### PR TITLE
ext: Import Atmel SAM4L header files from ASF library

### DIFF
--- a/asf/sam/include/sam4l/README
+++ b/asf/sam/include/sam4l/README
@@ -1,0 +1,40 @@
+Atmel SAM4L
+###########
+
+Origin:
+   Microchip Packs Repository
+   http://packs.download.atmel.com/
+
+   Atmel SAM4L Series Device Support (1.1.61)
+   http://packs.download.atmel.com/Atmel.SAM4L_DFP.1.1.61.atpack
+
+Status:
+   version 1.1.61
+
+Purpose:
+   Official package for SAM4L.
+
+Description:
+   Atmel Software Framework (ASF) provides a set of low-level
+   header files that give access to different hardware
+   peripherals of Atmel's ICs.
+
+URL:
+   http://packs.download.atmel.com/
+   http://packs.download.atmel.com/Atmel.SAM4L_DFP.1.1.61.atpack
+
+commit:
+  n/a
+
+Maintained-by:
+   External
+
+License:
+   Apache-2.0
+
+License Link:
+   https://www.apache.org/licenses/LICENSE-2.0
+
+Patch Lst:
+   * Add MPU peripheral in device file. Updated header files.
+   * Updated documentation links.

--- a/asf/sam/include/sam4l/component-version.h
+++ b/asf/sam/include/sam4l/component-version.h
@@ -1,0 +1,72 @@
+/*****************************************************************************
+ *
+ * Copyright (C) 2016 Atmel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ *
+ * * Neither the name of the copyright holders nor the names of
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ ****************************************************************************/
+
+
+#ifndef _COMPONENT_VERSION_H_INCLUDED
+#define _COMPONENT_VERSION_H_INCLUDED
+
+#define COMPONENT_VERSION_MAJOR 1
+#define COMPONENT_VERSION_MINOR 1
+
+//
+// The COMPONENT_VERSION define is composed of the major and the minor version number.
+//
+// The last four digits of the COMPONENT_VERSION is the minor version with leading zeros.
+// The rest of the COMPONENT_VERSION is the major version, with leading zeros. The COMPONENT_VERSION
+// is at least 8 digits long.
+//
+#define COMPONENT_VERSION 00010001
+
+//
+// The build number does not refer to the component, but to the build number
+// of the device pack that provides the component.
+//
+#define BUILD_NUMBER 61
+
+//
+// The COMPONENT_VERSION_STRING is a string (enclosed in ") that can be used for logging or embedding.
+//
+#define COMPONENT_VERSION_STRING "1.1"
+
+//
+// The COMPONENT_DATE_STRING contains a timestamp of when the pack was generated.
+//
+// The COMPONENT_DATE_STRING is written out using the following strftime pattern.
+//
+//     "%Y-%m-%d %H:%M:%S"
+//
+//
+#define COMPONENT_DATE_STRING "2016-09-15 14:35:42"
+
+#endif/* #ifndef _COMPONENT_VERSION_H_INCLUDED */
+

--- a/asf/sam/include/sam4l/component/abdacb.h
+++ b/asf/sam/include/sam4l/component/abdacb.h
@@ -1,0 +1,397 @@
+/**
+ * \file
+ *
+ * \brief Component description for ABDACB
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_ABDACB_COMPONENT_
+#define _SAM4L_ABDACB_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR ABDACB */
+/* ========================================================================== */
+/** \addtogroup SAM4L_ABDACB Audio Bitstream DAC */
+/*@{*/
+
+#define ABDACB_I7563
+#define REV_ABDACB                  0x100
+
+/* -------- ABDACB_CR : (ABDACB Offset: 0x00) (R/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EN:1;             /*!< bit:      0  Enable                             */
+    uint32_t SWAP:1;           /*!< bit:      1  Swap Channels                      */
+    uint32_t :1;               /*!< bit:      2  Reserved                           */
+    uint32_t ALTUPR:1;         /*!< bit:      3  Alternative up-sampling ratio      */
+    uint32_t CMOC:1;           /*!< bit:      4  Common mode offset control         */
+    uint32_t MONO:1;           /*!< bit:      5  Mono mode                          */
+    uint32_t :1;               /*!< bit:      6  Reserved                           */
+    uint32_t SWRST:1;          /*!< bit:      7  Software reset                     */
+    uint32_t :8;               /*!< bit:  8..15  Reserved                           */
+    uint32_t DATAFORMAT:3;     /*!< bit: 16..18  Data word format                   */
+    uint32_t :5;               /*!< bit: 19..23  Reserved                           */
+    uint32_t FS:4;             /*!< bit: 24..27  Sampling frequency                 */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ABDACB_CR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ABDACB_CR_OFFSET            0x00         /**< \brief (ABDACB_CR offset) Control Register */
+#define ABDACB_CR_RESETVALUE        _U(0x00000000); /**< \brief (ABDACB_CR reset_value) Control Register */
+
+#define ABDACB_CR_EN_Pos            0            /**< \brief (ABDACB_CR) Enable */
+#define ABDACB_CR_EN                (_U(0x1) << ABDACB_CR_EN_Pos)
+#define   ABDACB_CR_EN_0_Val              _U(0x0)   /**< \brief (ABDACB_CR) Audio DAC is disabled */
+#define   ABDACB_CR_EN_1_Val              _U(0x1)   /**< \brief (ABDACB_CR) Audio DAC is enabled */
+#define ABDACB_CR_EN_0              (ABDACB_CR_EN_0_Val            << ABDACB_CR_EN_Pos)
+#define ABDACB_CR_EN_1              (ABDACB_CR_EN_1_Val            << ABDACB_CR_EN_Pos)
+#define ABDACB_CR_SWAP_Pos          1            /**< \brief (ABDACB_CR) Swap Channels */
+#define ABDACB_CR_SWAP              (_U(0x1) << ABDACB_CR_SWAP_Pos)
+#define   ABDACB_CR_SWAP_0_Val            _U(0x0)   /**< \brief (ABDACB_CR) The CHANNEL0 and CHANNEL1 samples will not be swapped when writing the Audio DAC Sample Data Register (SDR) */
+#define   ABDACB_CR_SWAP_1_Val            _U(0x1)   /**< \brief (ABDACB_CR) The CHANNEL0 and CHANNEL1 samples will be swapped when writing the Audio DAC Sample Data Register (SDR) */
+#define ABDACB_CR_SWAP_0            (ABDACB_CR_SWAP_0_Val          << ABDACB_CR_SWAP_Pos)
+#define ABDACB_CR_SWAP_1            (ABDACB_CR_SWAP_1_Val          << ABDACB_CR_SWAP_Pos)
+#define ABDACB_CR_ALTUPR_Pos        3            /**< \brief (ABDACB_CR) Alternative up-sampling ratio */
+#define ABDACB_CR_ALTUPR            (_U(0x1) << ABDACB_CR_ALTUPR_Pos)
+#define ABDACB_CR_CMOC_Pos          4            /**< \brief (ABDACB_CR) Common mode offset control */
+#define ABDACB_CR_CMOC              (_U(0x1) << ABDACB_CR_CMOC_Pos)
+#define ABDACB_CR_MONO_Pos          5            /**< \brief (ABDACB_CR) Mono mode */
+#define ABDACB_CR_MONO              (_U(0x1) << ABDACB_CR_MONO_Pos)
+#define ABDACB_CR_SWRST_Pos         7            /**< \brief (ABDACB_CR) Software reset */
+#define ABDACB_CR_SWRST             (_U(0x1) << ABDACB_CR_SWRST_Pos)
+#define ABDACB_CR_DATAFORMAT_Pos    16           /**< \brief (ABDACB_CR) Data word format */
+#define ABDACB_CR_DATAFORMAT_Msk    (_U(0x7) << ABDACB_CR_DATAFORMAT_Pos)
+#define ABDACB_CR_DATAFORMAT(value) (ABDACB_CR_DATAFORMAT_Msk & ((value) << ABDACB_CR_DATAFORMAT_Pos))
+#define ABDACB_CR_FS_Pos            24           /**< \brief (ABDACB_CR) Sampling frequency */
+#define ABDACB_CR_FS_Msk            (_U(0xF) << ABDACB_CR_FS_Pos)
+#define ABDACB_CR_FS(value)         (ABDACB_CR_FS_Msk & ((value) << ABDACB_CR_FS_Pos))
+#define ABDACB_CR_MASK              _U(0x0F0700BB) /**< \brief (ABDACB_CR) MASK Register */
+
+/* -------- ABDACB_SDR0 : (ABDACB Offset: 0x04) (R/W 32) Sample Data Register 0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATA:32;          /*!< bit:  0..31  Sample Data                        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ABDACB_SDR0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ABDACB_SDR0_OFFSET          0x04         /**< \brief (ABDACB_SDR0 offset) Sample Data Register 0 */
+#define ABDACB_SDR0_RESETVALUE      _U(0x00000000); /**< \brief (ABDACB_SDR0 reset_value) Sample Data Register 0 */
+
+#define ABDACB_SDR0_DATA_Pos        0            /**< \brief (ABDACB_SDR0) Sample Data */
+#define ABDACB_SDR0_DATA_Msk        (_U(0xFFFFFFFF) << ABDACB_SDR0_DATA_Pos)
+#define ABDACB_SDR0_DATA(value)     (ABDACB_SDR0_DATA_Msk & ((value) << ABDACB_SDR0_DATA_Pos))
+#define ABDACB_SDR0_MASK            _U(0xFFFFFFFF) /**< \brief (ABDACB_SDR0) MASK Register */
+
+/* -------- ABDACB_SDR1 : (ABDACB Offset: 0x08) (R/W 32) Sample Data Register 1 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATA:32;          /*!< bit:  0..31  Sample Data                        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ABDACB_SDR1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ABDACB_SDR1_OFFSET          0x08         /**< \brief (ABDACB_SDR1 offset) Sample Data Register 1 */
+#define ABDACB_SDR1_RESETVALUE      _U(0x00000000); /**< \brief (ABDACB_SDR1 reset_value) Sample Data Register 1 */
+
+#define ABDACB_SDR1_DATA_Pos        0            /**< \brief (ABDACB_SDR1) Sample Data */
+#define ABDACB_SDR1_DATA_Msk        (_U(0xFFFFFFFF) << ABDACB_SDR1_DATA_Pos)
+#define ABDACB_SDR1_DATA(value)     (ABDACB_SDR1_DATA_Msk & ((value) << ABDACB_SDR1_DATA_Pos))
+#define ABDACB_SDR1_MASK            _U(0xFFFFFFFF) /**< \brief (ABDACB_SDR1) MASK Register */
+
+/* -------- ABDACB_VCR0 : (ABDACB Offset: 0x0C) (R/W 32) Volume Control Register 0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VOLUME:15;        /*!< bit:  0..14  Volume Control                     */
+    uint32_t :16;              /*!< bit: 15..30  Reserved                           */
+    uint32_t MUTE:1;           /*!< bit:     31  Mute                               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ABDACB_VCR0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ABDACB_VCR0_OFFSET          0x0C         /**< \brief (ABDACB_VCR0 offset) Volume Control Register 0 */
+#define ABDACB_VCR0_RESETVALUE      _U(0x00000000); /**< \brief (ABDACB_VCR0 reset_value) Volume Control Register 0 */
+
+#define ABDACB_VCR0_VOLUME_Pos      0            /**< \brief (ABDACB_VCR0) Volume Control */
+#define ABDACB_VCR0_VOLUME_Msk      (_U(0x7FFF) << ABDACB_VCR0_VOLUME_Pos)
+#define ABDACB_VCR0_VOLUME(value)   (ABDACB_VCR0_VOLUME_Msk & ((value) << ABDACB_VCR0_VOLUME_Pos))
+#define ABDACB_VCR0_MUTE_Pos        31           /**< \brief (ABDACB_VCR0) Mute */
+#define ABDACB_VCR0_MUTE            (_U(0x1) << ABDACB_VCR0_MUTE_Pos)
+#define ABDACB_VCR0_MASK            _U(0x80007FFF) /**< \brief (ABDACB_VCR0) MASK Register */
+
+/* -------- ABDACB_VCR1 : (ABDACB Offset: 0x10) (R/W 32) Volume Control Register 1 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VOLUME:15;        /*!< bit:  0..14  Volume Control                     */
+    uint32_t :16;              /*!< bit: 15..30  Reserved                           */
+    uint32_t MUTE:1;           /*!< bit:     31  Mute                               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ABDACB_VCR1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ABDACB_VCR1_OFFSET          0x10         /**< \brief (ABDACB_VCR1 offset) Volume Control Register 1 */
+#define ABDACB_VCR1_RESETVALUE      _U(0x00000000); /**< \brief (ABDACB_VCR1 reset_value) Volume Control Register 1 */
+
+#define ABDACB_VCR1_VOLUME_Pos      0            /**< \brief (ABDACB_VCR1) Volume Control */
+#define ABDACB_VCR1_VOLUME_Msk      (_U(0x7FFF) << ABDACB_VCR1_VOLUME_Pos)
+#define ABDACB_VCR1_VOLUME(value)   (ABDACB_VCR1_VOLUME_Msk & ((value) << ABDACB_VCR1_VOLUME_Pos))
+#define ABDACB_VCR1_MUTE_Pos        31           /**< \brief (ABDACB_VCR1) Mute */
+#define ABDACB_VCR1_MUTE            (_U(0x1) << ABDACB_VCR1_MUTE_Pos)
+#define ABDACB_VCR1_MASK            _U(0x80007FFF) /**< \brief (ABDACB_VCR1) MASK Register */
+
+/* -------- ABDACB_IER : (ABDACB Offset: 0x14) ( /W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t TXRDY:1;          /*!< bit:      1  Transmit Ready Interrupt Enable    */
+    uint32_t TXUR:1;           /*!< bit:      2  Transmit Underrun Interrupt Enable */
+    uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ABDACB_IER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ABDACB_IER_OFFSET           0x14         /**< \brief (ABDACB_IER offset) Interrupt Enable Register */
+#define ABDACB_IER_RESETVALUE       _U(0x00000000); /**< \brief (ABDACB_IER reset_value) Interrupt Enable Register */
+
+#define ABDACB_IER_TXRDY_Pos        1            /**< \brief (ABDACB_IER) Transmit Ready Interrupt Enable */
+#define ABDACB_IER_TXRDY            (_U(0x1) << ABDACB_IER_TXRDY_Pos)
+#define   ABDACB_IER_TXRDY_0_Val          _U(0x0)   /**< \brief (ABDACB_IER) No effect */
+#define   ABDACB_IER_TXRDY_1_Val          _U(0x1)   /**< \brief (ABDACB_IER) Enables the Audio DAC TX Ready interrupt */
+#define ABDACB_IER_TXRDY_0          (ABDACB_IER_TXRDY_0_Val        << ABDACB_IER_TXRDY_Pos)
+#define ABDACB_IER_TXRDY_1          (ABDACB_IER_TXRDY_1_Val        << ABDACB_IER_TXRDY_Pos)
+#define ABDACB_IER_TXUR_Pos         2            /**< \brief (ABDACB_IER) Transmit Underrun Interrupt Enable */
+#define ABDACB_IER_TXUR             (_U(0x1) << ABDACB_IER_TXUR_Pos)
+#define   ABDACB_IER_TXUR_0_Val           _U(0x0)   /**< \brief (ABDACB_IER) No effect */
+#define   ABDACB_IER_TXUR_1_Val           _U(0x1)   /**< \brief (ABDACB_IER) Enables the Audio DAC Underrun interrupt */
+#define ABDACB_IER_TXUR_0           (ABDACB_IER_TXUR_0_Val         << ABDACB_IER_TXUR_Pos)
+#define ABDACB_IER_TXUR_1           (ABDACB_IER_TXUR_1_Val         << ABDACB_IER_TXUR_Pos)
+#define ABDACB_IER_MASK             _U(0x00000006) /**< \brief (ABDACB_IER) MASK Register */
+
+/* -------- ABDACB_IDR : (ABDACB Offset: 0x18) ( /W 32) Interupt Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t TXRDY:1;          /*!< bit:      1  Transmit Ready Interrupt Disable   */
+    uint32_t TXUR:1;           /*!< bit:      2  Transmit Underrun Interrupt Disable */
+    uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ABDACB_IDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ABDACB_IDR_OFFSET           0x18         /**< \brief (ABDACB_IDR offset) Interupt Disable Register */
+#define ABDACB_IDR_RESETVALUE       _U(0x00000000); /**< \brief (ABDACB_IDR reset_value) Interupt Disable Register */
+
+#define ABDACB_IDR_TXRDY_Pos        1            /**< \brief (ABDACB_IDR) Transmit Ready Interrupt Disable */
+#define ABDACB_IDR_TXRDY            (_U(0x1) << ABDACB_IDR_TXRDY_Pos)
+#define   ABDACB_IDR_TXRDY_0_Val          _U(0x0)   /**< \brief (ABDACB_IDR) No effect */
+#define   ABDACB_IDR_TXRDY_1_Val          _U(0x1)   /**< \brief (ABDACB_IDR) Disable the Audio DAC TX Ready interrupt */
+#define ABDACB_IDR_TXRDY_0          (ABDACB_IDR_TXRDY_0_Val        << ABDACB_IDR_TXRDY_Pos)
+#define ABDACB_IDR_TXRDY_1          (ABDACB_IDR_TXRDY_1_Val        << ABDACB_IDR_TXRDY_Pos)
+#define ABDACB_IDR_TXUR_Pos         2            /**< \brief (ABDACB_IDR) Transmit Underrun Interrupt Disable */
+#define ABDACB_IDR_TXUR             (_U(0x1) << ABDACB_IDR_TXUR_Pos)
+#define   ABDACB_IDR_TXUR_0_Val           _U(0x0)   /**< \brief (ABDACB_IDR) No effect */
+#define   ABDACB_IDR_TXUR_1_Val           _U(0x1)   /**< \brief (ABDACB_IDR) Disable the Audio DAC Underrun interrupt */
+#define ABDACB_IDR_TXUR_0           (ABDACB_IDR_TXUR_0_Val         << ABDACB_IDR_TXUR_Pos)
+#define ABDACB_IDR_TXUR_1           (ABDACB_IDR_TXUR_1_Val         << ABDACB_IDR_TXUR_Pos)
+#define ABDACB_IDR_MASK             _U(0x00000006) /**< \brief (ABDACB_IDR) MASK Register */
+
+/* -------- ABDACB_IMR : (ABDACB Offset: 0x1C) (R/  32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t TXRDY:1;          /*!< bit:      1  Transmit Ready Interrupt Mask      */
+    uint32_t TXUR:1;           /*!< bit:      2  Transmit Underrun Interrupt Mask   */
+    uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ABDACB_IMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ABDACB_IMR_OFFSET           0x1C         /**< \brief (ABDACB_IMR offset) Interrupt Mask Register */
+#define ABDACB_IMR_RESETVALUE       _U(0x00000000); /**< \brief (ABDACB_IMR reset_value) Interrupt Mask Register */
+
+#define ABDACB_IMR_TXRDY_Pos        1            /**< \brief (ABDACB_IMR) Transmit Ready Interrupt Mask */
+#define ABDACB_IMR_TXRDY            (_U(0x1) << ABDACB_IMR_TXRDY_Pos)
+#define   ABDACB_IMR_TXRDY_0_Val          _U(0x0)   /**< \brief (ABDACB_IMR) The Audio DAC TX Ready interrupt is disabled */
+#define   ABDACB_IMR_TXRDY_1_Val          _U(0x1)   /**< \brief (ABDACB_IMR) The Audio DAC TX Ready interrupt is enabled */
+#define ABDACB_IMR_TXRDY_0          (ABDACB_IMR_TXRDY_0_Val        << ABDACB_IMR_TXRDY_Pos)
+#define ABDACB_IMR_TXRDY_1          (ABDACB_IMR_TXRDY_1_Val        << ABDACB_IMR_TXRDY_Pos)
+#define ABDACB_IMR_TXUR_Pos         2            /**< \brief (ABDACB_IMR) Transmit Underrun Interrupt Mask */
+#define ABDACB_IMR_TXUR             (_U(0x1) << ABDACB_IMR_TXUR_Pos)
+#define   ABDACB_IMR_TXUR_0_Val           _U(0x0)   /**< \brief (ABDACB_IMR) The Audio DAC Underrun interrupt is disabled */
+#define   ABDACB_IMR_TXUR_1_Val           _U(0x1)   /**< \brief (ABDACB_IMR) The Audio DAC Underrun interrupt is enabled */
+#define ABDACB_IMR_TXUR_0           (ABDACB_IMR_TXUR_0_Val         << ABDACB_IMR_TXUR_Pos)
+#define ABDACB_IMR_TXUR_1           (ABDACB_IMR_TXUR_1_Val         << ABDACB_IMR_TXUR_Pos)
+#define ABDACB_IMR_MASK             _U(0x00000006) /**< \brief (ABDACB_IMR) MASK Register */
+
+/* -------- ABDACB_SR : (ABDACB Offset: 0x20) (R/  32) Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t BUSY:1;           /*!< bit:      0  ABDACB Busy                        */
+    uint32_t TXRDY:1;          /*!< bit:      1  Transmit Ready                     */
+    uint32_t TXUR:1;           /*!< bit:      2  Transmit Underrun                  */
+    uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ABDACB_SR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ABDACB_SR_OFFSET            0x20         /**< \brief (ABDACB_SR offset) Status Register */
+#define ABDACB_SR_RESETVALUE        _U(0x00000000); /**< \brief (ABDACB_SR reset_value) Status Register */
+
+#define ABDACB_SR_BUSY_Pos          0            /**< \brief (ABDACB_SR) ABDACB Busy */
+#define ABDACB_SR_BUSY              (_U(0x1) << ABDACB_SR_BUSY_Pos)
+#define ABDACB_SR_TXRDY_Pos         1            /**< \brief (ABDACB_SR) Transmit Ready */
+#define ABDACB_SR_TXRDY             (_U(0x1) << ABDACB_SR_TXRDY_Pos)
+#define   ABDACB_SR_TXRDY_0_Val           _U(0x0)   /**< \brief (ABDACB_SR) No Audio DAC TX Ready has occured since the last time ISR was read or since reset */
+#define   ABDACB_SR_TXRDY_1_Val           _U(0x1)   /**< \brief (ABDACB_SR) At least one Audio DAC TX Ready has occured since the last time ISR was read or since reset */
+#define ABDACB_SR_TXRDY_0           (ABDACB_SR_TXRDY_0_Val         << ABDACB_SR_TXRDY_Pos)
+#define ABDACB_SR_TXRDY_1           (ABDACB_SR_TXRDY_1_Val         << ABDACB_SR_TXRDY_Pos)
+#define ABDACB_SR_TXUR_Pos          2            /**< \brief (ABDACB_SR) Transmit Underrun */
+#define ABDACB_SR_TXUR              (_U(0x1) << ABDACB_SR_TXUR_Pos)
+#define   ABDACB_SR_TXUR_0_Val            _U(0x0)   /**< \brief (ABDACB_SR) No Audio DAC Underrun has occured since the last time ISR was read or since reset */
+#define   ABDACB_SR_TXUR_1_Val            _U(0x1)   /**< \brief (ABDACB_SR) At least one Audio DAC Underrun has occured since the last time ISR was read or since reset */
+#define ABDACB_SR_TXUR_0            (ABDACB_SR_TXUR_0_Val          << ABDACB_SR_TXUR_Pos)
+#define ABDACB_SR_TXUR_1            (ABDACB_SR_TXUR_1_Val          << ABDACB_SR_TXUR_Pos)
+#define ABDACB_SR_MASK              _U(0x00000007) /**< \brief (ABDACB_SR) MASK Register */
+
+/* -------- ABDACB_SCR : (ABDACB Offset: 0x24) ( /W 32) Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t TXRDY:1;          /*!< bit:      1  Transmit Ready Interrupt Clear     */
+    uint32_t TXUR:1;           /*!< bit:      2  Transmit Underrun Interrupt Clear  */
+    uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ABDACB_SCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ABDACB_SCR_OFFSET           0x24         /**< \brief (ABDACB_SCR offset) Status Clear Register */
+#define ABDACB_SCR_RESETVALUE       _U(0x00000000); /**< \brief (ABDACB_SCR reset_value) Status Clear Register */
+
+#define ABDACB_SCR_TXRDY_Pos        1            /**< \brief (ABDACB_SCR) Transmit Ready Interrupt Clear */
+#define ABDACB_SCR_TXRDY            (_U(0x1) << ABDACB_SCR_TXRDY_Pos)
+#define   ABDACB_SCR_TXRDY_0_Val          _U(0x0)   /**< \brief (ABDACB_SCR) No effect */
+#define   ABDACB_SCR_TXRDY_1_Val          _U(0x1)   /**< \brief (ABDACB_SCR) Clear the Audio DAC TX Ready interrupt */
+#define ABDACB_SCR_TXRDY_0          (ABDACB_SCR_TXRDY_0_Val        << ABDACB_SCR_TXRDY_Pos)
+#define ABDACB_SCR_TXRDY_1          (ABDACB_SCR_TXRDY_1_Val        << ABDACB_SCR_TXRDY_Pos)
+#define ABDACB_SCR_TXUR_Pos         2            /**< \brief (ABDACB_SCR) Transmit Underrun Interrupt Clear */
+#define ABDACB_SCR_TXUR             (_U(0x1) << ABDACB_SCR_TXUR_Pos)
+#define   ABDACB_SCR_TXUR_0_Val           _U(0x0)   /**< \brief (ABDACB_SCR) No effect */
+#define   ABDACB_SCR_TXUR_1_Val           _U(0x1)   /**< \brief (ABDACB_SCR) Clear the Audio DAC Underrun interrupt */
+#define ABDACB_SCR_TXUR_0           (ABDACB_SCR_TXUR_0_Val         << ABDACB_SCR_TXUR_Pos)
+#define ABDACB_SCR_TXUR_1           (ABDACB_SCR_TXUR_1_Val         << ABDACB_SCR_TXUR_Pos)
+#define ABDACB_SCR_MASK             _U(0x00000006) /**< \brief (ABDACB_SCR) MASK Register */
+
+/* -------- ABDACB_PARAMETER : (ABDACB Offset: 0x28) (R/  32) Parameter Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} ABDACB_PARAMETER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ABDACB_PARAMETER_OFFSET     0x28         /**< \brief (ABDACB_PARAMETER offset) Parameter Register */
+#define ABDACB_PARAMETER_RESETVALUE _U(0x00000000); /**< \brief (ABDACB_PARAMETER reset_value) Parameter Register */
+#define ABDACB_PARAMETER_MASK       _U(0xFFFFFFFF) /**< \brief (ABDACB_PARAMETER) MASK Register */
+
+/* -------- ABDACB_VERSION : (ABDACB Offset: 0x2C) (R/  32) Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version Number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant Number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ABDACB_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ABDACB_VERSION_OFFSET       0x2C         /**< \brief (ABDACB_VERSION offset) Version Register */
+#define ABDACB_VERSION_RESETVALUE   _U(0x00000100); /**< \brief (ABDACB_VERSION reset_value) Version Register */
+
+#define ABDACB_VERSION_VERSION_Pos  0            /**< \brief (ABDACB_VERSION) Version Number */
+#define ABDACB_VERSION_VERSION_Msk  (_U(0xFFF) << ABDACB_VERSION_VERSION_Pos)
+#define ABDACB_VERSION_VERSION(value) (ABDACB_VERSION_VERSION_Msk & ((value) << ABDACB_VERSION_VERSION_Pos))
+#define ABDACB_VERSION_VARIANT_Pos  16           /**< \brief (ABDACB_VERSION) Variant Number */
+#define ABDACB_VERSION_VARIANT_Msk  (_U(0xF) << ABDACB_VERSION_VARIANT_Pos)
+#define ABDACB_VERSION_VARIANT(value) (ABDACB_VERSION_VARIANT_Msk & ((value) << ABDACB_VERSION_VARIANT_Pos))
+#define ABDACB_VERSION_MASK         _U(0x000F0FFF) /**< \brief (ABDACB_VERSION) MASK Register */
+
+/** \brief ABDACB hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __IO ABDACB_CR_Type            CR;          /**< \brief Offset: 0x00 (R/W 32) Control Register */
+  __IO ABDACB_SDR0_Type          SDR0;        /**< \brief Offset: 0x04 (R/W 32) Sample Data Register 0 */
+  __IO ABDACB_SDR1_Type          SDR1;        /**< \brief Offset: 0x08 (R/W 32) Sample Data Register 1 */
+  __IO ABDACB_VCR0_Type          VCR0;        /**< \brief Offset: 0x0C (R/W 32) Volume Control Register 0 */
+  __IO ABDACB_VCR1_Type          VCR1;        /**< \brief Offset: 0x10 (R/W 32) Volume Control Register 1 */
+  __O  ABDACB_IER_Type           IER;         /**< \brief Offset: 0x14 ( /W 32) Interrupt Enable Register */
+  __O  ABDACB_IDR_Type           IDR;         /**< \brief Offset: 0x18 ( /W 32) Interupt Disable Register */
+  __I  ABDACB_IMR_Type           IMR;         /**< \brief Offset: 0x1C (R/  32) Interrupt Mask Register */
+  __I  ABDACB_SR_Type            SR;          /**< \brief Offset: 0x20 (R/  32) Status Register */
+  __O  ABDACB_SCR_Type           SCR;         /**< \brief Offset: 0x24 ( /W 32) Status Clear Register */
+  __I  ABDACB_PARAMETER_Type     PARAMETER;   /**< \brief Offset: 0x28 (R/  32) Parameter Register */
+  __I  ABDACB_VERSION_Type       VERSION;     /**< \brief Offset: 0x2C (R/  32) Version Register */
+ } bf;
+ struct {
+  RwReg   ABDACB_CR;          /**< \brief (ABDACB Offset: 0x00) Control Register */
+  RwReg   ABDACB_SDR0;        /**< \brief (ABDACB Offset: 0x04) Sample Data Register 0 */
+  RwReg   ABDACB_SDR1;        /**< \brief (ABDACB Offset: 0x08) Sample Data Register 1 */
+  RwReg   ABDACB_VCR0;        /**< \brief (ABDACB Offset: 0x0C) Volume Control Register 0 */
+  RwReg   ABDACB_VCR1;        /**< \brief (ABDACB Offset: 0x10) Volume Control Register 1 */
+  WoReg   ABDACB_IER;         /**< \brief (ABDACB Offset: 0x14) Interrupt Enable Register */
+  WoReg   ABDACB_IDR;         /**< \brief (ABDACB Offset: 0x18) Interupt Disable Register */
+  RoReg   ABDACB_IMR;         /**< \brief (ABDACB Offset: 0x1C) Interrupt Mask Register */
+  RoReg   ABDACB_SR;          /**< \brief (ABDACB Offset: 0x20) Status Register */
+  WoReg   ABDACB_SCR;         /**< \brief (ABDACB Offset: 0x24) Status Clear Register */
+  RoReg   ABDACB_PARAMETER;   /**< \brief (ABDACB Offset: 0x28) Parameter Register */
+  RoReg   ABDACB_VERSION;     /**< \brief (ABDACB Offset: 0x2C) Version Register */
+ } reg;
+} Abdacb;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_ABDACB_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/abdacb.h
+++ b/asf/sam/include/sam4l/component/abdacb.h
@@ -360,35 +360,19 @@ typedef union {
 
 /** \brief ABDACB hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __IO ABDACB_CR_Type            CR;          /**< \brief Offset: 0x00 (R/W 32) Control Register */
-  __IO ABDACB_SDR0_Type          SDR0;        /**< \brief Offset: 0x04 (R/W 32) Sample Data Register 0 */
-  __IO ABDACB_SDR1_Type          SDR1;        /**< \brief Offset: 0x08 (R/W 32) Sample Data Register 1 */
-  __IO ABDACB_VCR0_Type          VCR0;        /**< \brief Offset: 0x0C (R/W 32) Volume Control Register 0 */
-  __IO ABDACB_VCR1_Type          VCR1;        /**< \brief Offset: 0x10 (R/W 32) Volume Control Register 1 */
-  __O  ABDACB_IER_Type           IER;         /**< \brief Offset: 0x14 ( /W 32) Interrupt Enable Register */
-  __O  ABDACB_IDR_Type           IDR;         /**< \brief Offset: 0x18 ( /W 32) Interupt Disable Register */
-  __I  ABDACB_IMR_Type           IMR;         /**< \brief Offset: 0x1C (R/  32) Interrupt Mask Register */
-  __I  ABDACB_SR_Type            SR;          /**< \brief Offset: 0x20 (R/  32) Status Register */
-  __O  ABDACB_SCR_Type           SCR;         /**< \brief Offset: 0x24 ( /W 32) Status Clear Register */
-  __I  ABDACB_PARAMETER_Type     PARAMETER;   /**< \brief Offset: 0x28 (R/  32) Parameter Register */
-  __I  ABDACB_VERSION_Type       VERSION;     /**< \brief Offset: 0x2C (R/  32) Version Register */
- } bf;
- struct {
-  RwReg   ABDACB_CR;          /**< \brief (ABDACB Offset: 0x00) Control Register */
-  RwReg   ABDACB_SDR0;        /**< \brief (ABDACB Offset: 0x04) Sample Data Register 0 */
-  RwReg   ABDACB_SDR1;        /**< \brief (ABDACB Offset: 0x08) Sample Data Register 1 */
-  RwReg   ABDACB_VCR0;        /**< \brief (ABDACB Offset: 0x0C) Volume Control Register 0 */
-  RwReg   ABDACB_VCR1;        /**< \brief (ABDACB Offset: 0x10) Volume Control Register 1 */
-  WoReg   ABDACB_IER;         /**< \brief (ABDACB Offset: 0x14) Interrupt Enable Register */
-  WoReg   ABDACB_IDR;         /**< \brief (ABDACB Offset: 0x18) Interupt Disable Register */
-  RoReg   ABDACB_IMR;         /**< \brief (ABDACB Offset: 0x1C) Interrupt Mask Register */
-  RoReg   ABDACB_SR;          /**< \brief (ABDACB Offset: 0x20) Status Register */
-  WoReg   ABDACB_SCR;         /**< \brief (ABDACB Offset: 0x24) Status Clear Register */
-  RoReg   ABDACB_PARAMETER;   /**< \brief (ABDACB Offset: 0x28) Parameter Register */
-  RoReg   ABDACB_VERSION;     /**< \brief (ABDACB Offset: 0x2C) Version Register */
- } reg;
+typedef struct {
+  __IO uint32_t CR;          /**< \brief Offset: 0x00 (R/W 32) Control Register */
+  __IO uint32_t SDR0;        /**< \brief Offset: 0x04 (R/W 32) Sample Data Register 0 */
+  __IO uint32_t SDR1;        /**< \brief Offset: 0x08 (R/W 32) Sample Data Register 1 */
+  __IO uint32_t VCR0;        /**< \brief Offset: 0x0C (R/W 32) Volume Control Register 0 */
+  __IO uint32_t VCR1;        /**< \brief Offset: 0x10 (R/W 32) Volume Control Register 1 */
+  __O  uint32_t IER;         /**< \brief Offset: 0x14 ( /W 32) Interrupt Enable Register */
+  __O  uint32_t IDR;         /**< \brief Offset: 0x18 ( /W 32) Interupt Disable Register */
+  __I  uint32_t IMR;         /**< \brief Offset: 0x1C (R/  32) Interrupt Mask Register */
+  __I  uint32_t SR;          /**< \brief Offset: 0x20 (R/  32) Status Register */
+  __O  uint32_t SCR;         /**< \brief Offset: 0x24 ( /W 32) Status Clear Register */
+  __I  uint32_t PARAMETER;   /**< \brief Offset: 0x28 (R/  32) Parameter Register */
+  __I  uint32_t VERSION;     /**< \brief Offset: 0x2C (R/  32) Version Register */
 } Abdacb;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/abdacb.h
+++ b/asf/sam/include/sam4l/component/abdacb.h
@@ -61,35 +61,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ABDACB_CR_OFFSET            0x00         /**< \brief (ABDACB_CR offset) Control Register */
-#define ABDACB_CR_RESETVALUE        _U(0x00000000); /**< \brief (ABDACB_CR reset_value) Control Register */
+#define ABDACB_CR_RESETVALUE        _U_(0x00000000); /**< \brief (ABDACB_CR reset_value) Control Register */
 
 #define ABDACB_CR_EN_Pos            0            /**< \brief (ABDACB_CR) Enable */
-#define ABDACB_CR_EN                (_U(0x1) << ABDACB_CR_EN_Pos)
-#define   ABDACB_CR_EN_0_Val              _U(0x0)   /**< \brief (ABDACB_CR) Audio DAC is disabled */
-#define   ABDACB_CR_EN_1_Val              _U(0x1)   /**< \brief (ABDACB_CR) Audio DAC is enabled */
+#define ABDACB_CR_EN                (_U_(0x1) << ABDACB_CR_EN_Pos)
+#define   ABDACB_CR_EN_0_Val              _U_(0x0)   /**< \brief (ABDACB_CR) Audio DAC is disabled */
+#define   ABDACB_CR_EN_1_Val              _U_(0x1)   /**< \brief (ABDACB_CR) Audio DAC is enabled */
 #define ABDACB_CR_EN_0              (ABDACB_CR_EN_0_Val            << ABDACB_CR_EN_Pos)
 #define ABDACB_CR_EN_1              (ABDACB_CR_EN_1_Val            << ABDACB_CR_EN_Pos)
 #define ABDACB_CR_SWAP_Pos          1            /**< \brief (ABDACB_CR) Swap Channels */
-#define ABDACB_CR_SWAP              (_U(0x1) << ABDACB_CR_SWAP_Pos)
-#define   ABDACB_CR_SWAP_0_Val            _U(0x0)   /**< \brief (ABDACB_CR) The CHANNEL0 and CHANNEL1 samples will not be swapped when writing the Audio DAC Sample Data Register (SDR) */
-#define   ABDACB_CR_SWAP_1_Val            _U(0x1)   /**< \brief (ABDACB_CR) The CHANNEL0 and CHANNEL1 samples will be swapped when writing the Audio DAC Sample Data Register (SDR) */
+#define ABDACB_CR_SWAP              (_U_(0x1) << ABDACB_CR_SWAP_Pos)
+#define   ABDACB_CR_SWAP_0_Val            _U_(0x0)   /**< \brief (ABDACB_CR) The CHANNEL0 and CHANNEL1 samples will not be swapped when writing the Audio DAC Sample Data Register (SDR) */
+#define   ABDACB_CR_SWAP_1_Val            _U_(0x1)   /**< \brief (ABDACB_CR) The CHANNEL0 and CHANNEL1 samples will be swapped when writing the Audio DAC Sample Data Register (SDR) */
 #define ABDACB_CR_SWAP_0            (ABDACB_CR_SWAP_0_Val          << ABDACB_CR_SWAP_Pos)
 #define ABDACB_CR_SWAP_1            (ABDACB_CR_SWAP_1_Val          << ABDACB_CR_SWAP_Pos)
 #define ABDACB_CR_ALTUPR_Pos        3            /**< \brief (ABDACB_CR) Alternative up-sampling ratio */
-#define ABDACB_CR_ALTUPR            (_U(0x1) << ABDACB_CR_ALTUPR_Pos)
+#define ABDACB_CR_ALTUPR            (_U_(0x1) << ABDACB_CR_ALTUPR_Pos)
 #define ABDACB_CR_CMOC_Pos          4            /**< \brief (ABDACB_CR) Common mode offset control */
-#define ABDACB_CR_CMOC              (_U(0x1) << ABDACB_CR_CMOC_Pos)
+#define ABDACB_CR_CMOC              (_U_(0x1) << ABDACB_CR_CMOC_Pos)
 #define ABDACB_CR_MONO_Pos          5            /**< \brief (ABDACB_CR) Mono mode */
-#define ABDACB_CR_MONO              (_U(0x1) << ABDACB_CR_MONO_Pos)
+#define ABDACB_CR_MONO              (_U_(0x1) << ABDACB_CR_MONO_Pos)
 #define ABDACB_CR_SWRST_Pos         7            /**< \brief (ABDACB_CR) Software reset */
-#define ABDACB_CR_SWRST             (_U(0x1) << ABDACB_CR_SWRST_Pos)
+#define ABDACB_CR_SWRST             (_U_(0x1) << ABDACB_CR_SWRST_Pos)
 #define ABDACB_CR_DATAFORMAT_Pos    16           /**< \brief (ABDACB_CR) Data word format */
-#define ABDACB_CR_DATAFORMAT_Msk    (_U(0x7) << ABDACB_CR_DATAFORMAT_Pos)
+#define ABDACB_CR_DATAFORMAT_Msk    (_U_(0x7) << ABDACB_CR_DATAFORMAT_Pos)
 #define ABDACB_CR_DATAFORMAT(value) (ABDACB_CR_DATAFORMAT_Msk & ((value) << ABDACB_CR_DATAFORMAT_Pos))
 #define ABDACB_CR_FS_Pos            24           /**< \brief (ABDACB_CR) Sampling frequency */
-#define ABDACB_CR_FS_Msk            (_U(0xF) << ABDACB_CR_FS_Pos)
+#define ABDACB_CR_FS_Msk            (_U_(0xF) << ABDACB_CR_FS_Pos)
 #define ABDACB_CR_FS(value)         (ABDACB_CR_FS_Msk & ((value) << ABDACB_CR_FS_Pos))
-#define ABDACB_CR_MASK              _U(0x0F0700BB) /**< \brief (ABDACB_CR) MASK Register */
+#define ABDACB_CR_MASK              _U_(0x0F0700BB) /**< \brief (ABDACB_CR) MASK Register */
 
 /* -------- ABDACB_SDR0 : (ABDACB Offset: 0x04) (R/W 32) Sample Data Register 0 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -102,12 +102,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ABDACB_SDR0_OFFSET          0x04         /**< \brief (ABDACB_SDR0 offset) Sample Data Register 0 */
-#define ABDACB_SDR0_RESETVALUE      _U(0x00000000); /**< \brief (ABDACB_SDR0 reset_value) Sample Data Register 0 */
+#define ABDACB_SDR0_RESETVALUE      _U_(0x00000000); /**< \brief (ABDACB_SDR0 reset_value) Sample Data Register 0 */
 
 #define ABDACB_SDR0_DATA_Pos        0            /**< \brief (ABDACB_SDR0) Sample Data */
-#define ABDACB_SDR0_DATA_Msk        (_U(0xFFFFFFFF) << ABDACB_SDR0_DATA_Pos)
+#define ABDACB_SDR0_DATA_Msk        (_U_(0xFFFFFFFF) << ABDACB_SDR0_DATA_Pos)
 #define ABDACB_SDR0_DATA(value)     (ABDACB_SDR0_DATA_Msk & ((value) << ABDACB_SDR0_DATA_Pos))
-#define ABDACB_SDR0_MASK            _U(0xFFFFFFFF) /**< \brief (ABDACB_SDR0) MASK Register */
+#define ABDACB_SDR0_MASK            _U_(0xFFFFFFFF) /**< \brief (ABDACB_SDR0) MASK Register */
 
 /* -------- ABDACB_SDR1 : (ABDACB Offset: 0x08) (R/W 32) Sample Data Register 1 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -120,12 +120,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ABDACB_SDR1_OFFSET          0x08         /**< \brief (ABDACB_SDR1 offset) Sample Data Register 1 */
-#define ABDACB_SDR1_RESETVALUE      _U(0x00000000); /**< \brief (ABDACB_SDR1 reset_value) Sample Data Register 1 */
+#define ABDACB_SDR1_RESETVALUE      _U_(0x00000000); /**< \brief (ABDACB_SDR1 reset_value) Sample Data Register 1 */
 
 #define ABDACB_SDR1_DATA_Pos        0            /**< \brief (ABDACB_SDR1) Sample Data */
-#define ABDACB_SDR1_DATA_Msk        (_U(0xFFFFFFFF) << ABDACB_SDR1_DATA_Pos)
+#define ABDACB_SDR1_DATA_Msk        (_U_(0xFFFFFFFF) << ABDACB_SDR1_DATA_Pos)
 #define ABDACB_SDR1_DATA(value)     (ABDACB_SDR1_DATA_Msk & ((value) << ABDACB_SDR1_DATA_Pos))
-#define ABDACB_SDR1_MASK            _U(0xFFFFFFFF) /**< \brief (ABDACB_SDR1) MASK Register */
+#define ABDACB_SDR1_MASK            _U_(0xFFFFFFFF) /**< \brief (ABDACB_SDR1) MASK Register */
 
 /* -------- ABDACB_VCR0 : (ABDACB Offset: 0x0C) (R/W 32) Volume Control Register 0 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -140,14 +140,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ABDACB_VCR0_OFFSET          0x0C         /**< \brief (ABDACB_VCR0 offset) Volume Control Register 0 */
-#define ABDACB_VCR0_RESETVALUE      _U(0x00000000); /**< \brief (ABDACB_VCR0 reset_value) Volume Control Register 0 */
+#define ABDACB_VCR0_RESETVALUE      _U_(0x00000000); /**< \brief (ABDACB_VCR0 reset_value) Volume Control Register 0 */
 
 #define ABDACB_VCR0_VOLUME_Pos      0            /**< \brief (ABDACB_VCR0) Volume Control */
-#define ABDACB_VCR0_VOLUME_Msk      (_U(0x7FFF) << ABDACB_VCR0_VOLUME_Pos)
+#define ABDACB_VCR0_VOLUME_Msk      (_U_(0x7FFF) << ABDACB_VCR0_VOLUME_Pos)
 #define ABDACB_VCR0_VOLUME(value)   (ABDACB_VCR0_VOLUME_Msk & ((value) << ABDACB_VCR0_VOLUME_Pos))
 #define ABDACB_VCR0_MUTE_Pos        31           /**< \brief (ABDACB_VCR0) Mute */
-#define ABDACB_VCR0_MUTE            (_U(0x1) << ABDACB_VCR0_MUTE_Pos)
-#define ABDACB_VCR0_MASK            _U(0x80007FFF) /**< \brief (ABDACB_VCR0) MASK Register */
+#define ABDACB_VCR0_MUTE            (_U_(0x1) << ABDACB_VCR0_MUTE_Pos)
+#define ABDACB_VCR0_MASK            _U_(0x80007FFF) /**< \brief (ABDACB_VCR0) MASK Register */
 
 /* -------- ABDACB_VCR1 : (ABDACB Offset: 0x10) (R/W 32) Volume Control Register 1 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -162,14 +162,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ABDACB_VCR1_OFFSET          0x10         /**< \brief (ABDACB_VCR1 offset) Volume Control Register 1 */
-#define ABDACB_VCR1_RESETVALUE      _U(0x00000000); /**< \brief (ABDACB_VCR1 reset_value) Volume Control Register 1 */
+#define ABDACB_VCR1_RESETVALUE      _U_(0x00000000); /**< \brief (ABDACB_VCR1 reset_value) Volume Control Register 1 */
 
 #define ABDACB_VCR1_VOLUME_Pos      0            /**< \brief (ABDACB_VCR1) Volume Control */
-#define ABDACB_VCR1_VOLUME_Msk      (_U(0x7FFF) << ABDACB_VCR1_VOLUME_Pos)
+#define ABDACB_VCR1_VOLUME_Msk      (_U_(0x7FFF) << ABDACB_VCR1_VOLUME_Pos)
 #define ABDACB_VCR1_VOLUME(value)   (ABDACB_VCR1_VOLUME_Msk & ((value) << ABDACB_VCR1_VOLUME_Pos))
 #define ABDACB_VCR1_MUTE_Pos        31           /**< \brief (ABDACB_VCR1) Mute */
-#define ABDACB_VCR1_MUTE            (_U(0x1) << ABDACB_VCR1_MUTE_Pos)
-#define ABDACB_VCR1_MASK            _U(0x80007FFF) /**< \brief (ABDACB_VCR1) MASK Register */
+#define ABDACB_VCR1_MUTE            (_U_(0x1) << ABDACB_VCR1_MUTE_Pos)
+#define ABDACB_VCR1_MASK            _U_(0x80007FFF) /**< \brief (ABDACB_VCR1) MASK Register */
 
 /* -------- ABDACB_IER : (ABDACB Offset: 0x14) ( /W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -185,21 +185,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ABDACB_IER_OFFSET           0x14         /**< \brief (ABDACB_IER offset) Interrupt Enable Register */
-#define ABDACB_IER_RESETVALUE       _U(0x00000000); /**< \brief (ABDACB_IER reset_value) Interrupt Enable Register */
+#define ABDACB_IER_RESETVALUE       _U_(0x00000000); /**< \brief (ABDACB_IER reset_value) Interrupt Enable Register */
 
 #define ABDACB_IER_TXRDY_Pos        1            /**< \brief (ABDACB_IER) Transmit Ready Interrupt Enable */
-#define ABDACB_IER_TXRDY            (_U(0x1) << ABDACB_IER_TXRDY_Pos)
-#define   ABDACB_IER_TXRDY_0_Val          _U(0x0)   /**< \brief (ABDACB_IER) No effect */
-#define   ABDACB_IER_TXRDY_1_Val          _U(0x1)   /**< \brief (ABDACB_IER) Enables the Audio DAC TX Ready interrupt */
+#define ABDACB_IER_TXRDY            (_U_(0x1) << ABDACB_IER_TXRDY_Pos)
+#define   ABDACB_IER_TXRDY_0_Val          _U_(0x0)   /**< \brief (ABDACB_IER) No effect */
+#define   ABDACB_IER_TXRDY_1_Val          _U_(0x1)   /**< \brief (ABDACB_IER) Enables the Audio DAC TX Ready interrupt */
 #define ABDACB_IER_TXRDY_0          (ABDACB_IER_TXRDY_0_Val        << ABDACB_IER_TXRDY_Pos)
 #define ABDACB_IER_TXRDY_1          (ABDACB_IER_TXRDY_1_Val        << ABDACB_IER_TXRDY_Pos)
 #define ABDACB_IER_TXUR_Pos         2            /**< \brief (ABDACB_IER) Transmit Underrun Interrupt Enable */
-#define ABDACB_IER_TXUR             (_U(0x1) << ABDACB_IER_TXUR_Pos)
-#define   ABDACB_IER_TXUR_0_Val           _U(0x0)   /**< \brief (ABDACB_IER) No effect */
-#define   ABDACB_IER_TXUR_1_Val           _U(0x1)   /**< \brief (ABDACB_IER) Enables the Audio DAC Underrun interrupt */
+#define ABDACB_IER_TXUR             (_U_(0x1) << ABDACB_IER_TXUR_Pos)
+#define   ABDACB_IER_TXUR_0_Val           _U_(0x0)   /**< \brief (ABDACB_IER) No effect */
+#define   ABDACB_IER_TXUR_1_Val           _U_(0x1)   /**< \brief (ABDACB_IER) Enables the Audio DAC Underrun interrupt */
 #define ABDACB_IER_TXUR_0           (ABDACB_IER_TXUR_0_Val         << ABDACB_IER_TXUR_Pos)
 #define ABDACB_IER_TXUR_1           (ABDACB_IER_TXUR_1_Val         << ABDACB_IER_TXUR_Pos)
-#define ABDACB_IER_MASK             _U(0x00000006) /**< \brief (ABDACB_IER) MASK Register */
+#define ABDACB_IER_MASK             _U_(0x00000006) /**< \brief (ABDACB_IER) MASK Register */
 
 /* -------- ABDACB_IDR : (ABDACB Offset: 0x18) ( /W 32) Interupt Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -215,21 +215,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ABDACB_IDR_OFFSET           0x18         /**< \brief (ABDACB_IDR offset) Interupt Disable Register */
-#define ABDACB_IDR_RESETVALUE       _U(0x00000000); /**< \brief (ABDACB_IDR reset_value) Interupt Disable Register */
+#define ABDACB_IDR_RESETVALUE       _U_(0x00000000); /**< \brief (ABDACB_IDR reset_value) Interupt Disable Register */
 
 #define ABDACB_IDR_TXRDY_Pos        1            /**< \brief (ABDACB_IDR) Transmit Ready Interrupt Disable */
-#define ABDACB_IDR_TXRDY            (_U(0x1) << ABDACB_IDR_TXRDY_Pos)
-#define   ABDACB_IDR_TXRDY_0_Val          _U(0x0)   /**< \brief (ABDACB_IDR) No effect */
-#define   ABDACB_IDR_TXRDY_1_Val          _U(0x1)   /**< \brief (ABDACB_IDR) Disable the Audio DAC TX Ready interrupt */
+#define ABDACB_IDR_TXRDY            (_U_(0x1) << ABDACB_IDR_TXRDY_Pos)
+#define   ABDACB_IDR_TXRDY_0_Val          _U_(0x0)   /**< \brief (ABDACB_IDR) No effect */
+#define   ABDACB_IDR_TXRDY_1_Val          _U_(0x1)   /**< \brief (ABDACB_IDR) Disable the Audio DAC TX Ready interrupt */
 #define ABDACB_IDR_TXRDY_0          (ABDACB_IDR_TXRDY_0_Val        << ABDACB_IDR_TXRDY_Pos)
 #define ABDACB_IDR_TXRDY_1          (ABDACB_IDR_TXRDY_1_Val        << ABDACB_IDR_TXRDY_Pos)
 #define ABDACB_IDR_TXUR_Pos         2            /**< \brief (ABDACB_IDR) Transmit Underrun Interrupt Disable */
-#define ABDACB_IDR_TXUR             (_U(0x1) << ABDACB_IDR_TXUR_Pos)
-#define   ABDACB_IDR_TXUR_0_Val           _U(0x0)   /**< \brief (ABDACB_IDR) No effect */
-#define   ABDACB_IDR_TXUR_1_Val           _U(0x1)   /**< \brief (ABDACB_IDR) Disable the Audio DAC Underrun interrupt */
+#define ABDACB_IDR_TXUR             (_U_(0x1) << ABDACB_IDR_TXUR_Pos)
+#define   ABDACB_IDR_TXUR_0_Val           _U_(0x0)   /**< \brief (ABDACB_IDR) No effect */
+#define   ABDACB_IDR_TXUR_1_Val           _U_(0x1)   /**< \brief (ABDACB_IDR) Disable the Audio DAC Underrun interrupt */
 #define ABDACB_IDR_TXUR_0           (ABDACB_IDR_TXUR_0_Val         << ABDACB_IDR_TXUR_Pos)
 #define ABDACB_IDR_TXUR_1           (ABDACB_IDR_TXUR_1_Val         << ABDACB_IDR_TXUR_Pos)
-#define ABDACB_IDR_MASK             _U(0x00000006) /**< \brief (ABDACB_IDR) MASK Register */
+#define ABDACB_IDR_MASK             _U_(0x00000006) /**< \brief (ABDACB_IDR) MASK Register */
 
 /* -------- ABDACB_IMR : (ABDACB Offset: 0x1C) (R/  32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -245,21 +245,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ABDACB_IMR_OFFSET           0x1C         /**< \brief (ABDACB_IMR offset) Interrupt Mask Register */
-#define ABDACB_IMR_RESETVALUE       _U(0x00000000); /**< \brief (ABDACB_IMR reset_value) Interrupt Mask Register */
+#define ABDACB_IMR_RESETVALUE       _U_(0x00000000); /**< \brief (ABDACB_IMR reset_value) Interrupt Mask Register */
 
 #define ABDACB_IMR_TXRDY_Pos        1            /**< \brief (ABDACB_IMR) Transmit Ready Interrupt Mask */
-#define ABDACB_IMR_TXRDY            (_U(0x1) << ABDACB_IMR_TXRDY_Pos)
-#define   ABDACB_IMR_TXRDY_0_Val          _U(0x0)   /**< \brief (ABDACB_IMR) The Audio DAC TX Ready interrupt is disabled */
-#define   ABDACB_IMR_TXRDY_1_Val          _U(0x1)   /**< \brief (ABDACB_IMR) The Audio DAC TX Ready interrupt is enabled */
+#define ABDACB_IMR_TXRDY            (_U_(0x1) << ABDACB_IMR_TXRDY_Pos)
+#define   ABDACB_IMR_TXRDY_0_Val          _U_(0x0)   /**< \brief (ABDACB_IMR) The Audio DAC TX Ready interrupt is disabled */
+#define   ABDACB_IMR_TXRDY_1_Val          _U_(0x1)   /**< \brief (ABDACB_IMR) The Audio DAC TX Ready interrupt is enabled */
 #define ABDACB_IMR_TXRDY_0          (ABDACB_IMR_TXRDY_0_Val        << ABDACB_IMR_TXRDY_Pos)
 #define ABDACB_IMR_TXRDY_1          (ABDACB_IMR_TXRDY_1_Val        << ABDACB_IMR_TXRDY_Pos)
 #define ABDACB_IMR_TXUR_Pos         2            /**< \brief (ABDACB_IMR) Transmit Underrun Interrupt Mask */
-#define ABDACB_IMR_TXUR             (_U(0x1) << ABDACB_IMR_TXUR_Pos)
-#define   ABDACB_IMR_TXUR_0_Val           _U(0x0)   /**< \brief (ABDACB_IMR) The Audio DAC Underrun interrupt is disabled */
-#define   ABDACB_IMR_TXUR_1_Val           _U(0x1)   /**< \brief (ABDACB_IMR) The Audio DAC Underrun interrupt is enabled */
+#define ABDACB_IMR_TXUR             (_U_(0x1) << ABDACB_IMR_TXUR_Pos)
+#define   ABDACB_IMR_TXUR_0_Val           _U_(0x0)   /**< \brief (ABDACB_IMR) The Audio DAC Underrun interrupt is disabled */
+#define   ABDACB_IMR_TXUR_1_Val           _U_(0x1)   /**< \brief (ABDACB_IMR) The Audio DAC Underrun interrupt is enabled */
 #define ABDACB_IMR_TXUR_0           (ABDACB_IMR_TXUR_0_Val         << ABDACB_IMR_TXUR_Pos)
 #define ABDACB_IMR_TXUR_1           (ABDACB_IMR_TXUR_1_Val         << ABDACB_IMR_TXUR_Pos)
-#define ABDACB_IMR_MASK             _U(0x00000006) /**< \brief (ABDACB_IMR) MASK Register */
+#define ABDACB_IMR_MASK             _U_(0x00000006) /**< \brief (ABDACB_IMR) MASK Register */
 
 /* -------- ABDACB_SR : (ABDACB Offset: 0x20) (R/  32) Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -275,23 +275,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ABDACB_SR_OFFSET            0x20         /**< \brief (ABDACB_SR offset) Status Register */
-#define ABDACB_SR_RESETVALUE        _U(0x00000000); /**< \brief (ABDACB_SR reset_value) Status Register */
+#define ABDACB_SR_RESETVALUE        _U_(0x00000000); /**< \brief (ABDACB_SR reset_value) Status Register */
 
 #define ABDACB_SR_BUSY_Pos          0            /**< \brief (ABDACB_SR) ABDACB Busy */
-#define ABDACB_SR_BUSY              (_U(0x1) << ABDACB_SR_BUSY_Pos)
+#define ABDACB_SR_BUSY              (_U_(0x1) << ABDACB_SR_BUSY_Pos)
 #define ABDACB_SR_TXRDY_Pos         1            /**< \brief (ABDACB_SR) Transmit Ready */
-#define ABDACB_SR_TXRDY             (_U(0x1) << ABDACB_SR_TXRDY_Pos)
-#define   ABDACB_SR_TXRDY_0_Val           _U(0x0)   /**< \brief (ABDACB_SR) No Audio DAC TX Ready has occured since the last time ISR was read or since reset */
-#define   ABDACB_SR_TXRDY_1_Val           _U(0x1)   /**< \brief (ABDACB_SR) At least one Audio DAC TX Ready has occured since the last time ISR was read or since reset */
+#define ABDACB_SR_TXRDY             (_U_(0x1) << ABDACB_SR_TXRDY_Pos)
+#define   ABDACB_SR_TXRDY_0_Val           _U_(0x0)   /**< \brief (ABDACB_SR) No Audio DAC TX Ready has occured since the last time ISR was read or since reset */
+#define   ABDACB_SR_TXRDY_1_Val           _U_(0x1)   /**< \brief (ABDACB_SR) At least one Audio DAC TX Ready has occured since the last time ISR was read or since reset */
 #define ABDACB_SR_TXRDY_0           (ABDACB_SR_TXRDY_0_Val         << ABDACB_SR_TXRDY_Pos)
 #define ABDACB_SR_TXRDY_1           (ABDACB_SR_TXRDY_1_Val         << ABDACB_SR_TXRDY_Pos)
 #define ABDACB_SR_TXUR_Pos          2            /**< \brief (ABDACB_SR) Transmit Underrun */
-#define ABDACB_SR_TXUR              (_U(0x1) << ABDACB_SR_TXUR_Pos)
-#define   ABDACB_SR_TXUR_0_Val            _U(0x0)   /**< \brief (ABDACB_SR) No Audio DAC Underrun has occured since the last time ISR was read or since reset */
-#define   ABDACB_SR_TXUR_1_Val            _U(0x1)   /**< \brief (ABDACB_SR) At least one Audio DAC Underrun has occured since the last time ISR was read or since reset */
+#define ABDACB_SR_TXUR              (_U_(0x1) << ABDACB_SR_TXUR_Pos)
+#define   ABDACB_SR_TXUR_0_Val            _U_(0x0)   /**< \brief (ABDACB_SR) No Audio DAC Underrun has occured since the last time ISR was read or since reset */
+#define   ABDACB_SR_TXUR_1_Val            _U_(0x1)   /**< \brief (ABDACB_SR) At least one Audio DAC Underrun has occured since the last time ISR was read or since reset */
 #define ABDACB_SR_TXUR_0            (ABDACB_SR_TXUR_0_Val          << ABDACB_SR_TXUR_Pos)
 #define ABDACB_SR_TXUR_1            (ABDACB_SR_TXUR_1_Val          << ABDACB_SR_TXUR_Pos)
-#define ABDACB_SR_MASK              _U(0x00000007) /**< \brief (ABDACB_SR) MASK Register */
+#define ABDACB_SR_MASK              _U_(0x00000007) /**< \brief (ABDACB_SR) MASK Register */
 
 /* -------- ABDACB_SCR : (ABDACB Offset: 0x24) ( /W 32) Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -307,21 +307,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ABDACB_SCR_OFFSET           0x24         /**< \brief (ABDACB_SCR offset) Status Clear Register */
-#define ABDACB_SCR_RESETVALUE       _U(0x00000000); /**< \brief (ABDACB_SCR reset_value) Status Clear Register */
+#define ABDACB_SCR_RESETVALUE       _U_(0x00000000); /**< \brief (ABDACB_SCR reset_value) Status Clear Register */
 
 #define ABDACB_SCR_TXRDY_Pos        1            /**< \brief (ABDACB_SCR) Transmit Ready Interrupt Clear */
-#define ABDACB_SCR_TXRDY            (_U(0x1) << ABDACB_SCR_TXRDY_Pos)
-#define   ABDACB_SCR_TXRDY_0_Val          _U(0x0)   /**< \brief (ABDACB_SCR) No effect */
-#define   ABDACB_SCR_TXRDY_1_Val          _U(0x1)   /**< \brief (ABDACB_SCR) Clear the Audio DAC TX Ready interrupt */
+#define ABDACB_SCR_TXRDY            (_U_(0x1) << ABDACB_SCR_TXRDY_Pos)
+#define   ABDACB_SCR_TXRDY_0_Val          _U_(0x0)   /**< \brief (ABDACB_SCR) No effect */
+#define   ABDACB_SCR_TXRDY_1_Val          _U_(0x1)   /**< \brief (ABDACB_SCR) Clear the Audio DAC TX Ready interrupt */
 #define ABDACB_SCR_TXRDY_0          (ABDACB_SCR_TXRDY_0_Val        << ABDACB_SCR_TXRDY_Pos)
 #define ABDACB_SCR_TXRDY_1          (ABDACB_SCR_TXRDY_1_Val        << ABDACB_SCR_TXRDY_Pos)
 #define ABDACB_SCR_TXUR_Pos         2            /**< \brief (ABDACB_SCR) Transmit Underrun Interrupt Clear */
-#define ABDACB_SCR_TXUR             (_U(0x1) << ABDACB_SCR_TXUR_Pos)
-#define   ABDACB_SCR_TXUR_0_Val           _U(0x0)   /**< \brief (ABDACB_SCR) No effect */
-#define   ABDACB_SCR_TXUR_1_Val           _U(0x1)   /**< \brief (ABDACB_SCR) Clear the Audio DAC Underrun interrupt */
+#define ABDACB_SCR_TXUR             (_U_(0x1) << ABDACB_SCR_TXUR_Pos)
+#define   ABDACB_SCR_TXUR_0_Val           _U_(0x0)   /**< \brief (ABDACB_SCR) No effect */
+#define   ABDACB_SCR_TXUR_1_Val           _U_(0x1)   /**< \brief (ABDACB_SCR) Clear the Audio DAC Underrun interrupt */
 #define ABDACB_SCR_TXUR_0           (ABDACB_SCR_TXUR_0_Val         << ABDACB_SCR_TXUR_Pos)
 #define ABDACB_SCR_TXUR_1           (ABDACB_SCR_TXUR_1_Val         << ABDACB_SCR_TXUR_Pos)
-#define ABDACB_SCR_MASK             _U(0x00000006) /**< \brief (ABDACB_SCR) MASK Register */
+#define ABDACB_SCR_MASK             _U_(0x00000006) /**< \brief (ABDACB_SCR) MASK Register */
 
 /* -------- ABDACB_PARAMETER : (ABDACB Offset: 0x28) (R/  32) Parameter Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -331,8 +331,8 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ABDACB_PARAMETER_OFFSET     0x28         /**< \brief (ABDACB_PARAMETER offset) Parameter Register */
-#define ABDACB_PARAMETER_RESETVALUE _U(0x00000000); /**< \brief (ABDACB_PARAMETER reset_value) Parameter Register */
-#define ABDACB_PARAMETER_MASK       _U(0xFFFFFFFF) /**< \brief (ABDACB_PARAMETER) MASK Register */
+#define ABDACB_PARAMETER_RESETVALUE _U_(0x00000000); /**< \brief (ABDACB_PARAMETER reset_value) Parameter Register */
+#define ABDACB_PARAMETER_MASK       _U_(0xFFFFFFFF) /**< \brief (ABDACB_PARAMETER) MASK Register */
 
 /* -------- ABDACB_VERSION : (ABDACB Offset: 0x2C) (R/  32) Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -348,15 +348,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ABDACB_VERSION_OFFSET       0x2C         /**< \brief (ABDACB_VERSION offset) Version Register */
-#define ABDACB_VERSION_RESETVALUE   _U(0x00000100); /**< \brief (ABDACB_VERSION reset_value) Version Register */
+#define ABDACB_VERSION_RESETVALUE   _U_(0x00000100); /**< \brief (ABDACB_VERSION reset_value) Version Register */
 
 #define ABDACB_VERSION_VERSION_Pos  0            /**< \brief (ABDACB_VERSION) Version Number */
-#define ABDACB_VERSION_VERSION_Msk  (_U(0xFFF) << ABDACB_VERSION_VERSION_Pos)
+#define ABDACB_VERSION_VERSION_Msk  (_U_(0xFFF) << ABDACB_VERSION_VERSION_Pos)
 #define ABDACB_VERSION_VERSION(value) (ABDACB_VERSION_VERSION_Msk & ((value) << ABDACB_VERSION_VERSION_Pos))
 #define ABDACB_VERSION_VARIANT_Pos  16           /**< \brief (ABDACB_VERSION) Variant Number */
-#define ABDACB_VERSION_VARIANT_Msk  (_U(0xF) << ABDACB_VERSION_VARIANT_Pos)
+#define ABDACB_VERSION_VARIANT_Msk  (_U_(0xF) << ABDACB_VERSION_VARIANT_Pos)
 #define ABDACB_VERSION_VARIANT(value) (ABDACB_VERSION_VARIANT_Msk & ((value) << ABDACB_VERSION_VARIANT_Pos))
-#define ABDACB_VERSION_MASK         _U(0x000F0FFF) /**< \brief (ABDACB_VERSION) MASK Register */
+#define ABDACB_VERSION_MASK         _U_(0x000F0FFF) /**< \brief (ABDACB_VERSION) MASK Register */
 
 /** \brief ABDACB hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/acifc.h
+++ b/asf/sam/include/sam4l/component/acifc.h
@@ -744,43 +744,23 @@ typedef union {
 
 /** \brief ACIFC hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __IO ACIFC_CTRL_Type           CTRL;        /**< \brief Offset: 0x00 (R/W 32) Control Register */
-  __I  ACIFC_SR_Type             SR;          /**< \brief Offset: 0x04 (R/  32) Status Register */
-       RoReg8                    Reserved1[0x8];
-  __O  ACIFC_IER_Type            IER;         /**< \brief Offset: 0x10 ( /W 32) Interrupt Enable Register */
-  __O  ACIFC_IDR_Type            IDR;         /**< \brief Offset: 0x14 ( /W 32) Interrupt Disable Register */
-  __I  ACIFC_IMR_Type            IMR;         /**< \brief Offset: 0x18 (R/  32) Interrupt Mask Register */
-  __I  ACIFC_ISR_Type            ISR;         /**< \brief Offset: 0x1C (R/  32) Interrupt Status Register */
-  __O  ACIFC_ICR_Type            ICR;         /**< \brief Offset: 0x20 ( /W 32) Interrupt Status Clear Register */
-  __IO ACIFC_TR_Type             TR;          /**< \brief Offset: 0x24 (R/W 32) Test Register */
-       RoReg8                    Reserved2[0x8];
-  __I  ACIFC_PARAMETER_Type      PARAMETER;   /**< \brief Offset: 0x30 (R/  32) Parameter Register */
-  __I  ACIFC_VERSION_Type        VERSION;     /**< \brief Offset: 0x34 (R/  32) Version Register */
-       RoReg8                    Reserved3[0x48];
-       AcifcConfw                Confw[4];    /**< \brief Offset: 0x80 AcifcConfw groups */
-       RoReg8                    Reserved4[0x40];
-       AcifcConf                 Conf[8];     /**< \brief Offset: 0xD0 AcifcConf groups */
- } bf;
- struct {
-  RwReg   ACIFC_CTRL;         /**< \brief (ACIFC Offset: 0x00) Control Register */
-  RoReg   ACIFC_SR;           /**< \brief (ACIFC Offset: 0x04) Status Register */
-  RoReg8  Reserved5[0x8];
-  WoReg   ACIFC_IER;          /**< \brief (ACIFC Offset: 0x10) Interrupt Enable Register */
-  WoReg   ACIFC_IDR;          /**< \brief (ACIFC Offset: 0x14) Interrupt Disable Register */
-  RoReg   ACIFC_IMR;          /**< \brief (ACIFC Offset: 0x18) Interrupt Mask Register */
-  RoReg   ACIFC_ISR;          /**< \brief (ACIFC Offset: 0x1C) Interrupt Status Register */
-  WoReg   ACIFC_ICR;          /**< \brief (ACIFC Offset: 0x20) Interrupt Status Clear Register */
-  RwReg   ACIFC_TR;           /**< \brief (ACIFC Offset: 0x24) Test Register */
-  RoReg8  Reserved6[0x8];
-  RoReg   ACIFC_PARAMETER;    /**< \brief (ACIFC Offset: 0x30) Parameter Register */
-  RoReg   ACIFC_VERSION;      /**< \brief (ACIFC Offset: 0x34) Version Register */
-  RoReg8  Reserved7[0x48];
-  AcifcConfw ACIFC_CONFW[4];     /**< \brief (ACIFC Offset: 0x80) AcifcConfw groups */
-  RoReg8  Reserved8[0x40];
-  AcifcConf ACIFC_CONF[8];      /**< \brief (ACIFC Offset: 0xD0) AcifcConf groups */
- } reg;
+typedef struct {
+  __IO uint32_t CTRL;        /**< \brief Offset: 0x00 (R/W 32) Control Register */
+  __I  uint32_t SR;          /**< \brief Offset: 0x04 (R/  32) Status Register */
+       RoReg8   Reserved1[0x8];
+  __O  uint32_t IER;         /**< \brief Offset: 0x10 ( /W 32) Interrupt Enable Register */
+  __O  uint32_t IDR;         /**< \brief Offset: 0x14 ( /W 32) Interrupt Disable Register */
+  __I  uint32_t IMR;         /**< \brief Offset: 0x18 (R/  32) Interrupt Mask Register */
+  __I  uint32_t ISR;         /**< \brief Offset: 0x1C (R/  32) Interrupt Status Register */
+  __O  uint32_t ICR;         /**< \brief Offset: 0x20 ( /W 32) Interrupt Status Clear Register */
+  __IO uint32_t TR;          /**< \brief Offset: 0x24 (R/W 32) Test Register */
+       RoReg8   Reserved2[0x8];
+  __I  uint32_t PARAMETER;   /**< \brief Offset: 0x30 (R/  32) Parameter Register */
+  __I  uint32_t VERSION;     /**< \brief Offset: 0x34 (R/  32) Version Register */
+       RoReg8   Reserved3[0x48];
+  __IO uint32_t Confw[4];    /**< \brief Offset: 0x80 AcifcConfw groups */
+       RoReg8   Reserved4[0x40];
+  __IO uint32_t Conf[8];     /**< \brief Offset: 0xD0 AcifcConf groups */
 } Acifc;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/acifc.h
+++ b/asf/sam/include/sam4l/component/acifc.h
@@ -56,19 +56,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACIFC_CTRL_OFFSET           0x00         /**< \brief (ACIFC_CTRL offset) Control Register */
-#define ACIFC_CTRL_RESETVALUE       _U(0x00000000); /**< \brief (ACIFC_CTRL reset_value) Control Register */
+#define ACIFC_CTRL_RESETVALUE       _U_(0x00000000); /**< \brief (ACIFC_CTRL reset_value) Control Register */
 
 #define ACIFC_CTRL_EN_Pos           0            /**< \brief (ACIFC_CTRL) ACIFC Enable */
-#define ACIFC_CTRL_EN               (_U(0x1) << ACIFC_CTRL_EN_Pos)
+#define ACIFC_CTRL_EN               (_U_(0x1) << ACIFC_CTRL_EN_Pos)
 #define ACIFC_CTRL_EVENTEN_Pos      1            /**< \brief (ACIFC_CTRL) Peripheral Event Trigger Enable */
-#define ACIFC_CTRL_EVENTEN          (_U(0x1) << ACIFC_CTRL_EVENTEN_Pos)
+#define ACIFC_CTRL_EVENTEN          (_U_(0x1) << ACIFC_CTRL_EVENTEN_Pos)
 #define ACIFC_CTRL_USTART_Pos       4            /**< \brief (ACIFC_CTRL) User Start Single Comparison */
-#define ACIFC_CTRL_USTART           (_U(0x1) << ACIFC_CTRL_USTART_Pos)
+#define ACIFC_CTRL_USTART           (_U_(0x1) << ACIFC_CTRL_USTART_Pos)
 #define ACIFC_CTRL_ESTART_Pos       5            /**< \brief (ACIFC_CTRL) Peripheral Event Start Single Comparison */
-#define ACIFC_CTRL_ESTART           (_U(0x1) << ACIFC_CTRL_ESTART_Pos)
+#define ACIFC_CTRL_ESTART           (_U_(0x1) << ACIFC_CTRL_ESTART_Pos)
 #define ACIFC_CTRL_ACTEST_Pos       7            /**< \brief (ACIFC_CTRL) Analog Comparator Test Mode */
-#define ACIFC_CTRL_ACTEST           (_U(0x1) << ACIFC_CTRL_ACTEST_Pos)
-#define ACIFC_CTRL_MASK             _U(0x000000B3) /**< \brief (ACIFC_CTRL) MASK Register */
+#define ACIFC_CTRL_ACTEST           (_U_(0x1) << ACIFC_CTRL_ACTEST_Pos)
+#define ACIFC_CTRL_MASK             _U_(0x000000B3) /**< \brief (ACIFC_CTRL) MASK Register */
 
 /* -------- ACIFC_SR : (ACIFC Offset: 0x04) (R/  32) Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -102,49 +102,49 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACIFC_SR_OFFSET             0x04         /**< \brief (ACIFC_SR offset) Status Register */
-#define ACIFC_SR_RESETVALUE         _U(0x00000000); /**< \brief (ACIFC_SR reset_value) Status Register */
+#define ACIFC_SR_RESETVALUE         _U_(0x00000000); /**< \brief (ACIFC_SR reset_value) Status Register */
 
 #define ACIFC_SR_ACCS0_Pos          0            /**< \brief (ACIFC_SR) AC0 Current Comparison Status */
-#define ACIFC_SR_ACCS0              (_U(0x1) << ACIFC_SR_ACCS0_Pos)
+#define ACIFC_SR_ACCS0              (_U_(0x1) << ACIFC_SR_ACCS0_Pos)
 #define ACIFC_SR_ACRDY0_Pos         1            /**< \brief (ACIFC_SR) AC0 Ready */
-#define ACIFC_SR_ACRDY0             (_U(0x1) << ACIFC_SR_ACRDY0_Pos)
+#define ACIFC_SR_ACRDY0             (_U_(0x1) << ACIFC_SR_ACRDY0_Pos)
 #define ACIFC_SR_ACCS1_Pos          2            /**< \brief (ACIFC_SR) AC1 Current Comparison Status */
-#define ACIFC_SR_ACCS1              (_U(0x1) << ACIFC_SR_ACCS1_Pos)
+#define ACIFC_SR_ACCS1              (_U_(0x1) << ACIFC_SR_ACCS1_Pos)
 #define ACIFC_SR_ACRDY1_Pos         3            /**< \brief (ACIFC_SR) AC1 Ready */
-#define ACIFC_SR_ACRDY1             (_U(0x1) << ACIFC_SR_ACRDY1_Pos)
+#define ACIFC_SR_ACRDY1             (_U_(0x1) << ACIFC_SR_ACRDY1_Pos)
 #define ACIFC_SR_ACCS2_Pos          4            /**< \brief (ACIFC_SR) AC2 Current Comparison Status */
-#define ACIFC_SR_ACCS2              (_U(0x1) << ACIFC_SR_ACCS2_Pos)
+#define ACIFC_SR_ACCS2              (_U_(0x1) << ACIFC_SR_ACCS2_Pos)
 #define ACIFC_SR_ACRDY2_Pos         5            /**< \brief (ACIFC_SR) AC2 Ready */
-#define ACIFC_SR_ACRDY2             (_U(0x1) << ACIFC_SR_ACRDY2_Pos)
+#define ACIFC_SR_ACRDY2             (_U_(0x1) << ACIFC_SR_ACRDY2_Pos)
 #define ACIFC_SR_ACCS3_Pos          6            /**< \brief (ACIFC_SR) AC3 Current Comparison Status */
-#define ACIFC_SR_ACCS3              (_U(0x1) << ACIFC_SR_ACCS3_Pos)
+#define ACIFC_SR_ACCS3              (_U_(0x1) << ACIFC_SR_ACCS3_Pos)
 #define ACIFC_SR_ACRDY3_Pos         7            /**< \brief (ACIFC_SR) AC3 Ready */
-#define ACIFC_SR_ACRDY3             (_U(0x1) << ACIFC_SR_ACRDY3_Pos)
+#define ACIFC_SR_ACRDY3             (_U_(0x1) << ACIFC_SR_ACRDY3_Pos)
 #define ACIFC_SR_ACCS4_Pos          8            /**< \brief (ACIFC_SR) AC4 Current Comparison Status */
-#define ACIFC_SR_ACCS4              (_U(0x1) << ACIFC_SR_ACCS4_Pos)
+#define ACIFC_SR_ACCS4              (_U_(0x1) << ACIFC_SR_ACCS4_Pos)
 #define ACIFC_SR_ACRDY4_Pos         9            /**< \brief (ACIFC_SR) AC4 Ready */
-#define ACIFC_SR_ACRDY4             (_U(0x1) << ACIFC_SR_ACRDY4_Pos)
+#define ACIFC_SR_ACRDY4             (_U_(0x1) << ACIFC_SR_ACRDY4_Pos)
 #define ACIFC_SR_ACCS5_Pos          10           /**< \brief (ACIFC_SR) AC5 Current Comparison Status */
-#define ACIFC_SR_ACCS5              (_U(0x1) << ACIFC_SR_ACCS5_Pos)
+#define ACIFC_SR_ACCS5              (_U_(0x1) << ACIFC_SR_ACCS5_Pos)
 #define ACIFC_SR_ACRDY5_Pos         11           /**< \brief (ACIFC_SR) AC5 Ready */
-#define ACIFC_SR_ACRDY5             (_U(0x1) << ACIFC_SR_ACRDY5_Pos)
+#define ACIFC_SR_ACRDY5             (_U_(0x1) << ACIFC_SR_ACRDY5_Pos)
 #define ACIFC_SR_ACCS6_Pos          12           /**< \brief (ACIFC_SR) AC6 Current Comparison Status */
-#define ACIFC_SR_ACCS6              (_U(0x1) << ACIFC_SR_ACCS6_Pos)
+#define ACIFC_SR_ACCS6              (_U_(0x1) << ACIFC_SR_ACCS6_Pos)
 #define ACIFC_SR_ACRDY6_Pos         13           /**< \brief (ACIFC_SR) AC6 Ready */
-#define ACIFC_SR_ACRDY6             (_U(0x1) << ACIFC_SR_ACRDY6_Pos)
+#define ACIFC_SR_ACRDY6             (_U_(0x1) << ACIFC_SR_ACRDY6_Pos)
 #define ACIFC_SR_ACCS7_Pos          14           /**< \brief (ACIFC_SR) AC7 Current Comparison Status */
-#define ACIFC_SR_ACCS7              (_U(0x1) << ACIFC_SR_ACCS7_Pos)
+#define ACIFC_SR_ACCS7              (_U_(0x1) << ACIFC_SR_ACCS7_Pos)
 #define ACIFC_SR_ACRDY7_Pos         15           /**< \brief (ACIFC_SR) AC7 Ready */
-#define ACIFC_SR_ACRDY7             (_U(0x1) << ACIFC_SR_ACRDY7_Pos)
+#define ACIFC_SR_ACRDY7             (_U_(0x1) << ACIFC_SR_ACRDY7_Pos)
 #define ACIFC_SR_WFCS0_Pos          24           /**< \brief (ACIFC_SR) Window0 Mode Current Status */
-#define ACIFC_SR_WFCS0              (_U(0x1) << ACIFC_SR_WFCS0_Pos)
+#define ACIFC_SR_WFCS0              (_U_(0x1) << ACIFC_SR_WFCS0_Pos)
 #define ACIFC_SR_WFCS1_Pos          25           /**< \brief (ACIFC_SR) Window1 Mode Current Status */
-#define ACIFC_SR_WFCS1              (_U(0x1) << ACIFC_SR_WFCS1_Pos)
+#define ACIFC_SR_WFCS1              (_U_(0x1) << ACIFC_SR_WFCS1_Pos)
 #define ACIFC_SR_WFCS2_Pos          26           /**< \brief (ACIFC_SR) Window2 Mode Current Status */
-#define ACIFC_SR_WFCS2              (_U(0x1) << ACIFC_SR_WFCS2_Pos)
+#define ACIFC_SR_WFCS2              (_U_(0x1) << ACIFC_SR_WFCS2_Pos)
 #define ACIFC_SR_WFCS3_Pos          27           /**< \brief (ACIFC_SR) Window3 Mode Current Status */
-#define ACIFC_SR_WFCS3              (_U(0x1) << ACIFC_SR_WFCS3_Pos)
-#define ACIFC_SR_MASK               _U(0x0F00FFFF) /**< \brief (ACIFC_SR) MASK Register */
+#define ACIFC_SR_WFCS3              (_U_(0x1) << ACIFC_SR_WFCS3_Pos)
+#define ACIFC_SR_MASK               _U_(0x0F00FFFF) /**< \brief (ACIFC_SR) MASK Register */
 
 /* -------- ACIFC_IER : (ACIFC Offset: 0x10) ( /W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -178,49 +178,49 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACIFC_IER_OFFSET            0x10         /**< \brief (ACIFC_IER offset) Interrupt Enable Register */
-#define ACIFC_IER_RESETVALUE        _U(0x00000000); /**< \brief (ACIFC_IER reset_value) Interrupt Enable Register */
+#define ACIFC_IER_RESETVALUE        _U_(0x00000000); /**< \brief (ACIFC_IER reset_value) Interrupt Enable Register */
 
 #define ACIFC_IER_ACINT0_Pos        0            /**< \brief (ACIFC_IER) AC0 Interrupt Enable */
-#define ACIFC_IER_ACINT0            (_U(0x1) << ACIFC_IER_ACINT0_Pos)
+#define ACIFC_IER_ACINT0            (_U_(0x1) << ACIFC_IER_ACINT0_Pos)
 #define ACIFC_IER_SUTINT0_Pos       1            /**< \brief (ACIFC_IER) AC0 Startup Time Interrupt Enable */
-#define ACIFC_IER_SUTINT0           (_U(0x1) << ACIFC_IER_SUTINT0_Pos)
+#define ACIFC_IER_SUTINT0           (_U_(0x1) << ACIFC_IER_SUTINT0_Pos)
 #define ACIFC_IER_ACINT1_Pos        2            /**< \brief (ACIFC_IER) AC1 Interrupt Enable */
-#define ACIFC_IER_ACINT1            (_U(0x1) << ACIFC_IER_ACINT1_Pos)
+#define ACIFC_IER_ACINT1            (_U_(0x1) << ACIFC_IER_ACINT1_Pos)
 #define ACIFC_IER_SUTINT1_Pos       3            /**< \brief (ACIFC_IER) AC1 Startup Time Interrupt Enable */
-#define ACIFC_IER_SUTINT1           (_U(0x1) << ACIFC_IER_SUTINT1_Pos)
+#define ACIFC_IER_SUTINT1           (_U_(0x1) << ACIFC_IER_SUTINT1_Pos)
 #define ACIFC_IER_ACINT2_Pos        4            /**< \brief (ACIFC_IER) AC2 Interrupt Enable */
-#define ACIFC_IER_ACINT2            (_U(0x1) << ACIFC_IER_ACINT2_Pos)
+#define ACIFC_IER_ACINT2            (_U_(0x1) << ACIFC_IER_ACINT2_Pos)
 #define ACIFC_IER_SUTINT2_Pos       5            /**< \brief (ACIFC_IER) AC2 Startup Time Interrupt Enable */
-#define ACIFC_IER_SUTINT2           (_U(0x1) << ACIFC_IER_SUTINT2_Pos)
+#define ACIFC_IER_SUTINT2           (_U_(0x1) << ACIFC_IER_SUTINT2_Pos)
 #define ACIFC_IER_ACINT3_Pos        6            /**< \brief (ACIFC_IER) AC3 Interrupt Enable */
-#define ACIFC_IER_ACINT3            (_U(0x1) << ACIFC_IER_ACINT3_Pos)
+#define ACIFC_IER_ACINT3            (_U_(0x1) << ACIFC_IER_ACINT3_Pos)
 #define ACIFC_IER_SUTINT3_Pos       7            /**< \brief (ACIFC_IER) AC3 Startup Time Interrupt Enable */
-#define ACIFC_IER_SUTINT3           (_U(0x1) << ACIFC_IER_SUTINT3_Pos)
+#define ACIFC_IER_SUTINT3           (_U_(0x1) << ACIFC_IER_SUTINT3_Pos)
 #define ACIFC_IER_ACINT4_Pos        8            /**< \brief (ACIFC_IER) AC4 Interrupt Enable */
-#define ACIFC_IER_ACINT4            (_U(0x1) << ACIFC_IER_ACINT4_Pos)
+#define ACIFC_IER_ACINT4            (_U_(0x1) << ACIFC_IER_ACINT4_Pos)
 #define ACIFC_IER_SUTINT4_Pos       9            /**< \brief (ACIFC_IER) AC4 Startup Time Interrupt Enable */
-#define ACIFC_IER_SUTINT4           (_U(0x1) << ACIFC_IER_SUTINT4_Pos)
+#define ACIFC_IER_SUTINT4           (_U_(0x1) << ACIFC_IER_SUTINT4_Pos)
 #define ACIFC_IER_ACINT5_Pos        10           /**< \brief (ACIFC_IER) AC5 Interrupt Enable */
-#define ACIFC_IER_ACINT5            (_U(0x1) << ACIFC_IER_ACINT5_Pos)
+#define ACIFC_IER_ACINT5            (_U_(0x1) << ACIFC_IER_ACINT5_Pos)
 #define ACIFC_IER_SUTINT5_Pos       11           /**< \brief (ACIFC_IER) AC5 Startup Time Interrupt Enable */
-#define ACIFC_IER_SUTINT5           (_U(0x1) << ACIFC_IER_SUTINT5_Pos)
+#define ACIFC_IER_SUTINT5           (_U_(0x1) << ACIFC_IER_SUTINT5_Pos)
 #define ACIFC_IER_ACINT6_Pos        12           /**< \brief (ACIFC_IER) AC6 Interrupt Enable */
-#define ACIFC_IER_ACINT6            (_U(0x1) << ACIFC_IER_ACINT6_Pos)
+#define ACIFC_IER_ACINT6            (_U_(0x1) << ACIFC_IER_ACINT6_Pos)
 #define ACIFC_IER_SUTINT6_Pos       13           /**< \brief (ACIFC_IER) AC6 Startup Time Interrupt Enable */
-#define ACIFC_IER_SUTINT6           (_U(0x1) << ACIFC_IER_SUTINT6_Pos)
+#define ACIFC_IER_SUTINT6           (_U_(0x1) << ACIFC_IER_SUTINT6_Pos)
 #define ACIFC_IER_ACINT7_Pos        14           /**< \brief (ACIFC_IER) AC7 Interrupt Enable */
-#define ACIFC_IER_ACINT7            (_U(0x1) << ACIFC_IER_ACINT7_Pos)
+#define ACIFC_IER_ACINT7            (_U_(0x1) << ACIFC_IER_ACINT7_Pos)
 #define ACIFC_IER_SUTINT7_Pos       15           /**< \brief (ACIFC_IER) AC7 Startup Time Interrupt Enable */
-#define ACIFC_IER_SUTINT7           (_U(0x1) << ACIFC_IER_SUTINT7_Pos)
+#define ACIFC_IER_SUTINT7           (_U_(0x1) << ACIFC_IER_SUTINT7_Pos)
 #define ACIFC_IER_WFINT0_Pos        24           /**< \brief (ACIFC_IER) Window0 Mode Interrupt Enable */
-#define ACIFC_IER_WFINT0            (_U(0x1) << ACIFC_IER_WFINT0_Pos)
+#define ACIFC_IER_WFINT0            (_U_(0x1) << ACIFC_IER_WFINT0_Pos)
 #define ACIFC_IER_WFINT1_Pos        25           /**< \brief (ACIFC_IER) Window1 Mode Interrupt Enable */
-#define ACIFC_IER_WFINT1            (_U(0x1) << ACIFC_IER_WFINT1_Pos)
+#define ACIFC_IER_WFINT1            (_U_(0x1) << ACIFC_IER_WFINT1_Pos)
 #define ACIFC_IER_WFINT2_Pos        26           /**< \brief (ACIFC_IER) Window2 Mode Interrupt Enable */
-#define ACIFC_IER_WFINT2            (_U(0x1) << ACIFC_IER_WFINT2_Pos)
+#define ACIFC_IER_WFINT2            (_U_(0x1) << ACIFC_IER_WFINT2_Pos)
 #define ACIFC_IER_WFINT3_Pos        27           /**< \brief (ACIFC_IER) Window3 Mode Interrupt Enable */
-#define ACIFC_IER_WFINT3            (_U(0x1) << ACIFC_IER_WFINT3_Pos)
-#define ACIFC_IER_MASK              _U(0x0F00FFFF) /**< \brief (ACIFC_IER) MASK Register */
+#define ACIFC_IER_WFINT3            (_U_(0x1) << ACIFC_IER_WFINT3_Pos)
+#define ACIFC_IER_MASK              _U_(0x0F00FFFF) /**< \brief (ACIFC_IER) MASK Register */
 
 /* -------- ACIFC_IDR : (ACIFC Offset: 0x14) ( /W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -254,49 +254,49 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACIFC_IDR_OFFSET            0x14         /**< \brief (ACIFC_IDR offset) Interrupt Disable Register */
-#define ACIFC_IDR_RESETVALUE        _U(0x00000000); /**< \brief (ACIFC_IDR reset_value) Interrupt Disable Register */
+#define ACIFC_IDR_RESETVALUE        _U_(0x00000000); /**< \brief (ACIFC_IDR reset_value) Interrupt Disable Register */
 
 #define ACIFC_IDR_ACINT0_Pos        0            /**< \brief (ACIFC_IDR) AC0 Interrupt Disable */
-#define ACIFC_IDR_ACINT0            (_U(0x1) << ACIFC_IDR_ACINT0_Pos)
+#define ACIFC_IDR_ACINT0            (_U_(0x1) << ACIFC_IDR_ACINT0_Pos)
 #define ACIFC_IDR_SUTINT0_Pos       1            /**< \brief (ACIFC_IDR) AC0 Startup Time Interrupt Disable */
-#define ACIFC_IDR_SUTINT0           (_U(0x1) << ACIFC_IDR_SUTINT0_Pos)
+#define ACIFC_IDR_SUTINT0           (_U_(0x1) << ACIFC_IDR_SUTINT0_Pos)
 #define ACIFC_IDR_ACINT1_Pos        2            /**< \brief (ACIFC_IDR) AC1 Interrupt Disable */
-#define ACIFC_IDR_ACINT1            (_U(0x1) << ACIFC_IDR_ACINT1_Pos)
+#define ACIFC_IDR_ACINT1            (_U_(0x1) << ACIFC_IDR_ACINT1_Pos)
 #define ACIFC_IDR_SUTINT1_Pos       3            /**< \brief (ACIFC_IDR) AC1 Startup Time Interrupt Disable */
-#define ACIFC_IDR_SUTINT1           (_U(0x1) << ACIFC_IDR_SUTINT1_Pos)
+#define ACIFC_IDR_SUTINT1           (_U_(0x1) << ACIFC_IDR_SUTINT1_Pos)
 #define ACIFC_IDR_ACINT2_Pos        4            /**< \brief (ACIFC_IDR) AC2 Interrupt Disable */
-#define ACIFC_IDR_ACINT2            (_U(0x1) << ACIFC_IDR_ACINT2_Pos)
+#define ACIFC_IDR_ACINT2            (_U_(0x1) << ACIFC_IDR_ACINT2_Pos)
 #define ACIFC_IDR_SUTINT2_Pos       5            /**< \brief (ACIFC_IDR) AC2 Startup Time Interrupt Disable */
-#define ACIFC_IDR_SUTINT2           (_U(0x1) << ACIFC_IDR_SUTINT2_Pos)
+#define ACIFC_IDR_SUTINT2           (_U_(0x1) << ACIFC_IDR_SUTINT2_Pos)
 #define ACIFC_IDR_ACINT3_Pos        6            /**< \brief (ACIFC_IDR) AC3 Interrupt Disable */
-#define ACIFC_IDR_ACINT3            (_U(0x1) << ACIFC_IDR_ACINT3_Pos)
+#define ACIFC_IDR_ACINT3            (_U_(0x1) << ACIFC_IDR_ACINT3_Pos)
 #define ACIFC_IDR_SUTINT3_Pos       7            /**< \brief (ACIFC_IDR) AC3 Startup Time Interrupt Disable */
-#define ACIFC_IDR_SUTINT3           (_U(0x1) << ACIFC_IDR_SUTINT3_Pos)
+#define ACIFC_IDR_SUTINT3           (_U_(0x1) << ACIFC_IDR_SUTINT3_Pos)
 #define ACIFC_IDR_ACINT4_Pos        8            /**< \brief (ACIFC_IDR) AC4 Interrupt Disable */
-#define ACIFC_IDR_ACINT4            (_U(0x1) << ACIFC_IDR_ACINT4_Pos)
+#define ACIFC_IDR_ACINT4            (_U_(0x1) << ACIFC_IDR_ACINT4_Pos)
 #define ACIFC_IDR_SUTINT4_Pos       9            /**< \brief (ACIFC_IDR) AC4 Startup Time Interrupt Disable */
-#define ACIFC_IDR_SUTINT4           (_U(0x1) << ACIFC_IDR_SUTINT4_Pos)
+#define ACIFC_IDR_SUTINT4           (_U_(0x1) << ACIFC_IDR_SUTINT4_Pos)
 #define ACIFC_IDR_ACINT5_Pos        10           /**< \brief (ACIFC_IDR) AC5 Interrupt Disable */
-#define ACIFC_IDR_ACINT5            (_U(0x1) << ACIFC_IDR_ACINT5_Pos)
+#define ACIFC_IDR_ACINT5            (_U_(0x1) << ACIFC_IDR_ACINT5_Pos)
 #define ACIFC_IDR_SUTINT5_Pos       11           /**< \brief (ACIFC_IDR) AC5 Startup Time Interrupt Disable */
-#define ACIFC_IDR_SUTINT5           (_U(0x1) << ACIFC_IDR_SUTINT5_Pos)
+#define ACIFC_IDR_SUTINT5           (_U_(0x1) << ACIFC_IDR_SUTINT5_Pos)
 #define ACIFC_IDR_ACINT6_Pos        12           /**< \brief (ACIFC_IDR) AC6 Interrupt Disable */
-#define ACIFC_IDR_ACINT6            (_U(0x1) << ACIFC_IDR_ACINT6_Pos)
+#define ACIFC_IDR_ACINT6            (_U_(0x1) << ACIFC_IDR_ACINT6_Pos)
 #define ACIFC_IDR_SUTINT6_Pos       13           /**< \brief (ACIFC_IDR) AC6 Startup Time Interrupt Disable */
-#define ACIFC_IDR_SUTINT6           (_U(0x1) << ACIFC_IDR_SUTINT6_Pos)
+#define ACIFC_IDR_SUTINT6           (_U_(0x1) << ACIFC_IDR_SUTINT6_Pos)
 #define ACIFC_IDR_ACINT7_Pos        14           /**< \brief (ACIFC_IDR) AC7 Interrupt Disable */
-#define ACIFC_IDR_ACINT7            (_U(0x1) << ACIFC_IDR_ACINT7_Pos)
+#define ACIFC_IDR_ACINT7            (_U_(0x1) << ACIFC_IDR_ACINT7_Pos)
 #define ACIFC_IDR_SUTINT7_Pos       15           /**< \brief (ACIFC_IDR) AC7 Startup Time Interrupt Disable */
-#define ACIFC_IDR_SUTINT7           (_U(0x1) << ACIFC_IDR_SUTINT7_Pos)
+#define ACIFC_IDR_SUTINT7           (_U_(0x1) << ACIFC_IDR_SUTINT7_Pos)
 #define ACIFC_IDR_WFINT0_Pos        24           /**< \brief (ACIFC_IDR) Window0 Mode Interrupt Disable */
-#define ACIFC_IDR_WFINT0            (_U(0x1) << ACIFC_IDR_WFINT0_Pos)
+#define ACIFC_IDR_WFINT0            (_U_(0x1) << ACIFC_IDR_WFINT0_Pos)
 #define ACIFC_IDR_WFINT1_Pos        25           /**< \brief (ACIFC_IDR) Window1 Mode Interrupt Disable */
-#define ACIFC_IDR_WFINT1            (_U(0x1) << ACIFC_IDR_WFINT1_Pos)
+#define ACIFC_IDR_WFINT1            (_U_(0x1) << ACIFC_IDR_WFINT1_Pos)
 #define ACIFC_IDR_WFINT2_Pos        26           /**< \brief (ACIFC_IDR) Window2 Mode Interrupt Disable */
-#define ACIFC_IDR_WFINT2            (_U(0x1) << ACIFC_IDR_WFINT2_Pos)
+#define ACIFC_IDR_WFINT2            (_U_(0x1) << ACIFC_IDR_WFINT2_Pos)
 #define ACIFC_IDR_WFINT3_Pos        27           /**< \brief (ACIFC_IDR) Window3 Mode Interrupt Disable */
-#define ACIFC_IDR_WFINT3            (_U(0x1) << ACIFC_IDR_WFINT3_Pos)
-#define ACIFC_IDR_MASK              _U(0x0F00FFFF) /**< \brief (ACIFC_IDR) MASK Register */
+#define ACIFC_IDR_WFINT3            (_U_(0x1) << ACIFC_IDR_WFINT3_Pos)
+#define ACIFC_IDR_MASK              _U_(0x0F00FFFF) /**< \brief (ACIFC_IDR) MASK Register */
 
 /* -------- ACIFC_IMR : (ACIFC Offset: 0x18) (R/  32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -330,49 +330,49 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACIFC_IMR_OFFSET            0x18         /**< \brief (ACIFC_IMR offset) Interrupt Mask Register */
-#define ACIFC_IMR_RESETVALUE        _U(0x00000000); /**< \brief (ACIFC_IMR reset_value) Interrupt Mask Register */
+#define ACIFC_IMR_RESETVALUE        _U_(0x00000000); /**< \brief (ACIFC_IMR reset_value) Interrupt Mask Register */
 
 #define ACIFC_IMR_ACINT0_Pos        0            /**< \brief (ACIFC_IMR) AC0 Interrupt Mask */
-#define ACIFC_IMR_ACINT0            (_U(0x1) << ACIFC_IMR_ACINT0_Pos)
+#define ACIFC_IMR_ACINT0            (_U_(0x1) << ACIFC_IMR_ACINT0_Pos)
 #define ACIFC_IMR_SUTINT0_Pos       1            /**< \brief (ACIFC_IMR) AC0 Startup Time Interrupt Mask */
-#define ACIFC_IMR_SUTINT0           (_U(0x1) << ACIFC_IMR_SUTINT0_Pos)
+#define ACIFC_IMR_SUTINT0           (_U_(0x1) << ACIFC_IMR_SUTINT0_Pos)
 #define ACIFC_IMR_ACINT1_Pos        2            /**< \brief (ACIFC_IMR) AC1 Interrupt Mask */
-#define ACIFC_IMR_ACINT1            (_U(0x1) << ACIFC_IMR_ACINT1_Pos)
+#define ACIFC_IMR_ACINT1            (_U_(0x1) << ACIFC_IMR_ACINT1_Pos)
 #define ACIFC_IMR_SUTINT1_Pos       3            /**< \brief (ACIFC_IMR) AC1 Startup Time Interrupt Mask */
-#define ACIFC_IMR_SUTINT1           (_U(0x1) << ACIFC_IMR_SUTINT1_Pos)
+#define ACIFC_IMR_SUTINT1           (_U_(0x1) << ACIFC_IMR_SUTINT1_Pos)
 #define ACIFC_IMR_ACINT2_Pos        4            /**< \brief (ACIFC_IMR) AC2 Interrupt Mask */
-#define ACIFC_IMR_ACINT2            (_U(0x1) << ACIFC_IMR_ACINT2_Pos)
+#define ACIFC_IMR_ACINT2            (_U_(0x1) << ACIFC_IMR_ACINT2_Pos)
 #define ACIFC_IMR_SUTINT2_Pos       5            /**< \brief (ACIFC_IMR) AC2 Startup Time Interrupt Mask */
-#define ACIFC_IMR_SUTINT2           (_U(0x1) << ACIFC_IMR_SUTINT2_Pos)
+#define ACIFC_IMR_SUTINT2           (_U_(0x1) << ACIFC_IMR_SUTINT2_Pos)
 #define ACIFC_IMR_ACINT3_Pos        6            /**< \brief (ACIFC_IMR) AC3 Interrupt Mask */
-#define ACIFC_IMR_ACINT3            (_U(0x1) << ACIFC_IMR_ACINT3_Pos)
+#define ACIFC_IMR_ACINT3            (_U_(0x1) << ACIFC_IMR_ACINT3_Pos)
 #define ACIFC_IMR_SUTINT3_Pos       7            /**< \brief (ACIFC_IMR) AC3 Startup Time Interrupt Mask */
-#define ACIFC_IMR_SUTINT3           (_U(0x1) << ACIFC_IMR_SUTINT3_Pos)
+#define ACIFC_IMR_SUTINT3           (_U_(0x1) << ACIFC_IMR_SUTINT3_Pos)
 #define ACIFC_IMR_ACINT4_Pos        8            /**< \brief (ACIFC_IMR) AC4 Interrupt Mask */
-#define ACIFC_IMR_ACINT4            (_U(0x1) << ACIFC_IMR_ACINT4_Pos)
+#define ACIFC_IMR_ACINT4            (_U_(0x1) << ACIFC_IMR_ACINT4_Pos)
 #define ACIFC_IMR_SUTINT4_Pos       9            /**< \brief (ACIFC_IMR) AC4 Startup Time Interrupt Mask */
-#define ACIFC_IMR_SUTINT4           (_U(0x1) << ACIFC_IMR_SUTINT4_Pos)
+#define ACIFC_IMR_SUTINT4           (_U_(0x1) << ACIFC_IMR_SUTINT4_Pos)
 #define ACIFC_IMR_ACINT5_Pos        10           /**< \brief (ACIFC_IMR) AC5 Interrupt Mask */
-#define ACIFC_IMR_ACINT5            (_U(0x1) << ACIFC_IMR_ACINT5_Pos)
+#define ACIFC_IMR_ACINT5            (_U_(0x1) << ACIFC_IMR_ACINT5_Pos)
 #define ACIFC_IMR_SUTINT5_Pos       11           /**< \brief (ACIFC_IMR) AC5 Startup Time Interrupt Mask */
-#define ACIFC_IMR_SUTINT5           (_U(0x1) << ACIFC_IMR_SUTINT5_Pos)
+#define ACIFC_IMR_SUTINT5           (_U_(0x1) << ACIFC_IMR_SUTINT5_Pos)
 #define ACIFC_IMR_ACINT6_Pos        12           /**< \brief (ACIFC_IMR) AC6 Interrupt Mask */
-#define ACIFC_IMR_ACINT6            (_U(0x1) << ACIFC_IMR_ACINT6_Pos)
+#define ACIFC_IMR_ACINT6            (_U_(0x1) << ACIFC_IMR_ACINT6_Pos)
 #define ACIFC_IMR_SUTINT6_Pos       13           /**< \brief (ACIFC_IMR) AC6 Startup Time Interrupt Mask */
-#define ACIFC_IMR_SUTINT6           (_U(0x1) << ACIFC_IMR_SUTINT6_Pos)
+#define ACIFC_IMR_SUTINT6           (_U_(0x1) << ACIFC_IMR_SUTINT6_Pos)
 #define ACIFC_IMR_ACINT7_Pos        14           /**< \brief (ACIFC_IMR) AC7 Interrupt Mask */
-#define ACIFC_IMR_ACINT7            (_U(0x1) << ACIFC_IMR_ACINT7_Pos)
+#define ACIFC_IMR_ACINT7            (_U_(0x1) << ACIFC_IMR_ACINT7_Pos)
 #define ACIFC_IMR_SUTINT7_Pos       15           /**< \brief (ACIFC_IMR) AC7 Startup Time Interrupt Mask */
-#define ACIFC_IMR_SUTINT7           (_U(0x1) << ACIFC_IMR_SUTINT7_Pos)
+#define ACIFC_IMR_SUTINT7           (_U_(0x1) << ACIFC_IMR_SUTINT7_Pos)
 #define ACIFC_IMR_WFINT0_Pos        24           /**< \brief (ACIFC_IMR) Window0 Mode Interrupt Mask */
-#define ACIFC_IMR_WFINT0            (_U(0x1) << ACIFC_IMR_WFINT0_Pos)
+#define ACIFC_IMR_WFINT0            (_U_(0x1) << ACIFC_IMR_WFINT0_Pos)
 #define ACIFC_IMR_WFINT1_Pos        25           /**< \brief (ACIFC_IMR) Window1 Mode Interrupt Mask */
-#define ACIFC_IMR_WFINT1            (_U(0x1) << ACIFC_IMR_WFINT1_Pos)
+#define ACIFC_IMR_WFINT1            (_U_(0x1) << ACIFC_IMR_WFINT1_Pos)
 #define ACIFC_IMR_WFINT2_Pos        26           /**< \brief (ACIFC_IMR) Window2 Mode Interrupt Mask */
-#define ACIFC_IMR_WFINT2            (_U(0x1) << ACIFC_IMR_WFINT2_Pos)
+#define ACIFC_IMR_WFINT2            (_U_(0x1) << ACIFC_IMR_WFINT2_Pos)
 #define ACIFC_IMR_WFINT3_Pos        27           /**< \brief (ACIFC_IMR) Window3 Mode Interrupt Mask */
-#define ACIFC_IMR_WFINT3            (_U(0x1) << ACIFC_IMR_WFINT3_Pos)
-#define ACIFC_IMR_MASK              _U(0x0F00FFFF) /**< \brief (ACIFC_IMR) MASK Register */
+#define ACIFC_IMR_WFINT3            (_U_(0x1) << ACIFC_IMR_WFINT3_Pos)
+#define ACIFC_IMR_MASK              _U_(0x0F00FFFF) /**< \brief (ACIFC_IMR) MASK Register */
 
 /* -------- ACIFC_ISR : (ACIFC Offset: 0x1C) (R/  32) Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -406,49 +406,49 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACIFC_ISR_OFFSET            0x1C         /**< \brief (ACIFC_ISR offset) Interrupt Status Register */
-#define ACIFC_ISR_RESETVALUE        _U(0x00000000); /**< \brief (ACIFC_ISR reset_value) Interrupt Status Register */
+#define ACIFC_ISR_RESETVALUE        _U_(0x00000000); /**< \brief (ACIFC_ISR reset_value) Interrupt Status Register */
 
 #define ACIFC_ISR_ACINT0_Pos        0            /**< \brief (ACIFC_ISR) AC0 Interrupt Status */
-#define ACIFC_ISR_ACINT0            (_U(0x1) << ACIFC_ISR_ACINT0_Pos)
+#define ACIFC_ISR_ACINT0            (_U_(0x1) << ACIFC_ISR_ACINT0_Pos)
 #define ACIFC_ISR_SUTINT0_Pos       1            /**< \brief (ACIFC_ISR) AC0 Startup Time Interrupt Status */
-#define ACIFC_ISR_SUTINT0           (_U(0x1) << ACIFC_ISR_SUTINT0_Pos)
+#define ACIFC_ISR_SUTINT0           (_U_(0x1) << ACIFC_ISR_SUTINT0_Pos)
 #define ACIFC_ISR_ACINT1_Pos        2            /**< \brief (ACIFC_ISR) AC1 Interrupt Status */
-#define ACIFC_ISR_ACINT1            (_U(0x1) << ACIFC_ISR_ACINT1_Pos)
+#define ACIFC_ISR_ACINT1            (_U_(0x1) << ACIFC_ISR_ACINT1_Pos)
 #define ACIFC_ISR_SUTINT1_Pos       3            /**< \brief (ACIFC_ISR) AC1 Startup Time Interrupt Status */
-#define ACIFC_ISR_SUTINT1           (_U(0x1) << ACIFC_ISR_SUTINT1_Pos)
+#define ACIFC_ISR_SUTINT1           (_U_(0x1) << ACIFC_ISR_SUTINT1_Pos)
 #define ACIFC_ISR_ACINT2_Pos        4            /**< \brief (ACIFC_ISR) AC2 Interrupt Status */
-#define ACIFC_ISR_ACINT2            (_U(0x1) << ACIFC_ISR_ACINT2_Pos)
+#define ACIFC_ISR_ACINT2            (_U_(0x1) << ACIFC_ISR_ACINT2_Pos)
 #define ACIFC_ISR_SUTINT2_Pos       5            /**< \brief (ACIFC_ISR) AC2 Startup Time Interrupt Status */
-#define ACIFC_ISR_SUTINT2           (_U(0x1) << ACIFC_ISR_SUTINT2_Pos)
+#define ACIFC_ISR_SUTINT2           (_U_(0x1) << ACIFC_ISR_SUTINT2_Pos)
 #define ACIFC_ISR_ACINT3_Pos        6            /**< \brief (ACIFC_ISR) AC3 Interrupt Status */
-#define ACIFC_ISR_ACINT3            (_U(0x1) << ACIFC_ISR_ACINT3_Pos)
+#define ACIFC_ISR_ACINT3            (_U_(0x1) << ACIFC_ISR_ACINT3_Pos)
 #define ACIFC_ISR_SUTINT3_Pos       7            /**< \brief (ACIFC_ISR) AC3 Startup Time Interrupt Status */
-#define ACIFC_ISR_SUTINT3           (_U(0x1) << ACIFC_ISR_SUTINT3_Pos)
+#define ACIFC_ISR_SUTINT3           (_U_(0x1) << ACIFC_ISR_SUTINT3_Pos)
 #define ACIFC_ISR_ACINT4_Pos        8            /**< \brief (ACIFC_ISR) AC4 Interrupt Status */
-#define ACIFC_ISR_ACINT4            (_U(0x1) << ACIFC_ISR_ACINT4_Pos)
+#define ACIFC_ISR_ACINT4            (_U_(0x1) << ACIFC_ISR_ACINT4_Pos)
 #define ACIFC_ISR_SUTINT4_Pos       9            /**< \brief (ACIFC_ISR) AC4 Startup Time Interrupt Status */
-#define ACIFC_ISR_SUTINT4           (_U(0x1) << ACIFC_ISR_SUTINT4_Pos)
+#define ACIFC_ISR_SUTINT4           (_U_(0x1) << ACIFC_ISR_SUTINT4_Pos)
 #define ACIFC_ISR_ACINT5_Pos        10           /**< \brief (ACIFC_ISR) AC5 Interrupt Status */
-#define ACIFC_ISR_ACINT5            (_U(0x1) << ACIFC_ISR_ACINT5_Pos)
+#define ACIFC_ISR_ACINT5            (_U_(0x1) << ACIFC_ISR_ACINT5_Pos)
 #define ACIFC_ISR_SUTINT5_Pos       11           /**< \brief (ACIFC_ISR) AC5 Startup Time Interrupt Status */
-#define ACIFC_ISR_SUTINT5           (_U(0x1) << ACIFC_ISR_SUTINT5_Pos)
+#define ACIFC_ISR_SUTINT5           (_U_(0x1) << ACIFC_ISR_SUTINT5_Pos)
 #define ACIFC_ISR_ACINT6_Pos        12           /**< \brief (ACIFC_ISR) AC6 Interrupt Status */
-#define ACIFC_ISR_ACINT6            (_U(0x1) << ACIFC_ISR_ACINT6_Pos)
+#define ACIFC_ISR_ACINT6            (_U_(0x1) << ACIFC_ISR_ACINT6_Pos)
 #define ACIFC_ISR_SUTINT6_Pos       13           /**< \brief (ACIFC_ISR) AC6 Startup Time Interrupt Status */
-#define ACIFC_ISR_SUTINT6           (_U(0x1) << ACIFC_ISR_SUTINT6_Pos)
+#define ACIFC_ISR_SUTINT6           (_U_(0x1) << ACIFC_ISR_SUTINT6_Pos)
 #define ACIFC_ISR_ACINT7_Pos        14           /**< \brief (ACIFC_ISR) AC7 Interrupt Status */
-#define ACIFC_ISR_ACINT7            (_U(0x1) << ACIFC_ISR_ACINT7_Pos)
+#define ACIFC_ISR_ACINT7            (_U_(0x1) << ACIFC_ISR_ACINT7_Pos)
 #define ACIFC_ISR_SUTINT7_Pos       15           /**< \brief (ACIFC_ISR) AC7 Startup Time Interrupt Status */
-#define ACIFC_ISR_SUTINT7           (_U(0x1) << ACIFC_ISR_SUTINT7_Pos)
+#define ACIFC_ISR_SUTINT7           (_U_(0x1) << ACIFC_ISR_SUTINT7_Pos)
 #define ACIFC_ISR_WFINT0_Pos        24           /**< \brief (ACIFC_ISR) Window0 Mode Interrupt Status */
-#define ACIFC_ISR_WFINT0            (_U(0x1) << ACIFC_ISR_WFINT0_Pos)
+#define ACIFC_ISR_WFINT0            (_U_(0x1) << ACIFC_ISR_WFINT0_Pos)
 #define ACIFC_ISR_WFINT1_Pos        25           /**< \brief (ACIFC_ISR) Window1 Mode Interrupt Status */
-#define ACIFC_ISR_WFINT1            (_U(0x1) << ACIFC_ISR_WFINT1_Pos)
+#define ACIFC_ISR_WFINT1            (_U_(0x1) << ACIFC_ISR_WFINT1_Pos)
 #define ACIFC_ISR_WFINT2_Pos        26           /**< \brief (ACIFC_ISR) Window2 Mode Interrupt Status */
-#define ACIFC_ISR_WFINT2            (_U(0x1) << ACIFC_ISR_WFINT2_Pos)
+#define ACIFC_ISR_WFINT2            (_U_(0x1) << ACIFC_ISR_WFINT2_Pos)
 #define ACIFC_ISR_WFINT3_Pos        27           /**< \brief (ACIFC_ISR) Window3 Mode Interrupt Status */
-#define ACIFC_ISR_WFINT3            (_U(0x1) << ACIFC_ISR_WFINT3_Pos)
-#define ACIFC_ISR_MASK              _U(0x0F00FFFF) /**< \brief (ACIFC_ISR) MASK Register */
+#define ACIFC_ISR_WFINT3            (_U_(0x1) << ACIFC_ISR_WFINT3_Pos)
+#define ACIFC_ISR_MASK              _U_(0x0F00FFFF) /**< \brief (ACIFC_ISR) MASK Register */
 
 /* -------- ACIFC_ICR : (ACIFC Offset: 0x20) ( /W 32) Interrupt Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -482,49 +482,49 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACIFC_ICR_OFFSET            0x20         /**< \brief (ACIFC_ICR offset) Interrupt Status Clear Register */
-#define ACIFC_ICR_RESETVALUE        _U(0x00000000); /**< \brief (ACIFC_ICR reset_value) Interrupt Status Clear Register */
+#define ACIFC_ICR_RESETVALUE        _U_(0x00000000); /**< \brief (ACIFC_ICR reset_value) Interrupt Status Clear Register */
 
 #define ACIFC_ICR_ACINT0_Pos        0            /**< \brief (ACIFC_ICR) AC0 Interrupt Status Clear */
-#define ACIFC_ICR_ACINT0            (_U(0x1) << ACIFC_ICR_ACINT0_Pos)
+#define ACIFC_ICR_ACINT0            (_U_(0x1) << ACIFC_ICR_ACINT0_Pos)
 #define ACIFC_ICR_SUTINT0_Pos       1            /**< \brief (ACIFC_ICR) AC0 Startup Time Interrupt Status Clear */
-#define ACIFC_ICR_SUTINT0           (_U(0x1) << ACIFC_ICR_SUTINT0_Pos)
+#define ACIFC_ICR_SUTINT0           (_U_(0x1) << ACIFC_ICR_SUTINT0_Pos)
 #define ACIFC_ICR_ACINT1_Pos        2            /**< \brief (ACIFC_ICR) AC1 Interrupt Status Clear */
-#define ACIFC_ICR_ACINT1            (_U(0x1) << ACIFC_ICR_ACINT1_Pos)
+#define ACIFC_ICR_ACINT1            (_U_(0x1) << ACIFC_ICR_ACINT1_Pos)
 #define ACIFC_ICR_SUTINT1_Pos       3            /**< \brief (ACIFC_ICR) AC1 Startup Time Interrupt Status Clear */
-#define ACIFC_ICR_SUTINT1           (_U(0x1) << ACIFC_ICR_SUTINT1_Pos)
+#define ACIFC_ICR_SUTINT1           (_U_(0x1) << ACIFC_ICR_SUTINT1_Pos)
 #define ACIFC_ICR_ACINT2_Pos        4            /**< \brief (ACIFC_ICR) AC2 Interrupt Status Clear */
-#define ACIFC_ICR_ACINT2            (_U(0x1) << ACIFC_ICR_ACINT2_Pos)
+#define ACIFC_ICR_ACINT2            (_U_(0x1) << ACIFC_ICR_ACINT2_Pos)
 #define ACIFC_ICR_SUTINT2_Pos       5            /**< \brief (ACIFC_ICR) AC2 Startup Time Interrupt Status Clear */
-#define ACIFC_ICR_SUTINT2           (_U(0x1) << ACIFC_ICR_SUTINT2_Pos)
+#define ACIFC_ICR_SUTINT2           (_U_(0x1) << ACIFC_ICR_SUTINT2_Pos)
 #define ACIFC_ICR_ACINT3_Pos        6            /**< \brief (ACIFC_ICR) AC3 Interrupt Status Clear */
-#define ACIFC_ICR_ACINT3            (_U(0x1) << ACIFC_ICR_ACINT3_Pos)
+#define ACIFC_ICR_ACINT3            (_U_(0x1) << ACIFC_ICR_ACINT3_Pos)
 #define ACIFC_ICR_SUTINT3_Pos       7            /**< \brief (ACIFC_ICR) AC3 Startup Time Interrupt Status Clear */
-#define ACIFC_ICR_SUTINT3           (_U(0x1) << ACIFC_ICR_SUTINT3_Pos)
+#define ACIFC_ICR_SUTINT3           (_U_(0x1) << ACIFC_ICR_SUTINT3_Pos)
 #define ACIFC_ICR_ACINT4_Pos        8            /**< \brief (ACIFC_ICR) AC4 Interrupt Status Clear */
-#define ACIFC_ICR_ACINT4            (_U(0x1) << ACIFC_ICR_ACINT4_Pos)
+#define ACIFC_ICR_ACINT4            (_U_(0x1) << ACIFC_ICR_ACINT4_Pos)
 #define ACIFC_ICR_SUTINT4_Pos       9            /**< \brief (ACIFC_ICR) AC4 Startup Time Interrupt Status Clear */
-#define ACIFC_ICR_SUTINT4           (_U(0x1) << ACIFC_ICR_SUTINT4_Pos)
+#define ACIFC_ICR_SUTINT4           (_U_(0x1) << ACIFC_ICR_SUTINT4_Pos)
 #define ACIFC_ICR_ACINT5_Pos        10           /**< \brief (ACIFC_ICR) AC5 Interrupt Status Clear */
-#define ACIFC_ICR_ACINT5            (_U(0x1) << ACIFC_ICR_ACINT5_Pos)
+#define ACIFC_ICR_ACINT5            (_U_(0x1) << ACIFC_ICR_ACINT5_Pos)
 #define ACIFC_ICR_SUTINT5_Pos       11           /**< \brief (ACIFC_ICR) AC5 Startup Time Interrupt Status Clear */
-#define ACIFC_ICR_SUTINT5           (_U(0x1) << ACIFC_ICR_SUTINT5_Pos)
+#define ACIFC_ICR_SUTINT5           (_U_(0x1) << ACIFC_ICR_SUTINT5_Pos)
 #define ACIFC_ICR_ACINT6_Pos        12           /**< \brief (ACIFC_ICR) AC6 Interrupt Status Clear */
-#define ACIFC_ICR_ACINT6            (_U(0x1) << ACIFC_ICR_ACINT6_Pos)
+#define ACIFC_ICR_ACINT6            (_U_(0x1) << ACIFC_ICR_ACINT6_Pos)
 #define ACIFC_ICR_SUTINT6_Pos       13           /**< \brief (ACIFC_ICR) AC6 Startup Time Interrupt Status Clear */
-#define ACIFC_ICR_SUTINT6           (_U(0x1) << ACIFC_ICR_SUTINT6_Pos)
+#define ACIFC_ICR_SUTINT6           (_U_(0x1) << ACIFC_ICR_SUTINT6_Pos)
 #define ACIFC_ICR_ACINT7_Pos        14           /**< \brief (ACIFC_ICR) AC7 Interrupt Status Clear */
-#define ACIFC_ICR_ACINT7            (_U(0x1) << ACIFC_ICR_ACINT7_Pos)
+#define ACIFC_ICR_ACINT7            (_U_(0x1) << ACIFC_ICR_ACINT7_Pos)
 #define ACIFC_ICR_SUTINT7_Pos       15           /**< \brief (ACIFC_ICR) AC7 Startup Time Interrupt Status Clear */
-#define ACIFC_ICR_SUTINT7           (_U(0x1) << ACIFC_ICR_SUTINT7_Pos)
+#define ACIFC_ICR_SUTINT7           (_U_(0x1) << ACIFC_ICR_SUTINT7_Pos)
 #define ACIFC_ICR_WFINT0_Pos        24           /**< \brief (ACIFC_ICR) Window0 Mode Interrupt Status Clear */
-#define ACIFC_ICR_WFINT0            (_U(0x1) << ACIFC_ICR_WFINT0_Pos)
+#define ACIFC_ICR_WFINT0            (_U_(0x1) << ACIFC_ICR_WFINT0_Pos)
 #define ACIFC_ICR_WFINT1_Pos        25           /**< \brief (ACIFC_ICR) Window1 Mode Interrupt Status Clear */
-#define ACIFC_ICR_WFINT1            (_U(0x1) << ACIFC_ICR_WFINT1_Pos)
+#define ACIFC_ICR_WFINT1            (_U_(0x1) << ACIFC_ICR_WFINT1_Pos)
 #define ACIFC_ICR_WFINT2_Pos        26           /**< \brief (ACIFC_ICR) Window2 Mode Interrupt Status Clear */
-#define ACIFC_ICR_WFINT2            (_U(0x1) << ACIFC_ICR_WFINT2_Pos)
+#define ACIFC_ICR_WFINT2            (_U_(0x1) << ACIFC_ICR_WFINT2_Pos)
 #define ACIFC_ICR_WFINT3_Pos        27           /**< \brief (ACIFC_ICR) Window3 Mode Interrupt Status Clear */
-#define ACIFC_ICR_WFINT3            (_U(0x1) << ACIFC_ICR_WFINT3_Pos)
-#define ACIFC_ICR_MASK              _U(0x0F00FFFF) /**< \brief (ACIFC_ICR) MASK Register */
+#define ACIFC_ICR_WFINT3            (_U_(0x1) << ACIFC_ICR_WFINT3_Pos)
+#define ACIFC_ICR_MASK              _U_(0x0F00FFFF) /**< \brief (ACIFC_ICR) MASK Register */
 
 /* -------- ACIFC_TR : (ACIFC Offset: 0x24) (R/W 32) Test Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -545,25 +545,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACIFC_TR_OFFSET             0x24         /**< \brief (ACIFC_TR offset) Test Register */
-#define ACIFC_TR_RESETVALUE         _U(0x00000000); /**< \brief (ACIFC_TR reset_value) Test Register */
+#define ACIFC_TR_RESETVALUE         _U_(0x00000000); /**< \brief (ACIFC_TR reset_value) Test Register */
 
 #define ACIFC_TR_ACTEST0_Pos        0            /**< \brief (ACIFC_TR) AC0 Output Override Value */
-#define ACIFC_TR_ACTEST0            (_U(0x1) << ACIFC_TR_ACTEST0_Pos)
+#define ACIFC_TR_ACTEST0            (_U_(0x1) << ACIFC_TR_ACTEST0_Pos)
 #define ACIFC_TR_ACTEST1_Pos        1            /**< \brief (ACIFC_TR) AC1 Output Override Value */
-#define ACIFC_TR_ACTEST1            (_U(0x1) << ACIFC_TR_ACTEST1_Pos)
+#define ACIFC_TR_ACTEST1            (_U_(0x1) << ACIFC_TR_ACTEST1_Pos)
 #define ACIFC_TR_ACTEST2_Pos        2            /**< \brief (ACIFC_TR) AC2 Output Override Value */
-#define ACIFC_TR_ACTEST2            (_U(0x1) << ACIFC_TR_ACTEST2_Pos)
+#define ACIFC_TR_ACTEST2            (_U_(0x1) << ACIFC_TR_ACTEST2_Pos)
 #define ACIFC_TR_ACTEST3_Pos        3            /**< \brief (ACIFC_TR) AC3 Output Override Value */
-#define ACIFC_TR_ACTEST3            (_U(0x1) << ACIFC_TR_ACTEST3_Pos)
+#define ACIFC_TR_ACTEST3            (_U_(0x1) << ACIFC_TR_ACTEST3_Pos)
 #define ACIFC_TR_ACTEST4_Pos        4            /**< \brief (ACIFC_TR) AC4 Output Override Value */
-#define ACIFC_TR_ACTEST4            (_U(0x1) << ACIFC_TR_ACTEST4_Pos)
+#define ACIFC_TR_ACTEST4            (_U_(0x1) << ACIFC_TR_ACTEST4_Pos)
 #define ACIFC_TR_ACTEST5_Pos        5            /**< \brief (ACIFC_TR) AC5 Output Override Value */
-#define ACIFC_TR_ACTEST5            (_U(0x1) << ACIFC_TR_ACTEST5_Pos)
+#define ACIFC_TR_ACTEST5            (_U_(0x1) << ACIFC_TR_ACTEST5_Pos)
 #define ACIFC_TR_ACTEST6_Pos        6            /**< \brief (ACIFC_TR) AC6 Output Override Value */
-#define ACIFC_TR_ACTEST6            (_U(0x1) << ACIFC_TR_ACTEST6_Pos)
+#define ACIFC_TR_ACTEST6            (_U_(0x1) << ACIFC_TR_ACTEST6_Pos)
 #define ACIFC_TR_ACTEST7_Pos        7            /**< \brief (ACIFC_TR) AC7 Output Override Value */
-#define ACIFC_TR_ACTEST7            (_U(0x1) << ACIFC_TR_ACTEST7_Pos)
-#define ACIFC_TR_MASK               _U(0x000000FF) /**< \brief (ACIFC_TR) MASK Register */
+#define ACIFC_TR_ACTEST7            (_U_(0x1) << ACIFC_TR_ACTEST7_Pos)
+#define ACIFC_TR_MASK               _U_(0x000000FF) /**< \brief (ACIFC_TR) MASK Register */
 
 /* -------- ACIFC_PARAMETER : (ACIFC Offset: 0x30) (R/  32) Parameter Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -591,30 +591,30 @@ typedef union {
 #define ACIFC_PARAMETER_OFFSET      0x30         /**< \brief (ACIFC_PARAMETER offset) Parameter Register */
 
 #define ACIFC_PARAMETER_ACIMPL0_Pos 0            /**< \brief (ACIFC_PARAMETER) Analog Comparator 0 Implemented */
-#define ACIFC_PARAMETER_ACIMPL0     (_U(0x1) << ACIFC_PARAMETER_ACIMPL0_Pos)
+#define ACIFC_PARAMETER_ACIMPL0     (_U_(0x1) << ACIFC_PARAMETER_ACIMPL0_Pos)
 #define ACIFC_PARAMETER_ACIMPL1_Pos 1            /**< \brief (ACIFC_PARAMETER) Analog Comparator 1 Implemented */
-#define ACIFC_PARAMETER_ACIMPL1     (_U(0x1) << ACIFC_PARAMETER_ACIMPL1_Pos)
+#define ACIFC_PARAMETER_ACIMPL1     (_U_(0x1) << ACIFC_PARAMETER_ACIMPL1_Pos)
 #define ACIFC_PARAMETER_ACIMPL2_Pos 2            /**< \brief (ACIFC_PARAMETER) Analog Comparator 2 Implemented */
-#define ACIFC_PARAMETER_ACIMPL2     (_U(0x1) << ACIFC_PARAMETER_ACIMPL2_Pos)
+#define ACIFC_PARAMETER_ACIMPL2     (_U_(0x1) << ACIFC_PARAMETER_ACIMPL2_Pos)
 #define ACIFC_PARAMETER_ACIMPL3_Pos 3            /**< \brief (ACIFC_PARAMETER) Analog Comparator 3 Implemented */
-#define ACIFC_PARAMETER_ACIMPL3     (_U(0x1) << ACIFC_PARAMETER_ACIMPL3_Pos)
+#define ACIFC_PARAMETER_ACIMPL3     (_U_(0x1) << ACIFC_PARAMETER_ACIMPL3_Pos)
 #define ACIFC_PARAMETER_ACIMPL4_Pos 4            /**< \brief (ACIFC_PARAMETER) Analog Comparator 4 Implemented */
-#define ACIFC_PARAMETER_ACIMPL4     (_U(0x1) << ACIFC_PARAMETER_ACIMPL4_Pos)
+#define ACIFC_PARAMETER_ACIMPL4     (_U_(0x1) << ACIFC_PARAMETER_ACIMPL4_Pos)
 #define ACIFC_PARAMETER_ACIMPL5_Pos 5            /**< \brief (ACIFC_PARAMETER) Analog Comparator 5 Implemented */
-#define ACIFC_PARAMETER_ACIMPL5     (_U(0x1) << ACIFC_PARAMETER_ACIMPL5_Pos)
+#define ACIFC_PARAMETER_ACIMPL5     (_U_(0x1) << ACIFC_PARAMETER_ACIMPL5_Pos)
 #define ACIFC_PARAMETER_ACIMPL6_Pos 6            /**< \brief (ACIFC_PARAMETER) Analog Comparator 6 Implemented */
-#define ACIFC_PARAMETER_ACIMPL6     (_U(0x1) << ACIFC_PARAMETER_ACIMPL6_Pos)
+#define ACIFC_PARAMETER_ACIMPL6     (_U_(0x1) << ACIFC_PARAMETER_ACIMPL6_Pos)
 #define ACIFC_PARAMETER_ACIMPL7_Pos 7            /**< \brief (ACIFC_PARAMETER) Analog Comparator 7 Implemented */
-#define ACIFC_PARAMETER_ACIMPL7     (_U(0x1) << ACIFC_PARAMETER_ACIMPL7_Pos)
+#define ACIFC_PARAMETER_ACIMPL7     (_U_(0x1) << ACIFC_PARAMETER_ACIMPL7_Pos)
 #define ACIFC_PARAMETER_WIMPL0_Pos  16           /**< \brief (ACIFC_PARAMETER) Window0 Mode  Implemented */
-#define ACIFC_PARAMETER_WIMPL0      (_U(0x1) << ACIFC_PARAMETER_WIMPL0_Pos)
+#define ACIFC_PARAMETER_WIMPL0      (_U_(0x1) << ACIFC_PARAMETER_WIMPL0_Pos)
 #define ACIFC_PARAMETER_WIMPL1_Pos  17           /**< \brief (ACIFC_PARAMETER) Window1 Mode  Implemented */
-#define ACIFC_PARAMETER_WIMPL1      (_U(0x1) << ACIFC_PARAMETER_WIMPL1_Pos)
+#define ACIFC_PARAMETER_WIMPL1      (_U_(0x1) << ACIFC_PARAMETER_WIMPL1_Pos)
 #define ACIFC_PARAMETER_WIMPL2_Pos  18           /**< \brief (ACIFC_PARAMETER) Window2 Mode  Implemented */
-#define ACIFC_PARAMETER_WIMPL2      (_U(0x1) << ACIFC_PARAMETER_WIMPL2_Pos)
+#define ACIFC_PARAMETER_WIMPL2      (_U_(0x1) << ACIFC_PARAMETER_WIMPL2_Pos)
 #define ACIFC_PARAMETER_WIMPL3_Pos  19           /**< \brief (ACIFC_PARAMETER) Window3 Mode  Implemented */
-#define ACIFC_PARAMETER_WIMPL3      (_U(0x1) << ACIFC_PARAMETER_WIMPL3_Pos)
-#define ACIFC_PARAMETER_MASK        _U(0x000F00FF) /**< \brief (ACIFC_PARAMETER) MASK Register */
+#define ACIFC_PARAMETER_WIMPL3      (_U_(0x1) << ACIFC_PARAMETER_WIMPL3_Pos)
+#define ACIFC_PARAMETER_MASK        _U_(0x000F00FF) /**< \brief (ACIFC_PARAMETER) MASK Register */
 
 /* -------- ACIFC_VERSION : (ACIFC Offset: 0x34) (R/  32) Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -630,15 +630,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACIFC_VERSION_OFFSET        0x34         /**< \brief (ACIFC_VERSION offset) Version Register */
-#define ACIFC_VERSION_RESETVALUE    _U(0x00000101); /**< \brief (ACIFC_VERSION reset_value) Version Register */
+#define ACIFC_VERSION_RESETVALUE    _U_(0x00000101); /**< \brief (ACIFC_VERSION reset_value) Version Register */
 
 #define ACIFC_VERSION_VERSION_Pos   0            /**< \brief (ACIFC_VERSION) Version Number */
-#define ACIFC_VERSION_VERSION_Msk   (_U(0xFFF) << ACIFC_VERSION_VERSION_Pos)
+#define ACIFC_VERSION_VERSION_Msk   (_U_(0xFFF) << ACIFC_VERSION_VERSION_Pos)
 #define ACIFC_VERSION_VERSION(value) (ACIFC_VERSION_VERSION_Msk & ((value) << ACIFC_VERSION_VERSION_Pos))
 #define ACIFC_VERSION_VARIANT_Pos   16           /**< \brief (ACIFC_VERSION) Variant Number */
-#define ACIFC_VERSION_VARIANT_Msk   (_U(0xF) << ACIFC_VERSION_VARIANT_Pos)
+#define ACIFC_VERSION_VARIANT_Msk   (_U_(0xF) << ACIFC_VERSION_VARIANT_Pos)
 #define ACIFC_VERSION_VARIANT(value) (ACIFC_VERSION_VARIANT_Msk & ((value) << ACIFC_VERSION_VARIANT_Pos))
-#define ACIFC_VERSION_MASK          _U(0x000F0FFF) /**< \brief (ACIFC_VERSION) MASK Register */
+#define ACIFC_VERSION_MASK          _U_(0x000F0FFF) /**< \brief (ACIFC_VERSION) MASK Register */
 
 /* -------- ACIFC_CONFW : (ACIFC Offset: 0x80) (R/W 32) CONFW Window configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -657,19 +657,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACIFC_CONFW_OFFSET          0x80         /**< \brief (ACIFC_CONFW offset) Window configuration Register */
-#define ACIFC_CONFW_RESETVALUE      _U(0x00000000); /**< \brief (ACIFC_CONFW reset_value) Window configuration Register */
+#define ACIFC_CONFW_RESETVALUE      _U_(0x00000000); /**< \brief (ACIFC_CONFW reset_value) Window configuration Register */
 
 #define ACIFC_CONFW_WIS_Pos         0            /**< \brief (ACIFC_CONFW) Window Mode Interrupt Settings */
-#define ACIFC_CONFW_WIS_Msk         (_U(0x7) << ACIFC_CONFW_WIS_Pos)
+#define ACIFC_CONFW_WIS_Msk         (_U_(0x7) << ACIFC_CONFW_WIS_Pos)
 #define ACIFC_CONFW_WIS(value)      (ACIFC_CONFW_WIS_Msk & ((value) << ACIFC_CONFW_WIS_Pos))
 #define ACIFC_CONFW_WEVSRC_Pos      8            /**< \brief (ACIFC_CONFW) Peripheral Event Sourse Selection for Window Mode */
-#define ACIFC_CONFW_WEVSRC_Msk      (_U(0x7) << ACIFC_CONFW_WEVSRC_Pos)
+#define ACIFC_CONFW_WEVSRC_Msk      (_U_(0x7) << ACIFC_CONFW_WEVSRC_Pos)
 #define ACIFC_CONFW_WEVSRC(value)   (ACIFC_CONFW_WEVSRC_Msk & ((value) << ACIFC_CONFW_WEVSRC_Pos))
 #define ACIFC_CONFW_WEVEN_Pos       11           /**< \brief (ACIFC_CONFW) Window Peripheral Event Enable */
-#define ACIFC_CONFW_WEVEN           (_U(0x1) << ACIFC_CONFW_WEVEN_Pos)
+#define ACIFC_CONFW_WEVEN           (_U_(0x1) << ACIFC_CONFW_WEVEN_Pos)
 #define ACIFC_CONFW_WFEN_Pos        16           /**< \brief (ACIFC_CONFW) Window Mode Enable */
-#define ACIFC_CONFW_WFEN            (_U(0x1) << ACIFC_CONFW_WFEN_Pos)
-#define ACIFC_CONFW_MASK            _U(0x00010F07) /**< \brief (ACIFC_CONFW) MASK Register */
+#define ACIFC_CONFW_WFEN            (_U_(0x1) << ACIFC_CONFW_WFEN_Pos)
+#define ACIFC_CONFW_MASK            _U_(0x00010F07) /**< \brief (ACIFC_CONFW) MASK Register */
 
 /* -------- ACIFC_CONF : (ACIFC Offset: 0xD0) (R/W 32) CONF AC Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -694,29 +694,29 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACIFC_CONF_OFFSET           0xD0         /**< \brief (ACIFC_CONF offset) AC Configuration Register */
-#define ACIFC_CONF_RESETVALUE       _U(0x00000000); /**< \brief (ACIFC_CONF reset_value) AC Configuration Register */
+#define ACIFC_CONF_RESETVALUE       _U_(0x00000000); /**< \brief (ACIFC_CONF reset_value) AC Configuration Register */
 
 #define ACIFC_CONF_IS_Pos           0            /**< \brief (ACIFC_CONF) Interupt Settings */
-#define ACIFC_CONF_IS_Msk           (_U(0x3) << ACIFC_CONF_IS_Pos)
+#define ACIFC_CONF_IS_Msk           (_U_(0x3) << ACIFC_CONF_IS_Pos)
 #define ACIFC_CONF_IS(value)        (ACIFC_CONF_IS_Msk & ((value) << ACIFC_CONF_IS_Pos))
 #define ACIFC_CONF_MODE_Pos         4            /**< \brief (ACIFC_CONF) Analog Comparator Mode */
-#define ACIFC_CONF_MODE_Msk         (_U(0x3) << ACIFC_CONF_MODE_Pos)
+#define ACIFC_CONF_MODE_Msk         (_U_(0x3) << ACIFC_CONF_MODE_Pos)
 #define ACIFC_CONF_MODE(value)      (ACIFC_CONF_MODE_Msk & ((value) << ACIFC_CONF_MODE_Pos))
 #define ACIFC_CONF_INSELN_Pos       8            /**< \brief (ACIFC_CONF) Negative Input Select */
-#define ACIFC_CONF_INSELN_Msk       (_U(0x3) << ACIFC_CONF_INSELN_Pos)
+#define ACIFC_CONF_INSELN_Msk       (_U_(0x3) << ACIFC_CONF_INSELN_Pos)
 #define ACIFC_CONF_INSELN(value)    (ACIFC_CONF_INSELN_Msk & ((value) << ACIFC_CONF_INSELN_Pos))
 #define ACIFC_CONF_EVENN_Pos        16           /**< \brief (ACIFC_CONF) Peripheral Event Enable Negative */
-#define ACIFC_CONF_EVENN            (_U(0x1) << ACIFC_CONF_EVENN_Pos)
+#define ACIFC_CONF_EVENN            (_U_(0x1) << ACIFC_CONF_EVENN_Pos)
 #define ACIFC_CONF_EVENP_Pos        17           /**< \brief (ACIFC_CONF) Peripheral Event Enable Positive */
-#define ACIFC_CONF_EVENP            (_U(0x1) << ACIFC_CONF_EVENP_Pos)
+#define ACIFC_CONF_EVENP            (_U_(0x1) << ACIFC_CONF_EVENP_Pos)
 #define ACIFC_CONF_HYS_Pos          24           /**< \brief (ACIFC_CONF) Hysteresis Voltage Value */
-#define ACIFC_CONF_HYS_Msk          (_U(0x3) << ACIFC_CONF_HYS_Pos)
+#define ACIFC_CONF_HYS_Msk          (_U_(0x3) << ACIFC_CONF_HYS_Pos)
 #define ACIFC_CONF_HYS(value)       (ACIFC_CONF_HYS_Msk & ((value) << ACIFC_CONF_HYS_Pos))
 #define ACIFC_CONF_FAST_Pos         26           /**< \brief (ACIFC_CONF) Fast Mode Enable */
-#define ACIFC_CONF_FAST             (_U(0x1) << ACIFC_CONF_FAST_Pos)
+#define ACIFC_CONF_FAST             (_U_(0x1) << ACIFC_CONF_FAST_Pos)
 #define ACIFC_CONF_ALWAYSON_Pos     27           /**< \brief (ACIFC_CONF) Always On */
-#define ACIFC_CONF_ALWAYSON         (_U(0x1) << ACIFC_CONF_ALWAYSON_Pos)
-#define ACIFC_CONF_MASK             _U(0x0F030333) /**< \brief (ACIFC_CONF) MASK Register */
+#define ACIFC_CONF_ALWAYSON         (_U_(0x1) << ACIFC_CONF_ALWAYSON_Pos)
+#define ACIFC_CONF_MASK             _U_(0x0F030333) /**< \brief (ACIFC_CONF) MASK Register */
 
 /** \brief AcifcConf hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/acifc.h
+++ b/asf/sam/include/sam4l/component/acifc.h
@@ -1,0 +1,789 @@
+/**
+ * \file
+ *
+ * \brief Component description for ACIFC
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_ACIFC_COMPONENT_
+#define _SAM4L_ACIFC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR ACIFC */
+/* ========================================================================== */
+/** \addtogroup SAM4L_ACIFC Analog Comparator Interface */
+/*@{*/
+
+#define ACIFC_I7564
+#define REV_ACIFC                   0x101
+
+/* -------- ACIFC_CTRL : (ACIFC Offset: 0x00) (R/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EN:1;             /*!< bit:      0  ACIFC Enable                       */
+    uint32_t EVENTEN:1;        /*!< bit:      1  Peripheral Event Trigger Enable    */
+    uint32_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint32_t USTART:1;         /*!< bit:      4  User Start Single Comparison       */
+    uint32_t ESTART:1;         /*!< bit:      5  Peripheral Event Start Single Comparison */
+    uint32_t :1;               /*!< bit:      6  Reserved                           */
+    uint32_t ACTEST:1;         /*!< bit:      7  Analog Comparator Test Mode        */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ACIFC_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACIFC_CTRL_OFFSET           0x00         /**< \brief (ACIFC_CTRL offset) Control Register */
+#define ACIFC_CTRL_RESETVALUE       _U(0x00000000); /**< \brief (ACIFC_CTRL reset_value) Control Register */
+
+#define ACIFC_CTRL_EN_Pos           0            /**< \brief (ACIFC_CTRL) ACIFC Enable */
+#define ACIFC_CTRL_EN               (_U(0x1) << ACIFC_CTRL_EN_Pos)
+#define ACIFC_CTRL_EVENTEN_Pos      1            /**< \brief (ACIFC_CTRL) Peripheral Event Trigger Enable */
+#define ACIFC_CTRL_EVENTEN          (_U(0x1) << ACIFC_CTRL_EVENTEN_Pos)
+#define ACIFC_CTRL_USTART_Pos       4            /**< \brief (ACIFC_CTRL) User Start Single Comparison */
+#define ACIFC_CTRL_USTART           (_U(0x1) << ACIFC_CTRL_USTART_Pos)
+#define ACIFC_CTRL_ESTART_Pos       5            /**< \brief (ACIFC_CTRL) Peripheral Event Start Single Comparison */
+#define ACIFC_CTRL_ESTART           (_U(0x1) << ACIFC_CTRL_ESTART_Pos)
+#define ACIFC_CTRL_ACTEST_Pos       7            /**< \brief (ACIFC_CTRL) Analog Comparator Test Mode */
+#define ACIFC_CTRL_ACTEST           (_U(0x1) << ACIFC_CTRL_ACTEST_Pos)
+#define ACIFC_CTRL_MASK             _U(0x000000B3) /**< \brief (ACIFC_CTRL) MASK Register */
+
+/* -------- ACIFC_SR : (ACIFC Offset: 0x04) (R/  32) Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ACCS0:1;          /*!< bit:      0  AC0 Current Comparison Status      */
+    uint32_t ACRDY0:1;         /*!< bit:      1  AC0 Ready                          */
+    uint32_t ACCS1:1;          /*!< bit:      2  AC1 Current Comparison Status      */
+    uint32_t ACRDY1:1;         /*!< bit:      3  AC1 Ready                          */
+    uint32_t ACCS2:1;          /*!< bit:      4  AC2 Current Comparison Status      */
+    uint32_t ACRDY2:1;         /*!< bit:      5  AC2 Ready                          */
+    uint32_t ACCS3:1;          /*!< bit:      6  AC3 Current Comparison Status      */
+    uint32_t ACRDY3:1;         /*!< bit:      7  AC3 Ready                          */
+    uint32_t ACCS4:1;          /*!< bit:      8  AC4 Current Comparison Status      */
+    uint32_t ACRDY4:1;         /*!< bit:      9  AC4 Ready                          */
+    uint32_t ACCS5:1;          /*!< bit:     10  AC5 Current Comparison Status      */
+    uint32_t ACRDY5:1;         /*!< bit:     11  AC5 Ready                          */
+    uint32_t ACCS6:1;          /*!< bit:     12  AC6 Current Comparison Status      */
+    uint32_t ACRDY6:1;         /*!< bit:     13  AC6 Ready                          */
+    uint32_t ACCS7:1;          /*!< bit:     14  AC7 Current Comparison Status      */
+    uint32_t ACRDY7:1;         /*!< bit:     15  AC7 Ready                          */
+    uint32_t :8;               /*!< bit: 16..23  Reserved                           */
+    uint32_t WFCS0:1;          /*!< bit:     24  Window0 Mode Current Status        */
+    uint32_t WFCS1:1;          /*!< bit:     25  Window1 Mode Current Status        */
+    uint32_t WFCS2:1;          /*!< bit:     26  Window2 Mode Current Status        */
+    uint32_t WFCS3:1;          /*!< bit:     27  Window3 Mode Current Status        */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ACIFC_SR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACIFC_SR_OFFSET             0x04         /**< \brief (ACIFC_SR offset) Status Register */
+#define ACIFC_SR_RESETVALUE         _U(0x00000000); /**< \brief (ACIFC_SR reset_value) Status Register */
+
+#define ACIFC_SR_ACCS0_Pos          0            /**< \brief (ACIFC_SR) AC0 Current Comparison Status */
+#define ACIFC_SR_ACCS0              (_U(0x1) << ACIFC_SR_ACCS0_Pos)
+#define ACIFC_SR_ACRDY0_Pos         1            /**< \brief (ACIFC_SR) AC0 Ready */
+#define ACIFC_SR_ACRDY0             (_U(0x1) << ACIFC_SR_ACRDY0_Pos)
+#define ACIFC_SR_ACCS1_Pos          2            /**< \brief (ACIFC_SR) AC1 Current Comparison Status */
+#define ACIFC_SR_ACCS1              (_U(0x1) << ACIFC_SR_ACCS1_Pos)
+#define ACIFC_SR_ACRDY1_Pos         3            /**< \brief (ACIFC_SR) AC1 Ready */
+#define ACIFC_SR_ACRDY1             (_U(0x1) << ACIFC_SR_ACRDY1_Pos)
+#define ACIFC_SR_ACCS2_Pos          4            /**< \brief (ACIFC_SR) AC2 Current Comparison Status */
+#define ACIFC_SR_ACCS2              (_U(0x1) << ACIFC_SR_ACCS2_Pos)
+#define ACIFC_SR_ACRDY2_Pos         5            /**< \brief (ACIFC_SR) AC2 Ready */
+#define ACIFC_SR_ACRDY2             (_U(0x1) << ACIFC_SR_ACRDY2_Pos)
+#define ACIFC_SR_ACCS3_Pos          6            /**< \brief (ACIFC_SR) AC3 Current Comparison Status */
+#define ACIFC_SR_ACCS3              (_U(0x1) << ACIFC_SR_ACCS3_Pos)
+#define ACIFC_SR_ACRDY3_Pos         7            /**< \brief (ACIFC_SR) AC3 Ready */
+#define ACIFC_SR_ACRDY3             (_U(0x1) << ACIFC_SR_ACRDY3_Pos)
+#define ACIFC_SR_ACCS4_Pos          8            /**< \brief (ACIFC_SR) AC4 Current Comparison Status */
+#define ACIFC_SR_ACCS4              (_U(0x1) << ACIFC_SR_ACCS4_Pos)
+#define ACIFC_SR_ACRDY4_Pos         9            /**< \brief (ACIFC_SR) AC4 Ready */
+#define ACIFC_SR_ACRDY4             (_U(0x1) << ACIFC_SR_ACRDY4_Pos)
+#define ACIFC_SR_ACCS5_Pos          10           /**< \brief (ACIFC_SR) AC5 Current Comparison Status */
+#define ACIFC_SR_ACCS5              (_U(0x1) << ACIFC_SR_ACCS5_Pos)
+#define ACIFC_SR_ACRDY5_Pos         11           /**< \brief (ACIFC_SR) AC5 Ready */
+#define ACIFC_SR_ACRDY5             (_U(0x1) << ACIFC_SR_ACRDY5_Pos)
+#define ACIFC_SR_ACCS6_Pos          12           /**< \brief (ACIFC_SR) AC6 Current Comparison Status */
+#define ACIFC_SR_ACCS6              (_U(0x1) << ACIFC_SR_ACCS6_Pos)
+#define ACIFC_SR_ACRDY6_Pos         13           /**< \brief (ACIFC_SR) AC6 Ready */
+#define ACIFC_SR_ACRDY6             (_U(0x1) << ACIFC_SR_ACRDY6_Pos)
+#define ACIFC_SR_ACCS7_Pos          14           /**< \brief (ACIFC_SR) AC7 Current Comparison Status */
+#define ACIFC_SR_ACCS7              (_U(0x1) << ACIFC_SR_ACCS7_Pos)
+#define ACIFC_SR_ACRDY7_Pos         15           /**< \brief (ACIFC_SR) AC7 Ready */
+#define ACIFC_SR_ACRDY7             (_U(0x1) << ACIFC_SR_ACRDY7_Pos)
+#define ACIFC_SR_WFCS0_Pos          24           /**< \brief (ACIFC_SR) Window0 Mode Current Status */
+#define ACIFC_SR_WFCS0              (_U(0x1) << ACIFC_SR_WFCS0_Pos)
+#define ACIFC_SR_WFCS1_Pos          25           /**< \brief (ACIFC_SR) Window1 Mode Current Status */
+#define ACIFC_SR_WFCS1              (_U(0x1) << ACIFC_SR_WFCS1_Pos)
+#define ACIFC_SR_WFCS2_Pos          26           /**< \brief (ACIFC_SR) Window2 Mode Current Status */
+#define ACIFC_SR_WFCS2              (_U(0x1) << ACIFC_SR_WFCS2_Pos)
+#define ACIFC_SR_WFCS3_Pos          27           /**< \brief (ACIFC_SR) Window3 Mode Current Status */
+#define ACIFC_SR_WFCS3              (_U(0x1) << ACIFC_SR_WFCS3_Pos)
+#define ACIFC_SR_MASK               _U(0x0F00FFFF) /**< \brief (ACIFC_SR) MASK Register */
+
+/* -------- ACIFC_IER : (ACIFC Offset: 0x10) ( /W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ACINT0:1;         /*!< bit:      0  AC0 Interrupt Enable               */
+    uint32_t SUTINT0:1;        /*!< bit:      1  AC0 Startup Time Interrupt Enable  */
+    uint32_t ACINT1:1;         /*!< bit:      2  AC1 Interrupt Enable               */
+    uint32_t SUTINT1:1;        /*!< bit:      3  AC1 Startup Time Interrupt Enable  */
+    uint32_t ACINT2:1;         /*!< bit:      4  AC2 Interrupt Enable               */
+    uint32_t SUTINT2:1;        /*!< bit:      5  AC2 Startup Time Interrupt Enable  */
+    uint32_t ACINT3:1;         /*!< bit:      6  AC3 Interrupt Enable               */
+    uint32_t SUTINT3:1;        /*!< bit:      7  AC3 Startup Time Interrupt Enable  */
+    uint32_t ACINT4:1;         /*!< bit:      8  AC4 Interrupt Enable               */
+    uint32_t SUTINT4:1;        /*!< bit:      9  AC4 Startup Time Interrupt Enable  */
+    uint32_t ACINT5:1;         /*!< bit:     10  AC5 Interrupt Enable               */
+    uint32_t SUTINT5:1;        /*!< bit:     11  AC5 Startup Time Interrupt Enable  */
+    uint32_t ACINT6:1;         /*!< bit:     12  AC6 Interrupt Enable               */
+    uint32_t SUTINT6:1;        /*!< bit:     13  AC6 Startup Time Interrupt Enable  */
+    uint32_t ACINT7:1;         /*!< bit:     14  AC7 Interrupt Enable               */
+    uint32_t SUTINT7:1;        /*!< bit:     15  AC7 Startup Time Interrupt Enable  */
+    uint32_t :8;               /*!< bit: 16..23  Reserved                           */
+    uint32_t WFINT0:1;         /*!< bit:     24  Window0 Mode Interrupt Enable      */
+    uint32_t WFINT1:1;         /*!< bit:     25  Window1 Mode Interrupt Enable      */
+    uint32_t WFINT2:1;         /*!< bit:     26  Window2 Mode Interrupt Enable      */
+    uint32_t WFINT3:1;         /*!< bit:     27  Window3 Mode Interrupt Enable      */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ACIFC_IER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACIFC_IER_OFFSET            0x10         /**< \brief (ACIFC_IER offset) Interrupt Enable Register */
+#define ACIFC_IER_RESETVALUE        _U(0x00000000); /**< \brief (ACIFC_IER reset_value) Interrupt Enable Register */
+
+#define ACIFC_IER_ACINT0_Pos        0            /**< \brief (ACIFC_IER) AC0 Interrupt Enable */
+#define ACIFC_IER_ACINT0            (_U(0x1) << ACIFC_IER_ACINT0_Pos)
+#define ACIFC_IER_SUTINT0_Pos       1            /**< \brief (ACIFC_IER) AC0 Startup Time Interrupt Enable */
+#define ACIFC_IER_SUTINT0           (_U(0x1) << ACIFC_IER_SUTINT0_Pos)
+#define ACIFC_IER_ACINT1_Pos        2            /**< \brief (ACIFC_IER) AC1 Interrupt Enable */
+#define ACIFC_IER_ACINT1            (_U(0x1) << ACIFC_IER_ACINT1_Pos)
+#define ACIFC_IER_SUTINT1_Pos       3            /**< \brief (ACIFC_IER) AC1 Startup Time Interrupt Enable */
+#define ACIFC_IER_SUTINT1           (_U(0x1) << ACIFC_IER_SUTINT1_Pos)
+#define ACIFC_IER_ACINT2_Pos        4            /**< \brief (ACIFC_IER) AC2 Interrupt Enable */
+#define ACIFC_IER_ACINT2            (_U(0x1) << ACIFC_IER_ACINT2_Pos)
+#define ACIFC_IER_SUTINT2_Pos       5            /**< \brief (ACIFC_IER) AC2 Startup Time Interrupt Enable */
+#define ACIFC_IER_SUTINT2           (_U(0x1) << ACIFC_IER_SUTINT2_Pos)
+#define ACIFC_IER_ACINT3_Pos        6            /**< \brief (ACIFC_IER) AC3 Interrupt Enable */
+#define ACIFC_IER_ACINT3            (_U(0x1) << ACIFC_IER_ACINT3_Pos)
+#define ACIFC_IER_SUTINT3_Pos       7            /**< \brief (ACIFC_IER) AC3 Startup Time Interrupt Enable */
+#define ACIFC_IER_SUTINT3           (_U(0x1) << ACIFC_IER_SUTINT3_Pos)
+#define ACIFC_IER_ACINT4_Pos        8            /**< \brief (ACIFC_IER) AC4 Interrupt Enable */
+#define ACIFC_IER_ACINT4            (_U(0x1) << ACIFC_IER_ACINT4_Pos)
+#define ACIFC_IER_SUTINT4_Pos       9            /**< \brief (ACIFC_IER) AC4 Startup Time Interrupt Enable */
+#define ACIFC_IER_SUTINT4           (_U(0x1) << ACIFC_IER_SUTINT4_Pos)
+#define ACIFC_IER_ACINT5_Pos        10           /**< \brief (ACIFC_IER) AC5 Interrupt Enable */
+#define ACIFC_IER_ACINT5            (_U(0x1) << ACIFC_IER_ACINT5_Pos)
+#define ACIFC_IER_SUTINT5_Pos       11           /**< \brief (ACIFC_IER) AC5 Startup Time Interrupt Enable */
+#define ACIFC_IER_SUTINT5           (_U(0x1) << ACIFC_IER_SUTINT5_Pos)
+#define ACIFC_IER_ACINT6_Pos        12           /**< \brief (ACIFC_IER) AC6 Interrupt Enable */
+#define ACIFC_IER_ACINT6            (_U(0x1) << ACIFC_IER_ACINT6_Pos)
+#define ACIFC_IER_SUTINT6_Pos       13           /**< \brief (ACIFC_IER) AC6 Startup Time Interrupt Enable */
+#define ACIFC_IER_SUTINT6           (_U(0x1) << ACIFC_IER_SUTINT6_Pos)
+#define ACIFC_IER_ACINT7_Pos        14           /**< \brief (ACIFC_IER) AC7 Interrupt Enable */
+#define ACIFC_IER_ACINT7            (_U(0x1) << ACIFC_IER_ACINT7_Pos)
+#define ACIFC_IER_SUTINT7_Pos       15           /**< \brief (ACIFC_IER) AC7 Startup Time Interrupt Enable */
+#define ACIFC_IER_SUTINT7           (_U(0x1) << ACIFC_IER_SUTINT7_Pos)
+#define ACIFC_IER_WFINT0_Pos        24           /**< \brief (ACIFC_IER) Window0 Mode Interrupt Enable */
+#define ACIFC_IER_WFINT0            (_U(0x1) << ACIFC_IER_WFINT0_Pos)
+#define ACIFC_IER_WFINT1_Pos        25           /**< \brief (ACIFC_IER) Window1 Mode Interrupt Enable */
+#define ACIFC_IER_WFINT1            (_U(0x1) << ACIFC_IER_WFINT1_Pos)
+#define ACIFC_IER_WFINT2_Pos        26           /**< \brief (ACIFC_IER) Window2 Mode Interrupt Enable */
+#define ACIFC_IER_WFINT2            (_U(0x1) << ACIFC_IER_WFINT2_Pos)
+#define ACIFC_IER_WFINT3_Pos        27           /**< \brief (ACIFC_IER) Window3 Mode Interrupt Enable */
+#define ACIFC_IER_WFINT3            (_U(0x1) << ACIFC_IER_WFINT3_Pos)
+#define ACIFC_IER_MASK              _U(0x0F00FFFF) /**< \brief (ACIFC_IER) MASK Register */
+
+/* -------- ACIFC_IDR : (ACIFC Offset: 0x14) ( /W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ACINT0:1;         /*!< bit:      0  AC0 Interrupt Disable              */
+    uint32_t SUTINT0:1;        /*!< bit:      1  AC0 Startup Time Interrupt Disable */
+    uint32_t ACINT1:1;         /*!< bit:      2  AC1 Interrupt Disable              */
+    uint32_t SUTINT1:1;        /*!< bit:      3  AC1 Startup Time Interrupt Disable */
+    uint32_t ACINT2:1;         /*!< bit:      4  AC2 Interrupt Disable              */
+    uint32_t SUTINT2:1;        /*!< bit:      5  AC2 Startup Time Interrupt Disable */
+    uint32_t ACINT3:1;         /*!< bit:      6  AC3 Interrupt Disable              */
+    uint32_t SUTINT3:1;        /*!< bit:      7  AC3 Startup Time Interrupt Disable */
+    uint32_t ACINT4:1;         /*!< bit:      8  AC4 Interrupt Disable              */
+    uint32_t SUTINT4:1;        /*!< bit:      9  AC4 Startup Time Interrupt Disable */
+    uint32_t ACINT5:1;         /*!< bit:     10  AC5 Interrupt Disable              */
+    uint32_t SUTINT5:1;        /*!< bit:     11  AC5 Startup Time Interrupt Disable */
+    uint32_t ACINT6:1;         /*!< bit:     12  AC6 Interrupt Disable              */
+    uint32_t SUTINT6:1;        /*!< bit:     13  AC6 Startup Time Interrupt Disable */
+    uint32_t ACINT7:1;         /*!< bit:     14  AC7 Interrupt Disable              */
+    uint32_t SUTINT7:1;        /*!< bit:     15  AC7 Startup Time Interrupt Disable */
+    uint32_t :8;               /*!< bit: 16..23  Reserved                           */
+    uint32_t WFINT0:1;         /*!< bit:     24  Window0 Mode Interrupt Disable     */
+    uint32_t WFINT1:1;         /*!< bit:     25  Window1 Mode Interrupt Disable     */
+    uint32_t WFINT2:1;         /*!< bit:     26  Window2 Mode Interrupt Disable     */
+    uint32_t WFINT3:1;         /*!< bit:     27  Window3 Mode Interrupt Disable     */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ACIFC_IDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACIFC_IDR_OFFSET            0x14         /**< \brief (ACIFC_IDR offset) Interrupt Disable Register */
+#define ACIFC_IDR_RESETVALUE        _U(0x00000000); /**< \brief (ACIFC_IDR reset_value) Interrupt Disable Register */
+
+#define ACIFC_IDR_ACINT0_Pos        0            /**< \brief (ACIFC_IDR) AC0 Interrupt Disable */
+#define ACIFC_IDR_ACINT0            (_U(0x1) << ACIFC_IDR_ACINT0_Pos)
+#define ACIFC_IDR_SUTINT0_Pos       1            /**< \brief (ACIFC_IDR) AC0 Startup Time Interrupt Disable */
+#define ACIFC_IDR_SUTINT0           (_U(0x1) << ACIFC_IDR_SUTINT0_Pos)
+#define ACIFC_IDR_ACINT1_Pos        2            /**< \brief (ACIFC_IDR) AC1 Interrupt Disable */
+#define ACIFC_IDR_ACINT1            (_U(0x1) << ACIFC_IDR_ACINT1_Pos)
+#define ACIFC_IDR_SUTINT1_Pos       3            /**< \brief (ACIFC_IDR) AC1 Startup Time Interrupt Disable */
+#define ACIFC_IDR_SUTINT1           (_U(0x1) << ACIFC_IDR_SUTINT1_Pos)
+#define ACIFC_IDR_ACINT2_Pos        4            /**< \brief (ACIFC_IDR) AC2 Interrupt Disable */
+#define ACIFC_IDR_ACINT2            (_U(0x1) << ACIFC_IDR_ACINT2_Pos)
+#define ACIFC_IDR_SUTINT2_Pos       5            /**< \brief (ACIFC_IDR) AC2 Startup Time Interrupt Disable */
+#define ACIFC_IDR_SUTINT2           (_U(0x1) << ACIFC_IDR_SUTINT2_Pos)
+#define ACIFC_IDR_ACINT3_Pos        6            /**< \brief (ACIFC_IDR) AC3 Interrupt Disable */
+#define ACIFC_IDR_ACINT3            (_U(0x1) << ACIFC_IDR_ACINT3_Pos)
+#define ACIFC_IDR_SUTINT3_Pos       7            /**< \brief (ACIFC_IDR) AC3 Startup Time Interrupt Disable */
+#define ACIFC_IDR_SUTINT3           (_U(0x1) << ACIFC_IDR_SUTINT3_Pos)
+#define ACIFC_IDR_ACINT4_Pos        8            /**< \brief (ACIFC_IDR) AC4 Interrupt Disable */
+#define ACIFC_IDR_ACINT4            (_U(0x1) << ACIFC_IDR_ACINT4_Pos)
+#define ACIFC_IDR_SUTINT4_Pos       9            /**< \brief (ACIFC_IDR) AC4 Startup Time Interrupt Disable */
+#define ACIFC_IDR_SUTINT4           (_U(0x1) << ACIFC_IDR_SUTINT4_Pos)
+#define ACIFC_IDR_ACINT5_Pos        10           /**< \brief (ACIFC_IDR) AC5 Interrupt Disable */
+#define ACIFC_IDR_ACINT5            (_U(0x1) << ACIFC_IDR_ACINT5_Pos)
+#define ACIFC_IDR_SUTINT5_Pos       11           /**< \brief (ACIFC_IDR) AC5 Startup Time Interrupt Disable */
+#define ACIFC_IDR_SUTINT5           (_U(0x1) << ACIFC_IDR_SUTINT5_Pos)
+#define ACIFC_IDR_ACINT6_Pos        12           /**< \brief (ACIFC_IDR) AC6 Interrupt Disable */
+#define ACIFC_IDR_ACINT6            (_U(0x1) << ACIFC_IDR_ACINT6_Pos)
+#define ACIFC_IDR_SUTINT6_Pos       13           /**< \brief (ACIFC_IDR) AC6 Startup Time Interrupt Disable */
+#define ACIFC_IDR_SUTINT6           (_U(0x1) << ACIFC_IDR_SUTINT6_Pos)
+#define ACIFC_IDR_ACINT7_Pos        14           /**< \brief (ACIFC_IDR) AC7 Interrupt Disable */
+#define ACIFC_IDR_ACINT7            (_U(0x1) << ACIFC_IDR_ACINT7_Pos)
+#define ACIFC_IDR_SUTINT7_Pos       15           /**< \brief (ACIFC_IDR) AC7 Startup Time Interrupt Disable */
+#define ACIFC_IDR_SUTINT7           (_U(0x1) << ACIFC_IDR_SUTINT7_Pos)
+#define ACIFC_IDR_WFINT0_Pos        24           /**< \brief (ACIFC_IDR) Window0 Mode Interrupt Disable */
+#define ACIFC_IDR_WFINT0            (_U(0x1) << ACIFC_IDR_WFINT0_Pos)
+#define ACIFC_IDR_WFINT1_Pos        25           /**< \brief (ACIFC_IDR) Window1 Mode Interrupt Disable */
+#define ACIFC_IDR_WFINT1            (_U(0x1) << ACIFC_IDR_WFINT1_Pos)
+#define ACIFC_IDR_WFINT2_Pos        26           /**< \brief (ACIFC_IDR) Window2 Mode Interrupt Disable */
+#define ACIFC_IDR_WFINT2            (_U(0x1) << ACIFC_IDR_WFINT2_Pos)
+#define ACIFC_IDR_WFINT3_Pos        27           /**< \brief (ACIFC_IDR) Window3 Mode Interrupt Disable */
+#define ACIFC_IDR_WFINT3            (_U(0x1) << ACIFC_IDR_WFINT3_Pos)
+#define ACIFC_IDR_MASK              _U(0x0F00FFFF) /**< \brief (ACIFC_IDR) MASK Register */
+
+/* -------- ACIFC_IMR : (ACIFC Offset: 0x18) (R/  32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ACINT0:1;         /*!< bit:      0  AC0 Interrupt Mask                 */
+    uint32_t SUTINT0:1;        /*!< bit:      1  AC0 Startup Time Interrupt Mask    */
+    uint32_t ACINT1:1;         /*!< bit:      2  AC1 Interrupt Mask                 */
+    uint32_t SUTINT1:1;        /*!< bit:      3  AC1 Startup Time Interrupt Mask    */
+    uint32_t ACINT2:1;         /*!< bit:      4  AC2 Interrupt Mask                 */
+    uint32_t SUTINT2:1;        /*!< bit:      5  AC2 Startup Time Interrupt Mask    */
+    uint32_t ACINT3:1;         /*!< bit:      6  AC3 Interrupt Mask                 */
+    uint32_t SUTINT3:1;        /*!< bit:      7  AC3 Startup Time Interrupt Mask    */
+    uint32_t ACINT4:1;         /*!< bit:      8  AC4 Interrupt Mask                 */
+    uint32_t SUTINT4:1;        /*!< bit:      9  AC4 Startup Time Interrupt Mask    */
+    uint32_t ACINT5:1;         /*!< bit:     10  AC5 Interrupt Mask                 */
+    uint32_t SUTINT5:1;        /*!< bit:     11  AC5 Startup Time Interrupt Mask    */
+    uint32_t ACINT6:1;         /*!< bit:     12  AC6 Interrupt Mask                 */
+    uint32_t SUTINT6:1;        /*!< bit:     13  AC6 Startup Time Interrupt Mask    */
+    uint32_t ACINT7:1;         /*!< bit:     14  AC7 Interrupt Mask                 */
+    uint32_t SUTINT7:1;        /*!< bit:     15  AC7 Startup Time Interrupt Mask    */
+    uint32_t :8;               /*!< bit: 16..23  Reserved                           */
+    uint32_t WFINT0:1;         /*!< bit:     24  Window0 Mode Interrupt Mask        */
+    uint32_t WFINT1:1;         /*!< bit:     25  Window1 Mode Interrupt Mask        */
+    uint32_t WFINT2:1;         /*!< bit:     26  Window2 Mode Interrupt Mask        */
+    uint32_t WFINT3:1;         /*!< bit:     27  Window3 Mode Interrupt Mask        */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ACIFC_IMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACIFC_IMR_OFFSET            0x18         /**< \brief (ACIFC_IMR offset) Interrupt Mask Register */
+#define ACIFC_IMR_RESETVALUE        _U(0x00000000); /**< \brief (ACIFC_IMR reset_value) Interrupt Mask Register */
+
+#define ACIFC_IMR_ACINT0_Pos        0            /**< \brief (ACIFC_IMR) AC0 Interrupt Mask */
+#define ACIFC_IMR_ACINT0            (_U(0x1) << ACIFC_IMR_ACINT0_Pos)
+#define ACIFC_IMR_SUTINT0_Pos       1            /**< \brief (ACIFC_IMR) AC0 Startup Time Interrupt Mask */
+#define ACIFC_IMR_SUTINT0           (_U(0x1) << ACIFC_IMR_SUTINT0_Pos)
+#define ACIFC_IMR_ACINT1_Pos        2            /**< \brief (ACIFC_IMR) AC1 Interrupt Mask */
+#define ACIFC_IMR_ACINT1            (_U(0x1) << ACIFC_IMR_ACINT1_Pos)
+#define ACIFC_IMR_SUTINT1_Pos       3            /**< \brief (ACIFC_IMR) AC1 Startup Time Interrupt Mask */
+#define ACIFC_IMR_SUTINT1           (_U(0x1) << ACIFC_IMR_SUTINT1_Pos)
+#define ACIFC_IMR_ACINT2_Pos        4            /**< \brief (ACIFC_IMR) AC2 Interrupt Mask */
+#define ACIFC_IMR_ACINT2            (_U(0x1) << ACIFC_IMR_ACINT2_Pos)
+#define ACIFC_IMR_SUTINT2_Pos       5            /**< \brief (ACIFC_IMR) AC2 Startup Time Interrupt Mask */
+#define ACIFC_IMR_SUTINT2           (_U(0x1) << ACIFC_IMR_SUTINT2_Pos)
+#define ACIFC_IMR_ACINT3_Pos        6            /**< \brief (ACIFC_IMR) AC3 Interrupt Mask */
+#define ACIFC_IMR_ACINT3            (_U(0x1) << ACIFC_IMR_ACINT3_Pos)
+#define ACIFC_IMR_SUTINT3_Pos       7            /**< \brief (ACIFC_IMR) AC3 Startup Time Interrupt Mask */
+#define ACIFC_IMR_SUTINT3           (_U(0x1) << ACIFC_IMR_SUTINT3_Pos)
+#define ACIFC_IMR_ACINT4_Pos        8            /**< \brief (ACIFC_IMR) AC4 Interrupt Mask */
+#define ACIFC_IMR_ACINT4            (_U(0x1) << ACIFC_IMR_ACINT4_Pos)
+#define ACIFC_IMR_SUTINT4_Pos       9            /**< \brief (ACIFC_IMR) AC4 Startup Time Interrupt Mask */
+#define ACIFC_IMR_SUTINT4           (_U(0x1) << ACIFC_IMR_SUTINT4_Pos)
+#define ACIFC_IMR_ACINT5_Pos        10           /**< \brief (ACIFC_IMR) AC5 Interrupt Mask */
+#define ACIFC_IMR_ACINT5            (_U(0x1) << ACIFC_IMR_ACINT5_Pos)
+#define ACIFC_IMR_SUTINT5_Pos       11           /**< \brief (ACIFC_IMR) AC5 Startup Time Interrupt Mask */
+#define ACIFC_IMR_SUTINT5           (_U(0x1) << ACIFC_IMR_SUTINT5_Pos)
+#define ACIFC_IMR_ACINT6_Pos        12           /**< \brief (ACIFC_IMR) AC6 Interrupt Mask */
+#define ACIFC_IMR_ACINT6            (_U(0x1) << ACIFC_IMR_ACINT6_Pos)
+#define ACIFC_IMR_SUTINT6_Pos       13           /**< \brief (ACIFC_IMR) AC6 Startup Time Interrupt Mask */
+#define ACIFC_IMR_SUTINT6           (_U(0x1) << ACIFC_IMR_SUTINT6_Pos)
+#define ACIFC_IMR_ACINT7_Pos        14           /**< \brief (ACIFC_IMR) AC7 Interrupt Mask */
+#define ACIFC_IMR_ACINT7            (_U(0x1) << ACIFC_IMR_ACINT7_Pos)
+#define ACIFC_IMR_SUTINT7_Pos       15           /**< \brief (ACIFC_IMR) AC7 Startup Time Interrupt Mask */
+#define ACIFC_IMR_SUTINT7           (_U(0x1) << ACIFC_IMR_SUTINT7_Pos)
+#define ACIFC_IMR_WFINT0_Pos        24           /**< \brief (ACIFC_IMR) Window0 Mode Interrupt Mask */
+#define ACIFC_IMR_WFINT0            (_U(0x1) << ACIFC_IMR_WFINT0_Pos)
+#define ACIFC_IMR_WFINT1_Pos        25           /**< \brief (ACIFC_IMR) Window1 Mode Interrupt Mask */
+#define ACIFC_IMR_WFINT1            (_U(0x1) << ACIFC_IMR_WFINT1_Pos)
+#define ACIFC_IMR_WFINT2_Pos        26           /**< \brief (ACIFC_IMR) Window2 Mode Interrupt Mask */
+#define ACIFC_IMR_WFINT2            (_U(0x1) << ACIFC_IMR_WFINT2_Pos)
+#define ACIFC_IMR_WFINT3_Pos        27           /**< \brief (ACIFC_IMR) Window3 Mode Interrupt Mask */
+#define ACIFC_IMR_WFINT3            (_U(0x1) << ACIFC_IMR_WFINT3_Pos)
+#define ACIFC_IMR_MASK              _U(0x0F00FFFF) /**< \brief (ACIFC_IMR) MASK Register */
+
+/* -------- ACIFC_ISR : (ACIFC Offset: 0x1C) (R/  32) Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ACINT0:1;         /*!< bit:      0  AC0 Interrupt Status               */
+    uint32_t SUTINT0:1;        /*!< bit:      1  AC0 Startup Time Interrupt Status  */
+    uint32_t ACINT1:1;         /*!< bit:      2  AC1 Interrupt Status               */
+    uint32_t SUTINT1:1;        /*!< bit:      3  AC1 Startup Time Interrupt Status  */
+    uint32_t ACINT2:1;         /*!< bit:      4  AC2 Interrupt Status               */
+    uint32_t SUTINT2:1;        /*!< bit:      5  AC2 Startup Time Interrupt Status  */
+    uint32_t ACINT3:1;         /*!< bit:      6  AC3 Interrupt Status               */
+    uint32_t SUTINT3:1;        /*!< bit:      7  AC3 Startup Time Interrupt Status  */
+    uint32_t ACINT4:1;         /*!< bit:      8  AC4 Interrupt Status               */
+    uint32_t SUTINT4:1;        /*!< bit:      9  AC4 Startup Time Interrupt Status  */
+    uint32_t ACINT5:1;         /*!< bit:     10  AC5 Interrupt Status               */
+    uint32_t SUTINT5:1;        /*!< bit:     11  AC5 Startup Time Interrupt Status  */
+    uint32_t ACINT6:1;         /*!< bit:     12  AC6 Interrupt Status               */
+    uint32_t SUTINT6:1;        /*!< bit:     13  AC6 Startup Time Interrupt Status  */
+    uint32_t ACINT7:1;         /*!< bit:     14  AC7 Interrupt Status               */
+    uint32_t SUTINT7:1;        /*!< bit:     15  AC7 Startup Time Interrupt Status  */
+    uint32_t :8;               /*!< bit: 16..23  Reserved                           */
+    uint32_t WFINT0:1;         /*!< bit:     24  Window0 Mode Interrupt Status      */
+    uint32_t WFINT1:1;         /*!< bit:     25  Window1 Mode Interrupt Status      */
+    uint32_t WFINT2:1;         /*!< bit:     26  Window2 Mode Interrupt Status      */
+    uint32_t WFINT3:1;         /*!< bit:     27  Window3 Mode Interrupt Status      */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ACIFC_ISR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACIFC_ISR_OFFSET            0x1C         /**< \brief (ACIFC_ISR offset) Interrupt Status Register */
+#define ACIFC_ISR_RESETVALUE        _U(0x00000000); /**< \brief (ACIFC_ISR reset_value) Interrupt Status Register */
+
+#define ACIFC_ISR_ACINT0_Pos        0            /**< \brief (ACIFC_ISR) AC0 Interrupt Status */
+#define ACIFC_ISR_ACINT0            (_U(0x1) << ACIFC_ISR_ACINT0_Pos)
+#define ACIFC_ISR_SUTINT0_Pos       1            /**< \brief (ACIFC_ISR) AC0 Startup Time Interrupt Status */
+#define ACIFC_ISR_SUTINT0           (_U(0x1) << ACIFC_ISR_SUTINT0_Pos)
+#define ACIFC_ISR_ACINT1_Pos        2            /**< \brief (ACIFC_ISR) AC1 Interrupt Status */
+#define ACIFC_ISR_ACINT1            (_U(0x1) << ACIFC_ISR_ACINT1_Pos)
+#define ACIFC_ISR_SUTINT1_Pos       3            /**< \brief (ACIFC_ISR) AC1 Startup Time Interrupt Status */
+#define ACIFC_ISR_SUTINT1           (_U(0x1) << ACIFC_ISR_SUTINT1_Pos)
+#define ACIFC_ISR_ACINT2_Pos        4            /**< \brief (ACIFC_ISR) AC2 Interrupt Status */
+#define ACIFC_ISR_ACINT2            (_U(0x1) << ACIFC_ISR_ACINT2_Pos)
+#define ACIFC_ISR_SUTINT2_Pos       5            /**< \brief (ACIFC_ISR) AC2 Startup Time Interrupt Status */
+#define ACIFC_ISR_SUTINT2           (_U(0x1) << ACIFC_ISR_SUTINT2_Pos)
+#define ACIFC_ISR_ACINT3_Pos        6            /**< \brief (ACIFC_ISR) AC3 Interrupt Status */
+#define ACIFC_ISR_ACINT3            (_U(0x1) << ACIFC_ISR_ACINT3_Pos)
+#define ACIFC_ISR_SUTINT3_Pos       7            /**< \brief (ACIFC_ISR) AC3 Startup Time Interrupt Status */
+#define ACIFC_ISR_SUTINT3           (_U(0x1) << ACIFC_ISR_SUTINT3_Pos)
+#define ACIFC_ISR_ACINT4_Pos        8            /**< \brief (ACIFC_ISR) AC4 Interrupt Status */
+#define ACIFC_ISR_ACINT4            (_U(0x1) << ACIFC_ISR_ACINT4_Pos)
+#define ACIFC_ISR_SUTINT4_Pos       9            /**< \brief (ACIFC_ISR) AC4 Startup Time Interrupt Status */
+#define ACIFC_ISR_SUTINT4           (_U(0x1) << ACIFC_ISR_SUTINT4_Pos)
+#define ACIFC_ISR_ACINT5_Pos        10           /**< \brief (ACIFC_ISR) AC5 Interrupt Status */
+#define ACIFC_ISR_ACINT5            (_U(0x1) << ACIFC_ISR_ACINT5_Pos)
+#define ACIFC_ISR_SUTINT5_Pos       11           /**< \brief (ACIFC_ISR) AC5 Startup Time Interrupt Status */
+#define ACIFC_ISR_SUTINT5           (_U(0x1) << ACIFC_ISR_SUTINT5_Pos)
+#define ACIFC_ISR_ACINT6_Pos        12           /**< \brief (ACIFC_ISR) AC6 Interrupt Status */
+#define ACIFC_ISR_ACINT6            (_U(0x1) << ACIFC_ISR_ACINT6_Pos)
+#define ACIFC_ISR_SUTINT6_Pos       13           /**< \brief (ACIFC_ISR) AC6 Startup Time Interrupt Status */
+#define ACIFC_ISR_SUTINT6           (_U(0x1) << ACIFC_ISR_SUTINT6_Pos)
+#define ACIFC_ISR_ACINT7_Pos        14           /**< \brief (ACIFC_ISR) AC7 Interrupt Status */
+#define ACIFC_ISR_ACINT7            (_U(0x1) << ACIFC_ISR_ACINT7_Pos)
+#define ACIFC_ISR_SUTINT7_Pos       15           /**< \brief (ACIFC_ISR) AC7 Startup Time Interrupt Status */
+#define ACIFC_ISR_SUTINT7           (_U(0x1) << ACIFC_ISR_SUTINT7_Pos)
+#define ACIFC_ISR_WFINT0_Pos        24           /**< \brief (ACIFC_ISR) Window0 Mode Interrupt Status */
+#define ACIFC_ISR_WFINT0            (_U(0x1) << ACIFC_ISR_WFINT0_Pos)
+#define ACIFC_ISR_WFINT1_Pos        25           /**< \brief (ACIFC_ISR) Window1 Mode Interrupt Status */
+#define ACIFC_ISR_WFINT1            (_U(0x1) << ACIFC_ISR_WFINT1_Pos)
+#define ACIFC_ISR_WFINT2_Pos        26           /**< \brief (ACIFC_ISR) Window2 Mode Interrupt Status */
+#define ACIFC_ISR_WFINT2            (_U(0x1) << ACIFC_ISR_WFINT2_Pos)
+#define ACIFC_ISR_WFINT3_Pos        27           /**< \brief (ACIFC_ISR) Window3 Mode Interrupt Status */
+#define ACIFC_ISR_WFINT3            (_U(0x1) << ACIFC_ISR_WFINT3_Pos)
+#define ACIFC_ISR_MASK              _U(0x0F00FFFF) /**< \brief (ACIFC_ISR) MASK Register */
+
+/* -------- ACIFC_ICR : (ACIFC Offset: 0x20) ( /W 32) Interrupt Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ACINT0:1;         /*!< bit:      0  AC0 Interrupt Status Clear         */
+    uint32_t SUTINT0:1;        /*!< bit:      1  AC0 Startup Time Interrupt Status Clear */
+    uint32_t ACINT1:1;         /*!< bit:      2  AC1 Interrupt Status Clear         */
+    uint32_t SUTINT1:1;        /*!< bit:      3  AC1 Startup Time Interrupt Status Clear */
+    uint32_t ACINT2:1;         /*!< bit:      4  AC2 Interrupt Status Clear         */
+    uint32_t SUTINT2:1;        /*!< bit:      5  AC2 Startup Time Interrupt Status Clear */
+    uint32_t ACINT3:1;         /*!< bit:      6  AC3 Interrupt Status Clear         */
+    uint32_t SUTINT3:1;        /*!< bit:      7  AC3 Startup Time Interrupt Status Clear */
+    uint32_t ACINT4:1;         /*!< bit:      8  AC4 Interrupt Status Clear         */
+    uint32_t SUTINT4:1;        /*!< bit:      9  AC4 Startup Time Interrupt Status Clear */
+    uint32_t ACINT5:1;         /*!< bit:     10  AC5 Interrupt Status Clear         */
+    uint32_t SUTINT5:1;        /*!< bit:     11  AC5 Startup Time Interrupt Status Clear */
+    uint32_t ACINT6:1;         /*!< bit:     12  AC6 Interrupt Status Clear         */
+    uint32_t SUTINT6:1;        /*!< bit:     13  AC6 Startup Time Interrupt Status Clear */
+    uint32_t ACINT7:1;         /*!< bit:     14  AC7 Interrupt Status Clear         */
+    uint32_t SUTINT7:1;        /*!< bit:     15  AC7 Startup Time Interrupt Status Clear */
+    uint32_t :8;               /*!< bit: 16..23  Reserved                           */
+    uint32_t WFINT0:1;         /*!< bit:     24  Window0 Mode Interrupt Status Clear */
+    uint32_t WFINT1:1;         /*!< bit:     25  Window1 Mode Interrupt Status Clear */
+    uint32_t WFINT2:1;         /*!< bit:     26  Window2 Mode Interrupt Status Clear */
+    uint32_t WFINT3:1;         /*!< bit:     27  Window3 Mode Interrupt Status Clear */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ACIFC_ICR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACIFC_ICR_OFFSET            0x20         /**< \brief (ACIFC_ICR offset) Interrupt Status Clear Register */
+#define ACIFC_ICR_RESETVALUE        _U(0x00000000); /**< \brief (ACIFC_ICR reset_value) Interrupt Status Clear Register */
+
+#define ACIFC_ICR_ACINT0_Pos        0            /**< \brief (ACIFC_ICR) AC0 Interrupt Status Clear */
+#define ACIFC_ICR_ACINT0            (_U(0x1) << ACIFC_ICR_ACINT0_Pos)
+#define ACIFC_ICR_SUTINT0_Pos       1            /**< \brief (ACIFC_ICR) AC0 Startup Time Interrupt Status Clear */
+#define ACIFC_ICR_SUTINT0           (_U(0x1) << ACIFC_ICR_SUTINT0_Pos)
+#define ACIFC_ICR_ACINT1_Pos        2            /**< \brief (ACIFC_ICR) AC1 Interrupt Status Clear */
+#define ACIFC_ICR_ACINT1            (_U(0x1) << ACIFC_ICR_ACINT1_Pos)
+#define ACIFC_ICR_SUTINT1_Pos       3            /**< \brief (ACIFC_ICR) AC1 Startup Time Interrupt Status Clear */
+#define ACIFC_ICR_SUTINT1           (_U(0x1) << ACIFC_ICR_SUTINT1_Pos)
+#define ACIFC_ICR_ACINT2_Pos        4            /**< \brief (ACIFC_ICR) AC2 Interrupt Status Clear */
+#define ACIFC_ICR_ACINT2            (_U(0x1) << ACIFC_ICR_ACINT2_Pos)
+#define ACIFC_ICR_SUTINT2_Pos       5            /**< \brief (ACIFC_ICR) AC2 Startup Time Interrupt Status Clear */
+#define ACIFC_ICR_SUTINT2           (_U(0x1) << ACIFC_ICR_SUTINT2_Pos)
+#define ACIFC_ICR_ACINT3_Pos        6            /**< \brief (ACIFC_ICR) AC3 Interrupt Status Clear */
+#define ACIFC_ICR_ACINT3            (_U(0x1) << ACIFC_ICR_ACINT3_Pos)
+#define ACIFC_ICR_SUTINT3_Pos       7            /**< \brief (ACIFC_ICR) AC3 Startup Time Interrupt Status Clear */
+#define ACIFC_ICR_SUTINT3           (_U(0x1) << ACIFC_ICR_SUTINT3_Pos)
+#define ACIFC_ICR_ACINT4_Pos        8            /**< \brief (ACIFC_ICR) AC4 Interrupt Status Clear */
+#define ACIFC_ICR_ACINT4            (_U(0x1) << ACIFC_ICR_ACINT4_Pos)
+#define ACIFC_ICR_SUTINT4_Pos       9            /**< \brief (ACIFC_ICR) AC4 Startup Time Interrupt Status Clear */
+#define ACIFC_ICR_SUTINT4           (_U(0x1) << ACIFC_ICR_SUTINT4_Pos)
+#define ACIFC_ICR_ACINT5_Pos        10           /**< \brief (ACIFC_ICR) AC5 Interrupt Status Clear */
+#define ACIFC_ICR_ACINT5            (_U(0x1) << ACIFC_ICR_ACINT5_Pos)
+#define ACIFC_ICR_SUTINT5_Pos       11           /**< \brief (ACIFC_ICR) AC5 Startup Time Interrupt Status Clear */
+#define ACIFC_ICR_SUTINT5           (_U(0x1) << ACIFC_ICR_SUTINT5_Pos)
+#define ACIFC_ICR_ACINT6_Pos        12           /**< \brief (ACIFC_ICR) AC6 Interrupt Status Clear */
+#define ACIFC_ICR_ACINT6            (_U(0x1) << ACIFC_ICR_ACINT6_Pos)
+#define ACIFC_ICR_SUTINT6_Pos       13           /**< \brief (ACIFC_ICR) AC6 Startup Time Interrupt Status Clear */
+#define ACIFC_ICR_SUTINT6           (_U(0x1) << ACIFC_ICR_SUTINT6_Pos)
+#define ACIFC_ICR_ACINT7_Pos        14           /**< \brief (ACIFC_ICR) AC7 Interrupt Status Clear */
+#define ACIFC_ICR_ACINT7            (_U(0x1) << ACIFC_ICR_ACINT7_Pos)
+#define ACIFC_ICR_SUTINT7_Pos       15           /**< \brief (ACIFC_ICR) AC7 Startup Time Interrupt Status Clear */
+#define ACIFC_ICR_SUTINT7           (_U(0x1) << ACIFC_ICR_SUTINT7_Pos)
+#define ACIFC_ICR_WFINT0_Pos        24           /**< \brief (ACIFC_ICR) Window0 Mode Interrupt Status Clear */
+#define ACIFC_ICR_WFINT0            (_U(0x1) << ACIFC_ICR_WFINT0_Pos)
+#define ACIFC_ICR_WFINT1_Pos        25           /**< \brief (ACIFC_ICR) Window1 Mode Interrupt Status Clear */
+#define ACIFC_ICR_WFINT1            (_U(0x1) << ACIFC_ICR_WFINT1_Pos)
+#define ACIFC_ICR_WFINT2_Pos        26           /**< \brief (ACIFC_ICR) Window2 Mode Interrupt Status Clear */
+#define ACIFC_ICR_WFINT2            (_U(0x1) << ACIFC_ICR_WFINT2_Pos)
+#define ACIFC_ICR_WFINT3_Pos        27           /**< \brief (ACIFC_ICR) Window3 Mode Interrupt Status Clear */
+#define ACIFC_ICR_WFINT3            (_U(0x1) << ACIFC_ICR_WFINT3_Pos)
+#define ACIFC_ICR_MASK              _U(0x0F00FFFF) /**< \brief (ACIFC_ICR) MASK Register */
+
+/* -------- ACIFC_TR : (ACIFC Offset: 0x24) (R/W 32) Test Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ACTEST0:1;        /*!< bit:      0  AC0 Output Override Value          */
+    uint32_t ACTEST1:1;        /*!< bit:      1  AC1 Output Override Value          */
+    uint32_t ACTEST2:1;        /*!< bit:      2  AC2 Output Override Value          */
+    uint32_t ACTEST3:1;        /*!< bit:      3  AC3 Output Override Value          */
+    uint32_t ACTEST4:1;        /*!< bit:      4  AC4 Output Override Value          */
+    uint32_t ACTEST5:1;        /*!< bit:      5  AC5 Output Override Value          */
+    uint32_t ACTEST6:1;        /*!< bit:      6  AC6 Output Override Value          */
+    uint32_t ACTEST7:1;        /*!< bit:      7  AC7 Output Override Value          */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ACIFC_TR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACIFC_TR_OFFSET             0x24         /**< \brief (ACIFC_TR offset) Test Register */
+#define ACIFC_TR_RESETVALUE         _U(0x00000000); /**< \brief (ACIFC_TR reset_value) Test Register */
+
+#define ACIFC_TR_ACTEST0_Pos        0            /**< \brief (ACIFC_TR) AC0 Output Override Value */
+#define ACIFC_TR_ACTEST0            (_U(0x1) << ACIFC_TR_ACTEST0_Pos)
+#define ACIFC_TR_ACTEST1_Pos        1            /**< \brief (ACIFC_TR) AC1 Output Override Value */
+#define ACIFC_TR_ACTEST1            (_U(0x1) << ACIFC_TR_ACTEST1_Pos)
+#define ACIFC_TR_ACTEST2_Pos        2            /**< \brief (ACIFC_TR) AC2 Output Override Value */
+#define ACIFC_TR_ACTEST2            (_U(0x1) << ACIFC_TR_ACTEST2_Pos)
+#define ACIFC_TR_ACTEST3_Pos        3            /**< \brief (ACIFC_TR) AC3 Output Override Value */
+#define ACIFC_TR_ACTEST3            (_U(0x1) << ACIFC_TR_ACTEST3_Pos)
+#define ACIFC_TR_ACTEST4_Pos        4            /**< \brief (ACIFC_TR) AC4 Output Override Value */
+#define ACIFC_TR_ACTEST4            (_U(0x1) << ACIFC_TR_ACTEST4_Pos)
+#define ACIFC_TR_ACTEST5_Pos        5            /**< \brief (ACIFC_TR) AC5 Output Override Value */
+#define ACIFC_TR_ACTEST5            (_U(0x1) << ACIFC_TR_ACTEST5_Pos)
+#define ACIFC_TR_ACTEST6_Pos        6            /**< \brief (ACIFC_TR) AC6 Output Override Value */
+#define ACIFC_TR_ACTEST6            (_U(0x1) << ACIFC_TR_ACTEST6_Pos)
+#define ACIFC_TR_ACTEST7_Pos        7            /**< \brief (ACIFC_TR) AC7 Output Override Value */
+#define ACIFC_TR_ACTEST7            (_U(0x1) << ACIFC_TR_ACTEST7_Pos)
+#define ACIFC_TR_MASK               _U(0x000000FF) /**< \brief (ACIFC_TR) MASK Register */
+
+/* -------- ACIFC_PARAMETER : (ACIFC Offset: 0x30) (R/  32) Parameter Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ACIMPL0:1;        /*!< bit:      0  Analog Comparator 0 Implemented    */
+    uint32_t ACIMPL1:1;        /*!< bit:      1  Analog Comparator 1 Implemented    */
+    uint32_t ACIMPL2:1;        /*!< bit:      2  Analog Comparator 2 Implemented    */
+    uint32_t ACIMPL3:1;        /*!< bit:      3  Analog Comparator 3 Implemented    */
+    uint32_t ACIMPL4:1;        /*!< bit:      4  Analog Comparator 4 Implemented    */
+    uint32_t ACIMPL5:1;        /*!< bit:      5  Analog Comparator 5 Implemented    */
+    uint32_t ACIMPL6:1;        /*!< bit:      6  Analog Comparator 6 Implemented    */
+    uint32_t ACIMPL7:1;        /*!< bit:      7  Analog Comparator 7 Implemented    */
+    uint32_t :8;               /*!< bit:  8..15  Reserved                           */
+    uint32_t WIMPL0:1;         /*!< bit:     16  Window0 Mode  Implemented          */
+    uint32_t WIMPL1:1;         /*!< bit:     17  Window1 Mode  Implemented          */
+    uint32_t WIMPL2:1;         /*!< bit:     18  Window2 Mode  Implemented          */
+    uint32_t WIMPL3:1;         /*!< bit:     19  Window3 Mode  Implemented          */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ACIFC_PARAMETER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACIFC_PARAMETER_OFFSET      0x30         /**< \brief (ACIFC_PARAMETER offset) Parameter Register */
+
+#define ACIFC_PARAMETER_ACIMPL0_Pos 0            /**< \brief (ACIFC_PARAMETER) Analog Comparator 0 Implemented */
+#define ACIFC_PARAMETER_ACIMPL0     (_U(0x1) << ACIFC_PARAMETER_ACIMPL0_Pos)
+#define ACIFC_PARAMETER_ACIMPL1_Pos 1            /**< \brief (ACIFC_PARAMETER) Analog Comparator 1 Implemented */
+#define ACIFC_PARAMETER_ACIMPL1     (_U(0x1) << ACIFC_PARAMETER_ACIMPL1_Pos)
+#define ACIFC_PARAMETER_ACIMPL2_Pos 2            /**< \brief (ACIFC_PARAMETER) Analog Comparator 2 Implemented */
+#define ACIFC_PARAMETER_ACIMPL2     (_U(0x1) << ACIFC_PARAMETER_ACIMPL2_Pos)
+#define ACIFC_PARAMETER_ACIMPL3_Pos 3            /**< \brief (ACIFC_PARAMETER) Analog Comparator 3 Implemented */
+#define ACIFC_PARAMETER_ACIMPL3     (_U(0x1) << ACIFC_PARAMETER_ACIMPL3_Pos)
+#define ACIFC_PARAMETER_ACIMPL4_Pos 4            /**< \brief (ACIFC_PARAMETER) Analog Comparator 4 Implemented */
+#define ACIFC_PARAMETER_ACIMPL4     (_U(0x1) << ACIFC_PARAMETER_ACIMPL4_Pos)
+#define ACIFC_PARAMETER_ACIMPL5_Pos 5            /**< \brief (ACIFC_PARAMETER) Analog Comparator 5 Implemented */
+#define ACIFC_PARAMETER_ACIMPL5     (_U(0x1) << ACIFC_PARAMETER_ACIMPL5_Pos)
+#define ACIFC_PARAMETER_ACIMPL6_Pos 6            /**< \brief (ACIFC_PARAMETER) Analog Comparator 6 Implemented */
+#define ACIFC_PARAMETER_ACIMPL6     (_U(0x1) << ACIFC_PARAMETER_ACIMPL6_Pos)
+#define ACIFC_PARAMETER_ACIMPL7_Pos 7            /**< \brief (ACIFC_PARAMETER) Analog Comparator 7 Implemented */
+#define ACIFC_PARAMETER_ACIMPL7     (_U(0x1) << ACIFC_PARAMETER_ACIMPL7_Pos)
+#define ACIFC_PARAMETER_WIMPL0_Pos  16           /**< \brief (ACIFC_PARAMETER) Window0 Mode  Implemented */
+#define ACIFC_PARAMETER_WIMPL0      (_U(0x1) << ACIFC_PARAMETER_WIMPL0_Pos)
+#define ACIFC_PARAMETER_WIMPL1_Pos  17           /**< \brief (ACIFC_PARAMETER) Window1 Mode  Implemented */
+#define ACIFC_PARAMETER_WIMPL1      (_U(0x1) << ACIFC_PARAMETER_WIMPL1_Pos)
+#define ACIFC_PARAMETER_WIMPL2_Pos  18           /**< \brief (ACIFC_PARAMETER) Window2 Mode  Implemented */
+#define ACIFC_PARAMETER_WIMPL2      (_U(0x1) << ACIFC_PARAMETER_WIMPL2_Pos)
+#define ACIFC_PARAMETER_WIMPL3_Pos  19           /**< \brief (ACIFC_PARAMETER) Window3 Mode  Implemented */
+#define ACIFC_PARAMETER_WIMPL3      (_U(0x1) << ACIFC_PARAMETER_WIMPL3_Pos)
+#define ACIFC_PARAMETER_MASK        _U(0x000F00FF) /**< \brief (ACIFC_PARAMETER) MASK Register */
+
+/* -------- ACIFC_VERSION : (ACIFC Offset: 0x34) (R/  32) Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version Number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant Number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ACIFC_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACIFC_VERSION_OFFSET        0x34         /**< \brief (ACIFC_VERSION offset) Version Register */
+#define ACIFC_VERSION_RESETVALUE    _U(0x00000101); /**< \brief (ACIFC_VERSION reset_value) Version Register */
+
+#define ACIFC_VERSION_VERSION_Pos   0            /**< \brief (ACIFC_VERSION) Version Number */
+#define ACIFC_VERSION_VERSION_Msk   (_U(0xFFF) << ACIFC_VERSION_VERSION_Pos)
+#define ACIFC_VERSION_VERSION(value) (ACIFC_VERSION_VERSION_Msk & ((value) << ACIFC_VERSION_VERSION_Pos))
+#define ACIFC_VERSION_VARIANT_Pos   16           /**< \brief (ACIFC_VERSION) Variant Number */
+#define ACIFC_VERSION_VARIANT_Msk   (_U(0xF) << ACIFC_VERSION_VARIANT_Pos)
+#define ACIFC_VERSION_VARIANT(value) (ACIFC_VERSION_VARIANT_Msk & ((value) << ACIFC_VERSION_VARIANT_Pos))
+#define ACIFC_VERSION_MASK          _U(0x000F0FFF) /**< \brief (ACIFC_VERSION) MASK Register */
+
+/* -------- ACIFC_CONFW : (ACIFC Offset: 0x80) (R/W 32) CONFW Window configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t WIS:3;            /*!< bit:  0.. 2  Window Mode Interrupt Settings     */
+    uint32_t :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint32_t WEVSRC:3;         /*!< bit:  8..10  Peripheral Event Sourse Selection for Window Mode */
+    uint32_t WEVEN:1;          /*!< bit:     11  Window Peripheral Event Enable     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t WFEN:1;           /*!< bit:     16  Window Mode Enable                 */
+    uint32_t :15;              /*!< bit: 17..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ACIFC_CONFW_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACIFC_CONFW_OFFSET          0x80         /**< \brief (ACIFC_CONFW offset) Window configuration Register */
+#define ACIFC_CONFW_RESETVALUE      _U(0x00000000); /**< \brief (ACIFC_CONFW reset_value) Window configuration Register */
+
+#define ACIFC_CONFW_WIS_Pos         0            /**< \brief (ACIFC_CONFW) Window Mode Interrupt Settings */
+#define ACIFC_CONFW_WIS_Msk         (_U(0x7) << ACIFC_CONFW_WIS_Pos)
+#define ACIFC_CONFW_WIS(value)      (ACIFC_CONFW_WIS_Msk & ((value) << ACIFC_CONFW_WIS_Pos))
+#define ACIFC_CONFW_WEVSRC_Pos      8            /**< \brief (ACIFC_CONFW) Peripheral Event Sourse Selection for Window Mode */
+#define ACIFC_CONFW_WEVSRC_Msk      (_U(0x7) << ACIFC_CONFW_WEVSRC_Pos)
+#define ACIFC_CONFW_WEVSRC(value)   (ACIFC_CONFW_WEVSRC_Msk & ((value) << ACIFC_CONFW_WEVSRC_Pos))
+#define ACIFC_CONFW_WEVEN_Pos       11           /**< \brief (ACIFC_CONFW) Window Peripheral Event Enable */
+#define ACIFC_CONFW_WEVEN           (_U(0x1) << ACIFC_CONFW_WEVEN_Pos)
+#define ACIFC_CONFW_WFEN_Pos        16           /**< \brief (ACIFC_CONFW) Window Mode Enable */
+#define ACIFC_CONFW_WFEN            (_U(0x1) << ACIFC_CONFW_WFEN_Pos)
+#define ACIFC_CONFW_MASK            _U(0x00010F07) /**< \brief (ACIFC_CONFW) MASK Register */
+
+/* -------- ACIFC_CONF : (ACIFC Offset: 0xD0) (R/W 32) CONF AC Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t IS:2;             /*!< bit:  0.. 1  Interupt Settings                  */
+    uint32_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint32_t MODE:2;           /*!< bit:  4.. 5  Analog Comparator Mode             */
+    uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t INSELN:2;         /*!< bit:  8.. 9  Negative Input Select              */
+    uint32_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint32_t EVENN:1;          /*!< bit:     16  Peripheral Event Enable Negative   */
+    uint32_t EVENP:1;          /*!< bit:     17  Peripheral Event Enable Positive   */
+    uint32_t :6;               /*!< bit: 18..23  Reserved                           */
+    uint32_t HYS:2;            /*!< bit: 24..25  Hysteresis Voltage Value           */
+    uint32_t FAST:1;           /*!< bit:     26  Fast Mode Enable                   */
+    uint32_t ALWAYSON:1;       /*!< bit:     27  Always On                          */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ACIFC_CONF_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ACIFC_CONF_OFFSET           0xD0         /**< \brief (ACIFC_CONF offset) AC Configuration Register */
+#define ACIFC_CONF_RESETVALUE       _U(0x00000000); /**< \brief (ACIFC_CONF reset_value) AC Configuration Register */
+
+#define ACIFC_CONF_IS_Pos           0            /**< \brief (ACIFC_CONF) Interupt Settings */
+#define ACIFC_CONF_IS_Msk           (_U(0x3) << ACIFC_CONF_IS_Pos)
+#define ACIFC_CONF_IS(value)        (ACIFC_CONF_IS_Msk & ((value) << ACIFC_CONF_IS_Pos))
+#define ACIFC_CONF_MODE_Pos         4            /**< \brief (ACIFC_CONF) Analog Comparator Mode */
+#define ACIFC_CONF_MODE_Msk         (_U(0x3) << ACIFC_CONF_MODE_Pos)
+#define ACIFC_CONF_MODE(value)      (ACIFC_CONF_MODE_Msk & ((value) << ACIFC_CONF_MODE_Pos))
+#define ACIFC_CONF_INSELN_Pos       8            /**< \brief (ACIFC_CONF) Negative Input Select */
+#define ACIFC_CONF_INSELN_Msk       (_U(0x3) << ACIFC_CONF_INSELN_Pos)
+#define ACIFC_CONF_INSELN(value)    (ACIFC_CONF_INSELN_Msk & ((value) << ACIFC_CONF_INSELN_Pos))
+#define ACIFC_CONF_EVENN_Pos        16           /**< \brief (ACIFC_CONF) Peripheral Event Enable Negative */
+#define ACIFC_CONF_EVENN            (_U(0x1) << ACIFC_CONF_EVENN_Pos)
+#define ACIFC_CONF_EVENP_Pos        17           /**< \brief (ACIFC_CONF) Peripheral Event Enable Positive */
+#define ACIFC_CONF_EVENP            (_U(0x1) << ACIFC_CONF_EVENP_Pos)
+#define ACIFC_CONF_HYS_Pos          24           /**< \brief (ACIFC_CONF) Hysteresis Voltage Value */
+#define ACIFC_CONF_HYS_Msk          (_U(0x3) << ACIFC_CONF_HYS_Pos)
+#define ACIFC_CONF_HYS(value)       (ACIFC_CONF_HYS_Msk & ((value) << ACIFC_CONF_HYS_Pos))
+#define ACIFC_CONF_FAST_Pos         26           /**< \brief (ACIFC_CONF) Fast Mode Enable */
+#define ACIFC_CONF_FAST             (_U(0x1) << ACIFC_CONF_FAST_Pos)
+#define ACIFC_CONF_ALWAYSON_Pos     27           /**< \brief (ACIFC_CONF) Always On */
+#define ACIFC_CONF_ALWAYSON         (_U(0x1) << ACIFC_CONF_ALWAYSON_Pos)
+#define ACIFC_CONF_MASK             _U(0x0F030333) /**< \brief (ACIFC_CONF) MASK Register */
+
+/** \brief AcifcConf hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __IO ACIFC_CONF_Type           CONF;        /**< \brief Offset: 0x00 (R/W 32) AC Configuration Register */
+ } bf;
+ struct {
+  RwReg   ACIFC_CONF;         /**< \brief (ACIFC Offset: 0x00) AC Configuration Register */
+ } reg;
+} AcifcConf;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief AcifcConfw hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __IO ACIFC_CONFW_Type          CONFW;       /**< \brief Offset: 0x00 (R/W 32) Window configuration Register */
+ } bf;
+ struct {
+  RwReg   ACIFC_CONFW;        /**< \brief (ACIFC Offset: 0x00) Window configuration Register */
+ } reg;
+} AcifcConfw;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief ACIFC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __IO ACIFC_CTRL_Type           CTRL;        /**< \brief Offset: 0x00 (R/W 32) Control Register */
+  __I  ACIFC_SR_Type             SR;          /**< \brief Offset: 0x04 (R/  32) Status Register */
+       RoReg8                    Reserved1[0x8];
+  __O  ACIFC_IER_Type            IER;         /**< \brief Offset: 0x10 ( /W 32) Interrupt Enable Register */
+  __O  ACIFC_IDR_Type            IDR;         /**< \brief Offset: 0x14 ( /W 32) Interrupt Disable Register */
+  __I  ACIFC_IMR_Type            IMR;         /**< \brief Offset: 0x18 (R/  32) Interrupt Mask Register */
+  __I  ACIFC_ISR_Type            ISR;         /**< \brief Offset: 0x1C (R/  32) Interrupt Status Register */
+  __O  ACIFC_ICR_Type            ICR;         /**< \brief Offset: 0x20 ( /W 32) Interrupt Status Clear Register */
+  __IO ACIFC_TR_Type             TR;          /**< \brief Offset: 0x24 (R/W 32) Test Register */
+       RoReg8                    Reserved2[0x8];
+  __I  ACIFC_PARAMETER_Type      PARAMETER;   /**< \brief Offset: 0x30 (R/  32) Parameter Register */
+  __I  ACIFC_VERSION_Type        VERSION;     /**< \brief Offset: 0x34 (R/  32) Version Register */
+       RoReg8                    Reserved3[0x48];
+       AcifcConfw                Confw[4];    /**< \brief Offset: 0x80 AcifcConfw groups */
+       RoReg8                    Reserved4[0x40];
+       AcifcConf                 Conf[8];     /**< \brief Offset: 0xD0 AcifcConf groups */
+ } bf;
+ struct {
+  RwReg   ACIFC_CTRL;         /**< \brief (ACIFC Offset: 0x00) Control Register */
+  RoReg   ACIFC_SR;           /**< \brief (ACIFC Offset: 0x04) Status Register */
+  RoReg8  Reserved5[0x8];
+  WoReg   ACIFC_IER;          /**< \brief (ACIFC Offset: 0x10) Interrupt Enable Register */
+  WoReg   ACIFC_IDR;          /**< \brief (ACIFC Offset: 0x14) Interrupt Disable Register */
+  RoReg   ACIFC_IMR;          /**< \brief (ACIFC Offset: 0x18) Interrupt Mask Register */
+  RoReg   ACIFC_ISR;          /**< \brief (ACIFC Offset: 0x1C) Interrupt Status Register */
+  WoReg   ACIFC_ICR;          /**< \brief (ACIFC Offset: 0x20) Interrupt Status Clear Register */
+  RwReg   ACIFC_TR;           /**< \brief (ACIFC Offset: 0x24) Test Register */
+  RoReg8  Reserved6[0x8];
+  RoReg   ACIFC_PARAMETER;    /**< \brief (ACIFC Offset: 0x30) Parameter Register */
+  RoReg   ACIFC_VERSION;      /**< \brief (ACIFC Offset: 0x34) Version Register */
+  RoReg8  Reserved7[0x48];
+  AcifcConfw ACIFC_CONFW[4];     /**< \brief (ACIFC Offset: 0x80) AcifcConfw groups */
+  RoReg8  Reserved8[0x40];
+  AcifcConf ACIFC_CONF[8];      /**< \brief (ACIFC Offset: 0xD0) AcifcConf groups */
+ } reg;
+} Acifc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_ACIFC_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/adcife.h
+++ b/asf/sam/include/sam4l/component/adcife.h
@@ -60,29 +60,29 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADCIFE_CR_OFFSET            0x00         /**< \brief (ADCIFE_CR offset) Control Register */
-#define ADCIFE_CR_RESETVALUE        _U(0x00000000); /**< \brief (ADCIFE_CR reset_value) Control Register */
+#define ADCIFE_CR_RESETVALUE        _U_(0x00000000); /**< \brief (ADCIFE_CR reset_value) Control Register */
 
 #define ADCIFE_CR_SWRST_Pos         0            /**< \brief (ADCIFE_CR) Software reset */
-#define ADCIFE_CR_SWRST             (_U(0x1) << ADCIFE_CR_SWRST_Pos)
+#define ADCIFE_CR_SWRST             (_U_(0x1) << ADCIFE_CR_SWRST_Pos)
 #define ADCIFE_CR_TSTOP_Pos         1            /**< \brief (ADCIFE_CR) Internal timer stop bit */
-#define ADCIFE_CR_TSTOP             (_U(0x1) << ADCIFE_CR_TSTOP_Pos)
+#define ADCIFE_CR_TSTOP             (_U_(0x1) << ADCIFE_CR_TSTOP_Pos)
 #define ADCIFE_CR_TSTART_Pos        2            /**< \brief (ADCIFE_CR) Internal timer start bit */
-#define ADCIFE_CR_TSTART            (_U(0x1) << ADCIFE_CR_TSTART_Pos)
+#define ADCIFE_CR_TSTART            (_U_(0x1) << ADCIFE_CR_TSTART_Pos)
 #define ADCIFE_CR_STRIG_Pos         3            /**< \brief (ADCIFE_CR) Sequencer trigger */
-#define ADCIFE_CR_STRIG             (_U(0x1) << ADCIFE_CR_STRIG_Pos)
+#define ADCIFE_CR_STRIG             (_U_(0x1) << ADCIFE_CR_STRIG_Pos)
 #define ADCIFE_CR_REFBUFEN_Pos      4            /**< \brief (ADCIFE_CR) Reference buffer enable */
-#define ADCIFE_CR_REFBUFEN          (_U(0x1) << ADCIFE_CR_REFBUFEN_Pos)
+#define ADCIFE_CR_REFBUFEN          (_U_(0x1) << ADCIFE_CR_REFBUFEN_Pos)
 #define ADCIFE_CR_REFBUFDIS_Pos     5            /**< \brief (ADCIFE_CR) Reference buffer disable */
-#define ADCIFE_CR_REFBUFDIS         (_U(0x1) << ADCIFE_CR_REFBUFDIS_Pos)
+#define ADCIFE_CR_REFBUFDIS         (_U_(0x1) << ADCIFE_CR_REFBUFDIS_Pos)
 #define ADCIFE_CR_EN_Pos            8            /**< \brief (ADCIFE_CR) ADCIFD enable */
-#define ADCIFE_CR_EN                (_U(0x1) << ADCIFE_CR_EN_Pos)
+#define ADCIFE_CR_EN                (_U_(0x1) << ADCIFE_CR_EN_Pos)
 #define ADCIFE_CR_DIS_Pos           9            /**< \brief (ADCIFE_CR) ADCIFD disable */
-#define ADCIFE_CR_DIS               (_U(0x1) << ADCIFE_CR_DIS_Pos)
+#define ADCIFE_CR_DIS               (_U_(0x1) << ADCIFE_CR_DIS_Pos)
 #define ADCIFE_CR_BGREQEN_Pos       10           /**< \brief (ADCIFE_CR) Bandgap buffer request enable */
-#define ADCIFE_CR_BGREQEN           (_U(0x1) << ADCIFE_CR_BGREQEN_Pos)
+#define ADCIFE_CR_BGREQEN           (_U_(0x1) << ADCIFE_CR_BGREQEN_Pos)
 #define ADCIFE_CR_BGREQDIS_Pos      11           /**< \brief (ADCIFE_CR) Bandgap buffer request disable */
-#define ADCIFE_CR_BGREQDIS          (_U(0x1) << ADCIFE_CR_BGREQDIS_Pos)
-#define ADCIFE_CR_MASK              _U(0x00000F3F) /**< \brief (ADCIFE_CR) MASK Register */
+#define ADCIFE_CR_BGREQDIS          (_U_(0x1) << ADCIFE_CR_BGREQDIS_Pos)
+#define ADCIFE_CR_MASK              _U_(0x00000F3F) /**< \brief (ADCIFE_CR) MASK Register */
 
 /* -------- ADCIFE_CFG : (ADCIFE Offset: 0x04) (R/W 32) Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -101,20 +101,20 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADCIFE_CFG_OFFSET           0x04         /**< \brief (ADCIFE_CFG offset) Configuration Register */
-#define ADCIFE_CFG_RESETVALUE       _U(0x00000000); /**< \brief (ADCIFE_CFG reset_value) Configuration Register */
+#define ADCIFE_CFG_RESETVALUE       _U_(0x00000000); /**< \brief (ADCIFE_CFG reset_value) Configuration Register */
 
 #define ADCIFE_CFG_REFSEL_Pos       1            /**< \brief (ADCIFE_CFG) ADC Reference Selection */
-#define ADCIFE_CFG_REFSEL_Msk       (_U(0x7) << ADCIFE_CFG_REFSEL_Pos)
+#define ADCIFE_CFG_REFSEL_Msk       (_U_(0x7) << ADCIFE_CFG_REFSEL_Pos)
 #define ADCIFE_CFG_REFSEL(value)    (ADCIFE_CFG_REFSEL_Msk & ((value) << ADCIFE_CFG_REFSEL_Pos))
 #define ADCIFE_CFG_SPEED_Pos        4            /**< \brief (ADCIFE_CFG) ADC current reduction */
-#define ADCIFE_CFG_SPEED_Msk        (_U(0x3) << ADCIFE_CFG_SPEED_Pos)
+#define ADCIFE_CFG_SPEED_Msk        (_U_(0x3) << ADCIFE_CFG_SPEED_Pos)
 #define ADCIFE_CFG_SPEED(value)     (ADCIFE_CFG_SPEED_Msk & ((value) << ADCIFE_CFG_SPEED_Pos))
 #define ADCIFE_CFG_CLKSEL_Pos       6            /**< \brief (ADCIFE_CFG) Clock Selection for sequencer/ADC cell */
-#define ADCIFE_CFG_CLKSEL           (_U(0x1) << ADCIFE_CFG_CLKSEL_Pos)
+#define ADCIFE_CFG_CLKSEL           (_U_(0x1) << ADCIFE_CFG_CLKSEL_Pos)
 #define ADCIFE_CFG_PRESCAL_Pos      8            /**< \brief (ADCIFE_CFG) Prescaler Rate Selection */
-#define ADCIFE_CFG_PRESCAL_Msk      (_U(0x7) << ADCIFE_CFG_PRESCAL_Pos)
+#define ADCIFE_CFG_PRESCAL_Msk      (_U_(0x7) << ADCIFE_CFG_PRESCAL_Pos)
 #define ADCIFE_CFG_PRESCAL(value)   (ADCIFE_CFG_PRESCAL_Msk & ((value) << ADCIFE_CFG_PRESCAL_Pos))
-#define ADCIFE_CFG_MASK             _U(0x0000077E) /**< \brief (ADCIFE_CFG) MASK Register */
+#define ADCIFE_CFG_MASK             _U_(0x0000077E) /**< \brief (ADCIFE_CFG) MASK Register */
 
 /* -------- ADCIFE_SR : (ADCIFE Offset: 0x08) (R/  32) Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -139,31 +139,31 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADCIFE_SR_OFFSET            0x08         /**< \brief (ADCIFE_SR offset) Status Register */
-#define ADCIFE_SR_RESETVALUE        _U(0x00000000); /**< \brief (ADCIFE_SR reset_value) Status Register */
+#define ADCIFE_SR_RESETVALUE        _U_(0x00000000); /**< \brief (ADCIFE_SR reset_value) Status Register */
 
 #define ADCIFE_SR_SEOC_Pos          0            /**< \brief (ADCIFE_SR) Sequencer end of conversion */
-#define ADCIFE_SR_SEOC              (_U(0x1) << ADCIFE_SR_SEOC_Pos)
+#define ADCIFE_SR_SEOC              (_U_(0x1) << ADCIFE_SR_SEOC_Pos)
 #define ADCIFE_SR_LOVR_Pos          1            /**< \brief (ADCIFE_SR) Sequencer last converted value overrun */
-#define ADCIFE_SR_LOVR              (_U(0x1) << ADCIFE_SR_LOVR_Pos)
+#define ADCIFE_SR_LOVR              (_U_(0x1) << ADCIFE_SR_LOVR_Pos)
 #define ADCIFE_SR_WM_Pos            2            /**< \brief (ADCIFE_SR) Window monitor */
-#define ADCIFE_SR_WM                (_U(0x1) << ADCIFE_SR_WM_Pos)
+#define ADCIFE_SR_WM                (_U_(0x1) << ADCIFE_SR_WM_Pos)
 #define ADCIFE_SR_SMTRG_Pos         3            /**< \brief (ADCIFE_SR) Sequencer missed trigger event */
-#define ADCIFE_SR_SMTRG             (_U(0x1) << ADCIFE_SR_SMTRG_Pos)
+#define ADCIFE_SR_SMTRG             (_U_(0x1) << ADCIFE_SR_SMTRG_Pos)
 #define ADCIFE_SR_SUTD_Pos          4            /**< \brief (ADCIFE_SR) Start-up time done */
-#define ADCIFE_SR_SUTD              (_U(0x1) << ADCIFE_SR_SUTD_Pos)
+#define ADCIFE_SR_SUTD              (_U_(0x1) << ADCIFE_SR_SUTD_Pos)
 #define ADCIFE_SR_TTO_Pos           5            /**< \brief (ADCIFE_SR) Timer time-out */
-#define ADCIFE_SR_TTO               (_U(0x1) << ADCIFE_SR_TTO_Pos)
+#define ADCIFE_SR_TTO               (_U_(0x1) << ADCIFE_SR_TTO_Pos)
 #define ADCIFE_SR_EN_Pos            24           /**< \brief (ADCIFE_SR) Enable Status */
-#define ADCIFE_SR_EN                (_U(0x1) << ADCIFE_SR_EN_Pos)
+#define ADCIFE_SR_EN                (_U_(0x1) << ADCIFE_SR_EN_Pos)
 #define ADCIFE_SR_TBUSY_Pos         25           /**< \brief (ADCIFE_SR) Timer busy */
-#define ADCIFE_SR_TBUSY             (_U(0x1) << ADCIFE_SR_TBUSY_Pos)
+#define ADCIFE_SR_TBUSY             (_U_(0x1) << ADCIFE_SR_TBUSY_Pos)
 #define ADCIFE_SR_SBUSY_Pos         26           /**< \brief (ADCIFE_SR) Sequencer busy */
-#define ADCIFE_SR_SBUSY             (_U(0x1) << ADCIFE_SR_SBUSY_Pos)
+#define ADCIFE_SR_SBUSY             (_U_(0x1) << ADCIFE_SR_SBUSY_Pos)
 #define ADCIFE_SR_CBUSY_Pos         27           /**< \brief (ADCIFE_SR) Conversion busy */
-#define ADCIFE_SR_CBUSY             (_U(0x1) << ADCIFE_SR_CBUSY_Pos)
+#define ADCIFE_SR_CBUSY             (_U_(0x1) << ADCIFE_SR_CBUSY_Pos)
 #define ADCIFE_SR_REFBUF_Pos        28           /**< \brief (ADCIFE_SR) Reference buffer status */
-#define ADCIFE_SR_REFBUF            (_U(0x1) << ADCIFE_SR_REFBUF_Pos)
-#define ADCIFE_SR_MASK              _U(0x1F00003F) /**< \brief (ADCIFE_SR) MASK Register */
+#define ADCIFE_SR_REFBUF            (_U_(0x1) << ADCIFE_SR_REFBUF_Pos)
+#define ADCIFE_SR_MASK              _U_(0x1F00003F) /**< \brief (ADCIFE_SR) MASK Register */
 
 /* -------- ADCIFE_SCR : (ADCIFE Offset: 0x0C) ( /W 32) Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -182,21 +182,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADCIFE_SCR_OFFSET           0x0C         /**< \brief (ADCIFE_SCR offset) Status Clear Register */
-#define ADCIFE_SCR_RESETVALUE       _U(0x00000000); /**< \brief (ADCIFE_SCR reset_value) Status Clear Register */
+#define ADCIFE_SCR_RESETVALUE       _U_(0x00000000); /**< \brief (ADCIFE_SCR reset_value) Status Clear Register */
 
 #define ADCIFE_SCR_SEOC_Pos         0            /**< \brief (ADCIFE_SCR) Sequencer end of conversion */
-#define ADCIFE_SCR_SEOC             (_U(0x1) << ADCIFE_SCR_SEOC_Pos)
+#define ADCIFE_SCR_SEOC             (_U_(0x1) << ADCIFE_SCR_SEOC_Pos)
 #define ADCIFE_SCR_LOVR_Pos         1            /**< \brief (ADCIFE_SCR) Sequencer last converted value overrun */
-#define ADCIFE_SCR_LOVR             (_U(0x1) << ADCIFE_SCR_LOVR_Pos)
+#define ADCIFE_SCR_LOVR             (_U_(0x1) << ADCIFE_SCR_LOVR_Pos)
 #define ADCIFE_SCR_WM_Pos           2            /**< \brief (ADCIFE_SCR) Window monitor */
-#define ADCIFE_SCR_WM               (_U(0x1) << ADCIFE_SCR_WM_Pos)
+#define ADCIFE_SCR_WM               (_U_(0x1) << ADCIFE_SCR_WM_Pos)
 #define ADCIFE_SCR_SMTRG_Pos        3            /**< \brief (ADCIFE_SCR) Sequencer missed trigger event */
-#define ADCIFE_SCR_SMTRG            (_U(0x1) << ADCIFE_SCR_SMTRG_Pos)
+#define ADCIFE_SCR_SMTRG            (_U_(0x1) << ADCIFE_SCR_SMTRG_Pos)
 #define ADCIFE_SCR_SUTD_Pos         4            /**< \brief (ADCIFE_SCR) Start-up time done */
-#define ADCIFE_SCR_SUTD             (_U(0x1) << ADCIFE_SCR_SUTD_Pos)
+#define ADCIFE_SCR_SUTD             (_U_(0x1) << ADCIFE_SCR_SUTD_Pos)
 #define ADCIFE_SCR_TTO_Pos          5            /**< \brief (ADCIFE_SCR) Timer time-out */
-#define ADCIFE_SCR_TTO              (_U(0x1) << ADCIFE_SCR_TTO_Pos)
-#define ADCIFE_SCR_MASK             _U(0x0000003F) /**< \brief (ADCIFE_SCR) MASK Register */
+#define ADCIFE_SCR_TTO              (_U_(0x1) << ADCIFE_SCR_TTO_Pos)
+#define ADCIFE_SCR_MASK             _U_(0x0000003F) /**< \brief (ADCIFE_SCR) MASK Register */
 
 /* -------- ADCIFE_RTS : (ADCIFE Offset: 0x10) (R/W 32) Resistive Touch Screen Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -206,9 +206,9 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADCIFE_RTS_OFFSET           0x10         /**< \brief (ADCIFE_RTS offset) Resistive Touch Screen Register */
-#define ADCIFE_RTS_RESETVALUE       _U(0x00000000); /**< \brief (ADCIFE_RTS reset_value) Resistive Touch Screen Register */
+#define ADCIFE_RTS_RESETVALUE       _U_(0x00000000); /**< \brief (ADCIFE_RTS reset_value) Resistive Touch Screen Register */
 
-#define ADCIFE_RTS_MASK             _U(0x00000000) /**< \brief (ADCIFE_RTS) MASK Register */
+#define ADCIFE_RTS_MASK             _U_(0x00000000) /**< \brief (ADCIFE_RTS) MASK Register */
 
 /* -------- ADCIFE_SEQCFG : (ADCIFE Offset: 0x14) (R/W 32) Sequencer Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -236,35 +236,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADCIFE_SEQCFG_OFFSET        0x14         /**< \brief (ADCIFE_SEQCFG offset) Sequencer Configuration Register */
-#define ADCIFE_SEQCFG_RESETVALUE    _U(0x00000000); /**< \brief (ADCIFE_SEQCFG reset_value) Sequencer Configuration Register */
+#define ADCIFE_SEQCFG_RESETVALUE    _U_(0x00000000); /**< \brief (ADCIFE_SEQCFG reset_value) Sequencer Configuration Register */
 
 #define ADCIFE_SEQCFG_HWLA_Pos      0            /**< \brief (ADCIFE_SEQCFG) Half word left adjust */
-#define ADCIFE_SEQCFG_HWLA          (_U(0x1) << ADCIFE_SEQCFG_HWLA_Pos)
+#define ADCIFE_SEQCFG_HWLA          (_U_(0x1) << ADCIFE_SEQCFG_HWLA_Pos)
 #define ADCIFE_SEQCFG_BIPOLAR_Pos   2            /**< \brief (ADCIFE_SEQCFG) Bipolar Mode */
-#define ADCIFE_SEQCFG_BIPOLAR       (_U(0x1) << ADCIFE_SEQCFG_BIPOLAR_Pos)
+#define ADCIFE_SEQCFG_BIPOLAR       (_U_(0x1) << ADCIFE_SEQCFG_BIPOLAR_Pos)
 #define ADCIFE_SEQCFG_GAIN_Pos      4            /**< \brief (ADCIFE_SEQCFG) Gain factor */
-#define ADCIFE_SEQCFG_GAIN_Msk      (_U(0x7) << ADCIFE_SEQCFG_GAIN_Pos)
+#define ADCIFE_SEQCFG_GAIN_Msk      (_U_(0x7) << ADCIFE_SEQCFG_GAIN_Pos)
 #define ADCIFE_SEQCFG_GAIN(value)   (ADCIFE_SEQCFG_GAIN_Msk & ((value) << ADCIFE_SEQCFG_GAIN_Pos))
 #define ADCIFE_SEQCFG_GCOMP_Pos     7            /**< \brief (ADCIFE_SEQCFG) Gain Compensation */
-#define ADCIFE_SEQCFG_GCOMP         (_U(0x1) << ADCIFE_SEQCFG_GCOMP_Pos)
+#define ADCIFE_SEQCFG_GCOMP         (_U_(0x1) << ADCIFE_SEQCFG_GCOMP_Pos)
 #define ADCIFE_SEQCFG_TRGSEL_Pos    8            /**< \brief (ADCIFE_SEQCFG) Trigger selection */
-#define ADCIFE_SEQCFG_TRGSEL_Msk    (_U(0x7) << ADCIFE_SEQCFG_TRGSEL_Pos)
+#define ADCIFE_SEQCFG_TRGSEL_Msk    (_U_(0x7) << ADCIFE_SEQCFG_TRGSEL_Pos)
 #define ADCIFE_SEQCFG_TRGSEL(value) (ADCIFE_SEQCFG_TRGSEL_Msk & ((value) << ADCIFE_SEQCFG_TRGSEL_Pos))
 #define ADCIFE_SEQCFG_RES_Pos       12           /**< \brief (ADCIFE_SEQCFG) Resolution */
-#define ADCIFE_SEQCFG_RES           (_U(0x1) << ADCIFE_SEQCFG_RES_Pos)
+#define ADCIFE_SEQCFG_RES           (_U_(0x1) << ADCIFE_SEQCFG_RES_Pos)
 #define ADCIFE_SEQCFG_INTERNAL_Pos  14           /**< \brief (ADCIFE_SEQCFG) Internal Voltage Source Selection */
-#define ADCIFE_SEQCFG_INTERNAL_Msk  (_U(0x3) << ADCIFE_SEQCFG_INTERNAL_Pos)
+#define ADCIFE_SEQCFG_INTERNAL_Msk  (_U_(0x3) << ADCIFE_SEQCFG_INTERNAL_Pos)
 #define ADCIFE_SEQCFG_INTERNAL(value) (ADCIFE_SEQCFG_INTERNAL_Msk & ((value) << ADCIFE_SEQCFG_INTERNAL_Pos))
 #define ADCIFE_SEQCFG_MUXPOS_Pos    16           /**< \brief (ADCIFE_SEQCFG) MUX selection on Positive ADC input channel */
-#define ADCIFE_SEQCFG_MUXPOS_Msk    (_U(0xF) << ADCIFE_SEQCFG_MUXPOS_Pos)
+#define ADCIFE_SEQCFG_MUXPOS_Msk    (_U_(0xF) << ADCIFE_SEQCFG_MUXPOS_Pos)
 #define ADCIFE_SEQCFG_MUXPOS(value) (ADCIFE_SEQCFG_MUXPOS_Msk & ((value) << ADCIFE_SEQCFG_MUXPOS_Pos))
 #define ADCIFE_SEQCFG_MUXNEG_Pos    20           /**< \brief (ADCIFE_SEQCFG) MUX selection on Negative ADC input channel */
-#define ADCIFE_SEQCFG_MUXNEG_Msk    (_U(0x7) << ADCIFE_SEQCFG_MUXNEG_Pos)
+#define ADCIFE_SEQCFG_MUXNEG_Msk    (_U_(0x7) << ADCIFE_SEQCFG_MUXNEG_Pos)
 #define ADCIFE_SEQCFG_MUXNEG(value) (ADCIFE_SEQCFG_MUXNEG_Msk & ((value) << ADCIFE_SEQCFG_MUXNEG_Pos))
 #define ADCIFE_SEQCFG_ZOOMRANGE_Pos 28           /**< \brief (ADCIFE_SEQCFG) Zoom shift/unipolar reference source selection */
-#define ADCIFE_SEQCFG_ZOOMRANGE_Msk (_U(0x7) << ADCIFE_SEQCFG_ZOOMRANGE_Pos)
+#define ADCIFE_SEQCFG_ZOOMRANGE_Msk (_U_(0x7) << ADCIFE_SEQCFG_ZOOMRANGE_Pos)
 #define ADCIFE_SEQCFG_ZOOMRANGE(value) (ADCIFE_SEQCFG_ZOOMRANGE_Msk & ((value) << ADCIFE_SEQCFG_ZOOMRANGE_Pos))
-#define ADCIFE_SEQCFG_MASK          _U(0x707FD7F5) /**< \brief (ADCIFE_SEQCFG) MASK Register */
+#define ADCIFE_SEQCFG_MASK          _U_(0x707FD7F5) /**< \brief (ADCIFE_SEQCFG) MASK Register */
 
 /* -------- ADCIFE_CDMA : (ADCIFE Offset: 0x18) ( /W 32) Configuration Direct Memory Access Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -300,98 +300,98 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADCIFE_CDMA_OFFSET          0x18         /**< \brief (ADCIFE_CDMA offset) Configuration Direct Memory Access Register */
-#define ADCIFE_CDMA_RESETVALUE      _U(0x00000000); /**< \brief (ADCIFE_CDMA reset_value) Configuration Direct Memory Access Register */
+#define ADCIFE_CDMA_RESETVALUE      _U_(0x00000000); /**< \brief (ADCIFE_CDMA reset_value) Configuration Direct Memory Access Register */
 
 // FIRST_DMA_WORD mode
 #define ADCIFE_CDMA_FIRST_DMA_WORD_HWLA_Pos 0            /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) Half word left adjust */
-#define ADCIFE_CDMA_FIRST_DMA_WORD_HWLA (_U(0x1) << ADCIFE_CDMA_FIRST_DMA_WORD_HWLA_Pos)
+#define ADCIFE_CDMA_FIRST_DMA_WORD_HWLA (_U_(0x1) << ADCIFE_CDMA_FIRST_DMA_WORD_HWLA_Pos)
 #define ADCIFE_CDMA_FIRST_DMA_WORD_BIPOLAR_Pos 2            /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) Bipolar Mode */
-#define ADCIFE_CDMA_FIRST_DMA_WORD_BIPOLAR (_U(0x1) << ADCIFE_CDMA_FIRST_DMA_WORD_BIPOLAR_Pos)
+#define ADCIFE_CDMA_FIRST_DMA_WORD_BIPOLAR (_U_(0x1) << ADCIFE_CDMA_FIRST_DMA_WORD_BIPOLAR_Pos)
 #define ADCIFE_CDMA_FIRST_DMA_WORD_STRIG_Pos 3            /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) Sequencer Trigger Event */
-#define ADCIFE_CDMA_FIRST_DMA_WORD_STRIG (_U(0x1) << ADCIFE_CDMA_FIRST_DMA_WORD_STRIG_Pos)
+#define ADCIFE_CDMA_FIRST_DMA_WORD_STRIG (_U_(0x1) << ADCIFE_CDMA_FIRST_DMA_WORD_STRIG_Pos)
 #define ADCIFE_CDMA_FIRST_DMA_WORD_GAIN_Pos 4            /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) Gain factor */
-#define ADCIFE_CDMA_FIRST_DMA_WORD_GAIN_Msk (_U(0x7) << ADCIFE_CDMA_FIRST_DMA_WORD_GAIN_Pos)
+#define ADCIFE_CDMA_FIRST_DMA_WORD_GAIN_Msk (_U_(0x7) << ADCIFE_CDMA_FIRST_DMA_WORD_GAIN_Pos)
 #define ADCIFE_CDMA_FIRST_DMA_WORD_GAIN(value) (ADCIFE_CDMA_FIRST_DMA_WORD_GAIN_Msk & ((value) << ADCIFE_CDMA_FIRST_DMA_WORD_GAIN_Pos))
 #define ADCIFE_CDMA_FIRST_DMA_WORD_GCOMP_Pos 7            /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) Gain Compensation */
-#define ADCIFE_CDMA_FIRST_DMA_WORD_GCOMP (_U(0x1) << ADCIFE_CDMA_FIRST_DMA_WORD_GCOMP_Pos)
+#define ADCIFE_CDMA_FIRST_DMA_WORD_GCOMP (_U_(0x1) << ADCIFE_CDMA_FIRST_DMA_WORD_GCOMP_Pos)
 #define ADCIFE_CDMA_FIRST_DMA_WORD_ENSTUP_Pos 8            /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) Enable Start-Up Time */
-#define ADCIFE_CDMA_FIRST_DMA_WORD_ENSTUP (_U(0x1) << ADCIFE_CDMA_FIRST_DMA_WORD_ENSTUP_Pos)
+#define ADCIFE_CDMA_FIRST_DMA_WORD_ENSTUP (_U_(0x1) << ADCIFE_CDMA_FIRST_DMA_WORD_ENSTUP_Pos)
 #define ADCIFE_CDMA_FIRST_DMA_WORD_RES_Pos 12           /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) Resolution */
-#define ADCIFE_CDMA_FIRST_DMA_WORD_RES (_U(0x1) << ADCIFE_CDMA_FIRST_DMA_WORD_RES_Pos)
+#define ADCIFE_CDMA_FIRST_DMA_WORD_RES (_U_(0x1) << ADCIFE_CDMA_FIRST_DMA_WORD_RES_Pos)
 #define ADCIFE_CDMA_FIRST_DMA_WORD_TSS_Pos 13           /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) Internal timer start or stop bit */
-#define ADCIFE_CDMA_FIRST_DMA_WORD_TSS (_U(0x1) << ADCIFE_CDMA_FIRST_DMA_WORD_TSS_Pos)
+#define ADCIFE_CDMA_FIRST_DMA_WORD_TSS (_U_(0x1) << ADCIFE_CDMA_FIRST_DMA_WORD_TSS_Pos)
 #define ADCIFE_CDMA_FIRST_DMA_WORD_INTERNAL_Pos 14           /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) Internal Voltage Source Selection */
-#define ADCIFE_CDMA_FIRST_DMA_WORD_INTERNAL_Msk (_U(0x3) << ADCIFE_CDMA_FIRST_DMA_WORD_INTERNAL_Pos)
+#define ADCIFE_CDMA_FIRST_DMA_WORD_INTERNAL_Msk (_U_(0x3) << ADCIFE_CDMA_FIRST_DMA_WORD_INTERNAL_Pos)
 #define ADCIFE_CDMA_FIRST_DMA_WORD_INTERNAL(value) (ADCIFE_CDMA_FIRST_DMA_WORD_INTERNAL_Msk & ((value) << ADCIFE_CDMA_FIRST_DMA_WORD_INTERNAL_Pos))
 #define ADCIFE_CDMA_FIRST_DMA_WORD_MUXPOS_Pos 16           /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) MUX selection on Positive ADC input channel */
-#define ADCIFE_CDMA_FIRST_DMA_WORD_MUXPOS_Msk (_U(0xF) << ADCIFE_CDMA_FIRST_DMA_WORD_MUXPOS_Pos)
+#define ADCIFE_CDMA_FIRST_DMA_WORD_MUXPOS_Msk (_U_(0xF) << ADCIFE_CDMA_FIRST_DMA_WORD_MUXPOS_Pos)
 #define ADCIFE_CDMA_FIRST_DMA_WORD_MUXPOS(value) (ADCIFE_CDMA_FIRST_DMA_WORD_MUXPOS_Msk & ((value) << ADCIFE_CDMA_FIRST_DMA_WORD_MUXPOS_Pos))
 #define ADCIFE_CDMA_FIRST_DMA_WORD_MUXNEG_Pos 20           /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) MUX selection on Negative ADC input channel */
-#define ADCIFE_CDMA_FIRST_DMA_WORD_MUXNEG_Msk (_U(0x7) << ADCIFE_CDMA_FIRST_DMA_WORD_MUXNEG_Pos)
+#define ADCIFE_CDMA_FIRST_DMA_WORD_MUXNEG_Msk (_U_(0x7) << ADCIFE_CDMA_FIRST_DMA_WORD_MUXNEG_Pos)
 #define ADCIFE_CDMA_FIRST_DMA_WORD_MUXNEG(value) (ADCIFE_CDMA_FIRST_DMA_WORD_MUXNEG_Msk & ((value) << ADCIFE_CDMA_FIRST_DMA_WORD_MUXNEG_Pos))
 #define ADCIFE_CDMA_FIRST_DMA_WORD_ZOOMRANGE_Pos 28           /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) Zoom shift/unipolar reference source selection */
-#define ADCIFE_CDMA_FIRST_DMA_WORD_ZOOMRANGE_Msk (_U(0x7) << ADCIFE_CDMA_FIRST_DMA_WORD_ZOOMRANGE_Pos)
+#define ADCIFE_CDMA_FIRST_DMA_WORD_ZOOMRANGE_Msk (_U_(0x7) << ADCIFE_CDMA_FIRST_DMA_WORD_ZOOMRANGE_Pos)
 #define ADCIFE_CDMA_FIRST_DMA_WORD_ZOOMRANGE(value) (ADCIFE_CDMA_FIRST_DMA_WORD_ZOOMRANGE_Msk & ((value) << ADCIFE_CDMA_FIRST_DMA_WORD_ZOOMRANGE_Pos))
 #define ADCIFE_CDMA_FIRST_DMA_WORD_DW_Pos 31           /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) Double Word transmitting */
-#define ADCIFE_CDMA_FIRST_DMA_WORD_DW (_U(0x1) << ADCIFE_CDMA_FIRST_DMA_WORD_DW_Pos)
-#define ADCIFE_CDMA_FIRST_DMA_WORD_MASK _U(0xF07FF1FD) /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) MASK Register */
+#define ADCIFE_CDMA_FIRST_DMA_WORD_DW (_U_(0x1) << ADCIFE_CDMA_FIRST_DMA_WORD_DW_Pos)
+#define ADCIFE_CDMA_FIRST_DMA_WORD_MASK _U_(0xF07FF1FD) /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) MASK Register */
 
 // SECOND_DMA_WORD mode
 #define ADCIFE_CDMA_SECOND_DMA_WORD_LT_Pos 0            /**< \brief (ADCIFE_CDMA_SECOND_DMA_WORD) Low Threshold */
-#define ADCIFE_CDMA_SECOND_DMA_WORD_LT_Msk (_U(0xFFF) << ADCIFE_CDMA_SECOND_DMA_WORD_LT_Pos)
+#define ADCIFE_CDMA_SECOND_DMA_WORD_LT_Msk (_U_(0xFFF) << ADCIFE_CDMA_SECOND_DMA_WORD_LT_Pos)
 #define ADCIFE_CDMA_SECOND_DMA_WORD_LT(value) (ADCIFE_CDMA_SECOND_DMA_WORD_LT_Msk & ((value) << ADCIFE_CDMA_SECOND_DMA_WORD_LT_Pos))
 #define ADCIFE_CDMA_SECOND_DMA_WORD_WM_Pos 12           /**< \brief (ADCIFE_CDMA_SECOND_DMA_WORD) Window Monitor Mode */
-#define ADCIFE_CDMA_SECOND_DMA_WORD_WM_Msk (_U(0x7) << ADCIFE_CDMA_SECOND_DMA_WORD_WM_Pos)
+#define ADCIFE_CDMA_SECOND_DMA_WORD_WM_Msk (_U_(0x7) << ADCIFE_CDMA_SECOND_DMA_WORD_WM_Pos)
 #define ADCIFE_CDMA_SECOND_DMA_WORD_WM(value) (ADCIFE_CDMA_SECOND_DMA_WORD_WM_Msk & ((value) << ADCIFE_CDMA_SECOND_DMA_WORD_WM_Pos))
 #define ADCIFE_CDMA_SECOND_DMA_WORD_HT_Pos 16           /**< \brief (ADCIFE_CDMA_SECOND_DMA_WORD) High Threshold */
-#define ADCIFE_CDMA_SECOND_DMA_WORD_HT_Msk (_U(0xFFF) << ADCIFE_CDMA_SECOND_DMA_WORD_HT_Pos)
+#define ADCIFE_CDMA_SECOND_DMA_WORD_HT_Msk (_U_(0xFFF) << ADCIFE_CDMA_SECOND_DMA_WORD_HT_Pos)
 #define ADCIFE_CDMA_SECOND_DMA_WORD_HT(value) (ADCIFE_CDMA_SECOND_DMA_WORD_HT_Msk & ((value) << ADCIFE_CDMA_SECOND_DMA_WORD_HT_Pos))
 #define ADCIFE_CDMA_SECOND_DMA_WORD_DW_Pos 31           /**< \brief (ADCIFE_CDMA_SECOND_DMA_WORD) Double Word transmitting */
-#define ADCIFE_CDMA_SECOND_DMA_WORD_DW (_U(0x1) << ADCIFE_CDMA_SECOND_DMA_WORD_DW_Pos)
-#define ADCIFE_CDMA_SECOND_DMA_WORD_MASK _U(0x8FFF7FFF) /**< \brief (ADCIFE_CDMA_SECOND_DMA_WORD) MASK Register */
+#define ADCIFE_CDMA_SECOND_DMA_WORD_DW (_U_(0x1) << ADCIFE_CDMA_SECOND_DMA_WORD_DW_Pos)
+#define ADCIFE_CDMA_SECOND_DMA_WORD_MASK _U_(0x8FFF7FFF) /**< \brief (ADCIFE_CDMA_SECOND_DMA_WORD) MASK Register */
 
 // Any mode
 #define ADCIFE_CDMA_HWLA_Pos        0            /**< \brief (ADCIFE_CDMA) Half word left adjust */
-#define ADCIFE_CDMA_HWLA            (_U(0x1) << ADCIFE_CDMA_HWLA_Pos)
+#define ADCIFE_CDMA_HWLA            (_U_(0x1) << ADCIFE_CDMA_HWLA_Pos)
 #define ADCIFE_CDMA_LT_Pos          0            /**< \brief (ADCIFE_CDMA) Low Threshold */
-#define ADCIFE_CDMA_LT_Msk          (_U(0xFFF) << ADCIFE_CDMA_LT_Pos)
+#define ADCIFE_CDMA_LT_Msk          (_U_(0xFFF) << ADCIFE_CDMA_LT_Pos)
 #define ADCIFE_CDMA_LT(value)       (ADCIFE_CDMA_LT_Msk & ((value) << ADCIFE_CDMA_LT_Pos))
 #define ADCIFE_CDMA_BIPOLAR_Pos     2            /**< \brief (ADCIFE_CDMA) Bipolar Mode */
-#define ADCIFE_CDMA_BIPOLAR         (_U(0x1) << ADCIFE_CDMA_BIPOLAR_Pos)
+#define ADCIFE_CDMA_BIPOLAR         (_U_(0x1) << ADCIFE_CDMA_BIPOLAR_Pos)
 #define ADCIFE_CDMA_STRIG_Pos       3            /**< \brief (ADCIFE_CDMA) Sequencer Trigger Event */
-#define ADCIFE_CDMA_STRIG           (_U(0x1) << ADCIFE_CDMA_STRIG_Pos)
+#define ADCIFE_CDMA_STRIG           (_U_(0x1) << ADCIFE_CDMA_STRIG_Pos)
 #define ADCIFE_CDMA_GAIN_Pos        4            /**< \brief (ADCIFE_CDMA) Gain factor */
-#define ADCIFE_CDMA_GAIN_Msk        (_U(0x7) << ADCIFE_CDMA_GAIN_Pos)
+#define ADCIFE_CDMA_GAIN_Msk        (_U_(0x7) << ADCIFE_CDMA_GAIN_Pos)
 #define ADCIFE_CDMA_GAIN(value)     (ADCIFE_CDMA_GAIN_Msk & ((value) << ADCIFE_CDMA_GAIN_Pos))
 #define ADCIFE_CDMA_GCOMP_Pos       7            /**< \brief (ADCIFE_CDMA) Gain Compensation */
-#define ADCIFE_CDMA_GCOMP           (_U(0x1) << ADCIFE_CDMA_GCOMP_Pos)
+#define ADCIFE_CDMA_GCOMP           (_U_(0x1) << ADCIFE_CDMA_GCOMP_Pos)
 #define ADCIFE_CDMA_ENSTUP_Pos      8            /**< \brief (ADCIFE_CDMA) Enable Start-Up Time */
-#define ADCIFE_CDMA_ENSTUP          (_U(0x1) << ADCIFE_CDMA_ENSTUP_Pos)
+#define ADCIFE_CDMA_ENSTUP          (_U_(0x1) << ADCIFE_CDMA_ENSTUP_Pos)
 #define ADCIFE_CDMA_RES_Pos         12           /**< \brief (ADCIFE_CDMA) Resolution */
-#define ADCIFE_CDMA_RES             (_U(0x1) << ADCIFE_CDMA_RES_Pos)
+#define ADCIFE_CDMA_RES             (_U_(0x1) << ADCIFE_CDMA_RES_Pos)
 #define ADCIFE_CDMA_WM_Pos          12           /**< \brief (ADCIFE_CDMA) Window Monitor Mode */
-#define ADCIFE_CDMA_WM_Msk          (_U(0x7) << ADCIFE_CDMA_WM_Pos)
+#define ADCIFE_CDMA_WM_Msk          (_U_(0x7) << ADCIFE_CDMA_WM_Pos)
 #define ADCIFE_CDMA_WM(value)       (ADCIFE_CDMA_WM_Msk & ((value) << ADCIFE_CDMA_WM_Pos))
 #define ADCIFE_CDMA_TSS_Pos         13           /**< \brief (ADCIFE_CDMA) Internal timer start or stop bit */
-#define ADCIFE_CDMA_TSS             (_U(0x1) << ADCIFE_CDMA_TSS_Pos)
+#define ADCIFE_CDMA_TSS             (_U_(0x1) << ADCIFE_CDMA_TSS_Pos)
 #define ADCIFE_CDMA_INTERNAL_Pos    14           /**< \brief (ADCIFE_CDMA) Internal Voltage Source Selection */
-#define ADCIFE_CDMA_INTERNAL_Msk    (_U(0x3) << ADCIFE_CDMA_INTERNAL_Pos)
+#define ADCIFE_CDMA_INTERNAL_Msk    (_U_(0x3) << ADCIFE_CDMA_INTERNAL_Pos)
 #define ADCIFE_CDMA_INTERNAL(value) (ADCIFE_CDMA_INTERNAL_Msk & ((value) << ADCIFE_CDMA_INTERNAL_Pos))
 #define ADCIFE_CDMA_MUXPOS_Pos      16           /**< \brief (ADCIFE_CDMA) MUX selection on Positive ADC input channel */
-#define ADCIFE_CDMA_MUXPOS_Msk      (_U(0xF) << ADCIFE_CDMA_MUXPOS_Pos)
+#define ADCIFE_CDMA_MUXPOS_Msk      (_U_(0xF) << ADCIFE_CDMA_MUXPOS_Pos)
 #define ADCIFE_CDMA_MUXPOS(value)   (ADCIFE_CDMA_MUXPOS_Msk & ((value) << ADCIFE_CDMA_MUXPOS_Pos))
 #define ADCIFE_CDMA_HT_Pos          16           /**< \brief (ADCIFE_CDMA) High Threshold */
-#define ADCIFE_CDMA_HT_Msk          (_U(0xFFF) << ADCIFE_CDMA_HT_Pos)
+#define ADCIFE_CDMA_HT_Msk          (_U_(0xFFF) << ADCIFE_CDMA_HT_Pos)
 #define ADCIFE_CDMA_HT(value)       (ADCIFE_CDMA_HT_Msk & ((value) << ADCIFE_CDMA_HT_Pos))
 #define ADCIFE_CDMA_MUXNEG_Pos      20           /**< \brief (ADCIFE_CDMA) MUX selection on Negative ADC input channel */
-#define ADCIFE_CDMA_MUXNEG_Msk      (_U(0x7) << ADCIFE_CDMA_MUXNEG_Pos)
+#define ADCIFE_CDMA_MUXNEG_Msk      (_U_(0x7) << ADCIFE_CDMA_MUXNEG_Pos)
 #define ADCIFE_CDMA_MUXNEG(value)   (ADCIFE_CDMA_MUXNEG_Msk & ((value) << ADCIFE_CDMA_MUXNEG_Pos))
 #define ADCIFE_CDMA_ZOOMRANGE_Pos   28           /**< \brief (ADCIFE_CDMA) Zoom shift/unipolar reference source selection */
-#define ADCIFE_CDMA_ZOOMRANGE_Msk   (_U(0x7) << ADCIFE_CDMA_ZOOMRANGE_Pos)
+#define ADCIFE_CDMA_ZOOMRANGE_Msk   (_U_(0x7) << ADCIFE_CDMA_ZOOMRANGE_Pos)
 #define ADCIFE_CDMA_ZOOMRANGE(value) (ADCIFE_CDMA_ZOOMRANGE_Msk & ((value) << ADCIFE_CDMA_ZOOMRANGE_Pos))
 #define ADCIFE_CDMA_DW_Pos          31           /**< \brief (ADCIFE_CDMA) Double Word transmitting */
-#define ADCIFE_CDMA_DW              (_U(0x1) << ADCIFE_CDMA_DW_Pos)
-#define ADCIFE_CDMA_MASK            _U(0xFFFFFFFF) /**< \brief (ADCIFE_CDMA) MASK Register */
+#define ADCIFE_CDMA_DW              (_U_(0x1) << ADCIFE_CDMA_DW_Pos)
+#define ADCIFE_CDMA_MASK            _U_(0xFFFFFFFF) /**< \brief (ADCIFE_CDMA) MASK Register */
 
 /* -------- ADCIFE_TIM : (ADCIFE Offset: 0x1C) (R/W 32) Timing Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -407,14 +407,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADCIFE_TIM_OFFSET           0x1C         /**< \brief (ADCIFE_TIM offset) Timing Configuration Register */
-#define ADCIFE_TIM_RESETVALUE       _U(0x00000000); /**< \brief (ADCIFE_TIM reset_value) Timing Configuration Register */
+#define ADCIFE_TIM_RESETVALUE       _U_(0x00000000); /**< \brief (ADCIFE_TIM reset_value) Timing Configuration Register */
 
 #define ADCIFE_TIM_STARTUP_Pos      0            /**< \brief (ADCIFE_TIM) Startup time */
-#define ADCIFE_TIM_STARTUP_Msk      (_U(0x1F) << ADCIFE_TIM_STARTUP_Pos)
+#define ADCIFE_TIM_STARTUP_Msk      (_U_(0x1F) << ADCIFE_TIM_STARTUP_Pos)
 #define ADCIFE_TIM_STARTUP(value)   (ADCIFE_TIM_STARTUP_Msk & ((value) << ADCIFE_TIM_STARTUP_Pos))
 #define ADCIFE_TIM_ENSTUP_Pos       8            /**< \brief (ADCIFE_TIM) Enable Startup */
-#define ADCIFE_TIM_ENSTUP           (_U(0x1) << ADCIFE_TIM_ENSTUP_Pos)
-#define ADCIFE_TIM_MASK             _U(0x0000011F) /**< \brief (ADCIFE_TIM) MASK Register */
+#define ADCIFE_TIM_ENSTUP           (_U_(0x1) << ADCIFE_TIM_ENSTUP_Pos)
+#define ADCIFE_TIM_MASK             _U_(0x0000011F) /**< \brief (ADCIFE_TIM) MASK Register */
 
 /* -------- ADCIFE_ITIMER : (ADCIFE Offset: 0x20) (R/W 32) Internal Timer Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -428,12 +428,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADCIFE_ITIMER_OFFSET        0x20         /**< \brief (ADCIFE_ITIMER offset) Internal Timer Register */
-#define ADCIFE_ITIMER_RESETVALUE    _U(0x00000000); /**< \brief (ADCIFE_ITIMER reset_value) Internal Timer Register */
+#define ADCIFE_ITIMER_RESETVALUE    _U_(0x00000000); /**< \brief (ADCIFE_ITIMER reset_value) Internal Timer Register */
 
 #define ADCIFE_ITIMER_ITMC_Pos      0            /**< \brief (ADCIFE_ITIMER) Internal timer max counter */
-#define ADCIFE_ITIMER_ITMC_Msk      (_U(0xFFFF) << ADCIFE_ITIMER_ITMC_Pos)
+#define ADCIFE_ITIMER_ITMC_Msk      (_U_(0xFFFF) << ADCIFE_ITIMER_ITMC_Pos)
 #define ADCIFE_ITIMER_ITMC(value)   (ADCIFE_ITIMER_ITMC_Msk & ((value) << ADCIFE_ITIMER_ITMC_Pos))
-#define ADCIFE_ITIMER_MASK          _U(0x0000FFFF) /**< \brief (ADCIFE_ITIMER) MASK Register */
+#define ADCIFE_ITIMER_MASK          _U_(0x0000FFFF) /**< \brief (ADCIFE_ITIMER) MASK Register */
 
 /* -------- ADCIFE_WCFG : (ADCIFE Offset: 0x24) (R/W 32) Window Monitor Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -448,12 +448,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADCIFE_WCFG_OFFSET          0x24         /**< \brief (ADCIFE_WCFG offset) Window Monitor Configuration Register */
-#define ADCIFE_WCFG_RESETVALUE      _U(0x00000000); /**< \brief (ADCIFE_WCFG reset_value) Window Monitor Configuration Register */
+#define ADCIFE_WCFG_RESETVALUE      _U_(0x00000000); /**< \brief (ADCIFE_WCFG reset_value) Window Monitor Configuration Register */
 
 #define ADCIFE_WCFG_WM_Pos          12           /**< \brief (ADCIFE_WCFG) Window Monitor Mode */
-#define ADCIFE_WCFG_WM_Msk          (_U(0x7) << ADCIFE_WCFG_WM_Pos)
+#define ADCIFE_WCFG_WM_Msk          (_U_(0x7) << ADCIFE_WCFG_WM_Pos)
 #define ADCIFE_WCFG_WM(value)       (ADCIFE_WCFG_WM_Msk & ((value) << ADCIFE_WCFG_WM_Pos))
-#define ADCIFE_WCFG_MASK            _U(0x00007000) /**< \brief (ADCIFE_WCFG) MASK Register */
+#define ADCIFE_WCFG_MASK            _U_(0x00007000) /**< \brief (ADCIFE_WCFG) MASK Register */
 
 /* -------- ADCIFE_WTH : (ADCIFE Offset: 0x28) (R/W 32) Window Monitor Threshold Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -469,15 +469,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADCIFE_WTH_OFFSET           0x28         /**< \brief (ADCIFE_WTH offset) Window Monitor Threshold Configuration Register */
-#define ADCIFE_WTH_RESETVALUE       _U(0x00000000); /**< \brief (ADCIFE_WTH reset_value) Window Monitor Threshold Configuration Register */
+#define ADCIFE_WTH_RESETVALUE       _U_(0x00000000); /**< \brief (ADCIFE_WTH reset_value) Window Monitor Threshold Configuration Register */
 
 #define ADCIFE_WTH_LT_Pos           0            /**< \brief (ADCIFE_WTH) Low threshold */
-#define ADCIFE_WTH_LT_Msk           (_U(0xFFF) << ADCIFE_WTH_LT_Pos)
+#define ADCIFE_WTH_LT_Msk           (_U_(0xFFF) << ADCIFE_WTH_LT_Pos)
 #define ADCIFE_WTH_LT(value)        (ADCIFE_WTH_LT_Msk & ((value) << ADCIFE_WTH_LT_Pos))
 #define ADCIFE_WTH_HT_Pos           16           /**< \brief (ADCIFE_WTH) High Threshold */
-#define ADCIFE_WTH_HT_Msk           (_U(0xFFF) << ADCIFE_WTH_HT_Pos)
+#define ADCIFE_WTH_HT_Msk           (_U_(0xFFF) << ADCIFE_WTH_HT_Pos)
 #define ADCIFE_WTH_HT(value)        (ADCIFE_WTH_HT_Msk & ((value) << ADCIFE_WTH_HT_Pos))
-#define ADCIFE_WTH_MASK             _U(0x0FFF0FFF) /**< \brief (ADCIFE_WTH) MASK Register */
+#define ADCIFE_WTH_MASK             _U_(0x0FFF0FFF) /**< \brief (ADCIFE_WTH) MASK Register */
 
 /* -------- ADCIFE_LCV : (ADCIFE Offset: 0x2C) (R/  32) Sequencer Last Converted Value Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -493,18 +493,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADCIFE_LCV_OFFSET           0x2C         /**< \brief (ADCIFE_LCV offset) Sequencer Last Converted Value Register */
-#define ADCIFE_LCV_RESETVALUE       _U(0x00000000); /**< \brief (ADCIFE_LCV reset_value) Sequencer Last Converted Value Register */
+#define ADCIFE_LCV_RESETVALUE       _U_(0x00000000); /**< \brief (ADCIFE_LCV reset_value) Sequencer Last Converted Value Register */
 
 #define ADCIFE_LCV_LCV_Pos          0            /**< \brief (ADCIFE_LCV) Last converted value */
-#define ADCIFE_LCV_LCV_Msk          (_U(0xFFFF) << ADCIFE_LCV_LCV_Pos)
+#define ADCIFE_LCV_LCV_Msk          (_U_(0xFFFF) << ADCIFE_LCV_LCV_Pos)
 #define ADCIFE_LCV_LCV(value)       (ADCIFE_LCV_LCV_Msk & ((value) << ADCIFE_LCV_LCV_Pos))
 #define ADCIFE_LCV_LCPC_Pos         16           /**< \brief (ADCIFE_LCV) Last converted positive channel */
-#define ADCIFE_LCV_LCPC_Msk         (_U(0xF) << ADCIFE_LCV_LCPC_Pos)
+#define ADCIFE_LCV_LCPC_Msk         (_U_(0xF) << ADCIFE_LCV_LCPC_Pos)
 #define ADCIFE_LCV_LCPC(value)      (ADCIFE_LCV_LCPC_Msk & ((value) << ADCIFE_LCV_LCPC_Pos))
 #define ADCIFE_LCV_LCNC_Pos         20           /**< \brief (ADCIFE_LCV) Last converted negative channel */
-#define ADCIFE_LCV_LCNC_Msk         (_U(0x7) << ADCIFE_LCV_LCNC_Pos)
+#define ADCIFE_LCV_LCNC_Msk         (_U_(0x7) << ADCIFE_LCV_LCNC_Pos)
 #define ADCIFE_LCV_LCNC(value)      (ADCIFE_LCV_LCNC_Msk & ((value) << ADCIFE_LCV_LCNC_Pos))
-#define ADCIFE_LCV_MASK             _U(0x007FFFFF) /**< \brief (ADCIFE_LCV) MASK Register */
+#define ADCIFE_LCV_MASK             _U_(0x007FFFFF) /**< \brief (ADCIFE_LCV) MASK Register */
 
 /* -------- ADCIFE_IER : (ADCIFE Offset: 0x30) ( /W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -523,19 +523,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADCIFE_IER_OFFSET           0x30         /**< \brief (ADCIFE_IER offset) Interrupt Enable Register */
-#define ADCIFE_IER_RESETVALUE       _U(0x00000000); /**< \brief (ADCIFE_IER reset_value) Interrupt Enable Register */
+#define ADCIFE_IER_RESETVALUE       _U_(0x00000000); /**< \brief (ADCIFE_IER reset_value) Interrupt Enable Register */
 
 #define ADCIFE_IER_SEOC_Pos         0            /**< \brief (ADCIFE_IER) Sequencer end of conversion Interrupt Enable */
-#define ADCIFE_IER_SEOC             (_U(0x1) << ADCIFE_IER_SEOC_Pos)
+#define ADCIFE_IER_SEOC             (_U_(0x1) << ADCIFE_IER_SEOC_Pos)
 #define ADCIFE_IER_LOVR_Pos         1            /**< \brief (ADCIFE_IER) Sequencer last converted value overrun Interrupt Enable */
-#define ADCIFE_IER_LOVR             (_U(0x1) << ADCIFE_IER_LOVR_Pos)
+#define ADCIFE_IER_LOVR             (_U_(0x1) << ADCIFE_IER_LOVR_Pos)
 #define ADCIFE_IER_WM_Pos           2            /**< \brief (ADCIFE_IER) Window monitor Interrupt Enable */
-#define ADCIFE_IER_WM               (_U(0x1) << ADCIFE_IER_WM_Pos)
+#define ADCIFE_IER_WM               (_U_(0x1) << ADCIFE_IER_WM_Pos)
 #define ADCIFE_IER_SMTRG_Pos        3            /**< \brief (ADCIFE_IER) Sequencer missed trigger event Interrupt Enable */
-#define ADCIFE_IER_SMTRG            (_U(0x1) << ADCIFE_IER_SMTRG_Pos)
+#define ADCIFE_IER_SMTRG            (_U_(0x1) << ADCIFE_IER_SMTRG_Pos)
 #define ADCIFE_IER_TTO_Pos          5            /**< \brief (ADCIFE_IER) Timer time-out Interrupt Enable */
-#define ADCIFE_IER_TTO              (_U(0x1) << ADCIFE_IER_TTO_Pos)
-#define ADCIFE_IER_MASK             _U(0x0000002F) /**< \brief (ADCIFE_IER) MASK Register */
+#define ADCIFE_IER_TTO              (_U_(0x1) << ADCIFE_IER_TTO_Pos)
+#define ADCIFE_IER_MASK             _U_(0x0000002F) /**< \brief (ADCIFE_IER) MASK Register */
 
 /* -------- ADCIFE_IDR : (ADCIFE Offset: 0x34) ( /W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -554,19 +554,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADCIFE_IDR_OFFSET           0x34         /**< \brief (ADCIFE_IDR offset) Interrupt Disable Register */
-#define ADCIFE_IDR_RESETVALUE       _U(0x00000000); /**< \brief (ADCIFE_IDR reset_value) Interrupt Disable Register */
+#define ADCIFE_IDR_RESETVALUE       _U_(0x00000000); /**< \brief (ADCIFE_IDR reset_value) Interrupt Disable Register */
 
 #define ADCIFE_IDR_SEOC_Pos         0            /**< \brief (ADCIFE_IDR) Sequencer end of conversion Interrupt Disable */
-#define ADCIFE_IDR_SEOC             (_U(0x1) << ADCIFE_IDR_SEOC_Pos)
+#define ADCIFE_IDR_SEOC             (_U_(0x1) << ADCIFE_IDR_SEOC_Pos)
 #define ADCIFE_IDR_LOVR_Pos         1            /**< \brief (ADCIFE_IDR) Sequencer last converted value overrun Interrupt Disable */
-#define ADCIFE_IDR_LOVR             (_U(0x1) << ADCIFE_IDR_LOVR_Pos)
+#define ADCIFE_IDR_LOVR             (_U_(0x1) << ADCIFE_IDR_LOVR_Pos)
 #define ADCIFE_IDR_WM_Pos           2            /**< \brief (ADCIFE_IDR) Window monitor Interrupt Disable */
-#define ADCIFE_IDR_WM               (_U(0x1) << ADCIFE_IDR_WM_Pos)
+#define ADCIFE_IDR_WM               (_U_(0x1) << ADCIFE_IDR_WM_Pos)
 #define ADCIFE_IDR_SMTRG_Pos        3            /**< \brief (ADCIFE_IDR) Sequencer missed trigger event Interrupt Disable */
-#define ADCIFE_IDR_SMTRG            (_U(0x1) << ADCIFE_IDR_SMTRG_Pos)
+#define ADCIFE_IDR_SMTRG            (_U_(0x1) << ADCIFE_IDR_SMTRG_Pos)
 #define ADCIFE_IDR_TTO_Pos          5            /**< \brief (ADCIFE_IDR) Timer time-out Interrupt Disable */
-#define ADCIFE_IDR_TTO              (_U(0x1) << ADCIFE_IDR_TTO_Pos)
-#define ADCIFE_IDR_MASK             _U(0x0000002F) /**< \brief (ADCIFE_IDR) MASK Register */
+#define ADCIFE_IDR_TTO              (_U_(0x1) << ADCIFE_IDR_TTO_Pos)
+#define ADCIFE_IDR_MASK             _U_(0x0000002F) /**< \brief (ADCIFE_IDR) MASK Register */
 
 /* -------- ADCIFE_IMR : (ADCIFE Offset: 0x38) (R/  32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -585,19 +585,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADCIFE_IMR_OFFSET           0x38         /**< \brief (ADCIFE_IMR offset) Interrupt Mask Register */
-#define ADCIFE_IMR_RESETVALUE       _U(0x00000000); /**< \brief (ADCIFE_IMR reset_value) Interrupt Mask Register */
+#define ADCIFE_IMR_RESETVALUE       _U_(0x00000000); /**< \brief (ADCIFE_IMR reset_value) Interrupt Mask Register */
 
 #define ADCIFE_IMR_SEOC_Pos         0            /**< \brief (ADCIFE_IMR) Sequencer end of conversion Interrupt Mask */
-#define ADCIFE_IMR_SEOC             (_U(0x1) << ADCIFE_IMR_SEOC_Pos)
+#define ADCIFE_IMR_SEOC             (_U_(0x1) << ADCIFE_IMR_SEOC_Pos)
 #define ADCIFE_IMR_LOVR_Pos         1            /**< \brief (ADCIFE_IMR) Sequencer last converted value overrun Interrupt Mask */
-#define ADCIFE_IMR_LOVR             (_U(0x1) << ADCIFE_IMR_LOVR_Pos)
+#define ADCIFE_IMR_LOVR             (_U_(0x1) << ADCIFE_IMR_LOVR_Pos)
 #define ADCIFE_IMR_WM_Pos           2            /**< \brief (ADCIFE_IMR) Window monitor Interrupt Mask */
-#define ADCIFE_IMR_WM               (_U(0x1) << ADCIFE_IMR_WM_Pos)
+#define ADCIFE_IMR_WM               (_U_(0x1) << ADCIFE_IMR_WM_Pos)
 #define ADCIFE_IMR_SMTRG_Pos        3            /**< \brief (ADCIFE_IMR) Sequencer missed trigger event Interrupt Mask */
-#define ADCIFE_IMR_SMTRG            (_U(0x1) << ADCIFE_IMR_SMTRG_Pos)
+#define ADCIFE_IMR_SMTRG            (_U_(0x1) << ADCIFE_IMR_SMTRG_Pos)
 #define ADCIFE_IMR_TTO_Pos          5            /**< \brief (ADCIFE_IMR) Timer time-out Interrupt Mask */
-#define ADCIFE_IMR_TTO              (_U(0x1) << ADCIFE_IMR_TTO_Pos)
-#define ADCIFE_IMR_MASK             _U(0x0000002F) /**< \brief (ADCIFE_IMR) MASK Register */
+#define ADCIFE_IMR_TTO              (_U_(0x1) << ADCIFE_IMR_TTO_Pos)
+#define ADCIFE_IMR_MASK             _U_(0x0000002F) /**< \brief (ADCIFE_IMR) MASK Register */
 
 /* -------- ADCIFE_CALIB : (ADCIFE Offset: 0x3C) (R/W 32) Calibration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -615,19 +615,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADCIFE_CALIB_OFFSET         0x3C         /**< \brief (ADCIFE_CALIB offset) Calibration Register */
-#define ADCIFE_CALIB_RESETVALUE     _U(0x00000000); /**< \brief (ADCIFE_CALIB reset_value) Calibration Register */
+#define ADCIFE_CALIB_RESETVALUE     _U_(0x00000000); /**< \brief (ADCIFE_CALIB reset_value) Calibration Register */
 
 #define ADCIFE_CALIB_CALIB_Pos      0            /**< \brief (ADCIFE_CALIB) Calibration Value */
-#define ADCIFE_CALIB_CALIB_Msk      (_U(0xFF) << ADCIFE_CALIB_CALIB_Pos)
+#define ADCIFE_CALIB_CALIB_Msk      (_U_(0xFF) << ADCIFE_CALIB_CALIB_Pos)
 #define ADCIFE_CALIB_CALIB(value)   (ADCIFE_CALIB_CALIB_Msk & ((value) << ADCIFE_CALIB_CALIB_Pos))
 #define ADCIFE_CALIB_BIASSEL_Pos    8            /**< \brief (ADCIFE_CALIB) Select bias mode */
-#define ADCIFE_CALIB_BIASSEL        (_U(0x1) << ADCIFE_CALIB_BIASSEL_Pos)
+#define ADCIFE_CALIB_BIASSEL        (_U_(0x1) << ADCIFE_CALIB_BIASSEL_Pos)
 #define ADCIFE_CALIB_BIASCAL_Pos    12           /**< \brief (ADCIFE_CALIB) Bias Calibration */
-#define ADCIFE_CALIB_BIASCAL_Msk    (_U(0xF) << ADCIFE_CALIB_BIASCAL_Pos)
+#define ADCIFE_CALIB_BIASCAL_Msk    (_U_(0xF) << ADCIFE_CALIB_BIASCAL_Pos)
 #define ADCIFE_CALIB_BIASCAL(value) (ADCIFE_CALIB_BIASCAL_Msk & ((value) << ADCIFE_CALIB_BIASCAL_Pos))
 #define ADCIFE_CALIB_FCD_Pos        16           /**< \brief (ADCIFE_CALIB) Flash Calibration Done */
-#define ADCIFE_CALIB_FCD            (_U(0x1) << ADCIFE_CALIB_FCD_Pos)
-#define ADCIFE_CALIB_MASK           _U(0x0001F1FF) /**< \brief (ADCIFE_CALIB) MASK Register */
+#define ADCIFE_CALIB_FCD            (_U_(0x1) << ADCIFE_CALIB_FCD_Pos)
+#define ADCIFE_CALIB_MASK           _U_(0x0001F1FF) /**< \brief (ADCIFE_CALIB) MASK Register */
 
 /* -------- ADCIFE_VERSION : (ADCIFE Offset: 0x40) (R/  32) Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -643,15 +643,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ADCIFE_VERSION_OFFSET       0x40         /**< \brief (ADCIFE_VERSION offset) Version Register */
-#define ADCIFE_VERSION_RESETVALUE   _U(0x00000100); /**< \brief (ADCIFE_VERSION reset_value) Version Register */
+#define ADCIFE_VERSION_RESETVALUE   _U_(0x00000100); /**< \brief (ADCIFE_VERSION reset_value) Version Register */
 
 #define ADCIFE_VERSION_VERSION_Pos  0            /**< \brief (ADCIFE_VERSION) Version number */
-#define ADCIFE_VERSION_VERSION_Msk  (_U(0xFFF) << ADCIFE_VERSION_VERSION_Pos)
+#define ADCIFE_VERSION_VERSION_Msk  (_U_(0xFFF) << ADCIFE_VERSION_VERSION_Pos)
 #define ADCIFE_VERSION_VERSION(value) (ADCIFE_VERSION_VERSION_Msk & ((value) << ADCIFE_VERSION_VERSION_Pos))
 #define ADCIFE_VERSION_VARIANT_Pos  16           /**< \brief (ADCIFE_VERSION) Variant number */
-#define ADCIFE_VERSION_VARIANT_Msk  (_U(0xF) << ADCIFE_VERSION_VARIANT_Pos)
+#define ADCIFE_VERSION_VARIANT_Msk  (_U_(0xF) << ADCIFE_VERSION_VARIANT_Pos)
 #define ADCIFE_VERSION_VARIANT(value) (ADCIFE_VERSION_VARIANT_Msk & ((value) << ADCIFE_VERSION_VARIANT_Pos))
-#define ADCIFE_VERSION_MASK         _U(0x000F0FFF) /**< \brief (ADCIFE_VERSION) MASK Register */
+#define ADCIFE_VERSION_MASK         _U_(0x000F0FFF) /**< \brief (ADCIFE_VERSION) MASK Register */
 
 /* -------- ADCIFE_PARAMETER : (ADCIFE Offset: 0x44) (R/  32) Parameter Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -667,9 +667,9 @@ typedef union {
 #define ADCIFE_PARAMETER_OFFSET     0x44         /**< \brief (ADCIFE_PARAMETER offset) Parameter Register */
 
 #define ADCIFE_PARAMETER_N_Pos      0            /**< \brief (ADCIFE_PARAMETER) Number of channels */
-#define ADCIFE_PARAMETER_N_Msk      (_U(0xFF) << ADCIFE_PARAMETER_N_Pos)
+#define ADCIFE_PARAMETER_N_Msk      (_U_(0xFF) << ADCIFE_PARAMETER_N_Pos)
 #define ADCIFE_PARAMETER_N(value)   (ADCIFE_PARAMETER_N_Msk & ((value) << ADCIFE_PARAMETER_N_Pos))
-#define ADCIFE_PARAMETER_MASK       _U(0x000000FF) /**< \brief (ADCIFE_PARAMETER) MASK Register */
+#define ADCIFE_PARAMETER_MASK       _U_(0x000000FF) /**< \brief (ADCIFE_PARAMETER) MASK Register */
 
 /** \brief ADCIFE hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/adcife.h
+++ b/asf/sam/include/sam4l/component/adcife.h
@@ -1,0 +1,722 @@
+/**
+ * \file
+ *
+ * \brief Component description for ADCIFE
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_ADCIFE_COMPONENT_
+#define _SAM4L_ADCIFE_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR ADCIFE */
+/* ========================================================================== */
+/** \addtogroup SAM4L_ADCIFE ADC controller interface */
+/*@{*/
+
+#define ADCIFE_I7569
+#define REV_ADCIFE                  0x100
+
+/* -------- ADCIFE_CR : (ADCIFE Offset: 0x00) ( /W 32) Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software reset                     */
+    uint32_t TSTOP:1;          /*!< bit:      1  Internal timer stop bit            */
+    uint32_t TSTART:1;         /*!< bit:      2  Internal timer start bit           */
+    uint32_t STRIG:1;          /*!< bit:      3  Sequencer trigger                  */
+    uint32_t REFBUFEN:1;       /*!< bit:      4  Reference buffer enable            */
+    uint32_t REFBUFDIS:1;      /*!< bit:      5  Reference buffer disable           */
+    uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t EN:1;             /*!< bit:      8  ADCIFD enable                      */
+    uint32_t DIS:1;            /*!< bit:      9  ADCIFD disable                     */
+    uint32_t BGREQEN:1;        /*!< bit:     10  Bandgap buffer request enable      */
+    uint32_t BGREQDIS:1;       /*!< bit:     11  Bandgap buffer request disable     */
+    uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ADCIFE_CR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADCIFE_CR_OFFSET            0x00         /**< \brief (ADCIFE_CR offset) Control Register */
+#define ADCIFE_CR_RESETVALUE        _U(0x00000000); /**< \brief (ADCIFE_CR reset_value) Control Register */
+
+#define ADCIFE_CR_SWRST_Pos         0            /**< \brief (ADCIFE_CR) Software reset */
+#define ADCIFE_CR_SWRST             (_U(0x1) << ADCIFE_CR_SWRST_Pos)
+#define ADCIFE_CR_TSTOP_Pos         1            /**< \brief (ADCIFE_CR) Internal timer stop bit */
+#define ADCIFE_CR_TSTOP             (_U(0x1) << ADCIFE_CR_TSTOP_Pos)
+#define ADCIFE_CR_TSTART_Pos        2            /**< \brief (ADCIFE_CR) Internal timer start bit */
+#define ADCIFE_CR_TSTART            (_U(0x1) << ADCIFE_CR_TSTART_Pos)
+#define ADCIFE_CR_STRIG_Pos         3            /**< \brief (ADCIFE_CR) Sequencer trigger */
+#define ADCIFE_CR_STRIG             (_U(0x1) << ADCIFE_CR_STRIG_Pos)
+#define ADCIFE_CR_REFBUFEN_Pos      4            /**< \brief (ADCIFE_CR) Reference buffer enable */
+#define ADCIFE_CR_REFBUFEN          (_U(0x1) << ADCIFE_CR_REFBUFEN_Pos)
+#define ADCIFE_CR_REFBUFDIS_Pos     5            /**< \brief (ADCIFE_CR) Reference buffer disable */
+#define ADCIFE_CR_REFBUFDIS         (_U(0x1) << ADCIFE_CR_REFBUFDIS_Pos)
+#define ADCIFE_CR_EN_Pos            8            /**< \brief (ADCIFE_CR) ADCIFD enable */
+#define ADCIFE_CR_EN                (_U(0x1) << ADCIFE_CR_EN_Pos)
+#define ADCIFE_CR_DIS_Pos           9            /**< \brief (ADCIFE_CR) ADCIFD disable */
+#define ADCIFE_CR_DIS               (_U(0x1) << ADCIFE_CR_DIS_Pos)
+#define ADCIFE_CR_BGREQEN_Pos       10           /**< \brief (ADCIFE_CR) Bandgap buffer request enable */
+#define ADCIFE_CR_BGREQEN           (_U(0x1) << ADCIFE_CR_BGREQEN_Pos)
+#define ADCIFE_CR_BGREQDIS_Pos      11           /**< \brief (ADCIFE_CR) Bandgap buffer request disable */
+#define ADCIFE_CR_BGREQDIS          (_U(0x1) << ADCIFE_CR_BGREQDIS_Pos)
+#define ADCIFE_CR_MASK              _U(0x00000F3F) /**< \brief (ADCIFE_CR) MASK Register */
+
+/* -------- ADCIFE_CFG : (ADCIFE Offset: 0x04) (R/W 32) Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t REFSEL:3;         /*!< bit:  1.. 3  ADC Reference Selection            */
+    uint32_t SPEED:2;          /*!< bit:  4.. 5  ADC current reduction              */
+    uint32_t CLKSEL:1;         /*!< bit:      6  Clock Selection for sequencer/ADC cell */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t PRESCAL:3;        /*!< bit:  8..10  Prescaler Rate Selection           */
+    uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ADCIFE_CFG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADCIFE_CFG_OFFSET           0x04         /**< \brief (ADCIFE_CFG offset) Configuration Register */
+#define ADCIFE_CFG_RESETVALUE       _U(0x00000000); /**< \brief (ADCIFE_CFG reset_value) Configuration Register */
+
+#define ADCIFE_CFG_REFSEL_Pos       1            /**< \brief (ADCIFE_CFG) ADC Reference Selection */
+#define ADCIFE_CFG_REFSEL_Msk       (_U(0x7) << ADCIFE_CFG_REFSEL_Pos)
+#define ADCIFE_CFG_REFSEL(value)    (ADCIFE_CFG_REFSEL_Msk & ((value) << ADCIFE_CFG_REFSEL_Pos))
+#define ADCIFE_CFG_SPEED_Pos        4            /**< \brief (ADCIFE_CFG) ADC current reduction */
+#define ADCIFE_CFG_SPEED_Msk        (_U(0x3) << ADCIFE_CFG_SPEED_Pos)
+#define ADCIFE_CFG_SPEED(value)     (ADCIFE_CFG_SPEED_Msk & ((value) << ADCIFE_CFG_SPEED_Pos))
+#define ADCIFE_CFG_CLKSEL_Pos       6            /**< \brief (ADCIFE_CFG) Clock Selection for sequencer/ADC cell */
+#define ADCIFE_CFG_CLKSEL           (_U(0x1) << ADCIFE_CFG_CLKSEL_Pos)
+#define ADCIFE_CFG_PRESCAL_Pos      8            /**< \brief (ADCIFE_CFG) Prescaler Rate Selection */
+#define ADCIFE_CFG_PRESCAL_Msk      (_U(0x7) << ADCIFE_CFG_PRESCAL_Pos)
+#define ADCIFE_CFG_PRESCAL(value)   (ADCIFE_CFG_PRESCAL_Msk & ((value) << ADCIFE_CFG_PRESCAL_Pos))
+#define ADCIFE_CFG_MASK             _U(0x0000077E) /**< \brief (ADCIFE_CFG) MASK Register */
+
+/* -------- ADCIFE_SR : (ADCIFE Offset: 0x08) (R/  32) Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SEOC:1;           /*!< bit:      0  Sequencer end of conversion        */
+    uint32_t LOVR:1;           /*!< bit:      1  Sequencer last converted value overrun */
+    uint32_t WM:1;             /*!< bit:      2  Window monitor                     */
+    uint32_t SMTRG:1;          /*!< bit:      3  Sequencer missed trigger event     */
+    uint32_t SUTD:1;           /*!< bit:      4  Start-up time done                 */
+    uint32_t TTO:1;            /*!< bit:      5  Timer time-out                     */
+    uint32_t :18;              /*!< bit:  6..23  Reserved                           */
+    uint32_t EN:1;             /*!< bit:     24  Enable Status                      */
+    uint32_t TBUSY:1;          /*!< bit:     25  Timer busy                         */
+    uint32_t SBUSY:1;          /*!< bit:     26  Sequencer busy                     */
+    uint32_t CBUSY:1;          /*!< bit:     27  Conversion busy                    */
+    uint32_t REFBUF:1;         /*!< bit:     28  Reference buffer status            */
+    uint32_t :3;               /*!< bit: 29..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ADCIFE_SR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADCIFE_SR_OFFSET            0x08         /**< \brief (ADCIFE_SR offset) Status Register */
+#define ADCIFE_SR_RESETVALUE        _U(0x00000000); /**< \brief (ADCIFE_SR reset_value) Status Register */
+
+#define ADCIFE_SR_SEOC_Pos          0            /**< \brief (ADCIFE_SR) Sequencer end of conversion */
+#define ADCIFE_SR_SEOC              (_U(0x1) << ADCIFE_SR_SEOC_Pos)
+#define ADCIFE_SR_LOVR_Pos          1            /**< \brief (ADCIFE_SR) Sequencer last converted value overrun */
+#define ADCIFE_SR_LOVR              (_U(0x1) << ADCIFE_SR_LOVR_Pos)
+#define ADCIFE_SR_WM_Pos            2            /**< \brief (ADCIFE_SR) Window monitor */
+#define ADCIFE_SR_WM                (_U(0x1) << ADCIFE_SR_WM_Pos)
+#define ADCIFE_SR_SMTRG_Pos         3            /**< \brief (ADCIFE_SR) Sequencer missed trigger event */
+#define ADCIFE_SR_SMTRG             (_U(0x1) << ADCIFE_SR_SMTRG_Pos)
+#define ADCIFE_SR_SUTD_Pos          4            /**< \brief (ADCIFE_SR) Start-up time done */
+#define ADCIFE_SR_SUTD              (_U(0x1) << ADCIFE_SR_SUTD_Pos)
+#define ADCIFE_SR_TTO_Pos           5            /**< \brief (ADCIFE_SR) Timer time-out */
+#define ADCIFE_SR_TTO               (_U(0x1) << ADCIFE_SR_TTO_Pos)
+#define ADCIFE_SR_EN_Pos            24           /**< \brief (ADCIFE_SR) Enable Status */
+#define ADCIFE_SR_EN                (_U(0x1) << ADCIFE_SR_EN_Pos)
+#define ADCIFE_SR_TBUSY_Pos         25           /**< \brief (ADCIFE_SR) Timer busy */
+#define ADCIFE_SR_TBUSY             (_U(0x1) << ADCIFE_SR_TBUSY_Pos)
+#define ADCIFE_SR_SBUSY_Pos         26           /**< \brief (ADCIFE_SR) Sequencer busy */
+#define ADCIFE_SR_SBUSY             (_U(0x1) << ADCIFE_SR_SBUSY_Pos)
+#define ADCIFE_SR_CBUSY_Pos         27           /**< \brief (ADCIFE_SR) Conversion busy */
+#define ADCIFE_SR_CBUSY             (_U(0x1) << ADCIFE_SR_CBUSY_Pos)
+#define ADCIFE_SR_REFBUF_Pos        28           /**< \brief (ADCIFE_SR) Reference buffer status */
+#define ADCIFE_SR_REFBUF            (_U(0x1) << ADCIFE_SR_REFBUF_Pos)
+#define ADCIFE_SR_MASK              _U(0x1F00003F) /**< \brief (ADCIFE_SR) MASK Register */
+
+/* -------- ADCIFE_SCR : (ADCIFE Offset: 0x0C) ( /W 32) Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SEOC:1;           /*!< bit:      0  Sequencer end of conversion        */
+    uint32_t LOVR:1;           /*!< bit:      1  Sequencer last converted value overrun */
+    uint32_t WM:1;             /*!< bit:      2  Window monitor                     */
+    uint32_t SMTRG:1;          /*!< bit:      3  Sequencer missed trigger event     */
+    uint32_t SUTD:1;           /*!< bit:      4  Start-up time done                 */
+    uint32_t TTO:1;            /*!< bit:      5  Timer time-out                     */
+    uint32_t :26;              /*!< bit:  6..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ADCIFE_SCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADCIFE_SCR_OFFSET           0x0C         /**< \brief (ADCIFE_SCR offset) Status Clear Register */
+#define ADCIFE_SCR_RESETVALUE       _U(0x00000000); /**< \brief (ADCIFE_SCR reset_value) Status Clear Register */
+
+#define ADCIFE_SCR_SEOC_Pos         0            /**< \brief (ADCIFE_SCR) Sequencer end of conversion */
+#define ADCIFE_SCR_SEOC             (_U(0x1) << ADCIFE_SCR_SEOC_Pos)
+#define ADCIFE_SCR_LOVR_Pos         1            /**< \brief (ADCIFE_SCR) Sequencer last converted value overrun */
+#define ADCIFE_SCR_LOVR             (_U(0x1) << ADCIFE_SCR_LOVR_Pos)
+#define ADCIFE_SCR_WM_Pos           2            /**< \brief (ADCIFE_SCR) Window monitor */
+#define ADCIFE_SCR_WM               (_U(0x1) << ADCIFE_SCR_WM_Pos)
+#define ADCIFE_SCR_SMTRG_Pos        3            /**< \brief (ADCIFE_SCR) Sequencer missed trigger event */
+#define ADCIFE_SCR_SMTRG            (_U(0x1) << ADCIFE_SCR_SMTRG_Pos)
+#define ADCIFE_SCR_SUTD_Pos         4            /**< \brief (ADCIFE_SCR) Start-up time done */
+#define ADCIFE_SCR_SUTD             (_U(0x1) << ADCIFE_SCR_SUTD_Pos)
+#define ADCIFE_SCR_TTO_Pos          5            /**< \brief (ADCIFE_SCR) Timer time-out */
+#define ADCIFE_SCR_TTO              (_U(0x1) << ADCIFE_SCR_TTO_Pos)
+#define ADCIFE_SCR_MASK             _U(0x0000003F) /**< \brief (ADCIFE_SCR) MASK Register */
+
+/* -------- ADCIFE_RTS : (ADCIFE Offset: 0x10) (R/W 32) Resistive Touch Screen Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} ADCIFE_RTS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADCIFE_RTS_OFFSET           0x10         /**< \brief (ADCIFE_RTS offset) Resistive Touch Screen Register */
+#define ADCIFE_RTS_RESETVALUE       _U(0x00000000); /**< \brief (ADCIFE_RTS reset_value) Resistive Touch Screen Register */
+
+#define ADCIFE_RTS_MASK             _U(0x00000000) /**< \brief (ADCIFE_RTS) MASK Register */
+
+/* -------- ADCIFE_SEQCFG : (ADCIFE Offset: 0x14) (R/W 32) Sequencer Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t HWLA:1;           /*!< bit:      0  Half word left adjust              */
+    uint32_t :1;               /*!< bit:      1  Reserved                           */
+    uint32_t BIPOLAR:1;        /*!< bit:      2  Bipolar Mode                       */
+    uint32_t :1;               /*!< bit:      3  Reserved                           */
+    uint32_t GAIN:3;           /*!< bit:  4.. 6  Gain factor                        */
+    uint32_t GCOMP:1;          /*!< bit:      7  Gain Compensation                  */
+    uint32_t TRGSEL:3;         /*!< bit:  8..10  Trigger selection                  */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t RES:1;            /*!< bit:     12  Resolution                         */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t INTERNAL:2;       /*!< bit: 14..15  Internal Voltage Source Selection  */
+    uint32_t MUXPOS:4;         /*!< bit: 16..19  MUX selection on Positive ADC input channel */
+    uint32_t MUXNEG:3;         /*!< bit: 20..22  MUX selection on Negative ADC input channel */
+    uint32_t :5;               /*!< bit: 23..27  Reserved                           */
+    uint32_t ZOOMRANGE:3;      /*!< bit: 28..30  Zoom shift/unipolar reference source selection */
+    uint32_t :1;               /*!< bit:     31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ADCIFE_SEQCFG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADCIFE_SEQCFG_OFFSET        0x14         /**< \brief (ADCIFE_SEQCFG offset) Sequencer Configuration Register */
+#define ADCIFE_SEQCFG_RESETVALUE    _U(0x00000000); /**< \brief (ADCIFE_SEQCFG reset_value) Sequencer Configuration Register */
+
+#define ADCIFE_SEQCFG_HWLA_Pos      0            /**< \brief (ADCIFE_SEQCFG) Half word left adjust */
+#define ADCIFE_SEQCFG_HWLA          (_U(0x1) << ADCIFE_SEQCFG_HWLA_Pos)
+#define ADCIFE_SEQCFG_BIPOLAR_Pos   2            /**< \brief (ADCIFE_SEQCFG) Bipolar Mode */
+#define ADCIFE_SEQCFG_BIPOLAR       (_U(0x1) << ADCIFE_SEQCFG_BIPOLAR_Pos)
+#define ADCIFE_SEQCFG_GAIN_Pos      4            /**< \brief (ADCIFE_SEQCFG) Gain factor */
+#define ADCIFE_SEQCFG_GAIN_Msk      (_U(0x7) << ADCIFE_SEQCFG_GAIN_Pos)
+#define ADCIFE_SEQCFG_GAIN(value)   (ADCIFE_SEQCFG_GAIN_Msk & ((value) << ADCIFE_SEQCFG_GAIN_Pos))
+#define ADCIFE_SEQCFG_GCOMP_Pos     7            /**< \brief (ADCIFE_SEQCFG) Gain Compensation */
+#define ADCIFE_SEQCFG_GCOMP         (_U(0x1) << ADCIFE_SEQCFG_GCOMP_Pos)
+#define ADCIFE_SEQCFG_TRGSEL_Pos    8            /**< \brief (ADCIFE_SEQCFG) Trigger selection */
+#define ADCIFE_SEQCFG_TRGSEL_Msk    (_U(0x7) << ADCIFE_SEQCFG_TRGSEL_Pos)
+#define ADCIFE_SEQCFG_TRGSEL(value) (ADCIFE_SEQCFG_TRGSEL_Msk & ((value) << ADCIFE_SEQCFG_TRGSEL_Pos))
+#define ADCIFE_SEQCFG_RES_Pos       12           /**< \brief (ADCIFE_SEQCFG) Resolution */
+#define ADCIFE_SEQCFG_RES           (_U(0x1) << ADCIFE_SEQCFG_RES_Pos)
+#define ADCIFE_SEQCFG_INTERNAL_Pos  14           /**< \brief (ADCIFE_SEQCFG) Internal Voltage Source Selection */
+#define ADCIFE_SEQCFG_INTERNAL_Msk  (_U(0x3) << ADCIFE_SEQCFG_INTERNAL_Pos)
+#define ADCIFE_SEQCFG_INTERNAL(value) (ADCIFE_SEQCFG_INTERNAL_Msk & ((value) << ADCIFE_SEQCFG_INTERNAL_Pos))
+#define ADCIFE_SEQCFG_MUXPOS_Pos    16           /**< \brief (ADCIFE_SEQCFG) MUX selection on Positive ADC input channel */
+#define ADCIFE_SEQCFG_MUXPOS_Msk    (_U(0xF) << ADCIFE_SEQCFG_MUXPOS_Pos)
+#define ADCIFE_SEQCFG_MUXPOS(value) (ADCIFE_SEQCFG_MUXPOS_Msk & ((value) << ADCIFE_SEQCFG_MUXPOS_Pos))
+#define ADCIFE_SEQCFG_MUXNEG_Pos    20           /**< \brief (ADCIFE_SEQCFG) MUX selection on Negative ADC input channel */
+#define ADCIFE_SEQCFG_MUXNEG_Msk    (_U(0x7) << ADCIFE_SEQCFG_MUXNEG_Pos)
+#define ADCIFE_SEQCFG_MUXNEG(value) (ADCIFE_SEQCFG_MUXNEG_Msk & ((value) << ADCIFE_SEQCFG_MUXNEG_Pos))
+#define ADCIFE_SEQCFG_ZOOMRANGE_Pos 28           /**< \brief (ADCIFE_SEQCFG) Zoom shift/unipolar reference source selection */
+#define ADCIFE_SEQCFG_ZOOMRANGE_Msk (_U(0x7) << ADCIFE_SEQCFG_ZOOMRANGE_Pos)
+#define ADCIFE_SEQCFG_ZOOMRANGE(value) (ADCIFE_SEQCFG_ZOOMRANGE_Msk & ((value) << ADCIFE_SEQCFG_ZOOMRANGE_Pos))
+#define ADCIFE_SEQCFG_MASK          _U(0x707FD7F5) /**< \brief (ADCIFE_SEQCFG) MASK Register */
+
+/* -------- ADCIFE_CDMA : (ADCIFE Offset: 0x18) ( /W 32) Configuration Direct Memory Access Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct { // FIRST_DMA_WORD mode
+    uint32_t HWLA:1;           /*!< bit:      0  Half word left adjust              */
+    uint32_t :1;               /*!< bit:      1  Reserved                           */
+    uint32_t BIPOLAR:1;        /*!< bit:      2  Bipolar Mode                       */
+    uint32_t STRIG:1;          /*!< bit:      3  Sequencer Trigger Event            */
+    uint32_t GAIN:3;           /*!< bit:  4.. 6  Gain factor                        */
+    uint32_t GCOMP:1;          /*!< bit:      7  Gain Compensation                  */
+    uint32_t ENSTUP:1;         /*!< bit:      8  Enable Start-Up Time               */
+    uint32_t :3;               /*!< bit:  9..11  Reserved                           */
+    uint32_t RES:1;            /*!< bit:     12  Resolution                         */
+    uint32_t TSS:1;            /*!< bit:     13  Internal timer start or stop bit   */
+    uint32_t INTERNAL:2;       /*!< bit: 14..15  Internal Voltage Source Selection  */
+    uint32_t MUXPOS:4;         /*!< bit: 16..19  MUX selection on Positive ADC input channel */
+    uint32_t MUXNEG:3;         /*!< bit: 20..22  MUX selection on Negative ADC input channel */
+    uint32_t :5;               /*!< bit: 23..27  Reserved                           */
+    uint32_t ZOOMRANGE:3;      /*!< bit: 28..30  Zoom shift/unipolar reference source selection */
+    uint32_t DW:1;             /*!< bit:     31  Double Word transmitting           */
+  } FIRST_DMA_WORD;            /*!< Structure used for FIRST_DMA_WORD               */
+  struct { // SECOND_DMA_WORD mode
+    uint32_t LT:12;            /*!< bit:  0..11  Low Threshold                      */
+    uint32_t WM:3;             /*!< bit: 12..14  Window Monitor Mode                */
+    uint32_t :1;               /*!< bit:     15  Reserved                           */
+    uint32_t HT:12;            /*!< bit: 16..27  High Threshold                     */
+    uint32_t :3;               /*!< bit: 28..30  Reserved                           */
+    uint32_t DW:1;             /*!< bit:     31  Double Word transmitting           */
+  } SECOND_DMA_WORD;           /*!< Structure used for SECOND_DMA_WORD              */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ADCIFE_CDMA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADCIFE_CDMA_OFFSET          0x18         /**< \brief (ADCIFE_CDMA offset) Configuration Direct Memory Access Register */
+#define ADCIFE_CDMA_RESETVALUE      _U(0x00000000); /**< \brief (ADCIFE_CDMA reset_value) Configuration Direct Memory Access Register */
+
+// FIRST_DMA_WORD mode
+#define ADCIFE_CDMA_FIRST_DMA_WORD_HWLA_Pos 0            /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) Half word left adjust */
+#define ADCIFE_CDMA_FIRST_DMA_WORD_HWLA (_U(0x1) << ADCIFE_CDMA_FIRST_DMA_WORD_HWLA_Pos)
+#define ADCIFE_CDMA_FIRST_DMA_WORD_BIPOLAR_Pos 2            /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) Bipolar Mode */
+#define ADCIFE_CDMA_FIRST_DMA_WORD_BIPOLAR (_U(0x1) << ADCIFE_CDMA_FIRST_DMA_WORD_BIPOLAR_Pos)
+#define ADCIFE_CDMA_FIRST_DMA_WORD_STRIG_Pos 3            /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) Sequencer Trigger Event */
+#define ADCIFE_CDMA_FIRST_DMA_WORD_STRIG (_U(0x1) << ADCIFE_CDMA_FIRST_DMA_WORD_STRIG_Pos)
+#define ADCIFE_CDMA_FIRST_DMA_WORD_GAIN_Pos 4            /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) Gain factor */
+#define ADCIFE_CDMA_FIRST_DMA_WORD_GAIN_Msk (_U(0x7) << ADCIFE_CDMA_FIRST_DMA_WORD_GAIN_Pos)
+#define ADCIFE_CDMA_FIRST_DMA_WORD_GAIN(value) (ADCIFE_CDMA_FIRST_DMA_WORD_GAIN_Msk & ((value) << ADCIFE_CDMA_FIRST_DMA_WORD_GAIN_Pos))
+#define ADCIFE_CDMA_FIRST_DMA_WORD_GCOMP_Pos 7            /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) Gain Compensation */
+#define ADCIFE_CDMA_FIRST_DMA_WORD_GCOMP (_U(0x1) << ADCIFE_CDMA_FIRST_DMA_WORD_GCOMP_Pos)
+#define ADCIFE_CDMA_FIRST_DMA_WORD_ENSTUP_Pos 8            /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) Enable Start-Up Time */
+#define ADCIFE_CDMA_FIRST_DMA_WORD_ENSTUP (_U(0x1) << ADCIFE_CDMA_FIRST_DMA_WORD_ENSTUP_Pos)
+#define ADCIFE_CDMA_FIRST_DMA_WORD_RES_Pos 12           /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) Resolution */
+#define ADCIFE_CDMA_FIRST_DMA_WORD_RES (_U(0x1) << ADCIFE_CDMA_FIRST_DMA_WORD_RES_Pos)
+#define ADCIFE_CDMA_FIRST_DMA_WORD_TSS_Pos 13           /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) Internal timer start or stop bit */
+#define ADCIFE_CDMA_FIRST_DMA_WORD_TSS (_U(0x1) << ADCIFE_CDMA_FIRST_DMA_WORD_TSS_Pos)
+#define ADCIFE_CDMA_FIRST_DMA_WORD_INTERNAL_Pos 14           /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) Internal Voltage Source Selection */
+#define ADCIFE_CDMA_FIRST_DMA_WORD_INTERNAL_Msk (_U(0x3) << ADCIFE_CDMA_FIRST_DMA_WORD_INTERNAL_Pos)
+#define ADCIFE_CDMA_FIRST_DMA_WORD_INTERNAL(value) (ADCIFE_CDMA_FIRST_DMA_WORD_INTERNAL_Msk & ((value) << ADCIFE_CDMA_FIRST_DMA_WORD_INTERNAL_Pos))
+#define ADCIFE_CDMA_FIRST_DMA_WORD_MUXPOS_Pos 16           /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) MUX selection on Positive ADC input channel */
+#define ADCIFE_CDMA_FIRST_DMA_WORD_MUXPOS_Msk (_U(0xF) << ADCIFE_CDMA_FIRST_DMA_WORD_MUXPOS_Pos)
+#define ADCIFE_CDMA_FIRST_DMA_WORD_MUXPOS(value) (ADCIFE_CDMA_FIRST_DMA_WORD_MUXPOS_Msk & ((value) << ADCIFE_CDMA_FIRST_DMA_WORD_MUXPOS_Pos))
+#define ADCIFE_CDMA_FIRST_DMA_WORD_MUXNEG_Pos 20           /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) MUX selection on Negative ADC input channel */
+#define ADCIFE_CDMA_FIRST_DMA_WORD_MUXNEG_Msk (_U(0x7) << ADCIFE_CDMA_FIRST_DMA_WORD_MUXNEG_Pos)
+#define ADCIFE_CDMA_FIRST_DMA_WORD_MUXNEG(value) (ADCIFE_CDMA_FIRST_DMA_WORD_MUXNEG_Msk & ((value) << ADCIFE_CDMA_FIRST_DMA_WORD_MUXNEG_Pos))
+#define ADCIFE_CDMA_FIRST_DMA_WORD_ZOOMRANGE_Pos 28           /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) Zoom shift/unipolar reference source selection */
+#define ADCIFE_CDMA_FIRST_DMA_WORD_ZOOMRANGE_Msk (_U(0x7) << ADCIFE_CDMA_FIRST_DMA_WORD_ZOOMRANGE_Pos)
+#define ADCIFE_CDMA_FIRST_DMA_WORD_ZOOMRANGE(value) (ADCIFE_CDMA_FIRST_DMA_WORD_ZOOMRANGE_Msk & ((value) << ADCIFE_CDMA_FIRST_DMA_WORD_ZOOMRANGE_Pos))
+#define ADCIFE_CDMA_FIRST_DMA_WORD_DW_Pos 31           /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) Double Word transmitting */
+#define ADCIFE_CDMA_FIRST_DMA_WORD_DW (_U(0x1) << ADCIFE_CDMA_FIRST_DMA_WORD_DW_Pos)
+#define ADCIFE_CDMA_FIRST_DMA_WORD_MASK _U(0xF07FF1FD) /**< \brief (ADCIFE_CDMA_FIRST_DMA_WORD) MASK Register */
+
+// SECOND_DMA_WORD mode
+#define ADCIFE_CDMA_SECOND_DMA_WORD_LT_Pos 0            /**< \brief (ADCIFE_CDMA_SECOND_DMA_WORD) Low Threshold */
+#define ADCIFE_CDMA_SECOND_DMA_WORD_LT_Msk (_U(0xFFF) << ADCIFE_CDMA_SECOND_DMA_WORD_LT_Pos)
+#define ADCIFE_CDMA_SECOND_DMA_WORD_LT(value) (ADCIFE_CDMA_SECOND_DMA_WORD_LT_Msk & ((value) << ADCIFE_CDMA_SECOND_DMA_WORD_LT_Pos))
+#define ADCIFE_CDMA_SECOND_DMA_WORD_WM_Pos 12           /**< \brief (ADCIFE_CDMA_SECOND_DMA_WORD) Window Monitor Mode */
+#define ADCIFE_CDMA_SECOND_DMA_WORD_WM_Msk (_U(0x7) << ADCIFE_CDMA_SECOND_DMA_WORD_WM_Pos)
+#define ADCIFE_CDMA_SECOND_DMA_WORD_WM(value) (ADCIFE_CDMA_SECOND_DMA_WORD_WM_Msk & ((value) << ADCIFE_CDMA_SECOND_DMA_WORD_WM_Pos))
+#define ADCIFE_CDMA_SECOND_DMA_WORD_HT_Pos 16           /**< \brief (ADCIFE_CDMA_SECOND_DMA_WORD) High Threshold */
+#define ADCIFE_CDMA_SECOND_DMA_WORD_HT_Msk (_U(0xFFF) << ADCIFE_CDMA_SECOND_DMA_WORD_HT_Pos)
+#define ADCIFE_CDMA_SECOND_DMA_WORD_HT(value) (ADCIFE_CDMA_SECOND_DMA_WORD_HT_Msk & ((value) << ADCIFE_CDMA_SECOND_DMA_WORD_HT_Pos))
+#define ADCIFE_CDMA_SECOND_DMA_WORD_DW_Pos 31           /**< \brief (ADCIFE_CDMA_SECOND_DMA_WORD) Double Word transmitting */
+#define ADCIFE_CDMA_SECOND_DMA_WORD_DW (_U(0x1) << ADCIFE_CDMA_SECOND_DMA_WORD_DW_Pos)
+#define ADCIFE_CDMA_SECOND_DMA_WORD_MASK _U(0x8FFF7FFF) /**< \brief (ADCIFE_CDMA_SECOND_DMA_WORD) MASK Register */
+
+// Any mode
+#define ADCIFE_CDMA_HWLA_Pos        0            /**< \brief (ADCIFE_CDMA) Half word left adjust */
+#define ADCIFE_CDMA_HWLA            (_U(0x1) << ADCIFE_CDMA_HWLA_Pos)
+#define ADCIFE_CDMA_LT_Pos          0            /**< \brief (ADCIFE_CDMA) Low Threshold */
+#define ADCIFE_CDMA_LT_Msk          (_U(0xFFF) << ADCIFE_CDMA_LT_Pos)
+#define ADCIFE_CDMA_LT(value)       (ADCIFE_CDMA_LT_Msk & ((value) << ADCIFE_CDMA_LT_Pos))
+#define ADCIFE_CDMA_BIPOLAR_Pos     2            /**< \brief (ADCIFE_CDMA) Bipolar Mode */
+#define ADCIFE_CDMA_BIPOLAR         (_U(0x1) << ADCIFE_CDMA_BIPOLAR_Pos)
+#define ADCIFE_CDMA_STRIG_Pos       3            /**< \brief (ADCIFE_CDMA) Sequencer Trigger Event */
+#define ADCIFE_CDMA_STRIG           (_U(0x1) << ADCIFE_CDMA_STRIG_Pos)
+#define ADCIFE_CDMA_GAIN_Pos        4            /**< \brief (ADCIFE_CDMA) Gain factor */
+#define ADCIFE_CDMA_GAIN_Msk        (_U(0x7) << ADCIFE_CDMA_GAIN_Pos)
+#define ADCIFE_CDMA_GAIN(value)     (ADCIFE_CDMA_GAIN_Msk & ((value) << ADCIFE_CDMA_GAIN_Pos))
+#define ADCIFE_CDMA_GCOMP_Pos       7            /**< \brief (ADCIFE_CDMA) Gain Compensation */
+#define ADCIFE_CDMA_GCOMP           (_U(0x1) << ADCIFE_CDMA_GCOMP_Pos)
+#define ADCIFE_CDMA_ENSTUP_Pos      8            /**< \brief (ADCIFE_CDMA) Enable Start-Up Time */
+#define ADCIFE_CDMA_ENSTUP          (_U(0x1) << ADCIFE_CDMA_ENSTUP_Pos)
+#define ADCIFE_CDMA_RES_Pos         12           /**< \brief (ADCIFE_CDMA) Resolution */
+#define ADCIFE_CDMA_RES             (_U(0x1) << ADCIFE_CDMA_RES_Pos)
+#define ADCIFE_CDMA_WM_Pos          12           /**< \brief (ADCIFE_CDMA) Window Monitor Mode */
+#define ADCIFE_CDMA_WM_Msk          (_U(0x7) << ADCIFE_CDMA_WM_Pos)
+#define ADCIFE_CDMA_WM(value)       (ADCIFE_CDMA_WM_Msk & ((value) << ADCIFE_CDMA_WM_Pos))
+#define ADCIFE_CDMA_TSS_Pos         13           /**< \brief (ADCIFE_CDMA) Internal timer start or stop bit */
+#define ADCIFE_CDMA_TSS             (_U(0x1) << ADCIFE_CDMA_TSS_Pos)
+#define ADCIFE_CDMA_INTERNAL_Pos    14           /**< \brief (ADCIFE_CDMA) Internal Voltage Source Selection */
+#define ADCIFE_CDMA_INTERNAL_Msk    (_U(0x3) << ADCIFE_CDMA_INTERNAL_Pos)
+#define ADCIFE_CDMA_INTERNAL(value) (ADCIFE_CDMA_INTERNAL_Msk & ((value) << ADCIFE_CDMA_INTERNAL_Pos))
+#define ADCIFE_CDMA_MUXPOS_Pos      16           /**< \brief (ADCIFE_CDMA) MUX selection on Positive ADC input channel */
+#define ADCIFE_CDMA_MUXPOS_Msk      (_U(0xF) << ADCIFE_CDMA_MUXPOS_Pos)
+#define ADCIFE_CDMA_MUXPOS(value)   (ADCIFE_CDMA_MUXPOS_Msk & ((value) << ADCIFE_CDMA_MUXPOS_Pos))
+#define ADCIFE_CDMA_HT_Pos          16           /**< \brief (ADCIFE_CDMA) High Threshold */
+#define ADCIFE_CDMA_HT_Msk          (_U(0xFFF) << ADCIFE_CDMA_HT_Pos)
+#define ADCIFE_CDMA_HT(value)       (ADCIFE_CDMA_HT_Msk & ((value) << ADCIFE_CDMA_HT_Pos))
+#define ADCIFE_CDMA_MUXNEG_Pos      20           /**< \brief (ADCIFE_CDMA) MUX selection on Negative ADC input channel */
+#define ADCIFE_CDMA_MUXNEG_Msk      (_U(0x7) << ADCIFE_CDMA_MUXNEG_Pos)
+#define ADCIFE_CDMA_MUXNEG(value)   (ADCIFE_CDMA_MUXNEG_Msk & ((value) << ADCIFE_CDMA_MUXNEG_Pos))
+#define ADCIFE_CDMA_ZOOMRANGE_Pos   28           /**< \brief (ADCIFE_CDMA) Zoom shift/unipolar reference source selection */
+#define ADCIFE_CDMA_ZOOMRANGE_Msk   (_U(0x7) << ADCIFE_CDMA_ZOOMRANGE_Pos)
+#define ADCIFE_CDMA_ZOOMRANGE(value) (ADCIFE_CDMA_ZOOMRANGE_Msk & ((value) << ADCIFE_CDMA_ZOOMRANGE_Pos))
+#define ADCIFE_CDMA_DW_Pos          31           /**< \brief (ADCIFE_CDMA) Double Word transmitting */
+#define ADCIFE_CDMA_DW              (_U(0x1) << ADCIFE_CDMA_DW_Pos)
+#define ADCIFE_CDMA_MASK            _U(0xFFFFFFFF) /**< \brief (ADCIFE_CDMA) MASK Register */
+
+/* -------- ADCIFE_TIM : (ADCIFE Offset: 0x1C) (R/W 32) Timing Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t STARTUP:5;        /*!< bit:  0.. 4  Startup time                       */
+    uint32_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint32_t ENSTUP:1;         /*!< bit:      8  Enable Startup                     */
+    uint32_t :23;              /*!< bit:  9..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ADCIFE_TIM_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADCIFE_TIM_OFFSET           0x1C         /**< \brief (ADCIFE_TIM offset) Timing Configuration Register */
+#define ADCIFE_TIM_RESETVALUE       _U(0x00000000); /**< \brief (ADCIFE_TIM reset_value) Timing Configuration Register */
+
+#define ADCIFE_TIM_STARTUP_Pos      0            /**< \brief (ADCIFE_TIM) Startup time */
+#define ADCIFE_TIM_STARTUP_Msk      (_U(0x1F) << ADCIFE_TIM_STARTUP_Pos)
+#define ADCIFE_TIM_STARTUP(value)   (ADCIFE_TIM_STARTUP_Msk & ((value) << ADCIFE_TIM_STARTUP_Pos))
+#define ADCIFE_TIM_ENSTUP_Pos       8            /**< \brief (ADCIFE_TIM) Enable Startup */
+#define ADCIFE_TIM_ENSTUP           (_U(0x1) << ADCIFE_TIM_ENSTUP_Pos)
+#define ADCIFE_TIM_MASK             _U(0x0000011F) /**< \brief (ADCIFE_TIM) MASK Register */
+
+/* -------- ADCIFE_ITIMER : (ADCIFE Offset: 0x20) (R/W 32) Internal Timer Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ITMC:16;          /*!< bit:  0..15  Internal timer max counter         */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ADCIFE_ITIMER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADCIFE_ITIMER_OFFSET        0x20         /**< \brief (ADCIFE_ITIMER offset) Internal Timer Register */
+#define ADCIFE_ITIMER_RESETVALUE    _U(0x00000000); /**< \brief (ADCIFE_ITIMER reset_value) Internal Timer Register */
+
+#define ADCIFE_ITIMER_ITMC_Pos      0            /**< \brief (ADCIFE_ITIMER) Internal timer max counter */
+#define ADCIFE_ITIMER_ITMC_Msk      (_U(0xFFFF) << ADCIFE_ITIMER_ITMC_Pos)
+#define ADCIFE_ITIMER_ITMC(value)   (ADCIFE_ITIMER_ITMC_Msk & ((value) << ADCIFE_ITIMER_ITMC_Pos))
+#define ADCIFE_ITIMER_MASK          _U(0x0000FFFF) /**< \brief (ADCIFE_ITIMER) MASK Register */
+
+/* -------- ADCIFE_WCFG : (ADCIFE Offset: 0x24) (R/W 32) Window Monitor Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :12;              /*!< bit:  0..11  Reserved                           */
+    uint32_t WM:3;             /*!< bit: 12..14  Window Monitor Mode                */
+    uint32_t :17;              /*!< bit: 15..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ADCIFE_WCFG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADCIFE_WCFG_OFFSET          0x24         /**< \brief (ADCIFE_WCFG offset) Window Monitor Configuration Register */
+#define ADCIFE_WCFG_RESETVALUE      _U(0x00000000); /**< \brief (ADCIFE_WCFG reset_value) Window Monitor Configuration Register */
+
+#define ADCIFE_WCFG_WM_Pos          12           /**< \brief (ADCIFE_WCFG) Window Monitor Mode */
+#define ADCIFE_WCFG_WM_Msk          (_U(0x7) << ADCIFE_WCFG_WM_Pos)
+#define ADCIFE_WCFG_WM(value)       (ADCIFE_WCFG_WM_Msk & ((value) << ADCIFE_WCFG_WM_Pos))
+#define ADCIFE_WCFG_MASK            _U(0x00007000) /**< \brief (ADCIFE_WCFG) MASK Register */
+
+/* -------- ADCIFE_WTH : (ADCIFE Offset: 0x28) (R/W 32) Window Monitor Threshold Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t LT:12;            /*!< bit:  0..11  Low threshold                      */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t HT:12;            /*!< bit: 16..27  High Threshold                     */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ADCIFE_WTH_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADCIFE_WTH_OFFSET           0x28         /**< \brief (ADCIFE_WTH offset) Window Monitor Threshold Configuration Register */
+#define ADCIFE_WTH_RESETVALUE       _U(0x00000000); /**< \brief (ADCIFE_WTH reset_value) Window Monitor Threshold Configuration Register */
+
+#define ADCIFE_WTH_LT_Pos           0            /**< \brief (ADCIFE_WTH) Low threshold */
+#define ADCIFE_WTH_LT_Msk           (_U(0xFFF) << ADCIFE_WTH_LT_Pos)
+#define ADCIFE_WTH_LT(value)        (ADCIFE_WTH_LT_Msk & ((value) << ADCIFE_WTH_LT_Pos))
+#define ADCIFE_WTH_HT_Pos           16           /**< \brief (ADCIFE_WTH) High Threshold */
+#define ADCIFE_WTH_HT_Msk           (_U(0xFFF) << ADCIFE_WTH_HT_Pos)
+#define ADCIFE_WTH_HT(value)        (ADCIFE_WTH_HT_Msk & ((value) << ADCIFE_WTH_HT_Pos))
+#define ADCIFE_WTH_MASK             _U(0x0FFF0FFF) /**< \brief (ADCIFE_WTH) MASK Register */
+
+/* -------- ADCIFE_LCV : (ADCIFE Offset: 0x2C) (R/  32) Sequencer Last Converted Value Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t LCV:16;           /*!< bit:  0..15  Last converted value               */
+    uint32_t LCPC:4;           /*!< bit: 16..19  Last converted positive channel    */
+    uint32_t LCNC:3;           /*!< bit: 20..22  Last converted negative channel    */
+    uint32_t :9;               /*!< bit: 23..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ADCIFE_LCV_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADCIFE_LCV_OFFSET           0x2C         /**< \brief (ADCIFE_LCV offset) Sequencer Last Converted Value Register */
+#define ADCIFE_LCV_RESETVALUE       _U(0x00000000); /**< \brief (ADCIFE_LCV reset_value) Sequencer Last Converted Value Register */
+
+#define ADCIFE_LCV_LCV_Pos          0            /**< \brief (ADCIFE_LCV) Last converted value */
+#define ADCIFE_LCV_LCV_Msk          (_U(0xFFFF) << ADCIFE_LCV_LCV_Pos)
+#define ADCIFE_LCV_LCV(value)       (ADCIFE_LCV_LCV_Msk & ((value) << ADCIFE_LCV_LCV_Pos))
+#define ADCIFE_LCV_LCPC_Pos         16           /**< \brief (ADCIFE_LCV) Last converted positive channel */
+#define ADCIFE_LCV_LCPC_Msk         (_U(0xF) << ADCIFE_LCV_LCPC_Pos)
+#define ADCIFE_LCV_LCPC(value)      (ADCIFE_LCV_LCPC_Msk & ((value) << ADCIFE_LCV_LCPC_Pos))
+#define ADCIFE_LCV_LCNC_Pos         20           /**< \brief (ADCIFE_LCV) Last converted negative channel */
+#define ADCIFE_LCV_LCNC_Msk         (_U(0x7) << ADCIFE_LCV_LCNC_Pos)
+#define ADCIFE_LCV_LCNC(value)      (ADCIFE_LCV_LCNC_Msk & ((value) << ADCIFE_LCV_LCNC_Pos))
+#define ADCIFE_LCV_MASK             _U(0x007FFFFF) /**< \brief (ADCIFE_LCV) MASK Register */
+
+/* -------- ADCIFE_IER : (ADCIFE Offset: 0x30) ( /W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SEOC:1;           /*!< bit:      0  Sequencer end of conversion Interrupt Enable */
+    uint32_t LOVR:1;           /*!< bit:      1  Sequencer last converted value overrun Interrupt Enable */
+    uint32_t WM:1;             /*!< bit:      2  Window monitor Interrupt Enable    */
+    uint32_t SMTRG:1;          /*!< bit:      3  Sequencer missed trigger event Interrupt Enable */
+    uint32_t :1;               /*!< bit:      4  Reserved                           */
+    uint32_t TTO:1;            /*!< bit:      5  Timer time-out Interrupt Enable    */
+    uint32_t :26;              /*!< bit:  6..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ADCIFE_IER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADCIFE_IER_OFFSET           0x30         /**< \brief (ADCIFE_IER offset) Interrupt Enable Register */
+#define ADCIFE_IER_RESETVALUE       _U(0x00000000); /**< \brief (ADCIFE_IER reset_value) Interrupt Enable Register */
+
+#define ADCIFE_IER_SEOC_Pos         0            /**< \brief (ADCIFE_IER) Sequencer end of conversion Interrupt Enable */
+#define ADCIFE_IER_SEOC             (_U(0x1) << ADCIFE_IER_SEOC_Pos)
+#define ADCIFE_IER_LOVR_Pos         1            /**< \brief (ADCIFE_IER) Sequencer last converted value overrun Interrupt Enable */
+#define ADCIFE_IER_LOVR             (_U(0x1) << ADCIFE_IER_LOVR_Pos)
+#define ADCIFE_IER_WM_Pos           2            /**< \brief (ADCIFE_IER) Window monitor Interrupt Enable */
+#define ADCIFE_IER_WM               (_U(0x1) << ADCIFE_IER_WM_Pos)
+#define ADCIFE_IER_SMTRG_Pos        3            /**< \brief (ADCIFE_IER) Sequencer missed trigger event Interrupt Enable */
+#define ADCIFE_IER_SMTRG            (_U(0x1) << ADCIFE_IER_SMTRG_Pos)
+#define ADCIFE_IER_TTO_Pos          5            /**< \brief (ADCIFE_IER) Timer time-out Interrupt Enable */
+#define ADCIFE_IER_TTO              (_U(0x1) << ADCIFE_IER_TTO_Pos)
+#define ADCIFE_IER_MASK             _U(0x0000002F) /**< \brief (ADCIFE_IER) MASK Register */
+
+/* -------- ADCIFE_IDR : (ADCIFE Offset: 0x34) ( /W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SEOC:1;           /*!< bit:      0  Sequencer end of conversion Interrupt Disable */
+    uint32_t LOVR:1;           /*!< bit:      1  Sequencer last converted value overrun Interrupt Disable */
+    uint32_t WM:1;             /*!< bit:      2  Window monitor Interrupt Disable   */
+    uint32_t SMTRG:1;          /*!< bit:      3  Sequencer missed trigger event Interrupt Disable */
+    uint32_t :1;               /*!< bit:      4  Reserved                           */
+    uint32_t TTO:1;            /*!< bit:      5  Timer time-out Interrupt Disable   */
+    uint32_t :26;              /*!< bit:  6..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ADCIFE_IDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADCIFE_IDR_OFFSET           0x34         /**< \brief (ADCIFE_IDR offset) Interrupt Disable Register */
+#define ADCIFE_IDR_RESETVALUE       _U(0x00000000); /**< \brief (ADCIFE_IDR reset_value) Interrupt Disable Register */
+
+#define ADCIFE_IDR_SEOC_Pos         0            /**< \brief (ADCIFE_IDR) Sequencer end of conversion Interrupt Disable */
+#define ADCIFE_IDR_SEOC             (_U(0x1) << ADCIFE_IDR_SEOC_Pos)
+#define ADCIFE_IDR_LOVR_Pos         1            /**< \brief (ADCIFE_IDR) Sequencer last converted value overrun Interrupt Disable */
+#define ADCIFE_IDR_LOVR             (_U(0x1) << ADCIFE_IDR_LOVR_Pos)
+#define ADCIFE_IDR_WM_Pos           2            /**< \brief (ADCIFE_IDR) Window monitor Interrupt Disable */
+#define ADCIFE_IDR_WM               (_U(0x1) << ADCIFE_IDR_WM_Pos)
+#define ADCIFE_IDR_SMTRG_Pos        3            /**< \brief (ADCIFE_IDR) Sequencer missed trigger event Interrupt Disable */
+#define ADCIFE_IDR_SMTRG            (_U(0x1) << ADCIFE_IDR_SMTRG_Pos)
+#define ADCIFE_IDR_TTO_Pos          5            /**< \brief (ADCIFE_IDR) Timer time-out Interrupt Disable */
+#define ADCIFE_IDR_TTO              (_U(0x1) << ADCIFE_IDR_TTO_Pos)
+#define ADCIFE_IDR_MASK             _U(0x0000002F) /**< \brief (ADCIFE_IDR) MASK Register */
+
+/* -------- ADCIFE_IMR : (ADCIFE Offset: 0x38) (R/  32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SEOC:1;           /*!< bit:      0  Sequencer end of conversion Interrupt Mask */
+    uint32_t LOVR:1;           /*!< bit:      1  Sequencer last converted value overrun Interrupt Mask */
+    uint32_t WM:1;             /*!< bit:      2  Window monitor Interrupt Mask      */
+    uint32_t SMTRG:1;          /*!< bit:      3  Sequencer missed trigger event Interrupt Mask */
+    uint32_t :1;               /*!< bit:      4  Reserved                           */
+    uint32_t TTO:1;            /*!< bit:      5  Timer time-out Interrupt Mask      */
+    uint32_t :26;              /*!< bit:  6..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ADCIFE_IMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADCIFE_IMR_OFFSET           0x38         /**< \brief (ADCIFE_IMR offset) Interrupt Mask Register */
+#define ADCIFE_IMR_RESETVALUE       _U(0x00000000); /**< \brief (ADCIFE_IMR reset_value) Interrupt Mask Register */
+
+#define ADCIFE_IMR_SEOC_Pos         0            /**< \brief (ADCIFE_IMR) Sequencer end of conversion Interrupt Mask */
+#define ADCIFE_IMR_SEOC             (_U(0x1) << ADCIFE_IMR_SEOC_Pos)
+#define ADCIFE_IMR_LOVR_Pos         1            /**< \brief (ADCIFE_IMR) Sequencer last converted value overrun Interrupt Mask */
+#define ADCIFE_IMR_LOVR             (_U(0x1) << ADCIFE_IMR_LOVR_Pos)
+#define ADCIFE_IMR_WM_Pos           2            /**< \brief (ADCIFE_IMR) Window monitor Interrupt Mask */
+#define ADCIFE_IMR_WM               (_U(0x1) << ADCIFE_IMR_WM_Pos)
+#define ADCIFE_IMR_SMTRG_Pos        3            /**< \brief (ADCIFE_IMR) Sequencer missed trigger event Interrupt Mask */
+#define ADCIFE_IMR_SMTRG            (_U(0x1) << ADCIFE_IMR_SMTRG_Pos)
+#define ADCIFE_IMR_TTO_Pos          5            /**< \brief (ADCIFE_IMR) Timer time-out Interrupt Mask */
+#define ADCIFE_IMR_TTO              (_U(0x1) << ADCIFE_IMR_TTO_Pos)
+#define ADCIFE_IMR_MASK             _U(0x0000002F) /**< \brief (ADCIFE_IMR) MASK Register */
+
+/* -------- ADCIFE_CALIB : (ADCIFE Offset: 0x3C) (R/W 32) Calibration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CALIB:8;          /*!< bit:  0.. 7  Calibration Value                  */
+    uint32_t BIASSEL:1;        /*!< bit:      8  Select bias mode                   */
+    uint32_t :3;               /*!< bit:  9..11  Reserved                           */
+    uint32_t BIASCAL:4;        /*!< bit: 12..15  Bias Calibration                   */
+    uint32_t FCD:1;            /*!< bit:     16  Flash Calibration Done             */
+    uint32_t :15;              /*!< bit: 17..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ADCIFE_CALIB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADCIFE_CALIB_OFFSET         0x3C         /**< \brief (ADCIFE_CALIB offset) Calibration Register */
+#define ADCIFE_CALIB_RESETVALUE     _U(0x00000000); /**< \brief (ADCIFE_CALIB reset_value) Calibration Register */
+
+#define ADCIFE_CALIB_CALIB_Pos      0            /**< \brief (ADCIFE_CALIB) Calibration Value */
+#define ADCIFE_CALIB_CALIB_Msk      (_U(0xFF) << ADCIFE_CALIB_CALIB_Pos)
+#define ADCIFE_CALIB_CALIB(value)   (ADCIFE_CALIB_CALIB_Msk & ((value) << ADCIFE_CALIB_CALIB_Pos))
+#define ADCIFE_CALIB_BIASSEL_Pos    8            /**< \brief (ADCIFE_CALIB) Select bias mode */
+#define ADCIFE_CALIB_BIASSEL        (_U(0x1) << ADCIFE_CALIB_BIASSEL_Pos)
+#define ADCIFE_CALIB_BIASCAL_Pos    12           /**< \brief (ADCIFE_CALIB) Bias Calibration */
+#define ADCIFE_CALIB_BIASCAL_Msk    (_U(0xF) << ADCIFE_CALIB_BIASCAL_Pos)
+#define ADCIFE_CALIB_BIASCAL(value) (ADCIFE_CALIB_BIASCAL_Msk & ((value) << ADCIFE_CALIB_BIASCAL_Pos))
+#define ADCIFE_CALIB_FCD_Pos        16           /**< \brief (ADCIFE_CALIB) Flash Calibration Done */
+#define ADCIFE_CALIB_FCD            (_U(0x1) << ADCIFE_CALIB_FCD_Pos)
+#define ADCIFE_CALIB_MASK           _U(0x0001F1FF) /**< \brief (ADCIFE_CALIB) MASK Register */
+
+/* -------- ADCIFE_VERSION : (ADCIFE Offset: 0x40) (R/  32) Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ADCIFE_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADCIFE_VERSION_OFFSET       0x40         /**< \brief (ADCIFE_VERSION offset) Version Register */
+#define ADCIFE_VERSION_RESETVALUE   _U(0x00000100); /**< \brief (ADCIFE_VERSION reset_value) Version Register */
+
+#define ADCIFE_VERSION_VERSION_Pos  0            /**< \brief (ADCIFE_VERSION) Version number */
+#define ADCIFE_VERSION_VERSION_Msk  (_U(0xFFF) << ADCIFE_VERSION_VERSION_Pos)
+#define ADCIFE_VERSION_VERSION(value) (ADCIFE_VERSION_VERSION_Msk & ((value) << ADCIFE_VERSION_VERSION_Pos))
+#define ADCIFE_VERSION_VARIANT_Pos  16           /**< \brief (ADCIFE_VERSION) Variant number */
+#define ADCIFE_VERSION_VARIANT_Msk  (_U(0xF) << ADCIFE_VERSION_VARIANT_Pos)
+#define ADCIFE_VERSION_VARIANT(value) (ADCIFE_VERSION_VARIANT_Msk & ((value) << ADCIFE_VERSION_VARIANT_Pos))
+#define ADCIFE_VERSION_MASK         _U(0x000F0FFF) /**< \brief (ADCIFE_VERSION) MASK Register */
+
+/* -------- ADCIFE_PARAMETER : (ADCIFE Offset: 0x44) (R/  32) Parameter Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t N:8;              /*!< bit:  0.. 7  Number of channels                 */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ADCIFE_PARAMETER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADCIFE_PARAMETER_OFFSET     0x44         /**< \brief (ADCIFE_PARAMETER offset) Parameter Register */
+
+#define ADCIFE_PARAMETER_N_Pos      0            /**< \brief (ADCIFE_PARAMETER) Number of channels */
+#define ADCIFE_PARAMETER_N_Msk      (_U(0xFF) << ADCIFE_PARAMETER_N_Pos)
+#define ADCIFE_PARAMETER_N(value)   (ADCIFE_PARAMETER_N_Msk & ((value) << ADCIFE_PARAMETER_N_Pos))
+#define ADCIFE_PARAMETER_MASK       _U(0x000000FF) /**< \brief (ADCIFE_PARAMETER) MASK Register */
+
+/** \brief ADCIFE hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __O  ADCIFE_CR_Type            CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
+  __IO ADCIFE_CFG_Type           CFG;         /**< \brief Offset: 0x04 (R/W 32) Configuration Register */
+  __I  ADCIFE_SR_Type            SR;          /**< \brief Offset: 0x08 (R/  32) Status Register */
+  __O  ADCIFE_SCR_Type           SCR;         /**< \brief Offset: 0x0C ( /W 32) Status Clear Register */
+  __IO ADCIFE_RTS_Type           RTS;         /**< \brief Offset: 0x10 (R/W 32) Resistive Touch Screen Register */
+  __IO ADCIFE_SEQCFG_Type        SEQCFG;      /**< \brief Offset: 0x14 (R/W 32) Sequencer Configuration Register */
+  __O  ADCIFE_CDMA_Type          CDMA;        /**< \brief Offset: 0x18 ( /W 32) Configuration Direct Memory Access Register */
+  __IO ADCIFE_TIM_Type           TIM;         /**< \brief Offset: 0x1C (R/W 32) Timing Configuration Register */
+  __IO ADCIFE_ITIMER_Type        ITIMER;      /**< \brief Offset: 0x20 (R/W 32) Internal Timer Register */
+  __IO ADCIFE_WCFG_Type          WCFG;        /**< \brief Offset: 0x24 (R/W 32) Window Monitor Configuration Register */
+  __IO ADCIFE_WTH_Type           WTH;         /**< \brief Offset: 0x28 (R/W 32) Window Monitor Threshold Configuration Register */
+  __I  ADCIFE_LCV_Type           LCV;         /**< \brief Offset: 0x2C (R/  32) Sequencer Last Converted Value Register */
+  __O  ADCIFE_IER_Type           IER;         /**< \brief Offset: 0x30 ( /W 32) Interrupt Enable Register */
+  __O  ADCIFE_IDR_Type           IDR;         /**< \brief Offset: 0x34 ( /W 32) Interrupt Disable Register */
+  __I  ADCIFE_IMR_Type           IMR;         /**< \brief Offset: 0x38 (R/  32) Interrupt Mask Register */
+  __IO ADCIFE_CALIB_Type         CALIB;       /**< \brief Offset: 0x3C (R/W 32) Calibration Register */
+  __I  ADCIFE_VERSION_Type       VERSION;     /**< \brief Offset: 0x40 (R/  32) Version Register */
+  __I  ADCIFE_PARAMETER_Type     PARAMETER;   /**< \brief Offset: 0x44 (R/  32) Parameter Register */
+ } bf;
+ struct {
+  WoReg   ADCIFE_CR;          /**< \brief (ADCIFE Offset: 0x00) Control Register */
+  RwReg   ADCIFE_CFG;         /**< \brief (ADCIFE Offset: 0x04) Configuration Register */
+  RoReg   ADCIFE_SR;          /**< \brief (ADCIFE Offset: 0x08) Status Register */
+  WoReg   ADCIFE_SCR;         /**< \brief (ADCIFE Offset: 0x0C) Status Clear Register */
+  RwReg   ADCIFE_RTS;         /**< \brief (ADCIFE Offset: 0x10) Resistive Touch Screen Register */
+  RwReg   ADCIFE_SEQCFG;      /**< \brief (ADCIFE Offset: 0x14) Sequencer Configuration Register */
+  WoReg   ADCIFE_CDMA;        /**< \brief (ADCIFE Offset: 0x18) Configuration Direct Memory Access Register */
+  RwReg   ADCIFE_TIM;         /**< \brief (ADCIFE Offset: 0x1C) Timing Configuration Register */
+  RwReg   ADCIFE_ITIMER;      /**< \brief (ADCIFE Offset: 0x20) Internal Timer Register */
+  RwReg   ADCIFE_WCFG;        /**< \brief (ADCIFE Offset: 0x24) Window Monitor Configuration Register */
+  RwReg   ADCIFE_WTH;         /**< \brief (ADCIFE Offset: 0x28) Window Monitor Threshold Configuration Register */
+  RoReg   ADCIFE_LCV;         /**< \brief (ADCIFE Offset: 0x2C) Sequencer Last Converted Value Register */
+  WoReg   ADCIFE_IER;         /**< \brief (ADCIFE Offset: 0x30) Interrupt Enable Register */
+  WoReg   ADCIFE_IDR;         /**< \brief (ADCIFE Offset: 0x34) Interrupt Disable Register */
+  RoReg   ADCIFE_IMR;         /**< \brief (ADCIFE Offset: 0x38) Interrupt Mask Register */
+  RwReg   ADCIFE_CALIB;       /**< \brief (ADCIFE Offset: 0x3C) Calibration Register */
+  RoReg   ADCIFE_VERSION;     /**< \brief (ADCIFE Offset: 0x40) Version Register */
+  RoReg   ADCIFE_PARAMETER;   /**< \brief (ADCIFE Offset: 0x44) Parameter Register */
+ } reg;
+} Adcife;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_ADCIFE_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/adcife.h
+++ b/asf/sam/include/sam4l/component/adcife.h
@@ -673,47 +673,25 @@ typedef union {
 
 /** \brief ADCIFE hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __O  ADCIFE_CR_Type            CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
-  __IO ADCIFE_CFG_Type           CFG;         /**< \brief Offset: 0x04 (R/W 32) Configuration Register */
-  __I  ADCIFE_SR_Type            SR;          /**< \brief Offset: 0x08 (R/  32) Status Register */
-  __O  ADCIFE_SCR_Type           SCR;         /**< \brief Offset: 0x0C ( /W 32) Status Clear Register */
-  __IO ADCIFE_RTS_Type           RTS;         /**< \brief Offset: 0x10 (R/W 32) Resistive Touch Screen Register */
-  __IO ADCIFE_SEQCFG_Type        SEQCFG;      /**< \brief Offset: 0x14 (R/W 32) Sequencer Configuration Register */
-  __O  ADCIFE_CDMA_Type          CDMA;        /**< \brief Offset: 0x18 ( /W 32) Configuration Direct Memory Access Register */
-  __IO ADCIFE_TIM_Type           TIM;         /**< \brief Offset: 0x1C (R/W 32) Timing Configuration Register */
-  __IO ADCIFE_ITIMER_Type        ITIMER;      /**< \brief Offset: 0x20 (R/W 32) Internal Timer Register */
-  __IO ADCIFE_WCFG_Type          WCFG;        /**< \brief Offset: 0x24 (R/W 32) Window Monitor Configuration Register */
-  __IO ADCIFE_WTH_Type           WTH;         /**< \brief Offset: 0x28 (R/W 32) Window Monitor Threshold Configuration Register */
-  __I  ADCIFE_LCV_Type           LCV;         /**< \brief Offset: 0x2C (R/  32) Sequencer Last Converted Value Register */
-  __O  ADCIFE_IER_Type           IER;         /**< \brief Offset: 0x30 ( /W 32) Interrupt Enable Register */
-  __O  ADCIFE_IDR_Type           IDR;         /**< \brief Offset: 0x34 ( /W 32) Interrupt Disable Register */
-  __I  ADCIFE_IMR_Type           IMR;         /**< \brief Offset: 0x38 (R/  32) Interrupt Mask Register */
-  __IO ADCIFE_CALIB_Type         CALIB;       /**< \brief Offset: 0x3C (R/W 32) Calibration Register */
-  __I  ADCIFE_VERSION_Type       VERSION;     /**< \brief Offset: 0x40 (R/  32) Version Register */
-  __I  ADCIFE_PARAMETER_Type     PARAMETER;   /**< \brief Offset: 0x44 (R/  32) Parameter Register */
- } bf;
- struct {
-  WoReg   ADCIFE_CR;          /**< \brief (ADCIFE Offset: 0x00) Control Register */
-  RwReg   ADCIFE_CFG;         /**< \brief (ADCIFE Offset: 0x04) Configuration Register */
-  RoReg   ADCIFE_SR;          /**< \brief (ADCIFE Offset: 0x08) Status Register */
-  WoReg   ADCIFE_SCR;         /**< \brief (ADCIFE Offset: 0x0C) Status Clear Register */
-  RwReg   ADCIFE_RTS;         /**< \brief (ADCIFE Offset: 0x10) Resistive Touch Screen Register */
-  RwReg   ADCIFE_SEQCFG;      /**< \brief (ADCIFE Offset: 0x14) Sequencer Configuration Register */
-  WoReg   ADCIFE_CDMA;        /**< \brief (ADCIFE Offset: 0x18) Configuration Direct Memory Access Register */
-  RwReg   ADCIFE_TIM;         /**< \brief (ADCIFE Offset: 0x1C) Timing Configuration Register */
-  RwReg   ADCIFE_ITIMER;      /**< \brief (ADCIFE Offset: 0x20) Internal Timer Register */
-  RwReg   ADCIFE_WCFG;        /**< \brief (ADCIFE Offset: 0x24) Window Monitor Configuration Register */
-  RwReg   ADCIFE_WTH;         /**< \brief (ADCIFE Offset: 0x28) Window Monitor Threshold Configuration Register */
-  RoReg   ADCIFE_LCV;         /**< \brief (ADCIFE Offset: 0x2C) Sequencer Last Converted Value Register */
-  WoReg   ADCIFE_IER;         /**< \brief (ADCIFE Offset: 0x30) Interrupt Enable Register */
-  WoReg   ADCIFE_IDR;         /**< \brief (ADCIFE Offset: 0x34) Interrupt Disable Register */
-  RoReg   ADCIFE_IMR;         /**< \brief (ADCIFE Offset: 0x38) Interrupt Mask Register */
-  RwReg   ADCIFE_CALIB;       /**< \brief (ADCIFE Offset: 0x3C) Calibration Register */
-  RoReg   ADCIFE_VERSION;     /**< \brief (ADCIFE Offset: 0x40) Version Register */
-  RoReg   ADCIFE_PARAMETER;   /**< \brief (ADCIFE Offset: 0x44) Parameter Register */
- } reg;
+typedef struct {
+  __O  uint32_t CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
+  __IO uint32_t CFG;         /**< \brief Offset: 0x04 (R/W 32) Configuration Register */
+  __I  uint32_t SR;          /**< \brief Offset: 0x08 (R/  32) Status Register */
+  __O  uint32_t SCR;         /**< \brief Offset: 0x0C ( /W 32) Status Clear Register */
+  __IO uint32_t RTS;         /**< \brief Offset: 0x10 (R/W 32) Resistive Touch Screen Register */
+  __IO uint32_t SEQCFG;      /**< \brief Offset: 0x14 (R/W 32) Sequencer Configuration Register */
+  __O  uint32_t CDMA;        /**< \brief Offset: 0x18 ( /W 32) Configuration Direct Memory Access Register */
+  __IO uint32_t TIM;         /**< \brief Offset: 0x1C (R/W 32) Timing Configuration Register */
+  __IO uint32_t ITIMER;      /**< \brief Offset: 0x20 (R/W 32) Internal Timer Register */
+  __IO uint32_t WCFG;        /**< \brief Offset: 0x24 (R/W 32) Window Monitor Configuration Register */
+  __IO uint32_t WTH;         /**< \brief Offset: 0x28 (R/W 32) Window Monitor Threshold Configuration Register */
+  __I  uint32_t LCV;         /**< \brief Offset: 0x2C (R/  32) Sequencer Last Converted Value Register */
+  __O  uint32_t IER;         /**< \brief Offset: 0x30 ( /W 32) Interrupt Enable Register */
+  __O  uint32_t IDR;         /**< \brief Offset: 0x34 ( /W 32) Interrupt Disable Register */
+  __I  uint32_t IMR;         /**< \brief Offset: 0x38 (R/  32) Interrupt Mask Register */
+  __IO uint32_t CALIB;       /**< \brief Offset: 0x3C (R/W 32) Calibration Register */
+  __I  uint32_t VERSION;     /**< \brief Offset: 0x40 (R/  32) Version Register */
+  __I  uint32_t PARAMETER;   /**< \brief Offset: 0x44 (R/  32) Parameter Register */
 } Adcife;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/aesa.h
+++ b/asf/sam/include/sam4l/component/aesa.h
@@ -384,47 +384,25 @@ typedef union {
 
 /** \brief AESA hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __IO AESA_CTRL_Type            CTRL;        /**< \brief Offset: 0x00 (R/W 32) Control Register */
-  __IO AESA_MODE_Type            MODE;        /**< \brief Offset: 0x04 (R/W 32) Mode Register */
-  __IO AESA_DATABUFPTR_Type      DATABUFPTR;  /**< \brief Offset: 0x08 (R/W 32) Data Buffer Pointer Register */
-  __I  AESA_SR_Type              SR;          /**< \brief Offset: 0x0C (R/  32) Status Register */
-  __O  AESA_IER_Type             IER;         /**< \brief Offset: 0x10 ( /W 32) Interrupt Enable Register */
-  __O  AESA_IDR_Type             IDR;         /**< \brief Offset: 0x14 ( /W 32) Interrupt Disable Register */
-  __I  AESA_IMR_Type             IMR;         /**< \brief Offset: 0x18 (R/  32) Interrupt Mask Register */
-       RoReg8                    Reserved1[0x4];
-       AesaKey                   Key[8];      /**< \brief Offset: 0x20 AesaKey groups */
-       AesaInitvect              Initvect[4]; /**< \brief Offset: 0x40 AesaInitvect groups */
-  __O  AESA_IDATA_Type           IDATA;       /**< \brief Offset: 0x50 ( /W 32) Input Data Register */
-       RoReg8                    Reserved2[0xC];
-  __I  AESA_ODATA_Type           ODATA;       /**< \brief Offset: 0x60 (R/  32) Output Data Register */
-       RoReg8                    Reserved3[0xC];
-  __O  AESA_DRNGSEED_Type        DRNGSEED;    /**< \brief Offset: 0x70 ( /W 32) DRNG Seed Register */
-       RoReg8                    Reserved4[0x84];
-  __I  AESA_PARAMETER_Type       PARAMETER;   /**< \brief Offset: 0xF8 (R/  32) Parameter Register */
-  __I  AESA_VERSION_Type         VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
- } bf;
- struct {
-  RwReg   AESA_CTRL;          /**< \brief (AESA Offset: 0x00) Control Register */
-  RwReg   AESA_MODE;          /**< \brief (AESA Offset: 0x04) Mode Register */
-  RwReg   AESA_DATABUFPTR;    /**< \brief (AESA Offset: 0x08) Data Buffer Pointer Register */
-  RoReg   AESA_SR;            /**< \brief (AESA Offset: 0x0C) Status Register */
-  WoReg   AESA_IER;           /**< \brief (AESA Offset: 0x10) Interrupt Enable Register */
-  WoReg   AESA_IDR;           /**< \brief (AESA Offset: 0x14) Interrupt Disable Register */
-  RoReg   AESA_IMR;           /**< \brief (AESA Offset: 0x18) Interrupt Mask Register */
-  RoReg8  Reserved5[0x4];
-  AesaKey AESA_KEY[8];        /**< \brief (AESA Offset: 0x20) AesaKey groups */
-  AesaInitvect AESA_INITVECT[4];   /**< \brief (AESA Offset: 0x40) AesaInitvect groups */
-  WoReg   AESA_IDATA;         /**< \brief (AESA Offset: 0x50) Input Data Register */
-  RoReg8  Reserved6[0xC];
-  RoReg   AESA_ODATA;         /**< \brief (AESA Offset: 0x60) Output Data Register */
-  RoReg8  Reserved7[0xC];
-  WoReg   AESA_DRNGSEED;      /**< \brief (AESA Offset: 0x70) DRNG Seed Register */
-  RoReg8  Reserved8[0x84];
-  RoReg   AESA_PARAMETER;     /**< \brief (AESA Offset: 0xF8) Parameter Register */
-  RoReg   AESA_VERSION;       /**< \brief (AESA Offset: 0xFC) Version Register */
- } reg;
+typedef struct {
+  __IO uint32_t CTRL;        /**< \brief Offset: 0x00 (R/W 32) Control Register */
+  __IO uint32_t MODE;        /**< \brief Offset: 0x04 (R/W 32) Mode Register */
+  __IO uint32_t DATABUFPTR;  /**< \brief Offset: 0x08 (R/W 32) Data Buffer Pointer Register */
+  __I  uint32_t SR;          /**< \brief Offset: 0x0C (R/  32) Status Register */
+  __O  uint32_t IER;         /**< \brief Offset: 0x10 ( /W 32) Interrupt Enable Register */
+  __O  uint32_t IDR;         /**< \brief Offset: 0x14 ( /W 32) Interrupt Disable Register */
+  __I  uint32_t IMR;         /**< \brief Offset: 0x18 (R/  32) Interrupt Mask Register */
+       RoReg8   Reserved1[0x4];
+  __O  uint32_t Key[8];      /**< \brief Offset: 0x20 AesaKey groups */
+  __O  uint32_t Initvect[4]; /**< \brief Offset: 0x40 AesaInitvect groups */
+  __O  uint32_t IDATA;       /**< \brief Offset: 0x50 ( /W 32) Input Data Register */
+       RoReg8   Reserved2[0xC];
+  __I  uint32_t ODATA;       /**< \brief Offset: 0x60 (R/  32) Output Data Register */
+       RoReg8   Reserved3[0xC];
+  __O  uint32_t DRNGSEED;    /**< \brief Offset: 0x70 ( /W 32) DRNG Seed Register */
+       RoReg8   Reserved4[0x84];
+  __I  uint32_t PARAMETER;   /**< \brief Offset: 0xF8 (R/  32) Parameter Register */
+  __I  uint32_t VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
 } Aesa;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/aesa.h
+++ b/asf/sam/include/sam4l/component/aesa.h
@@ -1,0 +1,433 @@
+/**
+ * \file
+ *
+ * \brief Component description for AESA
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_AESA_COMPONENT_
+#define _SAM4L_AESA_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR AESA */
+/* ========================================================================== */
+/** \addtogroup SAM4L_AESA Advanced Encryption Standard */
+/*@{*/
+
+#define AESA_I7558
+#define REV_AESA                    0x102
+
+/* -------- AESA_CTRL : (AESA Offset: 0x00) (R/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ENABLE:1;         /*!< bit:      0  Enable Module                      */
+    uint32_t DKEYGEN:1;        /*!< bit:      1  Decryption Key Generate            */
+    uint32_t NEWMSG:1;         /*!< bit:      2  New Message                        */
+    uint32_t :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint32_t SWRST:1;          /*!< bit:      8  Software Reset                     */
+    uint32_t :23;              /*!< bit:  9..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AESA_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AESA_CTRL_OFFSET            0x00         /**< \brief (AESA_CTRL offset) Control Register */
+#define AESA_CTRL_RESETVALUE        _U(0x00000000); /**< \brief (AESA_CTRL reset_value) Control Register */
+
+#define AESA_CTRL_ENABLE_Pos        0            /**< \brief (AESA_CTRL) Enable Module */
+#define AESA_CTRL_ENABLE            (_U(0x1) << AESA_CTRL_ENABLE_Pos)
+#define AESA_CTRL_DKEYGEN_Pos       1            /**< \brief (AESA_CTRL) Decryption Key Generate */
+#define AESA_CTRL_DKEYGEN           (_U(0x1) << AESA_CTRL_DKEYGEN_Pos)
+#define AESA_CTRL_NEWMSG_Pos        2            /**< \brief (AESA_CTRL) New Message */
+#define AESA_CTRL_NEWMSG            (_U(0x1) << AESA_CTRL_NEWMSG_Pos)
+#define AESA_CTRL_SWRST_Pos         8            /**< \brief (AESA_CTRL) Software Reset */
+#define AESA_CTRL_SWRST             (_U(0x1) << AESA_CTRL_SWRST_Pos)
+#define AESA_CTRL_MASK              _U(0x00000107) /**< \brief (AESA_CTRL) MASK Register */
+
+/* -------- AESA_MODE : (AESA Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ENCRYPT:1;        /*!< bit:      0  Encryption                         */
+    uint32_t KEYSIZE:2;        /*!< bit:  1.. 2  Key Size                           */
+    uint32_t DMA:1;            /*!< bit:      3  DMA Mode                           */
+    uint32_t OPMODE:3;         /*!< bit:  4.. 6  Confidentiality Mode of Operation  */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t CFBS:3;           /*!< bit:  8..10  Cipher Feedback Data Segment Size  */
+    uint32_t :5;               /*!< bit: 11..15  Reserved                           */
+    uint32_t CTYPE:4;          /*!< bit: 16..19  Countermeasure Type                */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AESA_MODE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AESA_MODE_OFFSET            0x04         /**< \brief (AESA_MODE offset) Mode Register */
+#define AESA_MODE_RESETVALUE        _U(0x000F0000); /**< \brief (AESA_MODE reset_value) Mode Register */
+
+#define AESA_MODE_ENCRYPT_Pos       0            /**< \brief (AESA_MODE) Encryption */
+#define AESA_MODE_ENCRYPT           (_U(0x1) << AESA_MODE_ENCRYPT_Pos)
+#define AESA_MODE_KEYSIZE_Pos       1            /**< \brief (AESA_MODE) Key Size */
+#define AESA_MODE_KEYSIZE_Msk       (_U(0x3) << AESA_MODE_KEYSIZE_Pos)
+#define AESA_MODE_KEYSIZE(value)    (AESA_MODE_KEYSIZE_Msk & ((value) << AESA_MODE_KEYSIZE_Pos))
+#define AESA_MODE_DMA_Pos           3            /**< \brief (AESA_MODE) DMA Mode */
+#define AESA_MODE_DMA               (_U(0x1) << AESA_MODE_DMA_Pos)
+#define AESA_MODE_OPMODE_Pos        4            /**< \brief (AESA_MODE) Confidentiality Mode of Operation */
+#define AESA_MODE_OPMODE_Msk        (_U(0x7) << AESA_MODE_OPMODE_Pos)
+#define AESA_MODE_OPMODE(value)     (AESA_MODE_OPMODE_Msk & ((value) << AESA_MODE_OPMODE_Pos))
+#define AESA_MODE_CFBS_Pos          8            /**< \brief (AESA_MODE) Cipher Feedback Data Segment Size */
+#define AESA_MODE_CFBS_Msk          (_U(0x7) << AESA_MODE_CFBS_Pos)
+#define AESA_MODE_CFBS(value)       (AESA_MODE_CFBS_Msk & ((value) << AESA_MODE_CFBS_Pos))
+#define AESA_MODE_CTYPE_Pos         16           /**< \brief (AESA_MODE) Countermeasure Type */
+#define AESA_MODE_CTYPE_Msk         (_U(0xF) << AESA_MODE_CTYPE_Pos)
+#define AESA_MODE_CTYPE(value)      (AESA_MODE_CTYPE_Msk & ((value) << AESA_MODE_CTYPE_Pos))
+#define AESA_MODE_MASK              _U(0x000F077F) /**< \brief (AESA_MODE) MASK Register */
+
+/* -------- AESA_DATABUFPTR : (AESA Offset: 0x08) (R/W 32) Data Buffer Pointer Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t IDATAW:2;         /*!< bit:  0.. 1  Input Data Word                    */
+    uint32_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint32_t ODATAW:2;         /*!< bit:  4.. 5  Output Data Word                   */
+    uint32_t :26;              /*!< bit:  6..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AESA_DATABUFPTR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AESA_DATABUFPTR_OFFSET      0x08         /**< \brief (AESA_DATABUFPTR offset) Data Buffer Pointer Register */
+#define AESA_DATABUFPTR_RESETVALUE  _U(0x00000000); /**< \brief (AESA_DATABUFPTR reset_value) Data Buffer Pointer Register */
+
+#define AESA_DATABUFPTR_IDATAW_Pos  0            /**< \brief (AESA_DATABUFPTR) Input Data Word */
+#define AESA_DATABUFPTR_IDATAW_Msk  (_U(0x3) << AESA_DATABUFPTR_IDATAW_Pos)
+#define AESA_DATABUFPTR_IDATAW(value) (AESA_DATABUFPTR_IDATAW_Msk & ((value) << AESA_DATABUFPTR_IDATAW_Pos))
+#define AESA_DATABUFPTR_ODATAW_Pos  4            /**< \brief (AESA_DATABUFPTR) Output Data Word */
+#define AESA_DATABUFPTR_ODATAW_Msk  (_U(0x3) << AESA_DATABUFPTR_ODATAW_Pos)
+#define AESA_DATABUFPTR_ODATAW(value) (AESA_DATABUFPTR_ODATAW_Msk & ((value) << AESA_DATABUFPTR_ODATAW_Pos))
+#define AESA_DATABUFPTR_MASK        _U(0x00000033) /**< \brief (AESA_DATABUFPTR) MASK Register */
+
+/* -------- AESA_SR : (AESA Offset: 0x0C) (R/  32) Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ODATARDY:1;       /*!< bit:      0  Output Data Ready                  */
+    uint32_t :15;              /*!< bit:  1..15  Reserved                           */
+    uint32_t IBUFRDY:1;        /*!< bit:     16  Input Buffer Ready                 */
+    uint32_t :15;              /*!< bit: 17..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AESA_SR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AESA_SR_OFFSET              0x0C         /**< \brief (AESA_SR offset) Status Register */
+#define AESA_SR_RESETVALUE          _U(0x00010000); /**< \brief (AESA_SR reset_value) Status Register */
+
+#define AESA_SR_ODATARDY_Pos        0            /**< \brief (AESA_SR) Output Data Ready */
+#define AESA_SR_ODATARDY            (_U(0x1) << AESA_SR_ODATARDY_Pos)
+#define AESA_SR_IBUFRDY_Pos         16           /**< \brief (AESA_SR) Input Buffer Ready */
+#define AESA_SR_IBUFRDY             (_U(0x1) << AESA_SR_IBUFRDY_Pos)
+#define AESA_SR_MASK                _U(0x00010001) /**< \brief (AESA_SR) MASK Register */
+
+/* -------- AESA_IER : (AESA Offset: 0x10) ( /W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ODATARDY:1;       /*!< bit:      0  Output Data Ready Interrupt Enable */
+    uint32_t :15;              /*!< bit:  1..15  Reserved                           */
+    uint32_t IBUFRDY:1;        /*!< bit:     16  Input Buffer Ready Interrupt Enable */
+    uint32_t :15;              /*!< bit: 17..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AESA_IER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AESA_IER_OFFSET             0x10         /**< \brief (AESA_IER offset) Interrupt Enable Register */
+#define AESA_IER_RESETVALUE         _U(0x00000000); /**< \brief (AESA_IER reset_value) Interrupt Enable Register */
+
+#define AESA_IER_ODATARDY_Pos       0            /**< \brief (AESA_IER) Output Data Ready Interrupt Enable */
+#define AESA_IER_ODATARDY           (_U(0x1) << AESA_IER_ODATARDY_Pos)
+#define AESA_IER_IBUFRDY_Pos        16           /**< \brief (AESA_IER) Input Buffer Ready Interrupt Enable */
+#define AESA_IER_IBUFRDY            (_U(0x1) << AESA_IER_IBUFRDY_Pos)
+#define AESA_IER_MASK               _U(0x00010001) /**< \brief (AESA_IER) MASK Register */
+
+/* -------- AESA_IDR : (AESA Offset: 0x14) ( /W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ODATARDY:1;       /*!< bit:      0  Output Data Ready Interrupt Disable */
+    uint32_t :15;              /*!< bit:  1..15  Reserved                           */
+    uint32_t IBUFRDY:1;        /*!< bit:     16  Input Buffer Ready Interrupt Disable */
+    uint32_t :15;              /*!< bit: 17..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AESA_IDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AESA_IDR_OFFSET             0x14         /**< \brief (AESA_IDR offset) Interrupt Disable Register */
+#define AESA_IDR_RESETVALUE         _U(0x00000000); /**< \brief (AESA_IDR reset_value) Interrupt Disable Register */
+
+#define AESA_IDR_ODATARDY_Pos       0            /**< \brief (AESA_IDR) Output Data Ready Interrupt Disable */
+#define AESA_IDR_ODATARDY           (_U(0x1) << AESA_IDR_ODATARDY_Pos)
+#define AESA_IDR_IBUFRDY_Pos        16           /**< \brief (AESA_IDR) Input Buffer Ready Interrupt Disable */
+#define AESA_IDR_IBUFRDY            (_U(0x1) << AESA_IDR_IBUFRDY_Pos)
+#define AESA_IDR_MASK               _U(0x00010001) /**< \brief (AESA_IDR) MASK Register */
+
+/* -------- AESA_IMR : (AESA Offset: 0x18) (R/  32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ODATARDY:1;       /*!< bit:      0  Output Data Ready Interrupt Mask   */
+    uint32_t :15;              /*!< bit:  1..15  Reserved                           */
+    uint32_t IBUFRDY:1;        /*!< bit:     16  Input Buffer Ready Interrupt Mask  */
+    uint32_t :15;              /*!< bit: 17..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AESA_IMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AESA_IMR_OFFSET             0x18         /**< \brief (AESA_IMR offset) Interrupt Mask Register */
+#define AESA_IMR_RESETVALUE         _U(0x00000000); /**< \brief (AESA_IMR reset_value) Interrupt Mask Register */
+
+#define AESA_IMR_ODATARDY_Pos       0            /**< \brief (AESA_IMR) Output Data Ready Interrupt Mask */
+#define AESA_IMR_ODATARDY           (_U(0x1) << AESA_IMR_ODATARDY_Pos)
+#define AESA_IMR_IBUFRDY_Pos        16           /**< \brief (AESA_IMR) Input Buffer Ready Interrupt Mask */
+#define AESA_IMR_IBUFRDY            (_U(0x1) << AESA_IMR_IBUFRDY_Pos)
+#define AESA_IMR_MASK               _U(0x00010001) /**< \brief (AESA_IMR) MASK Register */
+
+/* -------- AESA_KEY : (AESA Offset: 0x20) ( /W 32) KEY Key Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t KEY0:32;          /*!< bit:  0..31  Key Word 0                         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AESA_KEY_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AESA_KEY_OFFSET             0x20         /**< \brief (AESA_KEY offset) Key Register */
+#define AESA_KEY_RESETVALUE         _U(0x00000000); /**< \brief (AESA_KEY reset_value) Key Register */
+
+#define AESA_KEY_KEY0_Pos           0            /**< \brief (AESA_KEY) Key Word 0 */
+#define AESA_KEY_KEY0_Msk           (_U(0xFFFFFFFF) << AESA_KEY_KEY0_Pos)
+#define AESA_KEY_KEY0(value)        (AESA_KEY_KEY0_Msk & ((value) << AESA_KEY_KEY0_Pos))
+#define AESA_KEY_MASK               _U(0xFFFFFFFF) /**< \brief (AESA_KEY) MASK Register */
+
+/* -------- AESA_INITVECT : (AESA Offset: 0x40) ( /W 32) INITVECT Initialization Vector Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t INITVECT0:32;     /*!< bit:  0..31  Initialization Vector Word 0       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AESA_INITVECT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AESA_INITVECT_OFFSET        0x40         /**< \brief (AESA_INITVECT offset) Initialization Vector Register */
+#define AESA_INITVECT_RESETVALUE    _U(0x00000000); /**< \brief (AESA_INITVECT reset_value) Initialization Vector Register */
+
+#define AESA_INITVECT_INITVECT0_Pos 0            /**< \brief (AESA_INITVECT) Initialization Vector Word 0 */
+#define AESA_INITVECT_INITVECT0_Msk (_U(0xFFFFFFFF) << AESA_INITVECT_INITVECT0_Pos)
+#define AESA_INITVECT_INITVECT0(value) (AESA_INITVECT_INITVECT0_Msk & ((value) << AESA_INITVECT_INITVECT0_Pos))
+#define AESA_INITVECT_MASK          _U(0xFFFFFFFF) /**< \brief (AESA_INITVECT) MASK Register */
+
+/* -------- AESA_IDATA : (AESA Offset: 0x50) ( /W 32) Input Data Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t IDATA:32;         /*!< bit:  0..31  Input Data                         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AESA_IDATA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AESA_IDATA_OFFSET           0x50         /**< \brief (AESA_IDATA offset) Input Data Register */
+#define AESA_IDATA_RESETVALUE       _U(0x00000000); /**< \brief (AESA_IDATA reset_value) Input Data Register */
+
+#define AESA_IDATA_IDATA_Pos        0            /**< \brief (AESA_IDATA) Input Data */
+#define AESA_IDATA_IDATA_Msk        (_U(0xFFFFFFFF) << AESA_IDATA_IDATA_Pos)
+#define AESA_IDATA_IDATA(value)     (AESA_IDATA_IDATA_Msk & ((value) << AESA_IDATA_IDATA_Pos))
+#define AESA_IDATA_MASK             _U(0xFFFFFFFF) /**< \brief (AESA_IDATA) MASK Register */
+
+/* -------- AESA_ODATA : (AESA Offset: 0x60) (R/  32) Output Data Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ODATA:32;         /*!< bit:  0..31  Output Data                        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AESA_ODATA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AESA_ODATA_OFFSET           0x60         /**< \brief (AESA_ODATA offset) Output Data Register */
+#define AESA_ODATA_RESETVALUE       _U(0x00000000); /**< \brief (AESA_ODATA reset_value) Output Data Register */
+
+#define AESA_ODATA_ODATA_Pos        0            /**< \brief (AESA_ODATA) Output Data */
+#define AESA_ODATA_ODATA_Msk        (_U(0xFFFFFFFF) << AESA_ODATA_ODATA_Pos)
+#define AESA_ODATA_ODATA(value)     (AESA_ODATA_ODATA_Msk & ((value) << AESA_ODATA_ODATA_Pos))
+#define AESA_ODATA_MASK             _U(0xFFFFFFFF) /**< \brief (AESA_ODATA) MASK Register */
+
+/* -------- AESA_DRNGSEED : (AESA Offset: 0x70) ( /W 32) DRNG Seed Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SEED:32;          /*!< bit:  0..31  DRNG Seed                          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AESA_DRNGSEED_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AESA_DRNGSEED_OFFSET        0x70         /**< \brief (AESA_DRNGSEED offset) DRNG Seed Register */
+#define AESA_DRNGSEED_RESETVALUE    _U(0x00000000); /**< \brief (AESA_DRNGSEED reset_value) DRNG Seed Register */
+
+#define AESA_DRNGSEED_SEED_Pos      0            /**< \brief (AESA_DRNGSEED) DRNG Seed */
+#define AESA_DRNGSEED_SEED_Msk      (_U(0xFFFFFFFF) << AESA_DRNGSEED_SEED_Pos)
+#define AESA_DRNGSEED_SEED(value)   (AESA_DRNGSEED_SEED_Msk & ((value) << AESA_DRNGSEED_SEED_Pos))
+#define AESA_DRNGSEED_MASK          _U(0xFFFFFFFF) /**< \brief (AESA_DRNGSEED) MASK Register */
+
+/* -------- AESA_PARAMETER : (AESA Offset: 0xF8) (R/  32) Parameter Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t KEYSIZE:2;        /*!< bit:  0.. 1  Maximum Key Size                   */
+    uint32_t OPMODE:3;         /*!< bit:  2.. 4  Maximum Number of Confidentiality Modes of Operation */
+    uint32_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint32_t CTRMEAS:1;        /*!< bit:      8  Countermeasures                    */
+    uint32_t :23;              /*!< bit:  9..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AESA_PARAMETER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AESA_PARAMETER_OFFSET       0xF8         /**< \brief (AESA_PARAMETER offset) Parameter Register */
+#define AESA_PARAMETER_RESETVALUE   _U(0x00000112); /**< \brief (AESA_PARAMETER reset_value) Parameter Register */
+
+#define AESA_PARAMETER_KEYSIZE_Pos  0            /**< \brief (AESA_PARAMETER) Maximum Key Size */
+#define AESA_PARAMETER_KEYSIZE_Msk  (_U(0x3) << AESA_PARAMETER_KEYSIZE_Pos)
+#define AESA_PARAMETER_KEYSIZE(value) (AESA_PARAMETER_KEYSIZE_Msk & ((value) << AESA_PARAMETER_KEYSIZE_Pos))
+#define AESA_PARAMETER_OPMODE_Pos   2            /**< \brief (AESA_PARAMETER) Maximum Number of Confidentiality Modes of Operation */
+#define AESA_PARAMETER_OPMODE_Msk   (_U(0x7) << AESA_PARAMETER_OPMODE_Pos)
+#define AESA_PARAMETER_OPMODE(value) (AESA_PARAMETER_OPMODE_Msk & ((value) << AESA_PARAMETER_OPMODE_Pos))
+#define AESA_PARAMETER_CTRMEAS_Pos  8            /**< \brief (AESA_PARAMETER) Countermeasures */
+#define AESA_PARAMETER_CTRMEAS      (_U(0x1) << AESA_PARAMETER_CTRMEAS_Pos)
+#define AESA_PARAMETER_MASK         _U(0x0000011F) /**< \brief (AESA_PARAMETER) MASK Register */
+
+/* -------- AESA_VERSION : (AESA Offset: 0xFC) (R/  32) Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version Number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant Number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AESA_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AESA_VERSION_OFFSET         0xFC         /**< \brief (AESA_VERSION offset) Version Register */
+#define AESA_VERSION_RESETVALUE     _U(0x00000102); /**< \brief (AESA_VERSION reset_value) Version Register */
+
+#define AESA_VERSION_VERSION_Pos    0            /**< \brief (AESA_VERSION) Version Number */
+#define AESA_VERSION_VERSION_Msk    (_U(0xFFF) << AESA_VERSION_VERSION_Pos)
+#define AESA_VERSION_VERSION(value) (AESA_VERSION_VERSION_Msk & ((value) << AESA_VERSION_VERSION_Pos))
+#define AESA_VERSION_VARIANT_Pos    16           /**< \brief (AESA_VERSION) Variant Number */
+#define AESA_VERSION_VARIANT_Msk    (_U(0xF) << AESA_VERSION_VARIANT_Pos)
+#define AESA_VERSION_VARIANT(value) (AESA_VERSION_VARIANT_Msk & ((value) << AESA_VERSION_VARIANT_Pos))
+#define AESA_VERSION_MASK           _U(0x000F0FFF) /**< \brief (AESA_VERSION) MASK Register */
+
+/** \brief AesaInitvect hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __O  AESA_INITVECT_Type        INITVECT;    /**< \brief Offset: 0x00 ( /W 32) Initialization Vector Register */
+ } bf;
+ struct {
+  WoReg   AESA_INITVECT;      /**< \brief (AESA Offset: 0x00) Initialization Vector Register */
+ } reg;
+} AesaInitvect;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief AesaKey hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __O  AESA_KEY_Type             KEY;         /**< \brief Offset: 0x00 ( /W 32) Key Register */
+ } bf;
+ struct {
+  WoReg   AESA_KEY;           /**< \brief (AESA Offset: 0x00) Key Register */
+ } reg;
+} AesaKey;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief AESA hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __IO AESA_CTRL_Type            CTRL;        /**< \brief Offset: 0x00 (R/W 32) Control Register */
+  __IO AESA_MODE_Type            MODE;        /**< \brief Offset: 0x04 (R/W 32) Mode Register */
+  __IO AESA_DATABUFPTR_Type      DATABUFPTR;  /**< \brief Offset: 0x08 (R/W 32) Data Buffer Pointer Register */
+  __I  AESA_SR_Type              SR;          /**< \brief Offset: 0x0C (R/  32) Status Register */
+  __O  AESA_IER_Type             IER;         /**< \brief Offset: 0x10 ( /W 32) Interrupt Enable Register */
+  __O  AESA_IDR_Type             IDR;         /**< \brief Offset: 0x14 ( /W 32) Interrupt Disable Register */
+  __I  AESA_IMR_Type             IMR;         /**< \brief Offset: 0x18 (R/  32) Interrupt Mask Register */
+       RoReg8                    Reserved1[0x4];
+       AesaKey                   Key[8];      /**< \brief Offset: 0x20 AesaKey groups */
+       AesaInitvect              Initvect[4]; /**< \brief Offset: 0x40 AesaInitvect groups */
+  __O  AESA_IDATA_Type           IDATA;       /**< \brief Offset: 0x50 ( /W 32) Input Data Register */
+       RoReg8                    Reserved2[0xC];
+  __I  AESA_ODATA_Type           ODATA;       /**< \brief Offset: 0x60 (R/  32) Output Data Register */
+       RoReg8                    Reserved3[0xC];
+  __O  AESA_DRNGSEED_Type        DRNGSEED;    /**< \brief Offset: 0x70 ( /W 32) DRNG Seed Register */
+       RoReg8                    Reserved4[0x84];
+  __I  AESA_PARAMETER_Type       PARAMETER;   /**< \brief Offset: 0xF8 (R/  32) Parameter Register */
+  __I  AESA_VERSION_Type         VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
+ } bf;
+ struct {
+  RwReg   AESA_CTRL;          /**< \brief (AESA Offset: 0x00) Control Register */
+  RwReg   AESA_MODE;          /**< \brief (AESA Offset: 0x04) Mode Register */
+  RwReg   AESA_DATABUFPTR;    /**< \brief (AESA Offset: 0x08) Data Buffer Pointer Register */
+  RoReg   AESA_SR;            /**< \brief (AESA Offset: 0x0C) Status Register */
+  WoReg   AESA_IER;           /**< \brief (AESA Offset: 0x10) Interrupt Enable Register */
+  WoReg   AESA_IDR;           /**< \brief (AESA Offset: 0x14) Interrupt Disable Register */
+  RoReg   AESA_IMR;           /**< \brief (AESA Offset: 0x18) Interrupt Mask Register */
+  RoReg8  Reserved5[0x4];
+  AesaKey AESA_KEY[8];        /**< \brief (AESA Offset: 0x20) AesaKey groups */
+  AesaInitvect AESA_INITVECT[4];   /**< \brief (AESA Offset: 0x40) AesaInitvect groups */
+  WoReg   AESA_IDATA;         /**< \brief (AESA Offset: 0x50) Input Data Register */
+  RoReg8  Reserved6[0xC];
+  RoReg   AESA_ODATA;         /**< \brief (AESA Offset: 0x60) Output Data Register */
+  RoReg8  Reserved7[0xC];
+  WoReg   AESA_DRNGSEED;      /**< \brief (AESA Offset: 0x70) DRNG Seed Register */
+  RoReg8  Reserved8[0x84];
+  RoReg   AESA_PARAMETER;     /**< \brief (AESA Offset: 0xF8) Parameter Register */
+  RoReg   AESA_VERSION;       /**< \brief (AESA Offset: 0xFC) Version Register */
+ } reg;
+} Aesa;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_AESA_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/aesa.h
+++ b/asf/sam/include/sam4l/component/aesa.h
@@ -54,17 +54,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AESA_CTRL_OFFSET            0x00         /**< \brief (AESA_CTRL offset) Control Register */
-#define AESA_CTRL_RESETVALUE        _U(0x00000000); /**< \brief (AESA_CTRL reset_value) Control Register */
+#define AESA_CTRL_RESETVALUE        _U_(0x00000000); /**< \brief (AESA_CTRL reset_value) Control Register */
 
 #define AESA_CTRL_ENABLE_Pos        0            /**< \brief (AESA_CTRL) Enable Module */
-#define AESA_CTRL_ENABLE            (_U(0x1) << AESA_CTRL_ENABLE_Pos)
+#define AESA_CTRL_ENABLE            (_U_(0x1) << AESA_CTRL_ENABLE_Pos)
 #define AESA_CTRL_DKEYGEN_Pos       1            /**< \brief (AESA_CTRL) Decryption Key Generate */
-#define AESA_CTRL_DKEYGEN           (_U(0x1) << AESA_CTRL_DKEYGEN_Pos)
+#define AESA_CTRL_DKEYGEN           (_U_(0x1) << AESA_CTRL_DKEYGEN_Pos)
 #define AESA_CTRL_NEWMSG_Pos        2            /**< \brief (AESA_CTRL) New Message */
-#define AESA_CTRL_NEWMSG            (_U(0x1) << AESA_CTRL_NEWMSG_Pos)
+#define AESA_CTRL_NEWMSG            (_U_(0x1) << AESA_CTRL_NEWMSG_Pos)
 #define AESA_CTRL_SWRST_Pos         8            /**< \brief (AESA_CTRL) Software Reset */
-#define AESA_CTRL_SWRST             (_U(0x1) << AESA_CTRL_SWRST_Pos)
-#define AESA_CTRL_MASK              _U(0x00000107) /**< \brief (AESA_CTRL) MASK Register */
+#define AESA_CTRL_SWRST             (_U_(0x1) << AESA_CTRL_SWRST_Pos)
+#define AESA_CTRL_MASK              _U_(0x00000107) /**< \brief (AESA_CTRL) MASK Register */
 
 /* -------- AESA_MODE : (AESA Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -85,25 +85,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AESA_MODE_OFFSET            0x04         /**< \brief (AESA_MODE offset) Mode Register */
-#define AESA_MODE_RESETVALUE        _U(0x000F0000); /**< \brief (AESA_MODE reset_value) Mode Register */
+#define AESA_MODE_RESETVALUE        _U_(0x000F0000); /**< \brief (AESA_MODE reset_value) Mode Register */
 
 #define AESA_MODE_ENCRYPT_Pos       0            /**< \brief (AESA_MODE) Encryption */
-#define AESA_MODE_ENCRYPT           (_U(0x1) << AESA_MODE_ENCRYPT_Pos)
+#define AESA_MODE_ENCRYPT           (_U_(0x1) << AESA_MODE_ENCRYPT_Pos)
 #define AESA_MODE_KEYSIZE_Pos       1            /**< \brief (AESA_MODE) Key Size */
-#define AESA_MODE_KEYSIZE_Msk       (_U(0x3) << AESA_MODE_KEYSIZE_Pos)
+#define AESA_MODE_KEYSIZE_Msk       (_U_(0x3) << AESA_MODE_KEYSIZE_Pos)
 #define AESA_MODE_KEYSIZE(value)    (AESA_MODE_KEYSIZE_Msk & ((value) << AESA_MODE_KEYSIZE_Pos))
 #define AESA_MODE_DMA_Pos           3            /**< \brief (AESA_MODE) DMA Mode */
-#define AESA_MODE_DMA               (_U(0x1) << AESA_MODE_DMA_Pos)
+#define AESA_MODE_DMA               (_U_(0x1) << AESA_MODE_DMA_Pos)
 #define AESA_MODE_OPMODE_Pos        4            /**< \brief (AESA_MODE) Confidentiality Mode of Operation */
-#define AESA_MODE_OPMODE_Msk        (_U(0x7) << AESA_MODE_OPMODE_Pos)
+#define AESA_MODE_OPMODE_Msk        (_U_(0x7) << AESA_MODE_OPMODE_Pos)
 #define AESA_MODE_OPMODE(value)     (AESA_MODE_OPMODE_Msk & ((value) << AESA_MODE_OPMODE_Pos))
 #define AESA_MODE_CFBS_Pos          8            /**< \brief (AESA_MODE) Cipher Feedback Data Segment Size */
-#define AESA_MODE_CFBS_Msk          (_U(0x7) << AESA_MODE_CFBS_Pos)
+#define AESA_MODE_CFBS_Msk          (_U_(0x7) << AESA_MODE_CFBS_Pos)
 #define AESA_MODE_CFBS(value)       (AESA_MODE_CFBS_Msk & ((value) << AESA_MODE_CFBS_Pos))
 #define AESA_MODE_CTYPE_Pos         16           /**< \brief (AESA_MODE) Countermeasure Type */
-#define AESA_MODE_CTYPE_Msk         (_U(0xF) << AESA_MODE_CTYPE_Pos)
+#define AESA_MODE_CTYPE_Msk         (_U_(0xF) << AESA_MODE_CTYPE_Pos)
 #define AESA_MODE_CTYPE(value)      (AESA_MODE_CTYPE_Msk & ((value) << AESA_MODE_CTYPE_Pos))
-#define AESA_MODE_MASK              _U(0x000F077F) /**< \brief (AESA_MODE) MASK Register */
+#define AESA_MODE_MASK              _U_(0x000F077F) /**< \brief (AESA_MODE) MASK Register */
 
 /* -------- AESA_DATABUFPTR : (AESA Offset: 0x08) (R/W 32) Data Buffer Pointer Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -119,15 +119,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AESA_DATABUFPTR_OFFSET      0x08         /**< \brief (AESA_DATABUFPTR offset) Data Buffer Pointer Register */
-#define AESA_DATABUFPTR_RESETVALUE  _U(0x00000000); /**< \brief (AESA_DATABUFPTR reset_value) Data Buffer Pointer Register */
+#define AESA_DATABUFPTR_RESETVALUE  _U_(0x00000000); /**< \brief (AESA_DATABUFPTR reset_value) Data Buffer Pointer Register */
 
 #define AESA_DATABUFPTR_IDATAW_Pos  0            /**< \brief (AESA_DATABUFPTR) Input Data Word */
-#define AESA_DATABUFPTR_IDATAW_Msk  (_U(0x3) << AESA_DATABUFPTR_IDATAW_Pos)
+#define AESA_DATABUFPTR_IDATAW_Msk  (_U_(0x3) << AESA_DATABUFPTR_IDATAW_Pos)
 #define AESA_DATABUFPTR_IDATAW(value) (AESA_DATABUFPTR_IDATAW_Msk & ((value) << AESA_DATABUFPTR_IDATAW_Pos))
 #define AESA_DATABUFPTR_ODATAW_Pos  4            /**< \brief (AESA_DATABUFPTR) Output Data Word */
-#define AESA_DATABUFPTR_ODATAW_Msk  (_U(0x3) << AESA_DATABUFPTR_ODATAW_Pos)
+#define AESA_DATABUFPTR_ODATAW_Msk  (_U_(0x3) << AESA_DATABUFPTR_ODATAW_Pos)
 #define AESA_DATABUFPTR_ODATAW(value) (AESA_DATABUFPTR_ODATAW_Msk & ((value) << AESA_DATABUFPTR_ODATAW_Pos))
-#define AESA_DATABUFPTR_MASK        _U(0x00000033) /**< \brief (AESA_DATABUFPTR) MASK Register */
+#define AESA_DATABUFPTR_MASK        _U_(0x00000033) /**< \brief (AESA_DATABUFPTR) MASK Register */
 
 /* -------- AESA_SR : (AESA Offset: 0x0C) (R/  32) Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -143,13 +143,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AESA_SR_OFFSET              0x0C         /**< \brief (AESA_SR offset) Status Register */
-#define AESA_SR_RESETVALUE          _U(0x00010000); /**< \brief (AESA_SR reset_value) Status Register */
+#define AESA_SR_RESETVALUE          _U_(0x00010000); /**< \brief (AESA_SR reset_value) Status Register */
 
 #define AESA_SR_ODATARDY_Pos        0            /**< \brief (AESA_SR) Output Data Ready */
-#define AESA_SR_ODATARDY            (_U(0x1) << AESA_SR_ODATARDY_Pos)
+#define AESA_SR_ODATARDY            (_U_(0x1) << AESA_SR_ODATARDY_Pos)
 #define AESA_SR_IBUFRDY_Pos         16           /**< \brief (AESA_SR) Input Buffer Ready */
-#define AESA_SR_IBUFRDY             (_U(0x1) << AESA_SR_IBUFRDY_Pos)
-#define AESA_SR_MASK                _U(0x00010001) /**< \brief (AESA_SR) MASK Register */
+#define AESA_SR_IBUFRDY             (_U_(0x1) << AESA_SR_IBUFRDY_Pos)
+#define AESA_SR_MASK                _U_(0x00010001) /**< \brief (AESA_SR) MASK Register */
 
 /* -------- AESA_IER : (AESA Offset: 0x10) ( /W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -165,13 +165,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AESA_IER_OFFSET             0x10         /**< \brief (AESA_IER offset) Interrupt Enable Register */
-#define AESA_IER_RESETVALUE         _U(0x00000000); /**< \brief (AESA_IER reset_value) Interrupt Enable Register */
+#define AESA_IER_RESETVALUE         _U_(0x00000000); /**< \brief (AESA_IER reset_value) Interrupt Enable Register */
 
 #define AESA_IER_ODATARDY_Pos       0            /**< \brief (AESA_IER) Output Data Ready Interrupt Enable */
-#define AESA_IER_ODATARDY           (_U(0x1) << AESA_IER_ODATARDY_Pos)
+#define AESA_IER_ODATARDY           (_U_(0x1) << AESA_IER_ODATARDY_Pos)
 #define AESA_IER_IBUFRDY_Pos        16           /**< \brief (AESA_IER) Input Buffer Ready Interrupt Enable */
-#define AESA_IER_IBUFRDY            (_U(0x1) << AESA_IER_IBUFRDY_Pos)
-#define AESA_IER_MASK               _U(0x00010001) /**< \brief (AESA_IER) MASK Register */
+#define AESA_IER_IBUFRDY            (_U_(0x1) << AESA_IER_IBUFRDY_Pos)
+#define AESA_IER_MASK               _U_(0x00010001) /**< \brief (AESA_IER) MASK Register */
 
 /* -------- AESA_IDR : (AESA Offset: 0x14) ( /W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -187,13 +187,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AESA_IDR_OFFSET             0x14         /**< \brief (AESA_IDR offset) Interrupt Disable Register */
-#define AESA_IDR_RESETVALUE         _U(0x00000000); /**< \brief (AESA_IDR reset_value) Interrupt Disable Register */
+#define AESA_IDR_RESETVALUE         _U_(0x00000000); /**< \brief (AESA_IDR reset_value) Interrupt Disable Register */
 
 #define AESA_IDR_ODATARDY_Pos       0            /**< \brief (AESA_IDR) Output Data Ready Interrupt Disable */
-#define AESA_IDR_ODATARDY           (_U(0x1) << AESA_IDR_ODATARDY_Pos)
+#define AESA_IDR_ODATARDY           (_U_(0x1) << AESA_IDR_ODATARDY_Pos)
 #define AESA_IDR_IBUFRDY_Pos        16           /**< \brief (AESA_IDR) Input Buffer Ready Interrupt Disable */
-#define AESA_IDR_IBUFRDY            (_U(0x1) << AESA_IDR_IBUFRDY_Pos)
-#define AESA_IDR_MASK               _U(0x00010001) /**< \brief (AESA_IDR) MASK Register */
+#define AESA_IDR_IBUFRDY            (_U_(0x1) << AESA_IDR_IBUFRDY_Pos)
+#define AESA_IDR_MASK               _U_(0x00010001) /**< \brief (AESA_IDR) MASK Register */
 
 /* -------- AESA_IMR : (AESA Offset: 0x18) (R/  32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -209,13 +209,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AESA_IMR_OFFSET             0x18         /**< \brief (AESA_IMR offset) Interrupt Mask Register */
-#define AESA_IMR_RESETVALUE         _U(0x00000000); /**< \brief (AESA_IMR reset_value) Interrupt Mask Register */
+#define AESA_IMR_RESETVALUE         _U_(0x00000000); /**< \brief (AESA_IMR reset_value) Interrupt Mask Register */
 
 #define AESA_IMR_ODATARDY_Pos       0            /**< \brief (AESA_IMR) Output Data Ready Interrupt Mask */
-#define AESA_IMR_ODATARDY           (_U(0x1) << AESA_IMR_ODATARDY_Pos)
+#define AESA_IMR_ODATARDY           (_U_(0x1) << AESA_IMR_ODATARDY_Pos)
 #define AESA_IMR_IBUFRDY_Pos        16           /**< \brief (AESA_IMR) Input Buffer Ready Interrupt Mask */
-#define AESA_IMR_IBUFRDY            (_U(0x1) << AESA_IMR_IBUFRDY_Pos)
-#define AESA_IMR_MASK               _U(0x00010001) /**< \brief (AESA_IMR) MASK Register */
+#define AESA_IMR_IBUFRDY            (_U_(0x1) << AESA_IMR_IBUFRDY_Pos)
+#define AESA_IMR_MASK               _U_(0x00010001) /**< \brief (AESA_IMR) MASK Register */
 
 /* -------- AESA_KEY : (AESA Offset: 0x20) ( /W 32) KEY Key Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -228,12 +228,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AESA_KEY_OFFSET             0x20         /**< \brief (AESA_KEY offset) Key Register */
-#define AESA_KEY_RESETVALUE         _U(0x00000000); /**< \brief (AESA_KEY reset_value) Key Register */
+#define AESA_KEY_RESETVALUE         _U_(0x00000000); /**< \brief (AESA_KEY reset_value) Key Register */
 
 #define AESA_KEY_KEY0_Pos           0            /**< \brief (AESA_KEY) Key Word 0 */
-#define AESA_KEY_KEY0_Msk           (_U(0xFFFFFFFF) << AESA_KEY_KEY0_Pos)
+#define AESA_KEY_KEY0_Msk           (_U_(0xFFFFFFFF) << AESA_KEY_KEY0_Pos)
 #define AESA_KEY_KEY0(value)        (AESA_KEY_KEY0_Msk & ((value) << AESA_KEY_KEY0_Pos))
-#define AESA_KEY_MASK               _U(0xFFFFFFFF) /**< \brief (AESA_KEY) MASK Register */
+#define AESA_KEY_MASK               _U_(0xFFFFFFFF) /**< \brief (AESA_KEY) MASK Register */
 
 /* -------- AESA_INITVECT : (AESA Offset: 0x40) ( /W 32) INITVECT Initialization Vector Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -246,12 +246,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AESA_INITVECT_OFFSET        0x40         /**< \brief (AESA_INITVECT offset) Initialization Vector Register */
-#define AESA_INITVECT_RESETVALUE    _U(0x00000000); /**< \brief (AESA_INITVECT reset_value) Initialization Vector Register */
+#define AESA_INITVECT_RESETVALUE    _U_(0x00000000); /**< \brief (AESA_INITVECT reset_value) Initialization Vector Register */
 
 #define AESA_INITVECT_INITVECT0_Pos 0            /**< \brief (AESA_INITVECT) Initialization Vector Word 0 */
-#define AESA_INITVECT_INITVECT0_Msk (_U(0xFFFFFFFF) << AESA_INITVECT_INITVECT0_Pos)
+#define AESA_INITVECT_INITVECT0_Msk (_U_(0xFFFFFFFF) << AESA_INITVECT_INITVECT0_Pos)
 #define AESA_INITVECT_INITVECT0(value) (AESA_INITVECT_INITVECT0_Msk & ((value) << AESA_INITVECT_INITVECT0_Pos))
-#define AESA_INITVECT_MASK          _U(0xFFFFFFFF) /**< \brief (AESA_INITVECT) MASK Register */
+#define AESA_INITVECT_MASK          _U_(0xFFFFFFFF) /**< \brief (AESA_INITVECT) MASK Register */
 
 /* -------- AESA_IDATA : (AESA Offset: 0x50) ( /W 32) Input Data Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -264,12 +264,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AESA_IDATA_OFFSET           0x50         /**< \brief (AESA_IDATA offset) Input Data Register */
-#define AESA_IDATA_RESETVALUE       _U(0x00000000); /**< \brief (AESA_IDATA reset_value) Input Data Register */
+#define AESA_IDATA_RESETVALUE       _U_(0x00000000); /**< \brief (AESA_IDATA reset_value) Input Data Register */
 
 #define AESA_IDATA_IDATA_Pos        0            /**< \brief (AESA_IDATA) Input Data */
-#define AESA_IDATA_IDATA_Msk        (_U(0xFFFFFFFF) << AESA_IDATA_IDATA_Pos)
+#define AESA_IDATA_IDATA_Msk        (_U_(0xFFFFFFFF) << AESA_IDATA_IDATA_Pos)
 #define AESA_IDATA_IDATA(value)     (AESA_IDATA_IDATA_Msk & ((value) << AESA_IDATA_IDATA_Pos))
-#define AESA_IDATA_MASK             _U(0xFFFFFFFF) /**< \brief (AESA_IDATA) MASK Register */
+#define AESA_IDATA_MASK             _U_(0xFFFFFFFF) /**< \brief (AESA_IDATA) MASK Register */
 
 /* -------- AESA_ODATA : (AESA Offset: 0x60) (R/  32) Output Data Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -282,12 +282,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AESA_ODATA_OFFSET           0x60         /**< \brief (AESA_ODATA offset) Output Data Register */
-#define AESA_ODATA_RESETVALUE       _U(0x00000000); /**< \brief (AESA_ODATA reset_value) Output Data Register */
+#define AESA_ODATA_RESETVALUE       _U_(0x00000000); /**< \brief (AESA_ODATA reset_value) Output Data Register */
 
 #define AESA_ODATA_ODATA_Pos        0            /**< \brief (AESA_ODATA) Output Data */
-#define AESA_ODATA_ODATA_Msk        (_U(0xFFFFFFFF) << AESA_ODATA_ODATA_Pos)
+#define AESA_ODATA_ODATA_Msk        (_U_(0xFFFFFFFF) << AESA_ODATA_ODATA_Pos)
 #define AESA_ODATA_ODATA(value)     (AESA_ODATA_ODATA_Msk & ((value) << AESA_ODATA_ODATA_Pos))
-#define AESA_ODATA_MASK             _U(0xFFFFFFFF) /**< \brief (AESA_ODATA) MASK Register */
+#define AESA_ODATA_MASK             _U_(0xFFFFFFFF) /**< \brief (AESA_ODATA) MASK Register */
 
 /* -------- AESA_DRNGSEED : (AESA Offset: 0x70) ( /W 32) DRNG Seed Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -300,12 +300,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AESA_DRNGSEED_OFFSET        0x70         /**< \brief (AESA_DRNGSEED offset) DRNG Seed Register */
-#define AESA_DRNGSEED_RESETVALUE    _U(0x00000000); /**< \brief (AESA_DRNGSEED reset_value) DRNG Seed Register */
+#define AESA_DRNGSEED_RESETVALUE    _U_(0x00000000); /**< \brief (AESA_DRNGSEED reset_value) DRNG Seed Register */
 
 #define AESA_DRNGSEED_SEED_Pos      0            /**< \brief (AESA_DRNGSEED) DRNG Seed */
-#define AESA_DRNGSEED_SEED_Msk      (_U(0xFFFFFFFF) << AESA_DRNGSEED_SEED_Pos)
+#define AESA_DRNGSEED_SEED_Msk      (_U_(0xFFFFFFFF) << AESA_DRNGSEED_SEED_Pos)
 #define AESA_DRNGSEED_SEED(value)   (AESA_DRNGSEED_SEED_Msk & ((value) << AESA_DRNGSEED_SEED_Pos))
-#define AESA_DRNGSEED_MASK          _U(0xFFFFFFFF) /**< \brief (AESA_DRNGSEED) MASK Register */
+#define AESA_DRNGSEED_MASK          _U_(0xFFFFFFFF) /**< \brief (AESA_DRNGSEED) MASK Register */
 
 /* -------- AESA_PARAMETER : (AESA Offset: 0xF8) (R/  32) Parameter Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -322,17 +322,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AESA_PARAMETER_OFFSET       0xF8         /**< \brief (AESA_PARAMETER offset) Parameter Register */
-#define AESA_PARAMETER_RESETVALUE   _U(0x00000112); /**< \brief (AESA_PARAMETER reset_value) Parameter Register */
+#define AESA_PARAMETER_RESETVALUE   _U_(0x00000112); /**< \brief (AESA_PARAMETER reset_value) Parameter Register */
 
 #define AESA_PARAMETER_KEYSIZE_Pos  0            /**< \brief (AESA_PARAMETER) Maximum Key Size */
-#define AESA_PARAMETER_KEYSIZE_Msk  (_U(0x3) << AESA_PARAMETER_KEYSIZE_Pos)
+#define AESA_PARAMETER_KEYSIZE_Msk  (_U_(0x3) << AESA_PARAMETER_KEYSIZE_Pos)
 #define AESA_PARAMETER_KEYSIZE(value) (AESA_PARAMETER_KEYSIZE_Msk & ((value) << AESA_PARAMETER_KEYSIZE_Pos))
 #define AESA_PARAMETER_OPMODE_Pos   2            /**< \brief (AESA_PARAMETER) Maximum Number of Confidentiality Modes of Operation */
-#define AESA_PARAMETER_OPMODE_Msk   (_U(0x7) << AESA_PARAMETER_OPMODE_Pos)
+#define AESA_PARAMETER_OPMODE_Msk   (_U_(0x7) << AESA_PARAMETER_OPMODE_Pos)
 #define AESA_PARAMETER_OPMODE(value) (AESA_PARAMETER_OPMODE_Msk & ((value) << AESA_PARAMETER_OPMODE_Pos))
 #define AESA_PARAMETER_CTRMEAS_Pos  8            /**< \brief (AESA_PARAMETER) Countermeasures */
-#define AESA_PARAMETER_CTRMEAS      (_U(0x1) << AESA_PARAMETER_CTRMEAS_Pos)
-#define AESA_PARAMETER_MASK         _U(0x0000011F) /**< \brief (AESA_PARAMETER) MASK Register */
+#define AESA_PARAMETER_CTRMEAS      (_U_(0x1) << AESA_PARAMETER_CTRMEAS_Pos)
+#define AESA_PARAMETER_MASK         _U_(0x0000011F) /**< \brief (AESA_PARAMETER) MASK Register */
 
 /* -------- AESA_VERSION : (AESA Offset: 0xFC) (R/  32) Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -348,15 +348,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AESA_VERSION_OFFSET         0xFC         /**< \brief (AESA_VERSION offset) Version Register */
-#define AESA_VERSION_RESETVALUE     _U(0x00000102); /**< \brief (AESA_VERSION reset_value) Version Register */
+#define AESA_VERSION_RESETVALUE     _U_(0x00000102); /**< \brief (AESA_VERSION reset_value) Version Register */
 
 #define AESA_VERSION_VERSION_Pos    0            /**< \brief (AESA_VERSION) Version Number */
-#define AESA_VERSION_VERSION_Msk    (_U(0xFFF) << AESA_VERSION_VERSION_Pos)
+#define AESA_VERSION_VERSION_Msk    (_U_(0xFFF) << AESA_VERSION_VERSION_Pos)
 #define AESA_VERSION_VERSION(value) (AESA_VERSION_VERSION_Msk & ((value) << AESA_VERSION_VERSION_Pos))
 #define AESA_VERSION_VARIANT_Pos    16           /**< \brief (AESA_VERSION) Variant Number */
-#define AESA_VERSION_VARIANT_Msk    (_U(0xF) << AESA_VERSION_VARIANT_Pos)
+#define AESA_VERSION_VARIANT_Msk    (_U_(0xF) << AESA_VERSION_VARIANT_Pos)
 #define AESA_VERSION_VARIANT(value) (AESA_VERSION_VARIANT_Msk & ((value) << AESA_VERSION_VARIANT_Pos))
-#define AESA_VERSION_MASK           _U(0x000F0FFF) /**< \brief (AESA_VERSION) MASK Register */
+#define AESA_VERSION_MASK           _U_(0x000F0FFF) /**< \brief (AESA_VERSION) MASK Register */
 
 /** \brief AesaInitvect hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/ast.h
+++ b/asf/sam/include/sam4l/component/ast.h
@@ -57,26 +57,26 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AST_CR_OFFSET               0x00         /**< \brief (AST_CR offset) Control Register */
-#define AST_CR_RESETVALUE           _U(0x00000000); /**< \brief (AST_CR reset_value) Control Register */
+#define AST_CR_RESETVALUE           _U_(0x00000000); /**< \brief (AST_CR reset_value) Control Register */
 
 #define AST_CR_EN_Pos               0            /**< \brief (AST_CR) Enable */
-#define AST_CR_EN                   (_U(0x1) << AST_CR_EN_Pos)
-#define   AST_CR_EN_0_Val                 _U(0x0)   /**< \brief (AST_CR) The AST is disabled. */
-#define   AST_CR_EN_1_Val                 _U(0x1)   /**< \brief (AST_CR) The AST is enabled */
+#define AST_CR_EN                   (_U_(0x1) << AST_CR_EN_Pos)
+#define   AST_CR_EN_0_Val                 _U_(0x0)   /**< \brief (AST_CR) The AST is disabled. */
+#define   AST_CR_EN_1_Val                 _U_(0x1)   /**< \brief (AST_CR) The AST is enabled */
 #define AST_CR_EN_0                 (AST_CR_EN_0_Val               << AST_CR_EN_Pos)
 #define AST_CR_EN_1                 (AST_CR_EN_1_Val               << AST_CR_EN_Pos)
 #define AST_CR_PCLR_Pos             1            /**< \brief (AST_CR) Prescaler Clear */
-#define AST_CR_PCLR                 (_U(0x1) << AST_CR_PCLR_Pos)
+#define AST_CR_PCLR                 (_U_(0x1) << AST_CR_PCLR_Pos)
 #define AST_CR_CAL_Pos              2            /**< \brief (AST_CR) Calendar mode */
-#define AST_CR_CAL                  (_U(0x1) << AST_CR_CAL_Pos)
+#define AST_CR_CAL                  (_U_(0x1) << AST_CR_CAL_Pos)
 #define AST_CR_CA0_Pos              8            /**< \brief (AST_CR) Clear on Alarm 0 */
-#define AST_CR_CA0                  (_U(0x1) << AST_CR_CA0_Pos)
+#define AST_CR_CA0                  (_U_(0x1) << AST_CR_CA0_Pos)
 #define AST_CR_CA1_Pos              9            /**< \brief (AST_CR) Clear on Alarm 1 */
-#define AST_CR_CA1                  (_U(0x1) << AST_CR_CA1_Pos)
+#define AST_CR_CA1                  (_U_(0x1) << AST_CR_CA1_Pos)
 #define AST_CR_PSEL_Pos             16           /**< \brief (AST_CR) Prescaler Select */
-#define AST_CR_PSEL_Msk             (_U(0x1F) << AST_CR_PSEL_Pos)
+#define AST_CR_PSEL_Msk             (_U_(0x1F) << AST_CR_PSEL_Pos)
 #define AST_CR_PSEL(value)          (AST_CR_PSEL_Msk & ((value) << AST_CR_PSEL_Pos))
-#define AST_CR_MASK                 _U(0x001F0307) /**< \brief (AST_CR) MASK Register */
+#define AST_CR_MASK                 _U_(0x001F0307) /**< \brief (AST_CR) MASK Register */
 
 /* -------- AST_CV : (AST Offset: 0x04) (R/W 32) Counter Value -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -89,12 +89,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AST_CV_OFFSET               0x04         /**< \brief (AST_CV offset) Counter Value */
-#define AST_CV_RESETVALUE           _U(0x00000000); /**< \brief (AST_CV reset_value) Counter Value */
+#define AST_CV_RESETVALUE           _U_(0x00000000); /**< \brief (AST_CV reset_value) Counter Value */
 
 #define AST_CV_VALUE_Pos            0            /**< \brief (AST_CV) AST Value */
-#define AST_CV_VALUE_Msk            (_U(0xFFFFFFFF) << AST_CV_VALUE_Pos)
+#define AST_CV_VALUE_Msk            (_U_(0xFFFFFFFF) << AST_CV_VALUE_Pos)
 #define AST_CV_VALUE(value)         (AST_CV_VALUE_Msk & ((value) << AST_CV_VALUE_Pos))
-#define AST_CV_MASK                 _U(0xFFFFFFFF) /**< \brief (AST_CV) MASK Register */
+#define AST_CV_MASK                 _U_(0xFFFFFFFF) /**< \brief (AST_CV) MASK Register */
 
 /* -------- AST_SR : (AST Offset: 0x08) (R/  32) Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -120,35 +120,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AST_SR_OFFSET               0x08         /**< \brief (AST_SR offset) Status Register */
-#define AST_SR_RESETVALUE           _U(0x00000000); /**< \brief (AST_SR reset_value) Status Register */
+#define AST_SR_RESETVALUE           _U_(0x00000000); /**< \brief (AST_SR reset_value) Status Register */
 
 #define AST_SR_OVF_Pos              0            /**< \brief (AST_SR) Overflow */
-#define AST_SR_OVF                  (_U(0x1) << AST_SR_OVF_Pos)
+#define AST_SR_OVF                  (_U_(0x1) << AST_SR_OVF_Pos)
 #define AST_SR_ALARM0_Pos           8            /**< \brief (AST_SR) Alarm 0 */
-#define AST_SR_ALARM0               (_U(0x1) << AST_SR_ALARM0_Pos)
+#define AST_SR_ALARM0               (_U_(0x1) << AST_SR_ALARM0_Pos)
 #define AST_SR_ALARM1_Pos           9            /**< \brief (AST_SR) Alarm 1 */
-#define AST_SR_ALARM1               (_U(0x1) << AST_SR_ALARM1_Pos)
+#define AST_SR_ALARM1               (_U_(0x1) << AST_SR_ALARM1_Pos)
 #define AST_SR_PER0_Pos             16           /**< \brief (AST_SR) Periodic 0 */
-#define AST_SR_PER0                 (_U(0x1) << AST_SR_PER0_Pos)
+#define AST_SR_PER0                 (_U_(0x1) << AST_SR_PER0_Pos)
 #define AST_SR_PER1_Pos             17           /**< \brief (AST_SR) Periodic 1 */
-#define AST_SR_PER1                 (_U(0x1) << AST_SR_PER1_Pos)
+#define AST_SR_PER1                 (_U_(0x1) << AST_SR_PER1_Pos)
 #define AST_SR_BUSY_Pos             24           /**< \brief (AST_SR) AST Busy */
-#define AST_SR_BUSY                 (_U(0x1) << AST_SR_BUSY_Pos)
-#define   AST_SR_BUSY_0_Val               _U(0x0)   /**< \brief (AST_SR) The AST accepts writes to CV, WER, DTR, SCR, AR, PIR and CR */
-#define   AST_SR_BUSY_1_Val               _U(0x1)   /**< \brief (AST_SR) The AST is busy and will discard writes to CV, WER, DTR, SCR, AR, PIR and CR */
+#define AST_SR_BUSY                 (_U_(0x1) << AST_SR_BUSY_Pos)
+#define   AST_SR_BUSY_0_Val               _U_(0x0)   /**< \brief (AST_SR) The AST accepts writes to CV, WER, DTR, SCR, AR, PIR and CR */
+#define   AST_SR_BUSY_1_Val               _U_(0x1)   /**< \brief (AST_SR) The AST is busy and will discard writes to CV, WER, DTR, SCR, AR, PIR and CR */
 #define AST_SR_BUSY_0               (AST_SR_BUSY_0_Val             << AST_SR_BUSY_Pos)
 #define AST_SR_BUSY_1               (AST_SR_BUSY_1_Val             << AST_SR_BUSY_Pos)
 #define AST_SR_READY_Pos            25           /**< \brief (AST_SR) AST Ready */
-#define AST_SR_READY                (_U(0x1) << AST_SR_READY_Pos)
+#define AST_SR_READY                (_U_(0x1) << AST_SR_READY_Pos)
 #define AST_SR_CLKBUSY_Pos          28           /**< \brief (AST_SR) Clock Busy */
-#define AST_SR_CLKBUSY              (_U(0x1) << AST_SR_CLKBUSY_Pos)
-#define   AST_SR_CLKBUSY_0_Val            _U(0x0)   /**< \brief (AST_SR) The clock is ready and can be changed */
-#define   AST_SR_CLKBUSY_1_Val            _U(0x1)   /**< \brief (AST_SR) CEN has been written and the clock is busy */
+#define AST_SR_CLKBUSY              (_U_(0x1) << AST_SR_CLKBUSY_Pos)
+#define   AST_SR_CLKBUSY_0_Val            _U_(0x0)   /**< \brief (AST_SR) The clock is ready and can be changed */
+#define   AST_SR_CLKBUSY_1_Val            _U_(0x1)   /**< \brief (AST_SR) CEN has been written and the clock is busy */
 #define AST_SR_CLKBUSY_0            (AST_SR_CLKBUSY_0_Val          << AST_SR_CLKBUSY_Pos)
 #define AST_SR_CLKBUSY_1            (AST_SR_CLKBUSY_1_Val          << AST_SR_CLKBUSY_Pos)
 #define AST_SR_CLKRDY_Pos           29           /**< \brief (AST_SR) Clock Ready */
-#define AST_SR_CLKRDY               (_U(0x1) << AST_SR_CLKRDY_Pos)
-#define AST_SR_MASK                 _U(0x33030301) /**< \brief (AST_SR) MASK Register */
+#define AST_SR_CLKRDY               (_U_(0x1) << AST_SR_CLKRDY_Pos)
+#define AST_SR_MASK                 _U_(0x33030301) /**< \brief (AST_SR) MASK Register */
 
 /* -------- AST_SCR : (AST Offset: 0x0C) ( /W 32) Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -172,23 +172,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AST_SCR_OFFSET              0x0C         /**< \brief (AST_SCR offset) Status Clear Register */
-#define AST_SCR_RESETVALUE          _U(0x00000000); /**< \brief (AST_SCR reset_value) Status Clear Register */
+#define AST_SCR_RESETVALUE          _U_(0x00000000); /**< \brief (AST_SCR reset_value) Status Clear Register */
 
 #define AST_SCR_OVF_Pos             0            /**< \brief (AST_SCR) Overflow */
-#define AST_SCR_OVF                 (_U(0x1) << AST_SCR_OVF_Pos)
+#define AST_SCR_OVF                 (_U_(0x1) << AST_SCR_OVF_Pos)
 #define AST_SCR_ALARM0_Pos          8            /**< \brief (AST_SCR) Alarm 0 */
-#define AST_SCR_ALARM0              (_U(0x1) << AST_SCR_ALARM0_Pos)
+#define AST_SCR_ALARM0              (_U_(0x1) << AST_SCR_ALARM0_Pos)
 #define AST_SCR_ALARM1_Pos          9            /**< \brief (AST_SCR) Alarm 1 */
-#define AST_SCR_ALARM1              (_U(0x1) << AST_SCR_ALARM1_Pos)
+#define AST_SCR_ALARM1              (_U_(0x1) << AST_SCR_ALARM1_Pos)
 #define AST_SCR_PER0_Pos            16           /**< \brief (AST_SCR) Periodic 0 */
-#define AST_SCR_PER0                (_U(0x1) << AST_SCR_PER0_Pos)
+#define AST_SCR_PER0                (_U_(0x1) << AST_SCR_PER0_Pos)
 #define AST_SCR_PER1_Pos            17           /**< \brief (AST_SCR) Periodic 1 */
-#define AST_SCR_PER1                (_U(0x1) << AST_SCR_PER1_Pos)
+#define AST_SCR_PER1                (_U_(0x1) << AST_SCR_PER1_Pos)
 #define AST_SCR_READY_Pos           25           /**< \brief (AST_SCR) AST Ready */
-#define AST_SCR_READY               (_U(0x1) << AST_SCR_READY_Pos)
+#define AST_SCR_READY               (_U_(0x1) << AST_SCR_READY_Pos)
 #define AST_SCR_CLKRDY_Pos          29           /**< \brief (AST_SCR) Clock Ready */
-#define AST_SCR_CLKRDY              (_U(0x1) << AST_SCR_CLKRDY_Pos)
-#define AST_SCR_MASK                _U(0x22030301) /**< \brief (AST_SCR) MASK Register */
+#define AST_SCR_CLKRDY              (_U_(0x1) << AST_SCR_CLKRDY_Pos)
+#define AST_SCR_MASK                _U_(0x22030301) /**< \brief (AST_SCR) MASK Register */
 
 /* -------- AST_IER : (AST Offset: 0x10) ( /W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -212,51 +212,51 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AST_IER_OFFSET              0x10         /**< \brief (AST_IER offset) Interrupt Enable Register */
-#define AST_IER_RESETVALUE          _U(0x00000000); /**< \brief (AST_IER reset_value) Interrupt Enable Register */
+#define AST_IER_RESETVALUE          _U_(0x00000000); /**< \brief (AST_IER reset_value) Interrupt Enable Register */
 
 #define AST_IER_OVF_Pos             0            /**< \brief (AST_IER) Overflow */
-#define AST_IER_OVF                 (_U(0x1) << AST_IER_OVF_Pos)
-#define   AST_IER_OVF_0_Val               _U(0x0)   /**< \brief (AST_IER) No effect */
-#define   AST_IER_OVF_1_Val               _U(0x1)   /**< \brief (AST_IER) Enable Interrupt. */
+#define AST_IER_OVF                 (_U_(0x1) << AST_IER_OVF_Pos)
+#define   AST_IER_OVF_0_Val               _U_(0x0)   /**< \brief (AST_IER) No effect */
+#define   AST_IER_OVF_1_Val               _U_(0x1)   /**< \brief (AST_IER) Enable Interrupt. */
 #define AST_IER_OVF_0               (AST_IER_OVF_0_Val             << AST_IER_OVF_Pos)
 #define AST_IER_OVF_1               (AST_IER_OVF_1_Val             << AST_IER_OVF_Pos)
 #define AST_IER_ALARM0_Pos          8            /**< \brief (AST_IER) Alarm 0 */
-#define AST_IER_ALARM0              (_U(0x1) << AST_IER_ALARM0_Pos)
-#define   AST_IER_ALARM0_0_Val            _U(0x0)   /**< \brief (AST_IER) No effect */
-#define   AST_IER_ALARM0_1_Val            _U(0x1)   /**< \brief (AST_IER) Enable interrupt */
+#define AST_IER_ALARM0              (_U_(0x1) << AST_IER_ALARM0_Pos)
+#define   AST_IER_ALARM0_0_Val            _U_(0x0)   /**< \brief (AST_IER) No effect */
+#define   AST_IER_ALARM0_1_Val            _U_(0x1)   /**< \brief (AST_IER) Enable interrupt */
 #define AST_IER_ALARM0_0            (AST_IER_ALARM0_0_Val          << AST_IER_ALARM0_Pos)
 #define AST_IER_ALARM0_1            (AST_IER_ALARM0_1_Val          << AST_IER_ALARM0_Pos)
 #define AST_IER_ALARM1_Pos          9            /**< \brief (AST_IER) Alarm 1 */
-#define AST_IER_ALARM1              (_U(0x1) << AST_IER_ALARM1_Pos)
-#define   AST_IER_ALARM1_0_Val            _U(0x0)   /**< \brief (AST_IER) No effect */
-#define   AST_IER_ALARM1_1_Val            _U(0x1)   /**< \brief (AST_IER) Enable interrupt */
+#define AST_IER_ALARM1              (_U_(0x1) << AST_IER_ALARM1_Pos)
+#define   AST_IER_ALARM1_0_Val            _U_(0x0)   /**< \brief (AST_IER) No effect */
+#define   AST_IER_ALARM1_1_Val            _U_(0x1)   /**< \brief (AST_IER) Enable interrupt */
 #define AST_IER_ALARM1_0            (AST_IER_ALARM1_0_Val          << AST_IER_ALARM1_Pos)
 #define AST_IER_ALARM1_1            (AST_IER_ALARM1_1_Val          << AST_IER_ALARM1_Pos)
 #define AST_IER_PER0_Pos            16           /**< \brief (AST_IER) Periodic 0 */
-#define AST_IER_PER0                (_U(0x1) << AST_IER_PER0_Pos)
-#define   AST_IER_PER0_0_Val              _U(0x0)   /**< \brief (AST_IER) No effect */
-#define   AST_IER_PER0_1_Val              _U(0x1)   /**< \brief (AST_IER) Enable interrupt */
+#define AST_IER_PER0                (_U_(0x1) << AST_IER_PER0_Pos)
+#define   AST_IER_PER0_0_Val              _U_(0x0)   /**< \brief (AST_IER) No effect */
+#define   AST_IER_PER0_1_Val              _U_(0x1)   /**< \brief (AST_IER) Enable interrupt */
 #define AST_IER_PER0_0              (AST_IER_PER0_0_Val            << AST_IER_PER0_Pos)
 #define AST_IER_PER0_1              (AST_IER_PER0_1_Val            << AST_IER_PER0_Pos)
 #define AST_IER_PER1_Pos            17           /**< \brief (AST_IER) Periodic 1 */
-#define AST_IER_PER1                (_U(0x1) << AST_IER_PER1_Pos)
-#define   AST_IER_PER1_0_Val              _U(0x0)   /**< \brief (AST_IER) No effect */
-#define   AST_IER_PER1_1_Val              _U(0x1)   /**< \brief (AST_IER) Enable interrupt */
+#define AST_IER_PER1                (_U_(0x1) << AST_IER_PER1_Pos)
+#define   AST_IER_PER1_0_Val              _U_(0x0)   /**< \brief (AST_IER) No effect */
+#define   AST_IER_PER1_1_Val              _U_(0x1)   /**< \brief (AST_IER) Enable interrupt */
 #define AST_IER_PER1_0              (AST_IER_PER1_0_Val            << AST_IER_PER1_Pos)
 #define AST_IER_PER1_1              (AST_IER_PER1_1_Val            << AST_IER_PER1_Pos)
 #define AST_IER_READY_Pos           25           /**< \brief (AST_IER) AST Ready */
-#define AST_IER_READY               (_U(0x1) << AST_IER_READY_Pos)
-#define   AST_IER_READY_0_Val             _U(0x0)   /**< \brief (AST_IER) No effect */
-#define   AST_IER_READY_1_Val             _U(0x1)   /**< \brief (AST_IER) Enable interrupt */
+#define AST_IER_READY               (_U_(0x1) << AST_IER_READY_Pos)
+#define   AST_IER_READY_0_Val             _U_(0x0)   /**< \brief (AST_IER) No effect */
+#define   AST_IER_READY_1_Val             _U_(0x1)   /**< \brief (AST_IER) Enable interrupt */
 #define AST_IER_READY_0             (AST_IER_READY_0_Val           << AST_IER_READY_Pos)
 #define AST_IER_READY_1             (AST_IER_READY_1_Val           << AST_IER_READY_Pos)
 #define AST_IER_CLKRDY_Pos          29           /**< \brief (AST_IER) Clock Ready */
-#define AST_IER_CLKRDY              (_U(0x1) << AST_IER_CLKRDY_Pos)
-#define   AST_IER_CLKRDY_0_Val            _U(0x0)   /**< \brief (AST_IER) No effect */
-#define   AST_IER_CLKRDY_1_Val            _U(0x1)   /**< \brief (AST_IER) Enable interrupt */
+#define AST_IER_CLKRDY              (_U_(0x1) << AST_IER_CLKRDY_Pos)
+#define   AST_IER_CLKRDY_0_Val            _U_(0x0)   /**< \brief (AST_IER) No effect */
+#define   AST_IER_CLKRDY_1_Val            _U_(0x1)   /**< \brief (AST_IER) Enable interrupt */
 #define AST_IER_CLKRDY_0            (AST_IER_CLKRDY_0_Val          << AST_IER_CLKRDY_Pos)
 #define AST_IER_CLKRDY_1            (AST_IER_CLKRDY_1_Val          << AST_IER_CLKRDY_Pos)
-#define AST_IER_MASK                _U(0x22030301) /**< \brief (AST_IER) MASK Register */
+#define AST_IER_MASK                _U_(0x22030301) /**< \brief (AST_IER) MASK Register */
 
 /* -------- AST_IDR : (AST Offset: 0x14) ( /W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -280,51 +280,51 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AST_IDR_OFFSET              0x14         /**< \brief (AST_IDR offset) Interrupt Disable Register */
-#define AST_IDR_RESETVALUE          _U(0x00000000); /**< \brief (AST_IDR reset_value) Interrupt Disable Register */
+#define AST_IDR_RESETVALUE          _U_(0x00000000); /**< \brief (AST_IDR reset_value) Interrupt Disable Register */
 
 #define AST_IDR_OVF_Pos             0            /**< \brief (AST_IDR) Overflow */
-#define AST_IDR_OVF                 (_U(0x1) << AST_IDR_OVF_Pos)
-#define   AST_IDR_OVF_0_Val               _U(0x0)   /**< \brief (AST_IDR) No effect */
-#define   AST_IDR_OVF_1_Val               _U(0x1)   /**< \brief (AST_IDR) Disable Interrupt. */
+#define AST_IDR_OVF                 (_U_(0x1) << AST_IDR_OVF_Pos)
+#define   AST_IDR_OVF_0_Val               _U_(0x0)   /**< \brief (AST_IDR) No effect */
+#define   AST_IDR_OVF_1_Val               _U_(0x1)   /**< \brief (AST_IDR) Disable Interrupt. */
 #define AST_IDR_OVF_0               (AST_IDR_OVF_0_Val             << AST_IDR_OVF_Pos)
 #define AST_IDR_OVF_1               (AST_IDR_OVF_1_Val             << AST_IDR_OVF_Pos)
 #define AST_IDR_ALARM0_Pos          8            /**< \brief (AST_IDR) Alarm 0 */
-#define AST_IDR_ALARM0              (_U(0x1) << AST_IDR_ALARM0_Pos)
-#define   AST_IDR_ALARM0_0_Val            _U(0x0)   /**< \brief (AST_IDR) No effect */
-#define   AST_IDR_ALARM0_1_Val            _U(0x1)   /**< \brief (AST_IDR) Disable interrupt */
+#define AST_IDR_ALARM0              (_U_(0x1) << AST_IDR_ALARM0_Pos)
+#define   AST_IDR_ALARM0_0_Val            _U_(0x0)   /**< \brief (AST_IDR) No effect */
+#define   AST_IDR_ALARM0_1_Val            _U_(0x1)   /**< \brief (AST_IDR) Disable interrupt */
 #define AST_IDR_ALARM0_0            (AST_IDR_ALARM0_0_Val          << AST_IDR_ALARM0_Pos)
 #define AST_IDR_ALARM0_1            (AST_IDR_ALARM0_1_Val          << AST_IDR_ALARM0_Pos)
 #define AST_IDR_ALARM1_Pos          9            /**< \brief (AST_IDR) Alarm 1 */
-#define AST_IDR_ALARM1              (_U(0x1) << AST_IDR_ALARM1_Pos)
-#define   AST_IDR_ALARM1_0_Val            _U(0x0)   /**< \brief (AST_IDR) No effect */
-#define   AST_IDR_ALARM1_1_Val            _U(0x1)   /**< \brief (AST_IDR) Disable interrupt */
+#define AST_IDR_ALARM1              (_U_(0x1) << AST_IDR_ALARM1_Pos)
+#define   AST_IDR_ALARM1_0_Val            _U_(0x0)   /**< \brief (AST_IDR) No effect */
+#define   AST_IDR_ALARM1_1_Val            _U_(0x1)   /**< \brief (AST_IDR) Disable interrupt */
 #define AST_IDR_ALARM1_0            (AST_IDR_ALARM1_0_Val          << AST_IDR_ALARM1_Pos)
 #define AST_IDR_ALARM1_1            (AST_IDR_ALARM1_1_Val          << AST_IDR_ALARM1_Pos)
 #define AST_IDR_PER0_Pos            16           /**< \brief (AST_IDR) Periodic 0 */
-#define AST_IDR_PER0                (_U(0x1) << AST_IDR_PER0_Pos)
-#define   AST_IDR_PER0_0_Val              _U(0x0)   /**< \brief (AST_IDR) No effet */
-#define   AST_IDR_PER0_1_Val              _U(0x1)   /**< \brief (AST_IDR) Disalbe interrupt */
+#define AST_IDR_PER0                (_U_(0x1) << AST_IDR_PER0_Pos)
+#define   AST_IDR_PER0_0_Val              _U_(0x0)   /**< \brief (AST_IDR) No effet */
+#define   AST_IDR_PER0_1_Val              _U_(0x1)   /**< \brief (AST_IDR) Disalbe interrupt */
 #define AST_IDR_PER0_0              (AST_IDR_PER0_0_Val            << AST_IDR_PER0_Pos)
 #define AST_IDR_PER0_1              (AST_IDR_PER0_1_Val            << AST_IDR_PER0_Pos)
 #define AST_IDR_PER1_Pos            17           /**< \brief (AST_IDR) Periodic 1 */
-#define AST_IDR_PER1                (_U(0x1) << AST_IDR_PER1_Pos)
-#define   AST_IDR_PER1_0_Val              _U(0x0)   /**< \brief (AST_IDR) No effect */
-#define   AST_IDR_PER1_1_Val              _U(0x1)   /**< \brief (AST_IDR) Disable interrupt */
+#define AST_IDR_PER1                (_U_(0x1) << AST_IDR_PER1_Pos)
+#define   AST_IDR_PER1_0_Val              _U_(0x0)   /**< \brief (AST_IDR) No effect */
+#define   AST_IDR_PER1_1_Val              _U_(0x1)   /**< \brief (AST_IDR) Disable interrupt */
 #define AST_IDR_PER1_0              (AST_IDR_PER1_0_Val            << AST_IDR_PER1_Pos)
 #define AST_IDR_PER1_1              (AST_IDR_PER1_1_Val            << AST_IDR_PER1_Pos)
 #define AST_IDR_READY_Pos           25           /**< \brief (AST_IDR) AST Ready */
-#define AST_IDR_READY               (_U(0x1) << AST_IDR_READY_Pos)
-#define   AST_IDR_READY_0_Val             _U(0x0)   /**< \brief (AST_IDR) No effect */
-#define   AST_IDR_READY_1_Val             _U(0x1)   /**< \brief (AST_IDR) Disable interrupt */
+#define AST_IDR_READY               (_U_(0x1) << AST_IDR_READY_Pos)
+#define   AST_IDR_READY_0_Val             _U_(0x0)   /**< \brief (AST_IDR) No effect */
+#define   AST_IDR_READY_1_Val             _U_(0x1)   /**< \brief (AST_IDR) Disable interrupt */
 #define AST_IDR_READY_0             (AST_IDR_READY_0_Val           << AST_IDR_READY_Pos)
 #define AST_IDR_READY_1             (AST_IDR_READY_1_Val           << AST_IDR_READY_Pos)
 #define AST_IDR_CLKRDY_Pos          29           /**< \brief (AST_IDR) Clock Ready */
-#define AST_IDR_CLKRDY              (_U(0x1) << AST_IDR_CLKRDY_Pos)
-#define   AST_IDR_CLKRDY_0_Val            _U(0x0)   /**< \brief (AST_IDR) No effect */
-#define   AST_IDR_CLKRDY_1_Val            _U(0x1)   /**< \brief (AST_IDR) Disable interrupt */
+#define AST_IDR_CLKRDY              (_U_(0x1) << AST_IDR_CLKRDY_Pos)
+#define   AST_IDR_CLKRDY_0_Val            _U_(0x0)   /**< \brief (AST_IDR) No effect */
+#define   AST_IDR_CLKRDY_1_Val            _U_(0x1)   /**< \brief (AST_IDR) Disable interrupt */
 #define AST_IDR_CLKRDY_0            (AST_IDR_CLKRDY_0_Val          << AST_IDR_CLKRDY_Pos)
 #define AST_IDR_CLKRDY_1            (AST_IDR_CLKRDY_1_Val          << AST_IDR_CLKRDY_Pos)
-#define AST_IDR_MASK                _U(0x22030301) /**< \brief (AST_IDR) MASK Register */
+#define AST_IDR_MASK                _U_(0x22030301) /**< \brief (AST_IDR) MASK Register */
 
 /* -------- AST_IMR : (AST Offset: 0x18) (R/  32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -348,51 +348,51 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AST_IMR_OFFSET              0x18         /**< \brief (AST_IMR offset) Interrupt Mask Register */
-#define AST_IMR_RESETVALUE          _U(0x00000000); /**< \brief (AST_IMR reset_value) Interrupt Mask Register */
+#define AST_IMR_RESETVALUE          _U_(0x00000000); /**< \brief (AST_IMR reset_value) Interrupt Mask Register */
 
 #define AST_IMR_OVF_Pos             0            /**< \brief (AST_IMR) Overflow */
-#define AST_IMR_OVF                 (_U(0x1) << AST_IMR_OVF_Pos)
-#define   AST_IMR_OVF_0_Val               _U(0x0)   /**< \brief (AST_IMR) Interrupt is disabled */
-#define   AST_IMR_OVF_1_Val               _U(0x1)   /**< \brief (AST_IMR) Interrupt is enabled. */
+#define AST_IMR_OVF                 (_U_(0x1) << AST_IMR_OVF_Pos)
+#define   AST_IMR_OVF_0_Val               _U_(0x0)   /**< \brief (AST_IMR) Interrupt is disabled */
+#define   AST_IMR_OVF_1_Val               _U_(0x1)   /**< \brief (AST_IMR) Interrupt is enabled. */
 #define AST_IMR_OVF_0               (AST_IMR_OVF_0_Val             << AST_IMR_OVF_Pos)
 #define AST_IMR_OVF_1               (AST_IMR_OVF_1_Val             << AST_IMR_OVF_Pos)
 #define AST_IMR_ALARM0_Pos          8            /**< \brief (AST_IMR) Alarm 0 */
-#define AST_IMR_ALARM0              (_U(0x1) << AST_IMR_ALARM0_Pos)
-#define   AST_IMR_ALARM0_0_Val            _U(0x0)   /**< \brief (AST_IMR) Interupt is disabled */
-#define   AST_IMR_ALARM0_1_Val            _U(0x1)   /**< \brief (AST_IMR) Interrupt is enabled */
+#define AST_IMR_ALARM0              (_U_(0x1) << AST_IMR_ALARM0_Pos)
+#define   AST_IMR_ALARM0_0_Val            _U_(0x0)   /**< \brief (AST_IMR) Interupt is disabled */
+#define   AST_IMR_ALARM0_1_Val            _U_(0x1)   /**< \brief (AST_IMR) Interrupt is enabled */
 #define AST_IMR_ALARM0_0            (AST_IMR_ALARM0_0_Val          << AST_IMR_ALARM0_Pos)
 #define AST_IMR_ALARM0_1            (AST_IMR_ALARM0_1_Val          << AST_IMR_ALARM0_Pos)
 #define AST_IMR_ALARM1_Pos          9            /**< \brief (AST_IMR) Alarm 1 */
-#define AST_IMR_ALARM1              (_U(0x1) << AST_IMR_ALARM1_Pos)
-#define   AST_IMR_ALARM1_0_Val            _U(0x0)   /**< \brief (AST_IMR) Interrupt is disabled */
-#define   AST_IMR_ALARM1_1_Val            _U(0x1)   /**< \brief (AST_IMR) Interrupt is enabled */
+#define AST_IMR_ALARM1              (_U_(0x1) << AST_IMR_ALARM1_Pos)
+#define   AST_IMR_ALARM1_0_Val            _U_(0x0)   /**< \brief (AST_IMR) Interrupt is disabled */
+#define   AST_IMR_ALARM1_1_Val            _U_(0x1)   /**< \brief (AST_IMR) Interrupt is enabled */
 #define AST_IMR_ALARM1_0            (AST_IMR_ALARM1_0_Val          << AST_IMR_ALARM1_Pos)
 #define AST_IMR_ALARM1_1            (AST_IMR_ALARM1_1_Val          << AST_IMR_ALARM1_Pos)
 #define AST_IMR_PER0_Pos            16           /**< \brief (AST_IMR) Periodic 0 */
-#define AST_IMR_PER0                (_U(0x1) << AST_IMR_PER0_Pos)
-#define   AST_IMR_PER0_0_Val              _U(0x0)   /**< \brief (AST_IMR) Interrupt is disabled */
-#define   AST_IMR_PER0_1_Val              _U(0x1)   /**< \brief (AST_IMR) Interrupt is enabled */
+#define AST_IMR_PER0                (_U_(0x1) << AST_IMR_PER0_Pos)
+#define   AST_IMR_PER0_0_Val              _U_(0x0)   /**< \brief (AST_IMR) Interrupt is disabled */
+#define   AST_IMR_PER0_1_Val              _U_(0x1)   /**< \brief (AST_IMR) Interrupt is enabled */
 #define AST_IMR_PER0_0              (AST_IMR_PER0_0_Val            << AST_IMR_PER0_Pos)
 #define AST_IMR_PER0_1              (AST_IMR_PER0_1_Val            << AST_IMR_PER0_Pos)
 #define AST_IMR_PER1_Pos            17           /**< \brief (AST_IMR) Periodic 1 */
-#define AST_IMR_PER1                (_U(0x1) << AST_IMR_PER1_Pos)
-#define   AST_IMR_PER1_0_Val              _U(0x0)   /**< \brief (AST_IMR) Interrupt is disabled */
-#define   AST_IMR_PER1_1_Val              _U(0x1)   /**< \brief (AST_IMR) Interrupt is enabled */
+#define AST_IMR_PER1                (_U_(0x1) << AST_IMR_PER1_Pos)
+#define   AST_IMR_PER1_0_Val              _U_(0x0)   /**< \brief (AST_IMR) Interrupt is disabled */
+#define   AST_IMR_PER1_1_Val              _U_(0x1)   /**< \brief (AST_IMR) Interrupt is enabled */
 #define AST_IMR_PER1_0              (AST_IMR_PER1_0_Val            << AST_IMR_PER1_Pos)
 #define AST_IMR_PER1_1              (AST_IMR_PER1_1_Val            << AST_IMR_PER1_Pos)
 #define AST_IMR_READY_Pos           25           /**< \brief (AST_IMR) AST Ready */
-#define AST_IMR_READY               (_U(0x1) << AST_IMR_READY_Pos)
-#define   AST_IMR_READY_0_Val             _U(0x0)   /**< \brief (AST_IMR) Interrupt is disabled */
-#define   AST_IMR_READY_1_Val             _U(0x1)   /**< \brief (AST_IMR) Interrupt is enabled */
+#define AST_IMR_READY               (_U_(0x1) << AST_IMR_READY_Pos)
+#define   AST_IMR_READY_0_Val             _U_(0x0)   /**< \brief (AST_IMR) Interrupt is disabled */
+#define   AST_IMR_READY_1_Val             _U_(0x1)   /**< \brief (AST_IMR) Interrupt is enabled */
 #define AST_IMR_READY_0             (AST_IMR_READY_0_Val           << AST_IMR_READY_Pos)
 #define AST_IMR_READY_1             (AST_IMR_READY_1_Val           << AST_IMR_READY_Pos)
 #define AST_IMR_CLKRDY_Pos          29           /**< \brief (AST_IMR) Clock Ready */
-#define AST_IMR_CLKRDY              (_U(0x1) << AST_IMR_CLKRDY_Pos)
-#define   AST_IMR_CLKRDY_0_Val            _U(0x0)   /**< \brief (AST_IMR) Interrupt is disabled */
-#define   AST_IMR_CLKRDY_1_Val            _U(0x1)   /**< \brief (AST_IMR) Interrupt is enabled */
+#define AST_IMR_CLKRDY              (_U_(0x1) << AST_IMR_CLKRDY_Pos)
+#define   AST_IMR_CLKRDY_0_Val            _U_(0x0)   /**< \brief (AST_IMR) Interrupt is disabled */
+#define   AST_IMR_CLKRDY_1_Val            _U_(0x1)   /**< \brief (AST_IMR) Interrupt is enabled */
 #define AST_IMR_CLKRDY_0            (AST_IMR_CLKRDY_0_Val          << AST_IMR_CLKRDY_Pos)
 #define AST_IMR_CLKRDY_1            (AST_IMR_CLKRDY_1_Val          << AST_IMR_CLKRDY_Pos)
-#define AST_IMR_MASK                _U(0x22030301) /**< \brief (AST_IMR) MASK Register */
+#define AST_IMR_MASK                _U_(0x22030301) /**< \brief (AST_IMR) MASK Register */
 
 /* -------- AST_WER : (AST Offset: 0x1C) (R/W 32) Wake Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -412,39 +412,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AST_WER_OFFSET              0x1C         /**< \brief (AST_WER offset) Wake Enable Register */
-#define AST_WER_RESETVALUE          _U(0x00000000); /**< \brief (AST_WER reset_value) Wake Enable Register */
+#define AST_WER_RESETVALUE          _U_(0x00000000); /**< \brief (AST_WER reset_value) Wake Enable Register */
 
 #define AST_WER_OVF_Pos             0            /**< \brief (AST_WER) Overflow */
-#define AST_WER_OVF                 (_U(0x1) << AST_WER_OVF_Pos)
-#define   AST_WER_OVF_0_Val               _U(0x0)   /**< \brief (AST_WER) The corresponing event will not wake up the CPU from sleep mode */
-#define   AST_WER_OVF_1_Val               _U(0x1)   /**< \brief (AST_WER) The corresponding event will wake up the CPU from sleep mode */
+#define AST_WER_OVF                 (_U_(0x1) << AST_WER_OVF_Pos)
+#define   AST_WER_OVF_0_Val               _U_(0x0)   /**< \brief (AST_WER) The corresponing event will not wake up the CPU from sleep mode */
+#define   AST_WER_OVF_1_Val               _U_(0x1)   /**< \brief (AST_WER) The corresponding event will wake up the CPU from sleep mode */
 #define AST_WER_OVF_0               (AST_WER_OVF_0_Val             << AST_WER_OVF_Pos)
 #define AST_WER_OVF_1               (AST_WER_OVF_1_Val             << AST_WER_OVF_Pos)
 #define AST_WER_ALARM0_Pos          8            /**< \brief (AST_WER) Alarm 0 */
-#define AST_WER_ALARM0              (_U(0x1) << AST_WER_ALARM0_Pos)
-#define   AST_WER_ALARM0_0_Val            _U(0x0)   /**< \brief (AST_WER) The corresponing event will not wake up the CPU from sleep mode */
-#define   AST_WER_ALARM0_1_Val            _U(0x1)   /**< \brief (AST_WER) The corresponding event will wake up the CPU from sleep mode */
+#define AST_WER_ALARM0              (_U_(0x1) << AST_WER_ALARM0_Pos)
+#define   AST_WER_ALARM0_0_Val            _U_(0x0)   /**< \brief (AST_WER) The corresponing event will not wake up the CPU from sleep mode */
+#define   AST_WER_ALARM0_1_Val            _U_(0x1)   /**< \brief (AST_WER) The corresponding event will wake up the CPU from sleep mode */
 #define AST_WER_ALARM0_0            (AST_WER_ALARM0_0_Val          << AST_WER_ALARM0_Pos)
 #define AST_WER_ALARM0_1            (AST_WER_ALARM0_1_Val          << AST_WER_ALARM0_Pos)
 #define AST_WER_ALARM1_Pos          9            /**< \brief (AST_WER) Alarm 1 */
-#define AST_WER_ALARM1              (_U(0x1) << AST_WER_ALARM1_Pos)
-#define   AST_WER_ALARM1_0_Val            _U(0x0)   /**< \brief (AST_WER) The corresponing event will not wake up the CPU from sleep mode */
-#define   AST_WER_ALARM1_1_Val            _U(0x1)   /**< \brief (AST_WER) The corresponding event will wake up the CPU from sleep mode */
+#define AST_WER_ALARM1              (_U_(0x1) << AST_WER_ALARM1_Pos)
+#define   AST_WER_ALARM1_0_Val            _U_(0x0)   /**< \brief (AST_WER) The corresponing event will not wake up the CPU from sleep mode */
+#define   AST_WER_ALARM1_1_Val            _U_(0x1)   /**< \brief (AST_WER) The corresponding event will wake up the CPU from sleep mode */
 #define AST_WER_ALARM1_0            (AST_WER_ALARM1_0_Val          << AST_WER_ALARM1_Pos)
 #define AST_WER_ALARM1_1            (AST_WER_ALARM1_1_Val          << AST_WER_ALARM1_Pos)
 #define AST_WER_PER0_Pos            16           /**< \brief (AST_WER) Periodic 0 */
-#define AST_WER_PER0                (_U(0x1) << AST_WER_PER0_Pos)
-#define   AST_WER_PER0_0_Val              _U(0x0)   /**< \brief (AST_WER) The corresponing event will not wake up the CPU from sleep mode */
-#define   AST_WER_PER0_1_Val              _U(0x1)   /**< \brief (AST_WER) The corresponding event will wake up the CPU from sleep mode */
+#define AST_WER_PER0                (_U_(0x1) << AST_WER_PER0_Pos)
+#define   AST_WER_PER0_0_Val              _U_(0x0)   /**< \brief (AST_WER) The corresponing event will not wake up the CPU from sleep mode */
+#define   AST_WER_PER0_1_Val              _U_(0x1)   /**< \brief (AST_WER) The corresponding event will wake up the CPU from sleep mode */
 #define AST_WER_PER0_0              (AST_WER_PER0_0_Val            << AST_WER_PER0_Pos)
 #define AST_WER_PER0_1              (AST_WER_PER0_1_Val            << AST_WER_PER0_Pos)
 #define AST_WER_PER1_Pos            17           /**< \brief (AST_WER) Periodic 1 */
-#define AST_WER_PER1                (_U(0x1) << AST_WER_PER1_Pos)
-#define   AST_WER_PER1_0_Val              _U(0x0)   /**< \brief (AST_WER) The corresponing event will not wake up the CPU from sleep mode */
-#define   AST_WER_PER1_1_Val              _U(0x1)   /**< \brief (AST_WER) The corresponding event will wake up the CPU from sleep mode */
+#define AST_WER_PER1                (_U_(0x1) << AST_WER_PER1_Pos)
+#define   AST_WER_PER1_0_Val              _U_(0x0)   /**< \brief (AST_WER) The corresponing event will not wake up the CPU from sleep mode */
+#define   AST_WER_PER1_1_Val              _U_(0x1)   /**< \brief (AST_WER) The corresponding event will wake up the CPU from sleep mode */
 #define AST_WER_PER1_0              (AST_WER_PER1_0_Val            << AST_WER_PER1_Pos)
 #define AST_WER_PER1_1              (AST_WER_PER1_1_Val            << AST_WER_PER1_Pos)
-#define AST_WER_MASK                _U(0x00030301) /**< \brief (AST_WER) MASK Register */
+#define AST_WER_MASK                _U_(0x00030301) /**< \brief (AST_WER) MASK Register */
 
 /* -------- AST_AR0 : (AST Offset: 0x20) (R/W 32) Alarm Register 0 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -457,12 +457,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AST_AR0_OFFSET              0x20         /**< \brief (AST_AR0 offset) Alarm Register 0 */
-#define AST_AR0_RESETVALUE          _U(0x00000000); /**< \brief (AST_AR0 reset_value) Alarm Register 0 */
+#define AST_AR0_RESETVALUE          _U_(0x00000000); /**< \brief (AST_AR0 reset_value) Alarm Register 0 */
 
 #define AST_AR0_VALUE_Pos           0            /**< \brief (AST_AR0) Alarm Value */
-#define AST_AR0_VALUE_Msk           (_U(0xFFFFFFFF) << AST_AR0_VALUE_Pos)
+#define AST_AR0_VALUE_Msk           (_U_(0xFFFFFFFF) << AST_AR0_VALUE_Pos)
 #define AST_AR0_VALUE(value)        (AST_AR0_VALUE_Msk & ((value) << AST_AR0_VALUE_Pos))
-#define AST_AR0_MASK                _U(0xFFFFFFFF) /**< \brief (AST_AR0) MASK Register */
+#define AST_AR0_MASK                _U_(0xFFFFFFFF) /**< \brief (AST_AR0) MASK Register */
 
 /* -------- AST_AR1 : (AST Offset: 0x24) (R/W 32) Alarm Register 1 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -475,12 +475,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AST_AR1_OFFSET              0x24         /**< \brief (AST_AR1 offset) Alarm Register 1 */
-#define AST_AR1_RESETVALUE          _U(0x00000000); /**< \brief (AST_AR1 reset_value) Alarm Register 1 */
+#define AST_AR1_RESETVALUE          _U_(0x00000000); /**< \brief (AST_AR1 reset_value) Alarm Register 1 */
 
 #define AST_AR1_VALUE_Pos           0            /**< \brief (AST_AR1) Alarm Value */
-#define AST_AR1_VALUE_Msk           (_U(0xFFFFFFFF) << AST_AR1_VALUE_Pos)
+#define AST_AR1_VALUE_Msk           (_U_(0xFFFFFFFF) << AST_AR1_VALUE_Pos)
 #define AST_AR1_VALUE(value)        (AST_AR1_VALUE_Msk & ((value) << AST_AR1_VALUE_Pos))
-#define AST_AR1_MASK                _U(0xFFFFFFFF) /**< \brief (AST_AR1) MASK Register */
+#define AST_AR1_MASK                _U_(0xFFFFFFFF) /**< \brief (AST_AR1) MASK Register */
 
 /* -------- AST_PIR0 : (AST Offset: 0x30) (R/W 32) Periodic Interval Register 0 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -494,12 +494,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AST_PIR0_OFFSET             0x30         /**< \brief (AST_PIR0 offset) Periodic Interval Register 0 */
-#define AST_PIR0_RESETVALUE         _U(0x00000000); /**< \brief (AST_PIR0 reset_value) Periodic Interval Register 0 */
+#define AST_PIR0_RESETVALUE         _U_(0x00000000); /**< \brief (AST_PIR0 reset_value) Periodic Interval Register 0 */
 
 #define AST_PIR0_INSEL_Pos          0            /**< \brief (AST_PIR0) Interval Select */
-#define AST_PIR0_INSEL_Msk          (_U(0x1F) << AST_PIR0_INSEL_Pos)
+#define AST_PIR0_INSEL_Msk          (_U_(0x1F) << AST_PIR0_INSEL_Pos)
 #define AST_PIR0_INSEL(value)       (AST_PIR0_INSEL_Msk & ((value) << AST_PIR0_INSEL_Pos))
-#define AST_PIR0_MASK               _U(0x0000001F) /**< \brief (AST_PIR0) MASK Register */
+#define AST_PIR0_MASK               _U_(0x0000001F) /**< \brief (AST_PIR0) MASK Register */
 
 /* -------- AST_PIR1 : (AST Offset: 0x34) (R/W 32) Periodic Interval Register 1 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -513,12 +513,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AST_PIR1_OFFSET             0x34         /**< \brief (AST_PIR1 offset) Periodic Interval Register 1 */
-#define AST_PIR1_RESETVALUE         _U(0x00000000); /**< \brief (AST_PIR1 reset_value) Periodic Interval Register 1 */
+#define AST_PIR1_RESETVALUE         _U_(0x00000000); /**< \brief (AST_PIR1 reset_value) Periodic Interval Register 1 */
 
 #define AST_PIR1_INSEL_Pos          0            /**< \brief (AST_PIR1) Interval Select */
-#define AST_PIR1_INSEL_Msk          (_U(0x1F) << AST_PIR1_INSEL_Pos)
+#define AST_PIR1_INSEL_Msk          (_U_(0x1F) << AST_PIR1_INSEL_Pos)
 #define AST_PIR1_INSEL(value)       (AST_PIR1_INSEL_Msk & ((value) << AST_PIR1_INSEL_Pos))
-#define AST_PIR1_MASK               _U(0x0000001F) /**< \brief (AST_PIR1) MASK Register */
+#define AST_PIR1_MASK               _U_(0x0000001F) /**< \brief (AST_PIR1) MASK Register */
 
 /* -------- AST_CLOCK : (AST Offset: 0x40) (R/W 32) Clock Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -534,28 +534,28 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AST_CLOCK_OFFSET            0x40         /**< \brief (AST_CLOCK offset) Clock Control Register */
-#define AST_CLOCK_RESETVALUE        _U(0x00000000); /**< \brief (AST_CLOCK reset_value) Clock Control Register */
+#define AST_CLOCK_RESETVALUE        _U_(0x00000000); /**< \brief (AST_CLOCK reset_value) Clock Control Register */
 
 #define AST_CLOCK_CEN_Pos           0            /**< \brief (AST_CLOCK) Clock Enable */
-#define AST_CLOCK_CEN               (_U(0x1) << AST_CLOCK_CEN_Pos)
-#define   AST_CLOCK_CEN_0_Val             _U(0x0)   /**< \brief (AST_CLOCK) The clock is disabled */
-#define   AST_CLOCK_CEN_1_Val             _U(0x1)   /**< \brief (AST_CLOCK) The clock is enabled */
+#define AST_CLOCK_CEN               (_U_(0x1) << AST_CLOCK_CEN_Pos)
+#define   AST_CLOCK_CEN_0_Val             _U_(0x0)   /**< \brief (AST_CLOCK) The clock is disabled */
+#define   AST_CLOCK_CEN_1_Val             _U_(0x1)   /**< \brief (AST_CLOCK) The clock is enabled */
 #define AST_CLOCK_CEN_0             (AST_CLOCK_CEN_0_Val           << AST_CLOCK_CEN_Pos)
 #define AST_CLOCK_CEN_1             (AST_CLOCK_CEN_1_Val           << AST_CLOCK_CEN_Pos)
 #define AST_CLOCK_CSSEL_Pos         8            /**< \brief (AST_CLOCK) Clock Source Selection */
-#define AST_CLOCK_CSSEL_Msk         (_U(0x7) << AST_CLOCK_CSSEL_Pos)
+#define AST_CLOCK_CSSEL_Msk         (_U_(0x7) << AST_CLOCK_CSSEL_Pos)
 #define AST_CLOCK_CSSEL(value)      (AST_CLOCK_CSSEL_Msk & ((value) << AST_CLOCK_CSSEL_Pos))
-#define   AST_CLOCK_CSSEL_SLOWCLOCK_Val   _U(0x0)   /**< \brief (AST_CLOCK) Slow clock */
-#define   AST_CLOCK_CSSEL_32KHZCLK_Val    _U(0x1)   /**< \brief (AST_CLOCK) 32 kHz clock */
-#define   AST_CLOCK_CSSEL_PBCLOCK_Val     _U(0x2)   /**< \brief (AST_CLOCK) PB clock */
-#define   AST_CLOCK_CSSEL_GCLK_Val        _U(0x3)   /**< \brief (AST_CLOCK) Generic clock */
-#define   AST_CLOCK_CSSEL_1KHZCLK_Val     _U(0x4)   /**< \brief (AST_CLOCK) 1kHz clock from 32 kHz oscillator */
+#define   AST_CLOCK_CSSEL_SLOWCLOCK_Val   _U_(0x0)   /**< \brief (AST_CLOCK) Slow clock */
+#define   AST_CLOCK_CSSEL_32KHZCLK_Val    _U_(0x1)   /**< \brief (AST_CLOCK) 32 kHz clock */
+#define   AST_CLOCK_CSSEL_PBCLOCK_Val     _U_(0x2)   /**< \brief (AST_CLOCK) PB clock */
+#define   AST_CLOCK_CSSEL_GCLK_Val        _U_(0x3)   /**< \brief (AST_CLOCK) Generic clock */
+#define   AST_CLOCK_CSSEL_1KHZCLK_Val     _U_(0x4)   /**< \brief (AST_CLOCK) 1kHz clock from 32 kHz oscillator */
 #define AST_CLOCK_CSSEL_SLOWCLOCK   (AST_CLOCK_CSSEL_SLOWCLOCK_Val << AST_CLOCK_CSSEL_Pos)
 #define AST_CLOCK_CSSEL_32KHZCLK    (AST_CLOCK_CSSEL_32KHZCLK_Val  << AST_CLOCK_CSSEL_Pos)
 #define AST_CLOCK_CSSEL_PBCLOCK     (AST_CLOCK_CSSEL_PBCLOCK_Val   << AST_CLOCK_CSSEL_Pos)
 #define AST_CLOCK_CSSEL_GCLK        (AST_CLOCK_CSSEL_GCLK_Val      << AST_CLOCK_CSSEL_Pos)
 #define AST_CLOCK_CSSEL_1KHZCLK     (AST_CLOCK_CSSEL_1KHZCLK_Val   << AST_CLOCK_CSSEL_Pos)
-#define AST_CLOCK_MASK              _U(0x00000701) /**< \brief (AST_CLOCK) MASK Register */
+#define AST_CLOCK_MASK              _U_(0x00000701) /**< \brief (AST_CLOCK) MASK Register */
 
 /* -------- AST_DTR : (AST Offset: 0x44) (R/W 32) Digital Tuner Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -572,17 +572,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AST_DTR_OFFSET              0x44         /**< \brief (AST_DTR offset) Digital Tuner Register */
-#define AST_DTR_RESETVALUE          _U(0x00000000); /**< \brief (AST_DTR reset_value) Digital Tuner Register */
+#define AST_DTR_RESETVALUE          _U_(0x00000000); /**< \brief (AST_DTR reset_value) Digital Tuner Register */
 
 #define AST_DTR_EXP_Pos             0            /**< \brief (AST_DTR) EXP */
-#define AST_DTR_EXP_Msk             (_U(0x1F) << AST_DTR_EXP_Pos)
+#define AST_DTR_EXP_Msk             (_U_(0x1F) << AST_DTR_EXP_Pos)
 #define AST_DTR_EXP(value)          (AST_DTR_EXP_Msk & ((value) << AST_DTR_EXP_Pos))
 #define AST_DTR_ADD_Pos             5            /**< \brief (AST_DTR) ADD */
-#define AST_DTR_ADD                 (_U(0x1) << AST_DTR_ADD_Pos)
+#define AST_DTR_ADD                 (_U_(0x1) << AST_DTR_ADD_Pos)
 #define AST_DTR_VALUE_Pos           8            /**< \brief (AST_DTR) VALUE */
-#define AST_DTR_VALUE_Msk           (_U(0xFF) << AST_DTR_VALUE_Pos)
+#define AST_DTR_VALUE_Msk           (_U_(0xFF) << AST_DTR_VALUE_Pos)
 #define AST_DTR_VALUE(value)        (AST_DTR_VALUE_Msk & ((value) << AST_DTR_VALUE_Pos))
-#define AST_DTR_MASK                _U(0x0000FF3F) /**< \brief (AST_DTR) MASK Register */
+#define AST_DTR_MASK                _U_(0x0000FF3F) /**< \brief (AST_DTR) MASK Register */
 
 /* -------- AST_EVE : (AST Offset: 0x48) ( /W 32) Event Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -602,19 +602,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AST_EVE_OFFSET              0x48         /**< \brief (AST_EVE offset) Event Enable Register */
-#define AST_EVE_RESETVALUE          _U(0x00000000); /**< \brief (AST_EVE reset_value) Event Enable Register */
+#define AST_EVE_RESETVALUE          _U_(0x00000000); /**< \brief (AST_EVE reset_value) Event Enable Register */
 
 #define AST_EVE_OVF_Pos             0            /**< \brief (AST_EVE) Overflow */
-#define AST_EVE_OVF                 (_U(0x1) << AST_EVE_OVF_Pos)
+#define AST_EVE_OVF                 (_U_(0x1) << AST_EVE_OVF_Pos)
 #define AST_EVE_ALARM0_Pos          8            /**< \brief (AST_EVE) Alarm 0 */
-#define AST_EVE_ALARM0              (_U(0x1) << AST_EVE_ALARM0_Pos)
+#define AST_EVE_ALARM0              (_U_(0x1) << AST_EVE_ALARM0_Pos)
 #define AST_EVE_ALARM1_Pos          9            /**< \brief (AST_EVE) Alarm 1 */
-#define AST_EVE_ALARM1              (_U(0x1) << AST_EVE_ALARM1_Pos)
+#define AST_EVE_ALARM1              (_U_(0x1) << AST_EVE_ALARM1_Pos)
 #define AST_EVE_PER0_Pos            16           /**< \brief (AST_EVE) Perioidc 0 */
-#define AST_EVE_PER0                (_U(0x1) << AST_EVE_PER0_Pos)
+#define AST_EVE_PER0                (_U_(0x1) << AST_EVE_PER0_Pos)
 #define AST_EVE_PER1_Pos            17           /**< \brief (AST_EVE) Periodic 1 */
-#define AST_EVE_PER1                (_U(0x1) << AST_EVE_PER1_Pos)
-#define AST_EVE_MASK                _U(0x00030301) /**< \brief (AST_EVE) MASK Register */
+#define AST_EVE_PER1                (_U_(0x1) << AST_EVE_PER1_Pos)
+#define AST_EVE_MASK                _U_(0x00030301) /**< \brief (AST_EVE) MASK Register */
 
 /* -------- AST_EVD : (AST Offset: 0x4C) ( /W 32) Event Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -634,19 +634,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AST_EVD_OFFSET              0x4C         /**< \brief (AST_EVD offset) Event Disable Register */
-#define AST_EVD_RESETVALUE          _U(0x00000000); /**< \brief (AST_EVD reset_value) Event Disable Register */
+#define AST_EVD_RESETVALUE          _U_(0x00000000); /**< \brief (AST_EVD reset_value) Event Disable Register */
 
 #define AST_EVD_OVF_Pos             0            /**< \brief (AST_EVD) Overflow */
-#define AST_EVD_OVF                 (_U(0x1) << AST_EVD_OVF_Pos)
+#define AST_EVD_OVF                 (_U_(0x1) << AST_EVD_OVF_Pos)
 #define AST_EVD_ALARM0_Pos          8            /**< \brief (AST_EVD) Alarm 0 */
-#define AST_EVD_ALARM0              (_U(0x1) << AST_EVD_ALARM0_Pos)
+#define AST_EVD_ALARM0              (_U_(0x1) << AST_EVD_ALARM0_Pos)
 #define AST_EVD_ALARM1_Pos          9            /**< \brief (AST_EVD) Alarm 1 */
-#define AST_EVD_ALARM1              (_U(0x1) << AST_EVD_ALARM1_Pos)
+#define AST_EVD_ALARM1              (_U_(0x1) << AST_EVD_ALARM1_Pos)
 #define AST_EVD_PER0_Pos            16           /**< \brief (AST_EVD) Perioidc 0 */
-#define AST_EVD_PER0                (_U(0x1) << AST_EVD_PER0_Pos)
+#define AST_EVD_PER0                (_U_(0x1) << AST_EVD_PER0_Pos)
 #define AST_EVD_PER1_Pos            17           /**< \brief (AST_EVD) Periodic 1 */
-#define AST_EVD_PER1                (_U(0x1) << AST_EVD_PER1_Pos)
-#define AST_EVD_MASK                _U(0x00030301) /**< \brief (AST_EVD) MASK Register */
+#define AST_EVD_PER1                (_U_(0x1) << AST_EVD_PER1_Pos)
+#define AST_EVD_MASK                _U_(0x00030301) /**< \brief (AST_EVD) MASK Register */
 
 /* -------- AST_EVM : (AST Offset: 0x50) (R/  32) Event Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -666,19 +666,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AST_EVM_OFFSET              0x50         /**< \brief (AST_EVM offset) Event Mask Register */
-#define AST_EVM_RESETVALUE          _U(0x00000000); /**< \brief (AST_EVM reset_value) Event Mask Register */
+#define AST_EVM_RESETVALUE          _U_(0x00000000); /**< \brief (AST_EVM reset_value) Event Mask Register */
 
 #define AST_EVM_OVF_Pos             0            /**< \brief (AST_EVM) Overflow */
-#define AST_EVM_OVF                 (_U(0x1) << AST_EVM_OVF_Pos)
+#define AST_EVM_OVF                 (_U_(0x1) << AST_EVM_OVF_Pos)
 #define AST_EVM_ALARM0_Pos          8            /**< \brief (AST_EVM) Alarm 0 */
-#define AST_EVM_ALARM0              (_U(0x1) << AST_EVM_ALARM0_Pos)
+#define AST_EVM_ALARM0              (_U_(0x1) << AST_EVM_ALARM0_Pos)
 #define AST_EVM_ALARM1_Pos          9            /**< \brief (AST_EVM) Alarm 1 */
-#define AST_EVM_ALARM1              (_U(0x1) << AST_EVM_ALARM1_Pos)
+#define AST_EVM_ALARM1              (_U_(0x1) << AST_EVM_ALARM1_Pos)
 #define AST_EVM_PER0_Pos            16           /**< \brief (AST_EVM) Perioidc 0 */
-#define AST_EVM_PER0                (_U(0x1) << AST_EVM_PER0_Pos)
+#define AST_EVM_PER0                (_U_(0x1) << AST_EVM_PER0_Pos)
 #define AST_EVM_PER1_Pos            17           /**< \brief (AST_EVM) Periodic 1 */
-#define AST_EVM_PER1                (_U(0x1) << AST_EVM_PER1_Pos)
-#define AST_EVM_MASK                _U(0x00030301) /**< \brief (AST_EVM) MASK Register */
+#define AST_EVM_PER1                (_U_(0x1) << AST_EVM_PER1_Pos)
+#define AST_EVM_MASK                _U_(0x00030301) /**< \brief (AST_EVM) MASK Register */
 
 /* -------- AST_CALV : (AST Offset: 0x54) (R/W 32) Calendar Value -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -696,27 +696,27 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AST_CALV_OFFSET             0x54         /**< \brief (AST_CALV offset) Calendar Value */
-#define AST_CALV_RESETVALUE         _U(0x00000000); /**< \brief (AST_CALV reset_value) Calendar Value */
+#define AST_CALV_RESETVALUE         _U_(0x00000000); /**< \brief (AST_CALV reset_value) Calendar Value */
 
 #define AST_CALV_SEC_Pos            0            /**< \brief (AST_CALV) Second */
-#define AST_CALV_SEC_Msk            (_U(0x3F) << AST_CALV_SEC_Pos)
+#define AST_CALV_SEC_Msk            (_U_(0x3F) << AST_CALV_SEC_Pos)
 #define AST_CALV_SEC(value)         (AST_CALV_SEC_Msk & ((value) << AST_CALV_SEC_Pos))
 #define AST_CALV_MIN_Pos            6            /**< \brief (AST_CALV) Minute */
-#define AST_CALV_MIN_Msk            (_U(0x3F) << AST_CALV_MIN_Pos)
+#define AST_CALV_MIN_Msk            (_U_(0x3F) << AST_CALV_MIN_Pos)
 #define AST_CALV_MIN(value)         (AST_CALV_MIN_Msk & ((value) << AST_CALV_MIN_Pos))
 #define AST_CALV_HOUR_Pos           12           /**< \brief (AST_CALV) Hour */
-#define AST_CALV_HOUR_Msk           (_U(0x1F) << AST_CALV_HOUR_Pos)
+#define AST_CALV_HOUR_Msk           (_U_(0x1F) << AST_CALV_HOUR_Pos)
 #define AST_CALV_HOUR(value)        (AST_CALV_HOUR_Msk & ((value) << AST_CALV_HOUR_Pos))
 #define AST_CALV_DAY_Pos            17           /**< \brief (AST_CALV) Day */
-#define AST_CALV_DAY_Msk            (_U(0x1F) << AST_CALV_DAY_Pos)
+#define AST_CALV_DAY_Msk            (_U_(0x1F) << AST_CALV_DAY_Pos)
 #define AST_CALV_DAY(value)         (AST_CALV_DAY_Msk & ((value) << AST_CALV_DAY_Pos))
 #define AST_CALV_MONTH_Pos          22           /**< \brief (AST_CALV) Month */
-#define AST_CALV_MONTH_Msk          (_U(0xF) << AST_CALV_MONTH_Pos)
+#define AST_CALV_MONTH_Msk          (_U_(0xF) << AST_CALV_MONTH_Pos)
 #define AST_CALV_MONTH(value)       (AST_CALV_MONTH_Msk & ((value) << AST_CALV_MONTH_Pos))
 #define AST_CALV_YEAR_Pos           26           /**< \brief (AST_CALV) Year */
-#define AST_CALV_YEAR_Msk           (_U(0x3F) << AST_CALV_YEAR_Pos)
+#define AST_CALV_YEAR_Msk           (_U_(0x3F) << AST_CALV_YEAR_Pos)
 #define AST_CALV_YEAR(value)        (AST_CALV_YEAR_Msk & ((value) << AST_CALV_YEAR_Pos))
-#define AST_CALV_MASK               _U(0xFFFFFFFF) /**< \brief (AST_CALV) MASK Register */
+#define AST_CALV_MASK               _U_(0xFFFFFFFF) /**< \brief (AST_CALV) MASK Register */
 
 /* -------- AST_PARAMETER : (AST Offset: 0xF0) (R/  32) Parameter Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -744,54 +744,54 @@ typedef union {
 #define AST_PARAMETER_OFFSET        0xF0         /**< \brief (AST_PARAMETER offset) Parameter Register */
 
 #define AST_PARAMETER_DT_Pos        0            /**< \brief (AST_PARAMETER) Digital Tuner */
-#define AST_PARAMETER_DT            (_U(0x1) << AST_PARAMETER_DT_Pos)
-#define   AST_PARAMETER_DT_OFF_Val        _U(0x0)   /**< \brief (AST_PARAMETER) Digital tuner off */
-#define   AST_PARAMETER_DT_ON_Val         _U(0x1)   /**< \brief (AST_PARAMETER) Digital tuner on */
+#define AST_PARAMETER_DT            (_U_(0x1) << AST_PARAMETER_DT_Pos)
+#define   AST_PARAMETER_DT_OFF_Val        _U_(0x0)   /**< \brief (AST_PARAMETER) Digital tuner off */
+#define   AST_PARAMETER_DT_ON_Val         _U_(0x1)   /**< \brief (AST_PARAMETER) Digital tuner on */
 #define AST_PARAMETER_DT_OFF        (AST_PARAMETER_DT_OFF_Val      << AST_PARAMETER_DT_Pos)
 #define AST_PARAMETER_DT_ON         (AST_PARAMETER_DT_ON_Val       << AST_PARAMETER_DT_Pos)
 #define AST_PARAMETER_DTEXPWA_Pos   1            /**< \brief (AST_PARAMETER) Digital Tuner Exponent Writeable */
-#define AST_PARAMETER_DTEXPWA       (_U(0x1) << AST_PARAMETER_DTEXPWA_Pos)
-#define   AST_PARAMETER_DTEXPWA_0_Val     _U(0x0)   /**< \brief (AST_PARAMETER) Digital tuner exponent is a constant value. Writes to EXP bitfield in DTR will be discarded. */
-#define   AST_PARAMETER_DTEXPWA_1_Val     _U(0x1)   /**< \brief (AST_PARAMETER) Digital tuner exponent is chosen by writing to EXP bitfield in DTR */
+#define AST_PARAMETER_DTEXPWA       (_U_(0x1) << AST_PARAMETER_DTEXPWA_Pos)
+#define   AST_PARAMETER_DTEXPWA_0_Val     _U_(0x0)   /**< \brief (AST_PARAMETER) Digital tuner exponent is a constant value. Writes to EXP bitfield in DTR will be discarded. */
+#define   AST_PARAMETER_DTEXPWA_1_Val     _U_(0x1)   /**< \brief (AST_PARAMETER) Digital tuner exponent is chosen by writing to EXP bitfield in DTR */
 #define AST_PARAMETER_DTEXPWA_0     (AST_PARAMETER_DTEXPWA_0_Val   << AST_PARAMETER_DTEXPWA_Pos)
 #define AST_PARAMETER_DTEXPWA_1     (AST_PARAMETER_DTEXPWA_1_Val   << AST_PARAMETER_DTEXPWA_Pos)
 #define AST_PARAMETER_DTEXPVALUE_Pos 2            /**< \brief (AST_PARAMETER) Digital Tuner Exponent Value */
-#define AST_PARAMETER_DTEXPVALUE_Msk (_U(0x1F) << AST_PARAMETER_DTEXPVALUE_Pos)
+#define AST_PARAMETER_DTEXPVALUE_Msk (_U_(0x1F) << AST_PARAMETER_DTEXPVALUE_Pos)
 #define AST_PARAMETER_DTEXPVALUE(value) (AST_PARAMETER_DTEXPVALUE_Msk & ((value) << AST_PARAMETER_DTEXPVALUE_Pos))
 #define AST_PARAMETER_NUMAR_Pos     8            /**< \brief (AST_PARAMETER) Number of alarm comparators */
-#define AST_PARAMETER_NUMAR_Msk     (_U(0x3) << AST_PARAMETER_NUMAR_Pos)
+#define AST_PARAMETER_NUMAR_Msk     (_U_(0x3) << AST_PARAMETER_NUMAR_Pos)
 #define AST_PARAMETER_NUMAR(value)  (AST_PARAMETER_NUMAR_Msk & ((value) << AST_PARAMETER_NUMAR_Pos))
-#define   AST_PARAMETER_NUMAR_ZERO_Val    _U(0x0)   /**< \brief (AST_PARAMETER) No alarm comparators */
-#define   AST_PARAMETER_NUMAR_ONE_Val     _U(0x1)   /**< \brief (AST_PARAMETER) One alarm comparator */
-#define   AST_PARAMETER_NUMAR_TWO_Val     _U(0x2)   /**< \brief (AST_PARAMETER) Two alarm comparators */
+#define   AST_PARAMETER_NUMAR_ZERO_Val    _U_(0x0)   /**< \brief (AST_PARAMETER) No alarm comparators */
+#define   AST_PARAMETER_NUMAR_ONE_Val     _U_(0x1)   /**< \brief (AST_PARAMETER) One alarm comparator */
+#define   AST_PARAMETER_NUMAR_TWO_Val     _U_(0x2)   /**< \brief (AST_PARAMETER) Two alarm comparators */
 #define AST_PARAMETER_NUMAR_ZERO    (AST_PARAMETER_NUMAR_ZERO_Val  << AST_PARAMETER_NUMAR_Pos)
 #define AST_PARAMETER_NUMAR_ONE     (AST_PARAMETER_NUMAR_ONE_Val   << AST_PARAMETER_NUMAR_Pos)
 #define AST_PARAMETER_NUMAR_TWO     (AST_PARAMETER_NUMAR_TWO_Val   << AST_PARAMETER_NUMAR_Pos)
 #define AST_PARAMETER_NUMPIR_Pos    12           /**< \brief (AST_PARAMETER) Number of periodic comparators */
-#define AST_PARAMETER_NUMPIR        (_U(0x1) << AST_PARAMETER_NUMPIR_Pos)
-#define   AST_PARAMETER_NUMPIR_ONE_Val    _U(0x0)   /**< \brief (AST_PARAMETER) One periodic comparator */
-#define   AST_PARAMETER_NUMPIR_TWO_Val    _U(0x1)   /**< \brief (AST_PARAMETER) Two periodic comparators */
+#define AST_PARAMETER_NUMPIR        (_U_(0x1) << AST_PARAMETER_NUMPIR_Pos)
+#define   AST_PARAMETER_NUMPIR_ONE_Val    _U_(0x0)   /**< \brief (AST_PARAMETER) One periodic comparator */
+#define   AST_PARAMETER_NUMPIR_TWO_Val    _U_(0x1)   /**< \brief (AST_PARAMETER) Two periodic comparators */
 #define AST_PARAMETER_NUMPIR_ONE    (AST_PARAMETER_NUMPIR_ONE_Val  << AST_PARAMETER_NUMPIR_Pos)
 #define AST_PARAMETER_NUMPIR_TWO    (AST_PARAMETER_NUMPIR_TWO_Val  << AST_PARAMETER_NUMPIR_Pos)
 #define AST_PARAMETER_PIR0WA_Pos    14           /**< \brief (AST_PARAMETER) Periodic Interval 0 Writeable */
-#define AST_PARAMETER_PIR0WA        (_U(0x1) << AST_PARAMETER_PIR0WA_Pos)
-#define   AST_PARAMETER_PIR0WA_0_Val      _U(0x0)   /**< \brief (AST_PARAMETER) Periodic alarm prescaler 0 tapping is a constant value. Writes to INSEL bitfield in PIR0 will be discarded. */
-#define   AST_PARAMETER_PIR0WA_1_Val      _U(0x1)   /**< \brief (AST_PARAMETER) Periodic alarm prescaler 0 tapping is chosen by writing to INSEL bitfield in PIR0 */
+#define AST_PARAMETER_PIR0WA        (_U_(0x1) << AST_PARAMETER_PIR0WA_Pos)
+#define   AST_PARAMETER_PIR0WA_0_Val      _U_(0x0)   /**< \brief (AST_PARAMETER) Periodic alarm prescaler 0 tapping is a constant value. Writes to INSEL bitfield in PIR0 will be discarded. */
+#define   AST_PARAMETER_PIR0WA_1_Val      _U_(0x1)   /**< \brief (AST_PARAMETER) Periodic alarm prescaler 0 tapping is chosen by writing to INSEL bitfield in PIR0 */
 #define AST_PARAMETER_PIR0WA_0      (AST_PARAMETER_PIR0WA_0_Val    << AST_PARAMETER_PIR0WA_Pos)
 #define AST_PARAMETER_PIR0WA_1      (AST_PARAMETER_PIR0WA_1_Val    << AST_PARAMETER_PIR0WA_Pos)
 #define AST_PARAMETER_PIR1WA_Pos    15           /**< \brief (AST_PARAMETER) Periodic Interval 1 Writeable */
-#define AST_PARAMETER_PIR1WA        (_U(0x1) << AST_PARAMETER_PIR1WA_Pos)
-#define   AST_PARAMETER_PIR1WA_0_Val      _U(0x0)   /**< \brief (AST_PARAMETER) Writes to PIR1 will be discarded */
-#define   AST_PARAMETER_PIR1WA_1_Val      _U(0x1)   /**< \brief (AST_PARAMETER) PIR1 can be written */
+#define AST_PARAMETER_PIR1WA        (_U_(0x1) << AST_PARAMETER_PIR1WA_Pos)
+#define   AST_PARAMETER_PIR1WA_0_Val      _U_(0x0)   /**< \brief (AST_PARAMETER) Writes to PIR1 will be discarded */
+#define   AST_PARAMETER_PIR1WA_1_Val      _U_(0x1)   /**< \brief (AST_PARAMETER) PIR1 can be written */
 #define AST_PARAMETER_PIR1WA_0      (AST_PARAMETER_PIR1WA_0_Val    << AST_PARAMETER_PIR1WA_Pos)
 #define AST_PARAMETER_PIR1WA_1      (AST_PARAMETER_PIR1WA_1_Val    << AST_PARAMETER_PIR1WA_Pos)
 #define AST_PARAMETER_PER0VALUE_Pos 16           /**< \brief (AST_PARAMETER) Periodic Interval 0 Value */
-#define AST_PARAMETER_PER0VALUE_Msk (_U(0x1F) << AST_PARAMETER_PER0VALUE_Pos)
+#define AST_PARAMETER_PER0VALUE_Msk (_U_(0x1F) << AST_PARAMETER_PER0VALUE_Pos)
 #define AST_PARAMETER_PER0VALUE(value) (AST_PARAMETER_PER0VALUE_Msk & ((value) << AST_PARAMETER_PER0VALUE_Pos))
 #define AST_PARAMETER_PER1VALUE_Pos 24           /**< \brief (AST_PARAMETER) Periodic Interval 1 Value */
-#define AST_PARAMETER_PER1VALUE_Msk (_U(0x1F) << AST_PARAMETER_PER1VALUE_Pos)
+#define AST_PARAMETER_PER1VALUE_Msk (_U_(0x1F) << AST_PARAMETER_PER1VALUE_Pos)
 #define AST_PARAMETER_PER1VALUE(value) (AST_PARAMETER_PER1VALUE_Msk & ((value) << AST_PARAMETER_PER1VALUE_Pos))
-#define AST_PARAMETER_MASK          _U(0x1F1FD37F) /**< \brief (AST_PARAMETER) MASK Register */
+#define AST_PARAMETER_MASK          _U_(0x1F1FD37F) /**< \brief (AST_PARAMETER) MASK Register */
 
 /* -------- AST_VERSION : (AST Offset: 0xFC) (R/  32) Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -807,15 +807,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AST_VERSION_OFFSET          0xFC         /**< \brief (AST_VERSION offset) Version Register */
-#define AST_VERSION_RESETVALUE      _U(0x00000311); /**< \brief (AST_VERSION reset_value) Version Register */
+#define AST_VERSION_RESETVALUE      _U_(0x00000311); /**< \brief (AST_VERSION reset_value) Version Register */
 
 #define AST_VERSION_VERSION_Pos     0            /**< \brief (AST_VERSION) Version Number */
-#define AST_VERSION_VERSION_Msk     (_U(0xFFF) << AST_VERSION_VERSION_Pos)
+#define AST_VERSION_VERSION_Msk     (_U_(0xFFF) << AST_VERSION_VERSION_Pos)
 #define AST_VERSION_VERSION(value)  (AST_VERSION_VERSION_Msk & ((value) << AST_VERSION_VERSION_Pos))
 #define AST_VERSION_VARIANT_Pos     16           /**< \brief (AST_VERSION) Variant Number */
-#define AST_VERSION_VARIANT_Msk     (_U(0xF) << AST_VERSION_VARIANT_Pos)
+#define AST_VERSION_VARIANT_Msk     (_U_(0xF) << AST_VERSION_VARIANT_Pos)
 #define AST_VERSION_VARIANT(value)  (AST_VERSION_VARIANT_Msk & ((value) << AST_VERSION_VARIANT_Pos))
-#define AST_VERSION_MASK            _U(0x000F0FFF) /**< \brief (AST_VERSION) MASK Register */
+#define AST_VERSION_MASK            _U_(0x000F0FFF) /**< \brief (AST_VERSION) MASK Register */
 
 /** \brief AST hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/ast.h
+++ b/asf/sam/include/sam4l/component/ast.h
@@ -1,0 +1,880 @@
+/**
+ * \file
+ *
+ * \brief Component description for AST
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_AST_COMPONENT_
+#define _SAM4L_AST_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR AST */
+/* ========================================================================== */
+/** \addtogroup SAM4L_AST Asynchronous Timer */
+/*@{*/
+
+#define AST_I7532
+#define REV_AST                     0x311
+
+/* -------- AST_CR : (AST Offset: 0x00) (R/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EN:1;             /*!< bit:      0  Enable                             */
+    uint32_t PCLR:1;           /*!< bit:      1  Prescaler Clear                    */
+    uint32_t CAL:1;            /*!< bit:      2  Calendar mode                      */
+    uint32_t :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint32_t CA0:1;            /*!< bit:      8  Clear on Alarm 0                   */
+    uint32_t CA1:1;            /*!< bit:      9  Clear on Alarm 1                   */
+    uint32_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint32_t PSEL:5;           /*!< bit: 16..20  Prescaler Select                   */
+    uint32_t :11;              /*!< bit: 21..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AST_CR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AST_CR_OFFSET               0x00         /**< \brief (AST_CR offset) Control Register */
+#define AST_CR_RESETVALUE           _U(0x00000000); /**< \brief (AST_CR reset_value) Control Register */
+
+#define AST_CR_EN_Pos               0            /**< \brief (AST_CR) Enable */
+#define AST_CR_EN                   (_U(0x1) << AST_CR_EN_Pos)
+#define   AST_CR_EN_0_Val                 _U(0x0)   /**< \brief (AST_CR) The AST is disabled. */
+#define   AST_CR_EN_1_Val                 _U(0x1)   /**< \brief (AST_CR) The AST is enabled */
+#define AST_CR_EN_0                 (AST_CR_EN_0_Val               << AST_CR_EN_Pos)
+#define AST_CR_EN_1                 (AST_CR_EN_1_Val               << AST_CR_EN_Pos)
+#define AST_CR_PCLR_Pos             1            /**< \brief (AST_CR) Prescaler Clear */
+#define AST_CR_PCLR                 (_U(0x1) << AST_CR_PCLR_Pos)
+#define AST_CR_CAL_Pos              2            /**< \brief (AST_CR) Calendar mode */
+#define AST_CR_CAL                  (_U(0x1) << AST_CR_CAL_Pos)
+#define AST_CR_CA0_Pos              8            /**< \brief (AST_CR) Clear on Alarm 0 */
+#define AST_CR_CA0                  (_U(0x1) << AST_CR_CA0_Pos)
+#define AST_CR_CA1_Pos              9            /**< \brief (AST_CR) Clear on Alarm 1 */
+#define AST_CR_CA1                  (_U(0x1) << AST_CR_CA1_Pos)
+#define AST_CR_PSEL_Pos             16           /**< \brief (AST_CR) Prescaler Select */
+#define AST_CR_PSEL_Msk             (_U(0x1F) << AST_CR_PSEL_Pos)
+#define AST_CR_PSEL(value)          (AST_CR_PSEL_Msk & ((value) << AST_CR_PSEL_Pos))
+#define AST_CR_MASK                 _U(0x001F0307) /**< \brief (AST_CR) MASK Register */
+
+/* -------- AST_CV : (AST Offset: 0x04) (R/W 32) Counter Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VALUE:32;         /*!< bit:  0..31  AST Value                          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AST_CV_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AST_CV_OFFSET               0x04         /**< \brief (AST_CV offset) Counter Value */
+#define AST_CV_RESETVALUE           _U(0x00000000); /**< \brief (AST_CV reset_value) Counter Value */
+
+#define AST_CV_VALUE_Pos            0            /**< \brief (AST_CV) AST Value */
+#define AST_CV_VALUE_Msk            (_U(0xFFFFFFFF) << AST_CV_VALUE_Pos)
+#define AST_CV_VALUE(value)         (AST_CV_VALUE_Msk & ((value) << AST_CV_VALUE_Pos))
+#define AST_CV_MASK                 _U(0xFFFFFFFF) /**< \brief (AST_CV) MASK Register */
+
+/* -------- AST_SR : (AST Offset: 0x08) (R/  32) Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OVF:1;            /*!< bit:      0  Overflow                           */
+    uint32_t :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint32_t ALARM0:1;         /*!< bit:      8  Alarm 0                            */
+    uint32_t ALARM1:1;         /*!< bit:      9  Alarm 1                            */
+    uint32_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint32_t PER0:1;           /*!< bit:     16  Periodic 0                         */
+    uint32_t PER1:1;           /*!< bit:     17  Periodic 1                         */
+    uint32_t :6;               /*!< bit: 18..23  Reserved                           */
+    uint32_t BUSY:1;           /*!< bit:     24  AST Busy                           */
+    uint32_t READY:1;          /*!< bit:     25  AST Ready                          */
+    uint32_t :2;               /*!< bit: 26..27  Reserved                           */
+    uint32_t CLKBUSY:1;        /*!< bit:     28  Clock Busy                         */
+    uint32_t CLKRDY:1;         /*!< bit:     29  Clock Ready                        */
+    uint32_t :2;               /*!< bit: 30..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AST_SR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AST_SR_OFFSET               0x08         /**< \brief (AST_SR offset) Status Register */
+#define AST_SR_RESETVALUE           _U(0x00000000); /**< \brief (AST_SR reset_value) Status Register */
+
+#define AST_SR_OVF_Pos              0            /**< \brief (AST_SR) Overflow */
+#define AST_SR_OVF                  (_U(0x1) << AST_SR_OVF_Pos)
+#define AST_SR_ALARM0_Pos           8            /**< \brief (AST_SR) Alarm 0 */
+#define AST_SR_ALARM0               (_U(0x1) << AST_SR_ALARM0_Pos)
+#define AST_SR_ALARM1_Pos           9            /**< \brief (AST_SR) Alarm 1 */
+#define AST_SR_ALARM1               (_U(0x1) << AST_SR_ALARM1_Pos)
+#define AST_SR_PER0_Pos             16           /**< \brief (AST_SR) Periodic 0 */
+#define AST_SR_PER0                 (_U(0x1) << AST_SR_PER0_Pos)
+#define AST_SR_PER1_Pos             17           /**< \brief (AST_SR) Periodic 1 */
+#define AST_SR_PER1                 (_U(0x1) << AST_SR_PER1_Pos)
+#define AST_SR_BUSY_Pos             24           /**< \brief (AST_SR) AST Busy */
+#define AST_SR_BUSY                 (_U(0x1) << AST_SR_BUSY_Pos)
+#define   AST_SR_BUSY_0_Val               _U(0x0)   /**< \brief (AST_SR) The AST accepts writes to CV, WER, DTR, SCR, AR, PIR and CR */
+#define   AST_SR_BUSY_1_Val               _U(0x1)   /**< \brief (AST_SR) The AST is busy and will discard writes to CV, WER, DTR, SCR, AR, PIR and CR */
+#define AST_SR_BUSY_0               (AST_SR_BUSY_0_Val             << AST_SR_BUSY_Pos)
+#define AST_SR_BUSY_1               (AST_SR_BUSY_1_Val             << AST_SR_BUSY_Pos)
+#define AST_SR_READY_Pos            25           /**< \brief (AST_SR) AST Ready */
+#define AST_SR_READY                (_U(0x1) << AST_SR_READY_Pos)
+#define AST_SR_CLKBUSY_Pos          28           /**< \brief (AST_SR) Clock Busy */
+#define AST_SR_CLKBUSY              (_U(0x1) << AST_SR_CLKBUSY_Pos)
+#define   AST_SR_CLKBUSY_0_Val            _U(0x0)   /**< \brief (AST_SR) The clock is ready and can be changed */
+#define   AST_SR_CLKBUSY_1_Val            _U(0x1)   /**< \brief (AST_SR) CEN has been written and the clock is busy */
+#define AST_SR_CLKBUSY_0            (AST_SR_CLKBUSY_0_Val          << AST_SR_CLKBUSY_Pos)
+#define AST_SR_CLKBUSY_1            (AST_SR_CLKBUSY_1_Val          << AST_SR_CLKBUSY_Pos)
+#define AST_SR_CLKRDY_Pos           29           /**< \brief (AST_SR) Clock Ready */
+#define AST_SR_CLKRDY               (_U(0x1) << AST_SR_CLKRDY_Pos)
+#define AST_SR_MASK                 _U(0x33030301) /**< \brief (AST_SR) MASK Register */
+
+/* -------- AST_SCR : (AST Offset: 0x0C) ( /W 32) Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OVF:1;            /*!< bit:      0  Overflow                           */
+    uint32_t :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint32_t ALARM0:1;         /*!< bit:      8  Alarm 0                            */
+    uint32_t ALARM1:1;         /*!< bit:      9  Alarm 1                            */
+    uint32_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint32_t PER0:1;           /*!< bit:     16  Periodic 0                         */
+    uint32_t PER1:1;           /*!< bit:     17  Periodic 1                         */
+    uint32_t :7;               /*!< bit: 18..24  Reserved                           */
+    uint32_t READY:1;          /*!< bit:     25  AST Ready                          */
+    uint32_t :3;               /*!< bit: 26..28  Reserved                           */
+    uint32_t CLKRDY:1;         /*!< bit:     29  Clock Ready                        */
+    uint32_t :2;               /*!< bit: 30..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AST_SCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AST_SCR_OFFSET              0x0C         /**< \brief (AST_SCR offset) Status Clear Register */
+#define AST_SCR_RESETVALUE          _U(0x00000000); /**< \brief (AST_SCR reset_value) Status Clear Register */
+
+#define AST_SCR_OVF_Pos             0            /**< \brief (AST_SCR) Overflow */
+#define AST_SCR_OVF                 (_U(0x1) << AST_SCR_OVF_Pos)
+#define AST_SCR_ALARM0_Pos          8            /**< \brief (AST_SCR) Alarm 0 */
+#define AST_SCR_ALARM0              (_U(0x1) << AST_SCR_ALARM0_Pos)
+#define AST_SCR_ALARM1_Pos          9            /**< \brief (AST_SCR) Alarm 1 */
+#define AST_SCR_ALARM1              (_U(0x1) << AST_SCR_ALARM1_Pos)
+#define AST_SCR_PER0_Pos            16           /**< \brief (AST_SCR) Periodic 0 */
+#define AST_SCR_PER0                (_U(0x1) << AST_SCR_PER0_Pos)
+#define AST_SCR_PER1_Pos            17           /**< \brief (AST_SCR) Periodic 1 */
+#define AST_SCR_PER1                (_U(0x1) << AST_SCR_PER1_Pos)
+#define AST_SCR_READY_Pos           25           /**< \brief (AST_SCR) AST Ready */
+#define AST_SCR_READY               (_U(0x1) << AST_SCR_READY_Pos)
+#define AST_SCR_CLKRDY_Pos          29           /**< \brief (AST_SCR) Clock Ready */
+#define AST_SCR_CLKRDY              (_U(0x1) << AST_SCR_CLKRDY_Pos)
+#define AST_SCR_MASK                _U(0x22030301) /**< \brief (AST_SCR) MASK Register */
+
+/* -------- AST_IER : (AST Offset: 0x10) ( /W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OVF:1;            /*!< bit:      0  Overflow                           */
+    uint32_t :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint32_t ALARM0:1;         /*!< bit:      8  Alarm 0                            */
+    uint32_t ALARM1:1;         /*!< bit:      9  Alarm 1                            */
+    uint32_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint32_t PER0:1;           /*!< bit:     16  Periodic 0                         */
+    uint32_t PER1:1;           /*!< bit:     17  Periodic 1                         */
+    uint32_t :7;               /*!< bit: 18..24  Reserved                           */
+    uint32_t READY:1;          /*!< bit:     25  AST Ready                          */
+    uint32_t :3;               /*!< bit: 26..28  Reserved                           */
+    uint32_t CLKRDY:1;         /*!< bit:     29  Clock Ready                        */
+    uint32_t :2;               /*!< bit: 30..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AST_IER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AST_IER_OFFSET              0x10         /**< \brief (AST_IER offset) Interrupt Enable Register */
+#define AST_IER_RESETVALUE          _U(0x00000000); /**< \brief (AST_IER reset_value) Interrupt Enable Register */
+
+#define AST_IER_OVF_Pos             0            /**< \brief (AST_IER) Overflow */
+#define AST_IER_OVF                 (_U(0x1) << AST_IER_OVF_Pos)
+#define   AST_IER_OVF_0_Val               _U(0x0)   /**< \brief (AST_IER) No effect */
+#define   AST_IER_OVF_1_Val               _U(0x1)   /**< \brief (AST_IER) Enable Interrupt. */
+#define AST_IER_OVF_0               (AST_IER_OVF_0_Val             << AST_IER_OVF_Pos)
+#define AST_IER_OVF_1               (AST_IER_OVF_1_Val             << AST_IER_OVF_Pos)
+#define AST_IER_ALARM0_Pos          8            /**< \brief (AST_IER) Alarm 0 */
+#define AST_IER_ALARM0              (_U(0x1) << AST_IER_ALARM0_Pos)
+#define   AST_IER_ALARM0_0_Val            _U(0x0)   /**< \brief (AST_IER) No effect */
+#define   AST_IER_ALARM0_1_Val            _U(0x1)   /**< \brief (AST_IER) Enable interrupt */
+#define AST_IER_ALARM0_0            (AST_IER_ALARM0_0_Val          << AST_IER_ALARM0_Pos)
+#define AST_IER_ALARM0_1            (AST_IER_ALARM0_1_Val          << AST_IER_ALARM0_Pos)
+#define AST_IER_ALARM1_Pos          9            /**< \brief (AST_IER) Alarm 1 */
+#define AST_IER_ALARM1              (_U(0x1) << AST_IER_ALARM1_Pos)
+#define   AST_IER_ALARM1_0_Val            _U(0x0)   /**< \brief (AST_IER) No effect */
+#define   AST_IER_ALARM1_1_Val            _U(0x1)   /**< \brief (AST_IER) Enable interrupt */
+#define AST_IER_ALARM1_0            (AST_IER_ALARM1_0_Val          << AST_IER_ALARM1_Pos)
+#define AST_IER_ALARM1_1            (AST_IER_ALARM1_1_Val          << AST_IER_ALARM1_Pos)
+#define AST_IER_PER0_Pos            16           /**< \brief (AST_IER) Periodic 0 */
+#define AST_IER_PER0                (_U(0x1) << AST_IER_PER0_Pos)
+#define   AST_IER_PER0_0_Val              _U(0x0)   /**< \brief (AST_IER) No effect */
+#define   AST_IER_PER0_1_Val              _U(0x1)   /**< \brief (AST_IER) Enable interrupt */
+#define AST_IER_PER0_0              (AST_IER_PER0_0_Val            << AST_IER_PER0_Pos)
+#define AST_IER_PER0_1              (AST_IER_PER0_1_Val            << AST_IER_PER0_Pos)
+#define AST_IER_PER1_Pos            17           /**< \brief (AST_IER) Periodic 1 */
+#define AST_IER_PER1                (_U(0x1) << AST_IER_PER1_Pos)
+#define   AST_IER_PER1_0_Val              _U(0x0)   /**< \brief (AST_IER) No effect */
+#define   AST_IER_PER1_1_Val              _U(0x1)   /**< \brief (AST_IER) Enable interrupt */
+#define AST_IER_PER1_0              (AST_IER_PER1_0_Val            << AST_IER_PER1_Pos)
+#define AST_IER_PER1_1              (AST_IER_PER1_1_Val            << AST_IER_PER1_Pos)
+#define AST_IER_READY_Pos           25           /**< \brief (AST_IER) AST Ready */
+#define AST_IER_READY               (_U(0x1) << AST_IER_READY_Pos)
+#define   AST_IER_READY_0_Val             _U(0x0)   /**< \brief (AST_IER) No effect */
+#define   AST_IER_READY_1_Val             _U(0x1)   /**< \brief (AST_IER) Enable interrupt */
+#define AST_IER_READY_0             (AST_IER_READY_0_Val           << AST_IER_READY_Pos)
+#define AST_IER_READY_1             (AST_IER_READY_1_Val           << AST_IER_READY_Pos)
+#define AST_IER_CLKRDY_Pos          29           /**< \brief (AST_IER) Clock Ready */
+#define AST_IER_CLKRDY              (_U(0x1) << AST_IER_CLKRDY_Pos)
+#define   AST_IER_CLKRDY_0_Val            _U(0x0)   /**< \brief (AST_IER) No effect */
+#define   AST_IER_CLKRDY_1_Val            _U(0x1)   /**< \brief (AST_IER) Enable interrupt */
+#define AST_IER_CLKRDY_0            (AST_IER_CLKRDY_0_Val          << AST_IER_CLKRDY_Pos)
+#define AST_IER_CLKRDY_1            (AST_IER_CLKRDY_1_Val          << AST_IER_CLKRDY_Pos)
+#define AST_IER_MASK                _U(0x22030301) /**< \brief (AST_IER) MASK Register */
+
+/* -------- AST_IDR : (AST Offset: 0x14) ( /W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OVF:1;            /*!< bit:      0  Overflow                           */
+    uint32_t :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint32_t ALARM0:1;         /*!< bit:      8  Alarm 0                            */
+    uint32_t ALARM1:1;         /*!< bit:      9  Alarm 1                            */
+    uint32_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint32_t PER0:1;           /*!< bit:     16  Periodic 0                         */
+    uint32_t PER1:1;           /*!< bit:     17  Periodic 1                         */
+    uint32_t :7;               /*!< bit: 18..24  Reserved                           */
+    uint32_t READY:1;          /*!< bit:     25  AST Ready                          */
+    uint32_t :3;               /*!< bit: 26..28  Reserved                           */
+    uint32_t CLKRDY:1;         /*!< bit:     29  Clock Ready                        */
+    uint32_t :2;               /*!< bit: 30..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AST_IDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AST_IDR_OFFSET              0x14         /**< \brief (AST_IDR offset) Interrupt Disable Register */
+#define AST_IDR_RESETVALUE          _U(0x00000000); /**< \brief (AST_IDR reset_value) Interrupt Disable Register */
+
+#define AST_IDR_OVF_Pos             0            /**< \brief (AST_IDR) Overflow */
+#define AST_IDR_OVF                 (_U(0x1) << AST_IDR_OVF_Pos)
+#define   AST_IDR_OVF_0_Val               _U(0x0)   /**< \brief (AST_IDR) No effect */
+#define   AST_IDR_OVF_1_Val               _U(0x1)   /**< \brief (AST_IDR) Disable Interrupt. */
+#define AST_IDR_OVF_0               (AST_IDR_OVF_0_Val             << AST_IDR_OVF_Pos)
+#define AST_IDR_OVF_1               (AST_IDR_OVF_1_Val             << AST_IDR_OVF_Pos)
+#define AST_IDR_ALARM0_Pos          8            /**< \brief (AST_IDR) Alarm 0 */
+#define AST_IDR_ALARM0              (_U(0x1) << AST_IDR_ALARM0_Pos)
+#define   AST_IDR_ALARM0_0_Val            _U(0x0)   /**< \brief (AST_IDR) No effect */
+#define   AST_IDR_ALARM0_1_Val            _U(0x1)   /**< \brief (AST_IDR) Disable interrupt */
+#define AST_IDR_ALARM0_0            (AST_IDR_ALARM0_0_Val          << AST_IDR_ALARM0_Pos)
+#define AST_IDR_ALARM0_1            (AST_IDR_ALARM0_1_Val          << AST_IDR_ALARM0_Pos)
+#define AST_IDR_ALARM1_Pos          9            /**< \brief (AST_IDR) Alarm 1 */
+#define AST_IDR_ALARM1              (_U(0x1) << AST_IDR_ALARM1_Pos)
+#define   AST_IDR_ALARM1_0_Val            _U(0x0)   /**< \brief (AST_IDR) No effect */
+#define   AST_IDR_ALARM1_1_Val            _U(0x1)   /**< \brief (AST_IDR) Disable interrupt */
+#define AST_IDR_ALARM1_0            (AST_IDR_ALARM1_0_Val          << AST_IDR_ALARM1_Pos)
+#define AST_IDR_ALARM1_1            (AST_IDR_ALARM1_1_Val          << AST_IDR_ALARM1_Pos)
+#define AST_IDR_PER0_Pos            16           /**< \brief (AST_IDR) Periodic 0 */
+#define AST_IDR_PER0                (_U(0x1) << AST_IDR_PER0_Pos)
+#define   AST_IDR_PER0_0_Val              _U(0x0)   /**< \brief (AST_IDR) No effet */
+#define   AST_IDR_PER0_1_Val              _U(0x1)   /**< \brief (AST_IDR) Disalbe interrupt */
+#define AST_IDR_PER0_0              (AST_IDR_PER0_0_Val            << AST_IDR_PER0_Pos)
+#define AST_IDR_PER0_1              (AST_IDR_PER0_1_Val            << AST_IDR_PER0_Pos)
+#define AST_IDR_PER1_Pos            17           /**< \brief (AST_IDR) Periodic 1 */
+#define AST_IDR_PER1                (_U(0x1) << AST_IDR_PER1_Pos)
+#define   AST_IDR_PER1_0_Val              _U(0x0)   /**< \brief (AST_IDR) No effect */
+#define   AST_IDR_PER1_1_Val              _U(0x1)   /**< \brief (AST_IDR) Disable interrupt */
+#define AST_IDR_PER1_0              (AST_IDR_PER1_0_Val            << AST_IDR_PER1_Pos)
+#define AST_IDR_PER1_1              (AST_IDR_PER1_1_Val            << AST_IDR_PER1_Pos)
+#define AST_IDR_READY_Pos           25           /**< \brief (AST_IDR) AST Ready */
+#define AST_IDR_READY               (_U(0x1) << AST_IDR_READY_Pos)
+#define   AST_IDR_READY_0_Val             _U(0x0)   /**< \brief (AST_IDR) No effect */
+#define   AST_IDR_READY_1_Val             _U(0x1)   /**< \brief (AST_IDR) Disable interrupt */
+#define AST_IDR_READY_0             (AST_IDR_READY_0_Val           << AST_IDR_READY_Pos)
+#define AST_IDR_READY_1             (AST_IDR_READY_1_Val           << AST_IDR_READY_Pos)
+#define AST_IDR_CLKRDY_Pos          29           /**< \brief (AST_IDR) Clock Ready */
+#define AST_IDR_CLKRDY              (_U(0x1) << AST_IDR_CLKRDY_Pos)
+#define   AST_IDR_CLKRDY_0_Val            _U(0x0)   /**< \brief (AST_IDR) No effect */
+#define   AST_IDR_CLKRDY_1_Val            _U(0x1)   /**< \brief (AST_IDR) Disable interrupt */
+#define AST_IDR_CLKRDY_0            (AST_IDR_CLKRDY_0_Val          << AST_IDR_CLKRDY_Pos)
+#define AST_IDR_CLKRDY_1            (AST_IDR_CLKRDY_1_Val          << AST_IDR_CLKRDY_Pos)
+#define AST_IDR_MASK                _U(0x22030301) /**< \brief (AST_IDR) MASK Register */
+
+/* -------- AST_IMR : (AST Offset: 0x18) (R/  32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OVF:1;            /*!< bit:      0  Overflow                           */
+    uint32_t :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint32_t ALARM0:1;         /*!< bit:      8  Alarm 0                            */
+    uint32_t ALARM1:1;         /*!< bit:      9  Alarm 1                            */
+    uint32_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint32_t PER0:1;           /*!< bit:     16  Periodic 0                         */
+    uint32_t PER1:1;           /*!< bit:     17  Periodic 1                         */
+    uint32_t :7;               /*!< bit: 18..24  Reserved                           */
+    uint32_t READY:1;          /*!< bit:     25  AST Ready                          */
+    uint32_t :3;               /*!< bit: 26..28  Reserved                           */
+    uint32_t CLKRDY:1;         /*!< bit:     29  Clock Ready                        */
+    uint32_t :2;               /*!< bit: 30..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AST_IMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AST_IMR_OFFSET              0x18         /**< \brief (AST_IMR offset) Interrupt Mask Register */
+#define AST_IMR_RESETVALUE          _U(0x00000000); /**< \brief (AST_IMR reset_value) Interrupt Mask Register */
+
+#define AST_IMR_OVF_Pos             0            /**< \brief (AST_IMR) Overflow */
+#define AST_IMR_OVF                 (_U(0x1) << AST_IMR_OVF_Pos)
+#define   AST_IMR_OVF_0_Val               _U(0x0)   /**< \brief (AST_IMR) Interrupt is disabled */
+#define   AST_IMR_OVF_1_Val               _U(0x1)   /**< \brief (AST_IMR) Interrupt is enabled. */
+#define AST_IMR_OVF_0               (AST_IMR_OVF_0_Val             << AST_IMR_OVF_Pos)
+#define AST_IMR_OVF_1               (AST_IMR_OVF_1_Val             << AST_IMR_OVF_Pos)
+#define AST_IMR_ALARM0_Pos          8            /**< \brief (AST_IMR) Alarm 0 */
+#define AST_IMR_ALARM0              (_U(0x1) << AST_IMR_ALARM0_Pos)
+#define   AST_IMR_ALARM0_0_Val            _U(0x0)   /**< \brief (AST_IMR) Interupt is disabled */
+#define   AST_IMR_ALARM0_1_Val            _U(0x1)   /**< \brief (AST_IMR) Interrupt is enabled */
+#define AST_IMR_ALARM0_0            (AST_IMR_ALARM0_0_Val          << AST_IMR_ALARM0_Pos)
+#define AST_IMR_ALARM0_1            (AST_IMR_ALARM0_1_Val          << AST_IMR_ALARM0_Pos)
+#define AST_IMR_ALARM1_Pos          9            /**< \brief (AST_IMR) Alarm 1 */
+#define AST_IMR_ALARM1              (_U(0x1) << AST_IMR_ALARM1_Pos)
+#define   AST_IMR_ALARM1_0_Val            _U(0x0)   /**< \brief (AST_IMR) Interrupt is disabled */
+#define   AST_IMR_ALARM1_1_Val            _U(0x1)   /**< \brief (AST_IMR) Interrupt is enabled */
+#define AST_IMR_ALARM1_0            (AST_IMR_ALARM1_0_Val          << AST_IMR_ALARM1_Pos)
+#define AST_IMR_ALARM1_1            (AST_IMR_ALARM1_1_Val          << AST_IMR_ALARM1_Pos)
+#define AST_IMR_PER0_Pos            16           /**< \brief (AST_IMR) Periodic 0 */
+#define AST_IMR_PER0                (_U(0x1) << AST_IMR_PER0_Pos)
+#define   AST_IMR_PER0_0_Val              _U(0x0)   /**< \brief (AST_IMR) Interrupt is disabled */
+#define   AST_IMR_PER0_1_Val              _U(0x1)   /**< \brief (AST_IMR) Interrupt is enabled */
+#define AST_IMR_PER0_0              (AST_IMR_PER0_0_Val            << AST_IMR_PER0_Pos)
+#define AST_IMR_PER0_1              (AST_IMR_PER0_1_Val            << AST_IMR_PER0_Pos)
+#define AST_IMR_PER1_Pos            17           /**< \brief (AST_IMR) Periodic 1 */
+#define AST_IMR_PER1                (_U(0x1) << AST_IMR_PER1_Pos)
+#define   AST_IMR_PER1_0_Val              _U(0x0)   /**< \brief (AST_IMR) Interrupt is disabled */
+#define   AST_IMR_PER1_1_Val              _U(0x1)   /**< \brief (AST_IMR) Interrupt is enabled */
+#define AST_IMR_PER1_0              (AST_IMR_PER1_0_Val            << AST_IMR_PER1_Pos)
+#define AST_IMR_PER1_1              (AST_IMR_PER1_1_Val            << AST_IMR_PER1_Pos)
+#define AST_IMR_READY_Pos           25           /**< \brief (AST_IMR) AST Ready */
+#define AST_IMR_READY               (_U(0x1) << AST_IMR_READY_Pos)
+#define   AST_IMR_READY_0_Val             _U(0x0)   /**< \brief (AST_IMR) Interrupt is disabled */
+#define   AST_IMR_READY_1_Val             _U(0x1)   /**< \brief (AST_IMR) Interrupt is enabled */
+#define AST_IMR_READY_0             (AST_IMR_READY_0_Val           << AST_IMR_READY_Pos)
+#define AST_IMR_READY_1             (AST_IMR_READY_1_Val           << AST_IMR_READY_Pos)
+#define AST_IMR_CLKRDY_Pos          29           /**< \brief (AST_IMR) Clock Ready */
+#define AST_IMR_CLKRDY              (_U(0x1) << AST_IMR_CLKRDY_Pos)
+#define   AST_IMR_CLKRDY_0_Val            _U(0x0)   /**< \brief (AST_IMR) Interrupt is disabled */
+#define   AST_IMR_CLKRDY_1_Val            _U(0x1)   /**< \brief (AST_IMR) Interrupt is enabled */
+#define AST_IMR_CLKRDY_0            (AST_IMR_CLKRDY_0_Val          << AST_IMR_CLKRDY_Pos)
+#define AST_IMR_CLKRDY_1            (AST_IMR_CLKRDY_1_Val          << AST_IMR_CLKRDY_Pos)
+#define AST_IMR_MASK                _U(0x22030301) /**< \brief (AST_IMR) MASK Register */
+
+/* -------- AST_WER : (AST Offset: 0x1C) (R/W 32) Wake Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OVF:1;            /*!< bit:      0  Overflow                           */
+    uint32_t :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint32_t ALARM0:1;         /*!< bit:      8  Alarm 0                            */
+    uint32_t ALARM1:1;         /*!< bit:      9  Alarm 1                            */
+    uint32_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint32_t PER0:1;           /*!< bit:     16  Periodic 0                         */
+    uint32_t PER1:1;           /*!< bit:     17  Periodic 1                         */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AST_WER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AST_WER_OFFSET              0x1C         /**< \brief (AST_WER offset) Wake Enable Register */
+#define AST_WER_RESETVALUE          _U(0x00000000); /**< \brief (AST_WER reset_value) Wake Enable Register */
+
+#define AST_WER_OVF_Pos             0            /**< \brief (AST_WER) Overflow */
+#define AST_WER_OVF                 (_U(0x1) << AST_WER_OVF_Pos)
+#define   AST_WER_OVF_0_Val               _U(0x0)   /**< \brief (AST_WER) The corresponing event will not wake up the CPU from sleep mode */
+#define   AST_WER_OVF_1_Val               _U(0x1)   /**< \brief (AST_WER) The corresponding event will wake up the CPU from sleep mode */
+#define AST_WER_OVF_0               (AST_WER_OVF_0_Val             << AST_WER_OVF_Pos)
+#define AST_WER_OVF_1               (AST_WER_OVF_1_Val             << AST_WER_OVF_Pos)
+#define AST_WER_ALARM0_Pos          8            /**< \brief (AST_WER) Alarm 0 */
+#define AST_WER_ALARM0              (_U(0x1) << AST_WER_ALARM0_Pos)
+#define   AST_WER_ALARM0_0_Val            _U(0x0)   /**< \brief (AST_WER) The corresponing event will not wake up the CPU from sleep mode */
+#define   AST_WER_ALARM0_1_Val            _U(0x1)   /**< \brief (AST_WER) The corresponding event will wake up the CPU from sleep mode */
+#define AST_WER_ALARM0_0            (AST_WER_ALARM0_0_Val          << AST_WER_ALARM0_Pos)
+#define AST_WER_ALARM0_1            (AST_WER_ALARM0_1_Val          << AST_WER_ALARM0_Pos)
+#define AST_WER_ALARM1_Pos          9            /**< \brief (AST_WER) Alarm 1 */
+#define AST_WER_ALARM1              (_U(0x1) << AST_WER_ALARM1_Pos)
+#define   AST_WER_ALARM1_0_Val            _U(0x0)   /**< \brief (AST_WER) The corresponing event will not wake up the CPU from sleep mode */
+#define   AST_WER_ALARM1_1_Val            _U(0x1)   /**< \brief (AST_WER) The corresponding event will wake up the CPU from sleep mode */
+#define AST_WER_ALARM1_0            (AST_WER_ALARM1_0_Val          << AST_WER_ALARM1_Pos)
+#define AST_WER_ALARM1_1            (AST_WER_ALARM1_1_Val          << AST_WER_ALARM1_Pos)
+#define AST_WER_PER0_Pos            16           /**< \brief (AST_WER) Periodic 0 */
+#define AST_WER_PER0                (_U(0x1) << AST_WER_PER0_Pos)
+#define   AST_WER_PER0_0_Val              _U(0x0)   /**< \brief (AST_WER) The corresponing event will not wake up the CPU from sleep mode */
+#define   AST_WER_PER0_1_Val              _U(0x1)   /**< \brief (AST_WER) The corresponding event will wake up the CPU from sleep mode */
+#define AST_WER_PER0_0              (AST_WER_PER0_0_Val            << AST_WER_PER0_Pos)
+#define AST_WER_PER0_1              (AST_WER_PER0_1_Val            << AST_WER_PER0_Pos)
+#define AST_WER_PER1_Pos            17           /**< \brief (AST_WER) Periodic 1 */
+#define AST_WER_PER1                (_U(0x1) << AST_WER_PER1_Pos)
+#define   AST_WER_PER1_0_Val              _U(0x0)   /**< \brief (AST_WER) The corresponing event will not wake up the CPU from sleep mode */
+#define   AST_WER_PER1_1_Val              _U(0x1)   /**< \brief (AST_WER) The corresponding event will wake up the CPU from sleep mode */
+#define AST_WER_PER1_0              (AST_WER_PER1_0_Val            << AST_WER_PER1_Pos)
+#define AST_WER_PER1_1              (AST_WER_PER1_1_Val            << AST_WER_PER1_Pos)
+#define AST_WER_MASK                _U(0x00030301) /**< \brief (AST_WER) MASK Register */
+
+/* -------- AST_AR0 : (AST Offset: 0x20) (R/W 32) Alarm Register 0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VALUE:32;         /*!< bit:  0..31  Alarm Value                        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AST_AR0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AST_AR0_OFFSET              0x20         /**< \brief (AST_AR0 offset) Alarm Register 0 */
+#define AST_AR0_RESETVALUE          _U(0x00000000); /**< \brief (AST_AR0 reset_value) Alarm Register 0 */
+
+#define AST_AR0_VALUE_Pos           0            /**< \brief (AST_AR0) Alarm Value */
+#define AST_AR0_VALUE_Msk           (_U(0xFFFFFFFF) << AST_AR0_VALUE_Pos)
+#define AST_AR0_VALUE(value)        (AST_AR0_VALUE_Msk & ((value) << AST_AR0_VALUE_Pos))
+#define AST_AR0_MASK                _U(0xFFFFFFFF) /**< \brief (AST_AR0) MASK Register */
+
+/* -------- AST_AR1 : (AST Offset: 0x24) (R/W 32) Alarm Register 1 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VALUE:32;         /*!< bit:  0..31  Alarm Value                        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AST_AR1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AST_AR1_OFFSET              0x24         /**< \brief (AST_AR1 offset) Alarm Register 1 */
+#define AST_AR1_RESETVALUE          _U(0x00000000); /**< \brief (AST_AR1 reset_value) Alarm Register 1 */
+
+#define AST_AR1_VALUE_Pos           0            /**< \brief (AST_AR1) Alarm Value */
+#define AST_AR1_VALUE_Msk           (_U(0xFFFFFFFF) << AST_AR1_VALUE_Pos)
+#define AST_AR1_VALUE(value)        (AST_AR1_VALUE_Msk & ((value) << AST_AR1_VALUE_Pos))
+#define AST_AR1_MASK                _U(0xFFFFFFFF) /**< \brief (AST_AR1) MASK Register */
+
+/* -------- AST_PIR0 : (AST Offset: 0x30) (R/W 32) Periodic Interval Register 0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t INSEL:5;          /*!< bit:  0.. 4  Interval Select                    */
+    uint32_t :27;              /*!< bit:  5..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AST_PIR0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AST_PIR0_OFFSET             0x30         /**< \brief (AST_PIR0 offset) Periodic Interval Register 0 */
+#define AST_PIR0_RESETVALUE         _U(0x00000000); /**< \brief (AST_PIR0 reset_value) Periodic Interval Register 0 */
+
+#define AST_PIR0_INSEL_Pos          0            /**< \brief (AST_PIR0) Interval Select */
+#define AST_PIR0_INSEL_Msk          (_U(0x1F) << AST_PIR0_INSEL_Pos)
+#define AST_PIR0_INSEL(value)       (AST_PIR0_INSEL_Msk & ((value) << AST_PIR0_INSEL_Pos))
+#define AST_PIR0_MASK               _U(0x0000001F) /**< \brief (AST_PIR0) MASK Register */
+
+/* -------- AST_PIR1 : (AST Offset: 0x34) (R/W 32) Periodic Interval Register 1 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t INSEL:5;          /*!< bit:  0.. 4  Interval Select                    */
+    uint32_t :27;              /*!< bit:  5..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AST_PIR1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AST_PIR1_OFFSET             0x34         /**< \brief (AST_PIR1 offset) Periodic Interval Register 1 */
+#define AST_PIR1_RESETVALUE         _U(0x00000000); /**< \brief (AST_PIR1 reset_value) Periodic Interval Register 1 */
+
+#define AST_PIR1_INSEL_Pos          0            /**< \brief (AST_PIR1) Interval Select */
+#define AST_PIR1_INSEL_Msk          (_U(0x1F) << AST_PIR1_INSEL_Pos)
+#define AST_PIR1_INSEL(value)       (AST_PIR1_INSEL_Msk & ((value) << AST_PIR1_INSEL_Pos))
+#define AST_PIR1_MASK               _U(0x0000001F) /**< \brief (AST_PIR1) MASK Register */
+
+/* -------- AST_CLOCK : (AST Offset: 0x40) (R/W 32) Clock Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CEN:1;            /*!< bit:      0  Clock Enable                       */
+    uint32_t :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint32_t CSSEL:3;          /*!< bit:  8..10  Clock Source Selection             */
+    uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AST_CLOCK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AST_CLOCK_OFFSET            0x40         /**< \brief (AST_CLOCK offset) Clock Control Register */
+#define AST_CLOCK_RESETVALUE        _U(0x00000000); /**< \brief (AST_CLOCK reset_value) Clock Control Register */
+
+#define AST_CLOCK_CEN_Pos           0            /**< \brief (AST_CLOCK) Clock Enable */
+#define AST_CLOCK_CEN               (_U(0x1) << AST_CLOCK_CEN_Pos)
+#define   AST_CLOCK_CEN_0_Val             _U(0x0)   /**< \brief (AST_CLOCK) The clock is disabled */
+#define   AST_CLOCK_CEN_1_Val             _U(0x1)   /**< \brief (AST_CLOCK) The clock is enabled */
+#define AST_CLOCK_CEN_0             (AST_CLOCK_CEN_0_Val           << AST_CLOCK_CEN_Pos)
+#define AST_CLOCK_CEN_1             (AST_CLOCK_CEN_1_Val           << AST_CLOCK_CEN_Pos)
+#define AST_CLOCK_CSSEL_Pos         8            /**< \brief (AST_CLOCK) Clock Source Selection */
+#define AST_CLOCK_CSSEL_Msk         (_U(0x7) << AST_CLOCK_CSSEL_Pos)
+#define AST_CLOCK_CSSEL(value)      (AST_CLOCK_CSSEL_Msk & ((value) << AST_CLOCK_CSSEL_Pos))
+#define   AST_CLOCK_CSSEL_SLOWCLOCK_Val   _U(0x0)   /**< \brief (AST_CLOCK) Slow clock */
+#define   AST_CLOCK_CSSEL_32KHZCLK_Val    _U(0x1)   /**< \brief (AST_CLOCK) 32 kHz clock */
+#define   AST_CLOCK_CSSEL_PBCLOCK_Val     _U(0x2)   /**< \brief (AST_CLOCK) PB clock */
+#define   AST_CLOCK_CSSEL_GCLK_Val        _U(0x3)   /**< \brief (AST_CLOCK) Generic clock */
+#define   AST_CLOCK_CSSEL_1KHZCLK_Val     _U(0x4)   /**< \brief (AST_CLOCK) 1kHz clock from 32 kHz oscillator */
+#define AST_CLOCK_CSSEL_SLOWCLOCK   (AST_CLOCK_CSSEL_SLOWCLOCK_Val << AST_CLOCK_CSSEL_Pos)
+#define AST_CLOCK_CSSEL_32KHZCLK    (AST_CLOCK_CSSEL_32KHZCLK_Val  << AST_CLOCK_CSSEL_Pos)
+#define AST_CLOCK_CSSEL_PBCLOCK     (AST_CLOCK_CSSEL_PBCLOCK_Val   << AST_CLOCK_CSSEL_Pos)
+#define AST_CLOCK_CSSEL_GCLK        (AST_CLOCK_CSSEL_GCLK_Val      << AST_CLOCK_CSSEL_Pos)
+#define AST_CLOCK_CSSEL_1KHZCLK     (AST_CLOCK_CSSEL_1KHZCLK_Val   << AST_CLOCK_CSSEL_Pos)
+#define AST_CLOCK_MASK              _U(0x00000701) /**< \brief (AST_CLOCK) MASK Register */
+
+/* -------- AST_DTR : (AST Offset: 0x44) (R/W 32) Digital Tuner Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EXP:5;            /*!< bit:  0.. 4  EXP                                */
+    uint32_t ADD:1;            /*!< bit:      5  ADD                                */
+    uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t VALUE:8;          /*!< bit:  8..15  VALUE                              */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AST_DTR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AST_DTR_OFFSET              0x44         /**< \brief (AST_DTR offset) Digital Tuner Register */
+#define AST_DTR_RESETVALUE          _U(0x00000000); /**< \brief (AST_DTR reset_value) Digital Tuner Register */
+
+#define AST_DTR_EXP_Pos             0            /**< \brief (AST_DTR) EXP */
+#define AST_DTR_EXP_Msk             (_U(0x1F) << AST_DTR_EXP_Pos)
+#define AST_DTR_EXP(value)          (AST_DTR_EXP_Msk & ((value) << AST_DTR_EXP_Pos))
+#define AST_DTR_ADD_Pos             5            /**< \brief (AST_DTR) ADD */
+#define AST_DTR_ADD                 (_U(0x1) << AST_DTR_ADD_Pos)
+#define AST_DTR_VALUE_Pos           8            /**< \brief (AST_DTR) VALUE */
+#define AST_DTR_VALUE_Msk           (_U(0xFF) << AST_DTR_VALUE_Pos)
+#define AST_DTR_VALUE(value)        (AST_DTR_VALUE_Msk & ((value) << AST_DTR_VALUE_Pos))
+#define AST_DTR_MASK                _U(0x0000FF3F) /**< \brief (AST_DTR) MASK Register */
+
+/* -------- AST_EVE : (AST Offset: 0x48) ( /W 32) Event Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OVF:1;            /*!< bit:      0  Overflow                           */
+    uint32_t :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint32_t ALARM0:1;         /*!< bit:      8  Alarm 0                            */
+    uint32_t ALARM1:1;         /*!< bit:      9  Alarm 1                            */
+    uint32_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint32_t PER0:1;           /*!< bit:     16  Perioidc 0                         */
+    uint32_t PER1:1;           /*!< bit:     17  Periodic 1                         */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AST_EVE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AST_EVE_OFFSET              0x48         /**< \brief (AST_EVE offset) Event Enable Register */
+#define AST_EVE_RESETVALUE          _U(0x00000000); /**< \brief (AST_EVE reset_value) Event Enable Register */
+
+#define AST_EVE_OVF_Pos             0            /**< \brief (AST_EVE) Overflow */
+#define AST_EVE_OVF                 (_U(0x1) << AST_EVE_OVF_Pos)
+#define AST_EVE_ALARM0_Pos          8            /**< \brief (AST_EVE) Alarm 0 */
+#define AST_EVE_ALARM0              (_U(0x1) << AST_EVE_ALARM0_Pos)
+#define AST_EVE_ALARM1_Pos          9            /**< \brief (AST_EVE) Alarm 1 */
+#define AST_EVE_ALARM1              (_U(0x1) << AST_EVE_ALARM1_Pos)
+#define AST_EVE_PER0_Pos            16           /**< \brief (AST_EVE) Perioidc 0 */
+#define AST_EVE_PER0                (_U(0x1) << AST_EVE_PER0_Pos)
+#define AST_EVE_PER1_Pos            17           /**< \brief (AST_EVE) Periodic 1 */
+#define AST_EVE_PER1                (_U(0x1) << AST_EVE_PER1_Pos)
+#define AST_EVE_MASK                _U(0x00030301) /**< \brief (AST_EVE) MASK Register */
+
+/* -------- AST_EVD : (AST Offset: 0x4C) ( /W 32) Event Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OVF:1;            /*!< bit:      0  Overflow                           */
+    uint32_t :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint32_t ALARM0:1;         /*!< bit:      8  Alarm 0                            */
+    uint32_t ALARM1:1;         /*!< bit:      9  Alarm 1                            */
+    uint32_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint32_t PER0:1;           /*!< bit:     16  Perioidc 0                         */
+    uint32_t PER1:1;           /*!< bit:     17  Periodic 1                         */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AST_EVD_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AST_EVD_OFFSET              0x4C         /**< \brief (AST_EVD offset) Event Disable Register */
+#define AST_EVD_RESETVALUE          _U(0x00000000); /**< \brief (AST_EVD reset_value) Event Disable Register */
+
+#define AST_EVD_OVF_Pos             0            /**< \brief (AST_EVD) Overflow */
+#define AST_EVD_OVF                 (_U(0x1) << AST_EVD_OVF_Pos)
+#define AST_EVD_ALARM0_Pos          8            /**< \brief (AST_EVD) Alarm 0 */
+#define AST_EVD_ALARM0              (_U(0x1) << AST_EVD_ALARM0_Pos)
+#define AST_EVD_ALARM1_Pos          9            /**< \brief (AST_EVD) Alarm 1 */
+#define AST_EVD_ALARM1              (_U(0x1) << AST_EVD_ALARM1_Pos)
+#define AST_EVD_PER0_Pos            16           /**< \brief (AST_EVD) Perioidc 0 */
+#define AST_EVD_PER0                (_U(0x1) << AST_EVD_PER0_Pos)
+#define AST_EVD_PER1_Pos            17           /**< \brief (AST_EVD) Periodic 1 */
+#define AST_EVD_PER1                (_U(0x1) << AST_EVD_PER1_Pos)
+#define AST_EVD_MASK                _U(0x00030301) /**< \brief (AST_EVD) MASK Register */
+
+/* -------- AST_EVM : (AST Offset: 0x50) (R/  32) Event Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OVF:1;            /*!< bit:      0  Overflow                           */
+    uint32_t :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint32_t ALARM0:1;         /*!< bit:      8  Alarm 0                            */
+    uint32_t ALARM1:1;         /*!< bit:      9  Alarm 1                            */
+    uint32_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint32_t PER0:1;           /*!< bit:     16  Perioidc 0                         */
+    uint32_t PER1:1;           /*!< bit:     17  Periodic 1                         */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AST_EVM_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AST_EVM_OFFSET              0x50         /**< \brief (AST_EVM offset) Event Mask Register */
+#define AST_EVM_RESETVALUE          _U(0x00000000); /**< \brief (AST_EVM reset_value) Event Mask Register */
+
+#define AST_EVM_OVF_Pos             0            /**< \brief (AST_EVM) Overflow */
+#define AST_EVM_OVF                 (_U(0x1) << AST_EVM_OVF_Pos)
+#define AST_EVM_ALARM0_Pos          8            /**< \brief (AST_EVM) Alarm 0 */
+#define AST_EVM_ALARM0              (_U(0x1) << AST_EVM_ALARM0_Pos)
+#define AST_EVM_ALARM1_Pos          9            /**< \brief (AST_EVM) Alarm 1 */
+#define AST_EVM_ALARM1              (_U(0x1) << AST_EVM_ALARM1_Pos)
+#define AST_EVM_PER0_Pos            16           /**< \brief (AST_EVM) Perioidc 0 */
+#define AST_EVM_PER0                (_U(0x1) << AST_EVM_PER0_Pos)
+#define AST_EVM_PER1_Pos            17           /**< \brief (AST_EVM) Periodic 1 */
+#define AST_EVM_PER1                (_U(0x1) << AST_EVM_PER1_Pos)
+#define AST_EVM_MASK                _U(0x00030301) /**< \brief (AST_EVM) MASK Register */
+
+/* -------- AST_CALV : (AST Offset: 0x54) (R/W 32) Calendar Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SEC:6;            /*!< bit:  0.. 5  Second                             */
+    uint32_t MIN:6;            /*!< bit:  6..11  Minute                             */
+    uint32_t HOUR:5;           /*!< bit: 12..16  Hour                               */
+    uint32_t DAY:5;            /*!< bit: 17..21  Day                                */
+    uint32_t MONTH:4;          /*!< bit: 22..25  Month                              */
+    uint32_t YEAR:6;           /*!< bit: 26..31  Year                               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AST_CALV_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AST_CALV_OFFSET             0x54         /**< \brief (AST_CALV offset) Calendar Value */
+#define AST_CALV_RESETVALUE         _U(0x00000000); /**< \brief (AST_CALV reset_value) Calendar Value */
+
+#define AST_CALV_SEC_Pos            0            /**< \brief (AST_CALV) Second */
+#define AST_CALV_SEC_Msk            (_U(0x3F) << AST_CALV_SEC_Pos)
+#define AST_CALV_SEC(value)         (AST_CALV_SEC_Msk & ((value) << AST_CALV_SEC_Pos))
+#define AST_CALV_MIN_Pos            6            /**< \brief (AST_CALV) Minute */
+#define AST_CALV_MIN_Msk            (_U(0x3F) << AST_CALV_MIN_Pos)
+#define AST_CALV_MIN(value)         (AST_CALV_MIN_Msk & ((value) << AST_CALV_MIN_Pos))
+#define AST_CALV_HOUR_Pos           12           /**< \brief (AST_CALV) Hour */
+#define AST_CALV_HOUR_Msk           (_U(0x1F) << AST_CALV_HOUR_Pos)
+#define AST_CALV_HOUR(value)        (AST_CALV_HOUR_Msk & ((value) << AST_CALV_HOUR_Pos))
+#define AST_CALV_DAY_Pos            17           /**< \brief (AST_CALV) Day */
+#define AST_CALV_DAY_Msk            (_U(0x1F) << AST_CALV_DAY_Pos)
+#define AST_CALV_DAY(value)         (AST_CALV_DAY_Msk & ((value) << AST_CALV_DAY_Pos))
+#define AST_CALV_MONTH_Pos          22           /**< \brief (AST_CALV) Month */
+#define AST_CALV_MONTH_Msk          (_U(0xF) << AST_CALV_MONTH_Pos)
+#define AST_CALV_MONTH(value)       (AST_CALV_MONTH_Msk & ((value) << AST_CALV_MONTH_Pos))
+#define AST_CALV_YEAR_Pos           26           /**< \brief (AST_CALV) Year */
+#define AST_CALV_YEAR_Msk           (_U(0x3F) << AST_CALV_YEAR_Pos)
+#define AST_CALV_YEAR(value)        (AST_CALV_YEAR_Msk & ((value) << AST_CALV_YEAR_Pos))
+#define AST_CALV_MASK               _U(0xFFFFFFFF) /**< \brief (AST_CALV) MASK Register */
+
+/* -------- AST_PARAMETER : (AST Offset: 0xF0) (R/  32) Parameter Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DT:1;             /*!< bit:      0  Digital Tuner                      */
+    uint32_t DTEXPWA:1;        /*!< bit:      1  Digital Tuner Exponent Writeable   */
+    uint32_t DTEXPVALUE:5;     /*!< bit:  2.. 6  Digital Tuner Exponent Value       */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t NUMAR:2;          /*!< bit:  8.. 9  Number of alarm comparators        */
+    uint32_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint32_t NUMPIR:1;         /*!< bit:     12  Number of periodic comparators     */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t PIR0WA:1;         /*!< bit:     14  Periodic Interval 0 Writeable      */
+    uint32_t PIR1WA:1;         /*!< bit:     15  Periodic Interval 1 Writeable      */
+    uint32_t PER0VALUE:5;      /*!< bit: 16..20  Periodic Interval 0 Value          */
+    uint32_t :3;               /*!< bit: 21..23  Reserved                           */
+    uint32_t PER1VALUE:5;      /*!< bit: 24..28  Periodic Interval 1 Value          */
+    uint32_t :3;               /*!< bit: 29..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AST_PARAMETER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AST_PARAMETER_OFFSET        0xF0         /**< \brief (AST_PARAMETER offset) Parameter Register */
+
+#define AST_PARAMETER_DT_Pos        0            /**< \brief (AST_PARAMETER) Digital Tuner */
+#define AST_PARAMETER_DT            (_U(0x1) << AST_PARAMETER_DT_Pos)
+#define   AST_PARAMETER_DT_OFF_Val        _U(0x0)   /**< \brief (AST_PARAMETER) Digital tuner off */
+#define   AST_PARAMETER_DT_ON_Val         _U(0x1)   /**< \brief (AST_PARAMETER) Digital tuner on */
+#define AST_PARAMETER_DT_OFF        (AST_PARAMETER_DT_OFF_Val      << AST_PARAMETER_DT_Pos)
+#define AST_PARAMETER_DT_ON         (AST_PARAMETER_DT_ON_Val       << AST_PARAMETER_DT_Pos)
+#define AST_PARAMETER_DTEXPWA_Pos   1            /**< \brief (AST_PARAMETER) Digital Tuner Exponent Writeable */
+#define AST_PARAMETER_DTEXPWA       (_U(0x1) << AST_PARAMETER_DTEXPWA_Pos)
+#define   AST_PARAMETER_DTEXPWA_0_Val     _U(0x0)   /**< \brief (AST_PARAMETER) Digital tuner exponent is a constant value. Writes to EXP bitfield in DTR will be discarded. */
+#define   AST_PARAMETER_DTEXPWA_1_Val     _U(0x1)   /**< \brief (AST_PARAMETER) Digital tuner exponent is chosen by writing to EXP bitfield in DTR */
+#define AST_PARAMETER_DTEXPWA_0     (AST_PARAMETER_DTEXPWA_0_Val   << AST_PARAMETER_DTEXPWA_Pos)
+#define AST_PARAMETER_DTEXPWA_1     (AST_PARAMETER_DTEXPWA_1_Val   << AST_PARAMETER_DTEXPWA_Pos)
+#define AST_PARAMETER_DTEXPVALUE_Pos 2            /**< \brief (AST_PARAMETER) Digital Tuner Exponent Value */
+#define AST_PARAMETER_DTEXPVALUE_Msk (_U(0x1F) << AST_PARAMETER_DTEXPVALUE_Pos)
+#define AST_PARAMETER_DTEXPVALUE(value) (AST_PARAMETER_DTEXPVALUE_Msk & ((value) << AST_PARAMETER_DTEXPVALUE_Pos))
+#define AST_PARAMETER_NUMAR_Pos     8            /**< \brief (AST_PARAMETER) Number of alarm comparators */
+#define AST_PARAMETER_NUMAR_Msk     (_U(0x3) << AST_PARAMETER_NUMAR_Pos)
+#define AST_PARAMETER_NUMAR(value)  (AST_PARAMETER_NUMAR_Msk & ((value) << AST_PARAMETER_NUMAR_Pos))
+#define   AST_PARAMETER_NUMAR_ZERO_Val    _U(0x0)   /**< \brief (AST_PARAMETER) No alarm comparators */
+#define   AST_PARAMETER_NUMAR_ONE_Val     _U(0x1)   /**< \brief (AST_PARAMETER) One alarm comparator */
+#define   AST_PARAMETER_NUMAR_TWO_Val     _U(0x2)   /**< \brief (AST_PARAMETER) Two alarm comparators */
+#define AST_PARAMETER_NUMAR_ZERO    (AST_PARAMETER_NUMAR_ZERO_Val  << AST_PARAMETER_NUMAR_Pos)
+#define AST_PARAMETER_NUMAR_ONE     (AST_PARAMETER_NUMAR_ONE_Val   << AST_PARAMETER_NUMAR_Pos)
+#define AST_PARAMETER_NUMAR_TWO     (AST_PARAMETER_NUMAR_TWO_Val   << AST_PARAMETER_NUMAR_Pos)
+#define AST_PARAMETER_NUMPIR_Pos    12           /**< \brief (AST_PARAMETER) Number of periodic comparators */
+#define AST_PARAMETER_NUMPIR        (_U(0x1) << AST_PARAMETER_NUMPIR_Pos)
+#define   AST_PARAMETER_NUMPIR_ONE_Val    _U(0x0)   /**< \brief (AST_PARAMETER) One periodic comparator */
+#define   AST_PARAMETER_NUMPIR_TWO_Val    _U(0x1)   /**< \brief (AST_PARAMETER) Two periodic comparators */
+#define AST_PARAMETER_NUMPIR_ONE    (AST_PARAMETER_NUMPIR_ONE_Val  << AST_PARAMETER_NUMPIR_Pos)
+#define AST_PARAMETER_NUMPIR_TWO    (AST_PARAMETER_NUMPIR_TWO_Val  << AST_PARAMETER_NUMPIR_Pos)
+#define AST_PARAMETER_PIR0WA_Pos    14           /**< \brief (AST_PARAMETER) Periodic Interval 0 Writeable */
+#define AST_PARAMETER_PIR0WA        (_U(0x1) << AST_PARAMETER_PIR0WA_Pos)
+#define   AST_PARAMETER_PIR0WA_0_Val      _U(0x0)   /**< \brief (AST_PARAMETER) Periodic alarm prescaler 0 tapping is a constant value. Writes to INSEL bitfield in PIR0 will be discarded. */
+#define   AST_PARAMETER_PIR0WA_1_Val      _U(0x1)   /**< \brief (AST_PARAMETER) Periodic alarm prescaler 0 tapping is chosen by writing to INSEL bitfield in PIR0 */
+#define AST_PARAMETER_PIR0WA_0      (AST_PARAMETER_PIR0WA_0_Val    << AST_PARAMETER_PIR0WA_Pos)
+#define AST_PARAMETER_PIR0WA_1      (AST_PARAMETER_PIR0WA_1_Val    << AST_PARAMETER_PIR0WA_Pos)
+#define AST_PARAMETER_PIR1WA_Pos    15           /**< \brief (AST_PARAMETER) Periodic Interval 1 Writeable */
+#define AST_PARAMETER_PIR1WA        (_U(0x1) << AST_PARAMETER_PIR1WA_Pos)
+#define   AST_PARAMETER_PIR1WA_0_Val      _U(0x0)   /**< \brief (AST_PARAMETER) Writes to PIR1 will be discarded */
+#define   AST_PARAMETER_PIR1WA_1_Val      _U(0x1)   /**< \brief (AST_PARAMETER) PIR1 can be written */
+#define AST_PARAMETER_PIR1WA_0      (AST_PARAMETER_PIR1WA_0_Val    << AST_PARAMETER_PIR1WA_Pos)
+#define AST_PARAMETER_PIR1WA_1      (AST_PARAMETER_PIR1WA_1_Val    << AST_PARAMETER_PIR1WA_Pos)
+#define AST_PARAMETER_PER0VALUE_Pos 16           /**< \brief (AST_PARAMETER) Periodic Interval 0 Value */
+#define AST_PARAMETER_PER0VALUE_Msk (_U(0x1F) << AST_PARAMETER_PER0VALUE_Pos)
+#define AST_PARAMETER_PER0VALUE(value) (AST_PARAMETER_PER0VALUE_Msk & ((value) << AST_PARAMETER_PER0VALUE_Pos))
+#define AST_PARAMETER_PER1VALUE_Pos 24           /**< \brief (AST_PARAMETER) Periodic Interval 1 Value */
+#define AST_PARAMETER_PER1VALUE_Msk (_U(0x1F) << AST_PARAMETER_PER1VALUE_Pos)
+#define AST_PARAMETER_PER1VALUE(value) (AST_PARAMETER_PER1VALUE_Msk & ((value) << AST_PARAMETER_PER1VALUE_Pos))
+#define AST_PARAMETER_MASK          _U(0x1F1FD37F) /**< \brief (AST_PARAMETER) MASK Register */
+
+/* -------- AST_VERSION : (AST Offset: 0xFC) (R/  32) Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version Number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant Number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AST_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AST_VERSION_OFFSET          0xFC         /**< \brief (AST_VERSION offset) Version Register */
+#define AST_VERSION_RESETVALUE      _U(0x00000311); /**< \brief (AST_VERSION reset_value) Version Register */
+
+#define AST_VERSION_VERSION_Pos     0            /**< \brief (AST_VERSION) Version Number */
+#define AST_VERSION_VERSION_Msk     (_U(0xFFF) << AST_VERSION_VERSION_Pos)
+#define AST_VERSION_VERSION(value)  (AST_VERSION_VERSION_Msk & ((value) << AST_VERSION_VERSION_Pos))
+#define AST_VERSION_VARIANT_Pos     16           /**< \brief (AST_VERSION) Variant Number */
+#define AST_VERSION_VARIANT_Msk     (_U(0xF) << AST_VERSION_VARIANT_Pos)
+#define AST_VERSION_VARIANT(value)  (AST_VERSION_VARIANT_Msk & ((value) << AST_VERSION_VARIANT_Pos))
+#define AST_VERSION_MASK            _U(0x000F0FFF) /**< \brief (AST_VERSION) MASK Register */
+
+/** \brief AST hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __IO AST_CR_Type               CR;          /**< \brief Offset: 0x00 (R/W 32) Control Register */
+  __IO AST_CV_Type               CV;          /**< \brief Offset: 0x04 (R/W 32) Counter Value */
+  __I  AST_SR_Type               SR;          /**< \brief Offset: 0x08 (R/  32) Status Register */
+  __O  AST_SCR_Type              SCR;         /**< \brief Offset: 0x0C ( /W 32) Status Clear Register */
+  __O  AST_IER_Type              IER;         /**< \brief Offset: 0x10 ( /W 32) Interrupt Enable Register */
+  __O  AST_IDR_Type              IDR;         /**< \brief Offset: 0x14 ( /W 32) Interrupt Disable Register */
+  __I  AST_IMR_Type              IMR;         /**< \brief Offset: 0x18 (R/  32) Interrupt Mask Register */
+  __IO AST_WER_Type              WER;         /**< \brief Offset: 0x1C (R/W 32) Wake Enable Register */
+  __IO AST_AR0_Type              AR0;         /**< \brief Offset: 0x20 (R/W 32) Alarm Register 0 */
+  __IO AST_AR1_Type              AR1;         /**< \brief Offset: 0x24 (R/W 32) Alarm Register 1 */
+       RoReg8                    Reserved1[0x8];
+  __IO AST_PIR0_Type             PIR0;        /**< \brief Offset: 0x30 (R/W 32) Periodic Interval Register 0 */
+  __IO AST_PIR1_Type             PIR1;        /**< \brief Offset: 0x34 (R/W 32) Periodic Interval Register 1 */
+       RoReg8                    Reserved2[0x8];
+  __IO AST_CLOCK_Type            CLOCK;       /**< \brief Offset: 0x40 (R/W 32) Clock Control Register */
+  __IO AST_DTR_Type              DTR;         /**< \brief Offset: 0x44 (R/W 32) Digital Tuner Register */
+  __O  AST_EVE_Type              EVE;         /**< \brief Offset: 0x48 ( /W 32) Event Enable Register */
+  __O  AST_EVD_Type              EVD;         /**< \brief Offset: 0x4C ( /W 32) Event Disable Register */
+  __I  AST_EVM_Type              EVM;         /**< \brief Offset: 0x50 (R/  32) Event Mask Register */
+  __IO AST_CALV_Type             CALV;        /**< \brief Offset: 0x54 (R/W 32) Calendar Value */
+       RoReg8                    Reserved3[0x98];
+  __I  AST_PARAMETER_Type        PARAMETER;   /**< \brief Offset: 0xF0 (R/  32) Parameter Register */
+       RoReg8                    Reserved4[0x8];
+  __I  AST_VERSION_Type          VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
+ } bf;
+ struct {
+  RwReg   AST_CR;             /**< \brief (AST Offset: 0x00) Control Register */
+  RwReg   AST_CV;             /**< \brief (AST Offset: 0x04) Counter Value */
+  RoReg   AST_SR;             /**< \brief (AST Offset: 0x08) Status Register */
+  WoReg   AST_SCR;            /**< \brief (AST Offset: 0x0C) Status Clear Register */
+  WoReg   AST_IER;            /**< \brief (AST Offset: 0x10) Interrupt Enable Register */
+  WoReg   AST_IDR;            /**< \brief (AST Offset: 0x14) Interrupt Disable Register */
+  RoReg   AST_IMR;            /**< \brief (AST Offset: 0x18) Interrupt Mask Register */
+  RwReg   AST_WER;            /**< \brief (AST Offset: 0x1C) Wake Enable Register */
+  RwReg   AST_AR0;            /**< \brief (AST Offset: 0x20) Alarm Register 0 */
+  RwReg   AST_AR1;            /**< \brief (AST Offset: 0x24) Alarm Register 1 */
+  RoReg8  Reserved5[0x8];
+  RwReg   AST_PIR0;           /**< \brief (AST Offset: 0x30) Periodic Interval Register 0 */
+  RwReg   AST_PIR1;           /**< \brief (AST Offset: 0x34) Periodic Interval Register 1 */
+  RoReg8  Reserved6[0x8];
+  RwReg   AST_CLOCK;          /**< \brief (AST Offset: 0x40) Clock Control Register */
+  RwReg   AST_DTR;            /**< \brief (AST Offset: 0x44) Digital Tuner Register */
+  WoReg   AST_EVE;            /**< \brief (AST Offset: 0x48) Event Enable Register */
+  WoReg   AST_EVD;            /**< \brief (AST Offset: 0x4C) Event Disable Register */
+  RoReg   AST_EVM;            /**< \brief (AST Offset: 0x50) Event Mask Register */
+  RwReg   AST_CALV;           /**< \brief (AST Offset: 0x54) Calendar Value */
+  RoReg8  Reserved7[0x98];
+  RoReg   AST_PARAMETER;      /**< \brief (AST Offset: 0xF0) Parameter Register */
+  RoReg8  Reserved8[0x8];
+  RoReg   AST_VERSION;        /**< \brief (AST Offset: 0xFC) Version Register */
+ } reg;
+} Ast;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_AST_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/ast.h
+++ b/asf/sam/include/sam4l/component/ast.h
@@ -819,59 +819,31 @@ typedef union {
 
 /** \brief AST hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __IO AST_CR_Type               CR;          /**< \brief Offset: 0x00 (R/W 32) Control Register */
-  __IO AST_CV_Type               CV;          /**< \brief Offset: 0x04 (R/W 32) Counter Value */
-  __I  AST_SR_Type               SR;          /**< \brief Offset: 0x08 (R/  32) Status Register */
-  __O  AST_SCR_Type              SCR;         /**< \brief Offset: 0x0C ( /W 32) Status Clear Register */
-  __O  AST_IER_Type              IER;         /**< \brief Offset: 0x10 ( /W 32) Interrupt Enable Register */
-  __O  AST_IDR_Type              IDR;         /**< \brief Offset: 0x14 ( /W 32) Interrupt Disable Register */
-  __I  AST_IMR_Type              IMR;         /**< \brief Offset: 0x18 (R/  32) Interrupt Mask Register */
-  __IO AST_WER_Type              WER;         /**< \brief Offset: 0x1C (R/W 32) Wake Enable Register */
-  __IO AST_AR0_Type              AR0;         /**< \brief Offset: 0x20 (R/W 32) Alarm Register 0 */
-  __IO AST_AR1_Type              AR1;         /**< \brief Offset: 0x24 (R/W 32) Alarm Register 1 */
-       RoReg8                    Reserved1[0x8];
-  __IO AST_PIR0_Type             PIR0;        /**< \brief Offset: 0x30 (R/W 32) Periodic Interval Register 0 */
-  __IO AST_PIR1_Type             PIR1;        /**< \brief Offset: 0x34 (R/W 32) Periodic Interval Register 1 */
-       RoReg8                    Reserved2[0x8];
-  __IO AST_CLOCK_Type            CLOCK;       /**< \brief Offset: 0x40 (R/W 32) Clock Control Register */
-  __IO AST_DTR_Type              DTR;         /**< \brief Offset: 0x44 (R/W 32) Digital Tuner Register */
-  __O  AST_EVE_Type              EVE;         /**< \brief Offset: 0x48 ( /W 32) Event Enable Register */
-  __O  AST_EVD_Type              EVD;         /**< \brief Offset: 0x4C ( /W 32) Event Disable Register */
-  __I  AST_EVM_Type              EVM;         /**< \brief Offset: 0x50 (R/  32) Event Mask Register */
-  __IO AST_CALV_Type             CALV;        /**< \brief Offset: 0x54 (R/W 32) Calendar Value */
-       RoReg8                    Reserved3[0x98];
-  __I  AST_PARAMETER_Type        PARAMETER;   /**< \brief Offset: 0xF0 (R/  32) Parameter Register */
-       RoReg8                    Reserved4[0x8];
-  __I  AST_VERSION_Type          VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
- } bf;
- struct {
-  RwReg   AST_CR;             /**< \brief (AST Offset: 0x00) Control Register */
-  RwReg   AST_CV;             /**< \brief (AST Offset: 0x04) Counter Value */
-  RoReg   AST_SR;             /**< \brief (AST Offset: 0x08) Status Register */
-  WoReg   AST_SCR;            /**< \brief (AST Offset: 0x0C) Status Clear Register */
-  WoReg   AST_IER;            /**< \brief (AST Offset: 0x10) Interrupt Enable Register */
-  WoReg   AST_IDR;            /**< \brief (AST Offset: 0x14) Interrupt Disable Register */
-  RoReg   AST_IMR;            /**< \brief (AST Offset: 0x18) Interrupt Mask Register */
-  RwReg   AST_WER;            /**< \brief (AST Offset: 0x1C) Wake Enable Register */
-  RwReg   AST_AR0;            /**< \brief (AST Offset: 0x20) Alarm Register 0 */
-  RwReg   AST_AR1;            /**< \brief (AST Offset: 0x24) Alarm Register 1 */
-  RoReg8  Reserved5[0x8];
-  RwReg   AST_PIR0;           /**< \brief (AST Offset: 0x30) Periodic Interval Register 0 */
-  RwReg   AST_PIR1;           /**< \brief (AST Offset: 0x34) Periodic Interval Register 1 */
-  RoReg8  Reserved6[0x8];
-  RwReg   AST_CLOCK;          /**< \brief (AST Offset: 0x40) Clock Control Register */
-  RwReg   AST_DTR;            /**< \brief (AST Offset: 0x44) Digital Tuner Register */
-  WoReg   AST_EVE;            /**< \brief (AST Offset: 0x48) Event Enable Register */
-  WoReg   AST_EVD;            /**< \brief (AST Offset: 0x4C) Event Disable Register */
-  RoReg   AST_EVM;            /**< \brief (AST Offset: 0x50) Event Mask Register */
-  RwReg   AST_CALV;           /**< \brief (AST Offset: 0x54) Calendar Value */
-  RoReg8  Reserved7[0x98];
-  RoReg   AST_PARAMETER;      /**< \brief (AST Offset: 0xF0) Parameter Register */
-  RoReg8  Reserved8[0x8];
-  RoReg   AST_VERSION;        /**< \brief (AST Offset: 0xFC) Version Register */
- } reg;
+typedef struct {
+  __IO uint32_t CR;          /**< \brief Offset: 0x00 (R/W 32) Control Register */
+  __IO uint32_t CV;          /**< \brief Offset: 0x04 (R/W 32) Counter Value */
+  __I  uint32_t SR;          /**< \brief Offset: 0x08 (R/  32) Status Register */
+  __O  uint32_t SCR;         /**< \brief Offset: 0x0C ( /W 32) Status Clear Register */
+  __O  uint32_t IER;         /**< \brief Offset: 0x10 ( /W 32) Interrupt Enable Register */
+  __O  uint32_t IDR;         /**< \brief Offset: 0x14 ( /W 32) Interrupt Disable Register */
+  __I  uint32_t IMR;         /**< \brief Offset: 0x18 (R/  32) Interrupt Mask Register */
+  __IO uint32_t WER;         /**< \brief Offset: 0x1C (R/W 32) Wake Enable Register */
+  __IO uint32_t AR0;         /**< \brief Offset: 0x20 (R/W 32) Alarm Register 0 */
+  __IO uint32_t AR1;         /**< \brief Offset: 0x24 (R/W 32) Alarm Register 1 */
+       RoReg8   Reserved1[0x8];
+  __IO uint32_t PIR0;        /**< \brief Offset: 0x30 (R/W 32) Periodic Interval Register 0 */
+  __IO uint32_t PIR1;        /**< \brief Offset: 0x34 (R/W 32) Periodic Interval Register 1 */
+       RoReg8   Reserved2[0x8];
+  __IO uint32_t CLOCK;       /**< \brief Offset: 0x40 (R/W 32) Clock Control Register */
+  __IO uint32_t DTR;         /**< \brief Offset: 0x44 (R/W 32) Digital Tuner Register */
+  __O  uint32_t EVE;         /**< \brief Offset: 0x48 ( /W 32) Event Enable Register */
+  __O  uint32_t EVD;         /**< \brief Offset: 0x4C ( /W 32) Event Disable Register */
+  __I  uint32_t EVM;         /**< \brief Offset: 0x50 (R/  32) Event Mask Register */
+  __IO uint32_t CALV;        /**< \brief Offset: 0x54 (R/W 32) Calendar Value */
+       RoReg8   Reserved3[0x98];
+  __I  uint32_t PARAMETER;   /**< \brief Offset: 0xF0 (R/  32) Parameter Register */
+       RoReg8   Reserved4[0x8];
+  __I  uint32_t VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
 } Ast;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/bpm.h
+++ b/asf/sam/include/sam4l/component/bpm.h
@@ -51,13 +51,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BPM_IER_OFFSET              0x00         /**< \brief (BPM_IER offset) Interrupt Enable Register */
-#define BPM_IER_RESETVALUE          _U(0x00000000); /**< \brief (BPM_IER reset_value) Interrupt Enable Register */
+#define BPM_IER_RESETVALUE          _U_(0x00000000); /**< \brief (BPM_IER reset_value) Interrupt Enable Register */
 
 #define BPM_IER_PSOK_Pos            0            /**< \brief (BPM_IER) Power Scaling OK Interrupt Enable */
-#define BPM_IER_PSOK                (_U(0x1) << BPM_IER_PSOK_Pos)
+#define BPM_IER_PSOK                (_U_(0x1) << BPM_IER_PSOK_Pos)
 #define BPM_IER_AE_Pos              31           /**< \brief (BPM_IER) Access Error Interrupt Enable */
-#define BPM_IER_AE                  (_U(0x1) << BPM_IER_AE_Pos)
-#define BPM_IER_MASK                _U(0x80000001) /**< \brief (BPM_IER) MASK Register */
+#define BPM_IER_AE                  (_U_(0x1) << BPM_IER_AE_Pos)
+#define BPM_IER_MASK                _U_(0x80000001) /**< \brief (BPM_IER) MASK Register */
 
 /* -------- BPM_IDR : (BPM Offset: 0x04) ( /W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -72,13 +72,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BPM_IDR_OFFSET              0x04         /**< \brief (BPM_IDR offset) Interrupt Disable Register */
-#define BPM_IDR_RESETVALUE          _U(0x00000000); /**< \brief (BPM_IDR reset_value) Interrupt Disable Register */
+#define BPM_IDR_RESETVALUE          _U_(0x00000000); /**< \brief (BPM_IDR reset_value) Interrupt Disable Register */
 
 #define BPM_IDR_PSOK_Pos            0            /**< \brief (BPM_IDR) Power Scaling OK Interrupt Disable */
-#define BPM_IDR_PSOK                (_U(0x1) << BPM_IDR_PSOK_Pos)
+#define BPM_IDR_PSOK                (_U_(0x1) << BPM_IDR_PSOK_Pos)
 #define BPM_IDR_AE_Pos              31           /**< \brief (BPM_IDR) Access Error Interrupt Disable */
-#define BPM_IDR_AE                  (_U(0x1) << BPM_IDR_AE_Pos)
-#define BPM_IDR_MASK                _U(0x80000001) /**< \brief (BPM_IDR) MASK Register */
+#define BPM_IDR_AE                  (_U_(0x1) << BPM_IDR_AE_Pos)
+#define BPM_IDR_MASK                _U_(0x80000001) /**< \brief (BPM_IDR) MASK Register */
 
 /* -------- BPM_IMR : (BPM Offset: 0x08) (R/  32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -93,13 +93,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BPM_IMR_OFFSET              0x08         /**< \brief (BPM_IMR offset) Interrupt Mask Register */
-#define BPM_IMR_RESETVALUE          _U(0x00000000); /**< \brief (BPM_IMR reset_value) Interrupt Mask Register */
+#define BPM_IMR_RESETVALUE          _U_(0x00000000); /**< \brief (BPM_IMR reset_value) Interrupt Mask Register */
 
 #define BPM_IMR_PSOK_Pos            0            /**< \brief (BPM_IMR) Power Scaling OK Interrupt Mask */
-#define BPM_IMR_PSOK                (_U(0x1) << BPM_IMR_PSOK_Pos)
+#define BPM_IMR_PSOK                (_U_(0x1) << BPM_IMR_PSOK_Pos)
 #define BPM_IMR_AE_Pos              31           /**< \brief (BPM_IMR) Access Error Interrupt Mask */
-#define BPM_IMR_AE                  (_U(0x1) << BPM_IMR_AE_Pos)
-#define BPM_IMR_MASK                _U(0x80000001) /**< \brief (BPM_IMR) MASK Register */
+#define BPM_IMR_AE                  (_U_(0x1) << BPM_IMR_AE_Pos)
+#define BPM_IMR_MASK                _U_(0x80000001) /**< \brief (BPM_IMR) MASK Register */
 
 /* -------- BPM_ISR : (BPM Offset: 0x0C) (R/  32) Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -114,13 +114,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BPM_ISR_OFFSET              0x0C         /**< \brief (BPM_ISR offset) Interrupt Status Register */
-#define BPM_ISR_RESETVALUE          _U(0x00000000); /**< \brief (BPM_ISR reset_value) Interrupt Status Register */
+#define BPM_ISR_RESETVALUE          _U_(0x00000000); /**< \brief (BPM_ISR reset_value) Interrupt Status Register */
 
 #define BPM_ISR_PSOK_Pos            0            /**< \brief (BPM_ISR) Power Scaling OK Interrupt Status */
-#define BPM_ISR_PSOK                (_U(0x1) << BPM_ISR_PSOK_Pos)
+#define BPM_ISR_PSOK                (_U_(0x1) << BPM_ISR_PSOK_Pos)
 #define BPM_ISR_AE_Pos              31           /**< \brief (BPM_ISR) Access Error Interrupt Status */
-#define BPM_ISR_AE                  (_U(0x1) << BPM_ISR_AE_Pos)
-#define BPM_ISR_MASK                _U(0x80000001) /**< \brief (BPM_ISR) MASK Register */
+#define BPM_ISR_AE                  (_U_(0x1) << BPM_ISR_AE_Pos)
+#define BPM_ISR_MASK                _U_(0x80000001) /**< \brief (BPM_ISR) MASK Register */
 
 /* -------- BPM_ICR : (BPM Offset: 0x10) ( /W 32) Interrupt Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -135,13 +135,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BPM_ICR_OFFSET              0x10         /**< \brief (BPM_ICR offset) Interrupt Clear Register */
-#define BPM_ICR_RESETVALUE          _U(0x00000000); /**< \brief (BPM_ICR reset_value) Interrupt Clear Register */
+#define BPM_ICR_RESETVALUE          _U_(0x00000000); /**< \brief (BPM_ICR reset_value) Interrupt Clear Register */
 
 #define BPM_ICR_PSOK_Pos            0            /**< \brief (BPM_ICR) Power Scaling OK Interrupt Status Clear */
-#define BPM_ICR_PSOK                (_U(0x1) << BPM_ICR_PSOK_Pos)
+#define BPM_ICR_PSOK                (_U_(0x1) << BPM_ICR_PSOK_Pos)
 #define BPM_ICR_AE_Pos              31           /**< \brief (BPM_ICR) Access Error Interrupt Status Clear */
-#define BPM_ICR_AE                  (_U(0x1) << BPM_ICR_AE_Pos)
-#define BPM_ICR_MASK                _U(0x80000001) /**< \brief (BPM_ICR) MASK Register */
+#define BPM_ICR_AE                  (_U_(0x1) << BPM_ICR_AE_Pos)
+#define BPM_ICR_MASK                _U_(0x80000001) /**< \brief (BPM_ICR) MASK Register */
 
 /* -------- BPM_SR : (BPM Offset: 0x14) (R/  32) Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -156,13 +156,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BPM_SR_OFFSET               0x14         /**< \brief (BPM_SR offset) Status Register */
-#define BPM_SR_RESETVALUE           _U(0x00000000); /**< \brief (BPM_SR reset_value) Status Register */
+#define BPM_SR_RESETVALUE           _U_(0x00000000); /**< \brief (BPM_SR reset_value) Status Register */
 
 #define BPM_SR_PSOK_Pos             0            /**< \brief (BPM_SR) Power Scaling OK Status */
-#define BPM_SR_PSOK                 (_U(0x1) << BPM_SR_PSOK_Pos)
+#define BPM_SR_PSOK                 (_U_(0x1) << BPM_SR_PSOK_Pos)
 #define BPM_SR_AE_Pos               31           /**< \brief (BPM_SR) Access Error */
-#define BPM_SR_AE                   (_U(0x1) << BPM_SR_AE_Pos)
-#define BPM_SR_MASK                 _U(0x80000001) /**< \brief (BPM_SR) MASK Register */
+#define BPM_SR_AE                   (_U_(0x1) << BPM_SR_AE_Pos)
+#define BPM_SR_MASK                 _U_(0x80000001) /**< \brief (BPM_SR) MASK Register */
 
 /* -------- BPM_UNLOCK : (BPM Offset: 0x18) ( /W 32) Unlock Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -177,15 +177,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BPM_UNLOCK_OFFSET           0x18         /**< \brief (BPM_UNLOCK offset) Unlock Register */
-#define BPM_UNLOCK_RESETVALUE       _U(0x00000000); /**< \brief (BPM_UNLOCK reset_value) Unlock Register */
+#define BPM_UNLOCK_RESETVALUE       _U_(0x00000000); /**< \brief (BPM_UNLOCK reset_value) Unlock Register */
 
 #define BPM_UNLOCK_ADDR_Pos         0            /**< \brief (BPM_UNLOCK) Unlock Address */
-#define BPM_UNLOCK_ADDR_Msk         (_U(0x3FF) << BPM_UNLOCK_ADDR_Pos)
+#define BPM_UNLOCK_ADDR_Msk         (_U_(0x3FF) << BPM_UNLOCK_ADDR_Pos)
 #define BPM_UNLOCK_ADDR(value)      (BPM_UNLOCK_ADDR_Msk & ((value) << BPM_UNLOCK_ADDR_Pos))
 #define BPM_UNLOCK_KEY_Pos          24           /**< \brief (BPM_UNLOCK) Unlock Key */
-#define BPM_UNLOCK_KEY_Msk          (_U(0xFF) << BPM_UNLOCK_KEY_Pos)
+#define BPM_UNLOCK_KEY_Msk          (_U_(0xFF) << BPM_UNLOCK_KEY_Pos)
 #define BPM_UNLOCK_KEY(value)       (BPM_UNLOCK_KEY_Msk & ((value) << BPM_UNLOCK_KEY_Pos))
-#define BPM_UNLOCK_MASK             _U(0xFF0003FF) /**< \brief (BPM_UNLOCK) MASK Register */
+#define BPM_UNLOCK_MASK             _U_(0xFF0003FF) /**< \brief (BPM_UNLOCK) MASK Register */
 
 /* -------- BPM_PMCON : (BPM Offset: 0x1C) (R/W 32) Power Mode Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -210,27 +210,27 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BPM_PMCON_OFFSET            0x1C         /**< \brief (BPM_PMCON offset) Power Mode Control Register */
-#define BPM_PMCON_RESETVALUE        _U(0x00000000); /**< \brief (BPM_PMCON reset_value) Power Mode Control Register */
+#define BPM_PMCON_RESETVALUE        _U_(0x00000000); /**< \brief (BPM_PMCON reset_value) Power Mode Control Register */
 
 #define BPM_PMCON_PS_Pos            0            /**< \brief (BPM_PMCON) Power Scaling Configuration Value */
-#define BPM_PMCON_PS_Msk            (_U(0x3) << BPM_PMCON_PS_Pos)
+#define BPM_PMCON_PS_Msk            (_U_(0x3) << BPM_PMCON_PS_Pos)
 #define BPM_PMCON_PS(value)         (BPM_PMCON_PS_Msk & ((value) << BPM_PMCON_PS_Pos))
 #define BPM_PMCON_PSCREQ_Pos        2            /**< \brief (BPM_PMCON) Power Scaling Change Request */
-#define BPM_PMCON_PSCREQ            (_U(0x1) << BPM_PMCON_PSCREQ_Pos)
+#define BPM_PMCON_PSCREQ            (_U_(0x1) << BPM_PMCON_PSCREQ_Pos)
 #define BPM_PMCON_PSCM_Pos          3            /**< \brief (BPM_PMCON) Power Scaling Change Mode */
-#define BPM_PMCON_PSCM              (_U(0x1) << BPM_PMCON_PSCM_Pos)
+#define BPM_PMCON_PSCM              (_U_(0x1) << BPM_PMCON_PSCM_Pos)
 #define BPM_PMCON_BKUP_Pos          8            /**< \brief (BPM_PMCON) BACKUP Mode */
-#define BPM_PMCON_BKUP              (_U(0x1) << BPM_PMCON_BKUP_Pos)
+#define BPM_PMCON_BKUP              (_U_(0x1) << BPM_PMCON_BKUP_Pos)
 #define BPM_PMCON_RET_Pos           9            /**< \brief (BPM_PMCON) RETENTION Mode */
-#define BPM_PMCON_RET               (_U(0x1) << BPM_PMCON_RET_Pos)
+#define BPM_PMCON_RET               (_U_(0x1) << BPM_PMCON_RET_Pos)
 #define BPM_PMCON_SLEEP_Pos         12           /**< \brief (BPM_PMCON) SLEEP mode Configuration */
-#define BPM_PMCON_SLEEP_Msk         (_U(0x3) << BPM_PMCON_SLEEP_Pos)
+#define BPM_PMCON_SLEEP_Msk         (_U_(0x3) << BPM_PMCON_SLEEP_Pos)
 #define BPM_PMCON_SLEEP(value)      (BPM_PMCON_SLEEP_Msk & ((value) << BPM_PMCON_SLEEP_Pos))
 #define BPM_PMCON_CK32S_Pos         16           /**< \brief (BPM_PMCON) 32Khz-1Khz Clock Source Selection */
-#define BPM_PMCON_CK32S             (_U(0x1) << BPM_PMCON_CK32S_Pos)
+#define BPM_PMCON_CK32S             (_U_(0x1) << BPM_PMCON_CK32S_Pos)
 #define BPM_PMCON_FASTWKUP_Pos      24           /**< \brief (BPM_PMCON) Fast Wakeup */
-#define BPM_PMCON_FASTWKUP          (_U(0x1) << BPM_PMCON_FASTWKUP_Pos)
-#define BPM_PMCON_MASK              _U(0x0101330F) /**< \brief (BPM_PMCON) MASK Register */
+#define BPM_PMCON_FASTWKUP          (_U_(0x1) << BPM_PMCON_FASTWKUP_Pos)
+#define BPM_PMCON_MASK              _U_(0x0101330F) /**< \brief (BPM_PMCON) MASK Register */
 
 /* -------- BPM_BKUPWCAUSE : (BPM Offset: 0x28) (R/  32) Backup Wake up Cause Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -240,8 +240,8 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BPM_BKUPWCAUSE_OFFSET       0x28         /**< \brief (BPM_BKUPWCAUSE offset) Backup Wake up Cause Register */
-#define BPM_BKUPWCAUSE_RESETVALUE   _U(0x00000000); /**< \brief (BPM_BKUPWCAUSE reset_value) Backup Wake up Cause Register */
-#define BPM_BKUPWCAUSE_MASK         _U(0xFFFFFFFF) /**< \brief (BPM_BKUPWCAUSE) MASK Register */
+#define BPM_BKUPWCAUSE_RESETVALUE   _U_(0x00000000); /**< \brief (BPM_BKUPWCAUSE reset_value) Backup Wake up Cause Register */
+#define BPM_BKUPWCAUSE_MASK         _U_(0xFFFFFFFF) /**< \brief (BPM_BKUPWCAUSE) MASK Register */
 
 /* -------- BPM_BKUPWEN : (BPM Offset: 0x2C) (R/W 32) Backup Wake up Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -251,8 +251,8 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BPM_BKUPWEN_OFFSET          0x2C         /**< \brief (BPM_BKUPWEN offset) Backup Wake up Enable Register */
-#define BPM_BKUPWEN_RESETVALUE      _U(0x00000000); /**< \brief (BPM_BKUPWEN reset_value) Backup Wake up Enable Register */
-#define BPM_BKUPWEN_MASK            _U(0xFFFFFFFF) /**< \brief (BPM_BKUPWEN) MASK Register */
+#define BPM_BKUPWEN_RESETVALUE      _U_(0x00000000); /**< \brief (BPM_BKUPWEN reset_value) Backup Wake up Enable Register */
+#define BPM_BKUPWEN_MASK            _U_(0xFFFFFFFF) /**< \brief (BPM_BKUPWEN) MASK Register */
 
 /* -------- BPM_BKUPPMUX : (BPM Offset: 0x30) (R/W 32) Backup Pin Muxing Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -266,12 +266,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BPM_BKUPPMUX_OFFSET         0x30         /**< \brief (BPM_BKUPPMUX offset) Backup Pin Muxing Register */
-#define BPM_BKUPPMUX_RESETVALUE     _U(0x00000000); /**< \brief (BPM_BKUPPMUX reset_value) Backup Pin Muxing Register */
+#define BPM_BKUPPMUX_RESETVALUE     _U_(0x00000000); /**< \brief (BPM_BKUPPMUX reset_value) Backup Pin Muxing Register */
 
 #define BPM_BKUPPMUX_BKUPPMUX_Pos   0            /**< \brief (BPM_BKUPPMUX) Backup Pin Muxing */
-#define BPM_BKUPPMUX_BKUPPMUX_Msk   (_U(0x1FF) << BPM_BKUPPMUX_BKUPPMUX_Pos)
+#define BPM_BKUPPMUX_BKUPPMUX_Msk   (_U_(0x1FF) << BPM_BKUPPMUX_BKUPPMUX_Pos)
 #define BPM_BKUPPMUX_BKUPPMUX(value) (BPM_BKUPPMUX_BKUPPMUX_Msk & ((value) << BPM_BKUPPMUX_BKUPPMUX_Pos))
-#define BPM_BKUPPMUX_MASK           _U(0x000001FF) /**< \brief (BPM_BKUPPMUX) MASK Register */
+#define BPM_BKUPPMUX_MASK           _U_(0x000001FF) /**< \brief (BPM_BKUPPMUX) MASK Register */
 
 /* -------- BPM_IORET : (BPM Offset: 0x34) (R/W 32) Input Output Retention Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -285,11 +285,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BPM_IORET_OFFSET            0x34         /**< \brief (BPM_IORET offset) Input Output Retention Register */
-#define BPM_IORET_RESETVALUE        _U(0x00000000); /**< \brief (BPM_IORET reset_value) Input Output Retention Register */
+#define BPM_IORET_RESETVALUE        _U_(0x00000000); /**< \brief (BPM_IORET reset_value) Input Output Retention Register */
 
 #define BPM_IORET_RET_Pos           0            /**< \brief (BPM_IORET) Retention on I/O lines after waking up from the BACKUP mode */
-#define BPM_IORET_RET               (_U(0x1) << BPM_IORET_RET_Pos)
-#define BPM_IORET_MASK              _U(0x00000001) /**< \brief (BPM_IORET) MASK Register */
+#define BPM_IORET_RET               (_U_(0x1) << BPM_IORET_RET_Pos)
+#define BPM_IORET_MASK              _U_(0x00000001) /**< \brief (BPM_IORET) MASK Register */
 
 /* -------- BPM_BPR : (BPM Offset: 0x40) (R/W 32) Bypass Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -315,35 +315,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BPM_BPR_OFFSET              0x40         /**< \brief (BPM_BPR offset) Bypass Register */
-#define BPM_BPR_RESETVALUE          _U(0x00000000); /**< \brief (BPM_BPR reset_value) Bypass Register */
+#define BPM_BPR_RESETVALUE          _U_(0x00000000); /**< \brief (BPM_BPR reset_value) Bypass Register */
 
 #define BPM_BPR_RUNPSPB_Pos         0            /**< \brief (BPM_BPR) Run Mode Power Scaling Preset Bypass */
-#define BPM_BPR_RUNPSPB             (_U(0x1) << BPM_BPR_RUNPSPB_Pos)
+#define BPM_BPR_RUNPSPB             (_U_(0x1) << BPM_BPR_RUNPSPB_Pos)
 #define BPM_BPR_PSMPSPB_Pos         1            /**< \brief (BPM_BPR) Power Save Mode Power Scaling Preset Bypass */
-#define BPM_BPR_PSMPSPB             (_U(0x1) << BPM_BPR_PSMPSPB_Pos)
+#define BPM_BPR_PSMPSPB             (_U_(0x1) << BPM_BPR_PSMPSPB_Pos)
 #define BPM_BPR_SEQSTN_Pos          2            /**< \brief (BPM_BPR) Sequencial Startup from ULP (Active Low) */
-#define BPM_BPR_SEQSTN              (_U(0x1) << BPM_BPR_SEQSTN_Pos)
+#define BPM_BPR_SEQSTN              (_U_(0x1) << BPM_BPR_SEQSTN_Pos)
 #define BPM_BPR_PSBTD_Pos           3            /**< \brief (BPM_BPR) Power Scaling Bias Timing Disable */
-#define BPM_BPR_PSBTD               (_U(0x1) << BPM_BPR_PSBTD_Pos)
+#define BPM_BPR_PSBTD               (_U_(0x1) << BPM_BPR_PSBTD_Pos)
 #define BPM_BPR_PSHFD_Pos           4            /**< \brief (BPM_BPR) Power Scaling Halt Flash Until VREGOK Disable */
-#define BPM_BPR_PSHFD               (_U(0x1) << BPM_BPR_PSHFD_Pos)
+#define BPM_BPR_PSHFD               (_U_(0x1) << BPM_BPR_PSHFD_Pos)
 #define BPM_BPR_DLYRSTD_Pos         5            /**< \brief (BPM_BPR) Delaying Reset Disable */
-#define BPM_BPR_DLYRSTD             (_U(0x1) << BPM_BPR_DLYRSTD_Pos)
+#define BPM_BPR_DLYRSTD             (_U_(0x1) << BPM_BPR_DLYRSTD_Pos)
 #define BPM_BPR_BIASSEN_Pos         6            /**< \brief (BPM_BPR) Bias Switch Enable */
-#define BPM_BPR_BIASSEN             (_U(0x1) << BPM_BPR_BIASSEN_Pos)
+#define BPM_BPR_BIASSEN             (_U_(0x1) << BPM_BPR_BIASSEN_Pos)
 #define BPM_BPR_LATSEN_Pos          7            /**< \brief (BPM_BPR) Latdel Switch Enable */
-#define BPM_BPR_LATSEN              (_U(0x1) << BPM_BPR_LATSEN_Pos)
+#define BPM_BPR_LATSEN              (_U_(0x1) << BPM_BPR_LATSEN_Pos)
 #define BPM_BPR_BOD18CONT_Pos       8            /**< \brief (BPM_BPR) BOD18 in continuous mode not disabled in WAIT/RET/BACKUP modes */
-#define BPM_BPR_BOD18CONT           (_U(0x1) << BPM_BPR_BOD18CONT_Pos)
+#define BPM_BPR_BOD18CONT           (_U_(0x1) << BPM_BPR_BOD18CONT_Pos)
 #define BPM_BPR_POBS_Pos            9            /**< \brief (BPM_BPR) Pico Uart Observability */
-#define BPM_BPR_POBS                (_U(0x1) << BPM_BPR_POBS_Pos)
+#define BPM_BPR_POBS                (_U_(0x1) << BPM_BPR_POBS_Pos)
 #define BPM_BPR_FFFW_Pos            10           /**< \brief (BPM_BPR) Force Flash Fast Wakeup */
-#define BPM_BPR_FFFW                (_U(0x1) << BPM_BPR_FFFW_Pos)
+#define BPM_BPR_FFFW                (_U_(0x1) << BPM_BPR_FFFW_Pos)
 #define BPM_BPR_FBRDYEN_Pos         11           /**< \brief (BPM_BPR) Flash Bias Ready Enable */
-#define BPM_BPR_FBRDYEN             (_U(0x1) << BPM_BPR_FBRDYEN_Pos)
+#define BPM_BPR_FBRDYEN             (_U_(0x1) << BPM_BPR_FBRDYEN_Pos)
 #define BPM_BPR_FVREFSEN_Pos        12           /**< \brief (BPM_BPR) Flash Vref Switch Enable */
-#define BPM_BPR_FVREFSEN            (_U(0x1) << BPM_BPR_FVREFSEN_Pos)
-#define BPM_BPR_MASK                _U(0x00001FFF) /**< \brief (BPM_BPR) MASK Register */
+#define BPM_BPR_FVREFSEN            (_U_(0x1) << BPM_BPR_FVREFSEN_Pos)
+#define BPM_BPR_MASK                _U_(0x00001FFF) /**< \brief (BPM_BPR) MASK Register */
 
 /* -------- BPM_FWRUNPS : (BPM Offset: 0x44) (R/  32) Factory Word Run PS Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -365,43 +365,43 @@ typedef union {
 #define BPM_FWRUNPS_OFFSET          0x44         /**< \brief (BPM_FWRUNPS offset) Factory Word Run PS Register */
 
 #define BPM_FWRUNPS_REGLEVEL_Pos    0            /**< \brief (BPM_FWRUNPS) Regulator Voltage Level */
-#define BPM_FWRUNPS_REGLEVEL_Msk    (_U(0xF) << BPM_FWRUNPS_REGLEVEL_Pos)
+#define BPM_FWRUNPS_REGLEVEL_Msk    (_U_(0xF) << BPM_FWRUNPS_REGLEVEL_Pos)
 #define BPM_FWRUNPS_REGLEVEL(value) (BPM_FWRUNPS_REGLEVEL_Msk & ((value) << BPM_FWRUNPS_REGLEVEL_Pos))
 #define BPM_FWRUNPS_REGTYPE_Pos     4            /**< \brief (BPM_FWRUNPS) Regulator Type */
-#define BPM_FWRUNPS_REGTYPE_Msk     (_U(0x3) << BPM_FWRUNPS_REGTYPE_Pos)
+#define BPM_FWRUNPS_REGTYPE_Msk     (_U_(0x3) << BPM_FWRUNPS_REGTYPE_Pos)
 #define BPM_FWRUNPS_REGTYPE(value)  (BPM_FWRUNPS_REGTYPE_Msk & ((value) << BPM_FWRUNPS_REGTYPE_Pos))
-#define   BPM_FWRUNPS_REGTYPE_NORMAL_Val  _U(0x0)   /**< \brief (BPM_FWRUNPS)  */
-#define   BPM_FWRUNPS_REGTYPE_LP_Val      _U(0x1)   /**< \brief (BPM_FWRUNPS)  */
-#define   BPM_FWRUNPS_REGTYPE_XULP_Val    _U(0x2)   /**< \brief (BPM_FWRUNPS)  */
+#define   BPM_FWRUNPS_REGTYPE_NORMAL_Val  _U_(0x0)   /**< \brief (BPM_FWRUNPS)  */
+#define   BPM_FWRUNPS_REGTYPE_LP_Val      _U_(0x1)   /**< \brief (BPM_FWRUNPS)  */
+#define   BPM_FWRUNPS_REGTYPE_XULP_Val    _U_(0x2)   /**< \brief (BPM_FWRUNPS)  */
 #define BPM_FWRUNPS_REGTYPE_NORMAL  (BPM_FWRUNPS_REGTYPE_NORMAL_Val << BPM_FWRUNPS_REGTYPE_Pos)
 #define BPM_FWRUNPS_REGTYPE_LP      (BPM_FWRUNPS_REGTYPE_LP_Val    << BPM_FWRUNPS_REGTYPE_Pos)
 #define BPM_FWRUNPS_REGTYPE_XULP    (BPM_FWRUNPS_REGTYPE_XULP_Val  << BPM_FWRUNPS_REGTYPE_Pos)
 #define BPM_FWRUNPS_REFTYPE_Pos     6            /**< \brief (BPM_FWRUNPS) Reference Type */
-#define BPM_FWRUNPS_REFTYPE_Msk     (_U(0x3) << BPM_FWRUNPS_REFTYPE_Pos)
+#define BPM_FWRUNPS_REFTYPE_Msk     (_U_(0x3) << BPM_FWRUNPS_REFTYPE_Pos)
 #define BPM_FWRUNPS_REFTYPE(value)  (BPM_FWRUNPS_REFTYPE_Msk & ((value) << BPM_FWRUNPS_REFTYPE_Pos))
-#define   BPM_FWRUNPS_REFTYPE_BOTH_Val    _U(0x0)   /**< \brief (BPM_FWRUNPS)  */
-#define   BPM_FWRUNPS_REFTYPE_BG_Val      _U(0x1)   /**< \brief (BPM_FWRUNPS)  */
-#define   BPM_FWRUNPS_REFTYPE_LPBG_Val    _U(0x2)   /**< \brief (BPM_FWRUNPS)  */
-#define   BPM_FWRUNPS_REFTYPE_INTERNAL_Val _U(0x3)   /**< \brief (BPM_FWRUNPS)  */
+#define   BPM_FWRUNPS_REFTYPE_BOTH_Val    _U_(0x0)   /**< \brief (BPM_FWRUNPS)  */
+#define   BPM_FWRUNPS_REFTYPE_BG_Val      _U_(0x1)   /**< \brief (BPM_FWRUNPS)  */
+#define   BPM_FWRUNPS_REFTYPE_LPBG_Val    _U_(0x2)   /**< \brief (BPM_FWRUNPS)  */
+#define   BPM_FWRUNPS_REFTYPE_INTERNAL_Val _U_(0x3)   /**< \brief (BPM_FWRUNPS)  */
 #define BPM_FWRUNPS_REFTYPE_BOTH    (BPM_FWRUNPS_REFTYPE_BOTH_Val  << BPM_FWRUNPS_REFTYPE_Pos)
 #define BPM_FWRUNPS_REFTYPE_BG      (BPM_FWRUNPS_REFTYPE_BG_Val    << BPM_FWRUNPS_REFTYPE_Pos)
 #define BPM_FWRUNPS_REFTYPE_LPBG    (BPM_FWRUNPS_REFTYPE_LPBG_Val  << BPM_FWRUNPS_REFTYPE_Pos)
 #define BPM_FWRUNPS_REFTYPE_INTERNAL (BPM_FWRUNPS_REFTYPE_INTERNAL_Val << BPM_FWRUNPS_REFTYPE_Pos)
 #define BPM_FWRUNPS_FLASHLATDEL_Pos 8            /**< \brief (BPM_FWRUNPS) Flash Latch Delay Value */
-#define BPM_FWRUNPS_FLASHLATDEL_Msk (_U(0x1F) << BPM_FWRUNPS_FLASHLATDEL_Pos)
+#define BPM_FWRUNPS_FLASHLATDEL_Msk (_U_(0x1F) << BPM_FWRUNPS_FLASHLATDEL_Pos)
 #define BPM_FWRUNPS_FLASHLATDEL(value) (BPM_FWRUNPS_FLASHLATDEL_Msk & ((value) << BPM_FWRUNPS_FLASHLATDEL_Pos))
 #define BPM_FWRUNPS_FLASHBIAS_Pos   13           /**< \brief (BPM_FWRUNPS) Flash Bias Value */
-#define BPM_FWRUNPS_FLASHBIAS_Msk   (_U(0xF) << BPM_FWRUNPS_FLASHBIAS_Pos)
+#define BPM_FWRUNPS_FLASHBIAS_Msk   (_U_(0xF) << BPM_FWRUNPS_FLASHBIAS_Pos)
 #define BPM_FWRUNPS_FLASHBIAS(value) (BPM_FWRUNPS_FLASHBIAS_Msk & ((value) << BPM_FWRUNPS_FLASHBIAS_Pos))
 #define BPM_FWRUNPS_FPPW_Pos        17           /**< \brief (BPM_FWRUNPS) Flash Pico Power Mode */
-#define BPM_FWRUNPS_FPPW            (_U(0x1) << BPM_FWRUNPS_FPPW_Pos)
+#define BPM_FWRUNPS_FPPW            (_U_(0x1) << BPM_FWRUNPS_FPPW_Pos)
 #define BPM_FWRUNPS_RC115_Pos       18           /**< \brief (BPM_FWRUNPS) RC 115KHZ Calibration Value */
-#define BPM_FWRUNPS_RC115_Msk       (_U(0x7F) << BPM_FWRUNPS_RC115_Pos)
+#define BPM_FWRUNPS_RC115_Msk       (_U_(0x7F) << BPM_FWRUNPS_RC115_Pos)
 #define BPM_FWRUNPS_RC115(value)    (BPM_FWRUNPS_RC115_Msk & ((value) << BPM_FWRUNPS_RC115_Pos))
 #define BPM_FWRUNPS_RCFAST_Pos      25           /**< \brief (BPM_FWRUNPS) RCFAST Calibration Value */
-#define BPM_FWRUNPS_RCFAST_Msk      (_U(0x7F) << BPM_FWRUNPS_RCFAST_Pos)
+#define BPM_FWRUNPS_RCFAST_Msk      (_U_(0x7F) << BPM_FWRUNPS_RCFAST_Pos)
 #define BPM_FWRUNPS_RCFAST(value)   (BPM_FWRUNPS_RCFAST_Msk & ((value) << BPM_FWRUNPS_RCFAST_Pos))
-#define BPM_FWRUNPS_MASK            _U(0xFFFFFFFF) /**< \brief (BPM_FWRUNPS) MASK Register */
+#define BPM_FWRUNPS_MASK            _U_(0xFFFFFFFF) /**< \brief (BPM_FWRUNPS) MASK Register */
 
 /* -------- BPM_FWPSAVEPS : (BPM Offset: 0x48) (R/  32) Factory Word Power Save PS Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -424,31 +424,31 @@ typedef union {
 #define BPM_FWPSAVEPS_OFFSET        0x48         /**< \brief (BPM_FWPSAVEPS offset) Factory Word Power Save PS Register */
 
 #define BPM_FWPSAVEPS_WREGLEVEL_Pos 0            /**< \brief (BPM_FWPSAVEPS) Wait mode Regulator Level */
-#define BPM_FWPSAVEPS_WREGLEVEL_Msk (_U(0xF) << BPM_FWPSAVEPS_WREGLEVEL_Pos)
+#define BPM_FWPSAVEPS_WREGLEVEL_Msk (_U_(0xF) << BPM_FWPSAVEPS_WREGLEVEL_Pos)
 #define BPM_FWPSAVEPS_WREGLEVEL(value) (BPM_FWPSAVEPS_WREGLEVEL_Msk & ((value) << BPM_FWPSAVEPS_WREGLEVEL_Pos))
 #define BPM_FWPSAVEPS_WBIAS_Pos     4            /**< \brief (BPM_FWPSAVEPS) Bias in wait mode */
-#define BPM_FWPSAVEPS_WBIAS_Msk     (_U(0xF) << BPM_FWPSAVEPS_WBIAS_Pos)
+#define BPM_FWPSAVEPS_WBIAS_Msk     (_U_(0xF) << BPM_FWPSAVEPS_WBIAS_Pos)
 #define BPM_FWPSAVEPS_WBIAS(value)  (BPM_FWPSAVEPS_WBIAS_Msk & ((value) << BPM_FWPSAVEPS_WBIAS_Pos))
 #define BPM_FWPSAVEPS_WLATDEL_Pos   8            /**< \brief (BPM_FWPSAVEPS) Flash Latdel in wait mode */
-#define BPM_FWPSAVEPS_WLATDEL_Msk   (_U(0x1F) << BPM_FWPSAVEPS_WLATDEL_Pos)
+#define BPM_FWPSAVEPS_WLATDEL_Msk   (_U_(0x1F) << BPM_FWPSAVEPS_WLATDEL_Pos)
 #define BPM_FWPSAVEPS_WLATDEL(value) (BPM_FWPSAVEPS_WLATDEL_Msk & ((value) << BPM_FWPSAVEPS_WLATDEL_Pos))
 #define BPM_FWPSAVEPS_RREGLEVEL_Pos 13           /**< \brief (BPM_FWPSAVEPS) Retention mode Regulator Level */
-#define BPM_FWPSAVEPS_RREGLEVEL_Msk (_U(0xF) << BPM_FWPSAVEPS_RREGLEVEL_Pos)
+#define BPM_FWPSAVEPS_RREGLEVEL_Msk (_U_(0xF) << BPM_FWPSAVEPS_RREGLEVEL_Pos)
 #define BPM_FWPSAVEPS_RREGLEVEL(value) (BPM_FWPSAVEPS_RREGLEVEL_Msk & ((value) << BPM_FWPSAVEPS_RREGLEVEL_Pos))
 #define BPM_FWPSAVEPS_RBIAS_Pos     17           /**< \brief (BPM_FWPSAVEPS) Bias in Retention mode */
-#define BPM_FWPSAVEPS_RBIAS_Msk     (_U(0xF) << BPM_FWPSAVEPS_RBIAS_Pos)
+#define BPM_FWPSAVEPS_RBIAS_Msk     (_U_(0xF) << BPM_FWPSAVEPS_RBIAS_Pos)
 #define BPM_FWPSAVEPS_RBIAS(value)  (BPM_FWPSAVEPS_RBIAS_Msk & ((value) << BPM_FWPSAVEPS_RBIAS_Pos))
 #define BPM_FWPSAVEPS_RLATDEL_Pos   21           /**< \brief (BPM_FWPSAVEPS) Flash Latdel in Retention mode */
-#define BPM_FWPSAVEPS_RLATDEL_Msk   (_U(0x1F) << BPM_FWPSAVEPS_RLATDEL_Pos)
+#define BPM_FWPSAVEPS_RLATDEL_Msk   (_U_(0x1F) << BPM_FWPSAVEPS_RLATDEL_Pos)
 #define BPM_FWPSAVEPS_RLATDEL(value) (BPM_FWPSAVEPS_RLATDEL_Msk & ((value) << BPM_FWPSAVEPS_RLATDEL_Pos))
 #define BPM_FWPSAVEPS_BREGLEVEL_Pos 26           /**< \brief (BPM_FWPSAVEPS) Backup mode Regulator Level */
-#define BPM_FWPSAVEPS_BREGLEVEL_Msk (_U(0xF) << BPM_FWPSAVEPS_BREGLEVEL_Pos)
+#define BPM_FWPSAVEPS_BREGLEVEL_Msk (_U_(0xF) << BPM_FWPSAVEPS_BREGLEVEL_Pos)
 #define BPM_FWPSAVEPS_BREGLEVEL(value) (BPM_FWPSAVEPS_BREGLEVEL_Msk & ((value) << BPM_FWPSAVEPS_BREGLEVEL_Pos))
 #define BPM_FWPSAVEPS_POR18DIS_Pos  30           /**< \brief (BPM_FWPSAVEPS) POR 18 Disable */
-#define BPM_FWPSAVEPS_POR18DIS      (_U(0x1) << BPM_FWPSAVEPS_POR18DIS_Pos)
+#define BPM_FWPSAVEPS_POR18DIS      (_U_(0x1) << BPM_FWPSAVEPS_POR18DIS_Pos)
 #define BPM_FWPSAVEPS_FWSAS_Pos     31           /**< \brief (BPM_FWPSAVEPS) Flash Wait State Automatic Switching */
-#define BPM_FWPSAVEPS_FWSAS         (_U(0x1) << BPM_FWPSAVEPS_FWSAS_Pos)
-#define BPM_FWPSAVEPS_MASK          _U(0xFFFFFFFF) /**< \brief (BPM_FWPSAVEPS) MASK Register */
+#define BPM_FWPSAVEPS_FWSAS         (_U_(0x1) << BPM_FWPSAVEPS_FWSAS_Pos)
+#define BPM_FWPSAVEPS_MASK          _U_(0xFFFFFFFF) /**< \brief (BPM_FWPSAVEPS) MASK Register */
 
 /* -------- BPM_VERSION : (BPM Offset: 0xFC) (R/  32) Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -464,15 +464,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BPM_VERSION_OFFSET          0xFC         /**< \brief (BPM_VERSION offset) Version Register */
-#define BPM_VERSION_RESETVALUE      _U(0x00000120); /**< \brief (BPM_VERSION reset_value) Version Register */
+#define BPM_VERSION_RESETVALUE      _U_(0x00000120); /**< \brief (BPM_VERSION reset_value) Version Register */
 
 #define BPM_VERSION_VERSION_Pos     0            /**< \brief (BPM_VERSION) Version Number */
-#define BPM_VERSION_VERSION_Msk     (_U(0xFFF) << BPM_VERSION_VERSION_Pos)
+#define BPM_VERSION_VERSION_Msk     (_U_(0xFFF) << BPM_VERSION_VERSION_Pos)
 #define BPM_VERSION_VERSION(value)  (BPM_VERSION_VERSION_Msk & ((value) << BPM_VERSION_VERSION_Pos))
 #define BPM_VERSION_VARIANT_Pos     16           /**< \brief (BPM_VERSION) Variant Number */
-#define BPM_VERSION_VARIANT_Msk     (_U(0xF) << BPM_VERSION_VARIANT_Pos)
+#define BPM_VERSION_VARIANT_Msk     (_U_(0xF) << BPM_VERSION_VARIANT_Pos)
 #define BPM_VERSION_VARIANT(value)  (BPM_VERSION_VARIANT_Msk & ((value) << BPM_VERSION_VARIANT_Pos))
-#define BPM_VERSION_MASK            _U(0x000F0FFF) /**< \brief (BPM_VERSION) MASK Register */
+#define BPM_VERSION_MASK            _U_(0x000F0FFF) /**< \brief (BPM_VERSION) MASK Register */
 
 /** \brief BPM hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/bpm.h
+++ b/asf/sam/include/sam4l/component/bpm.h
@@ -476,49 +476,26 @@ typedef union {
 
 /** \brief BPM hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __O  BPM_IER_Type              IER;         /**< \brief Offset: 0x00 ( /W 32) Interrupt Enable Register */
-  __O  BPM_IDR_Type              IDR;         /**< \brief Offset: 0x04 ( /W 32) Interrupt Disable Register */
-  __I  BPM_IMR_Type              IMR;         /**< \brief Offset: 0x08 (R/  32) Interrupt Mask Register */
-  __I  BPM_ISR_Type              ISR;         /**< \brief Offset: 0x0C (R/  32) Interrupt Status Register */
-  __O  BPM_ICR_Type              ICR;         /**< \brief Offset: 0x10 ( /W 32) Interrupt Clear Register */
-  __I  BPM_SR_Type               SR;          /**< \brief Offset: 0x14 (R/  32) Status Register */
-  __O  BPM_UNLOCK_Type           UNLOCK;      /**< \brief Offset: 0x18 ( /W 32) Unlock Register */
-  __IO BPM_PMCON_Type            PMCON;       /**< \brief Offset: 0x1C (R/W 32) Power Mode Control Register */
-       RoReg8                    Reserved1[0x8];
-  __I  BPM_BKUPWCAUSE_Type       BKUPWCAUSE;  /**< \brief Offset: 0x28 (R/  32) Backup Wake up Cause Register */
-  __IO BPM_BKUPWEN_Type          BKUPWEN;     /**< \brief Offset: 0x2C (R/W 32) Backup Wake up Enable Register */
-  __IO BPM_BKUPPMUX_Type         BKUPPMUX;    /**< \brief Offset: 0x30 (R/W 32) Backup Pin Muxing Register */
-  __IO BPM_IORET_Type            IORET;       /**< \brief Offset: 0x34 (R/W 32) Input Output Retention Register */
-       RoReg8                    Reserved2[0x8];
-  __IO BPM_BPR_Type              BPR;         /**< \brief Offset: 0x40 (R/W 32) Bypass Register */
-  __I  BPM_FWRUNPS_Type          FWRUNPS;     /**< \brief Offset: 0x44 (R/  32) Factory Word Run PS Register */
-  __I  BPM_FWPSAVEPS_Type        FWPSAVEPS;   /**< \brief Offset: 0x48 (R/  32) Factory Word Power Save PS Register */
-       RoReg8                    Reserved3[0xB0];
-  __I  BPM_VERSION_Type          VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
- } bf;
- struct {
-  WoReg   BPM_IER;            /**< \brief (BPM Offset: 0x00) Interrupt Enable Register */
-  WoReg   BPM_IDR;            /**< \brief (BPM Offset: 0x04) Interrupt Disable Register */
-  RoReg   BPM_IMR;            /**< \brief (BPM Offset: 0x08) Interrupt Mask Register */
-  RoReg   BPM_ISR;            /**< \brief (BPM Offset: 0x0C) Interrupt Status Register */
-  WoReg   BPM_ICR;            /**< \brief (BPM Offset: 0x10) Interrupt Clear Register */
-  RoReg   BPM_SR;             /**< \brief (BPM Offset: 0x14) Status Register */
-  WoReg   BPM_UNLOCK;         /**< \brief (BPM Offset: 0x18) Unlock Register */
-  RwReg   BPM_PMCON;          /**< \brief (BPM Offset: 0x1C) Power Mode Control Register */
-  RoReg8  Reserved4[0x8];
-  RoReg   BPM_BKUPWCAUSE;     /**< \brief (BPM Offset: 0x28) Backup Wake up Cause Register */
-  RwReg   BPM_BKUPWEN;        /**< \brief (BPM Offset: 0x2C) Backup Wake up Enable Register */
-  RwReg   BPM_BKUPPMUX;       /**< \brief (BPM Offset: 0x30) Backup Pin Muxing Register */
-  RwReg   BPM_IORET;          /**< \brief (BPM Offset: 0x34) Input Output Retention Register */
-  RoReg8  Reserved5[0x8];
-  RwReg   BPM_BPR;            /**< \brief (BPM Offset: 0x40) Bypass Register */
-  RoReg   BPM_FWRUNPS;        /**< \brief (BPM Offset: 0x44) Factory Word Run PS Register */
-  RoReg   BPM_FWPSAVEPS;      /**< \brief (BPM Offset: 0x48) Factory Word Power Save PS Register */
-  RoReg8  Reserved6[0xB0];
-  RoReg   BPM_VERSION;        /**< \brief (BPM Offset: 0xFC) Version Register */
- } reg;
+typedef struct {
+  __O  uint32_t IER;         /**< \brief Offset: 0x00 ( /W 32) Interrupt Enable Register */
+  __O  uint32_t IDR;         /**< \brief Offset: 0x04 ( /W 32) Interrupt Disable Register */
+  __I  uint32_t IMR;         /**< \brief Offset: 0x08 (R/  32) Interrupt Mask Register */
+  __I  uint32_t ISR;         /**< \brief Offset: 0x0C (R/  32) Interrupt Status Register */
+  __O  uint32_t ICR;         /**< \brief Offset: 0x10 ( /W 32) Interrupt Clear Register */
+  __I  uint32_t SR;          /**< \brief Offset: 0x14 (R/  32) Status Register */
+  __O  uint32_t UNLOCK;      /**< \brief Offset: 0x18 ( /W 32) Unlock Register */
+  __IO uint32_t PMCON;       /**< \brief Offset: 0x1C (R/W 32) Power Mode Control Register */
+       RoReg8   Reserved1[0x8];
+  __I  uint32_t BKUPWCAUSE;  /**< \brief Offset: 0x28 (R/  32) Backup Wake up Cause Register */
+  __IO uint32_t BKUPWEN;     /**< \brief Offset: 0x2C (R/W 32) Backup Wake up Enable Register */
+  __IO uint32_t BKUPPMUX;    /**< \brief Offset: 0x30 (R/W 32) Backup Pin Muxing Register */
+  __IO uint32_t IORET;       /**< \brief Offset: 0x34 (R/W 32) Input Output Retention Register */
+       RoReg8   Reserved2[0x8];
+  __IO uint32_t BPR;         /**< \brief Offset: 0x40 (R/W 32) Bypass Register */
+  __I  uint32_t FWRUNPS;     /**< \brief Offset: 0x44 (R/  32) Factory Word Run PS Register */
+  __I  uint32_t FWPSAVEPS;   /**< \brief Offset: 0x48 (R/  32) Factory Word Power Save PS Register */
+       RoReg8   Reserved3[0xB0];
+  __I  uint32_t VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
 } Bpm;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/bpm.h
+++ b/asf/sam/include/sam4l/component/bpm.h
@@ -1,0 +1,527 @@
+/**
+ * \file
+ *
+ * \brief Component description for BPM
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_BPM_COMPONENT_
+#define _SAM4L_BPM_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR BPM */
+/* ========================================================================== */
+/** \addtogroup SAM4L_BPM Backup Power Manager */
+/*@{*/
+
+#define BPM_I7197
+#define REV_BPM                     0x120
+
+/* -------- BPM_IER : (BPM Offset: 0x00) ( /W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PSOK:1;           /*!< bit:      0  Power Scaling OK Interrupt Enable  */
+    uint32_t :30;              /*!< bit:  1..30  Reserved                           */
+    uint32_t AE:1;             /*!< bit:     31  Access Error Interrupt Enable      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BPM_IER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BPM_IER_OFFSET              0x00         /**< \brief (BPM_IER offset) Interrupt Enable Register */
+#define BPM_IER_RESETVALUE          _U(0x00000000); /**< \brief (BPM_IER reset_value) Interrupt Enable Register */
+
+#define BPM_IER_PSOK_Pos            0            /**< \brief (BPM_IER) Power Scaling OK Interrupt Enable */
+#define BPM_IER_PSOK                (_U(0x1) << BPM_IER_PSOK_Pos)
+#define BPM_IER_AE_Pos              31           /**< \brief (BPM_IER) Access Error Interrupt Enable */
+#define BPM_IER_AE                  (_U(0x1) << BPM_IER_AE_Pos)
+#define BPM_IER_MASK                _U(0x80000001) /**< \brief (BPM_IER) MASK Register */
+
+/* -------- BPM_IDR : (BPM Offset: 0x04) ( /W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PSOK:1;           /*!< bit:      0  Power Scaling OK Interrupt Disable */
+    uint32_t :30;              /*!< bit:  1..30  Reserved                           */
+    uint32_t AE:1;             /*!< bit:     31  Access Error Interrupt Disable     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BPM_IDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BPM_IDR_OFFSET              0x04         /**< \brief (BPM_IDR offset) Interrupt Disable Register */
+#define BPM_IDR_RESETVALUE          _U(0x00000000); /**< \brief (BPM_IDR reset_value) Interrupt Disable Register */
+
+#define BPM_IDR_PSOK_Pos            0            /**< \brief (BPM_IDR) Power Scaling OK Interrupt Disable */
+#define BPM_IDR_PSOK                (_U(0x1) << BPM_IDR_PSOK_Pos)
+#define BPM_IDR_AE_Pos              31           /**< \brief (BPM_IDR) Access Error Interrupt Disable */
+#define BPM_IDR_AE                  (_U(0x1) << BPM_IDR_AE_Pos)
+#define BPM_IDR_MASK                _U(0x80000001) /**< \brief (BPM_IDR) MASK Register */
+
+/* -------- BPM_IMR : (BPM Offset: 0x08) (R/  32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PSOK:1;           /*!< bit:      0  Power Scaling OK Interrupt Mask    */
+    uint32_t :30;              /*!< bit:  1..30  Reserved                           */
+    uint32_t AE:1;             /*!< bit:     31  Access Error Interrupt Mask        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BPM_IMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BPM_IMR_OFFSET              0x08         /**< \brief (BPM_IMR offset) Interrupt Mask Register */
+#define BPM_IMR_RESETVALUE          _U(0x00000000); /**< \brief (BPM_IMR reset_value) Interrupt Mask Register */
+
+#define BPM_IMR_PSOK_Pos            0            /**< \brief (BPM_IMR) Power Scaling OK Interrupt Mask */
+#define BPM_IMR_PSOK                (_U(0x1) << BPM_IMR_PSOK_Pos)
+#define BPM_IMR_AE_Pos              31           /**< \brief (BPM_IMR) Access Error Interrupt Mask */
+#define BPM_IMR_AE                  (_U(0x1) << BPM_IMR_AE_Pos)
+#define BPM_IMR_MASK                _U(0x80000001) /**< \brief (BPM_IMR) MASK Register */
+
+/* -------- BPM_ISR : (BPM Offset: 0x0C) (R/  32) Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PSOK:1;           /*!< bit:      0  Power Scaling OK Interrupt Status  */
+    uint32_t :30;              /*!< bit:  1..30  Reserved                           */
+    uint32_t AE:1;             /*!< bit:     31  Access Error Interrupt Status      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BPM_ISR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BPM_ISR_OFFSET              0x0C         /**< \brief (BPM_ISR offset) Interrupt Status Register */
+#define BPM_ISR_RESETVALUE          _U(0x00000000); /**< \brief (BPM_ISR reset_value) Interrupt Status Register */
+
+#define BPM_ISR_PSOK_Pos            0            /**< \brief (BPM_ISR) Power Scaling OK Interrupt Status */
+#define BPM_ISR_PSOK                (_U(0x1) << BPM_ISR_PSOK_Pos)
+#define BPM_ISR_AE_Pos              31           /**< \brief (BPM_ISR) Access Error Interrupt Status */
+#define BPM_ISR_AE                  (_U(0x1) << BPM_ISR_AE_Pos)
+#define BPM_ISR_MASK                _U(0x80000001) /**< \brief (BPM_ISR) MASK Register */
+
+/* -------- BPM_ICR : (BPM Offset: 0x10) ( /W 32) Interrupt Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PSOK:1;           /*!< bit:      0  Power Scaling OK Interrupt Status Clear */
+    uint32_t :30;              /*!< bit:  1..30  Reserved                           */
+    uint32_t AE:1;             /*!< bit:     31  Access Error Interrupt Status Clear */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BPM_ICR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BPM_ICR_OFFSET              0x10         /**< \brief (BPM_ICR offset) Interrupt Clear Register */
+#define BPM_ICR_RESETVALUE          _U(0x00000000); /**< \brief (BPM_ICR reset_value) Interrupt Clear Register */
+
+#define BPM_ICR_PSOK_Pos            0            /**< \brief (BPM_ICR) Power Scaling OK Interrupt Status Clear */
+#define BPM_ICR_PSOK                (_U(0x1) << BPM_ICR_PSOK_Pos)
+#define BPM_ICR_AE_Pos              31           /**< \brief (BPM_ICR) Access Error Interrupt Status Clear */
+#define BPM_ICR_AE                  (_U(0x1) << BPM_ICR_AE_Pos)
+#define BPM_ICR_MASK                _U(0x80000001) /**< \brief (BPM_ICR) MASK Register */
+
+/* -------- BPM_SR : (BPM Offset: 0x14) (R/  32) Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PSOK:1;           /*!< bit:      0  Power Scaling OK Status            */
+    uint32_t :30;              /*!< bit:  1..30  Reserved                           */
+    uint32_t AE:1;             /*!< bit:     31  Access Error                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BPM_SR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BPM_SR_OFFSET               0x14         /**< \brief (BPM_SR offset) Status Register */
+#define BPM_SR_RESETVALUE           _U(0x00000000); /**< \brief (BPM_SR reset_value) Status Register */
+
+#define BPM_SR_PSOK_Pos             0            /**< \brief (BPM_SR) Power Scaling OK Status */
+#define BPM_SR_PSOK                 (_U(0x1) << BPM_SR_PSOK_Pos)
+#define BPM_SR_AE_Pos               31           /**< \brief (BPM_SR) Access Error */
+#define BPM_SR_AE                   (_U(0x1) << BPM_SR_AE_Pos)
+#define BPM_SR_MASK                 _U(0x80000001) /**< \brief (BPM_SR) MASK Register */
+
+/* -------- BPM_UNLOCK : (BPM Offset: 0x18) ( /W 32) Unlock Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ADDR:10;          /*!< bit:  0.. 9  Unlock Address                     */
+    uint32_t :14;              /*!< bit: 10..23  Reserved                           */
+    uint32_t KEY:8;            /*!< bit: 24..31  Unlock Key                         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BPM_UNLOCK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BPM_UNLOCK_OFFSET           0x18         /**< \brief (BPM_UNLOCK offset) Unlock Register */
+#define BPM_UNLOCK_RESETVALUE       _U(0x00000000); /**< \brief (BPM_UNLOCK reset_value) Unlock Register */
+
+#define BPM_UNLOCK_ADDR_Pos         0            /**< \brief (BPM_UNLOCK) Unlock Address */
+#define BPM_UNLOCK_ADDR_Msk         (_U(0x3FF) << BPM_UNLOCK_ADDR_Pos)
+#define BPM_UNLOCK_ADDR(value)      (BPM_UNLOCK_ADDR_Msk & ((value) << BPM_UNLOCK_ADDR_Pos))
+#define BPM_UNLOCK_KEY_Pos          24           /**< \brief (BPM_UNLOCK) Unlock Key */
+#define BPM_UNLOCK_KEY_Msk          (_U(0xFF) << BPM_UNLOCK_KEY_Pos)
+#define BPM_UNLOCK_KEY(value)       (BPM_UNLOCK_KEY_Msk & ((value) << BPM_UNLOCK_KEY_Pos))
+#define BPM_UNLOCK_MASK             _U(0xFF0003FF) /**< \brief (BPM_UNLOCK) MASK Register */
+
+/* -------- BPM_PMCON : (BPM Offset: 0x1C) (R/W 32) Power Mode Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PS:2;             /*!< bit:  0.. 1  Power Scaling Configuration Value  */
+    uint32_t PSCREQ:1;         /*!< bit:      2  Power Scaling Change Request       */
+    uint32_t PSCM:1;           /*!< bit:      3  Power Scaling Change Mode          */
+    uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint32_t BKUP:1;           /*!< bit:      8  BACKUP Mode                        */
+    uint32_t RET:1;            /*!< bit:      9  RETENTION Mode                     */
+    uint32_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint32_t SLEEP:2;          /*!< bit: 12..13  SLEEP mode Configuration           */
+    uint32_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint32_t CK32S:1;          /*!< bit:     16  32Khz-1Khz Clock Source Selection  */
+    uint32_t :7;               /*!< bit: 17..23  Reserved                           */
+    uint32_t FASTWKUP:1;       /*!< bit:     24  Fast Wakeup                        */
+    uint32_t :7;               /*!< bit: 25..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BPM_PMCON_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BPM_PMCON_OFFSET            0x1C         /**< \brief (BPM_PMCON offset) Power Mode Control Register */
+#define BPM_PMCON_RESETVALUE        _U(0x00000000); /**< \brief (BPM_PMCON reset_value) Power Mode Control Register */
+
+#define BPM_PMCON_PS_Pos            0            /**< \brief (BPM_PMCON) Power Scaling Configuration Value */
+#define BPM_PMCON_PS_Msk            (_U(0x3) << BPM_PMCON_PS_Pos)
+#define BPM_PMCON_PS(value)         (BPM_PMCON_PS_Msk & ((value) << BPM_PMCON_PS_Pos))
+#define BPM_PMCON_PSCREQ_Pos        2            /**< \brief (BPM_PMCON) Power Scaling Change Request */
+#define BPM_PMCON_PSCREQ            (_U(0x1) << BPM_PMCON_PSCREQ_Pos)
+#define BPM_PMCON_PSCM_Pos          3            /**< \brief (BPM_PMCON) Power Scaling Change Mode */
+#define BPM_PMCON_PSCM              (_U(0x1) << BPM_PMCON_PSCM_Pos)
+#define BPM_PMCON_BKUP_Pos          8            /**< \brief (BPM_PMCON) BACKUP Mode */
+#define BPM_PMCON_BKUP              (_U(0x1) << BPM_PMCON_BKUP_Pos)
+#define BPM_PMCON_RET_Pos           9            /**< \brief (BPM_PMCON) RETENTION Mode */
+#define BPM_PMCON_RET               (_U(0x1) << BPM_PMCON_RET_Pos)
+#define BPM_PMCON_SLEEP_Pos         12           /**< \brief (BPM_PMCON) SLEEP mode Configuration */
+#define BPM_PMCON_SLEEP_Msk         (_U(0x3) << BPM_PMCON_SLEEP_Pos)
+#define BPM_PMCON_SLEEP(value)      (BPM_PMCON_SLEEP_Msk & ((value) << BPM_PMCON_SLEEP_Pos))
+#define BPM_PMCON_CK32S_Pos         16           /**< \brief (BPM_PMCON) 32Khz-1Khz Clock Source Selection */
+#define BPM_PMCON_CK32S             (_U(0x1) << BPM_PMCON_CK32S_Pos)
+#define BPM_PMCON_FASTWKUP_Pos      24           /**< \brief (BPM_PMCON) Fast Wakeup */
+#define BPM_PMCON_FASTWKUP          (_U(0x1) << BPM_PMCON_FASTWKUP_Pos)
+#define BPM_PMCON_MASK              _U(0x0101330F) /**< \brief (BPM_PMCON) MASK Register */
+
+/* -------- BPM_BKUPWCAUSE : (BPM Offset: 0x28) (R/  32) Backup Wake up Cause Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} BPM_BKUPWCAUSE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BPM_BKUPWCAUSE_OFFSET       0x28         /**< \brief (BPM_BKUPWCAUSE offset) Backup Wake up Cause Register */
+#define BPM_BKUPWCAUSE_RESETVALUE   _U(0x00000000); /**< \brief (BPM_BKUPWCAUSE reset_value) Backup Wake up Cause Register */
+#define BPM_BKUPWCAUSE_MASK         _U(0xFFFFFFFF) /**< \brief (BPM_BKUPWCAUSE) MASK Register */
+
+/* -------- BPM_BKUPWEN : (BPM Offset: 0x2C) (R/W 32) Backup Wake up Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} BPM_BKUPWEN_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BPM_BKUPWEN_OFFSET          0x2C         /**< \brief (BPM_BKUPWEN offset) Backup Wake up Enable Register */
+#define BPM_BKUPWEN_RESETVALUE      _U(0x00000000); /**< \brief (BPM_BKUPWEN reset_value) Backup Wake up Enable Register */
+#define BPM_BKUPWEN_MASK            _U(0xFFFFFFFF) /**< \brief (BPM_BKUPWEN) MASK Register */
+
+/* -------- BPM_BKUPPMUX : (BPM Offset: 0x30) (R/W 32) Backup Pin Muxing Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t BKUPPMUX:9;       /*!< bit:  0.. 8  Backup Pin Muxing                  */
+    uint32_t :23;              /*!< bit:  9..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BPM_BKUPPMUX_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BPM_BKUPPMUX_OFFSET         0x30         /**< \brief (BPM_BKUPPMUX offset) Backup Pin Muxing Register */
+#define BPM_BKUPPMUX_RESETVALUE     _U(0x00000000); /**< \brief (BPM_BKUPPMUX reset_value) Backup Pin Muxing Register */
+
+#define BPM_BKUPPMUX_BKUPPMUX_Pos   0            /**< \brief (BPM_BKUPPMUX) Backup Pin Muxing */
+#define BPM_BKUPPMUX_BKUPPMUX_Msk   (_U(0x1FF) << BPM_BKUPPMUX_BKUPPMUX_Pos)
+#define BPM_BKUPPMUX_BKUPPMUX(value) (BPM_BKUPPMUX_BKUPPMUX_Msk & ((value) << BPM_BKUPPMUX_BKUPPMUX_Pos))
+#define BPM_BKUPPMUX_MASK           _U(0x000001FF) /**< \brief (BPM_BKUPPMUX) MASK Register */
+
+/* -------- BPM_IORET : (BPM Offset: 0x34) (R/W 32) Input Output Retention Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RET:1;            /*!< bit:      0  Retention on I/O lines after waking up from the BACKUP mode */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BPM_IORET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BPM_IORET_OFFSET            0x34         /**< \brief (BPM_IORET offset) Input Output Retention Register */
+#define BPM_IORET_RESETVALUE        _U(0x00000000); /**< \brief (BPM_IORET reset_value) Input Output Retention Register */
+
+#define BPM_IORET_RET_Pos           0            /**< \brief (BPM_IORET) Retention on I/O lines after waking up from the BACKUP mode */
+#define BPM_IORET_RET               (_U(0x1) << BPM_IORET_RET_Pos)
+#define BPM_IORET_MASK              _U(0x00000001) /**< \brief (BPM_IORET) MASK Register */
+
+/* -------- BPM_BPR : (BPM Offset: 0x40) (R/W 32) Bypass Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RUNPSPB:1;        /*!< bit:      0  Run Mode Power Scaling Preset Bypass */
+    uint32_t PSMPSPB:1;        /*!< bit:      1  Power Save Mode Power Scaling Preset Bypass */
+    uint32_t SEQSTN:1;         /*!< bit:      2  Sequencial Startup from ULP (Active Low) */
+    uint32_t PSBTD:1;          /*!< bit:      3  Power Scaling Bias Timing Disable  */
+    uint32_t PSHFD:1;          /*!< bit:      4  Power Scaling Halt Flash Until VREGOK Disable */
+    uint32_t DLYRSTD:1;        /*!< bit:      5  Delaying Reset Disable             */
+    uint32_t BIASSEN:1;        /*!< bit:      6  Bias Switch Enable                 */
+    uint32_t LATSEN:1;         /*!< bit:      7  Latdel Switch Enable               */
+    uint32_t BOD18CONT:1;      /*!< bit:      8  BOD18 in continuous mode not disabled in WAIT/RET/BACKUP modes */
+    uint32_t POBS:1;           /*!< bit:      9  Pico Uart Observability            */
+    uint32_t FFFW:1;           /*!< bit:     10  Force Flash Fast Wakeup            */
+    uint32_t FBRDYEN:1;        /*!< bit:     11  Flash Bias Ready Enable            */
+    uint32_t FVREFSEN:1;       /*!< bit:     12  Flash Vref Switch Enable           */
+    uint32_t :19;              /*!< bit: 13..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BPM_BPR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BPM_BPR_OFFSET              0x40         /**< \brief (BPM_BPR offset) Bypass Register */
+#define BPM_BPR_RESETVALUE          _U(0x00000000); /**< \brief (BPM_BPR reset_value) Bypass Register */
+
+#define BPM_BPR_RUNPSPB_Pos         0            /**< \brief (BPM_BPR) Run Mode Power Scaling Preset Bypass */
+#define BPM_BPR_RUNPSPB             (_U(0x1) << BPM_BPR_RUNPSPB_Pos)
+#define BPM_BPR_PSMPSPB_Pos         1            /**< \brief (BPM_BPR) Power Save Mode Power Scaling Preset Bypass */
+#define BPM_BPR_PSMPSPB             (_U(0x1) << BPM_BPR_PSMPSPB_Pos)
+#define BPM_BPR_SEQSTN_Pos          2            /**< \brief (BPM_BPR) Sequencial Startup from ULP (Active Low) */
+#define BPM_BPR_SEQSTN              (_U(0x1) << BPM_BPR_SEQSTN_Pos)
+#define BPM_BPR_PSBTD_Pos           3            /**< \brief (BPM_BPR) Power Scaling Bias Timing Disable */
+#define BPM_BPR_PSBTD               (_U(0x1) << BPM_BPR_PSBTD_Pos)
+#define BPM_BPR_PSHFD_Pos           4            /**< \brief (BPM_BPR) Power Scaling Halt Flash Until VREGOK Disable */
+#define BPM_BPR_PSHFD               (_U(0x1) << BPM_BPR_PSHFD_Pos)
+#define BPM_BPR_DLYRSTD_Pos         5            /**< \brief (BPM_BPR) Delaying Reset Disable */
+#define BPM_BPR_DLYRSTD             (_U(0x1) << BPM_BPR_DLYRSTD_Pos)
+#define BPM_BPR_BIASSEN_Pos         6            /**< \brief (BPM_BPR) Bias Switch Enable */
+#define BPM_BPR_BIASSEN             (_U(0x1) << BPM_BPR_BIASSEN_Pos)
+#define BPM_BPR_LATSEN_Pos          7            /**< \brief (BPM_BPR) Latdel Switch Enable */
+#define BPM_BPR_LATSEN              (_U(0x1) << BPM_BPR_LATSEN_Pos)
+#define BPM_BPR_BOD18CONT_Pos       8            /**< \brief (BPM_BPR) BOD18 in continuous mode not disabled in WAIT/RET/BACKUP modes */
+#define BPM_BPR_BOD18CONT           (_U(0x1) << BPM_BPR_BOD18CONT_Pos)
+#define BPM_BPR_POBS_Pos            9            /**< \brief (BPM_BPR) Pico Uart Observability */
+#define BPM_BPR_POBS                (_U(0x1) << BPM_BPR_POBS_Pos)
+#define BPM_BPR_FFFW_Pos            10           /**< \brief (BPM_BPR) Force Flash Fast Wakeup */
+#define BPM_BPR_FFFW                (_U(0x1) << BPM_BPR_FFFW_Pos)
+#define BPM_BPR_FBRDYEN_Pos         11           /**< \brief (BPM_BPR) Flash Bias Ready Enable */
+#define BPM_BPR_FBRDYEN             (_U(0x1) << BPM_BPR_FBRDYEN_Pos)
+#define BPM_BPR_FVREFSEN_Pos        12           /**< \brief (BPM_BPR) Flash Vref Switch Enable */
+#define BPM_BPR_FVREFSEN            (_U(0x1) << BPM_BPR_FVREFSEN_Pos)
+#define BPM_BPR_MASK                _U(0x00001FFF) /**< \brief (BPM_BPR) MASK Register */
+
+/* -------- BPM_FWRUNPS : (BPM Offset: 0x44) (R/  32) Factory Word Run PS Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t REGLEVEL:4;       /*!< bit:  0.. 3  Regulator Voltage Level            */
+    uint32_t REGTYPE:2;        /*!< bit:  4.. 5  Regulator Type                     */
+    uint32_t REFTYPE:2;        /*!< bit:  6.. 7  Reference Type                     */
+    uint32_t FLASHLATDEL:5;    /*!< bit:  8..12  Flash Latch Delay Value            */
+    uint32_t FLASHBIAS:4;      /*!< bit: 13..16  Flash Bias Value                   */
+    uint32_t FPPW:1;           /*!< bit:     17  Flash Pico Power Mode              */
+    uint32_t RC115:7;          /*!< bit: 18..24  RC 115KHZ Calibration Value        */
+    uint32_t RCFAST:7;         /*!< bit: 25..31  RCFAST Calibration Value           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BPM_FWRUNPS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BPM_FWRUNPS_OFFSET          0x44         /**< \brief (BPM_FWRUNPS offset) Factory Word Run PS Register */
+
+#define BPM_FWRUNPS_REGLEVEL_Pos    0            /**< \brief (BPM_FWRUNPS) Regulator Voltage Level */
+#define BPM_FWRUNPS_REGLEVEL_Msk    (_U(0xF) << BPM_FWRUNPS_REGLEVEL_Pos)
+#define BPM_FWRUNPS_REGLEVEL(value) (BPM_FWRUNPS_REGLEVEL_Msk & ((value) << BPM_FWRUNPS_REGLEVEL_Pos))
+#define BPM_FWRUNPS_REGTYPE_Pos     4            /**< \brief (BPM_FWRUNPS) Regulator Type */
+#define BPM_FWRUNPS_REGTYPE_Msk     (_U(0x3) << BPM_FWRUNPS_REGTYPE_Pos)
+#define BPM_FWRUNPS_REGTYPE(value)  (BPM_FWRUNPS_REGTYPE_Msk & ((value) << BPM_FWRUNPS_REGTYPE_Pos))
+#define   BPM_FWRUNPS_REGTYPE_NORMAL_Val  _U(0x0)   /**< \brief (BPM_FWRUNPS)  */
+#define   BPM_FWRUNPS_REGTYPE_LP_Val      _U(0x1)   /**< \brief (BPM_FWRUNPS)  */
+#define   BPM_FWRUNPS_REGTYPE_XULP_Val    _U(0x2)   /**< \brief (BPM_FWRUNPS)  */
+#define BPM_FWRUNPS_REGTYPE_NORMAL  (BPM_FWRUNPS_REGTYPE_NORMAL_Val << BPM_FWRUNPS_REGTYPE_Pos)
+#define BPM_FWRUNPS_REGTYPE_LP      (BPM_FWRUNPS_REGTYPE_LP_Val    << BPM_FWRUNPS_REGTYPE_Pos)
+#define BPM_FWRUNPS_REGTYPE_XULP    (BPM_FWRUNPS_REGTYPE_XULP_Val  << BPM_FWRUNPS_REGTYPE_Pos)
+#define BPM_FWRUNPS_REFTYPE_Pos     6            /**< \brief (BPM_FWRUNPS) Reference Type */
+#define BPM_FWRUNPS_REFTYPE_Msk     (_U(0x3) << BPM_FWRUNPS_REFTYPE_Pos)
+#define BPM_FWRUNPS_REFTYPE(value)  (BPM_FWRUNPS_REFTYPE_Msk & ((value) << BPM_FWRUNPS_REFTYPE_Pos))
+#define   BPM_FWRUNPS_REFTYPE_BOTH_Val    _U(0x0)   /**< \brief (BPM_FWRUNPS)  */
+#define   BPM_FWRUNPS_REFTYPE_BG_Val      _U(0x1)   /**< \brief (BPM_FWRUNPS)  */
+#define   BPM_FWRUNPS_REFTYPE_LPBG_Val    _U(0x2)   /**< \brief (BPM_FWRUNPS)  */
+#define   BPM_FWRUNPS_REFTYPE_INTERNAL_Val _U(0x3)   /**< \brief (BPM_FWRUNPS)  */
+#define BPM_FWRUNPS_REFTYPE_BOTH    (BPM_FWRUNPS_REFTYPE_BOTH_Val  << BPM_FWRUNPS_REFTYPE_Pos)
+#define BPM_FWRUNPS_REFTYPE_BG      (BPM_FWRUNPS_REFTYPE_BG_Val    << BPM_FWRUNPS_REFTYPE_Pos)
+#define BPM_FWRUNPS_REFTYPE_LPBG    (BPM_FWRUNPS_REFTYPE_LPBG_Val  << BPM_FWRUNPS_REFTYPE_Pos)
+#define BPM_FWRUNPS_REFTYPE_INTERNAL (BPM_FWRUNPS_REFTYPE_INTERNAL_Val << BPM_FWRUNPS_REFTYPE_Pos)
+#define BPM_FWRUNPS_FLASHLATDEL_Pos 8            /**< \brief (BPM_FWRUNPS) Flash Latch Delay Value */
+#define BPM_FWRUNPS_FLASHLATDEL_Msk (_U(0x1F) << BPM_FWRUNPS_FLASHLATDEL_Pos)
+#define BPM_FWRUNPS_FLASHLATDEL(value) (BPM_FWRUNPS_FLASHLATDEL_Msk & ((value) << BPM_FWRUNPS_FLASHLATDEL_Pos))
+#define BPM_FWRUNPS_FLASHBIAS_Pos   13           /**< \brief (BPM_FWRUNPS) Flash Bias Value */
+#define BPM_FWRUNPS_FLASHBIAS_Msk   (_U(0xF) << BPM_FWRUNPS_FLASHBIAS_Pos)
+#define BPM_FWRUNPS_FLASHBIAS(value) (BPM_FWRUNPS_FLASHBIAS_Msk & ((value) << BPM_FWRUNPS_FLASHBIAS_Pos))
+#define BPM_FWRUNPS_FPPW_Pos        17           /**< \brief (BPM_FWRUNPS) Flash Pico Power Mode */
+#define BPM_FWRUNPS_FPPW            (_U(0x1) << BPM_FWRUNPS_FPPW_Pos)
+#define BPM_FWRUNPS_RC115_Pos       18           /**< \brief (BPM_FWRUNPS) RC 115KHZ Calibration Value */
+#define BPM_FWRUNPS_RC115_Msk       (_U(0x7F) << BPM_FWRUNPS_RC115_Pos)
+#define BPM_FWRUNPS_RC115(value)    (BPM_FWRUNPS_RC115_Msk & ((value) << BPM_FWRUNPS_RC115_Pos))
+#define BPM_FWRUNPS_RCFAST_Pos      25           /**< \brief (BPM_FWRUNPS) RCFAST Calibration Value */
+#define BPM_FWRUNPS_RCFAST_Msk      (_U(0x7F) << BPM_FWRUNPS_RCFAST_Pos)
+#define BPM_FWRUNPS_RCFAST(value)   (BPM_FWRUNPS_RCFAST_Msk & ((value) << BPM_FWRUNPS_RCFAST_Pos))
+#define BPM_FWRUNPS_MASK            _U(0xFFFFFFFF) /**< \brief (BPM_FWRUNPS) MASK Register */
+
+/* -------- BPM_FWPSAVEPS : (BPM Offset: 0x48) (R/  32) Factory Word Power Save PS Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t WREGLEVEL:4;      /*!< bit:  0.. 3  Wait mode Regulator Level          */
+    uint32_t WBIAS:4;          /*!< bit:  4.. 7  Bias in wait mode                  */
+    uint32_t WLATDEL:5;        /*!< bit:  8..12  Flash Latdel in wait mode          */
+    uint32_t RREGLEVEL:4;      /*!< bit: 13..16  Retention mode Regulator Level     */
+    uint32_t RBIAS:4;          /*!< bit: 17..20  Bias in Retention mode             */
+    uint32_t RLATDEL:5;        /*!< bit: 21..25  Flash Latdel in Retention mode     */
+    uint32_t BREGLEVEL:4;      /*!< bit: 26..29  Backup mode Regulator Level        */
+    uint32_t POR18DIS:1;       /*!< bit:     30  POR 18 Disable                     */
+    uint32_t FWSAS:1;          /*!< bit:     31  Flash Wait State Automatic Switching */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BPM_FWPSAVEPS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BPM_FWPSAVEPS_OFFSET        0x48         /**< \brief (BPM_FWPSAVEPS offset) Factory Word Power Save PS Register */
+
+#define BPM_FWPSAVEPS_WREGLEVEL_Pos 0            /**< \brief (BPM_FWPSAVEPS) Wait mode Regulator Level */
+#define BPM_FWPSAVEPS_WREGLEVEL_Msk (_U(0xF) << BPM_FWPSAVEPS_WREGLEVEL_Pos)
+#define BPM_FWPSAVEPS_WREGLEVEL(value) (BPM_FWPSAVEPS_WREGLEVEL_Msk & ((value) << BPM_FWPSAVEPS_WREGLEVEL_Pos))
+#define BPM_FWPSAVEPS_WBIAS_Pos     4            /**< \brief (BPM_FWPSAVEPS) Bias in wait mode */
+#define BPM_FWPSAVEPS_WBIAS_Msk     (_U(0xF) << BPM_FWPSAVEPS_WBIAS_Pos)
+#define BPM_FWPSAVEPS_WBIAS(value)  (BPM_FWPSAVEPS_WBIAS_Msk & ((value) << BPM_FWPSAVEPS_WBIAS_Pos))
+#define BPM_FWPSAVEPS_WLATDEL_Pos   8            /**< \brief (BPM_FWPSAVEPS) Flash Latdel in wait mode */
+#define BPM_FWPSAVEPS_WLATDEL_Msk   (_U(0x1F) << BPM_FWPSAVEPS_WLATDEL_Pos)
+#define BPM_FWPSAVEPS_WLATDEL(value) (BPM_FWPSAVEPS_WLATDEL_Msk & ((value) << BPM_FWPSAVEPS_WLATDEL_Pos))
+#define BPM_FWPSAVEPS_RREGLEVEL_Pos 13           /**< \brief (BPM_FWPSAVEPS) Retention mode Regulator Level */
+#define BPM_FWPSAVEPS_RREGLEVEL_Msk (_U(0xF) << BPM_FWPSAVEPS_RREGLEVEL_Pos)
+#define BPM_FWPSAVEPS_RREGLEVEL(value) (BPM_FWPSAVEPS_RREGLEVEL_Msk & ((value) << BPM_FWPSAVEPS_RREGLEVEL_Pos))
+#define BPM_FWPSAVEPS_RBIAS_Pos     17           /**< \brief (BPM_FWPSAVEPS) Bias in Retention mode */
+#define BPM_FWPSAVEPS_RBIAS_Msk     (_U(0xF) << BPM_FWPSAVEPS_RBIAS_Pos)
+#define BPM_FWPSAVEPS_RBIAS(value)  (BPM_FWPSAVEPS_RBIAS_Msk & ((value) << BPM_FWPSAVEPS_RBIAS_Pos))
+#define BPM_FWPSAVEPS_RLATDEL_Pos   21           /**< \brief (BPM_FWPSAVEPS) Flash Latdel in Retention mode */
+#define BPM_FWPSAVEPS_RLATDEL_Msk   (_U(0x1F) << BPM_FWPSAVEPS_RLATDEL_Pos)
+#define BPM_FWPSAVEPS_RLATDEL(value) (BPM_FWPSAVEPS_RLATDEL_Msk & ((value) << BPM_FWPSAVEPS_RLATDEL_Pos))
+#define BPM_FWPSAVEPS_BREGLEVEL_Pos 26           /**< \brief (BPM_FWPSAVEPS) Backup mode Regulator Level */
+#define BPM_FWPSAVEPS_BREGLEVEL_Msk (_U(0xF) << BPM_FWPSAVEPS_BREGLEVEL_Pos)
+#define BPM_FWPSAVEPS_BREGLEVEL(value) (BPM_FWPSAVEPS_BREGLEVEL_Msk & ((value) << BPM_FWPSAVEPS_BREGLEVEL_Pos))
+#define BPM_FWPSAVEPS_POR18DIS_Pos  30           /**< \brief (BPM_FWPSAVEPS) POR 18 Disable */
+#define BPM_FWPSAVEPS_POR18DIS      (_U(0x1) << BPM_FWPSAVEPS_POR18DIS_Pos)
+#define BPM_FWPSAVEPS_FWSAS_Pos     31           /**< \brief (BPM_FWPSAVEPS) Flash Wait State Automatic Switching */
+#define BPM_FWPSAVEPS_FWSAS         (_U(0x1) << BPM_FWPSAVEPS_FWSAS_Pos)
+#define BPM_FWPSAVEPS_MASK          _U(0xFFFFFFFF) /**< \brief (BPM_FWPSAVEPS) MASK Register */
+
+/* -------- BPM_VERSION : (BPM Offset: 0xFC) (R/  32) Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version Number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant Number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BPM_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BPM_VERSION_OFFSET          0xFC         /**< \brief (BPM_VERSION offset) Version Register */
+#define BPM_VERSION_RESETVALUE      _U(0x00000120); /**< \brief (BPM_VERSION reset_value) Version Register */
+
+#define BPM_VERSION_VERSION_Pos     0            /**< \brief (BPM_VERSION) Version Number */
+#define BPM_VERSION_VERSION_Msk     (_U(0xFFF) << BPM_VERSION_VERSION_Pos)
+#define BPM_VERSION_VERSION(value)  (BPM_VERSION_VERSION_Msk & ((value) << BPM_VERSION_VERSION_Pos))
+#define BPM_VERSION_VARIANT_Pos     16           /**< \brief (BPM_VERSION) Variant Number */
+#define BPM_VERSION_VARIANT_Msk     (_U(0xF) << BPM_VERSION_VARIANT_Pos)
+#define BPM_VERSION_VARIANT(value)  (BPM_VERSION_VARIANT_Msk & ((value) << BPM_VERSION_VARIANT_Pos))
+#define BPM_VERSION_MASK            _U(0x000F0FFF) /**< \brief (BPM_VERSION) MASK Register */
+
+/** \brief BPM hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __O  BPM_IER_Type              IER;         /**< \brief Offset: 0x00 ( /W 32) Interrupt Enable Register */
+  __O  BPM_IDR_Type              IDR;         /**< \brief Offset: 0x04 ( /W 32) Interrupt Disable Register */
+  __I  BPM_IMR_Type              IMR;         /**< \brief Offset: 0x08 (R/  32) Interrupt Mask Register */
+  __I  BPM_ISR_Type              ISR;         /**< \brief Offset: 0x0C (R/  32) Interrupt Status Register */
+  __O  BPM_ICR_Type              ICR;         /**< \brief Offset: 0x10 ( /W 32) Interrupt Clear Register */
+  __I  BPM_SR_Type               SR;          /**< \brief Offset: 0x14 (R/  32) Status Register */
+  __O  BPM_UNLOCK_Type           UNLOCK;      /**< \brief Offset: 0x18 ( /W 32) Unlock Register */
+  __IO BPM_PMCON_Type            PMCON;       /**< \brief Offset: 0x1C (R/W 32) Power Mode Control Register */
+       RoReg8                    Reserved1[0x8];
+  __I  BPM_BKUPWCAUSE_Type       BKUPWCAUSE;  /**< \brief Offset: 0x28 (R/  32) Backup Wake up Cause Register */
+  __IO BPM_BKUPWEN_Type          BKUPWEN;     /**< \brief Offset: 0x2C (R/W 32) Backup Wake up Enable Register */
+  __IO BPM_BKUPPMUX_Type         BKUPPMUX;    /**< \brief Offset: 0x30 (R/W 32) Backup Pin Muxing Register */
+  __IO BPM_IORET_Type            IORET;       /**< \brief Offset: 0x34 (R/W 32) Input Output Retention Register */
+       RoReg8                    Reserved2[0x8];
+  __IO BPM_BPR_Type              BPR;         /**< \brief Offset: 0x40 (R/W 32) Bypass Register */
+  __I  BPM_FWRUNPS_Type          FWRUNPS;     /**< \brief Offset: 0x44 (R/  32) Factory Word Run PS Register */
+  __I  BPM_FWPSAVEPS_Type        FWPSAVEPS;   /**< \brief Offset: 0x48 (R/  32) Factory Word Power Save PS Register */
+       RoReg8                    Reserved3[0xB0];
+  __I  BPM_VERSION_Type          VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
+ } bf;
+ struct {
+  WoReg   BPM_IER;            /**< \brief (BPM Offset: 0x00) Interrupt Enable Register */
+  WoReg   BPM_IDR;            /**< \brief (BPM Offset: 0x04) Interrupt Disable Register */
+  RoReg   BPM_IMR;            /**< \brief (BPM Offset: 0x08) Interrupt Mask Register */
+  RoReg   BPM_ISR;            /**< \brief (BPM Offset: 0x0C) Interrupt Status Register */
+  WoReg   BPM_ICR;            /**< \brief (BPM Offset: 0x10) Interrupt Clear Register */
+  RoReg   BPM_SR;             /**< \brief (BPM Offset: 0x14) Status Register */
+  WoReg   BPM_UNLOCK;         /**< \brief (BPM Offset: 0x18) Unlock Register */
+  RwReg   BPM_PMCON;          /**< \brief (BPM Offset: 0x1C) Power Mode Control Register */
+  RoReg8  Reserved4[0x8];
+  RoReg   BPM_BKUPWCAUSE;     /**< \brief (BPM Offset: 0x28) Backup Wake up Cause Register */
+  RwReg   BPM_BKUPWEN;        /**< \brief (BPM Offset: 0x2C) Backup Wake up Enable Register */
+  RwReg   BPM_BKUPPMUX;       /**< \brief (BPM Offset: 0x30) Backup Pin Muxing Register */
+  RwReg   BPM_IORET;          /**< \brief (BPM Offset: 0x34) Input Output Retention Register */
+  RoReg8  Reserved5[0x8];
+  RwReg   BPM_BPR;            /**< \brief (BPM Offset: 0x40) Bypass Register */
+  RoReg   BPM_FWRUNPS;        /**< \brief (BPM Offset: 0x44) Factory Word Run PS Register */
+  RoReg   BPM_FWPSAVEPS;      /**< \brief (BPM Offset: 0x48) Factory Word Power Save PS Register */
+  RoReg8  Reserved6[0xB0];
+  RoReg   BPM_VERSION;        /**< \brief (BPM Offset: 0xFC) Version Register */
+ } reg;
+} Bpm;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_BPM_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/bscif.h
+++ b/asf/sam/include/sam4l/component/bscif.h
@@ -989,95 +989,50 @@ typedef union {
 
 /** \brief BscifBr hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __IO BSCIF_BR_Type             BR;          /**< \brief Offset: 0x000 (R/W 32) Backup Register */
- } bf;
- struct {
-  RwReg   BSCIF_BR;           /**< \brief (BSCIF Offset: 0x000) Backup Register */
- } reg;
+typedef struct {
+  __IO uint32_t BR;          /**< \brief Offset: 0x000 (R/W 32) Backup Register */
 } BscifBr;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /** \brief BSCIF hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __O  BSCIF_IER_Type            IER;         /**< \brief Offset: 0x000 ( /W 32) Interrupt Enable Register */
-  __O  BSCIF_IDR_Type            IDR;         /**< \brief Offset: 0x004 ( /W 32) Interrupt Disable Register */
-  __I  BSCIF_IMR_Type            IMR;         /**< \brief Offset: 0x008 (R/  32) Interrupt Mask Register */
-  __I  BSCIF_ISR_Type            ISR;         /**< \brief Offset: 0x00C (R/  32) Interrupt Status Register */
-  __O  BSCIF_ICR_Type            ICR;         /**< \brief Offset: 0x010 ( /W 32) Interrupt Clear Register */
-  __I  BSCIF_PCLKSR_Type         PCLKSR;      /**< \brief Offset: 0x014 (R/  32) Power and Clocks Status Register */
-  __O  BSCIF_UNLOCK_Type         UNLOCK;      /**< \brief Offset: 0x018 ( /W 32) Unlock Register */
-  __IO BSCIF_CSCR_Type           CSCR;        /**< \brief Offset: 0x01C (R/W 32) Chip Specific Configuration Register */
-  __IO BSCIF_OSCCTRL32_Type      OSCCTRL32;   /**< \brief Offset: 0x020 (R/W 32) Oscillator 32 Control Register */
-  __IO BSCIF_RC32KCR_Type        RC32KCR;     /**< \brief Offset: 0x024 (R/W 32) 32 kHz RC Oscillator Control Register */
-  __IO BSCIF_RC32KTUNE_Type      RC32KTUNE;   /**< \brief Offset: 0x028 (R/W 32) 32kHz RC Oscillator Tuning Register */
-  __IO BSCIF_BOD33CTRL_Type      BOD33CTRL;   /**< \brief Offset: 0x02C (R/W 32) BOD33 Control Register */
-  __IO BSCIF_BOD33LEVEL_Type     BOD33LEVEL;  /**< \brief Offset: 0x030 (R/W 32) BOD33 Level Register */
-  __IO BSCIF_BOD33SAMPLING_Type  BOD33SAMPLING; /**< \brief Offset: 0x034 (R/W 32) BOD33 Sampling Control Register */
-  __IO BSCIF_BOD18CTRL_Type      BOD18CTRL;   /**< \brief Offset: 0x038 (R/W 32) BOD18 Control Register */
-  __IO BSCIF_BOD18LEVEL_Type     BOD18LEVEL;  /**< \brief Offset: 0x03C (R/W 32) BOD18 Level Register */
-       RoReg8                    Reserved1[0x4];
-  __IO BSCIF_VREGCR_Type         VREGCR;      /**< \brief Offset: 0x044 (R/W 32) Voltage Regulator Configuration Register */
-       RoReg8                    Reserved2[0x4];
-  __IO BSCIF_VREGNCSR_Type       VREGNCSR;    /**< \brief Offset: 0x04C (R/W 32) Normal Mode Control and Status Register */
-  __IO BSCIF_VREGLPCSR_Type      VREGLPCSR;   /**< \brief Offset: 0x050 (R/W 32) LP Mode Control and Status Register */
-       RoReg8                    Reserved3[0x4];
-  __IO BSCIF_RC1MCR_Type         RC1MCR;      /**< \brief Offset: 0x058 (R/W 32) 1MHz RC Clock Configuration Register */
-  __IO BSCIF_BGCR_Type           BGCR;        /**< \brief Offset: 0x05C (R/W 32) Bandgap Calibration Register */
-  __IO BSCIF_BGCTRL_Type         BGCTRL;      /**< \brief Offset: 0x060 (R/W 32) Bandgap Control Register */
-  __I  BSCIF_BGSR_Type           BGSR;        /**< \brief Offset: 0x064 (R/  32) Bandgap Status Register */
-       RoReg8                    Reserved4[0x10];
-       BscifBr                   Br[4];       /**< \brief Offset: 0x078 BscifBr groups */
-       RoReg8                    Reserved5[0x35C];
-  __I  BSCIF_BRIFBVERSION_Type   BRIFBVERSION; /**< \brief Offset: 0x3E4 (R/  32) Backup Register Interface Version Register */
-  __I  BSCIF_BGREFIFBVERSION_Type BGREFIFBVERSION; /**< \brief Offset: 0x3E8 (R/  32) BGREFIFB Version Register */
-  __I  BSCIF_VREGIFGVERSION_Type VREGIFGVERSION; /**< \brief Offset: 0x3EC (R/  32) VREGIFA Version Register */
-  __I  BSCIF_BODIFCVERSION_Type  BODIFCVERSION; /**< \brief Offset: 0x3F0 (R/  32) BODIFC Version Register */
-  __I  BSCIF_RC32KIFBVERSION_Type RC32KIFBVERSION; /**< \brief Offset: 0x3F4 (R/  32) 32 kHz RC Oscillator Version Register */
-  __I  BSCIF_OSC32IFAVERSION_Type OSC32IFAVERSION; /**< \brief Offset: 0x3F8 (R/  32) 32 KHz Oscillator Version Register */
-  __I  BSCIF_VERSION_Type        VERSION;     /**< \brief Offset: 0x3FC (R/  32) BSCIF Version Register */
- } bf;
- struct {
-  WoReg   BSCIF_IER;          /**< \brief (BSCIF Offset: 0x000) Interrupt Enable Register */
-  WoReg   BSCIF_IDR;          /**< \brief (BSCIF Offset: 0x004) Interrupt Disable Register */
-  RoReg   BSCIF_IMR;          /**< \brief (BSCIF Offset: 0x008) Interrupt Mask Register */
-  RoReg   BSCIF_ISR;          /**< \brief (BSCIF Offset: 0x00C) Interrupt Status Register */
-  WoReg   BSCIF_ICR;          /**< \brief (BSCIF Offset: 0x010) Interrupt Clear Register */
-  RoReg   BSCIF_PCLKSR;       /**< \brief (BSCIF Offset: 0x014) Power and Clocks Status Register */
-  WoReg   BSCIF_UNLOCK;       /**< \brief (BSCIF Offset: 0x018) Unlock Register */
-  RwReg   BSCIF_CSCR;         /**< \brief (BSCIF Offset: 0x01C) Chip Specific Configuration Register */
-  RwReg   BSCIF_OSCCTRL32;    /**< \brief (BSCIF Offset: 0x020) Oscillator 32 Control Register */
-  RwReg   BSCIF_RC32KCR;      /**< \brief (BSCIF Offset: 0x024) 32 kHz RC Oscillator Control Register */
-  RwReg   BSCIF_RC32KTUNE;    /**< \brief (BSCIF Offset: 0x028) 32kHz RC Oscillator Tuning Register */
-  RwReg   BSCIF_BOD33CTRL;    /**< \brief (BSCIF Offset: 0x02C) BOD33 Control Register */
-  RwReg   BSCIF_BOD33LEVEL;   /**< \brief (BSCIF Offset: 0x030) BOD33 Level Register */
-  RwReg   BSCIF_BOD33SAMPLING; /**< \brief (BSCIF Offset: 0x034) BOD33 Sampling Control Register */
-  RwReg   BSCIF_BOD18CTRL;    /**< \brief (BSCIF Offset: 0x038) BOD18 Control Register */
-  RwReg   BSCIF_BOD18LEVEL;   /**< \brief (BSCIF Offset: 0x03C) BOD18 Level Register */
-  RoReg8  Reserved6[0x4];
-  RwReg   BSCIF_VREGCR;       /**< \brief (BSCIF Offset: 0x044) Voltage Regulator Configuration Register */
-  RoReg8  Reserved7[0x4];
-  RwReg   BSCIF_VREGNCSR;     /**< \brief (BSCIF Offset: 0x04C) Normal Mode Control and Status Register */
-  RwReg   BSCIF_VREGLPCSR;    /**< \brief (BSCIF Offset: 0x050) LP Mode Control and Status Register */
-  RoReg8  Reserved8[0x4];
-  RwReg   BSCIF_RC1MCR;       /**< \brief (BSCIF Offset: 0x058) 1MHz RC Clock Configuration Register */
-  RwReg   BSCIF_BGCR;         /**< \brief (BSCIF Offset: 0x05C) Bandgap Calibration Register */
-  RwReg   BSCIF_BGCTRL;       /**< \brief (BSCIF Offset: 0x060) Bandgap Control Register */
-  RoReg   BSCIF_BGSR;         /**< \brief (BSCIF Offset: 0x064) Bandgap Status Register */
-  RoReg8  Reserved9[0x10];
-  BscifBr BSCIF_BR[4];        /**< \brief (BSCIF Offset: 0x078) BscifBr groups */
-  RoReg8  Reserved10[0x35C];
-  RoReg   BSCIF_BRIFBVERSION; /**< \brief (BSCIF Offset: 0x3E4) Backup Register Interface Version Register */
-  RoReg   BSCIF_BGREFIFBVERSION; /**< \brief (BSCIF Offset: 0x3E8) BGREFIFB Version Register */
-  RoReg   BSCIF_VREGIFGVERSION; /**< \brief (BSCIF Offset: 0x3EC) VREGIFA Version Register */
-  RoReg   BSCIF_BODIFCVERSION; /**< \brief (BSCIF Offset: 0x3F0) BODIFC Version Register */
-  RoReg   BSCIF_RC32KIFBVERSION; /**< \brief (BSCIF Offset: 0x3F4) 32 kHz RC Oscillator Version Register */
-  RoReg   BSCIF_OSC32IFAVERSION; /**< \brief (BSCIF Offset: 0x3F8) 32 KHz Oscillator Version Register */
-  RoReg   BSCIF_VERSION;      /**< \brief (BSCIF Offset: 0x3FC) BSCIF Version Register */
- } reg;
+typedef struct {
+  __O  uint32_t IER;             /**< \brief Offset: 0x000 ( /W 32) Interrupt Enable Register */
+  __O  uint32_t IDR;             /**< \brief Offset: 0x004 ( /W 32) Interrupt Disable Register */
+  __I  uint32_t IMR;             /**< \brief Offset: 0x008 (R/  32) Interrupt Mask Register */
+  __I  uint32_t ISR;             /**< \brief Offset: 0x00C (R/  32) Interrupt Status Register */
+  __O  uint32_t ICR;             /**< \brief Offset: 0x010 ( /W 32) Interrupt Clear Register */
+  __I  uint32_t PCLKSR;          /**< \brief Offset: 0x014 (R/  32) Power and Clocks Status Register */
+  __O  uint32_t UNLOCK;          /**< \brief Offset: 0x018 ( /W 32) Unlock Register */
+  __IO uint32_t CSCR;            /**< \brief Offset: 0x01C (R/W 32) Chip Specific Configuration Register */
+  __IO uint32_t OSCCTRL32;       /**< \brief Offset: 0x020 (R/W 32) Oscillator 32 Control Register */
+  __IO uint32_t RC32KCR;         /**< \brief Offset: 0x024 (R/W 32) 32 kHz RC Oscillator Control Register */
+  __IO uint32_t RC32KTUNE;       /**< \brief Offset: 0x028 (R/W 32) 32kHz RC Oscillator Tuning Register */
+  __IO uint32_t BOD33CTRL;       /**< \brief Offset: 0x02C (R/W 32) BOD33 Control Register */
+  __IO uint32_t BOD33LEVEL;      /**< \brief Offset: 0x030 (R/W 32) BOD33 Level Register */
+  __IO uint32_t BOD33SAMPLING;   /**< \brief Offset: 0x034 (R/W 32) BOD33 Sampling Control Register */
+  __IO uint32_t BOD18CTRL;       /**< \brief Offset: 0x038 (R/W 32) BOD18 Control Register */
+  __IO uint32_t BOD18LEVEL;      /**< \brief Offset: 0x03C (R/W 32) BOD18 Level Register */
+       RoReg8   Reserved1[0x4];
+  __IO uint32_t VREGCR;          /**< \brief Offset: 0x044 (R/W 32) Voltage Regulator Configuration Register */
+       RoReg8   Reserved2[0x4];
+  __IO uint32_t VREGNCSR;        /**< \brief Offset: 0x04C (R/W 32) Normal Mode Control and Status Register */
+  __IO uint32_t VREGLPCSR;       /**< \brief Offset: 0x050 (R/W 32) LP Mode Control and Status Register */
+       RoReg8   Reserved3[0x4];
+  __IO uint32_t RC1MCR;          /**< \brief Offset: 0x058 (R/W 32) 1MHz RC Clock Configuration Register */
+  __IO uint32_t BGCR;            /**< \brief Offset: 0x05C (R/W 32) Bandgap Calibration Register */
+  __IO uint32_t BGCTRL;          /**< \brief Offset: 0x060 (R/W 32) Bandgap Control Register */
+  __I  uint32_t BGSR;            /**< \brief Offset: 0x064 (R/  32) Bandgap Status Register */
+       RoReg8   Reserved4[0x10];
+       uint32_t BR[4];           /**< \brief Offset: 0x078 BscifBr groups */
+       RoReg8   Reserved5[0x35C];
+  __I  uint32_t BRIFBVERSION;    /**< \brief Offset: 0x3E4 (R/  32) Backup Register Interface Version Register */
+  __I  uint32_t BGREFIFBVERSION; /**< \brief Offset: 0x3E8 (R/  32) BGREFIFB Version Register */
+  __I  uint32_t VREGIFGVERSION;  /**< \brief Offset: 0x3EC (R/  32) VREGIFA Version Register */
+  __I  uint32_t BODIFCVERSION;   /**< \brief Offset: 0x3F0 (R/  32) BODIFC Version Register */
+  __I  uint32_t RC32KIFBVERSION; /**< \brief Offset: 0x3F4 (R/  32) 32 kHz RC Oscillator Version Register */
+  __I  uint32_t OSC32IFAVERSION; /**< \brief Offset: 0x3F8 (R/  32) 32 KHz Oscillator Version Register */
+  __I  uint32_t VERSION;         /**< \brief Offset: 0x3FC (R/  32) BSCIF Version Register */
 } Bscif;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/bscif.h
+++ b/asf/sam/include/sam4l/component/bscif.h
@@ -1,0 +1,1086 @@
+/**
+ * \file
+ *
+ * \brief Component description for BSCIF
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_BSCIF_COMPONENT_
+#define _SAM4L_BSCIF_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR BSCIF */
+/* ========================================================================== */
+/** \addtogroup SAM4L_BSCIF Backup System Control Interface */
+/*@{*/
+
+#define BSCIF_
+#define REV_BSCIF                   0x100
+
+/* -------- BSCIF_IER : (BSCIF Offset: 0x000) ( /W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OSC32RDY:1;       /*!< bit:      0  32kHz Oscillator Ready             */
+    uint32_t RC32KRDY:1;       /*!< bit:      1  32kHz RC Oscillator Ready          */
+    uint32_t RC32KLOCK:1;      /*!< bit:      2  32kHz RC Oscillator Lock           */
+    uint32_t RC32KREFE:1;      /*!< bit:      3  32kHz RC Oscillator Reference Error */
+    uint32_t RC32KSAT:1;       /*!< bit:      4  32kHz RC Oscillator Saturation     */
+    uint32_t BOD33DET:1;       /*!< bit:      5  BOD33 Detected                     */
+    uint32_t BOD18DET:1;       /*!< bit:      6  BOD18 Detected                     */
+    uint32_t BOD33SYNRDY:1;    /*!< bit:      7  BOD33 Synchronization Ready        */
+    uint32_t BOD18SYNRDY:1;    /*!< bit:      8  BOD18 Synchronization Ready        */
+    uint32_t SSWRDY:1;         /*!< bit:      9  VREG Stop Switching Ready          */
+    uint32_t VREGOK:1;         /*!< bit:     10  Main VREG OK                       */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t LPBGRDY:1;        /*!< bit:     12  Low Power Bandgap Voltage Reference Ready */
+    uint32_t :18;              /*!< bit: 13..30  Reserved                           */
+    uint32_t AE:1;             /*!< bit:     31  Access Error                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_IER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_IER_OFFSET            0x000        /**< \brief (BSCIF_IER offset) Interrupt Enable Register */
+#define BSCIF_IER_RESETVALUE        _U(0x00000000); /**< \brief (BSCIF_IER reset_value) Interrupt Enable Register */
+
+#define BSCIF_IER_OSC32RDY_Pos      0            /**< \brief (BSCIF_IER) 32kHz Oscillator Ready */
+#define BSCIF_IER_OSC32RDY          (_U(0x1) << BSCIF_IER_OSC32RDY_Pos)
+#define BSCIF_IER_RC32KRDY_Pos      1            /**< \brief (BSCIF_IER) 32kHz RC Oscillator Ready */
+#define BSCIF_IER_RC32KRDY          (_U(0x1) << BSCIF_IER_RC32KRDY_Pos)
+#define BSCIF_IER_RC32KLOCK_Pos     2            /**< \brief (BSCIF_IER) 32kHz RC Oscillator Lock */
+#define BSCIF_IER_RC32KLOCK         (_U(0x1) << BSCIF_IER_RC32KLOCK_Pos)
+#define BSCIF_IER_RC32KREFE_Pos     3            /**< \brief (BSCIF_IER) 32kHz RC Oscillator Reference Error */
+#define BSCIF_IER_RC32KREFE         (_U(0x1) << BSCIF_IER_RC32KREFE_Pos)
+#define BSCIF_IER_RC32KSAT_Pos      4            /**< \brief (BSCIF_IER) 32kHz RC Oscillator Saturation */
+#define BSCIF_IER_RC32KSAT          (_U(0x1) << BSCIF_IER_RC32KSAT_Pos)
+#define BSCIF_IER_BOD33DET_Pos      5            /**< \brief (BSCIF_IER) BOD33 Detected */
+#define BSCIF_IER_BOD33DET          (_U(0x1) << BSCIF_IER_BOD33DET_Pos)
+#define BSCIF_IER_BOD18DET_Pos      6            /**< \brief (BSCIF_IER) BOD18 Detected */
+#define BSCIF_IER_BOD18DET          (_U(0x1) << BSCIF_IER_BOD18DET_Pos)
+#define BSCIF_IER_BOD33SYNRDY_Pos   7            /**< \brief (BSCIF_IER) BOD33 Synchronization Ready */
+#define BSCIF_IER_BOD33SYNRDY       (_U(0x1) << BSCIF_IER_BOD33SYNRDY_Pos)
+#define BSCIF_IER_BOD18SYNRDY_Pos   8            /**< \brief (BSCIF_IER) BOD18 Synchronization Ready */
+#define BSCIF_IER_BOD18SYNRDY       (_U(0x1) << BSCIF_IER_BOD18SYNRDY_Pos)
+#define BSCIF_IER_SSWRDY_Pos        9            /**< \brief (BSCIF_IER) VREG Stop Switching Ready */
+#define BSCIF_IER_SSWRDY            (_U(0x1) << BSCIF_IER_SSWRDY_Pos)
+#define BSCIF_IER_VREGOK_Pos        10           /**< \brief (BSCIF_IER) Main VREG OK */
+#define BSCIF_IER_VREGOK            (_U(0x1) << BSCIF_IER_VREGOK_Pos)
+#define BSCIF_IER_LPBGRDY_Pos       12           /**< \brief (BSCIF_IER) Low Power Bandgap Voltage Reference Ready */
+#define BSCIF_IER_LPBGRDY           (_U(0x1) << BSCIF_IER_LPBGRDY_Pos)
+#define BSCIF_IER_AE_Pos            31           /**< \brief (BSCIF_IER) Access Error */
+#define BSCIF_IER_AE                (_U(0x1) << BSCIF_IER_AE_Pos)
+#define BSCIF_IER_MASK              _U(0x800017FF) /**< \brief (BSCIF_IER) MASK Register */
+
+/* -------- BSCIF_IDR : (BSCIF Offset: 0x004) ( /W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OSC32RDY:1;       /*!< bit:      0  32kHz Oscillator Ready             */
+    uint32_t RC32KRDY:1;       /*!< bit:      1  32kHz RC Oscillator Ready          */
+    uint32_t RC32KLOCK:1;      /*!< bit:      2  32kHz RC Oscillator Lock           */
+    uint32_t RC32KREFE:1;      /*!< bit:      3  32kHz RC Oscillator Reference Error */
+    uint32_t RC32KSAT:1;       /*!< bit:      4  32kHz RC Oscillator Saturation     */
+    uint32_t BOD33DET:1;       /*!< bit:      5  BOD33 Detected                     */
+    uint32_t BOD18DET:1;       /*!< bit:      6  BOD18 Detected                     */
+    uint32_t BOD33SYNRDY:1;    /*!< bit:      7  BOD33 Synchronization Ready        */
+    uint32_t BOD18SYNRDY:1;    /*!< bit:      8  BOD18 Synchronization Ready        */
+    uint32_t SSWRDY:1;         /*!< bit:      9  VREG Stop Switching Ready          */
+    uint32_t VREGOK:1;         /*!< bit:     10  Mai n VREG OK                      */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t LPBGRDY:1;        /*!< bit:     12  Low Power Bandgap Voltage Reference Ready */
+    uint32_t :18;              /*!< bit: 13..30  Reserved                           */
+    uint32_t AE:1;             /*!< bit:     31  Access Error                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_IDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_IDR_OFFSET            0x004        /**< \brief (BSCIF_IDR offset) Interrupt Disable Register */
+#define BSCIF_IDR_RESETVALUE        _U(0x00000000); /**< \brief (BSCIF_IDR reset_value) Interrupt Disable Register */
+
+#define BSCIF_IDR_OSC32RDY_Pos      0            /**< \brief (BSCIF_IDR) 32kHz Oscillator Ready */
+#define BSCIF_IDR_OSC32RDY          (_U(0x1) << BSCIF_IDR_OSC32RDY_Pos)
+#define BSCIF_IDR_RC32KRDY_Pos      1            /**< \brief (BSCIF_IDR) 32kHz RC Oscillator Ready */
+#define BSCIF_IDR_RC32KRDY          (_U(0x1) << BSCIF_IDR_RC32KRDY_Pos)
+#define BSCIF_IDR_RC32KLOCK_Pos     2            /**< \brief (BSCIF_IDR) 32kHz RC Oscillator Lock */
+#define BSCIF_IDR_RC32KLOCK         (_U(0x1) << BSCIF_IDR_RC32KLOCK_Pos)
+#define BSCIF_IDR_RC32KREFE_Pos     3            /**< \brief (BSCIF_IDR) 32kHz RC Oscillator Reference Error */
+#define BSCIF_IDR_RC32KREFE         (_U(0x1) << BSCIF_IDR_RC32KREFE_Pos)
+#define BSCIF_IDR_RC32KSAT_Pos      4            /**< \brief (BSCIF_IDR) 32kHz RC Oscillator Saturation */
+#define BSCIF_IDR_RC32KSAT          (_U(0x1) << BSCIF_IDR_RC32KSAT_Pos)
+#define BSCIF_IDR_BOD33DET_Pos      5            /**< \brief (BSCIF_IDR) BOD33 Detected */
+#define BSCIF_IDR_BOD33DET          (_U(0x1) << BSCIF_IDR_BOD33DET_Pos)
+#define BSCIF_IDR_BOD18DET_Pos      6            /**< \brief (BSCIF_IDR) BOD18 Detected */
+#define BSCIF_IDR_BOD18DET          (_U(0x1) << BSCIF_IDR_BOD18DET_Pos)
+#define BSCIF_IDR_BOD33SYNRDY_Pos   7            /**< \brief (BSCIF_IDR) BOD33 Synchronization Ready */
+#define BSCIF_IDR_BOD33SYNRDY       (_U(0x1) << BSCIF_IDR_BOD33SYNRDY_Pos)
+#define BSCIF_IDR_BOD18SYNRDY_Pos   8            /**< \brief (BSCIF_IDR) BOD18 Synchronization Ready */
+#define BSCIF_IDR_BOD18SYNRDY       (_U(0x1) << BSCIF_IDR_BOD18SYNRDY_Pos)
+#define BSCIF_IDR_SSWRDY_Pos        9            /**< \brief (BSCIF_IDR) VREG Stop Switching Ready */
+#define BSCIF_IDR_SSWRDY            (_U(0x1) << BSCIF_IDR_SSWRDY_Pos)
+#define BSCIF_IDR_VREGOK_Pos        10           /**< \brief (BSCIF_IDR) Mai n VREG OK */
+#define BSCIF_IDR_VREGOK            (_U(0x1) << BSCIF_IDR_VREGOK_Pos)
+#define BSCIF_IDR_LPBGRDY_Pos       12           /**< \brief (BSCIF_IDR) Low Power Bandgap Voltage Reference Ready */
+#define BSCIF_IDR_LPBGRDY           (_U(0x1) << BSCIF_IDR_LPBGRDY_Pos)
+#define BSCIF_IDR_AE_Pos            31           /**< \brief (BSCIF_IDR) Access Error */
+#define BSCIF_IDR_AE                (_U(0x1) << BSCIF_IDR_AE_Pos)
+#define BSCIF_IDR_MASK              _U(0x800017FF) /**< \brief (BSCIF_IDR) MASK Register */
+
+/* -------- BSCIF_IMR : (BSCIF Offset: 0x008) (R/  32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OSC32RDY:1;       /*!< bit:      0  32kHz Oscillator Ready             */
+    uint32_t RC32KRDY:1;       /*!< bit:      1  32kHz RC Oscillator Ready          */
+    uint32_t RC32KLOCK:1;      /*!< bit:      2  32kHz RC Oscillator Lock           */
+    uint32_t RC32KREFE:1;      /*!< bit:      3  32kHz RC Oscillator Reference Error */
+    uint32_t RC32KSAT:1;       /*!< bit:      4  32kHz RC Oscillator Saturation     */
+    uint32_t BOD33DET:1;       /*!< bit:      5  BOD33 Detected                     */
+    uint32_t BOD18DET:1;       /*!< bit:      6  BOD18 Detected                     */
+    uint32_t BOD33SYNRDY:1;    /*!< bit:      7  BOD33 Synchronization Ready        */
+    uint32_t BOD18SYNRDY:1;    /*!< bit:      8  BOD18 Synchronization Ready        */
+    uint32_t SSWRDY:1;         /*!< bit:      9  VREG Stop Switching Ready          */
+    uint32_t VREGOK:1;         /*!< bit:     10  Main VREG OK                       */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t LPBGRDY:1;        /*!< bit:     12  Low Power Bandgap Voltage Reference Ready */
+    uint32_t :18;              /*!< bit: 13..30  Reserved                           */
+    uint32_t AE:1;             /*!< bit:     31  Access Error                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_IMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_IMR_OFFSET            0x008        /**< \brief (BSCIF_IMR offset) Interrupt Mask Register */
+#define BSCIF_IMR_RESETVALUE        _U(0x00000000); /**< \brief (BSCIF_IMR reset_value) Interrupt Mask Register */
+
+#define BSCIF_IMR_OSC32RDY_Pos      0            /**< \brief (BSCIF_IMR) 32kHz Oscillator Ready */
+#define BSCIF_IMR_OSC32RDY          (_U(0x1) << BSCIF_IMR_OSC32RDY_Pos)
+#define BSCIF_IMR_RC32KRDY_Pos      1            /**< \brief (BSCIF_IMR) 32kHz RC Oscillator Ready */
+#define BSCIF_IMR_RC32KRDY          (_U(0x1) << BSCIF_IMR_RC32KRDY_Pos)
+#define BSCIF_IMR_RC32KLOCK_Pos     2            /**< \brief (BSCIF_IMR) 32kHz RC Oscillator Lock */
+#define BSCIF_IMR_RC32KLOCK         (_U(0x1) << BSCIF_IMR_RC32KLOCK_Pos)
+#define BSCIF_IMR_RC32KREFE_Pos     3            /**< \brief (BSCIF_IMR) 32kHz RC Oscillator Reference Error */
+#define BSCIF_IMR_RC32KREFE         (_U(0x1) << BSCIF_IMR_RC32KREFE_Pos)
+#define BSCIF_IMR_RC32KSAT_Pos      4            /**< \brief (BSCIF_IMR) 32kHz RC Oscillator Saturation */
+#define BSCIF_IMR_RC32KSAT          (_U(0x1) << BSCIF_IMR_RC32KSAT_Pos)
+#define BSCIF_IMR_BOD33DET_Pos      5            /**< \brief (BSCIF_IMR) BOD33 Detected */
+#define BSCIF_IMR_BOD33DET          (_U(0x1) << BSCIF_IMR_BOD33DET_Pos)
+#define BSCIF_IMR_BOD18DET_Pos      6            /**< \brief (BSCIF_IMR) BOD18 Detected */
+#define BSCIF_IMR_BOD18DET          (_U(0x1) << BSCIF_IMR_BOD18DET_Pos)
+#define BSCIF_IMR_BOD33SYNRDY_Pos   7            /**< \brief (BSCIF_IMR) BOD33 Synchronization Ready */
+#define BSCIF_IMR_BOD33SYNRDY       (_U(0x1) << BSCIF_IMR_BOD33SYNRDY_Pos)
+#define BSCIF_IMR_BOD18SYNRDY_Pos   8            /**< \brief (BSCIF_IMR) BOD18 Synchronization Ready */
+#define BSCIF_IMR_BOD18SYNRDY       (_U(0x1) << BSCIF_IMR_BOD18SYNRDY_Pos)
+#define BSCIF_IMR_SSWRDY_Pos        9            /**< \brief (BSCIF_IMR) VREG Stop Switching Ready */
+#define BSCIF_IMR_SSWRDY            (_U(0x1) << BSCIF_IMR_SSWRDY_Pos)
+#define BSCIF_IMR_VREGOK_Pos        10           /**< \brief (BSCIF_IMR) Main VREG OK */
+#define BSCIF_IMR_VREGOK            (_U(0x1) << BSCIF_IMR_VREGOK_Pos)
+#define BSCIF_IMR_LPBGRDY_Pos       12           /**< \brief (BSCIF_IMR) Low Power Bandgap Voltage Reference Ready */
+#define BSCIF_IMR_LPBGRDY           (_U(0x1) << BSCIF_IMR_LPBGRDY_Pos)
+#define BSCIF_IMR_AE_Pos            31           /**< \brief (BSCIF_IMR) Access Error */
+#define BSCIF_IMR_AE                (_U(0x1) << BSCIF_IMR_AE_Pos)
+#define BSCIF_IMR_MASK              _U(0x800017FF) /**< \brief (BSCIF_IMR) MASK Register */
+
+/* -------- BSCIF_ISR : (BSCIF Offset: 0x00C) (R/  32) Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OSC32RDY:1;       /*!< bit:      0  32kHz Oscillator Ready             */
+    uint32_t RC32KRDY:1;       /*!< bit:      1  32kHz RC Oscillator Ready          */
+    uint32_t RC32KLOCK:1;      /*!< bit:      2  32kHz RC Oscillator Lock           */
+    uint32_t RC32KREFE:1;      /*!< bit:      3  32kHz RC Oscillator Reference Error */
+    uint32_t RC32KSAT:1;       /*!< bit:      4  32kHz RC Oscillator Saturation     */
+    uint32_t BOD33DET:1;       /*!< bit:      5  BOD33 Detected                     */
+    uint32_t BOD18DET:1;       /*!< bit:      6  BOD18 Detected                     */
+    uint32_t BOD33SYNRDY:1;    /*!< bit:      7  BOD33 Synchronization Ready        */
+    uint32_t BOD18SYNRDY:1;    /*!< bit:      8  BOD18 Synchronization Ready        */
+    uint32_t SSWRDY:1;         /*!< bit:      9  VREG Stop Switching Ready          */
+    uint32_t VREGOK:1;         /*!< bit:     10  Main VREG OK                       */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t LPBGRDY:1;        /*!< bit:     12  Low Power Bandgap Voltage Reference Ready */
+    uint32_t :18;              /*!< bit: 13..30  Reserved                           */
+    uint32_t AE:1;             /*!< bit:     31  Access Error                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_ISR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_ISR_OFFSET            0x00C        /**< \brief (BSCIF_ISR offset) Interrupt Status Register */
+#define BSCIF_ISR_RESETVALUE        _U(0x00000000); /**< \brief (BSCIF_ISR reset_value) Interrupt Status Register */
+
+#define BSCIF_ISR_OSC32RDY_Pos      0            /**< \brief (BSCIF_ISR) 32kHz Oscillator Ready */
+#define BSCIF_ISR_OSC32RDY          (_U(0x1) << BSCIF_ISR_OSC32RDY_Pos)
+#define BSCIF_ISR_RC32KRDY_Pos      1            /**< \brief (BSCIF_ISR) 32kHz RC Oscillator Ready */
+#define BSCIF_ISR_RC32KRDY          (_U(0x1) << BSCIF_ISR_RC32KRDY_Pos)
+#define BSCIF_ISR_RC32KLOCK_Pos     2            /**< \brief (BSCIF_ISR) 32kHz RC Oscillator Lock */
+#define BSCIF_ISR_RC32KLOCK         (_U(0x1) << BSCIF_ISR_RC32KLOCK_Pos)
+#define BSCIF_ISR_RC32KREFE_Pos     3            /**< \brief (BSCIF_ISR) 32kHz RC Oscillator Reference Error */
+#define BSCIF_ISR_RC32KREFE         (_U(0x1) << BSCIF_ISR_RC32KREFE_Pos)
+#define BSCIF_ISR_RC32KSAT_Pos      4            /**< \brief (BSCIF_ISR) 32kHz RC Oscillator Saturation */
+#define BSCIF_ISR_RC32KSAT          (_U(0x1) << BSCIF_ISR_RC32KSAT_Pos)
+#define BSCIF_ISR_BOD33DET_Pos      5            /**< \brief (BSCIF_ISR) BOD33 Detected */
+#define BSCIF_ISR_BOD33DET          (_U(0x1) << BSCIF_ISR_BOD33DET_Pos)
+#define BSCIF_ISR_BOD18DET_Pos      6            /**< \brief (BSCIF_ISR) BOD18 Detected */
+#define BSCIF_ISR_BOD18DET          (_U(0x1) << BSCIF_ISR_BOD18DET_Pos)
+#define BSCIF_ISR_BOD33SYNRDY_Pos   7            /**< \brief (BSCIF_ISR) BOD33 Synchronization Ready */
+#define BSCIF_ISR_BOD33SYNRDY       (_U(0x1) << BSCIF_ISR_BOD33SYNRDY_Pos)
+#define BSCIF_ISR_BOD18SYNRDY_Pos   8            /**< \brief (BSCIF_ISR) BOD18 Synchronization Ready */
+#define BSCIF_ISR_BOD18SYNRDY       (_U(0x1) << BSCIF_ISR_BOD18SYNRDY_Pos)
+#define BSCIF_ISR_SSWRDY_Pos        9            /**< \brief (BSCIF_ISR) VREG Stop Switching Ready */
+#define BSCIF_ISR_SSWRDY            (_U(0x1) << BSCIF_ISR_SSWRDY_Pos)
+#define BSCIF_ISR_VREGOK_Pos        10           /**< \brief (BSCIF_ISR) Main VREG OK */
+#define BSCIF_ISR_VREGOK            (_U(0x1) << BSCIF_ISR_VREGOK_Pos)
+#define BSCIF_ISR_LPBGRDY_Pos       12           /**< \brief (BSCIF_ISR) Low Power Bandgap Voltage Reference Ready */
+#define BSCIF_ISR_LPBGRDY           (_U(0x1) << BSCIF_ISR_LPBGRDY_Pos)
+#define BSCIF_ISR_AE_Pos            31           /**< \brief (BSCIF_ISR) Access Error */
+#define BSCIF_ISR_AE                (_U(0x1) << BSCIF_ISR_AE_Pos)
+#define BSCIF_ISR_MASK              _U(0x800017FF) /**< \brief (BSCIF_ISR) MASK Register */
+
+/* -------- BSCIF_ICR : (BSCIF Offset: 0x010) ( /W 32) Interrupt Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OSC32RDY:1;       /*!< bit:      0  32kHz Oscillator Ready             */
+    uint32_t RC32KRDY:1;       /*!< bit:      1  32kHz RC Oscillator Ready          */
+    uint32_t RC32KLOCK:1;      /*!< bit:      2  32kHz RC Oscillator Lock           */
+    uint32_t RC32KREFE:1;      /*!< bit:      3  32kHz RC Oscillator Reference Error */
+    uint32_t RC32KSAT:1;       /*!< bit:      4  32kHz RC Oscillator Saturation     */
+    uint32_t BOD33DET:1;       /*!< bit:      5  BOD33 Detected                     */
+    uint32_t BOD18DET:1;       /*!< bit:      6  BOD18 Detected                     */
+    uint32_t BOD33SYNRDY:1;    /*!< bit:      7  BOD33 Synchronization Ready        */
+    uint32_t BOD18SYNRDY:1;    /*!< bit:      8  BOD18 Synchronization Ready        */
+    uint32_t SSWRDY:1;         /*!< bit:      9  VREG Stop Switching Ready          */
+    uint32_t VREGOK:1;         /*!< bit:     10  Main VREG OK                       */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t LPBGRDY:1;        /*!< bit:     12  Low Power Bandgap Voltage Reference Ready */
+    uint32_t :18;              /*!< bit: 13..30  Reserved                           */
+    uint32_t AE:1;             /*!< bit:     31  Access Error                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_ICR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_ICR_OFFSET            0x010        /**< \brief (BSCIF_ICR offset) Interrupt Clear Register */
+#define BSCIF_ICR_RESETVALUE        _U(0x00000000); /**< \brief (BSCIF_ICR reset_value) Interrupt Clear Register */
+
+#define BSCIF_ICR_OSC32RDY_Pos      0            /**< \brief (BSCIF_ICR) 32kHz Oscillator Ready */
+#define BSCIF_ICR_OSC32RDY          (_U(0x1) << BSCIF_ICR_OSC32RDY_Pos)
+#define BSCIF_ICR_RC32KRDY_Pos      1            /**< \brief (BSCIF_ICR) 32kHz RC Oscillator Ready */
+#define BSCIF_ICR_RC32KRDY          (_U(0x1) << BSCIF_ICR_RC32KRDY_Pos)
+#define BSCIF_ICR_RC32KLOCK_Pos     2            /**< \brief (BSCIF_ICR) 32kHz RC Oscillator Lock */
+#define BSCIF_ICR_RC32KLOCK         (_U(0x1) << BSCIF_ICR_RC32KLOCK_Pos)
+#define BSCIF_ICR_RC32KREFE_Pos     3            /**< \brief (BSCIF_ICR) 32kHz RC Oscillator Reference Error */
+#define BSCIF_ICR_RC32KREFE         (_U(0x1) << BSCIF_ICR_RC32KREFE_Pos)
+#define BSCIF_ICR_RC32KSAT_Pos      4            /**< \brief (BSCIF_ICR) 32kHz RC Oscillator Saturation */
+#define BSCIF_ICR_RC32KSAT          (_U(0x1) << BSCIF_ICR_RC32KSAT_Pos)
+#define BSCIF_ICR_BOD33DET_Pos      5            /**< \brief (BSCIF_ICR) BOD33 Detected */
+#define BSCIF_ICR_BOD33DET          (_U(0x1) << BSCIF_ICR_BOD33DET_Pos)
+#define BSCIF_ICR_BOD18DET_Pos      6            /**< \brief (BSCIF_ICR) BOD18 Detected */
+#define BSCIF_ICR_BOD18DET          (_U(0x1) << BSCIF_ICR_BOD18DET_Pos)
+#define BSCIF_ICR_BOD33SYNRDY_Pos   7            /**< \brief (BSCIF_ICR) BOD33 Synchronization Ready */
+#define BSCIF_ICR_BOD33SYNRDY       (_U(0x1) << BSCIF_ICR_BOD33SYNRDY_Pos)
+#define BSCIF_ICR_BOD18SYNRDY_Pos   8            /**< \brief (BSCIF_ICR) BOD18 Synchronization Ready */
+#define BSCIF_ICR_BOD18SYNRDY       (_U(0x1) << BSCIF_ICR_BOD18SYNRDY_Pos)
+#define BSCIF_ICR_SSWRDY_Pos        9            /**< \brief (BSCIF_ICR) VREG Stop Switching Ready */
+#define BSCIF_ICR_SSWRDY            (_U(0x1) << BSCIF_ICR_SSWRDY_Pos)
+#define BSCIF_ICR_VREGOK_Pos        10           /**< \brief (BSCIF_ICR) Main VREG OK */
+#define BSCIF_ICR_VREGOK            (_U(0x1) << BSCIF_ICR_VREGOK_Pos)
+#define BSCIF_ICR_LPBGRDY_Pos       12           /**< \brief (BSCIF_ICR) Low Power Bandgap Voltage Reference Ready */
+#define BSCIF_ICR_LPBGRDY           (_U(0x1) << BSCIF_ICR_LPBGRDY_Pos)
+#define BSCIF_ICR_AE_Pos            31           /**< \brief (BSCIF_ICR) Access Error */
+#define BSCIF_ICR_AE                (_U(0x1) << BSCIF_ICR_AE_Pos)
+#define BSCIF_ICR_MASK              _U(0x800017FF) /**< \brief (BSCIF_ICR) MASK Register */
+
+/* -------- BSCIF_PCLKSR : (BSCIF Offset: 0x014) (R/  32) Power and Clocks Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OSC32RDY:1;       /*!< bit:      0  32kHz Oscillator Ready             */
+    uint32_t RC32KRDY:1;       /*!< bit:      1  32kHz RC Oscillator Ready          */
+    uint32_t RC32KLOCK:1;      /*!< bit:      2  32kHz RC Oscillator Lock           */
+    uint32_t RC32KREFE:1;      /*!< bit:      3  32kHz RC Oscillator Reference Error */
+    uint32_t RC32KSAT:1;       /*!< bit:      4  32kHz RC Oscillator Saturation     */
+    uint32_t BOD33DET:1;       /*!< bit:      5  BOD33 Detected                     */
+    uint32_t BOD18DET:1;       /*!< bit:      6  BOD18 Detected                     */
+    uint32_t BOD33SYNRDY:1;    /*!< bit:      7  BOD33 Synchronization Ready        */
+    uint32_t BOD18SYNRDY:1;    /*!< bit:      8  BOD18 Synchronization Ready        */
+    uint32_t SSWRDY:1;         /*!< bit:      9  VREG Stop Switching Ready          */
+    uint32_t VREGOK:1;         /*!< bit:     10  Main VREG OK                       */
+    uint32_t RC1MRDY:1;        /*!< bit:     11  RC 1MHz Oscillator Ready           */
+    uint32_t LPBGRDY:1;        /*!< bit:     12  Low Power Bandgap Voltage Reference Ready */
+    uint32_t :19;              /*!< bit: 13..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_PCLKSR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_PCLKSR_OFFSET         0x014        /**< \brief (BSCIF_PCLKSR offset) Power and Clocks Status Register */
+#define BSCIF_PCLKSR_RESETVALUE     _U(0x00000000); /**< \brief (BSCIF_PCLKSR reset_value) Power and Clocks Status Register */
+
+#define BSCIF_PCLKSR_OSC32RDY_Pos   0            /**< \brief (BSCIF_PCLKSR) 32kHz Oscillator Ready */
+#define BSCIF_PCLKSR_OSC32RDY       (_U(0x1) << BSCIF_PCLKSR_OSC32RDY_Pos)
+#define BSCIF_PCLKSR_RC32KRDY_Pos   1            /**< \brief (BSCIF_PCLKSR) 32kHz RC Oscillator Ready */
+#define BSCIF_PCLKSR_RC32KRDY       (_U(0x1) << BSCIF_PCLKSR_RC32KRDY_Pos)
+#define BSCIF_PCLKSR_RC32KLOCK_Pos  2            /**< \brief (BSCIF_PCLKSR) 32kHz RC Oscillator Lock */
+#define BSCIF_PCLKSR_RC32KLOCK      (_U(0x1) << BSCIF_PCLKSR_RC32KLOCK_Pos)
+#define BSCIF_PCLKSR_RC32KREFE_Pos  3            /**< \brief (BSCIF_PCLKSR) 32kHz RC Oscillator Reference Error */
+#define BSCIF_PCLKSR_RC32KREFE      (_U(0x1) << BSCIF_PCLKSR_RC32KREFE_Pos)
+#define BSCIF_PCLKSR_RC32KSAT_Pos   4            /**< \brief (BSCIF_PCLKSR) 32kHz RC Oscillator Saturation */
+#define BSCIF_PCLKSR_RC32KSAT       (_U(0x1) << BSCIF_PCLKSR_RC32KSAT_Pos)
+#define BSCIF_PCLKSR_BOD33DET_Pos   5            /**< \brief (BSCIF_PCLKSR) BOD33 Detected */
+#define BSCIF_PCLKSR_BOD33DET       (_U(0x1) << BSCIF_PCLKSR_BOD33DET_Pos)
+#define BSCIF_PCLKSR_BOD18DET_Pos   6            /**< \brief (BSCIF_PCLKSR) BOD18 Detected */
+#define BSCIF_PCLKSR_BOD18DET       (_U(0x1) << BSCIF_PCLKSR_BOD18DET_Pos)
+#define BSCIF_PCLKSR_BOD33SYNRDY_Pos 7            /**< \brief (BSCIF_PCLKSR) BOD33 Synchronization Ready */
+#define BSCIF_PCLKSR_BOD33SYNRDY    (_U(0x1) << BSCIF_PCLKSR_BOD33SYNRDY_Pos)
+#define BSCIF_PCLKSR_BOD18SYNRDY_Pos 8            /**< \brief (BSCIF_PCLKSR) BOD18 Synchronization Ready */
+#define BSCIF_PCLKSR_BOD18SYNRDY    (_U(0x1) << BSCIF_PCLKSR_BOD18SYNRDY_Pos)
+#define BSCIF_PCLKSR_SSWRDY_Pos     9            /**< \brief (BSCIF_PCLKSR) VREG Stop Switching Ready */
+#define BSCIF_PCLKSR_SSWRDY         (_U(0x1) << BSCIF_PCLKSR_SSWRDY_Pos)
+#define BSCIF_PCLKSR_VREGOK_Pos     10           /**< \brief (BSCIF_PCLKSR) Main VREG OK */
+#define BSCIF_PCLKSR_VREGOK         (_U(0x1) << BSCIF_PCLKSR_VREGOK_Pos)
+#define BSCIF_PCLKSR_RC1MRDY_Pos    11           /**< \brief (BSCIF_PCLKSR) RC 1MHz Oscillator Ready */
+#define BSCIF_PCLKSR_RC1MRDY        (_U(0x1) << BSCIF_PCLKSR_RC1MRDY_Pos)
+#define BSCIF_PCLKSR_LPBGRDY_Pos    12           /**< \brief (BSCIF_PCLKSR) Low Power Bandgap Voltage Reference Ready */
+#define BSCIF_PCLKSR_LPBGRDY        (_U(0x1) << BSCIF_PCLKSR_LPBGRDY_Pos)
+#define BSCIF_PCLKSR_MASK           _U(0x00001FFF) /**< \brief (BSCIF_PCLKSR) MASK Register */
+
+/* -------- BSCIF_UNLOCK : (BSCIF Offset: 0x018) ( /W 32) Unlock Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ADDR:10;          /*!< bit:  0.. 9  Unlock Address                     */
+    uint32_t :14;              /*!< bit: 10..23  Reserved                           */
+    uint32_t KEY:8;            /*!< bit: 24..31  Unlock Key                         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_UNLOCK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_UNLOCK_OFFSET         0x018        /**< \brief (BSCIF_UNLOCK offset) Unlock Register */
+#define BSCIF_UNLOCK_RESETVALUE     _U(0x00000000); /**< \brief (BSCIF_UNLOCK reset_value) Unlock Register */
+
+#define BSCIF_UNLOCK_ADDR_Pos       0            /**< \brief (BSCIF_UNLOCK) Unlock Address */
+#define BSCIF_UNLOCK_ADDR_Msk       (_U(0x3FF) << BSCIF_UNLOCK_ADDR_Pos)
+#define BSCIF_UNLOCK_ADDR(value)    (BSCIF_UNLOCK_ADDR_Msk & ((value) << BSCIF_UNLOCK_ADDR_Pos))
+#define BSCIF_UNLOCK_KEY_Pos        24           /**< \brief (BSCIF_UNLOCK) Unlock Key */
+#define BSCIF_UNLOCK_KEY_Msk        (_U(0xFF) << BSCIF_UNLOCK_KEY_Pos)
+#define BSCIF_UNLOCK_KEY(value)     (BSCIF_UNLOCK_KEY_Msk & ((value) << BSCIF_UNLOCK_KEY_Pos))
+#define   BSCIF_UNLOCK_KEY_VALID_Val      _U(0xAA)   /**< \brief (BSCIF_UNLOCK) Valid Key to Unlock register */
+#define BSCIF_UNLOCK_KEY_VALID      (BSCIF_UNLOCK_KEY_VALID_Val    << BSCIF_UNLOCK_KEY_Pos)
+#define BSCIF_UNLOCK_MASK           _U(0xFF0003FF) /**< \brief (BSCIF_UNLOCK) MASK Register */
+
+/* -------- BSCIF_CSCR : (BSCIF Offset: 0x01C) (R/W 32) Chip Specific Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_CSCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_CSCR_OFFSET           0x01C        /**< \brief (BSCIF_CSCR offset) Chip Specific Configuration Register */
+#define BSCIF_CSCR_RESETVALUE       _U(0x00000000); /**< \brief (BSCIF_CSCR reset_value) Chip Specific Configuration Register */
+
+#define BSCIF_CSCR_MASK             _U(0x00000000) /**< \brief (BSCIF_CSCR) MASK Register */
+
+/* -------- BSCIF_OSCCTRL32 : (BSCIF Offset: 0x020) (R/W 32) Oscillator 32 Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OSC32EN:1;        /*!< bit:      0  32 KHz Oscillator Enable           */
+    uint32_t PINSEL:1;         /*!< bit:      1  Pins Select                        */
+    uint32_t EN32K:1;          /*!< bit:      2  32 KHz output Enable               */
+    uint32_t EN1K:1;           /*!< bit:      3  1 KHz output Enable                */
+    uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint32_t MODE:3;           /*!< bit:  8..10  Oscillator Mode                    */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t SELCURR:4;        /*!< bit: 12..15  Current selection                  */
+    uint32_t STARTUP:3;        /*!< bit: 16..18  Oscillator Start-up Time           */
+    uint32_t :13;              /*!< bit: 19..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_OSCCTRL32_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_OSCCTRL32_OFFSET      0x020        /**< \brief (BSCIF_OSCCTRL32 offset) Oscillator 32 Control Register */
+#define BSCIF_OSCCTRL32_RESETVALUE  _U(0x00000004); /**< \brief (BSCIF_OSCCTRL32 reset_value) Oscillator 32 Control Register */
+
+#define BSCIF_OSCCTRL32_OSC32EN_Pos 0            /**< \brief (BSCIF_OSCCTRL32) 32 KHz Oscillator Enable */
+#define BSCIF_OSCCTRL32_OSC32EN     (_U(0x1) << BSCIF_OSCCTRL32_OSC32EN_Pos)
+#define BSCIF_OSCCTRL32_PINSEL_Pos  1            /**< \brief (BSCIF_OSCCTRL32) Pins Select */
+#define BSCIF_OSCCTRL32_PINSEL      (_U(0x1) << BSCIF_OSCCTRL32_PINSEL_Pos)
+#define BSCIF_OSCCTRL32_EN32K_Pos   2            /**< \brief (BSCIF_OSCCTRL32) 32 KHz output Enable */
+#define BSCIF_OSCCTRL32_EN32K       (_U(0x1) << BSCIF_OSCCTRL32_EN32K_Pos)
+#define BSCIF_OSCCTRL32_EN1K_Pos    3            /**< \brief (BSCIF_OSCCTRL32) 1 KHz output Enable */
+#define BSCIF_OSCCTRL32_EN1K        (_U(0x1) << BSCIF_OSCCTRL32_EN1K_Pos)
+#define BSCIF_OSCCTRL32_MODE_Pos    8            /**< \brief (BSCIF_OSCCTRL32) Oscillator Mode */
+#define BSCIF_OSCCTRL32_MODE_Msk    (_U(0x7) << BSCIF_OSCCTRL32_MODE_Pos)
+#define BSCIF_OSCCTRL32_MODE(value) (BSCIF_OSCCTRL32_MODE_Msk & ((value) << BSCIF_OSCCTRL32_MODE_Pos))
+#define BSCIF_OSCCTRL32_SELCURR_Pos 12           /**< \brief (BSCIF_OSCCTRL32) Current selection */
+#define BSCIF_OSCCTRL32_SELCURR_Msk (_U(0xF) << BSCIF_OSCCTRL32_SELCURR_Pos)
+#define BSCIF_OSCCTRL32_SELCURR(value) (BSCIF_OSCCTRL32_SELCURR_Msk & ((value) << BSCIF_OSCCTRL32_SELCURR_Pos))
+#define BSCIF_OSCCTRL32_STARTUP_Pos 16           /**< \brief (BSCIF_OSCCTRL32) Oscillator Start-up Time */
+#define BSCIF_OSCCTRL32_STARTUP_Msk (_U(0x7) << BSCIF_OSCCTRL32_STARTUP_Pos)
+#define BSCIF_OSCCTRL32_STARTUP(value) (BSCIF_OSCCTRL32_STARTUP_Msk & ((value) << BSCIF_OSCCTRL32_STARTUP_Pos))
+#define BSCIF_OSCCTRL32_MASK        _U(0x0007F70F) /**< \brief (BSCIF_OSCCTRL32) MASK Register */
+
+/* -------- BSCIF_RC32KCR : (BSCIF Offset: 0x024) (R/W 32) 32 kHz RC Oscillator Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EN:1;             /*!< bit:      0  Enable as Generic clock source     */
+    uint32_t TCEN:1;           /*!< bit:      1  Temperature Compensation Enable    */
+    uint32_t EN32K:1;          /*!< bit:      2  Enable 32 KHz output               */
+    uint32_t EN1K:1;           /*!< bit:      3  Enable 1 kHz output                */
+    uint32_t MODE:1;           /*!< bit:      4  Mode Selection                     */
+    uint32_t REF:1;            /*!< bit:      5  Reference select                   */
+    uint32_t :1;               /*!< bit:      6  Reserved                           */
+    uint32_t FCD:1;            /*!< bit:      7  Flash calibration done             */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_RC32KCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_RC32KCR_OFFSET        0x024        /**< \brief (BSCIF_RC32KCR offset) 32 kHz RC Oscillator Control Register */
+#define BSCIF_RC32KCR_RESETVALUE    _U(0x00000000); /**< \brief (BSCIF_RC32KCR reset_value) 32 kHz RC Oscillator Control Register */
+
+#define BSCIF_RC32KCR_EN_Pos        0            /**< \brief (BSCIF_RC32KCR) Enable as Generic clock source */
+#define BSCIF_RC32KCR_EN            (_U(0x1) << BSCIF_RC32KCR_EN_Pos)
+#define BSCIF_RC32KCR_TCEN_Pos      1            /**< \brief (BSCIF_RC32KCR) Temperature Compensation Enable */
+#define BSCIF_RC32KCR_TCEN          (_U(0x1) << BSCIF_RC32KCR_TCEN_Pos)
+#define BSCIF_RC32KCR_EN32K_Pos     2            /**< \brief (BSCIF_RC32KCR) Enable 32 KHz output */
+#define BSCIF_RC32KCR_EN32K         (_U(0x1) << BSCIF_RC32KCR_EN32K_Pos)
+#define BSCIF_RC32KCR_EN1K_Pos      3            /**< \brief (BSCIF_RC32KCR) Enable 1 kHz output */
+#define BSCIF_RC32KCR_EN1K          (_U(0x1) << BSCIF_RC32KCR_EN1K_Pos)
+#define BSCIF_RC32KCR_MODE_Pos      4            /**< \brief (BSCIF_RC32KCR) Mode Selection */
+#define BSCIF_RC32KCR_MODE          (_U(0x1) << BSCIF_RC32KCR_MODE_Pos)
+#define BSCIF_RC32KCR_REF_Pos       5            /**< \brief (BSCIF_RC32KCR) Reference select */
+#define BSCIF_RC32KCR_REF           (_U(0x1) << BSCIF_RC32KCR_REF_Pos)
+#define BSCIF_RC32KCR_FCD_Pos       7            /**< \brief (BSCIF_RC32KCR) Flash calibration done */
+#define BSCIF_RC32KCR_FCD           (_U(0x1) << BSCIF_RC32KCR_FCD_Pos)
+#define BSCIF_RC32KCR_MASK          _U(0x000000BF) /**< \brief (BSCIF_RC32KCR) MASK Register */
+
+/* -------- BSCIF_RC32KTUNE : (BSCIF Offset: 0x028) (R/W 32) 32kHz RC Oscillator Tuning Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t FINE:6;           /*!< bit:  0.. 5  Fine value                         */
+    uint32_t :10;              /*!< bit:  6..15  Reserved                           */
+    uint32_t COARSE:7;         /*!< bit: 16..22  Coarse Value                       */
+    uint32_t :9;               /*!< bit: 23..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_RC32KTUNE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_RC32KTUNE_OFFSET      0x028        /**< \brief (BSCIF_RC32KTUNE offset) 32kHz RC Oscillator Tuning Register */
+#define BSCIF_RC32KTUNE_RESETVALUE  _U(0x00000000); /**< \brief (BSCIF_RC32KTUNE reset_value) 32kHz RC Oscillator Tuning Register */
+
+#define BSCIF_RC32KTUNE_FINE_Pos    0            /**< \brief (BSCIF_RC32KTUNE) Fine value */
+#define BSCIF_RC32KTUNE_FINE_Msk    (_U(0x3F) << BSCIF_RC32KTUNE_FINE_Pos)
+#define BSCIF_RC32KTUNE_FINE(value) (BSCIF_RC32KTUNE_FINE_Msk & ((value) << BSCIF_RC32KTUNE_FINE_Pos))
+#define BSCIF_RC32KTUNE_COARSE_Pos  16           /**< \brief (BSCIF_RC32KTUNE) Coarse Value */
+#define BSCIF_RC32KTUNE_COARSE_Msk  (_U(0x7F) << BSCIF_RC32KTUNE_COARSE_Pos)
+#define BSCIF_RC32KTUNE_COARSE(value) (BSCIF_RC32KTUNE_COARSE_Msk & ((value) << BSCIF_RC32KTUNE_COARSE_Pos))
+#define BSCIF_RC32KTUNE_MASK        _U(0x007F003F) /**< \brief (BSCIF_RC32KTUNE) MASK Register */
+
+/* -------- BSCIF_BOD33CTRL : (BSCIF Offset: 0x02C) (R/W 32) BOD33 Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EN:1;             /*!< bit:      0  Enable                             */
+    uint32_t HYST:1;           /*!< bit:      1  BOD Hysteresis                     */
+    uint32_t :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint32_t ACTION:2;         /*!< bit:  8.. 9  Action                             */
+    uint32_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint32_t MODE:1;           /*!< bit:     16  Operation modes                    */
+    uint32_t :13;              /*!< bit: 17..29  Reserved                           */
+    uint32_t FCD:1;            /*!< bit:     30  BOD Fuse Calibration Done          */
+    uint32_t SFV:1;            /*!< bit:     31  BOD Control Register Store Final Value */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_BOD33CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_BOD33CTRL_OFFSET      0x02C        /**< \brief (BSCIF_BOD33CTRL offset) BOD33 Control Register */
+
+#define BSCIF_BOD33CTRL_EN_Pos      0            /**< \brief (BSCIF_BOD33CTRL) Enable */
+#define BSCIF_BOD33CTRL_EN          (_U(0x1) << BSCIF_BOD33CTRL_EN_Pos)
+#define BSCIF_BOD33CTRL_HYST_Pos    1            /**< \brief (BSCIF_BOD33CTRL) BOD Hysteresis */
+#define BSCIF_BOD33CTRL_HYST        (_U(0x1) << BSCIF_BOD33CTRL_HYST_Pos)
+#define BSCIF_BOD33CTRL_ACTION_Pos  8            /**< \brief (BSCIF_BOD33CTRL) Action */
+#define BSCIF_BOD33CTRL_ACTION_Msk  (_U(0x3) << BSCIF_BOD33CTRL_ACTION_Pos)
+#define BSCIF_BOD33CTRL_ACTION(value) (BSCIF_BOD33CTRL_ACTION_Msk & ((value) << BSCIF_BOD33CTRL_ACTION_Pos))
+#define BSCIF_BOD33CTRL_MODE_Pos    16           /**< \brief (BSCIF_BOD33CTRL) Operation modes */
+#define BSCIF_BOD33CTRL_MODE        (_U(0x1) << BSCIF_BOD33CTRL_MODE_Pos)
+#define BSCIF_BOD33CTRL_FCD_Pos     30           /**< \brief (BSCIF_BOD33CTRL) BOD Fuse Calibration Done */
+#define BSCIF_BOD33CTRL_FCD         (_U(0x1) << BSCIF_BOD33CTRL_FCD_Pos)
+#define BSCIF_BOD33CTRL_SFV_Pos     31           /**< \brief (BSCIF_BOD33CTRL) BOD Control Register Store Final Value */
+#define BSCIF_BOD33CTRL_SFV         (_U(0x1) << BSCIF_BOD33CTRL_SFV_Pos)
+#define BSCIF_BOD33CTRL_MASK        _U(0xC0010303) /**< \brief (BSCIF_BOD33CTRL) MASK Register */
+
+/* -------- BSCIF_BOD33LEVEL : (BSCIF Offset: 0x030) (R/W 32) BOD33 Level Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VAL:6;            /*!< bit:  0.. 5  BOD Value                          */
+    uint32_t :26;              /*!< bit:  6..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_BOD33LEVEL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_BOD33LEVEL_OFFSET     0x030        /**< \brief (BSCIF_BOD33LEVEL offset) BOD33 Level Register */
+#define BSCIF_BOD33LEVEL_RESETVALUE _U(0x00000000); /**< \brief (BSCIF_BOD33LEVEL reset_value) BOD33 Level Register */
+
+#define BSCIF_BOD33LEVEL_VAL_Pos    0            /**< \brief (BSCIF_BOD33LEVEL) BOD Value */
+#define BSCIF_BOD33LEVEL_VAL_Msk    (_U(0x3F) << BSCIF_BOD33LEVEL_VAL_Pos)
+#define BSCIF_BOD33LEVEL_VAL(value) (BSCIF_BOD33LEVEL_VAL_Msk & ((value) << BSCIF_BOD33LEVEL_VAL_Pos))
+#define BSCIF_BOD33LEVEL_MASK       _U(0x0000003F) /**< \brief (BSCIF_BOD33LEVEL) MASK Register */
+
+/* -------- BSCIF_BOD33SAMPLING : (BSCIF Offset: 0x034) (R/W 32) BOD33 Sampling Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CEN:1;            /*!< bit:      0  Clock Enable                       */
+    uint32_t CSSEL:1;          /*!< bit:      1  Clock Source Select                */
+    uint32_t :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint32_t PSEL:4;           /*!< bit:  8..11  Prescaler Select                   */
+    uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_BOD33SAMPLING_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_BOD33SAMPLING_OFFSET  0x034        /**< \brief (BSCIF_BOD33SAMPLING offset) BOD33 Sampling Control Register */
+#define BSCIF_BOD33SAMPLING_RESETVALUE _U(0x00000000); /**< \brief (BSCIF_BOD33SAMPLING reset_value) BOD33 Sampling Control Register */
+
+#define BSCIF_BOD33SAMPLING_CEN_Pos 0            /**< \brief (BSCIF_BOD33SAMPLING) Clock Enable */
+#define BSCIF_BOD33SAMPLING_CEN     (_U(0x1) << BSCIF_BOD33SAMPLING_CEN_Pos)
+#define BSCIF_BOD33SAMPLING_CSSEL_Pos 1            /**< \brief (BSCIF_BOD33SAMPLING) Clock Source Select */
+#define BSCIF_BOD33SAMPLING_CSSEL   (_U(0x1) << BSCIF_BOD33SAMPLING_CSSEL_Pos)
+#define BSCIF_BOD33SAMPLING_PSEL_Pos 8            /**< \brief (BSCIF_BOD33SAMPLING) Prescaler Select */
+#define BSCIF_BOD33SAMPLING_PSEL_Msk (_U(0xF) << BSCIF_BOD33SAMPLING_PSEL_Pos)
+#define BSCIF_BOD33SAMPLING_PSEL(value) (BSCIF_BOD33SAMPLING_PSEL_Msk & ((value) << BSCIF_BOD33SAMPLING_PSEL_Pos))
+#define BSCIF_BOD33SAMPLING_MASK    _U(0x00000F03) /**< \brief (BSCIF_BOD33SAMPLING) MASK Register */
+
+/* -------- BSCIF_BOD18CTRL : (BSCIF Offset: 0x038) (R/W 32) BOD18 Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EN:1;             /*!< bit:      0  Enable                             */
+    uint32_t HYST:1;           /*!< bit:      1  BOD Hysteresis                     */
+    uint32_t :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint32_t ACTION:2;         /*!< bit:  8.. 9  Action                             */
+    uint32_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint32_t MODE:1;           /*!< bit:     16  Operation modes                    */
+    uint32_t :13;              /*!< bit: 17..29  Reserved                           */
+    uint32_t FCD:1;            /*!< bit:     30  BOD Fuse Calibration Done          */
+    uint32_t SFV:1;            /*!< bit:     31  BOD Control Register Store Final Value */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_BOD18CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_BOD18CTRL_OFFSET      0x038        /**< \brief (BSCIF_BOD18CTRL offset) BOD18 Control Register */
+#define BSCIF_BOD18CTRL_RESETVALUE  _U(0x00000000); /**< \brief (BSCIF_BOD18CTRL reset_value) BOD18 Control Register */
+
+#define BSCIF_BOD18CTRL_EN_Pos      0            /**< \brief (BSCIF_BOD18CTRL) Enable */
+#define BSCIF_BOD18CTRL_EN          (_U(0x1) << BSCIF_BOD18CTRL_EN_Pos)
+#define BSCIF_BOD18CTRL_HYST_Pos    1            /**< \brief (BSCIF_BOD18CTRL) BOD Hysteresis */
+#define BSCIF_BOD18CTRL_HYST        (_U(0x1) << BSCIF_BOD18CTRL_HYST_Pos)
+#define BSCIF_BOD18CTRL_ACTION_Pos  8            /**< \brief (BSCIF_BOD18CTRL) Action */
+#define BSCIF_BOD18CTRL_ACTION_Msk  (_U(0x3) << BSCIF_BOD18CTRL_ACTION_Pos)
+#define BSCIF_BOD18CTRL_ACTION(value) (BSCIF_BOD18CTRL_ACTION_Msk & ((value) << BSCIF_BOD18CTRL_ACTION_Pos))
+#define BSCIF_BOD18CTRL_MODE_Pos    16           /**< \brief (BSCIF_BOD18CTRL) Operation modes */
+#define BSCIF_BOD18CTRL_MODE        (_U(0x1) << BSCIF_BOD18CTRL_MODE_Pos)
+#define BSCIF_BOD18CTRL_FCD_Pos     30           /**< \brief (BSCIF_BOD18CTRL) BOD Fuse Calibration Done */
+#define BSCIF_BOD18CTRL_FCD         (_U(0x1) << BSCIF_BOD18CTRL_FCD_Pos)
+#define BSCIF_BOD18CTRL_SFV_Pos     31           /**< \brief (BSCIF_BOD18CTRL) BOD Control Register Store Final Value */
+#define BSCIF_BOD18CTRL_SFV         (_U(0x1) << BSCIF_BOD18CTRL_SFV_Pos)
+#define BSCIF_BOD18CTRL_MASK        _U(0xC0010303) /**< \brief (BSCIF_BOD18CTRL) MASK Register */
+
+/* -------- BSCIF_BOD18LEVEL : (BSCIF Offset: 0x03C) (R/W 32) BOD18 Level Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VAL:6;            /*!< bit:  0.. 5  BOD Value                          */
+    uint32_t :25;              /*!< bit:  6..30  Reserved                           */
+    uint32_t RANGE:1;          /*!< bit:     31  BOD Threshold Range                */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_BOD18LEVEL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_BOD18LEVEL_OFFSET     0x03C        /**< \brief (BSCIF_BOD18LEVEL offset) BOD18 Level Register */
+#define BSCIF_BOD18LEVEL_RESETVALUE _U(0x00000000); /**< \brief (BSCIF_BOD18LEVEL reset_value) BOD18 Level Register */
+
+#define BSCIF_BOD18LEVEL_VAL_Pos    0            /**< \brief (BSCIF_BOD18LEVEL) BOD Value */
+#define BSCIF_BOD18LEVEL_VAL_Msk    (_U(0x3F) << BSCIF_BOD18LEVEL_VAL_Pos)
+#define BSCIF_BOD18LEVEL_VAL(value) (BSCIF_BOD18LEVEL_VAL_Msk & ((value) << BSCIF_BOD18LEVEL_VAL_Pos))
+#define BSCIF_BOD18LEVEL_RANGE_Pos  31           /**< \brief (BSCIF_BOD18LEVEL) BOD Threshold Range */
+#define BSCIF_BOD18LEVEL_RANGE      (_U(0x1) << BSCIF_BOD18LEVEL_RANGE_Pos)
+#define BSCIF_BOD18LEVEL_MASK       _U(0x8000003F) /**< \brief (BSCIF_BOD18LEVEL) MASK Register */
+
+/* -------- BSCIF_VREGCR : (BSCIF Offset: 0x044) (R/W 32) Voltage Regulator Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DIS:1;            /*!< bit:      0  Voltage Regulator disable          */
+    uint32_t :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint32_t SSG:1;            /*!< bit:      8  Spread Spectrum Generator Enable   */
+    uint32_t SSW:1;            /*!< bit:      9  Stop Switching                     */
+    uint32_t SSWEVT:1;         /*!< bit:     10  Stop Switching On Event Enable     */
+    uint32_t :20;              /*!< bit: 11..30  Reserved                           */
+    uint32_t SFV:1;            /*!< bit:     31  Store Final Value                  */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_VREGCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_VREGCR_OFFSET         0x044        /**< \brief (BSCIF_VREGCR offset) Voltage Regulator Configuration Register */
+#define BSCIF_VREGCR_RESETVALUE     _U(0x00000000); /**< \brief (BSCIF_VREGCR reset_value) Voltage Regulator Configuration Register */
+
+#define BSCIF_VREGCR_DIS_Pos        0            /**< \brief (BSCIF_VREGCR) Voltage Regulator disable */
+#define BSCIF_VREGCR_DIS            (_U(0x1) << BSCIF_VREGCR_DIS_Pos)
+#define BSCIF_VREGCR_SSG_Pos        8            /**< \brief (BSCIF_VREGCR) Spread Spectrum Generator Enable */
+#define BSCIF_VREGCR_SSG            (_U(0x1) << BSCIF_VREGCR_SSG_Pos)
+#define BSCIF_VREGCR_SSW_Pos        9            /**< \brief (BSCIF_VREGCR) Stop Switching */
+#define BSCIF_VREGCR_SSW            (_U(0x1) << BSCIF_VREGCR_SSW_Pos)
+#define BSCIF_VREGCR_SSWEVT_Pos     10           /**< \brief (BSCIF_VREGCR) Stop Switching On Event Enable */
+#define BSCIF_VREGCR_SSWEVT         (_U(0x1) << BSCIF_VREGCR_SSWEVT_Pos)
+#define BSCIF_VREGCR_SFV_Pos        31           /**< \brief (BSCIF_VREGCR) Store Final Value */
+#define BSCIF_VREGCR_SFV            (_U(0x1) << BSCIF_VREGCR_SFV_Pos)
+#define BSCIF_VREGCR_MASK           _U(0x80000701) /**< \brief (BSCIF_VREGCR) MASK Register */
+
+/* -------- BSCIF_VREGNCSR : (BSCIF Offset: 0x04C) (R/W 32) Normal Mode Control and Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_VREGNCSR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_VREGNCSR_OFFSET       0x04C        /**< \brief (BSCIF_VREGNCSR offset) Normal Mode Control and Status Register */
+#define BSCIF_VREGNCSR_RESETVALUE   _U(0x00000000); /**< \brief (BSCIF_VREGNCSR reset_value) Normal Mode Control and Status Register */
+
+#define BSCIF_VREGNCSR_MASK         _U(0x00000000) /**< \brief (BSCIF_VREGNCSR) MASK Register */
+
+/* -------- BSCIF_VREGLPCSR : (BSCIF Offset: 0x050) (R/W 32) LP Mode Control and Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_VREGLPCSR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_VREGLPCSR_OFFSET      0x050        /**< \brief (BSCIF_VREGLPCSR offset) LP Mode Control and Status Register */
+#define BSCIF_VREGLPCSR_RESETVALUE  _U(0x00000000); /**< \brief (BSCIF_VREGLPCSR reset_value) LP Mode Control and Status Register */
+
+#define BSCIF_VREGLPCSR_MASK        _U(0x00000000) /**< \brief (BSCIF_VREGLPCSR) MASK Register */
+
+/* -------- BSCIF_RC1MCR : (BSCIF Offset: 0x058) (R/W 32) 1MHz RC Clock Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CLKOE:1;          /*!< bit:      0  1MHz RC Osc Clock Output Enable    */
+    uint32_t :6;               /*!< bit:  1.. 6  Reserved                           */
+    uint32_t FCD:1;            /*!< bit:      7  Flash Calibration Done             */
+    uint32_t CLKCAL:5;         /*!< bit:  8..12  1MHz RC Osc Calibration            */
+    uint32_t :19;              /*!< bit: 13..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_RC1MCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_RC1MCR_OFFSET         0x058        /**< \brief (BSCIF_RC1MCR offset) 1MHz RC Clock Configuration Register */
+#define BSCIF_RC1MCR_RESETVALUE     _U(0x00000F00); /**< \brief (BSCIF_RC1MCR reset_value) 1MHz RC Clock Configuration Register */
+
+#define BSCIF_RC1MCR_CLKOE_Pos      0            /**< \brief (BSCIF_RC1MCR) 1MHz RC Osc Clock Output Enable */
+#define BSCIF_RC1MCR_CLKOE          (_U(0x1) << BSCIF_RC1MCR_CLKOE_Pos)
+#define BSCIF_RC1MCR_FCD_Pos        7            /**< \brief (BSCIF_RC1MCR) Flash Calibration Done */
+#define BSCIF_RC1MCR_FCD            (_U(0x1) << BSCIF_RC1MCR_FCD_Pos)
+#define BSCIF_RC1MCR_CLKCAL_Pos     8            /**< \brief (BSCIF_RC1MCR) 1MHz RC Osc Calibration */
+#define BSCIF_RC1MCR_CLKCAL_Msk     (_U(0x1F) << BSCIF_RC1MCR_CLKCAL_Pos)
+#define BSCIF_RC1MCR_CLKCAL(value)  (BSCIF_RC1MCR_CLKCAL_Msk & ((value) << BSCIF_RC1MCR_CLKCAL_Pos))
+#define BSCIF_RC1MCR_MASK           _U(0x00001F81) /**< \brief (BSCIF_RC1MCR) MASK Register */
+
+/* -------- BSCIF_BGCR : (BSCIF Offset: 0x05C) (R/W 32) Bandgap Calibration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_BGCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_BGCR_OFFSET           0x05C        /**< \brief (BSCIF_BGCR offset) Bandgap Calibration Register */
+#define BSCIF_BGCR_RESETVALUE       _U(0x00000000); /**< \brief (BSCIF_BGCR reset_value) Bandgap Calibration Register */
+
+#define BSCIF_BGCR_MASK             _U(0x00000000) /**< \brief (BSCIF_BGCR) MASK Register */
+
+/* -------- BSCIF_BGCTRL : (BSCIF Offset: 0x060) (R/W 32) Bandgap Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ADCISEL:2;        /*!< bit:  0.. 1  ADC Input Selection                */
+    uint32_t :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint32_t TSEN:1;           /*!< bit:      8  Temperature Sensor Enable          */
+    uint32_t :23;              /*!< bit:  9..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_BGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_BGCTRL_OFFSET         0x060        /**< \brief (BSCIF_BGCTRL offset) Bandgap Control Register */
+#define BSCIF_BGCTRL_RESETVALUE     _U(0x00000000); /**< \brief (BSCIF_BGCTRL reset_value) Bandgap Control Register */
+
+#define BSCIF_BGCTRL_ADCISEL_Pos    0            /**< \brief (BSCIF_BGCTRL) ADC Input Selection */
+#define BSCIF_BGCTRL_ADCISEL_Msk    (_U(0x3) << BSCIF_BGCTRL_ADCISEL_Pos)
+#define BSCIF_BGCTRL_ADCISEL(value) (BSCIF_BGCTRL_ADCISEL_Msk & ((value) << BSCIF_BGCTRL_ADCISEL_Pos))
+#define   BSCIF_BGCTRL_ADCISEL_DIS_Val    _U(0x0)   /**< \brief (BSCIF_BGCTRL)  */
+#define   BSCIF_BGCTRL_ADCISEL_VTEMP_Val  _U(0x1)   /**< \brief (BSCIF_BGCTRL)  */
+#define   BSCIF_BGCTRL_ADCISEL_VREF_Val   _U(0x2)   /**< \brief (BSCIF_BGCTRL)  */
+#define BSCIF_BGCTRL_ADCISEL_DIS    (BSCIF_BGCTRL_ADCISEL_DIS_Val  << BSCIF_BGCTRL_ADCISEL_Pos)
+#define BSCIF_BGCTRL_ADCISEL_VTEMP  (BSCIF_BGCTRL_ADCISEL_VTEMP_Val << BSCIF_BGCTRL_ADCISEL_Pos)
+#define BSCIF_BGCTRL_ADCISEL_VREF   (BSCIF_BGCTRL_ADCISEL_VREF_Val << BSCIF_BGCTRL_ADCISEL_Pos)
+#define BSCIF_BGCTRL_TSEN_Pos       8            /**< \brief (BSCIF_BGCTRL) Temperature Sensor Enable */
+#define BSCIF_BGCTRL_TSEN           (_U(0x1) << BSCIF_BGCTRL_TSEN_Pos)
+#define BSCIF_BGCTRL_MASK           _U(0x00000103) /**< \brief (BSCIF_BGCTRL) MASK Register */
+
+/* -------- BSCIF_BGSR : (BSCIF Offset: 0x064) (R/  32) Bandgap Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t BGBUFRDY:8;       /*!< bit:  0.. 7  Bandgap Buffer Ready               */
+    uint32_t :8;               /*!< bit:  8..15  Reserved                           */
+    uint32_t BGRDY:1;          /*!< bit:     16  Bandgap Voltage Reference Ready    */
+    uint32_t LPBGRDY:1;        /*!< bit:     17  Low Power Bandgap Voltage Reference Ready */
+    uint32_t VREF:2;           /*!< bit: 18..19  Voltage Reference Used by the System */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_BGSR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_BGSR_OFFSET           0x064        /**< \brief (BSCIF_BGSR offset) Bandgap Status Register */
+#define BSCIF_BGSR_RESETVALUE       _U(0x00000000); /**< \brief (BSCIF_BGSR reset_value) Bandgap Status Register */
+
+#define BSCIF_BGSR_BGBUFRDY_Pos     0            /**< \brief (BSCIF_BGSR) Bandgap Buffer Ready */
+#define BSCIF_BGSR_BGBUFRDY_Msk     (_U(0xFF) << BSCIF_BGSR_BGBUFRDY_Pos)
+#define BSCIF_BGSR_BGBUFRDY(value)  (BSCIF_BGSR_BGBUFRDY_Msk & ((value) << BSCIF_BGSR_BGBUFRDY_Pos))
+#define   BSCIF_BGSR_BGBUFRDY_FLASH_Val   _U(0x1)   /**< \brief (BSCIF_BGSR)  */
+#define   BSCIF_BGSR_BGBUFRDY_PLL_Val     _U(0x2)   /**< \brief (BSCIF_BGSR)  */
+#define   BSCIF_BGSR_BGBUFRDY_VREG_Val    _U(0x4)   /**< \brief (BSCIF_BGSR)  */
+#define   BSCIF_BGSR_BGBUFRDY_BUFRR_Val   _U(0x8)   /**< \brief (BSCIF_BGSR)  */
+#define   BSCIF_BGSR_BGBUFRDY_ADC_Val     _U(0x10)   /**< \brief (BSCIF_BGSR)  */
+#define   BSCIF_BGSR_BGBUFRDY_LCD_Val     _U(0x20)   /**< \brief (BSCIF_BGSR)  */
+#define BSCIF_BGSR_BGBUFRDY_FLASH   (BSCIF_BGSR_BGBUFRDY_FLASH_Val << BSCIF_BGSR_BGBUFRDY_Pos)
+#define BSCIF_BGSR_BGBUFRDY_PLL     (BSCIF_BGSR_BGBUFRDY_PLL_Val   << BSCIF_BGSR_BGBUFRDY_Pos)
+#define BSCIF_BGSR_BGBUFRDY_VREG    (BSCIF_BGSR_BGBUFRDY_VREG_Val  << BSCIF_BGSR_BGBUFRDY_Pos)
+#define BSCIF_BGSR_BGBUFRDY_BUFRR   (BSCIF_BGSR_BGBUFRDY_BUFRR_Val << BSCIF_BGSR_BGBUFRDY_Pos)
+#define BSCIF_BGSR_BGBUFRDY_ADC     (BSCIF_BGSR_BGBUFRDY_ADC_Val   << BSCIF_BGSR_BGBUFRDY_Pos)
+#define BSCIF_BGSR_BGBUFRDY_LCD     (BSCIF_BGSR_BGBUFRDY_LCD_Val   << BSCIF_BGSR_BGBUFRDY_Pos)
+#define BSCIF_BGSR_BGRDY_Pos        16           /**< \brief (BSCIF_BGSR) Bandgap Voltage Reference Ready */
+#define BSCIF_BGSR_BGRDY            (_U(0x1) << BSCIF_BGSR_BGRDY_Pos)
+#define BSCIF_BGSR_LPBGRDY_Pos      17           /**< \brief (BSCIF_BGSR) Low Power Bandgap Voltage Reference Ready */
+#define BSCIF_BGSR_LPBGRDY          (_U(0x1) << BSCIF_BGSR_LPBGRDY_Pos)
+#define BSCIF_BGSR_VREF_Pos         18           /**< \brief (BSCIF_BGSR) Voltage Reference Used by the System */
+#define BSCIF_BGSR_VREF_Msk         (_U(0x3) << BSCIF_BGSR_VREF_Pos)
+#define BSCIF_BGSR_VREF(value)      (BSCIF_BGSR_VREF_Msk & ((value) << BSCIF_BGSR_VREF_Pos))
+#define BSCIF_BGSR_MASK             _U(0x000F00FF) /**< \brief (BSCIF_BGSR) MASK Register */
+
+/* -------- BSCIF_BR : (BSCIF Offset: 0x078) (R/W 32) br Backup Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_BR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_BR_OFFSET             0x078        /**< \brief (BSCIF_BR offset) Backup Register */
+#define BSCIF_BR_RESETVALUE         _U(0x00000000); /**< \brief (BSCIF_BR reset_value) Backup Register */
+#define BSCIF_BR_MASK               _U(0xFFFFFFFF) /**< \brief (BSCIF_BR) MASK Register */
+
+/* -------- BSCIF_BRIFBVERSION : (BSCIF Offset: 0x3E4) (R/  32) Backup Register Interface Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version Number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant Number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_BRIFBVERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_BRIFBVERSION_OFFSET   0x3E4        /**< \brief (BSCIF_BRIFBVERSION offset) Backup Register Interface Version Register */
+#define BSCIF_BRIFBVERSION_RESETVALUE _U(0x00000100); /**< \brief (BSCIF_BRIFBVERSION reset_value) Backup Register Interface Version Register */
+
+#define BSCIF_BRIFBVERSION_VERSION_Pos 0            /**< \brief (BSCIF_BRIFBVERSION) Version Number */
+#define BSCIF_BRIFBVERSION_VERSION_Msk (_U(0xFFF) << BSCIF_BRIFBVERSION_VERSION_Pos)
+#define BSCIF_BRIFBVERSION_VERSION(value) (BSCIF_BRIFBVERSION_VERSION_Msk & ((value) << BSCIF_BRIFBVERSION_VERSION_Pos))
+#define BSCIF_BRIFBVERSION_VARIANT_Pos 16           /**< \brief (BSCIF_BRIFBVERSION) Variant Number */
+#define BSCIF_BRIFBVERSION_VARIANT_Msk (_U(0xF) << BSCIF_BRIFBVERSION_VARIANT_Pos)
+#define BSCIF_BRIFBVERSION_VARIANT(value) (BSCIF_BRIFBVERSION_VARIANT_Msk & ((value) << BSCIF_BRIFBVERSION_VARIANT_Pos))
+#define BSCIF_BRIFBVERSION_MASK     _U(0x000F0FFF) /**< \brief (BSCIF_BRIFBVERSION) MASK Register */
+
+/* -------- BSCIF_BGREFIFBVERSION : (BSCIF Offset: 0x3E8) (R/  32) BGREFIFB Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version Number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant Number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_BGREFIFBVERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_BGREFIFBVERSION_OFFSET 0x3E8        /**< \brief (BSCIF_BGREFIFBVERSION offset) BGREFIFB Version Register */
+#define BSCIF_BGREFIFBVERSION_RESETVALUE _U(0x00000110); /**< \brief (BSCIF_BGREFIFBVERSION reset_value) BGREFIFB Version Register */
+
+#define BSCIF_BGREFIFBVERSION_VERSION_Pos 0            /**< \brief (BSCIF_BGREFIFBVERSION) Version Number */
+#define BSCIF_BGREFIFBVERSION_VERSION_Msk (_U(0xFFF) << BSCIF_BGREFIFBVERSION_VERSION_Pos)
+#define BSCIF_BGREFIFBVERSION_VERSION(value) (BSCIF_BGREFIFBVERSION_VERSION_Msk & ((value) << BSCIF_BGREFIFBVERSION_VERSION_Pos))
+#define BSCIF_BGREFIFBVERSION_VARIANT_Pos 16           /**< \brief (BSCIF_BGREFIFBVERSION) Variant Number */
+#define BSCIF_BGREFIFBVERSION_VARIANT_Msk (_U(0xF) << BSCIF_BGREFIFBVERSION_VARIANT_Pos)
+#define BSCIF_BGREFIFBVERSION_VARIANT(value) (BSCIF_BGREFIFBVERSION_VARIANT_Msk & ((value) << BSCIF_BGREFIFBVERSION_VARIANT_Pos))
+#define BSCIF_BGREFIFBVERSION_MASK  _U(0x000F0FFF) /**< \brief (BSCIF_BGREFIFBVERSION) MASK Register */
+
+/* -------- BSCIF_VREGIFGVERSION : (BSCIF Offset: 0x3EC) (R/  32) VREGIFA Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version Number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant Number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_VREGIFGVERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_VREGIFGVERSION_OFFSET 0x3EC        /**< \brief (BSCIF_VREGIFGVERSION offset) VREGIFA Version Register */
+#define BSCIF_VREGIFGVERSION_RESETVALUE _U(0x00000110); /**< \brief (BSCIF_VREGIFGVERSION reset_value) VREGIFA Version Register */
+
+#define BSCIF_VREGIFGVERSION_VERSION_Pos 0            /**< \brief (BSCIF_VREGIFGVERSION) Version Number */
+#define BSCIF_VREGIFGVERSION_VERSION_Msk (_U(0xFFF) << BSCIF_VREGIFGVERSION_VERSION_Pos)
+#define BSCIF_VREGIFGVERSION_VERSION(value) (BSCIF_VREGIFGVERSION_VERSION_Msk & ((value) << BSCIF_VREGIFGVERSION_VERSION_Pos))
+#define BSCIF_VREGIFGVERSION_VARIANT_Pos 16           /**< \brief (BSCIF_VREGIFGVERSION) Variant Number */
+#define BSCIF_VREGIFGVERSION_VARIANT_Msk (_U(0xF) << BSCIF_VREGIFGVERSION_VARIANT_Pos)
+#define BSCIF_VREGIFGVERSION_VARIANT(value) (BSCIF_VREGIFGVERSION_VARIANT_Msk & ((value) << BSCIF_VREGIFGVERSION_VARIANT_Pos))
+#define BSCIF_VREGIFGVERSION_MASK   _U(0x000F0FFF) /**< \brief (BSCIF_VREGIFGVERSION) MASK Register */
+
+/* -------- BSCIF_BODIFCVERSION : (BSCIF Offset: 0x3F0) (R/  32) BODIFC Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version Number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant Number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_BODIFCVERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_BODIFCVERSION_OFFSET  0x3F0        /**< \brief (BSCIF_BODIFCVERSION offset) BODIFC Version Register */
+#define BSCIF_BODIFCVERSION_RESETVALUE _U(0x00000110); /**< \brief (BSCIF_BODIFCVERSION reset_value) BODIFC Version Register */
+
+#define BSCIF_BODIFCVERSION_VERSION_Pos 0            /**< \brief (BSCIF_BODIFCVERSION) Version Number */
+#define BSCIF_BODIFCVERSION_VERSION_Msk (_U(0xFFF) << BSCIF_BODIFCVERSION_VERSION_Pos)
+#define BSCIF_BODIFCVERSION_VERSION(value) (BSCIF_BODIFCVERSION_VERSION_Msk & ((value) << BSCIF_BODIFCVERSION_VERSION_Pos))
+#define BSCIF_BODIFCVERSION_VARIANT_Pos 16           /**< \brief (BSCIF_BODIFCVERSION) Variant Number */
+#define BSCIF_BODIFCVERSION_VARIANT_Msk (_U(0xF) << BSCIF_BODIFCVERSION_VARIANT_Pos)
+#define BSCIF_BODIFCVERSION_VARIANT(value) (BSCIF_BODIFCVERSION_VARIANT_Msk & ((value) << BSCIF_BODIFCVERSION_VARIANT_Pos))
+#define BSCIF_BODIFCVERSION_MASK    _U(0x000F0FFF) /**< \brief (BSCIF_BODIFCVERSION) MASK Register */
+
+/* -------- BSCIF_RC32KIFBVERSION : (BSCIF Offset: 0x3F4) (R/  32) 32 kHz RC Oscillator Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_RC32KIFBVERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_RC32KIFBVERSION_OFFSET 0x3F4        /**< \brief (BSCIF_RC32KIFBVERSION offset) 32 kHz RC Oscillator Version Register */
+#define BSCIF_RC32KIFBVERSION_RESETVALUE _U(0x00000100); /**< \brief (BSCIF_RC32KIFBVERSION reset_value) 32 kHz RC Oscillator Version Register */
+
+#define BSCIF_RC32KIFBVERSION_VERSION_Pos 0            /**< \brief (BSCIF_RC32KIFBVERSION) Version number */
+#define BSCIF_RC32KIFBVERSION_VERSION_Msk (_U(0xFFF) << BSCIF_RC32KIFBVERSION_VERSION_Pos)
+#define BSCIF_RC32KIFBVERSION_VERSION(value) (BSCIF_RC32KIFBVERSION_VERSION_Msk & ((value) << BSCIF_RC32KIFBVERSION_VERSION_Pos))
+#define BSCIF_RC32KIFBVERSION_VARIANT_Pos 16           /**< \brief (BSCIF_RC32KIFBVERSION) Variant number */
+#define BSCIF_RC32KIFBVERSION_VARIANT_Msk (_U(0xF) << BSCIF_RC32KIFBVERSION_VARIANT_Pos)
+#define BSCIF_RC32KIFBVERSION_VARIANT(value) (BSCIF_RC32KIFBVERSION_VARIANT_Msk & ((value) << BSCIF_RC32KIFBVERSION_VARIANT_Pos))
+#define BSCIF_RC32KIFBVERSION_MASK  _U(0x000F0FFF) /**< \brief (BSCIF_RC32KIFBVERSION) MASK Register */
+
+/* -------- BSCIF_OSC32IFAVERSION : (BSCIF Offset: 0x3F8) (R/  32) 32 KHz Oscillator Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant nubmer                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_OSC32IFAVERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_OSC32IFAVERSION_OFFSET 0x3F8        /**< \brief (BSCIF_OSC32IFAVERSION offset) 32 KHz Oscillator Version Register */
+#define BSCIF_OSC32IFAVERSION_RESETVALUE _U(0x00000200); /**< \brief (BSCIF_OSC32IFAVERSION reset_value) 32 KHz Oscillator Version Register */
+
+#define BSCIF_OSC32IFAVERSION_VERSION_Pos 0            /**< \brief (BSCIF_OSC32IFAVERSION) Version number */
+#define BSCIF_OSC32IFAVERSION_VERSION_Msk (_U(0xFFF) << BSCIF_OSC32IFAVERSION_VERSION_Pos)
+#define BSCIF_OSC32IFAVERSION_VERSION(value) (BSCIF_OSC32IFAVERSION_VERSION_Msk & ((value) << BSCIF_OSC32IFAVERSION_VERSION_Pos))
+#define BSCIF_OSC32IFAVERSION_VARIANT_Pos 16           /**< \brief (BSCIF_OSC32IFAVERSION) Variant nubmer */
+#define BSCIF_OSC32IFAVERSION_VARIANT_Msk (_U(0xF) << BSCIF_OSC32IFAVERSION_VARIANT_Pos)
+#define BSCIF_OSC32IFAVERSION_VARIANT(value) (BSCIF_OSC32IFAVERSION_VARIANT_Msk & ((value) << BSCIF_OSC32IFAVERSION_VARIANT_Pos))
+#define BSCIF_OSC32IFAVERSION_MASK  _U(0x000F0FFF) /**< \brief (BSCIF_OSC32IFAVERSION) MASK Register */
+
+/* -------- BSCIF_VERSION : (BSCIF Offset: 0x3FC) (R/  32) BSCIF Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version Number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant Number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} BSCIF_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define BSCIF_VERSION_OFFSET        0x3FC        /**< \brief (BSCIF_VERSION offset) BSCIF Version Register */
+#define BSCIF_VERSION_RESETVALUE    _U(0x00000100); /**< \brief (BSCIF_VERSION reset_value) BSCIF Version Register */
+
+#define BSCIF_VERSION_VERSION_Pos   0            /**< \brief (BSCIF_VERSION) Version Number */
+#define BSCIF_VERSION_VERSION_Msk   (_U(0xFFF) << BSCIF_VERSION_VERSION_Pos)
+#define BSCIF_VERSION_VERSION(value) (BSCIF_VERSION_VERSION_Msk & ((value) << BSCIF_VERSION_VERSION_Pos))
+#define BSCIF_VERSION_VARIANT_Pos   16           /**< \brief (BSCIF_VERSION) Variant Number */
+#define BSCIF_VERSION_VARIANT_Msk   (_U(0xF) << BSCIF_VERSION_VARIANT_Pos)
+#define BSCIF_VERSION_VARIANT(value) (BSCIF_VERSION_VARIANT_Msk & ((value) << BSCIF_VERSION_VARIANT_Pos))
+#define BSCIF_VERSION_MASK          _U(0x000F0FFF) /**< \brief (BSCIF_VERSION) MASK Register */
+
+/** \brief BscifBr hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __IO BSCIF_BR_Type             BR;          /**< \brief Offset: 0x000 (R/W 32) Backup Register */
+ } bf;
+ struct {
+  RwReg   BSCIF_BR;           /**< \brief (BSCIF Offset: 0x000) Backup Register */
+ } reg;
+} BscifBr;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief BSCIF hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __O  BSCIF_IER_Type            IER;         /**< \brief Offset: 0x000 ( /W 32) Interrupt Enable Register */
+  __O  BSCIF_IDR_Type            IDR;         /**< \brief Offset: 0x004 ( /W 32) Interrupt Disable Register */
+  __I  BSCIF_IMR_Type            IMR;         /**< \brief Offset: 0x008 (R/  32) Interrupt Mask Register */
+  __I  BSCIF_ISR_Type            ISR;         /**< \brief Offset: 0x00C (R/  32) Interrupt Status Register */
+  __O  BSCIF_ICR_Type            ICR;         /**< \brief Offset: 0x010 ( /W 32) Interrupt Clear Register */
+  __I  BSCIF_PCLKSR_Type         PCLKSR;      /**< \brief Offset: 0x014 (R/  32) Power and Clocks Status Register */
+  __O  BSCIF_UNLOCK_Type         UNLOCK;      /**< \brief Offset: 0x018 ( /W 32) Unlock Register */
+  __IO BSCIF_CSCR_Type           CSCR;        /**< \brief Offset: 0x01C (R/W 32) Chip Specific Configuration Register */
+  __IO BSCIF_OSCCTRL32_Type      OSCCTRL32;   /**< \brief Offset: 0x020 (R/W 32) Oscillator 32 Control Register */
+  __IO BSCIF_RC32KCR_Type        RC32KCR;     /**< \brief Offset: 0x024 (R/W 32) 32 kHz RC Oscillator Control Register */
+  __IO BSCIF_RC32KTUNE_Type      RC32KTUNE;   /**< \brief Offset: 0x028 (R/W 32) 32kHz RC Oscillator Tuning Register */
+  __IO BSCIF_BOD33CTRL_Type      BOD33CTRL;   /**< \brief Offset: 0x02C (R/W 32) BOD33 Control Register */
+  __IO BSCIF_BOD33LEVEL_Type     BOD33LEVEL;  /**< \brief Offset: 0x030 (R/W 32) BOD33 Level Register */
+  __IO BSCIF_BOD33SAMPLING_Type  BOD33SAMPLING; /**< \brief Offset: 0x034 (R/W 32) BOD33 Sampling Control Register */
+  __IO BSCIF_BOD18CTRL_Type      BOD18CTRL;   /**< \brief Offset: 0x038 (R/W 32) BOD18 Control Register */
+  __IO BSCIF_BOD18LEVEL_Type     BOD18LEVEL;  /**< \brief Offset: 0x03C (R/W 32) BOD18 Level Register */
+       RoReg8                    Reserved1[0x4];
+  __IO BSCIF_VREGCR_Type         VREGCR;      /**< \brief Offset: 0x044 (R/W 32) Voltage Regulator Configuration Register */
+       RoReg8                    Reserved2[0x4];
+  __IO BSCIF_VREGNCSR_Type       VREGNCSR;    /**< \brief Offset: 0x04C (R/W 32) Normal Mode Control and Status Register */
+  __IO BSCIF_VREGLPCSR_Type      VREGLPCSR;   /**< \brief Offset: 0x050 (R/W 32) LP Mode Control and Status Register */
+       RoReg8                    Reserved3[0x4];
+  __IO BSCIF_RC1MCR_Type         RC1MCR;      /**< \brief Offset: 0x058 (R/W 32) 1MHz RC Clock Configuration Register */
+  __IO BSCIF_BGCR_Type           BGCR;        /**< \brief Offset: 0x05C (R/W 32) Bandgap Calibration Register */
+  __IO BSCIF_BGCTRL_Type         BGCTRL;      /**< \brief Offset: 0x060 (R/W 32) Bandgap Control Register */
+  __I  BSCIF_BGSR_Type           BGSR;        /**< \brief Offset: 0x064 (R/  32) Bandgap Status Register */
+       RoReg8                    Reserved4[0x10];
+       BscifBr                   Br[4];       /**< \brief Offset: 0x078 BscifBr groups */
+       RoReg8                    Reserved5[0x35C];
+  __I  BSCIF_BRIFBVERSION_Type   BRIFBVERSION; /**< \brief Offset: 0x3E4 (R/  32) Backup Register Interface Version Register */
+  __I  BSCIF_BGREFIFBVERSION_Type BGREFIFBVERSION; /**< \brief Offset: 0x3E8 (R/  32) BGREFIFB Version Register */
+  __I  BSCIF_VREGIFGVERSION_Type VREGIFGVERSION; /**< \brief Offset: 0x3EC (R/  32) VREGIFA Version Register */
+  __I  BSCIF_BODIFCVERSION_Type  BODIFCVERSION; /**< \brief Offset: 0x3F0 (R/  32) BODIFC Version Register */
+  __I  BSCIF_RC32KIFBVERSION_Type RC32KIFBVERSION; /**< \brief Offset: 0x3F4 (R/  32) 32 kHz RC Oscillator Version Register */
+  __I  BSCIF_OSC32IFAVERSION_Type OSC32IFAVERSION; /**< \brief Offset: 0x3F8 (R/  32) 32 KHz Oscillator Version Register */
+  __I  BSCIF_VERSION_Type        VERSION;     /**< \brief Offset: 0x3FC (R/  32) BSCIF Version Register */
+ } bf;
+ struct {
+  WoReg   BSCIF_IER;          /**< \brief (BSCIF Offset: 0x000) Interrupt Enable Register */
+  WoReg   BSCIF_IDR;          /**< \brief (BSCIF Offset: 0x004) Interrupt Disable Register */
+  RoReg   BSCIF_IMR;          /**< \brief (BSCIF Offset: 0x008) Interrupt Mask Register */
+  RoReg   BSCIF_ISR;          /**< \brief (BSCIF Offset: 0x00C) Interrupt Status Register */
+  WoReg   BSCIF_ICR;          /**< \brief (BSCIF Offset: 0x010) Interrupt Clear Register */
+  RoReg   BSCIF_PCLKSR;       /**< \brief (BSCIF Offset: 0x014) Power and Clocks Status Register */
+  WoReg   BSCIF_UNLOCK;       /**< \brief (BSCIF Offset: 0x018) Unlock Register */
+  RwReg   BSCIF_CSCR;         /**< \brief (BSCIF Offset: 0x01C) Chip Specific Configuration Register */
+  RwReg   BSCIF_OSCCTRL32;    /**< \brief (BSCIF Offset: 0x020) Oscillator 32 Control Register */
+  RwReg   BSCIF_RC32KCR;      /**< \brief (BSCIF Offset: 0x024) 32 kHz RC Oscillator Control Register */
+  RwReg   BSCIF_RC32KTUNE;    /**< \brief (BSCIF Offset: 0x028) 32kHz RC Oscillator Tuning Register */
+  RwReg   BSCIF_BOD33CTRL;    /**< \brief (BSCIF Offset: 0x02C) BOD33 Control Register */
+  RwReg   BSCIF_BOD33LEVEL;   /**< \brief (BSCIF Offset: 0x030) BOD33 Level Register */
+  RwReg   BSCIF_BOD33SAMPLING; /**< \brief (BSCIF Offset: 0x034) BOD33 Sampling Control Register */
+  RwReg   BSCIF_BOD18CTRL;    /**< \brief (BSCIF Offset: 0x038) BOD18 Control Register */
+  RwReg   BSCIF_BOD18LEVEL;   /**< \brief (BSCIF Offset: 0x03C) BOD18 Level Register */
+  RoReg8  Reserved6[0x4];
+  RwReg   BSCIF_VREGCR;       /**< \brief (BSCIF Offset: 0x044) Voltage Regulator Configuration Register */
+  RoReg8  Reserved7[0x4];
+  RwReg   BSCIF_VREGNCSR;     /**< \brief (BSCIF Offset: 0x04C) Normal Mode Control and Status Register */
+  RwReg   BSCIF_VREGLPCSR;    /**< \brief (BSCIF Offset: 0x050) LP Mode Control and Status Register */
+  RoReg8  Reserved8[0x4];
+  RwReg   BSCIF_RC1MCR;       /**< \brief (BSCIF Offset: 0x058) 1MHz RC Clock Configuration Register */
+  RwReg   BSCIF_BGCR;         /**< \brief (BSCIF Offset: 0x05C) Bandgap Calibration Register */
+  RwReg   BSCIF_BGCTRL;       /**< \brief (BSCIF Offset: 0x060) Bandgap Control Register */
+  RoReg   BSCIF_BGSR;         /**< \brief (BSCIF Offset: 0x064) Bandgap Status Register */
+  RoReg8  Reserved9[0x10];
+  BscifBr BSCIF_BR[4];        /**< \brief (BSCIF Offset: 0x078) BscifBr groups */
+  RoReg8  Reserved10[0x35C];
+  RoReg   BSCIF_BRIFBVERSION; /**< \brief (BSCIF Offset: 0x3E4) Backup Register Interface Version Register */
+  RoReg   BSCIF_BGREFIFBVERSION; /**< \brief (BSCIF Offset: 0x3E8) BGREFIFB Version Register */
+  RoReg   BSCIF_VREGIFGVERSION; /**< \brief (BSCIF Offset: 0x3EC) VREGIFA Version Register */
+  RoReg   BSCIF_BODIFCVERSION; /**< \brief (BSCIF Offset: 0x3F0) BODIFC Version Register */
+  RoReg   BSCIF_RC32KIFBVERSION; /**< \brief (BSCIF Offset: 0x3F4) 32 kHz RC Oscillator Version Register */
+  RoReg   BSCIF_OSC32IFAVERSION; /**< \brief (BSCIF Offset: 0x3F8) 32 KHz Oscillator Version Register */
+  RoReg   BSCIF_VERSION;      /**< \brief (BSCIF Offset: 0x3FC) BSCIF Version Register */
+ } reg;
+} Bscif;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_BSCIF_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/bscif.h
+++ b/asf/sam/include/sam4l/component/bscif.h
@@ -63,35 +63,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_IER_OFFSET            0x000        /**< \brief (BSCIF_IER offset) Interrupt Enable Register */
-#define BSCIF_IER_RESETVALUE        _U(0x00000000); /**< \brief (BSCIF_IER reset_value) Interrupt Enable Register */
+#define BSCIF_IER_RESETVALUE        _U_(0x00000000); /**< \brief (BSCIF_IER reset_value) Interrupt Enable Register */
 
 #define BSCIF_IER_OSC32RDY_Pos      0            /**< \brief (BSCIF_IER) 32kHz Oscillator Ready */
-#define BSCIF_IER_OSC32RDY          (_U(0x1) << BSCIF_IER_OSC32RDY_Pos)
+#define BSCIF_IER_OSC32RDY          (_U_(0x1) << BSCIF_IER_OSC32RDY_Pos)
 #define BSCIF_IER_RC32KRDY_Pos      1            /**< \brief (BSCIF_IER) 32kHz RC Oscillator Ready */
-#define BSCIF_IER_RC32KRDY          (_U(0x1) << BSCIF_IER_RC32KRDY_Pos)
+#define BSCIF_IER_RC32KRDY          (_U_(0x1) << BSCIF_IER_RC32KRDY_Pos)
 #define BSCIF_IER_RC32KLOCK_Pos     2            /**< \brief (BSCIF_IER) 32kHz RC Oscillator Lock */
-#define BSCIF_IER_RC32KLOCK         (_U(0x1) << BSCIF_IER_RC32KLOCK_Pos)
+#define BSCIF_IER_RC32KLOCK         (_U_(0x1) << BSCIF_IER_RC32KLOCK_Pos)
 #define BSCIF_IER_RC32KREFE_Pos     3            /**< \brief (BSCIF_IER) 32kHz RC Oscillator Reference Error */
-#define BSCIF_IER_RC32KREFE         (_U(0x1) << BSCIF_IER_RC32KREFE_Pos)
+#define BSCIF_IER_RC32KREFE         (_U_(0x1) << BSCIF_IER_RC32KREFE_Pos)
 #define BSCIF_IER_RC32KSAT_Pos      4            /**< \brief (BSCIF_IER) 32kHz RC Oscillator Saturation */
-#define BSCIF_IER_RC32KSAT          (_U(0x1) << BSCIF_IER_RC32KSAT_Pos)
+#define BSCIF_IER_RC32KSAT          (_U_(0x1) << BSCIF_IER_RC32KSAT_Pos)
 #define BSCIF_IER_BOD33DET_Pos      5            /**< \brief (BSCIF_IER) BOD33 Detected */
-#define BSCIF_IER_BOD33DET          (_U(0x1) << BSCIF_IER_BOD33DET_Pos)
+#define BSCIF_IER_BOD33DET          (_U_(0x1) << BSCIF_IER_BOD33DET_Pos)
 #define BSCIF_IER_BOD18DET_Pos      6            /**< \brief (BSCIF_IER) BOD18 Detected */
-#define BSCIF_IER_BOD18DET          (_U(0x1) << BSCIF_IER_BOD18DET_Pos)
+#define BSCIF_IER_BOD18DET          (_U_(0x1) << BSCIF_IER_BOD18DET_Pos)
 #define BSCIF_IER_BOD33SYNRDY_Pos   7            /**< \brief (BSCIF_IER) BOD33 Synchronization Ready */
-#define BSCIF_IER_BOD33SYNRDY       (_U(0x1) << BSCIF_IER_BOD33SYNRDY_Pos)
+#define BSCIF_IER_BOD33SYNRDY       (_U_(0x1) << BSCIF_IER_BOD33SYNRDY_Pos)
 #define BSCIF_IER_BOD18SYNRDY_Pos   8            /**< \brief (BSCIF_IER) BOD18 Synchronization Ready */
-#define BSCIF_IER_BOD18SYNRDY       (_U(0x1) << BSCIF_IER_BOD18SYNRDY_Pos)
+#define BSCIF_IER_BOD18SYNRDY       (_U_(0x1) << BSCIF_IER_BOD18SYNRDY_Pos)
 #define BSCIF_IER_SSWRDY_Pos        9            /**< \brief (BSCIF_IER) VREG Stop Switching Ready */
-#define BSCIF_IER_SSWRDY            (_U(0x1) << BSCIF_IER_SSWRDY_Pos)
+#define BSCIF_IER_SSWRDY            (_U_(0x1) << BSCIF_IER_SSWRDY_Pos)
 #define BSCIF_IER_VREGOK_Pos        10           /**< \brief (BSCIF_IER) Main VREG OK */
-#define BSCIF_IER_VREGOK            (_U(0x1) << BSCIF_IER_VREGOK_Pos)
+#define BSCIF_IER_VREGOK            (_U_(0x1) << BSCIF_IER_VREGOK_Pos)
 #define BSCIF_IER_LPBGRDY_Pos       12           /**< \brief (BSCIF_IER) Low Power Bandgap Voltage Reference Ready */
-#define BSCIF_IER_LPBGRDY           (_U(0x1) << BSCIF_IER_LPBGRDY_Pos)
+#define BSCIF_IER_LPBGRDY           (_U_(0x1) << BSCIF_IER_LPBGRDY_Pos)
 #define BSCIF_IER_AE_Pos            31           /**< \brief (BSCIF_IER) Access Error */
-#define BSCIF_IER_AE                (_U(0x1) << BSCIF_IER_AE_Pos)
-#define BSCIF_IER_MASK              _U(0x800017FF) /**< \brief (BSCIF_IER) MASK Register */
+#define BSCIF_IER_AE                (_U_(0x1) << BSCIF_IER_AE_Pos)
+#define BSCIF_IER_MASK              _U_(0x800017FF) /**< \brief (BSCIF_IER) MASK Register */
 
 /* -------- BSCIF_IDR : (BSCIF Offset: 0x004) ( /W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -118,35 +118,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_IDR_OFFSET            0x004        /**< \brief (BSCIF_IDR offset) Interrupt Disable Register */
-#define BSCIF_IDR_RESETVALUE        _U(0x00000000); /**< \brief (BSCIF_IDR reset_value) Interrupt Disable Register */
+#define BSCIF_IDR_RESETVALUE        _U_(0x00000000); /**< \brief (BSCIF_IDR reset_value) Interrupt Disable Register */
 
 #define BSCIF_IDR_OSC32RDY_Pos      0            /**< \brief (BSCIF_IDR) 32kHz Oscillator Ready */
-#define BSCIF_IDR_OSC32RDY          (_U(0x1) << BSCIF_IDR_OSC32RDY_Pos)
+#define BSCIF_IDR_OSC32RDY          (_U_(0x1) << BSCIF_IDR_OSC32RDY_Pos)
 #define BSCIF_IDR_RC32KRDY_Pos      1            /**< \brief (BSCIF_IDR) 32kHz RC Oscillator Ready */
-#define BSCIF_IDR_RC32KRDY          (_U(0x1) << BSCIF_IDR_RC32KRDY_Pos)
+#define BSCIF_IDR_RC32KRDY          (_U_(0x1) << BSCIF_IDR_RC32KRDY_Pos)
 #define BSCIF_IDR_RC32KLOCK_Pos     2            /**< \brief (BSCIF_IDR) 32kHz RC Oscillator Lock */
-#define BSCIF_IDR_RC32KLOCK         (_U(0x1) << BSCIF_IDR_RC32KLOCK_Pos)
+#define BSCIF_IDR_RC32KLOCK         (_U_(0x1) << BSCIF_IDR_RC32KLOCK_Pos)
 #define BSCIF_IDR_RC32KREFE_Pos     3            /**< \brief (BSCIF_IDR) 32kHz RC Oscillator Reference Error */
-#define BSCIF_IDR_RC32KREFE         (_U(0x1) << BSCIF_IDR_RC32KREFE_Pos)
+#define BSCIF_IDR_RC32KREFE         (_U_(0x1) << BSCIF_IDR_RC32KREFE_Pos)
 #define BSCIF_IDR_RC32KSAT_Pos      4            /**< \brief (BSCIF_IDR) 32kHz RC Oscillator Saturation */
-#define BSCIF_IDR_RC32KSAT          (_U(0x1) << BSCIF_IDR_RC32KSAT_Pos)
+#define BSCIF_IDR_RC32KSAT          (_U_(0x1) << BSCIF_IDR_RC32KSAT_Pos)
 #define BSCIF_IDR_BOD33DET_Pos      5            /**< \brief (BSCIF_IDR) BOD33 Detected */
-#define BSCIF_IDR_BOD33DET          (_U(0x1) << BSCIF_IDR_BOD33DET_Pos)
+#define BSCIF_IDR_BOD33DET          (_U_(0x1) << BSCIF_IDR_BOD33DET_Pos)
 #define BSCIF_IDR_BOD18DET_Pos      6            /**< \brief (BSCIF_IDR) BOD18 Detected */
-#define BSCIF_IDR_BOD18DET          (_U(0x1) << BSCIF_IDR_BOD18DET_Pos)
+#define BSCIF_IDR_BOD18DET          (_U_(0x1) << BSCIF_IDR_BOD18DET_Pos)
 #define BSCIF_IDR_BOD33SYNRDY_Pos   7            /**< \brief (BSCIF_IDR) BOD33 Synchronization Ready */
-#define BSCIF_IDR_BOD33SYNRDY       (_U(0x1) << BSCIF_IDR_BOD33SYNRDY_Pos)
+#define BSCIF_IDR_BOD33SYNRDY       (_U_(0x1) << BSCIF_IDR_BOD33SYNRDY_Pos)
 #define BSCIF_IDR_BOD18SYNRDY_Pos   8            /**< \brief (BSCIF_IDR) BOD18 Synchronization Ready */
-#define BSCIF_IDR_BOD18SYNRDY       (_U(0x1) << BSCIF_IDR_BOD18SYNRDY_Pos)
+#define BSCIF_IDR_BOD18SYNRDY       (_U_(0x1) << BSCIF_IDR_BOD18SYNRDY_Pos)
 #define BSCIF_IDR_SSWRDY_Pos        9            /**< \brief (BSCIF_IDR) VREG Stop Switching Ready */
-#define BSCIF_IDR_SSWRDY            (_U(0x1) << BSCIF_IDR_SSWRDY_Pos)
+#define BSCIF_IDR_SSWRDY            (_U_(0x1) << BSCIF_IDR_SSWRDY_Pos)
 #define BSCIF_IDR_VREGOK_Pos        10           /**< \brief (BSCIF_IDR) Mai n VREG OK */
-#define BSCIF_IDR_VREGOK            (_U(0x1) << BSCIF_IDR_VREGOK_Pos)
+#define BSCIF_IDR_VREGOK            (_U_(0x1) << BSCIF_IDR_VREGOK_Pos)
 #define BSCIF_IDR_LPBGRDY_Pos       12           /**< \brief (BSCIF_IDR) Low Power Bandgap Voltage Reference Ready */
-#define BSCIF_IDR_LPBGRDY           (_U(0x1) << BSCIF_IDR_LPBGRDY_Pos)
+#define BSCIF_IDR_LPBGRDY           (_U_(0x1) << BSCIF_IDR_LPBGRDY_Pos)
 #define BSCIF_IDR_AE_Pos            31           /**< \brief (BSCIF_IDR) Access Error */
-#define BSCIF_IDR_AE                (_U(0x1) << BSCIF_IDR_AE_Pos)
-#define BSCIF_IDR_MASK              _U(0x800017FF) /**< \brief (BSCIF_IDR) MASK Register */
+#define BSCIF_IDR_AE                (_U_(0x1) << BSCIF_IDR_AE_Pos)
+#define BSCIF_IDR_MASK              _U_(0x800017FF) /**< \brief (BSCIF_IDR) MASK Register */
 
 /* -------- BSCIF_IMR : (BSCIF Offset: 0x008) (R/  32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -173,35 +173,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_IMR_OFFSET            0x008        /**< \brief (BSCIF_IMR offset) Interrupt Mask Register */
-#define BSCIF_IMR_RESETVALUE        _U(0x00000000); /**< \brief (BSCIF_IMR reset_value) Interrupt Mask Register */
+#define BSCIF_IMR_RESETVALUE        _U_(0x00000000); /**< \brief (BSCIF_IMR reset_value) Interrupt Mask Register */
 
 #define BSCIF_IMR_OSC32RDY_Pos      0            /**< \brief (BSCIF_IMR) 32kHz Oscillator Ready */
-#define BSCIF_IMR_OSC32RDY          (_U(0x1) << BSCIF_IMR_OSC32RDY_Pos)
+#define BSCIF_IMR_OSC32RDY          (_U_(0x1) << BSCIF_IMR_OSC32RDY_Pos)
 #define BSCIF_IMR_RC32KRDY_Pos      1            /**< \brief (BSCIF_IMR) 32kHz RC Oscillator Ready */
-#define BSCIF_IMR_RC32KRDY          (_U(0x1) << BSCIF_IMR_RC32KRDY_Pos)
+#define BSCIF_IMR_RC32KRDY          (_U_(0x1) << BSCIF_IMR_RC32KRDY_Pos)
 #define BSCIF_IMR_RC32KLOCK_Pos     2            /**< \brief (BSCIF_IMR) 32kHz RC Oscillator Lock */
-#define BSCIF_IMR_RC32KLOCK         (_U(0x1) << BSCIF_IMR_RC32KLOCK_Pos)
+#define BSCIF_IMR_RC32KLOCK         (_U_(0x1) << BSCIF_IMR_RC32KLOCK_Pos)
 #define BSCIF_IMR_RC32KREFE_Pos     3            /**< \brief (BSCIF_IMR) 32kHz RC Oscillator Reference Error */
-#define BSCIF_IMR_RC32KREFE         (_U(0x1) << BSCIF_IMR_RC32KREFE_Pos)
+#define BSCIF_IMR_RC32KREFE         (_U_(0x1) << BSCIF_IMR_RC32KREFE_Pos)
 #define BSCIF_IMR_RC32KSAT_Pos      4            /**< \brief (BSCIF_IMR) 32kHz RC Oscillator Saturation */
-#define BSCIF_IMR_RC32KSAT          (_U(0x1) << BSCIF_IMR_RC32KSAT_Pos)
+#define BSCIF_IMR_RC32KSAT          (_U_(0x1) << BSCIF_IMR_RC32KSAT_Pos)
 #define BSCIF_IMR_BOD33DET_Pos      5            /**< \brief (BSCIF_IMR) BOD33 Detected */
-#define BSCIF_IMR_BOD33DET          (_U(0x1) << BSCIF_IMR_BOD33DET_Pos)
+#define BSCIF_IMR_BOD33DET          (_U_(0x1) << BSCIF_IMR_BOD33DET_Pos)
 #define BSCIF_IMR_BOD18DET_Pos      6            /**< \brief (BSCIF_IMR) BOD18 Detected */
-#define BSCIF_IMR_BOD18DET          (_U(0x1) << BSCIF_IMR_BOD18DET_Pos)
+#define BSCIF_IMR_BOD18DET          (_U_(0x1) << BSCIF_IMR_BOD18DET_Pos)
 #define BSCIF_IMR_BOD33SYNRDY_Pos   7            /**< \brief (BSCIF_IMR) BOD33 Synchronization Ready */
-#define BSCIF_IMR_BOD33SYNRDY       (_U(0x1) << BSCIF_IMR_BOD33SYNRDY_Pos)
+#define BSCIF_IMR_BOD33SYNRDY       (_U_(0x1) << BSCIF_IMR_BOD33SYNRDY_Pos)
 #define BSCIF_IMR_BOD18SYNRDY_Pos   8            /**< \brief (BSCIF_IMR) BOD18 Synchronization Ready */
-#define BSCIF_IMR_BOD18SYNRDY       (_U(0x1) << BSCIF_IMR_BOD18SYNRDY_Pos)
+#define BSCIF_IMR_BOD18SYNRDY       (_U_(0x1) << BSCIF_IMR_BOD18SYNRDY_Pos)
 #define BSCIF_IMR_SSWRDY_Pos        9            /**< \brief (BSCIF_IMR) VREG Stop Switching Ready */
-#define BSCIF_IMR_SSWRDY            (_U(0x1) << BSCIF_IMR_SSWRDY_Pos)
+#define BSCIF_IMR_SSWRDY            (_U_(0x1) << BSCIF_IMR_SSWRDY_Pos)
 #define BSCIF_IMR_VREGOK_Pos        10           /**< \brief (BSCIF_IMR) Main VREG OK */
-#define BSCIF_IMR_VREGOK            (_U(0x1) << BSCIF_IMR_VREGOK_Pos)
+#define BSCIF_IMR_VREGOK            (_U_(0x1) << BSCIF_IMR_VREGOK_Pos)
 #define BSCIF_IMR_LPBGRDY_Pos       12           /**< \brief (BSCIF_IMR) Low Power Bandgap Voltage Reference Ready */
-#define BSCIF_IMR_LPBGRDY           (_U(0x1) << BSCIF_IMR_LPBGRDY_Pos)
+#define BSCIF_IMR_LPBGRDY           (_U_(0x1) << BSCIF_IMR_LPBGRDY_Pos)
 #define BSCIF_IMR_AE_Pos            31           /**< \brief (BSCIF_IMR) Access Error */
-#define BSCIF_IMR_AE                (_U(0x1) << BSCIF_IMR_AE_Pos)
-#define BSCIF_IMR_MASK              _U(0x800017FF) /**< \brief (BSCIF_IMR) MASK Register */
+#define BSCIF_IMR_AE                (_U_(0x1) << BSCIF_IMR_AE_Pos)
+#define BSCIF_IMR_MASK              _U_(0x800017FF) /**< \brief (BSCIF_IMR) MASK Register */
 
 /* -------- BSCIF_ISR : (BSCIF Offset: 0x00C) (R/  32) Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -228,35 +228,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_ISR_OFFSET            0x00C        /**< \brief (BSCIF_ISR offset) Interrupt Status Register */
-#define BSCIF_ISR_RESETVALUE        _U(0x00000000); /**< \brief (BSCIF_ISR reset_value) Interrupt Status Register */
+#define BSCIF_ISR_RESETVALUE        _U_(0x00000000); /**< \brief (BSCIF_ISR reset_value) Interrupt Status Register */
 
 #define BSCIF_ISR_OSC32RDY_Pos      0            /**< \brief (BSCIF_ISR) 32kHz Oscillator Ready */
-#define BSCIF_ISR_OSC32RDY          (_U(0x1) << BSCIF_ISR_OSC32RDY_Pos)
+#define BSCIF_ISR_OSC32RDY          (_U_(0x1) << BSCIF_ISR_OSC32RDY_Pos)
 #define BSCIF_ISR_RC32KRDY_Pos      1            /**< \brief (BSCIF_ISR) 32kHz RC Oscillator Ready */
-#define BSCIF_ISR_RC32KRDY          (_U(0x1) << BSCIF_ISR_RC32KRDY_Pos)
+#define BSCIF_ISR_RC32KRDY          (_U_(0x1) << BSCIF_ISR_RC32KRDY_Pos)
 #define BSCIF_ISR_RC32KLOCK_Pos     2            /**< \brief (BSCIF_ISR) 32kHz RC Oscillator Lock */
-#define BSCIF_ISR_RC32KLOCK         (_U(0x1) << BSCIF_ISR_RC32KLOCK_Pos)
+#define BSCIF_ISR_RC32KLOCK         (_U_(0x1) << BSCIF_ISR_RC32KLOCK_Pos)
 #define BSCIF_ISR_RC32KREFE_Pos     3            /**< \brief (BSCIF_ISR) 32kHz RC Oscillator Reference Error */
-#define BSCIF_ISR_RC32KREFE         (_U(0x1) << BSCIF_ISR_RC32KREFE_Pos)
+#define BSCIF_ISR_RC32KREFE         (_U_(0x1) << BSCIF_ISR_RC32KREFE_Pos)
 #define BSCIF_ISR_RC32KSAT_Pos      4            /**< \brief (BSCIF_ISR) 32kHz RC Oscillator Saturation */
-#define BSCIF_ISR_RC32KSAT          (_U(0x1) << BSCIF_ISR_RC32KSAT_Pos)
+#define BSCIF_ISR_RC32KSAT          (_U_(0x1) << BSCIF_ISR_RC32KSAT_Pos)
 #define BSCIF_ISR_BOD33DET_Pos      5            /**< \brief (BSCIF_ISR) BOD33 Detected */
-#define BSCIF_ISR_BOD33DET          (_U(0x1) << BSCIF_ISR_BOD33DET_Pos)
+#define BSCIF_ISR_BOD33DET          (_U_(0x1) << BSCIF_ISR_BOD33DET_Pos)
 #define BSCIF_ISR_BOD18DET_Pos      6            /**< \brief (BSCIF_ISR) BOD18 Detected */
-#define BSCIF_ISR_BOD18DET          (_U(0x1) << BSCIF_ISR_BOD18DET_Pos)
+#define BSCIF_ISR_BOD18DET          (_U_(0x1) << BSCIF_ISR_BOD18DET_Pos)
 #define BSCIF_ISR_BOD33SYNRDY_Pos   7            /**< \brief (BSCIF_ISR) BOD33 Synchronization Ready */
-#define BSCIF_ISR_BOD33SYNRDY       (_U(0x1) << BSCIF_ISR_BOD33SYNRDY_Pos)
+#define BSCIF_ISR_BOD33SYNRDY       (_U_(0x1) << BSCIF_ISR_BOD33SYNRDY_Pos)
 #define BSCIF_ISR_BOD18SYNRDY_Pos   8            /**< \brief (BSCIF_ISR) BOD18 Synchronization Ready */
-#define BSCIF_ISR_BOD18SYNRDY       (_U(0x1) << BSCIF_ISR_BOD18SYNRDY_Pos)
+#define BSCIF_ISR_BOD18SYNRDY       (_U_(0x1) << BSCIF_ISR_BOD18SYNRDY_Pos)
 #define BSCIF_ISR_SSWRDY_Pos        9            /**< \brief (BSCIF_ISR) VREG Stop Switching Ready */
-#define BSCIF_ISR_SSWRDY            (_U(0x1) << BSCIF_ISR_SSWRDY_Pos)
+#define BSCIF_ISR_SSWRDY            (_U_(0x1) << BSCIF_ISR_SSWRDY_Pos)
 #define BSCIF_ISR_VREGOK_Pos        10           /**< \brief (BSCIF_ISR) Main VREG OK */
-#define BSCIF_ISR_VREGOK            (_U(0x1) << BSCIF_ISR_VREGOK_Pos)
+#define BSCIF_ISR_VREGOK            (_U_(0x1) << BSCIF_ISR_VREGOK_Pos)
 #define BSCIF_ISR_LPBGRDY_Pos       12           /**< \brief (BSCIF_ISR) Low Power Bandgap Voltage Reference Ready */
-#define BSCIF_ISR_LPBGRDY           (_U(0x1) << BSCIF_ISR_LPBGRDY_Pos)
+#define BSCIF_ISR_LPBGRDY           (_U_(0x1) << BSCIF_ISR_LPBGRDY_Pos)
 #define BSCIF_ISR_AE_Pos            31           /**< \brief (BSCIF_ISR) Access Error */
-#define BSCIF_ISR_AE                (_U(0x1) << BSCIF_ISR_AE_Pos)
-#define BSCIF_ISR_MASK              _U(0x800017FF) /**< \brief (BSCIF_ISR) MASK Register */
+#define BSCIF_ISR_AE                (_U_(0x1) << BSCIF_ISR_AE_Pos)
+#define BSCIF_ISR_MASK              _U_(0x800017FF) /**< \brief (BSCIF_ISR) MASK Register */
 
 /* -------- BSCIF_ICR : (BSCIF Offset: 0x010) ( /W 32) Interrupt Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -283,35 +283,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_ICR_OFFSET            0x010        /**< \brief (BSCIF_ICR offset) Interrupt Clear Register */
-#define BSCIF_ICR_RESETVALUE        _U(0x00000000); /**< \brief (BSCIF_ICR reset_value) Interrupt Clear Register */
+#define BSCIF_ICR_RESETVALUE        _U_(0x00000000); /**< \brief (BSCIF_ICR reset_value) Interrupt Clear Register */
 
 #define BSCIF_ICR_OSC32RDY_Pos      0            /**< \brief (BSCIF_ICR) 32kHz Oscillator Ready */
-#define BSCIF_ICR_OSC32RDY          (_U(0x1) << BSCIF_ICR_OSC32RDY_Pos)
+#define BSCIF_ICR_OSC32RDY          (_U_(0x1) << BSCIF_ICR_OSC32RDY_Pos)
 #define BSCIF_ICR_RC32KRDY_Pos      1            /**< \brief (BSCIF_ICR) 32kHz RC Oscillator Ready */
-#define BSCIF_ICR_RC32KRDY          (_U(0x1) << BSCIF_ICR_RC32KRDY_Pos)
+#define BSCIF_ICR_RC32KRDY          (_U_(0x1) << BSCIF_ICR_RC32KRDY_Pos)
 #define BSCIF_ICR_RC32KLOCK_Pos     2            /**< \brief (BSCIF_ICR) 32kHz RC Oscillator Lock */
-#define BSCIF_ICR_RC32KLOCK         (_U(0x1) << BSCIF_ICR_RC32KLOCK_Pos)
+#define BSCIF_ICR_RC32KLOCK         (_U_(0x1) << BSCIF_ICR_RC32KLOCK_Pos)
 #define BSCIF_ICR_RC32KREFE_Pos     3            /**< \brief (BSCIF_ICR) 32kHz RC Oscillator Reference Error */
-#define BSCIF_ICR_RC32KREFE         (_U(0x1) << BSCIF_ICR_RC32KREFE_Pos)
+#define BSCIF_ICR_RC32KREFE         (_U_(0x1) << BSCIF_ICR_RC32KREFE_Pos)
 #define BSCIF_ICR_RC32KSAT_Pos      4            /**< \brief (BSCIF_ICR) 32kHz RC Oscillator Saturation */
-#define BSCIF_ICR_RC32KSAT          (_U(0x1) << BSCIF_ICR_RC32KSAT_Pos)
+#define BSCIF_ICR_RC32KSAT          (_U_(0x1) << BSCIF_ICR_RC32KSAT_Pos)
 #define BSCIF_ICR_BOD33DET_Pos      5            /**< \brief (BSCIF_ICR) BOD33 Detected */
-#define BSCIF_ICR_BOD33DET          (_U(0x1) << BSCIF_ICR_BOD33DET_Pos)
+#define BSCIF_ICR_BOD33DET          (_U_(0x1) << BSCIF_ICR_BOD33DET_Pos)
 #define BSCIF_ICR_BOD18DET_Pos      6            /**< \brief (BSCIF_ICR) BOD18 Detected */
-#define BSCIF_ICR_BOD18DET          (_U(0x1) << BSCIF_ICR_BOD18DET_Pos)
+#define BSCIF_ICR_BOD18DET          (_U_(0x1) << BSCIF_ICR_BOD18DET_Pos)
 #define BSCIF_ICR_BOD33SYNRDY_Pos   7            /**< \brief (BSCIF_ICR) BOD33 Synchronization Ready */
-#define BSCIF_ICR_BOD33SYNRDY       (_U(0x1) << BSCIF_ICR_BOD33SYNRDY_Pos)
+#define BSCIF_ICR_BOD33SYNRDY       (_U_(0x1) << BSCIF_ICR_BOD33SYNRDY_Pos)
 #define BSCIF_ICR_BOD18SYNRDY_Pos   8            /**< \brief (BSCIF_ICR) BOD18 Synchronization Ready */
-#define BSCIF_ICR_BOD18SYNRDY       (_U(0x1) << BSCIF_ICR_BOD18SYNRDY_Pos)
+#define BSCIF_ICR_BOD18SYNRDY       (_U_(0x1) << BSCIF_ICR_BOD18SYNRDY_Pos)
 #define BSCIF_ICR_SSWRDY_Pos        9            /**< \brief (BSCIF_ICR) VREG Stop Switching Ready */
-#define BSCIF_ICR_SSWRDY            (_U(0x1) << BSCIF_ICR_SSWRDY_Pos)
+#define BSCIF_ICR_SSWRDY            (_U_(0x1) << BSCIF_ICR_SSWRDY_Pos)
 #define BSCIF_ICR_VREGOK_Pos        10           /**< \brief (BSCIF_ICR) Main VREG OK */
-#define BSCIF_ICR_VREGOK            (_U(0x1) << BSCIF_ICR_VREGOK_Pos)
+#define BSCIF_ICR_VREGOK            (_U_(0x1) << BSCIF_ICR_VREGOK_Pos)
 #define BSCIF_ICR_LPBGRDY_Pos       12           /**< \brief (BSCIF_ICR) Low Power Bandgap Voltage Reference Ready */
-#define BSCIF_ICR_LPBGRDY           (_U(0x1) << BSCIF_ICR_LPBGRDY_Pos)
+#define BSCIF_ICR_LPBGRDY           (_U_(0x1) << BSCIF_ICR_LPBGRDY_Pos)
 #define BSCIF_ICR_AE_Pos            31           /**< \brief (BSCIF_ICR) Access Error */
-#define BSCIF_ICR_AE                (_U(0x1) << BSCIF_ICR_AE_Pos)
-#define BSCIF_ICR_MASK              _U(0x800017FF) /**< \brief (BSCIF_ICR) MASK Register */
+#define BSCIF_ICR_AE                (_U_(0x1) << BSCIF_ICR_AE_Pos)
+#define BSCIF_ICR_MASK              _U_(0x800017FF) /**< \brief (BSCIF_ICR) MASK Register */
 
 /* -------- BSCIF_PCLKSR : (BSCIF Offset: 0x014) (R/  32) Power and Clocks Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -337,35 +337,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_PCLKSR_OFFSET         0x014        /**< \brief (BSCIF_PCLKSR offset) Power and Clocks Status Register */
-#define BSCIF_PCLKSR_RESETVALUE     _U(0x00000000); /**< \brief (BSCIF_PCLKSR reset_value) Power and Clocks Status Register */
+#define BSCIF_PCLKSR_RESETVALUE     _U_(0x00000000); /**< \brief (BSCIF_PCLKSR reset_value) Power and Clocks Status Register */
 
 #define BSCIF_PCLKSR_OSC32RDY_Pos   0            /**< \brief (BSCIF_PCLKSR) 32kHz Oscillator Ready */
-#define BSCIF_PCLKSR_OSC32RDY       (_U(0x1) << BSCIF_PCLKSR_OSC32RDY_Pos)
+#define BSCIF_PCLKSR_OSC32RDY       (_U_(0x1) << BSCIF_PCLKSR_OSC32RDY_Pos)
 #define BSCIF_PCLKSR_RC32KRDY_Pos   1            /**< \brief (BSCIF_PCLKSR) 32kHz RC Oscillator Ready */
-#define BSCIF_PCLKSR_RC32KRDY       (_U(0x1) << BSCIF_PCLKSR_RC32KRDY_Pos)
+#define BSCIF_PCLKSR_RC32KRDY       (_U_(0x1) << BSCIF_PCLKSR_RC32KRDY_Pos)
 #define BSCIF_PCLKSR_RC32KLOCK_Pos  2            /**< \brief (BSCIF_PCLKSR) 32kHz RC Oscillator Lock */
-#define BSCIF_PCLKSR_RC32KLOCK      (_U(0x1) << BSCIF_PCLKSR_RC32KLOCK_Pos)
+#define BSCIF_PCLKSR_RC32KLOCK      (_U_(0x1) << BSCIF_PCLKSR_RC32KLOCK_Pos)
 #define BSCIF_PCLKSR_RC32KREFE_Pos  3            /**< \brief (BSCIF_PCLKSR) 32kHz RC Oscillator Reference Error */
-#define BSCIF_PCLKSR_RC32KREFE      (_U(0x1) << BSCIF_PCLKSR_RC32KREFE_Pos)
+#define BSCIF_PCLKSR_RC32KREFE      (_U_(0x1) << BSCIF_PCLKSR_RC32KREFE_Pos)
 #define BSCIF_PCLKSR_RC32KSAT_Pos   4            /**< \brief (BSCIF_PCLKSR) 32kHz RC Oscillator Saturation */
-#define BSCIF_PCLKSR_RC32KSAT       (_U(0x1) << BSCIF_PCLKSR_RC32KSAT_Pos)
+#define BSCIF_PCLKSR_RC32KSAT       (_U_(0x1) << BSCIF_PCLKSR_RC32KSAT_Pos)
 #define BSCIF_PCLKSR_BOD33DET_Pos   5            /**< \brief (BSCIF_PCLKSR) BOD33 Detected */
-#define BSCIF_PCLKSR_BOD33DET       (_U(0x1) << BSCIF_PCLKSR_BOD33DET_Pos)
+#define BSCIF_PCLKSR_BOD33DET       (_U_(0x1) << BSCIF_PCLKSR_BOD33DET_Pos)
 #define BSCIF_PCLKSR_BOD18DET_Pos   6            /**< \brief (BSCIF_PCLKSR) BOD18 Detected */
-#define BSCIF_PCLKSR_BOD18DET       (_U(0x1) << BSCIF_PCLKSR_BOD18DET_Pos)
+#define BSCIF_PCLKSR_BOD18DET       (_U_(0x1) << BSCIF_PCLKSR_BOD18DET_Pos)
 #define BSCIF_PCLKSR_BOD33SYNRDY_Pos 7            /**< \brief (BSCIF_PCLKSR) BOD33 Synchronization Ready */
-#define BSCIF_PCLKSR_BOD33SYNRDY    (_U(0x1) << BSCIF_PCLKSR_BOD33SYNRDY_Pos)
+#define BSCIF_PCLKSR_BOD33SYNRDY    (_U_(0x1) << BSCIF_PCLKSR_BOD33SYNRDY_Pos)
 #define BSCIF_PCLKSR_BOD18SYNRDY_Pos 8            /**< \brief (BSCIF_PCLKSR) BOD18 Synchronization Ready */
-#define BSCIF_PCLKSR_BOD18SYNRDY    (_U(0x1) << BSCIF_PCLKSR_BOD18SYNRDY_Pos)
+#define BSCIF_PCLKSR_BOD18SYNRDY    (_U_(0x1) << BSCIF_PCLKSR_BOD18SYNRDY_Pos)
 #define BSCIF_PCLKSR_SSWRDY_Pos     9            /**< \brief (BSCIF_PCLKSR) VREG Stop Switching Ready */
-#define BSCIF_PCLKSR_SSWRDY         (_U(0x1) << BSCIF_PCLKSR_SSWRDY_Pos)
+#define BSCIF_PCLKSR_SSWRDY         (_U_(0x1) << BSCIF_PCLKSR_SSWRDY_Pos)
 #define BSCIF_PCLKSR_VREGOK_Pos     10           /**< \brief (BSCIF_PCLKSR) Main VREG OK */
-#define BSCIF_PCLKSR_VREGOK         (_U(0x1) << BSCIF_PCLKSR_VREGOK_Pos)
+#define BSCIF_PCLKSR_VREGOK         (_U_(0x1) << BSCIF_PCLKSR_VREGOK_Pos)
 #define BSCIF_PCLKSR_RC1MRDY_Pos    11           /**< \brief (BSCIF_PCLKSR) RC 1MHz Oscillator Ready */
-#define BSCIF_PCLKSR_RC1MRDY        (_U(0x1) << BSCIF_PCLKSR_RC1MRDY_Pos)
+#define BSCIF_PCLKSR_RC1MRDY        (_U_(0x1) << BSCIF_PCLKSR_RC1MRDY_Pos)
 #define BSCIF_PCLKSR_LPBGRDY_Pos    12           /**< \brief (BSCIF_PCLKSR) Low Power Bandgap Voltage Reference Ready */
-#define BSCIF_PCLKSR_LPBGRDY        (_U(0x1) << BSCIF_PCLKSR_LPBGRDY_Pos)
-#define BSCIF_PCLKSR_MASK           _U(0x00001FFF) /**< \brief (BSCIF_PCLKSR) MASK Register */
+#define BSCIF_PCLKSR_LPBGRDY        (_U_(0x1) << BSCIF_PCLKSR_LPBGRDY_Pos)
+#define BSCIF_PCLKSR_MASK           _U_(0x00001FFF) /**< \brief (BSCIF_PCLKSR) MASK Register */
 
 /* -------- BSCIF_UNLOCK : (BSCIF Offset: 0x018) ( /W 32) Unlock Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -380,17 +380,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_UNLOCK_OFFSET         0x018        /**< \brief (BSCIF_UNLOCK offset) Unlock Register */
-#define BSCIF_UNLOCK_RESETVALUE     _U(0x00000000); /**< \brief (BSCIF_UNLOCK reset_value) Unlock Register */
+#define BSCIF_UNLOCK_RESETVALUE     _U_(0x00000000); /**< \brief (BSCIF_UNLOCK reset_value) Unlock Register */
 
 #define BSCIF_UNLOCK_ADDR_Pos       0            /**< \brief (BSCIF_UNLOCK) Unlock Address */
-#define BSCIF_UNLOCK_ADDR_Msk       (_U(0x3FF) << BSCIF_UNLOCK_ADDR_Pos)
+#define BSCIF_UNLOCK_ADDR_Msk       (_U_(0x3FF) << BSCIF_UNLOCK_ADDR_Pos)
 #define BSCIF_UNLOCK_ADDR(value)    (BSCIF_UNLOCK_ADDR_Msk & ((value) << BSCIF_UNLOCK_ADDR_Pos))
 #define BSCIF_UNLOCK_KEY_Pos        24           /**< \brief (BSCIF_UNLOCK) Unlock Key */
-#define BSCIF_UNLOCK_KEY_Msk        (_U(0xFF) << BSCIF_UNLOCK_KEY_Pos)
+#define BSCIF_UNLOCK_KEY_Msk        (_U_(0xFF) << BSCIF_UNLOCK_KEY_Pos)
 #define BSCIF_UNLOCK_KEY(value)     (BSCIF_UNLOCK_KEY_Msk & ((value) << BSCIF_UNLOCK_KEY_Pos))
-#define   BSCIF_UNLOCK_KEY_VALID_Val      _U(0xAA)   /**< \brief (BSCIF_UNLOCK) Valid Key to Unlock register */
+#define   BSCIF_UNLOCK_KEY_VALID_Val      _U_(0xAA)   /**< \brief (BSCIF_UNLOCK) Valid Key to Unlock register */
 #define BSCIF_UNLOCK_KEY_VALID      (BSCIF_UNLOCK_KEY_VALID_Val    << BSCIF_UNLOCK_KEY_Pos)
-#define BSCIF_UNLOCK_MASK           _U(0xFF0003FF) /**< \brief (BSCIF_UNLOCK) MASK Register */
+#define BSCIF_UNLOCK_MASK           _U_(0xFF0003FF) /**< \brief (BSCIF_UNLOCK) MASK Register */
 
 /* -------- BSCIF_CSCR : (BSCIF Offset: 0x01C) (R/W 32) Chip Specific Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -400,9 +400,9 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_CSCR_OFFSET           0x01C        /**< \brief (BSCIF_CSCR offset) Chip Specific Configuration Register */
-#define BSCIF_CSCR_RESETVALUE       _U(0x00000000); /**< \brief (BSCIF_CSCR reset_value) Chip Specific Configuration Register */
+#define BSCIF_CSCR_RESETVALUE       _U_(0x00000000); /**< \brief (BSCIF_CSCR reset_value) Chip Specific Configuration Register */
 
-#define BSCIF_CSCR_MASK             _U(0x00000000) /**< \brief (BSCIF_CSCR) MASK Register */
+#define BSCIF_CSCR_MASK             _U_(0x00000000) /**< \brief (BSCIF_CSCR) MASK Register */
 
 /* -------- BSCIF_OSCCTRL32 : (BSCIF Offset: 0x020) (R/W 32) Oscillator 32 Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -424,26 +424,26 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_OSCCTRL32_OFFSET      0x020        /**< \brief (BSCIF_OSCCTRL32 offset) Oscillator 32 Control Register */
-#define BSCIF_OSCCTRL32_RESETVALUE  _U(0x00000004); /**< \brief (BSCIF_OSCCTRL32 reset_value) Oscillator 32 Control Register */
+#define BSCIF_OSCCTRL32_RESETVALUE  _U_(0x00000004); /**< \brief (BSCIF_OSCCTRL32 reset_value) Oscillator 32 Control Register */
 
 #define BSCIF_OSCCTRL32_OSC32EN_Pos 0            /**< \brief (BSCIF_OSCCTRL32) 32 KHz Oscillator Enable */
-#define BSCIF_OSCCTRL32_OSC32EN     (_U(0x1) << BSCIF_OSCCTRL32_OSC32EN_Pos)
+#define BSCIF_OSCCTRL32_OSC32EN     (_U_(0x1) << BSCIF_OSCCTRL32_OSC32EN_Pos)
 #define BSCIF_OSCCTRL32_PINSEL_Pos  1            /**< \brief (BSCIF_OSCCTRL32) Pins Select */
-#define BSCIF_OSCCTRL32_PINSEL      (_U(0x1) << BSCIF_OSCCTRL32_PINSEL_Pos)
+#define BSCIF_OSCCTRL32_PINSEL      (_U_(0x1) << BSCIF_OSCCTRL32_PINSEL_Pos)
 #define BSCIF_OSCCTRL32_EN32K_Pos   2            /**< \brief (BSCIF_OSCCTRL32) 32 KHz output Enable */
-#define BSCIF_OSCCTRL32_EN32K       (_U(0x1) << BSCIF_OSCCTRL32_EN32K_Pos)
+#define BSCIF_OSCCTRL32_EN32K       (_U_(0x1) << BSCIF_OSCCTRL32_EN32K_Pos)
 #define BSCIF_OSCCTRL32_EN1K_Pos    3            /**< \brief (BSCIF_OSCCTRL32) 1 KHz output Enable */
-#define BSCIF_OSCCTRL32_EN1K        (_U(0x1) << BSCIF_OSCCTRL32_EN1K_Pos)
+#define BSCIF_OSCCTRL32_EN1K        (_U_(0x1) << BSCIF_OSCCTRL32_EN1K_Pos)
 #define BSCIF_OSCCTRL32_MODE_Pos    8            /**< \brief (BSCIF_OSCCTRL32) Oscillator Mode */
-#define BSCIF_OSCCTRL32_MODE_Msk    (_U(0x7) << BSCIF_OSCCTRL32_MODE_Pos)
+#define BSCIF_OSCCTRL32_MODE_Msk    (_U_(0x7) << BSCIF_OSCCTRL32_MODE_Pos)
 #define BSCIF_OSCCTRL32_MODE(value) (BSCIF_OSCCTRL32_MODE_Msk & ((value) << BSCIF_OSCCTRL32_MODE_Pos))
 #define BSCIF_OSCCTRL32_SELCURR_Pos 12           /**< \brief (BSCIF_OSCCTRL32) Current selection */
-#define BSCIF_OSCCTRL32_SELCURR_Msk (_U(0xF) << BSCIF_OSCCTRL32_SELCURR_Pos)
+#define BSCIF_OSCCTRL32_SELCURR_Msk (_U_(0xF) << BSCIF_OSCCTRL32_SELCURR_Pos)
 #define BSCIF_OSCCTRL32_SELCURR(value) (BSCIF_OSCCTRL32_SELCURR_Msk & ((value) << BSCIF_OSCCTRL32_SELCURR_Pos))
 #define BSCIF_OSCCTRL32_STARTUP_Pos 16           /**< \brief (BSCIF_OSCCTRL32) Oscillator Start-up Time */
-#define BSCIF_OSCCTRL32_STARTUP_Msk (_U(0x7) << BSCIF_OSCCTRL32_STARTUP_Pos)
+#define BSCIF_OSCCTRL32_STARTUP_Msk (_U_(0x7) << BSCIF_OSCCTRL32_STARTUP_Pos)
 #define BSCIF_OSCCTRL32_STARTUP(value) (BSCIF_OSCCTRL32_STARTUP_Msk & ((value) << BSCIF_OSCCTRL32_STARTUP_Pos))
-#define BSCIF_OSCCTRL32_MASK        _U(0x0007F70F) /**< \brief (BSCIF_OSCCTRL32) MASK Register */
+#define BSCIF_OSCCTRL32_MASK        _U_(0x0007F70F) /**< \brief (BSCIF_OSCCTRL32) MASK Register */
 
 /* -------- BSCIF_RC32KCR : (BSCIF Offset: 0x024) (R/W 32) 32 kHz RC Oscillator Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -464,23 +464,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_RC32KCR_OFFSET        0x024        /**< \brief (BSCIF_RC32KCR offset) 32 kHz RC Oscillator Control Register */
-#define BSCIF_RC32KCR_RESETVALUE    _U(0x00000000); /**< \brief (BSCIF_RC32KCR reset_value) 32 kHz RC Oscillator Control Register */
+#define BSCIF_RC32KCR_RESETVALUE    _U_(0x00000000); /**< \brief (BSCIF_RC32KCR reset_value) 32 kHz RC Oscillator Control Register */
 
 #define BSCIF_RC32KCR_EN_Pos        0            /**< \brief (BSCIF_RC32KCR) Enable as Generic clock source */
-#define BSCIF_RC32KCR_EN            (_U(0x1) << BSCIF_RC32KCR_EN_Pos)
+#define BSCIF_RC32KCR_EN            (_U_(0x1) << BSCIF_RC32KCR_EN_Pos)
 #define BSCIF_RC32KCR_TCEN_Pos      1            /**< \brief (BSCIF_RC32KCR) Temperature Compensation Enable */
-#define BSCIF_RC32KCR_TCEN          (_U(0x1) << BSCIF_RC32KCR_TCEN_Pos)
+#define BSCIF_RC32KCR_TCEN          (_U_(0x1) << BSCIF_RC32KCR_TCEN_Pos)
 #define BSCIF_RC32KCR_EN32K_Pos     2            /**< \brief (BSCIF_RC32KCR) Enable 32 KHz output */
-#define BSCIF_RC32KCR_EN32K         (_U(0x1) << BSCIF_RC32KCR_EN32K_Pos)
+#define BSCIF_RC32KCR_EN32K         (_U_(0x1) << BSCIF_RC32KCR_EN32K_Pos)
 #define BSCIF_RC32KCR_EN1K_Pos      3            /**< \brief (BSCIF_RC32KCR) Enable 1 kHz output */
-#define BSCIF_RC32KCR_EN1K          (_U(0x1) << BSCIF_RC32KCR_EN1K_Pos)
+#define BSCIF_RC32KCR_EN1K          (_U_(0x1) << BSCIF_RC32KCR_EN1K_Pos)
 #define BSCIF_RC32KCR_MODE_Pos      4            /**< \brief (BSCIF_RC32KCR) Mode Selection */
-#define BSCIF_RC32KCR_MODE          (_U(0x1) << BSCIF_RC32KCR_MODE_Pos)
+#define BSCIF_RC32KCR_MODE          (_U_(0x1) << BSCIF_RC32KCR_MODE_Pos)
 #define BSCIF_RC32KCR_REF_Pos       5            /**< \brief (BSCIF_RC32KCR) Reference select */
-#define BSCIF_RC32KCR_REF           (_U(0x1) << BSCIF_RC32KCR_REF_Pos)
+#define BSCIF_RC32KCR_REF           (_U_(0x1) << BSCIF_RC32KCR_REF_Pos)
 #define BSCIF_RC32KCR_FCD_Pos       7            /**< \brief (BSCIF_RC32KCR) Flash calibration done */
-#define BSCIF_RC32KCR_FCD           (_U(0x1) << BSCIF_RC32KCR_FCD_Pos)
-#define BSCIF_RC32KCR_MASK          _U(0x000000BF) /**< \brief (BSCIF_RC32KCR) MASK Register */
+#define BSCIF_RC32KCR_FCD           (_U_(0x1) << BSCIF_RC32KCR_FCD_Pos)
+#define BSCIF_RC32KCR_MASK          _U_(0x000000BF) /**< \brief (BSCIF_RC32KCR) MASK Register */
 
 /* -------- BSCIF_RC32KTUNE : (BSCIF Offset: 0x028) (R/W 32) 32kHz RC Oscillator Tuning Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -496,15 +496,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_RC32KTUNE_OFFSET      0x028        /**< \brief (BSCIF_RC32KTUNE offset) 32kHz RC Oscillator Tuning Register */
-#define BSCIF_RC32KTUNE_RESETVALUE  _U(0x00000000); /**< \brief (BSCIF_RC32KTUNE reset_value) 32kHz RC Oscillator Tuning Register */
+#define BSCIF_RC32KTUNE_RESETVALUE  _U_(0x00000000); /**< \brief (BSCIF_RC32KTUNE reset_value) 32kHz RC Oscillator Tuning Register */
 
 #define BSCIF_RC32KTUNE_FINE_Pos    0            /**< \brief (BSCIF_RC32KTUNE) Fine value */
-#define BSCIF_RC32KTUNE_FINE_Msk    (_U(0x3F) << BSCIF_RC32KTUNE_FINE_Pos)
+#define BSCIF_RC32KTUNE_FINE_Msk    (_U_(0x3F) << BSCIF_RC32KTUNE_FINE_Pos)
 #define BSCIF_RC32KTUNE_FINE(value) (BSCIF_RC32KTUNE_FINE_Msk & ((value) << BSCIF_RC32KTUNE_FINE_Pos))
 #define BSCIF_RC32KTUNE_COARSE_Pos  16           /**< \brief (BSCIF_RC32KTUNE) Coarse Value */
-#define BSCIF_RC32KTUNE_COARSE_Msk  (_U(0x7F) << BSCIF_RC32KTUNE_COARSE_Pos)
+#define BSCIF_RC32KTUNE_COARSE_Msk  (_U_(0x7F) << BSCIF_RC32KTUNE_COARSE_Pos)
 #define BSCIF_RC32KTUNE_COARSE(value) (BSCIF_RC32KTUNE_COARSE_Msk & ((value) << BSCIF_RC32KTUNE_COARSE_Pos))
-#define BSCIF_RC32KTUNE_MASK        _U(0x007F003F) /**< \brief (BSCIF_RC32KTUNE) MASK Register */
+#define BSCIF_RC32KTUNE_MASK        _U_(0x007F003F) /**< \brief (BSCIF_RC32KTUNE) MASK Register */
 
 /* -------- BSCIF_BOD33CTRL : (BSCIF Offset: 0x02C) (R/W 32) BOD33 Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -527,19 +527,19 @@ typedef union {
 #define BSCIF_BOD33CTRL_OFFSET      0x02C        /**< \brief (BSCIF_BOD33CTRL offset) BOD33 Control Register */
 
 #define BSCIF_BOD33CTRL_EN_Pos      0            /**< \brief (BSCIF_BOD33CTRL) Enable */
-#define BSCIF_BOD33CTRL_EN          (_U(0x1) << BSCIF_BOD33CTRL_EN_Pos)
+#define BSCIF_BOD33CTRL_EN          (_U_(0x1) << BSCIF_BOD33CTRL_EN_Pos)
 #define BSCIF_BOD33CTRL_HYST_Pos    1            /**< \brief (BSCIF_BOD33CTRL) BOD Hysteresis */
-#define BSCIF_BOD33CTRL_HYST        (_U(0x1) << BSCIF_BOD33CTRL_HYST_Pos)
+#define BSCIF_BOD33CTRL_HYST        (_U_(0x1) << BSCIF_BOD33CTRL_HYST_Pos)
 #define BSCIF_BOD33CTRL_ACTION_Pos  8            /**< \brief (BSCIF_BOD33CTRL) Action */
-#define BSCIF_BOD33CTRL_ACTION_Msk  (_U(0x3) << BSCIF_BOD33CTRL_ACTION_Pos)
+#define BSCIF_BOD33CTRL_ACTION_Msk  (_U_(0x3) << BSCIF_BOD33CTRL_ACTION_Pos)
 #define BSCIF_BOD33CTRL_ACTION(value) (BSCIF_BOD33CTRL_ACTION_Msk & ((value) << BSCIF_BOD33CTRL_ACTION_Pos))
 #define BSCIF_BOD33CTRL_MODE_Pos    16           /**< \brief (BSCIF_BOD33CTRL) Operation modes */
-#define BSCIF_BOD33CTRL_MODE        (_U(0x1) << BSCIF_BOD33CTRL_MODE_Pos)
+#define BSCIF_BOD33CTRL_MODE        (_U_(0x1) << BSCIF_BOD33CTRL_MODE_Pos)
 #define BSCIF_BOD33CTRL_FCD_Pos     30           /**< \brief (BSCIF_BOD33CTRL) BOD Fuse Calibration Done */
-#define BSCIF_BOD33CTRL_FCD         (_U(0x1) << BSCIF_BOD33CTRL_FCD_Pos)
+#define BSCIF_BOD33CTRL_FCD         (_U_(0x1) << BSCIF_BOD33CTRL_FCD_Pos)
 #define BSCIF_BOD33CTRL_SFV_Pos     31           /**< \brief (BSCIF_BOD33CTRL) BOD Control Register Store Final Value */
-#define BSCIF_BOD33CTRL_SFV         (_U(0x1) << BSCIF_BOD33CTRL_SFV_Pos)
-#define BSCIF_BOD33CTRL_MASK        _U(0xC0010303) /**< \brief (BSCIF_BOD33CTRL) MASK Register */
+#define BSCIF_BOD33CTRL_SFV         (_U_(0x1) << BSCIF_BOD33CTRL_SFV_Pos)
+#define BSCIF_BOD33CTRL_MASK        _U_(0xC0010303) /**< \brief (BSCIF_BOD33CTRL) MASK Register */
 
 /* -------- BSCIF_BOD33LEVEL : (BSCIF Offset: 0x030) (R/W 32) BOD33 Level Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -553,12 +553,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_BOD33LEVEL_OFFSET     0x030        /**< \brief (BSCIF_BOD33LEVEL offset) BOD33 Level Register */
-#define BSCIF_BOD33LEVEL_RESETVALUE _U(0x00000000); /**< \brief (BSCIF_BOD33LEVEL reset_value) BOD33 Level Register */
+#define BSCIF_BOD33LEVEL_RESETVALUE _U_(0x00000000); /**< \brief (BSCIF_BOD33LEVEL reset_value) BOD33 Level Register */
 
 #define BSCIF_BOD33LEVEL_VAL_Pos    0            /**< \brief (BSCIF_BOD33LEVEL) BOD Value */
-#define BSCIF_BOD33LEVEL_VAL_Msk    (_U(0x3F) << BSCIF_BOD33LEVEL_VAL_Pos)
+#define BSCIF_BOD33LEVEL_VAL_Msk    (_U_(0x3F) << BSCIF_BOD33LEVEL_VAL_Pos)
 #define BSCIF_BOD33LEVEL_VAL(value) (BSCIF_BOD33LEVEL_VAL_Msk & ((value) << BSCIF_BOD33LEVEL_VAL_Pos))
-#define BSCIF_BOD33LEVEL_MASK       _U(0x0000003F) /**< \brief (BSCIF_BOD33LEVEL) MASK Register */
+#define BSCIF_BOD33LEVEL_MASK       _U_(0x0000003F) /**< \brief (BSCIF_BOD33LEVEL) MASK Register */
 
 /* -------- BSCIF_BOD33SAMPLING : (BSCIF Offset: 0x034) (R/W 32) BOD33 Sampling Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -575,16 +575,16 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_BOD33SAMPLING_OFFSET  0x034        /**< \brief (BSCIF_BOD33SAMPLING offset) BOD33 Sampling Control Register */
-#define BSCIF_BOD33SAMPLING_RESETVALUE _U(0x00000000); /**< \brief (BSCIF_BOD33SAMPLING reset_value) BOD33 Sampling Control Register */
+#define BSCIF_BOD33SAMPLING_RESETVALUE _U_(0x00000000); /**< \brief (BSCIF_BOD33SAMPLING reset_value) BOD33 Sampling Control Register */
 
 #define BSCIF_BOD33SAMPLING_CEN_Pos 0            /**< \brief (BSCIF_BOD33SAMPLING) Clock Enable */
-#define BSCIF_BOD33SAMPLING_CEN     (_U(0x1) << BSCIF_BOD33SAMPLING_CEN_Pos)
+#define BSCIF_BOD33SAMPLING_CEN     (_U_(0x1) << BSCIF_BOD33SAMPLING_CEN_Pos)
 #define BSCIF_BOD33SAMPLING_CSSEL_Pos 1            /**< \brief (BSCIF_BOD33SAMPLING) Clock Source Select */
-#define BSCIF_BOD33SAMPLING_CSSEL   (_U(0x1) << BSCIF_BOD33SAMPLING_CSSEL_Pos)
+#define BSCIF_BOD33SAMPLING_CSSEL   (_U_(0x1) << BSCIF_BOD33SAMPLING_CSSEL_Pos)
 #define BSCIF_BOD33SAMPLING_PSEL_Pos 8            /**< \brief (BSCIF_BOD33SAMPLING) Prescaler Select */
-#define BSCIF_BOD33SAMPLING_PSEL_Msk (_U(0xF) << BSCIF_BOD33SAMPLING_PSEL_Pos)
+#define BSCIF_BOD33SAMPLING_PSEL_Msk (_U_(0xF) << BSCIF_BOD33SAMPLING_PSEL_Pos)
 #define BSCIF_BOD33SAMPLING_PSEL(value) (BSCIF_BOD33SAMPLING_PSEL_Msk & ((value) << BSCIF_BOD33SAMPLING_PSEL_Pos))
-#define BSCIF_BOD33SAMPLING_MASK    _U(0x00000F03) /**< \brief (BSCIF_BOD33SAMPLING) MASK Register */
+#define BSCIF_BOD33SAMPLING_MASK    _U_(0x00000F03) /**< \brief (BSCIF_BOD33SAMPLING) MASK Register */
 
 /* -------- BSCIF_BOD18CTRL : (BSCIF Offset: 0x038) (R/W 32) BOD18 Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -605,22 +605,22 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_BOD18CTRL_OFFSET      0x038        /**< \brief (BSCIF_BOD18CTRL offset) BOD18 Control Register */
-#define BSCIF_BOD18CTRL_RESETVALUE  _U(0x00000000); /**< \brief (BSCIF_BOD18CTRL reset_value) BOD18 Control Register */
+#define BSCIF_BOD18CTRL_RESETVALUE  _U_(0x00000000); /**< \brief (BSCIF_BOD18CTRL reset_value) BOD18 Control Register */
 
 #define BSCIF_BOD18CTRL_EN_Pos      0            /**< \brief (BSCIF_BOD18CTRL) Enable */
-#define BSCIF_BOD18CTRL_EN          (_U(0x1) << BSCIF_BOD18CTRL_EN_Pos)
+#define BSCIF_BOD18CTRL_EN          (_U_(0x1) << BSCIF_BOD18CTRL_EN_Pos)
 #define BSCIF_BOD18CTRL_HYST_Pos    1            /**< \brief (BSCIF_BOD18CTRL) BOD Hysteresis */
-#define BSCIF_BOD18CTRL_HYST        (_U(0x1) << BSCIF_BOD18CTRL_HYST_Pos)
+#define BSCIF_BOD18CTRL_HYST        (_U_(0x1) << BSCIF_BOD18CTRL_HYST_Pos)
 #define BSCIF_BOD18CTRL_ACTION_Pos  8            /**< \brief (BSCIF_BOD18CTRL) Action */
-#define BSCIF_BOD18CTRL_ACTION_Msk  (_U(0x3) << BSCIF_BOD18CTRL_ACTION_Pos)
+#define BSCIF_BOD18CTRL_ACTION_Msk  (_U_(0x3) << BSCIF_BOD18CTRL_ACTION_Pos)
 #define BSCIF_BOD18CTRL_ACTION(value) (BSCIF_BOD18CTRL_ACTION_Msk & ((value) << BSCIF_BOD18CTRL_ACTION_Pos))
 #define BSCIF_BOD18CTRL_MODE_Pos    16           /**< \brief (BSCIF_BOD18CTRL) Operation modes */
-#define BSCIF_BOD18CTRL_MODE        (_U(0x1) << BSCIF_BOD18CTRL_MODE_Pos)
+#define BSCIF_BOD18CTRL_MODE        (_U_(0x1) << BSCIF_BOD18CTRL_MODE_Pos)
 #define BSCIF_BOD18CTRL_FCD_Pos     30           /**< \brief (BSCIF_BOD18CTRL) BOD Fuse Calibration Done */
-#define BSCIF_BOD18CTRL_FCD         (_U(0x1) << BSCIF_BOD18CTRL_FCD_Pos)
+#define BSCIF_BOD18CTRL_FCD         (_U_(0x1) << BSCIF_BOD18CTRL_FCD_Pos)
 #define BSCIF_BOD18CTRL_SFV_Pos     31           /**< \brief (BSCIF_BOD18CTRL) BOD Control Register Store Final Value */
-#define BSCIF_BOD18CTRL_SFV         (_U(0x1) << BSCIF_BOD18CTRL_SFV_Pos)
-#define BSCIF_BOD18CTRL_MASK        _U(0xC0010303) /**< \brief (BSCIF_BOD18CTRL) MASK Register */
+#define BSCIF_BOD18CTRL_SFV         (_U_(0x1) << BSCIF_BOD18CTRL_SFV_Pos)
+#define BSCIF_BOD18CTRL_MASK        _U_(0xC0010303) /**< \brief (BSCIF_BOD18CTRL) MASK Register */
 
 /* -------- BSCIF_BOD18LEVEL : (BSCIF Offset: 0x03C) (R/W 32) BOD18 Level Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -635,14 +635,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_BOD18LEVEL_OFFSET     0x03C        /**< \brief (BSCIF_BOD18LEVEL offset) BOD18 Level Register */
-#define BSCIF_BOD18LEVEL_RESETVALUE _U(0x00000000); /**< \brief (BSCIF_BOD18LEVEL reset_value) BOD18 Level Register */
+#define BSCIF_BOD18LEVEL_RESETVALUE _U_(0x00000000); /**< \brief (BSCIF_BOD18LEVEL reset_value) BOD18 Level Register */
 
 #define BSCIF_BOD18LEVEL_VAL_Pos    0            /**< \brief (BSCIF_BOD18LEVEL) BOD Value */
-#define BSCIF_BOD18LEVEL_VAL_Msk    (_U(0x3F) << BSCIF_BOD18LEVEL_VAL_Pos)
+#define BSCIF_BOD18LEVEL_VAL_Msk    (_U_(0x3F) << BSCIF_BOD18LEVEL_VAL_Pos)
 #define BSCIF_BOD18LEVEL_VAL(value) (BSCIF_BOD18LEVEL_VAL_Msk & ((value) << BSCIF_BOD18LEVEL_VAL_Pos))
 #define BSCIF_BOD18LEVEL_RANGE_Pos  31           /**< \brief (BSCIF_BOD18LEVEL) BOD Threshold Range */
-#define BSCIF_BOD18LEVEL_RANGE      (_U(0x1) << BSCIF_BOD18LEVEL_RANGE_Pos)
-#define BSCIF_BOD18LEVEL_MASK       _U(0x8000003F) /**< \brief (BSCIF_BOD18LEVEL) MASK Register */
+#define BSCIF_BOD18LEVEL_RANGE      (_U_(0x1) << BSCIF_BOD18LEVEL_RANGE_Pos)
+#define BSCIF_BOD18LEVEL_MASK       _U_(0x8000003F) /**< \brief (BSCIF_BOD18LEVEL) MASK Register */
 
 /* -------- BSCIF_VREGCR : (BSCIF Offset: 0x044) (R/W 32) Voltage Regulator Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -661,19 +661,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_VREGCR_OFFSET         0x044        /**< \brief (BSCIF_VREGCR offset) Voltage Regulator Configuration Register */
-#define BSCIF_VREGCR_RESETVALUE     _U(0x00000000); /**< \brief (BSCIF_VREGCR reset_value) Voltage Regulator Configuration Register */
+#define BSCIF_VREGCR_RESETVALUE     _U_(0x00000000); /**< \brief (BSCIF_VREGCR reset_value) Voltage Regulator Configuration Register */
 
 #define BSCIF_VREGCR_DIS_Pos        0            /**< \brief (BSCIF_VREGCR) Voltage Regulator disable */
-#define BSCIF_VREGCR_DIS            (_U(0x1) << BSCIF_VREGCR_DIS_Pos)
+#define BSCIF_VREGCR_DIS            (_U_(0x1) << BSCIF_VREGCR_DIS_Pos)
 #define BSCIF_VREGCR_SSG_Pos        8            /**< \brief (BSCIF_VREGCR) Spread Spectrum Generator Enable */
-#define BSCIF_VREGCR_SSG            (_U(0x1) << BSCIF_VREGCR_SSG_Pos)
+#define BSCIF_VREGCR_SSG            (_U_(0x1) << BSCIF_VREGCR_SSG_Pos)
 #define BSCIF_VREGCR_SSW_Pos        9            /**< \brief (BSCIF_VREGCR) Stop Switching */
-#define BSCIF_VREGCR_SSW            (_U(0x1) << BSCIF_VREGCR_SSW_Pos)
+#define BSCIF_VREGCR_SSW            (_U_(0x1) << BSCIF_VREGCR_SSW_Pos)
 #define BSCIF_VREGCR_SSWEVT_Pos     10           /**< \brief (BSCIF_VREGCR) Stop Switching On Event Enable */
-#define BSCIF_VREGCR_SSWEVT         (_U(0x1) << BSCIF_VREGCR_SSWEVT_Pos)
+#define BSCIF_VREGCR_SSWEVT         (_U_(0x1) << BSCIF_VREGCR_SSWEVT_Pos)
 #define BSCIF_VREGCR_SFV_Pos        31           /**< \brief (BSCIF_VREGCR) Store Final Value */
-#define BSCIF_VREGCR_SFV            (_U(0x1) << BSCIF_VREGCR_SFV_Pos)
-#define BSCIF_VREGCR_MASK           _U(0x80000701) /**< \brief (BSCIF_VREGCR) MASK Register */
+#define BSCIF_VREGCR_SFV            (_U_(0x1) << BSCIF_VREGCR_SFV_Pos)
+#define BSCIF_VREGCR_MASK           _U_(0x80000701) /**< \brief (BSCIF_VREGCR) MASK Register */
 
 /* -------- BSCIF_VREGNCSR : (BSCIF Offset: 0x04C) (R/W 32) Normal Mode Control and Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -683,9 +683,9 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_VREGNCSR_OFFSET       0x04C        /**< \brief (BSCIF_VREGNCSR offset) Normal Mode Control and Status Register */
-#define BSCIF_VREGNCSR_RESETVALUE   _U(0x00000000); /**< \brief (BSCIF_VREGNCSR reset_value) Normal Mode Control and Status Register */
+#define BSCIF_VREGNCSR_RESETVALUE   _U_(0x00000000); /**< \brief (BSCIF_VREGNCSR reset_value) Normal Mode Control and Status Register */
 
-#define BSCIF_VREGNCSR_MASK         _U(0x00000000) /**< \brief (BSCIF_VREGNCSR) MASK Register */
+#define BSCIF_VREGNCSR_MASK         _U_(0x00000000) /**< \brief (BSCIF_VREGNCSR) MASK Register */
 
 /* -------- BSCIF_VREGLPCSR : (BSCIF Offset: 0x050) (R/W 32) LP Mode Control and Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -695,9 +695,9 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_VREGLPCSR_OFFSET      0x050        /**< \brief (BSCIF_VREGLPCSR offset) LP Mode Control and Status Register */
-#define BSCIF_VREGLPCSR_RESETVALUE  _U(0x00000000); /**< \brief (BSCIF_VREGLPCSR reset_value) LP Mode Control and Status Register */
+#define BSCIF_VREGLPCSR_RESETVALUE  _U_(0x00000000); /**< \brief (BSCIF_VREGLPCSR reset_value) LP Mode Control and Status Register */
 
-#define BSCIF_VREGLPCSR_MASK        _U(0x00000000) /**< \brief (BSCIF_VREGLPCSR) MASK Register */
+#define BSCIF_VREGLPCSR_MASK        _U_(0x00000000) /**< \brief (BSCIF_VREGLPCSR) MASK Register */
 
 /* -------- BSCIF_RC1MCR : (BSCIF Offset: 0x058) (R/W 32) 1MHz RC Clock Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -714,16 +714,16 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_RC1MCR_OFFSET         0x058        /**< \brief (BSCIF_RC1MCR offset) 1MHz RC Clock Configuration Register */
-#define BSCIF_RC1MCR_RESETVALUE     _U(0x00000F00); /**< \brief (BSCIF_RC1MCR reset_value) 1MHz RC Clock Configuration Register */
+#define BSCIF_RC1MCR_RESETVALUE     _U_(0x00000F00); /**< \brief (BSCIF_RC1MCR reset_value) 1MHz RC Clock Configuration Register */
 
 #define BSCIF_RC1MCR_CLKOE_Pos      0            /**< \brief (BSCIF_RC1MCR) 1MHz RC Osc Clock Output Enable */
-#define BSCIF_RC1MCR_CLKOE          (_U(0x1) << BSCIF_RC1MCR_CLKOE_Pos)
+#define BSCIF_RC1MCR_CLKOE          (_U_(0x1) << BSCIF_RC1MCR_CLKOE_Pos)
 #define BSCIF_RC1MCR_FCD_Pos        7            /**< \brief (BSCIF_RC1MCR) Flash Calibration Done */
-#define BSCIF_RC1MCR_FCD            (_U(0x1) << BSCIF_RC1MCR_FCD_Pos)
+#define BSCIF_RC1MCR_FCD            (_U_(0x1) << BSCIF_RC1MCR_FCD_Pos)
 #define BSCIF_RC1MCR_CLKCAL_Pos     8            /**< \brief (BSCIF_RC1MCR) 1MHz RC Osc Calibration */
-#define BSCIF_RC1MCR_CLKCAL_Msk     (_U(0x1F) << BSCIF_RC1MCR_CLKCAL_Pos)
+#define BSCIF_RC1MCR_CLKCAL_Msk     (_U_(0x1F) << BSCIF_RC1MCR_CLKCAL_Pos)
 #define BSCIF_RC1MCR_CLKCAL(value)  (BSCIF_RC1MCR_CLKCAL_Msk & ((value) << BSCIF_RC1MCR_CLKCAL_Pos))
-#define BSCIF_RC1MCR_MASK           _U(0x00001F81) /**< \brief (BSCIF_RC1MCR) MASK Register */
+#define BSCIF_RC1MCR_MASK           _U_(0x00001F81) /**< \brief (BSCIF_RC1MCR) MASK Register */
 
 /* -------- BSCIF_BGCR : (BSCIF Offset: 0x05C) (R/W 32) Bandgap Calibration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -733,9 +733,9 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_BGCR_OFFSET           0x05C        /**< \brief (BSCIF_BGCR offset) Bandgap Calibration Register */
-#define BSCIF_BGCR_RESETVALUE       _U(0x00000000); /**< \brief (BSCIF_BGCR reset_value) Bandgap Calibration Register */
+#define BSCIF_BGCR_RESETVALUE       _U_(0x00000000); /**< \brief (BSCIF_BGCR reset_value) Bandgap Calibration Register */
 
-#define BSCIF_BGCR_MASK             _U(0x00000000) /**< \brief (BSCIF_BGCR) MASK Register */
+#define BSCIF_BGCR_MASK             _U_(0x00000000) /**< \brief (BSCIF_BGCR) MASK Register */
 
 /* -------- BSCIF_BGCTRL : (BSCIF Offset: 0x060) (R/W 32) Bandgap Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -751,20 +751,20 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_BGCTRL_OFFSET         0x060        /**< \brief (BSCIF_BGCTRL offset) Bandgap Control Register */
-#define BSCIF_BGCTRL_RESETVALUE     _U(0x00000000); /**< \brief (BSCIF_BGCTRL reset_value) Bandgap Control Register */
+#define BSCIF_BGCTRL_RESETVALUE     _U_(0x00000000); /**< \brief (BSCIF_BGCTRL reset_value) Bandgap Control Register */
 
 #define BSCIF_BGCTRL_ADCISEL_Pos    0            /**< \brief (BSCIF_BGCTRL) ADC Input Selection */
-#define BSCIF_BGCTRL_ADCISEL_Msk    (_U(0x3) << BSCIF_BGCTRL_ADCISEL_Pos)
+#define BSCIF_BGCTRL_ADCISEL_Msk    (_U_(0x3) << BSCIF_BGCTRL_ADCISEL_Pos)
 #define BSCIF_BGCTRL_ADCISEL(value) (BSCIF_BGCTRL_ADCISEL_Msk & ((value) << BSCIF_BGCTRL_ADCISEL_Pos))
-#define   BSCIF_BGCTRL_ADCISEL_DIS_Val    _U(0x0)   /**< \brief (BSCIF_BGCTRL)  */
-#define   BSCIF_BGCTRL_ADCISEL_VTEMP_Val  _U(0x1)   /**< \brief (BSCIF_BGCTRL)  */
-#define   BSCIF_BGCTRL_ADCISEL_VREF_Val   _U(0x2)   /**< \brief (BSCIF_BGCTRL)  */
+#define   BSCIF_BGCTRL_ADCISEL_DIS_Val    _U_(0x0)   /**< \brief (BSCIF_BGCTRL)  */
+#define   BSCIF_BGCTRL_ADCISEL_VTEMP_Val  _U_(0x1)   /**< \brief (BSCIF_BGCTRL)  */
+#define   BSCIF_BGCTRL_ADCISEL_VREF_Val   _U_(0x2)   /**< \brief (BSCIF_BGCTRL)  */
 #define BSCIF_BGCTRL_ADCISEL_DIS    (BSCIF_BGCTRL_ADCISEL_DIS_Val  << BSCIF_BGCTRL_ADCISEL_Pos)
 #define BSCIF_BGCTRL_ADCISEL_VTEMP  (BSCIF_BGCTRL_ADCISEL_VTEMP_Val << BSCIF_BGCTRL_ADCISEL_Pos)
 #define BSCIF_BGCTRL_ADCISEL_VREF   (BSCIF_BGCTRL_ADCISEL_VREF_Val << BSCIF_BGCTRL_ADCISEL_Pos)
 #define BSCIF_BGCTRL_TSEN_Pos       8            /**< \brief (BSCIF_BGCTRL) Temperature Sensor Enable */
-#define BSCIF_BGCTRL_TSEN           (_U(0x1) << BSCIF_BGCTRL_TSEN_Pos)
-#define BSCIF_BGCTRL_MASK           _U(0x00000103) /**< \brief (BSCIF_BGCTRL) MASK Register */
+#define BSCIF_BGCTRL_TSEN           (_U_(0x1) << BSCIF_BGCTRL_TSEN_Pos)
+#define BSCIF_BGCTRL_MASK           _U_(0x00000103) /**< \brief (BSCIF_BGCTRL) MASK Register */
 
 /* -------- BSCIF_BGSR : (BSCIF Offset: 0x064) (R/  32) Bandgap Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -782,17 +782,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_BGSR_OFFSET           0x064        /**< \brief (BSCIF_BGSR offset) Bandgap Status Register */
-#define BSCIF_BGSR_RESETVALUE       _U(0x00000000); /**< \brief (BSCIF_BGSR reset_value) Bandgap Status Register */
+#define BSCIF_BGSR_RESETVALUE       _U_(0x00000000); /**< \brief (BSCIF_BGSR reset_value) Bandgap Status Register */
 
 #define BSCIF_BGSR_BGBUFRDY_Pos     0            /**< \brief (BSCIF_BGSR) Bandgap Buffer Ready */
-#define BSCIF_BGSR_BGBUFRDY_Msk     (_U(0xFF) << BSCIF_BGSR_BGBUFRDY_Pos)
+#define BSCIF_BGSR_BGBUFRDY_Msk     (_U_(0xFF) << BSCIF_BGSR_BGBUFRDY_Pos)
 #define BSCIF_BGSR_BGBUFRDY(value)  (BSCIF_BGSR_BGBUFRDY_Msk & ((value) << BSCIF_BGSR_BGBUFRDY_Pos))
-#define   BSCIF_BGSR_BGBUFRDY_FLASH_Val   _U(0x1)   /**< \brief (BSCIF_BGSR)  */
-#define   BSCIF_BGSR_BGBUFRDY_PLL_Val     _U(0x2)   /**< \brief (BSCIF_BGSR)  */
-#define   BSCIF_BGSR_BGBUFRDY_VREG_Val    _U(0x4)   /**< \brief (BSCIF_BGSR)  */
-#define   BSCIF_BGSR_BGBUFRDY_BUFRR_Val   _U(0x8)   /**< \brief (BSCIF_BGSR)  */
-#define   BSCIF_BGSR_BGBUFRDY_ADC_Val     _U(0x10)   /**< \brief (BSCIF_BGSR)  */
-#define   BSCIF_BGSR_BGBUFRDY_LCD_Val     _U(0x20)   /**< \brief (BSCIF_BGSR)  */
+#define   BSCIF_BGSR_BGBUFRDY_FLASH_Val   _U_(0x1)   /**< \brief (BSCIF_BGSR)  */
+#define   BSCIF_BGSR_BGBUFRDY_PLL_Val     _U_(0x2)   /**< \brief (BSCIF_BGSR)  */
+#define   BSCIF_BGSR_BGBUFRDY_VREG_Val    _U_(0x4)   /**< \brief (BSCIF_BGSR)  */
+#define   BSCIF_BGSR_BGBUFRDY_BUFRR_Val   _U_(0x8)   /**< \brief (BSCIF_BGSR)  */
+#define   BSCIF_BGSR_BGBUFRDY_ADC_Val     _U_(0x10)   /**< \brief (BSCIF_BGSR)  */
+#define   BSCIF_BGSR_BGBUFRDY_LCD_Val     _U_(0x20)   /**< \brief (BSCIF_BGSR)  */
 #define BSCIF_BGSR_BGBUFRDY_FLASH   (BSCIF_BGSR_BGBUFRDY_FLASH_Val << BSCIF_BGSR_BGBUFRDY_Pos)
 #define BSCIF_BGSR_BGBUFRDY_PLL     (BSCIF_BGSR_BGBUFRDY_PLL_Val   << BSCIF_BGSR_BGBUFRDY_Pos)
 #define BSCIF_BGSR_BGBUFRDY_VREG    (BSCIF_BGSR_BGBUFRDY_VREG_Val  << BSCIF_BGSR_BGBUFRDY_Pos)
@@ -800,13 +800,13 @@ typedef union {
 #define BSCIF_BGSR_BGBUFRDY_ADC     (BSCIF_BGSR_BGBUFRDY_ADC_Val   << BSCIF_BGSR_BGBUFRDY_Pos)
 #define BSCIF_BGSR_BGBUFRDY_LCD     (BSCIF_BGSR_BGBUFRDY_LCD_Val   << BSCIF_BGSR_BGBUFRDY_Pos)
 #define BSCIF_BGSR_BGRDY_Pos        16           /**< \brief (BSCIF_BGSR) Bandgap Voltage Reference Ready */
-#define BSCIF_BGSR_BGRDY            (_U(0x1) << BSCIF_BGSR_BGRDY_Pos)
+#define BSCIF_BGSR_BGRDY            (_U_(0x1) << BSCIF_BGSR_BGRDY_Pos)
 #define BSCIF_BGSR_LPBGRDY_Pos      17           /**< \brief (BSCIF_BGSR) Low Power Bandgap Voltage Reference Ready */
-#define BSCIF_BGSR_LPBGRDY          (_U(0x1) << BSCIF_BGSR_LPBGRDY_Pos)
+#define BSCIF_BGSR_LPBGRDY          (_U_(0x1) << BSCIF_BGSR_LPBGRDY_Pos)
 #define BSCIF_BGSR_VREF_Pos         18           /**< \brief (BSCIF_BGSR) Voltage Reference Used by the System */
-#define BSCIF_BGSR_VREF_Msk         (_U(0x3) << BSCIF_BGSR_VREF_Pos)
+#define BSCIF_BGSR_VREF_Msk         (_U_(0x3) << BSCIF_BGSR_VREF_Pos)
 #define BSCIF_BGSR_VREF(value)      (BSCIF_BGSR_VREF_Msk & ((value) << BSCIF_BGSR_VREF_Pos))
-#define BSCIF_BGSR_MASK             _U(0x000F00FF) /**< \brief (BSCIF_BGSR) MASK Register */
+#define BSCIF_BGSR_MASK             _U_(0x000F00FF) /**< \brief (BSCIF_BGSR) MASK Register */
 
 /* -------- BSCIF_BR : (BSCIF Offset: 0x078) (R/W 32) br Backup Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -816,8 +816,8 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_BR_OFFSET             0x078        /**< \brief (BSCIF_BR offset) Backup Register */
-#define BSCIF_BR_RESETVALUE         _U(0x00000000); /**< \brief (BSCIF_BR reset_value) Backup Register */
-#define BSCIF_BR_MASK               _U(0xFFFFFFFF) /**< \brief (BSCIF_BR) MASK Register */
+#define BSCIF_BR_RESETVALUE         _U_(0x00000000); /**< \brief (BSCIF_BR reset_value) Backup Register */
+#define BSCIF_BR_MASK               _U_(0xFFFFFFFF) /**< \brief (BSCIF_BR) MASK Register */
 
 /* -------- BSCIF_BRIFBVERSION : (BSCIF Offset: 0x3E4) (R/  32) Backup Register Interface Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -833,15 +833,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_BRIFBVERSION_OFFSET   0x3E4        /**< \brief (BSCIF_BRIFBVERSION offset) Backup Register Interface Version Register */
-#define BSCIF_BRIFBVERSION_RESETVALUE _U(0x00000100); /**< \brief (BSCIF_BRIFBVERSION reset_value) Backup Register Interface Version Register */
+#define BSCIF_BRIFBVERSION_RESETVALUE _U_(0x00000100); /**< \brief (BSCIF_BRIFBVERSION reset_value) Backup Register Interface Version Register */
 
 #define BSCIF_BRIFBVERSION_VERSION_Pos 0            /**< \brief (BSCIF_BRIFBVERSION) Version Number */
-#define BSCIF_BRIFBVERSION_VERSION_Msk (_U(0xFFF) << BSCIF_BRIFBVERSION_VERSION_Pos)
+#define BSCIF_BRIFBVERSION_VERSION_Msk (_U_(0xFFF) << BSCIF_BRIFBVERSION_VERSION_Pos)
 #define BSCIF_BRIFBVERSION_VERSION(value) (BSCIF_BRIFBVERSION_VERSION_Msk & ((value) << BSCIF_BRIFBVERSION_VERSION_Pos))
 #define BSCIF_BRIFBVERSION_VARIANT_Pos 16           /**< \brief (BSCIF_BRIFBVERSION) Variant Number */
-#define BSCIF_BRIFBVERSION_VARIANT_Msk (_U(0xF) << BSCIF_BRIFBVERSION_VARIANT_Pos)
+#define BSCIF_BRIFBVERSION_VARIANT_Msk (_U_(0xF) << BSCIF_BRIFBVERSION_VARIANT_Pos)
 #define BSCIF_BRIFBVERSION_VARIANT(value) (BSCIF_BRIFBVERSION_VARIANT_Msk & ((value) << BSCIF_BRIFBVERSION_VARIANT_Pos))
-#define BSCIF_BRIFBVERSION_MASK     _U(0x000F0FFF) /**< \brief (BSCIF_BRIFBVERSION) MASK Register */
+#define BSCIF_BRIFBVERSION_MASK     _U_(0x000F0FFF) /**< \brief (BSCIF_BRIFBVERSION) MASK Register */
 
 /* -------- BSCIF_BGREFIFBVERSION : (BSCIF Offset: 0x3E8) (R/  32) BGREFIFB Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -857,15 +857,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_BGREFIFBVERSION_OFFSET 0x3E8        /**< \brief (BSCIF_BGREFIFBVERSION offset) BGREFIFB Version Register */
-#define BSCIF_BGREFIFBVERSION_RESETVALUE _U(0x00000110); /**< \brief (BSCIF_BGREFIFBVERSION reset_value) BGREFIFB Version Register */
+#define BSCIF_BGREFIFBVERSION_RESETVALUE _U_(0x00000110); /**< \brief (BSCIF_BGREFIFBVERSION reset_value) BGREFIFB Version Register */
 
 #define BSCIF_BGREFIFBVERSION_VERSION_Pos 0            /**< \brief (BSCIF_BGREFIFBVERSION) Version Number */
-#define BSCIF_BGREFIFBVERSION_VERSION_Msk (_U(0xFFF) << BSCIF_BGREFIFBVERSION_VERSION_Pos)
+#define BSCIF_BGREFIFBVERSION_VERSION_Msk (_U_(0xFFF) << BSCIF_BGREFIFBVERSION_VERSION_Pos)
 #define BSCIF_BGREFIFBVERSION_VERSION(value) (BSCIF_BGREFIFBVERSION_VERSION_Msk & ((value) << BSCIF_BGREFIFBVERSION_VERSION_Pos))
 #define BSCIF_BGREFIFBVERSION_VARIANT_Pos 16           /**< \brief (BSCIF_BGREFIFBVERSION) Variant Number */
-#define BSCIF_BGREFIFBVERSION_VARIANT_Msk (_U(0xF) << BSCIF_BGREFIFBVERSION_VARIANT_Pos)
+#define BSCIF_BGREFIFBVERSION_VARIANT_Msk (_U_(0xF) << BSCIF_BGREFIFBVERSION_VARIANT_Pos)
 #define BSCIF_BGREFIFBVERSION_VARIANT(value) (BSCIF_BGREFIFBVERSION_VARIANT_Msk & ((value) << BSCIF_BGREFIFBVERSION_VARIANT_Pos))
-#define BSCIF_BGREFIFBVERSION_MASK  _U(0x000F0FFF) /**< \brief (BSCIF_BGREFIFBVERSION) MASK Register */
+#define BSCIF_BGREFIFBVERSION_MASK  _U_(0x000F0FFF) /**< \brief (BSCIF_BGREFIFBVERSION) MASK Register */
 
 /* -------- BSCIF_VREGIFGVERSION : (BSCIF Offset: 0x3EC) (R/  32) VREGIFA Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -881,15 +881,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_VREGIFGVERSION_OFFSET 0x3EC        /**< \brief (BSCIF_VREGIFGVERSION offset) VREGIFA Version Register */
-#define BSCIF_VREGIFGVERSION_RESETVALUE _U(0x00000110); /**< \brief (BSCIF_VREGIFGVERSION reset_value) VREGIFA Version Register */
+#define BSCIF_VREGIFGVERSION_RESETVALUE _U_(0x00000110); /**< \brief (BSCIF_VREGIFGVERSION reset_value) VREGIFA Version Register */
 
 #define BSCIF_VREGIFGVERSION_VERSION_Pos 0            /**< \brief (BSCIF_VREGIFGVERSION) Version Number */
-#define BSCIF_VREGIFGVERSION_VERSION_Msk (_U(0xFFF) << BSCIF_VREGIFGVERSION_VERSION_Pos)
+#define BSCIF_VREGIFGVERSION_VERSION_Msk (_U_(0xFFF) << BSCIF_VREGIFGVERSION_VERSION_Pos)
 #define BSCIF_VREGIFGVERSION_VERSION(value) (BSCIF_VREGIFGVERSION_VERSION_Msk & ((value) << BSCIF_VREGIFGVERSION_VERSION_Pos))
 #define BSCIF_VREGIFGVERSION_VARIANT_Pos 16           /**< \brief (BSCIF_VREGIFGVERSION) Variant Number */
-#define BSCIF_VREGIFGVERSION_VARIANT_Msk (_U(0xF) << BSCIF_VREGIFGVERSION_VARIANT_Pos)
+#define BSCIF_VREGIFGVERSION_VARIANT_Msk (_U_(0xF) << BSCIF_VREGIFGVERSION_VARIANT_Pos)
 #define BSCIF_VREGIFGVERSION_VARIANT(value) (BSCIF_VREGIFGVERSION_VARIANT_Msk & ((value) << BSCIF_VREGIFGVERSION_VARIANT_Pos))
-#define BSCIF_VREGIFGVERSION_MASK   _U(0x000F0FFF) /**< \brief (BSCIF_VREGIFGVERSION) MASK Register */
+#define BSCIF_VREGIFGVERSION_MASK   _U_(0x000F0FFF) /**< \brief (BSCIF_VREGIFGVERSION) MASK Register */
 
 /* -------- BSCIF_BODIFCVERSION : (BSCIF Offset: 0x3F0) (R/  32) BODIFC Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -905,15 +905,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_BODIFCVERSION_OFFSET  0x3F0        /**< \brief (BSCIF_BODIFCVERSION offset) BODIFC Version Register */
-#define BSCIF_BODIFCVERSION_RESETVALUE _U(0x00000110); /**< \brief (BSCIF_BODIFCVERSION reset_value) BODIFC Version Register */
+#define BSCIF_BODIFCVERSION_RESETVALUE _U_(0x00000110); /**< \brief (BSCIF_BODIFCVERSION reset_value) BODIFC Version Register */
 
 #define BSCIF_BODIFCVERSION_VERSION_Pos 0            /**< \brief (BSCIF_BODIFCVERSION) Version Number */
-#define BSCIF_BODIFCVERSION_VERSION_Msk (_U(0xFFF) << BSCIF_BODIFCVERSION_VERSION_Pos)
+#define BSCIF_BODIFCVERSION_VERSION_Msk (_U_(0xFFF) << BSCIF_BODIFCVERSION_VERSION_Pos)
 #define BSCIF_BODIFCVERSION_VERSION(value) (BSCIF_BODIFCVERSION_VERSION_Msk & ((value) << BSCIF_BODIFCVERSION_VERSION_Pos))
 #define BSCIF_BODIFCVERSION_VARIANT_Pos 16           /**< \brief (BSCIF_BODIFCVERSION) Variant Number */
-#define BSCIF_BODIFCVERSION_VARIANT_Msk (_U(0xF) << BSCIF_BODIFCVERSION_VARIANT_Pos)
+#define BSCIF_BODIFCVERSION_VARIANT_Msk (_U_(0xF) << BSCIF_BODIFCVERSION_VARIANT_Pos)
 #define BSCIF_BODIFCVERSION_VARIANT(value) (BSCIF_BODIFCVERSION_VARIANT_Msk & ((value) << BSCIF_BODIFCVERSION_VARIANT_Pos))
-#define BSCIF_BODIFCVERSION_MASK    _U(0x000F0FFF) /**< \brief (BSCIF_BODIFCVERSION) MASK Register */
+#define BSCIF_BODIFCVERSION_MASK    _U_(0x000F0FFF) /**< \brief (BSCIF_BODIFCVERSION) MASK Register */
 
 /* -------- BSCIF_RC32KIFBVERSION : (BSCIF Offset: 0x3F4) (R/  32) 32 kHz RC Oscillator Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -929,15 +929,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_RC32KIFBVERSION_OFFSET 0x3F4        /**< \brief (BSCIF_RC32KIFBVERSION offset) 32 kHz RC Oscillator Version Register */
-#define BSCIF_RC32KIFBVERSION_RESETVALUE _U(0x00000100); /**< \brief (BSCIF_RC32KIFBVERSION reset_value) 32 kHz RC Oscillator Version Register */
+#define BSCIF_RC32KIFBVERSION_RESETVALUE _U_(0x00000100); /**< \brief (BSCIF_RC32KIFBVERSION reset_value) 32 kHz RC Oscillator Version Register */
 
 #define BSCIF_RC32KIFBVERSION_VERSION_Pos 0            /**< \brief (BSCIF_RC32KIFBVERSION) Version number */
-#define BSCIF_RC32KIFBVERSION_VERSION_Msk (_U(0xFFF) << BSCIF_RC32KIFBVERSION_VERSION_Pos)
+#define BSCIF_RC32KIFBVERSION_VERSION_Msk (_U_(0xFFF) << BSCIF_RC32KIFBVERSION_VERSION_Pos)
 #define BSCIF_RC32KIFBVERSION_VERSION(value) (BSCIF_RC32KIFBVERSION_VERSION_Msk & ((value) << BSCIF_RC32KIFBVERSION_VERSION_Pos))
 #define BSCIF_RC32KIFBVERSION_VARIANT_Pos 16           /**< \brief (BSCIF_RC32KIFBVERSION) Variant number */
-#define BSCIF_RC32KIFBVERSION_VARIANT_Msk (_U(0xF) << BSCIF_RC32KIFBVERSION_VARIANT_Pos)
+#define BSCIF_RC32KIFBVERSION_VARIANT_Msk (_U_(0xF) << BSCIF_RC32KIFBVERSION_VARIANT_Pos)
 #define BSCIF_RC32KIFBVERSION_VARIANT(value) (BSCIF_RC32KIFBVERSION_VARIANT_Msk & ((value) << BSCIF_RC32KIFBVERSION_VARIANT_Pos))
-#define BSCIF_RC32KIFBVERSION_MASK  _U(0x000F0FFF) /**< \brief (BSCIF_RC32KIFBVERSION) MASK Register */
+#define BSCIF_RC32KIFBVERSION_MASK  _U_(0x000F0FFF) /**< \brief (BSCIF_RC32KIFBVERSION) MASK Register */
 
 /* -------- BSCIF_OSC32IFAVERSION : (BSCIF Offset: 0x3F8) (R/  32) 32 KHz Oscillator Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -953,15 +953,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_OSC32IFAVERSION_OFFSET 0x3F8        /**< \brief (BSCIF_OSC32IFAVERSION offset) 32 KHz Oscillator Version Register */
-#define BSCIF_OSC32IFAVERSION_RESETVALUE _U(0x00000200); /**< \brief (BSCIF_OSC32IFAVERSION reset_value) 32 KHz Oscillator Version Register */
+#define BSCIF_OSC32IFAVERSION_RESETVALUE _U_(0x00000200); /**< \brief (BSCIF_OSC32IFAVERSION reset_value) 32 KHz Oscillator Version Register */
 
 #define BSCIF_OSC32IFAVERSION_VERSION_Pos 0            /**< \brief (BSCIF_OSC32IFAVERSION) Version number */
-#define BSCIF_OSC32IFAVERSION_VERSION_Msk (_U(0xFFF) << BSCIF_OSC32IFAVERSION_VERSION_Pos)
+#define BSCIF_OSC32IFAVERSION_VERSION_Msk (_U_(0xFFF) << BSCIF_OSC32IFAVERSION_VERSION_Pos)
 #define BSCIF_OSC32IFAVERSION_VERSION(value) (BSCIF_OSC32IFAVERSION_VERSION_Msk & ((value) << BSCIF_OSC32IFAVERSION_VERSION_Pos))
 #define BSCIF_OSC32IFAVERSION_VARIANT_Pos 16           /**< \brief (BSCIF_OSC32IFAVERSION) Variant nubmer */
-#define BSCIF_OSC32IFAVERSION_VARIANT_Msk (_U(0xF) << BSCIF_OSC32IFAVERSION_VARIANT_Pos)
+#define BSCIF_OSC32IFAVERSION_VARIANT_Msk (_U_(0xF) << BSCIF_OSC32IFAVERSION_VARIANT_Pos)
 #define BSCIF_OSC32IFAVERSION_VARIANT(value) (BSCIF_OSC32IFAVERSION_VARIANT_Msk & ((value) << BSCIF_OSC32IFAVERSION_VARIANT_Pos))
-#define BSCIF_OSC32IFAVERSION_MASK  _U(0x000F0FFF) /**< \brief (BSCIF_OSC32IFAVERSION) MASK Register */
+#define BSCIF_OSC32IFAVERSION_MASK  _U_(0x000F0FFF) /**< \brief (BSCIF_OSC32IFAVERSION) MASK Register */
 
 /* -------- BSCIF_VERSION : (BSCIF Offset: 0x3FC) (R/  32) BSCIF Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -977,15 +977,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define BSCIF_VERSION_OFFSET        0x3FC        /**< \brief (BSCIF_VERSION offset) BSCIF Version Register */
-#define BSCIF_VERSION_RESETVALUE    _U(0x00000100); /**< \brief (BSCIF_VERSION reset_value) BSCIF Version Register */
+#define BSCIF_VERSION_RESETVALUE    _U_(0x00000100); /**< \brief (BSCIF_VERSION reset_value) BSCIF Version Register */
 
 #define BSCIF_VERSION_VERSION_Pos   0            /**< \brief (BSCIF_VERSION) Version Number */
-#define BSCIF_VERSION_VERSION_Msk   (_U(0xFFF) << BSCIF_VERSION_VERSION_Pos)
+#define BSCIF_VERSION_VERSION_Msk   (_U_(0xFFF) << BSCIF_VERSION_VERSION_Pos)
 #define BSCIF_VERSION_VERSION(value) (BSCIF_VERSION_VERSION_Msk & ((value) << BSCIF_VERSION_VERSION_Pos))
 #define BSCIF_VERSION_VARIANT_Pos   16           /**< \brief (BSCIF_VERSION) Variant Number */
-#define BSCIF_VERSION_VARIANT_Msk   (_U(0xF) << BSCIF_VERSION_VARIANT_Pos)
+#define BSCIF_VERSION_VARIANT_Msk   (_U_(0xF) << BSCIF_VERSION_VARIANT_Pos)
 #define BSCIF_VERSION_VARIANT(value) (BSCIF_VERSION_VARIANT_Msk & ((value) << BSCIF_VERSION_VARIANT_Pos))
-#define BSCIF_VERSION_MASK          _U(0x000F0FFF) /**< \brief (BSCIF_VERSION) MASK Register */
+#define BSCIF_VERSION_MASK          _U_(0x000F0FFF) /**< \brief (BSCIF_VERSION) MASK Register */
 
 /** \brief BscifBr hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/catb.h
+++ b/asf/sam/include/sam4l/component/catb.h
@@ -569,61 +569,32 @@ typedef union {
 
 /** \brief CATB hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __IO CATB_CR_Type              CR;          /**< \brief Offset: 0x00 (R/W 32) Control Register */
-  __IO CATB_CNTCR_Type           CNTCR;       /**< \brief Offset: 0x04 (R/W 32) Counter Control Register */
-  __IO CATB_IDLE_Type            IDLE;        /**< \brief Offset: 0x08 (R/W 32) Sensor Idle Level */
-  __I  CATB_LEVEL_Type           LEVEL;       /**< \brief Offset: 0x0C (R/  32) Sensor Relative Level */
-  __I  CATB_RAW_Type             RAW;         /**< \brief Offset: 0x10 (R/  32) Sensor Raw Value */
-  __IO CATB_TIMING_Type          TIMING;      /**< \brief Offset: 0x14 (R/W 32) Filter Timing Register */
-  __IO CATB_THRESH_Type          THRESH;      /**< \brief Offset: 0x18 (R/W 32) Threshold Register */
-  __IO CATB_PINSEL_Type          PINSEL;      /**< \brief Offset: 0x1C (R/W 32) Pin Selection Register */
-  __IO CATB_DMA_Type             DMA;         /**< \brief Offset: 0x20 (R/W 32) Direct Memory Access Register */
-  __I  CATB_ISR_Type             ISR;         /**< \brief Offset: 0x24 (R/  32) Interrupt Status Register */
-  __O  CATB_IER_Type             IER;         /**< \brief Offset: 0x28 ( /W 32) Interrupt Enable Register */
-  __O  CATB_IDR_Type             IDR;         /**< \brief Offset: 0x2C ( /W 32) Interrupt Disable Register */
-  __I  CATB_IMR_Type             IMR;         /**< \brief Offset: 0x30 (R/  32) Interrupt Mask Register */
-  __O  CATB_SCR_Type             SCR;         /**< \brief Offset: 0x34 ( /W 32) Status Clear Register */
-       RoReg8                    Reserved1[0x8];
-       CatbIntch                 Intch[1];    /**< \brief Offset: 0x40 CatbIntch groups [STATUS_REG_NUMBER] */
-       RoReg8                    Reserved2[0xC];
-       CatbIntchclr              Intchclr[1]; /**< \brief Offset: 0x50 CatbIntchclr groups [STATUS_REG_NUMBER] */
-       RoReg8                    Reserved3[0xC];
-       CatbOuttch                Outtch[1];   /**< \brief Offset: 0x60 CatbOuttch groups [STATUS_REG_NUMBER] */
-       RoReg8                    Reserved4[0xC];
-       CatbOuttchclr             Outtchclr[1]; /**< \brief Offset: 0x70 CatbOuttchclr groups [STATUS_REG_NUMBER] */
-       RoReg8                    Reserved5[0x84];
-  __I  CATB_PARAMETER_Type       PARAMETER;   /**< \brief Offset: 0xF8 (R/  32) Parameter Register */
-  __I  CATB_VERSION_Type         VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
- } bf;
- struct {
-  RwReg   CATB_CR;            /**< \brief (CATB Offset: 0x00) Control Register */
-  RwReg   CATB_CNTCR;         /**< \brief (CATB Offset: 0x04) Counter Control Register */
-  RwReg   CATB_IDLE;          /**< \brief (CATB Offset: 0x08) Sensor Idle Level */
-  RoReg   CATB_LEVEL;         /**< \brief (CATB Offset: 0x0C) Sensor Relative Level */
-  RoReg   CATB_RAW;           /**< \brief (CATB Offset: 0x10) Sensor Raw Value */
-  RwReg   CATB_TIMING;        /**< \brief (CATB Offset: 0x14) Filter Timing Register */
-  RwReg   CATB_THRESH;        /**< \brief (CATB Offset: 0x18) Threshold Register */
-  RwReg   CATB_PINSEL;        /**< \brief (CATB Offset: 0x1C) Pin Selection Register */
-  RwReg   CATB_DMA;           /**< \brief (CATB Offset: 0x20) Direct Memory Access Register */
-  RoReg   CATB_ISR;           /**< \brief (CATB Offset: 0x24) Interrupt Status Register */
-  WoReg   CATB_IER;           /**< \brief (CATB Offset: 0x28) Interrupt Enable Register */
-  WoReg   CATB_IDR;           /**< \brief (CATB Offset: 0x2C) Interrupt Disable Register */
-  RoReg   CATB_IMR;           /**< \brief (CATB Offset: 0x30) Interrupt Mask Register */
-  WoReg   CATB_SCR;           /**< \brief (CATB Offset: 0x34) Status Clear Register */
-  RoReg8  Reserved6[0x8];
-  CatbIntch CATB_INTCH[1];      /**< \brief (CATB Offset: 0x40) CatbIntch groups [STATUS_REG_NUMBER] */
-  RoReg8  Reserved7[0xC];
-  CatbIntchclr CATB_INTCHCLR[1];   /**< \brief (CATB Offset: 0x50) CatbIntchclr groups [STATUS_REG_NUMBER] */
-  RoReg8  Reserved8[0xC];
-  CatbOuttch CATB_OUTTCH[1];     /**< \brief (CATB Offset: 0x60) CatbOuttch groups [STATUS_REG_NUMBER] */
-  RoReg8  Reserved9[0xC];
-  CatbOuttchclr CATB_OUTTCHCLR[1];  /**< \brief (CATB Offset: 0x70) CatbOuttchclr groups [STATUS_REG_NUMBER] */
-  RoReg8  Reserved10[0x84];
-  RoReg   CATB_PARAMETER;     /**< \brief (CATB Offset: 0xF8) Parameter Register */
-  RoReg   CATB_VERSION;       /**< \brief (CATB Offset: 0xFC) Version Register */
- } reg;
+typedef struct {
+  __IO uint32_t CR;          /**< \brief Offset: 0x00 (R/W 32) Control Register */
+  __IO uint32_t CNTCR;       /**< \brief Offset: 0x04 (R/W 32) Counter Control Register */
+  __IO uint32_t IDLE;        /**< \brief Offset: 0x08 (R/W 32) Sensor Idle Level */
+  __I  uint32_t LEVEL;       /**< \brief Offset: 0x0C (R/  32) Sensor Relative Level */
+  __I  uint32_t RAW;         /**< \brief Offset: 0x10 (R/  32) Sensor Raw Value */
+  __IO uint32_t TIMING;      /**< \brief Offset: 0x14 (R/W 32) Filter Timing Register */
+  __IO uint32_t THRESH;      /**< \brief Offset: 0x18 (R/W 32) Threshold Register */
+  __IO uint32_t PINSEL;      /**< \brief Offset: 0x1C (R/W 32) Pin Selection Register */
+  __IO uint32_t DMA;         /**< \brief Offset: 0x20 (R/W 32) Direct Memory Access Register */
+  __I  uint32_t ISR;         /**< \brief Offset: 0x24 (R/  32) Interrupt Status Register */
+  __O  uint32_t IER;         /**< \brief Offset: 0x28 ( /W 32) Interrupt Enable Register */
+  __O  uint32_t IDR;         /**< \brief Offset: 0x2C ( /W 32) Interrupt Disable Register */
+  __I  uint32_t IMR;         /**< \brief Offset: 0x30 (R/  32) Interrupt Mask Register */
+  __O  uint32_t SCR;         /**< \brief Offset: 0x34 ( /W 32) Status Clear Register */
+       RoReg8   Reserved1[0x8];
+  __I  uint32_t Intch[1];    /**< \brief Offset: 0x40 CatbIntch groups [STATUS_REG_NUMBER] */
+       RoReg8   Reserved2[0xC];
+  __O  uint32_t Intchclr[1]; /**< \brief Offset: 0x50 CatbIntchclr groups [STATUS_REG_NUMBER] */
+       RoReg8   Reserved3[0xC];
+  __I  uint32_t Outtch[1];   /**< \brief Offset: 0x60 CatbOuttch groups [STATUS_REG_NUMBER] */
+       RoReg8   Reserved4[0xC];
+  __O  uint32_t Outtchclr[1]; /**< \brief Offset: 0x70 CatbOuttchclr groups [STATUS_REG_NUMBER] */
+       RoReg8   Reserved5[0x84];
+  __I  uint32_t PARAMETER;   /**< \brief Offset: 0xF8 (R/  32) Parameter Register */
+  __I  uint32_t VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
 } Catb;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/catb.h
+++ b/asf/sam/include/sam4l/component/catb.h
@@ -1,0 +1,632 @@
+/**
+ * \file
+ *
+ * \brief Component description for CATB
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_CATB_COMPONENT_
+#define _SAM4L_CATB_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR CATB */
+/* ========================================================================== */
+/** \addtogroup SAM4L_CATB Capacitive Touch Module B */
+/*@{*/
+
+#define CATB_I7567
+#define REV_CATB                    0x100
+
+/* -------- CATB_CR : (CATB Offset: 0x00) (R/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EN:1;             /*!< bit:      0  Module Enable                      */
+    uint32_t RUN:1;            /*!< bit:      1  Start Operation                    */
+    uint32_t IIDLE:1;          /*!< bit:      2  Initialize Idle Value              */
+    uint32_t ETRIG:1;          /*!< bit:      3  Event Triggered Operation          */
+    uint32_t INTRES:1;         /*!< bit:      4  Internal Resistors                 */
+    uint32_t CKSEL:1;          /*!< bit:      5  Clock Select                       */
+    uint32_t DIFF:1;           /*!< bit:      6  Differential Mode                  */
+    uint32_t DMAEN:1;          /*!< bit:      7  DMA Enable                         */
+    uint32_t ESAMPLES:7;       /*!< bit:  8..14  Number of Event Samples            */
+    uint32_t :1;               /*!< bit:     15  Reserved                           */
+    uint32_t CHARGET:4;        /*!< bit: 16..19  Charge Time                        */
+    uint32_t :11;              /*!< bit: 20..30  Reserved                           */
+    uint32_t SWRST:1;          /*!< bit:     31  Software Reset                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CATB_CR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CATB_CR_OFFSET              0x00         /**< \brief (CATB_CR offset) Control Register */
+#define CATB_CR_RESETVALUE          _U(0x00000000); /**< \brief (CATB_CR reset_value) Control Register */
+
+#define CATB_CR_EN_Pos              0            /**< \brief (CATB_CR) Module Enable */
+#define CATB_CR_EN                  (_U(0x1) << CATB_CR_EN_Pos)
+#define CATB_CR_RUN_Pos             1            /**< \brief (CATB_CR) Start Operation */
+#define CATB_CR_RUN                 (_U(0x1) << CATB_CR_RUN_Pos)
+#define CATB_CR_IIDLE_Pos           2            /**< \brief (CATB_CR) Initialize Idle Value */
+#define CATB_CR_IIDLE               (_U(0x1) << CATB_CR_IIDLE_Pos)
+#define CATB_CR_ETRIG_Pos           3            /**< \brief (CATB_CR) Event Triggered Operation */
+#define CATB_CR_ETRIG               (_U(0x1) << CATB_CR_ETRIG_Pos)
+#define CATB_CR_INTRES_Pos          4            /**< \brief (CATB_CR) Internal Resistors */
+#define CATB_CR_INTRES              (_U(0x1) << CATB_CR_INTRES_Pos)
+#define CATB_CR_CKSEL_Pos           5            /**< \brief (CATB_CR) Clock Select */
+#define CATB_CR_CKSEL               (_U(0x1) << CATB_CR_CKSEL_Pos)
+#define CATB_CR_DIFF_Pos            6            /**< \brief (CATB_CR) Differential Mode */
+#define CATB_CR_DIFF                (_U(0x1) << CATB_CR_DIFF_Pos)
+#define CATB_CR_DMAEN_Pos           7            /**< \brief (CATB_CR) DMA Enable */
+#define CATB_CR_DMAEN               (_U(0x1) << CATB_CR_DMAEN_Pos)
+#define CATB_CR_ESAMPLES_Pos        8            /**< \brief (CATB_CR) Number of Event Samples */
+#define CATB_CR_ESAMPLES_Msk        (_U(0x7F) << CATB_CR_ESAMPLES_Pos)
+#define CATB_CR_ESAMPLES(value)     (CATB_CR_ESAMPLES_Msk & ((value) << CATB_CR_ESAMPLES_Pos))
+#define CATB_CR_CHARGET_Pos         16           /**< \brief (CATB_CR) Charge Time */
+#define CATB_CR_CHARGET_Msk         (_U(0xF) << CATB_CR_CHARGET_Pos)
+#define CATB_CR_CHARGET(value)      (CATB_CR_CHARGET_Msk & ((value) << CATB_CR_CHARGET_Pos))
+#define CATB_CR_SWRST_Pos           31           /**< \brief (CATB_CR) Software Reset */
+#define CATB_CR_SWRST               (_U(0x1) << CATB_CR_SWRST_Pos)
+#define CATB_CR_MASK                _U(0x800F7FFF) /**< \brief (CATB_CR) MASK Register */
+
+/* -------- CATB_CNTCR : (CATB Offset: 0x04) (R/W 32) Counter Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TOP:24;           /*!< bit:  0..23  Counter Top Value                  */
+    uint32_t SPREAD:4;         /*!< bit: 24..27  Spread Spectrum                    */
+    uint32_t REPEAT:3;         /*!< bit: 28..30  Repeat Measurements                */
+    uint32_t :1;               /*!< bit:     31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CATB_CNTCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CATB_CNTCR_OFFSET           0x04         /**< \brief (CATB_CNTCR offset) Counter Control Register */
+#define CATB_CNTCR_RESETVALUE       _U(0x00000000); /**< \brief (CATB_CNTCR reset_value) Counter Control Register */
+
+#define CATB_CNTCR_TOP_Pos          0            /**< \brief (CATB_CNTCR) Counter Top Value */
+#define CATB_CNTCR_TOP_Msk          (_U(0xFFFFFF) << CATB_CNTCR_TOP_Pos)
+#define CATB_CNTCR_TOP(value)       (CATB_CNTCR_TOP_Msk & ((value) << CATB_CNTCR_TOP_Pos))
+#define CATB_CNTCR_SPREAD_Pos       24           /**< \brief (CATB_CNTCR) Spread Spectrum */
+#define CATB_CNTCR_SPREAD_Msk       (_U(0xF) << CATB_CNTCR_SPREAD_Pos)
+#define CATB_CNTCR_SPREAD(value)    (CATB_CNTCR_SPREAD_Msk & ((value) << CATB_CNTCR_SPREAD_Pos))
+#define CATB_CNTCR_REPEAT_Pos       28           /**< \brief (CATB_CNTCR) Repeat Measurements */
+#define CATB_CNTCR_REPEAT_Msk       (_U(0x7) << CATB_CNTCR_REPEAT_Pos)
+#define CATB_CNTCR_REPEAT(value)    (CATB_CNTCR_REPEAT_Msk & ((value) << CATB_CNTCR_REPEAT_Pos))
+#define CATB_CNTCR_MASK             _U(0x7FFFFFFF) /**< \brief (CATB_CNTCR) MASK Register */
+
+/* -------- CATB_IDLE : (CATB Offset: 0x08) (R/W 32) Sensor Idle Level -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t FIDLE:12;         /*!< bit:  0..11  Fractional Sensor Idle             */
+    uint32_t RIDLE:16;         /*!< bit: 12..27  Integer Sensor Idle                */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CATB_IDLE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CATB_IDLE_OFFSET            0x08         /**< \brief (CATB_IDLE offset) Sensor Idle Level */
+#define CATB_IDLE_RESETVALUE        _U(0x00000000); /**< \brief (CATB_IDLE reset_value) Sensor Idle Level */
+
+#define CATB_IDLE_FIDLE_Pos         0            /**< \brief (CATB_IDLE) Fractional Sensor Idle */
+#define CATB_IDLE_FIDLE_Msk         (_U(0xFFF) << CATB_IDLE_FIDLE_Pos)
+#define CATB_IDLE_FIDLE(value)      (CATB_IDLE_FIDLE_Msk & ((value) << CATB_IDLE_FIDLE_Pos))
+#define CATB_IDLE_RIDLE_Pos         12           /**< \brief (CATB_IDLE) Integer Sensor Idle */
+#define CATB_IDLE_RIDLE_Msk         (_U(0xFFFF) << CATB_IDLE_RIDLE_Pos)
+#define CATB_IDLE_RIDLE(value)      (CATB_IDLE_RIDLE_Msk & ((value) << CATB_IDLE_RIDLE_Pos))
+#define CATB_IDLE_MASK              _U(0x0FFFFFFF) /**< \brief (CATB_IDLE) MASK Register */
+
+/* -------- CATB_LEVEL : (CATB Offset: 0x0C) (R/  32) Sensor Relative Level -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t FLEVEL:12;        /*!< bit:  0..11  Fractional Sensor Level            */
+    uint32_t RLEVEL:8;         /*!< bit: 12..19  Integer Sensor Level               */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CATB_LEVEL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CATB_LEVEL_OFFSET           0x0C         /**< \brief (CATB_LEVEL offset) Sensor Relative Level */
+#define CATB_LEVEL_RESETVALUE       _U(0x00000000); /**< \brief (CATB_LEVEL reset_value) Sensor Relative Level */
+
+#define CATB_LEVEL_FLEVEL_Pos       0            /**< \brief (CATB_LEVEL) Fractional Sensor Level */
+#define CATB_LEVEL_FLEVEL_Msk       (_U(0xFFF) << CATB_LEVEL_FLEVEL_Pos)
+#define CATB_LEVEL_FLEVEL(value)    (CATB_LEVEL_FLEVEL_Msk & ((value) << CATB_LEVEL_FLEVEL_Pos))
+#define CATB_LEVEL_RLEVEL_Pos       12           /**< \brief (CATB_LEVEL) Integer Sensor Level */
+#define CATB_LEVEL_RLEVEL_Msk       (_U(0xFF) << CATB_LEVEL_RLEVEL_Pos)
+#define CATB_LEVEL_RLEVEL(value)    (CATB_LEVEL_RLEVEL_Msk & ((value) << CATB_LEVEL_RLEVEL_Pos))
+#define CATB_LEVEL_MASK             _U(0x000FFFFF) /**< \brief (CATB_LEVEL) MASK Register */
+
+/* -------- CATB_RAW : (CATB Offset: 0x10) (R/  32) Sensor Raw Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    uint32_t RAWA:8;           /*!< bit: 16..23  Current Sensor Raw Value           */
+    uint32_t RAWB:8;           /*!< bit: 24..31  Last Sensor Raw Value              */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CATB_RAW_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CATB_RAW_OFFSET             0x10         /**< \brief (CATB_RAW offset) Sensor Raw Value */
+#define CATB_RAW_RESETVALUE         _U(0x00000000); /**< \brief (CATB_RAW reset_value) Sensor Raw Value */
+
+#define CATB_RAW_RAWA_Pos           16           /**< \brief (CATB_RAW) Current Sensor Raw Value */
+#define CATB_RAW_RAWA_Msk           (_U(0xFF) << CATB_RAW_RAWA_Pos)
+#define CATB_RAW_RAWA(value)        (CATB_RAW_RAWA_Msk & ((value) << CATB_RAW_RAWA_Pos))
+#define CATB_RAW_RAWB_Pos           24           /**< \brief (CATB_RAW) Last Sensor Raw Value */
+#define CATB_RAW_RAWB_Msk           (_U(0xFF) << CATB_RAW_RAWB_Pos)
+#define CATB_RAW_RAWB(value)        (CATB_RAW_RAWB_Msk & ((value) << CATB_RAW_RAWB_Pos))
+#define CATB_RAW_MASK               _U(0xFFFF0000) /**< \brief (CATB_RAW) MASK Register */
+
+/* -------- CATB_TIMING : (CATB Offset: 0x14) (R/W 32) Filter Timing Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TLEVEL:12;        /*!< bit:  0..11  Relative Level Smoothing           */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t TIDLE:12;         /*!< bit: 16..27  Idle Smoothening                   */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CATB_TIMING_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CATB_TIMING_OFFSET          0x14         /**< \brief (CATB_TIMING offset) Filter Timing Register */
+#define CATB_TIMING_RESETVALUE      _U(0x00000000); /**< \brief (CATB_TIMING reset_value) Filter Timing Register */
+
+#define CATB_TIMING_TLEVEL_Pos      0            /**< \brief (CATB_TIMING) Relative Level Smoothing */
+#define CATB_TIMING_TLEVEL_Msk      (_U(0xFFF) << CATB_TIMING_TLEVEL_Pos)
+#define CATB_TIMING_TLEVEL(value)   (CATB_TIMING_TLEVEL_Msk & ((value) << CATB_TIMING_TLEVEL_Pos))
+#define CATB_TIMING_TIDLE_Pos       16           /**< \brief (CATB_TIMING) Idle Smoothening */
+#define CATB_TIMING_TIDLE_Msk       (_U(0xFFF) << CATB_TIMING_TIDLE_Pos)
+#define CATB_TIMING_TIDLE(value)    (CATB_TIMING_TIDLE_Msk & ((value) << CATB_TIMING_TIDLE_Pos))
+#define CATB_TIMING_MASK            _U(0x0FFF0FFF) /**< \brief (CATB_TIMING) MASK Register */
+
+/* -------- CATB_THRESH : (CATB Offset: 0x18) (R/W 32) Threshold Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t FTHRESH:12;       /*!< bit:  0..11  Fractional part of Threshold Value */
+    uint32_t RTHRESH:8;        /*!< bit: 12..19  Rational part of Threshold Value   */
+    uint32_t :3;               /*!< bit: 20..22  Reserved                           */
+    uint32_t DIR:1;            /*!< bit:     23  Threshold Direction                */
+    uint32_t LENGTH:5;         /*!< bit: 24..28  Threshold Length                   */
+    uint32_t :3;               /*!< bit: 29..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CATB_THRESH_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CATB_THRESH_OFFSET          0x18         /**< \brief (CATB_THRESH offset) Threshold Register */
+#define CATB_THRESH_RESETVALUE      _U(0x00000000); /**< \brief (CATB_THRESH reset_value) Threshold Register */
+
+#define CATB_THRESH_FTHRESH_Pos     0            /**< \brief (CATB_THRESH) Fractional part of Threshold Value */
+#define CATB_THRESH_FTHRESH_Msk     (_U(0xFFF) << CATB_THRESH_FTHRESH_Pos)
+#define CATB_THRESH_FTHRESH(value)  (CATB_THRESH_FTHRESH_Msk & ((value) << CATB_THRESH_FTHRESH_Pos))
+#define CATB_THRESH_RTHRESH_Pos     12           /**< \brief (CATB_THRESH) Rational part of Threshold Value */
+#define CATB_THRESH_RTHRESH_Msk     (_U(0xFF) << CATB_THRESH_RTHRESH_Pos)
+#define CATB_THRESH_RTHRESH(value)  (CATB_THRESH_RTHRESH_Msk & ((value) << CATB_THRESH_RTHRESH_Pos))
+#define CATB_THRESH_DIR_Pos         23           /**< \brief (CATB_THRESH) Threshold Direction */
+#define CATB_THRESH_DIR             (_U(0x1) << CATB_THRESH_DIR_Pos)
+#define CATB_THRESH_LENGTH_Pos      24           /**< \brief (CATB_THRESH) Threshold Length */
+#define CATB_THRESH_LENGTH_Msk      (_U(0x1F) << CATB_THRESH_LENGTH_Pos)
+#define CATB_THRESH_LENGTH(value)   (CATB_THRESH_LENGTH_Msk & ((value) << CATB_THRESH_LENGTH_Pos))
+#define CATB_THRESH_MASK            _U(0x1F8FFFFF) /**< \brief (CATB_THRESH) MASK Register */
+
+/* -------- CATB_PINSEL : (CATB Offset: 0x1C) (R/W 32) Pin Selection Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PINSEL:8;         /*!< bit:  0.. 7  Pin Select                         */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CATB_PINSEL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CATB_PINSEL_OFFSET          0x1C         /**< \brief (CATB_PINSEL offset) Pin Selection Register */
+#define CATB_PINSEL_RESETVALUE      _U(0x00000000); /**< \brief (CATB_PINSEL reset_value) Pin Selection Register */
+
+#define CATB_PINSEL_PINSEL_Pos      0            /**< \brief (CATB_PINSEL) Pin Select */
+#define CATB_PINSEL_PINSEL_Msk      (_U(0xFF) << CATB_PINSEL_PINSEL_Pos)
+#define CATB_PINSEL_PINSEL(value)   (CATB_PINSEL_PINSEL_Msk & ((value) << CATB_PINSEL_PINSEL_Pos))
+#define CATB_PINSEL_MASK            _U(0x000000FF) /**< \brief (CATB_PINSEL) MASK Register */
+
+/* -------- CATB_DMA : (CATB Offset: 0x20) (R/W 32) Direct Memory Access Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DMA:32;           /*!< bit:  0..31  Direct Memory Access               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CATB_DMA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CATB_DMA_OFFSET             0x20         /**< \brief (CATB_DMA offset) Direct Memory Access Register */
+#define CATB_DMA_RESETVALUE         _U(0x00000000); /**< \brief (CATB_DMA reset_value) Direct Memory Access Register */
+
+#define CATB_DMA_DMA_Pos            0            /**< \brief (CATB_DMA) Direct Memory Access */
+#define CATB_DMA_DMA_Msk            (_U(0xFFFFFFFF) << CATB_DMA_DMA_Pos)
+#define CATB_DMA_DMA(value)         (CATB_DMA_DMA_Msk & ((value) << CATB_DMA_DMA_Pos))
+#define CATB_DMA_MASK               _U(0xFFFFFFFF) /**< \brief (CATB_DMA) MASK Register */
+
+/* -------- CATB_ISR : (CATB Offset: 0x24) (R/  32) Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SAMPLE:1;         /*!< bit:      0  Sample Ready Interrupt Status      */
+    uint32_t INTCH:1;          /*!< bit:      1  In-touch Interrupt Status          */
+    uint32_t OUTTCH:1;         /*!< bit:      2  Out-of-Touch Interrupt Status      */
+    uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CATB_ISR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CATB_ISR_OFFSET             0x24         /**< \brief (CATB_ISR offset) Interrupt Status Register */
+#define CATB_ISR_RESETVALUE         _U(0x00000000); /**< \brief (CATB_ISR reset_value) Interrupt Status Register */
+
+#define CATB_ISR_SAMPLE_Pos         0            /**< \brief (CATB_ISR) Sample Ready Interrupt Status */
+#define CATB_ISR_SAMPLE             (_U(0x1) << CATB_ISR_SAMPLE_Pos)
+#define CATB_ISR_INTCH_Pos          1            /**< \brief (CATB_ISR) In-touch Interrupt Status */
+#define CATB_ISR_INTCH              (_U(0x1) << CATB_ISR_INTCH_Pos)
+#define CATB_ISR_OUTTCH_Pos         2            /**< \brief (CATB_ISR) Out-of-Touch Interrupt Status */
+#define CATB_ISR_OUTTCH             (_U(0x1) << CATB_ISR_OUTTCH_Pos)
+#define CATB_ISR_MASK               _U(0x00000007) /**< \brief (CATB_ISR) MASK Register */
+
+/* -------- CATB_IER : (CATB Offset: 0x28) ( /W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SAMPLE:1;         /*!< bit:      0  Sample Ready Interrupt Enable      */
+    uint32_t INTCH:1;          /*!< bit:      1  In-touch Interrupt Enable          */
+    uint32_t OUTTCH:1;         /*!< bit:      2  Out-of-Touch Interrupt Enable      */
+    uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CATB_IER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CATB_IER_OFFSET             0x28         /**< \brief (CATB_IER offset) Interrupt Enable Register */
+#define CATB_IER_RESETVALUE         _U(0x00000000); /**< \brief (CATB_IER reset_value) Interrupt Enable Register */
+
+#define CATB_IER_SAMPLE_Pos         0            /**< \brief (CATB_IER) Sample Ready Interrupt Enable */
+#define CATB_IER_SAMPLE             (_U(0x1) << CATB_IER_SAMPLE_Pos)
+#define CATB_IER_INTCH_Pos          1            /**< \brief (CATB_IER) In-touch Interrupt Enable */
+#define CATB_IER_INTCH              (_U(0x1) << CATB_IER_INTCH_Pos)
+#define CATB_IER_OUTTCH_Pos         2            /**< \brief (CATB_IER) Out-of-Touch Interrupt Enable */
+#define CATB_IER_OUTTCH             (_U(0x1) << CATB_IER_OUTTCH_Pos)
+#define CATB_IER_MASK               _U(0x00000007) /**< \brief (CATB_IER) MASK Register */
+
+/* -------- CATB_IDR : (CATB Offset: 0x2C) ( /W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SAMPLE:1;         /*!< bit:      0  Sample Ready Interrupt Disable     */
+    uint32_t INTCH:1;          /*!< bit:      1  In-touch Interrupt Disable         */
+    uint32_t OUTTCH:1;         /*!< bit:      2  Out-of-Touch Interrupt Disable     */
+    uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CATB_IDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CATB_IDR_OFFSET             0x2C         /**< \brief (CATB_IDR offset) Interrupt Disable Register */
+#define CATB_IDR_RESETVALUE         _U(0x00000000); /**< \brief (CATB_IDR reset_value) Interrupt Disable Register */
+
+#define CATB_IDR_SAMPLE_Pos         0            /**< \brief (CATB_IDR) Sample Ready Interrupt Disable */
+#define CATB_IDR_SAMPLE             (_U(0x1) << CATB_IDR_SAMPLE_Pos)
+#define CATB_IDR_INTCH_Pos          1            /**< \brief (CATB_IDR) In-touch Interrupt Disable */
+#define CATB_IDR_INTCH              (_U(0x1) << CATB_IDR_INTCH_Pos)
+#define CATB_IDR_OUTTCH_Pos         2            /**< \brief (CATB_IDR) Out-of-Touch Interrupt Disable */
+#define CATB_IDR_OUTTCH             (_U(0x1) << CATB_IDR_OUTTCH_Pos)
+#define CATB_IDR_MASK               _U(0x00000007) /**< \brief (CATB_IDR) MASK Register */
+
+/* -------- CATB_IMR : (CATB Offset: 0x30) (R/  32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SAMPLE:1;         /*!< bit:      0  Sample Ready Interrupt Mask        */
+    uint32_t INTCH:1;          /*!< bit:      1  In-touch Interrupt Mask            */
+    uint32_t OUTTCH:1;         /*!< bit:      2  Out-of-Touch Interrupt Mask        */
+    uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CATB_IMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CATB_IMR_OFFSET             0x30         /**< \brief (CATB_IMR offset) Interrupt Mask Register */
+#define CATB_IMR_RESETVALUE         _U(0x00000000); /**< \brief (CATB_IMR reset_value) Interrupt Mask Register */
+
+#define CATB_IMR_SAMPLE_Pos         0            /**< \brief (CATB_IMR) Sample Ready Interrupt Mask */
+#define CATB_IMR_SAMPLE             (_U(0x1) << CATB_IMR_SAMPLE_Pos)
+#define CATB_IMR_INTCH_Pos          1            /**< \brief (CATB_IMR) In-touch Interrupt Mask */
+#define CATB_IMR_INTCH              (_U(0x1) << CATB_IMR_INTCH_Pos)
+#define CATB_IMR_OUTTCH_Pos         2            /**< \brief (CATB_IMR) Out-of-Touch Interrupt Mask */
+#define CATB_IMR_OUTTCH             (_U(0x1) << CATB_IMR_OUTTCH_Pos)
+#define CATB_IMR_MASK               _U(0x00000007) /**< \brief (CATB_IMR) MASK Register */
+
+/* -------- CATB_SCR : (CATB Offset: 0x34) ( /W 32) Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SAMPLE:1;         /*!< bit:      0  Sample Ready                       */
+    uint32_t INTCH:1;          /*!< bit:      1  In-touch                           */
+    uint32_t OUTTCH:1;         /*!< bit:      2  Out-of-Touch                       */
+    uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CATB_SCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CATB_SCR_OFFSET             0x34         /**< \brief (CATB_SCR offset) Status Clear Register */
+#define CATB_SCR_RESETVALUE         _U(0x00000000); /**< \brief (CATB_SCR reset_value) Status Clear Register */
+
+#define CATB_SCR_SAMPLE_Pos         0            /**< \brief (CATB_SCR) Sample Ready */
+#define CATB_SCR_SAMPLE             (_U(0x1) << CATB_SCR_SAMPLE_Pos)
+#define CATB_SCR_INTCH_Pos          1            /**< \brief (CATB_SCR) In-touch */
+#define CATB_SCR_INTCH              (_U(0x1) << CATB_SCR_INTCH_Pos)
+#define CATB_SCR_OUTTCH_Pos         2            /**< \brief (CATB_SCR) Out-of-Touch */
+#define CATB_SCR_OUTTCH             (_U(0x1) << CATB_SCR_OUTTCH_Pos)
+#define CATB_SCR_MASK               _U(0x00000007) /**< \brief (CATB_SCR) MASK Register */
+
+/* -------- CATB_INTCH : (CATB Offset: 0x40) (R/  32) INTCH In-Touch Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t INTCH:32;         /*!< bit:  0..31  In-Touch                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CATB_INTCH_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CATB_INTCH_OFFSET           0x40         /**< \brief (CATB_INTCH offset) In-Touch Status Register */
+#define CATB_INTCH_RESETVALUE       _U(0x00000000); /**< \brief (CATB_INTCH reset_value) In-Touch Status Register */
+
+#define CATB_INTCH_INTCH_Pos        0            /**< \brief (CATB_INTCH) In-Touch */
+#define CATB_INTCH_INTCH_Msk        (_U(0xFFFFFFFF) << CATB_INTCH_INTCH_Pos)
+#define CATB_INTCH_INTCH(value)     (CATB_INTCH_INTCH_Msk & ((value) << CATB_INTCH_INTCH_Pos))
+#define CATB_INTCH_MASK             _U(0xFFFFFFFF) /**< \brief (CATB_INTCH) MASK Register */
+
+/* -------- CATB_INTCHCLR : (CATB Offset: 0x50) ( /W 32) INTCHCLR In-Touch Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t INTCHCLR:32;      /*!< bit:  0..31  In-Touch Clear                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CATB_INTCHCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CATB_INTCHCLR_OFFSET        0x50         /**< \brief (CATB_INTCHCLR offset) In-Touch Status Clear Register */
+#define CATB_INTCHCLR_RESETVALUE    _U(0x00000000); /**< \brief (CATB_INTCHCLR reset_value) In-Touch Status Clear Register */
+
+#define CATB_INTCHCLR_INTCHCLR_Pos  0            /**< \brief (CATB_INTCHCLR) In-Touch Clear */
+#define CATB_INTCHCLR_INTCHCLR_Msk  (_U(0xFFFFFFFF) << CATB_INTCHCLR_INTCHCLR_Pos)
+#define CATB_INTCHCLR_INTCHCLR(value) (CATB_INTCHCLR_INTCHCLR_Msk & ((value) << CATB_INTCHCLR_INTCHCLR_Pos))
+#define CATB_INTCHCLR_MASK          _U(0xFFFFFFFF) /**< \brief (CATB_INTCHCLR) MASK Register */
+
+/* -------- CATB_OUTTCH : (CATB Offset: 0x60) (R/  32) OUTTCH Out-of-Touch Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OUTTCH:32;        /*!< bit:  0..31  Out-of-Touch                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CATB_OUTTCH_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CATB_OUTTCH_OFFSET          0x60         /**< \brief (CATB_OUTTCH offset) Out-of-Touch Status Register */
+#define CATB_OUTTCH_RESETVALUE      _U(0x00000000); /**< \brief (CATB_OUTTCH reset_value) Out-of-Touch Status Register */
+
+#define CATB_OUTTCH_OUTTCH_Pos      0            /**< \brief (CATB_OUTTCH) Out-of-Touch */
+#define CATB_OUTTCH_OUTTCH_Msk      (_U(0xFFFFFFFF) << CATB_OUTTCH_OUTTCH_Pos)
+#define CATB_OUTTCH_OUTTCH(value)   (CATB_OUTTCH_OUTTCH_Msk & ((value) << CATB_OUTTCH_OUTTCH_Pos))
+#define CATB_OUTTCH_MASK            _U(0xFFFFFFFF) /**< \brief (CATB_OUTTCH) MASK Register */
+
+/* -------- CATB_OUTTCHCLR : (CATB Offset: 0x70) ( /W 32) OUTTCHCLR Out-of-Touch Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OUTTCHCLR:32;     /*!< bit:  0..31  Out of Touch                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CATB_OUTTCHCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CATB_OUTTCHCLR_OFFSET       0x70         /**< \brief (CATB_OUTTCHCLR offset) Out-of-Touch Status Clear Register */
+#define CATB_OUTTCHCLR_RESETVALUE   _U(0x00000000); /**< \brief (CATB_OUTTCHCLR reset_value) Out-of-Touch Status Clear Register */
+
+#define CATB_OUTTCHCLR_OUTTCHCLR_Pos 0            /**< \brief (CATB_OUTTCHCLR) Out of Touch */
+#define CATB_OUTTCHCLR_OUTTCHCLR_Msk (_U(0xFFFFFFFF) << CATB_OUTTCHCLR_OUTTCHCLR_Pos)
+#define CATB_OUTTCHCLR_OUTTCHCLR(value) (CATB_OUTTCHCLR_OUTTCHCLR_Msk & ((value) << CATB_OUTTCHCLR_OUTTCHCLR_Pos))
+#define CATB_OUTTCHCLR_MASK         _U(0xFFFFFFFF) /**< \brief (CATB_OUTTCHCLR) MASK Register */
+
+/* -------- CATB_PARAMETER : (CATB Offset: 0xF8) (R/  32) Parameter Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t NPINS:8;          /*!< bit:  0.. 7  Number of Pins                     */
+    uint32_t NSTATUS:8;        /*!< bit:  8..15  Number of Status bits              */
+    uint32_t FRACTIONAL:4;     /*!< bit: 16..19  Number of Fractional bits          */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CATB_PARAMETER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CATB_PARAMETER_OFFSET       0xF8         /**< \brief (CATB_PARAMETER offset) Parameter Register */
+
+#define CATB_PARAMETER_NPINS_Pos    0            /**< \brief (CATB_PARAMETER) Number of Pins */
+#define CATB_PARAMETER_NPINS_Msk    (_U(0xFF) << CATB_PARAMETER_NPINS_Pos)
+#define CATB_PARAMETER_NPINS(value) (CATB_PARAMETER_NPINS_Msk & ((value) << CATB_PARAMETER_NPINS_Pos))
+#define CATB_PARAMETER_NSTATUS_Pos  8            /**< \brief (CATB_PARAMETER) Number of Status bits */
+#define CATB_PARAMETER_NSTATUS_Msk  (_U(0xFF) << CATB_PARAMETER_NSTATUS_Pos)
+#define CATB_PARAMETER_NSTATUS(value) (CATB_PARAMETER_NSTATUS_Msk & ((value) << CATB_PARAMETER_NSTATUS_Pos))
+#define CATB_PARAMETER_FRACTIONAL_Pos 16           /**< \brief (CATB_PARAMETER) Number of Fractional bits */
+#define CATB_PARAMETER_FRACTIONAL_Msk (_U(0xF) << CATB_PARAMETER_FRACTIONAL_Pos)
+#define CATB_PARAMETER_FRACTIONAL(value) (CATB_PARAMETER_FRACTIONAL_Msk & ((value) << CATB_PARAMETER_FRACTIONAL_Pos))
+#define CATB_PARAMETER_MASK         _U(0x000FFFFF) /**< \brief (CATB_PARAMETER) MASK Register */
+
+/* -------- CATB_VERSION : (CATB Offset: 0xFC) (R/  32) Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CATB_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CATB_VERSION_OFFSET         0xFC         /**< \brief (CATB_VERSION offset) Version Register */
+#define CATB_VERSION_RESETVALUE     _U(0x00000100); /**< \brief (CATB_VERSION reset_value) Version Register */
+
+#define CATB_VERSION_VERSION_Pos    0            /**< \brief (CATB_VERSION) Version number */
+#define CATB_VERSION_VERSION_Msk    (_U(0xFFF) << CATB_VERSION_VERSION_Pos)
+#define CATB_VERSION_VERSION(value) (CATB_VERSION_VERSION_Msk & ((value) << CATB_VERSION_VERSION_Pos))
+#define CATB_VERSION_VARIANT_Pos    16           /**< \brief (CATB_VERSION) Variant number */
+#define CATB_VERSION_VARIANT_Msk    (_U(0xF) << CATB_VERSION_VARIANT_Pos)
+#define CATB_VERSION_VARIANT(value) (CATB_VERSION_VARIANT_Msk & ((value) << CATB_VERSION_VARIANT_Pos))
+#define CATB_VERSION_MASK           _U(0x000F0FFF) /**< \brief (CATB_VERSION) MASK Register */
+
+/** \brief CatbIntch hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __I  CATB_INTCH_Type           INTCH;       /**< \brief Offset: 0x00 (R/  32) In-Touch Status Register */
+ } bf;
+ struct {
+  RoReg   CATB_INTCH;         /**< \brief (CATB Offset: 0x00) In-Touch Status Register */
+ } reg;
+} CatbIntch;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief CatbIntchclr hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __O  CATB_INTCHCLR_Type        INTCHCLR;    /**< \brief Offset: 0x00 ( /W 32) In-Touch Status Clear Register */
+ } bf;
+ struct {
+  WoReg   CATB_INTCHCLR;      /**< \brief (CATB Offset: 0x00) In-Touch Status Clear Register */
+ } reg;
+} CatbIntchclr;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief CatbOuttch hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __I  CATB_OUTTCH_Type          OUTTCH;      /**< \brief Offset: 0x00 (R/  32) Out-of-Touch Status Register */
+ } bf;
+ struct {
+  RoReg   CATB_OUTTCH;        /**< \brief (CATB Offset: 0x00) Out-of-Touch Status Register */
+ } reg;
+} CatbOuttch;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief CatbOuttchclr hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __O  CATB_OUTTCHCLR_Type       OUTTCHCLR;   /**< \brief Offset: 0x00 ( /W 32) Out-of-Touch Status Clear Register */
+ } bf;
+ struct {
+  WoReg   CATB_OUTTCHCLR;     /**< \brief (CATB Offset: 0x00) Out-of-Touch Status Clear Register */
+ } reg;
+} CatbOuttchclr;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief CATB hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __IO CATB_CR_Type              CR;          /**< \brief Offset: 0x00 (R/W 32) Control Register */
+  __IO CATB_CNTCR_Type           CNTCR;       /**< \brief Offset: 0x04 (R/W 32) Counter Control Register */
+  __IO CATB_IDLE_Type            IDLE;        /**< \brief Offset: 0x08 (R/W 32) Sensor Idle Level */
+  __I  CATB_LEVEL_Type           LEVEL;       /**< \brief Offset: 0x0C (R/  32) Sensor Relative Level */
+  __I  CATB_RAW_Type             RAW;         /**< \brief Offset: 0x10 (R/  32) Sensor Raw Value */
+  __IO CATB_TIMING_Type          TIMING;      /**< \brief Offset: 0x14 (R/W 32) Filter Timing Register */
+  __IO CATB_THRESH_Type          THRESH;      /**< \brief Offset: 0x18 (R/W 32) Threshold Register */
+  __IO CATB_PINSEL_Type          PINSEL;      /**< \brief Offset: 0x1C (R/W 32) Pin Selection Register */
+  __IO CATB_DMA_Type             DMA;         /**< \brief Offset: 0x20 (R/W 32) Direct Memory Access Register */
+  __I  CATB_ISR_Type             ISR;         /**< \brief Offset: 0x24 (R/  32) Interrupt Status Register */
+  __O  CATB_IER_Type             IER;         /**< \brief Offset: 0x28 ( /W 32) Interrupt Enable Register */
+  __O  CATB_IDR_Type             IDR;         /**< \brief Offset: 0x2C ( /W 32) Interrupt Disable Register */
+  __I  CATB_IMR_Type             IMR;         /**< \brief Offset: 0x30 (R/  32) Interrupt Mask Register */
+  __O  CATB_SCR_Type             SCR;         /**< \brief Offset: 0x34 ( /W 32) Status Clear Register */
+       RoReg8                    Reserved1[0x8];
+       CatbIntch                 Intch[1];    /**< \brief Offset: 0x40 CatbIntch groups [STATUS_REG_NUMBER] */
+       RoReg8                    Reserved2[0xC];
+       CatbIntchclr              Intchclr[1]; /**< \brief Offset: 0x50 CatbIntchclr groups [STATUS_REG_NUMBER] */
+       RoReg8                    Reserved3[0xC];
+       CatbOuttch                Outtch[1];   /**< \brief Offset: 0x60 CatbOuttch groups [STATUS_REG_NUMBER] */
+       RoReg8                    Reserved4[0xC];
+       CatbOuttchclr             Outtchclr[1]; /**< \brief Offset: 0x70 CatbOuttchclr groups [STATUS_REG_NUMBER] */
+       RoReg8                    Reserved5[0x84];
+  __I  CATB_PARAMETER_Type       PARAMETER;   /**< \brief Offset: 0xF8 (R/  32) Parameter Register */
+  __I  CATB_VERSION_Type         VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
+ } bf;
+ struct {
+  RwReg   CATB_CR;            /**< \brief (CATB Offset: 0x00) Control Register */
+  RwReg   CATB_CNTCR;         /**< \brief (CATB Offset: 0x04) Counter Control Register */
+  RwReg   CATB_IDLE;          /**< \brief (CATB Offset: 0x08) Sensor Idle Level */
+  RoReg   CATB_LEVEL;         /**< \brief (CATB Offset: 0x0C) Sensor Relative Level */
+  RoReg   CATB_RAW;           /**< \brief (CATB Offset: 0x10) Sensor Raw Value */
+  RwReg   CATB_TIMING;        /**< \brief (CATB Offset: 0x14) Filter Timing Register */
+  RwReg   CATB_THRESH;        /**< \brief (CATB Offset: 0x18) Threshold Register */
+  RwReg   CATB_PINSEL;        /**< \brief (CATB Offset: 0x1C) Pin Selection Register */
+  RwReg   CATB_DMA;           /**< \brief (CATB Offset: 0x20) Direct Memory Access Register */
+  RoReg   CATB_ISR;           /**< \brief (CATB Offset: 0x24) Interrupt Status Register */
+  WoReg   CATB_IER;           /**< \brief (CATB Offset: 0x28) Interrupt Enable Register */
+  WoReg   CATB_IDR;           /**< \brief (CATB Offset: 0x2C) Interrupt Disable Register */
+  RoReg   CATB_IMR;           /**< \brief (CATB Offset: 0x30) Interrupt Mask Register */
+  WoReg   CATB_SCR;           /**< \brief (CATB Offset: 0x34) Status Clear Register */
+  RoReg8  Reserved6[0x8];
+  CatbIntch CATB_INTCH[1];      /**< \brief (CATB Offset: 0x40) CatbIntch groups [STATUS_REG_NUMBER] */
+  RoReg8  Reserved7[0xC];
+  CatbIntchclr CATB_INTCHCLR[1];   /**< \brief (CATB Offset: 0x50) CatbIntchclr groups [STATUS_REG_NUMBER] */
+  RoReg8  Reserved8[0xC];
+  CatbOuttch CATB_OUTTCH[1];     /**< \brief (CATB Offset: 0x60) CatbOuttch groups [STATUS_REG_NUMBER] */
+  RoReg8  Reserved9[0xC];
+  CatbOuttchclr CATB_OUTTCHCLR[1];  /**< \brief (CATB Offset: 0x70) CatbOuttchclr groups [STATUS_REG_NUMBER] */
+  RoReg8  Reserved10[0x84];
+  RoReg   CATB_PARAMETER;     /**< \brief (CATB Offset: 0xF8) Parameter Register */
+  RoReg   CATB_VERSION;       /**< \brief (CATB Offset: 0xFC) Version Register */
+ } reg;
+} Catb;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_CATB_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/catb.h
+++ b/asf/sam/include/sam4l/component/catb.h
@@ -61,33 +61,33 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CATB_CR_OFFSET              0x00         /**< \brief (CATB_CR offset) Control Register */
-#define CATB_CR_RESETVALUE          _U(0x00000000); /**< \brief (CATB_CR reset_value) Control Register */
+#define CATB_CR_RESETVALUE          _U_(0x00000000); /**< \brief (CATB_CR reset_value) Control Register */
 
 #define CATB_CR_EN_Pos              0            /**< \brief (CATB_CR) Module Enable */
-#define CATB_CR_EN                  (_U(0x1) << CATB_CR_EN_Pos)
+#define CATB_CR_EN                  (_U_(0x1) << CATB_CR_EN_Pos)
 #define CATB_CR_RUN_Pos             1            /**< \brief (CATB_CR) Start Operation */
-#define CATB_CR_RUN                 (_U(0x1) << CATB_CR_RUN_Pos)
+#define CATB_CR_RUN                 (_U_(0x1) << CATB_CR_RUN_Pos)
 #define CATB_CR_IIDLE_Pos           2            /**< \brief (CATB_CR) Initialize Idle Value */
-#define CATB_CR_IIDLE               (_U(0x1) << CATB_CR_IIDLE_Pos)
+#define CATB_CR_IIDLE               (_U_(0x1) << CATB_CR_IIDLE_Pos)
 #define CATB_CR_ETRIG_Pos           3            /**< \brief (CATB_CR) Event Triggered Operation */
-#define CATB_CR_ETRIG               (_U(0x1) << CATB_CR_ETRIG_Pos)
+#define CATB_CR_ETRIG               (_U_(0x1) << CATB_CR_ETRIG_Pos)
 #define CATB_CR_INTRES_Pos          4            /**< \brief (CATB_CR) Internal Resistors */
-#define CATB_CR_INTRES              (_U(0x1) << CATB_CR_INTRES_Pos)
+#define CATB_CR_INTRES              (_U_(0x1) << CATB_CR_INTRES_Pos)
 #define CATB_CR_CKSEL_Pos           5            /**< \brief (CATB_CR) Clock Select */
-#define CATB_CR_CKSEL               (_U(0x1) << CATB_CR_CKSEL_Pos)
+#define CATB_CR_CKSEL               (_U_(0x1) << CATB_CR_CKSEL_Pos)
 #define CATB_CR_DIFF_Pos            6            /**< \brief (CATB_CR) Differential Mode */
-#define CATB_CR_DIFF                (_U(0x1) << CATB_CR_DIFF_Pos)
+#define CATB_CR_DIFF                (_U_(0x1) << CATB_CR_DIFF_Pos)
 #define CATB_CR_DMAEN_Pos           7            /**< \brief (CATB_CR) DMA Enable */
-#define CATB_CR_DMAEN               (_U(0x1) << CATB_CR_DMAEN_Pos)
+#define CATB_CR_DMAEN               (_U_(0x1) << CATB_CR_DMAEN_Pos)
 #define CATB_CR_ESAMPLES_Pos        8            /**< \brief (CATB_CR) Number of Event Samples */
-#define CATB_CR_ESAMPLES_Msk        (_U(0x7F) << CATB_CR_ESAMPLES_Pos)
+#define CATB_CR_ESAMPLES_Msk        (_U_(0x7F) << CATB_CR_ESAMPLES_Pos)
 #define CATB_CR_ESAMPLES(value)     (CATB_CR_ESAMPLES_Msk & ((value) << CATB_CR_ESAMPLES_Pos))
 #define CATB_CR_CHARGET_Pos         16           /**< \brief (CATB_CR) Charge Time */
-#define CATB_CR_CHARGET_Msk         (_U(0xF) << CATB_CR_CHARGET_Pos)
+#define CATB_CR_CHARGET_Msk         (_U_(0xF) << CATB_CR_CHARGET_Pos)
 #define CATB_CR_CHARGET(value)      (CATB_CR_CHARGET_Msk & ((value) << CATB_CR_CHARGET_Pos))
 #define CATB_CR_SWRST_Pos           31           /**< \brief (CATB_CR) Software Reset */
-#define CATB_CR_SWRST               (_U(0x1) << CATB_CR_SWRST_Pos)
-#define CATB_CR_MASK                _U(0x800F7FFF) /**< \brief (CATB_CR) MASK Register */
+#define CATB_CR_SWRST               (_U_(0x1) << CATB_CR_SWRST_Pos)
+#define CATB_CR_MASK                _U_(0x800F7FFF) /**< \brief (CATB_CR) MASK Register */
 
 /* -------- CATB_CNTCR : (CATB Offset: 0x04) (R/W 32) Counter Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -103,18 +103,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CATB_CNTCR_OFFSET           0x04         /**< \brief (CATB_CNTCR offset) Counter Control Register */
-#define CATB_CNTCR_RESETVALUE       _U(0x00000000); /**< \brief (CATB_CNTCR reset_value) Counter Control Register */
+#define CATB_CNTCR_RESETVALUE       _U_(0x00000000); /**< \brief (CATB_CNTCR reset_value) Counter Control Register */
 
 #define CATB_CNTCR_TOP_Pos          0            /**< \brief (CATB_CNTCR) Counter Top Value */
-#define CATB_CNTCR_TOP_Msk          (_U(0xFFFFFF) << CATB_CNTCR_TOP_Pos)
+#define CATB_CNTCR_TOP_Msk          (_U_(0xFFFFFF) << CATB_CNTCR_TOP_Pos)
 #define CATB_CNTCR_TOP(value)       (CATB_CNTCR_TOP_Msk & ((value) << CATB_CNTCR_TOP_Pos))
 #define CATB_CNTCR_SPREAD_Pos       24           /**< \brief (CATB_CNTCR) Spread Spectrum */
-#define CATB_CNTCR_SPREAD_Msk       (_U(0xF) << CATB_CNTCR_SPREAD_Pos)
+#define CATB_CNTCR_SPREAD_Msk       (_U_(0xF) << CATB_CNTCR_SPREAD_Pos)
 #define CATB_CNTCR_SPREAD(value)    (CATB_CNTCR_SPREAD_Msk & ((value) << CATB_CNTCR_SPREAD_Pos))
 #define CATB_CNTCR_REPEAT_Pos       28           /**< \brief (CATB_CNTCR) Repeat Measurements */
-#define CATB_CNTCR_REPEAT_Msk       (_U(0x7) << CATB_CNTCR_REPEAT_Pos)
+#define CATB_CNTCR_REPEAT_Msk       (_U_(0x7) << CATB_CNTCR_REPEAT_Pos)
 #define CATB_CNTCR_REPEAT(value)    (CATB_CNTCR_REPEAT_Msk & ((value) << CATB_CNTCR_REPEAT_Pos))
-#define CATB_CNTCR_MASK             _U(0x7FFFFFFF) /**< \brief (CATB_CNTCR) MASK Register */
+#define CATB_CNTCR_MASK             _U_(0x7FFFFFFF) /**< \brief (CATB_CNTCR) MASK Register */
 
 /* -------- CATB_IDLE : (CATB Offset: 0x08) (R/W 32) Sensor Idle Level -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -129,15 +129,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CATB_IDLE_OFFSET            0x08         /**< \brief (CATB_IDLE offset) Sensor Idle Level */
-#define CATB_IDLE_RESETVALUE        _U(0x00000000); /**< \brief (CATB_IDLE reset_value) Sensor Idle Level */
+#define CATB_IDLE_RESETVALUE        _U_(0x00000000); /**< \brief (CATB_IDLE reset_value) Sensor Idle Level */
 
 #define CATB_IDLE_FIDLE_Pos         0            /**< \brief (CATB_IDLE) Fractional Sensor Idle */
-#define CATB_IDLE_FIDLE_Msk         (_U(0xFFF) << CATB_IDLE_FIDLE_Pos)
+#define CATB_IDLE_FIDLE_Msk         (_U_(0xFFF) << CATB_IDLE_FIDLE_Pos)
 #define CATB_IDLE_FIDLE(value)      (CATB_IDLE_FIDLE_Msk & ((value) << CATB_IDLE_FIDLE_Pos))
 #define CATB_IDLE_RIDLE_Pos         12           /**< \brief (CATB_IDLE) Integer Sensor Idle */
-#define CATB_IDLE_RIDLE_Msk         (_U(0xFFFF) << CATB_IDLE_RIDLE_Pos)
+#define CATB_IDLE_RIDLE_Msk         (_U_(0xFFFF) << CATB_IDLE_RIDLE_Pos)
 #define CATB_IDLE_RIDLE(value)      (CATB_IDLE_RIDLE_Msk & ((value) << CATB_IDLE_RIDLE_Pos))
-#define CATB_IDLE_MASK              _U(0x0FFFFFFF) /**< \brief (CATB_IDLE) MASK Register */
+#define CATB_IDLE_MASK              _U_(0x0FFFFFFF) /**< \brief (CATB_IDLE) MASK Register */
 
 /* -------- CATB_LEVEL : (CATB Offset: 0x0C) (R/  32) Sensor Relative Level -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -152,15 +152,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CATB_LEVEL_OFFSET           0x0C         /**< \brief (CATB_LEVEL offset) Sensor Relative Level */
-#define CATB_LEVEL_RESETVALUE       _U(0x00000000); /**< \brief (CATB_LEVEL reset_value) Sensor Relative Level */
+#define CATB_LEVEL_RESETVALUE       _U_(0x00000000); /**< \brief (CATB_LEVEL reset_value) Sensor Relative Level */
 
 #define CATB_LEVEL_FLEVEL_Pos       0            /**< \brief (CATB_LEVEL) Fractional Sensor Level */
-#define CATB_LEVEL_FLEVEL_Msk       (_U(0xFFF) << CATB_LEVEL_FLEVEL_Pos)
+#define CATB_LEVEL_FLEVEL_Msk       (_U_(0xFFF) << CATB_LEVEL_FLEVEL_Pos)
 #define CATB_LEVEL_FLEVEL(value)    (CATB_LEVEL_FLEVEL_Msk & ((value) << CATB_LEVEL_FLEVEL_Pos))
 #define CATB_LEVEL_RLEVEL_Pos       12           /**< \brief (CATB_LEVEL) Integer Sensor Level */
-#define CATB_LEVEL_RLEVEL_Msk       (_U(0xFF) << CATB_LEVEL_RLEVEL_Pos)
+#define CATB_LEVEL_RLEVEL_Msk       (_U_(0xFF) << CATB_LEVEL_RLEVEL_Pos)
 #define CATB_LEVEL_RLEVEL(value)    (CATB_LEVEL_RLEVEL_Msk & ((value) << CATB_LEVEL_RLEVEL_Pos))
-#define CATB_LEVEL_MASK             _U(0x000FFFFF) /**< \brief (CATB_LEVEL) MASK Register */
+#define CATB_LEVEL_MASK             _U_(0x000FFFFF) /**< \brief (CATB_LEVEL) MASK Register */
 
 /* -------- CATB_RAW : (CATB Offset: 0x10) (R/  32) Sensor Raw Value -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -175,15 +175,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CATB_RAW_OFFSET             0x10         /**< \brief (CATB_RAW offset) Sensor Raw Value */
-#define CATB_RAW_RESETVALUE         _U(0x00000000); /**< \brief (CATB_RAW reset_value) Sensor Raw Value */
+#define CATB_RAW_RESETVALUE         _U_(0x00000000); /**< \brief (CATB_RAW reset_value) Sensor Raw Value */
 
 #define CATB_RAW_RAWA_Pos           16           /**< \brief (CATB_RAW) Current Sensor Raw Value */
-#define CATB_RAW_RAWA_Msk           (_U(0xFF) << CATB_RAW_RAWA_Pos)
+#define CATB_RAW_RAWA_Msk           (_U_(0xFF) << CATB_RAW_RAWA_Pos)
 #define CATB_RAW_RAWA(value)        (CATB_RAW_RAWA_Msk & ((value) << CATB_RAW_RAWA_Pos))
 #define CATB_RAW_RAWB_Pos           24           /**< \brief (CATB_RAW) Last Sensor Raw Value */
-#define CATB_RAW_RAWB_Msk           (_U(0xFF) << CATB_RAW_RAWB_Pos)
+#define CATB_RAW_RAWB_Msk           (_U_(0xFF) << CATB_RAW_RAWB_Pos)
 #define CATB_RAW_RAWB(value)        (CATB_RAW_RAWB_Msk & ((value) << CATB_RAW_RAWB_Pos))
-#define CATB_RAW_MASK               _U(0xFFFF0000) /**< \brief (CATB_RAW) MASK Register */
+#define CATB_RAW_MASK               _U_(0xFFFF0000) /**< \brief (CATB_RAW) MASK Register */
 
 /* -------- CATB_TIMING : (CATB Offset: 0x14) (R/W 32) Filter Timing Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -199,15 +199,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CATB_TIMING_OFFSET          0x14         /**< \brief (CATB_TIMING offset) Filter Timing Register */
-#define CATB_TIMING_RESETVALUE      _U(0x00000000); /**< \brief (CATB_TIMING reset_value) Filter Timing Register */
+#define CATB_TIMING_RESETVALUE      _U_(0x00000000); /**< \brief (CATB_TIMING reset_value) Filter Timing Register */
 
 #define CATB_TIMING_TLEVEL_Pos      0            /**< \brief (CATB_TIMING) Relative Level Smoothing */
-#define CATB_TIMING_TLEVEL_Msk      (_U(0xFFF) << CATB_TIMING_TLEVEL_Pos)
+#define CATB_TIMING_TLEVEL_Msk      (_U_(0xFFF) << CATB_TIMING_TLEVEL_Pos)
 #define CATB_TIMING_TLEVEL(value)   (CATB_TIMING_TLEVEL_Msk & ((value) << CATB_TIMING_TLEVEL_Pos))
 #define CATB_TIMING_TIDLE_Pos       16           /**< \brief (CATB_TIMING) Idle Smoothening */
-#define CATB_TIMING_TIDLE_Msk       (_U(0xFFF) << CATB_TIMING_TIDLE_Pos)
+#define CATB_TIMING_TIDLE_Msk       (_U_(0xFFF) << CATB_TIMING_TIDLE_Pos)
 #define CATB_TIMING_TIDLE(value)    (CATB_TIMING_TIDLE_Msk & ((value) << CATB_TIMING_TIDLE_Pos))
-#define CATB_TIMING_MASK            _U(0x0FFF0FFF) /**< \brief (CATB_TIMING) MASK Register */
+#define CATB_TIMING_MASK            _U_(0x0FFF0FFF) /**< \brief (CATB_TIMING) MASK Register */
 
 /* -------- CATB_THRESH : (CATB Offset: 0x18) (R/W 32) Threshold Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -225,20 +225,20 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CATB_THRESH_OFFSET          0x18         /**< \brief (CATB_THRESH offset) Threshold Register */
-#define CATB_THRESH_RESETVALUE      _U(0x00000000); /**< \brief (CATB_THRESH reset_value) Threshold Register */
+#define CATB_THRESH_RESETVALUE      _U_(0x00000000); /**< \brief (CATB_THRESH reset_value) Threshold Register */
 
 #define CATB_THRESH_FTHRESH_Pos     0            /**< \brief (CATB_THRESH) Fractional part of Threshold Value */
-#define CATB_THRESH_FTHRESH_Msk     (_U(0xFFF) << CATB_THRESH_FTHRESH_Pos)
+#define CATB_THRESH_FTHRESH_Msk     (_U_(0xFFF) << CATB_THRESH_FTHRESH_Pos)
 #define CATB_THRESH_FTHRESH(value)  (CATB_THRESH_FTHRESH_Msk & ((value) << CATB_THRESH_FTHRESH_Pos))
 #define CATB_THRESH_RTHRESH_Pos     12           /**< \brief (CATB_THRESH) Rational part of Threshold Value */
-#define CATB_THRESH_RTHRESH_Msk     (_U(0xFF) << CATB_THRESH_RTHRESH_Pos)
+#define CATB_THRESH_RTHRESH_Msk     (_U_(0xFF) << CATB_THRESH_RTHRESH_Pos)
 #define CATB_THRESH_RTHRESH(value)  (CATB_THRESH_RTHRESH_Msk & ((value) << CATB_THRESH_RTHRESH_Pos))
 #define CATB_THRESH_DIR_Pos         23           /**< \brief (CATB_THRESH) Threshold Direction */
-#define CATB_THRESH_DIR             (_U(0x1) << CATB_THRESH_DIR_Pos)
+#define CATB_THRESH_DIR             (_U_(0x1) << CATB_THRESH_DIR_Pos)
 #define CATB_THRESH_LENGTH_Pos      24           /**< \brief (CATB_THRESH) Threshold Length */
-#define CATB_THRESH_LENGTH_Msk      (_U(0x1F) << CATB_THRESH_LENGTH_Pos)
+#define CATB_THRESH_LENGTH_Msk      (_U_(0x1F) << CATB_THRESH_LENGTH_Pos)
 #define CATB_THRESH_LENGTH(value)   (CATB_THRESH_LENGTH_Msk & ((value) << CATB_THRESH_LENGTH_Pos))
-#define CATB_THRESH_MASK            _U(0x1F8FFFFF) /**< \brief (CATB_THRESH) MASK Register */
+#define CATB_THRESH_MASK            _U_(0x1F8FFFFF) /**< \brief (CATB_THRESH) MASK Register */
 
 /* -------- CATB_PINSEL : (CATB Offset: 0x1C) (R/W 32) Pin Selection Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -252,12 +252,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CATB_PINSEL_OFFSET          0x1C         /**< \brief (CATB_PINSEL offset) Pin Selection Register */
-#define CATB_PINSEL_RESETVALUE      _U(0x00000000); /**< \brief (CATB_PINSEL reset_value) Pin Selection Register */
+#define CATB_PINSEL_RESETVALUE      _U_(0x00000000); /**< \brief (CATB_PINSEL reset_value) Pin Selection Register */
 
 #define CATB_PINSEL_PINSEL_Pos      0            /**< \brief (CATB_PINSEL) Pin Select */
-#define CATB_PINSEL_PINSEL_Msk      (_U(0xFF) << CATB_PINSEL_PINSEL_Pos)
+#define CATB_PINSEL_PINSEL_Msk      (_U_(0xFF) << CATB_PINSEL_PINSEL_Pos)
 #define CATB_PINSEL_PINSEL(value)   (CATB_PINSEL_PINSEL_Msk & ((value) << CATB_PINSEL_PINSEL_Pos))
-#define CATB_PINSEL_MASK            _U(0x000000FF) /**< \brief (CATB_PINSEL) MASK Register */
+#define CATB_PINSEL_MASK            _U_(0x000000FF) /**< \brief (CATB_PINSEL) MASK Register */
 
 /* -------- CATB_DMA : (CATB Offset: 0x20) (R/W 32) Direct Memory Access Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -270,12 +270,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CATB_DMA_OFFSET             0x20         /**< \brief (CATB_DMA offset) Direct Memory Access Register */
-#define CATB_DMA_RESETVALUE         _U(0x00000000); /**< \brief (CATB_DMA reset_value) Direct Memory Access Register */
+#define CATB_DMA_RESETVALUE         _U_(0x00000000); /**< \brief (CATB_DMA reset_value) Direct Memory Access Register */
 
 #define CATB_DMA_DMA_Pos            0            /**< \brief (CATB_DMA) Direct Memory Access */
-#define CATB_DMA_DMA_Msk            (_U(0xFFFFFFFF) << CATB_DMA_DMA_Pos)
+#define CATB_DMA_DMA_Msk            (_U_(0xFFFFFFFF) << CATB_DMA_DMA_Pos)
 #define CATB_DMA_DMA(value)         (CATB_DMA_DMA_Msk & ((value) << CATB_DMA_DMA_Pos))
-#define CATB_DMA_MASK               _U(0xFFFFFFFF) /**< \brief (CATB_DMA) MASK Register */
+#define CATB_DMA_MASK               _U_(0xFFFFFFFF) /**< \brief (CATB_DMA) MASK Register */
 
 /* -------- CATB_ISR : (CATB Offset: 0x24) (R/  32) Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -291,15 +291,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CATB_ISR_OFFSET             0x24         /**< \brief (CATB_ISR offset) Interrupt Status Register */
-#define CATB_ISR_RESETVALUE         _U(0x00000000); /**< \brief (CATB_ISR reset_value) Interrupt Status Register */
+#define CATB_ISR_RESETVALUE         _U_(0x00000000); /**< \brief (CATB_ISR reset_value) Interrupt Status Register */
 
 #define CATB_ISR_SAMPLE_Pos         0            /**< \brief (CATB_ISR) Sample Ready Interrupt Status */
-#define CATB_ISR_SAMPLE             (_U(0x1) << CATB_ISR_SAMPLE_Pos)
+#define CATB_ISR_SAMPLE             (_U_(0x1) << CATB_ISR_SAMPLE_Pos)
 #define CATB_ISR_INTCH_Pos          1            /**< \brief (CATB_ISR) In-touch Interrupt Status */
-#define CATB_ISR_INTCH              (_U(0x1) << CATB_ISR_INTCH_Pos)
+#define CATB_ISR_INTCH              (_U_(0x1) << CATB_ISR_INTCH_Pos)
 #define CATB_ISR_OUTTCH_Pos         2            /**< \brief (CATB_ISR) Out-of-Touch Interrupt Status */
-#define CATB_ISR_OUTTCH             (_U(0x1) << CATB_ISR_OUTTCH_Pos)
-#define CATB_ISR_MASK               _U(0x00000007) /**< \brief (CATB_ISR) MASK Register */
+#define CATB_ISR_OUTTCH             (_U_(0x1) << CATB_ISR_OUTTCH_Pos)
+#define CATB_ISR_MASK               _U_(0x00000007) /**< \brief (CATB_ISR) MASK Register */
 
 /* -------- CATB_IER : (CATB Offset: 0x28) ( /W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -315,15 +315,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CATB_IER_OFFSET             0x28         /**< \brief (CATB_IER offset) Interrupt Enable Register */
-#define CATB_IER_RESETVALUE         _U(0x00000000); /**< \brief (CATB_IER reset_value) Interrupt Enable Register */
+#define CATB_IER_RESETVALUE         _U_(0x00000000); /**< \brief (CATB_IER reset_value) Interrupt Enable Register */
 
 #define CATB_IER_SAMPLE_Pos         0            /**< \brief (CATB_IER) Sample Ready Interrupt Enable */
-#define CATB_IER_SAMPLE             (_U(0x1) << CATB_IER_SAMPLE_Pos)
+#define CATB_IER_SAMPLE             (_U_(0x1) << CATB_IER_SAMPLE_Pos)
 #define CATB_IER_INTCH_Pos          1            /**< \brief (CATB_IER) In-touch Interrupt Enable */
-#define CATB_IER_INTCH              (_U(0x1) << CATB_IER_INTCH_Pos)
+#define CATB_IER_INTCH              (_U_(0x1) << CATB_IER_INTCH_Pos)
 #define CATB_IER_OUTTCH_Pos         2            /**< \brief (CATB_IER) Out-of-Touch Interrupt Enable */
-#define CATB_IER_OUTTCH             (_U(0x1) << CATB_IER_OUTTCH_Pos)
-#define CATB_IER_MASK               _U(0x00000007) /**< \brief (CATB_IER) MASK Register */
+#define CATB_IER_OUTTCH             (_U_(0x1) << CATB_IER_OUTTCH_Pos)
+#define CATB_IER_MASK               _U_(0x00000007) /**< \brief (CATB_IER) MASK Register */
 
 /* -------- CATB_IDR : (CATB Offset: 0x2C) ( /W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -339,15 +339,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CATB_IDR_OFFSET             0x2C         /**< \brief (CATB_IDR offset) Interrupt Disable Register */
-#define CATB_IDR_RESETVALUE         _U(0x00000000); /**< \brief (CATB_IDR reset_value) Interrupt Disable Register */
+#define CATB_IDR_RESETVALUE         _U_(0x00000000); /**< \brief (CATB_IDR reset_value) Interrupt Disable Register */
 
 #define CATB_IDR_SAMPLE_Pos         0            /**< \brief (CATB_IDR) Sample Ready Interrupt Disable */
-#define CATB_IDR_SAMPLE             (_U(0x1) << CATB_IDR_SAMPLE_Pos)
+#define CATB_IDR_SAMPLE             (_U_(0x1) << CATB_IDR_SAMPLE_Pos)
 #define CATB_IDR_INTCH_Pos          1            /**< \brief (CATB_IDR) In-touch Interrupt Disable */
-#define CATB_IDR_INTCH              (_U(0x1) << CATB_IDR_INTCH_Pos)
+#define CATB_IDR_INTCH              (_U_(0x1) << CATB_IDR_INTCH_Pos)
 #define CATB_IDR_OUTTCH_Pos         2            /**< \brief (CATB_IDR) Out-of-Touch Interrupt Disable */
-#define CATB_IDR_OUTTCH             (_U(0x1) << CATB_IDR_OUTTCH_Pos)
-#define CATB_IDR_MASK               _U(0x00000007) /**< \brief (CATB_IDR) MASK Register */
+#define CATB_IDR_OUTTCH             (_U_(0x1) << CATB_IDR_OUTTCH_Pos)
+#define CATB_IDR_MASK               _U_(0x00000007) /**< \brief (CATB_IDR) MASK Register */
 
 /* -------- CATB_IMR : (CATB Offset: 0x30) (R/  32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -363,15 +363,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CATB_IMR_OFFSET             0x30         /**< \brief (CATB_IMR offset) Interrupt Mask Register */
-#define CATB_IMR_RESETVALUE         _U(0x00000000); /**< \brief (CATB_IMR reset_value) Interrupt Mask Register */
+#define CATB_IMR_RESETVALUE         _U_(0x00000000); /**< \brief (CATB_IMR reset_value) Interrupt Mask Register */
 
 #define CATB_IMR_SAMPLE_Pos         0            /**< \brief (CATB_IMR) Sample Ready Interrupt Mask */
-#define CATB_IMR_SAMPLE             (_U(0x1) << CATB_IMR_SAMPLE_Pos)
+#define CATB_IMR_SAMPLE             (_U_(0x1) << CATB_IMR_SAMPLE_Pos)
 #define CATB_IMR_INTCH_Pos          1            /**< \brief (CATB_IMR) In-touch Interrupt Mask */
-#define CATB_IMR_INTCH              (_U(0x1) << CATB_IMR_INTCH_Pos)
+#define CATB_IMR_INTCH              (_U_(0x1) << CATB_IMR_INTCH_Pos)
 #define CATB_IMR_OUTTCH_Pos         2            /**< \brief (CATB_IMR) Out-of-Touch Interrupt Mask */
-#define CATB_IMR_OUTTCH             (_U(0x1) << CATB_IMR_OUTTCH_Pos)
-#define CATB_IMR_MASK               _U(0x00000007) /**< \brief (CATB_IMR) MASK Register */
+#define CATB_IMR_OUTTCH             (_U_(0x1) << CATB_IMR_OUTTCH_Pos)
+#define CATB_IMR_MASK               _U_(0x00000007) /**< \brief (CATB_IMR) MASK Register */
 
 /* -------- CATB_SCR : (CATB Offset: 0x34) ( /W 32) Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -387,15 +387,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CATB_SCR_OFFSET             0x34         /**< \brief (CATB_SCR offset) Status Clear Register */
-#define CATB_SCR_RESETVALUE         _U(0x00000000); /**< \brief (CATB_SCR reset_value) Status Clear Register */
+#define CATB_SCR_RESETVALUE         _U_(0x00000000); /**< \brief (CATB_SCR reset_value) Status Clear Register */
 
 #define CATB_SCR_SAMPLE_Pos         0            /**< \brief (CATB_SCR) Sample Ready */
-#define CATB_SCR_SAMPLE             (_U(0x1) << CATB_SCR_SAMPLE_Pos)
+#define CATB_SCR_SAMPLE             (_U_(0x1) << CATB_SCR_SAMPLE_Pos)
 #define CATB_SCR_INTCH_Pos          1            /**< \brief (CATB_SCR) In-touch */
-#define CATB_SCR_INTCH              (_U(0x1) << CATB_SCR_INTCH_Pos)
+#define CATB_SCR_INTCH              (_U_(0x1) << CATB_SCR_INTCH_Pos)
 #define CATB_SCR_OUTTCH_Pos         2            /**< \brief (CATB_SCR) Out-of-Touch */
-#define CATB_SCR_OUTTCH             (_U(0x1) << CATB_SCR_OUTTCH_Pos)
-#define CATB_SCR_MASK               _U(0x00000007) /**< \brief (CATB_SCR) MASK Register */
+#define CATB_SCR_OUTTCH             (_U_(0x1) << CATB_SCR_OUTTCH_Pos)
+#define CATB_SCR_MASK               _U_(0x00000007) /**< \brief (CATB_SCR) MASK Register */
 
 /* -------- CATB_INTCH : (CATB Offset: 0x40) (R/  32) INTCH In-Touch Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -408,12 +408,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CATB_INTCH_OFFSET           0x40         /**< \brief (CATB_INTCH offset) In-Touch Status Register */
-#define CATB_INTCH_RESETVALUE       _U(0x00000000); /**< \brief (CATB_INTCH reset_value) In-Touch Status Register */
+#define CATB_INTCH_RESETVALUE       _U_(0x00000000); /**< \brief (CATB_INTCH reset_value) In-Touch Status Register */
 
 #define CATB_INTCH_INTCH_Pos        0            /**< \brief (CATB_INTCH) In-Touch */
-#define CATB_INTCH_INTCH_Msk        (_U(0xFFFFFFFF) << CATB_INTCH_INTCH_Pos)
+#define CATB_INTCH_INTCH_Msk        (_U_(0xFFFFFFFF) << CATB_INTCH_INTCH_Pos)
 #define CATB_INTCH_INTCH(value)     (CATB_INTCH_INTCH_Msk & ((value) << CATB_INTCH_INTCH_Pos))
-#define CATB_INTCH_MASK             _U(0xFFFFFFFF) /**< \brief (CATB_INTCH) MASK Register */
+#define CATB_INTCH_MASK             _U_(0xFFFFFFFF) /**< \brief (CATB_INTCH) MASK Register */
 
 /* -------- CATB_INTCHCLR : (CATB Offset: 0x50) ( /W 32) INTCHCLR In-Touch Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -426,12 +426,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CATB_INTCHCLR_OFFSET        0x50         /**< \brief (CATB_INTCHCLR offset) In-Touch Status Clear Register */
-#define CATB_INTCHCLR_RESETVALUE    _U(0x00000000); /**< \brief (CATB_INTCHCLR reset_value) In-Touch Status Clear Register */
+#define CATB_INTCHCLR_RESETVALUE    _U_(0x00000000); /**< \brief (CATB_INTCHCLR reset_value) In-Touch Status Clear Register */
 
 #define CATB_INTCHCLR_INTCHCLR_Pos  0            /**< \brief (CATB_INTCHCLR) In-Touch Clear */
-#define CATB_INTCHCLR_INTCHCLR_Msk  (_U(0xFFFFFFFF) << CATB_INTCHCLR_INTCHCLR_Pos)
+#define CATB_INTCHCLR_INTCHCLR_Msk  (_U_(0xFFFFFFFF) << CATB_INTCHCLR_INTCHCLR_Pos)
 #define CATB_INTCHCLR_INTCHCLR(value) (CATB_INTCHCLR_INTCHCLR_Msk & ((value) << CATB_INTCHCLR_INTCHCLR_Pos))
-#define CATB_INTCHCLR_MASK          _U(0xFFFFFFFF) /**< \brief (CATB_INTCHCLR) MASK Register */
+#define CATB_INTCHCLR_MASK          _U_(0xFFFFFFFF) /**< \brief (CATB_INTCHCLR) MASK Register */
 
 /* -------- CATB_OUTTCH : (CATB Offset: 0x60) (R/  32) OUTTCH Out-of-Touch Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -444,12 +444,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CATB_OUTTCH_OFFSET          0x60         /**< \brief (CATB_OUTTCH offset) Out-of-Touch Status Register */
-#define CATB_OUTTCH_RESETVALUE      _U(0x00000000); /**< \brief (CATB_OUTTCH reset_value) Out-of-Touch Status Register */
+#define CATB_OUTTCH_RESETVALUE      _U_(0x00000000); /**< \brief (CATB_OUTTCH reset_value) Out-of-Touch Status Register */
 
 #define CATB_OUTTCH_OUTTCH_Pos      0            /**< \brief (CATB_OUTTCH) Out-of-Touch */
-#define CATB_OUTTCH_OUTTCH_Msk      (_U(0xFFFFFFFF) << CATB_OUTTCH_OUTTCH_Pos)
+#define CATB_OUTTCH_OUTTCH_Msk      (_U_(0xFFFFFFFF) << CATB_OUTTCH_OUTTCH_Pos)
 #define CATB_OUTTCH_OUTTCH(value)   (CATB_OUTTCH_OUTTCH_Msk & ((value) << CATB_OUTTCH_OUTTCH_Pos))
-#define CATB_OUTTCH_MASK            _U(0xFFFFFFFF) /**< \brief (CATB_OUTTCH) MASK Register */
+#define CATB_OUTTCH_MASK            _U_(0xFFFFFFFF) /**< \brief (CATB_OUTTCH) MASK Register */
 
 /* -------- CATB_OUTTCHCLR : (CATB Offset: 0x70) ( /W 32) OUTTCHCLR Out-of-Touch Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -462,12 +462,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CATB_OUTTCHCLR_OFFSET       0x70         /**< \brief (CATB_OUTTCHCLR offset) Out-of-Touch Status Clear Register */
-#define CATB_OUTTCHCLR_RESETVALUE   _U(0x00000000); /**< \brief (CATB_OUTTCHCLR reset_value) Out-of-Touch Status Clear Register */
+#define CATB_OUTTCHCLR_RESETVALUE   _U_(0x00000000); /**< \brief (CATB_OUTTCHCLR reset_value) Out-of-Touch Status Clear Register */
 
 #define CATB_OUTTCHCLR_OUTTCHCLR_Pos 0            /**< \brief (CATB_OUTTCHCLR) Out of Touch */
-#define CATB_OUTTCHCLR_OUTTCHCLR_Msk (_U(0xFFFFFFFF) << CATB_OUTTCHCLR_OUTTCHCLR_Pos)
+#define CATB_OUTTCHCLR_OUTTCHCLR_Msk (_U_(0xFFFFFFFF) << CATB_OUTTCHCLR_OUTTCHCLR_Pos)
 #define CATB_OUTTCHCLR_OUTTCHCLR(value) (CATB_OUTTCHCLR_OUTTCHCLR_Msk & ((value) << CATB_OUTTCHCLR_OUTTCHCLR_Pos))
-#define CATB_OUTTCHCLR_MASK         _U(0xFFFFFFFF) /**< \brief (CATB_OUTTCHCLR) MASK Register */
+#define CATB_OUTTCHCLR_MASK         _U_(0xFFFFFFFF) /**< \brief (CATB_OUTTCHCLR) MASK Register */
 
 /* -------- CATB_PARAMETER : (CATB Offset: 0xF8) (R/  32) Parameter Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -485,15 +485,15 @@ typedef union {
 #define CATB_PARAMETER_OFFSET       0xF8         /**< \brief (CATB_PARAMETER offset) Parameter Register */
 
 #define CATB_PARAMETER_NPINS_Pos    0            /**< \brief (CATB_PARAMETER) Number of Pins */
-#define CATB_PARAMETER_NPINS_Msk    (_U(0xFF) << CATB_PARAMETER_NPINS_Pos)
+#define CATB_PARAMETER_NPINS_Msk    (_U_(0xFF) << CATB_PARAMETER_NPINS_Pos)
 #define CATB_PARAMETER_NPINS(value) (CATB_PARAMETER_NPINS_Msk & ((value) << CATB_PARAMETER_NPINS_Pos))
 #define CATB_PARAMETER_NSTATUS_Pos  8            /**< \brief (CATB_PARAMETER) Number of Status bits */
-#define CATB_PARAMETER_NSTATUS_Msk  (_U(0xFF) << CATB_PARAMETER_NSTATUS_Pos)
+#define CATB_PARAMETER_NSTATUS_Msk  (_U_(0xFF) << CATB_PARAMETER_NSTATUS_Pos)
 #define CATB_PARAMETER_NSTATUS(value) (CATB_PARAMETER_NSTATUS_Msk & ((value) << CATB_PARAMETER_NSTATUS_Pos))
 #define CATB_PARAMETER_FRACTIONAL_Pos 16           /**< \brief (CATB_PARAMETER) Number of Fractional bits */
-#define CATB_PARAMETER_FRACTIONAL_Msk (_U(0xF) << CATB_PARAMETER_FRACTIONAL_Pos)
+#define CATB_PARAMETER_FRACTIONAL_Msk (_U_(0xF) << CATB_PARAMETER_FRACTIONAL_Pos)
 #define CATB_PARAMETER_FRACTIONAL(value) (CATB_PARAMETER_FRACTIONAL_Msk & ((value) << CATB_PARAMETER_FRACTIONAL_Pos))
-#define CATB_PARAMETER_MASK         _U(0x000FFFFF) /**< \brief (CATB_PARAMETER) MASK Register */
+#define CATB_PARAMETER_MASK         _U_(0x000FFFFF) /**< \brief (CATB_PARAMETER) MASK Register */
 
 /* -------- CATB_VERSION : (CATB Offset: 0xFC) (R/  32) Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -509,15 +509,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CATB_VERSION_OFFSET         0xFC         /**< \brief (CATB_VERSION offset) Version Register */
-#define CATB_VERSION_RESETVALUE     _U(0x00000100); /**< \brief (CATB_VERSION reset_value) Version Register */
+#define CATB_VERSION_RESETVALUE     _U_(0x00000100); /**< \brief (CATB_VERSION reset_value) Version Register */
 
 #define CATB_VERSION_VERSION_Pos    0            /**< \brief (CATB_VERSION) Version number */
-#define CATB_VERSION_VERSION_Msk    (_U(0xFFF) << CATB_VERSION_VERSION_Pos)
+#define CATB_VERSION_VERSION_Msk    (_U_(0xFFF) << CATB_VERSION_VERSION_Pos)
 #define CATB_VERSION_VERSION(value) (CATB_VERSION_VERSION_Msk & ((value) << CATB_VERSION_VERSION_Pos))
 #define CATB_VERSION_VARIANT_Pos    16           /**< \brief (CATB_VERSION) Variant number */
-#define CATB_VERSION_VARIANT_Msk    (_U(0xF) << CATB_VERSION_VARIANT_Pos)
+#define CATB_VERSION_VARIANT_Msk    (_U_(0xF) << CATB_VERSION_VARIANT_Pos)
 #define CATB_VERSION_VARIANT(value) (CATB_VERSION_VARIANT_Msk & ((value) << CATB_VERSION_VARIANT_Pos))
-#define CATB_VERSION_MASK           _U(0x000F0FFF) /**< \brief (CATB_VERSION) MASK Register */
+#define CATB_VERSION_MASK           _U_(0x000F0FFF) /**< \brief (CATB_VERSION) MASK Register */
 
 /** \brief CatbIntch hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/chipid.h
+++ b/asf/sam/include/sam4l/component/chipid.h
@@ -62,17 +62,10 @@ typedef union {
 
 /** \brief CHIPID hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-       RoReg8                    Reserved1[0x340];
-  __I  CHIPID_CIDR_Type          CIDR;        /**< \brief Offset: 0x340 (R/  32) Chip ID Register */
-  __I  CHIPID_EXID_Type          EXID;        /**< \brief Offset: 0x344 (R/  32) Chip ID Extension Register */
- } bf;
- struct {
-  RoReg8  Reserved2[0x340];
-  RoReg   CHIPID_CIDR;        /**< \brief (CHIPID Offset: 0x340) Chip ID Register */
-  RoReg   CHIPID_EXID;        /**< \brief (CHIPID Offset: 0x344) Chip ID Extension Register */
- } reg;
+typedef struct {
+       RoReg8   Reserved1[0x340];
+  __I  uint32_t CIDR;        /**< \brief Offset: 0x340 (R/  32) Chip ID Register */
+  __I  uint32_t EXID;        /**< \brief Offset: 0x344 (R/  32) Chip ID Extension Register */
 } Chipid;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/chipid.h
+++ b/asf/sam/include/sam4l/component/chipid.h
@@ -1,0 +1,81 @@
+/**
+ * \file
+ *
+ * \brief Component description for CHIPID
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_CHIPID_COMPONENT_
+#define _SAM4L_CHIPID_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR CHIPID */
+/* ========================================================================== */
+/** \addtogroup SAM4L_CHIPID Chip ID Registers */
+/*@{*/
+
+#define CHIPID_
+#define REV_CHIPID                  0x100
+
+/* -------- CHIPID_CIDR : (CHIPID Offset: 0x340) (R/  32) Chip ID Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} CHIPID_CIDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CHIPID_CIDR_OFFSET          0x340        /**< \brief (CHIPID_CIDR offset) Chip ID Register */
+#define CHIPID_CIDR_RESETVALUE      _U(0xAB0A09E0); /**< \brief (CHIPID_CIDR reset_value) Chip ID Register */
+#define CHIPID_CIDR_MASK            _U(0xFFFFFFFF) /**< \brief (CHIPID_CIDR) MASK Register */
+
+/* -------- CHIPID_EXID : (CHIPID Offset: 0x344) (R/  32) Chip ID Extension Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} CHIPID_EXID_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CHIPID_EXID_OFFSET          0x344        /**< \brief (CHIPID_EXID offset) Chip ID Extension Register */
+#define CHIPID_EXID_RESETVALUE      _U(0x0400000F); /**< \brief (CHIPID_EXID reset_value) Chip ID Extension Register */
+#define CHIPID_EXID_MASK            _U(0xFFFFFFFF) /**< \brief (CHIPID_EXID) MASK Register */
+
+/** \brief CHIPID hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+       RoReg8                    Reserved1[0x340];
+  __I  CHIPID_CIDR_Type          CIDR;        /**< \brief Offset: 0x340 (R/  32) Chip ID Register */
+  __I  CHIPID_EXID_Type          EXID;        /**< \brief Offset: 0x344 (R/  32) Chip ID Extension Register */
+ } bf;
+ struct {
+  RoReg8  Reserved2[0x340];
+  RoReg   CHIPID_CIDR;        /**< \brief (CHIPID Offset: 0x340) Chip ID Register */
+  RoReg   CHIPID_EXID;        /**< \brief (CHIPID Offset: 0x344) Chip ID Extension Register */
+ } reg;
+} Chipid;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_CHIPID_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/chipid.h
+++ b/asf/sam/include/sam4l/component/chipid.h
@@ -46,8 +46,8 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CHIPID_CIDR_OFFSET          0x340        /**< \brief (CHIPID_CIDR offset) Chip ID Register */
-#define CHIPID_CIDR_RESETVALUE      _U(0xAB0A09E0); /**< \brief (CHIPID_CIDR reset_value) Chip ID Register */
-#define CHIPID_CIDR_MASK            _U(0xFFFFFFFF) /**< \brief (CHIPID_CIDR) MASK Register */
+#define CHIPID_CIDR_RESETVALUE      _U_(0xAB0A09E0); /**< \brief (CHIPID_CIDR reset_value) Chip ID Register */
+#define CHIPID_CIDR_MASK            _U_(0xFFFFFFFF) /**< \brief (CHIPID_CIDR) MASK Register */
 
 /* -------- CHIPID_EXID : (CHIPID Offset: 0x344) (R/  32) Chip ID Extension Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -57,8 +57,8 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CHIPID_EXID_OFFSET          0x344        /**< \brief (CHIPID_EXID offset) Chip ID Extension Register */
-#define CHIPID_EXID_RESETVALUE      _U(0x0400000F); /**< \brief (CHIPID_EXID reset_value) Chip ID Extension Register */
-#define CHIPID_EXID_MASK            _U(0xFFFFFFFF) /**< \brief (CHIPID_EXID) MASK Register */
+#define CHIPID_EXID_RESETVALUE      _U_(0x0400000F); /**< \brief (CHIPID_EXID reset_value) Chip ID Extension Register */
+#define CHIPID_EXID_MASK            _U_(0xFFFFFFFF) /**< \brief (CHIPID_EXID) MASK Register */
 
 /** \brief CHIPID hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/crccu.h
+++ b/asf/sam/include/sam4l/component/crccu.h
@@ -352,49 +352,26 @@ typedef union {
 
 /** \brief CRCCU hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __IO CRCCU_DSCR_Type           DSCR;        /**< \brief Offset: 0x00 (R/W 32) Descriptor Base Register */
-       RoReg8                    Reserved1[0x4];
-  __O  CRCCU_DMAEN_Type          DMAEN;       /**< \brief Offset: 0x08 ( /W 32) DMA Enable Register */
-  __O  CRCCU_DMADIS_Type         DMADIS;      /**< \brief Offset: 0x0C ( /W 32) DMA Disable Register */
-  __I  CRCCU_DMASR_Type          DMASR;       /**< \brief Offset: 0x10 (R/  32) DMA Status Register */
-  __O  CRCCU_DMAIER_Type         DMAIER;      /**< \brief Offset: 0x14 ( /W 32) DMA Interrupt Enable Register */
-  __O  CRCCU_DMAIDR_Type         DMAIDR;      /**< \brief Offset: 0x18 ( /W 32) DMA Interrupt Disable Register */
-  __I  CRCCU_DMAIMR_Type         DMAIMR;      /**< \brief Offset: 0x1C (R/  32) DMA Interrupt Mask Register */
-  __I  CRCCU_DMAISR_Type         DMAISR;      /**< \brief Offset: 0x20 (R/  32) DMA Interrupt Status Register */
-       RoReg8                    Reserved2[0x10];
-  __O  CRCCU_CR_Type             CR;          /**< \brief Offset: 0x34 ( /W 32) Control Register */
-  __IO CRCCU_MR_Type             MR;          /**< \brief Offset: 0x38 (R/W 32) Mode Register */
-  __I  CRCCU_SR_Type             SR;          /**< \brief Offset: 0x3C (R/  32) Status Register */
-  __O  CRCCU_IER_Type            IER;         /**< \brief Offset: 0x40 ( /W 32) Interrupt Enable Register */
-  __O  CRCCU_IDR_Type            IDR;         /**< \brief Offset: 0x44 ( /W 32) Interrupt Disable Register */
-  __I  CRCCU_IMR_Type            IMR;         /**< \brief Offset: 0x48 (R/  32) Interrupt Mask Register */
-  __I  CRCCU_ISR_Type            ISR;         /**< \brief Offset: 0x4C (R/  32) Interrupt Status Register */
-       RoReg8                    Reserved3[0xAC];
-  __I  CRCCU_VERSION_Type        VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
- } bf;
- struct {
-  RwReg   CRCCU_DSCR;         /**< \brief (CRCCU Offset: 0x00) Descriptor Base Register */
-  RoReg8  Reserved4[0x4];
-  WoReg   CRCCU_DMAEN;        /**< \brief (CRCCU Offset: 0x08) DMA Enable Register */
-  WoReg   CRCCU_DMADIS;       /**< \brief (CRCCU Offset: 0x0C) DMA Disable Register */
-  RoReg   CRCCU_DMASR;        /**< \brief (CRCCU Offset: 0x10) DMA Status Register */
-  WoReg   CRCCU_DMAIER;       /**< \brief (CRCCU Offset: 0x14) DMA Interrupt Enable Register */
-  WoReg   CRCCU_DMAIDR;       /**< \brief (CRCCU Offset: 0x18) DMA Interrupt Disable Register */
-  RoReg   CRCCU_DMAIMR;       /**< \brief (CRCCU Offset: 0x1C) DMA Interrupt Mask Register */
-  RoReg   CRCCU_DMAISR;       /**< \brief (CRCCU Offset: 0x20) DMA Interrupt Status Register */
-  RoReg8  Reserved5[0x10];
-  WoReg   CRCCU_CR;           /**< \brief (CRCCU Offset: 0x34) Control Register */
-  RwReg   CRCCU_MR;           /**< \brief (CRCCU Offset: 0x38) Mode Register */
-  RoReg   CRCCU_SR;           /**< \brief (CRCCU Offset: 0x3C) Status Register */
-  WoReg   CRCCU_IER;          /**< \brief (CRCCU Offset: 0x40) Interrupt Enable Register */
-  WoReg   CRCCU_IDR;          /**< \brief (CRCCU Offset: 0x44) Interrupt Disable Register */
-  RoReg   CRCCU_IMR;          /**< \brief (CRCCU Offset: 0x48) Interrupt Mask Register */
-  RoReg   CRCCU_ISR;          /**< \brief (CRCCU Offset: 0x4C) Interrupt Status Register */
-  RoReg8  Reserved6[0xAC];
-  RoReg   CRCCU_VERSION;      /**< \brief (CRCCU Offset: 0xFC) Version Register */
- } reg;
+typedef struct {
+  __IO uint32_t DSCR;        /**< \brief Offset: 0x00 (R/W 32) Descriptor Base Register */
+       RoReg8   Reserved1[0x4];
+  __O  uint32_t DMAEN;       /**< \brief Offset: 0x08 ( /W 32) DMA Enable Register */
+  __O  uint32_t DMADIS;      /**< \brief Offset: 0x0C ( /W 32) DMA Disable Register */
+  __I  uint32_t DMASR;       /**< \brief Offset: 0x10 (R/  32) DMA Status Register */
+  __O  uint32_t DMAIER;      /**< \brief Offset: 0x14 ( /W 32) DMA Interrupt Enable Register */
+  __O  uint32_t DMAIDR;      /**< \brief Offset: 0x18 ( /W 32) DMA Interrupt Disable Register */
+  __I  uint32_t DMAIMR;      /**< \brief Offset: 0x1C (R/  32) DMA Interrupt Mask Register */
+  __I  uint32_t DMAISR;      /**< \brief Offset: 0x20 (R/  32) DMA Interrupt Status Register */
+       RoReg8   Reserved2[0x10];
+  __O  uint32_t CR;          /**< \brief Offset: 0x34 ( /W 32) Control Register */
+  __IO uint32_t MR;          /**< \brief Offset: 0x38 (R/W 32) Mode Register */
+  __I  uint32_t SR;          /**< \brief Offset: 0x3C (R/  32) Status Register */
+  __O  uint32_t IER;         /**< \brief Offset: 0x40 ( /W 32) Interrupt Enable Register */
+  __O  uint32_t IDR;         /**< \brief Offset: 0x44 ( /W 32) Interrupt Disable Register */
+  __I  uint32_t IMR;         /**< \brief Offset: 0x48 (R/  32) Interrupt Mask Register */
+  __I  uint32_t ISR;         /**< \brief Offset: 0x4C (R/  32) Interrupt Status Register */
+       RoReg8   Reserved3[0xAC];
+  __I  uint32_t VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
 } Crccu;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/crccu.h
+++ b/asf/sam/include/sam4l/component/crccu.h
@@ -1,0 +1,403 @@
+/**
+ * \file
+ *
+ * \brief Component description for CRCCU
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_CRCCU_COMPONENT_
+#define _SAM4L_CRCCU_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR CRCCU */
+/* ========================================================================== */
+/** \addtogroup SAM4L_CRCCU CRC Calculation Unit */
+/*@{*/
+
+#define CRCCU_I7644
+#define REV_CRCCU                   0x202
+
+/* -------- CRCCU_DSCR : (CRCCU Offset: 0x00) (R/W 32) Descriptor Base Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :9;               /*!< bit:  0.. 8  Reserved                           */
+    uint32_t DSCR:23;          /*!< bit:  9..31  Description Base Address           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CRCCU_DSCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CRCCU_DSCR_OFFSET           0x00         /**< \brief (CRCCU_DSCR offset) Descriptor Base Register */
+#define CRCCU_DSCR_RESETVALUE       _U(0x00000000); /**< \brief (CRCCU_DSCR reset_value) Descriptor Base Register */
+
+#define CRCCU_DSCR_DSCR_Pos         9            /**< \brief (CRCCU_DSCR) Description Base Address */
+#define CRCCU_DSCR_DSCR_Msk         (_U(0x7FFFFF) << CRCCU_DSCR_DSCR_Pos)
+#define CRCCU_DSCR_DSCR(value)      (CRCCU_DSCR_DSCR_Msk & ((value) << CRCCU_DSCR_DSCR_Pos))
+#define CRCCU_DSCR_MASK             _U(0xFFFFFE00) /**< \brief (CRCCU_DSCR) MASK Register */
+
+/* -------- CRCCU_DMAEN : (CRCCU Offset: 0x08) ( /W 32) DMA Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DMAEN:1;          /*!< bit:      0  DMA Enable                         */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CRCCU_DMAEN_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CRCCU_DMAEN_OFFSET          0x08         /**< \brief (CRCCU_DMAEN offset) DMA Enable Register */
+#define CRCCU_DMAEN_RESETVALUE      _U(0x00000000); /**< \brief (CRCCU_DMAEN reset_value) DMA Enable Register */
+
+#define CRCCU_DMAEN_DMAEN_Pos       0            /**< \brief (CRCCU_DMAEN) DMA Enable */
+#define CRCCU_DMAEN_DMAEN           (_U(0x1) << CRCCU_DMAEN_DMAEN_Pos)
+#define CRCCU_DMAEN_MASK            _U(0x00000001) /**< \brief (CRCCU_DMAEN) MASK Register */
+
+/* -------- CRCCU_DMADIS : (CRCCU Offset: 0x0C) ( /W 32) DMA Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DMADIS:1;         /*!< bit:      0  DMA Disable                        */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CRCCU_DMADIS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CRCCU_DMADIS_OFFSET         0x0C         /**< \brief (CRCCU_DMADIS offset) DMA Disable Register */
+#define CRCCU_DMADIS_RESETVALUE     _U(0x00000000); /**< \brief (CRCCU_DMADIS reset_value) DMA Disable Register */
+
+#define CRCCU_DMADIS_DMADIS_Pos     0            /**< \brief (CRCCU_DMADIS) DMA Disable */
+#define CRCCU_DMADIS_DMADIS         (_U(0x1) << CRCCU_DMADIS_DMADIS_Pos)
+#define CRCCU_DMADIS_MASK           _U(0x00000001) /**< \brief (CRCCU_DMADIS) MASK Register */
+
+/* -------- CRCCU_DMASR : (CRCCU Offset: 0x10) (R/  32) DMA Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DMASR:1;          /*!< bit:      0  DMA Channel Status                 */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CRCCU_DMASR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CRCCU_DMASR_OFFSET          0x10         /**< \brief (CRCCU_DMASR offset) DMA Status Register */
+#define CRCCU_DMASR_RESETVALUE      _U(0x00000000); /**< \brief (CRCCU_DMASR reset_value) DMA Status Register */
+
+#define CRCCU_DMASR_DMASR_Pos       0            /**< \brief (CRCCU_DMASR) DMA Channel Status */
+#define CRCCU_DMASR_DMASR           (_U(0x1) << CRCCU_DMASR_DMASR_Pos)
+#define CRCCU_DMASR_MASK            _U(0x00000001) /**< \brief (CRCCU_DMASR) MASK Register */
+
+/* -------- CRCCU_DMAIER : (CRCCU Offset: 0x14) ( /W 32) DMA Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DMAIER:1;         /*!< bit:      0  DMA Interrupt Enable               */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CRCCU_DMAIER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CRCCU_DMAIER_OFFSET         0x14         /**< \brief (CRCCU_DMAIER offset) DMA Interrupt Enable Register */
+#define CRCCU_DMAIER_RESETVALUE     _U(0x00000000); /**< \brief (CRCCU_DMAIER reset_value) DMA Interrupt Enable Register */
+
+#define CRCCU_DMAIER_DMAIER_Pos     0            /**< \brief (CRCCU_DMAIER) DMA Interrupt Enable */
+#define CRCCU_DMAIER_DMAIER         (_U(0x1) << CRCCU_DMAIER_DMAIER_Pos)
+#define CRCCU_DMAIER_MASK           _U(0x00000001) /**< \brief (CRCCU_DMAIER) MASK Register */
+
+/* -------- CRCCU_DMAIDR : (CRCCU Offset: 0x18) ( /W 32) DMA Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DMAIDR:1;         /*!< bit:      0  DMA Interrupt Disable              */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CRCCU_DMAIDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CRCCU_DMAIDR_OFFSET         0x18         /**< \brief (CRCCU_DMAIDR offset) DMA Interrupt Disable Register */
+#define CRCCU_DMAIDR_RESETVALUE     _U(0x00000000); /**< \brief (CRCCU_DMAIDR reset_value) DMA Interrupt Disable Register */
+
+#define CRCCU_DMAIDR_DMAIDR_Pos     0            /**< \brief (CRCCU_DMAIDR) DMA Interrupt Disable */
+#define CRCCU_DMAIDR_DMAIDR         (_U(0x1) << CRCCU_DMAIDR_DMAIDR_Pos)
+#define CRCCU_DMAIDR_MASK           _U(0x00000001) /**< \brief (CRCCU_DMAIDR) MASK Register */
+
+/* -------- CRCCU_DMAIMR : (CRCCU Offset: 0x1C) (R/  32) DMA Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DMAIMR:1;         /*!< bit:      0  DMA Interrupt Mask                 */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CRCCU_DMAIMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CRCCU_DMAIMR_OFFSET         0x1C         /**< \brief (CRCCU_DMAIMR offset) DMA Interrupt Mask Register */
+#define CRCCU_DMAIMR_RESETVALUE     _U(0x00000000); /**< \brief (CRCCU_DMAIMR reset_value) DMA Interrupt Mask Register */
+
+#define CRCCU_DMAIMR_DMAIMR_Pos     0            /**< \brief (CRCCU_DMAIMR) DMA Interrupt Mask */
+#define CRCCU_DMAIMR_DMAIMR         (_U(0x1) << CRCCU_DMAIMR_DMAIMR_Pos)
+#define CRCCU_DMAIMR_MASK           _U(0x00000001) /**< \brief (CRCCU_DMAIMR) MASK Register */
+
+/* -------- CRCCU_DMAISR : (CRCCU Offset: 0x20) (R/  32) DMA Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DMAISR:1;         /*!< bit:      0  DMA Interrupt Status               */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CRCCU_DMAISR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CRCCU_DMAISR_OFFSET         0x20         /**< \brief (CRCCU_DMAISR offset) DMA Interrupt Status Register */
+#define CRCCU_DMAISR_RESETVALUE     _U(0x00000000); /**< \brief (CRCCU_DMAISR reset_value) DMA Interrupt Status Register */
+
+#define CRCCU_DMAISR_DMAISR_Pos     0            /**< \brief (CRCCU_DMAISR) DMA Interrupt Status */
+#define CRCCU_DMAISR_DMAISR         (_U(0x1) << CRCCU_DMAISR_DMAISR_Pos)
+#define CRCCU_DMAISR_MASK           _U(0x00000001) /**< \brief (CRCCU_DMAISR) MASK Register */
+
+/* -------- CRCCU_CR : (CRCCU Offset: 0x34) ( /W 32) Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RESET:1;          /*!< bit:      0  Reset CRCComputation               */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CRCCU_CR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CRCCU_CR_OFFSET             0x34         /**< \brief (CRCCU_CR offset) Control Register */
+#define CRCCU_CR_RESETVALUE         _U(0x00000000); /**< \brief (CRCCU_CR reset_value) Control Register */
+
+#define CRCCU_CR_RESET_Pos          0            /**< \brief (CRCCU_CR) Reset CRCComputation */
+#define CRCCU_CR_RESET              (_U(0x1) << CRCCU_CR_RESET_Pos)
+#define CRCCU_CR_MASK               _U(0x00000001) /**< \brief (CRCCU_CR) MASK Register */
+
+/* -------- CRCCU_MR : (CRCCU Offset: 0x38) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ENABLE:1;         /*!< bit:      0  CRC Computation Enable             */
+    uint32_t COMPARE:1;        /*!< bit:      1  CRC Compare                        */
+    uint32_t PTYPE:2;          /*!< bit:  2.. 3  Polynomial Type                    */
+    uint32_t DIVIDER:4;        /*!< bit:  4.. 7  Bandwidth Divider                  */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CRCCU_MR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CRCCU_MR_OFFSET             0x38         /**< \brief (CRCCU_MR offset) Mode Register */
+#define CRCCU_MR_RESETVALUE         _U(0x00000000); /**< \brief (CRCCU_MR reset_value) Mode Register */
+
+#define CRCCU_MR_ENABLE_Pos         0            /**< \brief (CRCCU_MR) CRC Computation Enable */
+#define CRCCU_MR_ENABLE             (_U(0x1) << CRCCU_MR_ENABLE_Pos)
+#define CRCCU_MR_COMPARE_Pos        1            /**< \brief (CRCCU_MR) CRC Compare */
+#define CRCCU_MR_COMPARE            (_U(0x1) << CRCCU_MR_COMPARE_Pos)
+#define CRCCU_MR_PTYPE_Pos          2            /**< \brief (CRCCU_MR) Polynomial Type */
+#define CRCCU_MR_PTYPE_Msk          (_U(0x3) << CRCCU_MR_PTYPE_Pos)
+#define CRCCU_MR_PTYPE(value)       (CRCCU_MR_PTYPE_Msk & ((value) << CRCCU_MR_PTYPE_Pos))
+#define   CRCCU_MR_PTYPE_CCITT8023_Val    _U(0x0)   /**< \brief (CRCCU_MR)  */
+#define   CRCCU_MR_PTYPE_CASTAGNOLI_Val   _U(0x1)   /**< \brief (CRCCU_MR)  */
+#define   CRCCU_MR_PTYPE_CCITT16_Val      _U(0x2)   /**< \brief (CRCCU_MR)  */
+#define CRCCU_MR_PTYPE_CCITT8023    (CRCCU_MR_PTYPE_CCITT8023_Val  << CRCCU_MR_PTYPE_Pos)
+#define CRCCU_MR_PTYPE_CASTAGNOLI   (CRCCU_MR_PTYPE_CASTAGNOLI_Val << CRCCU_MR_PTYPE_Pos)
+#define CRCCU_MR_PTYPE_CCITT16      (CRCCU_MR_PTYPE_CCITT16_Val    << CRCCU_MR_PTYPE_Pos)
+#define CRCCU_MR_DIVIDER_Pos        4            /**< \brief (CRCCU_MR) Bandwidth Divider */
+#define CRCCU_MR_DIVIDER_Msk        (_U(0xF) << CRCCU_MR_DIVIDER_Pos)
+#define CRCCU_MR_DIVIDER(value)     (CRCCU_MR_DIVIDER_Msk & ((value) << CRCCU_MR_DIVIDER_Pos))
+#define CRCCU_MR_MASK               _U(0x000000FF) /**< \brief (CRCCU_MR) MASK Register */
+
+/* -------- CRCCU_SR : (CRCCU Offset: 0x3C) (R/  32) Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CRC:32;           /*!< bit:  0..31  Cyclic Redundancy Check Value      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CRCCU_SR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CRCCU_SR_OFFSET             0x3C         /**< \brief (CRCCU_SR offset) Status Register */
+#define CRCCU_SR_RESETVALUE         _U(0xFFFFFFFF); /**< \brief (CRCCU_SR reset_value) Status Register */
+
+#define CRCCU_SR_CRC_Pos            0            /**< \brief (CRCCU_SR) Cyclic Redundancy Check Value */
+#define CRCCU_SR_CRC_Msk            (_U(0xFFFFFFFF) << CRCCU_SR_CRC_Pos)
+#define CRCCU_SR_CRC(value)         (CRCCU_SR_CRC_Msk & ((value) << CRCCU_SR_CRC_Pos))
+#define CRCCU_SR_MASK               _U(0xFFFFFFFF) /**< \brief (CRCCU_SR) MASK Register */
+
+/* -------- CRCCU_IER : (CRCCU Offset: 0x40) ( /W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ERRIER:1;         /*!< bit:      0  CRC Error Interrupt Enable         */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CRCCU_IER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CRCCU_IER_OFFSET            0x40         /**< \brief (CRCCU_IER offset) Interrupt Enable Register */
+#define CRCCU_IER_RESETVALUE        _U(0x00000000); /**< \brief (CRCCU_IER reset_value) Interrupt Enable Register */
+
+#define CRCCU_IER_ERRIER_Pos        0            /**< \brief (CRCCU_IER) CRC Error Interrupt Enable */
+#define CRCCU_IER_ERRIER            (_U(0x1) << CRCCU_IER_ERRIER_Pos)
+#define CRCCU_IER_MASK              _U(0x00000001) /**< \brief (CRCCU_IER) MASK Register */
+
+/* -------- CRCCU_IDR : (CRCCU Offset: 0x44) ( /W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ERRIDR:1;         /*!< bit:      0  CRC Error Interrupt Disable        */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CRCCU_IDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CRCCU_IDR_OFFSET            0x44         /**< \brief (CRCCU_IDR offset) Interrupt Disable Register */
+#define CRCCU_IDR_RESETVALUE        _U(0x00000000); /**< \brief (CRCCU_IDR reset_value) Interrupt Disable Register */
+
+#define CRCCU_IDR_ERRIDR_Pos        0            /**< \brief (CRCCU_IDR) CRC Error Interrupt Disable */
+#define CRCCU_IDR_ERRIDR            (_U(0x1) << CRCCU_IDR_ERRIDR_Pos)
+#define CRCCU_IDR_MASK              _U(0x00000001) /**< \brief (CRCCU_IDR) MASK Register */
+
+/* -------- CRCCU_IMR : (CRCCU Offset: 0x48) (R/  32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ERRIMR:1;         /*!< bit:      0  CRC Error Interrupt Mask           */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CRCCU_IMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CRCCU_IMR_OFFSET            0x48         /**< \brief (CRCCU_IMR offset) Interrupt Mask Register */
+#define CRCCU_IMR_RESETVALUE        _U(0x00000000); /**< \brief (CRCCU_IMR reset_value) Interrupt Mask Register */
+
+#define CRCCU_IMR_ERRIMR_Pos        0            /**< \brief (CRCCU_IMR) CRC Error Interrupt Mask */
+#define CRCCU_IMR_ERRIMR            (_U(0x1) << CRCCU_IMR_ERRIMR_Pos)
+#define CRCCU_IMR_MASK              _U(0x00000001) /**< \brief (CRCCU_IMR) MASK Register */
+
+/* -------- CRCCU_ISR : (CRCCU Offset: 0x4C) (R/  32) Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ERRISR:1;         /*!< bit:      0  CRC Error Interrupt Status         */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CRCCU_ISR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CRCCU_ISR_OFFSET            0x4C         /**< \brief (CRCCU_ISR offset) Interrupt Status Register */
+#define CRCCU_ISR_RESETVALUE        _U(0x00000000); /**< \brief (CRCCU_ISR reset_value) Interrupt Status Register */
+
+#define CRCCU_ISR_ERRISR_Pos        0            /**< \brief (CRCCU_ISR) CRC Error Interrupt Status */
+#define CRCCU_ISR_ERRISR            (_U(0x1) << CRCCU_ISR_ERRISR_Pos)
+#define CRCCU_ISR_MASK              _U(0x00000001) /**< \brief (CRCCU_ISR) MASK Register */
+
+/* -------- CRCCU_VERSION : (CRCCU Offset: 0xFC) (R/  32) Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version Number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant Number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} CRCCU_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define CRCCU_VERSION_OFFSET        0xFC         /**< \brief (CRCCU_VERSION offset) Version Register */
+#define CRCCU_VERSION_RESETVALUE    _U(0x00000202); /**< \brief (CRCCU_VERSION reset_value) Version Register */
+
+#define CRCCU_VERSION_VERSION_Pos   0            /**< \brief (CRCCU_VERSION) Version Number */
+#define CRCCU_VERSION_VERSION_Msk   (_U(0xFFF) << CRCCU_VERSION_VERSION_Pos)
+#define CRCCU_VERSION_VERSION(value) (CRCCU_VERSION_VERSION_Msk & ((value) << CRCCU_VERSION_VERSION_Pos))
+#define CRCCU_VERSION_VARIANT_Pos   16           /**< \brief (CRCCU_VERSION) Variant Number */
+#define CRCCU_VERSION_VARIANT_Msk   (_U(0xF) << CRCCU_VERSION_VARIANT_Pos)
+#define CRCCU_VERSION_VARIANT(value) (CRCCU_VERSION_VARIANT_Msk & ((value) << CRCCU_VERSION_VARIANT_Pos))
+#define CRCCU_VERSION_MASK          _U(0x000F0FFF) /**< \brief (CRCCU_VERSION) MASK Register */
+
+/** \brief CRCCU hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __IO CRCCU_DSCR_Type           DSCR;        /**< \brief Offset: 0x00 (R/W 32) Descriptor Base Register */
+       RoReg8                    Reserved1[0x4];
+  __O  CRCCU_DMAEN_Type          DMAEN;       /**< \brief Offset: 0x08 ( /W 32) DMA Enable Register */
+  __O  CRCCU_DMADIS_Type         DMADIS;      /**< \brief Offset: 0x0C ( /W 32) DMA Disable Register */
+  __I  CRCCU_DMASR_Type          DMASR;       /**< \brief Offset: 0x10 (R/  32) DMA Status Register */
+  __O  CRCCU_DMAIER_Type         DMAIER;      /**< \brief Offset: 0x14 ( /W 32) DMA Interrupt Enable Register */
+  __O  CRCCU_DMAIDR_Type         DMAIDR;      /**< \brief Offset: 0x18 ( /W 32) DMA Interrupt Disable Register */
+  __I  CRCCU_DMAIMR_Type         DMAIMR;      /**< \brief Offset: 0x1C (R/  32) DMA Interrupt Mask Register */
+  __I  CRCCU_DMAISR_Type         DMAISR;      /**< \brief Offset: 0x20 (R/  32) DMA Interrupt Status Register */
+       RoReg8                    Reserved2[0x10];
+  __O  CRCCU_CR_Type             CR;          /**< \brief Offset: 0x34 ( /W 32) Control Register */
+  __IO CRCCU_MR_Type             MR;          /**< \brief Offset: 0x38 (R/W 32) Mode Register */
+  __I  CRCCU_SR_Type             SR;          /**< \brief Offset: 0x3C (R/  32) Status Register */
+  __O  CRCCU_IER_Type            IER;         /**< \brief Offset: 0x40 ( /W 32) Interrupt Enable Register */
+  __O  CRCCU_IDR_Type            IDR;         /**< \brief Offset: 0x44 ( /W 32) Interrupt Disable Register */
+  __I  CRCCU_IMR_Type            IMR;         /**< \brief Offset: 0x48 (R/  32) Interrupt Mask Register */
+  __I  CRCCU_ISR_Type            ISR;         /**< \brief Offset: 0x4C (R/  32) Interrupt Status Register */
+       RoReg8                    Reserved3[0xAC];
+  __I  CRCCU_VERSION_Type        VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
+ } bf;
+ struct {
+  RwReg   CRCCU_DSCR;         /**< \brief (CRCCU Offset: 0x00) Descriptor Base Register */
+  RoReg8  Reserved4[0x4];
+  WoReg   CRCCU_DMAEN;        /**< \brief (CRCCU Offset: 0x08) DMA Enable Register */
+  WoReg   CRCCU_DMADIS;       /**< \brief (CRCCU Offset: 0x0C) DMA Disable Register */
+  RoReg   CRCCU_DMASR;        /**< \brief (CRCCU Offset: 0x10) DMA Status Register */
+  WoReg   CRCCU_DMAIER;       /**< \brief (CRCCU Offset: 0x14) DMA Interrupt Enable Register */
+  WoReg   CRCCU_DMAIDR;       /**< \brief (CRCCU Offset: 0x18) DMA Interrupt Disable Register */
+  RoReg   CRCCU_DMAIMR;       /**< \brief (CRCCU Offset: 0x1C) DMA Interrupt Mask Register */
+  RoReg   CRCCU_DMAISR;       /**< \brief (CRCCU Offset: 0x20) DMA Interrupt Status Register */
+  RoReg8  Reserved5[0x10];
+  WoReg   CRCCU_CR;           /**< \brief (CRCCU Offset: 0x34) Control Register */
+  RwReg   CRCCU_MR;           /**< \brief (CRCCU Offset: 0x38) Mode Register */
+  RoReg   CRCCU_SR;           /**< \brief (CRCCU Offset: 0x3C) Status Register */
+  WoReg   CRCCU_IER;          /**< \brief (CRCCU Offset: 0x40) Interrupt Enable Register */
+  WoReg   CRCCU_IDR;          /**< \brief (CRCCU Offset: 0x44) Interrupt Disable Register */
+  RoReg   CRCCU_IMR;          /**< \brief (CRCCU Offset: 0x48) Interrupt Mask Register */
+  RoReg   CRCCU_ISR;          /**< \brief (CRCCU Offset: 0x4C) Interrupt Status Register */
+  RoReg8  Reserved6[0xAC];
+  RoReg   CRCCU_VERSION;      /**< \brief (CRCCU Offset: 0xFC) Version Register */
+ } reg;
+} Crccu;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_CRCCU_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/crccu.h
+++ b/asf/sam/include/sam4l/component/crccu.h
@@ -50,12 +50,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CRCCU_DSCR_OFFSET           0x00         /**< \brief (CRCCU_DSCR offset) Descriptor Base Register */
-#define CRCCU_DSCR_RESETVALUE       _U(0x00000000); /**< \brief (CRCCU_DSCR reset_value) Descriptor Base Register */
+#define CRCCU_DSCR_RESETVALUE       _U_(0x00000000); /**< \brief (CRCCU_DSCR reset_value) Descriptor Base Register */
 
 #define CRCCU_DSCR_DSCR_Pos         9            /**< \brief (CRCCU_DSCR) Description Base Address */
-#define CRCCU_DSCR_DSCR_Msk         (_U(0x7FFFFF) << CRCCU_DSCR_DSCR_Pos)
+#define CRCCU_DSCR_DSCR_Msk         (_U_(0x7FFFFF) << CRCCU_DSCR_DSCR_Pos)
 #define CRCCU_DSCR_DSCR(value)      (CRCCU_DSCR_DSCR_Msk & ((value) << CRCCU_DSCR_DSCR_Pos))
-#define CRCCU_DSCR_MASK             _U(0xFFFFFE00) /**< \brief (CRCCU_DSCR) MASK Register */
+#define CRCCU_DSCR_MASK             _U_(0xFFFFFE00) /**< \brief (CRCCU_DSCR) MASK Register */
 
 /* -------- CRCCU_DMAEN : (CRCCU Offset: 0x08) ( /W 32) DMA Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -69,11 +69,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CRCCU_DMAEN_OFFSET          0x08         /**< \brief (CRCCU_DMAEN offset) DMA Enable Register */
-#define CRCCU_DMAEN_RESETVALUE      _U(0x00000000); /**< \brief (CRCCU_DMAEN reset_value) DMA Enable Register */
+#define CRCCU_DMAEN_RESETVALUE      _U_(0x00000000); /**< \brief (CRCCU_DMAEN reset_value) DMA Enable Register */
 
 #define CRCCU_DMAEN_DMAEN_Pos       0            /**< \brief (CRCCU_DMAEN) DMA Enable */
-#define CRCCU_DMAEN_DMAEN           (_U(0x1) << CRCCU_DMAEN_DMAEN_Pos)
-#define CRCCU_DMAEN_MASK            _U(0x00000001) /**< \brief (CRCCU_DMAEN) MASK Register */
+#define CRCCU_DMAEN_DMAEN           (_U_(0x1) << CRCCU_DMAEN_DMAEN_Pos)
+#define CRCCU_DMAEN_MASK            _U_(0x00000001) /**< \brief (CRCCU_DMAEN) MASK Register */
 
 /* -------- CRCCU_DMADIS : (CRCCU Offset: 0x0C) ( /W 32) DMA Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -87,11 +87,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CRCCU_DMADIS_OFFSET         0x0C         /**< \brief (CRCCU_DMADIS offset) DMA Disable Register */
-#define CRCCU_DMADIS_RESETVALUE     _U(0x00000000); /**< \brief (CRCCU_DMADIS reset_value) DMA Disable Register */
+#define CRCCU_DMADIS_RESETVALUE     _U_(0x00000000); /**< \brief (CRCCU_DMADIS reset_value) DMA Disable Register */
 
 #define CRCCU_DMADIS_DMADIS_Pos     0            /**< \brief (CRCCU_DMADIS) DMA Disable */
-#define CRCCU_DMADIS_DMADIS         (_U(0x1) << CRCCU_DMADIS_DMADIS_Pos)
-#define CRCCU_DMADIS_MASK           _U(0x00000001) /**< \brief (CRCCU_DMADIS) MASK Register */
+#define CRCCU_DMADIS_DMADIS         (_U_(0x1) << CRCCU_DMADIS_DMADIS_Pos)
+#define CRCCU_DMADIS_MASK           _U_(0x00000001) /**< \brief (CRCCU_DMADIS) MASK Register */
 
 /* -------- CRCCU_DMASR : (CRCCU Offset: 0x10) (R/  32) DMA Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -105,11 +105,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CRCCU_DMASR_OFFSET          0x10         /**< \brief (CRCCU_DMASR offset) DMA Status Register */
-#define CRCCU_DMASR_RESETVALUE      _U(0x00000000); /**< \brief (CRCCU_DMASR reset_value) DMA Status Register */
+#define CRCCU_DMASR_RESETVALUE      _U_(0x00000000); /**< \brief (CRCCU_DMASR reset_value) DMA Status Register */
 
 #define CRCCU_DMASR_DMASR_Pos       0            /**< \brief (CRCCU_DMASR) DMA Channel Status */
-#define CRCCU_DMASR_DMASR           (_U(0x1) << CRCCU_DMASR_DMASR_Pos)
-#define CRCCU_DMASR_MASK            _U(0x00000001) /**< \brief (CRCCU_DMASR) MASK Register */
+#define CRCCU_DMASR_DMASR           (_U_(0x1) << CRCCU_DMASR_DMASR_Pos)
+#define CRCCU_DMASR_MASK            _U_(0x00000001) /**< \brief (CRCCU_DMASR) MASK Register */
 
 /* -------- CRCCU_DMAIER : (CRCCU Offset: 0x14) ( /W 32) DMA Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -123,11 +123,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CRCCU_DMAIER_OFFSET         0x14         /**< \brief (CRCCU_DMAIER offset) DMA Interrupt Enable Register */
-#define CRCCU_DMAIER_RESETVALUE     _U(0x00000000); /**< \brief (CRCCU_DMAIER reset_value) DMA Interrupt Enable Register */
+#define CRCCU_DMAIER_RESETVALUE     _U_(0x00000000); /**< \brief (CRCCU_DMAIER reset_value) DMA Interrupt Enable Register */
 
 #define CRCCU_DMAIER_DMAIER_Pos     0            /**< \brief (CRCCU_DMAIER) DMA Interrupt Enable */
-#define CRCCU_DMAIER_DMAIER         (_U(0x1) << CRCCU_DMAIER_DMAIER_Pos)
-#define CRCCU_DMAIER_MASK           _U(0x00000001) /**< \brief (CRCCU_DMAIER) MASK Register */
+#define CRCCU_DMAIER_DMAIER         (_U_(0x1) << CRCCU_DMAIER_DMAIER_Pos)
+#define CRCCU_DMAIER_MASK           _U_(0x00000001) /**< \brief (CRCCU_DMAIER) MASK Register */
 
 /* -------- CRCCU_DMAIDR : (CRCCU Offset: 0x18) ( /W 32) DMA Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -141,11 +141,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CRCCU_DMAIDR_OFFSET         0x18         /**< \brief (CRCCU_DMAIDR offset) DMA Interrupt Disable Register */
-#define CRCCU_DMAIDR_RESETVALUE     _U(0x00000000); /**< \brief (CRCCU_DMAIDR reset_value) DMA Interrupt Disable Register */
+#define CRCCU_DMAIDR_RESETVALUE     _U_(0x00000000); /**< \brief (CRCCU_DMAIDR reset_value) DMA Interrupt Disable Register */
 
 #define CRCCU_DMAIDR_DMAIDR_Pos     0            /**< \brief (CRCCU_DMAIDR) DMA Interrupt Disable */
-#define CRCCU_DMAIDR_DMAIDR         (_U(0x1) << CRCCU_DMAIDR_DMAIDR_Pos)
-#define CRCCU_DMAIDR_MASK           _U(0x00000001) /**< \brief (CRCCU_DMAIDR) MASK Register */
+#define CRCCU_DMAIDR_DMAIDR         (_U_(0x1) << CRCCU_DMAIDR_DMAIDR_Pos)
+#define CRCCU_DMAIDR_MASK           _U_(0x00000001) /**< \brief (CRCCU_DMAIDR) MASK Register */
 
 /* -------- CRCCU_DMAIMR : (CRCCU Offset: 0x1C) (R/  32) DMA Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -159,11 +159,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CRCCU_DMAIMR_OFFSET         0x1C         /**< \brief (CRCCU_DMAIMR offset) DMA Interrupt Mask Register */
-#define CRCCU_DMAIMR_RESETVALUE     _U(0x00000000); /**< \brief (CRCCU_DMAIMR reset_value) DMA Interrupt Mask Register */
+#define CRCCU_DMAIMR_RESETVALUE     _U_(0x00000000); /**< \brief (CRCCU_DMAIMR reset_value) DMA Interrupt Mask Register */
 
 #define CRCCU_DMAIMR_DMAIMR_Pos     0            /**< \brief (CRCCU_DMAIMR) DMA Interrupt Mask */
-#define CRCCU_DMAIMR_DMAIMR         (_U(0x1) << CRCCU_DMAIMR_DMAIMR_Pos)
-#define CRCCU_DMAIMR_MASK           _U(0x00000001) /**< \brief (CRCCU_DMAIMR) MASK Register */
+#define CRCCU_DMAIMR_DMAIMR         (_U_(0x1) << CRCCU_DMAIMR_DMAIMR_Pos)
+#define CRCCU_DMAIMR_MASK           _U_(0x00000001) /**< \brief (CRCCU_DMAIMR) MASK Register */
 
 /* -------- CRCCU_DMAISR : (CRCCU Offset: 0x20) (R/  32) DMA Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -177,11 +177,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CRCCU_DMAISR_OFFSET         0x20         /**< \brief (CRCCU_DMAISR offset) DMA Interrupt Status Register */
-#define CRCCU_DMAISR_RESETVALUE     _U(0x00000000); /**< \brief (CRCCU_DMAISR reset_value) DMA Interrupt Status Register */
+#define CRCCU_DMAISR_RESETVALUE     _U_(0x00000000); /**< \brief (CRCCU_DMAISR reset_value) DMA Interrupt Status Register */
 
 #define CRCCU_DMAISR_DMAISR_Pos     0            /**< \brief (CRCCU_DMAISR) DMA Interrupt Status */
-#define CRCCU_DMAISR_DMAISR         (_U(0x1) << CRCCU_DMAISR_DMAISR_Pos)
-#define CRCCU_DMAISR_MASK           _U(0x00000001) /**< \brief (CRCCU_DMAISR) MASK Register */
+#define CRCCU_DMAISR_DMAISR         (_U_(0x1) << CRCCU_DMAISR_DMAISR_Pos)
+#define CRCCU_DMAISR_MASK           _U_(0x00000001) /**< \brief (CRCCU_DMAISR) MASK Register */
 
 /* -------- CRCCU_CR : (CRCCU Offset: 0x34) ( /W 32) Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -195,11 +195,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CRCCU_CR_OFFSET             0x34         /**< \brief (CRCCU_CR offset) Control Register */
-#define CRCCU_CR_RESETVALUE         _U(0x00000000); /**< \brief (CRCCU_CR reset_value) Control Register */
+#define CRCCU_CR_RESETVALUE         _U_(0x00000000); /**< \brief (CRCCU_CR reset_value) Control Register */
 
 #define CRCCU_CR_RESET_Pos          0            /**< \brief (CRCCU_CR) Reset CRCComputation */
-#define CRCCU_CR_RESET              (_U(0x1) << CRCCU_CR_RESET_Pos)
-#define CRCCU_CR_MASK               _U(0x00000001) /**< \brief (CRCCU_CR) MASK Register */
+#define CRCCU_CR_RESET              (_U_(0x1) << CRCCU_CR_RESET_Pos)
+#define CRCCU_CR_MASK               _U_(0x00000001) /**< \brief (CRCCU_CR) MASK Register */
 
 /* -------- CRCCU_MR : (CRCCU Offset: 0x38) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -216,25 +216,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CRCCU_MR_OFFSET             0x38         /**< \brief (CRCCU_MR offset) Mode Register */
-#define CRCCU_MR_RESETVALUE         _U(0x00000000); /**< \brief (CRCCU_MR reset_value) Mode Register */
+#define CRCCU_MR_RESETVALUE         _U_(0x00000000); /**< \brief (CRCCU_MR reset_value) Mode Register */
 
 #define CRCCU_MR_ENABLE_Pos         0            /**< \brief (CRCCU_MR) CRC Computation Enable */
-#define CRCCU_MR_ENABLE             (_U(0x1) << CRCCU_MR_ENABLE_Pos)
+#define CRCCU_MR_ENABLE             (_U_(0x1) << CRCCU_MR_ENABLE_Pos)
 #define CRCCU_MR_COMPARE_Pos        1            /**< \brief (CRCCU_MR) CRC Compare */
-#define CRCCU_MR_COMPARE            (_U(0x1) << CRCCU_MR_COMPARE_Pos)
+#define CRCCU_MR_COMPARE            (_U_(0x1) << CRCCU_MR_COMPARE_Pos)
 #define CRCCU_MR_PTYPE_Pos          2            /**< \brief (CRCCU_MR) Polynomial Type */
-#define CRCCU_MR_PTYPE_Msk          (_U(0x3) << CRCCU_MR_PTYPE_Pos)
+#define CRCCU_MR_PTYPE_Msk          (_U_(0x3) << CRCCU_MR_PTYPE_Pos)
 #define CRCCU_MR_PTYPE(value)       (CRCCU_MR_PTYPE_Msk & ((value) << CRCCU_MR_PTYPE_Pos))
-#define   CRCCU_MR_PTYPE_CCITT8023_Val    _U(0x0)   /**< \brief (CRCCU_MR)  */
-#define   CRCCU_MR_PTYPE_CASTAGNOLI_Val   _U(0x1)   /**< \brief (CRCCU_MR)  */
-#define   CRCCU_MR_PTYPE_CCITT16_Val      _U(0x2)   /**< \brief (CRCCU_MR)  */
+#define   CRCCU_MR_PTYPE_CCITT8023_Val    _U_(0x0)   /**< \brief (CRCCU_MR)  */
+#define   CRCCU_MR_PTYPE_CASTAGNOLI_Val   _U_(0x1)   /**< \brief (CRCCU_MR)  */
+#define   CRCCU_MR_PTYPE_CCITT16_Val      _U_(0x2)   /**< \brief (CRCCU_MR)  */
 #define CRCCU_MR_PTYPE_CCITT8023    (CRCCU_MR_PTYPE_CCITT8023_Val  << CRCCU_MR_PTYPE_Pos)
 #define CRCCU_MR_PTYPE_CASTAGNOLI   (CRCCU_MR_PTYPE_CASTAGNOLI_Val << CRCCU_MR_PTYPE_Pos)
 #define CRCCU_MR_PTYPE_CCITT16      (CRCCU_MR_PTYPE_CCITT16_Val    << CRCCU_MR_PTYPE_Pos)
 #define CRCCU_MR_DIVIDER_Pos        4            /**< \brief (CRCCU_MR) Bandwidth Divider */
-#define CRCCU_MR_DIVIDER_Msk        (_U(0xF) << CRCCU_MR_DIVIDER_Pos)
+#define CRCCU_MR_DIVIDER_Msk        (_U_(0xF) << CRCCU_MR_DIVIDER_Pos)
 #define CRCCU_MR_DIVIDER(value)     (CRCCU_MR_DIVIDER_Msk & ((value) << CRCCU_MR_DIVIDER_Pos))
-#define CRCCU_MR_MASK               _U(0x000000FF) /**< \brief (CRCCU_MR) MASK Register */
+#define CRCCU_MR_MASK               _U_(0x000000FF) /**< \brief (CRCCU_MR) MASK Register */
 
 /* -------- CRCCU_SR : (CRCCU Offset: 0x3C) (R/  32) Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -247,12 +247,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CRCCU_SR_OFFSET             0x3C         /**< \brief (CRCCU_SR offset) Status Register */
-#define CRCCU_SR_RESETVALUE         _U(0xFFFFFFFF); /**< \brief (CRCCU_SR reset_value) Status Register */
+#define CRCCU_SR_RESETVALUE         _U_(0xFFFFFFFF); /**< \brief (CRCCU_SR reset_value) Status Register */
 
 #define CRCCU_SR_CRC_Pos            0            /**< \brief (CRCCU_SR) Cyclic Redundancy Check Value */
-#define CRCCU_SR_CRC_Msk            (_U(0xFFFFFFFF) << CRCCU_SR_CRC_Pos)
+#define CRCCU_SR_CRC_Msk            (_U_(0xFFFFFFFF) << CRCCU_SR_CRC_Pos)
 #define CRCCU_SR_CRC(value)         (CRCCU_SR_CRC_Msk & ((value) << CRCCU_SR_CRC_Pos))
-#define CRCCU_SR_MASK               _U(0xFFFFFFFF) /**< \brief (CRCCU_SR) MASK Register */
+#define CRCCU_SR_MASK               _U_(0xFFFFFFFF) /**< \brief (CRCCU_SR) MASK Register */
 
 /* -------- CRCCU_IER : (CRCCU Offset: 0x40) ( /W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -266,11 +266,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CRCCU_IER_OFFSET            0x40         /**< \brief (CRCCU_IER offset) Interrupt Enable Register */
-#define CRCCU_IER_RESETVALUE        _U(0x00000000); /**< \brief (CRCCU_IER reset_value) Interrupt Enable Register */
+#define CRCCU_IER_RESETVALUE        _U_(0x00000000); /**< \brief (CRCCU_IER reset_value) Interrupt Enable Register */
 
 #define CRCCU_IER_ERRIER_Pos        0            /**< \brief (CRCCU_IER) CRC Error Interrupt Enable */
-#define CRCCU_IER_ERRIER            (_U(0x1) << CRCCU_IER_ERRIER_Pos)
-#define CRCCU_IER_MASK              _U(0x00000001) /**< \brief (CRCCU_IER) MASK Register */
+#define CRCCU_IER_ERRIER            (_U_(0x1) << CRCCU_IER_ERRIER_Pos)
+#define CRCCU_IER_MASK              _U_(0x00000001) /**< \brief (CRCCU_IER) MASK Register */
 
 /* -------- CRCCU_IDR : (CRCCU Offset: 0x44) ( /W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -284,11 +284,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CRCCU_IDR_OFFSET            0x44         /**< \brief (CRCCU_IDR offset) Interrupt Disable Register */
-#define CRCCU_IDR_RESETVALUE        _U(0x00000000); /**< \brief (CRCCU_IDR reset_value) Interrupt Disable Register */
+#define CRCCU_IDR_RESETVALUE        _U_(0x00000000); /**< \brief (CRCCU_IDR reset_value) Interrupt Disable Register */
 
 #define CRCCU_IDR_ERRIDR_Pos        0            /**< \brief (CRCCU_IDR) CRC Error Interrupt Disable */
-#define CRCCU_IDR_ERRIDR            (_U(0x1) << CRCCU_IDR_ERRIDR_Pos)
-#define CRCCU_IDR_MASK              _U(0x00000001) /**< \brief (CRCCU_IDR) MASK Register */
+#define CRCCU_IDR_ERRIDR            (_U_(0x1) << CRCCU_IDR_ERRIDR_Pos)
+#define CRCCU_IDR_MASK              _U_(0x00000001) /**< \brief (CRCCU_IDR) MASK Register */
 
 /* -------- CRCCU_IMR : (CRCCU Offset: 0x48) (R/  32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -302,11 +302,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CRCCU_IMR_OFFSET            0x48         /**< \brief (CRCCU_IMR offset) Interrupt Mask Register */
-#define CRCCU_IMR_RESETVALUE        _U(0x00000000); /**< \brief (CRCCU_IMR reset_value) Interrupt Mask Register */
+#define CRCCU_IMR_RESETVALUE        _U_(0x00000000); /**< \brief (CRCCU_IMR reset_value) Interrupt Mask Register */
 
 #define CRCCU_IMR_ERRIMR_Pos        0            /**< \brief (CRCCU_IMR) CRC Error Interrupt Mask */
-#define CRCCU_IMR_ERRIMR            (_U(0x1) << CRCCU_IMR_ERRIMR_Pos)
-#define CRCCU_IMR_MASK              _U(0x00000001) /**< \brief (CRCCU_IMR) MASK Register */
+#define CRCCU_IMR_ERRIMR            (_U_(0x1) << CRCCU_IMR_ERRIMR_Pos)
+#define CRCCU_IMR_MASK              _U_(0x00000001) /**< \brief (CRCCU_IMR) MASK Register */
 
 /* -------- CRCCU_ISR : (CRCCU Offset: 0x4C) (R/  32) Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -320,11 +320,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CRCCU_ISR_OFFSET            0x4C         /**< \brief (CRCCU_ISR offset) Interrupt Status Register */
-#define CRCCU_ISR_RESETVALUE        _U(0x00000000); /**< \brief (CRCCU_ISR reset_value) Interrupt Status Register */
+#define CRCCU_ISR_RESETVALUE        _U_(0x00000000); /**< \brief (CRCCU_ISR reset_value) Interrupt Status Register */
 
 #define CRCCU_ISR_ERRISR_Pos        0            /**< \brief (CRCCU_ISR) CRC Error Interrupt Status */
-#define CRCCU_ISR_ERRISR            (_U(0x1) << CRCCU_ISR_ERRISR_Pos)
-#define CRCCU_ISR_MASK              _U(0x00000001) /**< \brief (CRCCU_ISR) MASK Register */
+#define CRCCU_ISR_ERRISR            (_U_(0x1) << CRCCU_ISR_ERRISR_Pos)
+#define CRCCU_ISR_MASK              _U_(0x00000001) /**< \brief (CRCCU_ISR) MASK Register */
 
 /* -------- CRCCU_VERSION : (CRCCU Offset: 0xFC) (R/  32) Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -340,15 +340,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CRCCU_VERSION_OFFSET        0xFC         /**< \brief (CRCCU_VERSION offset) Version Register */
-#define CRCCU_VERSION_RESETVALUE    _U(0x00000202); /**< \brief (CRCCU_VERSION reset_value) Version Register */
+#define CRCCU_VERSION_RESETVALUE    _U_(0x00000202); /**< \brief (CRCCU_VERSION reset_value) Version Register */
 
 #define CRCCU_VERSION_VERSION_Pos   0            /**< \brief (CRCCU_VERSION) Version Number */
-#define CRCCU_VERSION_VERSION_Msk   (_U(0xFFF) << CRCCU_VERSION_VERSION_Pos)
+#define CRCCU_VERSION_VERSION_Msk   (_U_(0xFFF) << CRCCU_VERSION_VERSION_Pos)
 #define CRCCU_VERSION_VERSION(value) (CRCCU_VERSION_VERSION_Msk & ((value) << CRCCU_VERSION_VERSION_Pos))
 #define CRCCU_VERSION_VARIANT_Pos   16           /**< \brief (CRCCU_VERSION) Variant Number */
-#define CRCCU_VERSION_VARIANT_Msk   (_U(0xF) << CRCCU_VERSION_VARIANT_Pos)
+#define CRCCU_VERSION_VARIANT_Msk   (_U_(0xF) << CRCCU_VERSION_VARIANT_Pos)
 #define CRCCU_VERSION_VARIANT(value) (CRCCU_VERSION_VARIANT_Msk & ((value) << CRCCU_VERSION_VARIANT_Pos))
-#define CRCCU_VERSION_MASK          _U(0x000F0FFF) /**< \brief (CRCCU_VERSION) MASK Register */
+#define CRCCU_VERSION_MASK          _U_(0x000F0FFF) /**< \brief (CRCCU_VERSION) MASK Register */
 
 /** \brief CRCCU hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/dacc.h
+++ b/asf/sam/include/sam4l/component/dacc.h
@@ -50,11 +50,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_CR_OFFSET              0x00         /**< \brief (DACC_CR offset) Control Register */
-#define DACC_CR_RESETVALUE          _U(0x00000000); /**< \brief (DACC_CR reset_value) Control Register */
+#define DACC_CR_RESETVALUE          _U_(0x00000000); /**< \brief (DACC_CR reset_value) Control Register */
 
 #define DACC_CR_SWRST_Pos           0            /**< \brief (DACC_CR) Software Reset */
-#define DACC_CR_SWRST               (_U(0x1) << DACC_CR_SWRST_Pos)
-#define DACC_CR_MASK                _U(0x00000001) /**< \brief (DACC_CR) MASK Register */
+#define DACC_CR_SWRST               (_U_(0x1) << DACC_CR_SWRST_Pos)
+#define DACC_CR_MASK                _U_(0x00000001) /**< \brief (DACC_CR) MASK Register */
 
 /* -------- DACC_MR : (DACC Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -73,24 +73,24 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_MR_OFFSET              0x04         /**< \brief (DACC_MR offset) Mode Register */
-#define DACC_MR_RESETVALUE          _U(0x00000000); /**< \brief (DACC_MR reset_value) Mode Register */
+#define DACC_MR_RESETVALUE          _U_(0x00000000); /**< \brief (DACC_MR reset_value) Mode Register */
 
 #define DACC_MR_TRGEN_Pos           0            /**< \brief (DACC_MR) Trigger Enable */
-#define DACC_MR_TRGEN               (_U(0x1) << DACC_MR_TRGEN_Pos)
+#define DACC_MR_TRGEN               (_U_(0x1) << DACC_MR_TRGEN_Pos)
 #define DACC_MR_TRGSEL_Pos          1            /**< \brief (DACC_MR) Trigger Selection */
-#define DACC_MR_TRGSEL_Msk          (_U(0x7) << DACC_MR_TRGSEL_Pos)
+#define DACC_MR_TRGSEL_Msk          (_U_(0x7) << DACC_MR_TRGSEL_Pos)
 #define DACC_MR_TRGSEL(value)       (DACC_MR_TRGSEL_Msk & ((value) << DACC_MR_TRGSEL_Pos))
 #define DACC_MR_DACEN_Pos           4            /**< \brief (DACC_MR) DAC Enable */
-#define DACC_MR_DACEN               (_U(0x1) << DACC_MR_DACEN_Pos)
+#define DACC_MR_DACEN               (_U_(0x1) << DACC_MR_DACEN_Pos)
 #define DACC_MR_WORD_Pos            5            /**< \brief (DACC_MR) Word Transfer */
-#define DACC_MR_WORD                (_U(0x1) << DACC_MR_WORD_Pos)
+#define DACC_MR_WORD                (_U_(0x1) << DACC_MR_WORD_Pos)
 #define DACC_MR_STARTUP_Pos         8            /**< \brief (DACC_MR) Startup Time Selection */
-#define DACC_MR_STARTUP_Msk         (_U(0xFF) << DACC_MR_STARTUP_Pos)
+#define DACC_MR_STARTUP_Msk         (_U_(0xFF) << DACC_MR_STARTUP_Pos)
 #define DACC_MR_STARTUP(value)      (DACC_MR_STARTUP_Msk & ((value) << DACC_MR_STARTUP_Pos))
 #define DACC_MR_CLKDIV_Pos          16           /**< \brief (DACC_MR) Clock Divider for Internal Trigger */
-#define DACC_MR_CLKDIV_Msk          (_U(0xFFFF) << DACC_MR_CLKDIV_Pos)
+#define DACC_MR_CLKDIV_Msk          (_U_(0xFFFF) << DACC_MR_CLKDIV_Pos)
 #define DACC_MR_CLKDIV(value)       (DACC_MR_CLKDIV_Msk & ((value) << DACC_MR_CLKDIV_Pos))
-#define DACC_MR_MASK                _U(0xFFFFFF3F) /**< \brief (DACC_MR) MASK Register */
+#define DACC_MR_MASK                _U_(0xFFFFFF3F) /**< \brief (DACC_MR) MASK Register */
 
 /* -------- DACC_CDR : (DACC Offset: 0x08) ( /W 32) Conversion Data Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -103,12 +103,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_CDR_OFFSET             0x08         /**< \brief (DACC_CDR offset) Conversion Data Register */
-#define DACC_CDR_RESETVALUE         _U(0x00000000); /**< \brief (DACC_CDR reset_value) Conversion Data Register */
+#define DACC_CDR_RESETVALUE         _U_(0x00000000); /**< \brief (DACC_CDR reset_value) Conversion Data Register */
 
 #define DACC_CDR_DATA_Pos           0            /**< \brief (DACC_CDR) Data to Convert */
-#define DACC_CDR_DATA_Msk           (_U(0xFFFFFFFF) << DACC_CDR_DATA_Pos)
+#define DACC_CDR_DATA_Msk           (_U_(0xFFFFFFFF) << DACC_CDR_DATA_Pos)
 #define DACC_CDR_DATA(value)        (DACC_CDR_DATA_Msk & ((value) << DACC_CDR_DATA_Pos))
-#define DACC_CDR_MASK               _U(0xFFFFFFFF) /**< \brief (DACC_CDR) MASK Register */
+#define DACC_CDR_MASK               _U_(0xFFFFFFFF) /**< \brief (DACC_CDR) MASK Register */
 
 /* -------- DACC_IER : (DACC Offset: 0x0C) ( /W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -122,11 +122,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_IER_OFFSET             0x0C         /**< \brief (DACC_IER offset) Interrupt Enable Register */
-#define DACC_IER_RESETVALUE         _U(0x00000000); /**< \brief (DACC_IER reset_value) Interrupt Enable Register */
+#define DACC_IER_RESETVALUE         _U_(0x00000000); /**< \brief (DACC_IER reset_value) Interrupt Enable Register */
 
 #define DACC_IER_TXRDY_Pos          0            /**< \brief (DACC_IER) Transmit Ready Interrupt Enable */
-#define DACC_IER_TXRDY              (_U(0x1) << DACC_IER_TXRDY_Pos)
-#define DACC_IER_MASK               _U(0x00000001) /**< \brief (DACC_IER) MASK Register */
+#define DACC_IER_TXRDY              (_U_(0x1) << DACC_IER_TXRDY_Pos)
+#define DACC_IER_MASK               _U_(0x00000001) /**< \brief (DACC_IER) MASK Register */
 
 /* -------- DACC_IDR : (DACC Offset: 0x10) ( /W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -142,8 +142,8 @@ typedef union {
 #define DACC_IDR_OFFSET             0x10         /**< \brief (DACC_IDR offset) Interrupt Disable Register */
 
 #define DACC_IDR_TXRDY_Pos          0            /**< \brief (DACC_IDR) Transmit Ready Interrupt Disable */
-#define DACC_IDR_TXRDY              (_U(0x1) << DACC_IDR_TXRDY_Pos)
-#define DACC_IDR_MASK               _U(0x00000001) /**< \brief (DACC_IDR) MASK Register */
+#define DACC_IDR_TXRDY              (_U_(0x1) << DACC_IDR_TXRDY_Pos)
+#define DACC_IDR_MASK               _U_(0x00000001) /**< \brief (DACC_IDR) MASK Register */
 
 /* -------- DACC_IMR : (DACC Offset: 0x14) (R/  32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -157,11 +157,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_IMR_OFFSET             0x14         /**< \brief (DACC_IMR offset) Interrupt Mask Register */
-#define DACC_IMR_RESETVALUE         _U(0x00000000); /**< \brief (DACC_IMR reset_value) Interrupt Mask Register */
+#define DACC_IMR_RESETVALUE         _U_(0x00000000); /**< \brief (DACC_IMR reset_value) Interrupt Mask Register */
 
 #define DACC_IMR_TXRDY_Pos          0            /**< \brief (DACC_IMR) Transmit Ready Interrupt Mask */
-#define DACC_IMR_TXRDY              (_U(0x1) << DACC_IMR_TXRDY_Pos)
-#define DACC_IMR_MASK               _U(0x00000001) /**< \brief (DACC_IMR) MASK Register */
+#define DACC_IMR_TXRDY              (_U_(0x1) << DACC_IMR_TXRDY_Pos)
+#define DACC_IMR_MASK               _U_(0x00000001) /**< \brief (DACC_IMR) MASK Register */
 
 /* -------- DACC_ISR : (DACC Offset: 0x18) (R/  32) Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -175,11 +175,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_ISR_OFFSET             0x18         /**< \brief (DACC_ISR offset) Interrupt Status Register */
-#define DACC_ISR_RESETVALUE         _U(0x00000000); /**< \brief (DACC_ISR reset_value) Interrupt Status Register */
+#define DACC_ISR_RESETVALUE         _U_(0x00000000); /**< \brief (DACC_ISR reset_value) Interrupt Status Register */
 
 #define DACC_ISR_TXRDY_Pos          0            /**< \brief (DACC_ISR) Transmit Ready Interrupt Status */
-#define DACC_ISR_TXRDY              (_U(0x1) << DACC_ISR_TXRDY_Pos)
-#define DACC_ISR_MASK               _U(0x00000001) /**< \brief (DACC_ISR) MASK Register */
+#define DACC_ISR_TXRDY              (_U_(0x1) << DACC_ISR_TXRDY_Pos)
+#define DACC_ISR_MASK               _U_(0x00000001) /**< \brief (DACC_ISR) MASK Register */
 
 /* -------- DACC_WPMR : (DACC Offset: 0xE4) (R/W 32) Write Protect Mode Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -194,14 +194,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_WPMR_OFFSET            0xE4         /**< \brief (DACC_WPMR offset) Write Protect Mode Register */
-#define DACC_WPMR_RESETVALUE        _U(0x00000000); /**< \brief (DACC_WPMR reset_value) Write Protect Mode Register */
+#define DACC_WPMR_RESETVALUE        _U_(0x00000000); /**< \brief (DACC_WPMR reset_value) Write Protect Mode Register */
 
 #define DACC_WPMR_WPEN_Pos          0            /**< \brief (DACC_WPMR) Write Protect Enable */
-#define DACC_WPMR_WPEN              (_U(0x1) << DACC_WPMR_WPEN_Pos)
+#define DACC_WPMR_WPEN              (_U_(0x1) << DACC_WPMR_WPEN_Pos)
 #define DACC_WPMR_WPKEY_Pos         8            /**< \brief (DACC_WPMR) Write Protect Key */
-#define DACC_WPMR_WPKEY_Msk         (_U(0xFFFFFF) << DACC_WPMR_WPKEY_Pos)
+#define DACC_WPMR_WPKEY_Msk         (_U_(0xFFFFFF) << DACC_WPMR_WPKEY_Pos)
 #define DACC_WPMR_WPKEY(value)      (DACC_WPMR_WPKEY_Msk & ((value) << DACC_WPMR_WPKEY_Pos))
-#define DACC_WPMR_MASK              _U(0xFFFFFF01) /**< \brief (DACC_WPMR) MASK Register */
+#define DACC_WPMR_MASK              _U_(0xFFFFFF01) /**< \brief (DACC_WPMR) MASK Register */
 
 /* -------- DACC_WPSR : (DACC Offset: 0xE8) (R/  32) Write Protect Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -217,14 +217,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_WPSR_OFFSET            0xE8         /**< \brief (DACC_WPSR offset) Write Protect Status Register */
-#define DACC_WPSR_RESETVALUE        _U(0x00000000); /**< \brief (DACC_WPSR reset_value) Write Protect Status Register */
+#define DACC_WPSR_RESETVALUE        _U_(0x00000000); /**< \brief (DACC_WPSR reset_value) Write Protect Status Register */
 
 #define DACC_WPSR_WPROTERR_Pos      0            /**< \brief (DACC_WPSR) Write Protection Error */
-#define DACC_WPSR_WPROTERR          (_U(0x1) << DACC_WPSR_WPROTERR_Pos)
+#define DACC_WPSR_WPROTERR          (_U_(0x1) << DACC_WPSR_WPROTERR_Pos)
 #define DACC_WPSR_WPROTADDR_Pos     8            /**< \brief (DACC_WPSR) Write Protection Error Address */
-#define DACC_WPSR_WPROTADDR_Msk     (_U(0xFF) << DACC_WPSR_WPROTADDR_Pos)
+#define DACC_WPSR_WPROTADDR_Msk     (_U_(0xFF) << DACC_WPSR_WPROTADDR_Pos)
 #define DACC_WPSR_WPROTADDR(value)  (DACC_WPSR_WPROTADDR_Msk & ((value) << DACC_WPSR_WPROTADDR_Pos))
-#define DACC_WPSR_MASK              _U(0x0000FF01) /**< \brief (DACC_WPSR) MASK Register */
+#define DACC_WPSR_MASK              _U_(0x0000FF01) /**< \brief (DACC_WPSR) MASK Register */
 
 /* -------- DACC_VERSION : (DACC Offset: 0xFC) (R/  32) Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -240,15 +240,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_VERSION_OFFSET         0xFC         /**< \brief (DACC_VERSION offset) Version Register */
-#define DACC_VERSION_RESETVALUE     _U(0x00000111); /**< \brief (DACC_VERSION reset_value) Version Register */
+#define DACC_VERSION_RESETVALUE     _U_(0x00000111); /**< \brief (DACC_VERSION reset_value) Version Register */
 
 #define DACC_VERSION_VERSION_Pos    0            /**< \brief (DACC_VERSION) Version Number */
-#define DACC_VERSION_VERSION_Msk    (_U(0xFFF) << DACC_VERSION_VERSION_Pos)
+#define DACC_VERSION_VERSION_Msk    (_U_(0xFFF) << DACC_VERSION_VERSION_Pos)
 #define DACC_VERSION_VERSION(value) (DACC_VERSION_VERSION_Msk & ((value) << DACC_VERSION_VERSION_Pos))
 #define DACC_VERSION_VARIANT_Pos    16           /**< \brief (DACC_VERSION) Variant Number */
-#define DACC_VERSION_VARIANT_Msk    (_U(0x7) << DACC_VERSION_VARIANT_Pos)
+#define DACC_VERSION_VARIANT_Msk    (_U_(0x7) << DACC_VERSION_VARIANT_Pos)
 #define DACC_VERSION_VARIANT(value) (DACC_VERSION_VARIANT_Msk & ((value) << DACC_VERSION_VARIANT_Pos))
-#define DACC_VERSION_MASK           _U(0x00070FFF) /**< \brief (DACC_VERSION) MASK Register */
+#define DACC_VERSION_MASK           _U_(0x00070FFF) /**< \brief (DACC_VERSION) MASK Register */
 
 /** \brief DACC hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/dacc.h
+++ b/asf/sam/include/sam4l/component/dacc.h
@@ -1,0 +1,289 @@
+/**
+ * \file
+ *
+ * \brief Component description for DACC
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_DACC_COMPONENT_
+#define _SAM4L_DACC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR DACC */
+/* ========================================================================== */
+/** \addtogroup SAM4L_DACC DAC Controller */
+/*@{*/
+
+#define DACC_I7645
+#define REV_DACC                    0x111
+
+/* -------- DACC_CR : (DACC Offset: 0x00) ( /W 32) Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DACC_CR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_CR_OFFSET              0x00         /**< \brief (DACC_CR offset) Control Register */
+#define DACC_CR_RESETVALUE          _U(0x00000000); /**< \brief (DACC_CR reset_value) Control Register */
+
+#define DACC_CR_SWRST_Pos           0            /**< \brief (DACC_CR) Software Reset */
+#define DACC_CR_SWRST               (_U(0x1) << DACC_CR_SWRST_Pos)
+#define DACC_CR_MASK                _U(0x00000001) /**< \brief (DACC_CR) MASK Register */
+
+/* -------- DACC_MR : (DACC Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TRGEN:1;          /*!< bit:      0  Trigger Enable                     */
+    uint32_t TRGSEL:3;         /*!< bit:  1.. 3  Trigger Selection                  */
+    uint32_t DACEN:1;          /*!< bit:      4  DAC Enable                         */
+    uint32_t WORD:1;           /*!< bit:      5  Word Transfer                      */
+    uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t STARTUP:8;        /*!< bit:  8..15  Startup Time Selection             */
+    uint32_t CLKDIV:16;        /*!< bit: 16..31  Clock Divider for Internal Trigger */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DACC_MR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_MR_OFFSET              0x04         /**< \brief (DACC_MR offset) Mode Register */
+#define DACC_MR_RESETVALUE          _U(0x00000000); /**< \brief (DACC_MR reset_value) Mode Register */
+
+#define DACC_MR_TRGEN_Pos           0            /**< \brief (DACC_MR) Trigger Enable */
+#define DACC_MR_TRGEN               (_U(0x1) << DACC_MR_TRGEN_Pos)
+#define DACC_MR_TRGSEL_Pos          1            /**< \brief (DACC_MR) Trigger Selection */
+#define DACC_MR_TRGSEL_Msk          (_U(0x7) << DACC_MR_TRGSEL_Pos)
+#define DACC_MR_TRGSEL(value)       (DACC_MR_TRGSEL_Msk & ((value) << DACC_MR_TRGSEL_Pos))
+#define DACC_MR_DACEN_Pos           4            /**< \brief (DACC_MR) DAC Enable */
+#define DACC_MR_DACEN               (_U(0x1) << DACC_MR_DACEN_Pos)
+#define DACC_MR_WORD_Pos            5            /**< \brief (DACC_MR) Word Transfer */
+#define DACC_MR_WORD                (_U(0x1) << DACC_MR_WORD_Pos)
+#define DACC_MR_STARTUP_Pos         8            /**< \brief (DACC_MR) Startup Time Selection */
+#define DACC_MR_STARTUP_Msk         (_U(0xFF) << DACC_MR_STARTUP_Pos)
+#define DACC_MR_STARTUP(value)      (DACC_MR_STARTUP_Msk & ((value) << DACC_MR_STARTUP_Pos))
+#define DACC_MR_CLKDIV_Pos          16           /**< \brief (DACC_MR) Clock Divider for Internal Trigger */
+#define DACC_MR_CLKDIV_Msk          (_U(0xFFFF) << DACC_MR_CLKDIV_Pos)
+#define DACC_MR_CLKDIV(value)       (DACC_MR_CLKDIV_Msk & ((value) << DACC_MR_CLKDIV_Pos))
+#define DACC_MR_MASK                _U(0xFFFFFF3F) /**< \brief (DACC_MR) MASK Register */
+
+/* -------- DACC_CDR : (DACC Offset: 0x08) ( /W 32) Conversion Data Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATA:32;          /*!< bit:  0..31  Data to Convert                    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DACC_CDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_CDR_OFFSET             0x08         /**< \brief (DACC_CDR offset) Conversion Data Register */
+#define DACC_CDR_RESETVALUE         _U(0x00000000); /**< \brief (DACC_CDR reset_value) Conversion Data Register */
+
+#define DACC_CDR_DATA_Pos           0            /**< \brief (DACC_CDR) Data to Convert */
+#define DACC_CDR_DATA_Msk           (_U(0xFFFFFFFF) << DACC_CDR_DATA_Pos)
+#define DACC_CDR_DATA(value)        (DACC_CDR_DATA_Msk & ((value) << DACC_CDR_DATA_Pos))
+#define DACC_CDR_MASK               _U(0xFFFFFFFF) /**< \brief (DACC_CDR) MASK Register */
+
+/* -------- DACC_IER : (DACC Offset: 0x0C) ( /W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXRDY:1;          /*!< bit:      0  Transmit Ready Interrupt Enable    */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DACC_IER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_IER_OFFSET             0x0C         /**< \brief (DACC_IER offset) Interrupt Enable Register */
+#define DACC_IER_RESETVALUE         _U(0x00000000); /**< \brief (DACC_IER reset_value) Interrupt Enable Register */
+
+#define DACC_IER_TXRDY_Pos          0            /**< \brief (DACC_IER) Transmit Ready Interrupt Enable */
+#define DACC_IER_TXRDY              (_U(0x1) << DACC_IER_TXRDY_Pos)
+#define DACC_IER_MASK               _U(0x00000001) /**< \brief (DACC_IER) MASK Register */
+
+/* -------- DACC_IDR : (DACC Offset: 0x10) ( /W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXRDY:1;          /*!< bit:      0  Transmit Ready Interrupt Disable   */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DACC_IDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_IDR_OFFSET             0x10         /**< \brief (DACC_IDR offset) Interrupt Disable Register */
+
+#define DACC_IDR_TXRDY_Pos          0            /**< \brief (DACC_IDR) Transmit Ready Interrupt Disable */
+#define DACC_IDR_TXRDY              (_U(0x1) << DACC_IDR_TXRDY_Pos)
+#define DACC_IDR_MASK               _U(0x00000001) /**< \brief (DACC_IDR) MASK Register */
+
+/* -------- DACC_IMR : (DACC Offset: 0x14) (R/  32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXRDY:1;          /*!< bit:      0  Transmit Ready Interrupt Mask      */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DACC_IMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_IMR_OFFSET             0x14         /**< \brief (DACC_IMR offset) Interrupt Mask Register */
+#define DACC_IMR_RESETVALUE         _U(0x00000000); /**< \brief (DACC_IMR reset_value) Interrupt Mask Register */
+
+#define DACC_IMR_TXRDY_Pos          0            /**< \brief (DACC_IMR) Transmit Ready Interrupt Mask */
+#define DACC_IMR_TXRDY              (_U(0x1) << DACC_IMR_TXRDY_Pos)
+#define DACC_IMR_MASK               _U(0x00000001) /**< \brief (DACC_IMR) MASK Register */
+
+/* -------- DACC_ISR : (DACC Offset: 0x18) (R/  32) Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXRDY:1;          /*!< bit:      0  Transmit Ready Interrupt Status    */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DACC_ISR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_ISR_OFFSET             0x18         /**< \brief (DACC_ISR offset) Interrupt Status Register */
+#define DACC_ISR_RESETVALUE         _U(0x00000000); /**< \brief (DACC_ISR reset_value) Interrupt Status Register */
+
+#define DACC_ISR_TXRDY_Pos          0            /**< \brief (DACC_ISR) Transmit Ready Interrupt Status */
+#define DACC_ISR_TXRDY              (_U(0x1) << DACC_ISR_TXRDY_Pos)
+#define DACC_ISR_MASK               _U(0x00000001) /**< \brief (DACC_ISR) MASK Register */
+
+/* -------- DACC_WPMR : (DACC Offset: 0xE4) (R/W 32) Write Protect Mode Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t WPEN:1;           /*!< bit:      0  Write Protect Enable               */
+    uint32_t :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint32_t WPKEY:24;         /*!< bit:  8..31  Write Protect Key                  */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DACC_WPMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_WPMR_OFFSET            0xE4         /**< \brief (DACC_WPMR offset) Write Protect Mode Register */
+#define DACC_WPMR_RESETVALUE        _U(0x00000000); /**< \brief (DACC_WPMR reset_value) Write Protect Mode Register */
+
+#define DACC_WPMR_WPEN_Pos          0            /**< \brief (DACC_WPMR) Write Protect Enable */
+#define DACC_WPMR_WPEN              (_U(0x1) << DACC_WPMR_WPEN_Pos)
+#define DACC_WPMR_WPKEY_Pos         8            /**< \brief (DACC_WPMR) Write Protect Key */
+#define DACC_WPMR_WPKEY_Msk         (_U(0xFFFFFF) << DACC_WPMR_WPKEY_Pos)
+#define DACC_WPMR_WPKEY(value)      (DACC_WPMR_WPKEY_Msk & ((value) << DACC_WPMR_WPKEY_Pos))
+#define DACC_WPMR_MASK              _U(0xFFFFFF01) /**< \brief (DACC_WPMR) MASK Register */
+
+/* -------- DACC_WPSR : (DACC Offset: 0xE8) (R/  32) Write Protect Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t WPROTERR:1;       /*!< bit:      0  Write Protection Error             */
+    uint32_t :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint32_t WPROTADDR:8;      /*!< bit:  8..15  Write Protection Error Address     */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DACC_WPSR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_WPSR_OFFSET            0xE8         /**< \brief (DACC_WPSR offset) Write Protect Status Register */
+#define DACC_WPSR_RESETVALUE        _U(0x00000000); /**< \brief (DACC_WPSR reset_value) Write Protect Status Register */
+
+#define DACC_WPSR_WPROTERR_Pos      0            /**< \brief (DACC_WPSR) Write Protection Error */
+#define DACC_WPSR_WPROTERR          (_U(0x1) << DACC_WPSR_WPROTERR_Pos)
+#define DACC_WPSR_WPROTADDR_Pos     8            /**< \brief (DACC_WPSR) Write Protection Error Address */
+#define DACC_WPSR_WPROTADDR_Msk     (_U(0xFF) << DACC_WPSR_WPROTADDR_Pos)
+#define DACC_WPSR_WPROTADDR(value)  (DACC_WPSR_WPROTADDR_Msk & ((value) << DACC_WPSR_WPROTADDR_Pos))
+#define DACC_WPSR_MASK              _U(0x0000FF01) /**< \brief (DACC_WPSR) MASK Register */
+
+/* -------- DACC_VERSION : (DACC Offset: 0xFC) (R/  32) Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version Number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:3;        /*!< bit: 16..18  Variant Number                     */
+    uint32_t :13;              /*!< bit: 19..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DACC_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DACC_VERSION_OFFSET         0xFC         /**< \brief (DACC_VERSION offset) Version Register */
+#define DACC_VERSION_RESETVALUE     _U(0x00000111); /**< \brief (DACC_VERSION reset_value) Version Register */
+
+#define DACC_VERSION_VERSION_Pos    0            /**< \brief (DACC_VERSION) Version Number */
+#define DACC_VERSION_VERSION_Msk    (_U(0xFFF) << DACC_VERSION_VERSION_Pos)
+#define DACC_VERSION_VERSION(value) (DACC_VERSION_VERSION_Msk & ((value) << DACC_VERSION_VERSION_Pos))
+#define DACC_VERSION_VARIANT_Pos    16           /**< \brief (DACC_VERSION) Variant Number */
+#define DACC_VERSION_VARIANT_Msk    (_U(0x7) << DACC_VERSION_VARIANT_Pos)
+#define DACC_VERSION_VARIANT(value) (DACC_VERSION_VARIANT_Msk & ((value) << DACC_VERSION_VARIANT_Pos))
+#define DACC_VERSION_MASK           _U(0x00070FFF) /**< \brief (DACC_VERSION) MASK Register */
+
+/** \brief DACC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __O  DACC_CR_Type              CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
+  __IO DACC_MR_Type              MR;          /**< \brief Offset: 0x04 (R/W 32) Mode Register */
+  __O  DACC_CDR_Type             CDR;         /**< \brief Offset: 0x08 ( /W 32) Conversion Data Register */
+  __O  DACC_IER_Type             IER;         /**< \brief Offset: 0x0C ( /W 32) Interrupt Enable Register */
+  __O  DACC_IDR_Type             IDR;         /**< \brief Offset: 0x10 ( /W 32) Interrupt Disable Register */
+  __I  DACC_IMR_Type             IMR;         /**< \brief Offset: 0x14 (R/  32) Interrupt Mask Register */
+  __I  DACC_ISR_Type             ISR;         /**< \brief Offset: 0x18 (R/  32) Interrupt Status Register */
+       RoReg8                    Reserved1[0xC8];
+  __IO DACC_WPMR_Type            WPMR;        /**< \brief Offset: 0xE4 (R/W 32) Write Protect Mode Register */
+  __I  DACC_WPSR_Type            WPSR;        /**< \brief Offset: 0xE8 (R/  32) Write Protect Status Register */
+       RoReg8                    Reserved2[0x10];
+  __I  DACC_VERSION_Type         VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
+ } bf;
+ struct {
+  WoReg   DACC_CR;            /**< \brief (DACC Offset: 0x00) Control Register */
+  RwReg   DACC_MR;            /**< \brief (DACC Offset: 0x04) Mode Register */
+  WoReg   DACC_CDR;           /**< \brief (DACC Offset: 0x08) Conversion Data Register */
+  WoReg   DACC_IER;           /**< \brief (DACC Offset: 0x0C) Interrupt Enable Register */
+  WoReg   DACC_IDR;           /**< \brief (DACC Offset: 0x10) Interrupt Disable Register */
+  RoReg   DACC_IMR;           /**< \brief (DACC Offset: 0x14) Interrupt Mask Register */
+  RoReg   DACC_ISR;           /**< \brief (DACC Offset: 0x18) Interrupt Status Register */
+  RoReg8  Reserved3[0xC8];
+  RwReg   DACC_WPMR;          /**< \brief (DACC Offset: 0xE4) Write Protect Mode Register */
+  RoReg   DACC_WPSR;          /**< \brief (DACC Offset: 0xE8) Write Protect Status Register */
+  RoReg8  Reserved4[0x10];
+  RoReg   DACC_VERSION;       /**< \brief (DACC Offset: 0xFC) Version Register */
+ } reg;
+} Dacc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_DACC_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/dacc.h
+++ b/asf/sam/include/sam4l/component/dacc.h
@@ -252,35 +252,19 @@ typedef union {
 
 /** \brief DACC hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __O  DACC_CR_Type              CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
-  __IO DACC_MR_Type              MR;          /**< \brief Offset: 0x04 (R/W 32) Mode Register */
-  __O  DACC_CDR_Type             CDR;         /**< \brief Offset: 0x08 ( /W 32) Conversion Data Register */
-  __O  DACC_IER_Type             IER;         /**< \brief Offset: 0x0C ( /W 32) Interrupt Enable Register */
-  __O  DACC_IDR_Type             IDR;         /**< \brief Offset: 0x10 ( /W 32) Interrupt Disable Register */
-  __I  DACC_IMR_Type             IMR;         /**< \brief Offset: 0x14 (R/  32) Interrupt Mask Register */
-  __I  DACC_ISR_Type             ISR;         /**< \brief Offset: 0x18 (R/  32) Interrupt Status Register */
-       RoReg8                    Reserved1[0xC8];
-  __IO DACC_WPMR_Type            WPMR;        /**< \brief Offset: 0xE4 (R/W 32) Write Protect Mode Register */
-  __I  DACC_WPSR_Type            WPSR;        /**< \brief Offset: 0xE8 (R/  32) Write Protect Status Register */
-       RoReg8                    Reserved2[0x10];
-  __I  DACC_VERSION_Type         VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
- } bf;
- struct {
-  WoReg   DACC_CR;            /**< \brief (DACC Offset: 0x00) Control Register */
-  RwReg   DACC_MR;            /**< \brief (DACC Offset: 0x04) Mode Register */
-  WoReg   DACC_CDR;           /**< \brief (DACC Offset: 0x08) Conversion Data Register */
-  WoReg   DACC_IER;           /**< \brief (DACC Offset: 0x0C) Interrupt Enable Register */
-  WoReg   DACC_IDR;           /**< \brief (DACC Offset: 0x10) Interrupt Disable Register */
-  RoReg   DACC_IMR;           /**< \brief (DACC Offset: 0x14) Interrupt Mask Register */
-  RoReg   DACC_ISR;           /**< \brief (DACC Offset: 0x18) Interrupt Status Register */
-  RoReg8  Reserved3[0xC8];
-  RwReg   DACC_WPMR;          /**< \brief (DACC Offset: 0xE4) Write Protect Mode Register */
-  RoReg   DACC_WPSR;          /**< \brief (DACC Offset: 0xE8) Write Protect Status Register */
-  RoReg8  Reserved4[0x10];
-  RoReg   DACC_VERSION;       /**< \brief (DACC Offset: 0xFC) Version Register */
- } reg;
+typedef struct {
+  __O  uint32_t CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
+  __IO uint32_t MR;          /**< \brief Offset: 0x04 (R/W 32) Mode Register */
+  __O  uint32_t CDR;         /**< \brief Offset: 0x08 ( /W 32) Conversion Data Register */
+  __O  uint32_t IER;         /**< \brief Offset: 0x0C ( /W 32) Interrupt Enable Register */
+  __O  uint32_t IDR;         /**< \brief Offset: 0x10 ( /W 32) Interrupt Disable Register */
+  __I  uint32_t IMR;         /**< \brief Offset: 0x14 (R/  32) Interrupt Mask Register */
+  __I  uint32_t ISR;         /**< \brief Offset: 0x18 (R/  32) Interrupt Status Register */
+       RoReg8   Reserved1[0xC8];
+  __IO uint32_t WPMR;        /**< \brief Offset: 0xE4 (R/W 32) Write Protect Mode Register */
+  __I  uint32_t WPSR;        /**< \brief Offset: 0xE8 (R/  32) Write Protect Status Register */
+       RoReg8   Reserved2[0x10];
+  __I  uint32_t VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
 } Dacc;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/eic.h
+++ b/asf/sam/include/sam4l/component/eic.h
@@ -65,57 +65,57 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EIC_IER_OFFSET              0x000        /**< \brief (EIC_IER offset) Interrupt Enable Register */
-#define EIC_IER_RESETVALUE          _U(0x00000000); /**< \brief (EIC_IER reset_value) Interrupt Enable Register */
+#define EIC_IER_RESETVALUE          _U_(0x00000000); /**< \brief (EIC_IER reset_value) Interrupt Enable Register */
 
 #define EIC_IER_NMI_Pos             0            /**< \brief (EIC_IER) External Non Maskable CPU interrupt */
-#define EIC_IER_NMI                 (_U(0x1) << EIC_IER_NMI_Pos)
+#define EIC_IER_NMI                 (_U_(0x1) << EIC_IER_NMI_Pos)
 #define EIC_IER_INT1_Pos            1            /**< \brief (EIC_IER) External Interrupt 1 */
-#define EIC_IER_INT1                (_U(0x1) << EIC_IER_INT1_Pos)
-#define   EIC_IER_INT1_0_Val              _U(0x0)   /**< \brief (EIC_IER) No effect */
-#define   EIC_IER_INT1_1_Val              _U(0x1)   /**< \brief (EIC_IER) Enable Interrupt. */
+#define EIC_IER_INT1                (_U_(0x1) << EIC_IER_INT1_Pos)
+#define   EIC_IER_INT1_0_Val              _U_(0x0)   /**< \brief (EIC_IER) No effect */
+#define   EIC_IER_INT1_1_Val              _U_(0x1)   /**< \brief (EIC_IER) Enable Interrupt. */
 #define EIC_IER_INT1_0              (EIC_IER_INT1_0_Val            << EIC_IER_INT1_Pos)
 #define EIC_IER_INT1_1              (EIC_IER_INT1_1_Val            << EIC_IER_INT1_Pos)
 #define EIC_IER_INT2_Pos            2            /**< \brief (EIC_IER) External Interrupt 2 */
-#define EIC_IER_INT2                (_U(0x1) << EIC_IER_INT2_Pos)
-#define   EIC_IER_INT2_0_Val              _U(0x0)   /**< \brief (EIC_IER) No effect */
-#define   EIC_IER_INT2_1_Val              _U(0x1)   /**< \brief (EIC_IER) Enable Interrupt. */
+#define EIC_IER_INT2                (_U_(0x1) << EIC_IER_INT2_Pos)
+#define   EIC_IER_INT2_0_Val              _U_(0x0)   /**< \brief (EIC_IER) No effect */
+#define   EIC_IER_INT2_1_Val              _U_(0x1)   /**< \brief (EIC_IER) Enable Interrupt. */
 #define EIC_IER_INT2_0              (EIC_IER_INT2_0_Val            << EIC_IER_INT2_Pos)
 #define EIC_IER_INT2_1              (EIC_IER_INT2_1_Val            << EIC_IER_INT2_Pos)
 #define EIC_IER_INT3_Pos            3            /**< \brief (EIC_IER) External Interrupt 3 */
-#define EIC_IER_INT3                (_U(0x1) << EIC_IER_INT3_Pos)
-#define   EIC_IER_INT3_0_Val              _U(0x0)   /**< \brief (EIC_IER) No effect */
-#define   EIC_IER_INT3_1_Val              _U(0x1)   /**< \brief (EIC_IER) Enable Interrupt. */
+#define EIC_IER_INT3                (_U_(0x1) << EIC_IER_INT3_Pos)
+#define   EIC_IER_INT3_0_Val              _U_(0x0)   /**< \brief (EIC_IER) No effect */
+#define   EIC_IER_INT3_1_Val              _U_(0x1)   /**< \brief (EIC_IER) Enable Interrupt. */
 #define EIC_IER_INT3_0              (EIC_IER_INT3_0_Val            << EIC_IER_INT3_Pos)
 #define EIC_IER_INT3_1              (EIC_IER_INT3_1_Val            << EIC_IER_INT3_Pos)
 #define EIC_IER_INT4_Pos            4            /**< \brief (EIC_IER) External Interrupt 4 */
-#define EIC_IER_INT4                (_U(0x1) << EIC_IER_INT4_Pos)
-#define   EIC_IER_INT4_0_Val              _U(0x0)   /**< \brief (EIC_IER) No effect */
-#define   EIC_IER_INT4_1_Val              _U(0x1)   /**< \brief (EIC_IER) Enable Interrupt. */
+#define EIC_IER_INT4                (_U_(0x1) << EIC_IER_INT4_Pos)
+#define   EIC_IER_INT4_0_Val              _U_(0x0)   /**< \brief (EIC_IER) No effect */
+#define   EIC_IER_INT4_1_Val              _U_(0x1)   /**< \brief (EIC_IER) Enable Interrupt. */
 #define EIC_IER_INT4_0              (EIC_IER_INT4_0_Val            << EIC_IER_INT4_Pos)
 #define EIC_IER_INT4_1              (EIC_IER_INT4_1_Val            << EIC_IER_INT4_Pos)
 #define EIC_IER_INT5_Pos            5            /**< \brief (EIC_IER) External Interrupt 5 */
-#define EIC_IER_INT5                (_U(0x1) << EIC_IER_INT5_Pos)
+#define EIC_IER_INT5                (_U_(0x1) << EIC_IER_INT5_Pos)
 #define EIC_IER_INT6_Pos            6            /**< \brief (EIC_IER) External Interrupt 6 */
-#define EIC_IER_INT6                (_U(0x1) << EIC_IER_INT6_Pos)
+#define EIC_IER_INT6                (_U_(0x1) << EIC_IER_INT6_Pos)
 #define EIC_IER_INT7_Pos            7            /**< \brief (EIC_IER) External Interrupt 7 */
-#define EIC_IER_INT7                (_U(0x1) << EIC_IER_INT7_Pos)
+#define EIC_IER_INT7                (_U_(0x1) << EIC_IER_INT7_Pos)
 #define EIC_IER_INT8_Pos            8            /**< \brief (EIC_IER) External Interrupt 8 */
-#define EIC_IER_INT8                (_U(0x1) << EIC_IER_INT8_Pos)
+#define EIC_IER_INT8                (_U_(0x1) << EIC_IER_INT8_Pos)
 #define EIC_IER_INT9_Pos            9            /**< \brief (EIC_IER) External Interrupt 9 */
-#define EIC_IER_INT9                (_U(0x1) << EIC_IER_INT9_Pos)
+#define EIC_IER_INT9                (_U_(0x1) << EIC_IER_INT9_Pos)
 #define EIC_IER_INT10_Pos           10           /**< \brief (EIC_IER) External Interrupt 10 */
-#define EIC_IER_INT10               (_U(0x1) << EIC_IER_INT10_Pos)
+#define EIC_IER_INT10               (_U_(0x1) << EIC_IER_INT10_Pos)
 #define EIC_IER_INT11_Pos           11           /**< \brief (EIC_IER) External Interrupt 11 */
-#define EIC_IER_INT11               (_U(0x1) << EIC_IER_INT11_Pos)
+#define EIC_IER_INT11               (_U_(0x1) << EIC_IER_INT11_Pos)
 #define EIC_IER_INT12_Pos           12           /**< \brief (EIC_IER) External Interrupt 12 */
-#define EIC_IER_INT12               (_U(0x1) << EIC_IER_INT12_Pos)
+#define EIC_IER_INT12               (_U_(0x1) << EIC_IER_INT12_Pos)
 #define EIC_IER_INT13_Pos           13           /**< \brief (EIC_IER) External Interrupt 13 */
-#define EIC_IER_INT13               (_U(0x1) << EIC_IER_INT13_Pos)
+#define EIC_IER_INT13               (_U_(0x1) << EIC_IER_INT13_Pos)
 #define EIC_IER_INT14_Pos           14           /**< \brief (EIC_IER) External Interrupt 14 */
-#define EIC_IER_INT14               (_U(0x1) << EIC_IER_INT14_Pos)
+#define EIC_IER_INT14               (_U_(0x1) << EIC_IER_INT14_Pos)
 #define EIC_IER_INT15_Pos           15           /**< \brief (EIC_IER) External Interrupt 15 */
-#define EIC_IER_INT15               (_U(0x1) << EIC_IER_INT15_Pos)
-#define EIC_IER_MASK                _U(0x0000FFFF) /**< \brief (EIC_IER) MASK Register */
+#define EIC_IER_INT15               (_U_(0x1) << EIC_IER_INT15_Pos)
+#define EIC_IER_MASK                _U_(0x0000FFFF) /**< \brief (EIC_IER) MASK Register */
 
 /* -------- EIC_IDR : (EIC Offset: 0x004) ( /W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -144,57 +144,57 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EIC_IDR_OFFSET              0x004        /**< \brief (EIC_IDR offset) Interrupt Disable Register */
-#define EIC_IDR_RESETVALUE          _U(0x00000000); /**< \brief (EIC_IDR reset_value) Interrupt Disable Register */
+#define EIC_IDR_RESETVALUE          _U_(0x00000000); /**< \brief (EIC_IDR reset_value) Interrupt Disable Register */
 
 #define EIC_IDR_NMI_Pos             0            /**< \brief (EIC_IDR) External Non Maskable CPU interrupt */
-#define EIC_IDR_NMI                 (_U(0x1) << EIC_IDR_NMI_Pos)
+#define EIC_IDR_NMI                 (_U_(0x1) << EIC_IDR_NMI_Pos)
 #define EIC_IDR_INT1_Pos            1            /**< \brief (EIC_IDR) External Interrupt 1 */
-#define EIC_IDR_INT1                (_U(0x1) << EIC_IDR_INT1_Pos)
-#define   EIC_IDR_INT1_0_Val              _U(0x0)   /**< \brief (EIC_IDR) No effect */
-#define   EIC_IDR_INT1_1_Val              _U(0x1)   /**< \brief (EIC_IDR) Disable Interrupt. */
+#define EIC_IDR_INT1                (_U_(0x1) << EIC_IDR_INT1_Pos)
+#define   EIC_IDR_INT1_0_Val              _U_(0x0)   /**< \brief (EIC_IDR) No effect */
+#define   EIC_IDR_INT1_1_Val              _U_(0x1)   /**< \brief (EIC_IDR) Disable Interrupt. */
 #define EIC_IDR_INT1_0              (EIC_IDR_INT1_0_Val            << EIC_IDR_INT1_Pos)
 #define EIC_IDR_INT1_1              (EIC_IDR_INT1_1_Val            << EIC_IDR_INT1_Pos)
 #define EIC_IDR_INT2_Pos            2            /**< \brief (EIC_IDR) External Interrupt 2 */
-#define EIC_IDR_INT2                (_U(0x1) << EIC_IDR_INT2_Pos)
-#define   EIC_IDR_INT2_0_Val              _U(0x0)   /**< \brief (EIC_IDR) No effect */
-#define   EIC_IDR_INT2_1_Val              _U(0x1)   /**< \brief (EIC_IDR) Disable Interrupt. */
+#define EIC_IDR_INT2                (_U_(0x1) << EIC_IDR_INT2_Pos)
+#define   EIC_IDR_INT2_0_Val              _U_(0x0)   /**< \brief (EIC_IDR) No effect */
+#define   EIC_IDR_INT2_1_Val              _U_(0x1)   /**< \brief (EIC_IDR) Disable Interrupt. */
 #define EIC_IDR_INT2_0              (EIC_IDR_INT2_0_Val            << EIC_IDR_INT2_Pos)
 #define EIC_IDR_INT2_1              (EIC_IDR_INT2_1_Val            << EIC_IDR_INT2_Pos)
 #define EIC_IDR_INT3_Pos            3            /**< \brief (EIC_IDR) External Interrupt 3 */
-#define EIC_IDR_INT3                (_U(0x1) << EIC_IDR_INT3_Pos)
-#define   EIC_IDR_INT3_0_Val              _U(0x0)   /**< \brief (EIC_IDR) No effect */
-#define   EIC_IDR_INT3_1_Val              _U(0x1)   /**< \brief (EIC_IDR) Disable Interrupt. */
+#define EIC_IDR_INT3                (_U_(0x1) << EIC_IDR_INT3_Pos)
+#define   EIC_IDR_INT3_0_Val              _U_(0x0)   /**< \brief (EIC_IDR) No effect */
+#define   EIC_IDR_INT3_1_Val              _U_(0x1)   /**< \brief (EIC_IDR) Disable Interrupt. */
 #define EIC_IDR_INT3_0              (EIC_IDR_INT3_0_Val            << EIC_IDR_INT3_Pos)
 #define EIC_IDR_INT3_1              (EIC_IDR_INT3_1_Val            << EIC_IDR_INT3_Pos)
 #define EIC_IDR_INT4_Pos            4            /**< \brief (EIC_IDR) External Interrupt 4 */
-#define EIC_IDR_INT4                (_U(0x1) << EIC_IDR_INT4_Pos)
-#define   EIC_IDR_INT4_0_Val              _U(0x0)   /**< \brief (EIC_IDR) No effect */
-#define   EIC_IDR_INT4_1_Val              _U(0x1)   /**< \brief (EIC_IDR) Disable Interrupt. */
+#define EIC_IDR_INT4                (_U_(0x1) << EIC_IDR_INT4_Pos)
+#define   EIC_IDR_INT4_0_Val              _U_(0x0)   /**< \brief (EIC_IDR) No effect */
+#define   EIC_IDR_INT4_1_Val              _U_(0x1)   /**< \brief (EIC_IDR) Disable Interrupt. */
 #define EIC_IDR_INT4_0              (EIC_IDR_INT4_0_Val            << EIC_IDR_INT4_Pos)
 #define EIC_IDR_INT4_1              (EIC_IDR_INT4_1_Val            << EIC_IDR_INT4_Pos)
 #define EIC_IDR_INT5_Pos            5            /**< \brief (EIC_IDR) External Interrupt 5 */
-#define EIC_IDR_INT5                (_U(0x1) << EIC_IDR_INT5_Pos)
+#define EIC_IDR_INT5                (_U_(0x1) << EIC_IDR_INT5_Pos)
 #define EIC_IDR_INT6_Pos            6            /**< \brief (EIC_IDR) External Interrupt 6 */
-#define EIC_IDR_INT6                (_U(0x1) << EIC_IDR_INT6_Pos)
+#define EIC_IDR_INT6                (_U_(0x1) << EIC_IDR_INT6_Pos)
 #define EIC_IDR_INT7_Pos            7            /**< \brief (EIC_IDR) External Interrupt 7 */
-#define EIC_IDR_INT7                (_U(0x1) << EIC_IDR_INT7_Pos)
+#define EIC_IDR_INT7                (_U_(0x1) << EIC_IDR_INT7_Pos)
 #define EIC_IDR_INT8_Pos            8            /**< \brief (EIC_IDR) External Interrupt 8 */
-#define EIC_IDR_INT8                (_U(0x1) << EIC_IDR_INT8_Pos)
+#define EIC_IDR_INT8                (_U_(0x1) << EIC_IDR_INT8_Pos)
 #define EIC_IDR_INT9_Pos            9            /**< \brief (EIC_IDR) External Interrupt 9 */
-#define EIC_IDR_INT9                (_U(0x1) << EIC_IDR_INT9_Pos)
+#define EIC_IDR_INT9                (_U_(0x1) << EIC_IDR_INT9_Pos)
 #define EIC_IDR_INT10_Pos           10           /**< \brief (EIC_IDR) External Interrupt 10 */
-#define EIC_IDR_INT10               (_U(0x1) << EIC_IDR_INT10_Pos)
+#define EIC_IDR_INT10               (_U_(0x1) << EIC_IDR_INT10_Pos)
 #define EIC_IDR_INT11_Pos           11           /**< \brief (EIC_IDR) External Interrupt 11 */
-#define EIC_IDR_INT11               (_U(0x1) << EIC_IDR_INT11_Pos)
+#define EIC_IDR_INT11               (_U_(0x1) << EIC_IDR_INT11_Pos)
 #define EIC_IDR_INT12_Pos           12           /**< \brief (EIC_IDR) External Interrupt 12 */
-#define EIC_IDR_INT12               (_U(0x1) << EIC_IDR_INT12_Pos)
+#define EIC_IDR_INT12               (_U_(0x1) << EIC_IDR_INT12_Pos)
 #define EIC_IDR_INT13_Pos           13           /**< \brief (EIC_IDR) External Interrupt 13 */
-#define EIC_IDR_INT13               (_U(0x1) << EIC_IDR_INT13_Pos)
+#define EIC_IDR_INT13               (_U_(0x1) << EIC_IDR_INT13_Pos)
 #define EIC_IDR_INT14_Pos           14           /**< \brief (EIC_IDR) External Interrupt 14 */
-#define EIC_IDR_INT14               (_U(0x1) << EIC_IDR_INT14_Pos)
+#define EIC_IDR_INT14               (_U_(0x1) << EIC_IDR_INT14_Pos)
 #define EIC_IDR_INT15_Pos           15           /**< \brief (EIC_IDR) External Interrupt 15 */
-#define EIC_IDR_INT15               (_U(0x1) << EIC_IDR_INT15_Pos)
-#define EIC_IDR_MASK                _U(0x0000FFFF) /**< \brief (EIC_IDR) MASK Register */
+#define EIC_IDR_INT15               (_U_(0x1) << EIC_IDR_INT15_Pos)
+#define EIC_IDR_MASK                _U_(0x0000FFFF) /**< \brief (EIC_IDR) MASK Register */
 
 /* -------- EIC_IMR : (EIC Offset: 0x008) (R/  32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -223,57 +223,57 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EIC_IMR_OFFSET              0x008        /**< \brief (EIC_IMR offset) Interrupt Mask Register */
-#define EIC_IMR_RESETVALUE          _U(0x00000000); /**< \brief (EIC_IMR reset_value) Interrupt Mask Register */
+#define EIC_IMR_RESETVALUE          _U_(0x00000000); /**< \brief (EIC_IMR reset_value) Interrupt Mask Register */
 
 #define EIC_IMR_NMI_Pos             0            /**< \brief (EIC_IMR) External Non Maskable CPU interrupt */
-#define EIC_IMR_NMI                 (_U(0x1) << EIC_IMR_NMI_Pos)
+#define EIC_IMR_NMI                 (_U_(0x1) << EIC_IMR_NMI_Pos)
 #define EIC_IMR_INT1_Pos            1            /**< \brief (EIC_IMR) External Interrupt 1 */
-#define EIC_IMR_INT1                (_U(0x1) << EIC_IMR_INT1_Pos)
-#define   EIC_IMR_INT1_0_Val              _U(0x0)   /**< \brief (EIC_IMR) Interrupt is disabled */
-#define   EIC_IMR_INT1_1_Val              _U(0x1)   /**< \brief (EIC_IMR) Interrupt is enabled. */
+#define EIC_IMR_INT1                (_U_(0x1) << EIC_IMR_INT1_Pos)
+#define   EIC_IMR_INT1_0_Val              _U_(0x0)   /**< \brief (EIC_IMR) Interrupt is disabled */
+#define   EIC_IMR_INT1_1_Val              _U_(0x1)   /**< \brief (EIC_IMR) Interrupt is enabled. */
 #define EIC_IMR_INT1_0              (EIC_IMR_INT1_0_Val            << EIC_IMR_INT1_Pos)
 #define EIC_IMR_INT1_1              (EIC_IMR_INT1_1_Val            << EIC_IMR_INT1_Pos)
 #define EIC_IMR_INT2_Pos            2            /**< \brief (EIC_IMR) External Interrupt 2 */
-#define EIC_IMR_INT2                (_U(0x1) << EIC_IMR_INT2_Pos)
-#define   EIC_IMR_INT2_0_Val              _U(0x0)   /**< \brief (EIC_IMR) Interrupt is disabled */
-#define   EIC_IMR_INT2_1_Val              _U(0x1)   /**< \brief (EIC_IMR) Interrupt is enabled. */
+#define EIC_IMR_INT2                (_U_(0x1) << EIC_IMR_INT2_Pos)
+#define   EIC_IMR_INT2_0_Val              _U_(0x0)   /**< \brief (EIC_IMR) Interrupt is disabled */
+#define   EIC_IMR_INT2_1_Val              _U_(0x1)   /**< \brief (EIC_IMR) Interrupt is enabled. */
 #define EIC_IMR_INT2_0              (EIC_IMR_INT2_0_Val            << EIC_IMR_INT2_Pos)
 #define EIC_IMR_INT2_1              (EIC_IMR_INT2_1_Val            << EIC_IMR_INT2_Pos)
 #define EIC_IMR_INT3_Pos            3            /**< \brief (EIC_IMR) External Interrupt 3 */
-#define EIC_IMR_INT3                (_U(0x1) << EIC_IMR_INT3_Pos)
-#define   EIC_IMR_INT3_0_Val              _U(0x0)   /**< \brief (EIC_IMR) Interrupt is disabled */
-#define   EIC_IMR_INT3_1_Val              _U(0x1)   /**< \brief (EIC_IMR) Interrupt is enabled. */
+#define EIC_IMR_INT3                (_U_(0x1) << EIC_IMR_INT3_Pos)
+#define   EIC_IMR_INT3_0_Val              _U_(0x0)   /**< \brief (EIC_IMR) Interrupt is disabled */
+#define   EIC_IMR_INT3_1_Val              _U_(0x1)   /**< \brief (EIC_IMR) Interrupt is enabled. */
 #define EIC_IMR_INT3_0              (EIC_IMR_INT3_0_Val            << EIC_IMR_INT3_Pos)
 #define EIC_IMR_INT3_1              (EIC_IMR_INT3_1_Val            << EIC_IMR_INT3_Pos)
 #define EIC_IMR_INT4_Pos            4            /**< \brief (EIC_IMR) External Interrupt 4 */
-#define EIC_IMR_INT4                (_U(0x1) << EIC_IMR_INT4_Pos)
-#define   EIC_IMR_INT4_0_Val              _U(0x0)   /**< \brief (EIC_IMR) Interrupt is disabled */
-#define   EIC_IMR_INT4_1_Val              _U(0x1)   /**< \brief (EIC_IMR) Interrupt is enabled. */
+#define EIC_IMR_INT4                (_U_(0x1) << EIC_IMR_INT4_Pos)
+#define   EIC_IMR_INT4_0_Val              _U_(0x0)   /**< \brief (EIC_IMR) Interrupt is disabled */
+#define   EIC_IMR_INT4_1_Val              _U_(0x1)   /**< \brief (EIC_IMR) Interrupt is enabled. */
 #define EIC_IMR_INT4_0              (EIC_IMR_INT4_0_Val            << EIC_IMR_INT4_Pos)
 #define EIC_IMR_INT4_1              (EIC_IMR_INT4_1_Val            << EIC_IMR_INT4_Pos)
 #define EIC_IMR_INT5_Pos            5            /**< \brief (EIC_IMR) External Interrupt 5 */
-#define EIC_IMR_INT5                (_U(0x1) << EIC_IMR_INT5_Pos)
+#define EIC_IMR_INT5                (_U_(0x1) << EIC_IMR_INT5_Pos)
 #define EIC_IMR_INT6_Pos            6            /**< \brief (EIC_IMR) External Interrupt 6 */
-#define EIC_IMR_INT6                (_U(0x1) << EIC_IMR_INT6_Pos)
+#define EIC_IMR_INT6                (_U_(0x1) << EIC_IMR_INT6_Pos)
 #define EIC_IMR_INT7_Pos            7            /**< \brief (EIC_IMR) External Interrupt 7 */
-#define EIC_IMR_INT7                (_U(0x1) << EIC_IMR_INT7_Pos)
+#define EIC_IMR_INT7                (_U_(0x1) << EIC_IMR_INT7_Pos)
 #define EIC_IMR_INT8_Pos            8            /**< \brief (EIC_IMR) External Interrupt 8 */
-#define EIC_IMR_INT8                (_U(0x1) << EIC_IMR_INT8_Pos)
+#define EIC_IMR_INT8                (_U_(0x1) << EIC_IMR_INT8_Pos)
 #define EIC_IMR_INT9_Pos            9            /**< \brief (EIC_IMR) External Interrupt 9 */
-#define EIC_IMR_INT9                (_U(0x1) << EIC_IMR_INT9_Pos)
+#define EIC_IMR_INT9                (_U_(0x1) << EIC_IMR_INT9_Pos)
 #define EIC_IMR_INT10_Pos           10           /**< \brief (EIC_IMR) External Interrupt 10 */
-#define EIC_IMR_INT10               (_U(0x1) << EIC_IMR_INT10_Pos)
+#define EIC_IMR_INT10               (_U_(0x1) << EIC_IMR_INT10_Pos)
 #define EIC_IMR_INT11_Pos           11           /**< \brief (EIC_IMR) External Interrupt 11 */
-#define EIC_IMR_INT11               (_U(0x1) << EIC_IMR_INT11_Pos)
+#define EIC_IMR_INT11               (_U_(0x1) << EIC_IMR_INT11_Pos)
 #define EIC_IMR_INT12_Pos           12           /**< \brief (EIC_IMR) External Interrupt 12 */
-#define EIC_IMR_INT12               (_U(0x1) << EIC_IMR_INT12_Pos)
+#define EIC_IMR_INT12               (_U_(0x1) << EIC_IMR_INT12_Pos)
 #define EIC_IMR_INT13_Pos           13           /**< \brief (EIC_IMR) External Interrupt 13 */
-#define EIC_IMR_INT13               (_U(0x1) << EIC_IMR_INT13_Pos)
+#define EIC_IMR_INT13               (_U_(0x1) << EIC_IMR_INT13_Pos)
 #define EIC_IMR_INT14_Pos           14           /**< \brief (EIC_IMR) External Interrupt 14 */
-#define EIC_IMR_INT14               (_U(0x1) << EIC_IMR_INT14_Pos)
+#define EIC_IMR_INT14               (_U_(0x1) << EIC_IMR_INT14_Pos)
 #define EIC_IMR_INT15_Pos           15           /**< \brief (EIC_IMR) External Interrupt 15 */
-#define EIC_IMR_INT15               (_U(0x1) << EIC_IMR_INT15_Pos)
-#define EIC_IMR_MASK                _U(0x0000FFFF) /**< \brief (EIC_IMR) MASK Register */
+#define EIC_IMR_INT15               (_U_(0x1) << EIC_IMR_INT15_Pos)
+#define EIC_IMR_MASK                _U_(0x0000FFFF) /**< \brief (EIC_IMR) MASK Register */
 
 /* -------- EIC_ISR : (EIC Offset: 0x00C) (R/  32) Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -302,57 +302,57 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EIC_ISR_OFFSET              0x00C        /**< \brief (EIC_ISR offset) Interrupt Status Register */
-#define EIC_ISR_RESETVALUE          _U(0x00000000); /**< \brief (EIC_ISR reset_value) Interrupt Status Register */
+#define EIC_ISR_RESETVALUE          _U_(0x00000000); /**< \brief (EIC_ISR reset_value) Interrupt Status Register */
 
 #define EIC_ISR_NMI_Pos             0            /**< \brief (EIC_ISR) External Non Maskable CPU interrupt */
-#define EIC_ISR_NMI                 (_U(0x1) << EIC_ISR_NMI_Pos)
+#define EIC_ISR_NMI                 (_U_(0x1) << EIC_ISR_NMI_Pos)
 #define EIC_ISR_INT1_Pos            1            /**< \brief (EIC_ISR) External Interrupt 1 */
-#define EIC_ISR_INT1                (_U(0x1) << EIC_ISR_INT1_Pos)
-#define   EIC_ISR_INT1_0_Val              _U(0x0)   /**< \brief (EIC_ISR) An interrupt event has not occurred */
-#define   EIC_ISR_INT1_1_Val              _U(0x1)   /**< \brief (EIC_ISR) An interrupt event has occurred. */
+#define EIC_ISR_INT1                (_U_(0x1) << EIC_ISR_INT1_Pos)
+#define   EIC_ISR_INT1_0_Val              _U_(0x0)   /**< \brief (EIC_ISR) An interrupt event has not occurred */
+#define   EIC_ISR_INT1_1_Val              _U_(0x1)   /**< \brief (EIC_ISR) An interrupt event has occurred. */
 #define EIC_ISR_INT1_0              (EIC_ISR_INT1_0_Val            << EIC_ISR_INT1_Pos)
 #define EIC_ISR_INT1_1              (EIC_ISR_INT1_1_Val            << EIC_ISR_INT1_Pos)
 #define EIC_ISR_INT2_Pos            2            /**< \brief (EIC_ISR) External Interrupt 2 */
-#define EIC_ISR_INT2                (_U(0x1) << EIC_ISR_INT2_Pos)
-#define   EIC_ISR_INT2_0_Val              _U(0x0)   /**< \brief (EIC_ISR) An interrupt event has not occurred */
-#define   EIC_ISR_INT2_1_Val              _U(0x1)   /**< \brief (EIC_ISR) An interrupt event has occurred. */
+#define EIC_ISR_INT2                (_U_(0x1) << EIC_ISR_INT2_Pos)
+#define   EIC_ISR_INT2_0_Val              _U_(0x0)   /**< \brief (EIC_ISR) An interrupt event has not occurred */
+#define   EIC_ISR_INT2_1_Val              _U_(0x1)   /**< \brief (EIC_ISR) An interrupt event has occurred. */
 #define EIC_ISR_INT2_0              (EIC_ISR_INT2_0_Val            << EIC_ISR_INT2_Pos)
 #define EIC_ISR_INT2_1              (EIC_ISR_INT2_1_Val            << EIC_ISR_INT2_Pos)
 #define EIC_ISR_INT3_Pos            3            /**< \brief (EIC_ISR) External Interrupt 3 */
-#define EIC_ISR_INT3                (_U(0x1) << EIC_ISR_INT3_Pos)
-#define   EIC_ISR_INT3_0_Val              _U(0x0)   /**< \brief (EIC_ISR) An interrupt event has not occurred */
-#define   EIC_ISR_INT3_1_Val              _U(0x1)   /**< \brief (EIC_ISR) An interrupt event has occurred. */
+#define EIC_ISR_INT3                (_U_(0x1) << EIC_ISR_INT3_Pos)
+#define   EIC_ISR_INT3_0_Val              _U_(0x0)   /**< \brief (EIC_ISR) An interrupt event has not occurred */
+#define   EIC_ISR_INT3_1_Val              _U_(0x1)   /**< \brief (EIC_ISR) An interrupt event has occurred. */
 #define EIC_ISR_INT3_0              (EIC_ISR_INT3_0_Val            << EIC_ISR_INT3_Pos)
 #define EIC_ISR_INT3_1              (EIC_ISR_INT3_1_Val            << EIC_ISR_INT3_Pos)
 #define EIC_ISR_INT4_Pos            4            /**< \brief (EIC_ISR) External Interrupt 4 */
-#define EIC_ISR_INT4                (_U(0x1) << EIC_ISR_INT4_Pos)
-#define   EIC_ISR_INT4_0_Val              _U(0x0)   /**< \brief (EIC_ISR) An interrupt event has not occurred */
-#define   EIC_ISR_INT4_1_Val              _U(0x1)   /**< \brief (EIC_ISR) An interrupt event has occurred. */
+#define EIC_ISR_INT4                (_U_(0x1) << EIC_ISR_INT4_Pos)
+#define   EIC_ISR_INT4_0_Val              _U_(0x0)   /**< \brief (EIC_ISR) An interrupt event has not occurred */
+#define   EIC_ISR_INT4_1_Val              _U_(0x1)   /**< \brief (EIC_ISR) An interrupt event has occurred. */
 #define EIC_ISR_INT4_0              (EIC_ISR_INT4_0_Val            << EIC_ISR_INT4_Pos)
 #define EIC_ISR_INT4_1              (EIC_ISR_INT4_1_Val            << EIC_ISR_INT4_Pos)
 #define EIC_ISR_INT5_Pos            5            /**< \brief (EIC_ISR) External Interrupt 5 */
-#define EIC_ISR_INT5                (_U(0x1) << EIC_ISR_INT5_Pos)
+#define EIC_ISR_INT5                (_U_(0x1) << EIC_ISR_INT5_Pos)
 #define EIC_ISR_INT6_Pos            6            /**< \brief (EIC_ISR) External Interrupt 6 */
-#define EIC_ISR_INT6                (_U(0x1) << EIC_ISR_INT6_Pos)
+#define EIC_ISR_INT6                (_U_(0x1) << EIC_ISR_INT6_Pos)
 #define EIC_ISR_INT7_Pos            7            /**< \brief (EIC_ISR) External Interrupt 7 */
-#define EIC_ISR_INT7                (_U(0x1) << EIC_ISR_INT7_Pos)
+#define EIC_ISR_INT7                (_U_(0x1) << EIC_ISR_INT7_Pos)
 #define EIC_ISR_INT8_Pos            8            /**< \brief (EIC_ISR) External Interrupt 8 */
-#define EIC_ISR_INT8                (_U(0x1) << EIC_ISR_INT8_Pos)
+#define EIC_ISR_INT8                (_U_(0x1) << EIC_ISR_INT8_Pos)
 #define EIC_ISR_INT9_Pos            9            /**< \brief (EIC_ISR) External Interrupt 9 */
-#define EIC_ISR_INT9                (_U(0x1) << EIC_ISR_INT9_Pos)
+#define EIC_ISR_INT9                (_U_(0x1) << EIC_ISR_INT9_Pos)
 #define EIC_ISR_INT10_Pos           10           /**< \brief (EIC_ISR) External Interrupt 10 */
-#define EIC_ISR_INT10               (_U(0x1) << EIC_ISR_INT10_Pos)
+#define EIC_ISR_INT10               (_U_(0x1) << EIC_ISR_INT10_Pos)
 #define EIC_ISR_INT11_Pos           11           /**< \brief (EIC_ISR) External Interrupt 11 */
-#define EIC_ISR_INT11               (_U(0x1) << EIC_ISR_INT11_Pos)
+#define EIC_ISR_INT11               (_U_(0x1) << EIC_ISR_INT11_Pos)
 #define EIC_ISR_INT12_Pos           12           /**< \brief (EIC_ISR) External Interrupt 12 */
-#define EIC_ISR_INT12               (_U(0x1) << EIC_ISR_INT12_Pos)
+#define EIC_ISR_INT12               (_U_(0x1) << EIC_ISR_INT12_Pos)
 #define EIC_ISR_INT13_Pos           13           /**< \brief (EIC_ISR) External Interrupt 13 */
-#define EIC_ISR_INT13               (_U(0x1) << EIC_ISR_INT13_Pos)
+#define EIC_ISR_INT13               (_U_(0x1) << EIC_ISR_INT13_Pos)
 #define EIC_ISR_INT14_Pos           14           /**< \brief (EIC_ISR) External Interrupt 14 */
-#define EIC_ISR_INT14               (_U(0x1) << EIC_ISR_INT14_Pos)
+#define EIC_ISR_INT14               (_U_(0x1) << EIC_ISR_INT14_Pos)
 #define EIC_ISR_INT15_Pos           15           /**< \brief (EIC_ISR) External Interrupt 15 */
-#define EIC_ISR_INT15               (_U(0x1) << EIC_ISR_INT15_Pos)
-#define EIC_ISR_MASK                _U(0x0000FFFF) /**< \brief (EIC_ISR) MASK Register */
+#define EIC_ISR_INT15               (_U_(0x1) << EIC_ISR_INT15_Pos)
+#define EIC_ISR_MASK                _U_(0x0000FFFF) /**< \brief (EIC_ISR) MASK Register */
 
 /* -------- EIC_ICR : (EIC Offset: 0x010) ( /W 32) Interrupt Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -381,57 +381,57 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EIC_ICR_OFFSET              0x010        /**< \brief (EIC_ICR offset) Interrupt Clear Register */
-#define EIC_ICR_RESETVALUE          _U(0x00000000); /**< \brief (EIC_ICR reset_value) Interrupt Clear Register */
+#define EIC_ICR_RESETVALUE          _U_(0x00000000); /**< \brief (EIC_ICR reset_value) Interrupt Clear Register */
 
 #define EIC_ICR_NMI_Pos             0            /**< \brief (EIC_ICR) External Non Maskable CPU interrupt */
-#define EIC_ICR_NMI                 (_U(0x1) << EIC_ICR_NMI_Pos)
+#define EIC_ICR_NMI                 (_U_(0x1) << EIC_ICR_NMI_Pos)
 #define EIC_ICR_INT1_Pos            1            /**< \brief (EIC_ICR) External Interrupt 1 */
-#define EIC_ICR_INT1                (_U(0x1) << EIC_ICR_INT1_Pos)
-#define   EIC_ICR_INT1_0_Val              _U(0x0)   /**< \brief (EIC_ICR) No effect */
-#define   EIC_ICR_INT1_1_Val              _U(0x1)   /**< \brief (EIC_ICR) Clear Interrupt. */
+#define EIC_ICR_INT1                (_U_(0x1) << EIC_ICR_INT1_Pos)
+#define   EIC_ICR_INT1_0_Val              _U_(0x0)   /**< \brief (EIC_ICR) No effect */
+#define   EIC_ICR_INT1_1_Val              _U_(0x1)   /**< \brief (EIC_ICR) Clear Interrupt. */
 #define EIC_ICR_INT1_0              (EIC_ICR_INT1_0_Val            << EIC_ICR_INT1_Pos)
 #define EIC_ICR_INT1_1              (EIC_ICR_INT1_1_Val            << EIC_ICR_INT1_Pos)
 #define EIC_ICR_INT2_Pos            2            /**< \brief (EIC_ICR) External Interrupt 2 */
-#define EIC_ICR_INT2                (_U(0x1) << EIC_ICR_INT2_Pos)
-#define   EIC_ICR_INT2_0_Val              _U(0x0)   /**< \brief (EIC_ICR) No effect */
-#define   EIC_ICR_INT2_1_Val              _U(0x1)   /**< \brief (EIC_ICR) Clear Interrupt. */
+#define EIC_ICR_INT2                (_U_(0x1) << EIC_ICR_INT2_Pos)
+#define   EIC_ICR_INT2_0_Val              _U_(0x0)   /**< \brief (EIC_ICR) No effect */
+#define   EIC_ICR_INT2_1_Val              _U_(0x1)   /**< \brief (EIC_ICR) Clear Interrupt. */
 #define EIC_ICR_INT2_0              (EIC_ICR_INT2_0_Val            << EIC_ICR_INT2_Pos)
 #define EIC_ICR_INT2_1              (EIC_ICR_INT2_1_Val            << EIC_ICR_INT2_Pos)
 #define EIC_ICR_INT3_Pos            3            /**< \brief (EIC_ICR) External Interrupt 3 */
-#define EIC_ICR_INT3                (_U(0x1) << EIC_ICR_INT3_Pos)
-#define   EIC_ICR_INT3_0_Val              _U(0x0)   /**< \brief (EIC_ICR) No effect */
-#define   EIC_ICR_INT3_1_Val              _U(0x1)   /**< \brief (EIC_ICR) Clear Interrupt. */
+#define EIC_ICR_INT3                (_U_(0x1) << EIC_ICR_INT3_Pos)
+#define   EIC_ICR_INT3_0_Val              _U_(0x0)   /**< \brief (EIC_ICR) No effect */
+#define   EIC_ICR_INT3_1_Val              _U_(0x1)   /**< \brief (EIC_ICR) Clear Interrupt. */
 #define EIC_ICR_INT3_0              (EIC_ICR_INT3_0_Val            << EIC_ICR_INT3_Pos)
 #define EIC_ICR_INT3_1              (EIC_ICR_INT3_1_Val            << EIC_ICR_INT3_Pos)
 #define EIC_ICR_INT4_Pos            4            /**< \brief (EIC_ICR) External Interrupt 4 */
-#define EIC_ICR_INT4                (_U(0x1) << EIC_ICR_INT4_Pos)
-#define   EIC_ICR_INT4_0_Val              _U(0x0)   /**< \brief (EIC_ICR) No effect */
-#define   EIC_ICR_INT4_1_Val              _U(0x1)   /**< \brief (EIC_ICR) Clear Interrupt. */
+#define EIC_ICR_INT4                (_U_(0x1) << EIC_ICR_INT4_Pos)
+#define   EIC_ICR_INT4_0_Val              _U_(0x0)   /**< \brief (EIC_ICR) No effect */
+#define   EIC_ICR_INT4_1_Val              _U_(0x1)   /**< \brief (EIC_ICR) Clear Interrupt. */
 #define EIC_ICR_INT4_0              (EIC_ICR_INT4_0_Val            << EIC_ICR_INT4_Pos)
 #define EIC_ICR_INT4_1              (EIC_ICR_INT4_1_Val            << EIC_ICR_INT4_Pos)
 #define EIC_ICR_INT5_Pos            5            /**< \brief (EIC_ICR) External Interrupt 5 */
-#define EIC_ICR_INT5                (_U(0x1) << EIC_ICR_INT5_Pos)
+#define EIC_ICR_INT5                (_U_(0x1) << EIC_ICR_INT5_Pos)
 #define EIC_ICR_INT6_Pos            6            /**< \brief (EIC_ICR) External Interrupt 6 */
-#define EIC_ICR_INT6                (_U(0x1) << EIC_ICR_INT6_Pos)
+#define EIC_ICR_INT6                (_U_(0x1) << EIC_ICR_INT6_Pos)
 #define EIC_ICR_INT7_Pos            7            /**< \brief (EIC_ICR) External Interrupt 7 */
-#define EIC_ICR_INT7                (_U(0x1) << EIC_ICR_INT7_Pos)
+#define EIC_ICR_INT7                (_U_(0x1) << EIC_ICR_INT7_Pos)
 #define EIC_ICR_INT8_Pos            8            /**< \brief (EIC_ICR) External Interrupt 8 */
-#define EIC_ICR_INT8                (_U(0x1) << EIC_ICR_INT8_Pos)
+#define EIC_ICR_INT8                (_U_(0x1) << EIC_ICR_INT8_Pos)
 #define EIC_ICR_INT9_Pos            9            /**< \brief (EIC_ICR) External Interrupt 9 */
-#define EIC_ICR_INT9                (_U(0x1) << EIC_ICR_INT9_Pos)
+#define EIC_ICR_INT9                (_U_(0x1) << EIC_ICR_INT9_Pos)
 #define EIC_ICR_INT10_Pos           10           /**< \brief (EIC_ICR) External Interrupt 10 */
-#define EIC_ICR_INT10               (_U(0x1) << EIC_ICR_INT10_Pos)
+#define EIC_ICR_INT10               (_U_(0x1) << EIC_ICR_INT10_Pos)
 #define EIC_ICR_INT11_Pos           11           /**< \brief (EIC_ICR) External Interrupt 11 */
-#define EIC_ICR_INT11               (_U(0x1) << EIC_ICR_INT11_Pos)
+#define EIC_ICR_INT11               (_U_(0x1) << EIC_ICR_INT11_Pos)
 #define EIC_ICR_INT12_Pos           12           /**< \brief (EIC_ICR) External Interrupt 12 */
-#define EIC_ICR_INT12               (_U(0x1) << EIC_ICR_INT12_Pos)
+#define EIC_ICR_INT12               (_U_(0x1) << EIC_ICR_INT12_Pos)
 #define EIC_ICR_INT13_Pos           13           /**< \brief (EIC_ICR) External Interrupt 13 */
-#define EIC_ICR_INT13               (_U(0x1) << EIC_ICR_INT13_Pos)
+#define EIC_ICR_INT13               (_U_(0x1) << EIC_ICR_INT13_Pos)
 #define EIC_ICR_INT14_Pos           14           /**< \brief (EIC_ICR) External Interrupt 14 */
-#define EIC_ICR_INT14               (_U(0x1) << EIC_ICR_INT14_Pos)
+#define EIC_ICR_INT14               (_U_(0x1) << EIC_ICR_INT14_Pos)
 #define EIC_ICR_INT15_Pos           15           /**< \brief (EIC_ICR) External Interrupt 15 */
-#define EIC_ICR_INT15               (_U(0x1) << EIC_ICR_INT15_Pos)
-#define EIC_ICR_MASK                _U(0x0000FFFF) /**< \brief (EIC_ICR) MASK Register */
+#define EIC_ICR_INT15               (_U_(0x1) << EIC_ICR_INT15_Pos)
+#define EIC_ICR_MASK                _U_(0x0000FFFF) /**< \brief (EIC_ICR) MASK Register */
 
 /* -------- EIC_MODE : (EIC Offset: 0x014) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -460,57 +460,57 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EIC_MODE_OFFSET             0x014        /**< \brief (EIC_MODE offset) Mode Register */
-#define EIC_MODE_RESETVALUE         _U(0x00000000); /**< \brief (EIC_MODE reset_value) Mode Register */
+#define EIC_MODE_RESETVALUE         _U_(0x00000000); /**< \brief (EIC_MODE reset_value) Mode Register */
 
 #define EIC_MODE_NMI_Pos            0            /**< \brief (EIC_MODE) External Non Maskable CPU interrupt */
-#define EIC_MODE_NMI                (_U(0x1) << EIC_MODE_NMI_Pos)
+#define EIC_MODE_NMI                (_U_(0x1) << EIC_MODE_NMI_Pos)
 #define EIC_MODE_INT1_Pos           1            /**< \brief (EIC_MODE) External Interrupt 1 */
-#define EIC_MODE_INT1               (_U(0x1) << EIC_MODE_INT1_Pos)
-#define   EIC_MODE_INT1_0_Val             _U(0x0)   /**< \brief (EIC_MODE) Edge triggered interrupt */
-#define   EIC_MODE_INT1_1_Val             _U(0x1)   /**< \brief (EIC_MODE) Level triggered interrupt */
+#define EIC_MODE_INT1               (_U_(0x1) << EIC_MODE_INT1_Pos)
+#define   EIC_MODE_INT1_0_Val             _U_(0x0)   /**< \brief (EIC_MODE) Edge triggered interrupt */
+#define   EIC_MODE_INT1_1_Val             _U_(0x1)   /**< \brief (EIC_MODE) Level triggered interrupt */
 #define EIC_MODE_INT1_0             (EIC_MODE_INT1_0_Val           << EIC_MODE_INT1_Pos)
 #define EIC_MODE_INT1_1             (EIC_MODE_INT1_1_Val           << EIC_MODE_INT1_Pos)
 #define EIC_MODE_INT2_Pos           2            /**< \brief (EIC_MODE) External Interrupt 2 */
-#define EIC_MODE_INT2               (_U(0x1) << EIC_MODE_INT2_Pos)
-#define   EIC_MODE_INT2_0_Val             _U(0x0)   /**< \brief (EIC_MODE) Edge triggered interrupt */
-#define   EIC_MODE_INT2_1_Val             _U(0x1)   /**< \brief (EIC_MODE) Level triggered interrupt */
+#define EIC_MODE_INT2               (_U_(0x1) << EIC_MODE_INT2_Pos)
+#define   EIC_MODE_INT2_0_Val             _U_(0x0)   /**< \brief (EIC_MODE) Edge triggered interrupt */
+#define   EIC_MODE_INT2_1_Val             _U_(0x1)   /**< \brief (EIC_MODE) Level triggered interrupt */
 #define EIC_MODE_INT2_0             (EIC_MODE_INT2_0_Val           << EIC_MODE_INT2_Pos)
 #define EIC_MODE_INT2_1             (EIC_MODE_INT2_1_Val           << EIC_MODE_INT2_Pos)
 #define EIC_MODE_INT3_Pos           3            /**< \brief (EIC_MODE) External Interrupt 3 */
-#define EIC_MODE_INT3               (_U(0x1) << EIC_MODE_INT3_Pos)
-#define   EIC_MODE_INT3_0_Val             _U(0x0)   /**< \brief (EIC_MODE) Edge triggered interrupt */
-#define   EIC_MODE_INT3_1_Val             _U(0x1)   /**< \brief (EIC_MODE) Level triggered interrupt */
+#define EIC_MODE_INT3               (_U_(0x1) << EIC_MODE_INT3_Pos)
+#define   EIC_MODE_INT3_0_Val             _U_(0x0)   /**< \brief (EIC_MODE) Edge triggered interrupt */
+#define   EIC_MODE_INT3_1_Val             _U_(0x1)   /**< \brief (EIC_MODE) Level triggered interrupt */
 #define EIC_MODE_INT3_0             (EIC_MODE_INT3_0_Val           << EIC_MODE_INT3_Pos)
 #define EIC_MODE_INT3_1             (EIC_MODE_INT3_1_Val           << EIC_MODE_INT3_Pos)
 #define EIC_MODE_INT4_Pos           4            /**< \brief (EIC_MODE) External Interrupt 4 */
-#define EIC_MODE_INT4               (_U(0x1) << EIC_MODE_INT4_Pos)
-#define   EIC_MODE_INT4_0_Val             _U(0x0)   /**< \brief (EIC_MODE) Edge triggered interrupt */
-#define   EIC_MODE_INT4_1_Val             _U(0x1)   /**< \brief (EIC_MODE) Level triggered interrupt */
+#define EIC_MODE_INT4               (_U_(0x1) << EIC_MODE_INT4_Pos)
+#define   EIC_MODE_INT4_0_Val             _U_(0x0)   /**< \brief (EIC_MODE) Edge triggered interrupt */
+#define   EIC_MODE_INT4_1_Val             _U_(0x1)   /**< \brief (EIC_MODE) Level triggered interrupt */
 #define EIC_MODE_INT4_0             (EIC_MODE_INT4_0_Val           << EIC_MODE_INT4_Pos)
 #define EIC_MODE_INT4_1             (EIC_MODE_INT4_1_Val           << EIC_MODE_INT4_Pos)
 #define EIC_MODE_INT5_Pos           5            /**< \brief (EIC_MODE) External Interrupt 5 */
-#define EIC_MODE_INT5               (_U(0x1) << EIC_MODE_INT5_Pos)
+#define EIC_MODE_INT5               (_U_(0x1) << EIC_MODE_INT5_Pos)
 #define EIC_MODE_INT6_Pos           6            /**< \brief (EIC_MODE) External Interrupt 6 */
-#define EIC_MODE_INT6               (_U(0x1) << EIC_MODE_INT6_Pos)
+#define EIC_MODE_INT6               (_U_(0x1) << EIC_MODE_INT6_Pos)
 #define EIC_MODE_INT7_Pos           7            /**< \brief (EIC_MODE) External Interrupt 7 */
-#define EIC_MODE_INT7               (_U(0x1) << EIC_MODE_INT7_Pos)
+#define EIC_MODE_INT7               (_U_(0x1) << EIC_MODE_INT7_Pos)
 #define EIC_MODE_INT8_Pos           8            /**< \brief (EIC_MODE) External Interrupt 8 */
-#define EIC_MODE_INT8               (_U(0x1) << EIC_MODE_INT8_Pos)
+#define EIC_MODE_INT8               (_U_(0x1) << EIC_MODE_INT8_Pos)
 #define EIC_MODE_INT9_Pos           9            /**< \brief (EIC_MODE) External Interrupt 9 */
-#define EIC_MODE_INT9               (_U(0x1) << EIC_MODE_INT9_Pos)
+#define EIC_MODE_INT9               (_U_(0x1) << EIC_MODE_INT9_Pos)
 #define EIC_MODE_INT10_Pos          10           /**< \brief (EIC_MODE) External Interrupt 10 */
-#define EIC_MODE_INT10              (_U(0x1) << EIC_MODE_INT10_Pos)
+#define EIC_MODE_INT10              (_U_(0x1) << EIC_MODE_INT10_Pos)
 #define EIC_MODE_INT11_Pos          11           /**< \brief (EIC_MODE) External Interrupt 11 */
-#define EIC_MODE_INT11              (_U(0x1) << EIC_MODE_INT11_Pos)
+#define EIC_MODE_INT11              (_U_(0x1) << EIC_MODE_INT11_Pos)
 #define EIC_MODE_INT12_Pos          12           /**< \brief (EIC_MODE) External Interrupt 12 */
-#define EIC_MODE_INT12              (_U(0x1) << EIC_MODE_INT12_Pos)
+#define EIC_MODE_INT12              (_U_(0x1) << EIC_MODE_INT12_Pos)
 #define EIC_MODE_INT13_Pos          13           /**< \brief (EIC_MODE) External Interrupt 13 */
-#define EIC_MODE_INT13              (_U(0x1) << EIC_MODE_INT13_Pos)
+#define EIC_MODE_INT13              (_U_(0x1) << EIC_MODE_INT13_Pos)
 #define EIC_MODE_INT14_Pos          14           /**< \brief (EIC_MODE) External Interrupt 14 */
-#define EIC_MODE_INT14              (_U(0x1) << EIC_MODE_INT14_Pos)
+#define EIC_MODE_INT14              (_U_(0x1) << EIC_MODE_INT14_Pos)
 #define EIC_MODE_INT15_Pos          15           /**< \brief (EIC_MODE) External Interrupt 15 */
-#define EIC_MODE_INT15              (_U(0x1) << EIC_MODE_INT15_Pos)
-#define EIC_MODE_MASK               _U(0x0000FFFF) /**< \brief (EIC_MODE) MASK Register */
+#define EIC_MODE_INT15              (_U_(0x1) << EIC_MODE_INT15_Pos)
+#define EIC_MODE_MASK               _U_(0x0000FFFF) /**< \brief (EIC_MODE) MASK Register */
 
 /* -------- EIC_EDGE : (EIC Offset: 0x018) (R/W 32) Edge Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -539,57 +539,57 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EIC_EDGE_OFFSET             0x018        /**< \brief (EIC_EDGE offset) Edge Register */
-#define EIC_EDGE_RESETVALUE         _U(0x00000000); /**< \brief (EIC_EDGE reset_value) Edge Register */
+#define EIC_EDGE_RESETVALUE         _U_(0x00000000); /**< \brief (EIC_EDGE reset_value) Edge Register */
 
 #define EIC_EDGE_NMI_Pos            0            /**< \brief (EIC_EDGE) External Non Maskable CPU interrupt */
-#define EIC_EDGE_NMI                (_U(0x1) << EIC_EDGE_NMI_Pos)
+#define EIC_EDGE_NMI                (_U_(0x1) << EIC_EDGE_NMI_Pos)
 #define EIC_EDGE_INT1_Pos           1            /**< \brief (EIC_EDGE) External Interrupt 1 */
-#define EIC_EDGE_INT1               (_U(0x1) << EIC_EDGE_INT1_Pos)
-#define   EIC_EDGE_INT1_0_Val             _U(0x0)   /**< \brief (EIC_EDGE) Triggers on falling edge */
-#define   EIC_EDGE_INT1_1_Val             _U(0x1)   /**< \brief (EIC_EDGE) Triggers on rising edge. */
+#define EIC_EDGE_INT1               (_U_(0x1) << EIC_EDGE_INT1_Pos)
+#define   EIC_EDGE_INT1_0_Val             _U_(0x0)   /**< \brief (EIC_EDGE) Triggers on falling edge */
+#define   EIC_EDGE_INT1_1_Val             _U_(0x1)   /**< \brief (EIC_EDGE) Triggers on rising edge. */
 #define EIC_EDGE_INT1_0             (EIC_EDGE_INT1_0_Val           << EIC_EDGE_INT1_Pos)
 #define EIC_EDGE_INT1_1             (EIC_EDGE_INT1_1_Val           << EIC_EDGE_INT1_Pos)
 #define EIC_EDGE_INT2_Pos           2            /**< \brief (EIC_EDGE) External Interrupt 2 */
-#define EIC_EDGE_INT2               (_U(0x1) << EIC_EDGE_INT2_Pos)
-#define   EIC_EDGE_INT2_0_Val             _U(0x0)   /**< \brief (EIC_EDGE) Triggers on falling edge */
-#define   EIC_EDGE_INT2_1_Val             _U(0x1)   /**< \brief (EIC_EDGE) Triggers on rising edge. */
+#define EIC_EDGE_INT2               (_U_(0x1) << EIC_EDGE_INT2_Pos)
+#define   EIC_EDGE_INT2_0_Val             _U_(0x0)   /**< \brief (EIC_EDGE) Triggers on falling edge */
+#define   EIC_EDGE_INT2_1_Val             _U_(0x1)   /**< \brief (EIC_EDGE) Triggers on rising edge. */
 #define EIC_EDGE_INT2_0             (EIC_EDGE_INT2_0_Val           << EIC_EDGE_INT2_Pos)
 #define EIC_EDGE_INT2_1             (EIC_EDGE_INT2_1_Val           << EIC_EDGE_INT2_Pos)
 #define EIC_EDGE_INT3_Pos           3            /**< \brief (EIC_EDGE) External Interrupt 3 */
-#define EIC_EDGE_INT3               (_U(0x1) << EIC_EDGE_INT3_Pos)
-#define   EIC_EDGE_INT3_0_Val             _U(0x0)   /**< \brief (EIC_EDGE) Triggers on falling edge */
-#define   EIC_EDGE_INT3_1_Val             _U(0x1)   /**< \brief (EIC_EDGE) Triggers on rising edge. */
+#define EIC_EDGE_INT3               (_U_(0x1) << EIC_EDGE_INT3_Pos)
+#define   EIC_EDGE_INT3_0_Val             _U_(0x0)   /**< \brief (EIC_EDGE) Triggers on falling edge */
+#define   EIC_EDGE_INT3_1_Val             _U_(0x1)   /**< \brief (EIC_EDGE) Triggers on rising edge. */
 #define EIC_EDGE_INT3_0             (EIC_EDGE_INT3_0_Val           << EIC_EDGE_INT3_Pos)
 #define EIC_EDGE_INT3_1             (EIC_EDGE_INT3_1_Val           << EIC_EDGE_INT3_Pos)
 #define EIC_EDGE_INT4_Pos           4            /**< \brief (EIC_EDGE) External Interrupt 4 */
-#define EIC_EDGE_INT4               (_U(0x1) << EIC_EDGE_INT4_Pos)
-#define   EIC_EDGE_INT4_0_Val             _U(0x0)   /**< \brief (EIC_EDGE) Triggers on falling edge */
-#define   EIC_EDGE_INT4_1_Val             _U(0x1)   /**< \brief (EIC_EDGE) Triggers on rising edge. */
+#define EIC_EDGE_INT4               (_U_(0x1) << EIC_EDGE_INT4_Pos)
+#define   EIC_EDGE_INT4_0_Val             _U_(0x0)   /**< \brief (EIC_EDGE) Triggers on falling edge */
+#define   EIC_EDGE_INT4_1_Val             _U_(0x1)   /**< \brief (EIC_EDGE) Triggers on rising edge. */
 #define EIC_EDGE_INT4_0             (EIC_EDGE_INT4_0_Val           << EIC_EDGE_INT4_Pos)
 #define EIC_EDGE_INT4_1             (EIC_EDGE_INT4_1_Val           << EIC_EDGE_INT4_Pos)
 #define EIC_EDGE_INT5_Pos           5            /**< \brief (EIC_EDGE) External Interrupt 5 */
-#define EIC_EDGE_INT5               (_U(0x1) << EIC_EDGE_INT5_Pos)
+#define EIC_EDGE_INT5               (_U_(0x1) << EIC_EDGE_INT5_Pos)
 #define EIC_EDGE_INT6_Pos           6            /**< \brief (EIC_EDGE) External Interrupt 6 */
-#define EIC_EDGE_INT6               (_U(0x1) << EIC_EDGE_INT6_Pos)
+#define EIC_EDGE_INT6               (_U_(0x1) << EIC_EDGE_INT6_Pos)
 #define EIC_EDGE_INT7_Pos           7            /**< \brief (EIC_EDGE) External Interrupt 7 */
-#define EIC_EDGE_INT7               (_U(0x1) << EIC_EDGE_INT7_Pos)
+#define EIC_EDGE_INT7               (_U_(0x1) << EIC_EDGE_INT7_Pos)
 #define EIC_EDGE_INT8_Pos           8            /**< \brief (EIC_EDGE) External Interrupt 8 */
-#define EIC_EDGE_INT8               (_U(0x1) << EIC_EDGE_INT8_Pos)
+#define EIC_EDGE_INT8               (_U_(0x1) << EIC_EDGE_INT8_Pos)
 #define EIC_EDGE_INT9_Pos           9            /**< \brief (EIC_EDGE) External Interrupt 9 */
-#define EIC_EDGE_INT9               (_U(0x1) << EIC_EDGE_INT9_Pos)
+#define EIC_EDGE_INT9               (_U_(0x1) << EIC_EDGE_INT9_Pos)
 #define EIC_EDGE_INT10_Pos          10           /**< \brief (EIC_EDGE) External Interrupt 10 */
-#define EIC_EDGE_INT10              (_U(0x1) << EIC_EDGE_INT10_Pos)
+#define EIC_EDGE_INT10              (_U_(0x1) << EIC_EDGE_INT10_Pos)
 #define EIC_EDGE_INT11_Pos          11           /**< \brief (EIC_EDGE) External Interrupt 11 */
-#define EIC_EDGE_INT11              (_U(0x1) << EIC_EDGE_INT11_Pos)
+#define EIC_EDGE_INT11              (_U_(0x1) << EIC_EDGE_INT11_Pos)
 #define EIC_EDGE_INT12_Pos          12           /**< \brief (EIC_EDGE) External Interrupt 12 */
-#define EIC_EDGE_INT12              (_U(0x1) << EIC_EDGE_INT12_Pos)
+#define EIC_EDGE_INT12              (_U_(0x1) << EIC_EDGE_INT12_Pos)
 #define EIC_EDGE_INT13_Pos          13           /**< \brief (EIC_EDGE) External Interrupt 13 */
-#define EIC_EDGE_INT13              (_U(0x1) << EIC_EDGE_INT13_Pos)
+#define EIC_EDGE_INT13              (_U_(0x1) << EIC_EDGE_INT13_Pos)
 #define EIC_EDGE_INT14_Pos          14           /**< \brief (EIC_EDGE) External Interrupt 14 */
-#define EIC_EDGE_INT14              (_U(0x1) << EIC_EDGE_INT14_Pos)
+#define EIC_EDGE_INT14              (_U_(0x1) << EIC_EDGE_INT14_Pos)
 #define EIC_EDGE_INT15_Pos          15           /**< \brief (EIC_EDGE) External Interrupt 15 */
-#define EIC_EDGE_INT15              (_U(0x1) << EIC_EDGE_INT15_Pos)
-#define EIC_EDGE_MASK               _U(0x0000FFFF) /**< \brief (EIC_EDGE) MASK Register */
+#define EIC_EDGE_INT15              (_U_(0x1) << EIC_EDGE_INT15_Pos)
+#define EIC_EDGE_MASK               _U_(0x0000FFFF) /**< \brief (EIC_EDGE) MASK Register */
 
 /* -------- EIC_LEVEL : (EIC Offset: 0x01C) (R/W 32) Level Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -618,41 +618,41 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EIC_LEVEL_OFFSET            0x01C        /**< \brief (EIC_LEVEL offset) Level Register */
-#define EIC_LEVEL_RESETVALUE        _U(0x00000000); /**< \brief (EIC_LEVEL reset_value) Level Register */
+#define EIC_LEVEL_RESETVALUE        _U_(0x00000000); /**< \brief (EIC_LEVEL reset_value) Level Register */
 
 #define EIC_LEVEL_NMI_Pos           0            /**< \brief (EIC_LEVEL) External Non Maskable CPU interrupt */
-#define EIC_LEVEL_NMI               (_U(0x1) << EIC_LEVEL_NMI_Pos)
+#define EIC_LEVEL_NMI               (_U_(0x1) << EIC_LEVEL_NMI_Pos)
 #define EIC_LEVEL_INT1_Pos          1            /**< \brief (EIC_LEVEL) External Interrupt 1 */
-#define EIC_LEVEL_INT1              (_U(0x1) << EIC_LEVEL_INT1_Pos)
+#define EIC_LEVEL_INT1              (_U_(0x1) << EIC_LEVEL_INT1_Pos)
 #define EIC_LEVEL_INT2_Pos          2            /**< \brief (EIC_LEVEL) External Interrupt 2 */
-#define EIC_LEVEL_INT2              (_U(0x1) << EIC_LEVEL_INT2_Pos)
+#define EIC_LEVEL_INT2              (_U_(0x1) << EIC_LEVEL_INT2_Pos)
 #define EIC_LEVEL_INT3_Pos          3            /**< \brief (EIC_LEVEL) External Interrupt 3 */
-#define EIC_LEVEL_INT3              (_U(0x1) << EIC_LEVEL_INT3_Pos)
+#define EIC_LEVEL_INT3              (_U_(0x1) << EIC_LEVEL_INT3_Pos)
 #define EIC_LEVEL_INT4_Pos          4            /**< \brief (EIC_LEVEL) External Interrupt 4 */
-#define EIC_LEVEL_INT4              (_U(0x1) << EIC_LEVEL_INT4_Pos)
+#define EIC_LEVEL_INT4              (_U_(0x1) << EIC_LEVEL_INT4_Pos)
 #define EIC_LEVEL_INT5_Pos          5            /**< \brief (EIC_LEVEL) External Interrupt 5 */
-#define EIC_LEVEL_INT5              (_U(0x1) << EIC_LEVEL_INT5_Pos)
+#define EIC_LEVEL_INT5              (_U_(0x1) << EIC_LEVEL_INT5_Pos)
 #define EIC_LEVEL_INT6_Pos          6            /**< \brief (EIC_LEVEL) External Interrupt 6 */
-#define EIC_LEVEL_INT6              (_U(0x1) << EIC_LEVEL_INT6_Pos)
+#define EIC_LEVEL_INT6              (_U_(0x1) << EIC_LEVEL_INT6_Pos)
 #define EIC_LEVEL_INT7_Pos          7            /**< \brief (EIC_LEVEL) External Interrupt 7 */
-#define EIC_LEVEL_INT7              (_U(0x1) << EIC_LEVEL_INT7_Pos)
+#define EIC_LEVEL_INT7              (_U_(0x1) << EIC_LEVEL_INT7_Pos)
 #define EIC_LEVEL_INT8_Pos          8            /**< \brief (EIC_LEVEL) External Interrupt 8 */
-#define EIC_LEVEL_INT8              (_U(0x1) << EIC_LEVEL_INT8_Pos)
+#define EIC_LEVEL_INT8              (_U_(0x1) << EIC_LEVEL_INT8_Pos)
 #define EIC_LEVEL_INT9_Pos          9            /**< \brief (EIC_LEVEL) External Interrupt 9 */
-#define EIC_LEVEL_INT9              (_U(0x1) << EIC_LEVEL_INT9_Pos)
+#define EIC_LEVEL_INT9              (_U_(0x1) << EIC_LEVEL_INT9_Pos)
 #define EIC_LEVEL_INT10_Pos         10           /**< \brief (EIC_LEVEL) External Interrupt 10 */
-#define EIC_LEVEL_INT10             (_U(0x1) << EIC_LEVEL_INT10_Pos)
+#define EIC_LEVEL_INT10             (_U_(0x1) << EIC_LEVEL_INT10_Pos)
 #define EIC_LEVEL_INT11_Pos         11           /**< \brief (EIC_LEVEL) External Interrupt 11 */
-#define EIC_LEVEL_INT11             (_U(0x1) << EIC_LEVEL_INT11_Pos)
+#define EIC_LEVEL_INT11             (_U_(0x1) << EIC_LEVEL_INT11_Pos)
 #define EIC_LEVEL_INT12_Pos         12           /**< \brief (EIC_LEVEL) External Interrupt 12 */
-#define EIC_LEVEL_INT12             (_U(0x1) << EIC_LEVEL_INT12_Pos)
+#define EIC_LEVEL_INT12             (_U_(0x1) << EIC_LEVEL_INT12_Pos)
 #define EIC_LEVEL_INT13_Pos         13           /**< \brief (EIC_LEVEL) External Interrupt 13 */
-#define EIC_LEVEL_INT13             (_U(0x1) << EIC_LEVEL_INT13_Pos)
+#define EIC_LEVEL_INT13             (_U_(0x1) << EIC_LEVEL_INT13_Pos)
 #define EIC_LEVEL_INT14_Pos         14           /**< \brief (EIC_LEVEL) External Interrupt 14 */
-#define EIC_LEVEL_INT14             (_U(0x1) << EIC_LEVEL_INT14_Pos)
+#define EIC_LEVEL_INT14             (_U_(0x1) << EIC_LEVEL_INT14_Pos)
 #define EIC_LEVEL_INT15_Pos         15           /**< \brief (EIC_LEVEL) External Interrupt 15 */
-#define EIC_LEVEL_INT15             (_U(0x1) << EIC_LEVEL_INT15_Pos)
-#define EIC_LEVEL_MASK              _U(0x0000FFFF) /**< \brief (EIC_LEVEL) MASK Register */
+#define EIC_LEVEL_INT15             (_U_(0x1) << EIC_LEVEL_INT15_Pos)
+#define EIC_LEVEL_MASK              _U_(0x0000FFFF) /**< \brief (EIC_LEVEL) MASK Register */
 
 /* -------- EIC_FILTER : (EIC Offset: 0x020) (R/W 32) Filter Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -681,41 +681,41 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EIC_FILTER_OFFSET           0x020        /**< \brief (EIC_FILTER offset) Filter Register */
-#define EIC_FILTER_RESETVALUE       _U(0x00000000); /**< \brief (EIC_FILTER reset_value) Filter Register */
+#define EIC_FILTER_RESETVALUE       _U_(0x00000000); /**< \brief (EIC_FILTER reset_value) Filter Register */
 
 #define EIC_FILTER_NMI_Pos          0            /**< \brief (EIC_FILTER) External Non Maskable CPU interrupt */
-#define EIC_FILTER_NMI              (_U(0x1) << EIC_FILTER_NMI_Pos)
+#define EIC_FILTER_NMI              (_U_(0x1) << EIC_FILTER_NMI_Pos)
 #define EIC_FILTER_INT1_Pos         1            /**< \brief (EIC_FILTER) External Interrupt 1 */
-#define EIC_FILTER_INT1             (_U(0x1) << EIC_FILTER_INT1_Pos)
+#define EIC_FILTER_INT1             (_U_(0x1) << EIC_FILTER_INT1_Pos)
 #define EIC_FILTER_INT2_Pos         2            /**< \brief (EIC_FILTER) External Interrupt 2 */
-#define EIC_FILTER_INT2             (_U(0x1) << EIC_FILTER_INT2_Pos)
+#define EIC_FILTER_INT2             (_U_(0x1) << EIC_FILTER_INT2_Pos)
 #define EIC_FILTER_INT3_Pos         3            /**< \brief (EIC_FILTER) External Interrupt 3 */
-#define EIC_FILTER_INT3             (_U(0x1) << EIC_FILTER_INT3_Pos)
+#define EIC_FILTER_INT3             (_U_(0x1) << EIC_FILTER_INT3_Pos)
 #define EIC_FILTER_INT4_Pos         4            /**< \brief (EIC_FILTER) External Interrupt 4 */
-#define EIC_FILTER_INT4             (_U(0x1) << EIC_FILTER_INT4_Pos)
+#define EIC_FILTER_INT4             (_U_(0x1) << EIC_FILTER_INT4_Pos)
 #define EIC_FILTER_INT5_Pos         5            /**< \brief (EIC_FILTER) External Interrupt 5 */
-#define EIC_FILTER_INT5             (_U(0x1) << EIC_FILTER_INT5_Pos)
+#define EIC_FILTER_INT5             (_U_(0x1) << EIC_FILTER_INT5_Pos)
 #define EIC_FILTER_INT6_Pos         6            /**< \brief (EIC_FILTER) External Interrupt 6 */
-#define EIC_FILTER_INT6             (_U(0x1) << EIC_FILTER_INT6_Pos)
+#define EIC_FILTER_INT6             (_U_(0x1) << EIC_FILTER_INT6_Pos)
 #define EIC_FILTER_INT7_Pos         7            /**< \brief (EIC_FILTER) External Interrupt 7 */
-#define EIC_FILTER_INT7             (_U(0x1) << EIC_FILTER_INT7_Pos)
+#define EIC_FILTER_INT7             (_U_(0x1) << EIC_FILTER_INT7_Pos)
 #define EIC_FILTER_INT8_Pos         8            /**< \brief (EIC_FILTER) External Interrupt 8 */
-#define EIC_FILTER_INT8             (_U(0x1) << EIC_FILTER_INT8_Pos)
+#define EIC_FILTER_INT8             (_U_(0x1) << EIC_FILTER_INT8_Pos)
 #define EIC_FILTER_INT9_Pos         9            /**< \brief (EIC_FILTER) External Interrupt 9 */
-#define EIC_FILTER_INT9             (_U(0x1) << EIC_FILTER_INT9_Pos)
+#define EIC_FILTER_INT9             (_U_(0x1) << EIC_FILTER_INT9_Pos)
 #define EIC_FILTER_INT10_Pos        10           /**< \brief (EIC_FILTER) External Interrupt 10 */
-#define EIC_FILTER_INT10            (_U(0x1) << EIC_FILTER_INT10_Pos)
+#define EIC_FILTER_INT10            (_U_(0x1) << EIC_FILTER_INT10_Pos)
 #define EIC_FILTER_INT11_Pos        11           /**< \brief (EIC_FILTER) External Interrupt 11 */
-#define EIC_FILTER_INT11            (_U(0x1) << EIC_FILTER_INT11_Pos)
+#define EIC_FILTER_INT11            (_U_(0x1) << EIC_FILTER_INT11_Pos)
 #define EIC_FILTER_INT12_Pos        12           /**< \brief (EIC_FILTER) External Interrupt 12 */
-#define EIC_FILTER_INT12            (_U(0x1) << EIC_FILTER_INT12_Pos)
+#define EIC_FILTER_INT12            (_U_(0x1) << EIC_FILTER_INT12_Pos)
 #define EIC_FILTER_INT13_Pos        13           /**< \brief (EIC_FILTER) External Interrupt 13 */
-#define EIC_FILTER_INT13            (_U(0x1) << EIC_FILTER_INT13_Pos)
+#define EIC_FILTER_INT13            (_U_(0x1) << EIC_FILTER_INT13_Pos)
 #define EIC_FILTER_INT14_Pos        14           /**< \brief (EIC_FILTER) External Interrupt 14 */
-#define EIC_FILTER_INT14            (_U(0x1) << EIC_FILTER_INT14_Pos)
+#define EIC_FILTER_INT14            (_U_(0x1) << EIC_FILTER_INT14_Pos)
 #define EIC_FILTER_INT15_Pos        15           /**< \brief (EIC_FILTER) External Interrupt 15 */
-#define EIC_FILTER_INT15            (_U(0x1) << EIC_FILTER_INT15_Pos)
-#define EIC_FILTER_MASK             _U(0x0000FFFF) /**< \brief (EIC_FILTER) MASK Register */
+#define EIC_FILTER_INT15            (_U_(0x1) << EIC_FILTER_INT15_Pos)
+#define EIC_FILTER_MASK             _U_(0x0000FFFF) /**< \brief (EIC_FILTER) MASK Register */
 
 /* -------- EIC_ASYNC : (EIC Offset: 0x028) (R/W 32) Asynchronous Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -744,41 +744,41 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EIC_ASYNC_OFFSET            0x028        /**< \brief (EIC_ASYNC offset) Asynchronous Register */
-#define EIC_ASYNC_RESETVALUE        _U(0x00000000); /**< \brief (EIC_ASYNC reset_value) Asynchronous Register */
+#define EIC_ASYNC_RESETVALUE        _U_(0x00000000); /**< \brief (EIC_ASYNC reset_value) Asynchronous Register */
 
 #define EIC_ASYNC_NMI_Pos           0            /**< \brief (EIC_ASYNC) External Non Maskable CPU interrupt */
-#define EIC_ASYNC_NMI               (_U(0x1) << EIC_ASYNC_NMI_Pos)
+#define EIC_ASYNC_NMI               (_U_(0x1) << EIC_ASYNC_NMI_Pos)
 #define EIC_ASYNC_INT1_Pos          1            /**< \brief (EIC_ASYNC) External Interrupt 1 */
-#define EIC_ASYNC_INT1              (_U(0x1) << EIC_ASYNC_INT1_Pos)
+#define EIC_ASYNC_INT1              (_U_(0x1) << EIC_ASYNC_INT1_Pos)
 #define EIC_ASYNC_INT2_Pos          2            /**< \brief (EIC_ASYNC) External Interrupt 2 */
-#define EIC_ASYNC_INT2              (_U(0x1) << EIC_ASYNC_INT2_Pos)
+#define EIC_ASYNC_INT2              (_U_(0x1) << EIC_ASYNC_INT2_Pos)
 #define EIC_ASYNC_INT3_Pos          3            /**< \brief (EIC_ASYNC) External Interrupt 3 */
-#define EIC_ASYNC_INT3              (_U(0x1) << EIC_ASYNC_INT3_Pos)
+#define EIC_ASYNC_INT3              (_U_(0x1) << EIC_ASYNC_INT3_Pos)
 #define EIC_ASYNC_INT4_Pos          4            /**< \brief (EIC_ASYNC) External Interrupt 4 */
-#define EIC_ASYNC_INT4              (_U(0x1) << EIC_ASYNC_INT4_Pos)
+#define EIC_ASYNC_INT4              (_U_(0x1) << EIC_ASYNC_INT4_Pos)
 #define EIC_ASYNC_INT5_Pos          5            /**< \brief (EIC_ASYNC) External Interrupt 5 */
-#define EIC_ASYNC_INT5              (_U(0x1) << EIC_ASYNC_INT5_Pos)
+#define EIC_ASYNC_INT5              (_U_(0x1) << EIC_ASYNC_INT5_Pos)
 #define EIC_ASYNC_INT6_Pos          6            /**< \brief (EIC_ASYNC) External Interrupt 6 */
-#define EIC_ASYNC_INT6              (_U(0x1) << EIC_ASYNC_INT6_Pos)
+#define EIC_ASYNC_INT6              (_U_(0x1) << EIC_ASYNC_INT6_Pos)
 #define EIC_ASYNC_INT7_Pos          7            /**< \brief (EIC_ASYNC) External Interrupt 7 */
-#define EIC_ASYNC_INT7              (_U(0x1) << EIC_ASYNC_INT7_Pos)
+#define EIC_ASYNC_INT7              (_U_(0x1) << EIC_ASYNC_INT7_Pos)
 #define EIC_ASYNC_INT8_Pos          8            /**< \brief (EIC_ASYNC) External Interrupt 8 */
-#define EIC_ASYNC_INT8              (_U(0x1) << EIC_ASYNC_INT8_Pos)
+#define EIC_ASYNC_INT8              (_U_(0x1) << EIC_ASYNC_INT8_Pos)
 #define EIC_ASYNC_INT9_Pos          9            /**< \brief (EIC_ASYNC) External Interrupt 9 */
-#define EIC_ASYNC_INT9              (_U(0x1) << EIC_ASYNC_INT9_Pos)
+#define EIC_ASYNC_INT9              (_U_(0x1) << EIC_ASYNC_INT9_Pos)
 #define EIC_ASYNC_INT10_Pos         10           /**< \brief (EIC_ASYNC) External Interrupt 10 */
-#define EIC_ASYNC_INT10             (_U(0x1) << EIC_ASYNC_INT10_Pos)
+#define EIC_ASYNC_INT10             (_U_(0x1) << EIC_ASYNC_INT10_Pos)
 #define EIC_ASYNC_INT11_Pos         11           /**< \brief (EIC_ASYNC) External Interrupt 11 */
-#define EIC_ASYNC_INT11             (_U(0x1) << EIC_ASYNC_INT11_Pos)
+#define EIC_ASYNC_INT11             (_U_(0x1) << EIC_ASYNC_INT11_Pos)
 #define EIC_ASYNC_INT12_Pos         12           /**< \brief (EIC_ASYNC) External Interrupt 12 */
-#define EIC_ASYNC_INT12             (_U(0x1) << EIC_ASYNC_INT12_Pos)
+#define EIC_ASYNC_INT12             (_U_(0x1) << EIC_ASYNC_INT12_Pos)
 #define EIC_ASYNC_INT13_Pos         13           /**< \brief (EIC_ASYNC) External Interrupt 13 */
-#define EIC_ASYNC_INT13             (_U(0x1) << EIC_ASYNC_INT13_Pos)
+#define EIC_ASYNC_INT13             (_U_(0x1) << EIC_ASYNC_INT13_Pos)
 #define EIC_ASYNC_INT14_Pos         14           /**< \brief (EIC_ASYNC) External Interrupt 14 */
-#define EIC_ASYNC_INT14             (_U(0x1) << EIC_ASYNC_INT14_Pos)
+#define EIC_ASYNC_INT14             (_U_(0x1) << EIC_ASYNC_INT14_Pos)
 #define EIC_ASYNC_INT15_Pos         15           /**< \brief (EIC_ASYNC) External Interrupt 15 */
-#define EIC_ASYNC_INT15             (_U(0x1) << EIC_ASYNC_INT15_Pos)
-#define EIC_ASYNC_MASK              _U(0x0000FFFF) /**< \brief (EIC_ASYNC) MASK Register */
+#define EIC_ASYNC_INT15             (_U_(0x1) << EIC_ASYNC_INT15_Pos)
+#define EIC_ASYNC_MASK              _U_(0x0000FFFF) /**< \brief (EIC_ASYNC) MASK Register */
 
 /* -------- EIC_EN : (EIC Offset: 0x030) ( /W 32) Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -807,41 +807,41 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EIC_EN_OFFSET               0x030        /**< \brief (EIC_EN offset) Enable Register */
-#define EIC_EN_RESETVALUE           _U(0x00000000); /**< \brief (EIC_EN reset_value) Enable Register */
+#define EIC_EN_RESETVALUE           _U_(0x00000000); /**< \brief (EIC_EN reset_value) Enable Register */
 
 #define EIC_EN_NMI_Pos              0            /**< \brief (EIC_EN) External Non Maskable CPU interrupt */
-#define EIC_EN_NMI                  (_U(0x1) << EIC_EN_NMI_Pos)
+#define EIC_EN_NMI                  (_U_(0x1) << EIC_EN_NMI_Pos)
 #define EIC_EN_INT1_Pos             1            /**< \brief (EIC_EN) External Interrupt 1 */
-#define EIC_EN_INT1                 (_U(0x1) << EIC_EN_INT1_Pos)
+#define EIC_EN_INT1                 (_U_(0x1) << EIC_EN_INT1_Pos)
 #define EIC_EN_INT2_Pos             2            /**< \brief (EIC_EN) External Interrupt 2 */
-#define EIC_EN_INT2                 (_U(0x1) << EIC_EN_INT2_Pos)
+#define EIC_EN_INT2                 (_U_(0x1) << EIC_EN_INT2_Pos)
 #define EIC_EN_INT3_Pos             3            /**< \brief (EIC_EN) External Interrupt 3 */
-#define EIC_EN_INT3                 (_U(0x1) << EIC_EN_INT3_Pos)
+#define EIC_EN_INT3                 (_U_(0x1) << EIC_EN_INT3_Pos)
 #define EIC_EN_INT4_Pos             4            /**< \brief (EIC_EN) External Interrupt 4 */
-#define EIC_EN_INT4                 (_U(0x1) << EIC_EN_INT4_Pos)
+#define EIC_EN_INT4                 (_U_(0x1) << EIC_EN_INT4_Pos)
 #define EIC_EN_INT5_Pos             5            /**< \brief (EIC_EN) External Interrupt 5 */
-#define EIC_EN_INT5                 (_U(0x1) << EIC_EN_INT5_Pos)
+#define EIC_EN_INT5                 (_U_(0x1) << EIC_EN_INT5_Pos)
 #define EIC_EN_INT6_Pos             6            /**< \brief (EIC_EN) External Interrupt 6 */
-#define EIC_EN_INT6                 (_U(0x1) << EIC_EN_INT6_Pos)
+#define EIC_EN_INT6                 (_U_(0x1) << EIC_EN_INT6_Pos)
 #define EIC_EN_INT7_Pos             7            /**< \brief (EIC_EN) External Interrupt 7 */
-#define EIC_EN_INT7                 (_U(0x1) << EIC_EN_INT7_Pos)
+#define EIC_EN_INT7                 (_U_(0x1) << EIC_EN_INT7_Pos)
 #define EIC_EN_INT8_Pos             8            /**< \brief (EIC_EN) External Interrupt 8 */
-#define EIC_EN_INT8                 (_U(0x1) << EIC_EN_INT8_Pos)
+#define EIC_EN_INT8                 (_U_(0x1) << EIC_EN_INT8_Pos)
 #define EIC_EN_INT9_Pos             9            /**< \brief (EIC_EN) External Interrupt 9 */
-#define EIC_EN_INT9                 (_U(0x1) << EIC_EN_INT9_Pos)
+#define EIC_EN_INT9                 (_U_(0x1) << EIC_EN_INT9_Pos)
 #define EIC_EN_INT10_Pos            10           /**< \brief (EIC_EN) External Interrupt 10 */
-#define EIC_EN_INT10                (_U(0x1) << EIC_EN_INT10_Pos)
+#define EIC_EN_INT10                (_U_(0x1) << EIC_EN_INT10_Pos)
 #define EIC_EN_INT11_Pos            11           /**< \brief (EIC_EN) External Interrupt 11 */
-#define EIC_EN_INT11                (_U(0x1) << EIC_EN_INT11_Pos)
+#define EIC_EN_INT11                (_U_(0x1) << EIC_EN_INT11_Pos)
 #define EIC_EN_INT12_Pos            12           /**< \brief (EIC_EN) External Interrupt 12 */
-#define EIC_EN_INT12                (_U(0x1) << EIC_EN_INT12_Pos)
+#define EIC_EN_INT12                (_U_(0x1) << EIC_EN_INT12_Pos)
 #define EIC_EN_INT13_Pos            13           /**< \brief (EIC_EN) External Interrupt 13 */
-#define EIC_EN_INT13                (_U(0x1) << EIC_EN_INT13_Pos)
+#define EIC_EN_INT13                (_U_(0x1) << EIC_EN_INT13_Pos)
 #define EIC_EN_INT14_Pos            14           /**< \brief (EIC_EN) External Interrupt 14 */
-#define EIC_EN_INT14                (_U(0x1) << EIC_EN_INT14_Pos)
+#define EIC_EN_INT14                (_U_(0x1) << EIC_EN_INT14_Pos)
 #define EIC_EN_INT15_Pos            15           /**< \brief (EIC_EN) External Interrupt 15 */
-#define EIC_EN_INT15                (_U(0x1) << EIC_EN_INT15_Pos)
-#define EIC_EN_MASK                 _U(0x0000FFFF) /**< \brief (EIC_EN) MASK Register */
+#define EIC_EN_INT15                (_U_(0x1) << EIC_EN_INT15_Pos)
+#define EIC_EN_MASK                 _U_(0x0000FFFF) /**< \brief (EIC_EN) MASK Register */
 
 /* -------- EIC_DIS : (EIC Offset: 0x034) ( /W 32) Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -870,41 +870,41 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EIC_DIS_OFFSET              0x034        /**< \brief (EIC_DIS offset) Disable Register */
-#define EIC_DIS_RESETVALUE          _U(0x00000000); /**< \brief (EIC_DIS reset_value) Disable Register */
+#define EIC_DIS_RESETVALUE          _U_(0x00000000); /**< \brief (EIC_DIS reset_value) Disable Register */
 
 #define EIC_DIS_NMI_Pos             0            /**< \brief (EIC_DIS) External Non Maskable CPU interrupt */
-#define EIC_DIS_NMI                 (_U(0x1) << EIC_DIS_NMI_Pos)
+#define EIC_DIS_NMI                 (_U_(0x1) << EIC_DIS_NMI_Pos)
 #define EIC_DIS_INT1_Pos            1            /**< \brief (EIC_DIS) External Interrupt 1 */
-#define EIC_DIS_INT1                (_U(0x1) << EIC_DIS_INT1_Pos)
+#define EIC_DIS_INT1                (_U_(0x1) << EIC_DIS_INT1_Pos)
 #define EIC_DIS_INT2_Pos            2            /**< \brief (EIC_DIS) External Interrupt 2 */
-#define EIC_DIS_INT2                (_U(0x1) << EIC_DIS_INT2_Pos)
+#define EIC_DIS_INT2                (_U_(0x1) << EIC_DIS_INT2_Pos)
 #define EIC_DIS_INT3_Pos            3            /**< \brief (EIC_DIS) External Interrupt 3 */
-#define EIC_DIS_INT3                (_U(0x1) << EIC_DIS_INT3_Pos)
+#define EIC_DIS_INT3                (_U_(0x1) << EIC_DIS_INT3_Pos)
 #define EIC_DIS_INT4_Pos            4            /**< \brief (EIC_DIS) External Interrupt 4 */
-#define EIC_DIS_INT4                (_U(0x1) << EIC_DIS_INT4_Pos)
+#define EIC_DIS_INT4                (_U_(0x1) << EIC_DIS_INT4_Pos)
 #define EIC_DIS_INT5_Pos            5            /**< \brief (EIC_DIS) External Interrupt 5 */
-#define EIC_DIS_INT5                (_U(0x1) << EIC_DIS_INT5_Pos)
+#define EIC_DIS_INT5                (_U_(0x1) << EIC_DIS_INT5_Pos)
 #define EIC_DIS_INT6_Pos            6            /**< \brief (EIC_DIS) External Interrupt 6 */
-#define EIC_DIS_INT6                (_U(0x1) << EIC_DIS_INT6_Pos)
+#define EIC_DIS_INT6                (_U_(0x1) << EIC_DIS_INT6_Pos)
 #define EIC_DIS_INT7_Pos            7            /**< \brief (EIC_DIS) External Interrupt 7 */
-#define EIC_DIS_INT7                (_U(0x1) << EIC_DIS_INT7_Pos)
+#define EIC_DIS_INT7                (_U_(0x1) << EIC_DIS_INT7_Pos)
 #define EIC_DIS_INT8_Pos            8            /**< \brief (EIC_DIS) External Interrupt 8 */
-#define EIC_DIS_INT8                (_U(0x1) << EIC_DIS_INT8_Pos)
+#define EIC_DIS_INT8                (_U_(0x1) << EIC_DIS_INT8_Pos)
 #define EIC_DIS_INT9_Pos            9            /**< \brief (EIC_DIS) External Interrupt 9 */
-#define EIC_DIS_INT9                (_U(0x1) << EIC_DIS_INT9_Pos)
+#define EIC_DIS_INT9                (_U_(0x1) << EIC_DIS_INT9_Pos)
 #define EIC_DIS_INT10_Pos           10           /**< \brief (EIC_DIS) External Interrupt 10 */
-#define EIC_DIS_INT10               (_U(0x1) << EIC_DIS_INT10_Pos)
+#define EIC_DIS_INT10               (_U_(0x1) << EIC_DIS_INT10_Pos)
 #define EIC_DIS_INT11_Pos           11           /**< \brief (EIC_DIS) External Interrupt 11 */
-#define EIC_DIS_INT11               (_U(0x1) << EIC_DIS_INT11_Pos)
+#define EIC_DIS_INT11               (_U_(0x1) << EIC_DIS_INT11_Pos)
 #define EIC_DIS_INT12_Pos           12           /**< \brief (EIC_DIS) External Interrupt 12 */
-#define EIC_DIS_INT12               (_U(0x1) << EIC_DIS_INT12_Pos)
+#define EIC_DIS_INT12               (_U_(0x1) << EIC_DIS_INT12_Pos)
 #define EIC_DIS_INT13_Pos           13           /**< \brief (EIC_DIS) External Interrupt 13 */
-#define EIC_DIS_INT13               (_U(0x1) << EIC_DIS_INT13_Pos)
+#define EIC_DIS_INT13               (_U_(0x1) << EIC_DIS_INT13_Pos)
 #define EIC_DIS_INT14_Pos           14           /**< \brief (EIC_DIS) External Interrupt 14 */
-#define EIC_DIS_INT14               (_U(0x1) << EIC_DIS_INT14_Pos)
+#define EIC_DIS_INT14               (_U_(0x1) << EIC_DIS_INT14_Pos)
 #define EIC_DIS_INT15_Pos           15           /**< \brief (EIC_DIS) External Interrupt 15 */
-#define EIC_DIS_INT15               (_U(0x1) << EIC_DIS_INT15_Pos)
-#define EIC_DIS_MASK                _U(0x0000FFFF) /**< \brief (EIC_DIS) MASK Register */
+#define EIC_DIS_INT15               (_U_(0x1) << EIC_DIS_INT15_Pos)
+#define EIC_DIS_MASK                _U_(0x0000FFFF) /**< \brief (EIC_DIS) MASK Register */
 
 /* -------- EIC_CTRL : (EIC Offset: 0x038) (R/  32) Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -933,41 +933,41 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EIC_CTRL_OFFSET             0x038        /**< \brief (EIC_CTRL offset) Control Register */
-#define EIC_CTRL_RESETVALUE         _U(0x00000000); /**< \brief (EIC_CTRL reset_value) Control Register */
+#define EIC_CTRL_RESETVALUE         _U_(0x00000000); /**< \brief (EIC_CTRL reset_value) Control Register */
 
 #define EIC_CTRL_NMI_Pos            0            /**< \brief (EIC_CTRL) External Non Maskable CPU interrupt */
-#define EIC_CTRL_NMI                (_U(0x1) << EIC_CTRL_NMI_Pos)
+#define EIC_CTRL_NMI                (_U_(0x1) << EIC_CTRL_NMI_Pos)
 #define EIC_CTRL_INT1_Pos           1            /**< \brief (EIC_CTRL) External Interrupt 1 */
-#define EIC_CTRL_INT1               (_U(0x1) << EIC_CTRL_INT1_Pos)
+#define EIC_CTRL_INT1               (_U_(0x1) << EIC_CTRL_INT1_Pos)
 #define EIC_CTRL_INT2_Pos           2            /**< \brief (EIC_CTRL) External Interrupt 2 */
-#define EIC_CTRL_INT2               (_U(0x1) << EIC_CTRL_INT2_Pos)
+#define EIC_CTRL_INT2               (_U_(0x1) << EIC_CTRL_INT2_Pos)
 #define EIC_CTRL_INT3_Pos           3            /**< \brief (EIC_CTRL) External Interrupt 3 */
-#define EIC_CTRL_INT3               (_U(0x1) << EIC_CTRL_INT3_Pos)
+#define EIC_CTRL_INT3               (_U_(0x1) << EIC_CTRL_INT3_Pos)
 #define EIC_CTRL_INT4_Pos           4            /**< \brief (EIC_CTRL) External Interrupt 4 */
-#define EIC_CTRL_INT4               (_U(0x1) << EIC_CTRL_INT4_Pos)
+#define EIC_CTRL_INT4               (_U_(0x1) << EIC_CTRL_INT4_Pos)
 #define EIC_CTRL_INT5_Pos           5            /**< \brief (EIC_CTRL) External Interrupt 5 */
-#define EIC_CTRL_INT5               (_U(0x1) << EIC_CTRL_INT5_Pos)
+#define EIC_CTRL_INT5               (_U_(0x1) << EIC_CTRL_INT5_Pos)
 #define EIC_CTRL_INT6_Pos           6            /**< \brief (EIC_CTRL) External Interrupt 6 */
-#define EIC_CTRL_INT6               (_U(0x1) << EIC_CTRL_INT6_Pos)
+#define EIC_CTRL_INT6               (_U_(0x1) << EIC_CTRL_INT6_Pos)
 #define EIC_CTRL_INT7_Pos           7            /**< \brief (EIC_CTRL) External Interrupt 7 */
-#define EIC_CTRL_INT7               (_U(0x1) << EIC_CTRL_INT7_Pos)
+#define EIC_CTRL_INT7               (_U_(0x1) << EIC_CTRL_INT7_Pos)
 #define EIC_CTRL_INT8_Pos           8            /**< \brief (EIC_CTRL) External Interrupt 8 */
-#define EIC_CTRL_INT8               (_U(0x1) << EIC_CTRL_INT8_Pos)
+#define EIC_CTRL_INT8               (_U_(0x1) << EIC_CTRL_INT8_Pos)
 #define EIC_CTRL_INT9_Pos           9            /**< \brief (EIC_CTRL) External Interrupt 9 */
-#define EIC_CTRL_INT9               (_U(0x1) << EIC_CTRL_INT9_Pos)
+#define EIC_CTRL_INT9               (_U_(0x1) << EIC_CTRL_INT9_Pos)
 #define EIC_CTRL_INT10_Pos          10           /**< \brief (EIC_CTRL) External Interrupt 10 */
-#define EIC_CTRL_INT10              (_U(0x1) << EIC_CTRL_INT10_Pos)
+#define EIC_CTRL_INT10              (_U_(0x1) << EIC_CTRL_INT10_Pos)
 #define EIC_CTRL_INT11_Pos          11           /**< \brief (EIC_CTRL) External Interrupt 11 */
-#define EIC_CTRL_INT11              (_U(0x1) << EIC_CTRL_INT11_Pos)
+#define EIC_CTRL_INT11              (_U_(0x1) << EIC_CTRL_INT11_Pos)
 #define EIC_CTRL_INT12_Pos          12           /**< \brief (EIC_CTRL) External Interrupt 12 */
-#define EIC_CTRL_INT12              (_U(0x1) << EIC_CTRL_INT12_Pos)
+#define EIC_CTRL_INT12              (_U_(0x1) << EIC_CTRL_INT12_Pos)
 #define EIC_CTRL_INT13_Pos          13           /**< \brief (EIC_CTRL) External Interrupt 13 */
-#define EIC_CTRL_INT13              (_U(0x1) << EIC_CTRL_INT13_Pos)
+#define EIC_CTRL_INT13              (_U_(0x1) << EIC_CTRL_INT13_Pos)
 #define EIC_CTRL_INT14_Pos          14           /**< \brief (EIC_CTRL) External Interrupt 14 */
-#define EIC_CTRL_INT14              (_U(0x1) << EIC_CTRL_INT14_Pos)
+#define EIC_CTRL_INT14              (_U_(0x1) << EIC_CTRL_INT14_Pos)
 #define EIC_CTRL_INT15_Pos          15           /**< \brief (EIC_CTRL) External Interrupt 15 */
-#define EIC_CTRL_INT15              (_U(0x1) << EIC_CTRL_INT15_Pos)
-#define EIC_CTRL_MASK               _U(0x0000FFFF) /**< \brief (EIC_CTRL) MASK Register */
+#define EIC_CTRL_INT15              (_U_(0x1) << EIC_CTRL_INT15_Pos)
+#define EIC_CTRL_MASK               _U_(0x0000FFFF) /**< \brief (EIC_CTRL) MASK Register */
 
 /* -------- EIC_VERSION : (EIC Offset: 0x3FC) (R/  32) Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -981,12 +981,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EIC_VERSION_OFFSET          0x3FC        /**< \brief (EIC_VERSION offset) Version Register */
-#define EIC_VERSION_RESETVALUE      _U(0x00000302); /**< \brief (EIC_VERSION reset_value) Version Register */
+#define EIC_VERSION_RESETVALUE      _U_(0x00000302); /**< \brief (EIC_VERSION reset_value) Version Register */
 
 #define EIC_VERSION_VERSION_Pos     0            /**< \brief (EIC_VERSION) Version bits */
-#define EIC_VERSION_VERSION_Msk     (_U(0xFFF) << EIC_VERSION_VERSION_Pos)
+#define EIC_VERSION_VERSION_Msk     (_U_(0xFFF) << EIC_VERSION_VERSION_Pos)
 #define EIC_VERSION_VERSION(value)  (EIC_VERSION_VERSION_Msk & ((value) << EIC_VERSION_VERSION_Pos))
-#define EIC_VERSION_MASK            _U(0x00000FFF) /**< \brief (EIC_VERSION) MASK Register */
+#define EIC_VERSION_MASK            _U_(0x00000FFF) /**< \brief (EIC_VERSION) MASK Register */
 
 /** \brief EIC hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/eic.h
+++ b/asf/sam/include/sam4l/component/eic.h
@@ -990,45 +990,24 @@ typedef union {
 
 /** \brief EIC hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __O  EIC_IER_Type              IER;         /**< \brief Offset: 0x000 ( /W 32) Interrupt Enable Register */
-  __O  EIC_IDR_Type              IDR;         /**< \brief Offset: 0x004 ( /W 32) Interrupt Disable Register */
-  __I  EIC_IMR_Type              IMR;         /**< \brief Offset: 0x008 (R/  32) Interrupt Mask Register */
-  __I  EIC_ISR_Type              ISR;         /**< \brief Offset: 0x00C (R/  32) Interrupt Status Register */
-  __O  EIC_ICR_Type              ICR;         /**< \brief Offset: 0x010 ( /W 32) Interrupt Clear Register */
-  __IO EIC_MODE_Type             MODE;        /**< \brief Offset: 0x014 (R/W 32) Mode Register */
-  __IO EIC_EDGE_Type             EDGE;        /**< \brief Offset: 0x018 (R/W 32) Edge Register */
-  __IO EIC_LEVEL_Type            LEVEL;       /**< \brief Offset: 0x01C (R/W 32) Level Register */
-  __IO EIC_FILTER_Type           FILTER;      /**< \brief Offset: 0x020 (R/W 32) Filter Register */
-       RoReg8                    Reserved1[0x4];
-  __IO EIC_ASYNC_Type            ASYNC;       /**< \brief Offset: 0x028 (R/W 32) Asynchronous Register */
-       RoReg8                    Reserved2[0x4];
-  __O  EIC_EN_Type               EN;          /**< \brief Offset: 0x030 ( /W 32) Enable Register */
-  __O  EIC_DIS_Type              DIS;         /**< \brief Offset: 0x034 ( /W 32) Disable Register */
-  __I  EIC_CTRL_Type             CTRL;        /**< \brief Offset: 0x038 (R/  32) Control Register */
-       RoReg8                    Reserved3[0x3C0];
-  __I  EIC_VERSION_Type          VERSION;     /**< \brief Offset: 0x3FC (R/  32) Version Register */
- } bf;
- struct {
-  WoReg   EIC_IER;            /**< \brief (EIC Offset: 0x000) Interrupt Enable Register */
-  WoReg   EIC_IDR;            /**< \brief (EIC Offset: 0x004) Interrupt Disable Register */
-  RoReg   EIC_IMR;            /**< \brief (EIC Offset: 0x008) Interrupt Mask Register */
-  RoReg   EIC_ISR;            /**< \brief (EIC Offset: 0x00C) Interrupt Status Register */
-  WoReg   EIC_ICR;            /**< \brief (EIC Offset: 0x010) Interrupt Clear Register */
-  RwReg   EIC_MODE;           /**< \brief (EIC Offset: 0x014) Mode Register */
-  RwReg   EIC_EDGE;           /**< \brief (EIC Offset: 0x018) Edge Register */
-  RwReg   EIC_LEVEL;          /**< \brief (EIC Offset: 0x01C) Level Register */
-  RwReg   EIC_FILTER;         /**< \brief (EIC Offset: 0x020) Filter Register */
-  RoReg8  Reserved4[0x4];
-  RwReg   EIC_ASYNC;          /**< \brief (EIC Offset: 0x028) Asynchronous Register */
-  RoReg8  Reserved5[0x4];
-  WoReg   EIC_EN;             /**< \brief (EIC Offset: 0x030) Enable Register */
-  WoReg   EIC_DIS;            /**< \brief (EIC Offset: 0x034) Disable Register */
-  RoReg   EIC_CTRL;           /**< \brief (EIC Offset: 0x038) Control Register */
-  RoReg8  Reserved6[0x3C0];
-  RoReg   EIC_VERSION;        /**< \brief (EIC Offset: 0x3FC) Version Register */
- } reg;
+typedef struct {
+  __O  uint32_t IER;         /**< \brief Offset: 0x000 ( /W 32) Interrupt Enable Register */
+  __O  uint32_t IDR;         /**< \brief Offset: 0x004 ( /W 32) Interrupt Disable Register */
+  __I  uint32_t IMR;         /**< \brief Offset: 0x008 (R/  32) Interrupt Mask Register */
+  __I  uint32_t ISR;         /**< \brief Offset: 0x00C (R/  32) Interrupt Status Register */
+  __O  uint32_t ICR;         /**< \brief Offset: 0x010 ( /W 32) Interrupt Clear Register */
+  __IO uint32_t MODE;        /**< \brief Offset: 0x014 (R/W 32) Mode Register */
+  __IO uint32_t EDGE;        /**< \brief Offset: 0x018 (R/W 32) Edge Register */
+  __IO uint32_t LEVEL;       /**< \brief Offset: 0x01C (R/W 32) Level Register */
+  __IO uint32_t FILTER;      /**< \brief Offset: 0x020 (R/W 32) Filter Register */
+       RoReg8   Reserved1[0x4];
+  __IO uint32_t ASYNC;       /**< \brief Offset: 0x028 (R/W 32) Asynchronous Register */
+       RoReg8   Reserved2[0x4];
+  __O  uint32_t EN;          /**< \brief Offset: 0x030 ( /W 32) Enable Register */
+  __O  uint32_t DIS;         /**< \brief Offset: 0x034 ( /W 32) Disable Register */
+  __I  uint32_t CTRL;        /**< \brief Offset: 0x038 (R/  32) Control Register */
+       RoReg8   Reserved3[0x3C0];
+  __I  uint32_t VERSION;     /**< \brief Offset: 0x3FC (R/  32) Version Register */
 } Eic;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/eic.h
+++ b/asf/sam/include/sam4l/component/eic.h
@@ -1,0 +1,1037 @@
+/**
+ * \file
+ *
+ * \brief Component description for EIC
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_EIC_COMPONENT_
+#define _SAM4L_EIC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR EIC */
+/* ========================================================================== */
+/** \addtogroup SAM4L_EIC External Interrupt Controller */
+/*@{*/
+
+#define EIC_I7529
+#define REV_EIC                     0x302
+
+/* -------- EIC_IER : (EIC Offset: 0x000) ( /W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t NMI:1;            /*!< bit:      0  External Non Maskable CPU interrupt */
+    uint32_t INT1:1;           /*!< bit:      1  External Interrupt 1               */
+    uint32_t INT2:1;           /*!< bit:      2  External Interrupt 2               */
+    uint32_t INT3:1;           /*!< bit:      3  External Interrupt 3               */
+    uint32_t INT4:1;           /*!< bit:      4  External Interrupt 4               */
+    uint32_t INT5:1;           /*!< bit:      5  External Interrupt 5               */
+    uint32_t INT6:1;           /*!< bit:      6  External Interrupt 6               */
+    uint32_t INT7:1;           /*!< bit:      7  External Interrupt 7               */
+    uint32_t INT8:1;           /*!< bit:      8  External Interrupt 8               */
+    uint32_t INT9:1;           /*!< bit:      9  External Interrupt 9               */
+    uint32_t INT10:1;          /*!< bit:     10  External Interrupt 10              */
+    uint32_t INT11:1;          /*!< bit:     11  External Interrupt 11              */
+    uint32_t INT12:1;          /*!< bit:     12  External Interrupt 12              */
+    uint32_t INT13:1;          /*!< bit:     13  External Interrupt 13              */
+    uint32_t INT14:1;          /*!< bit:     14  External Interrupt 14              */
+    uint32_t INT15:1;          /*!< bit:     15  External Interrupt 15              */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_IER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_IER_OFFSET              0x000        /**< \brief (EIC_IER offset) Interrupt Enable Register */
+#define EIC_IER_RESETVALUE          _U(0x00000000); /**< \brief (EIC_IER reset_value) Interrupt Enable Register */
+
+#define EIC_IER_NMI_Pos             0            /**< \brief (EIC_IER) External Non Maskable CPU interrupt */
+#define EIC_IER_NMI                 (_U(0x1) << EIC_IER_NMI_Pos)
+#define EIC_IER_INT1_Pos            1            /**< \brief (EIC_IER) External Interrupt 1 */
+#define EIC_IER_INT1                (_U(0x1) << EIC_IER_INT1_Pos)
+#define   EIC_IER_INT1_0_Val              _U(0x0)   /**< \brief (EIC_IER) No effect */
+#define   EIC_IER_INT1_1_Val              _U(0x1)   /**< \brief (EIC_IER) Enable Interrupt. */
+#define EIC_IER_INT1_0              (EIC_IER_INT1_0_Val            << EIC_IER_INT1_Pos)
+#define EIC_IER_INT1_1              (EIC_IER_INT1_1_Val            << EIC_IER_INT1_Pos)
+#define EIC_IER_INT2_Pos            2            /**< \brief (EIC_IER) External Interrupt 2 */
+#define EIC_IER_INT2                (_U(0x1) << EIC_IER_INT2_Pos)
+#define   EIC_IER_INT2_0_Val              _U(0x0)   /**< \brief (EIC_IER) No effect */
+#define   EIC_IER_INT2_1_Val              _U(0x1)   /**< \brief (EIC_IER) Enable Interrupt. */
+#define EIC_IER_INT2_0              (EIC_IER_INT2_0_Val            << EIC_IER_INT2_Pos)
+#define EIC_IER_INT2_1              (EIC_IER_INT2_1_Val            << EIC_IER_INT2_Pos)
+#define EIC_IER_INT3_Pos            3            /**< \brief (EIC_IER) External Interrupt 3 */
+#define EIC_IER_INT3                (_U(0x1) << EIC_IER_INT3_Pos)
+#define   EIC_IER_INT3_0_Val              _U(0x0)   /**< \brief (EIC_IER) No effect */
+#define   EIC_IER_INT3_1_Val              _U(0x1)   /**< \brief (EIC_IER) Enable Interrupt. */
+#define EIC_IER_INT3_0              (EIC_IER_INT3_0_Val            << EIC_IER_INT3_Pos)
+#define EIC_IER_INT3_1              (EIC_IER_INT3_1_Val            << EIC_IER_INT3_Pos)
+#define EIC_IER_INT4_Pos            4            /**< \brief (EIC_IER) External Interrupt 4 */
+#define EIC_IER_INT4                (_U(0x1) << EIC_IER_INT4_Pos)
+#define   EIC_IER_INT4_0_Val              _U(0x0)   /**< \brief (EIC_IER) No effect */
+#define   EIC_IER_INT4_1_Val              _U(0x1)   /**< \brief (EIC_IER) Enable Interrupt. */
+#define EIC_IER_INT4_0              (EIC_IER_INT4_0_Val            << EIC_IER_INT4_Pos)
+#define EIC_IER_INT4_1              (EIC_IER_INT4_1_Val            << EIC_IER_INT4_Pos)
+#define EIC_IER_INT5_Pos            5            /**< \brief (EIC_IER) External Interrupt 5 */
+#define EIC_IER_INT5                (_U(0x1) << EIC_IER_INT5_Pos)
+#define EIC_IER_INT6_Pos            6            /**< \brief (EIC_IER) External Interrupt 6 */
+#define EIC_IER_INT6                (_U(0x1) << EIC_IER_INT6_Pos)
+#define EIC_IER_INT7_Pos            7            /**< \brief (EIC_IER) External Interrupt 7 */
+#define EIC_IER_INT7                (_U(0x1) << EIC_IER_INT7_Pos)
+#define EIC_IER_INT8_Pos            8            /**< \brief (EIC_IER) External Interrupt 8 */
+#define EIC_IER_INT8                (_U(0x1) << EIC_IER_INT8_Pos)
+#define EIC_IER_INT9_Pos            9            /**< \brief (EIC_IER) External Interrupt 9 */
+#define EIC_IER_INT9                (_U(0x1) << EIC_IER_INT9_Pos)
+#define EIC_IER_INT10_Pos           10           /**< \brief (EIC_IER) External Interrupt 10 */
+#define EIC_IER_INT10               (_U(0x1) << EIC_IER_INT10_Pos)
+#define EIC_IER_INT11_Pos           11           /**< \brief (EIC_IER) External Interrupt 11 */
+#define EIC_IER_INT11               (_U(0x1) << EIC_IER_INT11_Pos)
+#define EIC_IER_INT12_Pos           12           /**< \brief (EIC_IER) External Interrupt 12 */
+#define EIC_IER_INT12               (_U(0x1) << EIC_IER_INT12_Pos)
+#define EIC_IER_INT13_Pos           13           /**< \brief (EIC_IER) External Interrupt 13 */
+#define EIC_IER_INT13               (_U(0x1) << EIC_IER_INT13_Pos)
+#define EIC_IER_INT14_Pos           14           /**< \brief (EIC_IER) External Interrupt 14 */
+#define EIC_IER_INT14               (_U(0x1) << EIC_IER_INT14_Pos)
+#define EIC_IER_INT15_Pos           15           /**< \brief (EIC_IER) External Interrupt 15 */
+#define EIC_IER_INT15               (_U(0x1) << EIC_IER_INT15_Pos)
+#define EIC_IER_MASK                _U(0x0000FFFF) /**< \brief (EIC_IER) MASK Register */
+
+/* -------- EIC_IDR : (EIC Offset: 0x004) ( /W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t NMI:1;            /*!< bit:      0  External Non Maskable CPU interrupt */
+    uint32_t INT1:1;           /*!< bit:      1  External Interrupt 1               */
+    uint32_t INT2:1;           /*!< bit:      2  External Interrupt 2               */
+    uint32_t INT3:1;           /*!< bit:      3  External Interrupt 3               */
+    uint32_t INT4:1;           /*!< bit:      4  External Interrupt 4               */
+    uint32_t INT5:1;           /*!< bit:      5  External Interrupt 5               */
+    uint32_t INT6:1;           /*!< bit:      6  External Interrupt 6               */
+    uint32_t INT7:1;           /*!< bit:      7  External Interrupt 7               */
+    uint32_t INT8:1;           /*!< bit:      8  External Interrupt 8               */
+    uint32_t INT9:1;           /*!< bit:      9  External Interrupt 9               */
+    uint32_t INT10:1;          /*!< bit:     10  External Interrupt 10              */
+    uint32_t INT11:1;          /*!< bit:     11  External Interrupt 11              */
+    uint32_t INT12:1;          /*!< bit:     12  External Interrupt 12              */
+    uint32_t INT13:1;          /*!< bit:     13  External Interrupt 13              */
+    uint32_t INT14:1;          /*!< bit:     14  External Interrupt 14              */
+    uint32_t INT15:1;          /*!< bit:     15  External Interrupt 15              */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_IDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_IDR_OFFSET              0x004        /**< \brief (EIC_IDR offset) Interrupt Disable Register */
+#define EIC_IDR_RESETVALUE          _U(0x00000000); /**< \brief (EIC_IDR reset_value) Interrupt Disable Register */
+
+#define EIC_IDR_NMI_Pos             0            /**< \brief (EIC_IDR) External Non Maskable CPU interrupt */
+#define EIC_IDR_NMI                 (_U(0x1) << EIC_IDR_NMI_Pos)
+#define EIC_IDR_INT1_Pos            1            /**< \brief (EIC_IDR) External Interrupt 1 */
+#define EIC_IDR_INT1                (_U(0x1) << EIC_IDR_INT1_Pos)
+#define   EIC_IDR_INT1_0_Val              _U(0x0)   /**< \brief (EIC_IDR) No effect */
+#define   EIC_IDR_INT1_1_Val              _U(0x1)   /**< \brief (EIC_IDR) Disable Interrupt. */
+#define EIC_IDR_INT1_0              (EIC_IDR_INT1_0_Val            << EIC_IDR_INT1_Pos)
+#define EIC_IDR_INT1_1              (EIC_IDR_INT1_1_Val            << EIC_IDR_INT1_Pos)
+#define EIC_IDR_INT2_Pos            2            /**< \brief (EIC_IDR) External Interrupt 2 */
+#define EIC_IDR_INT2                (_U(0x1) << EIC_IDR_INT2_Pos)
+#define   EIC_IDR_INT2_0_Val              _U(0x0)   /**< \brief (EIC_IDR) No effect */
+#define   EIC_IDR_INT2_1_Val              _U(0x1)   /**< \brief (EIC_IDR) Disable Interrupt. */
+#define EIC_IDR_INT2_0              (EIC_IDR_INT2_0_Val            << EIC_IDR_INT2_Pos)
+#define EIC_IDR_INT2_1              (EIC_IDR_INT2_1_Val            << EIC_IDR_INT2_Pos)
+#define EIC_IDR_INT3_Pos            3            /**< \brief (EIC_IDR) External Interrupt 3 */
+#define EIC_IDR_INT3                (_U(0x1) << EIC_IDR_INT3_Pos)
+#define   EIC_IDR_INT3_0_Val              _U(0x0)   /**< \brief (EIC_IDR) No effect */
+#define   EIC_IDR_INT3_1_Val              _U(0x1)   /**< \brief (EIC_IDR) Disable Interrupt. */
+#define EIC_IDR_INT3_0              (EIC_IDR_INT3_0_Val            << EIC_IDR_INT3_Pos)
+#define EIC_IDR_INT3_1              (EIC_IDR_INT3_1_Val            << EIC_IDR_INT3_Pos)
+#define EIC_IDR_INT4_Pos            4            /**< \brief (EIC_IDR) External Interrupt 4 */
+#define EIC_IDR_INT4                (_U(0x1) << EIC_IDR_INT4_Pos)
+#define   EIC_IDR_INT4_0_Val              _U(0x0)   /**< \brief (EIC_IDR) No effect */
+#define   EIC_IDR_INT4_1_Val              _U(0x1)   /**< \brief (EIC_IDR) Disable Interrupt. */
+#define EIC_IDR_INT4_0              (EIC_IDR_INT4_0_Val            << EIC_IDR_INT4_Pos)
+#define EIC_IDR_INT4_1              (EIC_IDR_INT4_1_Val            << EIC_IDR_INT4_Pos)
+#define EIC_IDR_INT5_Pos            5            /**< \brief (EIC_IDR) External Interrupt 5 */
+#define EIC_IDR_INT5                (_U(0x1) << EIC_IDR_INT5_Pos)
+#define EIC_IDR_INT6_Pos            6            /**< \brief (EIC_IDR) External Interrupt 6 */
+#define EIC_IDR_INT6                (_U(0x1) << EIC_IDR_INT6_Pos)
+#define EIC_IDR_INT7_Pos            7            /**< \brief (EIC_IDR) External Interrupt 7 */
+#define EIC_IDR_INT7                (_U(0x1) << EIC_IDR_INT7_Pos)
+#define EIC_IDR_INT8_Pos            8            /**< \brief (EIC_IDR) External Interrupt 8 */
+#define EIC_IDR_INT8                (_U(0x1) << EIC_IDR_INT8_Pos)
+#define EIC_IDR_INT9_Pos            9            /**< \brief (EIC_IDR) External Interrupt 9 */
+#define EIC_IDR_INT9                (_U(0x1) << EIC_IDR_INT9_Pos)
+#define EIC_IDR_INT10_Pos           10           /**< \brief (EIC_IDR) External Interrupt 10 */
+#define EIC_IDR_INT10               (_U(0x1) << EIC_IDR_INT10_Pos)
+#define EIC_IDR_INT11_Pos           11           /**< \brief (EIC_IDR) External Interrupt 11 */
+#define EIC_IDR_INT11               (_U(0x1) << EIC_IDR_INT11_Pos)
+#define EIC_IDR_INT12_Pos           12           /**< \brief (EIC_IDR) External Interrupt 12 */
+#define EIC_IDR_INT12               (_U(0x1) << EIC_IDR_INT12_Pos)
+#define EIC_IDR_INT13_Pos           13           /**< \brief (EIC_IDR) External Interrupt 13 */
+#define EIC_IDR_INT13               (_U(0x1) << EIC_IDR_INT13_Pos)
+#define EIC_IDR_INT14_Pos           14           /**< \brief (EIC_IDR) External Interrupt 14 */
+#define EIC_IDR_INT14               (_U(0x1) << EIC_IDR_INT14_Pos)
+#define EIC_IDR_INT15_Pos           15           /**< \brief (EIC_IDR) External Interrupt 15 */
+#define EIC_IDR_INT15               (_U(0x1) << EIC_IDR_INT15_Pos)
+#define EIC_IDR_MASK                _U(0x0000FFFF) /**< \brief (EIC_IDR) MASK Register */
+
+/* -------- EIC_IMR : (EIC Offset: 0x008) (R/  32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t NMI:1;            /*!< bit:      0  External Non Maskable CPU interrupt */
+    uint32_t INT1:1;           /*!< bit:      1  External Interrupt 1               */
+    uint32_t INT2:1;           /*!< bit:      2  External Interrupt 2               */
+    uint32_t INT3:1;           /*!< bit:      3  External Interrupt 3               */
+    uint32_t INT4:1;           /*!< bit:      4  External Interrupt 4               */
+    uint32_t INT5:1;           /*!< bit:      5  External Interrupt 5               */
+    uint32_t INT6:1;           /*!< bit:      6  External Interrupt 6               */
+    uint32_t INT7:1;           /*!< bit:      7  External Interrupt 7               */
+    uint32_t INT8:1;           /*!< bit:      8  External Interrupt 8               */
+    uint32_t INT9:1;           /*!< bit:      9  External Interrupt 9               */
+    uint32_t INT10:1;          /*!< bit:     10  External Interrupt 10              */
+    uint32_t INT11:1;          /*!< bit:     11  External Interrupt 11              */
+    uint32_t INT12:1;          /*!< bit:     12  External Interrupt 12              */
+    uint32_t INT13:1;          /*!< bit:     13  External Interrupt 13              */
+    uint32_t INT14:1;          /*!< bit:     14  External Interrupt 14              */
+    uint32_t INT15:1;          /*!< bit:     15  External Interrupt 15              */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_IMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_IMR_OFFSET              0x008        /**< \brief (EIC_IMR offset) Interrupt Mask Register */
+#define EIC_IMR_RESETVALUE          _U(0x00000000); /**< \brief (EIC_IMR reset_value) Interrupt Mask Register */
+
+#define EIC_IMR_NMI_Pos             0            /**< \brief (EIC_IMR) External Non Maskable CPU interrupt */
+#define EIC_IMR_NMI                 (_U(0x1) << EIC_IMR_NMI_Pos)
+#define EIC_IMR_INT1_Pos            1            /**< \brief (EIC_IMR) External Interrupt 1 */
+#define EIC_IMR_INT1                (_U(0x1) << EIC_IMR_INT1_Pos)
+#define   EIC_IMR_INT1_0_Val              _U(0x0)   /**< \brief (EIC_IMR) Interrupt is disabled */
+#define   EIC_IMR_INT1_1_Val              _U(0x1)   /**< \brief (EIC_IMR) Interrupt is enabled. */
+#define EIC_IMR_INT1_0              (EIC_IMR_INT1_0_Val            << EIC_IMR_INT1_Pos)
+#define EIC_IMR_INT1_1              (EIC_IMR_INT1_1_Val            << EIC_IMR_INT1_Pos)
+#define EIC_IMR_INT2_Pos            2            /**< \brief (EIC_IMR) External Interrupt 2 */
+#define EIC_IMR_INT2                (_U(0x1) << EIC_IMR_INT2_Pos)
+#define   EIC_IMR_INT2_0_Val              _U(0x0)   /**< \brief (EIC_IMR) Interrupt is disabled */
+#define   EIC_IMR_INT2_1_Val              _U(0x1)   /**< \brief (EIC_IMR) Interrupt is enabled. */
+#define EIC_IMR_INT2_0              (EIC_IMR_INT2_0_Val            << EIC_IMR_INT2_Pos)
+#define EIC_IMR_INT2_1              (EIC_IMR_INT2_1_Val            << EIC_IMR_INT2_Pos)
+#define EIC_IMR_INT3_Pos            3            /**< \brief (EIC_IMR) External Interrupt 3 */
+#define EIC_IMR_INT3                (_U(0x1) << EIC_IMR_INT3_Pos)
+#define   EIC_IMR_INT3_0_Val              _U(0x0)   /**< \brief (EIC_IMR) Interrupt is disabled */
+#define   EIC_IMR_INT3_1_Val              _U(0x1)   /**< \brief (EIC_IMR) Interrupt is enabled. */
+#define EIC_IMR_INT3_0              (EIC_IMR_INT3_0_Val            << EIC_IMR_INT3_Pos)
+#define EIC_IMR_INT3_1              (EIC_IMR_INT3_1_Val            << EIC_IMR_INT3_Pos)
+#define EIC_IMR_INT4_Pos            4            /**< \brief (EIC_IMR) External Interrupt 4 */
+#define EIC_IMR_INT4                (_U(0x1) << EIC_IMR_INT4_Pos)
+#define   EIC_IMR_INT4_0_Val              _U(0x0)   /**< \brief (EIC_IMR) Interrupt is disabled */
+#define   EIC_IMR_INT4_1_Val              _U(0x1)   /**< \brief (EIC_IMR) Interrupt is enabled. */
+#define EIC_IMR_INT4_0              (EIC_IMR_INT4_0_Val            << EIC_IMR_INT4_Pos)
+#define EIC_IMR_INT4_1              (EIC_IMR_INT4_1_Val            << EIC_IMR_INT4_Pos)
+#define EIC_IMR_INT5_Pos            5            /**< \brief (EIC_IMR) External Interrupt 5 */
+#define EIC_IMR_INT5                (_U(0x1) << EIC_IMR_INT5_Pos)
+#define EIC_IMR_INT6_Pos            6            /**< \brief (EIC_IMR) External Interrupt 6 */
+#define EIC_IMR_INT6                (_U(0x1) << EIC_IMR_INT6_Pos)
+#define EIC_IMR_INT7_Pos            7            /**< \brief (EIC_IMR) External Interrupt 7 */
+#define EIC_IMR_INT7                (_U(0x1) << EIC_IMR_INT7_Pos)
+#define EIC_IMR_INT8_Pos            8            /**< \brief (EIC_IMR) External Interrupt 8 */
+#define EIC_IMR_INT8                (_U(0x1) << EIC_IMR_INT8_Pos)
+#define EIC_IMR_INT9_Pos            9            /**< \brief (EIC_IMR) External Interrupt 9 */
+#define EIC_IMR_INT9                (_U(0x1) << EIC_IMR_INT9_Pos)
+#define EIC_IMR_INT10_Pos           10           /**< \brief (EIC_IMR) External Interrupt 10 */
+#define EIC_IMR_INT10               (_U(0x1) << EIC_IMR_INT10_Pos)
+#define EIC_IMR_INT11_Pos           11           /**< \brief (EIC_IMR) External Interrupt 11 */
+#define EIC_IMR_INT11               (_U(0x1) << EIC_IMR_INT11_Pos)
+#define EIC_IMR_INT12_Pos           12           /**< \brief (EIC_IMR) External Interrupt 12 */
+#define EIC_IMR_INT12               (_U(0x1) << EIC_IMR_INT12_Pos)
+#define EIC_IMR_INT13_Pos           13           /**< \brief (EIC_IMR) External Interrupt 13 */
+#define EIC_IMR_INT13               (_U(0x1) << EIC_IMR_INT13_Pos)
+#define EIC_IMR_INT14_Pos           14           /**< \brief (EIC_IMR) External Interrupt 14 */
+#define EIC_IMR_INT14               (_U(0x1) << EIC_IMR_INT14_Pos)
+#define EIC_IMR_INT15_Pos           15           /**< \brief (EIC_IMR) External Interrupt 15 */
+#define EIC_IMR_INT15               (_U(0x1) << EIC_IMR_INT15_Pos)
+#define EIC_IMR_MASK                _U(0x0000FFFF) /**< \brief (EIC_IMR) MASK Register */
+
+/* -------- EIC_ISR : (EIC Offset: 0x00C) (R/  32) Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t NMI:1;            /*!< bit:      0  External Non Maskable CPU interrupt */
+    uint32_t INT1:1;           /*!< bit:      1  External Interrupt 1               */
+    uint32_t INT2:1;           /*!< bit:      2  External Interrupt 2               */
+    uint32_t INT3:1;           /*!< bit:      3  External Interrupt 3               */
+    uint32_t INT4:1;           /*!< bit:      4  External Interrupt 4               */
+    uint32_t INT5:1;           /*!< bit:      5  External Interrupt 5               */
+    uint32_t INT6:1;           /*!< bit:      6  External Interrupt 6               */
+    uint32_t INT7:1;           /*!< bit:      7  External Interrupt 7               */
+    uint32_t INT8:1;           /*!< bit:      8  External Interrupt 8               */
+    uint32_t INT9:1;           /*!< bit:      9  External Interrupt 9               */
+    uint32_t INT10:1;          /*!< bit:     10  External Interrupt 10              */
+    uint32_t INT11:1;          /*!< bit:     11  External Interrupt 11              */
+    uint32_t INT12:1;          /*!< bit:     12  External Interrupt 12              */
+    uint32_t INT13:1;          /*!< bit:     13  External Interrupt 13              */
+    uint32_t INT14:1;          /*!< bit:     14  External Interrupt 14              */
+    uint32_t INT15:1;          /*!< bit:     15  External Interrupt 15              */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_ISR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_ISR_OFFSET              0x00C        /**< \brief (EIC_ISR offset) Interrupt Status Register */
+#define EIC_ISR_RESETVALUE          _U(0x00000000); /**< \brief (EIC_ISR reset_value) Interrupt Status Register */
+
+#define EIC_ISR_NMI_Pos             0            /**< \brief (EIC_ISR) External Non Maskable CPU interrupt */
+#define EIC_ISR_NMI                 (_U(0x1) << EIC_ISR_NMI_Pos)
+#define EIC_ISR_INT1_Pos            1            /**< \brief (EIC_ISR) External Interrupt 1 */
+#define EIC_ISR_INT1                (_U(0x1) << EIC_ISR_INT1_Pos)
+#define   EIC_ISR_INT1_0_Val              _U(0x0)   /**< \brief (EIC_ISR) An interrupt event has not occurred */
+#define   EIC_ISR_INT1_1_Val              _U(0x1)   /**< \brief (EIC_ISR) An interrupt event has occurred. */
+#define EIC_ISR_INT1_0              (EIC_ISR_INT1_0_Val            << EIC_ISR_INT1_Pos)
+#define EIC_ISR_INT1_1              (EIC_ISR_INT1_1_Val            << EIC_ISR_INT1_Pos)
+#define EIC_ISR_INT2_Pos            2            /**< \brief (EIC_ISR) External Interrupt 2 */
+#define EIC_ISR_INT2                (_U(0x1) << EIC_ISR_INT2_Pos)
+#define   EIC_ISR_INT2_0_Val              _U(0x0)   /**< \brief (EIC_ISR) An interrupt event has not occurred */
+#define   EIC_ISR_INT2_1_Val              _U(0x1)   /**< \brief (EIC_ISR) An interrupt event has occurred. */
+#define EIC_ISR_INT2_0              (EIC_ISR_INT2_0_Val            << EIC_ISR_INT2_Pos)
+#define EIC_ISR_INT2_1              (EIC_ISR_INT2_1_Val            << EIC_ISR_INT2_Pos)
+#define EIC_ISR_INT3_Pos            3            /**< \brief (EIC_ISR) External Interrupt 3 */
+#define EIC_ISR_INT3                (_U(0x1) << EIC_ISR_INT3_Pos)
+#define   EIC_ISR_INT3_0_Val              _U(0x0)   /**< \brief (EIC_ISR) An interrupt event has not occurred */
+#define   EIC_ISR_INT3_1_Val              _U(0x1)   /**< \brief (EIC_ISR) An interrupt event has occurred. */
+#define EIC_ISR_INT3_0              (EIC_ISR_INT3_0_Val            << EIC_ISR_INT3_Pos)
+#define EIC_ISR_INT3_1              (EIC_ISR_INT3_1_Val            << EIC_ISR_INT3_Pos)
+#define EIC_ISR_INT4_Pos            4            /**< \brief (EIC_ISR) External Interrupt 4 */
+#define EIC_ISR_INT4                (_U(0x1) << EIC_ISR_INT4_Pos)
+#define   EIC_ISR_INT4_0_Val              _U(0x0)   /**< \brief (EIC_ISR) An interrupt event has not occurred */
+#define   EIC_ISR_INT4_1_Val              _U(0x1)   /**< \brief (EIC_ISR) An interrupt event has occurred. */
+#define EIC_ISR_INT4_0              (EIC_ISR_INT4_0_Val            << EIC_ISR_INT4_Pos)
+#define EIC_ISR_INT4_1              (EIC_ISR_INT4_1_Val            << EIC_ISR_INT4_Pos)
+#define EIC_ISR_INT5_Pos            5            /**< \brief (EIC_ISR) External Interrupt 5 */
+#define EIC_ISR_INT5                (_U(0x1) << EIC_ISR_INT5_Pos)
+#define EIC_ISR_INT6_Pos            6            /**< \brief (EIC_ISR) External Interrupt 6 */
+#define EIC_ISR_INT6                (_U(0x1) << EIC_ISR_INT6_Pos)
+#define EIC_ISR_INT7_Pos            7            /**< \brief (EIC_ISR) External Interrupt 7 */
+#define EIC_ISR_INT7                (_U(0x1) << EIC_ISR_INT7_Pos)
+#define EIC_ISR_INT8_Pos            8            /**< \brief (EIC_ISR) External Interrupt 8 */
+#define EIC_ISR_INT8                (_U(0x1) << EIC_ISR_INT8_Pos)
+#define EIC_ISR_INT9_Pos            9            /**< \brief (EIC_ISR) External Interrupt 9 */
+#define EIC_ISR_INT9                (_U(0x1) << EIC_ISR_INT9_Pos)
+#define EIC_ISR_INT10_Pos           10           /**< \brief (EIC_ISR) External Interrupt 10 */
+#define EIC_ISR_INT10               (_U(0x1) << EIC_ISR_INT10_Pos)
+#define EIC_ISR_INT11_Pos           11           /**< \brief (EIC_ISR) External Interrupt 11 */
+#define EIC_ISR_INT11               (_U(0x1) << EIC_ISR_INT11_Pos)
+#define EIC_ISR_INT12_Pos           12           /**< \brief (EIC_ISR) External Interrupt 12 */
+#define EIC_ISR_INT12               (_U(0x1) << EIC_ISR_INT12_Pos)
+#define EIC_ISR_INT13_Pos           13           /**< \brief (EIC_ISR) External Interrupt 13 */
+#define EIC_ISR_INT13               (_U(0x1) << EIC_ISR_INT13_Pos)
+#define EIC_ISR_INT14_Pos           14           /**< \brief (EIC_ISR) External Interrupt 14 */
+#define EIC_ISR_INT14               (_U(0x1) << EIC_ISR_INT14_Pos)
+#define EIC_ISR_INT15_Pos           15           /**< \brief (EIC_ISR) External Interrupt 15 */
+#define EIC_ISR_INT15               (_U(0x1) << EIC_ISR_INT15_Pos)
+#define EIC_ISR_MASK                _U(0x0000FFFF) /**< \brief (EIC_ISR) MASK Register */
+
+/* -------- EIC_ICR : (EIC Offset: 0x010) ( /W 32) Interrupt Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t NMI:1;            /*!< bit:      0  External Non Maskable CPU interrupt */
+    uint32_t INT1:1;           /*!< bit:      1  External Interrupt 1               */
+    uint32_t INT2:1;           /*!< bit:      2  External Interrupt 2               */
+    uint32_t INT3:1;           /*!< bit:      3  External Interrupt 3               */
+    uint32_t INT4:1;           /*!< bit:      4  External Interrupt 4               */
+    uint32_t INT5:1;           /*!< bit:      5  External Interrupt 5               */
+    uint32_t INT6:1;           /*!< bit:      6  External Interrupt 6               */
+    uint32_t INT7:1;           /*!< bit:      7  External Interrupt 7               */
+    uint32_t INT8:1;           /*!< bit:      8  External Interrupt 8               */
+    uint32_t INT9:1;           /*!< bit:      9  External Interrupt 9               */
+    uint32_t INT10:1;          /*!< bit:     10  External Interrupt 10              */
+    uint32_t INT11:1;          /*!< bit:     11  External Interrupt 11              */
+    uint32_t INT12:1;          /*!< bit:     12  External Interrupt 12              */
+    uint32_t INT13:1;          /*!< bit:     13  External Interrupt 13              */
+    uint32_t INT14:1;          /*!< bit:     14  External Interrupt 14              */
+    uint32_t INT15:1;          /*!< bit:     15  External Interrupt 15              */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_ICR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_ICR_OFFSET              0x010        /**< \brief (EIC_ICR offset) Interrupt Clear Register */
+#define EIC_ICR_RESETVALUE          _U(0x00000000); /**< \brief (EIC_ICR reset_value) Interrupt Clear Register */
+
+#define EIC_ICR_NMI_Pos             0            /**< \brief (EIC_ICR) External Non Maskable CPU interrupt */
+#define EIC_ICR_NMI                 (_U(0x1) << EIC_ICR_NMI_Pos)
+#define EIC_ICR_INT1_Pos            1            /**< \brief (EIC_ICR) External Interrupt 1 */
+#define EIC_ICR_INT1                (_U(0x1) << EIC_ICR_INT1_Pos)
+#define   EIC_ICR_INT1_0_Val              _U(0x0)   /**< \brief (EIC_ICR) No effect */
+#define   EIC_ICR_INT1_1_Val              _U(0x1)   /**< \brief (EIC_ICR) Clear Interrupt. */
+#define EIC_ICR_INT1_0              (EIC_ICR_INT1_0_Val            << EIC_ICR_INT1_Pos)
+#define EIC_ICR_INT1_1              (EIC_ICR_INT1_1_Val            << EIC_ICR_INT1_Pos)
+#define EIC_ICR_INT2_Pos            2            /**< \brief (EIC_ICR) External Interrupt 2 */
+#define EIC_ICR_INT2                (_U(0x1) << EIC_ICR_INT2_Pos)
+#define   EIC_ICR_INT2_0_Val              _U(0x0)   /**< \brief (EIC_ICR) No effect */
+#define   EIC_ICR_INT2_1_Val              _U(0x1)   /**< \brief (EIC_ICR) Clear Interrupt. */
+#define EIC_ICR_INT2_0              (EIC_ICR_INT2_0_Val            << EIC_ICR_INT2_Pos)
+#define EIC_ICR_INT2_1              (EIC_ICR_INT2_1_Val            << EIC_ICR_INT2_Pos)
+#define EIC_ICR_INT3_Pos            3            /**< \brief (EIC_ICR) External Interrupt 3 */
+#define EIC_ICR_INT3                (_U(0x1) << EIC_ICR_INT3_Pos)
+#define   EIC_ICR_INT3_0_Val              _U(0x0)   /**< \brief (EIC_ICR) No effect */
+#define   EIC_ICR_INT3_1_Val              _U(0x1)   /**< \brief (EIC_ICR) Clear Interrupt. */
+#define EIC_ICR_INT3_0              (EIC_ICR_INT3_0_Val            << EIC_ICR_INT3_Pos)
+#define EIC_ICR_INT3_1              (EIC_ICR_INT3_1_Val            << EIC_ICR_INT3_Pos)
+#define EIC_ICR_INT4_Pos            4            /**< \brief (EIC_ICR) External Interrupt 4 */
+#define EIC_ICR_INT4                (_U(0x1) << EIC_ICR_INT4_Pos)
+#define   EIC_ICR_INT4_0_Val              _U(0x0)   /**< \brief (EIC_ICR) No effect */
+#define   EIC_ICR_INT4_1_Val              _U(0x1)   /**< \brief (EIC_ICR) Clear Interrupt. */
+#define EIC_ICR_INT4_0              (EIC_ICR_INT4_0_Val            << EIC_ICR_INT4_Pos)
+#define EIC_ICR_INT4_1              (EIC_ICR_INT4_1_Val            << EIC_ICR_INT4_Pos)
+#define EIC_ICR_INT5_Pos            5            /**< \brief (EIC_ICR) External Interrupt 5 */
+#define EIC_ICR_INT5                (_U(0x1) << EIC_ICR_INT5_Pos)
+#define EIC_ICR_INT6_Pos            6            /**< \brief (EIC_ICR) External Interrupt 6 */
+#define EIC_ICR_INT6                (_U(0x1) << EIC_ICR_INT6_Pos)
+#define EIC_ICR_INT7_Pos            7            /**< \brief (EIC_ICR) External Interrupt 7 */
+#define EIC_ICR_INT7                (_U(0x1) << EIC_ICR_INT7_Pos)
+#define EIC_ICR_INT8_Pos            8            /**< \brief (EIC_ICR) External Interrupt 8 */
+#define EIC_ICR_INT8                (_U(0x1) << EIC_ICR_INT8_Pos)
+#define EIC_ICR_INT9_Pos            9            /**< \brief (EIC_ICR) External Interrupt 9 */
+#define EIC_ICR_INT9                (_U(0x1) << EIC_ICR_INT9_Pos)
+#define EIC_ICR_INT10_Pos           10           /**< \brief (EIC_ICR) External Interrupt 10 */
+#define EIC_ICR_INT10               (_U(0x1) << EIC_ICR_INT10_Pos)
+#define EIC_ICR_INT11_Pos           11           /**< \brief (EIC_ICR) External Interrupt 11 */
+#define EIC_ICR_INT11               (_U(0x1) << EIC_ICR_INT11_Pos)
+#define EIC_ICR_INT12_Pos           12           /**< \brief (EIC_ICR) External Interrupt 12 */
+#define EIC_ICR_INT12               (_U(0x1) << EIC_ICR_INT12_Pos)
+#define EIC_ICR_INT13_Pos           13           /**< \brief (EIC_ICR) External Interrupt 13 */
+#define EIC_ICR_INT13               (_U(0x1) << EIC_ICR_INT13_Pos)
+#define EIC_ICR_INT14_Pos           14           /**< \brief (EIC_ICR) External Interrupt 14 */
+#define EIC_ICR_INT14               (_U(0x1) << EIC_ICR_INT14_Pos)
+#define EIC_ICR_INT15_Pos           15           /**< \brief (EIC_ICR) External Interrupt 15 */
+#define EIC_ICR_INT15               (_U(0x1) << EIC_ICR_INT15_Pos)
+#define EIC_ICR_MASK                _U(0x0000FFFF) /**< \brief (EIC_ICR) MASK Register */
+
+/* -------- EIC_MODE : (EIC Offset: 0x014) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t NMI:1;            /*!< bit:      0  External Non Maskable CPU interrupt */
+    uint32_t INT1:1;           /*!< bit:      1  External Interrupt 1               */
+    uint32_t INT2:1;           /*!< bit:      2  External Interrupt 2               */
+    uint32_t INT3:1;           /*!< bit:      3  External Interrupt 3               */
+    uint32_t INT4:1;           /*!< bit:      4  External Interrupt 4               */
+    uint32_t INT5:1;           /*!< bit:      5  External Interrupt 5               */
+    uint32_t INT6:1;           /*!< bit:      6  External Interrupt 6               */
+    uint32_t INT7:1;           /*!< bit:      7  External Interrupt 7               */
+    uint32_t INT8:1;           /*!< bit:      8  External Interrupt 8               */
+    uint32_t INT9:1;           /*!< bit:      9  External Interrupt 9               */
+    uint32_t INT10:1;          /*!< bit:     10  External Interrupt 10              */
+    uint32_t INT11:1;          /*!< bit:     11  External Interrupt 11              */
+    uint32_t INT12:1;          /*!< bit:     12  External Interrupt 12              */
+    uint32_t INT13:1;          /*!< bit:     13  External Interrupt 13              */
+    uint32_t INT14:1;          /*!< bit:     14  External Interrupt 14              */
+    uint32_t INT15:1;          /*!< bit:     15  External Interrupt 15              */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_MODE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_MODE_OFFSET             0x014        /**< \brief (EIC_MODE offset) Mode Register */
+#define EIC_MODE_RESETVALUE         _U(0x00000000); /**< \brief (EIC_MODE reset_value) Mode Register */
+
+#define EIC_MODE_NMI_Pos            0            /**< \brief (EIC_MODE) External Non Maskable CPU interrupt */
+#define EIC_MODE_NMI                (_U(0x1) << EIC_MODE_NMI_Pos)
+#define EIC_MODE_INT1_Pos           1            /**< \brief (EIC_MODE) External Interrupt 1 */
+#define EIC_MODE_INT1               (_U(0x1) << EIC_MODE_INT1_Pos)
+#define   EIC_MODE_INT1_0_Val             _U(0x0)   /**< \brief (EIC_MODE) Edge triggered interrupt */
+#define   EIC_MODE_INT1_1_Val             _U(0x1)   /**< \brief (EIC_MODE) Level triggered interrupt */
+#define EIC_MODE_INT1_0             (EIC_MODE_INT1_0_Val           << EIC_MODE_INT1_Pos)
+#define EIC_MODE_INT1_1             (EIC_MODE_INT1_1_Val           << EIC_MODE_INT1_Pos)
+#define EIC_MODE_INT2_Pos           2            /**< \brief (EIC_MODE) External Interrupt 2 */
+#define EIC_MODE_INT2               (_U(0x1) << EIC_MODE_INT2_Pos)
+#define   EIC_MODE_INT2_0_Val             _U(0x0)   /**< \brief (EIC_MODE) Edge triggered interrupt */
+#define   EIC_MODE_INT2_1_Val             _U(0x1)   /**< \brief (EIC_MODE) Level triggered interrupt */
+#define EIC_MODE_INT2_0             (EIC_MODE_INT2_0_Val           << EIC_MODE_INT2_Pos)
+#define EIC_MODE_INT2_1             (EIC_MODE_INT2_1_Val           << EIC_MODE_INT2_Pos)
+#define EIC_MODE_INT3_Pos           3            /**< \brief (EIC_MODE) External Interrupt 3 */
+#define EIC_MODE_INT3               (_U(0x1) << EIC_MODE_INT3_Pos)
+#define   EIC_MODE_INT3_0_Val             _U(0x0)   /**< \brief (EIC_MODE) Edge triggered interrupt */
+#define   EIC_MODE_INT3_1_Val             _U(0x1)   /**< \brief (EIC_MODE) Level triggered interrupt */
+#define EIC_MODE_INT3_0             (EIC_MODE_INT3_0_Val           << EIC_MODE_INT3_Pos)
+#define EIC_MODE_INT3_1             (EIC_MODE_INT3_1_Val           << EIC_MODE_INT3_Pos)
+#define EIC_MODE_INT4_Pos           4            /**< \brief (EIC_MODE) External Interrupt 4 */
+#define EIC_MODE_INT4               (_U(0x1) << EIC_MODE_INT4_Pos)
+#define   EIC_MODE_INT4_0_Val             _U(0x0)   /**< \brief (EIC_MODE) Edge triggered interrupt */
+#define   EIC_MODE_INT4_1_Val             _U(0x1)   /**< \brief (EIC_MODE) Level triggered interrupt */
+#define EIC_MODE_INT4_0             (EIC_MODE_INT4_0_Val           << EIC_MODE_INT4_Pos)
+#define EIC_MODE_INT4_1             (EIC_MODE_INT4_1_Val           << EIC_MODE_INT4_Pos)
+#define EIC_MODE_INT5_Pos           5            /**< \brief (EIC_MODE) External Interrupt 5 */
+#define EIC_MODE_INT5               (_U(0x1) << EIC_MODE_INT5_Pos)
+#define EIC_MODE_INT6_Pos           6            /**< \brief (EIC_MODE) External Interrupt 6 */
+#define EIC_MODE_INT6               (_U(0x1) << EIC_MODE_INT6_Pos)
+#define EIC_MODE_INT7_Pos           7            /**< \brief (EIC_MODE) External Interrupt 7 */
+#define EIC_MODE_INT7               (_U(0x1) << EIC_MODE_INT7_Pos)
+#define EIC_MODE_INT8_Pos           8            /**< \brief (EIC_MODE) External Interrupt 8 */
+#define EIC_MODE_INT8               (_U(0x1) << EIC_MODE_INT8_Pos)
+#define EIC_MODE_INT9_Pos           9            /**< \brief (EIC_MODE) External Interrupt 9 */
+#define EIC_MODE_INT9               (_U(0x1) << EIC_MODE_INT9_Pos)
+#define EIC_MODE_INT10_Pos          10           /**< \brief (EIC_MODE) External Interrupt 10 */
+#define EIC_MODE_INT10              (_U(0x1) << EIC_MODE_INT10_Pos)
+#define EIC_MODE_INT11_Pos          11           /**< \brief (EIC_MODE) External Interrupt 11 */
+#define EIC_MODE_INT11              (_U(0x1) << EIC_MODE_INT11_Pos)
+#define EIC_MODE_INT12_Pos          12           /**< \brief (EIC_MODE) External Interrupt 12 */
+#define EIC_MODE_INT12              (_U(0x1) << EIC_MODE_INT12_Pos)
+#define EIC_MODE_INT13_Pos          13           /**< \brief (EIC_MODE) External Interrupt 13 */
+#define EIC_MODE_INT13              (_U(0x1) << EIC_MODE_INT13_Pos)
+#define EIC_MODE_INT14_Pos          14           /**< \brief (EIC_MODE) External Interrupt 14 */
+#define EIC_MODE_INT14              (_U(0x1) << EIC_MODE_INT14_Pos)
+#define EIC_MODE_INT15_Pos          15           /**< \brief (EIC_MODE) External Interrupt 15 */
+#define EIC_MODE_INT15              (_U(0x1) << EIC_MODE_INT15_Pos)
+#define EIC_MODE_MASK               _U(0x0000FFFF) /**< \brief (EIC_MODE) MASK Register */
+
+/* -------- EIC_EDGE : (EIC Offset: 0x018) (R/W 32) Edge Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t NMI:1;            /*!< bit:      0  External Non Maskable CPU interrupt */
+    uint32_t INT1:1;           /*!< bit:      1  External Interrupt 1               */
+    uint32_t INT2:1;           /*!< bit:      2  External Interrupt 2               */
+    uint32_t INT3:1;           /*!< bit:      3  External Interrupt 3               */
+    uint32_t INT4:1;           /*!< bit:      4  External Interrupt 4               */
+    uint32_t INT5:1;           /*!< bit:      5  External Interrupt 5               */
+    uint32_t INT6:1;           /*!< bit:      6  External Interrupt 6               */
+    uint32_t INT7:1;           /*!< bit:      7  External Interrupt 7               */
+    uint32_t INT8:1;           /*!< bit:      8  External Interrupt 8               */
+    uint32_t INT9:1;           /*!< bit:      9  External Interrupt 9               */
+    uint32_t INT10:1;          /*!< bit:     10  External Interrupt 10              */
+    uint32_t INT11:1;          /*!< bit:     11  External Interrupt 11              */
+    uint32_t INT12:1;          /*!< bit:     12  External Interrupt 12              */
+    uint32_t INT13:1;          /*!< bit:     13  External Interrupt 13              */
+    uint32_t INT14:1;          /*!< bit:     14  External Interrupt 14              */
+    uint32_t INT15:1;          /*!< bit:     15  External Interrupt 15              */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_EDGE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_EDGE_OFFSET             0x018        /**< \brief (EIC_EDGE offset) Edge Register */
+#define EIC_EDGE_RESETVALUE         _U(0x00000000); /**< \brief (EIC_EDGE reset_value) Edge Register */
+
+#define EIC_EDGE_NMI_Pos            0            /**< \brief (EIC_EDGE) External Non Maskable CPU interrupt */
+#define EIC_EDGE_NMI                (_U(0x1) << EIC_EDGE_NMI_Pos)
+#define EIC_EDGE_INT1_Pos           1            /**< \brief (EIC_EDGE) External Interrupt 1 */
+#define EIC_EDGE_INT1               (_U(0x1) << EIC_EDGE_INT1_Pos)
+#define   EIC_EDGE_INT1_0_Val             _U(0x0)   /**< \brief (EIC_EDGE) Triggers on falling edge */
+#define   EIC_EDGE_INT1_1_Val             _U(0x1)   /**< \brief (EIC_EDGE) Triggers on rising edge. */
+#define EIC_EDGE_INT1_0             (EIC_EDGE_INT1_0_Val           << EIC_EDGE_INT1_Pos)
+#define EIC_EDGE_INT1_1             (EIC_EDGE_INT1_1_Val           << EIC_EDGE_INT1_Pos)
+#define EIC_EDGE_INT2_Pos           2            /**< \brief (EIC_EDGE) External Interrupt 2 */
+#define EIC_EDGE_INT2               (_U(0x1) << EIC_EDGE_INT2_Pos)
+#define   EIC_EDGE_INT2_0_Val             _U(0x0)   /**< \brief (EIC_EDGE) Triggers on falling edge */
+#define   EIC_EDGE_INT2_1_Val             _U(0x1)   /**< \brief (EIC_EDGE) Triggers on rising edge. */
+#define EIC_EDGE_INT2_0             (EIC_EDGE_INT2_0_Val           << EIC_EDGE_INT2_Pos)
+#define EIC_EDGE_INT2_1             (EIC_EDGE_INT2_1_Val           << EIC_EDGE_INT2_Pos)
+#define EIC_EDGE_INT3_Pos           3            /**< \brief (EIC_EDGE) External Interrupt 3 */
+#define EIC_EDGE_INT3               (_U(0x1) << EIC_EDGE_INT3_Pos)
+#define   EIC_EDGE_INT3_0_Val             _U(0x0)   /**< \brief (EIC_EDGE) Triggers on falling edge */
+#define   EIC_EDGE_INT3_1_Val             _U(0x1)   /**< \brief (EIC_EDGE) Triggers on rising edge. */
+#define EIC_EDGE_INT3_0             (EIC_EDGE_INT3_0_Val           << EIC_EDGE_INT3_Pos)
+#define EIC_EDGE_INT3_1             (EIC_EDGE_INT3_1_Val           << EIC_EDGE_INT3_Pos)
+#define EIC_EDGE_INT4_Pos           4            /**< \brief (EIC_EDGE) External Interrupt 4 */
+#define EIC_EDGE_INT4               (_U(0x1) << EIC_EDGE_INT4_Pos)
+#define   EIC_EDGE_INT4_0_Val             _U(0x0)   /**< \brief (EIC_EDGE) Triggers on falling edge */
+#define   EIC_EDGE_INT4_1_Val             _U(0x1)   /**< \brief (EIC_EDGE) Triggers on rising edge. */
+#define EIC_EDGE_INT4_0             (EIC_EDGE_INT4_0_Val           << EIC_EDGE_INT4_Pos)
+#define EIC_EDGE_INT4_1             (EIC_EDGE_INT4_1_Val           << EIC_EDGE_INT4_Pos)
+#define EIC_EDGE_INT5_Pos           5            /**< \brief (EIC_EDGE) External Interrupt 5 */
+#define EIC_EDGE_INT5               (_U(0x1) << EIC_EDGE_INT5_Pos)
+#define EIC_EDGE_INT6_Pos           6            /**< \brief (EIC_EDGE) External Interrupt 6 */
+#define EIC_EDGE_INT6               (_U(0x1) << EIC_EDGE_INT6_Pos)
+#define EIC_EDGE_INT7_Pos           7            /**< \brief (EIC_EDGE) External Interrupt 7 */
+#define EIC_EDGE_INT7               (_U(0x1) << EIC_EDGE_INT7_Pos)
+#define EIC_EDGE_INT8_Pos           8            /**< \brief (EIC_EDGE) External Interrupt 8 */
+#define EIC_EDGE_INT8               (_U(0x1) << EIC_EDGE_INT8_Pos)
+#define EIC_EDGE_INT9_Pos           9            /**< \brief (EIC_EDGE) External Interrupt 9 */
+#define EIC_EDGE_INT9               (_U(0x1) << EIC_EDGE_INT9_Pos)
+#define EIC_EDGE_INT10_Pos          10           /**< \brief (EIC_EDGE) External Interrupt 10 */
+#define EIC_EDGE_INT10              (_U(0x1) << EIC_EDGE_INT10_Pos)
+#define EIC_EDGE_INT11_Pos          11           /**< \brief (EIC_EDGE) External Interrupt 11 */
+#define EIC_EDGE_INT11              (_U(0x1) << EIC_EDGE_INT11_Pos)
+#define EIC_EDGE_INT12_Pos          12           /**< \brief (EIC_EDGE) External Interrupt 12 */
+#define EIC_EDGE_INT12              (_U(0x1) << EIC_EDGE_INT12_Pos)
+#define EIC_EDGE_INT13_Pos          13           /**< \brief (EIC_EDGE) External Interrupt 13 */
+#define EIC_EDGE_INT13              (_U(0x1) << EIC_EDGE_INT13_Pos)
+#define EIC_EDGE_INT14_Pos          14           /**< \brief (EIC_EDGE) External Interrupt 14 */
+#define EIC_EDGE_INT14              (_U(0x1) << EIC_EDGE_INT14_Pos)
+#define EIC_EDGE_INT15_Pos          15           /**< \brief (EIC_EDGE) External Interrupt 15 */
+#define EIC_EDGE_INT15              (_U(0x1) << EIC_EDGE_INT15_Pos)
+#define EIC_EDGE_MASK               _U(0x0000FFFF) /**< \brief (EIC_EDGE) MASK Register */
+
+/* -------- EIC_LEVEL : (EIC Offset: 0x01C) (R/W 32) Level Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t NMI:1;            /*!< bit:      0  External Non Maskable CPU interrupt */
+    uint32_t INT1:1;           /*!< bit:      1  External Interrupt 1               */
+    uint32_t INT2:1;           /*!< bit:      2  External Interrupt 2               */
+    uint32_t INT3:1;           /*!< bit:      3  External Interrupt 3               */
+    uint32_t INT4:1;           /*!< bit:      4  External Interrupt 4               */
+    uint32_t INT5:1;           /*!< bit:      5  External Interrupt 5               */
+    uint32_t INT6:1;           /*!< bit:      6  External Interrupt 6               */
+    uint32_t INT7:1;           /*!< bit:      7  External Interrupt 7               */
+    uint32_t INT8:1;           /*!< bit:      8  External Interrupt 8               */
+    uint32_t INT9:1;           /*!< bit:      9  External Interrupt 9               */
+    uint32_t INT10:1;          /*!< bit:     10  External Interrupt 10              */
+    uint32_t INT11:1;          /*!< bit:     11  External Interrupt 11              */
+    uint32_t INT12:1;          /*!< bit:     12  External Interrupt 12              */
+    uint32_t INT13:1;          /*!< bit:     13  External Interrupt 13              */
+    uint32_t INT14:1;          /*!< bit:     14  External Interrupt 14              */
+    uint32_t INT15:1;          /*!< bit:     15  External Interrupt 15              */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_LEVEL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_LEVEL_OFFSET            0x01C        /**< \brief (EIC_LEVEL offset) Level Register */
+#define EIC_LEVEL_RESETVALUE        _U(0x00000000); /**< \brief (EIC_LEVEL reset_value) Level Register */
+
+#define EIC_LEVEL_NMI_Pos           0            /**< \brief (EIC_LEVEL) External Non Maskable CPU interrupt */
+#define EIC_LEVEL_NMI               (_U(0x1) << EIC_LEVEL_NMI_Pos)
+#define EIC_LEVEL_INT1_Pos          1            /**< \brief (EIC_LEVEL) External Interrupt 1 */
+#define EIC_LEVEL_INT1              (_U(0x1) << EIC_LEVEL_INT1_Pos)
+#define EIC_LEVEL_INT2_Pos          2            /**< \brief (EIC_LEVEL) External Interrupt 2 */
+#define EIC_LEVEL_INT2              (_U(0x1) << EIC_LEVEL_INT2_Pos)
+#define EIC_LEVEL_INT3_Pos          3            /**< \brief (EIC_LEVEL) External Interrupt 3 */
+#define EIC_LEVEL_INT3              (_U(0x1) << EIC_LEVEL_INT3_Pos)
+#define EIC_LEVEL_INT4_Pos          4            /**< \brief (EIC_LEVEL) External Interrupt 4 */
+#define EIC_LEVEL_INT4              (_U(0x1) << EIC_LEVEL_INT4_Pos)
+#define EIC_LEVEL_INT5_Pos          5            /**< \brief (EIC_LEVEL) External Interrupt 5 */
+#define EIC_LEVEL_INT5              (_U(0x1) << EIC_LEVEL_INT5_Pos)
+#define EIC_LEVEL_INT6_Pos          6            /**< \brief (EIC_LEVEL) External Interrupt 6 */
+#define EIC_LEVEL_INT6              (_U(0x1) << EIC_LEVEL_INT6_Pos)
+#define EIC_LEVEL_INT7_Pos          7            /**< \brief (EIC_LEVEL) External Interrupt 7 */
+#define EIC_LEVEL_INT7              (_U(0x1) << EIC_LEVEL_INT7_Pos)
+#define EIC_LEVEL_INT8_Pos          8            /**< \brief (EIC_LEVEL) External Interrupt 8 */
+#define EIC_LEVEL_INT8              (_U(0x1) << EIC_LEVEL_INT8_Pos)
+#define EIC_LEVEL_INT9_Pos          9            /**< \brief (EIC_LEVEL) External Interrupt 9 */
+#define EIC_LEVEL_INT9              (_U(0x1) << EIC_LEVEL_INT9_Pos)
+#define EIC_LEVEL_INT10_Pos         10           /**< \brief (EIC_LEVEL) External Interrupt 10 */
+#define EIC_LEVEL_INT10             (_U(0x1) << EIC_LEVEL_INT10_Pos)
+#define EIC_LEVEL_INT11_Pos         11           /**< \brief (EIC_LEVEL) External Interrupt 11 */
+#define EIC_LEVEL_INT11             (_U(0x1) << EIC_LEVEL_INT11_Pos)
+#define EIC_LEVEL_INT12_Pos         12           /**< \brief (EIC_LEVEL) External Interrupt 12 */
+#define EIC_LEVEL_INT12             (_U(0x1) << EIC_LEVEL_INT12_Pos)
+#define EIC_LEVEL_INT13_Pos         13           /**< \brief (EIC_LEVEL) External Interrupt 13 */
+#define EIC_LEVEL_INT13             (_U(0x1) << EIC_LEVEL_INT13_Pos)
+#define EIC_LEVEL_INT14_Pos         14           /**< \brief (EIC_LEVEL) External Interrupt 14 */
+#define EIC_LEVEL_INT14             (_U(0x1) << EIC_LEVEL_INT14_Pos)
+#define EIC_LEVEL_INT15_Pos         15           /**< \brief (EIC_LEVEL) External Interrupt 15 */
+#define EIC_LEVEL_INT15             (_U(0x1) << EIC_LEVEL_INT15_Pos)
+#define EIC_LEVEL_MASK              _U(0x0000FFFF) /**< \brief (EIC_LEVEL) MASK Register */
+
+/* -------- EIC_FILTER : (EIC Offset: 0x020) (R/W 32) Filter Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t NMI:1;            /*!< bit:      0  External Non Maskable CPU interrupt */
+    uint32_t INT1:1;           /*!< bit:      1  External Interrupt 1               */
+    uint32_t INT2:1;           /*!< bit:      2  External Interrupt 2               */
+    uint32_t INT3:1;           /*!< bit:      3  External Interrupt 3               */
+    uint32_t INT4:1;           /*!< bit:      4  External Interrupt 4               */
+    uint32_t INT5:1;           /*!< bit:      5  External Interrupt 5               */
+    uint32_t INT6:1;           /*!< bit:      6  External Interrupt 6               */
+    uint32_t INT7:1;           /*!< bit:      7  External Interrupt 7               */
+    uint32_t INT8:1;           /*!< bit:      8  External Interrupt 8               */
+    uint32_t INT9:1;           /*!< bit:      9  External Interrupt 9               */
+    uint32_t INT10:1;          /*!< bit:     10  External Interrupt 10              */
+    uint32_t INT11:1;          /*!< bit:     11  External Interrupt 11              */
+    uint32_t INT12:1;          /*!< bit:     12  External Interrupt 12              */
+    uint32_t INT13:1;          /*!< bit:     13  External Interrupt 13              */
+    uint32_t INT14:1;          /*!< bit:     14  External Interrupt 14              */
+    uint32_t INT15:1;          /*!< bit:     15  External Interrupt 15              */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_FILTER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_FILTER_OFFSET           0x020        /**< \brief (EIC_FILTER offset) Filter Register */
+#define EIC_FILTER_RESETVALUE       _U(0x00000000); /**< \brief (EIC_FILTER reset_value) Filter Register */
+
+#define EIC_FILTER_NMI_Pos          0            /**< \brief (EIC_FILTER) External Non Maskable CPU interrupt */
+#define EIC_FILTER_NMI              (_U(0x1) << EIC_FILTER_NMI_Pos)
+#define EIC_FILTER_INT1_Pos         1            /**< \brief (EIC_FILTER) External Interrupt 1 */
+#define EIC_FILTER_INT1             (_U(0x1) << EIC_FILTER_INT1_Pos)
+#define EIC_FILTER_INT2_Pos         2            /**< \brief (EIC_FILTER) External Interrupt 2 */
+#define EIC_FILTER_INT2             (_U(0x1) << EIC_FILTER_INT2_Pos)
+#define EIC_FILTER_INT3_Pos         3            /**< \brief (EIC_FILTER) External Interrupt 3 */
+#define EIC_FILTER_INT3             (_U(0x1) << EIC_FILTER_INT3_Pos)
+#define EIC_FILTER_INT4_Pos         4            /**< \brief (EIC_FILTER) External Interrupt 4 */
+#define EIC_FILTER_INT4             (_U(0x1) << EIC_FILTER_INT4_Pos)
+#define EIC_FILTER_INT5_Pos         5            /**< \brief (EIC_FILTER) External Interrupt 5 */
+#define EIC_FILTER_INT5             (_U(0x1) << EIC_FILTER_INT5_Pos)
+#define EIC_FILTER_INT6_Pos         6            /**< \brief (EIC_FILTER) External Interrupt 6 */
+#define EIC_FILTER_INT6             (_U(0x1) << EIC_FILTER_INT6_Pos)
+#define EIC_FILTER_INT7_Pos         7            /**< \brief (EIC_FILTER) External Interrupt 7 */
+#define EIC_FILTER_INT7             (_U(0x1) << EIC_FILTER_INT7_Pos)
+#define EIC_FILTER_INT8_Pos         8            /**< \brief (EIC_FILTER) External Interrupt 8 */
+#define EIC_FILTER_INT8             (_U(0x1) << EIC_FILTER_INT8_Pos)
+#define EIC_FILTER_INT9_Pos         9            /**< \brief (EIC_FILTER) External Interrupt 9 */
+#define EIC_FILTER_INT9             (_U(0x1) << EIC_FILTER_INT9_Pos)
+#define EIC_FILTER_INT10_Pos        10           /**< \brief (EIC_FILTER) External Interrupt 10 */
+#define EIC_FILTER_INT10            (_U(0x1) << EIC_FILTER_INT10_Pos)
+#define EIC_FILTER_INT11_Pos        11           /**< \brief (EIC_FILTER) External Interrupt 11 */
+#define EIC_FILTER_INT11            (_U(0x1) << EIC_FILTER_INT11_Pos)
+#define EIC_FILTER_INT12_Pos        12           /**< \brief (EIC_FILTER) External Interrupt 12 */
+#define EIC_FILTER_INT12            (_U(0x1) << EIC_FILTER_INT12_Pos)
+#define EIC_FILTER_INT13_Pos        13           /**< \brief (EIC_FILTER) External Interrupt 13 */
+#define EIC_FILTER_INT13            (_U(0x1) << EIC_FILTER_INT13_Pos)
+#define EIC_FILTER_INT14_Pos        14           /**< \brief (EIC_FILTER) External Interrupt 14 */
+#define EIC_FILTER_INT14            (_U(0x1) << EIC_FILTER_INT14_Pos)
+#define EIC_FILTER_INT15_Pos        15           /**< \brief (EIC_FILTER) External Interrupt 15 */
+#define EIC_FILTER_INT15            (_U(0x1) << EIC_FILTER_INT15_Pos)
+#define EIC_FILTER_MASK             _U(0x0000FFFF) /**< \brief (EIC_FILTER) MASK Register */
+
+/* -------- EIC_ASYNC : (EIC Offset: 0x028) (R/W 32) Asynchronous Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t NMI:1;            /*!< bit:      0  External Non Maskable CPU interrupt */
+    uint32_t INT1:1;           /*!< bit:      1  External Interrupt 1               */
+    uint32_t INT2:1;           /*!< bit:      2  External Interrupt 2               */
+    uint32_t INT3:1;           /*!< bit:      3  External Interrupt 3               */
+    uint32_t INT4:1;           /*!< bit:      4  External Interrupt 4               */
+    uint32_t INT5:1;           /*!< bit:      5  External Interrupt 5               */
+    uint32_t INT6:1;           /*!< bit:      6  External Interrupt 6               */
+    uint32_t INT7:1;           /*!< bit:      7  External Interrupt 7               */
+    uint32_t INT8:1;           /*!< bit:      8  External Interrupt 8               */
+    uint32_t INT9:1;           /*!< bit:      9  External Interrupt 9               */
+    uint32_t INT10:1;          /*!< bit:     10  External Interrupt 10              */
+    uint32_t INT11:1;          /*!< bit:     11  External Interrupt 11              */
+    uint32_t INT12:1;          /*!< bit:     12  External Interrupt 12              */
+    uint32_t INT13:1;          /*!< bit:     13  External Interrupt 13              */
+    uint32_t INT14:1;          /*!< bit:     14  External Interrupt 14              */
+    uint32_t INT15:1;          /*!< bit:     15  External Interrupt 15              */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_ASYNC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_ASYNC_OFFSET            0x028        /**< \brief (EIC_ASYNC offset) Asynchronous Register */
+#define EIC_ASYNC_RESETVALUE        _U(0x00000000); /**< \brief (EIC_ASYNC reset_value) Asynchronous Register */
+
+#define EIC_ASYNC_NMI_Pos           0            /**< \brief (EIC_ASYNC) External Non Maskable CPU interrupt */
+#define EIC_ASYNC_NMI               (_U(0x1) << EIC_ASYNC_NMI_Pos)
+#define EIC_ASYNC_INT1_Pos          1            /**< \brief (EIC_ASYNC) External Interrupt 1 */
+#define EIC_ASYNC_INT1              (_U(0x1) << EIC_ASYNC_INT1_Pos)
+#define EIC_ASYNC_INT2_Pos          2            /**< \brief (EIC_ASYNC) External Interrupt 2 */
+#define EIC_ASYNC_INT2              (_U(0x1) << EIC_ASYNC_INT2_Pos)
+#define EIC_ASYNC_INT3_Pos          3            /**< \brief (EIC_ASYNC) External Interrupt 3 */
+#define EIC_ASYNC_INT3              (_U(0x1) << EIC_ASYNC_INT3_Pos)
+#define EIC_ASYNC_INT4_Pos          4            /**< \brief (EIC_ASYNC) External Interrupt 4 */
+#define EIC_ASYNC_INT4              (_U(0x1) << EIC_ASYNC_INT4_Pos)
+#define EIC_ASYNC_INT5_Pos          5            /**< \brief (EIC_ASYNC) External Interrupt 5 */
+#define EIC_ASYNC_INT5              (_U(0x1) << EIC_ASYNC_INT5_Pos)
+#define EIC_ASYNC_INT6_Pos          6            /**< \brief (EIC_ASYNC) External Interrupt 6 */
+#define EIC_ASYNC_INT6              (_U(0x1) << EIC_ASYNC_INT6_Pos)
+#define EIC_ASYNC_INT7_Pos          7            /**< \brief (EIC_ASYNC) External Interrupt 7 */
+#define EIC_ASYNC_INT7              (_U(0x1) << EIC_ASYNC_INT7_Pos)
+#define EIC_ASYNC_INT8_Pos          8            /**< \brief (EIC_ASYNC) External Interrupt 8 */
+#define EIC_ASYNC_INT8              (_U(0x1) << EIC_ASYNC_INT8_Pos)
+#define EIC_ASYNC_INT9_Pos          9            /**< \brief (EIC_ASYNC) External Interrupt 9 */
+#define EIC_ASYNC_INT9              (_U(0x1) << EIC_ASYNC_INT9_Pos)
+#define EIC_ASYNC_INT10_Pos         10           /**< \brief (EIC_ASYNC) External Interrupt 10 */
+#define EIC_ASYNC_INT10             (_U(0x1) << EIC_ASYNC_INT10_Pos)
+#define EIC_ASYNC_INT11_Pos         11           /**< \brief (EIC_ASYNC) External Interrupt 11 */
+#define EIC_ASYNC_INT11             (_U(0x1) << EIC_ASYNC_INT11_Pos)
+#define EIC_ASYNC_INT12_Pos         12           /**< \brief (EIC_ASYNC) External Interrupt 12 */
+#define EIC_ASYNC_INT12             (_U(0x1) << EIC_ASYNC_INT12_Pos)
+#define EIC_ASYNC_INT13_Pos         13           /**< \brief (EIC_ASYNC) External Interrupt 13 */
+#define EIC_ASYNC_INT13             (_U(0x1) << EIC_ASYNC_INT13_Pos)
+#define EIC_ASYNC_INT14_Pos         14           /**< \brief (EIC_ASYNC) External Interrupt 14 */
+#define EIC_ASYNC_INT14             (_U(0x1) << EIC_ASYNC_INT14_Pos)
+#define EIC_ASYNC_INT15_Pos         15           /**< \brief (EIC_ASYNC) External Interrupt 15 */
+#define EIC_ASYNC_INT15             (_U(0x1) << EIC_ASYNC_INT15_Pos)
+#define EIC_ASYNC_MASK              _U(0x0000FFFF) /**< \brief (EIC_ASYNC) MASK Register */
+
+/* -------- EIC_EN : (EIC Offset: 0x030) ( /W 32) Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t NMI:1;            /*!< bit:      0  External Non Maskable CPU interrupt */
+    uint32_t INT1:1;           /*!< bit:      1  External Interrupt 1               */
+    uint32_t INT2:1;           /*!< bit:      2  External Interrupt 2               */
+    uint32_t INT3:1;           /*!< bit:      3  External Interrupt 3               */
+    uint32_t INT4:1;           /*!< bit:      4  External Interrupt 4               */
+    uint32_t INT5:1;           /*!< bit:      5  External Interrupt 5               */
+    uint32_t INT6:1;           /*!< bit:      6  External Interrupt 6               */
+    uint32_t INT7:1;           /*!< bit:      7  External Interrupt 7               */
+    uint32_t INT8:1;           /*!< bit:      8  External Interrupt 8               */
+    uint32_t INT9:1;           /*!< bit:      9  External Interrupt 9               */
+    uint32_t INT10:1;          /*!< bit:     10  External Interrupt 10              */
+    uint32_t INT11:1;          /*!< bit:     11  External Interrupt 11              */
+    uint32_t INT12:1;          /*!< bit:     12  External Interrupt 12              */
+    uint32_t INT13:1;          /*!< bit:     13  External Interrupt 13              */
+    uint32_t INT14:1;          /*!< bit:     14  External Interrupt 14              */
+    uint32_t INT15:1;          /*!< bit:     15  External Interrupt 15              */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_EN_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_EN_OFFSET               0x030        /**< \brief (EIC_EN offset) Enable Register */
+#define EIC_EN_RESETVALUE           _U(0x00000000); /**< \brief (EIC_EN reset_value) Enable Register */
+
+#define EIC_EN_NMI_Pos              0            /**< \brief (EIC_EN) External Non Maskable CPU interrupt */
+#define EIC_EN_NMI                  (_U(0x1) << EIC_EN_NMI_Pos)
+#define EIC_EN_INT1_Pos             1            /**< \brief (EIC_EN) External Interrupt 1 */
+#define EIC_EN_INT1                 (_U(0x1) << EIC_EN_INT1_Pos)
+#define EIC_EN_INT2_Pos             2            /**< \brief (EIC_EN) External Interrupt 2 */
+#define EIC_EN_INT2                 (_U(0x1) << EIC_EN_INT2_Pos)
+#define EIC_EN_INT3_Pos             3            /**< \brief (EIC_EN) External Interrupt 3 */
+#define EIC_EN_INT3                 (_U(0x1) << EIC_EN_INT3_Pos)
+#define EIC_EN_INT4_Pos             4            /**< \brief (EIC_EN) External Interrupt 4 */
+#define EIC_EN_INT4                 (_U(0x1) << EIC_EN_INT4_Pos)
+#define EIC_EN_INT5_Pos             5            /**< \brief (EIC_EN) External Interrupt 5 */
+#define EIC_EN_INT5                 (_U(0x1) << EIC_EN_INT5_Pos)
+#define EIC_EN_INT6_Pos             6            /**< \brief (EIC_EN) External Interrupt 6 */
+#define EIC_EN_INT6                 (_U(0x1) << EIC_EN_INT6_Pos)
+#define EIC_EN_INT7_Pos             7            /**< \brief (EIC_EN) External Interrupt 7 */
+#define EIC_EN_INT7                 (_U(0x1) << EIC_EN_INT7_Pos)
+#define EIC_EN_INT8_Pos             8            /**< \brief (EIC_EN) External Interrupt 8 */
+#define EIC_EN_INT8                 (_U(0x1) << EIC_EN_INT8_Pos)
+#define EIC_EN_INT9_Pos             9            /**< \brief (EIC_EN) External Interrupt 9 */
+#define EIC_EN_INT9                 (_U(0x1) << EIC_EN_INT9_Pos)
+#define EIC_EN_INT10_Pos            10           /**< \brief (EIC_EN) External Interrupt 10 */
+#define EIC_EN_INT10                (_U(0x1) << EIC_EN_INT10_Pos)
+#define EIC_EN_INT11_Pos            11           /**< \brief (EIC_EN) External Interrupt 11 */
+#define EIC_EN_INT11                (_U(0x1) << EIC_EN_INT11_Pos)
+#define EIC_EN_INT12_Pos            12           /**< \brief (EIC_EN) External Interrupt 12 */
+#define EIC_EN_INT12                (_U(0x1) << EIC_EN_INT12_Pos)
+#define EIC_EN_INT13_Pos            13           /**< \brief (EIC_EN) External Interrupt 13 */
+#define EIC_EN_INT13                (_U(0x1) << EIC_EN_INT13_Pos)
+#define EIC_EN_INT14_Pos            14           /**< \brief (EIC_EN) External Interrupt 14 */
+#define EIC_EN_INT14                (_U(0x1) << EIC_EN_INT14_Pos)
+#define EIC_EN_INT15_Pos            15           /**< \brief (EIC_EN) External Interrupt 15 */
+#define EIC_EN_INT15                (_U(0x1) << EIC_EN_INT15_Pos)
+#define EIC_EN_MASK                 _U(0x0000FFFF) /**< \brief (EIC_EN) MASK Register */
+
+/* -------- EIC_DIS : (EIC Offset: 0x034) ( /W 32) Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t NMI:1;            /*!< bit:      0  External Non Maskable CPU interrupt */
+    uint32_t INT1:1;           /*!< bit:      1  External Interrupt 1               */
+    uint32_t INT2:1;           /*!< bit:      2  External Interrupt 2               */
+    uint32_t INT3:1;           /*!< bit:      3  External Interrupt 3               */
+    uint32_t INT4:1;           /*!< bit:      4  External Interrupt 4               */
+    uint32_t INT5:1;           /*!< bit:      5  External Interrupt 5               */
+    uint32_t INT6:1;           /*!< bit:      6  External Interrupt 6               */
+    uint32_t INT7:1;           /*!< bit:      7  External Interrupt 7               */
+    uint32_t INT8:1;           /*!< bit:      8  External Interrupt 8               */
+    uint32_t INT9:1;           /*!< bit:      9  External Interrupt 9               */
+    uint32_t INT10:1;          /*!< bit:     10  External Interrupt 10              */
+    uint32_t INT11:1;          /*!< bit:     11  External Interrupt 11              */
+    uint32_t INT12:1;          /*!< bit:     12  External Interrupt 12              */
+    uint32_t INT13:1;          /*!< bit:     13  External Interrupt 13              */
+    uint32_t INT14:1;          /*!< bit:     14  External Interrupt 14              */
+    uint32_t INT15:1;          /*!< bit:     15  External Interrupt 15              */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_DIS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_DIS_OFFSET              0x034        /**< \brief (EIC_DIS offset) Disable Register */
+#define EIC_DIS_RESETVALUE          _U(0x00000000); /**< \brief (EIC_DIS reset_value) Disable Register */
+
+#define EIC_DIS_NMI_Pos             0            /**< \brief (EIC_DIS) External Non Maskable CPU interrupt */
+#define EIC_DIS_NMI                 (_U(0x1) << EIC_DIS_NMI_Pos)
+#define EIC_DIS_INT1_Pos            1            /**< \brief (EIC_DIS) External Interrupt 1 */
+#define EIC_DIS_INT1                (_U(0x1) << EIC_DIS_INT1_Pos)
+#define EIC_DIS_INT2_Pos            2            /**< \brief (EIC_DIS) External Interrupt 2 */
+#define EIC_DIS_INT2                (_U(0x1) << EIC_DIS_INT2_Pos)
+#define EIC_DIS_INT3_Pos            3            /**< \brief (EIC_DIS) External Interrupt 3 */
+#define EIC_DIS_INT3                (_U(0x1) << EIC_DIS_INT3_Pos)
+#define EIC_DIS_INT4_Pos            4            /**< \brief (EIC_DIS) External Interrupt 4 */
+#define EIC_DIS_INT4                (_U(0x1) << EIC_DIS_INT4_Pos)
+#define EIC_DIS_INT5_Pos            5            /**< \brief (EIC_DIS) External Interrupt 5 */
+#define EIC_DIS_INT5                (_U(0x1) << EIC_DIS_INT5_Pos)
+#define EIC_DIS_INT6_Pos            6            /**< \brief (EIC_DIS) External Interrupt 6 */
+#define EIC_DIS_INT6                (_U(0x1) << EIC_DIS_INT6_Pos)
+#define EIC_DIS_INT7_Pos            7            /**< \brief (EIC_DIS) External Interrupt 7 */
+#define EIC_DIS_INT7                (_U(0x1) << EIC_DIS_INT7_Pos)
+#define EIC_DIS_INT8_Pos            8            /**< \brief (EIC_DIS) External Interrupt 8 */
+#define EIC_DIS_INT8                (_U(0x1) << EIC_DIS_INT8_Pos)
+#define EIC_DIS_INT9_Pos            9            /**< \brief (EIC_DIS) External Interrupt 9 */
+#define EIC_DIS_INT9                (_U(0x1) << EIC_DIS_INT9_Pos)
+#define EIC_DIS_INT10_Pos           10           /**< \brief (EIC_DIS) External Interrupt 10 */
+#define EIC_DIS_INT10               (_U(0x1) << EIC_DIS_INT10_Pos)
+#define EIC_DIS_INT11_Pos           11           /**< \brief (EIC_DIS) External Interrupt 11 */
+#define EIC_DIS_INT11               (_U(0x1) << EIC_DIS_INT11_Pos)
+#define EIC_DIS_INT12_Pos           12           /**< \brief (EIC_DIS) External Interrupt 12 */
+#define EIC_DIS_INT12               (_U(0x1) << EIC_DIS_INT12_Pos)
+#define EIC_DIS_INT13_Pos           13           /**< \brief (EIC_DIS) External Interrupt 13 */
+#define EIC_DIS_INT13               (_U(0x1) << EIC_DIS_INT13_Pos)
+#define EIC_DIS_INT14_Pos           14           /**< \brief (EIC_DIS) External Interrupt 14 */
+#define EIC_DIS_INT14               (_U(0x1) << EIC_DIS_INT14_Pos)
+#define EIC_DIS_INT15_Pos           15           /**< \brief (EIC_DIS) External Interrupt 15 */
+#define EIC_DIS_INT15               (_U(0x1) << EIC_DIS_INT15_Pos)
+#define EIC_DIS_MASK                _U(0x0000FFFF) /**< \brief (EIC_DIS) MASK Register */
+
+/* -------- EIC_CTRL : (EIC Offset: 0x038) (R/  32) Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t NMI:1;            /*!< bit:      0  External Non Maskable CPU interrupt */
+    uint32_t INT1:1;           /*!< bit:      1  External Interrupt 1               */
+    uint32_t INT2:1;           /*!< bit:      2  External Interrupt 2               */
+    uint32_t INT3:1;           /*!< bit:      3  External Interrupt 3               */
+    uint32_t INT4:1;           /*!< bit:      4  External Interrupt 4               */
+    uint32_t INT5:1;           /*!< bit:      5  External Interrupt 5               */
+    uint32_t INT6:1;           /*!< bit:      6  External Interrupt 6               */
+    uint32_t INT7:1;           /*!< bit:      7  External Interrupt 7               */
+    uint32_t INT8:1;           /*!< bit:      8  External Interrupt 8               */
+    uint32_t INT9:1;           /*!< bit:      9  External Interrupt 9               */
+    uint32_t INT10:1;          /*!< bit:     10  External Interrupt 10              */
+    uint32_t INT11:1;          /*!< bit:     11  External Interrupt 11              */
+    uint32_t INT12:1;          /*!< bit:     12  External Interrupt 12              */
+    uint32_t INT13:1;          /*!< bit:     13  External Interrupt 13              */
+    uint32_t INT14:1;          /*!< bit:     14  External Interrupt 14              */
+    uint32_t INT15:1;          /*!< bit:     15  External Interrupt 15              */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_CTRL_OFFSET             0x038        /**< \brief (EIC_CTRL offset) Control Register */
+#define EIC_CTRL_RESETVALUE         _U(0x00000000); /**< \brief (EIC_CTRL reset_value) Control Register */
+
+#define EIC_CTRL_NMI_Pos            0            /**< \brief (EIC_CTRL) External Non Maskable CPU interrupt */
+#define EIC_CTRL_NMI                (_U(0x1) << EIC_CTRL_NMI_Pos)
+#define EIC_CTRL_INT1_Pos           1            /**< \brief (EIC_CTRL) External Interrupt 1 */
+#define EIC_CTRL_INT1               (_U(0x1) << EIC_CTRL_INT1_Pos)
+#define EIC_CTRL_INT2_Pos           2            /**< \brief (EIC_CTRL) External Interrupt 2 */
+#define EIC_CTRL_INT2               (_U(0x1) << EIC_CTRL_INT2_Pos)
+#define EIC_CTRL_INT3_Pos           3            /**< \brief (EIC_CTRL) External Interrupt 3 */
+#define EIC_CTRL_INT3               (_U(0x1) << EIC_CTRL_INT3_Pos)
+#define EIC_CTRL_INT4_Pos           4            /**< \brief (EIC_CTRL) External Interrupt 4 */
+#define EIC_CTRL_INT4               (_U(0x1) << EIC_CTRL_INT4_Pos)
+#define EIC_CTRL_INT5_Pos           5            /**< \brief (EIC_CTRL) External Interrupt 5 */
+#define EIC_CTRL_INT5               (_U(0x1) << EIC_CTRL_INT5_Pos)
+#define EIC_CTRL_INT6_Pos           6            /**< \brief (EIC_CTRL) External Interrupt 6 */
+#define EIC_CTRL_INT6               (_U(0x1) << EIC_CTRL_INT6_Pos)
+#define EIC_CTRL_INT7_Pos           7            /**< \brief (EIC_CTRL) External Interrupt 7 */
+#define EIC_CTRL_INT7               (_U(0x1) << EIC_CTRL_INT7_Pos)
+#define EIC_CTRL_INT8_Pos           8            /**< \brief (EIC_CTRL) External Interrupt 8 */
+#define EIC_CTRL_INT8               (_U(0x1) << EIC_CTRL_INT8_Pos)
+#define EIC_CTRL_INT9_Pos           9            /**< \brief (EIC_CTRL) External Interrupt 9 */
+#define EIC_CTRL_INT9               (_U(0x1) << EIC_CTRL_INT9_Pos)
+#define EIC_CTRL_INT10_Pos          10           /**< \brief (EIC_CTRL) External Interrupt 10 */
+#define EIC_CTRL_INT10              (_U(0x1) << EIC_CTRL_INT10_Pos)
+#define EIC_CTRL_INT11_Pos          11           /**< \brief (EIC_CTRL) External Interrupt 11 */
+#define EIC_CTRL_INT11              (_U(0x1) << EIC_CTRL_INT11_Pos)
+#define EIC_CTRL_INT12_Pos          12           /**< \brief (EIC_CTRL) External Interrupt 12 */
+#define EIC_CTRL_INT12              (_U(0x1) << EIC_CTRL_INT12_Pos)
+#define EIC_CTRL_INT13_Pos          13           /**< \brief (EIC_CTRL) External Interrupt 13 */
+#define EIC_CTRL_INT13              (_U(0x1) << EIC_CTRL_INT13_Pos)
+#define EIC_CTRL_INT14_Pos          14           /**< \brief (EIC_CTRL) External Interrupt 14 */
+#define EIC_CTRL_INT14              (_U(0x1) << EIC_CTRL_INT14_Pos)
+#define EIC_CTRL_INT15_Pos          15           /**< \brief (EIC_CTRL) External Interrupt 15 */
+#define EIC_CTRL_INT15              (_U(0x1) << EIC_CTRL_INT15_Pos)
+#define EIC_CTRL_MASK               _U(0x0000FFFF) /**< \brief (EIC_CTRL) MASK Register */
+
+/* -------- EIC_VERSION : (EIC Offset: 0x3FC) (R/  32) Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version bits                       */
+    uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_VERSION_OFFSET          0x3FC        /**< \brief (EIC_VERSION offset) Version Register */
+#define EIC_VERSION_RESETVALUE      _U(0x00000302); /**< \brief (EIC_VERSION reset_value) Version Register */
+
+#define EIC_VERSION_VERSION_Pos     0            /**< \brief (EIC_VERSION) Version bits */
+#define EIC_VERSION_VERSION_Msk     (_U(0xFFF) << EIC_VERSION_VERSION_Pos)
+#define EIC_VERSION_VERSION(value)  (EIC_VERSION_VERSION_Msk & ((value) << EIC_VERSION_VERSION_Pos))
+#define EIC_VERSION_MASK            _U(0x00000FFF) /**< \brief (EIC_VERSION) MASK Register */
+
+/** \brief EIC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __O  EIC_IER_Type              IER;         /**< \brief Offset: 0x000 ( /W 32) Interrupt Enable Register */
+  __O  EIC_IDR_Type              IDR;         /**< \brief Offset: 0x004 ( /W 32) Interrupt Disable Register */
+  __I  EIC_IMR_Type              IMR;         /**< \brief Offset: 0x008 (R/  32) Interrupt Mask Register */
+  __I  EIC_ISR_Type              ISR;         /**< \brief Offset: 0x00C (R/  32) Interrupt Status Register */
+  __O  EIC_ICR_Type              ICR;         /**< \brief Offset: 0x010 ( /W 32) Interrupt Clear Register */
+  __IO EIC_MODE_Type             MODE;        /**< \brief Offset: 0x014 (R/W 32) Mode Register */
+  __IO EIC_EDGE_Type             EDGE;        /**< \brief Offset: 0x018 (R/W 32) Edge Register */
+  __IO EIC_LEVEL_Type            LEVEL;       /**< \brief Offset: 0x01C (R/W 32) Level Register */
+  __IO EIC_FILTER_Type           FILTER;      /**< \brief Offset: 0x020 (R/W 32) Filter Register */
+       RoReg8                    Reserved1[0x4];
+  __IO EIC_ASYNC_Type            ASYNC;       /**< \brief Offset: 0x028 (R/W 32) Asynchronous Register */
+       RoReg8                    Reserved2[0x4];
+  __O  EIC_EN_Type               EN;          /**< \brief Offset: 0x030 ( /W 32) Enable Register */
+  __O  EIC_DIS_Type              DIS;         /**< \brief Offset: 0x034 ( /W 32) Disable Register */
+  __I  EIC_CTRL_Type             CTRL;        /**< \brief Offset: 0x038 (R/  32) Control Register */
+       RoReg8                    Reserved3[0x3C0];
+  __I  EIC_VERSION_Type          VERSION;     /**< \brief Offset: 0x3FC (R/  32) Version Register */
+ } bf;
+ struct {
+  WoReg   EIC_IER;            /**< \brief (EIC Offset: 0x000) Interrupt Enable Register */
+  WoReg   EIC_IDR;            /**< \brief (EIC Offset: 0x004) Interrupt Disable Register */
+  RoReg   EIC_IMR;            /**< \brief (EIC Offset: 0x008) Interrupt Mask Register */
+  RoReg   EIC_ISR;            /**< \brief (EIC Offset: 0x00C) Interrupt Status Register */
+  WoReg   EIC_ICR;            /**< \brief (EIC Offset: 0x010) Interrupt Clear Register */
+  RwReg   EIC_MODE;           /**< \brief (EIC Offset: 0x014) Mode Register */
+  RwReg   EIC_EDGE;           /**< \brief (EIC Offset: 0x018) Edge Register */
+  RwReg   EIC_LEVEL;          /**< \brief (EIC Offset: 0x01C) Level Register */
+  RwReg   EIC_FILTER;         /**< \brief (EIC Offset: 0x020) Filter Register */
+  RoReg8  Reserved4[0x4];
+  RwReg   EIC_ASYNC;          /**< \brief (EIC Offset: 0x028) Asynchronous Register */
+  RoReg8  Reserved5[0x4];
+  WoReg   EIC_EN;             /**< \brief (EIC Offset: 0x030) Enable Register */
+  WoReg   EIC_DIS;            /**< \brief (EIC Offset: 0x034) Disable Register */
+  RoReg   EIC_CTRL;           /**< \brief (EIC Offset: 0x038) Control Register */
+  RoReg8  Reserved6[0x3C0];
+  RoReg   EIC_VERSION;        /**< \brief (EIC Offset: 0x3FC) Version Register */
+ } reg;
+} Eic;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_EIC_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/flashcalw.h
+++ b/asf/sam/include/sam4l/component/flashcalw.h
@@ -511,25 +511,14 @@ typedef union {
 
 /** \brief FLASHCALW APB hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __IO FLASHCALW_FCR_Type        FCR;         /**< \brief Offset: 0x00 (R/W 32) Flash Controller Control Register */
-  __IO FLASHCALW_FCMD_Type       FCMD;        /**< \brief Offset: 0x04 (R/W 32) Flash Controller Command Register */
-  __IO FLASHCALW_FSR_Type        FSR;         /**< \brief Offset: 0x08 (R/W 32) Flash Controller Status Register */
-  __I  FLASHCALW_FPR_Type        FPR;         /**< \brief Offset: 0x0C (R/  32) Flash Controller Parameter Register */
-  __I  FLASHCALW_VERSION_Type    VERSION;     /**< \brief Offset: 0x10 (R/  32) Flash Controller Version Register */
-  __IO FLASHCALW_FGPFRHI_Type    FGPFRHI;     /**< \brief Offset: 0x14 (R/W 32) Flash Controller General Purpose Fuse Register High */
-  __IO FLASHCALW_FGPFRLO_Type    FGPFRLO;     /**< \brief Offset: 0x18 (R/W 32) Flash Controller General Purpose Fuse Register Low */
- } bf;
- struct {
-  RwReg   FLASHCALW_FCR;      /**< \brief (FLASHCALW Offset: 0x00) Flash Controller Control Register */
-  RwReg   FLASHCALW_FCMD;     /**< \brief (FLASHCALW Offset: 0x04) Flash Controller Command Register */
-  RwReg   FLASHCALW_FSR;      /**< \brief (FLASHCALW Offset: 0x08) Flash Controller Status Register */
-  RoReg   FLASHCALW_FPR;      /**< \brief (FLASHCALW Offset: 0x0C) Flash Controller Parameter Register */
-  RoReg   FLASHCALW_VERSION;  /**< \brief (FLASHCALW Offset: 0x10) Flash Controller Version Register */
-  RwReg   FLASHCALW_FGPFRHI;  /**< \brief (FLASHCALW Offset: 0x14) Flash Controller General Purpose Fuse Register High */
-  RwReg   FLASHCALW_FGPFRLO;  /**< \brief (FLASHCALW Offset: 0x18) Flash Controller General Purpose Fuse Register Low */
- } reg;
+typedef struct {
+  __IO uint32_t FCR;         /**< \brief Offset: 0x00 (R/W 32) Flash Controller Control Register */
+  __IO uint32_t FCMD;        /**< \brief Offset: 0x04 (R/W 32) Flash Controller Command Register */
+  __IO uint32_t FSR;         /**< \brief Offset: 0x08 (R/W 32) Flash Controller Status Register */
+  __I  uint32_t FPR;         /**< \brief Offset: 0x0C (R/  32) Flash Controller Parameter Register */
+  __I  uint32_t VERSION;     /**< \brief Offset: 0x10 (R/  32) Flash Controller Version Register */
+  __IO uint32_t FGPFRHI;     /**< \brief Offset: 0x14 (R/W 32) Flash Controller General Purpose Fuse Register High */
+  __IO uint32_t FGPFRLO;     /**< \brief Offset: 0x18 (R/W 32) Flash Controller General Purpose Fuse Register Low */
 } Flashcalw;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/flashcalw.h
+++ b/asf/sam/include/sam4l/component/flashcalw.h
@@ -1,0 +1,591 @@
+/**
+ * \file
+ *
+ * \brief Component description for FLASHCALW
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_FLASHCALW_COMPONENT_
+#define _SAM4L_FLASHCALW_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR FLASHCALW */
+/* ========================================================================== */
+/** \addtogroup SAM4L_FLASHCALW Flash Controller */
+/*@{*/
+
+#define FLASHCALW_I8322
+#define REV_FLASHCALW               0x110
+
+/* -------- FLASHCALW_FCR : (FLASHCALW Offset: 0x00) (R/W 32) Flash Controller Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t FRDY:1;           /*!< bit:      0  Flash Ready Interrupt Enable       */
+    uint32_t :1;               /*!< bit:      1  Reserved                           */
+    uint32_t LOCKE:1;          /*!< bit:      2  Lock Error Interrupt Enable        */
+    uint32_t PROGE:1;          /*!< bit:      3  Programming Error Interrupt Enable */
+    uint32_t :2;               /*!< bit:  4.. 5  Reserved                           */
+    uint32_t FWS:1;            /*!< bit:      6  Flash Wait State                   */
+    uint32_t WS1OPT:1;         /*!< bit:      7  Wait State 1 Optimization          */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} FLASHCALW_FCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FLASHCALW_FCR_OFFSET        0x00         /**< \brief (FLASHCALW_FCR offset) Flash Controller Control Register */
+#define FLASHCALW_FCR_RESETVALUE    _U(0x00000000); /**< \brief (FLASHCALW_FCR reset_value) Flash Controller Control Register */
+
+#define FLASHCALW_FCR_FRDY_Pos      0            /**< \brief (FLASHCALW_FCR) Flash Ready Interrupt Enable */
+#define FLASHCALW_FCR_FRDY          (_U(0x1) << FLASHCALW_FCR_FRDY_Pos)
+#define   FLASHCALW_FCR_FRDY_0_Val        _U(0x0)   /**< \brief (FLASHCALW_FCR) Flash Ready does not generate an interrupt */
+#define   FLASHCALW_FCR_FRDY_1_Val        _U(0x1)   /**< \brief (FLASHCALW_FCR) Flash Ready generates an interrupt */
+#define FLASHCALW_FCR_FRDY_0        (FLASHCALW_FCR_FRDY_0_Val      << FLASHCALW_FCR_FRDY_Pos)
+#define FLASHCALW_FCR_FRDY_1        (FLASHCALW_FCR_FRDY_1_Val      << FLASHCALW_FCR_FRDY_Pos)
+#define FLASHCALW_FCR_LOCKE_Pos     2            /**< \brief (FLASHCALW_FCR) Lock Error Interrupt Enable */
+#define FLASHCALW_FCR_LOCKE         (_U(0x1) << FLASHCALW_FCR_LOCKE_Pos)
+#define   FLASHCALW_FCR_LOCKE_0_Val       _U(0x0)   /**< \brief (FLASHCALW_FCR) Lock Error does not generate an interrupt */
+#define   FLASHCALW_FCR_LOCKE_1_Val       _U(0x1)   /**< \brief (FLASHCALW_FCR) Lock Error generates an interrupt */
+#define FLASHCALW_FCR_LOCKE_0       (FLASHCALW_FCR_LOCKE_0_Val     << FLASHCALW_FCR_LOCKE_Pos)
+#define FLASHCALW_FCR_LOCKE_1       (FLASHCALW_FCR_LOCKE_1_Val     << FLASHCALW_FCR_LOCKE_Pos)
+#define FLASHCALW_FCR_PROGE_Pos     3            /**< \brief (FLASHCALW_FCR) Programming Error Interrupt Enable */
+#define FLASHCALW_FCR_PROGE         (_U(0x1) << FLASHCALW_FCR_PROGE_Pos)
+#define   FLASHCALW_FCR_PROGE_0_Val       _U(0x0)   /**< \brief (FLASHCALW_FCR) Programming Error does not generate an interrupt */
+#define   FLASHCALW_FCR_PROGE_1_Val       _U(0x1)   /**< \brief (FLASHCALW_FCR) Programming Error generates an interrupt */
+#define FLASHCALW_FCR_PROGE_0       (FLASHCALW_FCR_PROGE_0_Val     << FLASHCALW_FCR_PROGE_Pos)
+#define FLASHCALW_FCR_PROGE_1       (FLASHCALW_FCR_PROGE_1_Val     << FLASHCALW_FCR_PROGE_Pos)
+#define FLASHCALW_FCR_FWS_Pos       6            /**< \brief (FLASHCALW_FCR) Flash Wait State */
+#define FLASHCALW_FCR_FWS           (_U(0x1) << FLASHCALW_FCR_FWS_Pos)
+#define   FLASHCALW_FCR_FWS_0_Val         _U(0x0)   /**< \brief (FLASHCALW_FCR) The flash is read with 0 wait states */
+#define   FLASHCALW_FCR_FWS_1_Val         _U(0x1)   /**< \brief (FLASHCALW_FCR) The flash is read with 1 wait states */
+#define FLASHCALW_FCR_FWS_0         (FLASHCALW_FCR_FWS_0_Val       << FLASHCALW_FCR_FWS_Pos)
+#define FLASHCALW_FCR_FWS_1         (FLASHCALW_FCR_FWS_1_Val       << FLASHCALW_FCR_FWS_Pos)
+#define FLASHCALW_FCR_WS1OPT_Pos    7            /**< \brief (FLASHCALW_FCR) Wait State 1 Optimization */
+#define FLASHCALW_FCR_WS1OPT        (_U(0x1) << FLASHCALW_FCR_WS1OPT_Pos)
+#define FLASHCALW_FCR_MASK          _U(0x000000CD) /**< \brief (FLASHCALW_FCR) MASK Register */
+
+/* -------- FLASHCALW_FCMD : (FLASHCALW Offset: 0x04) (R/W 32) Flash Controller Command Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CMD:6;            /*!< bit:  0.. 5  Command                            */
+    uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t PAGEN:16;         /*!< bit:  8..23  Page number                        */
+    uint32_t KEY:8;            /*!< bit: 24..31  Write protection key               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} FLASHCALW_FCMD_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FLASHCALW_FCMD_OFFSET       0x04         /**< \brief (FLASHCALW_FCMD offset) Flash Controller Command Register */
+#define FLASHCALW_FCMD_RESETVALUE   _U(0x00000000); /**< \brief (FLASHCALW_FCMD reset_value) Flash Controller Command Register */
+
+#define FLASHCALW_FCMD_CMD_Pos      0            /**< \brief (FLASHCALW_FCMD) Command */
+#define FLASHCALW_FCMD_CMD_Msk      (_U(0x3F) << FLASHCALW_FCMD_CMD_Pos)
+#define FLASHCALW_FCMD_CMD(value)   (FLASHCALW_FCMD_CMD_Msk & ((value) << FLASHCALW_FCMD_CMD_Pos))
+#define   FLASHCALW_FCMD_CMD_NOP_Val      _U(0x0)   /**< \brief (FLASHCALW_FCMD) No Operation */
+#define   FLASHCALW_FCMD_CMD_WP_Val       _U(0x1)   /**< \brief (FLASHCALW_FCMD) Write Page */
+#define   FLASHCALW_FCMD_CMD_EP_Val       _U(0x2)   /**< \brief (FLASHCALW_FCMD) Erase Page */
+#define   FLASHCALW_FCMD_CMD_CPB_Val      _U(0x3)   /**< \brief (FLASHCALW_FCMD) Clear Page Buffer */
+#define   FLASHCALW_FCMD_CMD_LP_Val       _U(0x4)   /**< \brief (FLASHCALW_FCMD) Lock Region containing page */
+#define   FLASHCALW_FCMD_CMD_UP_Val       _U(0x5)   /**< \brief (FLASHCALW_FCMD) Unlock Region containing page */
+#define   FLASHCALW_FCMD_CMD_EA_Val       _U(0x6)   /**< \brief (FLASHCALW_FCMD) Erase All, including secuity and fuse bits */
+#define   FLASHCALW_FCMD_CMD_WGPB_Val     _U(0x7)   /**< \brief (FLASHCALW_FCMD) Write General-Purpose fuse Bit */
+#define   FLASHCALW_FCMD_CMD_EGPB_Val     _U(0x8)   /**< \brief (FLASHCALW_FCMD) Erase General-Purpose fuse Bit */
+#define   FLASHCALW_FCMD_CMD_SSB_Val      _U(0x9)   /**< \brief (FLASHCALW_FCMD) Set Security Bit */
+#define   FLASHCALW_FCMD_CMD_PGPFB_Val    _U(0xA)   /**< \brief (FLASHCALW_FCMD) Program GPFuse Byte */
+#define   FLASHCALW_FCMD_CMD_EAGPF_Val    _U(0xB)   /**< \brief (FLASHCALW_FCMD) Erase All GP Fuses */
+#define   FLASHCALW_FCMD_CMD_QPR_Val      _U(0xC)   /**< \brief (FLASHCALW_FCMD) Quick Page Read */
+#define   FLASHCALW_FCMD_CMD_WUP_Val      _U(0xD)   /**< \brief (FLASHCALW_FCMD) Write User Page */
+#define   FLASHCALW_FCMD_CMD_EUP_Val      _U(0xE)   /**< \brief (FLASHCALW_FCMD) Erase User Page */
+#define   FLASHCALW_FCMD_CMD_QPRUP_Val    _U(0xF)   /**< \brief (FLASHCALW_FCMD) Quick Page Read User Page */
+#define   FLASHCALW_FCMD_CMD_HSEN_Val     _U(0x10)   /**< \brief (FLASHCALW_FCMD) High Speed Mode Enable */
+#define   FLASHCALW_FCMD_CMD_HSDIS_Val    _U(0x11)   /**< \brief (FLASHCALW_FCMD) High Speed Mode Disable */
+#define FLASHCALW_FCMD_CMD_NOP      (FLASHCALW_FCMD_CMD_NOP_Val    << FLASHCALW_FCMD_CMD_Pos)
+#define FLASHCALW_FCMD_CMD_WP       (FLASHCALW_FCMD_CMD_WP_Val     << FLASHCALW_FCMD_CMD_Pos)
+#define FLASHCALW_FCMD_CMD_EP       (FLASHCALW_FCMD_CMD_EP_Val     << FLASHCALW_FCMD_CMD_Pos)
+#define FLASHCALW_FCMD_CMD_CPB      (FLASHCALW_FCMD_CMD_CPB_Val    << FLASHCALW_FCMD_CMD_Pos)
+#define FLASHCALW_FCMD_CMD_LP       (FLASHCALW_FCMD_CMD_LP_Val     << FLASHCALW_FCMD_CMD_Pos)
+#define FLASHCALW_FCMD_CMD_UP       (FLASHCALW_FCMD_CMD_UP_Val     << FLASHCALW_FCMD_CMD_Pos)
+#define FLASHCALW_FCMD_CMD_EA       (FLASHCALW_FCMD_CMD_EA_Val     << FLASHCALW_FCMD_CMD_Pos)
+#define FLASHCALW_FCMD_CMD_WGPB     (FLASHCALW_FCMD_CMD_WGPB_Val   << FLASHCALW_FCMD_CMD_Pos)
+#define FLASHCALW_FCMD_CMD_EGPB     (FLASHCALW_FCMD_CMD_EGPB_Val   << FLASHCALW_FCMD_CMD_Pos)
+#define FLASHCALW_FCMD_CMD_SSB      (FLASHCALW_FCMD_CMD_SSB_Val    << FLASHCALW_FCMD_CMD_Pos)
+#define FLASHCALW_FCMD_CMD_PGPFB    (FLASHCALW_FCMD_CMD_PGPFB_Val  << FLASHCALW_FCMD_CMD_Pos)
+#define FLASHCALW_FCMD_CMD_EAGPF    (FLASHCALW_FCMD_CMD_EAGPF_Val  << FLASHCALW_FCMD_CMD_Pos)
+#define FLASHCALW_FCMD_CMD_QPR      (FLASHCALW_FCMD_CMD_QPR_Val    << FLASHCALW_FCMD_CMD_Pos)
+#define FLASHCALW_FCMD_CMD_WUP      (FLASHCALW_FCMD_CMD_WUP_Val    << FLASHCALW_FCMD_CMD_Pos)
+#define FLASHCALW_FCMD_CMD_EUP      (FLASHCALW_FCMD_CMD_EUP_Val    << FLASHCALW_FCMD_CMD_Pos)
+#define FLASHCALW_FCMD_CMD_QPRUP    (FLASHCALW_FCMD_CMD_QPRUP_Val  << FLASHCALW_FCMD_CMD_Pos)
+#define FLASHCALW_FCMD_CMD_HSEN     (FLASHCALW_FCMD_CMD_HSEN_Val   << FLASHCALW_FCMD_CMD_Pos)
+#define FLASHCALW_FCMD_CMD_HSDIS    (FLASHCALW_FCMD_CMD_HSDIS_Val  << FLASHCALW_FCMD_CMD_Pos)
+#define FLASHCALW_FCMD_PAGEN_Pos    8            /**< \brief (FLASHCALW_FCMD) Page number */
+#define FLASHCALW_FCMD_PAGEN_Msk    (_U(0xFFFF) << FLASHCALW_FCMD_PAGEN_Pos)
+#define FLASHCALW_FCMD_PAGEN(value) (FLASHCALW_FCMD_PAGEN_Msk & ((value) << FLASHCALW_FCMD_PAGEN_Pos))
+#define FLASHCALW_FCMD_KEY_Pos      24           /**< \brief (FLASHCALW_FCMD) Write protection key */
+#define FLASHCALW_FCMD_KEY_Msk      (_U(0xFF) << FLASHCALW_FCMD_KEY_Pos)
+#define FLASHCALW_FCMD_KEY(value)   (FLASHCALW_FCMD_KEY_Msk & ((value) << FLASHCALW_FCMD_KEY_Pos))
+#define   FLASHCALW_FCMD_KEY_KEY_Val      _U(0xA5)   /**< \brief (FLASHCALW_FCMD)  */
+#define FLASHCALW_FCMD_KEY_KEY      (FLASHCALW_FCMD_KEY_KEY_Val    << FLASHCALW_FCMD_KEY_Pos)
+#define FLASHCALW_FCMD_MASK         _U(0xFFFFFF3F) /**< \brief (FLASHCALW_FCMD) MASK Register */
+
+/* -------- FLASHCALW_FSR : (FLASHCALW Offset: 0x08) (R/W 32) Flash Controller Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t FRDY:1;           /*!< bit:      0  Flash Ready Status                 */
+    uint32_t :1;               /*!< bit:      1  Reserved                           */
+    uint32_t LOCKE:1;          /*!< bit:      2  Lock Error Status                  */
+    uint32_t PROGE:1;          /*!< bit:      3  Programming Error Status           */
+    uint32_t SECURITY:1;       /*!< bit:      4  Security Bit Status                */
+    uint32_t QPRR:1;           /*!< bit:      5  Quick Page Read Result             */
+    uint32_t HSMODE:1;         /*!< bit:      6  High Speed Mode                    */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t ECCERR:2;         /*!< bit:  8.. 9  ECC Error Status                   */
+    uint32_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint32_t LOCK0:1;          /*!< bit:     16  Lock Region 0 Lock Status          */
+    uint32_t LOCK1:1;          /*!< bit:     17  Lock Region 1 Lock Status          */
+    uint32_t LOCK2:1;          /*!< bit:     18  Lock Region 2 Lock Status          */
+    uint32_t LOCK3:1;          /*!< bit:     19  Lock Region 3 Lock Status          */
+    uint32_t LOCK4:1;          /*!< bit:     20  Lock Region 4 Lock Status          */
+    uint32_t LOCK5:1;          /*!< bit:     21  Lock Region 5 Lock Status          */
+    uint32_t LOCK6:1;          /*!< bit:     22  Lock Region 6 Lock Status          */
+    uint32_t LOCK7:1;          /*!< bit:     23  Lock Region 7 Lock Status          */
+    uint32_t LOCK8:1;          /*!< bit:     24  Lock Region 8 Lock Status          */
+    uint32_t LOCK9:1;          /*!< bit:     25  Lock Region 9 Lock Status          */
+    uint32_t LOCK10:1;         /*!< bit:     26  Lock Region 10 Lock Status         */
+    uint32_t LOCK11:1;         /*!< bit:     27  Lock Region 11 Lock Status         */
+    uint32_t LOCK12:1;         /*!< bit:     28  Lock Region 12 Lock Status         */
+    uint32_t LOCK13:1;         /*!< bit:     29  Lock Region 13 Lock Status         */
+    uint32_t LOCK14:1;         /*!< bit:     30  Lock Region 14 Lock Status         */
+    uint32_t LOCK15:1;         /*!< bit:     31  Lock Region 15 Lock Status         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} FLASHCALW_FSR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FLASHCALW_FSR_OFFSET        0x08         /**< \brief (FLASHCALW_FSR offset) Flash Controller Status Register */
+#define FLASHCALW_FSR_RESETVALUE    _U(0x00000000); /**< \brief (FLASHCALW_FSR reset_value) Flash Controller Status Register */
+
+#define FLASHCALW_FSR_FRDY_Pos      0            /**< \brief (FLASHCALW_FSR) Flash Ready Status */
+#define FLASHCALW_FSR_FRDY          (_U(0x1) << FLASHCALW_FSR_FRDY_Pos)
+#define FLASHCALW_FSR_LOCKE_Pos     2            /**< \brief (FLASHCALW_FSR) Lock Error Status */
+#define FLASHCALW_FSR_LOCKE         (_U(0x1) << FLASHCALW_FSR_LOCKE_Pos)
+#define FLASHCALW_FSR_PROGE_Pos     3            /**< \brief (FLASHCALW_FSR) Programming Error Status */
+#define FLASHCALW_FSR_PROGE         (_U(0x1) << FLASHCALW_FSR_PROGE_Pos)
+#define FLASHCALW_FSR_SECURITY_Pos  4            /**< \brief (FLASHCALW_FSR) Security Bit Status */
+#define FLASHCALW_FSR_SECURITY      (_U(0x1) << FLASHCALW_FSR_SECURITY_Pos)
+#define FLASHCALW_FSR_QPRR_Pos      5            /**< \brief (FLASHCALW_FSR) Quick Page Read Result */
+#define FLASHCALW_FSR_QPRR          (_U(0x1) << FLASHCALW_FSR_QPRR_Pos)
+#define FLASHCALW_FSR_HSMODE_Pos    6            /**< \brief (FLASHCALW_FSR) High Speed Mode */
+#define FLASHCALW_FSR_HSMODE        (_U(0x1) << FLASHCALW_FSR_HSMODE_Pos)
+#define FLASHCALW_FSR_ECCERR_Pos    8            /**< \brief (FLASHCALW_FSR) ECC Error Status */
+#define FLASHCALW_FSR_ECCERR_Msk    (_U(0x3) << FLASHCALW_FSR_ECCERR_Pos)
+#define FLASHCALW_FSR_ECCERR(value) (FLASHCALW_FSR_ECCERR_Msk & ((value) << FLASHCALW_FSR_ECCERR_Pos))
+#define   FLASHCALW_FSR_ECCERR_NOERROR_Val _U(0x0)   /**< \brief (FLASHCALW_FSR) no error */
+#define   FLASHCALW_FSR_ECCERR_ONEECCERR_Val _U(0x1)   /**< \brief (FLASHCALW_FSR) one ECC error detected */
+#define   FLASHCALW_FSR_ECCERR_TWOECCERR_Val _U(0x2)   /**< \brief (FLASHCALW_FSR) two ECC errors detected */
+#define FLASHCALW_FSR_ECCERR_NOERROR (FLASHCALW_FSR_ECCERR_NOERROR_Val << FLASHCALW_FSR_ECCERR_Pos)
+#define FLASHCALW_FSR_ECCERR_ONEECCERR (FLASHCALW_FSR_ECCERR_ONEECCERR_Val << FLASHCALW_FSR_ECCERR_Pos)
+#define FLASHCALW_FSR_ECCERR_TWOECCERR (FLASHCALW_FSR_ECCERR_TWOECCERR_Val << FLASHCALW_FSR_ECCERR_Pos)
+#define FLASHCALW_FSR_LOCK0_Pos     16           /**< \brief (FLASHCALW_FSR) Lock Region 0 Lock Status */
+#define FLASHCALW_FSR_LOCK0         (_U(0x1) << FLASHCALW_FSR_LOCK0_Pos)
+#define FLASHCALW_FSR_LOCK1_Pos     17           /**< \brief (FLASHCALW_FSR) Lock Region 1 Lock Status */
+#define FLASHCALW_FSR_LOCK1         (_U(0x1) << FLASHCALW_FSR_LOCK1_Pos)
+#define FLASHCALW_FSR_LOCK2_Pos     18           /**< \brief (FLASHCALW_FSR) Lock Region 2 Lock Status */
+#define FLASHCALW_FSR_LOCK2         (_U(0x1) << FLASHCALW_FSR_LOCK2_Pos)
+#define FLASHCALW_FSR_LOCK3_Pos     19           /**< \brief (FLASHCALW_FSR) Lock Region 3 Lock Status */
+#define FLASHCALW_FSR_LOCK3         (_U(0x1) << FLASHCALW_FSR_LOCK3_Pos)
+#define FLASHCALW_FSR_LOCK4_Pos     20           /**< \brief (FLASHCALW_FSR) Lock Region 4 Lock Status */
+#define FLASHCALW_FSR_LOCK4         (_U(0x1) << FLASHCALW_FSR_LOCK4_Pos)
+#define FLASHCALW_FSR_LOCK5_Pos     21           /**< \brief (FLASHCALW_FSR) Lock Region 5 Lock Status */
+#define FLASHCALW_FSR_LOCK5         (_U(0x1) << FLASHCALW_FSR_LOCK5_Pos)
+#define FLASHCALW_FSR_LOCK6_Pos     22           /**< \brief (FLASHCALW_FSR) Lock Region 6 Lock Status */
+#define FLASHCALW_FSR_LOCK6         (_U(0x1) << FLASHCALW_FSR_LOCK6_Pos)
+#define FLASHCALW_FSR_LOCK7_Pos     23           /**< \brief (FLASHCALW_FSR) Lock Region 7 Lock Status */
+#define FLASHCALW_FSR_LOCK7         (_U(0x1) << FLASHCALW_FSR_LOCK7_Pos)
+#define FLASHCALW_FSR_LOCK8_Pos     24           /**< \brief (FLASHCALW_FSR) Lock Region 8 Lock Status */
+#define FLASHCALW_FSR_LOCK8         (_U(0x1) << FLASHCALW_FSR_LOCK8_Pos)
+#define FLASHCALW_FSR_LOCK9_Pos     25           /**< \brief (FLASHCALW_FSR) Lock Region 9 Lock Status */
+#define FLASHCALW_FSR_LOCK9         (_U(0x1) << FLASHCALW_FSR_LOCK9_Pos)
+#define FLASHCALW_FSR_LOCK10_Pos    26           /**< \brief (FLASHCALW_FSR) Lock Region 10 Lock Status */
+#define FLASHCALW_FSR_LOCK10        (_U(0x1) << FLASHCALW_FSR_LOCK10_Pos)
+#define FLASHCALW_FSR_LOCK11_Pos    27           /**< \brief (FLASHCALW_FSR) Lock Region 11 Lock Status */
+#define FLASHCALW_FSR_LOCK11        (_U(0x1) << FLASHCALW_FSR_LOCK11_Pos)
+#define FLASHCALW_FSR_LOCK12_Pos    28           /**< \brief (FLASHCALW_FSR) Lock Region 12 Lock Status */
+#define FLASHCALW_FSR_LOCK12        (_U(0x1) << FLASHCALW_FSR_LOCK12_Pos)
+#define FLASHCALW_FSR_LOCK13_Pos    29           /**< \brief (FLASHCALW_FSR) Lock Region 13 Lock Status */
+#define FLASHCALW_FSR_LOCK13        (_U(0x1) << FLASHCALW_FSR_LOCK13_Pos)
+#define FLASHCALW_FSR_LOCK14_Pos    30           /**< \brief (FLASHCALW_FSR) Lock Region 14 Lock Status */
+#define FLASHCALW_FSR_LOCK14        (_U(0x1) << FLASHCALW_FSR_LOCK14_Pos)
+#define FLASHCALW_FSR_LOCK15_Pos    31           /**< \brief (FLASHCALW_FSR) Lock Region 15 Lock Status */
+#define FLASHCALW_FSR_LOCK15        (_U(0x1) << FLASHCALW_FSR_LOCK15_Pos)
+#define FLASHCALW_FSR_MASK          _U(0xFFFF037D) /**< \brief (FLASHCALW_FSR) MASK Register */
+
+/* -------- FLASHCALW_FPR : (FLASHCALW Offset: 0x0C) (R/  32) Flash Controller Parameter Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t FSZ:4;            /*!< bit:  0.. 3  Flash Size                         */
+    uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint32_t PSZ:3;            /*!< bit:  8..10  Page Size                          */
+    uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} FLASHCALW_FPR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FLASHCALW_FPR_OFFSET        0x0C         /**< \brief (FLASHCALW_FPR offset) Flash Controller Parameter Register */
+
+#define FLASHCALW_FPR_FSZ_Pos       0            /**< \brief (FLASHCALW_FPR) Flash Size */
+#define FLASHCALW_FPR_FSZ_Msk       (_U(0xF) << FLASHCALW_FPR_FSZ_Pos)
+#define FLASHCALW_FPR_FSZ(value)    (FLASHCALW_FPR_FSZ_Msk & ((value) << FLASHCALW_FPR_FSZ_Pos))
+#define FLASHCALW_FPR_PSZ_Pos       8            /**< \brief (FLASHCALW_FPR) Page Size */
+#define FLASHCALW_FPR_PSZ_Msk       (_U(0x7) << FLASHCALW_FPR_PSZ_Pos)
+#define FLASHCALW_FPR_PSZ(value)    (FLASHCALW_FPR_PSZ_Msk & ((value) << FLASHCALW_FPR_PSZ_Pos))
+#define FLASHCALW_FPR_MASK          _U(0x0000070F) /**< \brief (FLASHCALW_FPR) MASK Register */
+
+/* -------- FLASHCALW_VERSION : (FLASHCALW Offset: 0x10) (R/  32) Flash Controller Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version Number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant Number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} FLASHCALW_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FLASHCALW_VERSION_OFFSET    0x10         /**< \brief (FLASHCALW_VERSION offset) Flash Controller Version Register */
+#define FLASHCALW_VERSION_RESETVALUE _U(0x00000110); /**< \brief (FLASHCALW_VERSION reset_value) Flash Controller Version Register */
+
+#define FLASHCALW_VERSION_VERSION_Pos 0            /**< \brief (FLASHCALW_VERSION) Version Number */
+#define FLASHCALW_VERSION_VERSION_Msk (_U(0xFFF) << FLASHCALW_VERSION_VERSION_Pos)
+#define FLASHCALW_VERSION_VERSION(value) (FLASHCALW_VERSION_VERSION_Msk & ((value) << FLASHCALW_VERSION_VERSION_Pos))
+#define FLASHCALW_VERSION_VARIANT_Pos 16           /**< \brief (FLASHCALW_VERSION) Variant Number */
+#define FLASHCALW_VERSION_VARIANT_Msk (_U(0xF) << FLASHCALW_VERSION_VARIANT_Pos)
+#define FLASHCALW_VERSION_VARIANT(value) (FLASHCALW_VERSION_VARIANT_Msk & ((value) << FLASHCALW_VERSION_VARIANT_Pos))
+#define FLASHCALW_VERSION_MASK      _U(0x000F0FFF) /**< \brief (FLASHCALW_VERSION) MASK Register */
+
+/* -------- FLASHCALW_FGPFRHI : (FLASHCALW Offset: 0x14) (R/W 32) Flash Controller General Purpose Fuse Register High -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t GPF32:1;          /*!< bit:      0  General Purpose Fuse 32            */
+    uint32_t GPF33:1;          /*!< bit:      1  General Purpose Fuse 33            */
+    uint32_t GPF34:1;          /*!< bit:      2  General Purpose Fuse 34            */
+    uint32_t GPF35:1;          /*!< bit:      3  General Purpose Fuse 35            */
+    uint32_t GPF36:1;          /*!< bit:      4  General Purpose Fuse 36            */
+    uint32_t GPF37:1;          /*!< bit:      5  General Purpose Fuse 37            */
+    uint32_t GPF38:1;          /*!< bit:      6  General Purpose Fuse 38            */
+    uint32_t GPF39:1;          /*!< bit:      7  General Purpose Fuse 39            */
+    uint32_t GPF40:1;          /*!< bit:      8  General Purpose Fuse 40            */
+    uint32_t GPF41:1;          /*!< bit:      9  General Purpose Fuse 41            */
+    uint32_t GPF42:1;          /*!< bit:     10  General Purpose Fuse 42            */
+    uint32_t GPF43:1;          /*!< bit:     11  General Purpose Fuse 43            */
+    uint32_t GPF44:1;          /*!< bit:     12  General Purpose Fuse 44            */
+    uint32_t GPF45:1;          /*!< bit:     13  General Purpose Fuse 45            */
+    uint32_t GPF46:1;          /*!< bit:     14  General Purpose Fuse 46            */
+    uint32_t GPF47:1;          /*!< bit:     15  General Purpose Fuse 47            */
+    uint32_t GPF48:1;          /*!< bit:     16  General Purpose Fuse 48            */
+    uint32_t GPF49:1;          /*!< bit:     17  General Purpose Fuse 49            */
+    uint32_t GPF50:1;          /*!< bit:     18  General Purpose Fuse 50            */
+    uint32_t GPF51:1;          /*!< bit:     19  General Purpose Fuse 51            */
+    uint32_t GPF52:1;          /*!< bit:     20  General Purpose Fuse 52            */
+    uint32_t GPF53:1;          /*!< bit:     21  General Purpose Fuse 53            */
+    uint32_t GPF54:1;          /*!< bit:     22  General Purpose Fuse 54            */
+    uint32_t GPF55:1;          /*!< bit:     23  General Purpose Fuse 55            */
+    uint32_t GPF56:1;          /*!< bit:     24  General Purpose Fuse 56            */
+    uint32_t GPF57:1;          /*!< bit:     25  General Purpose Fuse 57            */
+    uint32_t GPF58:1;          /*!< bit:     26  General Purpose Fuse 58            */
+    uint32_t GPF59:1;          /*!< bit:     27  General Purpose Fuse 59            */
+    uint32_t GPF60:1;          /*!< bit:     28  General Purpose Fuse 60            */
+    uint32_t GPF61:1;          /*!< bit:     29  General Purpose Fuse 61            */
+    uint32_t GPF62:1;          /*!< bit:     30  General Purpose Fuse 62            */
+    uint32_t GPF63:1;          /*!< bit:     31  General Purpose Fuse 63            */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} FLASHCALW_FGPFRHI_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FLASHCALW_FGPFRHI_OFFSET    0x14         /**< \brief (FLASHCALW_FGPFRHI offset) Flash Controller General Purpose Fuse Register High */
+
+#define FLASHCALW_FGPFRHI_GPF32_Pos 0            /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 32 */
+#define FLASHCALW_FGPFRHI_GPF32     (_U(0x1) << FLASHCALW_FGPFRHI_GPF32_Pos)
+#define FLASHCALW_FGPFRHI_GPF33_Pos 1            /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 33 */
+#define FLASHCALW_FGPFRHI_GPF33     (_U(0x1) << FLASHCALW_FGPFRHI_GPF33_Pos)
+#define FLASHCALW_FGPFRHI_GPF34_Pos 2            /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 34 */
+#define FLASHCALW_FGPFRHI_GPF34     (_U(0x1) << FLASHCALW_FGPFRHI_GPF34_Pos)
+#define FLASHCALW_FGPFRHI_GPF35_Pos 3            /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 35 */
+#define FLASHCALW_FGPFRHI_GPF35     (_U(0x1) << FLASHCALW_FGPFRHI_GPF35_Pos)
+#define FLASHCALW_FGPFRHI_GPF36_Pos 4            /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 36 */
+#define FLASHCALW_FGPFRHI_GPF36     (_U(0x1) << FLASHCALW_FGPFRHI_GPF36_Pos)
+#define FLASHCALW_FGPFRHI_GPF37_Pos 5            /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 37 */
+#define FLASHCALW_FGPFRHI_GPF37     (_U(0x1) << FLASHCALW_FGPFRHI_GPF37_Pos)
+#define FLASHCALW_FGPFRHI_GPF38_Pos 6            /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 38 */
+#define FLASHCALW_FGPFRHI_GPF38     (_U(0x1) << FLASHCALW_FGPFRHI_GPF38_Pos)
+#define FLASHCALW_FGPFRHI_GPF39_Pos 7            /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 39 */
+#define FLASHCALW_FGPFRHI_GPF39     (_U(0x1) << FLASHCALW_FGPFRHI_GPF39_Pos)
+#define FLASHCALW_FGPFRHI_GPF40_Pos 8            /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 40 */
+#define FLASHCALW_FGPFRHI_GPF40     (_U(0x1) << FLASHCALW_FGPFRHI_GPF40_Pos)
+#define FLASHCALW_FGPFRHI_GPF41_Pos 9            /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 41 */
+#define FLASHCALW_FGPFRHI_GPF41     (_U(0x1) << FLASHCALW_FGPFRHI_GPF41_Pos)
+#define FLASHCALW_FGPFRHI_GPF42_Pos 10           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 42 */
+#define FLASHCALW_FGPFRHI_GPF42     (_U(0x1) << FLASHCALW_FGPFRHI_GPF42_Pos)
+#define FLASHCALW_FGPFRHI_GPF43_Pos 11           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 43 */
+#define FLASHCALW_FGPFRHI_GPF43     (_U(0x1) << FLASHCALW_FGPFRHI_GPF43_Pos)
+#define FLASHCALW_FGPFRHI_GPF44_Pos 12           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 44 */
+#define FLASHCALW_FGPFRHI_GPF44     (_U(0x1) << FLASHCALW_FGPFRHI_GPF44_Pos)
+#define FLASHCALW_FGPFRHI_GPF45_Pos 13           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 45 */
+#define FLASHCALW_FGPFRHI_GPF45     (_U(0x1) << FLASHCALW_FGPFRHI_GPF45_Pos)
+#define FLASHCALW_FGPFRHI_GPF46_Pos 14           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 46 */
+#define FLASHCALW_FGPFRHI_GPF46     (_U(0x1) << FLASHCALW_FGPFRHI_GPF46_Pos)
+#define FLASHCALW_FGPFRHI_GPF47_Pos 15           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 47 */
+#define FLASHCALW_FGPFRHI_GPF47     (_U(0x1) << FLASHCALW_FGPFRHI_GPF47_Pos)
+#define FLASHCALW_FGPFRHI_GPF48_Pos 16           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 48 */
+#define FLASHCALW_FGPFRHI_GPF48     (_U(0x1) << FLASHCALW_FGPFRHI_GPF48_Pos)
+#define FLASHCALW_FGPFRHI_GPF49_Pos 17           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 49 */
+#define FLASHCALW_FGPFRHI_GPF49     (_U(0x1) << FLASHCALW_FGPFRHI_GPF49_Pos)
+#define FLASHCALW_FGPFRHI_GPF50_Pos 18           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 50 */
+#define FLASHCALW_FGPFRHI_GPF50     (_U(0x1) << FLASHCALW_FGPFRHI_GPF50_Pos)
+#define FLASHCALW_FGPFRHI_GPF51_Pos 19           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 51 */
+#define FLASHCALW_FGPFRHI_GPF51     (_U(0x1) << FLASHCALW_FGPFRHI_GPF51_Pos)
+#define FLASHCALW_FGPFRHI_GPF52_Pos 20           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 52 */
+#define FLASHCALW_FGPFRHI_GPF52     (_U(0x1) << FLASHCALW_FGPFRHI_GPF52_Pos)
+#define FLASHCALW_FGPFRHI_GPF53_Pos 21           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 53 */
+#define FLASHCALW_FGPFRHI_GPF53     (_U(0x1) << FLASHCALW_FGPFRHI_GPF53_Pos)
+#define FLASHCALW_FGPFRHI_GPF54_Pos 22           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 54 */
+#define FLASHCALW_FGPFRHI_GPF54     (_U(0x1) << FLASHCALW_FGPFRHI_GPF54_Pos)
+#define FLASHCALW_FGPFRHI_GPF55_Pos 23           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 55 */
+#define FLASHCALW_FGPFRHI_GPF55     (_U(0x1) << FLASHCALW_FGPFRHI_GPF55_Pos)
+#define FLASHCALW_FGPFRHI_GPF56_Pos 24           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 56 */
+#define FLASHCALW_FGPFRHI_GPF56     (_U(0x1) << FLASHCALW_FGPFRHI_GPF56_Pos)
+#define FLASHCALW_FGPFRHI_GPF57_Pos 25           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 57 */
+#define FLASHCALW_FGPFRHI_GPF57     (_U(0x1) << FLASHCALW_FGPFRHI_GPF57_Pos)
+#define FLASHCALW_FGPFRHI_GPF58_Pos 26           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 58 */
+#define FLASHCALW_FGPFRHI_GPF58     (_U(0x1) << FLASHCALW_FGPFRHI_GPF58_Pos)
+#define FLASHCALW_FGPFRHI_GPF59_Pos 27           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 59 */
+#define FLASHCALW_FGPFRHI_GPF59     (_U(0x1) << FLASHCALW_FGPFRHI_GPF59_Pos)
+#define FLASHCALW_FGPFRHI_GPF60_Pos 28           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 60 */
+#define FLASHCALW_FGPFRHI_GPF60     (_U(0x1) << FLASHCALW_FGPFRHI_GPF60_Pos)
+#define FLASHCALW_FGPFRHI_GPF61_Pos 29           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 61 */
+#define FLASHCALW_FGPFRHI_GPF61     (_U(0x1) << FLASHCALW_FGPFRHI_GPF61_Pos)
+#define FLASHCALW_FGPFRHI_GPF62_Pos 30           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 62 */
+#define FLASHCALW_FGPFRHI_GPF62     (_U(0x1) << FLASHCALW_FGPFRHI_GPF62_Pos)
+#define FLASHCALW_FGPFRHI_GPF63_Pos 31           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 63 */
+#define FLASHCALW_FGPFRHI_GPF63     (_U(0x1) << FLASHCALW_FGPFRHI_GPF63_Pos)
+#define FLASHCALW_FGPFRHI_MASK      _U(0xFFFFFFFF) /**< \brief (FLASHCALW_FGPFRHI) MASK Register */
+
+/* -------- FLASHCALW_FGPFRLO : (FLASHCALW Offset: 0x18) (R/W 32) Flash Controller General Purpose Fuse Register Low -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t LOCK0:1;          /*!< bit:      0  Lock Bit 0                         */
+    uint32_t LOCK1:1;          /*!< bit:      1  Lock Bit 1                         */
+    uint32_t LOCK2:1;          /*!< bit:      2  Lock Bit 2                         */
+    uint32_t LOCK3:1;          /*!< bit:      3  Lock Bit 3                         */
+    uint32_t LOCK4:1;          /*!< bit:      4  Lock Bit 4                         */
+    uint32_t LOCK5:1;          /*!< bit:      5  Lock Bit 5                         */
+    uint32_t LOCK6:1;          /*!< bit:      6  Lock Bit 6                         */
+    uint32_t LOCK7:1;          /*!< bit:      7  Lock Bit 7                         */
+    uint32_t LOCK8:1;          /*!< bit:      8  Lock Bit 8                         */
+    uint32_t LOCK9:1;          /*!< bit:      9  Lock Bit 9                         */
+    uint32_t LOCK10:1;         /*!< bit:     10  Lock Bit 10                        */
+    uint32_t LOCK11:1;         /*!< bit:     11  Lock Bit 11                        */
+    uint32_t LOCK12:1;         /*!< bit:     12  Lock Bit 12                        */
+    uint32_t LOCK13:1;         /*!< bit:     13  Lock Bit 13                        */
+    uint32_t LOCK14:1;         /*!< bit:     14  Lock Bit 14                        */
+    uint32_t LOCK15:1;         /*!< bit:     15  Lock Bit 15                        */
+    uint32_t GPF16:1;          /*!< bit:     16  General Purpose Fuse 16            */
+    uint32_t GPF17:1;          /*!< bit:     17  General Purpose Fuse 17            */
+    uint32_t GPF18:1;          /*!< bit:     18  General Purpose Fuse 18            */
+    uint32_t GPF19:1;          /*!< bit:     19  General Purpose Fuse 19            */
+    uint32_t GPF20:1;          /*!< bit:     20  General Purpose Fuse 20            */
+    uint32_t GPF21:1;          /*!< bit:     21  General Purpose Fuse 21            */
+    uint32_t GPF22:1;          /*!< bit:     22  General Purpose Fuse 22            */
+    uint32_t GPF23:1;          /*!< bit:     23  General Purpose Fuse 23            */
+    uint32_t GPF24:1;          /*!< bit:     24  General Purpose Fuse 24            */
+    uint32_t GPF25:1;          /*!< bit:     25  General Purpose Fuse 25            */
+    uint32_t GPF26:1;          /*!< bit:     26  General Purpose Fuse 26            */
+    uint32_t GPF27:1;          /*!< bit:     27  General Purpose Fuse 27            */
+    uint32_t GPF28:1;          /*!< bit:     28  General Purpose Fuse 28            */
+    uint32_t GPF29:1;          /*!< bit:     29  General Purpose Fuse 29            */
+    uint32_t GPF30:1;          /*!< bit:     30  General Purpose Fuse 30            */
+    uint32_t GPF31:1;          /*!< bit:     31  General Purpose Fuse 31            */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} FLASHCALW_FGPFRLO_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FLASHCALW_FGPFRLO_OFFSET    0x18         /**< \brief (FLASHCALW_FGPFRLO offset) Flash Controller General Purpose Fuse Register Low */
+
+#define FLASHCALW_FGPFRLO_LOCK0_Pos 0            /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 0 */
+#define FLASHCALW_FGPFRLO_LOCK0     (_U(0x1) << FLASHCALW_FGPFRLO_LOCK0_Pos)
+#define FLASHCALW_FGPFRLO_LOCK1_Pos 1            /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 1 */
+#define FLASHCALW_FGPFRLO_LOCK1     (_U(0x1) << FLASHCALW_FGPFRLO_LOCK1_Pos)
+#define FLASHCALW_FGPFRLO_LOCK2_Pos 2            /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 2 */
+#define FLASHCALW_FGPFRLO_LOCK2     (_U(0x1) << FLASHCALW_FGPFRLO_LOCK2_Pos)
+#define FLASHCALW_FGPFRLO_LOCK3_Pos 3            /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 3 */
+#define FLASHCALW_FGPFRLO_LOCK3     (_U(0x1) << FLASHCALW_FGPFRLO_LOCK3_Pos)
+#define FLASHCALW_FGPFRLO_LOCK4_Pos 4            /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 4 */
+#define FLASHCALW_FGPFRLO_LOCK4     (_U(0x1) << FLASHCALW_FGPFRLO_LOCK4_Pos)
+#define FLASHCALW_FGPFRLO_LOCK5_Pos 5            /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 5 */
+#define FLASHCALW_FGPFRLO_LOCK5     (_U(0x1) << FLASHCALW_FGPFRLO_LOCK5_Pos)
+#define FLASHCALW_FGPFRLO_LOCK6_Pos 6            /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 6 */
+#define FLASHCALW_FGPFRLO_LOCK6     (_U(0x1) << FLASHCALW_FGPFRLO_LOCK6_Pos)
+#define FLASHCALW_FGPFRLO_LOCK7_Pos 7            /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 7 */
+#define FLASHCALW_FGPFRLO_LOCK7     (_U(0x1) << FLASHCALW_FGPFRLO_LOCK7_Pos)
+#define FLASHCALW_FGPFRLO_LOCK8_Pos 8            /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 8 */
+#define FLASHCALW_FGPFRLO_LOCK8     (_U(0x1) << FLASHCALW_FGPFRLO_LOCK8_Pos)
+#define FLASHCALW_FGPFRLO_LOCK9_Pos 9            /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 9 */
+#define FLASHCALW_FGPFRLO_LOCK9     (_U(0x1) << FLASHCALW_FGPFRLO_LOCK9_Pos)
+#define FLASHCALW_FGPFRLO_LOCK10_Pos 10           /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 10 */
+#define FLASHCALW_FGPFRLO_LOCK10    (_U(0x1) << FLASHCALW_FGPFRLO_LOCK10_Pos)
+#define FLASHCALW_FGPFRLO_LOCK11_Pos 11           /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 11 */
+#define FLASHCALW_FGPFRLO_LOCK11    (_U(0x1) << FLASHCALW_FGPFRLO_LOCK11_Pos)
+#define FLASHCALW_FGPFRLO_LOCK12_Pos 12           /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 12 */
+#define FLASHCALW_FGPFRLO_LOCK12    (_U(0x1) << FLASHCALW_FGPFRLO_LOCK12_Pos)
+#define FLASHCALW_FGPFRLO_LOCK13_Pos 13           /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 13 */
+#define FLASHCALW_FGPFRLO_LOCK13    (_U(0x1) << FLASHCALW_FGPFRLO_LOCK13_Pos)
+#define FLASHCALW_FGPFRLO_LOCK14_Pos 14           /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 14 */
+#define FLASHCALW_FGPFRLO_LOCK14    (_U(0x1) << FLASHCALW_FGPFRLO_LOCK14_Pos)
+#define FLASHCALW_FGPFRLO_LOCK15_Pos 15           /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 15 */
+#define FLASHCALW_FGPFRLO_LOCK15    (_U(0x1) << FLASHCALW_FGPFRLO_LOCK15_Pos)
+#define FLASHCALW_FGPFRLO_GPF16_Pos 16           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 16 */
+#define FLASHCALW_FGPFRLO_GPF16     (_U(0x1) << FLASHCALW_FGPFRLO_GPF16_Pos)
+#define FLASHCALW_FGPFRLO_GPF17_Pos 17           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 17 */
+#define FLASHCALW_FGPFRLO_GPF17     (_U(0x1) << FLASHCALW_FGPFRLO_GPF17_Pos)
+#define FLASHCALW_FGPFRLO_GPF18_Pos 18           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 18 */
+#define FLASHCALW_FGPFRLO_GPF18     (_U(0x1) << FLASHCALW_FGPFRLO_GPF18_Pos)
+#define FLASHCALW_FGPFRLO_GPF19_Pos 19           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 19 */
+#define FLASHCALW_FGPFRLO_GPF19     (_U(0x1) << FLASHCALW_FGPFRLO_GPF19_Pos)
+#define FLASHCALW_FGPFRLO_GPF20_Pos 20           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 20 */
+#define FLASHCALW_FGPFRLO_GPF20     (_U(0x1) << FLASHCALW_FGPFRLO_GPF20_Pos)
+#define FLASHCALW_FGPFRLO_GPF21_Pos 21           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 21 */
+#define FLASHCALW_FGPFRLO_GPF21     (_U(0x1) << FLASHCALW_FGPFRLO_GPF21_Pos)
+#define FLASHCALW_FGPFRLO_GPF22_Pos 22           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 22 */
+#define FLASHCALW_FGPFRLO_GPF22     (_U(0x1) << FLASHCALW_FGPFRLO_GPF22_Pos)
+#define FLASHCALW_FGPFRLO_GPF23_Pos 23           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 23 */
+#define FLASHCALW_FGPFRLO_GPF23     (_U(0x1) << FLASHCALW_FGPFRLO_GPF23_Pos)
+#define FLASHCALW_FGPFRLO_GPF24_Pos 24           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 24 */
+#define FLASHCALW_FGPFRLO_GPF24     (_U(0x1) << FLASHCALW_FGPFRLO_GPF24_Pos)
+#define FLASHCALW_FGPFRLO_GPF25_Pos 25           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 25 */
+#define FLASHCALW_FGPFRLO_GPF25     (_U(0x1) << FLASHCALW_FGPFRLO_GPF25_Pos)
+#define FLASHCALW_FGPFRLO_GPF26_Pos 26           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 26 */
+#define FLASHCALW_FGPFRLO_GPF26     (_U(0x1) << FLASHCALW_FGPFRLO_GPF26_Pos)
+#define FLASHCALW_FGPFRLO_GPF27_Pos 27           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 27 */
+#define FLASHCALW_FGPFRLO_GPF27     (_U(0x1) << FLASHCALW_FGPFRLO_GPF27_Pos)
+#define FLASHCALW_FGPFRLO_GPF28_Pos 28           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 28 */
+#define FLASHCALW_FGPFRLO_GPF28     (_U(0x1) << FLASHCALW_FGPFRLO_GPF28_Pos)
+#define FLASHCALW_FGPFRLO_GPF29_Pos 29           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 29 */
+#define FLASHCALW_FGPFRLO_GPF29     (_U(0x1) << FLASHCALW_FGPFRLO_GPF29_Pos)
+#define FLASHCALW_FGPFRLO_GPF30_Pos 30           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 30 */
+#define FLASHCALW_FGPFRLO_GPF30     (_U(0x1) << FLASHCALW_FGPFRLO_GPF30_Pos)
+#define FLASHCALW_FGPFRLO_GPF31_Pos 31           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 31 */
+#define FLASHCALW_FGPFRLO_GPF31     (_U(0x1) << FLASHCALW_FGPFRLO_GPF31_Pos)
+#define FLASHCALW_FGPFRLO_MASK      _U(0xFFFFFFFF) /**< \brief (FLASHCALW_FGPFRLO) MASK Register */
+
+/** \brief FLASHCALW APB hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __IO FLASHCALW_FCR_Type        FCR;         /**< \brief Offset: 0x00 (R/W 32) Flash Controller Control Register */
+  __IO FLASHCALW_FCMD_Type       FCMD;        /**< \brief Offset: 0x04 (R/W 32) Flash Controller Command Register */
+  __IO FLASHCALW_FSR_Type        FSR;         /**< \brief Offset: 0x08 (R/W 32) Flash Controller Status Register */
+  __I  FLASHCALW_FPR_Type        FPR;         /**< \brief Offset: 0x0C (R/  32) Flash Controller Parameter Register */
+  __I  FLASHCALW_VERSION_Type    VERSION;     /**< \brief Offset: 0x10 (R/  32) Flash Controller Version Register */
+  __IO FLASHCALW_FGPFRHI_Type    FGPFRHI;     /**< \brief Offset: 0x14 (R/W 32) Flash Controller General Purpose Fuse Register High */
+  __IO FLASHCALW_FGPFRLO_Type    FGPFRLO;     /**< \brief Offset: 0x18 (R/W 32) Flash Controller General Purpose Fuse Register Low */
+ } bf;
+ struct {
+  RwReg   FLASHCALW_FCR;      /**< \brief (FLASHCALW Offset: 0x00) Flash Controller Control Register */
+  RwReg   FLASHCALW_FCMD;     /**< \brief (FLASHCALW Offset: 0x04) Flash Controller Command Register */
+  RwReg   FLASHCALW_FSR;      /**< \brief (FLASHCALW Offset: 0x08) Flash Controller Status Register */
+  RoReg   FLASHCALW_FPR;      /**< \brief (FLASHCALW Offset: 0x0C) Flash Controller Parameter Register */
+  RoReg   FLASHCALW_VERSION;  /**< \brief (FLASHCALW Offset: 0x10) Flash Controller Version Register */
+  RwReg   FLASHCALW_FGPFRHI;  /**< \brief (FLASHCALW Offset: 0x14) Flash Controller General Purpose Fuse Register High */
+  RwReg   FLASHCALW_FGPFRLO;  /**< \brief (FLASHCALW Offset: 0x18) Flash Controller General Purpose Fuse Register Low */
+ } reg;
+} Flashcalw;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SECTION_FLASHCALW_FROW
+
+#define SECTION_FLASHCALW_USER
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR NON-VOLATILE FUSES */
+/* ************************************************************************** */
+/** \addtogroup fuses_api Peripheral Software API */
+/*@{*/
+
+
+#define FUSES_BOD18ACTION_ADDR      HFLASHC_USER
+#define FUSES_BOD18ACTION_Pos       18           /**< \brief (HFLASHC_USER) BOD18 Action */
+#define FUSES_BOD18ACTION_Msk       (_U(0x3) << FUSES_BOD18ACTION_Pos)
+#define FUSES_BOD18ACTION(value)    (FUSES_BOD18ACTION_Msk & ((value) << FUSES_BOD18ACTION_Pos))
+
+#define FUSES_BOD18EN_ADDR          HFLASHC_USER
+#define FUSES_BOD18EN_Pos           17           /**< \brief (HFLASHC_USER) BOD18 Enable */
+#define FUSES_BOD18EN_Msk           (_U(0x1) << FUSES_BOD18EN_Pos)
+
+#define FUSES_BOD18HYST_ADDR        HFLASHC_USER
+#define FUSES_BOD18HYST_Pos         20           /**< \brief (HFLASHC_USER) BOD18 Hysteresis */
+#define FUSES_BOD18HYST_Msk         (_U(0x1) << FUSES_BOD18HYST_Pos)
+
+#define FUSES_BOD18LV_ADDR          HFLASHC_USER
+#define FUSES_BOD18LV_Pos           11           /**< \brief (HFLASHC_USER) BOD18 Level */
+#define FUSES_BOD18LV_Msk           (_U(0x3F) << FUSES_BOD18LV_Pos)
+#define FUSES_BOD18LV(value)        (FUSES_BOD18LV_Msk & ((value) << FUSES_BOD18LV_Pos))
+
+#define FUSES_BOD33ACTION_ADDR      HFLASHC_USER
+#define FUSES_BOD33ACTION_Pos       8            /**< \brief (HFLASHC_USER) BOD33 Action */
+#define FUSES_BOD33ACTION_Msk       (_U(0x3) << FUSES_BOD33ACTION_Pos)
+#define FUSES_BOD33ACTION(value)    (FUSES_BOD33ACTION_Msk & ((value) << FUSES_BOD33ACTION_Pos))
+
+#define FUSES_BOD33EN_ADDR          HFLASHC_USER
+#define FUSES_BOD33EN_Pos           7            /**< \brief (HFLASHC_USER) BOD33 Enable */
+#define FUSES_BOD33EN_Msk           (_U(0x1) << FUSES_BOD33EN_Pos)
+
+#define FUSES_BOD33LEVEL_ADDR       HFLASHC_USER
+#define FUSES_BOD33LEVEL_Pos        1            /**< \brief (HFLASHC_USER) BOD33 Level */
+#define FUSES_BOD33LEVEL_Msk        (_U(0x3F) << FUSES_BOD33LEVEL_Pos)
+#define FUSES_BOD33LEVEL(value)     (FUSES_BOD33LEVEL_Msk & ((value) << FUSES_BOD33LEVEL_Pos))
+
+#define FUSES_BOD33_HYST_ADDR       HFLASHC_USER
+#define FUSES_BOD33_HYST_Pos        10           /**< \brief (HFLASHC_USER) BOD33 Hysteresis */
+#define FUSES_BOD33_HYST_Msk        (_U(0x1) << FUSES_BOD33_HYST_Pos)
+
+#define WDT_FUSES_WDTAUTO_ADDR      HFLASHC_USER
+#define WDT_FUSES_WDTAUTO_Pos       0            /**< \brief (HFLASHC_USER) Watchdog Enabled at Reset */
+#define WDT_FUSES_WDTAUTO_Msk       (_U(0x1) << WDT_FUSES_WDTAUTO_Pos)
+
+/*@}*/
+
+#endif /* _SAM4L_FLASHCALW_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/flashcalw.h
+++ b/asf/sam/include/sam4l/component/flashcalw.h
@@ -56,35 +56,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define FLASHCALW_FCR_OFFSET        0x00         /**< \brief (FLASHCALW_FCR offset) Flash Controller Control Register */
-#define FLASHCALW_FCR_RESETVALUE    _U(0x00000000); /**< \brief (FLASHCALW_FCR reset_value) Flash Controller Control Register */
+#define FLASHCALW_FCR_RESETVALUE    _U_(0x00000000); /**< \brief (FLASHCALW_FCR reset_value) Flash Controller Control Register */
 
 #define FLASHCALW_FCR_FRDY_Pos      0            /**< \brief (FLASHCALW_FCR) Flash Ready Interrupt Enable */
-#define FLASHCALW_FCR_FRDY          (_U(0x1) << FLASHCALW_FCR_FRDY_Pos)
-#define   FLASHCALW_FCR_FRDY_0_Val        _U(0x0)   /**< \brief (FLASHCALW_FCR) Flash Ready does not generate an interrupt */
-#define   FLASHCALW_FCR_FRDY_1_Val        _U(0x1)   /**< \brief (FLASHCALW_FCR) Flash Ready generates an interrupt */
+#define FLASHCALW_FCR_FRDY          (_U_(0x1) << FLASHCALW_FCR_FRDY_Pos)
+#define   FLASHCALW_FCR_FRDY_0_Val        _U_(0x0)   /**< \brief (FLASHCALW_FCR) Flash Ready does not generate an interrupt */
+#define   FLASHCALW_FCR_FRDY_1_Val        _U_(0x1)   /**< \brief (FLASHCALW_FCR) Flash Ready generates an interrupt */
 #define FLASHCALW_FCR_FRDY_0        (FLASHCALW_FCR_FRDY_0_Val      << FLASHCALW_FCR_FRDY_Pos)
 #define FLASHCALW_FCR_FRDY_1        (FLASHCALW_FCR_FRDY_1_Val      << FLASHCALW_FCR_FRDY_Pos)
 #define FLASHCALW_FCR_LOCKE_Pos     2            /**< \brief (FLASHCALW_FCR) Lock Error Interrupt Enable */
-#define FLASHCALW_FCR_LOCKE         (_U(0x1) << FLASHCALW_FCR_LOCKE_Pos)
-#define   FLASHCALW_FCR_LOCKE_0_Val       _U(0x0)   /**< \brief (FLASHCALW_FCR) Lock Error does not generate an interrupt */
-#define   FLASHCALW_FCR_LOCKE_1_Val       _U(0x1)   /**< \brief (FLASHCALW_FCR) Lock Error generates an interrupt */
+#define FLASHCALW_FCR_LOCKE         (_U_(0x1) << FLASHCALW_FCR_LOCKE_Pos)
+#define   FLASHCALW_FCR_LOCKE_0_Val       _U_(0x0)   /**< \brief (FLASHCALW_FCR) Lock Error does not generate an interrupt */
+#define   FLASHCALW_FCR_LOCKE_1_Val       _U_(0x1)   /**< \brief (FLASHCALW_FCR) Lock Error generates an interrupt */
 #define FLASHCALW_FCR_LOCKE_0       (FLASHCALW_FCR_LOCKE_0_Val     << FLASHCALW_FCR_LOCKE_Pos)
 #define FLASHCALW_FCR_LOCKE_1       (FLASHCALW_FCR_LOCKE_1_Val     << FLASHCALW_FCR_LOCKE_Pos)
 #define FLASHCALW_FCR_PROGE_Pos     3            /**< \brief (FLASHCALW_FCR) Programming Error Interrupt Enable */
-#define FLASHCALW_FCR_PROGE         (_U(0x1) << FLASHCALW_FCR_PROGE_Pos)
-#define   FLASHCALW_FCR_PROGE_0_Val       _U(0x0)   /**< \brief (FLASHCALW_FCR) Programming Error does not generate an interrupt */
-#define   FLASHCALW_FCR_PROGE_1_Val       _U(0x1)   /**< \brief (FLASHCALW_FCR) Programming Error generates an interrupt */
+#define FLASHCALW_FCR_PROGE         (_U_(0x1) << FLASHCALW_FCR_PROGE_Pos)
+#define   FLASHCALW_FCR_PROGE_0_Val       _U_(0x0)   /**< \brief (FLASHCALW_FCR) Programming Error does not generate an interrupt */
+#define   FLASHCALW_FCR_PROGE_1_Val       _U_(0x1)   /**< \brief (FLASHCALW_FCR) Programming Error generates an interrupt */
 #define FLASHCALW_FCR_PROGE_0       (FLASHCALW_FCR_PROGE_0_Val     << FLASHCALW_FCR_PROGE_Pos)
 #define FLASHCALW_FCR_PROGE_1       (FLASHCALW_FCR_PROGE_1_Val     << FLASHCALW_FCR_PROGE_Pos)
 #define FLASHCALW_FCR_FWS_Pos       6            /**< \brief (FLASHCALW_FCR) Flash Wait State */
-#define FLASHCALW_FCR_FWS           (_U(0x1) << FLASHCALW_FCR_FWS_Pos)
-#define   FLASHCALW_FCR_FWS_0_Val         _U(0x0)   /**< \brief (FLASHCALW_FCR) The flash is read with 0 wait states */
-#define   FLASHCALW_FCR_FWS_1_Val         _U(0x1)   /**< \brief (FLASHCALW_FCR) The flash is read with 1 wait states */
+#define FLASHCALW_FCR_FWS           (_U_(0x1) << FLASHCALW_FCR_FWS_Pos)
+#define   FLASHCALW_FCR_FWS_0_Val         _U_(0x0)   /**< \brief (FLASHCALW_FCR) The flash is read with 0 wait states */
+#define   FLASHCALW_FCR_FWS_1_Val         _U_(0x1)   /**< \brief (FLASHCALW_FCR) The flash is read with 1 wait states */
 #define FLASHCALW_FCR_FWS_0         (FLASHCALW_FCR_FWS_0_Val       << FLASHCALW_FCR_FWS_Pos)
 #define FLASHCALW_FCR_FWS_1         (FLASHCALW_FCR_FWS_1_Val       << FLASHCALW_FCR_FWS_Pos)
 #define FLASHCALW_FCR_WS1OPT_Pos    7            /**< \brief (FLASHCALW_FCR) Wait State 1 Optimization */
-#define FLASHCALW_FCR_WS1OPT        (_U(0x1) << FLASHCALW_FCR_WS1OPT_Pos)
-#define FLASHCALW_FCR_MASK          _U(0x000000CD) /**< \brief (FLASHCALW_FCR) MASK Register */
+#define FLASHCALW_FCR_WS1OPT        (_U_(0x1) << FLASHCALW_FCR_WS1OPT_Pos)
+#define FLASHCALW_FCR_MASK          _U_(0x000000CD) /**< \brief (FLASHCALW_FCR) MASK Register */
 
 /* -------- FLASHCALW_FCMD : (FLASHCALW Offset: 0x04) (R/W 32) Flash Controller Command Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -100,29 +100,29 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define FLASHCALW_FCMD_OFFSET       0x04         /**< \brief (FLASHCALW_FCMD offset) Flash Controller Command Register */
-#define FLASHCALW_FCMD_RESETVALUE   _U(0x00000000); /**< \brief (FLASHCALW_FCMD reset_value) Flash Controller Command Register */
+#define FLASHCALW_FCMD_RESETVALUE   _U_(0x00000000); /**< \brief (FLASHCALW_FCMD reset_value) Flash Controller Command Register */
 
 #define FLASHCALW_FCMD_CMD_Pos      0            /**< \brief (FLASHCALW_FCMD) Command */
-#define FLASHCALW_FCMD_CMD_Msk      (_U(0x3F) << FLASHCALW_FCMD_CMD_Pos)
+#define FLASHCALW_FCMD_CMD_Msk      (_U_(0x3F) << FLASHCALW_FCMD_CMD_Pos)
 #define FLASHCALW_FCMD_CMD(value)   (FLASHCALW_FCMD_CMD_Msk & ((value) << FLASHCALW_FCMD_CMD_Pos))
-#define   FLASHCALW_FCMD_CMD_NOP_Val      _U(0x0)   /**< \brief (FLASHCALW_FCMD) No Operation */
-#define   FLASHCALW_FCMD_CMD_WP_Val       _U(0x1)   /**< \brief (FLASHCALW_FCMD) Write Page */
-#define   FLASHCALW_FCMD_CMD_EP_Val       _U(0x2)   /**< \brief (FLASHCALW_FCMD) Erase Page */
-#define   FLASHCALW_FCMD_CMD_CPB_Val      _U(0x3)   /**< \brief (FLASHCALW_FCMD) Clear Page Buffer */
-#define   FLASHCALW_FCMD_CMD_LP_Val       _U(0x4)   /**< \brief (FLASHCALW_FCMD) Lock Region containing page */
-#define   FLASHCALW_FCMD_CMD_UP_Val       _U(0x5)   /**< \brief (FLASHCALW_FCMD) Unlock Region containing page */
-#define   FLASHCALW_FCMD_CMD_EA_Val       _U(0x6)   /**< \brief (FLASHCALW_FCMD) Erase All, including secuity and fuse bits */
-#define   FLASHCALW_FCMD_CMD_WGPB_Val     _U(0x7)   /**< \brief (FLASHCALW_FCMD) Write General-Purpose fuse Bit */
-#define   FLASHCALW_FCMD_CMD_EGPB_Val     _U(0x8)   /**< \brief (FLASHCALW_FCMD) Erase General-Purpose fuse Bit */
-#define   FLASHCALW_FCMD_CMD_SSB_Val      _U(0x9)   /**< \brief (FLASHCALW_FCMD) Set Security Bit */
-#define   FLASHCALW_FCMD_CMD_PGPFB_Val    _U(0xA)   /**< \brief (FLASHCALW_FCMD) Program GPFuse Byte */
-#define   FLASHCALW_FCMD_CMD_EAGPF_Val    _U(0xB)   /**< \brief (FLASHCALW_FCMD) Erase All GP Fuses */
-#define   FLASHCALW_FCMD_CMD_QPR_Val      _U(0xC)   /**< \brief (FLASHCALW_FCMD) Quick Page Read */
-#define   FLASHCALW_FCMD_CMD_WUP_Val      _U(0xD)   /**< \brief (FLASHCALW_FCMD) Write User Page */
-#define   FLASHCALW_FCMD_CMD_EUP_Val      _U(0xE)   /**< \brief (FLASHCALW_FCMD) Erase User Page */
-#define   FLASHCALW_FCMD_CMD_QPRUP_Val    _U(0xF)   /**< \brief (FLASHCALW_FCMD) Quick Page Read User Page */
-#define   FLASHCALW_FCMD_CMD_HSEN_Val     _U(0x10)   /**< \brief (FLASHCALW_FCMD) High Speed Mode Enable */
-#define   FLASHCALW_FCMD_CMD_HSDIS_Val    _U(0x11)   /**< \brief (FLASHCALW_FCMD) High Speed Mode Disable */
+#define   FLASHCALW_FCMD_CMD_NOP_Val      _U_(0x0)   /**< \brief (FLASHCALW_FCMD) No Operation */
+#define   FLASHCALW_FCMD_CMD_WP_Val       _U_(0x1)   /**< \brief (FLASHCALW_FCMD) Write Page */
+#define   FLASHCALW_FCMD_CMD_EP_Val       _U_(0x2)   /**< \brief (FLASHCALW_FCMD) Erase Page */
+#define   FLASHCALW_FCMD_CMD_CPB_Val      _U_(0x3)   /**< \brief (FLASHCALW_FCMD) Clear Page Buffer */
+#define   FLASHCALW_FCMD_CMD_LP_Val       _U_(0x4)   /**< \brief (FLASHCALW_FCMD) Lock Region containing page */
+#define   FLASHCALW_FCMD_CMD_UP_Val       _U_(0x5)   /**< \brief (FLASHCALW_FCMD) Unlock Region containing page */
+#define   FLASHCALW_FCMD_CMD_EA_Val       _U_(0x6)   /**< \brief (FLASHCALW_FCMD) Erase All, including secuity and fuse bits */
+#define   FLASHCALW_FCMD_CMD_WGPB_Val     _U_(0x7)   /**< \brief (FLASHCALW_FCMD) Write General-Purpose fuse Bit */
+#define   FLASHCALW_FCMD_CMD_EGPB_Val     _U_(0x8)   /**< \brief (FLASHCALW_FCMD) Erase General-Purpose fuse Bit */
+#define   FLASHCALW_FCMD_CMD_SSB_Val      _U_(0x9)   /**< \brief (FLASHCALW_FCMD) Set Security Bit */
+#define   FLASHCALW_FCMD_CMD_PGPFB_Val    _U_(0xA)   /**< \brief (FLASHCALW_FCMD) Program GPFuse Byte */
+#define   FLASHCALW_FCMD_CMD_EAGPF_Val    _U_(0xB)   /**< \brief (FLASHCALW_FCMD) Erase All GP Fuses */
+#define   FLASHCALW_FCMD_CMD_QPR_Val      _U_(0xC)   /**< \brief (FLASHCALW_FCMD) Quick Page Read */
+#define   FLASHCALW_FCMD_CMD_WUP_Val      _U_(0xD)   /**< \brief (FLASHCALW_FCMD) Write User Page */
+#define   FLASHCALW_FCMD_CMD_EUP_Val      _U_(0xE)   /**< \brief (FLASHCALW_FCMD) Erase User Page */
+#define   FLASHCALW_FCMD_CMD_QPRUP_Val    _U_(0xF)   /**< \brief (FLASHCALW_FCMD) Quick Page Read User Page */
+#define   FLASHCALW_FCMD_CMD_HSEN_Val     _U_(0x10)   /**< \brief (FLASHCALW_FCMD) High Speed Mode Enable */
+#define   FLASHCALW_FCMD_CMD_HSDIS_Val    _U_(0x11)   /**< \brief (FLASHCALW_FCMD) High Speed Mode Disable */
 #define FLASHCALW_FCMD_CMD_NOP      (FLASHCALW_FCMD_CMD_NOP_Val    << FLASHCALW_FCMD_CMD_Pos)
 #define FLASHCALW_FCMD_CMD_WP       (FLASHCALW_FCMD_CMD_WP_Val     << FLASHCALW_FCMD_CMD_Pos)
 #define FLASHCALW_FCMD_CMD_EP       (FLASHCALW_FCMD_CMD_EP_Val     << FLASHCALW_FCMD_CMD_Pos)
@@ -142,14 +142,14 @@ typedef union {
 #define FLASHCALW_FCMD_CMD_HSEN     (FLASHCALW_FCMD_CMD_HSEN_Val   << FLASHCALW_FCMD_CMD_Pos)
 #define FLASHCALW_FCMD_CMD_HSDIS    (FLASHCALW_FCMD_CMD_HSDIS_Val  << FLASHCALW_FCMD_CMD_Pos)
 #define FLASHCALW_FCMD_PAGEN_Pos    8            /**< \brief (FLASHCALW_FCMD) Page number */
-#define FLASHCALW_FCMD_PAGEN_Msk    (_U(0xFFFF) << FLASHCALW_FCMD_PAGEN_Pos)
+#define FLASHCALW_FCMD_PAGEN_Msk    (_U_(0xFFFF) << FLASHCALW_FCMD_PAGEN_Pos)
 #define FLASHCALW_FCMD_PAGEN(value) (FLASHCALW_FCMD_PAGEN_Msk & ((value) << FLASHCALW_FCMD_PAGEN_Pos))
 #define FLASHCALW_FCMD_KEY_Pos      24           /**< \brief (FLASHCALW_FCMD) Write protection key */
-#define FLASHCALW_FCMD_KEY_Msk      (_U(0xFF) << FLASHCALW_FCMD_KEY_Pos)
+#define FLASHCALW_FCMD_KEY_Msk      (_U_(0xFF) << FLASHCALW_FCMD_KEY_Pos)
 #define FLASHCALW_FCMD_KEY(value)   (FLASHCALW_FCMD_KEY_Msk & ((value) << FLASHCALW_FCMD_KEY_Pos))
-#define   FLASHCALW_FCMD_KEY_KEY_Val      _U(0xA5)   /**< \brief (FLASHCALW_FCMD)  */
+#define   FLASHCALW_FCMD_KEY_KEY_Val      _U_(0xA5)   /**< \brief (FLASHCALW_FCMD)  */
 #define FLASHCALW_FCMD_KEY_KEY      (FLASHCALW_FCMD_KEY_KEY_Val    << FLASHCALW_FCMD_KEY_Pos)
-#define FLASHCALW_FCMD_MASK         _U(0xFFFFFF3F) /**< \brief (FLASHCALW_FCMD) MASK Register */
+#define FLASHCALW_FCMD_MASK         _U_(0xFFFFFF3F) /**< \brief (FLASHCALW_FCMD) MASK Register */
 
 /* -------- FLASHCALW_FSR : (FLASHCALW Offset: 0x08) (R/W 32) Flash Controller Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -187,62 +187,62 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define FLASHCALW_FSR_OFFSET        0x08         /**< \brief (FLASHCALW_FSR offset) Flash Controller Status Register */
-#define FLASHCALW_FSR_RESETVALUE    _U(0x00000000); /**< \brief (FLASHCALW_FSR reset_value) Flash Controller Status Register */
+#define FLASHCALW_FSR_RESETVALUE    _U_(0x00000000); /**< \brief (FLASHCALW_FSR reset_value) Flash Controller Status Register */
 
 #define FLASHCALW_FSR_FRDY_Pos      0            /**< \brief (FLASHCALW_FSR) Flash Ready Status */
-#define FLASHCALW_FSR_FRDY          (_U(0x1) << FLASHCALW_FSR_FRDY_Pos)
+#define FLASHCALW_FSR_FRDY          (_U_(0x1) << FLASHCALW_FSR_FRDY_Pos)
 #define FLASHCALW_FSR_LOCKE_Pos     2            /**< \brief (FLASHCALW_FSR) Lock Error Status */
-#define FLASHCALW_FSR_LOCKE         (_U(0x1) << FLASHCALW_FSR_LOCKE_Pos)
+#define FLASHCALW_FSR_LOCKE         (_U_(0x1) << FLASHCALW_FSR_LOCKE_Pos)
 #define FLASHCALW_FSR_PROGE_Pos     3            /**< \brief (FLASHCALW_FSR) Programming Error Status */
-#define FLASHCALW_FSR_PROGE         (_U(0x1) << FLASHCALW_FSR_PROGE_Pos)
+#define FLASHCALW_FSR_PROGE         (_U_(0x1) << FLASHCALW_FSR_PROGE_Pos)
 #define FLASHCALW_FSR_SECURITY_Pos  4            /**< \brief (FLASHCALW_FSR) Security Bit Status */
-#define FLASHCALW_FSR_SECURITY      (_U(0x1) << FLASHCALW_FSR_SECURITY_Pos)
+#define FLASHCALW_FSR_SECURITY      (_U_(0x1) << FLASHCALW_FSR_SECURITY_Pos)
 #define FLASHCALW_FSR_QPRR_Pos      5            /**< \brief (FLASHCALW_FSR) Quick Page Read Result */
-#define FLASHCALW_FSR_QPRR          (_U(0x1) << FLASHCALW_FSR_QPRR_Pos)
+#define FLASHCALW_FSR_QPRR          (_U_(0x1) << FLASHCALW_FSR_QPRR_Pos)
 #define FLASHCALW_FSR_HSMODE_Pos    6            /**< \brief (FLASHCALW_FSR) High Speed Mode */
-#define FLASHCALW_FSR_HSMODE        (_U(0x1) << FLASHCALW_FSR_HSMODE_Pos)
+#define FLASHCALW_FSR_HSMODE        (_U_(0x1) << FLASHCALW_FSR_HSMODE_Pos)
 #define FLASHCALW_FSR_ECCERR_Pos    8            /**< \brief (FLASHCALW_FSR) ECC Error Status */
-#define FLASHCALW_FSR_ECCERR_Msk    (_U(0x3) << FLASHCALW_FSR_ECCERR_Pos)
+#define FLASHCALW_FSR_ECCERR_Msk    (_U_(0x3) << FLASHCALW_FSR_ECCERR_Pos)
 #define FLASHCALW_FSR_ECCERR(value) (FLASHCALW_FSR_ECCERR_Msk & ((value) << FLASHCALW_FSR_ECCERR_Pos))
-#define   FLASHCALW_FSR_ECCERR_NOERROR_Val _U(0x0)   /**< \brief (FLASHCALW_FSR) no error */
-#define   FLASHCALW_FSR_ECCERR_ONEECCERR_Val _U(0x1)   /**< \brief (FLASHCALW_FSR) one ECC error detected */
-#define   FLASHCALW_FSR_ECCERR_TWOECCERR_Val _U(0x2)   /**< \brief (FLASHCALW_FSR) two ECC errors detected */
+#define   FLASHCALW_FSR_ECCERR_NOERROR_Val _U_(0x0)   /**< \brief (FLASHCALW_FSR) no error */
+#define   FLASHCALW_FSR_ECCERR_ONEECCERR_Val _U_(0x1)   /**< \brief (FLASHCALW_FSR) one ECC error detected */
+#define   FLASHCALW_FSR_ECCERR_TWOECCERR_Val _U_(0x2)   /**< \brief (FLASHCALW_FSR) two ECC errors detected */
 #define FLASHCALW_FSR_ECCERR_NOERROR (FLASHCALW_FSR_ECCERR_NOERROR_Val << FLASHCALW_FSR_ECCERR_Pos)
 #define FLASHCALW_FSR_ECCERR_ONEECCERR (FLASHCALW_FSR_ECCERR_ONEECCERR_Val << FLASHCALW_FSR_ECCERR_Pos)
 #define FLASHCALW_FSR_ECCERR_TWOECCERR (FLASHCALW_FSR_ECCERR_TWOECCERR_Val << FLASHCALW_FSR_ECCERR_Pos)
 #define FLASHCALW_FSR_LOCK0_Pos     16           /**< \brief (FLASHCALW_FSR) Lock Region 0 Lock Status */
-#define FLASHCALW_FSR_LOCK0         (_U(0x1) << FLASHCALW_FSR_LOCK0_Pos)
+#define FLASHCALW_FSR_LOCK0         (_U_(0x1) << FLASHCALW_FSR_LOCK0_Pos)
 #define FLASHCALW_FSR_LOCK1_Pos     17           /**< \brief (FLASHCALW_FSR) Lock Region 1 Lock Status */
-#define FLASHCALW_FSR_LOCK1         (_U(0x1) << FLASHCALW_FSR_LOCK1_Pos)
+#define FLASHCALW_FSR_LOCK1         (_U_(0x1) << FLASHCALW_FSR_LOCK1_Pos)
 #define FLASHCALW_FSR_LOCK2_Pos     18           /**< \brief (FLASHCALW_FSR) Lock Region 2 Lock Status */
-#define FLASHCALW_FSR_LOCK2         (_U(0x1) << FLASHCALW_FSR_LOCK2_Pos)
+#define FLASHCALW_FSR_LOCK2         (_U_(0x1) << FLASHCALW_FSR_LOCK2_Pos)
 #define FLASHCALW_FSR_LOCK3_Pos     19           /**< \brief (FLASHCALW_FSR) Lock Region 3 Lock Status */
-#define FLASHCALW_FSR_LOCK3         (_U(0x1) << FLASHCALW_FSR_LOCK3_Pos)
+#define FLASHCALW_FSR_LOCK3         (_U_(0x1) << FLASHCALW_FSR_LOCK3_Pos)
 #define FLASHCALW_FSR_LOCK4_Pos     20           /**< \brief (FLASHCALW_FSR) Lock Region 4 Lock Status */
-#define FLASHCALW_FSR_LOCK4         (_U(0x1) << FLASHCALW_FSR_LOCK4_Pos)
+#define FLASHCALW_FSR_LOCK4         (_U_(0x1) << FLASHCALW_FSR_LOCK4_Pos)
 #define FLASHCALW_FSR_LOCK5_Pos     21           /**< \brief (FLASHCALW_FSR) Lock Region 5 Lock Status */
-#define FLASHCALW_FSR_LOCK5         (_U(0x1) << FLASHCALW_FSR_LOCK5_Pos)
+#define FLASHCALW_FSR_LOCK5         (_U_(0x1) << FLASHCALW_FSR_LOCK5_Pos)
 #define FLASHCALW_FSR_LOCK6_Pos     22           /**< \brief (FLASHCALW_FSR) Lock Region 6 Lock Status */
-#define FLASHCALW_FSR_LOCK6         (_U(0x1) << FLASHCALW_FSR_LOCK6_Pos)
+#define FLASHCALW_FSR_LOCK6         (_U_(0x1) << FLASHCALW_FSR_LOCK6_Pos)
 #define FLASHCALW_FSR_LOCK7_Pos     23           /**< \brief (FLASHCALW_FSR) Lock Region 7 Lock Status */
-#define FLASHCALW_FSR_LOCK7         (_U(0x1) << FLASHCALW_FSR_LOCK7_Pos)
+#define FLASHCALW_FSR_LOCK7         (_U_(0x1) << FLASHCALW_FSR_LOCK7_Pos)
 #define FLASHCALW_FSR_LOCK8_Pos     24           /**< \brief (FLASHCALW_FSR) Lock Region 8 Lock Status */
-#define FLASHCALW_FSR_LOCK8         (_U(0x1) << FLASHCALW_FSR_LOCK8_Pos)
+#define FLASHCALW_FSR_LOCK8         (_U_(0x1) << FLASHCALW_FSR_LOCK8_Pos)
 #define FLASHCALW_FSR_LOCK9_Pos     25           /**< \brief (FLASHCALW_FSR) Lock Region 9 Lock Status */
-#define FLASHCALW_FSR_LOCK9         (_U(0x1) << FLASHCALW_FSR_LOCK9_Pos)
+#define FLASHCALW_FSR_LOCK9         (_U_(0x1) << FLASHCALW_FSR_LOCK9_Pos)
 #define FLASHCALW_FSR_LOCK10_Pos    26           /**< \brief (FLASHCALW_FSR) Lock Region 10 Lock Status */
-#define FLASHCALW_FSR_LOCK10        (_U(0x1) << FLASHCALW_FSR_LOCK10_Pos)
+#define FLASHCALW_FSR_LOCK10        (_U_(0x1) << FLASHCALW_FSR_LOCK10_Pos)
 #define FLASHCALW_FSR_LOCK11_Pos    27           /**< \brief (FLASHCALW_FSR) Lock Region 11 Lock Status */
-#define FLASHCALW_FSR_LOCK11        (_U(0x1) << FLASHCALW_FSR_LOCK11_Pos)
+#define FLASHCALW_FSR_LOCK11        (_U_(0x1) << FLASHCALW_FSR_LOCK11_Pos)
 #define FLASHCALW_FSR_LOCK12_Pos    28           /**< \brief (FLASHCALW_FSR) Lock Region 12 Lock Status */
-#define FLASHCALW_FSR_LOCK12        (_U(0x1) << FLASHCALW_FSR_LOCK12_Pos)
+#define FLASHCALW_FSR_LOCK12        (_U_(0x1) << FLASHCALW_FSR_LOCK12_Pos)
 #define FLASHCALW_FSR_LOCK13_Pos    29           /**< \brief (FLASHCALW_FSR) Lock Region 13 Lock Status */
-#define FLASHCALW_FSR_LOCK13        (_U(0x1) << FLASHCALW_FSR_LOCK13_Pos)
+#define FLASHCALW_FSR_LOCK13        (_U_(0x1) << FLASHCALW_FSR_LOCK13_Pos)
 #define FLASHCALW_FSR_LOCK14_Pos    30           /**< \brief (FLASHCALW_FSR) Lock Region 14 Lock Status */
-#define FLASHCALW_FSR_LOCK14        (_U(0x1) << FLASHCALW_FSR_LOCK14_Pos)
+#define FLASHCALW_FSR_LOCK14        (_U_(0x1) << FLASHCALW_FSR_LOCK14_Pos)
 #define FLASHCALW_FSR_LOCK15_Pos    31           /**< \brief (FLASHCALW_FSR) Lock Region 15 Lock Status */
-#define FLASHCALW_FSR_LOCK15        (_U(0x1) << FLASHCALW_FSR_LOCK15_Pos)
-#define FLASHCALW_FSR_MASK          _U(0xFFFF037D) /**< \brief (FLASHCALW_FSR) MASK Register */
+#define FLASHCALW_FSR_LOCK15        (_U_(0x1) << FLASHCALW_FSR_LOCK15_Pos)
+#define FLASHCALW_FSR_MASK          _U_(0xFFFF037D) /**< \brief (FLASHCALW_FSR) MASK Register */
 
 /* -------- FLASHCALW_FPR : (FLASHCALW Offset: 0x0C) (R/  32) Flash Controller Parameter Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -260,12 +260,12 @@ typedef union {
 #define FLASHCALW_FPR_OFFSET        0x0C         /**< \brief (FLASHCALW_FPR offset) Flash Controller Parameter Register */
 
 #define FLASHCALW_FPR_FSZ_Pos       0            /**< \brief (FLASHCALW_FPR) Flash Size */
-#define FLASHCALW_FPR_FSZ_Msk       (_U(0xF) << FLASHCALW_FPR_FSZ_Pos)
+#define FLASHCALW_FPR_FSZ_Msk       (_U_(0xF) << FLASHCALW_FPR_FSZ_Pos)
 #define FLASHCALW_FPR_FSZ(value)    (FLASHCALW_FPR_FSZ_Msk & ((value) << FLASHCALW_FPR_FSZ_Pos))
 #define FLASHCALW_FPR_PSZ_Pos       8            /**< \brief (FLASHCALW_FPR) Page Size */
-#define FLASHCALW_FPR_PSZ_Msk       (_U(0x7) << FLASHCALW_FPR_PSZ_Pos)
+#define FLASHCALW_FPR_PSZ_Msk       (_U_(0x7) << FLASHCALW_FPR_PSZ_Pos)
 #define FLASHCALW_FPR_PSZ(value)    (FLASHCALW_FPR_PSZ_Msk & ((value) << FLASHCALW_FPR_PSZ_Pos))
-#define FLASHCALW_FPR_MASK          _U(0x0000070F) /**< \brief (FLASHCALW_FPR) MASK Register */
+#define FLASHCALW_FPR_MASK          _U_(0x0000070F) /**< \brief (FLASHCALW_FPR) MASK Register */
 
 /* -------- FLASHCALW_VERSION : (FLASHCALW Offset: 0x10) (R/  32) Flash Controller Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -281,15 +281,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define FLASHCALW_VERSION_OFFSET    0x10         /**< \brief (FLASHCALW_VERSION offset) Flash Controller Version Register */
-#define FLASHCALW_VERSION_RESETVALUE _U(0x00000110); /**< \brief (FLASHCALW_VERSION reset_value) Flash Controller Version Register */
+#define FLASHCALW_VERSION_RESETVALUE _U_(0x00000110); /**< \brief (FLASHCALW_VERSION reset_value) Flash Controller Version Register */
 
 #define FLASHCALW_VERSION_VERSION_Pos 0            /**< \brief (FLASHCALW_VERSION) Version Number */
-#define FLASHCALW_VERSION_VERSION_Msk (_U(0xFFF) << FLASHCALW_VERSION_VERSION_Pos)
+#define FLASHCALW_VERSION_VERSION_Msk (_U_(0xFFF) << FLASHCALW_VERSION_VERSION_Pos)
 #define FLASHCALW_VERSION_VERSION(value) (FLASHCALW_VERSION_VERSION_Msk & ((value) << FLASHCALW_VERSION_VERSION_Pos))
 #define FLASHCALW_VERSION_VARIANT_Pos 16           /**< \brief (FLASHCALW_VERSION) Variant Number */
-#define FLASHCALW_VERSION_VARIANT_Msk (_U(0xF) << FLASHCALW_VERSION_VARIANT_Pos)
+#define FLASHCALW_VERSION_VARIANT_Msk (_U_(0xF) << FLASHCALW_VERSION_VARIANT_Pos)
 #define FLASHCALW_VERSION_VARIANT(value) (FLASHCALW_VERSION_VARIANT_Msk & ((value) << FLASHCALW_VERSION_VARIANT_Pos))
-#define FLASHCALW_VERSION_MASK      _U(0x000F0FFF) /**< \brief (FLASHCALW_VERSION) MASK Register */
+#define FLASHCALW_VERSION_MASK      _U_(0x000F0FFF) /**< \brief (FLASHCALW_VERSION) MASK Register */
 
 /* -------- FLASHCALW_FGPFRHI : (FLASHCALW Offset: 0x14) (R/W 32) Flash Controller General Purpose Fuse Register High -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -335,70 +335,70 @@ typedef union {
 #define FLASHCALW_FGPFRHI_OFFSET    0x14         /**< \brief (FLASHCALW_FGPFRHI offset) Flash Controller General Purpose Fuse Register High */
 
 #define FLASHCALW_FGPFRHI_GPF32_Pos 0            /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 32 */
-#define FLASHCALW_FGPFRHI_GPF32     (_U(0x1) << FLASHCALW_FGPFRHI_GPF32_Pos)
+#define FLASHCALW_FGPFRHI_GPF32     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF32_Pos)
 #define FLASHCALW_FGPFRHI_GPF33_Pos 1            /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 33 */
-#define FLASHCALW_FGPFRHI_GPF33     (_U(0x1) << FLASHCALW_FGPFRHI_GPF33_Pos)
+#define FLASHCALW_FGPFRHI_GPF33     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF33_Pos)
 #define FLASHCALW_FGPFRHI_GPF34_Pos 2            /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 34 */
-#define FLASHCALW_FGPFRHI_GPF34     (_U(0x1) << FLASHCALW_FGPFRHI_GPF34_Pos)
+#define FLASHCALW_FGPFRHI_GPF34     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF34_Pos)
 #define FLASHCALW_FGPFRHI_GPF35_Pos 3            /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 35 */
-#define FLASHCALW_FGPFRHI_GPF35     (_U(0x1) << FLASHCALW_FGPFRHI_GPF35_Pos)
+#define FLASHCALW_FGPFRHI_GPF35     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF35_Pos)
 #define FLASHCALW_FGPFRHI_GPF36_Pos 4            /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 36 */
-#define FLASHCALW_FGPFRHI_GPF36     (_U(0x1) << FLASHCALW_FGPFRHI_GPF36_Pos)
+#define FLASHCALW_FGPFRHI_GPF36     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF36_Pos)
 #define FLASHCALW_FGPFRHI_GPF37_Pos 5            /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 37 */
-#define FLASHCALW_FGPFRHI_GPF37     (_U(0x1) << FLASHCALW_FGPFRHI_GPF37_Pos)
+#define FLASHCALW_FGPFRHI_GPF37     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF37_Pos)
 #define FLASHCALW_FGPFRHI_GPF38_Pos 6            /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 38 */
-#define FLASHCALW_FGPFRHI_GPF38     (_U(0x1) << FLASHCALW_FGPFRHI_GPF38_Pos)
+#define FLASHCALW_FGPFRHI_GPF38     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF38_Pos)
 #define FLASHCALW_FGPFRHI_GPF39_Pos 7            /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 39 */
-#define FLASHCALW_FGPFRHI_GPF39     (_U(0x1) << FLASHCALW_FGPFRHI_GPF39_Pos)
+#define FLASHCALW_FGPFRHI_GPF39     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF39_Pos)
 #define FLASHCALW_FGPFRHI_GPF40_Pos 8            /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 40 */
-#define FLASHCALW_FGPFRHI_GPF40     (_U(0x1) << FLASHCALW_FGPFRHI_GPF40_Pos)
+#define FLASHCALW_FGPFRHI_GPF40     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF40_Pos)
 #define FLASHCALW_FGPFRHI_GPF41_Pos 9            /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 41 */
-#define FLASHCALW_FGPFRHI_GPF41     (_U(0x1) << FLASHCALW_FGPFRHI_GPF41_Pos)
+#define FLASHCALW_FGPFRHI_GPF41     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF41_Pos)
 #define FLASHCALW_FGPFRHI_GPF42_Pos 10           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 42 */
-#define FLASHCALW_FGPFRHI_GPF42     (_U(0x1) << FLASHCALW_FGPFRHI_GPF42_Pos)
+#define FLASHCALW_FGPFRHI_GPF42     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF42_Pos)
 #define FLASHCALW_FGPFRHI_GPF43_Pos 11           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 43 */
-#define FLASHCALW_FGPFRHI_GPF43     (_U(0x1) << FLASHCALW_FGPFRHI_GPF43_Pos)
+#define FLASHCALW_FGPFRHI_GPF43     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF43_Pos)
 #define FLASHCALW_FGPFRHI_GPF44_Pos 12           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 44 */
-#define FLASHCALW_FGPFRHI_GPF44     (_U(0x1) << FLASHCALW_FGPFRHI_GPF44_Pos)
+#define FLASHCALW_FGPFRHI_GPF44     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF44_Pos)
 #define FLASHCALW_FGPFRHI_GPF45_Pos 13           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 45 */
-#define FLASHCALW_FGPFRHI_GPF45     (_U(0x1) << FLASHCALW_FGPFRHI_GPF45_Pos)
+#define FLASHCALW_FGPFRHI_GPF45     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF45_Pos)
 #define FLASHCALW_FGPFRHI_GPF46_Pos 14           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 46 */
-#define FLASHCALW_FGPFRHI_GPF46     (_U(0x1) << FLASHCALW_FGPFRHI_GPF46_Pos)
+#define FLASHCALW_FGPFRHI_GPF46     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF46_Pos)
 #define FLASHCALW_FGPFRHI_GPF47_Pos 15           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 47 */
-#define FLASHCALW_FGPFRHI_GPF47     (_U(0x1) << FLASHCALW_FGPFRHI_GPF47_Pos)
+#define FLASHCALW_FGPFRHI_GPF47     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF47_Pos)
 #define FLASHCALW_FGPFRHI_GPF48_Pos 16           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 48 */
-#define FLASHCALW_FGPFRHI_GPF48     (_U(0x1) << FLASHCALW_FGPFRHI_GPF48_Pos)
+#define FLASHCALW_FGPFRHI_GPF48     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF48_Pos)
 #define FLASHCALW_FGPFRHI_GPF49_Pos 17           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 49 */
-#define FLASHCALW_FGPFRHI_GPF49     (_U(0x1) << FLASHCALW_FGPFRHI_GPF49_Pos)
+#define FLASHCALW_FGPFRHI_GPF49     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF49_Pos)
 #define FLASHCALW_FGPFRHI_GPF50_Pos 18           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 50 */
-#define FLASHCALW_FGPFRHI_GPF50     (_U(0x1) << FLASHCALW_FGPFRHI_GPF50_Pos)
+#define FLASHCALW_FGPFRHI_GPF50     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF50_Pos)
 #define FLASHCALW_FGPFRHI_GPF51_Pos 19           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 51 */
-#define FLASHCALW_FGPFRHI_GPF51     (_U(0x1) << FLASHCALW_FGPFRHI_GPF51_Pos)
+#define FLASHCALW_FGPFRHI_GPF51     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF51_Pos)
 #define FLASHCALW_FGPFRHI_GPF52_Pos 20           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 52 */
-#define FLASHCALW_FGPFRHI_GPF52     (_U(0x1) << FLASHCALW_FGPFRHI_GPF52_Pos)
+#define FLASHCALW_FGPFRHI_GPF52     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF52_Pos)
 #define FLASHCALW_FGPFRHI_GPF53_Pos 21           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 53 */
-#define FLASHCALW_FGPFRHI_GPF53     (_U(0x1) << FLASHCALW_FGPFRHI_GPF53_Pos)
+#define FLASHCALW_FGPFRHI_GPF53     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF53_Pos)
 #define FLASHCALW_FGPFRHI_GPF54_Pos 22           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 54 */
-#define FLASHCALW_FGPFRHI_GPF54     (_U(0x1) << FLASHCALW_FGPFRHI_GPF54_Pos)
+#define FLASHCALW_FGPFRHI_GPF54     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF54_Pos)
 #define FLASHCALW_FGPFRHI_GPF55_Pos 23           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 55 */
-#define FLASHCALW_FGPFRHI_GPF55     (_U(0x1) << FLASHCALW_FGPFRHI_GPF55_Pos)
+#define FLASHCALW_FGPFRHI_GPF55     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF55_Pos)
 #define FLASHCALW_FGPFRHI_GPF56_Pos 24           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 56 */
-#define FLASHCALW_FGPFRHI_GPF56     (_U(0x1) << FLASHCALW_FGPFRHI_GPF56_Pos)
+#define FLASHCALW_FGPFRHI_GPF56     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF56_Pos)
 #define FLASHCALW_FGPFRHI_GPF57_Pos 25           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 57 */
-#define FLASHCALW_FGPFRHI_GPF57     (_U(0x1) << FLASHCALW_FGPFRHI_GPF57_Pos)
+#define FLASHCALW_FGPFRHI_GPF57     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF57_Pos)
 #define FLASHCALW_FGPFRHI_GPF58_Pos 26           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 58 */
-#define FLASHCALW_FGPFRHI_GPF58     (_U(0x1) << FLASHCALW_FGPFRHI_GPF58_Pos)
+#define FLASHCALW_FGPFRHI_GPF58     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF58_Pos)
 #define FLASHCALW_FGPFRHI_GPF59_Pos 27           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 59 */
-#define FLASHCALW_FGPFRHI_GPF59     (_U(0x1) << FLASHCALW_FGPFRHI_GPF59_Pos)
+#define FLASHCALW_FGPFRHI_GPF59     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF59_Pos)
 #define FLASHCALW_FGPFRHI_GPF60_Pos 28           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 60 */
-#define FLASHCALW_FGPFRHI_GPF60     (_U(0x1) << FLASHCALW_FGPFRHI_GPF60_Pos)
+#define FLASHCALW_FGPFRHI_GPF60     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF60_Pos)
 #define FLASHCALW_FGPFRHI_GPF61_Pos 29           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 61 */
-#define FLASHCALW_FGPFRHI_GPF61     (_U(0x1) << FLASHCALW_FGPFRHI_GPF61_Pos)
+#define FLASHCALW_FGPFRHI_GPF61     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF61_Pos)
 #define FLASHCALW_FGPFRHI_GPF62_Pos 30           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 62 */
-#define FLASHCALW_FGPFRHI_GPF62     (_U(0x1) << FLASHCALW_FGPFRHI_GPF62_Pos)
+#define FLASHCALW_FGPFRHI_GPF62     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF62_Pos)
 #define FLASHCALW_FGPFRHI_GPF63_Pos 31           /**< \brief (FLASHCALW_FGPFRHI) General Purpose Fuse 63 */
-#define FLASHCALW_FGPFRHI_GPF63     (_U(0x1) << FLASHCALW_FGPFRHI_GPF63_Pos)
-#define FLASHCALW_FGPFRHI_MASK      _U(0xFFFFFFFF) /**< \brief (FLASHCALW_FGPFRHI) MASK Register */
+#define FLASHCALW_FGPFRHI_GPF63     (_U_(0x1) << FLASHCALW_FGPFRHI_GPF63_Pos)
+#define FLASHCALW_FGPFRHI_MASK      _U_(0xFFFFFFFF) /**< \brief (FLASHCALW_FGPFRHI) MASK Register */
 
 /* -------- FLASHCALW_FGPFRLO : (FLASHCALW Offset: 0x18) (R/W 32) Flash Controller General Purpose Fuse Register Low -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -444,70 +444,70 @@ typedef union {
 #define FLASHCALW_FGPFRLO_OFFSET    0x18         /**< \brief (FLASHCALW_FGPFRLO offset) Flash Controller General Purpose Fuse Register Low */
 
 #define FLASHCALW_FGPFRLO_LOCK0_Pos 0            /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 0 */
-#define FLASHCALW_FGPFRLO_LOCK0     (_U(0x1) << FLASHCALW_FGPFRLO_LOCK0_Pos)
+#define FLASHCALW_FGPFRLO_LOCK0     (_U_(0x1) << FLASHCALW_FGPFRLO_LOCK0_Pos)
 #define FLASHCALW_FGPFRLO_LOCK1_Pos 1            /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 1 */
-#define FLASHCALW_FGPFRLO_LOCK1     (_U(0x1) << FLASHCALW_FGPFRLO_LOCK1_Pos)
+#define FLASHCALW_FGPFRLO_LOCK1     (_U_(0x1) << FLASHCALW_FGPFRLO_LOCK1_Pos)
 #define FLASHCALW_FGPFRLO_LOCK2_Pos 2            /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 2 */
-#define FLASHCALW_FGPFRLO_LOCK2     (_U(0x1) << FLASHCALW_FGPFRLO_LOCK2_Pos)
+#define FLASHCALW_FGPFRLO_LOCK2     (_U_(0x1) << FLASHCALW_FGPFRLO_LOCK2_Pos)
 #define FLASHCALW_FGPFRLO_LOCK3_Pos 3            /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 3 */
-#define FLASHCALW_FGPFRLO_LOCK3     (_U(0x1) << FLASHCALW_FGPFRLO_LOCK3_Pos)
+#define FLASHCALW_FGPFRLO_LOCK3     (_U_(0x1) << FLASHCALW_FGPFRLO_LOCK3_Pos)
 #define FLASHCALW_FGPFRLO_LOCK4_Pos 4            /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 4 */
-#define FLASHCALW_FGPFRLO_LOCK4     (_U(0x1) << FLASHCALW_FGPFRLO_LOCK4_Pos)
+#define FLASHCALW_FGPFRLO_LOCK4     (_U_(0x1) << FLASHCALW_FGPFRLO_LOCK4_Pos)
 #define FLASHCALW_FGPFRLO_LOCK5_Pos 5            /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 5 */
-#define FLASHCALW_FGPFRLO_LOCK5     (_U(0x1) << FLASHCALW_FGPFRLO_LOCK5_Pos)
+#define FLASHCALW_FGPFRLO_LOCK5     (_U_(0x1) << FLASHCALW_FGPFRLO_LOCK5_Pos)
 #define FLASHCALW_FGPFRLO_LOCK6_Pos 6            /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 6 */
-#define FLASHCALW_FGPFRLO_LOCK6     (_U(0x1) << FLASHCALW_FGPFRLO_LOCK6_Pos)
+#define FLASHCALW_FGPFRLO_LOCK6     (_U_(0x1) << FLASHCALW_FGPFRLO_LOCK6_Pos)
 #define FLASHCALW_FGPFRLO_LOCK7_Pos 7            /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 7 */
-#define FLASHCALW_FGPFRLO_LOCK7     (_U(0x1) << FLASHCALW_FGPFRLO_LOCK7_Pos)
+#define FLASHCALW_FGPFRLO_LOCK7     (_U_(0x1) << FLASHCALW_FGPFRLO_LOCK7_Pos)
 #define FLASHCALW_FGPFRLO_LOCK8_Pos 8            /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 8 */
-#define FLASHCALW_FGPFRLO_LOCK8     (_U(0x1) << FLASHCALW_FGPFRLO_LOCK8_Pos)
+#define FLASHCALW_FGPFRLO_LOCK8     (_U_(0x1) << FLASHCALW_FGPFRLO_LOCK8_Pos)
 #define FLASHCALW_FGPFRLO_LOCK9_Pos 9            /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 9 */
-#define FLASHCALW_FGPFRLO_LOCK9     (_U(0x1) << FLASHCALW_FGPFRLO_LOCK9_Pos)
+#define FLASHCALW_FGPFRLO_LOCK9     (_U_(0x1) << FLASHCALW_FGPFRLO_LOCK9_Pos)
 #define FLASHCALW_FGPFRLO_LOCK10_Pos 10           /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 10 */
-#define FLASHCALW_FGPFRLO_LOCK10    (_U(0x1) << FLASHCALW_FGPFRLO_LOCK10_Pos)
+#define FLASHCALW_FGPFRLO_LOCK10    (_U_(0x1) << FLASHCALW_FGPFRLO_LOCK10_Pos)
 #define FLASHCALW_FGPFRLO_LOCK11_Pos 11           /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 11 */
-#define FLASHCALW_FGPFRLO_LOCK11    (_U(0x1) << FLASHCALW_FGPFRLO_LOCK11_Pos)
+#define FLASHCALW_FGPFRLO_LOCK11    (_U_(0x1) << FLASHCALW_FGPFRLO_LOCK11_Pos)
 #define FLASHCALW_FGPFRLO_LOCK12_Pos 12           /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 12 */
-#define FLASHCALW_FGPFRLO_LOCK12    (_U(0x1) << FLASHCALW_FGPFRLO_LOCK12_Pos)
+#define FLASHCALW_FGPFRLO_LOCK12    (_U_(0x1) << FLASHCALW_FGPFRLO_LOCK12_Pos)
 #define FLASHCALW_FGPFRLO_LOCK13_Pos 13           /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 13 */
-#define FLASHCALW_FGPFRLO_LOCK13    (_U(0x1) << FLASHCALW_FGPFRLO_LOCK13_Pos)
+#define FLASHCALW_FGPFRLO_LOCK13    (_U_(0x1) << FLASHCALW_FGPFRLO_LOCK13_Pos)
 #define FLASHCALW_FGPFRLO_LOCK14_Pos 14           /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 14 */
-#define FLASHCALW_FGPFRLO_LOCK14    (_U(0x1) << FLASHCALW_FGPFRLO_LOCK14_Pos)
+#define FLASHCALW_FGPFRLO_LOCK14    (_U_(0x1) << FLASHCALW_FGPFRLO_LOCK14_Pos)
 #define FLASHCALW_FGPFRLO_LOCK15_Pos 15           /**< \brief (FLASHCALW_FGPFRLO) Lock Bit 15 */
-#define FLASHCALW_FGPFRLO_LOCK15    (_U(0x1) << FLASHCALW_FGPFRLO_LOCK15_Pos)
+#define FLASHCALW_FGPFRLO_LOCK15    (_U_(0x1) << FLASHCALW_FGPFRLO_LOCK15_Pos)
 #define FLASHCALW_FGPFRLO_GPF16_Pos 16           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 16 */
-#define FLASHCALW_FGPFRLO_GPF16     (_U(0x1) << FLASHCALW_FGPFRLO_GPF16_Pos)
+#define FLASHCALW_FGPFRLO_GPF16     (_U_(0x1) << FLASHCALW_FGPFRLO_GPF16_Pos)
 #define FLASHCALW_FGPFRLO_GPF17_Pos 17           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 17 */
-#define FLASHCALW_FGPFRLO_GPF17     (_U(0x1) << FLASHCALW_FGPFRLO_GPF17_Pos)
+#define FLASHCALW_FGPFRLO_GPF17     (_U_(0x1) << FLASHCALW_FGPFRLO_GPF17_Pos)
 #define FLASHCALW_FGPFRLO_GPF18_Pos 18           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 18 */
-#define FLASHCALW_FGPFRLO_GPF18     (_U(0x1) << FLASHCALW_FGPFRLO_GPF18_Pos)
+#define FLASHCALW_FGPFRLO_GPF18     (_U_(0x1) << FLASHCALW_FGPFRLO_GPF18_Pos)
 #define FLASHCALW_FGPFRLO_GPF19_Pos 19           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 19 */
-#define FLASHCALW_FGPFRLO_GPF19     (_U(0x1) << FLASHCALW_FGPFRLO_GPF19_Pos)
+#define FLASHCALW_FGPFRLO_GPF19     (_U_(0x1) << FLASHCALW_FGPFRLO_GPF19_Pos)
 #define FLASHCALW_FGPFRLO_GPF20_Pos 20           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 20 */
-#define FLASHCALW_FGPFRLO_GPF20     (_U(0x1) << FLASHCALW_FGPFRLO_GPF20_Pos)
+#define FLASHCALW_FGPFRLO_GPF20     (_U_(0x1) << FLASHCALW_FGPFRLO_GPF20_Pos)
 #define FLASHCALW_FGPFRLO_GPF21_Pos 21           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 21 */
-#define FLASHCALW_FGPFRLO_GPF21     (_U(0x1) << FLASHCALW_FGPFRLO_GPF21_Pos)
+#define FLASHCALW_FGPFRLO_GPF21     (_U_(0x1) << FLASHCALW_FGPFRLO_GPF21_Pos)
 #define FLASHCALW_FGPFRLO_GPF22_Pos 22           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 22 */
-#define FLASHCALW_FGPFRLO_GPF22     (_U(0x1) << FLASHCALW_FGPFRLO_GPF22_Pos)
+#define FLASHCALW_FGPFRLO_GPF22     (_U_(0x1) << FLASHCALW_FGPFRLO_GPF22_Pos)
 #define FLASHCALW_FGPFRLO_GPF23_Pos 23           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 23 */
-#define FLASHCALW_FGPFRLO_GPF23     (_U(0x1) << FLASHCALW_FGPFRLO_GPF23_Pos)
+#define FLASHCALW_FGPFRLO_GPF23     (_U_(0x1) << FLASHCALW_FGPFRLO_GPF23_Pos)
 #define FLASHCALW_FGPFRLO_GPF24_Pos 24           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 24 */
-#define FLASHCALW_FGPFRLO_GPF24     (_U(0x1) << FLASHCALW_FGPFRLO_GPF24_Pos)
+#define FLASHCALW_FGPFRLO_GPF24     (_U_(0x1) << FLASHCALW_FGPFRLO_GPF24_Pos)
 #define FLASHCALW_FGPFRLO_GPF25_Pos 25           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 25 */
-#define FLASHCALW_FGPFRLO_GPF25     (_U(0x1) << FLASHCALW_FGPFRLO_GPF25_Pos)
+#define FLASHCALW_FGPFRLO_GPF25     (_U_(0x1) << FLASHCALW_FGPFRLO_GPF25_Pos)
 #define FLASHCALW_FGPFRLO_GPF26_Pos 26           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 26 */
-#define FLASHCALW_FGPFRLO_GPF26     (_U(0x1) << FLASHCALW_FGPFRLO_GPF26_Pos)
+#define FLASHCALW_FGPFRLO_GPF26     (_U_(0x1) << FLASHCALW_FGPFRLO_GPF26_Pos)
 #define FLASHCALW_FGPFRLO_GPF27_Pos 27           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 27 */
-#define FLASHCALW_FGPFRLO_GPF27     (_U(0x1) << FLASHCALW_FGPFRLO_GPF27_Pos)
+#define FLASHCALW_FGPFRLO_GPF27     (_U_(0x1) << FLASHCALW_FGPFRLO_GPF27_Pos)
 #define FLASHCALW_FGPFRLO_GPF28_Pos 28           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 28 */
-#define FLASHCALW_FGPFRLO_GPF28     (_U(0x1) << FLASHCALW_FGPFRLO_GPF28_Pos)
+#define FLASHCALW_FGPFRLO_GPF28     (_U_(0x1) << FLASHCALW_FGPFRLO_GPF28_Pos)
 #define FLASHCALW_FGPFRLO_GPF29_Pos 29           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 29 */
-#define FLASHCALW_FGPFRLO_GPF29     (_U(0x1) << FLASHCALW_FGPFRLO_GPF29_Pos)
+#define FLASHCALW_FGPFRLO_GPF29     (_U_(0x1) << FLASHCALW_FGPFRLO_GPF29_Pos)
 #define FLASHCALW_FGPFRLO_GPF30_Pos 30           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 30 */
-#define FLASHCALW_FGPFRLO_GPF30     (_U(0x1) << FLASHCALW_FGPFRLO_GPF30_Pos)
+#define FLASHCALW_FGPFRLO_GPF30     (_U_(0x1) << FLASHCALW_FGPFRLO_GPF30_Pos)
 #define FLASHCALW_FGPFRLO_GPF31_Pos 31           /**< \brief (FLASHCALW_FGPFRLO) General Purpose Fuse 31 */
-#define FLASHCALW_FGPFRLO_GPF31     (_U(0x1) << FLASHCALW_FGPFRLO_GPF31_Pos)
-#define FLASHCALW_FGPFRLO_MASK      _U(0xFFFFFFFF) /**< \brief (FLASHCALW_FGPFRLO) MASK Register */
+#define FLASHCALW_FGPFRLO_GPF31     (_U_(0x1) << FLASHCALW_FGPFRLO_GPF31_Pos)
+#define FLASHCALW_FGPFRLO_MASK      _U_(0xFFFFFFFF) /**< \brief (FLASHCALW_FGPFRLO) MASK Register */
 
 /** \brief FLASHCALW APB hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -548,43 +548,43 @@ typedef union {
 
 #define FUSES_BOD18ACTION_ADDR      HFLASHC_USER
 #define FUSES_BOD18ACTION_Pos       18           /**< \brief (HFLASHC_USER) BOD18 Action */
-#define FUSES_BOD18ACTION_Msk       (_U(0x3) << FUSES_BOD18ACTION_Pos)
+#define FUSES_BOD18ACTION_Msk       (_U_(0x3) << FUSES_BOD18ACTION_Pos)
 #define FUSES_BOD18ACTION(value)    (FUSES_BOD18ACTION_Msk & ((value) << FUSES_BOD18ACTION_Pos))
 
 #define FUSES_BOD18EN_ADDR          HFLASHC_USER
 #define FUSES_BOD18EN_Pos           17           /**< \brief (HFLASHC_USER) BOD18 Enable */
-#define FUSES_BOD18EN_Msk           (_U(0x1) << FUSES_BOD18EN_Pos)
+#define FUSES_BOD18EN_Msk           (_U_(0x1) << FUSES_BOD18EN_Pos)
 
 #define FUSES_BOD18HYST_ADDR        HFLASHC_USER
 #define FUSES_BOD18HYST_Pos         20           /**< \brief (HFLASHC_USER) BOD18 Hysteresis */
-#define FUSES_BOD18HYST_Msk         (_U(0x1) << FUSES_BOD18HYST_Pos)
+#define FUSES_BOD18HYST_Msk         (_U_(0x1) << FUSES_BOD18HYST_Pos)
 
 #define FUSES_BOD18LV_ADDR          HFLASHC_USER
 #define FUSES_BOD18LV_Pos           11           /**< \brief (HFLASHC_USER) BOD18 Level */
-#define FUSES_BOD18LV_Msk           (_U(0x3F) << FUSES_BOD18LV_Pos)
+#define FUSES_BOD18LV_Msk           (_U_(0x3F) << FUSES_BOD18LV_Pos)
 #define FUSES_BOD18LV(value)        (FUSES_BOD18LV_Msk & ((value) << FUSES_BOD18LV_Pos))
 
 #define FUSES_BOD33ACTION_ADDR      HFLASHC_USER
 #define FUSES_BOD33ACTION_Pos       8            /**< \brief (HFLASHC_USER) BOD33 Action */
-#define FUSES_BOD33ACTION_Msk       (_U(0x3) << FUSES_BOD33ACTION_Pos)
+#define FUSES_BOD33ACTION_Msk       (_U_(0x3) << FUSES_BOD33ACTION_Pos)
 #define FUSES_BOD33ACTION(value)    (FUSES_BOD33ACTION_Msk & ((value) << FUSES_BOD33ACTION_Pos))
 
 #define FUSES_BOD33EN_ADDR          HFLASHC_USER
 #define FUSES_BOD33EN_Pos           7            /**< \brief (HFLASHC_USER) BOD33 Enable */
-#define FUSES_BOD33EN_Msk           (_U(0x1) << FUSES_BOD33EN_Pos)
+#define FUSES_BOD33EN_Msk           (_U_(0x1) << FUSES_BOD33EN_Pos)
 
 #define FUSES_BOD33LEVEL_ADDR       HFLASHC_USER
 #define FUSES_BOD33LEVEL_Pos        1            /**< \brief (HFLASHC_USER) BOD33 Level */
-#define FUSES_BOD33LEVEL_Msk        (_U(0x3F) << FUSES_BOD33LEVEL_Pos)
+#define FUSES_BOD33LEVEL_Msk        (_U_(0x3F) << FUSES_BOD33LEVEL_Pos)
 #define FUSES_BOD33LEVEL(value)     (FUSES_BOD33LEVEL_Msk & ((value) << FUSES_BOD33LEVEL_Pos))
 
 #define FUSES_BOD33_HYST_ADDR       HFLASHC_USER
 #define FUSES_BOD33_HYST_Pos        10           /**< \brief (HFLASHC_USER) BOD33 Hysteresis */
-#define FUSES_BOD33_HYST_Msk        (_U(0x1) << FUSES_BOD33_HYST_Pos)
+#define FUSES_BOD33_HYST_Msk        (_U_(0x1) << FUSES_BOD33_HYST_Pos)
 
 #define WDT_FUSES_WDTAUTO_ADDR      HFLASHC_USER
 #define WDT_FUSES_WDTAUTO_Pos       0            /**< \brief (HFLASHC_USER) Watchdog Enabled at Reset */
-#define WDT_FUSES_WDTAUTO_Msk       (_U(0x1) << WDT_FUSES_WDTAUTO_Pos)
+#define WDT_FUSES_WDTAUTO_Msk       (_U_(0x1) << WDT_FUSES_WDTAUTO_Pos)
 
 /*@}*/
 

--- a/asf/sam/include/sam4l/component/freqm.h
+++ b/asf/sam/include/sam4l/component/freqm.h
@@ -50,11 +50,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define FREQM_CTRL_OFFSET           0x000        /**< \brief (FREQM_CTRL offset) Control register */
-#define FREQM_CTRL_RESETVALUE       _U(0x00000000); /**< \brief (FREQM_CTRL reset_value) Control register */
+#define FREQM_CTRL_RESETVALUE       _U_(0x00000000); /**< \brief (FREQM_CTRL reset_value) Control register */
 
 #define FREQM_CTRL_START_Pos        0            /**< \brief (FREQM_CTRL) Start frequency measurement */
-#define FREQM_CTRL_START            (_U(0x1) << FREQM_CTRL_START_Pos)
-#define FREQM_CTRL_MASK             _U(0x00000001) /**< \brief (FREQM_CTRL) MASK Register */
+#define FREQM_CTRL_START            (_U_(0x1) << FREQM_CTRL_START_Pos)
+#define FREQM_CTRL_MASK             _U_(0x00000001) /**< \brief (FREQM_CTRL) MASK Register */
 
 /* -------- FREQM_MODE : (FREQM Offset: 0x004) (R/W 32) Mode  register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -72,20 +72,20 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define FREQM_MODE_OFFSET           0x004        /**< \brief (FREQM_MODE offset) Mode  register */
-#define FREQM_MODE_RESETVALUE       _U(0x00000000); /**< \brief (FREQM_MODE reset_value) Mode  register */
+#define FREQM_MODE_RESETVALUE       _U_(0x00000000); /**< \brief (FREQM_MODE reset_value) Mode  register */
 
 #define FREQM_MODE_REFSEL_Pos       0            /**< \brief (FREQM_MODE) Reference Clock Selection */
-#define FREQM_MODE_REFSEL_Msk       (_U(0x3) << FREQM_MODE_REFSEL_Pos)
+#define FREQM_MODE_REFSEL_Msk       (_U_(0x3) << FREQM_MODE_REFSEL_Pos)
 #define FREQM_MODE_REFSEL(value)    (FREQM_MODE_REFSEL_Msk & ((value) << FREQM_MODE_REFSEL_Pos))
 #define FREQM_MODE_REFNUM_Pos       8            /**< \brief (FREQM_MODE) Number of Reference CLock Cycles */
-#define FREQM_MODE_REFNUM_Msk       (_U(0xFF) << FREQM_MODE_REFNUM_Pos)
+#define FREQM_MODE_REFNUM_Msk       (_U_(0xFF) << FREQM_MODE_REFNUM_Pos)
 #define FREQM_MODE_REFNUM(value)    (FREQM_MODE_REFNUM_Msk & ((value) << FREQM_MODE_REFNUM_Pos))
 #define FREQM_MODE_CLKSEL_Pos       16           /**< \brief (FREQM_MODE) Clock Source Selection */
-#define FREQM_MODE_CLKSEL_Msk       (_U(0x1F) << FREQM_MODE_CLKSEL_Pos)
+#define FREQM_MODE_CLKSEL_Msk       (_U_(0x1F) << FREQM_MODE_CLKSEL_Pos)
 #define FREQM_MODE_CLKSEL(value)    (FREQM_MODE_CLKSEL_Msk & ((value) << FREQM_MODE_CLKSEL_Pos))
 #define FREQM_MODE_REFCEN_Pos       31           /**< \brief (FREQM_MODE) Reference Clock Enable */
-#define FREQM_MODE_REFCEN           (_U(0x1) << FREQM_MODE_REFCEN_Pos)
-#define FREQM_MODE_MASK             _U(0x801FFF03) /**< \brief (FREQM_MODE) MASK Register */
+#define FREQM_MODE_REFCEN           (_U_(0x1) << FREQM_MODE_REFCEN_Pos)
+#define FREQM_MODE_MASK             _U_(0x801FFF03) /**< \brief (FREQM_MODE) MASK Register */
 
 /* -------- FREQM_STATUS : (FREQM Offset: 0x008) (R/  32) Status  register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -100,13 +100,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define FREQM_STATUS_OFFSET         0x008        /**< \brief (FREQM_STATUS offset) Status  register */
-#define FREQM_STATUS_RESETVALUE     _U(0x00000000); /**< \brief (FREQM_STATUS reset_value) Status  register */
+#define FREQM_STATUS_RESETVALUE     _U_(0x00000000); /**< \brief (FREQM_STATUS reset_value) Status  register */
 
 #define FREQM_STATUS_BUSY_Pos       0            /**< \brief (FREQM_STATUS) Frequency measurement on-going */
-#define FREQM_STATUS_BUSY           (_U(0x1) << FREQM_STATUS_BUSY_Pos)
+#define FREQM_STATUS_BUSY           (_U_(0x1) << FREQM_STATUS_BUSY_Pos)
 #define FREQM_STATUS_RCLKBUSY_Pos   1            /**< \brief (FREQM_STATUS) Reference Clock busy */
-#define FREQM_STATUS_RCLKBUSY       (_U(0x1) << FREQM_STATUS_RCLKBUSY_Pos)
-#define FREQM_STATUS_MASK           _U(0x00000003) /**< \brief (FREQM_STATUS) MASK Register */
+#define FREQM_STATUS_RCLKBUSY       (_U_(0x1) << FREQM_STATUS_RCLKBUSY_Pos)
+#define FREQM_STATUS_MASK           _U_(0x00000003) /**< \brief (FREQM_STATUS) MASK Register */
 
 /* -------- FREQM_VALUE : (FREQM Offset: 0x00C) (R/  32) Value register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -120,12 +120,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define FREQM_VALUE_OFFSET          0x00C        /**< \brief (FREQM_VALUE offset) Value register */
-#define FREQM_VALUE_RESETVALUE      _U(0x00000000); /**< \brief (FREQM_VALUE reset_value) Value register */
+#define FREQM_VALUE_RESETVALUE      _U_(0x00000000); /**< \brief (FREQM_VALUE reset_value) Value register */
 
 #define FREQM_VALUE_VALUE_Pos       0            /**< \brief (FREQM_VALUE) Measured frequency */
-#define FREQM_VALUE_VALUE_Msk       (_U(0xFFFFFF) << FREQM_VALUE_VALUE_Pos)
+#define FREQM_VALUE_VALUE_Msk       (_U_(0xFFFFFF) << FREQM_VALUE_VALUE_Pos)
 #define FREQM_VALUE_VALUE(value)    (FREQM_VALUE_VALUE_Msk & ((value) << FREQM_VALUE_VALUE_Pos))
-#define FREQM_VALUE_MASK            _U(0x00FFFFFF) /**< \brief (FREQM_VALUE) MASK Register */
+#define FREQM_VALUE_MASK            _U_(0x00FFFFFF) /**< \brief (FREQM_VALUE) MASK Register */
 
 /* -------- FREQM_IER : (FREQM Offset: 0x010) ( /W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -140,13 +140,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define FREQM_IER_OFFSET            0x010        /**< \brief (FREQM_IER offset) Interrupt Enable Register */
-#define FREQM_IER_RESETVALUE        _U(0x00000000); /**< \brief (FREQM_IER reset_value) Interrupt Enable Register */
+#define FREQM_IER_RESETVALUE        _U_(0x00000000); /**< \brief (FREQM_IER reset_value) Interrupt Enable Register */
 
 #define FREQM_IER_DONE_Pos          0            /**< \brief (FREQM_IER) Frequency measurment done */
-#define FREQM_IER_DONE              (_U(0x1) << FREQM_IER_DONE_Pos)
+#define FREQM_IER_DONE              (_U_(0x1) << FREQM_IER_DONE_Pos)
 #define FREQM_IER_RCLKRDY_Pos       1            /**< \brief (FREQM_IER) Reference Clock ready */
-#define FREQM_IER_RCLKRDY           (_U(0x1) << FREQM_IER_RCLKRDY_Pos)
-#define FREQM_IER_MASK              _U(0x00000003) /**< \brief (FREQM_IER) MASK Register */
+#define FREQM_IER_RCLKRDY           (_U_(0x1) << FREQM_IER_RCLKRDY_Pos)
+#define FREQM_IER_MASK              _U_(0x00000003) /**< \brief (FREQM_IER) MASK Register */
 
 /* -------- FREQM_IDR : (FREQM Offset: 0x014) ( /W 32) Interrupt Diable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -161,13 +161,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define FREQM_IDR_OFFSET            0x014        /**< \brief (FREQM_IDR offset) Interrupt Diable Register */
-#define FREQM_IDR_RESETVALUE        _U(0x00000000); /**< \brief (FREQM_IDR reset_value) Interrupt Diable Register */
+#define FREQM_IDR_RESETVALUE        _U_(0x00000000); /**< \brief (FREQM_IDR reset_value) Interrupt Diable Register */
 
 #define FREQM_IDR_DONE_Pos          0            /**< \brief (FREQM_IDR) Frequency measurment done */
-#define FREQM_IDR_DONE              (_U(0x1) << FREQM_IDR_DONE_Pos)
+#define FREQM_IDR_DONE              (_U_(0x1) << FREQM_IDR_DONE_Pos)
 #define FREQM_IDR_RCLKRDY_Pos       1            /**< \brief (FREQM_IDR) Reference Clock ready */
-#define FREQM_IDR_RCLKRDY           (_U(0x1) << FREQM_IDR_RCLKRDY_Pos)
-#define FREQM_IDR_MASK              _U(0x00000003) /**< \brief (FREQM_IDR) MASK Register */
+#define FREQM_IDR_RCLKRDY           (_U_(0x1) << FREQM_IDR_RCLKRDY_Pos)
+#define FREQM_IDR_MASK              _U_(0x00000003) /**< \brief (FREQM_IDR) MASK Register */
 
 /* -------- FREQM_IMR : (FREQM Offset: 0x018) (R/  32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -182,13 +182,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define FREQM_IMR_OFFSET            0x018        /**< \brief (FREQM_IMR offset) Interrupt Mask Register */
-#define FREQM_IMR_RESETVALUE        _U(0x00000000); /**< \brief (FREQM_IMR reset_value) Interrupt Mask Register */
+#define FREQM_IMR_RESETVALUE        _U_(0x00000000); /**< \brief (FREQM_IMR reset_value) Interrupt Mask Register */
 
 #define FREQM_IMR_DONE_Pos          0            /**< \brief (FREQM_IMR) Frequency measurment done */
-#define FREQM_IMR_DONE              (_U(0x1) << FREQM_IMR_DONE_Pos)
+#define FREQM_IMR_DONE              (_U_(0x1) << FREQM_IMR_DONE_Pos)
 #define FREQM_IMR_RCLKRDY_Pos       1            /**< \brief (FREQM_IMR) Reference Clock ready */
-#define FREQM_IMR_RCLKRDY           (_U(0x1) << FREQM_IMR_RCLKRDY_Pos)
-#define FREQM_IMR_MASK              _U(0x00000003) /**< \brief (FREQM_IMR) MASK Register */
+#define FREQM_IMR_RCLKRDY           (_U_(0x1) << FREQM_IMR_RCLKRDY_Pos)
+#define FREQM_IMR_MASK              _U_(0x00000003) /**< \brief (FREQM_IMR) MASK Register */
 
 /* -------- FREQM_ISR : (FREQM Offset: 0x01C) (R/  32) Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -203,13 +203,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define FREQM_ISR_OFFSET            0x01C        /**< \brief (FREQM_ISR offset) Interrupt Status Register */
-#define FREQM_ISR_RESETVALUE        _U(0x00000000); /**< \brief (FREQM_ISR reset_value) Interrupt Status Register */
+#define FREQM_ISR_RESETVALUE        _U_(0x00000000); /**< \brief (FREQM_ISR reset_value) Interrupt Status Register */
 
 #define FREQM_ISR_DONE_Pos          0            /**< \brief (FREQM_ISR) Frequency measurment done */
-#define FREQM_ISR_DONE              (_U(0x1) << FREQM_ISR_DONE_Pos)
+#define FREQM_ISR_DONE              (_U_(0x1) << FREQM_ISR_DONE_Pos)
 #define FREQM_ISR_RCLKRDY_Pos       1            /**< \brief (FREQM_ISR) Reference Clock ready */
-#define FREQM_ISR_RCLKRDY           (_U(0x1) << FREQM_ISR_RCLKRDY_Pos)
-#define FREQM_ISR_MASK              _U(0x00000003) /**< \brief (FREQM_ISR) MASK Register */
+#define FREQM_ISR_RCLKRDY           (_U_(0x1) << FREQM_ISR_RCLKRDY_Pos)
+#define FREQM_ISR_MASK              _U_(0x00000003) /**< \brief (FREQM_ISR) MASK Register */
 
 /* -------- FREQM_ICR : (FREQM Offset: 0x020) ( /W 32) Interrupt Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -224,13 +224,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define FREQM_ICR_OFFSET            0x020        /**< \brief (FREQM_ICR offset) Interrupt Clear Register */
-#define FREQM_ICR_RESETVALUE        _U(0x00000000); /**< \brief (FREQM_ICR reset_value) Interrupt Clear Register */
+#define FREQM_ICR_RESETVALUE        _U_(0x00000000); /**< \brief (FREQM_ICR reset_value) Interrupt Clear Register */
 
 #define FREQM_ICR_DONE_Pos          0            /**< \brief (FREQM_ICR) Frequency measurment done */
-#define FREQM_ICR_DONE              (_U(0x1) << FREQM_ICR_DONE_Pos)
+#define FREQM_ICR_DONE              (_U_(0x1) << FREQM_ICR_DONE_Pos)
 #define FREQM_ICR_RCLKRDY_Pos       1            /**< \brief (FREQM_ICR) Reference Clock ready */
-#define FREQM_ICR_RCLKRDY           (_U(0x1) << FREQM_ICR_RCLKRDY_Pos)
-#define FREQM_ICR_MASK              _U(0x00000003) /**< \brief (FREQM_ICR) MASK Register */
+#define FREQM_ICR_RCLKRDY           (_U_(0x1) << FREQM_ICR_RCLKRDY_Pos)
+#define FREQM_ICR_MASK              _U_(0x00000003) /**< \brief (FREQM_ICR) MASK Register */
 
 /* -------- FREQM_VERSION : (FREQM Offset: 0x3FC) (R/  32) Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -246,15 +246,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define FREQM_VERSION_OFFSET        0x3FC        /**< \brief (FREQM_VERSION offset) Version Register */
-#define FREQM_VERSION_RESETVALUE    _U(0x00000311); /**< \brief (FREQM_VERSION reset_value) Version Register */
+#define FREQM_VERSION_RESETVALUE    _U_(0x00000311); /**< \brief (FREQM_VERSION reset_value) Version Register */
 
 #define FREQM_VERSION_VERSION_Pos   0            /**< \brief (FREQM_VERSION) Version number */
-#define FREQM_VERSION_VERSION_Msk   (_U(0xFFF) << FREQM_VERSION_VERSION_Pos)
+#define FREQM_VERSION_VERSION_Msk   (_U_(0xFFF) << FREQM_VERSION_VERSION_Pos)
 #define FREQM_VERSION_VERSION(value) (FREQM_VERSION_VERSION_Msk & ((value) << FREQM_VERSION_VERSION_Pos))
 #define FREQM_VERSION_VARIANT_Pos   16           /**< \brief (FREQM_VERSION) Variant number */
-#define FREQM_VERSION_VARIANT_Msk   (_U(0xF) << FREQM_VERSION_VARIANT_Pos)
+#define FREQM_VERSION_VARIANT_Msk   (_U_(0xF) << FREQM_VERSION_VARIANT_Pos)
 #define FREQM_VERSION_VARIANT(value) (FREQM_VERSION_VARIANT_Msk & ((value) << FREQM_VERSION_VARIANT_Pos))
-#define FREQM_VERSION_MASK          _U(0x000F0FFF) /**< \brief (FREQM_VERSION) MASK Register */
+#define FREQM_VERSION_MASK          _U_(0x000F0FFF) /**< \brief (FREQM_VERSION) MASK Register */
 
 /** \brief FREQM hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/freqm.h
+++ b/asf/sam/include/sam4l/component/freqm.h
@@ -1,0 +1,293 @@
+/**
+ * \file
+ *
+ * \brief Component description for FREQM
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_FREQM_COMPONENT_
+#define _SAM4L_FREQM_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR FREQM */
+/* ========================================================================== */
+/** \addtogroup SAM4L_FREQM Frequency Meter */
+/*@{*/
+
+#define FREQM_I7530
+#define REV_FREQM                   0x311
+
+/* -------- FREQM_CTRL : (FREQM Offset: 0x000) ( /W 32) Control register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t START:1;          /*!< bit:      0  Start frequency measurement        */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} FREQM_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_CTRL_OFFSET           0x000        /**< \brief (FREQM_CTRL offset) Control register */
+#define FREQM_CTRL_RESETVALUE       _U(0x00000000); /**< \brief (FREQM_CTRL reset_value) Control register */
+
+#define FREQM_CTRL_START_Pos        0            /**< \brief (FREQM_CTRL) Start frequency measurement */
+#define FREQM_CTRL_START            (_U(0x1) << FREQM_CTRL_START_Pos)
+#define FREQM_CTRL_MASK             _U(0x00000001) /**< \brief (FREQM_CTRL) MASK Register */
+
+/* -------- FREQM_MODE : (FREQM Offset: 0x004) (R/W 32) Mode  register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t REFSEL:2;         /*!< bit:  0.. 1  Reference Clock Selection          */
+    uint32_t :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint32_t REFNUM:8;         /*!< bit:  8..15  Number of Reference CLock Cycles   */
+    uint32_t CLKSEL:5;         /*!< bit: 16..20  Clock Source Selection             */
+    uint32_t :10;              /*!< bit: 21..30  Reserved                           */
+    uint32_t REFCEN:1;         /*!< bit:     31  Reference Clock Enable             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} FREQM_MODE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_MODE_OFFSET           0x004        /**< \brief (FREQM_MODE offset) Mode  register */
+#define FREQM_MODE_RESETVALUE       _U(0x00000000); /**< \brief (FREQM_MODE reset_value) Mode  register */
+
+#define FREQM_MODE_REFSEL_Pos       0            /**< \brief (FREQM_MODE) Reference Clock Selection */
+#define FREQM_MODE_REFSEL_Msk       (_U(0x3) << FREQM_MODE_REFSEL_Pos)
+#define FREQM_MODE_REFSEL(value)    (FREQM_MODE_REFSEL_Msk & ((value) << FREQM_MODE_REFSEL_Pos))
+#define FREQM_MODE_REFNUM_Pos       8            /**< \brief (FREQM_MODE) Number of Reference CLock Cycles */
+#define FREQM_MODE_REFNUM_Msk       (_U(0xFF) << FREQM_MODE_REFNUM_Pos)
+#define FREQM_MODE_REFNUM(value)    (FREQM_MODE_REFNUM_Msk & ((value) << FREQM_MODE_REFNUM_Pos))
+#define FREQM_MODE_CLKSEL_Pos       16           /**< \brief (FREQM_MODE) Clock Source Selection */
+#define FREQM_MODE_CLKSEL_Msk       (_U(0x1F) << FREQM_MODE_CLKSEL_Pos)
+#define FREQM_MODE_CLKSEL(value)    (FREQM_MODE_CLKSEL_Msk & ((value) << FREQM_MODE_CLKSEL_Pos))
+#define FREQM_MODE_REFCEN_Pos       31           /**< \brief (FREQM_MODE) Reference Clock Enable */
+#define FREQM_MODE_REFCEN           (_U(0x1) << FREQM_MODE_REFCEN_Pos)
+#define FREQM_MODE_MASK             _U(0x801FFF03) /**< \brief (FREQM_MODE) MASK Register */
+
+/* -------- FREQM_STATUS : (FREQM Offset: 0x008) (R/  32) Status  register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t BUSY:1;           /*!< bit:      0  Frequency measurement on-going     */
+    uint32_t RCLKBUSY:1;       /*!< bit:      1  Reference Clock busy               */
+    uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} FREQM_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_STATUS_OFFSET         0x008        /**< \brief (FREQM_STATUS offset) Status  register */
+#define FREQM_STATUS_RESETVALUE     _U(0x00000000); /**< \brief (FREQM_STATUS reset_value) Status  register */
+
+#define FREQM_STATUS_BUSY_Pos       0            /**< \brief (FREQM_STATUS) Frequency measurement on-going */
+#define FREQM_STATUS_BUSY           (_U(0x1) << FREQM_STATUS_BUSY_Pos)
+#define FREQM_STATUS_RCLKBUSY_Pos   1            /**< \brief (FREQM_STATUS) Reference Clock busy */
+#define FREQM_STATUS_RCLKBUSY       (_U(0x1) << FREQM_STATUS_RCLKBUSY_Pos)
+#define FREQM_STATUS_MASK           _U(0x00000003) /**< \brief (FREQM_STATUS) MASK Register */
+
+/* -------- FREQM_VALUE : (FREQM Offset: 0x00C) (R/  32) Value register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VALUE:24;         /*!< bit:  0..23  Measured frequency                 */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} FREQM_VALUE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_VALUE_OFFSET          0x00C        /**< \brief (FREQM_VALUE offset) Value register */
+#define FREQM_VALUE_RESETVALUE      _U(0x00000000); /**< \brief (FREQM_VALUE reset_value) Value register */
+
+#define FREQM_VALUE_VALUE_Pos       0            /**< \brief (FREQM_VALUE) Measured frequency */
+#define FREQM_VALUE_VALUE_Msk       (_U(0xFFFFFF) << FREQM_VALUE_VALUE_Pos)
+#define FREQM_VALUE_VALUE(value)    (FREQM_VALUE_VALUE_Msk & ((value) << FREQM_VALUE_VALUE_Pos))
+#define FREQM_VALUE_MASK            _U(0x00FFFFFF) /**< \brief (FREQM_VALUE) MASK Register */
+
+/* -------- FREQM_IER : (FREQM Offset: 0x010) ( /W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DONE:1;           /*!< bit:      0  Frequency measurment done          */
+    uint32_t RCLKRDY:1;        /*!< bit:      1  Reference Clock ready              */
+    uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} FREQM_IER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_IER_OFFSET            0x010        /**< \brief (FREQM_IER offset) Interrupt Enable Register */
+#define FREQM_IER_RESETVALUE        _U(0x00000000); /**< \brief (FREQM_IER reset_value) Interrupt Enable Register */
+
+#define FREQM_IER_DONE_Pos          0            /**< \brief (FREQM_IER) Frequency measurment done */
+#define FREQM_IER_DONE              (_U(0x1) << FREQM_IER_DONE_Pos)
+#define FREQM_IER_RCLKRDY_Pos       1            /**< \brief (FREQM_IER) Reference Clock ready */
+#define FREQM_IER_RCLKRDY           (_U(0x1) << FREQM_IER_RCLKRDY_Pos)
+#define FREQM_IER_MASK              _U(0x00000003) /**< \brief (FREQM_IER) MASK Register */
+
+/* -------- FREQM_IDR : (FREQM Offset: 0x014) ( /W 32) Interrupt Diable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DONE:1;           /*!< bit:      0  Frequency measurment done          */
+    uint32_t RCLKRDY:1;        /*!< bit:      1  Reference Clock ready              */
+    uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} FREQM_IDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_IDR_OFFSET            0x014        /**< \brief (FREQM_IDR offset) Interrupt Diable Register */
+#define FREQM_IDR_RESETVALUE        _U(0x00000000); /**< \brief (FREQM_IDR reset_value) Interrupt Diable Register */
+
+#define FREQM_IDR_DONE_Pos          0            /**< \brief (FREQM_IDR) Frequency measurment done */
+#define FREQM_IDR_DONE              (_U(0x1) << FREQM_IDR_DONE_Pos)
+#define FREQM_IDR_RCLKRDY_Pos       1            /**< \brief (FREQM_IDR) Reference Clock ready */
+#define FREQM_IDR_RCLKRDY           (_U(0x1) << FREQM_IDR_RCLKRDY_Pos)
+#define FREQM_IDR_MASK              _U(0x00000003) /**< \brief (FREQM_IDR) MASK Register */
+
+/* -------- FREQM_IMR : (FREQM Offset: 0x018) (R/  32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DONE:1;           /*!< bit:      0  Frequency measurment done          */
+    uint32_t RCLKRDY:1;        /*!< bit:      1  Reference Clock ready              */
+    uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} FREQM_IMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_IMR_OFFSET            0x018        /**< \brief (FREQM_IMR offset) Interrupt Mask Register */
+#define FREQM_IMR_RESETVALUE        _U(0x00000000); /**< \brief (FREQM_IMR reset_value) Interrupt Mask Register */
+
+#define FREQM_IMR_DONE_Pos          0            /**< \brief (FREQM_IMR) Frequency measurment done */
+#define FREQM_IMR_DONE              (_U(0x1) << FREQM_IMR_DONE_Pos)
+#define FREQM_IMR_RCLKRDY_Pos       1            /**< \brief (FREQM_IMR) Reference Clock ready */
+#define FREQM_IMR_RCLKRDY           (_U(0x1) << FREQM_IMR_RCLKRDY_Pos)
+#define FREQM_IMR_MASK              _U(0x00000003) /**< \brief (FREQM_IMR) MASK Register */
+
+/* -------- FREQM_ISR : (FREQM Offset: 0x01C) (R/  32) Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DONE:1;           /*!< bit:      0  Frequency measurment done          */
+    uint32_t RCLKRDY:1;        /*!< bit:      1  Reference Clock ready              */
+    uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} FREQM_ISR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_ISR_OFFSET            0x01C        /**< \brief (FREQM_ISR offset) Interrupt Status Register */
+#define FREQM_ISR_RESETVALUE        _U(0x00000000); /**< \brief (FREQM_ISR reset_value) Interrupt Status Register */
+
+#define FREQM_ISR_DONE_Pos          0            /**< \brief (FREQM_ISR) Frequency measurment done */
+#define FREQM_ISR_DONE              (_U(0x1) << FREQM_ISR_DONE_Pos)
+#define FREQM_ISR_RCLKRDY_Pos       1            /**< \brief (FREQM_ISR) Reference Clock ready */
+#define FREQM_ISR_RCLKRDY           (_U(0x1) << FREQM_ISR_RCLKRDY_Pos)
+#define FREQM_ISR_MASK              _U(0x00000003) /**< \brief (FREQM_ISR) MASK Register */
+
+/* -------- FREQM_ICR : (FREQM Offset: 0x020) ( /W 32) Interrupt Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DONE:1;           /*!< bit:      0  Frequency measurment done          */
+    uint32_t RCLKRDY:1;        /*!< bit:      1  Reference Clock ready              */
+    uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} FREQM_ICR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_ICR_OFFSET            0x020        /**< \brief (FREQM_ICR offset) Interrupt Clear Register */
+#define FREQM_ICR_RESETVALUE        _U(0x00000000); /**< \brief (FREQM_ICR reset_value) Interrupt Clear Register */
+
+#define FREQM_ICR_DONE_Pos          0            /**< \brief (FREQM_ICR) Frequency measurment done */
+#define FREQM_ICR_DONE              (_U(0x1) << FREQM_ICR_DONE_Pos)
+#define FREQM_ICR_RCLKRDY_Pos       1            /**< \brief (FREQM_ICR) Reference Clock ready */
+#define FREQM_ICR_RCLKRDY           (_U(0x1) << FREQM_ICR_RCLKRDY_Pos)
+#define FREQM_ICR_MASK              _U(0x00000003) /**< \brief (FREQM_ICR) MASK Register */
+
+/* -------- FREQM_VERSION : (FREQM Offset: 0x3FC) (R/  32) Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} FREQM_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define FREQM_VERSION_OFFSET        0x3FC        /**< \brief (FREQM_VERSION offset) Version Register */
+#define FREQM_VERSION_RESETVALUE    _U(0x00000311); /**< \brief (FREQM_VERSION reset_value) Version Register */
+
+#define FREQM_VERSION_VERSION_Pos   0            /**< \brief (FREQM_VERSION) Version number */
+#define FREQM_VERSION_VERSION_Msk   (_U(0xFFF) << FREQM_VERSION_VERSION_Pos)
+#define FREQM_VERSION_VERSION(value) (FREQM_VERSION_VERSION_Msk & ((value) << FREQM_VERSION_VERSION_Pos))
+#define FREQM_VERSION_VARIANT_Pos   16           /**< \brief (FREQM_VERSION) Variant number */
+#define FREQM_VERSION_VARIANT_Msk   (_U(0xF) << FREQM_VERSION_VARIANT_Pos)
+#define FREQM_VERSION_VARIANT(value) (FREQM_VERSION_VARIANT_Msk & ((value) << FREQM_VERSION_VARIANT_Pos))
+#define FREQM_VERSION_MASK          _U(0x000F0FFF) /**< \brief (FREQM_VERSION) MASK Register */
+
+/** \brief FREQM hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __O  FREQM_CTRL_Type           CTRL;        /**< \brief Offset: 0x000 ( /W 32) Control register */
+  __IO FREQM_MODE_Type           MODE;        /**< \brief Offset: 0x004 (R/W 32) Mode  register */
+  __I  FREQM_STATUS_Type         STATUS;      /**< \brief Offset: 0x008 (R/  32) Status  register */
+  __I  FREQM_VALUE_Type          VALUE;       /**< \brief Offset: 0x00C (R/  32) Value register */
+  __O  FREQM_IER_Type            IER;         /**< \brief Offset: 0x010 ( /W 32) Interrupt Enable Register */
+  __O  FREQM_IDR_Type            IDR;         /**< \brief Offset: 0x014 ( /W 32) Interrupt Diable Register */
+  __I  FREQM_IMR_Type            IMR;         /**< \brief Offset: 0x018 (R/  32) Interrupt Mask Register */
+  __I  FREQM_ISR_Type            ISR;         /**< \brief Offset: 0x01C (R/  32) Interrupt Status Register */
+  __O  FREQM_ICR_Type            ICR;         /**< \brief Offset: 0x020 ( /W 32) Interrupt Clear Register */
+       RoReg8                    Reserved1[0x3D8];
+  __I  FREQM_VERSION_Type        VERSION;     /**< \brief Offset: 0x3FC (R/  32) Version Register */
+ } bf;
+ struct {
+  WoReg   FREQM_CTRL;         /**< \brief (FREQM Offset: 0x000) Control register */
+  RwReg   FREQM_MODE;         /**< \brief (FREQM Offset: 0x004) Mode  register */
+  RoReg   FREQM_STATUS;       /**< \brief (FREQM Offset: 0x008) Status  register */
+  RoReg   FREQM_VALUE;        /**< \brief (FREQM Offset: 0x00C) Value register */
+  WoReg   FREQM_IER;          /**< \brief (FREQM Offset: 0x010) Interrupt Enable Register */
+  WoReg   FREQM_IDR;          /**< \brief (FREQM Offset: 0x014) Interrupt Diable Register */
+  RoReg   FREQM_IMR;          /**< \brief (FREQM Offset: 0x018) Interrupt Mask Register */
+  RoReg   FREQM_ISR;          /**< \brief (FREQM Offset: 0x01C) Interrupt Status Register */
+  WoReg   FREQM_ICR;          /**< \brief (FREQM Offset: 0x020) Interrupt Clear Register */
+  RoReg8  Reserved2[0x3D8];
+  RoReg   FREQM_VERSION;      /**< \brief (FREQM Offset: 0x3FC) Version Register */
+ } reg;
+} Freqm;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_FREQM_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/freqm.h
+++ b/asf/sam/include/sam4l/component/freqm.h
@@ -258,33 +258,18 @@ typedef union {
 
 /** \brief FREQM hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __O  FREQM_CTRL_Type           CTRL;        /**< \brief Offset: 0x000 ( /W 32) Control register */
-  __IO FREQM_MODE_Type           MODE;        /**< \brief Offset: 0x004 (R/W 32) Mode  register */
-  __I  FREQM_STATUS_Type         STATUS;      /**< \brief Offset: 0x008 (R/  32) Status  register */
-  __I  FREQM_VALUE_Type          VALUE;       /**< \brief Offset: 0x00C (R/  32) Value register */
-  __O  FREQM_IER_Type            IER;         /**< \brief Offset: 0x010 ( /W 32) Interrupt Enable Register */
-  __O  FREQM_IDR_Type            IDR;         /**< \brief Offset: 0x014 ( /W 32) Interrupt Diable Register */
-  __I  FREQM_IMR_Type            IMR;         /**< \brief Offset: 0x018 (R/  32) Interrupt Mask Register */
-  __I  FREQM_ISR_Type            ISR;         /**< \brief Offset: 0x01C (R/  32) Interrupt Status Register */
-  __O  FREQM_ICR_Type            ICR;         /**< \brief Offset: 0x020 ( /W 32) Interrupt Clear Register */
-       RoReg8                    Reserved1[0x3D8];
-  __I  FREQM_VERSION_Type        VERSION;     /**< \brief Offset: 0x3FC (R/  32) Version Register */
- } bf;
- struct {
-  WoReg   FREQM_CTRL;         /**< \brief (FREQM Offset: 0x000) Control register */
-  RwReg   FREQM_MODE;         /**< \brief (FREQM Offset: 0x004) Mode  register */
-  RoReg   FREQM_STATUS;       /**< \brief (FREQM Offset: 0x008) Status  register */
-  RoReg   FREQM_VALUE;        /**< \brief (FREQM Offset: 0x00C) Value register */
-  WoReg   FREQM_IER;          /**< \brief (FREQM Offset: 0x010) Interrupt Enable Register */
-  WoReg   FREQM_IDR;          /**< \brief (FREQM Offset: 0x014) Interrupt Diable Register */
-  RoReg   FREQM_IMR;          /**< \brief (FREQM Offset: 0x018) Interrupt Mask Register */
-  RoReg   FREQM_ISR;          /**< \brief (FREQM Offset: 0x01C) Interrupt Status Register */
-  WoReg   FREQM_ICR;          /**< \brief (FREQM Offset: 0x020) Interrupt Clear Register */
-  RoReg8  Reserved2[0x3D8];
-  RoReg   FREQM_VERSION;      /**< \brief (FREQM Offset: 0x3FC) Version Register */
- } reg;
+typedef struct {
+  __O  uint32_t CTRL;        /**< \brief Offset: 0x000 ( /W 32) Control register */
+  __IO uint32_t MODE;        /**< \brief Offset: 0x004 (R/W 32) Mode  register */
+  __I  uint32_t STATUS;      /**< \brief Offset: 0x008 (R/  32) Status  register */
+  __I  uint32_t VALUE;       /**< \brief Offset: 0x00C (R/  32) Value register */
+  __O  uint32_t IER;         /**< \brief Offset: 0x010 ( /W 32) Interrupt Enable Register */
+  __O  uint32_t IDR;         /**< \brief Offset: 0x014 ( /W 32) Interrupt Diable Register */
+  __I  uint32_t IMR;         /**< \brief Offset: 0x018 (R/  32) Interrupt Mask Register */
+  __I  uint32_t ISR;         /**< \brief Offset: 0x01C (R/  32) Interrupt Status Register */
+  __O  uint32_t ICR;         /**< \brief Offset: 0x020 ( /W 32) Interrupt Clear Register */
+       RoReg8   Reserved1[0x3D8];
+  __I  uint32_t VERSION;     /**< \brief Offset: 0x3FC (R/  32) Version Register */
 } Freqm;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/gloc.h
+++ b/asf/sam/include/sam4l/component/gloc.h
@@ -1,0 +1,158 @@
+/**
+ * \file
+ *
+ * \brief Component description for GLOC
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_GLOC_COMPONENT_
+#define _SAM4L_GLOC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR GLOC */
+/* ========================================================================== */
+/** \addtogroup SAM4L_GLOC Glue Logic Controller */
+/*@{*/
+
+#define GLOC_I7551
+#define REV_GLOC                    0x102
+
+/* -------- GLOC_CR : (GLOC Offset: 0x00) (R/W 32) LUT Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t AEN:4;            /*!< bit:  0.. 3  Input mask                         */
+    uint32_t :27;              /*!< bit:  4..30  Reserved                           */
+    uint32_t FILTEN:1;         /*!< bit:     31  Filter enable                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GLOC_CR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GLOC_CR_OFFSET              0x00         /**< \brief (GLOC_CR offset) Control Register */
+#define GLOC_CR_RESETVALUE          _U(0x00000000); /**< \brief (GLOC_CR reset_value) Control Register */
+
+#define GLOC_CR_AEN_Pos             0            /**< \brief (GLOC_CR) Input mask */
+#define GLOC_CR_AEN_Msk             (_U(0xF) << GLOC_CR_AEN_Pos)
+#define GLOC_CR_AEN(value)          (GLOC_CR_AEN_Msk & ((value) << GLOC_CR_AEN_Pos))
+#define GLOC_CR_FILTEN_Pos          31           /**< \brief (GLOC_CR) Filter enable */
+#define GLOC_CR_FILTEN              (_U(0x1) << GLOC_CR_FILTEN_Pos)
+#define GLOC_CR_MASK                _U(0x8000000F) /**< \brief (GLOC_CR) MASK Register */
+
+/* -------- GLOC_TRUTH : (GLOC Offset: 0x04) (R/W 32) LUT Truth Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TRUTH:16;         /*!< bit:  0..15  Truth                              */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GLOC_TRUTH_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GLOC_TRUTH_OFFSET           0x04         /**< \brief (GLOC_TRUTH offset) Truth Register */
+#define GLOC_TRUTH_RESETVALUE       _U(0x00000000); /**< \brief (GLOC_TRUTH reset_value) Truth Register */
+
+#define GLOC_TRUTH_TRUTH_Pos        0            /**< \brief (GLOC_TRUTH) Truth */
+#define GLOC_TRUTH_TRUTH_Msk        (_U(0xFFFF) << GLOC_TRUTH_TRUTH_Pos)
+#define GLOC_TRUTH_TRUTH(value)     (GLOC_TRUTH_TRUTH_Msk & ((value) << GLOC_TRUTH_TRUTH_Pos))
+#define GLOC_TRUTH_MASK             _U(0x0000FFFF) /**< \brief (GLOC_TRUTH) MASK Register */
+
+/* -------- GLOC_PARAMETER : (GLOC Offset: 0x38) (R/  32) Parameter Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t LUTS:8;           /*!< bit:  0.. 7  LUTs                               */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GLOC_PARAMETER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GLOC_PARAMETER_OFFSET       0x38         /**< \brief (GLOC_PARAMETER offset) Parameter Register */
+
+#define GLOC_PARAMETER_LUTS_Pos     0            /**< \brief (GLOC_PARAMETER) LUTs */
+#define GLOC_PARAMETER_LUTS_Msk     (_U(0xFF) << GLOC_PARAMETER_LUTS_Pos)
+#define GLOC_PARAMETER_LUTS(value)  (GLOC_PARAMETER_LUTS_Msk & ((value) << GLOC_PARAMETER_LUTS_Pos))
+#define GLOC_PARAMETER_MASK         _U(0x000000FF) /**< \brief (GLOC_PARAMETER) MASK Register */
+
+/* -------- GLOC_VERSION : (GLOC Offset: 0x3C) (R/  32) Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version                            */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant                            */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GLOC_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GLOC_VERSION_OFFSET         0x3C         /**< \brief (GLOC_VERSION offset) Version Register */
+#define GLOC_VERSION_RESETVALUE     _U(0x00000102); /**< \brief (GLOC_VERSION reset_value) Version Register */
+
+#define GLOC_VERSION_VERSION_Pos    0            /**< \brief (GLOC_VERSION) Version */
+#define GLOC_VERSION_VERSION_Msk    (_U(0xFFF) << GLOC_VERSION_VERSION_Pos)
+#define GLOC_VERSION_VERSION(value) (GLOC_VERSION_VERSION_Msk & ((value) << GLOC_VERSION_VERSION_Pos))
+#define GLOC_VERSION_VARIANT_Pos    16           /**< \brief (GLOC_VERSION) Variant */
+#define GLOC_VERSION_VARIANT_Msk    (_U(0xF) << GLOC_VERSION_VARIANT_Pos)
+#define GLOC_VERSION_VARIANT(value) (GLOC_VERSION_VARIANT_Msk & ((value) << GLOC_VERSION_VARIANT_Pos))
+#define GLOC_VERSION_MASK           _U(0x000F0FFF) /**< \brief (GLOC_VERSION) MASK Register */
+
+/** \brief GlocLut hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __IO GLOC_CR_Type              CR;          /**< \brief Offset: 0x00 (R/W 32) Control Register */
+  __IO GLOC_TRUTH_Type           TRUTH;       /**< \brief Offset: 0x04 (R/W 32) Truth Register */
+ } bf;
+ struct {
+  RwReg   GLOC_CR;            /**< \brief (GLOC Offset: 0x00) Control Register */
+  RwReg   GLOC_TRUTH;         /**< \brief (GLOC Offset: 0x04) Truth Register */
+ } reg;
+} GlocLut;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief GLOC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+       GlocLut                   Lut[2];      /**< \brief Offset: 0x00 GlocLut groups [LUTS] */
+       RoReg8                    Reserved1[0x28];
+  __I  GLOC_PARAMETER_Type       PARAMETER;   /**< \brief Offset: 0x38 (R/  32) Parameter Register */
+  __I  GLOC_VERSION_Type         VERSION;     /**< \brief Offset: 0x3C (R/  32) Version Register */
+ } bf;
+ struct {
+  GlocLut GLOC_LUT[2];        /**< \brief (GLOC Offset: 0x00) GlocLut groups [LUTS] */
+  RoReg8  Reserved2[0x28];
+  RoReg   GLOC_PARAMETER;     /**< \brief (GLOC Offset: 0x38) Parameter Register */
+  RoReg   GLOC_VERSION;       /**< \brief (GLOC Offset: 0x3C) Version Register */
+ } reg;
+} Gloc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_GLOC_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/gloc.h
+++ b/asf/sam/include/sam4l/component/gloc.h
@@ -51,14 +51,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GLOC_CR_OFFSET              0x00         /**< \brief (GLOC_CR offset) Control Register */
-#define GLOC_CR_RESETVALUE          _U(0x00000000); /**< \brief (GLOC_CR reset_value) Control Register */
+#define GLOC_CR_RESETVALUE          _U_(0x00000000); /**< \brief (GLOC_CR reset_value) Control Register */
 
 #define GLOC_CR_AEN_Pos             0            /**< \brief (GLOC_CR) Input mask */
-#define GLOC_CR_AEN_Msk             (_U(0xF) << GLOC_CR_AEN_Pos)
+#define GLOC_CR_AEN_Msk             (_U_(0xF) << GLOC_CR_AEN_Pos)
 #define GLOC_CR_AEN(value)          (GLOC_CR_AEN_Msk & ((value) << GLOC_CR_AEN_Pos))
 #define GLOC_CR_FILTEN_Pos          31           /**< \brief (GLOC_CR) Filter enable */
-#define GLOC_CR_FILTEN              (_U(0x1) << GLOC_CR_FILTEN_Pos)
-#define GLOC_CR_MASK                _U(0x8000000F) /**< \brief (GLOC_CR) MASK Register */
+#define GLOC_CR_FILTEN              (_U_(0x1) << GLOC_CR_FILTEN_Pos)
+#define GLOC_CR_MASK                _U_(0x8000000F) /**< \brief (GLOC_CR) MASK Register */
 
 /* -------- GLOC_TRUTH : (GLOC Offset: 0x04) (R/W 32) LUT Truth Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -72,12 +72,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GLOC_TRUTH_OFFSET           0x04         /**< \brief (GLOC_TRUTH offset) Truth Register */
-#define GLOC_TRUTH_RESETVALUE       _U(0x00000000); /**< \brief (GLOC_TRUTH reset_value) Truth Register */
+#define GLOC_TRUTH_RESETVALUE       _U_(0x00000000); /**< \brief (GLOC_TRUTH reset_value) Truth Register */
 
 #define GLOC_TRUTH_TRUTH_Pos        0            /**< \brief (GLOC_TRUTH) Truth */
-#define GLOC_TRUTH_TRUTH_Msk        (_U(0xFFFF) << GLOC_TRUTH_TRUTH_Pos)
+#define GLOC_TRUTH_TRUTH_Msk        (_U_(0xFFFF) << GLOC_TRUTH_TRUTH_Pos)
 #define GLOC_TRUTH_TRUTH(value)     (GLOC_TRUTH_TRUTH_Msk & ((value) << GLOC_TRUTH_TRUTH_Pos))
-#define GLOC_TRUTH_MASK             _U(0x0000FFFF) /**< \brief (GLOC_TRUTH) MASK Register */
+#define GLOC_TRUTH_MASK             _U_(0x0000FFFF) /**< \brief (GLOC_TRUTH) MASK Register */
 
 /* -------- GLOC_PARAMETER : (GLOC Offset: 0x38) (R/  32) Parameter Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -93,9 +93,9 @@ typedef union {
 #define GLOC_PARAMETER_OFFSET       0x38         /**< \brief (GLOC_PARAMETER offset) Parameter Register */
 
 #define GLOC_PARAMETER_LUTS_Pos     0            /**< \brief (GLOC_PARAMETER) LUTs */
-#define GLOC_PARAMETER_LUTS_Msk     (_U(0xFF) << GLOC_PARAMETER_LUTS_Pos)
+#define GLOC_PARAMETER_LUTS_Msk     (_U_(0xFF) << GLOC_PARAMETER_LUTS_Pos)
 #define GLOC_PARAMETER_LUTS(value)  (GLOC_PARAMETER_LUTS_Msk & ((value) << GLOC_PARAMETER_LUTS_Pos))
-#define GLOC_PARAMETER_MASK         _U(0x000000FF) /**< \brief (GLOC_PARAMETER) MASK Register */
+#define GLOC_PARAMETER_MASK         _U_(0x000000FF) /**< \brief (GLOC_PARAMETER) MASK Register */
 
 /* -------- GLOC_VERSION : (GLOC Offset: 0x3C) (R/  32) Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -111,15 +111,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GLOC_VERSION_OFFSET         0x3C         /**< \brief (GLOC_VERSION offset) Version Register */
-#define GLOC_VERSION_RESETVALUE     _U(0x00000102); /**< \brief (GLOC_VERSION reset_value) Version Register */
+#define GLOC_VERSION_RESETVALUE     _U_(0x00000102); /**< \brief (GLOC_VERSION reset_value) Version Register */
 
 #define GLOC_VERSION_VERSION_Pos    0            /**< \brief (GLOC_VERSION) Version */
-#define GLOC_VERSION_VERSION_Msk    (_U(0xFFF) << GLOC_VERSION_VERSION_Pos)
+#define GLOC_VERSION_VERSION_Msk    (_U_(0xFFF) << GLOC_VERSION_VERSION_Pos)
 #define GLOC_VERSION_VERSION(value) (GLOC_VERSION_VERSION_Msk & ((value) << GLOC_VERSION_VERSION_Pos))
 #define GLOC_VERSION_VARIANT_Pos    16           /**< \brief (GLOC_VERSION) Variant */
-#define GLOC_VERSION_VARIANT_Msk    (_U(0xF) << GLOC_VERSION_VARIANT_Pos)
+#define GLOC_VERSION_VARIANT_Msk    (_U_(0xF) << GLOC_VERSION_VARIANT_Pos)
 #define GLOC_VERSION_VARIANT(value) (GLOC_VERSION_VARIANT_Msk & ((value) << GLOC_VERSION_VARIANT_Pos))
-#define GLOC_VERSION_MASK           _U(0x000F0FFF) /**< \brief (GLOC_VERSION) MASK Register */
+#define GLOC_VERSION_MASK           _U_(0x000F0FFF) /**< \brief (GLOC_VERSION) MASK Register */
 
 /** \brief GlocLut hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/gloc.h
+++ b/asf/sam/include/sam4l/component/gloc.h
@@ -137,19 +137,11 @@ typedef union {
 
 /** \brief GLOC hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-       GlocLut                   Lut[2];      /**< \brief Offset: 0x00 GlocLut groups [LUTS] */
-       RoReg8                    Reserved1[0x28];
-  __I  GLOC_PARAMETER_Type       PARAMETER;   /**< \brief Offset: 0x38 (R/  32) Parameter Register */
-  __I  GLOC_VERSION_Type         VERSION;     /**< \brief Offset: 0x3C (R/  32) Version Register */
- } bf;
- struct {
-  GlocLut GLOC_LUT[2];        /**< \brief (GLOC Offset: 0x00) GlocLut groups [LUTS] */
-  RoReg8  Reserved2[0x28];
-  RoReg   GLOC_PARAMETER;     /**< \brief (GLOC Offset: 0x38) Parameter Register */
-  RoReg   GLOC_VERSION;       /**< \brief (GLOC Offset: 0x3C) Version Register */
- } reg;
+typedef struct {
+  __IO uint32_t Lut[2];      /**< \brief Offset: 0x00 GlocLut groups [LUTS] */
+       RoReg8   Reserved1[0x28];
+  __I  uint32_t PARAMETER;   /**< \brief Offset: 0x38 (R/  32) Parameter Register */
+  __I  uint32_t VERSION;     /**< \brief Offset: 0x3C (R/  32) Version Register */
 } Gloc;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/gpio.h
+++ b/asf/sam/include/sam4l/component/gpio.h
@@ -1,0 +1,8942 @@
+/**
+ * \file
+ *
+ * \brief Component description for GPIO
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_GPIO_COMPONENT_
+#define _SAM4L_GPIO_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR GPIO */
+/* ========================================================================== */
+/** \addtogroup SAM4L_GPIO General-Purpose Input/Output Controller */
+/*@{*/
+
+#define GPIO_I7512
+#define REV_GPIO                    0x215
+
+/* -------- GPIO_GPER : (GPIO Offset: 0x000) (R/W 32) port GPIO Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  GPIO Enable                        */
+    uint32_t P1:1;             /*!< bit:      1  GPIO Enable                        */
+    uint32_t P2:1;             /*!< bit:      2  GPIO Enable                        */
+    uint32_t P3:1;             /*!< bit:      3  GPIO Enable                        */
+    uint32_t P4:1;             /*!< bit:      4  GPIO Enable                        */
+    uint32_t P5:1;             /*!< bit:      5  GPIO Enable                        */
+    uint32_t P6:1;             /*!< bit:      6  GPIO Enable                        */
+    uint32_t P7:1;             /*!< bit:      7  GPIO Enable                        */
+    uint32_t P8:1;             /*!< bit:      8  GPIO Enable                        */
+    uint32_t P9:1;             /*!< bit:      9  GPIO Enable                        */
+    uint32_t P10:1;            /*!< bit:     10  GPIO Enable                        */
+    uint32_t P11:1;            /*!< bit:     11  GPIO Enable                        */
+    uint32_t P12:1;            /*!< bit:     12  GPIO Enable                        */
+    uint32_t P13:1;            /*!< bit:     13  GPIO Enable                        */
+    uint32_t P14:1;            /*!< bit:     14  GPIO Enable                        */
+    uint32_t P15:1;            /*!< bit:     15  GPIO Enable                        */
+    uint32_t P16:1;            /*!< bit:     16  GPIO Enable                        */
+    uint32_t P17:1;            /*!< bit:     17  GPIO Enable                        */
+    uint32_t P18:1;            /*!< bit:     18  GPIO Enable                        */
+    uint32_t P19:1;            /*!< bit:     19  GPIO Enable                        */
+    uint32_t P20:1;            /*!< bit:     20  GPIO Enable                        */
+    uint32_t P21:1;            /*!< bit:     21  GPIO Enable                        */
+    uint32_t P22:1;            /*!< bit:     22  GPIO Enable                        */
+    uint32_t P23:1;            /*!< bit:     23  GPIO Enable                        */
+    uint32_t P24:1;            /*!< bit:     24  GPIO Enable                        */
+    uint32_t P25:1;            /*!< bit:     25  GPIO Enable                        */
+    uint32_t P26:1;            /*!< bit:     26  GPIO Enable                        */
+    uint32_t P27:1;            /*!< bit:     27  GPIO Enable                        */
+    uint32_t P28:1;            /*!< bit:     28  GPIO Enable                        */
+    uint32_t P29:1;            /*!< bit:     29  GPIO Enable                        */
+    uint32_t P30:1;            /*!< bit:     30  GPIO Enable                        */
+    uint32_t P31:1;            /*!< bit:     31  GPIO Enable                        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_GPER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_GPER_OFFSET            0x000        /**< \brief (GPIO_GPER offset) GPIO Enable Register */
+
+#define GPIO_GPER_P0_Pos            0            /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P0                (_U(0x1) << GPIO_GPER_P0_Pos)
+#define GPIO_GPER_P1_Pos            1            /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P1                (_U(0x1) << GPIO_GPER_P1_Pos)
+#define GPIO_GPER_P2_Pos            2            /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P2                (_U(0x1) << GPIO_GPER_P2_Pos)
+#define GPIO_GPER_P3_Pos            3            /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P3                (_U(0x1) << GPIO_GPER_P3_Pos)
+#define GPIO_GPER_P4_Pos            4            /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P4                (_U(0x1) << GPIO_GPER_P4_Pos)
+#define GPIO_GPER_P5_Pos            5            /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P5                (_U(0x1) << GPIO_GPER_P5_Pos)
+#define GPIO_GPER_P6_Pos            6            /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P6                (_U(0x1) << GPIO_GPER_P6_Pos)
+#define GPIO_GPER_P7_Pos            7            /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P7                (_U(0x1) << GPIO_GPER_P7_Pos)
+#define GPIO_GPER_P8_Pos            8            /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P8                (_U(0x1) << GPIO_GPER_P8_Pos)
+#define GPIO_GPER_P9_Pos            9            /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P9                (_U(0x1) << GPIO_GPER_P9_Pos)
+#define GPIO_GPER_P10_Pos           10           /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P10               (_U(0x1) << GPIO_GPER_P10_Pos)
+#define GPIO_GPER_P11_Pos           11           /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P11               (_U(0x1) << GPIO_GPER_P11_Pos)
+#define GPIO_GPER_P12_Pos           12           /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P12               (_U(0x1) << GPIO_GPER_P12_Pos)
+#define GPIO_GPER_P13_Pos           13           /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P13               (_U(0x1) << GPIO_GPER_P13_Pos)
+#define GPIO_GPER_P14_Pos           14           /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P14               (_U(0x1) << GPIO_GPER_P14_Pos)
+#define GPIO_GPER_P15_Pos           15           /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P15               (_U(0x1) << GPIO_GPER_P15_Pos)
+#define GPIO_GPER_P16_Pos           16           /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P16               (_U(0x1) << GPIO_GPER_P16_Pos)
+#define GPIO_GPER_P17_Pos           17           /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P17               (_U(0x1) << GPIO_GPER_P17_Pos)
+#define GPIO_GPER_P18_Pos           18           /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P18               (_U(0x1) << GPIO_GPER_P18_Pos)
+#define GPIO_GPER_P19_Pos           19           /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P19               (_U(0x1) << GPIO_GPER_P19_Pos)
+#define GPIO_GPER_P20_Pos           20           /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P20               (_U(0x1) << GPIO_GPER_P20_Pos)
+#define GPIO_GPER_P21_Pos           21           /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P21               (_U(0x1) << GPIO_GPER_P21_Pos)
+#define GPIO_GPER_P22_Pos           22           /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P22               (_U(0x1) << GPIO_GPER_P22_Pos)
+#define GPIO_GPER_P23_Pos           23           /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P23               (_U(0x1) << GPIO_GPER_P23_Pos)
+#define GPIO_GPER_P24_Pos           24           /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P24               (_U(0x1) << GPIO_GPER_P24_Pos)
+#define GPIO_GPER_P25_Pos           25           /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P25               (_U(0x1) << GPIO_GPER_P25_Pos)
+#define GPIO_GPER_P26_Pos           26           /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P26               (_U(0x1) << GPIO_GPER_P26_Pos)
+#define GPIO_GPER_P27_Pos           27           /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P27               (_U(0x1) << GPIO_GPER_P27_Pos)
+#define GPIO_GPER_P28_Pos           28           /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P28               (_U(0x1) << GPIO_GPER_P28_Pos)
+#define GPIO_GPER_P29_Pos           29           /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P29               (_U(0x1) << GPIO_GPER_P29_Pos)
+#define GPIO_GPER_P30_Pos           30           /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P30               (_U(0x1) << GPIO_GPER_P30_Pos)
+#define GPIO_GPER_P31_Pos           31           /**< \brief (GPIO_GPER) GPIO Enable */
+#define GPIO_GPER_P31               (_U(0x1) << GPIO_GPER_P31_Pos)
+#define GPIO_GPER_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_GPER) MASK Register */
+
+/* -------- GPIO_GPERS : (GPIO Offset: 0x004) ( /W 32) port GPIO Enable Register - Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  GPIO Enable                        */
+    uint32_t P1:1;             /*!< bit:      1  GPIO Enable                        */
+    uint32_t P2:1;             /*!< bit:      2  GPIO Enable                        */
+    uint32_t P3:1;             /*!< bit:      3  GPIO Enable                        */
+    uint32_t P4:1;             /*!< bit:      4  GPIO Enable                        */
+    uint32_t P5:1;             /*!< bit:      5  GPIO Enable                        */
+    uint32_t P6:1;             /*!< bit:      6  GPIO Enable                        */
+    uint32_t P7:1;             /*!< bit:      7  GPIO Enable                        */
+    uint32_t P8:1;             /*!< bit:      8  GPIO Enable                        */
+    uint32_t P9:1;             /*!< bit:      9  GPIO Enable                        */
+    uint32_t P10:1;            /*!< bit:     10  GPIO Enable                        */
+    uint32_t P11:1;            /*!< bit:     11  GPIO Enable                        */
+    uint32_t P12:1;            /*!< bit:     12  GPIO Enable                        */
+    uint32_t P13:1;            /*!< bit:     13  GPIO Enable                        */
+    uint32_t P14:1;            /*!< bit:     14  GPIO Enable                        */
+    uint32_t P15:1;            /*!< bit:     15  GPIO Enable                        */
+    uint32_t P16:1;            /*!< bit:     16  GPIO Enable                        */
+    uint32_t P17:1;            /*!< bit:     17  GPIO Enable                        */
+    uint32_t P18:1;            /*!< bit:     18  GPIO Enable                        */
+    uint32_t P19:1;            /*!< bit:     19  GPIO Enable                        */
+    uint32_t P20:1;            /*!< bit:     20  GPIO Enable                        */
+    uint32_t P21:1;            /*!< bit:     21  GPIO Enable                        */
+    uint32_t P22:1;            /*!< bit:     22  GPIO Enable                        */
+    uint32_t P23:1;            /*!< bit:     23  GPIO Enable                        */
+    uint32_t P24:1;            /*!< bit:     24  GPIO Enable                        */
+    uint32_t P25:1;            /*!< bit:     25  GPIO Enable                        */
+    uint32_t P26:1;            /*!< bit:     26  GPIO Enable                        */
+    uint32_t P27:1;            /*!< bit:     27  GPIO Enable                        */
+    uint32_t P28:1;            /*!< bit:     28  GPIO Enable                        */
+    uint32_t P29:1;            /*!< bit:     29  GPIO Enable                        */
+    uint32_t P30:1;            /*!< bit:     30  GPIO Enable                        */
+    uint32_t P31:1;            /*!< bit:     31  GPIO Enable                        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_GPERS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_GPERS_OFFSET           0x004        /**< \brief (GPIO_GPERS offset) GPIO Enable Register - Set */
+
+#define GPIO_GPERS_P0_Pos           0            /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P0               (_U(0x1) << GPIO_GPERS_P0_Pos)
+#define GPIO_GPERS_P1_Pos           1            /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P1               (_U(0x1) << GPIO_GPERS_P1_Pos)
+#define GPIO_GPERS_P2_Pos           2            /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P2               (_U(0x1) << GPIO_GPERS_P2_Pos)
+#define GPIO_GPERS_P3_Pos           3            /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P3               (_U(0x1) << GPIO_GPERS_P3_Pos)
+#define GPIO_GPERS_P4_Pos           4            /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P4               (_U(0x1) << GPIO_GPERS_P4_Pos)
+#define GPIO_GPERS_P5_Pos           5            /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P5               (_U(0x1) << GPIO_GPERS_P5_Pos)
+#define GPIO_GPERS_P6_Pos           6            /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P6               (_U(0x1) << GPIO_GPERS_P6_Pos)
+#define GPIO_GPERS_P7_Pos           7            /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P7               (_U(0x1) << GPIO_GPERS_P7_Pos)
+#define GPIO_GPERS_P8_Pos           8            /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P8               (_U(0x1) << GPIO_GPERS_P8_Pos)
+#define GPIO_GPERS_P9_Pos           9            /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P9               (_U(0x1) << GPIO_GPERS_P9_Pos)
+#define GPIO_GPERS_P10_Pos          10           /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P10              (_U(0x1) << GPIO_GPERS_P10_Pos)
+#define GPIO_GPERS_P11_Pos          11           /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P11              (_U(0x1) << GPIO_GPERS_P11_Pos)
+#define GPIO_GPERS_P12_Pos          12           /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P12              (_U(0x1) << GPIO_GPERS_P12_Pos)
+#define GPIO_GPERS_P13_Pos          13           /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P13              (_U(0x1) << GPIO_GPERS_P13_Pos)
+#define GPIO_GPERS_P14_Pos          14           /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P14              (_U(0x1) << GPIO_GPERS_P14_Pos)
+#define GPIO_GPERS_P15_Pos          15           /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P15              (_U(0x1) << GPIO_GPERS_P15_Pos)
+#define GPIO_GPERS_P16_Pos          16           /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P16              (_U(0x1) << GPIO_GPERS_P16_Pos)
+#define GPIO_GPERS_P17_Pos          17           /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P17              (_U(0x1) << GPIO_GPERS_P17_Pos)
+#define GPIO_GPERS_P18_Pos          18           /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P18              (_U(0x1) << GPIO_GPERS_P18_Pos)
+#define GPIO_GPERS_P19_Pos          19           /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P19              (_U(0x1) << GPIO_GPERS_P19_Pos)
+#define GPIO_GPERS_P20_Pos          20           /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P20              (_U(0x1) << GPIO_GPERS_P20_Pos)
+#define GPIO_GPERS_P21_Pos          21           /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P21              (_U(0x1) << GPIO_GPERS_P21_Pos)
+#define GPIO_GPERS_P22_Pos          22           /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P22              (_U(0x1) << GPIO_GPERS_P22_Pos)
+#define GPIO_GPERS_P23_Pos          23           /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P23              (_U(0x1) << GPIO_GPERS_P23_Pos)
+#define GPIO_GPERS_P24_Pos          24           /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P24              (_U(0x1) << GPIO_GPERS_P24_Pos)
+#define GPIO_GPERS_P25_Pos          25           /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P25              (_U(0x1) << GPIO_GPERS_P25_Pos)
+#define GPIO_GPERS_P26_Pos          26           /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P26              (_U(0x1) << GPIO_GPERS_P26_Pos)
+#define GPIO_GPERS_P27_Pos          27           /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P27              (_U(0x1) << GPIO_GPERS_P27_Pos)
+#define GPIO_GPERS_P28_Pos          28           /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P28              (_U(0x1) << GPIO_GPERS_P28_Pos)
+#define GPIO_GPERS_P29_Pos          29           /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P29              (_U(0x1) << GPIO_GPERS_P29_Pos)
+#define GPIO_GPERS_P30_Pos          30           /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P30              (_U(0x1) << GPIO_GPERS_P30_Pos)
+#define GPIO_GPERS_P31_Pos          31           /**< \brief (GPIO_GPERS) GPIO Enable */
+#define GPIO_GPERS_P31              (_U(0x1) << GPIO_GPERS_P31_Pos)
+#define GPIO_GPERS_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_GPERS) MASK Register */
+
+/* -------- GPIO_GPERC : (GPIO Offset: 0x008) ( /W 32) port GPIO Enable Register - Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  GPIO Enable                        */
+    uint32_t P1:1;             /*!< bit:      1  GPIO Enable                        */
+    uint32_t P2:1;             /*!< bit:      2  GPIO Enable                        */
+    uint32_t P3:1;             /*!< bit:      3  GPIO Enable                        */
+    uint32_t P4:1;             /*!< bit:      4  GPIO Enable                        */
+    uint32_t P5:1;             /*!< bit:      5  GPIO Enable                        */
+    uint32_t P6:1;             /*!< bit:      6  GPIO Enable                        */
+    uint32_t P7:1;             /*!< bit:      7  GPIO Enable                        */
+    uint32_t P8:1;             /*!< bit:      8  GPIO Enable                        */
+    uint32_t P9:1;             /*!< bit:      9  GPIO Enable                        */
+    uint32_t P10:1;            /*!< bit:     10  GPIO Enable                        */
+    uint32_t P11:1;            /*!< bit:     11  GPIO Enable                        */
+    uint32_t P12:1;            /*!< bit:     12  GPIO Enable                        */
+    uint32_t P13:1;            /*!< bit:     13  GPIO Enable                        */
+    uint32_t P14:1;            /*!< bit:     14  GPIO Enable                        */
+    uint32_t P15:1;            /*!< bit:     15  GPIO Enable                        */
+    uint32_t P16:1;            /*!< bit:     16  GPIO Enable                        */
+    uint32_t P17:1;            /*!< bit:     17  GPIO Enable                        */
+    uint32_t P18:1;            /*!< bit:     18  GPIO Enable                        */
+    uint32_t P19:1;            /*!< bit:     19  GPIO Enable                        */
+    uint32_t P20:1;            /*!< bit:     20  GPIO Enable                        */
+    uint32_t P21:1;            /*!< bit:     21  GPIO Enable                        */
+    uint32_t P22:1;            /*!< bit:     22  GPIO Enable                        */
+    uint32_t P23:1;            /*!< bit:     23  GPIO Enable                        */
+    uint32_t P24:1;            /*!< bit:     24  GPIO Enable                        */
+    uint32_t P25:1;            /*!< bit:     25  GPIO Enable                        */
+    uint32_t P26:1;            /*!< bit:     26  GPIO Enable                        */
+    uint32_t P27:1;            /*!< bit:     27  GPIO Enable                        */
+    uint32_t P28:1;            /*!< bit:     28  GPIO Enable                        */
+    uint32_t P29:1;            /*!< bit:     29  GPIO Enable                        */
+    uint32_t P30:1;            /*!< bit:     30  GPIO Enable                        */
+    uint32_t P31:1;            /*!< bit:     31  GPIO Enable                        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_GPERC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_GPERC_OFFSET           0x008        /**< \brief (GPIO_GPERC offset) GPIO Enable Register - Clear */
+
+#define GPIO_GPERC_P0_Pos           0            /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P0               (_U(0x1) << GPIO_GPERC_P0_Pos)
+#define GPIO_GPERC_P1_Pos           1            /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P1               (_U(0x1) << GPIO_GPERC_P1_Pos)
+#define GPIO_GPERC_P2_Pos           2            /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P2               (_U(0x1) << GPIO_GPERC_P2_Pos)
+#define GPIO_GPERC_P3_Pos           3            /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P3               (_U(0x1) << GPIO_GPERC_P3_Pos)
+#define GPIO_GPERC_P4_Pos           4            /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P4               (_U(0x1) << GPIO_GPERC_P4_Pos)
+#define GPIO_GPERC_P5_Pos           5            /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P5               (_U(0x1) << GPIO_GPERC_P5_Pos)
+#define GPIO_GPERC_P6_Pos           6            /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P6               (_U(0x1) << GPIO_GPERC_P6_Pos)
+#define GPIO_GPERC_P7_Pos           7            /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P7               (_U(0x1) << GPIO_GPERC_P7_Pos)
+#define GPIO_GPERC_P8_Pos           8            /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P8               (_U(0x1) << GPIO_GPERC_P8_Pos)
+#define GPIO_GPERC_P9_Pos           9            /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P9               (_U(0x1) << GPIO_GPERC_P9_Pos)
+#define GPIO_GPERC_P10_Pos          10           /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P10              (_U(0x1) << GPIO_GPERC_P10_Pos)
+#define GPIO_GPERC_P11_Pos          11           /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P11              (_U(0x1) << GPIO_GPERC_P11_Pos)
+#define GPIO_GPERC_P12_Pos          12           /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P12              (_U(0x1) << GPIO_GPERC_P12_Pos)
+#define GPIO_GPERC_P13_Pos          13           /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P13              (_U(0x1) << GPIO_GPERC_P13_Pos)
+#define GPIO_GPERC_P14_Pos          14           /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P14              (_U(0x1) << GPIO_GPERC_P14_Pos)
+#define GPIO_GPERC_P15_Pos          15           /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P15              (_U(0x1) << GPIO_GPERC_P15_Pos)
+#define GPIO_GPERC_P16_Pos          16           /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P16              (_U(0x1) << GPIO_GPERC_P16_Pos)
+#define GPIO_GPERC_P17_Pos          17           /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P17              (_U(0x1) << GPIO_GPERC_P17_Pos)
+#define GPIO_GPERC_P18_Pos          18           /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P18              (_U(0x1) << GPIO_GPERC_P18_Pos)
+#define GPIO_GPERC_P19_Pos          19           /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P19              (_U(0x1) << GPIO_GPERC_P19_Pos)
+#define GPIO_GPERC_P20_Pos          20           /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P20              (_U(0x1) << GPIO_GPERC_P20_Pos)
+#define GPIO_GPERC_P21_Pos          21           /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P21              (_U(0x1) << GPIO_GPERC_P21_Pos)
+#define GPIO_GPERC_P22_Pos          22           /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P22              (_U(0x1) << GPIO_GPERC_P22_Pos)
+#define GPIO_GPERC_P23_Pos          23           /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P23              (_U(0x1) << GPIO_GPERC_P23_Pos)
+#define GPIO_GPERC_P24_Pos          24           /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P24              (_U(0x1) << GPIO_GPERC_P24_Pos)
+#define GPIO_GPERC_P25_Pos          25           /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P25              (_U(0x1) << GPIO_GPERC_P25_Pos)
+#define GPIO_GPERC_P26_Pos          26           /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P26              (_U(0x1) << GPIO_GPERC_P26_Pos)
+#define GPIO_GPERC_P27_Pos          27           /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P27              (_U(0x1) << GPIO_GPERC_P27_Pos)
+#define GPIO_GPERC_P28_Pos          28           /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P28              (_U(0x1) << GPIO_GPERC_P28_Pos)
+#define GPIO_GPERC_P29_Pos          29           /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P29              (_U(0x1) << GPIO_GPERC_P29_Pos)
+#define GPIO_GPERC_P30_Pos          30           /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P30              (_U(0x1) << GPIO_GPERC_P30_Pos)
+#define GPIO_GPERC_P31_Pos          31           /**< \brief (GPIO_GPERC) GPIO Enable */
+#define GPIO_GPERC_P31              (_U(0x1) << GPIO_GPERC_P31_Pos)
+#define GPIO_GPERC_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_GPERC) MASK Register */
+
+/* -------- GPIO_GPERT : (GPIO Offset: 0x00C) ( /W 32) port GPIO Enable Register - Toggle -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  GPIO Enable                        */
+    uint32_t P1:1;             /*!< bit:      1  GPIO Enable                        */
+    uint32_t P2:1;             /*!< bit:      2  GPIO Enable                        */
+    uint32_t P3:1;             /*!< bit:      3  GPIO Enable                        */
+    uint32_t P4:1;             /*!< bit:      4  GPIO Enable                        */
+    uint32_t P5:1;             /*!< bit:      5  GPIO Enable                        */
+    uint32_t P6:1;             /*!< bit:      6  GPIO Enable                        */
+    uint32_t P7:1;             /*!< bit:      7  GPIO Enable                        */
+    uint32_t P8:1;             /*!< bit:      8  GPIO Enable                        */
+    uint32_t P9:1;             /*!< bit:      9  GPIO Enable                        */
+    uint32_t P10:1;            /*!< bit:     10  GPIO Enable                        */
+    uint32_t P11:1;            /*!< bit:     11  GPIO Enable                        */
+    uint32_t P12:1;            /*!< bit:     12  GPIO Enable                        */
+    uint32_t P13:1;            /*!< bit:     13  GPIO Enable                        */
+    uint32_t P14:1;            /*!< bit:     14  GPIO Enable                        */
+    uint32_t P15:1;            /*!< bit:     15  GPIO Enable                        */
+    uint32_t P16:1;            /*!< bit:     16  GPIO Enable                        */
+    uint32_t P17:1;            /*!< bit:     17  GPIO Enable                        */
+    uint32_t P18:1;            /*!< bit:     18  GPIO Enable                        */
+    uint32_t P19:1;            /*!< bit:     19  GPIO Enable                        */
+    uint32_t P20:1;            /*!< bit:     20  GPIO Enable                        */
+    uint32_t P21:1;            /*!< bit:     21  GPIO Enable                        */
+    uint32_t P22:1;            /*!< bit:     22  GPIO Enable                        */
+    uint32_t P23:1;            /*!< bit:     23  GPIO Enable                        */
+    uint32_t P24:1;            /*!< bit:     24  GPIO Enable                        */
+    uint32_t P25:1;            /*!< bit:     25  GPIO Enable                        */
+    uint32_t P26:1;            /*!< bit:     26  GPIO Enable                        */
+    uint32_t P27:1;            /*!< bit:     27  GPIO Enable                        */
+    uint32_t P28:1;            /*!< bit:     28  GPIO Enable                        */
+    uint32_t P29:1;            /*!< bit:     29  GPIO Enable                        */
+    uint32_t P30:1;            /*!< bit:     30  GPIO Enable                        */
+    uint32_t P31:1;            /*!< bit:     31  GPIO Enable                        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_GPERT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_GPERT_OFFSET           0x00C        /**< \brief (GPIO_GPERT offset) GPIO Enable Register - Toggle */
+
+#define GPIO_GPERT_P0_Pos           0            /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P0               (_U(0x1) << GPIO_GPERT_P0_Pos)
+#define GPIO_GPERT_P1_Pos           1            /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P1               (_U(0x1) << GPIO_GPERT_P1_Pos)
+#define GPIO_GPERT_P2_Pos           2            /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P2               (_U(0x1) << GPIO_GPERT_P2_Pos)
+#define GPIO_GPERT_P3_Pos           3            /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P3               (_U(0x1) << GPIO_GPERT_P3_Pos)
+#define GPIO_GPERT_P4_Pos           4            /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P4               (_U(0x1) << GPIO_GPERT_P4_Pos)
+#define GPIO_GPERT_P5_Pos           5            /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P5               (_U(0x1) << GPIO_GPERT_P5_Pos)
+#define GPIO_GPERT_P6_Pos           6            /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P6               (_U(0x1) << GPIO_GPERT_P6_Pos)
+#define GPIO_GPERT_P7_Pos           7            /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P7               (_U(0x1) << GPIO_GPERT_P7_Pos)
+#define GPIO_GPERT_P8_Pos           8            /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P8               (_U(0x1) << GPIO_GPERT_P8_Pos)
+#define GPIO_GPERT_P9_Pos           9            /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P9               (_U(0x1) << GPIO_GPERT_P9_Pos)
+#define GPIO_GPERT_P10_Pos          10           /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P10              (_U(0x1) << GPIO_GPERT_P10_Pos)
+#define GPIO_GPERT_P11_Pos          11           /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P11              (_U(0x1) << GPIO_GPERT_P11_Pos)
+#define GPIO_GPERT_P12_Pos          12           /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P12              (_U(0x1) << GPIO_GPERT_P12_Pos)
+#define GPIO_GPERT_P13_Pos          13           /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P13              (_U(0x1) << GPIO_GPERT_P13_Pos)
+#define GPIO_GPERT_P14_Pos          14           /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P14              (_U(0x1) << GPIO_GPERT_P14_Pos)
+#define GPIO_GPERT_P15_Pos          15           /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P15              (_U(0x1) << GPIO_GPERT_P15_Pos)
+#define GPIO_GPERT_P16_Pos          16           /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P16              (_U(0x1) << GPIO_GPERT_P16_Pos)
+#define GPIO_GPERT_P17_Pos          17           /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P17              (_U(0x1) << GPIO_GPERT_P17_Pos)
+#define GPIO_GPERT_P18_Pos          18           /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P18              (_U(0x1) << GPIO_GPERT_P18_Pos)
+#define GPIO_GPERT_P19_Pos          19           /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P19              (_U(0x1) << GPIO_GPERT_P19_Pos)
+#define GPIO_GPERT_P20_Pos          20           /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P20              (_U(0x1) << GPIO_GPERT_P20_Pos)
+#define GPIO_GPERT_P21_Pos          21           /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P21              (_U(0x1) << GPIO_GPERT_P21_Pos)
+#define GPIO_GPERT_P22_Pos          22           /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P22              (_U(0x1) << GPIO_GPERT_P22_Pos)
+#define GPIO_GPERT_P23_Pos          23           /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P23              (_U(0x1) << GPIO_GPERT_P23_Pos)
+#define GPIO_GPERT_P24_Pos          24           /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P24              (_U(0x1) << GPIO_GPERT_P24_Pos)
+#define GPIO_GPERT_P25_Pos          25           /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P25              (_U(0x1) << GPIO_GPERT_P25_Pos)
+#define GPIO_GPERT_P26_Pos          26           /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P26              (_U(0x1) << GPIO_GPERT_P26_Pos)
+#define GPIO_GPERT_P27_Pos          27           /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P27              (_U(0x1) << GPIO_GPERT_P27_Pos)
+#define GPIO_GPERT_P28_Pos          28           /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P28              (_U(0x1) << GPIO_GPERT_P28_Pos)
+#define GPIO_GPERT_P29_Pos          29           /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P29              (_U(0x1) << GPIO_GPERT_P29_Pos)
+#define GPIO_GPERT_P30_Pos          30           /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P30              (_U(0x1) << GPIO_GPERT_P30_Pos)
+#define GPIO_GPERT_P31_Pos          31           /**< \brief (GPIO_GPERT) GPIO Enable */
+#define GPIO_GPERT_P31              (_U(0x1) << GPIO_GPERT_P31_Pos)
+#define GPIO_GPERT_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_GPERT) MASK Register */
+
+/* -------- GPIO_PMR0 : (GPIO Offset: 0x010) (R/W 32) port Peripheral Mux Register 0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Peripheral Multiplexer Select bit 0 */
+    uint32_t P1:1;             /*!< bit:      1  Peripheral Multiplexer Select bit 0 */
+    uint32_t P2:1;             /*!< bit:      2  Peripheral Multiplexer Select bit 0 */
+    uint32_t P3:1;             /*!< bit:      3  Peripheral Multiplexer Select bit 0 */
+    uint32_t P4:1;             /*!< bit:      4  Peripheral Multiplexer Select bit 0 */
+    uint32_t P5:1;             /*!< bit:      5  Peripheral Multiplexer Select bit 0 */
+    uint32_t P6:1;             /*!< bit:      6  Peripheral Multiplexer Select bit 0 */
+    uint32_t P7:1;             /*!< bit:      7  Peripheral Multiplexer Select bit 0 */
+    uint32_t P8:1;             /*!< bit:      8  Peripheral Multiplexer Select bit 0 */
+    uint32_t P9:1;             /*!< bit:      9  Peripheral Multiplexer Select bit 0 */
+    uint32_t P10:1;            /*!< bit:     10  Peripheral Multiplexer Select bit 0 */
+    uint32_t P11:1;            /*!< bit:     11  Peripheral Multiplexer Select bit 0 */
+    uint32_t P12:1;            /*!< bit:     12  Peripheral Multiplexer Select bit 0 */
+    uint32_t P13:1;            /*!< bit:     13  Peripheral Multiplexer Select bit 0 */
+    uint32_t P14:1;            /*!< bit:     14  Peripheral Multiplexer Select bit 0 */
+    uint32_t P15:1;            /*!< bit:     15  Peripheral Multiplexer Select bit 0 */
+    uint32_t P16:1;            /*!< bit:     16  Peripheral Multiplexer Select bit 0 */
+    uint32_t P17:1;            /*!< bit:     17  Peripheral Multiplexer Select bit 0 */
+    uint32_t P18:1;            /*!< bit:     18  Peripheral Multiplexer Select bit 0 */
+    uint32_t P19:1;            /*!< bit:     19  Peripheral Multiplexer Select bit 0 */
+    uint32_t P20:1;            /*!< bit:     20  Peripheral Multiplexer Select bit 0 */
+    uint32_t P21:1;            /*!< bit:     21  Peripheral Multiplexer Select bit 0 */
+    uint32_t P22:1;            /*!< bit:     22  Peripheral Multiplexer Select bit 0 */
+    uint32_t P23:1;            /*!< bit:     23  Peripheral Multiplexer Select bit 0 */
+    uint32_t P24:1;            /*!< bit:     24  Peripheral Multiplexer Select bit 0 */
+    uint32_t P25:1;            /*!< bit:     25  Peripheral Multiplexer Select bit 0 */
+    uint32_t P26:1;            /*!< bit:     26  Peripheral Multiplexer Select bit 0 */
+    uint32_t P27:1;            /*!< bit:     27  Peripheral Multiplexer Select bit 0 */
+    uint32_t P28:1;            /*!< bit:     28  Peripheral Multiplexer Select bit 0 */
+    uint32_t P29:1;            /*!< bit:     29  Peripheral Multiplexer Select bit 0 */
+    uint32_t P30:1;            /*!< bit:     30  Peripheral Multiplexer Select bit 0 */
+    uint32_t P31:1;            /*!< bit:     31  Peripheral Multiplexer Select bit 0 */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_PMR0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_PMR0_OFFSET            0x010        /**< \brief (GPIO_PMR0 offset) Peripheral Mux Register 0 */
+
+#define GPIO_PMR0_P0_Pos            0            /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P0                (_U(0x1) << GPIO_PMR0_P0_Pos)
+#define GPIO_PMR0_P1_Pos            1            /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P1                (_U(0x1) << GPIO_PMR0_P1_Pos)
+#define GPIO_PMR0_P2_Pos            2            /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P2                (_U(0x1) << GPIO_PMR0_P2_Pos)
+#define GPIO_PMR0_P3_Pos            3            /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P3                (_U(0x1) << GPIO_PMR0_P3_Pos)
+#define GPIO_PMR0_P4_Pos            4            /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P4                (_U(0x1) << GPIO_PMR0_P4_Pos)
+#define GPIO_PMR0_P5_Pos            5            /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P5                (_U(0x1) << GPIO_PMR0_P5_Pos)
+#define GPIO_PMR0_P6_Pos            6            /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P6                (_U(0x1) << GPIO_PMR0_P6_Pos)
+#define GPIO_PMR0_P7_Pos            7            /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P7                (_U(0x1) << GPIO_PMR0_P7_Pos)
+#define GPIO_PMR0_P8_Pos            8            /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P8                (_U(0x1) << GPIO_PMR0_P8_Pos)
+#define GPIO_PMR0_P9_Pos            9            /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P9                (_U(0x1) << GPIO_PMR0_P9_Pos)
+#define GPIO_PMR0_P10_Pos           10           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P10               (_U(0x1) << GPIO_PMR0_P10_Pos)
+#define GPIO_PMR0_P11_Pos           11           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P11               (_U(0x1) << GPIO_PMR0_P11_Pos)
+#define GPIO_PMR0_P12_Pos           12           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P12               (_U(0x1) << GPIO_PMR0_P12_Pos)
+#define GPIO_PMR0_P13_Pos           13           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P13               (_U(0x1) << GPIO_PMR0_P13_Pos)
+#define GPIO_PMR0_P14_Pos           14           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P14               (_U(0x1) << GPIO_PMR0_P14_Pos)
+#define GPIO_PMR0_P15_Pos           15           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P15               (_U(0x1) << GPIO_PMR0_P15_Pos)
+#define GPIO_PMR0_P16_Pos           16           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P16               (_U(0x1) << GPIO_PMR0_P16_Pos)
+#define GPIO_PMR0_P17_Pos           17           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P17               (_U(0x1) << GPIO_PMR0_P17_Pos)
+#define GPIO_PMR0_P18_Pos           18           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P18               (_U(0x1) << GPIO_PMR0_P18_Pos)
+#define GPIO_PMR0_P19_Pos           19           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P19               (_U(0x1) << GPIO_PMR0_P19_Pos)
+#define GPIO_PMR0_P20_Pos           20           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P20               (_U(0x1) << GPIO_PMR0_P20_Pos)
+#define GPIO_PMR0_P21_Pos           21           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P21               (_U(0x1) << GPIO_PMR0_P21_Pos)
+#define GPIO_PMR0_P22_Pos           22           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P22               (_U(0x1) << GPIO_PMR0_P22_Pos)
+#define GPIO_PMR0_P23_Pos           23           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P23               (_U(0x1) << GPIO_PMR0_P23_Pos)
+#define GPIO_PMR0_P24_Pos           24           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P24               (_U(0x1) << GPIO_PMR0_P24_Pos)
+#define GPIO_PMR0_P25_Pos           25           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P25               (_U(0x1) << GPIO_PMR0_P25_Pos)
+#define GPIO_PMR0_P26_Pos           26           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P26               (_U(0x1) << GPIO_PMR0_P26_Pos)
+#define GPIO_PMR0_P27_Pos           27           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P27               (_U(0x1) << GPIO_PMR0_P27_Pos)
+#define GPIO_PMR0_P28_Pos           28           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P28               (_U(0x1) << GPIO_PMR0_P28_Pos)
+#define GPIO_PMR0_P29_Pos           29           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P29               (_U(0x1) << GPIO_PMR0_P29_Pos)
+#define GPIO_PMR0_P30_Pos           30           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P30               (_U(0x1) << GPIO_PMR0_P30_Pos)
+#define GPIO_PMR0_P31_Pos           31           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0_P31               (_U(0x1) << GPIO_PMR0_P31_Pos)
+#define GPIO_PMR0_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_PMR0) MASK Register */
+
+/* -------- GPIO_PMR0S : (GPIO Offset: 0x014) ( /W 32) port Peripheral Mux Register 0 - Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Peripheral Multiplexer Select bit 0 */
+    uint32_t P1:1;             /*!< bit:      1  Peripheral Multiplexer Select bit 0 */
+    uint32_t P2:1;             /*!< bit:      2  Peripheral Multiplexer Select bit 0 */
+    uint32_t P3:1;             /*!< bit:      3  Peripheral Multiplexer Select bit 0 */
+    uint32_t P4:1;             /*!< bit:      4  Peripheral Multiplexer Select bit 0 */
+    uint32_t P5:1;             /*!< bit:      5  Peripheral Multiplexer Select bit 0 */
+    uint32_t P6:1;             /*!< bit:      6  Peripheral Multiplexer Select bit 0 */
+    uint32_t P7:1;             /*!< bit:      7  Peripheral Multiplexer Select bit 0 */
+    uint32_t P8:1;             /*!< bit:      8  Peripheral Multiplexer Select bit 0 */
+    uint32_t P9:1;             /*!< bit:      9  Peripheral Multiplexer Select bit 0 */
+    uint32_t P10:1;            /*!< bit:     10  Peripheral Multiplexer Select bit 0 */
+    uint32_t P11:1;            /*!< bit:     11  Peripheral Multiplexer Select bit 0 */
+    uint32_t P12:1;            /*!< bit:     12  Peripheral Multiplexer Select bit 0 */
+    uint32_t P13:1;            /*!< bit:     13  Peripheral Multiplexer Select bit 0 */
+    uint32_t P14:1;            /*!< bit:     14  Peripheral Multiplexer Select bit 0 */
+    uint32_t P15:1;            /*!< bit:     15  Peripheral Multiplexer Select bit 0 */
+    uint32_t P16:1;            /*!< bit:     16  Peripheral Multiplexer Select bit 0 */
+    uint32_t P17:1;            /*!< bit:     17  Peripheral Multiplexer Select bit 0 */
+    uint32_t P18:1;            /*!< bit:     18  Peripheral Multiplexer Select bit 0 */
+    uint32_t P19:1;            /*!< bit:     19  Peripheral Multiplexer Select bit 0 */
+    uint32_t P20:1;            /*!< bit:     20  Peripheral Multiplexer Select bit 0 */
+    uint32_t P21:1;            /*!< bit:     21  Peripheral Multiplexer Select bit 0 */
+    uint32_t P22:1;            /*!< bit:     22  Peripheral Multiplexer Select bit 0 */
+    uint32_t P23:1;            /*!< bit:     23  Peripheral Multiplexer Select bit 0 */
+    uint32_t P24:1;            /*!< bit:     24  Peripheral Multiplexer Select bit 0 */
+    uint32_t P25:1;            /*!< bit:     25  Peripheral Multiplexer Select bit 0 */
+    uint32_t P26:1;            /*!< bit:     26  Peripheral Multiplexer Select bit 0 */
+    uint32_t P27:1;            /*!< bit:     27  Peripheral Multiplexer Select bit 0 */
+    uint32_t P28:1;            /*!< bit:     28  Peripheral Multiplexer Select bit 0 */
+    uint32_t P29:1;            /*!< bit:     29  Peripheral Multiplexer Select bit 0 */
+    uint32_t P30:1;            /*!< bit:     30  Peripheral Multiplexer Select bit 0 */
+    uint32_t P31:1;            /*!< bit:     31  Peripheral Multiplexer Select bit 0 */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_PMR0S_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_PMR0S_OFFSET           0x014        /**< \brief (GPIO_PMR0S offset) Peripheral Mux Register 0 - Set */
+
+#define GPIO_PMR0S_P0_Pos           0            /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P0               (_U(0x1) << GPIO_PMR0S_P0_Pos)
+#define GPIO_PMR0S_P1_Pos           1            /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P1               (_U(0x1) << GPIO_PMR0S_P1_Pos)
+#define GPIO_PMR0S_P2_Pos           2            /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P2               (_U(0x1) << GPIO_PMR0S_P2_Pos)
+#define GPIO_PMR0S_P3_Pos           3            /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P3               (_U(0x1) << GPIO_PMR0S_P3_Pos)
+#define GPIO_PMR0S_P4_Pos           4            /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P4               (_U(0x1) << GPIO_PMR0S_P4_Pos)
+#define GPIO_PMR0S_P5_Pos           5            /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P5               (_U(0x1) << GPIO_PMR0S_P5_Pos)
+#define GPIO_PMR0S_P6_Pos           6            /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P6               (_U(0x1) << GPIO_PMR0S_P6_Pos)
+#define GPIO_PMR0S_P7_Pos           7            /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P7               (_U(0x1) << GPIO_PMR0S_P7_Pos)
+#define GPIO_PMR0S_P8_Pos           8            /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P8               (_U(0x1) << GPIO_PMR0S_P8_Pos)
+#define GPIO_PMR0S_P9_Pos           9            /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P9               (_U(0x1) << GPIO_PMR0S_P9_Pos)
+#define GPIO_PMR0S_P10_Pos          10           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P10              (_U(0x1) << GPIO_PMR0S_P10_Pos)
+#define GPIO_PMR0S_P11_Pos          11           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P11              (_U(0x1) << GPIO_PMR0S_P11_Pos)
+#define GPIO_PMR0S_P12_Pos          12           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P12              (_U(0x1) << GPIO_PMR0S_P12_Pos)
+#define GPIO_PMR0S_P13_Pos          13           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P13              (_U(0x1) << GPIO_PMR0S_P13_Pos)
+#define GPIO_PMR0S_P14_Pos          14           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P14              (_U(0x1) << GPIO_PMR0S_P14_Pos)
+#define GPIO_PMR0S_P15_Pos          15           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P15              (_U(0x1) << GPIO_PMR0S_P15_Pos)
+#define GPIO_PMR0S_P16_Pos          16           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P16              (_U(0x1) << GPIO_PMR0S_P16_Pos)
+#define GPIO_PMR0S_P17_Pos          17           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P17              (_U(0x1) << GPIO_PMR0S_P17_Pos)
+#define GPIO_PMR0S_P18_Pos          18           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P18              (_U(0x1) << GPIO_PMR0S_P18_Pos)
+#define GPIO_PMR0S_P19_Pos          19           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P19              (_U(0x1) << GPIO_PMR0S_P19_Pos)
+#define GPIO_PMR0S_P20_Pos          20           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P20              (_U(0x1) << GPIO_PMR0S_P20_Pos)
+#define GPIO_PMR0S_P21_Pos          21           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P21              (_U(0x1) << GPIO_PMR0S_P21_Pos)
+#define GPIO_PMR0S_P22_Pos          22           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P22              (_U(0x1) << GPIO_PMR0S_P22_Pos)
+#define GPIO_PMR0S_P23_Pos          23           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P23              (_U(0x1) << GPIO_PMR0S_P23_Pos)
+#define GPIO_PMR0S_P24_Pos          24           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P24              (_U(0x1) << GPIO_PMR0S_P24_Pos)
+#define GPIO_PMR0S_P25_Pos          25           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P25              (_U(0x1) << GPIO_PMR0S_P25_Pos)
+#define GPIO_PMR0S_P26_Pos          26           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P26              (_U(0x1) << GPIO_PMR0S_P26_Pos)
+#define GPIO_PMR0S_P27_Pos          27           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P27              (_U(0x1) << GPIO_PMR0S_P27_Pos)
+#define GPIO_PMR0S_P28_Pos          28           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P28              (_U(0x1) << GPIO_PMR0S_P28_Pos)
+#define GPIO_PMR0S_P29_Pos          29           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P29              (_U(0x1) << GPIO_PMR0S_P29_Pos)
+#define GPIO_PMR0S_P30_Pos          30           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P30              (_U(0x1) << GPIO_PMR0S_P30_Pos)
+#define GPIO_PMR0S_P31_Pos          31           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0S_P31              (_U(0x1) << GPIO_PMR0S_P31_Pos)
+#define GPIO_PMR0S_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PMR0S) MASK Register */
+
+/* -------- GPIO_PMR0C : (GPIO Offset: 0x018) ( /W 32) port Peripheral Mux Register 0 - Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Peripheral Multiplexer Select bit 0 */
+    uint32_t P1:1;             /*!< bit:      1  Peripheral Multiplexer Select bit 0 */
+    uint32_t P2:1;             /*!< bit:      2  Peripheral Multiplexer Select bit 0 */
+    uint32_t P3:1;             /*!< bit:      3  Peripheral Multiplexer Select bit 0 */
+    uint32_t P4:1;             /*!< bit:      4  Peripheral Multiplexer Select bit 0 */
+    uint32_t P5:1;             /*!< bit:      5  Peripheral Multiplexer Select bit 0 */
+    uint32_t P6:1;             /*!< bit:      6  Peripheral Multiplexer Select bit 0 */
+    uint32_t P7:1;             /*!< bit:      7  Peripheral Multiplexer Select bit 0 */
+    uint32_t P8:1;             /*!< bit:      8  Peripheral Multiplexer Select bit 0 */
+    uint32_t P9:1;             /*!< bit:      9  Peripheral Multiplexer Select bit 0 */
+    uint32_t P10:1;            /*!< bit:     10  Peripheral Multiplexer Select bit 0 */
+    uint32_t P11:1;            /*!< bit:     11  Peripheral Multiplexer Select bit 0 */
+    uint32_t P12:1;            /*!< bit:     12  Peripheral Multiplexer Select bit 0 */
+    uint32_t P13:1;            /*!< bit:     13  Peripheral Multiplexer Select bit 0 */
+    uint32_t P14:1;            /*!< bit:     14  Peripheral Multiplexer Select bit 0 */
+    uint32_t P15:1;            /*!< bit:     15  Peripheral Multiplexer Select bit 0 */
+    uint32_t P16:1;            /*!< bit:     16  Peripheral Multiplexer Select bit 0 */
+    uint32_t P17:1;            /*!< bit:     17  Peripheral Multiplexer Select bit 0 */
+    uint32_t P18:1;            /*!< bit:     18  Peripheral Multiplexer Select bit 0 */
+    uint32_t P19:1;            /*!< bit:     19  Peripheral Multiplexer Select bit 0 */
+    uint32_t P20:1;            /*!< bit:     20  Peripheral Multiplexer Select bit 0 */
+    uint32_t P21:1;            /*!< bit:     21  Peripheral Multiplexer Select bit 0 */
+    uint32_t P22:1;            /*!< bit:     22  Peripheral Multiplexer Select bit 0 */
+    uint32_t P23:1;            /*!< bit:     23  Peripheral Multiplexer Select bit 0 */
+    uint32_t P24:1;            /*!< bit:     24  Peripheral Multiplexer Select bit 0 */
+    uint32_t P25:1;            /*!< bit:     25  Peripheral Multiplexer Select bit 0 */
+    uint32_t P26:1;            /*!< bit:     26  Peripheral Multiplexer Select bit 0 */
+    uint32_t P27:1;            /*!< bit:     27  Peripheral Multiplexer Select bit 0 */
+    uint32_t P28:1;            /*!< bit:     28  Peripheral Multiplexer Select bit 0 */
+    uint32_t P29:1;            /*!< bit:     29  Peripheral Multiplexer Select bit 0 */
+    uint32_t P30:1;            /*!< bit:     30  Peripheral Multiplexer Select bit 0 */
+    uint32_t P31:1;            /*!< bit:     31  Peripheral Multiplexer Select bit 0 */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_PMR0C_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_PMR0C_OFFSET           0x018        /**< \brief (GPIO_PMR0C offset) Peripheral Mux Register 0 - Clear */
+
+#define GPIO_PMR0C_P0_Pos           0            /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P0               (_U(0x1) << GPIO_PMR0C_P0_Pos)
+#define GPIO_PMR0C_P1_Pos           1            /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P1               (_U(0x1) << GPIO_PMR0C_P1_Pos)
+#define GPIO_PMR0C_P2_Pos           2            /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P2               (_U(0x1) << GPIO_PMR0C_P2_Pos)
+#define GPIO_PMR0C_P3_Pos           3            /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P3               (_U(0x1) << GPIO_PMR0C_P3_Pos)
+#define GPIO_PMR0C_P4_Pos           4            /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P4               (_U(0x1) << GPIO_PMR0C_P4_Pos)
+#define GPIO_PMR0C_P5_Pos           5            /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P5               (_U(0x1) << GPIO_PMR0C_P5_Pos)
+#define GPIO_PMR0C_P6_Pos           6            /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P6               (_U(0x1) << GPIO_PMR0C_P6_Pos)
+#define GPIO_PMR0C_P7_Pos           7            /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P7               (_U(0x1) << GPIO_PMR0C_P7_Pos)
+#define GPIO_PMR0C_P8_Pos           8            /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P8               (_U(0x1) << GPIO_PMR0C_P8_Pos)
+#define GPIO_PMR0C_P9_Pos           9            /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P9               (_U(0x1) << GPIO_PMR0C_P9_Pos)
+#define GPIO_PMR0C_P10_Pos          10           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P10              (_U(0x1) << GPIO_PMR0C_P10_Pos)
+#define GPIO_PMR0C_P11_Pos          11           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P11              (_U(0x1) << GPIO_PMR0C_P11_Pos)
+#define GPIO_PMR0C_P12_Pos          12           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P12              (_U(0x1) << GPIO_PMR0C_P12_Pos)
+#define GPIO_PMR0C_P13_Pos          13           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P13              (_U(0x1) << GPIO_PMR0C_P13_Pos)
+#define GPIO_PMR0C_P14_Pos          14           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P14              (_U(0x1) << GPIO_PMR0C_P14_Pos)
+#define GPIO_PMR0C_P15_Pos          15           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P15              (_U(0x1) << GPIO_PMR0C_P15_Pos)
+#define GPIO_PMR0C_P16_Pos          16           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P16              (_U(0x1) << GPIO_PMR0C_P16_Pos)
+#define GPIO_PMR0C_P17_Pos          17           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P17              (_U(0x1) << GPIO_PMR0C_P17_Pos)
+#define GPIO_PMR0C_P18_Pos          18           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P18              (_U(0x1) << GPIO_PMR0C_P18_Pos)
+#define GPIO_PMR0C_P19_Pos          19           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P19              (_U(0x1) << GPIO_PMR0C_P19_Pos)
+#define GPIO_PMR0C_P20_Pos          20           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P20              (_U(0x1) << GPIO_PMR0C_P20_Pos)
+#define GPIO_PMR0C_P21_Pos          21           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P21              (_U(0x1) << GPIO_PMR0C_P21_Pos)
+#define GPIO_PMR0C_P22_Pos          22           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P22              (_U(0x1) << GPIO_PMR0C_P22_Pos)
+#define GPIO_PMR0C_P23_Pos          23           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P23              (_U(0x1) << GPIO_PMR0C_P23_Pos)
+#define GPIO_PMR0C_P24_Pos          24           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P24              (_U(0x1) << GPIO_PMR0C_P24_Pos)
+#define GPIO_PMR0C_P25_Pos          25           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P25              (_U(0x1) << GPIO_PMR0C_P25_Pos)
+#define GPIO_PMR0C_P26_Pos          26           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P26              (_U(0x1) << GPIO_PMR0C_P26_Pos)
+#define GPIO_PMR0C_P27_Pos          27           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P27              (_U(0x1) << GPIO_PMR0C_P27_Pos)
+#define GPIO_PMR0C_P28_Pos          28           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P28              (_U(0x1) << GPIO_PMR0C_P28_Pos)
+#define GPIO_PMR0C_P29_Pos          29           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P29              (_U(0x1) << GPIO_PMR0C_P29_Pos)
+#define GPIO_PMR0C_P30_Pos          30           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P30              (_U(0x1) << GPIO_PMR0C_P30_Pos)
+#define GPIO_PMR0C_P31_Pos          31           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0C_P31              (_U(0x1) << GPIO_PMR0C_P31_Pos)
+#define GPIO_PMR0C_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PMR0C) MASK Register */
+
+/* -------- GPIO_PMR0T : (GPIO Offset: 0x01C) ( /W 32) port Peripheral Mux Register 0 - Toggle -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Peripheral Multiplexer Select bit 0 */
+    uint32_t P1:1;             /*!< bit:      1  Peripheral Multiplexer Select bit 0 */
+    uint32_t P2:1;             /*!< bit:      2  Peripheral Multiplexer Select bit 0 */
+    uint32_t P3:1;             /*!< bit:      3  Peripheral Multiplexer Select bit 0 */
+    uint32_t P4:1;             /*!< bit:      4  Peripheral Multiplexer Select bit 0 */
+    uint32_t P5:1;             /*!< bit:      5  Peripheral Multiplexer Select bit 0 */
+    uint32_t P6:1;             /*!< bit:      6  Peripheral Multiplexer Select bit 0 */
+    uint32_t P7:1;             /*!< bit:      7  Peripheral Multiplexer Select bit 0 */
+    uint32_t P8:1;             /*!< bit:      8  Peripheral Multiplexer Select bit 0 */
+    uint32_t P9:1;             /*!< bit:      9  Peripheral Multiplexer Select bit 0 */
+    uint32_t P10:1;            /*!< bit:     10  Peripheral Multiplexer Select bit 0 */
+    uint32_t P11:1;            /*!< bit:     11  Peripheral Multiplexer Select bit 0 */
+    uint32_t P12:1;            /*!< bit:     12  Peripheral Multiplexer Select bit 0 */
+    uint32_t P13:1;            /*!< bit:     13  Peripheral Multiplexer Select bit 0 */
+    uint32_t P14:1;            /*!< bit:     14  Peripheral Multiplexer Select bit 0 */
+    uint32_t P15:1;            /*!< bit:     15  Peripheral Multiplexer Select bit 0 */
+    uint32_t P16:1;            /*!< bit:     16  Peripheral Multiplexer Select bit 0 */
+    uint32_t P17:1;            /*!< bit:     17  Peripheral Multiplexer Select bit 0 */
+    uint32_t P18:1;            /*!< bit:     18  Peripheral Multiplexer Select bit 0 */
+    uint32_t P19:1;            /*!< bit:     19  Peripheral Multiplexer Select bit 0 */
+    uint32_t P20:1;            /*!< bit:     20  Peripheral Multiplexer Select bit 0 */
+    uint32_t P21:1;            /*!< bit:     21  Peripheral Multiplexer Select bit 0 */
+    uint32_t P22:1;            /*!< bit:     22  Peripheral Multiplexer Select bit 0 */
+    uint32_t P23:1;            /*!< bit:     23  Peripheral Multiplexer Select bit 0 */
+    uint32_t P24:1;            /*!< bit:     24  Peripheral Multiplexer Select bit 0 */
+    uint32_t P25:1;            /*!< bit:     25  Peripheral Multiplexer Select bit 0 */
+    uint32_t P26:1;            /*!< bit:     26  Peripheral Multiplexer Select bit 0 */
+    uint32_t P27:1;            /*!< bit:     27  Peripheral Multiplexer Select bit 0 */
+    uint32_t P28:1;            /*!< bit:     28  Peripheral Multiplexer Select bit 0 */
+    uint32_t P29:1;            /*!< bit:     29  Peripheral Multiplexer Select bit 0 */
+    uint32_t P30:1;            /*!< bit:     30  Peripheral Multiplexer Select bit 0 */
+    uint32_t P31:1;            /*!< bit:     31  Peripheral Multiplexer Select bit 0 */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_PMR0T_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_PMR0T_OFFSET           0x01C        /**< \brief (GPIO_PMR0T offset) Peripheral Mux Register 0 - Toggle */
+
+#define GPIO_PMR0T_P0_Pos           0            /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P0               (_U(0x1) << GPIO_PMR0T_P0_Pos)
+#define GPIO_PMR0T_P1_Pos           1            /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P1               (_U(0x1) << GPIO_PMR0T_P1_Pos)
+#define GPIO_PMR0T_P2_Pos           2            /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P2               (_U(0x1) << GPIO_PMR0T_P2_Pos)
+#define GPIO_PMR0T_P3_Pos           3            /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P3               (_U(0x1) << GPIO_PMR0T_P3_Pos)
+#define GPIO_PMR0T_P4_Pos           4            /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P4               (_U(0x1) << GPIO_PMR0T_P4_Pos)
+#define GPIO_PMR0T_P5_Pos           5            /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P5               (_U(0x1) << GPIO_PMR0T_P5_Pos)
+#define GPIO_PMR0T_P6_Pos           6            /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P6               (_U(0x1) << GPIO_PMR0T_P6_Pos)
+#define GPIO_PMR0T_P7_Pos           7            /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P7               (_U(0x1) << GPIO_PMR0T_P7_Pos)
+#define GPIO_PMR0T_P8_Pos           8            /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P8               (_U(0x1) << GPIO_PMR0T_P8_Pos)
+#define GPIO_PMR0T_P9_Pos           9            /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P9               (_U(0x1) << GPIO_PMR0T_P9_Pos)
+#define GPIO_PMR0T_P10_Pos          10           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P10              (_U(0x1) << GPIO_PMR0T_P10_Pos)
+#define GPIO_PMR0T_P11_Pos          11           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P11              (_U(0x1) << GPIO_PMR0T_P11_Pos)
+#define GPIO_PMR0T_P12_Pos          12           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P12              (_U(0x1) << GPIO_PMR0T_P12_Pos)
+#define GPIO_PMR0T_P13_Pos          13           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P13              (_U(0x1) << GPIO_PMR0T_P13_Pos)
+#define GPIO_PMR0T_P14_Pos          14           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P14              (_U(0x1) << GPIO_PMR0T_P14_Pos)
+#define GPIO_PMR0T_P15_Pos          15           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P15              (_U(0x1) << GPIO_PMR0T_P15_Pos)
+#define GPIO_PMR0T_P16_Pos          16           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P16              (_U(0x1) << GPIO_PMR0T_P16_Pos)
+#define GPIO_PMR0T_P17_Pos          17           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P17              (_U(0x1) << GPIO_PMR0T_P17_Pos)
+#define GPIO_PMR0T_P18_Pos          18           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P18              (_U(0x1) << GPIO_PMR0T_P18_Pos)
+#define GPIO_PMR0T_P19_Pos          19           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P19              (_U(0x1) << GPIO_PMR0T_P19_Pos)
+#define GPIO_PMR0T_P20_Pos          20           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P20              (_U(0x1) << GPIO_PMR0T_P20_Pos)
+#define GPIO_PMR0T_P21_Pos          21           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P21              (_U(0x1) << GPIO_PMR0T_P21_Pos)
+#define GPIO_PMR0T_P22_Pos          22           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P22              (_U(0x1) << GPIO_PMR0T_P22_Pos)
+#define GPIO_PMR0T_P23_Pos          23           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P23              (_U(0x1) << GPIO_PMR0T_P23_Pos)
+#define GPIO_PMR0T_P24_Pos          24           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P24              (_U(0x1) << GPIO_PMR0T_P24_Pos)
+#define GPIO_PMR0T_P25_Pos          25           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P25              (_U(0x1) << GPIO_PMR0T_P25_Pos)
+#define GPIO_PMR0T_P26_Pos          26           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P26              (_U(0x1) << GPIO_PMR0T_P26_Pos)
+#define GPIO_PMR0T_P27_Pos          27           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P27              (_U(0x1) << GPIO_PMR0T_P27_Pos)
+#define GPIO_PMR0T_P28_Pos          28           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P28              (_U(0x1) << GPIO_PMR0T_P28_Pos)
+#define GPIO_PMR0T_P29_Pos          29           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P29              (_U(0x1) << GPIO_PMR0T_P29_Pos)
+#define GPIO_PMR0T_P30_Pos          30           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P30              (_U(0x1) << GPIO_PMR0T_P30_Pos)
+#define GPIO_PMR0T_P31_Pos          31           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
+#define GPIO_PMR0T_P31              (_U(0x1) << GPIO_PMR0T_P31_Pos)
+#define GPIO_PMR0T_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PMR0T) MASK Register */
+
+/* -------- GPIO_PMR1 : (GPIO Offset: 0x020) (R/W 32) port Peripheral Mux Register 1 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Peripheral Multiplexer Select bit 1 */
+    uint32_t P1:1;             /*!< bit:      1  Peripheral Multiplexer Select bit 1 */
+    uint32_t P2:1;             /*!< bit:      2  Peripheral Multiplexer Select bit 1 */
+    uint32_t P3:1;             /*!< bit:      3  Peripheral Multiplexer Select bit 1 */
+    uint32_t P4:1;             /*!< bit:      4  Peripheral Multiplexer Select bit 1 */
+    uint32_t P5:1;             /*!< bit:      5  Peripheral Multiplexer Select bit 1 */
+    uint32_t P6:1;             /*!< bit:      6  Peripheral Multiplexer Select bit 1 */
+    uint32_t P7:1;             /*!< bit:      7  Peripheral Multiplexer Select bit 1 */
+    uint32_t P8:1;             /*!< bit:      8  Peripheral Multiplexer Select bit 1 */
+    uint32_t P9:1;             /*!< bit:      9  Peripheral Multiplexer Select bit 1 */
+    uint32_t P10:1;            /*!< bit:     10  Peripheral Multiplexer Select bit 1 */
+    uint32_t P11:1;            /*!< bit:     11  Peripheral Multiplexer Select bit 1 */
+    uint32_t P12:1;            /*!< bit:     12  Peripheral Multiplexer Select bit 1 */
+    uint32_t P13:1;            /*!< bit:     13  Peripheral Multiplexer Select bit 1 */
+    uint32_t P14:1;            /*!< bit:     14  Peripheral Multiplexer Select bit 1 */
+    uint32_t P15:1;            /*!< bit:     15  Peripheral Multiplexer Select bit 1 */
+    uint32_t P16:1;            /*!< bit:     16  Peripheral Multiplexer Select bit 1 */
+    uint32_t P17:1;            /*!< bit:     17  Peripheral Multiplexer Select bit 1 */
+    uint32_t P18:1;            /*!< bit:     18  Peripheral Multiplexer Select bit 1 */
+    uint32_t P19:1;            /*!< bit:     19  Peripheral Multiplexer Select bit 1 */
+    uint32_t P20:1;            /*!< bit:     20  Peripheral Multiplexer Select bit 1 */
+    uint32_t P21:1;            /*!< bit:     21  Peripheral Multiplexer Select bit 1 */
+    uint32_t P22:1;            /*!< bit:     22  Peripheral Multiplexer Select bit 1 */
+    uint32_t P23:1;            /*!< bit:     23  Peripheral Multiplexer Select bit 1 */
+    uint32_t P24:1;            /*!< bit:     24  Peripheral Multiplexer Select bit 1 */
+    uint32_t P25:1;            /*!< bit:     25  Peripheral Multiplexer Select bit 1 */
+    uint32_t P26:1;            /*!< bit:     26  Peripheral Multiplexer Select bit 1 */
+    uint32_t P27:1;            /*!< bit:     27  Peripheral Multiplexer Select bit 1 */
+    uint32_t P28:1;            /*!< bit:     28  Peripheral Multiplexer Select bit 1 */
+    uint32_t P29:1;            /*!< bit:     29  Peripheral Multiplexer Select bit 1 */
+    uint32_t P30:1;            /*!< bit:     30  Peripheral Multiplexer Select bit 1 */
+    uint32_t P31:1;            /*!< bit:     31  Peripheral Multiplexer Select bit 1 */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_PMR1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_PMR1_OFFSET            0x020        /**< \brief (GPIO_PMR1 offset) Peripheral Mux Register 1 */
+
+#define GPIO_PMR1_P0_Pos            0            /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P0                (_U(0x1) << GPIO_PMR1_P0_Pos)
+#define GPIO_PMR1_P1_Pos            1            /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P1                (_U(0x1) << GPIO_PMR1_P1_Pos)
+#define GPIO_PMR1_P2_Pos            2            /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P2                (_U(0x1) << GPIO_PMR1_P2_Pos)
+#define GPIO_PMR1_P3_Pos            3            /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P3                (_U(0x1) << GPIO_PMR1_P3_Pos)
+#define GPIO_PMR1_P4_Pos            4            /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P4                (_U(0x1) << GPIO_PMR1_P4_Pos)
+#define GPIO_PMR1_P5_Pos            5            /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P5                (_U(0x1) << GPIO_PMR1_P5_Pos)
+#define GPIO_PMR1_P6_Pos            6            /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P6                (_U(0x1) << GPIO_PMR1_P6_Pos)
+#define GPIO_PMR1_P7_Pos            7            /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P7                (_U(0x1) << GPIO_PMR1_P7_Pos)
+#define GPIO_PMR1_P8_Pos            8            /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P8                (_U(0x1) << GPIO_PMR1_P8_Pos)
+#define GPIO_PMR1_P9_Pos            9            /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P9                (_U(0x1) << GPIO_PMR1_P9_Pos)
+#define GPIO_PMR1_P10_Pos           10           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P10               (_U(0x1) << GPIO_PMR1_P10_Pos)
+#define GPIO_PMR1_P11_Pos           11           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P11               (_U(0x1) << GPIO_PMR1_P11_Pos)
+#define GPIO_PMR1_P12_Pos           12           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P12               (_U(0x1) << GPIO_PMR1_P12_Pos)
+#define GPIO_PMR1_P13_Pos           13           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P13               (_U(0x1) << GPIO_PMR1_P13_Pos)
+#define GPIO_PMR1_P14_Pos           14           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P14               (_U(0x1) << GPIO_PMR1_P14_Pos)
+#define GPIO_PMR1_P15_Pos           15           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P15               (_U(0x1) << GPIO_PMR1_P15_Pos)
+#define GPIO_PMR1_P16_Pos           16           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P16               (_U(0x1) << GPIO_PMR1_P16_Pos)
+#define GPIO_PMR1_P17_Pos           17           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P17               (_U(0x1) << GPIO_PMR1_P17_Pos)
+#define GPIO_PMR1_P18_Pos           18           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P18               (_U(0x1) << GPIO_PMR1_P18_Pos)
+#define GPIO_PMR1_P19_Pos           19           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P19               (_U(0x1) << GPIO_PMR1_P19_Pos)
+#define GPIO_PMR1_P20_Pos           20           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P20               (_U(0x1) << GPIO_PMR1_P20_Pos)
+#define GPIO_PMR1_P21_Pos           21           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P21               (_U(0x1) << GPIO_PMR1_P21_Pos)
+#define GPIO_PMR1_P22_Pos           22           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P22               (_U(0x1) << GPIO_PMR1_P22_Pos)
+#define GPIO_PMR1_P23_Pos           23           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P23               (_U(0x1) << GPIO_PMR1_P23_Pos)
+#define GPIO_PMR1_P24_Pos           24           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P24               (_U(0x1) << GPIO_PMR1_P24_Pos)
+#define GPIO_PMR1_P25_Pos           25           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P25               (_U(0x1) << GPIO_PMR1_P25_Pos)
+#define GPIO_PMR1_P26_Pos           26           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P26               (_U(0x1) << GPIO_PMR1_P26_Pos)
+#define GPIO_PMR1_P27_Pos           27           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P27               (_U(0x1) << GPIO_PMR1_P27_Pos)
+#define GPIO_PMR1_P28_Pos           28           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P28               (_U(0x1) << GPIO_PMR1_P28_Pos)
+#define GPIO_PMR1_P29_Pos           29           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P29               (_U(0x1) << GPIO_PMR1_P29_Pos)
+#define GPIO_PMR1_P30_Pos           30           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P30               (_U(0x1) << GPIO_PMR1_P30_Pos)
+#define GPIO_PMR1_P31_Pos           31           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1_P31               (_U(0x1) << GPIO_PMR1_P31_Pos)
+#define GPIO_PMR1_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_PMR1) MASK Register */
+
+/* -------- GPIO_PMR1S : (GPIO Offset: 0x024) ( /W 32) port Peripheral Mux Register 1 - Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Peripheral Multiplexer Select bit 1 */
+    uint32_t P1:1;             /*!< bit:      1  Peripheral Multiplexer Select bit 1 */
+    uint32_t P2:1;             /*!< bit:      2  Peripheral Multiplexer Select bit 1 */
+    uint32_t P3:1;             /*!< bit:      3  Peripheral Multiplexer Select bit 1 */
+    uint32_t P4:1;             /*!< bit:      4  Peripheral Multiplexer Select bit 1 */
+    uint32_t P5:1;             /*!< bit:      5  Peripheral Multiplexer Select bit 1 */
+    uint32_t P6:1;             /*!< bit:      6  Peripheral Multiplexer Select bit 1 */
+    uint32_t P7:1;             /*!< bit:      7  Peripheral Multiplexer Select bit 1 */
+    uint32_t P8:1;             /*!< bit:      8  Peripheral Multiplexer Select bit 1 */
+    uint32_t P9:1;             /*!< bit:      9  Peripheral Multiplexer Select bit 1 */
+    uint32_t P10:1;            /*!< bit:     10  Peripheral Multiplexer Select bit 1 */
+    uint32_t P11:1;            /*!< bit:     11  Peripheral Multiplexer Select bit 1 */
+    uint32_t P12:1;            /*!< bit:     12  Peripheral Multiplexer Select bit 1 */
+    uint32_t P13:1;            /*!< bit:     13  Peripheral Multiplexer Select bit 1 */
+    uint32_t P14:1;            /*!< bit:     14  Peripheral Multiplexer Select bit 1 */
+    uint32_t P15:1;            /*!< bit:     15  Peripheral Multiplexer Select bit 1 */
+    uint32_t P16:1;            /*!< bit:     16  Peripheral Multiplexer Select bit 1 */
+    uint32_t P17:1;            /*!< bit:     17  Peripheral Multiplexer Select bit 1 */
+    uint32_t P18:1;            /*!< bit:     18  Peripheral Multiplexer Select bit 1 */
+    uint32_t P19:1;            /*!< bit:     19  Peripheral Multiplexer Select bit 1 */
+    uint32_t P20:1;            /*!< bit:     20  Peripheral Multiplexer Select bit 1 */
+    uint32_t P21:1;            /*!< bit:     21  Peripheral Multiplexer Select bit 1 */
+    uint32_t P22:1;            /*!< bit:     22  Peripheral Multiplexer Select bit 1 */
+    uint32_t P23:1;            /*!< bit:     23  Peripheral Multiplexer Select bit 1 */
+    uint32_t P24:1;            /*!< bit:     24  Peripheral Multiplexer Select bit 1 */
+    uint32_t P25:1;            /*!< bit:     25  Peripheral Multiplexer Select bit 1 */
+    uint32_t P26:1;            /*!< bit:     26  Peripheral Multiplexer Select bit 1 */
+    uint32_t P27:1;            /*!< bit:     27  Peripheral Multiplexer Select bit 1 */
+    uint32_t P28:1;            /*!< bit:     28  Peripheral Multiplexer Select bit 1 */
+    uint32_t P29:1;            /*!< bit:     29  Peripheral Multiplexer Select bit 1 */
+    uint32_t P30:1;            /*!< bit:     30  Peripheral Multiplexer Select bit 1 */
+    uint32_t P31:1;            /*!< bit:     31  Peripheral Multiplexer Select bit 1 */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_PMR1S_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_PMR1S_OFFSET           0x024        /**< \brief (GPIO_PMR1S offset) Peripheral Mux Register 1 - Set */
+
+#define GPIO_PMR1S_P0_Pos           0            /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P0               (_U(0x1) << GPIO_PMR1S_P0_Pos)
+#define GPIO_PMR1S_P1_Pos           1            /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P1               (_U(0x1) << GPIO_PMR1S_P1_Pos)
+#define GPIO_PMR1S_P2_Pos           2            /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P2               (_U(0x1) << GPIO_PMR1S_P2_Pos)
+#define GPIO_PMR1S_P3_Pos           3            /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P3               (_U(0x1) << GPIO_PMR1S_P3_Pos)
+#define GPIO_PMR1S_P4_Pos           4            /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P4               (_U(0x1) << GPIO_PMR1S_P4_Pos)
+#define GPIO_PMR1S_P5_Pos           5            /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P5               (_U(0x1) << GPIO_PMR1S_P5_Pos)
+#define GPIO_PMR1S_P6_Pos           6            /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P6               (_U(0x1) << GPIO_PMR1S_P6_Pos)
+#define GPIO_PMR1S_P7_Pos           7            /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P7               (_U(0x1) << GPIO_PMR1S_P7_Pos)
+#define GPIO_PMR1S_P8_Pos           8            /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P8               (_U(0x1) << GPIO_PMR1S_P8_Pos)
+#define GPIO_PMR1S_P9_Pos           9            /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P9               (_U(0x1) << GPIO_PMR1S_P9_Pos)
+#define GPIO_PMR1S_P10_Pos          10           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P10              (_U(0x1) << GPIO_PMR1S_P10_Pos)
+#define GPIO_PMR1S_P11_Pos          11           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P11              (_U(0x1) << GPIO_PMR1S_P11_Pos)
+#define GPIO_PMR1S_P12_Pos          12           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P12              (_U(0x1) << GPIO_PMR1S_P12_Pos)
+#define GPIO_PMR1S_P13_Pos          13           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P13              (_U(0x1) << GPIO_PMR1S_P13_Pos)
+#define GPIO_PMR1S_P14_Pos          14           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P14              (_U(0x1) << GPIO_PMR1S_P14_Pos)
+#define GPIO_PMR1S_P15_Pos          15           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P15              (_U(0x1) << GPIO_PMR1S_P15_Pos)
+#define GPIO_PMR1S_P16_Pos          16           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P16              (_U(0x1) << GPIO_PMR1S_P16_Pos)
+#define GPIO_PMR1S_P17_Pos          17           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P17              (_U(0x1) << GPIO_PMR1S_P17_Pos)
+#define GPIO_PMR1S_P18_Pos          18           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P18              (_U(0x1) << GPIO_PMR1S_P18_Pos)
+#define GPIO_PMR1S_P19_Pos          19           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P19              (_U(0x1) << GPIO_PMR1S_P19_Pos)
+#define GPIO_PMR1S_P20_Pos          20           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P20              (_U(0x1) << GPIO_PMR1S_P20_Pos)
+#define GPIO_PMR1S_P21_Pos          21           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P21              (_U(0x1) << GPIO_PMR1S_P21_Pos)
+#define GPIO_PMR1S_P22_Pos          22           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P22              (_U(0x1) << GPIO_PMR1S_P22_Pos)
+#define GPIO_PMR1S_P23_Pos          23           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P23              (_U(0x1) << GPIO_PMR1S_P23_Pos)
+#define GPIO_PMR1S_P24_Pos          24           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P24              (_U(0x1) << GPIO_PMR1S_P24_Pos)
+#define GPIO_PMR1S_P25_Pos          25           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P25              (_U(0x1) << GPIO_PMR1S_P25_Pos)
+#define GPIO_PMR1S_P26_Pos          26           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P26              (_U(0x1) << GPIO_PMR1S_P26_Pos)
+#define GPIO_PMR1S_P27_Pos          27           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P27              (_U(0x1) << GPIO_PMR1S_P27_Pos)
+#define GPIO_PMR1S_P28_Pos          28           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P28              (_U(0x1) << GPIO_PMR1S_P28_Pos)
+#define GPIO_PMR1S_P29_Pos          29           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P29              (_U(0x1) << GPIO_PMR1S_P29_Pos)
+#define GPIO_PMR1S_P30_Pos          30           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P30              (_U(0x1) << GPIO_PMR1S_P30_Pos)
+#define GPIO_PMR1S_P31_Pos          31           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1S_P31              (_U(0x1) << GPIO_PMR1S_P31_Pos)
+#define GPIO_PMR1S_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PMR1S) MASK Register */
+
+/* -------- GPIO_PMR1C : (GPIO Offset: 0x028) ( /W 32) port Peripheral Mux Register 1 - Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Peripheral Multiplexer Select bit 1 */
+    uint32_t P1:1;             /*!< bit:      1  Peripheral Multiplexer Select bit 1 */
+    uint32_t P2:1;             /*!< bit:      2  Peripheral Multiplexer Select bit 1 */
+    uint32_t P3:1;             /*!< bit:      3  Peripheral Multiplexer Select bit 1 */
+    uint32_t P4:1;             /*!< bit:      4  Peripheral Multiplexer Select bit 1 */
+    uint32_t P5:1;             /*!< bit:      5  Peripheral Multiplexer Select bit 1 */
+    uint32_t P6:1;             /*!< bit:      6  Peripheral Multiplexer Select bit 1 */
+    uint32_t P7:1;             /*!< bit:      7  Peripheral Multiplexer Select bit 1 */
+    uint32_t P8:1;             /*!< bit:      8  Peripheral Multiplexer Select bit 1 */
+    uint32_t P9:1;             /*!< bit:      9  Peripheral Multiplexer Select bit 1 */
+    uint32_t P10:1;            /*!< bit:     10  Peripheral Multiplexer Select bit 1 */
+    uint32_t P11:1;            /*!< bit:     11  Peripheral Multiplexer Select bit 1 */
+    uint32_t P12:1;            /*!< bit:     12  Peripheral Multiplexer Select bit 1 */
+    uint32_t P13:1;            /*!< bit:     13  Peripheral Multiplexer Select bit 1 */
+    uint32_t P14:1;            /*!< bit:     14  Peripheral Multiplexer Select bit 1 */
+    uint32_t P15:1;            /*!< bit:     15  Peripheral Multiplexer Select bit 1 */
+    uint32_t P16:1;            /*!< bit:     16  Peripheral Multiplexer Select bit 1 */
+    uint32_t P17:1;            /*!< bit:     17  Peripheral Multiplexer Select bit 1 */
+    uint32_t P18:1;            /*!< bit:     18  Peripheral Multiplexer Select bit 1 */
+    uint32_t P19:1;            /*!< bit:     19  Peripheral Multiplexer Select bit 1 */
+    uint32_t P20:1;            /*!< bit:     20  Peripheral Multiplexer Select bit 1 */
+    uint32_t P21:1;            /*!< bit:     21  Peripheral Multiplexer Select bit 1 */
+    uint32_t P22:1;            /*!< bit:     22  Peripheral Multiplexer Select bit 1 */
+    uint32_t P23:1;            /*!< bit:     23  Peripheral Multiplexer Select bit 1 */
+    uint32_t P24:1;            /*!< bit:     24  Peripheral Multiplexer Select bit 1 */
+    uint32_t P25:1;            /*!< bit:     25  Peripheral Multiplexer Select bit 1 */
+    uint32_t P26:1;            /*!< bit:     26  Peripheral Multiplexer Select bit 1 */
+    uint32_t P27:1;            /*!< bit:     27  Peripheral Multiplexer Select bit 1 */
+    uint32_t P28:1;            /*!< bit:     28  Peripheral Multiplexer Select bit 1 */
+    uint32_t P29:1;            /*!< bit:     29  Peripheral Multiplexer Select bit 1 */
+    uint32_t P30:1;            /*!< bit:     30  Peripheral Multiplexer Select bit 1 */
+    uint32_t P31:1;            /*!< bit:     31  Peripheral Multiplexer Select bit 1 */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_PMR1C_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_PMR1C_OFFSET           0x028        /**< \brief (GPIO_PMR1C offset) Peripheral Mux Register 1 - Clear */
+
+#define GPIO_PMR1C_P0_Pos           0            /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P0               (_U(0x1) << GPIO_PMR1C_P0_Pos)
+#define GPIO_PMR1C_P1_Pos           1            /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P1               (_U(0x1) << GPIO_PMR1C_P1_Pos)
+#define GPIO_PMR1C_P2_Pos           2            /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P2               (_U(0x1) << GPIO_PMR1C_P2_Pos)
+#define GPIO_PMR1C_P3_Pos           3            /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P3               (_U(0x1) << GPIO_PMR1C_P3_Pos)
+#define GPIO_PMR1C_P4_Pos           4            /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P4               (_U(0x1) << GPIO_PMR1C_P4_Pos)
+#define GPIO_PMR1C_P5_Pos           5            /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P5               (_U(0x1) << GPIO_PMR1C_P5_Pos)
+#define GPIO_PMR1C_P6_Pos           6            /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P6               (_U(0x1) << GPIO_PMR1C_P6_Pos)
+#define GPIO_PMR1C_P7_Pos           7            /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P7               (_U(0x1) << GPIO_PMR1C_P7_Pos)
+#define GPIO_PMR1C_P8_Pos           8            /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P8               (_U(0x1) << GPIO_PMR1C_P8_Pos)
+#define GPIO_PMR1C_P9_Pos           9            /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P9               (_U(0x1) << GPIO_PMR1C_P9_Pos)
+#define GPIO_PMR1C_P10_Pos          10           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P10              (_U(0x1) << GPIO_PMR1C_P10_Pos)
+#define GPIO_PMR1C_P11_Pos          11           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P11              (_U(0x1) << GPIO_PMR1C_P11_Pos)
+#define GPIO_PMR1C_P12_Pos          12           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P12              (_U(0x1) << GPIO_PMR1C_P12_Pos)
+#define GPIO_PMR1C_P13_Pos          13           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P13              (_U(0x1) << GPIO_PMR1C_P13_Pos)
+#define GPIO_PMR1C_P14_Pos          14           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P14              (_U(0x1) << GPIO_PMR1C_P14_Pos)
+#define GPIO_PMR1C_P15_Pos          15           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P15              (_U(0x1) << GPIO_PMR1C_P15_Pos)
+#define GPIO_PMR1C_P16_Pos          16           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P16              (_U(0x1) << GPIO_PMR1C_P16_Pos)
+#define GPIO_PMR1C_P17_Pos          17           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P17              (_U(0x1) << GPIO_PMR1C_P17_Pos)
+#define GPIO_PMR1C_P18_Pos          18           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P18              (_U(0x1) << GPIO_PMR1C_P18_Pos)
+#define GPIO_PMR1C_P19_Pos          19           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P19              (_U(0x1) << GPIO_PMR1C_P19_Pos)
+#define GPIO_PMR1C_P20_Pos          20           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P20              (_U(0x1) << GPIO_PMR1C_P20_Pos)
+#define GPIO_PMR1C_P21_Pos          21           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P21              (_U(0x1) << GPIO_PMR1C_P21_Pos)
+#define GPIO_PMR1C_P22_Pos          22           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P22              (_U(0x1) << GPIO_PMR1C_P22_Pos)
+#define GPIO_PMR1C_P23_Pos          23           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P23              (_U(0x1) << GPIO_PMR1C_P23_Pos)
+#define GPIO_PMR1C_P24_Pos          24           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P24              (_U(0x1) << GPIO_PMR1C_P24_Pos)
+#define GPIO_PMR1C_P25_Pos          25           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P25              (_U(0x1) << GPIO_PMR1C_P25_Pos)
+#define GPIO_PMR1C_P26_Pos          26           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P26              (_U(0x1) << GPIO_PMR1C_P26_Pos)
+#define GPIO_PMR1C_P27_Pos          27           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P27              (_U(0x1) << GPIO_PMR1C_P27_Pos)
+#define GPIO_PMR1C_P28_Pos          28           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P28              (_U(0x1) << GPIO_PMR1C_P28_Pos)
+#define GPIO_PMR1C_P29_Pos          29           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P29              (_U(0x1) << GPIO_PMR1C_P29_Pos)
+#define GPIO_PMR1C_P30_Pos          30           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P30              (_U(0x1) << GPIO_PMR1C_P30_Pos)
+#define GPIO_PMR1C_P31_Pos          31           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1C_P31              (_U(0x1) << GPIO_PMR1C_P31_Pos)
+#define GPIO_PMR1C_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PMR1C) MASK Register */
+
+/* -------- GPIO_PMR1T : (GPIO Offset: 0x02C) ( /W 32) port Peripheral Mux Register 1 - Toggle -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Peripheral Multiplexer Select bit 1 */
+    uint32_t P1:1;             /*!< bit:      1  Peripheral Multiplexer Select bit 1 */
+    uint32_t P2:1;             /*!< bit:      2  Peripheral Multiplexer Select bit 1 */
+    uint32_t P3:1;             /*!< bit:      3  Peripheral Multiplexer Select bit 1 */
+    uint32_t P4:1;             /*!< bit:      4  Peripheral Multiplexer Select bit 1 */
+    uint32_t P5:1;             /*!< bit:      5  Peripheral Multiplexer Select bit 1 */
+    uint32_t P6:1;             /*!< bit:      6  Peripheral Multiplexer Select bit 1 */
+    uint32_t P7:1;             /*!< bit:      7  Peripheral Multiplexer Select bit 1 */
+    uint32_t P8:1;             /*!< bit:      8  Peripheral Multiplexer Select bit 1 */
+    uint32_t P9:1;             /*!< bit:      9  Peripheral Multiplexer Select bit 1 */
+    uint32_t P10:1;            /*!< bit:     10  Peripheral Multiplexer Select bit 1 */
+    uint32_t P11:1;            /*!< bit:     11  Peripheral Multiplexer Select bit 1 */
+    uint32_t P12:1;            /*!< bit:     12  Peripheral Multiplexer Select bit 1 */
+    uint32_t P13:1;            /*!< bit:     13  Peripheral Multiplexer Select bit 1 */
+    uint32_t P14:1;            /*!< bit:     14  Peripheral Multiplexer Select bit 1 */
+    uint32_t P15:1;            /*!< bit:     15  Peripheral Multiplexer Select bit 1 */
+    uint32_t P16:1;            /*!< bit:     16  Peripheral Multiplexer Select bit 1 */
+    uint32_t P17:1;            /*!< bit:     17  Peripheral Multiplexer Select bit 1 */
+    uint32_t P18:1;            /*!< bit:     18  Peripheral Multiplexer Select bit 1 */
+    uint32_t P19:1;            /*!< bit:     19  Peripheral Multiplexer Select bit 1 */
+    uint32_t P20:1;            /*!< bit:     20  Peripheral Multiplexer Select bit 1 */
+    uint32_t P21:1;            /*!< bit:     21  Peripheral Multiplexer Select bit 1 */
+    uint32_t P22:1;            /*!< bit:     22  Peripheral Multiplexer Select bit 1 */
+    uint32_t P23:1;            /*!< bit:     23  Peripheral Multiplexer Select bit 1 */
+    uint32_t P24:1;            /*!< bit:     24  Peripheral Multiplexer Select bit 1 */
+    uint32_t P25:1;            /*!< bit:     25  Peripheral Multiplexer Select bit 1 */
+    uint32_t P26:1;            /*!< bit:     26  Peripheral Multiplexer Select bit 1 */
+    uint32_t P27:1;            /*!< bit:     27  Peripheral Multiplexer Select bit 1 */
+    uint32_t P28:1;            /*!< bit:     28  Peripheral Multiplexer Select bit 1 */
+    uint32_t P29:1;            /*!< bit:     29  Peripheral Multiplexer Select bit 1 */
+    uint32_t P30:1;            /*!< bit:     30  Peripheral Multiplexer Select bit 1 */
+    uint32_t P31:1;            /*!< bit:     31  Peripheral Multiplexer Select bit 1 */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_PMR1T_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_PMR1T_OFFSET           0x02C        /**< \brief (GPIO_PMR1T offset) Peripheral Mux Register 1 - Toggle */
+
+#define GPIO_PMR1T_P0_Pos           0            /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P0               (_U(0x1) << GPIO_PMR1T_P0_Pos)
+#define GPIO_PMR1T_P1_Pos           1            /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P1               (_U(0x1) << GPIO_PMR1T_P1_Pos)
+#define GPIO_PMR1T_P2_Pos           2            /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P2               (_U(0x1) << GPIO_PMR1T_P2_Pos)
+#define GPIO_PMR1T_P3_Pos           3            /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P3               (_U(0x1) << GPIO_PMR1T_P3_Pos)
+#define GPIO_PMR1T_P4_Pos           4            /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P4               (_U(0x1) << GPIO_PMR1T_P4_Pos)
+#define GPIO_PMR1T_P5_Pos           5            /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P5               (_U(0x1) << GPIO_PMR1T_P5_Pos)
+#define GPIO_PMR1T_P6_Pos           6            /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P6               (_U(0x1) << GPIO_PMR1T_P6_Pos)
+#define GPIO_PMR1T_P7_Pos           7            /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P7               (_U(0x1) << GPIO_PMR1T_P7_Pos)
+#define GPIO_PMR1T_P8_Pos           8            /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P8               (_U(0x1) << GPIO_PMR1T_P8_Pos)
+#define GPIO_PMR1T_P9_Pos           9            /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P9               (_U(0x1) << GPIO_PMR1T_P9_Pos)
+#define GPIO_PMR1T_P10_Pos          10           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P10              (_U(0x1) << GPIO_PMR1T_P10_Pos)
+#define GPIO_PMR1T_P11_Pos          11           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P11              (_U(0x1) << GPIO_PMR1T_P11_Pos)
+#define GPIO_PMR1T_P12_Pos          12           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P12              (_U(0x1) << GPIO_PMR1T_P12_Pos)
+#define GPIO_PMR1T_P13_Pos          13           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P13              (_U(0x1) << GPIO_PMR1T_P13_Pos)
+#define GPIO_PMR1T_P14_Pos          14           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P14              (_U(0x1) << GPIO_PMR1T_P14_Pos)
+#define GPIO_PMR1T_P15_Pos          15           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P15              (_U(0x1) << GPIO_PMR1T_P15_Pos)
+#define GPIO_PMR1T_P16_Pos          16           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P16              (_U(0x1) << GPIO_PMR1T_P16_Pos)
+#define GPIO_PMR1T_P17_Pos          17           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P17              (_U(0x1) << GPIO_PMR1T_P17_Pos)
+#define GPIO_PMR1T_P18_Pos          18           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P18              (_U(0x1) << GPIO_PMR1T_P18_Pos)
+#define GPIO_PMR1T_P19_Pos          19           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P19              (_U(0x1) << GPIO_PMR1T_P19_Pos)
+#define GPIO_PMR1T_P20_Pos          20           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P20              (_U(0x1) << GPIO_PMR1T_P20_Pos)
+#define GPIO_PMR1T_P21_Pos          21           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P21              (_U(0x1) << GPIO_PMR1T_P21_Pos)
+#define GPIO_PMR1T_P22_Pos          22           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P22              (_U(0x1) << GPIO_PMR1T_P22_Pos)
+#define GPIO_PMR1T_P23_Pos          23           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P23              (_U(0x1) << GPIO_PMR1T_P23_Pos)
+#define GPIO_PMR1T_P24_Pos          24           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P24              (_U(0x1) << GPIO_PMR1T_P24_Pos)
+#define GPIO_PMR1T_P25_Pos          25           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P25              (_U(0x1) << GPIO_PMR1T_P25_Pos)
+#define GPIO_PMR1T_P26_Pos          26           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P26              (_U(0x1) << GPIO_PMR1T_P26_Pos)
+#define GPIO_PMR1T_P27_Pos          27           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P27              (_U(0x1) << GPIO_PMR1T_P27_Pos)
+#define GPIO_PMR1T_P28_Pos          28           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P28              (_U(0x1) << GPIO_PMR1T_P28_Pos)
+#define GPIO_PMR1T_P29_Pos          29           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P29              (_U(0x1) << GPIO_PMR1T_P29_Pos)
+#define GPIO_PMR1T_P30_Pos          30           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P30              (_U(0x1) << GPIO_PMR1T_P30_Pos)
+#define GPIO_PMR1T_P31_Pos          31           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
+#define GPIO_PMR1T_P31              (_U(0x1) << GPIO_PMR1T_P31_Pos)
+#define GPIO_PMR1T_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PMR1T) MASK Register */
+
+/* -------- GPIO_PMR2 : (GPIO Offset: 0x030) (R/W 32) port Peripheral Mux Register 2 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Peripheral Multiplexer Select bit 2 */
+    uint32_t P1:1;             /*!< bit:      1  Peripheral Multiplexer Select bit 2 */
+    uint32_t P2:1;             /*!< bit:      2  Peripheral Multiplexer Select bit 2 */
+    uint32_t P3:1;             /*!< bit:      3  Peripheral Multiplexer Select bit 2 */
+    uint32_t P4:1;             /*!< bit:      4  Peripheral Multiplexer Select bit 2 */
+    uint32_t P5:1;             /*!< bit:      5  Peripheral Multiplexer Select bit 2 */
+    uint32_t P6:1;             /*!< bit:      6  Peripheral Multiplexer Select bit 2 */
+    uint32_t P7:1;             /*!< bit:      7  Peripheral Multiplexer Select bit 2 */
+    uint32_t P8:1;             /*!< bit:      8  Peripheral Multiplexer Select bit 2 */
+    uint32_t P9:1;             /*!< bit:      9  Peripheral Multiplexer Select bit 2 */
+    uint32_t P10:1;            /*!< bit:     10  Peripheral Multiplexer Select bit 2 */
+    uint32_t P11:1;            /*!< bit:     11  Peripheral Multiplexer Select bit 2 */
+    uint32_t P12:1;            /*!< bit:     12  Peripheral Multiplexer Select bit 2 */
+    uint32_t P13:1;            /*!< bit:     13  Peripheral Multiplexer Select bit 2 */
+    uint32_t P14:1;            /*!< bit:     14  Peripheral Multiplexer Select bit 2 */
+    uint32_t P15:1;            /*!< bit:     15  Peripheral Multiplexer Select bit 2 */
+    uint32_t P16:1;            /*!< bit:     16  Peripheral Multiplexer Select bit 2 */
+    uint32_t P17:1;            /*!< bit:     17  Peripheral Multiplexer Select bit 2 */
+    uint32_t P18:1;            /*!< bit:     18  Peripheral Multiplexer Select bit 2 */
+    uint32_t P19:1;            /*!< bit:     19  Peripheral Multiplexer Select bit 2 */
+    uint32_t P20:1;            /*!< bit:     20  Peripheral Multiplexer Select bit 2 */
+    uint32_t P21:1;            /*!< bit:     21  Peripheral Multiplexer Select bit 2 */
+    uint32_t P22:1;            /*!< bit:     22  Peripheral Multiplexer Select bit 2 */
+    uint32_t P23:1;            /*!< bit:     23  Peripheral Multiplexer Select bit 2 */
+    uint32_t P24:1;            /*!< bit:     24  Peripheral Multiplexer Select bit 2 */
+    uint32_t P25:1;            /*!< bit:     25  Peripheral Multiplexer Select bit 2 */
+    uint32_t P26:1;            /*!< bit:     26  Peripheral Multiplexer Select bit 2 */
+    uint32_t P27:1;            /*!< bit:     27  Peripheral Multiplexer Select bit 2 */
+    uint32_t P28:1;            /*!< bit:     28  Peripheral Multiplexer Select bit 2 */
+    uint32_t P29:1;            /*!< bit:     29  Peripheral Multiplexer Select bit 2 */
+    uint32_t P30:1;            /*!< bit:     30  Peripheral Multiplexer Select bit 2 */
+    uint32_t P31:1;            /*!< bit:     31  Peripheral Multiplexer Select bit 2 */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_PMR2_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_PMR2_OFFSET            0x030        /**< \brief (GPIO_PMR2 offset) Peripheral Mux Register 2 */
+
+#define GPIO_PMR2_P0_Pos            0            /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P0                (_U(0x1) << GPIO_PMR2_P0_Pos)
+#define GPIO_PMR2_P1_Pos            1            /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P1                (_U(0x1) << GPIO_PMR2_P1_Pos)
+#define GPIO_PMR2_P2_Pos            2            /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P2                (_U(0x1) << GPIO_PMR2_P2_Pos)
+#define GPIO_PMR2_P3_Pos            3            /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P3                (_U(0x1) << GPIO_PMR2_P3_Pos)
+#define GPIO_PMR2_P4_Pos            4            /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P4                (_U(0x1) << GPIO_PMR2_P4_Pos)
+#define GPIO_PMR2_P5_Pos            5            /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P5                (_U(0x1) << GPIO_PMR2_P5_Pos)
+#define GPIO_PMR2_P6_Pos            6            /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P6                (_U(0x1) << GPIO_PMR2_P6_Pos)
+#define GPIO_PMR2_P7_Pos            7            /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P7                (_U(0x1) << GPIO_PMR2_P7_Pos)
+#define GPIO_PMR2_P8_Pos            8            /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P8                (_U(0x1) << GPIO_PMR2_P8_Pos)
+#define GPIO_PMR2_P9_Pos            9            /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P9                (_U(0x1) << GPIO_PMR2_P9_Pos)
+#define GPIO_PMR2_P10_Pos           10           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P10               (_U(0x1) << GPIO_PMR2_P10_Pos)
+#define GPIO_PMR2_P11_Pos           11           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P11               (_U(0x1) << GPIO_PMR2_P11_Pos)
+#define GPIO_PMR2_P12_Pos           12           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P12               (_U(0x1) << GPIO_PMR2_P12_Pos)
+#define GPIO_PMR2_P13_Pos           13           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P13               (_U(0x1) << GPIO_PMR2_P13_Pos)
+#define GPIO_PMR2_P14_Pos           14           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P14               (_U(0x1) << GPIO_PMR2_P14_Pos)
+#define GPIO_PMR2_P15_Pos           15           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P15               (_U(0x1) << GPIO_PMR2_P15_Pos)
+#define GPIO_PMR2_P16_Pos           16           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P16               (_U(0x1) << GPIO_PMR2_P16_Pos)
+#define GPIO_PMR2_P17_Pos           17           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P17               (_U(0x1) << GPIO_PMR2_P17_Pos)
+#define GPIO_PMR2_P18_Pos           18           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P18               (_U(0x1) << GPIO_PMR2_P18_Pos)
+#define GPIO_PMR2_P19_Pos           19           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P19               (_U(0x1) << GPIO_PMR2_P19_Pos)
+#define GPIO_PMR2_P20_Pos           20           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P20               (_U(0x1) << GPIO_PMR2_P20_Pos)
+#define GPIO_PMR2_P21_Pos           21           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P21               (_U(0x1) << GPIO_PMR2_P21_Pos)
+#define GPIO_PMR2_P22_Pos           22           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P22               (_U(0x1) << GPIO_PMR2_P22_Pos)
+#define GPIO_PMR2_P23_Pos           23           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P23               (_U(0x1) << GPIO_PMR2_P23_Pos)
+#define GPIO_PMR2_P24_Pos           24           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P24               (_U(0x1) << GPIO_PMR2_P24_Pos)
+#define GPIO_PMR2_P25_Pos           25           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P25               (_U(0x1) << GPIO_PMR2_P25_Pos)
+#define GPIO_PMR2_P26_Pos           26           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P26               (_U(0x1) << GPIO_PMR2_P26_Pos)
+#define GPIO_PMR2_P27_Pos           27           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P27               (_U(0x1) << GPIO_PMR2_P27_Pos)
+#define GPIO_PMR2_P28_Pos           28           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P28               (_U(0x1) << GPIO_PMR2_P28_Pos)
+#define GPIO_PMR2_P29_Pos           29           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P29               (_U(0x1) << GPIO_PMR2_P29_Pos)
+#define GPIO_PMR2_P30_Pos           30           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P30               (_U(0x1) << GPIO_PMR2_P30_Pos)
+#define GPIO_PMR2_P31_Pos           31           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2_P31               (_U(0x1) << GPIO_PMR2_P31_Pos)
+#define GPIO_PMR2_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_PMR2) MASK Register */
+
+/* -------- GPIO_PMR2S : (GPIO Offset: 0x034) ( /W 32) port Peripheral Mux Register 2 - Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Peripheral Multiplexer Select bit 2 */
+    uint32_t P1:1;             /*!< bit:      1  Peripheral Multiplexer Select bit 2 */
+    uint32_t P2:1;             /*!< bit:      2  Peripheral Multiplexer Select bit 2 */
+    uint32_t P3:1;             /*!< bit:      3  Peripheral Multiplexer Select bit 2 */
+    uint32_t P4:1;             /*!< bit:      4  Peripheral Multiplexer Select bit 2 */
+    uint32_t P5:1;             /*!< bit:      5  Peripheral Multiplexer Select bit 2 */
+    uint32_t P6:1;             /*!< bit:      6  Peripheral Multiplexer Select bit 2 */
+    uint32_t P7:1;             /*!< bit:      7  Peripheral Multiplexer Select bit 2 */
+    uint32_t P8:1;             /*!< bit:      8  Peripheral Multiplexer Select bit 2 */
+    uint32_t P9:1;             /*!< bit:      9  Peripheral Multiplexer Select bit 2 */
+    uint32_t P10:1;            /*!< bit:     10  Peripheral Multiplexer Select bit 2 */
+    uint32_t P11:1;            /*!< bit:     11  Peripheral Multiplexer Select bit 2 */
+    uint32_t P12:1;            /*!< bit:     12  Peripheral Multiplexer Select bit 2 */
+    uint32_t P13:1;            /*!< bit:     13  Peripheral Multiplexer Select bit 2 */
+    uint32_t P14:1;            /*!< bit:     14  Peripheral Multiplexer Select bit 2 */
+    uint32_t P15:1;            /*!< bit:     15  Peripheral Multiplexer Select bit 2 */
+    uint32_t P16:1;            /*!< bit:     16  Peripheral Multiplexer Select bit 2 */
+    uint32_t P17:1;            /*!< bit:     17  Peripheral Multiplexer Select bit 2 */
+    uint32_t P18:1;            /*!< bit:     18  Peripheral Multiplexer Select bit 2 */
+    uint32_t P19:1;            /*!< bit:     19  Peripheral Multiplexer Select bit 2 */
+    uint32_t P20:1;            /*!< bit:     20  Peripheral Multiplexer Select bit 2 */
+    uint32_t P21:1;            /*!< bit:     21  Peripheral Multiplexer Select bit 2 */
+    uint32_t P22:1;            /*!< bit:     22  Peripheral Multiplexer Select bit 2 */
+    uint32_t P23:1;            /*!< bit:     23  Peripheral Multiplexer Select bit 2 */
+    uint32_t P24:1;            /*!< bit:     24  Peripheral Multiplexer Select bit 2 */
+    uint32_t P25:1;            /*!< bit:     25  Peripheral Multiplexer Select bit 2 */
+    uint32_t P26:1;            /*!< bit:     26  Peripheral Multiplexer Select bit 2 */
+    uint32_t P27:1;            /*!< bit:     27  Peripheral Multiplexer Select bit 2 */
+    uint32_t P28:1;            /*!< bit:     28  Peripheral Multiplexer Select bit 2 */
+    uint32_t P29:1;            /*!< bit:     29  Peripheral Multiplexer Select bit 2 */
+    uint32_t P30:1;            /*!< bit:     30  Peripheral Multiplexer Select bit 2 */
+    uint32_t P31:1;            /*!< bit:     31  Peripheral Multiplexer Select bit 2 */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_PMR2S_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_PMR2S_OFFSET           0x034        /**< \brief (GPIO_PMR2S offset) Peripheral Mux Register 2 - Set */
+
+#define GPIO_PMR2S_P0_Pos           0            /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P0               (_U(0x1) << GPIO_PMR2S_P0_Pos)
+#define GPIO_PMR2S_P1_Pos           1            /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P1               (_U(0x1) << GPIO_PMR2S_P1_Pos)
+#define GPIO_PMR2S_P2_Pos           2            /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P2               (_U(0x1) << GPIO_PMR2S_P2_Pos)
+#define GPIO_PMR2S_P3_Pos           3            /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P3               (_U(0x1) << GPIO_PMR2S_P3_Pos)
+#define GPIO_PMR2S_P4_Pos           4            /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P4               (_U(0x1) << GPIO_PMR2S_P4_Pos)
+#define GPIO_PMR2S_P5_Pos           5            /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P5               (_U(0x1) << GPIO_PMR2S_P5_Pos)
+#define GPIO_PMR2S_P6_Pos           6            /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P6               (_U(0x1) << GPIO_PMR2S_P6_Pos)
+#define GPIO_PMR2S_P7_Pos           7            /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P7               (_U(0x1) << GPIO_PMR2S_P7_Pos)
+#define GPIO_PMR2S_P8_Pos           8            /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P8               (_U(0x1) << GPIO_PMR2S_P8_Pos)
+#define GPIO_PMR2S_P9_Pos           9            /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P9               (_U(0x1) << GPIO_PMR2S_P9_Pos)
+#define GPIO_PMR2S_P10_Pos          10           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P10              (_U(0x1) << GPIO_PMR2S_P10_Pos)
+#define GPIO_PMR2S_P11_Pos          11           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P11              (_U(0x1) << GPIO_PMR2S_P11_Pos)
+#define GPIO_PMR2S_P12_Pos          12           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P12              (_U(0x1) << GPIO_PMR2S_P12_Pos)
+#define GPIO_PMR2S_P13_Pos          13           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P13              (_U(0x1) << GPIO_PMR2S_P13_Pos)
+#define GPIO_PMR2S_P14_Pos          14           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P14              (_U(0x1) << GPIO_PMR2S_P14_Pos)
+#define GPIO_PMR2S_P15_Pos          15           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P15              (_U(0x1) << GPIO_PMR2S_P15_Pos)
+#define GPIO_PMR2S_P16_Pos          16           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P16              (_U(0x1) << GPIO_PMR2S_P16_Pos)
+#define GPIO_PMR2S_P17_Pos          17           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P17              (_U(0x1) << GPIO_PMR2S_P17_Pos)
+#define GPIO_PMR2S_P18_Pos          18           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P18              (_U(0x1) << GPIO_PMR2S_P18_Pos)
+#define GPIO_PMR2S_P19_Pos          19           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P19              (_U(0x1) << GPIO_PMR2S_P19_Pos)
+#define GPIO_PMR2S_P20_Pos          20           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P20              (_U(0x1) << GPIO_PMR2S_P20_Pos)
+#define GPIO_PMR2S_P21_Pos          21           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P21              (_U(0x1) << GPIO_PMR2S_P21_Pos)
+#define GPIO_PMR2S_P22_Pos          22           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P22              (_U(0x1) << GPIO_PMR2S_P22_Pos)
+#define GPIO_PMR2S_P23_Pos          23           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P23              (_U(0x1) << GPIO_PMR2S_P23_Pos)
+#define GPIO_PMR2S_P24_Pos          24           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P24              (_U(0x1) << GPIO_PMR2S_P24_Pos)
+#define GPIO_PMR2S_P25_Pos          25           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P25              (_U(0x1) << GPIO_PMR2S_P25_Pos)
+#define GPIO_PMR2S_P26_Pos          26           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P26              (_U(0x1) << GPIO_PMR2S_P26_Pos)
+#define GPIO_PMR2S_P27_Pos          27           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P27              (_U(0x1) << GPIO_PMR2S_P27_Pos)
+#define GPIO_PMR2S_P28_Pos          28           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P28              (_U(0x1) << GPIO_PMR2S_P28_Pos)
+#define GPIO_PMR2S_P29_Pos          29           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P29              (_U(0x1) << GPIO_PMR2S_P29_Pos)
+#define GPIO_PMR2S_P30_Pos          30           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P30              (_U(0x1) << GPIO_PMR2S_P30_Pos)
+#define GPIO_PMR2S_P31_Pos          31           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2S_P31              (_U(0x1) << GPIO_PMR2S_P31_Pos)
+#define GPIO_PMR2S_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PMR2S) MASK Register */
+
+/* -------- GPIO_PMR2C : (GPIO Offset: 0x038) ( /W 32) port Peripheral Mux Register 2 - Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Peripheral Multiplexer Select bit 2 */
+    uint32_t P1:1;             /*!< bit:      1  Peripheral Multiplexer Select bit 2 */
+    uint32_t P2:1;             /*!< bit:      2  Peripheral Multiplexer Select bit 2 */
+    uint32_t P3:1;             /*!< bit:      3  Peripheral Multiplexer Select bit 2 */
+    uint32_t P4:1;             /*!< bit:      4  Peripheral Multiplexer Select bit 2 */
+    uint32_t P5:1;             /*!< bit:      5  Peripheral Multiplexer Select bit 2 */
+    uint32_t P6:1;             /*!< bit:      6  Peripheral Multiplexer Select bit 2 */
+    uint32_t P7:1;             /*!< bit:      7  Peripheral Multiplexer Select bit 2 */
+    uint32_t P8:1;             /*!< bit:      8  Peripheral Multiplexer Select bit 2 */
+    uint32_t P9:1;             /*!< bit:      9  Peripheral Multiplexer Select bit 2 */
+    uint32_t P10:1;            /*!< bit:     10  Peripheral Multiplexer Select bit 2 */
+    uint32_t P11:1;            /*!< bit:     11  Peripheral Multiplexer Select bit 2 */
+    uint32_t P12:1;            /*!< bit:     12  Peripheral Multiplexer Select bit 2 */
+    uint32_t P13:1;            /*!< bit:     13  Peripheral Multiplexer Select bit 2 */
+    uint32_t P14:1;            /*!< bit:     14  Peripheral Multiplexer Select bit 2 */
+    uint32_t P15:1;            /*!< bit:     15  Peripheral Multiplexer Select bit 2 */
+    uint32_t P16:1;            /*!< bit:     16  Peripheral Multiplexer Select bit 2 */
+    uint32_t P17:1;            /*!< bit:     17  Peripheral Multiplexer Select bit 2 */
+    uint32_t P18:1;            /*!< bit:     18  Peripheral Multiplexer Select bit 2 */
+    uint32_t P19:1;            /*!< bit:     19  Peripheral Multiplexer Select bit 2 */
+    uint32_t P20:1;            /*!< bit:     20  Peripheral Multiplexer Select bit 2 */
+    uint32_t P21:1;            /*!< bit:     21  Peripheral Multiplexer Select bit 2 */
+    uint32_t P22:1;            /*!< bit:     22  Peripheral Multiplexer Select bit 2 */
+    uint32_t P23:1;            /*!< bit:     23  Peripheral Multiplexer Select bit 2 */
+    uint32_t P24:1;            /*!< bit:     24  Peripheral Multiplexer Select bit 2 */
+    uint32_t P25:1;            /*!< bit:     25  Peripheral Multiplexer Select bit 2 */
+    uint32_t P26:1;            /*!< bit:     26  Peripheral Multiplexer Select bit 2 */
+    uint32_t P27:1;            /*!< bit:     27  Peripheral Multiplexer Select bit 2 */
+    uint32_t P28:1;            /*!< bit:     28  Peripheral Multiplexer Select bit 2 */
+    uint32_t P29:1;            /*!< bit:     29  Peripheral Multiplexer Select bit 2 */
+    uint32_t P30:1;            /*!< bit:     30  Peripheral Multiplexer Select bit 2 */
+    uint32_t P31:1;            /*!< bit:     31  Peripheral Multiplexer Select bit 2 */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_PMR2C_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_PMR2C_OFFSET           0x038        /**< \brief (GPIO_PMR2C offset) Peripheral Mux Register 2 - Clear */
+
+#define GPIO_PMR2C_P0_Pos           0            /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P0               (_U(0x1) << GPIO_PMR2C_P0_Pos)
+#define GPIO_PMR2C_P1_Pos           1            /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P1               (_U(0x1) << GPIO_PMR2C_P1_Pos)
+#define GPIO_PMR2C_P2_Pos           2            /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P2               (_U(0x1) << GPIO_PMR2C_P2_Pos)
+#define GPIO_PMR2C_P3_Pos           3            /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P3               (_U(0x1) << GPIO_PMR2C_P3_Pos)
+#define GPIO_PMR2C_P4_Pos           4            /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P4               (_U(0x1) << GPIO_PMR2C_P4_Pos)
+#define GPIO_PMR2C_P5_Pos           5            /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P5               (_U(0x1) << GPIO_PMR2C_P5_Pos)
+#define GPIO_PMR2C_P6_Pos           6            /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P6               (_U(0x1) << GPIO_PMR2C_P6_Pos)
+#define GPIO_PMR2C_P7_Pos           7            /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P7               (_U(0x1) << GPIO_PMR2C_P7_Pos)
+#define GPIO_PMR2C_P8_Pos           8            /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P8               (_U(0x1) << GPIO_PMR2C_P8_Pos)
+#define GPIO_PMR2C_P9_Pos           9            /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P9               (_U(0x1) << GPIO_PMR2C_P9_Pos)
+#define GPIO_PMR2C_P10_Pos          10           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P10              (_U(0x1) << GPIO_PMR2C_P10_Pos)
+#define GPIO_PMR2C_P11_Pos          11           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P11              (_U(0x1) << GPIO_PMR2C_P11_Pos)
+#define GPIO_PMR2C_P12_Pos          12           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P12              (_U(0x1) << GPIO_PMR2C_P12_Pos)
+#define GPIO_PMR2C_P13_Pos          13           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P13              (_U(0x1) << GPIO_PMR2C_P13_Pos)
+#define GPIO_PMR2C_P14_Pos          14           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P14              (_U(0x1) << GPIO_PMR2C_P14_Pos)
+#define GPIO_PMR2C_P15_Pos          15           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P15              (_U(0x1) << GPIO_PMR2C_P15_Pos)
+#define GPIO_PMR2C_P16_Pos          16           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P16              (_U(0x1) << GPIO_PMR2C_P16_Pos)
+#define GPIO_PMR2C_P17_Pos          17           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P17              (_U(0x1) << GPIO_PMR2C_P17_Pos)
+#define GPIO_PMR2C_P18_Pos          18           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P18              (_U(0x1) << GPIO_PMR2C_P18_Pos)
+#define GPIO_PMR2C_P19_Pos          19           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P19              (_U(0x1) << GPIO_PMR2C_P19_Pos)
+#define GPIO_PMR2C_P20_Pos          20           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P20              (_U(0x1) << GPIO_PMR2C_P20_Pos)
+#define GPIO_PMR2C_P21_Pos          21           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P21              (_U(0x1) << GPIO_PMR2C_P21_Pos)
+#define GPIO_PMR2C_P22_Pos          22           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P22              (_U(0x1) << GPIO_PMR2C_P22_Pos)
+#define GPIO_PMR2C_P23_Pos          23           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P23              (_U(0x1) << GPIO_PMR2C_P23_Pos)
+#define GPIO_PMR2C_P24_Pos          24           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P24              (_U(0x1) << GPIO_PMR2C_P24_Pos)
+#define GPIO_PMR2C_P25_Pos          25           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P25              (_U(0x1) << GPIO_PMR2C_P25_Pos)
+#define GPIO_PMR2C_P26_Pos          26           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P26              (_U(0x1) << GPIO_PMR2C_P26_Pos)
+#define GPIO_PMR2C_P27_Pos          27           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P27              (_U(0x1) << GPIO_PMR2C_P27_Pos)
+#define GPIO_PMR2C_P28_Pos          28           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P28              (_U(0x1) << GPIO_PMR2C_P28_Pos)
+#define GPIO_PMR2C_P29_Pos          29           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P29              (_U(0x1) << GPIO_PMR2C_P29_Pos)
+#define GPIO_PMR2C_P30_Pos          30           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P30              (_U(0x1) << GPIO_PMR2C_P30_Pos)
+#define GPIO_PMR2C_P31_Pos          31           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2C_P31              (_U(0x1) << GPIO_PMR2C_P31_Pos)
+#define GPIO_PMR2C_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PMR2C) MASK Register */
+
+/* -------- GPIO_PMR2T : (GPIO Offset: 0x03C) ( /W 32) port Peripheral Mux Register 2 - Toggle -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Peripheral Multiplexer Select bit 2 */
+    uint32_t P1:1;             /*!< bit:      1  Peripheral Multiplexer Select bit 2 */
+    uint32_t P2:1;             /*!< bit:      2  Peripheral Multiplexer Select bit 2 */
+    uint32_t P3:1;             /*!< bit:      3  Peripheral Multiplexer Select bit 2 */
+    uint32_t P4:1;             /*!< bit:      4  Peripheral Multiplexer Select bit 2 */
+    uint32_t P5:1;             /*!< bit:      5  Peripheral Multiplexer Select bit 2 */
+    uint32_t P6:1;             /*!< bit:      6  Peripheral Multiplexer Select bit 2 */
+    uint32_t P7:1;             /*!< bit:      7  Peripheral Multiplexer Select bit 2 */
+    uint32_t P8:1;             /*!< bit:      8  Peripheral Multiplexer Select bit 2 */
+    uint32_t P9:1;             /*!< bit:      9  Peripheral Multiplexer Select bit 2 */
+    uint32_t P10:1;            /*!< bit:     10  Peripheral Multiplexer Select bit 2 */
+    uint32_t P11:1;            /*!< bit:     11  Peripheral Multiplexer Select bit 2 */
+    uint32_t P12:1;            /*!< bit:     12  Peripheral Multiplexer Select bit 2 */
+    uint32_t P13:1;            /*!< bit:     13  Peripheral Multiplexer Select bit 2 */
+    uint32_t P14:1;            /*!< bit:     14  Peripheral Multiplexer Select bit 2 */
+    uint32_t P15:1;            /*!< bit:     15  Peripheral Multiplexer Select bit 2 */
+    uint32_t P16:1;            /*!< bit:     16  Peripheral Multiplexer Select bit 2 */
+    uint32_t P17:1;            /*!< bit:     17  Peripheral Multiplexer Select bit 2 */
+    uint32_t P18:1;            /*!< bit:     18  Peripheral Multiplexer Select bit 2 */
+    uint32_t P19:1;            /*!< bit:     19  Peripheral Multiplexer Select bit 2 */
+    uint32_t P20:1;            /*!< bit:     20  Peripheral Multiplexer Select bit 2 */
+    uint32_t P21:1;            /*!< bit:     21  Peripheral Multiplexer Select bit 2 */
+    uint32_t P22:1;            /*!< bit:     22  Peripheral Multiplexer Select bit 2 */
+    uint32_t P23:1;            /*!< bit:     23  Peripheral Multiplexer Select bit 2 */
+    uint32_t P24:1;            /*!< bit:     24  Peripheral Multiplexer Select bit 2 */
+    uint32_t P25:1;            /*!< bit:     25  Peripheral Multiplexer Select bit 2 */
+    uint32_t P26:1;            /*!< bit:     26  Peripheral Multiplexer Select bit 2 */
+    uint32_t P27:1;            /*!< bit:     27  Peripheral Multiplexer Select bit 2 */
+    uint32_t P28:1;            /*!< bit:     28  Peripheral Multiplexer Select bit 2 */
+    uint32_t P29:1;            /*!< bit:     29  Peripheral Multiplexer Select bit 2 */
+    uint32_t P30:1;            /*!< bit:     30  Peripheral Multiplexer Select bit 2 */
+    uint32_t P31:1;            /*!< bit:     31  Peripheral Multiplexer Select bit 2 */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_PMR2T_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_PMR2T_OFFSET           0x03C        /**< \brief (GPIO_PMR2T offset) Peripheral Mux Register 2 - Toggle */
+
+#define GPIO_PMR2T_P0_Pos           0            /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P0               (_U(0x1) << GPIO_PMR2T_P0_Pos)
+#define GPIO_PMR2T_P1_Pos           1            /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P1               (_U(0x1) << GPIO_PMR2T_P1_Pos)
+#define GPIO_PMR2T_P2_Pos           2            /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P2               (_U(0x1) << GPIO_PMR2T_P2_Pos)
+#define GPIO_PMR2T_P3_Pos           3            /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P3               (_U(0x1) << GPIO_PMR2T_P3_Pos)
+#define GPIO_PMR2T_P4_Pos           4            /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P4               (_U(0x1) << GPIO_PMR2T_P4_Pos)
+#define GPIO_PMR2T_P5_Pos           5            /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P5               (_U(0x1) << GPIO_PMR2T_P5_Pos)
+#define GPIO_PMR2T_P6_Pos           6            /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P6               (_U(0x1) << GPIO_PMR2T_P6_Pos)
+#define GPIO_PMR2T_P7_Pos           7            /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P7               (_U(0x1) << GPIO_PMR2T_P7_Pos)
+#define GPIO_PMR2T_P8_Pos           8            /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P8               (_U(0x1) << GPIO_PMR2T_P8_Pos)
+#define GPIO_PMR2T_P9_Pos           9            /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P9               (_U(0x1) << GPIO_PMR2T_P9_Pos)
+#define GPIO_PMR2T_P10_Pos          10           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P10              (_U(0x1) << GPIO_PMR2T_P10_Pos)
+#define GPIO_PMR2T_P11_Pos          11           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P11              (_U(0x1) << GPIO_PMR2T_P11_Pos)
+#define GPIO_PMR2T_P12_Pos          12           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P12              (_U(0x1) << GPIO_PMR2T_P12_Pos)
+#define GPIO_PMR2T_P13_Pos          13           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P13              (_U(0x1) << GPIO_PMR2T_P13_Pos)
+#define GPIO_PMR2T_P14_Pos          14           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P14              (_U(0x1) << GPIO_PMR2T_P14_Pos)
+#define GPIO_PMR2T_P15_Pos          15           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P15              (_U(0x1) << GPIO_PMR2T_P15_Pos)
+#define GPIO_PMR2T_P16_Pos          16           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P16              (_U(0x1) << GPIO_PMR2T_P16_Pos)
+#define GPIO_PMR2T_P17_Pos          17           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P17              (_U(0x1) << GPIO_PMR2T_P17_Pos)
+#define GPIO_PMR2T_P18_Pos          18           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P18              (_U(0x1) << GPIO_PMR2T_P18_Pos)
+#define GPIO_PMR2T_P19_Pos          19           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P19              (_U(0x1) << GPIO_PMR2T_P19_Pos)
+#define GPIO_PMR2T_P20_Pos          20           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P20              (_U(0x1) << GPIO_PMR2T_P20_Pos)
+#define GPIO_PMR2T_P21_Pos          21           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P21              (_U(0x1) << GPIO_PMR2T_P21_Pos)
+#define GPIO_PMR2T_P22_Pos          22           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P22              (_U(0x1) << GPIO_PMR2T_P22_Pos)
+#define GPIO_PMR2T_P23_Pos          23           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P23              (_U(0x1) << GPIO_PMR2T_P23_Pos)
+#define GPIO_PMR2T_P24_Pos          24           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P24              (_U(0x1) << GPIO_PMR2T_P24_Pos)
+#define GPIO_PMR2T_P25_Pos          25           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P25              (_U(0x1) << GPIO_PMR2T_P25_Pos)
+#define GPIO_PMR2T_P26_Pos          26           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P26              (_U(0x1) << GPIO_PMR2T_P26_Pos)
+#define GPIO_PMR2T_P27_Pos          27           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P27              (_U(0x1) << GPIO_PMR2T_P27_Pos)
+#define GPIO_PMR2T_P28_Pos          28           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P28              (_U(0x1) << GPIO_PMR2T_P28_Pos)
+#define GPIO_PMR2T_P29_Pos          29           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P29              (_U(0x1) << GPIO_PMR2T_P29_Pos)
+#define GPIO_PMR2T_P30_Pos          30           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P30              (_U(0x1) << GPIO_PMR2T_P30_Pos)
+#define GPIO_PMR2T_P31_Pos          31           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
+#define GPIO_PMR2T_P31              (_U(0x1) << GPIO_PMR2T_P31_Pos)
+#define GPIO_PMR2T_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PMR2T) MASK Register */
+
+/* -------- GPIO_ODER : (GPIO Offset: 0x040) (R/W 32) port Output Driver Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Output Driver Enable               */
+    uint32_t P1:1;             /*!< bit:      1  Output Driver Enable               */
+    uint32_t P2:1;             /*!< bit:      2  Output Driver Enable               */
+    uint32_t P3:1;             /*!< bit:      3  Output Driver Enable               */
+    uint32_t P4:1;             /*!< bit:      4  Output Driver Enable               */
+    uint32_t P5:1;             /*!< bit:      5  Output Driver Enable               */
+    uint32_t P6:1;             /*!< bit:      6  Output Driver Enable               */
+    uint32_t P7:1;             /*!< bit:      7  Output Driver Enable               */
+    uint32_t P8:1;             /*!< bit:      8  Output Driver Enable               */
+    uint32_t P9:1;             /*!< bit:      9  Output Driver Enable               */
+    uint32_t P10:1;            /*!< bit:     10  Output Driver Enable               */
+    uint32_t P11:1;            /*!< bit:     11  Output Driver Enable               */
+    uint32_t P12:1;            /*!< bit:     12  Output Driver Enable               */
+    uint32_t P13:1;            /*!< bit:     13  Output Driver Enable               */
+    uint32_t P14:1;            /*!< bit:     14  Output Driver Enable               */
+    uint32_t P15:1;            /*!< bit:     15  Output Driver Enable               */
+    uint32_t P16:1;            /*!< bit:     16  Output Driver Enable               */
+    uint32_t P17:1;            /*!< bit:     17  Output Driver Enable               */
+    uint32_t P18:1;            /*!< bit:     18  Output Driver Enable               */
+    uint32_t P19:1;            /*!< bit:     19  Output Driver Enable               */
+    uint32_t P20:1;            /*!< bit:     20  Output Driver Enable               */
+    uint32_t P21:1;            /*!< bit:     21  Output Driver Enable               */
+    uint32_t P22:1;            /*!< bit:     22  Output Driver Enable               */
+    uint32_t P23:1;            /*!< bit:     23  Output Driver Enable               */
+    uint32_t P24:1;            /*!< bit:     24  Output Driver Enable               */
+    uint32_t P25:1;            /*!< bit:     25  Output Driver Enable               */
+    uint32_t P26:1;            /*!< bit:     26  Output Driver Enable               */
+    uint32_t P27:1;            /*!< bit:     27  Output Driver Enable               */
+    uint32_t P28:1;            /*!< bit:     28  Output Driver Enable               */
+    uint32_t P29:1;            /*!< bit:     29  Output Driver Enable               */
+    uint32_t P30:1;            /*!< bit:     30  Output Driver Enable               */
+    uint32_t P31:1;            /*!< bit:     31  Output Driver Enable               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_ODER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_ODER_OFFSET            0x040        /**< \brief (GPIO_ODER offset) Output Driver Enable Register */
+
+#define GPIO_ODER_P0_Pos            0            /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P0                (_U(0x1) << GPIO_ODER_P0_Pos)
+#define GPIO_ODER_P1_Pos            1            /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P1                (_U(0x1) << GPIO_ODER_P1_Pos)
+#define GPIO_ODER_P2_Pos            2            /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P2                (_U(0x1) << GPIO_ODER_P2_Pos)
+#define GPIO_ODER_P3_Pos            3            /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P3                (_U(0x1) << GPIO_ODER_P3_Pos)
+#define GPIO_ODER_P4_Pos            4            /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P4                (_U(0x1) << GPIO_ODER_P4_Pos)
+#define GPIO_ODER_P5_Pos            5            /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P5                (_U(0x1) << GPIO_ODER_P5_Pos)
+#define GPIO_ODER_P6_Pos            6            /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P6                (_U(0x1) << GPIO_ODER_P6_Pos)
+#define GPIO_ODER_P7_Pos            7            /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P7                (_U(0x1) << GPIO_ODER_P7_Pos)
+#define GPIO_ODER_P8_Pos            8            /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P8                (_U(0x1) << GPIO_ODER_P8_Pos)
+#define GPIO_ODER_P9_Pos            9            /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P9                (_U(0x1) << GPIO_ODER_P9_Pos)
+#define GPIO_ODER_P10_Pos           10           /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P10               (_U(0x1) << GPIO_ODER_P10_Pos)
+#define GPIO_ODER_P11_Pos           11           /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P11               (_U(0x1) << GPIO_ODER_P11_Pos)
+#define GPIO_ODER_P12_Pos           12           /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P12               (_U(0x1) << GPIO_ODER_P12_Pos)
+#define GPIO_ODER_P13_Pos           13           /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P13               (_U(0x1) << GPIO_ODER_P13_Pos)
+#define GPIO_ODER_P14_Pos           14           /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P14               (_U(0x1) << GPIO_ODER_P14_Pos)
+#define GPIO_ODER_P15_Pos           15           /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P15               (_U(0x1) << GPIO_ODER_P15_Pos)
+#define GPIO_ODER_P16_Pos           16           /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P16               (_U(0x1) << GPIO_ODER_P16_Pos)
+#define GPIO_ODER_P17_Pos           17           /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P17               (_U(0x1) << GPIO_ODER_P17_Pos)
+#define GPIO_ODER_P18_Pos           18           /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P18               (_U(0x1) << GPIO_ODER_P18_Pos)
+#define GPIO_ODER_P19_Pos           19           /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P19               (_U(0x1) << GPIO_ODER_P19_Pos)
+#define GPIO_ODER_P20_Pos           20           /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P20               (_U(0x1) << GPIO_ODER_P20_Pos)
+#define GPIO_ODER_P21_Pos           21           /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P21               (_U(0x1) << GPIO_ODER_P21_Pos)
+#define GPIO_ODER_P22_Pos           22           /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P22               (_U(0x1) << GPIO_ODER_P22_Pos)
+#define GPIO_ODER_P23_Pos           23           /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P23               (_U(0x1) << GPIO_ODER_P23_Pos)
+#define GPIO_ODER_P24_Pos           24           /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P24               (_U(0x1) << GPIO_ODER_P24_Pos)
+#define GPIO_ODER_P25_Pos           25           /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P25               (_U(0x1) << GPIO_ODER_P25_Pos)
+#define GPIO_ODER_P26_Pos           26           /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P26               (_U(0x1) << GPIO_ODER_P26_Pos)
+#define GPIO_ODER_P27_Pos           27           /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P27               (_U(0x1) << GPIO_ODER_P27_Pos)
+#define GPIO_ODER_P28_Pos           28           /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P28               (_U(0x1) << GPIO_ODER_P28_Pos)
+#define GPIO_ODER_P29_Pos           29           /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P29               (_U(0x1) << GPIO_ODER_P29_Pos)
+#define GPIO_ODER_P30_Pos           30           /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P30               (_U(0x1) << GPIO_ODER_P30_Pos)
+#define GPIO_ODER_P31_Pos           31           /**< \brief (GPIO_ODER) Output Driver Enable */
+#define GPIO_ODER_P31               (_U(0x1) << GPIO_ODER_P31_Pos)
+#define GPIO_ODER_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_ODER) MASK Register */
+
+/* -------- GPIO_ODERS : (GPIO Offset: 0x044) ( /W 32) port Output Driver Enable Register - Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Output Driver Enable               */
+    uint32_t P1:1;             /*!< bit:      1  Output Driver Enable               */
+    uint32_t P2:1;             /*!< bit:      2  Output Driver Enable               */
+    uint32_t P3:1;             /*!< bit:      3  Output Driver Enable               */
+    uint32_t P4:1;             /*!< bit:      4  Output Driver Enable               */
+    uint32_t P5:1;             /*!< bit:      5  Output Driver Enable               */
+    uint32_t P6:1;             /*!< bit:      6  Output Driver Enable               */
+    uint32_t P7:1;             /*!< bit:      7  Output Driver Enable               */
+    uint32_t P8:1;             /*!< bit:      8  Output Driver Enable               */
+    uint32_t P9:1;             /*!< bit:      9  Output Driver Enable               */
+    uint32_t P10:1;            /*!< bit:     10  Output Driver Enable               */
+    uint32_t P11:1;            /*!< bit:     11  Output Driver Enable               */
+    uint32_t P12:1;            /*!< bit:     12  Output Driver Enable               */
+    uint32_t P13:1;            /*!< bit:     13  Output Driver Enable               */
+    uint32_t P14:1;            /*!< bit:     14  Output Driver Enable               */
+    uint32_t P15:1;            /*!< bit:     15  Output Driver Enable               */
+    uint32_t P16:1;            /*!< bit:     16  Output Driver Enable               */
+    uint32_t P17:1;            /*!< bit:     17  Output Driver Enable               */
+    uint32_t P18:1;            /*!< bit:     18  Output Driver Enable               */
+    uint32_t P19:1;            /*!< bit:     19  Output Driver Enable               */
+    uint32_t P20:1;            /*!< bit:     20  Output Driver Enable               */
+    uint32_t P21:1;            /*!< bit:     21  Output Driver Enable               */
+    uint32_t P22:1;            /*!< bit:     22  Output Driver Enable               */
+    uint32_t P23:1;            /*!< bit:     23  Output Driver Enable               */
+    uint32_t P24:1;            /*!< bit:     24  Output Driver Enable               */
+    uint32_t P25:1;            /*!< bit:     25  Output Driver Enable               */
+    uint32_t P26:1;            /*!< bit:     26  Output Driver Enable               */
+    uint32_t P27:1;            /*!< bit:     27  Output Driver Enable               */
+    uint32_t P28:1;            /*!< bit:     28  Output Driver Enable               */
+    uint32_t P29:1;            /*!< bit:     29  Output Driver Enable               */
+    uint32_t P30:1;            /*!< bit:     30  Output Driver Enable               */
+    uint32_t P31:1;            /*!< bit:     31  Output Driver Enable               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_ODERS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_ODERS_OFFSET           0x044        /**< \brief (GPIO_ODERS offset) Output Driver Enable Register - Set */
+
+#define GPIO_ODERS_P0_Pos           0            /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P0               (_U(0x1) << GPIO_ODERS_P0_Pos)
+#define GPIO_ODERS_P1_Pos           1            /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P1               (_U(0x1) << GPIO_ODERS_P1_Pos)
+#define GPIO_ODERS_P2_Pos           2            /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P2               (_U(0x1) << GPIO_ODERS_P2_Pos)
+#define GPIO_ODERS_P3_Pos           3            /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P3               (_U(0x1) << GPIO_ODERS_P3_Pos)
+#define GPIO_ODERS_P4_Pos           4            /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P4               (_U(0x1) << GPIO_ODERS_P4_Pos)
+#define GPIO_ODERS_P5_Pos           5            /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P5               (_U(0x1) << GPIO_ODERS_P5_Pos)
+#define GPIO_ODERS_P6_Pos           6            /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P6               (_U(0x1) << GPIO_ODERS_P6_Pos)
+#define GPIO_ODERS_P7_Pos           7            /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P7               (_U(0x1) << GPIO_ODERS_P7_Pos)
+#define GPIO_ODERS_P8_Pos           8            /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P8               (_U(0x1) << GPIO_ODERS_P8_Pos)
+#define GPIO_ODERS_P9_Pos           9            /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P9               (_U(0x1) << GPIO_ODERS_P9_Pos)
+#define GPIO_ODERS_P10_Pos          10           /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P10              (_U(0x1) << GPIO_ODERS_P10_Pos)
+#define GPIO_ODERS_P11_Pos          11           /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P11              (_U(0x1) << GPIO_ODERS_P11_Pos)
+#define GPIO_ODERS_P12_Pos          12           /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P12              (_U(0x1) << GPIO_ODERS_P12_Pos)
+#define GPIO_ODERS_P13_Pos          13           /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P13              (_U(0x1) << GPIO_ODERS_P13_Pos)
+#define GPIO_ODERS_P14_Pos          14           /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P14              (_U(0x1) << GPIO_ODERS_P14_Pos)
+#define GPIO_ODERS_P15_Pos          15           /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P15              (_U(0x1) << GPIO_ODERS_P15_Pos)
+#define GPIO_ODERS_P16_Pos          16           /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P16              (_U(0x1) << GPIO_ODERS_P16_Pos)
+#define GPIO_ODERS_P17_Pos          17           /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P17              (_U(0x1) << GPIO_ODERS_P17_Pos)
+#define GPIO_ODERS_P18_Pos          18           /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P18              (_U(0x1) << GPIO_ODERS_P18_Pos)
+#define GPIO_ODERS_P19_Pos          19           /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P19              (_U(0x1) << GPIO_ODERS_P19_Pos)
+#define GPIO_ODERS_P20_Pos          20           /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P20              (_U(0x1) << GPIO_ODERS_P20_Pos)
+#define GPIO_ODERS_P21_Pos          21           /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P21              (_U(0x1) << GPIO_ODERS_P21_Pos)
+#define GPIO_ODERS_P22_Pos          22           /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P22              (_U(0x1) << GPIO_ODERS_P22_Pos)
+#define GPIO_ODERS_P23_Pos          23           /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P23              (_U(0x1) << GPIO_ODERS_P23_Pos)
+#define GPIO_ODERS_P24_Pos          24           /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P24              (_U(0x1) << GPIO_ODERS_P24_Pos)
+#define GPIO_ODERS_P25_Pos          25           /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P25              (_U(0x1) << GPIO_ODERS_P25_Pos)
+#define GPIO_ODERS_P26_Pos          26           /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P26              (_U(0x1) << GPIO_ODERS_P26_Pos)
+#define GPIO_ODERS_P27_Pos          27           /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P27              (_U(0x1) << GPIO_ODERS_P27_Pos)
+#define GPIO_ODERS_P28_Pos          28           /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P28              (_U(0x1) << GPIO_ODERS_P28_Pos)
+#define GPIO_ODERS_P29_Pos          29           /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P29              (_U(0x1) << GPIO_ODERS_P29_Pos)
+#define GPIO_ODERS_P30_Pos          30           /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P30              (_U(0x1) << GPIO_ODERS_P30_Pos)
+#define GPIO_ODERS_P31_Pos          31           /**< \brief (GPIO_ODERS) Output Driver Enable */
+#define GPIO_ODERS_P31              (_U(0x1) << GPIO_ODERS_P31_Pos)
+#define GPIO_ODERS_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_ODERS) MASK Register */
+
+/* -------- GPIO_ODERC : (GPIO Offset: 0x048) ( /W 32) port Output Driver Enable Register - Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Output Driver Enable               */
+    uint32_t P1:1;             /*!< bit:      1  Output Driver Enable               */
+    uint32_t P2:1;             /*!< bit:      2  Output Driver Enable               */
+    uint32_t P3:1;             /*!< bit:      3  Output Driver Enable               */
+    uint32_t P4:1;             /*!< bit:      4  Output Driver Enable               */
+    uint32_t P5:1;             /*!< bit:      5  Output Driver Enable               */
+    uint32_t P6:1;             /*!< bit:      6  Output Driver Enable               */
+    uint32_t P7:1;             /*!< bit:      7  Output Driver Enable               */
+    uint32_t P8:1;             /*!< bit:      8  Output Driver Enable               */
+    uint32_t P9:1;             /*!< bit:      9  Output Driver Enable               */
+    uint32_t P10:1;            /*!< bit:     10  Output Driver Enable               */
+    uint32_t P11:1;            /*!< bit:     11  Output Driver Enable               */
+    uint32_t P12:1;            /*!< bit:     12  Output Driver Enable               */
+    uint32_t P13:1;            /*!< bit:     13  Output Driver Enable               */
+    uint32_t P14:1;            /*!< bit:     14  Output Driver Enable               */
+    uint32_t P15:1;            /*!< bit:     15  Output Driver Enable               */
+    uint32_t P16:1;            /*!< bit:     16  Output Driver Enable               */
+    uint32_t P17:1;            /*!< bit:     17  Output Driver Enable               */
+    uint32_t P18:1;            /*!< bit:     18  Output Driver Enable               */
+    uint32_t P19:1;            /*!< bit:     19  Output Driver Enable               */
+    uint32_t P20:1;            /*!< bit:     20  Output Driver Enable               */
+    uint32_t P21:1;            /*!< bit:     21  Output Driver Enable               */
+    uint32_t P22:1;            /*!< bit:     22  Output Driver Enable               */
+    uint32_t P23:1;            /*!< bit:     23  Output Driver Enable               */
+    uint32_t P24:1;            /*!< bit:     24  Output Driver Enable               */
+    uint32_t P25:1;            /*!< bit:     25  Output Driver Enable               */
+    uint32_t P26:1;            /*!< bit:     26  Output Driver Enable               */
+    uint32_t P27:1;            /*!< bit:     27  Output Driver Enable               */
+    uint32_t P28:1;            /*!< bit:     28  Output Driver Enable               */
+    uint32_t P29:1;            /*!< bit:     29  Output Driver Enable               */
+    uint32_t P30:1;            /*!< bit:     30  Output Driver Enable               */
+    uint32_t P31:1;            /*!< bit:     31  Output Driver Enable               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_ODERC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_ODERC_OFFSET           0x048        /**< \brief (GPIO_ODERC offset) Output Driver Enable Register - Clear */
+
+#define GPIO_ODERC_P0_Pos           0            /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P0               (_U(0x1) << GPIO_ODERC_P0_Pos)
+#define GPIO_ODERC_P1_Pos           1            /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P1               (_U(0x1) << GPIO_ODERC_P1_Pos)
+#define GPIO_ODERC_P2_Pos           2            /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P2               (_U(0x1) << GPIO_ODERC_P2_Pos)
+#define GPIO_ODERC_P3_Pos           3            /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P3               (_U(0x1) << GPIO_ODERC_P3_Pos)
+#define GPIO_ODERC_P4_Pos           4            /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P4               (_U(0x1) << GPIO_ODERC_P4_Pos)
+#define GPIO_ODERC_P5_Pos           5            /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P5               (_U(0x1) << GPIO_ODERC_P5_Pos)
+#define GPIO_ODERC_P6_Pos           6            /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P6               (_U(0x1) << GPIO_ODERC_P6_Pos)
+#define GPIO_ODERC_P7_Pos           7            /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P7               (_U(0x1) << GPIO_ODERC_P7_Pos)
+#define GPIO_ODERC_P8_Pos           8            /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P8               (_U(0x1) << GPIO_ODERC_P8_Pos)
+#define GPIO_ODERC_P9_Pos           9            /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P9               (_U(0x1) << GPIO_ODERC_P9_Pos)
+#define GPIO_ODERC_P10_Pos          10           /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P10              (_U(0x1) << GPIO_ODERC_P10_Pos)
+#define GPIO_ODERC_P11_Pos          11           /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P11              (_U(0x1) << GPIO_ODERC_P11_Pos)
+#define GPIO_ODERC_P12_Pos          12           /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P12              (_U(0x1) << GPIO_ODERC_P12_Pos)
+#define GPIO_ODERC_P13_Pos          13           /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P13              (_U(0x1) << GPIO_ODERC_P13_Pos)
+#define GPIO_ODERC_P14_Pos          14           /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P14              (_U(0x1) << GPIO_ODERC_P14_Pos)
+#define GPIO_ODERC_P15_Pos          15           /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P15              (_U(0x1) << GPIO_ODERC_P15_Pos)
+#define GPIO_ODERC_P16_Pos          16           /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P16              (_U(0x1) << GPIO_ODERC_P16_Pos)
+#define GPIO_ODERC_P17_Pos          17           /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P17              (_U(0x1) << GPIO_ODERC_P17_Pos)
+#define GPIO_ODERC_P18_Pos          18           /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P18              (_U(0x1) << GPIO_ODERC_P18_Pos)
+#define GPIO_ODERC_P19_Pos          19           /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P19              (_U(0x1) << GPIO_ODERC_P19_Pos)
+#define GPIO_ODERC_P20_Pos          20           /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P20              (_U(0x1) << GPIO_ODERC_P20_Pos)
+#define GPIO_ODERC_P21_Pos          21           /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P21              (_U(0x1) << GPIO_ODERC_P21_Pos)
+#define GPIO_ODERC_P22_Pos          22           /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P22              (_U(0x1) << GPIO_ODERC_P22_Pos)
+#define GPIO_ODERC_P23_Pos          23           /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P23              (_U(0x1) << GPIO_ODERC_P23_Pos)
+#define GPIO_ODERC_P24_Pos          24           /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P24              (_U(0x1) << GPIO_ODERC_P24_Pos)
+#define GPIO_ODERC_P25_Pos          25           /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P25              (_U(0x1) << GPIO_ODERC_P25_Pos)
+#define GPIO_ODERC_P26_Pos          26           /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P26              (_U(0x1) << GPIO_ODERC_P26_Pos)
+#define GPIO_ODERC_P27_Pos          27           /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P27              (_U(0x1) << GPIO_ODERC_P27_Pos)
+#define GPIO_ODERC_P28_Pos          28           /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P28              (_U(0x1) << GPIO_ODERC_P28_Pos)
+#define GPIO_ODERC_P29_Pos          29           /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P29              (_U(0x1) << GPIO_ODERC_P29_Pos)
+#define GPIO_ODERC_P30_Pos          30           /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P30              (_U(0x1) << GPIO_ODERC_P30_Pos)
+#define GPIO_ODERC_P31_Pos          31           /**< \brief (GPIO_ODERC) Output Driver Enable */
+#define GPIO_ODERC_P31              (_U(0x1) << GPIO_ODERC_P31_Pos)
+#define GPIO_ODERC_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_ODERC) MASK Register */
+
+/* -------- GPIO_ODERT : (GPIO Offset: 0x04C) ( /W 32) port Output Driver Enable Register - Toggle -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Output Driver Enable               */
+    uint32_t P1:1;             /*!< bit:      1  Output Driver Enable               */
+    uint32_t P2:1;             /*!< bit:      2  Output Driver Enable               */
+    uint32_t P3:1;             /*!< bit:      3  Output Driver Enable               */
+    uint32_t P4:1;             /*!< bit:      4  Output Driver Enable               */
+    uint32_t P5:1;             /*!< bit:      5  Output Driver Enable               */
+    uint32_t P6:1;             /*!< bit:      6  Output Driver Enable               */
+    uint32_t P7:1;             /*!< bit:      7  Output Driver Enable               */
+    uint32_t P8:1;             /*!< bit:      8  Output Driver Enable               */
+    uint32_t P9:1;             /*!< bit:      9  Output Driver Enable               */
+    uint32_t P10:1;            /*!< bit:     10  Output Driver Enable               */
+    uint32_t P11:1;            /*!< bit:     11  Output Driver Enable               */
+    uint32_t P12:1;            /*!< bit:     12  Output Driver Enable               */
+    uint32_t P13:1;            /*!< bit:     13  Output Driver Enable               */
+    uint32_t P14:1;            /*!< bit:     14  Output Driver Enable               */
+    uint32_t P15:1;            /*!< bit:     15  Output Driver Enable               */
+    uint32_t P16:1;            /*!< bit:     16  Output Driver Enable               */
+    uint32_t P17:1;            /*!< bit:     17  Output Driver Enable               */
+    uint32_t P18:1;            /*!< bit:     18  Output Driver Enable               */
+    uint32_t P19:1;            /*!< bit:     19  Output Driver Enable               */
+    uint32_t P20:1;            /*!< bit:     20  Output Driver Enable               */
+    uint32_t P21:1;            /*!< bit:     21  Output Driver Enable               */
+    uint32_t P22:1;            /*!< bit:     22  Output Driver Enable               */
+    uint32_t P23:1;            /*!< bit:     23  Output Driver Enable               */
+    uint32_t P24:1;            /*!< bit:     24  Output Driver Enable               */
+    uint32_t P25:1;            /*!< bit:     25  Output Driver Enable               */
+    uint32_t P26:1;            /*!< bit:     26  Output Driver Enable               */
+    uint32_t P27:1;            /*!< bit:     27  Output Driver Enable               */
+    uint32_t P28:1;            /*!< bit:     28  Output Driver Enable               */
+    uint32_t P29:1;            /*!< bit:     29  Output Driver Enable               */
+    uint32_t P30:1;            /*!< bit:     30  Output Driver Enable               */
+    uint32_t P31:1;            /*!< bit:     31  Output Driver Enable               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_ODERT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_ODERT_OFFSET           0x04C        /**< \brief (GPIO_ODERT offset) Output Driver Enable Register - Toggle */
+
+#define GPIO_ODERT_P0_Pos           0            /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P0               (_U(0x1) << GPIO_ODERT_P0_Pos)
+#define GPIO_ODERT_P1_Pos           1            /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P1               (_U(0x1) << GPIO_ODERT_P1_Pos)
+#define GPIO_ODERT_P2_Pos           2            /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P2               (_U(0x1) << GPIO_ODERT_P2_Pos)
+#define GPIO_ODERT_P3_Pos           3            /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P3               (_U(0x1) << GPIO_ODERT_P3_Pos)
+#define GPIO_ODERT_P4_Pos           4            /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P4               (_U(0x1) << GPIO_ODERT_P4_Pos)
+#define GPIO_ODERT_P5_Pos           5            /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P5               (_U(0x1) << GPIO_ODERT_P5_Pos)
+#define GPIO_ODERT_P6_Pos           6            /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P6               (_U(0x1) << GPIO_ODERT_P6_Pos)
+#define GPIO_ODERT_P7_Pos           7            /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P7               (_U(0x1) << GPIO_ODERT_P7_Pos)
+#define GPIO_ODERT_P8_Pos           8            /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P8               (_U(0x1) << GPIO_ODERT_P8_Pos)
+#define GPIO_ODERT_P9_Pos           9            /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P9               (_U(0x1) << GPIO_ODERT_P9_Pos)
+#define GPIO_ODERT_P10_Pos          10           /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P10              (_U(0x1) << GPIO_ODERT_P10_Pos)
+#define GPIO_ODERT_P11_Pos          11           /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P11              (_U(0x1) << GPIO_ODERT_P11_Pos)
+#define GPIO_ODERT_P12_Pos          12           /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P12              (_U(0x1) << GPIO_ODERT_P12_Pos)
+#define GPIO_ODERT_P13_Pos          13           /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P13              (_U(0x1) << GPIO_ODERT_P13_Pos)
+#define GPIO_ODERT_P14_Pos          14           /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P14              (_U(0x1) << GPIO_ODERT_P14_Pos)
+#define GPIO_ODERT_P15_Pos          15           /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P15              (_U(0x1) << GPIO_ODERT_P15_Pos)
+#define GPIO_ODERT_P16_Pos          16           /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P16              (_U(0x1) << GPIO_ODERT_P16_Pos)
+#define GPIO_ODERT_P17_Pos          17           /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P17              (_U(0x1) << GPIO_ODERT_P17_Pos)
+#define GPIO_ODERT_P18_Pos          18           /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P18              (_U(0x1) << GPIO_ODERT_P18_Pos)
+#define GPIO_ODERT_P19_Pos          19           /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P19              (_U(0x1) << GPIO_ODERT_P19_Pos)
+#define GPIO_ODERT_P20_Pos          20           /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P20              (_U(0x1) << GPIO_ODERT_P20_Pos)
+#define GPIO_ODERT_P21_Pos          21           /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P21              (_U(0x1) << GPIO_ODERT_P21_Pos)
+#define GPIO_ODERT_P22_Pos          22           /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P22              (_U(0x1) << GPIO_ODERT_P22_Pos)
+#define GPIO_ODERT_P23_Pos          23           /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P23              (_U(0x1) << GPIO_ODERT_P23_Pos)
+#define GPIO_ODERT_P24_Pos          24           /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P24              (_U(0x1) << GPIO_ODERT_P24_Pos)
+#define GPIO_ODERT_P25_Pos          25           /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P25              (_U(0x1) << GPIO_ODERT_P25_Pos)
+#define GPIO_ODERT_P26_Pos          26           /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P26              (_U(0x1) << GPIO_ODERT_P26_Pos)
+#define GPIO_ODERT_P27_Pos          27           /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P27              (_U(0x1) << GPIO_ODERT_P27_Pos)
+#define GPIO_ODERT_P28_Pos          28           /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P28              (_U(0x1) << GPIO_ODERT_P28_Pos)
+#define GPIO_ODERT_P29_Pos          29           /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P29              (_U(0x1) << GPIO_ODERT_P29_Pos)
+#define GPIO_ODERT_P30_Pos          30           /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P30              (_U(0x1) << GPIO_ODERT_P30_Pos)
+#define GPIO_ODERT_P31_Pos          31           /**< \brief (GPIO_ODERT) Output Driver Enable */
+#define GPIO_ODERT_P31              (_U(0x1) << GPIO_ODERT_P31_Pos)
+#define GPIO_ODERT_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_ODERT) MASK Register */
+
+/* -------- GPIO_OVR : (GPIO Offset: 0x050) (R/W 32) port Output Value Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Output Value                       */
+    uint32_t P1:1;             /*!< bit:      1  Output Value                       */
+    uint32_t P2:1;             /*!< bit:      2  Output Value                       */
+    uint32_t P3:1;             /*!< bit:      3  Output Value                       */
+    uint32_t P4:1;             /*!< bit:      4  Output Value                       */
+    uint32_t P5:1;             /*!< bit:      5  Output Value                       */
+    uint32_t P6:1;             /*!< bit:      6  Output Value                       */
+    uint32_t P7:1;             /*!< bit:      7  Output Value                       */
+    uint32_t P8:1;             /*!< bit:      8  Output Value                       */
+    uint32_t P9:1;             /*!< bit:      9  Output Value                       */
+    uint32_t P10:1;            /*!< bit:     10  Output Value                       */
+    uint32_t P11:1;            /*!< bit:     11  Output Value                       */
+    uint32_t P12:1;            /*!< bit:     12  Output Value                       */
+    uint32_t P13:1;            /*!< bit:     13  Output Value                       */
+    uint32_t P14:1;            /*!< bit:     14  Output Value                       */
+    uint32_t P15:1;            /*!< bit:     15  Output Value                       */
+    uint32_t P16:1;            /*!< bit:     16  Output Value                       */
+    uint32_t P17:1;            /*!< bit:     17  Output Value                       */
+    uint32_t P18:1;            /*!< bit:     18  Output Value                       */
+    uint32_t P19:1;            /*!< bit:     19  Output Value                       */
+    uint32_t P20:1;            /*!< bit:     20  Output Value                       */
+    uint32_t P21:1;            /*!< bit:     21  Output Value                       */
+    uint32_t P22:1;            /*!< bit:     22  Output Value                       */
+    uint32_t P23:1;            /*!< bit:     23  Output Value                       */
+    uint32_t P24:1;            /*!< bit:     24  Output Value                       */
+    uint32_t P25:1;            /*!< bit:     25  Output Value                       */
+    uint32_t P26:1;            /*!< bit:     26  Output Value                       */
+    uint32_t P27:1;            /*!< bit:     27  Output Value                       */
+    uint32_t P28:1;            /*!< bit:     28  Output Value                       */
+    uint32_t P29:1;            /*!< bit:     29  Output Value                       */
+    uint32_t P30:1;            /*!< bit:     30  Output Value                       */
+    uint32_t P31:1;            /*!< bit:     31  Output Value                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_OVR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_OVR_OFFSET             0x050        /**< \brief (GPIO_OVR offset) Output Value Register */
+
+#define GPIO_OVR_P0_Pos             0            /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P0                 (_U(0x1) << GPIO_OVR_P0_Pos)
+#define GPIO_OVR_P1_Pos             1            /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P1                 (_U(0x1) << GPIO_OVR_P1_Pos)
+#define GPIO_OVR_P2_Pos             2            /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P2                 (_U(0x1) << GPIO_OVR_P2_Pos)
+#define GPIO_OVR_P3_Pos             3            /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P3                 (_U(0x1) << GPIO_OVR_P3_Pos)
+#define GPIO_OVR_P4_Pos             4            /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P4                 (_U(0x1) << GPIO_OVR_P4_Pos)
+#define GPIO_OVR_P5_Pos             5            /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P5                 (_U(0x1) << GPIO_OVR_P5_Pos)
+#define GPIO_OVR_P6_Pos             6            /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P6                 (_U(0x1) << GPIO_OVR_P6_Pos)
+#define GPIO_OVR_P7_Pos             7            /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P7                 (_U(0x1) << GPIO_OVR_P7_Pos)
+#define GPIO_OVR_P8_Pos             8            /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P8                 (_U(0x1) << GPIO_OVR_P8_Pos)
+#define GPIO_OVR_P9_Pos             9            /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P9                 (_U(0x1) << GPIO_OVR_P9_Pos)
+#define GPIO_OVR_P10_Pos            10           /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P10                (_U(0x1) << GPIO_OVR_P10_Pos)
+#define GPIO_OVR_P11_Pos            11           /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P11                (_U(0x1) << GPIO_OVR_P11_Pos)
+#define GPIO_OVR_P12_Pos            12           /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P12                (_U(0x1) << GPIO_OVR_P12_Pos)
+#define GPIO_OVR_P13_Pos            13           /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P13                (_U(0x1) << GPIO_OVR_P13_Pos)
+#define GPIO_OVR_P14_Pos            14           /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P14                (_U(0x1) << GPIO_OVR_P14_Pos)
+#define GPIO_OVR_P15_Pos            15           /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P15                (_U(0x1) << GPIO_OVR_P15_Pos)
+#define GPIO_OVR_P16_Pos            16           /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P16                (_U(0x1) << GPIO_OVR_P16_Pos)
+#define GPIO_OVR_P17_Pos            17           /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P17                (_U(0x1) << GPIO_OVR_P17_Pos)
+#define GPIO_OVR_P18_Pos            18           /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P18                (_U(0x1) << GPIO_OVR_P18_Pos)
+#define GPIO_OVR_P19_Pos            19           /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P19                (_U(0x1) << GPIO_OVR_P19_Pos)
+#define GPIO_OVR_P20_Pos            20           /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P20                (_U(0x1) << GPIO_OVR_P20_Pos)
+#define GPIO_OVR_P21_Pos            21           /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P21                (_U(0x1) << GPIO_OVR_P21_Pos)
+#define GPIO_OVR_P22_Pos            22           /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P22                (_U(0x1) << GPIO_OVR_P22_Pos)
+#define GPIO_OVR_P23_Pos            23           /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P23                (_U(0x1) << GPIO_OVR_P23_Pos)
+#define GPIO_OVR_P24_Pos            24           /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P24                (_U(0x1) << GPIO_OVR_P24_Pos)
+#define GPIO_OVR_P25_Pos            25           /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P25                (_U(0x1) << GPIO_OVR_P25_Pos)
+#define GPIO_OVR_P26_Pos            26           /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P26                (_U(0x1) << GPIO_OVR_P26_Pos)
+#define GPIO_OVR_P27_Pos            27           /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P27                (_U(0x1) << GPIO_OVR_P27_Pos)
+#define GPIO_OVR_P28_Pos            28           /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P28                (_U(0x1) << GPIO_OVR_P28_Pos)
+#define GPIO_OVR_P29_Pos            29           /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P29                (_U(0x1) << GPIO_OVR_P29_Pos)
+#define GPIO_OVR_P30_Pos            30           /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P30                (_U(0x1) << GPIO_OVR_P30_Pos)
+#define GPIO_OVR_P31_Pos            31           /**< \brief (GPIO_OVR) Output Value */
+#define GPIO_OVR_P31                (_U(0x1) << GPIO_OVR_P31_Pos)
+#define GPIO_OVR_MASK               _U(0xFFFFFFFF) /**< \brief (GPIO_OVR) MASK Register */
+
+/* -------- GPIO_OVRS : (GPIO Offset: 0x054) ( /W 32) port Output Value Register - Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Output Value                       */
+    uint32_t P1:1;             /*!< bit:      1  Output Value                       */
+    uint32_t P2:1;             /*!< bit:      2  Output Value                       */
+    uint32_t P3:1;             /*!< bit:      3  Output Value                       */
+    uint32_t P4:1;             /*!< bit:      4  Output Value                       */
+    uint32_t P5:1;             /*!< bit:      5  Output Value                       */
+    uint32_t P6:1;             /*!< bit:      6  Output Value                       */
+    uint32_t P7:1;             /*!< bit:      7  Output Value                       */
+    uint32_t P8:1;             /*!< bit:      8  Output Value                       */
+    uint32_t P9:1;             /*!< bit:      9  Output Value                       */
+    uint32_t P10:1;            /*!< bit:     10  Output Value                       */
+    uint32_t P11:1;            /*!< bit:     11  Output Value                       */
+    uint32_t P12:1;            /*!< bit:     12  Output Value                       */
+    uint32_t P13:1;            /*!< bit:     13  Output Value                       */
+    uint32_t P14:1;            /*!< bit:     14  Output Value                       */
+    uint32_t P15:1;            /*!< bit:     15  Output Value                       */
+    uint32_t P16:1;            /*!< bit:     16  Output Value                       */
+    uint32_t P17:1;            /*!< bit:     17  Output Value                       */
+    uint32_t P18:1;            /*!< bit:     18  Output Value                       */
+    uint32_t P19:1;            /*!< bit:     19  Output Value                       */
+    uint32_t P20:1;            /*!< bit:     20  Output Value                       */
+    uint32_t P21:1;            /*!< bit:     21  Output Value                       */
+    uint32_t P22:1;            /*!< bit:     22  Output Value                       */
+    uint32_t P23:1;            /*!< bit:     23  Output Value                       */
+    uint32_t P24:1;            /*!< bit:     24  Output Value                       */
+    uint32_t P25:1;            /*!< bit:     25  Output Value                       */
+    uint32_t P26:1;            /*!< bit:     26  Output Value                       */
+    uint32_t P27:1;            /*!< bit:     27  Output Value                       */
+    uint32_t P28:1;            /*!< bit:     28  Output Value                       */
+    uint32_t P29:1;            /*!< bit:     29  Output Value                       */
+    uint32_t P30:1;            /*!< bit:     30  Output Value                       */
+    uint32_t P31:1;            /*!< bit:     31  Output Value                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_OVRS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_OVRS_OFFSET            0x054        /**< \brief (GPIO_OVRS offset) Output Value Register - Set */
+
+#define GPIO_OVRS_P0_Pos            0            /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P0                (_U(0x1) << GPIO_OVRS_P0_Pos)
+#define GPIO_OVRS_P1_Pos            1            /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P1                (_U(0x1) << GPIO_OVRS_P1_Pos)
+#define GPIO_OVRS_P2_Pos            2            /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P2                (_U(0x1) << GPIO_OVRS_P2_Pos)
+#define GPIO_OVRS_P3_Pos            3            /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P3                (_U(0x1) << GPIO_OVRS_P3_Pos)
+#define GPIO_OVRS_P4_Pos            4            /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P4                (_U(0x1) << GPIO_OVRS_P4_Pos)
+#define GPIO_OVRS_P5_Pos            5            /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P5                (_U(0x1) << GPIO_OVRS_P5_Pos)
+#define GPIO_OVRS_P6_Pos            6            /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P6                (_U(0x1) << GPIO_OVRS_P6_Pos)
+#define GPIO_OVRS_P7_Pos            7            /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P7                (_U(0x1) << GPIO_OVRS_P7_Pos)
+#define GPIO_OVRS_P8_Pos            8            /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P8                (_U(0x1) << GPIO_OVRS_P8_Pos)
+#define GPIO_OVRS_P9_Pos            9            /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P9                (_U(0x1) << GPIO_OVRS_P9_Pos)
+#define GPIO_OVRS_P10_Pos           10           /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P10               (_U(0x1) << GPIO_OVRS_P10_Pos)
+#define GPIO_OVRS_P11_Pos           11           /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P11               (_U(0x1) << GPIO_OVRS_P11_Pos)
+#define GPIO_OVRS_P12_Pos           12           /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P12               (_U(0x1) << GPIO_OVRS_P12_Pos)
+#define GPIO_OVRS_P13_Pos           13           /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P13               (_U(0x1) << GPIO_OVRS_P13_Pos)
+#define GPIO_OVRS_P14_Pos           14           /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P14               (_U(0x1) << GPIO_OVRS_P14_Pos)
+#define GPIO_OVRS_P15_Pos           15           /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P15               (_U(0x1) << GPIO_OVRS_P15_Pos)
+#define GPIO_OVRS_P16_Pos           16           /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P16               (_U(0x1) << GPIO_OVRS_P16_Pos)
+#define GPIO_OVRS_P17_Pos           17           /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P17               (_U(0x1) << GPIO_OVRS_P17_Pos)
+#define GPIO_OVRS_P18_Pos           18           /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P18               (_U(0x1) << GPIO_OVRS_P18_Pos)
+#define GPIO_OVRS_P19_Pos           19           /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P19               (_U(0x1) << GPIO_OVRS_P19_Pos)
+#define GPIO_OVRS_P20_Pos           20           /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P20               (_U(0x1) << GPIO_OVRS_P20_Pos)
+#define GPIO_OVRS_P21_Pos           21           /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P21               (_U(0x1) << GPIO_OVRS_P21_Pos)
+#define GPIO_OVRS_P22_Pos           22           /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P22               (_U(0x1) << GPIO_OVRS_P22_Pos)
+#define GPIO_OVRS_P23_Pos           23           /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P23               (_U(0x1) << GPIO_OVRS_P23_Pos)
+#define GPIO_OVRS_P24_Pos           24           /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P24               (_U(0x1) << GPIO_OVRS_P24_Pos)
+#define GPIO_OVRS_P25_Pos           25           /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P25               (_U(0x1) << GPIO_OVRS_P25_Pos)
+#define GPIO_OVRS_P26_Pos           26           /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P26               (_U(0x1) << GPIO_OVRS_P26_Pos)
+#define GPIO_OVRS_P27_Pos           27           /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P27               (_U(0x1) << GPIO_OVRS_P27_Pos)
+#define GPIO_OVRS_P28_Pos           28           /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P28               (_U(0x1) << GPIO_OVRS_P28_Pos)
+#define GPIO_OVRS_P29_Pos           29           /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P29               (_U(0x1) << GPIO_OVRS_P29_Pos)
+#define GPIO_OVRS_P30_Pos           30           /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P30               (_U(0x1) << GPIO_OVRS_P30_Pos)
+#define GPIO_OVRS_P31_Pos           31           /**< \brief (GPIO_OVRS) Output Value */
+#define GPIO_OVRS_P31               (_U(0x1) << GPIO_OVRS_P31_Pos)
+#define GPIO_OVRS_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_OVRS) MASK Register */
+
+/* -------- GPIO_OVRC : (GPIO Offset: 0x058) ( /W 32) port Output Value Register - Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Output Value                       */
+    uint32_t P1:1;             /*!< bit:      1  Output Value                       */
+    uint32_t P2:1;             /*!< bit:      2  Output Value                       */
+    uint32_t P3:1;             /*!< bit:      3  Output Value                       */
+    uint32_t P4:1;             /*!< bit:      4  Output Value                       */
+    uint32_t P5:1;             /*!< bit:      5  Output Value                       */
+    uint32_t P6:1;             /*!< bit:      6  Output Value                       */
+    uint32_t P7:1;             /*!< bit:      7  Output Value                       */
+    uint32_t P8:1;             /*!< bit:      8  Output Value                       */
+    uint32_t P9:1;             /*!< bit:      9  Output Value                       */
+    uint32_t P10:1;            /*!< bit:     10  Output Value                       */
+    uint32_t P11:1;            /*!< bit:     11  Output Value                       */
+    uint32_t P12:1;            /*!< bit:     12  Output Value                       */
+    uint32_t P13:1;            /*!< bit:     13  Output Value                       */
+    uint32_t P14:1;            /*!< bit:     14  Output Value                       */
+    uint32_t P15:1;            /*!< bit:     15  Output Value                       */
+    uint32_t P16:1;            /*!< bit:     16  Output Value                       */
+    uint32_t P17:1;            /*!< bit:     17  Output Value                       */
+    uint32_t P18:1;            /*!< bit:     18  Output Value                       */
+    uint32_t P19:1;            /*!< bit:     19  Output Value                       */
+    uint32_t P20:1;            /*!< bit:     20  Output Value                       */
+    uint32_t P21:1;            /*!< bit:     21  Output Value                       */
+    uint32_t P22:1;            /*!< bit:     22  Output Value                       */
+    uint32_t P23:1;            /*!< bit:     23  Output Value                       */
+    uint32_t P24:1;            /*!< bit:     24  Output Value                       */
+    uint32_t P25:1;            /*!< bit:     25  Output Value                       */
+    uint32_t P26:1;            /*!< bit:     26  Output Value                       */
+    uint32_t P27:1;            /*!< bit:     27  Output Value                       */
+    uint32_t P28:1;            /*!< bit:     28  Output Value                       */
+    uint32_t P29:1;            /*!< bit:     29  Output Value                       */
+    uint32_t P30:1;            /*!< bit:     30  Output Value                       */
+    uint32_t P31:1;            /*!< bit:     31  Output Value                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_OVRC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_OVRC_OFFSET            0x058        /**< \brief (GPIO_OVRC offset) Output Value Register - Clear */
+
+#define GPIO_OVRC_P0_Pos            0            /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P0                (_U(0x1) << GPIO_OVRC_P0_Pos)
+#define GPIO_OVRC_P1_Pos            1            /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P1                (_U(0x1) << GPIO_OVRC_P1_Pos)
+#define GPIO_OVRC_P2_Pos            2            /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P2                (_U(0x1) << GPIO_OVRC_P2_Pos)
+#define GPIO_OVRC_P3_Pos            3            /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P3                (_U(0x1) << GPIO_OVRC_P3_Pos)
+#define GPIO_OVRC_P4_Pos            4            /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P4                (_U(0x1) << GPIO_OVRC_P4_Pos)
+#define GPIO_OVRC_P5_Pos            5            /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P5                (_U(0x1) << GPIO_OVRC_P5_Pos)
+#define GPIO_OVRC_P6_Pos            6            /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P6                (_U(0x1) << GPIO_OVRC_P6_Pos)
+#define GPIO_OVRC_P7_Pos            7            /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P7                (_U(0x1) << GPIO_OVRC_P7_Pos)
+#define GPIO_OVRC_P8_Pos            8            /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P8                (_U(0x1) << GPIO_OVRC_P8_Pos)
+#define GPIO_OVRC_P9_Pos            9            /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P9                (_U(0x1) << GPIO_OVRC_P9_Pos)
+#define GPIO_OVRC_P10_Pos           10           /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P10               (_U(0x1) << GPIO_OVRC_P10_Pos)
+#define GPIO_OVRC_P11_Pos           11           /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P11               (_U(0x1) << GPIO_OVRC_P11_Pos)
+#define GPIO_OVRC_P12_Pos           12           /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P12               (_U(0x1) << GPIO_OVRC_P12_Pos)
+#define GPIO_OVRC_P13_Pos           13           /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P13               (_U(0x1) << GPIO_OVRC_P13_Pos)
+#define GPIO_OVRC_P14_Pos           14           /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P14               (_U(0x1) << GPIO_OVRC_P14_Pos)
+#define GPIO_OVRC_P15_Pos           15           /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P15               (_U(0x1) << GPIO_OVRC_P15_Pos)
+#define GPIO_OVRC_P16_Pos           16           /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P16               (_U(0x1) << GPIO_OVRC_P16_Pos)
+#define GPIO_OVRC_P17_Pos           17           /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P17               (_U(0x1) << GPIO_OVRC_P17_Pos)
+#define GPIO_OVRC_P18_Pos           18           /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P18               (_U(0x1) << GPIO_OVRC_P18_Pos)
+#define GPIO_OVRC_P19_Pos           19           /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P19               (_U(0x1) << GPIO_OVRC_P19_Pos)
+#define GPIO_OVRC_P20_Pos           20           /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P20               (_U(0x1) << GPIO_OVRC_P20_Pos)
+#define GPIO_OVRC_P21_Pos           21           /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P21               (_U(0x1) << GPIO_OVRC_P21_Pos)
+#define GPIO_OVRC_P22_Pos           22           /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P22               (_U(0x1) << GPIO_OVRC_P22_Pos)
+#define GPIO_OVRC_P23_Pos           23           /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P23               (_U(0x1) << GPIO_OVRC_P23_Pos)
+#define GPIO_OVRC_P24_Pos           24           /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P24               (_U(0x1) << GPIO_OVRC_P24_Pos)
+#define GPIO_OVRC_P25_Pos           25           /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P25               (_U(0x1) << GPIO_OVRC_P25_Pos)
+#define GPIO_OVRC_P26_Pos           26           /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P26               (_U(0x1) << GPIO_OVRC_P26_Pos)
+#define GPIO_OVRC_P27_Pos           27           /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P27               (_U(0x1) << GPIO_OVRC_P27_Pos)
+#define GPIO_OVRC_P28_Pos           28           /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P28               (_U(0x1) << GPIO_OVRC_P28_Pos)
+#define GPIO_OVRC_P29_Pos           29           /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P29               (_U(0x1) << GPIO_OVRC_P29_Pos)
+#define GPIO_OVRC_P30_Pos           30           /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P30               (_U(0x1) << GPIO_OVRC_P30_Pos)
+#define GPIO_OVRC_P31_Pos           31           /**< \brief (GPIO_OVRC) Output Value */
+#define GPIO_OVRC_P31               (_U(0x1) << GPIO_OVRC_P31_Pos)
+#define GPIO_OVRC_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_OVRC) MASK Register */
+
+/* -------- GPIO_OVRT : (GPIO Offset: 0x05C) ( /W 32) port Output Value Register - Toggle -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Output Value                       */
+    uint32_t P1:1;             /*!< bit:      1  Output Value                       */
+    uint32_t P2:1;             /*!< bit:      2  Output Value                       */
+    uint32_t P3:1;             /*!< bit:      3  Output Value                       */
+    uint32_t P4:1;             /*!< bit:      4  Output Value                       */
+    uint32_t P5:1;             /*!< bit:      5  Output Value                       */
+    uint32_t P6:1;             /*!< bit:      6  Output Value                       */
+    uint32_t P7:1;             /*!< bit:      7  Output Value                       */
+    uint32_t P8:1;             /*!< bit:      8  Output Value                       */
+    uint32_t P9:1;             /*!< bit:      9  Output Value                       */
+    uint32_t P10:1;            /*!< bit:     10  Output Value                       */
+    uint32_t P11:1;            /*!< bit:     11  Output Value                       */
+    uint32_t P12:1;            /*!< bit:     12  Output Value                       */
+    uint32_t P13:1;            /*!< bit:     13  Output Value                       */
+    uint32_t P14:1;            /*!< bit:     14  Output Value                       */
+    uint32_t P15:1;            /*!< bit:     15  Output Value                       */
+    uint32_t P16:1;            /*!< bit:     16  Output Value                       */
+    uint32_t P17:1;            /*!< bit:     17  Output Value                       */
+    uint32_t P18:1;            /*!< bit:     18  Output Value                       */
+    uint32_t P19:1;            /*!< bit:     19  Output Value                       */
+    uint32_t P20:1;            /*!< bit:     20  Output Value                       */
+    uint32_t P21:1;            /*!< bit:     21  Output Value                       */
+    uint32_t P22:1;            /*!< bit:     22  Output Value                       */
+    uint32_t P23:1;            /*!< bit:     23  Output Value                       */
+    uint32_t P24:1;            /*!< bit:     24  Output Value                       */
+    uint32_t P25:1;            /*!< bit:     25  Output Value                       */
+    uint32_t P26:1;            /*!< bit:     26  Output Value                       */
+    uint32_t P27:1;            /*!< bit:     27  Output Value                       */
+    uint32_t P28:1;            /*!< bit:     28  Output Value                       */
+    uint32_t P29:1;            /*!< bit:     29  Output Value                       */
+    uint32_t P30:1;            /*!< bit:     30  Output Value                       */
+    uint32_t P31:1;            /*!< bit:     31  Output Value                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_OVRT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_OVRT_OFFSET            0x05C        /**< \brief (GPIO_OVRT offset) Output Value Register - Toggle */
+
+#define GPIO_OVRT_P0_Pos            0            /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P0                (_U(0x1) << GPIO_OVRT_P0_Pos)
+#define GPIO_OVRT_P1_Pos            1            /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P1                (_U(0x1) << GPIO_OVRT_P1_Pos)
+#define GPIO_OVRT_P2_Pos            2            /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P2                (_U(0x1) << GPIO_OVRT_P2_Pos)
+#define GPIO_OVRT_P3_Pos            3            /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P3                (_U(0x1) << GPIO_OVRT_P3_Pos)
+#define GPIO_OVRT_P4_Pos            4            /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P4                (_U(0x1) << GPIO_OVRT_P4_Pos)
+#define GPIO_OVRT_P5_Pos            5            /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P5                (_U(0x1) << GPIO_OVRT_P5_Pos)
+#define GPIO_OVRT_P6_Pos            6            /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P6                (_U(0x1) << GPIO_OVRT_P6_Pos)
+#define GPIO_OVRT_P7_Pos            7            /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P7                (_U(0x1) << GPIO_OVRT_P7_Pos)
+#define GPIO_OVRT_P8_Pos            8            /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P8                (_U(0x1) << GPIO_OVRT_P8_Pos)
+#define GPIO_OVRT_P9_Pos            9            /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P9                (_U(0x1) << GPIO_OVRT_P9_Pos)
+#define GPIO_OVRT_P10_Pos           10           /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P10               (_U(0x1) << GPIO_OVRT_P10_Pos)
+#define GPIO_OVRT_P11_Pos           11           /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P11               (_U(0x1) << GPIO_OVRT_P11_Pos)
+#define GPIO_OVRT_P12_Pos           12           /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P12               (_U(0x1) << GPIO_OVRT_P12_Pos)
+#define GPIO_OVRT_P13_Pos           13           /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P13               (_U(0x1) << GPIO_OVRT_P13_Pos)
+#define GPIO_OVRT_P14_Pos           14           /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P14               (_U(0x1) << GPIO_OVRT_P14_Pos)
+#define GPIO_OVRT_P15_Pos           15           /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P15               (_U(0x1) << GPIO_OVRT_P15_Pos)
+#define GPIO_OVRT_P16_Pos           16           /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P16               (_U(0x1) << GPIO_OVRT_P16_Pos)
+#define GPIO_OVRT_P17_Pos           17           /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P17               (_U(0x1) << GPIO_OVRT_P17_Pos)
+#define GPIO_OVRT_P18_Pos           18           /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P18               (_U(0x1) << GPIO_OVRT_P18_Pos)
+#define GPIO_OVRT_P19_Pos           19           /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P19               (_U(0x1) << GPIO_OVRT_P19_Pos)
+#define GPIO_OVRT_P20_Pos           20           /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P20               (_U(0x1) << GPIO_OVRT_P20_Pos)
+#define GPIO_OVRT_P21_Pos           21           /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P21               (_U(0x1) << GPIO_OVRT_P21_Pos)
+#define GPIO_OVRT_P22_Pos           22           /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P22               (_U(0x1) << GPIO_OVRT_P22_Pos)
+#define GPIO_OVRT_P23_Pos           23           /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P23               (_U(0x1) << GPIO_OVRT_P23_Pos)
+#define GPIO_OVRT_P24_Pos           24           /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P24               (_U(0x1) << GPIO_OVRT_P24_Pos)
+#define GPIO_OVRT_P25_Pos           25           /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P25               (_U(0x1) << GPIO_OVRT_P25_Pos)
+#define GPIO_OVRT_P26_Pos           26           /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P26               (_U(0x1) << GPIO_OVRT_P26_Pos)
+#define GPIO_OVRT_P27_Pos           27           /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P27               (_U(0x1) << GPIO_OVRT_P27_Pos)
+#define GPIO_OVRT_P28_Pos           28           /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P28               (_U(0x1) << GPIO_OVRT_P28_Pos)
+#define GPIO_OVRT_P29_Pos           29           /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P29               (_U(0x1) << GPIO_OVRT_P29_Pos)
+#define GPIO_OVRT_P30_Pos           30           /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P30               (_U(0x1) << GPIO_OVRT_P30_Pos)
+#define GPIO_OVRT_P31_Pos           31           /**< \brief (GPIO_OVRT) Output Value */
+#define GPIO_OVRT_P31               (_U(0x1) << GPIO_OVRT_P31_Pos)
+#define GPIO_OVRT_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_OVRT) MASK Register */
+
+/* -------- GPIO_PVR : (GPIO Offset: 0x060) (R/  32) port Pin Value Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Pin Value                          */
+    uint32_t P1:1;             /*!< bit:      1  Pin Value                          */
+    uint32_t P2:1;             /*!< bit:      2  Pin Value                          */
+    uint32_t P3:1;             /*!< bit:      3  Pin Value                          */
+    uint32_t P4:1;             /*!< bit:      4  Pin Value                          */
+    uint32_t P5:1;             /*!< bit:      5  Pin Value                          */
+    uint32_t P6:1;             /*!< bit:      6  Pin Value                          */
+    uint32_t P7:1;             /*!< bit:      7  Pin Value                          */
+    uint32_t P8:1;             /*!< bit:      8  Pin Value                          */
+    uint32_t P9:1;             /*!< bit:      9  Pin Value                          */
+    uint32_t P10:1;            /*!< bit:     10  Pin Value                          */
+    uint32_t P11:1;            /*!< bit:     11  Pin Value                          */
+    uint32_t P12:1;            /*!< bit:     12  Pin Value                          */
+    uint32_t P13:1;            /*!< bit:     13  Pin Value                          */
+    uint32_t P14:1;            /*!< bit:     14  Pin Value                          */
+    uint32_t P15:1;            /*!< bit:     15  Pin Value                          */
+    uint32_t P16:1;            /*!< bit:     16  Pin Value                          */
+    uint32_t P17:1;            /*!< bit:     17  Pin Value                          */
+    uint32_t P18:1;            /*!< bit:     18  Pin Value                          */
+    uint32_t P19:1;            /*!< bit:     19  Pin Value                          */
+    uint32_t P20:1;            /*!< bit:     20  Pin Value                          */
+    uint32_t P21:1;            /*!< bit:     21  Pin Value                          */
+    uint32_t P22:1;            /*!< bit:     22  Pin Value                          */
+    uint32_t P23:1;            /*!< bit:     23  Pin Value                          */
+    uint32_t P24:1;            /*!< bit:     24  Pin Value                          */
+    uint32_t P25:1;            /*!< bit:     25  Pin Value                          */
+    uint32_t P26:1;            /*!< bit:     26  Pin Value                          */
+    uint32_t P27:1;            /*!< bit:     27  Pin Value                          */
+    uint32_t P28:1;            /*!< bit:     28  Pin Value                          */
+    uint32_t P29:1;            /*!< bit:     29  Pin Value                          */
+    uint32_t P30:1;            /*!< bit:     30  Pin Value                          */
+    uint32_t P31:1;            /*!< bit:     31  Pin Value                          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_PVR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_PVR_OFFSET             0x060        /**< \brief (GPIO_PVR offset) Pin Value Register */
+
+#define GPIO_PVR_P0_Pos             0            /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P0                 (_U(0x1) << GPIO_PVR_P0_Pos)
+#define GPIO_PVR_P1_Pos             1            /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P1                 (_U(0x1) << GPIO_PVR_P1_Pos)
+#define GPIO_PVR_P2_Pos             2            /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P2                 (_U(0x1) << GPIO_PVR_P2_Pos)
+#define GPIO_PVR_P3_Pos             3            /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P3                 (_U(0x1) << GPIO_PVR_P3_Pos)
+#define GPIO_PVR_P4_Pos             4            /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P4                 (_U(0x1) << GPIO_PVR_P4_Pos)
+#define GPIO_PVR_P5_Pos             5            /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P5                 (_U(0x1) << GPIO_PVR_P5_Pos)
+#define GPIO_PVR_P6_Pos             6            /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P6                 (_U(0x1) << GPIO_PVR_P6_Pos)
+#define GPIO_PVR_P7_Pos             7            /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P7                 (_U(0x1) << GPIO_PVR_P7_Pos)
+#define GPIO_PVR_P8_Pos             8            /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P8                 (_U(0x1) << GPIO_PVR_P8_Pos)
+#define GPIO_PVR_P9_Pos             9            /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P9                 (_U(0x1) << GPIO_PVR_P9_Pos)
+#define GPIO_PVR_P10_Pos            10           /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P10                (_U(0x1) << GPIO_PVR_P10_Pos)
+#define GPIO_PVR_P11_Pos            11           /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P11                (_U(0x1) << GPIO_PVR_P11_Pos)
+#define GPIO_PVR_P12_Pos            12           /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P12                (_U(0x1) << GPIO_PVR_P12_Pos)
+#define GPIO_PVR_P13_Pos            13           /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P13                (_U(0x1) << GPIO_PVR_P13_Pos)
+#define GPIO_PVR_P14_Pos            14           /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P14                (_U(0x1) << GPIO_PVR_P14_Pos)
+#define GPIO_PVR_P15_Pos            15           /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P15                (_U(0x1) << GPIO_PVR_P15_Pos)
+#define GPIO_PVR_P16_Pos            16           /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P16                (_U(0x1) << GPIO_PVR_P16_Pos)
+#define GPIO_PVR_P17_Pos            17           /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P17                (_U(0x1) << GPIO_PVR_P17_Pos)
+#define GPIO_PVR_P18_Pos            18           /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P18                (_U(0x1) << GPIO_PVR_P18_Pos)
+#define GPIO_PVR_P19_Pos            19           /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P19                (_U(0x1) << GPIO_PVR_P19_Pos)
+#define GPIO_PVR_P20_Pos            20           /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P20                (_U(0x1) << GPIO_PVR_P20_Pos)
+#define GPIO_PVR_P21_Pos            21           /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P21                (_U(0x1) << GPIO_PVR_P21_Pos)
+#define GPIO_PVR_P22_Pos            22           /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P22                (_U(0x1) << GPIO_PVR_P22_Pos)
+#define GPIO_PVR_P23_Pos            23           /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P23                (_U(0x1) << GPIO_PVR_P23_Pos)
+#define GPIO_PVR_P24_Pos            24           /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P24                (_U(0x1) << GPIO_PVR_P24_Pos)
+#define GPIO_PVR_P25_Pos            25           /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P25                (_U(0x1) << GPIO_PVR_P25_Pos)
+#define GPIO_PVR_P26_Pos            26           /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P26                (_U(0x1) << GPIO_PVR_P26_Pos)
+#define GPIO_PVR_P27_Pos            27           /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P27                (_U(0x1) << GPIO_PVR_P27_Pos)
+#define GPIO_PVR_P28_Pos            28           /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P28                (_U(0x1) << GPIO_PVR_P28_Pos)
+#define GPIO_PVR_P29_Pos            29           /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P29                (_U(0x1) << GPIO_PVR_P29_Pos)
+#define GPIO_PVR_P30_Pos            30           /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P30                (_U(0x1) << GPIO_PVR_P30_Pos)
+#define GPIO_PVR_P31_Pos            31           /**< \brief (GPIO_PVR) Pin Value */
+#define GPIO_PVR_P31                (_U(0x1) << GPIO_PVR_P31_Pos)
+#define GPIO_PVR_MASK               _U(0xFFFFFFFF) /**< \brief (GPIO_PVR) MASK Register */
+
+/* -------- GPIO_PUER : (GPIO Offset: 0x070) (R/W 32) port Pull-up Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Pull-up Enable                     */
+    uint32_t P1:1;             /*!< bit:      1  Pull-up Enable                     */
+    uint32_t P2:1;             /*!< bit:      2  Pull-up Enable                     */
+    uint32_t P3:1;             /*!< bit:      3  Pull-up Enable                     */
+    uint32_t P4:1;             /*!< bit:      4  Pull-up Enable                     */
+    uint32_t P5:1;             /*!< bit:      5  Pull-up Enable                     */
+    uint32_t P6:1;             /*!< bit:      6  Pull-up Enable                     */
+    uint32_t P7:1;             /*!< bit:      7  Pull-up Enable                     */
+    uint32_t P8:1;             /*!< bit:      8  Pull-up Enable                     */
+    uint32_t P9:1;             /*!< bit:      9  Pull-up Enable                     */
+    uint32_t P10:1;            /*!< bit:     10  Pull-up Enable                     */
+    uint32_t P11:1;            /*!< bit:     11  Pull-up Enable                     */
+    uint32_t P12:1;            /*!< bit:     12  Pull-up Enable                     */
+    uint32_t P13:1;            /*!< bit:     13  Pull-up Enable                     */
+    uint32_t P14:1;            /*!< bit:     14  Pull-up Enable                     */
+    uint32_t P15:1;            /*!< bit:     15  Pull-up Enable                     */
+    uint32_t P16:1;            /*!< bit:     16  Pull-up Enable                     */
+    uint32_t P17:1;            /*!< bit:     17  Pull-up Enable                     */
+    uint32_t P18:1;            /*!< bit:     18  Pull-up Enable                     */
+    uint32_t P19:1;            /*!< bit:     19  Pull-up Enable                     */
+    uint32_t P20:1;            /*!< bit:     20  Pull-up Enable                     */
+    uint32_t P21:1;            /*!< bit:     21  Pull-up Enable                     */
+    uint32_t P22:1;            /*!< bit:     22  Pull-up Enable                     */
+    uint32_t P23:1;            /*!< bit:     23  Pull-up Enable                     */
+    uint32_t P24:1;            /*!< bit:     24  Pull-up Enable                     */
+    uint32_t P25:1;            /*!< bit:     25  Pull-up Enable                     */
+    uint32_t P26:1;            /*!< bit:     26  Pull-up Enable                     */
+    uint32_t P27:1;            /*!< bit:     27  Pull-up Enable                     */
+    uint32_t P28:1;            /*!< bit:     28  Pull-up Enable                     */
+    uint32_t P29:1;            /*!< bit:     29  Pull-up Enable                     */
+    uint32_t P30:1;            /*!< bit:     30  Pull-up Enable                     */
+    uint32_t P31:1;            /*!< bit:     31  Pull-up Enable                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_PUER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_PUER_OFFSET            0x070        /**< \brief (GPIO_PUER offset) Pull-up Enable Register */
+
+#define GPIO_PUER_P0_Pos            0            /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P0                (_U(0x1) << GPIO_PUER_P0_Pos)
+#define GPIO_PUER_P1_Pos            1            /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P1                (_U(0x1) << GPIO_PUER_P1_Pos)
+#define GPIO_PUER_P2_Pos            2            /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P2                (_U(0x1) << GPIO_PUER_P2_Pos)
+#define GPIO_PUER_P3_Pos            3            /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P3                (_U(0x1) << GPIO_PUER_P3_Pos)
+#define GPIO_PUER_P4_Pos            4            /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P4                (_U(0x1) << GPIO_PUER_P4_Pos)
+#define GPIO_PUER_P5_Pos            5            /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P5                (_U(0x1) << GPIO_PUER_P5_Pos)
+#define GPIO_PUER_P6_Pos            6            /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P6                (_U(0x1) << GPIO_PUER_P6_Pos)
+#define GPIO_PUER_P7_Pos            7            /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P7                (_U(0x1) << GPIO_PUER_P7_Pos)
+#define GPIO_PUER_P8_Pos            8            /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P8                (_U(0x1) << GPIO_PUER_P8_Pos)
+#define GPIO_PUER_P9_Pos            9            /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P9                (_U(0x1) << GPIO_PUER_P9_Pos)
+#define GPIO_PUER_P10_Pos           10           /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P10               (_U(0x1) << GPIO_PUER_P10_Pos)
+#define GPIO_PUER_P11_Pos           11           /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P11               (_U(0x1) << GPIO_PUER_P11_Pos)
+#define GPIO_PUER_P12_Pos           12           /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P12               (_U(0x1) << GPIO_PUER_P12_Pos)
+#define GPIO_PUER_P13_Pos           13           /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P13               (_U(0x1) << GPIO_PUER_P13_Pos)
+#define GPIO_PUER_P14_Pos           14           /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P14               (_U(0x1) << GPIO_PUER_P14_Pos)
+#define GPIO_PUER_P15_Pos           15           /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P15               (_U(0x1) << GPIO_PUER_P15_Pos)
+#define GPIO_PUER_P16_Pos           16           /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P16               (_U(0x1) << GPIO_PUER_P16_Pos)
+#define GPIO_PUER_P17_Pos           17           /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P17               (_U(0x1) << GPIO_PUER_P17_Pos)
+#define GPIO_PUER_P18_Pos           18           /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P18               (_U(0x1) << GPIO_PUER_P18_Pos)
+#define GPIO_PUER_P19_Pos           19           /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P19               (_U(0x1) << GPIO_PUER_P19_Pos)
+#define GPIO_PUER_P20_Pos           20           /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P20               (_U(0x1) << GPIO_PUER_P20_Pos)
+#define GPIO_PUER_P21_Pos           21           /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P21               (_U(0x1) << GPIO_PUER_P21_Pos)
+#define GPIO_PUER_P22_Pos           22           /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P22               (_U(0x1) << GPIO_PUER_P22_Pos)
+#define GPIO_PUER_P23_Pos           23           /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P23               (_U(0x1) << GPIO_PUER_P23_Pos)
+#define GPIO_PUER_P24_Pos           24           /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P24               (_U(0x1) << GPIO_PUER_P24_Pos)
+#define GPIO_PUER_P25_Pos           25           /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P25               (_U(0x1) << GPIO_PUER_P25_Pos)
+#define GPIO_PUER_P26_Pos           26           /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P26               (_U(0x1) << GPIO_PUER_P26_Pos)
+#define GPIO_PUER_P27_Pos           27           /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P27               (_U(0x1) << GPIO_PUER_P27_Pos)
+#define GPIO_PUER_P28_Pos           28           /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P28               (_U(0x1) << GPIO_PUER_P28_Pos)
+#define GPIO_PUER_P29_Pos           29           /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P29               (_U(0x1) << GPIO_PUER_P29_Pos)
+#define GPIO_PUER_P30_Pos           30           /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P30               (_U(0x1) << GPIO_PUER_P30_Pos)
+#define GPIO_PUER_P31_Pos           31           /**< \brief (GPIO_PUER) Pull-up Enable */
+#define GPIO_PUER_P31               (_U(0x1) << GPIO_PUER_P31_Pos)
+#define GPIO_PUER_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_PUER) MASK Register */
+
+/* -------- GPIO_PUERS : (GPIO Offset: 0x074) ( /W 32) port Pull-up Enable Register - Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Pull-up Enable                     */
+    uint32_t P1:1;             /*!< bit:      1  Pull-up Enable                     */
+    uint32_t P2:1;             /*!< bit:      2  Pull-up Enable                     */
+    uint32_t P3:1;             /*!< bit:      3  Pull-up Enable                     */
+    uint32_t P4:1;             /*!< bit:      4  Pull-up Enable                     */
+    uint32_t P5:1;             /*!< bit:      5  Pull-up Enable                     */
+    uint32_t P6:1;             /*!< bit:      6  Pull-up Enable                     */
+    uint32_t P7:1;             /*!< bit:      7  Pull-up Enable                     */
+    uint32_t P8:1;             /*!< bit:      8  Pull-up Enable                     */
+    uint32_t P9:1;             /*!< bit:      9  Pull-up Enable                     */
+    uint32_t P10:1;            /*!< bit:     10  Pull-up Enable                     */
+    uint32_t P11:1;            /*!< bit:     11  Pull-up Enable                     */
+    uint32_t P12:1;            /*!< bit:     12  Pull-up Enable                     */
+    uint32_t P13:1;            /*!< bit:     13  Pull-up Enable                     */
+    uint32_t P14:1;            /*!< bit:     14  Pull-up Enable                     */
+    uint32_t P15:1;            /*!< bit:     15  Pull-up Enable                     */
+    uint32_t P16:1;            /*!< bit:     16  Pull-up Enable                     */
+    uint32_t P17:1;            /*!< bit:     17  Pull-up Enable                     */
+    uint32_t P18:1;            /*!< bit:     18  Pull-up Enable                     */
+    uint32_t P19:1;            /*!< bit:     19  Pull-up Enable                     */
+    uint32_t P20:1;            /*!< bit:     20  Pull-up Enable                     */
+    uint32_t P21:1;            /*!< bit:     21  Pull-up Enable                     */
+    uint32_t P22:1;            /*!< bit:     22  Pull-up Enable                     */
+    uint32_t P23:1;            /*!< bit:     23  Pull-up Enable                     */
+    uint32_t P24:1;            /*!< bit:     24  Pull-up Enable                     */
+    uint32_t P25:1;            /*!< bit:     25  Pull-up Enable                     */
+    uint32_t P26:1;            /*!< bit:     26  Pull-up Enable                     */
+    uint32_t P27:1;            /*!< bit:     27  Pull-up Enable                     */
+    uint32_t P28:1;            /*!< bit:     28  Pull-up Enable                     */
+    uint32_t P29:1;            /*!< bit:     29  Pull-up Enable                     */
+    uint32_t P30:1;            /*!< bit:     30  Pull-up Enable                     */
+    uint32_t P31:1;            /*!< bit:     31  Pull-up Enable                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_PUERS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_PUERS_OFFSET           0x074        /**< \brief (GPIO_PUERS offset) Pull-up Enable Register - Set */
+
+#define GPIO_PUERS_P0_Pos           0            /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P0               (_U(0x1) << GPIO_PUERS_P0_Pos)
+#define GPIO_PUERS_P1_Pos           1            /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P1               (_U(0x1) << GPIO_PUERS_P1_Pos)
+#define GPIO_PUERS_P2_Pos           2            /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P2               (_U(0x1) << GPIO_PUERS_P2_Pos)
+#define GPIO_PUERS_P3_Pos           3            /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P3               (_U(0x1) << GPIO_PUERS_P3_Pos)
+#define GPIO_PUERS_P4_Pos           4            /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P4               (_U(0x1) << GPIO_PUERS_P4_Pos)
+#define GPIO_PUERS_P5_Pos           5            /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P5               (_U(0x1) << GPIO_PUERS_P5_Pos)
+#define GPIO_PUERS_P6_Pos           6            /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P6               (_U(0x1) << GPIO_PUERS_P6_Pos)
+#define GPIO_PUERS_P7_Pos           7            /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P7               (_U(0x1) << GPIO_PUERS_P7_Pos)
+#define GPIO_PUERS_P8_Pos           8            /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P8               (_U(0x1) << GPIO_PUERS_P8_Pos)
+#define GPIO_PUERS_P9_Pos           9            /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P9               (_U(0x1) << GPIO_PUERS_P9_Pos)
+#define GPIO_PUERS_P10_Pos          10           /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P10              (_U(0x1) << GPIO_PUERS_P10_Pos)
+#define GPIO_PUERS_P11_Pos          11           /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P11              (_U(0x1) << GPIO_PUERS_P11_Pos)
+#define GPIO_PUERS_P12_Pos          12           /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P12              (_U(0x1) << GPIO_PUERS_P12_Pos)
+#define GPIO_PUERS_P13_Pos          13           /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P13              (_U(0x1) << GPIO_PUERS_P13_Pos)
+#define GPIO_PUERS_P14_Pos          14           /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P14              (_U(0x1) << GPIO_PUERS_P14_Pos)
+#define GPIO_PUERS_P15_Pos          15           /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P15              (_U(0x1) << GPIO_PUERS_P15_Pos)
+#define GPIO_PUERS_P16_Pos          16           /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P16              (_U(0x1) << GPIO_PUERS_P16_Pos)
+#define GPIO_PUERS_P17_Pos          17           /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P17              (_U(0x1) << GPIO_PUERS_P17_Pos)
+#define GPIO_PUERS_P18_Pos          18           /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P18              (_U(0x1) << GPIO_PUERS_P18_Pos)
+#define GPIO_PUERS_P19_Pos          19           /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P19              (_U(0x1) << GPIO_PUERS_P19_Pos)
+#define GPIO_PUERS_P20_Pos          20           /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P20              (_U(0x1) << GPIO_PUERS_P20_Pos)
+#define GPIO_PUERS_P21_Pos          21           /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P21              (_U(0x1) << GPIO_PUERS_P21_Pos)
+#define GPIO_PUERS_P22_Pos          22           /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P22              (_U(0x1) << GPIO_PUERS_P22_Pos)
+#define GPIO_PUERS_P23_Pos          23           /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P23              (_U(0x1) << GPIO_PUERS_P23_Pos)
+#define GPIO_PUERS_P24_Pos          24           /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P24              (_U(0x1) << GPIO_PUERS_P24_Pos)
+#define GPIO_PUERS_P25_Pos          25           /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P25              (_U(0x1) << GPIO_PUERS_P25_Pos)
+#define GPIO_PUERS_P26_Pos          26           /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P26              (_U(0x1) << GPIO_PUERS_P26_Pos)
+#define GPIO_PUERS_P27_Pos          27           /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P27              (_U(0x1) << GPIO_PUERS_P27_Pos)
+#define GPIO_PUERS_P28_Pos          28           /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P28              (_U(0x1) << GPIO_PUERS_P28_Pos)
+#define GPIO_PUERS_P29_Pos          29           /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P29              (_U(0x1) << GPIO_PUERS_P29_Pos)
+#define GPIO_PUERS_P30_Pos          30           /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P30              (_U(0x1) << GPIO_PUERS_P30_Pos)
+#define GPIO_PUERS_P31_Pos          31           /**< \brief (GPIO_PUERS) Pull-up Enable */
+#define GPIO_PUERS_P31              (_U(0x1) << GPIO_PUERS_P31_Pos)
+#define GPIO_PUERS_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PUERS) MASK Register */
+
+/* -------- GPIO_PUERC : (GPIO Offset: 0x078) ( /W 32) port Pull-up Enable Register - Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Pull-up Enable                     */
+    uint32_t P1:1;             /*!< bit:      1  Pull-up Enable                     */
+    uint32_t P2:1;             /*!< bit:      2  Pull-up Enable                     */
+    uint32_t P3:1;             /*!< bit:      3  Pull-up Enable                     */
+    uint32_t P4:1;             /*!< bit:      4  Pull-up Enable                     */
+    uint32_t P5:1;             /*!< bit:      5  Pull-up Enable                     */
+    uint32_t P6:1;             /*!< bit:      6  Pull-up Enable                     */
+    uint32_t P7:1;             /*!< bit:      7  Pull-up Enable                     */
+    uint32_t P8:1;             /*!< bit:      8  Pull-up Enable                     */
+    uint32_t P9:1;             /*!< bit:      9  Pull-up Enable                     */
+    uint32_t P10:1;            /*!< bit:     10  Pull-up Enable                     */
+    uint32_t P11:1;            /*!< bit:     11  Pull-up Enable                     */
+    uint32_t P12:1;            /*!< bit:     12  Pull-up Enable                     */
+    uint32_t P13:1;            /*!< bit:     13  Pull-up Enable                     */
+    uint32_t P14:1;            /*!< bit:     14  Pull-up Enable                     */
+    uint32_t P15:1;            /*!< bit:     15  Pull-up Enable                     */
+    uint32_t P16:1;            /*!< bit:     16  Pull-up Enable                     */
+    uint32_t P17:1;            /*!< bit:     17  Pull-up Enable                     */
+    uint32_t P18:1;            /*!< bit:     18  Pull-up Enable                     */
+    uint32_t P19:1;            /*!< bit:     19  Pull-up Enable                     */
+    uint32_t P20:1;            /*!< bit:     20  Pull-up Enable                     */
+    uint32_t P21:1;            /*!< bit:     21  Pull-up Enable                     */
+    uint32_t P22:1;            /*!< bit:     22  Pull-up Enable                     */
+    uint32_t P23:1;            /*!< bit:     23  Pull-up Enable                     */
+    uint32_t P24:1;            /*!< bit:     24  Pull-up Enable                     */
+    uint32_t P25:1;            /*!< bit:     25  Pull-up Enable                     */
+    uint32_t P26:1;            /*!< bit:     26  Pull-up Enable                     */
+    uint32_t P27:1;            /*!< bit:     27  Pull-up Enable                     */
+    uint32_t P28:1;            /*!< bit:     28  Pull-up Enable                     */
+    uint32_t P29:1;            /*!< bit:     29  Pull-up Enable                     */
+    uint32_t P30:1;            /*!< bit:     30  Pull-up Enable                     */
+    uint32_t P31:1;            /*!< bit:     31  Pull-up Enable                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_PUERC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_PUERC_OFFSET           0x078        /**< \brief (GPIO_PUERC offset) Pull-up Enable Register - Clear */
+
+#define GPIO_PUERC_P0_Pos           0            /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P0               (_U(0x1) << GPIO_PUERC_P0_Pos)
+#define GPIO_PUERC_P1_Pos           1            /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P1               (_U(0x1) << GPIO_PUERC_P1_Pos)
+#define GPIO_PUERC_P2_Pos           2            /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P2               (_U(0x1) << GPIO_PUERC_P2_Pos)
+#define GPIO_PUERC_P3_Pos           3            /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P3               (_U(0x1) << GPIO_PUERC_P3_Pos)
+#define GPIO_PUERC_P4_Pos           4            /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P4               (_U(0x1) << GPIO_PUERC_P4_Pos)
+#define GPIO_PUERC_P5_Pos           5            /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P5               (_U(0x1) << GPIO_PUERC_P5_Pos)
+#define GPIO_PUERC_P6_Pos           6            /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P6               (_U(0x1) << GPIO_PUERC_P6_Pos)
+#define GPIO_PUERC_P7_Pos           7            /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P7               (_U(0x1) << GPIO_PUERC_P7_Pos)
+#define GPIO_PUERC_P8_Pos           8            /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P8               (_U(0x1) << GPIO_PUERC_P8_Pos)
+#define GPIO_PUERC_P9_Pos           9            /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P9               (_U(0x1) << GPIO_PUERC_P9_Pos)
+#define GPIO_PUERC_P10_Pos          10           /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P10              (_U(0x1) << GPIO_PUERC_P10_Pos)
+#define GPIO_PUERC_P11_Pos          11           /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P11              (_U(0x1) << GPIO_PUERC_P11_Pos)
+#define GPIO_PUERC_P12_Pos          12           /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P12              (_U(0x1) << GPIO_PUERC_P12_Pos)
+#define GPIO_PUERC_P13_Pos          13           /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P13              (_U(0x1) << GPIO_PUERC_P13_Pos)
+#define GPIO_PUERC_P14_Pos          14           /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P14              (_U(0x1) << GPIO_PUERC_P14_Pos)
+#define GPIO_PUERC_P15_Pos          15           /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P15              (_U(0x1) << GPIO_PUERC_P15_Pos)
+#define GPIO_PUERC_P16_Pos          16           /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P16              (_U(0x1) << GPIO_PUERC_P16_Pos)
+#define GPIO_PUERC_P17_Pos          17           /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P17              (_U(0x1) << GPIO_PUERC_P17_Pos)
+#define GPIO_PUERC_P18_Pos          18           /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P18              (_U(0x1) << GPIO_PUERC_P18_Pos)
+#define GPIO_PUERC_P19_Pos          19           /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P19              (_U(0x1) << GPIO_PUERC_P19_Pos)
+#define GPIO_PUERC_P20_Pos          20           /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P20              (_U(0x1) << GPIO_PUERC_P20_Pos)
+#define GPIO_PUERC_P21_Pos          21           /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P21              (_U(0x1) << GPIO_PUERC_P21_Pos)
+#define GPIO_PUERC_P22_Pos          22           /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P22              (_U(0x1) << GPIO_PUERC_P22_Pos)
+#define GPIO_PUERC_P23_Pos          23           /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P23              (_U(0x1) << GPIO_PUERC_P23_Pos)
+#define GPIO_PUERC_P24_Pos          24           /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P24              (_U(0x1) << GPIO_PUERC_P24_Pos)
+#define GPIO_PUERC_P25_Pos          25           /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P25              (_U(0x1) << GPIO_PUERC_P25_Pos)
+#define GPIO_PUERC_P26_Pos          26           /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P26              (_U(0x1) << GPIO_PUERC_P26_Pos)
+#define GPIO_PUERC_P27_Pos          27           /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P27              (_U(0x1) << GPIO_PUERC_P27_Pos)
+#define GPIO_PUERC_P28_Pos          28           /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P28              (_U(0x1) << GPIO_PUERC_P28_Pos)
+#define GPIO_PUERC_P29_Pos          29           /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P29              (_U(0x1) << GPIO_PUERC_P29_Pos)
+#define GPIO_PUERC_P30_Pos          30           /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P30              (_U(0x1) << GPIO_PUERC_P30_Pos)
+#define GPIO_PUERC_P31_Pos          31           /**< \brief (GPIO_PUERC) Pull-up Enable */
+#define GPIO_PUERC_P31              (_U(0x1) << GPIO_PUERC_P31_Pos)
+#define GPIO_PUERC_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PUERC) MASK Register */
+
+/* -------- GPIO_PUERT : (GPIO Offset: 0x07C) ( /W 32) port Pull-up Enable Register - Toggle -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Pull-up Enable                     */
+    uint32_t P1:1;             /*!< bit:      1  Pull-up Enable                     */
+    uint32_t P2:1;             /*!< bit:      2  Pull-up Enable                     */
+    uint32_t P3:1;             /*!< bit:      3  Pull-up Enable                     */
+    uint32_t P4:1;             /*!< bit:      4  Pull-up Enable                     */
+    uint32_t P5:1;             /*!< bit:      5  Pull-up Enable                     */
+    uint32_t P6:1;             /*!< bit:      6  Pull-up Enable                     */
+    uint32_t P7:1;             /*!< bit:      7  Pull-up Enable                     */
+    uint32_t P8:1;             /*!< bit:      8  Pull-up Enable                     */
+    uint32_t P9:1;             /*!< bit:      9  Pull-up Enable                     */
+    uint32_t P10:1;            /*!< bit:     10  Pull-up Enable                     */
+    uint32_t P11:1;            /*!< bit:     11  Pull-up Enable                     */
+    uint32_t P12:1;            /*!< bit:     12  Pull-up Enable                     */
+    uint32_t P13:1;            /*!< bit:     13  Pull-up Enable                     */
+    uint32_t P14:1;            /*!< bit:     14  Pull-up Enable                     */
+    uint32_t P15:1;            /*!< bit:     15  Pull-up Enable                     */
+    uint32_t P16:1;            /*!< bit:     16  Pull-up Enable                     */
+    uint32_t P17:1;            /*!< bit:     17  Pull-up Enable                     */
+    uint32_t P18:1;            /*!< bit:     18  Pull-up Enable                     */
+    uint32_t P19:1;            /*!< bit:     19  Pull-up Enable                     */
+    uint32_t P20:1;            /*!< bit:     20  Pull-up Enable                     */
+    uint32_t P21:1;            /*!< bit:     21  Pull-up Enable                     */
+    uint32_t P22:1;            /*!< bit:     22  Pull-up Enable                     */
+    uint32_t P23:1;            /*!< bit:     23  Pull-up Enable                     */
+    uint32_t P24:1;            /*!< bit:     24  Pull-up Enable                     */
+    uint32_t P25:1;            /*!< bit:     25  Pull-up Enable                     */
+    uint32_t P26:1;            /*!< bit:     26  Pull-up Enable                     */
+    uint32_t P27:1;            /*!< bit:     27  Pull-up Enable                     */
+    uint32_t P28:1;            /*!< bit:     28  Pull-up Enable                     */
+    uint32_t P29:1;            /*!< bit:     29  Pull-up Enable                     */
+    uint32_t P30:1;            /*!< bit:     30  Pull-up Enable                     */
+    uint32_t P31:1;            /*!< bit:     31  Pull-up Enable                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_PUERT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_PUERT_OFFSET           0x07C        /**< \brief (GPIO_PUERT offset) Pull-up Enable Register - Toggle */
+
+#define GPIO_PUERT_P0_Pos           0            /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P0               (_U(0x1) << GPIO_PUERT_P0_Pos)
+#define GPIO_PUERT_P1_Pos           1            /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P1               (_U(0x1) << GPIO_PUERT_P1_Pos)
+#define GPIO_PUERT_P2_Pos           2            /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P2               (_U(0x1) << GPIO_PUERT_P2_Pos)
+#define GPIO_PUERT_P3_Pos           3            /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P3               (_U(0x1) << GPIO_PUERT_P3_Pos)
+#define GPIO_PUERT_P4_Pos           4            /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P4               (_U(0x1) << GPIO_PUERT_P4_Pos)
+#define GPIO_PUERT_P5_Pos           5            /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P5               (_U(0x1) << GPIO_PUERT_P5_Pos)
+#define GPIO_PUERT_P6_Pos           6            /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P6               (_U(0x1) << GPIO_PUERT_P6_Pos)
+#define GPIO_PUERT_P7_Pos           7            /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P7               (_U(0x1) << GPIO_PUERT_P7_Pos)
+#define GPIO_PUERT_P8_Pos           8            /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P8               (_U(0x1) << GPIO_PUERT_P8_Pos)
+#define GPIO_PUERT_P9_Pos           9            /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P9               (_U(0x1) << GPIO_PUERT_P9_Pos)
+#define GPIO_PUERT_P10_Pos          10           /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P10              (_U(0x1) << GPIO_PUERT_P10_Pos)
+#define GPIO_PUERT_P11_Pos          11           /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P11              (_U(0x1) << GPIO_PUERT_P11_Pos)
+#define GPIO_PUERT_P12_Pos          12           /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P12              (_U(0x1) << GPIO_PUERT_P12_Pos)
+#define GPIO_PUERT_P13_Pos          13           /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P13              (_U(0x1) << GPIO_PUERT_P13_Pos)
+#define GPIO_PUERT_P14_Pos          14           /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P14              (_U(0x1) << GPIO_PUERT_P14_Pos)
+#define GPIO_PUERT_P15_Pos          15           /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P15              (_U(0x1) << GPIO_PUERT_P15_Pos)
+#define GPIO_PUERT_P16_Pos          16           /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P16              (_U(0x1) << GPIO_PUERT_P16_Pos)
+#define GPIO_PUERT_P17_Pos          17           /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P17              (_U(0x1) << GPIO_PUERT_P17_Pos)
+#define GPIO_PUERT_P18_Pos          18           /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P18              (_U(0x1) << GPIO_PUERT_P18_Pos)
+#define GPIO_PUERT_P19_Pos          19           /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P19              (_U(0x1) << GPIO_PUERT_P19_Pos)
+#define GPIO_PUERT_P20_Pos          20           /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P20              (_U(0x1) << GPIO_PUERT_P20_Pos)
+#define GPIO_PUERT_P21_Pos          21           /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P21              (_U(0x1) << GPIO_PUERT_P21_Pos)
+#define GPIO_PUERT_P22_Pos          22           /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P22              (_U(0x1) << GPIO_PUERT_P22_Pos)
+#define GPIO_PUERT_P23_Pos          23           /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P23              (_U(0x1) << GPIO_PUERT_P23_Pos)
+#define GPIO_PUERT_P24_Pos          24           /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P24              (_U(0x1) << GPIO_PUERT_P24_Pos)
+#define GPIO_PUERT_P25_Pos          25           /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P25              (_U(0x1) << GPIO_PUERT_P25_Pos)
+#define GPIO_PUERT_P26_Pos          26           /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P26              (_U(0x1) << GPIO_PUERT_P26_Pos)
+#define GPIO_PUERT_P27_Pos          27           /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P27              (_U(0x1) << GPIO_PUERT_P27_Pos)
+#define GPIO_PUERT_P28_Pos          28           /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P28              (_U(0x1) << GPIO_PUERT_P28_Pos)
+#define GPIO_PUERT_P29_Pos          29           /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P29              (_U(0x1) << GPIO_PUERT_P29_Pos)
+#define GPIO_PUERT_P30_Pos          30           /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P30              (_U(0x1) << GPIO_PUERT_P30_Pos)
+#define GPIO_PUERT_P31_Pos          31           /**< \brief (GPIO_PUERT) Pull-up Enable */
+#define GPIO_PUERT_P31              (_U(0x1) << GPIO_PUERT_P31_Pos)
+#define GPIO_PUERT_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PUERT) MASK Register */
+
+/* -------- GPIO_PDER : (GPIO Offset: 0x080) (R/W 32) port Pull-down Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Pull-down Enable                   */
+    uint32_t P1:1;             /*!< bit:      1  Pull-down Enable                   */
+    uint32_t P2:1;             /*!< bit:      2  Pull-down Enable                   */
+    uint32_t P3:1;             /*!< bit:      3  Pull-down Enable                   */
+    uint32_t P4:1;             /*!< bit:      4  Pull-down Enable                   */
+    uint32_t P5:1;             /*!< bit:      5  Pull-down Enable                   */
+    uint32_t P6:1;             /*!< bit:      6  Pull-down Enable                   */
+    uint32_t P7:1;             /*!< bit:      7  Pull-down Enable                   */
+    uint32_t P8:1;             /*!< bit:      8  Pull-down Enable                   */
+    uint32_t P9:1;             /*!< bit:      9  Pull-down Enable                   */
+    uint32_t P10:1;            /*!< bit:     10  Pull-down Enable                   */
+    uint32_t P11:1;            /*!< bit:     11  Pull-down Enable                   */
+    uint32_t P12:1;            /*!< bit:     12  Pull-down Enable                   */
+    uint32_t P13:1;            /*!< bit:     13  Pull-down Enable                   */
+    uint32_t P14:1;            /*!< bit:     14  Pull-down Enable                   */
+    uint32_t P15:1;            /*!< bit:     15  Pull-down Enable                   */
+    uint32_t P16:1;            /*!< bit:     16  Pull-down Enable                   */
+    uint32_t P17:1;            /*!< bit:     17  Pull-down Enable                   */
+    uint32_t P18:1;            /*!< bit:     18  Pull-down Enable                   */
+    uint32_t P19:1;            /*!< bit:     19  Pull-down Enable                   */
+    uint32_t P20:1;            /*!< bit:     20  Pull-down Enable                   */
+    uint32_t P21:1;            /*!< bit:     21  Pull-down Enable                   */
+    uint32_t P22:1;            /*!< bit:     22  Pull-down Enable                   */
+    uint32_t P23:1;            /*!< bit:     23  Pull-down Enable                   */
+    uint32_t P24:1;            /*!< bit:     24  Pull-down Enable                   */
+    uint32_t P25:1;            /*!< bit:     25  Pull-down Enable                   */
+    uint32_t P26:1;            /*!< bit:     26  Pull-down Enable                   */
+    uint32_t P27:1;            /*!< bit:     27  Pull-down Enable                   */
+    uint32_t P28:1;            /*!< bit:     28  Pull-down Enable                   */
+    uint32_t P29:1;            /*!< bit:     29  Pull-down Enable                   */
+    uint32_t P30:1;            /*!< bit:     30  Pull-down Enable                   */
+    uint32_t P31:1;            /*!< bit:     31  Pull-down Enable                   */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_PDER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_PDER_OFFSET            0x080        /**< \brief (GPIO_PDER offset) Pull-down Enable Register */
+
+#define GPIO_PDER_P0_Pos            0            /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P0                (_U(0x1) << GPIO_PDER_P0_Pos)
+#define GPIO_PDER_P1_Pos            1            /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P1                (_U(0x1) << GPIO_PDER_P1_Pos)
+#define GPIO_PDER_P2_Pos            2            /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P2                (_U(0x1) << GPIO_PDER_P2_Pos)
+#define GPIO_PDER_P3_Pos            3            /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P3                (_U(0x1) << GPIO_PDER_P3_Pos)
+#define GPIO_PDER_P4_Pos            4            /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P4                (_U(0x1) << GPIO_PDER_P4_Pos)
+#define GPIO_PDER_P5_Pos            5            /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P5                (_U(0x1) << GPIO_PDER_P5_Pos)
+#define GPIO_PDER_P6_Pos            6            /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P6                (_U(0x1) << GPIO_PDER_P6_Pos)
+#define GPIO_PDER_P7_Pos            7            /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P7                (_U(0x1) << GPIO_PDER_P7_Pos)
+#define GPIO_PDER_P8_Pos            8            /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P8                (_U(0x1) << GPIO_PDER_P8_Pos)
+#define GPIO_PDER_P9_Pos            9            /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P9                (_U(0x1) << GPIO_PDER_P9_Pos)
+#define GPIO_PDER_P10_Pos           10           /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P10               (_U(0x1) << GPIO_PDER_P10_Pos)
+#define GPIO_PDER_P11_Pos           11           /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P11               (_U(0x1) << GPIO_PDER_P11_Pos)
+#define GPIO_PDER_P12_Pos           12           /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P12               (_U(0x1) << GPIO_PDER_P12_Pos)
+#define GPIO_PDER_P13_Pos           13           /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P13               (_U(0x1) << GPIO_PDER_P13_Pos)
+#define GPIO_PDER_P14_Pos           14           /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P14               (_U(0x1) << GPIO_PDER_P14_Pos)
+#define GPIO_PDER_P15_Pos           15           /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P15               (_U(0x1) << GPIO_PDER_P15_Pos)
+#define GPIO_PDER_P16_Pos           16           /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P16               (_U(0x1) << GPIO_PDER_P16_Pos)
+#define GPIO_PDER_P17_Pos           17           /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P17               (_U(0x1) << GPIO_PDER_P17_Pos)
+#define GPIO_PDER_P18_Pos           18           /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P18               (_U(0x1) << GPIO_PDER_P18_Pos)
+#define GPIO_PDER_P19_Pos           19           /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P19               (_U(0x1) << GPIO_PDER_P19_Pos)
+#define GPIO_PDER_P20_Pos           20           /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P20               (_U(0x1) << GPIO_PDER_P20_Pos)
+#define GPIO_PDER_P21_Pos           21           /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P21               (_U(0x1) << GPIO_PDER_P21_Pos)
+#define GPIO_PDER_P22_Pos           22           /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P22               (_U(0x1) << GPIO_PDER_P22_Pos)
+#define GPIO_PDER_P23_Pos           23           /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P23               (_U(0x1) << GPIO_PDER_P23_Pos)
+#define GPIO_PDER_P24_Pos           24           /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P24               (_U(0x1) << GPIO_PDER_P24_Pos)
+#define GPIO_PDER_P25_Pos           25           /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P25               (_U(0x1) << GPIO_PDER_P25_Pos)
+#define GPIO_PDER_P26_Pos           26           /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P26               (_U(0x1) << GPIO_PDER_P26_Pos)
+#define GPIO_PDER_P27_Pos           27           /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P27               (_U(0x1) << GPIO_PDER_P27_Pos)
+#define GPIO_PDER_P28_Pos           28           /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P28               (_U(0x1) << GPIO_PDER_P28_Pos)
+#define GPIO_PDER_P29_Pos           29           /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P29               (_U(0x1) << GPIO_PDER_P29_Pos)
+#define GPIO_PDER_P30_Pos           30           /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P30               (_U(0x1) << GPIO_PDER_P30_Pos)
+#define GPIO_PDER_P31_Pos           31           /**< \brief (GPIO_PDER) Pull-down Enable */
+#define GPIO_PDER_P31               (_U(0x1) << GPIO_PDER_P31_Pos)
+#define GPIO_PDER_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_PDER) MASK Register */
+
+/* -------- GPIO_PDERS : (GPIO Offset: 0x084) ( /W 32) port Pull-down Enable Register - Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Pull-down Enable                   */
+    uint32_t P1:1;             /*!< bit:      1  Pull-down Enable                   */
+    uint32_t P2:1;             /*!< bit:      2  Pull-down Enable                   */
+    uint32_t P3:1;             /*!< bit:      3  Pull-down Enable                   */
+    uint32_t P4:1;             /*!< bit:      4  Pull-down Enable                   */
+    uint32_t P5:1;             /*!< bit:      5  Pull-down Enable                   */
+    uint32_t P6:1;             /*!< bit:      6  Pull-down Enable                   */
+    uint32_t P7:1;             /*!< bit:      7  Pull-down Enable                   */
+    uint32_t P8:1;             /*!< bit:      8  Pull-down Enable                   */
+    uint32_t P9:1;             /*!< bit:      9  Pull-down Enable                   */
+    uint32_t P10:1;            /*!< bit:     10  Pull-down Enable                   */
+    uint32_t P11:1;            /*!< bit:     11  Pull-down Enable                   */
+    uint32_t P12:1;            /*!< bit:     12  Pull-down Enable                   */
+    uint32_t P13:1;            /*!< bit:     13  Pull-down Enable                   */
+    uint32_t P14:1;            /*!< bit:     14  Pull-down Enable                   */
+    uint32_t P15:1;            /*!< bit:     15  Pull-down Enable                   */
+    uint32_t P16:1;            /*!< bit:     16  Pull-down Enable                   */
+    uint32_t P17:1;            /*!< bit:     17  Pull-down Enable                   */
+    uint32_t P18:1;            /*!< bit:     18  Pull-down Enable                   */
+    uint32_t P19:1;            /*!< bit:     19  Pull-down Enable                   */
+    uint32_t P20:1;            /*!< bit:     20  Pull-down Enable                   */
+    uint32_t P21:1;            /*!< bit:     21  Pull-down Enable                   */
+    uint32_t P22:1;            /*!< bit:     22  Pull-down Enable                   */
+    uint32_t P23:1;            /*!< bit:     23  Pull-down Enable                   */
+    uint32_t P24:1;            /*!< bit:     24  Pull-down Enable                   */
+    uint32_t P25:1;            /*!< bit:     25  Pull-down Enable                   */
+    uint32_t P26:1;            /*!< bit:     26  Pull-down Enable                   */
+    uint32_t P27:1;            /*!< bit:     27  Pull-down Enable                   */
+    uint32_t P28:1;            /*!< bit:     28  Pull-down Enable                   */
+    uint32_t P29:1;            /*!< bit:     29  Pull-down Enable                   */
+    uint32_t P30:1;            /*!< bit:     30  Pull-down Enable                   */
+    uint32_t P31:1;            /*!< bit:     31  Pull-down Enable                   */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_PDERS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_PDERS_OFFSET           0x084        /**< \brief (GPIO_PDERS offset) Pull-down Enable Register - Set */
+
+#define GPIO_PDERS_P0_Pos           0            /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P0               (_U(0x1) << GPIO_PDERS_P0_Pos)
+#define GPIO_PDERS_P1_Pos           1            /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P1               (_U(0x1) << GPIO_PDERS_P1_Pos)
+#define GPIO_PDERS_P2_Pos           2            /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P2               (_U(0x1) << GPIO_PDERS_P2_Pos)
+#define GPIO_PDERS_P3_Pos           3            /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P3               (_U(0x1) << GPIO_PDERS_P3_Pos)
+#define GPIO_PDERS_P4_Pos           4            /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P4               (_U(0x1) << GPIO_PDERS_P4_Pos)
+#define GPIO_PDERS_P5_Pos           5            /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P5               (_U(0x1) << GPIO_PDERS_P5_Pos)
+#define GPIO_PDERS_P6_Pos           6            /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P6               (_U(0x1) << GPIO_PDERS_P6_Pos)
+#define GPIO_PDERS_P7_Pos           7            /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P7               (_U(0x1) << GPIO_PDERS_P7_Pos)
+#define GPIO_PDERS_P8_Pos           8            /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P8               (_U(0x1) << GPIO_PDERS_P8_Pos)
+#define GPIO_PDERS_P9_Pos           9            /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P9               (_U(0x1) << GPIO_PDERS_P9_Pos)
+#define GPIO_PDERS_P10_Pos          10           /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P10              (_U(0x1) << GPIO_PDERS_P10_Pos)
+#define GPIO_PDERS_P11_Pos          11           /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P11              (_U(0x1) << GPIO_PDERS_P11_Pos)
+#define GPIO_PDERS_P12_Pos          12           /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P12              (_U(0x1) << GPIO_PDERS_P12_Pos)
+#define GPIO_PDERS_P13_Pos          13           /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P13              (_U(0x1) << GPIO_PDERS_P13_Pos)
+#define GPIO_PDERS_P14_Pos          14           /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P14              (_U(0x1) << GPIO_PDERS_P14_Pos)
+#define GPIO_PDERS_P15_Pos          15           /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P15              (_U(0x1) << GPIO_PDERS_P15_Pos)
+#define GPIO_PDERS_P16_Pos          16           /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P16              (_U(0x1) << GPIO_PDERS_P16_Pos)
+#define GPIO_PDERS_P17_Pos          17           /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P17              (_U(0x1) << GPIO_PDERS_P17_Pos)
+#define GPIO_PDERS_P18_Pos          18           /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P18              (_U(0x1) << GPIO_PDERS_P18_Pos)
+#define GPIO_PDERS_P19_Pos          19           /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P19              (_U(0x1) << GPIO_PDERS_P19_Pos)
+#define GPIO_PDERS_P20_Pos          20           /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P20              (_U(0x1) << GPIO_PDERS_P20_Pos)
+#define GPIO_PDERS_P21_Pos          21           /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P21              (_U(0x1) << GPIO_PDERS_P21_Pos)
+#define GPIO_PDERS_P22_Pos          22           /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P22              (_U(0x1) << GPIO_PDERS_P22_Pos)
+#define GPIO_PDERS_P23_Pos          23           /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P23              (_U(0x1) << GPIO_PDERS_P23_Pos)
+#define GPIO_PDERS_P24_Pos          24           /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P24              (_U(0x1) << GPIO_PDERS_P24_Pos)
+#define GPIO_PDERS_P25_Pos          25           /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P25              (_U(0x1) << GPIO_PDERS_P25_Pos)
+#define GPIO_PDERS_P26_Pos          26           /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P26              (_U(0x1) << GPIO_PDERS_P26_Pos)
+#define GPIO_PDERS_P27_Pos          27           /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P27              (_U(0x1) << GPIO_PDERS_P27_Pos)
+#define GPIO_PDERS_P28_Pos          28           /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P28              (_U(0x1) << GPIO_PDERS_P28_Pos)
+#define GPIO_PDERS_P29_Pos          29           /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P29              (_U(0x1) << GPIO_PDERS_P29_Pos)
+#define GPIO_PDERS_P30_Pos          30           /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P30              (_U(0x1) << GPIO_PDERS_P30_Pos)
+#define GPIO_PDERS_P31_Pos          31           /**< \brief (GPIO_PDERS) Pull-down Enable */
+#define GPIO_PDERS_P31              (_U(0x1) << GPIO_PDERS_P31_Pos)
+#define GPIO_PDERS_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PDERS) MASK Register */
+
+/* -------- GPIO_PDERC : (GPIO Offset: 0x088) ( /W 32) port Pull-down Enable Register - Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Pull-down Enable                   */
+    uint32_t P1:1;             /*!< bit:      1  Pull-down Enable                   */
+    uint32_t P2:1;             /*!< bit:      2  Pull-down Enable                   */
+    uint32_t P3:1;             /*!< bit:      3  Pull-down Enable                   */
+    uint32_t P4:1;             /*!< bit:      4  Pull-down Enable                   */
+    uint32_t P5:1;             /*!< bit:      5  Pull-down Enable                   */
+    uint32_t P6:1;             /*!< bit:      6  Pull-down Enable                   */
+    uint32_t P7:1;             /*!< bit:      7  Pull-down Enable                   */
+    uint32_t P8:1;             /*!< bit:      8  Pull-down Enable                   */
+    uint32_t P9:1;             /*!< bit:      9  Pull-down Enable                   */
+    uint32_t P10:1;            /*!< bit:     10  Pull-down Enable                   */
+    uint32_t P11:1;            /*!< bit:     11  Pull-down Enable                   */
+    uint32_t P12:1;            /*!< bit:     12  Pull-down Enable                   */
+    uint32_t P13:1;            /*!< bit:     13  Pull-down Enable                   */
+    uint32_t P14:1;            /*!< bit:     14  Pull-down Enable                   */
+    uint32_t P15:1;            /*!< bit:     15  Pull-down Enable                   */
+    uint32_t P16:1;            /*!< bit:     16  Pull-down Enable                   */
+    uint32_t P17:1;            /*!< bit:     17  Pull-down Enable                   */
+    uint32_t P18:1;            /*!< bit:     18  Pull-down Enable                   */
+    uint32_t P19:1;            /*!< bit:     19  Pull-down Enable                   */
+    uint32_t P20:1;            /*!< bit:     20  Pull-down Enable                   */
+    uint32_t P21:1;            /*!< bit:     21  Pull-down Enable                   */
+    uint32_t P22:1;            /*!< bit:     22  Pull-down Enable                   */
+    uint32_t P23:1;            /*!< bit:     23  Pull-down Enable                   */
+    uint32_t P24:1;            /*!< bit:     24  Pull-down Enable                   */
+    uint32_t P25:1;            /*!< bit:     25  Pull-down Enable                   */
+    uint32_t P26:1;            /*!< bit:     26  Pull-down Enable                   */
+    uint32_t P27:1;            /*!< bit:     27  Pull-down Enable                   */
+    uint32_t P28:1;            /*!< bit:     28  Pull-down Enable                   */
+    uint32_t P29:1;            /*!< bit:     29  Pull-down Enable                   */
+    uint32_t P30:1;            /*!< bit:     30  Pull-down Enable                   */
+    uint32_t P31:1;            /*!< bit:     31  Pull-down Enable                   */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_PDERC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_PDERC_OFFSET           0x088        /**< \brief (GPIO_PDERC offset) Pull-down Enable Register - Clear */
+
+#define GPIO_PDERC_P0_Pos           0            /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P0               (_U(0x1) << GPIO_PDERC_P0_Pos)
+#define GPIO_PDERC_P1_Pos           1            /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P1               (_U(0x1) << GPIO_PDERC_P1_Pos)
+#define GPIO_PDERC_P2_Pos           2            /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P2               (_U(0x1) << GPIO_PDERC_P2_Pos)
+#define GPIO_PDERC_P3_Pos           3            /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P3               (_U(0x1) << GPIO_PDERC_P3_Pos)
+#define GPIO_PDERC_P4_Pos           4            /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P4               (_U(0x1) << GPIO_PDERC_P4_Pos)
+#define GPIO_PDERC_P5_Pos           5            /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P5               (_U(0x1) << GPIO_PDERC_P5_Pos)
+#define GPIO_PDERC_P6_Pos           6            /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P6               (_U(0x1) << GPIO_PDERC_P6_Pos)
+#define GPIO_PDERC_P7_Pos           7            /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P7               (_U(0x1) << GPIO_PDERC_P7_Pos)
+#define GPIO_PDERC_P8_Pos           8            /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P8               (_U(0x1) << GPIO_PDERC_P8_Pos)
+#define GPIO_PDERC_P9_Pos           9            /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P9               (_U(0x1) << GPIO_PDERC_P9_Pos)
+#define GPIO_PDERC_P10_Pos          10           /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P10              (_U(0x1) << GPIO_PDERC_P10_Pos)
+#define GPIO_PDERC_P11_Pos          11           /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P11              (_U(0x1) << GPIO_PDERC_P11_Pos)
+#define GPIO_PDERC_P12_Pos          12           /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P12              (_U(0x1) << GPIO_PDERC_P12_Pos)
+#define GPIO_PDERC_P13_Pos          13           /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P13              (_U(0x1) << GPIO_PDERC_P13_Pos)
+#define GPIO_PDERC_P14_Pos          14           /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P14              (_U(0x1) << GPIO_PDERC_P14_Pos)
+#define GPIO_PDERC_P15_Pos          15           /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P15              (_U(0x1) << GPIO_PDERC_P15_Pos)
+#define GPIO_PDERC_P16_Pos          16           /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P16              (_U(0x1) << GPIO_PDERC_P16_Pos)
+#define GPIO_PDERC_P17_Pos          17           /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P17              (_U(0x1) << GPIO_PDERC_P17_Pos)
+#define GPIO_PDERC_P18_Pos          18           /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P18              (_U(0x1) << GPIO_PDERC_P18_Pos)
+#define GPIO_PDERC_P19_Pos          19           /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P19              (_U(0x1) << GPIO_PDERC_P19_Pos)
+#define GPIO_PDERC_P20_Pos          20           /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P20              (_U(0x1) << GPIO_PDERC_P20_Pos)
+#define GPIO_PDERC_P21_Pos          21           /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P21              (_U(0x1) << GPIO_PDERC_P21_Pos)
+#define GPIO_PDERC_P22_Pos          22           /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P22              (_U(0x1) << GPIO_PDERC_P22_Pos)
+#define GPIO_PDERC_P23_Pos          23           /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P23              (_U(0x1) << GPIO_PDERC_P23_Pos)
+#define GPIO_PDERC_P24_Pos          24           /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P24              (_U(0x1) << GPIO_PDERC_P24_Pos)
+#define GPIO_PDERC_P25_Pos          25           /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P25              (_U(0x1) << GPIO_PDERC_P25_Pos)
+#define GPIO_PDERC_P26_Pos          26           /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P26              (_U(0x1) << GPIO_PDERC_P26_Pos)
+#define GPIO_PDERC_P27_Pos          27           /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P27              (_U(0x1) << GPIO_PDERC_P27_Pos)
+#define GPIO_PDERC_P28_Pos          28           /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P28              (_U(0x1) << GPIO_PDERC_P28_Pos)
+#define GPIO_PDERC_P29_Pos          29           /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P29              (_U(0x1) << GPIO_PDERC_P29_Pos)
+#define GPIO_PDERC_P30_Pos          30           /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P30              (_U(0x1) << GPIO_PDERC_P30_Pos)
+#define GPIO_PDERC_P31_Pos          31           /**< \brief (GPIO_PDERC) Pull-down Enable */
+#define GPIO_PDERC_P31              (_U(0x1) << GPIO_PDERC_P31_Pos)
+#define GPIO_PDERC_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PDERC) MASK Register */
+
+/* -------- GPIO_PDERT : (GPIO Offset: 0x08C) ( /W 32) port Pull-down Enable Register - Toggle -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Pull-down Enable                   */
+    uint32_t P1:1;             /*!< bit:      1  Pull-down Enable                   */
+    uint32_t P2:1;             /*!< bit:      2  Pull-down Enable                   */
+    uint32_t P3:1;             /*!< bit:      3  Pull-down Enable                   */
+    uint32_t P4:1;             /*!< bit:      4  Pull-down Enable                   */
+    uint32_t P5:1;             /*!< bit:      5  Pull-down Enable                   */
+    uint32_t P6:1;             /*!< bit:      6  Pull-down Enable                   */
+    uint32_t P7:1;             /*!< bit:      7  Pull-down Enable                   */
+    uint32_t P8:1;             /*!< bit:      8  Pull-down Enable                   */
+    uint32_t P9:1;             /*!< bit:      9  Pull-down Enable                   */
+    uint32_t P10:1;            /*!< bit:     10  Pull-down Enable                   */
+    uint32_t P11:1;            /*!< bit:     11  Pull-down Enable                   */
+    uint32_t P12:1;            /*!< bit:     12  Pull-down Enable                   */
+    uint32_t P13:1;            /*!< bit:     13  Pull-down Enable                   */
+    uint32_t P14:1;            /*!< bit:     14  Pull-down Enable                   */
+    uint32_t P15:1;            /*!< bit:     15  Pull-down Enable                   */
+    uint32_t P16:1;            /*!< bit:     16  Pull-down Enable                   */
+    uint32_t P17:1;            /*!< bit:     17  Pull-down Enable                   */
+    uint32_t P18:1;            /*!< bit:     18  Pull-down Enable                   */
+    uint32_t P19:1;            /*!< bit:     19  Pull-down Enable                   */
+    uint32_t P20:1;            /*!< bit:     20  Pull-down Enable                   */
+    uint32_t P21:1;            /*!< bit:     21  Pull-down Enable                   */
+    uint32_t P22:1;            /*!< bit:     22  Pull-down Enable                   */
+    uint32_t P23:1;            /*!< bit:     23  Pull-down Enable                   */
+    uint32_t P24:1;            /*!< bit:     24  Pull-down Enable                   */
+    uint32_t P25:1;            /*!< bit:     25  Pull-down Enable                   */
+    uint32_t P26:1;            /*!< bit:     26  Pull-down Enable                   */
+    uint32_t P27:1;            /*!< bit:     27  Pull-down Enable                   */
+    uint32_t P28:1;            /*!< bit:     28  Pull-down Enable                   */
+    uint32_t P29:1;            /*!< bit:     29  Pull-down Enable                   */
+    uint32_t P30:1;            /*!< bit:     30  Pull-down Enable                   */
+    uint32_t P31:1;            /*!< bit:     31  Pull-down Enable                   */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_PDERT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_PDERT_OFFSET           0x08C        /**< \brief (GPIO_PDERT offset) Pull-down Enable Register - Toggle */
+
+#define GPIO_PDERT_P0_Pos           0            /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P0               (_U(0x1) << GPIO_PDERT_P0_Pos)
+#define GPIO_PDERT_P1_Pos           1            /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P1               (_U(0x1) << GPIO_PDERT_P1_Pos)
+#define GPIO_PDERT_P2_Pos           2            /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P2               (_U(0x1) << GPIO_PDERT_P2_Pos)
+#define GPIO_PDERT_P3_Pos           3            /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P3               (_U(0x1) << GPIO_PDERT_P3_Pos)
+#define GPIO_PDERT_P4_Pos           4            /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P4               (_U(0x1) << GPIO_PDERT_P4_Pos)
+#define GPIO_PDERT_P5_Pos           5            /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P5               (_U(0x1) << GPIO_PDERT_P5_Pos)
+#define GPIO_PDERT_P6_Pos           6            /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P6               (_U(0x1) << GPIO_PDERT_P6_Pos)
+#define GPIO_PDERT_P7_Pos           7            /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P7               (_U(0x1) << GPIO_PDERT_P7_Pos)
+#define GPIO_PDERT_P8_Pos           8            /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P8               (_U(0x1) << GPIO_PDERT_P8_Pos)
+#define GPIO_PDERT_P9_Pos           9            /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P9               (_U(0x1) << GPIO_PDERT_P9_Pos)
+#define GPIO_PDERT_P10_Pos          10           /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P10              (_U(0x1) << GPIO_PDERT_P10_Pos)
+#define GPIO_PDERT_P11_Pos          11           /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P11              (_U(0x1) << GPIO_PDERT_P11_Pos)
+#define GPIO_PDERT_P12_Pos          12           /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P12              (_U(0x1) << GPIO_PDERT_P12_Pos)
+#define GPIO_PDERT_P13_Pos          13           /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P13              (_U(0x1) << GPIO_PDERT_P13_Pos)
+#define GPIO_PDERT_P14_Pos          14           /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P14              (_U(0x1) << GPIO_PDERT_P14_Pos)
+#define GPIO_PDERT_P15_Pos          15           /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P15              (_U(0x1) << GPIO_PDERT_P15_Pos)
+#define GPIO_PDERT_P16_Pos          16           /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P16              (_U(0x1) << GPIO_PDERT_P16_Pos)
+#define GPIO_PDERT_P17_Pos          17           /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P17              (_U(0x1) << GPIO_PDERT_P17_Pos)
+#define GPIO_PDERT_P18_Pos          18           /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P18              (_U(0x1) << GPIO_PDERT_P18_Pos)
+#define GPIO_PDERT_P19_Pos          19           /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P19              (_U(0x1) << GPIO_PDERT_P19_Pos)
+#define GPIO_PDERT_P20_Pos          20           /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P20              (_U(0x1) << GPIO_PDERT_P20_Pos)
+#define GPIO_PDERT_P21_Pos          21           /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P21              (_U(0x1) << GPIO_PDERT_P21_Pos)
+#define GPIO_PDERT_P22_Pos          22           /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P22              (_U(0x1) << GPIO_PDERT_P22_Pos)
+#define GPIO_PDERT_P23_Pos          23           /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P23              (_U(0x1) << GPIO_PDERT_P23_Pos)
+#define GPIO_PDERT_P24_Pos          24           /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P24              (_U(0x1) << GPIO_PDERT_P24_Pos)
+#define GPIO_PDERT_P25_Pos          25           /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P25              (_U(0x1) << GPIO_PDERT_P25_Pos)
+#define GPIO_PDERT_P26_Pos          26           /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P26              (_U(0x1) << GPIO_PDERT_P26_Pos)
+#define GPIO_PDERT_P27_Pos          27           /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P27              (_U(0x1) << GPIO_PDERT_P27_Pos)
+#define GPIO_PDERT_P28_Pos          28           /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P28              (_U(0x1) << GPIO_PDERT_P28_Pos)
+#define GPIO_PDERT_P29_Pos          29           /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P29              (_U(0x1) << GPIO_PDERT_P29_Pos)
+#define GPIO_PDERT_P30_Pos          30           /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P30              (_U(0x1) << GPIO_PDERT_P30_Pos)
+#define GPIO_PDERT_P31_Pos          31           /**< \brief (GPIO_PDERT) Pull-down Enable */
+#define GPIO_PDERT_P31              (_U(0x1) << GPIO_PDERT_P31_Pos)
+#define GPIO_PDERT_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PDERT) MASK Register */
+
+/* -------- GPIO_IER : (GPIO Offset: 0x090) (R/W 32) port Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Interrupt Enable                   */
+    uint32_t P1:1;             /*!< bit:      1  Interrupt Enable                   */
+    uint32_t P2:1;             /*!< bit:      2  Interrupt Enable                   */
+    uint32_t P3:1;             /*!< bit:      3  Interrupt Enable                   */
+    uint32_t P4:1;             /*!< bit:      4  Interrupt Enable                   */
+    uint32_t P5:1;             /*!< bit:      5  Interrupt Enable                   */
+    uint32_t P6:1;             /*!< bit:      6  Interrupt Enable                   */
+    uint32_t P7:1;             /*!< bit:      7  Interrupt Enable                   */
+    uint32_t P8:1;             /*!< bit:      8  Interrupt Enable                   */
+    uint32_t P9:1;             /*!< bit:      9  Interrupt Enable                   */
+    uint32_t P10:1;            /*!< bit:     10  Interrupt Enable                   */
+    uint32_t P11:1;            /*!< bit:     11  Interrupt Enable                   */
+    uint32_t P12:1;            /*!< bit:     12  Interrupt Enable                   */
+    uint32_t P13:1;            /*!< bit:     13  Interrupt Enable                   */
+    uint32_t P14:1;            /*!< bit:     14  Interrupt Enable                   */
+    uint32_t P15:1;            /*!< bit:     15  Interrupt Enable                   */
+    uint32_t P16:1;            /*!< bit:     16  Interrupt Enable                   */
+    uint32_t P17:1;            /*!< bit:     17  Interrupt Enable                   */
+    uint32_t P18:1;            /*!< bit:     18  Interrupt Enable                   */
+    uint32_t P19:1;            /*!< bit:     19  Interrupt Enable                   */
+    uint32_t P20:1;            /*!< bit:     20  Interrupt Enable                   */
+    uint32_t P21:1;            /*!< bit:     21  Interrupt Enable                   */
+    uint32_t P22:1;            /*!< bit:     22  Interrupt Enable                   */
+    uint32_t P23:1;            /*!< bit:     23  Interrupt Enable                   */
+    uint32_t P24:1;            /*!< bit:     24  Interrupt Enable                   */
+    uint32_t P25:1;            /*!< bit:     25  Interrupt Enable                   */
+    uint32_t P26:1;            /*!< bit:     26  Interrupt Enable                   */
+    uint32_t P27:1;            /*!< bit:     27  Interrupt Enable                   */
+    uint32_t P28:1;            /*!< bit:     28  Interrupt Enable                   */
+    uint32_t P29:1;            /*!< bit:     29  Interrupt Enable                   */
+    uint32_t P30:1;            /*!< bit:     30  Interrupt Enable                   */
+    uint32_t P31:1;            /*!< bit:     31  Interrupt Enable                   */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_IER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_IER_OFFSET             0x090        /**< \brief (GPIO_IER offset) Interrupt Enable Register */
+
+#define GPIO_IER_P0_Pos             0            /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P0                 (_U(0x1) << GPIO_IER_P0_Pos)
+#define GPIO_IER_P1_Pos             1            /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P1                 (_U(0x1) << GPIO_IER_P1_Pos)
+#define GPIO_IER_P2_Pos             2            /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P2                 (_U(0x1) << GPIO_IER_P2_Pos)
+#define GPIO_IER_P3_Pos             3            /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P3                 (_U(0x1) << GPIO_IER_P3_Pos)
+#define GPIO_IER_P4_Pos             4            /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P4                 (_U(0x1) << GPIO_IER_P4_Pos)
+#define GPIO_IER_P5_Pos             5            /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P5                 (_U(0x1) << GPIO_IER_P5_Pos)
+#define GPIO_IER_P6_Pos             6            /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P6                 (_U(0x1) << GPIO_IER_P6_Pos)
+#define GPIO_IER_P7_Pos             7            /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P7                 (_U(0x1) << GPIO_IER_P7_Pos)
+#define GPIO_IER_P8_Pos             8            /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P8                 (_U(0x1) << GPIO_IER_P8_Pos)
+#define GPIO_IER_P9_Pos             9            /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P9                 (_U(0x1) << GPIO_IER_P9_Pos)
+#define GPIO_IER_P10_Pos            10           /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P10                (_U(0x1) << GPIO_IER_P10_Pos)
+#define GPIO_IER_P11_Pos            11           /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P11                (_U(0x1) << GPIO_IER_P11_Pos)
+#define GPIO_IER_P12_Pos            12           /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P12                (_U(0x1) << GPIO_IER_P12_Pos)
+#define GPIO_IER_P13_Pos            13           /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P13                (_U(0x1) << GPIO_IER_P13_Pos)
+#define GPIO_IER_P14_Pos            14           /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P14                (_U(0x1) << GPIO_IER_P14_Pos)
+#define GPIO_IER_P15_Pos            15           /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P15                (_U(0x1) << GPIO_IER_P15_Pos)
+#define GPIO_IER_P16_Pos            16           /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P16                (_U(0x1) << GPIO_IER_P16_Pos)
+#define GPIO_IER_P17_Pos            17           /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P17                (_U(0x1) << GPIO_IER_P17_Pos)
+#define GPIO_IER_P18_Pos            18           /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P18                (_U(0x1) << GPIO_IER_P18_Pos)
+#define GPIO_IER_P19_Pos            19           /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P19                (_U(0x1) << GPIO_IER_P19_Pos)
+#define GPIO_IER_P20_Pos            20           /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P20                (_U(0x1) << GPIO_IER_P20_Pos)
+#define GPIO_IER_P21_Pos            21           /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P21                (_U(0x1) << GPIO_IER_P21_Pos)
+#define GPIO_IER_P22_Pos            22           /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P22                (_U(0x1) << GPIO_IER_P22_Pos)
+#define GPIO_IER_P23_Pos            23           /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P23                (_U(0x1) << GPIO_IER_P23_Pos)
+#define GPIO_IER_P24_Pos            24           /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P24                (_U(0x1) << GPIO_IER_P24_Pos)
+#define GPIO_IER_P25_Pos            25           /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P25                (_U(0x1) << GPIO_IER_P25_Pos)
+#define GPIO_IER_P26_Pos            26           /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P26                (_U(0x1) << GPIO_IER_P26_Pos)
+#define GPIO_IER_P27_Pos            27           /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P27                (_U(0x1) << GPIO_IER_P27_Pos)
+#define GPIO_IER_P28_Pos            28           /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P28                (_U(0x1) << GPIO_IER_P28_Pos)
+#define GPIO_IER_P29_Pos            29           /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P29                (_U(0x1) << GPIO_IER_P29_Pos)
+#define GPIO_IER_P30_Pos            30           /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P30                (_U(0x1) << GPIO_IER_P30_Pos)
+#define GPIO_IER_P31_Pos            31           /**< \brief (GPIO_IER) Interrupt Enable */
+#define GPIO_IER_P31                (_U(0x1) << GPIO_IER_P31_Pos)
+#define GPIO_IER_MASK               _U(0xFFFFFFFF) /**< \brief (GPIO_IER) MASK Register */
+
+/* -------- GPIO_IERS : (GPIO Offset: 0x094) ( /W 32) port Interrupt Enable Register - Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Interrupt Enable                   */
+    uint32_t P1:1;             /*!< bit:      1  Interrupt Enable                   */
+    uint32_t P2:1;             /*!< bit:      2  Interrupt Enable                   */
+    uint32_t P3:1;             /*!< bit:      3  Interrupt Enable                   */
+    uint32_t P4:1;             /*!< bit:      4  Interrupt Enable                   */
+    uint32_t P5:1;             /*!< bit:      5  Interrupt Enable                   */
+    uint32_t P6:1;             /*!< bit:      6  Interrupt Enable                   */
+    uint32_t P7:1;             /*!< bit:      7  Interrupt Enable                   */
+    uint32_t P8:1;             /*!< bit:      8  Interrupt Enable                   */
+    uint32_t P9:1;             /*!< bit:      9  Interrupt Enable                   */
+    uint32_t P10:1;            /*!< bit:     10  Interrupt Enable                   */
+    uint32_t P11:1;            /*!< bit:     11  Interrupt Enable                   */
+    uint32_t P12:1;            /*!< bit:     12  Interrupt Enable                   */
+    uint32_t P13:1;            /*!< bit:     13  Interrupt Enable                   */
+    uint32_t P14:1;            /*!< bit:     14  Interrupt Enable                   */
+    uint32_t P15:1;            /*!< bit:     15  Interrupt Enable                   */
+    uint32_t P16:1;            /*!< bit:     16  Interrupt Enable                   */
+    uint32_t P17:1;            /*!< bit:     17  Interrupt Enable                   */
+    uint32_t P18:1;            /*!< bit:     18  Interrupt Enable                   */
+    uint32_t P19:1;            /*!< bit:     19  Interrupt Enable                   */
+    uint32_t P20:1;            /*!< bit:     20  Interrupt Enable                   */
+    uint32_t P21:1;            /*!< bit:     21  Interrupt Enable                   */
+    uint32_t P22:1;            /*!< bit:     22  Interrupt Enable                   */
+    uint32_t P23:1;            /*!< bit:     23  Interrupt Enable                   */
+    uint32_t P24:1;            /*!< bit:     24  Interrupt Enable                   */
+    uint32_t P25:1;            /*!< bit:     25  Interrupt Enable                   */
+    uint32_t P26:1;            /*!< bit:     26  Interrupt Enable                   */
+    uint32_t P27:1;            /*!< bit:     27  Interrupt Enable                   */
+    uint32_t P28:1;            /*!< bit:     28  Interrupt Enable                   */
+    uint32_t P29:1;            /*!< bit:     29  Interrupt Enable                   */
+    uint32_t P30:1;            /*!< bit:     30  Interrupt Enable                   */
+    uint32_t P31:1;            /*!< bit:     31  Interrupt Enable                   */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_IERS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_IERS_OFFSET            0x094        /**< \brief (GPIO_IERS offset) Interrupt Enable Register - Set */
+
+#define GPIO_IERS_P0_Pos            0            /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P0                (_U(0x1) << GPIO_IERS_P0_Pos)
+#define GPIO_IERS_P1_Pos            1            /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P1                (_U(0x1) << GPIO_IERS_P1_Pos)
+#define GPIO_IERS_P2_Pos            2            /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P2                (_U(0x1) << GPIO_IERS_P2_Pos)
+#define GPIO_IERS_P3_Pos            3            /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P3                (_U(0x1) << GPIO_IERS_P3_Pos)
+#define GPIO_IERS_P4_Pos            4            /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P4                (_U(0x1) << GPIO_IERS_P4_Pos)
+#define GPIO_IERS_P5_Pos            5            /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P5                (_U(0x1) << GPIO_IERS_P5_Pos)
+#define GPIO_IERS_P6_Pos            6            /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P6                (_U(0x1) << GPIO_IERS_P6_Pos)
+#define GPIO_IERS_P7_Pos            7            /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P7                (_U(0x1) << GPIO_IERS_P7_Pos)
+#define GPIO_IERS_P8_Pos            8            /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P8                (_U(0x1) << GPIO_IERS_P8_Pos)
+#define GPIO_IERS_P9_Pos            9            /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P9                (_U(0x1) << GPIO_IERS_P9_Pos)
+#define GPIO_IERS_P10_Pos           10           /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P10               (_U(0x1) << GPIO_IERS_P10_Pos)
+#define GPIO_IERS_P11_Pos           11           /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P11               (_U(0x1) << GPIO_IERS_P11_Pos)
+#define GPIO_IERS_P12_Pos           12           /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P12               (_U(0x1) << GPIO_IERS_P12_Pos)
+#define GPIO_IERS_P13_Pos           13           /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P13               (_U(0x1) << GPIO_IERS_P13_Pos)
+#define GPIO_IERS_P14_Pos           14           /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P14               (_U(0x1) << GPIO_IERS_P14_Pos)
+#define GPIO_IERS_P15_Pos           15           /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P15               (_U(0x1) << GPIO_IERS_P15_Pos)
+#define GPIO_IERS_P16_Pos           16           /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P16               (_U(0x1) << GPIO_IERS_P16_Pos)
+#define GPIO_IERS_P17_Pos           17           /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P17               (_U(0x1) << GPIO_IERS_P17_Pos)
+#define GPIO_IERS_P18_Pos           18           /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P18               (_U(0x1) << GPIO_IERS_P18_Pos)
+#define GPIO_IERS_P19_Pos           19           /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P19               (_U(0x1) << GPIO_IERS_P19_Pos)
+#define GPIO_IERS_P20_Pos           20           /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P20               (_U(0x1) << GPIO_IERS_P20_Pos)
+#define GPIO_IERS_P21_Pos           21           /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P21               (_U(0x1) << GPIO_IERS_P21_Pos)
+#define GPIO_IERS_P22_Pos           22           /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P22               (_U(0x1) << GPIO_IERS_P22_Pos)
+#define GPIO_IERS_P23_Pos           23           /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P23               (_U(0x1) << GPIO_IERS_P23_Pos)
+#define GPIO_IERS_P24_Pos           24           /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P24               (_U(0x1) << GPIO_IERS_P24_Pos)
+#define GPIO_IERS_P25_Pos           25           /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P25               (_U(0x1) << GPIO_IERS_P25_Pos)
+#define GPIO_IERS_P26_Pos           26           /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P26               (_U(0x1) << GPIO_IERS_P26_Pos)
+#define GPIO_IERS_P27_Pos           27           /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P27               (_U(0x1) << GPIO_IERS_P27_Pos)
+#define GPIO_IERS_P28_Pos           28           /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P28               (_U(0x1) << GPIO_IERS_P28_Pos)
+#define GPIO_IERS_P29_Pos           29           /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P29               (_U(0x1) << GPIO_IERS_P29_Pos)
+#define GPIO_IERS_P30_Pos           30           /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P30               (_U(0x1) << GPIO_IERS_P30_Pos)
+#define GPIO_IERS_P31_Pos           31           /**< \brief (GPIO_IERS) Interrupt Enable */
+#define GPIO_IERS_P31               (_U(0x1) << GPIO_IERS_P31_Pos)
+#define GPIO_IERS_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_IERS) MASK Register */
+
+/* -------- GPIO_IERC : (GPIO Offset: 0x098) ( /W 32) port Interrupt Enable Register - Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Interrupt Enable                   */
+    uint32_t P1:1;             /*!< bit:      1  Interrupt Enable                   */
+    uint32_t P2:1;             /*!< bit:      2  Interrupt Enable                   */
+    uint32_t P3:1;             /*!< bit:      3  Interrupt Enable                   */
+    uint32_t P4:1;             /*!< bit:      4  Interrupt Enable                   */
+    uint32_t P5:1;             /*!< bit:      5  Interrupt Enable                   */
+    uint32_t P6:1;             /*!< bit:      6  Interrupt Enable                   */
+    uint32_t P7:1;             /*!< bit:      7  Interrupt Enable                   */
+    uint32_t P8:1;             /*!< bit:      8  Interrupt Enable                   */
+    uint32_t P9:1;             /*!< bit:      9  Interrupt Enable                   */
+    uint32_t P10:1;            /*!< bit:     10  Interrupt Enable                   */
+    uint32_t P11:1;            /*!< bit:     11  Interrupt Enable                   */
+    uint32_t P12:1;            /*!< bit:     12  Interrupt Enable                   */
+    uint32_t P13:1;            /*!< bit:     13  Interrupt Enable                   */
+    uint32_t P14:1;            /*!< bit:     14  Interrupt Enable                   */
+    uint32_t P15:1;            /*!< bit:     15  Interrupt Enable                   */
+    uint32_t P16:1;            /*!< bit:     16  Interrupt Enable                   */
+    uint32_t P17:1;            /*!< bit:     17  Interrupt Enable                   */
+    uint32_t P18:1;            /*!< bit:     18  Interrupt Enable                   */
+    uint32_t P19:1;            /*!< bit:     19  Interrupt Enable                   */
+    uint32_t P20:1;            /*!< bit:     20  Interrupt Enable                   */
+    uint32_t P21:1;            /*!< bit:     21  Interrupt Enable                   */
+    uint32_t P22:1;            /*!< bit:     22  Interrupt Enable                   */
+    uint32_t P23:1;            /*!< bit:     23  Interrupt Enable                   */
+    uint32_t P24:1;            /*!< bit:     24  Interrupt Enable                   */
+    uint32_t P25:1;            /*!< bit:     25  Interrupt Enable                   */
+    uint32_t P26:1;            /*!< bit:     26  Interrupt Enable                   */
+    uint32_t P27:1;            /*!< bit:     27  Interrupt Enable                   */
+    uint32_t P28:1;            /*!< bit:     28  Interrupt Enable                   */
+    uint32_t P29:1;            /*!< bit:     29  Interrupt Enable                   */
+    uint32_t P30:1;            /*!< bit:     30  Interrupt Enable                   */
+    uint32_t P31:1;            /*!< bit:     31  Interrupt Enable                   */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_IERC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_IERC_OFFSET            0x098        /**< \brief (GPIO_IERC offset) Interrupt Enable Register - Clear */
+
+#define GPIO_IERC_P0_Pos            0            /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P0                (_U(0x1) << GPIO_IERC_P0_Pos)
+#define GPIO_IERC_P1_Pos            1            /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P1                (_U(0x1) << GPIO_IERC_P1_Pos)
+#define GPIO_IERC_P2_Pos            2            /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P2                (_U(0x1) << GPIO_IERC_P2_Pos)
+#define GPIO_IERC_P3_Pos            3            /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P3                (_U(0x1) << GPIO_IERC_P3_Pos)
+#define GPIO_IERC_P4_Pos            4            /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P4                (_U(0x1) << GPIO_IERC_P4_Pos)
+#define GPIO_IERC_P5_Pos            5            /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P5                (_U(0x1) << GPIO_IERC_P5_Pos)
+#define GPIO_IERC_P6_Pos            6            /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P6                (_U(0x1) << GPIO_IERC_P6_Pos)
+#define GPIO_IERC_P7_Pos            7            /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P7                (_U(0x1) << GPIO_IERC_P7_Pos)
+#define GPIO_IERC_P8_Pos            8            /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P8                (_U(0x1) << GPIO_IERC_P8_Pos)
+#define GPIO_IERC_P9_Pos            9            /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P9                (_U(0x1) << GPIO_IERC_P9_Pos)
+#define GPIO_IERC_P10_Pos           10           /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P10               (_U(0x1) << GPIO_IERC_P10_Pos)
+#define GPIO_IERC_P11_Pos           11           /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P11               (_U(0x1) << GPIO_IERC_P11_Pos)
+#define GPIO_IERC_P12_Pos           12           /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P12               (_U(0x1) << GPIO_IERC_P12_Pos)
+#define GPIO_IERC_P13_Pos           13           /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P13               (_U(0x1) << GPIO_IERC_P13_Pos)
+#define GPIO_IERC_P14_Pos           14           /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P14               (_U(0x1) << GPIO_IERC_P14_Pos)
+#define GPIO_IERC_P15_Pos           15           /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P15               (_U(0x1) << GPIO_IERC_P15_Pos)
+#define GPIO_IERC_P16_Pos           16           /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P16               (_U(0x1) << GPIO_IERC_P16_Pos)
+#define GPIO_IERC_P17_Pos           17           /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P17               (_U(0x1) << GPIO_IERC_P17_Pos)
+#define GPIO_IERC_P18_Pos           18           /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P18               (_U(0x1) << GPIO_IERC_P18_Pos)
+#define GPIO_IERC_P19_Pos           19           /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P19               (_U(0x1) << GPIO_IERC_P19_Pos)
+#define GPIO_IERC_P20_Pos           20           /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P20               (_U(0x1) << GPIO_IERC_P20_Pos)
+#define GPIO_IERC_P21_Pos           21           /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P21               (_U(0x1) << GPIO_IERC_P21_Pos)
+#define GPIO_IERC_P22_Pos           22           /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P22               (_U(0x1) << GPIO_IERC_P22_Pos)
+#define GPIO_IERC_P23_Pos           23           /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P23               (_U(0x1) << GPIO_IERC_P23_Pos)
+#define GPIO_IERC_P24_Pos           24           /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P24               (_U(0x1) << GPIO_IERC_P24_Pos)
+#define GPIO_IERC_P25_Pos           25           /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P25               (_U(0x1) << GPIO_IERC_P25_Pos)
+#define GPIO_IERC_P26_Pos           26           /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P26               (_U(0x1) << GPIO_IERC_P26_Pos)
+#define GPIO_IERC_P27_Pos           27           /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P27               (_U(0x1) << GPIO_IERC_P27_Pos)
+#define GPIO_IERC_P28_Pos           28           /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P28               (_U(0x1) << GPIO_IERC_P28_Pos)
+#define GPIO_IERC_P29_Pos           29           /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P29               (_U(0x1) << GPIO_IERC_P29_Pos)
+#define GPIO_IERC_P30_Pos           30           /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P30               (_U(0x1) << GPIO_IERC_P30_Pos)
+#define GPIO_IERC_P31_Pos           31           /**< \brief (GPIO_IERC) Interrupt Enable */
+#define GPIO_IERC_P31               (_U(0x1) << GPIO_IERC_P31_Pos)
+#define GPIO_IERC_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_IERC) MASK Register */
+
+/* -------- GPIO_IERT : (GPIO Offset: 0x09C) ( /W 32) port Interrupt Enable Register - Toggle -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Interrupt Enable                   */
+    uint32_t P1:1;             /*!< bit:      1  Interrupt Enable                   */
+    uint32_t P2:1;             /*!< bit:      2  Interrupt Enable                   */
+    uint32_t P3:1;             /*!< bit:      3  Interrupt Enable                   */
+    uint32_t P4:1;             /*!< bit:      4  Interrupt Enable                   */
+    uint32_t P5:1;             /*!< bit:      5  Interrupt Enable                   */
+    uint32_t P6:1;             /*!< bit:      6  Interrupt Enable                   */
+    uint32_t P7:1;             /*!< bit:      7  Interrupt Enable                   */
+    uint32_t P8:1;             /*!< bit:      8  Interrupt Enable                   */
+    uint32_t P9:1;             /*!< bit:      9  Interrupt Enable                   */
+    uint32_t P10:1;            /*!< bit:     10  Interrupt Enable                   */
+    uint32_t P11:1;            /*!< bit:     11  Interrupt Enable                   */
+    uint32_t P12:1;            /*!< bit:     12  Interrupt Enable                   */
+    uint32_t P13:1;            /*!< bit:     13  Interrupt Enable                   */
+    uint32_t P14:1;            /*!< bit:     14  Interrupt Enable                   */
+    uint32_t P15:1;            /*!< bit:     15  Interrupt Enable                   */
+    uint32_t P16:1;            /*!< bit:     16  Interrupt Enable                   */
+    uint32_t P17:1;            /*!< bit:     17  Interrupt Enable                   */
+    uint32_t P18:1;            /*!< bit:     18  Interrupt Enable                   */
+    uint32_t P19:1;            /*!< bit:     19  Interrupt Enable                   */
+    uint32_t P20:1;            /*!< bit:     20  Interrupt Enable                   */
+    uint32_t P21:1;            /*!< bit:     21  Interrupt Enable                   */
+    uint32_t P22:1;            /*!< bit:     22  Interrupt Enable                   */
+    uint32_t P23:1;            /*!< bit:     23  Interrupt Enable                   */
+    uint32_t P24:1;            /*!< bit:     24  Interrupt Enable                   */
+    uint32_t P25:1;            /*!< bit:     25  Interrupt Enable                   */
+    uint32_t P26:1;            /*!< bit:     26  Interrupt Enable                   */
+    uint32_t P27:1;            /*!< bit:     27  Interrupt Enable                   */
+    uint32_t P28:1;            /*!< bit:     28  Interrupt Enable                   */
+    uint32_t P29:1;            /*!< bit:     29  Interrupt Enable                   */
+    uint32_t P30:1;            /*!< bit:     30  Interrupt Enable                   */
+    uint32_t P31:1;            /*!< bit:     31  Interrupt Enable                   */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_IERT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_IERT_OFFSET            0x09C        /**< \brief (GPIO_IERT offset) Interrupt Enable Register - Toggle */
+
+#define GPIO_IERT_P0_Pos            0            /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P0                (_U(0x1) << GPIO_IERT_P0_Pos)
+#define GPIO_IERT_P1_Pos            1            /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P1                (_U(0x1) << GPIO_IERT_P1_Pos)
+#define GPIO_IERT_P2_Pos            2            /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P2                (_U(0x1) << GPIO_IERT_P2_Pos)
+#define GPIO_IERT_P3_Pos            3            /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P3                (_U(0x1) << GPIO_IERT_P3_Pos)
+#define GPIO_IERT_P4_Pos            4            /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P4                (_U(0x1) << GPIO_IERT_P4_Pos)
+#define GPIO_IERT_P5_Pos            5            /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P5                (_U(0x1) << GPIO_IERT_P5_Pos)
+#define GPIO_IERT_P6_Pos            6            /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P6                (_U(0x1) << GPIO_IERT_P6_Pos)
+#define GPIO_IERT_P7_Pos            7            /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P7                (_U(0x1) << GPIO_IERT_P7_Pos)
+#define GPIO_IERT_P8_Pos            8            /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P8                (_U(0x1) << GPIO_IERT_P8_Pos)
+#define GPIO_IERT_P9_Pos            9            /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P9                (_U(0x1) << GPIO_IERT_P9_Pos)
+#define GPIO_IERT_P10_Pos           10           /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P10               (_U(0x1) << GPIO_IERT_P10_Pos)
+#define GPIO_IERT_P11_Pos           11           /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P11               (_U(0x1) << GPIO_IERT_P11_Pos)
+#define GPIO_IERT_P12_Pos           12           /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P12               (_U(0x1) << GPIO_IERT_P12_Pos)
+#define GPIO_IERT_P13_Pos           13           /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P13               (_U(0x1) << GPIO_IERT_P13_Pos)
+#define GPIO_IERT_P14_Pos           14           /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P14               (_U(0x1) << GPIO_IERT_P14_Pos)
+#define GPIO_IERT_P15_Pos           15           /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P15               (_U(0x1) << GPIO_IERT_P15_Pos)
+#define GPIO_IERT_P16_Pos           16           /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P16               (_U(0x1) << GPIO_IERT_P16_Pos)
+#define GPIO_IERT_P17_Pos           17           /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P17               (_U(0x1) << GPIO_IERT_P17_Pos)
+#define GPIO_IERT_P18_Pos           18           /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P18               (_U(0x1) << GPIO_IERT_P18_Pos)
+#define GPIO_IERT_P19_Pos           19           /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P19               (_U(0x1) << GPIO_IERT_P19_Pos)
+#define GPIO_IERT_P20_Pos           20           /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P20               (_U(0x1) << GPIO_IERT_P20_Pos)
+#define GPIO_IERT_P21_Pos           21           /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P21               (_U(0x1) << GPIO_IERT_P21_Pos)
+#define GPIO_IERT_P22_Pos           22           /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P22               (_U(0x1) << GPIO_IERT_P22_Pos)
+#define GPIO_IERT_P23_Pos           23           /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P23               (_U(0x1) << GPIO_IERT_P23_Pos)
+#define GPIO_IERT_P24_Pos           24           /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P24               (_U(0x1) << GPIO_IERT_P24_Pos)
+#define GPIO_IERT_P25_Pos           25           /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P25               (_U(0x1) << GPIO_IERT_P25_Pos)
+#define GPIO_IERT_P26_Pos           26           /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P26               (_U(0x1) << GPIO_IERT_P26_Pos)
+#define GPIO_IERT_P27_Pos           27           /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P27               (_U(0x1) << GPIO_IERT_P27_Pos)
+#define GPIO_IERT_P28_Pos           28           /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P28               (_U(0x1) << GPIO_IERT_P28_Pos)
+#define GPIO_IERT_P29_Pos           29           /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P29               (_U(0x1) << GPIO_IERT_P29_Pos)
+#define GPIO_IERT_P30_Pos           30           /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P30               (_U(0x1) << GPIO_IERT_P30_Pos)
+#define GPIO_IERT_P31_Pos           31           /**< \brief (GPIO_IERT) Interrupt Enable */
+#define GPIO_IERT_P31               (_U(0x1) << GPIO_IERT_P31_Pos)
+#define GPIO_IERT_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_IERT) MASK Register */
+
+/* -------- GPIO_IMR0 : (GPIO Offset: 0x0A0) (R/W 32) port Interrupt Mode Register 0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Interrupt Mode Bit 0               */
+    uint32_t P1:1;             /*!< bit:      1  Interrupt Mode Bit 0               */
+    uint32_t P2:1;             /*!< bit:      2  Interrupt Mode Bit 0               */
+    uint32_t P3:1;             /*!< bit:      3  Interrupt Mode Bit 0               */
+    uint32_t P4:1;             /*!< bit:      4  Interrupt Mode Bit 0               */
+    uint32_t P5:1;             /*!< bit:      5  Interrupt Mode Bit 0               */
+    uint32_t P6:1;             /*!< bit:      6  Interrupt Mode Bit 0               */
+    uint32_t P7:1;             /*!< bit:      7  Interrupt Mode Bit 0               */
+    uint32_t P8:1;             /*!< bit:      8  Interrupt Mode Bit 0               */
+    uint32_t P9:1;             /*!< bit:      9  Interrupt Mode Bit 0               */
+    uint32_t P10:1;            /*!< bit:     10  Interrupt Mode Bit 0               */
+    uint32_t P11:1;            /*!< bit:     11  Interrupt Mode Bit 0               */
+    uint32_t P12:1;            /*!< bit:     12  Interrupt Mode Bit 0               */
+    uint32_t P13:1;            /*!< bit:     13  Interrupt Mode Bit 0               */
+    uint32_t P14:1;            /*!< bit:     14  Interrupt Mode Bit 0               */
+    uint32_t P15:1;            /*!< bit:     15  Interrupt Mode Bit 0               */
+    uint32_t P16:1;            /*!< bit:     16  Interrupt Mode Bit 0               */
+    uint32_t P17:1;            /*!< bit:     17  Interrupt Mode Bit 0               */
+    uint32_t P18:1;            /*!< bit:     18  Interrupt Mode Bit 0               */
+    uint32_t P19:1;            /*!< bit:     19  Interrupt Mode Bit 0               */
+    uint32_t P20:1;            /*!< bit:     20  Interrupt Mode Bit 0               */
+    uint32_t P21:1;            /*!< bit:     21  Interrupt Mode Bit 0               */
+    uint32_t P22:1;            /*!< bit:     22  Interrupt Mode Bit 0               */
+    uint32_t P23:1;            /*!< bit:     23  Interrupt Mode Bit 0               */
+    uint32_t P24:1;            /*!< bit:     24  Interrupt Mode Bit 0               */
+    uint32_t P25:1;            /*!< bit:     25  Interrupt Mode Bit 0               */
+    uint32_t P26:1;            /*!< bit:     26  Interrupt Mode Bit 0               */
+    uint32_t P27:1;            /*!< bit:     27  Interrupt Mode Bit 0               */
+    uint32_t P28:1;            /*!< bit:     28  Interrupt Mode Bit 0               */
+    uint32_t P29:1;            /*!< bit:     29  Interrupt Mode Bit 0               */
+    uint32_t P30:1;            /*!< bit:     30  Interrupt Mode Bit 0               */
+    uint32_t P31:1;            /*!< bit:     31  Interrupt Mode Bit 0               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_IMR0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_IMR0_OFFSET            0x0A0        /**< \brief (GPIO_IMR0 offset) Interrupt Mode Register 0 */
+
+#define GPIO_IMR0_P0_Pos            0            /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P0                (_U(0x1) << GPIO_IMR0_P0_Pos)
+#define GPIO_IMR0_P1_Pos            1            /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P1                (_U(0x1) << GPIO_IMR0_P1_Pos)
+#define GPIO_IMR0_P2_Pos            2            /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P2                (_U(0x1) << GPIO_IMR0_P2_Pos)
+#define GPIO_IMR0_P3_Pos            3            /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P3                (_U(0x1) << GPIO_IMR0_P3_Pos)
+#define GPIO_IMR0_P4_Pos            4            /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P4                (_U(0x1) << GPIO_IMR0_P4_Pos)
+#define GPIO_IMR0_P5_Pos            5            /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P5                (_U(0x1) << GPIO_IMR0_P5_Pos)
+#define GPIO_IMR0_P6_Pos            6            /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P6                (_U(0x1) << GPIO_IMR0_P6_Pos)
+#define GPIO_IMR0_P7_Pos            7            /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P7                (_U(0x1) << GPIO_IMR0_P7_Pos)
+#define GPIO_IMR0_P8_Pos            8            /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P8                (_U(0x1) << GPIO_IMR0_P8_Pos)
+#define GPIO_IMR0_P9_Pos            9            /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P9                (_U(0x1) << GPIO_IMR0_P9_Pos)
+#define GPIO_IMR0_P10_Pos           10           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P10               (_U(0x1) << GPIO_IMR0_P10_Pos)
+#define GPIO_IMR0_P11_Pos           11           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P11               (_U(0x1) << GPIO_IMR0_P11_Pos)
+#define GPIO_IMR0_P12_Pos           12           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P12               (_U(0x1) << GPIO_IMR0_P12_Pos)
+#define GPIO_IMR0_P13_Pos           13           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P13               (_U(0x1) << GPIO_IMR0_P13_Pos)
+#define GPIO_IMR0_P14_Pos           14           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P14               (_U(0x1) << GPIO_IMR0_P14_Pos)
+#define GPIO_IMR0_P15_Pos           15           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P15               (_U(0x1) << GPIO_IMR0_P15_Pos)
+#define GPIO_IMR0_P16_Pos           16           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P16               (_U(0x1) << GPIO_IMR0_P16_Pos)
+#define GPIO_IMR0_P17_Pos           17           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P17               (_U(0x1) << GPIO_IMR0_P17_Pos)
+#define GPIO_IMR0_P18_Pos           18           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P18               (_U(0x1) << GPIO_IMR0_P18_Pos)
+#define GPIO_IMR0_P19_Pos           19           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P19               (_U(0x1) << GPIO_IMR0_P19_Pos)
+#define GPIO_IMR0_P20_Pos           20           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P20               (_U(0x1) << GPIO_IMR0_P20_Pos)
+#define GPIO_IMR0_P21_Pos           21           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P21               (_U(0x1) << GPIO_IMR0_P21_Pos)
+#define GPIO_IMR0_P22_Pos           22           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P22               (_U(0x1) << GPIO_IMR0_P22_Pos)
+#define GPIO_IMR0_P23_Pos           23           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P23               (_U(0x1) << GPIO_IMR0_P23_Pos)
+#define GPIO_IMR0_P24_Pos           24           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P24               (_U(0x1) << GPIO_IMR0_P24_Pos)
+#define GPIO_IMR0_P25_Pos           25           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P25               (_U(0x1) << GPIO_IMR0_P25_Pos)
+#define GPIO_IMR0_P26_Pos           26           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P26               (_U(0x1) << GPIO_IMR0_P26_Pos)
+#define GPIO_IMR0_P27_Pos           27           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P27               (_U(0x1) << GPIO_IMR0_P27_Pos)
+#define GPIO_IMR0_P28_Pos           28           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P28               (_U(0x1) << GPIO_IMR0_P28_Pos)
+#define GPIO_IMR0_P29_Pos           29           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P29               (_U(0x1) << GPIO_IMR0_P29_Pos)
+#define GPIO_IMR0_P30_Pos           30           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P30               (_U(0x1) << GPIO_IMR0_P30_Pos)
+#define GPIO_IMR0_P31_Pos           31           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
+#define GPIO_IMR0_P31               (_U(0x1) << GPIO_IMR0_P31_Pos)
+#define GPIO_IMR0_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_IMR0) MASK Register */
+
+/* -------- GPIO_IMR0S : (GPIO Offset: 0x0A4) ( /W 32) port Interrupt Mode Register 0 - Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Interrupt Mode Bit 0               */
+    uint32_t P1:1;             /*!< bit:      1  Interrupt Mode Bit 0               */
+    uint32_t P2:1;             /*!< bit:      2  Interrupt Mode Bit 0               */
+    uint32_t P3:1;             /*!< bit:      3  Interrupt Mode Bit 0               */
+    uint32_t P4:1;             /*!< bit:      4  Interrupt Mode Bit 0               */
+    uint32_t P5:1;             /*!< bit:      5  Interrupt Mode Bit 0               */
+    uint32_t P6:1;             /*!< bit:      6  Interrupt Mode Bit 0               */
+    uint32_t P7:1;             /*!< bit:      7  Interrupt Mode Bit 0               */
+    uint32_t P8:1;             /*!< bit:      8  Interrupt Mode Bit 0               */
+    uint32_t P9:1;             /*!< bit:      9  Interrupt Mode Bit 0               */
+    uint32_t P10:1;            /*!< bit:     10  Interrupt Mode Bit 0               */
+    uint32_t P11:1;            /*!< bit:     11  Interrupt Mode Bit 0               */
+    uint32_t P12:1;            /*!< bit:     12  Interrupt Mode Bit 0               */
+    uint32_t P13:1;            /*!< bit:     13  Interrupt Mode Bit 0               */
+    uint32_t P14:1;            /*!< bit:     14  Interrupt Mode Bit 0               */
+    uint32_t P15:1;            /*!< bit:     15  Interrupt Mode Bit 0               */
+    uint32_t P16:1;            /*!< bit:     16  Interrupt Mode Bit 0               */
+    uint32_t P17:1;            /*!< bit:     17  Interrupt Mode Bit 0               */
+    uint32_t P18:1;            /*!< bit:     18  Interrupt Mode Bit 0               */
+    uint32_t P19:1;            /*!< bit:     19  Interrupt Mode Bit 0               */
+    uint32_t P20:1;            /*!< bit:     20  Interrupt Mode Bit 0               */
+    uint32_t P21:1;            /*!< bit:     21  Interrupt Mode Bit 0               */
+    uint32_t P22:1;            /*!< bit:     22  Interrupt Mode Bit 0               */
+    uint32_t P23:1;            /*!< bit:     23  Interrupt Mode Bit 0               */
+    uint32_t P24:1;            /*!< bit:     24  Interrupt Mode Bit 0               */
+    uint32_t P25:1;            /*!< bit:     25  Interrupt Mode Bit 0               */
+    uint32_t P26:1;            /*!< bit:     26  Interrupt Mode Bit 0               */
+    uint32_t P27:1;            /*!< bit:     27  Interrupt Mode Bit 0               */
+    uint32_t P28:1;            /*!< bit:     28  Interrupt Mode Bit 0               */
+    uint32_t P29:1;            /*!< bit:     29  Interrupt Mode Bit 0               */
+    uint32_t P30:1;            /*!< bit:     30  Interrupt Mode Bit 0               */
+    uint32_t P31:1;            /*!< bit:     31  Interrupt Mode Bit 0               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_IMR0S_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_IMR0S_OFFSET           0x0A4        /**< \brief (GPIO_IMR0S offset) Interrupt Mode Register 0 - Set */
+
+#define GPIO_IMR0S_P0_Pos           0            /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P0               (_U(0x1) << GPIO_IMR0S_P0_Pos)
+#define GPIO_IMR0S_P1_Pos           1            /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P1               (_U(0x1) << GPIO_IMR0S_P1_Pos)
+#define GPIO_IMR0S_P2_Pos           2            /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P2               (_U(0x1) << GPIO_IMR0S_P2_Pos)
+#define GPIO_IMR0S_P3_Pos           3            /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P3               (_U(0x1) << GPIO_IMR0S_P3_Pos)
+#define GPIO_IMR0S_P4_Pos           4            /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P4               (_U(0x1) << GPIO_IMR0S_P4_Pos)
+#define GPIO_IMR0S_P5_Pos           5            /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P5               (_U(0x1) << GPIO_IMR0S_P5_Pos)
+#define GPIO_IMR0S_P6_Pos           6            /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P6               (_U(0x1) << GPIO_IMR0S_P6_Pos)
+#define GPIO_IMR0S_P7_Pos           7            /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P7               (_U(0x1) << GPIO_IMR0S_P7_Pos)
+#define GPIO_IMR0S_P8_Pos           8            /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P8               (_U(0x1) << GPIO_IMR0S_P8_Pos)
+#define GPIO_IMR0S_P9_Pos           9            /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P9               (_U(0x1) << GPIO_IMR0S_P9_Pos)
+#define GPIO_IMR0S_P10_Pos          10           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P10              (_U(0x1) << GPIO_IMR0S_P10_Pos)
+#define GPIO_IMR0S_P11_Pos          11           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P11              (_U(0x1) << GPIO_IMR0S_P11_Pos)
+#define GPIO_IMR0S_P12_Pos          12           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P12              (_U(0x1) << GPIO_IMR0S_P12_Pos)
+#define GPIO_IMR0S_P13_Pos          13           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P13              (_U(0x1) << GPIO_IMR0S_P13_Pos)
+#define GPIO_IMR0S_P14_Pos          14           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P14              (_U(0x1) << GPIO_IMR0S_P14_Pos)
+#define GPIO_IMR0S_P15_Pos          15           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P15              (_U(0x1) << GPIO_IMR0S_P15_Pos)
+#define GPIO_IMR0S_P16_Pos          16           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P16              (_U(0x1) << GPIO_IMR0S_P16_Pos)
+#define GPIO_IMR0S_P17_Pos          17           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P17              (_U(0x1) << GPIO_IMR0S_P17_Pos)
+#define GPIO_IMR0S_P18_Pos          18           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P18              (_U(0x1) << GPIO_IMR0S_P18_Pos)
+#define GPIO_IMR0S_P19_Pos          19           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P19              (_U(0x1) << GPIO_IMR0S_P19_Pos)
+#define GPIO_IMR0S_P20_Pos          20           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P20              (_U(0x1) << GPIO_IMR0S_P20_Pos)
+#define GPIO_IMR0S_P21_Pos          21           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P21              (_U(0x1) << GPIO_IMR0S_P21_Pos)
+#define GPIO_IMR0S_P22_Pos          22           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P22              (_U(0x1) << GPIO_IMR0S_P22_Pos)
+#define GPIO_IMR0S_P23_Pos          23           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P23              (_U(0x1) << GPIO_IMR0S_P23_Pos)
+#define GPIO_IMR0S_P24_Pos          24           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P24              (_U(0x1) << GPIO_IMR0S_P24_Pos)
+#define GPIO_IMR0S_P25_Pos          25           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P25              (_U(0x1) << GPIO_IMR0S_P25_Pos)
+#define GPIO_IMR0S_P26_Pos          26           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P26              (_U(0x1) << GPIO_IMR0S_P26_Pos)
+#define GPIO_IMR0S_P27_Pos          27           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P27              (_U(0x1) << GPIO_IMR0S_P27_Pos)
+#define GPIO_IMR0S_P28_Pos          28           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P28              (_U(0x1) << GPIO_IMR0S_P28_Pos)
+#define GPIO_IMR0S_P29_Pos          29           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P29              (_U(0x1) << GPIO_IMR0S_P29_Pos)
+#define GPIO_IMR0S_P30_Pos          30           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P30              (_U(0x1) << GPIO_IMR0S_P30_Pos)
+#define GPIO_IMR0S_P31_Pos          31           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
+#define GPIO_IMR0S_P31              (_U(0x1) << GPIO_IMR0S_P31_Pos)
+#define GPIO_IMR0S_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_IMR0S) MASK Register */
+
+/* -------- GPIO_IMR0C : (GPIO Offset: 0x0A8) ( /W 32) port Interrupt Mode Register 0 - Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Interrupt Mode Bit 0               */
+    uint32_t P1:1;             /*!< bit:      1  Interrupt Mode Bit 0               */
+    uint32_t P2:1;             /*!< bit:      2  Interrupt Mode Bit 0               */
+    uint32_t P3:1;             /*!< bit:      3  Interrupt Mode Bit 0               */
+    uint32_t P4:1;             /*!< bit:      4  Interrupt Mode Bit 0               */
+    uint32_t P5:1;             /*!< bit:      5  Interrupt Mode Bit 0               */
+    uint32_t P6:1;             /*!< bit:      6  Interrupt Mode Bit 0               */
+    uint32_t P7:1;             /*!< bit:      7  Interrupt Mode Bit 0               */
+    uint32_t P8:1;             /*!< bit:      8  Interrupt Mode Bit 0               */
+    uint32_t P9:1;             /*!< bit:      9  Interrupt Mode Bit 0               */
+    uint32_t P10:1;            /*!< bit:     10  Interrupt Mode Bit 0               */
+    uint32_t P11:1;            /*!< bit:     11  Interrupt Mode Bit 0               */
+    uint32_t P12:1;            /*!< bit:     12  Interrupt Mode Bit 0               */
+    uint32_t P13:1;            /*!< bit:     13  Interrupt Mode Bit 0               */
+    uint32_t P14:1;            /*!< bit:     14  Interrupt Mode Bit 0               */
+    uint32_t P15:1;            /*!< bit:     15  Interrupt Mode Bit 0               */
+    uint32_t P16:1;            /*!< bit:     16  Interrupt Mode Bit 0               */
+    uint32_t P17:1;            /*!< bit:     17  Interrupt Mode Bit 0               */
+    uint32_t P18:1;            /*!< bit:     18  Interrupt Mode Bit 0               */
+    uint32_t P19:1;            /*!< bit:     19  Interrupt Mode Bit 0               */
+    uint32_t P20:1;            /*!< bit:     20  Interrupt Mode Bit 0               */
+    uint32_t P21:1;            /*!< bit:     21  Interrupt Mode Bit 0               */
+    uint32_t P22:1;            /*!< bit:     22  Interrupt Mode Bit 0               */
+    uint32_t P23:1;            /*!< bit:     23  Interrupt Mode Bit 0               */
+    uint32_t P24:1;            /*!< bit:     24  Interrupt Mode Bit 0               */
+    uint32_t P25:1;            /*!< bit:     25  Interrupt Mode Bit 0               */
+    uint32_t P26:1;            /*!< bit:     26  Interrupt Mode Bit 0               */
+    uint32_t P27:1;            /*!< bit:     27  Interrupt Mode Bit 0               */
+    uint32_t P28:1;            /*!< bit:     28  Interrupt Mode Bit 0               */
+    uint32_t P29:1;            /*!< bit:     29  Interrupt Mode Bit 0               */
+    uint32_t P30:1;            /*!< bit:     30  Interrupt Mode Bit 0               */
+    uint32_t P31:1;            /*!< bit:     31  Interrupt Mode Bit 0               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_IMR0C_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_IMR0C_OFFSET           0x0A8        /**< \brief (GPIO_IMR0C offset) Interrupt Mode Register 0 - Clear */
+
+#define GPIO_IMR0C_P0_Pos           0            /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P0               (_U(0x1) << GPIO_IMR0C_P0_Pos)
+#define GPIO_IMR0C_P1_Pos           1            /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P1               (_U(0x1) << GPIO_IMR0C_P1_Pos)
+#define GPIO_IMR0C_P2_Pos           2            /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P2               (_U(0x1) << GPIO_IMR0C_P2_Pos)
+#define GPIO_IMR0C_P3_Pos           3            /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P3               (_U(0x1) << GPIO_IMR0C_P3_Pos)
+#define GPIO_IMR0C_P4_Pos           4            /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P4               (_U(0x1) << GPIO_IMR0C_P4_Pos)
+#define GPIO_IMR0C_P5_Pos           5            /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P5               (_U(0x1) << GPIO_IMR0C_P5_Pos)
+#define GPIO_IMR0C_P6_Pos           6            /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P6               (_U(0x1) << GPIO_IMR0C_P6_Pos)
+#define GPIO_IMR0C_P7_Pos           7            /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P7               (_U(0x1) << GPIO_IMR0C_P7_Pos)
+#define GPIO_IMR0C_P8_Pos           8            /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P8               (_U(0x1) << GPIO_IMR0C_P8_Pos)
+#define GPIO_IMR0C_P9_Pos           9            /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P9               (_U(0x1) << GPIO_IMR0C_P9_Pos)
+#define GPIO_IMR0C_P10_Pos          10           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P10              (_U(0x1) << GPIO_IMR0C_P10_Pos)
+#define GPIO_IMR0C_P11_Pos          11           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P11              (_U(0x1) << GPIO_IMR0C_P11_Pos)
+#define GPIO_IMR0C_P12_Pos          12           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P12              (_U(0x1) << GPIO_IMR0C_P12_Pos)
+#define GPIO_IMR0C_P13_Pos          13           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P13              (_U(0x1) << GPIO_IMR0C_P13_Pos)
+#define GPIO_IMR0C_P14_Pos          14           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P14              (_U(0x1) << GPIO_IMR0C_P14_Pos)
+#define GPIO_IMR0C_P15_Pos          15           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P15              (_U(0x1) << GPIO_IMR0C_P15_Pos)
+#define GPIO_IMR0C_P16_Pos          16           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P16              (_U(0x1) << GPIO_IMR0C_P16_Pos)
+#define GPIO_IMR0C_P17_Pos          17           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P17              (_U(0x1) << GPIO_IMR0C_P17_Pos)
+#define GPIO_IMR0C_P18_Pos          18           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P18              (_U(0x1) << GPIO_IMR0C_P18_Pos)
+#define GPIO_IMR0C_P19_Pos          19           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P19              (_U(0x1) << GPIO_IMR0C_P19_Pos)
+#define GPIO_IMR0C_P20_Pos          20           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P20              (_U(0x1) << GPIO_IMR0C_P20_Pos)
+#define GPIO_IMR0C_P21_Pos          21           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P21              (_U(0x1) << GPIO_IMR0C_P21_Pos)
+#define GPIO_IMR0C_P22_Pos          22           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P22              (_U(0x1) << GPIO_IMR0C_P22_Pos)
+#define GPIO_IMR0C_P23_Pos          23           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P23              (_U(0x1) << GPIO_IMR0C_P23_Pos)
+#define GPIO_IMR0C_P24_Pos          24           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P24              (_U(0x1) << GPIO_IMR0C_P24_Pos)
+#define GPIO_IMR0C_P25_Pos          25           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P25              (_U(0x1) << GPIO_IMR0C_P25_Pos)
+#define GPIO_IMR0C_P26_Pos          26           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P26              (_U(0x1) << GPIO_IMR0C_P26_Pos)
+#define GPIO_IMR0C_P27_Pos          27           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P27              (_U(0x1) << GPIO_IMR0C_P27_Pos)
+#define GPIO_IMR0C_P28_Pos          28           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P28              (_U(0x1) << GPIO_IMR0C_P28_Pos)
+#define GPIO_IMR0C_P29_Pos          29           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P29              (_U(0x1) << GPIO_IMR0C_P29_Pos)
+#define GPIO_IMR0C_P30_Pos          30           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P30              (_U(0x1) << GPIO_IMR0C_P30_Pos)
+#define GPIO_IMR0C_P31_Pos          31           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
+#define GPIO_IMR0C_P31              (_U(0x1) << GPIO_IMR0C_P31_Pos)
+#define GPIO_IMR0C_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_IMR0C) MASK Register */
+
+/* -------- GPIO_IMR0T : (GPIO Offset: 0x0AC) ( /W 32) port Interrupt Mode Register 0 - Toggle -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Interrupt Mode Bit 0               */
+    uint32_t P1:1;             /*!< bit:      1  Interrupt Mode Bit 0               */
+    uint32_t P2:1;             /*!< bit:      2  Interrupt Mode Bit 0               */
+    uint32_t P3:1;             /*!< bit:      3  Interrupt Mode Bit 0               */
+    uint32_t P4:1;             /*!< bit:      4  Interrupt Mode Bit 0               */
+    uint32_t P5:1;             /*!< bit:      5  Interrupt Mode Bit 0               */
+    uint32_t P6:1;             /*!< bit:      6  Interrupt Mode Bit 0               */
+    uint32_t P7:1;             /*!< bit:      7  Interrupt Mode Bit 0               */
+    uint32_t P8:1;             /*!< bit:      8  Interrupt Mode Bit 0               */
+    uint32_t P9:1;             /*!< bit:      9  Interrupt Mode Bit 0               */
+    uint32_t P10:1;            /*!< bit:     10  Interrupt Mode Bit 0               */
+    uint32_t P11:1;            /*!< bit:     11  Interrupt Mode Bit 0               */
+    uint32_t P12:1;            /*!< bit:     12  Interrupt Mode Bit 0               */
+    uint32_t P13:1;            /*!< bit:     13  Interrupt Mode Bit 0               */
+    uint32_t P14:1;            /*!< bit:     14  Interrupt Mode Bit 0               */
+    uint32_t P15:1;            /*!< bit:     15  Interrupt Mode Bit 0               */
+    uint32_t P16:1;            /*!< bit:     16  Interrupt Mode Bit 0               */
+    uint32_t P17:1;            /*!< bit:     17  Interrupt Mode Bit 0               */
+    uint32_t P18:1;            /*!< bit:     18  Interrupt Mode Bit 0               */
+    uint32_t P19:1;            /*!< bit:     19  Interrupt Mode Bit 0               */
+    uint32_t P20:1;            /*!< bit:     20  Interrupt Mode Bit 0               */
+    uint32_t P21:1;            /*!< bit:     21  Interrupt Mode Bit 0               */
+    uint32_t P22:1;            /*!< bit:     22  Interrupt Mode Bit 0               */
+    uint32_t P23:1;            /*!< bit:     23  Interrupt Mode Bit 0               */
+    uint32_t P24:1;            /*!< bit:     24  Interrupt Mode Bit 0               */
+    uint32_t P25:1;            /*!< bit:     25  Interrupt Mode Bit 0               */
+    uint32_t P26:1;            /*!< bit:     26  Interrupt Mode Bit 0               */
+    uint32_t P27:1;            /*!< bit:     27  Interrupt Mode Bit 0               */
+    uint32_t P28:1;            /*!< bit:     28  Interrupt Mode Bit 0               */
+    uint32_t P29:1;            /*!< bit:     29  Interrupt Mode Bit 0               */
+    uint32_t P30:1;            /*!< bit:     30  Interrupt Mode Bit 0               */
+    uint32_t P31:1;            /*!< bit:     31  Interrupt Mode Bit 0               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_IMR0T_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_IMR0T_OFFSET           0x0AC        /**< \brief (GPIO_IMR0T offset) Interrupt Mode Register 0 - Toggle */
+
+#define GPIO_IMR0T_P0_Pos           0            /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P0               (_U(0x1) << GPIO_IMR0T_P0_Pos)
+#define GPIO_IMR0T_P1_Pos           1            /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P1               (_U(0x1) << GPIO_IMR0T_P1_Pos)
+#define GPIO_IMR0T_P2_Pos           2            /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P2               (_U(0x1) << GPIO_IMR0T_P2_Pos)
+#define GPIO_IMR0T_P3_Pos           3            /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P3               (_U(0x1) << GPIO_IMR0T_P3_Pos)
+#define GPIO_IMR0T_P4_Pos           4            /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P4               (_U(0x1) << GPIO_IMR0T_P4_Pos)
+#define GPIO_IMR0T_P5_Pos           5            /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P5               (_U(0x1) << GPIO_IMR0T_P5_Pos)
+#define GPIO_IMR0T_P6_Pos           6            /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P6               (_U(0x1) << GPIO_IMR0T_P6_Pos)
+#define GPIO_IMR0T_P7_Pos           7            /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P7               (_U(0x1) << GPIO_IMR0T_P7_Pos)
+#define GPIO_IMR0T_P8_Pos           8            /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P8               (_U(0x1) << GPIO_IMR0T_P8_Pos)
+#define GPIO_IMR0T_P9_Pos           9            /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P9               (_U(0x1) << GPIO_IMR0T_P9_Pos)
+#define GPIO_IMR0T_P10_Pos          10           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P10              (_U(0x1) << GPIO_IMR0T_P10_Pos)
+#define GPIO_IMR0T_P11_Pos          11           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P11              (_U(0x1) << GPIO_IMR0T_P11_Pos)
+#define GPIO_IMR0T_P12_Pos          12           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P12              (_U(0x1) << GPIO_IMR0T_P12_Pos)
+#define GPIO_IMR0T_P13_Pos          13           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P13              (_U(0x1) << GPIO_IMR0T_P13_Pos)
+#define GPIO_IMR0T_P14_Pos          14           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P14              (_U(0x1) << GPIO_IMR0T_P14_Pos)
+#define GPIO_IMR0T_P15_Pos          15           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P15              (_U(0x1) << GPIO_IMR0T_P15_Pos)
+#define GPIO_IMR0T_P16_Pos          16           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P16              (_U(0x1) << GPIO_IMR0T_P16_Pos)
+#define GPIO_IMR0T_P17_Pos          17           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P17              (_U(0x1) << GPIO_IMR0T_P17_Pos)
+#define GPIO_IMR0T_P18_Pos          18           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P18              (_U(0x1) << GPIO_IMR0T_P18_Pos)
+#define GPIO_IMR0T_P19_Pos          19           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P19              (_U(0x1) << GPIO_IMR0T_P19_Pos)
+#define GPIO_IMR0T_P20_Pos          20           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P20              (_U(0x1) << GPIO_IMR0T_P20_Pos)
+#define GPIO_IMR0T_P21_Pos          21           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P21              (_U(0x1) << GPIO_IMR0T_P21_Pos)
+#define GPIO_IMR0T_P22_Pos          22           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P22              (_U(0x1) << GPIO_IMR0T_P22_Pos)
+#define GPIO_IMR0T_P23_Pos          23           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P23              (_U(0x1) << GPIO_IMR0T_P23_Pos)
+#define GPIO_IMR0T_P24_Pos          24           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P24              (_U(0x1) << GPIO_IMR0T_P24_Pos)
+#define GPIO_IMR0T_P25_Pos          25           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P25              (_U(0x1) << GPIO_IMR0T_P25_Pos)
+#define GPIO_IMR0T_P26_Pos          26           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P26              (_U(0x1) << GPIO_IMR0T_P26_Pos)
+#define GPIO_IMR0T_P27_Pos          27           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P27              (_U(0x1) << GPIO_IMR0T_P27_Pos)
+#define GPIO_IMR0T_P28_Pos          28           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P28              (_U(0x1) << GPIO_IMR0T_P28_Pos)
+#define GPIO_IMR0T_P29_Pos          29           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P29              (_U(0x1) << GPIO_IMR0T_P29_Pos)
+#define GPIO_IMR0T_P30_Pos          30           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P30              (_U(0x1) << GPIO_IMR0T_P30_Pos)
+#define GPIO_IMR0T_P31_Pos          31           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
+#define GPIO_IMR0T_P31              (_U(0x1) << GPIO_IMR0T_P31_Pos)
+#define GPIO_IMR0T_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_IMR0T) MASK Register */
+
+/* -------- GPIO_IMR1 : (GPIO Offset: 0x0B0) (R/W 32) port Interrupt Mode Register 1 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Interrupt Mode Bit 1               */
+    uint32_t P1:1;             /*!< bit:      1  Interrupt Mode Bit 1               */
+    uint32_t P2:1;             /*!< bit:      2  Interrupt Mode Bit 1               */
+    uint32_t P3:1;             /*!< bit:      3  Interrupt Mode Bit 1               */
+    uint32_t P4:1;             /*!< bit:      4  Interrupt Mode Bit 1               */
+    uint32_t P5:1;             /*!< bit:      5  Interrupt Mode Bit 1               */
+    uint32_t P6:1;             /*!< bit:      6  Interrupt Mode Bit 1               */
+    uint32_t P7:1;             /*!< bit:      7  Interrupt Mode Bit 1               */
+    uint32_t P8:1;             /*!< bit:      8  Interrupt Mode Bit 1               */
+    uint32_t P9:1;             /*!< bit:      9  Interrupt Mode Bit 1               */
+    uint32_t P10:1;            /*!< bit:     10  Interrupt Mode Bit 1               */
+    uint32_t P11:1;            /*!< bit:     11  Interrupt Mode Bit 1               */
+    uint32_t P12:1;            /*!< bit:     12  Interrupt Mode Bit 1               */
+    uint32_t P13:1;            /*!< bit:     13  Interrupt Mode Bit 1               */
+    uint32_t P14:1;            /*!< bit:     14  Interrupt Mode Bit 1               */
+    uint32_t P15:1;            /*!< bit:     15  Interrupt Mode Bit 1               */
+    uint32_t P16:1;            /*!< bit:     16  Interrupt Mode Bit 1               */
+    uint32_t P17:1;            /*!< bit:     17  Interrupt Mode Bit 1               */
+    uint32_t P18:1;            /*!< bit:     18  Interrupt Mode Bit 1               */
+    uint32_t P19:1;            /*!< bit:     19  Interrupt Mode Bit 1               */
+    uint32_t P20:1;            /*!< bit:     20  Interrupt Mode Bit 1               */
+    uint32_t P21:1;            /*!< bit:     21  Interrupt Mode Bit 1               */
+    uint32_t P22:1;            /*!< bit:     22  Interrupt Mode Bit 1               */
+    uint32_t P23:1;            /*!< bit:     23  Interrupt Mode Bit 1               */
+    uint32_t P24:1;            /*!< bit:     24  Interrupt Mode Bit 1               */
+    uint32_t P25:1;            /*!< bit:     25  Interrupt Mode Bit 1               */
+    uint32_t P26:1;            /*!< bit:     26  Interrupt Mode Bit 1               */
+    uint32_t P27:1;            /*!< bit:     27  Interrupt Mode Bit 1               */
+    uint32_t P28:1;            /*!< bit:     28  Interrupt Mode Bit 1               */
+    uint32_t P29:1;            /*!< bit:     29  Interrupt Mode Bit 1               */
+    uint32_t P30:1;            /*!< bit:     30  Interrupt Mode Bit 1               */
+    uint32_t P31:1;            /*!< bit:     31  Interrupt Mode Bit 1               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_IMR1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_IMR1_OFFSET            0x0B0        /**< \brief (GPIO_IMR1 offset) Interrupt Mode Register 1 */
+
+#define GPIO_IMR1_P0_Pos            0            /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P0                (_U(0x1) << GPIO_IMR1_P0_Pos)
+#define GPIO_IMR1_P1_Pos            1            /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P1                (_U(0x1) << GPIO_IMR1_P1_Pos)
+#define GPIO_IMR1_P2_Pos            2            /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P2                (_U(0x1) << GPIO_IMR1_P2_Pos)
+#define GPIO_IMR1_P3_Pos            3            /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P3                (_U(0x1) << GPIO_IMR1_P3_Pos)
+#define GPIO_IMR1_P4_Pos            4            /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P4                (_U(0x1) << GPIO_IMR1_P4_Pos)
+#define GPIO_IMR1_P5_Pos            5            /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P5                (_U(0x1) << GPIO_IMR1_P5_Pos)
+#define GPIO_IMR1_P6_Pos            6            /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P6                (_U(0x1) << GPIO_IMR1_P6_Pos)
+#define GPIO_IMR1_P7_Pos            7            /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P7                (_U(0x1) << GPIO_IMR1_P7_Pos)
+#define GPIO_IMR1_P8_Pos            8            /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P8                (_U(0x1) << GPIO_IMR1_P8_Pos)
+#define GPIO_IMR1_P9_Pos            9            /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P9                (_U(0x1) << GPIO_IMR1_P9_Pos)
+#define GPIO_IMR1_P10_Pos           10           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P10               (_U(0x1) << GPIO_IMR1_P10_Pos)
+#define GPIO_IMR1_P11_Pos           11           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P11               (_U(0x1) << GPIO_IMR1_P11_Pos)
+#define GPIO_IMR1_P12_Pos           12           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P12               (_U(0x1) << GPIO_IMR1_P12_Pos)
+#define GPIO_IMR1_P13_Pos           13           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P13               (_U(0x1) << GPIO_IMR1_P13_Pos)
+#define GPIO_IMR1_P14_Pos           14           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P14               (_U(0x1) << GPIO_IMR1_P14_Pos)
+#define GPIO_IMR1_P15_Pos           15           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P15               (_U(0x1) << GPIO_IMR1_P15_Pos)
+#define GPIO_IMR1_P16_Pos           16           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P16               (_U(0x1) << GPIO_IMR1_P16_Pos)
+#define GPIO_IMR1_P17_Pos           17           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P17               (_U(0x1) << GPIO_IMR1_P17_Pos)
+#define GPIO_IMR1_P18_Pos           18           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P18               (_U(0x1) << GPIO_IMR1_P18_Pos)
+#define GPIO_IMR1_P19_Pos           19           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P19               (_U(0x1) << GPIO_IMR1_P19_Pos)
+#define GPIO_IMR1_P20_Pos           20           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P20               (_U(0x1) << GPIO_IMR1_P20_Pos)
+#define GPIO_IMR1_P21_Pos           21           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P21               (_U(0x1) << GPIO_IMR1_P21_Pos)
+#define GPIO_IMR1_P22_Pos           22           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P22               (_U(0x1) << GPIO_IMR1_P22_Pos)
+#define GPIO_IMR1_P23_Pos           23           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P23               (_U(0x1) << GPIO_IMR1_P23_Pos)
+#define GPIO_IMR1_P24_Pos           24           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P24               (_U(0x1) << GPIO_IMR1_P24_Pos)
+#define GPIO_IMR1_P25_Pos           25           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P25               (_U(0x1) << GPIO_IMR1_P25_Pos)
+#define GPIO_IMR1_P26_Pos           26           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P26               (_U(0x1) << GPIO_IMR1_P26_Pos)
+#define GPIO_IMR1_P27_Pos           27           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P27               (_U(0x1) << GPIO_IMR1_P27_Pos)
+#define GPIO_IMR1_P28_Pos           28           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P28               (_U(0x1) << GPIO_IMR1_P28_Pos)
+#define GPIO_IMR1_P29_Pos           29           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P29               (_U(0x1) << GPIO_IMR1_P29_Pos)
+#define GPIO_IMR1_P30_Pos           30           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P30               (_U(0x1) << GPIO_IMR1_P30_Pos)
+#define GPIO_IMR1_P31_Pos           31           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
+#define GPIO_IMR1_P31               (_U(0x1) << GPIO_IMR1_P31_Pos)
+#define GPIO_IMR1_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_IMR1) MASK Register */
+
+/* -------- GPIO_IMR1S : (GPIO Offset: 0x0B4) ( /W 32) port Interrupt Mode Register 1 - Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Interrupt Mode Bit 1               */
+    uint32_t P1:1;             /*!< bit:      1  Interrupt Mode Bit 1               */
+    uint32_t P2:1;             /*!< bit:      2  Interrupt Mode Bit 1               */
+    uint32_t P3:1;             /*!< bit:      3  Interrupt Mode Bit 1               */
+    uint32_t P4:1;             /*!< bit:      4  Interrupt Mode Bit 1               */
+    uint32_t P5:1;             /*!< bit:      5  Interrupt Mode Bit 1               */
+    uint32_t P6:1;             /*!< bit:      6  Interrupt Mode Bit 1               */
+    uint32_t P7:1;             /*!< bit:      7  Interrupt Mode Bit 1               */
+    uint32_t P8:1;             /*!< bit:      8  Interrupt Mode Bit 1               */
+    uint32_t P9:1;             /*!< bit:      9  Interrupt Mode Bit 1               */
+    uint32_t P10:1;            /*!< bit:     10  Interrupt Mode Bit 1               */
+    uint32_t P11:1;            /*!< bit:     11  Interrupt Mode Bit 1               */
+    uint32_t P12:1;            /*!< bit:     12  Interrupt Mode Bit 1               */
+    uint32_t P13:1;            /*!< bit:     13  Interrupt Mode Bit 1               */
+    uint32_t P14:1;            /*!< bit:     14  Interrupt Mode Bit 1               */
+    uint32_t P15:1;            /*!< bit:     15  Interrupt Mode Bit 1               */
+    uint32_t P16:1;            /*!< bit:     16  Interrupt Mode Bit 1               */
+    uint32_t P17:1;            /*!< bit:     17  Interrupt Mode Bit 1               */
+    uint32_t P18:1;            /*!< bit:     18  Interrupt Mode Bit 1               */
+    uint32_t P19:1;            /*!< bit:     19  Interrupt Mode Bit 1               */
+    uint32_t P20:1;            /*!< bit:     20  Interrupt Mode Bit 1               */
+    uint32_t P21:1;            /*!< bit:     21  Interrupt Mode Bit 1               */
+    uint32_t P22:1;            /*!< bit:     22  Interrupt Mode Bit 1               */
+    uint32_t P23:1;            /*!< bit:     23  Interrupt Mode Bit 1               */
+    uint32_t P24:1;            /*!< bit:     24  Interrupt Mode Bit 1               */
+    uint32_t P25:1;            /*!< bit:     25  Interrupt Mode Bit 1               */
+    uint32_t P26:1;            /*!< bit:     26  Interrupt Mode Bit 1               */
+    uint32_t P27:1;            /*!< bit:     27  Interrupt Mode Bit 1               */
+    uint32_t P28:1;            /*!< bit:     28  Interrupt Mode Bit 1               */
+    uint32_t P29:1;            /*!< bit:     29  Interrupt Mode Bit 1               */
+    uint32_t P30:1;            /*!< bit:     30  Interrupt Mode Bit 1               */
+    uint32_t P31:1;            /*!< bit:     31  Interrupt Mode Bit 1               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_IMR1S_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_IMR1S_OFFSET           0x0B4        /**< \brief (GPIO_IMR1S offset) Interrupt Mode Register 1 - Set */
+
+#define GPIO_IMR1S_P0_Pos           0            /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P0               (_U(0x1) << GPIO_IMR1S_P0_Pos)
+#define GPIO_IMR1S_P1_Pos           1            /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P1               (_U(0x1) << GPIO_IMR1S_P1_Pos)
+#define GPIO_IMR1S_P2_Pos           2            /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P2               (_U(0x1) << GPIO_IMR1S_P2_Pos)
+#define GPIO_IMR1S_P3_Pos           3            /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P3               (_U(0x1) << GPIO_IMR1S_P3_Pos)
+#define GPIO_IMR1S_P4_Pos           4            /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P4               (_U(0x1) << GPIO_IMR1S_P4_Pos)
+#define GPIO_IMR1S_P5_Pos           5            /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P5               (_U(0x1) << GPIO_IMR1S_P5_Pos)
+#define GPIO_IMR1S_P6_Pos           6            /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P6               (_U(0x1) << GPIO_IMR1S_P6_Pos)
+#define GPIO_IMR1S_P7_Pos           7            /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P7               (_U(0x1) << GPIO_IMR1S_P7_Pos)
+#define GPIO_IMR1S_P8_Pos           8            /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P8               (_U(0x1) << GPIO_IMR1S_P8_Pos)
+#define GPIO_IMR1S_P9_Pos           9            /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P9               (_U(0x1) << GPIO_IMR1S_P9_Pos)
+#define GPIO_IMR1S_P10_Pos          10           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P10              (_U(0x1) << GPIO_IMR1S_P10_Pos)
+#define GPIO_IMR1S_P11_Pos          11           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P11              (_U(0x1) << GPIO_IMR1S_P11_Pos)
+#define GPIO_IMR1S_P12_Pos          12           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P12              (_U(0x1) << GPIO_IMR1S_P12_Pos)
+#define GPIO_IMR1S_P13_Pos          13           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P13              (_U(0x1) << GPIO_IMR1S_P13_Pos)
+#define GPIO_IMR1S_P14_Pos          14           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P14              (_U(0x1) << GPIO_IMR1S_P14_Pos)
+#define GPIO_IMR1S_P15_Pos          15           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P15              (_U(0x1) << GPIO_IMR1S_P15_Pos)
+#define GPIO_IMR1S_P16_Pos          16           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P16              (_U(0x1) << GPIO_IMR1S_P16_Pos)
+#define GPIO_IMR1S_P17_Pos          17           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P17              (_U(0x1) << GPIO_IMR1S_P17_Pos)
+#define GPIO_IMR1S_P18_Pos          18           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P18              (_U(0x1) << GPIO_IMR1S_P18_Pos)
+#define GPIO_IMR1S_P19_Pos          19           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P19              (_U(0x1) << GPIO_IMR1S_P19_Pos)
+#define GPIO_IMR1S_P20_Pos          20           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P20              (_U(0x1) << GPIO_IMR1S_P20_Pos)
+#define GPIO_IMR1S_P21_Pos          21           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P21              (_U(0x1) << GPIO_IMR1S_P21_Pos)
+#define GPIO_IMR1S_P22_Pos          22           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P22              (_U(0x1) << GPIO_IMR1S_P22_Pos)
+#define GPIO_IMR1S_P23_Pos          23           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P23              (_U(0x1) << GPIO_IMR1S_P23_Pos)
+#define GPIO_IMR1S_P24_Pos          24           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P24              (_U(0x1) << GPIO_IMR1S_P24_Pos)
+#define GPIO_IMR1S_P25_Pos          25           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P25              (_U(0x1) << GPIO_IMR1S_P25_Pos)
+#define GPIO_IMR1S_P26_Pos          26           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P26              (_U(0x1) << GPIO_IMR1S_P26_Pos)
+#define GPIO_IMR1S_P27_Pos          27           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P27              (_U(0x1) << GPIO_IMR1S_P27_Pos)
+#define GPIO_IMR1S_P28_Pos          28           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P28              (_U(0x1) << GPIO_IMR1S_P28_Pos)
+#define GPIO_IMR1S_P29_Pos          29           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P29              (_U(0x1) << GPIO_IMR1S_P29_Pos)
+#define GPIO_IMR1S_P30_Pos          30           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P30              (_U(0x1) << GPIO_IMR1S_P30_Pos)
+#define GPIO_IMR1S_P31_Pos          31           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
+#define GPIO_IMR1S_P31              (_U(0x1) << GPIO_IMR1S_P31_Pos)
+#define GPIO_IMR1S_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_IMR1S) MASK Register */
+
+/* -------- GPIO_IMR1C : (GPIO Offset: 0x0B8) ( /W 32) port Interrupt Mode Register 1 - Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Interrupt Mode Bit 1               */
+    uint32_t P1:1;             /*!< bit:      1  Interrupt Mode Bit 1               */
+    uint32_t P2:1;             /*!< bit:      2  Interrupt Mode Bit 1               */
+    uint32_t P3:1;             /*!< bit:      3  Interrupt Mode Bit 1               */
+    uint32_t P4:1;             /*!< bit:      4  Interrupt Mode Bit 1               */
+    uint32_t P5:1;             /*!< bit:      5  Interrupt Mode Bit 1               */
+    uint32_t P6:1;             /*!< bit:      6  Interrupt Mode Bit 1               */
+    uint32_t P7:1;             /*!< bit:      7  Interrupt Mode Bit 1               */
+    uint32_t P8:1;             /*!< bit:      8  Interrupt Mode Bit 1               */
+    uint32_t P9:1;             /*!< bit:      9  Interrupt Mode Bit 1               */
+    uint32_t P10:1;            /*!< bit:     10  Interrupt Mode Bit 1               */
+    uint32_t P11:1;            /*!< bit:     11  Interrupt Mode Bit 1               */
+    uint32_t P12:1;            /*!< bit:     12  Interrupt Mode Bit 1               */
+    uint32_t P13:1;            /*!< bit:     13  Interrupt Mode Bit 1               */
+    uint32_t P14:1;            /*!< bit:     14  Interrupt Mode Bit 1               */
+    uint32_t P15:1;            /*!< bit:     15  Interrupt Mode Bit 1               */
+    uint32_t P16:1;            /*!< bit:     16  Interrupt Mode Bit 1               */
+    uint32_t P17:1;            /*!< bit:     17  Interrupt Mode Bit 1               */
+    uint32_t P18:1;            /*!< bit:     18  Interrupt Mode Bit 1               */
+    uint32_t P19:1;            /*!< bit:     19  Interrupt Mode Bit 1               */
+    uint32_t P20:1;            /*!< bit:     20  Interrupt Mode Bit 1               */
+    uint32_t P21:1;            /*!< bit:     21  Interrupt Mode Bit 1               */
+    uint32_t P22:1;            /*!< bit:     22  Interrupt Mode Bit 1               */
+    uint32_t P23:1;            /*!< bit:     23  Interrupt Mode Bit 1               */
+    uint32_t P24:1;            /*!< bit:     24  Interrupt Mode Bit 1               */
+    uint32_t P25:1;            /*!< bit:     25  Interrupt Mode Bit 1               */
+    uint32_t P26:1;            /*!< bit:     26  Interrupt Mode Bit 1               */
+    uint32_t P27:1;            /*!< bit:     27  Interrupt Mode Bit 1               */
+    uint32_t P28:1;            /*!< bit:     28  Interrupt Mode Bit 1               */
+    uint32_t P29:1;            /*!< bit:     29  Interrupt Mode Bit 1               */
+    uint32_t P30:1;            /*!< bit:     30  Interrupt Mode Bit 1               */
+    uint32_t P31:1;            /*!< bit:     31  Interrupt Mode Bit 1               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_IMR1C_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_IMR1C_OFFSET           0x0B8        /**< \brief (GPIO_IMR1C offset) Interrupt Mode Register 1 - Clear */
+
+#define GPIO_IMR1C_P0_Pos           0            /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P0               (_U(0x1) << GPIO_IMR1C_P0_Pos)
+#define GPIO_IMR1C_P1_Pos           1            /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P1               (_U(0x1) << GPIO_IMR1C_P1_Pos)
+#define GPIO_IMR1C_P2_Pos           2            /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P2               (_U(0x1) << GPIO_IMR1C_P2_Pos)
+#define GPIO_IMR1C_P3_Pos           3            /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P3               (_U(0x1) << GPIO_IMR1C_P3_Pos)
+#define GPIO_IMR1C_P4_Pos           4            /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P4               (_U(0x1) << GPIO_IMR1C_P4_Pos)
+#define GPIO_IMR1C_P5_Pos           5            /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P5               (_U(0x1) << GPIO_IMR1C_P5_Pos)
+#define GPIO_IMR1C_P6_Pos           6            /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P6               (_U(0x1) << GPIO_IMR1C_P6_Pos)
+#define GPIO_IMR1C_P7_Pos           7            /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P7               (_U(0x1) << GPIO_IMR1C_P7_Pos)
+#define GPIO_IMR1C_P8_Pos           8            /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P8               (_U(0x1) << GPIO_IMR1C_P8_Pos)
+#define GPIO_IMR1C_P9_Pos           9            /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P9               (_U(0x1) << GPIO_IMR1C_P9_Pos)
+#define GPIO_IMR1C_P10_Pos          10           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P10              (_U(0x1) << GPIO_IMR1C_P10_Pos)
+#define GPIO_IMR1C_P11_Pos          11           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P11              (_U(0x1) << GPIO_IMR1C_P11_Pos)
+#define GPIO_IMR1C_P12_Pos          12           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P12              (_U(0x1) << GPIO_IMR1C_P12_Pos)
+#define GPIO_IMR1C_P13_Pos          13           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P13              (_U(0x1) << GPIO_IMR1C_P13_Pos)
+#define GPIO_IMR1C_P14_Pos          14           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P14              (_U(0x1) << GPIO_IMR1C_P14_Pos)
+#define GPIO_IMR1C_P15_Pos          15           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P15              (_U(0x1) << GPIO_IMR1C_P15_Pos)
+#define GPIO_IMR1C_P16_Pos          16           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P16              (_U(0x1) << GPIO_IMR1C_P16_Pos)
+#define GPIO_IMR1C_P17_Pos          17           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P17              (_U(0x1) << GPIO_IMR1C_P17_Pos)
+#define GPIO_IMR1C_P18_Pos          18           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P18              (_U(0x1) << GPIO_IMR1C_P18_Pos)
+#define GPIO_IMR1C_P19_Pos          19           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P19              (_U(0x1) << GPIO_IMR1C_P19_Pos)
+#define GPIO_IMR1C_P20_Pos          20           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P20              (_U(0x1) << GPIO_IMR1C_P20_Pos)
+#define GPIO_IMR1C_P21_Pos          21           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P21              (_U(0x1) << GPIO_IMR1C_P21_Pos)
+#define GPIO_IMR1C_P22_Pos          22           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P22              (_U(0x1) << GPIO_IMR1C_P22_Pos)
+#define GPIO_IMR1C_P23_Pos          23           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P23              (_U(0x1) << GPIO_IMR1C_P23_Pos)
+#define GPIO_IMR1C_P24_Pos          24           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P24              (_U(0x1) << GPIO_IMR1C_P24_Pos)
+#define GPIO_IMR1C_P25_Pos          25           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P25              (_U(0x1) << GPIO_IMR1C_P25_Pos)
+#define GPIO_IMR1C_P26_Pos          26           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P26              (_U(0x1) << GPIO_IMR1C_P26_Pos)
+#define GPIO_IMR1C_P27_Pos          27           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P27              (_U(0x1) << GPIO_IMR1C_P27_Pos)
+#define GPIO_IMR1C_P28_Pos          28           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P28              (_U(0x1) << GPIO_IMR1C_P28_Pos)
+#define GPIO_IMR1C_P29_Pos          29           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P29              (_U(0x1) << GPIO_IMR1C_P29_Pos)
+#define GPIO_IMR1C_P30_Pos          30           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P30              (_U(0x1) << GPIO_IMR1C_P30_Pos)
+#define GPIO_IMR1C_P31_Pos          31           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
+#define GPIO_IMR1C_P31              (_U(0x1) << GPIO_IMR1C_P31_Pos)
+#define GPIO_IMR1C_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_IMR1C) MASK Register */
+
+/* -------- GPIO_IMR1T : (GPIO Offset: 0x0BC) ( /W 32) port Interrupt Mode Register 1 - Toggle -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Interrupt Mode Bit 1               */
+    uint32_t P1:1;             /*!< bit:      1  Interrupt Mode Bit 1               */
+    uint32_t P2:1;             /*!< bit:      2  Interrupt Mode Bit 1               */
+    uint32_t P3:1;             /*!< bit:      3  Interrupt Mode Bit 1               */
+    uint32_t P4:1;             /*!< bit:      4  Interrupt Mode Bit 1               */
+    uint32_t P5:1;             /*!< bit:      5  Interrupt Mode Bit 1               */
+    uint32_t P6:1;             /*!< bit:      6  Interrupt Mode Bit 1               */
+    uint32_t P7:1;             /*!< bit:      7  Interrupt Mode Bit 1               */
+    uint32_t P8:1;             /*!< bit:      8  Interrupt Mode Bit 1               */
+    uint32_t P9:1;             /*!< bit:      9  Interrupt Mode Bit 1               */
+    uint32_t P10:1;            /*!< bit:     10  Interrupt Mode Bit 1               */
+    uint32_t P11:1;            /*!< bit:     11  Interrupt Mode Bit 1               */
+    uint32_t P12:1;            /*!< bit:     12  Interrupt Mode Bit 1               */
+    uint32_t P13:1;            /*!< bit:     13  Interrupt Mode Bit 1               */
+    uint32_t P14:1;            /*!< bit:     14  Interrupt Mode Bit 1               */
+    uint32_t P15:1;            /*!< bit:     15  Interrupt Mode Bit 1               */
+    uint32_t P16:1;            /*!< bit:     16  Interrupt Mode Bit 1               */
+    uint32_t P17:1;            /*!< bit:     17  Interrupt Mode Bit 1               */
+    uint32_t P18:1;            /*!< bit:     18  Interrupt Mode Bit 1               */
+    uint32_t P19:1;            /*!< bit:     19  Interrupt Mode Bit 1               */
+    uint32_t P20:1;            /*!< bit:     20  Interrupt Mode Bit 1               */
+    uint32_t P21:1;            /*!< bit:     21  Interrupt Mode Bit 1               */
+    uint32_t P22:1;            /*!< bit:     22  Interrupt Mode Bit 1               */
+    uint32_t P23:1;            /*!< bit:     23  Interrupt Mode Bit 1               */
+    uint32_t P24:1;            /*!< bit:     24  Interrupt Mode Bit 1               */
+    uint32_t P25:1;            /*!< bit:     25  Interrupt Mode Bit 1               */
+    uint32_t P26:1;            /*!< bit:     26  Interrupt Mode Bit 1               */
+    uint32_t P27:1;            /*!< bit:     27  Interrupt Mode Bit 1               */
+    uint32_t P28:1;            /*!< bit:     28  Interrupt Mode Bit 1               */
+    uint32_t P29:1;            /*!< bit:     29  Interrupt Mode Bit 1               */
+    uint32_t P30:1;            /*!< bit:     30  Interrupt Mode Bit 1               */
+    uint32_t P31:1;            /*!< bit:     31  Interrupt Mode Bit 1               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_IMR1T_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_IMR1T_OFFSET           0x0BC        /**< \brief (GPIO_IMR1T offset) Interrupt Mode Register 1 - Toggle */
+
+#define GPIO_IMR1T_P0_Pos           0            /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P0               (_U(0x1) << GPIO_IMR1T_P0_Pos)
+#define GPIO_IMR1T_P1_Pos           1            /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P1               (_U(0x1) << GPIO_IMR1T_P1_Pos)
+#define GPIO_IMR1T_P2_Pos           2            /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P2               (_U(0x1) << GPIO_IMR1T_P2_Pos)
+#define GPIO_IMR1T_P3_Pos           3            /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P3               (_U(0x1) << GPIO_IMR1T_P3_Pos)
+#define GPIO_IMR1T_P4_Pos           4            /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P4               (_U(0x1) << GPIO_IMR1T_P4_Pos)
+#define GPIO_IMR1T_P5_Pos           5            /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P5               (_U(0x1) << GPIO_IMR1T_P5_Pos)
+#define GPIO_IMR1T_P6_Pos           6            /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P6               (_U(0x1) << GPIO_IMR1T_P6_Pos)
+#define GPIO_IMR1T_P7_Pos           7            /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P7               (_U(0x1) << GPIO_IMR1T_P7_Pos)
+#define GPIO_IMR1T_P8_Pos           8            /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P8               (_U(0x1) << GPIO_IMR1T_P8_Pos)
+#define GPIO_IMR1T_P9_Pos           9            /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P9               (_U(0x1) << GPIO_IMR1T_P9_Pos)
+#define GPIO_IMR1T_P10_Pos          10           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P10              (_U(0x1) << GPIO_IMR1T_P10_Pos)
+#define GPIO_IMR1T_P11_Pos          11           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P11              (_U(0x1) << GPIO_IMR1T_P11_Pos)
+#define GPIO_IMR1T_P12_Pos          12           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P12              (_U(0x1) << GPIO_IMR1T_P12_Pos)
+#define GPIO_IMR1T_P13_Pos          13           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P13              (_U(0x1) << GPIO_IMR1T_P13_Pos)
+#define GPIO_IMR1T_P14_Pos          14           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P14              (_U(0x1) << GPIO_IMR1T_P14_Pos)
+#define GPIO_IMR1T_P15_Pos          15           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P15              (_U(0x1) << GPIO_IMR1T_P15_Pos)
+#define GPIO_IMR1T_P16_Pos          16           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P16              (_U(0x1) << GPIO_IMR1T_P16_Pos)
+#define GPIO_IMR1T_P17_Pos          17           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P17              (_U(0x1) << GPIO_IMR1T_P17_Pos)
+#define GPIO_IMR1T_P18_Pos          18           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P18              (_U(0x1) << GPIO_IMR1T_P18_Pos)
+#define GPIO_IMR1T_P19_Pos          19           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P19              (_U(0x1) << GPIO_IMR1T_P19_Pos)
+#define GPIO_IMR1T_P20_Pos          20           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P20              (_U(0x1) << GPIO_IMR1T_P20_Pos)
+#define GPIO_IMR1T_P21_Pos          21           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P21              (_U(0x1) << GPIO_IMR1T_P21_Pos)
+#define GPIO_IMR1T_P22_Pos          22           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P22              (_U(0x1) << GPIO_IMR1T_P22_Pos)
+#define GPIO_IMR1T_P23_Pos          23           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P23              (_U(0x1) << GPIO_IMR1T_P23_Pos)
+#define GPIO_IMR1T_P24_Pos          24           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P24              (_U(0x1) << GPIO_IMR1T_P24_Pos)
+#define GPIO_IMR1T_P25_Pos          25           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P25              (_U(0x1) << GPIO_IMR1T_P25_Pos)
+#define GPIO_IMR1T_P26_Pos          26           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P26              (_U(0x1) << GPIO_IMR1T_P26_Pos)
+#define GPIO_IMR1T_P27_Pos          27           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P27              (_U(0x1) << GPIO_IMR1T_P27_Pos)
+#define GPIO_IMR1T_P28_Pos          28           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P28              (_U(0x1) << GPIO_IMR1T_P28_Pos)
+#define GPIO_IMR1T_P29_Pos          29           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P29              (_U(0x1) << GPIO_IMR1T_P29_Pos)
+#define GPIO_IMR1T_P30_Pos          30           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P30              (_U(0x1) << GPIO_IMR1T_P30_Pos)
+#define GPIO_IMR1T_P31_Pos          31           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
+#define GPIO_IMR1T_P31              (_U(0x1) << GPIO_IMR1T_P31_Pos)
+#define GPIO_IMR1T_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_IMR1T) MASK Register */
+
+/* -------- GPIO_GFER : (GPIO Offset: 0x0C0) (R/W 32) port Glitch Filter Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Glitch Filter Enable               */
+    uint32_t P1:1;             /*!< bit:      1  Glitch Filter Enable               */
+    uint32_t P2:1;             /*!< bit:      2  Glitch Filter Enable               */
+    uint32_t P3:1;             /*!< bit:      3  Glitch Filter Enable               */
+    uint32_t P4:1;             /*!< bit:      4  Glitch Filter Enable               */
+    uint32_t P5:1;             /*!< bit:      5  Glitch Filter Enable               */
+    uint32_t P6:1;             /*!< bit:      6  Glitch Filter Enable               */
+    uint32_t P7:1;             /*!< bit:      7  Glitch Filter Enable               */
+    uint32_t P8:1;             /*!< bit:      8  Glitch Filter Enable               */
+    uint32_t P9:1;             /*!< bit:      9  Glitch Filter Enable               */
+    uint32_t P10:1;            /*!< bit:     10  Glitch Filter Enable               */
+    uint32_t P11:1;            /*!< bit:     11  Glitch Filter Enable               */
+    uint32_t P12:1;            /*!< bit:     12  Glitch Filter Enable               */
+    uint32_t P13:1;            /*!< bit:     13  Glitch Filter Enable               */
+    uint32_t P14:1;            /*!< bit:     14  Glitch Filter Enable               */
+    uint32_t P15:1;            /*!< bit:     15  Glitch Filter Enable               */
+    uint32_t P16:1;            /*!< bit:     16  Glitch Filter Enable               */
+    uint32_t P17:1;            /*!< bit:     17  Glitch Filter Enable               */
+    uint32_t P18:1;            /*!< bit:     18  Glitch Filter Enable               */
+    uint32_t P19:1;            /*!< bit:     19  Glitch Filter Enable               */
+    uint32_t P20:1;            /*!< bit:     20  Glitch Filter Enable               */
+    uint32_t P21:1;            /*!< bit:     21  Glitch Filter Enable               */
+    uint32_t P22:1;            /*!< bit:     22  Glitch Filter Enable               */
+    uint32_t P23:1;            /*!< bit:     23  Glitch Filter Enable               */
+    uint32_t P24:1;            /*!< bit:     24  Glitch Filter Enable               */
+    uint32_t P25:1;            /*!< bit:     25  Glitch Filter Enable               */
+    uint32_t P26:1;            /*!< bit:     26  Glitch Filter Enable               */
+    uint32_t P27:1;            /*!< bit:     27  Glitch Filter Enable               */
+    uint32_t P28:1;            /*!< bit:     28  Glitch Filter Enable               */
+    uint32_t P29:1;            /*!< bit:     29  Glitch Filter Enable               */
+    uint32_t P30:1;            /*!< bit:     30  Glitch Filter Enable               */
+    uint32_t P31:1;            /*!< bit:     31  Glitch Filter Enable               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_GFER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_GFER_OFFSET            0x0C0        /**< \brief (GPIO_GFER offset) Glitch Filter Enable Register */
+
+#define GPIO_GFER_P0_Pos            0            /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P0                (_U(0x1) << GPIO_GFER_P0_Pos)
+#define GPIO_GFER_P1_Pos            1            /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P1                (_U(0x1) << GPIO_GFER_P1_Pos)
+#define GPIO_GFER_P2_Pos            2            /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P2                (_U(0x1) << GPIO_GFER_P2_Pos)
+#define GPIO_GFER_P3_Pos            3            /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P3                (_U(0x1) << GPIO_GFER_P3_Pos)
+#define GPIO_GFER_P4_Pos            4            /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P4                (_U(0x1) << GPIO_GFER_P4_Pos)
+#define GPIO_GFER_P5_Pos            5            /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P5                (_U(0x1) << GPIO_GFER_P5_Pos)
+#define GPIO_GFER_P6_Pos            6            /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P6                (_U(0x1) << GPIO_GFER_P6_Pos)
+#define GPIO_GFER_P7_Pos            7            /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P7                (_U(0x1) << GPIO_GFER_P7_Pos)
+#define GPIO_GFER_P8_Pos            8            /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P8                (_U(0x1) << GPIO_GFER_P8_Pos)
+#define GPIO_GFER_P9_Pos            9            /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P9                (_U(0x1) << GPIO_GFER_P9_Pos)
+#define GPIO_GFER_P10_Pos           10           /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P10               (_U(0x1) << GPIO_GFER_P10_Pos)
+#define GPIO_GFER_P11_Pos           11           /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P11               (_U(0x1) << GPIO_GFER_P11_Pos)
+#define GPIO_GFER_P12_Pos           12           /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P12               (_U(0x1) << GPIO_GFER_P12_Pos)
+#define GPIO_GFER_P13_Pos           13           /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P13               (_U(0x1) << GPIO_GFER_P13_Pos)
+#define GPIO_GFER_P14_Pos           14           /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P14               (_U(0x1) << GPIO_GFER_P14_Pos)
+#define GPIO_GFER_P15_Pos           15           /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P15               (_U(0x1) << GPIO_GFER_P15_Pos)
+#define GPIO_GFER_P16_Pos           16           /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P16               (_U(0x1) << GPIO_GFER_P16_Pos)
+#define GPIO_GFER_P17_Pos           17           /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P17               (_U(0x1) << GPIO_GFER_P17_Pos)
+#define GPIO_GFER_P18_Pos           18           /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P18               (_U(0x1) << GPIO_GFER_P18_Pos)
+#define GPIO_GFER_P19_Pos           19           /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P19               (_U(0x1) << GPIO_GFER_P19_Pos)
+#define GPIO_GFER_P20_Pos           20           /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P20               (_U(0x1) << GPIO_GFER_P20_Pos)
+#define GPIO_GFER_P21_Pos           21           /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P21               (_U(0x1) << GPIO_GFER_P21_Pos)
+#define GPIO_GFER_P22_Pos           22           /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P22               (_U(0x1) << GPIO_GFER_P22_Pos)
+#define GPIO_GFER_P23_Pos           23           /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P23               (_U(0x1) << GPIO_GFER_P23_Pos)
+#define GPIO_GFER_P24_Pos           24           /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P24               (_U(0x1) << GPIO_GFER_P24_Pos)
+#define GPIO_GFER_P25_Pos           25           /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P25               (_U(0x1) << GPIO_GFER_P25_Pos)
+#define GPIO_GFER_P26_Pos           26           /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P26               (_U(0x1) << GPIO_GFER_P26_Pos)
+#define GPIO_GFER_P27_Pos           27           /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P27               (_U(0x1) << GPIO_GFER_P27_Pos)
+#define GPIO_GFER_P28_Pos           28           /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P28               (_U(0x1) << GPIO_GFER_P28_Pos)
+#define GPIO_GFER_P29_Pos           29           /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P29               (_U(0x1) << GPIO_GFER_P29_Pos)
+#define GPIO_GFER_P30_Pos           30           /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P30               (_U(0x1) << GPIO_GFER_P30_Pos)
+#define GPIO_GFER_P31_Pos           31           /**< \brief (GPIO_GFER) Glitch Filter Enable */
+#define GPIO_GFER_P31               (_U(0x1) << GPIO_GFER_P31_Pos)
+#define GPIO_GFER_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_GFER) MASK Register */
+
+/* -------- GPIO_GFERS : (GPIO Offset: 0x0C4) ( /W 32) port Glitch Filter Enable Register - Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Glitch Filter Enable               */
+    uint32_t P1:1;             /*!< bit:      1  Glitch Filter Enable               */
+    uint32_t P2:1;             /*!< bit:      2  Glitch Filter Enable               */
+    uint32_t P3:1;             /*!< bit:      3  Glitch Filter Enable               */
+    uint32_t P4:1;             /*!< bit:      4  Glitch Filter Enable               */
+    uint32_t P5:1;             /*!< bit:      5  Glitch Filter Enable               */
+    uint32_t P6:1;             /*!< bit:      6  Glitch Filter Enable               */
+    uint32_t P7:1;             /*!< bit:      7  Glitch Filter Enable               */
+    uint32_t P8:1;             /*!< bit:      8  Glitch Filter Enable               */
+    uint32_t P9:1;             /*!< bit:      9  Glitch Filter Enable               */
+    uint32_t P10:1;            /*!< bit:     10  Glitch Filter Enable               */
+    uint32_t P11:1;            /*!< bit:     11  Glitch Filter Enable               */
+    uint32_t P12:1;            /*!< bit:     12  Glitch Filter Enable               */
+    uint32_t P13:1;            /*!< bit:     13  Glitch Filter Enable               */
+    uint32_t P14:1;            /*!< bit:     14  Glitch Filter Enable               */
+    uint32_t P15:1;            /*!< bit:     15  Glitch Filter Enable               */
+    uint32_t P16:1;            /*!< bit:     16  Glitch Filter Enable               */
+    uint32_t P17:1;            /*!< bit:     17  Glitch Filter Enable               */
+    uint32_t P18:1;            /*!< bit:     18  Glitch Filter Enable               */
+    uint32_t P19:1;            /*!< bit:     19  Glitch Filter Enable               */
+    uint32_t P20:1;            /*!< bit:     20  Glitch Filter Enable               */
+    uint32_t P21:1;            /*!< bit:     21  Glitch Filter Enable               */
+    uint32_t P22:1;            /*!< bit:     22  Glitch Filter Enable               */
+    uint32_t P23:1;            /*!< bit:     23  Glitch Filter Enable               */
+    uint32_t P24:1;            /*!< bit:     24  Glitch Filter Enable               */
+    uint32_t P25:1;            /*!< bit:     25  Glitch Filter Enable               */
+    uint32_t P26:1;            /*!< bit:     26  Glitch Filter Enable               */
+    uint32_t P27:1;            /*!< bit:     27  Glitch Filter Enable               */
+    uint32_t P28:1;            /*!< bit:     28  Glitch Filter Enable               */
+    uint32_t P29:1;            /*!< bit:     29  Glitch Filter Enable               */
+    uint32_t P30:1;            /*!< bit:     30  Glitch Filter Enable               */
+    uint32_t P31:1;            /*!< bit:     31  Glitch Filter Enable               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_GFERS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_GFERS_OFFSET           0x0C4        /**< \brief (GPIO_GFERS offset) Glitch Filter Enable Register - Set */
+
+#define GPIO_GFERS_P0_Pos           0            /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P0               (_U(0x1) << GPIO_GFERS_P0_Pos)
+#define GPIO_GFERS_P1_Pos           1            /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P1               (_U(0x1) << GPIO_GFERS_P1_Pos)
+#define GPIO_GFERS_P2_Pos           2            /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P2               (_U(0x1) << GPIO_GFERS_P2_Pos)
+#define GPIO_GFERS_P3_Pos           3            /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P3               (_U(0x1) << GPIO_GFERS_P3_Pos)
+#define GPIO_GFERS_P4_Pos           4            /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P4               (_U(0x1) << GPIO_GFERS_P4_Pos)
+#define GPIO_GFERS_P5_Pos           5            /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P5               (_U(0x1) << GPIO_GFERS_P5_Pos)
+#define GPIO_GFERS_P6_Pos           6            /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P6               (_U(0x1) << GPIO_GFERS_P6_Pos)
+#define GPIO_GFERS_P7_Pos           7            /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P7               (_U(0x1) << GPIO_GFERS_P7_Pos)
+#define GPIO_GFERS_P8_Pos           8            /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P8               (_U(0x1) << GPIO_GFERS_P8_Pos)
+#define GPIO_GFERS_P9_Pos           9            /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P9               (_U(0x1) << GPIO_GFERS_P9_Pos)
+#define GPIO_GFERS_P10_Pos          10           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P10              (_U(0x1) << GPIO_GFERS_P10_Pos)
+#define GPIO_GFERS_P11_Pos          11           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P11              (_U(0x1) << GPIO_GFERS_P11_Pos)
+#define GPIO_GFERS_P12_Pos          12           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P12              (_U(0x1) << GPIO_GFERS_P12_Pos)
+#define GPIO_GFERS_P13_Pos          13           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P13              (_U(0x1) << GPIO_GFERS_P13_Pos)
+#define GPIO_GFERS_P14_Pos          14           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P14              (_U(0x1) << GPIO_GFERS_P14_Pos)
+#define GPIO_GFERS_P15_Pos          15           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P15              (_U(0x1) << GPIO_GFERS_P15_Pos)
+#define GPIO_GFERS_P16_Pos          16           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P16              (_U(0x1) << GPIO_GFERS_P16_Pos)
+#define GPIO_GFERS_P17_Pos          17           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P17              (_U(0x1) << GPIO_GFERS_P17_Pos)
+#define GPIO_GFERS_P18_Pos          18           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P18              (_U(0x1) << GPIO_GFERS_P18_Pos)
+#define GPIO_GFERS_P19_Pos          19           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P19              (_U(0x1) << GPIO_GFERS_P19_Pos)
+#define GPIO_GFERS_P20_Pos          20           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P20              (_U(0x1) << GPIO_GFERS_P20_Pos)
+#define GPIO_GFERS_P21_Pos          21           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P21              (_U(0x1) << GPIO_GFERS_P21_Pos)
+#define GPIO_GFERS_P22_Pos          22           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P22              (_U(0x1) << GPIO_GFERS_P22_Pos)
+#define GPIO_GFERS_P23_Pos          23           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P23              (_U(0x1) << GPIO_GFERS_P23_Pos)
+#define GPIO_GFERS_P24_Pos          24           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P24              (_U(0x1) << GPIO_GFERS_P24_Pos)
+#define GPIO_GFERS_P25_Pos          25           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P25              (_U(0x1) << GPIO_GFERS_P25_Pos)
+#define GPIO_GFERS_P26_Pos          26           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P26              (_U(0x1) << GPIO_GFERS_P26_Pos)
+#define GPIO_GFERS_P27_Pos          27           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P27              (_U(0x1) << GPIO_GFERS_P27_Pos)
+#define GPIO_GFERS_P28_Pos          28           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P28              (_U(0x1) << GPIO_GFERS_P28_Pos)
+#define GPIO_GFERS_P29_Pos          29           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P29              (_U(0x1) << GPIO_GFERS_P29_Pos)
+#define GPIO_GFERS_P30_Pos          30           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P30              (_U(0x1) << GPIO_GFERS_P30_Pos)
+#define GPIO_GFERS_P31_Pos          31           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
+#define GPIO_GFERS_P31              (_U(0x1) << GPIO_GFERS_P31_Pos)
+#define GPIO_GFERS_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_GFERS) MASK Register */
+
+/* -------- GPIO_GFERC : (GPIO Offset: 0x0C8) ( /W 32) port Glitch Filter Enable Register - Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Glitch Filter Enable               */
+    uint32_t P1:1;             /*!< bit:      1  Glitch Filter Enable               */
+    uint32_t P2:1;             /*!< bit:      2  Glitch Filter Enable               */
+    uint32_t P3:1;             /*!< bit:      3  Glitch Filter Enable               */
+    uint32_t P4:1;             /*!< bit:      4  Glitch Filter Enable               */
+    uint32_t P5:1;             /*!< bit:      5  Glitch Filter Enable               */
+    uint32_t P6:1;             /*!< bit:      6  Glitch Filter Enable               */
+    uint32_t P7:1;             /*!< bit:      7  Glitch Filter Enable               */
+    uint32_t P8:1;             /*!< bit:      8  Glitch Filter Enable               */
+    uint32_t P9:1;             /*!< bit:      9  Glitch Filter Enable               */
+    uint32_t P10:1;            /*!< bit:     10  Glitch Filter Enable               */
+    uint32_t P11:1;            /*!< bit:     11  Glitch Filter Enable               */
+    uint32_t P12:1;            /*!< bit:     12  Glitch Filter Enable               */
+    uint32_t P13:1;            /*!< bit:     13  Glitch Filter Enable               */
+    uint32_t P14:1;            /*!< bit:     14  Glitch Filter Enable               */
+    uint32_t P15:1;            /*!< bit:     15  Glitch Filter Enable               */
+    uint32_t P16:1;            /*!< bit:     16  Glitch Filter Enable               */
+    uint32_t P17:1;            /*!< bit:     17  Glitch Filter Enable               */
+    uint32_t P18:1;            /*!< bit:     18  Glitch Filter Enable               */
+    uint32_t P19:1;            /*!< bit:     19  Glitch Filter Enable               */
+    uint32_t P20:1;            /*!< bit:     20  Glitch Filter Enable               */
+    uint32_t P21:1;            /*!< bit:     21  Glitch Filter Enable               */
+    uint32_t P22:1;            /*!< bit:     22  Glitch Filter Enable               */
+    uint32_t P23:1;            /*!< bit:     23  Glitch Filter Enable               */
+    uint32_t P24:1;            /*!< bit:     24  Glitch Filter Enable               */
+    uint32_t P25:1;            /*!< bit:     25  Glitch Filter Enable               */
+    uint32_t P26:1;            /*!< bit:     26  Glitch Filter Enable               */
+    uint32_t P27:1;            /*!< bit:     27  Glitch Filter Enable               */
+    uint32_t P28:1;            /*!< bit:     28  Glitch Filter Enable               */
+    uint32_t P29:1;            /*!< bit:     29  Glitch Filter Enable               */
+    uint32_t P30:1;            /*!< bit:     30  Glitch Filter Enable               */
+    uint32_t P31:1;            /*!< bit:     31  Glitch Filter Enable               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_GFERC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_GFERC_OFFSET           0x0C8        /**< \brief (GPIO_GFERC offset) Glitch Filter Enable Register - Clear */
+
+#define GPIO_GFERC_P0_Pos           0            /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P0               (_U(0x1) << GPIO_GFERC_P0_Pos)
+#define GPIO_GFERC_P1_Pos           1            /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P1               (_U(0x1) << GPIO_GFERC_P1_Pos)
+#define GPIO_GFERC_P2_Pos           2            /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P2               (_U(0x1) << GPIO_GFERC_P2_Pos)
+#define GPIO_GFERC_P3_Pos           3            /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P3               (_U(0x1) << GPIO_GFERC_P3_Pos)
+#define GPIO_GFERC_P4_Pos           4            /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P4               (_U(0x1) << GPIO_GFERC_P4_Pos)
+#define GPIO_GFERC_P5_Pos           5            /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P5               (_U(0x1) << GPIO_GFERC_P5_Pos)
+#define GPIO_GFERC_P6_Pos           6            /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P6               (_U(0x1) << GPIO_GFERC_P6_Pos)
+#define GPIO_GFERC_P7_Pos           7            /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P7               (_U(0x1) << GPIO_GFERC_P7_Pos)
+#define GPIO_GFERC_P8_Pos           8            /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P8               (_U(0x1) << GPIO_GFERC_P8_Pos)
+#define GPIO_GFERC_P9_Pos           9            /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P9               (_U(0x1) << GPIO_GFERC_P9_Pos)
+#define GPIO_GFERC_P10_Pos          10           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P10              (_U(0x1) << GPIO_GFERC_P10_Pos)
+#define GPIO_GFERC_P11_Pos          11           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P11              (_U(0x1) << GPIO_GFERC_P11_Pos)
+#define GPIO_GFERC_P12_Pos          12           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P12              (_U(0x1) << GPIO_GFERC_P12_Pos)
+#define GPIO_GFERC_P13_Pos          13           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P13              (_U(0x1) << GPIO_GFERC_P13_Pos)
+#define GPIO_GFERC_P14_Pos          14           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P14              (_U(0x1) << GPIO_GFERC_P14_Pos)
+#define GPIO_GFERC_P15_Pos          15           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P15              (_U(0x1) << GPIO_GFERC_P15_Pos)
+#define GPIO_GFERC_P16_Pos          16           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P16              (_U(0x1) << GPIO_GFERC_P16_Pos)
+#define GPIO_GFERC_P17_Pos          17           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P17              (_U(0x1) << GPIO_GFERC_P17_Pos)
+#define GPIO_GFERC_P18_Pos          18           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P18              (_U(0x1) << GPIO_GFERC_P18_Pos)
+#define GPIO_GFERC_P19_Pos          19           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P19              (_U(0x1) << GPIO_GFERC_P19_Pos)
+#define GPIO_GFERC_P20_Pos          20           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P20              (_U(0x1) << GPIO_GFERC_P20_Pos)
+#define GPIO_GFERC_P21_Pos          21           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P21              (_U(0x1) << GPIO_GFERC_P21_Pos)
+#define GPIO_GFERC_P22_Pos          22           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P22              (_U(0x1) << GPIO_GFERC_P22_Pos)
+#define GPIO_GFERC_P23_Pos          23           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P23              (_U(0x1) << GPIO_GFERC_P23_Pos)
+#define GPIO_GFERC_P24_Pos          24           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P24              (_U(0x1) << GPIO_GFERC_P24_Pos)
+#define GPIO_GFERC_P25_Pos          25           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P25              (_U(0x1) << GPIO_GFERC_P25_Pos)
+#define GPIO_GFERC_P26_Pos          26           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P26              (_U(0x1) << GPIO_GFERC_P26_Pos)
+#define GPIO_GFERC_P27_Pos          27           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P27              (_U(0x1) << GPIO_GFERC_P27_Pos)
+#define GPIO_GFERC_P28_Pos          28           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P28              (_U(0x1) << GPIO_GFERC_P28_Pos)
+#define GPIO_GFERC_P29_Pos          29           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P29              (_U(0x1) << GPIO_GFERC_P29_Pos)
+#define GPIO_GFERC_P30_Pos          30           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P30              (_U(0x1) << GPIO_GFERC_P30_Pos)
+#define GPIO_GFERC_P31_Pos          31           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
+#define GPIO_GFERC_P31              (_U(0x1) << GPIO_GFERC_P31_Pos)
+#define GPIO_GFERC_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_GFERC) MASK Register */
+
+/* -------- GPIO_GFERT : (GPIO Offset: 0x0CC) ( /W 32) port Glitch Filter Enable Register - Toggle -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Glitch Filter Enable               */
+    uint32_t P1:1;             /*!< bit:      1  Glitch Filter Enable               */
+    uint32_t P2:1;             /*!< bit:      2  Glitch Filter Enable               */
+    uint32_t P3:1;             /*!< bit:      3  Glitch Filter Enable               */
+    uint32_t P4:1;             /*!< bit:      4  Glitch Filter Enable               */
+    uint32_t P5:1;             /*!< bit:      5  Glitch Filter Enable               */
+    uint32_t P6:1;             /*!< bit:      6  Glitch Filter Enable               */
+    uint32_t P7:1;             /*!< bit:      7  Glitch Filter Enable               */
+    uint32_t P8:1;             /*!< bit:      8  Glitch Filter Enable               */
+    uint32_t P9:1;             /*!< bit:      9  Glitch Filter Enable               */
+    uint32_t P10:1;            /*!< bit:     10  Glitch Filter Enable               */
+    uint32_t P11:1;            /*!< bit:     11  Glitch Filter Enable               */
+    uint32_t P12:1;            /*!< bit:     12  Glitch Filter Enable               */
+    uint32_t P13:1;            /*!< bit:     13  Glitch Filter Enable               */
+    uint32_t P14:1;            /*!< bit:     14  Glitch Filter Enable               */
+    uint32_t P15:1;            /*!< bit:     15  Glitch Filter Enable               */
+    uint32_t P16:1;            /*!< bit:     16  Glitch Filter Enable               */
+    uint32_t P17:1;            /*!< bit:     17  Glitch Filter Enable               */
+    uint32_t P18:1;            /*!< bit:     18  Glitch Filter Enable               */
+    uint32_t P19:1;            /*!< bit:     19  Glitch Filter Enable               */
+    uint32_t P20:1;            /*!< bit:     20  Glitch Filter Enable               */
+    uint32_t P21:1;            /*!< bit:     21  Glitch Filter Enable               */
+    uint32_t P22:1;            /*!< bit:     22  Glitch Filter Enable               */
+    uint32_t P23:1;            /*!< bit:     23  Glitch Filter Enable               */
+    uint32_t P24:1;            /*!< bit:     24  Glitch Filter Enable               */
+    uint32_t P25:1;            /*!< bit:     25  Glitch Filter Enable               */
+    uint32_t P26:1;            /*!< bit:     26  Glitch Filter Enable               */
+    uint32_t P27:1;            /*!< bit:     27  Glitch Filter Enable               */
+    uint32_t P28:1;            /*!< bit:     28  Glitch Filter Enable               */
+    uint32_t P29:1;            /*!< bit:     29  Glitch Filter Enable               */
+    uint32_t P30:1;            /*!< bit:     30  Glitch Filter Enable               */
+    uint32_t P31:1;            /*!< bit:     31  Glitch Filter Enable               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_GFERT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_GFERT_OFFSET           0x0CC        /**< \brief (GPIO_GFERT offset) Glitch Filter Enable Register - Toggle */
+
+#define GPIO_GFERT_P0_Pos           0            /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P0               (_U(0x1) << GPIO_GFERT_P0_Pos)
+#define GPIO_GFERT_P1_Pos           1            /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P1               (_U(0x1) << GPIO_GFERT_P1_Pos)
+#define GPIO_GFERT_P2_Pos           2            /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P2               (_U(0x1) << GPIO_GFERT_P2_Pos)
+#define GPIO_GFERT_P3_Pos           3            /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P3               (_U(0x1) << GPIO_GFERT_P3_Pos)
+#define GPIO_GFERT_P4_Pos           4            /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P4               (_U(0x1) << GPIO_GFERT_P4_Pos)
+#define GPIO_GFERT_P5_Pos           5            /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P5               (_U(0x1) << GPIO_GFERT_P5_Pos)
+#define GPIO_GFERT_P6_Pos           6            /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P6               (_U(0x1) << GPIO_GFERT_P6_Pos)
+#define GPIO_GFERT_P7_Pos           7            /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P7               (_U(0x1) << GPIO_GFERT_P7_Pos)
+#define GPIO_GFERT_P8_Pos           8            /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P8               (_U(0x1) << GPIO_GFERT_P8_Pos)
+#define GPIO_GFERT_P9_Pos           9            /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P9               (_U(0x1) << GPIO_GFERT_P9_Pos)
+#define GPIO_GFERT_P10_Pos          10           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P10              (_U(0x1) << GPIO_GFERT_P10_Pos)
+#define GPIO_GFERT_P11_Pos          11           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P11              (_U(0x1) << GPIO_GFERT_P11_Pos)
+#define GPIO_GFERT_P12_Pos          12           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P12              (_U(0x1) << GPIO_GFERT_P12_Pos)
+#define GPIO_GFERT_P13_Pos          13           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P13              (_U(0x1) << GPIO_GFERT_P13_Pos)
+#define GPIO_GFERT_P14_Pos          14           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P14              (_U(0x1) << GPIO_GFERT_P14_Pos)
+#define GPIO_GFERT_P15_Pos          15           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P15              (_U(0x1) << GPIO_GFERT_P15_Pos)
+#define GPIO_GFERT_P16_Pos          16           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P16              (_U(0x1) << GPIO_GFERT_P16_Pos)
+#define GPIO_GFERT_P17_Pos          17           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P17              (_U(0x1) << GPIO_GFERT_P17_Pos)
+#define GPIO_GFERT_P18_Pos          18           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P18              (_U(0x1) << GPIO_GFERT_P18_Pos)
+#define GPIO_GFERT_P19_Pos          19           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P19              (_U(0x1) << GPIO_GFERT_P19_Pos)
+#define GPIO_GFERT_P20_Pos          20           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P20              (_U(0x1) << GPIO_GFERT_P20_Pos)
+#define GPIO_GFERT_P21_Pos          21           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P21              (_U(0x1) << GPIO_GFERT_P21_Pos)
+#define GPIO_GFERT_P22_Pos          22           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P22              (_U(0x1) << GPIO_GFERT_P22_Pos)
+#define GPIO_GFERT_P23_Pos          23           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P23              (_U(0x1) << GPIO_GFERT_P23_Pos)
+#define GPIO_GFERT_P24_Pos          24           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P24              (_U(0x1) << GPIO_GFERT_P24_Pos)
+#define GPIO_GFERT_P25_Pos          25           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P25              (_U(0x1) << GPIO_GFERT_P25_Pos)
+#define GPIO_GFERT_P26_Pos          26           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P26              (_U(0x1) << GPIO_GFERT_P26_Pos)
+#define GPIO_GFERT_P27_Pos          27           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P27              (_U(0x1) << GPIO_GFERT_P27_Pos)
+#define GPIO_GFERT_P28_Pos          28           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P28              (_U(0x1) << GPIO_GFERT_P28_Pos)
+#define GPIO_GFERT_P29_Pos          29           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P29              (_U(0x1) << GPIO_GFERT_P29_Pos)
+#define GPIO_GFERT_P30_Pos          30           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P30              (_U(0x1) << GPIO_GFERT_P30_Pos)
+#define GPIO_GFERT_P31_Pos          31           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
+#define GPIO_GFERT_P31              (_U(0x1) << GPIO_GFERT_P31_Pos)
+#define GPIO_GFERT_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_GFERT) MASK Register */
+
+/* -------- GPIO_IFR : (GPIO Offset: 0x0D0) (R/  32) port Interrupt Flag Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Interrupt Flag                     */
+    uint32_t P1:1;             /*!< bit:      1  Interrupt Flag                     */
+    uint32_t P2:1;             /*!< bit:      2  Interrupt Flag                     */
+    uint32_t P3:1;             /*!< bit:      3  Interrupt Flag                     */
+    uint32_t P4:1;             /*!< bit:      4  Interrupt Flag                     */
+    uint32_t P5:1;             /*!< bit:      5  Interrupt Flag                     */
+    uint32_t P6:1;             /*!< bit:      6  Interrupt Flag                     */
+    uint32_t P7:1;             /*!< bit:      7  Interrupt Flag                     */
+    uint32_t P8:1;             /*!< bit:      8  Interrupt Flag                     */
+    uint32_t P9:1;             /*!< bit:      9  Interrupt Flag                     */
+    uint32_t P10:1;            /*!< bit:     10  Interrupt Flag                     */
+    uint32_t P11:1;            /*!< bit:     11  Interrupt Flag                     */
+    uint32_t P12:1;            /*!< bit:     12  Interrupt Flag                     */
+    uint32_t P13:1;            /*!< bit:     13  Interrupt Flag                     */
+    uint32_t P14:1;            /*!< bit:     14  Interrupt Flag                     */
+    uint32_t P15:1;            /*!< bit:     15  Interrupt Flag                     */
+    uint32_t P16:1;            /*!< bit:     16  Interrupt Flag                     */
+    uint32_t P17:1;            /*!< bit:     17  Interrupt Flag                     */
+    uint32_t P18:1;            /*!< bit:     18  Interrupt Flag                     */
+    uint32_t P19:1;            /*!< bit:     19  Interrupt Flag                     */
+    uint32_t P20:1;            /*!< bit:     20  Interrupt Flag                     */
+    uint32_t P21:1;            /*!< bit:     21  Interrupt Flag                     */
+    uint32_t P22:1;            /*!< bit:     22  Interrupt Flag                     */
+    uint32_t P23:1;            /*!< bit:     23  Interrupt Flag                     */
+    uint32_t P24:1;            /*!< bit:     24  Interrupt Flag                     */
+    uint32_t P25:1;            /*!< bit:     25  Interrupt Flag                     */
+    uint32_t P26:1;            /*!< bit:     26  Interrupt Flag                     */
+    uint32_t P27:1;            /*!< bit:     27  Interrupt Flag                     */
+    uint32_t P28:1;            /*!< bit:     28  Interrupt Flag                     */
+    uint32_t P29:1;            /*!< bit:     29  Interrupt Flag                     */
+    uint32_t P30:1;            /*!< bit:     30  Interrupt Flag                     */
+    uint32_t P31:1;            /*!< bit:     31  Interrupt Flag                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_IFR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_IFR_OFFSET             0x0D0        /**< \brief (GPIO_IFR offset) Interrupt Flag Register */
+
+#define GPIO_IFR_P0_Pos             0            /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P0                 (_U(0x1) << GPIO_IFR_P0_Pos)
+#define GPIO_IFR_P1_Pos             1            /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P1                 (_U(0x1) << GPIO_IFR_P1_Pos)
+#define GPIO_IFR_P2_Pos             2            /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P2                 (_U(0x1) << GPIO_IFR_P2_Pos)
+#define GPIO_IFR_P3_Pos             3            /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P3                 (_U(0x1) << GPIO_IFR_P3_Pos)
+#define GPIO_IFR_P4_Pos             4            /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P4                 (_U(0x1) << GPIO_IFR_P4_Pos)
+#define GPIO_IFR_P5_Pos             5            /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P5                 (_U(0x1) << GPIO_IFR_P5_Pos)
+#define GPIO_IFR_P6_Pos             6            /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P6                 (_U(0x1) << GPIO_IFR_P6_Pos)
+#define GPIO_IFR_P7_Pos             7            /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P7                 (_U(0x1) << GPIO_IFR_P7_Pos)
+#define GPIO_IFR_P8_Pos             8            /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P8                 (_U(0x1) << GPIO_IFR_P8_Pos)
+#define GPIO_IFR_P9_Pos             9            /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P9                 (_U(0x1) << GPIO_IFR_P9_Pos)
+#define GPIO_IFR_P10_Pos            10           /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P10                (_U(0x1) << GPIO_IFR_P10_Pos)
+#define GPIO_IFR_P11_Pos            11           /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P11                (_U(0x1) << GPIO_IFR_P11_Pos)
+#define GPIO_IFR_P12_Pos            12           /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P12                (_U(0x1) << GPIO_IFR_P12_Pos)
+#define GPIO_IFR_P13_Pos            13           /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P13                (_U(0x1) << GPIO_IFR_P13_Pos)
+#define GPIO_IFR_P14_Pos            14           /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P14                (_U(0x1) << GPIO_IFR_P14_Pos)
+#define GPIO_IFR_P15_Pos            15           /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P15                (_U(0x1) << GPIO_IFR_P15_Pos)
+#define GPIO_IFR_P16_Pos            16           /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P16                (_U(0x1) << GPIO_IFR_P16_Pos)
+#define GPIO_IFR_P17_Pos            17           /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P17                (_U(0x1) << GPIO_IFR_P17_Pos)
+#define GPIO_IFR_P18_Pos            18           /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P18                (_U(0x1) << GPIO_IFR_P18_Pos)
+#define GPIO_IFR_P19_Pos            19           /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P19                (_U(0x1) << GPIO_IFR_P19_Pos)
+#define GPIO_IFR_P20_Pos            20           /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P20                (_U(0x1) << GPIO_IFR_P20_Pos)
+#define GPIO_IFR_P21_Pos            21           /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P21                (_U(0x1) << GPIO_IFR_P21_Pos)
+#define GPIO_IFR_P22_Pos            22           /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P22                (_U(0x1) << GPIO_IFR_P22_Pos)
+#define GPIO_IFR_P23_Pos            23           /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P23                (_U(0x1) << GPIO_IFR_P23_Pos)
+#define GPIO_IFR_P24_Pos            24           /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P24                (_U(0x1) << GPIO_IFR_P24_Pos)
+#define GPIO_IFR_P25_Pos            25           /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P25                (_U(0x1) << GPIO_IFR_P25_Pos)
+#define GPIO_IFR_P26_Pos            26           /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P26                (_U(0x1) << GPIO_IFR_P26_Pos)
+#define GPIO_IFR_P27_Pos            27           /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P27                (_U(0x1) << GPIO_IFR_P27_Pos)
+#define GPIO_IFR_P28_Pos            28           /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P28                (_U(0x1) << GPIO_IFR_P28_Pos)
+#define GPIO_IFR_P29_Pos            29           /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P29                (_U(0x1) << GPIO_IFR_P29_Pos)
+#define GPIO_IFR_P30_Pos            30           /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P30                (_U(0x1) << GPIO_IFR_P30_Pos)
+#define GPIO_IFR_P31_Pos            31           /**< \brief (GPIO_IFR) Interrupt Flag */
+#define GPIO_IFR_P31                (_U(0x1) << GPIO_IFR_P31_Pos)
+#define GPIO_IFR_MASK               _U(0xFFFFFFFF) /**< \brief (GPIO_IFR) MASK Register */
+
+/* -------- GPIO_IFRC : (GPIO Offset: 0x0D8) ( /W 32) port Interrupt Flag Register - Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Interrupt Flag                     */
+    uint32_t P1:1;             /*!< bit:      1  Interrupt Flag                     */
+    uint32_t P2:1;             /*!< bit:      2  Interrupt Flag                     */
+    uint32_t P3:1;             /*!< bit:      3  Interrupt Flag                     */
+    uint32_t P4:1;             /*!< bit:      4  Interrupt Flag                     */
+    uint32_t P5:1;             /*!< bit:      5  Interrupt Flag                     */
+    uint32_t P6:1;             /*!< bit:      6  Interrupt Flag                     */
+    uint32_t P7:1;             /*!< bit:      7  Interrupt Flag                     */
+    uint32_t P8:1;             /*!< bit:      8  Interrupt Flag                     */
+    uint32_t P9:1;             /*!< bit:      9  Interrupt Flag                     */
+    uint32_t P10:1;            /*!< bit:     10  Interrupt Flag                     */
+    uint32_t P11:1;            /*!< bit:     11  Interrupt Flag                     */
+    uint32_t P12:1;            /*!< bit:     12  Interrupt Flag                     */
+    uint32_t P13:1;            /*!< bit:     13  Interrupt Flag                     */
+    uint32_t P14:1;            /*!< bit:     14  Interrupt Flag                     */
+    uint32_t P15:1;            /*!< bit:     15  Interrupt Flag                     */
+    uint32_t P16:1;            /*!< bit:     16  Interrupt Flag                     */
+    uint32_t P17:1;            /*!< bit:     17  Interrupt Flag                     */
+    uint32_t P18:1;            /*!< bit:     18  Interrupt Flag                     */
+    uint32_t P19:1;            /*!< bit:     19  Interrupt Flag                     */
+    uint32_t P20:1;            /*!< bit:     20  Interrupt Flag                     */
+    uint32_t P21:1;            /*!< bit:     21  Interrupt Flag                     */
+    uint32_t P22:1;            /*!< bit:     22  Interrupt Flag                     */
+    uint32_t P23:1;            /*!< bit:     23  Interrupt Flag                     */
+    uint32_t P24:1;            /*!< bit:     24  Interrupt Flag                     */
+    uint32_t P25:1;            /*!< bit:     25  Interrupt Flag                     */
+    uint32_t P26:1;            /*!< bit:     26  Interrupt Flag                     */
+    uint32_t P27:1;            /*!< bit:     27  Interrupt Flag                     */
+    uint32_t P28:1;            /*!< bit:     28  Interrupt Flag                     */
+    uint32_t P29:1;            /*!< bit:     29  Interrupt Flag                     */
+    uint32_t P30:1;            /*!< bit:     30  Interrupt Flag                     */
+    uint32_t P31:1;            /*!< bit:     31  Interrupt Flag                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_IFRC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_IFRC_OFFSET            0x0D8        /**< \brief (GPIO_IFRC offset) Interrupt Flag Register - Clear */
+
+#define GPIO_IFRC_P0_Pos            0            /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P0                (_U(0x1) << GPIO_IFRC_P0_Pos)
+#define GPIO_IFRC_P1_Pos            1            /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P1                (_U(0x1) << GPIO_IFRC_P1_Pos)
+#define GPIO_IFRC_P2_Pos            2            /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P2                (_U(0x1) << GPIO_IFRC_P2_Pos)
+#define GPIO_IFRC_P3_Pos            3            /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P3                (_U(0x1) << GPIO_IFRC_P3_Pos)
+#define GPIO_IFRC_P4_Pos            4            /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P4                (_U(0x1) << GPIO_IFRC_P4_Pos)
+#define GPIO_IFRC_P5_Pos            5            /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P5                (_U(0x1) << GPIO_IFRC_P5_Pos)
+#define GPIO_IFRC_P6_Pos            6            /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P6                (_U(0x1) << GPIO_IFRC_P6_Pos)
+#define GPIO_IFRC_P7_Pos            7            /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P7                (_U(0x1) << GPIO_IFRC_P7_Pos)
+#define GPIO_IFRC_P8_Pos            8            /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P8                (_U(0x1) << GPIO_IFRC_P8_Pos)
+#define GPIO_IFRC_P9_Pos            9            /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P9                (_U(0x1) << GPIO_IFRC_P9_Pos)
+#define GPIO_IFRC_P10_Pos           10           /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P10               (_U(0x1) << GPIO_IFRC_P10_Pos)
+#define GPIO_IFRC_P11_Pos           11           /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P11               (_U(0x1) << GPIO_IFRC_P11_Pos)
+#define GPIO_IFRC_P12_Pos           12           /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P12               (_U(0x1) << GPIO_IFRC_P12_Pos)
+#define GPIO_IFRC_P13_Pos           13           /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P13               (_U(0x1) << GPIO_IFRC_P13_Pos)
+#define GPIO_IFRC_P14_Pos           14           /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P14               (_U(0x1) << GPIO_IFRC_P14_Pos)
+#define GPIO_IFRC_P15_Pos           15           /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P15               (_U(0x1) << GPIO_IFRC_P15_Pos)
+#define GPIO_IFRC_P16_Pos           16           /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P16               (_U(0x1) << GPIO_IFRC_P16_Pos)
+#define GPIO_IFRC_P17_Pos           17           /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P17               (_U(0x1) << GPIO_IFRC_P17_Pos)
+#define GPIO_IFRC_P18_Pos           18           /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P18               (_U(0x1) << GPIO_IFRC_P18_Pos)
+#define GPIO_IFRC_P19_Pos           19           /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P19               (_U(0x1) << GPIO_IFRC_P19_Pos)
+#define GPIO_IFRC_P20_Pos           20           /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P20               (_U(0x1) << GPIO_IFRC_P20_Pos)
+#define GPIO_IFRC_P21_Pos           21           /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P21               (_U(0x1) << GPIO_IFRC_P21_Pos)
+#define GPIO_IFRC_P22_Pos           22           /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P22               (_U(0x1) << GPIO_IFRC_P22_Pos)
+#define GPIO_IFRC_P23_Pos           23           /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P23               (_U(0x1) << GPIO_IFRC_P23_Pos)
+#define GPIO_IFRC_P24_Pos           24           /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P24               (_U(0x1) << GPIO_IFRC_P24_Pos)
+#define GPIO_IFRC_P25_Pos           25           /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P25               (_U(0x1) << GPIO_IFRC_P25_Pos)
+#define GPIO_IFRC_P26_Pos           26           /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P26               (_U(0x1) << GPIO_IFRC_P26_Pos)
+#define GPIO_IFRC_P27_Pos           27           /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P27               (_U(0x1) << GPIO_IFRC_P27_Pos)
+#define GPIO_IFRC_P28_Pos           28           /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P28               (_U(0x1) << GPIO_IFRC_P28_Pos)
+#define GPIO_IFRC_P29_Pos           29           /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P29               (_U(0x1) << GPIO_IFRC_P29_Pos)
+#define GPIO_IFRC_P30_Pos           30           /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P30               (_U(0x1) << GPIO_IFRC_P30_Pos)
+#define GPIO_IFRC_P31_Pos           31           /**< \brief (GPIO_IFRC) Interrupt Flag */
+#define GPIO_IFRC_P31               (_U(0x1) << GPIO_IFRC_P31_Pos)
+#define GPIO_IFRC_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_IFRC) MASK Register */
+
+/* -------- GPIO_ODMER : (GPIO Offset: 0x0E0) (R/W 32) port Open Drain Mode Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Open Drain Mode Enable             */
+    uint32_t P1:1;             /*!< bit:      1  Open Drain Mode Enable             */
+    uint32_t P2:1;             /*!< bit:      2  Open Drain Mode Enable             */
+    uint32_t P3:1;             /*!< bit:      3  Open Drain Mode Enable             */
+    uint32_t P4:1;             /*!< bit:      4  Open Drain Mode Enable             */
+    uint32_t P5:1;             /*!< bit:      5  Open Drain Mode Enable             */
+    uint32_t P6:1;             /*!< bit:      6  Open Drain Mode Enable             */
+    uint32_t P7:1;             /*!< bit:      7  Open Drain Mode Enable             */
+    uint32_t P8:1;             /*!< bit:      8  Open Drain Mode Enable             */
+    uint32_t P9:1;             /*!< bit:      9  Open Drain Mode Enable             */
+    uint32_t P10:1;            /*!< bit:     10  Open Drain Mode Enable             */
+    uint32_t P11:1;            /*!< bit:     11  Open Drain Mode Enable             */
+    uint32_t P12:1;            /*!< bit:     12  Open Drain Mode Enable             */
+    uint32_t P13:1;            /*!< bit:     13  Open Drain Mode Enable             */
+    uint32_t P14:1;            /*!< bit:     14  Open Drain Mode Enable             */
+    uint32_t P15:1;            /*!< bit:     15  Open Drain Mode Enable             */
+    uint32_t P16:1;            /*!< bit:     16  Open Drain Mode Enable             */
+    uint32_t P17:1;            /*!< bit:     17  Open Drain Mode Enable             */
+    uint32_t P18:1;            /*!< bit:     18  Open Drain Mode Enable             */
+    uint32_t P19:1;            /*!< bit:     19  Open Drain Mode Enable             */
+    uint32_t P20:1;            /*!< bit:     20  Open Drain Mode Enable             */
+    uint32_t P21:1;            /*!< bit:     21  Open Drain Mode Enable             */
+    uint32_t P22:1;            /*!< bit:     22  Open Drain Mode Enable             */
+    uint32_t P23:1;            /*!< bit:     23  Open Drain Mode Enable             */
+    uint32_t P24:1;            /*!< bit:     24  Open Drain Mode Enable             */
+    uint32_t P25:1;            /*!< bit:     25  Open Drain Mode Enable             */
+    uint32_t P26:1;            /*!< bit:     26  Open Drain Mode Enable             */
+    uint32_t P27:1;            /*!< bit:     27  Open Drain Mode Enable             */
+    uint32_t P28:1;            /*!< bit:     28  Open Drain Mode Enable             */
+    uint32_t P29:1;            /*!< bit:     29  Open Drain Mode Enable             */
+    uint32_t P30:1;            /*!< bit:     30  Open Drain Mode Enable             */
+    uint32_t P31:1;            /*!< bit:     31  Open Drain Mode Enable             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_ODMER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_ODMER_OFFSET           0x0E0        /**< \brief (GPIO_ODMER offset) Open Drain Mode Register */
+
+#define GPIO_ODMER_P0_Pos           0            /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P0               (_U(0x1) << GPIO_ODMER_P0_Pos)
+#define GPIO_ODMER_P1_Pos           1            /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P1               (_U(0x1) << GPIO_ODMER_P1_Pos)
+#define GPIO_ODMER_P2_Pos           2            /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P2               (_U(0x1) << GPIO_ODMER_P2_Pos)
+#define GPIO_ODMER_P3_Pos           3            /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P3               (_U(0x1) << GPIO_ODMER_P3_Pos)
+#define GPIO_ODMER_P4_Pos           4            /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P4               (_U(0x1) << GPIO_ODMER_P4_Pos)
+#define GPIO_ODMER_P5_Pos           5            /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P5               (_U(0x1) << GPIO_ODMER_P5_Pos)
+#define GPIO_ODMER_P6_Pos           6            /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P6               (_U(0x1) << GPIO_ODMER_P6_Pos)
+#define GPIO_ODMER_P7_Pos           7            /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P7               (_U(0x1) << GPIO_ODMER_P7_Pos)
+#define GPIO_ODMER_P8_Pos           8            /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P8               (_U(0x1) << GPIO_ODMER_P8_Pos)
+#define GPIO_ODMER_P9_Pos           9            /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P9               (_U(0x1) << GPIO_ODMER_P9_Pos)
+#define GPIO_ODMER_P10_Pos          10           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P10              (_U(0x1) << GPIO_ODMER_P10_Pos)
+#define GPIO_ODMER_P11_Pos          11           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P11              (_U(0x1) << GPIO_ODMER_P11_Pos)
+#define GPIO_ODMER_P12_Pos          12           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P12              (_U(0x1) << GPIO_ODMER_P12_Pos)
+#define GPIO_ODMER_P13_Pos          13           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P13              (_U(0x1) << GPIO_ODMER_P13_Pos)
+#define GPIO_ODMER_P14_Pos          14           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P14              (_U(0x1) << GPIO_ODMER_P14_Pos)
+#define GPIO_ODMER_P15_Pos          15           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P15              (_U(0x1) << GPIO_ODMER_P15_Pos)
+#define GPIO_ODMER_P16_Pos          16           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P16              (_U(0x1) << GPIO_ODMER_P16_Pos)
+#define GPIO_ODMER_P17_Pos          17           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P17              (_U(0x1) << GPIO_ODMER_P17_Pos)
+#define GPIO_ODMER_P18_Pos          18           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P18              (_U(0x1) << GPIO_ODMER_P18_Pos)
+#define GPIO_ODMER_P19_Pos          19           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P19              (_U(0x1) << GPIO_ODMER_P19_Pos)
+#define GPIO_ODMER_P20_Pos          20           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P20              (_U(0x1) << GPIO_ODMER_P20_Pos)
+#define GPIO_ODMER_P21_Pos          21           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P21              (_U(0x1) << GPIO_ODMER_P21_Pos)
+#define GPIO_ODMER_P22_Pos          22           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P22              (_U(0x1) << GPIO_ODMER_P22_Pos)
+#define GPIO_ODMER_P23_Pos          23           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P23              (_U(0x1) << GPIO_ODMER_P23_Pos)
+#define GPIO_ODMER_P24_Pos          24           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P24              (_U(0x1) << GPIO_ODMER_P24_Pos)
+#define GPIO_ODMER_P25_Pos          25           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P25              (_U(0x1) << GPIO_ODMER_P25_Pos)
+#define GPIO_ODMER_P26_Pos          26           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P26              (_U(0x1) << GPIO_ODMER_P26_Pos)
+#define GPIO_ODMER_P27_Pos          27           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P27              (_U(0x1) << GPIO_ODMER_P27_Pos)
+#define GPIO_ODMER_P28_Pos          28           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P28              (_U(0x1) << GPIO_ODMER_P28_Pos)
+#define GPIO_ODMER_P29_Pos          29           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P29              (_U(0x1) << GPIO_ODMER_P29_Pos)
+#define GPIO_ODMER_P30_Pos          30           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P30              (_U(0x1) << GPIO_ODMER_P30_Pos)
+#define GPIO_ODMER_P31_Pos          31           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
+#define GPIO_ODMER_P31              (_U(0x1) << GPIO_ODMER_P31_Pos)
+#define GPIO_ODMER_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_ODMER) MASK Register */
+
+/* -------- GPIO_ODMERS : (GPIO Offset: 0x0E4) ( /W 32) port Open Drain Mode Register - Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Open Drain Mode Enable             */
+    uint32_t P1:1;             /*!< bit:      1  Open Drain Mode Enable             */
+    uint32_t P2:1;             /*!< bit:      2  Open Drain Mode Enable             */
+    uint32_t P3:1;             /*!< bit:      3  Open Drain Mode Enable             */
+    uint32_t P4:1;             /*!< bit:      4  Open Drain Mode Enable             */
+    uint32_t P5:1;             /*!< bit:      5  Open Drain Mode Enable             */
+    uint32_t P6:1;             /*!< bit:      6  Open Drain Mode Enable             */
+    uint32_t P7:1;             /*!< bit:      7  Open Drain Mode Enable             */
+    uint32_t P8:1;             /*!< bit:      8  Open Drain Mode Enable             */
+    uint32_t P9:1;             /*!< bit:      9  Open Drain Mode Enable             */
+    uint32_t P10:1;            /*!< bit:     10  Open Drain Mode Enable             */
+    uint32_t P11:1;            /*!< bit:     11  Open Drain Mode Enable             */
+    uint32_t P12:1;            /*!< bit:     12  Open Drain Mode Enable             */
+    uint32_t P13:1;            /*!< bit:     13  Open Drain Mode Enable             */
+    uint32_t P14:1;            /*!< bit:     14  Open Drain Mode Enable             */
+    uint32_t P15:1;            /*!< bit:     15  Open Drain Mode Enable             */
+    uint32_t P16:1;            /*!< bit:     16  Open Drain Mode Enable             */
+    uint32_t P17:1;            /*!< bit:     17  Open Drain Mode Enable             */
+    uint32_t P18:1;            /*!< bit:     18  Open Drain Mode Enable             */
+    uint32_t P19:1;            /*!< bit:     19  Open Drain Mode Enable             */
+    uint32_t P20:1;            /*!< bit:     20  Open Drain Mode Enable             */
+    uint32_t P21:1;            /*!< bit:     21  Open Drain Mode Enable             */
+    uint32_t P22:1;            /*!< bit:     22  Open Drain Mode Enable             */
+    uint32_t P23:1;            /*!< bit:     23  Open Drain Mode Enable             */
+    uint32_t P24:1;            /*!< bit:     24  Open Drain Mode Enable             */
+    uint32_t P25:1;            /*!< bit:     25  Open Drain Mode Enable             */
+    uint32_t P26:1;            /*!< bit:     26  Open Drain Mode Enable             */
+    uint32_t P27:1;            /*!< bit:     27  Open Drain Mode Enable             */
+    uint32_t P28:1;            /*!< bit:     28  Open Drain Mode Enable             */
+    uint32_t P29:1;            /*!< bit:     29  Open Drain Mode Enable             */
+    uint32_t P30:1;            /*!< bit:     30  Open Drain Mode Enable             */
+    uint32_t P31:1;            /*!< bit:     31  Open Drain Mode Enable             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_ODMERS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_ODMERS_OFFSET          0x0E4        /**< \brief (GPIO_ODMERS offset) Open Drain Mode Register - Set */
+
+#define GPIO_ODMERS_P0_Pos          0            /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P0              (_U(0x1) << GPIO_ODMERS_P0_Pos)
+#define GPIO_ODMERS_P1_Pos          1            /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P1              (_U(0x1) << GPIO_ODMERS_P1_Pos)
+#define GPIO_ODMERS_P2_Pos          2            /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P2              (_U(0x1) << GPIO_ODMERS_P2_Pos)
+#define GPIO_ODMERS_P3_Pos          3            /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P3              (_U(0x1) << GPIO_ODMERS_P3_Pos)
+#define GPIO_ODMERS_P4_Pos          4            /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P4              (_U(0x1) << GPIO_ODMERS_P4_Pos)
+#define GPIO_ODMERS_P5_Pos          5            /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P5              (_U(0x1) << GPIO_ODMERS_P5_Pos)
+#define GPIO_ODMERS_P6_Pos          6            /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P6              (_U(0x1) << GPIO_ODMERS_P6_Pos)
+#define GPIO_ODMERS_P7_Pos          7            /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P7              (_U(0x1) << GPIO_ODMERS_P7_Pos)
+#define GPIO_ODMERS_P8_Pos          8            /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P8              (_U(0x1) << GPIO_ODMERS_P8_Pos)
+#define GPIO_ODMERS_P9_Pos          9            /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P9              (_U(0x1) << GPIO_ODMERS_P9_Pos)
+#define GPIO_ODMERS_P10_Pos         10           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P10             (_U(0x1) << GPIO_ODMERS_P10_Pos)
+#define GPIO_ODMERS_P11_Pos         11           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P11             (_U(0x1) << GPIO_ODMERS_P11_Pos)
+#define GPIO_ODMERS_P12_Pos         12           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P12             (_U(0x1) << GPIO_ODMERS_P12_Pos)
+#define GPIO_ODMERS_P13_Pos         13           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P13             (_U(0x1) << GPIO_ODMERS_P13_Pos)
+#define GPIO_ODMERS_P14_Pos         14           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P14             (_U(0x1) << GPIO_ODMERS_P14_Pos)
+#define GPIO_ODMERS_P15_Pos         15           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P15             (_U(0x1) << GPIO_ODMERS_P15_Pos)
+#define GPIO_ODMERS_P16_Pos         16           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P16             (_U(0x1) << GPIO_ODMERS_P16_Pos)
+#define GPIO_ODMERS_P17_Pos         17           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P17             (_U(0x1) << GPIO_ODMERS_P17_Pos)
+#define GPIO_ODMERS_P18_Pos         18           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P18             (_U(0x1) << GPIO_ODMERS_P18_Pos)
+#define GPIO_ODMERS_P19_Pos         19           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P19             (_U(0x1) << GPIO_ODMERS_P19_Pos)
+#define GPIO_ODMERS_P20_Pos         20           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P20             (_U(0x1) << GPIO_ODMERS_P20_Pos)
+#define GPIO_ODMERS_P21_Pos         21           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P21             (_U(0x1) << GPIO_ODMERS_P21_Pos)
+#define GPIO_ODMERS_P22_Pos         22           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P22             (_U(0x1) << GPIO_ODMERS_P22_Pos)
+#define GPIO_ODMERS_P23_Pos         23           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P23             (_U(0x1) << GPIO_ODMERS_P23_Pos)
+#define GPIO_ODMERS_P24_Pos         24           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P24             (_U(0x1) << GPIO_ODMERS_P24_Pos)
+#define GPIO_ODMERS_P25_Pos         25           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P25             (_U(0x1) << GPIO_ODMERS_P25_Pos)
+#define GPIO_ODMERS_P26_Pos         26           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P26             (_U(0x1) << GPIO_ODMERS_P26_Pos)
+#define GPIO_ODMERS_P27_Pos         27           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P27             (_U(0x1) << GPIO_ODMERS_P27_Pos)
+#define GPIO_ODMERS_P28_Pos         28           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P28             (_U(0x1) << GPIO_ODMERS_P28_Pos)
+#define GPIO_ODMERS_P29_Pos         29           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P29             (_U(0x1) << GPIO_ODMERS_P29_Pos)
+#define GPIO_ODMERS_P30_Pos         30           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P30             (_U(0x1) << GPIO_ODMERS_P30_Pos)
+#define GPIO_ODMERS_P31_Pos         31           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
+#define GPIO_ODMERS_P31             (_U(0x1) << GPIO_ODMERS_P31_Pos)
+#define GPIO_ODMERS_MASK            _U(0xFFFFFFFF) /**< \brief (GPIO_ODMERS) MASK Register */
+
+/* -------- GPIO_ODMERC : (GPIO Offset: 0x0E8) ( /W 32) port Open Drain Mode Register - Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Open Drain Mode Enable             */
+    uint32_t P1:1;             /*!< bit:      1  Open Drain Mode Enable             */
+    uint32_t P2:1;             /*!< bit:      2  Open Drain Mode Enable             */
+    uint32_t P3:1;             /*!< bit:      3  Open Drain Mode Enable             */
+    uint32_t P4:1;             /*!< bit:      4  Open Drain Mode Enable             */
+    uint32_t P5:1;             /*!< bit:      5  Open Drain Mode Enable             */
+    uint32_t P6:1;             /*!< bit:      6  Open Drain Mode Enable             */
+    uint32_t P7:1;             /*!< bit:      7  Open Drain Mode Enable             */
+    uint32_t P8:1;             /*!< bit:      8  Open Drain Mode Enable             */
+    uint32_t P9:1;             /*!< bit:      9  Open Drain Mode Enable             */
+    uint32_t P10:1;            /*!< bit:     10  Open Drain Mode Enable             */
+    uint32_t P11:1;            /*!< bit:     11  Open Drain Mode Enable             */
+    uint32_t P12:1;            /*!< bit:     12  Open Drain Mode Enable             */
+    uint32_t P13:1;            /*!< bit:     13  Open Drain Mode Enable             */
+    uint32_t P14:1;            /*!< bit:     14  Open Drain Mode Enable             */
+    uint32_t P15:1;            /*!< bit:     15  Open Drain Mode Enable             */
+    uint32_t P16:1;            /*!< bit:     16  Open Drain Mode Enable             */
+    uint32_t P17:1;            /*!< bit:     17  Open Drain Mode Enable             */
+    uint32_t P18:1;            /*!< bit:     18  Open Drain Mode Enable             */
+    uint32_t P19:1;            /*!< bit:     19  Open Drain Mode Enable             */
+    uint32_t P20:1;            /*!< bit:     20  Open Drain Mode Enable             */
+    uint32_t P21:1;            /*!< bit:     21  Open Drain Mode Enable             */
+    uint32_t P22:1;            /*!< bit:     22  Open Drain Mode Enable             */
+    uint32_t P23:1;            /*!< bit:     23  Open Drain Mode Enable             */
+    uint32_t P24:1;            /*!< bit:     24  Open Drain Mode Enable             */
+    uint32_t P25:1;            /*!< bit:     25  Open Drain Mode Enable             */
+    uint32_t P26:1;            /*!< bit:     26  Open Drain Mode Enable             */
+    uint32_t P27:1;            /*!< bit:     27  Open Drain Mode Enable             */
+    uint32_t P28:1;            /*!< bit:     28  Open Drain Mode Enable             */
+    uint32_t P29:1;            /*!< bit:     29  Open Drain Mode Enable             */
+    uint32_t P30:1;            /*!< bit:     30  Open Drain Mode Enable             */
+    uint32_t P31:1;            /*!< bit:     31  Open Drain Mode Enable             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_ODMERC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_ODMERC_OFFSET          0x0E8        /**< \brief (GPIO_ODMERC offset) Open Drain Mode Register - Clear */
+
+#define GPIO_ODMERC_P0_Pos          0            /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P0              (_U(0x1) << GPIO_ODMERC_P0_Pos)
+#define GPIO_ODMERC_P1_Pos          1            /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P1              (_U(0x1) << GPIO_ODMERC_P1_Pos)
+#define GPIO_ODMERC_P2_Pos          2            /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P2              (_U(0x1) << GPIO_ODMERC_P2_Pos)
+#define GPIO_ODMERC_P3_Pos          3            /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P3              (_U(0x1) << GPIO_ODMERC_P3_Pos)
+#define GPIO_ODMERC_P4_Pos          4            /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P4              (_U(0x1) << GPIO_ODMERC_P4_Pos)
+#define GPIO_ODMERC_P5_Pos          5            /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P5              (_U(0x1) << GPIO_ODMERC_P5_Pos)
+#define GPIO_ODMERC_P6_Pos          6            /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P6              (_U(0x1) << GPIO_ODMERC_P6_Pos)
+#define GPIO_ODMERC_P7_Pos          7            /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P7              (_U(0x1) << GPIO_ODMERC_P7_Pos)
+#define GPIO_ODMERC_P8_Pos          8            /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P8              (_U(0x1) << GPIO_ODMERC_P8_Pos)
+#define GPIO_ODMERC_P9_Pos          9            /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P9              (_U(0x1) << GPIO_ODMERC_P9_Pos)
+#define GPIO_ODMERC_P10_Pos         10           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P10             (_U(0x1) << GPIO_ODMERC_P10_Pos)
+#define GPIO_ODMERC_P11_Pos         11           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P11             (_U(0x1) << GPIO_ODMERC_P11_Pos)
+#define GPIO_ODMERC_P12_Pos         12           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P12             (_U(0x1) << GPIO_ODMERC_P12_Pos)
+#define GPIO_ODMERC_P13_Pos         13           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P13             (_U(0x1) << GPIO_ODMERC_P13_Pos)
+#define GPIO_ODMERC_P14_Pos         14           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P14             (_U(0x1) << GPIO_ODMERC_P14_Pos)
+#define GPIO_ODMERC_P15_Pos         15           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P15             (_U(0x1) << GPIO_ODMERC_P15_Pos)
+#define GPIO_ODMERC_P16_Pos         16           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P16             (_U(0x1) << GPIO_ODMERC_P16_Pos)
+#define GPIO_ODMERC_P17_Pos         17           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P17             (_U(0x1) << GPIO_ODMERC_P17_Pos)
+#define GPIO_ODMERC_P18_Pos         18           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P18             (_U(0x1) << GPIO_ODMERC_P18_Pos)
+#define GPIO_ODMERC_P19_Pos         19           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P19             (_U(0x1) << GPIO_ODMERC_P19_Pos)
+#define GPIO_ODMERC_P20_Pos         20           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P20             (_U(0x1) << GPIO_ODMERC_P20_Pos)
+#define GPIO_ODMERC_P21_Pos         21           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P21             (_U(0x1) << GPIO_ODMERC_P21_Pos)
+#define GPIO_ODMERC_P22_Pos         22           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P22             (_U(0x1) << GPIO_ODMERC_P22_Pos)
+#define GPIO_ODMERC_P23_Pos         23           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P23             (_U(0x1) << GPIO_ODMERC_P23_Pos)
+#define GPIO_ODMERC_P24_Pos         24           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P24             (_U(0x1) << GPIO_ODMERC_P24_Pos)
+#define GPIO_ODMERC_P25_Pos         25           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P25             (_U(0x1) << GPIO_ODMERC_P25_Pos)
+#define GPIO_ODMERC_P26_Pos         26           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P26             (_U(0x1) << GPIO_ODMERC_P26_Pos)
+#define GPIO_ODMERC_P27_Pos         27           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P27             (_U(0x1) << GPIO_ODMERC_P27_Pos)
+#define GPIO_ODMERC_P28_Pos         28           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P28             (_U(0x1) << GPIO_ODMERC_P28_Pos)
+#define GPIO_ODMERC_P29_Pos         29           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P29             (_U(0x1) << GPIO_ODMERC_P29_Pos)
+#define GPIO_ODMERC_P30_Pos         30           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P30             (_U(0x1) << GPIO_ODMERC_P30_Pos)
+#define GPIO_ODMERC_P31_Pos         31           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
+#define GPIO_ODMERC_P31             (_U(0x1) << GPIO_ODMERC_P31_Pos)
+#define GPIO_ODMERC_MASK            _U(0xFFFFFFFF) /**< \brief (GPIO_ODMERC) MASK Register */
+
+/* -------- GPIO_ODMERT : (GPIO Offset: 0x0EC) ( /W 32) port Open Drain Mode Register - Toggle -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Open Drain Mode Enable             */
+    uint32_t P1:1;             /*!< bit:      1  Open Drain Mode Enable             */
+    uint32_t P2:1;             /*!< bit:      2  Open Drain Mode Enable             */
+    uint32_t P3:1;             /*!< bit:      3  Open Drain Mode Enable             */
+    uint32_t P4:1;             /*!< bit:      4  Open Drain Mode Enable             */
+    uint32_t P5:1;             /*!< bit:      5  Open Drain Mode Enable             */
+    uint32_t P6:1;             /*!< bit:      6  Open Drain Mode Enable             */
+    uint32_t P7:1;             /*!< bit:      7  Open Drain Mode Enable             */
+    uint32_t P8:1;             /*!< bit:      8  Open Drain Mode Enable             */
+    uint32_t P9:1;             /*!< bit:      9  Open Drain Mode Enable             */
+    uint32_t P10:1;            /*!< bit:     10  Open Drain Mode Enable             */
+    uint32_t P11:1;            /*!< bit:     11  Open Drain Mode Enable             */
+    uint32_t P12:1;            /*!< bit:     12  Open Drain Mode Enable             */
+    uint32_t P13:1;            /*!< bit:     13  Open Drain Mode Enable             */
+    uint32_t P14:1;            /*!< bit:     14  Open Drain Mode Enable             */
+    uint32_t P15:1;            /*!< bit:     15  Open Drain Mode Enable             */
+    uint32_t P16:1;            /*!< bit:     16  Open Drain Mode Enable             */
+    uint32_t P17:1;            /*!< bit:     17  Open Drain Mode Enable             */
+    uint32_t P18:1;            /*!< bit:     18  Open Drain Mode Enable             */
+    uint32_t P19:1;            /*!< bit:     19  Open Drain Mode Enable             */
+    uint32_t P20:1;            /*!< bit:     20  Open Drain Mode Enable             */
+    uint32_t P21:1;            /*!< bit:     21  Open Drain Mode Enable             */
+    uint32_t P22:1;            /*!< bit:     22  Open Drain Mode Enable             */
+    uint32_t P23:1;            /*!< bit:     23  Open Drain Mode Enable             */
+    uint32_t P24:1;            /*!< bit:     24  Open Drain Mode Enable             */
+    uint32_t P25:1;            /*!< bit:     25  Open Drain Mode Enable             */
+    uint32_t P26:1;            /*!< bit:     26  Open Drain Mode Enable             */
+    uint32_t P27:1;            /*!< bit:     27  Open Drain Mode Enable             */
+    uint32_t P28:1;            /*!< bit:     28  Open Drain Mode Enable             */
+    uint32_t P29:1;            /*!< bit:     29  Open Drain Mode Enable             */
+    uint32_t P30:1;            /*!< bit:     30  Open Drain Mode Enable             */
+    uint32_t P31:1;            /*!< bit:     31  Open Drain Mode Enable             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_ODMERT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_ODMERT_OFFSET          0x0EC        /**< \brief (GPIO_ODMERT offset) Open Drain Mode Register - Toggle */
+
+#define GPIO_ODMERT_P0_Pos          0            /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P0              (_U(0x1) << GPIO_ODMERT_P0_Pos)
+#define GPIO_ODMERT_P1_Pos          1            /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P1              (_U(0x1) << GPIO_ODMERT_P1_Pos)
+#define GPIO_ODMERT_P2_Pos          2            /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P2              (_U(0x1) << GPIO_ODMERT_P2_Pos)
+#define GPIO_ODMERT_P3_Pos          3            /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P3              (_U(0x1) << GPIO_ODMERT_P3_Pos)
+#define GPIO_ODMERT_P4_Pos          4            /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P4              (_U(0x1) << GPIO_ODMERT_P4_Pos)
+#define GPIO_ODMERT_P5_Pos          5            /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P5              (_U(0x1) << GPIO_ODMERT_P5_Pos)
+#define GPIO_ODMERT_P6_Pos          6            /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P6              (_U(0x1) << GPIO_ODMERT_P6_Pos)
+#define GPIO_ODMERT_P7_Pos          7            /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P7              (_U(0x1) << GPIO_ODMERT_P7_Pos)
+#define GPIO_ODMERT_P8_Pos          8            /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P8              (_U(0x1) << GPIO_ODMERT_P8_Pos)
+#define GPIO_ODMERT_P9_Pos          9            /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P9              (_U(0x1) << GPIO_ODMERT_P9_Pos)
+#define GPIO_ODMERT_P10_Pos         10           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P10             (_U(0x1) << GPIO_ODMERT_P10_Pos)
+#define GPIO_ODMERT_P11_Pos         11           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P11             (_U(0x1) << GPIO_ODMERT_P11_Pos)
+#define GPIO_ODMERT_P12_Pos         12           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P12             (_U(0x1) << GPIO_ODMERT_P12_Pos)
+#define GPIO_ODMERT_P13_Pos         13           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P13             (_U(0x1) << GPIO_ODMERT_P13_Pos)
+#define GPIO_ODMERT_P14_Pos         14           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P14             (_U(0x1) << GPIO_ODMERT_P14_Pos)
+#define GPIO_ODMERT_P15_Pos         15           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P15             (_U(0x1) << GPIO_ODMERT_P15_Pos)
+#define GPIO_ODMERT_P16_Pos         16           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P16             (_U(0x1) << GPIO_ODMERT_P16_Pos)
+#define GPIO_ODMERT_P17_Pos         17           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P17             (_U(0x1) << GPIO_ODMERT_P17_Pos)
+#define GPIO_ODMERT_P18_Pos         18           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P18             (_U(0x1) << GPIO_ODMERT_P18_Pos)
+#define GPIO_ODMERT_P19_Pos         19           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P19             (_U(0x1) << GPIO_ODMERT_P19_Pos)
+#define GPIO_ODMERT_P20_Pos         20           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P20             (_U(0x1) << GPIO_ODMERT_P20_Pos)
+#define GPIO_ODMERT_P21_Pos         21           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P21             (_U(0x1) << GPIO_ODMERT_P21_Pos)
+#define GPIO_ODMERT_P22_Pos         22           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P22             (_U(0x1) << GPIO_ODMERT_P22_Pos)
+#define GPIO_ODMERT_P23_Pos         23           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P23             (_U(0x1) << GPIO_ODMERT_P23_Pos)
+#define GPIO_ODMERT_P24_Pos         24           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P24             (_U(0x1) << GPIO_ODMERT_P24_Pos)
+#define GPIO_ODMERT_P25_Pos         25           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P25             (_U(0x1) << GPIO_ODMERT_P25_Pos)
+#define GPIO_ODMERT_P26_Pos         26           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P26             (_U(0x1) << GPIO_ODMERT_P26_Pos)
+#define GPIO_ODMERT_P27_Pos         27           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P27             (_U(0x1) << GPIO_ODMERT_P27_Pos)
+#define GPIO_ODMERT_P28_Pos         28           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P28             (_U(0x1) << GPIO_ODMERT_P28_Pos)
+#define GPIO_ODMERT_P29_Pos         29           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P29             (_U(0x1) << GPIO_ODMERT_P29_Pos)
+#define GPIO_ODMERT_P30_Pos         30           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P30             (_U(0x1) << GPIO_ODMERT_P30_Pos)
+#define GPIO_ODMERT_P31_Pos         31           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
+#define GPIO_ODMERT_P31             (_U(0x1) << GPIO_ODMERT_P31_Pos)
+#define GPIO_ODMERT_MASK            _U(0xFFFFFFFF) /**< \brief (GPIO_ODMERT) MASK Register */
+
+/* -------- GPIO_ODCR0 : (GPIO Offset: 0x100) (R/W 32) port Output Driving Capability Register 0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Output Driving Capability Register Bit 0 */
+    uint32_t P1:1;             /*!< bit:      1  Output Driving Capability Register Bit 0 */
+    uint32_t P2:1;             /*!< bit:      2  Output Driving Capability Register Bit 0 */
+    uint32_t P3:1;             /*!< bit:      3  Output Driving Capability Register Bit 0 */
+    uint32_t P4:1;             /*!< bit:      4  Output Driving Capability Register Bit 0 */
+    uint32_t P5:1;             /*!< bit:      5  Output Driving Capability Register Bit 0 */
+    uint32_t P6:1;             /*!< bit:      6  Output Driving Capability Register Bit 0 */
+    uint32_t P7:1;             /*!< bit:      7  Output Driving Capability Register Bit 0 */
+    uint32_t P8:1;             /*!< bit:      8  Output Driving Capability Register Bit 0 */
+    uint32_t P9:1;             /*!< bit:      9  Output Driving Capability Register Bit 0 */
+    uint32_t P10:1;            /*!< bit:     10  Output Driving Capability Register Bit 0 */
+    uint32_t P11:1;            /*!< bit:     11  Output Driving Capability Register Bit 0 */
+    uint32_t P12:1;            /*!< bit:     12  Output Driving Capability Register Bit 0 */
+    uint32_t P13:1;            /*!< bit:     13  Output Driving Capability Register Bit 0 */
+    uint32_t P14:1;            /*!< bit:     14  Output Driving Capability Register Bit 0 */
+    uint32_t P15:1;            /*!< bit:     15  Output Driving Capability Register Bit 0 */
+    uint32_t P16:1;            /*!< bit:     16  Output Driving Capability Register Bit 0 */
+    uint32_t P17:1;            /*!< bit:     17  Output Driving Capability Register Bit 0 */
+    uint32_t P18:1;            /*!< bit:     18  Output Driving Capability Register Bit 0 */
+    uint32_t P19:1;            /*!< bit:     19  Output Driving Capability Register Bit 0 */
+    uint32_t P20:1;            /*!< bit:     20  Output Driving Capability Register Bit 0 */
+    uint32_t P21:1;            /*!< bit:     21  Output Driving Capability Register Bit 0 */
+    uint32_t P22:1;            /*!< bit:     22  Output Driving Capability Register Bit 0 */
+    uint32_t P23:1;            /*!< bit:     23  Output Driving Capability Register Bit 0 */
+    uint32_t P24:1;            /*!< bit:     24  Output Driving Capability Register Bit 0 */
+    uint32_t P25:1;            /*!< bit:     25  Output Driving Capability Register Bit 0 */
+    uint32_t P26:1;            /*!< bit:     26  Output Driving Capability Register Bit 0 */
+    uint32_t P27:1;            /*!< bit:     27  Output Driving Capability Register Bit 0 */
+    uint32_t P28:1;            /*!< bit:     28  Output Driving Capability Register Bit 0 */
+    uint32_t P29:1;            /*!< bit:     29  Output Driving Capability Register Bit 0 */
+    uint32_t P30:1;            /*!< bit:     30  Output Driving Capability Register Bit 0 */
+    uint32_t P31:1;            /*!< bit:     31  Output Driving Capability Register Bit 0 */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_ODCR0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_ODCR0_OFFSET           0x100        /**< \brief (GPIO_ODCR0 offset) Output Driving Capability Register 0 */
+
+#define GPIO_ODCR0_P0_Pos           0            /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P0               (_U(0x1) << GPIO_ODCR0_P0_Pos)
+#define GPIO_ODCR0_P1_Pos           1            /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P1               (_U(0x1) << GPIO_ODCR0_P1_Pos)
+#define GPIO_ODCR0_P2_Pos           2            /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P2               (_U(0x1) << GPIO_ODCR0_P2_Pos)
+#define GPIO_ODCR0_P3_Pos           3            /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P3               (_U(0x1) << GPIO_ODCR0_P3_Pos)
+#define GPIO_ODCR0_P4_Pos           4            /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P4               (_U(0x1) << GPIO_ODCR0_P4_Pos)
+#define GPIO_ODCR0_P5_Pos           5            /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P5               (_U(0x1) << GPIO_ODCR0_P5_Pos)
+#define GPIO_ODCR0_P6_Pos           6            /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P6               (_U(0x1) << GPIO_ODCR0_P6_Pos)
+#define GPIO_ODCR0_P7_Pos           7            /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P7               (_U(0x1) << GPIO_ODCR0_P7_Pos)
+#define GPIO_ODCR0_P8_Pos           8            /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P8               (_U(0x1) << GPIO_ODCR0_P8_Pos)
+#define GPIO_ODCR0_P9_Pos           9            /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P9               (_U(0x1) << GPIO_ODCR0_P9_Pos)
+#define GPIO_ODCR0_P10_Pos          10           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P10              (_U(0x1) << GPIO_ODCR0_P10_Pos)
+#define GPIO_ODCR0_P11_Pos          11           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P11              (_U(0x1) << GPIO_ODCR0_P11_Pos)
+#define GPIO_ODCR0_P12_Pos          12           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P12              (_U(0x1) << GPIO_ODCR0_P12_Pos)
+#define GPIO_ODCR0_P13_Pos          13           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P13              (_U(0x1) << GPIO_ODCR0_P13_Pos)
+#define GPIO_ODCR0_P14_Pos          14           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P14              (_U(0x1) << GPIO_ODCR0_P14_Pos)
+#define GPIO_ODCR0_P15_Pos          15           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P15              (_U(0x1) << GPIO_ODCR0_P15_Pos)
+#define GPIO_ODCR0_P16_Pos          16           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P16              (_U(0x1) << GPIO_ODCR0_P16_Pos)
+#define GPIO_ODCR0_P17_Pos          17           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P17              (_U(0x1) << GPIO_ODCR0_P17_Pos)
+#define GPIO_ODCR0_P18_Pos          18           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P18              (_U(0x1) << GPIO_ODCR0_P18_Pos)
+#define GPIO_ODCR0_P19_Pos          19           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P19              (_U(0x1) << GPIO_ODCR0_P19_Pos)
+#define GPIO_ODCR0_P20_Pos          20           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P20              (_U(0x1) << GPIO_ODCR0_P20_Pos)
+#define GPIO_ODCR0_P21_Pos          21           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P21              (_U(0x1) << GPIO_ODCR0_P21_Pos)
+#define GPIO_ODCR0_P22_Pos          22           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P22              (_U(0x1) << GPIO_ODCR0_P22_Pos)
+#define GPIO_ODCR0_P23_Pos          23           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P23              (_U(0x1) << GPIO_ODCR0_P23_Pos)
+#define GPIO_ODCR0_P24_Pos          24           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P24              (_U(0x1) << GPIO_ODCR0_P24_Pos)
+#define GPIO_ODCR0_P25_Pos          25           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P25              (_U(0x1) << GPIO_ODCR0_P25_Pos)
+#define GPIO_ODCR0_P26_Pos          26           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P26              (_U(0x1) << GPIO_ODCR0_P26_Pos)
+#define GPIO_ODCR0_P27_Pos          27           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P27              (_U(0x1) << GPIO_ODCR0_P27_Pos)
+#define GPIO_ODCR0_P28_Pos          28           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P28              (_U(0x1) << GPIO_ODCR0_P28_Pos)
+#define GPIO_ODCR0_P29_Pos          29           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P29              (_U(0x1) << GPIO_ODCR0_P29_Pos)
+#define GPIO_ODCR0_P30_Pos          30           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P30              (_U(0x1) << GPIO_ODCR0_P30_Pos)
+#define GPIO_ODCR0_P31_Pos          31           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0_P31              (_U(0x1) << GPIO_ODCR0_P31_Pos)
+#define GPIO_ODCR0_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_ODCR0) MASK Register */
+
+/* -------- GPIO_ODCR0S : (GPIO Offset: 0x104) (R/W 32) port Output Driving Capability Register 0 - Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Output Driving Capability Register Bit 0 */
+    uint32_t P1:1;             /*!< bit:      1  Output Driving Capability Register Bit 0 */
+    uint32_t P2:1;             /*!< bit:      2  Output Driving Capability Register Bit 0 */
+    uint32_t P3:1;             /*!< bit:      3  Output Driving Capability Register Bit 0 */
+    uint32_t P4:1;             /*!< bit:      4  Output Driving Capability Register Bit 0 */
+    uint32_t P5:1;             /*!< bit:      5  Output Driving Capability Register Bit 0 */
+    uint32_t P6:1;             /*!< bit:      6  Output Driving Capability Register Bit 0 */
+    uint32_t P7:1;             /*!< bit:      7  Output Driving Capability Register Bit 0 */
+    uint32_t P8:1;             /*!< bit:      8  Output Driving Capability Register Bit 0 */
+    uint32_t P9:1;             /*!< bit:      9  Output Driving Capability Register Bit 0 */
+    uint32_t P10:1;            /*!< bit:     10  Output Driving Capability Register Bit 0 */
+    uint32_t P11:1;            /*!< bit:     11  Output Driving Capability Register Bit 0 */
+    uint32_t P12:1;            /*!< bit:     12  Output Driving Capability Register Bit 0 */
+    uint32_t P13:1;            /*!< bit:     13  Output Driving Capability Register Bit 0 */
+    uint32_t P14:1;            /*!< bit:     14  Output Driving Capability Register Bit 0 */
+    uint32_t P15:1;            /*!< bit:     15  Output Driving Capability Register Bit 0 */
+    uint32_t P16:1;            /*!< bit:     16  Output Driving Capability Register Bit 0 */
+    uint32_t P17:1;            /*!< bit:     17  Output Driving Capability Register Bit 0 */
+    uint32_t P18:1;            /*!< bit:     18  Output Driving Capability Register Bit 0 */
+    uint32_t P19:1;            /*!< bit:     19  Output Driving Capability Register Bit 0 */
+    uint32_t P20:1;            /*!< bit:     20  Output Driving Capability Register Bit 0 */
+    uint32_t P21:1;            /*!< bit:     21  Output Driving Capability Register Bit 0 */
+    uint32_t P22:1;            /*!< bit:     22  Output Driving Capability Register Bit 0 */
+    uint32_t P23:1;            /*!< bit:     23  Output Driving Capability Register Bit 0 */
+    uint32_t P24:1;            /*!< bit:     24  Output Driving Capability Register Bit 0 */
+    uint32_t P25:1;            /*!< bit:     25  Output Driving Capability Register Bit 0 */
+    uint32_t P26:1;            /*!< bit:     26  Output Driving Capability Register Bit 0 */
+    uint32_t P27:1;            /*!< bit:     27  Output Driving Capability Register Bit 0 */
+    uint32_t P28:1;            /*!< bit:     28  Output Driving Capability Register Bit 0 */
+    uint32_t P29:1;            /*!< bit:     29  Output Driving Capability Register Bit 0 */
+    uint32_t P30:1;            /*!< bit:     30  Output Driving Capability Register Bit 0 */
+    uint32_t P31:1;            /*!< bit:     31  Output Driving Capability Register Bit 0 */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_ODCR0S_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_ODCR0S_OFFSET          0x104        /**< \brief (GPIO_ODCR0S offset) Output Driving Capability Register 0 - Set */
+
+#define GPIO_ODCR0S_P0_Pos          0            /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P0              (_U(0x1) << GPIO_ODCR0S_P0_Pos)
+#define GPIO_ODCR0S_P1_Pos          1            /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P1              (_U(0x1) << GPIO_ODCR0S_P1_Pos)
+#define GPIO_ODCR0S_P2_Pos          2            /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P2              (_U(0x1) << GPIO_ODCR0S_P2_Pos)
+#define GPIO_ODCR0S_P3_Pos          3            /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P3              (_U(0x1) << GPIO_ODCR0S_P3_Pos)
+#define GPIO_ODCR0S_P4_Pos          4            /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P4              (_U(0x1) << GPIO_ODCR0S_P4_Pos)
+#define GPIO_ODCR0S_P5_Pos          5            /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P5              (_U(0x1) << GPIO_ODCR0S_P5_Pos)
+#define GPIO_ODCR0S_P6_Pos          6            /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P6              (_U(0x1) << GPIO_ODCR0S_P6_Pos)
+#define GPIO_ODCR0S_P7_Pos          7            /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P7              (_U(0x1) << GPIO_ODCR0S_P7_Pos)
+#define GPIO_ODCR0S_P8_Pos          8            /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P8              (_U(0x1) << GPIO_ODCR0S_P8_Pos)
+#define GPIO_ODCR0S_P9_Pos          9            /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P9              (_U(0x1) << GPIO_ODCR0S_P9_Pos)
+#define GPIO_ODCR0S_P10_Pos         10           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P10             (_U(0x1) << GPIO_ODCR0S_P10_Pos)
+#define GPIO_ODCR0S_P11_Pos         11           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P11             (_U(0x1) << GPIO_ODCR0S_P11_Pos)
+#define GPIO_ODCR0S_P12_Pos         12           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P12             (_U(0x1) << GPIO_ODCR0S_P12_Pos)
+#define GPIO_ODCR0S_P13_Pos         13           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P13             (_U(0x1) << GPIO_ODCR0S_P13_Pos)
+#define GPIO_ODCR0S_P14_Pos         14           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P14             (_U(0x1) << GPIO_ODCR0S_P14_Pos)
+#define GPIO_ODCR0S_P15_Pos         15           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P15             (_U(0x1) << GPIO_ODCR0S_P15_Pos)
+#define GPIO_ODCR0S_P16_Pos         16           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P16             (_U(0x1) << GPIO_ODCR0S_P16_Pos)
+#define GPIO_ODCR0S_P17_Pos         17           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P17             (_U(0x1) << GPIO_ODCR0S_P17_Pos)
+#define GPIO_ODCR0S_P18_Pos         18           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P18             (_U(0x1) << GPIO_ODCR0S_P18_Pos)
+#define GPIO_ODCR0S_P19_Pos         19           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P19             (_U(0x1) << GPIO_ODCR0S_P19_Pos)
+#define GPIO_ODCR0S_P20_Pos         20           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P20             (_U(0x1) << GPIO_ODCR0S_P20_Pos)
+#define GPIO_ODCR0S_P21_Pos         21           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P21             (_U(0x1) << GPIO_ODCR0S_P21_Pos)
+#define GPIO_ODCR0S_P22_Pos         22           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P22             (_U(0x1) << GPIO_ODCR0S_P22_Pos)
+#define GPIO_ODCR0S_P23_Pos         23           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P23             (_U(0x1) << GPIO_ODCR0S_P23_Pos)
+#define GPIO_ODCR0S_P24_Pos         24           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P24             (_U(0x1) << GPIO_ODCR0S_P24_Pos)
+#define GPIO_ODCR0S_P25_Pos         25           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P25             (_U(0x1) << GPIO_ODCR0S_P25_Pos)
+#define GPIO_ODCR0S_P26_Pos         26           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P26             (_U(0x1) << GPIO_ODCR0S_P26_Pos)
+#define GPIO_ODCR0S_P27_Pos         27           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P27             (_U(0x1) << GPIO_ODCR0S_P27_Pos)
+#define GPIO_ODCR0S_P28_Pos         28           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P28             (_U(0x1) << GPIO_ODCR0S_P28_Pos)
+#define GPIO_ODCR0S_P29_Pos         29           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P29             (_U(0x1) << GPIO_ODCR0S_P29_Pos)
+#define GPIO_ODCR0S_P30_Pos         30           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P30             (_U(0x1) << GPIO_ODCR0S_P30_Pos)
+#define GPIO_ODCR0S_P31_Pos         31           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0S_P31             (_U(0x1) << GPIO_ODCR0S_P31_Pos)
+#define GPIO_ODCR0S_MASK            _U(0xFFFFFFFF) /**< \brief (GPIO_ODCR0S) MASK Register */
+
+/* -------- GPIO_ODCR0C : (GPIO Offset: 0x108) (R/W 32) port Output Driving Capability Register 0 - Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Output Driving Capability Register Bit 0 */
+    uint32_t P1:1;             /*!< bit:      1  Output Driving Capability Register Bit 0 */
+    uint32_t P2:1;             /*!< bit:      2  Output Driving Capability Register Bit 0 */
+    uint32_t P3:1;             /*!< bit:      3  Output Driving Capability Register Bit 0 */
+    uint32_t P4:1;             /*!< bit:      4  Output Driving Capability Register Bit 0 */
+    uint32_t P5:1;             /*!< bit:      5  Output Driving Capability Register Bit 0 */
+    uint32_t P6:1;             /*!< bit:      6  Output Driving Capability Register Bit 0 */
+    uint32_t P7:1;             /*!< bit:      7  Output Driving Capability Register Bit 0 */
+    uint32_t P8:1;             /*!< bit:      8  Output Driving Capability Register Bit 0 */
+    uint32_t P9:1;             /*!< bit:      9  Output Driving Capability Register Bit 0 */
+    uint32_t P10:1;            /*!< bit:     10  Output Driving Capability Register Bit 0 */
+    uint32_t P11:1;            /*!< bit:     11  Output Driving Capability Register Bit 0 */
+    uint32_t P12:1;            /*!< bit:     12  Output Driving Capability Register Bit 0 */
+    uint32_t P13:1;            /*!< bit:     13  Output Driving Capability Register Bit 0 */
+    uint32_t P14:1;            /*!< bit:     14  Output Driving Capability Register Bit 0 */
+    uint32_t P15:1;            /*!< bit:     15  Output Driving Capability Register Bit 0 */
+    uint32_t P16:1;            /*!< bit:     16  Output Driving Capability Register Bit 0 */
+    uint32_t P17:1;            /*!< bit:     17  Output Driving Capability Register Bit 0 */
+    uint32_t P18:1;            /*!< bit:     18  Output Driving Capability Register Bit 0 */
+    uint32_t P19:1;            /*!< bit:     19  Output Driving Capability Register Bit 0 */
+    uint32_t P20:1;            /*!< bit:     20  Output Driving Capability Register Bit 0 */
+    uint32_t P21:1;            /*!< bit:     21  Output Driving Capability Register Bit 0 */
+    uint32_t P22:1;            /*!< bit:     22  Output Driving Capability Register Bit 0 */
+    uint32_t P23:1;            /*!< bit:     23  Output Driving Capability Register Bit 0 */
+    uint32_t P24:1;            /*!< bit:     24  Output Driving Capability Register Bit 0 */
+    uint32_t P25:1;            /*!< bit:     25  Output Driving Capability Register Bit 0 */
+    uint32_t P26:1;            /*!< bit:     26  Output Driving Capability Register Bit 0 */
+    uint32_t P27:1;            /*!< bit:     27  Output Driving Capability Register Bit 0 */
+    uint32_t P28:1;            /*!< bit:     28  Output Driving Capability Register Bit 0 */
+    uint32_t P29:1;            /*!< bit:     29  Output Driving Capability Register Bit 0 */
+    uint32_t P30:1;            /*!< bit:     30  Output Driving Capability Register Bit 0 */
+    uint32_t P31:1;            /*!< bit:     31  Output Driving Capability Register Bit 0 */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_ODCR0C_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_ODCR0C_OFFSET          0x108        /**< \brief (GPIO_ODCR0C offset) Output Driving Capability Register 0 - Clear */
+
+#define GPIO_ODCR0C_P0_Pos          0            /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P0              (_U(0x1) << GPIO_ODCR0C_P0_Pos)
+#define GPIO_ODCR0C_P1_Pos          1            /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P1              (_U(0x1) << GPIO_ODCR0C_P1_Pos)
+#define GPIO_ODCR0C_P2_Pos          2            /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P2              (_U(0x1) << GPIO_ODCR0C_P2_Pos)
+#define GPIO_ODCR0C_P3_Pos          3            /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P3              (_U(0x1) << GPIO_ODCR0C_P3_Pos)
+#define GPIO_ODCR0C_P4_Pos          4            /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P4              (_U(0x1) << GPIO_ODCR0C_P4_Pos)
+#define GPIO_ODCR0C_P5_Pos          5            /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P5              (_U(0x1) << GPIO_ODCR0C_P5_Pos)
+#define GPIO_ODCR0C_P6_Pos          6            /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P6              (_U(0x1) << GPIO_ODCR0C_P6_Pos)
+#define GPIO_ODCR0C_P7_Pos          7            /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P7              (_U(0x1) << GPIO_ODCR0C_P7_Pos)
+#define GPIO_ODCR0C_P8_Pos          8            /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P8              (_U(0x1) << GPIO_ODCR0C_P8_Pos)
+#define GPIO_ODCR0C_P9_Pos          9            /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P9              (_U(0x1) << GPIO_ODCR0C_P9_Pos)
+#define GPIO_ODCR0C_P10_Pos         10           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P10             (_U(0x1) << GPIO_ODCR0C_P10_Pos)
+#define GPIO_ODCR0C_P11_Pos         11           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P11             (_U(0x1) << GPIO_ODCR0C_P11_Pos)
+#define GPIO_ODCR0C_P12_Pos         12           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P12             (_U(0x1) << GPIO_ODCR0C_P12_Pos)
+#define GPIO_ODCR0C_P13_Pos         13           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P13             (_U(0x1) << GPIO_ODCR0C_P13_Pos)
+#define GPIO_ODCR0C_P14_Pos         14           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P14             (_U(0x1) << GPIO_ODCR0C_P14_Pos)
+#define GPIO_ODCR0C_P15_Pos         15           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P15             (_U(0x1) << GPIO_ODCR0C_P15_Pos)
+#define GPIO_ODCR0C_P16_Pos         16           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P16             (_U(0x1) << GPIO_ODCR0C_P16_Pos)
+#define GPIO_ODCR0C_P17_Pos         17           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P17             (_U(0x1) << GPIO_ODCR0C_P17_Pos)
+#define GPIO_ODCR0C_P18_Pos         18           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P18             (_U(0x1) << GPIO_ODCR0C_P18_Pos)
+#define GPIO_ODCR0C_P19_Pos         19           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P19             (_U(0x1) << GPIO_ODCR0C_P19_Pos)
+#define GPIO_ODCR0C_P20_Pos         20           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P20             (_U(0x1) << GPIO_ODCR0C_P20_Pos)
+#define GPIO_ODCR0C_P21_Pos         21           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P21             (_U(0x1) << GPIO_ODCR0C_P21_Pos)
+#define GPIO_ODCR0C_P22_Pos         22           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P22             (_U(0x1) << GPIO_ODCR0C_P22_Pos)
+#define GPIO_ODCR0C_P23_Pos         23           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P23             (_U(0x1) << GPIO_ODCR0C_P23_Pos)
+#define GPIO_ODCR0C_P24_Pos         24           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P24             (_U(0x1) << GPIO_ODCR0C_P24_Pos)
+#define GPIO_ODCR0C_P25_Pos         25           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P25             (_U(0x1) << GPIO_ODCR0C_P25_Pos)
+#define GPIO_ODCR0C_P26_Pos         26           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P26             (_U(0x1) << GPIO_ODCR0C_P26_Pos)
+#define GPIO_ODCR0C_P27_Pos         27           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P27             (_U(0x1) << GPIO_ODCR0C_P27_Pos)
+#define GPIO_ODCR0C_P28_Pos         28           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P28             (_U(0x1) << GPIO_ODCR0C_P28_Pos)
+#define GPIO_ODCR0C_P29_Pos         29           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P29             (_U(0x1) << GPIO_ODCR0C_P29_Pos)
+#define GPIO_ODCR0C_P30_Pos         30           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P30             (_U(0x1) << GPIO_ODCR0C_P30_Pos)
+#define GPIO_ODCR0C_P31_Pos         31           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0C_P31             (_U(0x1) << GPIO_ODCR0C_P31_Pos)
+#define GPIO_ODCR0C_MASK            _U(0xFFFFFFFF) /**< \brief (GPIO_ODCR0C) MASK Register */
+
+/* -------- GPIO_ODCR0T : (GPIO Offset: 0x10C) (R/W 32) port Output Driving Capability Register 0 - Toggle -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Output Driving Capability Register Bit 0 */
+    uint32_t P1:1;             /*!< bit:      1  Output Driving Capability Register Bit 0 */
+    uint32_t P2:1;             /*!< bit:      2  Output Driving Capability Register Bit 0 */
+    uint32_t P3:1;             /*!< bit:      3  Output Driving Capability Register Bit 0 */
+    uint32_t P4:1;             /*!< bit:      4  Output Driving Capability Register Bit 0 */
+    uint32_t P5:1;             /*!< bit:      5  Output Driving Capability Register Bit 0 */
+    uint32_t P6:1;             /*!< bit:      6  Output Driving Capability Register Bit 0 */
+    uint32_t P7:1;             /*!< bit:      7  Output Driving Capability Register Bit 0 */
+    uint32_t P8:1;             /*!< bit:      8  Output Driving Capability Register Bit 0 */
+    uint32_t P9:1;             /*!< bit:      9  Output Driving Capability Register Bit 0 */
+    uint32_t P10:1;            /*!< bit:     10  Output Driving Capability Register Bit 0 */
+    uint32_t P11:1;            /*!< bit:     11  Output Driving Capability Register Bit 0 */
+    uint32_t P12:1;            /*!< bit:     12  Output Driving Capability Register Bit 0 */
+    uint32_t P13:1;            /*!< bit:     13  Output Driving Capability Register Bit 0 */
+    uint32_t P14:1;            /*!< bit:     14  Output Driving Capability Register Bit 0 */
+    uint32_t P15:1;            /*!< bit:     15  Output Driving Capability Register Bit 0 */
+    uint32_t P16:1;            /*!< bit:     16  Output Driving Capability Register Bit 0 */
+    uint32_t P17:1;            /*!< bit:     17  Output Driving Capability Register Bit 0 */
+    uint32_t P18:1;            /*!< bit:     18  Output Driving Capability Register Bit 0 */
+    uint32_t P19:1;            /*!< bit:     19  Output Driving Capability Register Bit 0 */
+    uint32_t P20:1;            /*!< bit:     20  Output Driving Capability Register Bit 0 */
+    uint32_t P21:1;            /*!< bit:     21  Output Driving Capability Register Bit 0 */
+    uint32_t P22:1;            /*!< bit:     22  Output Driving Capability Register Bit 0 */
+    uint32_t P23:1;            /*!< bit:     23  Output Driving Capability Register Bit 0 */
+    uint32_t P24:1;            /*!< bit:     24  Output Driving Capability Register Bit 0 */
+    uint32_t P25:1;            /*!< bit:     25  Output Driving Capability Register Bit 0 */
+    uint32_t P26:1;            /*!< bit:     26  Output Driving Capability Register Bit 0 */
+    uint32_t P27:1;            /*!< bit:     27  Output Driving Capability Register Bit 0 */
+    uint32_t P28:1;            /*!< bit:     28  Output Driving Capability Register Bit 0 */
+    uint32_t P29:1;            /*!< bit:     29  Output Driving Capability Register Bit 0 */
+    uint32_t P30:1;            /*!< bit:     30  Output Driving Capability Register Bit 0 */
+    uint32_t P31:1;            /*!< bit:     31  Output Driving Capability Register Bit 0 */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_ODCR0T_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_ODCR0T_OFFSET          0x10C        /**< \brief (GPIO_ODCR0T offset) Output Driving Capability Register 0 - Toggle */
+
+#define GPIO_ODCR0T_P0_Pos          0            /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P0              (_U(0x1) << GPIO_ODCR0T_P0_Pos)
+#define GPIO_ODCR0T_P1_Pos          1            /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P1              (_U(0x1) << GPIO_ODCR0T_P1_Pos)
+#define GPIO_ODCR0T_P2_Pos          2            /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P2              (_U(0x1) << GPIO_ODCR0T_P2_Pos)
+#define GPIO_ODCR0T_P3_Pos          3            /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P3              (_U(0x1) << GPIO_ODCR0T_P3_Pos)
+#define GPIO_ODCR0T_P4_Pos          4            /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P4              (_U(0x1) << GPIO_ODCR0T_P4_Pos)
+#define GPIO_ODCR0T_P5_Pos          5            /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P5              (_U(0x1) << GPIO_ODCR0T_P5_Pos)
+#define GPIO_ODCR0T_P6_Pos          6            /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P6              (_U(0x1) << GPIO_ODCR0T_P6_Pos)
+#define GPIO_ODCR0T_P7_Pos          7            /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P7              (_U(0x1) << GPIO_ODCR0T_P7_Pos)
+#define GPIO_ODCR0T_P8_Pos          8            /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P8              (_U(0x1) << GPIO_ODCR0T_P8_Pos)
+#define GPIO_ODCR0T_P9_Pos          9            /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P9              (_U(0x1) << GPIO_ODCR0T_P9_Pos)
+#define GPIO_ODCR0T_P10_Pos         10           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P10             (_U(0x1) << GPIO_ODCR0T_P10_Pos)
+#define GPIO_ODCR0T_P11_Pos         11           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P11             (_U(0x1) << GPIO_ODCR0T_P11_Pos)
+#define GPIO_ODCR0T_P12_Pos         12           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P12             (_U(0x1) << GPIO_ODCR0T_P12_Pos)
+#define GPIO_ODCR0T_P13_Pos         13           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P13             (_U(0x1) << GPIO_ODCR0T_P13_Pos)
+#define GPIO_ODCR0T_P14_Pos         14           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P14             (_U(0x1) << GPIO_ODCR0T_P14_Pos)
+#define GPIO_ODCR0T_P15_Pos         15           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P15             (_U(0x1) << GPIO_ODCR0T_P15_Pos)
+#define GPIO_ODCR0T_P16_Pos         16           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P16             (_U(0x1) << GPIO_ODCR0T_P16_Pos)
+#define GPIO_ODCR0T_P17_Pos         17           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P17             (_U(0x1) << GPIO_ODCR0T_P17_Pos)
+#define GPIO_ODCR0T_P18_Pos         18           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P18             (_U(0x1) << GPIO_ODCR0T_P18_Pos)
+#define GPIO_ODCR0T_P19_Pos         19           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P19             (_U(0x1) << GPIO_ODCR0T_P19_Pos)
+#define GPIO_ODCR0T_P20_Pos         20           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P20             (_U(0x1) << GPIO_ODCR0T_P20_Pos)
+#define GPIO_ODCR0T_P21_Pos         21           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P21             (_U(0x1) << GPIO_ODCR0T_P21_Pos)
+#define GPIO_ODCR0T_P22_Pos         22           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P22             (_U(0x1) << GPIO_ODCR0T_P22_Pos)
+#define GPIO_ODCR0T_P23_Pos         23           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P23             (_U(0x1) << GPIO_ODCR0T_P23_Pos)
+#define GPIO_ODCR0T_P24_Pos         24           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P24             (_U(0x1) << GPIO_ODCR0T_P24_Pos)
+#define GPIO_ODCR0T_P25_Pos         25           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P25             (_U(0x1) << GPIO_ODCR0T_P25_Pos)
+#define GPIO_ODCR0T_P26_Pos         26           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P26             (_U(0x1) << GPIO_ODCR0T_P26_Pos)
+#define GPIO_ODCR0T_P27_Pos         27           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P27             (_U(0x1) << GPIO_ODCR0T_P27_Pos)
+#define GPIO_ODCR0T_P28_Pos         28           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P28             (_U(0x1) << GPIO_ODCR0T_P28_Pos)
+#define GPIO_ODCR0T_P29_Pos         29           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P29             (_U(0x1) << GPIO_ODCR0T_P29_Pos)
+#define GPIO_ODCR0T_P30_Pos         30           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P30             (_U(0x1) << GPIO_ODCR0T_P30_Pos)
+#define GPIO_ODCR0T_P31_Pos         31           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
+#define GPIO_ODCR0T_P31             (_U(0x1) << GPIO_ODCR0T_P31_Pos)
+#define GPIO_ODCR0T_MASK            _U(0xFFFFFFFF) /**< \brief (GPIO_ODCR0T) MASK Register */
+
+/* -------- GPIO_ODCR1 : (GPIO Offset: 0x110) (R/W 32) port Output Driving Capability Register 1 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Output Driving Capability Register Bit 1 */
+    uint32_t P1:1;             /*!< bit:      1  Output Driving Capability Register Bit 1 */
+    uint32_t P2:1;             /*!< bit:      2  Output Driving Capability Register Bit 1 */
+    uint32_t P3:1;             /*!< bit:      3  Output Driving Capability Register Bit 1 */
+    uint32_t P4:1;             /*!< bit:      4  Output Driving Capability Register Bit 1 */
+    uint32_t P5:1;             /*!< bit:      5  Output Driving Capability Register Bit 1 */
+    uint32_t P6:1;             /*!< bit:      6  Output Driving Capability Register Bit 1 */
+    uint32_t P7:1;             /*!< bit:      7  Output Driving Capability Register Bit 1 */
+    uint32_t P8:1;             /*!< bit:      8  Output Driving Capability Register Bit 1 */
+    uint32_t P9:1;             /*!< bit:      9  Output Driving Capability Register Bit 1 */
+    uint32_t P10:1;            /*!< bit:     10  Output Driving Capability Register Bit 1 */
+    uint32_t P11:1;            /*!< bit:     11  Output Driving Capability Register Bit 1 */
+    uint32_t P12:1;            /*!< bit:     12  Output Driving Capability Register Bit 1 */
+    uint32_t P13:1;            /*!< bit:     13  Output Driving Capability Register Bit 1 */
+    uint32_t P14:1;            /*!< bit:     14  Output Driving Capability Register Bit 1 */
+    uint32_t P15:1;            /*!< bit:     15  Output Driving Capability Register Bit 1 */
+    uint32_t P16:1;            /*!< bit:     16  Output Driving Capability Register Bit 1 */
+    uint32_t P17:1;            /*!< bit:     17  Output Driving Capability Register Bit 1 */
+    uint32_t P18:1;            /*!< bit:     18  Output Driving Capability Register Bit 1 */
+    uint32_t P19:1;            /*!< bit:     19  Output Driving Capability Register Bit 1 */
+    uint32_t P20:1;            /*!< bit:     20  Output Driving Capability Register Bit 1 */
+    uint32_t P21:1;            /*!< bit:     21  Output Driving Capability Register Bit 1 */
+    uint32_t P22:1;            /*!< bit:     22  Output Driving Capability Register Bit 1 */
+    uint32_t P23:1;            /*!< bit:     23  Output Driving Capability Register Bit 1 */
+    uint32_t P24:1;            /*!< bit:     24  Output Driving Capability Register Bit 1 */
+    uint32_t P25:1;            /*!< bit:     25  Output Driving Capability Register Bit 1 */
+    uint32_t P26:1;            /*!< bit:     26  Output Driving Capability Register Bit 1 */
+    uint32_t P27:1;            /*!< bit:     27  Output Driving Capability Register Bit 1 */
+    uint32_t P28:1;            /*!< bit:     28  Output Driving Capability Register Bit 1 */
+    uint32_t P29:1;            /*!< bit:     29  Output Driving Capability Register Bit 1 */
+    uint32_t P30:1;            /*!< bit:     30  Output Driving Capability Register Bit 1 */
+    uint32_t P31:1;            /*!< bit:     31  Output Driving Capability Register Bit 1 */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_ODCR1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_ODCR1_OFFSET           0x110        /**< \brief (GPIO_ODCR1 offset) Output Driving Capability Register 1 */
+
+#define GPIO_ODCR1_P0_Pos           0            /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P0               (_U(0x1) << GPIO_ODCR1_P0_Pos)
+#define GPIO_ODCR1_P1_Pos           1            /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P1               (_U(0x1) << GPIO_ODCR1_P1_Pos)
+#define GPIO_ODCR1_P2_Pos           2            /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P2               (_U(0x1) << GPIO_ODCR1_P2_Pos)
+#define GPIO_ODCR1_P3_Pos           3            /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P3               (_U(0x1) << GPIO_ODCR1_P3_Pos)
+#define GPIO_ODCR1_P4_Pos           4            /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P4               (_U(0x1) << GPIO_ODCR1_P4_Pos)
+#define GPIO_ODCR1_P5_Pos           5            /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P5               (_U(0x1) << GPIO_ODCR1_P5_Pos)
+#define GPIO_ODCR1_P6_Pos           6            /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P6               (_U(0x1) << GPIO_ODCR1_P6_Pos)
+#define GPIO_ODCR1_P7_Pos           7            /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P7               (_U(0x1) << GPIO_ODCR1_P7_Pos)
+#define GPIO_ODCR1_P8_Pos           8            /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P8               (_U(0x1) << GPIO_ODCR1_P8_Pos)
+#define GPIO_ODCR1_P9_Pos           9            /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P9               (_U(0x1) << GPIO_ODCR1_P9_Pos)
+#define GPIO_ODCR1_P10_Pos          10           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P10              (_U(0x1) << GPIO_ODCR1_P10_Pos)
+#define GPIO_ODCR1_P11_Pos          11           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P11              (_U(0x1) << GPIO_ODCR1_P11_Pos)
+#define GPIO_ODCR1_P12_Pos          12           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P12              (_U(0x1) << GPIO_ODCR1_P12_Pos)
+#define GPIO_ODCR1_P13_Pos          13           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P13              (_U(0x1) << GPIO_ODCR1_P13_Pos)
+#define GPIO_ODCR1_P14_Pos          14           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P14              (_U(0x1) << GPIO_ODCR1_P14_Pos)
+#define GPIO_ODCR1_P15_Pos          15           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P15              (_U(0x1) << GPIO_ODCR1_P15_Pos)
+#define GPIO_ODCR1_P16_Pos          16           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P16              (_U(0x1) << GPIO_ODCR1_P16_Pos)
+#define GPIO_ODCR1_P17_Pos          17           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P17              (_U(0x1) << GPIO_ODCR1_P17_Pos)
+#define GPIO_ODCR1_P18_Pos          18           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P18              (_U(0x1) << GPIO_ODCR1_P18_Pos)
+#define GPIO_ODCR1_P19_Pos          19           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P19              (_U(0x1) << GPIO_ODCR1_P19_Pos)
+#define GPIO_ODCR1_P20_Pos          20           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P20              (_U(0x1) << GPIO_ODCR1_P20_Pos)
+#define GPIO_ODCR1_P21_Pos          21           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P21              (_U(0x1) << GPIO_ODCR1_P21_Pos)
+#define GPIO_ODCR1_P22_Pos          22           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P22              (_U(0x1) << GPIO_ODCR1_P22_Pos)
+#define GPIO_ODCR1_P23_Pos          23           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P23              (_U(0x1) << GPIO_ODCR1_P23_Pos)
+#define GPIO_ODCR1_P24_Pos          24           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P24              (_U(0x1) << GPIO_ODCR1_P24_Pos)
+#define GPIO_ODCR1_P25_Pos          25           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P25              (_U(0x1) << GPIO_ODCR1_P25_Pos)
+#define GPIO_ODCR1_P26_Pos          26           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P26              (_U(0x1) << GPIO_ODCR1_P26_Pos)
+#define GPIO_ODCR1_P27_Pos          27           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P27              (_U(0x1) << GPIO_ODCR1_P27_Pos)
+#define GPIO_ODCR1_P28_Pos          28           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P28              (_U(0x1) << GPIO_ODCR1_P28_Pos)
+#define GPIO_ODCR1_P29_Pos          29           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P29              (_U(0x1) << GPIO_ODCR1_P29_Pos)
+#define GPIO_ODCR1_P30_Pos          30           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P30              (_U(0x1) << GPIO_ODCR1_P30_Pos)
+#define GPIO_ODCR1_P31_Pos          31           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1_P31              (_U(0x1) << GPIO_ODCR1_P31_Pos)
+#define GPIO_ODCR1_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_ODCR1) MASK Register */
+
+/* -------- GPIO_ODCR1S : (GPIO Offset: 0x114) (R/W 32) port Output Driving Capability Register 1 - Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Output Driving Capability Register Bit 1 */
+    uint32_t P1:1;             /*!< bit:      1  Output Driving Capability Register Bit 1 */
+    uint32_t P2:1;             /*!< bit:      2  Output Driving Capability Register Bit 1 */
+    uint32_t P3:1;             /*!< bit:      3  Output Driving Capability Register Bit 1 */
+    uint32_t P4:1;             /*!< bit:      4  Output Driving Capability Register Bit 1 */
+    uint32_t P5:1;             /*!< bit:      5  Output Driving Capability Register Bit 1 */
+    uint32_t P6:1;             /*!< bit:      6  Output Driving Capability Register Bit 1 */
+    uint32_t P7:1;             /*!< bit:      7  Output Driving Capability Register Bit 1 */
+    uint32_t P8:1;             /*!< bit:      8  Output Driving Capability Register Bit 1 */
+    uint32_t P9:1;             /*!< bit:      9  Output Driving Capability Register Bit 1 */
+    uint32_t P10:1;            /*!< bit:     10  Output Driving Capability Register Bit 1 */
+    uint32_t P11:1;            /*!< bit:     11  Output Driving Capability Register Bit 1 */
+    uint32_t P12:1;            /*!< bit:     12  Output Driving Capability Register Bit 1 */
+    uint32_t P13:1;            /*!< bit:     13  Output Driving Capability Register Bit 1 */
+    uint32_t P14:1;            /*!< bit:     14  Output Driving Capability Register Bit 1 */
+    uint32_t P15:1;            /*!< bit:     15  Output Driving Capability Register Bit 1 */
+    uint32_t P16:1;            /*!< bit:     16  Output Driving Capability Register Bit 1 */
+    uint32_t P17:1;            /*!< bit:     17  Output Driving Capability Register Bit 1 */
+    uint32_t P18:1;            /*!< bit:     18  Output Driving Capability Register Bit 1 */
+    uint32_t P19:1;            /*!< bit:     19  Output Driving Capability Register Bit 1 */
+    uint32_t P20:1;            /*!< bit:     20  Output Driving Capability Register Bit 1 */
+    uint32_t P21:1;            /*!< bit:     21  Output Driving Capability Register Bit 1 */
+    uint32_t P22:1;            /*!< bit:     22  Output Driving Capability Register Bit 1 */
+    uint32_t P23:1;            /*!< bit:     23  Output Driving Capability Register Bit 1 */
+    uint32_t P24:1;            /*!< bit:     24  Output Driving Capability Register Bit 1 */
+    uint32_t P25:1;            /*!< bit:     25  Output Driving Capability Register Bit 1 */
+    uint32_t P26:1;            /*!< bit:     26  Output Driving Capability Register Bit 1 */
+    uint32_t P27:1;            /*!< bit:     27  Output Driving Capability Register Bit 1 */
+    uint32_t P28:1;            /*!< bit:     28  Output Driving Capability Register Bit 1 */
+    uint32_t P29:1;            /*!< bit:     29  Output Driving Capability Register Bit 1 */
+    uint32_t P30:1;            /*!< bit:     30  Output Driving Capability Register Bit 1 */
+    uint32_t P31:1;            /*!< bit:     31  Output Driving Capability Register Bit 1 */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_ODCR1S_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_ODCR1S_OFFSET          0x114        /**< \brief (GPIO_ODCR1S offset) Output Driving Capability Register 1 - Set */
+
+#define GPIO_ODCR1S_P0_Pos          0            /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P0              (_U(0x1) << GPIO_ODCR1S_P0_Pos)
+#define GPIO_ODCR1S_P1_Pos          1            /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P1              (_U(0x1) << GPIO_ODCR1S_P1_Pos)
+#define GPIO_ODCR1S_P2_Pos          2            /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P2              (_U(0x1) << GPIO_ODCR1S_P2_Pos)
+#define GPIO_ODCR1S_P3_Pos          3            /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P3              (_U(0x1) << GPIO_ODCR1S_P3_Pos)
+#define GPIO_ODCR1S_P4_Pos          4            /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P4              (_U(0x1) << GPIO_ODCR1S_P4_Pos)
+#define GPIO_ODCR1S_P5_Pos          5            /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P5              (_U(0x1) << GPIO_ODCR1S_P5_Pos)
+#define GPIO_ODCR1S_P6_Pos          6            /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P6              (_U(0x1) << GPIO_ODCR1S_P6_Pos)
+#define GPIO_ODCR1S_P7_Pos          7            /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P7              (_U(0x1) << GPIO_ODCR1S_P7_Pos)
+#define GPIO_ODCR1S_P8_Pos          8            /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P8              (_U(0x1) << GPIO_ODCR1S_P8_Pos)
+#define GPIO_ODCR1S_P9_Pos          9            /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P9              (_U(0x1) << GPIO_ODCR1S_P9_Pos)
+#define GPIO_ODCR1S_P10_Pos         10           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P10             (_U(0x1) << GPIO_ODCR1S_P10_Pos)
+#define GPIO_ODCR1S_P11_Pos         11           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P11             (_U(0x1) << GPIO_ODCR1S_P11_Pos)
+#define GPIO_ODCR1S_P12_Pos         12           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P12             (_U(0x1) << GPIO_ODCR1S_P12_Pos)
+#define GPIO_ODCR1S_P13_Pos         13           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P13             (_U(0x1) << GPIO_ODCR1S_P13_Pos)
+#define GPIO_ODCR1S_P14_Pos         14           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P14             (_U(0x1) << GPIO_ODCR1S_P14_Pos)
+#define GPIO_ODCR1S_P15_Pos         15           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P15             (_U(0x1) << GPIO_ODCR1S_P15_Pos)
+#define GPIO_ODCR1S_P16_Pos         16           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P16             (_U(0x1) << GPIO_ODCR1S_P16_Pos)
+#define GPIO_ODCR1S_P17_Pos         17           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P17             (_U(0x1) << GPIO_ODCR1S_P17_Pos)
+#define GPIO_ODCR1S_P18_Pos         18           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P18             (_U(0x1) << GPIO_ODCR1S_P18_Pos)
+#define GPIO_ODCR1S_P19_Pos         19           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P19             (_U(0x1) << GPIO_ODCR1S_P19_Pos)
+#define GPIO_ODCR1S_P20_Pos         20           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P20             (_U(0x1) << GPIO_ODCR1S_P20_Pos)
+#define GPIO_ODCR1S_P21_Pos         21           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P21             (_U(0x1) << GPIO_ODCR1S_P21_Pos)
+#define GPIO_ODCR1S_P22_Pos         22           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P22             (_U(0x1) << GPIO_ODCR1S_P22_Pos)
+#define GPIO_ODCR1S_P23_Pos         23           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P23             (_U(0x1) << GPIO_ODCR1S_P23_Pos)
+#define GPIO_ODCR1S_P24_Pos         24           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P24             (_U(0x1) << GPIO_ODCR1S_P24_Pos)
+#define GPIO_ODCR1S_P25_Pos         25           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P25             (_U(0x1) << GPIO_ODCR1S_P25_Pos)
+#define GPIO_ODCR1S_P26_Pos         26           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P26             (_U(0x1) << GPIO_ODCR1S_P26_Pos)
+#define GPIO_ODCR1S_P27_Pos         27           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P27             (_U(0x1) << GPIO_ODCR1S_P27_Pos)
+#define GPIO_ODCR1S_P28_Pos         28           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P28             (_U(0x1) << GPIO_ODCR1S_P28_Pos)
+#define GPIO_ODCR1S_P29_Pos         29           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P29             (_U(0x1) << GPIO_ODCR1S_P29_Pos)
+#define GPIO_ODCR1S_P30_Pos         30           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P30             (_U(0x1) << GPIO_ODCR1S_P30_Pos)
+#define GPIO_ODCR1S_P31_Pos         31           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1S_P31             (_U(0x1) << GPIO_ODCR1S_P31_Pos)
+#define GPIO_ODCR1S_MASK            _U(0xFFFFFFFF) /**< \brief (GPIO_ODCR1S) MASK Register */
+
+/* -------- GPIO_ODCR1C : (GPIO Offset: 0x118) (R/W 32) port Output Driving Capability Register 1 - Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Output Driving Capability Register Bit 1 */
+    uint32_t P1:1;             /*!< bit:      1  Output Driving Capability Register Bit 1 */
+    uint32_t P2:1;             /*!< bit:      2  Output Driving Capability Register Bit 1 */
+    uint32_t P3:1;             /*!< bit:      3  Output Driving Capability Register Bit 1 */
+    uint32_t P4:1;             /*!< bit:      4  Output Driving Capability Register Bit 1 */
+    uint32_t P5:1;             /*!< bit:      5  Output Driving Capability Register Bit 1 */
+    uint32_t P6:1;             /*!< bit:      6  Output Driving Capability Register Bit 1 */
+    uint32_t P7:1;             /*!< bit:      7  Output Driving Capability Register Bit 1 */
+    uint32_t P8:1;             /*!< bit:      8  Output Driving Capability Register Bit 1 */
+    uint32_t P9:1;             /*!< bit:      9  Output Driving Capability Register Bit 1 */
+    uint32_t P10:1;            /*!< bit:     10  Output Driving Capability Register Bit 1 */
+    uint32_t P11:1;            /*!< bit:     11  Output Driving Capability Register Bit 1 */
+    uint32_t P12:1;            /*!< bit:     12  Output Driving Capability Register Bit 1 */
+    uint32_t P13:1;            /*!< bit:     13  Output Driving Capability Register Bit 1 */
+    uint32_t P14:1;            /*!< bit:     14  Output Driving Capability Register Bit 1 */
+    uint32_t P15:1;            /*!< bit:     15  Output Driving Capability Register Bit 1 */
+    uint32_t P16:1;            /*!< bit:     16  Output Driving Capability Register Bit 1 */
+    uint32_t P17:1;            /*!< bit:     17  Output Driving Capability Register Bit 1 */
+    uint32_t P18:1;            /*!< bit:     18  Output Driving Capability Register Bit 1 */
+    uint32_t P19:1;            /*!< bit:     19  Output Driving Capability Register Bit 1 */
+    uint32_t P20:1;            /*!< bit:     20  Output Driving Capability Register Bit 1 */
+    uint32_t P21:1;            /*!< bit:     21  Output Driving Capability Register Bit 1 */
+    uint32_t P22:1;            /*!< bit:     22  Output Driving Capability Register Bit 1 */
+    uint32_t P23:1;            /*!< bit:     23  Output Driving Capability Register Bit 1 */
+    uint32_t P24:1;            /*!< bit:     24  Output Driving Capability Register Bit 1 */
+    uint32_t P25:1;            /*!< bit:     25  Output Driving Capability Register Bit 1 */
+    uint32_t P26:1;            /*!< bit:     26  Output Driving Capability Register Bit 1 */
+    uint32_t P27:1;            /*!< bit:     27  Output Driving Capability Register Bit 1 */
+    uint32_t P28:1;            /*!< bit:     28  Output Driving Capability Register Bit 1 */
+    uint32_t P29:1;            /*!< bit:     29  Output Driving Capability Register Bit 1 */
+    uint32_t P30:1;            /*!< bit:     30  Output Driving Capability Register Bit 1 */
+    uint32_t P31:1;            /*!< bit:     31  Output Driving Capability Register Bit 1 */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_ODCR1C_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_ODCR1C_OFFSET          0x118        /**< \brief (GPIO_ODCR1C offset) Output Driving Capability Register 1 - Clear */
+
+#define GPIO_ODCR1C_P0_Pos          0            /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P0              (_U(0x1) << GPIO_ODCR1C_P0_Pos)
+#define GPIO_ODCR1C_P1_Pos          1            /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P1              (_U(0x1) << GPIO_ODCR1C_P1_Pos)
+#define GPIO_ODCR1C_P2_Pos          2            /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P2              (_U(0x1) << GPIO_ODCR1C_P2_Pos)
+#define GPIO_ODCR1C_P3_Pos          3            /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P3              (_U(0x1) << GPIO_ODCR1C_P3_Pos)
+#define GPIO_ODCR1C_P4_Pos          4            /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P4              (_U(0x1) << GPIO_ODCR1C_P4_Pos)
+#define GPIO_ODCR1C_P5_Pos          5            /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P5              (_U(0x1) << GPIO_ODCR1C_P5_Pos)
+#define GPIO_ODCR1C_P6_Pos          6            /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P6              (_U(0x1) << GPIO_ODCR1C_P6_Pos)
+#define GPIO_ODCR1C_P7_Pos          7            /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P7              (_U(0x1) << GPIO_ODCR1C_P7_Pos)
+#define GPIO_ODCR1C_P8_Pos          8            /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P8              (_U(0x1) << GPIO_ODCR1C_P8_Pos)
+#define GPIO_ODCR1C_P9_Pos          9            /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P9              (_U(0x1) << GPIO_ODCR1C_P9_Pos)
+#define GPIO_ODCR1C_P10_Pos         10           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P10             (_U(0x1) << GPIO_ODCR1C_P10_Pos)
+#define GPIO_ODCR1C_P11_Pos         11           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P11             (_U(0x1) << GPIO_ODCR1C_P11_Pos)
+#define GPIO_ODCR1C_P12_Pos         12           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P12             (_U(0x1) << GPIO_ODCR1C_P12_Pos)
+#define GPIO_ODCR1C_P13_Pos         13           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P13             (_U(0x1) << GPIO_ODCR1C_P13_Pos)
+#define GPIO_ODCR1C_P14_Pos         14           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P14             (_U(0x1) << GPIO_ODCR1C_P14_Pos)
+#define GPIO_ODCR1C_P15_Pos         15           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P15             (_U(0x1) << GPIO_ODCR1C_P15_Pos)
+#define GPIO_ODCR1C_P16_Pos         16           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P16             (_U(0x1) << GPIO_ODCR1C_P16_Pos)
+#define GPIO_ODCR1C_P17_Pos         17           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P17             (_U(0x1) << GPIO_ODCR1C_P17_Pos)
+#define GPIO_ODCR1C_P18_Pos         18           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P18             (_U(0x1) << GPIO_ODCR1C_P18_Pos)
+#define GPIO_ODCR1C_P19_Pos         19           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P19             (_U(0x1) << GPIO_ODCR1C_P19_Pos)
+#define GPIO_ODCR1C_P20_Pos         20           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P20             (_U(0x1) << GPIO_ODCR1C_P20_Pos)
+#define GPIO_ODCR1C_P21_Pos         21           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P21             (_U(0x1) << GPIO_ODCR1C_P21_Pos)
+#define GPIO_ODCR1C_P22_Pos         22           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P22             (_U(0x1) << GPIO_ODCR1C_P22_Pos)
+#define GPIO_ODCR1C_P23_Pos         23           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P23             (_U(0x1) << GPIO_ODCR1C_P23_Pos)
+#define GPIO_ODCR1C_P24_Pos         24           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P24             (_U(0x1) << GPIO_ODCR1C_P24_Pos)
+#define GPIO_ODCR1C_P25_Pos         25           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P25             (_U(0x1) << GPIO_ODCR1C_P25_Pos)
+#define GPIO_ODCR1C_P26_Pos         26           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P26             (_U(0x1) << GPIO_ODCR1C_P26_Pos)
+#define GPIO_ODCR1C_P27_Pos         27           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P27             (_U(0x1) << GPIO_ODCR1C_P27_Pos)
+#define GPIO_ODCR1C_P28_Pos         28           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P28             (_U(0x1) << GPIO_ODCR1C_P28_Pos)
+#define GPIO_ODCR1C_P29_Pos         29           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P29             (_U(0x1) << GPIO_ODCR1C_P29_Pos)
+#define GPIO_ODCR1C_P30_Pos         30           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P30             (_U(0x1) << GPIO_ODCR1C_P30_Pos)
+#define GPIO_ODCR1C_P31_Pos         31           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1C_P31             (_U(0x1) << GPIO_ODCR1C_P31_Pos)
+#define GPIO_ODCR1C_MASK            _U(0xFFFFFFFF) /**< \brief (GPIO_ODCR1C) MASK Register */
+
+/* -------- GPIO_ODCR1T : (GPIO Offset: 0x11C) (R/W 32) port Output Driving Capability Register 1 - Toggle -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Output Driving Capability Register Bit 1 */
+    uint32_t P1:1;             /*!< bit:      1  Output Driving Capability Register Bit 1 */
+    uint32_t P2:1;             /*!< bit:      2  Output Driving Capability Register Bit 1 */
+    uint32_t P3:1;             /*!< bit:      3  Output Driving Capability Register Bit 1 */
+    uint32_t P4:1;             /*!< bit:      4  Output Driving Capability Register Bit 1 */
+    uint32_t P5:1;             /*!< bit:      5  Output Driving Capability Register Bit 1 */
+    uint32_t P6:1;             /*!< bit:      6  Output Driving Capability Register Bit 1 */
+    uint32_t P7:1;             /*!< bit:      7  Output Driving Capability Register Bit 1 */
+    uint32_t P8:1;             /*!< bit:      8  Output Driving Capability Register Bit 1 */
+    uint32_t P9:1;             /*!< bit:      9  Output Driving Capability Register Bit 1 */
+    uint32_t P10:1;            /*!< bit:     10  Output Driving Capability Register Bit 1 */
+    uint32_t P11:1;            /*!< bit:     11  Output Driving Capability Register Bit 1 */
+    uint32_t P12:1;            /*!< bit:     12  Output Driving Capability Register Bit 1 */
+    uint32_t P13:1;            /*!< bit:     13  Output Driving Capability Register Bit 1 */
+    uint32_t P14:1;            /*!< bit:     14  Output Driving Capability Register Bit 1 */
+    uint32_t P15:1;            /*!< bit:     15  Output Driving Capability Register Bit 1 */
+    uint32_t P16:1;            /*!< bit:     16  Output Driving Capability Register Bit 1 */
+    uint32_t P17:1;            /*!< bit:     17  Output Driving Capability Register Bit 1 */
+    uint32_t P18:1;            /*!< bit:     18  Output Driving Capability Register Bit 1 */
+    uint32_t P19:1;            /*!< bit:     19  Output Driving Capability Register Bit 1 */
+    uint32_t P20:1;            /*!< bit:     20  Output Driving Capability Register Bit 1 */
+    uint32_t P21:1;            /*!< bit:     21  Output Driving Capability Register Bit 1 */
+    uint32_t P22:1;            /*!< bit:     22  Output Driving Capability Register Bit 1 */
+    uint32_t P23:1;            /*!< bit:     23  Output Driving Capability Register Bit 1 */
+    uint32_t P24:1;            /*!< bit:     24  Output Driving Capability Register Bit 1 */
+    uint32_t P25:1;            /*!< bit:     25  Output Driving Capability Register Bit 1 */
+    uint32_t P26:1;            /*!< bit:     26  Output Driving Capability Register Bit 1 */
+    uint32_t P27:1;            /*!< bit:     27  Output Driving Capability Register Bit 1 */
+    uint32_t P28:1;            /*!< bit:     28  Output Driving Capability Register Bit 1 */
+    uint32_t P29:1;            /*!< bit:     29  Output Driving Capability Register Bit 1 */
+    uint32_t P30:1;            /*!< bit:     30  Output Driving Capability Register Bit 1 */
+    uint32_t P31:1;            /*!< bit:     31  Output Driving Capability Register Bit 1 */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_ODCR1T_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_ODCR1T_OFFSET          0x11C        /**< \brief (GPIO_ODCR1T offset) Output Driving Capability Register 1 - Toggle */
+
+#define GPIO_ODCR1T_P0_Pos          0            /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P0              (_U(0x1) << GPIO_ODCR1T_P0_Pos)
+#define GPIO_ODCR1T_P1_Pos          1            /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P1              (_U(0x1) << GPIO_ODCR1T_P1_Pos)
+#define GPIO_ODCR1T_P2_Pos          2            /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P2              (_U(0x1) << GPIO_ODCR1T_P2_Pos)
+#define GPIO_ODCR1T_P3_Pos          3            /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P3              (_U(0x1) << GPIO_ODCR1T_P3_Pos)
+#define GPIO_ODCR1T_P4_Pos          4            /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P4              (_U(0x1) << GPIO_ODCR1T_P4_Pos)
+#define GPIO_ODCR1T_P5_Pos          5            /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P5              (_U(0x1) << GPIO_ODCR1T_P5_Pos)
+#define GPIO_ODCR1T_P6_Pos          6            /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P6              (_U(0x1) << GPIO_ODCR1T_P6_Pos)
+#define GPIO_ODCR1T_P7_Pos          7            /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P7              (_U(0x1) << GPIO_ODCR1T_P7_Pos)
+#define GPIO_ODCR1T_P8_Pos          8            /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P8              (_U(0x1) << GPIO_ODCR1T_P8_Pos)
+#define GPIO_ODCR1T_P9_Pos          9            /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P9              (_U(0x1) << GPIO_ODCR1T_P9_Pos)
+#define GPIO_ODCR1T_P10_Pos         10           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P10             (_U(0x1) << GPIO_ODCR1T_P10_Pos)
+#define GPIO_ODCR1T_P11_Pos         11           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P11             (_U(0x1) << GPIO_ODCR1T_P11_Pos)
+#define GPIO_ODCR1T_P12_Pos         12           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P12             (_U(0x1) << GPIO_ODCR1T_P12_Pos)
+#define GPIO_ODCR1T_P13_Pos         13           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P13             (_U(0x1) << GPIO_ODCR1T_P13_Pos)
+#define GPIO_ODCR1T_P14_Pos         14           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P14             (_U(0x1) << GPIO_ODCR1T_P14_Pos)
+#define GPIO_ODCR1T_P15_Pos         15           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P15             (_U(0x1) << GPIO_ODCR1T_P15_Pos)
+#define GPIO_ODCR1T_P16_Pos         16           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P16             (_U(0x1) << GPIO_ODCR1T_P16_Pos)
+#define GPIO_ODCR1T_P17_Pos         17           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P17             (_U(0x1) << GPIO_ODCR1T_P17_Pos)
+#define GPIO_ODCR1T_P18_Pos         18           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P18             (_U(0x1) << GPIO_ODCR1T_P18_Pos)
+#define GPIO_ODCR1T_P19_Pos         19           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P19             (_U(0x1) << GPIO_ODCR1T_P19_Pos)
+#define GPIO_ODCR1T_P20_Pos         20           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P20             (_U(0x1) << GPIO_ODCR1T_P20_Pos)
+#define GPIO_ODCR1T_P21_Pos         21           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P21             (_U(0x1) << GPIO_ODCR1T_P21_Pos)
+#define GPIO_ODCR1T_P22_Pos         22           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P22             (_U(0x1) << GPIO_ODCR1T_P22_Pos)
+#define GPIO_ODCR1T_P23_Pos         23           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P23             (_U(0x1) << GPIO_ODCR1T_P23_Pos)
+#define GPIO_ODCR1T_P24_Pos         24           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P24             (_U(0x1) << GPIO_ODCR1T_P24_Pos)
+#define GPIO_ODCR1T_P25_Pos         25           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P25             (_U(0x1) << GPIO_ODCR1T_P25_Pos)
+#define GPIO_ODCR1T_P26_Pos         26           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P26             (_U(0x1) << GPIO_ODCR1T_P26_Pos)
+#define GPIO_ODCR1T_P27_Pos         27           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P27             (_U(0x1) << GPIO_ODCR1T_P27_Pos)
+#define GPIO_ODCR1T_P28_Pos         28           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P28             (_U(0x1) << GPIO_ODCR1T_P28_Pos)
+#define GPIO_ODCR1T_P29_Pos         29           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P29             (_U(0x1) << GPIO_ODCR1T_P29_Pos)
+#define GPIO_ODCR1T_P30_Pos         30           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P30             (_U(0x1) << GPIO_ODCR1T_P30_Pos)
+#define GPIO_ODCR1T_P31_Pos         31           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
+#define GPIO_ODCR1T_P31             (_U(0x1) << GPIO_ODCR1T_P31_Pos)
+#define GPIO_ODCR1T_MASK            _U(0xFFFFFFFF) /**< \brief (GPIO_ODCR1T) MASK Register */
+
+/* -------- GPIO_OSRR0 : (GPIO Offset: 0x130) (R/W 32) port Output Slew Rate Register 0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Output Slew Rate Control Enable    */
+    uint32_t P1:1;             /*!< bit:      1  Output Slew Rate Control Enable    */
+    uint32_t P2:1;             /*!< bit:      2  Output Slew Rate Control Enable    */
+    uint32_t P3:1;             /*!< bit:      3  Output Slew Rate Control Enable    */
+    uint32_t P4:1;             /*!< bit:      4  Output Slew Rate Control Enable    */
+    uint32_t P5:1;             /*!< bit:      5  Output Slew Rate Control Enable    */
+    uint32_t P6:1;             /*!< bit:      6  Output Slew Rate Control Enable    */
+    uint32_t P7:1;             /*!< bit:      7  Output Slew Rate Control Enable    */
+    uint32_t P8:1;             /*!< bit:      8  Output Slew Rate Control Enable    */
+    uint32_t P9:1;             /*!< bit:      9  Output Slew Rate Control Enable    */
+    uint32_t P10:1;            /*!< bit:     10  Output Slew Rate Control Enable    */
+    uint32_t P11:1;            /*!< bit:     11  Output Slew Rate Control Enable    */
+    uint32_t P12:1;            /*!< bit:     12  Output Slew Rate Control Enable    */
+    uint32_t P13:1;            /*!< bit:     13  Output Slew Rate Control Enable    */
+    uint32_t P14:1;            /*!< bit:     14  Output Slew Rate Control Enable    */
+    uint32_t P15:1;            /*!< bit:     15  Output Slew Rate Control Enable    */
+    uint32_t P16:1;            /*!< bit:     16  Output Slew Rate Control Enable    */
+    uint32_t P17:1;            /*!< bit:     17  Output Slew Rate Control Enable    */
+    uint32_t P18:1;            /*!< bit:     18  Output Slew Rate Control Enable    */
+    uint32_t P19:1;            /*!< bit:     19  Output Slew Rate Control Enable    */
+    uint32_t P20:1;            /*!< bit:     20  Output Slew Rate Control Enable    */
+    uint32_t P21:1;            /*!< bit:     21  Output Slew Rate Control Enable    */
+    uint32_t P22:1;            /*!< bit:     22  Output Slew Rate Control Enable    */
+    uint32_t P23:1;            /*!< bit:     23  Output Slew Rate Control Enable    */
+    uint32_t P24:1;            /*!< bit:     24  Output Slew Rate Control Enable    */
+    uint32_t P25:1;            /*!< bit:     25  Output Slew Rate Control Enable    */
+    uint32_t P26:1;            /*!< bit:     26  Output Slew Rate Control Enable    */
+    uint32_t P27:1;            /*!< bit:     27  Output Slew Rate Control Enable    */
+    uint32_t P28:1;            /*!< bit:     28  Output Slew Rate Control Enable    */
+    uint32_t P29:1;            /*!< bit:     29  Output Slew Rate Control Enable    */
+    uint32_t P30:1;            /*!< bit:     30  Output Slew Rate Control Enable    */
+    uint32_t P31:1;            /*!< bit:     31  Output Slew Rate Control Enable    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_OSRR0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_OSRR0_OFFSET           0x130        /**< \brief (GPIO_OSRR0 offset) Output Slew Rate Register 0 */
+
+#define GPIO_OSRR0_P0_Pos           0            /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P0               (_U(0x1) << GPIO_OSRR0_P0_Pos)
+#define GPIO_OSRR0_P1_Pos           1            /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P1               (_U(0x1) << GPIO_OSRR0_P1_Pos)
+#define GPIO_OSRR0_P2_Pos           2            /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P2               (_U(0x1) << GPIO_OSRR0_P2_Pos)
+#define GPIO_OSRR0_P3_Pos           3            /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P3               (_U(0x1) << GPIO_OSRR0_P3_Pos)
+#define GPIO_OSRR0_P4_Pos           4            /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P4               (_U(0x1) << GPIO_OSRR0_P4_Pos)
+#define GPIO_OSRR0_P5_Pos           5            /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P5               (_U(0x1) << GPIO_OSRR0_P5_Pos)
+#define GPIO_OSRR0_P6_Pos           6            /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P6               (_U(0x1) << GPIO_OSRR0_P6_Pos)
+#define GPIO_OSRR0_P7_Pos           7            /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P7               (_U(0x1) << GPIO_OSRR0_P7_Pos)
+#define GPIO_OSRR0_P8_Pos           8            /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P8               (_U(0x1) << GPIO_OSRR0_P8_Pos)
+#define GPIO_OSRR0_P9_Pos           9            /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P9               (_U(0x1) << GPIO_OSRR0_P9_Pos)
+#define GPIO_OSRR0_P10_Pos          10           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P10              (_U(0x1) << GPIO_OSRR0_P10_Pos)
+#define GPIO_OSRR0_P11_Pos          11           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P11              (_U(0x1) << GPIO_OSRR0_P11_Pos)
+#define GPIO_OSRR0_P12_Pos          12           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P12              (_U(0x1) << GPIO_OSRR0_P12_Pos)
+#define GPIO_OSRR0_P13_Pos          13           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P13              (_U(0x1) << GPIO_OSRR0_P13_Pos)
+#define GPIO_OSRR0_P14_Pos          14           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P14              (_U(0x1) << GPIO_OSRR0_P14_Pos)
+#define GPIO_OSRR0_P15_Pos          15           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P15              (_U(0x1) << GPIO_OSRR0_P15_Pos)
+#define GPIO_OSRR0_P16_Pos          16           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P16              (_U(0x1) << GPIO_OSRR0_P16_Pos)
+#define GPIO_OSRR0_P17_Pos          17           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P17              (_U(0x1) << GPIO_OSRR0_P17_Pos)
+#define GPIO_OSRR0_P18_Pos          18           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P18              (_U(0x1) << GPIO_OSRR0_P18_Pos)
+#define GPIO_OSRR0_P19_Pos          19           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P19              (_U(0x1) << GPIO_OSRR0_P19_Pos)
+#define GPIO_OSRR0_P20_Pos          20           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P20              (_U(0x1) << GPIO_OSRR0_P20_Pos)
+#define GPIO_OSRR0_P21_Pos          21           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P21              (_U(0x1) << GPIO_OSRR0_P21_Pos)
+#define GPIO_OSRR0_P22_Pos          22           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P22              (_U(0x1) << GPIO_OSRR0_P22_Pos)
+#define GPIO_OSRR0_P23_Pos          23           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P23              (_U(0x1) << GPIO_OSRR0_P23_Pos)
+#define GPIO_OSRR0_P24_Pos          24           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P24              (_U(0x1) << GPIO_OSRR0_P24_Pos)
+#define GPIO_OSRR0_P25_Pos          25           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P25              (_U(0x1) << GPIO_OSRR0_P25_Pos)
+#define GPIO_OSRR0_P26_Pos          26           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P26              (_U(0x1) << GPIO_OSRR0_P26_Pos)
+#define GPIO_OSRR0_P27_Pos          27           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P27              (_U(0x1) << GPIO_OSRR0_P27_Pos)
+#define GPIO_OSRR0_P28_Pos          28           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P28              (_U(0x1) << GPIO_OSRR0_P28_Pos)
+#define GPIO_OSRR0_P29_Pos          29           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P29              (_U(0x1) << GPIO_OSRR0_P29_Pos)
+#define GPIO_OSRR0_P30_Pos          30           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P30              (_U(0x1) << GPIO_OSRR0_P30_Pos)
+#define GPIO_OSRR0_P31_Pos          31           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
+#define GPIO_OSRR0_P31              (_U(0x1) << GPIO_OSRR0_P31_Pos)
+#define GPIO_OSRR0_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_OSRR0) MASK Register */
+
+/* -------- GPIO_OSRR0S : (GPIO Offset: 0x134) (R/W 32) port Output Slew Rate Register 0 - Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Output Slew Rate Control Enable    */
+    uint32_t P1:1;             /*!< bit:      1  Output Slew Rate Control Enable    */
+    uint32_t P2:1;             /*!< bit:      2  Output Slew Rate Control Enable    */
+    uint32_t P3:1;             /*!< bit:      3  Output Slew Rate Control Enable    */
+    uint32_t P4:1;             /*!< bit:      4  Output Slew Rate Control Enable    */
+    uint32_t P5:1;             /*!< bit:      5  Output Slew Rate Control Enable    */
+    uint32_t P6:1;             /*!< bit:      6  Output Slew Rate Control Enable    */
+    uint32_t P7:1;             /*!< bit:      7  Output Slew Rate Control Enable    */
+    uint32_t P8:1;             /*!< bit:      8  Output Slew Rate Control Enable    */
+    uint32_t P9:1;             /*!< bit:      9  Output Slew Rate Control Enable    */
+    uint32_t P10:1;            /*!< bit:     10  Output Slew Rate Control Enable    */
+    uint32_t P11:1;            /*!< bit:     11  Output Slew Rate Control Enable    */
+    uint32_t P12:1;            /*!< bit:     12  Output Slew Rate Control Enable    */
+    uint32_t P13:1;            /*!< bit:     13  Output Slew Rate Control Enable    */
+    uint32_t P14:1;            /*!< bit:     14  Output Slew Rate Control Enable    */
+    uint32_t P15:1;            /*!< bit:     15  Output Slew Rate Control Enable    */
+    uint32_t P16:1;            /*!< bit:     16  Output Slew Rate Control Enable    */
+    uint32_t P17:1;            /*!< bit:     17  Output Slew Rate Control Enable    */
+    uint32_t P18:1;            /*!< bit:     18  Output Slew Rate Control Enable    */
+    uint32_t P19:1;            /*!< bit:     19  Output Slew Rate Control Enable    */
+    uint32_t P20:1;            /*!< bit:     20  Output Slew Rate Control Enable    */
+    uint32_t P21:1;            /*!< bit:     21  Output Slew Rate Control Enable    */
+    uint32_t P22:1;            /*!< bit:     22  Output Slew Rate Control Enable    */
+    uint32_t P23:1;            /*!< bit:     23  Output Slew Rate Control Enable    */
+    uint32_t P24:1;            /*!< bit:     24  Output Slew Rate Control Enable    */
+    uint32_t P25:1;            /*!< bit:     25  Output Slew Rate Control Enable    */
+    uint32_t P26:1;            /*!< bit:     26  Output Slew Rate Control Enable    */
+    uint32_t P27:1;            /*!< bit:     27  Output Slew Rate Control Enable    */
+    uint32_t P28:1;            /*!< bit:     28  Output Slew Rate Control Enable    */
+    uint32_t P29:1;            /*!< bit:     29  Output Slew Rate Control Enable    */
+    uint32_t P30:1;            /*!< bit:     30  Output Slew Rate Control Enable    */
+    uint32_t P31:1;            /*!< bit:     31  Output Slew Rate Control Enable    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_OSRR0S_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_OSRR0S_OFFSET          0x134        /**< \brief (GPIO_OSRR0S offset) Output Slew Rate Register 0 - Set */
+
+#define GPIO_OSRR0S_P0_Pos          0            /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P0              (_U(0x1) << GPIO_OSRR0S_P0_Pos)
+#define GPIO_OSRR0S_P1_Pos          1            /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P1              (_U(0x1) << GPIO_OSRR0S_P1_Pos)
+#define GPIO_OSRR0S_P2_Pos          2            /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P2              (_U(0x1) << GPIO_OSRR0S_P2_Pos)
+#define GPIO_OSRR0S_P3_Pos          3            /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P3              (_U(0x1) << GPIO_OSRR0S_P3_Pos)
+#define GPIO_OSRR0S_P4_Pos          4            /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P4              (_U(0x1) << GPIO_OSRR0S_P4_Pos)
+#define GPIO_OSRR0S_P5_Pos          5            /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P5              (_U(0x1) << GPIO_OSRR0S_P5_Pos)
+#define GPIO_OSRR0S_P6_Pos          6            /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P6              (_U(0x1) << GPIO_OSRR0S_P6_Pos)
+#define GPIO_OSRR0S_P7_Pos          7            /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P7              (_U(0x1) << GPIO_OSRR0S_P7_Pos)
+#define GPIO_OSRR0S_P8_Pos          8            /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P8              (_U(0x1) << GPIO_OSRR0S_P8_Pos)
+#define GPIO_OSRR0S_P9_Pos          9            /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P9              (_U(0x1) << GPIO_OSRR0S_P9_Pos)
+#define GPIO_OSRR0S_P10_Pos         10           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P10             (_U(0x1) << GPIO_OSRR0S_P10_Pos)
+#define GPIO_OSRR0S_P11_Pos         11           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P11             (_U(0x1) << GPIO_OSRR0S_P11_Pos)
+#define GPIO_OSRR0S_P12_Pos         12           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P12             (_U(0x1) << GPIO_OSRR0S_P12_Pos)
+#define GPIO_OSRR0S_P13_Pos         13           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P13             (_U(0x1) << GPIO_OSRR0S_P13_Pos)
+#define GPIO_OSRR0S_P14_Pos         14           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P14             (_U(0x1) << GPIO_OSRR0S_P14_Pos)
+#define GPIO_OSRR0S_P15_Pos         15           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P15             (_U(0x1) << GPIO_OSRR0S_P15_Pos)
+#define GPIO_OSRR0S_P16_Pos         16           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P16             (_U(0x1) << GPIO_OSRR0S_P16_Pos)
+#define GPIO_OSRR0S_P17_Pos         17           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P17             (_U(0x1) << GPIO_OSRR0S_P17_Pos)
+#define GPIO_OSRR0S_P18_Pos         18           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P18             (_U(0x1) << GPIO_OSRR0S_P18_Pos)
+#define GPIO_OSRR0S_P19_Pos         19           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P19             (_U(0x1) << GPIO_OSRR0S_P19_Pos)
+#define GPIO_OSRR0S_P20_Pos         20           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P20             (_U(0x1) << GPIO_OSRR0S_P20_Pos)
+#define GPIO_OSRR0S_P21_Pos         21           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P21             (_U(0x1) << GPIO_OSRR0S_P21_Pos)
+#define GPIO_OSRR0S_P22_Pos         22           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P22             (_U(0x1) << GPIO_OSRR0S_P22_Pos)
+#define GPIO_OSRR0S_P23_Pos         23           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P23             (_U(0x1) << GPIO_OSRR0S_P23_Pos)
+#define GPIO_OSRR0S_P24_Pos         24           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P24             (_U(0x1) << GPIO_OSRR0S_P24_Pos)
+#define GPIO_OSRR0S_P25_Pos         25           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P25             (_U(0x1) << GPIO_OSRR0S_P25_Pos)
+#define GPIO_OSRR0S_P26_Pos         26           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P26             (_U(0x1) << GPIO_OSRR0S_P26_Pos)
+#define GPIO_OSRR0S_P27_Pos         27           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P27             (_U(0x1) << GPIO_OSRR0S_P27_Pos)
+#define GPIO_OSRR0S_P28_Pos         28           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P28             (_U(0x1) << GPIO_OSRR0S_P28_Pos)
+#define GPIO_OSRR0S_P29_Pos         29           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P29             (_U(0x1) << GPIO_OSRR0S_P29_Pos)
+#define GPIO_OSRR0S_P30_Pos         30           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P30             (_U(0x1) << GPIO_OSRR0S_P30_Pos)
+#define GPIO_OSRR0S_P31_Pos         31           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
+#define GPIO_OSRR0S_P31             (_U(0x1) << GPIO_OSRR0S_P31_Pos)
+#define GPIO_OSRR0S_MASK            _U(0xFFFFFFFF) /**< \brief (GPIO_OSRR0S) MASK Register */
+
+/* -------- GPIO_OSRR0C : (GPIO Offset: 0x138) (R/W 32) port Output Slew Rate Register 0 - Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Output Slew Rate Control Enable    */
+    uint32_t P1:1;             /*!< bit:      1  Output Slew Rate Control Enable    */
+    uint32_t P2:1;             /*!< bit:      2  Output Slew Rate Control Enable    */
+    uint32_t P3:1;             /*!< bit:      3  Output Slew Rate Control Enable    */
+    uint32_t P4:1;             /*!< bit:      4  Output Slew Rate Control Enable    */
+    uint32_t P5:1;             /*!< bit:      5  Output Slew Rate Control Enable    */
+    uint32_t P6:1;             /*!< bit:      6  Output Slew Rate Control Enable    */
+    uint32_t P7:1;             /*!< bit:      7  Output Slew Rate Control Enable    */
+    uint32_t P8:1;             /*!< bit:      8  Output Slew Rate Control Enable    */
+    uint32_t P9:1;             /*!< bit:      9  Output Slew Rate Control Enable    */
+    uint32_t P10:1;            /*!< bit:     10  Output Slew Rate Control Enable    */
+    uint32_t P11:1;            /*!< bit:     11  Output Slew Rate Control Enable    */
+    uint32_t P12:1;            /*!< bit:     12  Output Slew Rate Control Enable    */
+    uint32_t P13:1;            /*!< bit:     13  Output Slew Rate Control Enable    */
+    uint32_t P14:1;            /*!< bit:     14  Output Slew Rate Control Enable    */
+    uint32_t P15:1;            /*!< bit:     15  Output Slew Rate Control Enable    */
+    uint32_t P16:1;            /*!< bit:     16  Output Slew Rate Control Enable    */
+    uint32_t P17:1;            /*!< bit:     17  Output Slew Rate Control Enable    */
+    uint32_t P18:1;            /*!< bit:     18  Output Slew Rate Control Enable    */
+    uint32_t P19:1;            /*!< bit:     19  Output Slew Rate Control Enable    */
+    uint32_t P20:1;            /*!< bit:     20  Output Slew Rate Control Enable    */
+    uint32_t P21:1;            /*!< bit:     21  Output Slew Rate Control Enable    */
+    uint32_t P22:1;            /*!< bit:     22  Output Slew Rate Control Enable    */
+    uint32_t P23:1;            /*!< bit:     23  Output Slew Rate Control Enable    */
+    uint32_t P24:1;            /*!< bit:     24  Output Slew Rate Control Enable    */
+    uint32_t P25:1;            /*!< bit:     25  Output Slew Rate Control Enable    */
+    uint32_t P26:1;            /*!< bit:     26  Output Slew Rate Control Enable    */
+    uint32_t P27:1;            /*!< bit:     27  Output Slew Rate Control Enable    */
+    uint32_t P28:1;            /*!< bit:     28  Output Slew Rate Control Enable    */
+    uint32_t P29:1;            /*!< bit:     29  Output Slew Rate Control Enable    */
+    uint32_t P30:1;            /*!< bit:     30  Output Slew Rate Control Enable    */
+    uint32_t P31:1;            /*!< bit:     31  Output Slew Rate Control Enable    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_OSRR0C_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_OSRR0C_OFFSET          0x138        /**< \brief (GPIO_OSRR0C offset) Output Slew Rate Register 0 - Clear */
+
+#define GPIO_OSRR0C_P0_Pos          0            /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P0              (_U(0x1) << GPIO_OSRR0C_P0_Pos)
+#define GPIO_OSRR0C_P1_Pos          1            /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P1              (_U(0x1) << GPIO_OSRR0C_P1_Pos)
+#define GPIO_OSRR0C_P2_Pos          2            /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P2              (_U(0x1) << GPIO_OSRR0C_P2_Pos)
+#define GPIO_OSRR0C_P3_Pos          3            /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P3              (_U(0x1) << GPIO_OSRR0C_P3_Pos)
+#define GPIO_OSRR0C_P4_Pos          4            /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P4              (_U(0x1) << GPIO_OSRR0C_P4_Pos)
+#define GPIO_OSRR0C_P5_Pos          5            /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P5              (_U(0x1) << GPIO_OSRR0C_P5_Pos)
+#define GPIO_OSRR0C_P6_Pos          6            /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P6              (_U(0x1) << GPIO_OSRR0C_P6_Pos)
+#define GPIO_OSRR0C_P7_Pos          7            /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P7              (_U(0x1) << GPIO_OSRR0C_P7_Pos)
+#define GPIO_OSRR0C_P8_Pos          8            /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P8              (_U(0x1) << GPIO_OSRR0C_P8_Pos)
+#define GPIO_OSRR0C_P9_Pos          9            /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P9              (_U(0x1) << GPIO_OSRR0C_P9_Pos)
+#define GPIO_OSRR0C_P10_Pos         10           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P10             (_U(0x1) << GPIO_OSRR0C_P10_Pos)
+#define GPIO_OSRR0C_P11_Pos         11           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P11             (_U(0x1) << GPIO_OSRR0C_P11_Pos)
+#define GPIO_OSRR0C_P12_Pos         12           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P12             (_U(0x1) << GPIO_OSRR0C_P12_Pos)
+#define GPIO_OSRR0C_P13_Pos         13           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P13             (_U(0x1) << GPIO_OSRR0C_P13_Pos)
+#define GPIO_OSRR0C_P14_Pos         14           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P14             (_U(0x1) << GPIO_OSRR0C_P14_Pos)
+#define GPIO_OSRR0C_P15_Pos         15           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P15             (_U(0x1) << GPIO_OSRR0C_P15_Pos)
+#define GPIO_OSRR0C_P16_Pos         16           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P16             (_U(0x1) << GPIO_OSRR0C_P16_Pos)
+#define GPIO_OSRR0C_P17_Pos         17           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P17             (_U(0x1) << GPIO_OSRR0C_P17_Pos)
+#define GPIO_OSRR0C_P18_Pos         18           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P18             (_U(0x1) << GPIO_OSRR0C_P18_Pos)
+#define GPIO_OSRR0C_P19_Pos         19           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P19             (_U(0x1) << GPIO_OSRR0C_P19_Pos)
+#define GPIO_OSRR0C_P20_Pos         20           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P20             (_U(0x1) << GPIO_OSRR0C_P20_Pos)
+#define GPIO_OSRR0C_P21_Pos         21           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P21             (_U(0x1) << GPIO_OSRR0C_P21_Pos)
+#define GPIO_OSRR0C_P22_Pos         22           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P22             (_U(0x1) << GPIO_OSRR0C_P22_Pos)
+#define GPIO_OSRR0C_P23_Pos         23           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P23             (_U(0x1) << GPIO_OSRR0C_P23_Pos)
+#define GPIO_OSRR0C_P24_Pos         24           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P24             (_U(0x1) << GPIO_OSRR0C_P24_Pos)
+#define GPIO_OSRR0C_P25_Pos         25           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P25             (_U(0x1) << GPIO_OSRR0C_P25_Pos)
+#define GPIO_OSRR0C_P26_Pos         26           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P26             (_U(0x1) << GPIO_OSRR0C_P26_Pos)
+#define GPIO_OSRR0C_P27_Pos         27           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P27             (_U(0x1) << GPIO_OSRR0C_P27_Pos)
+#define GPIO_OSRR0C_P28_Pos         28           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P28             (_U(0x1) << GPIO_OSRR0C_P28_Pos)
+#define GPIO_OSRR0C_P29_Pos         29           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P29             (_U(0x1) << GPIO_OSRR0C_P29_Pos)
+#define GPIO_OSRR0C_P30_Pos         30           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P30             (_U(0x1) << GPIO_OSRR0C_P30_Pos)
+#define GPIO_OSRR0C_P31_Pos         31           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
+#define GPIO_OSRR0C_P31             (_U(0x1) << GPIO_OSRR0C_P31_Pos)
+#define GPIO_OSRR0C_MASK            _U(0xFFFFFFFF) /**< \brief (GPIO_OSRR0C) MASK Register */
+
+/* -------- GPIO_OSRR0T : (GPIO Offset: 0x13C) (R/W 32) port Output Slew Rate Register 0 - Toggle -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Output Slew Rate Control Enable    */
+    uint32_t P1:1;             /*!< bit:      1  Output Slew Rate Control Enable    */
+    uint32_t P2:1;             /*!< bit:      2  Output Slew Rate Control Enable    */
+    uint32_t P3:1;             /*!< bit:      3  Output Slew Rate Control Enable    */
+    uint32_t P4:1;             /*!< bit:      4  Output Slew Rate Control Enable    */
+    uint32_t P5:1;             /*!< bit:      5  Output Slew Rate Control Enable    */
+    uint32_t P6:1;             /*!< bit:      6  Output Slew Rate Control Enable    */
+    uint32_t P7:1;             /*!< bit:      7  Output Slew Rate Control Enable    */
+    uint32_t P8:1;             /*!< bit:      8  Output Slew Rate Control Enable    */
+    uint32_t P9:1;             /*!< bit:      9  Output Slew Rate Control Enable    */
+    uint32_t P10:1;            /*!< bit:     10  Output Slew Rate Control Enable    */
+    uint32_t P11:1;            /*!< bit:     11  Output Slew Rate Control Enable    */
+    uint32_t P12:1;            /*!< bit:     12  Output Slew Rate Control Enable    */
+    uint32_t P13:1;            /*!< bit:     13  Output Slew Rate Control Enable    */
+    uint32_t P14:1;            /*!< bit:     14  Output Slew Rate Control Enable    */
+    uint32_t P15:1;            /*!< bit:     15  Output Slew Rate Control Enable    */
+    uint32_t P16:1;            /*!< bit:     16  Output Slew Rate Control Enable    */
+    uint32_t P17:1;            /*!< bit:     17  Output Slew Rate Control Enable    */
+    uint32_t P18:1;            /*!< bit:     18  Output Slew Rate Control Enable    */
+    uint32_t P19:1;            /*!< bit:     19  Output Slew Rate Control Enable    */
+    uint32_t P20:1;            /*!< bit:     20  Output Slew Rate Control Enable    */
+    uint32_t P21:1;            /*!< bit:     21  Output Slew Rate Control Enable    */
+    uint32_t P22:1;            /*!< bit:     22  Output Slew Rate Control Enable    */
+    uint32_t P23:1;            /*!< bit:     23  Output Slew Rate Control Enable    */
+    uint32_t P24:1;            /*!< bit:     24  Output Slew Rate Control Enable    */
+    uint32_t P25:1;            /*!< bit:     25  Output Slew Rate Control Enable    */
+    uint32_t P26:1;            /*!< bit:     26  Output Slew Rate Control Enable    */
+    uint32_t P27:1;            /*!< bit:     27  Output Slew Rate Control Enable    */
+    uint32_t P28:1;            /*!< bit:     28  Output Slew Rate Control Enable    */
+    uint32_t P29:1;            /*!< bit:     29  Output Slew Rate Control Enable    */
+    uint32_t P30:1;            /*!< bit:     30  Output Slew Rate Control Enable    */
+    uint32_t P31:1;            /*!< bit:     31  Output Slew Rate Control Enable    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_OSRR0T_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_OSRR0T_OFFSET          0x13C        /**< \brief (GPIO_OSRR0T offset) Output Slew Rate Register 0 - Toggle */
+
+#define GPIO_OSRR0T_P0_Pos          0            /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P0              (_U(0x1) << GPIO_OSRR0T_P0_Pos)
+#define GPIO_OSRR0T_P1_Pos          1            /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P1              (_U(0x1) << GPIO_OSRR0T_P1_Pos)
+#define GPIO_OSRR0T_P2_Pos          2            /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P2              (_U(0x1) << GPIO_OSRR0T_P2_Pos)
+#define GPIO_OSRR0T_P3_Pos          3            /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P3              (_U(0x1) << GPIO_OSRR0T_P3_Pos)
+#define GPIO_OSRR0T_P4_Pos          4            /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P4              (_U(0x1) << GPIO_OSRR0T_P4_Pos)
+#define GPIO_OSRR0T_P5_Pos          5            /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P5              (_U(0x1) << GPIO_OSRR0T_P5_Pos)
+#define GPIO_OSRR0T_P6_Pos          6            /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P6              (_U(0x1) << GPIO_OSRR0T_P6_Pos)
+#define GPIO_OSRR0T_P7_Pos          7            /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P7              (_U(0x1) << GPIO_OSRR0T_P7_Pos)
+#define GPIO_OSRR0T_P8_Pos          8            /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P8              (_U(0x1) << GPIO_OSRR0T_P8_Pos)
+#define GPIO_OSRR0T_P9_Pos          9            /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P9              (_U(0x1) << GPIO_OSRR0T_P9_Pos)
+#define GPIO_OSRR0T_P10_Pos         10           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P10             (_U(0x1) << GPIO_OSRR0T_P10_Pos)
+#define GPIO_OSRR0T_P11_Pos         11           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P11             (_U(0x1) << GPIO_OSRR0T_P11_Pos)
+#define GPIO_OSRR0T_P12_Pos         12           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P12             (_U(0x1) << GPIO_OSRR0T_P12_Pos)
+#define GPIO_OSRR0T_P13_Pos         13           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P13             (_U(0x1) << GPIO_OSRR0T_P13_Pos)
+#define GPIO_OSRR0T_P14_Pos         14           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P14             (_U(0x1) << GPIO_OSRR0T_P14_Pos)
+#define GPIO_OSRR0T_P15_Pos         15           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P15             (_U(0x1) << GPIO_OSRR0T_P15_Pos)
+#define GPIO_OSRR0T_P16_Pos         16           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P16             (_U(0x1) << GPIO_OSRR0T_P16_Pos)
+#define GPIO_OSRR0T_P17_Pos         17           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P17             (_U(0x1) << GPIO_OSRR0T_P17_Pos)
+#define GPIO_OSRR0T_P18_Pos         18           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P18             (_U(0x1) << GPIO_OSRR0T_P18_Pos)
+#define GPIO_OSRR0T_P19_Pos         19           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P19             (_U(0x1) << GPIO_OSRR0T_P19_Pos)
+#define GPIO_OSRR0T_P20_Pos         20           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P20             (_U(0x1) << GPIO_OSRR0T_P20_Pos)
+#define GPIO_OSRR0T_P21_Pos         21           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P21             (_U(0x1) << GPIO_OSRR0T_P21_Pos)
+#define GPIO_OSRR0T_P22_Pos         22           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P22             (_U(0x1) << GPIO_OSRR0T_P22_Pos)
+#define GPIO_OSRR0T_P23_Pos         23           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P23             (_U(0x1) << GPIO_OSRR0T_P23_Pos)
+#define GPIO_OSRR0T_P24_Pos         24           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P24             (_U(0x1) << GPIO_OSRR0T_P24_Pos)
+#define GPIO_OSRR0T_P25_Pos         25           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P25             (_U(0x1) << GPIO_OSRR0T_P25_Pos)
+#define GPIO_OSRR0T_P26_Pos         26           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P26             (_U(0x1) << GPIO_OSRR0T_P26_Pos)
+#define GPIO_OSRR0T_P27_Pos         27           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P27             (_U(0x1) << GPIO_OSRR0T_P27_Pos)
+#define GPIO_OSRR0T_P28_Pos         28           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P28             (_U(0x1) << GPIO_OSRR0T_P28_Pos)
+#define GPIO_OSRR0T_P29_Pos         29           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P29             (_U(0x1) << GPIO_OSRR0T_P29_Pos)
+#define GPIO_OSRR0T_P30_Pos         30           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P30             (_U(0x1) << GPIO_OSRR0T_P30_Pos)
+#define GPIO_OSRR0T_P31_Pos         31           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
+#define GPIO_OSRR0T_P31             (_U(0x1) << GPIO_OSRR0T_P31_Pos)
+#define GPIO_OSRR0T_MASK            _U(0xFFFFFFFF) /**< \brief (GPIO_OSRR0T) MASK Register */
+
+/* -------- GPIO_STER : (GPIO Offset: 0x160) (R/W 32) port Schmitt Trigger Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Schmitt Trigger Enable             */
+    uint32_t P1:1;             /*!< bit:      1  Schmitt Trigger Enable             */
+    uint32_t P2:1;             /*!< bit:      2  Schmitt Trigger Enable             */
+    uint32_t P3:1;             /*!< bit:      3  Schmitt Trigger Enable             */
+    uint32_t P4:1;             /*!< bit:      4  Schmitt Trigger Enable             */
+    uint32_t P5:1;             /*!< bit:      5  Schmitt Trigger Enable             */
+    uint32_t P6:1;             /*!< bit:      6  Schmitt Trigger Enable             */
+    uint32_t P7:1;             /*!< bit:      7  Schmitt Trigger Enable             */
+    uint32_t P8:1;             /*!< bit:      8  Schmitt Trigger Enable             */
+    uint32_t P9:1;             /*!< bit:      9  Schmitt Trigger Enable             */
+    uint32_t P10:1;            /*!< bit:     10  Schmitt Trigger Enable             */
+    uint32_t P11:1;            /*!< bit:     11  Schmitt Trigger Enable             */
+    uint32_t P12:1;            /*!< bit:     12  Schmitt Trigger Enable             */
+    uint32_t P13:1;            /*!< bit:     13  Schmitt Trigger Enable             */
+    uint32_t P14:1;            /*!< bit:     14  Schmitt Trigger Enable             */
+    uint32_t P15:1;            /*!< bit:     15  Schmitt Trigger Enable             */
+    uint32_t P16:1;            /*!< bit:     16  Schmitt Trigger Enable             */
+    uint32_t P17:1;            /*!< bit:     17  Schmitt Trigger Enable             */
+    uint32_t P18:1;            /*!< bit:     18  Schmitt Trigger Enable             */
+    uint32_t P19:1;            /*!< bit:     19  Schmitt Trigger Enable             */
+    uint32_t P20:1;            /*!< bit:     20  Schmitt Trigger Enable             */
+    uint32_t P21:1;            /*!< bit:     21  Schmitt Trigger Enable             */
+    uint32_t P22:1;            /*!< bit:     22  Schmitt Trigger Enable             */
+    uint32_t P23:1;            /*!< bit:     23  Schmitt Trigger Enable             */
+    uint32_t P24:1;            /*!< bit:     24  Schmitt Trigger Enable             */
+    uint32_t P25:1;            /*!< bit:     25  Schmitt Trigger Enable             */
+    uint32_t P26:1;            /*!< bit:     26  Schmitt Trigger Enable             */
+    uint32_t P27:1;            /*!< bit:     27  Schmitt Trigger Enable             */
+    uint32_t P28:1;            /*!< bit:     28  Schmitt Trigger Enable             */
+    uint32_t P29:1;            /*!< bit:     29  Schmitt Trigger Enable             */
+    uint32_t P30:1;            /*!< bit:     30  Schmitt Trigger Enable             */
+    uint32_t P31:1;            /*!< bit:     31  Schmitt Trigger Enable             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_STER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_STER_OFFSET            0x160        /**< \brief (GPIO_STER offset) Schmitt Trigger Enable Register */
+
+#define GPIO_STER_P0_Pos            0            /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P0                (_U(0x1) << GPIO_STER_P0_Pos)
+#define GPIO_STER_P1_Pos            1            /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P1                (_U(0x1) << GPIO_STER_P1_Pos)
+#define GPIO_STER_P2_Pos            2            /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P2                (_U(0x1) << GPIO_STER_P2_Pos)
+#define GPIO_STER_P3_Pos            3            /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P3                (_U(0x1) << GPIO_STER_P3_Pos)
+#define GPIO_STER_P4_Pos            4            /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P4                (_U(0x1) << GPIO_STER_P4_Pos)
+#define GPIO_STER_P5_Pos            5            /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P5                (_U(0x1) << GPIO_STER_P5_Pos)
+#define GPIO_STER_P6_Pos            6            /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P6                (_U(0x1) << GPIO_STER_P6_Pos)
+#define GPIO_STER_P7_Pos            7            /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P7                (_U(0x1) << GPIO_STER_P7_Pos)
+#define GPIO_STER_P8_Pos            8            /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P8                (_U(0x1) << GPIO_STER_P8_Pos)
+#define GPIO_STER_P9_Pos            9            /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P9                (_U(0x1) << GPIO_STER_P9_Pos)
+#define GPIO_STER_P10_Pos           10           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P10               (_U(0x1) << GPIO_STER_P10_Pos)
+#define GPIO_STER_P11_Pos           11           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P11               (_U(0x1) << GPIO_STER_P11_Pos)
+#define GPIO_STER_P12_Pos           12           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P12               (_U(0x1) << GPIO_STER_P12_Pos)
+#define GPIO_STER_P13_Pos           13           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P13               (_U(0x1) << GPIO_STER_P13_Pos)
+#define GPIO_STER_P14_Pos           14           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P14               (_U(0x1) << GPIO_STER_P14_Pos)
+#define GPIO_STER_P15_Pos           15           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P15               (_U(0x1) << GPIO_STER_P15_Pos)
+#define GPIO_STER_P16_Pos           16           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P16               (_U(0x1) << GPIO_STER_P16_Pos)
+#define GPIO_STER_P17_Pos           17           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P17               (_U(0x1) << GPIO_STER_P17_Pos)
+#define GPIO_STER_P18_Pos           18           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P18               (_U(0x1) << GPIO_STER_P18_Pos)
+#define GPIO_STER_P19_Pos           19           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P19               (_U(0x1) << GPIO_STER_P19_Pos)
+#define GPIO_STER_P20_Pos           20           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P20               (_U(0x1) << GPIO_STER_P20_Pos)
+#define GPIO_STER_P21_Pos           21           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P21               (_U(0x1) << GPIO_STER_P21_Pos)
+#define GPIO_STER_P22_Pos           22           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P22               (_U(0x1) << GPIO_STER_P22_Pos)
+#define GPIO_STER_P23_Pos           23           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P23               (_U(0x1) << GPIO_STER_P23_Pos)
+#define GPIO_STER_P24_Pos           24           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P24               (_U(0x1) << GPIO_STER_P24_Pos)
+#define GPIO_STER_P25_Pos           25           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P25               (_U(0x1) << GPIO_STER_P25_Pos)
+#define GPIO_STER_P26_Pos           26           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P26               (_U(0x1) << GPIO_STER_P26_Pos)
+#define GPIO_STER_P27_Pos           27           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P27               (_U(0x1) << GPIO_STER_P27_Pos)
+#define GPIO_STER_P28_Pos           28           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P28               (_U(0x1) << GPIO_STER_P28_Pos)
+#define GPIO_STER_P29_Pos           29           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P29               (_U(0x1) << GPIO_STER_P29_Pos)
+#define GPIO_STER_P30_Pos           30           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P30               (_U(0x1) << GPIO_STER_P30_Pos)
+#define GPIO_STER_P31_Pos           31           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
+#define GPIO_STER_P31               (_U(0x1) << GPIO_STER_P31_Pos)
+#define GPIO_STER_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_STER) MASK Register */
+
+/* -------- GPIO_STERS : (GPIO Offset: 0x164) (R/W 32) port Schmitt Trigger Enable Register - Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Schmitt Trigger Enable             */
+    uint32_t P1:1;             /*!< bit:      1  Schmitt Trigger Enable             */
+    uint32_t P2:1;             /*!< bit:      2  Schmitt Trigger Enable             */
+    uint32_t P3:1;             /*!< bit:      3  Schmitt Trigger Enable             */
+    uint32_t P4:1;             /*!< bit:      4  Schmitt Trigger Enable             */
+    uint32_t P5:1;             /*!< bit:      5  Schmitt Trigger Enable             */
+    uint32_t P6:1;             /*!< bit:      6  Schmitt Trigger Enable             */
+    uint32_t P7:1;             /*!< bit:      7  Schmitt Trigger Enable             */
+    uint32_t P8:1;             /*!< bit:      8  Schmitt Trigger Enable             */
+    uint32_t P9:1;             /*!< bit:      9  Schmitt Trigger Enable             */
+    uint32_t P10:1;            /*!< bit:     10  Schmitt Trigger Enable             */
+    uint32_t P11:1;            /*!< bit:     11  Schmitt Trigger Enable             */
+    uint32_t P12:1;            /*!< bit:     12  Schmitt Trigger Enable             */
+    uint32_t P13:1;            /*!< bit:     13  Schmitt Trigger Enable             */
+    uint32_t P14:1;            /*!< bit:     14  Schmitt Trigger Enable             */
+    uint32_t P15:1;            /*!< bit:     15  Schmitt Trigger Enable             */
+    uint32_t P16:1;            /*!< bit:     16  Schmitt Trigger Enable             */
+    uint32_t P17:1;            /*!< bit:     17  Schmitt Trigger Enable             */
+    uint32_t P18:1;            /*!< bit:     18  Schmitt Trigger Enable             */
+    uint32_t P19:1;            /*!< bit:     19  Schmitt Trigger Enable             */
+    uint32_t P20:1;            /*!< bit:     20  Schmitt Trigger Enable             */
+    uint32_t P21:1;            /*!< bit:     21  Schmitt Trigger Enable             */
+    uint32_t P22:1;            /*!< bit:     22  Schmitt Trigger Enable             */
+    uint32_t P23:1;            /*!< bit:     23  Schmitt Trigger Enable             */
+    uint32_t P24:1;            /*!< bit:     24  Schmitt Trigger Enable             */
+    uint32_t P25:1;            /*!< bit:     25  Schmitt Trigger Enable             */
+    uint32_t P26:1;            /*!< bit:     26  Schmitt Trigger Enable             */
+    uint32_t P27:1;            /*!< bit:     27  Schmitt Trigger Enable             */
+    uint32_t P28:1;            /*!< bit:     28  Schmitt Trigger Enable             */
+    uint32_t P29:1;            /*!< bit:     29  Schmitt Trigger Enable             */
+    uint32_t P30:1;            /*!< bit:     30  Schmitt Trigger Enable             */
+    uint32_t P31:1;            /*!< bit:     31  Schmitt Trigger Enable             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_STERS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_STERS_OFFSET           0x164        /**< \brief (GPIO_STERS offset) Schmitt Trigger Enable Register - Set */
+
+#define GPIO_STERS_P0_Pos           0            /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P0               (_U(0x1) << GPIO_STERS_P0_Pos)
+#define GPIO_STERS_P1_Pos           1            /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P1               (_U(0x1) << GPIO_STERS_P1_Pos)
+#define GPIO_STERS_P2_Pos           2            /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P2               (_U(0x1) << GPIO_STERS_P2_Pos)
+#define GPIO_STERS_P3_Pos           3            /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P3               (_U(0x1) << GPIO_STERS_P3_Pos)
+#define GPIO_STERS_P4_Pos           4            /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P4               (_U(0x1) << GPIO_STERS_P4_Pos)
+#define GPIO_STERS_P5_Pos           5            /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P5               (_U(0x1) << GPIO_STERS_P5_Pos)
+#define GPIO_STERS_P6_Pos           6            /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P6               (_U(0x1) << GPIO_STERS_P6_Pos)
+#define GPIO_STERS_P7_Pos           7            /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P7               (_U(0x1) << GPIO_STERS_P7_Pos)
+#define GPIO_STERS_P8_Pos           8            /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P8               (_U(0x1) << GPIO_STERS_P8_Pos)
+#define GPIO_STERS_P9_Pos           9            /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P9               (_U(0x1) << GPIO_STERS_P9_Pos)
+#define GPIO_STERS_P10_Pos          10           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P10              (_U(0x1) << GPIO_STERS_P10_Pos)
+#define GPIO_STERS_P11_Pos          11           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P11              (_U(0x1) << GPIO_STERS_P11_Pos)
+#define GPIO_STERS_P12_Pos          12           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P12              (_U(0x1) << GPIO_STERS_P12_Pos)
+#define GPIO_STERS_P13_Pos          13           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P13              (_U(0x1) << GPIO_STERS_P13_Pos)
+#define GPIO_STERS_P14_Pos          14           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P14              (_U(0x1) << GPIO_STERS_P14_Pos)
+#define GPIO_STERS_P15_Pos          15           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P15              (_U(0x1) << GPIO_STERS_P15_Pos)
+#define GPIO_STERS_P16_Pos          16           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P16              (_U(0x1) << GPIO_STERS_P16_Pos)
+#define GPIO_STERS_P17_Pos          17           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P17              (_U(0x1) << GPIO_STERS_P17_Pos)
+#define GPIO_STERS_P18_Pos          18           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P18              (_U(0x1) << GPIO_STERS_P18_Pos)
+#define GPIO_STERS_P19_Pos          19           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P19              (_U(0x1) << GPIO_STERS_P19_Pos)
+#define GPIO_STERS_P20_Pos          20           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P20              (_U(0x1) << GPIO_STERS_P20_Pos)
+#define GPIO_STERS_P21_Pos          21           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P21              (_U(0x1) << GPIO_STERS_P21_Pos)
+#define GPIO_STERS_P22_Pos          22           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P22              (_U(0x1) << GPIO_STERS_P22_Pos)
+#define GPIO_STERS_P23_Pos          23           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P23              (_U(0x1) << GPIO_STERS_P23_Pos)
+#define GPIO_STERS_P24_Pos          24           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P24              (_U(0x1) << GPIO_STERS_P24_Pos)
+#define GPIO_STERS_P25_Pos          25           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P25              (_U(0x1) << GPIO_STERS_P25_Pos)
+#define GPIO_STERS_P26_Pos          26           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P26              (_U(0x1) << GPIO_STERS_P26_Pos)
+#define GPIO_STERS_P27_Pos          27           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P27              (_U(0x1) << GPIO_STERS_P27_Pos)
+#define GPIO_STERS_P28_Pos          28           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P28              (_U(0x1) << GPIO_STERS_P28_Pos)
+#define GPIO_STERS_P29_Pos          29           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P29              (_U(0x1) << GPIO_STERS_P29_Pos)
+#define GPIO_STERS_P30_Pos          30           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P30              (_U(0x1) << GPIO_STERS_P30_Pos)
+#define GPIO_STERS_P31_Pos          31           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
+#define GPIO_STERS_P31              (_U(0x1) << GPIO_STERS_P31_Pos)
+#define GPIO_STERS_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_STERS) MASK Register */
+
+/* -------- GPIO_STERC : (GPIO Offset: 0x168) (R/W 32) port Schmitt Trigger Enable Register - Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Schmitt Trigger Enable             */
+    uint32_t P1:1;             /*!< bit:      1  Schmitt Trigger Enable             */
+    uint32_t P2:1;             /*!< bit:      2  Schmitt Trigger Enable             */
+    uint32_t P3:1;             /*!< bit:      3  Schmitt Trigger Enable             */
+    uint32_t P4:1;             /*!< bit:      4  Schmitt Trigger Enable             */
+    uint32_t P5:1;             /*!< bit:      5  Schmitt Trigger Enable             */
+    uint32_t P6:1;             /*!< bit:      6  Schmitt Trigger Enable             */
+    uint32_t P7:1;             /*!< bit:      7  Schmitt Trigger Enable             */
+    uint32_t P8:1;             /*!< bit:      8  Schmitt Trigger Enable             */
+    uint32_t P9:1;             /*!< bit:      9  Schmitt Trigger Enable             */
+    uint32_t P10:1;            /*!< bit:     10  Schmitt Trigger Enable             */
+    uint32_t P11:1;            /*!< bit:     11  Schmitt Trigger Enable             */
+    uint32_t P12:1;            /*!< bit:     12  Schmitt Trigger Enable             */
+    uint32_t P13:1;            /*!< bit:     13  Schmitt Trigger Enable             */
+    uint32_t P14:1;            /*!< bit:     14  Schmitt Trigger Enable             */
+    uint32_t P15:1;            /*!< bit:     15  Schmitt Trigger Enable             */
+    uint32_t P16:1;            /*!< bit:     16  Schmitt Trigger Enable             */
+    uint32_t P17:1;            /*!< bit:     17  Schmitt Trigger Enable             */
+    uint32_t P18:1;            /*!< bit:     18  Schmitt Trigger Enable             */
+    uint32_t P19:1;            /*!< bit:     19  Schmitt Trigger Enable             */
+    uint32_t P20:1;            /*!< bit:     20  Schmitt Trigger Enable             */
+    uint32_t P21:1;            /*!< bit:     21  Schmitt Trigger Enable             */
+    uint32_t P22:1;            /*!< bit:     22  Schmitt Trigger Enable             */
+    uint32_t P23:1;            /*!< bit:     23  Schmitt Trigger Enable             */
+    uint32_t P24:1;            /*!< bit:     24  Schmitt Trigger Enable             */
+    uint32_t P25:1;            /*!< bit:     25  Schmitt Trigger Enable             */
+    uint32_t P26:1;            /*!< bit:     26  Schmitt Trigger Enable             */
+    uint32_t P27:1;            /*!< bit:     27  Schmitt Trigger Enable             */
+    uint32_t P28:1;            /*!< bit:     28  Schmitt Trigger Enable             */
+    uint32_t P29:1;            /*!< bit:     29  Schmitt Trigger Enable             */
+    uint32_t P30:1;            /*!< bit:     30  Schmitt Trigger Enable             */
+    uint32_t P31:1;            /*!< bit:     31  Schmitt Trigger Enable             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_STERC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_STERC_OFFSET           0x168        /**< \brief (GPIO_STERC offset) Schmitt Trigger Enable Register - Clear */
+
+#define GPIO_STERC_P0_Pos           0            /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P0               (_U(0x1) << GPIO_STERC_P0_Pos)
+#define GPIO_STERC_P1_Pos           1            /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P1               (_U(0x1) << GPIO_STERC_P1_Pos)
+#define GPIO_STERC_P2_Pos           2            /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P2               (_U(0x1) << GPIO_STERC_P2_Pos)
+#define GPIO_STERC_P3_Pos           3            /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P3               (_U(0x1) << GPIO_STERC_P3_Pos)
+#define GPIO_STERC_P4_Pos           4            /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P4               (_U(0x1) << GPIO_STERC_P4_Pos)
+#define GPIO_STERC_P5_Pos           5            /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P5               (_U(0x1) << GPIO_STERC_P5_Pos)
+#define GPIO_STERC_P6_Pos           6            /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P6               (_U(0x1) << GPIO_STERC_P6_Pos)
+#define GPIO_STERC_P7_Pos           7            /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P7               (_U(0x1) << GPIO_STERC_P7_Pos)
+#define GPIO_STERC_P8_Pos           8            /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P8               (_U(0x1) << GPIO_STERC_P8_Pos)
+#define GPIO_STERC_P9_Pos           9            /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P9               (_U(0x1) << GPIO_STERC_P9_Pos)
+#define GPIO_STERC_P10_Pos          10           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P10              (_U(0x1) << GPIO_STERC_P10_Pos)
+#define GPIO_STERC_P11_Pos          11           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P11              (_U(0x1) << GPIO_STERC_P11_Pos)
+#define GPIO_STERC_P12_Pos          12           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P12              (_U(0x1) << GPIO_STERC_P12_Pos)
+#define GPIO_STERC_P13_Pos          13           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P13              (_U(0x1) << GPIO_STERC_P13_Pos)
+#define GPIO_STERC_P14_Pos          14           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P14              (_U(0x1) << GPIO_STERC_P14_Pos)
+#define GPIO_STERC_P15_Pos          15           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P15              (_U(0x1) << GPIO_STERC_P15_Pos)
+#define GPIO_STERC_P16_Pos          16           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P16              (_U(0x1) << GPIO_STERC_P16_Pos)
+#define GPIO_STERC_P17_Pos          17           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P17              (_U(0x1) << GPIO_STERC_P17_Pos)
+#define GPIO_STERC_P18_Pos          18           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P18              (_U(0x1) << GPIO_STERC_P18_Pos)
+#define GPIO_STERC_P19_Pos          19           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P19              (_U(0x1) << GPIO_STERC_P19_Pos)
+#define GPIO_STERC_P20_Pos          20           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P20              (_U(0x1) << GPIO_STERC_P20_Pos)
+#define GPIO_STERC_P21_Pos          21           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P21              (_U(0x1) << GPIO_STERC_P21_Pos)
+#define GPIO_STERC_P22_Pos          22           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P22              (_U(0x1) << GPIO_STERC_P22_Pos)
+#define GPIO_STERC_P23_Pos          23           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P23              (_U(0x1) << GPIO_STERC_P23_Pos)
+#define GPIO_STERC_P24_Pos          24           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P24              (_U(0x1) << GPIO_STERC_P24_Pos)
+#define GPIO_STERC_P25_Pos          25           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P25              (_U(0x1) << GPIO_STERC_P25_Pos)
+#define GPIO_STERC_P26_Pos          26           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P26              (_U(0x1) << GPIO_STERC_P26_Pos)
+#define GPIO_STERC_P27_Pos          27           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P27              (_U(0x1) << GPIO_STERC_P27_Pos)
+#define GPIO_STERC_P28_Pos          28           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P28              (_U(0x1) << GPIO_STERC_P28_Pos)
+#define GPIO_STERC_P29_Pos          29           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P29              (_U(0x1) << GPIO_STERC_P29_Pos)
+#define GPIO_STERC_P30_Pos          30           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P30              (_U(0x1) << GPIO_STERC_P30_Pos)
+#define GPIO_STERC_P31_Pos          31           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
+#define GPIO_STERC_P31              (_U(0x1) << GPIO_STERC_P31_Pos)
+#define GPIO_STERC_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_STERC) MASK Register */
+
+/* -------- GPIO_STERT : (GPIO Offset: 0x16C) (R/W 32) port Schmitt Trigger Enable Register - Toggle -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Schmitt Trigger Enable             */
+    uint32_t P1:1;             /*!< bit:      1  Schmitt Trigger Enable             */
+    uint32_t P2:1;             /*!< bit:      2  Schmitt Trigger Enable             */
+    uint32_t P3:1;             /*!< bit:      3  Schmitt Trigger Enable             */
+    uint32_t P4:1;             /*!< bit:      4  Schmitt Trigger Enable             */
+    uint32_t P5:1;             /*!< bit:      5  Schmitt Trigger Enable             */
+    uint32_t P6:1;             /*!< bit:      6  Schmitt Trigger Enable             */
+    uint32_t P7:1;             /*!< bit:      7  Schmitt Trigger Enable             */
+    uint32_t P8:1;             /*!< bit:      8  Schmitt Trigger Enable             */
+    uint32_t P9:1;             /*!< bit:      9  Schmitt Trigger Enable             */
+    uint32_t P10:1;            /*!< bit:     10  Schmitt Trigger Enable             */
+    uint32_t P11:1;            /*!< bit:     11  Schmitt Trigger Enable             */
+    uint32_t P12:1;            /*!< bit:     12  Schmitt Trigger Enable             */
+    uint32_t P13:1;            /*!< bit:     13  Schmitt Trigger Enable             */
+    uint32_t P14:1;            /*!< bit:     14  Schmitt Trigger Enable             */
+    uint32_t P15:1;            /*!< bit:     15  Schmitt Trigger Enable             */
+    uint32_t P16:1;            /*!< bit:     16  Schmitt Trigger Enable             */
+    uint32_t P17:1;            /*!< bit:     17  Schmitt Trigger Enable             */
+    uint32_t P18:1;            /*!< bit:     18  Schmitt Trigger Enable             */
+    uint32_t P19:1;            /*!< bit:     19  Schmitt Trigger Enable             */
+    uint32_t P20:1;            /*!< bit:     20  Schmitt Trigger Enable             */
+    uint32_t P21:1;            /*!< bit:     21  Schmitt Trigger Enable             */
+    uint32_t P22:1;            /*!< bit:     22  Schmitt Trigger Enable             */
+    uint32_t P23:1;            /*!< bit:     23  Schmitt Trigger Enable             */
+    uint32_t P24:1;            /*!< bit:     24  Schmitt Trigger Enable             */
+    uint32_t P25:1;            /*!< bit:     25  Schmitt Trigger Enable             */
+    uint32_t P26:1;            /*!< bit:     26  Schmitt Trigger Enable             */
+    uint32_t P27:1;            /*!< bit:     27  Schmitt Trigger Enable             */
+    uint32_t P28:1;            /*!< bit:     28  Schmitt Trigger Enable             */
+    uint32_t P29:1;            /*!< bit:     29  Schmitt Trigger Enable             */
+    uint32_t P30:1;            /*!< bit:     30  Schmitt Trigger Enable             */
+    uint32_t P31:1;            /*!< bit:     31  Schmitt Trigger Enable             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_STERT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_STERT_OFFSET           0x16C        /**< \brief (GPIO_STERT offset) Schmitt Trigger Enable Register - Toggle */
+
+#define GPIO_STERT_P0_Pos           0            /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P0               (_U(0x1) << GPIO_STERT_P0_Pos)
+#define GPIO_STERT_P1_Pos           1            /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P1               (_U(0x1) << GPIO_STERT_P1_Pos)
+#define GPIO_STERT_P2_Pos           2            /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P2               (_U(0x1) << GPIO_STERT_P2_Pos)
+#define GPIO_STERT_P3_Pos           3            /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P3               (_U(0x1) << GPIO_STERT_P3_Pos)
+#define GPIO_STERT_P4_Pos           4            /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P4               (_U(0x1) << GPIO_STERT_P4_Pos)
+#define GPIO_STERT_P5_Pos           5            /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P5               (_U(0x1) << GPIO_STERT_P5_Pos)
+#define GPIO_STERT_P6_Pos           6            /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P6               (_U(0x1) << GPIO_STERT_P6_Pos)
+#define GPIO_STERT_P7_Pos           7            /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P7               (_U(0x1) << GPIO_STERT_P7_Pos)
+#define GPIO_STERT_P8_Pos           8            /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P8               (_U(0x1) << GPIO_STERT_P8_Pos)
+#define GPIO_STERT_P9_Pos           9            /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P9               (_U(0x1) << GPIO_STERT_P9_Pos)
+#define GPIO_STERT_P10_Pos          10           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P10              (_U(0x1) << GPIO_STERT_P10_Pos)
+#define GPIO_STERT_P11_Pos          11           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P11              (_U(0x1) << GPIO_STERT_P11_Pos)
+#define GPIO_STERT_P12_Pos          12           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P12              (_U(0x1) << GPIO_STERT_P12_Pos)
+#define GPIO_STERT_P13_Pos          13           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P13              (_U(0x1) << GPIO_STERT_P13_Pos)
+#define GPIO_STERT_P14_Pos          14           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P14              (_U(0x1) << GPIO_STERT_P14_Pos)
+#define GPIO_STERT_P15_Pos          15           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P15              (_U(0x1) << GPIO_STERT_P15_Pos)
+#define GPIO_STERT_P16_Pos          16           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P16              (_U(0x1) << GPIO_STERT_P16_Pos)
+#define GPIO_STERT_P17_Pos          17           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P17              (_U(0x1) << GPIO_STERT_P17_Pos)
+#define GPIO_STERT_P18_Pos          18           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P18              (_U(0x1) << GPIO_STERT_P18_Pos)
+#define GPIO_STERT_P19_Pos          19           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P19              (_U(0x1) << GPIO_STERT_P19_Pos)
+#define GPIO_STERT_P20_Pos          20           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P20              (_U(0x1) << GPIO_STERT_P20_Pos)
+#define GPIO_STERT_P21_Pos          21           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P21              (_U(0x1) << GPIO_STERT_P21_Pos)
+#define GPIO_STERT_P22_Pos          22           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P22              (_U(0x1) << GPIO_STERT_P22_Pos)
+#define GPIO_STERT_P23_Pos          23           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P23              (_U(0x1) << GPIO_STERT_P23_Pos)
+#define GPIO_STERT_P24_Pos          24           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P24              (_U(0x1) << GPIO_STERT_P24_Pos)
+#define GPIO_STERT_P25_Pos          25           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P25              (_U(0x1) << GPIO_STERT_P25_Pos)
+#define GPIO_STERT_P26_Pos          26           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P26              (_U(0x1) << GPIO_STERT_P26_Pos)
+#define GPIO_STERT_P27_Pos          27           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P27              (_U(0x1) << GPIO_STERT_P27_Pos)
+#define GPIO_STERT_P28_Pos          28           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P28              (_U(0x1) << GPIO_STERT_P28_Pos)
+#define GPIO_STERT_P29_Pos          29           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P29              (_U(0x1) << GPIO_STERT_P29_Pos)
+#define GPIO_STERT_P30_Pos          30           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P30              (_U(0x1) << GPIO_STERT_P30_Pos)
+#define GPIO_STERT_P31_Pos          31           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
+#define GPIO_STERT_P31              (_U(0x1) << GPIO_STERT_P31_Pos)
+#define GPIO_STERT_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_STERT) MASK Register */
+
+/* -------- GPIO_EVER : (GPIO Offset: 0x180) (R/W 32) port Event Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Event Enable                       */
+    uint32_t P1:1;             /*!< bit:      1  Event Enable                       */
+    uint32_t P2:1;             /*!< bit:      2  Event Enable                       */
+    uint32_t P3:1;             /*!< bit:      3  Event Enable                       */
+    uint32_t P4:1;             /*!< bit:      4  Event Enable                       */
+    uint32_t P5:1;             /*!< bit:      5  Event Enable                       */
+    uint32_t P6:1;             /*!< bit:      6  Event Enable                       */
+    uint32_t P7:1;             /*!< bit:      7  Event Enable                       */
+    uint32_t P8:1;             /*!< bit:      8  Event Enable                       */
+    uint32_t P9:1;             /*!< bit:      9  Event Enable                       */
+    uint32_t P10:1;            /*!< bit:     10  Event Enable                       */
+    uint32_t P11:1;            /*!< bit:     11  Event Enable                       */
+    uint32_t P12:1;            /*!< bit:     12  Event Enable                       */
+    uint32_t P13:1;            /*!< bit:     13  Event Enable                       */
+    uint32_t P14:1;            /*!< bit:     14  Event Enable                       */
+    uint32_t P15:1;            /*!< bit:     15  Event Enable                       */
+    uint32_t P16:1;            /*!< bit:     16  Event Enable                       */
+    uint32_t P17:1;            /*!< bit:     17  Event Enable                       */
+    uint32_t P18:1;            /*!< bit:     18  Event Enable                       */
+    uint32_t P19:1;            /*!< bit:     19  Event Enable                       */
+    uint32_t P20:1;            /*!< bit:     20  Event Enable                       */
+    uint32_t P21:1;            /*!< bit:     21  Event Enable                       */
+    uint32_t P22:1;            /*!< bit:     22  Event Enable                       */
+    uint32_t P23:1;            /*!< bit:     23  Event Enable                       */
+    uint32_t P24:1;            /*!< bit:     24  Event Enable                       */
+    uint32_t P25:1;            /*!< bit:     25  Event Enable                       */
+    uint32_t P26:1;            /*!< bit:     26  Event Enable                       */
+    uint32_t P27:1;            /*!< bit:     27  Event Enable                       */
+    uint32_t P28:1;            /*!< bit:     28  Event Enable                       */
+    uint32_t P29:1;            /*!< bit:     29  Event Enable                       */
+    uint32_t P30:1;            /*!< bit:     30  Event Enable                       */
+    uint32_t P31:1;            /*!< bit:     31  Event Enable                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_EVER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_EVER_OFFSET            0x180        /**< \brief (GPIO_EVER offset) Event Enable Register */
+
+#define GPIO_EVER_P0_Pos            0            /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P0                (_U(0x1) << GPIO_EVER_P0_Pos)
+#define GPIO_EVER_P1_Pos            1            /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P1                (_U(0x1) << GPIO_EVER_P1_Pos)
+#define GPIO_EVER_P2_Pos            2            /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P2                (_U(0x1) << GPIO_EVER_P2_Pos)
+#define GPIO_EVER_P3_Pos            3            /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P3                (_U(0x1) << GPIO_EVER_P3_Pos)
+#define GPIO_EVER_P4_Pos            4            /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P4                (_U(0x1) << GPIO_EVER_P4_Pos)
+#define GPIO_EVER_P5_Pos            5            /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P5                (_U(0x1) << GPIO_EVER_P5_Pos)
+#define GPIO_EVER_P6_Pos            6            /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P6                (_U(0x1) << GPIO_EVER_P6_Pos)
+#define GPIO_EVER_P7_Pos            7            /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P7                (_U(0x1) << GPIO_EVER_P7_Pos)
+#define GPIO_EVER_P8_Pos            8            /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P8                (_U(0x1) << GPIO_EVER_P8_Pos)
+#define GPIO_EVER_P9_Pos            9            /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P9                (_U(0x1) << GPIO_EVER_P9_Pos)
+#define GPIO_EVER_P10_Pos           10           /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P10               (_U(0x1) << GPIO_EVER_P10_Pos)
+#define GPIO_EVER_P11_Pos           11           /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P11               (_U(0x1) << GPIO_EVER_P11_Pos)
+#define GPIO_EVER_P12_Pos           12           /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P12               (_U(0x1) << GPIO_EVER_P12_Pos)
+#define GPIO_EVER_P13_Pos           13           /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P13               (_U(0x1) << GPIO_EVER_P13_Pos)
+#define GPIO_EVER_P14_Pos           14           /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P14               (_U(0x1) << GPIO_EVER_P14_Pos)
+#define GPIO_EVER_P15_Pos           15           /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P15               (_U(0x1) << GPIO_EVER_P15_Pos)
+#define GPIO_EVER_P16_Pos           16           /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P16               (_U(0x1) << GPIO_EVER_P16_Pos)
+#define GPIO_EVER_P17_Pos           17           /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P17               (_U(0x1) << GPIO_EVER_P17_Pos)
+#define GPIO_EVER_P18_Pos           18           /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P18               (_U(0x1) << GPIO_EVER_P18_Pos)
+#define GPIO_EVER_P19_Pos           19           /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P19               (_U(0x1) << GPIO_EVER_P19_Pos)
+#define GPIO_EVER_P20_Pos           20           /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P20               (_U(0x1) << GPIO_EVER_P20_Pos)
+#define GPIO_EVER_P21_Pos           21           /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P21               (_U(0x1) << GPIO_EVER_P21_Pos)
+#define GPIO_EVER_P22_Pos           22           /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P22               (_U(0x1) << GPIO_EVER_P22_Pos)
+#define GPIO_EVER_P23_Pos           23           /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P23               (_U(0x1) << GPIO_EVER_P23_Pos)
+#define GPIO_EVER_P24_Pos           24           /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P24               (_U(0x1) << GPIO_EVER_P24_Pos)
+#define GPIO_EVER_P25_Pos           25           /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P25               (_U(0x1) << GPIO_EVER_P25_Pos)
+#define GPIO_EVER_P26_Pos           26           /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P26               (_U(0x1) << GPIO_EVER_P26_Pos)
+#define GPIO_EVER_P27_Pos           27           /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P27               (_U(0x1) << GPIO_EVER_P27_Pos)
+#define GPIO_EVER_P28_Pos           28           /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P28               (_U(0x1) << GPIO_EVER_P28_Pos)
+#define GPIO_EVER_P29_Pos           29           /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P29               (_U(0x1) << GPIO_EVER_P29_Pos)
+#define GPIO_EVER_P30_Pos           30           /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P30               (_U(0x1) << GPIO_EVER_P30_Pos)
+#define GPIO_EVER_P31_Pos           31           /**< \brief (GPIO_EVER) Event Enable */
+#define GPIO_EVER_P31               (_U(0x1) << GPIO_EVER_P31_Pos)
+#define GPIO_EVER_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_EVER) MASK Register */
+
+/* -------- GPIO_EVERS : (GPIO Offset: 0x184) ( /W 32) port Event Enable Register - Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Event Enable                       */
+    uint32_t P1:1;             /*!< bit:      1  Event Enable                       */
+    uint32_t P2:1;             /*!< bit:      2  Event Enable                       */
+    uint32_t P3:1;             /*!< bit:      3  Event Enable                       */
+    uint32_t P4:1;             /*!< bit:      4  Event Enable                       */
+    uint32_t P5:1;             /*!< bit:      5  Event Enable                       */
+    uint32_t P6:1;             /*!< bit:      6  Event Enable                       */
+    uint32_t P7:1;             /*!< bit:      7  Event Enable                       */
+    uint32_t P8:1;             /*!< bit:      8  Event Enable                       */
+    uint32_t P9:1;             /*!< bit:      9  Event Enable                       */
+    uint32_t P10:1;            /*!< bit:     10  Event Enable                       */
+    uint32_t P11:1;            /*!< bit:     11  Event Enable                       */
+    uint32_t P12:1;            /*!< bit:     12  Event Enable                       */
+    uint32_t P13:1;            /*!< bit:     13  Event Enable                       */
+    uint32_t P14:1;            /*!< bit:     14  Event Enable                       */
+    uint32_t P15:1;            /*!< bit:     15  Event Enable                       */
+    uint32_t P16:1;            /*!< bit:     16  Event Enable                       */
+    uint32_t P17:1;            /*!< bit:     17  Event Enable                       */
+    uint32_t P18:1;            /*!< bit:     18  Event Enable                       */
+    uint32_t P19:1;            /*!< bit:     19  Event Enable                       */
+    uint32_t P20:1;            /*!< bit:     20  Event Enable                       */
+    uint32_t P21:1;            /*!< bit:     21  Event Enable                       */
+    uint32_t P22:1;            /*!< bit:     22  Event Enable                       */
+    uint32_t P23:1;            /*!< bit:     23  Event Enable                       */
+    uint32_t P24:1;            /*!< bit:     24  Event Enable                       */
+    uint32_t P25:1;            /*!< bit:     25  Event Enable                       */
+    uint32_t P26:1;            /*!< bit:     26  Event Enable                       */
+    uint32_t P27:1;            /*!< bit:     27  Event Enable                       */
+    uint32_t P28:1;            /*!< bit:     28  Event Enable                       */
+    uint32_t P29:1;            /*!< bit:     29  Event Enable                       */
+    uint32_t P30:1;            /*!< bit:     30  Event Enable                       */
+    uint32_t P31:1;            /*!< bit:     31  Event Enable                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_EVERS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_EVERS_OFFSET           0x184        /**< \brief (GPIO_EVERS offset) Event Enable Register - Set */
+
+#define GPIO_EVERS_P0_Pos           0            /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P0               (_U(0x1) << GPIO_EVERS_P0_Pos)
+#define GPIO_EVERS_P1_Pos           1            /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P1               (_U(0x1) << GPIO_EVERS_P1_Pos)
+#define GPIO_EVERS_P2_Pos           2            /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P2               (_U(0x1) << GPIO_EVERS_P2_Pos)
+#define GPIO_EVERS_P3_Pos           3            /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P3               (_U(0x1) << GPIO_EVERS_P3_Pos)
+#define GPIO_EVERS_P4_Pos           4            /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P4               (_U(0x1) << GPIO_EVERS_P4_Pos)
+#define GPIO_EVERS_P5_Pos           5            /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P5               (_U(0x1) << GPIO_EVERS_P5_Pos)
+#define GPIO_EVERS_P6_Pos           6            /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P6               (_U(0x1) << GPIO_EVERS_P6_Pos)
+#define GPIO_EVERS_P7_Pos           7            /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P7               (_U(0x1) << GPIO_EVERS_P7_Pos)
+#define GPIO_EVERS_P8_Pos           8            /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P8               (_U(0x1) << GPIO_EVERS_P8_Pos)
+#define GPIO_EVERS_P9_Pos           9            /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P9               (_U(0x1) << GPIO_EVERS_P9_Pos)
+#define GPIO_EVERS_P10_Pos          10           /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P10              (_U(0x1) << GPIO_EVERS_P10_Pos)
+#define GPIO_EVERS_P11_Pos          11           /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P11              (_U(0x1) << GPIO_EVERS_P11_Pos)
+#define GPIO_EVERS_P12_Pos          12           /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P12              (_U(0x1) << GPIO_EVERS_P12_Pos)
+#define GPIO_EVERS_P13_Pos          13           /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P13              (_U(0x1) << GPIO_EVERS_P13_Pos)
+#define GPIO_EVERS_P14_Pos          14           /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P14              (_U(0x1) << GPIO_EVERS_P14_Pos)
+#define GPIO_EVERS_P15_Pos          15           /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P15              (_U(0x1) << GPIO_EVERS_P15_Pos)
+#define GPIO_EVERS_P16_Pos          16           /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P16              (_U(0x1) << GPIO_EVERS_P16_Pos)
+#define GPIO_EVERS_P17_Pos          17           /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P17              (_U(0x1) << GPIO_EVERS_P17_Pos)
+#define GPIO_EVERS_P18_Pos          18           /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P18              (_U(0x1) << GPIO_EVERS_P18_Pos)
+#define GPIO_EVERS_P19_Pos          19           /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P19              (_U(0x1) << GPIO_EVERS_P19_Pos)
+#define GPIO_EVERS_P20_Pos          20           /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P20              (_U(0x1) << GPIO_EVERS_P20_Pos)
+#define GPIO_EVERS_P21_Pos          21           /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P21              (_U(0x1) << GPIO_EVERS_P21_Pos)
+#define GPIO_EVERS_P22_Pos          22           /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P22              (_U(0x1) << GPIO_EVERS_P22_Pos)
+#define GPIO_EVERS_P23_Pos          23           /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P23              (_U(0x1) << GPIO_EVERS_P23_Pos)
+#define GPIO_EVERS_P24_Pos          24           /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P24              (_U(0x1) << GPIO_EVERS_P24_Pos)
+#define GPIO_EVERS_P25_Pos          25           /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P25              (_U(0x1) << GPIO_EVERS_P25_Pos)
+#define GPIO_EVERS_P26_Pos          26           /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P26              (_U(0x1) << GPIO_EVERS_P26_Pos)
+#define GPIO_EVERS_P27_Pos          27           /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P27              (_U(0x1) << GPIO_EVERS_P27_Pos)
+#define GPIO_EVERS_P28_Pos          28           /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P28              (_U(0x1) << GPIO_EVERS_P28_Pos)
+#define GPIO_EVERS_P29_Pos          29           /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P29              (_U(0x1) << GPIO_EVERS_P29_Pos)
+#define GPIO_EVERS_P30_Pos          30           /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P30              (_U(0x1) << GPIO_EVERS_P30_Pos)
+#define GPIO_EVERS_P31_Pos          31           /**< \brief (GPIO_EVERS) Event Enable */
+#define GPIO_EVERS_P31              (_U(0x1) << GPIO_EVERS_P31_Pos)
+#define GPIO_EVERS_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_EVERS) MASK Register */
+
+/* -------- GPIO_EVERC : (GPIO Offset: 0x188) ( /W 32) port Event Enable Register - Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Event Enable                       */
+    uint32_t P1:1;             /*!< bit:      1  Event Enable                       */
+    uint32_t P2:1;             /*!< bit:      2  Event Enable                       */
+    uint32_t P3:1;             /*!< bit:      3  Event Enable                       */
+    uint32_t P4:1;             /*!< bit:      4  Event Enable                       */
+    uint32_t P5:1;             /*!< bit:      5  Event Enable                       */
+    uint32_t P6:1;             /*!< bit:      6  Event Enable                       */
+    uint32_t P7:1;             /*!< bit:      7  Event Enable                       */
+    uint32_t P8:1;             /*!< bit:      8  Event Enable                       */
+    uint32_t P9:1;             /*!< bit:      9  Event Enable                       */
+    uint32_t P10:1;            /*!< bit:     10  Event Enable                       */
+    uint32_t P11:1;            /*!< bit:     11  Event Enable                       */
+    uint32_t P12:1;            /*!< bit:     12  Event Enable                       */
+    uint32_t P13:1;            /*!< bit:     13  Event Enable                       */
+    uint32_t P14:1;            /*!< bit:     14  Event Enable                       */
+    uint32_t P15:1;            /*!< bit:     15  Event Enable                       */
+    uint32_t P16:1;            /*!< bit:     16  Event Enable                       */
+    uint32_t P17:1;            /*!< bit:     17  Event Enable                       */
+    uint32_t P18:1;            /*!< bit:     18  Event Enable                       */
+    uint32_t P19:1;            /*!< bit:     19  Event Enable                       */
+    uint32_t P20:1;            /*!< bit:     20  Event Enable                       */
+    uint32_t P21:1;            /*!< bit:     21  Event Enable                       */
+    uint32_t P22:1;            /*!< bit:     22  Event Enable                       */
+    uint32_t P23:1;            /*!< bit:     23  Event Enable                       */
+    uint32_t P24:1;            /*!< bit:     24  Event Enable                       */
+    uint32_t P25:1;            /*!< bit:     25  Event Enable                       */
+    uint32_t P26:1;            /*!< bit:     26  Event Enable                       */
+    uint32_t P27:1;            /*!< bit:     27  Event Enable                       */
+    uint32_t P28:1;            /*!< bit:     28  Event Enable                       */
+    uint32_t P29:1;            /*!< bit:     29  Event Enable                       */
+    uint32_t P30:1;            /*!< bit:     30  Event Enable                       */
+    uint32_t P31:1;            /*!< bit:     31  Event Enable                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_EVERC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_EVERC_OFFSET           0x188        /**< \brief (GPIO_EVERC offset) Event Enable Register - Clear */
+
+#define GPIO_EVERC_P0_Pos           0            /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P0               (_U(0x1) << GPIO_EVERC_P0_Pos)
+#define GPIO_EVERC_P1_Pos           1            /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P1               (_U(0x1) << GPIO_EVERC_P1_Pos)
+#define GPIO_EVERC_P2_Pos           2            /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P2               (_U(0x1) << GPIO_EVERC_P2_Pos)
+#define GPIO_EVERC_P3_Pos           3            /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P3               (_U(0x1) << GPIO_EVERC_P3_Pos)
+#define GPIO_EVERC_P4_Pos           4            /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P4               (_U(0x1) << GPIO_EVERC_P4_Pos)
+#define GPIO_EVERC_P5_Pos           5            /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P5               (_U(0x1) << GPIO_EVERC_P5_Pos)
+#define GPIO_EVERC_P6_Pos           6            /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P6               (_U(0x1) << GPIO_EVERC_P6_Pos)
+#define GPIO_EVERC_P7_Pos           7            /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P7               (_U(0x1) << GPIO_EVERC_P7_Pos)
+#define GPIO_EVERC_P8_Pos           8            /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P8               (_U(0x1) << GPIO_EVERC_P8_Pos)
+#define GPIO_EVERC_P9_Pos           9            /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P9               (_U(0x1) << GPIO_EVERC_P9_Pos)
+#define GPIO_EVERC_P10_Pos          10           /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P10              (_U(0x1) << GPIO_EVERC_P10_Pos)
+#define GPIO_EVERC_P11_Pos          11           /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P11              (_U(0x1) << GPIO_EVERC_P11_Pos)
+#define GPIO_EVERC_P12_Pos          12           /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P12              (_U(0x1) << GPIO_EVERC_P12_Pos)
+#define GPIO_EVERC_P13_Pos          13           /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P13              (_U(0x1) << GPIO_EVERC_P13_Pos)
+#define GPIO_EVERC_P14_Pos          14           /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P14              (_U(0x1) << GPIO_EVERC_P14_Pos)
+#define GPIO_EVERC_P15_Pos          15           /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P15              (_U(0x1) << GPIO_EVERC_P15_Pos)
+#define GPIO_EVERC_P16_Pos          16           /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P16              (_U(0x1) << GPIO_EVERC_P16_Pos)
+#define GPIO_EVERC_P17_Pos          17           /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P17              (_U(0x1) << GPIO_EVERC_P17_Pos)
+#define GPIO_EVERC_P18_Pos          18           /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P18              (_U(0x1) << GPIO_EVERC_P18_Pos)
+#define GPIO_EVERC_P19_Pos          19           /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P19              (_U(0x1) << GPIO_EVERC_P19_Pos)
+#define GPIO_EVERC_P20_Pos          20           /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P20              (_U(0x1) << GPIO_EVERC_P20_Pos)
+#define GPIO_EVERC_P21_Pos          21           /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P21              (_U(0x1) << GPIO_EVERC_P21_Pos)
+#define GPIO_EVERC_P22_Pos          22           /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P22              (_U(0x1) << GPIO_EVERC_P22_Pos)
+#define GPIO_EVERC_P23_Pos          23           /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P23              (_U(0x1) << GPIO_EVERC_P23_Pos)
+#define GPIO_EVERC_P24_Pos          24           /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P24              (_U(0x1) << GPIO_EVERC_P24_Pos)
+#define GPIO_EVERC_P25_Pos          25           /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P25              (_U(0x1) << GPIO_EVERC_P25_Pos)
+#define GPIO_EVERC_P26_Pos          26           /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P26              (_U(0x1) << GPIO_EVERC_P26_Pos)
+#define GPIO_EVERC_P27_Pos          27           /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P27              (_U(0x1) << GPIO_EVERC_P27_Pos)
+#define GPIO_EVERC_P28_Pos          28           /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P28              (_U(0x1) << GPIO_EVERC_P28_Pos)
+#define GPIO_EVERC_P29_Pos          29           /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P29              (_U(0x1) << GPIO_EVERC_P29_Pos)
+#define GPIO_EVERC_P30_Pos          30           /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P30              (_U(0x1) << GPIO_EVERC_P30_Pos)
+#define GPIO_EVERC_P31_Pos          31           /**< \brief (GPIO_EVERC) Event Enable */
+#define GPIO_EVERC_P31              (_U(0x1) << GPIO_EVERC_P31_Pos)
+#define GPIO_EVERC_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_EVERC) MASK Register */
+
+/* -------- GPIO_EVERT : (GPIO Offset: 0x18C) ( /W 32) port Event Enable Register - Toggle -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Event Enable                       */
+    uint32_t P1:1;             /*!< bit:      1  Event Enable                       */
+    uint32_t P2:1;             /*!< bit:      2  Event Enable                       */
+    uint32_t P3:1;             /*!< bit:      3  Event Enable                       */
+    uint32_t P4:1;             /*!< bit:      4  Event Enable                       */
+    uint32_t P5:1;             /*!< bit:      5  Event Enable                       */
+    uint32_t P6:1;             /*!< bit:      6  Event Enable                       */
+    uint32_t P7:1;             /*!< bit:      7  Event Enable                       */
+    uint32_t P8:1;             /*!< bit:      8  Event Enable                       */
+    uint32_t P9:1;             /*!< bit:      9  Event Enable                       */
+    uint32_t P10:1;            /*!< bit:     10  Event Enable                       */
+    uint32_t P11:1;            /*!< bit:     11  Event Enable                       */
+    uint32_t P12:1;            /*!< bit:     12  Event Enable                       */
+    uint32_t P13:1;            /*!< bit:     13  Event Enable                       */
+    uint32_t P14:1;            /*!< bit:     14  Event Enable                       */
+    uint32_t P15:1;            /*!< bit:     15  Event Enable                       */
+    uint32_t P16:1;            /*!< bit:     16  Event Enable                       */
+    uint32_t P17:1;            /*!< bit:     17  Event Enable                       */
+    uint32_t P18:1;            /*!< bit:     18  Event Enable                       */
+    uint32_t P19:1;            /*!< bit:     19  Event Enable                       */
+    uint32_t P20:1;            /*!< bit:     20  Event Enable                       */
+    uint32_t P21:1;            /*!< bit:     21  Event Enable                       */
+    uint32_t P22:1;            /*!< bit:     22  Event Enable                       */
+    uint32_t P23:1;            /*!< bit:     23  Event Enable                       */
+    uint32_t P24:1;            /*!< bit:     24  Event Enable                       */
+    uint32_t P25:1;            /*!< bit:     25  Event Enable                       */
+    uint32_t P26:1;            /*!< bit:     26  Event Enable                       */
+    uint32_t P27:1;            /*!< bit:     27  Event Enable                       */
+    uint32_t P28:1;            /*!< bit:     28  Event Enable                       */
+    uint32_t P29:1;            /*!< bit:     29  Event Enable                       */
+    uint32_t P30:1;            /*!< bit:     30  Event Enable                       */
+    uint32_t P31:1;            /*!< bit:     31  Event Enable                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_EVERT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_EVERT_OFFSET           0x18C        /**< \brief (GPIO_EVERT offset) Event Enable Register - Toggle */
+
+#define GPIO_EVERT_P0_Pos           0            /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P0               (_U(0x1) << GPIO_EVERT_P0_Pos)
+#define GPIO_EVERT_P1_Pos           1            /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P1               (_U(0x1) << GPIO_EVERT_P1_Pos)
+#define GPIO_EVERT_P2_Pos           2            /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P2               (_U(0x1) << GPIO_EVERT_P2_Pos)
+#define GPIO_EVERT_P3_Pos           3            /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P3               (_U(0x1) << GPIO_EVERT_P3_Pos)
+#define GPIO_EVERT_P4_Pos           4            /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P4               (_U(0x1) << GPIO_EVERT_P4_Pos)
+#define GPIO_EVERT_P5_Pos           5            /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P5               (_U(0x1) << GPIO_EVERT_P5_Pos)
+#define GPIO_EVERT_P6_Pos           6            /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P6               (_U(0x1) << GPIO_EVERT_P6_Pos)
+#define GPIO_EVERT_P7_Pos           7            /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P7               (_U(0x1) << GPIO_EVERT_P7_Pos)
+#define GPIO_EVERT_P8_Pos           8            /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P8               (_U(0x1) << GPIO_EVERT_P8_Pos)
+#define GPIO_EVERT_P9_Pos           9            /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P9               (_U(0x1) << GPIO_EVERT_P9_Pos)
+#define GPIO_EVERT_P10_Pos          10           /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P10              (_U(0x1) << GPIO_EVERT_P10_Pos)
+#define GPIO_EVERT_P11_Pos          11           /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P11              (_U(0x1) << GPIO_EVERT_P11_Pos)
+#define GPIO_EVERT_P12_Pos          12           /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P12              (_U(0x1) << GPIO_EVERT_P12_Pos)
+#define GPIO_EVERT_P13_Pos          13           /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P13              (_U(0x1) << GPIO_EVERT_P13_Pos)
+#define GPIO_EVERT_P14_Pos          14           /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P14              (_U(0x1) << GPIO_EVERT_P14_Pos)
+#define GPIO_EVERT_P15_Pos          15           /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P15              (_U(0x1) << GPIO_EVERT_P15_Pos)
+#define GPIO_EVERT_P16_Pos          16           /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P16              (_U(0x1) << GPIO_EVERT_P16_Pos)
+#define GPIO_EVERT_P17_Pos          17           /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P17              (_U(0x1) << GPIO_EVERT_P17_Pos)
+#define GPIO_EVERT_P18_Pos          18           /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P18              (_U(0x1) << GPIO_EVERT_P18_Pos)
+#define GPIO_EVERT_P19_Pos          19           /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P19              (_U(0x1) << GPIO_EVERT_P19_Pos)
+#define GPIO_EVERT_P20_Pos          20           /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P20              (_U(0x1) << GPIO_EVERT_P20_Pos)
+#define GPIO_EVERT_P21_Pos          21           /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P21              (_U(0x1) << GPIO_EVERT_P21_Pos)
+#define GPIO_EVERT_P22_Pos          22           /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P22              (_U(0x1) << GPIO_EVERT_P22_Pos)
+#define GPIO_EVERT_P23_Pos          23           /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P23              (_U(0x1) << GPIO_EVERT_P23_Pos)
+#define GPIO_EVERT_P24_Pos          24           /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P24              (_U(0x1) << GPIO_EVERT_P24_Pos)
+#define GPIO_EVERT_P25_Pos          25           /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P25              (_U(0x1) << GPIO_EVERT_P25_Pos)
+#define GPIO_EVERT_P26_Pos          26           /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P26              (_U(0x1) << GPIO_EVERT_P26_Pos)
+#define GPIO_EVERT_P27_Pos          27           /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P27              (_U(0x1) << GPIO_EVERT_P27_Pos)
+#define GPIO_EVERT_P28_Pos          28           /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P28              (_U(0x1) << GPIO_EVERT_P28_Pos)
+#define GPIO_EVERT_P29_Pos          29           /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P29              (_U(0x1) << GPIO_EVERT_P29_Pos)
+#define GPIO_EVERT_P30_Pos          30           /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P30              (_U(0x1) << GPIO_EVERT_P30_Pos)
+#define GPIO_EVERT_P31_Pos          31           /**< \brief (GPIO_EVERT) Event Enable */
+#define GPIO_EVERT_P31              (_U(0x1) << GPIO_EVERT_P31_Pos)
+#define GPIO_EVERT_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_EVERT) MASK Register */
+
+/* -------- GPIO_LOCK : (GPIO Offset: 0x1A0) (R/W 32) port Lock Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Lock State                         */
+    uint32_t P1:1;             /*!< bit:      1  Lock State                         */
+    uint32_t P2:1;             /*!< bit:      2  Lock State                         */
+    uint32_t P3:1;             /*!< bit:      3  Lock State                         */
+    uint32_t P4:1;             /*!< bit:      4  Lock State                         */
+    uint32_t P5:1;             /*!< bit:      5  Lock State                         */
+    uint32_t P6:1;             /*!< bit:      6  Lock State                         */
+    uint32_t P7:1;             /*!< bit:      7  Lock State                         */
+    uint32_t P8:1;             /*!< bit:      8  Lock State                         */
+    uint32_t P9:1;             /*!< bit:      9  Lock State                         */
+    uint32_t P10:1;            /*!< bit:     10  Lock State                         */
+    uint32_t P11:1;            /*!< bit:     11  Lock State                         */
+    uint32_t P12:1;            /*!< bit:     12  Lock State                         */
+    uint32_t P13:1;            /*!< bit:     13  Lock State                         */
+    uint32_t P14:1;            /*!< bit:     14  Lock State                         */
+    uint32_t P15:1;            /*!< bit:     15  Lock State                         */
+    uint32_t P16:1;            /*!< bit:     16  Lock State                         */
+    uint32_t P17:1;            /*!< bit:     17  Lock State                         */
+    uint32_t P18:1;            /*!< bit:     18  Lock State                         */
+    uint32_t P19:1;            /*!< bit:     19  Lock State                         */
+    uint32_t P20:1;            /*!< bit:     20  Lock State                         */
+    uint32_t P21:1;            /*!< bit:     21  Lock State                         */
+    uint32_t P22:1;            /*!< bit:     22  Lock State                         */
+    uint32_t P23:1;            /*!< bit:     23  Lock State                         */
+    uint32_t P24:1;            /*!< bit:     24  Lock State                         */
+    uint32_t P25:1;            /*!< bit:     25  Lock State                         */
+    uint32_t P26:1;            /*!< bit:     26  Lock State                         */
+    uint32_t P27:1;            /*!< bit:     27  Lock State                         */
+    uint32_t P28:1;            /*!< bit:     28  Lock State                         */
+    uint32_t P29:1;            /*!< bit:     29  Lock State                         */
+    uint32_t P30:1;            /*!< bit:     30  Lock State                         */
+    uint32_t P31:1;            /*!< bit:     31  Lock State                         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_LOCK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_LOCK_OFFSET            0x1A0        /**< \brief (GPIO_LOCK offset) Lock Register */
+
+#define GPIO_LOCK_P0_Pos            0            /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P0                (_U(0x1) << GPIO_LOCK_P0_Pos)
+#define GPIO_LOCK_P1_Pos            1            /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P1                (_U(0x1) << GPIO_LOCK_P1_Pos)
+#define GPIO_LOCK_P2_Pos            2            /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P2                (_U(0x1) << GPIO_LOCK_P2_Pos)
+#define GPIO_LOCK_P3_Pos            3            /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P3                (_U(0x1) << GPIO_LOCK_P3_Pos)
+#define GPIO_LOCK_P4_Pos            4            /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P4                (_U(0x1) << GPIO_LOCK_P4_Pos)
+#define GPIO_LOCK_P5_Pos            5            /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P5                (_U(0x1) << GPIO_LOCK_P5_Pos)
+#define GPIO_LOCK_P6_Pos            6            /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P6                (_U(0x1) << GPIO_LOCK_P6_Pos)
+#define GPIO_LOCK_P7_Pos            7            /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P7                (_U(0x1) << GPIO_LOCK_P7_Pos)
+#define GPIO_LOCK_P8_Pos            8            /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P8                (_U(0x1) << GPIO_LOCK_P8_Pos)
+#define GPIO_LOCK_P9_Pos            9            /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P9                (_U(0x1) << GPIO_LOCK_P9_Pos)
+#define GPIO_LOCK_P10_Pos           10           /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P10               (_U(0x1) << GPIO_LOCK_P10_Pos)
+#define GPIO_LOCK_P11_Pos           11           /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P11               (_U(0x1) << GPIO_LOCK_P11_Pos)
+#define GPIO_LOCK_P12_Pos           12           /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P12               (_U(0x1) << GPIO_LOCK_P12_Pos)
+#define GPIO_LOCK_P13_Pos           13           /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P13               (_U(0x1) << GPIO_LOCK_P13_Pos)
+#define GPIO_LOCK_P14_Pos           14           /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P14               (_U(0x1) << GPIO_LOCK_P14_Pos)
+#define GPIO_LOCK_P15_Pos           15           /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P15               (_U(0x1) << GPIO_LOCK_P15_Pos)
+#define GPIO_LOCK_P16_Pos           16           /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P16               (_U(0x1) << GPIO_LOCK_P16_Pos)
+#define GPIO_LOCK_P17_Pos           17           /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P17               (_U(0x1) << GPIO_LOCK_P17_Pos)
+#define GPIO_LOCK_P18_Pos           18           /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P18               (_U(0x1) << GPIO_LOCK_P18_Pos)
+#define GPIO_LOCK_P19_Pos           19           /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P19               (_U(0x1) << GPIO_LOCK_P19_Pos)
+#define GPIO_LOCK_P20_Pos           20           /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P20               (_U(0x1) << GPIO_LOCK_P20_Pos)
+#define GPIO_LOCK_P21_Pos           21           /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P21               (_U(0x1) << GPIO_LOCK_P21_Pos)
+#define GPIO_LOCK_P22_Pos           22           /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P22               (_U(0x1) << GPIO_LOCK_P22_Pos)
+#define GPIO_LOCK_P23_Pos           23           /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P23               (_U(0x1) << GPIO_LOCK_P23_Pos)
+#define GPIO_LOCK_P24_Pos           24           /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P24               (_U(0x1) << GPIO_LOCK_P24_Pos)
+#define GPIO_LOCK_P25_Pos           25           /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P25               (_U(0x1) << GPIO_LOCK_P25_Pos)
+#define GPIO_LOCK_P26_Pos           26           /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P26               (_U(0x1) << GPIO_LOCK_P26_Pos)
+#define GPIO_LOCK_P27_Pos           27           /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P27               (_U(0x1) << GPIO_LOCK_P27_Pos)
+#define GPIO_LOCK_P28_Pos           28           /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P28               (_U(0x1) << GPIO_LOCK_P28_Pos)
+#define GPIO_LOCK_P29_Pos           29           /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P29               (_U(0x1) << GPIO_LOCK_P29_Pos)
+#define GPIO_LOCK_P30_Pos           30           /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P30               (_U(0x1) << GPIO_LOCK_P30_Pos)
+#define GPIO_LOCK_P31_Pos           31           /**< \brief (GPIO_LOCK) Lock State */
+#define GPIO_LOCK_P31               (_U(0x1) << GPIO_LOCK_P31_Pos)
+#define GPIO_LOCK_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_LOCK) MASK Register */
+
+/* -------- GPIO_LOCKS : (GPIO Offset: 0x1A4) ( /W 32) port Lock Register - Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Lock State                         */
+    uint32_t P1:1;             /*!< bit:      1  Lock State                         */
+    uint32_t P2:1;             /*!< bit:      2  Lock State                         */
+    uint32_t P3:1;             /*!< bit:      3  Lock State                         */
+    uint32_t P4:1;             /*!< bit:      4  Lock State                         */
+    uint32_t P5:1;             /*!< bit:      5  Lock State                         */
+    uint32_t P6:1;             /*!< bit:      6  Lock State                         */
+    uint32_t P7:1;             /*!< bit:      7  Lock State                         */
+    uint32_t P8:1;             /*!< bit:      8  Lock State                         */
+    uint32_t P9:1;             /*!< bit:      9  Lock State                         */
+    uint32_t P10:1;            /*!< bit:     10  Lock State                         */
+    uint32_t P11:1;            /*!< bit:     11  Lock State                         */
+    uint32_t P12:1;            /*!< bit:     12  Lock State                         */
+    uint32_t P13:1;            /*!< bit:     13  Lock State                         */
+    uint32_t P14:1;            /*!< bit:     14  Lock State                         */
+    uint32_t P15:1;            /*!< bit:     15  Lock State                         */
+    uint32_t P16:1;            /*!< bit:     16  Lock State                         */
+    uint32_t P17:1;            /*!< bit:     17  Lock State                         */
+    uint32_t P18:1;            /*!< bit:     18  Lock State                         */
+    uint32_t P19:1;            /*!< bit:     19  Lock State                         */
+    uint32_t P20:1;            /*!< bit:     20  Lock State                         */
+    uint32_t P21:1;            /*!< bit:     21  Lock State                         */
+    uint32_t P22:1;            /*!< bit:     22  Lock State                         */
+    uint32_t P23:1;            /*!< bit:     23  Lock State                         */
+    uint32_t P24:1;            /*!< bit:     24  Lock State                         */
+    uint32_t P25:1;            /*!< bit:     25  Lock State                         */
+    uint32_t P26:1;            /*!< bit:     26  Lock State                         */
+    uint32_t P27:1;            /*!< bit:     27  Lock State                         */
+    uint32_t P28:1;            /*!< bit:     28  Lock State                         */
+    uint32_t P29:1;            /*!< bit:     29  Lock State                         */
+    uint32_t P30:1;            /*!< bit:     30  Lock State                         */
+    uint32_t P31:1;            /*!< bit:     31  Lock State                         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_LOCKS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_LOCKS_OFFSET           0x1A4        /**< \brief (GPIO_LOCKS offset) Lock Register - Set */
+
+#define GPIO_LOCKS_P0_Pos           0            /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P0               (_U(0x1) << GPIO_LOCKS_P0_Pos)
+#define GPIO_LOCKS_P1_Pos           1            /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P1               (_U(0x1) << GPIO_LOCKS_P1_Pos)
+#define GPIO_LOCKS_P2_Pos           2            /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P2               (_U(0x1) << GPIO_LOCKS_P2_Pos)
+#define GPIO_LOCKS_P3_Pos           3            /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P3               (_U(0x1) << GPIO_LOCKS_P3_Pos)
+#define GPIO_LOCKS_P4_Pos           4            /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P4               (_U(0x1) << GPIO_LOCKS_P4_Pos)
+#define GPIO_LOCKS_P5_Pos           5            /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P5               (_U(0x1) << GPIO_LOCKS_P5_Pos)
+#define GPIO_LOCKS_P6_Pos           6            /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P6               (_U(0x1) << GPIO_LOCKS_P6_Pos)
+#define GPIO_LOCKS_P7_Pos           7            /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P7               (_U(0x1) << GPIO_LOCKS_P7_Pos)
+#define GPIO_LOCKS_P8_Pos           8            /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P8               (_U(0x1) << GPIO_LOCKS_P8_Pos)
+#define GPIO_LOCKS_P9_Pos           9            /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P9               (_U(0x1) << GPIO_LOCKS_P9_Pos)
+#define GPIO_LOCKS_P10_Pos          10           /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P10              (_U(0x1) << GPIO_LOCKS_P10_Pos)
+#define GPIO_LOCKS_P11_Pos          11           /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P11              (_U(0x1) << GPIO_LOCKS_P11_Pos)
+#define GPIO_LOCKS_P12_Pos          12           /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P12              (_U(0x1) << GPIO_LOCKS_P12_Pos)
+#define GPIO_LOCKS_P13_Pos          13           /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P13              (_U(0x1) << GPIO_LOCKS_P13_Pos)
+#define GPIO_LOCKS_P14_Pos          14           /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P14              (_U(0x1) << GPIO_LOCKS_P14_Pos)
+#define GPIO_LOCKS_P15_Pos          15           /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P15              (_U(0x1) << GPIO_LOCKS_P15_Pos)
+#define GPIO_LOCKS_P16_Pos          16           /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P16              (_U(0x1) << GPIO_LOCKS_P16_Pos)
+#define GPIO_LOCKS_P17_Pos          17           /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P17              (_U(0x1) << GPIO_LOCKS_P17_Pos)
+#define GPIO_LOCKS_P18_Pos          18           /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P18              (_U(0x1) << GPIO_LOCKS_P18_Pos)
+#define GPIO_LOCKS_P19_Pos          19           /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P19              (_U(0x1) << GPIO_LOCKS_P19_Pos)
+#define GPIO_LOCKS_P20_Pos          20           /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P20              (_U(0x1) << GPIO_LOCKS_P20_Pos)
+#define GPIO_LOCKS_P21_Pos          21           /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P21              (_U(0x1) << GPIO_LOCKS_P21_Pos)
+#define GPIO_LOCKS_P22_Pos          22           /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P22              (_U(0x1) << GPIO_LOCKS_P22_Pos)
+#define GPIO_LOCKS_P23_Pos          23           /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P23              (_U(0x1) << GPIO_LOCKS_P23_Pos)
+#define GPIO_LOCKS_P24_Pos          24           /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P24              (_U(0x1) << GPIO_LOCKS_P24_Pos)
+#define GPIO_LOCKS_P25_Pos          25           /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P25              (_U(0x1) << GPIO_LOCKS_P25_Pos)
+#define GPIO_LOCKS_P26_Pos          26           /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P26              (_U(0x1) << GPIO_LOCKS_P26_Pos)
+#define GPIO_LOCKS_P27_Pos          27           /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P27              (_U(0x1) << GPIO_LOCKS_P27_Pos)
+#define GPIO_LOCKS_P28_Pos          28           /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P28              (_U(0x1) << GPIO_LOCKS_P28_Pos)
+#define GPIO_LOCKS_P29_Pos          29           /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P29              (_U(0x1) << GPIO_LOCKS_P29_Pos)
+#define GPIO_LOCKS_P30_Pos          30           /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P30              (_U(0x1) << GPIO_LOCKS_P30_Pos)
+#define GPIO_LOCKS_P31_Pos          31           /**< \brief (GPIO_LOCKS) Lock State */
+#define GPIO_LOCKS_P31              (_U(0x1) << GPIO_LOCKS_P31_Pos)
+#define GPIO_LOCKS_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_LOCKS) MASK Register */
+
+/* -------- GPIO_LOCKC : (GPIO Offset: 0x1A8) ( /W 32) port Lock Register - Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Lock State                         */
+    uint32_t P1:1;             /*!< bit:      1  Lock State                         */
+    uint32_t P2:1;             /*!< bit:      2  Lock State                         */
+    uint32_t P3:1;             /*!< bit:      3  Lock State                         */
+    uint32_t P4:1;             /*!< bit:      4  Lock State                         */
+    uint32_t P5:1;             /*!< bit:      5  Lock State                         */
+    uint32_t P6:1;             /*!< bit:      6  Lock State                         */
+    uint32_t P7:1;             /*!< bit:      7  Lock State                         */
+    uint32_t P8:1;             /*!< bit:      8  Lock State                         */
+    uint32_t P9:1;             /*!< bit:      9  Lock State                         */
+    uint32_t P10:1;            /*!< bit:     10  Lock State                         */
+    uint32_t P11:1;            /*!< bit:     11  Lock State                         */
+    uint32_t P12:1;            /*!< bit:     12  Lock State                         */
+    uint32_t P13:1;            /*!< bit:     13  Lock State                         */
+    uint32_t P14:1;            /*!< bit:     14  Lock State                         */
+    uint32_t P15:1;            /*!< bit:     15  Lock State                         */
+    uint32_t P16:1;            /*!< bit:     16  Lock State                         */
+    uint32_t P17:1;            /*!< bit:     17  Lock State                         */
+    uint32_t P18:1;            /*!< bit:     18  Lock State                         */
+    uint32_t P19:1;            /*!< bit:     19  Lock State                         */
+    uint32_t P20:1;            /*!< bit:     20  Lock State                         */
+    uint32_t P21:1;            /*!< bit:     21  Lock State                         */
+    uint32_t P22:1;            /*!< bit:     22  Lock State                         */
+    uint32_t P23:1;            /*!< bit:     23  Lock State                         */
+    uint32_t P24:1;            /*!< bit:     24  Lock State                         */
+    uint32_t P25:1;            /*!< bit:     25  Lock State                         */
+    uint32_t P26:1;            /*!< bit:     26  Lock State                         */
+    uint32_t P27:1;            /*!< bit:     27  Lock State                         */
+    uint32_t P28:1;            /*!< bit:     28  Lock State                         */
+    uint32_t P29:1;            /*!< bit:     29  Lock State                         */
+    uint32_t P30:1;            /*!< bit:     30  Lock State                         */
+    uint32_t P31:1;            /*!< bit:     31  Lock State                         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_LOCKC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_LOCKC_OFFSET           0x1A8        /**< \brief (GPIO_LOCKC offset) Lock Register - Clear */
+
+#define GPIO_LOCKC_P0_Pos           0            /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P0               (_U(0x1) << GPIO_LOCKC_P0_Pos)
+#define GPIO_LOCKC_P1_Pos           1            /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P1               (_U(0x1) << GPIO_LOCKC_P1_Pos)
+#define GPIO_LOCKC_P2_Pos           2            /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P2               (_U(0x1) << GPIO_LOCKC_P2_Pos)
+#define GPIO_LOCKC_P3_Pos           3            /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P3               (_U(0x1) << GPIO_LOCKC_P3_Pos)
+#define GPIO_LOCKC_P4_Pos           4            /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P4               (_U(0x1) << GPIO_LOCKC_P4_Pos)
+#define GPIO_LOCKC_P5_Pos           5            /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P5               (_U(0x1) << GPIO_LOCKC_P5_Pos)
+#define GPIO_LOCKC_P6_Pos           6            /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P6               (_U(0x1) << GPIO_LOCKC_P6_Pos)
+#define GPIO_LOCKC_P7_Pos           7            /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P7               (_U(0x1) << GPIO_LOCKC_P7_Pos)
+#define GPIO_LOCKC_P8_Pos           8            /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P8               (_U(0x1) << GPIO_LOCKC_P8_Pos)
+#define GPIO_LOCKC_P9_Pos           9            /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P9               (_U(0x1) << GPIO_LOCKC_P9_Pos)
+#define GPIO_LOCKC_P10_Pos          10           /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P10              (_U(0x1) << GPIO_LOCKC_P10_Pos)
+#define GPIO_LOCKC_P11_Pos          11           /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P11              (_U(0x1) << GPIO_LOCKC_P11_Pos)
+#define GPIO_LOCKC_P12_Pos          12           /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P12              (_U(0x1) << GPIO_LOCKC_P12_Pos)
+#define GPIO_LOCKC_P13_Pos          13           /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P13              (_U(0x1) << GPIO_LOCKC_P13_Pos)
+#define GPIO_LOCKC_P14_Pos          14           /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P14              (_U(0x1) << GPIO_LOCKC_P14_Pos)
+#define GPIO_LOCKC_P15_Pos          15           /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P15              (_U(0x1) << GPIO_LOCKC_P15_Pos)
+#define GPIO_LOCKC_P16_Pos          16           /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P16              (_U(0x1) << GPIO_LOCKC_P16_Pos)
+#define GPIO_LOCKC_P17_Pos          17           /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P17              (_U(0x1) << GPIO_LOCKC_P17_Pos)
+#define GPIO_LOCKC_P18_Pos          18           /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P18              (_U(0x1) << GPIO_LOCKC_P18_Pos)
+#define GPIO_LOCKC_P19_Pos          19           /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P19              (_U(0x1) << GPIO_LOCKC_P19_Pos)
+#define GPIO_LOCKC_P20_Pos          20           /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P20              (_U(0x1) << GPIO_LOCKC_P20_Pos)
+#define GPIO_LOCKC_P21_Pos          21           /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P21              (_U(0x1) << GPIO_LOCKC_P21_Pos)
+#define GPIO_LOCKC_P22_Pos          22           /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P22              (_U(0x1) << GPIO_LOCKC_P22_Pos)
+#define GPIO_LOCKC_P23_Pos          23           /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P23              (_U(0x1) << GPIO_LOCKC_P23_Pos)
+#define GPIO_LOCKC_P24_Pos          24           /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P24              (_U(0x1) << GPIO_LOCKC_P24_Pos)
+#define GPIO_LOCKC_P25_Pos          25           /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P25              (_U(0x1) << GPIO_LOCKC_P25_Pos)
+#define GPIO_LOCKC_P26_Pos          26           /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P26              (_U(0x1) << GPIO_LOCKC_P26_Pos)
+#define GPIO_LOCKC_P27_Pos          27           /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P27              (_U(0x1) << GPIO_LOCKC_P27_Pos)
+#define GPIO_LOCKC_P28_Pos          28           /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P28              (_U(0x1) << GPIO_LOCKC_P28_Pos)
+#define GPIO_LOCKC_P29_Pos          29           /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P29              (_U(0x1) << GPIO_LOCKC_P29_Pos)
+#define GPIO_LOCKC_P30_Pos          30           /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P30              (_U(0x1) << GPIO_LOCKC_P30_Pos)
+#define GPIO_LOCKC_P31_Pos          31           /**< \brief (GPIO_LOCKC) Lock State */
+#define GPIO_LOCKC_P31              (_U(0x1) << GPIO_LOCKC_P31_Pos)
+#define GPIO_LOCKC_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_LOCKC) MASK Register */
+
+/* -------- GPIO_LOCKT : (GPIO Offset: 0x1AC) ( /W 32) port Lock Register - Toggle -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t P0:1;             /*!< bit:      0  Lock State                         */
+    uint32_t P1:1;             /*!< bit:      1  Lock State                         */
+    uint32_t P2:1;             /*!< bit:      2  Lock State                         */
+    uint32_t P3:1;             /*!< bit:      3  Lock State                         */
+    uint32_t P4:1;             /*!< bit:      4  Lock State                         */
+    uint32_t P5:1;             /*!< bit:      5  Lock State                         */
+    uint32_t P6:1;             /*!< bit:      6  Lock State                         */
+    uint32_t P7:1;             /*!< bit:      7  Lock State                         */
+    uint32_t P8:1;             /*!< bit:      8  Lock State                         */
+    uint32_t P9:1;             /*!< bit:      9  Lock State                         */
+    uint32_t P10:1;            /*!< bit:     10  Lock State                         */
+    uint32_t P11:1;            /*!< bit:     11  Lock State                         */
+    uint32_t P12:1;            /*!< bit:     12  Lock State                         */
+    uint32_t P13:1;            /*!< bit:     13  Lock State                         */
+    uint32_t P14:1;            /*!< bit:     14  Lock State                         */
+    uint32_t P15:1;            /*!< bit:     15  Lock State                         */
+    uint32_t P16:1;            /*!< bit:     16  Lock State                         */
+    uint32_t P17:1;            /*!< bit:     17  Lock State                         */
+    uint32_t P18:1;            /*!< bit:     18  Lock State                         */
+    uint32_t P19:1;            /*!< bit:     19  Lock State                         */
+    uint32_t P20:1;            /*!< bit:     20  Lock State                         */
+    uint32_t P21:1;            /*!< bit:     21  Lock State                         */
+    uint32_t P22:1;            /*!< bit:     22  Lock State                         */
+    uint32_t P23:1;            /*!< bit:     23  Lock State                         */
+    uint32_t P24:1;            /*!< bit:     24  Lock State                         */
+    uint32_t P25:1;            /*!< bit:     25  Lock State                         */
+    uint32_t P26:1;            /*!< bit:     26  Lock State                         */
+    uint32_t P27:1;            /*!< bit:     27  Lock State                         */
+    uint32_t P28:1;            /*!< bit:     28  Lock State                         */
+    uint32_t P29:1;            /*!< bit:     29  Lock State                         */
+    uint32_t P30:1;            /*!< bit:     30  Lock State                         */
+    uint32_t P31:1;            /*!< bit:     31  Lock State                         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_LOCKT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_LOCKT_OFFSET           0x1AC        /**< \brief (GPIO_LOCKT offset) Lock Register - Toggle */
+
+#define GPIO_LOCKT_P0_Pos           0            /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P0               (_U(0x1) << GPIO_LOCKT_P0_Pos)
+#define GPIO_LOCKT_P1_Pos           1            /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P1               (_U(0x1) << GPIO_LOCKT_P1_Pos)
+#define GPIO_LOCKT_P2_Pos           2            /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P2               (_U(0x1) << GPIO_LOCKT_P2_Pos)
+#define GPIO_LOCKT_P3_Pos           3            /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P3               (_U(0x1) << GPIO_LOCKT_P3_Pos)
+#define GPIO_LOCKT_P4_Pos           4            /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P4               (_U(0x1) << GPIO_LOCKT_P4_Pos)
+#define GPIO_LOCKT_P5_Pos           5            /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P5               (_U(0x1) << GPIO_LOCKT_P5_Pos)
+#define GPIO_LOCKT_P6_Pos           6            /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P6               (_U(0x1) << GPIO_LOCKT_P6_Pos)
+#define GPIO_LOCKT_P7_Pos           7            /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P7               (_U(0x1) << GPIO_LOCKT_P7_Pos)
+#define GPIO_LOCKT_P8_Pos           8            /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P8               (_U(0x1) << GPIO_LOCKT_P8_Pos)
+#define GPIO_LOCKT_P9_Pos           9            /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P9               (_U(0x1) << GPIO_LOCKT_P9_Pos)
+#define GPIO_LOCKT_P10_Pos          10           /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P10              (_U(0x1) << GPIO_LOCKT_P10_Pos)
+#define GPIO_LOCKT_P11_Pos          11           /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P11              (_U(0x1) << GPIO_LOCKT_P11_Pos)
+#define GPIO_LOCKT_P12_Pos          12           /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P12              (_U(0x1) << GPIO_LOCKT_P12_Pos)
+#define GPIO_LOCKT_P13_Pos          13           /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P13              (_U(0x1) << GPIO_LOCKT_P13_Pos)
+#define GPIO_LOCKT_P14_Pos          14           /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P14              (_U(0x1) << GPIO_LOCKT_P14_Pos)
+#define GPIO_LOCKT_P15_Pos          15           /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P15              (_U(0x1) << GPIO_LOCKT_P15_Pos)
+#define GPIO_LOCKT_P16_Pos          16           /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P16              (_U(0x1) << GPIO_LOCKT_P16_Pos)
+#define GPIO_LOCKT_P17_Pos          17           /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P17              (_U(0x1) << GPIO_LOCKT_P17_Pos)
+#define GPIO_LOCKT_P18_Pos          18           /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P18              (_U(0x1) << GPIO_LOCKT_P18_Pos)
+#define GPIO_LOCKT_P19_Pos          19           /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P19              (_U(0x1) << GPIO_LOCKT_P19_Pos)
+#define GPIO_LOCKT_P20_Pos          20           /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P20              (_U(0x1) << GPIO_LOCKT_P20_Pos)
+#define GPIO_LOCKT_P21_Pos          21           /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P21              (_U(0x1) << GPIO_LOCKT_P21_Pos)
+#define GPIO_LOCKT_P22_Pos          22           /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P22              (_U(0x1) << GPIO_LOCKT_P22_Pos)
+#define GPIO_LOCKT_P23_Pos          23           /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P23              (_U(0x1) << GPIO_LOCKT_P23_Pos)
+#define GPIO_LOCKT_P24_Pos          24           /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P24              (_U(0x1) << GPIO_LOCKT_P24_Pos)
+#define GPIO_LOCKT_P25_Pos          25           /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P25              (_U(0x1) << GPIO_LOCKT_P25_Pos)
+#define GPIO_LOCKT_P26_Pos          26           /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P26              (_U(0x1) << GPIO_LOCKT_P26_Pos)
+#define GPIO_LOCKT_P27_Pos          27           /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P27              (_U(0x1) << GPIO_LOCKT_P27_Pos)
+#define GPIO_LOCKT_P28_Pos          28           /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P28              (_U(0x1) << GPIO_LOCKT_P28_Pos)
+#define GPIO_LOCKT_P29_Pos          29           /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P29              (_U(0x1) << GPIO_LOCKT_P29_Pos)
+#define GPIO_LOCKT_P30_Pos          30           /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P30              (_U(0x1) << GPIO_LOCKT_P30_Pos)
+#define GPIO_LOCKT_P31_Pos          31           /**< \brief (GPIO_LOCKT) Lock State */
+#define GPIO_LOCKT_P31              (_U(0x1) << GPIO_LOCKT_P31_Pos)
+#define GPIO_LOCKT_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_LOCKT) MASK Register */
+
+/* -------- GPIO_UNLOCK : (GPIO Offset: 0x1E0) ( /W 32) port Unlock Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ADDR:10;          /*!< bit:  0.. 9  Offset Register                    */
+    uint32_t :14;              /*!< bit: 10..23  Reserved                           */
+    uint32_t KEY:8;            /*!< bit: 24..31  Unlocking Key                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_UNLOCK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_UNLOCK_OFFSET          0x1E0        /**< \brief (GPIO_UNLOCK offset) Unlock Register */
+
+#define GPIO_UNLOCK_ADDR_Pos        0            /**< \brief (GPIO_UNLOCK) Offset Register */
+#define GPIO_UNLOCK_ADDR_Msk        (_U(0x3FF) << GPIO_UNLOCK_ADDR_Pos)
+#define GPIO_UNLOCK_ADDR(value)     (GPIO_UNLOCK_ADDR_Msk & ((value) << GPIO_UNLOCK_ADDR_Pos))
+#define GPIO_UNLOCK_KEY_Pos         24           /**< \brief (GPIO_UNLOCK) Unlocking Key */
+#define GPIO_UNLOCK_KEY_Msk         (_U(0xFF) << GPIO_UNLOCK_KEY_Pos)
+#define GPIO_UNLOCK_KEY(value)      (GPIO_UNLOCK_KEY_Msk & ((value) << GPIO_UNLOCK_KEY_Pos))
+#define GPIO_UNLOCK_MASK            _U(0xFF0003FF) /**< \brief (GPIO_UNLOCK) MASK Register */
+
+/* -------- GPIO_ASR : (GPIO Offset: 0x1E4) (R/W 32) port Access Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t AR:1;             /*!< bit:      0  Access Error                       */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_ASR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_ASR_OFFSET             0x1E4        /**< \brief (GPIO_ASR offset) Access Status Register */
+
+#define GPIO_ASR_AR_Pos             0            /**< \brief (GPIO_ASR) Access Error */
+#define GPIO_ASR_AR                 (_U(0x1) << GPIO_ASR_AR_Pos)
+#define GPIO_ASR_MASK               _U(0x00000001) /**< \brief (GPIO_ASR) MASK Register */
+
+/* -------- GPIO_PARAMETER : (GPIO Offset: 0x1F8) (R/  32) port Parameter Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PARAMETER:32;     /*!< bit:  0..31  Parameter                          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_PARAMETER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_PARAMETER_OFFSET       0x1F8        /**< \brief (GPIO_PARAMETER offset) Parameter Register */
+
+#define GPIO_PARAMETER_PARAMETER_Pos 0            /**< \brief (GPIO_PARAMETER) Parameter */
+#define GPIO_PARAMETER_PARAMETER_Msk (_U(0xFFFFFFFF) << GPIO_PARAMETER_PARAMETER_Pos)
+#define GPIO_PARAMETER_PARAMETER(value) (GPIO_PARAMETER_PARAMETER_Msk & ((value) << GPIO_PARAMETER_PARAMETER_Pos))
+#define GPIO_PARAMETER_MASK         _U(0xFFFFFFFF) /**< \brief (GPIO_PARAMETER) MASK Register */
+
+/* -------- GPIO_VERSION : (GPIO Offset: 0x1FC) (R/  32) port Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version Number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant Number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GPIO_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GPIO_VERSION_OFFSET         0x1FC        /**< \brief (GPIO_VERSION offset) Version Register */
+#define GPIO_VERSION_RESETVALUE     _U(0x00000215); /**< \brief (GPIO_VERSION reset_value) Version Register */
+
+#define GPIO_VERSION_VERSION_Pos    0            /**< \brief (GPIO_VERSION) Version Number */
+#define GPIO_VERSION_VERSION_Msk    (_U(0xFFF) << GPIO_VERSION_VERSION_Pos)
+#define GPIO_VERSION_VERSION(value) (GPIO_VERSION_VERSION_Msk & ((value) << GPIO_VERSION_VERSION_Pos))
+#define GPIO_VERSION_VARIANT_Pos    16           /**< \brief (GPIO_VERSION) Variant Number */
+#define GPIO_VERSION_VARIANT_Msk    (_U(0xF) << GPIO_VERSION_VARIANT_Pos)
+#define GPIO_VERSION_VARIANT(value) (GPIO_VERSION_VARIANT_Msk & ((value) << GPIO_VERSION_VARIANT_Pos))
+#define GPIO_VERSION_MASK           _U(0x000F0FFF) /**< \brief (GPIO_VERSION) MASK Register */
+
+/** \brief GpioPort hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __IO GPIO_GPER_Type            GPER;        /**< \brief Offset: 0x000 (R/W 32) GPIO Enable Register */
+  __O  GPIO_GPERS_Type           GPERS;       /**< \brief Offset: 0x004 ( /W 32) GPIO Enable Register - Set */
+  __O  GPIO_GPERC_Type           GPERC;       /**< \brief Offset: 0x008 ( /W 32) GPIO Enable Register - Clear */
+  __O  GPIO_GPERT_Type           GPERT;       /**< \brief Offset: 0x00C ( /W 32) GPIO Enable Register - Toggle */
+  __IO GPIO_PMR0_Type            PMR0;        /**< \brief Offset: 0x010 (R/W 32) Peripheral Mux Register 0 */
+  __O  GPIO_PMR0S_Type           PMR0S;       /**< \brief Offset: 0x014 ( /W 32) Peripheral Mux Register 0 - Set */
+  __O  GPIO_PMR0C_Type           PMR0C;       /**< \brief Offset: 0x018 ( /W 32) Peripheral Mux Register 0 - Clear */
+  __O  GPIO_PMR0T_Type           PMR0T;       /**< \brief Offset: 0x01C ( /W 32) Peripheral Mux Register 0 - Toggle */
+  __IO GPIO_PMR1_Type            PMR1;        /**< \brief Offset: 0x020 (R/W 32) Peripheral Mux Register 1 */
+  __O  GPIO_PMR1S_Type           PMR1S;       /**< \brief Offset: 0x024 ( /W 32) Peripheral Mux Register 1 - Set */
+  __O  GPIO_PMR1C_Type           PMR1C;       /**< \brief Offset: 0x028 ( /W 32) Peripheral Mux Register 1 - Clear */
+  __O  GPIO_PMR1T_Type           PMR1T;       /**< \brief Offset: 0x02C ( /W 32) Peripheral Mux Register 1 - Toggle */
+  __IO GPIO_PMR2_Type            PMR2;        /**< \brief Offset: 0x030 (R/W 32) Peripheral Mux Register 2 */
+  __O  GPIO_PMR2S_Type           PMR2S;       /**< \brief Offset: 0x034 ( /W 32) Peripheral Mux Register 2 - Set */
+  __O  GPIO_PMR2C_Type           PMR2C;       /**< \brief Offset: 0x038 ( /W 32) Peripheral Mux Register 2 - Clear */
+  __O  GPIO_PMR2T_Type           PMR2T;       /**< \brief Offset: 0x03C ( /W 32) Peripheral Mux Register 2 - Toggle */
+  __IO GPIO_ODER_Type            ODER;        /**< \brief Offset: 0x040 (R/W 32) Output Driver Enable Register */
+  __O  GPIO_ODERS_Type           ODERS;       /**< \brief Offset: 0x044 ( /W 32) Output Driver Enable Register - Set */
+  __O  GPIO_ODERC_Type           ODERC;       /**< \brief Offset: 0x048 ( /W 32) Output Driver Enable Register - Clear */
+  __O  GPIO_ODERT_Type           ODERT;       /**< \brief Offset: 0x04C ( /W 32) Output Driver Enable Register - Toggle */
+  __IO GPIO_OVR_Type             OVR;         /**< \brief Offset: 0x050 (R/W 32) Output Value Register */
+  __O  GPIO_OVRS_Type            OVRS;        /**< \brief Offset: 0x054 ( /W 32) Output Value Register - Set */
+  __O  GPIO_OVRC_Type            OVRC;        /**< \brief Offset: 0x058 ( /W 32) Output Value Register - Clear */
+  __O  GPIO_OVRT_Type            OVRT;        /**< \brief Offset: 0x05C ( /W 32) Output Value Register - Toggle */
+  __I  GPIO_PVR_Type             PVR;         /**< \brief Offset: 0x060 (R/  32) Pin Value Register */
+       RoReg8                    Reserved1[0xC];
+  __IO GPIO_PUER_Type            PUER;        /**< \brief Offset: 0x070 (R/W 32) Pull-up Enable Register */
+  __O  GPIO_PUERS_Type           PUERS;       /**< \brief Offset: 0x074 ( /W 32) Pull-up Enable Register - Set */
+  __O  GPIO_PUERC_Type           PUERC;       /**< \brief Offset: 0x078 ( /W 32) Pull-up Enable Register - Clear */
+  __O  GPIO_PUERT_Type           PUERT;       /**< \brief Offset: 0x07C ( /W 32) Pull-up Enable Register - Toggle */
+  __IO GPIO_PDER_Type            PDER;        /**< \brief Offset: 0x080 (R/W 32) Pull-down Enable Register */
+  __O  GPIO_PDERS_Type           PDERS;       /**< \brief Offset: 0x084 ( /W 32) Pull-down Enable Register - Set */
+  __O  GPIO_PDERC_Type           PDERC;       /**< \brief Offset: 0x088 ( /W 32) Pull-down Enable Register - Clear */
+  __O  GPIO_PDERT_Type           PDERT;       /**< \brief Offset: 0x08C ( /W 32) Pull-down Enable Register - Toggle */
+  __IO GPIO_IER_Type             IER;         /**< \brief Offset: 0x090 (R/W 32) Interrupt Enable Register */
+  __O  GPIO_IERS_Type            IERS;        /**< \brief Offset: 0x094 ( /W 32) Interrupt Enable Register - Set */
+  __O  GPIO_IERC_Type            IERC;        /**< \brief Offset: 0x098 ( /W 32) Interrupt Enable Register - Clear */
+  __O  GPIO_IERT_Type            IERT;        /**< \brief Offset: 0x09C ( /W 32) Interrupt Enable Register - Toggle */
+  __IO GPIO_IMR0_Type            IMR0;        /**< \brief Offset: 0x0A0 (R/W 32) Interrupt Mode Register 0 */
+  __O  GPIO_IMR0S_Type           IMR0S;       /**< \brief Offset: 0x0A4 ( /W 32) Interrupt Mode Register 0 - Set */
+  __O  GPIO_IMR0C_Type           IMR0C;       /**< \brief Offset: 0x0A8 ( /W 32) Interrupt Mode Register 0 - Clear */
+  __O  GPIO_IMR0T_Type           IMR0T;       /**< \brief Offset: 0x0AC ( /W 32) Interrupt Mode Register 0 - Toggle */
+  __IO GPIO_IMR1_Type            IMR1;        /**< \brief Offset: 0x0B0 (R/W 32) Interrupt Mode Register 1 */
+  __O  GPIO_IMR1S_Type           IMR1S;       /**< \brief Offset: 0x0B4 ( /W 32) Interrupt Mode Register 1 - Set */
+  __O  GPIO_IMR1C_Type           IMR1C;       /**< \brief Offset: 0x0B8 ( /W 32) Interrupt Mode Register 1 - Clear */
+  __O  GPIO_IMR1T_Type           IMR1T;       /**< \brief Offset: 0x0BC ( /W 32) Interrupt Mode Register 1 - Toggle */
+  __IO GPIO_GFER_Type            GFER;        /**< \brief Offset: 0x0C0 (R/W 32) Glitch Filter Enable Register */
+  __O  GPIO_GFERS_Type           GFERS;       /**< \brief Offset: 0x0C4 ( /W 32) Glitch Filter Enable Register - Set */
+  __O  GPIO_GFERC_Type           GFERC;       /**< \brief Offset: 0x0C8 ( /W 32) Glitch Filter Enable Register - Clear */
+  __O  GPIO_GFERT_Type           GFERT;       /**< \brief Offset: 0x0CC ( /W 32) Glitch Filter Enable Register - Toggle */
+  __I  GPIO_IFR_Type             IFR;         /**< \brief Offset: 0x0D0 (R/  32) Interrupt Flag Register */
+       RoReg8                    Reserved2[0x4];
+  __O  GPIO_IFRC_Type            IFRC;        /**< \brief Offset: 0x0D8 ( /W 32) Interrupt Flag Register - Clear */
+       RoReg8                    Reserved3[0x4];
+  __IO GPIO_ODMER_Type           ODMER;       /**< \brief Offset: 0x0E0 (R/W 32) Open Drain Mode Register */
+  __O  GPIO_ODMERS_Type          ODMERS;      /**< \brief Offset: 0x0E4 ( /W 32) Open Drain Mode Register - Set */
+  __O  GPIO_ODMERC_Type          ODMERC;      /**< \brief Offset: 0x0E8 ( /W 32) Open Drain Mode Register - Clear */
+  __O  GPIO_ODMERT_Type          ODMERT;      /**< \brief Offset: 0x0EC ( /W 32) Open Drain Mode Register - Toggle */
+       RoReg8                    Reserved4[0x10];
+  __IO GPIO_ODCR0_Type           ODCR0;       /**< \brief Offset: 0x100 (R/W 32) Output Driving Capability Register 0 */
+  __IO GPIO_ODCR0S_Type          ODCR0S;      /**< \brief Offset: 0x104 (R/W 32) Output Driving Capability Register 0 - Set */
+  __IO GPIO_ODCR0C_Type          ODCR0C;      /**< \brief Offset: 0x108 (R/W 32) Output Driving Capability Register 0 - Clear */
+  __IO GPIO_ODCR0T_Type          ODCR0T;      /**< \brief Offset: 0x10C (R/W 32) Output Driving Capability Register 0 - Toggle */
+  __IO GPIO_ODCR1_Type           ODCR1;       /**< \brief Offset: 0x110 (R/W 32) Output Driving Capability Register 1 */
+  __IO GPIO_ODCR1S_Type          ODCR1S;      /**< \brief Offset: 0x114 (R/W 32) Output Driving Capability Register 1 - Set */
+  __IO GPIO_ODCR1C_Type          ODCR1C;      /**< \brief Offset: 0x118 (R/W 32) Output Driving Capability Register 1 - Clear */
+  __IO GPIO_ODCR1T_Type          ODCR1T;      /**< \brief Offset: 0x11C (R/W 32) Output Driving Capability Register 1 - Toggle */
+       RoReg8                    Reserved5[0x10];
+  __IO GPIO_OSRR0_Type           OSRR0;       /**< \brief Offset: 0x130 (R/W 32) Output Slew Rate Register 0 */
+  __IO GPIO_OSRR0S_Type          OSRR0S;      /**< \brief Offset: 0x134 (R/W 32) Output Slew Rate Register 0 - Set */
+  __IO GPIO_OSRR0C_Type          OSRR0C;      /**< \brief Offset: 0x138 (R/W 32) Output Slew Rate Register 0 - Clear */
+  __IO GPIO_OSRR0T_Type          OSRR0T;      /**< \brief Offset: 0x13C (R/W 32) Output Slew Rate Register 0 - Toggle */
+       RoReg8                    Reserved6[0x20];
+  __IO GPIO_STER_Type            STER;        /**< \brief Offset: 0x160 (R/W 32) Schmitt Trigger Enable Register */
+  __IO GPIO_STERS_Type           STERS;       /**< \brief Offset: 0x164 (R/W 32) Schmitt Trigger Enable Register - Set */
+  __IO GPIO_STERC_Type           STERC;       /**< \brief Offset: 0x168 (R/W 32) Schmitt Trigger Enable Register - Clear */
+  __IO GPIO_STERT_Type           STERT;       /**< \brief Offset: 0x16C (R/W 32) Schmitt Trigger Enable Register - Toggle */
+       RoReg8                    Reserved7[0x10];
+  __IO GPIO_EVER_Type            EVER;        /**< \brief Offset: 0x180 (R/W 32) Event Enable Register */
+  __O  GPIO_EVERS_Type           EVERS;       /**< \brief Offset: 0x184 ( /W 32) Event Enable Register - Set */
+  __O  GPIO_EVERC_Type           EVERC;       /**< \brief Offset: 0x188 ( /W 32) Event Enable Register - Clear */
+  __O  GPIO_EVERT_Type           EVERT;       /**< \brief Offset: 0x18C ( /W 32) Event Enable Register - Toggle */
+       RoReg8                    Reserved8[0x10];
+  __IO GPIO_LOCK_Type            LOCK;        /**< \brief Offset: 0x1A0 (R/W 32) Lock Register */
+  __O  GPIO_LOCKS_Type           LOCKS;       /**< \brief Offset: 0x1A4 ( /W 32) Lock Register - Set */
+  __O  GPIO_LOCKC_Type           LOCKC;       /**< \brief Offset: 0x1A8 ( /W 32) Lock Register - Clear */
+  __O  GPIO_LOCKT_Type           LOCKT;       /**< \brief Offset: 0x1AC ( /W 32) Lock Register - Toggle */
+       RoReg8                    Reserved9[0x30];
+  __O  GPIO_UNLOCK_Type          UNLOCK;      /**< \brief Offset: 0x1E0 ( /W 32) Unlock Register */
+  __IO GPIO_ASR_Type             ASR;         /**< \brief Offset: 0x1E4 (R/W 32) Access Status Register */
+       RoReg8                    Reserved10[0x10];
+  __I  GPIO_PARAMETER_Type       PARAMETER;   /**< \brief Offset: 0x1F8 (R/  32) Parameter Register */
+  __I  GPIO_VERSION_Type         VERSION;     /**< \brief Offset: 0x1FC (R/  32) Version Register */
+ } bf;
+ struct {
+  RwReg   GPIO_GPER;          /**< \brief (GPIO Offset: 0x000) GPIO Enable Register */
+  WoReg   GPIO_GPERS;         /**< \brief (GPIO Offset: 0x004) GPIO Enable Register - Set */
+  WoReg   GPIO_GPERC;         /**< \brief (GPIO Offset: 0x008) GPIO Enable Register - Clear */
+  WoReg   GPIO_GPERT;         /**< \brief (GPIO Offset: 0x00C) GPIO Enable Register - Toggle */
+  RwReg   GPIO_PMR0;          /**< \brief (GPIO Offset: 0x010) Peripheral Mux Register 0 */
+  WoReg   GPIO_PMR0S;         /**< \brief (GPIO Offset: 0x014) Peripheral Mux Register 0 - Set */
+  WoReg   GPIO_PMR0C;         /**< \brief (GPIO Offset: 0x018) Peripheral Mux Register 0 - Clear */
+  WoReg   GPIO_PMR0T;         /**< \brief (GPIO Offset: 0x01C) Peripheral Mux Register 0 - Toggle */
+  RwReg   GPIO_PMR1;          /**< \brief (GPIO Offset: 0x020) Peripheral Mux Register 1 */
+  WoReg   GPIO_PMR1S;         /**< \brief (GPIO Offset: 0x024) Peripheral Mux Register 1 - Set */
+  WoReg   GPIO_PMR1C;         /**< \brief (GPIO Offset: 0x028) Peripheral Mux Register 1 - Clear */
+  WoReg   GPIO_PMR1T;         /**< \brief (GPIO Offset: 0x02C) Peripheral Mux Register 1 - Toggle */
+  RwReg   GPIO_PMR2;          /**< \brief (GPIO Offset: 0x030) Peripheral Mux Register 2 */
+  WoReg   GPIO_PMR2S;         /**< \brief (GPIO Offset: 0x034) Peripheral Mux Register 2 - Set */
+  WoReg   GPIO_PMR2C;         /**< \brief (GPIO Offset: 0x038) Peripheral Mux Register 2 - Clear */
+  WoReg   GPIO_PMR2T;         /**< \brief (GPIO Offset: 0x03C) Peripheral Mux Register 2 - Toggle */
+  RwReg   GPIO_ODER;          /**< \brief (GPIO Offset: 0x040) Output Driver Enable Register */
+  WoReg   GPIO_ODERS;         /**< \brief (GPIO Offset: 0x044) Output Driver Enable Register - Set */
+  WoReg   GPIO_ODERC;         /**< \brief (GPIO Offset: 0x048) Output Driver Enable Register - Clear */
+  WoReg   GPIO_ODERT;         /**< \brief (GPIO Offset: 0x04C) Output Driver Enable Register - Toggle */
+  RwReg   GPIO_OVR;           /**< \brief (GPIO Offset: 0x050) Output Value Register */
+  WoReg   GPIO_OVRS;          /**< \brief (GPIO Offset: 0x054) Output Value Register - Set */
+  WoReg   GPIO_OVRC;          /**< \brief (GPIO Offset: 0x058) Output Value Register - Clear */
+  WoReg   GPIO_OVRT;          /**< \brief (GPIO Offset: 0x05C) Output Value Register - Toggle */
+  RoReg   GPIO_PVR;           /**< \brief (GPIO Offset: 0x060) Pin Value Register */
+  RoReg8  Reserved11[0xC];
+  RwReg   GPIO_PUER;          /**< \brief (GPIO Offset: 0x070) Pull-up Enable Register */
+  WoReg   GPIO_PUERS;         /**< \brief (GPIO Offset: 0x074) Pull-up Enable Register - Set */
+  WoReg   GPIO_PUERC;         /**< \brief (GPIO Offset: 0x078) Pull-up Enable Register - Clear */
+  WoReg   GPIO_PUERT;         /**< \brief (GPIO Offset: 0x07C) Pull-up Enable Register - Toggle */
+  RwReg   GPIO_PDER;          /**< \brief (GPIO Offset: 0x080) Pull-down Enable Register */
+  WoReg   GPIO_PDERS;         /**< \brief (GPIO Offset: 0x084) Pull-down Enable Register - Set */
+  WoReg   GPIO_PDERC;         /**< \brief (GPIO Offset: 0x088) Pull-down Enable Register - Clear */
+  WoReg   GPIO_PDERT;         /**< \brief (GPIO Offset: 0x08C) Pull-down Enable Register - Toggle */
+  RwReg   GPIO_IER;           /**< \brief (GPIO Offset: 0x090) Interrupt Enable Register */
+  WoReg   GPIO_IERS;          /**< \brief (GPIO Offset: 0x094) Interrupt Enable Register - Set */
+  WoReg   GPIO_IERC;          /**< \brief (GPIO Offset: 0x098) Interrupt Enable Register - Clear */
+  WoReg   GPIO_IERT;          /**< \brief (GPIO Offset: 0x09C) Interrupt Enable Register - Toggle */
+  RwReg   GPIO_IMR0;          /**< \brief (GPIO Offset: 0x0A0) Interrupt Mode Register 0 */
+  WoReg   GPIO_IMR0S;         /**< \brief (GPIO Offset: 0x0A4) Interrupt Mode Register 0 - Set */
+  WoReg   GPIO_IMR0C;         /**< \brief (GPIO Offset: 0x0A8) Interrupt Mode Register 0 - Clear */
+  WoReg   GPIO_IMR0T;         /**< \brief (GPIO Offset: 0x0AC) Interrupt Mode Register 0 - Toggle */
+  RwReg   GPIO_IMR1;          /**< \brief (GPIO Offset: 0x0B0) Interrupt Mode Register 1 */
+  WoReg   GPIO_IMR1S;         /**< \brief (GPIO Offset: 0x0B4) Interrupt Mode Register 1 - Set */
+  WoReg   GPIO_IMR1C;         /**< \brief (GPIO Offset: 0x0B8) Interrupt Mode Register 1 - Clear */
+  WoReg   GPIO_IMR1T;         /**< \brief (GPIO Offset: 0x0BC) Interrupt Mode Register 1 - Toggle */
+  RwReg   GPIO_GFER;          /**< \brief (GPIO Offset: 0x0C0) Glitch Filter Enable Register */
+  WoReg   GPIO_GFERS;         /**< \brief (GPIO Offset: 0x0C4) Glitch Filter Enable Register - Set */
+  WoReg   GPIO_GFERC;         /**< \brief (GPIO Offset: 0x0C8) Glitch Filter Enable Register - Clear */
+  WoReg   GPIO_GFERT;         /**< \brief (GPIO Offset: 0x0CC) Glitch Filter Enable Register - Toggle */
+  RoReg   GPIO_IFR;           /**< \brief (GPIO Offset: 0x0D0) Interrupt Flag Register */
+  RoReg8  Reserved12[0x4];
+  WoReg   GPIO_IFRC;          /**< \brief (GPIO Offset: 0x0D8) Interrupt Flag Register - Clear */
+  RoReg8  Reserved13[0x4];
+  RwReg   GPIO_ODMER;         /**< \brief (GPIO Offset: 0x0E0) Open Drain Mode Register */
+  WoReg   GPIO_ODMERS;        /**< \brief (GPIO Offset: 0x0E4) Open Drain Mode Register - Set */
+  WoReg   GPIO_ODMERC;        /**< \brief (GPIO Offset: 0x0E8) Open Drain Mode Register - Clear */
+  WoReg   GPIO_ODMERT;        /**< \brief (GPIO Offset: 0x0EC) Open Drain Mode Register - Toggle */
+  RoReg8  Reserved14[0x10];
+  RwReg   GPIO_ODCR0;         /**< \brief (GPIO Offset: 0x100) Output Driving Capability Register 0 */
+  RwReg   GPIO_ODCR0S;        /**< \brief (GPIO Offset: 0x104) Output Driving Capability Register 0 - Set */
+  RwReg   GPIO_ODCR0C;        /**< \brief (GPIO Offset: 0x108) Output Driving Capability Register 0 - Clear */
+  RwReg   GPIO_ODCR0T;        /**< \brief (GPIO Offset: 0x10C) Output Driving Capability Register 0 - Toggle */
+  RwReg   GPIO_ODCR1;         /**< \brief (GPIO Offset: 0x110) Output Driving Capability Register 1 */
+  RwReg   GPIO_ODCR1S;        /**< \brief (GPIO Offset: 0x114) Output Driving Capability Register 1 - Set */
+  RwReg   GPIO_ODCR1C;        /**< \brief (GPIO Offset: 0x118) Output Driving Capability Register 1 - Clear */
+  RwReg   GPIO_ODCR1T;        /**< \brief (GPIO Offset: 0x11C) Output Driving Capability Register 1 - Toggle */
+  RoReg8  Reserved15[0x10];
+  RwReg   GPIO_OSRR0;         /**< \brief (GPIO Offset: 0x130) Output Slew Rate Register 0 */
+  RwReg   GPIO_OSRR0S;        /**< \brief (GPIO Offset: 0x134) Output Slew Rate Register 0 - Set */
+  RwReg   GPIO_OSRR0C;        /**< \brief (GPIO Offset: 0x138) Output Slew Rate Register 0 - Clear */
+  RwReg   GPIO_OSRR0T;        /**< \brief (GPIO Offset: 0x13C) Output Slew Rate Register 0 - Toggle */
+  RoReg8  Reserved16[0x20];
+  RwReg   GPIO_STER;          /**< \brief (GPIO Offset: 0x160) Schmitt Trigger Enable Register */
+  RwReg   GPIO_STERS;         /**< \brief (GPIO Offset: 0x164) Schmitt Trigger Enable Register - Set */
+  RwReg   GPIO_STERC;         /**< \brief (GPIO Offset: 0x168) Schmitt Trigger Enable Register - Clear */
+  RwReg   GPIO_STERT;         /**< \brief (GPIO Offset: 0x16C) Schmitt Trigger Enable Register - Toggle */
+  RoReg8  Reserved17[0x10];
+  RwReg   GPIO_EVER;          /**< \brief (GPIO Offset: 0x180) Event Enable Register */
+  WoReg   GPIO_EVERS;         /**< \brief (GPIO Offset: 0x184) Event Enable Register - Set */
+  WoReg   GPIO_EVERC;         /**< \brief (GPIO Offset: 0x188) Event Enable Register - Clear */
+  WoReg   GPIO_EVERT;         /**< \brief (GPIO Offset: 0x18C) Event Enable Register - Toggle */
+  RoReg8  Reserved18[0x10];
+  RwReg   GPIO_LOCK;          /**< \brief (GPIO Offset: 0x1A0) Lock Register */
+  WoReg   GPIO_LOCKS;         /**< \brief (GPIO Offset: 0x1A4) Lock Register - Set */
+  WoReg   GPIO_LOCKC;         /**< \brief (GPIO Offset: 0x1A8) Lock Register - Clear */
+  WoReg   GPIO_LOCKT;         /**< \brief (GPIO Offset: 0x1AC) Lock Register - Toggle */
+  RoReg8  Reserved19[0x30];
+  WoReg   GPIO_UNLOCK;        /**< \brief (GPIO Offset: 0x1E0) Unlock Register */
+  RwReg   GPIO_ASR;           /**< \brief (GPIO Offset: 0x1E4) Access Status Register */
+  RoReg8  Reserved20[0x10];
+  RoReg   GPIO_PARAMETER;     /**< \brief (GPIO Offset: 0x1F8) Parameter Register */
+  RoReg   GPIO_VERSION;       /**< \brief (GPIO Offset: 0x1FC) Version Register */
+ } reg;
+} GpioPort;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief GPIO hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+       GpioPort                  Port[3];     /**< \brief Offset: 0x000 GpioPort groups [PORT_LENGTH] */
+ } bf;
+ struct {
+  GpioPort GPIO_PORT[3];       /**< \brief (GPIO Offset: 0x000) GpioPort groups [PORT_LENGTH] */
+ } reg;
+} Gpio;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_GPIO_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/gpio.h
+++ b/asf/sam/include/sam4l/component/gpio.h
@@ -82,70 +82,70 @@ typedef union {
 #define GPIO_GPER_OFFSET            0x000        /**< \brief (GPIO_GPER offset) GPIO Enable Register */
 
 #define GPIO_GPER_P0_Pos            0            /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P0                (_U(0x1) << GPIO_GPER_P0_Pos)
+#define GPIO_GPER_P0                (_U_(0x1) << GPIO_GPER_P0_Pos)
 #define GPIO_GPER_P1_Pos            1            /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P1                (_U(0x1) << GPIO_GPER_P1_Pos)
+#define GPIO_GPER_P1                (_U_(0x1) << GPIO_GPER_P1_Pos)
 #define GPIO_GPER_P2_Pos            2            /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P2                (_U(0x1) << GPIO_GPER_P2_Pos)
+#define GPIO_GPER_P2                (_U_(0x1) << GPIO_GPER_P2_Pos)
 #define GPIO_GPER_P3_Pos            3            /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P3                (_U(0x1) << GPIO_GPER_P3_Pos)
+#define GPIO_GPER_P3                (_U_(0x1) << GPIO_GPER_P3_Pos)
 #define GPIO_GPER_P4_Pos            4            /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P4                (_U(0x1) << GPIO_GPER_P4_Pos)
+#define GPIO_GPER_P4                (_U_(0x1) << GPIO_GPER_P4_Pos)
 #define GPIO_GPER_P5_Pos            5            /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P5                (_U(0x1) << GPIO_GPER_P5_Pos)
+#define GPIO_GPER_P5                (_U_(0x1) << GPIO_GPER_P5_Pos)
 #define GPIO_GPER_P6_Pos            6            /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P6                (_U(0x1) << GPIO_GPER_P6_Pos)
+#define GPIO_GPER_P6                (_U_(0x1) << GPIO_GPER_P6_Pos)
 #define GPIO_GPER_P7_Pos            7            /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P7                (_U(0x1) << GPIO_GPER_P7_Pos)
+#define GPIO_GPER_P7                (_U_(0x1) << GPIO_GPER_P7_Pos)
 #define GPIO_GPER_P8_Pos            8            /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P8                (_U(0x1) << GPIO_GPER_P8_Pos)
+#define GPIO_GPER_P8                (_U_(0x1) << GPIO_GPER_P8_Pos)
 #define GPIO_GPER_P9_Pos            9            /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P9                (_U(0x1) << GPIO_GPER_P9_Pos)
+#define GPIO_GPER_P9                (_U_(0x1) << GPIO_GPER_P9_Pos)
 #define GPIO_GPER_P10_Pos           10           /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P10               (_U(0x1) << GPIO_GPER_P10_Pos)
+#define GPIO_GPER_P10               (_U_(0x1) << GPIO_GPER_P10_Pos)
 #define GPIO_GPER_P11_Pos           11           /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P11               (_U(0x1) << GPIO_GPER_P11_Pos)
+#define GPIO_GPER_P11               (_U_(0x1) << GPIO_GPER_P11_Pos)
 #define GPIO_GPER_P12_Pos           12           /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P12               (_U(0x1) << GPIO_GPER_P12_Pos)
+#define GPIO_GPER_P12               (_U_(0x1) << GPIO_GPER_P12_Pos)
 #define GPIO_GPER_P13_Pos           13           /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P13               (_U(0x1) << GPIO_GPER_P13_Pos)
+#define GPIO_GPER_P13               (_U_(0x1) << GPIO_GPER_P13_Pos)
 #define GPIO_GPER_P14_Pos           14           /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P14               (_U(0x1) << GPIO_GPER_P14_Pos)
+#define GPIO_GPER_P14               (_U_(0x1) << GPIO_GPER_P14_Pos)
 #define GPIO_GPER_P15_Pos           15           /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P15               (_U(0x1) << GPIO_GPER_P15_Pos)
+#define GPIO_GPER_P15               (_U_(0x1) << GPIO_GPER_P15_Pos)
 #define GPIO_GPER_P16_Pos           16           /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P16               (_U(0x1) << GPIO_GPER_P16_Pos)
+#define GPIO_GPER_P16               (_U_(0x1) << GPIO_GPER_P16_Pos)
 #define GPIO_GPER_P17_Pos           17           /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P17               (_U(0x1) << GPIO_GPER_P17_Pos)
+#define GPIO_GPER_P17               (_U_(0x1) << GPIO_GPER_P17_Pos)
 #define GPIO_GPER_P18_Pos           18           /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P18               (_U(0x1) << GPIO_GPER_P18_Pos)
+#define GPIO_GPER_P18               (_U_(0x1) << GPIO_GPER_P18_Pos)
 #define GPIO_GPER_P19_Pos           19           /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P19               (_U(0x1) << GPIO_GPER_P19_Pos)
+#define GPIO_GPER_P19               (_U_(0x1) << GPIO_GPER_P19_Pos)
 #define GPIO_GPER_P20_Pos           20           /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P20               (_U(0x1) << GPIO_GPER_P20_Pos)
+#define GPIO_GPER_P20               (_U_(0x1) << GPIO_GPER_P20_Pos)
 #define GPIO_GPER_P21_Pos           21           /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P21               (_U(0x1) << GPIO_GPER_P21_Pos)
+#define GPIO_GPER_P21               (_U_(0x1) << GPIO_GPER_P21_Pos)
 #define GPIO_GPER_P22_Pos           22           /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P22               (_U(0x1) << GPIO_GPER_P22_Pos)
+#define GPIO_GPER_P22               (_U_(0x1) << GPIO_GPER_P22_Pos)
 #define GPIO_GPER_P23_Pos           23           /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P23               (_U(0x1) << GPIO_GPER_P23_Pos)
+#define GPIO_GPER_P23               (_U_(0x1) << GPIO_GPER_P23_Pos)
 #define GPIO_GPER_P24_Pos           24           /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P24               (_U(0x1) << GPIO_GPER_P24_Pos)
+#define GPIO_GPER_P24               (_U_(0x1) << GPIO_GPER_P24_Pos)
 #define GPIO_GPER_P25_Pos           25           /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P25               (_U(0x1) << GPIO_GPER_P25_Pos)
+#define GPIO_GPER_P25               (_U_(0x1) << GPIO_GPER_P25_Pos)
 #define GPIO_GPER_P26_Pos           26           /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P26               (_U(0x1) << GPIO_GPER_P26_Pos)
+#define GPIO_GPER_P26               (_U_(0x1) << GPIO_GPER_P26_Pos)
 #define GPIO_GPER_P27_Pos           27           /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P27               (_U(0x1) << GPIO_GPER_P27_Pos)
+#define GPIO_GPER_P27               (_U_(0x1) << GPIO_GPER_P27_Pos)
 #define GPIO_GPER_P28_Pos           28           /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P28               (_U(0x1) << GPIO_GPER_P28_Pos)
+#define GPIO_GPER_P28               (_U_(0x1) << GPIO_GPER_P28_Pos)
 #define GPIO_GPER_P29_Pos           29           /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P29               (_U(0x1) << GPIO_GPER_P29_Pos)
+#define GPIO_GPER_P29               (_U_(0x1) << GPIO_GPER_P29_Pos)
 #define GPIO_GPER_P30_Pos           30           /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P30               (_U(0x1) << GPIO_GPER_P30_Pos)
+#define GPIO_GPER_P30               (_U_(0x1) << GPIO_GPER_P30_Pos)
 #define GPIO_GPER_P31_Pos           31           /**< \brief (GPIO_GPER) GPIO Enable */
-#define GPIO_GPER_P31               (_U(0x1) << GPIO_GPER_P31_Pos)
-#define GPIO_GPER_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_GPER) MASK Register */
+#define GPIO_GPER_P31               (_U_(0x1) << GPIO_GPER_P31_Pos)
+#define GPIO_GPER_MASK              _U_(0xFFFFFFFF) /**< \brief (GPIO_GPER) MASK Register */
 
 /* -------- GPIO_GPERS : (GPIO Offset: 0x004) ( /W 32) port GPIO Enable Register - Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -191,70 +191,70 @@ typedef union {
 #define GPIO_GPERS_OFFSET           0x004        /**< \brief (GPIO_GPERS offset) GPIO Enable Register - Set */
 
 #define GPIO_GPERS_P0_Pos           0            /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P0               (_U(0x1) << GPIO_GPERS_P0_Pos)
+#define GPIO_GPERS_P0               (_U_(0x1) << GPIO_GPERS_P0_Pos)
 #define GPIO_GPERS_P1_Pos           1            /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P1               (_U(0x1) << GPIO_GPERS_P1_Pos)
+#define GPIO_GPERS_P1               (_U_(0x1) << GPIO_GPERS_P1_Pos)
 #define GPIO_GPERS_P2_Pos           2            /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P2               (_U(0x1) << GPIO_GPERS_P2_Pos)
+#define GPIO_GPERS_P2               (_U_(0x1) << GPIO_GPERS_P2_Pos)
 #define GPIO_GPERS_P3_Pos           3            /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P3               (_U(0x1) << GPIO_GPERS_P3_Pos)
+#define GPIO_GPERS_P3               (_U_(0x1) << GPIO_GPERS_P3_Pos)
 #define GPIO_GPERS_P4_Pos           4            /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P4               (_U(0x1) << GPIO_GPERS_P4_Pos)
+#define GPIO_GPERS_P4               (_U_(0x1) << GPIO_GPERS_P4_Pos)
 #define GPIO_GPERS_P5_Pos           5            /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P5               (_U(0x1) << GPIO_GPERS_P5_Pos)
+#define GPIO_GPERS_P5               (_U_(0x1) << GPIO_GPERS_P5_Pos)
 #define GPIO_GPERS_P6_Pos           6            /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P6               (_U(0x1) << GPIO_GPERS_P6_Pos)
+#define GPIO_GPERS_P6               (_U_(0x1) << GPIO_GPERS_P6_Pos)
 #define GPIO_GPERS_P7_Pos           7            /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P7               (_U(0x1) << GPIO_GPERS_P7_Pos)
+#define GPIO_GPERS_P7               (_U_(0x1) << GPIO_GPERS_P7_Pos)
 #define GPIO_GPERS_P8_Pos           8            /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P8               (_U(0x1) << GPIO_GPERS_P8_Pos)
+#define GPIO_GPERS_P8               (_U_(0x1) << GPIO_GPERS_P8_Pos)
 #define GPIO_GPERS_P9_Pos           9            /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P9               (_U(0x1) << GPIO_GPERS_P9_Pos)
+#define GPIO_GPERS_P9               (_U_(0x1) << GPIO_GPERS_P9_Pos)
 #define GPIO_GPERS_P10_Pos          10           /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P10              (_U(0x1) << GPIO_GPERS_P10_Pos)
+#define GPIO_GPERS_P10              (_U_(0x1) << GPIO_GPERS_P10_Pos)
 #define GPIO_GPERS_P11_Pos          11           /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P11              (_U(0x1) << GPIO_GPERS_P11_Pos)
+#define GPIO_GPERS_P11              (_U_(0x1) << GPIO_GPERS_P11_Pos)
 #define GPIO_GPERS_P12_Pos          12           /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P12              (_U(0x1) << GPIO_GPERS_P12_Pos)
+#define GPIO_GPERS_P12              (_U_(0x1) << GPIO_GPERS_P12_Pos)
 #define GPIO_GPERS_P13_Pos          13           /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P13              (_U(0x1) << GPIO_GPERS_P13_Pos)
+#define GPIO_GPERS_P13              (_U_(0x1) << GPIO_GPERS_P13_Pos)
 #define GPIO_GPERS_P14_Pos          14           /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P14              (_U(0x1) << GPIO_GPERS_P14_Pos)
+#define GPIO_GPERS_P14              (_U_(0x1) << GPIO_GPERS_P14_Pos)
 #define GPIO_GPERS_P15_Pos          15           /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P15              (_U(0x1) << GPIO_GPERS_P15_Pos)
+#define GPIO_GPERS_P15              (_U_(0x1) << GPIO_GPERS_P15_Pos)
 #define GPIO_GPERS_P16_Pos          16           /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P16              (_U(0x1) << GPIO_GPERS_P16_Pos)
+#define GPIO_GPERS_P16              (_U_(0x1) << GPIO_GPERS_P16_Pos)
 #define GPIO_GPERS_P17_Pos          17           /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P17              (_U(0x1) << GPIO_GPERS_P17_Pos)
+#define GPIO_GPERS_P17              (_U_(0x1) << GPIO_GPERS_P17_Pos)
 #define GPIO_GPERS_P18_Pos          18           /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P18              (_U(0x1) << GPIO_GPERS_P18_Pos)
+#define GPIO_GPERS_P18              (_U_(0x1) << GPIO_GPERS_P18_Pos)
 #define GPIO_GPERS_P19_Pos          19           /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P19              (_U(0x1) << GPIO_GPERS_P19_Pos)
+#define GPIO_GPERS_P19              (_U_(0x1) << GPIO_GPERS_P19_Pos)
 #define GPIO_GPERS_P20_Pos          20           /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P20              (_U(0x1) << GPIO_GPERS_P20_Pos)
+#define GPIO_GPERS_P20              (_U_(0x1) << GPIO_GPERS_P20_Pos)
 #define GPIO_GPERS_P21_Pos          21           /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P21              (_U(0x1) << GPIO_GPERS_P21_Pos)
+#define GPIO_GPERS_P21              (_U_(0x1) << GPIO_GPERS_P21_Pos)
 #define GPIO_GPERS_P22_Pos          22           /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P22              (_U(0x1) << GPIO_GPERS_P22_Pos)
+#define GPIO_GPERS_P22              (_U_(0x1) << GPIO_GPERS_P22_Pos)
 #define GPIO_GPERS_P23_Pos          23           /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P23              (_U(0x1) << GPIO_GPERS_P23_Pos)
+#define GPIO_GPERS_P23              (_U_(0x1) << GPIO_GPERS_P23_Pos)
 #define GPIO_GPERS_P24_Pos          24           /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P24              (_U(0x1) << GPIO_GPERS_P24_Pos)
+#define GPIO_GPERS_P24              (_U_(0x1) << GPIO_GPERS_P24_Pos)
 #define GPIO_GPERS_P25_Pos          25           /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P25              (_U(0x1) << GPIO_GPERS_P25_Pos)
+#define GPIO_GPERS_P25              (_U_(0x1) << GPIO_GPERS_P25_Pos)
 #define GPIO_GPERS_P26_Pos          26           /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P26              (_U(0x1) << GPIO_GPERS_P26_Pos)
+#define GPIO_GPERS_P26              (_U_(0x1) << GPIO_GPERS_P26_Pos)
 #define GPIO_GPERS_P27_Pos          27           /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P27              (_U(0x1) << GPIO_GPERS_P27_Pos)
+#define GPIO_GPERS_P27              (_U_(0x1) << GPIO_GPERS_P27_Pos)
 #define GPIO_GPERS_P28_Pos          28           /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P28              (_U(0x1) << GPIO_GPERS_P28_Pos)
+#define GPIO_GPERS_P28              (_U_(0x1) << GPIO_GPERS_P28_Pos)
 #define GPIO_GPERS_P29_Pos          29           /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P29              (_U(0x1) << GPIO_GPERS_P29_Pos)
+#define GPIO_GPERS_P29              (_U_(0x1) << GPIO_GPERS_P29_Pos)
 #define GPIO_GPERS_P30_Pos          30           /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P30              (_U(0x1) << GPIO_GPERS_P30_Pos)
+#define GPIO_GPERS_P30              (_U_(0x1) << GPIO_GPERS_P30_Pos)
 #define GPIO_GPERS_P31_Pos          31           /**< \brief (GPIO_GPERS) GPIO Enable */
-#define GPIO_GPERS_P31              (_U(0x1) << GPIO_GPERS_P31_Pos)
-#define GPIO_GPERS_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_GPERS) MASK Register */
+#define GPIO_GPERS_P31              (_U_(0x1) << GPIO_GPERS_P31_Pos)
+#define GPIO_GPERS_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_GPERS) MASK Register */
 
 /* -------- GPIO_GPERC : (GPIO Offset: 0x008) ( /W 32) port GPIO Enable Register - Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -300,70 +300,70 @@ typedef union {
 #define GPIO_GPERC_OFFSET           0x008        /**< \brief (GPIO_GPERC offset) GPIO Enable Register - Clear */
 
 #define GPIO_GPERC_P0_Pos           0            /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P0               (_U(0x1) << GPIO_GPERC_P0_Pos)
+#define GPIO_GPERC_P0               (_U_(0x1) << GPIO_GPERC_P0_Pos)
 #define GPIO_GPERC_P1_Pos           1            /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P1               (_U(0x1) << GPIO_GPERC_P1_Pos)
+#define GPIO_GPERC_P1               (_U_(0x1) << GPIO_GPERC_P1_Pos)
 #define GPIO_GPERC_P2_Pos           2            /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P2               (_U(0x1) << GPIO_GPERC_P2_Pos)
+#define GPIO_GPERC_P2               (_U_(0x1) << GPIO_GPERC_P2_Pos)
 #define GPIO_GPERC_P3_Pos           3            /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P3               (_U(0x1) << GPIO_GPERC_P3_Pos)
+#define GPIO_GPERC_P3               (_U_(0x1) << GPIO_GPERC_P3_Pos)
 #define GPIO_GPERC_P4_Pos           4            /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P4               (_U(0x1) << GPIO_GPERC_P4_Pos)
+#define GPIO_GPERC_P4               (_U_(0x1) << GPIO_GPERC_P4_Pos)
 #define GPIO_GPERC_P5_Pos           5            /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P5               (_U(0x1) << GPIO_GPERC_P5_Pos)
+#define GPIO_GPERC_P5               (_U_(0x1) << GPIO_GPERC_P5_Pos)
 #define GPIO_GPERC_P6_Pos           6            /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P6               (_U(0x1) << GPIO_GPERC_P6_Pos)
+#define GPIO_GPERC_P6               (_U_(0x1) << GPIO_GPERC_P6_Pos)
 #define GPIO_GPERC_P7_Pos           7            /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P7               (_U(0x1) << GPIO_GPERC_P7_Pos)
+#define GPIO_GPERC_P7               (_U_(0x1) << GPIO_GPERC_P7_Pos)
 #define GPIO_GPERC_P8_Pos           8            /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P8               (_U(0x1) << GPIO_GPERC_P8_Pos)
+#define GPIO_GPERC_P8               (_U_(0x1) << GPIO_GPERC_P8_Pos)
 #define GPIO_GPERC_P9_Pos           9            /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P9               (_U(0x1) << GPIO_GPERC_P9_Pos)
+#define GPIO_GPERC_P9               (_U_(0x1) << GPIO_GPERC_P9_Pos)
 #define GPIO_GPERC_P10_Pos          10           /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P10              (_U(0x1) << GPIO_GPERC_P10_Pos)
+#define GPIO_GPERC_P10              (_U_(0x1) << GPIO_GPERC_P10_Pos)
 #define GPIO_GPERC_P11_Pos          11           /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P11              (_U(0x1) << GPIO_GPERC_P11_Pos)
+#define GPIO_GPERC_P11              (_U_(0x1) << GPIO_GPERC_P11_Pos)
 #define GPIO_GPERC_P12_Pos          12           /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P12              (_U(0x1) << GPIO_GPERC_P12_Pos)
+#define GPIO_GPERC_P12              (_U_(0x1) << GPIO_GPERC_P12_Pos)
 #define GPIO_GPERC_P13_Pos          13           /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P13              (_U(0x1) << GPIO_GPERC_P13_Pos)
+#define GPIO_GPERC_P13              (_U_(0x1) << GPIO_GPERC_P13_Pos)
 #define GPIO_GPERC_P14_Pos          14           /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P14              (_U(0x1) << GPIO_GPERC_P14_Pos)
+#define GPIO_GPERC_P14              (_U_(0x1) << GPIO_GPERC_P14_Pos)
 #define GPIO_GPERC_P15_Pos          15           /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P15              (_U(0x1) << GPIO_GPERC_P15_Pos)
+#define GPIO_GPERC_P15              (_U_(0x1) << GPIO_GPERC_P15_Pos)
 #define GPIO_GPERC_P16_Pos          16           /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P16              (_U(0x1) << GPIO_GPERC_P16_Pos)
+#define GPIO_GPERC_P16              (_U_(0x1) << GPIO_GPERC_P16_Pos)
 #define GPIO_GPERC_P17_Pos          17           /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P17              (_U(0x1) << GPIO_GPERC_P17_Pos)
+#define GPIO_GPERC_P17              (_U_(0x1) << GPIO_GPERC_P17_Pos)
 #define GPIO_GPERC_P18_Pos          18           /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P18              (_U(0x1) << GPIO_GPERC_P18_Pos)
+#define GPIO_GPERC_P18              (_U_(0x1) << GPIO_GPERC_P18_Pos)
 #define GPIO_GPERC_P19_Pos          19           /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P19              (_U(0x1) << GPIO_GPERC_P19_Pos)
+#define GPIO_GPERC_P19              (_U_(0x1) << GPIO_GPERC_P19_Pos)
 #define GPIO_GPERC_P20_Pos          20           /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P20              (_U(0x1) << GPIO_GPERC_P20_Pos)
+#define GPIO_GPERC_P20              (_U_(0x1) << GPIO_GPERC_P20_Pos)
 #define GPIO_GPERC_P21_Pos          21           /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P21              (_U(0x1) << GPIO_GPERC_P21_Pos)
+#define GPIO_GPERC_P21              (_U_(0x1) << GPIO_GPERC_P21_Pos)
 #define GPIO_GPERC_P22_Pos          22           /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P22              (_U(0x1) << GPIO_GPERC_P22_Pos)
+#define GPIO_GPERC_P22              (_U_(0x1) << GPIO_GPERC_P22_Pos)
 #define GPIO_GPERC_P23_Pos          23           /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P23              (_U(0x1) << GPIO_GPERC_P23_Pos)
+#define GPIO_GPERC_P23              (_U_(0x1) << GPIO_GPERC_P23_Pos)
 #define GPIO_GPERC_P24_Pos          24           /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P24              (_U(0x1) << GPIO_GPERC_P24_Pos)
+#define GPIO_GPERC_P24              (_U_(0x1) << GPIO_GPERC_P24_Pos)
 #define GPIO_GPERC_P25_Pos          25           /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P25              (_U(0x1) << GPIO_GPERC_P25_Pos)
+#define GPIO_GPERC_P25              (_U_(0x1) << GPIO_GPERC_P25_Pos)
 #define GPIO_GPERC_P26_Pos          26           /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P26              (_U(0x1) << GPIO_GPERC_P26_Pos)
+#define GPIO_GPERC_P26              (_U_(0x1) << GPIO_GPERC_P26_Pos)
 #define GPIO_GPERC_P27_Pos          27           /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P27              (_U(0x1) << GPIO_GPERC_P27_Pos)
+#define GPIO_GPERC_P27              (_U_(0x1) << GPIO_GPERC_P27_Pos)
 #define GPIO_GPERC_P28_Pos          28           /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P28              (_U(0x1) << GPIO_GPERC_P28_Pos)
+#define GPIO_GPERC_P28              (_U_(0x1) << GPIO_GPERC_P28_Pos)
 #define GPIO_GPERC_P29_Pos          29           /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P29              (_U(0x1) << GPIO_GPERC_P29_Pos)
+#define GPIO_GPERC_P29              (_U_(0x1) << GPIO_GPERC_P29_Pos)
 #define GPIO_GPERC_P30_Pos          30           /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P30              (_U(0x1) << GPIO_GPERC_P30_Pos)
+#define GPIO_GPERC_P30              (_U_(0x1) << GPIO_GPERC_P30_Pos)
 #define GPIO_GPERC_P31_Pos          31           /**< \brief (GPIO_GPERC) GPIO Enable */
-#define GPIO_GPERC_P31              (_U(0x1) << GPIO_GPERC_P31_Pos)
-#define GPIO_GPERC_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_GPERC) MASK Register */
+#define GPIO_GPERC_P31              (_U_(0x1) << GPIO_GPERC_P31_Pos)
+#define GPIO_GPERC_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_GPERC) MASK Register */
 
 /* -------- GPIO_GPERT : (GPIO Offset: 0x00C) ( /W 32) port GPIO Enable Register - Toggle -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -409,70 +409,70 @@ typedef union {
 #define GPIO_GPERT_OFFSET           0x00C        /**< \brief (GPIO_GPERT offset) GPIO Enable Register - Toggle */
 
 #define GPIO_GPERT_P0_Pos           0            /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P0               (_U(0x1) << GPIO_GPERT_P0_Pos)
+#define GPIO_GPERT_P0               (_U_(0x1) << GPIO_GPERT_P0_Pos)
 #define GPIO_GPERT_P1_Pos           1            /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P1               (_U(0x1) << GPIO_GPERT_P1_Pos)
+#define GPIO_GPERT_P1               (_U_(0x1) << GPIO_GPERT_P1_Pos)
 #define GPIO_GPERT_P2_Pos           2            /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P2               (_U(0x1) << GPIO_GPERT_P2_Pos)
+#define GPIO_GPERT_P2               (_U_(0x1) << GPIO_GPERT_P2_Pos)
 #define GPIO_GPERT_P3_Pos           3            /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P3               (_U(0x1) << GPIO_GPERT_P3_Pos)
+#define GPIO_GPERT_P3               (_U_(0x1) << GPIO_GPERT_P3_Pos)
 #define GPIO_GPERT_P4_Pos           4            /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P4               (_U(0x1) << GPIO_GPERT_P4_Pos)
+#define GPIO_GPERT_P4               (_U_(0x1) << GPIO_GPERT_P4_Pos)
 #define GPIO_GPERT_P5_Pos           5            /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P5               (_U(0x1) << GPIO_GPERT_P5_Pos)
+#define GPIO_GPERT_P5               (_U_(0x1) << GPIO_GPERT_P5_Pos)
 #define GPIO_GPERT_P6_Pos           6            /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P6               (_U(0x1) << GPIO_GPERT_P6_Pos)
+#define GPIO_GPERT_P6               (_U_(0x1) << GPIO_GPERT_P6_Pos)
 #define GPIO_GPERT_P7_Pos           7            /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P7               (_U(0x1) << GPIO_GPERT_P7_Pos)
+#define GPIO_GPERT_P7               (_U_(0x1) << GPIO_GPERT_P7_Pos)
 #define GPIO_GPERT_P8_Pos           8            /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P8               (_U(0x1) << GPIO_GPERT_P8_Pos)
+#define GPIO_GPERT_P8               (_U_(0x1) << GPIO_GPERT_P8_Pos)
 #define GPIO_GPERT_P9_Pos           9            /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P9               (_U(0x1) << GPIO_GPERT_P9_Pos)
+#define GPIO_GPERT_P9               (_U_(0x1) << GPIO_GPERT_P9_Pos)
 #define GPIO_GPERT_P10_Pos          10           /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P10              (_U(0x1) << GPIO_GPERT_P10_Pos)
+#define GPIO_GPERT_P10              (_U_(0x1) << GPIO_GPERT_P10_Pos)
 #define GPIO_GPERT_P11_Pos          11           /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P11              (_U(0x1) << GPIO_GPERT_P11_Pos)
+#define GPIO_GPERT_P11              (_U_(0x1) << GPIO_GPERT_P11_Pos)
 #define GPIO_GPERT_P12_Pos          12           /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P12              (_U(0x1) << GPIO_GPERT_P12_Pos)
+#define GPIO_GPERT_P12              (_U_(0x1) << GPIO_GPERT_P12_Pos)
 #define GPIO_GPERT_P13_Pos          13           /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P13              (_U(0x1) << GPIO_GPERT_P13_Pos)
+#define GPIO_GPERT_P13              (_U_(0x1) << GPIO_GPERT_P13_Pos)
 #define GPIO_GPERT_P14_Pos          14           /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P14              (_U(0x1) << GPIO_GPERT_P14_Pos)
+#define GPIO_GPERT_P14              (_U_(0x1) << GPIO_GPERT_P14_Pos)
 #define GPIO_GPERT_P15_Pos          15           /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P15              (_U(0x1) << GPIO_GPERT_P15_Pos)
+#define GPIO_GPERT_P15              (_U_(0x1) << GPIO_GPERT_P15_Pos)
 #define GPIO_GPERT_P16_Pos          16           /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P16              (_U(0x1) << GPIO_GPERT_P16_Pos)
+#define GPIO_GPERT_P16              (_U_(0x1) << GPIO_GPERT_P16_Pos)
 #define GPIO_GPERT_P17_Pos          17           /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P17              (_U(0x1) << GPIO_GPERT_P17_Pos)
+#define GPIO_GPERT_P17              (_U_(0x1) << GPIO_GPERT_P17_Pos)
 #define GPIO_GPERT_P18_Pos          18           /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P18              (_U(0x1) << GPIO_GPERT_P18_Pos)
+#define GPIO_GPERT_P18              (_U_(0x1) << GPIO_GPERT_P18_Pos)
 #define GPIO_GPERT_P19_Pos          19           /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P19              (_U(0x1) << GPIO_GPERT_P19_Pos)
+#define GPIO_GPERT_P19              (_U_(0x1) << GPIO_GPERT_P19_Pos)
 #define GPIO_GPERT_P20_Pos          20           /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P20              (_U(0x1) << GPIO_GPERT_P20_Pos)
+#define GPIO_GPERT_P20              (_U_(0x1) << GPIO_GPERT_P20_Pos)
 #define GPIO_GPERT_P21_Pos          21           /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P21              (_U(0x1) << GPIO_GPERT_P21_Pos)
+#define GPIO_GPERT_P21              (_U_(0x1) << GPIO_GPERT_P21_Pos)
 #define GPIO_GPERT_P22_Pos          22           /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P22              (_U(0x1) << GPIO_GPERT_P22_Pos)
+#define GPIO_GPERT_P22              (_U_(0x1) << GPIO_GPERT_P22_Pos)
 #define GPIO_GPERT_P23_Pos          23           /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P23              (_U(0x1) << GPIO_GPERT_P23_Pos)
+#define GPIO_GPERT_P23              (_U_(0x1) << GPIO_GPERT_P23_Pos)
 #define GPIO_GPERT_P24_Pos          24           /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P24              (_U(0x1) << GPIO_GPERT_P24_Pos)
+#define GPIO_GPERT_P24              (_U_(0x1) << GPIO_GPERT_P24_Pos)
 #define GPIO_GPERT_P25_Pos          25           /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P25              (_U(0x1) << GPIO_GPERT_P25_Pos)
+#define GPIO_GPERT_P25              (_U_(0x1) << GPIO_GPERT_P25_Pos)
 #define GPIO_GPERT_P26_Pos          26           /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P26              (_U(0x1) << GPIO_GPERT_P26_Pos)
+#define GPIO_GPERT_P26              (_U_(0x1) << GPIO_GPERT_P26_Pos)
 #define GPIO_GPERT_P27_Pos          27           /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P27              (_U(0x1) << GPIO_GPERT_P27_Pos)
+#define GPIO_GPERT_P27              (_U_(0x1) << GPIO_GPERT_P27_Pos)
 #define GPIO_GPERT_P28_Pos          28           /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P28              (_U(0x1) << GPIO_GPERT_P28_Pos)
+#define GPIO_GPERT_P28              (_U_(0x1) << GPIO_GPERT_P28_Pos)
 #define GPIO_GPERT_P29_Pos          29           /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P29              (_U(0x1) << GPIO_GPERT_P29_Pos)
+#define GPIO_GPERT_P29              (_U_(0x1) << GPIO_GPERT_P29_Pos)
 #define GPIO_GPERT_P30_Pos          30           /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P30              (_U(0x1) << GPIO_GPERT_P30_Pos)
+#define GPIO_GPERT_P30              (_U_(0x1) << GPIO_GPERT_P30_Pos)
 #define GPIO_GPERT_P31_Pos          31           /**< \brief (GPIO_GPERT) GPIO Enable */
-#define GPIO_GPERT_P31              (_U(0x1) << GPIO_GPERT_P31_Pos)
-#define GPIO_GPERT_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_GPERT) MASK Register */
+#define GPIO_GPERT_P31              (_U_(0x1) << GPIO_GPERT_P31_Pos)
+#define GPIO_GPERT_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_GPERT) MASK Register */
 
 /* -------- GPIO_PMR0 : (GPIO Offset: 0x010) (R/W 32) port Peripheral Mux Register 0 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -518,70 +518,70 @@ typedef union {
 #define GPIO_PMR0_OFFSET            0x010        /**< \brief (GPIO_PMR0 offset) Peripheral Mux Register 0 */
 
 #define GPIO_PMR0_P0_Pos            0            /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P0                (_U(0x1) << GPIO_PMR0_P0_Pos)
+#define GPIO_PMR0_P0                (_U_(0x1) << GPIO_PMR0_P0_Pos)
 #define GPIO_PMR0_P1_Pos            1            /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P1                (_U(0x1) << GPIO_PMR0_P1_Pos)
+#define GPIO_PMR0_P1                (_U_(0x1) << GPIO_PMR0_P1_Pos)
 #define GPIO_PMR0_P2_Pos            2            /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P2                (_U(0x1) << GPIO_PMR0_P2_Pos)
+#define GPIO_PMR0_P2                (_U_(0x1) << GPIO_PMR0_P2_Pos)
 #define GPIO_PMR0_P3_Pos            3            /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P3                (_U(0x1) << GPIO_PMR0_P3_Pos)
+#define GPIO_PMR0_P3                (_U_(0x1) << GPIO_PMR0_P3_Pos)
 #define GPIO_PMR0_P4_Pos            4            /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P4                (_U(0x1) << GPIO_PMR0_P4_Pos)
+#define GPIO_PMR0_P4                (_U_(0x1) << GPIO_PMR0_P4_Pos)
 #define GPIO_PMR0_P5_Pos            5            /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P5                (_U(0x1) << GPIO_PMR0_P5_Pos)
+#define GPIO_PMR0_P5                (_U_(0x1) << GPIO_PMR0_P5_Pos)
 #define GPIO_PMR0_P6_Pos            6            /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P6                (_U(0x1) << GPIO_PMR0_P6_Pos)
+#define GPIO_PMR0_P6                (_U_(0x1) << GPIO_PMR0_P6_Pos)
 #define GPIO_PMR0_P7_Pos            7            /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P7                (_U(0x1) << GPIO_PMR0_P7_Pos)
+#define GPIO_PMR0_P7                (_U_(0x1) << GPIO_PMR0_P7_Pos)
 #define GPIO_PMR0_P8_Pos            8            /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P8                (_U(0x1) << GPIO_PMR0_P8_Pos)
+#define GPIO_PMR0_P8                (_U_(0x1) << GPIO_PMR0_P8_Pos)
 #define GPIO_PMR0_P9_Pos            9            /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P9                (_U(0x1) << GPIO_PMR0_P9_Pos)
+#define GPIO_PMR0_P9                (_U_(0x1) << GPIO_PMR0_P9_Pos)
 #define GPIO_PMR0_P10_Pos           10           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P10               (_U(0x1) << GPIO_PMR0_P10_Pos)
+#define GPIO_PMR0_P10               (_U_(0x1) << GPIO_PMR0_P10_Pos)
 #define GPIO_PMR0_P11_Pos           11           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P11               (_U(0x1) << GPIO_PMR0_P11_Pos)
+#define GPIO_PMR0_P11               (_U_(0x1) << GPIO_PMR0_P11_Pos)
 #define GPIO_PMR0_P12_Pos           12           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P12               (_U(0x1) << GPIO_PMR0_P12_Pos)
+#define GPIO_PMR0_P12               (_U_(0x1) << GPIO_PMR0_P12_Pos)
 #define GPIO_PMR0_P13_Pos           13           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P13               (_U(0x1) << GPIO_PMR0_P13_Pos)
+#define GPIO_PMR0_P13               (_U_(0x1) << GPIO_PMR0_P13_Pos)
 #define GPIO_PMR0_P14_Pos           14           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P14               (_U(0x1) << GPIO_PMR0_P14_Pos)
+#define GPIO_PMR0_P14               (_U_(0x1) << GPIO_PMR0_P14_Pos)
 #define GPIO_PMR0_P15_Pos           15           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P15               (_U(0x1) << GPIO_PMR0_P15_Pos)
+#define GPIO_PMR0_P15               (_U_(0x1) << GPIO_PMR0_P15_Pos)
 #define GPIO_PMR0_P16_Pos           16           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P16               (_U(0x1) << GPIO_PMR0_P16_Pos)
+#define GPIO_PMR0_P16               (_U_(0x1) << GPIO_PMR0_P16_Pos)
 #define GPIO_PMR0_P17_Pos           17           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P17               (_U(0x1) << GPIO_PMR0_P17_Pos)
+#define GPIO_PMR0_P17               (_U_(0x1) << GPIO_PMR0_P17_Pos)
 #define GPIO_PMR0_P18_Pos           18           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P18               (_U(0x1) << GPIO_PMR0_P18_Pos)
+#define GPIO_PMR0_P18               (_U_(0x1) << GPIO_PMR0_P18_Pos)
 #define GPIO_PMR0_P19_Pos           19           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P19               (_U(0x1) << GPIO_PMR0_P19_Pos)
+#define GPIO_PMR0_P19               (_U_(0x1) << GPIO_PMR0_P19_Pos)
 #define GPIO_PMR0_P20_Pos           20           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P20               (_U(0x1) << GPIO_PMR0_P20_Pos)
+#define GPIO_PMR0_P20               (_U_(0x1) << GPIO_PMR0_P20_Pos)
 #define GPIO_PMR0_P21_Pos           21           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P21               (_U(0x1) << GPIO_PMR0_P21_Pos)
+#define GPIO_PMR0_P21               (_U_(0x1) << GPIO_PMR0_P21_Pos)
 #define GPIO_PMR0_P22_Pos           22           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P22               (_U(0x1) << GPIO_PMR0_P22_Pos)
+#define GPIO_PMR0_P22               (_U_(0x1) << GPIO_PMR0_P22_Pos)
 #define GPIO_PMR0_P23_Pos           23           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P23               (_U(0x1) << GPIO_PMR0_P23_Pos)
+#define GPIO_PMR0_P23               (_U_(0x1) << GPIO_PMR0_P23_Pos)
 #define GPIO_PMR0_P24_Pos           24           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P24               (_U(0x1) << GPIO_PMR0_P24_Pos)
+#define GPIO_PMR0_P24               (_U_(0x1) << GPIO_PMR0_P24_Pos)
 #define GPIO_PMR0_P25_Pos           25           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P25               (_U(0x1) << GPIO_PMR0_P25_Pos)
+#define GPIO_PMR0_P25               (_U_(0x1) << GPIO_PMR0_P25_Pos)
 #define GPIO_PMR0_P26_Pos           26           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P26               (_U(0x1) << GPIO_PMR0_P26_Pos)
+#define GPIO_PMR0_P26               (_U_(0x1) << GPIO_PMR0_P26_Pos)
 #define GPIO_PMR0_P27_Pos           27           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P27               (_U(0x1) << GPIO_PMR0_P27_Pos)
+#define GPIO_PMR0_P27               (_U_(0x1) << GPIO_PMR0_P27_Pos)
 #define GPIO_PMR0_P28_Pos           28           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P28               (_U(0x1) << GPIO_PMR0_P28_Pos)
+#define GPIO_PMR0_P28               (_U_(0x1) << GPIO_PMR0_P28_Pos)
 #define GPIO_PMR0_P29_Pos           29           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P29               (_U(0x1) << GPIO_PMR0_P29_Pos)
+#define GPIO_PMR0_P29               (_U_(0x1) << GPIO_PMR0_P29_Pos)
 #define GPIO_PMR0_P30_Pos           30           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P30               (_U(0x1) << GPIO_PMR0_P30_Pos)
+#define GPIO_PMR0_P30               (_U_(0x1) << GPIO_PMR0_P30_Pos)
 #define GPIO_PMR0_P31_Pos           31           /**< \brief (GPIO_PMR0) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0_P31               (_U(0x1) << GPIO_PMR0_P31_Pos)
-#define GPIO_PMR0_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_PMR0) MASK Register */
+#define GPIO_PMR0_P31               (_U_(0x1) << GPIO_PMR0_P31_Pos)
+#define GPIO_PMR0_MASK              _U_(0xFFFFFFFF) /**< \brief (GPIO_PMR0) MASK Register */
 
 /* -------- GPIO_PMR0S : (GPIO Offset: 0x014) ( /W 32) port Peripheral Mux Register 0 - Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -627,70 +627,70 @@ typedef union {
 #define GPIO_PMR0S_OFFSET           0x014        /**< \brief (GPIO_PMR0S offset) Peripheral Mux Register 0 - Set */
 
 #define GPIO_PMR0S_P0_Pos           0            /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P0               (_U(0x1) << GPIO_PMR0S_P0_Pos)
+#define GPIO_PMR0S_P0               (_U_(0x1) << GPIO_PMR0S_P0_Pos)
 #define GPIO_PMR0S_P1_Pos           1            /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P1               (_U(0x1) << GPIO_PMR0S_P1_Pos)
+#define GPIO_PMR0S_P1               (_U_(0x1) << GPIO_PMR0S_P1_Pos)
 #define GPIO_PMR0S_P2_Pos           2            /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P2               (_U(0x1) << GPIO_PMR0S_P2_Pos)
+#define GPIO_PMR0S_P2               (_U_(0x1) << GPIO_PMR0S_P2_Pos)
 #define GPIO_PMR0S_P3_Pos           3            /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P3               (_U(0x1) << GPIO_PMR0S_P3_Pos)
+#define GPIO_PMR0S_P3               (_U_(0x1) << GPIO_PMR0S_P3_Pos)
 #define GPIO_PMR0S_P4_Pos           4            /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P4               (_U(0x1) << GPIO_PMR0S_P4_Pos)
+#define GPIO_PMR0S_P4               (_U_(0x1) << GPIO_PMR0S_P4_Pos)
 #define GPIO_PMR0S_P5_Pos           5            /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P5               (_U(0x1) << GPIO_PMR0S_P5_Pos)
+#define GPIO_PMR0S_P5               (_U_(0x1) << GPIO_PMR0S_P5_Pos)
 #define GPIO_PMR0S_P6_Pos           6            /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P6               (_U(0x1) << GPIO_PMR0S_P6_Pos)
+#define GPIO_PMR0S_P6               (_U_(0x1) << GPIO_PMR0S_P6_Pos)
 #define GPIO_PMR0S_P7_Pos           7            /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P7               (_U(0x1) << GPIO_PMR0S_P7_Pos)
+#define GPIO_PMR0S_P7               (_U_(0x1) << GPIO_PMR0S_P7_Pos)
 #define GPIO_PMR0S_P8_Pos           8            /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P8               (_U(0x1) << GPIO_PMR0S_P8_Pos)
+#define GPIO_PMR0S_P8               (_U_(0x1) << GPIO_PMR0S_P8_Pos)
 #define GPIO_PMR0S_P9_Pos           9            /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P9               (_U(0x1) << GPIO_PMR0S_P9_Pos)
+#define GPIO_PMR0S_P9               (_U_(0x1) << GPIO_PMR0S_P9_Pos)
 #define GPIO_PMR0S_P10_Pos          10           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P10              (_U(0x1) << GPIO_PMR0S_P10_Pos)
+#define GPIO_PMR0S_P10              (_U_(0x1) << GPIO_PMR0S_P10_Pos)
 #define GPIO_PMR0S_P11_Pos          11           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P11              (_U(0x1) << GPIO_PMR0S_P11_Pos)
+#define GPIO_PMR0S_P11              (_U_(0x1) << GPIO_PMR0S_P11_Pos)
 #define GPIO_PMR0S_P12_Pos          12           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P12              (_U(0x1) << GPIO_PMR0S_P12_Pos)
+#define GPIO_PMR0S_P12              (_U_(0x1) << GPIO_PMR0S_P12_Pos)
 #define GPIO_PMR0S_P13_Pos          13           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P13              (_U(0x1) << GPIO_PMR0S_P13_Pos)
+#define GPIO_PMR0S_P13              (_U_(0x1) << GPIO_PMR0S_P13_Pos)
 #define GPIO_PMR0S_P14_Pos          14           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P14              (_U(0x1) << GPIO_PMR0S_P14_Pos)
+#define GPIO_PMR0S_P14              (_U_(0x1) << GPIO_PMR0S_P14_Pos)
 #define GPIO_PMR0S_P15_Pos          15           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P15              (_U(0x1) << GPIO_PMR0S_P15_Pos)
+#define GPIO_PMR0S_P15              (_U_(0x1) << GPIO_PMR0S_P15_Pos)
 #define GPIO_PMR0S_P16_Pos          16           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P16              (_U(0x1) << GPIO_PMR0S_P16_Pos)
+#define GPIO_PMR0S_P16              (_U_(0x1) << GPIO_PMR0S_P16_Pos)
 #define GPIO_PMR0S_P17_Pos          17           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P17              (_U(0x1) << GPIO_PMR0S_P17_Pos)
+#define GPIO_PMR0S_P17              (_U_(0x1) << GPIO_PMR0S_P17_Pos)
 #define GPIO_PMR0S_P18_Pos          18           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P18              (_U(0x1) << GPIO_PMR0S_P18_Pos)
+#define GPIO_PMR0S_P18              (_U_(0x1) << GPIO_PMR0S_P18_Pos)
 #define GPIO_PMR0S_P19_Pos          19           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P19              (_U(0x1) << GPIO_PMR0S_P19_Pos)
+#define GPIO_PMR0S_P19              (_U_(0x1) << GPIO_PMR0S_P19_Pos)
 #define GPIO_PMR0S_P20_Pos          20           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P20              (_U(0x1) << GPIO_PMR0S_P20_Pos)
+#define GPIO_PMR0S_P20              (_U_(0x1) << GPIO_PMR0S_P20_Pos)
 #define GPIO_PMR0S_P21_Pos          21           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P21              (_U(0x1) << GPIO_PMR0S_P21_Pos)
+#define GPIO_PMR0S_P21              (_U_(0x1) << GPIO_PMR0S_P21_Pos)
 #define GPIO_PMR0S_P22_Pos          22           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P22              (_U(0x1) << GPIO_PMR0S_P22_Pos)
+#define GPIO_PMR0S_P22              (_U_(0x1) << GPIO_PMR0S_P22_Pos)
 #define GPIO_PMR0S_P23_Pos          23           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P23              (_U(0x1) << GPIO_PMR0S_P23_Pos)
+#define GPIO_PMR0S_P23              (_U_(0x1) << GPIO_PMR0S_P23_Pos)
 #define GPIO_PMR0S_P24_Pos          24           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P24              (_U(0x1) << GPIO_PMR0S_P24_Pos)
+#define GPIO_PMR0S_P24              (_U_(0x1) << GPIO_PMR0S_P24_Pos)
 #define GPIO_PMR0S_P25_Pos          25           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P25              (_U(0x1) << GPIO_PMR0S_P25_Pos)
+#define GPIO_PMR0S_P25              (_U_(0x1) << GPIO_PMR0S_P25_Pos)
 #define GPIO_PMR0S_P26_Pos          26           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P26              (_U(0x1) << GPIO_PMR0S_P26_Pos)
+#define GPIO_PMR0S_P26              (_U_(0x1) << GPIO_PMR0S_P26_Pos)
 #define GPIO_PMR0S_P27_Pos          27           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P27              (_U(0x1) << GPIO_PMR0S_P27_Pos)
+#define GPIO_PMR0S_P27              (_U_(0x1) << GPIO_PMR0S_P27_Pos)
 #define GPIO_PMR0S_P28_Pos          28           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P28              (_U(0x1) << GPIO_PMR0S_P28_Pos)
+#define GPIO_PMR0S_P28              (_U_(0x1) << GPIO_PMR0S_P28_Pos)
 #define GPIO_PMR0S_P29_Pos          29           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P29              (_U(0x1) << GPIO_PMR0S_P29_Pos)
+#define GPIO_PMR0S_P29              (_U_(0x1) << GPIO_PMR0S_P29_Pos)
 #define GPIO_PMR0S_P30_Pos          30           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P30              (_U(0x1) << GPIO_PMR0S_P30_Pos)
+#define GPIO_PMR0S_P30              (_U_(0x1) << GPIO_PMR0S_P30_Pos)
 #define GPIO_PMR0S_P31_Pos          31           /**< \brief (GPIO_PMR0S) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0S_P31              (_U(0x1) << GPIO_PMR0S_P31_Pos)
-#define GPIO_PMR0S_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PMR0S) MASK Register */
+#define GPIO_PMR0S_P31              (_U_(0x1) << GPIO_PMR0S_P31_Pos)
+#define GPIO_PMR0S_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_PMR0S) MASK Register */
 
 /* -------- GPIO_PMR0C : (GPIO Offset: 0x018) ( /W 32) port Peripheral Mux Register 0 - Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -736,70 +736,70 @@ typedef union {
 #define GPIO_PMR0C_OFFSET           0x018        /**< \brief (GPIO_PMR0C offset) Peripheral Mux Register 0 - Clear */
 
 #define GPIO_PMR0C_P0_Pos           0            /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P0               (_U(0x1) << GPIO_PMR0C_P0_Pos)
+#define GPIO_PMR0C_P0               (_U_(0x1) << GPIO_PMR0C_P0_Pos)
 #define GPIO_PMR0C_P1_Pos           1            /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P1               (_U(0x1) << GPIO_PMR0C_P1_Pos)
+#define GPIO_PMR0C_P1               (_U_(0x1) << GPIO_PMR0C_P1_Pos)
 #define GPIO_PMR0C_P2_Pos           2            /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P2               (_U(0x1) << GPIO_PMR0C_P2_Pos)
+#define GPIO_PMR0C_P2               (_U_(0x1) << GPIO_PMR0C_P2_Pos)
 #define GPIO_PMR0C_P3_Pos           3            /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P3               (_U(0x1) << GPIO_PMR0C_P3_Pos)
+#define GPIO_PMR0C_P3               (_U_(0x1) << GPIO_PMR0C_P3_Pos)
 #define GPIO_PMR0C_P4_Pos           4            /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P4               (_U(0x1) << GPIO_PMR0C_P4_Pos)
+#define GPIO_PMR0C_P4               (_U_(0x1) << GPIO_PMR0C_P4_Pos)
 #define GPIO_PMR0C_P5_Pos           5            /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P5               (_U(0x1) << GPIO_PMR0C_P5_Pos)
+#define GPIO_PMR0C_P5               (_U_(0x1) << GPIO_PMR0C_P5_Pos)
 #define GPIO_PMR0C_P6_Pos           6            /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P6               (_U(0x1) << GPIO_PMR0C_P6_Pos)
+#define GPIO_PMR0C_P6               (_U_(0x1) << GPIO_PMR0C_P6_Pos)
 #define GPIO_PMR0C_P7_Pos           7            /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P7               (_U(0x1) << GPIO_PMR0C_P7_Pos)
+#define GPIO_PMR0C_P7               (_U_(0x1) << GPIO_PMR0C_P7_Pos)
 #define GPIO_PMR0C_P8_Pos           8            /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P8               (_U(0x1) << GPIO_PMR0C_P8_Pos)
+#define GPIO_PMR0C_P8               (_U_(0x1) << GPIO_PMR0C_P8_Pos)
 #define GPIO_PMR0C_P9_Pos           9            /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P9               (_U(0x1) << GPIO_PMR0C_P9_Pos)
+#define GPIO_PMR0C_P9               (_U_(0x1) << GPIO_PMR0C_P9_Pos)
 #define GPIO_PMR0C_P10_Pos          10           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P10              (_U(0x1) << GPIO_PMR0C_P10_Pos)
+#define GPIO_PMR0C_P10              (_U_(0x1) << GPIO_PMR0C_P10_Pos)
 #define GPIO_PMR0C_P11_Pos          11           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P11              (_U(0x1) << GPIO_PMR0C_P11_Pos)
+#define GPIO_PMR0C_P11              (_U_(0x1) << GPIO_PMR0C_P11_Pos)
 #define GPIO_PMR0C_P12_Pos          12           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P12              (_U(0x1) << GPIO_PMR0C_P12_Pos)
+#define GPIO_PMR0C_P12              (_U_(0x1) << GPIO_PMR0C_P12_Pos)
 #define GPIO_PMR0C_P13_Pos          13           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P13              (_U(0x1) << GPIO_PMR0C_P13_Pos)
+#define GPIO_PMR0C_P13              (_U_(0x1) << GPIO_PMR0C_P13_Pos)
 #define GPIO_PMR0C_P14_Pos          14           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P14              (_U(0x1) << GPIO_PMR0C_P14_Pos)
+#define GPIO_PMR0C_P14              (_U_(0x1) << GPIO_PMR0C_P14_Pos)
 #define GPIO_PMR0C_P15_Pos          15           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P15              (_U(0x1) << GPIO_PMR0C_P15_Pos)
+#define GPIO_PMR0C_P15              (_U_(0x1) << GPIO_PMR0C_P15_Pos)
 #define GPIO_PMR0C_P16_Pos          16           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P16              (_U(0x1) << GPIO_PMR0C_P16_Pos)
+#define GPIO_PMR0C_P16              (_U_(0x1) << GPIO_PMR0C_P16_Pos)
 #define GPIO_PMR0C_P17_Pos          17           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P17              (_U(0x1) << GPIO_PMR0C_P17_Pos)
+#define GPIO_PMR0C_P17              (_U_(0x1) << GPIO_PMR0C_P17_Pos)
 #define GPIO_PMR0C_P18_Pos          18           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P18              (_U(0x1) << GPIO_PMR0C_P18_Pos)
+#define GPIO_PMR0C_P18              (_U_(0x1) << GPIO_PMR0C_P18_Pos)
 #define GPIO_PMR0C_P19_Pos          19           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P19              (_U(0x1) << GPIO_PMR0C_P19_Pos)
+#define GPIO_PMR0C_P19              (_U_(0x1) << GPIO_PMR0C_P19_Pos)
 #define GPIO_PMR0C_P20_Pos          20           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P20              (_U(0x1) << GPIO_PMR0C_P20_Pos)
+#define GPIO_PMR0C_P20              (_U_(0x1) << GPIO_PMR0C_P20_Pos)
 #define GPIO_PMR0C_P21_Pos          21           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P21              (_U(0x1) << GPIO_PMR0C_P21_Pos)
+#define GPIO_PMR0C_P21              (_U_(0x1) << GPIO_PMR0C_P21_Pos)
 #define GPIO_PMR0C_P22_Pos          22           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P22              (_U(0x1) << GPIO_PMR0C_P22_Pos)
+#define GPIO_PMR0C_P22              (_U_(0x1) << GPIO_PMR0C_P22_Pos)
 #define GPIO_PMR0C_P23_Pos          23           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P23              (_U(0x1) << GPIO_PMR0C_P23_Pos)
+#define GPIO_PMR0C_P23              (_U_(0x1) << GPIO_PMR0C_P23_Pos)
 #define GPIO_PMR0C_P24_Pos          24           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P24              (_U(0x1) << GPIO_PMR0C_P24_Pos)
+#define GPIO_PMR0C_P24              (_U_(0x1) << GPIO_PMR0C_P24_Pos)
 #define GPIO_PMR0C_P25_Pos          25           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P25              (_U(0x1) << GPIO_PMR0C_P25_Pos)
+#define GPIO_PMR0C_P25              (_U_(0x1) << GPIO_PMR0C_P25_Pos)
 #define GPIO_PMR0C_P26_Pos          26           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P26              (_U(0x1) << GPIO_PMR0C_P26_Pos)
+#define GPIO_PMR0C_P26              (_U_(0x1) << GPIO_PMR0C_P26_Pos)
 #define GPIO_PMR0C_P27_Pos          27           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P27              (_U(0x1) << GPIO_PMR0C_P27_Pos)
+#define GPIO_PMR0C_P27              (_U_(0x1) << GPIO_PMR0C_P27_Pos)
 #define GPIO_PMR0C_P28_Pos          28           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P28              (_U(0x1) << GPIO_PMR0C_P28_Pos)
+#define GPIO_PMR0C_P28              (_U_(0x1) << GPIO_PMR0C_P28_Pos)
 #define GPIO_PMR0C_P29_Pos          29           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P29              (_U(0x1) << GPIO_PMR0C_P29_Pos)
+#define GPIO_PMR0C_P29              (_U_(0x1) << GPIO_PMR0C_P29_Pos)
 #define GPIO_PMR0C_P30_Pos          30           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P30              (_U(0x1) << GPIO_PMR0C_P30_Pos)
+#define GPIO_PMR0C_P30              (_U_(0x1) << GPIO_PMR0C_P30_Pos)
 #define GPIO_PMR0C_P31_Pos          31           /**< \brief (GPIO_PMR0C) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0C_P31              (_U(0x1) << GPIO_PMR0C_P31_Pos)
-#define GPIO_PMR0C_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PMR0C) MASK Register */
+#define GPIO_PMR0C_P31              (_U_(0x1) << GPIO_PMR0C_P31_Pos)
+#define GPIO_PMR0C_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_PMR0C) MASK Register */
 
 /* -------- GPIO_PMR0T : (GPIO Offset: 0x01C) ( /W 32) port Peripheral Mux Register 0 - Toggle -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -845,70 +845,70 @@ typedef union {
 #define GPIO_PMR0T_OFFSET           0x01C        /**< \brief (GPIO_PMR0T offset) Peripheral Mux Register 0 - Toggle */
 
 #define GPIO_PMR0T_P0_Pos           0            /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P0               (_U(0x1) << GPIO_PMR0T_P0_Pos)
+#define GPIO_PMR0T_P0               (_U_(0x1) << GPIO_PMR0T_P0_Pos)
 #define GPIO_PMR0T_P1_Pos           1            /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P1               (_U(0x1) << GPIO_PMR0T_P1_Pos)
+#define GPIO_PMR0T_P1               (_U_(0x1) << GPIO_PMR0T_P1_Pos)
 #define GPIO_PMR0T_P2_Pos           2            /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P2               (_U(0x1) << GPIO_PMR0T_P2_Pos)
+#define GPIO_PMR0T_P2               (_U_(0x1) << GPIO_PMR0T_P2_Pos)
 #define GPIO_PMR0T_P3_Pos           3            /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P3               (_U(0x1) << GPIO_PMR0T_P3_Pos)
+#define GPIO_PMR0T_P3               (_U_(0x1) << GPIO_PMR0T_P3_Pos)
 #define GPIO_PMR0T_P4_Pos           4            /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P4               (_U(0x1) << GPIO_PMR0T_P4_Pos)
+#define GPIO_PMR0T_P4               (_U_(0x1) << GPIO_PMR0T_P4_Pos)
 #define GPIO_PMR0T_P5_Pos           5            /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P5               (_U(0x1) << GPIO_PMR0T_P5_Pos)
+#define GPIO_PMR0T_P5               (_U_(0x1) << GPIO_PMR0T_P5_Pos)
 #define GPIO_PMR0T_P6_Pos           6            /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P6               (_U(0x1) << GPIO_PMR0T_P6_Pos)
+#define GPIO_PMR0T_P6               (_U_(0x1) << GPIO_PMR0T_P6_Pos)
 #define GPIO_PMR0T_P7_Pos           7            /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P7               (_U(0x1) << GPIO_PMR0T_P7_Pos)
+#define GPIO_PMR0T_P7               (_U_(0x1) << GPIO_PMR0T_P7_Pos)
 #define GPIO_PMR0T_P8_Pos           8            /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P8               (_U(0x1) << GPIO_PMR0T_P8_Pos)
+#define GPIO_PMR0T_P8               (_U_(0x1) << GPIO_PMR0T_P8_Pos)
 #define GPIO_PMR0T_P9_Pos           9            /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P9               (_U(0x1) << GPIO_PMR0T_P9_Pos)
+#define GPIO_PMR0T_P9               (_U_(0x1) << GPIO_PMR0T_P9_Pos)
 #define GPIO_PMR0T_P10_Pos          10           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P10              (_U(0x1) << GPIO_PMR0T_P10_Pos)
+#define GPIO_PMR0T_P10              (_U_(0x1) << GPIO_PMR0T_P10_Pos)
 #define GPIO_PMR0T_P11_Pos          11           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P11              (_U(0x1) << GPIO_PMR0T_P11_Pos)
+#define GPIO_PMR0T_P11              (_U_(0x1) << GPIO_PMR0T_P11_Pos)
 #define GPIO_PMR0T_P12_Pos          12           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P12              (_U(0x1) << GPIO_PMR0T_P12_Pos)
+#define GPIO_PMR0T_P12              (_U_(0x1) << GPIO_PMR0T_P12_Pos)
 #define GPIO_PMR0T_P13_Pos          13           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P13              (_U(0x1) << GPIO_PMR0T_P13_Pos)
+#define GPIO_PMR0T_P13              (_U_(0x1) << GPIO_PMR0T_P13_Pos)
 #define GPIO_PMR0T_P14_Pos          14           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P14              (_U(0x1) << GPIO_PMR0T_P14_Pos)
+#define GPIO_PMR0T_P14              (_U_(0x1) << GPIO_PMR0T_P14_Pos)
 #define GPIO_PMR0T_P15_Pos          15           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P15              (_U(0x1) << GPIO_PMR0T_P15_Pos)
+#define GPIO_PMR0T_P15              (_U_(0x1) << GPIO_PMR0T_P15_Pos)
 #define GPIO_PMR0T_P16_Pos          16           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P16              (_U(0x1) << GPIO_PMR0T_P16_Pos)
+#define GPIO_PMR0T_P16              (_U_(0x1) << GPIO_PMR0T_P16_Pos)
 #define GPIO_PMR0T_P17_Pos          17           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P17              (_U(0x1) << GPIO_PMR0T_P17_Pos)
+#define GPIO_PMR0T_P17              (_U_(0x1) << GPIO_PMR0T_P17_Pos)
 #define GPIO_PMR0T_P18_Pos          18           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P18              (_U(0x1) << GPIO_PMR0T_P18_Pos)
+#define GPIO_PMR0T_P18              (_U_(0x1) << GPIO_PMR0T_P18_Pos)
 #define GPIO_PMR0T_P19_Pos          19           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P19              (_U(0x1) << GPIO_PMR0T_P19_Pos)
+#define GPIO_PMR0T_P19              (_U_(0x1) << GPIO_PMR0T_P19_Pos)
 #define GPIO_PMR0T_P20_Pos          20           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P20              (_U(0x1) << GPIO_PMR0T_P20_Pos)
+#define GPIO_PMR0T_P20              (_U_(0x1) << GPIO_PMR0T_P20_Pos)
 #define GPIO_PMR0T_P21_Pos          21           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P21              (_U(0x1) << GPIO_PMR0T_P21_Pos)
+#define GPIO_PMR0T_P21              (_U_(0x1) << GPIO_PMR0T_P21_Pos)
 #define GPIO_PMR0T_P22_Pos          22           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P22              (_U(0x1) << GPIO_PMR0T_P22_Pos)
+#define GPIO_PMR0T_P22              (_U_(0x1) << GPIO_PMR0T_P22_Pos)
 #define GPIO_PMR0T_P23_Pos          23           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P23              (_U(0x1) << GPIO_PMR0T_P23_Pos)
+#define GPIO_PMR0T_P23              (_U_(0x1) << GPIO_PMR0T_P23_Pos)
 #define GPIO_PMR0T_P24_Pos          24           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P24              (_U(0x1) << GPIO_PMR0T_P24_Pos)
+#define GPIO_PMR0T_P24              (_U_(0x1) << GPIO_PMR0T_P24_Pos)
 #define GPIO_PMR0T_P25_Pos          25           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P25              (_U(0x1) << GPIO_PMR0T_P25_Pos)
+#define GPIO_PMR0T_P25              (_U_(0x1) << GPIO_PMR0T_P25_Pos)
 #define GPIO_PMR0T_P26_Pos          26           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P26              (_U(0x1) << GPIO_PMR0T_P26_Pos)
+#define GPIO_PMR0T_P26              (_U_(0x1) << GPIO_PMR0T_P26_Pos)
 #define GPIO_PMR0T_P27_Pos          27           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P27              (_U(0x1) << GPIO_PMR0T_P27_Pos)
+#define GPIO_PMR0T_P27              (_U_(0x1) << GPIO_PMR0T_P27_Pos)
 #define GPIO_PMR0T_P28_Pos          28           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P28              (_U(0x1) << GPIO_PMR0T_P28_Pos)
+#define GPIO_PMR0T_P28              (_U_(0x1) << GPIO_PMR0T_P28_Pos)
 #define GPIO_PMR0T_P29_Pos          29           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P29              (_U(0x1) << GPIO_PMR0T_P29_Pos)
+#define GPIO_PMR0T_P29              (_U_(0x1) << GPIO_PMR0T_P29_Pos)
 #define GPIO_PMR0T_P30_Pos          30           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P30              (_U(0x1) << GPIO_PMR0T_P30_Pos)
+#define GPIO_PMR0T_P30              (_U_(0x1) << GPIO_PMR0T_P30_Pos)
 #define GPIO_PMR0T_P31_Pos          31           /**< \brief (GPIO_PMR0T) Peripheral Multiplexer Select bit 0 */
-#define GPIO_PMR0T_P31              (_U(0x1) << GPIO_PMR0T_P31_Pos)
-#define GPIO_PMR0T_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PMR0T) MASK Register */
+#define GPIO_PMR0T_P31              (_U_(0x1) << GPIO_PMR0T_P31_Pos)
+#define GPIO_PMR0T_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_PMR0T) MASK Register */
 
 /* -------- GPIO_PMR1 : (GPIO Offset: 0x020) (R/W 32) port Peripheral Mux Register 1 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -954,70 +954,70 @@ typedef union {
 #define GPIO_PMR1_OFFSET            0x020        /**< \brief (GPIO_PMR1 offset) Peripheral Mux Register 1 */
 
 #define GPIO_PMR1_P0_Pos            0            /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P0                (_U(0x1) << GPIO_PMR1_P0_Pos)
+#define GPIO_PMR1_P0                (_U_(0x1) << GPIO_PMR1_P0_Pos)
 #define GPIO_PMR1_P1_Pos            1            /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P1                (_U(0x1) << GPIO_PMR1_P1_Pos)
+#define GPIO_PMR1_P1                (_U_(0x1) << GPIO_PMR1_P1_Pos)
 #define GPIO_PMR1_P2_Pos            2            /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P2                (_U(0x1) << GPIO_PMR1_P2_Pos)
+#define GPIO_PMR1_P2                (_U_(0x1) << GPIO_PMR1_P2_Pos)
 #define GPIO_PMR1_P3_Pos            3            /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P3                (_U(0x1) << GPIO_PMR1_P3_Pos)
+#define GPIO_PMR1_P3                (_U_(0x1) << GPIO_PMR1_P3_Pos)
 #define GPIO_PMR1_P4_Pos            4            /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P4                (_U(0x1) << GPIO_PMR1_P4_Pos)
+#define GPIO_PMR1_P4                (_U_(0x1) << GPIO_PMR1_P4_Pos)
 #define GPIO_PMR1_P5_Pos            5            /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P5                (_U(0x1) << GPIO_PMR1_P5_Pos)
+#define GPIO_PMR1_P5                (_U_(0x1) << GPIO_PMR1_P5_Pos)
 #define GPIO_PMR1_P6_Pos            6            /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P6                (_U(0x1) << GPIO_PMR1_P6_Pos)
+#define GPIO_PMR1_P6                (_U_(0x1) << GPIO_PMR1_P6_Pos)
 #define GPIO_PMR1_P7_Pos            7            /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P7                (_U(0x1) << GPIO_PMR1_P7_Pos)
+#define GPIO_PMR1_P7                (_U_(0x1) << GPIO_PMR1_P7_Pos)
 #define GPIO_PMR1_P8_Pos            8            /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P8                (_U(0x1) << GPIO_PMR1_P8_Pos)
+#define GPIO_PMR1_P8                (_U_(0x1) << GPIO_PMR1_P8_Pos)
 #define GPIO_PMR1_P9_Pos            9            /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P9                (_U(0x1) << GPIO_PMR1_P9_Pos)
+#define GPIO_PMR1_P9                (_U_(0x1) << GPIO_PMR1_P9_Pos)
 #define GPIO_PMR1_P10_Pos           10           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P10               (_U(0x1) << GPIO_PMR1_P10_Pos)
+#define GPIO_PMR1_P10               (_U_(0x1) << GPIO_PMR1_P10_Pos)
 #define GPIO_PMR1_P11_Pos           11           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P11               (_U(0x1) << GPIO_PMR1_P11_Pos)
+#define GPIO_PMR1_P11               (_U_(0x1) << GPIO_PMR1_P11_Pos)
 #define GPIO_PMR1_P12_Pos           12           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P12               (_U(0x1) << GPIO_PMR1_P12_Pos)
+#define GPIO_PMR1_P12               (_U_(0x1) << GPIO_PMR1_P12_Pos)
 #define GPIO_PMR1_P13_Pos           13           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P13               (_U(0x1) << GPIO_PMR1_P13_Pos)
+#define GPIO_PMR1_P13               (_U_(0x1) << GPIO_PMR1_P13_Pos)
 #define GPIO_PMR1_P14_Pos           14           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P14               (_U(0x1) << GPIO_PMR1_P14_Pos)
+#define GPIO_PMR1_P14               (_U_(0x1) << GPIO_PMR1_P14_Pos)
 #define GPIO_PMR1_P15_Pos           15           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P15               (_U(0x1) << GPIO_PMR1_P15_Pos)
+#define GPIO_PMR1_P15               (_U_(0x1) << GPIO_PMR1_P15_Pos)
 #define GPIO_PMR1_P16_Pos           16           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P16               (_U(0x1) << GPIO_PMR1_P16_Pos)
+#define GPIO_PMR1_P16               (_U_(0x1) << GPIO_PMR1_P16_Pos)
 #define GPIO_PMR1_P17_Pos           17           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P17               (_U(0x1) << GPIO_PMR1_P17_Pos)
+#define GPIO_PMR1_P17               (_U_(0x1) << GPIO_PMR1_P17_Pos)
 #define GPIO_PMR1_P18_Pos           18           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P18               (_U(0x1) << GPIO_PMR1_P18_Pos)
+#define GPIO_PMR1_P18               (_U_(0x1) << GPIO_PMR1_P18_Pos)
 #define GPIO_PMR1_P19_Pos           19           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P19               (_U(0x1) << GPIO_PMR1_P19_Pos)
+#define GPIO_PMR1_P19               (_U_(0x1) << GPIO_PMR1_P19_Pos)
 #define GPIO_PMR1_P20_Pos           20           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P20               (_U(0x1) << GPIO_PMR1_P20_Pos)
+#define GPIO_PMR1_P20               (_U_(0x1) << GPIO_PMR1_P20_Pos)
 #define GPIO_PMR1_P21_Pos           21           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P21               (_U(0x1) << GPIO_PMR1_P21_Pos)
+#define GPIO_PMR1_P21               (_U_(0x1) << GPIO_PMR1_P21_Pos)
 #define GPIO_PMR1_P22_Pos           22           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P22               (_U(0x1) << GPIO_PMR1_P22_Pos)
+#define GPIO_PMR1_P22               (_U_(0x1) << GPIO_PMR1_P22_Pos)
 #define GPIO_PMR1_P23_Pos           23           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P23               (_U(0x1) << GPIO_PMR1_P23_Pos)
+#define GPIO_PMR1_P23               (_U_(0x1) << GPIO_PMR1_P23_Pos)
 #define GPIO_PMR1_P24_Pos           24           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P24               (_U(0x1) << GPIO_PMR1_P24_Pos)
+#define GPIO_PMR1_P24               (_U_(0x1) << GPIO_PMR1_P24_Pos)
 #define GPIO_PMR1_P25_Pos           25           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P25               (_U(0x1) << GPIO_PMR1_P25_Pos)
+#define GPIO_PMR1_P25               (_U_(0x1) << GPIO_PMR1_P25_Pos)
 #define GPIO_PMR1_P26_Pos           26           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P26               (_U(0x1) << GPIO_PMR1_P26_Pos)
+#define GPIO_PMR1_P26               (_U_(0x1) << GPIO_PMR1_P26_Pos)
 #define GPIO_PMR1_P27_Pos           27           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P27               (_U(0x1) << GPIO_PMR1_P27_Pos)
+#define GPIO_PMR1_P27               (_U_(0x1) << GPIO_PMR1_P27_Pos)
 #define GPIO_PMR1_P28_Pos           28           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P28               (_U(0x1) << GPIO_PMR1_P28_Pos)
+#define GPIO_PMR1_P28               (_U_(0x1) << GPIO_PMR1_P28_Pos)
 #define GPIO_PMR1_P29_Pos           29           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P29               (_U(0x1) << GPIO_PMR1_P29_Pos)
+#define GPIO_PMR1_P29               (_U_(0x1) << GPIO_PMR1_P29_Pos)
 #define GPIO_PMR1_P30_Pos           30           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P30               (_U(0x1) << GPIO_PMR1_P30_Pos)
+#define GPIO_PMR1_P30               (_U_(0x1) << GPIO_PMR1_P30_Pos)
 #define GPIO_PMR1_P31_Pos           31           /**< \brief (GPIO_PMR1) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1_P31               (_U(0x1) << GPIO_PMR1_P31_Pos)
-#define GPIO_PMR1_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_PMR1) MASK Register */
+#define GPIO_PMR1_P31               (_U_(0x1) << GPIO_PMR1_P31_Pos)
+#define GPIO_PMR1_MASK              _U_(0xFFFFFFFF) /**< \brief (GPIO_PMR1) MASK Register */
 
 /* -------- GPIO_PMR1S : (GPIO Offset: 0x024) ( /W 32) port Peripheral Mux Register 1 - Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1063,70 +1063,70 @@ typedef union {
 #define GPIO_PMR1S_OFFSET           0x024        /**< \brief (GPIO_PMR1S offset) Peripheral Mux Register 1 - Set */
 
 #define GPIO_PMR1S_P0_Pos           0            /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P0               (_U(0x1) << GPIO_PMR1S_P0_Pos)
+#define GPIO_PMR1S_P0               (_U_(0x1) << GPIO_PMR1S_P0_Pos)
 #define GPIO_PMR1S_P1_Pos           1            /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P1               (_U(0x1) << GPIO_PMR1S_P1_Pos)
+#define GPIO_PMR1S_P1               (_U_(0x1) << GPIO_PMR1S_P1_Pos)
 #define GPIO_PMR1S_P2_Pos           2            /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P2               (_U(0x1) << GPIO_PMR1S_P2_Pos)
+#define GPIO_PMR1S_P2               (_U_(0x1) << GPIO_PMR1S_P2_Pos)
 #define GPIO_PMR1S_P3_Pos           3            /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P3               (_U(0x1) << GPIO_PMR1S_P3_Pos)
+#define GPIO_PMR1S_P3               (_U_(0x1) << GPIO_PMR1S_P3_Pos)
 #define GPIO_PMR1S_P4_Pos           4            /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P4               (_U(0x1) << GPIO_PMR1S_P4_Pos)
+#define GPIO_PMR1S_P4               (_U_(0x1) << GPIO_PMR1S_P4_Pos)
 #define GPIO_PMR1S_P5_Pos           5            /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P5               (_U(0x1) << GPIO_PMR1S_P5_Pos)
+#define GPIO_PMR1S_P5               (_U_(0x1) << GPIO_PMR1S_P5_Pos)
 #define GPIO_PMR1S_P6_Pos           6            /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P6               (_U(0x1) << GPIO_PMR1S_P6_Pos)
+#define GPIO_PMR1S_P6               (_U_(0x1) << GPIO_PMR1S_P6_Pos)
 #define GPIO_PMR1S_P7_Pos           7            /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P7               (_U(0x1) << GPIO_PMR1S_P7_Pos)
+#define GPIO_PMR1S_P7               (_U_(0x1) << GPIO_PMR1S_P7_Pos)
 #define GPIO_PMR1S_P8_Pos           8            /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P8               (_U(0x1) << GPIO_PMR1S_P8_Pos)
+#define GPIO_PMR1S_P8               (_U_(0x1) << GPIO_PMR1S_P8_Pos)
 #define GPIO_PMR1S_P9_Pos           9            /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P9               (_U(0x1) << GPIO_PMR1S_P9_Pos)
+#define GPIO_PMR1S_P9               (_U_(0x1) << GPIO_PMR1S_P9_Pos)
 #define GPIO_PMR1S_P10_Pos          10           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P10              (_U(0x1) << GPIO_PMR1S_P10_Pos)
+#define GPIO_PMR1S_P10              (_U_(0x1) << GPIO_PMR1S_P10_Pos)
 #define GPIO_PMR1S_P11_Pos          11           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P11              (_U(0x1) << GPIO_PMR1S_P11_Pos)
+#define GPIO_PMR1S_P11              (_U_(0x1) << GPIO_PMR1S_P11_Pos)
 #define GPIO_PMR1S_P12_Pos          12           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P12              (_U(0x1) << GPIO_PMR1S_P12_Pos)
+#define GPIO_PMR1S_P12              (_U_(0x1) << GPIO_PMR1S_P12_Pos)
 #define GPIO_PMR1S_P13_Pos          13           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P13              (_U(0x1) << GPIO_PMR1S_P13_Pos)
+#define GPIO_PMR1S_P13              (_U_(0x1) << GPIO_PMR1S_P13_Pos)
 #define GPIO_PMR1S_P14_Pos          14           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P14              (_U(0x1) << GPIO_PMR1S_P14_Pos)
+#define GPIO_PMR1S_P14              (_U_(0x1) << GPIO_PMR1S_P14_Pos)
 #define GPIO_PMR1S_P15_Pos          15           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P15              (_U(0x1) << GPIO_PMR1S_P15_Pos)
+#define GPIO_PMR1S_P15              (_U_(0x1) << GPIO_PMR1S_P15_Pos)
 #define GPIO_PMR1S_P16_Pos          16           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P16              (_U(0x1) << GPIO_PMR1S_P16_Pos)
+#define GPIO_PMR1S_P16              (_U_(0x1) << GPIO_PMR1S_P16_Pos)
 #define GPIO_PMR1S_P17_Pos          17           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P17              (_U(0x1) << GPIO_PMR1S_P17_Pos)
+#define GPIO_PMR1S_P17              (_U_(0x1) << GPIO_PMR1S_P17_Pos)
 #define GPIO_PMR1S_P18_Pos          18           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P18              (_U(0x1) << GPIO_PMR1S_P18_Pos)
+#define GPIO_PMR1S_P18              (_U_(0x1) << GPIO_PMR1S_P18_Pos)
 #define GPIO_PMR1S_P19_Pos          19           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P19              (_U(0x1) << GPIO_PMR1S_P19_Pos)
+#define GPIO_PMR1S_P19              (_U_(0x1) << GPIO_PMR1S_P19_Pos)
 #define GPIO_PMR1S_P20_Pos          20           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P20              (_U(0x1) << GPIO_PMR1S_P20_Pos)
+#define GPIO_PMR1S_P20              (_U_(0x1) << GPIO_PMR1S_P20_Pos)
 #define GPIO_PMR1S_P21_Pos          21           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P21              (_U(0x1) << GPIO_PMR1S_P21_Pos)
+#define GPIO_PMR1S_P21              (_U_(0x1) << GPIO_PMR1S_P21_Pos)
 #define GPIO_PMR1S_P22_Pos          22           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P22              (_U(0x1) << GPIO_PMR1S_P22_Pos)
+#define GPIO_PMR1S_P22              (_U_(0x1) << GPIO_PMR1S_P22_Pos)
 #define GPIO_PMR1S_P23_Pos          23           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P23              (_U(0x1) << GPIO_PMR1S_P23_Pos)
+#define GPIO_PMR1S_P23              (_U_(0x1) << GPIO_PMR1S_P23_Pos)
 #define GPIO_PMR1S_P24_Pos          24           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P24              (_U(0x1) << GPIO_PMR1S_P24_Pos)
+#define GPIO_PMR1S_P24              (_U_(0x1) << GPIO_PMR1S_P24_Pos)
 #define GPIO_PMR1S_P25_Pos          25           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P25              (_U(0x1) << GPIO_PMR1S_P25_Pos)
+#define GPIO_PMR1S_P25              (_U_(0x1) << GPIO_PMR1S_P25_Pos)
 #define GPIO_PMR1S_P26_Pos          26           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P26              (_U(0x1) << GPIO_PMR1S_P26_Pos)
+#define GPIO_PMR1S_P26              (_U_(0x1) << GPIO_PMR1S_P26_Pos)
 #define GPIO_PMR1S_P27_Pos          27           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P27              (_U(0x1) << GPIO_PMR1S_P27_Pos)
+#define GPIO_PMR1S_P27              (_U_(0x1) << GPIO_PMR1S_P27_Pos)
 #define GPIO_PMR1S_P28_Pos          28           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P28              (_U(0x1) << GPIO_PMR1S_P28_Pos)
+#define GPIO_PMR1S_P28              (_U_(0x1) << GPIO_PMR1S_P28_Pos)
 #define GPIO_PMR1S_P29_Pos          29           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P29              (_U(0x1) << GPIO_PMR1S_P29_Pos)
+#define GPIO_PMR1S_P29              (_U_(0x1) << GPIO_PMR1S_P29_Pos)
 #define GPIO_PMR1S_P30_Pos          30           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P30              (_U(0x1) << GPIO_PMR1S_P30_Pos)
+#define GPIO_PMR1S_P30              (_U_(0x1) << GPIO_PMR1S_P30_Pos)
 #define GPIO_PMR1S_P31_Pos          31           /**< \brief (GPIO_PMR1S) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1S_P31              (_U(0x1) << GPIO_PMR1S_P31_Pos)
-#define GPIO_PMR1S_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PMR1S) MASK Register */
+#define GPIO_PMR1S_P31              (_U_(0x1) << GPIO_PMR1S_P31_Pos)
+#define GPIO_PMR1S_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_PMR1S) MASK Register */
 
 /* -------- GPIO_PMR1C : (GPIO Offset: 0x028) ( /W 32) port Peripheral Mux Register 1 - Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1172,70 +1172,70 @@ typedef union {
 #define GPIO_PMR1C_OFFSET           0x028        /**< \brief (GPIO_PMR1C offset) Peripheral Mux Register 1 - Clear */
 
 #define GPIO_PMR1C_P0_Pos           0            /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P0               (_U(0x1) << GPIO_PMR1C_P0_Pos)
+#define GPIO_PMR1C_P0               (_U_(0x1) << GPIO_PMR1C_P0_Pos)
 #define GPIO_PMR1C_P1_Pos           1            /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P1               (_U(0x1) << GPIO_PMR1C_P1_Pos)
+#define GPIO_PMR1C_P1               (_U_(0x1) << GPIO_PMR1C_P1_Pos)
 #define GPIO_PMR1C_P2_Pos           2            /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P2               (_U(0x1) << GPIO_PMR1C_P2_Pos)
+#define GPIO_PMR1C_P2               (_U_(0x1) << GPIO_PMR1C_P2_Pos)
 #define GPIO_PMR1C_P3_Pos           3            /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P3               (_U(0x1) << GPIO_PMR1C_P3_Pos)
+#define GPIO_PMR1C_P3               (_U_(0x1) << GPIO_PMR1C_P3_Pos)
 #define GPIO_PMR1C_P4_Pos           4            /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P4               (_U(0x1) << GPIO_PMR1C_P4_Pos)
+#define GPIO_PMR1C_P4               (_U_(0x1) << GPIO_PMR1C_P4_Pos)
 #define GPIO_PMR1C_P5_Pos           5            /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P5               (_U(0x1) << GPIO_PMR1C_P5_Pos)
+#define GPIO_PMR1C_P5               (_U_(0x1) << GPIO_PMR1C_P5_Pos)
 #define GPIO_PMR1C_P6_Pos           6            /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P6               (_U(0x1) << GPIO_PMR1C_P6_Pos)
+#define GPIO_PMR1C_P6               (_U_(0x1) << GPIO_PMR1C_P6_Pos)
 #define GPIO_PMR1C_P7_Pos           7            /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P7               (_U(0x1) << GPIO_PMR1C_P7_Pos)
+#define GPIO_PMR1C_P7               (_U_(0x1) << GPIO_PMR1C_P7_Pos)
 #define GPIO_PMR1C_P8_Pos           8            /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P8               (_U(0x1) << GPIO_PMR1C_P8_Pos)
+#define GPIO_PMR1C_P8               (_U_(0x1) << GPIO_PMR1C_P8_Pos)
 #define GPIO_PMR1C_P9_Pos           9            /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P9               (_U(0x1) << GPIO_PMR1C_P9_Pos)
+#define GPIO_PMR1C_P9               (_U_(0x1) << GPIO_PMR1C_P9_Pos)
 #define GPIO_PMR1C_P10_Pos          10           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P10              (_U(0x1) << GPIO_PMR1C_P10_Pos)
+#define GPIO_PMR1C_P10              (_U_(0x1) << GPIO_PMR1C_P10_Pos)
 #define GPIO_PMR1C_P11_Pos          11           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P11              (_U(0x1) << GPIO_PMR1C_P11_Pos)
+#define GPIO_PMR1C_P11              (_U_(0x1) << GPIO_PMR1C_P11_Pos)
 #define GPIO_PMR1C_P12_Pos          12           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P12              (_U(0x1) << GPIO_PMR1C_P12_Pos)
+#define GPIO_PMR1C_P12              (_U_(0x1) << GPIO_PMR1C_P12_Pos)
 #define GPIO_PMR1C_P13_Pos          13           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P13              (_U(0x1) << GPIO_PMR1C_P13_Pos)
+#define GPIO_PMR1C_P13              (_U_(0x1) << GPIO_PMR1C_P13_Pos)
 #define GPIO_PMR1C_P14_Pos          14           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P14              (_U(0x1) << GPIO_PMR1C_P14_Pos)
+#define GPIO_PMR1C_P14              (_U_(0x1) << GPIO_PMR1C_P14_Pos)
 #define GPIO_PMR1C_P15_Pos          15           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P15              (_U(0x1) << GPIO_PMR1C_P15_Pos)
+#define GPIO_PMR1C_P15              (_U_(0x1) << GPIO_PMR1C_P15_Pos)
 #define GPIO_PMR1C_P16_Pos          16           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P16              (_U(0x1) << GPIO_PMR1C_P16_Pos)
+#define GPIO_PMR1C_P16              (_U_(0x1) << GPIO_PMR1C_P16_Pos)
 #define GPIO_PMR1C_P17_Pos          17           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P17              (_U(0x1) << GPIO_PMR1C_P17_Pos)
+#define GPIO_PMR1C_P17              (_U_(0x1) << GPIO_PMR1C_P17_Pos)
 #define GPIO_PMR1C_P18_Pos          18           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P18              (_U(0x1) << GPIO_PMR1C_P18_Pos)
+#define GPIO_PMR1C_P18              (_U_(0x1) << GPIO_PMR1C_P18_Pos)
 #define GPIO_PMR1C_P19_Pos          19           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P19              (_U(0x1) << GPIO_PMR1C_P19_Pos)
+#define GPIO_PMR1C_P19              (_U_(0x1) << GPIO_PMR1C_P19_Pos)
 #define GPIO_PMR1C_P20_Pos          20           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P20              (_U(0x1) << GPIO_PMR1C_P20_Pos)
+#define GPIO_PMR1C_P20              (_U_(0x1) << GPIO_PMR1C_P20_Pos)
 #define GPIO_PMR1C_P21_Pos          21           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P21              (_U(0x1) << GPIO_PMR1C_P21_Pos)
+#define GPIO_PMR1C_P21              (_U_(0x1) << GPIO_PMR1C_P21_Pos)
 #define GPIO_PMR1C_P22_Pos          22           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P22              (_U(0x1) << GPIO_PMR1C_P22_Pos)
+#define GPIO_PMR1C_P22              (_U_(0x1) << GPIO_PMR1C_P22_Pos)
 #define GPIO_PMR1C_P23_Pos          23           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P23              (_U(0x1) << GPIO_PMR1C_P23_Pos)
+#define GPIO_PMR1C_P23              (_U_(0x1) << GPIO_PMR1C_P23_Pos)
 #define GPIO_PMR1C_P24_Pos          24           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P24              (_U(0x1) << GPIO_PMR1C_P24_Pos)
+#define GPIO_PMR1C_P24              (_U_(0x1) << GPIO_PMR1C_P24_Pos)
 #define GPIO_PMR1C_P25_Pos          25           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P25              (_U(0x1) << GPIO_PMR1C_P25_Pos)
+#define GPIO_PMR1C_P25              (_U_(0x1) << GPIO_PMR1C_P25_Pos)
 #define GPIO_PMR1C_P26_Pos          26           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P26              (_U(0x1) << GPIO_PMR1C_P26_Pos)
+#define GPIO_PMR1C_P26              (_U_(0x1) << GPIO_PMR1C_P26_Pos)
 #define GPIO_PMR1C_P27_Pos          27           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P27              (_U(0x1) << GPIO_PMR1C_P27_Pos)
+#define GPIO_PMR1C_P27              (_U_(0x1) << GPIO_PMR1C_P27_Pos)
 #define GPIO_PMR1C_P28_Pos          28           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P28              (_U(0x1) << GPIO_PMR1C_P28_Pos)
+#define GPIO_PMR1C_P28              (_U_(0x1) << GPIO_PMR1C_P28_Pos)
 #define GPIO_PMR1C_P29_Pos          29           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P29              (_U(0x1) << GPIO_PMR1C_P29_Pos)
+#define GPIO_PMR1C_P29              (_U_(0x1) << GPIO_PMR1C_P29_Pos)
 #define GPIO_PMR1C_P30_Pos          30           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P30              (_U(0x1) << GPIO_PMR1C_P30_Pos)
+#define GPIO_PMR1C_P30              (_U_(0x1) << GPIO_PMR1C_P30_Pos)
 #define GPIO_PMR1C_P31_Pos          31           /**< \brief (GPIO_PMR1C) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1C_P31              (_U(0x1) << GPIO_PMR1C_P31_Pos)
-#define GPIO_PMR1C_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PMR1C) MASK Register */
+#define GPIO_PMR1C_P31              (_U_(0x1) << GPIO_PMR1C_P31_Pos)
+#define GPIO_PMR1C_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_PMR1C) MASK Register */
 
 /* -------- GPIO_PMR1T : (GPIO Offset: 0x02C) ( /W 32) port Peripheral Mux Register 1 - Toggle -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1281,70 +1281,70 @@ typedef union {
 #define GPIO_PMR1T_OFFSET           0x02C        /**< \brief (GPIO_PMR1T offset) Peripheral Mux Register 1 - Toggle */
 
 #define GPIO_PMR1T_P0_Pos           0            /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P0               (_U(0x1) << GPIO_PMR1T_P0_Pos)
+#define GPIO_PMR1T_P0               (_U_(0x1) << GPIO_PMR1T_P0_Pos)
 #define GPIO_PMR1T_P1_Pos           1            /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P1               (_U(0x1) << GPIO_PMR1T_P1_Pos)
+#define GPIO_PMR1T_P1               (_U_(0x1) << GPIO_PMR1T_P1_Pos)
 #define GPIO_PMR1T_P2_Pos           2            /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P2               (_U(0x1) << GPIO_PMR1T_P2_Pos)
+#define GPIO_PMR1T_P2               (_U_(0x1) << GPIO_PMR1T_P2_Pos)
 #define GPIO_PMR1T_P3_Pos           3            /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P3               (_U(0x1) << GPIO_PMR1T_P3_Pos)
+#define GPIO_PMR1T_P3               (_U_(0x1) << GPIO_PMR1T_P3_Pos)
 #define GPIO_PMR1T_P4_Pos           4            /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P4               (_U(0x1) << GPIO_PMR1T_P4_Pos)
+#define GPIO_PMR1T_P4               (_U_(0x1) << GPIO_PMR1T_P4_Pos)
 #define GPIO_PMR1T_P5_Pos           5            /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P5               (_U(0x1) << GPIO_PMR1T_P5_Pos)
+#define GPIO_PMR1T_P5               (_U_(0x1) << GPIO_PMR1T_P5_Pos)
 #define GPIO_PMR1T_P6_Pos           6            /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P6               (_U(0x1) << GPIO_PMR1T_P6_Pos)
+#define GPIO_PMR1T_P6               (_U_(0x1) << GPIO_PMR1T_P6_Pos)
 #define GPIO_PMR1T_P7_Pos           7            /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P7               (_U(0x1) << GPIO_PMR1T_P7_Pos)
+#define GPIO_PMR1T_P7               (_U_(0x1) << GPIO_PMR1T_P7_Pos)
 #define GPIO_PMR1T_P8_Pos           8            /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P8               (_U(0x1) << GPIO_PMR1T_P8_Pos)
+#define GPIO_PMR1T_P8               (_U_(0x1) << GPIO_PMR1T_P8_Pos)
 #define GPIO_PMR1T_P9_Pos           9            /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P9               (_U(0x1) << GPIO_PMR1T_P9_Pos)
+#define GPIO_PMR1T_P9               (_U_(0x1) << GPIO_PMR1T_P9_Pos)
 #define GPIO_PMR1T_P10_Pos          10           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P10              (_U(0x1) << GPIO_PMR1T_P10_Pos)
+#define GPIO_PMR1T_P10              (_U_(0x1) << GPIO_PMR1T_P10_Pos)
 #define GPIO_PMR1T_P11_Pos          11           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P11              (_U(0x1) << GPIO_PMR1T_P11_Pos)
+#define GPIO_PMR1T_P11              (_U_(0x1) << GPIO_PMR1T_P11_Pos)
 #define GPIO_PMR1T_P12_Pos          12           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P12              (_U(0x1) << GPIO_PMR1T_P12_Pos)
+#define GPIO_PMR1T_P12              (_U_(0x1) << GPIO_PMR1T_P12_Pos)
 #define GPIO_PMR1T_P13_Pos          13           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P13              (_U(0x1) << GPIO_PMR1T_P13_Pos)
+#define GPIO_PMR1T_P13              (_U_(0x1) << GPIO_PMR1T_P13_Pos)
 #define GPIO_PMR1T_P14_Pos          14           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P14              (_U(0x1) << GPIO_PMR1T_P14_Pos)
+#define GPIO_PMR1T_P14              (_U_(0x1) << GPIO_PMR1T_P14_Pos)
 #define GPIO_PMR1T_P15_Pos          15           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P15              (_U(0x1) << GPIO_PMR1T_P15_Pos)
+#define GPIO_PMR1T_P15              (_U_(0x1) << GPIO_PMR1T_P15_Pos)
 #define GPIO_PMR1T_P16_Pos          16           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P16              (_U(0x1) << GPIO_PMR1T_P16_Pos)
+#define GPIO_PMR1T_P16              (_U_(0x1) << GPIO_PMR1T_P16_Pos)
 #define GPIO_PMR1T_P17_Pos          17           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P17              (_U(0x1) << GPIO_PMR1T_P17_Pos)
+#define GPIO_PMR1T_P17              (_U_(0x1) << GPIO_PMR1T_P17_Pos)
 #define GPIO_PMR1T_P18_Pos          18           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P18              (_U(0x1) << GPIO_PMR1T_P18_Pos)
+#define GPIO_PMR1T_P18              (_U_(0x1) << GPIO_PMR1T_P18_Pos)
 #define GPIO_PMR1T_P19_Pos          19           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P19              (_U(0x1) << GPIO_PMR1T_P19_Pos)
+#define GPIO_PMR1T_P19              (_U_(0x1) << GPIO_PMR1T_P19_Pos)
 #define GPIO_PMR1T_P20_Pos          20           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P20              (_U(0x1) << GPIO_PMR1T_P20_Pos)
+#define GPIO_PMR1T_P20              (_U_(0x1) << GPIO_PMR1T_P20_Pos)
 #define GPIO_PMR1T_P21_Pos          21           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P21              (_U(0x1) << GPIO_PMR1T_P21_Pos)
+#define GPIO_PMR1T_P21              (_U_(0x1) << GPIO_PMR1T_P21_Pos)
 #define GPIO_PMR1T_P22_Pos          22           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P22              (_U(0x1) << GPIO_PMR1T_P22_Pos)
+#define GPIO_PMR1T_P22              (_U_(0x1) << GPIO_PMR1T_P22_Pos)
 #define GPIO_PMR1T_P23_Pos          23           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P23              (_U(0x1) << GPIO_PMR1T_P23_Pos)
+#define GPIO_PMR1T_P23              (_U_(0x1) << GPIO_PMR1T_P23_Pos)
 #define GPIO_PMR1T_P24_Pos          24           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P24              (_U(0x1) << GPIO_PMR1T_P24_Pos)
+#define GPIO_PMR1T_P24              (_U_(0x1) << GPIO_PMR1T_P24_Pos)
 #define GPIO_PMR1T_P25_Pos          25           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P25              (_U(0x1) << GPIO_PMR1T_P25_Pos)
+#define GPIO_PMR1T_P25              (_U_(0x1) << GPIO_PMR1T_P25_Pos)
 #define GPIO_PMR1T_P26_Pos          26           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P26              (_U(0x1) << GPIO_PMR1T_P26_Pos)
+#define GPIO_PMR1T_P26              (_U_(0x1) << GPIO_PMR1T_P26_Pos)
 #define GPIO_PMR1T_P27_Pos          27           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P27              (_U(0x1) << GPIO_PMR1T_P27_Pos)
+#define GPIO_PMR1T_P27              (_U_(0x1) << GPIO_PMR1T_P27_Pos)
 #define GPIO_PMR1T_P28_Pos          28           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P28              (_U(0x1) << GPIO_PMR1T_P28_Pos)
+#define GPIO_PMR1T_P28              (_U_(0x1) << GPIO_PMR1T_P28_Pos)
 #define GPIO_PMR1T_P29_Pos          29           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P29              (_U(0x1) << GPIO_PMR1T_P29_Pos)
+#define GPIO_PMR1T_P29              (_U_(0x1) << GPIO_PMR1T_P29_Pos)
 #define GPIO_PMR1T_P30_Pos          30           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P30              (_U(0x1) << GPIO_PMR1T_P30_Pos)
+#define GPIO_PMR1T_P30              (_U_(0x1) << GPIO_PMR1T_P30_Pos)
 #define GPIO_PMR1T_P31_Pos          31           /**< \brief (GPIO_PMR1T) Peripheral Multiplexer Select bit 1 */
-#define GPIO_PMR1T_P31              (_U(0x1) << GPIO_PMR1T_P31_Pos)
-#define GPIO_PMR1T_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PMR1T) MASK Register */
+#define GPIO_PMR1T_P31              (_U_(0x1) << GPIO_PMR1T_P31_Pos)
+#define GPIO_PMR1T_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_PMR1T) MASK Register */
 
 /* -------- GPIO_PMR2 : (GPIO Offset: 0x030) (R/W 32) port Peripheral Mux Register 2 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1390,70 +1390,70 @@ typedef union {
 #define GPIO_PMR2_OFFSET            0x030        /**< \brief (GPIO_PMR2 offset) Peripheral Mux Register 2 */
 
 #define GPIO_PMR2_P0_Pos            0            /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P0                (_U(0x1) << GPIO_PMR2_P0_Pos)
+#define GPIO_PMR2_P0                (_U_(0x1) << GPIO_PMR2_P0_Pos)
 #define GPIO_PMR2_P1_Pos            1            /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P1                (_U(0x1) << GPIO_PMR2_P1_Pos)
+#define GPIO_PMR2_P1                (_U_(0x1) << GPIO_PMR2_P1_Pos)
 #define GPIO_PMR2_P2_Pos            2            /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P2                (_U(0x1) << GPIO_PMR2_P2_Pos)
+#define GPIO_PMR2_P2                (_U_(0x1) << GPIO_PMR2_P2_Pos)
 #define GPIO_PMR2_P3_Pos            3            /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P3                (_U(0x1) << GPIO_PMR2_P3_Pos)
+#define GPIO_PMR2_P3                (_U_(0x1) << GPIO_PMR2_P3_Pos)
 #define GPIO_PMR2_P4_Pos            4            /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P4                (_U(0x1) << GPIO_PMR2_P4_Pos)
+#define GPIO_PMR2_P4                (_U_(0x1) << GPIO_PMR2_P4_Pos)
 #define GPIO_PMR2_P5_Pos            5            /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P5                (_U(0x1) << GPIO_PMR2_P5_Pos)
+#define GPIO_PMR2_P5                (_U_(0x1) << GPIO_PMR2_P5_Pos)
 #define GPIO_PMR2_P6_Pos            6            /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P6                (_U(0x1) << GPIO_PMR2_P6_Pos)
+#define GPIO_PMR2_P6                (_U_(0x1) << GPIO_PMR2_P6_Pos)
 #define GPIO_PMR2_P7_Pos            7            /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P7                (_U(0x1) << GPIO_PMR2_P7_Pos)
+#define GPIO_PMR2_P7                (_U_(0x1) << GPIO_PMR2_P7_Pos)
 #define GPIO_PMR2_P8_Pos            8            /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P8                (_U(0x1) << GPIO_PMR2_P8_Pos)
+#define GPIO_PMR2_P8                (_U_(0x1) << GPIO_PMR2_P8_Pos)
 #define GPIO_PMR2_P9_Pos            9            /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P9                (_U(0x1) << GPIO_PMR2_P9_Pos)
+#define GPIO_PMR2_P9                (_U_(0x1) << GPIO_PMR2_P9_Pos)
 #define GPIO_PMR2_P10_Pos           10           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P10               (_U(0x1) << GPIO_PMR2_P10_Pos)
+#define GPIO_PMR2_P10               (_U_(0x1) << GPIO_PMR2_P10_Pos)
 #define GPIO_PMR2_P11_Pos           11           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P11               (_U(0x1) << GPIO_PMR2_P11_Pos)
+#define GPIO_PMR2_P11               (_U_(0x1) << GPIO_PMR2_P11_Pos)
 #define GPIO_PMR2_P12_Pos           12           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P12               (_U(0x1) << GPIO_PMR2_P12_Pos)
+#define GPIO_PMR2_P12               (_U_(0x1) << GPIO_PMR2_P12_Pos)
 #define GPIO_PMR2_P13_Pos           13           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P13               (_U(0x1) << GPIO_PMR2_P13_Pos)
+#define GPIO_PMR2_P13               (_U_(0x1) << GPIO_PMR2_P13_Pos)
 #define GPIO_PMR2_P14_Pos           14           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P14               (_U(0x1) << GPIO_PMR2_P14_Pos)
+#define GPIO_PMR2_P14               (_U_(0x1) << GPIO_PMR2_P14_Pos)
 #define GPIO_PMR2_P15_Pos           15           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P15               (_U(0x1) << GPIO_PMR2_P15_Pos)
+#define GPIO_PMR2_P15               (_U_(0x1) << GPIO_PMR2_P15_Pos)
 #define GPIO_PMR2_P16_Pos           16           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P16               (_U(0x1) << GPIO_PMR2_P16_Pos)
+#define GPIO_PMR2_P16               (_U_(0x1) << GPIO_PMR2_P16_Pos)
 #define GPIO_PMR2_P17_Pos           17           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P17               (_U(0x1) << GPIO_PMR2_P17_Pos)
+#define GPIO_PMR2_P17               (_U_(0x1) << GPIO_PMR2_P17_Pos)
 #define GPIO_PMR2_P18_Pos           18           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P18               (_U(0x1) << GPIO_PMR2_P18_Pos)
+#define GPIO_PMR2_P18               (_U_(0x1) << GPIO_PMR2_P18_Pos)
 #define GPIO_PMR2_P19_Pos           19           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P19               (_U(0x1) << GPIO_PMR2_P19_Pos)
+#define GPIO_PMR2_P19               (_U_(0x1) << GPIO_PMR2_P19_Pos)
 #define GPIO_PMR2_P20_Pos           20           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P20               (_U(0x1) << GPIO_PMR2_P20_Pos)
+#define GPIO_PMR2_P20               (_U_(0x1) << GPIO_PMR2_P20_Pos)
 #define GPIO_PMR2_P21_Pos           21           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P21               (_U(0x1) << GPIO_PMR2_P21_Pos)
+#define GPIO_PMR2_P21               (_U_(0x1) << GPIO_PMR2_P21_Pos)
 #define GPIO_PMR2_P22_Pos           22           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P22               (_U(0x1) << GPIO_PMR2_P22_Pos)
+#define GPIO_PMR2_P22               (_U_(0x1) << GPIO_PMR2_P22_Pos)
 #define GPIO_PMR2_P23_Pos           23           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P23               (_U(0x1) << GPIO_PMR2_P23_Pos)
+#define GPIO_PMR2_P23               (_U_(0x1) << GPIO_PMR2_P23_Pos)
 #define GPIO_PMR2_P24_Pos           24           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P24               (_U(0x1) << GPIO_PMR2_P24_Pos)
+#define GPIO_PMR2_P24               (_U_(0x1) << GPIO_PMR2_P24_Pos)
 #define GPIO_PMR2_P25_Pos           25           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P25               (_U(0x1) << GPIO_PMR2_P25_Pos)
+#define GPIO_PMR2_P25               (_U_(0x1) << GPIO_PMR2_P25_Pos)
 #define GPIO_PMR2_P26_Pos           26           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P26               (_U(0x1) << GPIO_PMR2_P26_Pos)
+#define GPIO_PMR2_P26               (_U_(0x1) << GPIO_PMR2_P26_Pos)
 #define GPIO_PMR2_P27_Pos           27           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P27               (_U(0x1) << GPIO_PMR2_P27_Pos)
+#define GPIO_PMR2_P27               (_U_(0x1) << GPIO_PMR2_P27_Pos)
 #define GPIO_PMR2_P28_Pos           28           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P28               (_U(0x1) << GPIO_PMR2_P28_Pos)
+#define GPIO_PMR2_P28               (_U_(0x1) << GPIO_PMR2_P28_Pos)
 #define GPIO_PMR2_P29_Pos           29           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P29               (_U(0x1) << GPIO_PMR2_P29_Pos)
+#define GPIO_PMR2_P29               (_U_(0x1) << GPIO_PMR2_P29_Pos)
 #define GPIO_PMR2_P30_Pos           30           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P30               (_U(0x1) << GPIO_PMR2_P30_Pos)
+#define GPIO_PMR2_P30               (_U_(0x1) << GPIO_PMR2_P30_Pos)
 #define GPIO_PMR2_P31_Pos           31           /**< \brief (GPIO_PMR2) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2_P31               (_U(0x1) << GPIO_PMR2_P31_Pos)
-#define GPIO_PMR2_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_PMR2) MASK Register */
+#define GPIO_PMR2_P31               (_U_(0x1) << GPIO_PMR2_P31_Pos)
+#define GPIO_PMR2_MASK              _U_(0xFFFFFFFF) /**< \brief (GPIO_PMR2) MASK Register */
 
 /* -------- GPIO_PMR2S : (GPIO Offset: 0x034) ( /W 32) port Peripheral Mux Register 2 - Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1499,70 +1499,70 @@ typedef union {
 #define GPIO_PMR2S_OFFSET           0x034        /**< \brief (GPIO_PMR2S offset) Peripheral Mux Register 2 - Set */
 
 #define GPIO_PMR2S_P0_Pos           0            /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P0               (_U(0x1) << GPIO_PMR2S_P0_Pos)
+#define GPIO_PMR2S_P0               (_U_(0x1) << GPIO_PMR2S_P0_Pos)
 #define GPIO_PMR2S_P1_Pos           1            /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P1               (_U(0x1) << GPIO_PMR2S_P1_Pos)
+#define GPIO_PMR2S_P1               (_U_(0x1) << GPIO_PMR2S_P1_Pos)
 #define GPIO_PMR2S_P2_Pos           2            /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P2               (_U(0x1) << GPIO_PMR2S_P2_Pos)
+#define GPIO_PMR2S_P2               (_U_(0x1) << GPIO_PMR2S_P2_Pos)
 #define GPIO_PMR2S_P3_Pos           3            /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P3               (_U(0x1) << GPIO_PMR2S_P3_Pos)
+#define GPIO_PMR2S_P3               (_U_(0x1) << GPIO_PMR2S_P3_Pos)
 #define GPIO_PMR2S_P4_Pos           4            /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P4               (_U(0x1) << GPIO_PMR2S_P4_Pos)
+#define GPIO_PMR2S_P4               (_U_(0x1) << GPIO_PMR2S_P4_Pos)
 #define GPIO_PMR2S_P5_Pos           5            /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P5               (_U(0x1) << GPIO_PMR2S_P5_Pos)
+#define GPIO_PMR2S_P5               (_U_(0x1) << GPIO_PMR2S_P5_Pos)
 #define GPIO_PMR2S_P6_Pos           6            /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P6               (_U(0x1) << GPIO_PMR2S_P6_Pos)
+#define GPIO_PMR2S_P6               (_U_(0x1) << GPIO_PMR2S_P6_Pos)
 #define GPIO_PMR2S_P7_Pos           7            /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P7               (_U(0x1) << GPIO_PMR2S_P7_Pos)
+#define GPIO_PMR2S_P7               (_U_(0x1) << GPIO_PMR2S_P7_Pos)
 #define GPIO_PMR2S_P8_Pos           8            /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P8               (_U(0x1) << GPIO_PMR2S_P8_Pos)
+#define GPIO_PMR2S_P8               (_U_(0x1) << GPIO_PMR2S_P8_Pos)
 #define GPIO_PMR2S_P9_Pos           9            /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P9               (_U(0x1) << GPIO_PMR2S_P9_Pos)
+#define GPIO_PMR2S_P9               (_U_(0x1) << GPIO_PMR2S_P9_Pos)
 #define GPIO_PMR2S_P10_Pos          10           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P10              (_U(0x1) << GPIO_PMR2S_P10_Pos)
+#define GPIO_PMR2S_P10              (_U_(0x1) << GPIO_PMR2S_P10_Pos)
 #define GPIO_PMR2S_P11_Pos          11           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P11              (_U(0x1) << GPIO_PMR2S_P11_Pos)
+#define GPIO_PMR2S_P11              (_U_(0x1) << GPIO_PMR2S_P11_Pos)
 #define GPIO_PMR2S_P12_Pos          12           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P12              (_U(0x1) << GPIO_PMR2S_P12_Pos)
+#define GPIO_PMR2S_P12              (_U_(0x1) << GPIO_PMR2S_P12_Pos)
 #define GPIO_PMR2S_P13_Pos          13           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P13              (_U(0x1) << GPIO_PMR2S_P13_Pos)
+#define GPIO_PMR2S_P13              (_U_(0x1) << GPIO_PMR2S_P13_Pos)
 #define GPIO_PMR2S_P14_Pos          14           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P14              (_U(0x1) << GPIO_PMR2S_P14_Pos)
+#define GPIO_PMR2S_P14              (_U_(0x1) << GPIO_PMR2S_P14_Pos)
 #define GPIO_PMR2S_P15_Pos          15           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P15              (_U(0x1) << GPIO_PMR2S_P15_Pos)
+#define GPIO_PMR2S_P15              (_U_(0x1) << GPIO_PMR2S_P15_Pos)
 #define GPIO_PMR2S_P16_Pos          16           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P16              (_U(0x1) << GPIO_PMR2S_P16_Pos)
+#define GPIO_PMR2S_P16              (_U_(0x1) << GPIO_PMR2S_P16_Pos)
 #define GPIO_PMR2S_P17_Pos          17           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P17              (_U(0x1) << GPIO_PMR2S_P17_Pos)
+#define GPIO_PMR2S_P17              (_U_(0x1) << GPIO_PMR2S_P17_Pos)
 #define GPIO_PMR2S_P18_Pos          18           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P18              (_U(0x1) << GPIO_PMR2S_P18_Pos)
+#define GPIO_PMR2S_P18              (_U_(0x1) << GPIO_PMR2S_P18_Pos)
 #define GPIO_PMR2S_P19_Pos          19           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P19              (_U(0x1) << GPIO_PMR2S_P19_Pos)
+#define GPIO_PMR2S_P19              (_U_(0x1) << GPIO_PMR2S_P19_Pos)
 #define GPIO_PMR2S_P20_Pos          20           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P20              (_U(0x1) << GPIO_PMR2S_P20_Pos)
+#define GPIO_PMR2S_P20              (_U_(0x1) << GPIO_PMR2S_P20_Pos)
 #define GPIO_PMR2S_P21_Pos          21           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P21              (_U(0x1) << GPIO_PMR2S_P21_Pos)
+#define GPIO_PMR2S_P21              (_U_(0x1) << GPIO_PMR2S_P21_Pos)
 #define GPIO_PMR2S_P22_Pos          22           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P22              (_U(0x1) << GPIO_PMR2S_P22_Pos)
+#define GPIO_PMR2S_P22              (_U_(0x1) << GPIO_PMR2S_P22_Pos)
 #define GPIO_PMR2S_P23_Pos          23           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P23              (_U(0x1) << GPIO_PMR2S_P23_Pos)
+#define GPIO_PMR2S_P23              (_U_(0x1) << GPIO_PMR2S_P23_Pos)
 #define GPIO_PMR2S_P24_Pos          24           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P24              (_U(0x1) << GPIO_PMR2S_P24_Pos)
+#define GPIO_PMR2S_P24              (_U_(0x1) << GPIO_PMR2S_P24_Pos)
 #define GPIO_PMR2S_P25_Pos          25           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P25              (_U(0x1) << GPIO_PMR2S_P25_Pos)
+#define GPIO_PMR2S_P25              (_U_(0x1) << GPIO_PMR2S_P25_Pos)
 #define GPIO_PMR2S_P26_Pos          26           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P26              (_U(0x1) << GPIO_PMR2S_P26_Pos)
+#define GPIO_PMR2S_P26              (_U_(0x1) << GPIO_PMR2S_P26_Pos)
 #define GPIO_PMR2S_P27_Pos          27           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P27              (_U(0x1) << GPIO_PMR2S_P27_Pos)
+#define GPIO_PMR2S_P27              (_U_(0x1) << GPIO_PMR2S_P27_Pos)
 #define GPIO_PMR2S_P28_Pos          28           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P28              (_U(0x1) << GPIO_PMR2S_P28_Pos)
+#define GPIO_PMR2S_P28              (_U_(0x1) << GPIO_PMR2S_P28_Pos)
 #define GPIO_PMR2S_P29_Pos          29           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P29              (_U(0x1) << GPIO_PMR2S_P29_Pos)
+#define GPIO_PMR2S_P29              (_U_(0x1) << GPIO_PMR2S_P29_Pos)
 #define GPIO_PMR2S_P30_Pos          30           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P30              (_U(0x1) << GPIO_PMR2S_P30_Pos)
+#define GPIO_PMR2S_P30              (_U_(0x1) << GPIO_PMR2S_P30_Pos)
 #define GPIO_PMR2S_P31_Pos          31           /**< \brief (GPIO_PMR2S) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2S_P31              (_U(0x1) << GPIO_PMR2S_P31_Pos)
-#define GPIO_PMR2S_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PMR2S) MASK Register */
+#define GPIO_PMR2S_P31              (_U_(0x1) << GPIO_PMR2S_P31_Pos)
+#define GPIO_PMR2S_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_PMR2S) MASK Register */
 
 /* -------- GPIO_PMR2C : (GPIO Offset: 0x038) ( /W 32) port Peripheral Mux Register 2 - Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1608,70 +1608,70 @@ typedef union {
 #define GPIO_PMR2C_OFFSET           0x038        /**< \brief (GPIO_PMR2C offset) Peripheral Mux Register 2 - Clear */
 
 #define GPIO_PMR2C_P0_Pos           0            /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P0               (_U(0x1) << GPIO_PMR2C_P0_Pos)
+#define GPIO_PMR2C_P0               (_U_(0x1) << GPIO_PMR2C_P0_Pos)
 #define GPIO_PMR2C_P1_Pos           1            /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P1               (_U(0x1) << GPIO_PMR2C_P1_Pos)
+#define GPIO_PMR2C_P1               (_U_(0x1) << GPIO_PMR2C_P1_Pos)
 #define GPIO_PMR2C_P2_Pos           2            /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P2               (_U(0x1) << GPIO_PMR2C_P2_Pos)
+#define GPIO_PMR2C_P2               (_U_(0x1) << GPIO_PMR2C_P2_Pos)
 #define GPIO_PMR2C_P3_Pos           3            /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P3               (_U(0x1) << GPIO_PMR2C_P3_Pos)
+#define GPIO_PMR2C_P3               (_U_(0x1) << GPIO_PMR2C_P3_Pos)
 #define GPIO_PMR2C_P4_Pos           4            /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P4               (_U(0x1) << GPIO_PMR2C_P4_Pos)
+#define GPIO_PMR2C_P4               (_U_(0x1) << GPIO_PMR2C_P4_Pos)
 #define GPIO_PMR2C_P5_Pos           5            /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P5               (_U(0x1) << GPIO_PMR2C_P5_Pos)
+#define GPIO_PMR2C_P5               (_U_(0x1) << GPIO_PMR2C_P5_Pos)
 #define GPIO_PMR2C_P6_Pos           6            /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P6               (_U(0x1) << GPIO_PMR2C_P6_Pos)
+#define GPIO_PMR2C_P6               (_U_(0x1) << GPIO_PMR2C_P6_Pos)
 #define GPIO_PMR2C_P7_Pos           7            /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P7               (_U(0x1) << GPIO_PMR2C_P7_Pos)
+#define GPIO_PMR2C_P7               (_U_(0x1) << GPIO_PMR2C_P7_Pos)
 #define GPIO_PMR2C_P8_Pos           8            /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P8               (_U(0x1) << GPIO_PMR2C_P8_Pos)
+#define GPIO_PMR2C_P8               (_U_(0x1) << GPIO_PMR2C_P8_Pos)
 #define GPIO_PMR2C_P9_Pos           9            /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P9               (_U(0x1) << GPIO_PMR2C_P9_Pos)
+#define GPIO_PMR2C_P9               (_U_(0x1) << GPIO_PMR2C_P9_Pos)
 #define GPIO_PMR2C_P10_Pos          10           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P10              (_U(0x1) << GPIO_PMR2C_P10_Pos)
+#define GPIO_PMR2C_P10              (_U_(0x1) << GPIO_PMR2C_P10_Pos)
 #define GPIO_PMR2C_P11_Pos          11           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P11              (_U(0x1) << GPIO_PMR2C_P11_Pos)
+#define GPIO_PMR2C_P11              (_U_(0x1) << GPIO_PMR2C_P11_Pos)
 #define GPIO_PMR2C_P12_Pos          12           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P12              (_U(0x1) << GPIO_PMR2C_P12_Pos)
+#define GPIO_PMR2C_P12              (_U_(0x1) << GPIO_PMR2C_P12_Pos)
 #define GPIO_PMR2C_P13_Pos          13           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P13              (_U(0x1) << GPIO_PMR2C_P13_Pos)
+#define GPIO_PMR2C_P13              (_U_(0x1) << GPIO_PMR2C_P13_Pos)
 #define GPIO_PMR2C_P14_Pos          14           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P14              (_U(0x1) << GPIO_PMR2C_P14_Pos)
+#define GPIO_PMR2C_P14              (_U_(0x1) << GPIO_PMR2C_P14_Pos)
 #define GPIO_PMR2C_P15_Pos          15           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P15              (_U(0x1) << GPIO_PMR2C_P15_Pos)
+#define GPIO_PMR2C_P15              (_U_(0x1) << GPIO_PMR2C_P15_Pos)
 #define GPIO_PMR2C_P16_Pos          16           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P16              (_U(0x1) << GPIO_PMR2C_P16_Pos)
+#define GPIO_PMR2C_P16              (_U_(0x1) << GPIO_PMR2C_P16_Pos)
 #define GPIO_PMR2C_P17_Pos          17           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P17              (_U(0x1) << GPIO_PMR2C_P17_Pos)
+#define GPIO_PMR2C_P17              (_U_(0x1) << GPIO_PMR2C_P17_Pos)
 #define GPIO_PMR2C_P18_Pos          18           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P18              (_U(0x1) << GPIO_PMR2C_P18_Pos)
+#define GPIO_PMR2C_P18              (_U_(0x1) << GPIO_PMR2C_P18_Pos)
 #define GPIO_PMR2C_P19_Pos          19           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P19              (_U(0x1) << GPIO_PMR2C_P19_Pos)
+#define GPIO_PMR2C_P19              (_U_(0x1) << GPIO_PMR2C_P19_Pos)
 #define GPIO_PMR2C_P20_Pos          20           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P20              (_U(0x1) << GPIO_PMR2C_P20_Pos)
+#define GPIO_PMR2C_P20              (_U_(0x1) << GPIO_PMR2C_P20_Pos)
 #define GPIO_PMR2C_P21_Pos          21           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P21              (_U(0x1) << GPIO_PMR2C_P21_Pos)
+#define GPIO_PMR2C_P21              (_U_(0x1) << GPIO_PMR2C_P21_Pos)
 #define GPIO_PMR2C_P22_Pos          22           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P22              (_U(0x1) << GPIO_PMR2C_P22_Pos)
+#define GPIO_PMR2C_P22              (_U_(0x1) << GPIO_PMR2C_P22_Pos)
 #define GPIO_PMR2C_P23_Pos          23           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P23              (_U(0x1) << GPIO_PMR2C_P23_Pos)
+#define GPIO_PMR2C_P23              (_U_(0x1) << GPIO_PMR2C_P23_Pos)
 #define GPIO_PMR2C_P24_Pos          24           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P24              (_U(0x1) << GPIO_PMR2C_P24_Pos)
+#define GPIO_PMR2C_P24              (_U_(0x1) << GPIO_PMR2C_P24_Pos)
 #define GPIO_PMR2C_P25_Pos          25           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P25              (_U(0x1) << GPIO_PMR2C_P25_Pos)
+#define GPIO_PMR2C_P25              (_U_(0x1) << GPIO_PMR2C_P25_Pos)
 #define GPIO_PMR2C_P26_Pos          26           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P26              (_U(0x1) << GPIO_PMR2C_P26_Pos)
+#define GPIO_PMR2C_P26              (_U_(0x1) << GPIO_PMR2C_P26_Pos)
 #define GPIO_PMR2C_P27_Pos          27           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P27              (_U(0x1) << GPIO_PMR2C_P27_Pos)
+#define GPIO_PMR2C_P27              (_U_(0x1) << GPIO_PMR2C_P27_Pos)
 #define GPIO_PMR2C_P28_Pos          28           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P28              (_U(0x1) << GPIO_PMR2C_P28_Pos)
+#define GPIO_PMR2C_P28              (_U_(0x1) << GPIO_PMR2C_P28_Pos)
 #define GPIO_PMR2C_P29_Pos          29           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P29              (_U(0x1) << GPIO_PMR2C_P29_Pos)
+#define GPIO_PMR2C_P29              (_U_(0x1) << GPIO_PMR2C_P29_Pos)
 #define GPIO_PMR2C_P30_Pos          30           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P30              (_U(0x1) << GPIO_PMR2C_P30_Pos)
+#define GPIO_PMR2C_P30              (_U_(0x1) << GPIO_PMR2C_P30_Pos)
 #define GPIO_PMR2C_P31_Pos          31           /**< \brief (GPIO_PMR2C) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2C_P31              (_U(0x1) << GPIO_PMR2C_P31_Pos)
-#define GPIO_PMR2C_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PMR2C) MASK Register */
+#define GPIO_PMR2C_P31              (_U_(0x1) << GPIO_PMR2C_P31_Pos)
+#define GPIO_PMR2C_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_PMR2C) MASK Register */
 
 /* -------- GPIO_PMR2T : (GPIO Offset: 0x03C) ( /W 32) port Peripheral Mux Register 2 - Toggle -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1717,70 +1717,70 @@ typedef union {
 #define GPIO_PMR2T_OFFSET           0x03C        /**< \brief (GPIO_PMR2T offset) Peripheral Mux Register 2 - Toggle */
 
 #define GPIO_PMR2T_P0_Pos           0            /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P0               (_U(0x1) << GPIO_PMR2T_P0_Pos)
+#define GPIO_PMR2T_P0               (_U_(0x1) << GPIO_PMR2T_P0_Pos)
 #define GPIO_PMR2T_P1_Pos           1            /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P1               (_U(0x1) << GPIO_PMR2T_P1_Pos)
+#define GPIO_PMR2T_P1               (_U_(0x1) << GPIO_PMR2T_P1_Pos)
 #define GPIO_PMR2T_P2_Pos           2            /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P2               (_U(0x1) << GPIO_PMR2T_P2_Pos)
+#define GPIO_PMR2T_P2               (_U_(0x1) << GPIO_PMR2T_P2_Pos)
 #define GPIO_PMR2T_P3_Pos           3            /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P3               (_U(0x1) << GPIO_PMR2T_P3_Pos)
+#define GPIO_PMR2T_P3               (_U_(0x1) << GPIO_PMR2T_P3_Pos)
 #define GPIO_PMR2T_P4_Pos           4            /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P4               (_U(0x1) << GPIO_PMR2T_P4_Pos)
+#define GPIO_PMR2T_P4               (_U_(0x1) << GPIO_PMR2T_P4_Pos)
 #define GPIO_PMR2T_P5_Pos           5            /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P5               (_U(0x1) << GPIO_PMR2T_P5_Pos)
+#define GPIO_PMR2T_P5               (_U_(0x1) << GPIO_PMR2T_P5_Pos)
 #define GPIO_PMR2T_P6_Pos           6            /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P6               (_U(0x1) << GPIO_PMR2T_P6_Pos)
+#define GPIO_PMR2T_P6               (_U_(0x1) << GPIO_PMR2T_P6_Pos)
 #define GPIO_PMR2T_P7_Pos           7            /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P7               (_U(0x1) << GPIO_PMR2T_P7_Pos)
+#define GPIO_PMR2T_P7               (_U_(0x1) << GPIO_PMR2T_P7_Pos)
 #define GPIO_PMR2T_P8_Pos           8            /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P8               (_U(0x1) << GPIO_PMR2T_P8_Pos)
+#define GPIO_PMR2T_P8               (_U_(0x1) << GPIO_PMR2T_P8_Pos)
 #define GPIO_PMR2T_P9_Pos           9            /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P9               (_U(0x1) << GPIO_PMR2T_P9_Pos)
+#define GPIO_PMR2T_P9               (_U_(0x1) << GPIO_PMR2T_P9_Pos)
 #define GPIO_PMR2T_P10_Pos          10           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P10              (_U(0x1) << GPIO_PMR2T_P10_Pos)
+#define GPIO_PMR2T_P10              (_U_(0x1) << GPIO_PMR2T_P10_Pos)
 #define GPIO_PMR2T_P11_Pos          11           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P11              (_U(0x1) << GPIO_PMR2T_P11_Pos)
+#define GPIO_PMR2T_P11              (_U_(0x1) << GPIO_PMR2T_P11_Pos)
 #define GPIO_PMR2T_P12_Pos          12           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P12              (_U(0x1) << GPIO_PMR2T_P12_Pos)
+#define GPIO_PMR2T_P12              (_U_(0x1) << GPIO_PMR2T_P12_Pos)
 #define GPIO_PMR2T_P13_Pos          13           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P13              (_U(0x1) << GPIO_PMR2T_P13_Pos)
+#define GPIO_PMR2T_P13              (_U_(0x1) << GPIO_PMR2T_P13_Pos)
 #define GPIO_PMR2T_P14_Pos          14           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P14              (_U(0x1) << GPIO_PMR2T_P14_Pos)
+#define GPIO_PMR2T_P14              (_U_(0x1) << GPIO_PMR2T_P14_Pos)
 #define GPIO_PMR2T_P15_Pos          15           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P15              (_U(0x1) << GPIO_PMR2T_P15_Pos)
+#define GPIO_PMR2T_P15              (_U_(0x1) << GPIO_PMR2T_P15_Pos)
 #define GPIO_PMR2T_P16_Pos          16           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P16              (_U(0x1) << GPIO_PMR2T_P16_Pos)
+#define GPIO_PMR2T_P16              (_U_(0x1) << GPIO_PMR2T_P16_Pos)
 #define GPIO_PMR2T_P17_Pos          17           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P17              (_U(0x1) << GPIO_PMR2T_P17_Pos)
+#define GPIO_PMR2T_P17              (_U_(0x1) << GPIO_PMR2T_P17_Pos)
 #define GPIO_PMR2T_P18_Pos          18           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P18              (_U(0x1) << GPIO_PMR2T_P18_Pos)
+#define GPIO_PMR2T_P18              (_U_(0x1) << GPIO_PMR2T_P18_Pos)
 #define GPIO_PMR2T_P19_Pos          19           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P19              (_U(0x1) << GPIO_PMR2T_P19_Pos)
+#define GPIO_PMR2T_P19              (_U_(0x1) << GPIO_PMR2T_P19_Pos)
 #define GPIO_PMR2T_P20_Pos          20           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P20              (_U(0x1) << GPIO_PMR2T_P20_Pos)
+#define GPIO_PMR2T_P20              (_U_(0x1) << GPIO_PMR2T_P20_Pos)
 #define GPIO_PMR2T_P21_Pos          21           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P21              (_U(0x1) << GPIO_PMR2T_P21_Pos)
+#define GPIO_PMR2T_P21              (_U_(0x1) << GPIO_PMR2T_P21_Pos)
 #define GPIO_PMR2T_P22_Pos          22           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P22              (_U(0x1) << GPIO_PMR2T_P22_Pos)
+#define GPIO_PMR2T_P22              (_U_(0x1) << GPIO_PMR2T_P22_Pos)
 #define GPIO_PMR2T_P23_Pos          23           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P23              (_U(0x1) << GPIO_PMR2T_P23_Pos)
+#define GPIO_PMR2T_P23              (_U_(0x1) << GPIO_PMR2T_P23_Pos)
 #define GPIO_PMR2T_P24_Pos          24           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P24              (_U(0x1) << GPIO_PMR2T_P24_Pos)
+#define GPIO_PMR2T_P24              (_U_(0x1) << GPIO_PMR2T_P24_Pos)
 #define GPIO_PMR2T_P25_Pos          25           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P25              (_U(0x1) << GPIO_PMR2T_P25_Pos)
+#define GPIO_PMR2T_P25              (_U_(0x1) << GPIO_PMR2T_P25_Pos)
 #define GPIO_PMR2T_P26_Pos          26           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P26              (_U(0x1) << GPIO_PMR2T_P26_Pos)
+#define GPIO_PMR2T_P26              (_U_(0x1) << GPIO_PMR2T_P26_Pos)
 #define GPIO_PMR2T_P27_Pos          27           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P27              (_U(0x1) << GPIO_PMR2T_P27_Pos)
+#define GPIO_PMR2T_P27              (_U_(0x1) << GPIO_PMR2T_P27_Pos)
 #define GPIO_PMR2T_P28_Pos          28           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P28              (_U(0x1) << GPIO_PMR2T_P28_Pos)
+#define GPIO_PMR2T_P28              (_U_(0x1) << GPIO_PMR2T_P28_Pos)
 #define GPIO_PMR2T_P29_Pos          29           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P29              (_U(0x1) << GPIO_PMR2T_P29_Pos)
+#define GPIO_PMR2T_P29              (_U_(0x1) << GPIO_PMR2T_P29_Pos)
 #define GPIO_PMR2T_P30_Pos          30           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P30              (_U(0x1) << GPIO_PMR2T_P30_Pos)
+#define GPIO_PMR2T_P30              (_U_(0x1) << GPIO_PMR2T_P30_Pos)
 #define GPIO_PMR2T_P31_Pos          31           /**< \brief (GPIO_PMR2T) Peripheral Multiplexer Select bit 2 */
-#define GPIO_PMR2T_P31              (_U(0x1) << GPIO_PMR2T_P31_Pos)
-#define GPIO_PMR2T_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PMR2T) MASK Register */
+#define GPIO_PMR2T_P31              (_U_(0x1) << GPIO_PMR2T_P31_Pos)
+#define GPIO_PMR2T_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_PMR2T) MASK Register */
 
 /* -------- GPIO_ODER : (GPIO Offset: 0x040) (R/W 32) port Output Driver Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1826,70 +1826,70 @@ typedef union {
 #define GPIO_ODER_OFFSET            0x040        /**< \brief (GPIO_ODER offset) Output Driver Enable Register */
 
 #define GPIO_ODER_P0_Pos            0            /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P0                (_U(0x1) << GPIO_ODER_P0_Pos)
+#define GPIO_ODER_P0                (_U_(0x1) << GPIO_ODER_P0_Pos)
 #define GPIO_ODER_P1_Pos            1            /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P1                (_U(0x1) << GPIO_ODER_P1_Pos)
+#define GPIO_ODER_P1                (_U_(0x1) << GPIO_ODER_P1_Pos)
 #define GPIO_ODER_P2_Pos            2            /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P2                (_U(0x1) << GPIO_ODER_P2_Pos)
+#define GPIO_ODER_P2                (_U_(0x1) << GPIO_ODER_P2_Pos)
 #define GPIO_ODER_P3_Pos            3            /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P3                (_U(0x1) << GPIO_ODER_P3_Pos)
+#define GPIO_ODER_P3                (_U_(0x1) << GPIO_ODER_P3_Pos)
 #define GPIO_ODER_P4_Pos            4            /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P4                (_U(0x1) << GPIO_ODER_P4_Pos)
+#define GPIO_ODER_P4                (_U_(0x1) << GPIO_ODER_P4_Pos)
 #define GPIO_ODER_P5_Pos            5            /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P5                (_U(0x1) << GPIO_ODER_P5_Pos)
+#define GPIO_ODER_P5                (_U_(0x1) << GPIO_ODER_P5_Pos)
 #define GPIO_ODER_P6_Pos            6            /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P6                (_U(0x1) << GPIO_ODER_P6_Pos)
+#define GPIO_ODER_P6                (_U_(0x1) << GPIO_ODER_P6_Pos)
 #define GPIO_ODER_P7_Pos            7            /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P7                (_U(0x1) << GPIO_ODER_P7_Pos)
+#define GPIO_ODER_P7                (_U_(0x1) << GPIO_ODER_P7_Pos)
 #define GPIO_ODER_P8_Pos            8            /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P8                (_U(0x1) << GPIO_ODER_P8_Pos)
+#define GPIO_ODER_P8                (_U_(0x1) << GPIO_ODER_P8_Pos)
 #define GPIO_ODER_P9_Pos            9            /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P9                (_U(0x1) << GPIO_ODER_P9_Pos)
+#define GPIO_ODER_P9                (_U_(0x1) << GPIO_ODER_P9_Pos)
 #define GPIO_ODER_P10_Pos           10           /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P10               (_U(0x1) << GPIO_ODER_P10_Pos)
+#define GPIO_ODER_P10               (_U_(0x1) << GPIO_ODER_P10_Pos)
 #define GPIO_ODER_P11_Pos           11           /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P11               (_U(0x1) << GPIO_ODER_P11_Pos)
+#define GPIO_ODER_P11               (_U_(0x1) << GPIO_ODER_P11_Pos)
 #define GPIO_ODER_P12_Pos           12           /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P12               (_U(0x1) << GPIO_ODER_P12_Pos)
+#define GPIO_ODER_P12               (_U_(0x1) << GPIO_ODER_P12_Pos)
 #define GPIO_ODER_P13_Pos           13           /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P13               (_U(0x1) << GPIO_ODER_P13_Pos)
+#define GPIO_ODER_P13               (_U_(0x1) << GPIO_ODER_P13_Pos)
 #define GPIO_ODER_P14_Pos           14           /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P14               (_U(0x1) << GPIO_ODER_P14_Pos)
+#define GPIO_ODER_P14               (_U_(0x1) << GPIO_ODER_P14_Pos)
 #define GPIO_ODER_P15_Pos           15           /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P15               (_U(0x1) << GPIO_ODER_P15_Pos)
+#define GPIO_ODER_P15               (_U_(0x1) << GPIO_ODER_P15_Pos)
 #define GPIO_ODER_P16_Pos           16           /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P16               (_U(0x1) << GPIO_ODER_P16_Pos)
+#define GPIO_ODER_P16               (_U_(0x1) << GPIO_ODER_P16_Pos)
 #define GPIO_ODER_P17_Pos           17           /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P17               (_U(0x1) << GPIO_ODER_P17_Pos)
+#define GPIO_ODER_P17               (_U_(0x1) << GPIO_ODER_P17_Pos)
 #define GPIO_ODER_P18_Pos           18           /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P18               (_U(0x1) << GPIO_ODER_P18_Pos)
+#define GPIO_ODER_P18               (_U_(0x1) << GPIO_ODER_P18_Pos)
 #define GPIO_ODER_P19_Pos           19           /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P19               (_U(0x1) << GPIO_ODER_P19_Pos)
+#define GPIO_ODER_P19               (_U_(0x1) << GPIO_ODER_P19_Pos)
 #define GPIO_ODER_P20_Pos           20           /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P20               (_U(0x1) << GPIO_ODER_P20_Pos)
+#define GPIO_ODER_P20               (_U_(0x1) << GPIO_ODER_P20_Pos)
 #define GPIO_ODER_P21_Pos           21           /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P21               (_U(0x1) << GPIO_ODER_P21_Pos)
+#define GPIO_ODER_P21               (_U_(0x1) << GPIO_ODER_P21_Pos)
 #define GPIO_ODER_P22_Pos           22           /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P22               (_U(0x1) << GPIO_ODER_P22_Pos)
+#define GPIO_ODER_P22               (_U_(0x1) << GPIO_ODER_P22_Pos)
 #define GPIO_ODER_P23_Pos           23           /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P23               (_U(0x1) << GPIO_ODER_P23_Pos)
+#define GPIO_ODER_P23               (_U_(0x1) << GPIO_ODER_P23_Pos)
 #define GPIO_ODER_P24_Pos           24           /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P24               (_U(0x1) << GPIO_ODER_P24_Pos)
+#define GPIO_ODER_P24               (_U_(0x1) << GPIO_ODER_P24_Pos)
 #define GPIO_ODER_P25_Pos           25           /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P25               (_U(0x1) << GPIO_ODER_P25_Pos)
+#define GPIO_ODER_P25               (_U_(0x1) << GPIO_ODER_P25_Pos)
 #define GPIO_ODER_P26_Pos           26           /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P26               (_U(0x1) << GPIO_ODER_P26_Pos)
+#define GPIO_ODER_P26               (_U_(0x1) << GPIO_ODER_P26_Pos)
 #define GPIO_ODER_P27_Pos           27           /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P27               (_U(0x1) << GPIO_ODER_P27_Pos)
+#define GPIO_ODER_P27               (_U_(0x1) << GPIO_ODER_P27_Pos)
 #define GPIO_ODER_P28_Pos           28           /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P28               (_U(0x1) << GPIO_ODER_P28_Pos)
+#define GPIO_ODER_P28               (_U_(0x1) << GPIO_ODER_P28_Pos)
 #define GPIO_ODER_P29_Pos           29           /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P29               (_U(0x1) << GPIO_ODER_P29_Pos)
+#define GPIO_ODER_P29               (_U_(0x1) << GPIO_ODER_P29_Pos)
 #define GPIO_ODER_P30_Pos           30           /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P30               (_U(0x1) << GPIO_ODER_P30_Pos)
+#define GPIO_ODER_P30               (_U_(0x1) << GPIO_ODER_P30_Pos)
 #define GPIO_ODER_P31_Pos           31           /**< \brief (GPIO_ODER) Output Driver Enable */
-#define GPIO_ODER_P31               (_U(0x1) << GPIO_ODER_P31_Pos)
-#define GPIO_ODER_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_ODER) MASK Register */
+#define GPIO_ODER_P31               (_U_(0x1) << GPIO_ODER_P31_Pos)
+#define GPIO_ODER_MASK              _U_(0xFFFFFFFF) /**< \brief (GPIO_ODER) MASK Register */
 
 /* -------- GPIO_ODERS : (GPIO Offset: 0x044) ( /W 32) port Output Driver Enable Register - Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1935,70 +1935,70 @@ typedef union {
 #define GPIO_ODERS_OFFSET           0x044        /**< \brief (GPIO_ODERS offset) Output Driver Enable Register - Set */
 
 #define GPIO_ODERS_P0_Pos           0            /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P0               (_U(0x1) << GPIO_ODERS_P0_Pos)
+#define GPIO_ODERS_P0               (_U_(0x1) << GPIO_ODERS_P0_Pos)
 #define GPIO_ODERS_P1_Pos           1            /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P1               (_U(0x1) << GPIO_ODERS_P1_Pos)
+#define GPIO_ODERS_P1               (_U_(0x1) << GPIO_ODERS_P1_Pos)
 #define GPIO_ODERS_P2_Pos           2            /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P2               (_U(0x1) << GPIO_ODERS_P2_Pos)
+#define GPIO_ODERS_P2               (_U_(0x1) << GPIO_ODERS_P2_Pos)
 #define GPIO_ODERS_P3_Pos           3            /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P3               (_U(0x1) << GPIO_ODERS_P3_Pos)
+#define GPIO_ODERS_P3               (_U_(0x1) << GPIO_ODERS_P3_Pos)
 #define GPIO_ODERS_P4_Pos           4            /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P4               (_U(0x1) << GPIO_ODERS_P4_Pos)
+#define GPIO_ODERS_P4               (_U_(0x1) << GPIO_ODERS_P4_Pos)
 #define GPIO_ODERS_P5_Pos           5            /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P5               (_U(0x1) << GPIO_ODERS_P5_Pos)
+#define GPIO_ODERS_P5               (_U_(0x1) << GPIO_ODERS_P5_Pos)
 #define GPIO_ODERS_P6_Pos           6            /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P6               (_U(0x1) << GPIO_ODERS_P6_Pos)
+#define GPIO_ODERS_P6               (_U_(0x1) << GPIO_ODERS_P6_Pos)
 #define GPIO_ODERS_P7_Pos           7            /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P7               (_U(0x1) << GPIO_ODERS_P7_Pos)
+#define GPIO_ODERS_P7               (_U_(0x1) << GPIO_ODERS_P7_Pos)
 #define GPIO_ODERS_P8_Pos           8            /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P8               (_U(0x1) << GPIO_ODERS_P8_Pos)
+#define GPIO_ODERS_P8               (_U_(0x1) << GPIO_ODERS_P8_Pos)
 #define GPIO_ODERS_P9_Pos           9            /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P9               (_U(0x1) << GPIO_ODERS_P9_Pos)
+#define GPIO_ODERS_P9               (_U_(0x1) << GPIO_ODERS_P9_Pos)
 #define GPIO_ODERS_P10_Pos          10           /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P10              (_U(0x1) << GPIO_ODERS_P10_Pos)
+#define GPIO_ODERS_P10              (_U_(0x1) << GPIO_ODERS_P10_Pos)
 #define GPIO_ODERS_P11_Pos          11           /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P11              (_U(0x1) << GPIO_ODERS_P11_Pos)
+#define GPIO_ODERS_P11              (_U_(0x1) << GPIO_ODERS_P11_Pos)
 #define GPIO_ODERS_P12_Pos          12           /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P12              (_U(0x1) << GPIO_ODERS_P12_Pos)
+#define GPIO_ODERS_P12              (_U_(0x1) << GPIO_ODERS_P12_Pos)
 #define GPIO_ODERS_P13_Pos          13           /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P13              (_U(0x1) << GPIO_ODERS_P13_Pos)
+#define GPIO_ODERS_P13              (_U_(0x1) << GPIO_ODERS_P13_Pos)
 #define GPIO_ODERS_P14_Pos          14           /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P14              (_U(0x1) << GPIO_ODERS_P14_Pos)
+#define GPIO_ODERS_P14              (_U_(0x1) << GPIO_ODERS_P14_Pos)
 #define GPIO_ODERS_P15_Pos          15           /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P15              (_U(0x1) << GPIO_ODERS_P15_Pos)
+#define GPIO_ODERS_P15              (_U_(0x1) << GPIO_ODERS_P15_Pos)
 #define GPIO_ODERS_P16_Pos          16           /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P16              (_U(0x1) << GPIO_ODERS_P16_Pos)
+#define GPIO_ODERS_P16              (_U_(0x1) << GPIO_ODERS_P16_Pos)
 #define GPIO_ODERS_P17_Pos          17           /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P17              (_U(0x1) << GPIO_ODERS_P17_Pos)
+#define GPIO_ODERS_P17              (_U_(0x1) << GPIO_ODERS_P17_Pos)
 #define GPIO_ODERS_P18_Pos          18           /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P18              (_U(0x1) << GPIO_ODERS_P18_Pos)
+#define GPIO_ODERS_P18              (_U_(0x1) << GPIO_ODERS_P18_Pos)
 #define GPIO_ODERS_P19_Pos          19           /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P19              (_U(0x1) << GPIO_ODERS_P19_Pos)
+#define GPIO_ODERS_P19              (_U_(0x1) << GPIO_ODERS_P19_Pos)
 #define GPIO_ODERS_P20_Pos          20           /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P20              (_U(0x1) << GPIO_ODERS_P20_Pos)
+#define GPIO_ODERS_P20              (_U_(0x1) << GPIO_ODERS_P20_Pos)
 #define GPIO_ODERS_P21_Pos          21           /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P21              (_U(0x1) << GPIO_ODERS_P21_Pos)
+#define GPIO_ODERS_P21              (_U_(0x1) << GPIO_ODERS_P21_Pos)
 #define GPIO_ODERS_P22_Pos          22           /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P22              (_U(0x1) << GPIO_ODERS_P22_Pos)
+#define GPIO_ODERS_P22              (_U_(0x1) << GPIO_ODERS_P22_Pos)
 #define GPIO_ODERS_P23_Pos          23           /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P23              (_U(0x1) << GPIO_ODERS_P23_Pos)
+#define GPIO_ODERS_P23              (_U_(0x1) << GPIO_ODERS_P23_Pos)
 #define GPIO_ODERS_P24_Pos          24           /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P24              (_U(0x1) << GPIO_ODERS_P24_Pos)
+#define GPIO_ODERS_P24              (_U_(0x1) << GPIO_ODERS_P24_Pos)
 #define GPIO_ODERS_P25_Pos          25           /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P25              (_U(0x1) << GPIO_ODERS_P25_Pos)
+#define GPIO_ODERS_P25              (_U_(0x1) << GPIO_ODERS_P25_Pos)
 #define GPIO_ODERS_P26_Pos          26           /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P26              (_U(0x1) << GPIO_ODERS_P26_Pos)
+#define GPIO_ODERS_P26              (_U_(0x1) << GPIO_ODERS_P26_Pos)
 #define GPIO_ODERS_P27_Pos          27           /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P27              (_U(0x1) << GPIO_ODERS_P27_Pos)
+#define GPIO_ODERS_P27              (_U_(0x1) << GPIO_ODERS_P27_Pos)
 #define GPIO_ODERS_P28_Pos          28           /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P28              (_U(0x1) << GPIO_ODERS_P28_Pos)
+#define GPIO_ODERS_P28              (_U_(0x1) << GPIO_ODERS_P28_Pos)
 #define GPIO_ODERS_P29_Pos          29           /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P29              (_U(0x1) << GPIO_ODERS_P29_Pos)
+#define GPIO_ODERS_P29              (_U_(0x1) << GPIO_ODERS_P29_Pos)
 #define GPIO_ODERS_P30_Pos          30           /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P30              (_U(0x1) << GPIO_ODERS_P30_Pos)
+#define GPIO_ODERS_P30              (_U_(0x1) << GPIO_ODERS_P30_Pos)
 #define GPIO_ODERS_P31_Pos          31           /**< \brief (GPIO_ODERS) Output Driver Enable */
-#define GPIO_ODERS_P31              (_U(0x1) << GPIO_ODERS_P31_Pos)
-#define GPIO_ODERS_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_ODERS) MASK Register */
+#define GPIO_ODERS_P31              (_U_(0x1) << GPIO_ODERS_P31_Pos)
+#define GPIO_ODERS_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_ODERS) MASK Register */
 
 /* -------- GPIO_ODERC : (GPIO Offset: 0x048) ( /W 32) port Output Driver Enable Register - Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -2044,70 +2044,70 @@ typedef union {
 #define GPIO_ODERC_OFFSET           0x048        /**< \brief (GPIO_ODERC offset) Output Driver Enable Register - Clear */
 
 #define GPIO_ODERC_P0_Pos           0            /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P0               (_U(0x1) << GPIO_ODERC_P0_Pos)
+#define GPIO_ODERC_P0               (_U_(0x1) << GPIO_ODERC_P0_Pos)
 #define GPIO_ODERC_P1_Pos           1            /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P1               (_U(0x1) << GPIO_ODERC_P1_Pos)
+#define GPIO_ODERC_P1               (_U_(0x1) << GPIO_ODERC_P1_Pos)
 #define GPIO_ODERC_P2_Pos           2            /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P2               (_U(0x1) << GPIO_ODERC_P2_Pos)
+#define GPIO_ODERC_P2               (_U_(0x1) << GPIO_ODERC_P2_Pos)
 #define GPIO_ODERC_P3_Pos           3            /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P3               (_U(0x1) << GPIO_ODERC_P3_Pos)
+#define GPIO_ODERC_P3               (_U_(0x1) << GPIO_ODERC_P3_Pos)
 #define GPIO_ODERC_P4_Pos           4            /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P4               (_U(0x1) << GPIO_ODERC_P4_Pos)
+#define GPIO_ODERC_P4               (_U_(0x1) << GPIO_ODERC_P4_Pos)
 #define GPIO_ODERC_P5_Pos           5            /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P5               (_U(0x1) << GPIO_ODERC_P5_Pos)
+#define GPIO_ODERC_P5               (_U_(0x1) << GPIO_ODERC_P5_Pos)
 #define GPIO_ODERC_P6_Pos           6            /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P6               (_U(0x1) << GPIO_ODERC_P6_Pos)
+#define GPIO_ODERC_P6               (_U_(0x1) << GPIO_ODERC_P6_Pos)
 #define GPIO_ODERC_P7_Pos           7            /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P7               (_U(0x1) << GPIO_ODERC_P7_Pos)
+#define GPIO_ODERC_P7               (_U_(0x1) << GPIO_ODERC_P7_Pos)
 #define GPIO_ODERC_P8_Pos           8            /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P8               (_U(0x1) << GPIO_ODERC_P8_Pos)
+#define GPIO_ODERC_P8               (_U_(0x1) << GPIO_ODERC_P8_Pos)
 #define GPIO_ODERC_P9_Pos           9            /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P9               (_U(0x1) << GPIO_ODERC_P9_Pos)
+#define GPIO_ODERC_P9               (_U_(0x1) << GPIO_ODERC_P9_Pos)
 #define GPIO_ODERC_P10_Pos          10           /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P10              (_U(0x1) << GPIO_ODERC_P10_Pos)
+#define GPIO_ODERC_P10              (_U_(0x1) << GPIO_ODERC_P10_Pos)
 #define GPIO_ODERC_P11_Pos          11           /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P11              (_U(0x1) << GPIO_ODERC_P11_Pos)
+#define GPIO_ODERC_P11              (_U_(0x1) << GPIO_ODERC_P11_Pos)
 #define GPIO_ODERC_P12_Pos          12           /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P12              (_U(0x1) << GPIO_ODERC_P12_Pos)
+#define GPIO_ODERC_P12              (_U_(0x1) << GPIO_ODERC_P12_Pos)
 #define GPIO_ODERC_P13_Pos          13           /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P13              (_U(0x1) << GPIO_ODERC_P13_Pos)
+#define GPIO_ODERC_P13              (_U_(0x1) << GPIO_ODERC_P13_Pos)
 #define GPIO_ODERC_P14_Pos          14           /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P14              (_U(0x1) << GPIO_ODERC_P14_Pos)
+#define GPIO_ODERC_P14              (_U_(0x1) << GPIO_ODERC_P14_Pos)
 #define GPIO_ODERC_P15_Pos          15           /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P15              (_U(0x1) << GPIO_ODERC_P15_Pos)
+#define GPIO_ODERC_P15              (_U_(0x1) << GPIO_ODERC_P15_Pos)
 #define GPIO_ODERC_P16_Pos          16           /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P16              (_U(0x1) << GPIO_ODERC_P16_Pos)
+#define GPIO_ODERC_P16              (_U_(0x1) << GPIO_ODERC_P16_Pos)
 #define GPIO_ODERC_P17_Pos          17           /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P17              (_U(0x1) << GPIO_ODERC_P17_Pos)
+#define GPIO_ODERC_P17              (_U_(0x1) << GPIO_ODERC_P17_Pos)
 #define GPIO_ODERC_P18_Pos          18           /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P18              (_U(0x1) << GPIO_ODERC_P18_Pos)
+#define GPIO_ODERC_P18              (_U_(0x1) << GPIO_ODERC_P18_Pos)
 #define GPIO_ODERC_P19_Pos          19           /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P19              (_U(0x1) << GPIO_ODERC_P19_Pos)
+#define GPIO_ODERC_P19              (_U_(0x1) << GPIO_ODERC_P19_Pos)
 #define GPIO_ODERC_P20_Pos          20           /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P20              (_U(0x1) << GPIO_ODERC_P20_Pos)
+#define GPIO_ODERC_P20              (_U_(0x1) << GPIO_ODERC_P20_Pos)
 #define GPIO_ODERC_P21_Pos          21           /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P21              (_U(0x1) << GPIO_ODERC_P21_Pos)
+#define GPIO_ODERC_P21              (_U_(0x1) << GPIO_ODERC_P21_Pos)
 #define GPIO_ODERC_P22_Pos          22           /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P22              (_U(0x1) << GPIO_ODERC_P22_Pos)
+#define GPIO_ODERC_P22              (_U_(0x1) << GPIO_ODERC_P22_Pos)
 #define GPIO_ODERC_P23_Pos          23           /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P23              (_U(0x1) << GPIO_ODERC_P23_Pos)
+#define GPIO_ODERC_P23              (_U_(0x1) << GPIO_ODERC_P23_Pos)
 #define GPIO_ODERC_P24_Pos          24           /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P24              (_U(0x1) << GPIO_ODERC_P24_Pos)
+#define GPIO_ODERC_P24              (_U_(0x1) << GPIO_ODERC_P24_Pos)
 #define GPIO_ODERC_P25_Pos          25           /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P25              (_U(0x1) << GPIO_ODERC_P25_Pos)
+#define GPIO_ODERC_P25              (_U_(0x1) << GPIO_ODERC_P25_Pos)
 #define GPIO_ODERC_P26_Pos          26           /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P26              (_U(0x1) << GPIO_ODERC_P26_Pos)
+#define GPIO_ODERC_P26              (_U_(0x1) << GPIO_ODERC_P26_Pos)
 #define GPIO_ODERC_P27_Pos          27           /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P27              (_U(0x1) << GPIO_ODERC_P27_Pos)
+#define GPIO_ODERC_P27              (_U_(0x1) << GPIO_ODERC_P27_Pos)
 #define GPIO_ODERC_P28_Pos          28           /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P28              (_U(0x1) << GPIO_ODERC_P28_Pos)
+#define GPIO_ODERC_P28              (_U_(0x1) << GPIO_ODERC_P28_Pos)
 #define GPIO_ODERC_P29_Pos          29           /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P29              (_U(0x1) << GPIO_ODERC_P29_Pos)
+#define GPIO_ODERC_P29              (_U_(0x1) << GPIO_ODERC_P29_Pos)
 #define GPIO_ODERC_P30_Pos          30           /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P30              (_U(0x1) << GPIO_ODERC_P30_Pos)
+#define GPIO_ODERC_P30              (_U_(0x1) << GPIO_ODERC_P30_Pos)
 #define GPIO_ODERC_P31_Pos          31           /**< \brief (GPIO_ODERC) Output Driver Enable */
-#define GPIO_ODERC_P31              (_U(0x1) << GPIO_ODERC_P31_Pos)
-#define GPIO_ODERC_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_ODERC) MASK Register */
+#define GPIO_ODERC_P31              (_U_(0x1) << GPIO_ODERC_P31_Pos)
+#define GPIO_ODERC_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_ODERC) MASK Register */
 
 /* -------- GPIO_ODERT : (GPIO Offset: 0x04C) ( /W 32) port Output Driver Enable Register - Toggle -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -2153,70 +2153,70 @@ typedef union {
 #define GPIO_ODERT_OFFSET           0x04C        /**< \brief (GPIO_ODERT offset) Output Driver Enable Register - Toggle */
 
 #define GPIO_ODERT_P0_Pos           0            /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P0               (_U(0x1) << GPIO_ODERT_P0_Pos)
+#define GPIO_ODERT_P0               (_U_(0x1) << GPIO_ODERT_P0_Pos)
 #define GPIO_ODERT_P1_Pos           1            /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P1               (_U(0x1) << GPIO_ODERT_P1_Pos)
+#define GPIO_ODERT_P1               (_U_(0x1) << GPIO_ODERT_P1_Pos)
 #define GPIO_ODERT_P2_Pos           2            /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P2               (_U(0x1) << GPIO_ODERT_P2_Pos)
+#define GPIO_ODERT_P2               (_U_(0x1) << GPIO_ODERT_P2_Pos)
 #define GPIO_ODERT_P3_Pos           3            /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P3               (_U(0x1) << GPIO_ODERT_P3_Pos)
+#define GPIO_ODERT_P3               (_U_(0x1) << GPIO_ODERT_P3_Pos)
 #define GPIO_ODERT_P4_Pos           4            /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P4               (_U(0x1) << GPIO_ODERT_P4_Pos)
+#define GPIO_ODERT_P4               (_U_(0x1) << GPIO_ODERT_P4_Pos)
 #define GPIO_ODERT_P5_Pos           5            /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P5               (_U(0x1) << GPIO_ODERT_P5_Pos)
+#define GPIO_ODERT_P5               (_U_(0x1) << GPIO_ODERT_P5_Pos)
 #define GPIO_ODERT_P6_Pos           6            /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P6               (_U(0x1) << GPIO_ODERT_P6_Pos)
+#define GPIO_ODERT_P6               (_U_(0x1) << GPIO_ODERT_P6_Pos)
 #define GPIO_ODERT_P7_Pos           7            /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P7               (_U(0x1) << GPIO_ODERT_P7_Pos)
+#define GPIO_ODERT_P7               (_U_(0x1) << GPIO_ODERT_P7_Pos)
 #define GPIO_ODERT_P8_Pos           8            /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P8               (_U(0x1) << GPIO_ODERT_P8_Pos)
+#define GPIO_ODERT_P8               (_U_(0x1) << GPIO_ODERT_P8_Pos)
 #define GPIO_ODERT_P9_Pos           9            /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P9               (_U(0x1) << GPIO_ODERT_P9_Pos)
+#define GPIO_ODERT_P9               (_U_(0x1) << GPIO_ODERT_P9_Pos)
 #define GPIO_ODERT_P10_Pos          10           /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P10              (_U(0x1) << GPIO_ODERT_P10_Pos)
+#define GPIO_ODERT_P10              (_U_(0x1) << GPIO_ODERT_P10_Pos)
 #define GPIO_ODERT_P11_Pos          11           /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P11              (_U(0x1) << GPIO_ODERT_P11_Pos)
+#define GPIO_ODERT_P11              (_U_(0x1) << GPIO_ODERT_P11_Pos)
 #define GPIO_ODERT_P12_Pos          12           /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P12              (_U(0x1) << GPIO_ODERT_P12_Pos)
+#define GPIO_ODERT_P12              (_U_(0x1) << GPIO_ODERT_P12_Pos)
 #define GPIO_ODERT_P13_Pos          13           /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P13              (_U(0x1) << GPIO_ODERT_P13_Pos)
+#define GPIO_ODERT_P13              (_U_(0x1) << GPIO_ODERT_P13_Pos)
 #define GPIO_ODERT_P14_Pos          14           /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P14              (_U(0x1) << GPIO_ODERT_P14_Pos)
+#define GPIO_ODERT_P14              (_U_(0x1) << GPIO_ODERT_P14_Pos)
 #define GPIO_ODERT_P15_Pos          15           /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P15              (_U(0x1) << GPIO_ODERT_P15_Pos)
+#define GPIO_ODERT_P15              (_U_(0x1) << GPIO_ODERT_P15_Pos)
 #define GPIO_ODERT_P16_Pos          16           /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P16              (_U(0x1) << GPIO_ODERT_P16_Pos)
+#define GPIO_ODERT_P16              (_U_(0x1) << GPIO_ODERT_P16_Pos)
 #define GPIO_ODERT_P17_Pos          17           /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P17              (_U(0x1) << GPIO_ODERT_P17_Pos)
+#define GPIO_ODERT_P17              (_U_(0x1) << GPIO_ODERT_P17_Pos)
 #define GPIO_ODERT_P18_Pos          18           /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P18              (_U(0x1) << GPIO_ODERT_P18_Pos)
+#define GPIO_ODERT_P18              (_U_(0x1) << GPIO_ODERT_P18_Pos)
 #define GPIO_ODERT_P19_Pos          19           /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P19              (_U(0x1) << GPIO_ODERT_P19_Pos)
+#define GPIO_ODERT_P19              (_U_(0x1) << GPIO_ODERT_P19_Pos)
 #define GPIO_ODERT_P20_Pos          20           /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P20              (_U(0x1) << GPIO_ODERT_P20_Pos)
+#define GPIO_ODERT_P20              (_U_(0x1) << GPIO_ODERT_P20_Pos)
 #define GPIO_ODERT_P21_Pos          21           /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P21              (_U(0x1) << GPIO_ODERT_P21_Pos)
+#define GPIO_ODERT_P21              (_U_(0x1) << GPIO_ODERT_P21_Pos)
 #define GPIO_ODERT_P22_Pos          22           /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P22              (_U(0x1) << GPIO_ODERT_P22_Pos)
+#define GPIO_ODERT_P22              (_U_(0x1) << GPIO_ODERT_P22_Pos)
 #define GPIO_ODERT_P23_Pos          23           /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P23              (_U(0x1) << GPIO_ODERT_P23_Pos)
+#define GPIO_ODERT_P23              (_U_(0x1) << GPIO_ODERT_P23_Pos)
 #define GPIO_ODERT_P24_Pos          24           /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P24              (_U(0x1) << GPIO_ODERT_P24_Pos)
+#define GPIO_ODERT_P24              (_U_(0x1) << GPIO_ODERT_P24_Pos)
 #define GPIO_ODERT_P25_Pos          25           /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P25              (_U(0x1) << GPIO_ODERT_P25_Pos)
+#define GPIO_ODERT_P25              (_U_(0x1) << GPIO_ODERT_P25_Pos)
 #define GPIO_ODERT_P26_Pos          26           /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P26              (_U(0x1) << GPIO_ODERT_P26_Pos)
+#define GPIO_ODERT_P26              (_U_(0x1) << GPIO_ODERT_P26_Pos)
 #define GPIO_ODERT_P27_Pos          27           /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P27              (_U(0x1) << GPIO_ODERT_P27_Pos)
+#define GPIO_ODERT_P27              (_U_(0x1) << GPIO_ODERT_P27_Pos)
 #define GPIO_ODERT_P28_Pos          28           /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P28              (_U(0x1) << GPIO_ODERT_P28_Pos)
+#define GPIO_ODERT_P28              (_U_(0x1) << GPIO_ODERT_P28_Pos)
 #define GPIO_ODERT_P29_Pos          29           /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P29              (_U(0x1) << GPIO_ODERT_P29_Pos)
+#define GPIO_ODERT_P29              (_U_(0x1) << GPIO_ODERT_P29_Pos)
 #define GPIO_ODERT_P30_Pos          30           /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P30              (_U(0x1) << GPIO_ODERT_P30_Pos)
+#define GPIO_ODERT_P30              (_U_(0x1) << GPIO_ODERT_P30_Pos)
 #define GPIO_ODERT_P31_Pos          31           /**< \brief (GPIO_ODERT) Output Driver Enable */
-#define GPIO_ODERT_P31              (_U(0x1) << GPIO_ODERT_P31_Pos)
-#define GPIO_ODERT_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_ODERT) MASK Register */
+#define GPIO_ODERT_P31              (_U_(0x1) << GPIO_ODERT_P31_Pos)
+#define GPIO_ODERT_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_ODERT) MASK Register */
 
 /* -------- GPIO_OVR : (GPIO Offset: 0x050) (R/W 32) port Output Value Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -2262,70 +2262,70 @@ typedef union {
 #define GPIO_OVR_OFFSET             0x050        /**< \brief (GPIO_OVR offset) Output Value Register */
 
 #define GPIO_OVR_P0_Pos             0            /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P0                 (_U(0x1) << GPIO_OVR_P0_Pos)
+#define GPIO_OVR_P0                 (_U_(0x1) << GPIO_OVR_P0_Pos)
 #define GPIO_OVR_P1_Pos             1            /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P1                 (_U(0x1) << GPIO_OVR_P1_Pos)
+#define GPIO_OVR_P1                 (_U_(0x1) << GPIO_OVR_P1_Pos)
 #define GPIO_OVR_P2_Pos             2            /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P2                 (_U(0x1) << GPIO_OVR_P2_Pos)
+#define GPIO_OVR_P2                 (_U_(0x1) << GPIO_OVR_P2_Pos)
 #define GPIO_OVR_P3_Pos             3            /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P3                 (_U(0x1) << GPIO_OVR_P3_Pos)
+#define GPIO_OVR_P3                 (_U_(0x1) << GPIO_OVR_P3_Pos)
 #define GPIO_OVR_P4_Pos             4            /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P4                 (_U(0x1) << GPIO_OVR_P4_Pos)
+#define GPIO_OVR_P4                 (_U_(0x1) << GPIO_OVR_P4_Pos)
 #define GPIO_OVR_P5_Pos             5            /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P5                 (_U(0x1) << GPIO_OVR_P5_Pos)
+#define GPIO_OVR_P5                 (_U_(0x1) << GPIO_OVR_P5_Pos)
 #define GPIO_OVR_P6_Pos             6            /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P6                 (_U(0x1) << GPIO_OVR_P6_Pos)
+#define GPIO_OVR_P6                 (_U_(0x1) << GPIO_OVR_P6_Pos)
 #define GPIO_OVR_P7_Pos             7            /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P7                 (_U(0x1) << GPIO_OVR_P7_Pos)
+#define GPIO_OVR_P7                 (_U_(0x1) << GPIO_OVR_P7_Pos)
 #define GPIO_OVR_P8_Pos             8            /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P8                 (_U(0x1) << GPIO_OVR_P8_Pos)
+#define GPIO_OVR_P8                 (_U_(0x1) << GPIO_OVR_P8_Pos)
 #define GPIO_OVR_P9_Pos             9            /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P9                 (_U(0x1) << GPIO_OVR_P9_Pos)
+#define GPIO_OVR_P9                 (_U_(0x1) << GPIO_OVR_P9_Pos)
 #define GPIO_OVR_P10_Pos            10           /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P10                (_U(0x1) << GPIO_OVR_P10_Pos)
+#define GPIO_OVR_P10                (_U_(0x1) << GPIO_OVR_P10_Pos)
 #define GPIO_OVR_P11_Pos            11           /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P11                (_U(0x1) << GPIO_OVR_P11_Pos)
+#define GPIO_OVR_P11                (_U_(0x1) << GPIO_OVR_P11_Pos)
 #define GPIO_OVR_P12_Pos            12           /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P12                (_U(0x1) << GPIO_OVR_P12_Pos)
+#define GPIO_OVR_P12                (_U_(0x1) << GPIO_OVR_P12_Pos)
 #define GPIO_OVR_P13_Pos            13           /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P13                (_U(0x1) << GPIO_OVR_P13_Pos)
+#define GPIO_OVR_P13                (_U_(0x1) << GPIO_OVR_P13_Pos)
 #define GPIO_OVR_P14_Pos            14           /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P14                (_U(0x1) << GPIO_OVR_P14_Pos)
+#define GPIO_OVR_P14                (_U_(0x1) << GPIO_OVR_P14_Pos)
 #define GPIO_OVR_P15_Pos            15           /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P15                (_U(0x1) << GPIO_OVR_P15_Pos)
+#define GPIO_OVR_P15                (_U_(0x1) << GPIO_OVR_P15_Pos)
 #define GPIO_OVR_P16_Pos            16           /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P16                (_U(0x1) << GPIO_OVR_P16_Pos)
+#define GPIO_OVR_P16                (_U_(0x1) << GPIO_OVR_P16_Pos)
 #define GPIO_OVR_P17_Pos            17           /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P17                (_U(0x1) << GPIO_OVR_P17_Pos)
+#define GPIO_OVR_P17                (_U_(0x1) << GPIO_OVR_P17_Pos)
 #define GPIO_OVR_P18_Pos            18           /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P18                (_U(0x1) << GPIO_OVR_P18_Pos)
+#define GPIO_OVR_P18                (_U_(0x1) << GPIO_OVR_P18_Pos)
 #define GPIO_OVR_P19_Pos            19           /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P19                (_U(0x1) << GPIO_OVR_P19_Pos)
+#define GPIO_OVR_P19                (_U_(0x1) << GPIO_OVR_P19_Pos)
 #define GPIO_OVR_P20_Pos            20           /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P20                (_U(0x1) << GPIO_OVR_P20_Pos)
+#define GPIO_OVR_P20                (_U_(0x1) << GPIO_OVR_P20_Pos)
 #define GPIO_OVR_P21_Pos            21           /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P21                (_U(0x1) << GPIO_OVR_P21_Pos)
+#define GPIO_OVR_P21                (_U_(0x1) << GPIO_OVR_P21_Pos)
 #define GPIO_OVR_P22_Pos            22           /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P22                (_U(0x1) << GPIO_OVR_P22_Pos)
+#define GPIO_OVR_P22                (_U_(0x1) << GPIO_OVR_P22_Pos)
 #define GPIO_OVR_P23_Pos            23           /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P23                (_U(0x1) << GPIO_OVR_P23_Pos)
+#define GPIO_OVR_P23                (_U_(0x1) << GPIO_OVR_P23_Pos)
 #define GPIO_OVR_P24_Pos            24           /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P24                (_U(0x1) << GPIO_OVR_P24_Pos)
+#define GPIO_OVR_P24                (_U_(0x1) << GPIO_OVR_P24_Pos)
 #define GPIO_OVR_P25_Pos            25           /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P25                (_U(0x1) << GPIO_OVR_P25_Pos)
+#define GPIO_OVR_P25                (_U_(0x1) << GPIO_OVR_P25_Pos)
 #define GPIO_OVR_P26_Pos            26           /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P26                (_U(0x1) << GPIO_OVR_P26_Pos)
+#define GPIO_OVR_P26                (_U_(0x1) << GPIO_OVR_P26_Pos)
 #define GPIO_OVR_P27_Pos            27           /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P27                (_U(0x1) << GPIO_OVR_P27_Pos)
+#define GPIO_OVR_P27                (_U_(0x1) << GPIO_OVR_P27_Pos)
 #define GPIO_OVR_P28_Pos            28           /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P28                (_U(0x1) << GPIO_OVR_P28_Pos)
+#define GPIO_OVR_P28                (_U_(0x1) << GPIO_OVR_P28_Pos)
 #define GPIO_OVR_P29_Pos            29           /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P29                (_U(0x1) << GPIO_OVR_P29_Pos)
+#define GPIO_OVR_P29                (_U_(0x1) << GPIO_OVR_P29_Pos)
 #define GPIO_OVR_P30_Pos            30           /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P30                (_U(0x1) << GPIO_OVR_P30_Pos)
+#define GPIO_OVR_P30                (_U_(0x1) << GPIO_OVR_P30_Pos)
 #define GPIO_OVR_P31_Pos            31           /**< \brief (GPIO_OVR) Output Value */
-#define GPIO_OVR_P31                (_U(0x1) << GPIO_OVR_P31_Pos)
-#define GPIO_OVR_MASK               _U(0xFFFFFFFF) /**< \brief (GPIO_OVR) MASK Register */
+#define GPIO_OVR_P31                (_U_(0x1) << GPIO_OVR_P31_Pos)
+#define GPIO_OVR_MASK               _U_(0xFFFFFFFF) /**< \brief (GPIO_OVR) MASK Register */
 
 /* -------- GPIO_OVRS : (GPIO Offset: 0x054) ( /W 32) port Output Value Register - Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -2371,70 +2371,70 @@ typedef union {
 #define GPIO_OVRS_OFFSET            0x054        /**< \brief (GPIO_OVRS offset) Output Value Register - Set */
 
 #define GPIO_OVRS_P0_Pos            0            /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P0                (_U(0x1) << GPIO_OVRS_P0_Pos)
+#define GPIO_OVRS_P0                (_U_(0x1) << GPIO_OVRS_P0_Pos)
 #define GPIO_OVRS_P1_Pos            1            /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P1                (_U(0x1) << GPIO_OVRS_P1_Pos)
+#define GPIO_OVRS_P1                (_U_(0x1) << GPIO_OVRS_P1_Pos)
 #define GPIO_OVRS_P2_Pos            2            /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P2                (_U(0x1) << GPIO_OVRS_P2_Pos)
+#define GPIO_OVRS_P2                (_U_(0x1) << GPIO_OVRS_P2_Pos)
 #define GPIO_OVRS_P3_Pos            3            /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P3                (_U(0x1) << GPIO_OVRS_P3_Pos)
+#define GPIO_OVRS_P3                (_U_(0x1) << GPIO_OVRS_P3_Pos)
 #define GPIO_OVRS_P4_Pos            4            /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P4                (_U(0x1) << GPIO_OVRS_P4_Pos)
+#define GPIO_OVRS_P4                (_U_(0x1) << GPIO_OVRS_P4_Pos)
 #define GPIO_OVRS_P5_Pos            5            /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P5                (_U(0x1) << GPIO_OVRS_P5_Pos)
+#define GPIO_OVRS_P5                (_U_(0x1) << GPIO_OVRS_P5_Pos)
 #define GPIO_OVRS_P6_Pos            6            /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P6                (_U(0x1) << GPIO_OVRS_P6_Pos)
+#define GPIO_OVRS_P6                (_U_(0x1) << GPIO_OVRS_P6_Pos)
 #define GPIO_OVRS_P7_Pos            7            /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P7                (_U(0x1) << GPIO_OVRS_P7_Pos)
+#define GPIO_OVRS_P7                (_U_(0x1) << GPIO_OVRS_P7_Pos)
 #define GPIO_OVRS_P8_Pos            8            /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P8                (_U(0x1) << GPIO_OVRS_P8_Pos)
+#define GPIO_OVRS_P8                (_U_(0x1) << GPIO_OVRS_P8_Pos)
 #define GPIO_OVRS_P9_Pos            9            /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P9                (_U(0x1) << GPIO_OVRS_P9_Pos)
+#define GPIO_OVRS_P9                (_U_(0x1) << GPIO_OVRS_P9_Pos)
 #define GPIO_OVRS_P10_Pos           10           /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P10               (_U(0x1) << GPIO_OVRS_P10_Pos)
+#define GPIO_OVRS_P10               (_U_(0x1) << GPIO_OVRS_P10_Pos)
 #define GPIO_OVRS_P11_Pos           11           /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P11               (_U(0x1) << GPIO_OVRS_P11_Pos)
+#define GPIO_OVRS_P11               (_U_(0x1) << GPIO_OVRS_P11_Pos)
 #define GPIO_OVRS_P12_Pos           12           /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P12               (_U(0x1) << GPIO_OVRS_P12_Pos)
+#define GPIO_OVRS_P12               (_U_(0x1) << GPIO_OVRS_P12_Pos)
 #define GPIO_OVRS_P13_Pos           13           /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P13               (_U(0x1) << GPIO_OVRS_P13_Pos)
+#define GPIO_OVRS_P13               (_U_(0x1) << GPIO_OVRS_P13_Pos)
 #define GPIO_OVRS_P14_Pos           14           /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P14               (_U(0x1) << GPIO_OVRS_P14_Pos)
+#define GPIO_OVRS_P14               (_U_(0x1) << GPIO_OVRS_P14_Pos)
 #define GPIO_OVRS_P15_Pos           15           /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P15               (_U(0x1) << GPIO_OVRS_P15_Pos)
+#define GPIO_OVRS_P15               (_U_(0x1) << GPIO_OVRS_P15_Pos)
 #define GPIO_OVRS_P16_Pos           16           /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P16               (_U(0x1) << GPIO_OVRS_P16_Pos)
+#define GPIO_OVRS_P16               (_U_(0x1) << GPIO_OVRS_P16_Pos)
 #define GPIO_OVRS_P17_Pos           17           /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P17               (_U(0x1) << GPIO_OVRS_P17_Pos)
+#define GPIO_OVRS_P17               (_U_(0x1) << GPIO_OVRS_P17_Pos)
 #define GPIO_OVRS_P18_Pos           18           /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P18               (_U(0x1) << GPIO_OVRS_P18_Pos)
+#define GPIO_OVRS_P18               (_U_(0x1) << GPIO_OVRS_P18_Pos)
 #define GPIO_OVRS_P19_Pos           19           /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P19               (_U(0x1) << GPIO_OVRS_P19_Pos)
+#define GPIO_OVRS_P19               (_U_(0x1) << GPIO_OVRS_P19_Pos)
 #define GPIO_OVRS_P20_Pos           20           /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P20               (_U(0x1) << GPIO_OVRS_P20_Pos)
+#define GPIO_OVRS_P20               (_U_(0x1) << GPIO_OVRS_P20_Pos)
 #define GPIO_OVRS_P21_Pos           21           /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P21               (_U(0x1) << GPIO_OVRS_P21_Pos)
+#define GPIO_OVRS_P21               (_U_(0x1) << GPIO_OVRS_P21_Pos)
 #define GPIO_OVRS_P22_Pos           22           /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P22               (_U(0x1) << GPIO_OVRS_P22_Pos)
+#define GPIO_OVRS_P22               (_U_(0x1) << GPIO_OVRS_P22_Pos)
 #define GPIO_OVRS_P23_Pos           23           /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P23               (_U(0x1) << GPIO_OVRS_P23_Pos)
+#define GPIO_OVRS_P23               (_U_(0x1) << GPIO_OVRS_P23_Pos)
 #define GPIO_OVRS_P24_Pos           24           /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P24               (_U(0x1) << GPIO_OVRS_P24_Pos)
+#define GPIO_OVRS_P24               (_U_(0x1) << GPIO_OVRS_P24_Pos)
 #define GPIO_OVRS_P25_Pos           25           /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P25               (_U(0x1) << GPIO_OVRS_P25_Pos)
+#define GPIO_OVRS_P25               (_U_(0x1) << GPIO_OVRS_P25_Pos)
 #define GPIO_OVRS_P26_Pos           26           /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P26               (_U(0x1) << GPIO_OVRS_P26_Pos)
+#define GPIO_OVRS_P26               (_U_(0x1) << GPIO_OVRS_P26_Pos)
 #define GPIO_OVRS_P27_Pos           27           /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P27               (_U(0x1) << GPIO_OVRS_P27_Pos)
+#define GPIO_OVRS_P27               (_U_(0x1) << GPIO_OVRS_P27_Pos)
 #define GPIO_OVRS_P28_Pos           28           /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P28               (_U(0x1) << GPIO_OVRS_P28_Pos)
+#define GPIO_OVRS_P28               (_U_(0x1) << GPIO_OVRS_P28_Pos)
 #define GPIO_OVRS_P29_Pos           29           /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P29               (_U(0x1) << GPIO_OVRS_P29_Pos)
+#define GPIO_OVRS_P29               (_U_(0x1) << GPIO_OVRS_P29_Pos)
 #define GPIO_OVRS_P30_Pos           30           /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P30               (_U(0x1) << GPIO_OVRS_P30_Pos)
+#define GPIO_OVRS_P30               (_U_(0x1) << GPIO_OVRS_P30_Pos)
 #define GPIO_OVRS_P31_Pos           31           /**< \brief (GPIO_OVRS) Output Value */
-#define GPIO_OVRS_P31               (_U(0x1) << GPIO_OVRS_P31_Pos)
-#define GPIO_OVRS_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_OVRS) MASK Register */
+#define GPIO_OVRS_P31               (_U_(0x1) << GPIO_OVRS_P31_Pos)
+#define GPIO_OVRS_MASK              _U_(0xFFFFFFFF) /**< \brief (GPIO_OVRS) MASK Register */
 
 /* -------- GPIO_OVRC : (GPIO Offset: 0x058) ( /W 32) port Output Value Register - Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -2480,70 +2480,70 @@ typedef union {
 #define GPIO_OVRC_OFFSET            0x058        /**< \brief (GPIO_OVRC offset) Output Value Register - Clear */
 
 #define GPIO_OVRC_P0_Pos            0            /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P0                (_U(0x1) << GPIO_OVRC_P0_Pos)
+#define GPIO_OVRC_P0                (_U_(0x1) << GPIO_OVRC_P0_Pos)
 #define GPIO_OVRC_P1_Pos            1            /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P1                (_U(0x1) << GPIO_OVRC_P1_Pos)
+#define GPIO_OVRC_P1                (_U_(0x1) << GPIO_OVRC_P1_Pos)
 #define GPIO_OVRC_P2_Pos            2            /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P2                (_U(0x1) << GPIO_OVRC_P2_Pos)
+#define GPIO_OVRC_P2                (_U_(0x1) << GPIO_OVRC_P2_Pos)
 #define GPIO_OVRC_P3_Pos            3            /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P3                (_U(0x1) << GPIO_OVRC_P3_Pos)
+#define GPIO_OVRC_P3                (_U_(0x1) << GPIO_OVRC_P3_Pos)
 #define GPIO_OVRC_P4_Pos            4            /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P4                (_U(0x1) << GPIO_OVRC_P4_Pos)
+#define GPIO_OVRC_P4                (_U_(0x1) << GPIO_OVRC_P4_Pos)
 #define GPIO_OVRC_P5_Pos            5            /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P5                (_U(0x1) << GPIO_OVRC_P5_Pos)
+#define GPIO_OVRC_P5                (_U_(0x1) << GPIO_OVRC_P5_Pos)
 #define GPIO_OVRC_P6_Pos            6            /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P6                (_U(0x1) << GPIO_OVRC_P6_Pos)
+#define GPIO_OVRC_P6                (_U_(0x1) << GPIO_OVRC_P6_Pos)
 #define GPIO_OVRC_P7_Pos            7            /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P7                (_U(0x1) << GPIO_OVRC_P7_Pos)
+#define GPIO_OVRC_P7                (_U_(0x1) << GPIO_OVRC_P7_Pos)
 #define GPIO_OVRC_P8_Pos            8            /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P8                (_U(0x1) << GPIO_OVRC_P8_Pos)
+#define GPIO_OVRC_P8                (_U_(0x1) << GPIO_OVRC_P8_Pos)
 #define GPIO_OVRC_P9_Pos            9            /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P9                (_U(0x1) << GPIO_OVRC_P9_Pos)
+#define GPIO_OVRC_P9                (_U_(0x1) << GPIO_OVRC_P9_Pos)
 #define GPIO_OVRC_P10_Pos           10           /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P10               (_U(0x1) << GPIO_OVRC_P10_Pos)
+#define GPIO_OVRC_P10               (_U_(0x1) << GPIO_OVRC_P10_Pos)
 #define GPIO_OVRC_P11_Pos           11           /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P11               (_U(0x1) << GPIO_OVRC_P11_Pos)
+#define GPIO_OVRC_P11               (_U_(0x1) << GPIO_OVRC_P11_Pos)
 #define GPIO_OVRC_P12_Pos           12           /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P12               (_U(0x1) << GPIO_OVRC_P12_Pos)
+#define GPIO_OVRC_P12               (_U_(0x1) << GPIO_OVRC_P12_Pos)
 #define GPIO_OVRC_P13_Pos           13           /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P13               (_U(0x1) << GPIO_OVRC_P13_Pos)
+#define GPIO_OVRC_P13               (_U_(0x1) << GPIO_OVRC_P13_Pos)
 #define GPIO_OVRC_P14_Pos           14           /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P14               (_U(0x1) << GPIO_OVRC_P14_Pos)
+#define GPIO_OVRC_P14               (_U_(0x1) << GPIO_OVRC_P14_Pos)
 #define GPIO_OVRC_P15_Pos           15           /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P15               (_U(0x1) << GPIO_OVRC_P15_Pos)
+#define GPIO_OVRC_P15               (_U_(0x1) << GPIO_OVRC_P15_Pos)
 #define GPIO_OVRC_P16_Pos           16           /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P16               (_U(0x1) << GPIO_OVRC_P16_Pos)
+#define GPIO_OVRC_P16               (_U_(0x1) << GPIO_OVRC_P16_Pos)
 #define GPIO_OVRC_P17_Pos           17           /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P17               (_U(0x1) << GPIO_OVRC_P17_Pos)
+#define GPIO_OVRC_P17               (_U_(0x1) << GPIO_OVRC_P17_Pos)
 #define GPIO_OVRC_P18_Pos           18           /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P18               (_U(0x1) << GPIO_OVRC_P18_Pos)
+#define GPIO_OVRC_P18               (_U_(0x1) << GPIO_OVRC_P18_Pos)
 #define GPIO_OVRC_P19_Pos           19           /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P19               (_U(0x1) << GPIO_OVRC_P19_Pos)
+#define GPIO_OVRC_P19               (_U_(0x1) << GPIO_OVRC_P19_Pos)
 #define GPIO_OVRC_P20_Pos           20           /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P20               (_U(0x1) << GPIO_OVRC_P20_Pos)
+#define GPIO_OVRC_P20               (_U_(0x1) << GPIO_OVRC_P20_Pos)
 #define GPIO_OVRC_P21_Pos           21           /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P21               (_U(0x1) << GPIO_OVRC_P21_Pos)
+#define GPIO_OVRC_P21               (_U_(0x1) << GPIO_OVRC_P21_Pos)
 #define GPIO_OVRC_P22_Pos           22           /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P22               (_U(0x1) << GPIO_OVRC_P22_Pos)
+#define GPIO_OVRC_P22               (_U_(0x1) << GPIO_OVRC_P22_Pos)
 #define GPIO_OVRC_P23_Pos           23           /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P23               (_U(0x1) << GPIO_OVRC_P23_Pos)
+#define GPIO_OVRC_P23               (_U_(0x1) << GPIO_OVRC_P23_Pos)
 #define GPIO_OVRC_P24_Pos           24           /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P24               (_U(0x1) << GPIO_OVRC_P24_Pos)
+#define GPIO_OVRC_P24               (_U_(0x1) << GPIO_OVRC_P24_Pos)
 #define GPIO_OVRC_P25_Pos           25           /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P25               (_U(0x1) << GPIO_OVRC_P25_Pos)
+#define GPIO_OVRC_P25               (_U_(0x1) << GPIO_OVRC_P25_Pos)
 #define GPIO_OVRC_P26_Pos           26           /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P26               (_U(0x1) << GPIO_OVRC_P26_Pos)
+#define GPIO_OVRC_P26               (_U_(0x1) << GPIO_OVRC_P26_Pos)
 #define GPIO_OVRC_P27_Pos           27           /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P27               (_U(0x1) << GPIO_OVRC_P27_Pos)
+#define GPIO_OVRC_P27               (_U_(0x1) << GPIO_OVRC_P27_Pos)
 #define GPIO_OVRC_P28_Pos           28           /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P28               (_U(0x1) << GPIO_OVRC_P28_Pos)
+#define GPIO_OVRC_P28               (_U_(0x1) << GPIO_OVRC_P28_Pos)
 #define GPIO_OVRC_P29_Pos           29           /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P29               (_U(0x1) << GPIO_OVRC_P29_Pos)
+#define GPIO_OVRC_P29               (_U_(0x1) << GPIO_OVRC_P29_Pos)
 #define GPIO_OVRC_P30_Pos           30           /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P30               (_U(0x1) << GPIO_OVRC_P30_Pos)
+#define GPIO_OVRC_P30               (_U_(0x1) << GPIO_OVRC_P30_Pos)
 #define GPIO_OVRC_P31_Pos           31           /**< \brief (GPIO_OVRC) Output Value */
-#define GPIO_OVRC_P31               (_U(0x1) << GPIO_OVRC_P31_Pos)
-#define GPIO_OVRC_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_OVRC) MASK Register */
+#define GPIO_OVRC_P31               (_U_(0x1) << GPIO_OVRC_P31_Pos)
+#define GPIO_OVRC_MASK              _U_(0xFFFFFFFF) /**< \brief (GPIO_OVRC) MASK Register */
 
 /* -------- GPIO_OVRT : (GPIO Offset: 0x05C) ( /W 32) port Output Value Register - Toggle -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -2589,70 +2589,70 @@ typedef union {
 #define GPIO_OVRT_OFFSET            0x05C        /**< \brief (GPIO_OVRT offset) Output Value Register - Toggle */
 
 #define GPIO_OVRT_P0_Pos            0            /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P0                (_U(0x1) << GPIO_OVRT_P0_Pos)
+#define GPIO_OVRT_P0                (_U_(0x1) << GPIO_OVRT_P0_Pos)
 #define GPIO_OVRT_P1_Pos            1            /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P1                (_U(0x1) << GPIO_OVRT_P1_Pos)
+#define GPIO_OVRT_P1                (_U_(0x1) << GPIO_OVRT_P1_Pos)
 #define GPIO_OVRT_P2_Pos            2            /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P2                (_U(0x1) << GPIO_OVRT_P2_Pos)
+#define GPIO_OVRT_P2                (_U_(0x1) << GPIO_OVRT_P2_Pos)
 #define GPIO_OVRT_P3_Pos            3            /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P3                (_U(0x1) << GPIO_OVRT_P3_Pos)
+#define GPIO_OVRT_P3                (_U_(0x1) << GPIO_OVRT_P3_Pos)
 #define GPIO_OVRT_P4_Pos            4            /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P4                (_U(0x1) << GPIO_OVRT_P4_Pos)
+#define GPIO_OVRT_P4                (_U_(0x1) << GPIO_OVRT_P4_Pos)
 #define GPIO_OVRT_P5_Pos            5            /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P5                (_U(0x1) << GPIO_OVRT_P5_Pos)
+#define GPIO_OVRT_P5                (_U_(0x1) << GPIO_OVRT_P5_Pos)
 #define GPIO_OVRT_P6_Pos            6            /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P6                (_U(0x1) << GPIO_OVRT_P6_Pos)
+#define GPIO_OVRT_P6                (_U_(0x1) << GPIO_OVRT_P6_Pos)
 #define GPIO_OVRT_P7_Pos            7            /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P7                (_U(0x1) << GPIO_OVRT_P7_Pos)
+#define GPIO_OVRT_P7                (_U_(0x1) << GPIO_OVRT_P7_Pos)
 #define GPIO_OVRT_P8_Pos            8            /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P8                (_U(0x1) << GPIO_OVRT_P8_Pos)
+#define GPIO_OVRT_P8                (_U_(0x1) << GPIO_OVRT_P8_Pos)
 #define GPIO_OVRT_P9_Pos            9            /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P9                (_U(0x1) << GPIO_OVRT_P9_Pos)
+#define GPIO_OVRT_P9                (_U_(0x1) << GPIO_OVRT_P9_Pos)
 #define GPIO_OVRT_P10_Pos           10           /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P10               (_U(0x1) << GPIO_OVRT_P10_Pos)
+#define GPIO_OVRT_P10               (_U_(0x1) << GPIO_OVRT_P10_Pos)
 #define GPIO_OVRT_P11_Pos           11           /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P11               (_U(0x1) << GPIO_OVRT_P11_Pos)
+#define GPIO_OVRT_P11               (_U_(0x1) << GPIO_OVRT_P11_Pos)
 #define GPIO_OVRT_P12_Pos           12           /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P12               (_U(0x1) << GPIO_OVRT_P12_Pos)
+#define GPIO_OVRT_P12               (_U_(0x1) << GPIO_OVRT_P12_Pos)
 #define GPIO_OVRT_P13_Pos           13           /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P13               (_U(0x1) << GPIO_OVRT_P13_Pos)
+#define GPIO_OVRT_P13               (_U_(0x1) << GPIO_OVRT_P13_Pos)
 #define GPIO_OVRT_P14_Pos           14           /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P14               (_U(0x1) << GPIO_OVRT_P14_Pos)
+#define GPIO_OVRT_P14               (_U_(0x1) << GPIO_OVRT_P14_Pos)
 #define GPIO_OVRT_P15_Pos           15           /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P15               (_U(0x1) << GPIO_OVRT_P15_Pos)
+#define GPIO_OVRT_P15               (_U_(0x1) << GPIO_OVRT_P15_Pos)
 #define GPIO_OVRT_P16_Pos           16           /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P16               (_U(0x1) << GPIO_OVRT_P16_Pos)
+#define GPIO_OVRT_P16               (_U_(0x1) << GPIO_OVRT_P16_Pos)
 #define GPIO_OVRT_P17_Pos           17           /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P17               (_U(0x1) << GPIO_OVRT_P17_Pos)
+#define GPIO_OVRT_P17               (_U_(0x1) << GPIO_OVRT_P17_Pos)
 #define GPIO_OVRT_P18_Pos           18           /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P18               (_U(0x1) << GPIO_OVRT_P18_Pos)
+#define GPIO_OVRT_P18               (_U_(0x1) << GPIO_OVRT_P18_Pos)
 #define GPIO_OVRT_P19_Pos           19           /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P19               (_U(0x1) << GPIO_OVRT_P19_Pos)
+#define GPIO_OVRT_P19               (_U_(0x1) << GPIO_OVRT_P19_Pos)
 #define GPIO_OVRT_P20_Pos           20           /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P20               (_U(0x1) << GPIO_OVRT_P20_Pos)
+#define GPIO_OVRT_P20               (_U_(0x1) << GPIO_OVRT_P20_Pos)
 #define GPIO_OVRT_P21_Pos           21           /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P21               (_U(0x1) << GPIO_OVRT_P21_Pos)
+#define GPIO_OVRT_P21               (_U_(0x1) << GPIO_OVRT_P21_Pos)
 #define GPIO_OVRT_P22_Pos           22           /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P22               (_U(0x1) << GPIO_OVRT_P22_Pos)
+#define GPIO_OVRT_P22               (_U_(0x1) << GPIO_OVRT_P22_Pos)
 #define GPIO_OVRT_P23_Pos           23           /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P23               (_U(0x1) << GPIO_OVRT_P23_Pos)
+#define GPIO_OVRT_P23               (_U_(0x1) << GPIO_OVRT_P23_Pos)
 #define GPIO_OVRT_P24_Pos           24           /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P24               (_U(0x1) << GPIO_OVRT_P24_Pos)
+#define GPIO_OVRT_P24               (_U_(0x1) << GPIO_OVRT_P24_Pos)
 #define GPIO_OVRT_P25_Pos           25           /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P25               (_U(0x1) << GPIO_OVRT_P25_Pos)
+#define GPIO_OVRT_P25               (_U_(0x1) << GPIO_OVRT_P25_Pos)
 #define GPIO_OVRT_P26_Pos           26           /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P26               (_U(0x1) << GPIO_OVRT_P26_Pos)
+#define GPIO_OVRT_P26               (_U_(0x1) << GPIO_OVRT_P26_Pos)
 #define GPIO_OVRT_P27_Pos           27           /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P27               (_U(0x1) << GPIO_OVRT_P27_Pos)
+#define GPIO_OVRT_P27               (_U_(0x1) << GPIO_OVRT_P27_Pos)
 #define GPIO_OVRT_P28_Pos           28           /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P28               (_U(0x1) << GPIO_OVRT_P28_Pos)
+#define GPIO_OVRT_P28               (_U_(0x1) << GPIO_OVRT_P28_Pos)
 #define GPIO_OVRT_P29_Pos           29           /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P29               (_U(0x1) << GPIO_OVRT_P29_Pos)
+#define GPIO_OVRT_P29               (_U_(0x1) << GPIO_OVRT_P29_Pos)
 #define GPIO_OVRT_P30_Pos           30           /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P30               (_U(0x1) << GPIO_OVRT_P30_Pos)
+#define GPIO_OVRT_P30               (_U_(0x1) << GPIO_OVRT_P30_Pos)
 #define GPIO_OVRT_P31_Pos           31           /**< \brief (GPIO_OVRT) Output Value */
-#define GPIO_OVRT_P31               (_U(0x1) << GPIO_OVRT_P31_Pos)
-#define GPIO_OVRT_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_OVRT) MASK Register */
+#define GPIO_OVRT_P31               (_U_(0x1) << GPIO_OVRT_P31_Pos)
+#define GPIO_OVRT_MASK              _U_(0xFFFFFFFF) /**< \brief (GPIO_OVRT) MASK Register */
 
 /* -------- GPIO_PVR : (GPIO Offset: 0x060) (R/  32) port Pin Value Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -2698,70 +2698,70 @@ typedef union {
 #define GPIO_PVR_OFFSET             0x060        /**< \brief (GPIO_PVR offset) Pin Value Register */
 
 #define GPIO_PVR_P0_Pos             0            /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P0                 (_U(0x1) << GPIO_PVR_P0_Pos)
+#define GPIO_PVR_P0                 (_U_(0x1) << GPIO_PVR_P0_Pos)
 #define GPIO_PVR_P1_Pos             1            /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P1                 (_U(0x1) << GPIO_PVR_P1_Pos)
+#define GPIO_PVR_P1                 (_U_(0x1) << GPIO_PVR_P1_Pos)
 #define GPIO_PVR_P2_Pos             2            /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P2                 (_U(0x1) << GPIO_PVR_P2_Pos)
+#define GPIO_PVR_P2                 (_U_(0x1) << GPIO_PVR_P2_Pos)
 #define GPIO_PVR_P3_Pos             3            /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P3                 (_U(0x1) << GPIO_PVR_P3_Pos)
+#define GPIO_PVR_P3                 (_U_(0x1) << GPIO_PVR_P3_Pos)
 #define GPIO_PVR_P4_Pos             4            /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P4                 (_U(0x1) << GPIO_PVR_P4_Pos)
+#define GPIO_PVR_P4                 (_U_(0x1) << GPIO_PVR_P4_Pos)
 #define GPIO_PVR_P5_Pos             5            /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P5                 (_U(0x1) << GPIO_PVR_P5_Pos)
+#define GPIO_PVR_P5                 (_U_(0x1) << GPIO_PVR_P5_Pos)
 #define GPIO_PVR_P6_Pos             6            /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P6                 (_U(0x1) << GPIO_PVR_P6_Pos)
+#define GPIO_PVR_P6                 (_U_(0x1) << GPIO_PVR_P6_Pos)
 #define GPIO_PVR_P7_Pos             7            /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P7                 (_U(0x1) << GPIO_PVR_P7_Pos)
+#define GPIO_PVR_P7                 (_U_(0x1) << GPIO_PVR_P7_Pos)
 #define GPIO_PVR_P8_Pos             8            /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P8                 (_U(0x1) << GPIO_PVR_P8_Pos)
+#define GPIO_PVR_P8                 (_U_(0x1) << GPIO_PVR_P8_Pos)
 #define GPIO_PVR_P9_Pos             9            /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P9                 (_U(0x1) << GPIO_PVR_P9_Pos)
+#define GPIO_PVR_P9                 (_U_(0x1) << GPIO_PVR_P9_Pos)
 #define GPIO_PVR_P10_Pos            10           /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P10                (_U(0x1) << GPIO_PVR_P10_Pos)
+#define GPIO_PVR_P10                (_U_(0x1) << GPIO_PVR_P10_Pos)
 #define GPIO_PVR_P11_Pos            11           /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P11                (_U(0x1) << GPIO_PVR_P11_Pos)
+#define GPIO_PVR_P11                (_U_(0x1) << GPIO_PVR_P11_Pos)
 #define GPIO_PVR_P12_Pos            12           /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P12                (_U(0x1) << GPIO_PVR_P12_Pos)
+#define GPIO_PVR_P12                (_U_(0x1) << GPIO_PVR_P12_Pos)
 #define GPIO_PVR_P13_Pos            13           /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P13                (_U(0x1) << GPIO_PVR_P13_Pos)
+#define GPIO_PVR_P13                (_U_(0x1) << GPIO_PVR_P13_Pos)
 #define GPIO_PVR_P14_Pos            14           /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P14                (_U(0x1) << GPIO_PVR_P14_Pos)
+#define GPIO_PVR_P14                (_U_(0x1) << GPIO_PVR_P14_Pos)
 #define GPIO_PVR_P15_Pos            15           /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P15                (_U(0x1) << GPIO_PVR_P15_Pos)
+#define GPIO_PVR_P15                (_U_(0x1) << GPIO_PVR_P15_Pos)
 #define GPIO_PVR_P16_Pos            16           /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P16                (_U(0x1) << GPIO_PVR_P16_Pos)
+#define GPIO_PVR_P16                (_U_(0x1) << GPIO_PVR_P16_Pos)
 #define GPIO_PVR_P17_Pos            17           /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P17                (_U(0x1) << GPIO_PVR_P17_Pos)
+#define GPIO_PVR_P17                (_U_(0x1) << GPIO_PVR_P17_Pos)
 #define GPIO_PVR_P18_Pos            18           /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P18                (_U(0x1) << GPIO_PVR_P18_Pos)
+#define GPIO_PVR_P18                (_U_(0x1) << GPIO_PVR_P18_Pos)
 #define GPIO_PVR_P19_Pos            19           /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P19                (_U(0x1) << GPIO_PVR_P19_Pos)
+#define GPIO_PVR_P19                (_U_(0x1) << GPIO_PVR_P19_Pos)
 #define GPIO_PVR_P20_Pos            20           /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P20                (_U(0x1) << GPIO_PVR_P20_Pos)
+#define GPIO_PVR_P20                (_U_(0x1) << GPIO_PVR_P20_Pos)
 #define GPIO_PVR_P21_Pos            21           /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P21                (_U(0x1) << GPIO_PVR_P21_Pos)
+#define GPIO_PVR_P21                (_U_(0x1) << GPIO_PVR_P21_Pos)
 #define GPIO_PVR_P22_Pos            22           /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P22                (_U(0x1) << GPIO_PVR_P22_Pos)
+#define GPIO_PVR_P22                (_U_(0x1) << GPIO_PVR_P22_Pos)
 #define GPIO_PVR_P23_Pos            23           /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P23                (_U(0x1) << GPIO_PVR_P23_Pos)
+#define GPIO_PVR_P23                (_U_(0x1) << GPIO_PVR_P23_Pos)
 #define GPIO_PVR_P24_Pos            24           /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P24                (_U(0x1) << GPIO_PVR_P24_Pos)
+#define GPIO_PVR_P24                (_U_(0x1) << GPIO_PVR_P24_Pos)
 #define GPIO_PVR_P25_Pos            25           /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P25                (_U(0x1) << GPIO_PVR_P25_Pos)
+#define GPIO_PVR_P25                (_U_(0x1) << GPIO_PVR_P25_Pos)
 #define GPIO_PVR_P26_Pos            26           /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P26                (_U(0x1) << GPIO_PVR_P26_Pos)
+#define GPIO_PVR_P26                (_U_(0x1) << GPIO_PVR_P26_Pos)
 #define GPIO_PVR_P27_Pos            27           /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P27                (_U(0x1) << GPIO_PVR_P27_Pos)
+#define GPIO_PVR_P27                (_U_(0x1) << GPIO_PVR_P27_Pos)
 #define GPIO_PVR_P28_Pos            28           /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P28                (_U(0x1) << GPIO_PVR_P28_Pos)
+#define GPIO_PVR_P28                (_U_(0x1) << GPIO_PVR_P28_Pos)
 #define GPIO_PVR_P29_Pos            29           /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P29                (_U(0x1) << GPIO_PVR_P29_Pos)
+#define GPIO_PVR_P29                (_U_(0x1) << GPIO_PVR_P29_Pos)
 #define GPIO_PVR_P30_Pos            30           /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P30                (_U(0x1) << GPIO_PVR_P30_Pos)
+#define GPIO_PVR_P30                (_U_(0x1) << GPIO_PVR_P30_Pos)
 #define GPIO_PVR_P31_Pos            31           /**< \brief (GPIO_PVR) Pin Value */
-#define GPIO_PVR_P31                (_U(0x1) << GPIO_PVR_P31_Pos)
-#define GPIO_PVR_MASK               _U(0xFFFFFFFF) /**< \brief (GPIO_PVR) MASK Register */
+#define GPIO_PVR_P31                (_U_(0x1) << GPIO_PVR_P31_Pos)
+#define GPIO_PVR_MASK               _U_(0xFFFFFFFF) /**< \brief (GPIO_PVR) MASK Register */
 
 /* -------- GPIO_PUER : (GPIO Offset: 0x070) (R/W 32) port Pull-up Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -2807,70 +2807,70 @@ typedef union {
 #define GPIO_PUER_OFFSET            0x070        /**< \brief (GPIO_PUER offset) Pull-up Enable Register */
 
 #define GPIO_PUER_P0_Pos            0            /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P0                (_U(0x1) << GPIO_PUER_P0_Pos)
+#define GPIO_PUER_P0                (_U_(0x1) << GPIO_PUER_P0_Pos)
 #define GPIO_PUER_P1_Pos            1            /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P1                (_U(0x1) << GPIO_PUER_P1_Pos)
+#define GPIO_PUER_P1                (_U_(0x1) << GPIO_PUER_P1_Pos)
 #define GPIO_PUER_P2_Pos            2            /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P2                (_U(0x1) << GPIO_PUER_P2_Pos)
+#define GPIO_PUER_P2                (_U_(0x1) << GPIO_PUER_P2_Pos)
 #define GPIO_PUER_P3_Pos            3            /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P3                (_U(0x1) << GPIO_PUER_P3_Pos)
+#define GPIO_PUER_P3                (_U_(0x1) << GPIO_PUER_P3_Pos)
 #define GPIO_PUER_P4_Pos            4            /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P4                (_U(0x1) << GPIO_PUER_P4_Pos)
+#define GPIO_PUER_P4                (_U_(0x1) << GPIO_PUER_P4_Pos)
 #define GPIO_PUER_P5_Pos            5            /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P5                (_U(0x1) << GPIO_PUER_P5_Pos)
+#define GPIO_PUER_P5                (_U_(0x1) << GPIO_PUER_P5_Pos)
 #define GPIO_PUER_P6_Pos            6            /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P6                (_U(0x1) << GPIO_PUER_P6_Pos)
+#define GPIO_PUER_P6                (_U_(0x1) << GPIO_PUER_P6_Pos)
 #define GPIO_PUER_P7_Pos            7            /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P7                (_U(0x1) << GPIO_PUER_P7_Pos)
+#define GPIO_PUER_P7                (_U_(0x1) << GPIO_PUER_P7_Pos)
 #define GPIO_PUER_P8_Pos            8            /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P8                (_U(0x1) << GPIO_PUER_P8_Pos)
+#define GPIO_PUER_P8                (_U_(0x1) << GPIO_PUER_P8_Pos)
 #define GPIO_PUER_P9_Pos            9            /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P9                (_U(0x1) << GPIO_PUER_P9_Pos)
+#define GPIO_PUER_P9                (_U_(0x1) << GPIO_PUER_P9_Pos)
 #define GPIO_PUER_P10_Pos           10           /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P10               (_U(0x1) << GPIO_PUER_P10_Pos)
+#define GPIO_PUER_P10               (_U_(0x1) << GPIO_PUER_P10_Pos)
 #define GPIO_PUER_P11_Pos           11           /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P11               (_U(0x1) << GPIO_PUER_P11_Pos)
+#define GPIO_PUER_P11               (_U_(0x1) << GPIO_PUER_P11_Pos)
 #define GPIO_PUER_P12_Pos           12           /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P12               (_U(0x1) << GPIO_PUER_P12_Pos)
+#define GPIO_PUER_P12               (_U_(0x1) << GPIO_PUER_P12_Pos)
 #define GPIO_PUER_P13_Pos           13           /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P13               (_U(0x1) << GPIO_PUER_P13_Pos)
+#define GPIO_PUER_P13               (_U_(0x1) << GPIO_PUER_P13_Pos)
 #define GPIO_PUER_P14_Pos           14           /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P14               (_U(0x1) << GPIO_PUER_P14_Pos)
+#define GPIO_PUER_P14               (_U_(0x1) << GPIO_PUER_P14_Pos)
 #define GPIO_PUER_P15_Pos           15           /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P15               (_U(0x1) << GPIO_PUER_P15_Pos)
+#define GPIO_PUER_P15               (_U_(0x1) << GPIO_PUER_P15_Pos)
 #define GPIO_PUER_P16_Pos           16           /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P16               (_U(0x1) << GPIO_PUER_P16_Pos)
+#define GPIO_PUER_P16               (_U_(0x1) << GPIO_PUER_P16_Pos)
 #define GPIO_PUER_P17_Pos           17           /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P17               (_U(0x1) << GPIO_PUER_P17_Pos)
+#define GPIO_PUER_P17               (_U_(0x1) << GPIO_PUER_P17_Pos)
 #define GPIO_PUER_P18_Pos           18           /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P18               (_U(0x1) << GPIO_PUER_P18_Pos)
+#define GPIO_PUER_P18               (_U_(0x1) << GPIO_PUER_P18_Pos)
 #define GPIO_PUER_P19_Pos           19           /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P19               (_U(0x1) << GPIO_PUER_P19_Pos)
+#define GPIO_PUER_P19               (_U_(0x1) << GPIO_PUER_P19_Pos)
 #define GPIO_PUER_P20_Pos           20           /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P20               (_U(0x1) << GPIO_PUER_P20_Pos)
+#define GPIO_PUER_P20               (_U_(0x1) << GPIO_PUER_P20_Pos)
 #define GPIO_PUER_P21_Pos           21           /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P21               (_U(0x1) << GPIO_PUER_P21_Pos)
+#define GPIO_PUER_P21               (_U_(0x1) << GPIO_PUER_P21_Pos)
 #define GPIO_PUER_P22_Pos           22           /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P22               (_U(0x1) << GPIO_PUER_P22_Pos)
+#define GPIO_PUER_P22               (_U_(0x1) << GPIO_PUER_P22_Pos)
 #define GPIO_PUER_P23_Pos           23           /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P23               (_U(0x1) << GPIO_PUER_P23_Pos)
+#define GPIO_PUER_P23               (_U_(0x1) << GPIO_PUER_P23_Pos)
 #define GPIO_PUER_P24_Pos           24           /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P24               (_U(0x1) << GPIO_PUER_P24_Pos)
+#define GPIO_PUER_P24               (_U_(0x1) << GPIO_PUER_P24_Pos)
 #define GPIO_PUER_P25_Pos           25           /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P25               (_U(0x1) << GPIO_PUER_P25_Pos)
+#define GPIO_PUER_P25               (_U_(0x1) << GPIO_PUER_P25_Pos)
 #define GPIO_PUER_P26_Pos           26           /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P26               (_U(0x1) << GPIO_PUER_P26_Pos)
+#define GPIO_PUER_P26               (_U_(0x1) << GPIO_PUER_P26_Pos)
 #define GPIO_PUER_P27_Pos           27           /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P27               (_U(0x1) << GPIO_PUER_P27_Pos)
+#define GPIO_PUER_P27               (_U_(0x1) << GPIO_PUER_P27_Pos)
 #define GPIO_PUER_P28_Pos           28           /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P28               (_U(0x1) << GPIO_PUER_P28_Pos)
+#define GPIO_PUER_P28               (_U_(0x1) << GPIO_PUER_P28_Pos)
 #define GPIO_PUER_P29_Pos           29           /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P29               (_U(0x1) << GPIO_PUER_P29_Pos)
+#define GPIO_PUER_P29               (_U_(0x1) << GPIO_PUER_P29_Pos)
 #define GPIO_PUER_P30_Pos           30           /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P30               (_U(0x1) << GPIO_PUER_P30_Pos)
+#define GPIO_PUER_P30               (_U_(0x1) << GPIO_PUER_P30_Pos)
 #define GPIO_PUER_P31_Pos           31           /**< \brief (GPIO_PUER) Pull-up Enable */
-#define GPIO_PUER_P31               (_U(0x1) << GPIO_PUER_P31_Pos)
-#define GPIO_PUER_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_PUER) MASK Register */
+#define GPIO_PUER_P31               (_U_(0x1) << GPIO_PUER_P31_Pos)
+#define GPIO_PUER_MASK              _U_(0xFFFFFFFF) /**< \brief (GPIO_PUER) MASK Register */
 
 /* -------- GPIO_PUERS : (GPIO Offset: 0x074) ( /W 32) port Pull-up Enable Register - Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -2916,70 +2916,70 @@ typedef union {
 #define GPIO_PUERS_OFFSET           0x074        /**< \brief (GPIO_PUERS offset) Pull-up Enable Register - Set */
 
 #define GPIO_PUERS_P0_Pos           0            /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P0               (_U(0x1) << GPIO_PUERS_P0_Pos)
+#define GPIO_PUERS_P0               (_U_(0x1) << GPIO_PUERS_P0_Pos)
 #define GPIO_PUERS_P1_Pos           1            /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P1               (_U(0x1) << GPIO_PUERS_P1_Pos)
+#define GPIO_PUERS_P1               (_U_(0x1) << GPIO_PUERS_P1_Pos)
 #define GPIO_PUERS_P2_Pos           2            /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P2               (_U(0x1) << GPIO_PUERS_P2_Pos)
+#define GPIO_PUERS_P2               (_U_(0x1) << GPIO_PUERS_P2_Pos)
 #define GPIO_PUERS_P3_Pos           3            /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P3               (_U(0x1) << GPIO_PUERS_P3_Pos)
+#define GPIO_PUERS_P3               (_U_(0x1) << GPIO_PUERS_P3_Pos)
 #define GPIO_PUERS_P4_Pos           4            /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P4               (_U(0x1) << GPIO_PUERS_P4_Pos)
+#define GPIO_PUERS_P4               (_U_(0x1) << GPIO_PUERS_P4_Pos)
 #define GPIO_PUERS_P5_Pos           5            /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P5               (_U(0x1) << GPIO_PUERS_P5_Pos)
+#define GPIO_PUERS_P5               (_U_(0x1) << GPIO_PUERS_P5_Pos)
 #define GPIO_PUERS_P6_Pos           6            /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P6               (_U(0x1) << GPIO_PUERS_P6_Pos)
+#define GPIO_PUERS_P6               (_U_(0x1) << GPIO_PUERS_P6_Pos)
 #define GPIO_PUERS_P7_Pos           7            /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P7               (_U(0x1) << GPIO_PUERS_P7_Pos)
+#define GPIO_PUERS_P7               (_U_(0x1) << GPIO_PUERS_P7_Pos)
 #define GPIO_PUERS_P8_Pos           8            /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P8               (_U(0x1) << GPIO_PUERS_P8_Pos)
+#define GPIO_PUERS_P8               (_U_(0x1) << GPIO_PUERS_P8_Pos)
 #define GPIO_PUERS_P9_Pos           9            /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P9               (_U(0x1) << GPIO_PUERS_P9_Pos)
+#define GPIO_PUERS_P9               (_U_(0x1) << GPIO_PUERS_P9_Pos)
 #define GPIO_PUERS_P10_Pos          10           /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P10              (_U(0x1) << GPIO_PUERS_P10_Pos)
+#define GPIO_PUERS_P10              (_U_(0x1) << GPIO_PUERS_P10_Pos)
 #define GPIO_PUERS_P11_Pos          11           /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P11              (_U(0x1) << GPIO_PUERS_P11_Pos)
+#define GPIO_PUERS_P11              (_U_(0x1) << GPIO_PUERS_P11_Pos)
 #define GPIO_PUERS_P12_Pos          12           /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P12              (_U(0x1) << GPIO_PUERS_P12_Pos)
+#define GPIO_PUERS_P12              (_U_(0x1) << GPIO_PUERS_P12_Pos)
 #define GPIO_PUERS_P13_Pos          13           /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P13              (_U(0x1) << GPIO_PUERS_P13_Pos)
+#define GPIO_PUERS_P13              (_U_(0x1) << GPIO_PUERS_P13_Pos)
 #define GPIO_PUERS_P14_Pos          14           /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P14              (_U(0x1) << GPIO_PUERS_P14_Pos)
+#define GPIO_PUERS_P14              (_U_(0x1) << GPIO_PUERS_P14_Pos)
 #define GPIO_PUERS_P15_Pos          15           /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P15              (_U(0x1) << GPIO_PUERS_P15_Pos)
+#define GPIO_PUERS_P15              (_U_(0x1) << GPIO_PUERS_P15_Pos)
 #define GPIO_PUERS_P16_Pos          16           /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P16              (_U(0x1) << GPIO_PUERS_P16_Pos)
+#define GPIO_PUERS_P16              (_U_(0x1) << GPIO_PUERS_P16_Pos)
 #define GPIO_PUERS_P17_Pos          17           /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P17              (_U(0x1) << GPIO_PUERS_P17_Pos)
+#define GPIO_PUERS_P17              (_U_(0x1) << GPIO_PUERS_P17_Pos)
 #define GPIO_PUERS_P18_Pos          18           /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P18              (_U(0x1) << GPIO_PUERS_P18_Pos)
+#define GPIO_PUERS_P18              (_U_(0x1) << GPIO_PUERS_P18_Pos)
 #define GPIO_PUERS_P19_Pos          19           /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P19              (_U(0x1) << GPIO_PUERS_P19_Pos)
+#define GPIO_PUERS_P19              (_U_(0x1) << GPIO_PUERS_P19_Pos)
 #define GPIO_PUERS_P20_Pos          20           /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P20              (_U(0x1) << GPIO_PUERS_P20_Pos)
+#define GPIO_PUERS_P20              (_U_(0x1) << GPIO_PUERS_P20_Pos)
 #define GPIO_PUERS_P21_Pos          21           /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P21              (_U(0x1) << GPIO_PUERS_P21_Pos)
+#define GPIO_PUERS_P21              (_U_(0x1) << GPIO_PUERS_P21_Pos)
 #define GPIO_PUERS_P22_Pos          22           /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P22              (_U(0x1) << GPIO_PUERS_P22_Pos)
+#define GPIO_PUERS_P22              (_U_(0x1) << GPIO_PUERS_P22_Pos)
 #define GPIO_PUERS_P23_Pos          23           /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P23              (_U(0x1) << GPIO_PUERS_P23_Pos)
+#define GPIO_PUERS_P23              (_U_(0x1) << GPIO_PUERS_P23_Pos)
 #define GPIO_PUERS_P24_Pos          24           /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P24              (_U(0x1) << GPIO_PUERS_P24_Pos)
+#define GPIO_PUERS_P24              (_U_(0x1) << GPIO_PUERS_P24_Pos)
 #define GPIO_PUERS_P25_Pos          25           /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P25              (_U(0x1) << GPIO_PUERS_P25_Pos)
+#define GPIO_PUERS_P25              (_U_(0x1) << GPIO_PUERS_P25_Pos)
 #define GPIO_PUERS_P26_Pos          26           /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P26              (_U(0x1) << GPIO_PUERS_P26_Pos)
+#define GPIO_PUERS_P26              (_U_(0x1) << GPIO_PUERS_P26_Pos)
 #define GPIO_PUERS_P27_Pos          27           /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P27              (_U(0x1) << GPIO_PUERS_P27_Pos)
+#define GPIO_PUERS_P27              (_U_(0x1) << GPIO_PUERS_P27_Pos)
 #define GPIO_PUERS_P28_Pos          28           /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P28              (_U(0x1) << GPIO_PUERS_P28_Pos)
+#define GPIO_PUERS_P28              (_U_(0x1) << GPIO_PUERS_P28_Pos)
 #define GPIO_PUERS_P29_Pos          29           /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P29              (_U(0x1) << GPIO_PUERS_P29_Pos)
+#define GPIO_PUERS_P29              (_U_(0x1) << GPIO_PUERS_P29_Pos)
 #define GPIO_PUERS_P30_Pos          30           /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P30              (_U(0x1) << GPIO_PUERS_P30_Pos)
+#define GPIO_PUERS_P30              (_U_(0x1) << GPIO_PUERS_P30_Pos)
 #define GPIO_PUERS_P31_Pos          31           /**< \brief (GPIO_PUERS) Pull-up Enable */
-#define GPIO_PUERS_P31              (_U(0x1) << GPIO_PUERS_P31_Pos)
-#define GPIO_PUERS_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PUERS) MASK Register */
+#define GPIO_PUERS_P31              (_U_(0x1) << GPIO_PUERS_P31_Pos)
+#define GPIO_PUERS_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_PUERS) MASK Register */
 
 /* -------- GPIO_PUERC : (GPIO Offset: 0x078) ( /W 32) port Pull-up Enable Register - Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3025,70 +3025,70 @@ typedef union {
 #define GPIO_PUERC_OFFSET           0x078        /**< \brief (GPIO_PUERC offset) Pull-up Enable Register - Clear */
 
 #define GPIO_PUERC_P0_Pos           0            /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P0               (_U(0x1) << GPIO_PUERC_P0_Pos)
+#define GPIO_PUERC_P0               (_U_(0x1) << GPIO_PUERC_P0_Pos)
 #define GPIO_PUERC_P1_Pos           1            /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P1               (_U(0x1) << GPIO_PUERC_P1_Pos)
+#define GPIO_PUERC_P1               (_U_(0x1) << GPIO_PUERC_P1_Pos)
 #define GPIO_PUERC_P2_Pos           2            /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P2               (_U(0x1) << GPIO_PUERC_P2_Pos)
+#define GPIO_PUERC_P2               (_U_(0x1) << GPIO_PUERC_P2_Pos)
 #define GPIO_PUERC_P3_Pos           3            /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P3               (_U(0x1) << GPIO_PUERC_P3_Pos)
+#define GPIO_PUERC_P3               (_U_(0x1) << GPIO_PUERC_P3_Pos)
 #define GPIO_PUERC_P4_Pos           4            /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P4               (_U(0x1) << GPIO_PUERC_P4_Pos)
+#define GPIO_PUERC_P4               (_U_(0x1) << GPIO_PUERC_P4_Pos)
 #define GPIO_PUERC_P5_Pos           5            /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P5               (_U(0x1) << GPIO_PUERC_P5_Pos)
+#define GPIO_PUERC_P5               (_U_(0x1) << GPIO_PUERC_P5_Pos)
 #define GPIO_PUERC_P6_Pos           6            /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P6               (_U(0x1) << GPIO_PUERC_P6_Pos)
+#define GPIO_PUERC_P6               (_U_(0x1) << GPIO_PUERC_P6_Pos)
 #define GPIO_PUERC_P7_Pos           7            /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P7               (_U(0x1) << GPIO_PUERC_P7_Pos)
+#define GPIO_PUERC_P7               (_U_(0x1) << GPIO_PUERC_P7_Pos)
 #define GPIO_PUERC_P8_Pos           8            /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P8               (_U(0x1) << GPIO_PUERC_P8_Pos)
+#define GPIO_PUERC_P8               (_U_(0x1) << GPIO_PUERC_P8_Pos)
 #define GPIO_PUERC_P9_Pos           9            /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P9               (_U(0x1) << GPIO_PUERC_P9_Pos)
+#define GPIO_PUERC_P9               (_U_(0x1) << GPIO_PUERC_P9_Pos)
 #define GPIO_PUERC_P10_Pos          10           /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P10              (_U(0x1) << GPIO_PUERC_P10_Pos)
+#define GPIO_PUERC_P10              (_U_(0x1) << GPIO_PUERC_P10_Pos)
 #define GPIO_PUERC_P11_Pos          11           /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P11              (_U(0x1) << GPIO_PUERC_P11_Pos)
+#define GPIO_PUERC_P11              (_U_(0x1) << GPIO_PUERC_P11_Pos)
 #define GPIO_PUERC_P12_Pos          12           /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P12              (_U(0x1) << GPIO_PUERC_P12_Pos)
+#define GPIO_PUERC_P12              (_U_(0x1) << GPIO_PUERC_P12_Pos)
 #define GPIO_PUERC_P13_Pos          13           /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P13              (_U(0x1) << GPIO_PUERC_P13_Pos)
+#define GPIO_PUERC_P13              (_U_(0x1) << GPIO_PUERC_P13_Pos)
 #define GPIO_PUERC_P14_Pos          14           /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P14              (_U(0x1) << GPIO_PUERC_P14_Pos)
+#define GPIO_PUERC_P14              (_U_(0x1) << GPIO_PUERC_P14_Pos)
 #define GPIO_PUERC_P15_Pos          15           /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P15              (_U(0x1) << GPIO_PUERC_P15_Pos)
+#define GPIO_PUERC_P15              (_U_(0x1) << GPIO_PUERC_P15_Pos)
 #define GPIO_PUERC_P16_Pos          16           /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P16              (_U(0x1) << GPIO_PUERC_P16_Pos)
+#define GPIO_PUERC_P16              (_U_(0x1) << GPIO_PUERC_P16_Pos)
 #define GPIO_PUERC_P17_Pos          17           /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P17              (_U(0x1) << GPIO_PUERC_P17_Pos)
+#define GPIO_PUERC_P17              (_U_(0x1) << GPIO_PUERC_P17_Pos)
 #define GPIO_PUERC_P18_Pos          18           /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P18              (_U(0x1) << GPIO_PUERC_P18_Pos)
+#define GPIO_PUERC_P18              (_U_(0x1) << GPIO_PUERC_P18_Pos)
 #define GPIO_PUERC_P19_Pos          19           /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P19              (_U(0x1) << GPIO_PUERC_P19_Pos)
+#define GPIO_PUERC_P19              (_U_(0x1) << GPIO_PUERC_P19_Pos)
 #define GPIO_PUERC_P20_Pos          20           /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P20              (_U(0x1) << GPIO_PUERC_P20_Pos)
+#define GPIO_PUERC_P20              (_U_(0x1) << GPIO_PUERC_P20_Pos)
 #define GPIO_PUERC_P21_Pos          21           /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P21              (_U(0x1) << GPIO_PUERC_P21_Pos)
+#define GPIO_PUERC_P21              (_U_(0x1) << GPIO_PUERC_P21_Pos)
 #define GPIO_PUERC_P22_Pos          22           /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P22              (_U(0x1) << GPIO_PUERC_P22_Pos)
+#define GPIO_PUERC_P22              (_U_(0x1) << GPIO_PUERC_P22_Pos)
 #define GPIO_PUERC_P23_Pos          23           /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P23              (_U(0x1) << GPIO_PUERC_P23_Pos)
+#define GPIO_PUERC_P23              (_U_(0x1) << GPIO_PUERC_P23_Pos)
 #define GPIO_PUERC_P24_Pos          24           /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P24              (_U(0x1) << GPIO_PUERC_P24_Pos)
+#define GPIO_PUERC_P24              (_U_(0x1) << GPIO_PUERC_P24_Pos)
 #define GPIO_PUERC_P25_Pos          25           /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P25              (_U(0x1) << GPIO_PUERC_P25_Pos)
+#define GPIO_PUERC_P25              (_U_(0x1) << GPIO_PUERC_P25_Pos)
 #define GPIO_PUERC_P26_Pos          26           /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P26              (_U(0x1) << GPIO_PUERC_P26_Pos)
+#define GPIO_PUERC_P26              (_U_(0x1) << GPIO_PUERC_P26_Pos)
 #define GPIO_PUERC_P27_Pos          27           /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P27              (_U(0x1) << GPIO_PUERC_P27_Pos)
+#define GPIO_PUERC_P27              (_U_(0x1) << GPIO_PUERC_P27_Pos)
 #define GPIO_PUERC_P28_Pos          28           /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P28              (_U(0x1) << GPIO_PUERC_P28_Pos)
+#define GPIO_PUERC_P28              (_U_(0x1) << GPIO_PUERC_P28_Pos)
 #define GPIO_PUERC_P29_Pos          29           /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P29              (_U(0x1) << GPIO_PUERC_P29_Pos)
+#define GPIO_PUERC_P29              (_U_(0x1) << GPIO_PUERC_P29_Pos)
 #define GPIO_PUERC_P30_Pos          30           /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P30              (_U(0x1) << GPIO_PUERC_P30_Pos)
+#define GPIO_PUERC_P30              (_U_(0x1) << GPIO_PUERC_P30_Pos)
 #define GPIO_PUERC_P31_Pos          31           /**< \brief (GPIO_PUERC) Pull-up Enable */
-#define GPIO_PUERC_P31              (_U(0x1) << GPIO_PUERC_P31_Pos)
-#define GPIO_PUERC_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PUERC) MASK Register */
+#define GPIO_PUERC_P31              (_U_(0x1) << GPIO_PUERC_P31_Pos)
+#define GPIO_PUERC_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_PUERC) MASK Register */
 
 /* -------- GPIO_PUERT : (GPIO Offset: 0x07C) ( /W 32) port Pull-up Enable Register - Toggle -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3134,70 +3134,70 @@ typedef union {
 #define GPIO_PUERT_OFFSET           0x07C        /**< \brief (GPIO_PUERT offset) Pull-up Enable Register - Toggle */
 
 #define GPIO_PUERT_P0_Pos           0            /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P0               (_U(0x1) << GPIO_PUERT_P0_Pos)
+#define GPIO_PUERT_P0               (_U_(0x1) << GPIO_PUERT_P0_Pos)
 #define GPIO_PUERT_P1_Pos           1            /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P1               (_U(0x1) << GPIO_PUERT_P1_Pos)
+#define GPIO_PUERT_P1               (_U_(0x1) << GPIO_PUERT_P1_Pos)
 #define GPIO_PUERT_P2_Pos           2            /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P2               (_U(0x1) << GPIO_PUERT_P2_Pos)
+#define GPIO_PUERT_P2               (_U_(0x1) << GPIO_PUERT_P2_Pos)
 #define GPIO_PUERT_P3_Pos           3            /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P3               (_U(0x1) << GPIO_PUERT_P3_Pos)
+#define GPIO_PUERT_P3               (_U_(0x1) << GPIO_PUERT_P3_Pos)
 #define GPIO_PUERT_P4_Pos           4            /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P4               (_U(0x1) << GPIO_PUERT_P4_Pos)
+#define GPIO_PUERT_P4               (_U_(0x1) << GPIO_PUERT_P4_Pos)
 #define GPIO_PUERT_P5_Pos           5            /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P5               (_U(0x1) << GPIO_PUERT_P5_Pos)
+#define GPIO_PUERT_P5               (_U_(0x1) << GPIO_PUERT_P5_Pos)
 #define GPIO_PUERT_P6_Pos           6            /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P6               (_U(0x1) << GPIO_PUERT_P6_Pos)
+#define GPIO_PUERT_P6               (_U_(0x1) << GPIO_PUERT_P6_Pos)
 #define GPIO_PUERT_P7_Pos           7            /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P7               (_U(0x1) << GPIO_PUERT_P7_Pos)
+#define GPIO_PUERT_P7               (_U_(0x1) << GPIO_PUERT_P7_Pos)
 #define GPIO_PUERT_P8_Pos           8            /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P8               (_U(0x1) << GPIO_PUERT_P8_Pos)
+#define GPIO_PUERT_P8               (_U_(0x1) << GPIO_PUERT_P8_Pos)
 #define GPIO_PUERT_P9_Pos           9            /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P9               (_U(0x1) << GPIO_PUERT_P9_Pos)
+#define GPIO_PUERT_P9               (_U_(0x1) << GPIO_PUERT_P9_Pos)
 #define GPIO_PUERT_P10_Pos          10           /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P10              (_U(0x1) << GPIO_PUERT_P10_Pos)
+#define GPIO_PUERT_P10              (_U_(0x1) << GPIO_PUERT_P10_Pos)
 #define GPIO_PUERT_P11_Pos          11           /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P11              (_U(0x1) << GPIO_PUERT_P11_Pos)
+#define GPIO_PUERT_P11              (_U_(0x1) << GPIO_PUERT_P11_Pos)
 #define GPIO_PUERT_P12_Pos          12           /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P12              (_U(0x1) << GPIO_PUERT_P12_Pos)
+#define GPIO_PUERT_P12              (_U_(0x1) << GPIO_PUERT_P12_Pos)
 #define GPIO_PUERT_P13_Pos          13           /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P13              (_U(0x1) << GPIO_PUERT_P13_Pos)
+#define GPIO_PUERT_P13              (_U_(0x1) << GPIO_PUERT_P13_Pos)
 #define GPIO_PUERT_P14_Pos          14           /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P14              (_U(0x1) << GPIO_PUERT_P14_Pos)
+#define GPIO_PUERT_P14              (_U_(0x1) << GPIO_PUERT_P14_Pos)
 #define GPIO_PUERT_P15_Pos          15           /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P15              (_U(0x1) << GPIO_PUERT_P15_Pos)
+#define GPIO_PUERT_P15              (_U_(0x1) << GPIO_PUERT_P15_Pos)
 #define GPIO_PUERT_P16_Pos          16           /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P16              (_U(0x1) << GPIO_PUERT_P16_Pos)
+#define GPIO_PUERT_P16              (_U_(0x1) << GPIO_PUERT_P16_Pos)
 #define GPIO_PUERT_P17_Pos          17           /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P17              (_U(0x1) << GPIO_PUERT_P17_Pos)
+#define GPIO_PUERT_P17              (_U_(0x1) << GPIO_PUERT_P17_Pos)
 #define GPIO_PUERT_P18_Pos          18           /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P18              (_U(0x1) << GPIO_PUERT_P18_Pos)
+#define GPIO_PUERT_P18              (_U_(0x1) << GPIO_PUERT_P18_Pos)
 #define GPIO_PUERT_P19_Pos          19           /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P19              (_U(0x1) << GPIO_PUERT_P19_Pos)
+#define GPIO_PUERT_P19              (_U_(0x1) << GPIO_PUERT_P19_Pos)
 #define GPIO_PUERT_P20_Pos          20           /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P20              (_U(0x1) << GPIO_PUERT_P20_Pos)
+#define GPIO_PUERT_P20              (_U_(0x1) << GPIO_PUERT_P20_Pos)
 #define GPIO_PUERT_P21_Pos          21           /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P21              (_U(0x1) << GPIO_PUERT_P21_Pos)
+#define GPIO_PUERT_P21              (_U_(0x1) << GPIO_PUERT_P21_Pos)
 #define GPIO_PUERT_P22_Pos          22           /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P22              (_U(0x1) << GPIO_PUERT_P22_Pos)
+#define GPIO_PUERT_P22              (_U_(0x1) << GPIO_PUERT_P22_Pos)
 #define GPIO_PUERT_P23_Pos          23           /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P23              (_U(0x1) << GPIO_PUERT_P23_Pos)
+#define GPIO_PUERT_P23              (_U_(0x1) << GPIO_PUERT_P23_Pos)
 #define GPIO_PUERT_P24_Pos          24           /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P24              (_U(0x1) << GPIO_PUERT_P24_Pos)
+#define GPIO_PUERT_P24              (_U_(0x1) << GPIO_PUERT_P24_Pos)
 #define GPIO_PUERT_P25_Pos          25           /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P25              (_U(0x1) << GPIO_PUERT_P25_Pos)
+#define GPIO_PUERT_P25              (_U_(0x1) << GPIO_PUERT_P25_Pos)
 #define GPIO_PUERT_P26_Pos          26           /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P26              (_U(0x1) << GPIO_PUERT_P26_Pos)
+#define GPIO_PUERT_P26              (_U_(0x1) << GPIO_PUERT_P26_Pos)
 #define GPIO_PUERT_P27_Pos          27           /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P27              (_U(0x1) << GPIO_PUERT_P27_Pos)
+#define GPIO_PUERT_P27              (_U_(0x1) << GPIO_PUERT_P27_Pos)
 #define GPIO_PUERT_P28_Pos          28           /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P28              (_U(0x1) << GPIO_PUERT_P28_Pos)
+#define GPIO_PUERT_P28              (_U_(0x1) << GPIO_PUERT_P28_Pos)
 #define GPIO_PUERT_P29_Pos          29           /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P29              (_U(0x1) << GPIO_PUERT_P29_Pos)
+#define GPIO_PUERT_P29              (_U_(0x1) << GPIO_PUERT_P29_Pos)
 #define GPIO_PUERT_P30_Pos          30           /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P30              (_U(0x1) << GPIO_PUERT_P30_Pos)
+#define GPIO_PUERT_P30              (_U_(0x1) << GPIO_PUERT_P30_Pos)
 #define GPIO_PUERT_P31_Pos          31           /**< \brief (GPIO_PUERT) Pull-up Enable */
-#define GPIO_PUERT_P31              (_U(0x1) << GPIO_PUERT_P31_Pos)
-#define GPIO_PUERT_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PUERT) MASK Register */
+#define GPIO_PUERT_P31              (_U_(0x1) << GPIO_PUERT_P31_Pos)
+#define GPIO_PUERT_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_PUERT) MASK Register */
 
 /* -------- GPIO_PDER : (GPIO Offset: 0x080) (R/W 32) port Pull-down Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3243,70 +3243,70 @@ typedef union {
 #define GPIO_PDER_OFFSET            0x080        /**< \brief (GPIO_PDER offset) Pull-down Enable Register */
 
 #define GPIO_PDER_P0_Pos            0            /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P0                (_U(0x1) << GPIO_PDER_P0_Pos)
+#define GPIO_PDER_P0                (_U_(0x1) << GPIO_PDER_P0_Pos)
 #define GPIO_PDER_P1_Pos            1            /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P1                (_U(0x1) << GPIO_PDER_P1_Pos)
+#define GPIO_PDER_P1                (_U_(0x1) << GPIO_PDER_P1_Pos)
 #define GPIO_PDER_P2_Pos            2            /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P2                (_U(0x1) << GPIO_PDER_P2_Pos)
+#define GPIO_PDER_P2                (_U_(0x1) << GPIO_PDER_P2_Pos)
 #define GPIO_PDER_P3_Pos            3            /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P3                (_U(0x1) << GPIO_PDER_P3_Pos)
+#define GPIO_PDER_P3                (_U_(0x1) << GPIO_PDER_P3_Pos)
 #define GPIO_PDER_P4_Pos            4            /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P4                (_U(0x1) << GPIO_PDER_P4_Pos)
+#define GPIO_PDER_P4                (_U_(0x1) << GPIO_PDER_P4_Pos)
 #define GPIO_PDER_P5_Pos            5            /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P5                (_U(0x1) << GPIO_PDER_P5_Pos)
+#define GPIO_PDER_P5                (_U_(0x1) << GPIO_PDER_P5_Pos)
 #define GPIO_PDER_P6_Pos            6            /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P6                (_U(0x1) << GPIO_PDER_P6_Pos)
+#define GPIO_PDER_P6                (_U_(0x1) << GPIO_PDER_P6_Pos)
 #define GPIO_PDER_P7_Pos            7            /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P7                (_U(0x1) << GPIO_PDER_P7_Pos)
+#define GPIO_PDER_P7                (_U_(0x1) << GPIO_PDER_P7_Pos)
 #define GPIO_PDER_P8_Pos            8            /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P8                (_U(0x1) << GPIO_PDER_P8_Pos)
+#define GPIO_PDER_P8                (_U_(0x1) << GPIO_PDER_P8_Pos)
 #define GPIO_PDER_P9_Pos            9            /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P9                (_U(0x1) << GPIO_PDER_P9_Pos)
+#define GPIO_PDER_P9                (_U_(0x1) << GPIO_PDER_P9_Pos)
 #define GPIO_PDER_P10_Pos           10           /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P10               (_U(0x1) << GPIO_PDER_P10_Pos)
+#define GPIO_PDER_P10               (_U_(0x1) << GPIO_PDER_P10_Pos)
 #define GPIO_PDER_P11_Pos           11           /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P11               (_U(0x1) << GPIO_PDER_P11_Pos)
+#define GPIO_PDER_P11               (_U_(0x1) << GPIO_PDER_P11_Pos)
 #define GPIO_PDER_P12_Pos           12           /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P12               (_U(0x1) << GPIO_PDER_P12_Pos)
+#define GPIO_PDER_P12               (_U_(0x1) << GPIO_PDER_P12_Pos)
 #define GPIO_PDER_P13_Pos           13           /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P13               (_U(0x1) << GPIO_PDER_P13_Pos)
+#define GPIO_PDER_P13               (_U_(0x1) << GPIO_PDER_P13_Pos)
 #define GPIO_PDER_P14_Pos           14           /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P14               (_U(0x1) << GPIO_PDER_P14_Pos)
+#define GPIO_PDER_P14               (_U_(0x1) << GPIO_PDER_P14_Pos)
 #define GPIO_PDER_P15_Pos           15           /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P15               (_U(0x1) << GPIO_PDER_P15_Pos)
+#define GPIO_PDER_P15               (_U_(0x1) << GPIO_PDER_P15_Pos)
 #define GPIO_PDER_P16_Pos           16           /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P16               (_U(0x1) << GPIO_PDER_P16_Pos)
+#define GPIO_PDER_P16               (_U_(0x1) << GPIO_PDER_P16_Pos)
 #define GPIO_PDER_P17_Pos           17           /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P17               (_U(0x1) << GPIO_PDER_P17_Pos)
+#define GPIO_PDER_P17               (_U_(0x1) << GPIO_PDER_P17_Pos)
 #define GPIO_PDER_P18_Pos           18           /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P18               (_U(0x1) << GPIO_PDER_P18_Pos)
+#define GPIO_PDER_P18               (_U_(0x1) << GPIO_PDER_P18_Pos)
 #define GPIO_PDER_P19_Pos           19           /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P19               (_U(0x1) << GPIO_PDER_P19_Pos)
+#define GPIO_PDER_P19               (_U_(0x1) << GPIO_PDER_P19_Pos)
 #define GPIO_PDER_P20_Pos           20           /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P20               (_U(0x1) << GPIO_PDER_P20_Pos)
+#define GPIO_PDER_P20               (_U_(0x1) << GPIO_PDER_P20_Pos)
 #define GPIO_PDER_P21_Pos           21           /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P21               (_U(0x1) << GPIO_PDER_P21_Pos)
+#define GPIO_PDER_P21               (_U_(0x1) << GPIO_PDER_P21_Pos)
 #define GPIO_PDER_P22_Pos           22           /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P22               (_U(0x1) << GPIO_PDER_P22_Pos)
+#define GPIO_PDER_P22               (_U_(0x1) << GPIO_PDER_P22_Pos)
 #define GPIO_PDER_P23_Pos           23           /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P23               (_U(0x1) << GPIO_PDER_P23_Pos)
+#define GPIO_PDER_P23               (_U_(0x1) << GPIO_PDER_P23_Pos)
 #define GPIO_PDER_P24_Pos           24           /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P24               (_U(0x1) << GPIO_PDER_P24_Pos)
+#define GPIO_PDER_P24               (_U_(0x1) << GPIO_PDER_P24_Pos)
 #define GPIO_PDER_P25_Pos           25           /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P25               (_U(0x1) << GPIO_PDER_P25_Pos)
+#define GPIO_PDER_P25               (_U_(0x1) << GPIO_PDER_P25_Pos)
 #define GPIO_PDER_P26_Pos           26           /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P26               (_U(0x1) << GPIO_PDER_P26_Pos)
+#define GPIO_PDER_P26               (_U_(0x1) << GPIO_PDER_P26_Pos)
 #define GPIO_PDER_P27_Pos           27           /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P27               (_U(0x1) << GPIO_PDER_P27_Pos)
+#define GPIO_PDER_P27               (_U_(0x1) << GPIO_PDER_P27_Pos)
 #define GPIO_PDER_P28_Pos           28           /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P28               (_U(0x1) << GPIO_PDER_P28_Pos)
+#define GPIO_PDER_P28               (_U_(0x1) << GPIO_PDER_P28_Pos)
 #define GPIO_PDER_P29_Pos           29           /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P29               (_U(0x1) << GPIO_PDER_P29_Pos)
+#define GPIO_PDER_P29               (_U_(0x1) << GPIO_PDER_P29_Pos)
 #define GPIO_PDER_P30_Pos           30           /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P30               (_U(0x1) << GPIO_PDER_P30_Pos)
+#define GPIO_PDER_P30               (_U_(0x1) << GPIO_PDER_P30_Pos)
 #define GPIO_PDER_P31_Pos           31           /**< \brief (GPIO_PDER) Pull-down Enable */
-#define GPIO_PDER_P31               (_U(0x1) << GPIO_PDER_P31_Pos)
-#define GPIO_PDER_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_PDER) MASK Register */
+#define GPIO_PDER_P31               (_U_(0x1) << GPIO_PDER_P31_Pos)
+#define GPIO_PDER_MASK              _U_(0xFFFFFFFF) /**< \brief (GPIO_PDER) MASK Register */
 
 /* -------- GPIO_PDERS : (GPIO Offset: 0x084) ( /W 32) port Pull-down Enable Register - Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3352,70 +3352,70 @@ typedef union {
 #define GPIO_PDERS_OFFSET           0x084        /**< \brief (GPIO_PDERS offset) Pull-down Enable Register - Set */
 
 #define GPIO_PDERS_P0_Pos           0            /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P0               (_U(0x1) << GPIO_PDERS_P0_Pos)
+#define GPIO_PDERS_P0               (_U_(0x1) << GPIO_PDERS_P0_Pos)
 #define GPIO_PDERS_P1_Pos           1            /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P1               (_U(0x1) << GPIO_PDERS_P1_Pos)
+#define GPIO_PDERS_P1               (_U_(0x1) << GPIO_PDERS_P1_Pos)
 #define GPIO_PDERS_P2_Pos           2            /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P2               (_U(0x1) << GPIO_PDERS_P2_Pos)
+#define GPIO_PDERS_P2               (_U_(0x1) << GPIO_PDERS_P2_Pos)
 #define GPIO_PDERS_P3_Pos           3            /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P3               (_U(0x1) << GPIO_PDERS_P3_Pos)
+#define GPIO_PDERS_P3               (_U_(0x1) << GPIO_PDERS_P3_Pos)
 #define GPIO_PDERS_P4_Pos           4            /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P4               (_U(0x1) << GPIO_PDERS_P4_Pos)
+#define GPIO_PDERS_P4               (_U_(0x1) << GPIO_PDERS_P4_Pos)
 #define GPIO_PDERS_P5_Pos           5            /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P5               (_U(0x1) << GPIO_PDERS_P5_Pos)
+#define GPIO_PDERS_P5               (_U_(0x1) << GPIO_PDERS_P5_Pos)
 #define GPIO_PDERS_P6_Pos           6            /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P6               (_U(0x1) << GPIO_PDERS_P6_Pos)
+#define GPIO_PDERS_P6               (_U_(0x1) << GPIO_PDERS_P6_Pos)
 #define GPIO_PDERS_P7_Pos           7            /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P7               (_U(0x1) << GPIO_PDERS_P7_Pos)
+#define GPIO_PDERS_P7               (_U_(0x1) << GPIO_PDERS_P7_Pos)
 #define GPIO_PDERS_P8_Pos           8            /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P8               (_U(0x1) << GPIO_PDERS_P8_Pos)
+#define GPIO_PDERS_P8               (_U_(0x1) << GPIO_PDERS_P8_Pos)
 #define GPIO_PDERS_P9_Pos           9            /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P9               (_U(0x1) << GPIO_PDERS_P9_Pos)
+#define GPIO_PDERS_P9               (_U_(0x1) << GPIO_PDERS_P9_Pos)
 #define GPIO_PDERS_P10_Pos          10           /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P10              (_U(0x1) << GPIO_PDERS_P10_Pos)
+#define GPIO_PDERS_P10              (_U_(0x1) << GPIO_PDERS_P10_Pos)
 #define GPIO_PDERS_P11_Pos          11           /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P11              (_U(0x1) << GPIO_PDERS_P11_Pos)
+#define GPIO_PDERS_P11              (_U_(0x1) << GPIO_PDERS_P11_Pos)
 #define GPIO_PDERS_P12_Pos          12           /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P12              (_U(0x1) << GPIO_PDERS_P12_Pos)
+#define GPIO_PDERS_P12              (_U_(0x1) << GPIO_PDERS_P12_Pos)
 #define GPIO_PDERS_P13_Pos          13           /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P13              (_U(0x1) << GPIO_PDERS_P13_Pos)
+#define GPIO_PDERS_P13              (_U_(0x1) << GPIO_PDERS_P13_Pos)
 #define GPIO_PDERS_P14_Pos          14           /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P14              (_U(0x1) << GPIO_PDERS_P14_Pos)
+#define GPIO_PDERS_P14              (_U_(0x1) << GPIO_PDERS_P14_Pos)
 #define GPIO_PDERS_P15_Pos          15           /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P15              (_U(0x1) << GPIO_PDERS_P15_Pos)
+#define GPIO_PDERS_P15              (_U_(0x1) << GPIO_PDERS_P15_Pos)
 #define GPIO_PDERS_P16_Pos          16           /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P16              (_U(0x1) << GPIO_PDERS_P16_Pos)
+#define GPIO_PDERS_P16              (_U_(0x1) << GPIO_PDERS_P16_Pos)
 #define GPIO_PDERS_P17_Pos          17           /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P17              (_U(0x1) << GPIO_PDERS_P17_Pos)
+#define GPIO_PDERS_P17              (_U_(0x1) << GPIO_PDERS_P17_Pos)
 #define GPIO_PDERS_P18_Pos          18           /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P18              (_U(0x1) << GPIO_PDERS_P18_Pos)
+#define GPIO_PDERS_P18              (_U_(0x1) << GPIO_PDERS_P18_Pos)
 #define GPIO_PDERS_P19_Pos          19           /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P19              (_U(0x1) << GPIO_PDERS_P19_Pos)
+#define GPIO_PDERS_P19              (_U_(0x1) << GPIO_PDERS_P19_Pos)
 #define GPIO_PDERS_P20_Pos          20           /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P20              (_U(0x1) << GPIO_PDERS_P20_Pos)
+#define GPIO_PDERS_P20              (_U_(0x1) << GPIO_PDERS_P20_Pos)
 #define GPIO_PDERS_P21_Pos          21           /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P21              (_U(0x1) << GPIO_PDERS_P21_Pos)
+#define GPIO_PDERS_P21              (_U_(0x1) << GPIO_PDERS_P21_Pos)
 #define GPIO_PDERS_P22_Pos          22           /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P22              (_U(0x1) << GPIO_PDERS_P22_Pos)
+#define GPIO_PDERS_P22              (_U_(0x1) << GPIO_PDERS_P22_Pos)
 #define GPIO_PDERS_P23_Pos          23           /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P23              (_U(0x1) << GPIO_PDERS_P23_Pos)
+#define GPIO_PDERS_P23              (_U_(0x1) << GPIO_PDERS_P23_Pos)
 #define GPIO_PDERS_P24_Pos          24           /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P24              (_U(0x1) << GPIO_PDERS_P24_Pos)
+#define GPIO_PDERS_P24              (_U_(0x1) << GPIO_PDERS_P24_Pos)
 #define GPIO_PDERS_P25_Pos          25           /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P25              (_U(0x1) << GPIO_PDERS_P25_Pos)
+#define GPIO_PDERS_P25              (_U_(0x1) << GPIO_PDERS_P25_Pos)
 #define GPIO_PDERS_P26_Pos          26           /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P26              (_U(0x1) << GPIO_PDERS_P26_Pos)
+#define GPIO_PDERS_P26              (_U_(0x1) << GPIO_PDERS_P26_Pos)
 #define GPIO_PDERS_P27_Pos          27           /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P27              (_U(0x1) << GPIO_PDERS_P27_Pos)
+#define GPIO_PDERS_P27              (_U_(0x1) << GPIO_PDERS_P27_Pos)
 #define GPIO_PDERS_P28_Pos          28           /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P28              (_U(0x1) << GPIO_PDERS_P28_Pos)
+#define GPIO_PDERS_P28              (_U_(0x1) << GPIO_PDERS_P28_Pos)
 #define GPIO_PDERS_P29_Pos          29           /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P29              (_U(0x1) << GPIO_PDERS_P29_Pos)
+#define GPIO_PDERS_P29              (_U_(0x1) << GPIO_PDERS_P29_Pos)
 #define GPIO_PDERS_P30_Pos          30           /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P30              (_U(0x1) << GPIO_PDERS_P30_Pos)
+#define GPIO_PDERS_P30              (_U_(0x1) << GPIO_PDERS_P30_Pos)
 #define GPIO_PDERS_P31_Pos          31           /**< \brief (GPIO_PDERS) Pull-down Enable */
-#define GPIO_PDERS_P31              (_U(0x1) << GPIO_PDERS_P31_Pos)
-#define GPIO_PDERS_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PDERS) MASK Register */
+#define GPIO_PDERS_P31              (_U_(0x1) << GPIO_PDERS_P31_Pos)
+#define GPIO_PDERS_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_PDERS) MASK Register */
 
 /* -------- GPIO_PDERC : (GPIO Offset: 0x088) ( /W 32) port Pull-down Enable Register - Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3461,70 +3461,70 @@ typedef union {
 #define GPIO_PDERC_OFFSET           0x088        /**< \brief (GPIO_PDERC offset) Pull-down Enable Register - Clear */
 
 #define GPIO_PDERC_P0_Pos           0            /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P0               (_U(0x1) << GPIO_PDERC_P0_Pos)
+#define GPIO_PDERC_P0               (_U_(0x1) << GPIO_PDERC_P0_Pos)
 #define GPIO_PDERC_P1_Pos           1            /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P1               (_U(0x1) << GPIO_PDERC_P1_Pos)
+#define GPIO_PDERC_P1               (_U_(0x1) << GPIO_PDERC_P1_Pos)
 #define GPIO_PDERC_P2_Pos           2            /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P2               (_U(0x1) << GPIO_PDERC_P2_Pos)
+#define GPIO_PDERC_P2               (_U_(0x1) << GPIO_PDERC_P2_Pos)
 #define GPIO_PDERC_P3_Pos           3            /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P3               (_U(0x1) << GPIO_PDERC_P3_Pos)
+#define GPIO_PDERC_P3               (_U_(0x1) << GPIO_PDERC_P3_Pos)
 #define GPIO_PDERC_P4_Pos           4            /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P4               (_U(0x1) << GPIO_PDERC_P4_Pos)
+#define GPIO_PDERC_P4               (_U_(0x1) << GPIO_PDERC_P4_Pos)
 #define GPIO_PDERC_P5_Pos           5            /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P5               (_U(0x1) << GPIO_PDERC_P5_Pos)
+#define GPIO_PDERC_P5               (_U_(0x1) << GPIO_PDERC_P5_Pos)
 #define GPIO_PDERC_P6_Pos           6            /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P6               (_U(0x1) << GPIO_PDERC_P6_Pos)
+#define GPIO_PDERC_P6               (_U_(0x1) << GPIO_PDERC_P6_Pos)
 #define GPIO_PDERC_P7_Pos           7            /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P7               (_U(0x1) << GPIO_PDERC_P7_Pos)
+#define GPIO_PDERC_P7               (_U_(0x1) << GPIO_PDERC_P7_Pos)
 #define GPIO_PDERC_P8_Pos           8            /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P8               (_U(0x1) << GPIO_PDERC_P8_Pos)
+#define GPIO_PDERC_P8               (_U_(0x1) << GPIO_PDERC_P8_Pos)
 #define GPIO_PDERC_P9_Pos           9            /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P9               (_U(0x1) << GPIO_PDERC_P9_Pos)
+#define GPIO_PDERC_P9               (_U_(0x1) << GPIO_PDERC_P9_Pos)
 #define GPIO_PDERC_P10_Pos          10           /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P10              (_U(0x1) << GPIO_PDERC_P10_Pos)
+#define GPIO_PDERC_P10              (_U_(0x1) << GPIO_PDERC_P10_Pos)
 #define GPIO_PDERC_P11_Pos          11           /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P11              (_U(0x1) << GPIO_PDERC_P11_Pos)
+#define GPIO_PDERC_P11              (_U_(0x1) << GPIO_PDERC_P11_Pos)
 #define GPIO_PDERC_P12_Pos          12           /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P12              (_U(0x1) << GPIO_PDERC_P12_Pos)
+#define GPIO_PDERC_P12              (_U_(0x1) << GPIO_PDERC_P12_Pos)
 #define GPIO_PDERC_P13_Pos          13           /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P13              (_U(0x1) << GPIO_PDERC_P13_Pos)
+#define GPIO_PDERC_P13              (_U_(0x1) << GPIO_PDERC_P13_Pos)
 #define GPIO_PDERC_P14_Pos          14           /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P14              (_U(0x1) << GPIO_PDERC_P14_Pos)
+#define GPIO_PDERC_P14              (_U_(0x1) << GPIO_PDERC_P14_Pos)
 #define GPIO_PDERC_P15_Pos          15           /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P15              (_U(0x1) << GPIO_PDERC_P15_Pos)
+#define GPIO_PDERC_P15              (_U_(0x1) << GPIO_PDERC_P15_Pos)
 #define GPIO_PDERC_P16_Pos          16           /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P16              (_U(0x1) << GPIO_PDERC_P16_Pos)
+#define GPIO_PDERC_P16              (_U_(0x1) << GPIO_PDERC_P16_Pos)
 #define GPIO_PDERC_P17_Pos          17           /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P17              (_U(0x1) << GPIO_PDERC_P17_Pos)
+#define GPIO_PDERC_P17              (_U_(0x1) << GPIO_PDERC_P17_Pos)
 #define GPIO_PDERC_P18_Pos          18           /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P18              (_U(0x1) << GPIO_PDERC_P18_Pos)
+#define GPIO_PDERC_P18              (_U_(0x1) << GPIO_PDERC_P18_Pos)
 #define GPIO_PDERC_P19_Pos          19           /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P19              (_U(0x1) << GPIO_PDERC_P19_Pos)
+#define GPIO_PDERC_P19              (_U_(0x1) << GPIO_PDERC_P19_Pos)
 #define GPIO_PDERC_P20_Pos          20           /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P20              (_U(0x1) << GPIO_PDERC_P20_Pos)
+#define GPIO_PDERC_P20              (_U_(0x1) << GPIO_PDERC_P20_Pos)
 #define GPIO_PDERC_P21_Pos          21           /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P21              (_U(0x1) << GPIO_PDERC_P21_Pos)
+#define GPIO_PDERC_P21              (_U_(0x1) << GPIO_PDERC_P21_Pos)
 #define GPIO_PDERC_P22_Pos          22           /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P22              (_U(0x1) << GPIO_PDERC_P22_Pos)
+#define GPIO_PDERC_P22              (_U_(0x1) << GPIO_PDERC_P22_Pos)
 #define GPIO_PDERC_P23_Pos          23           /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P23              (_U(0x1) << GPIO_PDERC_P23_Pos)
+#define GPIO_PDERC_P23              (_U_(0x1) << GPIO_PDERC_P23_Pos)
 #define GPIO_PDERC_P24_Pos          24           /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P24              (_U(0x1) << GPIO_PDERC_P24_Pos)
+#define GPIO_PDERC_P24              (_U_(0x1) << GPIO_PDERC_P24_Pos)
 #define GPIO_PDERC_P25_Pos          25           /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P25              (_U(0x1) << GPIO_PDERC_P25_Pos)
+#define GPIO_PDERC_P25              (_U_(0x1) << GPIO_PDERC_P25_Pos)
 #define GPIO_PDERC_P26_Pos          26           /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P26              (_U(0x1) << GPIO_PDERC_P26_Pos)
+#define GPIO_PDERC_P26              (_U_(0x1) << GPIO_PDERC_P26_Pos)
 #define GPIO_PDERC_P27_Pos          27           /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P27              (_U(0x1) << GPIO_PDERC_P27_Pos)
+#define GPIO_PDERC_P27              (_U_(0x1) << GPIO_PDERC_P27_Pos)
 #define GPIO_PDERC_P28_Pos          28           /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P28              (_U(0x1) << GPIO_PDERC_P28_Pos)
+#define GPIO_PDERC_P28              (_U_(0x1) << GPIO_PDERC_P28_Pos)
 #define GPIO_PDERC_P29_Pos          29           /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P29              (_U(0x1) << GPIO_PDERC_P29_Pos)
+#define GPIO_PDERC_P29              (_U_(0x1) << GPIO_PDERC_P29_Pos)
 #define GPIO_PDERC_P30_Pos          30           /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P30              (_U(0x1) << GPIO_PDERC_P30_Pos)
+#define GPIO_PDERC_P30              (_U_(0x1) << GPIO_PDERC_P30_Pos)
 #define GPIO_PDERC_P31_Pos          31           /**< \brief (GPIO_PDERC) Pull-down Enable */
-#define GPIO_PDERC_P31              (_U(0x1) << GPIO_PDERC_P31_Pos)
-#define GPIO_PDERC_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PDERC) MASK Register */
+#define GPIO_PDERC_P31              (_U_(0x1) << GPIO_PDERC_P31_Pos)
+#define GPIO_PDERC_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_PDERC) MASK Register */
 
 /* -------- GPIO_PDERT : (GPIO Offset: 0x08C) ( /W 32) port Pull-down Enable Register - Toggle -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3570,70 +3570,70 @@ typedef union {
 #define GPIO_PDERT_OFFSET           0x08C        /**< \brief (GPIO_PDERT offset) Pull-down Enable Register - Toggle */
 
 #define GPIO_PDERT_P0_Pos           0            /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P0               (_U(0x1) << GPIO_PDERT_P0_Pos)
+#define GPIO_PDERT_P0               (_U_(0x1) << GPIO_PDERT_P0_Pos)
 #define GPIO_PDERT_P1_Pos           1            /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P1               (_U(0x1) << GPIO_PDERT_P1_Pos)
+#define GPIO_PDERT_P1               (_U_(0x1) << GPIO_PDERT_P1_Pos)
 #define GPIO_PDERT_P2_Pos           2            /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P2               (_U(0x1) << GPIO_PDERT_P2_Pos)
+#define GPIO_PDERT_P2               (_U_(0x1) << GPIO_PDERT_P2_Pos)
 #define GPIO_PDERT_P3_Pos           3            /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P3               (_U(0x1) << GPIO_PDERT_P3_Pos)
+#define GPIO_PDERT_P3               (_U_(0x1) << GPIO_PDERT_P3_Pos)
 #define GPIO_PDERT_P4_Pos           4            /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P4               (_U(0x1) << GPIO_PDERT_P4_Pos)
+#define GPIO_PDERT_P4               (_U_(0x1) << GPIO_PDERT_P4_Pos)
 #define GPIO_PDERT_P5_Pos           5            /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P5               (_U(0x1) << GPIO_PDERT_P5_Pos)
+#define GPIO_PDERT_P5               (_U_(0x1) << GPIO_PDERT_P5_Pos)
 #define GPIO_PDERT_P6_Pos           6            /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P6               (_U(0x1) << GPIO_PDERT_P6_Pos)
+#define GPIO_PDERT_P6               (_U_(0x1) << GPIO_PDERT_P6_Pos)
 #define GPIO_PDERT_P7_Pos           7            /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P7               (_U(0x1) << GPIO_PDERT_P7_Pos)
+#define GPIO_PDERT_P7               (_U_(0x1) << GPIO_PDERT_P7_Pos)
 #define GPIO_PDERT_P8_Pos           8            /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P8               (_U(0x1) << GPIO_PDERT_P8_Pos)
+#define GPIO_PDERT_P8               (_U_(0x1) << GPIO_PDERT_P8_Pos)
 #define GPIO_PDERT_P9_Pos           9            /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P9               (_U(0x1) << GPIO_PDERT_P9_Pos)
+#define GPIO_PDERT_P9               (_U_(0x1) << GPIO_PDERT_P9_Pos)
 #define GPIO_PDERT_P10_Pos          10           /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P10              (_U(0x1) << GPIO_PDERT_P10_Pos)
+#define GPIO_PDERT_P10              (_U_(0x1) << GPIO_PDERT_P10_Pos)
 #define GPIO_PDERT_P11_Pos          11           /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P11              (_U(0x1) << GPIO_PDERT_P11_Pos)
+#define GPIO_PDERT_P11              (_U_(0x1) << GPIO_PDERT_P11_Pos)
 #define GPIO_PDERT_P12_Pos          12           /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P12              (_U(0x1) << GPIO_PDERT_P12_Pos)
+#define GPIO_PDERT_P12              (_U_(0x1) << GPIO_PDERT_P12_Pos)
 #define GPIO_PDERT_P13_Pos          13           /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P13              (_U(0x1) << GPIO_PDERT_P13_Pos)
+#define GPIO_PDERT_P13              (_U_(0x1) << GPIO_PDERT_P13_Pos)
 #define GPIO_PDERT_P14_Pos          14           /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P14              (_U(0x1) << GPIO_PDERT_P14_Pos)
+#define GPIO_PDERT_P14              (_U_(0x1) << GPIO_PDERT_P14_Pos)
 #define GPIO_PDERT_P15_Pos          15           /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P15              (_U(0x1) << GPIO_PDERT_P15_Pos)
+#define GPIO_PDERT_P15              (_U_(0x1) << GPIO_PDERT_P15_Pos)
 #define GPIO_PDERT_P16_Pos          16           /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P16              (_U(0x1) << GPIO_PDERT_P16_Pos)
+#define GPIO_PDERT_P16              (_U_(0x1) << GPIO_PDERT_P16_Pos)
 #define GPIO_PDERT_P17_Pos          17           /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P17              (_U(0x1) << GPIO_PDERT_P17_Pos)
+#define GPIO_PDERT_P17              (_U_(0x1) << GPIO_PDERT_P17_Pos)
 #define GPIO_PDERT_P18_Pos          18           /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P18              (_U(0x1) << GPIO_PDERT_P18_Pos)
+#define GPIO_PDERT_P18              (_U_(0x1) << GPIO_PDERT_P18_Pos)
 #define GPIO_PDERT_P19_Pos          19           /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P19              (_U(0x1) << GPIO_PDERT_P19_Pos)
+#define GPIO_PDERT_P19              (_U_(0x1) << GPIO_PDERT_P19_Pos)
 #define GPIO_PDERT_P20_Pos          20           /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P20              (_U(0x1) << GPIO_PDERT_P20_Pos)
+#define GPIO_PDERT_P20              (_U_(0x1) << GPIO_PDERT_P20_Pos)
 #define GPIO_PDERT_P21_Pos          21           /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P21              (_U(0x1) << GPIO_PDERT_P21_Pos)
+#define GPIO_PDERT_P21              (_U_(0x1) << GPIO_PDERT_P21_Pos)
 #define GPIO_PDERT_P22_Pos          22           /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P22              (_U(0x1) << GPIO_PDERT_P22_Pos)
+#define GPIO_PDERT_P22              (_U_(0x1) << GPIO_PDERT_P22_Pos)
 #define GPIO_PDERT_P23_Pos          23           /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P23              (_U(0x1) << GPIO_PDERT_P23_Pos)
+#define GPIO_PDERT_P23              (_U_(0x1) << GPIO_PDERT_P23_Pos)
 #define GPIO_PDERT_P24_Pos          24           /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P24              (_U(0x1) << GPIO_PDERT_P24_Pos)
+#define GPIO_PDERT_P24              (_U_(0x1) << GPIO_PDERT_P24_Pos)
 #define GPIO_PDERT_P25_Pos          25           /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P25              (_U(0x1) << GPIO_PDERT_P25_Pos)
+#define GPIO_PDERT_P25              (_U_(0x1) << GPIO_PDERT_P25_Pos)
 #define GPIO_PDERT_P26_Pos          26           /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P26              (_U(0x1) << GPIO_PDERT_P26_Pos)
+#define GPIO_PDERT_P26              (_U_(0x1) << GPIO_PDERT_P26_Pos)
 #define GPIO_PDERT_P27_Pos          27           /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P27              (_U(0x1) << GPIO_PDERT_P27_Pos)
+#define GPIO_PDERT_P27              (_U_(0x1) << GPIO_PDERT_P27_Pos)
 #define GPIO_PDERT_P28_Pos          28           /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P28              (_U(0x1) << GPIO_PDERT_P28_Pos)
+#define GPIO_PDERT_P28              (_U_(0x1) << GPIO_PDERT_P28_Pos)
 #define GPIO_PDERT_P29_Pos          29           /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P29              (_U(0x1) << GPIO_PDERT_P29_Pos)
+#define GPIO_PDERT_P29              (_U_(0x1) << GPIO_PDERT_P29_Pos)
 #define GPIO_PDERT_P30_Pos          30           /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P30              (_U(0x1) << GPIO_PDERT_P30_Pos)
+#define GPIO_PDERT_P30              (_U_(0x1) << GPIO_PDERT_P30_Pos)
 #define GPIO_PDERT_P31_Pos          31           /**< \brief (GPIO_PDERT) Pull-down Enable */
-#define GPIO_PDERT_P31              (_U(0x1) << GPIO_PDERT_P31_Pos)
-#define GPIO_PDERT_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_PDERT) MASK Register */
+#define GPIO_PDERT_P31              (_U_(0x1) << GPIO_PDERT_P31_Pos)
+#define GPIO_PDERT_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_PDERT) MASK Register */
 
 /* -------- GPIO_IER : (GPIO Offset: 0x090) (R/W 32) port Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3679,70 +3679,70 @@ typedef union {
 #define GPIO_IER_OFFSET             0x090        /**< \brief (GPIO_IER offset) Interrupt Enable Register */
 
 #define GPIO_IER_P0_Pos             0            /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P0                 (_U(0x1) << GPIO_IER_P0_Pos)
+#define GPIO_IER_P0                 (_U_(0x1) << GPIO_IER_P0_Pos)
 #define GPIO_IER_P1_Pos             1            /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P1                 (_U(0x1) << GPIO_IER_P1_Pos)
+#define GPIO_IER_P1                 (_U_(0x1) << GPIO_IER_P1_Pos)
 #define GPIO_IER_P2_Pos             2            /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P2                 (_U(0x1) << GPIO_IER_P2_Pos)
+#define GPIO_IER_P2                 (_U_(0x1) << GPIO_IER_P2_Pos)
 #define GPIO_IER_P3_Pos             3            /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P3                 (_U(0x1) << GPIO_IER_P3_Pos)
+#define GPIO_IER_P3                 (_U_(0x1) << GPIO_IER_P3_Pos)
 #define GPIO_IER_P4_Pos             4            /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P4                 (_U(0x1) << GPIO_IER_P4_Pos)
+#define GPIO_IER_P4                 (_U_(0x1) << GPIO_IER_P4_Pos)
 #define GPIO_IER_P5_Pos             5            /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P5                 (_U(0x1) << GPIO_IER_P5_Pos)
+#define GPIO_IER_P5                 (_U_(0x1) << GPIO_IER_P5_Pos)
 #define GPIO_IER_P6_Pos             6            /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P6                 (_U(0x1) << GPIO_IER_P6_Pos)
+#define GPIO_IER_P6                 (_U_(0x1) << GPIO_IER_P6_Pos)
 #define GPIO_IER_P7_Pos             7            /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P7                 (_U(0x1) << GPIO_IER_P7_Pos)
+#define GPIO_IER_P7                 (_U_(0x1) << GPIO_IER_P7_Pos)
 #define GPIO_IER_P8_Pos             8            /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P8                 (_U(0x1) << GPIO_IER_P8_Pos)
+#define GPIO_IER_P8                 (_U_(0x1) << GPIO_IER_P8_Pos)
 #define GPIO_IER_P9_Pos             9            /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P9                 (_U(0x1) << GPIO_IER_P9_Pos)
+#define GPIO_IER_P9                 (_U_(0x1) << GPIO_IER_P9_Pos)
 #define GPIO_IER_P10_Pos            10           /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P10                (_U(0x1) << GPIO_IER_P10_Pos)
+#define GPIO_IER_P10                (_U_(0x1) << GPIO_IER_P10_Pos)
 #define GPIO_IER_P11_Pos            11           /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P11                (_U(0x1) << GPIO_IER_P11_Pos)
+#define GPIO_IER_P11                (_U_(0x1) << GPIO_IER_P11_Pos)
 #define GPIO_IER_P12_Pos            12           /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P12                (_U(0x1) << GPIO_IER_P12_Pos)
+#define GPIO_IER_P12                (_U_(0x1) << GPIO_IER_P12_Pos)
 #define GPIO_IER_P13_Pos            13           /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P13                (_U(0x1) << GPIO_IER_P13_Pos)
+#define GPIO_IER_P13                (_U_(0x1) << GPIO_IER_P13_Pos)
 #define GPIO_IER_P14_Pos            14           /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P14                (_U(0x1) << GPIO_IER_P14_Pos)
+#define GPIO_IER_P14                (_U_(0x1) << GPIO_IER_P14_Pos)
 #define GPIO_IER_P15_Pos            15           /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P15                (_U(0x1) << GPIO_IER_P15_Pos)
+#define GPIO_IER_P15                (_U_(0x1) << GPIO_IER_P15_Pos)
 #define GPIO_IER_P16_Pos            16           /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P16                (_U(0x1) << GPIO_IER_P16_Pos)
+#define GPIO_IER_P16                (_U_(0x1) << GPIO_IER_P16_Pos)
 #define GPIO_IER_P17_Pos            17           /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P17                (_U(0x1) << GPIO_IER_P17_Pos)
+#define GPIO_IER_P17                (_U_(0x1) << GPIO_IER_P17_Pos)
 #define GPIO_IER_P18_Pos            18           /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P18                (_U(0x1) << GPIO_IER_P18_Pos)
+#define GPIO_IER_P18                (_U_(0x1) << GPIO_IER_P18_Pos)
 #define GPIO_IER_P19_Pos            19           /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P19                (_U(0x1) << GPIO_IER_P19_Pos)
+#define GPIO_IER_P19                (_U_(0x1) << GPIO_IER_P19_Pos)
 #define GPIO_IER_P20_Pos            20           /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P20                (_U(0x1) << GPIO_IER_P20_Pos)
+#define GPIO_IER_P20                (_U_(0x1) << GPIO_IER_P20_Pos)
 #define GPIO_IER_P21_Pos            21           /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P21                (_U(0x1) << GPIO_IER_P21_Pos)
+#define GPIO_IER_P21                (_U_(0x1) << GPIO_IER_P21_Pos)
 #define GPIO_IER_P22_Pos            22           /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P22                (_U(0x1) << GPIO_IER_P22_Pos)
+#define GPIO_IER_P22                (_U_(0x1) << GPIO_IER_P22_Pos)
 #define GPIO_IER_P23_Pos            23           /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P23                (_U(0x1) << GPIO_IER_P23_Pos)
+#define GPIO_IER_P23                (_U_(0x1) << GPIO_IER_P23_Pos)
 #define GPIO_IER_P24_Pos            24           /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P24                (_U(0x1) << GPIO_IER_P24_Pos)
+#define GPIO_IER_P24                (_U_(0x1) << GPIO_IER_P24_Pos)
 #define GPIO_IER_P25_Pos            25           /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P25                (_U(0x1) << GPIO_IER_P25_Pos)
+#define GPIO_IER_P25                (_U_(0x1) << GPIO_IER_P25_Pos)
 #define GPIO_IER_P26_Pos            26           /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P26                (_U(0x1) << GPIO_IER_P26_Pos)
+#define GPIO_IER_P26                (_U_(0x1) << GPIO_IER_P26_Pos)
 #define GPIO_IER_P27_Pos            27           /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P27                (_U(0x1) << GPIO_IER_P27_Pos)
+#define GPIO_IER_P27                (_U_(0x1) << GPIO_IER_P27_Pos)
 #define GPIO_IER_P28_Pos            28           /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P28                (_U(0x1) << GPIO_IER_P28_Pos)
+#define GPIO_IER_P28                (_U_(0x1) << GPIO_IER_P28_Pos)
 #define GPIO_IER_P29_Pos            29           /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P29                (_U(0x1) << GPIO_IER_P29_Pos)
+#define GPIO_IER_P29                (_U_(0x1) << GPIO_IER_P29_Pos)
 #define GPIO_IER_P30_Pos            30           /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P30                (_U(0x1) << GPIO_IER_P30_Pos)
+#define GPIO_IER_P30                (_U_(0x1) << GPIO_IER_P30_Pos)
 #define GPIO_IER_P31_Pos            31           /**< \brief (GPIO_IER) Interrupt Enable */
-#define GPIO_IER_P31                (_U(0x1) << GPIO_IER_P31_Pos)
-#define GPIO_IER_MASK               _U(0xFFFFFFFF) /**< \brief (GPIO_IER) MASK Register */
+#define GPIO_IER_P31                (_U_(0x1) << GPIO_IER_P31_Pos)
+#define GPIO_IER_MASK               _U_(0xFFFFFFFF) /**< \brief (GPIO_IER) MASK Register */
 
 /* -------- GPIO_IERS : (GPIO Offset: 0x094) ( /W 32) port Interrupt Enable Register - Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3788,70 +3788,70 @@ typedef union {
 #define GPIO_IERS_OFFSET            0x094        /**< \brief (GPIO_IERS offset) Interrupt Enable Register - Set */
 
 #define GPIO_IERS_P0_Pos            0            /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P0                (_U(0x1) << GPIO_IERS_P0_Pos)
+#define GPIO_IERS_P0                (_U_(0x1) << GPIO_IERS_P0_Pos)
 #define GPIO_IERS_P1_Pos            1            /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P1                (_U(0x1) << GPIO_IERS_P1_Pos)
+#define GPIO_IERS_P1                (_U_(0x1) << GPIO_IERS_P1_Pos)
 #define GPIO_IERS_P2_Pos            2            /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P2                (_U(0x1) << GPIO_IERS_P2_Pos)
+#define GPIO_IERS_P2                (_U_(0x1) << GPIO_IERS_P2_Pos)
 #define GPIO_IERS_P3_Pos            3            /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P3                (_U(0x1) << GPIO_IERS_P3_Pos)
+#define GPIO_IERS_P3                (_U_(0x1) << GPIO_IERS_P3_Pos)
 #define GPIO_IERS_P4_Pos            4            /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P4                (_U(0x1) << GPIO_IERS_P4_Pos)
+#define GPIO_IERS_P4                (_U_(0x1) << GPIO_IERS_P4_Pos)
 #define GPIO_IERS_P5_Pos            5            /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P5                (_U(0x1) << GPIO_IERS_P5_Pos)
+#define GPIO_IERS_P5                (_U_(0x1) << GPIO_IERS_P5_Pos)
 #define GPIO_IERS_P6_Pos            6            /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P6                (_U(0x1) << GPIO_IERS_P6_Pos)
+#define GPIO_IERS_P6                (_U_(0x1) << GPIO_IERS_P6_Pos)
 #define GPIO_IERS_P7_Pos            7            /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P7                (_U(0x1) << GPIO_IERS_P7_Pos)
+#define GPIO_IERS_P7                (_U_(0x1) << GPIO_IERS_P7_Pos)
 #define GPIO_IERS_P8_Pos            8            /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P8                (_U(0x1) << GPIO_IERS_P8_Pos)
+#define GPIO_IERS_P8                (_U_(0x1) << GPIO_IERS_P8_Pos)
 #define GPIO_IERS_P9_Pos            9            /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P9                (_U(0x1) << GPIO_IERS_P9_Pos)
+#define GPIO_IERS_P9                (_U_(0x1) << GPIO_IERS_P9_Pos)
 #define GPIO_IERS_P10_Pos           10           /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P10               (_U(0x1) << GPIO_IERS_P10_Pos)
+#define GPIO_IERS_P10               (_U_(0x1) << GPIO_IERS_P10_Pos)
 #define GPIO_IERS_P11_Pos           11           /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P11               (_U(0x1) << GPIO_IERS_P11_Pos)
+#define GPIO_IERS_P11               (_U_(0x1) << GPIO_IERS_P11_Pos)
 #define GPIO_IERS_P12_Pos           12           /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P12               (_U(0x1) << GPIO_IERS_P12_Pos)
+#define GPIO_IERS_P12               (_U_(0x1) << GPIO_IERS_P12_Pos)
 #define GPIO_IERS_P13_Pos           13           /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P13               (_U(0x1) << GPIO_IERS_P13_Pos)
+#define GPIO_IERS_P13               (_U_(0x1) << GPIO_IERS_P13_Pos)
 #define GPIO_IERS_P14_Pos           14           /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P14               (_U(0x1) << GPIO_IERS_P14_Pos)
+#define GPIO_IERS_P14               (_U_(0x1) << GPIO_IERS_P14_Pos)
 #define GPIO_IERS_P15_Pos           15           /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P15               (_U(0x1) << GPIO_IERS_P15_Pos)
+#define GPIO_IERS_P15               (_U_(0x1) << GPIO_IERS_P15_Pos)
 #define GPIO_IERS_P16_Pos           16           /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P16               (_U(0x1) << GPIO_IERS_P16_Pos)
+#define GPIO_IERS_P16               (_U_(0x1) << GPIO_IERS_P16_Pos)
 #define GPIO_IERS_P17_Pos           17           /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P17               (_U(0x1) << GPIO_IERS_P17_Pos)
+#define GPIO_IERS_P17               (_U_(0x1) << GPIO_IERS_P17_Pos)
 #define GPIO_IERS_P18_Pos           18           /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P18               (_U(0x1) << GPIO_IERS_P18_Pos)
+#define GPIO_IERS_P18               (_U_(0x1) << GPIO_IERS_P18_Pos)
 #define GPIO_IERS_P19_Pos           19           /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P19               (_U(0x1) << GPIO_IERS_P19_Pos)
+#define GPIO_IERS_P19               (_U_(0x1) << GPIO_IERS_P19_Pos)
 #define GPIO_IERS_P20_Pos           20           /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P20               (_U(0x1) << GPIO_IERS_P20_Pos)
+#define GPIO_IERS_P20               (_U_(0x1) << GPIO_IERS_P20_Pos)
 #define GPIO_IERS_P21_Pos           21           /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P21               (_U(0x1) << GPIO_IERS_P21_Pos)
+#define GPIO_IERS_P21               (_U_(0x1) << GPIO_IERS_P21_Pos)
 #define GPIO_IERS_P22_Pos           22           /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P22               (_U(0x1) << GPIO_IERS_P22_Pos)
+#define GPIO_IERS_P22               (_U_(0x1) << GPIO_IERS_P22_Pos)
 #define GPIO_IERS_P23_Pos           23           /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P23               (_U(0x1) << GPIO_IERS_P23_Pos)
+#define GPIO_IERS_P23               (_U_(0x1) << GPIO_IERS_P23_Pos)
 #define GPIO_IERS_P24_Pos           24           /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P24               (_U(0x1) << GPIO_IERS_P24_Pos)
+#define GPIO_IERS_P24               (_U_(0x1) << GPIO_IERS_P24_Pos)
 #define GPIO_IERS_P25_Pos           25           /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P25               (_U(0x1) << GPIO_IERS_P25_Pos)
+#define GPIO_IERS_P25               (_U_(0x1) << GPIO_IERS_P25_Pos)
 #define GPIO_IERS_P26_Pos           26           /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P26               (_U(0x1) << GPIO_IERS_P26_Pos)
+#define GPIO_IERS_P26               (_U_(0x1) << GPIO_IERS_P26_Pos)
 #define GPIO_IERS_P27_Pos           27           /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P27               (_U(0x1) << GPIO_IERS_P27_Pos)
+#define GPIO_IERS_P27               (_U_(0x1) << GPIO_IERS_P27_Pos)
 #define GPIO_IERS_P28_Pos           28           /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P28               (_U(0x1) << GPIO_IERS_P28_Pos)
+#define GPIO_IERS_P28               (_U_(0x1) << GPIO_IERS_P28_Pos)
 #define GPIO_IERS_P29_Pos           29           /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P29               (_U(0x1) << GPIO_IERS_P29_Pos)
+#define GPIO_IERS_P29               (_U_(0x1) << GPIO_IERS_P29_Pos)
 #define GPIO_IERS_P30_Pos           30           /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P30               (_U(0x1) << GPIO_IERS_P30_Pos)
+#define GPIO_IERS_P30               (_U_(0x1) << GPIO_IERS_P30_Pos)
 #define GPIO_IERS_P31_Pos           31           /**< \brief (GPIO_IERS) Interrupt Enable */
-#define GPIO_IERS_P31               (_U(0x1) << GPIO_IERS_P31_Pos)
-#define GPIO_IERS_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_IERS) MASK Register */
+#define GPIO_IERS_P31               (_U_(0x1) << GPIO_IERS_P31_Pos)
+#define GPIO_IERS_MASK              _U_(0xFFFFFFFF) /**< \brief (GPIO_IERS) MASK Register */
 
 /* -------- GPIO_IERC : (GPIO Offset: 0x098) ( /W 32) port Interrupt Enable Register - Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3897,70 +3897,70 @@ typedef union {
 #define GPIO_IERC_OFFSET            0x098        /**< \brief (GPIO_IERC offset) Interrupt Enable Register - Clear */
 
 #define GPIO_IERC_P0_Pos            0            /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P0                (_U(0x1) << GPIO_IERC_P0_Pos)
+#define GPIO_IERC_P0                (_U_(0x1) << GPIO_IERC_P0_Pos)
 #define GPIO_IERC_P1_Pos            1            /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P1                (_U(0x1) << GPIO_IERC_P1_Pos)
+#define GPIO_IERC_P1                (_U_(0x1) << GPIO_IERC_P1_Pos)
 #define GPIO_IERC_P2_Pos            2            /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P2                (_U(0x1) << GPIO_IERC_P2_Pos)
+#define GPIO_IERC_P2                (_U_(0x1) << GPIO_IERC_P2_Pos)
 #define GPIO_IERC_P3_Pos            3            /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P3                (_U(0x1) << GPIO_IERC_P3_Pos)
+#define GPIO_IERC_P3                (_U_(0x1) << GPIO_IERC_P3_Pos)
 #define GPIO_IERC_P4_Pos            4            /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P4                (_U(0x1) << GPIO_IERC_P4_Pos)
+#define GPIO_IERC_P4                (_U_(0x1) << GPIO_IERC_P4_Pos)
 #define GPIO_IERC_P5_Pos            5            /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P5                (_U(0x1) << GPIO_IERC_P5_Pos)
+#define GPIO_IERC_P5                (_U_(0x1) << GPIO_IERC_P5_Pos)
 #define GPIO_IERC_P6_Pos            6            /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P6                (_U(0x1) << GPIO_IERC_P6_Pos)
+#define GPIO_IERC_P6                (_U_(0x1) << GPIO_IERC_P6_Pos)
 #define GPIO_IERC_P7_Pos            7            /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P7                (_U(0x1) << GPIO_IERC_P7_Pos)
+#define GPIO_IERC_P7                (_U_(0x1) << GPIO_IERC_P7_Pos)
 #define GPIO_IERC_P8_Pos            8            /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P8                (_U(0x1) << GPIO_IERC_P8_Pos)
+#define GPIO_IERC_P8                (_U_(0x1) << GPIO_IERC_P8_Pos)
 #define GPIO_IERC_P9_Pos            9            /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P9                (_U(0x1) << GPIO_IERC_P9_Pos)
+#define GPIO_IERC_P9                (_U_(0x1) << GPIO_IERC_P9_Pos)
 #define GPIO_IERC_P10_Pos           10           /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P10               (_U(0x1) << GPIO_IERC_P10_Pos)
+#define GPIO_IERC_P10               (_U_(0x1) << GPIO_IERC_P10_Pos)
 #define GPIO_IERC_P11_Pos           11           /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P11               (_U(0x1) << GPIO_IERC_P11_Pos)
+#define GPIO_IERC_P11               (_U_(0x1) << GPIO_IERC_P11_Pos)
 #define GPIO_IERC_P12_Pos           12           /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P12               (_U(0x1) << GPIO_IERC_P12_Pos)
+#define GPIO_IERC_P12               (_U_(0x1) << GPIO_IERC_P12_Pos)
 #define GPIO_IERC_P13_Pos           13           /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P13               (_U(0x1) << GPIO_IERC_P13_Pos)
+#define GPIO_IERC_P13               (_U_(0x1) << GPIO_IERC_P13_Pos)
 #define GPIO_IERC_P14_Pos           14           /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P14               (_U(0x1) << GPIO_IERC_P14_Pos)
+#define GPIO_IERC_P14               (_U_(0x1) << GPIO_IERC_P14_Pos)
 #define GPIO_IERC_P15_Pos           15           /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P15               (_U(0x1) << GPIO_IERC_P15_Pos)
+#define GPIO_IERC_P15               (_U_(0x1) << GPIO_IERC_P15_Pos)
 #define GPIO_IERC_P16_Pos           16           /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P16               (_U(0x1) << GPIO_IERC_P16_Pos)
+#define GPIO_IERC_P16               (_U_(0x1) << GPIO_IERC_P16_Pos)
 #define GPIO_IERC_P17_Pos           17           /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P17               (_U(0x1) << GPIO_IERC_P17_Pos)
+#define GPIO_IERC_P17               (_U_(0x1) << GPIO_IERC_P17_Pos)
 #define GPIO_IERC_P18_Pos           18           /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P18               (_U(0x1) << GPIO_IERC_P18_Pos)
+#define GPIO_IERC_P18               (_U_(0x1) << GPIO_IERC_P18_Pos)
 #define GPIO_IERC_P19_Pos           19           /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P19               (_U(0x1) << GPIO_IERC_P19_Pos)
+#define GPIO_IERC_P19               (_U_(0x1) << GPIO_IERC_P19_Pos)
 #define GPIO_IERC_P20_Pos           20           /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P20               (_U(0x1) << GPIO_IERC_P20_Pos)
+#define GPIO_IERC_P20               (_U_(0x1) << GPIO_IERC_P20_Pos)
 #define GPIO_IERC_P21_Pos           21           /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P21               (_U(0x1) << GPIO_IERC_P21_Pos)
+#define GPIO_IERC_P21               (_U_(0x1) << GPIO_IERC_P21_Pos)
 #define GPIO_IERC_P22_Pos           22           /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P22               (_U(0x1) << GPIO_IERC_P22_Pos)
+#define GPIO_IERC_P22               (_U_(0x1) << GPIO_IERC_P22_Pos)
 #define GPIO_IERC_P23_Pos           23           /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P23               (_U(0x1) << GPIO_IERC_P23_Pos)
+#define GPIO_IERC_P23               (_U_(0x1) << GPIO_IERC_P23_Pos)
 #define GPIO_IERC_P24_Pos           24           /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P24               (_U(0x1) << GPIO_IERC_P24_Pos)
+#define GPIO_IERC_P24               (_U_(0x1) << GPIO_IERC_P24_Pos)
 #define GPIO_IERC_P25_Pos           25           /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P25               (_U(0x1) << GPIO_IERC_P25_Pos)
+#define GPIO_IERC_P25               (_U_(0x1) << GPIO_IERC_P25_Pos)
 #define GPIO_IERC_P26_Pos           26           /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P26               (_U(0x1) << GPIO_IERC_P26_Pos)
+#define GPIO_IERC_P26               (_U_(0x1) << GPIO_IERC_P26_Pos)
 #define GPIO_IERC_P27_Pos           27           /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P27               (_U(0x1) << GPIO_IERC_P27_Pos)
+#define GPIO_IERC_P27               (_U_(0x1) << GPIO_IERC_P27_Pos)
 #define GPIO_IERC_P28_Pos           28           /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P28               (_U(0x1) << GPIO_IERC_P28_Pos)
+#define GPIO_IERC_P28               (_U_(0x1) << GPIO_IERC_P28_Pos)
 #define GPIO_IERC_P29_Pos           29           /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P29               (_U(0x1) << GPIO_IERC_P29_Pos)
+#define GPIO_IERC_P29               (_U_(0x1) << GPIO_IERC_P29_Pos)
 #define GPIO_IERC_P30_Pos           30           /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P30               (_U(0x1) << GPIO_IERC_P30_Pos)
+#define GPIO_IERC_P30               (_U_(0x1) << GPIO_IERC_P30_Pos)
 #define GPIO_IERC_P31_Pos           31           /**< \brief (GPIO_IERC) Interrupt Enable */
-#define GPIO_IERC_P31               (_U(0x1) << GPIO_IERC_P31_Pos)
-#define GPIO_IERC_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_IERC) MASK Register */
+#define GPIO_IERC_P31               (_U_(0x1) << GPIO_IERC_P31_Pos)
+#define GPIO_IERC_MASK              _U_(0xFFFFFFFF) /**< \brief (GPIO_IERC) MASK Register */
 
 /* -------- GPIO_IERT : (GPIO Offset: 0x09C) ( /W 32) port Interrupt Enable Register - Toggle -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4006,70 +4006,70 @@ typedef union {
 #define GPIO_IERT_OFFSET            0x09C        /**< \brief (GPIO_IERT offset) Interrupt Enable Register - Toggle */
 
 #define GPIO_IERT_P0_Pos            0            /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P0                (_U(0x1) << GPIO_IERT_P0_Pos)
+#define GPIO_IERT_P0                (_U_(0x1) << GPIO_IERT_P0_Pos)
 #define GPIO_IERT_P1_Pos            1            /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P1                (_U(0x1) << GPIO_IERT_P1_Pos)
+#define GPIO_IERT_P1                (_U_(0x1) << GPIO_IERT_P1_Pos)
 #define GPIO_IERT_P2_Pos            2            /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P2                (_U(0x1) << GPIO_IERT_P2_Pos)
+#define GPIO_IERT_P2                (_U_(0x1) << GPIO_IERT_P2_Pos)
 #define GPIO_IERT_P3_Pos            3            /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P3                (_U(0x1) << GPIO_IERT_P3_Pos)
+#define GPIO_IERT_P3                (_U_(0x1) << GPIO_IERT_P3_Pos)
 #define GPIO_IERT_P4_Pos            4            /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P4                (_U(0x1) << GPIO_IERT_P4_Pos)
+#define GPIO_IERT_P4                (_U_(0x1) << GPIO_IERT_P4_Pos)
 #define GPIO_IERT_P5_Pos            5            /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P5                (_U(0x1) << GPIO_IERT_P5_Pos)
+#define GPIO_IERT_P5                (_U_(0x1) << GPIO_IERT_P5_Pos)
 #define GPIO_IERT_P6_Pos            6            /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P6                (_U(0x1) << GPIO_IERT_P6_Pos)
+#define GPIO_IERT_P6                (_U_(0x1) << GPIO_IERT_P6_Pos)
 #define GPIO_IERT_P7_Pos            7            /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P7                (_U(0x1) << GPIO_IERT_P7_Pos)
+#define GPIO_IERT_P7                (_U_(0x1) << GPIO_IERT_P7_Pos)
 #define GPIO_IERT_P8_Pos            8            /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P8                (_U(0x1) << GPIO_IERT_P8_Pos)
+#define GPIO_IERT_P8                (_U_(0x1) << GPIO_IERT_P8_Pos)
 #define GPIO_IERT_P9_Pos            9            /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P9                (_U(0x1) << GPIO_IERT_P9_Pos)
+#define GPIO_IERT_P9                (_U_(0x1) << GPIO_IERT_P9_Pos)
 #define GPIO_IERT_P10_Pos           10           /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P10               (_U(0x1) << GPIO_IERT_P10_Pos)
+#define GPIO_IERT_P10               (_U_(0x1) << GPIO_IERT_P10_Pos)
 #define GPIO_IERT_P11_Pos           11           /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P11               (_U(0x1) << GPIO_IERT_P11_Pos)
+#define GPIO_IERT_P11               (_U_(0x1) << GPIO_IERT_P11_Pos)
 #define GPIO_IERT_P12_Pos           12           /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P12               (_U(0x1) << GPIO_IERT_P12_Pos)
+#define GPIO_IERT_P12               (_U_(0x1) << GPIO_IERT_P12_Pos)
 #define GPIO_IERT_P13_Pos           13           /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P13               (_U(0x1) << GPIO_IERT_P13_Pos)
+#define GPIO_IERT_P13               (_U_(0x1) << GPIO_IERT_P13_Pos)
 #define GPIO_IERT_P14_Pos           14           /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P14               (_U(0x1) << GPIO_IERT_P14_Pos)
+#define GPIO_IERT_P14               (_U_(0x1) << GPIO_IERT_P14_Pos)
 #define GPIO_IERT_P15_Pos           15           /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P15               (_U(0x1) << GPIO_IERT_P15_Pos)
+#define GPIO_IERT_P15               (_U_(0x1) << GPIO_IERT_P15_Pos)
 #define GPIO_IERT_P16_Pos           16           /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P16               (_U(0x1) << GPIO_IERT_P16_Pos)
+#define GPIO_IERT_P16               (_U_(0x1) << GPIO_IERT_P16_Pos)
 #define GPIO_IERT_P17_Pos           17           /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P17               (_U(0x1) << GPIO_IERT_P17_Pos)
+#define GPIO_IERT_P17               (_U_(0x1) << GPIO_IERT_P17_Pos)
 #define GPIO_IERT_P18_Pos           18           /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P18               (_U(0x1) << GPIO_IERT_P18_Pos)
+#define GPIO_IERT_P18               (_U_(0x1) << GPIO_IERT_P18_Pos)
 #define GPIO_IERT_P19_Pos           19           /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P19               (_U(0x1) << GPIO_IERT_P19_Pos)
+#define GPIO_IERT_P19               (_U_(0x1) << GPIO_IERT_P19_Pos)
 #define GPIO_IERT_P20_Pos           20           /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P20               (_U(0x1) << GPIO_IERT_P20_Pos)
+#define GPIO_IERT_P20               (_U_(0x1) << GPIO_IERT_P20_Pos)
 #define GPIO_IERT_P21_Pos           21           /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P21               (_U(0x1) << GPIO_IERT_P21_Pos)
+#define GPIO_IERT_P21               (_U_(0x1) << GPIO_IERT_P21_Pos)
 #define GPIO_IERT_P22_Pos           22           /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P22               (_U(0x1) << GPIO_IERT_P22_Pos)
+#define GPIO_IERT_P22               (_U_(0x1) << GPIO_IERT_P22_Pos)
 #define GPIO_IERT_P23_Pos           23           /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P23               (_U(0x1) << GPIO_IERT_P23_Pos)
+#define GPIO_IERT_P23               (_U_(0x1) << GPIO_IERT_P23_Pos)
 #define GPIO_IERT_P24_Pos           24           /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P24               (_U(0x1) << GPIO_IERT_P24_Pos)
+#define GPIO_IERT_P24               (_U_(0x1) << GPIO_IERT_P24_Pos)
 #define GPIO_IERT_P25_Pos           25           /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P25               (_U(0x1) << GPIO_IERT_P25_Pos)
+#define GPIO_IERT_P25               (_U_(0x1) << GPIO_IERT_P25_Pos)
 #define GPIO_IERT_P26_Pos           26           /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P26               (_U(0x1) << GPIO_IERT_P26_Pos)
+#define GPIO_IERT_P26               (_U_(0x1) << GPIO_IERT_P26_Pos)
 #define GPIO_IERT_P27_Pos           27           /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P27               (_U(0x1) << GPIO_IERT_P27_Pos)
+#define GPIO_IERT_P27               (_U_(0x1) << GPIO_IERT_P27_Pos)
 #define GPIO_IERT_P28_Pos           28           /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P28               (_U(0x1) << GPIO_IERT_P28_Pos)
+#define GPIO_IERT_P28               (_U_(0x1) << GPIO_IERT_P28_Pos)
 #define GPIO_IERT_P29_Pos           29           /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P29               (_U(0x1) << GPIO_IERT_P29_Pos)
+#define GPIO_IERT_P29               (_U_(0x1) << GPIO_IERT_P29_Pos)
 #define GPIO_IERT_P30_Pos           30           /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P30               (_U(0x1) << GPIO_IERT_P30_Pos)
+#define GPIO_IERT_P30               (_U_(0x1) << GPIO_IERT_P30_Pos)
 #define GPIO_IERT_P31_Pos           31           /**< \brief (GPIO_IERT) Interrupt Enable */
-#define GPIO_IERT_P31               (_U(0x1) << GPIO_IERT_P31_Pos)
-#define GPIO_IERT_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_IERT) MASK Register */
+#define GPIO_IERT_P31               (_U_(0x1) << GPIO_IERT_P31_Pos)
+#define GPIO_IERT_MASK              _U_(0xFFFFFFFF) /**< \brief (GPIO_IERT) MASK Register */
 
 /* -------- GPIO_IMR0 : (GPIO Offset: 0x0A0) (R/W 32) port Interrupt Mode Register 0 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4115,70 +4115,70 @@ typedef union {
 #define GPIO_IMR0_OFFSET            0x0A0        /**< \brief (GPIO_IMR0 offset) Interrupt Mode Register 0 */
 
 #define GPIO_IMR0_P0_Pos            0            /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P0                (_U(0x1) << GPIO_IMR0_P0_Pos)
+#define GPIO_IMR0_P0                (_U_(0x1) << GPIO_IMR0_P0_Pos)
 #define GPIO_IMR0_P1_Pos            1            /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P1                (_U(0x1) << GPIO_IMR0_P1_Pos)
+#define GPIO_IMR0_P1                (_U_(0x1) << GPIO_IMR0_P1_Pos)
 #define GPIO_IMR0_P2_Pos            2            /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P2                (_U(0x1) << GPIO_IMR0_P2_Pos)
+#define GPIO_IMR0_P2                (_U_(0x1) << GPIO_IMR0_P2_Pos)
 #define GPIO_IMR0_P3_Pos            3            /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P3                (_U(0x1) << GPIO_IMR0_P3_Pos)
+#define GPIO_IMR0_P3                (_U_(0x1) << GPIO_IMR0_P3_Pos)
 #define GPIO_IMR0_P4_Pos            4            /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P4                (_U(0x1) << GPIO_IMR0_P4_Pos)
+#define GPIO_IMR0_P4                (_U_(0x1) << GPIO_IMR0_P4_Pos)
 #define GPIO_IMR0_P5_Pos            5            /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P5                (_U(0x1) << GPIO_IMR0_P5_Pos)
+#define GPIO_IMR0_P5                (_U_(0x1) << GPIO_IMR0_P5_Pos)
 #define GPIO_IMR0_P6_Pos            6            /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P6                (_U(0x1) << GPIO_IMR0_P6_Pos)
+#define GPIO_IMR0_P6                (_U_(0x1) << GPIO_IMR0_P6_Pos)
 #define GPIO_IMR0_P7_Pos            7            /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P7                (_U(0x1) << GPIO_IMR0_P7_Pos)
+#define GPIO_IMR0_P7                (_U_(0x1) << GPIO_IMR0_P7_Pos)
 #define GPIO_IMR0_P8_Pos            8            /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P8                (_U(0x1) << GPIO_IMR0_P8_Pos)
+#define GPIO_IMR0_P8                (_U_(0x1) << GPIO_IMR0_P8_Pos)
 #define GPIO_IMR0_P9_Pos            9            /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P9                (_U(0x1) << GPIO_IMR0_P9_Pos)
+#define GPIO_IMR0_P9                (_U_(0x1) << GPIO_IMR0_P9_Pos)
 #define GPIO_IMR0_P10_Pos           10           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P10               (_U(0x1) << GPIO_IMR0_P10_Pos)
+#define GPIO_IMR0_P10               (_U_(0x1) << GPIO_IMR0_P10_Pos)
 #define GPIO_IMR0_P11_Pos           11           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P11               (_U(0x1) << GPIO_IMR0_P11_Pos)
+#define GPIO_IMR0_P11               (_U_(0x1) << GPIO_IMR0_P11_Pos)
 #define GPIO_IMR0_P12_Pos           12           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P12               (_U(0x1) << GPIO_IMR0_P12_Pos)
+#define GPIO_IMR0_P12               (_U_(0x1) << GPIO_IMR0_P12_Pos)
 #define GPIO_IMR0_P13_Pos           13           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P13               (_U(0x1) << GPIO_IMR0_P13_Pos)
+#define GPIO_IMR0_P13               (_U_(0x1) << GPIO_IMR0_P13_Pos)
 #define GPIO_IMR0_P14_Pos           14           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P14               (_U(0x1) << GPIO_IMR0_P14_Pos)
+#define GPIO_IMR0_P14               (_U_(0x1) << GPIO_IMR0_P14_Pos)
 #define GPIO_IMR0_P15_Pos           15           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P15               (_U(0x1) << GPIO_IMR0_P15_Pos)
+#define GPIO_IMR0_P15               (_U_(0x1) << GPIO_IMR0_P15_Pos)
 #define GPIO_IMR0_P16_Pos           16           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P16               (_U(0x1) << GPIO_IMR0_P16_Pos)
+#define GPIO_IMR0_P16               (_U_(0x1) << GPIO_IMR0_P16_Pos)
 #define GPIO_IMR0_P17_Pos           17           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P17               (_U(0x1) << GPIO_IMR0_P17_Pos)
+#define GPIO_IMR0_P17               (_U_(0x1) << GPIO_IMR0_P17_Pos)
 #define GPIO_IMR0_P18_Pos           18           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P18               (_U(0x1) << GPIO_IMR0_P18_Pos)
+#define GPIO_IMR0_P18               (_U_(0x1) << GPIO_IMR0_P18_Pos)
 #define GPIO_IMR0_P19_Pos           19           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P19               (_U(0x1) << GPIO_IMR0_P19_Pos)
+#define GPIO_IMR0_P19               (_U_(0x1) << GPIO_IMR0_P19_Pos)
 #define GPIO_IMR0_P20_Pos           20           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P20               (_U(0x1) << GPIO_IMR0_P20_Pos)
+#define GPIO_IMR0_P20               (_U_(0x1) << GPIO_IMR0_P20_Pos)
 #define GPIO_IMR0_P21_Pos           21           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P21               (_U(0x1) << GPIO_IMR0_P21_Pos)
+#define GPIO_IMR0_P21               (_U_(0x1) << GPIO_IMR0_P21_Pos)
 #define GPIO_IMR0_P22_Pos           22           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P22               (_U(0x1) << GPIO_IMR0_P22_Pos)
+#define GPIO_IMR0_P22               (_U_(0x1) << GPIO_IMR0_P22_Pos)
 #define GPIO_IMR0_P23_Pos           23           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P23               (_U(0x1) << GPIO_IMR0_P23_Pos)
+#define GPIO_IMR0_P23               (_U_(0x1) << GPIO_IMR0_P23_Pos)
 #define GPIO_IMR0_P24_Pos           24           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P24               (_U(0x1) << GPIO_IMR0_P24_Pos)
+#define GPIO_IMR0_P24               (_U_(0x1) << GPIO_IMR0_P24_Pos)
 #define GPIO_IMR0_P25_Pos           25           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P25               (_U(0x1) << GPIO_IMR0_P25_Pos)
+#define GPIO_IMR0_P25               (_U_(0x1) << GPIO_IMR0_P25_Pos)
 #define GPIO_IMR0_P26_Pos           26           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P26               (_U(0x1) << GPIO_IMR0_P26_Pos)
+#define GPIO_IMR0_P26               (_U_(0x1) << GPIO_IMR0_P26_Pos)
 #define GPIO_IMR0_P27_Pos           27           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P27               (_U(0x1) << GPIO_IMR0_P27_Pos)
+#define GPIO_IMR0_P27               (_U_(0x1) << GPIO_IMR0_P27_Pos)
 #define GPIO_IMR0_P28_Pos           28           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P28               (_U(0x1) << GPIO_IMR0_P28_Pos)
+#define GPIO_IMR0_P28               (_U_(0x1) << GPIO_IMR0_P28_Pos)
 #define GPIO_IMR0_P29_Pos           29           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P29               (_U(0x1) << GPIO_IMR0_P29_Pos)
+#define GPIO_IMR0_P29               (_U_(0x1) << GPIO_IMR0_P29_Pos)
 #define GPIO_IMR0_P30_Pos           30           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P30               (_U(0x1) << GPIO_IMR0_P30_Pos)
+#define GPIO_IMR0_P30               (_U_(0x1) << GPIO_IMR0_P30_Pos)
 #define GPIO_IMR0_P31_Pos           31           /**< \brief (GPIO_IMR0) Interrupt Mode Bit 0 */
-#define GPIO_IMR0_P31               (_U(0x1) << GPIO_IMR0_P31_Pos)
-#define GPIO_IMR0_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_IMR0) MASK Register */
+#define GPIO_IMR0_P31               (_U_(0x1) << GPIO_IMR0_P31_Pos)
+#define GPIO_IMR0_MASK              _U_(0xFFFFFFFF) /**< \brief (GPIO_IMR0) MASK Register */
 
 /* -------- GPIO_IMR0S : (GPIO Offset: 0x0A4) ( /W 32) port Interrupt Mode Register 0 - Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4224,70 +4224,70 @@ typedef union {
 #define GPIO_IMR0S_OFFSET           0x0A4        /**< \brief (GPIO_IMR0S offset) Interrupt Mode Register 0 - Set */
 
 #define GPIO_IMR0S_P0_Pos           0            /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P0               (_U(0x1) << GPIO_IMR0S_P0_Pos)
+#define GPIO_IMR0S_P0               (_U_(0x1) << GPIO_IMR0S_P0_Pos)
 #define GPIO_IMR0S_P1_Pos           1            /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P1               (_U(0x1) << GPIO_IMR0S_P1_Pos)
+#define GPIO_IMR0S_P1               (_U_(0x1) << GPIO_IMR0S_P1_Pos)
 #define GPIO_IMR0S_P2_Pos           2            /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P2               (_U(0x1) << GPIO_IMR0S_P2_Pos)
+#define GPIO_IMR0S_P2               (_U_(0x1) << GPIO_IMR0S_P2_Pos)
 #define GPIO_IMR0S_P3_Pos           3            /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P3               (_U(0x1) << GPIO_IMR0S_P3_Pos)
+#define GPIO_IMR0S_P3               (_U_(0x1) << GPIO_IMR0S_P3_Pos)
 #define GPIO_IMR0S_P4_Pos           4            /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P4               (_U(0x1) << GPIO_IMR0S_P4_Pos)
+#define GPIO_IMR0S_P4               (_U_(0x1) << GPIO_IMR0S_P4_Pos)
 #define GPIO_IMR0S_P5_Pos           5            /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P5               (_U(0x1) << GPIO_IMR0S_P5_Pos)
+#define GPIO_IMR0S_P5               (_U_(0x1) << GPIO_IMR0S_P5_Pos)
 #define GPIO_IMR0S_P6_Pos           6            /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P6               (_U(0x1) << GPIO_IMR0S_P6_Pos)
+#define GPIO_IMR0S_P6               (_U_(0x1) << GPIO_IMR0S_P6_Pos)
 #define GPIO_IMR0S_P7_Pos           7            /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P7               (_U(0x1) << GPIO_IMR0S_P7_Pos)
+#define GPIO_IMR0S_P7               (_U_(0x1) << GPIO_IMR0S_P7_Pos)
 #define GPIO_IMR0S_P8_Pos           8            /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P8               (_U(0x1) << GPIO_IMR0S_P8_Pos)
+#define GPIO_IMR0S_P8               (_U_(0x1) << GPIO_IMR0S_P8_Pos)
 #define GPIO_IMR0S_P9_Pos           9            /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P9               (_U(0x1) << GPIO_IMR0S_P9_Pos)
+#define GPIO_IMR0S_P9               (_U_(0x1) << GPIO_IMR0S_P9_Pos)
 #define GPIO_IMR0S_P10_Pos          10           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P10              (_U(0x1) << GPIO_IMR0S_P10_Pos)
+#define GPIO_IMR0S_P10              (_U_(0x1) << GPIO_IMR0S_P10_Pos)
 #define GPIO_IMR0S_P11_Pos          11           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P11              (_U(0x1) << GPIO_IMR0S_P11_Pos)
+#define GPIO_IMR0S_P11              (_U_(0x1) << GPIO_IMR0S_P11_Pos)
 #define GPIO_IMR0S_P12_Pos          12           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P12              (_U(0x1) << GPIO_IMR0S_P12_Pos)
+#define GPIO_IMR0S_P12              (_U_(0x1) << GPIO_IMR0S_P12_Pos)
 #define GPIO_IMR0S_P13_Pos          13           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P13              (_U(0x1) << GPIO_IMR0S_P13_Pos)
+#define GPIO_IMR0S_P13              (_U_(0x1) << GPIO_IMR0S_P13_Pos)
 #define GPIO_IMR0S_P14_Pos          14           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P14              (_U(0x1) << GPIO_IMR0S_P14_Pos)
+#define GPIO_IMR0S_P14              (_U_(0x1) << GPIO_IMR0S_P14_Pos)
 #define GPIO_IMR0S_P15_Pos          15           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P15              (_U(0x1) << GPIO_IMR0S_P15_Pos)
+#define GPIO_IMR0S_P15              (_U_(0x1) << GPIO_IMR0S_P15_Pos)
 #define GPIO_IMR0S_P16_Pos          16           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P16              (_U(0x1) << GPIO_IMR0S_P16_Pos)
+#define GPIO_IMR0S_P16              (_U_(0x1) << GPIO_IMR0S_P16_Pos)
 #define GPIO_IMR0S_P17_Pos          17           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P17              (_U(0x1) << GPIO_IMR0S_P17_Pos)
+#define GPIO_IMR0S_P17              (_U_(0x1) << GPIO_IMR0S_P17_Pos)
 #define GPIO_IMR0S_P18_Pos          18           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P18              (_U(0x1) << GPIO_IMR0S_P18_Pos)
+#define GPIO_IMR0S_P18              (_U_(0x1) << GPIO_IMR0S_P18_Pos)
 #define GPIO_IMR0S_P19_Pos          19           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P19              (_U(0x1) << GPIO_IMR0S_P19_Pos)
+#define GPIO_IMR0S_P19              (_U_(0x1) << GPIO_IMR0S_P19_Pos)
 #define GPIO_IMR0S_P20_Pos          20           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P20              (_U(0x1) << GPIO_IMR0S_P20_Pos)
+#define GPIO_IMR0S_P20              (_U_(0x1) << GPIO_IMR0S_P20_Pos)
 #define GPIO_IMR0S_P21_Pos          21           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P21              (_U(0x1) << GPIO_IMR0S_P21_Pos)
+#define GPIO_IMR0S_P21              (_U_(0x1) << GPIO_IMR0S_P21_Pos)
 #define GPIO_IMR0S_P22_Pos          22           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P22              (_U(0x1) << GPIO_IMR0S_P22_Pos)
+#define GPIO_IMR0S_P22              (_U_(0x1) << GPIO_IMR0S_P22_Pos)
 #define GPIO_IMR0S_P23_Pos          23           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P23              (_U(0x1) << GPIO_IMR0S_P23_Pos)
+#define GPIO_IMR0S_P23              (_U_(0x1) << GPIO_IMR0S_P23_Pos)
 #define GPIO_IMR0S_P24_Pos          24           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P24              (_U(0x1) << GPIO_IMR0S_P24_Pos)
+#define GPIO_IMR0S_P24              (_U_(0x1) << GPIO_IMR0S_P24_Pos)
 #define GPIO_IMR0S_P25_Pos          25           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P25              (_U(0x1) << GPIO_IMR0S_P25_Pos)
+#define GPIO_IMR0S_P25              (_U_(0x1) << GPIO_IMR0S_P25_Pos)
 #define GPIO_IMR0S_P26_Pos          26           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P26              (_U(0x1) << GPIO_IMR0S_P26_Pos)
+#define GPIO_IMR0S_P26              (_U_(0x1) << GPIO_IMR0S_P26_Pos)
 #define GPIO_IMR0S_P27_Pos          27           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P27              (_U(0x1) << GPIO_IMR0S_P27_Pos)
+#define GPIO_IMR0S_P27              (_U_(0x1) << GPIO_IMR0S_P27_Pos)
 #define GPIO_IMR0S_P28_Pos          28           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P28              (_U(0x1) << GPIO_IMR0S_P28_Pos)
+#define GPIO_IMR0S_P28              (_U_(0x1) << GPIO_IMR0S_P28_Pos)
 #define GPIO_IMR0S_P29_Pos          29           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P29              (_U(0x1) << GPIO_IMR0S_P29_Pos)
+#define GPIO_IMR0S_P29              (_U_(0x1) << GPIO_IMR0S_P29_Pos)
 #define GPIO_IMR0S_P30_Pos          30           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P30              (_U(0x1) << GPIO_IMR0S_P30_Pos)
+#define GPIO_IMR0S_P30              (_U_(0x1) << GPIO_IMR0S_P30_Pos)
 #define GPIO_IMR0S_P31_Pos          31           /**< \brief (GPIO_IMR0S) Interrupt Mode Bit 0 */
-#define GPIO_IMR0S_P31              (_U(0x1) << GPIO_IMR0S_P31_Pos)
-#define GPIO_IMR0S_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_IMR0S) MASK Register */
+#define GPIO_IMR0S_P31              (_U_(0x1) << GPIO_IMR0S_P31_Pos)
+#define GPIO_IMR0S_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_IMR0S) MASK Register */
 
 /* -------- GPIO_IMR0C : (GPIO Offset: 0x0A8) ( /W 32) port Interrupt Mode Register 0 - Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4333,70 +4333,70 @@ typedef union {
 #define GPIO_IMR0C_OFFSET           0x0A8        /**< \brief (GPIO_IMR0C offset) Interrupt Mode Register 0 - Clear */
 
 #define GPIO_IMR0C_P0_Pos           0            /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P0               (_U(0x1) << GPIO_IMR0C_P0_Pos)
+#define GPIO_IMR0C_P0               (_U_(0x1) << GPIO_IMR0C_P0_Pos)
 #define GPIO_IMR0C_P1_Pos           1            /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P1               (_U(0x1) << GPIO_IMR0C_P1_Pos)
+#define GPIO_IMR0C_P1               (_U_(0x1) << GPIO_IMR0C_P1_Pos)
 #define GPIO_IMR0C_P2_Pos           2            /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P2               (_U(0x1) << GPIO_IMR0C_P2_Pos)
+#define GPIO_IMR0C_P2               (_U_(0x1) << GPIO_IMR0C_P2_Pos)
 #define GPIO_IMR0C_P3_Pos           3            /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P3               (_U(0x1) << GPIO_IMR0C_P3_Pos)
+#define GPIO_IMR0C_P3               (_U_(0x1) << GPIO_IMR0C_P3_Pos)
 #define GPIO_IMR0C_P4_Pos           4            /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P4               (_U(0x1) << GPIO_IMR0C_P4_Pos)
+#define GPIO_IMR0C_P4               (_U_(0x1) << GPIO_IMR0C_P4_Pos)
 #define GPIO_IMR0C_P5_Pos           5            /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P5               (_U(0x1) << GPIO_IMR0C_P5_Pos)
+#define GPIO_IMR0C_P5               (_U_(0x1) << GPIO_IMR0C_P5_Pos)
 #define GPIO_IMR0C_P6_Pos           6            /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P6               (_U(0x1) << GPIO_IMR0C_P6_Pos)
+#define GPIO_IMR0C_P6               (_U_(0x1) << GPIO_IMR0C_P6_Pos)
 #define GPIO_IMR0C_P7_Pos           7            /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P7               (_U(0x1) << GPIO_IMR0C_P7_Pos)
+#define GPIO_IMR0C_P7               (_U_(0x1) << GPIO_IMR0C_P7_Pos)
 #define GPIO_IMR0C_P8_Pos           8            /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P8               (_U(0x1) << GPIO_IMR0C_P8_Pos)
+#define GPIO_IMR0C_P8               (_U_(0x1) << GPIO_IMR0C_P8_Pos)
 #define GPIO_IMR0C_P9_Pos           9            /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P9               (_U(0x1) << GPIO_IMR0C_P9_Pos)
+#define GPIO_IMR0C_P9               (_U_(0x1) << GPIO_IMR0C_P9_Pos)
 #define GPIO_IMR0C_P10_Pos          10           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P10              (_U(0x1) << GPIO_IMR0C_P10_Pos)
+#define GPIO_IMR0C_P10              (_U_(0x1) << GPIO_IMR0C_P10_Pos)
 #define GPIO_IMR0C_P11_Pos          11           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P11              (_U(0x1) << GPIO_IMR0C_P11_Pos)
+#define GPIO_IMR0C_P11              (_U_(0x1) << GPIO_IMR0C_P11_Pos)
 #define GPIO_IMR0C_P12_Pos          12           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P12              (_U(0x1) << GPIO_IMR0C_P12_Pos)
+#define GPIO_IMR0C_P12              (_U_(0x1) << GPIO_IMR0C_P12_Pos)
 #define GPIO_IMR0C_P13_Pos          13           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P13              (_U(0x1) << GPIO_IMR0C_P13_Pos)
+#define GPIO_IMR0C_P13              (_U_(0x1) << GPIO_IMR0C_P13_Pos)
 #define GPIO_IMR0C_P14_Pos          14           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P14              (_U(0x1) << GPIO_IMR0C_P14_Pos)
+#define GPIO_IMR0C_P14              (_U_(0x1) << GPIO_IMR0C_P14_Pos)
 #define GPIO_IMR0C_P15_Pos          15           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P15              (_U(0x1) << GPIO_IMR0C_P15_Pos)
+#define GPIO_IMR0C_P15              (_U_(0x1) << GPIO_IMR0C_P15_Pos)
 #define GPIO_IMR0C_P16_Pos          16           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P16              (_U(0x1) << GPIO_IMR0C_P16_Pos)
+#define GPIO_IMR0C_P16              (_U_(0x1) << GPIO_IMR0C_P16_Pos)
 #define GPIO_IMR0C_P17_Pos          17           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P17              (_U(0x1) << GPIO_IMR0C_P17_Pos)
+#define GPIO_IMR0C_P17              (_U_(0x1) << GPIO_IMR0C_P17_Pos)
 #define GPIO_IMR0C_P18_Pos          18           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P18              (_U(0x1) << GPIO_IMR0C_P18_Pos)
+#define GPIO_IMR0C_P18              (_U_(0x1) << GPIO_IMR0C_P18_Pos)
 #define GPIO_IMR0C_P19_Pos          19           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P19              (_U(0x1) << GPIO_IMR0C_P19_Pos)
+#define GPIO_IMR0C_P19              (_U_(0x1) << GPIO_IMR0C_P19_Pos)
 #define GPIO_IMR0C_P20_Pos          20           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P20              (_U(0x1) << GPIO_IMR0C_P20_Pos)
+#define GPIO_IMR0C_P20              (_U_(0x1) << GPIO_IMR0C_P20_Pos)
 #define GPIO_IMR0C_P21_Pos          21           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P21              (_U(0x1) << GPIO_IMR0C_P21_Pos)
+#define GPIO_IMR0C_P21              (_U_(0x1) << GPIO_IMR0C_P21_Pos)
 #define GPIO_IMR0C_P22_Pos          22           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P22              (_U(0x1) << GPIO_IMR0C_P22_Pos)
+#define GPIO_IMR0C_P22              (_U_(0x1) << GPIO_IMR0C_P22_Pos)
 #define GPIO_IMR0C_P23_Pos          23           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P23              (_U(0x1) << GPIO_IMR0C_P23_Pos)
+#define GPIO_IMR0C_P23              (_U_(0x1) << GPIO_IMR0C_P23_Pos)
 #define GPIO_IMR0C_P24_Pos          24           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P24              (_U(0x1) << GPIO_IMR0C_P24_Pos)
+#define GPIO_IMR0C_P24              (_U_(0x1) << GPIO_IMR0C_P24_Pos)
 #define GPIO_IMR0C_P25_Pos          25           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P25              (_U(0x1) << GPIO_IMR0C_P25_Pos)
+#define GPIO_IMR0C_P25              (_U_(0x1) << GPIO_IMR0C_P25_Pos)
 #define GPIO_IMR0C_P26_Pos          26           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P26              (_U(0x1) << GPIO_IMR0C_P26_Pos)
+#define GPIO_IMR0C_P26              (_U_(0x1) << GPIO_IMR0C_P26_Pos)
 #define GPIO_IMR0C_P27_Pos          27           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P27              (_U(0x1) << GPIO_IMR0C_P27_Pos)
+#define GPIO_IMR0C_P27              (_U_(0x1) << GPIO_IMR0C_P27_Pos)
 #define GPIO_IMR0C_P28_Pos          28           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P28              (_U(0x1) << GPIO_IMR0C_P28_Pos)
+#define GPIO_IMR0C_P28              (_U_(0x1) << GPIO_IMR0C_P28_Pos)
 #define GPIO_IMR0C_P29_Pos          29           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P29              (_U(0x1) << GPIO_IMR0C_P29_Pos)
+#define GPIO_IMR0C_P29              (_U_(0x1) << GPIO_IMR0C_P29_Pos)
 #define GPIO_IMR0C_P30_Pos          30           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P30              (_U(0x1) << GPIO_IMR0C_P30_Pos)
+#define GPIO_IMR0C_P30              (_U_(0x1) << GPIO_IMR0C_P30_Pos)
 #define GPIO_IMR0C_P31_Pos          31           /**< \brief (GPIO_IMR0C) Interrupt Mode Bit 0 */
-#define GPIO_IMR0C_P31              (_U(0x1) << GPIO_IMR0C_P31_Pos)
-#define GPIO_IMR0C_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_IMR0C) MASK Register */
+#define GPIO_IMR0C_P31              (_U_(0x1) << GPIO_IMR0C_P31_Pos)
+#define GPIO_IMR0C_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_IMR0C) MASK Register */
 
 /* -------- GPIO_IMR0T : (GPIO Offset: 0x0AC) ( /W 32) port Interrupt Mode Register 0 - Toggle -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4442,70 +4442,70 @@ typedef union {
 #define GPIO_IMR0T_OFFSET           0x0AC        /**< \brief (GPIO_IMR0T offset) Interrupt Mode Register 0 - Toggle */
 
 #define GPIO_IMR0T_P0_Pos           0            /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P0               (_U(0x1) << GPIO_IMR0T_P0_Pos)
+#define GPIO_IMR0T_P0               (_U_(0x1) << GPIO_IMR0T_P0_Pos)
 #define GPIO_IMR0T_P1_Pos           1            /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P1               (_U(0x1) << GPIO_IMR0T_P1_Pos)
+#define GPIO_IMR0T_P1               (_U_(0x1) << GPIO_IMR0T_P1_Pos)
 #define GPIO_IMR0T_P2_Pos           2            /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P2               (_U(0x1) << GPIO_IMR0T_P2_Pos)
+#define GPIO_IMR0T_P2               (_U_(0x1) << GPIO_IMR0T_P2_Pos)
 #define GPIO_IMR0T_P3_Pos           3            /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P3               (_U(0x1) << GPIO_IMR0T_P3_Pos)
+#define GPIO_IMR0T_P3               (_U_(0x1) << GPIO_IMR0T_P3_Pos)
 #define GPIO_IMR0T_P4_Pos           4            /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P4               (_U(0x1) << GPIO_IMR0T_P4_Pos)
+#define GPIO_IMR0T_P4               (_U_(0x1) << GPIO_IMR0T_P4_Pos)
 #define GPIO_IMR0T_P5_Pos           5            /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P5               (_U(0x1) << GPIO_IMR0T_P5_Pos)
+#define GPIO_IMR0T_P5               (_U_(0x1) << GPIO_IMR0T_P5_Pos)
 #define GPIO_IMR0T_P6_Pos           6            /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P6               (_U(0x1) << GPIO_IMR0T_P6_Pos)
+#define GPIO_IMR0T_P6               (_U_(0x1) << GPIO_IMR0T_P6_Pos)
 #define GPIO_IMR0T_P7_Pos           7            /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P7               (_U(0x1) << GPIO_IMR0T_P7_Pos)
+#define GPIO_IMR0T_P7               (_U_(0x1) << GPIO_IMR0T_P7_Pos)
 #define GPIO_IMR0T_P8_Pos           8            /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P8               (_U(0x1) << GPIO_IMR0T_P8_Pos)
+#define GPIO_IMR0T_P8               (_U_(0x1) << GPIO_IMR0T_P8_Pos)
 #define GPIO_IMR0T_P9_Pos           9            /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P9               (_U(0x1) << GPIO_IMR0T_P9_Pos)
+#define GPIO_IMR0T_P9               (_U_(0x1) << GPIO_IMR0T_P9_Pos)
 #define GPIO_IMR0T_P10_Pos          10           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P10              (_U(0x1) << GPIO_IMR0T_P10_Pos)
+#define GPIO_IMR0T_P10              (_U_(0x1) << GPIO_IMR0T_P10_Pos)
 #define GPIO_IMR0T_P11_Pos          11           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P11              (_U(0x1) << GPIO_IMR0T_P11_Pos)
+#define GPIO_IMR0T_P11              (_U_(0x1) << GPIO_IMR0T_P11_Pos)
 #define GPIO_IMR0T_P12_Pos          12           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P12              (_U(0x1) << GPIO_IMR0T_P12_Pos)
+#define GPIO_IMR0T_P12              (_U_(0x1) << GPIO_IMR0T_P12_Pos)
 #define GPIO_IMR0T_P13_Pos          13           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P13              (_U(0x1) << GPIO_IMR0T_P13_Pos)
+#define GPIO_IMR0T_P13              (_U_(0x1) << GPIO_IMR0T_P13_Pos)
 #define GPIO_IMR0T_P14_Pos          14           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P14              (_U(0x1) << GPIO_IMR0T_P14_Pos)
+#define GPIO_IMR0T_P14              (_U_(0x1) << GPIO_IMR0T_P14_Pos)
 #define GPIO_IMR0T_P15_Pos          15           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P15              (_U(0x1) << GPIO_IMR0T_P15_Pos)
+#define GPIO_IMR0T_P15              (_U_(0x1) << GPIO_IMR0T_P15_Pos)
 #define GPIO_IMR0T_P16_Pos          16           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P16              (_U(0x1) << GPIO_IMR0T_P16_Pos)
+#define GPIO_IMR0T_P16              (_U_(0x1) << GPIO_IMR0T_P16_Pos)
 #define GPIO_IMR0T_P17_Pos          17           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P17              (_U(0x1) << GPIO_IMR0T_P17_Pos)
+#define GPIO_IMR0T_P17              (_U_(0x1) << GPIO_IMR0T_P17_Pos)
 #define GPIO_IMR0T_P18_Pos          18           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P18              (_U(0x1) << GPIO_IMR0T_P18_Pos)
+#define GPIO_IMR0T_P18              (_U_(0x1) << GPIO_IMR0T_P18_Pos)
 #define GPIO_IMR0T_P19_Pos          19           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P19              (_U(0x1) << GPIO_IMR0T_P19_Pos)
+#define GPIO_IMR0T_P19              (_U_(0x1) << GPIO_IMR0T_P19_Pos)
 #define GPIO_IMR0T_P20_Pos          20           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P20              (_U(0x1) << GPIO_IMR0T_P20_Pos)
+#define GPIO_IMR0T_P20              (_U_(0x1) << GPIO_IMR0T_P20_Pos)
 #define GPIO_IMR0T_P21_Pos          21           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P21              (_U(0x1) << GPIO_IMR0T_P21_Pos)
+#define GPIO_IMR0T_P21              (_U_(0x1) << GPIO_IMR0T_P21_Pos)
 #define GPIO_IMR0T_P22_Pos          22           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P22              (_U(0x1) << GPIO_IMR0T_P22_Pos)
+#define GPIO_IMR0T_P22              (_U_(0x1) << GPIO_IMR0T_P22_Pos)
 #define GPIO_IMR0T_P23_Pos          23           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P23              (_U(0x1) << GPIO_IMR0T_P23_Pos)
+#define GPIO_IMR0T_P23              (_U_(0x1) << GPIO_IMR0T_P23_Pos)
 #define GPIO_IMR0T_P24_Pos          24           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P24              (_U(0x1) << GPIO_IMR0T_P24_Pos)
+#define GPIO_IMR0T_P24              (_U_(0x1) << GPIO_IMR0T_P24_Pos)
 #define GPIO_IMR0T_P25_Pos          25           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P25              (_U(0x1) << GPIO_IMR0T_P25_Pos)
+#define GPIO_IMR0T_P25              (_U_(0x1) << GPIO_IMR0T_P25_Pos)
 #define GPIO_IMR0T_P26_Pos          26           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P26              (_U(0x1) << GPIO_IMR0T_P26_Pos)
+#define GPIO_IMR0T_P26              (_U_(0x1) << GPIO_IMR0T_P26_Pos)
 #define GPIO_IMR0T_P27_Pos          27           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P27              (_U(0x1) << GPIO_IMR0T_P27_Pos)
+#define GPIO_IMR0T_P27              (_U_(0x1) << GPIO_IMR0T_P27_Pos)
 #define GPIO_IMR0T_P28_Pos          28           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P28              (_U(0x1) << GPIO_IMR0T_P28_Pos)
+#define GPIO_IMR0T_P28              (_U_(0x1) << GPIO_IMR0T_P28_Pos)
 #define GPIO_IMR0T_P29_Pos          29           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P29              (_U(0x1) << GPIO_IMR0T_P29_Pos)
+#define GPIO_IMR0T_P29              (_U_(0x1) << GPIO_IMR0T_P29_Pos)
 #define GPIO_IMR0T_P30_Pos          30           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P30              (_U(0x1) << GPIO_IMR0T_P30_Pos)
+#define GPIO_IMR0T_P30              (_U_(0x1) << GPIO_IMR0T_P30_Pos)
 #define GPIO_IMR0T_P31_Pos          31           /**< \brief (GPIO_IMR0T) Interrupt Mode Bit 0 */
-#define GPIO_IMR0T_P31              (_U(0x1) << GPIO_IMR0T_P31_Pos)
-#define GPIO_IMR0T_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_IMR0T) MASK Register */
+#define GPIO_IMR0T_P31              (_U_(0x1) << GPIO_IMR0T_P31_Pos)
+#define GPIO_IMR0T_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_IMR0T) MASK Register */
 
 /* -------- GPIO_IMR1 : (GPIO Offset: 0x0B0) (R/W 32) port Interrupt Mode Register 1 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4551,70 +4551,70 @@ typedef union {
 #define GPIO_IMR1_OFFSET            0x0B0        /**< \brief (GPIO_IMR1 offset) Interrupt Mode Register 1 */
 
 #define GPIO_IMR1_P0_Pos            0            /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P0                (_U(0x1) << GPIO_IMR1_P0_Pos)
+#define GPIO_IMR1_P0                (_U_(0x1) << GPIO_IMR1_P0_Pos)
 #define GPIO_IMR1_P1_Pos            1            /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P1                (_U(0x1) << GPIO_IMR1_P1_Pos)
+#define GPIO_IMR1_P1                (_U_(0x1) << GPIO_IMR1_P1_Pos)
 #define GPIO_IMR1_P2_Pos            2            /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P2                (_U(0x1) << GPIO_IMR1_P2_Pos)
+#define GPIO_IMR1_P2                (_U_(0x1) << GPIO_IMR1_P2_Pos)
 #define GPIO_IMR1_P3_Pos            3            /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P3                (_U(0x1) << GPIO_IMR1_P3_Pos)
+#define GPIO_IMR1_P3                (_U_(0x1) << GPIO_IMR1_P3_Pos)
 #define GPIO_IMR1_P4_Pos            4            /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P4                (_U(0x1) << GPIO_IMR1_P4_Pos)
+#define GPIO_IMR1_P4                (_U_(0x1) << GPIO_IMR1_P4_Pos)
 #define GPIO_IMR1_P5_Pos            5            /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P5                (_U(0x1) << GPIO_IMR1_P5_Pos)
+#define GPIO_IMR1_P5                (_U_(0x1) << GPIO_IMR1_P5_Pos)
 #define GPIO_IMR1_P6_Pos            6            /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P6                (_U(0x1) << GPIO_IMR1_P6_Pos)
+#define GPIO_IMR1_P6                (_U_(0x1) << GPIO_IMR1_P6_Pos)
 #define GPIO_IMR1_P7_Pos            7            /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P7                (_U(0x1) << GPIO_IMR1_P7_Pos)
+#define GPIO_IMR1_P7                (_U_(0x1) << GPIO_IMR1_P7_Pos)
 #define GPIO_IMR1_P8_Pos            8            /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P8                (_U(0x1) << GPIO_IMR1_P8_Pos)
+#define GPIO_IMR1_P8                (_U_(0x1) << GPIO_IMR1_P8_Pos)
 #define GPIO_IMR1_P9_Pos            9            /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P9                (_U(0x1) << GPIO_IMR1_P9_Pos)
+#define GPIO_IMR1_P9                (_U_(0x1) << GPIO_IMR1_P9_Pos)
 #define GPIO_IMR1_P10_Pos           10           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P10               (_U(0x1) << GPIO_IMR1_P10_Pos)
+#define GPIO_IMR1_P10               (_U_(0x1) << GPIO_IMR1_P10_Pos)
 #define GPIO_IMR1_P11_Pos           11           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P11               (_U(0x1) << GPIO_IMR1_P11_Pos)
+#define GPIO_IMR1_P11               (_U_(0x1) << GPIO_IMR1_P11_Pos)
 #define GPIO_IMR1_P12_Pos           12           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P12               (_U(0x1) << GPIO_IMR1_P12_Pos)
+#define GPIO_IMR1_P12               (_U_(0x1) << GPIO_IMR1_P12_Pos)
 #define GPIO_IMR1_P13_Pos           13           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P13               (_U(0x1) << GPIO_IMR1_P13_Pos)
+#define GPIO_IMR1_P13               (_U_(0x1) << GPIO_IMR1_P13_Pos)
 #define GPIO_IMR1_P14_Pos           14           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P14               (_U(0x1) << GPIO_IMR1_P14_Pos)
+#define GPIO_IMR1_P14               (_U_(0x1) << GPIO_IMR1_P14_Pos)
 #define GPIO_IMR1_P15_Pos           15           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P15               (_U(0x1) << GPIO_IMR1_P15_Pos)
+#define GPIO_IMR1_P15               (_U_(0x1) << GPIO_IMR1_P15_Pos)
 #define GPIO_IMR1_P16_Pos           16           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P16               (_U(0x1) << GPIO_IMR1_P16_Pos)
+#define GPIO_IMR1_P16               (_U_(0x1) << GPIO_IMR1_P16_Pos)
 #define GPIO_IMR1_P17_Pos           17           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P17               (_U(0x1) << GPIO_IMR1_P17_Pos)
+#define GPIO_IMR1_P17               (_U_(0x1) << GPIO_IMR1_P17_Pos)
 #define GPIO_IMR1_P18_Pos           18           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P18               (_U(0x1) << GPIO_IMR1_P18_Pos)
+#define GPIO_IMR1_P18               (_U_(0x1) << GPIO_IMR1_P18_Pos)
 #define GPIO_IMR1_P19_Pos           19           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P19               (_U(0x1) << GPIO_IMR1_P19_Pos)
+#define GPIO_IMR1_P19               (_U_(0x1) << GPIO_IMR1_P19_Pos)
 #define GPIO_IMR1_P20_Pos           20           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P20               (_U(0x1) << GPIO_IMR1_P20_Pos)
+#define GPIO_IMR1_P20               (_U_(0x1) << GPIO_IMR1_P20_Pos)
 #define GPIO_IMR1_P21_Pos           21           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P21               (_U(0x1) << GPIO_IMR1_P21_Pos)
+#define GPIO_IMR1_P21               (_U_(0x1) << GPIO_IMR1_P21_Pos)
 #define GPIO_IMR1_P22_Pos           22           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P22               (_U(0x1) << GPIO_IMR1_P22_Pos)
+#define GPIO_IMR1_P22               (_U_(0x1) << GPIO_IMR1_P22_Pos)
 #define GPIO_IMR1_P23_Pos           23           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P23               (_U(0x1) << GPIO_IMR1_P23_Pos)
+#define GPIO_IMR1_P23               (_U_(0x1) << GPIO_IMR1_P23_Pos)
 #define GPIO_IMR1_P24_Pos           24           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P24               (_U(0x1) << GPIO_IMR1_P24_Pos)
+#define GPIO_IMR1_P24               (_U_(0x1) << GPIO_IMR1_P24_Pos)
 #define GPIO_IMR1_P25_Pos           25           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P25               (_U(0x1) << GPIO_IMR1_P25_Pos)
+#define GPIO_IMR1_P25               (_U_(0x1) << GPIO_IMR1_P25_Pos)
 #define GPIO_IMR1_P26_Pos           26           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P26               (_U(0x1) << GPIO_IMR1_P26_Pos)
+#define GPIO_IMR1_P26               (_U_(0x1) << GPIO_IMR1_P26_Pos)
 #define GPIO_IMR1_P27_Pos           27           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P27               (_U(0x1) << GPIO_IMR1_P27_Pos)
+#define GPIO_IMR1_P27               (_U_(0x1) << GPIO_IMR1_P27_Pos)
 #define GPIO_IMR1_P28_Pos           28           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P28               (_U(0x1) << GPIO_IMR1_P28_Pos)
+#define GPIO_IMR1_P28               (_U_(0x1) << GPIO_IMR1_P28_Pos)
 #define GPIO_IMR1_P29_Pos           29           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P29               (_U(0x1) << GPIO_IMR1_P29_Pos)
+#define GPIO_IMR1_P29               (_U_(0x1) << GPIO_IMR1_P29_Pos)
 #define GPIO_IMR1_P30_Pos           30           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P30               (_U(0x1) << GPIO_IMR1_P30_Pos)
+#define GPIO_IMR1_P30               (_U_(0x1) << GPIO_IMR1_P30_Pos)
 #define GPIO_IMR1_P31_Pos           31           /**< \brief (GPIO_IMR1) Interrupt Mode Bit 1 */
-#define GPIO_IMR1_P31               (_U(0x1) << GPIO_IMR1_P31_Pos)
-#define GPIO_IMR1_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_IMR1) MASK Register */
+#define GPIO_IMR1_P31               (_U_(0x1) << GPIO_IMR1_P31_Pos)
+#define GPIO_IMR1_MASK              _U_(0xFFFFFFFF) /**< \brief (GPIO_IMR1) MASK Register */
 
 /* -------- GPIO_IMR1S : (GPIO Offset: 0x0B4) ( /W 32) port Interrupt Mode Register 1 - Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4660,70 +4660,70 @@ typedef union {
 #define GPIO_IMR1S_OFFSET           0x0B4        /**< \brief (GPIO_IMR1S offset) Interrupt Mode Register 1 - Set */
 
 #define GPIO_IMR1S_P0_Pos           0            /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P0               (_U(0x1) << GPIO_IMR1S_P0_Pos)
+#define GPIO_IMR1S_P0               (_U_(0x1) << GPIO_IMR1S_P0_Pos)
 #define GPIO_IMR1S_P1_Pos           1            /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P1               (_U(0x1) << GPIO_IMR1S_P1_Pos)
+#define GPIO_IMR1S_P1               (_U_(0x1) << GPIO_IMR1S_P1_Pos)
 #define GPIO_IMR1S_P2_Pos           2            /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P2               (_U(0x1) << GPIO_IMR1S_P2_Pos)
+#define GPIO_IMR1S_P2               (_U_(0x1) << GPIO_IMR1S_P2_Pos)
 #define GPIO_IMR1S_P3_Pos           3            /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P3               (_U(0x1) << GPIO_IMR1S_P3_Pos)
+#define GPIO_IMR1S_P3               (_U_(0x1) << GPIO_IMR1S_P3_Pos)
 #define GPIO_IMR1S_P4_Pos           4            /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P4               (_U(0x1) << GPIO_IMR1S_P4_Pos)
+#define GPIO_IMR1S_P4               (_U_(0x1) << GPIO_IMR1S_P4_Pos)
 #define GPIO_IMR1S_P5_Pos           5            /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P5               (_U(0x1) << GPIO_IMR1S_P5_Pos)
+#define GPIO_IMR1S_P5               (_U_(0x1) << GPIO_IMR1S_P5_Pos)
 #define GPIO_IMR1S_P6_Pos           6            /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P6               (_U(0x1) << GPIO_IMR1S_P6_Pos)
+#define GPIO_IMR1S_P6               (_U_(0x1) << GPIO_IMR1S_P6_Pos)
 #define GPIO_IMR1S_P7_Pos           7            /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P7               (_U(0x1) << GPIO_IMR1S_P7_Pos)
+#define GPIO_IMR1S_P7               (_U_(0x1) << GPIO_IMR1S_P7_Pos)
 #define GPIO_IMR1S_P8_Pos           8            /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P8               (_U(0x1) << GPIO_IMR1S_P8_Pos)
+#define GPIO_IMR1S_P8               (_U_(0x1) << GPIO_IMR1S_P8_Pos)
 #define GPIO_IMR1S_P9_Pos           9            /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P9               (_U(0x1) << GPIO_IMR1S_P9_Pos)
+#define GPIO_IMR1S_P9               (_U_(0x1) << GPIO_IMR1S_P9_Pos)
 #define GPIO_IMR1S_P10_Pos          10           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P10              (_U(0x1) << GPIO_IMR1S_P10_Pos)
+#define GPIO_IMR1S_P10              (_U_(0x1) << GPIO_IMR1S_P10_Pos)
 #define GPIO_IMR1S_P11_Pos          11           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P11              (_U(0x1) << GPIO_IMR1S_P11_Pos)
+#define GPIO_IMR1S_P11              (_U_(0x1) << GPIO_IMR1S_P11_Pos)
 #define GPIO_IMR1S_P12_Pos          12           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P12              (_U(0x1) << GPIO_IMR1S_P12_Pos)
+#define GPIO_IMR1S_P12              (_U_(0x1) << GPIO_IMR1S_P12_Pos)
 #define GPIO_IMR1S_P13_Pos          13           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P13              (_U(0x1) << GPIO_IMR1S_P13_Pos)
+#define GPIO_IMR1S_P13              (_U_(0x1) << GPIO_IMR1S_P13_Pos)
 #define GPIO_IMR1S_P14_Pos          14           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P14              (_U(0x1) << GPIO_IMR1S_P14_Pos)
+#define GPIO_IMR1S_P14              (_U_(0x1) << GPIO_IMR1S_P14_Pos)
 #define GPIO_IMR1S_P15_Pos          15           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P15              (_U(0x1) << GPIO_IMR1S_P15_Pos)
+#define GPIO_IMR1S_P15              (_U_(0x1) << GPIO_IMR1S_P15_Pos)
 #define GPIO_IMR1S_P16_Pos          16           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P16              (_U(0x1) << GPIO_IMR1S_P16_Pos)
+#define GPIO_IMR1S_P16              (_U_(0x1) << GPIO_IMR1S_P16_Pos)
 #define GPIO_IMR1S_P17_Pos          17           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P17              (_U(0x1) << GPIO_IMR1S_P17_Pos)
+#define GPIO_IMR1S_P17              (_U_(0x1) << GPIO_IMR1S_P17_Pos)
 #define GPIO_IMR1S_P18_Pos          18           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P18              (_U(0x1) << GPIO_IMR1S_P18_Pos)
+#define GPIO_IMR1S_P18              (_U_(0x1) << GPIO_IMR1S_P18_Pos)
 #define GPIO_IMR1S_P19_Pos          19           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P19              (_U(0x1) << GPIO_IMR1S_P19_Pos)
+#define GPIO_IMR1S_P19              (_U_(0x1) << GPIO_IMR1S_P19_Pos)
 #define GPIO_IMR1S_P20_Pos          20           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P20              (_U(0x1) << GPIO_IMR1S_P20_Pos)
+#define GPIO_IMR1S_P20              (_U_(0x1) << GPIO_IMR1S_P20_Pos)
 #define GPIO_IMR1S_P21_Pos          21           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P21              (_U(0x1) << GPIO_IMR1S_P21_Pos)
+#define GPIO_IMR1S_P21              (_U_(0x1) << GPIO_IMR1S_P21_Pos)
 #define GPIO_IMR1S_P22_Pos          22           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P22              (_U(0x1) << GPIO_IMR1S_P22_Pos)
+#define GPIO_IMR1S_P22              (_U_(0x1) << GPIO_IMR1S_P22_Pos)
 #define GPIO_IMR1S_P23_Pos          23           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P23              (_U(0x1) << GPIO_IMR1S_P23_Pos)
+#define GPIO_IMR1S_P23              (_U_(0x1) << GPIO_IMR1S_P23_Pos)
 #define GPIO_IMR1S_P24_Pos          24           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P24              (_U(0x1) << GPIO_IMR1S_P24_Pos)
+#define GPIO_IMR1S_P24              (_U_(0x1) << GPIO_IMR1S_P24_Pos)
 #define GPIO_IMR1S_P25_Pos          25           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P25              (_U(0x1) << GPIO_IMR1S_P25_Pos)
+#define GPIO_IMR1S_P25              (_U_(0x1) << GPIO_IMR1S_P25_Pos)
 #define GPIO_IMR1S_P26_Pos          26           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P26              (_U(0x1) << GPIO_IMR1S_P26_Pos)
+#define GPIO_IMR1S_P26              (_U_(0x1) << GPIO_IMR1S_P26_Pos)
 #define GPIO_IMR1S_P27_Pos          27           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P27              (_U(0x1) << GPIO_IMR1S_P27_Pos)
+#define GPIO_IMR1S_P27              (_U_(0x1) << GPIO_IMR1S_P27_Pos)
 #define GPIO_IMR1S_P28_Pos          28           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P28              (_U(0x1) << GPIO_IMR1S_P28_Pos)
+#define GPIO_IMR1S_P28              (_U_(0x1) << GPIO_IMR1S_P28_Pos)
 #define GPIO_IMR1S_P29_Pos          29           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P29              (_U(0x1) << GPIO_IMR1S_P29_Pos)
+#define GPIO_IMR1S_P29              (_U_(0x1) << GPIO_IMR1S_P29_Pos)
 #define GPIO_IMR1S_P30_Pos          30           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P30              (_U(0x1) << GPIO_IMR1S_P30_Pos)
+#define GPIO_IMR1S_P30              (_U_(0x1) << GPIO_IMR1S_P30_Pos)
 #define GPIO_IMR1S_P31_Pos          31           /**< \brief (GPIO_IMR1S) Interrupt Mode Bit 1 */
-#define GPIO_IMR1S_P31              (_U(0x1) << GPIO_IMR1S_P31_Pos)
-#define GPIO_IMR1S_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_IMR1S) MASK Register */
+#define GPIO_IMR1S_P31              (_U_(0x1) << GPIO_IMR1S_P31_Pos)
+#define GPIO_IMR1S_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_IMR1S) MASK Register */
 
 /* -------- GPIO_IMR1C : (GPIO Offset: 0x0B8) ( /W 32) port Interrupt Mode Register 1 - Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4769,70 +4769,70 @@ typedef union {
 #define GPIO_IMR1C_OFFSET           0x0B8        /**< \brief (GPIO_IMR1C offset) Interrupt Mode Register 1 - Clear */
 
 #define GPIO_IMR1C_P0_Pos           0            /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P0               (_U(0x1) << GPIO_IMR1C_P0_Pos)
+#define GPIO_IMR1C_P0               (_U_(0x1) << GPIO_IMR1C_P0_Pos)
 #define GPIO_IMR1C_P1_Pos           1            /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P1               (_U(0x1) << GPIO_IMR1C_P1_Pos)
+#define GPIO_IMR1C_P1               (_U_(0x1) << GPIO_IMR1C_P1_Pos)
 #define GPIO_IMR1C_P2_Pos           2            /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P2               (_U(0x1) << GPIO_IMR1C_P2_Pos)
+#define GPIO_IMR1C_P2               (_U_(0x1) << GPIO_IMR1C_P2_Pos)
 #define GPIO_IMR1C_P3_Pos           3            /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P3               (_U(0x1) << GPIO_IMR1C_P3_Pos)
+#define GPIO_IMR1C_P3               (_U_(0x1) << GPIO_IMR1C_P3_Pos)
 #define GPIO_IMR1C_P4_Pos           4            /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P4               (_U(0x1) << GPIO_IMR1C_P4_Pos)
+#define GPIO_IMR1C_P4               (_U_(0x1) << GPIO_IMR1C_P4_Pos)
 #define GPIO_IMR1C_P5_Pos           5            /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P5               (_U(0x1) << GPIO_IMR1C_P5_Pos)
+#define GPIO_IMR1C_P5               (_U_(0x1) << GPIO_IMR1C_P5_Pos)
 #define GPIO_IMR1C_P6_Pos           6            /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P6               (_U(0x1) << GPIO_IMR1C_P6_Pos)
+#define GPIO_IMR1C_P6               (_U_(0x1) << GPIO_IMR1C_P6_Pos)
 #define GPIO_IMR1C_P7_Pos           7            /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P7               (_U(0x1) << GPIO_IMR1C_P7_Pos)
+#define GPIO_IMR1C_P7               (_U_(0x1) << GPIO_IMR1C_P7_Pos)
 #define GPIO_IMR1C_P8_Pos           8            /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P8               (_U(0x1) << GPIO_IMR1C_P8_Pos)
+#define GPIO_IMR1C_P8               (_U_(0x1) << GPIO_IMR1C_P8_Pos)
 #define GPIO_IMR1C_P9_Pos           9            /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P9               (_U(0x1) << GPIO_IMR1C_P9_Pos)
+#define GPIO_IMR1C_P9               (_U_(0x1) << GPIO_IMR1C_P9_Pos)
 #define GPIO_IMR1C_P10_Pos          10           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P10              (_U(0x1) << GPIO_IMR1C_P10_Pos)
+#define GPIO_IMR1C_P10              (_U_(0x1) << GPIO_IMR1C_P10_Pos)
 #define GPIO_IMR1C_P11_Pos          11           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P11              (_U(0x1) << GPIO_IMR1C_P11_Pos)
+#define GPIO_IMR1C_P11              (_U_(0x1) << GPIO_IMR1C_P11_Pos)
 #define GPIO_IMR1C_P12_Pos          12           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P12              (_U(0x1) << GPIO_IMR1C_P12_Pos)
+#define GPIO_IMR1C_P12              (_U_(0x1) << GPIO_IMR1C_P12_Pos)
 #define GPIO_IMR1C_P13_Pos          13           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P13              (_U(0x1) << GPIO_IMR1C_P13_Pos)
+#define GPIO_IMR1C_P13              (_U_(0x1) << GPIO_IMR1C_P13_Pos)
 #define GPIO_IMR1C_P14_Pos          14           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P14              (_U(0x1) << GPIO_IMR1C_P14_Pos)
+#define GPIO_IMR1C_P14              (_U_(0x1) << GPIO_IMR1C_P14_Pos)
 #define GPIO_IMR1C_P15_Pos          15           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P15              (_U(0x1) << GPIO_IMR1C_P15_Pos)
+#define GPIO_IMR1C_P15              (_U_(0x1) << GPIO_IMR1C_P15_Pos)
 #define GPIO_IMR1C_P16_Pos          16           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P16              (_U(0x1) << GPIO_IMR1C_P16_Pos)
+#define GPIO_IMR1C_P16              (_U_(0x1) << GPIO_IMR1C_P16_Pos)
 #define GPIO_IMR1C_P17_Pos          17           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P17              (_U(0x1) << GPIO_IMR1C_P17_Pos)
+#define GPIO_IMR1C_P17              (_U_(0x1) << GPIO_IMR1C_P17_Pos)
 #define GPIO_IMR1C_P18_Pos          18           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P18              (_U(0x1) << GPIO_IMR1C_P18_Pos)
+#define GPIO_IMR1C_P18              (_U_(0x1) << GPIO_IMR1C_P18_Pos)
 #define GPIO_IMR1C_P19_Pos          19           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P19              (_U(0x1) << GPIO_IMR1C_P19_Pos)
+#define GPIO_IMR1C_P19              (_U_(0x1) << GPIO_IMR1C_P19_Pos)
 #define GPIO_IMR1C_P20_Pos          20           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P20              (_U(0x1) << GPIO_IMR1C_P20_Pos)
+#define GPIO_IMR1C_P20              (_U_(0x1) << GPIO_IMR1C_P20_Pos)
 #define GPIO_IMR1C_P21_Pos          21           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P21              (_U(0x1) << GPIO_IMR1C_P21_Pos)
+#define GPIO_IMR1C_P21              (_U_(0x1) << GPIO_IMR1C_P21_Pos)
 #define GPIO_IMR1C_P22_Pos          22           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P22              (_U(0x1) << GPIO_IMR1C_P22_Pos)
+#define GPIO_IMR1C_P22              (_U_(0x1) << GPIO_IMR1C_P22_Pos)
 #define GPIO_IMR1C_P23_Pos          23           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P23              (_U(0x1) << GPIO_IMR1C_P23_Pos)
+#define GPIO_IMR1C_P23              (_U_(0x1) << GPIO_IMR1C_P23_Pos)
 #define GPIO_IMR1C_P24_Pos          24           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P24              (_U(0x1) << GPIO_IMR1C_P24_Pos)
+#define GPIO_IMR1C_P24              (_U_(0x1) << GPIO_IMR1C_P24_Pos)
 #define GPIO_IMR1C_P25_Pos          25           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P25              (_U(0x1) << GPIO_IMR1C_P25_Pos)
+#define GPIO_IMR1C_P25              (_U_(0x1) << GPIO_IMR1C_P25_Pos)
 #define GPIO_IMR1C_P26_Pos          26           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P26              (_U(0x1) << GPIO_IMR1C_P26_Pos)
+#define GPIO_IMR1C_P26              (_U_(0x1) << GPIO_IMR1C_P26_Pos)
 #define GPIO_IMR1C_P27_Pos          27           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P27              (_U(0x1) << GPIO_IMR1C_P27_Pos)
+#define GPIO_IMR1C_P27              (_U_(0x1) << GPIO_IMR1C_P27_Pos)
 #define GPIO_IMR1C_P28_Pos          28           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P28              (_U(0x1) << GPIO_IMR1C_P28_Pos)
+#define GPIO_IMR1C_P28              (_U_(0x1) << GPIO_IMR1C_P28_Pos)
 #define GPIO_IMR1C_P29_Pos          29           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P29              (_U(0x1) << GPIO_IMR1C_P29_Pos)
+#define GPIO_IMR1C_P29              (_U_(0x1) << GPIO_IMR1C_P29_Pos)
 #define GPIO_IMR1C_P30_Pos          30           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P30              (_U(0x1) << GPIO_IMR1C_P30_Pos)
+#define GPIO_IMR1C_P30              (_U_(0x1) << GPIO_IMR1C_P30_Pos)
 #define GPIO_IMR1C_P31_Pos          31           /**< \brief (GPIO_IMR1C) Interrupt Mode Bit 1 */
-#define GPIO_IMR1C_P31              (_U(0x1) << GPIO_IMR1C_P31_Pos)
-#define GPIO_IMR1C_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_IMR1C) MASK Register */
+#define GPIO_IMR1C_P31              (_U_(0x1) << GPIO_IMR1C_P31_Pos)
+#define GPIO_IMR1C_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_IMR1C) MASK Register */
 
 /* -------- GPIO_IMR1T : (GPIO Offset: 0x0BC) ( /W 32) port Interrupt Mode Register 1 - Toggle -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4878,70 +4878,70 @@ typedef union {
 #define GPIO_IMR1T_OFFSET           0x0BC        /**< \brief (GPIO_IMR1T offset) Interrupt Mode Register 1 - Toggle */
 
 #define GPIO_IMR1T_P0_Pos           0            /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P0               (_U(0x1) << GPIO_IMR1T_P0_Pos)
+#define GPIO_IMR1T_P0               (_U_(0x1) << GPIO_IMR1T_P0_Pos)
 #define GPIO_IMR1T_P1_Pos           1            /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P1               (_U(0x1) << GPIO_IMR1T_P1_Pos)
+#define GPIO_IMR1T_P1               (_U_(0x1) << GPIO_IMR1T_P1_Pos)
 #define GPIO_IMR1T_P2_Pos           2            /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P2               (_U(0x1) << GPIO_IMR1T_P2_Pos)
+#define GPIO_IMR1T_P2               (_U_(0x1) << GPIO_IMR1T_P2_Pos)
 #define GPIO_IMR1T_P3_Pos           3            /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P3               (_U(0x1) << GPIO_IMR1T_P3_Pos)
+#define GPIO_IMR1T_P3               (_U_(0x1) << GPIO_IMR1T_P3_Pos)
 #define GPIO_IMR1T_P4_Pos           4            /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P4               (_U(0x1) << GPIO_IMR1T_P4_Pos)
+#define GPIO_IMR1T_P4               (_U_(0x1) << GPIO_IMR1T_P4_Pos)
 #define GPIO_IMR1T_P5_Pos           5            /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P5               (_U(0x1) << GPIO_IMR1T_P5_Pos)
+#define GPIO_IMR1T_P5               (_U_(0x1) << GPIO_IMR1T_P5_Pos)
 #define GPIO_IMR1T_P6_Pos           6            /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P6               (_U(0x1) << GPIO_IMR1T_P6_Pos)
+#define GPIO_IMR1T_P6               (_U_(0x1) << GPIO_IMR1T_P6_Pos)
 #define GPIO_IMR1T_P7_Pos           7            /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P7               (_U(0x1) << GPIO_IMR1T_P7_Pos)
+#define GPIO_IMR1T_P7               (_U_(0x1) << GPIO_IMR1T_P7_Pos)
 #define GPIO_IMR1T_P8_Pos           8            /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P8               (_U(0x1) << GPIO_IMR1T_P8_Pos)
+#define GPIO_IMR1T_P8               (_U_(0x1) << GPIO_IMR1T_P8_Pos)
 #define GPIO_IMR1T_P9_Pos           9            /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P9               (_U(0x1) << GPIO_IMR1T_P9_Pos)
+#define GPIO_IMR1T_P9               (_U_(0x1) << GPIO_IMR1T_P9_Pos)
 #define GPIO_IMR1T_P10_Pos          10           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P10              (_U(0x1) << GPIO_IMR1T_P10_Pos)
+#define GPIO_IMR1T_P10              (_U_(0x1) << GPIO_IMR1T_P10_Pos)
 #define GPIO_IMR1T_P11_Pos          11           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P11              (_U(0x1) << GPIO_IMR1T_P11_Pos)
+#define GPIO_IMR1T_P11              (_U_(0x1) << GPIO_IMR1T_P11_Pos)
 #define GPIO_IMR1T_P12_Pos          12           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P12              (_U(0x1) << GPIO_IMR1T_P12_Pos)
+#define GPIO_IMR1T_P12              (_U_(0x1) << GPIO_IMR1T_P12_Pos)
 #define GPIO_IMR1T_P13_Pos          13           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P13              (_U(0x1) << GPIO_IMR1T_P13_Pos)
+#define GPIO_IMR1T_P13              (_U_(0x1) << GPIO_IMR1T_P13_Pos)
 #define GPIO_IMR1T_P14_Pos          14           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P14              (_U(0x1) << GPIO_IMR1T_P14_Pos)
+#define GPIO_IMR1T_P14              (_U_(0x1) << GPIO_IMR1T_P14_Pos)
 #define GPIO_IMR1T_P15_Pos          15           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P15              (_U(0x1) << GPIO_IMR1T_P15_Pos)
+#define GPIO_IMR1T_P15              (_U_(0x1) << GPIO_IMR1T_P15_Pos)
 #define GPIO_IMR1T_P16_Pos          16           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P16              (_U(0x1) << GPIO_IMR1T_P16_Pos)
+#define GPIO_IMR1T_P16              (_U_(0x1) << GPIO_IMR1T_P16_Pos)
 #define GPIO_IMR1T_P17_Pos          17           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P17              (_U(0x1) << GPIO_IMR1T_P17_Pos)
+#define GPIO_IMR1T_P17              (_U_(0x1) << GPIO_IMR1T_P17_Pos)
 #define GPIO_IMR1T_P18_Pos          18           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P18              (_U(0x1) << GPIO_IMR1T_P18_Pos)
+#define GPIO_IMR1T_P18              (_U_(0x1) << GPIO_IMR1T_P18_Pos)
 #define GPIO_IMR1T_P19_Pos          19           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P19              (_U(0x1) << GPIO_IMR1T_P19_Pos)
+#define GPIO_IMR1T_P19              (_U_(0x1) << GPIO_IMR1T_P19_Pos)
 #define GPIO_IMR1T_P20_Pos          20           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P20              (_U(0x1) << GPIO_IMR1T_P20_Pos)
+#define GPIO_IMR1T_P20              (_U_(0x1) << GPIO_IMR1T_P20_Pos)
 #define GPIO_IMR1T_P21_Pos          21           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P21              (_U(0x1) << GPIO_IMR1T_P21_Pos)
+#define GPIO_IMR1T_P21              (_U_(0x1) << GPIO_IMR1T_P21_Pos)
 #define GPIO_IMR1T_P22_Pos          22           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P22              (_U(0x1) << GPIO_IMR1T_P22_Pos)
+#define GPIO_IMR1T_P22              (_U_(0x1) << GPIO_IMR1T_P22_Pos)
 #define GPIO_IMR1T_P23_Pos          23           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P23              (_U(0x1) << GPIO_IMR1T_P23_Pos)
+#define GPIO_IMR1T_P23              (_U_(0x1) << GPIO_IMR1T_P23_Pos)
 #define GPIO_IMR1T_P24_Pos          24           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P24              (_U(0x1) << GPIO_IMR1T_P24_Pos)
+#define GPIO_IMR1T_P24              (_U_(0x1) << GPIO_IMR1T_P24_Pos)
 #define GPIO_IMR1T_P25_Pos          25           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P25              (_U(0x1) << GPIO_IMR1T_P25_Pos)
+#define GPIO_IMR1T_P25              (_U_(0x1) << GPIO_IMR1T_P25_Pos)
 #define GPIO_IMR1T_P26_Pos          26           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P26              (_U(0x1) << GPIO_IMR1T_P26_Pos)
+#define GPIO_IMR1T_P26              (_U_(0x1) << GPIO_IMR1T_P26_Pos)
 #define GPIO_IMR1T_P27_Pos          27           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P27              (_U(0x1) << GPIO_IMR1T_P27_Pos)
+#define GPIO_IMR1T_P27              (_U_(0x1) << GPIO_IMR1T_P27_Pos)
 #define GPIO_IMR1T_P28_Pos          28           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P28              (_U(0x1) << GPIO_IMR1T_P28_Pos)
+#define GPIO_IMR1T_P28              (_U_(0x1) << GPIO_IMR1T_P28_Pos)
 #define GPIO_IMR1T_P29_Pos          29           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P29              (_U(0x1) << GPIO_IMR1T_P29_Pos)
+#define GPIO_IMR1T_P29              (_U_(0x1) << GPIO_IMR1T_P29_Pos)
 #define GPIO_IMR1T_P30_Pos          30           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P30              (_U(0x1) << GPIO_IMR1T_P30_Pos)
+#define GPIO_IMR1T_P30              (_U_(0x1) << GPIO_IMR1T_P30_Pos)
 #define GPIO_IMR1T_P31_Pos          31           /**< \brief (GPIO_IMR1T) Interrupt Mode Bit 1 */
-#define GPIO_IMR1T_P31              (_U(0x1) << GPIO_IMR1T_P31_Pos)
-#define GPIO_IMR1T_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_IMR1T) MASK Register */
+#define GPIO_IMR1T_P31              (_U_(0x1) << GPIO_IMR1T_P31_Pos)
+#define GPIO_IMR1T_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_IMR1T) MASK Register */
 
 /* -------- GPIO_GFER : (GPIO Offset: 0x0C0) (R/W 32) port Glitch Filter Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4987,70 +4987,70 @@ typedef union {
 #define GPIO_GFER_OFFSET            0x0C0        /**< \brief (GPIO_GFER offset) Glitch Filter Enable Register */
 
 #define GPIO_GFER_P0_Pos            0            /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P0                (_U(0x1) << GPIO_GFER_P0_Pos)
+#define GPIO_GFER_P0                (_U_(0x1) << GPIO_GFER_P0_Pos)
 #define GPIO_GFER_P1_Pos            1            /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P1                (_U(0x1) << GPIO_GFER_P1_Pos)
+#define GPIO_GFER_P1                (_U_(0x1) << GPIO_GFER_P1_Pos)
 #define GPIO_GFER_P2_Pos            2            /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P2                (_U(0x1) << GPIO_GFER_P2_Pos)
+#define GPIO_GFER_P2                (_U_(0x1) << GPIO_GFER_P2_Pos)
 #define GPIO_GFER_P3_Pos            3            /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P3                (_U(0x1) << GPIO_GFER_P3_Pos)
+#define GPIO_GFER_P3                (_U_(0x1) << GPIO_GFER_P3_Pos)
 #define GPIO_GFER_P4_Pos            4            /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P4                (_U(0x1) << GPIO_GFER_P4_Pos)
+#define GPIO_GFER_P4                (_U_(0x1) << GPIO_GFER_P4_Pos)
 #define GPIO_GFER_P5_Pos            5            /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P5                (_U(0x1) << GPIO_GFER_P5_Pos)
+#define GPIO_GFER_P5                (_U_(0x1) << GPIO_GFER_P5_Pos)
 #define GPIO_GFER_P6_Pos            6            /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P6                (_U(0x1) << GPIO_GFER_P6_Pos)
+#define GPIO_GFER_P6                (_U_(0x1) << GPIO_GFER_P6_Pos)
 #define GPIO_GFER_P7_Pos            7            /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P7                (_U(0x1) << GPIO_GFER_P7_Pos)
+#define GPIO_GFER_P7                (_U_(0x1) << GPIO_GFER_P7_Pos)
 #define GPIO_GFER_P8_Pos            8            /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P8                (_U(0x1) << GPIO_GFER_P8_Pos)
+#define GPIO_GFER_P8                (_U_(0x1) << GPIO_GFER_P8_Pos)
 #define GPIO_GFER_P9_Pos            9            /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P9                (_U(0x1) << GPIO_GFER_P9_Pos)
+#define GPIO_GFER_P9                (_U_(0x1) << GPIO_GFER_P9_Pos)
 #define GPIO_GFER_P10_Pos           10           /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P10               (_U(0x1) << GPIO_GFER_P10_Pos)
+#define GPIO_GFER_P10               (_U_(0x1) << GPIO_GFER_P10_Pos)
 #define GPIO_GFER_P11_Pos           11           /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P11               (_U(0x1) << GPIO_GFER_P11_Pos)
+#define GPIO_GFER_P11               (_U_(0x1) << GPIO_GFER_P11_Pos)
 #define GPIO_GFER_P12_Pos           12           /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P12               (_U(0x1) << GPIO_GFER_P12_Pos)
+#define GPIO_GFER_P12               (_U_(0x1) << GPIO_GFER_P12_Pos)
 #define GPIO_GFER_P13_Pos           13           /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P13               (_U(0x1) << GPIO_GFER_P13_Pos)
+#define GPIO_GFER_P13               (_U_(0x1) << GPIO_GFER_P13_Pos)
 #define GPIO_GFER_P14_Pos           14           /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P14               (_U(0x1) << GPIO_GFER_P14_Pos)
+#define GPIO_GFER_P14               (_U_(0x1) << GPIO_GFER_P14_Pos)
 #define GPIO_GFER_P15_Pos           15           /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P15               (_U(0x1) << GPIO_GFER_P15_Pos)
+#define GPIO_GFER_P15               (_U_(0x1) << GPIO_GFER_P15_Pos)
 #define GPIO_GFER_P16_Pos           16           /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P16               (_U(0x1) << GPIO_GFER_P16_Pos)
+#define GPIO_GFER_P16               (_U_(0x1) << GPIO_GFER_P16_Pos)
 #define GPIO_GFER_P17_Pos           17           /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P17               (_U(0x1) << GPIO_GFER_P17_Pos)
+#define GPIO_GFER_P17               (_U_(0x1) << GPIO_GFER_P17_Pos)
 #define GPIO_GFER_P18_Pos           18           /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P18               (_U(0x1) << GPIO_GFER_P18_Pos)
+#define GPIO_GFER_P18               (_U_(0x1) << GPIO_GFER_P18_Pos)
 #define GPIO_GFER_P19_Pos           19           /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P19               (_U(0x1) << GPIO_GFER_P19_Pos)
+#define GPIO_GFER_P19               (_U_(0x1) << GPIO_GFER_P19_Pos)
 #define GPIO_GFER_P20_Pos           20           /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P20               (_U(0x1) << GPIO_GFER_P20_Pos)
+#define GPIO_GFER_P20               (_U_(0x1) << GPIO_GFER_P20_Pos)
 #define GPIO_GFER_P21_Pos           21           /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P21               (_U(0x1) << GPIO_GFER_P21_Pos)
+#define GPIO_GFER_P21               (_U_(0x1) << GPIO_GFER_P21_Pos)
 #define GPIO_GFER_P22_Pos           22           /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P22               (_U(0x1) << GPIO_GFER_P22_Pos)
+#define GPIO_GFER_P22               (_U_(0x1) << GPIO_GFER_P22_Pos)
 #define GPIO_GFER_P23_Pos           23           /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P23               (_U(0x1) << GPIO_GFER_P23_Pos)
+#define GPIO_GFER_P23               (_U_(0x1) << GPIO_GFER_P23_Pos)
 #define GPIO_GFER_P24_Pos           24           /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P24               (_U(0x1) << GPIO_GFER_P24_Pos)
+#define GPIO_GFER_P24               (_U_(0x1) << GPIO_GFER_P24_Pos)
 #define GPIO_GFER_P25_Pos           25           /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P25               (_U(0x1) << GPIO_GFER_P25_Pos)
+#define GPIO_GFER_P25               (_U_(0x1) << GPIO_GFER_P25_Pos)
 #define GPIO_GFER_P26_Pos           26           /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P26               (_U(0x1) << GPIO_GFER_P26_Pos)
+#define GPIO_GFER_P26               (_U_(0x1) << GPIO_GFER_P26_Pos)
 #define GPIO_GFER_P27_Pos           27           /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P27               (_U(0x1) << GPIO_GFER_P27_Pos)
+#define GPIO_GFER_P27               (_U_(0x1) << GPIO_GFER_P27_Pos)
 #define GPIO_GFER_P28_Pos           28           /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P28               (_U(0x1) << GPIO_GFER_P28_Pos)
+#define GPIO_GFER_P28               (_U_(0x1) << GPIO_GFER_P28_Pos)
 #define GPIO_GFER_P29_Pos           29           /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P29               (_U(0x1) << GPIO_GFER_P29_Pos)
+#define GPIO_GFER_P29               (_U_(0x1) << GPIO_GFER_P29_Pos)
 #define GPIO_GFER_P30_Pos           30           /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P30               (_U(0x1) << GPIO_GFER_P30_Pos)
+#define GPIO_GFER_P30               (_U_(0x1) << GPIO_GFER_P30_Pos)
 #define GPIO_GFER_P31_Pos           31           /**< \brief (GPIO_GFER) Glitch Filter Enable */
-#define GPIO_GFER_P31               (_U(0x1) << GPIO_GFER_P31_Pos)
-#define GPIO_GFER_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_GFER) MASK Register */
+#define GPIO_GFER_P31               (_U_(0x1) << GPIO_GFER_P31_Pos)
+#define GPIO_GFER_MASK              _U_(0xFFFFFFFF) /**< \brief (GPIO_GFER) MASK Register */
 
 /* -------- GPIO_GFERS : (GPIO Offset: 0x0C4) ( /W 32) port Glitch Filter Enable Register - Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5096,70 +5096,70 @@ typedef union {
 #define GPIO_GFERS_OFFSET           0x0C4        /**< \brief (GPIO_GFERS offset) Glitch Filter Enable Register - Set */
 
 #define GPIO_GFERS_P0_Pos           0            /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P0               (_U(0x1) << GPIO_GFERS_P0_Pos)
+#define GPIO_GFERS_P0               (_U_(0x1) << GPIO_GFERS_P0_Pos)
 #define GPIO_GFERS_P1_Pos           1            /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P1               (_U(0x1) << GPIO_GFERS_P1_Pos)
+#define GPIO_GFERS_P1               (_U_(0x1) << GPIO_GFERS_P1_Pos)
 #define GPIO_GFERS_P2_Pos           2            /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P2               (_U(0x1) << GPIO_GFERS_P2_Pos)
+#define GPIO_GFERS_P2               (_U_(0x1) << GPIO_GFERS_P2_Pos)
 #define GPIO_GFERS_P3_Pos           3            /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P3               (_U(0x1) << GPIO_GFERS_P3_Pos)
+#define GPIO_GFERS_P3               (_U_(0x1) << GPIO_GFERS_P3_Pos)
 #define GPIO_GFERS_P4_Pos           4            /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P4               (_U(0x1) << GPIO_GFERS_P4_Pos)
+#define GPIO_GFERS_P4               (_U_(0x1) << GPIO_GFERS_P4_Pos)
 #define GPIO_GFERS_P5_Pos           5            /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P5               (_U(0x1) << GPIO_GFERS_P5_Pos)
+#define GPIO_GFERS_P5               (_U_(0x1) << GPIO_GFERS_P5_Pos)
 #define GPIO_GFERS_P6_Pos           6            /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P6               (_U(0x1) << GPIO_GFERS_P6_Pos)
+#define GPIO_GFERS_P6               (_U_(0x1) << GPIO_GFERS_P6_Pos)
 #define GPIO_GFERS_P7_Pos           7            /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P7               (_U(0x1) << GPIO_GFERS_P7_Pos)
+#define GPIO_GFERS_P7               (_U_(0x1) << GPIO_GFERS_P7_Pos)
 #define GPIO_GFERS_P8_Pos           8            /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P8               (_U(0x1) << GPIO_GFERS_P8_Pos)
+#define GPIO_GFERS_P8               (_U_(0x1) << GPIO_GFERS_P8_Pos)
 #define GPIO_GFERS_P9_Pos           9            /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P9               (_U(0x1) << GPIO_GFERS_P9_Pos)
+#define GPIO_GFERS_P9               (_U_(0x1) << GPIO_GFERS_P9_Pos)
 #define GPIO_GFERS_P10_Pos          10           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P10              (_U(0x1) << GPIO_GFERS_P10_Pos)
+#define GPIO_GFERS_P10              (_U_(0x1) << GPIO_GFERS_P10_Pos)
 #define GPIO_GFERS_P11_Pos          11           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P11              (_U(0x1) << GPIO_GFERS_P11_Pos)
+#define GPIO_GFERS_P11              (_U_(0x1) << GPIO_GFERS_P11_Pos)
 #define GPIO_GFERS_P12_Pos          12           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P12              (_U(0x1) << GPIO_GFERS_P12_Pos)
+#define GPIO_GFERS_P12              (_U_(0x1) << GPIO_GFERS_P12_Pos)
 #define GPIO_GFERS_P13_Pos          13           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P13              (_U(0x1) << GPIO_GFERS_P13_Pos)
+#define GPIO_GFERS_P13              (_U_(0x1) << GPIO_GFERS_P13_Pos)
 #define GPIO_GFERS_P14_Pos          14           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P14              (_U(0x1) << GPIO_GFERS_P14_Pos)
+#define GPIO_GFERS_P14              (_U_(0x1) << GPIO_GFERS_P14_Pos)
 #define GPIO_GFERS_P15_Pos          15           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P15              (_U(0x1) << GPIO_GFERS_P15_Pos)
+#define GPIO_GFERS_P15              (_U_(0x1) << GPIO_GFERS_P15_Pos)
 #define GPIO_GFERS_P16_Pos          16           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P16              (_U(0x1) << GPIO_GFERS_P16_Pos)
+#define GPIO_GFERS_P16              (_U_(0x1) << GPIO_GFERS_P16_Pos)
 #define GPIO_GFERS_P17_Pos          17           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P17              (_U(0x1) << GPIO_GFERS_P17_Pos)
+#define GPIO_GFERS_P17              (_U_(0x1) << GPIO_GFERS_P17_Pos)
 #define GPIO_GFERS_P18_Pos          18           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P18              (_U(0x1) << GPIO_GFERS_P18_Pos)
+#define GPIO_GFERS_P18              (_U_(0x1) << GPIO_GFERS_P18_Pos)
 #define GPIO_GFERS_P19_Pos          19           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P19              (_U(0x1) << GPIO_GFERS_P19_Pos)
+#define GPIO_GFERS_P19              (_U_(0x1) << GPIO_GFERS_P19_Pos)
 #define GPIO_GFERS_P20_Pos          20           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P20              (_U(0x1) << GPIO_GFERS_P20_Pos)
+#define GPIO_GFERS_P20              (_U_(0x1) << GPIO_GFERS_P20_Pos)
 #define GPIO_GFERS_P21_Pos          21           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P21              (_U(0x1) << GPIO_GFERS_P21_Pos)
+#define GPIO_GFERS_P21              (_U_(0x1) << GPIO_GFERS_P21_Pos)
 #define GPIO_GFERS_P22_Pos          22           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P22              (_U(0x1) << GPIO_GFERS_P22_Pos)
+#define GPIO_GFERS_P22              (_U_(0x1) << GPIO_GFERS_P22_Pos)
 #define GPIO_GFERS_P23_Pos          23           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P23              (_U(0x1) << GPIO_GFERS_P23_Pos)
+#define GPIO_GFERS_P23              (_U_(0x1) << GPIO_GFERS_P23_Pos)
 #define GPIO_GFERS_P24_Pos          24           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P24              (_U(0x1) << GPIO_GFERS_P24_Pos)
+#define GPIO_GFERS_P24              (_U_(0x1) << GPIO_GFERS_P24_Pos)
 #define GPIO_GFERS_P25_Pos          25           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P25              (_U(0x1) << GPIO_GFERS_P25_Pos)
+#define GPIO_GFERS_P25              (_U_(0x1) << GPIO_GFERS_P25_Pos)
 #define GPIO_GFERS_P26_Pos          26           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P26              (_U(0x1) << GPIO_GFERS_P26_Pos)
+#define GPIO_GFERS_P26              (_U_(0x1) << GPIO_GFERS_P26_Pos)
 #define GPIO_GFERS_P27_Pos          27           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P27              (_U(0x1) << GPIO_GFERS_P27_Pos)
+#define GPIO_GFERS_P27              (_U_(0x1) << GPIO_GFERS_P27_Pos)
 #define GPIO_GFERS_P28_Pos          28           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P28              (_U(0x1) << GPIO_GFERS_P28_Pos)
+#define GPIO_GFERS_P28              (_U_(0x1) << GPIO_GFERS_P28_Pos)
 #define GPIO_GFERS_P29_Pos          29           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P29              (_U(0x1) << GPIO_GFERS_P29_Pos)
+#define GPIO_GFERS_P29              (_U_(0x1) << GPIO_GFERS_P29_Pos)
 #define GPIO_GFERS_P30_Pos          30           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P30              (_U(0x1) << GPIO_GFERS_P30_Pos)
+#define GPIO_GFERS_P30              (_U_(0x1) << GPIO_GFERS_P30_Pos)
 #define GPIO_GFERS_P31_Pos          31           /**< \brief (GPIO_GFERS) Glitch Filter Enable */
-#define GPIO_GFERS_P31              (_U(0x1) << GPIO_GFERS_P31_Pos)
-#define GPIO_GFERS_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_GFERS) MASK Register */
+#define GPIO_GFERS_P31              (_U_(0x1) << GPIO_GFERS_P31_Pos)
+#define GPIO_GFERS_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_GFERS) MASK Register */
 
 /* -------- GPIO_GFERC : (GPIO Offset: 0x0C8) ( /W 32) port Glitch Filter Enable Register - Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5205,70 +5205,70 @@ typedef union {
 #define GPIO_GFERC_OFFSET           0x0C8        /**< \brief (GPIO_GFERC offset) Glitch Filter Enable Register - Clear */
 
 #define GPIO_GFERC_P0_Pos           0            /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P0               (_U(0x1) << GPIO_GFERC_P0_Pos)
+#define GPIO_GFERC_P0               (_U_(0x1) << GPIO_GFERC_P0_Pos)
 #define GPIO_GFERC_P1_Pos           1            /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P1               (_U(0x1) << GPIO_GFERC_P1_Pos)
+#define GPIO_GFERC_P1               (_U_(0x1) << GPIO_GFERC_P1_Pos)
 #define GPIO_GFERC_P2_Pos           2            /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P2               (_U(0x1) << GPIO_GFERC_P2_Pos)
+#define GPIO_GFERC_P2               (_U_(0x1) << GPIO_GFERC_P2_Pos)
 #define GPIO_GFERC_P3_Pos           3            /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P3               (_U(0x1) << GPIO_GFERC_P3_Pos)
+#define GPIO_GFERC_P3               (_U_(0x1) << GPIO_GFERC_P3_Pos)
 #define GPIO_GFERC_P4_Pos           4            /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P4               (_U(0x1) << GPIO_GFERC_P4_Pos)
+#define GPIO_GFERC_P4               (_U_(0x1) << GPIO_GFERC_P4_Pos)
 #define GPIO_GFERC_P5_Pos           5            /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P5               (_U(0x1) << GPIO_GFERC_P5_Pos)
+#define GPIO_GFERC_P5               (_U_(0x1) << GPIO_GFERC_P5_Pos)
 #define GPIO_GFERC_P6_Pos           6            /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P6               (_U(0x1) << GPIO_GFERC_P6_Pos)
+#define GPIO_GFERC_P6               (_U_(0x1) << GPIO_GFERC_P6_Pos)
 #define GPIO_GFERC_P7_Pos           7            /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P7               (_U(0x1) << GPIO_GFERC_P7_Pos)
+#define GPIO_GFERC_P7               (_U_(0x1) << GPIO_GFERC_P7_Pos)
 #define GPIO_GFERC_P8_Pos           8            /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P8               (_U(0x1) << GPIO_GFERC_P8_Pos)
+#define GPIO_GFERC_P8               (_U_(0x1) << GPIO_GFERC_P8_Pos)
 #define GPIO_GFERC_P9_Pos           9            /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P9               (_U(0x1) << GPIO_GFERC_P9_Pos)
+#define GPIO_GFERC_P9               (_U_(0x1) << GPIO_GFERC_P9_Pos)
 #define GPIO_GFERC_P10_Pos          10           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P10              (_U(0x1) << GPIO_GFERC_P10_Pos)
+#define GPIO_GFERC_P10              (_U_(0x1) << GPIO_GFERC_P10_Pos)
 #define GPIO_GFERC_P11_Pos          11           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P11              (_U(0x1) << GPIO_GFERC_P11_Pos)
+#define GPIO_GFERC_P11              (_U_(0x1) << GPIO_GFERC_P11_Pos)
 #define GPIO_GFERC_P12_Pos          12           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P12              (_U(0x1) << GPIO_GFERC_P12_Pos)
+#define GPIO_GFERC_P12              (_U_(0x1) << GPIO_GFERC_P12_Pos)
 #define GPIO_GFERC_P13_Pos          13           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P13              (_U(0x1) << GPIO_GFERC_P13_Pos)
+#define GPIO_GFERC_P13              (_U_(0x1) << GPIO_GFERC_P13_Pos)
 #define GPIO_GFERC_P14_Pos          14           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P14              (_U(0x1) << GPIO_GFERC_P14_Pos)
+#define GPIO_GFERC_P14              (_U_(0x1) << GPIO_GFERC_P14_Pos)
 #define GPIO_GFERC_P15_Pos          15           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P15              (_U(0x1) << GPIO_GFERC_P15_Pos)
+#define GPIO_GFERC_P15              (_U_(0x1) << GPIO_GFERC_P15_Pos)
 #define GPIO_GFERC_P16_Pos          16           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P16              (_U(0x1) << GPIO_GFERC_P16_Pos)
+#define GPIO_GFERC_P16              (_U_(0x1) << GPIO_GFERC_P16_Pos)
 #define GPIO_GFERC_P17_Pos          17           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P17              (_U(0x1) << GPIO_GFERC_P17_Pos)
+#define GPIO_GFERC_P17              (_U_(0x1) << GPIO_GFERC_P17_Pos)
 #define GPIO_GFERC_P18_Pos          18           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P18              (_U(0x1) << GPIO_GFERC_P18_Pos)
+#define GPIO_GFERC_P18              (_U_(0x1) << GPIO_GFERC_P18_Pos)
 #define GPIO_GFERC_P19_Pos          19           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P19              (_U(0x1) << GPIO_GFERC_P19_Pos)
+#define GPIO_GFERC_P19              (_U_(0x1) << GPIO_GFERC_P19_Pos)
 #define GPIO_GFERC_P20_Pos          20           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P20              (_U(0x1) << GPIO_GFERC_P20_Pos)
+#define GPIO_GFERC_P20              (_U_(0x1) << GPIO_GFERC_P20_Pos)
 #define GPIO_GFERC_P21_Pos          21           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P21              (_U(0x1) << GPIO_GFERC_P21_Pos)
+#define GPIO_GFERC_P21              (_U_(0x1) << GPIO_GFERC_P21_Pos)
 #define GPIO_GFERC_P22_Pos          22           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P22              (_U(0x1) << GPIO_GFERC_P22_Pos)
+#define GPIO_GFERC_P22              (_U_(0x1) << GPIO_GFERC_P22_Pos)
 #define GPIO_GFERC_P23_Pos          23           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P23              (_U(0x1) << GPIO_GFERC_P23_Pos)
+#define GPIO_GFERC_P23              (_U_(0x1) << GPIO_GFERC_P23_Pos)
 #define GPIO_GFERC_P24_Pos          24           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P24              (_U(0x1) << GPIO_GFERC_P24_Pos)
+#define GPIO_GFERC_P24              (_U_(0x1) << GPIO_GFERC_P24_Pos)
 #define GPIO_GFERC_P25_Pos          25           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P25              (_U(0x1) << GPIO_GFERC_P25_Pos)
+#define GPIO_GFERC_P25              (_U_(0x1) << GPIO_GFERC_P25_Pos)
 #define GPIO_GFERC_P26_Pos          26           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P26              (_U(0x1) << GPIO_GFERC_P26_Pos)
+#define GPIO_GFERC_P26              (_U_(0x1) << GPIO_GFERC_P26_Pos)
 #define GPIO_GFERC_P27_Pos          27           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P27              (_U(0x1) << GPIO_GFERC_P27_Pos)
+#define GPIO_GFERC_P27              (_U_(0x1) << GPIO_GFERC_P27_Pos)
 #define GPIO_GFERC_P28_Pos          28           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P28              (_U(0x1) << GPIO_GFERC_P28_Pos)
+#define GPIO_GFERC_P28              (_U_(0x1) << GPIO_GFERC_P28_Pos)
 #define GPIO_GFERC_P29_Pos          29           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P29              (_U(0x1) << GPIO_GFERC_P29_Pos)
+#define GPIO_GFERC_P29              (_U_(0x1) << GPIO_GFERC_P29_Pos)
 #define GPIO_GFERC_P30_Pos          30           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P30              (_U(0x1) << GPIO_GFERC_P30_Pos)
+#define GPIO_GFERC_P30              (_U_(0x1) << GPIO_GFERC_P30_Pos)
 #define GPIO_GFERC_P31_Pos          31           /**< \brief (GPIO_GFERC) Glitch Filter Enable */
-#define GPIO_GFERC_P31              (_U(0x1) << GPIO_GFERC_P31_Pos)
-#define GPIO_GFERC_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_GFERC) MASK Register */
+#define GPIO_GFERC_P31              (_U_(0x1) << GPIO_GFERC_P31_Pos)
+#define GPIO_GFERC_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_GFERC) MASK Register */
 
 /* -------- GPIO_GFERT : (GPIO Offset: 0x0CC) ( /W 32) port Glitch Filter Enable Register - Toggle -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5314,70 +5314,70 @@ typedef union {
 #define GPIO_GFERT_OFFSET           0x0CC        /**< \brief (GPIO_GFERT offset) Glitch Filter Enable Register - Toggle */
 
 #define GPIO_GFERT_P0_Pos           0            /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P0               (_U(0x1) << GPIO_GFERT_P0_Pos)
+#define GPIO_GFERT_P0               (_U_(0x1) << GPIO_GFERT_P0_Pos)
 #define GPIO_GFERT_P1_Pos           1            /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P1               (_U(0x1) << GPIO_GFERT_P1_Pos)
+#define GPIO_GFERT_P1               (_U_(0x1) << GPIO_GFERT_P1_Pos)
 #define GPIO_GFERT_P2_Pos           2            /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P2               (_U(0x1) << GPIO_GFERT_P2_Pos)
+#define GPIO_GFERT_P2               (_U_(0x1) << GPIO_GFERT_P2_Pos)
 #define GPIO_GFERT_P3_Pos           3            /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P3               (_U(0x1) << GPIO_GFERT_P3_Pos)
+#define GPIO_GFERT_P3               (_U_(0x1) << GPIO_GFERT_P3_Pos)
 #define GPIO_GFERT_P4_Pos           4            /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P4               (_U(0x1) << GPIO_GFERT_P4_Pos)
+#define GPIO_GFERT_P4               (_U_(0x1) << GPIO_GFERT_P4_Pos)
 #define GPIO_GFERT_P5_Pos           5            /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P5               (_U(0x1) << GPIO_GFERT_P5_Pos)
+#define GPIO_GFERT_P5               (_U_(0x1) << GPIO_GFERT_P5_Pos)
 #define GPIO_GFERT_P6_Pos           6            /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P6               (_U(0x1) << GPIO_GFERT_P6_Pos)
+#define GPIO_GFERT_P6               (_U_(0x1) << GPIO_GFERT_P6_Pos)
 #define GPIO_GFERT_P7_Pos           7            /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P7               (_U(0x1) << GPIO_GFERT_P7_Pos)
+#define GPIO_GFERT_P7               (_U_(0x1) << GPIO_GFERT_P7_Pos)
 #define GPIO_GFERT_P8_Pos           8            /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P8               (_U(0x1) << GPIO_GFERT_P8_Pos)
+#define GPIO_GFERT_P8               (_U_(0x1) << GPIO_GFERT_P8_Pos)
 #define GPIO_GFERT_P9_Pos           9            /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P9               (_U(0x1) << GPIO_GFERT_P9_Pos)
+#define GPIO_GFERT_P9               (_U_(0x1) << GPIO_GFERT_P9_Pos)
 #define GPIO_GFERT_P10_Pos          10           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P10              (_U(0x1) << GPIO_GFERT_P10_Pos)
+#define GPIO_GFERT_P10              (_U_(0x1) << GPIO_GFERT_P10_Pos)
 #define GPIO_GFERT_P11_Pos          11           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P11              (_U(0x1) << GPIO_GFERT_P11_Pos)
+#define GPIO_GFERT_P11              (_U_(0x1) << GPIO_GFERT_P11_Pos)
 #define GPIO_GFERT_P12_Pos          12           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P12              (_U(0x1) << GPIO_GFERT_P12_Pos)
+#define GPIO_GFERT_P12              (_U_(0x1) << GPIO_GFERT_P12_Pos)
 #define GPIO_GFERT_P13_Pos          13           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P13              (_U(0x1) << GPIO_GFERT_P13_Pos)
+#define GPIO_GFERT_P13              (_U_(0x1) << GPIO_GFERT_P13_Pos)
 #define GPIO_GFERT_P14_Pos          14           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P14              (_U(0x1) << GPIO_GFERT_P14_Pos)
+#define GPIO_GFERT_P14              (_U_(0x1) << GPIO_GFERT_P14_Pos)
 #define GPIO_GFERT_P15_Pos          15           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P15              (_U(0x1) << GPIO_GFERT_P15_Pos)
+#define GPIO_GFERT_P15              (_U_(0x1) << GPIO_GFERT_P15_Pos)
 #define GPIO_GFERT_P16_Pos          16           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P16              (_U(0x1) << GPIO_GFERT_P16_Pos)
+#define GPIO_GFERT_P16              (_U_(0x1) << GPIO_GFERT_P16_Pos)
 #define GPIO_GFERT_P17_Pos          17           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P17              (_U(0x1) << GPIO_GFERT_P17_Pos)
+#define GPIO_GFERT_P17              (_U_(0x1) << GPIO_GFERT_P17_Pos)
 #define GPIO_GFERT_P18_Pos          18           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P18              (_U(0x1) << GPIO_GFERT_P18_Pos)
+#define GPIO_GFERT_P18              (_U_(0x1) << GPIO_GFERT_P18_Pos)
 #define GPIO_GFERT_P19_Pos          19           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P19              (_U(0x1) << GPIO_GFERT_P19_Pos)
+#define GPIO_GFERT_P19              (_U_(0x1) << GPIO_GFERT_P19_Pos)
 #define GPIO_GFERT_P20_Pos          20           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P20              (_U(0x1) << GPIO_GFERT_P20_Pos)
+#define GPIO_GFERT_P20              (_U_(0x1) << GPIO_GFERT_P20_Pos)
 #define GPIO_GFERT_P21_Pos          21           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P21              (_U(0x1) << GPIO_GFERT_P21_Pos)
+#define GPIO_GFERT_P21              (_U_(0x1) << GPIO_GFERT_P21_Pos)
 #define GPIO_GFERT_P22_Pos          22           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P22              (_U(0x1) << GPIO_GFERT_P22_Pos)
+#define GPIO_GFERT_P22              (_U_(0x1) << GPIO_GFERT_P22_Pos)
 #define GPIO_GFERT_P23_Pos          23           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P23              (_U(0x1) << GPIO_GFERT_P23_Pos)
+#define GPIO_GFERT_P23              (_U_(0x1) << GPIO_GFERT_P23_Pos)
 #define GPIO_GFERT_P24_Pos          24           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P24              (_U(0x1) << GPIO_GFERT_P24_Pos)
+#define GPIO_GFERT_P24              (_U_(0x1) << GPIO_GFERT_P24_Pos)
 #define GPIO_GFERT_P25_Pos          25           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P25              (_U(0x1) << GPIO_GFERT_P25_Pos)
+#define GPIO_GFERT_P25              (_U_(0x1) << GPIO_GFERT_P25_Pos)
 #define GPIO_GFERT_P26_Pos          26           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P26              (_U(0x1) << GPIO_GFERT_P26_Pos)
+#define GPIO_GFERT_P26              (_U_(0x1) << GPIO_GFERT_P26_Pos)
 #define GPIO_GFERT_P27_Pos          27           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P27              (_U(0x1) << GPIO_GFERT_P27_Pos)
+#define GPIO_GFERT_P27              (_U_(0x1) << GPIO_GFERT_P27_Pos)
 #define GPIO_GFERT_P28_Pos          28           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P28              (_U(0x1) << GPIO_GFERT_P28_Pos)
+#define GPIO_GFERT_P28              (_U_(0x1) << GPIO_GFERT_P28_Pos)
 #define GPIO_GFERT_P29_Pos          29           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P29              (_U(0x1) << GPIO_GFERT_P29_Pos)
+#define GPIO_GFERT_P29              (_U_(0x1) << GPIO_GFERT_P29_Pos)
 #define GPIO_GFERT_P30_Pos          30           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P30              (_U(0x1) << GPIO_GFERT_P30_Pos)
+#define GPIO_GFERT_P30              (_U_(0x1) << GPIO_GFERT_P30_Pos)
 #define GPIO_GFERT_P31_Pos          31           /**< \brief (GPIO_GFERT) Glitch Filter Enable */
-#define GPIO_GFERT_P31              (_U(0x1) << GPIO_GFERT_P31_Pos)
-#define GPIO_GFERT_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_GFERT) MASK Register */
+#define GPIO_GFERT_P31              (_U_(0x1) << GPIO_GFERT_P31_Pos)
+#define GPIO_GFERT_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_GFERT) MASK Register */
 
 /* -------- GPIO_IFR : (GPIO Offset: 0x0D0) (R/  32) port Interrupt Flag Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5423,70 +5423,70 @@ typedef union {
 #define GPIO_IFR_OFFSET             0x0D0        /**< \brief (GPIO_IFR offset) Interrupt Flag Register */
 
 #define GPIO_IFR_P0_Pos             0            /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P0                 (_U(0x1) << GPIO_IFR_P0_Pos)
+#define GPIO_IFR_P0                 (_U_(0x1) << GPIO_IFR_P0_Pos)
 #define GPIO_IFR_P1_Pos             1            /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P1                 (_U(0x1) << GPIO_IFR_P1_Pos)
+#define GPIO_IFR_P1                 (_U_(0x1) << GPIO_IFR_P1_Pos)
 #define GPIO_IFR_P2_Pos             2            /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P2                 (_U(0x1) << GPIO_IFR_P2_Pos)
+#define GPIO_IFR_P2                 (_U_(0x1) << GPIO_IFR_P2_Pos)
 #define GPIO_IFR_P3_Pos             3            /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P3                 (_U(0x1) << GPIO_IFR_P3_Pos)
+#define GPIO_IFR_P3                 (_U_(0x1) << GPIO_IFR_P3_Pos)
 #define GPIO_IFR_P4_Pos             4            /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P4                 (_U(0x1) << GPIO_IFR_P4_Pos)
+#define GPIO_IFR_P4                 (_U_(0x1) << GPIO_IFR_P4_Pos)
 #define GPIO_IFR_P5_Pos             5            /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P5                 (_U(0x1) << GPIO_IFR_P5_Pos)
+#define GPIO_IFR_P5                 (_U_(0x1) << GPIO_IFR_P5_Pos)
 #define GPIO_IFR_P6_Pos             6            /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P6                 (_U(0x1) << GPIO_IFR_P6_Pos)
+#define GPIO_IFR_P6                 (_U_(0x1) << GPIO_IFR_P6_Pos)
 #define GPIO_IFR_P7_Pos             7            /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P7                 (_U(0x1) << GPIO_IFR_P7_Pos)
+#define GPIO_IFR_P7                 (_U_(0x1) << GPIO_IFR_P7_Pos)
 #define GPIO_IFR_P8_Pos             8            /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P8                 (_U(0x1) << GPIO_IFR_P8_Pos)
+#define GPIO_IFR_P8                 (_U_(0x1) << GPIO_IFR_P8_Pos)
 #define GPIO_IFR_P9_Pos             9            /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P9                 (_U(0x1) << GPIO_IFR_P9_Pos)
+#define GPIO_IFR_P9                 (_U_(0x1) << GPIO_IFR_P9_Pos)
 #define GPIO_IFR_P10_Pos            10           /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P10                (_U(0x1) << GPIO_IFR_P10_Pos)
+#define GPIO_IFR_P10                (_U_(0x1) << GPIO_IFR_P10_Pos)
 #define GPIO_IFR_P11_Pos            11           /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P11                (_U(0x1) << GPIO_IFR_P11_Pos)
+#define GPIO_IFR_P11                (_U_(0x1) << GPIO_IFR_P11_Pos)
 #define GPIO_IFR_P12_Pos            12           /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P12                (_U(0x1) << GPIO_IFR_P12_Pos)
+#define GPIO_IFR_P12                (_U_(0x1) << GPIO_IFR_P12_Pos)
 #define GPIO_IFR_P13_Pos            13           /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P13                (_U(0x1) << GPIO_IFR_P13_Pos)
+#define GPIO_IFR_P13                (_U_(0x1) << GPIO_IFR_P13_Pos)
 #define GPIO_IFR_P14_Pos            14           /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P14                (_U(0x1) << GPIO_IFR_P14_Pos)
+#define GPIO_IFR_P14                (_U_(0x1) << GPIO_IFR_P14_Pos)
 #define GPIO_IFR_P15_Pos            15           /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P15                (_U(0x1) << GPIO_IFR_P15_Pos)
+#define GPIO_IFR_P15                (_U_(0x1) << GPIO_IFR_P15_Pos)
 #define GPIO_IFR_P16_Pos            16           /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P16                (_U(0x1) << GPIO_IFR_P16_Pos)
+#define GPIO_IFR_P16                (_U_(0x1) << GPIO_IFR_P16_Pos)
 #define GPIO_IFR_P17_Pos            17           /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P17                (_U(0x1) << GPIO_IFR_P17_Pos)
+#define GPIO_IFR_P17                (_U_(0x1) << GPIO_IFR_P17_Pos)
 #define GPIO_IFR_P18_Pos            18           /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P18                (_U(0x1) << GPIO_IFR_P18_Pos)
+#define GPIO_IFR_P18                (_U_(0x1) << GPIO_IFR_P18_Pos)
 #define GPIO_IFR_P19_Pos            19           /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P19                (_U(0x1) << GPIO_IFR_P19_Pos)
+#define GPIO_IFR_P19                (_U_(0x1) << GPIO_IFR_P19_Pos)
 #define GPIO_IFR_P20_Pos            20           /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P20                (_U(0x1) << GPIO_IFR_P20_Pos)
+#define GPIO_IFR_P20                (_U_(0x1) << GPIO_IFR_P20_Pos)
 #define GPIO_IFR_P21_Pos            21           /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P21                (_U(0x1) << GPIO_IFR_P21_Pos)
+#define GPIO_IFR_P21                (_U_(0x1) << GPIO_IFR_P21_Pos)
 #define GPIO_IFR_P22_Pos            22           /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P22                (_U(0x1) << GPIO_IFR_P22_Pos)
+#define GPIO_IFR_P22                (_U_(0x1) << GPIO_IFR_P22_Pos)
 #define GPIO_IFR_P23_Pos            23           /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P23                (_U(0x1) << GPIO_IFR_P23_Pos)
+#define GPIO_IFR_P23                (_U_(0x1) << GPIO_IFR_P23_Pos)
 #define GPIO_IFR_P24_Pos            24           /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P24                (_U(0x1) << GPIO_IFR_P24_Pos)
+#define GPIO_IFR_P24                (_U_(0x1) << GPIO_IFR_P24_Pos)
 #define GPIO_IFR_P25_Pos            25           /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P25                (_U(0x1) << GPIO_IFR_P25_Pos)
+#define GPIO_IFR_P25                (_U_(0x1) << GPIO_IFR_P25_Pos)
 #define GPIO_IFR_P26_Pos            26           /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P26                (_U(0x1) << GPIO_IFR_P26_Pos)
+#define GPIO_IFR_P26                (_U_(0x1) << GPIO_IFR_P26_Pos)
 #define GPIO_IFR_P27_Pos            27           /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P27                (_U(0x1) << GPIO_IFR_P27_Pos)
+#define GPIO_IFR_P27                (_U_(0x1) << GPIO_IFR_P27_Pos)
 #define GPIO_IFR_P28_Pos            28           /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P28                (_U(0x1) << GPIO_IFR_P28_Pos)
+#define GPIO_IFR_P28                (_U_(0x1) << GPIO_IFR_P28_Pos)
 #define GPIO_IFR_P29_Pos            29           /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P29                (_U(0x1) << GPIO_IFR_P29_Pos)
+#define GPIO_IFR_P29                (_U_(0x1) << GPIO_IFR_P29_Pos)
 #define GPIO_IFR_P30_Pos            30           /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P30                (_U(0x1) << GPIO_IFR_P30_Pos)
+#define GPIO_IFR_P30                (_U_(0x1) << GPIO_IFR_P30_Pos)
 #define GPIO_IFR_P31_Pos            31           /**< \brief (GPIO_IFR) Interrupt Flag */
-#define GPIO_IFR_P31                (_U(0x1) << GPIO_IFR_P31_Pos)
-#define GPIO_IFR_MASK               _U(0xFFFFFFFF) /**< \brief (GPIO_IFR) MASK Register */
+#define GPIO_IFR_P31                (_U_(0x1) << GPIO_IFR_P31_Pos)
+#define GPIO_IFR_MASK               _U_(0xFFFFFFFF) /**< \brief (GPIO_IFR) MASK Register */
 
 /* -------- GPIO_IFRC : (GPIO Offset: 0x0D8) ( /W 32) port Interrupt Flag Register - Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5532,70 +5532,70 @@ typedef union {
 #define GPIO_IFRC_OFFSET            0x0D8        /**< \brief (GPIO_IFRC offset) Interrupt Flag Register - Clear */
 
 #define GPIO_IFRC_P0_Pos            0            /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P0                (_U(0x1) << GPIO_IFRC_P0_Pos)
+#define GPIO_IFRC_P0                (_U_(0x1) << GPIO_IFRC_P0_Pos)
 #define GPIO_IFRC_P1_Pos            1            /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P1                (_U(0x1) << GPIO_IFRC_P1_Pos)
+#define GPIO_IFRC_P1                (_U_(0x1) << GPIO_IFRC_P1_Pos)
 #define GPIO_IFRC_P2_Pos            2            /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P2                (_U(0x1) << GPIO_IFRC_P2_Pos)
+#define GPIO_IFRC_P2                (_U_(0x1) << GPIO_IFRC_P2_Pos)
 #define GPIO_IFRC_P3_Pos            3            /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P3                (_U(0x1) << GPIO_IFRC_P3_Pos)
+#define GPIO_IFRC_P3                (_U_(0x1) << GPIO_IFRC_P3_Pos)
 #define GPIO_IFRC_P4_Pos            4            /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P4                (_U(0x1) << GPIO_IFRC_P4_Pos)
+#define GPIO_IFRC_P4                (_U_(0x1) << GPIO_IFRC_P4_Pos)
 #define GPIO_IFRC_P5_Pos            5            /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P5                (_U(0x1) << GPIO_IFRC_P5_Pos)
+#define GPIO_IFRC_P5                (_U_(0x1) << GPIO_IFRC_P5_Pos)
 #define GPIO_IFRC_P6_Pos            6            /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P6                (_U(0x1) << GPIO_IFRC_P6_Pos)
+#define GPIO_IFRC_P6                (_U_(0x1) << GPIO_IFRC_P6_Pos)
 #define GPIO_IFRC_P7_Pos            7            /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P7                (_U(0x1) << GPIO_IFRC_P7_Pos)
+#define GPIO_IFRC_P7                (_U_(0x1) << GPIO_IFRC_P7_Pos)
 #define GPIO_IFRC_P8_Pos            8            /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P8                (_U(0x1) << GPIO_IFRC_P8_Pos)
+#define GPIO_IFRC_P8                (_U_(0x1) << GPIO_IFRC_P8_Pos)
 #define GPIO_IFRC_P9_Pos            9            /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P9                (_U(0x1) << GPIO_IFRC_P9_Pos)
+#define GPIO_IFRC_P9                (_U_(0x1) << GPIO_IFRC_P9_Pos)
 #define GPIO_IFRC_P10_Pos           10           /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P10               (_U(0x1) << GPIO_IFRC_P10_Pos)
+#define GPIO_IFRC_P10               (_U_(0x1) << GPIO_IFRC_P10_Pos)
 #define GPIO_IFRC_P11_Pos           11           /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P11               (_U(0x1) << GPIO_IFRC_P11_Pos)
+#define GPIO_IFRC_P11               (_U_(0x1) << GPIO_IFRC_P11_Pos)
 #define GPIO_IFRC_P12_Pos           12           /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P12               (_U(0x1) << GPIO_IFRC_P12_Pos)
+#define GPIO_IFRC_P12               (_U_(0x1) << GPIO_IFRC_P12_Pos)
 #define GPIO_IFRC_P13_Pos           13           /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P13               (_U(0x1) << GPIO_IFRC_P13_Pos)
+#define GPIO_IFRC_P13               (_U_(0x1) << GPIO_IFRC_P13_Pos)
 #define GPIO_IFRC_P14_Pos           14           /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P14               (_U(0x1) << GPIO_IFRC_P14_Pos)
+#define GPIO_IFRC_P14               (_U_(0x1) << GPIO_IFRC_P14_Pos)
 #define GPIO_IFRC_P15_Pos           15           /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P15               (_U(0x1) << GPIO_IFRC_P15_Pos)
+#define GPIO_IFRC_P15               (_U_(0x1) << GPIO_IFRC_P15_Pos)
 #define GPIO_IFRC_P16_Pos           16           /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P16               (_U(0x1) << GPIO_IFRC_P16_Pos)
+#define GPIO_IFRC_P16               (_U_(0x1) << GPIO_IFRC_P16_Pos)
 #define GPIO_IFRC_P17_Pos           17           /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P17               (_U(0x1) << GPIO_IFRC_P17_Pos)
+#define GPIO_IFRC_P17               (_U_(0x1) << GPIO_IFRC_P17_Pos)
 #define GPIO_IFRC_P18_Pos           18           /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P18               (_U(0x1) << GPIO_IFRC_P18_Pos)
+#define GPIO_IFRC_P18               (_U_(0x1) << GPIO_IFRC_P18_Pos)
 #define GPIO_IFRC_P19_Pos           19           /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P19               (_U(0x1) << GPIO_IFRC_P19_Pos)
+#define GPIO_IFRC_P19               (_U_(0x1) << GPIO_IFRC_P19_Pos)
 #define GPIO_IFRC_P20_Pos           20           /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P20               (_U(0x1) << GPIO_IFRC_P20_Pos)
+#define GPIO_IFRC_P20               (_U_(0x1) << GPIO_IFRC_P20_Pos)
 #define GPIO_IFRC_P21_Pos           21           /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P21               (_U(0x1) << GPIO_IFRC_P21_Pos)
+#define GPIO_IFRC_P21               (_U_(0x1) << GPIO_IFRC_P21_Pos)
 #define GPIO_IFRC_P22_Pos           22           /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P22               (_U(0x1) << GPIO_IFRC_P22_Pos)
+#define GPIO_IFRC_P22               (_U_(0x1) << GPIO_IFRC_P22_Pos)
 #define GPIO_IFRC_P23_Pos           23           /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P23               (_U(0x1) << GPIO_IFRC_P23_Pos)
+#define GPIO_IFRC_P23               (_U_(0x1) << GPIO_IFRC_P23_Pos)
 #define GPIO_IFRC_P24_Pos           24           /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P24               (_U(0x1) << GPIO_IFRC_P24_Pos)
+#define GPIO_IFRC_P24               (_U_(0x1) << GPIO_IFRC_P24_Pos)
 #define GPIO_IFRC_P25_Pos           25           /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P25               (_U(0x1) << GPIO_IFRC_P25_Pos)
+#define GPIO_IFRC_P25               (_U_(0x1) << GPIO_IFRC_P25_Pos)
 #define GPIO_IFRC_P26_Pos           26           /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P26               (_U(0x1) << GPIO_IFRC_P26_Pos)
+#define GPIO_IFRC_P26               (_U_(0x1) << GPIO_IFRC_P26_Pos)
 #define GPIO_IFRC_P27_Pos           27           /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P27               (_U(0x1) << GPIO_IFRC_P27_Pos)
+#define GPIO_IFRC_P27               (_U_(0x1) << GPIO_IFRC_P27_Pos)
 #define GPIO_IFRC_P28_Pos           28           /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P28               (_U(0x1) << GPIO_IFRC_P28_Pos)
+#define GPIO_IFRC_P28               (_U_(0x1) << GPIO_IFRC_P28_Pos)
 #define GPIO_IFRC_P29_Pos           29           /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P29               (_U(0x1) << GPIO_IFRC_P29_Pos)
+#define GPIO_IFRC_P29               (_U_(0x1) << GPIO_IFRC_P29_Pos)
 #define GPIO_IFRC_P30_Pos           30           /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P30               (_U(0x1) << GPIO_IFRC_P30_Pos)
+#define GPIO_IFRC_P30               (_U_(0x1) << GPIO_IFRC_P30_Pos)
 #define GPIO_IFRC_P31_Pos           31           /**< \brief (GPIO_IFRC) Interrupt Flag */
-#define GPIO_IFRC_P31               (_U(0x1) << GPIO_IFRC_P31_Pos)
-#define GPIO_IFRC_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_IFRC) MASK Register */
+#define GPIO_IFRC_P31               (_U_(0x1) << GPIO_IFRC_P31_Pos)
+#define GPIO_IFRC_MASK              _U_(0xFFFFFFFF) /**< \brief (GPIO_IFRC) MASK Register */
 
 /* -------- GPIO_ODMER : (GPIO Offset: 0x0E0) (R/W 32) port Open Drain Mode Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5641,70 +5641,70 @@ typedef union {
 #define GPIO_ODMER_OFFSET           0x0E0        /**< \brief (GPIO_ODMER offset) Open Drain Mode Register */
 
 #define GPIO_ODMER_P0_Pos           0            /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P0               (_U(0x1) << GPIO_ODMER_P0_Pos)
+#define GPIO_ODMER_P0               (_U_(0x1) << GPIO_ODMER_P0_Pos)
 #define GPIO_ODMER_P1_Pos           1            /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P1               (_U(0x1) << GPIO_ODMER_P1_Pos)
+#define GPIO_ODMER_P1               (_U_(0x1) << GPIO_ODMER_P1_Pos)
 #define GPIO_ODMER_P2_Pos           2            /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P2               (_U(0x1) << GPIO_ODMER_P2_Pos)
+#define GPIO_ODMER_P2               (_U_(0x1) << GPIO_ODMER_P2_Pos)
 #define GPIO_ODMER_P3_Pos           3            /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P3               (_U(0x1) << GPIO_ODMER_P3_Pos)
+#define GPIO_ODMER_P3               (_U_(0x1) << GPIO_ODMER_P3_Pos)
 #define GPIO_ODMER_P4_Pos           4            /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P4               (_U(0x1) << GPIO_ODMER_P4_Pos)
+#define GPIO_ODMER_P4               (_U_(0x1) << GPIO_ODMER_P4_Pos)
 #define GPIO_ODMER_P5_Pos           5            /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P5               (_U(0x1) << GPIO_ODMER_P5_Pos)
+#define GPIO_ODMER_P5               (_U_(0x1) << GPIO_ODMER_P5_Pos)
 #define GPIO_ODMER_P6_Pos           6            /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P6               (_U(0x1) << GPIO_ODMER_P6_Pos)
+#define GPIO_ODMER_P6               (_U_(0x1) << GPIO_ODMER_P6_Pos)
 #define GPIO_ODMER_P7_Pos           7            /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P7               (_U(0x1) << GPIO_ODMER_P7_Pos)
+#define GPIO_ODMER_P7               (_U_(0x1) << GPIO_ODMER_P7_Pos)
 #define GPIO_ODMER_P8_Pos           8            /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P8               (_U(0x1) << GPIO_ODMER_P8_Pos)
+#define GPIO_ODMER_P8               (_U_(0x1) << GPIO_ODMER_P8_Pos)
 #define GPIO_ODMER_P9_Pos           9            /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P9               (_U(0x1) << GPIO_ODMER_P9_Pos)
+#define GPIO_ODMER_P9               (_U_(0x1) << GPIO_ODMER_P9_Pos)
 #define GPIO_ODMER_P10_Pos          10           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P10              (_U(0x1) << GPIO_ODMER_P10_Pos)
+#define GPIO_ODMER_P10              (_U_(0x1) << GPIO_ODMER_P10_Pos)
 #define GPIO_ODMER_P11_Pos          11           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P11              (_U(0x1) << GPIO_ODMER_P11_Pos)
+#define GPIO_ODMER_P11              (_U_(0x1) << GPIO_ODMER_P11_Pos)
 #define GPIO_ODMER_P12_Pos          12           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P12              (_U(0x1) << GPIO_ODMER_P12_Pos)
+#define GPIO_ODMER_P12              (_U_(0x1) << GPIO_ODMER_P12_Pos)
 #define GPIO_ODMER_P13_Pos          13           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P13              (_U(0x1) << GPIO_ODMER_P13_Pos)
+#define GPIO_ODMER_P13              (_U_(0x1) << GPIO_ODMER_P13_Pos)
 #define GPIO_ODMER_P14_Pos          14           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P14              (_U(0x1) << GPIO_ODMER_P14_Pos)
+#define GPIO_ODMER_P14              (_U_(0x1) << GPIO_ODMER_P14_Pos)
 #define GPIO_ODMER_P15_Pos          15           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P15              (_U(0x1) << GPIO_ODMER_P15_Pos)
+#define GPIO_ODMER_P15              (_U_(0x1) << GPIO_ODMER_P15_Pos)
 #define GPIO_ODMER_P16_Pos          16           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P16              (_U(0x1) << GPIO_ODMER_P16_Pos)
+#define GPIO_ODMER_P16              (_U_(0x1) << GPIO_ODMER_P16_Pos)
 #define GPIO_ODMER_P17_Pos          17           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P17              (_U(0x1) << GPIO_ODMER_P17_Pos)
+#define GPIO_ODMER_P17              (_U_(0x1) << GPIO_ODMER_P17_Pos)
 #define GPIO_ODMER_P18_Pos          18           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P18              (_U(0x1) << GPIO_ODMER_P18_Pos)
+#define GPIO_ODMER_P18              (_U_(0x1) << GPIO_ODMER_P18_Pos)
 #define GPIO_ODMER_P19_Pos          19           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P19              (_U(0x1) << GPIO_ODMER_P19_Pos)
+#define GPIO_ODMER_P19              (_U_(0x1) << GPIO_ODMER_P19_Pos)
 #define GPIO_ODMER_P20_Pos          20           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P20              (_U(0x1) << GPIO_ODMER_P20_Pos)
+#define GPIO_ODMER_P20              (_U_(0x1) << GPIO_ODMER_P20_Pos)
 #define GPIO_ODMER_P21_Pos          21           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P21              (_U(0x1) << GPIO_ODMER_P21_Pos)
+#define GPIO_ODMER_P21              (_U_(0x1) << GPIO_ODMER_P21_Pos)
 #define GPIO_ODMER_P22_Pos          22           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P22              (_U(0x1) << GPIO_ODMER_P22_Pos)
+#define GPIO_ODMER_P22              (_U_(0x1) << GPIO_ODMER_P22_Pos)
 #define GPIO_ODMER_P23_Pos          23           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P23              (_U(0x1) << GPIO_ODMER_P23_Pos)
+#define GPIO_ODMER_P23              (_U_(0x1) << GPIO_ODMER_P23_Pos)
 #define GPIO_ODMER_P24_Pos          24           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P24              (_U(0x1) << GPIO_ODMER_P24_Pos)
+#define GPIO_ODMER_P24              (_U_(0x1) << GPIO_ODMER_P24_Pos)
 #define GPIO_ODMER_P25_Pos          25           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P25              (_U(0x1) << GPIO_ODMER_P25_Pos)
+#define GPIO_ODMER_P25              (_U_(0x1) << GPIO_ODMER_P25_Pos)
 #define GPIO_ODMER_P26_Pos          26           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P26              (_U(0x1) << GPIO_ODMER_P26_Pos)
+#define GPIO_ODMER_P26              (_U_(0x1) << GPIO_ODMER_P26_Pos)
 #define GPIO_ODMER_P27_Pos          27           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P27              (_U(0x1) << GPIO_ODMER_P27_Pos)
+#define GPIO_ODMER_P27              (_U_(0x1) << GPIO_ODMER_P27_Pos)
 #define GPIO_ODMER_P28_Pos          28           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P28              (_U(0x1) << GPIO_ODMER_P28_Pos)
+#define GPIO_ODMER_P28              (_U_(0x1) << GPIO_ODMER_P28_Pos)
 #define GPIO_ODMER_P29_Pos          29           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P29              (_U(0x1) << GPIO_ODMER_P29_Pos)
+#define GPIO_ODMER_P29              (_U_(0x1) << GPIO_ODMER_P29_Pos)
 #define GPIO_ODMER_P30_Pos          30           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P30              (_U(0x1) << GPIO_ODMER_P30_Pos)
+#define GPIO_ODMER_P30              (_U_(0x1) << GPIO_ODMER_P30_Pos)
 #define GPIO_ODMER_P31_Pos          31           /**< \brief (GPIO_ODMER) Open Drain Mode Enable */
-#define GPIO_ODMER_P31              (_U(0x1) << GPIO_ODMER_P31_Pos)
-#define GPIO_ODMER_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_ODMER) MASK Register */
+#define GPIO_ODMER_P31              (_U_(0x1) << GPIO_ODMER_P31_Pos)
+#define GPIO_ODMER_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_ODMER) MASK Register */
 
 /* -------- GPIO_ODMERS : (GPIO Offset: 0x0E4) ( /W 32) port Open Drain Mode Register - Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5750,70 +5750,70 @@ typedef union {
 #define GPIO_ODMERS_OFFSET          0x0E4        /**< \brief (GPIO_ODMERS offset) Open Drain Mode Register - Set */
 
 #define GPIO_ODMERS_P0_Pos          0            /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P0              (_U(0x1) << GPIO_ODMERS_P0_Pos)
+#define GPIO_ODMERS_P0              (_U_(0x1) << GPIO_ODMERS_P0_Pos)
 #define GPIO_ODMERS_P1_Pos          1            /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P1              (_U(0x1) << GPIO_ODMERS_P1_Pos)
+#define GPIO_ODMERS_P1              (_U_(0x1) << GPIO_ODMERS_P1_Pos)
 #define GPIO_ODMERS_P2_Pos          2            /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P2              (_U(0x1) << GPIO_ODMERS_P2_Pos)
+#define GPIO_ODMERS_P2              (_U_(0x1) << GPIO_ODMERS_P2_Pos)
 #define GPIO_ODMERS_P3_Pos          3            /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P3              (_U(0x1) << GPIO_ODMERS_P3_Pos)
+#define GPIO_ODMERS_P3              (_U_(0x1) << GPIO_ODMERS_P3_Pos)
 #define GPIO_ODMERS_P4_Pos          4            /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P4              (_U(0x1) << GPIO_ODMERS_P4_Pos)
+#define GPIO_ODMERS_P4              (_U_(0x1) << GPIO_ODMERS_P4_Pos)
 #define GPIO_ODMERS_P5_Pos          5            /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P5              (_U(0x1) << GPIO_ODMERS_P5_Pos)
+#define GPIO_ODMERS_P5              (_U_(0x1) << GPIO_ODMERS_P5_Pos)
 #define GPIO_ODMERS_P6_Pos          6            /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P6              (_U(0x1) << GPIO_ODMERS_P6_Pos)
+#define GPIO_ODMERS_P6              (_U_(0x1) << GPIO_ODMERS_P6_Pos)
 #define GPIO_ODMERS_P7_Pos          7            /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P7              (_U(0x1) << GPIO_ODMERS_P7_Pos)
+#define GPIO_ODMERS_P7              (_U_(0x1) << GPIO_ODMERS_P7_Pos)
 #define GPIO_ODMERS_P8_Pos          8            /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P8              (_U(0x1) << GPIO_ODMERS_P8_Pos)
+#define GPIO_ODMERS_P8              (_U_(0x1) << GPIO_ODMERS_P8_Pos)
 #define GPIO_ODMERS_P9_Pos          9            /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P9              (_U(0x1) << GPIO_ODMERS_P9_Pos)
+#define GPIO_ODMERS_P9              (_U_(0x1) << GPIO_ODMERS_P9_Pos)
 #define GPIO_ODMERS_P10_Pos         10           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P10             (_U(0x1) << GPIO_ODMERS_P10_Pos)
+#define GPIO_ODMERS_P10             (_U_(0x1) << GPIO_ODMERS_P10_Pos)
 #define GPIO_ODMERS_P11_Pos         11           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P11             (_U(0x1) << GPIO_ODMERS_P11_Pos)
+#define GPIO_ODMERS_P11             (_U_(0x1) << GPIO_ODMERS_P11_Pos)
 #define GPIO_ODMERS_P12_Pos         12           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P12             (_U(0x1) << GPIO_ODMERS_P12_Pos)
+#define GPIO_ODMERS_P12             (_U_(0x1) << GPIO_ODMERS_P12_Pos)
 #define GPIO_ODMERS_P13_Pos         13           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P13             (_U(0x1) << GPIO_ODMERS_P13_Pos)
+#define GPIO_ODMERS_P13             (_U_(0x1) << GPIO_ODMERS_P13_Pos)
 #define GPIO_ODMERS_P14_Pos         14           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P14             (_U(0x1) << GPIO_ODMERS_P14_Pos)
+#define GPIO_ODMERS_P14             (_U_(0x1) << GPIO_ODMERS_P14_Pos)
 #define GPIO_ODMERS_P15_Pos         15           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P15             (_U(0x1) << GPIO_ODMERS_P15_Pos)
+#define GPIO_ODMERS_P15             (_U_(0x1) << GPIO_ODMERS_P15_Pos)
 #define GPIO_ODMERS_P16_Pos         16           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P16             (_U(0x1) << GPIO_ODMERS_P16_Pos)
+#define GPIO_ODMERS_P16             (_U_(0x1) << GPIO_ODMERS_P16_Pos)
 #define GPIO_ODMERS_P17_Pos         17           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P17             (_U(0x1) << GPIO_ODMERS_P17_Pos)
+#define GPIO_ODMERS_P17             (_U_(0x1) << GPIO_ODMERS_P17_Pos)
 #define GPIO_ODMERS_P18_Pos         18           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P18             (_U(0x1) << GPIO_ODMERS_P18_Pos)
+#define GPIO_ODMERS_P18             (_U_(0x1) << GPIO_ODMERS_P18_Pos)
 #define GPIO_ODMERS_P19_Pos         19           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P19             (_U(0x1) << GPIO_ODMERS_P19_Pos)
+#define GPIO_ODMERS_P19             (_U_(0x1) << GPIO_ODMERS_P19_Pos)
 #define GPIO_ODMERS_P20_Pos         20           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P20             (_U(0x1) << GPIO_ODMERS_P20_Pos)
+#define GPIO_ODMERS_P20             (_U_(0x1) << GPIO_ODMERS_P20_Pos)
 #define GPIO_ODMERS_P21_Pos         21           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P21             (_U(0x1) << GPIO_ODMERS_P21_Pos)
+#define GPIO_ODMERS_P21             (_U_(0x1) << GPIO_ODMERS_P21_Pos)
 #define GPIO_ODMERS_P22_Pos         22           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P22             (_U(0x1) << GPIO_ODMERS_P22_Pos)
+#define GPIO_ODMERS_P22             (_U_(0x1) << GPIO_ODMERS_P22_Pos)
 #define GPIO_ODMERS_P23_Pos         23           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P23             (_U(0x1) << GPIO_ODMERS_P23_Pos)
+#define GPIO_ODMERS_P23             (_U_(0x1) << GPIO_ODMERS_P23_Pos)
 #define GPIO_ODMERS_P24_Pos         24           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P24             (_U(0x1) << GPIO_ODMERS_P24_Pos)
+#define GPIO_ODMERS_P24             (_U_(0x1) << GPIO_ODMERS_P24_Pos)
 #define GPIO_ODMERS_P25_Pos         25           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P25             (_U(0x1) << GPIO_ODMERS_P25_Pos)
+#define GPIO_ODMERS_P25             (_U_(0x1) << GPIO_ODMERS_P25_Pos)
 #define GPIO_ODMERS_P26_Pos         26           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P26             (_U(0x1) << GPIO_ODMERS_P26_Pos)
+#define GPIO_ODMERS_P26             (_U_(0x1) << GPIO_ODMERS_P26_Pos)
 #define GPIO_ODMERS_P27_Pos         27           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P27             (_U(0x1) << GPIO_ODMERS_P27_Pos)
+#define GPIO_ODMERS_P27             (_U_(0x1) << GPIO_ODMERS_P27_Pos)
 #define GPIO_ODMERS_P28_Pos         28           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P28             (_U(0x1) << GPIO_ODMERS_P28_Pos)
+#define GPIO_ODMERS_P28             (_U_(0x1) << GPIO_ODMERS_P28_Pos)
 #define GPIO_ODMERS_P29_Pos         29           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P29             (_U(0x1) << GPIO_ODMERS_P29_Pos)
+#define GPIO_ODMERS_P29             (_U_(0x1) << GPIO_ODMERS_P29_Pos)
 #define GPIO_ODMERS_P30_Pos         30           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P30             (_U(0x1) << GPIO_ODMERS_P30_Pos)
+#define GPIO_ODMERS_P30             (_U_(0x1) << GPIO_ODMERS_P30_Pos)
 #define GPIO_ODMERS_P31_Pos         31           /**< \brief (GPIO_ODMERS) Open Drain Mode Enable */
-#define GPIO_ODMERS_P31             (_U(0x1) << GPIO_ODMERS_P31_Pos)
-#define GPIO_ODMERS_MASK            _U(0xFFFFFFFF) /**< \brief (GPIO_ODMERS) MASK Register */
+#define GPIO_ODMERS_P31             (_U_(0x1) << GPIO_ODMERS_P31_Pos)
+#define GPIO_ODMERS_MASK            _U_(0xFFFFFFFF) /**< \brief (GPIO_ODMERS) MASK Register */
 
 /* -------- GPIO_ODMERC : (GPIO Offset: 0x0E8) ( /W 32) port Open Drain Mode Register - Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5859,70 +5859,70 @@ typedef union {
 #define GPIO_ODMERC_OFFSET          0x0E8        /**< \brief (GPIO_ODMERC offset) Open Drain Mode Register - Clear */
 
 #define GPIO_ODMERC_P0_Pos          0            /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P0              (_U(0x1) << GPIO_ODMERC_P0_Pos)
+#define GPIO_ODMERC_P0              (_U_(0x1) << GPIO_ODMERC_P0_Pos)
 #define GPIO_ODMERC_P1_Pos          1            /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P1              (_U(0x1) << GPIO_ODMERC_P1_Pos)
+#define GPIO_ODMERC_P1              (_U_(0x1) << GPIO_ODMERC_P1_Pos)
 #define GPIO_ODMERC_P2_Pos          2            /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P2              (_U(0x1) << GPIO_ODMERC_P2_Pos)
+#define GPIO_ODMERC_P2              (_U_(0x1) << GPIO_ODMERC_P2_Pos)
 #define GPIO_ODMERC_P3_Pos          3            /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P3              (_U(0x1) << GPIO_ODMERC_P3_Pos)
+#define GPIO_ODMERC_P3              (_U_(0x1) << GPIO_ODMERC_P3_Pos)
 #define GPIO_ODMERC_P4_Pos          4            /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P4              (_U(0x1) << GPIO_ODMERC_P4_Pos)
+#define GPIO_ODMERC_P4              (_U_(0x1) << GPIO_ODMERC_P4_Pos)
 #define GPIO_ODMERC_P5_Pos          5            /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P5              (_U(0x1) << GPIO_ODMERC_P5_Pos)
+#define GPIO_ODMERC_P5              (_U_(0x1) << GPIO_ODMERC_P5_Pos)
 #define GPIO_ODMERC_P6_Pos          6            /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P6              (_U(0x1) << GPIO_ODMERC_P6_Pos)
+#define GPIO_ODMERC_P6              (_U_(0x1) << GPIO_ODMERC_P6_Pos)
 #define GPIO_ODMERC_P7_Pos          7            /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P7              (_U(0x1) << GPIO_ODMERC_P7_Pos)
+#define GPIO_ODMERC_P7              (_U_(0x1) << GPIO_ODMERC_P7_Pos)
 #define GPIO_ODMERC_P8_Pos          8            /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P8              (_U(0x1) << GPIO_ODMERC_P8_Pos)
+#define GPIO_ODMERC_P8              (_U_(0x1) << GPIO_ODMERC_P8_Pos)
 #define GPIO_ODMERC_P9_Pos          9            /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P9              (_U(0x1) << GPIO_ODMERC_P9_Pos)
+#define GPIO_ODMERC_P9              (_U_(0x1) << GPIO_ODMERC_P9_Pos)
 #define GPIO_ODMERC_P10_Pos         10           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P10             (_U(0x1) << GPIO_ODMERC_P10_Pos)
+#define GPIO_ODMERC_P10             (_U_(0x1) << GPIO_ODMERC_P10_Pos)
 #define GPIO_ODMERC_P11_Pos         11           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P11             (_U(0x1) << GPIO_ODMERC_P11_Pos)
+#define GPIO_ODMERC_P11             (_U_(0x1) << GPIO_ODMERC_P11_Pos)
 #define GPIO_ODMERC_P12_Pos         12           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P12             (_U(0x1) << GPIO_ODMERC_P12_Pos)
+#define GPIO_ODMERC_P12             (_U_(0x1) << GPIO_ODMERC_P12_Pos)
 #define GPIO_ODMERC_P13_Pos         13           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P13             (_U(0x1) << GPIO_ODMERC_P13_Pos)
+#define GPIO_ODMERC_P13             (_U_(0x1) << GPIO_ODMERC_P13_Pos)
 #define GPIO_ODMERC_P14_Pos         14           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P14             (_U(0x1) << GPIO_ODMERC_P14_Pos)
+#define GPIO_ODMERC_P14             (_U_(0x1) << GPIO_ODMERC_P14_Pos)
 #define GPIO_ODMERC_P15_Pos         15           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P15             (_U(0x1) << GPIO_ODMERC_P15_Pos)
+#define GPIO_ODMERC_P15             (_U_(0x1) << GPIO_ODMERC_P15_Pos)
 #define GPIO_ODMERC_P16_Pos         16           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P16             (_U(0x1) << GPIO_ODMERC_P16_Pos)
+#define GPIO_ODMERC_P16             (_U_(0x1) << GPIO_ODMERC_P16_Pos)
 #define GPIO_ODMERC_P17_Pos         17           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P17             (_U(0x1) << GPIO_ODMERC_P17_Pos)
+#define GPIO_ODMERC_P17             (_U_(0x1) << GPIO_ODMERC_P17_Pos)
 #define GPIO_ODMERC_P18_Pos         18           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P18             (_U(0x1) << GPIO_ODMERC_P18_Pos)
+#define GPIO_ODMERC_P18             (_U_(0x1) << GPIO_ODMERC_P18_Pos)
 #define GPIO_ODMERC_P19_Pos         19           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P19             (_U(0x1) << GPIO_ODMERC_P19_Pos)
+#define GPIO_ODMERC_P19             (_U_(0x1) << GPIO_ODMERC_P19_Pos)
 #define GPIO_ODMERC_P20_Pos         20           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P20             (_U(0x1) << GPIO_ODMERC_P20_Pos)
+#define GPIO_ODMERC_P20             (_U_(0x1) << GPIO_ODMERC_P20_Pos)
 #define GPIO_ODMERC_P21_Pos         21           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P21             (_U(0x1) << GPIO_ODMERC_P21_Pos)
+#define GPIO_ODMERC_P21             (_U_(0x1) << GPIO_ODMERC_P21_Pos)
 #define GPIO_ODMERC_P22_Pos         22           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P22             (_U(0x1) << GPIO_ODMERC_P22_Pos)
+#define GPIO_ODMERC_P22             (_U_(0x1) << GPIO_ODMERC_P22_Pos)
 #define GPIO_ODMERC_P23_Pos         23           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P23             (_U(0x1) << GPIO_ODMERC_P23_Pos)
+#define GPIO_ODMERC_P23             (_U_(0x1) << GPIO_ODMERC_P23_Pos)
 #define GPIO_ODMERC_P24_Pos         24           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P24             (_U(0x1) << GPIO_ODMERC_P24_Pos)
+#define GPIO_ODMERC_P24             (_U_(0x1) << GPIO_ODMERC_P24_Pos)
 #define GPIO_ODMERC_P25_Pos         25           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P25             (_U(0x1) << GPIO_ODMERC_P25_Pos)
+#define GPIO_ODMERC_P25             (_U_(0x1) << GPIO_ODMERC_P25_Pos)
 #define GPIO_ODMERC_P26_Pos         26           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P26             (_U(0x1) << GPIO_ODMERC_P26_Pos)
+#define GPIO_ODMERC_P26             (_U_(0x1) << GPIO_ODMERC_P26_Pos)
 #define GPIO_ODMERC_P27_Pos         27           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P27             (_U(0x1) << GPIO_ODMERC_P27_Pos)
+#define GPIO_ODMERC_P27             (_U_(0x1) << GPIO_ODMERC_P27_Pos)
 #define GPIO_ODMERC_P28_Pos         28           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P28             (_U(0x1) << GPIO_ODMERC_P28_Pos)
+#define GPIO_ODMERC_P28             (_U_(0x1) << GPIO_ODMERC_P28_Pos)
 #define GPIO_ODMERC_P29_Pos         29           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P29             (_U(0x1) << GPIO_ODMERC_P29_Pos)
+#define GPIO_ODMERC_P29             (_U_(0x1) << GPIO_ODMERC_P29_Pos)
 #define GPIO_ODMERC_P30_Pos         30           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P30             (_U(0x1) << GPIO_ODMERC_P30_Pos)
+#define GPIO_ODMERC_P30             (_U_(0x1) << GPIO_ODMERC_P30_Pos)
 #define GPIO_ODMERC_P31_Pos         31           /**< \brief (GPIO_ODMERC) Open Drain Mode Enable */
-#define GPIO_ODMERC_P31             (_U(0x1) << GPIO_ODMERC_P31_Pos)
-#define GPIO_ODMERC_MASK            _U(0xFFFFFFFF) /**< \brief (GPIO_ODMERC) MASK Register */
+#define GPIO_ODMERC_P31             (_U_(0x1) << GPIO_ODMERC_P31_Pos)
+#define GPIO_ODMERC_MASK            _U_(0xFFFFFFFF) /**< \brief (GPIO_ODMERC) MASK Register */
 
 /* -------- GPIO_ODMERT : (GPIO Offset: 0x0EC) ( /W 32) port Open Drain Mode Register - Toggle -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5968,70 +5968,70 @@ typedef union {
 #define GPIO_ODMERT_OFFSET          0x0EC        /**< \brief (GPIO_ODMERT offset) Open Drain Mode Register - Toggle */
 
 #define GPIO_ODMERT_P0_Pos          0            /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P0              (_U(0x1) << GPIO_ODMERT_P0_Pos)
+#define GPIO_ODMERT_P0              (_U_(0x1) << GPIO_ODMERT_P0_Pos)
 #define GPIO_ODMERT_P1_Pos          1            /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P1              (_U(0x1) << GPIO_ODMERT_P1_Pos)
+#define GPIO_ODMERT_P1              (_U_(0x1) << GPIO_ODMERT_P1_Pos)
 #define GPIO_ODMERT_P2_Pos          2            /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P2              (_U(0x1) << GPIO_ODMERT_P2_Pos)
+#define GPIO_ODMERT_P2              (_U_(0x1) << GPIO_ODMERT_P2_Pos)
 #define GPIO_ODMERT_P3_Pos          3            /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P3              (_U(0x1) << GPIO_ODMERT_P3_Pos)
+#define GPIO_ODMERT_P3              (_U_(0x1) << GPIO_ODMERT_P3_Pos)
 #define GPIO_ODMERT_P4_Pos          4            /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P4              (_U(0x1) << GPIO_ODMERT_P4_Pos)
+#define GPIO_ODMERT_P4              (_U_(0x1) << GPIO_ODMERT_P4_Pos)
 #define GPIO_ODMERT_P5_Pos          5            /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P5              (_U(0x1) << GPIO_ODMERT_P5_Pos)
+#define GPIO_ODMERT_P5              (_U_(0x1) << GPIO_ODMERT_P5_Pos)
 #define GPIO_ODMERT_P6_Pos          6            /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P6              (_U(0x1) << GPIO_ODMERT_P6_Pos)
+#define GPIO_ODMERT_P6              (_U_(0x1) << GPIO_ODMERT_P6_Pos)
 #define GPIO_ODMERT_P7_Pos          7            /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P7              (_U(0x1) << GPIO_ODMERT_P7_Pos)
+#define GPIO_ODMERT_P7              (_U_(0x1) << GPIO_ODMERT_P7_Pos)
 #define GPIO_ODMERT_P8_Pos          8            /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P8              (_U(0x1) << GPIO_ODMERT_P8_Pos)
+#define GPIO_ODMERT_P8              (_U_(0x1) << GPIO_ODMERT_P8_Pos)
 #define GPIO_ODMERT_P9_Pos          9            /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P9              (_U(0x1) << GPIO_ODMERT_P9_Pos)
+#define GPIO_ODMERT_P9              (_U_(0x1) << GPIO_ODMERT_P9_Pos)
 #define GPIO_ODMERT_P10_Pos         10           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P10             (_U(0x1) << GPIO_ODMERT_P10_Pos)
+#define GPIO_ODMERT_P10             (_U_(0x1) << GPIO_ODMERT_P10_Pos)
 #define GPIO_ODMERT_P11_Pos         11           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P11             (_U(0x1) << GPIO_ODMERT_P11_Pos)
+#define GPIO_ODMERT_P11             (_U_(0x1) << GPIO_ODMERT_P11_Pos)
 #define GPIO_ODMERT_P12_Pos         12           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P12             (_U(0x1) << GPIO_ODMERT_P12_Pos)
+#define GPIO_ODMERT_P12             (_U_(0x1) << GPIO_ODMERT_P12_Pos)
 #define GPIO_ODMERT_P13_Pos         13           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P13             (_U(0x1) << GPIO_ODMERT_P13_Pos)
+#define GPIO_ODMERT_P13             (_U_(0x1) << GPIO_ODMERT_P13_Pos)
 #define GPIO_ODMERT_P14_Pos         14           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P14             (_U(0x1) << GPIO_ODMERT_P14_Pos)
+#define GPIO_ODMERT_P14             (_U_(0x1) << GPIO_ODMERT_P14_Pos)
 #define GPIO_ODMERT_P15_Pos         15           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P15             (_U(0x1) << GPIO_ODMERT_P15_Pos)
+#define GPIO_ODMERT_P15             (_U_(0x1) << GPIO_ODMERT_P15_Pos)
 #define GPIO_ODMERT_P16_Pos         16           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P16             (_U(0x1) << GPIO_ODMERT_P16_Pos)
+#define GPIO_ODMERT_P16             (_U_(0x1) << GPIO_ODMERT_P16_Pos)
 #define GPIO_ODMERT_P17_Pos         17           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P17             (_U(0x1) << GPIO_ODMERT_P17_Pos)
+#define GPIO_ODMERT_P17             (_U_(0x1) << GPIO_ODMERT_P17_Pos)
 #define GPIO_ODMERT_P18_Pos         18           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P18             (_U(0x1) << GPIO_ODMERT_P18_Pos)
+#define GPIO_ODMERT_P18             (_U_(0x1) << GPIO_ODMERT_P18_Pos)
 #define GPIO_ODMERT_P19_Pos         19           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P19             (_U(0x1) << GPIO_ODMERT_P19_Pos)
+#define GPIO_ODMERT_P19             (_U_(0x1) << GPIO_ODMERT_P19_Pos)
 #define GPIO_ODMERT_P20_Pos         20           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P20             (_U(0x1) << GPIO_ODMERT_P20_Pos)
+#define GPIO_ODMERT_P20             (_U_(0x1) << GPIO_ODMERT_P20_Pos)
 #define GPIO_ODMERT_P21_Pos         21           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P21             (_U(0x1) << GPIO_ODMERT_P21_Pos)
+#define GPIO_ODMERT_P21             (_U_(0x1) << GPIO_ODMERT_P21_Pos)
 #define GPIO_ODMERT_P22_Pos         22           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P22             (_U(0x1) << GPIO_ODMERT_P22_Pos)
+#define GPIO_ODMERT_P22             (_U_(0x1) << GPIO_ODMERT_P22_Pos)
 #define GPIO_ODMERT_P23_Pos         23           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P23             (_U(0x1) << GPIO_ODMERT_P23_Pos)
+#define GPIO_ODMERT_P23             (_U_(0x1) << GPIO_ODMERT_P23_Pos)
 #define GPIO_ODMERT_P24_Pos         24           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P24             (_U(0x1) << GPIO_ODMERT_P24_Pos)
+#define GPIO_ODMERT_P24             (_U_(0x1) << GPIO_ODMERT_P24_Pos)
 #define GPIO_ODMERT_P25_Pos         25           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P25             (_U(0x1) << GPIO_ODMERT_P25_Pos)
+#define GPIO_ODMERT_P25             (_U_(0x1) << GPIO_ODMERT_P25_Pos)
 #define GPIO_ODMERT_P26_Pos         26           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P26             (_U(0x1) << GPIO_ODMERT_P26_Pos)
+#define GPIO_ODMERT_P26             (_U_(0x1) << GPIO_ODMERT_P26_Pos)
 #define GPIO_ODMERT_P27_Pos         27           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P27             (_U(0x1) << GPIO_ODMERT_P27_Pos)
+#define GPIO_ODMERT_P27             (_U_(0x1) << GPIO_ODMERT_P27_Pos)
 #define GPIO_ODMERT_P28_Pos         28           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P28             (_U(0x1) << GPIO_ODMERT_P28_Pos)
+#define GPIO_ODMERT_P28             (_U_(0x1) << GPIO_ODMERT_P28_Pos)
 #define GPIO_ODMERT_P29_Pos         29           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P29             (_U(0x1) << GPIO_ODMERT_P29_Pos)
+#define GPIO_ODMERT_P29             (_U_(0x1) << GPIO_ODMERT_P29_Pos)
 #define GPIO_ODMERT_P30_Pos         30           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P30             (_U(0x1) << GPIO_ODMERT_P30_Pos)
+#define GPIO_ODMERT_P30             (_U_(0x1) << GPIO_ODMERT_P30_Pos)
 #define GPIO_ODMERT_P31_Pos         31           /**< \brief (GPIO_ODMERT) Open Drain Mode Enable */
-#define GPIO_ODMERT_P31             (_U(0x1) << GPIO_ODMERT_P31_Pos)
-#define GPIO_ODMERT_MASK            _U(0xFFFFFFFF) /**< \brief (GPIO_ODMERT) MASK Register */
+#define GPIO_ODMERT_P31             (_U_(0x1) << GPIO_ODMERT_P31_Pos)
+#define GPIO_ODMERT_MASK            _U_(0xFFFFFFFF) /**< \brief (GPIO_ODMERT) MASK Register */
 
 /* -------- GPIO_ODCR0 : (GPIO Offset: 0x100) (R/W 32) port Output Driving Capability Register 0 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -6077,70 +6077,70 @@ typedef union {
 #define GPIO_ODCR0_OFFSET           0x100        /**< \brief (GPIO_ODCR0 offset) Output Driving Capability Register 0 */
 
 #define GPIO_ODCR0_P0_Pos           0            /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P0               (_U(0x1) << GPIO_ODCR0_P0_Pos)
+#define GPIO_ODCR0_P0               (_U_(0x1) << GPIO_ODCR0_P0_Pos)
 #define GPIO_ODCR0_P1_Pos           1            /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P1               (_U(0x1) << GPIO_ODCR0_P1_Pos)
+#define GPIO_ODCR0_P1               (_U_(0x1) << GPIO_ODCR0_P1_Pos)
 #define GPIO_ODCR0_P2_Pos           2            /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P2               (_U(0x1) << GPIO_ODCR0_P2_Pos)
+#define GPIO_ODCR0_P2               (_U_(0x1) << GPIO_ODCR0_P2_Pos)
 #define GPIO_ODCR0_P3_Pos           3            /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P3               (_U(0x1) << GPIO_ODCR0_P3_Pos)
+#define GPIO_ODCR0_P3               (_U_(0x1) << GPIO_ODCR0_P3_Pos)
 #define GPIO_ODCR0_P4_Pos           4            /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P4               (_U(0x1) << GPIO_ODCR0_P4_Pos)
+#define GPIO_ODCR0_P4               (_U_(0x1) << GPIO_ODCR0_P4_Pos)
 #define GPIO_ODCR0_P5_Pos           5            /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P5               (_U(0x1) << GPIO_ODCR0_P5_Pos)
+#define GPIO_ODCR0_P5               (_U_(0x1) << GPIO_ODCR0_P5_Pos)
 #define GPIO_ODCR0_P6_Pos           6            /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P6               (_U(0x1) << GPIO_ODCR0_P6_Pos)
+#define GPIO_ODCR0_P6               (_U_(0x1) << GPIO_ODCR0_P6_Pos)
 #define GPIO_ODCR0_P7_Pos           7            /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P7               (_U(0x1) << GPIO_ODCR0_P7_Pos)
+#define GPIO_ODCR0_P7               (_U_(0x1) << GPIO_ODCR0_P7_Pos)
 #define GPIO_ODCR0_P8_Pos           8            /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P8               (_U(0x1) << GPIO_ODCR0_P8_Pos)
+#define GPIO_ODCR0_P8               (_U_(0x1) << GPIO_ODCR0_P8_Pos)
 #define GPIO_ODCR0_P9_Pos           9            /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P9               (_U(0x1) << GPIO_ODCR0_P9_Pos)
+#define GPIO_ODCR0_P9               (_U_(0x1) << GPIO_ODCR0_P9_Pos)
 #define GPIO_ODCR0_P10_Pos          10           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P10              (_U(0x1) << GPIO_ODCR0_P10_Pos)
+#define GPIO_ODCR0_P10              (_U_(0x1) << GPIO_ODCR0_P10_Pos)
 #define GPIO_ODCR0_P11_Pos          11           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P11              (_U(0x1) << GPIO_ODCR0_P11_Pos)
+#define GPIO_ODCR0_P11              (_U_(0x1) << GPIO_ODCR0_P11_Pos)
 #define GPIO_ODCR0_P12_Pos          12           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P12              (_U(0x1) << GPIO_ODCR0_P12_Pos)
+#define GPIO_ODCR0_P12              (_U_(0x1) << GPIO_ODCR0_P12_Pos)
 #define GPIO_ODCR0_P13_Pos          13           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P13              (_U(0x1) << GPIO_ODCR0_P13_Pos)
+#define GPIO_ODCR0_P13              (_U_(0x1) << GPIO_ODCR0_P13_Pos)
 #define GPIO_ODCR0_P14_Pos          14           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P14              (_U(0x1) << GPIO_ODCR0_P14_Pos)
+#define GPIO_ODCR0_P14              (_U_(0x1) << GPIO_ODCR0_P14_Pos)
 #define GPIO_ODCR0_P15_Pos          15           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P15              (_U(0x1) << GPIO_ODCR0_P15_Pos)
+#define GPIO_ODCR0_P15              (_U_(0x1) << GPIO_ODCR0_P15_Pos)
 #define GPIO_ODCR0_P16_Pos          16           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P16              (_U(0x1) << GPIO_ODCR0_P16_Pos)
+#define GPIO_ODCR0_P16              (_U_(0x1) << GPIO_ODCR0_P16_Pos)
 #define GPIO_ODCR0_P17_Pos          17           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P17              (_U(0x1) << GPIO_ODCR0_P17_Pos)
+#define GPIO_ODCR0_P17              (_U_(0x1) << GPIO_ODCR0_P17_Pos)
 #define GPIO_ODCR0_P18_Pos          18           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P18              (_U(0x1) << GPIO_ODCR0_P18_Pos)
+#define GPIO_ODCR0_P18              (_U_(0x1) << GPIO_ODCR0_P18_Pos)
 #define GPIO_ODCR0_P19_Pos          19           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P19              (_U(0x1) << GPIO_ODCR0_P19_Pos)
+#define GPIO_ODCR0_P19              (_U_(0x1) << GPIO_ODCR0_P19_Pos)
 #define GPIO_ODCR0_P20_Pos          20           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P20              (_U(0x1) << GPIO_ODCR0_P20_Pos)
+#define GPIO_ODCR0_P20              (_U_(0x1) << GPIO_ODCR0_P20_Pos)
 #define GPIO_ODCR0_P21_Pos          21           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P21              (_U(0x1) << GPIO_ODCR0_P21_Pos)
+#define GPIO_ODCR0_P21              (_U_(0x1) << GPIO_ODCR0_P21_Pos)
 #define GPIO_ODCR0_P22_Pos          22           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P22              (_U(0x1) << GPIO_ODCR0_P22_Pos)
+#define GPIO_ODCR0_P22              (_U_(0x1) << GPIO_ODCR0_P22_Pos)
 #define GPIO_ODCR0_P23_Pos          23           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P23              (_U(0x1) << GPIO_ODCR0_P23_Pos)
+#define GPIO_ODCR0_P23              (_U_(0x1) << GPIO_ODCR0_P23_Pos)
 #define GPIO_ODCR0_P24_Pos          24           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P24              (_U(0x1) << GPIO_ODCR0_P24_Pos)
+#define GPIO_ODCR0_P24              (_U_(0x1) << GPIO_ODCR0_P24_Pos)
 #define GPIO_ODCR0_P25_Pos          25           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P25              (_U(0x1) << GPIO_ODCR0_P25_Pos)
+#define GPIO_ODCR0_P25              (_U_(0x1) << GPIO_ODCR0_P25_Pos)
 #define GPIO_ODCR0_P26_Pos          26           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P26              (_U(0x1) << GPIO_ODCR0_P26_Pos)
+#define GPIO_ODCR0_P26              (_U_(0x1) << GPIO_ODCR0_P26_Pos)
 #define GPIO_ODCR0_P27_Pos          27           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P27              (_U(0x1) << GPIO_ODCR0_P27_Pos)
+#define GPIO_ODCR0_P27              (_U_(0x1) << GPIO_ODCR0_P27_Pos)
 #define GPIO_ODCR0_P28_Pos          28           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P28              (_U(0x1) << GPIO_ODCR0_P28_Pos)
+#define GPIO_ODCR0_P28              (_U_(0x1) << GPIO_ODCR0_P28_Pos)
 #define GPIO_ODCR0_P29_Pos          29           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P29              (_U(0x1) << GPIO_ODCR0_P29_Pos)
+#define GPIO_ODCR0_P29              (_U_(0x1) << GPIO_ODCR0_P29_Pos)
 #define GPIO_ODCR0_P30_Pos          30           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P30              (_U(0x1) << GPIO_ODCR0_P30_Pos)
+#define GPIO_ODCR0_P30              (_U_(0x1) << GPIO_ODCR0_P30_Pos)
 #define GPIO_ODCR0_P31_Pos          31           /**< \brief (GPIO_ODCR0) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0_P31              (_U(0x1) << GPIO_ODCR0_P31_Pos)
-#define GPIO_ODCR0_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_ODCR0) MASK Register */
+#define GPIO_ODCR0_P31              (_U_(0x1) << GPIO_ODCR0_P31_Pos)
+#define GPIO_ODCR0_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_ODCR0) MASK Register */
 
 /* -------- GPIO_ODCR0S : (GPIO Offset: 0x104) (R/W 32) port Output Driving Capability Register 0 - Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -6186,70 +6186,70 @@ typedef union {
 #define GPIO_ODCR0S_OFFSET          0x104        /**< \brief (GPIO_ODCR0S offset) Output Driving Capability Register 0 - Set */
 
 #define GPIO_ODCR0S_P0_Pos          0            /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P0              (_U(0x1) << GPIO_ODCR0S_P0_Pos)
+#define GPIO_ODCR0S_P0              (_U_(0x1) << GPIO_ODCR0S_P0_Pos)
 #define GPIO_ODCR0S_P1_Pos          1            /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P1              (_U(0x1) << GPIO_ODCR0S_P1_Pos)
+#define GPIO_ODCR0S_P1              (_U_(0x1) << GPIO_ODCR0S_P1_Pos)
 #define GPIO_ODCR0S_P2_Pos          2            /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P2              (_U(0x1) << GPIO_ODCR0S_P2_Pos)
+#define GPIO_ODCR0S_P2              (_U_(0x1) << GPIO_ODCR0S_P2_Pos)
 #define GPIO_ODCR0S_P3_Pos          3            /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P3              (_U(0x1) << GPIO_ODCR0S_P3_Pos)
+#define GPIO_ODCR0S_P3              (_U_(0x1) << GPIO_ODCR0S_P3_Pos)
 #define GPIO_ODCR0S_P4_Pos          4            /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P4              (_U(0x1) << GPIO_ODCR0S_P4_Pos)
+#define GPIO_ODCR0S_P4              (_U_(0x1) << GPIO_ODCR0S_P4_Pos)
 #define GPIO_ODCR0S_P5_Pos          5            /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P5              (_U(0x1) << GPIO_ODCR0S_P5_Pos)
+#define GPIO_ODCR0S_P5              (_U_(0x1) << GPIO_ODCR0S_P5_Pos)
 #define GPIO_ODCR0S_P6_Pos          6            /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P6              (_U(0x1) << GPIO_ODCR0S_P6_Pos)
+#define GPIO_ODCR0S_P6              (_U_(0x1) << GPIO_ODCR0S_P6_Pos)
 #define GPIO_ODCR0S_P7_Pos          7            /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P7              (_U(0x1) << GPIO_ODCR0S_P7_Pos)
+#define GPIO_ODCR0S_P7              (_U_(0x1) << GPIO_ODCR0S_P7_Pos)
 #define GPIO_ODCR0S_P8_Pos          8            /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P8              (_U(0x1) << GPIO_ODCR0S_P8_Pos)
+#define GPIO_ODCR0S_P8              (_U_(0x1) << GPIO_ODCR0S_P8_Pos)
 #define GPIO_ODCR0S_P9_Pos          9            /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P9              (_U(0x1) << GPIO_ODCR0S_P9_Pos)
+#define GPIO_ODCR0S_P9              (_U_(0x1) << GPIO_ODCR0S_P9_Pos)
 #define GPIO_ODCR0S_P10_Pos         10           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P10             (_U(0x1) << GPIO_ODCR0S_P10_Pos)
+#define GPIO_ODCR0S_P10             (_U_(0x1) << GPIO_ODCR0S_P10_Pos)
 #define GPIO_ODCR0S_P11_Pos         11           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P11             (_U(0x1) << GPIO_ODCR0S_P11_Pos)
+#define GPIO_ODCR0S_P11             (_U_(0x1) << GPIO_ODCR0S_P11_Pos)
 #define GPIO_ODCR0S_P12_Pos         12           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P12             (_U(0x1) << GPIO_ODCR0S_P12_Pos)
+#define GPIO_ODCR0S_P12             (_U_(0x1) << GPIO_ODCR0S_P12_Pos)
 #define GPIO_ODCR0S_P13_Pos         13           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P13             (_U(0x1) << GPIO_ODCR0S_P13_Pos)
+#define GPIO_ODCR0S_P13             (_U_(0x1) << GPIO_ODCR0S_P13_Pos)
 #define GPIO_ODCR0S_P14_Pos         14           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P14             (_U(0x1) << GPIO_ODCR0S_P14_Pos)
+#define GPIO_ODCR0S_P14             (_U_(0x1) << GPIO_ODCR0S_P14_Pos)
 #define GPIO_ODCR0S_P15_Pos         15           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P15             (_U(0x1) << GPIO_ODCR0S_P15_Pos)
+#define GPIO_ODCR0S_P15             (_U_(0x1) << GPIO_ODCR0S_P15_Pos)
 #define GPIO_ODCR0S_P16_Pos         16           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P16             (_U(0x1) << GPIO_ODCR0S_P16_Pos)
+#define GPIO_ODCR0S_P16             (_U_(0x1) << GPIO_ODCR0S_P16_Pos)
 #define GPIO_ODCR0S_P17_Pos         17           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P17             (_U(0x1) << GPIO_ODCR0S_P17_Pos)
+#define GPIO_ODCR0S_P17             (_U_(0x1) << GPIO_ODCR0S_P17_Pos)
 #define GPIO_ODCR0S_P18_Pos         18           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P18             (_U(0x1) << GPIO_ODCR0S_P18_Pos)
+#define GPIO_ODCR0S_P18             (_U_(0x1) << GPIO_ODCR0S_P18_Pos)
 #define GPIO_ODCR0S_P19_Pos         19           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P19             (_U(0x1) << GPIO_ODCR0S_P19_Pos)
+#define GPIO_ODCR0S_P19             (_U_(0x1) << GPIO_ODCR0S_P19_Pos)
 #define GPIO_ODCR0S_P20_Pos         20           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P20             (_U(0x1) << GPIO_ODCR0S_P20_Pos)
+#define GPIO_ODCR0S_P20             (_U_(0x1) << GPIO_ODCR0S_P20_Pos)
 #define GPIO_ODCR0S_P21_Pos         21           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P21             (_U(0x1) << GPIO_ODCR0S_P21_Pos)
+#define GPIO_ODCR0S_P21             (_U_(0x1) << GPIO_ODCR0S_P21_Pos)
 #define GPIO_ODCR0S_P22_Pos         22           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P22             (_U(0x1) << GPIO_ODCR0S_P22_Pos)
+#define GPIO_ODCR0S_P22             (_U_(0x1) << GPIO_ODCR0S_P22_Pos)
 #define GPIO_ODCR0S_P23_Pos         23           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P23             (_U(0x1) << GPIO_ODCR0S_P23_Pos)
+#define GPIO_ODCR0S_P23             (_U_(0x1) << GPIO_ODCR0S_P23_Pos)
 #define GPIO_ODCR0S_P24_Pos         24           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P24             (_U(0x1) << GPIO_ODCR0S_P24_Pos)
+#define GPIO_ODCR0S_P24             (_U_(0x1) << GPIO_ODCR0S_P24_Pos)
 #define GPIO_ODCR0S_P25_Pos         25           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P25             (_U(0x1) << GPIO_ODCR0S_P25_Pos)
+#define GPIO_ODCR0S_P25             (_U_(0x1) << GPIO_ODCR0S_P25_Pos)
 #define GPIO_ODCR0S_P26_Pos         26           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P26             (_U(0x1) << GPIO_ODCR0S_P26_Pos)
+#define GPIO_ODCR0S_P26             (_U_(0x1) << GPIO_ODCR0S_P26_Pos)
 #define GPIO_ODCR0S_P27_Pos         27           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P27             (_U(0x1) << GPIO_ODCR0S_P27_Pos)
+#define GPIO_ODCR0S_P27             (_U_(0x1) << GPIO_ODCR0S_P27_Pos)
 #define GPIO_ODCR0S_P28_Pos         28           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P28             (_U(0x1) << GPIO_ODCR0S_P28_Pos)
+#define GPIO_ODCR0S_P28             (_U_(0x1) << GPIO_ODCR0S_P28_Pos)
 #define GPIO_ODCR0S_P29_Pos         29           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P29             (_U(0x1) << GPIO_ODCR0S_P29_Pos)
+#define GPIO_ODCR0S_P29             (_U_(0x1) << GPIO_ODCR0S_P29_Pos)
 #define GPIO_ODCR0S_P30_Pos         30           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P30             (_U(0x1) << GPIO_ODCR0S_P30_Pos)
+#define GPIO_ODCR0S_P30             (_U_(0x1) << GPIO_ODCR0S_P30_Pos)
 #define GPIO_ODCR0S_P31_Pos         31           /**< \brief (GPIO_ODCR0S) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0S_P31             (_U(0x1) << GPIO_ODCR0S_P31_Pos)
-#define GPIO_ODCR0S_MASK            _U(0xFFFFFFFF) /**< \brief (GPIO_ODCR0S) MASK Register */
+#define GPIO_ODCR0S_P31             (_U_(0x1) << GPIO_ODCR0S_P31_Pos)
+#define GPIO_ODCR0S_MASK            _U_(0xFFFFFFFF) /**< \brief (GPIO_ODCR0S) MASK Register */
 
 /* -------- GPIO_ODCR0C : (GPIO Offset: 0x108) (R/W 32) port Output Driving Capability Register 0 - Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -6295,70 +6295,70 @@ typedef union {
 #define GPIO_ODCR0C_OFFSET          0x108        /**< \brief (GPIO_ODCR0C offset) Output Driving Capability Register 0 - Clear */
 
 #define GPIO_ODCR0C_P0_Pos          0            /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P0              (_U(0x1) << GPIO_ODCR0C_P0_Pos)
+#define GPIO_ODCR0C_P0              (_U_(0x1) << GPIO_ODCR0C_P0_Pos)
 #define GPIO_ODCR0C_P1_Pos          1            /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P1              (_U(0x1) << GPIO_ODCR0C_P1_Pos)
+#define GPIO_ODCR0C_P1              (_U_(0x1) << GPIO_ODCR0C_P1_Pos)
 #define GPIO_ODCR0C_P2_Pos          2            /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P2              (_U(0x1) << GPIO_ODCR0C_P2_Pos)
+#define GPIO_ODCR0C_P2              (_U_(0x1) << GPIO_ODCR0C_P2_Pos)
 #define GPIO_ODCR0C_P3_Pos          3            /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P3              (_U(0x1) << GPIO_ODCR0C_P3_Pos)
+#define GPIO_ODCR0C_P3              (_U_(0x1) << GPIO_ODCR0C_P3_Pos)
 #define GPIO_ODCR0C_P4_Pos          4            /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P4              (_U(0x1) << GPIO_ODCR0C_P4_Pos)
+#define GPIO_ODCR0C_P4              (_U_(0x1) << GPIO_ODCR0C_P4_Pos)
 #define GPIO_ODCR0C_P5_Pos          5            /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P5              (_U(0x1) << GPIO_ODCR0C_P5_Pos)
+#define GPIO_ODCR0C_P5              (_U_(0x1) << GPIO_ODCR0C_P5_Pos)
 #define GPIO_ODCR0C_P6_Pos          6            /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P6              (_U(0x1) << GPIO_ODCR0C_P6_Pos)
+#define GPIO_ODCR0C_P6              (_U_(0x1) << GPIO_ODCR0C_P6_Pos)
 #define GPIO_ODCR0C_P7_Pos          7            /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P7              (_U(0x1) << GPIO_ODCR0C_P7_Pos)
+#define GPIO_ODCR0C_P7              (_U_(0x1) << GPIO_ODCR0C_P7_Pos)
 #define GPIO_ODCR0C_P8_Pos          8            /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P8              (_U(0x1) << GPIO_ODCR0C_P8_Pos)
+#define GPIO_ODCR0C_P8              (_U_(0x1) << GPIO_ODCR0C_P8_Pos)
 #define GPIO_ODCR0C_P9_Pos          9            /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P9              (_U(0x1) << GPIO_ODCR0C_P9_Pos)
+#define GPIO_ODCR0C_P9              (_U_(0x1) << GPIO_ODCR0C_P9_Pos)
 #define GPIO_ODCR0C_P10_Pos         10           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P10             (_U(0x1) << GPIO_ODCR0C_P10_Pos)
+#define GPIO_ODCR0C_P10             (_U_(0x1) << GPIO_ODCR0C_P10_Pos)
 #define GPIO_ODCR0C_P11_Pos         11           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P11             (_U(0x1) << GPIO_ODCR0C_P11_Pos)
+#define GPIO_ODCR0C_P11             (_U_(0x1) << GPIO_ODCR0C_P11_Pos)
 #define GPIO_ODCR0C_P12_Pos         12           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P12             (_U(0x1) << GPIO_ODCR0C_P12_Pos)
+#define GPIO_ODCR0C_P12             (_U_(0x1) << GPIO_ODCR0C_P12_Pos)
 #define GPIO_ODCR0C_P13_Pos         13           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P13             (_U(0x1) << GPIO_ODCR0C_P13_Pos)
+#define GPIO_ODCR0C_P13             (_U_(0x1) << GPIO_ODCR0C_P13_Pos)
 #define GPIO_ODCR0C_P14_Pos         14           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P14             (_U(0x1) << GPIO_ODCR0C_P14_Pos)
+#define GPIO_ODCR0C_P14             (_U_(0x1) << GPIO_ODCR0C_P14_Pos)
 #define GPIO_ODCR0C_P15_Pos         15           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P15             (_U(0x1) << GPIO_ODCR0C_P15_Pos)
+#define GPIO_ODCR0C_P15             (_U_(0x1) << GPIO_ODCR0C_P15_Pos)
 #define GPIO_ODCR0C_P16_Pos         16           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P16             (_U(0x1) << GPIO_ODCR0C_P16_Pos)
+#define GPIO_ODCR0C_P16             (_U_(0x1) << GPIO_ODCR0C_P16_Pos)
 #define GPIO_ODCR0C_P17_Pos         17           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P17             (_U(0x1) << GPIO_ODCR0C_P17_Pos)
+#define GPIO_ODCR0C_P17             (_U_(0x1) << GPIO_ODCR0C_P17_Pos)
 #define GPIO_ODCR0C_P18_Pos         18           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P18             (_U(0x1) << GPIO_ODCR0C_P18_Pos)
+#define GPIO_ODCR0C_P18             (_U_(0x1) << GPIO_ODCR0C_P18_Pos)
 #define GPIO_ODCR0C_P19_Pos         19           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P19             (_U(0x1) << GPIO_ODCR0C_P19_Pos)
+#define GPIO_ODCR0C_P19             (_U_(0x1) << GPIO_ODCR0C_P19_Pos)
 #define GPIO_ODCR0C_P20_Pos         20           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P20             (_U(0x1) << GPIO_ODCR0C_P20_Pos)
+#define GPIO_ODCR0C_P20             (_U_(0x1) << GPIO_ODCR0C_P20_Pos)
 #define GPIO_ODCR0C_P21_Pos         21           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P21             (_U(0x1) << GPIO_ODCR0C_P21_Pos)
+#define GPIO_ODCR0C_P21             (_U_(0x1) << GPIO_ODCR0C_P21_Pos)
 #define GPIO_ODCR0C_P22_Pos         22           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P22             (_U(0x1) << GPIO_ODCR0C_P22_Pos)
+#define GPIO_ODCR0C_P22             (_U_(0x1) << GPIO_ODCR0C_P22_Pos)
 #define GPIO_ODCR0C_P23_Pos         23           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P23             (_U(0x1) << GPIO_ODCR0C_P23_Pos)
+#define GPIO_ODCR0C_P23             (_U_(0x1) << GPIO_ODCR0C_P23_Pos)
 #define GPIO_ODCR0C_P24_Pos         24           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P24             (_U(0x1) << GPIO_ODCR0C_P24_Pos)
+#define GPIO_ODCR0C_P24             (_U_(0x1) << GPIO_ODCR0C_P24_Pos)
 #define GPIO_ODCR0C_P25_Pos         25           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P25             (_U(0x1) << GPIO_ODCR0C_P25_Pos)
+#define GPIO_ODCR0C_P25             (_U_(0x1) << GPIO_ODCR0C_P25_Pos)
 #define GPIO_ODCR0C_P26_Pos         26           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P26             (_U(0x1) << GPIO_ODCR0C_P26_Pos)
+#define GPIO_ODCR0C_P26             (_U_(0x1) << GPIO_ODCR0C_P26_Pos)
 #define GPIO_ODCR0C_P27_Pos         27           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P27             (_U(0x1) << GPIO_ODCR0C_P27_Pos)
+#define GPIO_ODCR0C_P27             (_U_(0x1) << GPIO_ODCR0C_P27_Pos)
 #define GPIO_ODCR0C_P28_Pos         28           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P28             (_U(0x1) << GPIO_ODCR0C_P28_Pos)
+#define GPIO_ODCR0C_P28             (_U_(0x1) << GPIO_ODCR0C_P28_Pos)
 #define GPIO_ODCR0C_P29_Pos         29           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P29             (_U(0x1) << GPIO_ODCR0C_P29_Pos)
+#define GPIO_ODCR0C_P29             (_U_(0x1) << GPIO_ODCR0C_P29_Pos)
 #define GPIO_ODCR0C_P30_Pos         30           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P30             (_U(0x1) << GPIO_ODCR0C_P30_Pos)
+#define GPIO_ODCR0C_P30             (_U_(0x1) << GPIO_ODCR0C_P30_Pos)
 #define GPIO_ODCR0C_P31_Pos         31           /**< \brief (GPIO_ODCR0C) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0C_P31             (_U(0x1) << GPIO_ODCR0C_P31_Pos)
-#define GPIO_ODCR0C_MASK            _U(0xFFFFFFFF) /**< \brief (GPIO_ODCR0C) MASK Register */
+#define GPIO_ODCR0C_P31             (_U_(0x1) << GPIO_ODCR0C_P31_Pos)
+#define GPIO_ODCR0C_MASK            _U_(0xFFFFFFFF) /**< \brief (GPIO_ODCR0C) MASK Register */
 
 /* -------- GPIO_ODCR0T : (GPIO Offset: 0x10C) (R/W 32) port Output Driving Capability Register 0 - Toggle -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -6404,70 +6404,70 @@ typedef union {
 #define GPIO_ODCR0T_OFFSET          0x10C        /**< \brief (GPIO_ODCR0T offset) Output Driving Capability Register 0 - Toggle */
 
 #define GPIO_ODCR0T_P0_Pos          0            /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P0              (_U(0x1) << GPIO_ODCR0T_P0_Pos)
+#define GPIO_ODCR0T_P0              (_U_(0x1) << GPIO_ODCR0T_P0_Pos)
 #define GPIO_ODCR0T_P1_Pos          1            /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P1              (_U(0x1) << GPIO_ODCR0T_P1_Pos)
+#define GPIO_ODCR0T_P1              (_U_(0x1) << GPIO_ODCR0T_P1_Pos)
 #define GPIO_ODCR0T_P2_Pos          2            /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P2              (_U(0x1) << GPIO_ODCR0T_P2_Pos)
+#define GPIO_ODCR0T_P2              (_U_(0x1) << GPIO_ODCR0T_P2_Pos)
 #define GPIO_ODCR0T_P3_Pos          3            /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P3              (_U(0x1) << GPIO_ODCR0T_P3_Pos)
+#define GPIO_ODCR0T_P3              (_U_(0x1) << GPIO_ODCR0T_P3_Pos)
 #define GPIO_ODCR0T_P4_Pos          4            /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P4              (_U(0x1) << GPIO_ODCR0T_P4_Pos)
+#define GPIO_ODCR0T_P4              (_U_(0x1) << GPIO_ODCR0T_P4_Pos)
 #define GPIO_ODCR0T_P5_Pos          5            /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P5              (_U(0x1) << GPIO_ODCR0T_P5_Pos)
+#define GPIO_ODCR0T_P5              (_U_(0x1) << GPIO_ODCR0T_P5_Pos)
 #define GPIO_ODCR0T_P6_Pos          6            /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P6              (_U(0x1) << GPIO_ODCR0T_P6_Pos)
+#define GPIO_ODCR0T_P6              (_U_(0x1) << GPIO_ODCR0T_P6_Pos)
 #define GPIO_ODCR0T_P7_Pos          7            /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P7              (_U(0x1) << GPIO_ODCR0T_P7_Pos)
+#define GPIO_ODCR0T_P7              (_U_(0x1) << GPIO_ODCR0T_P7_Pos)
 #define GPIO_ODCR0T_P8_Pos          8            /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P8              (_U(0x1) << GPIO_ODCR0T_P8_Pos)
+#define GPIO_ODCR0T_P8              (_U_(0x1) << GPIO_ODCR0T_P8_Pos)
 #define GPIO_ODCR0T_P9_Pos          9            /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P9              (_U(0x1) << GPIO_ODCR0T_P9_Pos)
+#define GPIO_ODCR0T_P9              (_U_(0x1) << GPIO_ODCR0T_P9_Pos)
 #define GPIO_ODCR0T_P10_Pos         10           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P10             (_U(0x1) << GPIO_ODCR0T_P10_Pos)
+#define GPIO_ODCR0T_P10             (_U_(0x1) << GPIO_ODCR0T_P10_Pos)
 #define GPIO_ODCR0T_P11_Pos         11           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P11             (_U(0x1) << GPIO_ODCR0T_P11_Pos)
+#define GPIO_ODCR0T_P11             (_U_(0x1) << GPIO_ODCR0T_P11_Pos)
 #define GPIO_ODCR0T_P12_Pos         12           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P12             (_U(0x1) << GPIO_ODCR0T_P12_Pos)
+#define GPIO_ODCR0T_P12             (_U_(0x1) << GPIO_ODCR0T_P12_Pos)
 #define GPIO_ODCR0T_P13_Pos         13           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P13             (_U(0x1) << GPIO_ODCR0T_P13_Pos)
+#define GPIO_ODCR0T_P13             (_U_(0x1) << GPIO_ODCR0T_P13_Pos)
 #define GPIO_ODCR0T_P14_Pos         14           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P14             (_U(0x1) << GPIO_ODCR0T_P14_Pos)
+#define GPIO_ODCR0T_P14             (_U_(0x1) << GPIO_ODCR0T_P14_Pos)
 #define GPIO_ODCR0T_P15_Pos         15           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P15             (_U(0x1) << GPIO_ODCR0T_P15_Pos)
+#define GPIO_ODCR0T_P15             (_U_(0x1) << GPIO_ODCR0T_P15_Pos)
 #define GPIO_ODCR0T_P16_Pos         16           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P16             (_U(0x1) << GPIO_ODCR0T_P16_Pos)
+#define GPIO_ODCR0T_P16             (_U_(0x1) << GPIO_ODCR0T_P16_Pos)
 #define GPIO_ODCR0T_P17_Pos         17           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P17             (_U(0x1) << GPIO_ODCR0T_P17_Pos)
+#define GPIO_ODCR0T_P17             (_U_(0x1) << GPIO_ODCR0T_P17_Pos)
 #define GPIO_ODCR0T_P18_Pos         18           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P18             (_U(0x1) << GPIO_ODCR0T_P18_Pos)
+#define GPIO_ODCR0T_P18             (_U_(0x1) << GPIO_ODCR0T_P18_Pos)
 #define GPIO_ODCR0T_P19_Pos         19           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P19             (_U(0x1) << GPIO_ODCR0T_P19_Pos)
+#define GPIO_ODCR0T_P19             (_U_(0x1) << GPIO_ODCR0T_P19_Pos)
 #define GPIO_ODCR0T_P20_Pos         20           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P20             (_U(0x1) << GPIO_ODCR0T_P20_Pos)
+#define GPIO_ODCR0T_P20             (_U_(0x1) << GPIO_ODCR0T_P20_Pos)
 #define GPIO_ODCR0T_P21_Pos         21           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P21             (_U(0x1) << GPIO_ODCR0T_P21_Pos)
+#define GPIO_ODCR0T_P21             (_U_(0x1) << GPIO_ODCR0T_P21_Pos)
 #define GPIO_ODCR0T_P22_Pos         22           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P22             (_U(0x1) << GPIO_ODCR0T_P22_Pos)
+#define GPIO_ODCR0T_P22             (_U_(0x1) << GPIO_ODCR0T_P22_Pos)
 #define GPIO_ODCR0T_P23_Pos         23           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P23             (_U(0x1) << GPIO_ODCR0T_P23_Pos)
+#define GPIO_ODCR0T_P23             (_U_(0x1) << GPIO_ODCR0T_P23_Pos)
 #define GPIO_ODCR0T_P24_Pos         24           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P24             (_U(0x1) << GPIO_ODCR0T_P24_Pos)
+#define GPIO_ODCR0T_P24             (_U_(0x1) << GPIO_ODCR0T_P24_Pos)
 #define GPIO_ODCR0T_P25_Pos         25           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P25             (_U(0x1) << GPIO_ODCR0T_P25_Pos)
+#define GPIO_ODCR0T_P25             (_U_(0x1) << GPIO_ODCR0T_P25_Pos)
 #define GPIO_ODCR0T_P26_Pos         26           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P26             (_U(0x1) << GPIO_ODCR0T_P26_Pos)
+#define GPIO_ODCR0T_P26             (_U_(0x1) << GPIO_ODCR0T_P26_Pos)
 #define GPIO_ODCR0T_P27_Pos         27           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P27             (_U(0x1) << GPIO_ODCR0T_P27_Pos)
+#define GPIO_ODCR0T_P27             (_U_(0x1) << GPIO_ODCR0T_P27_Pos)
 #define GPIO_ODCR0T_P28_Pos         28           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P28             (_U(0x1) << GPIO_ODCR0T_P28_Pos)
+#define GPIO_ODCR0T_P28             (_U_(0x1) << GPIO_ODCR0T_P28_Pos)
 #define GPIO_ODCR0T_P29_Pos         29           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P29             (_U(0x1) << GPIO_ODCR0T_P29_Pos)
+#define GPIO_ODCR0T_P29             (_U_(0x1) << GPIO_ODCR0T_P29_Pos)
 #define GPIO_ODCR0T_P30_Pos         30           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P30             (_U(0x1) << GPIO_ODCR0T_P30_Pos)
+#define GPIO_ODCR0T_P30             (_U_(0x1) << GPIO_ODCR0T_P30_Pos)
 #define GPIO_ODCR0T_P31_Pos         31           /**< \brief (GPIO_ODCR0T) Output Driving Capability Register Bit 0 */
-#define GPIO_ODCR0T_P31             (_U(0x1) << GPIO_ODCR0T_P31_Pos)
-#define GPIO_ODCR0T_MASK            _U(0xFFFFFFFF) /**< \brief (GPIO_ODCR0T) MASK Register */
+#define GPIO_ODCR0T_P31             (_U_(0x1) << GPIO_ODCR0T_P31_Pos)
+#define GPIO_ODCR0T_MASK            _U_(0xFFFFFFFF) /**< \brief (GPIO_ODCR0T) MASK Register */
 
 /* -------- GPIO_ODCR1 : (GPIO Offset: 0x110) (R/W 32) port Output Driving Capability Register 1 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -6513,70 +6513,70 @@ typedef union {
 #define GPIO_ODCR1_OFFSET           0x110        /**< \brief (GPIO_ODCR1 offset) Output Driving Capability Register 1 */
 
 #define GPIO_ODCR1_P0_Pos           0            /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P0               (_U(0x1) << GPIO_ODCR1_P0_Pos)
+#define GPIO_ODCR1_P0               (_U_(0x1) << GPIO_ODCR1_P0_Pos)
 #define GPIO_ODCR1_P1_Pos           1            /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P1               (_U(0x1) << GPIO_ODCR1_P1_Pos)
+#define GPIO_ODCR1_P1               (_U_(0x1) << GPIO_ODCR1_P1_Pos)
 #define GPIO_ODCR1_P2_Pos           2            /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P2               (_U(0x1) << GPIO_ODCR1_P2_Pos)
+#define GPIO_ODCR1_P2               (_U_(0x1) << GPIO_ODCR1_P2_Pos)
 #define GPIO_ODCR1_P3_Pos           3            /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P3               (_U(0x1) << GPIO_ODCR1_P3_Pos)
+#define GPIO_ODCR1_P3               (_U_(0x1) << GPIO_ODCR1_P3_Pos)
 #define GPIO_ODCR1_P4_Pos           4            /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P4               (_U(0x1) << GPIO_ODCR1_P4_Pos)
+#define GPIO_ODCR1_P4               (_U_(0x1) << GPIO_ODCR1_P4_Pos)
 #define GPIO_ODCR1_P5_Pos           5            /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P5               (_U(0x1) << GPIO_ODCR1_P5_Pos)
+#define GPIO_ODCR1_P5               (_U_(0x1) << GPIO_ODCR1_P5_Pos)
 #define GPIO_ODCR1_P6_Pos           6            /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P6               (_U(0x1) << GPIO_ODCR1_P6_Pos)
+#define GPIO_ODCR1_P6               (_U_(0x1) << GPIO_ODCR1_P6_Pos)
 #define GPIO_ODCR1_P7_Pos           7            /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P7               (_U(0x1) << GPIO_ODCR1_P7_Pos)
+#define GPIO_ODCR1_P7               (_U_(0x1) << GPIO_ODCR1_P7_Pos)
 #define GPIO_ODCR1_P8_Pos           8            /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P8               (_U(0x1) << GPIO_ODCR1_P8_Pos)
+#define GPIO_ODCR1_P8               (_U_(0x1) << GPIO_ODCR1_P8_Pos)
 #define GPIO_ODCR1_P9_Pos           9            /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P9               (_U(0x1) << GPIO_ODCR1_P9_Pos)
+#define GPIO_ODCR1_P9               (_U_(0x1) << GPIO_ODCR1_P9_Pos)
 #define GPIO_ODCR1_P10_Pos          10           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P10              (_U(0x1) << GPIO_ODCR1_P10_Pos)
+#define GPIO_ODCR1_P10              (_U_(0x1) << GPIO_ODCR1_P10_Pos)
 #define GPIO_ODCR1_P11_Pos          11           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P11              (_U(0x1) << GPIO_ODCR1_P11_Pos)
+#define GPIO_ODCR1_P11              (_U_(0x1) << GPIO_ODCR1_P11_Pos)
 #define GPIO_ODCR1_P12_Pos          12           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P12              (_U(0x1) << GPIO_ODCR1_P12_Pos)
+#define GPIO_ODCR1_P12              (_U_(0x1) << GPIO_ODCR1_P12_Pos)
 #define GPIO_ODCR1_P13_Pos          13           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P13              (_U(0x1) << GPIO_ODCR1_P13_Pos)
+#define GPIO_ODCR1_P13              (_U_(0x1) << GPIO_ODCR1_P13_Pos)
 #define GPIO_ODCR1_P14_Pos          14           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P14              (_U(0x1) << GPIO_ODCR1_P14_Pos)
+#define GPIO_ODCR1_P14              (_U_(0x1) << GPIO_ODCR1_P14_Pos)
 #define GPIO_ODCR1_P15_Pos          15           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P15              (_U(0x1) << GPIO_ODCR1_P15_Pos)
+#define GPIO_ODCR1_P15              (_U_(0x1) << GPIO_ODCR1_P15_Pos)
 #define GPIO_ODCR1_P16_Pos          16           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P16              (_U(0x1) << GPIO_ODCR1_P16_Pos)
+#define GPIO_ODCR1_P16              (_U_(0x1) << GPIO_ODCR1_P16_Pos)
 #define GPIO_ODCR1_P17_Pos          17           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P17              (_U(0x1) << GPIO_ODCR1_P17_Pos)
+#define GPIO_ODCR1_P17              (_U_(0x1) << GPIO_ODCR1_P17_Pos)
 #define GPIO_ODCR1_P18_Pos          18           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P18              (_U(0x1) << GPIO_ODCR1_P18_Pos)
+#define GPIO_ODCR1_P18              (_U_(0x1) << GPIO_ODCR1_P18_Pos)
 #define GPIO_ODCR1_P19_Pos          19           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P19              (_U(0x1) << GPIO_ODCR1_P19_Pos)
+#define GPIO_ODCR1_P19              (_U_(0x1) << GPIO_ODCR1_P19_Pos)
 #define GPIO_ODCR1_P20_Pos          20           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P20              (_U(0x1) << GPIO_ODCR1_P20_Pos)
+#define GPIO_ODCR1_P20              (_U_(0x1) << GPIO_ODCR1_P20_Pos)
 #define GPIO_ODCR1_P21_Pos          21           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P21              (_U(0x1) << GPIO_ODCR1_P21_Pos)
+#define GPIO_ODCR1_P21              (_U_(0x1) << GPIO_ODCR1_P21_Pos)
 #define GPIO_ODCR1_P22_Pos          22           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P22              (_U(0x1) << GPIO_ODCR1_P22_Pos)
+#define GPIO_ODCR1_P22              (_U_(0x1) << GPIO_ODCR1_P22_Pos)
 #define GPIO_ODCR1_P23_Pos          23           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P23              (_U(0x1) << GPIO_ODCR1_P23_Pos)
+#define GPIO_ODCR1_P23              (_U_(0x1) << GPIO_ODCR1_P23_Pos)
 #define GPIO_ODCR1_P24_Pos          24           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P24              (_U(0x1) << GPIO_ODCR1_P24_Pos)
+#define GPIO_ODCR1_P24              (_U_(0x1) << GPIO_ODCR1_P24_Pos)
 #define GPIO_ODCR1_P25_Pos          25           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P25              (_U(0x1) << GPIO_ODCR1_P25_Pos)
+#define GPIO_ODCR1_P25              (_U_(0x1) << GPIO_ODCR1_P25_Pos)
 #define GPIO_ODCR1_P26_Pos          26           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P26              (_U(0x1) << GPIO_ODCR1_P26_Pos)
+#define GPIO_ODCR1_P26              (_U_(0x1) << GPIO_ODCR1_P26_Pos)
 #define GPIO_ODCR1_P27_Pos          27           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P27              (_U(0x1) << GPIO_ODCR1_P27_Pos)
+#define GPIO_ODCR1_P27              (_U_(0x1) << GPIO_ODCR1_P27_Pos)
 #define GPIO_ODCR1_P28_Pos          28           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P28              (_U(0x1) << GPIO_ODCR1_P28_Pos)
+#define GPIO_ODCR1_P28              (_U_(0x1) << GPIO_ODCR1_P28_Pos)
 #define GPIO_ODCR1_P29_Pos          29           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P29              (_U(0x1) << GPIO_ODCR1_P29_Pos)
+#define GPIO_ODCR1_P29              (_U_(0x1) << GPIO_ODCR1_P29_Pos)
 #define GPIO_ODCR1_P30_Pos          30           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P30              (_U(0x1) << GPIO_ODCR1_P30_Pos)
+#define GPIO_ODCR1_P30              (_U_(0x1) << GPIO_ODCR1_P30_Pos)
 #define GPIO_ODCR1_P31_Pos          31           /**< \brief (GPIO_ODCR1) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1_P31              (_U(0x1) << GPIO_ODCR1_P31_Pos)
-#define GPIO_ODCR1_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_ODCR1) MASK Register */
+#define GPIO_ODCR1_P31              (_U_(0x1) << GPIO_ODCR1_P31_Pos)
+#define GPIO_ODCR1_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_ODCR1) MASK Register */
 
 /* -------- GPIO_ODCR1S : (GPIO Offset: 0x114) (R/W 32) port Output Driving Capability Register 1 - Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -6622,70 +6622,70 @@ typedef union {
 #define GPIO_ODCR1S_OFFSET          0x114        /**< \brief (GPIO_ODCR1S offset) Output Driving Capability Register 1 - Set */
 
 #define GPIO_ODCR1S_P0_Pos          0            /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P0              (_U(0x1) << GPIO_ODCR1S_P0_Pos)
+#define GPIO_ODCR1S_P0              (_U_(0x1) << GPIO_ODCR1S_P0_Pos)
 #define GPIO_ODCR1S_P1_Pos          1            /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P1              (_U(0x1) << GPIO_ODCR1S_P1_Pos)
+#define GPIO_ODCR1S_P1              (_U_(0x1) << GPIO_ODCR1S_P1_Pos)
 #define GPIO_ODCR1S_P2_Pos          2            /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P2              (_U(0x1) << GPIO_ODCR1S_P2_Pos)
+#define GPIO_ODCR1S_P2              (_U_(0x1) << GPIO_ODCR1S_P2_Pos)
 #define GPIO_ODCR1S_P3_Pos          3            /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P3              (_U(0x1) << GPIO_ODCR1S_P3_Pos)
+#define GPIO_ODCR1S_P3              (_U_(0x1) << GPIO_ODCR1S_P3_Pos)
 #define GPIO_ODCR1S_P4_Pos          4            /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P4              (_U(0x1) << GPIO_ODCR1S_P4_Pos)
+#define GPIO_ODCR1S_P4              (_U_(0x1) << GPIO_ODCR1S_P4_Pos)
 #define GPIO_ODCR1S_P5_Pos          5            /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P5              (_U(0x1) << GPIO_ODCR1S_P5_Pos)
+#define GPIO_ODCR1S_P5              (_U_(0x1) << GPIO_ODCR1S_P5_Pos)
 #define GPIO_ODCR1S_P6_Pos          6            /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P6              (_U(0x1) << GPIO_ODCR1S_P6_Pos)
+#define GPIO_ODCR1S_P6              (_U_(0x1) << GPIO_ODCR1S_P6_Pos)
 #define GPIO_ODCR1S_P7_Pos          7            /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P7              (_U(0x1) << GPIO_ODCR1S_P7_Pos)
+#define GPIO_ODCR1S_P7              (_U_(0x1) << GPIO_ODCR1S_P7_Pos)
 #define GPIO_ODCR1S_P8_Pos          8            /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P8              (_U(0x1) << GPIO_ODCR1S_P8_Pos)
+#define GPIO_ODCR1S_P8              (_U_(0x1) << GPIO_ODCR1S_P8_Pos)
 #define GPIO_ODCR1S_P9_Pos          9            /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P9              (_U(0x1) << GPIO_ODCR1S_P9_Pos)
+#define GPIO_ODCR1S_P9              (_U_(0x1) << GPIO_ODCR1S_P9_Pos)
 #define GPIO_ODCR1S_P10_Pos         10           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P10             (_U(0x1) << GPIO_ODCR1S_P10_Pos)
+#define GPIO_ODCR1S_P10             (_U_(0x1) << GPIO_ODCR1S_P10_Pos)
 #define GPIO_ODCR1S_P11_Pos         11           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P11             (_U(0x1) << GPIO_ODCR1S_P11_Pos)
+#define GPIO_ODCR1S_P11             (_U_(0x1) << GPIO_ODCR1S_P11_Pos)
 #define GPIO_ODCR1S_P12_Pos         12           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P12             (_U(0x1) << GPIO_ODCR1S_P12_Pos)
+#define GPIO_ODCR1S_P12             (_U_(0x1) << GPIO_ODCR1S_P12_Pos)
 #define GPIO_ODCR1S_P13_Pos         13           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P13             (_U(0x1) << GPIO_ODCR1S_P13_Pos)
+#define GPIO_ODCR1S_P13             (_U_(0x1) << GPIO_ODCR1S_P13_Pos)
 #define GPIO_ODCR1S_P14_Pos         14           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P14             (_U(0x1) << GPIO_ODCR1S_P14_Pos)
+#define GPIO_ODCR1S_P14             (_U_(0x1) << GPIO_ODCR1S_P14_Pos)
 #define GPIO_ODCR1S_P15_Pos         15           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P15             (_U(0x1) << GPIO_ODCR1S_P15_Pos)
+#define GPIO_ODCR1S_P15             (_U_(0x1) << GPIO_ODCR1S_P15_Pos)
 #define GPIO_ODCR1S_P16_Pos         16           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P16             (_U(0x1) << GPIO_ODCR1S_P16_Pos)
+#define GPIO_ODCR1S_P16             (_U_(0x1) << GPIO_ODCR1S_P16_Pos)
 #define GPIO_ODCR1S_P17_Pos         17           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P17             (_U(0x1) << GPIO_ODCR1S_P17_Pos)
+#define GPIO_ODCR1S_P17             (_U_(0x1) << GPIO_ODCR1S_P17_Pos)
 #define GPIO_ODCR1S_P18_Pos         18           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P18             (_U(0x1) << GPIO_ODCR1S_P18_Pos)
+#define GPIO_ODCR1S_P18             (_U_(0x1) << GPIO_ODCR1S_P18_Pos)
 #define GPIO_ODCR1S_P19_Pos         19           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P19             (_U(0x1) << GPIO_ODCR1S_P19_Pos)
+#define GPIO_ODCR1S_P19             (_U_(0x1) << GPIO_ODCR1S_P19_Pos)
 #define GPIO_ODCR1S_P20_Pos         20           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P20             (_U(0x1) << GPIO_ODCR1S_P20_Pos)
+#define GPIO_ODCR1S_P20             (_U_(0x1) << GPIO_ODCR1S_P20_Pos)
 #define GPIO_ODCR1S_P21_Pos         21           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P21             (_U(0x1) << GPIO_ODCR1S_P21_Pos)
+#define GPIO_ODCR1S_P21             (_U_(0x1) << GPIO_ODCR1S_P21_Pos)
 #define GPIO_ODCR1S_P22_Pos         22           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P22             (_U(0x1) << GPIO_ODCR1S_P22_Pos)
+#define GPIO_ODCR1S_P22             (_U_(0x1) << GPIO_ODCR1S_P22_Pos)
 #define GPIO_ODCR1S_P23_Pos         23           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P23             (_U(0x1) << GPIO_ODCR1S_P23_Pos)
+#define GPIO_ODCR1S_P23             (_U_(0x1) << GPIO_ODCR1S_P23_Pos)
 #define GPIO_ODCR1S_P24_Pos         24           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P24             (_U(0x1) << GPIO_ODCR1S_P24_Pos)
+#define GPIO_ODCR1S_P24             (_U_(0x1) << GPIO_ODCR1S_P24_Pos)
 #define GPIO_ODCR1S_P25_Pos         25           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P25             (_U(0x1) << GPIO_ODCR1S_P25_Pos)
+#define GPIO_ODCR1S_P25             (_U_(0x1) << GPIO_ODCR1S_P25_Pos)
 #define GPIO_ODCR1S_P26_Pos         26           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P26             (_U(0x1) << GPIO_ODCR1S_P26_Pos)
+#define GPIO_ODCR1S_P26             (_U_(0x1) << GPIO_ODCR1S_P26_Pos)
 #define GPIO_ODCR1S_P27_Pos         27           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P27             (_U(0x1) << GPIO_ODCR1S_P27_Pos)
+#define GPIO_ODCR1S_P27             (_U_(0x1) << GPIO_ODCR1S_P27_Pos)
 #define GPIO_ODCR1S_P28_Pos         28           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P28             (_U(0x1) << GPIO_ODCR1S_P28_Pos)
+#define GPIO_ODCR1S_P28             (_U_(0x1) << GPIO_ODCR1S_P28_Pos)
 #define GPIO_ODCR1S_P29_Pos         29           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P29             (_U(0x1) << GPIO_ODCR1S_P29_Pos)
+#define GPIO_ODCR1S_P29             (_U_(0x1) << GPIO_ODCR1S_P29_Pos)
 #define GPIO_ODCR1S_P30_Pos         30           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P30             (_U(0x1) << GPIO_ODCR1S_P30_Pos)
+#define GPIO_ODCR1S_P30             (_U_(0x1) << GPIO_ODCR1S_P30_Pos)
 #define GPIO_ODCR1S_P31_Pos         31           /**< \brief (GPIO_ODCR1S) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1S_P31             (_U(0x1) << GPIO_ODCR1S_P31_Pos)
-#define GPIO_ODCR1S_MASK            _U(0xFFFFFFFF) /**< \brief (GPIO_ODCR1S) MASK Register */
+#define GPIO_ODCR1S_P31             (_U_(0x1) << GPIO_ODCR1S_P31_Pos)
+#define GPIO_ODCR1S_MASK            _U_(0xFFFFFFFF) /**< \brief (GPIO_ODCR1S) MASK Register */
 
 /* -------- GPIO_ODCR1C : (GPIO Offset: 0x118) (R/W 32) port Output Driving Capability Register 1 - Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -6731,70 +6731,70 @@ typedef union {
 #define GPIO_ODCR1C_OFFSET          0x118        /**< \brief (GPIO_ODCR1C offset) Output Driving Capability Register 1 - Clear */
 
 #define GPIO_ODCR1C_P0_Pos          0            /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P0              (_U(0x1) << GPIO_ODCR1C_P0_Pos)
+#define GPIO_ODCR1C_P0              (_U_(0x1) << GPIO_ODCR1C_P0_Pos)
 #define GPIO_ODCR1C_P1_Pos          1            /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P1              (_U(0x1) << GPIO_ODCR1C_P1_Pos)
+#define GPIO_ODCR1C_P1              (_U_(0x1) << GPIO_ODCR1C_P1_Pos)
 #define GPIO_ODCR1C_P2_Pos          2            /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P2              (_U(0x1) << GPIO_ODCR1C_P2_Pos)
+#define GPIO_ODCR1C_P2              (_U_(0x1) << GPIO_ODCR1C_P2_Pos)
 #define GPIO_ODCR1C_P3_Pos          3            /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P3              (_U(0x1) << GPIO_ODCR1C_P3_Pos)
+#define GPIO_ODCR1C_P3              (_U_(0x1) << GPIO_ODCR1C_P3_Pos)
 #define GPIO_ODCR1C_P4_Pos          4            /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P4              (_U(0x1) << GPIO_ODCR1C_P4_Pos)
+#define GPIO_ODCR1C_P4              (_U_(0x1) << GPIO_ODCR1C_P4_Pos)
 #define GPIO_ODCR1C_P5_Pos          5            /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P5              (_U(0x1) << GPIO_ODCR1C_P5_Pos)
+#define GPIO_ODCR1C_P5              (_U_(0x1) << GPIO_ODCR1C_P5_Pos)
 #define GPIO_ODCR1C_P6_Pos          6            /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P6              (_U(0x1) << GPIO_ODCR1C_P6_Pos)
+#define GPIO_ODCR1C_P6              (_U_(0x1) << GPIO_ODCR1C_P6_Pos)
 #define GPIO_ODCR1C_P7_Pos          7            /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P7              (_U(0x1) << GPIO_ODCR1C_P7_Pos)
+#define GPIO_ODCR1C_P7              (_U_(0x1) << GPIO_ODCR1C_P7_Pos)
 #define GPIO_ODCR1C_P8_Pos          8            /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P8              (_U(0x1) << GPIO_ODCR1C_P8_Pos)
+#define GPIO_ODCR1C_P8              (_U_(0x1) << GPIO_ODCR1C_P8_Pos)
 #define GPIO_ODCR1C_P9_Pos          9            /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P9              (_U(0x1) << GPIO_ODCR1C_P9_Pos)
+#define GPIO_ODCR1C_P9              (_U_(0x1) << GPIO_ODCR1C_P9_Pos)
 #define GPIO_ODCR1C_P10_Pos         10           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P10             (_U(0x1) << GPIO_ODCR1C_P10_Pos)
+#define GPIO_ODCR1C_P10             (_U_(0x1) << GPIO_ODCR1C_P10_Pos)
 #define GPIO_ODCR1C_P11_Pos         11           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P11             (_U(0x1) << GPIO_ODCR1C_P11_Pos)
+#define GPIO_ODCR1C_P11             (_U_(0x1) << GPIO_ODCR1C_P11_Pos)
 #define GPIO_ODCR1C_P12_Pos         12           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P12             (_U(0x1) << GPIO_ODCR1C_P12_Pos)
+#define GPIO_ODCR1C_P12             (_U_(0x1) << GPIO_ODCR1C_P12_Pos)
 #define GPIO_ODCR1C_P13_Pos         13           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P13             (_U(0x1) << GPIO_ODCR1C_P13_Pos)
+#define GPIO_ODCR1C_P13             (_U_(0x1) << GPIO_ODCR1C_P13_Pos)
 #define GPIO_ODCR1C_P14_Pos         14           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P14             (_U(0x1) << GPIO_ODCR1C_P14_Pos)
+#define GPIO_ODCR1C_P14             (_U_(0x1) << GPIO_ODCR1C_P14_Pos)
 #define GPIO_ODCR1C_P15_Pos         15           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P15             (_U(0x1) << GPIO_ODCR1C_P15_Pos)
+#define GPIO_ODCR1C_P15             (_U_(0x1) << GPIO_ODCR1C_P15_Pos)
 #define GPIO_ODCR1C_P16_Pos         16           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P16             (_U(0x1) << GPIO_ODCR1C_P16_Pos)
+#define GPIO_ODCR1C_P16             (_U_(0x1) << GPIO_ODCR1C_P16_Pos)
 #define GPIO_ODCR1C_P17_Pos         17           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P17             (_U(0x1) << GPIO_ODCR1C_P17_Pos)
+#define GPIO_ODCR1C_P17             (_U_(0x1) << GPIO_ODCR1C_P17_Pos)
 #define GPIO_ODCR1C_P18_Pos         18           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P18             (_U(0x1) << GPIO_ODCR1C_P18_Pos)
+#define GPIO_ODCR1C_P18             (_U_(0x1) << GPIO_ODCR1C_P18_Pos)
 #define GPIO_ODCR1C_P19_Pos         19           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P19             (_U(0x1) << GPIO_ODCR1C_P19_Pos)
+#define GPIO_ODCR1C_P19             (_U_(0x1) << GPIO_ODCR1C_P19_Pos)
 #define GPIO_ODCR1C_P20_Pos         20           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P20             (_U(0x1) << GPIO_ODCR1C_P20_Pos)
+#define GPIO_ODCR1C_P20             (_U_(0x1) << GPIO_ODCR1C_P20_Pos)
 #define GPIO_ODCR1C_P21_Pos         21           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P21             (_U(0x1) << GPIO_ODCR1C_P21_Pos)
+#define GPIO_ODCR1C_P21             (_U_(0x1) << GPIO_ODCR1C_P21_Pos)
 #define GPIO_ODCR1C_P22_Pos         22           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P22             (_U(0x1) << GPIO_ODCR1C_P22_Pos)
+#define GPIO_ODCR1C_P22             (_U_(0x1) << GPIO_ODCR1C_P22_Pos)
 #define GPIO_ODCR1C_P23_Pos         23           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P23             (_U(0x1) << GPIO_ODCR1C_P23_Pos)
+#define GPIO_ODCR1C_P23             (_U_(0x1) << GPIO_ODCR1C_P23_Pos)
 #define GPIO_ODCR1C_P24_Pos         24           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P24             (_U(0x1) << GPIO_ODCR1C_P24_Pos)
+#define GPIO_ODCR1C_P24             (_U_(0x1) << GPIO_ODCR1C_P24_Pos)
 #define GPIO_ODCR1C_P25_Pos         25           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P25             (_U(0x1) << GPIO_ODCR1C_P25_Pos)
+#define GPIO_ODCR1C_P25             (_U_(0x1) << GPIO_ODCR1C_P25_Pos)
 #define GPIO_ODCR1C_P26_Pos         26           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P26             (_U(0x1) << GPIO_ODCR1C_P26_Pos)
+#define GPIO_ODCR1C_P26             (_U_(0x1) << GPIO_ODCR1C_P26_Pos)
 #define GPIO_ODCR1C_P27_Pos         27           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P27             (_U(0x1) << GPIO_ODCR1C_P27_Pos)
+#define GPIO_ODCR1C_P27             (_U_(0x1) << GPIO_ODCR1C_P27_Pos)
 #define GPIO_ODCR1C_P28_Pos         28           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P28             (_U(0x1) << GPIO_ODCR1C_P28_Pos)
+#define GPIO_ODCR1C_P28             (_U_(0x1) << GPIO_ODCR1C_P28_Pos)
 #define GPIO_ODCR1C_P29_Pos         29           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P29             (_U(0x1) << GPIO_ODCR1C_P29_Pos)
+#define GPIO_ODCR1C_P29             (_U_(0x1) << GPIO_ODCR1C_P29_Pos)
 #define GPIO_ODCR1C_P30_Pos         30           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P30             (_U(0x1) << GPIO_ODCR1C_P30_Pos)
+#define GPIO_ODCR1C_P30             (_U_(0x1) << GPIO_ODCR1C_P30_Pos)
 #define GPIO_ODCR1C_P31_Pos         31           /**< \brief (GPIO_ODCR1C) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1C_P31             (_U(0x1) << GPIO_ODCR1C_P31_Pos)
-#define GPIO_ODCR1C_MASK            _U(0xFFFFFFFF) /**< \brief (GPIO_ODCR1C) MASK Register */
+#define GPIO_ODCR1C_P31             (_U_(0x1) << GPIO_ODCR1C_P31_Pos)
+#define GPIO_ODCR1C_MASK            _U_(0xFFFFFFFF) /**< \brief (GPIO_ODCR1C) MASK Register */
 
 /* -------- GPIO_ODCR1T : (GPIO Offset: 0x11C) (R/W 32) port Output Driving Capability Register 1 - Toggle -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -6840,70 +6840,70 @@ typedef union {
 #define GPIO_ODCR1T_OFFSET          0x11C        /**< \brief (GPIO_ODCR1T offset) Output Driving Capability Register 1 - Toggle */
 
 #define GPIO_ODCR1T_P0_Pos          0            /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P0              (_U(0x1) << GPIO_ODCR1T_P0_Pos)
+#define GPIO_ODCR1T_P0              (_U_(0x1) << GPIO_ODCR1T_P0_Pos)
 #define GPIO_ODCR1T_P1_Pos          1            /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P1              (_U(0x1) << GPIO_ODCR1T_P1_Pos)
+#define GPIO_ODCR1T_P1              (_U_(0x1) << GPIO_ODCR1T_P1_Pos)
 #define GPIO_ODCR1T_P2_Pos          2            /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P2              (_U(0x1) << GPIO_ODCR1T_P2_Pos)
+#define GPIO_ODCR1T_P2              (_U_(0x1) << GPIO_ODCR1T_P2_Pos)
 #define GPIO_ODCR1T_P3_Pos          3            /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P3              (_U(0x1) << GPIO_ODCR1T_P3_Pos)
+#define GPIO_ODCR1T_P3              (_U_(0x1) << GPIO_ODCR1T_P3_Pos)
 #define GPIO_ODCR1T_P4_Pos          4            /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P4              (_U(0x1) << GPIO_ODCR1T_P4_Pos)
+#define GPIO_ODCR1T_P4              (_U_(0x1) << GPIO_ODCR1T_P4_Pos)
 #define GPIO_ODCR1T_P5_Pos          5            /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P5              (_U(0x1) << GPIO_ODCR1T_P5_Pos)
+#define GPIO_ODCR1T_P5              (_U_(0x1) << GPIO_ODCR1T_P5_Pos)
 #define GPIO_ODCR1T_P6_Pos          6            /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P6              (_U(0x1) << GPIO_ODCR1T_P6_Pos)
+#define GPIO_ODCR1T_P6              (_U_(0x1) << GPIO_ODCR1T_P6_Pos)
 #define GPIO_ODCR1T_P7_Pos          7            /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P7              (_U(0x1) << GPIO_ODCR1T_P7_Pos)
+#define GPIO_ODCR1T_P7              (_U_(0x1) << GPIO_ODCR1T_P7_Pos)
 #define GPIO_ODCR1T_P8_Pos          8            /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P8              (_U(0x1) << GPIO_ODCR1T_P8_Pos)
+#define GPIO_ODCR1T_P8              (_U_(0x1) << GPIO_ODCR1T_P8_Pos)
 #define GPIO_ODCR1T_P9_Pos          9            /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P9              (_U(0x1) << GPIO_ODCR1T_P9_Pos)
+#define GPIO_ODCR1T_P9              (_U_(0x1) << GPIO_ODCR1T_P9_Pos)
 #define GPIO_ODCR1T_P10_Pos         10           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P10             (_U(0x1) << GPIO_ODCR1T_P10_Pos)
+#define GPIO_ODCR1T_P10             (_U_(0x1) << GPIO_ODCR1T_P10_Pos)
 #define GPIO_ODCR1T_P11_Pos         11           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P11             (_U(0x1) << GPIO_ODCR1T_P11_Pos)
+#define GPIO_ODCR1T_P11             (_U_(0x1) << GPIO_ODCR1T_P11_Pos)
 #define GPIO_ODCR1T_P12_Pos         12           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P12             (_U(0x1) << GPIO_ODCR1T_P12_Pos)
+#define GPIO_ODCR1T_P12             (_U_(0x1) << GPIO_ODCR1T_P12_Pos)
 #define GPIO_ODCR1T_P13_Pos         13           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P13             (_U(0x1) << GPIO_ODCR1T_P13_Pos)
+#define GPIO_ODCR1T_P13             (_U_(0x1) << GPIO_ODCR1T_P13_Pos)
 #define GPIO_ODCR1T_P14_Pos         14           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P14             (_U(0x1) << GPIO_ODCR1T_P14_Pos)
+#define GPIO_ODCR1T_P14             (_U_(0x1) << GPIO_ODCR1T_P14_Pos)
 #define GPIO_ODCR1T_P15_Pos         15           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P15             (_U(0x1) << GPIO_ODCR1T_P15_Pos)
+#define GPIO_ODCR1T_P15             (_U_(0x1) << GPIO_ODCR1T_P15_Pos)
 #define GPIO_ODCR1T_P16_Pos         16           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P16             (_U(0x1) << GPIO_ODCR1T_P16_Pos)
+#define GPIO_ODCR1T_P16             (_U_(0x1) << GPIO_ODCR1T_P16_Pos)
 #define GPIO_ODCR1T_P17_Pos         17           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P17             (_U(0x1) << GPIO_ODCR1T_P17_Pos)
+#define GPIO_ODCR1T_P17             (_U_(0x1) << GPIO_ODCR1T_P17_Pos)
 #define GPIO_ODCR1T_P18_Pos         18           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P18             (_U(0x1) << GPIO_ODCR1T_P18_Pos)
+#define GPIO_ODCR1T_P18             (_U_(0x1) << GPIO_ODCR1T_P18_Pos)
 #define GPIO_ODCR1T_P19_Pos         19           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P19             (_U(0x1) << GPIO_ODCR1T_P19_Pos)
+#define GPIO_ODCR1T_P19             (_U_(0x1) << GPIO_ODCR1T_P19_Pos)
 #define GPIO_ODCR1T_P20_Pos         20           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P20             (_U(0x1) << GPIO_ODCR1T_P20_Pos)
+#define GPIO_ODCR1T_P20             (_U_(0x1) << GPIO_ODCR1T_P20_Pos)
 #define GPIO_ODCR1T_P21_Pos         21           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P21             (_U(0x1) << GPIO_ODCR1T_P21_Pos)
+#define GPIO_ODCR1T_P21             (_U_(0x1) << GPIO_ODCR1T_P21_Pos)
 #define GPIO_ODCR1T_P22_Pos         22           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P22             (_U(0x1) << GPIO_ODCR1T_P22_Pos)
+#define GPIO_ODCR1T_P22             (_U_(0x1) << GPIO_ODCR1T_P22_Pos)
 #define GPIO_ODCR1T_P23_Pos         23           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P23             (_U(0x1) << GPIO_ODCR1T_P23_Pos)
+#define GPIO_ODCR1T_P23             (_U_(0x1) << GPIO_ODCR1T_P23_Pos)
 #define GPIO_ODCR1T_P24_Pos         24           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P24             (_U(0x1) << GPIO_ODCR1T_P24_Pos)
+#define GPIO_ODCR1T_P24             (_U_(0x1) << GPIO_ODCR1T_P24_Pos)
 #define GPIO_ODCR1T_P25_Pos         25           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P25             (_U(0x1) << GPIO_ODCR1T_P25_Pos)
+#define GPIO_ODCR1T_P25             (_U_(0x1) << GPIO_ODCR1T_P25_Pos)
 #define GPIO_ODCR1T_P26_Pos         26           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P26             (_U(0x1) << GPIO_ODCR1T_P26_Pos)
+#define GPIO_ODCR1T_P26             (_U_(0x1) << GPIO_ODCR1T_P26_Pos)
 #define GPIO_ODCR1T_P27_Pos         27           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P27             (_U(0x1) << GPIO_ODCR1T_P27_Pos)
+#define GPIO_ODCR1T_P27             (_U_(0x1) << GPIO_ODCR1T_P27_Pos)
 #define GPIO_ODCR1T_P28_Pos         28           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P28             (_U(0x1) << GPIO_ODCR1T_P28_Pos)
+#define GPIO_ODCR1T_P28             (_U_(0x1) << GPIO_ODCR1T_P28_Pos)
 #define GPIO_ODCR1T_P29_Pos         29           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P29             (_U(0x1) << GPIO_ODCR1T_P29_Pos)
+#define GPIO_ODCR1T_P29             (_U_(0x1) << GPIO_ODCR1T_P29_Pos)
 #define GPIO_ODCR1T_P30_Pos         30           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P30             (_U(0x1) << GPIO_ODCR1T_P30_Pos)
+#define GPIO_ODCR1T_P30             (_U_(0x1) << GPIO_ODCR1T_P30_Pos)
 #define GPIO_ODCR1T_P31_Pos         31           /**< \brief (GPIO_ODCR1T) Output Driving Capability Register Bit 1 */
-#define GPIO_ODCR1T_P31             (_U(0x1) << GPIO_ODCR1T_P31_Pos)
-#define GPIO_ODCR1T_MASK            _U(0xFFFFFFFF) /**< \brief (GPIO_ODCR1T) MASK Register */
+#define GPIO_ODCR1T_P31             (_U_(0x1) << GPIO_ODCR1T_P31_Pos)
+#define GPIO_ODCR1T_MASK            _U_(0xFFFFFFFF) /**< \brief (GPIO_ODCR1T) MASK Register */
 
 /* -------- GPIO_OSRR0 : (GPIO Offset: 0x130) (R/W 32) port Output Slew Rate Register 0 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -6949,70 +6949,70 @@ typedef union {
 #define GPIO_OSRR0_OFFSET           0x130        /**< \brief (GPIO_OSRR0 offset) Output Slew Rate Register 0 */
 
 #define GPIO_OSRR0_P0_Pos           0            /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P0               (_U(0x1) << GPIO_OSRR0_P0_Pos)
+#define GPIO_OSRR0_P0               (_U_(0x1) << GPIO_OSRR0_P0_Pos)
 #define GPIO_OSRR0_P1_Pos           1            /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P1               (_U(0x1) << GPIO_OSRR0_P1_Pos)
+#define GPIO_OSRR0_P1               (_U_(0x1) << GPIO_OSRR0_P1_Pos)
 #define GPIO_OSRR0_P2_Pos           2            /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P2               (_U(0x1) << GPIO_OSRR0_P2_Pos)
+#define GPIO_OSRR0_P2               (_U_(0x1) << GPIO_OSRR0_P2_Pos)
 #define GPIO_OSRR0_P3_Pos           3            /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P3               (_U(0x1) << GPIO_OSRR0_P3_Pos)
+#define GPIO_OSRR0_P3               (_U_(0x1) << GPIO_OSRR0_P3_Pos)
 #define GPIO_OSRR0_P4_Pos           4            /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P4               (_U(0x1) << GPIO_OSRR0_P4_Pos)
+#define GPIO_OSRR0_P4               (_U_(0x1) << GPIO_OSRR0_P4_Pos)
 #define GPIO_OSRR0_P5_Pos           5            /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P5               (_U(0x1) << GPIO_OSRR0_P5_Pos)
+#define GPIO_OSRR0_P5               (_U_(0x1) << GPIO_OSRR0_P5_Pos)
 #define GPIO_OSRR0_P6_Pos           6            /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P6               (_U(0x1) << GPIO_OSRR0_P6_Pos)
+#define GPIO_OSRR0_P6               (_U_(0x1) << GPIO_OSRR0_P6_Pos)
 #define GPIO_OSRR0_P7_Pos           7            /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P7               (_U(0x1) << GPIO_OSRR0_P7_Pos)
+#define GPIO_OSRR0_P7               (_U_(0x1) << GPIO_OSRR0_P7_Pos)
 #define GPIO_OSRR0_P8_Pos           8            /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P8               (_U(0x1) << GPIO_OSRR0_P8_Pos)
+#define GPIO_OSRR0_P8               (_U_(0x1) << GPIO_OSRR0_P8_Pos)
 #define GPIO_OSRR0_P9_Pos           9            /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P9               (_U(0x1) << GPIO_OSRR0_P9_Pos)
+#define GPIO_OSRR0_P9               (_U_(0x1) << GPIO_OSRR0_P9_Pos)
 #define GPIO_OSRR0_P10_Pos          10           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P10              (_U(0x1) << GPIO_OSRR0_P10_Pos)
+#define GPIO_OSRR0_P10              (_U_(0x1) << GPIO_OSRR0_P10_Pos)
 #define GPIO_OSRR0_P11_Pos          11           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P11              (_U(0x1) << GPIO_OSRR0_P11_Pos)
+#define GPIO_OSRR0_P11              (_U_(0x1) << GPIO_OSRR0_P11_Pos)
 #define GPIO_OSRR0_P12_Pos          12           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P12              (_U(0x1) << GPIO_OSRR0_P12_Pos)
+#define GPIO_OSRR0_P12              (_U_(0x1) << GPIO_OSRR0_P12_Pos)
 #define GPIO_OSRR0_P13_Pos          13           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P13              (_U(0x1) << GPIO_OSRR0_P13_Pos)
+#define GPIO_OSRR0_P13              (_U_(0x1) << GPIO_OSRR0_P13_Pos)
 #define GPIO_OSRR0_P14_Pos          14           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P14              (_U(0x1) << GPIO_OSRR0_P14_Pos)
+#define GPIO_OSRR0_P14              (_U_(0x1) << GPIO_OSRR0_P14_Pos)
 #define GPIO_OSRR0_P15_Pos          15           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P15              (_U(0x1) << GPIO_OSRR0_P15_Pos)
+#define GPIO_OSRR0_P15              (_U_(0x1) << GPIO_OSRR0_P15_Pos)
 #define GPIO_OSRR0_P16_Pos          16           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P16              (_U(0x1) << GPIO_OSRR0_P16_Pos)
+#define GPIO_OSRR0_P16              (_U_(0x1) << GPIO_OSRR0_P16_Pos)
 #define GPIO_OSRR0_P17_Pos          17           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P17              (_U(0x1) << GPIO_OSRR0_P17_Pos)
+#define GPIO_OSRR0_P17              (_U_(0x1) << GPIO_OSRR0_P17_Pos)
 #define GPIO_OSRR0_P18_Pos          18           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P18              (_U(0x1) << GPIO_OSRR0_P18_Pos)
+#define GPIO_OSRR0_P18              (_U_(0x1) << GPIO_OSRR0_P18_Pos)
 #define GPIO_OSRR0_P19_Pos          19           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P19              (_U(0x1) << GPIO_OSRR0_P19_Pos)
+#define GPIO_OSRR0_P19              (_U_(0x1) << GPIO_OSRR0_P19_Pos)
 #define GPIO_OSRR0_P20_Pos          20           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P20              (_U(0x1) << GPIO_OSRR0_P20_Pos)
+#define GPIO_OSRR0_P20              (_U_(0x1) << GPIO_OSRR0_P20_Pos)
 #define GPIO_OSRR0_P21_Pos          21           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P21              (_U(0x1) << GPIO_OSRR0_P21_Pos)
+#define GPIO_OSRR0_P21              (_U_(0x1) << GPIO_OSRR0_P21_Pos)
 #define GPIO_OSRR0_P22_Pos          22           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P22              (_U(0x1) << GPIO_OSRR0_P22_Pos)
+#define GPIO_OSRR0_P22              (_U_(0x1) << GPIO_OSRR0_P22_Pos)
 #define GPIO_OSRR0_P23_Pos          23           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P23              (_U(0x1) << GPIO_OSRR0_P23_Pos)
+#define GPIO_OSRR0_P23              (_U_(0x1) << GPIO_OSRR0_P23_Pos)
 #define GPIO_OSRR0_P24_Pos          24           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P24              (_U(0x1) << GPIO_OSRR0_P24_Pos)
+#define GPIO_OSRR0_P24              (_U_(0x1) << GPIO_OSRR0_P24_Pos)
 #define GPIO_OSRR0_P25_Pos          25           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P25              (_U(0x1) << GPIO_OSRR0_P25_Pos)
+#define GPIO_OSRR0_P25              (_U_(0x1) << GPIO_OSRR0_P25_Pos)
 #define GPIO_OSRR0_P26_Pos          26           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P26              (_U(0x1) << GPIO_OSRR0_P26_Pos)
+#define GPIO_OSRR0_P26              (_U_(0x1) << GPIO_OSRR0_P26_Pos)
 #define GPIO_OSRR0_P27_Pos          27           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P27              (_U(0x1) << GPIO_OSRR0_P27_Pos)
+#define GPIO_OSRR0_P27              (_U_(0x1) << GPIO_OSRR0_P27_Pos)
 #define GPIO_OSRR0_P28_Pos          28           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P28              (_U(0x1) << GPIO_OSRR0_P28_Pos)
+#define GPIO_OSRR0_P28              (_U_(0x1) << GPIO_OSRR0_P28_Pos)
 #define GPIO_OSRR0_P29_Pos          29           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P29              (_U(0x1) << GPIO_OSRR0_P29_Pos)
+#define GPIO_OSRR0_P29              (_U_(0x1) << GPIO_OSRR0_P29_Pos)
 #define GPIO_OSRR0_P30_Pos          30           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P30              (_U(0x1) << GPIO_OSRR0_P30_Pos)
+#define GPIO_OSRR0_P30              (_U_(0x1) << GPIO_OSRR0_P30_Pos)
 #define GPIO_OSRR0_P31_Pos          31           /**< \brief (GPIO_OSRR0) Output Slew Rate Control Enable */
-#define GPIO_OSRR0_P31              (_U(0x1) << GPIO_OSRR0_P31_Pos)
-#define GPIO_OSRR0_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_OSRR0) MASK Register */
+#define GPIO_OSRR0_P31              (_U_(0x1) << GPIO_OSRR0_P31_Pos)
+#define GPIO_OSRR0_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_OSRR0) MASK Register */
 
 /* -------- GPIO_OSRR0S : (GPIO Offset: 0x134) (R/W 32) port Output Slew Rate Register 0 - Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7058,70 +7058,70 @@ typedef union {
 #define GPIO_OSRR0S_OFFSET          0x134        /**< \brief (GPIO_OSRR0S offset) Output Slew Rate Register 0 - Set */
 
 #define GPIO_OSRR0S_P0_Pos          0            /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P0              (_U(0x1) << GPIO_OSRR0S_P0_Pos)
+#define GPIO_OSRR0S_P0              (_U_(0x1) << GPIO_OSRR0S_P0_Pos)
 #define GPIO_OSRR0S_P1_Pos          1            /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P1              (_U(0x1) << GPIO_OSRR0S_P1_Pos)
+#define GPIO_OSRR0S_P1              (_U_(0x1) << GPIO_OSRR0S_P1_Pos)
 #define GPIO_OSRR0S_P2_Pos          2            /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P2              (_U(0x1) << GPIO_OSRR0S_P2_Pos)
+#define GPIO_OSRR0S_P2              (_U_(0x1) << GPIO_OSRR0S_P2_Pos)
 #define GPIO_OSRR0S_P3_Pos          3            /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P3              (_U(0x1) << GPIO_OSRR0S_P3_Pos)
+#define GPIO_OSRR0S_P3              (_U_(0x1) << GPIO_OSRR0S_P3_Pos)
 #define GPIO_OSRR0S_P4_Pos          4            /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P4              (_U(0x1) << GPIO_OSRR0S_P4_Pos)
+#define GPIO_OSRR0S_P4              (_U_(0x1) << GPIO_OSRR0S_P4_Pos)
 #define GPIO_OSRR0S_P5_Pos          5            /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P5              (_U(0x1) << GPIO_OSRR0S_P5_Pos)
+#define GPIO_OSRR0S_P5              (_U_(0x1) << GPIO_OSRR0S_P5_Pos)
 #define GPIO_OSRR0S_P6_Pos          6            /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P6              (_U(0x1) << GPIO_OSRR0S_P6_Pos)
+#define GPIO_OSRR0S_P6              (_U_(0x1) << GPIO_OSRR0S_P6_Pos)
 #define GPIO_OSRR0S_P7_Pos          7            /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P7              (_U(0x1) << GPIO_OSRR0S_P7_Pos)
+#define GPIO_OSRR0S_P7              (_U_(0x1) << GPIO_OSRR0S_P7_Pos)
 #define GPIO_OSRR0S_P8_Pos          8            /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P8              (_U(0x1) << GPIO_OSRR0S_P8_Pos)
+#define GPIO_OSRR0S_P8              (_U_(0x1) << GPIO_OSRR0S_P8_Pos)
 #define GPIO_OSRR0S_P9_Pos          9            /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P9              (_U(0x1) << GPIO_OSRR0S_P9_Pos)
+#define GPIO_OSRR0S_P9              (_U_(0x1) << GPIO_OSRR0S_P9_Pos)
 #define GPIO_OSRR0S_P10_Pos         10           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P10             (_U(0x1) << GPIO_OSRR0S_P10_Pos)
+#define GPIO_OSRR0S_P10             (_U_(0x1) << GPIO_OSRR0S_P10_Pos)
 #define GPIO_OSRR0S_P11_Pos         11           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P11             (_U(0x1) << GPIO_OSRR0S_P11_Pos)
+#define GPIO_OSRR0S_P11             (_U_(0x1) << GPIO_OSRR0S_P11_Pos)
 #define GPIO_OSRR0S_P12_Pos         12           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P12             (_U(0x1) << GPIO_OSRR0S_P12_Pos)
+#define GPIO_OSRR0S_P12             (_U_(0x1) << GPIO_OSRR0S_P12_Pos)
 #define GPIO_OSRR0S_P13_Pos         13           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P13             (_U(0x1) << GPIO_OSRR0S_P13_Pos)
+#define GPIO_OSRR0S_P13             (_U_(0x1) << GPIO_OSRR0S_P13_Pos)
 #define GPIO_OSRR0S_P14_Pos         14           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P14             (_U(0x1) << GPIO_OSRR0S_P14_Pos)
+#define GPIO_OSRR0S_P14             (_U_(0x1) << GPIO_OSRR0S_P14_Pos)
 #define GPIO_OSRR0S_P15_Pos         15           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P15             (_U(0x1) << GPIO_OSRR0S_P15_Pos)
+#define GPIO_OSRR0S_P15             (_U_(0x1) << GPIO_OSRR0S_P15_Pos)
 #define GPIO_OSRR0S_P16_Pos         16           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P16             (_U(0x1) << GPIO_OSRR0S_P16_Pos)
+#define GPIO_OSRR0S_P16             (_U_(0x1) << GPIO_OSRR0S_P16_Pos)
 #define GPIO_OSRR0S_P17_Pos         17           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P17             (_U(0x1) << GPIO_OSRR0S_P17_Pos)
+#define GPIO_OSRR0S_P17             (_U_(0x1) << GPIO_OSRR0S_P17_Pos)
 #define GPIO_OSRR0S_P18_Pos         18           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P18             (_U(0x1) << GPIO_OSRR0S_P18_Pos)
+#define GPIO_OSRR0S_P18             (_U_(0x1) << GPIO_OSRR0S_P18_Pos)
 #define GPIO_OSRR0S_P19_Pos         19           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P19             (_U(0x1) << GPIO_OSRR0S_P19_Pos)
+#define GPIO_OSRR0S_P19             (_U_(0x1) << GPIO_OSRR0S_P19_Pos)
 #define GPIO_OSRR0S_P20_Pos         20           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P20             (_U(0x1) << GPIO_OSRR0S_P20_Pos)
+#define GPIO_OSRR0S_P20             (_U_(0x1) << GPIO_OSRR0S_P20_Pos)
 #define GPIO_OSRR0S_P21_Pos         21           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P21             (_U(0x1) << GPIO_OSRR0S_P21_Pos)
+#define GPIO_OSRR0S_P21             (_U_(0x1) << GPIO_OSRR0S_P21_Pos)
 #define GPIO_OSRR0S_P22_Pos         22           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P22             (_U(0x1) << GPIO_OSRR0S_P22_Pos)
+#define GPIO_OSRR0S_P22             (_U_(0x1) << GPIO_OSRR0S_P22_Pos)
 #define GPIO_OSRR0S_P23_Pos         23           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P23             (_U(0x1) << GPIO_OSRR0S_P23_Pos)
+#define GPIO_OSRR0S_P23             (_U_(0x1) << GPIO_OSRR0S_P23_Pos)
 #define GPIO_OSRR0S_P24_Pos         24           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P24             (_U(0x1) << GPIO_OSRR0S_P24_Pos)
+#define GPIO_OSRR0S_P24             (_U_(0x1) << GPIO_OSRR0S_P24_Pos)
 #define GPIO_OSRR0S_P25_Pos         25           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P25             (_U(0x1) << GPIO_OSRR0S_P25_Pos)
+#define GPIO_OSRR0S_P25             (_U_(0x1) << GPIO_OSRR0S_P25_Pos)
 #define GPIO_OSRR0S_P26_Pos         26           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P26             (_U(0x1) << GPIO_OSRR0S_P26_Pos)
+#define GPIO_OSRR0S_P26             (_U_(0x1) << GPIO_OSRR0S_P26_Pos)
 #define GPIO_OSRR0S_P27_Pos         27           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P27             (_U(0x1) << GPIO_OSRR0S_P27_Pos)
+#define GPIO_OSRR0S_P27             (_U_(0x1) << GPIO_OSRR0S_P27_Pos)
 #define GPIO_OSRR0S_P28_Pos         28           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P28             (_U(0x1) << GPIO_OSRR0S_P28_Pos)
+#define GPIO_OSRR0S_P28             (_U_(0x1) << GPIO_OSRR0S_P28_Pos)
 #define GPIO_OSRR0S_P29_Pos         29           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P29             (_U(0x1) << GPIO_OSRR0S_P29_Pos)
+#define GPIO_OSRR0S_P29             (_U_(0x1) << GPIO_OSRR0S_P29_Pos)
 #define GPIO_OSRR0S_P30_Pos         30           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P30             (_U(0x1) << GPIO_OSRR0S_P30_Pos)
+#define GPIO_OSRR0S_P30             (_U_(0x1) << GPIO_OSRR0S_P30_Pos)
 #define GPIO_OSRR0S_P31_Pos         31           /**< \brief (GPIO_OSRR0S) Output Slew Rate Control Enable */
-#define GPIO_OSRR0S_P31             (_U(0x1) << GPIO_OSRR0S_P31_Pos)
-#define GPIO_OSRR0S_MASK            _U(0xFFFFFFFF) /**< \brief (GPIO_OSRR0S) MASK Register */
+#define GPIO_OSRR0S_P31             (_U_(0x1) << GPIO_OSRR0S_P31_Pos)
+#define GPIO_OSRR0S_MASK            _U_(0xFFFFFFFF) /**< \brief (GPIO_OSRR0S) MASK Register */
 
 /* -------- GPIO_OSRR0C : (GPIO Offset: 0x138) (R/W 32) port Output Slew Rate Register 0 - Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7167,70 +7167,70 @@ typedef union {
 #define GPIO_OSRR0C_OFFSET          0x138        /**< \brief (GPIO_OSRR0C offset) Output Slew Rate Register 0 - Clear */
 
 #define GPIO_OSRR0C_P0_Pos          0            /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P0              (_U(0x1) << GPIO_OSRR0C_P0_Pos)
+#define GPIO_OSRR0C_P0              (_U_(0x1) << GPIO_OSRR0C_P0_Pos)
 #define GPIO_OSRR0C_P1_Pos          1            /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P1              (_U(0x1) << GPIO_OSRR0C_P1_Pos)
+#define GPIO_OSRR0C_P1              (_U_(0x1) << GPIO_OSRR0C_P1_Pos)
 #define GPIO_OSRR0C_P2_Pos          2            /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P2              (_U(0x1) << GPIO_OSRR0C_P2_Pos)
+#define GPIO_OSRR0C_P2              (_U_(0x1) << GPIO_OSRR0C_P2_Pos)
 #define GPIO_OSRR0C_P3_Pos          3            /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P3              (_U(0x1) << GPIO_OSRR0C_P3_Pos)
+#define GPIO_OSRR0C_P3              (_U_(0x1) << GPIO_OSRR0C_P3_Pos)
 #define GPIO_OSRR0C_P4_Pos          4            /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P4              (_U(0x1) << GPIO_OSRR0C_P4_Pos)
+#define GPIO_OSRR0C_P4              (_U_(0x1) << GPIO_OSRR0C_P4_Pos)
 #define GPIO_OSRR0C_P5_Pos          5            /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P5              (_U(0x1) << GPIO_OSRR0C_P5_Pos)
+#define GPIO_OSRR0C_P5              (_U_(0x1) << GPIO_OSRR0C_P5_Pos)
 #define GPIO_OSRR0C_P6_Pos          6            /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P6              (_U(0x1) << GPIO_OSRR0C_P6_Pos)
+#define GPIO_OSRR0C_P6              (_U_(0x1) << GPIO_OSRR0C_P6_Pos)
 #define GPIO_OSRR0C_P7_Pos          7            /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P7              (_U(0x1) << GPIO_OSRR0C_P7_Pos)
+#define GPIO_OSRR0C_P7              (_U_(0x1) << GPIO_OSRR0C_P7_Pos)
 #define GPIO_OSRR0C_P8_Pos          8            /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P8              (_U(0x1) << GPIO_OSRR0C_P8_Pos)
+#define GPIO_OSRR0C_P8              (_U_(0x1) << GPIO_OSRR0C_P8_Pos)
 #define GPIO_OSRR0C_P9_Pos          9            /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P9              (_U(0x1) << GPIO_OSRR0C_P9_Pos)
+#define GPIO_OSRR0C_P9              (_U_(0x1) << GPIO_OSRR0C_P9_Pos)
 #define GPIO_OSRR0C_P10_Pos         10           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P10             (_U(0x1) << GPIO_OSRR0C_P10_Pos)
+#define GPIO_OSRR0C_P10             (_U_(0x1) << GPIO_OSRR0C_P10_Pos)
 #define GPIO_OSRR0C_P11_Pos         11           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P11             (_U(0x1) << GPIO_OSRR0C_P11_Pos)
+#define GPIO_OSRR0C_P11             (_U_(0x1) << GPIO_OSRR0C_P11_Pos)
 #define GPIO_OSRR0C_P12_Pos         12           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P12             (_U(0x1) << GPIO_OSRR0C_P12_Pos)
+#define GPIO_OSRR0C_P12             (_U_(0x1) << GPIO_OSRR0C_P12_Pos)
 #define GPIO_OSRR0C_P13_Pos         13           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P13             (_U(0x1) << GPIO_OSRR0C_P13_Pos)
+#define GPIO_OSRR0C_P13             (_U_(0x1) << GPIO_OSRR0C_P13_Pos)
 #define GPIO_OSRR0C_P14_Pos         14           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P14             (_U(0x1) << GPIO_OSRR0C_P14_Pos)
+#define GPIO_OSRR0C_P14             (_U_(0x1) << GPIO_OSRR0C_P14_Pos)
 #define GPIO_OSRR0C_P15_Pos         15           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P15             (_U(0x1) << GPIO_OSRR0C_P15_Pos)
+#define GPIO_OSRR0C_P15             (_U_(0x1) << GPIO_OSRR0C_P15_Pos)
 #define GPIO_OSRR0C_P16_Pos         16           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P16             (_U(0x1) << GPIO_OSRR0C_P16_Pos)
+#define GPIO_OSRR0C_P16             (_U_(0x1) << GPIO_OSRR0C_P16_Pos)
 #define GPIO_OSRR0C_P17_Pos         17           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P17             (_U(0x1) << GPIO_OSRR0C_P17_Pos)
+#define GPIO_OSRR0C_P17             (_U_(0x1) << GPIO_OSRR0C_P17_Pos)
 #define GPIO_OSRR0C_P18_Pos         18           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P18             (_U(0x1) << GPIO_OSRR0C_P18_Pos)
+#define GPIO_OSRR0C_P18             (_U_(0x1) << GPIO_OSRR0C_P18_Pos)
 #define GPIO_OSRR0C_P19_Pos         19           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P19             (_U(0x1) << GPIO_OSRR0C_P19_Pos)
+#define GPIO_OSRR0C_P19             (_U_(0x1) << GPIO_OSRR0C_P19_Pos)
 #define GPIO_OSRR0C_P20_Pos         20           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P20             (_U(0x1) << GPIO_OSRR0C_P20_Pos)
+#define GPIO_OSRR0C_P20             (_U_(0x1) << GPIO_OSRR0C_P20_Pos)
 #define GPIO_OSRR0C_P21_Pos         21           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P21             (_U(0x1) << GPIO_OSRR0C_P21_Pos)
+#define GPIO_OSRR0C_P21             (_U_(0x1) << GPIO_OSRR0C_P21_Pos)
 #define GPIO_OSRR0C_P22_Pos         22           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P22             (_U(0x1) << GPIO_OSRR0C_P22_Pos)
+#define GPIO_OSRR0C_P22             (_U_(0x1) << GPIO_OSRR0C_P22_Pos)
 #define GPIO_OSRR0C_P23_Pos         23           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P23             (_U(0x1) << GPIO_OSRR0C_P23_Pos)
+#define GPIO_OSRR0C_P23             (_U_(0x1) << GPIO_OSRR0C_P23_Pos)
 #define GPIO_OSRR0C_P24_Pos         24           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P24             (_U(0x1) << GPIO_OSRR0C_P24_Pos)
+#define GPIO_OSRR0C_P24             (_U_(0x1) << GPIO_OSRR0C_P24_Pos)
 #define GPIO_OSRR0C_P25_Pos         25           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P25             (_U(0x1) << GPIO_OSRR0C_P25_Pos)
+#define GPIO_OSRR0C_P25             (_U_(0x1) << GPIO_OSRR0C_P25_Pos)
 #define GPIO_OSRR0C_P26_Pos         26           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P26             (_U(0x1) << GPIO_OSRR0C_P26_Pos)
+#define GPIO_OSRR0C_P26             (_U_(0x1) << GPIO_OSRR0C_P26_Pos)
 #define GPIO_OSRR0C_P27_Pos         27           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P27             (_U(0x1) << GPIO_OSRR0C_P27_Pos)
+#define GPIO_OSRR0C_P27             (_U_(0x1) << GPIO_OSRR0C_P27_Pos)
 #define GPIO_OSRR0C_P28_Pos         28           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P28             (_U(0x1) << GPIO_OSRR0C_P28_Pos)
+#define GPIO_OSRR0C_P28             (_U_(0x1) << GPIO_OSRR0C_P28_Pos)
 #define GPIO_OSRR0C_P29_Pos         29           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P29             (_U(0x1) << GPIO_OSRR0C_P29_Pos)
+#define GPIO_OSRR0C_P29             (_U_(0x1) << GPIO_OSRR0C_P29_Pos)
 #define GPIO_OSRR0C_P30_Pos         30           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P30             (_U(0x1) << GPIO_OSRR0C_P30_Pos)
+#define GPIO_OSRR0C_P30             (_U_(0x1) << GPIO_OSRR0C_P30_Pos)
 #define GPIO_OSRR0C_P31_Pos         31           /**< \brief (GPIO_OSRR0C) Output Slew Rate Control Enable */
-#define GPIO_OSRR0C_P31             (_U(0x1) << GPIO_OSRR0C_P31_Pos)
-#define GPIO_OSRR0C_MASK            _U(0xFFFFFFFF) /**< \brief (GPIO_OSRR0C) MASK Register */
+#define GPIO_OSRR0C_P31             (_U_(0x1) << GPIO_OSRR0C_P31_Pos)
+#define GPIO_OSRR0C_MASK            _U_(0xFFFFFFFF) /**< \brief (GPIO_OSRR0C) MASK Register */
 
 /* -------- GPIO_OSRR0T : (GPIO Offset: 0x13C) (R/W 32) port Output Slew Rate Register 0 - Toggle -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7276,70 +7276,70 @@ typedef union {
 #define GPIO_OSRR0T_OFFSET          0x13C        /**< \brief (GPIO_OSRR0T offset) Output Slew Rate Register 0 - Toggle */
 
 #define GPIO_OSRR0T_P0_Pos          0            /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P0              (_U(0x1) << GPIO_OSRR0T_P0_Pos)
+#define GPIO_OSRR0T_P0              (_U_(0x1) << GPIO_OSRR0T_P0_Pos)
 #define GPIO_OSRR0T_P1_Pos          1            /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P1              (_U(0x1) << GPIO_OSRR0T_P1_Pos)
+#define GPIO_OSRR0T_P1              (_U_(0x1) << GPIO_OSRR0T_P1_Pos)
 #define GPIO_OSRR0T_P2_Pos          2            /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P2              (_U(0x1) << GPIO_OSRR0T_P2_Pos)
+#define GPIO_OSRR0T_P2              (_U_(0x1) << GPIO_OSRR0T_P2_Pos)
 #define GPIO_OSRR0T_P3_Pos          3            /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P3              (_U(0x1) << GPIO_OSRR0T_P3_Pos)
+#define GPIO_OSRR0T_P3              (_U_(0x1) << GPIO_OSRR0T_P3_Pos)
 #define GPIO_OSRR0T_P4_Pos          4            /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P4              (_U(0x1) << GPIO_OSRR0T_P4_Pos)
+#define GPIO_OSRR0T_P4              (_U_(0x1) << GPIO_OSRR0T_P4_Pos)
 #define GPIO_OSRR0T_P5_Pos          5            /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P5              (_U(0x1) << GPIO_OSRR0T_P5_Pos)
+#define GPIO_OSRR0T_P5              (_U_(0x1) << GPIO_OSRR0T_P5_Pos)
 #define GPIO_OSRR0T_P6_Pos          6            /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P6              (_U(0x1) << GPIO_OSRR0T_P6_Pos)
+#define GPIO_OSRR0T_P6              (_U_(0x1) << GPIO_OSRR0T_P6_Pos)
 #define GPIO_OSRR0T_P7_Pos          7            /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P7              (_U(0x1) << GPIO_OSRR0T_P7_Pos)
+#define GPIO_OSRR0T_P7              (_U_(0x1) << GPIO_OSRR0T_P7_Pos)
 #define GPIO_OSRR0T_P8_Pos          8            /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P8              (_U(0x1) << GPIO_OSRR0T_P8_Pos)
+#define GPIO_OSRR0T_P8              (_U_(0x1) << GPIO_OSRR0T_P8_Pos)
 #define GPIO_OSRR0T_P9_Pos          9            /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P9              (_U(0x1) << GPIO_OSRR0T_P9_Pos)
+#define GPIO_OSRR0T_P9              (_U_(0x1) << GPIO_OSRR0T_P9_Pos)
 #define GPIO_OSRR0T_P10_Pos         10           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P10             (_U(0x1) << GPIO_OSRR0T_P10_Pos)
+#define GPIO_OSRR0T_P10             (_U_(0x1) << GPIO_OSRR0T_P10_Pos)
 #define GPIO_OSRR0T_P11_Pos         11           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P11             (_U(0x1) << GPIO_OSRR0T_P11_Pos)
+#define GPIO_OSRR0T_P11             (_U_(0x1) << GPIO_OSRR0T_P11_Pos)
 #define GPIO_OSRR0T_P12_Pos         12           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P12             (_U(0x1) << GPIO_OSRR0T_P12_Pos)
+#define GPIO_OSRR0T_P12             (_U_(0x1) << GPIO_OSRR0T_P12_Pos)
 #define GPIO_OSRR0T_P13_Pos         13           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P13             (_U(0x1) << GPIO_OSRR0T_P13_Pos)
+#define GPIO_OSRR0T_P13             (_U_(0x1) << GPIO_OSRR0T_P13_Pos)
 #define GPIO_OSRR0T_P14_Pos         14           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P14             (_U(0x1) << GPIO_OSRR0T_P14_Pos)
+#define GPIO_OSRR0T_P14             (_U_(0x1) << GPIO_OSRR0T_P14_Pos)
 #define GPIO_OSRR0T_P15_Pos         15           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P15             (_U(0x1) << GPIO_OSRR0T_P15_Pos)
+#define GPIO_OSRR0T_P15             (_U_(0x1) << GPIO_OSRR0T_P15_Pos)
 #define GPIO_OSRR0T_P16_Pos         16           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P16             (_U(0x1) << GPIO_OSRR0T_P16_Pos)
+#define GPIO_OSRR0T_P16             (_U_(0x1) << GPIO_OSRR0T_P16_Pos)
 #define GPIO_OSRR0T_P17_Pos         17           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P17             (_U(0x1) << GPIO_OSRR0T_P17_Pos)
+#define GPIO_OSRR0T_P17             (_U_(0x1) << GPIO_OSRR0T_P17_Pos)
 #define GPIO_OSRR0T_P18_Pos         18           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P18             (_U(0x1) << GPIO_OSRR0T_P18_Pos)
+#define GPIO_OSRR0T_P18             (_U_(0x1) << GPIO_OSRR0T_P18_Pos)
 #define GPIO_OSRR0T_P19_Pos         19           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P19             (_U(0x1) << GPIO_OSRR0T_P19_Pos)
+#define GPIO_OSRR0T_P19             (_U_(0x1) << GPIO_OSRR0T_P19_Pos)
 #define GPIO_OSRR0T_P20_Pos         20           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P20             (_U(0x1) << GPIO_OSRR0T_P20_Pos)
+#define GPIO_OSRR0T_P20             (_U_(0x1) << GPIO_OSRR0T_P20_Pos)
 #define GPIO_OSRR0T_P21_Pos         21           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P21             (_U(0x1) << GPIO_OSRR0T_P21_Pos)
+#define GPIO_OSRR0T_P21             (_U_(0x1) << GPIO_OSRR0T_P21_Pos)
 #define GPIO_OSRR0T_P22_Pos         22           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P22             (_U(0x1) << GPIO_OSRR0T_P22_Pos)
+#define GPIO_OSRR0T_P22             (_U_(0x1) << GPIO_OSRR0T_P22_Pos)
 #define GPIO_OSRR0T_P23_Pos         23           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P23             (_U(0x1) << GPIO_OSRR0T_P23_Pos)
+#define GPIO_OSRR0T_P23             (_U_(0x1) << GPIO_OSRR0T_P23_Pos)
 #define GPIO_OSRR0T_P24_Pos         24           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P24             (_U(0x1) << GPIO_OSRR0T_P24_Pos)
+#define GPIO_OSRR0T_P24             (_U_(0x1) << GPIO_OSRR0T_P24_Pos)
 #define GPIO_OSRR0T_P25_Pos         25           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P25             (_U(0x1) << GPIO_OSRR0T_P25_Pos)
+#define GPIO_OSRR0T_P25             (_U_(0x1) << GPIO_OSRR0T_P25_Pos)
 #define GPIO_OSRR0T_P26_Pos         26           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P26             (_U(0x1) << GPIO_OSRR0T_P26_Pos)
+#define GPIO_OSRR0T_P26             (_U_(0x1) << GPIO_OSRR0T_P26_Pos)
 #define GPIO_OSRR0T_P27_Pos         27           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P27             (_U(0x1) << GPIO_OSRR0T_P27_Pos)
+#define GPIO_OSRR0T_P27             (_U_(0x1) << GPIO_OSRR0T_P27_Pos)
 #define GPIO_OSRR0T_P28_Pos         28           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P28             (_U(0x1) << GPIO_OSRR0T_P28_Pos)
+#define GPIO_OSRR0T_P28             (_U_(0x1) << GPIO_OSRR0T_P28_Pos)
 #define GPIO_OSRR0T_P29_Pos         29           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P29             (_U(0x1) << GPIO_OSRR0T_P29_Pos)
+#define GPIO_OSRR0T_P29             (_U_(0x1) << GPIO_OSRR0T_P29_Pos)
 #define GPIO_OSRR0T_P30_Pos         30           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P30             (_U(0x1) << GPIO_OSRR0T_P30_Pos)
+#define GPIO_OSRR0T_P30             (_U_(0x1) << GPIO_OSRR0T_P30_Pos)
 #define GPIO_OSRR0T_P31_Pos         31           /**< \brief (GPIO_OSRR0T) Output Slew Rate Control Enable */
-#define GPIO_OSRR0T_P31             (_U(0x1) << GPIO_OSRR0T_P31_Pos)
-#define GPIO_OSRR0T_MASK            _U(0xFFFFFFFF) /**< \brief (GPIO_OSRR0T) MASK Register */
+#define GPIO_OSRR0T_P31             (_U_(0x1) << GPIO_OSRR0T_P31_Pos)
+#define GPIO_OSRR0T_MASK            _U_(0xFFFFFFFF) /**< \brief (GPIO_OSRR0T) MASK Register */
 
 /* -------- GPIO_STER : (GPIO Offset: 0x160) (R/W 32) port Schmitt Trigger Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7385,70 +7385,70 @@ typedef union {
 #define GPIO_STER_OFFSET            0x160        /**< \brief (GPIO_STER offset) Schmitt Trigger Enable Register */
 
 #define GPIO_STER_P0_Pos            0            /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P0                (_U(0x1) << GPIO_STER_P0_Pos)
+#define GPIO_STER_P0                (_U_(0x1) << GPIO_STER_P0_Pos)
 #define GPIO_STER_P1_Pos            1            /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P1                (_U(0x1) << GPIO_STER_P1_Pos)
+#define GPIO_STER_P1                (_U_(0x1) << GPIO_STER_P1_Pos)
 #define GPIO_STER_P2_Pos            2            /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P2                (_U(0x1) << GPIO_STER_P2_Pos)
+#define GPIO_STER_P2                (_U_(0x1) << GPIO_STER_P2_Pos)
 #define GPIO_STER_P3_Pos            3            /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P3                (_U(0x1) << GPIO_STER_P3_Pos)
+#define GPIO_STER_P3                (_U_(0x1) << GPIO_STER_P3_Pos)
 #define GPIO_STER_P4_Pos            4            /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P4                (_U(0x1) << GPIO_STER_P4_Pos)
+#define GPIO_STER_P4                (_U_(0x1) << GPIO_STER_P4_Pos)
 #define GPIO_STER_P5_Pos            5            /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P5                (_U(0x1) << GPIO_STER_P5_Pos)
+#define GPIO_STER_P5                (_U_(0x1) << GPIO_STER_P5_Pos)
 #define GPIO_STER_P6_Pos            6            /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P6                (_U(0x1) << GPIO_STER_P6_Pos)
+#define GPIO_STER_P6                (_U_(0x1) << GPIO_STER_P6_Pos)
 #define GPIO_STER_P7_Pos            7            /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P7                (_U(0x1) << GPIO_STER_P7_Pos)
+#define GPIO_STER_P7                (_U_(0x1) << GPIO_STER_P7_Pos)
 #define GPIO_STER_P8_Pos            8            /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P8                (_U(0x1) << GPIO_STER_P8_Pos)
+#define GPIO_STER_P8                (_U_(0x1) << GPIO_STER_P8_Pos)
 #define GPIO_STER_P9_Pos            9            /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P9                (_U(0x1) << GPIO_STER_P9_Pos)
+#define GPIO_STER_P9                (_U_(0x1) << GPIO_STER_P9_Pos)
 #define GPIO_STER_P10_Pos           10           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P10               (_U(0x1) << GPIO_STER_P10_Pos)
+#define GPIO_STER_P10               (_U_(0x1) << GPIO_STER_P10_Pos)
 #define GPIO_STER_P11_Pos           11           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P11               (_U(0x1) << GPIO_STER_P11_Pos)
+#define GPIO_STER_P11               (_U_(0x1) << GPIO_STER_P11_Pos)
 #define GPIO_STER_P12_Pos           12           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P12               (_U(0x1) << GPIO_STER_P12_Pos)
+#define GPIO_STER_P12               (_U_(0x1) << GPIO_STER_P12_Pos)
 #define GPIO_STER_P13_Pos           13           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P13               (_U(0x1) << GPIO_STER_P13_Pos)
+#define GPIO_STER_P13               (_U_(0x1) << GPIO_STER_P13_Pos)
 #define GPIO_STER_P14_Pos           14           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P14               (_U(0x1) << GPIO_STER_P14_Pos)
+#define GPIO_STER_P14               (_U_(0x1) << GPIO_STER_P14_Pos)
 #define GPIO_STER_P15_Pos           15           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P15               (_U(0x1) << GPIO_STER_P15_Pos)
+#define GPIO_STER_P15               (_U_(0x1) << GPIO_STER_P15_Pos)
 #define GPIO_STER_P16_Pos           16           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P16               (_U(0x1) << GPIO_STER_P16_Pos)
+#define GPIO_STER_P16               (_U_(0x1) << GPIO_STER_P16_Pos)
 #define GPIO_STER_P17_Pos           17           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P17               (_U(0x1) << GPIO_STER_P17_Pos)
+#define GPIO_STER_P17               (_U_(0x1) << GPIO_STER_P17_Pos)
 #define GPIO_STER_P18_Pos           18           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P18               (_U(0x1) << GPIO_STER_P18_Pos)
+#define GPIO_STER_P18               (_U_(0x1) << GPIO_STER_P18_Pos)
 #define GPIO_STER_P19_Pos           19           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P19               (_U(0x1) << GPIO_STER_P19_Pos)
+#define GPIO_STER_P19               (_U_(0x1) << GPIO_STER_P19_Pos)
 #define GPIO_STER_P20_Pos           20           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P20               (_U(0x1) << GPIO_STER_P20_Pos)
+#define GPIO_STER_P20               (_U_(0x1) << GPIO_STER_P20_Pos)
 #define GPIO_STER_P21_Pos           21           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P21               (_U(0x1) << GPIO_STER_P21_Pos)
+#define GPIO_STER_P21               (_U_(0x1) << GPIO_STER_P21_Pos)
 #define GPIO_STER_P22_Pos           22           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P22               (_U(0x1) << GPIO_STER_P22_Pos)
+#define GPIO_STER_P22               (_U_(0x1) << GPIO_STER_P22_Pos)
 #define GPIO_STER_P23_Pos           23           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P23               (_U(0x1) << GPIO_STER_P23_Pos)
+#define GPIO_STER_P23               (_U_(0x1) << GPIO_STER_P23_Pos)
 #define GPIO_STER_P24_Pos           24           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P24               (_U(0x1) << GPIO_STER_P24_Pos)
+#define GPIO_STER_P24               (_U_(0x1) << GPIO_STER_P24_Pos)
 #define GPIO_STER_P25_Pos           25           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P25               (_U(0x1) << GPIO_STER_P25_Pos)
+#define GPIO_STER_P25               (_U_(0x1) << GPIO_STER_P25_Pos)
 #define GPIO_STER_P26_Pos           26           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P26               (_U(0x1) << GPIO_STER_P26_Pos)
+#define GPIO_STER_P26               (_U_(0x1) << GPIO_STER_P26_Pos)
 #define GPIO_STER_P27_Pos           27           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P27               (_U(0x1) << GPIO_STER_P27_Pos)
+#define GPIO_STER_P27               (_U_(0x1) << GPIO_STER_P27_Pos)
 #define GPIO_STER_P28_Pos           28           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P28               (_U(0x1) << GPIO_STER_P28_Pos)
+#define GPIO_STER_P28               (_U_(0x1) << GPIO_STER_P28_Pos)
 #define GPIO_STER_P29_Pos           29           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P29               (_U(0x1) << GPIO_STER_P29_Pos)
+#define GPIO_STER_P29               (_U_(0x1) << GPIO_STER_P29_Pos)
 #define GPIO_STER_P30_Pos           30           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P30               (_U(0x1) << GPIO_STER_P30_Pos)
+#define GPIO_STER_P30               (_U_(0x1) << GPIO_STER_P30_Pos)
 #define GPIO_STER_P31_Pos           31           /**< \brief (GPIO_STER) Schmitt Trigger Enable */
-#define GPIO_STER_P31               (_U(0x1) << GPIO_STER_P31_Pos)
-#define GPIO_STER_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_STER) MASK Register */
+#define GPIO_STER_P31               (_U_(0x1) << GPIO_STER_P31_Pos)
+#define GPIO_STER_MASK              _U_(0xFFFFFFFF) /**< \brief (GPIO_STER) MASK Register */
 
 /* -------- GPIO_STERS : (GPIO Offset: 0x164) (R/W 32) port Schmitt Trigger Enable Register - Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7494,70 +7494,70 @@ typedef union {
 #define GPIO_STERS_OFFSET           0x164        /**< \brief (GPIO_STERS offset) Schmitt Trigger Enable Register - Set */
 
 #define GPIO_STERS_P0_Pos           0            /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P0               (_U(0x1) << GPIO_STERS_P0_Pos)
+#define GPIO_STERS_P0               (_U_(0x1) << GPIO_STERS_P0_Pos)
 #define GPIO_STERS_P1_Pos           1            /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P1               (_U(0x1) << GPIO_STERS_P1_Pos)
+#define GPIO_STERS_P1               (_U_(0x1) << GPIO_STERS_P1_Pos)
 #define GPIO_STERS_P2_Pos           2            /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P2               (_U(0x1) << GPIO_STERS_P2_Pos)
+#define GPIO_STERS_P2               (_U_(0x1) << GPIO_STERS_P2_Pos)
 #define GPIO_STERS_P3_Pos           3            /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P3               (_U(0x1) << GPIO_STERS_P3_Pos)
+#define GPIO_STERS_P3               (_U_(0x1) << GPIO_STERS_P3_Pos)
 #define GPIO_STERS_P4_Pos           4            /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P4               (_U(0x1) << GPIO_STERS_P4_Pos)
+#define GPIO_STERS_P4               (_U_(0x1) << GPIO_STERS_P4_Pos)
 #define GPIO_STERS_P5_Pos           5            /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P5               (_U(0x1) << GPIO_STERS_P5_Pos)
+#define GPIO_STERS_P5               (_U_(0x1) << GPIO_STERS_P5_Pos)
 #define GPIO_STERS_P6_Pos           6            /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P6               (_U(0x1) << GPIO_STERS_P6_Pos)
+#define GPIO_STERS_P6               (_U_(0x1) << GPIO_STERS_P6_Pos)
 #define GPIO_STERS_P7_Pos           7            /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P7               (_U(0x1) << GPIO_STERS_P7_Pos)
+#define GPIO_STERS_P7               (_U_(0x1) << GPIO_STERS_P7_Pos)
 #define GPIO_STERS_P8_Pos           8            /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P8               (_U(0x1) << GPIO_STERS_P8_Pos)
+#define GPIO_STERS_P8               (_U_(0x1) << GPIO_STERS_P8_Pos)
 #define GPIO_STERS_P9_Pos           9            /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P9               (_U(0x1) << GPIO_STERS_P9_Pos)
+#define GPIO_STERS_P9               (_U_(0x1) << GPIO_STERS_P9_Pos)
 #define GPIO_STERS_P10_Pos          10           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P10              (_U(0x1) << GPIO_STERS_P10_Pos)
+#define GPIO_STERS_P10              (_U_(0x1) << GPIO_STERS_P10_Pos)
 #define GPIO_STERS_P11_Pos          11           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P11              (_U(0x1) << GPIO_STERS_P11_Pos)
+#define GPIO_STERS_P11              (_U_(0x1) << GPIO_STERS_P11_Pos)
 #define GPIO_STERS_P12_Pos          12           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P12              (_U(0x1) << GPIO_STERS_P12_Pos)
+#define GPIO_STERS_P12              (_U_(0x1) << GPIO_STERS_P12_Pos)
 #define GPIO_STERS_P13_Pos          13           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P13              (_U(0x1) << GPIO_STERS_P13_Pos)
+#define GPIO_STERS_P13              (_U_(0x1) << GPIO_STERS_P13_Pos)
 #define GPIO_STERS_P14_Pos          14           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P14              (_U(0x1) << GPIO_STERS_P14_Pos)
+#define GPIO_STERS_P14              (_U_(0x1) << GPIO_STERS_P14_Pos)
 #define GPIO_STERS_P15_Pos          15           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P15              (_U(0x1) << GPIO_STERS_P15_Pos)
+#define GPIO_STERS_P15              (_U_(0x1) << GPIO_STERS_P15_Pos)
 #define GPIO_STERS_P16_Pos          16           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P16              (_U(0x1) << GPIO_STERS_P16_Pos)
+#define GPIO_STERS_P16              (_U_(0x1) << GPIO_STERS_P16_Pos)
 #define GPIO_STERS_P17_Pos          17           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P17              (_U(0x1) << GPIO_STERS_P17_Pos)
+#define GPIO_STERS_P17              (_U_(0x1) << GPIO_STERS_P17_Pos)
 #define GPIO_STERS_P18_Pos          18           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P18              (_U(0x1) << GPIO_STERS_P18_Pos)
+#define GPIO_STERS_P18              (_U_(0x1) << GPIO_STERS_P18_Pos)
 #define GPIO_STERS_P19_Pos          19           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P19              (_U(0x1) << GPIO_STERS_P19_Pos)
+#define GPIO_STERS_P19              (_U_(0x1) << GPIO_STERS_P19_Pos)
 #define GPIO_STERS_P20_Pos          20           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P20              (_U(0x1) << GPIO_STERS_P20_Pos)
+#define GPIO_STERS_P20              (_U_(0x1) << GPIO_STERS_P20_Pos)
 #define GPIO_STERS_P21_Pos          21           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P21              (_U(0x1) << GPIO_STERS_P21_Pos)
+#define GPIO_STERS_P21              (_U_(0x1) << GPIO_STERS_P21_Pos)
 #define GPIO_STERS_P22_Pos          22           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P22              (_U(0x1) << GPIO_STERS_P22_Pos)
+#define GPIO_STERS_P22              (_U_(0x1) << GPIO_STERS_P22_Pos)
 #define GPIO_STERS_P23_Pos          23           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P23              (_U(0x1) << GPIO_STERS_P23_Pos)
+#define GPIO_STERS_P23              (_U_(0x1) << GPIO_STERS_P23_Pos)
 #define GPIO_STERS_P24_Pos          24           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P24              (_U(0x1) << GPIO_STERS_P24_Pos)
+#define GPIO_STERS_P24              (_U_(0x1) << GPIO_STERS_P24_Pos)
 #define GPIO_STERS_P25_Pos          25           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P25              (_U(0x1) << GPIO_STERS_P25_Pos)
+#define GPIO_STERS_P25              (_U_(0x1) << GPIO_STERS_P25_Pos)
 #define GPIO_STERS_P26_Pos          26           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P26              (_U(0x1) << GPIO_STERS_P26_Pos)
+#define GPIO_STERS_P26              (_U_(0x1) << GPIO_STERS_P26_Pos)
 #define GPIO_STERS_P27_Pos          27           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P27              (_U(0x1) << GPIO_STERS_P27_Pos)
+#define GPIO_STERS_P27              (_U_(0x1) << GPIO_STERS_P27_Pos)
 #define GPIO_STERS_P28_Pos          28           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P28              (_U(0x1) << GPIO_STERS_P28_Pos)
+#define GPIO_STERS_P28              (_U_(0x1) << GPIO_STERS_P28_Pos)
 #define GPIO_STERS_P29_Pos          29           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P29              (_U(0x1) << GPIO_STERS_P29_Pos)
+#define GPIO_STERS_P29              (_U_(0x1) << GPIO_STERS_P29_Pos)
 #define GPIO_STERS_P30_Pos          30           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P30              (_U(0x1) << GPIO_STERS_P30_Pos)
+#define GPIO_STERS_P30              (_U_(0x1) << GPIO_STERS_P30_Pos)
 #define GPIO_STERS_P31_Pos          31           /**< \brief (GPIO_STERS) Schmitt Trigger Enable */
-#define GPIO_STERS_P31              (_U(0x1) << GPIO_STERS_P31_Pos)
-#define GPIO_STERS_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_STERS) MASK Register */
+#define GPIO_STERS_P31              (_U_(0x1) << GPIO_STERS_P31_Pos)
+#define GPIO_STERS_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_STERS) MASK Register */
 
 /* -------- GPIO_STERC : (GPIO Offset: 0x168) (R/W 32) port Schmitt Trigger Enable Register - Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7603,70 +7603,70 @@ typedef union {
 #define GPIO_STERC_OFFSET           0x168        /**< \brief (GPIO_STERC offset) Schmitt Trigger Enable Register - Clear */
 
 #define GPIO_STERC_P0_Pos           0            /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P0               (_U(0x1) << GPIO_STERC_P0_Pos)
+#define GPIO_STERC_P0               (_U_(0x1) << GPIO_STERC_P0_Pos)
 #define GPIO_STERC_P1_Pos           1            /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P1               (_U(0x1) << GPIO_STERC_P1_Pos)
+#define GPIO_STERC_P1               (_U_(0x1) << GPIO_STERC_P1_Pos)
 #define GPIO_STERC_P2_Pos           2            /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P2               (_U(0x1) << GPIO_STERC_P2_Pos)
+#define GPIO_STERC_P2               (_U_(0x1) << GPIO_STERC_P2_Pos)
 #define GPIO_STERC_P3_Pos           3            /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P3               (_U(0x1) << GPIO_STERC_P3_Pos)
+#define GPIO_STERC_P3               (_U_(0x1) << GPIO_STERC_P3_Pos)
 #define GPIO_STERC_P4_Pos           4            /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P4               (_U(0x1) << GPIO_STERC_P4_Pos)
+#define GPIO_STERC_P4               (_U_(0x1) << GPIO_STERC_P4_Pos)
 #define GPIO_STERC_P5_Pos           5            /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P5               (_U(0x1) << GPIO_STERC_P5_Pos)
+#define GPIO_STERC_P5               (_U_(0x1) << GPIO_STERC_P5_Pos)
 #define GPIO_STERC_P6_Pos           6            /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P6               (_U(0x1) << GPIO_STERC_P6_Pos)
+#define GPIO_STERC_P6               (_U_(0x1) << GPIO_STERC_P6_Pos)
 #define GPIO_STERC_P7_Pos           7            /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P7               (_U(0x1) << GPIO_STERC_P7_Pos)
+#define GPIO_STERC_P7               (_U_(0x1) << GPIO_STERC_P7_Pos)
 #define GPIO_STERC_P8_Pos           8            /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P8               (_U(0x1) << GPIO_STERC_P8_Pos)
+#define GPIO_STERC_P8               (_U_(0x1) << GPIO_STERC_P8_Pos)
 #define GPIO_STERC_P9_Pos           9            /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P9               (_U(0x1) << GPIO_STERC_P9_Pos)
+#define GPIO_STERC_P9               (_U_(0x1) << GPIO_STERC_P9_Pos)
 #define GPIO_STERC_P10_Pos          10           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P10              (_U(0x1) << GPIO_STERC_P10_Pos)
+#define GPIO_STERC_P10              (_U_(0x1) << GPIO_STERC_P10_Pos)
 #define GPIO_STERC_P11_Pos          11           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P11              (_U(0x1) << GPIO_STERC_P11_Pos)
+#define GPIO_STERC_P11              (_U_(0x1) << GPIO_STERC_P11_Pos)
 #define GPIO_STERC_P12_Pos          12           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P12              (_U(0x1) << GPIO_STERC_P12_Pos)
+#define GPIO_STERC_P12              (_U_(0x1) << GPIO_STERC_P12_Pos)
 #define GPIO_STERC_P13_Pos          13           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P13              (_U(0x1) << GPIO_STERC_P13_Pos)
+#define GPIO_STERC_P13              (_U_(0x1) << GPIO_STERC_P13_Pos)
 #define GPIO_STERC_P14_Pos          14           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P14              (_U(0x1) << GPIO_STERC_P14_Pos)
+#define GPIO_STERC_P14              (_U_(0x1) << GPIO_STERC_P14_Pos)
 #define GPIO_STERC_P15_Pos          15           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P15              (_U(0x1) << GPIO_STERC_P15_Pos)
+#define GPIO_STERC_P15              (_U_(0x1) << GPIO_STERC_P15_Pos)
 #define GPIO_STERC_P16_Pos          16           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P16              (_U(0x1) << GPIO_STERC_P16_Pos)
+#define GPIO_STERC_P16              (_U_(0x1) << GPIO_STERC_P16_Pos)
 #define GPIO_STERC_P17_Pos          17           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P17              (_U(0x1) << GPIO_STERC_P17_Pos)
+#define GPIO_STERC_P17              (_U_(0x1) << GPIO_STERC_P17_Pos)
 #define GPIO_STERC_P18_Pos          18           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P18              (_U(0x1) << GPIO_STERC_P18_Pos)
+#define GPIO_STERC_P18              (_U_(0x1) << GPIO_STERC_P18_Pos)
 #define GPIO_STERC_P19_Pos          19           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P19              (_U(0x1) << GPIO_STERC_P19_Pos)
+#define GPIO_STERC_P19              (_U_(0x1) << GPIO_STERC_P19_Pos)
 #define GPIO_STERC_P20_Pos          20           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P20              (_U(0x1) << GPIO_STERC_P20_Pos)
+#define GPIO_STERC_P20              (_U_(0x1) << GPIO_STERC_P20_Pos)
 #define GPIO_STERC_P21_Pos          21           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P21              (_U(0x1) << GPIO_STERC_P21_Pos)
+#define GPIO_STERC_P21              (_U_(0x1) << GPIO_STERC_P21_Pos)
 #define GPIO_STERC_P22_Pos          22           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P22              (_U(0x1) << GPIO_STERC_P22_Pos)
+#define GPIO_STERC_P22              (_U_(0x1) << GPIO_STERC_P22_Pos)
 #define GPIO_STERC_P23_Pos          23           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P23              (_U(0x1) << GPIO_STERC_P23_Pos)
+#define GPIO_STERC_P23              (_U_(0x1) << GPIO_STERC_P23_Pos)
 #define GPIO_STERC_P24_Pos          24           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P24              (_U(0x1) << GPIO_STERC_P24_Pos)
+#define GPIO_STERC_P24              (_U_(0x1) << GPIO_STERC_P24_Pos)
 #define GPIO_STERC_P25_Pos          25           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P25              (_U(0x1) << GPIO_STERC_P25_Pos)
+#define GPIO_STERC_P25              (_U_(0x1) << GPIO_STERC_P25_Pos)
 #define GPIO_STERC_P26_Pos          26           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P26              (_U(0x1) << GPIO_STERC_P26_Pos)
+#define GPIO_STERC_P26              (_U_(0x1) << GPIO_STERC_P26_Pos)
 #define GPIO_STERC_P27_Pos          27           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P27              (_U(0x1) << GPIO_STERC_P27_Pos)
+#define GPIO_STERC_P27              (_U_(0x1) << GPIO_STERC_P27_Pos)
 #define GPIO_STERC_P28_Pos          28           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P28              (_U(0x1) << GPIO_STERC_P28_Pos)
+#define GPIO_STERC_P28              (_U_(0x1) << GPIO_STERC_P28_Pos)
 #define GPIO_STERC_P29_Pos          29           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P29              (_U(0x1) << GPIO_STERC_P29_Pos)
+#define GPIO_STERC_P29              (_U_(0x1) << GPIO_STERC_P29_Pos)
 #define GPIO_STERC_P30_Pos          30           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P30              (_U(0x1) << GPIO_STERC_P30_Pos)
+#define GPIO_STERC_P30              (_U_(0x1) << GPIO_STERC_P30_Pos)
 #define GPIO_STERC_P31_Pos          31           /**< \brief (GPIO_STERC) Schmitt Trigger Enable */
-#define GPIO_STERC_P31              (_U(0x1) << GPIO_STERC_P31_Pos)
-#define GPIO_STERC_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_STERC) MASK Register */
+#define GPIO_STERC_P31              (_U_(0x1) << GPIO_STERC_P31_Pos)
+#define GPIO_STERC_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_STERC) MASK Register */
 
 /* -------- GPIO_STERT : (GPIO Offset: 0x16C) (R/W 32) port Schmitt Trigger Enable Register - Toggle -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7712,70 +7712,70 @@ typedef union {
 #define GPIO_STERT_OFFSET           0x16C        /**< \brief (GPIO_STERT offset) Schmitt Trigger Enable Register - Toggle */
 
 #define GPIO_STERT_P0_Pos           0            /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P0               (_U(0x1) << GPIO_STERT_P0_Pos)
+#define GPIO_STERT_P0               (_U_(0x1) << GPIO_STERT_P0_Pos)
 #define GPIO_STERT_P1_Pos           1            /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P1               (_U(0x1) << GPIO_STERT_P1_Pos)
+#define GPIO_STERT_P1               (_U_(0x1) << GPIO_STERT_P1_Pos)
 #define GPIO_STERT_P2_Pos           2            /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P2               (_U(0x1) << GPIO_STERT_P2_Pos)
+#define GPIO_STERT_P2               (_U_(0x1) << GPIO_STERT_P2_Pos)
 #define GPIO_STERT_P3_Pos           3            /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P3               (_U(0x1) << GPIO_STERT_P3_Pos)
+#define GPIO_STERT_P3               (_U_(0x1) << GPIO_STERT_P3_Pos)
 #define GPIO_STERT_P4_Pos           4            /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P4               (_U(0x1) << GPIO_STERT_P4_Pos)
+#define GPIO_STERT_P4               (_U_(0x1) << GPIO_STERT_P4_Pos)
 #define GPIO_STERT_P5_Pos           5            /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P5               (_U(0x1) << GPIO_STERT_P5_Pos)
+#define GPIO_STERT_P5               (_U_(0x1) << GPIO_STERT_P5_Pos)
 #define GPIO_STERT_P6_Pos           6            /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P6               (_U(0x1) << GPIO_STERT_P6_Pos)
+#define GPIO_STERT_P6               (_U_(0x1) << GPIO_STERT_P6_Pos)
 #define GPIO_STERT_P7_Pos           7            /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P7               (_U(0x1) << GPIO_STERT_P7_Pos)
+#define GPIO_STERT_P7               (_U_(0x1) << GPIO_STERT_P7_Pos)
 #define GPIO_STERT_P8_Pos           8            /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P8               (_U(0x1) << GPIO_STERT_P8_Pos)
+#define GPIO_STERT_P8               (_U_(0x1) << GPIO_STERT_P8_Pos)
 #define GPIO_STERT_P9_Pos           9            /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P9               (_U(0x1) << GPIO_STERT_P9_Pos)
+#define GPIO_STERT_P9               (_U_(0x1) << GPIO_STERT_P9_Pos)
 #define GPIO_STERT_P10_Pos          10           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P10              (_U(0x1) << GPIO_STERT_P10_Pos)
+#define GPIO_STERT_P10              (_U_(0x1) << GPIO_STERT_P10_Pos)
 #define GPIO_STERT_P11_Pos          11           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P11              (_U(0x1) << GPIO_STERT_P11_Pos)
+#define GPIO_STERT_P11              (_U_(0x1) << GPIO_STERT_P11_Pos)
 #define GPIO_STERT_P12_Pos          12           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P12              (_U(0x1) << GPIO_STERT_P12_Pos)
+#define GPIO_STERT_P12              (_U_(0x1) << GPIO_STERT_P12_Pos)
 #define GPIO_STERT_P13_Pos          13           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P13              (_U(0x1) << GPIO_STERT_P13_Pos)
+#define GPIO_STERT_P13              (_U_(0x1) << GPIO_STERT_P13_Pos)
 #define GPIO_STERT_P14_Pos          14           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P14              (_U(0x1) << GPIO_STERT_P14_Pos)
+#define GPIO_STERT_P14              (_U_(0x1) << GPIO_STERT_P14_Pos)
 #define GPIO_STERT_P15_Pos          15           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P15              (_U(0x1) << GPIO_STERT_P15_Pos)
+#define GPIO_STERT_P15              (_U_(0x1) << GPIO_STERT_P15_Pos)
 #define GPIO_STERT_P16_Pos          16           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P16              (_U(0x1) << GPIO_STERT_P16_Pos)
+#define GPIO_STERT_P16              (_U_(0x1) << GPIO_STERT_P16_Pos)
 #define GPIO_STERT_P17_Pos          17           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P17              (_U(0x1) << GPIO_STERT_P17_Pos)
+#define GPIO_STERT_P17              (_U_(0x1) << GPIO_STERT_P17_Pos)
 #define GPIO_STERT_P18_Pos          18           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P18              (_U(0x1) << GPIO_STERT_P18_Pos)
+#define GPIO_STERT_P18              (_U_(0x1) << GPIO_STERT_P18_Pos)
 #define GPIO_STERT_P19_Pos          19           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P19              (_U(0x1) << GPIO_STERT_P19_Pos)
+#define GPIO_STERT_P19              (_U_(0x1) << GPIO_STERT_P19_Pos)
 #define GPIO_STERT_P20_Pos          20           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P20              (_U(0x1) << GPIO_STERT_P20_Pos)
+#define GPIO_STERT_P20              (_U_(0x1) << GPIO_STERT_P20_Pos)
 #define GPIO_STERT_P21_Pos          21           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P21              (_U(0x1) << GPIO_STERT_P21_Pos)
+#define GPIO_STERT_P21              (_U_(0x1) << GPIO_STERT_P21_Pos)
 #define GPIO_STERT_P22_Pos          22           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P22              (_U(0x1) << GPIO_STERT_P22_Pos)
+#define GPIO_STERT_P22              (_U_(0x1) << GPIO_STERT_P22_Pos)
 #define GPIO_STERT_P23_Pos          23           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P23              (_U(0x1) << GPIO_STERT_P23_Pos)
+#define GPIO_STERT_P23              (_U_(0x1) << GPIO_STERT_P23_Pos)
 #define GPIO_STERT_P24_Pos          24           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P24              (_U(0x1) << GPIO_STERT_P24_Pos)
+#define GPIO_STERT_P24              (_U_(0x1) << GPIO_STERT_P24_Pos)
 #define GPIO_STERT_P25_Pos          25           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P25              (_U(0x1) << GPIO_STERT_P25_Pos)
+#define GPIO_STERT_P25              (_U_(0x1) << GPIO_STERT_P25_Pos)
 #define GPIO_STERT_P26_Pos          26           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P26              (_U(0x1) << GPIO_STERT_P26_Pos)
+#define GPIO_STERT_P26              (_U_(0x1) << GPIO_STERT_P26_Pos)
 #define GPIO_STERT_P27_Pos          27           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P27              (_U(0x1) << GPIO_STERT_P27_Pos)
+#define GPIO_STERT_P27              (_U_(0x1) << GPIO_STERT_P27_Pos)
 #define GPIO_STERT_P28_Pos          28           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P28              (_U(0x1) << GPIO_STERT_P28_Pos)
+#define GPIO_STERT_P28              (_U_(0x1) << GPIO_STERT_P28_Pos)
 #define GPIO_STERT_P29_Pos          29           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P29              (_U(0x1) << GPIO_STERT_P29_Pos)
+#define GPIO_STERT_P29              (_U_(0x1) << GPIO_STERT_P29_Pos)
 #define GPIO_STERT_P30_Pos          30           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P30              (_U(0x1) << GPIO_STERT_P30_Pos)
+#define GPIO_STERT_P30              (_U_(0x1) << GPIO_STERT_P30_Pos)
 #define GPIO_STERT_P31_Pos          31           /**< \brief (GPIO_STERT) Schmitt Trigger Enable */
-#define GPIO_STERT_P31              (_U(0x1) << GPIO_STERT_P31_Pos)
-#define GPIO_STERT_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_STERT) MASK Register */
+#define GPIO_STERT_P31              (_U_(0x1) << GPIO_STERT_P31_Pos)
+#define GPIO_STERT_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_STERT) MASK Register */
 
 /* -------- GPIO_EVER : (GPIO Offset: 0x180) (R/W 32) port Event Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7821,70 +7821,70 @@ typedef union {
 #define GPIO_EVER_OFFSET            0x180        /**< \brief (GPIO_EVER offset) Event Enable Register */
 
 #define GPIO_EVER_P0_Pos            0            /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P0                (_U(0x1) << GPIO_EVER_P0_Pos)
+#define GPIO_EVER_P0                (_U_(0x1) << GPIO_EVER_P0_Pos)
 #define GPIO_EVER_P1_Pos            1            /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P1                (_U(0x1) << GPIO_EVER_P1_Pos)
+#define GPIO_EVER_P1                (_U_(0x1) << GPIO_EVER_P1_Pos)
 #define GPIO_EVER_P2_Pos            2            /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P2                (_U(0x1) << GPIO_EVER_P2_Pos)
+#define GPIO_EVER_P2                (_U_(0x1) << GPIO_EVER_P2_Pos)
 #define GPIO_EVER_P3_Pos            3            /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P3                (_U(0x1) << GPIO_EVER_P3_Pos)
+#define GPIO_EVER_P3                (_U_(0x1) << GPIO_EVER_P3_Pos)
 #define GPIO_EVER_P4_Pos            4            /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P4                (_U(0x1) << GPIO_EVER_P4_Pos)
+#define GPIO_EVER_P4                (_U_(0x1) << GPIO_EVER_P4_Pos)
 #define GPIO_EVER_P5_Pos            5            /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P5                (_U(0x1) << GPIO_EVER_P5_Pos)
+#define GPIO_EVER_P5                (_U_(0x1) << GPIO_EVER_P5_Pos)
 #define GPIO_EVER_P6_Pos            6            /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P6                (_U(0x1) << GPIO_EVER_P6_Pos)
+#define GPIO_EVER_P6                (_U_(0x1) << GPIO_EVER_P6_Pos)
 #define GPIO_EVER_P7_Pos            7            /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P7                (_U(0x1) << GPIO_EVER_P7_Pos)
+#define GPIO_EVER_P7                (_U_(0x1) << GPIO_EVER_P7_Pos)
 #define GPIO_EVER_P8_Pos            8            /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P8                (_U(0x1) << GPIO_EVER_P8_Pos)
+#define GPIO_EVER_P8                (_U_(0x1) << GPIO_EVER_P8_Pos)
 #define GPIO_EVER_P9_Pos            9            /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P9                (_U(0x1) << GPIO_EVER_P9_Pos)
+#define GPIO_EVER_P9                (_U_(0x1) << GPIO_EVER_P9_Pos)
 #define GPIO_EVER_P10_Pos           10           /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P10               (_U(0x1) << GPIO_EVER_P10_Pos)
+#define GPIO_EVER_P10               (_U_(0x1) << GPIO_EVER_P10_Pos)
 #define GPIO_EVER_P11_Pos           11           /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P11               (_U(0x1) << GPIO_EVER_P11_Pos)
+#define GPIO_EVER_P11               (_U_(0x1) << GPIO_EVER_P11_Pos)
 #define GPIO_EVER_P12_Pos           12           /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P12               (_U(0x1) << GPIO_EVER_P12_Pos)
+#define GPIO_EVER_P12               (_U_(0x1) << GPIO_EVER_P12_Pos)
 #define GPIO_EVER_P13_Pos           13           /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P13               (_U(0x1) << GPIO_EVER_P13_Pos)
+#define GPIO_EVER_P13               (_U_(0x1) << GPIO_EVER_P13_Pos)
 #define GPIO_EVER_P14_Pos           14           /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P14               (_U(0x1) << GPIO_EVER_P14_Pos)
+#define GPIO_EVER_P14               (_U_(0x1) << GPIO_EVER_P14_Pos)
 #define GPIO_EVER_P15_Pos           15           /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P15               (_U(0x1) << GPIO_EVER_P15_Pos)
+#define GPIO_EVER_P15               (_U_(0x1) << GPIO_EVER_P15_Pos)
 #define GPIO_EVER_P16_Pos           16           /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P16               (_U(0x1) << GPIO_EVER_P16_Pos)
+#define GPIO_EVER_P16               (_U_(0x1) << GPIO_EVER_P16_Pos)
 #define GPIO_EVER_P17_Pos           17           /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P17               (_U(0x1) << GPIO_EVER_P17_Pos)
+#define GPIO_EVER_P17               (_U_(0x1) << GPIO_EVER_P17_Pos)
 #define GPIO_EVER_P18_Pos           18           /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P18               (_U(0x1) << GPIO_EVER_P18_Pos)
+#define GPIO_EVER_P18               (_U_(0x1) << GPIO_EVER_P18_Pos)
 #define GPIO_EVER_P19_Pos           19           /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P19               (_U(0x1) << GPIO_EVER_P19_Pos)
+#define GPIO_EVER_P19               (_U_(0x1) << GPIO_EVER_P19_Pos)
 #define GPIO_EVER_P20_Pos           20           /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P20               (_U(0x1) << GPIO_EVER_P20_Pos)
+#define GPIO_EVER_P20               (_U_(0x1) << GPIO_EVER_P20_Pos)
 #define GPIO_EVER_P21_Pos           21           /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P21               (_U(0x1) << GPIO_EVER_P21_Pos)
+#define GPIO_EVER_P21               (_U_(0x1) << GPIO_EVER_P21_Pos)
 #define GPIO_EVER_P22_Pos           22           /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P22               (_U(0x1) << GPIO_EVER_P22_Pos)
+#define GPIO_EVER_P22               (_U_(0x1) << GPIO_EVER_P22_Pos)
 #define GPIO_EVER_P23_Pos           23           /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P23               (_U(0x1) << GPIO_EVER_P23_Pos)
+#define GPIO_EVER_P23               (_U_(0x1) << GPIO_EVER_P23_Pos)
 #define GPIO_EVER_P24_Pos           24           /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P24               (_U(0x1) << GPIO_EVER_P24_Pos)
+#define GPIO_EVER_P24               (_U_(0x1) << GPIO_EVER_P24_Pos)
 #define GPIO_EVER_P25_Pos           25           /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P25               (_U(0x1) << GPIO_EVER_P25_Pos)
+#define GPIO_EVER_P25               (_U_(0x1) << GPIO_EVER_P25_Pos)
 #define GPIO_EVER_P26_Pos           26           /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P26               (_U(0x1) << GPIO_EVER_P26_Pos)
+#define GPIO_EVER_P26               (_U_(0x1) << GPIO_EVER_P26_Pos)
 #define GPIO_EVER_P27_Pos           27           /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P27               (_U(0x1) << GPIO_EVER_P27_Pos)
+#define GPIO_EVER_P27               (_U_(0x1) << GPIO_EVER_P27_Pos)
 #define GPIO_EVER_P28_Pos           28           /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P28               (_U(0x1) << GPIO_EVER_P28_Pos)
+#define GPIO_EVER_P28               (_U_(0x1) << GPIO_EVER_P28_Pos)
 #define GPIO_EVER_P29_Pos           29           /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P29               (_U(0x1) << GPIO_EVER_P29_Pos)
+#define GPIO_EVER_P29               (_U_(0x1) << GPIO_EVER_P29_Pos)
 #define GPIO_EVER_P30_Pos           30           /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P30               (_U(0x1) << GPIO_EVER_P30_Pos)
+#define GPIO_EVER_P30               (_U_(0x1) << GPIO_EVER_P30_Pos)
 #define GPIO_EVER_P31_Pos           31           /**< \brief (GPIO_EVER) Event Enable */
-#define GPIO_EVER_P31               (_U(0x1) << GPIO_EVER_P31_Pos)
-#define GPIO_EVER_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_EVER) MASK Register */
+#define GPIO_EVER_P31               (_U_(0x1) << GPIO_EVER_P31_Pos)
+#define GPIO_EVER_MASK              _U_(0xFFFFFFFF) /**< \brief (GPIO_EVER) MASK Register */
 
 /* -------- GPIO_EVERS : (GPIO Offset: 0x184) ( /W 32) port Event Enable Register - Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7930,70 +7930,70 @@ typedef union {
 #define GPIO_EVERS_OFFSET           0x184        /**< \brief (GPIO_EVERS offset) Event Enable Register - Set */
 
 #define GPIO_EVERS_P0_Pos           0            /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P0               (_U(0x1) << GPIO_EVERS_P0_Pos)
+#define GPIO_EVERS_P0               (_U_(0x1) << GPIO_EVERS_P0_Pos)
 #define GPIO_EVERS_P1_Pos           1            /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P1               (_U(0x1) << GPIO_EVERS_P1_Pos)
+#define GPIO_EVERS_P1               (_U_(0x1) << GPIO_EVERS_P1_Pos)
 #define GPIO_EVERS_P2_Pos           2            /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P2               (_U(0x1) << GPIO_EVERS_P2_Pos)
+#define GPIO_EVERS_P2               (_U_(0x1) << GPIO_EVERS_P2_Pos)
 #define GPIO_EVERS_P3_Pos           3            /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P3               (_U(0x1) << GPIO_EVERS_P3_Pos)
+#define GPIO_EVERS_P3               (_U_(0x1) << GPIO_EVERS_P3_Pos)
 #define GPIO_EVERS_P4_Pos           4            /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P4               (_U(0x1) << GPIO_EVERS_P4_Pos)
+#define GPIO_EVERS_P4               (_U_(0x1) << GPIO_EVERS_P4_Pos)
 #define GPIO_EVERS_P5_Pos           5            /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P5               (_U(0x1) << GPIO_EVERS_P5_Pos)
+#define GPIO_EVERS_P5               (_U_(0x1) << GPIO_EVERS_P5_Pos)
 #define GPIO_EVERS_P6_Pos           6            /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P6               (_U(0x1) << GPIO_EVERS_P6_Pos)
+#define GPIO_EVERS_P6               (_U_(0x1) << GPIO_EVERS_P6_Pos)
 #define GPIO_EVERS_P7_Pos           7            /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P7               (_U(0x1) << GPIO_EVERS_P7_Pos)
+#define GPIO_EVERS_P7               (_U_(0x1) << GPIO_EVERS_P7_Pos)
 #define GPIO_EVERS_P8_Pos           8            /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P8               (_U(0x1) << GPIO_EVERS_P8_Pos)
+#define GPIO_EVERS_P8               (_U_(0x1) << GPIO_EVERS_P8_Pos)
 #define GPIO_EVERS_P9_Pos           9            /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P9               (_U(0x1) << GPIO_EVERS_P9_Pos)
+#define GPIO_EVERS_P9               (_U_(0x1) << GPIO_EVERS_P9_Pos)
 #define GPIO_EVERS_P10_Pos          10           /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P10              (_U(0x1) << GPIO_EVERS_P10_Pos)
+#define GPIO_EVERS_P10              (_U_(0x1) << GPIO_EVERS_P10_Pos)
 #define GPIO_EVERS_P11_Pos          11           /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P11              (_U(0x1) << GPIO_EVERS_P11_Pos)
+#define GPIO_EVERS_P11              (_U_(0x1) << GPIO_EVERS_P11_Pos)
 #define GPIO_EVERS_P12_Pos          12           /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P12              (_U(0x1) << GPIO_EVERS_P12_Pos)
+#define GPIO_EVERS_P12              (_U_(0x1) << GPIO_EVERS_P12_Pos)
 #define GPIO_EVERS_P13_Pos          13           /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P13              (_U(0x1) << GPIO_EVERS_P13_Pos)
+#define GPIO_EVERS_P13              (_U_(0x1) << GPIO_EVERS_P13_Pos)
 #define GPIO_EVERS_P14_Pos          14           /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P14              (_U(0x1) << GPIO_EVERS_P14_Pos)
+#define GPIO_EVERS_P14              (_U_(0x1) << GPIO_EVERS_P14_Pos)
 #define GPIO_EVERS_P15_Pos          15           /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P15              (_U(0x1) << GPIO_EVERS_P15_Pos)
+#define GPIO_EVERS_P15              (_U_(0x1) << GPIO_EVERS_P15_Pos)
 #define GPIO_EVERS_P16_Pos          16           /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P16              (_U(0x1) << GPIO_EVERS_P16_Pos)
+#define GPIO_EVERS_P16              (_U_(0x1) << GPIO_EVERS_P16_Pos)
 #define GPIO_EVERS_P17_Pos          17           /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P17              (_U(0x1) << GPIO_EVERS_P17_Pos)
+#define GPIO_EVERS_P17              (_U_(0x1) << GPIO_EVERS_P17_Pos)
 #define GPIO_EVERS_P18_Pos          18           /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P18              (_U(0x1) << GPIO_EVERS_P18_Pos)
+#define GPIO_EVERS_P18              (_U_(0x1) << GPIO_EVERS_P18_Pos)
 #define GPIO_EVERS_P19_Pos          19           /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P19              (_U(0x1) << GPIO_EVERS_P19_Pos)
+#define GPIO_EVERS_P19              (_U_(0x1) << GPIO_EVERS_P19_Pos)
 #define GPIO_EVERS_P20_Pos          20           /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P20              (_U(0x1) << GPIO_EVERS_P20_Pos)
+#define GPIO_EVERS_P20              (_U_(0x1) << GPIO_EVERS_P20_Pos)
 #define GPIO_EVERS_P21_Pos          21           /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P21              (_U(0x1) << GPIO_EVERS_P21_Pos)
+#define GPIO_EVERS_P21              (_U_(0x1) << GPIO_EVERS_P21_Pos)
 #define GPIO_EVERS_P22_Pos          22           /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P22              (_U(0x1) << GPIO_EVERS_P22_Pos)
+#define GPIO_EVERS_P22              (_U_(0x1) << GPIO_EVERS_P22_Pos)
 #define GPIO_EVERS_P23_Pos          23           /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P23              (_U(0x1) << GPIO_EVERS_P23_Pos)
+#define GPIO_EVERS_P23              (_U_(0x1) << GPIO_EVERS_P23_Pos)
 #define GPIO_EVERS_P24_Pos          24           /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P24              (_U(0x1) << GPIO_EVERS_P24_Pos)
+#define GPIO_EVERS_P24              (_U_(0x1) << GPIO_EVERS_P24_Pos)
 #define GPIO_EVERS_P25_Pos          25           /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P25              (_U(0x1) << GPIO_EVERS_P25_Pos)
+#define GPIO_EVERS_P25              (_U_(0x1) << GPIO_EVERS_P25_Pos)
 #define GPIO_EVERS_P26_Pos          26           /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P26              (_U(0x1) << GPIO_EVERS_P26_Pos)
+#define GPIO_EVERS_P26              (_U_(0x1) << GPIO_EVERS_P26_Pos)
 #define GPIO_EVERS_P27_Pos          27           /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P27              (_U(0x1) << GPIO_EVERS_P27_Pos)
+#define GPIO_EVERS_P27              (_U_(0x1) << GPIO_EVERS_P27_Pos)
 #define GPIO_EVERS_P28_Pos          28           /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P28              (_U(0x1) << GPIO_EVERS_P28_Pos)
+#define GPIO_EVERS_P28              (_U_(0x1) << GPIO_EVERS_P28_Pos)
 #define GPIO_EVERS_P29_Pos          29           /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P29              (_U(0x1) << GPIO_EVERS_P29_Pos)
+#define GPIO_EVERS_P29              (_U_(0x1) << GPIO_EVERS_P29_Pos)
 #define GPIO_EVERS_P30_Pos          30           /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P30              (_U(0x1) << GPIO_EVERS_P30_Pos)
+#define GPIO_EVERS_P30              (_U_(0x1) << GPIO_EVERS_P30_Pos)
 #define GPIO_EVERS_P31_Pos          31           /**< \brief (GPIO_EVERS) Event Enable */
-#define GPIO_EVERS_P31              (_U(0x1) << GPIO_EVERS_P31_Pos)
-#define GPIO_EVERS_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_EVERS) MASK Register */
+#define GPIO_EVERS_P31              (_U_(0x1) << GPIO_EVERS_P31_Pos)
+#define GPIO_EVERS_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_EVERS) MASK Register */
 
 /* -------- GPIO_EVERC : (GPIO Offset: 0x188) ( /W 32) port Event Enable Register - Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -8039,70 +8039,70 @@ typedef union {
 #define GPIO_EVERC_OFFSET           0x188        /**< \brief (GPIO_EVERC offset) Event Enable Register - Clear */
 
 #define GPIO_EVERC_P0_Pos           0            /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P0               (_U(0x1) << GPIO_EVERC_P0_Pos)
+#define GPIO_EVERC_P0               (_U_(0x1) << GPIO_EVERC_P0_Pos)
 #define GPIO_EVERC_P1_Pos           1            /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P1               (_U(0x1) << GPIO_EVERC_P1_Pos)
+#define GPIO_EVERC_P1               (_U_(0x1) << GPIO_EVERC_P1_Pos)
 #define GPIO_EVERC_P2_Pos           2            /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P2               (_U(0x1) << GPIO_EVERC_P2_Pos)
+#define GPIO_EVERC_P2               (_U_(0x1) << GPIO_EVERC_P2_Pos)
 #define GPIO_EVERC_P3_Pos           3            /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P3               (_U(0x1) << GPIO_EVERC_P3_Pos)
+#define GPIO_EVERC_P3               (_U_(0x1) << GPIO_EVERC_P3_Pos)
 #define GPIO_EVERC_P4_Pos           4            /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P4               (_U(0x1) << GPIO_EVERC_P4_Pos)
+#define GPIO_EVERC_P4               (_U_(0x1) << GPIO_EVERC_P4_Pos)
 #define GPIO_EVERC_P5_Pos           5            /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P5               (_U(0x1) << GPIO_EVERC_P5_Pos)
+#define GPIO_EVERC_P5               (_U_(0x1) << GPIO_EVERC_P5_Pos)
 #define GPIO_EVERC_P6_Pos           6            /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P6               (_U(0x1) << GPIO_EVERC_P6_Pos)
+#define GPIO_EVERC_P6               (_U_(0x1) << GPIO_EVERC_P6_Pos)
 #define GPIO_EVERC_P7_Pos           7            /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P7               (_U(0x1) << GPIO_EVERC_P7_Pos)
+#define GPIO_EVERC_P7               (_U_(0x1) << GPIO_EVERC_P7_Pos)
 #define GPIO_EVERC_P8_Pos           8            /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P8               (_U(0x1) << GPIO_EVERC_P8_Pos)
+#define GPIO_EVERC_P8               (_U_(0x1) << GPIO_EVERC_P8_Pos)
 #define GPIO_EVERC_P9_Pos           9            /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P9               (_U(0x1) << GPIO_EVERC_P9_Pos)
+#define GPIO_EVERC_P9               (_U_(0x1) << GPIO_EVERC_P9_Pos)
 #define GPIO_EVERC_P10_Pos          10           /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P10              (_U(0x1) << GPIO_EVERC_P10_Pos)
+#define GPIO_EVERC_P10              (_U_(0x1) << GPIO_EVERC_P10_Pos)
 #define GPIO_EVERC_P11_Pos          11           /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P11              (_U(0x1) << GPIO_EVERC_P11_Pos)
+#define GPIO_EVERC_P11              (_U_(0x1) << GPIO_EVERC_P11_Pos)
 #define GPIO_EVERC_P12_Pos          12           /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P12              (_U(0x1) << GPIO_EVERC_P12_Pos)
+#define GPIO_EVERC_P12              (_U_(0x1) << GPIO_EVERC_P12_Pos)
 #define GPIO_EVERC_P13_Pos          13           /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P13              (_U(0x1) << GPIO_EVERC_P13_Pos)
+#define GPIO_EVERC_P13              (_U_(0x1) << GPIO_EVERC_P13_Pos)
 #define GPIO_EVERC_P14_Pos          14           /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P14              (_U(0x1) << GPIO_EVERC_P14_Pos)
+#define GPIO_EVERC_P14              (_U_(0x1) << GPIO_EVERC_P14_Pos)
 #define GPIO_EVERC_P15_Pos          15           /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P15              (_U(0x1) << GPIO_EVERC_P15_Pos)
+#define GPIO_EVERC_P15              (_U_(0x1) << GPIO_EVERC_P15_Pos)
 #define GPIO_EVERC_P16_Pos          16           /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P16              (_U(0x1) << GPIO_EVERC_P16_Pos)
+#define GPIO_EVERC_P16              (_U_(0x1) << GPIO_EVERC_P16_Pos)
 #define GPIO_EVERC_P17_Pos          17           /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P17              (_U(0x1) << GPIO_EVERC_P17_Pos)
+#define GPIO_EVERC_P17              (_U_(0x1) << GPIO_EVERC_P17_Pos)
 #define GPIO_EVERC_P18_Pos          18           /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P18              (_U(0x1) << GPIO_EVERC_P18_Pos)
+#define GPIO_EVERC_P18              (_U_(0x1) << GPIO_EVERC_P18_Pos)
 #define GPIO_EVERC_P19_Pos          19           /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P19              (_U(0x1) << GPIO_EVERC_P19_Pos)
+#define GPIO_EVERC_P19              (_U_(0x1) << GPIO_EVERC_P19_Pos)
 #define GPIO_EVERC_P20_Pos          20           /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P20              (_U(0x1) << GPIO_EVERC_P20_Pos)
+#define GPIO_EVERC_P20              (_U_(0x1) << GPIO_EVERC_P20_Pos)
 #define GPIO_EVERC_P21_Pos          21           /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P21              (_U(0x1) << GPIO_EVERC_P21_Pos)
+#define GPIO_EVERC_P21              (_U_(0x1) << GPIO_EVERC_P21_Pos)
 #define GPIO_EVERC_P22_Pos          22           /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P22              (_U(0x1) << GPIO_EVERC_P22_Pos)
+#define GPIO_EVERC_P22              (_U_(0x1) << GPIO_EVERC_P22_Pos)
 #define GPIO_EVERC_P23_Pos          23           /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P23              (_U(0x1) << GPIO_EVERC_P23_Pos)
+#define GPIO_EVERC_P23              (_U_(0x1) << GPIO_EVERC_P23_Pos)
 #define GPIO_EVERC_P24_Pos          24           /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P24              (_U(0x1) << GPIO_EVERC_P24_Pos)
+#define GPIO_EVERC_P24              (_U_(0x1) << GPIO_EVERC_P24_Pos)
 #define GPIO_EVERC_P25_Pos          25           /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P25              (_U(0x1) << GPIO_EVERC_P25_Pos)
+#define GPIO_EVERC_P25              (_U_(0x1) << GPIO_EVERC_P25_Pos)
 #define GPIO_EVERC_P26_Pos          26           /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P26              (_U(0x1) << GPIO_EVERC_P26_Pos)
+#define GPIO_EVERC_P26              (_U_(0x1) << GPIO_EVERC_P26_Pos)
 #define GPIO_EVERC_P27_Pos          27           /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P27              (_U(0x1) << GPIO_EVERC_P27_Pos)
+#define GPIO_EVERC_P27              (_U_(0x1) << GPIO_EVERC_P27_Pos)
 #define GPIO_EVERC_P28_Pos          28           /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P28              (_U(0x1) << GPIO_EVERC_P28_Pos)
+#define GPIO_EVERC_P28              (_U_(0x1) << GPIO_EVERC_P28_Pos)
 #define GPIO_EVERC_P29_Pos          29           /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P29              (_U(0x1) << GPIO_EVERC_P29_Pos)
+#define GPIO_EVERC_P29              (_U_(0x1) << GPIO_EVERC_P29_Pos)
 #define GPIO_EVERC_P30_Pos          30           /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P30              (_U(0x1) << GPIO_EVERC_P30_Pos)
+#define GPIO_EVERC_P30              (_U_(0x1) << GPIO_EVERC_P30_Pos)
 #define GPIO_EVERC_P31_Pos          31           /**< \brief (GPIO_EVERC) Event Enable */
-#define GPIO_EVERC_P31              (_U(0x1) << GPIO_EVERC_P31_Pos)
-#define GPIO_EVERC_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_EVERC) MASK Register */
+#define GPIO_EVERC_P31              (_U_(0x1) << GPIO_EVERC_P31_Pos)
+#define GPIO_EVERC_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_EVERC) MASK Register */
 
 /* -------- GPIO_EVERT : (GPIO Offset: 0x18C) ( /W 32) port Event Enable Register - Toggle -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -8148,70 +8148,70 @@ typedef union {
 #define GPIO_EVERT_OFFSET           0x18C        /**< \brief (GPIO_EVERT offset) Event Enable Register - Toggle */
 
 #define GPIO_EVERT_P0_Pos           0            /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P0               (_U(0x1) << GPIO_EVERT_P0_Pos)
+#define GPIO_EVERT_P0               (_U_(0x1) << GPIO_EVERT_P0_Pos)
 #define GPIO_EVERT_P1_Pos           1            /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P1               (_U(0x1) << GPIO_EVERT_P1_Pos)
+#define GPIO_EVERT_P1               (_U_(0x1) << GPIO_EVERT_P1_Pos)
 #define GPIO_EVERT_P2_Pos           2            /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P2               (_U(0x1) << GPIO_EVERT_P2_Pos)
+#define GPIO_EVERT_P2               (_U_(0x1) << GPIO_EVERT_P2_Pos)
 #define GPIO_EVERT_P3_Pos           3            /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P3               (_U(0x1) << GPIO_EVERT_P3_Pos)
+#define GPIO_EVERT_P3               (_U_(0x1) << GPIO_EVERT_P3_Pos)
 #define GPIO_EVERT_P4_Pos           4            /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P4               (_U(0x1) << GPIO_EVERT_P4_Pos)
+#define GPIO_EVERT_P4               (_U_(0x1) << GPIO_EVERT_P4_Pos)
 #define GPIO_EVERT_P5_Pos           5            /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P5               (_U(0x1) << GPIO_EVERT_P5_Pos)
+#define GPIO_EVERT_P5               (_U_(0x1) << GPIO_EVERT_P5_Pos)
 #define GPIO_EVERT_P6_Pos           6            /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P6               (_U(0x1) << GPIO_EVERT_P6_Pos)
+#define GPIO_EVERT_P6               (_U_(0x1) << GPIO_EVERT_P6_Pos)
 #define GPIO_EVERT_P7_Pos           7            /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P7               (_U(0x1) << GPIO_EVERT_P7_Pos)
+#define GPIO_EVERT_P7               (_U_(0x1) << GPIO_EVERT_P7_Pos)
 #define GPIO_EVERT_P8_Pos           8            /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P8               (_U(0x1) << GPIO_EVERT_P8_Pos)
+#define GPIO_EVERT_P8               (_U_(0x1) << GPIO_EVERT_P8_Pos)
 #define GPIO_EVERT_P9_Pos           9            /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P9               (_U(0x1) << GPIO_EVERT_P9_Pos)
+#define GPIO_EVERT_P9               (_U_(0x1) << GPIO_EVERT_P9_Pos)
 #define GPIO_EVERT_P10_Pos          10           /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P10              (_U(0x1) << GPIO_EVERT_P10_Pos)
+#define GPIO_EVERT_P10              (_U_(0x1) << GPIO_EVERT_P10_Pos)
 #define GPIO_EVERT_P11_Pos          11           /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P11              (_U(0x1) << GPIO_EVERT_P11_Pos)
+#define GPIO_EVERT_P11              (_U_(0x1) << GPIO_EVERT_P11_Pos)
 #define GPIO_EVERT_P12_Pos          12           /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P12              (_U(0x1) << GPIO_EVERT_P12_Pos)
+#define GPIO_EVERT_P12              (_U_(0x1) << GPIO_EVERT_P12_Pos)
 #define GPIO_EVERT_P13_Pos          13           /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P13              (_U(0x1) << GPIO_EVERT_P13_Pos)
+#define GPIO_EVERT_P13              (_U_(0x1) << GPIO_EVERT_P13_Pos)
 #define GPIO_EVERT_P14_Pos          14           /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P14              (_U(0x1) << GPIO_EVERT_P14_Pos)
+#define GPIO_EVERT_P14              (_U_(0x1) << GPIO_EVERT_P14_Pos)
 #define GPIO_EVERT_P15_Pos          15           /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P15              (_U(0x1) << GPIO_EVERT_P15_Pos)
+#define GPIO_EVERT_P15              (_U_(0x1) << GPIO_EVERT_P15_Pos)
 #define GPIO_EVERT_P16_Pos          16           /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P16              (_U(0x1) << GPIO_EVERT_P16_Pos)
+#define GPIO_EVERT_P16              (_U_(0x1) << GPIO_EVERT_P16_Pos)
 #define GPIO_EVERT_P17_Pos          17           /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P17              (_U(0x1) << GPIO_EVERT_P17_Pos)
+#define GPIO_EVERT_P17              (_U_(0x1) << GPIO_EVERT_P17_Pos)
 #define GPIO_EVERT_P18_Pos          18           /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P18              (_U(0x1) << GPIO_EVERT_P18_Pos)
+#define GPIO_EVERT_P18              (_U_(0x1) << GPIO_EVERT_P18_Pos)
 #define GPIO_EVERT_P19_Pos          19           /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P19              (_U(0x1) << GPIO_EVERT_P19_Pos)
+#define GPIO_EVERT_P19              (_U_(0x1) << GPIO_EVERT_P19_Pos)
 #define GPIO_EVERT_P20_Pos          20           /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P20              (_U(0x1) << GPIO_EVERT_P20_Pos)
+#define GPIO_EVERT_P20              (_U_(0x1) << GPIO_EVERT_P20_Pos)
 #define GPIO_EVERT_P21_Pos          21           /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P21              (_U(0x1) << GPIO_EVERT_P21_Pos)
+#define GPIO_EVERT_P21              (_U_(0x1) << GPIO_EVERT_P21_Pos)
 #define GPIO_EVERT_P22_Pos          22           /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P22              (_U(0x1) << GPIO_EVERT_P22_Pos)
+#define GPIO_EVERT_P22              (_U_(0x1) << GPIO_EVERT_P22_Pos)
 #define GPIO_EVERT_P23_Pos          23           /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P23              (_U(0x1) << GPIO_EVERT_P23_Pos)
+#define GPIO_EVERT_P23              (_U_(0x1) << GPIO_EVERT_P23_Pos)
 #define GPIO_EVERT_P24_Pos          24           /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P24              (_U(0x1) << GPIO_EVERT_P24_Pos)
+#define GPIO_EVERT_P24              (_U_(0x1) << GPIO_EVERT_P24_Pos)
 #define GPIO_EVERT_P25_Pos          25           /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P25              (_U(0x1) << GPIO_EVERT_P25_Pos)
+#define GPIO_EVERT_P25              (_U_(0x1) << GPIO_EVERT_P25_Pos)
 #define GPIO_EVERT_P26_Pos          26           /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P26              (_U(0x1) << GPIO_EVERT_P26_Pos)
+#define GPIO_EVERT_P26              (_U_(0x1) << GPIO_EVERT_P26_Pos)
 #define GPIO_EVERT_P27_Pos          27           /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P27              (_U(0x1) << GPIO_EVERT_P27_Pos)
+#define GPIO_EVERT_P27              (_U_(0x1) << GPIO_EVERT_P27_Pos)
 #define GPIO_EVERT_P28_Pos          28           /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P28              (_U(0x1) << GPIO_EVERT_P28_Pos)
+#define GPIO_EVERT_P28              (_U_(0x1) << GPIO_EVERT_P28_Pos)
 #define GPIO_EVERT_P29_Pos          29           /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P29              (_U(0x1) << GPIO_EVERT_P29_Pos)
+#define GPIO_EVERT_P29              (_U_(0x1) << GPIO_EVERT_P29_Pos)
 #define GPIO_EVERT_P30_Pos          30           /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P30              (_U(0x1) << GPIO_EVERT_P30_Pos)
+#define GPIO_EVERT_P30              (_U_(0x1) << GPIO_EVERT_P30_Pos)
 #define GPIO_EVERT_P31_Pos          31           /**< \brief (GPIO_EVERT) Event Enable */
-#define GPIO_EVERT_P31              (_U(0x1) << GPIO_EVERT_P31_Pos)
-#define GPIO_EVERT_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_EVERT) MASK Register */
+#define GPIO_EVERT_P31              (_U_(0x1) << GPIO_EVERT_P31_Pos)
+#define GPIO_EVERT_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_EVERT) MASK Register */
 
 /* -------- GPIO_LOCK : (GPIO Offset: 0x1A0) (R/W 32) port Lock Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -8257,70 +8257,70 @@ typedef union {
 #define GPIO_LOCK_OFFSET            0x1A0        /**< \brief (GPIO_LOCK offset) Lock Register */
 
 #define GPIO_LOCK_P0_Pos            0            /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P0                (_U(0x1) << GPIO_LOCK_P0_Pos)
+#define GPIO_LOCK_P0                (_U_(0x1) << GPIO_LOCK_P0_Pos)
 #define GPIO_LOCK_P1_Pos            1            /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P1                (_U(0x1) << GPIO_LOCK_P1_Pos)
+#define GPIO_LOCK_P1                (_U_(0x1) << GPIO_LOCK_P1_Pos)
 #define GPIO_LOCK_P2_Pos            2            /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P2                (_U(0x1) << GPIO_LOCK_P2_Pos)
+#define GPIO_LOCK_P2                (_U_(0x1) << GPIO_LOCK_P2_Pos)
 #define GPIO_LOCK_P3_Pos            3            /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P3                (_U(0x1) << GPIO_LOCK_P3_Pos)
+#define GPIO_LOCK_P3                (_U_(0x1) << GPIO_LOCK_P3_Pos)
 #define GPIO_LOCK_P4_Pos            4            /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P4                (_U(0x1) << GPIO_LOCK_P4_Pos)
+#define GPIO_LOCK_P4                (_U_(0x1) << GPIO_LOCK_P4_Pos)
 #define GPIO_LOCK_P5_Pos            5            /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P5                (_U(0x1) << GPIO_LOCK_P5_Pos)
+#define GPIO_LOCK_P5                (_U_(0x1) << GPIO_LOCK_P5_Pos)
 #define GPIO_LOCK_P6_Pos            6            /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P6                (_U(0x1) << GPIO_LOCK_P6_Pos)
+#define GPIO_LOCK_P6                (_U_(0x1) << GPIO_LOCK_P6_Pos)
 #define GPIO_LOCK_P7_Pos            7            /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P7                (_U(0x1) << GPIO_LOCK_P7_Pos)
+#define GPIO_LOCK_P7                (_U_(0x1) << GPIO_LOCK_P7_Pos)
 #define GPIO_LOCK_P8_Pos            8            /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P8                (_U(0x1) << GPIO_LOCK_P8_Pos)
+#define GPIO_LOCK_P8                (_U_(0x1) << GPIO_LOCK_P8_Pos)
 #define GPIO_LOCK_P9_Pos            9            /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P9                (_U(0x1) << GPIO_LOCK_P9_Pos)
+#define GPIO_LOCK_P9                (_U_(0x1) << GPIO_LOCK_P9_Pos)
 #define GPIO_LOCK_P10_Pos           10           /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P10               (_U(0x1) << GPIO_LOCK_P10_Pos)
+#define GPIO_LOCK_P10               (_U_(0x1) << GPIO_LOCK_P10_Pos)
 #define GPIO_LOCK_P11_Pos           11           /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P11               (_U(0x1) << GPIO_LOCK_P11_Pos)
+#define GPIO_LOCK_P11               (_U_(0x1) << GPIO_LOCK_P11_Pos)
 #define GPIO_LOCK_P12_Pos           12           /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P12               (_U(0x1) << GPIO_LOCK_P12_Pos)
+#define GPIO_LOCK_P12               (_U_(0x1) << GPIO_LOCK_P12_Pos)
 #define GPIO_LOCK_P13_Pos           13           /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P13               (_U(0x1) << GPIO_LOCK_P13_Pos)
+#define GPIO_LOCK_P13               (_U_(0x1) << GPIO_LOCK_P13_Pos)
 #define GPIO_LOCK_P14_Pos           14           /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P14               (_U(0x1) << GPIO_LOCK_P14_Pos)
+#define GPIO_LOCK_P14               (_U_(0x1) << GPIO_LOCK_P14_Pos)
 #define GPIO_LOCK_P15_Pos           15           /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P15               (_U(0x1) << GPIO_LOCK_P15_Pos)
+#define GPIO_LOCK_P15               (_U_(0x1) << GPIO_LOCK_P15_Pos)
 #define GPIO_LOCK_P16_Pos           16           /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P16               (_U(0x1) << GPIO_LOCK_P16_Pos)
+#define GPIO_LOCK_P16               (_U_(0x1) << GPIO_LOCK_P16_Pos)
 #define GPIO_LOCK_P17_Pos           17           /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P17               (_U(0x1) << GPIO_LOCK_P17_Pos)
+#define GPIO_LOCK_P17               (_U_(0x1) << GPIO_LOCK_P17_Pos)
 #define GPIO_LOCK_P18_Pos           18           /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P18               (_U(0x1) << GPIO_LOCK_P18_Pos)
+#define GPIO_LOCK_P18               (_U_(0x1) << GPIO_LOCK_P18_Pos)
 #define GPIO_LOCK_P19_Pos           19           /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P19               (_U(0x1) << GPIO_LOCK_P19_Pos)
+#define GPIO_LOCK_P19               (_U_(0x1) << GPIO_LOCK_P19_Pos)
 #define GPIO_LOCK_P20_Pos           20           /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P20               (_U(0x1) << GPIO_LOCK_P20_Pos)
+#define GPIO_LOCK_P20               (_U_(0x1) << GPIO_LOCK_P20_Pos)
 #define GPIO_LOCK_P21_Pos           21           /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P21               (_U(0x1) << GPIO_LOCK_P21_Pos)
+#define GPIO_LOCK_P21               (_U_(0x1) << GPIO_LOCK_P21_Pos)
 #define GPIO_LOCK_P22_Pos           22           /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P22               (_U(0x1) << GPIO_LOCK_P22_Pos)
+#define GPIO_LOCK_P22               (_U_(0x1) << GPIO_LOCK_P22_Pos)
 #define GPIO_LOCK_P23_Pos           23           /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P23               (_U(0x1) << GPIO_LOCK_P23_Pos)
+#define GPIO_LOCK_P23               (_U_(0x1) << GPIO_LOCK_P23_Pos)
 #define GPIO_LOCK_P24_Pos           24           /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P24               (_U(0x1) << GPIO_LOCK_P24_Pos)
+#define GPIO_LOCK_P24               (_U_(0x1) << GPIO_LOCK_P24_Pos)
 #define GPIO_LOCK_P25_Pos           25           /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P25               (_U(0x1) << GPIO_LOCK_P25_Pos)
+#define GPIO_LOCK_P25               (_U_(0x1) << GPIO_LOCK_P25_Pos)
 #define GPIO_LOCK_P26_Pos           26           /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P26               (_U(0x1) << GPIO_LOCK_P26_Pos)
+#define GPIO_LOCK_P26               (_U_(0x1) << GPIO_LOCK_P26_Pos)
 #define GPIO_LOCK_P27_Pos           27           /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P27               (_U(0x1) << GPIO_LOCK_P27_Pos)
+#define GPIO_LOCK_P27               (_U_(0x1) << GPIO_LOCK_P27_Pos)
 #define GPIO_LOCK_P28_Pos           28           /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P28               (_U(0x1) << GPIO_LOCK_P28_Pos)
+#define GPIO_LOCK_P28               (_U_(0x1) << GPIO_LOCK_P28_Pos)
 #define GPIO_LOCK_P29_Pos           29           /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P29               (_U(0x1) << GPIO_LOCK_P29_Pos)
+#define GPIO_LOCK_P29               (_U_(0x1) << GPIO_LOCK_P29_Pos)
 #define GPIO_LOCK_P30_Pos           30           /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P30               (_U(0x1) << GPIO_LOCK_P30_Pos)
+#define GPIO_LOCK_P30               (_U_(0x1) << GPIO_LOCK_P30_Pos)
 #define GPIO_LOCK_P31_Pos           31           /**< \brief (GPIO_LOCK) Lock State */
-#define GPIO_LOCK_P31               (_U(0x1) << GPIO_LOCK_P31_Pos)
-#define GPIO_LOCK_MASK              _U(0xFFFFFFFF) /**< \brief (GPIO_LOCK) MASK Register */
+#define GPIO_LOCK_P31               (_U_(0x1) << GPIO_LOCK_P31_Pos)
+#define GPIO_LOCK_MASK              _U_(0xFFFFFFFF) /**< \brief (GPIO_LOCK) MASK Register */
 
 /* -------- GPIO_LOCKS : (GPIO Offset: 0x1A4) ( /W 32) port Lock Register - Set -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -8366,70 +8366,70 @@ typedef union {
 #define GPIO_LOCKS_OFFSET           0x1A4        /**< \brief (GPIO_LOCKS offset) Lock Register - Set */
 
 #define GPIO_LOCKS_P0_Pos           0            /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P0               (_U(0x1) << GPIO_LOCKS_P0_Pos)
+#define GPIO_LOCKS_P0               (_U_(0x1) << GPIO_LOCKS_P0_Pos)
 #define GPIO_LOCKS_P1_Pos           1            /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P1               (_U(0x1) << GPIO_LOCKS_P1_Pos)
+#define GPIO_LOCKS_P1               (_U_(0x1) << GPIO_LOCKS_P1_Pos)
 #define GPIO_LOCKS_P2_Pos           2            /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P2               (_U(0x1) << GPIO_LOCKS_P2_Pos)
+#define GPIO_LOCKS_P2               (_U_(0x1) << GPIO_LOCKS_P2_Pos)
 #define GPIO_LOCKS_P3_Pos           3            /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P3               (_U(0x1) << GPIO_LOCKS_P3_Pos)
+#define GPIO_LOCKS_P3               (_U_(0x1) << GPIO_LOCKS_P3_Pos)
 #define GPIO_LOCKS_P4_Pos           4            /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P4               (_U(0x1) << GPIO_LOCKS_P4_Pos)
+#define GPIO_LOCKS_P4               (_U_(0x1) << GPIO_LOCKS_P4_Pos)
 #define GPIO_LOCKS_P5_Pos           5            /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P5               (_U(0x1) << GPIO_LOCKS_P5_Pos)
+#define GPIO_LOCKS_P5               (_U_(0x1) << GPIO_LOCKS_P5_Pos)
 #define GPIO_LOCKS_P6_Pos           6            /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P6               (_U(0x1) << GPIO_LOCKS_P6_Pos)
+#define GPIO_LOCKS_P6               (_U_(0x1) << GPIO_LOCKS_P6_Pos)
 #define GPIO_LOCKS_P7_Pos           7            /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P7               (_U(0x1) << GPIO_LOCKS_P7_Pos)
+#define GPIO_LOCKS_P7               (_U_(0x1) << GPIO_LOCKS_P7_Pos)
 #define GPIO_LOCKS_P8_Pos           8            /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P8               (_U(0x1) << GPIO_LOCKS_P8_Pos)
+#define GPIO_LOCKS_P8               (_U_(0x1) << GPIO_LOCKS_P8_Pos)
 #define GPIO_LOCKS_P9_Pos           9            /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P9               (_U(0x1) << GPIO_LOCKS_P9_Pos)
+#define GPIO_LOCKS_P9               (_U_(0x1) << GPIO_LOCKS_P9_Pos)
 #define GPIO_LOCKS_P10_Pos          10           /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P10              (_U(0x1) << GPIO_LOCKS_P10_Pos)
+#define GPIO_LOCKS_P10              (_U_(0x1) << GPIO_LOCKS_P10_Pos)
 #define GPIO_LOCKS_P11_Pos          11           /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P11              (_U(0x1) << GPIO_LOCKS_P11_Pos)
+#define GPIO_LOCKS_P11              (_U_(0x1) << GPIO_LOCKS_P11_Pos)
 #define GPIO_LOCKS_P12_Pos          12           /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P12              (_U(0x1) << GPIO_LOCKS_P12_Pos)
+#define GPIO_LOCKS_P12              (_U_(0x1) << GPIO_LOCKS_P12_Pos)
 #define GPIO_LOCKS_P13_Pos          13           /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P13              (_U(0x1) << GPIO_LOCKS_P13_Pos)
+#define GPIO_LOCKS_P13              (_U_(0x1) << GPIO_LOCKS_P13_Pos)
 #define GPIO_LOCKS_P14_Pos          14           /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P14              (_U(0x1) << GPIO_LOCKS_P14_Pos)
+#define GPIO_LOCKS_P14              (_U_(0x1) << GPIO_LOCKS_P14_Pos)
 #define GPIO_LOCKS_P15_Pos          15           /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P15              (_U(0x1) << GPIO_LOCKS_P15_Pos)
+#define GPIO_LOCKS_P15              (_U_(0x1) << GPIO_LOCKS_P15_Pos)
 #define GPIO_LOCKS_P16_Pos          16           /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P16              (_U(0x1) << GPIO_LOCKS_P16_Pos)
+#define GPIO_LOCKS_P16              (_U_(0x1) << GPIO_LOCKS_P16_Pos)
 #define GPIO_LOCKS_P17_Pos          17           /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P17              (_U(0x1) << GPIO_LOCKS_P17_Pos)
+#define GPIO_LOCKS_P17              (_U_(0x1) << GPIO_LOCKS_P17_Pos)
 #define GPIO_LOCKS_P18_Pos          18           /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P18              (_U(0x1) << GPIO_LOCKS_P18_Pos)
+#define GPIO_LOCKS_P18              (_U_(0x1) << GPIO_LOCKS_P18_Pos)
 #define GPIO_LOCKS_P19_Pos          19           /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P19              (_U(0x1) << GPIO_LOCKS_P19_Pos)
+#define GPIO_LOCKS_P19              (_U_(0x1) << GPIO_LOCKS_P19_Pos)
 #define GPIO_LOCKS_P20_Pos          20           /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P20              (_U(0x1) << GPIO_LOCKS_P20_Pos)
+#define GPIO_LOCKS_P20              (_U_(0x1) << GPIO_LOCKS_P20_Pos)
 #define GPIO_LOCKS_P21_Pos          21           /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P21              (_U(0x1) << GPIO_LOCKS_P21_Pos)
+#define GPIO_LOCKS_P21              (_U_(0x1) << GPIO_LOCKS_P21_Pos)
 #define GPIO_LOCKS_P22_Pos          22           /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P22              (_U(0x1) << GPIO_LOCKS_P22_Pos)
+#define GPIO_LOCKS_P22              (_U_(0x1) << GPIO_LOCKS_P22_Pos)
 #define GPIO_LOCKS_P23_Pos          23           /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P23              (_U(0x1) << GPIO_LOCKS_P23_Pos)
+#define GPIO_LOCKS_P23              (_U_(0x1) << GPIO_LOCKS_P23_Pos)
 #define GPIO_LOCKS_P24_Pos          24           /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P24              (_U(0x1) << GPIO_LOCKS_P24_Pos)
+#define GPIO_LOCKS_P24              (_U_(0x1) << GPIO_LOCKS_P24_Pos)
 #define GPIO_LOCKS_P25_Pos          25           /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P25              (_U(0x1) << GPIO_LOCKS_P25_Pos)
+#define GPIO_LOCKS_P25              (_U_(0x1) << GPIO_LOCKS_P25_Pos)
 #define GPIO_LOCKS_P26_Pos          26           /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P26              (_U(0x1) << GPIO_LOCKS_P26_Pos)
+#define GPIO_LOCKS_P26              (_U_(0x1) << GPIO_LOCKS_P26_Pos)
 #define GPIO_LOCKS_P27_Pos          27           /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P27              (_U(0x1) << GPIO_LOCKS_P27_Pos)
+#define GPIO_LOCKS_P27              (_U_(0x1) << GPIO_LOCKS_P27_Pos)
 #define GPIO_LOCKS_P28_Pos          28           /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P28              (_U(0x1) << GPIO_LOCKS_P28_Pos)
+#define GPIO_LOCKS_P28              (_U_(0x1) << GPIO_LOCKS_P28_Pos)
 #define GPIO_LOCKS_P29_Pos          29           /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P29              (_U(0x1) << GPIO_LOCKS_P29_Pos)
+#define GPIO_LOCKS_P29              (_U_(0x1) << GPIO_LOCKS_P29_Pos)
 #define GPIO_LOCKS_P30_Pos          30           /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P30              (_U(0x1) << GPIO_LOCKS_P30_Pos)
+#define GPIO_LOCKS_P30              (_U_(0x1) << GPIO_LOCKS_P30_Pos)
 #define GPIO_LOCKS_P31_Pos          31           /**< \brief (GPIO_LOCKS) Lock State */
-#define GPIO_LOCKS_P31              (_U(0x1) << GPIO_LOCKS_P31_Pos)
-#define GPIO_LOCKS_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_LOCKS) MASK Register */
+#define GPIO_LOCKS_P31              (_U_(0x1) << GPIO_LOCKS_P31_Pos)
+#define GPIO_LOCKS_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_LOCKS) MASK Register */
 
 /* -------- GPIO_LOCKC : (GPIO Offset: 0x1A8) ( /W 32) port Lock Register - Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -8475,70 +8475,70 @@ typedef union {
 #define GPIO_LOCKC_OFFSET           0x1A8        /**< \brief (GPIO_LOCKC offset) Lock Register - Clear */
 
 #define GPIO_LOCKC_P0_Pos           0            /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P0               (_U(0x1) << GPIO_LOCKC_P0_Pos)
+#define GPIO_LOCKC_P0               (_U_(0x1) << GPIO_LOCKC_P0_Pos)
 #define GPIO_LOCKC_P1_Pos           1            /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P1               (_U(0x1) << GPIO_LOCKC_P1_Pos)
+#define GPIO_LOCKC_P1               (_U_(0x1) << GPIO_LOCKC_P1_Pos)
 #define GPIO_LOCKC_P2_Pos           2            /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P2               (_U(0x1) << GPIO_LOCKC_P2_Pos)
+#define GPIO_LOCKC_P2               (_U_(0x1) << GPIO_LOCKC_P2_Pos)
 #define GPIO_LOCKC_P3_Pos           3            /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P3               (_U(0x1) << GPIO_LOCKC_P3_Pos)
+#define GPIO_LOCKC_P3               (_U_(0x1) << GPIO_LOCKC_P3_Pos)
 #define GPIO_LOCKC_P4_Pos           4            /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P4               (_U(0x1) << GPIO_LOCKC_P4_Pos)
+#define GPIO_LOCKC_P4               (_U_(0x1) << GPIO_LOCKC_P4_Pos)
 #define GPIO_LOCKC_P5_Pos           5            /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P5               (_U(0x1) << GPIO_LOCKC_P5_Pos)
+#define GPIO_LOCKC_P5               (_U_(0x1) << GPIO_LOCKC_P5_Pos)
 #define GPIO_LOCKC_P6_Pos           6            /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P6               (_U(0x1) << GPIO_LOCKC_P6_Pos)
+#define GPIO_LOCKC_P6               (_U_(0x1) << GPIO_LOCKC_P6_Pos)
 #define GPIO_LOCKC_P7_Pos           7            /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P7               (_U(0x1) << GPIO_LOCKC_P7_Pos)
+#define GPIO_LOCKC_P7               (_U_(0x1) << GPIO_LOCKC_P7_Pos)
 #define GPIO_LOCKC_P8_Pos           8            /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P8               (_U(0x1) << GPIO_LOCKC_P8_Pos)
+#define GPIO_LOCKC_P8               (_U_(0x1) << GPIO_LOCKC_P8_Pos)
 #define GPIO_LOCKC_P9_Pos           9            /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P9               (_U(0x1) << GPIO_LOCKC_P9_Pos)
+#define GPIO_LOCKC_P9               (_U_(0x1) << GPIO_LOCKC_P9_Pos)
 #define GPIO_LOCKC_P10_Pos          10           /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P10              (_U(0x1) << GPIO_LOCKC_P10_Pos)
+#define GPIO_LOCKC_P10              (_U_(0x1) << GPIO_LOCKC_P10_Pos)
 #define GPIO_LOCKC_P11_Pos          11           /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P11              (_U(0x1) << GPIO_LOCKC_P11_Pos)
+#define GPIO_LOCKC_P11              (_U_(0x1) << GPIO_LOCKC_P11_Pos)
 #define GPIO_LOCKC_P12_Pos          12           /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P12              (_U(0x1) << GPIO_LOCKC_P12_Pos)
+#define GPIO_LOCKC_P12              (_U_(0x1) << GPIO_LOCKC_P12_Pos)
 #define GPIO_LOCKC_P13_Pos          13           /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P13              (_U(0x1) << GPIO_LOCKC_P13_Pos)
+#define GPIO_LOCKC_P13              (_U_(0x1) << GPIO_LOCKC_P13_Pos)
 #define GPIO_LOCKC_P14_Pos          14           /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P14              (_U(0x1) << GPIO_LOCKC_P14_Pos)
+#define GPIO_LOCKC_P14              (_U_(0x1) << GPIO_LOCKC_P14_Pos)
 #define GPIO_LOCKC_P15_Pos          15           /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P15              (_U(0x1) << GPIO_LOCKC_P15_Pos)
+#define GPIO_LOCKC_P15              (_U_(0x1) << GPIO_LOCKC_P15_Pos)
 #define GPIO_LOCKC_P16_Pos          16           /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P16              (_U(0x1) << GPIO_LOCKC_P16_Pos)
+#define GPIO_LOCKC_P16              (_U_(0x1) << GPIO_LOCKC_P16_Pos)
 #define GPIO_LOCKC_P17_Pos          17           /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P17              (_U(0x1) << GPIO_LOCKC_P17_Pos)
+#define GPIO_LOCKC_P17              (_U_(0x1) << GPIO_LOCKC_P17_Pos)
 #define GPIO_LOCKC_P18_Pos          18           /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P18              (_U(0x1) << GPIO_LOCKC_P18_Pos)
+#define GPIO_LOCKC_P18              (_U_(0x1) << GPIO_LOCKC_P18_Pos)
 #define GPIO_LOCKC_P19_Pos          19           /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P19              (_U(0x1) << GPIO_LOCKC_P19_Pos)
+#define GPIO_LOCKC_P19              (_U_(0x1) << GPIO_LOCKC_P19_Pos)
 #define GPIO_LOCKC_P20_Pos          20           /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P20              (_U(0x1) << GPIO_LOCKC_P20_Pos)
+#define GPIO_LOCKC_P20              (_U_(0x1) << GPIO_LOCKC_P20_Pos)
 #define GPIO_LOCKC_P21_Pos          21           /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P21              (_U(0x1) << GPIO_LOCKC_P21_Pos)
+#define GPIO_LOCKC_P21              (_U_(0x1) << GPIO_LOCKC_P21_Pos)
 #define GPIO_LOCKC_P22_Pos          22           /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P22              (_U(0x1) << GPIO_LOCKC_P22_Pos)
+#define GPIO_LOCKC_P22              (_U_(0x1) << GPIO_LOCKC_P22_Pos)
 #define GPIO_LOCKC_P23_Pos          23           /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P23              (_U(0x1) << GPIO_LOCKC_P23_Pos)
+#define GPIO_LOCKC_P23              (_U_(0x1) << GPIO_LOCKC_P23_Pos)
 #define GPIO_LOCKC_P24_Pos          24           /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P24              (_U(0x1) << GPIO_LOCKC_P24_Pos)
+#define GPIO_LOCKC_P24              (_U_(0x1) << GPIO_LOCKC_P24_Pos)
 #define GPIO_LOCKC_P25_Pos          25           /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P25              (_U(0x1) << GPIO_LOCKC_P25_Pos)
+#define GPIO_LOCKC_P25              (_U_(0x1) << GPIO_LOCKC_P25_Pos)
 #define GPIO_LOCKC_P26_Pos          26           /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P26              (_U(0x1) << GPIO_LOCKC_P26_Pos)
+#define GPIO_LOCKC_P26              (_U_(0x1) << GPIO_LOCKC_P26_Pos)
 #define GPIO_LOCKC_P27_Pos          27           /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P27              (_U(0x1) << GPIO_LOCKC_P27_Pos)
+#define GPIO_LOCKC_P27              (_U_(0x1) << GPIO_LOCKC_P27_Pos)
 #define GPIO_LOCKC_P28_Pos          28           /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P28              (_U(0x1) << GPIO_LOCKC_P28_Pos)
+#define GPIO_LOCKC_P28              (_U_(0x1) << GPIO_LOCKC_P28_Pos)
 #define GPIO_LOCKC_P29_Pos          29           /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P29              (_U(0x1) << GPIO_LOCKC_P29_Pos)
+#define GPIO_LOCKC_P29              (_U_(0x1) << GPIO_LOCKC_P29_Pos)
 #define GPIO_LOCKC_P30_Pos          30           /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P30              (_U(0x1) << GPIO_LOCKC_P30_Pos)
+#define GPIO_LOCKC_P30              (_U_(0x1) << GPIO_LOCKC_P30_Pos)
 #define GPIO_LOCKC_P31_Pos          31           /**< \brief (GPIO_LOCKC) Lock State */
-#define GPIO_LOCKC_P31              (_U(0x1) << GPIO_LOCKC_P31_Pos)
-#define GPIO_LOCKC_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_LOCKC) MASK Register */
+#define GPIO_LOCKC_P31              (_U_(0x1) << GPIO_LOCKC_P31_Pos)
+#define GPIO_LOCKC_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_LOCKC) MASK Register */
 
 /* -------- GPIO_LOCKT : (GPIO Offset: 0x1AC) ( /W 32) port Lock Register - Toggle -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -8584,70 +8584,70 @@ typedef union {
 #define GPIO_LOCKT_OFFSET           0x1AC        /**< \brief (GPIO_LOCKT offset) Lock Register - Toggle */
 
 #define GPIO_LOCKT_P0_Pos           0            /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P0               (_U(0x1) << GPIO_LOCKT_P0_Pos)
+#define GPIO_LOCKT_P0               (_U_(0x1) << GPIO_LOCKT_P0_Pos)
 #define GPIO_LOCKT_P1_Pos           1            /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P1               (_U(0x1) << GPIO_LOCKT_P1_Pos)
+#define GPIO_LOCKT_P1               (_U_(0x1) << GPIO_LOCKT_P1_Pos)
 #define GPIO_LOCKT_P2_Pos           2            /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P2               (_U(0x1) << GPIO_LOCKT_P2_Pos)
+#define GPIO_LOCKT_P2               (_U_(0x1) << GPIO_LOCKT_P2_Pos)
 #define GPIO_LOCKT_P3_Pos           3            /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P3               (_U(0x1) << GPIO_LOCKT_P3_Pos)
+#define GPIO_LOCKT_P3               (_U_(0x1) << GPIO_LOCKT_P3_Pos)
 #define GPIO_LOCKT_P4_Pos           4            /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P4               (_U(0x1) << GPIO_LOCKT_P4_Pos)
+#define GPIO_LOCKT_P4               (_U_(0x1) << GPIO_LOCKT_P4_Pos)
 #define GPIO_LOCKT_P5_Pos           5            /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P5               (_U(0x1) << GPIO_LOCKT_P5_Pos)
+#define GPIO_LOCKT_P5               (_U_(0x1) << GPIO_LOCKT_P5_Pos)
 #define GPIO_LOCKT_P6_Pos           6            /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P6               (_U(0x1) << GPIO_LOCKT_P6_Pos)
+#define GPIO_LOCKT_P6               (_U_(0x1) << GPIO_LOCKT_P6_Pos)
 #define GPIO_LOCKT_P7_Pos           7            /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P7               (_U(0x1) << GPIO_LOCKT_P7_Pos)
+#define GPIO_LOCKT_P7               (_U_(0x1) << GPIO_LOCKT_P7_Pos)
 #define GPIO_LOCKT_P8_Pos           8            /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P8               (_U(0x1) << GPIO_LOCKT_P8_Pos)
+#define GPIO_LOCKT_P8               (_U_(0x1) << GPIO_LOCKT_P8_Pos)
 #define GPIO_LOCKT_P9_Pos           9            /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P9               (_U(0x1) << GPIO_LOCKT_P9_Pos)
+#define GPIO_LOCKT_P9               (_U_(0x1) << GPIO_LOCKT_P9_Pos)
 #define GPIO_LOCKT_P10_Pos          10           /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P10              (_U(0x1) << GPIO_LOCKT_P10_Pos)
+#define GPIO_LOCKT_P10              (_U_(0x1) << GPIO_LOCKT_P10_Pos)
 #define GPIO_LOCKT_P11_Pos          11           /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P11              (_U(0x1) << GPIO_LOCKT_P11_Pos)
+#define GPIO_LOCKT_P11              (_U_(0x1) << GPIO_LOCKT_P11_Pos)
 #define GPIO_LOCKT_P12_Pos          12           /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P12              (_U(0x1) << GPIO_LOCKT_P12_Pos)
+#define GPIO_LOCKT_P12              (_U_(0x1) << GPIO_LOCKT_P12_Pos)
 #define GPIO_LOCKT_P13_Pos          13           /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P13              (_U(0x1) << GPIO_LOCKT_P13_Pos)
+#define GPIO_LOCKT_P13              (_U_(0x1) << GPIO_LOCKT_P13_Pos)
 #define GPIO_LOCKT_P14_Pos          14           /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P14              (_U(0x1) << GPIO_LOCKT_P14_Pos)
+#define GPIO_LOCKT_P14              (_U_(0x1) << GPIO_LOCKT_P14_Pos)
 #define GPIO_LOCKT_P15_Pos          15           /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P15              (_U(0x1) << GPIO_LOCKT_P15_Pos)
+#define GPIO_LOCKT_P15              (_U_(0x1) << GPIO_LOCKT_P15_Pos)
 #define GPIO_LOCKT_P16_Pos          16           /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P16              (_U(0x1) << GPIO_LOCKT_P16_Pos)
+#define GPIO_LOCKT_P16              (_U_(0x1) << GPIO_LOCKT_P16_Pos)
 #define GPIO_LOCKT_P17_Pos          17           /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P17              (_U(0x1) << GPIO_LOCKT_P17_Pos)
+#define GPIO_LOCKT_P17              (_U_(0x1) << GPIO_LOCKT_P17_Pos)
 #define GPIO_LOCKT_P18_Pos          18           /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P18              (_U(0x1) << GPIO_LOCKT_P18_Pos)
+#define GPIO_LOCKT_P18              (_U_(0x1) << GPIO_LOCKT_P18_Pos)
 #define GPIO_LOCKT_P19_Pos          19           /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P19              (_U(0x1) << GPIO_LOCKT_P19_Pos)
+#define GPIO_LOCKT_P19              (_U_(0x1) << GPIO_LOCKT_P19_Pos)
 #define GPIO_LOCKT_P20_Pos          20           /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P20              (_U(0x1) << GPIO_LOCKT_P20_Pos)
+#define GPIO_LOCKT_P20              (_U_(0x1) << GPIO_LOCKT_P20_Pos)
 #define GPIO_LOCKT_P21_Pos          21           /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P21              (_U(0x1) << GPIO_LOCKT_P21_Pos)
+#define GPIO_LOCKT_P21              (_U_(0x1) << GPIO_LOCKT_P21_Pos)
 #define GPIO_LOCKT_P22_Pos          22           /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P22              (_U(0x1) << GPIO_LOCKT_P22_Pos)
+#define GPIO_LOCKT_P22              (_U_(0x1) << GPIO_LOCKT_P22_Pos)
 #define GPIO_LOCKT_P23_Pos          23           /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P23              (_U(0x1) << GPIO_LOCKT_P23_Pos)
+#define GPIO_LOCKT_P23              (_U_(0x1) << GPIO_LOCKT_P23_Pos)
 #define GPIO_LOCKT_P24_Pos          24           /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P24              (_U(0x1) << GPIO_LOCKT_P24_Pos)
+#define GPIO_LOCKT_P24              (_U_(0x1) << GPIO_LOCKT_P24_Pos)
 #define GPIO_LOCKT_P25_Pos          25           /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P25              (_U(0x1) << GPIO_LOCKT_P25_Pos)
+#define GPIO_LOCKT_P25              (_U_(0x1) << GPIO_LOCKT_P25_Pos)
 #define GPIO_LOCKT_P26_Pos          26           /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P26              (_U(0x1) << GPIO_LOCKT_P26_Pos)
+#define GPIO_LOCKT_P26              (_U_(0x1) << GPIO_LOCKT_P26_Pos)
 #define GPIO_LOCKT_P27_Pos          27           /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P27              (_U(0x1) << GPIO_LOCKT_P27_Pos)
+#define GPIO_LOCKT_P27              (_U_(0x1) << GPIO_LOCKT_P27_Pos)
 #define GPIO_LOCKT_P28_Pos          28           /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P28              (_U(0x1) << GPIO_LOCKT_P28_Pos)
+#define GPIO_LOCKT_P28              (_U_(0x1) << GPIO_LOCKT_P28_Pos)
 #define GPIO_LOCKT_P29_Pos          29           /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P29              (_U(0x1) << GPIO_LOCKT_P29_Pos)
+#define GPIO_LOCKT_P29              (_U_(0x1) << GPIO_LOCKT_P29_Pos)
 #define GPIO_LOCKT_P30_Pos          30           /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P30              (_U(0x1) << GPIO_LOCKT_P30_Pos)
+#define GPIO_LOCKT_P30              (_U_(0x1) << GPIO_LOCKT_P30_Pos)
 #define GPIO_LOCKT_P31_Pos          31           /**< \brief (GPIO_LOCKT) Lock State */
-#define GPIO_LOCKT_P31              (_U(0x1) << GPIO_LOCKT_P31_Pos)
-#define GPIO_LOCKT_MASK             _U(0xFFFFFFFF) /**< \brief (GPIO_LOCKT) MASK Register */
+#define GPIO_LOCKT_P31              (_U_(0x1) << GPIO_LOCKT_P31_Pos)
+#define GPIO_LOCKT_MASK             _U_(0xFFFFFFFF) /**< \brief (GPIO_LOCKT) MASK Register */
 
 /* -------- GPIO_UNLOCK : (GPIO Offset: 0x1E0) ( /W 32) port Unlock Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -8664,12 +8664,12 @@ typedef union {
 #define GPIO_UNLOCK_OFFSET          0x1E0        /**< \brief (GPIO_UNLOCK offset) Unlock Register */
 
 #define GPIO_UNLOCK_ADDR_Pos        0            /**< \brief (GPIO_UNLOCK) Offset Register */
-#define GPIO_UNLOCK_ADDR_Msk        (_U(0x3FF) << GPIO_UNLOCK_ADDR_Pos)
+#define GPIO_UNLOCK_ADDR_Msk        (_U_(0x3FF) << GPIO_UNLOCK_ADDR_Pos)
 #define GPIO_UNLOCK_ADDR(value)     (GPIO_UNLOCK_ADDR_Msk & ((value) << GPIO_UNLOCK_ADDR_Pos))
 #define GPIO_UNLOCK_KEY_Pos         24           /**< \brief (GPIO_UNLOCK) Unlocking Key */
-#define GPIO_UNLOCK_KEY_Msk         (_U(0xFF) << GPIO_UNLOCK_KEY_Pos)
+#define GPIO_UNLOCK_KEY_Msk         (_U_(0xFF) << GPIO_UNLOCK_KEY_Pos)
 #define GPIO_UNLOCK_KEY(value)      (GPIO_UNLOCK_KEY_Msk & ((value) << GPIO_UNLOCK_KEY_Pos))
-#define GPIO_UNLOCK_MASK            _U(0xFF0003FF) /**< \brief (GPIO_UNLOCK) MASK Register */
+#define GPIO_UNLOCK_MASK            _U_(0xFF0003FF) /**< \brief (GPIO_UNLOCK) MASK Register */
 
 /* -------- GPIO_ASR : (GPIO Offset: 0x1E4) (R/W 32) port Access Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -8685,8 +8685,8 @@ typedef union {
 #define GPIO_ASR_OFFSET             0x1E4        /**< \brief (GPIO_ASR offset) Access Status Register */
 
 #define GPIO_ASR_AR_Pos             0            /**< \brief (GPIO_ASR) Access Error */
-#define GPIO_ASR_AR                 (_U(0x1) << GPIO_ASR_AR_Pos)
-#define GPIO_ASR_MASK               _U(0x00000001) /**< \brief (GPIO_ASR) MASK Register */
+#define GPIO_ASR_AR                 (_U_(0x1) << GPIO_ASR_AR_Pos)
+#define GPIO_ASR_MASK               _U_(0x00000001) /**< \brief (GPIO_ASR) MASK Register */
 
 /* -------- GPIO_PARAMETER : (GPIO Offset: 0x1F8) (R/  32) port Parameter Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -8701,9 +8701,9 @@ typedef union {
 #define GPIO_PARAMETER_OFFSET       0x1F8        /**< \brief (GPIO_PARAMETER offset) Parameter Register */
 
 #define GPIO_PARAMETER_PARAMETER_Pos 0            /**< \brief (GPIO_PARAMETER) Parameter */
-#define GPIO_PARAMETER_PARAMETER_Msk (_U(0xFFFFFFFF) << GPIO_PARAMETER_PARAMETER_Pos)
+#define GPIO_PARAMETER_PARAMETER_Msk (_U_(0xFFFFFFFF) << GPIO_PARAMETER_PARAMETER_Pos)
 #define GPIO_PARAMETER_PARAMETER(value) (GPIO_PARAMETER_PARAMETER_Msk & ((value) << GPIO_PARAMETER_PARAMETER_Pos))
-#define GPIO_PARAMETER_MASK         _U(0xFFFFFFFF) /**< \brief (GPIO_PARAMETER) MASK Register */
+#define GPIO_PARAMETER_MASK         _U_(0xFFFFFFFF) /**< \brief (GPIO_PARAMETER) MASK Register */
 
 /* -------- GPIO_VERSION : (GPIO Offset: 0x1FC) (R/  32) port Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -8719,15 +8719,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GPIO_VERSION_OFFSET         0x1FC        /**< \brief (GPIO_VERSION offset) Version Register */
-#define GPIO_VERSION_RESETVALUE     _U(0x00000215); /**< \brief (GPIO_VERSION reset_value) Version Register */
+#define GPIO_VERSION_RESETVALUE     _U_(0x00000215); /**< \brief (GPIO_VERSION reset_value) Version Register */
 
 #define GPIO_VERSION_VERSION_Pos    0            /**< \brief (GPIO_VERSION) Version Number */
-#define GPIO_VERSION_VERSION_Msk    (_U(0xFFF) << GPIO_VERSION_VERSION_Pos)
+#define GPIO_VERSION_VERSION_Msk    (_U_(0xFFF) << GPIO_VERSION_VERSION_Pos)
 #define GPIO_VERSION_VERSION(value) (GPIO_VERSION_VERSION_Msk & ((value) << GPIO_VERSION_VERSION_Pos))
 #define GPIO_VERSION_VARIANT_Pos    16           /**< \brief (GPIO_VERSION) Variant Number */
-#define GPIO_VERSION_VARIANT_Msk    (_U(0xF) << GPIO_VERSION_VARIANT_Pos)
+#define GPIO_VERSION_VARIANT_Msk    (_U_(0xF) << GPIO_VERSION_VARIANT_Pos)
 #define GPIO_VERSION_VARIANT(value) (GPIO_VERSION_VARIANT_Msk & ((value) << GPIO_VERSION_VARIANT_Pos))
-#define GPIO_VERSION_MASK           _U(0x000F0FFF) /**< \brief (GPIO_VERSION) MASK Register */
+#define GPIO_VERSION_MASK           _U_(0x000F0FFF) /**< \brief (GPIO_VERSION) MASK Register */
 
 /** \brief GpioPort hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/gpio.h
+++ b/asf/sam/include/sam4l/component/gpio.h
@@ -8731,209 +8731,100 @@ typedef union {
 
 /** \brief GpioPort hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __IO GPIO_GPER_Type            GPER;        /**< \brief Offset: 0x000 (R/W 32) GPIO Enable Register */
-  __O  GPIO_GPERS_Type           GPERS;       /**< \brief Offset: 0x004 ( /W 32) GPIO Enable Register - Set */
-  __O  GPIO_GPERC_Type           GPERC;       /**< \brief Offset: 0x008 ( /W 32) GPIO Enable Register - Clear */
-  __O  GPIO_GPERT_Type           GPERT;       /**< \brief Offset: 0x00C ( /W 32) GPIO Enable Register - Toggle */
-  __IO GPIO_PMR0_Type            PMR0;        /**< \brief Offset: 0x010 (R/W 32) Peripheral Mux Register 0 */
-  __O  GPIO_PMR0S_Type           PMR0S;       /**< \brief Offset: 0x014 ( /W 32) Peripheral Mux Register 0 - Set */
-  __O  GPIO_PMR0C_Type           PMR0C;       /**< \brief Offset: 0x018 ( /W 32) Peripheral Mux Register 0 - Clear */
-  __O  GPIO_PMR0T_Type           PMR0T;       /**< \brief Offset: 0x01C ( /W 32) Peripheral Mux Register 0 - Toggle */
-  __IO GPIO_PMR1_Type            PMR1;        /**< \brief Offset: 0x020 (R/W 32) Peripheral Mux Register 1 */
-  __O  GPIO_PMR1S_Type           PMR1S;       /**< \brief Offset: 0x024 ( /W 32) Peripheral Mux Register 1 - Set */
-  __O  GPIO_PMR1C_Type           PMR1C;       /**< \brief Offset: 0x028 ( /W 32) Peripheral Mux Register 1 - Clear */
-  __O  GPIO_PMR1T_Type           PMR1T;       /**< \brief Offset: 0x02C ( /W 32) Peripheral Mux Register 1 - Toggle */
-  __IO GPIO_PMR2_Type            PMR2;        /**< \brief Offset: 0x030 (R/W 32) Peripheral Mux Register 2 */
-  __O  GPIO_PMR2S_Type           PMR2S;       /**< \brief Offset: 0x034 ( /W 32) Peripheral Mux Register 2 - Set */
-  __O  GPIO_PMR2C_Type           PMR2C;       /**< \brief Offset: 0x038 ( /W 32) Peripheral Mux Register 2 - Clear */
-  __O  GPIO_PMR2T_Type           PMR2T;       /**< \brief Offset: 0x03C ( /W 32) Peripheral Mux Register 2 - Toggle */
-  __IO GPIO_ODER_Type            ODER;        /**< \brief Offset: 0x040 (R/W 32) Output Driver Enable Register */
-  __O  GPIO_ODERS_Type           ODERS;       /**< \brief Offset: 0x044 ( /W 32) Output Driver Enable Register - Set */
-  __O  GPIO_ODERC_Type           ODERC;       /**< \brief Offset: 0x048 ( /W 32) Output Driver Enable Register - Clear */
-  __O  GPIO_ODERT_Type           ODERT;       /**< \brief Offset: 0x04C ( /W 32) Output Driver Enable Register - Toggle */
-  __IO GPIO_OVR_Type             OVR;         /**< \brief Offset: 0x050 (R/W 32) Output Value Register */
-  __O  GPIO_OVRS_Type            OVRS;        /**< \brief Offset: 0x054 ( /W 32) Output Value Register - Set */
-  __O  GPIO_OVRC_Type            OVRC;        /**< \brief Offset: 0x058 ( /W 32) Output Value Register - Clear */
-  __O  GPIO_OVRT_Type            OVRT;        /**< \brief Offset: 0x05C ( /W 32) Output Value Register - Toggle */
-  __I  GPIO_PVR_Type             PVR;         /**< \brief Offset: 0x060 (R/  32) Pin Value Register */
-       RoReg8                    Reserved1[0xC];
-  __IO GPIO_PUER_Type            PUER;        /**< \brief Offset: 0x070 (R/W 32) Pull-up Enable Register */
-  __O  GPIO_PUERS_Type           PUERS;       /**< \brief Offset: 0x074 ( /W 32) Pull-up Enable Register - Set */
-  __O  GPIO_PUERC_Type           PUERC;       /**< \brief Offset: 0x078 ( /W 32) Pull-up Enable Register - Clear */
-  __O  GPIO_PUERT_Type           PUERT;       /**< \brief Offset: 0x07C ( /W 32) Pull-up Enable Register - Toggle */
-  __IO GPIO_PDER_Type            PDER;        /**< \brief Offset: 0x080 (R/W 32) Pull-down Enable Register */
-  __O  GPIO_PDERS_Type           PDERS;       /**< \brief Offset: 0x084 ( /W 32) Pull-down Enable Register - Set */
-  __O  GPIO_PDERC_Type           PDERC;       /**< \brief Offset: 0x088 ( /W 32) Pull-down Enable Register - Clear */
-  __O  GPIO_PDERT_Type           PDERT;       /**< \brief Offset: 0x08C ( /W 32) Pull-down Enable Register - Toggle */
-  __IO GPIO_IER_Type             IER;         /**< \brief Offset: 0x090 (R/W 32) Interrupt Enable Register */
-  __O  GPIO_IERS_Type            IERS;        /**< \brief Offset: 0x094 ( /W 32) Interrupt Enable Register - Set */
-  __O  GPIO_IERC_Type            IERC;        /**< \brief Offset: 0x098 ( /W 32) Interrupt Enable Register - Clear */
-  __O  GPIO_IERT_Type            IERT;        /**< \brief Offset: 0x09C ( /W 32) Interrupt Enable Register - Toggle */
-  __IO GPIO_IMR0_Type            IMR0;        /**< \brief Offset: 0x0A0 (R/W 32) Interrupt Mode Register 0 */
-  __O  GPIO_IMR0S_Type           IMR0S;       /**< \brief Offset: 0x0A4 ( /W 32) Interrupt Mode Register 0 - Set */
-  __O  GPIO_IMR0C_Type           IMR0C;       /**< \brief Offset: 0x0A8 ( /W 32) Interrupt Mode Register 0 - Clear */
-  __O  GPIO_IMR0T_Type           IMR0T;       /**< \brief Offset: 0x0AC ( /W 32) Interrupt Mode Register 0 - Toggle */
-  __IO GPIO_IMR1_Type            IMR1;        /**< \brief Offset: 0x0B0 (R/W 32) Interrupt Mode Register 1 */
-  __O  GPIO_IMR1S_Type           IMR1S;       /**< \brief Offset: 0x0B4 ( /W 32) Interrupt Mode Register 1 - Set */
-  __O  GPIO_IMR1C_Type           IMR1C;       /**< \brief Offset: 0x0B8 ( /W 32) Interrupt Mode Register 1 - Clear */
-  __O  GPIO_IMR1T_Type           IMR1T;       /**< \brief Offset: 0x0BC ( /W 32) Interrupt Mode Register 1 - Toggle */
-  __IO GPIO_GFER_Type            GFER;        /**< \brief Offset: 0x0C0 (R/W 32) Glitch Filter Enable Register */
-  __O  GPIO_GFERS_Type           GFERS;       /**< \brief Offset: 0x0C4 ( /W 32) Glitch Filter Enable Register - Set */
-  __O  GPIO_GFERC_Type           GFERC;       /**< \brief Offset: 0x0C8 ( /W 32) Glitch Filter Enable Register - Clear */
-  __O  GPIO_GFERT_Type           GFERT;       /**< \brief Offset: 0x0CC ( /W 32) Glitch Filter Enable Register - Toggle */
-  __I  GPIO_IFR_Type             IFR;         /**< \brief Offset: 0x0D0 (R/  32) Interrupt Flag Register */
-       RoReg8                    Reserved2[0x4];
-  __O  GPIO_IFRC_Type            IFRC;        /**< \brief Offset: 0x0D8 ( /W 32) Interrupt Flag Register - Clear */
-       RoReg8                    Reserved3[0x4];
-  __IO GPIO_ODMER_Type           ODMER;       /**< \brief Offset: 0x0E0 (R/W 32) Open Drain Mode Register */
-  __O  GPIO_ODMERS_Type          ODMERS;      /**< \brief Offset: 0x0E4 ( /W 32) Open Drain Mode Register - Set */
-  __O  GPIO_ODMERC_Type          ODMERC;      /**< \brief Offset: 0x0E8 ( /W 32) Open Drain Mode Register - Clear */
-  __O  GPIO_ODMERT_Type          ODMERT;      /**< \brief Offset: 0x0EC ( /W 32) Open Drain Mode Register - Toggle */
-       RoReg8                    Reserved4[0x10];
-  __IO GPIO_ODCR0_Type           ODCR0;       /**< \brief Offset: 0x100 (R/W 32) Output Driving Capability Register 0 */
-  __IO GPIO_ODCR0S_Type          ODCR0S;      /**< \brief Offset: 0x104 (R/W 32) Output Driving Capability Register 0 - Set */
-  __IO GPIO_ODCR0C_Type          ODCR0C;      /**< \brief Offset: 0x108 (R/W 32) Output Driving Capability Register 0 - Clear */
-  __IO GPIO_ODCR0T_Type          ODCR0T;      /**< \brief Offset: 0x10C (R/W 32) Output Driving Capability Register 0 - Toggle */
-  __IO GPIO_ODCR1_Type           ODCR1;       /**< \brief Offset: 0x110 (R/W 32) Output Driving Capability Register 1 */
-  __IO GPIO_ODCR1S_Type          ODCR1S;      /**< \brief Offset: 0x114 (R/W 32) Output Driving Capability Register 1 - Set */
-  __IO GPIO_ODCR1C_Type          ODCR1C;      /**< \brief Offset: 0x118 (R/W 32) Output Driving Capability Register 1 - Clear */
-  __IO GPIO_ODCR1T_Type          ODCR1T;      /**< \brief Offset: 0x11C (R/W 32) Output Driving Capability Register 1 - Toggle */
-       RoReg8                    Reserved5[0x10];
-  __IO GPIO_OSRR0_Type           OSRR0;       /**< \brief Offset: 0x130 (R/W 32) Output Slew Rate Register 0 */
-  __IO GPIO_OSRR0S_Type          OSRR0S;      /**< \brief Offset: 0x134 (R/W 32) Output Slew Rate Register 0 - Set */
-  __IO GPIO_OSRR0C_Type          OSRR0C;      /**< \brief Offset: 0x138 (R/W 32) Output Slew Rate Register 0 - Clear */
-  __IO GPIO_OSRR0T_Type          OSRR0T;      /**< \brief Offset: 0x13C (R/W 32) Output Slew Rate Register 0 - Toggle */
-       RoReg8                    Reserved6[0x20];
-  __IO GPIO_STER_Type            STER;        /**< \brief Offset: 0x160 (R/W 32) Schmitt Trigger Enable Register */
-  __IO GPIO_STERS_Type           STERS;       /**< \brief Offset: 0x164 (R/W 32) Schmitt Trigger Enable Register - Set */
-  __IO GPIO_STERC_Type           STERC;       /**< \brief Offset: 0x168 (R/W 32) Schmitt Trigger Enable Register - Clear */
-  __IO GPIO_STERT_Type           STERT;       /**< \brief Offset: 0x16C (R/W 32) Schmitt Trigger Enable Register - Toggle */
-       RoReg8                    Reserved7[0x10];
-  __IO GPIO_EVER_Type            EVER;        /**< \brief Offset: 0x180 (R/W 32) Event Enable Register */
-  __O  GPIO_EVERS_Type           EVERS;       /**< \brief Offset: 0x184 ( /W 32) Event Enable Register - Set */
-  __O  GPIO_EVERC_Type           EVERC;       /**< \brief Offset: 0x188 ( /W 32) Event Enable Register - Clear */
-  __O  GPIO_EVERT_Type           EVERT;       /**< \brief Offset: 0x18C ( /W 32) Event Enable Register - Toggle */
-       RoReg8                    Reserved8[0x10];
-  __IO GPIO_LOCK_Type            LOCK;        /**< \brief Offset: 0x1A0 (R/W 32) Lock Register */
-  __O  GPIO_LOCKS_Type           LOCKS;       /**< \brief Offset: 0x1A4 ( /W 32) Lock Register - Set */
-  __O  GPIO_LOCKC_Type           LOCKC;       /**< \brief Offset: 0x1A8 ( /W 32) Lock Register - Clear */
-  __O  GPIO_LOCKT_Type           LOCKT;       /**< \brief Offset: 0x1AC ( /W 32) Lock Register - Toggle */
-       RoReg8                    Reserved9[0x30];
-  __O  GPIO_UNLOCK_Type          UNLOCK;      /**< \brief Offset: 0x1E0 ( /W 32) Unlock Register */
-  __IO GPIO_ASR_Type             ASR;         /**< \brief Offset: 0x1E4 (R/W 32) Access Status Register */
-       RoReg8                    Reserved10[0x10];
-  __I  GPIO_PARAMETER_Type       PARAMETER;   /**< \brief Offset: 0x1F8 (R/  32) Parameter Register */
-  __I  GPIO_VERSION_Type         VERSION;     /**< \brief Offset: 0x1FC (R/  32) Version Register */
- } bf;
- struct {
-  RwReg   GPIO_GPER;          /**< \brief (GPIO Offset: 0x000) GPIO Enable Register */
-  WoReg   GPIO_GPERS;         /**< \brief (GPIO Offset: 0x004) GPIO Enable Register - Set */
-  WoReg   GPIO_GPERC;         /**< \brief (GPIO Offset: 0x008) GPIO Enable Register - Clear */
-  WoReg   GPIO_GPERT;         /**< \brief (GPIO Offset: 0x00C) GPIO Enable Register - Toggle */
-  RwReg   GPIO_PMR0;          /**< \brief (GPIO Offset: 0x010) Peripheral Mux Register 0 */
-  WoReg   GPIO_PMR0S;         /**< \brief (GPIO Offset: 0x014) Peripheral Mux Register 0 - Set */
-  WoReg   GPIO_PMR0C;         /**< \brief (GPIO Offset: 0x018) Peripheral Mux Register 0 - Clear */
-  WoReg   GPIO_PMR0T;         /**< \brief (GPIO Offset: 0x01C) Peripheral Mux Register 0 - Toggle */
-  RwReg   GPIO_PMR1;          /**< \brief (GPIO Offset: 0x020) Peripheral Mux Register 1 */
-  WoReg   GPIO_PMR1S;         /**< \brief (GPIO Offset: 0x024) Peripheral Mux Register 1 - Set */
-  WoReg   GPIO_PMR1C;         /**< \brief (GPIO Offset: 0x028) Peripheral Mux Register 1 - Clear */
-  WoReg   GPIO_PMR1T;         /**< \brief (GPIO Offset: 0x02C) Peripheral Mux Register 1 - Toggle */
-  RwReg   GPIO_PMR2;          /**< \brief (GPIO Offset: 0x030) Peripheral Mux Register 2 */
-  WoReg   GPIO_PMR2S;         /**< \brief (GPIO Offset: 0x034) Peripheral Mux Register 2 - Set */
-  WoReg   GPIO_PMR2C;         /**< \brief (GPIO Offset: 0x038) Peripheral Mux Register 2 - Clear */
-  WoReg   GPIO_PMR2T;         /**< \brief (GPIO Offset: 0x03C) Peripheral Mux Register 2 - Toggle */
-  RwReg   GPIO_ODER;          /**< \brief (GPIO Offset: 0x040) Output Driver Enable Register */
-  WoReg   GPIO_ODERS;         /**< \brief (GPIO Offset: 0x044) Output Driver Enable Register - Set */
-  WoReg   GPIO_ODERC;         /**< \brief (GPIO Offset: 0x048) Output Driver Enable Register - Clear */
-  WoReg   GPIO_ODERT;         /**< \brief (GPIO Offset: 0x04C) Output Driver Enable Register - Toggle */
-  RwReg   GPIO_OVR;           /**< \brief (GPIO Offset: 0x050) Output Value Register */
-  WoReg   GPIO_OVRS;          /**< \brief (GPIO Offset: 0x054) Output Value Register - Set */
-  WoReg   GPIO_OVRC;          /**< \brief (GPIO Offset: 0x058) Output Value Register - Clear */
-  WoReg   GPIO_OVRT;          /**< \brief (GPIO Offset: 0x05C) Output Value Register - Toggle */
-  RoReg   GPIO_PVR;           /**< \brief (GPIO Offset: 0x060) Pin Value Register */
-  RoReg8  Reserved11[0xC];
-  RwReg   GPIO_PUER;          /**< \brief (GPIO Offset: 0x070) Pull-up Enable Register */
-  WoReg   GPIO_PUERS;         /**< \brief (GPIO Offset: 0x074) Pull-up Enable Register - Set */
-  WoReg   GPIO_PUERC;         /**< \brief (GPIO Offset: 0x078) Pull-up Enable Register - Clear */
-  WoReg   GPIO_PUERT;         /**< \brief (GPIO Offset: 0x07C) Pull-up Enable Register - Toggle */
-  RwReg   GPIO_PDER;          /**< \brief (GPIO Offset: 0x080) Pull-down Enable Register */
-  WoReg   GPIO_PDERS;         /**< \brief (GPIO Offset: 0x084) Pull-down Enable Register - Set */
-  WoReg   GPIO_PDERC;         /**< \brief (GPIO Offset: 0x088) Pull-down Enable Register - Clear */
-  WoReg   GPIO_PDERT;         /**< \brief (GPIO Offset: 0x08C) Pull-down Enable Register - Toggle */
-  RwReg   GPIO_IER;           /**< \brief (GPIO Offset: 0x090) Interrupt Enable Register */
-  WoReg   GPIO_IERS;          /**< \brief (GPIO Offset: 0x094) Interrupt Enable Register - Set */
-  WoReg   GPIO_IERC;          /**< \brief (GPIO Offset: 0x098) Interrupt Enable Register - Clear */
-  WoReg   GPIO_IERT;          /**< \brief (GPIO Offset: 0x09C) Interrupt Enable Register - Toggle */
-  RwReg   GPIO_IMR0;          /**< \brief (GPIO Offset: 0x0A0) Interrupt Mode Register 0 */
-  WoReg   GPIO_IMR0S;         /**< \brief (GPIO Offset: 0x0A4) Interrupt Mode Register 0 - Set */
-  WoReg   GPIO_IMR0C;         /**< \brief (GPIO Offset: 0x0A8) Interrupt Mode Register 0 - Clear */
-  WoReg   GPIO_IMR0T;         /**< \brief (GPIO Offset: 0x0AC) Interrupt Mode Register 0 - Toggle */
-  RwReg   GPIO_IMR1;          /**< \brief (GPIO Offset: 0x0B0) Interrupt Mode Register 1 */
-  WoReg   GPIO_IMR1S;         /**< \brief (GPIO Offset: 0x0B4) Interrupt Mode Register 1 - Set */
-  WoReg   GPIO_IMR1C;         /**< \brief (GPIO Offset: 0x0B8) Interrupt Mode Register 1 - Clear */
-  WoReg   GPIO_IMR1T;         /**< \brief (GPIO Offset: 0x0BC) Interrupt Mode Register 1 - Toggle */
-  RwReg   GPIO_GFER;          /**< \brief (GPIO Offset: 0x0C0) Glitch Filter Enable Register */
-  WoReg   GPIO_GFERS;         /**< \brief (GPIO Offset: 0x0C4) Glitch Filter Enable Register - Set */
-  WoReg   GPIO_GFERC;         /**< \brief (GPIO Offset: 0x0C8) Glitch Filter Enable Register - Clear */
-  WoReg   GPIO_GFERT;         /**< \brief (GPIO Offset: 0x0CC) Glitch Filter Enable Register - Toggle */
-  RoReg   GPIO_IFR;           /**< \brief (GPIO Offset: 0x0D0) Interrupt Flag Register */
-  RoReg8  Reserved12[0x4];
-  WoReg   GPIO_IFRC;          /**< \brief (GPIO Offset: 0x0D8) Interrupt Flag Register - Clear */
-  RoReg8  Reserved13[0x4];
-  RwReg   GPIO_ODMER;         /**< \brief (GPIO Offset: 0x0E0) Open Drain Mode Register */
-  WoReg   GPIO_ODMERS;        /**< \brief (GPIO Offset: 0x0E4) Open Drain Mode Register - Set */
-  WoReg   GPIO_ODMERC;        /**< \brief (GPIO Offset: 0x0E8) Open Drain Mode Register - Clear */
-  WoReg   GPIO_ODMERT;        /**< \brief (GPIO Offset: 0x0EC) Open Drain Mode Register - Toggle */
-  RoReg8  Reserved14[0x10];
-  RwReg   GPIO_ODCR0;         /**< \brief (GPIO Offset: 0x100) Output Driving Capability Register 0 */
-  RwReg   GPIO_ODCR0S;        /**< \brief (GPIO Offset: 0x104) Output Driving Capability Register 0 - Set */
-  RwReg   GPIO_ODCR0C;        /**< \brief (GPIO Offset: 0x108) Output Driving Capability Register 0 - Clear */
-  RwReg   GPIO_ODCR0T;        /**< \brief (GPIO Offset: 0x10C) Output Driving Capability Register 0 - Toggle */
-  RwReg   GPIO_ODCR1;         /**< \brief (GPIO Offset: 0x110) Output Driving Capability Register 1 */
-  RwReg   GPIO_ODCR1S;        /**< \brief (GPIO Offset: 0x114) Output Driving Capability Register 1 - Set */
-  RwReg   GPIO_ODCR1C;        /**< \brief (GPIO Offset: 0x118) Output Driving Capability Register 1 - Clear */
-  RwReg   GPIO_ODCR1T;        /**< \brief (GPIO Offset: 0x11C) Output Driving Capability Register 1 - Toggle */
-  RoReg8  Reserved15[0x10];
-  RwReg   GPIO_OSRR0;         /**< \brief (GPIO Offset: 0x130) Output Slew Rate Register 0 */
-  RwReg   GPIO_OSRR0S;        /**< \brief (GPIO Offset: 0x134) Output Slew Rate Register 0 - Set */
-  RwReg   GPIO_OSRR0C;        /**< \brief (GPIO Offset: 0x138) Output Slew Rate Register 0 - Clear */
-  RwReg   GPIO_OSRR0T;        /**< \brief (GPIO Offset: 0x13C) Output Slew Rate Register 0 - Toggle */
-  RoReg8  Reserved16[0x20];
-  RwReg   GPIO_STER;          /**< \brief (GPIO Offset: 0x160) Schmitt Trigger Enable Register */
-  RwReg   GPIO_STERS;         /**< \brief (GPIO Offset: 0x164) Schmitt Trigger Enable Register - Set */
-  RwReg   GPIO_STERC;         /**< \brief (GPIO Offset: 0x168) Schmitt Trigger Enable Register - Clear */
-  RwReg   GPIO_STERT;         /**< \brief (GPIO Offset: 0x16C) Schmitt Trigger Enable Register - Toggle */
-  RoReg8  Reserved17[0x10];
-  RwReg   GPIO_EVER;          /**< \brief (GPIO Offset: 0x180) Event Enable Register */
-  WoReg   GPIO_EVERS;         /**< \brief (GPIO Offset: 0x184) Event Enable Register - Set */
-  WoReg   GPIO_EVERC;         /**< \brief (GPIO Offset: 0x188) Event Enable Register - Clear */
-  WoReg   GPIO_EVERT;         /**< \brief (GPIO Offset: 0x18C) Event Enable Register - Toggle */
-  RoReg8  Reserved18[0x10];
-  RwReg   GPIO_LOCK;          /**< \brief (GPIO Offset: 0x1A0) Lock Register */
-  WoReg   GPIO_LOCKS;         /**< \brief (GPIO Offset: 0x1A4) Lock Register - Set */
-  WoReg   GPIO_LOCKC;         /**< \brief (GPIO Offset: 0x1A8) Lock Register - Clear */
-  WoReg   GPIO_LOCKT;         /**< \brief (GPIO Offset: 0x1AC) Lock Register - Toggle */
-  RoReg8  Reserved19[0x30];
-  WoReg   GPIO_UNLOCK;        /**< \brief (GPIO Offset: 0x1E0) Unlock Register */
-  RwReg   GPIO_ASR;           /**< \brief (GPIO Offset: 0x1E4) Access Status Register */
-  RoReg8  Reserved20[0x10];
-  RoReg   GPIO_PARAMETER;     /**< \brief (GPIO Offset: 0x1F8) Parameter Register */
-  RoReg   GPIO_VERSION;       /**< \brief (GPIO Offset: 0x1FC) Version Register */
- } reg;
-} GpioPort;
-#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-/** \brief GPIO hardware registers */
-#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-       GpioPort                  Port[3];     /**< \brief Offset: 0x000 GpioPort groups [PORT_LENGTH] */
- } bf;
- struct {
-  GpioPort GPIO_PORT[3];       /**< \brief (GPIO Offset: 0x000) GpioPort groups [PORT_LENGTH] */
- } reg;
+typedef struct {
+  __IO uint32_t GPER;        /**< \brief Offset: 0x000 (R/W 32) GPIO Enable Register */
+  __O  uint32_t GPERS;       /**< \brief Offset: 0x004 ( /W 32) GPIO Enable Register - Set */
+  __O  uint32_t GPERC;       /**< \brief Offset: 0x008 ( /W 32) GPIO Enable Register - Clear */
+  __O  uint32_t GPERT;       /**< \brief Offset: 0x00C ( /W 32) GPIO Enable Register - Toggle */
+  __IO uint32_t PMR0;        /**< \brief Offset: 0x010 (R/W 32) Peripheral Mux Register 0 */
+  __O  uint32_t PMR0S;       /**< \brief Offset: 0x014 ( /W 32) Peripheral Mux Register 0 - Set */
+  __O  uint32_t PMR0C;       /**< \brief Offset: 0x018 ( /W 32) Peripheral Mux Register 0 - Clear */
+  __O  uint32_t PMR0T;       /**< \brief Offset: 0x01C ( /W 32) Peripheral Mux Register 0 - Toggle */
+  __IO uint32_t PMR1;        /**< \brief Offset: 0x020 (R/W 32) Peripheral Mux Register 1 */
+  __O  uint32_t PMR1S;       /**< \brief Offset: 0x024 ( /W 32) Peripheral Mux Register 1 - Set */
+  __O  uint32_t PMR1C;       /**< \brief Offset: 0x028 ( /W 32) Peripheral Mux Register 1 - Clear */
+  __O  uint32_t PMR1T;       /**< \brief Offset: 0x02C ( /W 32) Peripheral Mux Register 1 - Toggle */
+  __IO uint32_t PMR2;        /**< \brief Offset: 0x030 (R/W 32) Peripheral Mux Register 2 */
+  __O  uint32_t PMR2S;       /**< \brief Offset: 0x034 ( /W 32) Peripheral Mux Register 2 - Set */
+  __O  uint32_t PMR2C;       /**< \brief Offset: 0x038 ( /W 32) Peripheral Mux Register 2 - Clear */
+  __O  uint32_t PMR2T;       /**< \brief Offset: 0x03C ( /W 32) Peripheral Mux Register 2 - Toggle */
+  __IO uint32_t ODER;        /**< \brief Offset: 0x040 (R/W 32) Output Driver Enable Register */
+  __O  uint32_t ODERS;       /**< \brief Offset: 0x044 ( /W 32) Output Driver Enable Register - Set */
+  __O  uint32_t ODERC;       /**< \brief Offset: 0x048 ( /W 32) Output Driver Enable Register - Clear */
+  __O  uint32_t ODERT;       /**< \brief Offset: 0x04C ( /W 32) Output Driver Enable Register - Toggle */
+  __IO uint32_t OVR;         /**< \brief Offset: 0x050 (R/W 32) Output Value Register */
+  __O  uint32_t OVRS;        /**< \brief Offset: 0x054 ( /W 32) Output Value Register - Set */
+  __O  uint32_t OVRC;        /**< \brief Offset: 0x058 ( /W 32) Output Value Register - Clear */
+  __O  uint32_t OVRT;        /**< \brief Offset: 0x05C ( /W 32) Output Value Register - Toggle */
+  __I  uint32_t PVR;         /**< \brief Offset: 0x060 (R/  32) Pin Value Register */
+       RoReg8   Reserved1[0xC];
+  __IO uint32_t PUER;        /**< \brief Offset: 0x070 (R/W 32) Pull-up Enable Register */
+  __O  uint32_t PUERS;       /**< \brief Offset: 0x074 ( /W 32) Pull-up Enable Register - Set */
+  __O  uint32_t PUERC;       /**< \brief Offset: 0x078 ( /W 32) Pull-up Enable Register - Clear */
+  __O  uint32_t PUERT;       /**< \brief Offset: 0x07C ( /W 32) Pull-up Enable Register - Toggle */
+  __IO uint32_t PDER;        /**< \brief Offset: 0x080 (R/W 32) Pull-down Enable Register */
+  __O  uint32_t PDERS;       /**< \brief Offset: 0x084 ( /W 32) Pull-down Enable Register - Set */
+  __O  uint32_t PDERC;       /**< \brief Offset: 0x088 ( /W 32) Pull-down Enable Register - Clear */
+  __O  uint32_t PDERT;       /**< \brief Offset: 0x08C ( /W 32) Pull-down Enable Register - Toggle */
+  __IO uint32_t IER;         /**< \brief Offset: 0x090 (R/W 32) Interrupt Enable Register */
+  __O  uint32_t IERS;        /**< \brief Offset: 0x094 ( /W 32) Interrupt Enable Register - Set */
+  __O  uint32_t IERC;        /**< \brief Offset: 0x098 ( /W 32) Interrupt Enable Register - Clear */
+  __O  uint32_t IERT;        /**< \brief Offset: 0x09C ( /W 32) Interrupt Enable Register - Toggle */
+  __IO uint32_t IMR0;        /**< \brief Offset: 0x0A0 (R/W 32) Interrupt Mode Register 0 */
+  __O  uint32_t IMR0S;       /**< \brief Offset: 0x0A4 ( /W 32) Interrupt Mode Register 0 - Set */
+  __O  uint32_t IMR0C;       /**< \brief Offset: 0x0A8 ( /W 32) Interrupt Mode Register 0 - Clear */
+  __O  uint32_t IMR0T;       /**< \brief Offset: 0x0AC ( /W 32) Interrupt Mode Register 0 - Toggle */
+  __IO uint32_t IMR1;        /**< \brief Offset: 0x0B0 (R/W 32) Interrupt Mode Register 1 */
+  __O  uint32_t IMR1S;       /**< \brief Offset: 0x0B4 ( /W 32) Interrupt Mode Register 1 - Set */
+  __O  uint32_t IMR1C;       /**< \brief Offset: 0x0B8 ( /W 32) Interrupt Mode Register 1 - Clear */
+  __O  uint32_t IMR1T;       /**< \brief Offset: 0x0BC ( /W 32) Interrupt Mode Register 1 - Toggle */
+  __IO uint32_t GFER;        /**< \brief Offset: 0x0C0 (R/W 32) Glitch Filter Enable Register */
+  __O  uint32_t GFERS;       /**< \brief Offset: 0x0C4 ( /W 32) Glitch Filter Enable Register - Set */
+  __O  uint32_t GFERC;       /**< \brief Offset: 0x0C8 ( /W 32) Glitch Filter Enable Register - Clear */
+  __O  uint32_t GFERT;       /**< \brief Offset: 0x0CC ( /W 32) Glitch Filter Enable Register - Toggle */
+  __I  uint32_t IFR;         /**< \brief Offset: 0x0D0 (R/  32) Interrupt Flag Register */
+       RoReg8   Reserved2[0x4];
+  __O  uint32_t IFRC;        /**< \brief Offset: 0x0D8 ( /W 32) Interrupt Flag Register - Clear */
+       RoReg8   Reserved3[0x4];
+  __IO uint32_t ODMER;       /**< \brief Offset: 0x0E0 (R/W 32) Open Drain Mode Register */
+  __O  uint32_t ODMERS;      /**< \brief Offset: 0x0E4 ( /W 32) Open Drain Mode Register - Set */
+  __O  uint32_t ODMERC;      /**< \brief Offset: 0x0E8 ( /W 32) Open Drain Mode Register - Clear */
+  __O  uint32_t ODMERT;      /**< \brief Offset: 0x0EC ( /W 32) Open Drain Mode Register - Toggle */
+       RoReg8   Reserved4[0x10];
+  __IO uint32_t ODCR0;       /**< \brief Offset: 0x100 (R/W 32) Output Driving Capability Register 0 */
+  __IO uint32_t ODCR0S;      /**< \brief Offset: 0x104 (R/W 32) Output Driving Capability Register 0 - Set */
+  __IO uint32_t ODCR0C;      /**< \brief Offset: 0x108 (R/W 32) Output Driving Capability Register 0 - Clear */
+  __IO uint32_t ODCR0T;      /**< \brief Offset: 0x10C (R/W 32) Output Driving Capability Register 0 - Toggle */
+  __IO uint32_t ODCR1;       /**< \brief Offset: 0x110 (R/W 32) Output Driving Capability Register 1 */
+  __IO uint32_t ODCR1S;      /**< \brief Offset: 0x114 (R/W 32) Output Driving Capability Register 1 - Set */
+  __IO uint32_t ODCR1C;      /**< \brief Offset: 0x118 (R/W 32) Output Driving Capability Register 1 - Clear */
+  __IO uint32_t ODCR1T;      /**< \brief Offset: 0x11C (R/W 32) Output Driving Capability Register 1 - Toggle */
+       RoReg8   Reserved5[0x10];
+  __IO uint32_t OSRR0;       /**< \brief Offset: 0x130 (R/W 32) Output Slew Rate Register 0 */
+  __IO uint32_t OSRR0S;      /**< \brief Offset: 0x134 (R/W 32) Output Slew Rate Register 0 - Set */
+  __IO uint32_t OSRR0C;      /**< \brief Offset: 0x138 (R/W 32) Output Slew Rate Register 0 - Clear */
+  __IO uint32_t OSRR0T;      /**< \brief Offset: 0x13C (R/W 32) Output Slew Rate Register 0 - Toggle */
+       RoReg8   Reserved6[0x20];
+  __IO uint32_t STER;        /**< \brief Offset: 0x160 (R/W 32) Schmitt Trigger Enable Register */
+  __IO uint32_t STERS;       /**< \brief Offset: 0x164 (R/W 32) Schmitt Trigger Enable Register - Set */
+  __IO uint32_t STERC;       /**< \brief Offset: 0x168 (R/W 32) Schmitt Trigger Enable Register - Clear */
+  __IO uint32_t STERT;       /**< \brief Offset: 0x16C (R/W 32) Schmitt Trigger Enable Register - Toggle */
+       RoReg8   Reserved7[0x10];
+  __IO uint32_t EVER;        /**< \brief Offset: 0x180 (R/W 32) Event Enable Register */
+  __O  uint32_t EVERS;       /**< \brief Offset: 0x184 ( /W 32) Event Enable Register - Set */
+  __O  uint32_t EVERC;       /**< \brief Offset: 0x188 ( /W 32) Event Enable Register - Clear */
+  __O  uint32_t EVERT;       /**< \brief Offset: 0x18C ( /W 32) Event Enable Register - Toggle */
+       RoReg8   Reserved8[0x10];
+  __IO uint32_t LOCK;        /**< \brief Offset: 0x1A0 (R/W 32) Lock Register */
+  __O  uint32_t LOCKS;       /**< \brief Offset: 0x1A4 ( /W 32) Lock Register - Set */
+  __O  uint32_t LOCKC;       /**< \brief Offset: 0x1A8 ( /W 32) Lock Register - Clear */
+  __O  uint32_t LOCKT;       /**< \brief Offset: 0x1AC ( /W 32) Lock Register - Toggle */
+       RoReg8   Reserved9[0x30];
+  __O  uint32_t UNLOCK;      /**< \brief Offset: 0x1E0 ( /W 32) Unlock Register */
+  __IO uint32_t ASR;         /**< \brief Offset: 0x1E4 (R/W 32) Access Status Register */
+       RoReg8   Reserved10[0x10];
+  __I  uint32_t PARAMETER;   /**< \brief Offset: 0x1F8 (R/  32) Parameter Register */
+  __I  uint32_t VERSION;     /**< \brief Offset: 0x1FC (R/  32) Version Register */
 } Gpio;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/hcache.h
+++ b/asf/sam/include/sam4l/component/hcache.h
@@ -1,0 +1,266 @@
+/**
+ * \file
+ *
+ * \brief Component description for HCACHE
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_HCACHE_COMPONENT_
+#define _SAM4L_HCACHE_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR HCACHE */
+/* ========================================================================== */
+/** \addtogroup SAM4L_HCACHE Cortex M I&D Cache Controller */
+/*@{*/
+
+#define HCACHE_I8323
+#define REV_HCACHE                  0x101
+
+/* -------- HCACHE_CTRL : (HCACHE Offset: 0x08) ( /W 32) Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CEN:1;            /*!< bit:      0  Cache Enable                       */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} HCACHE_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HCACHE_CTRL_OFFSET          0x08         /**< \brief (HCACHE_CTRL offset) Control Register */
+
+#define HCACHE_CTRL_CEN_Pos         0            /**< \brief (HCACHE_CTRL) Cache Enable */
+#define HCACHE_CTRL_CEN             (_U(0x1) << HCACHE_CTRL_CEN_Pos)
+#define   HCACHE_CTRL_CEN_NO_Val          _U(0x0)   /**< \brief (HCACHE_CTRL) Disable Cache Controller */
+#define   HCACHE_CTRL_CEN_YES_Val         _U(0x1)   /**< \brief (HCACHE_CTRL) Enable Cache Controller */
+#define HCACHE_CTRL_CEN_NO          (HCACHE_CTRL_CEN_NO_Val        << HCACHE_CTRL_CEN_Pos)
+#define HCACHE_CTRL_CEN_YES         (HCACHE_CTRL_CEN_YES_Val       << HCACHE_CTRL_CEN_Pos)
+#define HCACHE_CTRL_MASK            _U(0x00000001) /**< \brief (HCACHE_CTRL) MASK Register */
+
+/* -------- HCACHE_SR : (HCACHE Offset: 0x0C) (R/W 32) Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CSTS:1;           /*!< bit:      0  Cache Controller Status            */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} HCACHE_SR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HCACHE_SR_OFFSET            0x0C         /**< \brief (HCACHE_SR offset) Status Register */
+
+#define HCACHE_SR_CSTS_Pos          0            /**< \brief (HCACHE_SR) Cache Controller Status */
+#define HCACHE_SR_CSTS              (_U(0x1) << HCACHE_SR_CSTS_Pos)
+#define   HCACHE_SR_CSTS_DIS_Val          _U(0x0)   /**< \brief (HCACHE_SR) Cache Controller Disabled */
+#define   HCACHE_SR_CSTS_EN_Val           _U(0x1)   /**< \brief (HCACHE_SR) Cache Controller Enabled */
+#define HCACHE_SR_CSTS_DIS          (HCACHE_SR_CSTS_DIS_Val        << HCACHE_SR_CSTS_Pos)
+#define HCACHE_SR_CSTS_EN           (HCACHE_SR_CSTS_EN_Val         << HCACHE_SR_CSTS_Pos)
+#define HCACHE_SR_MASK              _U(0x00000001) /**< \brief (HCACHE_SR) MASK Register */
+
+/* -------- HCACHE_MAINT0 : (HCACHE Offset: 0x20) ( /W 32) Maintenance Register 0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t INVALL:1;         /*!< bit:      0  Cache Controller Invalidate All    */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} HCACHE_MAINT0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HCACHE_MAINT0_OFFSET        0x20         /**< \brief (HCACHE_MAINT0 offset) Maintenance Register 0 */
+
+#define HCACHE_MAINT0_INVALL_Pos    0            /**< \brief (HCACHE_MAINT0) Cache Controller Invalidate All */
+#define HCACHE_MAINT0_INVALL        (_U(0x1) << HCACHE_MAINT0_INVALL_Pos)
+#define   HCACHE_MAINT0_INVALL_NO_Val     _U(0x0)   /**< \brief (HCACHE_MAINT0) No effect */
+#define   HCACHE_MAINT0_INVALL_YES_Val    _U(0x1)   /**< \brief (HCACHE_MAINT0) Invalidate all cache entries */
+#define HCACHE_MAINT0_INVALL_NO     (HCACHE_MAINT0_INVALL_NO_Val   << HCACHE_MAINT0_INVALL_Pos)
+#define HCACHE_MAINT0_INVALL_YES    (HCACHE_MAINT0_INVALL_YES_Val  << HCACHE_MAINT0_INVALL_Pos)
+#define HCACHE_MAINT0_MASK          _U(0x00000001) /**< \brief (HCACHE_MAINT0) MASK Register */
+
+/* -------- HCACHE_MAINT1 : (HCACHE Offset: 0x24) ( /W 32) Maintenance Register 1 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint32_t INDEX:4;          /*!< bit:  4.. 7  Invalidate Index                   */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} HCACHE_MAINT1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HCACHE_MAINT1_OFFSET        0x24         /**< \brief (HCACHE_MAINT1 offset) Maintenance Register 1 */
+
+#define HCACHE_MAINT1_INDEX_Pos     4            /**< \brief (HCACHE_MAINT1) Invalidate Index */
+#define HCACHE_MAINT1_INDEX_Msk     (_U(0xF) << HCACHE_MAINT1_INDEX_Pos)
+#define HCACHE_MAINT1_INDEX(value)  (HCACHE_MAINT1_INDEX_Msk & ((value) << HCACHE_MAINT1_INDEX_Pos))
+#define HCACHE_MAINT1_MASK          _U(0x000000F0) /**< \brief (HCACHE_MAINT1) MASK Register */
+
+/* -------- HCACHE_MCFG : (HCACHE Offset: 0x28) (R/W 32) Monitor Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t MODE:2;           /*!< bit:  0.. 1  Cache Controller Monitor Counter Mode */
+    uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} HCACHE_MCFG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HCACHE_MCFG_OFFSET          0x28         /**< \brief (HCACHE_MCFG offset) Monitor Configuration Register */
+
+#define HCACHE_MCFG_MODE_Pos        0            /**< \brief (HCACHE_MCFG) Cache Controller Monitor Counter Mode */
+#define HCACHE_MCFG_MODE_Msk        (_U(0x3) << HCACHE_MCFG_MODE_Pos)
+#define HCACHE_MCFG_MODE(value)     (HCACHE_MCFG_MODE_Msk & ((value) << HCACHE_MCFG_MODE_Pos))
+#define   HCACHE_MCFG_MODE_CYCLE_Val      _U(0x0)   /**< \brief (HCACHE_MCFG) Cycle Counter */
+#define   HCACHE_MCFG_MODE_IHIT_Val       _U(0x1)   /**< \brief (HCACHE_MCFG) Instruction Hit Counter */
+#define   HCACHE_MCFG_MODE_DHIT_Val       _U(0x2)   /**< \brief (HCACHE_MCFG) Data Hit Counter */
+#define HCACHE_MCFG_MODE_CYCLE      (HCACHE_MCFG_MODE_CYCLE_Val    << HCACHE_MCFG_MODE_Pos)
+#define HCACHE_MCFG_MODE_IHIT       (HCACHE_MCFG_MODE_IHIT_Val     << HCACHE_MCFG_MODE_Pos)
+#define HCACHE_MCFG_MODE_DHIT       (HCACHE_MCFG_MODE_DHIT_Val     << HCACHE_MCFG_MODE_Pos)
+#define HCACHE_MCFG_MASK            _U(0x00000003) /**< \brief (HCACHE_MCFG) MASK Register */
+
+/* -------- HCACHE_MEN : (HCACHE Offset: 0x2C) (R/W 32) Monitor Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t MENABLE:1;        /*!< bit:      0  Monitor Enable                     */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} HCACHE_MEN_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HCACHE_MEN_OFFSET           0x2C         /**< \brief (HCACHE_MEN offset) Monitor Enable Register */
+
+#define HCACHE_MEN_MENABLE_Pos      0            /**< \brief (HCACHE_MEN) Monitor Enable */
+#define HCACHE_MEN_MENABLE          (_U(0x1) << HCACHE_MEN_MENABLE_Pos)
+#define   HCACHE_MEN_MENABLE_DIS_Val      _U(0x0)   /**< \brief (HCACHE_MEN) Disable Monitor Counter */
+#define   HCACHE_MEN_MENABLE_EN_Val       _U(0x1)   /**< \brief (HCACHE_MEN) Enable Monitor Counter */
+#define HCACHE_MEN_MENABLE_DIS      (HCACHE_MEN_MENABLE_DIS_Val    << HCACHE_MEN_MENABLE_Pos)
+#define HCACHE_MEN_MENABLE_EN       (HCACHE_MEN_MENABLE_EN_Val     << HCACHE_MEN_MENABLE_Pos)
+#define HCACHE_MEN_MASK             _U(0x00000001) /**< \brief (HCACHE_MEN) MASK Register */
+
+/* -------- HCACHE_MCTRL : (HCACHE Offset: 0x30) ( /W 32) Monitor Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Monitor Software Reset             */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} HCACHE_MCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HCACHE_MCTRL_OFFSET         0x30         /**< \brief (HCACHE_MCTRL offset) Monitor Control Register */
+
+#define HCACHE_MCTRL_SWRST_Pos      0            /**< \brief (HCACHE_MCTRL) Monitor Software Reset */
+#define HCACHE_MCTRL_SWRST          (_U(0x1) << HCACHE_MCTRL_SWRST_Pos)
+#define   HCACHE_MCTRL_SWRST_NO_Val       _U(0x0)   /**< \brief (HCACHE_MCTRL) No effect */
+#define   HCACHE_MCTRL_SWRST_YES_Val      _U(0x1)   /**< \brief (HCACHE_MCTRL) Reset event counter register */
+#define HCACHE_MCTRL_SWRST_NO       (HCACHE_MCTRL_SWRST_NO_Val     << HCACHE_MCTRL_SWRST_Pos)
+#define HCACHE_MCTRL_SWRST_YES      (HCACHE_MCTRL_SWRST_YES_Val    << HCACHE_MCTRL_SWRST_Pos)
+#define HCACHE_MCTRL_MASK           _U(0x00000001) /**< \brief (HCACHE_MCTRL) MASK Register */
+
+/* -------- HCACHE_MSR : (HCACHE Offset: 0x34) (R/  32) Monitor Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EVENTCNT:32;      /*!< bit:  0..31  Monitor Event Counter              */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} HCACHE_MSR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HCACHE_MSR_OFFSET           0x34         /**< \brief (HCACHE_MSR offset) Monitor Status Register */
+
+#define HCACHE_MSR_EVENTCNT_Pos     0            /**< \brief (HCACHE_MSR) Monitor Event Counter */
+#define HCACHE_MSR_EVENTCNT_Msk     (_U(0xFFFFFFFF) << HCACHE_MSR_EVENTCNT_Pos)
+#define HCACHE_MSR_EVENTCNT(value)  (HCACHE_MSR_EVENTCNT_Msk & ((value) << HCACHE_MSR_EVENTCNT_Pos))
+#define HCACHE_MSR_MASK             _U(0xFFFFFFFF) /**< \brief (HCACHE_MSR) MASK Register */
+
+/* -------- HCACHE_VERSION : (HCACHE Offset: 0xFC) (R/  32) Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  VERSION                            */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t MFN:4;            /*!< bit: 16..19  MFN                                */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} HCACHE_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HCACHE_VERSION_OFFSET       0xFC         /**< \brief (HCACHE_VERSION offset) Version Register */
+#define HCACHE_VERSION_RESETVALUE   _U(0x00000101); /**< \brief (HCACHE_VERSION reset_value) Version Register */
+
+#define HCACHE_VERSION_VERSION_Pos  0            /**< \brief (HCACHE_VERSION) VERSION */
+#define HCACHE_VERSION_VERSION_Msk  (_U(0xFFF) << HCACHE_VERSION_VERSION_Pos)
+#define HCACHE_VERSION_VERSION(value) (HCACHE_VERSION_VERSION_Msk & ((value) << HCACHE_VERSION_VERSION_Pos))
+#define HCACHE_VERSION_MFN_Pos      16           /**< \brief (HCACHE_VERSION) MFN */
+#define HCACHE_VERSION_MFN_Msk      (_U(0xF) << HCACHE_VERSION_MFN_Pos)
+#define HCACHE_VERSION_MFN(value)   (HCACHE_VERSION_MFN_Msk & ((value) << HCACHE_VERSION_MFN_Pos))
+#define HCACHE_VERSION_MASK         _U(0x000F0FFF) /**< \brief (HCACHE_VERSION) MASK Register */
+
+/** \brief HCACHE hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+       RoReg8                    Reserved1[0x8];
+  __O  HCACHE_CTRL_Type          CTRL;        /**< \brief Offset: 0x08 ( /W 32) Control Register */
+  __IO HCACHE_SR_Type            SR;          /**< \brief Offset: 0x0C (R/W 32) Status Register */
+       RoReg8                    Reserved2[0x10];
+  __O  HCACHE_MAINT0_Type        MAINT0;      /**< \brief Offset: 0x20 ( /W 32) Maintenance Register 0 */
+  __O  HCACHE_MAINT1_Type        MAINT1;      /**< \brief Offset: 0x24 ( /W 32) Maintenance Register 1 */
+  __IO HCACHE_MCFG_Type          MCFG;        /**< \brief Offset: 0x28 (R/W 32) Monitor Configuration Register */
+  __IO HCACHE_MEN_Type           MEN;         /**< \brief Offset: 0x2C (R/W 32) Monitor Enable Register */
+  __O  HCACHE_MCTRL_Type         MCTRL;       /**< \brief Offset: 0x30 ( /W 32) Monitor Control Register */
+  __I  HCACHE_MSR_Type           MSR;         /**< \brief Offset: 0x34 (R/  32) Monitor Status Register */
+       RoReg8                    Reserved3[0xC4];
+  __I  HCACHE_VERSION_Type       VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
+ } bf;
+ struct {
+  RoReg8  Reserved4[0x8];
+  WoReg   HCACHE_CTRL;        /**< \brief (HCACHE Offset: 0x08) Control Register */
+  RwReg   HCACHE_SR;          /**< \brief (HCACHE Offset: 0x0C) Status Register */
+  RoReg8  Reserved5[0x10];
+  WoReg   HCACHE_MAINT0;      /**< \brief (HCACHE Offset: 0x20) Maintenance Register 0 */
+  WoReg   HCACHE_MAINT1;      /**< \brief (HCACHE Offset: 0x24) Maintenance Register 1 */
+  RwReg   HCACHE_MCFG;        /**< \brief (HCACHE Offset: 0x28) Monitor Configuration Register */
+  RwReg   HCACHE_MEN;         /**< \brief (HCACHE Offset: 0x2C) Monitor Enable Register */
+  WoReg   HCACHE_MCTRL;       /**< \brief (HCACHE Offset: 0x30) Monitor Control Register */
+  RoReg   HCACHE_MSR;         /**< \brief (HCACHE Offset: 0x34) Monitor Status Register */
+  RoReg8  Reserved6[0xC4];
+  RoReg   HCACHE_VERSION;     /**< \brief (HCACHE Offset: 0xFC) Version Register */
+ } reg;
+} Hcache;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_HCACHE_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/hcache.h
+++ b/asf/sam/include/sam4l/component/hcache.h
@@ -52,12 +52,12 @@ typedef union {
 #define HCACHE_CTRL_OFFSET          0x08         /**< \brief (HCACHE_CTRL offset) Control Register */
 
 #define HCACHE_CTRL_CEN_Pos         0            /**< \brief (HCACHE_CTRL) Cache Enable */
-#define HCACHE_CTRL_CEN             (_U(0x1) << HCACHE_CTRL_CEN_Pos)
-#define   HCACHE_CTRL_CEN_NO_Val          _U(0x0)   /**< \brief (HCACHE_CTRL) Disable Cache Controller */
-#define   HCACHE_CTRL_CEN_YES_Val         _U(0x1)   /**< \brief (HCACHE_CTRL) Enable Cache Controller */
+#define HCACHE_CTRL_CEN             (_U_(0x1) << HCACHE_CTRL_CEN_Pos)
+#define   HCACHE_CTRL_CEN_NO_Val          _U_(0x0)   /**< \brief (HCACHE_CTRL) Disable Cache Controller */
+#define   HCACHE_CTRL_CEN_YES_Val         _U_(0x1)   /**< \brief (HCACHE_CTRL) Enable Cache Controller */
 #define HCACHE_CTRL_CEN_NO          (HCACHE_CTRL_CEN_NO_Val        << HCACHE_CTRL_CEN_Pos)
 #define HCACHE_CTRL_CEN_YES         (HCACHE_CTRL_CEN_YES_Val       << HCACHE_CTRL_CEN_Pos)
-#define HCACHE_CTRL_MASK            _U(0x00000001) /**< \brief (HCACHE_CTRL) MASK Register */
+#define HCACHE_CTRL_MASK            _U_(0x00000001) /**< \brief (HCACHE_CTRL) MASK Register */
 
 /* -------- HCACHE_SR : (HCACHE Offset: 0x0C) (R/W 32) Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -73,12 +73,12 @@ typedef union {
 #define HCACHE_SR_OFFSET            0x0C         /**< \brief (HCACHE_SR offset) Status Register */
 
 #define HCACHE_SR_CSTS_Pos          0            /**< \brief (HCACHE_SR) Cache Controller Status */
-#define HCACHE_SR_CSTS              (_U(0x1) << HCACHE_SR_CSTS_Pos)
-#define   HCACHE_SR_CSTS_DIS_Val          _U(0x0)   /**< \brief (HCACHE_SR) Cache Controller Disabled */
-#define   HCACHE_SR_CSTS_EN_Val           _U(0x1)   /**< \brief (HCACHE_SR) Cache Controller Enabled */
+#define HCACHE_SR_CSTS              (_U_(0x1) << HCACHE_SR_CSTS_Pos)
+#define   HCACHE_SR_CSTS_DIS_Val          _U_(0x0)   /**< \brief (HCACHE_SR) Cache Controller Disabled */
+#define   HCACHE_SR_CSTS_EN_Val           _U_(0x1)   /**< \brief (HCACHE_SR) Cache Controller Enabled */
 #define HCACHE_SR_CSTS_DIS          (HCACHE_SR_CSTS_DIS_Val        << HCACHE_SR_CSTS_Pos)
 #define HCACHE_SR_CSTS_EN           (HCACHE_SR_CSTS_EN_Val         << HCACHE_SR_CSTS_Pos)
-#define HCACHE_SR_MASK              _U(0x00000001) /**< \brief (HCACHE_SR) MASK Register */
+#define HCACHE_SR_MASK              _U_(0x00000001) /**< \brief (HCACHE_SR) MASK Register */
 
 /* -------- HCACHE_MAINT0 : (HCACHE Offset: 0x20) ( /W 32) Maintenance Register 0 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -94,12 +94,12 @@ typedef union {
 #define HCACHE_MAINT0_OFFSET        0x20         /**< \brief (HCACHE_MAINT0 offset) Maintenance Register 0 */
 
 #define HCACHE_MAINT0_INVALL_Pos    0            /**< \brief (HCACHE_MAINT0) Cache Controller Invalidate All */
-#define HCACHE_MAINT0_INVALL        (_U(0x1) << HCACHE_MAINT0_INVALL_Pos)
-#define   HCACHE_MAINT0_INVALL_NO_Val     _U(0x0)   /**< \brief (HCACHE_MAINT0) No effect */
-#define   HCACHE_MAINT0_INVALL_YES_Val    _U(0x1)   /**< \brief (HCACHE_MAINT0) Invalidate all cache entries */
+#define HCACHE_MAINT0_INVALL        (_U_(0x1) << HCACHE_MAINT0_INVALL_Pos)
+#define   HCACHE_MAINT0_INVALL_NO_Val     _U_(0x0)   /**< \brief (HCACHE_MAINT0) No effect */
+#define   HCACHE_MAINT0_INVALL_YES_Val    _U_(0x1)   /**< \brief (HCACHE_MAINT0) Invalidate all cache entries */
 #define HCACHE_MAINT0_INVALL_NO     (HCACHE_MAINT0_INVALL_NO_Val   << HCACHE_MAINT0_INVALL_Pos)
 #define HCACHE_MAINT0_INVALL_YES    (HCACHE_MAINT0_INVALL_YES_Val  << HCACHE_MAINT0_INVALL_Pos)
-#define HCACHE_MAINT0_MASK          _U(0x00000001) /**< \brief (HCACHE_MAINT0) MASK Register */
+#define HCACHE_MAINT0_MASK          _U_(0x00000001) /**< \brief (HCACHE_MAINT0) MASK Register */
 
 /* -------- HCACHE_MAINT1 : (HCACHE Offset: 0x24) ( /W 32) Maintenance Register 1 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -116,9 +116,9 @@ typedef union {
 #define HCACHE_MAINT1_OFFSET        0x24         /**< \brief (HCACHE_MAINT1 offset) Maintenance Register 1 */
 
 #define HCACHE_MAINT1_INDEX_Pos     4            /**< \brief (HCACHE_MAINT1) Invalidate Index */
-#define HCACHE_MAINT1_INDEX_Msk     (_U(0xF) << HCACHE_MAINT1_INDEX_Pos)
+#define HCACHE_MAINT1_INDEX_Msk     (_U_(0xF) << HCACHE_MAINT1_INDEX_Pos)
 #define HCACHE_MAINT1_INDEX(value)  (HCACHE_MAINT1_INDEX_Msk & ((value) << HCACHE_MAINT1_INDEX_Pos))
-#define HCACHE_MAINT1_MASK          _U(0x000000F0) /**< \brief (HCACHE_MAINT1) MASK Register */
+#define HCACHE_MAINT1_MASK          _U_(0x000000F0) /**< \brief (HCACHE_MAINT1) MASK Register */
 
 /* -------- HCACHE_MCFG : (HCACHE Offset: 0x28) (R/W 32) Monitor Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -134,15 +134,15 @@ typedef union {
 #define HCACHE_MCFG_OFFSET          0x28         /**< \brief (HCACHE_MCFG offset) Monitor Configuration Register */
 
 #define HCACHE_MCFG_MODE_Pos        0            /**< \brief (HCACHE_MCFG) Cache Controller Monitor Counter Mode */
-#define HCACHE_MCFG_MODE_Msk        (_U(0x3) << HCACHE_MCFG_MODE_Pos)
+#define HCACHE_MCFG_MODE_Msk        (_U_(0x3) << HCACHE_MCFG_MODE_Pos)
 #define HCACHE_MCFG_MODE(value)     (HCACHE_MCFG_MODE_Msk & ((value) << HCACHE_MCFG_MODE_Pos))
-#define   HCACHE_MCFG_MODE_CYCLE_Val      _U(0x0)   /**< \brief (HCACHE_MCFG) Cycle Counter */
-#define   HCACHE_MCFG_MODE_IHIT_Val       _U(0x1)   /**< \brief (HCACHE_MCFG) Instruction Hit Counter */
-#define   HCACHE_MCFG_MODE_DHIT_Val       _U(0x2)   /**< \brief (HCACHE_MCFG) Data Hit Counter */
+#define   HCACHE_MCFG_MODE_CYCLE_Val      _U_(0x0)   /**< \brief (HCACHE_MCFG) Cycle Counter */
+#define   HCACHE_MCFG_MODE_IHIT_Val       _U_(0x1)   /**< \brief (HCACHE_MCFG) Instruction Hit Counter */
+#define   HCACHE_MCFG_MODE_DHIT_Val       _U_(0x2)   /**< \brief (HCACHE_MCFG) Data Hit Counter */
 #define HCACHE_MCFG_MODE_CYCLE      (HCACHE_MCFG_MODE_CYCLE_Val    << HCACHE_MCFG_MODE_Pos)
 #define HCACHE_MCFG_MODE_IHIT       (HCACHE_MCFG_MODE_IHIT_Val     << HCACHE_MCFG_MODE_Pos)
 #define HCACHE_MCFG_MODE_DHIT       (HCACHE_MCFG_MODE_DHIT_Val     << HCACHE_MCFG_MODE_Pos)
-#define HCACHE_MCFG_MASK            _U(0x00000003) /**< \brief (HCACHE_MCFG) MASK Register */
+#define HCACHE_MCFG_MASK            _U_(0x00000003) /**< \brief (HCACHE_MCFG) MASK Register */
 
 /* -------- HCACHE_MEN : (HCACHE Offset: 0x2C) (R/W 32) Monitor Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -158,12 +158,12 @@ typedef union {
 #define HCACHE_MEN_OFFSET           0x2C         /**< \brief (HCACHE_MEN offset) Monitor Enable Register */
 
 #define HCACHE_MEN_MENABLE_Pos      0            /**< \brief (HCACHE_MEN) Monitor Enable */
-#define HCACHE_MEN_MENABLE          (_U(0x1) << HCACHE_MEN_MENABLE_Pos)
-#define   HCACHE_MEN_MENABLE_DIS_Val      _U(0x0)   /**< \brief (HCACHE_MEN) Disable Monitor Counter */
-#define   HCACHE_MEN_MENABLE_EN_Val       _U(0x1)   /**< \brief (HCACHE_MEN) Enable Monitor Counter */
+#define HCACHE_MEN_MENABLE          (_U_(0x1) << HCACHE_MEN_MENABLE_Pos)
+#define   HCACHE_MEN_MENABLE_DIS_Val      _U_(0x0)   /**< \brief (HCACHE_MEN) Disable Monitor Counter */
+#define   HCACHE_MEN_MENABLE_EN_Val       _U_(0x1)   /**< \brief (HCACHE_MEN) Enable Monitor Counter */
 #define HCACHE_MEN_MENABLE_DIS      (HCACHE_MEN_MENABLE_DIS_Val    << HCACHE_MEN_MENABLE_Pos)
 #define HCACHE_MEN_MENABLE_EN       (HCACHE_MEN_MENABLE_EN_Val     << HCACHE_MEN_MENABLE_Pos)
-#define HCACHE_MEN_MASK             _U(0x00000001) /**< \brief (HCACHE_MEN) MASK Register */
+#define HCACHE_MEN_MASK             _U_(0x00000001) /**< \brief (HCACHE_MEN) MASK Register */
 
 /* -------- HCACHE_MCTRL : (HCACHE Offset: 0x30) ( /W 32) Monitor Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -179,12 +179,12 @@ typedef union {
 #define HCACHE_MCTRL_OFFSET         0x30         /**< \brief (HCACHE_MCTRL offset) Monitor Control Register */
 
 #define HCACHE_MCTRL_SWRST_Pos      0            /**< \brief (HCACHE_MCTRL) Monitor Software Reset */
-#define HCACHE_MCTRL_SWRST          (_U(0x1) << HCACHE_MCTRL_SWRST_Pos)
-#define   HCACHE_MCTRL_SWRST_NO_Val       _U(0x0)   /**< \brief (HCACHE_MCTRL) No effect */
-#define   HCACHE_MCTRL_SWRST_YES_Val      _U(0x1)   /**< \brief (HCACHE_MCTRL) Reset event counter register */
+#define HCACHE_MCTRL_SWRST          (_U_(0x1) << HCACHE_MCTRL_SWRST_Pos)
+#define   HCACHE_MCTRL_SWRST_NO_Val       _U_(0x0)   /**< \brief (HCACHE_MCTRL) No effect */
+#define   HCACHE_MCTRL_SWRST_YES_Val      _U_(0x1)   /**< \brief (HCACHE_MCTRL) Reset event counter register */
 #define HCACHE_MCTRL_SWRST_NO       (HCACHE_MCTRL_SWRST_NO_Val     << HCACHE_MCTRL_SWRST_Pos)
 #define HCACHE_MCTRL_SWRST_YES      (HCACHE_MCTRL_SWRST_YES_Val    << HCACHE_MCTRL_SWRST_Pos)
-#define HCACHE_MCTRL_MASK           _U(0x00000001) /**< \brief (HCACHE_MCTRL) MASK Register */
+#define HCACHE_MCTRL_MASK           _U_(0x00000001) /**< \brief (HCACHE_MCTRL) MASK Register */
 
 /* -------- HCACHE_MSR : (HCACHE Offset: 0x34) (R/  32) Monitor Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -199,9 +199,9 @@ typedef union {
 #define HCACHE_MSR_OFFSET           0x34         /**< \brief (HCACHE_MSR offset) Monitor Status Register */
 
 #define HCACHE_MSR_EVENTCNT_Pos     0            /**< \brief (HCACHE_MSR) Monitor Event Counter */
-#define HCACHE_MSR_EVENTCNT_Msk     (_U(0xFFFFFFFF) << HCACHE_MSR_EVENTCNT_Pos)
+#define HCACHE_MSR_EVENTCNT_Msk     (_U_(0xFFFFFFFF) << HCACHE_MSR_EVENTCNT_Pos)
 #define HCACHE_MSR_EVENTCNT(value)  (HCACHE_MSR_EVENTCNT_Msk & ((value) << HCACHE_MSR_EVENTCNT_Pos))
-#define HCACHE_MSR_MASK             _U(0xFFFFFFFF) /**< \brief (HCACHE_MSR) MASK Register */
+#define HCACHE_MSR_MASK             _U_(0xFFFFFFFF) /**< \brief (HCACHE_MSR) MASK Register */
 
 /* -------- HCACHE_VERSION : (HCACHE Offset: 0xFC) (R/  32) Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -217,15 +217,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HCACHE_VERSION_OFFSET       0xFC         /**< \brief (HCACHE_VERSION offset) Version Register */
-#define HCACHE_VERSION_RESETVALUE   _U(0x00000101); /**< \brief (HCACHE_VERSION reset_value) Version Register */
+#define HCACHE_VERSION_RESETVALUE   _U_(0x00000101); /**< \brief (HCACHE_VERSION reset_value) Version Register */
 
 #define HCACHE_VERSION_VERSION_Pos  0            /**< \brief (HCACHE_VERSION) VERSION */
-#define HCACHE_VERSION_VERSION_Msk  (_U(0xFFF) << HCACHE_VERSION_VERSION_Pos)
+#define HCACHE_VERSION_VERSION_Msk  (_U_(0xFFF) << HCACHE_VERSION_VERSION_Pos)
 #define HCACHE_VERSION_VERSION(value) (HCACHE_VERSION_VERSION_Msk & ((value) << HCACHE_VERSION_VERSION_Pos))
 #define HCACHE_VERSION_MFN_Pos      16           /**< \brief (HCACHE_VERSION) MFN */
-#define HCACHE_VERSION_MFN_Msk      (_U(0xF) << HCACHE_VERSION_MFN_Pos)
+#define HCACHE_VERSION_MFN_Msk      (_U_(0xF) << HCACHE_VERSION_MFN_Pos)
 #define HCACHE_VERSION_MFN(value)   (HCACHE_VERSION_MFN_Msk & ((value) << HCACHE_VERSION_MFN_Pos))
-#define HCACHE_VERSION_MASK         _U(0x000F0FFF) /**< \brief (HCACHE_VERSION) MASK Register */
+#define HCACHE_VERSION_MASK         _U_(0x000F0FFF) /**< \brief (HCACHE_VERSION) MASK Register */
 
 /** \brief HCACHE hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/hcache.h
+++ b/asf/sam/include/sam4l/component/hcache.h
@@ -229,35 +229,19 @@ typedef union {
 
 /** \brief HCACHE hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-       RoReg8                    Reserved1[0x8];
-  __O  HCACHE_CTRL_Type          CTRL;        /**< \brief Offset: 0x08 ( /W 32) Control Register */
-  __IO HCACHE_SR_Type            SR;          /**< \brief Offset: 0x0C (R/W 32) Status Register */
-       RoReg8                    Reserved2[0x10];
-  __O  HCACHE_MAINT0_Type        MAINT0;      /**< \brief Offset: 0x20 ( /W 32) Maintenance Register 0 */
-  __O  HCACHE_MAINT1_Type        MAINT1;      /**< \brief Offset: 0x24 ( /W 32) Maintenance Register 1 */
-  __IO HCACHE_MCFG_Type          MCFG;        /**< \brief Offset: 0x28 (R/W 32) Monitor Configuration Register */
-  __IO HCACHE_MEN_Type           MEN;         /**< \brief Offset: 0x2C (R/W 32) Monitor Enable Register */
-  __O  HCACHE_MCTRL_Type         MCTRL;       /**< \brief Offset: 0x30 ( /W 32) Monitor Control Register */
-  __I  HCACHE_MSR_Type           MSR;         /**< \brief Offset: 0x34 (R/  32) Monitor Status Register */
-       RoReg8                    Reserved3[0xC4];
-  __I  HCACHE_VERSION_Type       VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
- } bf;
- struct {
-  RoReg8  Reserved4[0x8];
-  WoReg   HCACHE_CTRL;        /**< \brief (HCACHE Offset: 0x08) Control Register */
-  RwReg   HCACHE_SR;          /**< \brief (HCACHE Offset: 0x0C) Status Register */
-  RoReg8  Reserved5[0x10];
-  WoReg   HCACHE_MAINT0;      /**< \brief (HCACHE Offset: 0x20) Maintenance Register 0 */
-  WoReg   HCACHE_MAINT1;      /**< \brief (HCACHE Offset: 0x24) Maintenance Register 1 */
-  RwReg   HCACHE_MCFG;        /**< \brief (HCACHE Offset: 0x28) Monitor Configuration Register */
-  RwReg   HCACHE_MEN;         /**< \brief (HCACHE Offset: 0x2C) Monitor Enable Register */
-  WoReg   HCACHE_MCTRL;       /**< \brief (HCACHE Offset: 0x30) Monitor Control Register */
-  RoReg   HCACHE_MSR;         /**< \brief (HCACHE Offset: 0x34) Monitor Status Register */
-  RoReg8  Reserved6[0xC4];
-  RoReg   HCACHE_VERSION;     /**< \brief (HCACHE Offset: 0xFC) Version Register */
- } reg;
+typedef struct {
+       RoReg8   Reserved1[0x8];
+  __O  uint32_t CTRL;        /**< \brief Offset: 0x08 ( /W 32) Control Register */
+  __IO uint32_t SR;          /**< \brief Offset: 0x0C (R/W 32) Status Register */
+       RoReg8   Reserved2[0x10];
+  __O  uint32_t MAINT0;      /**< \brief Offset: 0x20 ( /W 32) Maintenance Register 0 */
+  __O  uint32_t MAINT1;      /**< \brief Offset: 0x24 ( /W 32) Maintenance Register 1 */
+  __IO uint32_t MCFG;        /**< \brief Offset: 0x28 (R/W 32) Monitor Configuration Register */
+  __IO uint32_t MEN;         /**< \brief Offset: 0x2C (R/W 32) Monitor Enable Register */
+  __O  uint32_t MCTRL;       /**< \brief Offset: 0x30 ( /W 32) Monitor Control Register */
+  __I  uint32_t MSR;         /**< \brief Offset: 0x34 (R/  32) Monitor Status Register */
+       RoReg8   Reserved3[0xC4];
+  __I  uint32_t VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
 } Hcache;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/hmatrixb.h
+++ b/asf/sam/include/sam4l/component/hmatrixb.h
@@ -1,0 +1,423 @@
+/**
+ * \file
+ *
+ * \brief Component description for HMATRIXB
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_HMATRIXB_COMPONENT_
+#define _SAM4L_HMATRIXB_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR HMATRIXB */
+/* ========================================================================== */
+/** \addtogroup SAM4L_HMATRIXB HSB Matrix */
+/*@{*/
+
+#define HMATRIXB_I7638
+#define REV_HMATRIXB                0x130
+
+/* -------- HMATRIXB_MCFG : (HMATRIXB Offset: 0x000) (R/W 32) mcfg Master Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ULBT:3;           /*!< bit:  0.. 2  Undefined Length Burst Type        */
+    uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} HMATRIXB_MCFG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HMATRIXB_MCFG_OFFSET        0x000        /**< \brief (HMATRIXB_MCFG offset) Master Configuration Register */
+#define HMATRIXB_MCFG_RESETVALUE    _U(0x00000002); /**< \brief (HMATRIXB_MCFG reset_value) Master Configuration Register */
+
+#define HMATRIXB_MCFG_ULBT_Pos      0            /**< \brief (HMATRIXB_MCFG) Undefined Length Burst Type */
+#define HMATRIXB_MCFG_ULBT_Msk      (_U(0x7) << HMATRIXB_MCFG_ULBT_Pos)
+#define HMATRIXB_MCFG_ULBT(value)   (HMATRIXB_MCFG_ULBT_Msk & ((value) << HMATRIXB_MCFG_ULBT_Pos))
+#define   HMATRIXB_MCFG_ULBT_INFINITE_Val _U(0x0)   /**< \brief (HMATRIXB_MCFG) Infinite Length */
+#define   HMATRIXB_MCFG_ULBT_SINGLE_Val   _U(0x1)   /**< \brief (HMATRIXB_MCFG) Single Access */
+#define   HMATRIXB_MCFG_ULBT_FOUR_BEAT_Val _U(0x2)   /**< \brief (HMATRIXB_MCFG) Four Beat Burst */
+#define   HMATRIXB_MCFG_ULBT_EIGHT_BEAT_Val _U(0x3)   /**< \brief (HMATRIXB_MCFG) Eight Beat Burst */
+#define   HMATRIXB_MCFG_ULBT_SIXTEEN_BEAT_Val _U(0x4)   /**< \brief (HMATRIXB_MCFG) Sixteen Beat Burst */
+#define HMATRIXB_MCFG_ULBT_INFINITE (HMATRIXB_MCFG_ULBT_INFINITE_Val << HMATRIXB_MCFG_ULBT_Pos)
+#define HMATRIXB_MCFG_ULBT_SINGLE   (HMATRIXB_MCFG_ULBT_SINGLE_Val << HMATRIXB_MCFG_ULBT_Pos)
+#define HMATRIXB_MCFG_ULBT_FOUR_BEAT (HMATRIXB_MCFG_ULBT_FOUR_BEAT_Val << HMATRIXB_MCFG_ULBT_Pos)
+#define HMATRIXB_MCFG_ULBT_EIGHT_BEAT (HMATRIXB_MCFG_ULBT_EIGHT_BEAT_Val << HMATRIXB_MCFG_ULBT_Pos)
+#define HMATRIXB_MCFG_ULBT_SIXTEEN_BEAT (HMATRIXB_MCFG_ULBT_SIXTEEN_BEAT_Val << HMATRIXB_MCFG_ULBT_Pos)
+#define HMATRIXB_MCFG_MASK          _U(0x00000007) /**< \brief (HMATRIXB_MCFG) MASK Register */
+
+/* -------- HMATRIXB_SCFG : (HMATRIXB Offset: 0x040) (R/W 32) scfg Slave Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SLOT_CYCLE:8;     /*!< bit:  0.. 7  Maximum Number of Allowed Cycles for a Burst */
+    uint32_t :8;               /*!< bit:  8..15  Reserved                           */
+    uint32_t DEFMSTR_TYPE:2;   /*!< bit: 16..17  Default Master Type                */
+    uint32_t FIXED_DEFMSTR:4;  /*!< bit: 18..21  Fixed Index of Default Master      */
+    uint32_t :2;               /*!< bit: 22..23  Reserved                           */
+    uint32_t ARBT:1;           /*!< bit:     24  Arbitration Type                   */
+    uint32_t :7;               /*!< bit: 25..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} HMATRIXB_SCFG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HMATRIXB_SCFG_OFFSET        0x040        /**< \brief (HMATRIXB_SCFG offset) Slave Configuration Register */
+#define HMATRIXB_SCFG_RESETVALUE    _U(0x00000010); /**< \brief (HMATRIXB_SCFG reset_value) Slave Configuration Register */
+
+#define HMATRIXB_SCFG_SLOT_CYCLE_Pos 0            /**< \brief (HMATRIXB_SCFG) Maximum Number of Allowed Cycles for a Burst */
+#define HMATRIXB_SCFG_SLOT_CYCLE_Msk (_U(0xFF) << HMATRIXB_SCFG_SLOT_CYCLE_Pos)
+#define HMATRIXB_SCFG_SLOT_CYCLE(value) (HMATRIXB_SCFG_SLOT_CYCLE_Msk & ((value) << HMATRIXB_SCFG_SLOT_CYCLE_Pos))
+#define HMATRIXB_SCFG_DEFMSTR_TYPE_Pos 16           /**< \brief (HMATRIXB_SCFG) Default Master Type */
+#define HMATRIXB_SCFG_DEFMSTR_TYPE_Msk (_U(0x3) << HMATRIXB_SCFG_DEFMSTR_TYPE_Pos)
+#define HMATRIXB_SCFG_DEFMSTR_TYPE(value) (HMATRIXB_SCFG_DEFMSTR_TYPE_Msk & ((value) << HMATRIXB_SCFG_DEFMSTR_TYPE_Pos))
+#define   HMATRIXB_SCFG_DEFMSTR_TYPE_NO_DEFAULT_Val _U(0x0)   /**< \brief (HMATRIXB_SCFG) No Default Master. At the end of current slave access, if no other master request is pending, the slave is deconnected from all masters. This resusts in having a one cycle latency for the first transfer of a burst. */
+#define   HMATRIXB_SCFG_DEFMSTR_TYPE_LAST_DEFAULT_Val _U(0x1)   /**< \brief (HMATRIXB_SCFG) Last Default Master At the end of current slave access, if no other master request is pending, the slave stay connected with the last master havingaccessed it.This resusts in not having the one cycle latency when the last master re-trying access on the slave. */
+#define   HMATRIXB_SCFG_DEFMSTR_TYPE_FIXED_DEFAULT_Val _U(0x2)   /**< \brief (HMATRIXB_SCFG) Fixed Default Master At the end of current slave access, if no other master request is pending, the slave connects with fixed master which numberis in FIXED_DEFMSTR register.This resusts in not having the one cycle latency when the fixed master re-trying access on the slave. */
+#define HMATRIXB_SCFG_DEFMSTR_TYPE_NO_DEFAULT (HMATRIXB_SCFG_DEFMSTR_TYPE_NO_DEFAULT_Val << HMATRIXB_SCFG_DEFMSTR_TYPE_Pos)
+#define HMATRIXB_SCFG_DEFMSTR_TYPE_LAST_DEFAULT (HMATRIXB_SCFG_DEFMSTR_TYPE_LAST_DEFAULT_Val << HMATRIXB_SCFG_DEFMSTR_TYPE_Pos)
+#define HMATRIXB_SCFG_DEFMSTR_TYPE_FIXED_DEFAULT (HMATRIXB_SCFG_DEFMSTR_TYPE_FIXED_DEFAULT_Val << HMATRIXB_SCFG_DEFMSTR_TYPE_Pos)
+#define HMATRIXB_SCFG_FIXED_DEFMSTR_Pos 18           /**< \brief (HMATRIXB_SCFG) Fixed Index of Default Master */
+#define HMATRIXB_SCFG_FIXED_DEFMSTR_Msk (_U(0xF) << HMATRIXB_SCFG_FIXED_DEFMSTR_Pos)
+#define HMATRIXB_SCFG_FIXED_DEFMSTR(value) (HMATRIXB_SCFG_FIXED_DEFMSTR_Msk & ((value) << HMATRIXB_SCFG_FIXED_DEFMSTR_Pos))
+#define HMATRIXB_SCFG_ARBT_Pos      24           /**< \brief (HMATRIXB_SCFG) Arbitration Type */
+#define HMATRIXB_SCFG_ARBT          (_U(0x1) << HMATRIXB_SCFG_ARBT_Pos)
+#define   HMATRIXB_SCFG_ARBT_ROUND_ROBIN_Val _U(0x0)   /**< \brief (HMATRIXB_SCFG) Round-Robin Arbitration */
+#define   HMATRIXB_SCFG_ARBT_FIXED_PRIORITY_Val _U(0x1)   /**< \brief (HMATRIXB_SCFG) Fixed Priority Arbitration */
+#define HMATRIXB_SCFG_ARBT_ROUND_ROBIN (HMATRIXB_SCFG_ARBT_ROUND_ROBIN_Val << HMATRIXB_SCFG_ARBT_Pos)
+#define HMATRIXB_SCFG_ARBT_FIXED_PRIORITY (HMATRIXB_SCFG_ARBT_FIXED_PRIORITY_Val << HMATRIXB_SCFG_ARBT_Pos)
+#define HMATRIXB_SCFG_MASK          _U(0x013F00FF) /**< \brief (HMATRIXB_SCFG) MASK Register */
+
+/* -------- HMATRIXB_PRAS : (HMATRIXB Offset: 0x080) (R/W 32) prs Priority Register A for Slave -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t M0PR:4;           /*!< bit:  0.. 3  Master 0 Priority                  */
+    uint32_t M1PR:4;           /*!< bit:  4.. 7  Master 1 Priority                  */
+    uint32_t M2PR:4;           /*!< bit:  8..11  Master 2 Priority                  */
+    uint32_t M3PR:4;           /*!< bit: 12..15  Master 3 Priority                  */
+    uint32_t M4PR:4;           /*!< bit: 16..19  Master 4 Priority                  */
+    uint32_t M5PR:4;           /*!< bit: 20..23  Master 5 Priority                  */
+    uint32_t M6PR:4;           /*!< bit: 24..27  Master 6 Priority                  */
+    uint32_t M7PR:4;           /*!< bit: 28..31  Master 7 Priority                  */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} HMATRIXB_PRAS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HMATRIXB_PRAS_OFFSET        0x080        /**< \brief (HMATRIXB_PRAS offset) Priority Register A for Slave */
+#define HMATRIXB_PRAS_RESETVALUE    _U(0x00000000); /**< \brief (HMATRIXB_PRAS reset_value) Priority Register A for Slave */
+
+#define HMATRIXB_PRAS_M0PR_Pos      0            /**< \brief (HMATRIXB_PRAS) Master 0 Priority */
+#define HMATRIXB_PRAS_M0PR_Msk      (_U(0xF) << HMATRIXB_PRAS_M0PR_Pos)
+#define HMATRIXB_PRAS_M0PR(value)   (HMATRIXB_PRAS_M0PR_Msk & ((value) << HMATRIXB_PRAS_M0PR_Pos))
+#define HMATRIXB_PRAS_M1PR_Pos      4            /**< \brief (HMATRIXB_PRAS) Master 1 Priority */
+#define HMATRIXB_PRAS_M1PR_Msk      (_U(0xF) << HMATRIXB_PRAS_M1PR_Pos)
+#define HMATRIXB_PRAS_M1PR(value)   (HMATRIXB_PRAS_M1PR_Msk & ((value) << HMATRIXB_PRAS_M1PR_Pos))
+#define HMATRIXB_PRAS_M2PR_Pos      8            /**< \brief (HMATRIXB_PRAS) Master 2 Priority */
+#define HMATRIXB_PRAS_M2PR_Msk      (_U(0xF) << HMATRIXB_PRAS_M2PR_Pos)
+#define HMATRIXB_PRAS_M2PR(value)   (HMATRIXB_PRAS_M2PR_Msk & ((value) << HMATRIXB_PRAS_M2PR_Pos))
+#define HMATRIXB_PRAS_M3PR_Pos      12           /**< \brief (HMATRIXB_PRAS) Master 3 Priority */
+#define HMATRIXB_PRAS_M3PR_Msk      (_U(0xF) << HMATRIXB_PRAS_M3PR_Pos)
+#define HMATRIXB_PRAS_M3PR(value)   (HMATRIXB_PRAS_M3PR_Msk & ((value) << HMATRIXB_PRAS_M3PR_Pos))
+#define HMATRIXB_PRAS_M4PR_Pos      16           /**< \brief (HMATRIXB_PRAS) Master 4 Priority */
+#define HMATRIXB_PRAS_M4PR_Msk      (_U(0xF) << HMATRIXB_PRAS_M4PR_Pos)
+#define HMATRIXB_PRAS_M4PR(value)   (HMATRIXB_PRAS_M4PR_Msk & ((value) << HMATRIXB_PRAS_M4PR_Pos))
+#define HMATRIXB_PRAS_M5PR_Pos      20           /**< \brief (HMATRIXB_PRAS) Master 5 Priority */
+#define HMATRIXB_PRAS_M5PR_Msk      (_U(0xF) << HMATRIXB_PRAS_M5PR_Pos)
+#define HMATRIXB_PRAS_M5PR(value)   (HMATRIXB_PRAS_M5PR_Msk & ((value) << HMATRIXB_PRAS_M5PR_Pos))
+#define HMATRIXB_PRAS_M6PR_Pos      24           /**< \brief (HMATRIXB_PRAS) Master 6 Priority */
+#define HMATRIXB_PRAS_M6PR_Msk      (_U(0xF) << HMATRIXB_PRAS_M6PR_Pos)
+#define HMATRIXB_PRAS_M6PR(value)   (HMATRIXB_PRAS_M6PR_Msk & ((value) << HMATRIXB_PRAS_M6PR_Pos))
+#define HMATRIXB_PRAS_M7PR_Pos      28           /**< \brief (HMATRIXB_PRAS) Master 7 Priority */
+#define HMATRIXB_PRAS_M7PR_Msk      (_U(0xF) << HMATRIXB_PRAS_M7PR_Pos)
+#define HMATRIXB_PRAS_M7PR(value)   (HMATRIXB_PRAS_M7PR_Msk & ((value) << HMATRIXB_PRAS_M7PR_Pos))
+#define HMATRIXB_PRAS_MASK          _U(0xFFFFFFFF) /**< \brief (HMATRIXB_PRAS) MASK Register */
+
+/* -------- HMATRIXB_PRBS : (HMATRIXB Offset: 0x084) (R/W 32) prs Priority Register B for Slave -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t M8PR:4;           /*!< bit:  0.. 3  Master 8 Priority                  */
+    uint32_t M9PR:4;           /*!< bit:  4.. 7  Master 9 Priority                  */
+    uint32_t M10PR:4;          /*!< bit:  8..11  Master 10 Priority                 */
+    uint32_t M11PR:4;          /*!< bit: 12..15  Master 11 Priority                 */
+    uint32_t M12PR:4;          /*!< bit: 16..19  Master 12 Priority                 */
+    uint32_t M13PR:4;          /*!< bit: 20..23  Master 13 Priority                 */
+    uint32_t M14PR:4;          /*!< bit: 24..27  Master 14 Priority                 */
+    uint32_t M15PR:4;          /*!< bit: 28..31  Master 15 Priority                 */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} HMATRIXB_PRBS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HMATRIXB_PRBS_OFFSET        0x084        /**< \brief (HMATRIXB_PRBS offset) Priority Register B for Slave */
+#define HMATRIXB_PRBS_RESETVALUE    _U(0x00000000); /**< \brief (HMATRIXB_PRBS reset_value) Priority Register B for Slave */
+
+#define HMATRIXB_PRBS_M8PR_Pos      0            /**< \brief (HMATRIXB_PRBS) Master 8 Priority */
+#define HMATRIXB_PRBS_M8PR_Msk      (_U(0xF) << HMATRIXB_PRBS_M8PR_Pos)
+#define HMATRIXB_PRBS_M8PR(value)   (HMATRIXB_PRBS_M8PR_Msk & ((value) << HMATRIXB_PRBS_M8PR_Pos))
+#define HMATRIXB_PRBS_M9PR_Pos      4            /**< \brief (HMATRIXB_PRBS) Master 9 Priority */
+#define HMATRIXB_PRBS_M9PR_Msk      (_U(0xF) << HMATRIXB_PRBS_M9PR_Pos)
+#define HMATRIXB_PRBS_M9PR(value)   (HMATRIXB_PRBS_M9PR_Msk & ((value) << HMATRIXB_PRBS_M9PR_Pos))
+#define HMATRIXB_PRBS_M10PR_Pos     8            /**< \brief (HMATRIXB_PRBS) Master 10 Priority */
+#define HMATRIXB_PRBS_M10PR_Msk     (_U(0xF) << HMATRIXB_PRBS_M10PR_Pos)
+#define HMATRIXB_PRBS_M10PR(value)  (HMATRIXB_PRBS_M10PR_Msk & ((value) << HMATRIXB_PRBS_M10PR_Pos))
+#define HMATRIXB_PRBS_M11PR_Pos     12           /**< \brief (HMATRIXB_PRBS) Master 11 Priority */
+#define HMATRIXB_PRBS_M11PR_Msk     (_U(0xF) << HMATRIXB_PRBS_M11PR_Pos)
+#define HMATRIXB_PRBS_M11PR(value)  (HMATRIXB_PRBS_M11PR_Msk & ((value) << HMATRIXB_PRBS_M11PR_Pos))
+#define HMATRIXB_PRBS_M12PR_Pos     16           /**< \brief (HMATRIXB_PRBS) Master 12 Priority */
+#define HMATRIXB_PRBS_M12PR_Msk     (_U(0xF) << HMATRIXB_PRBS_M12PR_Pos)
+#define HMATRIXB_PRBS_M12PR(value)  (HMATRIXB_PRBS_M12PR_Msk & ((value) << HMATRIXB_PRBS_M12PR_Pos))
+#define HMATRIXB_PRBS_M13PR_Pos     20           /**< \brief (HMATRIXB_PRBS) Master 13 Priority */
+#define HMATRIXB_PRBS_M13PR_Msk     (_U(0xF) << HMATRIXB_PRBS_M13PR_Pos)
+#define HMATRIXB_PRBS_M13PR(value)  (HMATRIXB_PRBS_M13PR_Msk & ((value) << HMATRIXB_PRBS_M13PR_Pos))
+#define HMATRIXB_PRBS_M14PR_Pos     24           /**< \brief (HMATRIXB_PRBS) Master 14 Priority */
+#define HMATRIXB_PRBS_M14PR_Msk     (_U(0xF) << HMATRIXB_PRBS_M14PR_Pos)
+#define HMATRIXB_PRBS_M14PR(value)  (HMATRIXB_PRBS_M14PR_Msk & ((value) << HMATRIXB_PRBS_M14PR_Pos))
+#define HMATRIXB_PRBS_M15PR_Pos     28           /**< \brief (HMATRIXB_PRBS) Master 15 Priority */
+#define HMATRIXB_PRBS_M15PR_Msk     (_U(0xF) << HMATRIXB_PRBS_M15PR_Pos)
+#define HMATRIXB_PRBS_M15PR(value)  (HMATRIXB_PRBS_M15PR_Msk & ((value) << HMATRIXB_PRBS_M15PR_Pos))
+#define HMATRIXB_PRBS_MASK          _U(0xFFFFFFFF) /**< \brief (HMATRIXB_PRBS) MASK Register */
+
+/* -------- HMATRIXB_MRCR : (HMATRIXB Offset: 0x100) (R/W 32) Master Remap Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RCB0:1;           /*!< bit:      0  Remap Command bit for Master 0     */
+    uint32_t RCB1:1;           /*!< bit:      1  Remap Command bit for Master 1     */
+    uint32_t RCB2:1;           /*!< bit:      2  Remap Command bit for Master 2     */
+    uint32_t RCB3:1;           /*!< bit:      3  Remap Command bit for Master 3     */
+    uint32_t RCB4:1;           /*!< bit:      4  Remap Command bit for Master 4     */
+    uint32_t RCB5:1;           /*!< bit:      5  Remap Command bit for Master 5     */
+    uint32_t RCB6:1;           /*!< bit:      6  Remap Command bit for Master 6     */
+    uint32_t RCB7:1;           /*!< bit:      7  Remap Command bit for Master 7     */
+    uint32_t RCB8:1;           /*!< bit:      8  Remap Command bit for Master 8     */
+    uint32_t RCB9:1;           /*!< bit:      9  Remap Command bit for Master 9     */
+    uint32_t RCB10:1;          /*!< bit:     10  Remap Command bit for Master 10    */
+    uint32_t RCB11:1;          /*!< bit:     11  Remap Command bit for Master 11    */
+    uint32_t RCB12:1;          /*!< bit:     12  Remap Command bit for Master 12    */
+    uint32_t RCB13:1;          /*!< bit:     13  Remap Command bit for Master 13    */
+    uint32_t RCB14:1;          /*!< bit:     14  Remap Command bit for Master 14    */
+    uint32_t RCB15:1;          /*!< bit:     15  Remap Command bit for Master 15    */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} HMATRIXB_MRCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HMATRIXB_MRCR_OFFSET        0x100        /**< \brief (HMATRIXB_MRCR offset) Master Remap Control Register */
+#define HMATRIXB_MRCR_RESETVALUE    _U(0x00000000); /**< \brief (HMATRIXB_MRCR reset_value) Master Remap Control Register */
+
+#define HMATRIXB_MRCR_RCB0_Pos      0            /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 0 */
+#define HMATRIXB_MRCR_RCB0          (_U(0x1) << HMATRIXB_MRCR_RCB0_Pos)
+#define   HMATRIXB_MRCR_RCB0_0_Val        _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB0_1_Val        _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB0_0        (HMATRIXB_MRCR_RCB0_0_Val      << HMATRIXB_MRCR_RCB0_Pos)
+#define HMATRIXB_MRCR_RCB0_1        (HMATRIXB_MRCR_RCB0_1_Val      << HMATRIXB_MRCR_RCB0_Pos)
+#define HMATRIXB_MRCR_RCB1_Pos      1            /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 1 */
+#define HMATRIXB_MRCR_RCB1          (_U(0x1) << HMATRIXB_MRCR_RCB1_Pos)
+#define   HMATRIXB_MRCR_RCB1_0_Val        _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB1_1_Val        _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB1_0        (HMATRIXB_MRCR_RCB1_0_Val      << HMATRIXB_MRCR_RCB1_Pos)
+#define HMATRIXB_MRCR_RCB1_1        (HMATRIXB_MRCR_RCB1_1_Val      << HMATRIXB_MRCR_RCB1_Pos)
+#define HMATRIXB_MRCR_RCB2_Pos      2            /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 2 */
+#define HMATRIXB_MRCR_RCB2          (_U(0x1) << HMATRIXB_MRCR_RCB2_Pos)
+#define   HMATRIXB_MRCR_RCB2_0_Val        _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB2_1_Val        _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB2_0        (HMATRIXB_MRCR_RCB2_0_Val      << HMATRIXB_MRCR_RCB2_Pos)
+#define HMATRIXB_MRCR_RCB2_1        (HMATRIXB_MRCR_RCB2_1_Val      << HMATRIXB_MRCR_RCB2_Pos)
+#define HMATRIXB_MRCR_RCB3_Pos      3            /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 3 */
+#define HMATRIXB_MRCR_RCB3          (_U(0x1) << HMATRIXB_MRCR_RCB3_Pos)
+#define   HMATRIXB_MRCR_RCB3_0_Val        _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB3_1_Val        _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB3_0        (HMATRIXB_MRCR_RCB3_0_Val      << HMATRIXB_MRCR_RCB3_Pos)
+#define HMATRIXB_MRCR_RCB3_1        (HMATRIXB_MRCR_RCB3_1_Val      << HMATRIXB_MRCR_RCB3_Pos)
+#define HMATRIXB_MRCR_RCB4_Pos      4            /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 4 */
+#define HMATRIXB_MRCR_RCB4          (_U(0x1) << HMATRIXB_MRCR_RCB4_Pos)
+#define   HMATRIXB_MRCR_RCB4_0_Val        _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB4_1_Val        _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB4_0        (HMATRIXB_MRCR_RCB4_0_Val      << HMATRIXB_MRCR_RCB4_Pos)
+#define HMATRIXB_MRCR_RCB4_1        (HMATRIXB_MRCR_RCB4_1_Val      << HMATRIXB_MRCR_RCB4_Pos)
+#define HMATRIXB_MRCR_RCB5_Pos      5            /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 5 */
+#define HMATRIXB_MRCR_RCB5          (_U(0x1) << HMATRIXB_MRCR_RCB5_Pos)
+#define   HMATRIXB_MRCR_RCB5_0_Val        _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB5_1_Val        _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB5_0        (HMATRIXB_MRCR_RCB5_0_Val      << HMATRIXB_MRCR_RCB5_Pos)
+#define HMATRIXB_MRCR_RCB5_1        (HMATRIXB_MRCR_RCB5_1_Val      << HMATRIXB_MRCR_RCB5_Pos)
+#define HMATRIXB_MRCR_RCB6_Pos      6            /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 6 */
+#define HMATRIXB_MRCR_RCB6          (_U(0x1) << HMATRIXB_MRCR_RCB6_Pos)
+#define   HMATRIXB_MRCR_RCB6_0_Val        _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB6_1_Val        _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB6_0        (HMATRIXB_MRCR_RCB6_0_Val      << HMATRIXB_MRCR_RCB6_Pos)
+#define HMATRIXB_MRCR_RCB6_1        (HMATRIXB_MRCR_RCB6_1_Val      << HMATRIXB_MRCR_RCB6_Pos)
+#define HMATRIXB_MRCR_RCB7_Pos      7            /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 7 */
+#define HMATRIXB_MRCR_RCB7          (_U(0x1) << HMATRIXB_MRCR_RCB7_Pos)
+#define   HMATRIXB_MRCR_RCB7_0_Val        _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB7_1_Val        _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB7_0        (HMATRIXB_MRCR_RCB7_0_Val      << HMATRIXB_MRCR_RCB7_Pos)
+#define HMATRIXB_MRCR_RCB7_1        (HMATRIXB_MRCR_RCB7_1_Val      << HMATRIXB_MRCR_RCB7_Pos)
+#define HMATRIXB_MRCR_RCB8_Pos      8            /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 8 */
+#define HMATRIXB_MRCR_RCB8          (_U(0x1) << HMATRIXB_MRCR_RCB8_Pos)
+#define   HMATRIXB_MRCR_RCB8_0_Val        _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB8_1_Val        _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB8_0        (HMATRIXB_MRCR_RCB8_0_Val      << HMATRIXB_MRCR_RCB8_Pos)
+#define HMATRIXB_MRCR_RCB8_1        (HMATRIXB_MRCR_RCB8_1_Val      << HMATRIXB_MRCR_RCB8_Pos)
+#define HMATRIXB_MRCR_RCB9_Pos      9            /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 9 */
+#define HMATRIXB_MRCR_RCB9          (_U(0x1) << HMATRIXB_MRCR_RCB9_Pos)
+#define   HMATRIXB_MRCR_RCB9_0_Val        _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB9_1_Val        _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB9_0        (HMATRIXB_MRCR_RCB9_0_Val      << HMATRIXB_MRCR_RCB9_Pos)
+#define HMATRIXB_MRCR_RCB9_1        (HMATRIXB_MRCR_RCB9_1_Val      << HMATRIXB_MRCR_RCB9_Pos)
+#define HMATRIXB_MRCR_RCB10_Pos     10           /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 10 */
+#define HMATRIXB_MRCR_RCB10         (_U(0x1) << HMATRIXB_MRCR_RCB10_Pos)
+#define   HMATRIXB_MRCR_RCB10_0_Val       _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB10_1_Val       _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB10_0       (HMATRIXB_MRCR_RCB10_0_Val     << HMATRIXB_MRCR_RCB10_Pos)
+#define HMATRIXB_MRCR_RCB10_1       (HMATRIXB_MRCR_RCB10_1_Val     << HMATRIXB_MRCR_RCB10_Pos)
+#define HMATRIXB_MRCR_RCB11_Pos     11           /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 11 */
+#define HMATRIXB_MRCR_RCB11         (_U(0x1) << HMATRIXB_MRCR_RCB11_Pos)
+#define   HMATRIXB_MRCR_RCB11_0_Val       _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB11_1_Val       _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB11_0       (HMATRIXB_MRCR_RCB11_0_Val     << HMATRIXB_MRCR_RCB11_Pos)
+#define HMATRIXB_MRCR_RCB11_1       (HMATRIXB_MRCR_RCB11_1_Val     << HMATRIXB_MRCR_RCB11_Pos)
+#define HMATRIXB_MRCR_RCB12_Pos     12           /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 12 */
+#define HMATRIXB_MRCR_RCB12         (_U(0x1) << HMATRIXB_MRCR_RCB12_Pos)
+#define   HMATRIXB_MRCR_RCB12_0_Val       _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB12_1_Val       _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB12_0       (HMATRIXB_MRCR_RCB12_0_Val     << HMATRIXB_MRCR_RCB12_Pos)
+#define HMATRIXB_MRCR_RCB12_1       (HMATRIXB_MRCR_RCB12_1_Val     << HMATRIXB_MRCR_RCB12_Pos)
+#define HMATRIXB_MRCR_RCB13_Pos     13           /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 13 */
+#define HMATRIXB_MRCR_RCB13         (_U(0x1) << HMATRIXB_MRCR_RCB13_Pos)
+#define   HMATRIXB_MRCR_RCB13_0_Val       _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB13_1_Val       _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB13_0       (HMATRIXB_MRCR_RCB13_0_Val     << HMATRIXB_MRCR_RCB13_Pos)
+#define HMATRIXB_MRCR_RCB13_1       (HMATRIXB_MRCR_RCB13_1_Val     << HMATRIXB_MRCR_RCB13_Pos)
+#define HMATRIXB_MRCR_RCB14_Pos     14           /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 14 */
+#define HMATRIXB_MRCR_RCB14         (_U(0x1) << HMATRIXB_MRCR_RCB14_Pos)
+#define   HMATRIXB_MRCR_RCB14_0_Val       _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB14_1_Val       _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB14_0       (HMATRIXB_MRCR_RCB14_0_Val     << HMATRIXB_MRCR_RCB14_Pos)
+#define HMATRIXB_MRCR_RCB14_1       (HMATRIXB_MRCR_RCB14_1_Val     << HMATRIXB_MRCR_RCB14_Pos)
+#define HMATRIXB_MRCR_RCB15_Pos     15           /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 15 */
+#define HMATRIXB_MRCR_RCB15         (_U(0x1) << HMATRIXB_MRCR_RCB15_Pos)
+#define   HMATRIXB_MRCR_RCB15_0_Val       _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB15_1_Val       _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB15_0       (HMATRIXB_MRCR_RCB15_0_Val     << HMATRIXB_MRCR_RCB15_Pos)
+#define HMATRIXB_MRCR_RCB15_1       (HMATRIXB_MRCR_RCB15_1_Val     << HMATRIXB_MRCR_RCB15_Pos)
+#define HMATRIXB_MRCR_MASK          _U(0x0000FFFF) /**< \brief (HMATRIXB_MRCR) MASK Register */
+
+/* -------- HMATRIXB_SFR : (HMATRIXB Offset: 0x110) (R/W 32) sfr Special Function Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SFR:32;           /*!< bit:  0..31  Special Function Register          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} HMATRIXB_SFR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define HMATRIXB_SFR_OFFSET         0x110        /**< \brief (HMATRIXB_SFR offset) Special Function Register */
+#define HMATRIXB_SFR_RESETVALUE     _U(0x00000000); /**< \brief (HMATRIXB_SFR reset_value) Special Function Register */
+
+#define HMATRIXB_SFR_SFR_Pos        0            /**< \brief (HMATRIXB_SFR) Special Function Register */
+#define HMATRIXB_SFR_SFR_Msk        (_U(0xFFFFFFFF) << HMATRIXB_SFR_SFR_Pos)
+#define HMATRIXB_SFR_SFR(value)     (HMATRIXB_SFR_SFR_Msk & ((value) << HMATRIXB_SFR_SFR_Pos))
+#define HMATRIXB_SFR_MASK           _U(0xFFFFFFFF) /**< \brief (HMATRIXB_SFR) MASK Register */
+
+/** \brief HmatrixbMcfg hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __IO HMATRIXB_MCFG_Type        MCFG;        /**< \brief Offset: 0x000 (R/W 32) Master Configuration Register */
+ } bf;
+ struct {
+  RwReg   HMATRIXB_MCFG;      /**< \brief (HMATRIXB Offset: 0x000) Master Configuration Register */
+ } reg;
+} HmatrixbMcfg;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief HmatrixbPrs hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __IO HMATRIXB_PRAS_Type        PRAS;        /**< \brief Offset: 0x000 (R/W 32) Priority Register A for Slave */
+  __IO HMATRIXB_PRBS_Type        PRBS;        /**< \brief Offset: 0x004 (R/W 32) Priority Register B for Slave */
+ } bf;
+ struct {
+  RwReg   HMATRIXB_PRAS;      /**< \brief (HMATRIXB Offset: 0x000) Priority Register A for Slave */
+  RwReg   HMATRIXB_PRBS;      /**< \brief (HMATRIXB Offset: 0x004) Priority Register B for Slave */
+ } reg;
+} HmatrixbPrs;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief HmatrixbScfg hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __IO HMATRIXB_SCFG_Type        SCFG;        /**< \brief Offset: 0x000 (R/W 32) Slave Configuration Register */
+ } bf;
+ struct {
+  RwReg   HMATRIXB_SCFG;      /**< \brief (HMATRIXB Offset: 0x000) Slave Configuration Register */
+ } reg;
+} HmatrixbScfg;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief HmatrixbSfr hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __IO HMATRIXB_SFR_Type         SFR;         /**< \brief Offset: 0x000 (R/W 32) Special Function Register */
+ } bf;
+ struct {
+  RwReg   HMATRIXB_SFR;       /**< \brief (HMATRIXB Offset: 0x000) Special Function Register */
+ } reg;
+} HmatrixbSfr;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief HMATRIXB hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+       HmatrixbMcfg              Mcfg[16];    /**< \brief Offset: 0x000 HmatrixbMcfg groups */
+       HmatrixbScfg              Scfg[16];    /**< \brief Offset: 0x040 HmatrixbScfg groups */
+       HmatrixbPrs               Prs[16];     /**< \brief Offset: 0x080 HmatrixbPrs groups */
+  __IO HMATRIXB_MRCR_Type        MRCR;        /**< \brief Offset: 0x100 (R/W 32) Master Remap Control Register */
+       RoReg8                    Reserved1[0xC];
+       HmatrixbSfr               Sfr[16];     /**< \brief Offset: 0x110 HmatrixbSfr groups */
+ } bf;
+ struct {
+  HmatrixbMcfg HMATRIXB_MCFG[16];  /**< \brief (HMATRIXB Offset: 0x000) HmatrixbMcfg groups */
+  HmatrixbScfg HMATRIXB_SCFG[16];  /**< \brief (HMATRIXB Offset: 0x040) HmatrixbScfg groups */
+  HmatrixbPrs HMATRIXB_PRS[16];   /**< \brief (HMATRIXB Offset: 0x080) HmatrixbPrs groups */
+  RwReg   HMATRIXB_MRCR;      /**< \brief (HMATRIXB Offset: 0x100) Master Remap Control Register */
+  RoReg8  Reserved2[0xC];
+  HmatrixbSfr HMATRIXB_SFR[16];   /**< \brief (HMATRIXB Offset: 0x110) HmatrixbSfr groups */
+ } reg;
+} Hmatrixb;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_HMATRIXB_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/hmatrixb.h
+++ b/asf/sam/include/sam4l/component/hmatrixb.h
@@ -398,23 +398,13 @@ typedef union {
 
 /** \brief HMATRIXB hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-       HmatrixbMcfg              Mcfg[16];    /**< \brief Offset: 0x000 HmatrixbMcfg groups */
-       HmatrixbScfg              Scfg[16];    /**< \brief Offset: 0x040 HmatrixbScfg groups */
-       HmatrixbPrs               Prs[16];     /**< \brief Offset: 0x080 HmatrixbPrs groups */
-  __IO HMATRIXB_MRCR_Type        MRCR;        /**< \brief Offset: 0x100 (R/W 32) Master Remap Control Register */
-       RoReg8                    Reserved1[0xC];
-       HmatrixbSfr               Sfr[16];     /**< \brief Offset: 0x110 HmatrixbSfr groups */
- } bf;
- struct {
-  HmatrixbMcfg HMATRIXB_MCFG[16];  /**< \brief (HMATRIXB Offset: 0x000) HmatrixbMcfg groups */
-  HmatrixbScfg HMATRIXB_SCFG[16];  /**< \brief (HMATRIXB Offset: 0x040) HmatrixbScfg groups */
-  HmatrixbPrs HMATRIXB_PRS[16];   /**< \brief (HMATRIXB Offset: 0x080) HmatrixbPrs groups */
-  RwReg   HMATRIXB_MRCR;      /**< \brief (HMATRIXB Offset: 0x100) Master Remap Control Register */
-  RoReg8  Reserved2[0xC];
-  HmatrixbSfr HMATRIXB_SFR[16];   /**< \brief (HMATRIXB Offset: 0x110) HmatrixbSfr groups */
- } reg;
+typedef struct {
+  __IO uint32_t Mcfg[16];    /**< \brief Offset: 0x000 HmatrixbMcfg groups */
+  __IO uint32_t Scfg[16];    /**< \brief Offset: 0x040 HmatrixbScfg groups */
+  __IO uint32_t Prs[16];     /**< \brief Offset: 0x080 HmatrixbPrs groups */
+  __IO uint32_t MRCR;        /**< \brief Offset: 0x100 (R/W 32) Master Remap Control Register */
+       RoReg8   Reserved1[0xC];
+  __IO uint32_t Sfr[16];     /**< \brief Offset: 0x110 HmatrixbSfr groups */
 } Hmatrixb;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/hmatrixb.h
+++ b/asf/sam/include/sam4l/component/hmatrixb.h
@@ -50,22 +50,22 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HMATRIXB_MCFG_OFFSET        0x000        /**< \brief (HMATRIXB_MCFG offset) Master Configuration Register */
-#define HMATRIXB_MCFG_RESETVALUE    _U(0x00000002); /**< \brief (HMATRIXB_MCFG reset_value) Master Configuration Register */
+#define HMATRIXB_MCFG_RESETVALUE    _U_(0x00000002); /**< \brief (HMATRIXB_MCFG reset_value) Master Configuration Register */
 
 #define HMATRIXB_MCFG_ULBT_Pos      0            /**< \brief (HMATRIXB_MCFG) Undefined Length Burst Type */
-#define HMATRIXB_MCFG_ULBT_Msk      (_U(0x7) << HMATRIXB_MCFG_ULBT_Pos)
+#define HMATRIXB_MCFG_ULBT_Msk      (_U_(0x7) << HMATRIXB_MCFG_ULBT_Pos)
 #define HMATRIXB_MCFG_ULBT(value)   (HMATRIXB_MCFG_ULBT_Msk & ((value) << HMATRIXB_MCFG_ULBT_Pos))
-#define   HMATRIXB_MCFG_ULBT_INFINITE_Val _U(0x0)   /**< \brief (HMATRIXB_MCFG) Infinite Length */
-#define   HMATRIXB_MCFG_ULBT_SINGLE_Val   _U(0x1)   /**< \brief (HMATRIXB_MCFG) Single Access */
-#define   HMATRIXB_MCFG_ULBT_FOUR_BEAT_Val _U(0x2)   /**< \brief (HMATRIXB_MCFG) Four Beat Burst */
-#define   HMATRIXB_MCFG_ULBT_EIGHT_BEAT_Val _U(0x3)   /**< \brief (HMATRIXB_MCFG) Eight Beat Burst */
-#define   HMATRIXB_MCFG_ULBT_SIXTEEN_BEAT_Val _U(0x4)   /**< \brief (HMATRIXB_MCFG) Sixteen Beat Burst */
+#define   HMATRIXB_MCFG_ULBT_INFINITE_Val _U_(0x0)   /**< \brief (HMATRIXB_MCFG) Infinite Length */
+#define   HMATRIXB_MCFG_ULBT_SINGLE_Val   _U_(0x1)   /**< \brief (HMATRIXB_MCFG) Single Access */
+#define   HMATRIXB_MCFG_ULBT_FOUR_BEAT_Val _U_(0x2)   /**< \brief (HMATRIXB_MCFG) Four Beat Burst */
+#define   HMATRIXB_MCFG_ULBT_EIGHT_BEAT_Val _U_(0x3)   /**< \brief (HMATRIXB_MCFG) Eight Beat Burst */
+#define   HMATRIXB_MCFG_ULBT_SIXTEEN_BEAT_Val _U_(0x4)   /**< \brief (HMATRIXB_MCFG) Sixteen Beat Burst */
 #define HMATRIXB_MCFG_ULBT_INFINITE (HMATRIXB_MCFG_ULBT_INFINITE_Val << HMATRIXB_MCFG_ULBT_Pos)
 #define HMATRIXB_MCFG_ULBT_SINGLE   (HMATRIXB_MCFG_ULBT_SINGLE_Val << HMATRIXB_MCFG_ULBT_Pos)
 #define HMATRIXB_MCFG_ULBT_FOUR_BEAT (HMATRIXB_MCFG_ULBT_FOUR_BEAT_Val << HMATRIXB_MCFG_ULBT_Pos)
 #define HMATRIXB_MCFG_ULBT_EIGHT_BEAT (HMATRIXB_MCFG_ULBT_EIGHT_BEAT_Val << HMATRIXB_MCFG_ULBT_Pos)
 #define HMATRIXB_MCFG_ULBT_SIXTEEN_BEAT (HMATRIXB_MCFG_ULBT_SIXTEEN_BEAT_Val << HMATRIXB_MCFG_ULBT_Pos)
-#define HMATRIXB_MCFG_MASK          _U(0x00000007) /**< \brief (HMATRIXB_MCFG) MASK Register */
+#define HMATRIXB_MCFG_MASK          _U_(0x00000007) /**< \brief (HMATRIXB_MCFG) MASK Register */
 
 /* -------- HMATRIXB_SCFG : (HMATRIXB Offset: 0x040) (R/W 32) scfg Slave Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -84,30 +84,30 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HMATRIXB_SCFG_OFFSET        0x040        /**< \brief (HMATRIXB_SCFG offset) Slave Configuration Register */
-#define HMATRIXB_SCFG_RESETVALUE    _U(0x00000010); /**< \brief (HMATRIXB_SCFG reset_value) Slave Configuration Register */
+#define HMATRIXB_SCFG_RESETVALUE    _U_(0x00000010); /**< \brief (HMATRIXB_SCFG reset_value) Slave Configuration Register */
 
 #define HMATRIXB_SCFG_SLOT_CYCLE_Pos 0            /**< \brief (HMATRIXB_SCFG) Maximum Number of Allowed Cycles for a Burst */
-#define HMATRIXB_SCFG_SLOT_CYCLE_Msk (_U(0xFF) << HMATRIXB_SCFG_SLOT_CYCLE_Pos)
+#define HMATRIXB_SCFG_SLOT_CYCLE_Msk (_U_(0xFF) << HMATRIXB_SCFG_SLOT_CYCLE_Pos)
 #define HMATRIXB_SCFG_SLOT_CYCLE(value) (HMATRIXB_SCFG_SLOT_CYCLE_Msk & ((value) << HMATRIXB_SCFG_SLOT_CYCLE_Pos))
 #define HMATRIXB_SCFG_DEFMSTR_TYPE_Pos 16           /**< \brief (HMATRIXB_SCFG) Default Master Type */
-#define HMATRIXB_SCFG_DEFMSTR_TYPE_Msk (_U(0x3) << HMATRIXB_SCFG_DEFMSTR_TYPE_Pos)
+#define HMATRIXB_SCFG_DEFMSTR_TYPE_Msk (_U_(0x3) << HMATRIXB_SCFG_DEFMSTR_TYPE_Pos)
 #define HMATRIXB_SCFG_DEFMSTR_TYPE(value) (HMATRIXB_SCFG_DEFMSTR_TYPE_Msk & ((value) << HMATRIXB_SCFG_DEFMSTR_TYPE_Pos))
-#define   HMATRIXB_SCFG_DEFMSTR_TYPE_NO_DEFAULT_Val _U(0x0)   /**< \brief (HMATRIXB_SCFG) No Default Master. At the end of current slave access, if no other master request is pending, the slave is deconnected from all masters. This resusts in having a one cycle latency for the first transfer of a burst. */
-#define   HMATRIXB_SCFG_DEFMSTR_TYPE_LAST_DEFAULT_Val _U(0x1)   /**< \brief (HMATRIXB_SCFG) Last Default Master At the end of current slave access, if no other master request is pending, the slave stay connected with the last master havingaccessed it.This resusts in not having the one cycle latency when the last master re-trying access on the slave. */
-#define   HMATRIXB_SCFG_DEFMSTR_TYPE_FIXED_DEFAULT_Val _U(0x2)   /**< \brief (HMATRIXB_SCFG) Fixed Default Master At the end of current slave access, if no other master request is pending, the slave connects with fixed master which numberis in FIXED_DEFMSTR register.This resusts in not having the one cycle latency when the fixed master re-trying access on the slave. */
+#define   HMATRIXB_SCFG_DEFMSTR_TYPE_NO_DEFAULT_Val _U_(0x0)   /**< \brief (HMATRIXB_SCFG) No Default Master. At the end of current slave access, if no other master request is pending, the slave is deconnected from all masters. This resusts in having a one cycle latency for the first transfer of a burst. */
+#define   HMATRIXB_SCFG_DEFMSTR_TYPE_LAST_DEFAULT_Val _U_(0x1)   /**< \brief (HMATRIXB_SCFG) Last Default Master At the end of current slave access, if no other master request is pending, the slave stay connected with the last master havingaccessed it.This resusts in not having the one cycle latency when the last master re-trying access on the slave. */
+#define   HMATRIXB_SCFG_DEFMSTR_TYPE_FIXED_DEFAULT_Val _U_(0x2)   /**< \brief (HMATRIXB_SCFG) Fixed Default Master At the end of current slave access, if no other master request is pending, the slave connects with fixed master which numberis in FIXED_DEFMSTR register.This resusts in not having the one cycle latency when the fixed master re-trying access on the slave. */
 #define HMATRIXB_SCFG_DEFMSTR_TYPE_NO_DEFAULT (HMATRIXB_SCFG_DEFMSTR_TYPE_NO_DEFAULT_Val << HMATRIXB_SCFG_DEFMSTR_TYPE_Pos)
 #define HMATRIXB_SCFG_DEFMSTR_TYPE_LAST_DEFAULT (HMATRIXB_SCFG_DEFMSTR_TYPE_LAST_DEFAULT_Val << HMATRIXB_SCFG_DEFMSTR_TYPE_Pos)
 #define HMATRIXB_SCFG_DEFMSTR_TYPE_FIXED_DEFAULT (HMATRIXB_SCFG_DEFMSTR_TYPE_FIXED_DEFAULT_Val << HMATRIXB_SCFG_DEFMSTR_TYPE_Pos)
 #define HMATRIXB_SCFG_FIXED_DEFMSTR_Pos 18           /**< \brief (HMATRIXB_SCFG) Fixed Index of Default Master */
-#define HMATRIXB_SCFG_FIXED_DEFMSTR_Msk (_U(0xF) << HMATRIXB_SCFG_FIXED_DEFMSTR_Pos)
+#define HMATRIXB_SCFG_FIXED_DEFMSTR_Msk (_U_(0xF) << HMATRIXB_SCFG_FIXED_DEFMSTR_Pos)
 #define HMATRIXB_SCFG_FIXED_DEFMSTR(value) (HMATRIXB_SCFG_FIXED_DEFMSTR_Msk & ((value) << HMATRIXB_SCFG_FIXED_DEFMSTR_Pos))
 #define HMATRIXB_SCFG_ARBT_Pos      24           /**< \brief (HMATRIXB_SCFG) Arbitration Type */
-#define HMATRIXB_SCFG_ARBT          (_U(0x1) << HMATRIXB_SCFG_ARBT_Pos)
-#define   HMATRIXB_SCFG_ARBT_ROUND_ROBIN_Val _U(0x0)   /**< \brief (HMATRIXB_SCFG) Round-Robin Arbitration */
-#define   HMATRIXB_SCFG_ARBT_FIXED_PRIORITY_Val _U(0x1)   /**< \brief (HMATRIXB_SCFG) Fixed Priority Arbitration */
+#define HMATRIXB_SCFG_ARBT          (_U_(0x1) << HMATRIXB_SCFG_ARBT_Pos)
+#define   HMATRIXB_SCFG_ARBT_ROUND_ROBIN_Val _U_(0x0)   /**< \brief (HMATRIXB_SCFG) Round-Robin Arbitration */
+#define   HMATRIXB_SCFG_ARBT_FIXED_PRIORITY_Val _U_(0x1)   /**< \brief (HMATRIXB_SCFG) Fixed Priority Arbitration */
 #define HMATRIXB_SCFG_ARBT_ROUND_ROBIN (HMATRIXB_SCFG_ARBT_ROUND_ROBIN_Val << HMATRIXB_SCFG_ARBT_Pos)
 #define HMATRIXB_SCFG_ARBT_FIXED_PRIORITY (HMATRIXB_SCFG_ARBT_FIXED_PRIORITY_Val << HMATRIXB_SCFG_ARBT_Pos)
-#define HMATRIXB_SCFG_MASK          _U(0x013F00FF) /**< \brief (HMATRIXB_SCFG) MASK Register */
+#define HMATRIXB_SCFG_MASK          _U_(0x013F00FF) /**< \brief (HMATRIXB_SCFG) MASK Register */
 
 /* -------- HMATRIXB_PRAS : (HMATRIXB Offset: 0x080) (R/W 32) prs Priority Register A for Slave -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -127,33 +127,33 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HMATRIXB_PRAS_OFFSET        0x080        /**< \brief (HMATRIXB_PRAS offset) Priority Register A for Slave */
-#define HMATRIXB_PRAS_RESETVALUE    _U(0x00000000); /**< \brief (HMATRIXB_PRAS reset_value) Priority Register A for Slave */
+#define HMATRIXB_PRAS_RESETVALUE    _U_(0x00000000); /**< \brief (HMATRIXB_PRAS reset_value) Priority Register A for Slave */
 
 #define HMATRIXB_PRAS_M0PR_Pos      0            /**< \brief (HMATRIXB_PRAS) Master 0 Priority */
-#define HMATRIXB_PRAS_M0PR_Msk      (_U(0xF) << HMATRIXB_PRAS_M0PR_Pos)
+#define HMATRIXB_PRAS_M0PR_Msk      (_U_(0xF) << HMATRIXB_PRAS_M0PR_Pos)
 #define HMATRIXB_PRAS_M0PR(value)   (HMATRIXB_PRAS_M0PR_Msk & ((value) << HMATRIXB_PRAS_M0PR_Pos))
 #define HMATRIXB_PRAS_M1PR_Pos      4            /**< \brief (HMATRIXB_PRAS) Master 1 Priority */
-#define HMATRIXB_PRAS_M1PR_Msk      (_U(0xF) << HMATRIXB_PRAS_M1PR_Pos)
+#define HMATRIXB_PRAS_M1PR_Msk      (_U_(0xF) << HMATRIXB_PRAS_M1PR_Pos)
 #define HMATRIXB_PRAS_M1PR(value)   (HMATRIXB_PRAS_M1PR_Msk & ((value) << HMATRIXB_PRAS_M1PR_Pos))
 #define HMATRIXB_PRAS_M2PR_Pos      8            /**< \brief (HMATRIXB_PRAS) Master 2 Priority */
-#define HMATRIXB_PRAS_M2PR_Msk      (_U(0xF) << HMATRIXB_PRAS_M2PR_Pos)
+#define HMATRIXB_PRAS_M2PR_Msk      (_U_(0xF) << HMATRIXB_PRAS_M2PR_Pos)
 #define HMATRIXB_PRAS_M2PR(value)   (HMATRIXB_PRAS_M2PR_Msk & ((value) << HMATRIXB_PRAS_M2PR_Pos))
 #define HMATRIXB_PRAS_M3PR_Pos      12           /**< \brief (HMATRIXB_PRAS) Master 3 Priority */
-#define HMATRIXB_PRAS_M3PR_Msk      (_U(0xF) << HMATRIXB_PRAS_M3PR_Pos)
+#define HMATRIXB_PRAS_M3PR_Msk      (_U_(0xF) << HMATRIXB_PRAS_M3PR_Pos)
 #define HMATRIXB_PRAS_M3PR(value)   (HMATRIXB_PRAS_M3PR_Msk & ((value) << HMATRIXB_PRAS_M3PR_Pos))
 #define HMATRIXB_PRAS_M4PR_Pos      16           /**< \brief (HMATRIXB_PRAS) Master 4 Priority */
-#define HMATRIXB_PRAS_M4PR_Msk      (_U(0xF) << HMATRIXB_PRAS_M4PR_Pos)
+#define HMATRIXB_PRAS_M4PR_Msk      (_U_(0xF) << HMATRIXB_PRAS_M4PR_Pos)
 #define HMATRIXB_PRAS_M4PR(value)   (HMATRIXB_PRAS_M4PR_Msk & ((value) << HMATRIXB_PRAS_M4PR_Pos))
 #define HMATRIXB_PRAS_M5PR_Pos      20           /**< \brief (HMATRIXB_PRAS) Master 5 Priority */
-#define HMATRIXB_PRAS_M5PR_Msk      (_U(0xF) << HMATRIXB_PRAS_M5PR_Pos)
+#define HMATRIXB_PRAS_M5PR_Msk      (_U_(0xF) << HMATRIXB_PRAS_M5PR_Pos)
 #define HMATRIXB_PRAS_M5PR(value)   (HMATRIXB_PRAS_M5PR_Msk & ((value) << HMATRIXB_PRAS_M5PR_Pos))
 #define HMATRIXB_PRAS_M6PR_Pos      24           /**< \brief (HMATRIXB_PRAS) Master 6 Priority */
-#define HMATRIXB_PRAS_M6PR_Msk      (_U(0xF) << HMATRIXB_PRAS_M6PR_Pos)
+#define HMATRIXB_PRAS_M6PR_Msk      (_U_(0xF) << HMATRIXB_PRAS_M6PR_Pos)
 #define HMATRIXB_PRAS_M6PR(value)   (HMATRIXB_PRAS_M6PR_Msk & ((value) << HMATRIXB_PRAS_M6PR_Pos))
 #define HMATRIXB_PRAS_M7PR_Pos      28           /**< \brief (HMATRIXB_PRAS) Master 7 Priority */
-#define HMATRIXB_PRAS_M7PR_Msk      (_U(0xF) << HMATRIXB_PRAS_M7PR_Pos)
+#define HMATRIXB_PRAS_M7PR_Msk      (_U_(0xF) << HMATRIXB_PRAS_M7PR_Pos)
 #define HMATRIXB_PRAS_M7PR(value)   (HMATRIXB_PRAS_M7PR_Msk & ((value) << HMATRIXB_PRAS_M7PR_Pos))
-#define HMATRIXB_PRAS_MASK          _U(0xFFFFFFFF) /**< \brief (HMATRIXB_PRAS) MASK Register */
+#define HMATRIXB_PRAS_MASK          _U_(0xFFFFFFFF) /**< \brief (HMATRIXB_PRAS) MASK Register */
 
 /* -------- HMATRIXB_PRBS : (HMATRIXB Offset: 0x084) (R/W 32) prs Priority Register B for Slave -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -173,33 +173,33 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HMATRIXB_PRBS_OFFSET        0x084        /**< \brief (HMATRIXB_PRBS offset) Priority Register B for Slave */
-#define HMATRIXB_PRBS_RESETVALUE    _U(0x00000000); /**< \brief (HMATRIXB_PRBS reset_value) Priority Register B for Slave */
+#define HMATRIXB_PRBS_RESETVALUE    _U_(0x00000000); /**< \brief (HMATRIXB_PRBS reset_value) Priority Register B for Slave */
 
 #define HMATRIXB_PRBS_M8PR_Pos      0            /**< \brief (HMATRIXB_PRBS) Master 8 Priority */
-#define HMATRIXB_PRBS_M8PR_Msk      (_U(0xF) << HMATRIXB_PRBS_M8PR_Pos)
+#define HMATRIXB_PRBS_M8PR_Msk      (_U_(0xF) << HMATRIXB_PRBS_M8PR_Pos)
 #define HMATRIXB_PRBS_M8PR(value)   (HMATRIXB_PRBS_M8PR_Msk & ((value) << HMATRIXB_PRBS_M8PR_Pos))
 #define HMATRIXB_PRBS_M9PR_Pos      4            /**< \brief (HMATRIXB_PRBS) Master 9 Priority */
-#define HMATRIXB_PRBS_M9PR_Msk      (_U(0xF) << HMATRIXB_PRBS_M9PR_Pos)
+#define HMATRIXB_PRBS_M9PR_Msk      (_U_(0xF) << HMATRIXB_PRBS_M9PR_Pos)
 #define HMATRIXB_PRBS_M9PR(value)   (HMATRIXB_PRBS_M9PR_Msk & ((value) << HMATRIXB_PRBS_M9PR_Pos))
 #define HMATRIXB_PRBS_M10PR_Pos     8            /**< \brief (HMATRIXB_PRBS) Master 10 Priority */
-#define HMATRIXB_PRBS_M10PR_Msk     (_U(0xF) << HMATRIXB_PRBS_M10PR_Pos)
+#define HMATRIXB_PRBS_M10PR_Msk     (_U_(0xF) << HMATRIXB_PRBS_M10PR_Pos)
 #define HMATRIXB_PRBS_M10PR(value)  (HMATRIXB_PRBS_M10PR_Msk & ((value) << HMATRIXB_PRBS_M10PR_Pos))
 #define HMATRIXB_PRBS_M11PR_Pos     12           /**< \brief (HMATRIXB_PRBS) Master 11 Priority */
-#define HMATRIXB_PRBS_M11PR_Msk     (_U(0xF) << HMATRIXB_PRBS_M11PR_Pos)
+#define HMATRIXB_PRBS_M11PR_Msk     (_U_(0xF) << HMATRIXB_PRBS_M11PR_Pos)
 #define HMATRIXB_PRBS_M11PR(value)  (HMATRIXB_PRBS_M11PR_Msk & ((value) << HMATRIXB_PRBS_M11PR_Pos))
 #define HMATRIXB_PRBS_M12PR_Pos     16           /**< \brief (HMATRIXB_PRBS) Master 12 Priority */
-#define HMATRIXB_PRBS_M12PR_Msk     (_U(0xF) << HMATRIXB_PRBS_M12PR_Pos)
+#define HMATRIXB_PRBS_M12PR_Msk     (_U_(0xF) << HMATRIXB_PRBS_M12PR_Pos)
 #define HMATRIXB_PRBS_M12PR(value)  (HMATRIXB_PRBS_M12PR_Msk & ((value) << HMATRIXB_PRBS_M12PR_Pos))
 #define HMATRIXB_PRBS_M13PR_Pos     20           /**< \brief (HMATRIXB_PRBS) Master 13 Priority */
-#define HMATRIXB_PRBS_M13PR_Msk     (_U(0xF) << HMATRIXB_PRBS_M13PR_Pos)
+#define HMATRIXB_PRBS_M13PR_Msk     (_U_(0xF) << HMATRIXB_PRBS_M13PR_Pos)
 #define HMATRIXB_PRBS_M13PR(value)  (HMATRIXB_PRBS_M13PR_Msk & ((value) << HMATRIXB_PRBS_M13PR_Pos))
 #define HMATRIXB_PRBS_M14PR_Pos     24           /**< \brief (HMATRIXB_PRBS) Master 14 Priority */
-#define HMATRIXB_PRBS_M14PR_Msk     (_U(0xF) << HMATRIXB_PRBS_M14PR_Pos)
+#define HMATRIXB_PRBS_M14PR_Msk     (_U_(0xF) << HMATRIXB_PRBS_M14PR_Pos)
 #define HMATRIXB_PRBS_M14PR(value)  (HMATRIXB_PRBS_M14PR_Msk & ((value) << HMATRIXB_PRBS_M14PR_Pos))
 #define HMATRIXB_PRBS_M15PR_Pos     28           /**< \brief (HMATRIXB_PRBS) Master 15 Priority */
-#define HMATRIXB_PRBS_M15PR_Msk     (_U(0xF) << HMATRIXB_PRBS_M15PR_Pos)
+#define HMATRIXB_PRBS_M15PR_Msk     (_U_(0xF) << HMATRIXB_PRBS_M15PR_Pos)
 #define HMATRIXB_PRBS_M15PR(value)  (HMATRIXB_PRBS_M15PR_Msk & ((value) << HMATRIXB_PRBS_M15PR_Pos))
-#define HMATRIXB_PRBS_MASK          _U(0xFFFFFFFF) /**< \brief (HMATRIXB_PRBS) MASK Register */
+#define HMATRIXB_PRBS_MASK          _U_(0xFFFFFFFF) /**< \brief (HMATRIXB_PRBS) MASK Register */
 
 /* -------- HMATRIXB_MRCR : (HMATRIXB Offset: 0x100) (R/W 32) Master Remap Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -228,105 +228,105 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HMATRIXB_MRCR_OFFSET        0x100        /**< \brief (HMATRIXB_MRCR offset) Master Remap Control Register */
-#define HMATRIXB_MRCR_RESETVALUE    _U(0x00000000); /**< \brief (HMATRIXB_MRCR reset_value) Master Remap Control Register */
+#define HMATRIXB_MRCR_RESETVALUE    _U_(0x00000000); /**< \brief (HMATRIXB_MRCR reset_value) Master Remap Control Register */
 
 #define HMATRIXB_MRCR_RCB0_Pos      0            /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 0 */
-#define HMATRIXB_MRCR_RCB0          (_U(0x1) << HMATRIXB_MRCR_RCB0_Pos)
-#define   HMATRIXB_MRCR_RCB0_0_Val        _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
-#define   HMATRIXB_MRCR_RCB0_1_Val        _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB0          (_U_(0x1) << HMATRIXB_MRCR_RCB0_Pos)
+#define   HMATRIXB_MRCR_RCB0_0_Val        _U_(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB0_1_Val        _U_(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
 #define HMATRIXB_MRCR_RCB0_0        (HMATRIXB_MRCR_RCB0_0_Val      << HMATRIXB_MRCR_RCB0_Pos)
 #define HMATRIXB_MRCR_RCB0_1        (HMATRIXB_MRCR_RCB0_1_Val      << HMATRIXB_MRCR_RCB0_Pos)
 #define HMATRIXB_MRCR_RCB1_Pos      1            /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 1 */
-#define HMATRIXB_MRCR_RCB1          (_U(0x1) << HMATRIXB_MRCR_RCB1_Pos)
-#define   HMATRIXB_MRCR_RCB1_0_Val        _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
-#define   HMATRIXB_MRCR_RCB1_1_Val        _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB1          (_U_(0x1) << HMATRIXB_MRCR_RCB1_Pos)
+#define   HMATRIXB_MRCR_RCB1_0_Val        _U_(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB1_1_Val        _U_(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
 #define HMATRIXB_MRCR_RCB1_0        (HMATRIXB_MRCR_RCB1_0_Val      << HMATRIXB_MRCR_RCB1_Pos)
 #define HMATRIXB_MRCR_RCB1_1        (HMATRIXB_MRCR_RCB1_1_Val      << HMATRIXB_MRCR_RCB1_Pos)
 #define HMATRIXB_MRCR_RCB2_Pos      2            /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 2 */
-#define HMATRIXB_MRCR_RCB2          (_U(0x1) << HMATRIXB_MRCR_RCB2_Pos)
-#define   HMATRIXB_MRCR_RCB2_0_Val        _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
-#define   HMATRIXB_MRCR_RCB2_1_Val        _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB2          (_U_(0x1) << HMATRIXB_MRCR_RCB2_Pos)
+#define   HMATRIXB_MRCR_RCB2_0_Val        _U_(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB2_1_Val        _U_(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
 #define HMATRIXB_MRCR_RCB2_0        (HMATRIXB_MRCR_RCB2_0_Val      << HMATRIXB_MRCR_RCB2_Pos)
 #define HMATRIXB_MRCR_RCB2_1        (HMATRIXB_MRCR_RCB2_1_Val      << HMATRIXB_MRCR_RCB2_Pos)
 #define HMATRIXB_MRCR_RCB3_Pos      3            /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 3 */
-#define HMATRIXB_MRCR_RCB3          (_U(0x1) << HMATRIXB_MRCR_RCB3_Pos)
-#define   HMATRIXB_MRCR_RCB3_0_Val        _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
-#define   HMATRIXB_MRCR_RCB3_1_Val        _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB3          (_U_(0x1) << HMATRIXB_MRCR_RCB3_Pos)
+#define   HMATRIXB_MRCR_RCB3_0_Val        _U_(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB3_1_Val        _U_(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
 #define HMATRIXB_MRCR_RCB3_0        (HMATRIXB_MRCR_RCB3_0_Val      << HMATRIXB_MRCR_RCB3_Pos)
 #define HMATRIXB_MRCR_RCB3_1        (HMATRIXB_MRCR_RCB3_1_Val      << HMATRIXB_MRCR_RCB3_Pos)
 #define HMATRIXB_MRCR_RCB4_Pos      4            /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 4 */
-#define HMATRIXB_MRCR_RCB4          (_U(0x1) << HMATRIXB_MRCR_RCB4_Pos)
-#define   HMATRIXB_MRCR_RCB4_0_Val        _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
-#define   HMATRIXB_MRCR_RCB4_1_Val        _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB4          (_U_(0x1) << HMATRIXB_MRCR_RCB4_Pos)
+#define   HMATRIXB_MRCR_RCB4_0_Val        _U_(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB4_1_Val        _U_(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
 #define HMATRIXB_MRCR_RCB4_0        (HMATRIXB_MRCR_RCB4_0_Val      << HMATRIXB_MRCR_RCB4_Pos)
 #define HMATRIXB_MRCR_RCB4_1        (HMATRIXB_MRCR_RCB4_1_Val      << HMATRIXB_MRCR_RCB4_Pos)
 #define HMATRIXB_MRCR_RCB5_Pos      5            /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 5 */
-#define HMATRIXB_MRCR_RCB5          (_U(0x1) << HMATRIXB_MRCR_RCB5_Pos)
-#define   HMATRIXB_MRCR_RCB5_0_Val        _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
-#define   HMATRIXB_MRCR_RCB5_1_Val        _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB5          (_U_(0x1) << HMATRIXB_MRCR_RCB5_Pos)
+#define   HMATRIXB_MRCR_RCB5_0_Val        _U_(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB5_1_Val        _U_(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
 #define HMATRIXB_MRCR_RCB5_0        (HMATRIXB_MRCR_RCB5_0_Val      << HMATRIXB_MRCR_RCB5_Pos)
 #define HMATRIXB_MRCR_RCB5_1        (HMATRIXB_MRCR_RCB5_1_Val      << HMATRIXB_MRCR_RCB5_Pos)
 #define HMATRIXB_MRCR_RCB6_Pos      6            /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 6 */
-#define HMATRIXB_MRCR_RCB6          (_U(0x1) << HMATRIXB_MRCR_RCB6_Pos)
-#define   HMATRIXB_MRCR_RCB6_0_Val        _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
-#define   HMATRIXB_MRCR_RCB6_1_Val        _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB6          (_U_(0x1) << HMATRIXB_MRCR_RCB6_Pos)
+#define   HMATRIXB_MRCR_RCB6_0_Val        _U_(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB6_1_Val        _U_(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
 #define HMATRIXB_MRCR_RCB6_0        (HMATRIXB_MRCR_RCB6_0_Val      << HMATRIXB_MRCR_RCB6_Pos)
 #define HMATRIXB_MRCR_RCB6_1        (HMATRIXB_MRCR_RCB6_1_Val      << HMATRIXB_MRCR_RCB6_Pos)
 #define HMATRIXB_MRCR_RCB7_Pos      7            /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 7 */
-#define HMATRIXB_MRCR_RCB7          (_U(0x1) << HMATRIXB_MRCR_RCB7_Pos)
-#define   HMATRIXB_MRCR_RCB7_0_Val        _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
-#define   HMATRIXB_MRCR_RCB7_1_Val        _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB7          (_U_(0x1) << HMATRIXB_MRCR_RCB7_Pos)
+#define   HMATRIXB_MRCR_RCB7_0_Val        _U_(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB7_1_Val        _U_(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
 #define HMATRIXB_MRCR_RCB7_0        (HMATRIXB_MRCR_RCB7_0_Val      << HMATRIXB_MRCR_RCB7_Pos)
 #define HMATRIXB_MRCR_RCB7_1        (HMATRIXB_MRCR_RCB7_1_Val      << HMATRIXB_MRCR_RCB7_Pos)
 #define HMATRIXB_MRCR_RCB8_Pos      8            /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 8 */
-#define HMATRIXB_MRCR_RCB8          (_U(0x1) << HMATRIXB_MRCR_RCB8_Pos)
-#define   HMATRIXB_MRCR_RCB8_0_Val        _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
-#define   HMATRIXB_MRCR_RCB8_1_Val        _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB8          (_U_(0x1) << HMATRIXB_MRCR_RCB8_Pos)
+#define   HMATRIXB_MRCR_RCB8_0_Val        _U_(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB8_1_Val        _U_(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
 #define HMATRIXB_MRCR_RCB8_0        (HMATRIXB_MRCR_RCB8_0_Val      << HMATRIXB_MRCR_RCB8_Pos)
 #define HMATRIXB_MRCR_RCB8_1        (HMATRIXB_MRCR_RCB8_1_Val      << HMATRIXB_MRCR_RCB8_Pos)
 #define HMATRIXB_MRCR_RCB9_Pos      9            /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 9 */
-#define HMATRIXB_MRCR_RCB9          (_U(0x1) << HMATRIXB_MRCR_RCB9_Pos)
-#define   HMATRIXB_MRCR_RCB9_0_Val        _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
-#define   HMATRIXB_MRCR_RCB9_1_Val        _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB9          (_U_(0x1) << HMATRIXB_MRCR_RCB9_Pos)
+#define   HMATRIXB_MRCR_RCB9_0_Val        _U_(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB9_1_Val        _U_(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
 #define HMATRIXB_MRCR_RCB9_0        (HMATRIXB_MRCR_RCB9_0_Val      << HMATRIXB_MRCR_RCB9_Pos)
 #define HMATRIXB_MRCR_RCB9_1        (HMATRIXB_MRCR_RCB9_1_Val      << HMATRIXB_MRCR_RCB9_Pos)
 #define HMATRIXB_MRCR_RCB10_Pos     10           /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 10 */
-#define HMATRIXB_MRCR_RCB10         (_U(0x1) << HMATRIXB_MRCR_RCB10_Pos)
-#define   HMATRIXB_MRCR_RCB10_0_Val       _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
-#define   HMATRIXB_MRCR_RCB10_1_Val       _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB10         (_U_(0x1) << HMATRIXB_MRCR_RCB10_Pos)
+#define   HMATRIXB_MRCR_RCB10_0_Val       _U_(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB10_1_Val       _U_(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
 #define HMATRIXB_MRCR_RCB10_0       (HMATRIXB_MRCR_RCB10_0_Val     << HMATRIXB_MRCR_RCB10_Pos)
 #define HMATRIXB_MRCR_RCB10_1       (HMATRIXB_MRCR_RCB10_1_Val     << HMATRIXB_MRCR_RCB10_Pos)
 #define HMATRIXB_MRCR_RCB11_Pos     11           /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 11 */
-#define HMATRIXB_MRCR_RCB11         (_U(0x1) << HMATRIXB_MRCR_RCB11_Pos)
-#define   HMATRIXB_MRCR_RCB11_0_Val       _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
-#define   HMATRIXB_MRCR_RCB11_1_Val       _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB11         (_U_(0x1) << HMATRIXB_MRCR_RCB11_Pos)
+#define   HMATRIXB_MRCR_RCB11_0_Val       _U_(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB11_1_Val       _U_(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
 #define HMATRIXB_MRCR_RCB11_0       (HMATRIXB_MRCR_RCB11_0_Val     << HMATRIXB_MRCR_RCB11_Pos)
 #define HMATRIXB_MRCR_RCB11_1       (HMATRIXB_MRCR_RCB11_1_Val     << HMATRIXB_MRCR_RCB11_Pos)
 #define HMATRIXB_MRCR_RCB12_Pos     12           /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 12 */
-#define HMATRIXB_MRCR_RCB12         (_U(0x1) << HMATRIXB_MRCR_RCB12_Pos)
-#define   HMATRIXB_MRCR_RCB12_0_Val       _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
-#define   HMATRIXB_MRCR_RCB12_1_Val       _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB12         (_U_(0x1) << HMATRIXB_MRCR_RCB12_Pos)
+#define   HMATRIXB_MRCR_RCB12_0_Val       _U_(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB12_1_Val       _U_(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
 #define HMATRIXB_MRCR_RCB12_0       (HMATRIXB_MRCR_RCB12_0_Val     << HMATRIXB_MRCR_RCB12_Pos)
 #define HMATRIXB_MRCR_RCB12_1       (HMATRIXB_MRCR_RCB12_1_Val     << HMATRIXB_MRCR_RCB12_Pos)
 #define HMATRIXB_MRCR_RCB13_Pos     13           /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 13 */
-#define HMATRIXB_MRCR_RCB13         (_U(0x1) << HMATRIXB_MRCR_RCB13_Pos)
-#define   HMATRIXB_MRCR_RCB13_0_Val       _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
-#define   HMATRIXB_MRCR_RCB13_1_Val       _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB13         (_U_(0x1) << HMATRIXB_MRCR_RCB13_Pos)
+#define   HMATRIXB_MRCR_RCB13_0_Val       _U_(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB13_1_Val       _U_(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
 #define HMATRIXB_MRCR_RCB13_0       (HMATRIXB_MRCR_RCB13_0_Val     << HMATRIXB_MRCR_RCB13_Pos)
 #define HMATRIXB_MRCR_RCB13_1       (HMATRIXB_MRCR_RCB13_1_Val     << HMATRIXB_MRCR_RCB13_Pos)
 #define HMATRIXB_MRCR_RCB14_Pos     14           /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 14 */
-#define HMATRIXB_MRCR_RCB14         (_U(0x1) << HMATRIXB_MRCR_RCB14_Pos)
-#define   HMATRIXB_MRCR_RCB14_0_Val       _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
-#define   HMATRIXB_MRCR_RCB14_1_Val       _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB14         (_U_(0x1) << HMATRIXB_MRCR_RCB14_Pos)
+#define   HMATRIXB_MRCR_RCB14_0_Val       _U_(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB14_1_Val       _U_(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
 #define HMATRIXB_MRCR_RCB14_0       (HMATRIXB_MRCR_RCB14_0_Val     << HMATRIXB_MRCR_RCB14_Pos)
 #define HMATRIXB_MRCR_RCB14_1       (HMATRIXB_MRCR_RCB14_1_Val     << HMATRIXB_MRCR_RCB14_Pos)
 #define HMATRIXB_MRCR_RCB15_Pos     15           /**< \brief (HMATRIXB_MRCR) Remap Command bit for Master 15 */
-#define HMATRIXB_MRCR_RCB15         (_U(0x1) << HMATRIXB_MRCR_RCB15_Pos)
-#define   HMATRIXB_MRCR_RCB15_0_Val       _U(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
-#define   HMATRIXB_MRCR_RCB15_1_Val       _U(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
+#define HMATRIXB_MRCR_RCB15         (_U_(0x1) << HMATRIXB_MRCR_RCB15_Pos)
+#define   HMATRIXB_MRCR_RCB15_0_Val       _U_(0x0)   /**< \brief (HMATRIXB_MRCR) Disable remapped address decoding for master */
+#define   HMATRIXB_MRCR_RCB15_1_Val       _U_(0x1)   /**< \brief (HMATRIXB_MRCR) Enable remapped address decoding for master */
 #define HMATRIXB_MRCR_RCB15_0       (HMATRIXB_MRCR_RCB15_0_Val     << HMATRIXB_MRCR_RCB15_Pos)
 #define HMATRIXB_MRCR_RCB15_1       (HMATRIXB_MRCR_RCB15_1_Val     << HMATRIXB_MRCR_RCB15_Pos)
-#define HMATRIXB_MRCR_MASK          _U(0x0000FFFF) /**< \brief (HMATRIXB_MRCR) MASK Register */
+#define HMATRIXB_MRCR_MASK          _U_(0x0000FFFF) /**< \brief (HMATRIXB_MRCR) MASK Register */
 
 /* -------- HMATRIXB_SFR : (HMATRIXB Offset: 0x110) (R/W 32) sfr Special Function Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -339,12 +339,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HMATRIXB_SFR_OFFSET         0x110        /**< \brief (HMATRIXB_SFR offset) Special Function Register */
-#define HMATRIXB_SFR_RESETVALUE     _U(0x00000000); /**< \brief (HMATRIXB_SFR reset_value) Special Function Register */
+#define HMATRIXB_SFR_RESETVALUE     _U_(0x00000000); /**< \brief (HMATRIXB_SFR reset_value) Special Function Register */
 
 #define HMATRIXB_SFR_SFR_Pos        0            /**< \brief (HMATRIXB_SFR) Special Function Register */
-#define HMATRIXB_SFR_SFR_Msk        (_U(0xFFFFFFFF) << HMATRIXB_SFR_SFR_Pos)
+#define HMATRIXB_SFR_SFR_Msk        (_U_(0xFFFFFFFF) << HMATRIXB_SFR_SFR_Pos)
 #define HMATRIXB_SFR_SFR(value)     (HMATRIXB_SFR_SFR_Msk & ((value) << HMATRIXB_SFR_SFR_Pos))
-#define HMATRIXB_SFR_MASK           _U(0xFFFFFFFF) /**< \brief (HMATRIXB_SFR) MASK Register */
+#define HMATRIXB_SFR_MASK           _U_(0xFFFFFFFF) /**< \brief (HMATRIXB_SFR) MASK Register */
 
 /** \brief HmatrixbMcfg hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/iisc.h
+++ b/asf/sam/include/sam4l/component/iisc.h
@@ -601,35 +601,19 @@ typedef union {
 
 /** \brief IISC hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __O  IISC_CR_Type              CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
-  __IO IISC_MR_Type              MR;          /**< \brief Offset: 0x04 (R/W 32) Mode Register */
-  __I  IISC_SR_Type              SR;          /**< \brief Offset: 0x08 (R/  32) Status Register */
-  __O  IISC_SCR_Type             SCR;         /**< \brief Offset: 0x0C ( /W 32) Status Clear Register */
-  __O  IISC_SSR_Type             SSR;         /**< \brief Offset: 0x10 ( /W 32) Status Set Register */
-  __O  IISC_IER_Type             IER;         /**< \brief Offset: 0x14 ( /W 32) Interrupt Enable Register */
-  __O  IISC_IDR_Type             IDR;         /**< \brief Offset: 0x18 ( /W 32) Interrupt Disable Register */
-  __I  IISC_IMR_Type             IMR;         /**< \brief Offset: 0x1C (R/  32) Interrupt Mask Register */
-  __I  IISC_RHR_Type             RHR;         /**< \brief Offset: 0x20 (R/  32) Receive Holding Register */
-  __O  IISC_THR_Type             THR;         /**< \brief Offset: 0x24 ( /W 32) Transmit Holding Register */
-  __I  IISC_VERSION_Type         VERSION;     /**< \brief Offset: 0x28 (R/  32) Version Register */
-  __I  IISC_PARAMETER_Type       PARAMETER;   /**< \brief Offset: 0x2C (R/  32) Parameter Register */
- } bf;
- struct {
-  WoReg   IISC_CR;            /**< \brief (IISC Offset: 0x00) Control Register */
-  RwReg   IISC_MR;            /**< \brief (IISC Offset: 0x04) Mode Register */
-  RoReg   IISC_SR;            /**< \brief (IISC Offset: 0x08) Status Register */
-  WoReg   IISC_SCR;           /**< \brief (IISC Offset: 0x0C) Status Clear Register */
-  WoReg   IISC_SSR;           /**< \brief (IISC Offset: 0x10) Status Set Register */
-  WoReg   IISC_IER;           /**< \brief (IISC Offset: 0x14) Interrupt Enable Register */
-  WoReg   IISC_IDR;           /**< \brief (IISC Offset: 0x18) Interrupt Disable Register */
-  RoReg   IISC_IMR;           /**< \brief (IISC Offset: 0x1C) Interrupt Mask Register */
-  RoReg   IISC_RHR;           /**< \brief (IISC Offset: 0x20) Receive Holding Register */
-  WoReg   IISC_THR;           /**< \brief (IISC Offset: 0x24) Transmit Holding Register */
-  RoReg   IISC_VERSION;       /**< \brief (IISC Offset: 0x28) Version Register */
-  RoReg   IISC_PARAMETER;     /**< \brief (IISC Offset: 0x2C) Parameter Register */
- } reg;
+typedef struct {
+  __O  uint32_t CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
+  __IO uint32_t MR;          /**< \brief Offset: 0x04 (R/W 32) Mode Register */
+  __I  uint32_t SR;          /**< \brief Offset: 0x08 (R/  32) Status Register */
+  __O  uint32_t SCR;         /**< \brief Offset: 0x0C ( /W 32) Status Clear Register */
+  __O  uint32_t SSR;         /**< \brief Offset: 0x10 ( /W 32) Status Set Register */
+  __O  uint32_t IER;         /**< \brief Offset: 0x14 ( /W 32) Interrupt Enable Register */
+  __O  uint32_t IDR;         /**< \brief Offset: 0x18 ( /W 32) Interrupt Disable Register */
+  __I  uint32_t IMR;         /**< \brief Offset: 0x1C (R/  32) Interrupt Mask Register */
+  __I  uint32_t RHR;         /**< \brief Offset: 0x20 (R/  32) Receive Holding Register */
+  __O  uint32_t THR;         /**< \brief Offset: 0x24 ( /W 32) Transmit Holding Register */
+  __I  uint32_t VERSION;     /**< \brief Offset: 0x28 (R/  32) Version Register */
+  __I  uint32_t PARAMETER;   /**< \brief Offset: 0x2C (R/  32) Parameter Register */
 } Iisc;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/iisc.h
+++ b/asf/sam/include/sam4l/component/iisc.h
@@ -1,0 +1,638 @@
+/**
+ * \file
+ *
+ * \brief Component description for IISC
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_IISC_COMPONENT_
+#define _SAM4L_IISC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR IISC */
+/* ========================================================================== */
+/** \addtogroup SAM4L_IISC Inter-IC Sound (I2S) Controller */
+/*@{*/
+
+#define IISC_I7560
+#define REV_IISC                    0x100
+
+/* -------- IISC_CR : (IISC Offset: 0x00) ( /W 32) Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXEN:1;           /*!< bit:      0  Receive Enable                     */
+    uint32_t RXDIS:1;          /*!< bit:      1  Receive Disable                    */
+    uint32_t CKEN:1;           /*!< bit:      2  Clocks Enable                      */
+    uint32_t CKDIS:1;          /*!< bit:      3  Clocks Disable                     */
+    uint32_t TXEN:1;           /*!< bit:      4  Transmit Enable                    */
+    uint32_t TXDIS:1;          /*!< bit:      5  Transmit Disable                   */
+    uint32_t :1;               /*!< bit:      6  Reserved                           */
+    uint32_t SWRST:1;          /*!< bit:      7  Software Reset                     */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} IISC_CR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define IISC_CR_OFFSET              0x00         /**< \brief (IISC_CR offset) Control Register */
+
+#define IISC_CR_RXEN_Pos            0            /**< \brief (IISC_CR) Receive Enable */
+#define IISC_CR_RXEN                (_U(0x1) << IISC_CR_RXEN_Pos)
+#define   IISC_CR_RXEN_OFF_Val            _U(0x0)   /**< \brief (IISC_CR) No effect */
+#define   IISC_CR_RXEN_ON_Val             _U(0x1)   /**< \brief (IISC_CR) Enables Data Receive if RXDIS is not set */
+#define IISC_CR_RXEN_OFF            (IISC_CR_RXEN_OFF_Val          << IISC_CR_RXEN_Pos)
+#define IISC_CR_RXEN_ON             (IISC_CR_RXEN_ON_Val           << IISC_CR_RXEN_Pos)
+#define IISC_CR_RXDIS_Pos           1            /**< \brief (IISC_CR) Receive Disable */
+#define IISC_CR_RXDIS               (_U(0x1) << IISC_CR_RXDIS_Pos)
+#define   IISC_CR_RXDIS_OFF_Val           _U(0x0)   /**< \brief (IISC_CR) No effect */
+#define   IISC_CR_RXDIS_ON_Val            _U(0x1)   /**< \brief (IISC_CR) Disables Data Receive */
+#define IISC_CR_RXDIS_OFF           (IISC_CR_RXDIS_OFF_Val         << IISC_CR_RXDIS_Pos)
+#define IISC_CR_RXDIS_ON            (IISC_CR_RXDIS_ON_Val          << IISC_CR_RXDIS_Pos)
+#define IISC_CR_CKEN_Pos            2            /**< \brief (IISC_CR) Clocks Enable */
+#define IISC_CR_CKEN                (_U(0x1) << IISC_CR_CKEN_Pos)
+#define   IISC_CR_CKEN_OFF_Val            _U(0x0)   /**< \brief (IISC_CR) No effect */
+#define   IISC_CR_CKEN_ON_Val             _U(0x1)   /**< \brief (IISC_CR) Enables clocks if CKDIS is not set */
+#define IISC_CR_CKEN_OFF            (IISC_CR_CKEN_OFF_Val          << IISC_CR_CKEN_Pos)
+#define IISC_CR_CKEN_ON             (IISC_CR_CKEN_ON_Val           << IISC_CR_CKEN_Pos)
+#define IISC_CR_CKDIS_Pos           3            /**< \brief (IISC_CR) Clocks Disable */
+#define IISC_CR_CKDIS               (_U(0x1) << IISC_CR_CKDIS_Pos)
+#define   IISC_CR_CKDIS_OFF_Val           _U(0x0)   /**< \brief (IISC_CR) No effect */
+#define   IISC_CR_CKDIS_ON_Val            _U(0x1)   /**< \brief (IISC_CR) Disables clocks */
+#define IISC_CR_CKDIS_OFF           (IISC_CR_CKDIS_OFF_Val         << IISC_CR_CKDIS_Pos)
+#define IISC_CR_CKDIS_ON            (IISC_CR_CKDIS_ON_Val          << IISC_CR_CKDIS_Pos)
+#define IISC_CR_TXEN_Pos            4            /**< \brief (IISC_CR) Transmit Enable */
+#define IISC_CR_TXEN                (_U(0x1) << IISC_CR_TXEN_Pos)
+#define   IISC_CR_TXEN_OFF_Val            _U(0x0)   /**< \brief (IISC_CR) No effect */
+#define   IISC_CR_TXEN_ON_Val             _U(0x1)   /**< \brief (IISC_CR) Enables Data Transmit if TXDIS is not set */
+#define IISC_CR_TXEN_OFF            (IISC_CR_TXEN_OFF_Val          << IISC_CR_TXEN_Pos)
+#define IISC_CR_TXEN_ON             (IISC_CR_TXEN_ON_Val           << IISC_CR_TXEN_Pos)
+#define IISC_CR_TXDIS_Pos           5            /**< \brief (IISC_CR) Transmit Disable */
+#define IISC_CR_TXDIS               (_U(0x1) << IISC_CR_TXDIS_Pos)
+#define   IISC_CR_TXDIS_OFF_Val           _U(0x0)   /**< \brief (IISC_CR) No effect */
+#define   IISC_CR_TXDIS_ON_Val            _U(0x1)   /**< \brief (IISC_CR) Disables Data Transmit */
+#define IISC_CR_TXDIS_OFF           (IISC_CR_TXDIS_OFF_Val         << IISC_CR_TXDIS_Pos)
+#define IISC_CR_TXDIS_ON            (IISC_CR_TXDIS_ON_Val          << IISC_CR_TXDIS_Pos)
+#define IISC_CR_SWRST_Pos           7            /**< \brief (IISC_CR) Software Reset */
+#define IISC_CR_SWRST               (_U(0x1) << IISC_CR_SWRST_Pos)
+#define   IISC_CR_SWRST_OFF_Val           _U(0x0)   /**< \brief (IISC_CR) No effect */
+#define   IISC_CR_SWRST_ON_Val            _U(0x1)   /**< \brief (IISC_CR) Performs a software reset. Has priority on any other bit in CR */
+#define IISC_CR_SWRST_OFF           (IISC_CR_SWRST_OFF_Val         << IISC_CR_SWRST_Pos)
+#define IISC_CR_SWRST_ON            (IISC_CR_SWRST_ON_Val          << IISC_CR_SWRST_Pos)
+#define IISC_CR_MASK                _U(0x000000BF) /**< \brief (IISC_CR) MASK Register */
+
+/* -------- IISC_MR : (IISC Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t MODE:1;           /*!< bit:      0  Master/Slave/Controller Mode       */
+    uint32_t :1;               /*!< bit:      1  Reserved                           */
+    uint32_t DATALENGTH:3;     /*!< bit:  2.. 4  Data Word Length                   */
+    uint32_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint32_t RXMONO:1;         /*!< bit:      8  Receiver Mono                      */
+    uint32_t RXDMA:1;          /*!< bit:      9  Single or Multiple DMA Channels for Receiver */
+    uint32_t RXLOOP:1;         /*!< bit:     10  Loop-back Test Mode                */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t TXMONO:1;         /*!< bit:     12  Transmitter Mono                   */
+    uint32_t TXDMA:1;          /*!< bit:     13  Single or Multiple DMA Channels for Transmitter */
+    uint32_t TXSAME:1;         /*!< bit:     14  Transmit Data when Underrun        */
+    uint32_t :9;               /*!< bit: 15..23  Reserved                           */
+    uint32_t IMCKFS:6;         /*!< bit: 24..29  Master Clock to fs Ratio           */
+    uint32_t IMCKMODE:1;       /*!< bit:     30  Master Clock Mode                  */
+    uint32_t IWS24:1;          /*!< bit:     31  IWS Data Slot Width                */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} IISC_MR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define IISC_MR_OFFSET              0x04         /**< \brief (IISC_MR offset) Mode Register */
+#define IISC_MR_RESETVALUE          _U(0x00000000); /**< \brief (IISC_MR reset_value) Mode Register */
+
+#define IISC_MR_MODE_Pos            0            /**< \brief (IISC_MR) Master/Slave/Controller Mode */
+#define IISC_MR_MODE                (_U(0x1) << IISC_MR_MODE_Pos)
+#define   IISC_MR_MODE_SLAVE_Val          _U(0x0)   /**< \brief (IISC_MR) Slave mode (only serial data handled, clocks received from external master or controller) */
+#define   IISC_MR_MODE_MASTER_Val         _U(0x1)   /**< \brief (IISC_MR) Master mode (clocks generated and output by IISC, serial data handled if CR.RXEN and/or CR.TXEN written to 1) */
+#define IISC_MR_MODE_SLAVE          (IISC_MR_MODE_SLAVE_Val        << IISC_MR_MODE_Pos)
+#define IISC_MR_MODE_MASTER         (IISC_MR_MODE_MASTER_Val       << IISC_MR_MODE_Pos)
+#define IISC_MR_DATALENGTH_Pos      2            /**< \brief (IISC_MR) Data Word Length */
+#define IISC_MR_DATALENGTH_Msk      (_U(0x7) << IISC_MR_DATALENGTH_Pos)
+#define IISC_MR_DATALENGTH(value)   (IISC_MR_DATALENGTH_Msk & ((value) << IISC_MR_DATALENGTH_Pos))
+#define   IISC_MR_DATALENGTH_32_Val       _U(0x0)   /**< \brief (IISC_MR) 32 bits */
+#define   IISC_MR_DATALENGTH_24_Val       _U(0x1)   /**< \brief (IISC_MR) 24 bits */
+#define   IISC_MR_DATALENGTH_20_Val       _U(0x2)   /**< \brief (IISC_MR) 20 bits */
+#define   IISC_MR_DATALENGTH_18_Val       _U(0x3)   /**< \brief (IISC_MR) 18 bits */
+#define   IISC_MR_DATALENGTH_16_Val       _U(0x4)   /**< \brief (IISC_MR) 16 bits */
+#define   IISC_MR_DATALENGTH_16C_Val      _U(0x5)   /**< \brief (IISC_MR) 16 bits compact stereo */
+#define   IISC_MR_DATALENGTH_8_Val        _U(0x6)   /**< \brief (IISC_MR) 8 bits */
+#define   IISC_MR_DATALENGTH_8C_Val       _U(0x7)   /**< \brief (IISC_MR) 8 bits compact stereo */
+#define IISC_MR_DATALENGTH_32       (IISC_MR_DATALENGTH_32_Val     << IISC_MR_DATALENGTH_Pos)
+#define IISC_MR_DATALENGTH_24       (IISC_MR_DATALENGTH_24_Val     << IISC_MR_DATALENGTH_Pos)
+#define IISC_MR_DATALENGTH_20       (IISC_MR_DATALENGTH_20_Val     << IISC_MR_DATALENGTH_Pos)
+#define IISC_MR_DATALENGTH_18       (IISC_MR_DATALENGTH_18_Val     << IISC_MR_DATALENGTH_Pos)
+#define IISC_MR_DATALENGTH_16       (IISC_MR_DATALENGTH_16_Val     << IISC_MR_DATALENGTH_Pos)
+#define IISC_MR_DATALENGTH_16C      (IISC_MR_DATALENGTH_16C_Val    << IISC_MR_DATALENGTH_Pos)
+#define IISC_MR_DATALENGTH_8        (IISC_MR_DATALENGTH_8_Val      << IISC_MR_DATALENGTH_Pos)
+#define IISC_MR_DATALENGTH_8C       (IISC_MR_DATALENGTH_8C_Val     << IISC_MR_DATALENGTH_Pos)
+#define IISC_MR_RXMONO_Pos          8            /**< \brief (IISC_MR) Receiver Mono */
+#define IISC_MR_RXMONO              (_U(0x1) << IISC_MR_RXMONO_Pos)
+#define   IISC_MR_RXMONO_STEREO_Val       _U(0x0)   /**< \brief (IISC_MR) Normal mode */
+#define   IISC_MR_RXMONO_MONO_Val         _U(0x1)   /**< \brief (IISC_MR) Left channel data is duplicated to right channel */
+#define IISC_MR_RXMONO_STEREO       (IISC_MR_RXMONO_STEREO_Val     << IISC_MR_RXMONO_Pos)
+#define IISC_MR_RXMONO_MONO         (IISC_MR_RXMONO_MONO_Val       << IISC_MR_RXMONO_Pos)
+#define IISC_MR_RXDMA_Pos           9            /**< \brief (IISC_MR) Single or Multiple DMA Channels for Receiver */
+#define IISC_MR_RXDMA               (_U(0x1) << IISC_MR_RXDMA_Pos)
+#define   IISC_MR_RXDMA_SINGLE_Val        _U(0x0)   /**< \brief (IISC_MR) Single DMA channel */
+#define   IISC_MR_RXDMA_MULTIPLE_Val      _U(0x1)   /**< \brief (IISC_MR) One DMA channel per data channel */
+#define IISC_MR_RXDMA_SINGLE        (IISC_MR_RXDMA_SINGLE_Val      << IISC_MR_RXDMA_Pos)
+#define IISC_MR_RXDMA_MULTIPLE      (IISC_MR_RXDMA_MULTIPLE_Val    << IISC_MR_RXDMA_Pos)
+#define IISC_MR_RXLOOP_Pos          10           /**< \brief (IISC_MR) Loop-back Test Mode */
+#define IISC_MR_RXLOOP              (_U(0x1) << IISC_MR_RXLOOP_Pos)
+#define   IISC_MR_RXLOOP_OFF_Val          _U(0x0)   /**< \brief (IISC_MR) Normal mode */
+#define   IISC_MR_RXLOOP_ON_Val           _U(0x1)   /**< \brief (IISC_MR) ISDO internally connected to ISDI */
+#define IISC_MR_RXLOOP_OFF          (IISC_MR_RXLOOP_OFF_Val        << IISC_MR_RXLOOP_Pos)
+#define IISC_MR_RXLOOP_ON           (IISC_MR_RXLOOP_ON_Val         << IISC_MR_RXLOOP_Pos)
+#define IISC_MR_TXMONO_Pos          12           /**< \brief (IISC_MR) Transmitter Mono */
+#define IISC_MR_TXMONO              (_U(0x1) << IISC_MR_TXMONO_Pos)
+#define   IISC_MR_TXMONO_STEREO_Val       _U(0x0)   /**< \brief (IISC_MR) Normal mode */
+#define   IISC_MR_TXMONO_MONO_Val         _U(0x1)   /**< \brief (IISC_MR) Left channel data is duplicated to right channel */
+#define IISC_MR_TXMONO_STEREO       (IISC_MR_TXMONO_STEREO_Val     << IISC_MR_TXMONO_Pos)
+#define IISC_MR_TXMONO_MONO         (IISC_MR_TXMONO_MONO_Val       << IISC_MR_TXMONO_Pos)
+#define IISC_MR_TXDMA_Pos           13           /**< \brief (IISC_MR) Single or Multiple DMA Channels for Transmitter */
+#define IISC_MR_TXDMA               (_U(0x1) << IISC_MR_TXDMA_Pos)
+#define   IISC_MR_TXDMA_SINGLE_Val        _U(0x0)   /**< \brief (IISC_MR) Single DMA channel */
+#define   IISC_MR_TXDMA_MULTIPLE_Val      _U(0x1)   /**< \brief (IISC_MR) One DMA channel per data channel */
+#define IISC_MR_TXDMA_SINGLE        (IISC_MR_TXDMA_SINGLE_Val      << IISC_MR_TXDMA_Pos)
+#define IISC_MR_TXDMA_MULTIPLE      (IISC_MR_TXDMA_MULTIPLE_Val    << IISC_MR_TXDMA_Pos)
+#define IISC_MR_TXSAME_Pos          14           /**< \brief (IISC_MR) Transmit Data when Underrun */
+#define IISC_MR_TXSAME              (_U(0x1) << IISC_MR_TXSAME_Pos)
+#define   IISC_MR_TXSAME_ZERO_Val         _U(0x0)   /**< \brief (IISC_MR) Zero data transmitted in case of underrun */
+#define   IISC_MR_TXSAME_SAME_Val         _U(0x1)   /**< \brief (IISC_MR) Last data transmitted in case of underrun */
+#define IISC_MR_TXSAME_ZERO         (IISC_MR_TXSAME_ZERO_Val       << IISC_MR_TXSAME_Pos)
+#define IISC_MR_TXSAME_SAME         (IISC_MR_TXSAME_SAME_Val       << IISC_MR_TXSAME_Pos)
+#define IISC_MR_IMCKFS_Pos          24           /**< \brief (IISC_MR) Master Clock to fs Ratio */
+#define IISC_MR_IMCKFS_Msk          (_U(0x3F) << IISC_MR_IMCKFS_Pos)
+#define IISC_MR_IMCKFS(value)       (IISC_MR_IMCKFS_Msk & ((value) << IISC_MR_IMCKFS_Pos))
+#define   IISC_MR_IMCKFS_16_Val           _U(0x0)   /**< \brief (IISC_MR) 16 fs */
+#define   IISC_MR_IMCKFS_32_Val           _U(0x1)   /**< \brief (IISC_MR) 32 fs */
+#define   IISC_MR_IMCKFS_64_Val           _U(0x3)   /**< \brief (IISC_MR) 64 fs */
+#define   IISC_MR_IMCKFS_128_Val          _U(0x7)   /**< \brief (IISC_MR) 128 fs */
+#define   IISC_MR_IMCKFS_256_Val          _U(0xF)   /**< \brief (IISC_MR) 256 fs */
+#define   IISC_MR_IMCKFS_384_Val          _U(0x17)   /**< \brief (IISC_MR) 384 fs */
+#define   IISC_MR_IMCKFS_512_Val          _U(0x1F)   /**< \brief (IISC_MR) 512 fs */
+#define   IISC_MR_IMCKFS_768_Val          _U(0x2F)   /**< \brief (IISC_MR) 768 fs */
+#define   IISC_MR_IMCKFS_1024_Val         _U(0x3F)   /**< \brief (IISC_MR) 1024 fs */
+#define IISC_MR_IMCKFS_16           (IISC_MR_IMCKFS_16_Val         << IISC_MR_IMCKFS_Pos)
+#define IISC_MR_IMCKFS_32           (IISC_MR_IMCKFS_32_Val         << IISC_MR_IMCKFS_Pos)
+#define IISC_MR_IMCKFS_64           (IISC_MR_IMCKFS_64_Val         << IISC_MR_IMCKFS_Pos)
+#define IISC_MR_IMCKFS_128          (IISC_MR_IMCKFS_128_Val        << IISC_MR_IMCKFS_Pos)
+#define IISC_MR_IMCKFS_256          (IISC_MR_IMCKFS_256_Val        << IISC_MR_IMCKFS_Pos)
+#define IISC_MR_IMCKFS_384          (IISC_MR_IMCKFS_384_Val        << IISC_MR_IMCKFS_Pos)
+#define IISC_MR_IMCKFS_512          (IISC_MR_IMCKFS_512_Val        << IISC_MR_IMCKFS_Pos)
+#define IISC_MR_IMCKFS_768          (IISC_MR_IMCKFS_768_Val        << IISC_MR_IMCKFS_Pos)
+#define IISC_MR_IMCKFS_1024         (IISC_MR_IMCKFS_1024_Val       << IISC_MR_IMCKFS_Pos)
+#define IISC_MR_IMCKMODE_Pos        30           /**< \brief (IISC_MR) Master Clock Mode */
+#define IISC_MR_IMCKMODE            (_U(0x1) << IISC_MR_IMCKMODE_Pos)
+#define   IISC_MR_IMCKMODE_NO_IMCK_Val    _U(0x0)   /**< \brief (IISC_MR) No IMCK generated */
+#define   IISC_MR_IMCKMODE_IMCK_Val       _U(0x1)   /**< \brief (IISC_MR) IMCK generated */
+#define IISC_MR_IMCKMODE_NO_IMCK    (IISC_MR_IMCKMODE_NO_IMCK_Val  << IISC_MR_IMCKMODE_Pos)
+#define IISC_MR_IMCKMODE_IMCK       (IISC_MR_IMCKMODE_IMCK_Val     << IISC_MR_IMCKMODE_Pos)
+#define IISC_MR_IWS24_Pos           31           /**< \brief (IISC_MR) IWS Data Slot Width */
+#define IISC_MR_IWS24               (_U(0x1) << IISC_MR_IWS24_Pos)
+#define   IISC_MR_IWS24_32_Val            _U(0x0)   /**< \brief (IISC_MR) IWS Data Slot is 32-bit wide for DATALENGTH=18/20/24-bit */
+#define   IISC_MR_IWS24_24_Val            _U(0x1)   /**< \brief (IISC_MR) IWS Data Slot is 24-bit wide for DATALENGTH=18/20/24-bit */
+#define IISC_MR_IWS24_32            (IISC_MR_IWS24_32_Val          << IISC_MR_IWS24_Pos)
+#define IISC_MR_IWS24_24            (IISC_MR_IWS24_24_Val          << IISC_MR_IWS24_Pos)
+#define IISC_MR_MASK                _U(0xFF00771D) /**< \brief (IISC_MR) MASK Register */
+
+/* -------- IISC_SR : (IISC Offset: 0x08) (R/  32) Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXEN:1;           /*!< bit:      0  Receive Enable                     */
+    uint32_t RXRDY:1;          /*!< bit:      1  Receive Ready                      */
+    uint32_t RXOR:1;           /*!< bit:      2  Receive Overrun                    */
+    uint32_t :1;               /*!< bit:      3  Reserved                           */
+    uint32_t TXEN:1;           /*!< bit:      4  Transmit Enable                    */
+    uint32_t TXRDY:1;          /*!< bit:      5  Transmit Ready                     */
+    uint32_t TXUR:1;           /*!< bit:      6  Transmit Underrun                  */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t RXORCH:2;         /*!< bit:  8.. 9  Receive Overrun Channels           */
+    uint32_t :10;              /*!< bit: 10..19  Reserved                           */
+    uint32_t TXURCH:2;         /*!< bit: 20..21  Transmit Underrun Channels         */
+    uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} IISC_SR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define IISC_SR_OFFSET              0x08         /**< \brief (IISC_SR offset) Status Register */
+#define IISC_SR_RESETVALUE          _U(0x00000000); /**< \brief (IISC_SR reset_value) Status Register */
+
+#define IISC_SR_RXEN_Pos            0            /**< \brief (IISC_SR) Receive Enable */
+#define IISC_SR_RXEN                (_U(0x1) << IISC_SR_RXEN_Pos)
+#define   IISC_SR_RXEN_OFF_Val            _U(0x0)   /**< \brief (IISC_SR) Receiver is effectively disabled, following a CR.RXDIS or CR.SWRST request */
+#define   IISC_SR_RXEN_ON_Val             _U(0x1)   /**< \brief (IISC_SR) Receiver is effectively enabled, following a CR.RXEN request */
+#define IISC_SR_RXEN_OFF            (IISC_SR_RXEN_OFF_Val          << IISC_SR_RXEN_Pos)
+#define IISC_SR_RXEN_ON             (IISC_SR_RXEN_ON_Val           << IISC_SR_RXEN_Pos)
+#define IISC_SR_RXRDY_Pos           1            /**< \brief (IISC_SR) Receive Ready */
+#define IISC_SR_RXRDY               (_U(0x1) << IISC_SR_RXRDY_Pos)
+#define   IISC_SR_RXRDY_EMPTY_Val         _U(0x0)   /**< \brief (IISC_SR) The register RHR is empty and can't be read */
+#define   IISC_SR_RXRDY_FULL_Val          _U(0x1)   /**< \brief (IISC_SR) The register RHR is full and is ready to be read */
+#define IISC_SR_RXRDY_EMPTY         (IISC_SR_RXRDY_EMPTY_Val       << IISC_SR_RXRDY_Pos)
+#define IISC_SR_RXRDY_FULL          (IISC_SR_RXRDY_FULL_Val        << IISC_SR_RXRDY_Pos)
+#define IISC_SR_RXOR_Pos            2            /**< \brief (IISC_SR) Receive Overrun */
+#define IISC_SR_RXOR                (_U(0x1) << IISC_SR_RXOR_Pos)
+#define   IISC_SR_RXOR_NO_Val             _U(0x0)   /**< \brief (IISC_SR) No overrun */
+#define   IISC_SR_RXOR_YES_Val            _U(0x1)   /**< \brief (IISC_SR) The previous received data has not been read. This data is lost */
+#define IISC_SR_RXOR_NO             (IISC_SR_RXOR_NO_Val           << IISC_SR_RXOR_Pos)
+#define IISC_SR_RXOR_YES            (IISC_SR_RXOR_YES_Val          << IISC_SR_RXOR_Pos)
+#define IISC_SR_TXEN_Pos            4            /**< \brief (IISC_SR) Transmit Enable */
+#define IISC_SR_TXEN                (_U(0x1) << IISC_SR_TXEN_Pos)
+#define   IISC_SR_TXEN_OFF_Val            _U(0x0)   /**< \brief (IISC_SR) Transmitter is effectively disabled, following a CR.TXDIS or CR.SWRST request */
+#define   IISC_SR_TXEN_ON_Val             _U(0x1)   /**< \brief (IISC_SR) Transmitter is effectively enabled, following a CR.TXEN request */
+#define IISC_SR_TXEN_OFF            (IISC_SR_TXEN_OFF_Val          << IISC_SR_TXEN_Pos)
+#define IISC_SR_TXEN_ON             (IISC_SR_TXEN_ON_Val           << IISC_SR_TXEN_Pos)
+#define IISC_SR_TXRDY_Pos           5            /**< \brief (IISC_SR) Transmit Ready */
+#define IISC_SR_TXRDY               (_U(0x1) << IISC_SR_TXRDY_Pos)
+#define   IISC_SR_TXRDY_FULL_Val          _U(0x0)   /**< \brief (IISC_SR) The register THR is full and can't be written */
+#define   IISC_SR_TXRDY_EMPTY_Val         _U(0x1)   /**< \brief (IISC_SR) The register THR is empty and is ready to be written */
+#define IISC_SR_TXRDY_FULL          (IISC_SR_TXRDY_FULL_Val        << IISC_SR_TXRDY_Pos)
+#define IISC_SR_TXRDY_EMPTY         (IISC_SR_TXRDY_EMPTY_Val       << IISC_SR_TXRDY_Pos)
+#define IISC_SR_TXUR_Pos            6            /**< \brief (IISC_SR) Transmit Underrun */
+#define IISC_SR_TXUR                (_U(0x1) << IISC_SR_TXUR_Pos)
+#define   IISC_SR_TXUR_NO_Val             _U(0x0)   /**< \brief (IISC_SR) No underrun */
+#define   IISC_SR_TXUR_YES_Val            _U(0x1)   /**< \brief (IISC_SR) The last bit of the last data written to the register THR has been set. Until the next write to THR, data will be sent according to MR.TXSAME field */
+#define IISC_SR_TXUR_NO             (IISC_SR_TXUR_NO_Val           << IISC_SR_TXUR_Pos)
+#define IISC_SR_TXUR_YES            (IISC_SR_TXUR_YES_Val          << IISC_SR_TXUR_Pos)
+#define IISC_SR_RXORCH_Pos          8            /**< \brief (IISC_SR) Receive Overrun Channels */
+#define IISC_SR_RXORCH_Msk          (_U(0x3) << IISC_SR_RXORCH_Pos)
+#define IISC_SR_RXORCH(value)       (IISC_SR_RXORCH_Msk & ((value) << IISC_SR_RXORCH_Pos))
+#define   IISC_SR_RXORCH_LEFT_Val         _U(0x0)   /**< \brief (IISC_SR) Overrun first occurred on left channel */
+#define   IISC_SR_RXORCH_RIGHT_Val        _U(0x1)   /**< \brief (IISC_SR) Overrun first occurred on right channel */
+#define IISC_SR_RXORCH_LEFT         (IISC_SR_RXORCH_LEFT_Val       << IISC_SR_RXORCH_Pos)
+#define IISC_SR_RXORCH_RIGHT        (IISC_SR_RXORCH_RIGHT_Val      << IISC_SR_RXORCH_Pos)
+#define IISC_SR_TXURCH_Pos          20           /**< \brief (IISC_SR) Transmit Underrun Channels */
+#define IISC_SR_TXURCH_Msk          (_U(0x3) << IISC_SR_TXURCH_Pos)
+#define IISC_SR_TXURCH(value)       (IISC_SR_TXURCH_Msk & ((value) << IISC_SR_TXURCH_Pos))
+#define   IISC_SR_TXURCH_LEFT_Val         _U(0x0)   /**< \brief (IISC_SR) Underrun first occurred on left channel */
+#define   IISC_SR_TXURCH_RIGHT_Val        _U(0x1)   /**< \brief (IISC_SR) Underrun first occurred on right channel */
+#define IISC_SR_TXURCH_LEFT         (IISC_SR_TXURCH_LEFT_Val       << IISC_SR_TXURCH_Pos)
+#define IISC_SR_TXURCH_RIGHT        (IISC_SR_TXURCH_RIGHT_Val      << IISC_SR_TXURCH_Pos)
+#define IISC_SR_MASK                _U(0x00300377) /**< \brief (IISC_SR) MASK Register */
+
+/* -------- IISC_SCR : (IISC Offset: 0x0C) ( /W 32) Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t RXOR:1;           /*!< bit:      2  Receive Overrun                    */
+    uint32_t :3;               /*!< bit:  3.. 5  Reserved                           */
+    uint32_t TXUR:1;           /*!< bit:      6  Transmit Underrun                  */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t RXORCH:2;         /*!< bit:  8.. 9  Receive Overrun Channels           */
+    uint32_t :10;              /*!< bit: 10..19  Reserved                           */
+    uint32_t TXURCH:2;         /*!< bit: 20..21  Transmit Underrun Channels         */
+    uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} IISC_SCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define IISC_SCR_OFFSET             0x0C         /**< \brief (IISC_SCR offset) Status Clear Register */
+
+#define IISC_SCR_RXOR_Pos           2            /**< \brief (IISC_SCR) Receive Overrun */
+#define IISC_SCR_RXOR               (_U(0x1) << IISC_SCR_RXOR_Pos)
+#define   IISC_SCR_RXOR_NO_Val            _U(0x0)   /**< \brief (IISC_SCR) No effect */
+#define   IISC_SCR_RXOR_CLEAR_Val         _U(0x1)   /**< \brief (IISC_SCR) Clears the corresponding SR bit */
+#define IISC_SCR_RXOR_NO            (IISC_SCR_RXOR_NO_Val          << IISC_SCR_RXOR_Pos)
+#define IISC_SCR_RXOR_CLEAR         (IISC_SCR_RXOR_CLEAR_Val       << IISC_SCR_RXOR_Pos)
+#define IISC_SCR_TXUR_Pos           6            /**< \brief (IISC_SCR) Transmit Underrun */
+#define IISC_SCR_TXUR               (_U(0x1) << IISC_SCR_TXUR_Pos)
+#define   IISC_SCR_TXUR_NO_Val            _U(0x0)   /**< \brief (IISC_SCR) No effect */
+#define   IISC_SCR_TXUR_CLEAR_Val         _U(0x1)   /**< \brief (IISC_SCR) Clears the corresponding SR bit */
+#define IISC_SCR_TXUR_NO            (IISC_SCR_TXUR_NO_Val          << IISC_SCR_TXUR_Pos)
+#define IISC_SCR_TXUR_CLEAR         (IISC_SCR_TXUR_CLEAR_Val       << IISC_SCR_TXUR_Pos)
+#define IISC_SCR_RXORCH_Pos         8            /**< \brief (IISC_SCR) Receive Overrun Channels */
+#define IISC_SCR_RXORCH_Msk         (_U(0x3) << IISC_SCR_RXORCH_Pos)
+#define IISC_SCR_RXORCH(value)      (IISC_SCR_RXORCH_Msk & ((value) << IISC_SCR_RXORCH_Pos))
+#define IISC_SCR_TXURCH_Pos         20           /**< \brief (IISC_SCR) Transmit Underrun Channels */
+#define IISC_SCR_TXURCH_Msk         (_U(0x3) << IISC_SCR_TXURCH_Pos)
+#define IISC_SCR_TXURCH(value)      (IISC_SCR_TXURCH_Msk & ((value) << IISC_SCR_TXURCH_Pos))
+#define IISC_SCR_MASK               _U(0x00300344) /**< \brief (IISC_SCR) MASK Register */
+
+/* -------- IISC_SSR : (IISC Offset: 0x10) ( /W 32) Status Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t RXOR:1;           /*!< bit:      2  Receive Overrun                    */
+    uint32_t :3;               /*!< bit:  3.. 5  Reserved                           */
+    uint32_t TXUR:1;           /*!< bit:      6  Transmit Underrun                  */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t RXORCH:2;         /*!< bit:  8.. 9  Receive Overrun Channels           */
+    uint32_t :10;              /*!< bit: 10..19  Reserved                           */
+    uint32_t TXURCH:2;         /*!< bit: 20..21  Transmit Underrun Channels         */
+    uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} IISC_SSR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define IISC_SSR_OFFSET             0x10         /**< \brief (IISC_SSR offset) Status Set Register */
+
+#define IISC_SSR_RXOR_Pos           2            /**< \brief (IISC_SSR) Receive Overrun */
+#define IISC_SSR_RXOR               (_U(0x1) << IISC_SSR_RXOR_Pos)
+#define   IISC_SSR_RXOR_NO_Val            _U(0x0)   /**< \brief (IISC_SSR) No effect */
+#define   IISC_SSR_RXOR_SET_Val           _U(0x1)   /**< \brief (IISC_SSR) Sets corresponding SR bit */
+#define IISC_SSR_RXOR_NO            (IISC_SSR_RXOR_NO_Val          << IISC_SSR_RXOR_Pos)
+#define IISC_SSR_RXOR_SET           (IISC_SSR_RXOR_SET_Val         << IISC_SSR_RXOR_Pos)
+#define IISC_SSR_TXUR_Pos           6            /**< \brief (IISC_SSR) Transmit Underrun */
+#define IISC_SSR_TXUR               (_U(0x1) << IISC_SSR_TXUR_Pos)
+#define   IISC_SSR_TXUR_NO_Val            _U(0x0)   /**< \brief (IISC_SSR) No effect */
+#define   IISC_SSR_TXUR_SET_Val           _U(0x1)   /**< \brief (IISC_SSR) Sets corresponding SR bit */
+#define IISC_SSR_TXUR_NO            (IISC_SSR_TXUR_NO_Val          << IISC_SSR_TXUR_Pos)
+#define IISC_SSR_TXUR_SET           (IISC_SSR_TXUR_SET_Val         << IISC_SSR_TXUR_Pos)
+#define IISC_SSR_RXORCH_Pos         8            /**< \brief (IISC_SSR) Receive Overrun Channels */
+#define IISC_SSR_RXORCH_Msk         (_U(0x3) << IISC_SSR_RXORCH_Pos)
+#define IISC_SSR_RXORCH(value)      (IISC_SSR_RXORCH_Msk & ((value) << IISC_SSR_RXORCH_Pos))
+#define IISC_SSR_TXURCH_Pos         20           /**< \brief (IISC_SSR) Transmit Underrun Channels */
+#define IISC_SSR_TXURCH_Msk         (_U(0x3) << IISC_SSR_TXURCH_Pos)
+#define IISC_SSR_TXURCH(value)      (IISC_SSR_TXURCH_Msk & ((value) << IISC_SSR_TXURCH_Pos))
+#define IISC_SSR_MASK               _U(0x00300344) /**< \brief (IISC_SSR) MASK Register */
+
+/* -------- IISC_IER : (IISC Offset: 0x14) ( /W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t RXRDY:1;          /*!< bit:      1  Receiver Ready Interrupt Enable    */
+    uint32_t RXOR:1;           /*!< bit:      2  Receive Overrun Interrupt Enable   */
+    uint32_t :2;               /*!< bit:  3.. 4  Reserved                           */
+    uint32_t TXRDY:1;          /*!< bit:      5  Transmit Ready Interrupt Enable    */
+    uint32_t TXUR:1;           /*!< bit:      6  Transmit Underrun Interrupt Enable */
+    uint32_t :25;              /*!< bit:  7..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} IISC_IER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define IISC_IER_OFFSET             0x14         /**< \brief (IISC_IER offset) Interrupt Enable Register */
+
+#define IISC_IER_RXRDY_Pos          1            /**< \brief (IISC_IER) Receiver Ready Interrupt Enable */
+#define IISC_IER_RXRDY              (_U(0x1) << IISC_IER_RXRDY_Pos)
+#define   IISC_IER_RXRDY_OFF_Val          _U(0x0)   /**< \brief (IISC_IER) No effect */
+#define   IISC_IER_RXRDY_ON_Val           _U(0x1)   /**< \brief (IISC_IER) Enables the corresponding interrupt */
+#define IISC_IER_RXRDY_OFF          (IISC_IER_RXRDY_OFF_Val        << IISC_IER_RXRDY_Pos)
+#define IISC_IER_RXRDY_ON           (IISC_IER_RXRDY_ON_Val         << IISC_IER_RXRDY_Pos)
+#define IISC_IER_RXOR_Pos           2            /**< \brief (IISC_IER) Receive Overrun Interrupt Enable */
+#define IISC_IER_RXOR               (_U(0x1) << IISC_IER_RXOR_Pos)
+#define   IISC_IER_RXOR_OFF_Val           _U(0x0)   /**< \brief (IISC_IER) No effect */
+#define   IISC_IER_RXOR_ON_Val            _U(0x1)   /**< \brief (IISC_IER) Enables the corresponding interrupt */
+#define IISC_IER_RXOR_OFF           (IISC_IER_RXOR_OFF_Val         << IISC_IER_RXOR_Pos)
+#define IISC_IER_RXOR_ON            (IISC_IER_RXOR_ON_Val          << IISC_IER_RXOR_Pos)
+#define IISC_IER_TXRDY_Pos          5            /**< \brief (IISC_IER) Transmit Ready Interrupt Enable */
+#define IISC_IER_TXRDY              (_U(0x1) << IISC_IER_TXRDY_Pos)
+#define   IISC_IER_TXRDY_OFF_Val          _U(0x0)   /**< \brief (IISC_IER) No effect */
+#define   IISC_IER_TXRDY_ON_Val           _U(0x1)   /**< \brief (IISC_IER) Enables the corresponding interrupt */
+#define IISC_IER_TXRDY_OFF          (IISC_IER_TXRDY_OFF_Val        << IISC_IER_TXRDY_Pos)
+#define IISC_IER_TXRDY_ON           (IISC_IER_TXRDY_ON_Val         << IISC_IER_TXRDY_Pos)
+#define IISC_IER_TXUR_Pos           6            /**< \brief (IISC_IER) Transmit Underrun Interrupt Enable */
+#define IISC_IER_TXUR               (_U(0x1) << IISC_IER_TXUR_Pos)
+#define   IISC_IER_TXUR_OFF_Val           _U(0x0)   /**< \brief (IISC_IER) No effect */
+#define   IISC_IER_TXUR_ON_Val            _U(0x1)   /**< \brief (IISC_IER) Enables the corresponding interrupt */
+#define IISC_IER_TXUR_OFF           (IISC_IER_TXUR_OFF_Val         << IISC_IER_TXUR_Pos)
+#define IISC_IER_TXUR_ON            (IISC_IER_TXUR_ON_Val          << IISC_IER_TXUR_Pos)
+#define IISC_IER_MASK               _U(0x00000066) /**< \brief (IISC_IER) MASK Register */
+
+/* -------- IISC_IDR : (IISC Offset: 0x18) ( /W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t RXRDY:1;          /*!< bit:      1  Receive Ready Interrupt Disable    */
+    uint32_t RXOR:1;           /*!< bit:      2  Receive Overrun Interrupt Disable  */
+    uint32_t :2;               /*!< bit:  3.. 4  Reserved                           */
+    uint32_t TXRDY:1;          /*!< bit:      5  Transmit Ready Interrupt Disable   */
+    uint32_t TXUR:1;           /*!< bit:      6  Transmit Underrun Interrupt Disable */
+    uint32_t :25;              /*!< bit:  7..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} IISC_IDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define IISC_IDR_OFFSET             0x18         /**< \brief (IISC_IDR offset) Interrupt Disable Register */
+
+#define IISC_IDR_RXRDY_Pos          1            /**< \brief (IISC_IDR) Receive Ready Interrupt Disable */
+#define IISC_IDR_RXRDY              (_U(0x1) << IISC_IDR_RXRDY_Pos)
+#define   IISC_IDR_RXRDY_OFF_Val          _U(0x0)   /**< \brief (IISC_IDR) No effect */
+#define   IISC_IDR_RXRDY_ON_Val           _U(0x1)   /**< \brief (IISC_IDR) Disables the corresponding interrupt */
+#define IISC_IDR_RXRDY_OFF          (IISC_IDR_RXRDY_OFF_Val        << IISC_IDR_RXRDY_Pos)
+#define IISC_IDR_RXRDY_ON           (IISC_IDR_RXRDY_ON_Val         << IISC_IDR_RXRDY_Pos)
+#define IISC_IDR_RXOR_Pos           2            /**< \brief (IISC_IDR) Receive Overrun Interrupt Disable */
+#define IISC_IDR_RXOR               (_U(0x1) << IISC_IDR_RXOR_Pos)
+#define   IISC_IDR_RXOR_OFF_Val           _U(0x0)   /**< \brief (IISC_IDR) No effect */
+#define   IISC_IDR_RXOR_ON_Val            _U(0x1)   /**< \brief (IISC_IDR) Disables the corresponding interrupt */
+#define IISC_IDR_RXOR_OFF           (IISC_IDR_RXOR_OFF_Val         << IISC_IDR_RXOR_Pos)
+#define IISC_IDR_RXOR_ON            (IISC_IDR_RXOR_ON_Val          << IISC_IDR_RXOR_Pos)
+#define IISC_IDR_TXRDY_Pos          5            /**< \brief (IISC_IDR) Transmit Ready Interrupt Disable */
+#define IISC_IDR_TXRDY              (_U(0x1) << IISC_IDR_TXRDY_Pos)
+#define   IISC_IDR_TXRDY_OFF_Val          _U(0x0)   /**< \brief (IISC_IDR) No effect */
+#define   IISC_IDR_TXRDY_ON_Val           _U(0x1)   /**< \brief (IISC_IDR) Disables the corresponding interrupt */
+#define IISC_IDR_TXRDY_OFF          (IISC_IDR_TXRDY_OFF_Val        << IISC_IDR_TXRDY_Pos)
+#define IISC_IDR_TXRDY_ON           (IISC_IDR_TXRDY_ON_Val         << IISC_IDR_TXRDY_Pos)
+#define IISC_IDR_TXUR_Pos           6            /**< \brief (IISC_IDR) Transmit Underrun Interrupt Disable */
+#define IISC_IDR_TXUR               (_U(0x1) << IISC_IDR_TXUR_Pos)
+#define   IISC_IDR_TXUR_OFF_Val           _U(0x0)   /**< \brief (IISC_IDR) No effect */
+#define   IISC_IDR_TXUR_ON_Val            _U(0x1)   /**< \brief (IISC_IDR) Disables the corresponding interrupt */
+#define IISC_IDR_TXUR_OFF           (IISC_IDR_TXUR_OFF_Val         << IISC_IDR_TXUR_Pos)
+#define IISC_IDR_TXUR_ON            (IISC_IDR_TXUR_ON_Val          << IISC_IDR_TXUR_Pos)
+#define IISC_IDR_MASK               _U(0x00000066) /**< \brief (IISC_IDR) MASK Register */
+
+/* -------- IISC_IMR : (IISC Offset: 0x1C) (R/  32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t RXRDY:1;          /*!< bit:      1  Receive Ready Interrupt Mask       */
+    uint32_t RXOR:1;           /*!< bit:      2  Receive Overrun Interrupt Mask     */
+    uint32_t :2;               /*!< bit:  3.. 4  Reserved                           */
+    uint32_t TXRDY:1;          /*!< bit:      5  Transmit Ready Interrupt Mask      */
+    uint32_t TXUR:1;           /*!< bit:      6  Transmit Underrun Interrupt Mask   */
+    uint32_t :25;              /*!< bit:  7..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} IISC_IMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define IISC_IMR_OFFSET             0x1C         /**< \brief (IISC_IMR offset) Interrupt Mask Register */
+#define IISC_IMR_RESETVALUE         _U(0x00000000); /**< \brief (IISC_IMR reset_value) Interrupt Mask Register */
+
+#define IISC_IMR_RXRDY_Pos          1            /**< \brief (IISC_IMR) Receive Ready Interrupt Mask */
+#define IISC_IMR_RXRDY              (_U(0x1) << IISC_IMR_RXRDY_Pos)
+#define   IISC_IMR_RXRDY_DISABLED_Val     _U(0x0)   /**< \brief (IISC_IMR) The corresponding interrupt is disabled */
+#define   IISC_IMR_RXRDY_ENABLED_Val      _U(0x1)   /**< \brief (IISC_IMR) The corresponding interrupt is enabled */
+#define IISC_IMR_RXRDY_DISABLED     (IISC_IMR_RXRDY_DISABLED_Val   << IISC_IMR_RXRDY_Pos)
+#define IISC_IMR_RXRDY_ENABLED      (IISC_IMR_RXRDY_ENABLED_Val    << IISC_IMR_RXRDY_Pos)
+#define IISC_IMR_RXOR_Pos           2            /**< \brief (IISC_IMR) Receive Overrun Interrupt Mask */
+#define IISC_IMR_RXOR               (_U(0x1) << IISC_IMR_RXOR_Pos)
+#define   IISC_IMR_RXOR_DISABLED_Val      _U(0x0)   /**< \brief (IISC_IMR) The corresponding interrupt is disabled */
+#define   IISC_IMR_RXOR_ENABLED_Val       _U(0x1)   /**< \brief (IISC_IMR) The corresponding interrupt is enabled */
+#define IISC_IMR_RXOR_DISABLED      (IISC_IMR_RXOR_DISABLED_Val    << IISC_IMR_RXOR_Pos)
+#define IISC_IMR_RXOR_ENABLED       (IISC_IMR_RXOR_ENABLED_Val     << IISC_IMR_RXOR_Pos)
+#define IISC_IMR_TXRDY_Pos          5            /**< \brief (IISC_IMR) Transmit Ready Interrupt Mask */
+#define IISC_IMR_TXRDY              (_U(0x1) << IISC_IMR_TXRDY_Pos)
+#define   IISC_IMR_TXRDY_DISABLED_Val     _U(0x0)   /**< \brief (IISC_IMR) The corresponding interrupt is disabled */
+#define   IISC_IMR_TXRDY_ENABLED_Val      _U(0x1)   /**< \brief (IISC_IMR) The corresponding interrupt is enabled */
+#define IISC_IMR_TXRDY_DISABLED     (IISC_IMR_TXRDY_DISABLED_Val   << IISC_IMR_TXRDY_Pos)
+#define IISC_IMR_TXRDY_ENABLED      (IISC_IMR_TXRDY_ENABLED_Val    << IISC_IMR_TXRDY_Pos)
+#define IISC_IMR_TXUR_Pos           6            /**< \brief (IISC_IMR) Transmit Underrun Interrupt Mask */
+#define IISC_IMR_TXUR               (_U(0x1) << IISC_IMR_TXUR_Pos)
+#define   IISC_IMR_TXUR_DISABLED_Val      _U(0x0)   /**< \brief (IISC_IMR) The corresponding interrupt is disabled */
+#define   IISC_IMR_TXUR_ENABLED_Val       _U(0x1)   /**< \brief (IISC_IMR) The corresponding interrupt is enabled */
+#define IISC_IMR_TXUR_DISABLED      (IISC_IMR_TXUR_DISABLED_Val    << IISC_IMR_TXUR_Pos)
+#define IISC_IMR_TXUR_ENABLED       (IISC_IMR_TXUR_ENABLED_Val     << IISC_IMR_TXUR_Pos)
+#define IISC_IMR_MASK               _U(0x00000066) /**< \brief (IISC_IMR) MASK Register */
+
+/* -------- IISC_RHR : (IISC Offset: 0x20) (R/  32) Receive Holding Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RDAT:32;          /*!< bit:  0..31  Receive Data                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} IISC_RHR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define IISC_RHR_OFFSET             0x20         /**< \brief (IISC_RHR offset) Receive Holding Register */
+#define IISC_RHR_RESETVALUE         _U(0x00000000); /**< \brief (IISC_RHR reset_value) Receive Holding Register */
+
+#define IISC_RHR_RDAT_Pos           0            /**< \brief (IISC_RHR) Receive Data */
+#define IISC_RHR_RDAT_Msk           (_U(0xFFFFFFFF) << IISC_RHR_RDAT_Pos)
+#define IISC_RHR_RDAT(value)        (IISC_RHR_RDAT_Msk & ((value) << IISC_RHR_RDAT_Pos))
+#define IISC_RHR_MASK               _U(0xFFFFFFFF) /**< \brief (IISC_RHR) MASK Register */
+
+/* -------- IISC_THR : (IISC Offset: 0x24) ( /W 32) Transmit Holding Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TDAT:32;          /*!< bit:  0..31  Transmit Data                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} IISC_THR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define IISC_THR_OFFSET             0x24         /**< \brief (IISC_THR offset) Transmit Holding Register */
+
+#define IISC_THR_TDAT_Pos           0            /**< \brief (IISC_THR) Transmit Data */
+#define IISC_THR_TDAT_Msk           (_U(0xFFFFFFFF) << IISC_THR_TDAT_Pos)
+#define IISC_THR_TDAT(value)        (IISC_THR_TDAT_Msk & ((value) << IISC_THR_TDAT_Pos))
+#define IISC_THR_MASK               _U(0xFFFFFFFF) /**< \brief (IISC_THR) MASK Register */
+
+/* -------- IISC_VERSION : (IISC Offset: 0x28) (R/  32) Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Reserved. Value subject to change. No functionality associated. This is the Atmel internal version of the macrocell. */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Reserved. Value subject to change. No functionality associated. */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} IISC_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define IISC_VERSION_OFFSET         0x28         /**< \brief (IISC_VERSION offset) Version Register */
+#define IISC_VERSION_RESETVALUE     _U(0x00000100); /**< \brief (IISC_VERSION reset_value) Version Register */
+
+#define IISC_VERSION_VERSION_Pos    0            /**< \brief (IISC_VERSION) Reserved. Value subject to change. No functionality associated. This is the Atmel internal version of the macrocell. */
+#define IISC_VERSION_VERSION_Msk    (_U(0xFFF) << IISC_VERSION_VERSION_Pos)
+#define IISC_VERSION_VERSION(value) (IISC_VERSION_VERSION_Msk & ((value) << IISC_VERSION_VERSION_Pos))
+#define IISC_VERSION_VARIANT_Pos    16           /**< \brief (IISC_VERSION) Reserved. Value subject to change. No functionality associated. */
+#define IISC_VERSION_VARIANT_Msk    (_U(0xF) << IISC_VERSION_VARIANT_Pos)
+#define IISC_VERSION_VARIANT(value) (IISC_VERSION_VARIANT_Msk & ((value) << IISC_VERSION_VARIANT_Pos))
+#define IISC_VERSION_MASK           _U(0x000F0FFF) /**< \brief (IISC_VERSION) MASK Register */
+
+/* -------- IISC_PARAMETER : (IISC Offset: 0x2C) (R/  32) Parameter Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :7;               /*!< bit:  0.. 6  Reserved                           */
+    uint32_t FORMAT:1;         /*!< bit:      7  Data protocol format               */
+    uint32_t :8;               /*!< bit:  8..15  Reserved                           */
+    uint32_t NBCHAN:5;         /*!< bit: 16..20  Maximum number of channels - 1     */
+    uint32_t :11;              /*!< bit: 21..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} IISC_PARAMETER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define IISC_PARAMETER_OFFSET       0x2C         /**< \brief (IISC_PARAMETER offset) Parameter Register */
+#define IISC_PARAMETER_RESETVALUE   _U(0x00010000); /**< \brief (IISC_PARAMETER reset_value) Parameter Register */
+
+#define IISC_PARAMETER_FORMAT_Pos   7            /**< \brief (IISC_PARAMETER) Data protocol format */
+#define IISC_PARAMETER_FORMAT       (_U(0x1) << IISC_PARAMETER_FORMAT_Pos)
+#define   IISC_PARAMETER_FORMAT_I2S_Val   _U(0x0)   /**< \brief (IISC_PARAMETER) I2S format, stereo with IWS low for left channel */
+#define IISC_PARAMETER_FORMAT_I2S   (IISC_PARAMETER_FORMAT_I2S_Val << IISC_PARAMETER_FORMAT_Pos)
+#define IISC_PARAMETER_NBCHAN_Pos   16           /**< \brief (IISC_PARAMETER) Maximum number of channels - 1 */
+#define IISC_PARAMETER_NBCHAN_Msk   (_U(0x1F) << IISC_PARAMETER_NBCHAN_Pos)
+#define IISC_PARAMETER_NBCHAN(value) (IISC_PARAMETER_NBCHAN_Msk & ((value) << IISC_PARAMETER_NBCHAN_Pos))
+#define IISC_PARAMETER_MASK         _U(0x001F0080) /**< \brief (IISC_PARAMETER) MASK Register */
+
+/** \brief IISC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __O  IISC_CR_Type              CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
+  __IO IISC_MR_Type              MR;          /**< \brief Offset: 0x04 (R/W 32) Mode Register */
+  __I  IISC_SR_Type              SR;          /**< \brief Offset: 0x08 (R/  32) Status Register */
+  __O  IISC_SCR_Type             SCR;         /**< \brief Offset: 0x0C ( /W 32) Status Clear Register */
+  __O  IISC_SSR_Type             SSR;         /**< \brief Offset: 0x10 ( /W 32) Status Set Register */
+  __O  IISC_IER_Type             IER;         /**< \brief Offset: 0x14 ( /W 32) Interrupt Enable Register */
+  __O  IISC_IDR_Type             IDR;         /**< \brief Offset: 0x18 ( /W 32) Interrupt Disable Register */
+  __I  IISC_IMR_Type             IMR;         /**< \brief Offset: 0x1C (R/  32) Interrupt Mask Register */
+  __I  IISC_RHR_Type             RHR;         /**< \brief Offset: 0x20 (R/  32) Receive Holding Register */
+  __O  IISC_THR_Type             THR;         /**< \brief Offset: 0x24 ( /W 32) Transmit Holding Register */
+  __I  IISC_VERSION_Type         VERSION;     /**< \brief Offset: 0x28 (R/  32) Version Register */
+  __I  IISC_PARAMETER_Type       PARAMETER;   /**< \brief Offset: 0x2C (R/  32) Parameter Register */
+ } bf;
+ struct {
+  WoReg   IISC_CR;            /**< \brief (IISC Offset: 0x00) Control Register */
+  RwReg   IISC_MR;            /**< \brief (IISC Offset: 0x04) Mode Register */
+  RoReg   IISC_SR;            /**< \brief (IISC Offset: 0x08) Status Register */
+  WoReg   IISC_SCR;           /**< \brief (IISC Offset: 0x0C) Status Clear Register */
+  WoReg   IISC_SSR;           /**< \brief (IISC Offset: 0x10) Status Set Register */
+  WoReg   IISC_IER;           /**< \brief (IISC Offset: 0x14) Interrupt Enable Register */
+  WoReg   IISC_IDR;           /**< \brief (IISC Offset: 0x18) Interrupt Disable Register */
+  RoReg   IISC_IMR;           /**< \brief (IISC Offset: 0x1C) Interrupt Mask Register */
+  RoReg   IISC_RHR;           /**< \brief (IISC Offset: 0x20) Receive Holding Register */
+  WoReg   IISC_THR;           /**< \brief (IISC Offset: 0x24) Transmit Holding Register */
+  RoReg   IISC_VERSION;       /**< \brief (IISC Offset: 0x28) Version Register */
+  RoReg   IISC_PARAMETER;     /**< \brief (IISC Offset: 0x2C) Parameter Register */
+ } reg;
+} Iisc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_IISC_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/iisc.h
+++ b/asf/sam/include/sam4l/component/iisc.h
@@ -59,48 +59,48 @@ typedef union {
 #define IISC_CR_OFFSET              0x00         /**< \brief (IISC_CR offset) Control Register */
 
 #define IISC_CR_RXEN_Pos            0            /**< \brief (IISC_CR) Receive Enable */
-#define IISC_CR_RXEN                (_U(0x1) << IISC_CR_RXEN_Pos)
-#define   IISC_CR_RXEN_OFF_Val            _U(0x0)   /**< \brief (IISC_CR) No effect */
-#define   IISC_CR_RXEN_ON_Val             _U(0x1)   /**< \brief (IISC_CR) Enables Data Receive if RXDIS is not set */
+#define IISC_CR_RXEN                (_U_(0x1) << IISC_CR_RXEN_Pos)
+#define   IISC_CR_RXEN_OFF_Val            _U_(0x0)   /**< \brief (IISC_CR) No effect */
+#define   IISC_CR_RXEN_ON_Val             _U_(0x1)   /**< \brief (IISC_CR) Enables Data Receive if RXDIS is not set */
 #define IISC_CR_RXEN_OFF            (IISC_CR_RXEN_OFF_Val          << IISC_CR_RXEN_Pos)
 #define IISC_CR_RXEN_ON             (IISC_CR_RXEN_ON_Val           << IISC_CR_RXEN_Pos)
 #define IISC_CR_RXDIS_Pos           1            /**< \brief (IISC_CR) Receive Disable */
-#define IISC_CR_RXDIS               (_U(0x1) << IISC_CR_RXDIS_Pos)
-#define   IISC_CR_RXDIS_OFF_Val           _U(0x0)   /**< \brief (IISC_CR) No effect */
-#define   IISC_CR_RXDIS_ON_Val            _U(0x1)   /**< \brief (IISC_CR) Disables Data Receive */
+#define IISC_CR_RXDIS               (_U_(0x1) << IISC_CR_RXDIS_Pos)
+#define   IISC_CR_RXDIS_OFF_Val           _U_(0x0)   /**< \brief (IISC_CR) No effect */
+#define   IISC_CR_RXDIS_ON_Val            _U_(0x1)   /**< \brief (IISC_CR) Disables Data Receive */
 #define IISC_CR_RXDIS_OFF           (IISC_CR_RXDIS_OFF_Val         << IISC_CR_RXDIS_Pos)
 #define IISC_CR_RXDIS_ON            (IISC_CR_RXDIS_ON_Val          << IISC_CR_RXDIS_Pos)
 #define IISC_CR_CKEN_Pos            2            /**< \brief (IISC_CR) Clocks Enable */
-#define IISC_CR_CKEN                (_U(0x1) << IISC_CR_CKEN_Pos)
-#define   IISC_CR_CKEN_OFF_Val            _U(0x0)   /**< \brief (IISC_CR) No effect */
-#define   IISC_CR_CKEN_ON_Val             _U(0x1)   /**< \brief (IISC_CR) Enables clocks if CKDIS is not set */
+#define IISC_CR_CKEN                (_U_(0x1) << IISC_CR_CKEN_Pos)
+#define   IISC_CR_CKEN_OFF_Val            _U_(0x0)   /**< \brief (IISC_CR) No effect */
+#define   IISC_CR_CKEN_ON_Val             _U_(0x1)   /**< \brief (IISC_CR) Enables clocks if CKDIS is not set */
 #define IISC_CR_CKEN_OFF            (IISC_CR_CKEN_OFF_Val          << IISC_CR_CKEN_Pos)
 #define IISC_CR_CKEN_ON             (IISC_CR_CKEN_ON_Val           << IISC_CR_CKEN_Pos)
 #define IISC_CR_CKDIS_Pos           3            /**< \brief (IISC_CR) Clocks Disable */
-#define IISC_CR_CKDIS               (_U(0x1) << IISC_CR_CKDIS_Pos)
-#define   IISC_CR_CKDIS_OFF_Val           _U(0x0)   /**< \brief (IISC_CR) No effect */
-#define   IISC_CR_CKDIS_ON_Val            _U(0x1)   /**< \brief (IISC_CR) Disables clocks */
+#define IISC_CR_CKDIS               (_U_(0x1) << IISC_CR_CKDIS_Pos)
+#define   IISC_CR_CKDIS_OFF_Val           _U_(0x0)   /**< \brief (IISC_CR) No effect */
+#define   IISC_CR_CKDIS_ON_Val            _U_(0x1)   /**< \brief (IISC_CR) Disables clocks */
 #define IISC_CR_CKDIS_OFF           (IISC_CR_CKDIS_OFF_Val         << IISC_CR_CKDIS_Pos)
 #define IISC_CR_CKDIS_ON            (IISC_CR_CKDIS_ON_Val          << IISC_CR_CKDIS_Pos)
 #define IISC_CR_TXEN_Pos            4            /**< \brief (IISC_CR) Transmit Enable */
-#define IISC_CR_TXEN                (_U(0x1) << IISC_CR_TXEN_Pos)
-#define   IISC_CR_TXEN_OFF_Val            _U(0x0)   /**< \brief (IISC_CR) No effect */
-#define   IISC_CR_TXEN_ON_Val             _U(0x1)   /**< \brief (IISC_CR) Enables Data Transmit if TXDIS is not set */
+#define IISC_CR_TXEN                (_U_(0x1) << IISC_CR_TXEN_Pos)
+#define   IISC_CR_TXEN_OFF_Val            _U_(0x0)   /**< \brief (IISC_CR) No effect */
+#define   IISC_CR_TXEN_ON_Val             _U_(0x1)   /**< \brief (IISC_CR) Enables Data Transmit if TXDIS is not set */
 #define IISC_CR_TXEN_OFF            (IISC_CR_TXEN_OFF_Val          << IISC_CR_TXEN_Pos)
 #define IISC_CR_TXEN_ON             (IISC_CR_TXEN_ON_Val           << IISC_CR_TXEN_Pos)
 #define IISC_CR_TXDIS_Pos           5            /**< \brief (IISC_CR) Transmit Disable */
-#define IISC_CR_TXDIS               (_U(0x1) << IISC_CR_TXDIS_Pos)
-#define   IISC_CR_TXDIS_OFF_Val           _U(0x0)   /**< \brief (IISC_CR) No effect */
-#define   IISC_CR_TXDIS_ON_Val            _U(0x1)   /**< \brief (IISC_CR) Disables Data Transmit */
+#define IISC_CR_TXDIS               (_U_(0x1) << IISC_CR_TXDIS_Pos)
+#define   IISC_CR_TXDIS_OFF_Val           _U_(0x0)   /**< \brief (IISC_CR) No effect */
+#define   IISC_CR_TXDIS_ON_Val            _U_(0x1)   /**< \brief (IISC_CR) Disables Data Transmit */
 #define IISC_CR_TXDIS_OFF           (IISC_CR_TXDIS_OFF_Val         << IISC_CR_TXDIS_Pos)
 #define IISC_CR_TXDIS_ON            (IISC_CR_TXDIS_ON_Val          << IISC_CR_TXDIS_Pos)
 #define IISC_CR_SWRST_Pos           7            /**< \brief (IISC_CR) Software Reset */
-#define IISC_CR_SWRST               (_U(0x1) << IISC_CR_SWRST_Pos)
-#define   IISC_CR_SWRST_OFF_Val           _U(0x0)   /**< \brief (IISC_CR) No effect */
-#define   IISC_CR_SWRST_ON_Val            _U(0x1)   /**< \brief (IISC_CR) Performs a software reset. Has priority on any other bit in CR */
+#define IISC_CR_SWRST               (_U_(0x1) << IISC_CR_SWRST_Pos)
+#define   IISC_CR_SWRST_OFF_Val           _U_(0x0)   /**< \brief (IISC_CR) No effect */
+#define   IISC_CR_SWRST_ON_Val            _U_(0x1)   /**< \brief (IISC_CR) Performs a software reset. Has priority on any other bit in CR */
 #define IISC_CR_SWRST_OFF           (IISC_CR_SWRST_OFF_Val         << IISC_CR_SWRST_Pos)
 #define IISC_CR_SWRST_ON            (IISC_CR_SWRST_ON_Val          << IISC_CR_SWRST_Pos)
-#define IISC_CR_MASK                _U(0x000000BF) /**< \brief (IISC_CR) MASK Register */
+#define IISC_CR_MASK                _U_(0x000000BF) /**< \brief (IISC_CR) MASK Register */
 
 /* -------- IISC_MR : (IISC Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -127,25 +127,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define IISC_MR_OFFSET              0x04         /**< \brief (IISC_MR offset) Mode Register */
-#define IISC_MR_RESETVALUE          _U(0x00000000); /**< \brief (IISC_MR reset_value) Mode Register */
+#define IISC_MR_RESETVALUE          _U_(0x00000000); /**< \brief (IISC_MR reset_value) Mode Register */
 
 #define IISC_MR_MODE_Pos            0            /**< \brief (IISC_MR) Master/Slave/Controller Mode */
-#define IISC_MR_MODE                (_U(0x1) << IISC_MR_MODE_Pos)
-#define   IISC_MR_MODE_SLAVE_Val          _U(0x0)   /**< \brief (IISC_MR) Slave mode (only serial data handled, clocks received from external master or controller) */
-#define   IISC_MR_MODE_MASTER_Val         _U(0x1)   /**< \brief (IISC_MR) Master mode (clocks generated and output by IISC, serial data handled if CR.RXEN and/or CR.TXEN written to 1) */
+#define IISC_MR_MODE                (_U_(0x1) << IISC_MR_MODE_Pos)
+#define   IISC_MR_MODE_SLAVE_Val          _U_(0x0)   /**< \brief (IISC_MR) Slave mode (only serial data handled, clocks received from external master or controller) */
+#define   IISC_MR_MODE_MASTER_Val         _U_(0x1)   /**< \brief (IISC_MR) Master mode (clocks generated and output by IISC, serial data handled if CR.RXEN and/or CR.TXEN written to 1) */
 #define IISC_MR_MODE_SLAVE          (IISC_MR_MODE_SLAVE_Val        << IISC_MR_MODE_Pos)
 #define IISC_MR_MODE_MASTER         (IISC_MR_MODE_MASTER_Val       << IISC_MR_MODE_Pos)
 #define IISC_MR_DATALENGTH_Pos      2            /**< \brief (IISC_MR) Data Word Length */
-#define IISC_MR_DATALENGTH_Msk      (_U(0x7) << IISC_MR_DATALENGTH_Pos)
+#define IISC_MR_DATALENGTH_Msk      (_U_(0x7) << IISC_MR_DATALENGTH_Pos)
 #define IISC_MR_DATALENGTH(value)   (IISC_MR_DATALENGTH_Msk & ((value) << IISC_MR_DATALENGTH_Pos))
-#define   IISC_MR_DATALENGTH_32_Val       _U(0x0)   /**< \brief (IISC_MR) 32 bits */
-#define   IISC_MR_DATALENGTH_24_Val       _U(0x1)   /**< \brief (IISC_MR) 24 bits */
-#define   IISC_MR_DATALENGTH_20_Val       _U(0x2)   /**< \brief (IISC_MR) 20 bits */
-#define   IISC_MR_DATALENGTH_18_Val       _U(0x3)   /**< \brief (IISC_MR) 18 bits */
-#define   IISC_MR_DATALENGTH_16_Val       _U(0x4)   /**< \brief (IISC_MR) 16 bits */
-#define   IISC_MR_DATALENGTH_16C_Val      _U(0x5)   /**< \brief (IISC_MR) 16 bits compact stereo */
-#define   IISC_MR_DATALENGTH_8_Val        _U(0x6)   /**< \brief (IISC_MR) 8 bits */
-#define   IISC_MR_DATALENGTH_8C_Val       _U(0x7)   /**< \brief (IISC_MR) 8 bits compact stereo */
+#define   IISC_MR_DATALENGTH_32_Val       _U_(0x0)   /**< \brief (IISC_MR) 32 bits */
+#define   IISC_MR_DATALENGTH_24_Val       _U_(0x1)   /**< \brief (IISC_MR) 24 bits */
+#define   IISC_MR_DATALENGTH_20_Val       _U_(0x2)   /**< \brief (IISC_MR) 20 bits */
+#define   IISC_MR_DATALENGTH_18_Val       _U_(0x3)   /**< \brief (IISC_MR) 18 bits */
+#define   IISC_MR_DATALENGTH_16_Val       _U_(0x4)   /**< \brief (IISC_MR) 16 bits */
+#define   IISC_MR_DATALENGTH_16C_Val      _U_(0x5)   /**< \brief (IISC_MR) 16 bits compact stereo */
+#define   IISC_MR_DATALENGTH_8_Val        _U_(0x6)   /**< \brief (IISC_MR) 8 bits */
+#define   IISC_MR_DATALENGTH_8C_Val       _U_(0x7)   /**< \brief (IISC_MR) 8 bits compact stereo */
 #define IISC_MR_DATALENGTH_32       (IISC_MR_DATALENGTH_32_Val     << IISC_MR_DATALENGTH_Pos)
 #define IISC_MR_DATALENGTH_24       (IISC_MR_DATALENGTH_24_Val     << IISC_MR_DATALENGTH_Pos)
 #define IISC_MR_DATALENGTH_20       (IISC_MR_DATALENGTH_20_Val     << IISC_MR_DATALENGTH_Pos)
@@ -155,53 +155,53 @@ typedef union {
 #define IISC_MR_DATALENGTH_8        (IISC_MR_DATALENGTH_8_Val      << IISC_MR_DATALENGTH_Pos)
 #define IISC_MR_DATALENGTH_8C       (IISC_MR_DATALENGTH_8C_Val     << IISC_MR_DATALENGTH_Pos)
 #define IISC_MR_RXMONO_Pos          8            /**< \brief (IISC_MR) Receiver Mono */
-#define IISC_MR_RXMONO              (_U(0x1) << IISC_MR_RXMONO_Pos)
-#define   IISC_MR_RXMONO_STEREO_Val       _U(0x0)   /**< \brief (IISC_MR) Normal mode */
-#define   IISC_MR_RXMONO_MONO_Val         _U(0x1)   /**< \brief (IISC_MR) Left channel data is duplicated to right channel */
+#define IISC_MR_RXMONO              (_U_(0x1) << IISC_MR_RXMONO_Pos)
+#define   IISC_MR_RXMONO_STEREO_Val       _U_(0x0)   /**< \brief (IISC_MR) Normal mode */
+#define   IISC_MR_RXMONO_MONO_Val         _U_(0x1)   /**< \brief (IISC_MR) Left channel data is duplicated to right channel */
 #define IISC_MR_RXMONO_STEREO       (IISC_MR_RXMONO_STEREO_Val     << IISC_MR_RXMONO_Pos)
 #define IISC_MR_RXMONO_MONO         (IISC_MR_RXMONO_MONO_Val       << IISC_MR_RXMONO_Pos)
 #define IISC_MR_RXDMA_Pos           9            /**< \brief (IISC_MR) Single or Multiple DMA Channels for Receiver */
-#define IISC_MR_RXDMA               (_U(0x1) << IISC_MR_RXDMA_Pos)
-#define   IISC_MR_RXDMA_SINGLE_Val        _U(0x0)   /**< \brief (IISC_MR) Single DMA channel */
-#define   IISC_MR_RXDMA_MULTIPLE_Val      _U(0x1)   /**< \brief (IISC_MR) One DMA channel per data channel */
+#define IISC_MR_RXDMA               (_U_(0x1) << IISC_MR_RXDMA_Pos)
+#define   IISC_MR_RXDMA_SINGLE_Val        _U_(0x0)   /**< \brief (IISC_MR) Single DMA channel */
+#define   IISC_MR_RXDMA_MULTIPLE_Val      _U_(0x1)   /**< \brief (IISC_MR) One DMA channel per data channel */
 #define IISC_MR_RXDMA_SINGLE        (IISC_MR_RXDMA_SINGLE_Val      << IISC_MR_RXDMA_Pos)
 #define IISC_MR_RXDMA_MULTIPLE      (IISC_MR_RXDMA_MULTIPLE_Val    << IISC_MR_RXDMA_Pos)
 #define IISC_MR_RXLOOP_Pos          10           /**< \brief (IISC_MR) Loop-back Test Mode */
-#define IISC_MR_RXLOOP              (_U(0x1) << IISC_MR_RXLOOP_Pos)
-#define   IISC_MR_RXLOOP_OFF_Val          _U(0x0)   /**< \brief (IISC_MR) Normal mode */
-#define   IISC_MR_RXLOOP_ON_Val           _U(0x1)   /**< \brief (IISC_MR) ISDO internally connected to ISDI */
+#define IISC_MR_RXLOOP              (_U_(0x1) << IISC_MR_RXLOOP_Pos)
+#define   IISC_MR_RXLOOP_OFF_Val          _U_(0x0)   /**< \brief (IISC_MR) Normal mode */
+#define   IISC_MR_RXLOOP_ON_Val           _U_(0x1)   /**< \brief (IISC_MR) ISDO internally connected to ISDI */
 #define IISC_MR_RXLOOP_OFF          (IISC_MR_RXLOOP_OFF_Val        << IISC_MR_RXLOOP_Pos)
 #define IISC_MR_RXLOOP_ON           (IISC_MR_RXLOOP_ON_Val         << IISC_MR_RXLOOP_Pos)
 #define IISC_MR_TXMONO_Pos          12           /**< \brief (IISC_MR) Transmitter Mono */
-#define IISC_MR_TXMONO              (_U(0x1) << IISC_MR_TXMONO_Pos)
-#define   IISC_MR_TXMONO_STEREO_Val       _U(0x0)   /**< \brief (IISC_MR) Normal mode */
-#define   IISC_MR_TXMONO_MONO_Val         _U(0x1)   /**< \brief (IISC_MR) Left channel data is duplicated to right channel */
+#define IISC_MR_TXMONO              (_U_(0x1) << IISC_MR_TXMONO_Pos)
+#define   IISC_MR_TXMONO_STEREO_Val       _U_(0x0)   /**< \brief (IISC_MR) Normal mode */
+#define   IISC_MR_TXMONO_MONO_Val         _U_(0x1)   /**< \brief (IISC_MR) Left channel data is duplicated to right channel */
 #define IISC_MR_TXMONO_STEREO       (IISC_MR_TXMONO_STEREO_Val     << IISC_MR_TXMONO_Pos)
 #define IISC_MR_TXMONO_MONO         (IISC_MR_TXMONO_MONO_Val       << IISC_MR_TXMONO_Pos)
 #define IISC_MR_TXDMA_Pos           13           /**< \brief (IISC_MR) Single or Multiple DMA Channels for Transmitter */
-#define IISC_MR_TXDMA               (_U(0x1) << IISC_MR_TXDMA_Pos)
-#define   IISC_MR_TXDMA_SINGLE_Val        _U(0x0)   /**< \brief (IISC_MR) Single DMA channel */
-#define   IISC_MR_TXDMA_MULTIPLE_Val      _U(0x1)   /**< \brief (IISC_MR) One DMA channel per data channel */
+#define IISC_MR_TXDMA               (_U_(0x1) << IISC_MR_TXDMA_Pos)
+#define   IISC_MR_TXDMA_SINGLE_Val        _U_(0x0)   /**< \brief (IISC_MR) Single DMA channel */
+#define   IISC_MR_TXDMA_MULTIPLE_Val      _U_(0x1)   /**< \brief (IISC_MR) One DMA channel per data channel */
 #define IISC_MR_TXDMA_SINGLE        (IISC_MR_TXDMA_SINGLE_Val      << IISC_MR_TXDMA_Pos)
 #define IISC_MR_TXDMA_MULTIPLE      (IISC_MR_TXDMA_MULTIPLE_Val    << IISC_MR_TXDMA_Pos)
 #define IISC_MR_TXSAME_Pos          14           /**< \brief (IISC_MR) Transmit Data when Underrun */
-#define IISC_MR_TXSAME              (_U(0x1) << IISC_MR_TXSAME_Pos)
-#define   IISC_MR_TXSAME_ZERO_Val         _U(0x0)   /**< \brief (IISC_MR) Zero data transmitted in case of underrun */
-#define   IISC_MR_TXSAME_SAME_Val         _U(0x1)   /**< \brief (IISC_MR) Last data transmitted in case of underrun */
+#define IISC_MR_TXSAME              (_U_(0x1) << IISC_MR_TXSAME_Pos)
+#define   IISC_MR_TXSAME_ZERO_Val         _U_(0x0)   /**< \brief (IISC_MR) Zero data transmitted in case of underrun */
+#define   IISC_MR_TXSAME_SAME_Val         _U_(0x1)   /**< \brief (IISC_MR) Last data transmitted in case of underrun */
 #define IISC_MR_TXSAME_ZERO         (IISC_MR_TXSAME_ZERO_Val       << IISC_MR_TXSAME_Pos)
 #define IISC_MR_TXSAME_SAME         (IISC_MR_TXSAME_SAME_Val       << IISC_MR_TXSAME_Pos)
 #define IISC_MR_IMCKFS_Pos          24           /**< \brief (IISC_MR) Master Clock to fs Ratio */
-#define IISC_MR_IMCKFS_Msk          (_U(0x3F) << IISC_MR_IMCKFS_Pos)
+#define IISC_MR_IMCKFS_Msk          (_U_(0x3F) << IISC_MR_IMCKFS_Pos)
 #define IISC_MR_IMCKFS(value)       (IISC_MR_IMCKFS_Msk & ((value) << IISC_MR_IMCKFS_Pos))
-#define   IISC_MR_IMCKFS_16_Val           _U(0x0)   /**< \brief (IISC_MR) 16 fs */
-#define   IISC_MR_IMCKFS_32_Val           _U(0x1)   /**< \brief (IISC_MR) 32 fs */
-#define   IISC_MR_IMCKFS_64_Val           _U(0x3)   /**< \brief (IISC_MR) 64 fs */
-#define   IISC_MR_IMCKFS_128_Val          _U(0x7)   /**< \brief (IISC_MR) 128 fs */
-#define   IISC_MR_IMCKFS_256_Val          _U(0xF)   /**< \brief (IISC_MR) 256 fs */
-#define   IISC_MR_IMCKFS_384_Val          _U(0x17)   /**< \brief (IISC_MR) 384 fs */
-#define   IISC_MR_IMCKFS_512_Val          _U(0x1F)   /**< \brief (IISC_MR) 512 fs */
-#define   IISC_MR_IMCKFS_768_Val          _U(0x2F)   /**< \brief (IISC_MR) 768 fs */
-#define   IISC_MR_IMCKFS_1024_Val         _U(0x3F)   /**< \brief (IISC_MR) 1024 fs */
+#define   IISC_MR_IMCKFS_16_Val           _U_(0x0)   /**< \brief (IISC_MR) 16 fs */
+#define   IISC_MR_IMCKFS_32_Val           _U_(0x1)   /**< \brief (IISC_MR) 32 fs */
+#define   IISC_MR_IMCKFS_64_Val           _U_(0x3)   /**< \brief (IISC_MR) 64 fs */
+#define   IISC_MR_IMCKFS_128_Val          _U_(0x7)   /**< \brief (IISC_MR) 128 fs */
+#define   IISC_MR_IMCKFS_256_Val          _U_(0xF)   /**< \brief (IISC_MR) 256 fs */
+#define   IISC_MR_IMCKFS_384_Val          _U_(0x17)   /**< \brief (IISC_MR) 384 fs */
+#define   IISC_MR_IMCKFS_512_Val          _U_(0x1F)   /**< \brief (IISC_MR) 512 fs */
+#define   IISC_MR_IMCKFS_768_Val          _U_(0x2F)   /**< \brief (IISC_MR) 768 fs */
+#define   IISC_MR_IMCKFS_1024_Val         _U_(0x3F)   /**< \brief (IISC_MR) 1024 fs */
 #define IISC_MR_IMCKFS_16           (IISC_MR_IMCKFS_16_Val         << IISC_MR_IMCKFS_Pos)
 #define IISC_MR_IMCKFS_32           (IISC_MR_IMCKFS_32_Val         << IISC_MR_IMCKFS_Pos)
 #define IISC_MR_IMCKFS_64           (IISC_MR_IMCKFS_64_Val         << IISC_MR_IMCKFS_Pos)
@@ -212,18 +212,18 @@ typedef union {
 #define IISC_MR_IMCKFS_768          (IISC_MR_IMCKFS_768_Val        << IISC_MR_IMCKFS_Pos)
 #define IISC_MR_IMCKFS_1024         (IISC_MR_IMCKFS_1024_Val       << IISC_MR_IMCKFS_Pos)
 #define IISC_MR_IMCKMODE_Pos        30           /**< \brief (IISC_MR) Master Clock Mode */
-#define IISC_MR_IMCKMODE            (_U(0x1) << IISC_MR_IMCKMODE_Pos)
-#define   IISC_MR_IMCKMODE_NO_IMCK_Val    _U(0x0)   /**< \brief (IISC_MR) No IMCK generated */
-#define   IISC_MR_IMCKMODE_IMCK_Val       _U(0x1)   /**< \brief (IISC_MR) IMCK generated */
+#define IISC_MR_IMCKMODE            (_U_(0x1) << IISC_MR_IMCKMODE_Pos)
+#define   IISC_MR_IMCKMODE_NO_IMCK_Val    _U_(0x0)   /**< \brief (IISC_MR) No IMCK generated */
+#define   IISC_MR_IMCKMODE_IMCK_Val       _U_(0x1)   /**< \brief (IISC_MR) IMCK generated */
 #define IISC_MR_IMCKMODE_NO_IMCK    (IISC_MR_IMCKMODE_NO_IMCK_Val  << IISC_MR_IMCKMODE_Pos)
 #define IISC_MR_IMCKMODE_IMCK       (IISC_MR_IMCKMODE_IMCK_Val     << IISC_MR_IMCKMODE_Pos)
 #define IISC_MR_IWS24_Pos           31           /**< \brief (IISC_MR) IWS Data Slot Width */
-#define IISC_MR_IWS24               (_U(0x1) << IISC_MR_IWS24_Pos)
-#define   IISC_MR_IWS24_32_Val            _U(0x0)   /**< \brief (IISC_MR) IWS Data Slot is 32-bit wide for DATALENGTH=18/20/24-bit */
-#define   IISC_MR_IWS24_24_Val            _U(0x1)   /**< \brief (IISC_MR) IWS Data Slot is 24-bit wide for DATALENGTH=18/20/24-bit */
+#define IISC_MR_IWS24               (_U_(0x1) << IISC_MR_IWS24_Pos)
+#define   IISC_MR_IWS24_32_Val            _U_(0x0)   /**< \brief (IISC_MR) IWS Data Slot is 32-bit wide for DATALENGTH=18/20/24-bit */
+#define   IISC_MR_IWS24_24_Val            _U_(0x1)   /**< \brief (IISC_MR) IWS Data Slot is 24-bit wide for DATALENGTH=18/20/24-bit */
 #define IISC_MR_IWS24_32            (IISC_MR_IWS24_32_Val          << IISC_MR_IWS24_Pos)
 #define IISC_MR_IWS24_24            (IISC_MR_IWS24_24_Val          << IISC_MR_IWS24_Pos)
-#define IISC_MR_MASK                _U(0xFF00771D) /**< \brief (IISC_MR) MASK Register */
+#define IISC_MR_MASK                _U_(0xFF00771D) /**< \brief (IISC_MR) MASK Register */
 
 /* -------- IISC_SR : (IISC Offset: 0x08) (R/  32) Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -247,59 +247,59 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define IISC_SR_OFFSET              0x08         /**< \brief (IISC_SR offset) Status Register */
-#define IISC_SR_RESETVALUE          _U(0x00000000); /**< \brief (IISC_SR reset_value) Status Register */
+#define IISC_SR_RESETVALUE          _U_(0x00000000); /**< \brief (IISC_SR reset_value) Status Register */
 
 #define IISC_SR_RXEN_Pos            0            /**< \brief (IISC_SR) Receive Enable */
-#define IISC_SR_RXEN                (_U(0x1) << IISC_SR_RXEN_Pos)
-#define   IISC_SR_RXEN_OFF_Val            _U(0x0)   /**< \brief (IISC_SR) Receiver is effectively disabled, following a CR.RXDIS or CR.SWRST request */
-#define   IISC_SR_RXEN_ON_Val             _U(0x1)   /**< \brief (IISC_SR) Receiver is effectively enabled, following a CR.RXEN request */
+#define IISC_SR_RXEN                (_U_(0x1) << IISC_SR_RXEN_Pos)
+#define   IISC_SR_RXEN_OFF_Val            _U_(0x0)   /**< \brief (IISC_SR) Receiver is effectively disabled, following a CR.RXDIS or CR.SWRST request */
+#define   IISC_SR_RXEN_ON_Val             _U_(0x1)   /**< \brief (IISC_SR) Receiver is effectively enabled, following a CR.RXEN request */
 #define IISC_SR_RXEN_OFF            (IISC_SR_RXEN_OFF_Val          << IISC_SR_RXEN_Pos)
 #define IISC_SR_RXEN_ON             (IISC_SR_RXEN_ON_Val           << IISC_SR_RXEN_Pos)
 #define IISC_SR_RXRDY_Pos           1            /**< \brief (IISC_SR) Receive Ready */
-#define IISC_SR_RXRDY               (_U(0x1) << IISC_SR_RXRDY_Pos)
-#define   IISC_SR_RXRDY_EMPTY_Val         _U(0x0)   /**< \brief (IISC_SR) The register RHR is empty and can't be read */
-#define   IISC_SR_RXRDY_FULL_Val          _U(0x1)   /**< \brief (IISC_SR) The register RHR is full and is ready to be read */
+#define IISC_SR_RXRDY               (_U_(0x1) << IISC_SR_RXRDY_Pos)
+#define   IISC_SR_RXRDY_EMPTY_Val         _U_(0x0)   /**< \brief (IISC_SR) The register RHR is empty and can't be read */
+#define   IISC_SR_RXRDY_FULL_Val          _U_(0x1)   /**< \brief (IISC_SR) The register RHR is full and is ready to be read */
 #define IISC_SR_RXRDY_EMPTY         (IISC_SR_RXRDY_EMPTY_Val       << IISC_SR_RXRDY_Pos)
 #define IISC_SR_RXRDY_FULL          (IISC_SR_RXRDY_FULL_Val        << IISC_SR_RXRDY_Pos)
 #define IISC_SR_RXOR_Pos            2            /**< \brief (IISC_SR) Receive Overrun */
-#define IISC_SR_RXOR                (_U(0x1) << IISC_SR_RXOR_Pos)
-#define   IISC_SR_RXOR_NO_Val             _U(0x0)   /**< \brief (IISC_SR) No overrun */
-#define   IISC_SR_RXOR_YES_Val            _U(0x1)   /**< \brief (IISC_SR) The previous received data has not been read. This data is lost */
+#define IISC_SR_RXOR                (_U_(0x1) << IISC_SR_RXOR_Pos)
+#define   IISC_SR_RXOR_NO_Val             _U_(0x0)   /**< \brief (IISC_SR) No overrun */
+#define   IISC_SR_RXOR_YES_Val            _U_(0x1)   /**< \brief (IISC_SR) The previous received data has not been read. This data is lost */
 #define IISC_SR_RXOR_NO             (IISC_SR_RXOR_NO_Val           << IISC_SR_RXOR_Pos)
 #define IISC_SR_RXOR_YES            (IISC_SR_RXOR_YES_Val          << IISC_SR_RXOR_Pos)
 #define IISC_SR_TXEN_Pos            4            /**< \brief (IISC_SR) Transmit Enable */
-#define IISC_SR_TXEN                (_U(0x1) << IISC_SR_TXEN_Pos)
-#define   IISC_SR_TXEN_OFF_Val            _U(0x0)   /**< \brief (IISC_SR) Transmitter is effectively disabled, following a CR.TXDIS or CR.SWRST request */
-#define   IISC_SR_TXEN_ON_Val             _U(0x1)   /**< \brief (IISC_SR) Transmitter is effectively enabled, following a CR.TXEN request */
+#define IISC_SR_TXEN                (_U_(0x1) << IISC_SR_TXEN_Pos)
+#define   IISC_SR_TXEN_OFF_Val            _U_(0x0)   /**< \brief (IISC_SR) Transmitter is effectively disabled, following a CR.TXDIS or CR.SWRST request */
+#define   IISC_SR_TXEN_ON_Val             _U_(0x1)   /**< \brief (IISC_SR) Transmitter is effectively enabled, following a CR.TXEN request */
 #define IISC_SR_TXEN_OFF            (IISC_SR_TXEN_OFF_Val          << IISC_SR_TXEN_Pos)
 #define IISC_SR_TXEN_ON             (IISC_SR_TXEN_ON_Val           << IISC_SR_TXEN_Pos)
 #define IISC_SR_TXRDY_Pos           5            /**< \brief (IISC_SR) Transmit Ready */
-#define IISC_SR_TXRDY               (_U(0x1) << IISC_SR_TXRDY_Pos)
-#define   IISC_SR_TXRDY_FULL_Val          _U(0x0)   /**< \brief (IISC_SR) The register THR is full and can't be written */
-#define   IISC_SR_TXRDY_EMPTY_Val         _U(0x1)   /**< \brief (IISC_SR) The register THR is empty and is ready to be written */
+#define IISC_SR_TXRDY               (_U_(0x1) << IISC_SR_TXRDY_Pos)
+#define   IISC_SR_TXRDY_FULL_Val          _U_(0x0)   /**< \brief (IISC_SR) The register THR is full and can't be written */
+#define   IISC_SR_TXRDY_EMPTY_Val         _U_(0x1)   /**< \brief (IISC_SR) The register THR is empty and is ready to be written */
 #define IISC_SR_TXRDY_FULL          (IISC_SR_TXRDY_FULL_Val        << IISC_SR_TXRDY_Pos)
 #define IISC_SR_TXRDY_EMPTY         (IISC_SR_TXRDY_EMPTY_Val       << IISC_SR_TXRDY_Pos)
 #define IISC_SR_TXUR_Pos            6            /**< \brief (IISC_SR) Transmit Underrun */
-#define IISC_SR_TXUR                (_U(0x1) << IISC_SR_TXUR_Pos)
-#define   IISC_SR_TXUR_NO_Val             _U(0x0)   /**< \brief (IISC_SR) No underrun */
-#define   IISC_SR_TXUR_YES_Val            _U(0x1)   /**< \brief (IISC_SR) The last bit of the last data written to the register THR has been set. Until the next write to THR, data will be sent according to MR.TXSAME field */
+#define IISC_SR_TXUR                (_U_(0x1) << IISC_SR_TXUR_Pos)
+#define   IISC_SR_TXUR_NO_Val             _U_(0x0)   /**< \brief (IISC_SR) No underrun */
+#define   IISC_SR_TXUR_YES_Val            _U_(0x1)   /**< \brief (IISC_SR) The last bit of the last data written to the register THR has been set. Until the next write to THR, data will be sent according to MR.TXSAME field */
 #define IISC_SR_TXUR_NO             (IISC_SR_TXUR_NO_Val           << IISC_SR_TXUR_Pos)
 #define IISC_SR_TXUR_YES            (IISC_SR_TXUR_YES_Val          << IISC_SR_TXUR_Pos)
 #define IISC_SR_RXORCH_Pos          8            /**< \brief (IISC_SR) Receive Overrun Channels */
-#define IISC_SR_RXORCH_Msk          (_U(0x3) << IISC_SR_RXORCH_Pos)
+#define IISC_SR_RXORCH_Msk          (_U_(0x3) << IISC_SR_RXORCH_Pos)
 #define IISC_SR_RXORCH(value)       (IISC_SR_RXORCH_Msk & ((value) << IISC_SR_RXORCH_Pos))
-#define   IISC_SR_RXORCH_LEFT_Val         _U(0x0)   /**< \brief (IISC_SR) Overrun first occurred on left channel */
-#define   IISC_SR_RXORCH_RIGHT_Val        _U(0x1)   /**< \brief (IISC_SR) Overrun first occurred on right channel */
+#define   IISC_SR_RXORCH_LEFT_Val         _U_(0x0)   /**< \brief (IISC_SR) Overrun first occurred on left channel */
+#define   IISC_SR_RXORCH_RIGHT_Val        _U_(0x1)   /**< \brief (IISC_SR) Overrun first occurred on right channel */
 #define IISC_SR_RXORCH_LEFT         (IISC_SR_RXORCH_LEFT_Val       << IISC_SR_RXORCH_Pos)
 #define IISC_SR_RXORCH_RIGHT        (IISC_SR_RXORCH_RIGHT_Val      << IISC_SR_RXORCH_Pos)
 #define IISC_SR_TXURCH_Pos          20           /**< \brief (IISC_SR) Transmit Underrun Channels */
-#define IISC_SR_TXURCH_Msk          (_U(0x3) << IISC_SR_TXURCH_Pos)
+#define IISC_SR_TXURCH_Msk          (_U_(0x3) << IISC_SR_TXURCH_Pos)
 #define IISC_SR_TXURCH(value)       (IISC_SR_TXURCH_Msk & ((value) << IISC_SR_TXURCH_Pos))
-#define   IISC_SR_TXURCH_LEFT_Val         _U(0x0)   /**< \brief (IISC_SR) Underrun first occurred on left channel */
-#define   IISC_SR_TXURCH_RIGHT_Val        _U(0x1)   /**< \brief (IISC_SR) Underrun first occurred on right channel */
+#define   IISC_SR_TXURCH_LEFT_Val         _U_(0x0)   /**< \brief (IISC_SR) Underrun first occurred on left channel */
+#define   IISC_SR_TXURCH_RIGHT_Val        _U_(0x1)   /**< \brief (IISC_SR) Underrun first occurred on right channel */
 #define IISC_SR_TXURCH_LEFT         (IISC_SR_TXURCH_LEFT_Val       << IISC_SR_TXURCH_Pos)
 #define IISC_SR_TXURCH_RIGHT        (IISC_SR_TXURCH_RIGHT_Val      << IISC_SR_TXURCH_Pos)
-#define IISC_SR_MASK                _U(0x00300377) /**< \brief (IISC_SR) MASK Register */
+#define IISC_SR_MASK                _U_(0x00300377) /**< \brief (IISC_SR) MASK Register */
 
 /* -------- IISC_SCR : (IISC Offset: 0x0C) ( /W 32) Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -322,24 +322,24 @@ typedef union {
 #define IISC_SCR_OFFSET             0x0C         /**< \brief (IISC_SCR offset) Status Clear Register */
 
 #define IISC_SCR_RXOR_Pos           2            /**< \brief (IISC_SCR) Receive Overrun */
-#define IISC_SCR_RXOR               (_U(0x1) << IISC_SCR_RXOR_Pos)
-#define   IISC_SCR_RXOR_NO_Val            _U(0x0)   /**< \brief (IISC_SCR) No effect */
-#define   IISC_SCR_RXOR_CLEAR_Val         _U(0x1)   /**< \brief (IISC_SCR) Clears the corresponding SR bit */
+#define IISC_SCR_RXOR               (_U_(0x1) << IISC_SCR_RXOR_Pos)
+#define   IISC_SCR_RXOR_NO_Val            _U_(0x0)   /**< \brief (IISC_SCR) No effect */
+#define   IISC_SCR_RXOR_CLEAR_Val         _U_(0x1)   /**< \brief (IISC_SCR) Clears the corresponding SR bit */
 #define IISC_SCR_RXOR_NO            (IISC_SCR_RXOR_NO_Val          << IISC_SCR_RXOR_Pos)
 #define IISC_SCR_RXOR_CLEAR         (IISC_SCR_RXOR_CLEAR_Val       << IISC_SCR_RXOR_Pos)
 #define IISC_SCR_TXUR_Pos           6            /**< \brief (IISC_SCR) Transmit Underrun */
-#define IISC_SCR_TXUR               (_U(0x1) << IISC_SCR_TXUR_Pos)
-#define   IISC_SCR_TXUR_NO_Val            _U(0x0)   /**< \brief (IISC_SCR) No effect */
-#define   IISC_SCR_TXUR_CLEAR_Val         _U(0x1)   /**< \brief (IISC_SCR) Clears the corresponding SR bit */
+#define IISC_SCR_TXUR               (_U_(0x1) << IISC_SCR_TXUR_Pos)
+#define   IISC_SCR_TXUR_NO_Val            _U_(0x0)   /**< \brief (IISC_SCR) No effect */
+#define   IISC_SCR_TXUR_CLEAR_Val         _U_(0x1)   /**< \brief (IISC_SCR) Clears the corresponding SR bit */
 #define IISC_SCR_TXUR_NO            (IISC_SCR_TXUR_NO_Val          << IISC_SCR_TXUR_Pos)
 #define IISC_SCR_TXUR_CLEAR         (IISC_SCR_TXUR_CLEAR_Val       << IISC_SCR_TXUR_Pos)
 #define IISC_SCR_RXORCH_Pos         8            /**< \brief (IISC_SCR) Receive Overrun Channels */
-#define IISC_SCR_RXORCH_Msk         (_U(0x3) << IISC_SCR_RXORCH_Pos)
+#define IISC_SCR_RXORCH_Msk         (_U_(0x3) << IISC_SCR_RXORCH_Pos)
 #define IISC_SCR_RXORCH(value)      (IISC_SCR_RXORCH_Msk & ((value) << IISC_SCR_RXORCH_Pos))
 #define IISC_SCR_TXURCH_Pos         20           /**< \brief (IISC_SCR) Transmit Underrun Channels */
-#define IISC_SCR_TXURCH_Msk         (_U(0x3) << IISC_SCR_TXURCH_Pos)
+#define IISC_SCR_TXURCH_Msk         (_U_(0x3) << IISC_SCR_TXURCH_Pos)
 #define IISC_SCR_TXURCH(value)      (IISC_SCR_TXURCH_Msk & ((value) << IISC_SCR_TXURCH_Pos))
-#define IISC_SCR_MASK               _U(0x00300344) /**< \brief (IISC_SCR) MASK Register */
+#define IISC_SCR_MASK               _U_(0x00300344) /**< \brief (IISC_SCR) MASK Register */
 
 /* -------- IISC_SSR : (IISC Offset: 0x10) ( /W 32) Status Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -362,24 +362,24 @@ typedef union {
 #define IISC_SSR_OFFSET             0x10         /**< \brief (IISC_SSR offset) Status Set Register */
 
 #define IISC_SSR_RXOR_Pos           2            /**< \brief (IISC_SSR) Receive Overrun */
-#define IISC_SSR_RXOR               (_U(0x1) << IISC_SSR_RXOR_Pos)
-#define   IISC_SSR_RXOR_NO_Val            _U(0x0)   /**< \brief (IISC_SSR) No effect */
-#define   IISC_SSR_RXOR_SET_Val           _U(0x1)   /**< \brief (IISC_SSR) Sets corresponding SR bit */
+#define IISC_SSR_RXOR               (_U_(0x1) << IISC_SSR_RXOR_Pos)
+#define   IISC_SSR_RXOR_NO_Val            _U_(0x0)   /**< \brief (IISC_SSR) No effect */
+#define   IISC_SSR_RXOR_SET_Val           _U_(0x1)   /**< \brief (IISC_SSR) Sets corresponding SR bit */
 #define IISC_SSR_RXOR_NO            (IISC_SSR_RXOR_NO_Val          << IISC_SSR_RXOR_Pos)
 #define IISC_SSR_RXOR_SET           (IISC_SSR_RXOR_SET_Val         << IISC_SSR_RXOR_Pos)
 #define IISC_SSR_TXUR_Pos           6            /**< \brief (IISC_SSR) Transmit Underrun */
-#define IISC_SSR_TXUR               (_U(0x1) << IISC_SSR_TXUR_Pos)
-#define   IISC_SSR_TXUR_NO_Val            _U(0x0)   /**< \brief (IISC_SSR) No effect */
-#define   IISC_SSR_TXUR_SET_Val           _U(0x1)   /**< \brief (IISC_SSR) Sets corresponding SR bit */
+#define IISC_SSR_TXUR               (_U_(0x1) << IISC_SSR_TXUR_Pos)
+#define   IISC_SSR_TXUR_NO_Val            _U_(0x0)   /**< \brief (IISC_SSR) No effect */
+#define   IISC_SSR_TXUR_SET_Val           _U_(0x1)   /**< \brief (IISC_SSR) Sets corresponding SR bit */
 #define IISC_SSR_TXUR_NO            (IISC_SSR_TXUR_NO_Val          << IISC_SSR_TXUR_Pos)
 #define IISC_SSR_TXUR_SET           (IISC_SSR_TXUR_SET_Val         << IISC_SSR_TXUR_Pos)
 #define IISC_SSR_RXORCH_Pos         8            /**< \brief (IISC_SSR) Receive Overrun Channels */
-#define IISC_SSR_RXORCH_Msk         (_U(0x3) << IISC_SSR_RXORCH_Pos)
+#define IISC_SSR_RXORCH_Msk         (_U_(0x3) << IISC_SSR_RXORCH_Pos)
 #define IISC_SSR_RXORCH(value)      (IISC_SSR_RXORCH_Msk & ((value) << IISC_SSR_RXORCH_Pos))
 #define IISC_SSR_TXURCH_Pos         20           /**< \brief (IISC_SSR) Transmit Underrun Channels */
-#define IISC_SSR_TXURCH_Msk         (_U(0x3) << IISC_SSR_TXURCH_Pos)
+#define IISC_SSR_TXURCH_Msk         (_U_(0x3) << IISC_SSR_TXURCH_Pos)
 #define IISC_SSR_TXURCH(value)      (IISC_SSR_TXURCH_Msk & ((value) << IISC_SSR_TXURCH_Pos))
-#define IISC_SSR_MASK               _U(0x00300344) /**< \brief (IISC_SSR) MASK Register */
+#define IISC_SSR_MASK               _U_(0x00300344) /**< \brief (IISC_SSR) MASK Register */
 
 /* -------- IISC_IER : (IISC Offset: 0x14) ( /W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -400,30 +400,30 @@ typedef union {
 #define IISC_IER_OFFSET             0x14         /**< \brief (IISC_IER offset) Interrupt Enable Register */
 
 #define IISC_IER_RXRDY_Pos          1            /**< \brief (IISC_IER) Receiver Ready Interrupt Enable */
-#define IISC_IER_RXRDY              (_U(0x1) << IISC_IER_RXRDY_Pos)
-#define   IISC_IER_RXRDY_OFF_Val          _U(0x0)   /**< \brief (IISC_IER) No effect */
-#define   IISC_IER_RXRDY_ON_Val           _U(0x1)   /**< \brief (IISC_IER) Enables the corresponding interrupt */
+#define IISC_IER_RXRDY              (_U_(0x1) << IISC_IER_RXRDY_Pos)
+#define   IISC_IER_RXRDY_OFF_Val          _U_(0x0)   /**< \brief (IISC_IER) No effect */
+#define   IISC_IER_RXRDY_ON_Val           _U_(0x1)   /**< \brief (IISC_IER) Enables the corresponding interrupt */
 #define IISC_IER_RXRDY_OFF          (IISC_IER_RXRDY_OFF_Val        << IISC_IER_RXRDY_Pos)
 #define IISC_IER_RXRDY_ON           (IISC_IER_RXRDY_ON_Val         << IISC_IER_RXRDY_Pos)
 #define IISC_IER_RXOR_Pos           2            /**< \brief (IISC_IER) Receive Overrun Interrupt Enable */
-#define IISC_IER_RXOR               (_U(0x1) << IISC_IER_RXOR_Pos)
-#define   IISC_IER_RXOR_OFF_Val           _U(0x0)   /**< \brief (IISC_IER) No effect */
-#define   IISC_IER_RXOR_ON_Val            _U(0x1)   /**< \brief (IISC_IER) Enables the corresponding interrupt */
+#define IISC_IER_RXOR               (_U_(0x1) << IISC_IER_RXOR_Pos)
+#define   IISC_IER_RXOR_OFF_Val           _U_(0x0)   /**< \brief (IISC_IER) No effect */
+#define   IISC_IER_RXOR_ON_Val            _U_(0x1)   /**< \brief (IISC_IER) Enables the corresponding interrupt */
 #define IISC_IER_RXOR_OFF           (IISC_IER_RXOR_OFF_Val         << IISC_IER_RXOR_Pos)
 #define IISC_IER_RXOR_ON            (IISC_IER_RXOR_ON_Val          << IISC_IER_RXOR_Pos)
 #define IISC_IER_TXRDY_Pos          5            /**< \brief (IISC_IER) Transmit Ready Interrupt Enable */
-#define IISC_IER_TXRDY              (_U(0x1) << IISC_IER_TXRDY_Pos)
-#define   IISC_IER_TXRDY_OFF_Val          _U(0x0)   /**< \brief (IISC_IER) No effect */
-#define   IISC_IER_TXRDY_ON_Val           _U(0x1)   /**< \brief (IISC_IER) Enables the corresponding interrupt */
+#define IISC_IER_TXRDY              (_U_(0x1) << IISC_IER_TXRDY_Pos)
+#define   IISC_IER_TXRDY_OFF_Val          _U_(0x0)   /**< \brief (IISC_IER) No effect */
+#define   IISC_IER_TXRDY_ON_Val           _U_(0x1)   /**< \brief (IISC_IER) Enables the corresponding interrupt */
 #define IISC_IER_TXRDY_OFF          (IISC_IER_TXRDY_OFF_Val        << IISC_IER_TXRDY_Pos)
 #define IISC_IER_TXRDY_ON           (IISC_IER_TXRDY_ON_Val         << IISC_IER_TXRDY_Pos)
 #define IISC_IER_TXUR_Pos           6            /**< \brief (IISC_IER) Transmit Underrun Interrupt Enable */
-#define IISC_IER_TXUR               (_U(0x1) << IISC_IER_TXUR_Pos)
-#define   IISC_IER_TXUR_OFF_Val           _U(0x0)   /**< \brief (IISC_IER) No effect */
-#define   IISC_IER_TXUR_ON_Val            _U(0x1)   /**< \brief (IISC_IER) Enables the corresponding interrupt */
+#define IISC_IER_TXUR               (_U_(0x1) << IISC_IER_TXUR_Pos)
+#define   IISC_IER_TXUR_OFF_Val           _U_(0x0)   /**< \brief (IISC_IER) No effect */
+#define   IISC_IER_TXUR_ON_Val            _U_(0x1)   /**< \brief (IISC_IER) Enables the corresponding interrupt */
 #define IISC_IER_TXUR_OFF           (IISC_IER_TXUR_OFF_Val         << IISC_IER_TXUR_Pos)
 #define IISC_IER_TXUR_ON            (IISC_IER_TXUR_ON_Val          << IISC_IER_TXUR_Pos)
-#define IISC_IER_MASK               _U(0x00000066) /**< \brief (IISC_IER) MASK Register */
+#define IISC_IER_MASK               _U_(0x00000066) /**< \brief (IISC_IER) MASK Register */
 
 /* -------- IISC_IDR : (IISC Offset: 0x18) ( /W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -444,30 +444,30 @@ typedef union {
 #define IISC_IDR_OFFSET             0x18         /**< \brief (IISC_IDR offset) Interrupt Disable Register */
 
 #define IISC_IDR_RXRDY_Pos          1            /**< \brief (IISC_IDR) Receive Ready Interrupt Disable */
-#define IISC_IDR_RXRDY              (_U(0x1) << IISC_IDR_RXRDY_Pos)
-#define   IISC_IDR_RXRDY_OFF_Val          _U(0x0)   /**< \brief (IISC_IDR) No effect */
-#define   IISC_IDR_RXRDY_ON_Val           _U(0x1)   /**< \brief (IISC_IDR) Disables the corresponding interrupt */
+#define IISC_IDR_RXRDY              (_U_(0x1) << IISC_IDR_RXRDY_Pos)
+#define   IISC_IDR_RXRDY_OFF_Val          _U_(0x0)   /**< \brief (IISC_IDR) No effect */
+#define   IISC_IDR_RXRDY_ON_Val           _U_(0x1)   /**< \brief (IISC_IDR) Disables the corresponding interrupt */
 #define IISC_IDR_RXRDY_OFF          (IISC_IDR_RXRDY_OFF_Val        << IISC_IDR_RXRDY_Pos)
 #define IISC_IDR_RXRDY_ON           (IISC_IDR_RXRDY_ON_Val         << IISC_IDR_RXRDY_Pos)
 #define IISC_IDR_RXOR_Pos           2            /**< \brief (IISC_IDR) Receive Overrun Interrupt Disable */
-#define IISC_IDR_RXOR               (_U(0x1) << IISC_IDR_RXOR_Pos)
-#define   IISC_IDR_RXOR_OFF_Val           _U(0x0)   /**< \brief (IISC_IDR) No effect */
-#define   IISC_IDR_RXOR_ON_Val            _U(0x1)   /**< \brief (IISC_IDR) Disables the corresponding interrupt */
+#define IISC_IDR_RXOR               (_U_(0x1) << IISC_IDR_RXOR_Pos)
+#define   IISC_IDR_RXOR_OFF_Val           _U_(0x0)   /**< \brief (IISC_IDR) No effect */
+#define   IISC_IDR_RXOR_ON_Val            _U_(0x1)   /**< \brief (IISC_IDR) Disables the corresponding interrupt */
 #define IISC_IDR_RXOR_OFF           (IISC_IDR_RXOR_OFF_Val         << IISC_IDR_RXOR_Pos)
 #define IISC_IDR_RXOR_ON            (IISC_IDR_RXOR_ON_Val          << IISC_IDR_RXOR_Pos)
 #define IISC_IDR_TXRDY_Pos          5            /**< \brief (IISC_IDR) Transmit Ready Interrupt Disable */
-#define IISC_IDR_TXRDY              (_U(0x1) << IISC_IDR_TXRDY_Pos)
-#define   IISC_IDR_TXRDY_OFF_Val          _U(0x0)   /**< \brief (IISC_IDR) No effect */
-#define   IISC_IDR_TXRDY_ON_Val           _U(0x1)   /**< \brief (IISC_IDR) Disables the corresponding interrupt */
+#define IISC_IDR_TXRDY              (_U_(0x1) << IISC_IDR_TXRDY_Pos)
+#define   IISC_IDR_TXRDY_OFF_Val          _U_(0x0)   /**< \brief (IISC_IDR) No effect */
+#define   IISC_IDR_TXRDY_ON_Val           _U_(0x1)   /**< \brief (IISC_IDR) Disables the corresponding interrupt */
 #define IISC_IDR_TXRDY_OFF          (IISC_IDR_TXRDY_OFF_Val        << IISC_IDR_TXRDY_Pos)
 #define IISC_IDR_TXRDY_ON           (IISC_IDR_TXRDY_ON_Val         << IISC_IDR_TXRDY_Pos)
 #define IISC_IDR_TXUR_Pos           6            /**< \brief (IISC_IDR) Transmit Underrun Interrupt Disable */
-#define IISC_IDR_TXUR               (_U(0x1) << IISC_IDR_TXUR_Pos)
-#define   IISC_IDR_TXUR_OFF_Val           _U(0x0)   /**< \brief (IISC_IDR) No effect */
-#define   IISC_IDR_TXUR_ON_Val            _U(0x1)   /**< \brief (IISC_IDR) Disables the corresponding interrupt */
+#define IISC_IDR_TXUR               (_U_(0x1) << IISC_IDR_TXUR_Pos)
+#define   IISC_IDR_TXUR_OFF_Val           _U_(0x0)   /**< \brief (IISC_IDR) No effect */
+#define   IISC_IDR_TXUR_ON_Val            _U_(0x1)   /**< \brief (IISC_IDR) Disables the corresponding interrupt */
 #define IISC_IDR_TXUR_OFF           (IISC_IDR_TXUR_OFF_Val         << IISC_IDR_TXUR_Pos)
 #define IISC_IDR_TXUR_ON            (IISC_IDR_TXUR_ON_Val          << IISC_IDR_TXUR_Pos)
-#define IISC_IDR_MASK               _U(0x00000066) /**< \brief (IISC_IDR) MASK Register */
+#define IISC_IDR_MASK               _U_(0x00000066) /**< \brief (IISC_IDR) MASK Register */
 
 /* -------- IISC_IMR : (IISC Offset: 0x1C) (R/  32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -486,33 +486,33 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define IISC_IMR_OFFSET             0x1C         /**< \brief (IISC_IMR offset) Interrupt Mask Register */
-#define IISC_IMR_RESETVALUE         _U(0x00000000); /**< \brief (IISC_IMR reset_value) Interrupt Mask Register */
+#define IISC_IMR_RESETVALUE         _U_(0x00000000); /**< \brief (IISC_IMR reset_value) Interrupt Mask Register */
 
 #define IISC_IMR_RXRDY_Pos          1            /**< \brief (IISC_IMR) Receive Ready Interrupt Mask */
-#define IISC_IMR_RXRDY              (_U(0x1) << IISC_IMR_RXRDY_Pos)
-#define   IISC_IMR_RXRDY_DISABLED_Val     _U(0x0)   /**< \brief (IISC_IMR) The corresponding interrupt is disabled */
-#define   IISC_IMR_RXRDY_ENABLED_Val      _U(0x1)   /**< \brief (IISC_IMR) The corresponding interrupt is enabled */
+#define IISC_IMR_RXRDY              (_U_(0x1) << IISC_IMR_RXRDY_Pos)
+#define   IISC_IMR_RXRDY_DISABLED_Val     _U_(0x0)   /**< \brief (IISC_IMR) The corresponding interrupt is disabled */
+#define   IISC_IMR_RXRDY_ENABLED_Val      _U_(0x1)   /**< \brief (IISC_IMR) The corresponding interrupt is enabled */
 #define IISC_IMR_RXRDY_DISABLED     (IISC_IMR_RXRDY_DISABLED_Val   << IISC_IMR_RXRDY_Pos)
 #define IISC_IMR_RXRDY_ENABLED      (IISC_IMR_RXRDY_ENABLED_Val    << IISC_IMR_RXRDY_Pos)
 #define IISC_IMR_RXOR_Pos           2            /**< \brief (IISC_IMR) Receive Overrun Interrupt Mask */
-#define IISC_IMR_RXOR               (_U(0x1) << IISC_IMR_RXOR_Pos)
-#define   IISC_IMR_RXOR_DISABLED_Val      _U(0x0)   /**< \brief (IISC_IMR) The corresponding interrupt is disabled */
-#define   IISC_IMR_RXOR_ENABLED_Val       _U(0x1)   /**< \brief (IISC_IMR) The corresponding interrupt is enabled */
+#define IISC_IMR_RXOR               (_U_(0x1) << IISC_IMR_RXOR_Pos)
+#define   IISC_IMR_RXOR_DISABLED_Val      _U_(0x0)   /**< \brief (IISC_IMR) The corresponding interrupt is disabled */
+#define   IISC_IMR_RXOR_ENABLED_Val       _U_(0x1)   /**< \brief (IISC_IMR) The corresponding interrupt is enabled */
 #define IISC_IMR_RXOR_DISABLED      (IISC_IMR_RXOR_DISABLED_Val    << IISC_IMR_RXOR_Pos)
 #define IISC_IMR_RXOR_ENABLED       (IISC_IMR_RXOR_ENABLED_Val     << IISC_IMR_RXOR_Pos)
 #define IISC_IMR_TXRDY_Pos          5            /**< \brief (IISC_IMR) Transmit Ready Interrupt Mask */
-#define IISC_IMR_TXRDY              (_U(0x1) << IISC_IMR_TXRDY_Pos)
-#define   IISC_IMR_TXRDY_DISABLED_Val     _U(0x0)   /**< \brief (IISC_IMR) The corresponding interrupt is disabled */
-#define   IISC_IMR_TXRDY_ENABLED_Val      _U(0x1)   /**< \brief (IISC_IMR) The corresponding interrupt is enabled */
+#define IISC_IMR_TXRDY              (_U_(0x1) << IISC_IMR_TXRDY_Pos)
+#define   IISC_IMR_TXRDY_DISABLED_Val     _U_(0x0)   /**< \brief (IISC_IMR) The corresponding interrupt is disabled */
+#define   IISC_IMR_TXRDY_ENABLED_Val      _U_(0x1)   /**< \brief (IISC_IMR) The corresponding interrupt is enabled */
 #define IISC_IMR_TXRDY_DISABLED     (IISC_IMR_TXRDY_DISABLED_Val   << IISC_IMR_TXRDY_Pos)
 #define IISC_IMR_TXRDY_ENABLED      (IISC_IMR_TXRDY_ENABLED_Val    << IISC_IMR_TXRDY_Pos)
 #define IISC_IMR_TXUR_Pos           6            /**< \brief (IISC_IMR) Transmit Underrun Interrupt Mask */
-#define IISC_IMR_TXUR               (_U(0x1) << IISC_IMR_TXUR_Pos)
-#define   IISC_IMR_TXUR_DISABLED_Val      _U(0x0)   /**< \brief (IISC_IMR) The corresponding interrupt is disabled */
-#define   IISC_IMR_TXUR_ENABLED_Val       _U(0x1)   /**< \brief (IISC_IMR) The corresponding interrupt is enabled */
+#define IISC_IMR_TXUR               (_U_(0x1) << IISC_IMR_TXUR_Pos)
+#define   IISC_IMR_TXUR_DISABLED_Val      _U_(0x0)   /**< \brief (IISC_IMR) The corresponding interrupt is disabled */
+#define   IISC_IMR_TXUR_ENABLED_Val       _U_(0x1)   /**< \brief (IISC_IMR) The corresponding interrupt is enabled */
 #define IISC_IMR_TXUR_DISABLED      (IISC_IMR_TXUR_DISABLED_Val    << IISC_IMR_TXUR_Pos)
 #define IISC_IMR_TXUR_ENABLED       (IISC_IMR_TXUR_ENABLED_Val     << IISC_IMR_TXUR_Pos)
-#define IISC_IMR_MASK               _U(0x00000066) /**< \brief (IISC_IMR) MASK Register */
+#define IISC_IMR_MASK               _U_(0x00000066) /**< \brief (IISC_IMR) MASK Register */
 
 /* -------- IISC_RHR : (IISC Offset: 0x20) (R/  32) Receive Holding Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -525,12 +525,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define IISC_RHR_OFFSET             0x20         /**< \brief (IISC_RHR offset) Receive Holding Register */
-#define IISC_RHR_RESETVALUE         _U(0x00000000); /**< \brief (IISC_RHR reset_value) Receive Holding Register */
+#define IISC_RHR_RESETVALUE         _U_(0x00000000); /**< \brief (IISC_RHR reset_value) Receive Holding Register */
 
 #define IISC_RHR_RDAT_Pos           0            /**< \brief (IISC_RHR) Receive Data */
-#define IISC_RHR_RDAT_Msk           (_U(0xFFFFFFFF) << IISC_RHR_RDAT_Pos)
+#define IISC_RHR_RDAT_Msk           (_U_(0xFFFFFFFF) << IISC_RHR_RDAT_Pos)
 #define IISC_RHR_RDAT(value)        (IISC_RHR_RDAT_Msk & ((value) << IISC_RHR_RDAT_Pos))
-#define IISC_RHR_MASK               _U(0xFFFFFFFF) /**< \brief (IISC_RHR) MASK Register */
+#define IISC_RHR_MASK               _U_(0xFFFFFFFF) /**< \brief (IISC_RHR) MASK Register */
 
 /* -------- IISC_THR : (IISC Offset: 0x24) ( /W 32) Transmit Holding Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -545,9 +545,9 @@ typedef union {
 #define IISC_THR_OFFSET             0x24         /**< \brief (IISC_THR offset) Transmit Holding Register */
 
 #define IISC_THR_TDAT_Pos           0            /**< \brief (IISC_THR) Transmit Data */
-#define IISC_THR_TDAT_Msk           (_U(0xFFFFFFFF) << IISC_THR_TDAT_Pos)
+#define IISC_THR_TDAT_Msk           (_U_(0xFFFFFFFF) << IISC_THR_TDAT_Pos)
 #define IISC_THR_TDAT(value)        (IISC_THR_TDAT_Msk & ((value) << IISC_THR_TDAT_Pos))
-#define IISC_THR_MASK               _U(0xFFFFFFFF) /**< \brief (IISC_THR) MASK Register */
+#define IISC_THR_MASK               _U_(0xFFFFFFFF) /**< \brief (IISC_THR) MASK Register */
 
 /* -------- IISC_VERSION : (IISC Offset: 0x28) (R/  32) Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -563,15 +563,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define IISC_VERSION_OFFSET         0x28         /**< \brief (IISC_VERSION offset) Version Register */
-#define IISC_VERSION_RESETVALUE     _U(0x00000100); /**< \brief (IISC_VERSION reset_value) Version Register */
+#define IISC_VERSION_RESETVALUE     _U_(0x00000100); /**< \brief (IISC_VERSION reset_value) Version Register */
 
 #define IISC_VERSION_VERSION_Pos    0            /**< \brief (IISC_VERSION) Reserved. Value subject to change. No functionality associated. This is the Atmel internal version of the macrocell. */
-#define IISC_VERSION_VERSION_Msk    (_U(0xFFF) << IISC_VERSION_VERSION_Pos)
+#define IISC_VERSION_VERSION_Msk    (_U_(0xFFF) << IISC_VERSION_VERSION_Pos)
 #define IISC_VERSION_VERSION(value) (IISC_VERSION_VERSION_Msk & ((value) << IISC_VERSION_VERSION_Pos))
 #define IISC_VERSION_VARIANT_Pos    16           /**< \brief (IISC_VERSION) Reserved. Value subject to change. No functionality associated. */
-#define IISC_VERSION_VARIANT_Msk    (_U(0xF) << IISC_VERSION_VARIANT_Pos)
+#define IISC_VERSION_VARIANT_Msk    (_U_(0xF) << IISC_VERSION_VARIANT_Pos)
 #define IISC_VERSION_VARIANT(value) (IISC_VERSION_VARIANT_Msk & ((value) << IISC_VERSION_VARIANT_Pos))
-#define IISC_VERSION_MASK           _U(0x000F0FFF) /**< \brief (IISC_VERSION) MASK Register */
+#define IISC_VERSION_MASK           _U_(0x000F0FFF) /**< \brief (IISC_VERSION) MASK Register */
 
 /* -------- IISC_PARAMETER : (IISC Offset: 0x2C) (R/  32) Parameter Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -588,16 +588,16 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define IISC_PARAMETER_OFFSET       0x2C         /**< \brief (IISC_PARAMETER offset) Parameter Register */
-#define IISC_PARAMETER_RESETVALUE   _U(0x00010000); /**< \brief (IISC_PARAMETER reset_value) Parameter Register */
+#define IISC_PARAMETER_RESETVALUE   _U_(0x00010000); /**< \brief (IISC_PARAMETER reset_value) Parameter Register */
 
 #define IISC_PARAMETER_FORMAT_Pos   7            /**< \brief (IISC_PARAMETER) Data protocol format */
-#define IISC_PARAMETER_FORMAT       (_U(0x1) << IISC_PARAMETER_FORMAT_Pos)
-#define   IISC_PARAMETER_FORMAT_I2S_Val   _U(0x0)   /**< \brief (IISC_PARAMETER) I2S format, stereo with IWS low for left channel */
+#define IISC_PARAMETER_FORMAT       (_U_(0x1) << IISC_PARAMETER_FORMAT_Pos)
+#define   IISC_PARAMETER_FORMAT_I2S_Val   _U_(0x0)   /**< \brief (IISC_PARAMETER) I2S format, stereo with IWS low for left channel */
 #define IISC_PARAMETER_FORMAT_I2S   (IISC_PARAMETER_FORMAT_I2S_Val << IISC_PARAMETER_FORMAT_Pos)
 #define IISC_PARAMETER_NBCHAN_Pos   16           /**< \brief (IISC_PARAMETER) Maximum number of channels - 1 */
-#define IISC_PARAMETER_NBCHAN_Msk   (_U(0x1F) << IISC_PARAMETER_NBCHAN_Pos)
+#define IISC_PARAMETER_NBCHAN_Msk   (_U_(0x1F) << IISC_PARAMETER_NBCHAN_Pos)
 #define IISC_PARAMETER_NBCHAN(value) (IISC_PARAMETER_NBCHAN_Msk & ((value) << IISC_PARAMETER_NBCHAN_Pos))
-#define IISC_PARAMETER_MASK         _U(0x001F0080) /**< \brief (IISC_PARAMETER) MASK Register */
+#define IISC_PARAMETER_MASK         _U_(0x001F0080) /**< \brief (IISC_PARAMETER) MASK Register */
 
 /** \brief IISC hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/lcdca.h
+++ b/asf/sam/include/sam4l/component/lcdca.h
@@ -722,63 +722,33 @@ typedef union {
 
 /** \brief LCDCA hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __O  LCDCA_CR_Type             CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
-  __IO LCDCA_CFG_Type            CFG;         /**< \brief Offset: 0x04 (R/W 32) Configuration Register */
-  __IO LCDCA_TIM_Type            TIM;         /**< \brief Offset: 0x08 (R/W 32) Timing Register */
-  __I  LCDCA_SR_Type             SR;          /**< \brief Offset: 0x0C (R/  32) Status Register */
-  __O  LCDCA_SCR_Type            SCR;         /**< \brief Offset: 0x10 ( /W 32) Status Clear Register */
-  __IO LCDCA_DRL0_Type           DRL0;        /**< \brief Offset: 0x14 (R/W 32) Data Register Low 0 */
-  __IO LCDCA_DRH0_Type           DRH0;        /**< \brief Offset: 0x18 (R/W 32) Data Register High 0 */
-  __IO LCDCA_DRL1_Type           DRL1;        /**< \brief Offset: 0x1C (R/W 32) Data Register Low 1 */
-  __IO LCDCA_DRH1_Type           DRH1;        /**< \brief Offset: 0x20 (R/W 32) Data Register High 1 */
-  __IO LCDCA_DRL2_Type           DRL2;        /**< \brief Offset: 0x24 (R/W 32) Data Register Low 2 */
-  __IO LCDCA_DRH2_Type           DRH2;        /**< \brief Offset: 0x28 (R/W 32) Data Register High 2 */
-  __IO LCDCA_DRL3_Type           DRL3;        /**< \brief Offset: 0x2C (R/W 32) Data Register Low 3 */
-  __IO LCDCA_DRH3_Type           DRH3;        /**< \brief Offset: 0x30 (R/W 32) Data Register High 3 */
-  __O  LCDCA_IADR_Type           IADR;        /**< \brief Offset: 0x34 ( /W 32) Indirect Access Data Register */
-  __IO LCDCA_BCFG_Type           BCFG;        /**< \brief Offset: 0x38 (R/W 32) Blink Configuration Register */
-  __IO LCDCA_CSRCFG_Type         CSRCFG;      /**< \brief Offset: 0x3C (R/W 32) Circular Shift Register Configuration */
-  __IO LCDCA_CMCFG_Type          CMCFG;       /**< \brief Offset: 0x40 (R/W 32) Character Mapping Configuration Register */
-  __O  LCDCA_CMDR_Type           CMDR;        /**< \brief Offset: 0x44 ( /W 32) Character Mapping Data Register */
-  __IO LCDCA_ACMCFG_Type         ACMCFG;      /**< \brief Offset: 0x48 (R/W 32) Automated Character Mapping Configuration Register */
-  __O  LCDCA_ACMDR_Type          ACMDR;       /**< \brief Offset: 0x4C ( /W 32) Automated Character Mapping Data Register */
-  __IO LCDCA_ABMCFG_Type         ABMCFG;      /**< \brief Offset: 0x50 (R/W 32) Automated Bit Mapping Configuration Register */
-  __O  LCDCA_ABMDR_Type          ABMDR;       /**< \brief Offset: 0x54 ( /W 32) Automated Bit Mapping Data Register */
-  __O  LCDCA_IER_Type            IER;         /**< \brief Offset: 0x58 ( /W 32) Interrupt Enable Register */
-  __O  LCDCA_IDR_Type            IDR;         /**< \brief Offset: 0x5C ( /W 32) Interrupt Disable Register */
-  __I  LCDCA_IMR_Type            IMR;         /**< \brief Offset: 0x60 (R/  32) Interrupt Mask Register */
-  __I  LCDCA_VERSION_Type        VERSION;     /**< \brief Offset: 0x64 (R/  32) Version Register */
- } bf;
- struct {
-  WoReg   LCDCA_CR;           /**< \brief (LCDCA Offset: 0x00) Control Register */
-  RwReg   LCDCA_CFG;          /**< \brief (LCDCA Offset: 0x04) Configuration Register */
-  RwReg   LCDCA_TIM;          /**< \brief (LCDCA Offset: 0x08) Timing Register */
-  RoReg   LCDCA_SR;           /**< \brief (LCDCA Offset: 0x0C) Status Register */
-  WoReg   LCDCA_SCR;          /**< \brief (LCDCA Offset: 0x10) Status Clear Register */
-  RwReg   LCDCA_DRL0;         /**< \brief (LCDCA Offset: 0x14) Data Register Low 0 */
-  RwReg   LCDCA_DRH0;         /**< \brief (LCDCA Offset: 0x18) Data Register High 0 */
-  RwReg   LCDCA_DRL1;         /**< \brief (LCDCA Offset: 0x1C) Data Register Low 1 */
-  RwReg   LCDCA_DRH1;         /**< \brief (LCDCA Offset: 0x20) Data Register High 1 */
-  RwReg   LCDCA_DRL2;         /**< \brief (LCDCA Offset: 0x24) Data Register Low 2 */
-  RwReg   LCDCA_DRH2;         /**< \brief (LCDCA Offset: 0x28) Data Register High 2 */
-  RwReg   LCDCA_DRL3;         /**< \brief (LCDCA Offset: 0x2C) Data Register Low 3 */
-  RwReg   LCDCA_DRH3;         /**< \brief (LCDCA Offset: 0x30) Data Register High 3 */
-  WoReg   LCDCA_IADR;         /**< \brief (LCDCA Offset: 0x34) Indirect Access Data Register */
-  RwReg   LCDCA_BCFG;         /**< \brief (LCDCA Offset: 0x38) Blink Configuration Register */
-  RwReg   LCDCA_CSRCFG;       /**< \brief (LCDCA Offset: 0x3C) Circular Shift Register Configuration */
-  RwReg   LCDCA_CMCFG;        /**< \brief (LCDCA Offset: 0x40) Character Mapping Configuration Register */
-  WoReg   LCDCA_CMDR;         /**< \brief (LCDCA Offset: 0x44) Character Mapping Data Register */
-  RwReg   LCDCA_ACMCFG;       /**< \brief (LCDCA Offset: 0x48) Automated Character Mapping Configuration Register */
-  WoReg   LCDCA_ACMDR;        /**< \brief (LCDCA Offset: 0x4C) Automated Character Mapping Data Register */
-  RwReg   LCDCA_ABMCFG;       /**< \brief (LCDCA Offset: 0x50) Automated Bit Mapping Configuration Register */
-  WoReg   LCDCA_ABMDR;        /**< \brief (LCDCA Offset: 0x54) Automated Bit Mapping Data Register */
-  WoReg   LCDCA_IER;          /**< \brief (LCDCA Offset: 0x58) Interrupt Enable Register */
-  WoReg   LCDCA_IDR;          /**< \brief (LCDCA Offset: 0x5C) Interrupt Disable Register */
-  RoReg   LCDCA_IMR;          /**< \brief (LCDCA Offset: 0x60) Interrupt Mask Register */
-  RoReg   LCDCA_VERSION;      /**< \brief (LCDCA Offset: 0x64) Version Register */
- } reg;
+typedef struct {
+  __O  uint32_t CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
+  __IO uint32_t CFG;         /**< \brief Offset: 0x04 (R/W 32) Configuration Register */
+  __IO uint32_t TIM;         /**< \brief Offset: 0x08 (R/W 32) Timing Register */
+  __I  uint32_t SR;          /**< \brief Offset: 0x0C (R/  32) Status Register */
+  __O  uint32_t SCR;         /**< \brief Offset: 0x10 ( /W 32) Status Clear Register */
+  __IO uint32_t DRL0;        /**< \brief Offset: 0x14 (R/W 32) Data Register Low 0 */
+  __IO uint32_t DRH0;        /**< \brief Offset: 0x18 (R/W 32) Data Register High 0 */
+  __IO uint32_t DRL1;        /**< \brief Offset: 0x1C (R/W 32) Data Register Low 1 */
+  __IO uint32_t DRH1;        /**< \brief Offset: 0x20 (R/W 32) Data Register High 1 */
+  __IO uint32_t DRL2;        /**< \brief Offset: 0x24 (R/W 32) Data Register Low 2 */
+  __IO uint32_t DRH2;        /**< \brief Offset: 0x28 (R/W 32) Data Register High 2 */
+  __IO uint32_t DRL3;        /**< \brief Offset: 0x2C (R/W 32) Data Register Low 3 */
+  __IO uint32_t DRH3;        /**< \brief Offset: 0x30 (R/W 32) Data Register High 3 */
+  __O  uint32_t IADR;        /**< \brief Offset: 0x34 ( /W 32) Indirect Access Data Register */
+  __IO uint32_t BCFG;        /**< \brief Offset: 0x38 (R/W 32) Blink Configuration Register */
+  __IO uint32_t CSRCFG;      /**< \brief Offset: 0x3C (R/W 32) Circular Shift Register Configuration */
+  __IO uint32_t CMCFG;       /**< \brief Offset: 0x40 (R/W 32) Character Mapping Configuration Register */
+  __O  uint32_t CMDR;        /**< \brief Offset: 0x44 ( /W 32) Character Mapping Data Register */
+  __IO uint32_t ACMCFG;      /**< \brief Offset: 0x48 (R/W 32) Automated Character Mapping Configuration Register */
+  __O  uint32_t ACMDR;       /**< \brief Offset: 0x4C ( /W 32) Automated Character Mapping Data Register */
+  __IO uint32_t ABMCFG;      /**< \brief Offset: 0x50 (R/W 32) Automated Bit Mapping Configuration Register */
+  __O  uint32_t ABMDR;       /**< \brief Offset: 0x54 ( /W 32) Automated Bit Mapping Data Register */
+  __O  uint32_t IER;         /**< \brief Offset: 0x58 ( /W 32) Interrupt Enable Register */
+  __O  uint32_t IDR;         /**< \brief Offset: 0x5C ( /W 32) Interrupt Disable Register */
+  __I  uint32_t IMR;         /**< \brief Offset: 0x60 (R/  32) Interrupt Mask Register */
+  __I  uint32_t VERSION;     /**< \brief Offset: 0x64 (R/  32) Version Register */
 } Lcdca;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/lcdca.h
+++ b/asf/sam/include/sam4l/component/lcdca.h
@@ -64,39 +64,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define LCDCA_CR_OFFSET             0x00         /**< \brief (LCDCA_CR offset) Control Register */
-#define LCDCA_CR_RESETVALUE         _U(0x00000000); /**< \brief (LCDCA_CR reset_value) Control Register */
+#define LCDCA_CR_RESETVALUE         _U_(0x00000000); /**< \brief (LCDCA_CR reset_value) Control Register */
 
 #define LCDCA_CR_DIS_Pos            0            /**< \brief (LCDCA_CR) Disable */
-#define LCDCA_CR_DIS                (_U(0x1) << LCDCA_CR_DIS_Pos)
+#define LCDCA_CR_DIS                (_U_(0x1) << LCDCA_CR_DIS_Pos)
 #define LCDCA_CR_EN_Pos             1            /**< \brief (LCDCA_CR) Enable */
-#define LCDCA_CR_EN                 (_U(0x1) << LCDCA_CR_EN_Pos)
+#define LCDCA_CR_EN                 (_U_(0x1) << LCDCA_CR_EN_Pos)
 #define LCDCA_CR_FC0DIS_Pos         2            /**< \brief (LCDCA_CR) Frame Counter 0 Disable */
-#define LCDCA_CR_FC0DIS             (_U(0x1) << LCDCA_CR_FC0DIS_Pos)
+#define LCDCA_CR_FC0DIS             (_U_(0x1) << LCDCA_CR_FC0DIS_Pos)
 #define LCDCA_CR_FC0EN_Pos          3            /**< \brief (LCDCA_CR) Frame Counter 0 Enable */
-#define LCDCA_CR_FC0EN              (_U(0x1) << LCDCA_CR_FC0EN_Pos)
+#define LCDCA_CR_FC0EN              (_U_(0x1) << LCDCA_CR_FC0EN_Pos)
 #define LCDCA_CR_FC1DIS_Pos         4            /**< \brief (LCDCA_CR) Frame Counter 1 Disable */
-#define LCDCA_CR_FC1DIS             (_U(0x1) << LCDCA_CR_FC1DIS_Pos)
+#define LCDCA_CR_FC1DIS             (_U_(0x1) << LCDCA_CR_FC1DIS_Pos)
 #define LCDCA_CR_FC1EN_Pos          5            /**< \brief (LCDCA_CR) Frame Counter 1 Enable */
-#define LCDCA_CR_FC1EN              (_U(0x1) << LCDCA_CR_FC1EN_Pos)
+#define LCDCA_CR_FC1EN              (_U_(0x1) << LCDCA_CR_FC1EN_Pos)
 #define LCDCA_CR_FC2DIS_Pos         6            /**< \brief (LCDCA_CR) Frame Counter 2 Disable */
-#define LCDCA_CR_FC2DIS             (_U(0x1) << LCDCA_CR_FC2DIS_Pos)
+#define LCDCA_CR_FC2DIS             (_U_(0x1) << LCDCA_CR_FC2DIS_Pos)
 #define LCDCA_CR_FC2EN_Pos          7            /**< \brief (LCDCA_CR) Frame Counter 2 Enable */
-#define LCDCA_CR_FC2EN              (_U(0x1) << LCDCA_CR_FC2EN_Pos)
+#define LCDCA_CR_FC2EN              (_U_(0x1) << LCDCA_CR_FC2EN_Pos)
 #define LCDCA_CR_CDM_Pos            8            /**< \brief (LCDCA_CR) Clear Display Memory */
-#define LCDCA_CR_CDM                (_U(0x1) << LCDCA_CR_CDM_Pos)
+#define LCDCA_CR_CDM                (_U_(0x1) << LCDCA_CR_CDM_Pos)
 #define LCDCA_CR_WDIS_Pos           9            /**< \brief (LCDCA_CR) Wake up Disable */
-#define LCDCA_CR_WDIS               (_U(0x1) << LCDCA_CR_WDIS_Pos)
+#define LCDCA_CR_WDIS               (_U_(0x1) << LCDCA_CR_WDIS_Pos)
 #define LCDCA_CR_WEN_Pos            10           /**< \brief (LCDCA_CR) Wake up Enable */
-#define LCDCA_CR_WEN                (_U(0x1) << LCDCA_CR_WEN_Pos)
+#define LCDCA_CR_WEN                (_U_(0x1) << LCDCA_CR_WEN_Pos)
 #define LCDCA_CR_BSTART_Pos         11           /**< \brief (LCDCA_CR) Blinking Start */
-#define LCDCA_CR_BSTART             (_U(0x1) << LCDCA_CR_BSTART_Pos)
+#define LCDCA_CR_BSTART             (_U_(0x1) << LCDCA_CR_BSTART_Pos)
 #define LCDCA_CR_BSTOP_Pos          12           /**< \brief (LCDCA_CR) Blinking Stop */
-#define LCDCA_CR_BSTOP              (_U(0x1) << LCDCA_CR_BSTOP_Pos)
+#define LCDCA_CR_BSTOP              (_U_(0x1) << LCDCA_CR_BSTOP_Pos)
 #define LCDCA_CR_CSTART_Pos         13           /**< \brief (LCDCA_CR) Circular Shift Start */
-#define LCDCA_CR_CSTART             (_U(0x1) << LCDCA_CR_CSTART_Pos)
+#define LCDCA_CR_CSTART             (_U_(0x1) << LCDCA_CR_CSTART_Pos)
 #define LCDCA_CR_CSTOP_Pos          14           /**< \brief (LCDCA_CR) Circular Shift Stop */
-#define LCDCA_CR_CSTOP              (_U(0x1) << LCDCA_CR_CSTOP_Pos)
-#define LCDCA_CR_MASK               _U(0x00007FFF) /**< \brief (LCDCA_CR) MASK Register */
+#define LCDCA_CR_CSTOP              (_U_(0x1) << LCDCA_CR_CSTOP_Pos)
+#define LCDCA_CR_MASK               _U_(0x00007FFF) /**< \brief (LCDCA_CR) MASK Register */
 
 /* -------- LCDCA_CFG : (LCDCA Offset: 0x04) (R/W 32) Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -119,26 +119,26 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define LCDCA_CFG_OFFSET            0x04         /**< \brief (LCDCA_CFG offset) Configuration Register */
-#define LCDCA_CFG_RESETVALUE        _U(0x00000000); /**< \brief (LCDCA_CFG reset_value) Configuration Register */
+#define LCDCA_CFG_RESETVALUE        _U_(0x00000000); /**< \brief (LCDCA_CFG reset_value) Configuration Register */
 
 #define LCDCA_CFG_XBIAS_Pos         0            /**< \brief (LCDCA_CFG) External Bias Generation */
-#define LCDCA_CFG_XBIAS             (_U(0x1) << LCDCA_CFG_XBIAS_Pos)
+#define LCDCA_CFG_XBIAS             (_U_(0x1) << LCDCA_CFG_XBIAS_Pos)
 #define LCDCA_CFG_WMOD_Pos          1            /**< \brief (LCDCA_CFG) Waveform Mode */
-#define LCDCA_CFG_WMOD              (_U(0x1) << LCDCA_CFG_WMOD_Pos)
+#define LCDCA_CFG_WMOD              (_U_(0x1) << LCDCA_CFG_WMOD_Pos)
 #define LCDCA_CFG_BLANK_Pos         2            /**< \brief (LCDCA_CFG) Blank LCD */
-#define LCDCA_CFG_BLANK             (_U(0x1) << LCDCA_CFG_BLANK_Pos)
+#define LCDCA_CFG_BLANK             (_U_(0x1) << LCDCA_CFG_BLANK_Pos)
 #define LCDCA_CFG_LOCK_Pos          3            /**< \brief (LCDCA_CFG) Lock */
-#define LCDCA_CFG_LOCK              (_U(0x1) << LCDCA_CFG_LOCK_Pos)
+#define LCDCA_CFG_LOCK              (_U_(0x1) << LCDCA_CFG_LOCK_Pos)
 #define LCDCA_CFG_DUTY_Pos          8            /**< \brief (LCDCA_CFG) Duty Select */
-#define LCDCA_CFG_DUTY_Msk          (_U(0x3) << LCDCA_CFG_DUTY_Pos)
+#define LCDCA_CFG_DUTY_Msk          (_U_(0x3) << LCDCA_CFG_DUTY_Pos)
 #define LCDCA_CFG_DUTY(value)       (LCDCA_CFG_DUTY_Msk & ((value) << LCDCA_CFG_DUTY_Pos))
 #define LCDCA_CFG_FCST_Pos          16           /**< \brief (LCDCA_CFG) Fine Contrast */
-#define LCDCA_CFG_FCST_Msk          (_U(0x3F) << LCDCA_CFG_FCST_Pos)
+#define LCDCA_CFG_FCST_Msk          (_U_(0x3F) << LCDCA_CFG_FCST_Pos)
 #define LCDCA_CFG_FCST(value)       (LCDCA_CFG_FCST_Msk & ((value) << LCDCA_CFG_FCST_Pos))
 #define LCDCA_CFG_NSU_Pos           24           /**< \brief (LCDCA_CFG) Number of Segment Terminals in Use */
-#define LCDCA_CFG_NSU_Msk           (_U(0x3F) << LCDCA_CFG_NSU_Pos)
+#define LCDCA_CFG_NSU_Msk           (_U_(0x3F) << LCDCA_CFG_NSU_Pos)
 #define LCDCA_CFG_NSU(value)        (LCDCA_CFG_NSU_Msk & ((value) << LCDCA_CFG_NSU_Pos))
-#define LCDCA_CFG_MASK              _U(0x3F3F030F) /**< \brief (LCDCA_CFG) MASK Register */
+#define LCDCA_CFG_MASK              _U_(0x3F3F030F) /**< \brief (LCDCA_CFG) MASK Register */
 
 /* -------- LCDCA_TIM : (LCDCA Offset: 0x08) (R/W 32) Timing Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -160,25 +160,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define LCDCA_TIM_OFFSET            0x08         /**< \brief (LCDCA_TIM offset) Timing Register */
-#define LCDCA_TIM_RESETVALUE        _U(0x00000000); /**< \brief (LCDCA_TIM reset_value) Timing Register */
+#define LCDCA_TIM_RESETVALUE        _U_(0x00000000); /**< \brief (LCDCA_TIM reset_value) Timing Register */
 
 #define LCDCA_TIM_PRESC_Pos         0            /**< \brief (LCDCA_TIM) LCD Prescaler Select */
-#define LCDCA_TIM_PRESC             (_U(0x1) << LCDCA_TIM_PRESC_Pos)
+#define LCDCA_TIM_PRESC             (_U_(0x1) << LCDCA_TIM_PRESC_Pos)
 #define LCDCA_TIM_CLKDIV_Pos        1            /**< \brief (LCDCA_TIM) LCD Clock Division */
-#define LCDCA_TIM_CLKDIV_Msk        (_U(0x7) << LCDCA_TIM_CLKDIV_Pos)
+#define LCDCA_TIM_CLKDIV_Msk        (_U_(0x7) << LCDCA_TIM_CLKDIV_Pos)
 #define LCDCA_TIM_CLKDIV(value)     (LCDCA_TIM_CLKDIV_Msk & ((value) << LCDCA_TIM_CLKDIV_Pos))
 #define LCDCA_TIM_FC0_Pos           8            /**< \brief (LCDCA_TIM) Frame Counter 0 */
-#define LCDCA_TIM_FC0_Msk           (_U(0x1F) << LCDCA_TIM_FC0_Pos)
+#define LCDCA_TIM_FC0_Msk           (_U_(0x1F) << LCDCA_TIM_FC0_Pos)
 #define LCDCA_TIM_FC0(value)        (LCDCA_TIM_FC0_Msk & ((value) << LCDCA_TIM_FC0_Pos))
 #define LCDCA_TIM_FC0PB_Pos         13           /**< \brief (LCDCA_TIM) Frame Counter 0 Prescaler Bypass */
-#define LCDCA_TIM_FC0PB             (_U(0x1) << LCDCA_TIM_FC0PB_Pos)
+#define LCDCA_TIM_FC0PB             (_U_(0x1) << LCDCA_TIM_FC0PB_Pos)
 #define LCDCA_TIM_FC1_Pos           16           /**< \brief (LCDCA_TIM) Frame Counter 1 */
-#define LCDCA_TIM_FC1_Msk           (_U(0x1F) << LCDCA_TIM_FC1_Pos)
+#define LCDCA_TIM_FC1_Msk           (_U_(0x1F) << LCDCA_TIM_FC1_Pos)
 #define LCDCA_TIM_FC1(value)        (LCDCA_TIM_FC1_Msk & ((value) << LCDCA_TIM_FC1_Pos))
 #define LCDCA_TIM_FC2_Pos           24           /**< \brief (LCDCA_TIM) Frame Counter 2 */
-#define LCDCA_TIM_FC2_Msk           (_U(0x1F) << LCDCA_TIM_FC2_Pos)
+#define LCDCA_TIM_FC2_Msk           (_U_(0x1F) << LCDCA_TIM_FC2_Pos)
 #define LCDCA_TIM_FC2(value)        (LCDCA_TIM_FC2_Msk & ((value) << LCDCA_TIM_FC2_Pos))
-#define LCDCA_TIM_MASK              _U(0x1F1F3F0F) /**< \brief (LCDCA_TIM) MASK Register */
+#define LCDCA_TIM_MASK              _U_(0x1F1F3F0F) /**< \brief (LCDCA_TIM) MASK Register */
 
 /* -------- LCDCA_SR : (LCDCA Offset: 0x0C) (R/  32) Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -200,27 +200,27 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define LCDCA_SR_OFFSET             0x0C         /**< \brief (LCDCA_SR offset) Status Register */
-#define LCDCA_SR_RESETVALUE         _U(0x00000000); /**< \brief (LCDCA_SR reset_value) Status Register */
+#define LCDCA_SR_RESETVALUE         _U_(0x00000000); /**< \brief (LCDCA_SR reset_value) Status Register */
 
 #define LCDCA_SR_FC0R_Pos           0            /**< \brief (LCDCA_SR) Frame Counter 0 Rollover */
-#define LCDCA_SR_FC0R               (_U(0x1) << LCDCA_SR_FC0R_Pos)
+#define LCDCA_SR_FC0R               (_U_(0x1) << LCDCA_SR_FC0R_Pos)
 #define LCDCA_SR_FC0S_Pos           1            /**< \brief (LCDCA_SR) Frame Counter 0 Status */
-#define LCDCA_SR_FC0S               (_U(0x1) << LCDCA_SR_FC0S_Pos)
+#define LCDCA_SR_FC0S               (_U_(0x1) << LCDCA_SR_FC0S_Pos)
 #define LCDCA_SR_FC1S_Pos           2            /**< \brief (LCDCA_SR) Frame Counter 1 Status */
-#define LCDCA_SR_FC1S               (_U(0x1) << LCDCA_SR_FC1S_Pos)
+#define LCDCA_SR_FC1S               (_U_(0x1) << LCDCA_SR_FC1S_Pos)
 #define LCDCA_SR_FC2S_Pos           3            /**< \brief (LCDCA_SR) Frame Counter 2 Status */
-#define LCDCA_SR_FC2S               (_U(0x1) << LCDCA_SR_FC2S_Pos)
+#define LCDCA_SR_FC2S               (_U_(0x1) << LCDCA_SR_FC2S_Pos)
 #define LCDCA_SR_EN_Pos             4            /**< \brief (LCDCA_SR) LCDCA Status */
-#define LCDCA_SR_EN                 (_U(0x1) << LCDCA_SR_EN_Pos)
+#define LCDCA_SR_EN                 (_U_(0x1) << LCDCA_SR_EN_Pos)
 #define LCDCA_SR_WEN_Pos            5            /**< \brief (LCDCA_SR) Wake up Status */
-#define LCDCA_SR_WEN                (_U(0x1) << LCDCA_SR_WEN_Pos)
+#define LCDCA_SR_WEN                (_U_(0x1) << LCDCA_SR_WEN_Pos)
 #define LCDCA_SR_BLKS_Pos           6            /**< \brief (LCDCA_SR) Blink Status */
-#define LCDCA_SR_BLKS               (_U(0x1) << LCDCA_SR_BLKS_Pos)
+#define LCDCA_SR_BLKS               (_U_(0x1) << LCDCA_SR_BLKS_Pos)
 #define LCDCA_SR_CSRS_Pos           7            /**< \brief (LCDCA_SR) Circular Shift Register Status */
-#define LCDCA_SR_CSRS               (_U(0x1) << LCDCA_SR_CSRS_Pos)
+#define LCDCA_SR_CSRS               (_U_(0x1) << LCDCA_SR_CSRS_Pos)
 #define LCDCA_SR_CPS_Pos            8            /**< \brief (LCDCA_SR) Charge Pump Status */
-#define LCDCA_SR_CPS                (_U(0x1) << LCDCA_SR_CPS_Pos)
-#define LCDCA_SR_MASK               _U(0x000001FF) /**< \brief (LCDCA_SR) MASK Register */
+#define LCDCA_SR_CPS                (_U_(0x1) << LCDCA_SR_CPS_Pos)
+#define LCDCA_SR_MASK               _U_(0x000001FF) /**< \brief (LCDCA_SR) MASK Register */
 
 /* -------- LCDCA_SCR : (LCDCA Offset: 0x10) ( /W 32) Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -234,11 +234,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define LCDCA_SCR_OFFSET            0x10         /**< \brief (LCDCA_SCR offset) Status Clear Register */
-#define LCDCA_SCR_RESETVALUE        _U(0x00000000); /**< \brief (LCDCA_SCR reset_value) Status Clear Register */
+#define LCDCA_SCR_RESETVALUE        _U_(0x00000000); /**< \brief (LCDCA_SCR reset_value) Status Clear Register */
 
 #define LCDCA_SCR_FC0R_Pos          0            /**< \brief (LCDCA_SCR) Frame Counter 0 Rollover */
-#define LCDCA_SCR_FC0R              (_U(0x1) << LCDCA_SCR_FC0R_Pos)
-#define LCDCA_SCR_MASK              _U(0x00000001) /**< \brief (LCDCA_SCR) MASK Register */
+#define LCDCA_SCR_FC0R              (_U_(0x1) << LCDCA_SCR_FC0R_Pos)
+#define LCDCA_SCR_MASK              _U_(0x00000001) /**< \brief (LCDCA_SCR) MASK Register */
 
 /* -------- LCDCA_DRL0 : (LCDCA Offset: 0x14) (R/W 32) Data Register Low 0 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -251,12 +251,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define LCDCA_DRL0_OFFSET           0x14         /**< \brief (LCDCA_DRL0 offset) Data Register Low 0 */
-#define LCDCA_DRL0_RESETVALUE       _U(0x00000000); /**< \brief (LCDCA_DRL0 reset_value) Data Register Low 0 */
+#define LCDCA_DRL0_RESETVALUE       _U_(0x00000000); /**< \brief (LCDCA_DRL0 reset_value) Data Register Low 0 */
 
 #define LCDCA_DRL0_DATA_Pos         0            /**< \brief (LCDCA_DRL0) Segments Value */
-#define LCDCA_DRL0_DATA_Msk         (_U(0xFFFFFFFF) << LCDCA_DRL0_DATA_Pos)
+#define LCDCA_DRL0_DATA_Msk         (_U_(0xFFFFFFFF) << LCDCA_DRL0_DATA_Pos)
 #define LCDCA_DRL0_DATA(value)      (LCDCA_DRL0_DATA_Msk & ((value) << LCDCA_DRL0_DATA_Pos))
-#define LCDCA_DRL0_MASK             _U(0xFFFFFFFF) /**< \brief (LCDCA_DRL0) MASK Register */
+#define LCDCA_DRL0_MASK             _U_(0xFFFFFFFF) /**< \brief (LCDCA_DRL0) MASK Register */
 
 /* -------- LCDCA_DRH0 : (LCDCA Offset: 0x18) (R/W 32) Data Register High 0 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -270,12 +270,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define LCDCA_DRH0_OFFSET           0x18         /**< \brief (LCDCA_DRH0 offset) Data Register High 0 */
-#define LCDCA_DRH0_RESETVALUE       _U(0x00000000); /**< \brief (LCDCA_DRH0 reset_value) Data Register High 0 */
+#define LCDCA_DRH0_RESETVALUE       _U_(0x00000000); /**< \brief (LCDCA_DRH0 reset_value) Data Register High 0 */
 
 #define LCDCA_DRH0_DATA_Pos         0            /**< \brief (LCDCA_DRH0) Segments Value */
-#define LCDCA_DRH0_DATA_Msk         (_U(0xFF) << LCDCA_DRH0_DATA_Pos)
+#define LCDCA_DRH0_DATA_Msk         (_U_(0xFF) << LCDCA_DRH0_DATA_Pos)
 #define LCDCA_DRH0_DATA(value)      (LCDCA_DRH0_DATA_Msk & ((value) << LCDCA_DRH0_DATA_Pos))
-#define LCDCA_DRH0_MASK             _U(0x000000FF) /**< \brief (LCDCA_DRH0) MASK Register */
+#define LCDCA_DRH0_MASK             _U_(0x000000FF) /**< \brief (LCDCA_DRH0) MASK Register */
 
 /* -------- LCDCA_DRL1 : (LCDCA Offset: 0x1C) (R/W 32) Data Register Low 1 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -288,12 +288,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define LCDCA_DRL1_OFFSET           0x1C         /**< \brief (LCDCA_DRL1 offset) Data Register Low 1 */
-#define LCDCA_DRL1_RESETVALUE       _U(0x00000000); /**< \brief (LCDCA_DRL1 reset_value) Data Register Low 1 */
+#define LCDCA_DRL1_RESETVALUE       _U_(0x00000000); /**< \brief (LCDCA_DRL1 reset_value) Data Register Low 1 */
 
 #define LCDCA_DRL1_DATA_Pos         0            /**< \brief (LCDCA_DRL1) Segments Value */
-#define LCDCA_DRL1_DATA_Msk         (_U(0xFFFFFFFF) << LCDCA_DRL1_DATA_Pos)
+#define LCDCA_DRL1_DATA_Msk         (_U_(0xFFFFFFFF) << LCDCA_DRL1_DATA_Pos)
 #define LCDCA_DRL1_DATA(value)      (LCDCA_DRL1_DATA_Msk & ((value) << LCDCA_DRL1_DATA_Pos))
-#define LCDCA_DRL1_MASK             _U(0xFFFFFFFF) /**< \brief (LCDCA_DRL1) MASK Register */
+#define LCDCA_DRL1_MASK             _U_(0xFFFFFFFF) /**< \brief (LCDCA_DRL1) MASK Register */
 
 /* -------- LCDCA_DRH1 : (LCDCA Offset: 0x20) (R/W 32) Data Register High 1 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -307,12 +307,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define LCDCA_DRH1_OFFSET           0x20         /**< \brief (LCDCA_DRH1 offset) Data Register High 1 */
-#define LCDCA_DRH1_RESETVALUE       _U(0x00000000); /**< \brief (LCDCA_DRH1 reset_value) Data Register High 1 */
+#define LCDCA_DRH1_RESETVALUE       _U_(0x00000000); /**< \brief (LCDCA_DRH1 reset_value) Data Register High 1 */
 
 #define LCDCA_DRH1_DATA_Pos         0            /**< \brief (LCDCA_DRH1) Segments Value */
-#define LCDCA_DRH1_DATA_Msk         (_U(0xFF) << LCDCA_DRH1_DATA_Pos)
+#define LCDCA_DRH1_DATA_Msk         (_U_(0xFF) << LCDCA_DRH1_DATA_Pos)
 #define LCDCA_DRH1_DATA(value)      (LCDCA_DRH1_DATA_Msk & ((value) << LCDCA_DRH1_DATA_Pos))
-#define LCDCA_DRH1_MASK             _U(0x000000FF) /**< \brief (LCDCA_DRH1) MASK Register */
+#define LCDCA_DRH1_MASK             _U_(0x000000FF) /**< \brief (LCDCA_DRH1) MASK Register */
 
 /* -------- LCDCA_DRL2 : (LCDCA Offset: 0x24) (R/W 32) Data Register Low 2 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -325,12 +325,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define LCDCA_DRL2_OFFSET           0x24         /**< \brief (LCDCA_DRL2 offset) Data Register Low 2 */
-#define LCDCA_DRL2_RESETVALUE       _U(0x00000000); /**< \brief (LCDCA_DRL2 reset_value) Data Register Low 2 */
+#define LCDCA_DRL2_RESETVALUE       _U_(0x00000000); /**< \brief (LCDCA_DRL2 reset_value) Data Register Low 2 */
 
 #define LCDCA_DRL2_DATA_Pos         0            /**< \brief (LCDCA_DRL2) Segments Value */
-#define LCDCA_DRL2_DATA_Msk         (_U(0xFFFFFFFF) << LCDCA_DRL2_DATA_Pos)
+#define LCDCA_DRL2_DATA_Msk         (_U_(0xFFFFFFFF) << LCDCA_DRL2_DATA_Pos)
 #define LCDCA_DRL2_DATA(value)      (LCDCA_DRL2_DATA_Msk & ((value) << LCDCA_DRL2_DATA_Pos))
-#define LCDCA_DRL2_MASK             _U(0xFFFFFFFF) /**< \brief (LCDCA_DRL2) MASK Register */
+#define LCDCA_DRL2_MASK             _U_(0xFFFFFFFF) /**< \brief (LCDCA_DRL2) MASK Register */
 
 /* -------- LCDCA_DRH2 : (LCDCA Offset: 0x28) (R/W 32) Data Register High 2 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -344,12 +344,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define LCDCA_DRH2_OFFSET           0x28         /**< \brief (LCDCA_DRH2 offset) Data Register High 2 */
-#define LCDCA_DRH2_RESETVALUE       _U(0x00000000); /**< \brief (LCDCA_DRH2 reset_value) Data Register High 2 */
+#define LCDCA_DRH2_RESETVALUE       _U_(0x00000000); /**< \brief (LCDCA_DRH2 reset_value) Data Register High 2 */
 
 #define LCDCA_DRH2_DATA_Pos         0            /**< \brief (LCDCA_DRH2) Segments Value */
-#define LCDCA_DRH2_DATA_Msk         (_U(0xFF) << LCDCA_DRH2_DATA_Pos)
+#define LCDCA_DRH2_DATA_Msk         (_U_(0xFF) << LCDCA_DRH2_DATA_Pos)
 #define LCDCA_DRH2_DATA(value)      (LCDCA_DRH2_DATA_Msk & ((value) << LCDCA_DRH2_DATA_Pos))
-#define LCDCA_DRH2_MASK             _U(0x000000FF) /**< \brief (LCDCA_DRH2) MASK Register */
+#define LCDCA_DRH2_MASK             _U_(0x000000FF) /**< \brief (LCDCA_DRH2) MASK Register */
 
 /* -------- LCDCA_DRL3 : (LCDCA Offset: 0x2C) (R/W 32) Data Register Low 3 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -362,12 +362,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define LCDCA_DRL3_OFFSET           0x2C         /**< \brief (LCDCA_DRL3 offset) Data Register Low 3 */
-#define LCDCA_DRL3_RESETVALUE       _U(0x00000000); /**< \brief (LCDCA_DRL3 reset_value) Data Register Low 3 */
+#define LCDCA_DRL3_RESETVALUE       _U_(0x00000000); /**< \brief (LCDCA_DRL3 reset_value) Data Register Low 3 */
 
 #define LCDCA_DRL3_DATA_Pos         0            /**< \brief (LCDCA_DRL3) Segments Value */
-#define LCDCA_DRL3_DATA_Msk         (_U(0xFFFFFFFF) << LCDCA_DRL3_DATA_Pos)
+#define LCDCA_DRL3_DATA_Msk         (_U_(0xFFFFFFFF) << LCDCA_DRL3_DATA_Pos)
 #define LCDCA_DRL3_DATA(value)      (LCDCA_DRL3_DATA_Msk & ((value) << LCDCA_DRL3_DATA_Pos))
-#define LCDCA_DRL3_MASK             _U(0xFFFFFFFF) /**< \brief (LCDCA_DRL3) MASK Register */
+#define LCDCA_DRL3_MASK             _U_(0xFFFFFFFF) /**< \brief (LCDCA_DRL3) MASK Register */
 
 /* -------- LCDCA_DRH3 : (LCDCA Offset: 0x30) (R/W 32) Data Register High 3 -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -381,12 +381,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define LCDCA_DRH3_OFFSET           0x30         /**< \brief (LCDCA_DRH3 offset) Data Register High 3 */
-#define LCDCA_DRH3_RESETVALUE       _U(0x00000000); /**< \brief (LCDCA_DRH3 reset_value) Data Register High 3 */
+#define LCDCA_DRH3_RESETVALUE       _U_(0x00000000); /**< \brief (LCDCA_DRH3 reset_value) Data Register High 3 */
 
 #define LCDCA_DRH3_DATA_Pos         0            /**< \brief (LCDCA_DRH3) Segments Value */
-#define LCDCA_DRH3_DATA_Msk         (_U(0xFF) << LCDCA_DRH3_DATA_Pos)
+#define LCDCA_DRH3_DATA_Msk         (_U_(0xFF) << LCDCA_DRH3_DATA_Pos)
 #define LCDCA_DRH3_DATA(value)      (LCDCA_DRH3_DATA_Msk & ((value) << LCDCA_DRH3_DATA_Pos))
-#define LCDCA_DRH3_MASK             _U(0x000000FF) /**< \brief (LCDCA_DRH3) MASK Register */
+#define LCDCA_DRH3_MASK             _U_(0x000000FF) /**< \brief (LCDCA_DRH3) MASK Register */
 
 /* -------- LCDCA_IADR : (LCDCA Offset: 0x34) ( /W 32) Indirect Access Data Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -402,18 +402,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define LCDCA_IADR_OFFSET           0x34         /**< \brief (LCDCA_IADR offset) Indirect Access Data Register */
-#define LCDCA_IADR_RESETVALUE       _U(0x00000000); /**< \brief (LCDCA_IADR reset_value) Indirect Access Data Register */
+#define LCDCA_IADR_RESETVALUE       _U_(0x00000000); /**< \brief (LCDCA_IADR reset_value) Indirect Access Data Register */
 
 #define LCDCA_IADR_DATA_Pos         0            /**< \brief (LCDCA_IADR) Segments Value */
-#define LCDCA_IADR_DATA_Msk         (_U(0xFF) << LCDCA_IADR_DATA_Pos)
+#define LCDCA_IADR_DATA_Msk         (_U_(0xFF) << LCDCA_IADR_DATA_Pos)
 #define LCDCA_IADR_DATA(value)      (LCDCA_IADR_DATA_Msk & ((value) << LCDCA_IADR_DATA_Pos))
 #define LCDCA_IADR_DMASK_Pos        8            /**< \brief (LCDCA_IADR) Data Mask */
-#define LCDCA_IADR_DMASK_Msk        (_U(0xFF) << LCDCA_IADR_DMASK_Pos)
+#define LCDCA_IADR_DMASK_Msk        (_U_(0xFF) << LCDCA_IADR_DMASK_Pos)
 #define LCDCA_IADR_DMASK(value)     (LCDCA_IADR_DMASK_Msk & ((value) << LCDCA_IADR_DMASK_Pos))
 #define LCDCA_IADR_OFF_Pos          16           /**< \brief (LCDCA_IADR) Byte Offset */
-#define LCDCA_IADR_OFF_Msk          (_U(0x1F) << LCDCA_IADR_OFF_Pos)
+#define LCDCA_IADR_OFF_Msk          (_U_(0x1F) << LCDCA_IADR_OFF_Pos)
 #define LCDCA_IADR_OFF(value)       (LCDCA_IADR_OFF_Msk & ((value) << LCDCA_IADR_OFF_Pos))
-#define LCDCA_IADR_MASK             _U(0x001FFFFF) /**< \brief (LCDCA_IADR) MASK Register */
+#define LCDCA_IADR_MASK             _U_(0x001FFFFF) /**< \brief (LCDCA_IADR) MASK Register */
 
 /* -------- LCDCA_BCFG : (LCDCA Offset: 0x38) (R/W 32) Blink Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -431,20 +431,20 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define LCDCA_BCFG_OFFSET           0x38         /**< \brief (LCDCA_BCFG offset) Blink Configuration Register */
-#define LCDCA_BCFG_RESETVALUE       _U(0x00000000); /**< \brief (LCDCA_BCFG reset_value) Blink Configuration Register */
+#define LCDCA_BCFG_RESETVALUE       _U_(0x00000000); /**< \brief (LCDCA_BCFG reset_value) Blink Configuration Register */
 
 #define LCDCA_BCFG_MODE_Pos         0            /**< \brief (LCDCA_BCFG) Blinking Mode */
-#define LCDCA_BCFG_MODE             (_U(0x1) << LCDCA_BCFG_MODE_Pos)
+#define LCDCA_BCFG_MODE             (_U_(0x1) << LCDCA_BCFG_MODE_Pos)
 #define LCDCA_BCFG_FCS_Pos          1            /**< \brief (LCDCA_BCFG) Frame Counter Selection */
-#define LCDCA_BCFG_FCS_Msk          (_U(0x3) << LCDCA_BCFG_FCS_Pos)
+#define LCDCA_BCFG_FCS_Msk          (_U_(0x3) << LCDCA_BCFG_FCS_Pos)
 #define LCDCA_BCFG_FCS(value)       (LCDCA_BCFG_FCS_Msk & ((value) << LCDCA_BCFG_FCS_Pos))
 #define LCDCA_BCFG_BSS0_Pos         8            /**< \brief (LCDCA_BCFG) Blink Segment Selection 0 */
-#define LCDCA_BCFG_BSS0_Msk         (_U(0xF) << LCDCA_BCFG_BSS0_Pos)
+#define LCDCA_BCFG_BSS0_Msk         (_U_(0xF) << LCDCA_BCFG_BSS0_Pos)
 #define LCDCA_BCFG_BSS0(value)      (LCDCA_BCFG_BSS0_Msk & ((value) << LCDCA_BCFG_BSS0_Pos))
 #define LCDCA_BCFG_BSS1_Pos         12           /**< \brief (LCDCA_BCFG) Blink Segment Selection 1 */
-#define LCDCA_BCFG_BSS1_Msk         (_U(0xF) << LCDCA_BCFG_BSS1_Pos)
+#define LCDCA_BCFG_BSS1_Msk         (_U_(0xF) << LCDCA_BCFG_BSS1_Pos)
 #define LCDCA_BCFG_BSS1(value)      (LCDCA_BCFG_BSS1_Msk & ((value) << LCDCA_BCFG_BSS1_Pos))
-#define LCDCA_BCFG_MASK             _U(0x0000FF07) /**< \brief (LCDCA_BCFG) MASK Register */
+#define LCDCA_BCFG_MASK             _U_(0x0000FF07) /**< \brief (LCDCA_BCFG) MASK Register */
 
 /* -------- LCDCA_CSRCFG : (LCDCA Offset: 0x3C) (R/W 32) Circular Shift Register Configuration -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -462,20 +462,20 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define LCDCA_CSRCFG_OFFSET         0x3C         /**< \brief (LCDCA_CSRCFG offset) Circular Shift Register Configuration */
-#define LCDCA_CSRCFG_RESETVALUE     _U(0x00000000); /**< \brief (LCDCA_CSRCFG reset_value) Circular Shift Register Configuration */
+#define LCDCA_CSRCFG_RESETVALUE     _U_(0x00000000); /**< \brief (LCDCA_CSRCFG reset_value) Circular Shift Register Configuration */
 
 #define LCDCA_CSRCFG_DIR_Pos        0            /**< \brief (LCDCA_CSRCFG) Direction */
-#define LCDCA_CSRCFG_DIR            (_U(0x1) << LCDCA_CSRCFG_DIR_Pos)
+#define LCDCA_CSRCFG_DIR            (_U_(0x1) << LCDCA_CSRCFG_DIR_Pos)
 #define LCDCA_CSRCFG_FCS_Pos        1            /**< \brief (LCDCA_CSRCFG) Frame Counter Selection */
-#define LCDCA_CSRCFG_FCS_Msk        (_U(0x3) << LCDCA_CSRCFG_FCS_Pos)
+#define LCDCA_CSRCFG_FCS_Msk        (_U_(0x3) << LCDCA_CSRCFG_FCS_Pos)
 #define LCDCA_CSRCFG_FCS(value)     (LCDCA_CSRCFG_FCS_Msk & ((value) << LCDCA_CSRCFG_FCS_Pos))
 #define LCDCA_CSRCFG_SIZE_Pos       3            /**< \brief (LCDCA_CSRCFG) Size */
-#define LCDCA_CSRCFG_SIZE_Msk       (_U(0x7) << LCDCA_CSRCFG_SIZE_Pos)
+#define LCDCA_CSRCFG_SIZE_Msk       (_U_(0x7) << LCDCA_CSRCFG_SIZE_Pos)
 #define LCDCA_CSRCFG_SIZE(value)    (LCDCA_CSRCFG_SIZE_Msk & ((value) << LCDCA_CSRCFG_SIZE_Pos))
 #define LCDCA_CSRCFG_DATA_Pos       8            /**< \brief (LCDCA_CSRCFG) Circular Shift Register Value */
-#define LCDCA_CSRCFG_DATA_Msk       (_U(0xFF) << LCDCA_CSRCFG_DATA_Pos)
+#define LCDCA_CSRCFG_DATA_Msk       (_U_(0xFF) << LCDCA_CSRCFG_DATA_Pos)
 #define LCDCA_CSRCFG_DATA(value)    (LCDCA_CSRCFG_DATA_Msk & ((value) << LCDCA_CSRCFG_DATA_Pos))
-#define LCDCA_CSRCFG_MASK           _U(0x0000FF3F) /**< \brief (LCDCA_CSRCFG) MASK Register */
+#define LCDCA_CSRCFG_MASK           _U_(0x0000FF3F) /**< \brief (LCDCA_CSRCFG) MASK Register */
 
 /* -------- LCDCA_CMCFG : (LCDCA Offset: 0x40) (R/W 32) Character Mapping Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -492,17 +492,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define LCDCA_CMCFG_OFFSET          0x40         /**< \brief (LCDCA_CMCFG offset) Character Mapping Configuration Register */
-#define LCDCA_CMCFG_RESETVALUE      _U(0x00000000); /**< \brief (LCDCA_CMCFG reset_value) Character Mapping Configuration Register */
+#define LCDCA_CMCFG_RESETVALUE      _U_(0x00000000); /**< \brief (LCDCA_CMCFG reset_value) Character Mapping Configuration Register */
 
 #define LCDCA_CMCFG_DREV_Pos        0            /**< \brief (LCDCA_CMCFG) Digit Reverse Mode */
-#define LCDCA_CMCFG_DREV            (_U(0x1) << LCDCA_CMCFG_DREV_Pos)
+#define LCDCA_CMCFG_DREV            (_U_(0x1) << LCDCA_CMCFG_DREV_Pos)
 #define LCDCA_CMCFG_TDG_Pos         1            /**< \brief (LCDCA_CMCFG) Type of Digit */
-#define LCDCA_CMCFG_TDG_Msk         (_U(0x3) << LCDCA_CMCFG_TDG_Pos)
+#define LCDCA_CMCFG_TDG_Msk         (_U_(0x3) << LCDCA_CMCFG_TDG_Pos)
 #define LCDCA_CMCFG_TDG(value)      (LCDCA_CMCFG_TDG_Msk & ((value) << LCDCA_CMCFG_TDG_Pos))
 #define LCDCA_CMCFG_STSEG_Pos       8            /**< \brief (LCDCA_CMCFG) Start Segment */
-#define LCDCA_CMCFG_STSEG_Msk       (_U(0x3F) << LCDCA_CMCFG_STSEG_Pos)
+#define LCDCA_CMCFG_STSEG_Msk       (_U_(0x3F) << LCDCA_CMCFG_STSEG_Pos)
 #define LCDCA_CMCFG_STSEG(value)    (LCDCA_CMCFG_STSEG_Msk & ((value) << LCDCA_CMCFG_STSEG_Pos))
-#define LCDCA_CMCFG_MASK            _U(0x00003F07) /**< \brief (LCDCA_CMCFG) MASK Register */
+#define LCDCA_CMCFG_MASK            _U_(0x00003F07) /**< \brief (LCDCA_CMCFG) MASK Register */
 
 /* -------- LCDCA_CMDR : (LCDCA Offset: 0x44) ( /W 32) Character Mapping Data Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -516,12 +516,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define LCDCA_CMDR_OFFSET           0x44         /**< \brief (LCDCA_CMDR offset) Character Mapping Data Register */
-#define LCDCA_CMDR_RESETVALUE       _U(0x00000000); /**< \brief (LCDCA_CMDR reset_value) Character Mapping Data Register */
+#define LCDCA_CMDR_RESETVALUE       _U_(0x00000000); /**< \brief (LCDCA_CMDR reset_value) Character Mapping Data Register */
 
 #define LCDCA_CMDR_ASCII_Pos        0            /**< \brief (LCDCA_CMDR) ASCII Code */
-#define LCDCA_CMDR_ASCII_Msk        (_U(0x7F) << LCDCA_CMDR_ASCII_Pos)
+#define LCDCA_CMDR_ASCII_Msk        (_U_(0x7F) << LCDCA_CMDR_ASCII_Pos)
 #define LCDCA_CMDR_ASCII(value)     (LCDCA_CMDR_ASCII_Msk & ((value) << LCDCA_CMDR_ASCII_Pos))
-#define LCDCA_CMDR_MASK             _U(0x0000007F) /**< \brief (LCDCA_CMDR) MASK Register */
+#define LCDCA_CMDR_MASK             _U_(0x0000007F) /**< \brief (LCDCA_CMDR) MASK Register */
 
 /* -------- LCDCA_ACMCFG : (LCDCA Offset: 0x48) (R/W 32) Automated Character Mapping Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -544,30 +544,30 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define LCDCA_ACMCFG_OFFSET         0x48         /**< \brief (LCDCA_ACMCFG offset) Automated Character Mapping Configuration Register */
-#define LCDCA_ACMCFG_RESETVALUE     _U(0x00000000); /**< \brief (LCDCA_ACMCFG reset_value) Automated Character Mapping Configuration Register */
+#define LCDCA_ACMCFG_RESETVALUE     _U_(0x00000000); /**< \brief (LCDCA_ACMCFG reset_value) Automated Character Mapping Configuration Register */
 
 #define LCDCA_ACMCFG_EN_Pos         0            /**< \brief (LCDCA_ACMCFG) Enable */
-#define LCDCA_ACMCFG_EN             (_U(0x1) << LCDCA_ACMCFG_EN_Pos)
+#define LCDCA_ACMCFG_EN             (_U_(0x1) << LCDCA_ACMCFG_EN_Pos)
 #define LCDCA_ACMCFG_FCS_Pos        1            /**< \brief (LCDCA_ACMCFG) Frame Counter Selection */
-#define LCDCA_ACMCFG_FCS_Msk        (_U(0x3) << LCDCA_ACMCFG_FCS_Pos)
+#define LCDCA_ACMCFG_FCS_Msk        (_U_(0x3) << LCDCA_ACMCFG_FCS_Pos)
 #define LCDCA_ACMCFG_FCS(value)     (LCDCA_ACMCFG_FCS_Msk & ((value) << LCDCA_ACMCFG_FCS_Pos))
 #define LCDCA_ACMCFG_MODE_Pos       3            /**< \brief (LCDCA_ACMCFG) Mode (sequential or scrolling) */
-#define LCDCA_ACMCFG_MODE           (_U(0x1) << LCDCA_ACMCFG_MODE_Pos)
+#define LCDCA_ACMCFG_MODE           (_U_(0x1) << LCDCA_ACMCFG_MODE_Pos)
 #define LCDCA_ACMCFG_DREV_Pos       4            /**< \brief (LCDCA_ACMCFG) Digit Reverse */
-#define LCDCA_ACMCFG_DREV           (_U(0x1) << LCDCA_ACMCFG_DREV_Pos)
+#define LCDCA_ACMCFG_DREV           (_U_(0x1) << LCDCA_ACMCFG_DREV_Pos)
 #define LCDCA_ACMCFG_TDG_Pos        5            /**< \brief (LCDCA_ACMCFG) Type of Digit */
-#define LCDCA_ACMCFG_TDG_Msk        (_U(0x3) << LCDCA_ACMCFG_TDG_Pos)
+#define LCDCA_ACMCFG_TDG_Msk        (_U_(0x3) << LCDCA_ACMCFG_TDG_Pos)
 #define LCDCA_ACMCFG_TDG(value)     (LCDCA_ACMCFG_TDG_Msk & ((value) << LCDCA_ACMCFG_TDG_Pos))
 #define LCDCA_ACMCFG_STSEG_Pos      8            /**< \brief (LCDCA_ACMCFG) Start Segment */
-#define LCDCA_ACMCFG_STSEG_Msk      (_U(0x3F) << LCDCA_ACMCFG_STSEG_Pos)
+#define LCDCA_ACMCFG_STSEG_Msk      (_U_(0x3F) << LCDCA_ACMCFG_STSEG_Pos)
 #define LCDCA_ACMCFG_STSEG(value)   (LCDCA_ACMCFG_STSEG_Msk & ((value) << LCDCA_ACMCFG_STSEG_Pos))
 #define LCDCA_ACMCFG_STEPS_Pos      16           /**< \brief (LCDCA_ACMCFG) Scrolling Steps */
-#define LCDCA_ACMCFG_STEPS_Msk      (_U(0xFF) << LCDCA_ACMCFG_STEPS_Pos)
+#define LCDCA_ACMCFG_STEPS_Msk      (_U_(0xFF) << LCDCA_ACMCFG_STEPS_Pos)
 #define LCDCA_ACMCFG_STEPS(value)   (LCDCA_ACMCFG_STEPS_Msk & ((value) << LCDCA_ACMCFG_STEPS_Pos))
 #define LCDCA_ACMCFG_DIGN_Pos       24           /**< \brief (LCDCA_ACMCFG) Digit Number */
-#define LCDCA_ACMCFG_DIGN_Msk       (_U(0xF) << LCDCA_ACMCFG_DIGN_Pos)
+#define LCDCA_ACMCFG_DIGN_Msk       (_U_(0xF) << LCDCA_ACMCFG_DIGN_Pos)
 #define LCDCA_ACMCFG_DIGN(value)    (LCDCA_ACMCFG_DIGN_Msk & ((value) << LCDCA_ACMCFG_DIGN_Pos))
-#define LCDCA_ACMCFG_MASK           _U(0x0FFF3F7F) /**< \brief (LCDCA_ACMCFG) MASK Register */
+#define LCDCA_ACMCFG_MASK           _U_(0x0FFF3F7F) /**< \brief (LCDCA_ACMCFG) MASK Register */
 
 /* -------- LCDCA_ACMDR : (LCDCA Offset: 0x4C) ( /W 32) Automated Character Mapping Data Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -581,12 +581,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define LCDCA_ACMDR_OFFSET          0x4C         /**< \brief (LCDCA_ACMDR offset) Automated Character Mapping Data Register */
-#define LCDCA_ACMDR_RESETVALUE      _U(0x00000000); /**< \brief (LCDCA_ACMDR reset_value) Automated Character Mapping Data Register */
+#define LCDCA_ACMDR_RESETVALUE      _U_(0x00000000); /**< \brief (LCDCA_ACMDR reset_value) Automated Character Mapping Data Register */
 
 #define LCDCA_ACMDR_ASCII_Pos       0            /**< \brief (LCDCA_ACMDR) ASCII Code */
-#define LCDCA_ACMDR_ASCII_Msk       (_U(0x7F) << LCDCA_ACMDR_ASCII_Pos)
+#define LCDCA_ACMDR_ASCII_Msk       (_U_(0x7F) << LCDCA_ACMDR_ASCII_Pos)
 #define LCDCA_ACMDR_ASCII(value)    (LCDCA_ACMDR_ASCII_Msk & ((value) << LCDCA_ACMDR_ASCII_Pos))
-#define LCDCA_ACMDR_MASK            _U(0x0000007F) /**< \brief (LCDCA_ACMDR) MASK Register */
+#define LCDCA_ACMDR_MASK            _U_(0x0000007F) /**< \brief (LCDCA_ACMDR) MASK Register */
 
 /* -------- LCDCA_ABMCFG : (LCDCA Offset: 0x50) (R/W 32) Automated Bit Mapping Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -603,17 +603,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define LCDCA_ABMCFG_OFFSET         0x50         /**< \brief (LCDCA_ABMCFG offset) Automated Bit Mapping Configuration Register */
-#define LCDCA_ABMCFG_RESETVALUE     _U(0x00000000); /**< \brief (LCDCA_ABMCFG reset_value) Automated Bit Mapping Configuration Register */
+#define LCDCA_ABMCFG_RESETVALUE     _U_(0x00000000); /**< \brief (LCDCA_ABMCFG reset_value) Automated Bit Mapping Configuration Register */
 
 #define LCDCA_ABMCFG_EN_Pos         0            /**< \brief (LCDCA_ABMCFG) Enable */
-#define LCDCA_ABMCFG_EN             (_U(0x1) << LCDCA_ABMCFG_EN_Pos)
+#define LCDCA_ABMCFG_EN             (_U_(0x1) << LCDCA_ABMCFG_EN_Pos)
 #define LCDCA_ABMCFG_FCS_Pos        1            /**< \brief (LCDCA_ABMCFG) Frame Counter Selection */
-#define LCDCA_ABMCFG_FCS_Msk        (_U(0x3) << LCDCA_ABMCFG_FCS_Pos)
+#define LCDCA_ABMCFG_FCS_Msk        (_U_(0x3) << LCDCA_ABMCFG_FCS_Pos)
 #define LCDCA_ABMCFG_FCS(value)     (LCDCA_ABMCFG_FCS_Msk & ((value) << LCDCA_ABMCFG_FCS_Pos))
 #define LCDCA_ABMCFG_SIZE_Pos       8            /**< \brief (LCDCA_ABMCFG) Size */
-#define LCDCA_ABMCFG_SIZE_Msk       (_U(0x1F) << LCDCA_ABMCFG_SIZE_Pos)
+#define LCDCA_ABMCFG_SIZE_Msk       (_U_(0x1F) << LCDCA_ABMCFG_SIZE_Pos)
 #define LCDCA_ABMCFG_SIZE(value)    (LCDCA_ABMCFG_SIZE_Msk & ((value) << LCDCA_ABMCFG_SIZE_Pos))
-#define LCDCA_ABMCFG_MASK           _U(0x00001F07) /**< \brief (LCDCA_ABMCFG) MASK Register */
+#define LCDCA_ABMCFG_MASK           _U_(0x00001F07) /**< \brief (LCDCA_ABMCFG) MASK Register */
 
 /* -------- LCDCA_ABMDR : (LCDCA Offset: 0x54) ( /W 32) Automated Bit Mapping Data Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -629,18 +629,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define LCDCA_ABMDR_OFFSET          0x54         /**< \brief (LCDCA_ABMDR offset) Automated Bit Mapping Data Register */
-#define LCDCA_ABMDR_RESETVALUE      _U(0x00000000); /**< \brief (LCDCA_ABMDR reset_value) Automated Bit Mapping Data Register */
+#define LCDCA_ABMDR_RESETVALUE      _U_(0x00000000); /**< \brief (LCDCA_ABMDR reset_value) Automated Bit Mapping Data Register */
 
 #define LCDCA_ABMDR_DATA_Pos        0            /**< \brief (LCDCA_ABMDR) Segments Value */
-#define LCDCA_ABMDR_DATA_Msk        (_U(0xFF) << LCDCA_ABMDR_DATA_Pos)
+#define LCDCA_ABMDR_DATA_Msk        (_U_(0xFF) << LCDCA_ABMDR_DATA_Pos)
 #define LCDCA_ABMDR_DATA(value)     (LCDCA_ABMDR_DATA_Msk & ((value) << LCDCA_ABMDR_DATA_Pos))
 #define LCDCA_ABMDR_DMASK_Pos       8            /**< \brief (LCDCA_ABMDR) Data Mask */
-#define LCDCA_ABMDR_DMASK_Msk       (_U(0xFF) << LCDCA_ABMDR_DMASK_Pos)
+#define LCDCA_ABMDR_DMASK_Msk       (_U_(0xFF) << LCDCA_ABMDR_DMASK_Pos)
 #define LCDCA_ABMDR_DMASK(value)    (LCDCA_ABMDR_DMASK_Msk & ((value) << LCDCA_ABMDR_DMASK_Pos))
 #define LCDCA_ABMDR_OFF_Pos         16           /**< \brief (LCDCA_ABMDR) Byte Offset */
-#define LCDCA_ABMDR_OFF_Msk         (_U(0x1F) << LCDCA_ABMDR_OFF_Pos)
+#define LCDCA_ABMDR_OFF_Msk         (_U_(0x1F) << LCDCA_ABMDR_OFF_Pos)
 #define LCDCA_ABMDR_OFF(value)      (LCDCA_ABMDR_OFF_Msk & ((value) << LCDCA_ABMDR_OFF_Pos))
-#define LCDCA_ABMDR_MASK            _U(0x001FFFFF) /**< \brief (LCDCA_ABMDR) MASK Register */
+#define LCDCA_ABMDR_MASK            _U_(0x001FFFFF) /**< \brief (LCDCA_ABMDR) MASK Register */
 
 /* -------- LCDCA_IER : (LCDCA Offset: 0x58) ( /W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -654,11 +654,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define LCDCA_IER_OFFSET            0x58         /**< \brief (LCDCA_IER offset) Interrupt Enable Register */
-#define LCDCA_IER_RESETVALUE        _U(0x00000000); /**< \brief (LCDCA_IER reset_value) Interrupt Enable Register */
+#define LCDCA_IER_RESETVALUE        _U_(0x00000000); /**< \brief (LCDCA_IER reset_value) Interrupt Enable Register */
 
 #define LCDCA_IER_FC0R_Pos          0            /**< \brief (LCDCA_IER) Frame Counter 0 Rollover */
-#define LCDCA_IER_FC0R              (_U(0x1) << LCDCA_IER_FC0R_Pos)
-#define LCDCA_IER_MASK              _U(0x00000001) /**< \brief (LCDCA_IER) MASK Register */
+#define LCDCA_IER_FC0R              (_U_(0x1) << LCDCA_IER_FC0R_Pos)
+#define LCDCA_IER_MASK              _U_(0x00000001) /**< \brief (LCDCA_IER) MASK Register */
 
 /* -------- LCDCA_IDR : (LCDCA Offset: 0x5C) ( /W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -672,11 +672,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define LCDCA_IDR_OFFSET            0x5C         /**< \brief (LCDCA_IDR offset) Interrupt Disable Register */
-#define LCDCA_IDR_RESETVALUE        _U(0x00000000); /**< \brief (LCDCA_IDR reset_value) Interrupt Disable Register */
+#define LCDCA_IDR_RESETVALUE        _U_(0x00000000); /**< \brief (LCDCA_IDR reset_value) Interrupt Disable Register */
 
 #define LCDCA_IDR_FC0R_Pos          0            /**< \brief (LCDCA_IDR) Frame Counter 0 Rollover */
-#define LCDCA_IDR_FC0R              (_U(0x1) << LCDCA_IDR_FC0R_Pos)
-#define LCDCA_IDR_MASK              _U(0x00000001) /**< \brief (LCDCA_IDR) MASK Register */
+#define LCDCA_IDR_FC0R              (_U_(0x1) << LCDCA_IDR_FC0R_Pos)
+#define LCDCA_IDR_MASK              _U_(0x00000001) /**< \brief (LCDCA_IDR) MASK Register */
 
 /* -------- LCDCA_IMR : (LCDCA Offset: 0x60) (R/  32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -690,11 +690,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define LCDCA_IMR_OFFSET            0x60         /**< \brief (LCDCA_IMR offset) Interrupt Mask Register */
-#define LCDCA_IMR_RESETVALUE        _U(0x00000000); /**< \brief (LCDCA_IMR reset_value) Interrupt Mask Register */
+#define LCDCA_IMR_RESETVALUE        _U_(0x00000000); /**< \brief (LCDCA_IMR reset_value) Interrupt Mask Register */
 
 #define LCDCA_IMR_FC0R_Pos          0            /**< \brief (LCDCA_IMR) Frame Counter 0 Rollover */
-#define LCDCA_IMR_FC0R              (_U(0x1) << LCDCA_IMR_FC0R_Pos)
-#define LCDCA_IMR_MASK              _U(0x00000001) /**< \brief (LCDCA_IMR) MASK Register */
+#define LCDCA_IMR_FC0R              (_U_(0x1) << LCDCA_IMR_FC0R_Pos)
+#define LCDCA_IMR_MASK              _U_(0x00000001) /**< \brief (LCDCA_IMR) MASK Register */
 
 /* -------- LCDCA_VERSION : (LCDCA Offset: 0x64) (R/  32) Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -710,15 +710,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define LCDCA_VERSION_OFFSET        0x64         /**< \brief (LCDCA_VERSION offset) Version Register */
-#define LCDCA_VERSION_RESETVALUE    _U(0x00000100); /**< \brief (LCDCA_VERSION reset_value) Version Register */
+#define LCDCA_VERSION_RESETVALUE    _U_(0x00000100); /**< \brief (LCDCA_VERSION reset_value) Version Register */
 
 #define LCDCA_VERSION_VERSION_Pos   0            /**< \brief (LCDCA_VERSION) Version Number */
-#define LCDCA_VERSION_VERSION_Msk   (_U(0xFFF) << LCDCA_VERSION_VERSION_Pos)
+#define LCDCA_VERSION_VERSION_Msk   (_U_(0xFFF) << LCDCA_VERSION_VERSION_Pos)
 #define LCDCA_VERSION_VERSION(value) (LCDCA_VERSION_VERSION_Msk & ((value) << LCDCA_VERSION_VERSION_Pos))
 #define LCDCA_VERSION_VARIANT_Pos   16           /**< \brief (LCDCA_VERSION) Variant Number */
-#define LCDCA_VERSION_VARIANT_Msk   (_U(0xF) << LCDCA_VERSION_VARIANT_Pos)
+#define LCDCA_VERSION_VARIANT_Msk   (_U_(0xF) << LCDCA_VERSION_VARIANT_Pos)
 #define LCDCA_VERSION_VARIANT(value) (LCDCA_VERSION_VARIANT_Msk & ((value) << LCDCA_VERSION_VARIANT_Pos))
-#define LCDCA_VERSION_MASK          _U(0x000F0FFF) /**< \brief (LCDCA_VERSION) MASK Register */
+#define LCDCA_VERSION_MASK          _U_(0x000F0FFF) /**< \brief (LCDCA_VERSION) MASK Register */
 
 /** \brief LCDCA hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/lcdca.h
+++ b/asf/sam/include/sam4l/component/lcdca.h
@@ -1,0 +1,787 @@
+/**
+ * \file
+ *
+ * \brief Component description for LCDCA
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_LCDCA_COMPONENT_
+#define _SAM4L_LCDCA_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR LCDCA */
+/* ========================================================================== */
+/** \addtogroup SAM4L_LCDCA LCD Controller */
+/*@{*/
+
+#define LCDCA_I7572
+#define REV_LCDCA                   0x100
+
+/* -------- LCDCA_CR : (LCDCA Offset: 0x00) ( /W 32) Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DIS:1;            /*!< bit:      0  Disable                            */
+    uint32_t EN:1;             /*!< bit:      1  Enable                             */
+    uint32_t FC0DIS:1;         /*!< bit:      2  Frame Counter 0 Disable            */
+    uint32_t FC0EN:1;          /*!< bit:      3  Frame Counter 0 Enable             */
+    uint32_t FC1DIS:1;         /*!< bit:      4  Frame Counter 1 Disable            */
+    uint32_t FC1EN:1;          /*!< bit:      5  Frame Counter 1 Enable             */
+    uint32_t FC2DIS:1;         /*!< bit:      6  Frame Counter 2 Disable            */
+    uint32_t FC2EN:1;          /*!< bit:      7  Frame Counter 2 Enable             */
+    uint32_t CDM:1;            /*!< bit:      8  Clear Display Memory               */
+    uint32_t WDIS:1;           /*!< bit:      9  Wake up Disable                    */
+    uint32_t WEN:1;            /*!< bit:     10  Wake up Enable                     */
+    uint32_t BSTART:1;         /*!< bit:     11  Blinking Start                     */
+    uint32_t BSTOP:1;          /*!< bit:     12  Blinking Stop                      */
+    uint32_t CSTART:1;         /*!< bit:     13  Circular Shift Start               */
+    uint32_t CSTOP:1;          /*!< bit:     14  Circular Shift Stop                */
+    uint32_t :17;              /*!< bit: 15..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} LCDCA_CR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define LCDCA_CR_OFFSET             0x00         /**< \brief (LCDCA_CR offset) Control Register */
+#define LCDCA_CR_RESETVALUE         _U(0x00000000); /**< \brief (LCDCA_CR reset_value) Control Register */
+
+#define LCDCA_CR_DIS_Pos            0            /**< \brief (LCDCA_CR) Disable */
+#define LCDCA_CR_DIS                (_U(0x1) << LCDCA_CR_DIS_Pos)
+#define LCDCA_CR_EN_Pos             1            /**< \brief (LCDCA_CR) Enable */
+#define LCDCA_CR_EN                 (_U(0x1) << LCDCA_CR_EN_Pos)
+#define LCDCA_CR_FC0DIS_Pos         2            /**< \brief (LCDCA_CR) Frame Counter 0 Disable */
+#define LCDCA_CR_FC0DIS             (_U(0x1) << LCDCA_CR_FC0DIS_Pos)
+#define LCDCA_CR_FC0EN_Pos          3            /**< \brief (LCDCA_CR) Frame Counter 0 Enable */
+#define LCDCA_CR_FC0EN              (_U(0x1) << LCDCA_CR_FC0EN_Pos)
+#define LCDCA_CR_FC1DIS_Pos         4            /**< \brief (LCDCA_CR) Frame Counter 1 Disable */
+#define LCDCA_CR_FC1DIS             (_U(0x1) << LCDCA_CR_FC1DIS_Pos)
+#define LCDCA_CR_FC1EN_Pos          5            /**< \brief (LCDCA_CR) Frame Counter 1 Enable */
+#define LCDCA_CR_FC1EN              (_U(0x1) << LCDCA_CR_FC1EN_Pos)
+#define LCDCA_CR_FC2DIS_Pos         6            /**< \brief (LCDCA_CR) Frame Counter 2 Disable */
+#define LCDCA_CR_FC2DIS             (_U(0x1) << LCDCA_CR_FC2DIS_Pos)
+#define LCDCA_CR_FC2EN_Pos          7            /**< \brief (LCDCA_CR) Frame Counter 2 Enable */
+#define LCDCA_CR_FC2EN              (_U(0x1) << LCDCA_CR_FC2EN_Pos)
+#define LCDCA_CR_CDM_Pos            8            /**< \brief (LCDCA_CR) Clear Display Memory */
+#define LCDCA_CR_CDM                (_U(0x1) << LCDCA_CR_CDM_Pos)
+#define LCDCA_CR_WDIS_Pos           9            /**< \brief (LCDCA_CR) Wake up Disable */
+#define LCDCA_CR_WDIS               (_U(0x1) << LCDCA_CR_WDIS_Pos)
+#define LCDCA_CR_WEN_Pos            10           /**< \brief (LCDCA_CR) Wake up Enable */
+#define LCDCA_CR_WEN                (_U(0x1) << LCDCA_CR_WEN_Pos)
+#define LCDCA_CR_BSTART_Pos         11           /**< \brief (LCDCA_CR) Blinking Start */
+#define LCDCA_CR_BSTART             (_U(0x1) << LCDCA_CR_BSTART_Pos)
+#define LCDCA_CR_BSTOP_Pos          12           /**< \brief (LCDCA_CR) Blinking Stop */
+#define LCDCA_CR_BSTOP              (_U(0x1) << LCDCA_CR_BSTOP_Pos)
+#define LCDCA_CR_CSTART_Pos         13           /**< \brief (LCDCA_CR) Circular Shift Start */
+#define LCDCA_CR_CSTART             (_U(0x1) << LCDCA_CR_CSTART_Pos)
+#define LCDCA_CR_CSTOP_Pos          14           /**< \brief (LCDCA_CR) Circular Shift Stop */
+#define LCDCA_CR_CSTOP              (_U(0x1) << LCDCA_CR_CSTOP_Pos)
+#define LCDCA_CR_MASK               _U(0x00007FFF) /**< \brief (LCDCA_CR) MASK Register */
+
+/* -------- LCDCA_CFG : (LCDCA Offset: 0x04) (R/W 32) Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t XBIAS:1;          /*!< bit:      0  External Bias Generation           */
+    uint32_t WMOD:1;           /*!< bit:      1  Waveform Mode                      */
+    uint32_t BLANK:1;          /*!< bit:      2  Blank LCD                          */
+    uint32_t LOCK:1;           /*!< bit:      3  Lock                               */
+    uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint32_t DUTY:2;           /*!< bit:  8.. 9  Duty Select                        */
+    uint32_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint32_t FCST:6;           /*!< bit: 16..21  Fine Contrast                      */
+    uint32_t :2;               /*!< bit: 22..23  Reserved                           */
+    uint32_t NSU:6;            /*!< bit: 24..29  Number of Segment Terminals in Use */
+    uint32_t :2;               /*!< bit: 30..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} LCDCA_CFG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define LCDCA_CFG_OFFSET            0x04         /**< \brief (LCDCA_CFG offset) Configuration Register */
+#define LCDCA_CFG_RESETVALUE        _U(0x00000000); /**< \brief (LCDCA_CFG reset_value) Configuration Register */
+
+#define LCDCA_CFG_XBIAS_Pos         0            /**< \brief (LCDCA_CFG) External Bias Generation */
+#define LCDCA_CFG_XBIAS             (_U(0x1) << LCDCA_CFG_XBIAS_Pos)
+#define LCDCA_CFG_WMOD_Pos          1            /**< \brief (LCDCA_CFG) Waveform Mode */
+#define LCDCA_CFG_WMOD              (_U(0x1) << LCDCA_CFG_WMOD_Pos)
+#define LCDCA_CFG_BLANK_Pos         2            /**< \brief (LCDCA_CFG) Blank LCD */
+#define LCDCA_CFG_BLANK             (_U(0x1) << LCDCA_CFG_BLANK_Pos)
+#define LCDCA_CFG_LOCK_Pos          3            /**< \brief (LCDCA_CFG) Lock */
+#define LCDCA_CFG_LOCK              (_U(0x1) << LCDCA_CFG_LOCK_Pos)
+#define LCDCA_CFG_DUTY_Pos          8            /**< \brief (LCDCA_CFG) Duty Select */
+#define LCDCA_CFG_DUTY_Msk          (_U(0x3) << LCDCA_CFG_DUTY_Pos)
+#define LCDCA_CFG_DUTY(value)       (LCDCA_CFG_DUTY_Msk & ((value) << LCDCA_CFG_DUTY_Pos))
+#define LCDCA_CFG_FCST_Pos          16           /**< \brief (LCDCA_CFG) Fine Contrast */
+#define LCDCA_CFG_FCST_Msk          (_U(0x3F) << LCDCA_CFG_FCST_Pos)
+#define LCDCA_CFG_FCST(value)       (LCDCA_CFG_FCST_Msk & ((value) << LCDCA_CFG_FCST_Pos))
+#define LCDCA_CFG_NSU_Pos           24           /**< \brief (LCDCA_CFG) Number of Segment Terminals in Use */
+#define LCDCA_CFG_NSU_Msk           (_U(0x3F) << LCDCA_CFG_NSU_Pos)
+#define LCDCA_CFG_NSU(value)        (LCDCA_CFG_NSU_Msk & ((value) << LCDCA_CFG_NSU_Pos))
+#define LCDCA_CFG_MASK              _U(0x3F3F030F) /**< \brief (LCDCA_CFG) MASK Register */
+
+/* -------- LCDCA_TIM : (LCDCA Offset: 0x08) (R/W 32) Timing Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PRESC:1;          /*!< bit:      0  LCD Prescaler Select               */
+    uint32_t CLKDIV:3;         /*!< bit:  1.. 3  LCD Clock Division                 */
+    uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint32_t FC0:5;            /*!< bit:  8..12  Frame Counter 0                    */
+    uint32_t FC0PB:1;          /*!< bit:     13  Frame Counter 0 Prescaler Bypass   */
+    uint32_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint32_t FC1:5;            /*!< bit: 16..20  Frame Counter 1                    */
+    uint32_t :3;               /*!< bit: 21..23  Reserved                           */
+    uint32_t FC2:5;            /*!< bit: 24..28  Frame Counter 2                    */
+    uint32_t :3;               /*!< bit: 29..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} LCDCA_TIM_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define LCDCA_TIM_OFFSET            0x08         /**< \brief (LCDCA_TIM offset) Timing Register */
+#define LCDCA_TIM_RESETVALUE        _U(0x00000000); /**< \brief (LCDCA_TIM reset_value) Timing Register */
+
+#define LCDCA_TIM_PRESC_Pos         0            /**< \brief (LCDCA_TIM) LCD Prescaler Select */
+#define LCDCA_TIM_PRESC             (_U(0x1) << LCDCA_TIM_PRESC_Pos)
+#define LCDCA_TIM_CLKDIV_Pos        1            /**< \brief (LCDCA_TIM) LCD Clock Division */
+#define LCDCA_TIM_CLKDIV_Msk        (_U(0x7) << LCDCA_TIM_CLKDIV_Pos)
+#define LCDCA_TIM_CLKDIV(value)     (LCDCA_TIM_CLKDIV_Msk & ((value) << LCDCA_TIM_CLKDIV_Pos))
+#define LCDCA_TIM_FC0_Pos           8            /**< \brief (LCDCA_TIM) Frame Counter 0 */
+#define LCDCA_TIM_FC0_Msk           (_U(0x1F) << LCDCA_TIM_FC0_Pos)
+#define LCDCA_TIM_FC0(value)        (LCDCA_TIM_FC0_Msk & ((value) << LCDCA_TIM_FC0_Pos))
+#define LCDCA_TIM_FC0PB_Pos         13           /**< \brief (LCDCA_TIM) Frame Counter 0 Prescaler Bypass */
+#define LCDCA_TIM_FC0PB             (_U(0x1) << LCDCA_TIM_FC0PB_Pos)
+#define LCDCA_TIM_FC1_Pos           16           /**< \brief (LCDCA_TIM) Frame Counter 1 */
+#define LCDCA_TIM_FC1_Msk           (_U(0x1F) << LCDCA_TIM_FC1_Pos)
+#define LCDCA_TIM_FC1(value)        (LCDCA_TIM_FC1_Msk & ((value) << LCDCA_TIM_FC1_Pos))
+#define LCDCA_TIM_FC2_Pos           24           /**< \brief (LCDCA_TIM) Frame Counter 2 */
+#define LCDCA_TIM_FC2_Msk           (_U(0x1F) << LCDCA_TIM_FC2_Pos)
+#define LCDCA_TIM_FC2(value)        (LCDCA_TIM_FC2_Msk & ((value) << LCDCA_TIM_FC2_Pos))
+#define LCDCA_TIM_MASK              _U(0x1F1F3F0F) /**< \brief (LCDCA_TIM) MASK Register */
+
+/* -------- LCDCA_SR : (LCDCA Offset: 0x0C) (R/  32) Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t FC0R:1;           /*!< bit:      0  Frame Counter 0 Rollover           */
+    uint32_t FC0S:1;           /*!< bit:      1  Frame Counter 0 Status             */
+    uint32_t FC1S:1;           /*!< bit:      2  Frame Counter 1 Status             */
+    uint32_t FC2S:1;           /*!< bit:      3  Frame Counter 2 Status             */
+    uint32_t EN:1;             /*!< bit:      4  LCDCA Status                       */
+    uint32_t WEN:1;            /*!< bit:      5  Wake up Status                     */
+    uint32_t BLKS:1;           /*!< bit:      6  Blink Status                       */
+    uint32_t CSRS:1;           /*!< bit:      7  Circular Shift Register Status     */
+    uint32_t CPS:1;            /*!< bit:      8  Charge Pump Status                 */
+    uint32_t :23;              /*!< bit:  9..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} LCDCA_SR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define LCDCA_SR_OFFSET             0x0C         /**< \brief (LCDCA_SR offset) Status Register */
+#define LCDCA_SR_RESETVALUE         _U(0x00000000); /**< \brief (LCDCA_SR reset_value) Status Register */
+
+#define LCDCA_SR_FC0R_Pos           0            /**< \brief (LCDCA_SR) Frame Counter 0 Rollover */
+#define LCDCA_SR_FC0R               (_U(0x1) << LCDCA_SR_FC0R_Pos)
+#define LCDCA_SR_FC0S_Pos           1            /**< \brief (LCDCA_SR) Frame Counter 0 Status */
+#define LCDCA_SR_FC0S               (_U(0x1) << LCDCA_SR_FC0S_Pos)
+#define LCDCA_SR_FC1S_Pos           2            /**< \brief (LCDCA_SR) Frame Counter 1 Status */
+#define LCDCA_SR_FC1S               (_U(0x1) << LCDCA_SR_FC1S_Pos)
+#define LCDCA_SR_FC2S_Pos           3            /**< \brief (LCDCA_SR) Frame Counter 2 Status */
+#define LCDCA_SR_FC2S               (_U(0x1) << LCDCA_SR_FC2S_Pos)
+#define LCDCA_SR_EN_Pos             4            /**< \brief (LCDCA_SR) LCDCA Status */
+#define LCDCA_SR_EN                 (_U(0x1) << LCDCA_SR_EN_Pos)
+#define LCDCA_SR_WEN_Pos            5            /**< \brief (LCDCA_SR) Wake up Status */
+#define LCDCA_SR_WEN                (_U(0x1) << LCDCA_SR_WEN_Pos)
+#define LCDCA_SR_BLKS_Pos           6            /**< \brief (LCDCA_SR) Blink Status */
+#define LCDCA_SR_BLKS               (_U(0x1) << LCDCA_SR_BLKS_Pos)
+#define LCDCA_SR_CSRS_Pos           7            /**< \brief (LCDCA_SR) Circular Shift Register Status */
+#define LCDCA_SR_CSRS               (_U(0x1) << LCDCA_SR_CSRS_Pos)
+#define LCDCA_SR_CPS_Pos            8            /**< \brief (LCDCA_SR) Charge Pump Status */
+#define LCDCA_SR_CPS                (_U(0x1) << LCDCA_SR_CPS_Pos)
+#define LCDCA_SR_MASK               _U(0x000001FF) /**< \brief (LCDCA_SR) MASK Register */
+
+/* -------- LCDCA_SCR : (LCDCA Offset: 0x10) ( /W 32) Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t FC0R:1;           /*!< bit:      0  Frame Counter 0 Rollover           */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} LCDCA_SCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define LCDCA_SCR_OFFSET            0x10         /**< \brief (LCDCA_SCR offset) Status Clear Register */
+#define LCDCA_SCR_RESETVALUE        _U(0x00000000); /**< \brief (LCDCA_SCR reset_value) Status Clear Register */
+
+#define LCDCA_SCR_FC0R_Pos          0            /**< \brief (LCDCA_SCR) Frame Counter 0 Rollover */
+#define LCDCA_SCR_FC0R              (_U(0x1) << LCDCA_SCR_FC0R_Pos)
+#define LCDCA_SCR_MASK              _U(0x00000001) /**< \brief (LCDCA_SCR) MASK Register */
+
+/* -------- LCDCA_DRL0 : (LCDCA Offset: 0x14) (R/W 32) Data Register Low 0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATA:32;          /*!< bit:  0..31  Segments Value                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} LCDCA_DRL0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define LCDCA_DRL0_OFFSET           0x14         /**< \brief (LCDCA_DRL0 offset) Data Register Low 0 */
+#define LCDCA_DRL0_RESETVALUE       _U(0x00000000); /**< \brief (LCDCA_DRL0 reset_value) Data Register Low 0 */
+
+#define LCDCA_DRL0_DATA_Pos         0            /**< \brief (LCDCA_DRL0) Segments Value */
+#define LCDCA_DRL0_DATA_Msk         (_U(0xFFFFFFFF) << LCDCA_DRL0_DATA_Pos)
+#define LCDCA_DRL0_DATA(value)      (LCDCA_DRL0_DATA_Msk & ((value) << LCDCA_DRL0_DATA_Pos))
+#define LCDCA_DRL0_MASK             _U(0xFFFFFFFF) /**< \brief (LCDCA_DRL0) MASK Register */
+
+/* -------- LCDCA_DRH0 : (LCDCA Offset: 0x18) (R/W 32) Data Register High 0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATA:8;           /*!< bit:  0.. 7  Segments Value                     */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} LCDCA_DRH0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define LCDCA_DRH0_OFFSET           0x18         /**< \brief (LCDCA_DRH0 offset) Data Register High 0 */
+#define LCDCA_DRH0_RESETVALUE       _U(0x00000000); /**< \brief (LCDCA_DRH0 reset_value) Data Register High 0 */
+
+#define LCDCA_DRH0_DATA_Pos         0            /**< \brief (LCDCA_DRH0) Segments Value */
+#define LCDCA_DRH0_DATA_Msk         (_U(0xFF) << LCDCA_DRH0_DATA_Pos)
+#define LCDCA_DRH0_DATA(value)      (LCDCA_DRH0_DATA_Msk & ((value) << LCDCA_DRH0_DATA_Pos))
+#define LCDCA_DRH0_MASK             _U(0x000000FF) /**< \brief (LCDCA_DRH0) MASK Register */
+
+/* -------- LCDCA_DRL1 : (LCDCA Offset: 0x1C) (R/W 32) Data Register Low 1 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATA:32;          /*!< bit:  0..31  Segments Value                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} LCDCA_DRL1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define LCDCA_DRL1_OFFSET           0x1C         /**< \brief (LCDCA_DRL1 offset) Data Register Low 1 */
+#define LCDCA_DRL1_RESETVALUE       _U(0x00000000); /**< \brief (LCDCA_DRL1 reset_value) Data Register Low 1 */
+
+#define LCDCA_DRL1_DATA_Pos         0            /**< \brief (LCDCA_DRL1) Segments Value */
+#define LCDCA_DRL1_DATA_Msk         (_U(0xFFFFFFFF) << LCDCA_DRL1_DATA_Pos)
+#define LCDCA_DRL1_DATA(value)      (LCDCA_DRL1_DATA_Msk & ((value) << LCDCA_DRL1_DATA_Pos))
+#define LCDCA_DRL1_MASK             _U(0xFFFFFFFF) /**< \brief (LCDCA_DRL1) MASK Register */
+
+/* -------- LCDCA_DRH1 : (LCDCA Offset: 0x20) (R/W 32) Data Register High 1 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATA:8;           /*!< bit:  0.. 7  Segments Value                     */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} LCDCA_DRH1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define LCDCA_DRH1_OFFSET           0x20         /**< \brief (LCDCA_DRH1 offset) Data Register High 1 */
+#define LCDCA_DRH1_RESETVALUE       _U(0x00000000); /**< \brief (LCDCA_DRH1 reset_value) Data Register High 1 */
+
+#define LCDCA_DRH1_DATA_Pos         0            /**< \brief (LCDCA_DRH1) Segments Value */
+#define LCDCA_DRH1_DATA_Msk         (_U(0xFF) << LCDCA_DRH1_DATA_Pos)
+#define LCDCA_DRH1_DATA(value)      (LCDCA_DRH1_DATA_Msk & ((value) << LCDCA_DRH1_DATA_Pos))
+#define LCDCA_DRH1_MASK             _U(0x000000FF) /**< \brief (LCDCA_DRH1) MASK Register */
+
+/* -------- LCDCA_DRL2 : (LCDCA Offset: 0x24) (R/W 32) Data Register Low 2 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATA:32;          /*!< bit:  0..31  Segments Value                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} LCDCA_DRL2_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define LCDCA_DRL2_OFFSET           0x24         /**< \brief (LCDCA_DRL2 offset) Data Register Low 2 */
+#define LCDCA_DRL2_RESETVALUE       _U(0x00000000); /**< \brief (LCDCA_DRL2 reset_value) Data Register Low 2 */
+
+#define LCDCA_DRL2_DATA_Pos         0            /**< \brief (LCDCA_DRL2) Segments Value */
+#define LCDCA_DRL2_DATA_Msk         (_U(0xFFFFFFFF) << LCDCA_DRL2_DATA_Pos)
+#define LCDCA_DRL2_DATA(value)      (LCDCA_DRL2_DATA_Msk & ((value) << LCDCA_DRL2_DATA_Pos))
+#define LCDCA_DRL2_MASK             _U(0xFFFFFFFF) /**< \brief (LCDCA_DRL2) MASK Register */
+
+/* -------- LCDCA_DRH2 : (LCDCA Offset: 0x28) (R/W 32) Data Register High 2 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATA:8;           /*!< bit:  0.. 7  Segments Value                     */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} LCDCA_DRH2_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define LCDCA_DRH2_OFFSET           0x28         /**< \brief (LCDCA_DRH2 offset) Data Register High 2 */
+#define LCDCA_DRH2_RESETVALUE       _U(0x00000000); /**< \brief (LCDCA_DRH2 reset_value) Data Register High 2 */
+
+#define LCDCA_DRH2_DATA_Pos         0            /**< \brief (LCDCA_DRH2) Segments Value */
+#define LCDCA_DRH2_DATA_Msk         (_U(0xFF) << LCDCA_DRH2_DATA_Pos)
+#define LCDCA_DRH2_DATA(value)      (LCDCA_DRH2_DATA_Msk & ((value) << LCDCA_DRH2_DATA_Pos))
+#define LCDCA_DRH2_MASK             _U(0x000000FF) /**< \brief (LCDCA_DRH2) MASK Register */
+
+/* -------- LCDCA_DRL3 : (LCDCA Offset: 0x2C) (R/W 32) Data Register Low 3 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATA:32;          /*!< bit:  0..31  Segments Value                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} LCDCA_DRL3_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define LCDCA_DRL3_OFFSET           0x2C         /**< \brief (LCDCA_DRL3 offset) Data Register Low 3 */
+#define LCDCA_DRL3_RESETVALUE       _U(0x00000000); /**< \brief (LCDCA_DRL3 reset_value) Data Register Low 3 */
+
+#define LCDCA_DRL3_DATA_Pos         0            /**< \brief (LCDCA_DRL3) Segments Value */
+#define LCDCA_DRL3_DATA_Msk         (_U(0xFFFFFFFF) << LCDCA_DRL3_DATA_Pos)
+#define LCDCA_DRL3_DATA(value)      (LCDCA_DRL3_DATA_Msk & ((value) << LCDCA_DRL3_DATA_Pos))
+#define LCDCA_DRL3_MASK             _U(0xFFFFFFFF) /**< \brief (LCDCA_DRL3) MASK Register */
+
+/* -------- LCDCA_DRH3 : (LCDCA Offset: 0x30) (R/W 32) Data Register High 3 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATA:8;           /*!< bit:  0.. 7  Segments Value                     */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} LCDCA_DRH3_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define LCDCA_DRH3_OFFSET           0x30         /**< \brief (LCDCA_DRH3 offset) Data Register High 3 */
+#define LCDCA_DRH3_RESETVALUE       _U(0x00000000); /**< \brief (LCDCA_DRH3 reset_value) Data Register High 3 */
+
+#define LCDCA_DRH3_DATA_Pos         0            /**< \brief (LCDCA_DRH3) Segments Value */
+#define LCDCA_DRH3_DATA_Msk         (_U(0xFF) << LCDCA_DRH3_DATA_Pos)
+#define LCDCA_DRH3_DATA(value)      (LCDCA_DRH3_DATA_Msk & ((value) << LCDCA_DRH3_DATA_Pos))
+#define LCDCA_DRH3_MASK             _U(0x000000FF) /**< \brief (LCDCA_DRH3) MASK Register */
+
+/* -------- LCDCA_IADR : (LCDCA Offset: 0x34) ( /W 32) Indirect Access Data Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATA:8;           /*!< bit:  0.. 7  Segments Value                     */
+    uint32_t DMASK:8;          /*!< bit:  8..15  Data Mask                          */
+    uint32_t OFF:5;            /*!< bit: 16..20  Byte Offset                        */
+    uint32_t :11;              /*!< bit: 21..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} LCDCA_IADR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define LCDCA_IADR_OFFSET           0x34         /**< \brief (LCDCA_IADR offset) Indirect Access Data Register */
+#define LCDCA_IADR_RESETVALUE       _U(0x00000000); /**< \brief (LCDCA_IADR reset_value) Indirect Access Data Register */
+
+#define LCDCA_IADR_DATA_Pos         0            /**< \brief (LCDCA_IADR) Segments Value */
+#define LCDCA_IADR_DATA_Msk         (_U(0xFF) << LCDCA_IADR_DATA_Pos)
+#define LCDCA_IADR_DATA(value)      (LCDCA_IADR_DATA_Msk & ((value) << LCDCA_IADR_DATA_Pos))
+#define LCDCA_IADR_DMASK_Pos        8            /**< \brief (LCDCA_IADR) Data Mask */
+#define LCDCA_IADR_DMASK_Msk        (_U(0xFF) << LCDCA_IADR_DMASK_Pos)
+#define LCDCA_IADR_DMASK(value)     (LCDCA_IADR_DMASK_Msk & ((value) << LCDCA_IADR_DMASK_Pos))
+#define LCDCA_IADR_OFF_Pos          16           /**< \brief (LCDCA_IADR) Byte Offset */
+#define LCDCA_IADR_OFF_Msk          (_U(0x1F) << LCDCA_IADR_OFF_Pos)
+#define LCDCA_IADR_OFF(value)       (LCDCA_IADR_OFF_Msk & ((value) << LCDCA_IADR_OFF_Pos))
+#define LCDCA_IADR_MASK             _U(0x001FFFFF) /**< \brief (LCDCA_IADR) MASK Register */
+
+/* -------- LCDCA_BCFG : (LCDCA Offset: 0x38) (R/W 32) Blink Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t MODE:1;           /*!< bit:      0  Blinking Mode                      */
+    uint32_t FCS:2;            /*!< bit:  1.. 2  Frame Counter Selection            */
+    uint32_t :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint32_t BSS0:4;           /*!< bit:  8..11  Blink Segment Selection 0          */
+    uint32_t BSS1:4;           /*!< bit: 12..15  Blink Segment Selection 1          */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} LCDCA_BCFG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define LCDCA_BCFG_OFFSET           0x38         /**< \brief (LCDCA_BCFG offset) Blink Configuration Register */
+#define LCDCA_BCFG_RESETVALUE       _U(0x00000000); /**< \brief (LCDCA_BCFG reset_value) Blink Configuration Register */
+
+#define LCDCA_BCFG_MODE_Pos         0            /**< \brief (LCDCA_BCFG) Blinking Mode */
+#define LCDCA_BCFG_MODE             (_U(0x1) << LCDCA_BCFG_MODE_Pos)
+#define LCDCA_BCFG_FCS_Pos          1            /**< \brief (LCDCA_BCFG) Frame Counter Selection */
+#define LCDCA_BCFG_FCS_Msk          (_U(0x3) << LCDCA_BCFG_FCS_Pos)
+#define LCDCA_BCFG_FCS(value)       (LCDCA_BCFG_FCS_Msk & ((value) << LCDCA_BCFG_FCS_Pos))
+#define LCDCA_BCFG_BSS0_Pos         8            /**< \brief (LCDCA_BCFG) Blink Segment Selection 0 */
+#define LCDCA_BCFG_BSS0_Msk         (_U(0xF) << LCDCA_BCFG_BSS0_Pos)
+#define LCDCA_BCFG_BSS0(value)      (LCDCA_BCFG_BSS0_Msk & ((value) << LCDCA_BCFG_BSS0_Pos))
+#define LCDCA_BCFG_BSS1_Pos         12           /**< \brief (LCDCA_BCFG) Blink Segment Selection 1 */
+#define LCDCA_BCFG_BSS1_Msk         (_U(0xF) << LCDCA_BCFG_BSS1_Pos)
+#define LCDCA_BCFG_BSS1(value)      (LCDCA_BCFG_BSS1_Msk & ((value) << LCDCA_BCFG_BSS1_Pos))
+#define LCDCA_BCFG_MASK             _U(0x0000FF07) /**< \brief (LCDCA_BCFG) MASK Register */
+
+/* -------- LCDCA_CSRCFG : (LCDCA Offset: 0x3C) (R/W 32) Circular Shift Register Configuration -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DIR:1;            /*!< bit:      0  Direction                          */
+    uint32_t FCS:2;            /*!< bit:  1.. 2  Frame Counter Selection            */
+    uint32_t SIZE:3;           /*!< bit:  3.. 5  Size                               */
+    uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t DATA:8;           /*!< bit:  8..15  Circular Shift Register Value      */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} LCDCA_CSRCFG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define LCDCA_CSRCFG_OFFSET         0x3C         /**< \brief (LCDCA_CSRCFG offset) Circular Shift Register Configuration */
+#define LCDCA_CSRCFG_RESETVALUE     _U(0x00000000); /**< \brief (LCDCA_CSRCFG reset_value) Circular Shift Register Configuration */
+
+#define LCDCA_CSRCFG_DIR_Pos        0            /**< \brief (LCDCA_CSRCFG) Direction */
+#define LCDCA_CSRCFG_DIR            (_U(0x1) << LCDCA_CSRCFG_DIR_Pos)
+#define LCDCA_CSRCFG_FCS_Pos        1            /**< \brief (LCDCA_CSRCFG) Frame Counter Selection */
+#define LCDCA_CSRCFG_FCS_Msk        (_U(0x3) << LCDCA_CSRCFG_FCS_Pos)
+#define LCDCA_CSRCFG_FCS(value)     (LCDCA_CSRCFG_FCS_Msk & ((value) << LCDCA_CSRCFG_FCS_Pos))
+#define LCDCA_CSRCFG_SIZE_Pos       3            /**< \brief (LCDCA_CSRCFG) Size */
+#define LCDCA_CSRCFG_SIZE_Msk       (_U(0x7) << LCDCA_CSRCFG_SIZE_Pos)
+#define LCDCA_CSRCFG_SIZE(value)    (LCDCA_CSRCFG_SIZE_Msk & ((value) << LCDCA_CSRCFG_SIZE_Pos))
+#define LCDCA_CSRCFG_DATA_Pos       8            /**< \brief (LCDCA_CSRCFG) Circular Shift Register Value */
+#define LCDCA_CSRCFG_DATA_Msk       (_U(0xFF) << LCDCA_CSRCFG_DATA_Pos)
+#define LCDCA_CSRCFG_DATA(value)    (LCDCA_CSRCFG_DATA_Msk & ((value) << LCDCA_CSRCFG_DATA_Pos))
+#define LCDCA_CSRCFG_MASK           _U(0x0000FF3F) /**< \brief (LCDCA_CSRCFG) MASK Register */
+
+/* -------- LCDCA_CMCFG : (LCDCA Offset: 0x40) (R/W 32) Character Mapping Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DREV:1;           /*!< bit:      0  Digit Reverse Mode                 */
+    uint32_t TDG:2;            /*!< bit:  1.. 2  Type of Digit                      */
+    uint32_t :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint32_t STSEG:6;          /*!< bit:  8..13  Start Segment                      */
+    uint32_t :18;              /*!< bit: 14..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} LCDCA_CMCFG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define LCDCA_CMCFG_OFFSET          0x40         /**< \brief (LCDCA_CMCFG offset) Character Mapping Configuration Register */
+#define LCDCA_CMCFG_RESETVALUE      _U(0x00000000); /**< \brief (LCDCA_CMCFG reset_value) Character Mapping Configuration Register */
+
+#define LCDCA_CMCFG_DREV_Pos        0            /**< \brief (LCDCA_CMCFG) Digit Reverse Mode */
+#define LCDCA_CMCFG_DREV            (_U(0x1) << LCDCA_CMCFG_DREV_Pos)
+#define LCDCA_CMCFG_TDG_Pos         1            /**< \brief (LCDCA_CMCFG) Type of Digit */
+#define LCDCA_CMCFG_TDG_Msk         (_U(0x3) << LCDCA_CMCFG_TDG_Pos)
+#define LCDCA_CMCFG_TDG(value)      (LCDCA_CMCFG_TDG_Msk & ((value) << LCDCA_CMCFG_TDG_Pos))
+#define LCDCA_CMCFG_STSEG_Pos       8            /**< \brief (LCDCA_CMCFG) Start Segment */
+#define LCDCA_CMCFG_STSEG_Msk       (_U(0x3F) << LCDCA_CMCFG_STSEG_Pos)
+#define LCDCA_CMCFG_STSEG(value)    (LCDCA_CMCFG_STSEG_Msk & ((value) << LCDCA_CMCFG_STSEG_Pos))
+#define LCDCA_CMCFG_MASK            _U(0x00003F07) /**< \brief (LCDCA_CMCFG) MASK Register */
+
+/* -------- LCDCA_CMDR : (LCDCA Offset: 0x44) ( /W 32) Character Mapping Data Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ASCII:7;          /*!< bit:  0.. 6  ASCII Code                         */
+    uint32_t :25;              /*!< bit:  7..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} LCDCA_CMDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define LCDCA_CMDR_OFFSET           0x44         /**< \brief (LCDCA_CMDR offset) Character Mapping Data Register */
+#define LCDCA_CMDR_RESETVALUE       _U(0x00000000); /**< \brief (LCDCA_CMDR reset_value) Character Mapping Data Register */
+
+#define LCDCA_CMDR_ASCII_Pos        0            /**< \brief (LCDCA_CMDR) ASCII Code */
+#define LCDCA_CMDR_ASCII_Msk        (_U(0x7F) << LCDCA_CMDR_ASCII_Pos)
+#define LCDCA_CMDR_ASCII(value)     (LCDCA_CMDR_ASCII_Msk & ((value) << LCDCA_CMDR_ASCII_Pos))
+#define LCDCA_CMDR_MASK             _U(0x0000007F) /**< \brief (LCDCA_CMDR) MASK Register */
+
+/* -------- LCDCA_ACMCFG : (LCDCA Offset: 0x48) (R/W 32) Automated Character Mapping Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EN:1;             /*!< bit:      0  Enable                             */
+    uint32_t FCS:2;            /*!< bit:  1.. 2  Frame Counter Selection            */
+    uint32_t MODE:1;           /*!< bit:      3  Mode (sequential or scrolling)     */
+    uint32_t DREV:1;           /*!< bit:      4  Digit Reverse                      */
+    uint32_t TDG:2;            /*!< bit:  5.. 6  Type of Digit                      */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t STSEG:6;          /*!< bit:  8..13  Start Segment                      */
+    uint32_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint32_t STEPS:8;          /*!< bit: 16..23  Scrolling Steps                    */
+    uint32_t DIGN:4;           /*!< bit: 24..27  Digit Number                       */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} LCDCA_ACMCFG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define LCDCA_ACMCFG_OFFSET         0x48         /**< \brief (LCDCA_ACMCFG offset) Automated Character Mapping Configuration Register */
+#define LCDCA_ACMCFG_RESETVALUE     _U(0x00000000); /**< \brief (LCDCA_ACMCFG reset_value) Automated Character Mapping Configuration Register */
+
+#define LCDCA_ACMCFG_EN_Pos         0            /**< \brief (LCDCA_ACMCFG) Enable */
+#define LCDCA_ACMCFG_EN             (_U(0x1) << LCDCA_ACMCFG_EN_Pos)
+#define LCDCA_ACMCFG_FCS_Pos        1            /**< \brief (LCDCA_ACMCFG) Frame Counter Selection */
+#define LCDCA_ACMCFG_FCS_Msk        (_U(0x3) << LCDCA_ACMCFG_FCS_Pos)
+#define LCDCA_ACMCFG_FCS(value)     (LCDCA_ACMCFG_FCS_Msk & ((value) << LCDCA_ACMCFG_FCS_Pos))
+#define LCDCA_ACMCFG_MODE_Pos       3            /**< \brief (LCDCA_ACMCFG) Mode (sequential or scrolling) */
+#define LCDCA_ACMCFG_MODE           (_U(0x1) << LCDCA_ACMCFG_MODE_Pos)
+#define LCDCA_ACMCFG_DREV_Pos       4            /**< \brief (LCDCA_ACMCFG) Digit Reverse */
+#define LCDCA_ACMCFG_DREV           (_U(0x1) << LCDCA_ACMCFG_DREV_Pos)
+#define LCDCA_ACMCFG_TDG_Pos        5            /**< \brief (LCDCA_ACMCFG) Type of Digit */
+#define LCDCA_ACMCFG_TDG_Msk        (_U(0x3) << LCDCA_ACMCFG_TDG_Pos)
+#define LCDCA_ACMCFG_TDG(value)     (LCDCA_ACMCFG_TDG_Msk & ((value) << LCDCA_ACMCFG_TDG_Pos))
+#define LCDCA_ACMCFG_STSEG_Pos      8            /**< \brief (LCDCA_ACMCFG) Start Segment */
+#define LCDCA_ACMCFG_STSEG_Msk      (_U(0x3F) << LCDCA_ACMCFG_STSEG_Pos)
+#define LCDCA_ACMCFG_STSEG(value)   (LCDCA_ACMCFG_STSEG_Msk & ((value) << LCDCA_ACMCFG_STSEG_Pos))
+#define LCDCA_ACMCFG_STEPS_Pos      16           /**< \brief (LCDCA_ACMCFG) Scrolling Steps */
+#define LCDCA_ACMCFG_STEPS_Msk      (_U(0xFF) << LCDCA_ACMCFG_STEPS_Pos)
+#define LCDCA_ACMCFG_STEPS(value)   (LCDCA_ACMCFG_STEPS_Msk & ((value) << LCDCA_ACMCFG_STEPS_Pos))
+#define LCDCA_ACMCFG_DIGN_Pos       24           /**< \brief (LCDCA_ACMCFG) Digit Number */
+#define LCDCA_ACMCFG_DIGN_Msk       (_U(0xF) << LCDCA_ACMCFG_DIGN_Pos)
+#define LCDCA_ACMCFG_DIGN(value)    (LCDCA_ACMCFG_DIGN_Msk & ((value) << LCDCA_ACMCFG_DIGN_Pos))
+#define LCDCA_ACMCFG_MASK           _U(0x0FFF3F7F) /**< \brief (LCDCA_ACMCFG) MASK Register */
+
+/* -------- LCDCA_ACMDR : (LCDCA Offset: 0x4C) ( /W 32) Automated Character Mapping Data Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ASCII:7;          /*!< bit:  0.. 6  ASCII Code                         */
+    uint32_t :25;              /*!< bit:  7..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} LCDCA_ACMDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define LCDCA_ACMDR_OFFSET          0x4C         /**< \brief (LCDCA_ACMDR offset) Automated Character Mapping Data Register */
+#define LCDCA_ACMDR_RESETVALUE      _U(0x00000000); /**< \brief (LCDCA_ACMDR reset_value) Automated Character Mapping Data Register */
+
+#define LCDCA_ACMDR_ASCII_Pos       0            /**< \brief (LCDCA_ACMDR) ASCII Code */
+#define LCDCA_ACMDR_ASCII_Msk       (_U(0x7F) << LCDCA_ACMDR_ASCII_Pos)
+#define LCDCA_ACMDR_ASCII(value)    (LCDCA_ACMDR_ASCII_Msk & ((value) << LCDCA_ACMDR_ASCII_Pos))
+#define LCDCA_ACMDR_MASK            _U(0x0000007F) /**< \brief (LCDCA_ACMDR) MASK Register */
+
+/* -------- LCDCA_ABMCFG : (LCDCA Offset: 0x50) (R/W 32) Automated Bit Mapping Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EN:1;             /*!< bit:      0  Enable                             */
+    uint32_t FCS:2;            /*!< bit:  1.. 2  Frame Counter Selection            */
+    uint32_t :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint32_t SIZE:5;           /*!< bit:  8..12  Size                               */
+    uint32_t :19;              /*!< bit: 13..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} LCDCA_ABMCFG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define LCDCA_ABMCFG_OFFSET         0x50         /**< \brief (LCDCA_ABMCFG offset) Automated Bit Mapping Configuration Register */
+#define LCDCA_ABMCFG_RESETVALUE     _U(0x00000000); /**< \brief (LCDCA_ABMCFG reset_value) Automated Bit Mapping Configuration Register */
+
+#define LCDCA_ABMCFG_EN_Pos         0            /**< \brief (LCDCA_ABMCFG) Enable */
+#define LCDCA_ABMCFG_EN             (_U(0x1) << LCDCA_ABMCFG_EN_Pos)
+#define LCDCA_ABMCFG_FCS_Pos        1            /**< \brief (LCDCA_ABMCFG) Frame Counter Selection */
+#define LCDCA_ABMCFG_FCS_Msk        (_U(0x3) << LCDCA_ABMCFG_FCS_Pos)
+#define LCDCA_ABMCFG_FCS(value)     (LCDCA_ABMCFG_FCS_Msk & ((value) << LCDCA_ABMCFG_FCS_Pos))
+#define LCDCA_ABMCFG_SIZE_Pos       8            /**< \brief (LCDCA_ABMCFG) Size */
+#define LCDCA_ABMCFG_SIZE_Msk       (_U(0x1F) << LCDCA_ABMCFG_SIZE_Pos)
+#define LCDCA_ABMCFG_SIZE(value)    (LCDCA_ABMCFG_SIZE_Msk & ((value) << LCDCA_ABMCFG_SIZE_Pos))
+#define LCDCA_ABMCFG_MASK           _U(0x00001F07) /**< \brief (LCDCA_ABMCFG) MASK Register */
+
+/* -------- LCDCA_ABMDR : (LCDCA Offset: 0x54) ( /W 32) Automated Bit Mapping Data Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATA:8;           /*!< bit:  0.. 7  Segments Value                     */
+    uint32_t DMASK:8;          /*!< bit:  8..15  Data Mask                          */
+    uint32_t OFF:5;            /*!< bit: 16..20  Byte Offset                        */
+    uint32_t :11;              /*!< bit: 21..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} LCDCA_ABMDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define LCDCA_ABMDR_OFFSET          0x54         /**< \brief (LCDCA_ABMDR offset) Automated Bit Mapping Data Register */
+#define LCDCA_ABMDR_RESETVALUE      _U(0x00000000); /**< \brief (LCDCA_ABMDR reset_value) Automated Bit Mapping Data Register */
+
+#define LCDCA_ABMDR_DATA_Pos        0            /**< \brief (LCDCA_ABMDR) Segments Value */
+#define LCDCA_ABMDR_DATA_Msk        (_U(0xFF) << LCDCA_ABMDR_DATA_Pos)
+#define LCDCA_ABMDR_DATA(value)     (LCDCA_ABMDR_DATA_Msk & ((value) << LCDCA_ABMDR_DATA_Pos))
+#define LCDCA_ABMDR_DMASK_Pos       8            /**< \brief (LCDCA_ABMDR) Data Mask */
+#define LCDCA_ABMDR_DMASK_Msk       (_U(0xFF) << LCDCA_ABMDR_DMASK_Pos)
+#define LCDCA_ABMDR_DMASK(value)    (LCDCA_ABMDR_DMASK_Msk & ((value) << LCDCA_ABMDR_DMASK_Pos))
+#define LCDCA_ABMDR_OFF_Pos         16           /**< \brief (LCDCA_ABMDR) Byte Offset */
+#define LCDCA_ABMDR_OFF_Msk         (_U(0x1F) << LCDCA_ABMDR_OFF_Pos)
+#define LCDCA_ABMDR_OFF(value)      (LCDCA_ABMDR_OFF_Msk & ((value) << LCDCA_ABMDR_OFF_Pos))
+#define LCDCA_ABMDR_MASK            _U(0x001FFFFF) /**< \brief (LCDCA_ABMDR) MASK Register */
+
+/* -------- LCDCA_IER : (LCDCA Offset: 0x58) ( /W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t FC0R:1;           /*!< bit:      0  Frame Counter 0 Rollover           */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} LCDCA_IER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define LCDCA_IER_OFFSET            0x58         /**< \brief (LCDCA_IER offset) Interrupt Enable Register */
+#define LCDCA_IER_RESETVALUE        _U(0x00000000); /**< \brief (LCDCA_IER reset_value) Interrupt Enable Register */
+
+#define LCDCA_IER_FC0R_Pos          0            /**< \brief (LCDCA_IER) Frame Counter 0 Rollover */
+#define LCDCA_IER_FC0R              (_U(0x1) << LCDCA_IER_FC0R_Pos)
+#define LCDCA_IER_MASK              _U(0x00000001) /**< \brief (LCDCA_IER) MASK Register */
+
+/* -------- LCDCA_IDR : (LCDCA Offset: 0x5C) ( /W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t FC0R:1;           /*!< bit:      0  Frame Counter 0 Rollover           */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} LCDCA_IDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define LCDCA_IDR_OFFSET            0x5C         /**< \brief (LCDCA_IDR offset) Interrupt Disable Register */
+#define LCDCA_IDR_RESETVALUE        _U(0x00000000); /**< \brief (LCDCA_IDR reset_value) Interrupt Disable Register */
+
+#define LCDCA_IDR_FC0R_Pos          0            /**< \brief (LCDCA_IDR) Frame Counter 0 Rollover */
+#define LCDCA_IDR_FC0R              (_U(0x1) << LCDCA_IDR_FC0R_Pos)
+#define LCDCA_IDR_MASK              _U(0x00000001) /**< \brief (LCDCA_IDR) MASK Register */
+
+/* -------- LCDCA_IMR : (LCDCA Offset: 0x60) (R/  32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t FC0R:1;           /*!< bit:      0  Frame Counter 0 Rollover           */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} LCDCA_IMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define LCDCA_IMR_OFFSET            0x60         /**< \brief (LCDCA_IMR offset) Interrupt Mask Register */
+#define LCDCA_IMR_RESETVALUE        _U(0x00000000); /**< \brief (LCDCA_IMR reset_value) Interrupt Mask Register */
+
+#define LCDCA_IMR_FC0R_Pos          0            /**< \brief (LCDCA_IMR) Frame Counter 0 Rollover */
+#define LCDCA_IMR_FC0R              (_U(0x1) << LCDCA_IMR_FC0R_Pos)
+#define LCDCA_IMR_MASK              _U(0x00000001) /**< \brief (LCDCA_IMR) MASK Register */
+
+/* -------- LCDCA_VERSION : (LCDCA Offset: 0x64) (R/  32) Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version Number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant Number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} LCDCA_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define LCDCA_VERSION_OFFSET        0x64         /**< \brief (LCDCA_VERSION offset) Version Register */
+#define LCDCA_VERSION_RESETVALUE    _U(0x00000100); /**< \brief (LCDCA_VERSION reset_value) Version Register */
+
+#define LCDCA_VERSION_VERSION_Pos   0            /**< \brief (LCDCA_VERSION) Version Number */
+#define LCDCA_VERSION_VERSION_Msk   (_U(0xFFF) << LCDCA_VERSION_VERSION_Pos)
+#define LCDCA_VERSION_VERSION(value) (LCDCA_VERSION_VERSION_Msk & ((value) << LCDCA_VERSION_VERSION_Pos))
+#define LCDCA_VERSION_VARIANT_Pos   16           /**< \brief (LCDCA_VERSION) Variant Number */
+#define LCDCA_VERSION_VARIANT_Msk   (_U(0xF) << LCDCA_VERSION_VARIANT_Pos)
+#define LCDCA_VERSION_VARIANT(value) (LCDCA_VERSION_VARIANT_Msk & ((value) << LCDCA_VERSION_VARIANT_Pos))
+#define LCDCA_VERSION_MASK          _U(0x000F0FFF) /**< \brief (LCDCA_VERSION) MASK Register */
+
+/** \brief LCDCA hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __O  LCDCA_CR_Type             CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
+  __IO LCDCA_CFG_Type            CFG;         /**< \brief Offset: 0x04 (R/W 32) Configuration Register */
+  __IO LCDCA_TIM_Type            TIM;         /**< \brief Offset: 0x08 (R/W 32) Timing Register */
+  __I  LCDCA_SR_Type             SR;          /**< \brief Offset: 0x0C (R/  32) Status Register */
+  __O  LCDCA_SCR_Type            SCR;         /**< \brief Offset: 0x10 ( /W 32) Status Clear Register */
+  __IO LCDCA_DRL0_Type           DRL0;        /**< \brief Offset: 0x14 (R/W 32) Data Register Low 0 */
+  __IO LCDCA_DRH0_Type           DRH0;        /**< \brief Offset: 0x18 (R/W 32) Data Register High 0 */
+  __IO LCDCA_DRL1_Type           DRL1;        /**< \brief Offset: 0x1C (R/W 32) Data Register Low 1 */
+  __IO LCDCA_DRH1_Type           DRH1;        /**< \brief Offset: 0x20 (R/W 32) Data Register High 1 */
+  __IO LCDCA_DRL2_Type           DRL2;        /**< \brief Offset: 0x24 (R/W 32) Data Register Low 2 */
+  __IO LCDCA_DRH2_Type           DRH2;        /**< \brief Offset: 0x28 (R/W 32) Data Register High 2 */
+  __IO LCDCA_DRL3_Type           DRL3;        /**< \brief Offset: 0x2C (R/W 32) Data Register Low 3 */
+  __IO LCDCA_DRH3_Type           DRH3;        /**< \brief Offset: 0x30 (R/W 32) Data Register High 3 */
+  __O  LCDCA_IADR_Type           IADR;        /**< \brief Offset: 0x34 ( /W 32) Indirect Access Data Register */
+  __IO LCDCA_BCFG_Type           BCFG;        /**< \brief Offset: 0x38 (R/W 32) Blink Configuration Register */
+  __IO LCDCA_CSRCFG_Type         CSRCFG;      /**< \brief Offset: 0x3C (R/W 32) Circular Shift Register Configuration */
+  __IO LCDCA_CMCFG_Type          CMCFG;       /**< \brief Offset: 0x40 (R/W 32) Character Mapping Configuration Register */
+  __O  LCDCA_CMDR_Type           CMDR;        /**< \brief Offset: 0x44 ( /W 32) Character Mapping Data Register */
+  __IO LCDCA_ACMCFG_Type         ACMCFG;      /**< \brief Offset: 0x48 (R/W 32) Automated Character Mapping Configuration Register */
+  __O  LCDCA_ACMDR_Type          ACMDR;       /**< \brief Offset: 0x4C ( /W 32) Automated Character Mapping Data Register */
+  __IO LCDCA_ABMCFG_Type         ABMCFG;      /**< \brief Offset: 0x50 (R/W 32) Automated Bit Mapping Configuration Register */
+  __O  LCDCA_ABMDR_Type          ABMDR;       /**< \brief Offset: 0x54 ( /W 32) Automated Bit Mapping Data Register */
+  __O  LCDCA_IER_Type            IER;         /**< \brief Offset: 0x58 ( /W 32) Interrupt Enable Register */
+  __O  LCDCA_IDR_Type            IDR;         /**< \brief Offset: 0x5C ( /W 32) Interrupt Disable Register */
+  __I  LCDCA_IMR_Type            IMR;         /**< \brief Offset: 0x60 (R/  32) Interrupt Mask Register */
+  __I  LCDCA_VERSION_Type        VERSION;     /**< \brief Offset: 0x64 (R/  32) Version Register */
+ } bf;
+ struct {
+  WoReg   LCDCA_CR;           /**< \brief (LCDCA Offset: 0x00) Control Register */
+  RwReg   LCDCA_CFG;          /**< \brief (LCDCA Offset: 0x04) Configuration Register */
+  RwReg   LCDCA_TIM;          /**< \brief (LCDCA Offset: 0x08) Timing Register */
+  RoReg   LCDCA_SR;           /**< \brief (LCDCA Offset: 0x0C) Status Register */
+  WoReg   LCDCA_SCR;          /**< \brief (LCDCA Offset: 0x10) Status Clear Register */
+  RwReg   LCDCA_DRL0;         /**< \brief (LCDCA Offset: 0x14) Data Register Low 0 */
+  RwReg   LCDCA_DRH0;         /**< \brief (LCDCA Offset: 0x18) Data Register High 0 */
+  RwReg   LCDCA_DRL1;         /**< \brief (LCDCA Offset: 0x1C) Data Register Low 1 */
+  RwReg   LCDCA_DRH1;         /**< \brief (LCDCA Offset: 0x20) Data Register High 1 */
+  RwReg   LCDCA_DRL2;         /**< \brief (LCDCA Offset: 0x24) Data Register Low 2 */
+  RwReg   LCDCA_DRH2;         /**< \brief (LCDCA Offset: 0x28) Data Register High 2 */
+  RwReg   LCDCA_DRL3;         /**< \brief (LCDCA Offset: 0x2C) Data Register Low 3 */
+  RwReg   LCDCA_DRH3;         /**< \brief (LCDCA Offset: 0x30) Data Register High 3 */
+  WoReg   LCDCA_IADR;         /**< \brief (LCDCA Offset: 0x34) Indirect Access Data Register */
+  RwReg   LCDCA_BCFG;         /**< \brief (LCDCA Offset: 0x38) Blink Configuration Register */
+  RwReg   LCDCA_CSRCFG;       /**< \brief (LCDCA Offset: 0x3C) Circular Shift Register Configuration */
+  RwReg   LCDCA_CMCFG;        /**< \brief (LCDCA Offset: 0x40) Character Mapping Configuration Register */
+  WoReg   LCDCA_CMDR;         /**< \brief (LCDCA Offset: 0x44) Character Mapping Data Register */
+  RwReg   LCDCA_ACMCFG;       /**< \brief (LCDCA Offset: 0x48) Automated Character Mapping Configuration Register */
+  WoReg   LCDCA_ACMDR;        /**< \brief (LCDCA Offset: 0x4C) Automated Character Mapping Data Register */
+  RwReg   LCDCA_ABMCFG;       /**< \brief (LCDCA Offset: 0x50) Automated Bit Mapping Configuration Register */
+  WoReg   LCDCA_ABMDR;        /**< \brief (LCDCA Offset: 0x54) Automated Bit Mapping Data Register */
+  WoReg   LCDCA_IER;          /**< \brief (LCDCA Offset: 0x58) Interrupt Enable Register */
+  WoReg   LCDCA_IDR;          /**< \brief (LCDCA Offset: 0x5C) Interrupt Disable Register */
+  RoReg   LCDCA_IMR;          /**< \brief (LCDCA Offset: 0x60) Interrupt Mask Register */
+  RoReg   LCDCA_VERSION;      /**< \brief (LCDCA Offset: 0x64) Version Register */
+ } reg;
+} Lcdca;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_LCDCA_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/parc.h
+++ b/asf/sam/include/sam4l/component/parc.h
@@ -55,23 +55,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PARC_CFG_OFFSET             0x00         /**< \brief (PARC_CFG offset) Configuration Register */
-#define PARC_CFG_RESETVALUE         _U(0x00000000); /**< \brief (PARC_CFG reset_value) Configuration Register */
+#define PARC_CFG_RESETVALUE         _U_(0x00000000); /**< \brief (PARC_CFG reset_value) Configuration Register */
 
 #define PARC_CFG_DSIZE_Pos          0            /**< \brief (PARC_CFG) Data Size */
-#define PARC_CFG_DSIZE_Msk          (_U(0x3) << PARC_CFG_DSIZE_Pos)
+#define PARC_CFG_DSIZE_Msk          (_U_(0x3) << PARC_CFG_DSIZE_Pos)
 #define PARC_CFG_DSIZE(value)       (PARC_CFG_DSIZE_Msk & ((value) << PARC_CFG_DSIZE_Pos))
 #define PARC_CFG_SMODE_Pos          2            /**< \brief (PARC_CFG) Sampling Mode */
-#define PARC_CFG_SMODE_Msk          (_U(0x3) << PARC_CFG_SMODE_Pos)
+#define PARC_CFG_SMODE_Msk          (_U_(0x3) << PARC_CFG_SMODE_Pos)
 #define PARC_CFG_SMODE(value)       (PARC_CFG_SMODE_Msk & ((value) << PARC_CFG_SMODE_Pos))
 #define PARC_CFG_EMODE_Pos          4            /**< \brief (PARC_CFG) Events Mode */
-#define PARC_CFG_EMODE              (_U(0x1) << PARC_CFG_EMODE_Pos)
+#define PARC_CFG_EMODE              (_U_(0x1) << PARC_CFG_EMODE_Pos)
 #define PARC_CFG_EDGE_Pos           5            /**< \brief (PARC_CFG) Sampling Edge Select */
-#define PARC_CFG_EDGE               (_U(0x1) << PARC_CFG_EDGE_Pos)
+#define PARC_CFG_EDGE               (_U_(0x1) << PARC_CFG_EDGE_Pos)
 #define PARC_CFG_HALF_Pos           6            /**< \brief (PARC_CFG) Half Capture */
-#define PARC_CFG_HALF               (_U(0x1) << PARC_CFG_HALF_Pos)
+#define PARC_CFG_HALF               (_U_(0x1) << PARC_CFG_HALF_Pos)
 #define PARC_CFG_ODD_Pos            7            /**< \brief (PARC_CFG) Odd Capture */
-#define PARC_CFG_ODD                (_U(0x1) << PARC_CFG_ODD_Pos)
-#define PARC_CFG_MASK               _U(0x000000FF) /**< \brief (PARC_CFG) MASK Register */
+#define PARC_CFG_ODD                (_U_(0x1) << PARC_CFG_ODD_Pos)
+#define PARC_CFG_MASK               _U_(0x000000FF) /**< \brief (PARC_CFG) MASK Register */
 
 /* -------- PARC_CR : (PARC Offset: 0x04) (R/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -88,17 +88,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PARC_CR_OFFSET              0x04         /**< \brief (PARC_CR offset) Control Register */
-#define PARC_CR_RESETVALUE          _U(0x00000000); /**< \brief (PARC_CR reset_value) Control Register */
+#define PARC_CR_RESETVALUE          _U_(0x00000000); /**< \brief (PARC_CR reset_value) Control Register */
 
 #define PARC_CR_EN_Pos              0            /**< \brief (PARC_CR) Enable */
-#define PARC_CR_EN                  (_U(0x1) << PARC_CR_EN_Pos)
+#define PARC_CR_EN                  (_U_(0x1) << PARC_CR_EN_Pos)
 #define PARC_CR_DIS_Pos             1            /**< \brief (PARC_CR) Disable */
-#define PARC_CR_DIS                 (_U(0x1) << PARC_CR_DIS_Pos)
+#define PARC_CR_DIS                 (_U_(0x1) << PARC_CR_DIS_Pos)
 #define PARC_CR_START_Pos           2            /**< \brief (PARC_CR) Start Capture */
-#define PARC_CR_START               (_U(0x1) << PARC_CR_START_Pos)
+#define PARC_CR_START               (_U_(0x1) << PARC_CR_START_Pos)
 #define PARC_CR_STOP_Pos            3            /**< \brief (PARC_CR) Stop Capture */
-#define PARC_CR_STOP                (_U(0x1) << PARC_CR_STOP_Pos)
-#define PARC_CR_MASK                _U(0x0000000F) /**< \brief (PARC_CR) MASK Register */
+#define PARC_CR_STOP                (_U_(0x1) << PARC_CR_STOP_Pos)
+#define PARC_CR_MASK                _U_(0x0000000F) /**< \brief (PARC_CR) MASK Register */
 
 /* -------- PARC_IER : (PARC Offset: 0x08) ( /W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -114,13 +114,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PARC_IER_OFFSET             0x08         /**< \brief (PARC_IER offset) Interrupt Enable Register */
-#define PARC_IER_RESETVALUE         _U(0x00000000); /**< \brief (PARC_IER reset_value) Interrupt Enable Register */
+#define PARC_IER_RESETVALUE         _U_(0x00000000); /**< \brief (PARC_IER reset_value) Interrupt Enable Register */
 
 #define PARC_IER_DRDY_Pos           2            /**< \brief (PARC_IER) Data Ready Interrupt Enable */
-#define PARC_IER_DRDY               (_U(0x1) << PARC_IER_DRDY_Pos)
+#define PARC_IER_DRDY               (_U_(0x1) << PARC_IER_DRDY_Pos)
 #define PARC_IER_OVR_Pos            3            /**< \brief (PARC_IER) Overrun Interrupt Enable */
-#define PARC_IER_OVR                (_U(0x1) << PARC_IER_OVR_Pos)
-#define PARC_IER_MASK               _U(0x0000000C) /**< \brief (PARC_IER) MASK Register */
+#define PARC_IER_OVR                (_U_(0x1) << PARC_IER_OVR_Pos)
+#define PARC_IER_MASK               _U_(0x0000000C) /**< \brief (PARC_IER) MASK Register */
 
 /* -------- PARC_IDR : (PARC Offset: 0x0C) ( /W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -136,13 +136,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PARC_IDR_OFFSET             0x0C         /**< \brief (PARC_IDR offset) Interrupt Disable Register */
-#define PARC_IDR_RESETVALUE         _U(0x00000000); /**< \brief (PARC_IDR reset_value) Interrupt Disable Register */
+#define PARC_IDR_RESETVALUE         _U_(0x00000000); /**< \brief (PARC_IDR reset_value) Interrupt Disable Register */
 
 #define PARC_IDR_DRDY_Pos           2            /**< \brief (PARC_IDR) Data Ready Interrupt Disable */
-#define PARC_IDR_DRDY               (_U(0x1) << PARC_IDR_DRDY_Pos)
+#define PARC_IDR_DRDY               (_U_(0x1) << PARC_IDR_DRDY_Pos)
 #define PARC_IDR_OVR_Pos            3            /**< \brief (PARC_IDR) Overrun Interrupt Disable */
-#define PARC_IDR_OVR                (_U(0x1) << PARC_IDR_OVR_Pos)
-#define PARC_IDR_MASK               _U(0x0000000C) /**< \brief (PARC_IDR) MASK Register */
+#define PARC_IDR_OVR                (_U_(0x1) << PARC_IDR_OVR_Pos)
+#define PARC_IDR_MASK               _U_(0x0000000C) /**< \brief (PARC_IDR) MASK Register */
 
 /* -------- PARC_IMR : (PARC Offset: 0x10) (R/  32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -158,13 +158,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PARC_IMR_OFFSET             0x10         /**< \brief (PARC_IMR offset) Interrupt Mask Register */
-#define PARC_IMR_RESETVALUE         _U(0x00000000); /**< \brief (PARC_IMR reset_value) Interrupt Mask Register */
+#define PARC_IMR_RESETVALUE         _U_(0x00000000); /**< \brief (PARC_IMR reset_value) Interrupt Mask Register */
 
 #define PARC_IMR_DRDY_Pos           2            /**< \brief (PARC_IMR) Data Ready Interrupt Mask */
-#define PARC_IMR_DRDY               (_U(0x1) << PARC_IMR_DRDY_Pos)
+#define PARC_IMR_DRDY               (_U_(0x1) << PARC_IMR_DRDY_Pos)
 #define PARC_IMR_OVR_Pos            3            /**< \brief (PARC_IMR) Overrun Interrupt Mask */
-#define PARC_IMR_OVR                (_U(0x1) << PARC_IMR_OVR_Pos)
-#define PARC_IMR_MASK               _U(0x0000000C) /**< \brief (PARC_IMR) MASK Register */
+#define PARC_IMR_OVR                (_U_(0x1) << PARC_IMR_OVR_Pos)
+#define PARC_IMR_MASK               _U_(0x0000000C) /**< \brief (PARC_IMR) MASK Register */
 
 /* -------- PARC_SR : (PARC Offset: 0x14) (R/  32) Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -181,17 +181,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PARC_SR_OFFSET              0x14         /**< \brief (PARC_SR offset) Status Register */
-#define PARC_SR_RESETVALUE          _U(0x00000000); /**< \brief (PARC_SR reset_value) Status Register */
+#define PARC_SR_RESETVALUE          _U_(0x00000000); /**< \brief (PARC_SR reset_value) Status Register */
 
 #define PARC_SR_EN_Pos              0            /**< \brief (PARC_SR) Enable Status */
-#define PARC_SR_EN                  (_U(0x1) << PARC_SR_EN_Pos)
+#define PARC_SR_EN                  (_U_(0x1) << PARC_SR_EN_Pos)
 #define PARC_SR_CS_Pos              1            /**< \brief (PARC_SR) Capture Status */
-#define PARC_SR_CS                  (_U(0x1) << PARC_SR_CS_Pos)
+#define PARC_SR_CS                  (_U_(0x1) << PARC_SR_CS_Pos)
 #define PARC_SR_DRDY_Pos            2            /**< \brief (PARC_SR) Data Ready Interrupt Status */
-#define PARC_SR_DRDY                (_U(0x1) << PARC_SR_DRDY_Pos)
+#define PARC_SR_DRDY                (_U_(0x1) << PARC_SR_DRDY_Pos)
 #define PARC_SR_OVR_Pos             3            /**< \brief (PARC_SR) Overrun Interrupt Status */
-#define PARC_SR_OVR                 (_U(0x1) << PARC_SR_OVR_Pos)
-#define PARC_SR_MASK                _U(0x0000000F) /**< \brief (PARC_SR) MASK Register */
+#define PARC_SR_OVR                 (_U_(0x1) << PARC_SR_OVR_Pos)
+#define PARC_SR_MASK                _U_(0x0000000F) /**< \brief (PARC_SR) MASK Register */
 
 /* -------- PARC_ICR : (PARC Offset: 0x18) ( /W 32) Interrupt Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -207,13 +207,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PARC_ICR_OFFSET             0x18         /**< \brief (PARC_ICR offset) Interrupt Status Clear Register */
-#define PARC_ICR_RESETVALUE         _U(0x00000000); /**< \brief (PARC_ICR reset_value) Interrupt Status Clear Register */
+#define PARC_ICR_RESETVALUE         _U_(0x00000000); /**< \brief (PARC_ICR reset_value) Interrupt Status Clear Register */
 
 #define PARC_ICR_DRDY_Pos           2            /**< \brief (PARC_ICR) Data Ready Interrupt Status Clear */
-#define PARC_ICR_DRDY               (_U(0x1) << PARC_ICR_DRDY_Pos)
+#define PARC_ICR_DRDY               (_U_(0x1) << PARC_ICR_DRDY_Pos)
 #define PARC_ICR_OVR_Pos            3            /**< \brief (PARC_ICR) Overrun Interrupt Status Clear */
-#define PARC_ICR_OVR                (_U(0x1) << PARC_ICR_OVR_Pos)
-#define PARC_ICR_MASK               _U(0x0000000C) /**< \brief (PARC_ICR) MASK Register */
+#define PARC_ICR_OVR                (_U_(0x1) << PARC_ICR_OVR_Pos)
+#define PARC_ICR_MASK               _U_(0x0000000C) /**< \brief (PARC_ICR) MASK Register */
 
 /* -------- PARC_RHR : (PARC Offset: 0x1C) (R/  32) Receive Holding Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -226,12 +226,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PARC_RHR_OFFSET             0x1C         /**< \brief (PARC_RHR offset) Receive Holding Register */
-#define PARC_RHR_RESETVALUE         _U(0x00000000); /**< \brief (PARC_RHR reset_value) Receive Holding Register */
+#define PARC_RHR_RESETVALUE         _U_(0x00000000); /**< \brief (PARC_RHR reset_value) Receive Holding Register */
 
 #define PARC_RHR_CDATA_Pos          0            /**< \brief (PARC_RHR) Captured Data */
-#define PARC_RHR_CDATA_Msk          (_U(0xFFFFFFFF) << PARC_RHR_CDATA_Pos)
+#define PARC_RHR_CDATA_Msk          (_U_(0xFFFFFFFF) << PARC_RHR_CDATA_Pos)
 #define PARC_RHR_CDATA(value)       (PARC_RHR_CDATA_Msk & ((value) << PARC_RHR_CDATA_Pos))
-#define PARC_RHR_MASK               _U(0xFFFFFFFF) /**< \brief (PARC_RHR) MASK Register */
+#define PARC_RHR_MASK               _U_(0xFFFFFFFF) /**< \brief (PARC_RHR) MASK Register */
 
 /* -------- PARC_VERSION : (PARC Offset: 0x20) (R/  32) Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -247,15 +247,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PARC_VERSION_OFFSET         0x20         /**< \brief (PARC_VERSION offset) Version Register */
-#define PARC_VERSION_RESETVALUE     _U(0x00000100); /**< \brief (PARC_VERSION reset_value) Version Register */
+#define PARC_VERSION_RESETVALUE     _U_(0x00000100); /**< \brief (PARC_VERSION reset_value) Version Register */
 
 #define PARC_VERSION_VERSION_Pos    0            /**< \brief (PARC_VERSION) Version Number */
-#define PARC_VERSION_VERSION_Msk    (_U(0xFFF) << PARC_VERSION_VERSION_Pos)
+#define PARC_VERSION_VERSION_Msk    (_U_(0xFFF) << PARC_VERSION_VERSION_Pos)
 #define PARC_VERSION_VERSION(value) (PARC_VERSION_VERSION_Msk & ((value) << PARC_VERSION_VERSION_Pos))
 #define PARC_VERSION_VARIANT_Pos    16           /**< \brief (PARC_VERSION) Variant Number */
-#define PARC_VERSION_VARIANT_Msk    (_U(0xF) << PARC_VERSION_VARIANT_Pos)
+#define PARC_VERSION_VARIANT_Msk    (_U_(0xF) << PARC_VERSION_VARIANT_Pos)
 #define PARC_VERSION_VARIANT(value) (PARC_VERSION_VARIANT_Msk & ((value) << PARC_VERSION_VARIANT_Pos))
-#define PARC_VERSION_MASK           _U(0x000F0FFF) /**< \brief (PARC_VERSION) MASK Register */
+#define PARC_VERSION_MASK           _U_(0x000F0FFF) /**< \brief (PARC_VERSION) MASK Register */
 
 /** \brief PARC hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/parc.h
+++ b/asf/sam/include/sam4l/component/parc.h
@@ -259,29 +259,16 @@ typedef union {
 
 /** \brief PARC hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __IO PARC_CFG_Type             CFG;         /**< \brief Offset: 0x00 (R/W 32) Configuration Register */
-  __IO PARC_CR_Type              CR;          /**< \brief Offset: 0x04 (R/W 32) Control Register */
-  __O  PARC_IER_Type             IER;         /**< \brief Offset: 0x08 ( /W 32) Interrupt Enable Register */
-  __O  PARC_IDR_Type             IDR;         /**< \brief Offset: 0x0C ( /W 32) Interrupt Disable Register */
-  __I  PARC_IMR_Type             IMR;         /**< \brief Offset: 0x10 (R/  32) Interrupt Mask Register */
-  __I  PARC_SR_Type              SR;          /**< \brief Offset: 0x14 (R/  32) Status Register */
-  __O  PARC_ICR_Type             ICR;         /**< \brief Offset: 0x18 ( /W 32) Interrupt Status Clear Register */
-  __I  PARC_RHR_Type             RHR;         /**< \brief Offset: 0x1C (R/  32) Receive Holding Register */
-  __I  PARC_VERSION_Type         VERSION;     /**< \brief Offset: 0x20 (R/  32) Version Register */
- } bf;
- struct {
-  RwReg   PARC_CFG;           /**< \brief (PARC Offset: 0x00) Configuration Register */
-  RwReg   PARC_CR;            /**< \brief (PARC Offset: 0x04) Control Register */
-  WoReg   PARC_IER;           /**< \brief (PARC Offset: 0x08) Interrupt Enable Register */
-  WoReg   PARC_IDR;           /**< \brief (PARC Offset: 0x0C) Interrupt Disable Register */
-  RoReg   PARC_IMR;           /**< \brief (PARC Offset: 0x10) Interrupt Mask Register */
-  RoReg   PARC_SR;            /**< \brief (PARC Offset: 0x14) Status Register */
-  WoReg   PARC_ICR;           /**< \brief (PARC Offset: 0x18) Interrupt Status Clear Register */
-  RoReg   PARC_RHR;           /**< \brief (PARC Offset: 0x1C) Receive Holding Register */
-  RoReg   PARC_VERSION;       /**< \brief (PARC Offset: 0x20) Version Register */
- } reg;
+typedef struct {
+  __IO uint32_t CFG;         /**< \brief Offset: 0x00 (R/W 32) Configuration Register */
+  __IO uint32_t CR;          /**< \brief Offset: 0x04 (R/W 32) Control Register */
+  __O  uint32_t IER;         /**< \brief Offset: 0x08 ( /W 32) Interrupt Enable Register */
+  __O  uint32_t IDR;         /**< \brief Offset: 0x0C ( /W 32) Interrupt Disable Register */
+  __I  uint32_t IMR;         /**< \brief Offset: 0x10 (R/  32) Interrupt Mask Register */
+  __I  uint32_t SR;          /**< \brief Offset: 0x14 (R/  32) Status Register */
+  __O  uint32_t ICR;         /**< \brief Offset: 0x18 ( /W 32) Interrupt Status Clear Register */
+  __I  uint32_t RHR;         /**< \brief Offset: 0x1C (R/  32) Receive Holding Register */
+  __I  uint32_t VERSION;     /**< \brief Offset: 0x20 (R/  32) Version Register */
 } Parc;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/parc.h
+++ b/asf/sam/include/sam4l/component/parc.h
@@ -1,0 +1,290 @@
+/**
+ * \file
+ *
+ * \brief Component description for PARC
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_PARC_COMPONENT_
+#define _SAM4L_PARC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PARC */
+/* ========================================================================== */
+/** \addtogroup SAM4L_PARC Parallel Capture */
+/*@{*/
+
+#define PARC_I7570
+#define REV_PARC                    0x100
+
+/* -------- PARC_CFG : (PARC Offset: 0x00) (R/W 32) Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DSIZE:2;          /*!< bit:  0.. 1  Data Size                          */
+    uint32_t SMODE:2;          /*!< bit:  2.. 3  Sampling Mode                      */
+    uint32_t EMODE:1;          /*!< bit:      4  Events Mode                        */
+    uint32_t EDGE:1;           /*!< bit:      5  Sampling Edge Select               */
+    uint32_t HALF:1;           /*!< bit:      6  Half Capture                       */
+    uint32_t ODD:1;            /*!< bit:      7  Odd Capture                        */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PARC_CFG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PARC_CFG_OFFSET             0x00         /**< \brief (PARC_CFG offset) Configuration Register */
+#define PARC_CFG_RESETVALUE         _U(0x00000000); /**< \brief (PARC_CFG reset_value) Configuration Register */
+
+#define PARC_CFG_DSIZE_Pos          0            /**< \brief (PARC_CFG) Data Size */
+#define PARC_CFG_DSIZE_Msk          (_U(0x3) << PARC_CFG_DSIZE_Pos)
+#define PARC_CFG_DSIZE(value)       (PARC_CFG_DSIZE_Msk & ((value) << PARC_CFG_DSIZE_Pos))
+#define PARC_CFG_SMODE_Pos          2            /**< \brief (PARC_CFG) Sampling Mode */
+#define PARC_CFG_SMODE_Msk          (_U(0x3) << PARC_CFG_SMODE_Pos)
+#define PARC_CFG_SMODE(value)       (PARC_CFG_SMODE_Msk & ((value) << PARC_CFG_SMODE_Pos))
+#define PARC_CFG_EMODE_Pos          4            /**< \brief (PARC_CFG) Events Mode */
+#define PARC_CFG_EMODE              (_U(0x1) << PARC_CFG_EMODE_Pos)
+#define PARC_CFG_EDGE_Pos           5            /**< \brief (PARC_CFG) Sampling Edge Select */
+#define PARC_CFG_EDGE               (_U(0x1) << PARC_CFG_EDGE_Pos)
+#define PARC_CFG_HALF_Pos           6            /**< \brief (PARC_CFG) Half Capture */
+#define PARC_CFG_HALF               (_U(0x1) << PARC_CFG_HALF_Pos)
+#define PARC_CFG_ODD_Pos            7            /**< \brief (PARC_CFG) Odd Capture */
+#define PARC_CFG_ODD                (_U(0x1) << PARC_CFG_ODD_Pos)
+#define PARC_CFG_MASK               _U(0x000000FF) /**< \brief (PARC_CFG) MASK Register */
+
+/* -------- PARC_CR : (PARC Offset: 0x04) (R/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EN:1;             /*!< bit:      0  Enable                             */
+    uint32_t DIS:1;            /*!< bit:      1  Disable                            */
+    uint32_t START:1;          /*!< bit:      2  Start Capture                      */
+    uint32_t STOP:1;           /*!< bit:      3  Stop Capture                       */
+    uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PARC_CR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PARC_CR_OFFSET              0x04         /**< \brief (PARC_CR offset) Control Register */
+#define PARC_CR_RESETVALUE          _U(0x00000000); /**< \brief (PARC_CR reset_value) Control Register */
+
+#define PARC_CR_EN_Pos              0            /**< \brief (PARC_CR) Enable */
+#define PARC_CR_EN                  (_U(0x1) << PARC_CR_EN_Pos)
+#define PARC_CR_DIS_Pos             1            /**< \brief (PARC_CR) Disable */
+#define PARC_CR_DIS                 (_U(0x1) << PARC_CR_DIS_Pos)
+#define PARC_CR_START_Pos           2            /**< \brief (PARC_CR) Start Capture */
+#define PARC_CR_START               (_U(0x1) << PARC_CR_START_Pos)
+#define PARC_CR_STOP_Pos            3            /**< \brief (PARC_CR) Stop Capture */
+#define PARC_CR_STOP                (_U(0x1) << PARC_CR_STOP_Pos)
+#define PARC_CR_MASK                _U(0x0000000F) /**< \brief (PARC_CR) MASK Register */
+
+/* -------- PARC_IER : (PARC Offset: 0x08) ( /W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t DRDY:1;           /*!< bit:      2  Data Ready Interrupt Enable        */
+    uint32_t OVR:1;            /*!< bit:      3  Overrun Interrupt Enable           */
+    uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PARC_IER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PARC_IER_OFFSET             0x08         /**< \brief (PARC_IER offset) Interrupt Enable Register */
+#define PARC_IER_RESETVALUE         _U(0x00000000); /**< \brief (PARC_IER reset_value) Interrupt Enable Register */
+
+#define PARC_IER_DRDY_Pos           2            /**< \brief (PARC_IER) Data Ready Interrupt Enable */
+#define PARC_IER_DRDY               (_U(0x1) << PARC_IER_DRDY_Pos)
+#define PARC_IER_OVR_Pos            3            /**< \brief (PARC_IER) Overrun Interrupt Enable */
+#define PARC_IER_OVR                (_U(0x1) << PARC_IER_OVR_Pos)
+#define PARC_IER_MASK               _U(0x0000000C) /**< \brief (PARC_IER) MASK Register */
+
+/* -------- PARC_IDR : (PARC Offset: 0x0C) ( /W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t DRDY:1;           /*!< bit:      2  Data Ready Interrupt Disable       */
+    uint32_t OVR:1;            /*!< bit:      3  Overrun Interrupt Disable          */
+    uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PARC_IDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PARC_IDR_OFFSET             0x0C         /**< \brief (PARC_IDR offset) Interrupt Disable Register */
+#define PARC_IDR_RESETVALUE         _U(0x00000000); /**< \brief (PARC_IDR reset_value) Interrupt Disable Register */
+
+#define PARC_IDR_DRDY_Pos           2            /**< \brief (PARC_IDR) Data Ready Interrupt Disable */
+#define PARC_IDR_DRDY               (_U(0x1) << PARC_IDR_DRDY_Pos)
+#define PARC_IDR_OVR_Pos            3            /**< \brief (PARC_IDR) Overrun Interrupt Disable */
+#define PARC_IDR_OVR                (_U(0x1) << PARC_IDR_OVR_Pos)
+#define PARC_IDR_MASK               _U(0x0000000C) /**< \brief (PARC_IDR) MASK Register */
+
+/* -------- PARC_IMR : (PARC Offset: 0x10) (R/  32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t DRDY:1;           /*!< bit:      2  Data Ready Interrupt Mask          */
+    uint32_t OVR:1;            /*!< bit:      3  Overrun Interrupt Mask             */
+    uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PARC_IMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PARC_IMR_OFFSET             0x10         /**< \brief (PARC_IMR offset) Interrupt Mask Register */
+#define PARC_IMR_RESETVALUE         _U(0x00000000); /**< \brief (PARC_IMR reset_value) Interrupt Mask Register */
+
+#define PARC_IMR_DRDY_Pos           2            /**< \brief (PARC_IMR) Data Ready Interrupt Mask */
+#define PARC_IMR_DRDY               (_U(0x1) << PARC_IMR_DRDY_Pos)
+#define PARC_IMR_OVR_Pos            3            /**< \brief (PARC_IMR) Overrun Interrupt Mask */
+#define PARC_IMR_OVR                (_U(0x1) << PARC_IMR_OVR_Pos)
+#define PARC_IMR_MASK               _U(0x0000000C) /**< \brief (PARC_IMR) MASK Register */
+
+/* -------- PARC_SR : (PARC Offset: 0x14) (R/  32) Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EN:1;             /*!< bit:      0  Enable Status                      */
+    uint32_t CS:1;             /*!< bit:      1  Capture Status                     */
+    uint32_t DRDY:1;           /*!< bit:      2  Data Ready Interrupt Status        */
+    uint32_t OVR:1;            /*!< bit:      3  Overrun Interrupt Status           */
+    uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PARC_SR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PARC_SR_OFFSET              0x14         /**< \brief (PARC_SR offset) Status Register */
+#define PARC_SR_RESETVALUE          _U(0x00000000); /**< \brief (PARC_SR reset_value) Status Register */
+
+#define PARC_SR_EN_Pos              0            /**< \brief (PARC_SR) Enable Status */
+#define PARC_SR_EN                  (_U(0x1) << PARC_SR_EN_Pos)
+#define PARC_SR_CS_Pos              1            /**< \brief (PARC_SR) Capture Status */
+#define PARC_SR_CS                  (_U(0x1) << PARC_SR_CS_Pos)
+#define PARC_SR_DRDY_Pos            2            /**< \brief (PARC_SR) Data Ready Interrupt Status */
+#define PARC_SR_DRDY                (_U(0x1) << PARC_SR_DRDY_Pos)
+#define PARC_SR_OVR_Pos             3            /**< \brief (PARC_SR) Overrun Interrupt Status */
+#define PARC_SR_OVR                 (_U(0x1) << PARC_SR_OVR_Pos)
+#define PARC_SR_MASK                _U(0x0000000F) /**< \brief (PARC_SR) MASK Register */
+
+/* -------- PARC_ICR : (PARC Offset: 0x18) ( /W 32) Interrupt Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t DRDY:1;           /*!< bit:      2  Data Ready Interrupt Status Clear  */
+    uint32_t OVR:1;            /*!< bit:      3  Overrun Interrupt Status Clear     */
+    uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PARC_ICR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PARC_ICR_OFFSET             0x18         /**< \brief (PARC_ICR offset) Interrupt Status Clear Register */
+#define PARC_ICR_RESETVALUE         _U(0x00000000); /**< \brief (PARC_ICR reset_value) Interrupt Status Clear Register */
+
+#define PARC_ICR_DRDY_Pos           2            /**< \brief (PARC_ICR) Data Ready Interrupt Status Clear */
+#define PARC_ICR_DRDY               (_U(0x1) << PARC_ICR_DRDY_Pos)
+#define PARC_ICR_OVR_Pos            3            /**< \brief (PARC_ICR) Overrun Interrupt Status Clear */
+#define PARC_ICR_OVR                (_U(0x1) << PARC_ICR_OVR_Pos)
+#define PARC_ICR_MASK               _U(0x0000000C) /**< \brief (PARC_ICR) MASK Register */
+
+/* -------- PARC_RHR : (PARC Offset: 0x1C) (R/  32) Receive Holding Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CDATA:32;         /*!< bit:  0..31  Captured Data                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PARC_RHR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PARC_RHR_OFFSET             0x1C         /**< \brief (PARC_RHR offset) Receive Holding Register */
+#define PARC_RHR_RESETVALUE         _U(0x00000000); /**< \brief (PARC_RHR reset_value) Receive Holding Register */
+
+#define PARC_RHR_CDATA_Pos          0            /**< \brief (PARC_RHR) Captured Data */
+#define PARC_RHR_CDATA_Msk          (_U(0xFFFFFFFF) << PARC_RHR_CDATA_Pos)
+#define PARC_RHR_CDATA(value)       (PARC_RHR_CDATA_Msk & ((value) << PARC_RHR_CDATA_Pos))
+#define PARC_RHR_MASK               _U(0xFFFFFFFF) /**< \brief (PARC_RHR) MASK Register */
+
+/* -------- PARC_VERSION : (PARC Offset: 0x20) (R/  32) Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version Number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant Number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PARC_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PARC_VERSION_OFFSET         0x20         /**< \brief (PARC_VERSION offset) Version Register */
+#define PARC_VERSION_RESETVALUE     _U(0x00000100); /**< \brief (PARC_VERSION reset_value) Version Register */
+
+#define PARC_VERSION_VERSION_Pos    0            /**< \brief (PARC_VERSION) Version Number */
+#define PARC_VERSION_VERSION_Msk    (_U(0xFFF) << PARC_VERSION_VERSION_Pos)
+#define PARC_VERSION_VERSION(value) (PARC_VERSION_VERSION_Msk & ((value) << PARC_VERSION_VERSION_Pos))
+#define PARC_VERSION_VARIANT_Pos    16           /**< \brief (PARC_VERSION) Variant Number */
+#define PARC_VERSION_VARIANT_Msk    (_U(0xF) << PARC_VERSION_VARIANT_Pos)
+#define PARC_VERSION_VARIANT(value) (PARC_VERSION_VARIANT_Msk & ((value) << PARC_VERSION_VARIANT_Pos))
+#define PARC_VERSION_MASK           _U(0x000F0FFF) /**< \brief (PARC_VERSION) MASK Register */
+
+/** \brief PARC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __IO PARC_CFG_Type             CFG;         /**< \brief Offset: 0x00 (R/W 32) Configuration Register */
+  __IO PARC_CR_Type              CR;          /**< \brief Offset: 0x04 (R/W 32) Control Register */
+  __O  PARC_IER_Type             IER;         /**< \brief Offset: 0x08 ( /W 32) Interrupt Enable Register */
+  __O  PARC_IDR_Type             IDR;         /**< \brief Offset: 0x0C ( /W 32) Interrupt Disable Register */
+  __I  PARC_IMR_Type             IMR;         /**< \brief Offset: 0x10 (R/  32) Interrupt Mask Register */
+  __I  PARC_SR_Type              SR;          /**< \brief Offset: 0x14 (R/  32) Status Register */
+  __O  PARC_ICR_Type             ICR;         /**< \brief Offset: 0x18 ( /W 32) Interrupt Status Clear Register */
+  __I  PARC_RHR_Type             RHR;         /**< \brief Offset: 0x1C (R/  32) Receive Holding Register */
+  __I  PARC_VERSION_Type         VERSION;     /**< \brief Offset: 0x20 (R/  32) Version Register */
+ } bf;
+ struct {
+  RwReg   PARC_CFG;           /**< \brief (PARC Offset: 0x00) Configuration Register */
+  RwReg   PARC_CR;            /**< \brief (PARC Offset: 0x04) Control Register */
+  WoReg   PARC_IER;           /**< \brief (PARC Offset: 0x08) Interrupt Enable Register */
+  WoReg   PARC_IDR;           /**< \brief (PARC Offset: 0x0C) Interrupt Disable Register */
+  RoReg   PARC_IMR;           /**< \brief (PARC Offset: 0x10) Interrupt Mask Register */
+  RoReg   PARC_SR;            /**< \brief (PARC Offset: 0x14) Status Register */
+  WoReg   PARC_ICR;           /**< \brief (PARC Offset: 0x18) Interrupt Status Clear Register */
+  RoReg   PARC_RHR;           /**< \brief (PARC Offset: 0x1C) Receive Holding Register */
+  RoReg   PARC_VERSION;       /**< \brief (PARC Offset: 0x20) Version Register */
+ } reg;
+} Parc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_PARC_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/pdca.h
+++ b/asf/sam/include/sam4l/component/pdca.h
@@ -49,12 +49,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PDCA_MAR_OFFSET             0x000        /**< \brief (PDCA_MAR offset) Memory Address Register */
-#define PDCA_MAR_RESETVALUE         _U(0x00000000); /**< \brief (PDCA_MAR reset_value) Memory Address Register */
+#define PDCA_MAR_RESETVALUE         _U_(0x00000000); /**< \brief (PDCA_MAR reset_value) Memory Address Register */
 
 #define PDCA_MAR_MADDR_Pos          0            /**< \brief (PDCA_MAR) Memory Address */
-#define PDCA_MAR_MADDR_Msk          (_U(0xFFFFFFFF) << PDCA_MAR_MADDR_Pos)
+#define PDCA_MAR_MADDR_Msk          (_U_(0xFFFFFFFF) << PDCA_MAR_MADDR_Pos)
 #define PDCA_MAR_MADDR(value)       (PDCA_MAR_MADDR_Msk & ((value) << PDCA_MAR_MADDR_Pos))
-#define PDCA_MAR_MASK               _U(0xFFFFFFFF) /**< \brief (PDCA_MAR) MASK Register */
+#define PDCA_MAR_MASK               _U_(0xFFFFFFFF) /**< \brief (PDCA_MAR) MASK Register */
 
 /* -------- PDCA_PSR : (PDCA Offset: 0x004) (R/W 32) channel Peripheral Select Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -70,9 +70,9 @@ typedef union {
 #define PDCA_PSR_OFFSET             0x004        /**< \brief (PDCA_PSR offset) Peripheral Select Register */
 
 #define PDCA_PSR_PID_Pos            0            /**< \brief (PDCA_PSR) Peripheral Identifier */
-#define PDCA_PSR_PID_Msk            (_U(0xFF) << PDCA_PSR_PID_Pos)
+#define PDCA_PSR_PID_Msk            (_U_(0xFF) << PDCA_PSR_PID_Pos)
 #define PDCA_PSR_PID(value)         (PDCA_PSR_PID_Msk & ((value) << PDCA_PSR_PID_Pos))
-#define PDCA_PSR_MASK               _U(0x000000FF) /**< \brief (PDCA_PSR) MASK Register */
+#define PDCA_PSR_MASK               _U_(0x000000FF) /**< \brief (PDCA_PSR) MASK Register */
 
 /* -------- PDCA_TCR : (PDCA Offset: 0x008) (R/W 32) channel Transfer Counter Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -86,12 +86,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PDCA_TCR_OFFSET             0x008        /**< \brief (PDCA_TCR offset) Transfer Counter Register */
-#define PDCA_TCR_RESETVALUE         _U(0x00000000); /**< \brief (PDCA_TCR reset_value) Transfer Counter Register */
+#define PDCA_TCR_RESETVALUE         _U_(0x00000000); /**< \brief (PDCA_TCR reset_value) Transfer Counter Register */
 
 #define PDCA_TCR_TCV_Pos            0            /**< \brief (PDCA_TCR) Transfer Counter Value */
-#define PDCA_TCR_TCV_Msk            (_U(0xFFFF) << PDCA_TCR_TCV_Pos)
+#define PDCA_TCR_TCV_Msk            (_U_(0xFFFF) << PDCA_TCR_TCV_Pos)
 #define PDCA_TCR_TCV(value)         (PDCA_TCR_TCV_Msk & ((value) << PDCA_TCR_TCV_Pos))
-#define PDCA_TCR_MASK               _U(0x0000FFFF) /**< \brief (PDCA_TCR) MASK Register */
+#define PDCA_TCR_MASK               _U_(0x0000FFFF) /**< \brief (PDCA_TCR) MASK Register */
 
 /* -------- PDCA_MARR : (PDCA Offset: 0x00C) (R/W 32) channel Memory Address Reload Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -104,12 +104,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PDCA_MARR_OFFSET            0x00C        /**< \brief (PDCA_MARR offset) Memory Address Reload Register */
-#define PDCA_MARR_RESETVALUE        _U(0x00000000); /**< \brief (PDCA_MARR reset_value) Memory Address Reload Register */
+#define PDCA_MARR_RESETVALUE        _U_(0x00000000); /**< \brief (PDCA_MARR reset_value) Memory Address Reload Register */
 
 #define PDCA_MARR_MARV_Pos          0            /**< \brief (PDCA_MARR) Memory Address Reload Value */
-#define PDCA_MARR_MARV_Msk          (_U(0xFFFFFFFF) << PDCA_MARR_MARV_Pos)
+#define PDCA_MARR_MARV_Msk          (_U_(0xFFFFFFFF) << PDCA_MARR_MARV_Pos)
 #define PDCA_MARR_MARV(value)       (PDCA_MARR_MARV_Msk & ((value) << PDCA_MARR_MARV_Pos))
-#define PDCA_MARR_MASK              _U(0xFFFFFFFF) /**< \brief (PDCA_MARR) MASK Register */
+#define PDCA_MARR_MASK              _U_(0xFFFFFFFF) /**< \brief (PDCA_MARR) MASK Register */
 
 /* -------- PDCA_TCRR : (PDCA Offset: 0x010) (R/W 32) channel Transfer Counter Reload Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -123,12 +123,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PDCA_TCRR_OFFSET            0x010        /**< \brief (PDCA_TCRR offset) Transfer Counter Reload Register */
-#define PDCA_TCRR_RESETVALUE        _U(0x00000000); /**< \brief (PDCA_TCRR reset_value) Transfer Counter Reload Register */
+#define PDCA_TCRR_RESETVALUE        _U_(0x00000000); /**< \brief (PDCA_TCRR reset_value) Transfer Counter Reload Register */
 
 #define PDCA_TCRR_TCRV_Pos          0            /**< \brief (PDCA_TCRR) Transfer Counter Reload Value */
-#define PDCA_TCRR_TCRV_Msk          (_U(0xFFFF) << PDCA_TCRR_TCRV_Pos)
+#define PDCA_TCRR_TCRV_Msk          (_U_(0xFFFF) << PDCA_TCRR_TCRV_Pos)
 #define PDCA_TCRR_TCRV(value)       (PDCA_TCRR_TCRV_Msk & ((value) << PDCA_TCRR_TCRV_Pos))
-#define PDCA_TCRR_MASK              _U(0x0000FFFF) /**< \brief (PDCA_TCRR) MASK Register */
+#define PDCA_TCRR_MASK              _U_(0x0000FFFF) /**< \brief (PDCA_TCRR) MASK Register */
 
 /* -------- PDCA_CR : (PDCA Offset: 0x014) ( /W 32) channel Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -145,15 +145,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PDCA_CR_OFFSET              0x014        /**< \brief (PDCA_CR offset) Control Register */
-#define PDCA_CR_RESETVALUE          _U(0x00000000); /**< \brief (PDCA_CR reset_value) Control Register */
+#define PDCA_CR_RESETVALUE          _U_(0x00000000); /**< \brief (PDCA_CR reset_value) Control Register */
 
 #define PDCA_CR_TEN_Pos             0            /**< \brief (PDCA_CR) Transfer Enable */
-#define PDCA_CR_TEN                 (_U(0x1) << PDCA_CR_TEN_Pos)
+#define PDCA_CR_TEN                 (_U_(0x1) << PDCA_CR_TEN_Pos)
 #define PDCA_CR_TDIS_Pos            1            /**< \brief (PDCA_CR) Transfer Disable */
-#define PDCA_CR_TDIS                (_U(0x1) << PDCA_CR_TDIS_Pos)
+#define PDCA_CR_TDIS                (_U_(0x1) << PDCA_CR_TDIS_Pos)
 #define PDCA_CR_ECLR_Pos            8            /**< \brief (PDCA_CR) Error Clear */
-#define PDCA_CR_ECLR                (_U(0x1) << PDCA_CR_ECLR_Pos)
-#define PDCA_CR_MASK                _U(0x00000103) /**< \brief (PDCA_CR) MASK Register */
+#define PDCA_CR_ECLR                (_U_(0x1) << PDCA_CR_ECLR_Pos)
+#define PDCA_CR_MASK                _U_(0x00000103) /**< \brief (PDCA_CR) MASK Register */
 
 /* -------- PDCA_MR : (PDCA Offset: 0x018) (R/W 32) channel Mode Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -169,22 +169,22 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PDCA_MR_OFFSET              0x018        /**< \brief (PDCA_MR offset) Mode Register */
-#define PDCA_MR_RESETVALUE          _U(0x00000000); /**< \brief (PDCA_MR reset_value) Mode Register */
+#define PDCA_MR_RESETVALUE          _U_(0x00000000); /**< \brief (PDCA_MR reset_value) Mode Register */
 
 #define PDCA_MR_SIZE_Pos            0            /**< \brief (PDCA_MR) Transfer size */
-#define PDCA_MR_SIZE_Msk            (_U(0x3) << PDCA_MR_SIZE_Pos)
+#define PDCA_MR_SIZE_Msk            (_U_(0x3) << PDCA_MR_SIZE_Pos)
 #define PDCA_MR_SIZE(value)         (PDCA_MR_SIZE_Msk & ((value) << PDCA_MR_SIZE_Pos))
-#define   PDCA_MR_SIZE_BYTE_Val           _U(0x0)   /**< \brief (PDCA_MR)  */
-#define   PDCA_MR_SIZE_HALF_WORD_Val      _U(0x1)   /**< \brief (PDCA_MR)  */
-#define   PDCA_MR_SIZE_WORD_Val           _U(0x2)   /**< \brief (PDCA_MR)  */
+#define   PDCA_MR_SIZE_BYTE_Val           _U_(0x0)   /**< \brief (PDCA_MR)  */
+#define   PDCA_MR_SIZE_HALF_WORD_Val      _U_(0x1)   /**< \brief (PDCA_MR)  */
+#define   PDCA_MR_SIZE_WORD_Val           _U_(0x2)   /**< \brief (PDCA_MR)  */
 #define PDCA_MR_SIZE_BYTE           (PDCA_MR_SIZE_BYTE_Val         << PDCA_MR_SIZE_Pos)
 #define PDCA_MR_SIZE_HALF_WORD      (PDCA_MR_SIZE_HALF_WORD_Val    << PDCA_MR_SIZE_Pos)
 #define PDCA_MR_SIZE_WORD           (PDCA_MR_SIZE_WORD_Val         << PDCA_MR_SIZE_Pos)
 #define PDCA_MR_ETRIG_Pos           2            /**< \brief (PDCA_MR) Event trigger */
-#define PDCA_MR_ETRIG               (_U(0x1) << PDCA_MR_ETRIG_Pos)
+#define PDCA_MR_ETRIG               (_U_(0x1) << PDCA_MR_ETRIG_Pos)
 #define PDCA_MR_RING_Pos            3            /**< \brief (PDCA_MR) Ring Buffer */
-#define PDCA_MR_RING                (_U(0x1) << PDCA_MR_RING_Pos)
-#define PDCA_MR_MASK                _U(0x0000000F) /**< \brief (PDCA_MR) MASK Register */
+#define PDCA_MR_RING                (_U_(0x1) << PDCA_MR_RING_Pos)
+#define PDCA_MR_MASK                _U_(0x0000000F) /**< \brief (PDCA_MR) MASK Register */
 
 /* -------- PDCA_SR : (PDCA Offset: 0x01C) (R/  32) channel Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -198,11 +198,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PDCA_SR_OFFSET              0x01C        /**< \brief (PDCA_SR offset) Status Register */
-#define PDCA_SR_RESETVALUE          _U(0x00000000); /**< \brief (PDCA_SR reset_value) Status Register */
+#define PDCA_SR_RESETVALUE          _U_(0x00000000); /**< \brief (PDCA_SR reset_value) Status Register */
 
 #define PDCA_SR_TEN_Pos             0            /**< \brief (PDCA_SR) Transfer Enabled */
-#define PDCA_SR_TEN                 (_U(0x1) << PDCA_SR_TEN_Pos)
-#define PDCA_SR_MASK                _U(0x00000001) /**< \brief (PDCA_SR) MASK Register */
+#define PDCA_SR_TEN                 (_U_(0x1) << PDCA_SR_TEN_Pos)
+#define PDCA_SR_MASK                _U_(0x00000001) /**< \brief (PDCA_SR) MASK Register */
 
 /* -------- PDCA_IER : (PDCA Offset: 0x020) ( /W 32) channel Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -218,15 +218,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PDCA_IER_OFFSET             0x020        /**< \brief (PDCA_IER offset) Interrupt Enable Register */
-#define PDCA_IER_RESETVALUE         _U(0x00000000); /**< \brief (PDCA_IER reset_value) Interrupt Enable Register */
+#define PDCA_IER_RESETVALUE         _U_(0x00000000); /**< \brief (PDCA_IER reset_value) Interrupt Enable Register */
 
 #define PDCA_IER_RCZ_Pos            0            /**< \brief (PDCA_IER) Reload Counter Zero */
-#define PDCA_IER_RCZ                (_U(0x1) << PDCA_IER_RCZ_Pos)
+#define PDCA_IER_RCZ                (_U_(0x1) << PDCA_IER_RCZ_Pos)
 #define PDCA_IER_TRC_Pos            1            /**< \brief (PDCA_IER) Transfer Complete */
-#define PDCA_IER_TRC                (_U(0x1) << PDCA_IER_TRC_Pos)
+#define PDCA_IER_TRC                (_U_(0x1) << PDCA_IER_TRC_Pos)
 #define PDCA_IER_TERR_Pos           2            /**< \brief (PDCA_IER) Transfer Error */
-#define PDCA_IER_TERR               (_U(0x1) << PDCA_IER_TERR_Pos)
-#define PDCA_IER_MASK               _U(0x00000007) /**< \brief (PDCA_IER) MASK Register */
+#define PDCA_IER_TERR               (_U_(0x1) << PDCA_IER_TERR_Pos)
+#define PDCA_IER_MASK               _U_(0x00000007) /**< \brief (PDCA_IER) MASK Register */
 
 /* -------- PDCA_IDR : (PDCA Offset: 0x024) ( /W 32) channel Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -242,15 +242,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PDCA_IDR_OFFSET             0x024        /**< \brief (PDCA_IDR offset) Interrupt Disable Register */
-#define PDCA_IDR_RESETVALUE         _U(0x00000000); /**< \brief (PDCA_IDR reset_value) Interrupt Disable Register */
+#define PDCA_IDR_RESETVALUE         _U_(0x00000000); /**< \brief (PDCA_IDR reset_value) Interrupt Disable Register */
 
 #define PDCA_IDR_RCZ_Pos            0            /**< \brief (PDCA_IDR) Reload Counter Zero */
-#define PDCA_IDR_RCZ                (_U(0x1) << PDCA_IDR_RCZ_Pos)
+#define PDCA_IDR_RCZ                (_U_(0x1) << PDCA_IDR_RCZ_Pos)
 #define PDCA_IDR_TRC_Pos            1            /**< \brief (PDCA_IDR) Transfer Complete */
-#define PDCA_IDR_TRC                (_U(0x1) << PDCA_IDR_TRC_Pos)
+#define PDCA_IDR_TRC                (_U_(0x1) << PDCA_IDR_TRC_Pos)
 #define PDCA_IDR_TERR_Pos           2            /**< \brief (PDCA_IDR) Transfer Error */
-#define PDCA_IDR_TERR               (_U(0x1) << PDCA_IDR_TERR_Pos)
-#define PDCA_IDR_MASK               _U(0x00000007) /**< \brief (PDCA_IDR) MASK Register */
+#define PDCA_IDR_TERR               (_U_(0x1) << PDCA_IDR_TERR_Pos)
+#define PDCA_IDR_MASK               _U_(0x00000007) /**< \brief (PDCA_IDR) MASK Register */
 
 /* -------- PDCA_IMR : (PDCA Offset: 0x028) (R/  32) channel Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -266,15 +266,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PDCA_IMR_OFFSET             0x028        /**< \brief (PDCA_IMR offset) Interrupt Mask Register */
-#define PDCA_IMR_RESETVALUE         _U(0x00000000); /**< \brief (PDCA_IMR reset_value) Interrupt Mask Register */
+#define PDCA_IMR_RESETVALUE         _U_(0x00000000); /**< \brief (PDCA_IMR reset_value) Interrupt Mask Register */
 
 #define PDCA_IMR_RCZ_Pos            0            /**< \brief (PDCA_IMR) Reload Counter Zero */
-#define PDCA_IMR_RCZ                (_U(0x1) << PDCA_IMR_RCZ_Pos)
+#define PDCA_IMR_RCZ                (_U_(0x1) << PDCA_IMR_RCZ_Pos)
 #define PDCA_IMR_TRC_Pos            1            /**< \brief (PDCA_IMR) Transfer Complete */
-#define PDCA_IMR_TRC                (_U(0x1) << PDCA_IMR_TRC_Pos)
+#define PDCA_IMR_TRC                (_U_(0x1) << PDCA_IMR_TRC_Pos)
 #define PDCA_IMR_TERR_Pos           2            /**< \brief (PDCA_IMR) Transfer Error */
-#define PDCA_IMR_TERR               (_U(0x1) << PDCA_IMR_TERR_Pos)
-#define PDCA_IMR_MASK               _U(0x00000007) /**< \brief (PDCA_IMR) MASK Register */
+#define PDCA_IMR_TERR               (_U_(0x1) << PDCA_IMR_TERR_Pos)
+#define PDCA_IMR_MASK               _U_(0x00000007) /**< \brief (PDCA_IMR) MASK Register */
 
 /* -------- PDCA_ISR : (PDCA Offset: 0x02C) (R/  32) channel Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -290,15 +290,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PDCA_ISR_OFFSET             0x02C        /**< \brief (PDCA_ISR offset) Interrupt Status Register */
-#define PDCA_ISR_RESETVALUE         _U(0x00000000); /**< \brief (PDCA_ISR reset_value) Interrupt Status Register */
+#define PDCA_ISR_RESETVALUE         _U_(0x00000000); /**< \brief (PDCA_ISR reset_value) Interrupt Status Register */
 
 #define PDCA_ISR_RCZ_Pos            0            /**< \brief (PDCA_ISR) Reload Counter Zero */
-#define PDCA_ISR_RCZ                (_U(0x1) << PDCA_ISR_RCZ_Pos)
+#define PDCA_ISR_RCZ                (_U_(0x1) << PDCA_ISR_RCZ_Pos)
 #define PDCA_ISR_TRC_Pos            1            /**< \brief (PDCA_ISR) Transfer Complete */
-#define PDCA_ISR_TRC                (_U(0x1) << PDCA_ISR_TRC_Pos)
+#define PDCA_ISR_TRC                (_U_(0x1) << PDCA_ISR_TRC_Pos)
 #define PDCA_ISR_TERR_Pos           2            /**< \brief (PDCA_ISR) Transfer Error */
-#define PDCA_ISR_TERR               (_U(0x1) << PDCA_ISR_TERR_Pos)
-#define PDCA_ISR_MASK               _U(0x00000007) /**< \brief (PDCA_ISR) MASK Register */
+#define PDCA_ISR_TERR               (_U_(0x1) << PDCA_ISR_TERR_Pos)
+#define PDCA_ISR_MASK               _U_(0x00000007) /**< \brief (PDCA_ISR) MASK Register */
 
 /* -------- PDCA_PCONTROL : (PDCA Offset: 0x800) (R/W 32) Performance Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -323,27 +323,27 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PDCA_PCONTROL_OFFSET        0x800        /**< \brief (PDCA_PCONTROL offset) Performance Control Register */
-#define PDCA_PCONTROL_RESETVALUE    _U(0x00000000); /**< \brief (PDCA_PCONTROL reset_value) Performance Control Register */
+#define PDCA_PCONTROL_RESETVALUE    _U_(0x00000000); /**< \brief (PDCA_PCONTROL reset_value) Performance Control Register */
 
 #define PDCA_PCONTROL_CH0EN_Pos     0            /**< \brief (PDCA_PCONTROL) Channel 0 Enabled */
-#define PDCA_PCONTROL_CH0EN         (_U(0x1) << PDCA_PCONTROL_CH0EN_Pos)
+#define PDCA_PCONTROL_CH0EN         (_U_(0x1) << PDCA_PCONTROL_CH0EN_Pos)
 #define PDCA_PCONTROL_CH1EN_Pos     1            /**< \brief (PDCA_PCONTROL) Channel 1 Enabled. */
-#define PDCA_PCONTROL_CH1EN         (_U(0x1) << PDCA_PCONTROL_CH1EN_Pos)
+#define PDCA_PCONTROL_CH1EN         (_U_(0x1) << PDCA_PCONTROL_CH1EN_Pos)
 #define PDCA_PCONTROL_CH0OF_Pos     4            /**< \brief (PDCA_PCONTROL) Channel 0 Overflow Freeze */
-#define PDCA_PCONTROL_CH0OF         (_U(0x1) << PDCA_PCONTROL_CH0OF_Pos)
+#define PDCA_PCONTROL_CH0OF         (_U_(0x1) << PDCA_PCONTROL_CH0OF_Pos)
 #define PDCA_PCONTROL_CH1OF_Pos     5            /**< \brief (PDCA_PCONTROL) Channel 1 overflow freeze */
-#define PDCA_PCONTROL_CH1OF         (_U(0x1) << PDCA_PCONTROL_CH1OF_Pos)
+#define PDCA_PCONTROL_CH1OF         (_U_(0x1) << PDCA_PCONTROL_CH1OF_Pos)
 #define PDCA_PCONTROL_CH0RES_Pos    8            /**< \brief (PDCA_PCONTROL) Channel 0 counter reset */
-#define PDCA_PCONTROL_CH0RES        (_U(0x1) << PDCA_PCONTROL_CH0RES_Pos)
+#define PDCA_PCONTROL_CH0RES        (_U_(0x1) << PDCA_PCONTROL_CH0RES_Pos)
 #define PDCA_PCONTROL_CH1RES_Pos    9            /**< \brief (PDCA_PCONTROL) Channel 1 counter reset */
-#define PDCA_PCONTROL_CH1RES        (_U(0x1) << PDCA_PCONTROL_CH1RES_Pos)
+#define PDCA_PCONTROL_CH1RES        (_U_(0x1) << PDCA_PCONTROL_CH1RES_Pos)
 #define PDCA_PCONTROL_MON0CH_Pos    16           /**< \brief (PDCA_PCONTROL) PDCA Channel to monitor with counter 0 */
-#define PDCA_PCONTROL_MON0CH_Msk    (_U(0x3F) << PDCA_PCONTROL_MON0CH_Pos)
+#define PDCA_PCONTROL_MON0CH_Msk    (_U_(0x3F) << PDCA_PCONTROL_MON0CH_Pos)
 #define PDCA_PCONTROL_MON0CH(value) (PDCA_PCONTROL_MON0CH_Msk & ((value) << PDCA_PCONTROL_MON0CH_Pos))
 #define PDCA_PCONTROL_MON1CH_Pos    24           /**< \brief (PDCA_PCONTROL) PDCA Channel to monitor with counter 1 */
-#define PDCA_PCONTROL_MON1CH_Msk    (_U(0x3F) << PDCA_PCONTROL_MON1CH_Pos)
+#define PDCA_PCONTROL_MON1CH_Msk    (_U_(0x3F) << PDCA_PCONTROL_MON1CH_Pos)
 #define PDCA_PCONTROL_MON1CH(value) (PDCA_PCONTROL_MON1CH_Msk & ((value) << PDCA_PCONTROL_MON1CH_Pos))
-#define PDCA_PCONTROL_MASK          _U(0x3F3F0333) /**< \brief (PDCA_PCONTROL) MASK Register */
+#define PDCA_PCONTROL_MASK          _U_(0x3F3F0333) /**< \brief (PDCA_PCONTROL) MASK Register */
 
 /* -------- PDCA_PRDATA0 : (PDCA Offset: 0x804) (R/  32) Channel 0 Read Data Cycles -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -356,12 +356,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PDCA_PRDATA0_OFFSET         0x804        /**< \brief (PDCA_PRDATA0 offset) Channel 0 Read Data Cycles */
-#define PDCA_PRDATA0_RESETVALUE     _U(0x00000000); /**< \brief (PDCA_PRDATA0 reset_value) Channel 0 Read Data Cycles */
+#define PDCA_PRDATA0_RESETVALUE     _U_(0x00000000); /**< \brief (PDCA_PRDATA0 reset_value) Channel 0 Read Data Cycles */
 
 #define PDCA_PRDATA0_DATA_Pos       0            /**< \brief (PDCA_PRDATA0) Data Cycles Counted Since Last reset */
-#define PDCA_PRDATA0_DATA_Msk       (_U(0xFFFFFFFF) << PDCA_PRDATA0_DATA_Pos)
+#define PDCA_PRDATA0_DATA_Msk       (_U_(0xFFFFFFFF) << PDCA_PRDATA0_DATA_Pos)
 #define PDCA_PRDATA0_DATA(value)    (PDCA_PRDATA0_DATA_Msk & ((value) << PDCA_PRDATA0_DATA_Pos))
-#define PDCA_PRDATA0_MASK           _U(0xFFFFFFFF) /**< \brief (PDCA_PRDATA0) MASK Register */
+#define PDCA_PRDATA0_MASK           _U_(0xFFFFFFFF) /**< \brief (PDCA_PRDATA0) MASK Register */
 
 /* -------- PDCA_PRSTALL0 : (PDCA Offset: 0x808) (R/  32) Channel 0 Read Stall Cycles -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -374,12 +374,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PDCA_PRSTALL0_OFFSET        0x808        /**< \brief (PDCA_PRSTALL0 offset) Channel 0 Read Stall Cycles */
-#define PDCA_PRSTALL0_RESETVALUE    _U(0x00000000); /**< \brief (PDCA_PRSTALL0 reset_value) Channel 0 Read Stall Cycles */
+#define PDCA_PRSTALL0_RESETVALUE    _U_(0x00000000); /**< \brief (PDCA_PRSTALL0 reset_value) Channel 0 Read Stall Cycles */
 
 #define PDCA_PRSTALL0_STALL_Pos     0            /**< \brief (PDCA_PRSTALL0) Stall Cycles counted since last reset */
-#define PDCA_PRSTALL0_STALL_Msk     (_U(0xFFFFFFFF) << PDCA_PRSTALL0_STALL_Pos)
+#define PDCA_PRSTALL0_STALL_Msk     (_U_(0xFFFFFFFF) << PDCA_PRSTALL0_STALL_Pos)
 #define PDCA_PRSTALL0_STALL(value)  (PDCA_PRSTALL0_STALL_Msk & ((value) << PDCA_PRSTALL0_STALL_Pos))
-#define PDCA_PRSTALL0_MASK          _U(0xFFFFFFFF) /**< \brief (PDCA_PRSTALL0) MASK Register */
+#define PDCA_PRSTALL0_MASK          _U_(0xFFFFFFFF) /**< \brief (PDCA_PRSTALL0) MASK Register */
 
 /* -------- PDCA_PRLAT0 : (PDCA Offset: 0x80C) (R/  32) Channel 0 Read Max Latency -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -393,12 +393,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PDCA_PRLAT0_OFFSET          0x80C        /**< \brief (PDCA_PRLAT0 offset) Channel 0 Read Max Latency */
-#define PDCA_PRLAT0_RESETVALUE      _U(0x00000000); /**< \brief (PDCA_PRLAT0 reset_value) Channel 0 Read Max Latency */
+#define PDCA_PRLAT0_RESETVALUE      _U_(0x00000000); /**< \brief (PDCA_PRLAT0 reset_value) Channel 0 Read Max Latency */
 
 #define PDCA_PRLAT0_LAT_Pos         0            /**< \brief (PDCA_PRLAT0) Maximum Transfer Initiation cycles counted since last reset */
-#define PDCA_PRLAT0_LAT_Msk         (_U(0xFFFF) << PDCA_PRLAT0_LAT_Pos)
+#define PDCA_PRLAT0_LAT_Msk         (_U_(0xFFFF) << PDCA_PRLAT0_LAT_Pos)
 #define PDCA_PRLAT0_LAT(value)      (PDCA_PRLAT0_LAT_Msk & ((value) << PDCA_PRLAT0_LAT_Pos))
-#define PDCA_PRLAT0_MASK            _U(0x0000FFFF) /**< \brief (PDCA_PRLAT0) MASK Register */
+#define PDCA_PRLAT0_MASK            _U_(0x0000FFFF) /**< \brief (PDCA_PRLAT0) MASK Register */
 
 /* -------- PDCA_PWDATA0 : (PDCA Offset: 0x810) (R/  32) Channel 0 Write Data Cycles -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -411,12 +411,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PDCA_PWDATA0_OFFSET         0x810        /**< \brief (PDCA_PWDATA0 offset) Channel 0 Write Data Cycles */
-#define PDCA_PWDATA0_RESETVALUE     _U(0x00000000); /**< \brief (PDCA_PWDATA0 reset_value) Channel 0 Write Data Cycles */
+#define PDCA_PWDATA0_RESETVALUE     _U_(0x00000000); /**< \brief (PDCA_PWDATA0 reset_value) Channel 0 Write Data Cycles */
 
 #define PDCA_PWDATA0_DATA_Pos       0            /**< \brief (PDCA_PWDATA0) Data Cycles Counted since last Reset */
-#define PDCA_PWDATA0_DATA_Msk       (_U(0xFFFFFFFF) << PDCA_PWDATA0_DATA_Pos)
+#define PDCA_PWDATA0_DATA_Msk       (_U_(0xFFFFFFFF) << PDCA_PWDATA0_DATA_Pos)
 #define PDCA_PWDATA0_DATA(value)    (PDCA_PWDATA0_DATA_Msk & ((value) << PDCA_PWDATA0_DATA_Pos))
-#define PDCA_PWDATA0_MASK           _U(0xFFFFFFFF) /**< \brief (PDCA_PWDATA0) MASK Register */
+#define PDCA_PWDATA0_MASK           _U_(0xFFFFFFFF) /**< \brief (PDCA_PWDATA0) MASK Register */
 
 /* -------- PDCA_PWSTALL0 : (PDCA Offset: 0x814) (R/  32) Channel 0 Write Stall Cycles -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -429,12 +429,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PDCA_PWSTALL0_OFFSET        0x814        /**< \brief (PDCA_PWSTALL0 offset) Channel 0 Write Stall Cycles */
-#define PDCA_PWSTALL0_RESETVALUE    _U(0x00000000); /**< \brief (PDCA_PWSTALL0 reset_value) Channel 0 Write Stall Cycles */
+#define PDCA_PWSTALL0_RESETVALUE    _U_(0x00000000); /**< \brief (PDCA_PWSTALL0 reset_value) Channel 0 Write Stall Cycles */
 
 #define PDCA_PWSTALL0_STALL_Pos     0            /**< \brief (PDCA_PWSTALL0) Stall cycles counted since last reset */
-#define PDCA_PWSTALL0_STALL_Msk     (_U(0xFFFFFFFF) << PDCA_PWSTALL0_STALL_Pos)
+#define PDCA_PWSTALL0_STALL_Msk     (_U_(0xFFFFFFFF) << PDCA_PWSTALL0_STALL_Pos)
 #define PDCA_PWSTALL0_STALL(value)  (PDCA_PWSTALL0_STALL_Msk & ((value) << PDCA_PWSTALL0_STALL_Pos))
-#define PDCA_PWSTALL0_MASK          _U(0xFFFFFFFF) /**< \brief (PDCA_PWSTALL0) MASK Register */
+#define PDCA_PWSTALL0_MASK          _U_(0xFFFFFFFF) /**< \brief (PDCA_PWSTALL0) MASK Register */
 
 /* -------- PDCA_PWLAT0 : (PDCA Offset: 0x818) (R/  32) Channel0 Write Max Latency -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -448,12 +448,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PDCA_PWLAT0_OFFSET          0x818        /**< \brief (PDCA_PWLAT0 offset) Channel0 Write Max Latency */
-#define PDCA_PWLAT0_RESETVALUE      _U(0x00000000); /**< \brief (PDCA_PWLAT0 reset_value) Channel0 Write Max Latency */
+#define PDCA_PWLAT0_RESETVALUE      _U_(0x00000000); /**< \brief (PDCA_PWLAT0 reset_value) Channel0 Write Max Latency */
 
 #define PDCA_PWLAT0_LAT_Pos         0            /**< \brief (PDCA_PWLAT0) Maximum transfer initiation cycles counted since last reset */
-#define PDCA_PWLAT0_LAT_Msk         (_U(0xFFFF) << PDCA_PWLAT0_LAT_Pos)
+#define PDCA_PWLAT0_LAT_Msk         (_U_(0xFFFF) << PDCA_PWLAT0_LAT_Pos)
 #define PDCA_PWLAT0_LAT(value)      (PDCA_PWLAT0_LAT_Msk & ((value) << PDCA_PWLAT0_LAT_Pos))
-#define PDCA_PWLAT0_MASK            _U(0x0000FFFF) /**< \brief (PDCA_PWLAT0) MASK Register */
+#define PDCA_PWLAT0_MASK            _U_(0x0000FFFF) /**< \brief (PDCA_PWLAT0) MASK Register */
 
 /* -------- PDCA_PRDATA1 : (PDCA Offset: 0x81C) (R/  32) Channel 1 Read Data Cycles -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -466,12 +466,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PDCA_PRDATA1_OFFSET         0x81C        /**< \brief (PDCA_PRDATA1 offset) Channel 1 Read Data Cycles */
-#define PDCA_PRDATA1_RESETVALUE     _U(0x00000000); /**< \brief (PDCA_PRDATA1 reset_value) Channel 1 Read Data Cycles */
+#define PDCA_PRDATA1_RESETVALUE     _U_(0x00000000); /**< \brief (PDCA_PRDATA1 reset_value) Channel 1 Read Data Cycles */
 
 #define PDCA_PRDATA1_DATA_Pos       0            /**< \brief (PDCA_PRDATA1) Data Cycles Counted Since Last reset */
-#define PDCA_PRDATA1_DATA_Msk       (_U(0xFFFFFFFF) << PDCA_PRDATA1_DATA_Pos)
+#define PDCA_PRDATA1_DATA_Msk       (_U_(0xFFFFFFFF) << PDCA_PRDATA1_DATA_Pos)
 #define PDCA_PRDATA1_DATA(value)    (PDCA_PRDATA1_DATA_Msk & ((value) << PDCA_PRDATA1_DATA_Pos))
-#define PDCA_PRDATA1_MASK           _U(0xFFFFFFFF) /**< \brief (PDCA_PRDATA1) MASK Register */
+#define PDCA_PRDATA1_MASK           _U_(0xFFFFFFFF) /**< \brief (PDCA_PRDATA1) MASK Register */
 
 /* -------- PDCA_PRSTALL1 : (PDCA Offset: 0x820) (R/  32) Channel Read Stall Cycles -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -484,12 +484,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PDCA_PRSTALL1_OFFSET        0x820        /**< \brief (PDCA_PRSTALL1 offset) Channel Read Stall Cycles */
-#define PDCA_PRSTALL1_RESETVALUE    _U(0x00000000); /**< \brief (PDCA_PRSTALL1 reset_value) Channel Read Stall Cycles */
+#define PDCA_PRSTALL1_RESETVALUE    _U_(0x00000000); /**< \brief (PDCA_PRSTALL1 reset_value) Channel Read Stall Cycles */
 
 #define PDCA_PRSTALL1_STALL_Pos     0            /**< \brief (PDCA_PRSTALL1) Stall Cycles Counted since last reset */
-#define PDCA_PRSTALL1_STALL_Msk     (_U(0xFFFFFFFF) << PDCA_PRSTALL1_STALL_Pos)
+#define PDCA_PRSTALL1_STALL_Msk     (_U_(0xFFFFFFFF) << PDCA_PRSTALL1_STALL_Pos)
 #define PDCA_PRSTALL1_STALL(value)  (PDCA_PRSTALL1_STALL_Msk & ((value) << PDCA_PRSTALL1_STALL_Pos))
-#define PDCA_PRSTALL1_MASK          _U(0xFFFFFFFF) /**< \brief (PDCA_PRSTALL1) MASK Register */
+#define PDCA_PRSTALL1_MASK          _U_(0xFFFFFFFF) /**< \brief (PDCA_PRSTALL1) MASK Register */
 
 /* -------- PDCA_PRLAT1 : (PDCA Offset: 0x824) (R/  32) Channel 1 Read Max Latency -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -503,12 +503,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PDCA_PRLAT1_OFFSET          0x824        /**< \brief (PDCA_PRLAT1 offset) Channel 1 Read Max Latency */
-#define PDCA_PRLAT1_RESETVALUE      _U(0x00000000); /**< \brief (PDCA_PRLAT1 reset_value) Channel 1 Read Max Latency */
+#define PDCA_PRLAT1_RESETVALUE      _U_(0x00000000); /**< \brief (PDCA_PRLAT1 reset_value) Channel 1 Read Max Latency */
 
 #define PDCA_PRLAT1_LAT_Pos         0            /**< \brief (PDCA_PRLAT1) Maximum Transfer initiation cycles counted since last reset */
-#define PDCA_PRLAT1_LAT_Msk         (_U(0xFFFF) << PDCA_PRLAT1_LAT_Pos)
+#define PDCA_PRLAT1_LAT_Msk         (_U_(0xFFFF) << PDCA_PRLAT1_LAT_Pos)
 #define PDCA_PRLAT1_LAT(value)      (PDCA_PRLAT1_LAT_Msk & ((value) << PDCA_PRLAT1_LAT_Pos))
-#define PDCA_PRLAT1_MASK            _U(0x0000FFFF) /**< \brief (PDCA_PRLAT1) MASK Register */
+#define PDCA_PRLAT1_MASK            _U_(0x0000FFFF) /**< \brief (PDCA_PRLAT1) MASK Register */
 
 /* -------- PDCA_PWDATA1 : (PDCA Offset: 0x828) (R/  32) Channel 1 Write Data Cycles -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -521,12 +521,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PDCA_PWDATA1_OFFSET         0x828        /**< \brief (PDCA_PWDATA1 offset) Channel 1 Write Data Cycles */
-#define PDCA_PWDATA1_RESETVALUE     _U(0x00000000); /**< \brief (PDCA_PWDATA1 reset_value) Channel 1 Write Data Cycles */
+#define PDCA_PWDATA1_RESETVALUE     _U_(0x00000000); /**< \brief (PDCA_PWDATA1 reset_value) Channel 1 Write Data Cycles */
 
 #define PDCA_PWDATA1_DATA_Pos       0            /**< \brief (PDCA_PWDATA1) Data cycles Counted Since last reset */
-#define PDCA_PWDATA1_DATA_Msk       (_U(0xFFFFFFFF) << PDCA_PWDATA1_DATA_Pos)
+#define PDCA_PWDATA1_DATA_Msk       (_U_(0xFFFFFFFF) << PDCA_PWDATA1_DATA_Pos)
 #define PDCA_PWDATA1_DATA(value)    (PDCA_PWDATA1_DATA_Msk & ((value) << PDCA_PWDATA1_DATA_Pos))
-#define PDCA_PWDATA1_MASK           _U(0xFFFFFFFF) /**< \brief (PDCA_PWDATA1) MASK Register */
+#define PDCA_PWDATA1_MASK           _U_(0xFFFFFFFF) /**< \brief (PDCA_PWDATA1) MASK Register */
 
 /* -------- PDCA_PWSTALL1 : (PDCA Offset: 0x82C) (R/  32) Channel 1 Write stall Cycles -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -539,12 +539,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PDCA_PWSTALL1_OFFSET        0x82C        /**< \brief (PDCA_PWSTALL1 offset) Channel 1 Write stall Cycles */
-#define PDCA_PWSTALL1_RESETVALUE    _U(0x00000000); /**< \brief (PDCA_PWSTALL1 reset_value) Channel 1 Write stall Cycles */
+#define PDCA_PWSTALL1_RESETVALUE    _U_(0x00000000); /**< \brief (PDCA_PWSTALL1 reset_value) Channel 1 Write stall Cycles */
 
 #define PDCA_PWSTALL1_STALL_Pos     0            /**< \brief (PDCA_PWSTALL1) Stall cycles counted since last reset */
-#define PDCA_PWSTALL1_STALL_Msk     (_U(0xFFFFFFFF) << PDCA_PWSTALL1_STALL_Pos)
+#define PDCA_PWSTALL1_STALL_Msk     (_U_(0xFFFFFFFF) << PDCA_PWSTALL1_STALL_Pos)
 #define PDCA_PWSTALL1_STALL(value)  (PDCA_PWSTALL1_STALL_Msk & ((value) << PDCA_PWSTALL1_STALL_Pos))
-#define PDCA_PWSTALL1_MASK          _U(0xFFFFFFFF) /**< \brief (PDCA_PWSTALL1) MASK Register */
+#define PDCA_PWSTALL1_MASK          _U_(0xFFFFFFFF) /**< \brief (PDCA_PWSTALL1) MASK Register */
 
 /* -------- PDCA_PWLAT1 : (PDCA Offset: 0x830) (R/  32) Channel 1 Read Max Latency -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -558,12 +558,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PDCA_PWLAT1_OFFSET          0x830        /**< \brief (PDCA_PWLAT1 offset) Channel 1 Read Max Latency */
-#define PDCA_PWLAT1_RESETVALUE      _U(0x00000000); /**< \brief (PDCA_PWLAT1 reset_value) Channel 1 Read Max Latency */
+#define PDCA_PWLAT1_RESETVALUE      _U_(0x00000000); /**< \brief (PDCA_PWLAT1 reset_value) Channel 1 Read Max Latency */
 
 #define PDCA_PWLAT1_LAT_Pos         0            /**< \brief (PDCA_PWLAT1) Maximum transfer initiation cycles counted since last reset */
-#define PDCA_PWLAT1_LAT_Msk         (_U(0xFFFF) << PDCA_PWLAT1_LAT_Pos)
+#define PDCA_PWLAT1_LAT_Msk         (_U_(0xFFFF) << PDCA_PWLAT1_LAT_Pos)
 #define PDCA_PWLAT1_LAT(value)      (PDCA_PWLAT1_LAT_Msk & ((value) << PDCA_PWLAT1_LAT_Pos))
-#define PDCA_PWLAT1_MASK            _U(0x0000FFFF) /**< \brief (PDCA_PWLAT1) MASK Register */
+#define PDCA_PWLAT1_MASK            _U_(0x0000FFFF) /**< \brief (PDCA_PWLAT1) MASK Register */
 
 /* -------- PDCA_VERSION : (PDCA Offset: 0x834) (R/  32) Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -579,15 +579,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PDCA_VERSION_OFFSET         0x834        /**< \brief (PDCA_VERSION offset) Version Register */
-#define PDCA_VERSION_RESETVALUE     _U(0x00000124); /**< \brief (PDCA_VERSION reset_value) Version Register */
+#define PDCA_VERSION_RESETVALUE     _U_(0x00000124); /**< \brief (PDCA_VERSION reset_value) Version Register */
 
 #define PDCA_VERSION_VERSION_Pos    0            /**< \brief (PDCA_VERSION) Version Number */
-#define PDCA_VERSION_VERSION_Msk    (_U(0xFFF) << PDCA_VERSION_VERSION_Pos)
+#define PDCA_VERSION_VERSION_Msk    (_U_(0xFFF) << PDCA_VERSION_VERSION_Pos)
 #define PDCA_VERSION_VERSION(value) (PDCA_VERSION_VERSION_Msk & ((value) << PDCA_VERSION_VERSION_Pos))
 #define PDCA_VERSION_VARIANT_Pos    16           /**< \brief (PDCA_VERSION) Variant Number */
-#define PDCA_VERSION_VARIANT_Msk    (_U(0xF) << PDCA_VERSION_VARIANT_Pos)
+#define PDCA_VERSION_VARIANT_Msk    (_U_(0xF) << PDCA_VERSION_VARIANT_Pos)
 #define PDCA_VERSION_VARIANT(value) (PDCA_VERSION_VARIANT_Msk & ((value) << PDCA_VERSION_VARIANT_Pos))
-#define PDCA_VERSION_MASK           _U(0x000F0FFF) /**< \brief (PDCA_VERSION) MASK Register */
+#define PDCA_VERSION_MASK           _U_(0x000F0FFF) /**< \brief (PDCA_VERSION) MASK Register */
 
 /** \brief PdcaChannel hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/pdca.h
+++ b/asf/sam/include/sam4l/component/pdca.h
@@ -627,43 +627,23 @@ typedef union {
 
 /** \brief PDCA hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-       PdcaChannel               Channel[16]; /**< \brief Offset: 0x000 PdcaChannel groups [CHANNEL_LENGTH] */
-       RoReg8                    Reserved1[0x400];
-  __IO PDCA_PCONTROL_Type        PCONTROL;    /**< \brief Offset: 0x800 (R/W 32) Performance Control Register */
-  __I  PDCA_PRDATA0_Type         PRDATA0;     /**< \brief Offset: 0x804 (R/  32) Channel 0 Read Data Cycles */
-  __I  PDCA_PRSTALL0_Type        PRSTALL0;    /**< \brief Offset: 0x808 (R/  32) Channel 0 Read Stall Cycles */
-  __I  PDCA_PRLAT0_Type          PRLAT0;      /**< \brief Offset: 0x80C (R/  32) Channel 0 Read Max Latency */
-  __I  PDCA_PWDATA0_Type         PWDATA0;     /**< \brief Offset: 0x810 (R/  32) Channel 0 Write Data Cycles */
-  __I  PDCA_PWSTALL0_Type        PWSTALL0;    /**< \brief Offset: 0x814 (R/  32) Channel 0 Write Stall Cycles */
-  __I  PDCA_PWLAT0_Type          PWLAT0;      /**< \brief Offset: 0x818 (R/  32) Channel0 Write Max Latency */
-  __I  PDCA_PRDATA1_Type         PRDATA1;     /**< \brief Offset: 0x81C (R/  32) Channel 1 Read Data Cycles */
-  __I  PDCA_PRSTALL1_Type        PRSTALL1;    /**< \brief Offset: 0x820 (R/  32) Channel Read Stall Cycles */
-  __I  PDCA_PRLAT1_Type          PRLAT1;      /**< \brief Offset: 0x824 (R/  32) Channel 1 Read Max Latency */
-  __I  PDCA_PWDATA1_Type         PWDATA1;     /**< \brief Offset: 0x828 (R/  32) Channel 1 Write Data Cycles */
-  __I  PDCA_PWSTALL1_Type        PWSTALL1;    /**< \brief Offset: 0x82C (R/  32) Channel 1 Write stall Cycles */
-  __I  PDCA_PWLAT1_Type          PWLAT1;      /**< \brief Offset: 0x830 (R/  32) Channel 1 Read Max Latency */
-  __I  PDCA_VERSION_Type         VERSION;     /**< \brief Offset: 0x834 (R/  32) Version Register */
- } bf;
- struct {
-  PdcaChannel PDCA_CHANNEL[16];   /**< \brief (PDCA Offset: 0x000) PdcaChannel groups [CHANNEL_LENGTH] */
-  RoReg8  Reserved2[0x400];
-  RwReg   PDCA_PCONTROL;      /**< \brief (PDCA Offset: 0x800) Performance Control Register */
-  RoReg   PDCA_PRDATA0;       /**< \brief (PDCA Offset: 0x804) Channel 0 Read Data Cycles */
-  RoReg   PDCA_PRSTALL0;      /**< \brief (PDCA Offset: 0x808) Channel 0 Read Stall Cycles */
-  RoReg   PDCA_PRLAT0;        /**< \brief (PDCA Offset: 0x80C) Channel 0 Read Max Latency */
-  RoReg   PDCA_PWDATA0;       /**< \brief (PDCA Offset: 0x810) Channel 0 Write Data Cycles */
-  RoReg   PDCA_PWSTALL0;      /**< \brief (PDCA Offset: 0x814) Channel 0 Write Stall Cycles */
-  RoReg   PDCA_PWLAT0;        /**< \brief (PDCA Offset: 0x818) Channel0 Write Max Latency */
-  RoReg   PDCA_PRDATA1;       /**< \brief (PDCA Offset: 0x81C) Channel 1 Read Data Cycles */
-  RoReg   PDCA_PRSTALL1;      /**< \brief (PDCA Offset: 0x820) Channel Read Stall Cycles */
-  RoReg   PDCA_PRLAT1;        /**< \brief (PDCA Offset: 0x824) Channel 1 Read Max Latency */
-  RoReg   PDCA_PWDATA1;       /**< \brief (PDCA Offset: 0x828) Channel 1 Write Data Cycles */
-  RoReg   PDCA_PWSTALL1;      /**< \brief (PDCA Offset: 0x82C) Channel 1 Write stall Cycles */
-  RoReg   PDCA_PWLAT1;        /**< \brief (PDCA Offset: 0x830) Channel 1 Read Max Latency */
-  RoReg   PDCA_VERSION;       /**< \brief (PDCA Offset: 0x834) Version Register */
- } reg;
+typedef struct {
+  __IO uint32_t Channel[16]; /**< \brief Offset: 0x000 PdcaChannel groups [CHANNEL_LENGTH] */
+       RoReg8   Reserved1[0x400];
+  __IO uint32_t PCONTROL;    /**< \brief Offset: 0x800 (R/W 32) Performance Control Register */
+  __I  uint32_t PRDATA0;     /**< \brief Offset: 0x804 (R/  32) Channel 0 Read Data Cycles */
+  __I  uint32_t PRSTALL0;    /**< \brief Offset: 0x808 (R/  32) Channel 0 Read Stall Cycles */
+  __I  uint32_t PRLAT0;      /**< \brief Offset: 0x80C (R/  32) Channel 0 Read Max Latency */
+  __I  uint32_t PWDATA0;     /**< \brief Offset: 0x810 (R/  32) Channel 0 Write Data Cycles */
+  __I  uint32_t PWSTALL0;    /**< \brief Offset: 0x814 (R/  32) Channel 0 Write Stall Cycles */
+  __I  uint32_t PWLAT0;      /**< \brief Offset: 0x818 (R/  32) Channel0 Write Max Latency */
+  __I  uint32_t PRDATA1;     /**< \brief Offset: 0x81C (R/  32) Channel 1 Read Data Cycles */
+  __I  uint32_t PRSTALL1;    /**< \brief Offset: 0x820 (R/  32) Channel Read Stall Cycles */
+  __I  uint32_t PRLAT1;      /**< \brief Offset: 0x824 (R/  32) Channel 1 Read Max Latency */
+  __I  uint32_t PWDATA1;     /**< \brief Offset: 0x828 (R/  32) Channel 1 Write Data Cycles */
+  __I  uint32_t PWSTALL1;    /**< \brief Offset: 0x82C (R/  32) Channel 1 Write stall Cycles */
+  __I  uint32_t PWLAT1;      /**< \brief Offset: 0x830 (R/  32) Channel 1 Read Max Latency */
+  __I  uint32_t VERSION;     /**< \brief Offset: 0x834 (R/  32) Version Register */
 } Pdca;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/pdca.h
+++ b/asf/sam/include/sam4l/component/pdca.h
@@ -1,0 +1,672 @@
+/**
+ * \file
+ *
+ * \brief Component description for PDCA
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_PDCA_COMPONENT_
+#define _SAM4L_PDCA_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PDCA */
+/* ========================================================================== */
+/** \addtogroup SAM4L_PDCA Peripheral DMA Controller */
+/*@{*/
+
+#define PDCA_I7514
+#define REV_PDCA                    0x124
+
+/* -------- PDCA_MAR : (PDCA Offset: 0x000) (R/W 32) channel Memory Address Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t MADDR:32;         /*!< bit:  0..31  Memory Address                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PDCA_MAR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PDCA_MAR_OFFSET             0x000        /**< \brief (PDCA_MAR offset) Memory Address Register */
+#define PDCA_MAR_RESETVALUE         _U(0x00000000); /**< \brief (PDCA_MAR reset_value) Memory Address Register */
+
+#define PDCA_MAR_MADDR_Pos          0            /**< \brief (PDCA_MAR) Memory Address */
+#define PDCA_MAR_MADDR_Msk          (_U(0xFFFFFFFF) << PDCA_MAR_MADDR_Pos)
+#define PDCA_MAR_MADDR(value)       (PDCA_MAR_MADDR_Msk & ((value) << PDCA_MAR_MADDR_Pos))
+#define PDCA_MAR_MASK               _U(0xFFFFFFFF) /**< \brief (PDCA_MAR) MASK Register */
+
+/* -------- PDCA_PSR : (PDCA Offset: 0x004) (R/W 32) channel Peripheral Select Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PID:8;            /*!< bit:  0.. 7  Peripheral Identifier              */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PDCA_PSR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PDCA_PSR_OFFSET             0x004        /**< \brief (PDCA_PSR offset) Peripheral Select Register */
+
+#define PDCA_PSR_PID_Pos            0            /**< \brief (PDCA_PSR) Peripheral Identifier */
+#define PDCA_PSR_PID_Msk            (_U(0xFF) << PDCA_PSR_PID_Pos)
+#define PDCA_PSR_PID(value)         (PDCA_PSR_PID_Msk & ((value) << PDCA_PSR_PID_Pos))
+#define PDCA_PSR_MASK               _U(0x000000FF) /**< \brief (PDCA_PSR) MASK Register */
+
+/* -------- PDCA_TCR : (PDCA Offset: 0x008) (R/W 32) channel Transfer Counter Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TCV:16;           /*!< bit:  0..15  Transfer Counter Value             */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PDCA_TCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PDCA_TCR_OFFSET             0x008        /**< \brief (PDCA_TCR offset) Transfer Counter Register */
+#define PDCA_TCR_RESETVALUE         _U(0x00000000); /**< \brief (PDCA_TCR reset_value) Transfer Counter Register */
+
+#define PDCA_TCR_TCV_Pos            0            /**< \brief (PDCA_TCR) Transfer Counter Value */
+#define PDCA_TCR_TCV_Msk            (_U(0xFFFF) << PDCA_TCR_TCV_Pos)
+#define PDCA_TCR_TCV(value)         (PDCA_TCR_TCV_Msk & ((value) << PDCA_TCR_TCV_Pos))
+#define PDCA_TCR_MASK               _U(0x0000FFFF) /**< \brief (PDCA_TCR) MASK Register */
+
+/* -------- PDCA_MARR : (PDCA Offset: 0x00C) (R/W 32) channel Memory Address Reload Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t MARV:32;          /*!< bit:  0..31  Memory Address Reload Value        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PDCA_MARR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PDCA_MARR_OFFSET            0x00C        /**< \brief (PDCA_MARR offset) Memory Address Reload Register */
+#define PDCA_MARR_RESETVALUE        _U(0x00000000); /**< \brief (PDCA_MARR reset_value) Memory Address Reload Register */
+
+#define PDCA_MARR_MARV_Pos          0            /**< \brief (PDCA_MARR) Memory Address Reload Value */
+#define PDCA_MARR_MARV_Msk          (_U(0xFFFFFFFF) << PDCA_MARR_MARV_Pos)
+#define PDCA_MARR_MARV(value)       (PDCA_MARR_MARV_Msk & ((value) << PDCA_MARR_MARV_Pos))
+#define PDCA_MARR_MASK              _U(0xFFFFFFFF) /**< \brief (PDCA_MARR) MASK Register */
+
+/* -------- PDCA_TCRR : (PDCA Offset: 0x010) (R/W 32) channel Transfer Counter Reload Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TCRV:16;          /*!< bit:  0..15  Transfer Counter Reload Value      */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PDCA_TCRR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PDCA_TCRR_OFFSET            0x010        /**< \brief (PDCA_TCRR offset) Transfer Counter Reload Register */
+#define PDCA_TCRR_RESETVALUE        _U(0x00000000); /**< \brief (PDCA_TCRR reset_value) Transfer Counter Reload Register */
+
+#define PDCA_TCRR_TCRV_Pos          0            /**< \brief (PDCA_TCRR) Transfer Counter Reload Value */
+#define PDCA_TCRR_TCRV_Msk          (_U(0xFFFF) << PDCA_TCRR_TCRV_Pos)
+#define PDCA_TCRR_TCRV(value)       (PDCA_TCRR_TCRV_Msk & ((value) << PDCA_TCRR_TCRV_Pos))
+#define PDCA_TCRR_MASK              _U(0x0000FFFF) /**< \brief (PDCA_TCRR) MASK Register */
+
+/* -------- PDCA_CR : (PDCA Offset: 0x014) ( /W 32) channel Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TEN:1;            /*!< bit:      0  Transfer Enable                    */
+    uint32_t TDIS:1;           /*!< bit:      1  Transfer Disable                   */
+    uint32_t :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint32_t ECLR:1;           /*!< bit:      8  Error Clear                        */
+    uint32_t :23;              /*!< bit:  9..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PDCA_CR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PDCA_CR_OFFSET              0x014        /**< \brief (PDCA_CR offset) Control Register */
+#define PDCA_CR_RESETVALUE          _U(0x00000000); /**< \brief (PDCA_CR reset_value) Control Register */
+
+#define PDCA_CR_TEN_Pos             0            /**< \brief (PDCA_CR) Transfer Enable */
+#define PDCA_CR_TEN                 (_U(0x1) << PDCA_CR_TEN_Pos)
+#define PDCA_CR_TDIS_Pos            1            /**< \brief (PDCA_CR) Transfer Disable */
+#define PDCA_CR_TDIS                (_U(0x1) << PDCA_CR_TDIS_Pos)
+#define PDCA_CR_ECLR_Pos            8            /**< \brief (PDCA_CR) Error Clear */
+#define PDCA_CR_ECLR                (_U(0x1) << PDCA_CR_ECLR_Pos)
+#define PDCA_CR_MASK                _U(0x00000103) /**< \brief (PDCA_CR) MASK Register */
+
+/* -------- PDCA_MR : (PDCA Offset: 0x018) (R/W 32) channel Mode Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SIZE:2;           /*!< bit:  0.. 1  Transfer size                      */
+    uint32_t ETRIG:1;          /*!< bit:      2  Event trigger                      */
+    uint32_t RING:1;           /*!< bit:      3  Ring Buffer                        */
+    uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PDCA_MR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PDCA_MR_OFFSET              0x018        /**< \brief (PDCA_MR offset) Mode Register */
+#define PDCA_MR_RESETVALUE          _U(0x00000000); /**< \brief (PDCA_MR reset_value) Mode Register */
+
+#define PDCA_MR_SIZE_Pos            0            /**< \brief (PDCA_MR) Transfer size */
+#define PDCA_MR_SIZE_Msk            (_U(0x3) << PDCA_MR_SIZE_Pos)
+#define PDCA_MR_SIZE(value)         (PDCA_MR_SIZE_Msk & ((value) << PDCA_MR_SIZE_Pos))
+#define   PDCA_MR_SIZE_BYTE_Val           _U(0x0)   /**< \brief (PDCA_MR)  */
+#define   PDCA_MR_SIZE_HALF_WORD_Val      _U(0x1)   /**< \brief (PDCA_MR)  */
+#define   PDCA_MR_SIZE_WORD_Val           _U(0x2)   /**< \brief (PDCA_MR)  */
+#define PDCA_MR_SIZE_BYTE           (PDCA_MR_SIZE_BYTE_Val         << PDCA_MR_SIZE_Pos)
+#define PDCA_MR_SIZE_HALF_WORD      (PDCA_MR_SIZE_HALF_WORD_Val    << PDCA_MR_SIZE_Pos)
+#define PDCA_MR_SIZE_WORD           (PDCA_MR_SIZE_WORD_Val         << PDCA_MR_SIZE_Pos)
+#define PDCA_MR_ETRIG_Pos           2            /**< \brief (PDCA_MR) Event trigger */
+#define PDCA_MR_ETRIG               (_U(0x1) << PDCA_MR_ETRIG_Pos)
+#define PDCA_MR_RING_Pos            3            /**< \brief (PDCA_MR) Ring Buffer */
+#define PDCA_MR_RING                (_U(0x1) << PDCA_MR_RING_Pos)
+#define PDCA_MR_MASK                _U(0x0000000F) /**< \brief (PDCA_MR) MASK Register */
+
+/* -------- PDCA_SR : (PDCA Offset: 0x01C) (R/  32) channel Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TEN:1;            /*!< bit:      0  Transfer Enabled                   */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PDCA_SR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PDCA_SR_OFFSET              0x01C        /**< \brief (PDCA_SR offset) Status Register */
+#define PDCA_SR_RESETVALUE          _U(0x00000000); /**< \brief (PDCA_SR reset_value) Status Register */
+
+#define PDCA_SR_TEN_Pos             0            /**< \brief (PDCA_SR) Transfer Enabled */
+#define PDCA_SR_TEN                 (_U(0x1) << PDCA_SR_TEN_Pos)
+#define PDCA_SR_MASK                _U(0x00000001) /**< \brief (PDCA_SR) MASK Register */
+
+/* -------- PDCA_IER : (PDCA Offset: 0x020) ( /W 32) channel Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RCZ:1;            /*!< bit:      0  Reload Counter Zero                */
+    uint32_t TRC:1;            /*!< bit:      1  Transfer Complete                  */
+    uint32_t TERR:1;           /*!< bit:      2  Transfer Error                     */
+    uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PDCA_IER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PDCA_IER_OFFSET             0x020        /**< \brief (PDCA_IER offset) Interrupt Enable Register */
+#define PDCA_IER_RESETVALUE         _U(0x00000000); /**< \brief (PDCA_IER reset_value) Interrupt Enable Register */
+
+#define PDCA_IER_RCZ_Pos            0            /**< \brief (PDCA_IER) Reload Counter Zero */
+#define PDCA_IER_RCZ                (_U(0x1) << PDCA_IER_RCZ_Pos)
+#define PDCA_IER_TRC_Pos            1            /**< \brief (PDCA_IER) Transfer Complete */
+#define PDCA_IER_TRC                (_U(0x1) << PDCA_IER_TRC_Pos)
+#define PDCA_IER_TERR_Pos           2            /**< \brief (PDCA_IER) Transfer Error */
+#define PDCA_IER_TERR               (_U(0x1) << PDCA_IER_TERR_Pos)
+#define PDCA_IER_MASK               _U(0x00000007) /**< \brief (PDCA_IER) MASK Register */
+
+/* -------- PDCA_IDR : (PDCA Offset: 0x024) ( /W 32) channel Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RCZ:1;            /*!< bit:      0  Reload Counter Zero                */
+    uint32_t TRC:1;            /*!< bit:      1  Transfer Complete                  */
+    uint32_t TERR:1;           /*!< bit:      2  Transfer Error                     */
+    uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PDCA_IDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PDCA_IDR_OFFSET             0x024        /**< \brief (PDCA_IDR offset) Interrupt Disable Register */
+#define PDCA_IDR_RESETVALUE         _U(0x00000000); /**< \brief (PDCA_IDR reset_value) Interrupt Disable Register */
+
+#define PDCA_IDR_RCZ_Pos            0            /**< \brief (PDCA_IDR) Reload Counter Zero */
+#define PDCA_IDR_RCZ                (_U(0x1) << PDCA_IDR_RCZ_Pos)
+#define PDCA_IDR_TRC_Pos            1            /**< \brief (PDCA_IDR) Transfer Complete */
+#define PDCA_IDR_TRC                (_U(0x1) << PDCA_IDR_TRC_Pos)
+#define PDCA_IDR_TERR_Pos           2            /**< \brief (PDCA_IDR) Transfer Error */
+#define PDCA_IDR_TERR               (_U(0x1) << PDCA_IDR_TERR_Pos)
+#define PDCA_IDR_MASK               _U(0x00000007) /**< \brief (PDCA_IDR) MASK Register */
+
+/* -------- PDCA_IMR : (PDCA Offset: 0x028) (R/  32) channel Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RCZ:1;            /*!< bit:      0  Reload Counter Zero                */
+    uint32_t TRC:1;            /*!< bit:      1  Transfer Complete                  */
+    uint32_t TERR:1;           /*!< bit:      2  Transfer Error                     */
+    uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PDCA_IMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PDCA_IMR_OFFSET             0x028        /**< \brief (PDCA_IMR offset) Interrupt Mask Register */
+#define PDCA_IMR_RESETVALUE         _U(0x00000000); /**< \brief (PDCA_IMR reset_value) Interrupt Mask Register */
+
+#define PDCA_IMR_RCZ_Pos            0            /**< \brief (PDCA_IMR) Reload Counter Zero */
+#define PDCA_IMR_RCZ                (_U(0x1) << PDCA_IMR_RCZ_Pos)
+#define PDCA_IMR_TRC_Pos            1            /**< \brief (PDCA_IMR) Transfer Complete */
+#define PDCA_IMR_TRC                (_U(0x1) << PDCA_IMR_TRC_Pos)
+#define PDCA_IMR_TERR_Pos           2            /**< \brief (PDCA_IMR) Transfer Error */
+#define PDCA_IMR_TERR               (_U(0x1) << PDCA_IMR_TERR_Pos)
+#define PDCA_IMR_MASK               _U(0x00000007) /**< \brief (PDCA_IMR) MASK Register */
+
+/* -------- PDCA_ISR : (PDCA Offset: 0x02C) (R/  32) channel Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RCZ:1;            /*!< bit:      0  Reload Counter Zero                */
+    uint32_t TRC:1;            /*!< bit:      1  Transfer Complete                  */
+    uint32_t TERR:1;           /*!< bit:      2  Transfer Error                     */
+    uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PDCA_ISR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PDCA_ISR_OFFSET             0x02C        /**< \brief (PDCA_ISR offset) Interrupt Status Register */
+#define PDCA_ISR_RESETVALUE         _U(0x00000000); /**< \brief (PDCA_ISR reset_value) Interrupt Status Register */
+
+#define PDCA_ISR_RCZ_Pos            0            /**< \brief (PDCA_ISR) Reload Counter Zero */
+#define PDCA_ISR_RCZ                (_U(0x1) << PDCA_ISR_RCZ_Pos)
+#define PDCA_ISR_TRC_Pos            1            /**< \brief (PDCA_ISR) Transfer Complete */
+#define PDCA_ISR_TRC                (_U(0x1) << PDCA_ISR_TRC_Pos)
+#define PDCA_ISR_TERR_Pos           2            /**< \brief (PDCA_ISR) Transfer Error */
+#define PDCA_ISR_TERR               (_U(0x1) << PDCA_ISR_TERR_Pos)
+#define PDCA_ISR_MASK               _U(0x00000007) /**< \brief (PDCA_ISR) MASK Register */
+
+/* -------- PDCA_PCONTROL : (PDCA Offset: 0x800) (R/W 32) Performance Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CH0EN:1;          /*!< bit:      0  Channel 0 Enabled                  */
+    uint32_t CH1EN:1;          /*!< bit:      1  Channel 1 Enabled.                 */
+    uint32_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint32_t CH0OF:1;          /*!< bit:      4  Channel 0 Overflow Freeze          */
+    uint32_t CH1OF:1;          /*!< bit:      5  Channel 1 overflow freeze          */
+    uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t CH0RES:1;         /*!< bit:      8  Channel 0 counter reset            */
+    uint32_t CH1RES:1;         /*!< bit:      9  Channel 1 counter reset            */
+    uint32_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint32_t MON0CH:6;         /*!< bit: 16..21  PDCA Channel to monitor with counter 0 */
+    uint32_t :2;               /*!< bit: 22..23  Reserved                           */
+    uint32_t MON1CH:6;         /*!< bit: 24..29  PDCA Channel to monitor with counter 1 */
+    uint32_t :2;               /*!< bit: 30..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PDCA_PCONTROL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PDCA_PCONTROL_OFFSET        0x800        /**< \brief (PDCA_PCONTROL offset) Performance Control Register */
+#define PDCA_PCONTROL_RESETVALUE    _U(0x00000000); /**< \brief (PDCA_PCONTROL reset_value) Performance Control Register */
+
+#define PDCA_PCONTROL_CH0EN_Pos     0            /**< \brief (PDCA_PCONTROL) Channel 0 Enabled */
+#define PDCA_PCONTROL_CH0EN         (_U(0x1) << PDCA_PCONTROL_CH0EN_Pos)
+#define PDCA_PCONTROL_CH1EN_Pos     1            /**< \brief (PDCA_PCONTROL) Channel 1 Enabled. */
+#define PDCA_PCONTROL_CH1EN         (_U(0x1) << PDCA_PCONTROL_CH1EN_Pos)
+#define PDCA_PCONTROL_CH0OF_Pos     4            /**< \brief (PDCA_PCONTROL) Channel 0 Overflow Freeze */
+#define PDCA_PCONTROL_CH0OF         (_U(0x1) << PDCA_PCONTROL_CH0OF_Pos)
+#define PDCA_PCONTROL_CH1OF_Pos     5            /**< \brief (PDCA_PCONTROL) Channel 1 overflow freeze */
+#define PDCA_PCONTROL_CH1OF         (_U(0x1) << PDCA_PCONTROL_CH1OF_Pos)
+#define PDCA_PCONTROL_CH0RES_Pos    8            /**< \brief (PDCA_PCONTROL) Channel 0 counter reset */
+#define PDCA_PCONTROL_CH0RES        (_U(0x1) << PDCA_PCONTROL_CH0RES_Pos)
+#define PDCA_PCONTROL_CH1RES_Pos    9            /**< \brief (PDCA_PCONTROL) Channel 1 counter reset */
+#define PDCA_PCONTROL_CH1RES        (_U(0x1) << PDCA_PCONTROL_CH1RES_Pos)
+#define PDCA_PCONTROL_MON0CH_Pos    16           /**< \brief (PDCA_PCONTROL) PDCA Channel to monitor with counter 0 */
+#define PDCA_PCONTROL_MON0CH_Msk    (_U(0x3F) << PDCA_PCONTROL_MON0CH_Pos)
+#define PDCA_PCONTROL_MON0CH(value) (PDCA_PCONTROL_MON0CH_Msk & ((value) << PDCA_PCONTROL_MON0CH_Pos))
+#define PDCA_PCONTROL_MON1CH_Pos    24           /**< \brief (PDCA_PCONTROL) PDCA Channel to monitor with counter 1 */
+#define PDCA_PCONTROL_MON1CH_Msk    (_U(0x3F) << PDCA_PCONTROL_MON1CH_Pos)
+#define PDCA_PCONTROL_MON1CH(value) (PDCA_PCONTROL_MON1CH_Msk & ((value) << PDCA_PCONTROL_MON1CH_Pos))
+#define PDCA_PCONTROL_MASK          _U(0x3F3F0333) /**< \brief (PDCA_PCONTROL) MASK Register */
+
+/* -------- PDCA_PRDATA0 : (PDCA Offset: 0x804) (R/  32) Channel 0 Read Data Cycles -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATA:32;          /*!< bit:  0..31  Data Cycles Counted Since Last reset */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PDCA_PRDATA0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PDCA_PRDATA0_OFFSET         0x804        /**< \brief (PDCA_PRDATA0 offset) Channel 0 Read Data Cycles */
+#define PDCA_PRDATA0_RESETVALUE     _U(0x00000000); /**< \brief (PDCA_PRDATA0 reset_value) Channel 0 Read Data Cycles */
+
+#define PDCA_PRDATA0_DATA_Pos       0            /**< \brief (PDCA_PRDATA0) Data Cycles Counted Since Last reset */
+#define PDCA_PRDATA0_DATA_Msk       (_U(0xFFFFFFFF) << PDCA_PRDATA0_DATA_Pos)
+#define PDCA_PRDATA0_DATA(value)    (PDCA_PRDATA0_DATA_Msk & ((value) << PDCA_PRDATA0_DATA_Pos))
+#define PDCA_PRDATA0_MASK           _U(0xFFFFFFFF) /**< \brief (PDCA_PRDATA0) MASK Register */
+
+/* -------- PDCA_PRSTALL0 : (PDCA Offset: 0x808) (R/  32) Channel 0 Read Stall Cycles -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t STALL:32;         /*!< bit:  0..31  Stall Cycles counted since last reset */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PDCA_PRSTALL0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PDCA_PRSTALL0_OFFSET        0x808        /**< \brief (PDCA_PRSTALL0 offset) Channel 0 Read Stall Cycles */
+#define PDCA_PRSTALL0_RESETVALUE    _U(0x00000000); /**< \brief (PDCA_PRSTALL0 reset_value) Channel 0 Read Stall Cycles */
+
+#define PDCA_PRSTALL0_STALL_Pos     0            /**< \brief (PDCA_PRSTALL0) Stall Cycles counted since last reset */
+#define PDCA_PRSTALL0_STALL_Msk     (_U(0xFFFFFFFF) << PDCA_PRSTALL0_STALL_Pos)
+#define PDCA_PRSTALL0_STALL(value)  (PDCA_PRSTALL0_STALL_Msk & ((value) << PDCA_PRSTALL0_STALL_Pos))
+#define PDCA_PRSTALL0_MASK          _U(0xFFFFFFFF) /**< \brief (PDCA_PRSTALL0) MASK Register */
+
+/* -------- PDCA_PRLAT0 : (PDCA Offset: 0x80C) (R/  32) Channel 0 Read Max Latency -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t LAT:16;           /*!< bit:  0..15  Maximum Transfer Initiation cycles counted since last reset */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PDCA_PRLAT0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PDCA_PRLAT0_OFFSET          0x80C        /**< \brief (PDCA_PRLAT0 offset) Channel 0 Read Max Latency */
+#define PDCA_PRLAT0_RESETVALUE      _U(0x00000000); /**< \brief (PDCA_PRLAT0 reset_value) Channel 0 Read Max Latency */
+
+#define PDCA_PRLAT0_LAT_Pos         0            /**< \brief (PDCA_PRLAT0) Maximum Transfer Initiation cycles counted since last reset */
+#define PDCA_PRLAT0_LAT_Msk         (_U(0xFFFF) << PDCA_PRLAT0_LAT_Pos)
+#define PDCA_PRLAT0_LAT(value)      (PDCA_PRLAT0_LAT_Msk & ((value) << PDCA_PRLAT0_LAT_Pos))
+#define PDCA_PRLAT0_MASK            _U(0x0000FFFF) /**< \brief (PDCA_PRLAT0) MASK Register */
+
+/* -------- PDCA_PWDATA0 : (PDCA Offset: 0x810) (R/  32) Channel 0 Write Data Cycles -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATA:32;          /*!< bit:  0..31  Data Cycles Counted since last Reset */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PDCA_PWDATA0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PDCA_PWDATA0_OFFSET         0x810        /**< \brief (PDCA_PWDATA0 offset) Channel 0 Write Data Cycles */
+#define PDCA_PWDATA0_RESETVALUE     _U(0x00000000); /**< \brief (PDCA_PWDATA0 reset_value) Channel 0 Write Data Cycles */
+
+#define PDCA_PWDATA0_DATA_Pos       0            /**< \brief (PDCA_PWDATA0) Data Cycles Counted since last Reset */
+#define PDCA_PWDATA0_DATA_Msk       (_U(0xFFFFFFFF) << PDCA_PWDATA0_DATA_Pos)
+#define PDCA_PWDATA0_DATA(value)    (PDCA_PWDATA0_DATA_Msk & ((value) << PDCA_PWDATA0_DATA_Pos))
+#define PDCA_PWDATA0_MASK           _U(0xFFFFFFFF) /**< \brief (PDCA_PWDATA0) MASK Register */
+
+/* -------- PDCA_PWSTALL0 : (PDCA Offset: 0x814) (R/  32) Channel 0 Write Stall Cycles -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t STALL:32;         /*!< bit:  0..31  Stall cycles counted since last reset */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PDCA_PWSTALL0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PDCA_PWSTALL0_OFFSET        0x814        /**< \brief (PDCA_PWSTALL0 offset) Channel 0 Write Stall Cycles */
+#define PDCA_PWSTALL0_RESETVALUE    _U(0x00000000); /**< \brief (PDCA_PWSTALL0 reset_value) Channel 0 Write Stall Cycles */
+
+#define PDCA_PWSTALL0_STALL_Pos     0            /**< \brief (PDCA_PWSTALL0) Stall cycles counted since last reset */
+#define PDCA_PWSTALL0_STALL_Msk     (_U(0xFFFFFFFF) << PDCA_PWSTALL0_STALL_Pos)
+#define PDCA_PWSTALL0_STALL(value)  (PDCA_PWSTALL0_STALL_Msk & ((value) << PDCA_PWSTALL0_STALL_Pos))
+#define PDCA_PWSTALL0_MASK          _U(0xFFFFFFFF) /**< \brief (PDCA_PWSTALL0) MASK Register */
+
+/* -------- PDCA_PWLAT0 : (PDCA Offset: 0x818) (R/  32) Channel0 Write Max Latency -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t LAT:16;           /*!< bit:  0..15  Maximum transfer initiation cycles counted since last reset */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PDCA_PWLAT0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PDCA_PWLAT0_OFFSET          0x818        /**< \brief (PDCA_PWLAT0 offset) Channel0 Write Max Latency */
+#define PDCA_PWLAT0_RESETVALUE      _U(0x00000000); /**< \brief (PDCA_PWLAT0 reset_value) Channel0 Write Max Latency */
+
+#define PDCA_PWLAT0_LAT_Pos         0            /**< \brief (PDCA_PWLAT0) Maximum transfer initiation cycles counted since last reset */
+#define PDCA_PWLAT0_LAT_Msk         (_U(0xFFFF) << PDCA_PWLAT0_LAT_Pos)
+#define PDCA_PWLAT0_LAT(value)      (PDCA_PWLAT0_LAT_Msk & ((value) << PDCA_PWLAT0_LAT_Pos))
+#define PDCA_PWLAT0_MASK            _U(0x0000FFFF) /**< \brief (PDCA_PWLAT0) MASK Register */
+
+/* -------- PDCA_PRDATA1 : (PDCA Offset: 0x81C) (R/  32) Channel 1 Read Data Cycles -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATA:32;          /*!< bit:  0..31  Data Cycles Counted Since Last reset */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PDCA_PRDATA1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PDCA_PRDATA1_OFFSET         0x81C        /**< \brief (PDCA_PRDATA1 offset) Channel 1 Read Data Cycles */
+#define PDCA_PRDATA1_RESETVALUE     _U(0x00000000); /**< \brief (PDCA_PRDATA1 reset_value) Channel 1 Read Data Cycles */
+
+#define PDCA_PRDATA1_DATA_Pos       0            /**< \brief (PDCA_PRDATA1) Data Cycles Counted Since Last reset */
+#define PDCA_PRDATA1_DATA_Msk       (_U(0xFFFFFFFF) << PDCA_PRDATA1_DATA_Pos)
+#define PDCA_PRDATA1_DATA(value)    (PDCA_PRDATA1_DATA_Msk & ((value) << PDCA_PRDATA1_DATA_Pos))
+#define PDCA_PRDATA1_MASK           _U(0xFFFFFFFF) /**< \brief (PDCA_PRDATA1) MASK Register */
+
+/* -------- PDCA_PRSTALL1 : (PDCA Offset: 0x820) (R/  32) Channel Read Stall Cycles -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t STALL:32;         /*!< bit:  0..31  Stall Cycles Counted since last reset */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PDCA_PRSTALL1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PDCA_PRSTALL1_OFFSET        0x820        /**< \brief (PDCA_PRSTALL1 offset) Channel Read Stall Cycles */
+#define PDCA_PRSTALL1_RESETVALUE    _U(0x00000000); /**< \brief (PDCA_PRSTALL1 reset_value) Channel Read Stall Cycles */
+
+#define PDCA_PRSTALL1_STALL_Pos     0            /**< \brief (PDCA_PRSTALL1) Stall Cycles Counted since last reset */
+#define PDCA_PRSTALL1_STALL_Msk     (_U(0xFFFFFFFF) << PDCA_PRSTALL1_STALL_Pos)
+#define PDCA_PRSTALL1_STALL(value)  (PDCA_PRSTALL1_STALL_Msk & ((value) << PDCA_PRSTALL1_STALL_Pos))
+#define PDCA_PRSTALL1_MASK          _U(0xFFFFFFFF) /**< \brief (PDCA_PRSTALL1) MASK Register */
+
+/* -------- PDCA_PRLAT1 : (PDCA Offset: 0x824) (R/  32) Channel 1 Read Max Latency -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t LAT:16;           /*!< bit:  0..15  Maximum Transfer initiation cycles counted since last reset */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PDCA_PRLAT1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PDCA_PRLAT1_OFFSET          0x824        /**< \brief (PDCA_PRLAT1 offset) Channel 1 Read Max Latency */
+#define PDCA_PRLAT1_RESETVALUE      _U(0x00000000); /**< \brief (PDCA_PRLAT1 reset_value) Channel 1 Read Max Latency */
+
+#define PDCA_PRLAT1_LAT_Pos         0            /**< \brief (PDCA_PRLAT1) Maximum Transfer initiation cycles counted since last reset */
+#define PDCA_PRLAT1_LAT_Msk         (_U(0xFFFF) << PDCA_PRLAT1_LAT_Pos)
+#define PDCA_PRLAT1_LAT(value)      (PDCA_PRLAT1_LAT_Msk & ((value) << PDCA_PRLAT1_LAT_Pos))
+#define PDCA_PRLAT1_MASK            _U(0x0000FFFF) /**< \brief (PDCA_PRLAT1) MASK Register */
+
+/* -------- PDCA_PWDATA1 : (PDCA Offset: 0x828) (R/  32) Channel 1 Write Data Cycles -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATA:32;          /*!< bit:  0..31  Data cycles Counted Since last reset */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PDCA_PWDATA1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PDCA_PWDATA1_OFFSET         0x828        /**< \brief (PDCA_PWDATA1 offset) Channel 1 Write Data Cycles */
+#define PDCA_PWDATA1_RESETVALUE     _U(0x00000000); /**< \brief (PDCA_PWDATA1 reset_value) Channel 1 Write Data Cycles */
+
+#define PDCA_PWDATA1_DATA_Pos       0            /**< \brief (PDCA_PWDATA1) Data cycles Counted Since last reset */
+#define PDCA_PWDATA1_DATA_Msk       (_U(0xFFFFFFFF) << PDCA_PWDATA1_DATA_Pos)
+#define PDCA_PWDATA1_DATA(value)    (PDCA_PWDATA1_DATA_Msk & ((value) << PDCA_PWDATA1_DATA_Pos))
+#define PDCA_PWDATA1_MASK           _U(0xFFFFFFFF) /**< \brief (PDCA_PWDATA1) MASK Register */
+
+/* -------- PDCA_PWSTALL1 : (PDCA Offset: 0x82C) (R/  32) Channel 1 Write stall Cycles -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t STALL:32;         /*!< bit:  0..31  Stall cycles counted since last reset */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PDCA_PWSTALL1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PDCA_PWSTALL1_OFFSET        0x82C        /**< \brief (PDCA_PWSTALL1 offset) Channel 1 Write stall Cycles */
+#define PDCA_PWSTALL1_RESETVALUE    _U(0x00000000); /**< \brief (PDCA_PWSTALL1 reset_value) Channel 1 Write stall Cycles */
+
+#define PDCA_PWSTALL1_STALL_Pos     0            /**< \brief (PDCA_PWSTALL1) Stall cycles counted since last reset */
+#define PDCA_PWSTALL1_STALL_Msk     (_U(0xFFFFFFFF) << PDCA_PWSTALL1_STALL_Pos)
+#define PDCA_PWSTALL1_STALL(value)  (PDCA_PWSTALL1_STALL_Msk & ((value) << PDCA_PWSTALL1_STALL_Pos))
+#define PDCA_PWSTALL1_MASK          _U(0xFFFFFFFF) /**< \brief (PDCA_PWSTALL1) MASK Register */
+
+/* -------- PDCA_PWLAT1 : (PDCA Offset: 0x830) (R/  32) Channel 1 Read Max Latency -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t LAT:16;           /*!< bit:  0..15  Maximum transfer initiation cycles counted since last reset */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PDCA_PWLAT1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PDCA_PWLAT1_OFFSET          0x830        /**< \brief (PDCA_PWLAT1 offset) Channel 1 Read Max Latency */
+#define PDCA_PWLAT1_RESETVALUE      _U(0x00000000); /**< \brief (PDCA_PWLAT1 reset_value) Channel 1 Read Max Latency */
+
+#define PDCA_PWLAT1_LAT_Pos         0            /**< \brief (PDCA_PWLAT1) Maximum transfer initiation cycles counted since last reset */
+#define PDCA_PWLAT1_LAT_Msk         (_U(0xFFFF) << PDCA_PWLAT1_LAT_Pos)
+#define PDCA_PWLAT1_LAT(value)      (PDCA_PWLAT1_LAT_Msk & ((value) << PDCA_PWLAT1_LAT_Pos))
+#define PDCA_PWLAT1_MASK            _U(0x0000FFFF) /**< \brief (PDCA_PWLAT1) MASK Register */
+
+/* -------- PDCA_VERSION : (PDCA Offset: 0x834) (R/  32) Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version Number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant Number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PDCA_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PDCA_VERSION_OFFSET         0x834        /**< \brief (PDCA_VERSION offset) Version Register */
+#define PDCA_VERSION_RESETVALUE     _U(0x00000124); /**< \brief (PDCA_VERSION reset_value) Version Register */
+
+#define PDCA_VERSION_VERSION_Pos    0            /**< \brief (PDCA_VERSION) Version Number */
+#define PDCA_VERSION_VERSION_Msk    (_U(0xFFF) << PDCA_VERSION_VERSION_Pos)
+#define PDCA_VERSION_VERSION(value) (PDCA_VERSION_VERSION_Msk & ((value) << PDCA_VERSION_VERSION_Pos))
+#define PDCA_VERSION_VARIANT_Pos    16           /**< \brief (PDCA_VERSION) Variant Number */
+#define PDCA_VERSION_VARIANT_Msk    (_U(0xF) << PDCA_VERSION_VARIANT_Pos)
+#define PDCA_VERSION_VARIANT(value) (PDCA_VERSION_VARIANT_Msk & ((value) << PDCA_VERSION_VARIANT_Pos))
+#define PDCA_VERSION_MASK           _U(0x000F0FFF) /**< \brief (PDCA_VERSION) MASK Register */
+
+/** \brief PdcaChannel hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __IO PDCA_MAR_Type             MAR;         /**< \brief Offset: 0x000 (R/W 32) Memory Address Register */
+  __IO PDCA_PSR_Type             PSR;         /**< \brief Offset: 0x004 (R/W 32) Peripheral Select Register */
+  __IO PDCA_TCR_Type             TCR;         /**< \brief Offset: 0x008 (R/W 32) Transfer Counter Register */
+  __IO PDCA_MARR_Type            MARR;        /**< \brief Offset: 0x00C (R/W 32) Memory Address Reload Register */
+  __IO PDCA_TCRR_Type            TCRR;        /**< \brief Offset: 0x010 (R/W 32) Transfer Counter Reload Register */
+  __O  PDCA_CR_Type              CR;          /**< \brief Offset: 0x014 ( /W 32) Control Register */
+  __IO PDCA_MR_Type              MR;          /**< \brief Offset: 0x018 (R/W 32) Mode Register */
+  __I  PDCA_SR_Type              SR;          /**< \brief Offset: 0x01C (R/  32) Status Register */
+  __O  PDCA_IER_Type             IER;         /**< \brief Offset: 0x020 ( /W 32) Interrupt Enable Register */
+  __O  PDCA_IDR_Type             IDR;         /**< \brief Offset: 0x024 ( /W 32) Interrupt Disable Register */
+  __I  PDCA_IMR_Type             IMR;         /**< \brief Offset: 0x028 (R/  32) Interrupt Mask Register */
+  __I  PDCA_ISR_Type             ISR;         /**< \brief Offset: 0x02C (R/  32) Interrupt Status Register */
+       RoReg8                    Reserved1[0x10];
+ } bf;
+ struct {
+  RwReg   PDCA_MAR;           /**< \brief (PDCA Offset: 0x000) Memory Address Register */
+  RwReg   PDCA_PSR;           /**< \brief (PDCA Offset: 0x004) Peripheral Select Register */
+  RwReg   PDCA_TCR;           /**< \brief (PDCA Offset: 0x008) Transfer Counter Register */
+  RwReg   PDCA_MARR;          /**< \brief (PDCA Offset: 0x00C) Memory Address Reload Register */
+  RwReg   PDCA_TCRR;          /**< \brief (PDCA Offset: 0x010) Transfer Counter Reload Register */
+  WoReg   PDCA_CR;            /**< \brief (PDCA Offset: 0x014) Control Register */
+  RwReg   PDCA_MR;            /**< \brief (PDCA Offset: 0x018) Mode Register */
+  RoReg   PDCA_SR;            /**< \brief (PDCA Offset: 0x01C) Status Register */
+  WoReg   PDCA_IER;           /**< \brief (PDCA Offset: 0x020) Interrupt Enable Register */
+  WoReg   PDCA_IDR;           /**< \brief (PDCA Offset: 0x024) Interrupt Disable Register */
+  RoReg   PDCA_IMR;           /**< \brief (PDCA Offset: 0x028) Interrupt Mask Register */
+  RoReg   PDCA_ISR;           /**< \brief (PDCA Offset: 0x02C) Interrupt Status Register */
+  RoReg8  Reserved2[0x10];
+ } reg;
+} PdcaChannel;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief PDCA hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+       PdcaChannel               Channel[16]; /**< \brief Offset: 0x000 PdcaChannel groups [CHANNEL_LENGTH] */
+       RoReg8                    Reserved1[0x400];
+  __IO PDCA_PCONTROL_Type        PCONTROL;    /**< \brief Offset: 0x800 (R/W 32) Performance Control Register */
+  __I  PDCA_PRDATA0_Type         PRDATA0;     /**< \brief Offset: 0x804 (R/  32) Channel 0 Read Data Cycles */
+  __I  PDCA_PRSTALL0_Type        PRSTALL0;    /**< \brief Offset: 0x808 (R/  32) Channel 0 Read Stall Cycles */
+  __I  PDCA_PRLAT0_Type          PRLAT0;      /**< \brief Offset: 0x80C (R/  32) Channel 0 Read Max Latency */
+  __I  PDCA_PWDATA0_Type         PWDATA0;     /**< \brief Offset: 0x810 (R/  32) Channel 0 Write Data Cycles */
+  __I  PDCA_PWSTALL0_Type        PWSTALL0;    /**< \brief Offset: 0x814 (R/  32) Channel 0 Write Stall Cycles */
+  __I  PDCA_PWLAT0_Type          PWLAT0;      /**< \brief Offset: 0x818 (R/  32) Channel0 Write Max Latency */
+  __I  PDCA_PRDATA1_Type         PRDATA1;     /**< \brief Offset: 0x81C (R/  32) Channel 1 Read Data Cycles */
+  __I  PDCA_PRSTALL1_Type        PRSTALL1;    /**< \brief Offset: 0x820 (R/  32) Channel Read Stall Cycles */
+  __I  PDCA_PRLAT1_Type          PRLAT1;      /**< \brief Offset: 0x824 (R/  32) Channel 1 Read Max Latency */
+  __I  PDCA_PWDATA1_Type         PWDATA1;     /**< \brief Offset: 0x828 (R/  32) Channel 1 Write Data Cycles */
+  __I  PDCA_PWSTALL1_Type        PWSTALL1;    /**< \brief Offset: 0x82C (R/  32) Channel 1 Write stall Cycles */
+  __I  PDCA_PWLAT1_Type          PWLAT1;      /**< \brief Offset: 0x830 (R/  32) Channel 1 Read Max Latency */
+  __I  PDCA_VERSION_Type         VERSION;     /**< \brief Offset: 0x834 (R/  32) Version Register */
+ } bf;
+ struct {
+  PdcaChannel PDCA_CHANNEL[16];   /**< \brief (PDCA Offset: 0x000) PdcaChannel groups [CHANNEL_LENGTH] */
+  RoReg8  Reserved2[0x400];
+  RwReg   PDCA_PCONTROL;      /**< \brief (PDCA Offset: 0x800) Performance Control Register */
+  RoReg   PDCA_PRDATA0;       /**< \brief (PDCA Offset: 0x804) Channel 0 Read Data Cycles */
+  RoReg   PDCA_PRSTALL0;      /**< \brief (PDCA Offset: 0x808) Channel 0 Read Stall Cycles */
+  RoReg   PDCA_PRLAT0;        /**< \brief (PDCA Offset: 0x80C) Channel 0 Read Max Latency */
+  RoReg   PDCA_PWDATA0;       /**< \brief (PDCA Offset: 0x810) Channel 0 Write Data Cycles */
+  RoReg   PDCA_PWSTALL0;      /**< \brief (PDCA Offset: 0x814) Channel 0 Write Stall Cycles */
+  RoReg   PDCA_PWLAT0;        /**< \brief (PDCA Offset: 0x818) Channel0 Write Max Latency */
+  RoReg   PDCA_PRDATA1;       /**< \brief (PDCA Offset: 0x81C) Channel 1 Read Data Cycles */
+  RoReg   PDCA_PRSTALL1;      /**< \brief (PDCA Offset: 0x820) Channel Read Stall Cycles */
+  RoReg   PDCA_PRLAT1;        /**< \brief (PDCA Offset: 0x824) Channel 1 Read Max Latency */
+  RoReg   PDCA_PWDATA1;       /**< \brief (PDCA Offset: 0x828) Channel 1 Write Data Cycles */
+  RoReg   PDCA_PWSTALL1;      /**< \brief (PDCA Offset: 0x82C) Channel 1 Write stall Cycles */
+  RoReg   PDCA_PWLAT1;        /**< \brief (PDCA Offset: 0x830) Channel 1 Read Max Latency */
+  RoReg   PDCA_VERSION;       /**< \brief (PDCA Offset: 0x834) Version Register */
+ } reg;
+} Pdca;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_PDCA_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/pevc.h
+++ b/asf/sam/include/sam4l/component/pevc.h
@@ -538,69 +538,36 @@ typedef union {
 
 /** \brief PEVC hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __I  PEVC_CHSR_Type            CHSR;        /**< \brief Offset: 0x000 (R/  32) Channel Status Register */
-  __O  PEVC_CHER_Type            CHER;        /**< \brief Offset: 0x004 ( /W 32) Channel Enable Register */
-  __O  PEVC_CHDR_Type            CHDR;        /**< \brief Offset: 0x008 ( /W 32) Channel Disable Register */
-       RoReg8                    Reserved1[0x4];
-  __O  PEVC_SEV_Type             SEV;         /**< \brief Offset: 0x010 ( /W 32) Software Event */
-  __I  PEVC_BUSY_Type            BUSY;        /**< \brief Offset: 0x014 (R/  32) Channel / User Busy */
-       RoReg8                    Reserved2[0x8];
-  __O  PEVC_TRIER_Type           TRIER;       /**< \brief Offset: 0x020 ( /W 32) Trigger Interrupt Mask Enable Register */
-  __O  PEVC_TRIDR_Type           TRIDR;       /**< \brief Offset: 0x024 ( /W 32) Trigger Interrupt Mask Disable Register */
-  __I  PEVC_TRIMR_Type           TRIMR;       /**< \brief Offset: 0x028 (R/  32) Trigger Interrupt Mask Register */
-       RoReg8                    Reserved3[0x4];
-  __I  PEVC_TRSR_Type            TRSR;        /**< \brief Offset: 0x030 (R/  32) Trigger Status Register */
-  __O  PEVC_TRSCR_Type           TRSCR;       /**< \brief Offset: 0x034 ( /W 32) Trigger Status Clear Register */
-       RoReg8                    Reserved4[0x8];
-  __O  PEVC_OVIER_Type           OVIER;       /**< \brief Offset: 0x040 ( /W 32) Overrun Interrupt Mask Enable Register */
-  __O  PEVC_OVIDR_Type           OVIDR;       /**< \brief Offset: 0x044 ( /W 32) Overrun Interrupt Mask Disable Register */
-  __I  PEVC_OVIMR_Type           OVIMR;       /**< \brief Offset: 0x048 (R/  32) Overrun Interrupt Mask Register */
-       RoReg8                    Reserved5[0x4];
-  __I  PEVC_OVSR_Type            OVSR;        /**< \brief Offset: 0x050 (R/  32) Overrun Status Register */
-  __O  PEVC_OVSCR_Type           OVSCR;       /**< \brief Offset: 0x054 ( /W 32) Overrun Status Clear Register */
-       RoReg8                    Reserved6[0xA8];
-       PevcChmx                  Chmx[19];    /**< \brief Offset: 0x100 PevcChmx groups [TRIGOUT_BITS] */
-       RoReg8                    Reserved7[0xB4];
-       PevcEvs                   Evs[31];     /**< \brief Offset: 0x200 PevcEvs groups [EVIN_BITS] */
-       RoReg8                    Reserved8[0x84];
-  __IO PEVC_IGFDR_Type           IGFDR;       /**< \brief Offset: 0x300 (R/W 32) Input Glitch Filter Divider Register */
-       RoReg8                    Reserved9[0xF4];
-  __I  PEVC_PARAMETER_Type       PARAMETER;   /**< \brief Offset: 0x3F8 (R/  32) Parameter */
-  __I  PEVC_VERSION_Type         VERSION;     /**< \brief Offset: 0x3FC (R/  32) Version */
- } bf;
- struct {
-  RoReg   PEVC_CHSR;          /**< \brief (PEVC Offset: 0x000) Channel Status Register */
-  WoReg   PEVC_CHER;          /**< \brief (PEVC Offset: 0x004) Channel Enable Register */
-  WoReg   PEVC_CHDR;          /**< \brief (PEVC Offset: 0x008) Channel Disable Register */
-  RoReg8  Reserved10[0x4];
-  WoReg   PEVC_SEV;           /**< \brief (PEVC Offset: 0x010) Software Event */
-  RoReg   PEVC_BUSY;          /**< \brief (PEVC Offset: 0x014) Channel / User Busy */
-  RoReg8  Reserved11[0x8];
-  WoReg   PEVC_TRIER;         /**< \brief (PEVC Offset: 0x020) Trigger Interrupt Mask Enable Register */
-  WoReg   PEVC_TRIDR;         /**< \brief (PEVC Offset: 0x024) Trigger Interrupt Mask Disable Register */
-  RoReg   PEVC_TRIMR;         /**< \brief (PEVC Offset: 0x028) Trigger Interrupt Mask Register */
-  RoReg8  Reserved12[0x4];
-  RoReg   PEVC_TRSR;          /**< \brief (PEVC Offset: 0x030) Trigger Status Register */
-  WoReg   PEVC_TRSCR;         /**< \brief (PEVC Offset: 0x034) Trigger Status Clear Register */
-  RoReg8  Reserved13[0x8];
-  WoReg   PEVC_OVIER;         /**< \brief (PEVC Offset: 0x040) Overrun Interrupt Mask Enable Register */
-  WoReg   PEVC_OVIDR;         /**< \brief (PEVC Offset: 0x044) Overrun Interrupt Mask Disable Register */
-  RoReg   PEVC_OVIMR;         /**< \brief (PEVC Offset: 0x048) Overrun Interrupt Mask Register */
-  RoReg8  Reserved14[0x4];
-  RoReg   PEVC_OVSR;          /**< \brief (PEVC Offset: 0x050) Overrun Status Register */
-  WoReg   PEVC_OVSCR;         /**< \brief (PEVC Offset: 0x054) Overrun Status Clear Register */
-  RoReg8  Reserved15[0xA8];
-  PevcChmx PEVC_CHMX[19];      /**< \brief (PEVC Offset: 0x100) PevcChmx groups [TRIGOUT_BITS] */
-  RoReg8  Reserved16[0xB4];
-  PevcEvs PEVC_EVS[31];       /**< \brief (PEVC Offset: 0x200) PevcEvs groups [EVIN_BITS] */
-  RoReg8  Reserved17[0x84];
-  RwReg   PEVC_IGFDR;         /**< \brief (PEVC Offset: 0x300) Input Glitch Filter Divider Register */
-  RoReg8  Reserved18[0xF4];
-  RoReg   PEVC_PARAMETER;     /**< \brief (PEVC Offset: 0x3F8) Parameter */
-  RoReg   PEVC_VERSION;       /**< \brief (PEVC Offset: 0x3FC) Version */
- } reg;
+typedef struct {
+  __I  uint32_t CHSR;        /**< \brief Offset: 0x000 (R/  32) Channel Status Register */
+  __O  uint32_t CHER;        /**< \brief Offset: 0x004 ( /W 32) Channel Enable Register */
+  __O  uint32_t CHDR;        /**< \brief Offset: 0x008 ( /W 32) Channel Disable Register */
+       RoReg8   Reserved1[0x4];
+  __O  uint32_t SEV;         /**< \brief Offset: 0x010 ( /W 32) Software Event */
+  __I  uint32_t BUSY;        /**< \brief Offset: 0x014 (R/  32) Channel / User Busy */
+       RoReg8   Reserved2[0x8];
+  __O  uint32_t TRIER;       /**< \brief Offset: 0x020 ( /W 32) Trigger Interrupt Mask Enable Register */
+  __O  uint32_t TRIDR;       /**< \brief Offset: 0x024 ( /W 32) Trigger Interrupt Mask Disable Register */
+  __I  uint32_t TRIMR;       /**< \brief Offset: 0x028 (R/  32) Trigger Interrupt Mask Register */
+       RoReg8   Reserved3[0x4];
+  __I  uint32_t TRSR;        /**< \brief Offset: 0x030 (R/  32) Trigger Status Register */
+  __O  uint32_t TRSCR;       /**< \brief Offset: 0x034 ( /W 32) Trigger Status Clear Register */
+       RoReg8   Reserved4[0x8];
+  __O  uint32_t OVIER;       /**< \brief Offset: 0x040 ( /W 32) Overrun Interrupt Mask Enable Register */
+  __O  uint32_t OVIDR;       /**< \brief Offset: 0x044 ( /W 32) Overrun Interrupt Mask Disable Register */
+  __I  uint32_t OVIMR;       /**< \brief Offset: 0x048 (R/  32) Overrun Interrupt Mask Register */
+       RoReg8   Reserved5[0x4];
+  __I  uint32_t OVSR;        /**< \brief Offset: 0x050 (R/  32) Overrun Status Register */
+  __O  uint32_t OVSCR;       /**< \brief Offset: 0x054 ( /W 32) Overrun Status Clear Register */
+       RoReg8   Reserved6[0xA8];
+  __IO uint32_t Chmx[19];    /**< \brief Offset: 0x100 PevcChmx groups [TRIGOUT_BITS] */
+       RoReg8   Reserved7[0xB4];
+  __IO uint32_t Evs[31];     /**< \brief Offset: 0x200 PevcEvs groups [EVIN_BITS] */
+       RoReg8   Reserved8[0x84];
+  __IO uint32_t IGFDR;       /**< \brief Offset: 0x300 (R/W 32) Input Glitch Filter Divider Register */
+       RoReg8   Reserved9[0xF4];
+  __I  uint32_t PARAMETER;   /**< \brief Offset: 0x3F8 (R/  32) Parameter */
+  __I  uint32_t VERSION;     /**< \brief Offset: 0x3FC (R/  32) Version */
 } Pevc;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/pevc.h
+++ b/asf/sam/include/sam4l/component/pevc.h
@@ -1,0 +1,609 @@
+/**
+ * \file
+ *
+ * \brief Component description for PEVC
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_PEVC_COMPONENT_
+#define _SAM4L_PEVC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PEVC */
+/* ========================================================================== */
+/** \addtogroup SAM4L_PEVC Peripheral Event Controller */
+/*@{*/
+
+#define PEVC_I7533
+#define REV_PEVC                    0x200
+
+/* -------- PEVC_CHSR : (PEVC Offset: 0x000) (R/  32) Channel Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CHS:32;           /*!< bit:  0..31  Channel Status                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PEVC_CHSR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PEVC_CHSR_OFFSET            0x000        /**< \brief (PEVC_CHSR offset) Channel Status Register */
+#define PEVC_CHSR_RESETVALUE        _U(0x00000000); /**< \brief (PEVC_CHSR reset_value) Channel Status Register */
+
+#define PEVC_CHSR_CHS_Pos           0            /**< \brief (PEVC_CHSR) Channel Status */
+#define PEVC_CHSR_CHS_Msk           (_U(0xFFFFFFFF) << PEVC_CHSR_CHS_Pos)
+#define PEVC_CHSR_CHS(value)        (PEVC_CHSR_CHS_Msk & ((value) << PEVC_CHSR_CHS_Pos))
+#define   PEVC_CHSR_CHS_0_Val             _U(0x0)   /**< \brief (PEVC_CHSR) Channel j Disabled */
+#define   PEVC_CHSR_CHS_1_Val             _U(0x1)   /**< \brief (PEVC_CHSR) Channel j Enabled */
+#define PEVC_CHSR_CHS_0             (PEVC_CHSR_CHS_0_Val           << PEVC_CHSR_CHS_Pos)
+#define PEVC_CHSR_CHS_1             (PEVC_CHSR_CHS_1_Val           << PEVC_CHSR_CHS_Pos)
+#define PEVC_CHSR_MASK              _U(0xFFFFFFFF) /**< \brief (PEVC_CHSR) MASK Register */
+
+/* -------- PEVC_CHER : (PEVC Offset: 0x004) ( /W 32) Channel Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CHE:32;           /*!< bit:  0..31  Channel Enable                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PEVC_CHER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PEVC_CHER_OFFSET            0x004        /**< \brief (PEVC_CHER offset) Channel Enable Register */
+#define PEVC_CHER_RESETVALUE        _U(0x00000000); /**< \brief (PEVC_CHER reset_value) Channel Enable Register */
+
+#define PEVC_CHER_CHE_Pos           0            /**< \brief (PEVC_CHER) Channel Enable */
+#define PEVC_CHER_CHE_Msk           (_U(0xFFFFFFFF) << PEVC_CHER_CHE_Pos)
+#define PEVC_CHER_CHE(value)        (PEVC_CHER_CHE_Msk & ((value) << PEVC_CHER_CHE_Pos))
+#define   PEVC_CHER_CHE_0_Val             _U(0x0)   /**< \brief (PEVC_CHER) No Action */
+#define   PEVC_CHER_CHE_1_Val             _U(0x1)   /**< \brief (PEVC_CHER) Enable Channel j */
+#define PEVC_CHER_CHE_0             (PEVC_CHER_CHE_0_Val           << PEVC_CHER_CHE_Pos)
+#define PEVC_CHER_CHE_1             (PEVC_CHER_CHE_1_Val           << PEVC_CHER_CHE_Pos)
+#define PEVC_CHER_MASK              _U(0xFFFFFFFF) /**< \brief (PEVC_CHER) MASK Register */
+
+/* -------- PEVC_CHDR : (PEVC Offset: 0x008) ( /W 32) Channel Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CHD:32;           /*!< bit:  0..31  Channel Disable                    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PEVC_CHDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PEVC_CHDR_OFFSET            0x008        /**< \brief (PEVC_CHDR offset) Channel Disable Register */
+#define PEVC_CHDR_RESETVALUE        _U(0x00000000); /**< \brief (PEVC_CHDR reset_value) Channel Disable Register */
+
+#define PEVC_CHDR_CHD_Pos           0            /**< \brief (PEVC_CHDR) Channel Disable */
+#define PEVC_CHDR_CHD_Msk           (_U(0xFFFFFFFF) << PEVC_CHDR_CHD_Pos)
+#define PEVC_CHDR_CHD(value)        (PEVC_CHDR_CHD_Msk & ((value) << PEVC_CHDR_CHD_Pos))
+#define   PEVC_CHDR_CHD_0_Val             _U(0x0)   /**< \brief (PEVC_CHDR) No Action */
+#define   PEVC_CHDR_CHD_1_Val             _U(0x1)   /**< \brief (PEVC_CHDR) Disable Channel j */
+#define PEVC_CHDR_CHD_0             (PEVC_CHDR_CHD_0_Val           << PEVC_CHDR_CHD_Pos)
+#define PEVC_CHDR_CHD_1             (PEVC_CHDR_CHD_1_Val           << PEVC_CHDR_CHD_Pos)
+#define PEVC_CHDR_MASK              _U(0xFFFFFFFF) /**< \brief (PEVC_CHDR) MASK Register */
+
+/* -------- PEVC_SEV : (PEVC Offset: 0x010) ( /W 32) Software Event -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SEV:32;           /*!< bit:  0..31  Software Event                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PEVC_SEV_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PEVC_SEV_OFFSET             0x010        /**< \brief (PEVC_SEV offset) Software Event */
+#define PEVC_SEV_RESETVALUE         _U(0x00000000); /**< \brief (PEVC_SEV reset_value) Software Event */
+
+#define PEVC_SEV_SEV_Pos            0            /**< \brief (PEVC_SEV) Software Event */
+#define PEVC_SEV_SEV_Msk            (_U(0xFFFFFFFF) << PEVC_SEV_SEV_Pos)
+#define PEVC_SEV_SEV(value)         (PEVC_SEV_SEV_Msk & ((value) << PEVC_SEV_SEV_Pos))
+#define   PEVC_SEV_SEV_0_Val              _U(0x0)   /**< \brief (PEVC_SEV) No Action */
+#define   PEVC_SEV_SEV_1_Val              _U(0x1)   /**< \brief (PEVC_SEV) CPU forces software event to channel j */
+#define PEVC_SEV_SEV_0              (PEVC_SEV_SEV_0_Val            << PEVC_SEV_SEV_Pos)
+#define PEVC_SEV_SEV_1              (PEVC_SEV_SEV_1_Val            << PEVC_SEV_SEV_Pos)
+#define PEVC_SEV_MASK               _U(0xFFFFFFFF) /**< \brief (PEVC_SEV) MASK Register */
+
+/* -------- PEVC_BUSY : (PEVC Offset: 0x014) (R/  32) Channel / User Busy -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t BUSY:32;          /*!< bit:  0..31  Channel Status                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PEVC_BUSY_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PEVC_BUSY_OFFSET            0x014        /**< \brief (PEVC_BUSY offset) Channel / User Busy */
+#define PEVC_BUSY_RESETVALUE        _U(0x00000000); /**< \brief (PEVC_BUSY reset_value) Channel / User Busy */
+
+#define PEVC_BUSY_BUSY_Pos          0            /**< \brief (PEVC_BUSY) Channel Status */
+#define PEVC_BUSY_BUSY_Msk          (_U(0xFFFFFFFF) << PEVC_BUSY_BUSY_Pos)
+#define PEVC_BUSY_BUSY(value)       (PEVC_BUSY_BUSY_Msk & ((value) << PEVC_BUSY_BUSY_Pos))
+#define   PEVC_BUSY_BUSY_0_Val            _U(0x0)   /**< \brief (PEVC_BUSY) No Action */
+#define   PEVC_BUSY_BUSY_1_Val            _U(0x1)   /**< \brief (PEVC_BUSY) Channel j or User j is Busy */
+#define PEVC_BUSY_BUSY_0            (PEVC_BUSY_BUSY_0_Val          << PEVC_BUSY_BUSY_Pos)
+#define PEVC_BUSY_BUSY_1            (PEVC_BUSY_BUSY_1_Val          << PEVC_BUSY_BUSY_Pos)
+#define PEVC_BUSY_MASK              _U(0xFFFFFFFF) /**< \brief (PEVC_BUSY) MASK Register */
+
+/* -------- PEVC_TRIER : (PEVC Offset: 0x020) ( /W 32) Trigger Interrupt Mask Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TRIE:32;          /*!< bit:  0..31  Trigger Interrupt Enable           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PEVC_TRIER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PEVC_TRIER_OFFSET           0x020        /**< \brief (PEVC_TRIER offset) Trigger Interrupt Mask Enable Register */
+#define PEVC_TRIER_RESETVALUE       _U(0x00000000); /**< \brief (PEVC_TRIER reset_value) Trigger Interrupt Mask Enable Register */
+
+#define PEVC_TRIER_TRIE_Pos         0            /**< \brief (PEVC_TRIER) Trigger Interrupt Enable */
+#define PEVC_TRIER_TRIE_Msk         (_U(0xFFFFFFFF) << PEVC_TRIER_TRIE_Pos)
+#define PEVC_TRIER_TRIE(value)      (PEVC_TRIER_TRIE_Msk & ((value) << PEVC_TRIER_TRIE_Pos))
+#define   PEVC_TRIER_TRIE_0_Val           _U(0x0)   /**< \brief (PEVC_TRIER) No Action */
+#define   PEVC_TRIER_TRIE_1_Val           _U(0x1)   /**< \brief (PEVC_TRIER) Enable Trigger j Interrupt */
+#define PEVC_TRIER_TRIE_0           (PEVC_TRIER_TRIE_0_Val         << PEVC_TRIER_TRIE_Pos)
+#define PEVC_TRIER_TRIE_1           (PEVC_TRIER_TRIE_1_Val         << PEVC_TRIER_TRIE_Pos)
+#define PEVC_TRIER_MASK             _U(0xFFFFFFFF) /**< \brief (PEVC_TRIER) MASK Register */
+
+/* -------- PEVC_TRIDR : (PEVC Offset: 0x024) ( /W 32) Trigger Interrupt Mask Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TRID:32;          /*!< bit:  0..31  Trigger Interrupt Disable          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PEVC_TRIDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PEVC_TRIDR_OFFSET           0x024        /**< \brief (PEVC_TRIDR offset) Trigger Interrupt Mask Disable Register */
+#define PEVC_TRIDR_RESETVALUE       _U(0x00000000); /**< \brief (PEVC_TRIDR reset_value) Trigger Interrupt Mask Disable Register */
+
+#define PEVC_TRIDR_TRID_Pos         0            /**< \brief (PEVC_TRIDR) Trigger Interrupt Disable */
+#define PEVC_TRIDR_TRID_Msk         (_U(0xFFFFFFFF) << PEVC_TRIDR_TRID_Pos)
+#define PEVC_TRIDR_TRID(value)      (PEVC_TRIDR_TRID_Msk & ((value) << PEVC_TRIDR_TRID_Pos))
+#define   PEVC_TRIDR_TRID_0_Val           _U(0x0)   /**< \brief (PEVC_TRIDR) No Action */
+#define   PEVC_TRIDR_TRID_1_Val           _U(0x1)   /**< \brief (PEVC_TRIDR) Disable Trigger j Interrupt */
+#define PEVC_TRIDR_TRID_0           (PEVC_TRIDR_TRID_0_Val         << PEVC_TRIDR_TRID_Pos)
+#define PEVC_TRIDR_TRID_1           (PEVC_TRIDR_TRID_1_Val         << PEVC_TRIDR_TRID_Pos)
+#define PEVC_TRIDR_MASK             _U(0xFFFFFFFF) /**< \brief (PEVC_TRIDR) MASK Register */
+
+/* -------- PEVC_TRIMR : (PEVC Offset: 0x028) (R/  32) Trigger Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TRIM:32;          /*!< bit:  0..31  Trigger Interrupt Mask             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PEVC_TRIMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PEVC_TRIMR_OFFSET           0x028        /**< \brief (PEVC_TRIMR offset) Trigger Interrupt Mask Register */
+#define PEVC_TRIMR_RESETVALUE       _U(0x00000000); /**< \brief (PEVC_TRIMR reset_value) Trigger Interrupt Mask Register */
+
+#define PEVC_TRIMR_TRIM_Pos         0            /**< \brief (PEVC_TRIMR) Trigger Interrupt Mask */
+#define PEVC_TRIMR_TRIM_Msk         (_U(0xFFFFFFFF) << PEVC_TRIMR_TRIM_Pos)
+#define PEVC_TRIMR_TRIM(value)      (PEVC_TRIMR_TRIM_Msk & ((value) << PEVC_TRIMR_TRIM_Pos))
+#define   PEVC_TRIMR_TRIM_0_Val           _U(0x0)   /**< \brief (PEVC_TRIMR) Trigger j Interrupt Disabled */
+#define   PEVC_TRIMR_TRIM_1_Val           _U(0x1)   /**< \brief (PEVC_TRIMR) Trigger j Interrupt Enabled */
+#define PEVC_TRIMR_TRIM_0           (PEVC_TRIMR_TRIM_0_Val         << PEVC_TRIMR_TRIM_Pos)
+#define PEVC_TRIMR_TRIM_1           (PEVC_TRIMR_TRIM_1_Val         << PEVC_TRIMR_TRIM_Pos)
+#define PEVC_TRIMR_MASK             _U(0xFFFFFFFF) /**< \brief (PEVC_TRIMR) MASK Register */
+
+/* -------- PEVC_TRSR : (PEVC Offset: 0x030) (R/  32) Trigger Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TRS:32;           /*!< bit:  0..31  Trigger Interrupt Status           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PEVC_TRSR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PEVC_TRSR_OFFSET            0x030        /**< \brief (PEVC_TRSR offset) Trigger Status Register */
+#define PEVC_TRSR_RESETVALUE        _U(0x00000000); /**< \brief (PEVC_TRSR reset_value) Trigger Status Register */
+
+#define PEVC_TRSR_TRS_Pos           0            /**< \brief (PEVC_TRSR) Trigger Interrupt Status */
+#define PEVC_TRSR_TRS_Msk           (_U(0xFFFFFFFF) << PEVC_TRSR_TRS_Pos)
+#define PEVC_TRSR_TRS(value)        (PEVC_TRSR_TRS_Msk & ((value) << PEVC_TRSR_TRS_Pos))
+#define   PEVC_TRSR_TRS_0_Val             _U(0x0)   /**< \brief (PEVC_TRSR) Channel j did not send out an Event in the past */
+#define   PEVC_TRSR_TRS_1_Val             _U(0x1)   /**< \brief (PEVC_TRSR) Channel j did send out an Event in the past */
+#define PEVC_TRSR_TRS_0             (PEVC_TRSR_TRS_0_Val           << PEVC_TRSR_TRS_Pos)
+#define PEVC_TRSR_TRS_1             (PEVC_TRSR_TRS_1_Val           << PEVC_TRSR_TRS_Pos)
+#define PEVC_TRSR_MASK              _U(0xFFFFFFFF) /**< \brief (PEVC_TRSR) MASK Register */
+
+/* -------- PEVC_TRSCR : (PEVC Offset: 0x034) ( /W 32) Trigger Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TRSC:32;          /*!< bit:  0..31  Trigger Interrupt Status Clear     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PEVC_TRSCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PEVC_TRSCR_OFFSET           0x034        /**< \brief (PEVC_TRSCR offset) Trigger Status Clear Register */
+#define PEVC_TRSCR_RESETVALUE       _U(0x00000000); /**< \brief (PEVC_TRSCR reset_value) Trigger Status Clear Register */
+
+#define PEVC_TRSCR_TRSC_Pos         0            /**< \brief (PEVC_TRSCR) Trigger Interrupt Status Clear */
+#define PEVC_TRSCR_TRSC_Msk         (_U(0xFFFFFFFF) << PEVC_TRSCR_TRSC_Pos)
+#define PEVC_TRSCR_TRSC(value)      (PEVC_TRSCR_TRSC_Msk & ((value) << PEVC_TRSCR_TRSC_Pos))
+#define   PEVC_TRSCR_TRSC_0_Val           _U(0x0)   /**< \brief (PEVC_TRSCR) No Action */
+#define   PEVC_TRSCR_TRSC_1_Val           _U(0x1)   /**< \brief (PEVC_TRSCR) Clear TRSR[j] */
+#define PEVC_TRSCR_TRSC_0           (PEVC_TRSCR_TRSC_0_Val         << PEVC_TRSCR_TRSC_Pos)
+#define PEVC_TRSCR_TRSC_1           (PEVC_TRSCR_TRSC_1_Val         << PEVC_TRSCR_TRSC_Pos)
+#define PEVC_TRSCR_MASK             _U(0xFFFFFFFF) /**< \brief (PEVC_TRSCR) MASK Register */
+
+/* -------- PEVC_OVIER : (PEVC Offset: 0x040) ( /W 32) Overrun Interrupt Mask Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OVIE:32;          /*!< bit:  0..31  Overrun Interrupt Enable           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PEVC_OVIER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PEVC_OVIER_OFFSET           0x040        /**< \brief (PEVC_OVIER offset) Overrun Interrupt Mask Enable Register */
+#define PEVC_OVIER_RESETVALUE       _U(0x00000000); /**< \brief (PEVC_OVIER reset_value) Overrun Interrupt Mask Enable Register */
+
+#define PEVC_OVIER_OVIE_Pos         0            /**< \brief (PEVC_OVIER) Overrun Interrupt Enable */
+#define PEVC_OVIER_OVIE_Msk         (_U(0xFFFFFFFF) << PEVC_OVIER_OVIE_Pos)
+#define PEVC_OVIER_OVIE(value)      (PEVC_OVIER_OVIE_Msk & ((value) << PEVC_OVIER_OVIE_Pos))
+#define   PEVC_OVIER_OVIE_0_Val           _U(0x0)   /**< \brief (PEVC_OVIER) No Action */
+#define   PEVC_OVIER_OVIE_1_Val           _U(0x1)   /**< \brief (PEVC_OVIER) Enable Overrun Interrupt for Channel j */
+#define PEVC_OVIER_OVIE_0           (PEVC_OVIER_OVIE_0_Val         << PEVC_OVIER_OVIE_Pos)
+#define PEVC_OVIER_OVIE_1           (PEVC_OVIER_OVIE_1_Val         << PEVC_OVIER_OVIE_Pos)
+#define PEVC_OVIER_MASK             _U(0xFFFFFFFF) /**< \brief (PEVC_OVIER) MASK Register */
+
+/* -------- PEVC_OVIDR : (PEVC Offset: 0x044) ( /W 32) Overrun Interrupt Mask Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OVID:32;          /*!< bit:  0..31  Overrun Interrupt Disable          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PEVC_OVIDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PEVC_OVIDR_OFFSET           0x044        /**< \brief (PEVC_OVIDR offset) Overrun Interrupt Mask Disable Register */
+#define PEVC_OVIDR_RESETVALUE       _U(0x00000000); /**< \brief (PEVC_OVIDR reset_value) Overrun Interrupt Mask Disable Register */
+
+#define PEVC_OVIDR_OVID_Pos         0            /**< \brief (PEVC_OVIDR) Overrun Interrupt Disable */
+#define PEVC_OVIDR_OVID_Msk         (_U(0xFFFFFFFF) << PEVC_OVIDR_OVID_Pos)
+#define PEVC_OVIDR_OVID(value)      (PEVC_OVIDR_OVID_Msk & ((value) << PEVC_OVIDR_OVID_Pos))
+#define   PEVC_OVIDR_OVID_0_Val           _U(0x0)   /**< \brief (PEVC_OVIDR) No Action */
+#define   PEVC_OVIDR_OVID_1_Val           _U(0x1)   /**< \brief (PEVC_OVIDR) Enable Overrun Interrupt for Channel j */
+#define PEVC_OVIDR_OVID_0           (PEVC_OVIDR_OVID_0_Val         << PEVC_OVIDR_OVID_Pos)
+#define PEVC_OVIDR_OVID_1           (PEVC_OVIDR_OVID_1_Val         << PEVC_OVIDR_OVID_Pos)
+#define PEVC_OVIDR_MASK             _U(0xFFFFFFFF) /**< \brief (PEVC_OVIDR) MASK Register */
+
+/* -------- PEVC_OVIMR : (PEVC Offset: 0x048) (R/  32) Overrun Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OVIM:32;          /*!< bit:  0..31  Overrun Interrupt Mask             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PEVC_OVIMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PEVC_OVIMR_OFFSET           0x048        /**< \brief (PEVC_OVIMR offset) Overrun Interrupt Mask Register */
+#define PEVC_OVIMR_RESETVALUE       _U(0x00000000); /**< \brief (PEVC_OVIMR reset_value) Overrun Interrupt Mask Register */
+
+#define PEVC_OVIMR_OVIM_Pos         0            /**< \brief (PEVC_OVIMR) Overrun Interrupt Mask */
+#define PEVC_OVIMR_OVIM_Msk         (_U(0xFFFFFFFF) << PEVC_OVIMR_OVIM_Pos)
+#define PEVC_OVIMR_OVIM(value)      (PEVC_OVIMR_OVIM_Msk & ((value) << PEVC_OVIMR_OVIM_Pos))
+#define   PEVC_OVIMR_OVIM_0_Val           _U(0x0)   /**< \brief (PEVC_OVIMR) Overrun Interrupt for Channel j Disabled */
+#define   PEVC_OVIMR_OVIM_1_Val           _U(0x1)   /**< \brief (PEVC_OVIMR) Overrun Interrupt for Channel j Enabled */
+#define PEVC_OVIMR_OVIM_0           (PEVC_OVIMR_OVIM_0_Val         << PEVC_OVIMR_OVIM_Pos)
+#define PEVC_OVIMR_OVIM_1           (PEVC_OVIMR_OVIM_1_Val         << PEVC_OVIMR_OVIM_Pos)
+#define PEVC_OVIMR_MASK             _U(0xFFFFFFFF) /**< \brief (PEVC_OVIMR) MASK Register */
+
+/* -------- PEVC_OVSR : (PEVC Offset: 0x050) (R/  32) Overrun Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OVS:32;           /*!< bit:  0..31  Overrun Interrupt Status           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PEVC_OVSR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PEVC_OVSR_OFFSET            0x050        /**< \brief (PEVC_OVSR offset) Overrun Status Register */
+#define PEVC_OVSR_RESETVALUE        _U(0x00000000); /**< \brief (PEVC_OVSR reset_value) Overrun Status Register */
+
+#define PEVC_OVSR_OVS_Pos           0            /**< \brief (PEVC_OVSR) Overrun Interrupt Status */
+#define PEVC_OVSR_OVS_Msk           (_U(0xFFFFFFFF) << PEVC_OVSR_OVS_Pos)
+#define PEVC_OVSR_OVS(value)        (PEVC_OVSR_OVS_Msk & ((value) << PEVC_OVSR_OVS_Pos))
+#define   PEVC_OVSR_OVS_0_Val             _U(0x0)   /**< \brief (PEVC_OVSR) No Overrun occured on Channel j */
+#define   PEVC_OVSR_OVS_1_Val             _U(0x1)   /**< \brief (PEVC_OVSR) Overrun occured on Channel j */
+#define PEVC_OVSR_OVS_0             (PEVC_OVSR_OVS_0_Val           << PEVC_OVSR_OVS_Pos)
+#define PEVC_OVSR_OVS_1             (PEVC_OVSR_OVS_1_Val           << PEVC_OVSR_OVS_Pos)
+#define PEVC_OVSR_MASK              _U(0xFFFFFFFF) /**< \brief (PEVC_OVSR) MASK Register */
+
+/* -------- PEVC_OVSCR : (PEVC Offset: 0x054) ( /W 32) Overrun Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OVSC:32;          /*!< bit:  0..31  Overrun Interrupt Status Clear     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PEVC_OVSCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PEVC_OVSCR_OFFSET           0x054        /**< \brief (PEVC_OVSCR offset) Overrun Status Clear Register */
+#define PEVC_OVSCR_RESETVALUE       _U(0x00000000); /**< \brief (PEVC_OVSCR reset_value) Overrun Status Clear Register */
+
+#define PEVC_OVSCR_OVSC_Pos         0            /**< \brief (PEVC_OVSCR) Overrun Interrupt Status Clear */
+#define PEVC_OVSCR_OVSC_Msk         (_U(0xFFFFFFFF) << PEVC_OVSCR_OVSC_Pos)
+#define PEVC_OVSCR_OVSC(value)      (PEVC_OVSCR_OVSC_Msk & ((value) << PEVC_OVSCR_OVSC_Pos))
+#define   PEVC_OVSCR_OVSC_0_Val           _U(0x0)   /**< \brief (PEVC_OVSCR) No Action */
+#define   PEVC_OVSCR_OVSC_1_Val           _U(0x1)   /**< \brief (PEVC_OVSCR) Clear Overrun Status Bit j */
+#define PEVC_OVSCR_OVSC_0           (PEVC_OVSCR_OVSC_0_Val         << PEVC_OVSCR_OVSC_Pos)
+#define PEVC_OVSCR_OVSC_1           (PEVC_OVSCR_OVSC_1_Val         << PEVC_OVSCR_OVSC_Pos)
+#define PEVC_OVSCR_MASK             _U(0xFFFFFFFF) /**< \brief (PEVC_OVSCR) MASK Register */
+
+/* -------- PEVC_CHMX : (PEVC Offset: 0x100) (R/W 32) CHMX Channel Multiplexer -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EVMX:6;           /*!< bit:  0.. 5  Event Multiplexer                  */
+    uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t SMX:1;            /*!< bit:      8  Software Event Multiplexer         */
+    uint32_t :23;              /*!< bit:  9..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PEVC_CHMX_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PEVC_CHMX_OFFSET            0x100        /**< \brief (PEVC_CHMX offset) Channel Multiplexer */
+#define PEVC_CHMX_RESETVALUE        _U(0x00000000); /**< \brief (PEVC_CHMX reset_value) Channel Multiplexer */
+
+#define PEVC_CHMX_EVMX_Pos          0            /**< \brief (PEVC_CHMX) Event Multiplexer */
+#define PEVC_CHMX_EVMX_Msk          (_U(0x3F) << PEVC_CHMX_EVMX_Pos)
+#define PEVC_CHMX_EVMX(value)       (PEVC_CHMX_EVMX_Msk & ((value) << PEVC_CHMX_EVMX_Pos))
+#define   PEVC_CHMX_EVMX_0_Val            _U(0x0)   /**< \brief (PEVC_CHMX) Event 0 */
+#define   PEVC_CHMX_EVMX_1_Val            _U(0x1)   /**< \brief (PEVC_CHMX) Event 1 */
+#define PEVC_CHMX_EVMX_0            (PEVC_CHMX_EVMX_0_Val          << PEVC_CHMX_EVMX_Pos)
+#define PEVC_CHMX_EVMX_1            (PEVC_CHMX_EVMX_1_Val          << PEVC_CHMX_EVMX_Pos)
+#define PEVC_CHMX_SMX_Pos           8            /**< \brief (PEVC_CHMX) Software Event Multiplexer */
+#define PEVC_CHMX_SMX               (_U(0x1) << PEVC_CHMX_SMX_Pos)
+#define   PEVC_CHMX_SMX_0_Val             _U(0x0)   /**< \brief (PEVC_CHMX) Hardware events */
+#define   PEVC_CHMX_SMX_1_Val             _U(0x1)   /**< \brief (PEVC_CHMX) Software event */
+#define PEVC_CHMX_SMX_0             (PEVC_CHMX_SMX_0_Val           << PEVC_CHMX_SMX_Pos)
+#define PEVC_CHMX_SMX_1             (PEVC_CHMX_SMX_1_Val           << PEVC_CHMX_SMX_Pos)
+#define PEVC_CHMX_MASK              _U(0x0000013F) /**< \brief (PEVC_CHMX) MASK Register */
+
+/* -------- PEVC_EVS : (PEVC Offset: 0x200) (R/W 32) EVS Event Shaper -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EN:1;             /*!< bit:      0  Event Shaper Enable                */
+    uint32_t :15;              /*!< bit:  1..15  Reserved                           */
+    uint32_t IGFR:1;           /*!< bit:     16  Input Glitch Filter Rise           */
+    uint32_t IGFF:1;           /*!< bit:     17  Input Glitch Filter Fall           */
+    uint32_t IGFON:1;          /*!< bit:     18  Input Glitch Filter Status         */
+    uint32_t :13;              /*!< bit: 19..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PEVC_EVS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PEVC_EVS_OFFSET             0x200        /**< \brief (PEVC_EVS offset) Event Shaper */
+#define PEVC_EVS_RESETVALUE         _U(0x00000000); /**< \brief (PEVC_EVS reset_value) Event Shaper */
+
+#define PEVC_EVS_EN_Pos             0            /**< \brief (PEVC_EVS) Event Shaper Enable */
+#define PEVC_EVS_EN                 (_U(0x1) << PEVC_EVS_EN_Pos)
+#define   PEVC_EVS_EN_0_Val               _U(0x0)   /**< \brief (PEVC_EVS) No Action */
+#define   PEVC_EVS_EN_1_Val               _U(0x1)   /**< \brief (PEVC_EVS) Event Shaper enable */
+#define PEVC_EVS_EN_0               (PEVC_EVS_EN_0_Val             << PEVC_EVS_EN_Pos)
+#define PEVC_EVS_EN_1               (PEVC_EVS_EN_1_Val             << PEVC_EVS_EN_Pos)
+#define PEVC_EVS_IGFR_Pos           16           /**< \brief (PEVC_EVS) Input Glitch Filter Rise */
+#define PEVC_EVS_IGFR               (_U(0x1) << PEVC_EVS_IGFR_Pos)
+#define   PEVC_EVS_IGFR_0_Val             _U(0x0)   /**< \brief (PEVC_EVS) No Action */
+#define   PEVC_EVS_IGFR_1_Val             _U(0x1)   /**< \brief (PEVC_EVS) Input Glitch Filter : a rising edge on event input will raise trigger output */
+#define PEVC_EVS_IGFR_0             (PEVC_EVS_IGFR_0_Val           << PEVC_EVS_IGFR_Pos)
+#define PEVC_EVS_IGFR_1             (PEVC_EVS_IGFR_1_Val           << PEVC_EVS_IGFR_Pos)
+#define PEVC_EVS_IGFF_Pos           17           /**< \brief (PEVC_EVS) Input Glitch Filter Fall */
+#define PEVC_EVS_IGFF               (_U(0x1) << PEVC_EVS_IGFF_Pos)
+#define   PEVC_EVS_IGFF_0_Val             _U(0x0)   /**< \brief (PEVC_EVS) No Action */
+#define   PEVC_EVS_IGFF_1_Val             _U(0x1)   /**< \brief (PEVC_EVS) Input Glitch Filter : a falling edge on event input will raise trigger output */
+#define PEVC_EVS_IGFF_0             (PEVC_EVS_IGFF_0_Val           << PEVC_EVS_IGFF_Pos)
+#define PEVC_EVS_IGFF_1             (PEVC_EVS_IGFF_1_Val           << PEVC_EVS_IGFF_Pos)
+#define PEVC_EVS_IGFON_Pos          18           /**< \brief (PEVC_EVS) Input Glitch Filter Status */
+#define PEVC_EVS_IGFON              (_U(0x1) << PEVC_EVS_IGFON_Pos)
+#define PEVC_EVS_MASK               _U(0x00070001) /**< \brief (PEVC_EVS) MASK Register */
+
+/* -------- PEVC_IGFDR : (PEVC Offset: 0x300) (R/W 32) Input Glitch Filter Divider Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t IGFDR:4;          /*!< bit:  0.. 3  Input Glitch Filter Divider Register */
+    uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PEVC_IGFDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PEVC_IGFDR_OFFSET           0x300        /**< \brief (PEVC_IGFDR offset) Input Glitch Filter Divider Register */
+#define PEVC_IGFDR_RESETVALUE       _U(0x00000000); /**< \brief (PEVC_IGFDR reset_value) Input Glitch Filter Divider Register */
+
+#define PEVC_IGFDR_IGFDR_Pos        0            /**< \brief (PEVC_IGFDR) Input Glitch Filter Divider Register */
+#define PEVC_IGFDR_IGFDR_Msk        (_U(0xF) << PEVC_IGFDR_IGFDR_Pos)
+#define PEVC_IGFDR_IGFDR(value)     (PEVC_IGFDR_IGFDR_Msk & ((value) << PEVC_IGFDR_IGFDR_Pos))
+#define PEVC_IGFDR_MASK             _U(0x0000000F) /**< \brief (PEVC_IGFDR) MASK Register */
+
+/* -------- PEVC_PARAMETER : (PEVC Offset: 0x3F8) (R/  32) Parameter -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t IGF_COUNT:8;      /*!< bit:  0.. 7  Number of Input Glitch Filters     */
+    uint32_t EVS_COUNT:8;      /*!< bit:  8..15  Number of Event Shapers            */
+    uint32_t EVIN:8;           /*!< bit: 16..23  Number of Event Inputs / Generators */
+    uint32_t TRIGOUT:8;        /*!< bit: 24..31  Number of Trigger Outputs / Channels / Users */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PEVC_PARAMETER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PEVC_PARAMETER_OFFSET       0x3F8        /**< \brief (PEVC_PARAMETER offset) Parameter */
+#define PEVC_PARAMETER_RESETVALUE   _U(0x14061824); /**< \brief (PEVC_PARAMETER reset_value) Parameter */
+
+#define PEVC_PARAMETER_IGF_COUNT_Pos 0            /**< \brief (PEVC_PARAMETER) Number of Input Glitch Filters */
+#define PEVC_PARAMETER_IGF_COUNT_Msk (_U(0xFF) << PEVC_PARAMETER_IGF_COUNT_Pos)
+#define PEVC_PARAMETER_IGF_COUNT(value) (PEVC_PARAMETER_IGF_COUNT_Msk & ((value) << PEVC_PARAMETER_IGF_COUNT_Pos))
+#define PEVC_PARAMETER_EVS_COUNT_Pos 8            /**< \brief (PEVC_PARAMETER) Number of Event Shapers */
+#define PEVC_PARAMETER_EVS_COUNT_Msk (_U(0xFF) << PEVC_PARAMETER_EVS_COUNT_Pos)
+#define PEVC_PARAMETER_EVS_COUNT(value) (PEVC_PARAMETER_EVS_COUNT_Msk & ((value) << PEVC_PARAMETER_EVS_COUNT_Pos))
+#define PEVC_PARAMETER_EVIN_Pos     16           /**< \brief (PEVC_PARAMETER) Number of Event Inputs / Generators */
+#define PEVC_PARAMETER_EVIN_Msk     (_U(0xFF) << PEVC_PARAMETER_EVIN_Pos)
+#define PEVC_PARAMETER_EVIN(value)  (PEVC_PARAMETER_EVIN_Msk & ((value) << PEVC_PARAMETER_EVIN_Pos))
+#define PEVC_PARAMETER_TRIGOUT_Pos  24           /**< \brief (PEVC_PARAMETER) Number of Trigger Outputs / Channels / Users */
+#define PEVC_PARAMETER_TRIGOUT_Msk  (_U(0xFF) << PEVC_PARAMETER_TRIGOUT_Pos)
+#define PEVC_PARAMETER_TRIGOUT(value) (PEVC_PARAMETER_TRIGOUT_Msk & ((value) << PEVC_PARAMETER_TRIGOUT_Pos))
+#define PEVC_PARAMETER_MASK         _U(0xFFFFFFFF) /**< \brief (PEVC_PARAMETER) MASK Register */
+
+/* -------- PEVC_VERSION : (PEVC Offset: 0x3FC) (R/  32) Version -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version Number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant Number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PEVC_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PEVC_VERSION_OFFSET         0x3FC        /**< \brief (PEVC_VERSION offset) Version */
+#define PEVC_VERSION_RESETVALUE     _U(0x00000200); /**< \brief (PEVC_VERSION reset_value) Version */
+
+#define PEVC_VERSION_VERSION_Pos    0            /**< \brief (PEVC_VERSION) Version Number */
+#define PEVC_VERSION_VERSION_Msk    (_U(0xFFF) << PEVC_VERSION_VERSION_Pos)
+#define PEVC_VERSION_VERSION(value) (PEVC_VERSION_VERSION_Msk & ((value) << PEVC_VERSION_VERSION_Pos))
+#define PEVC_VERSION_VARIANT_Pos    16           /**< \brief (PEVC_VERSION) Variant Number */
+#define PEVC_VERSION_VARIANT_Msk    (_U(0xF) << PEVC_VERSION_VARIANT_Pos)
+#define PEVC_VERSION_VARIANT(value) (PEVC_VERSION_VARIANT_Msk & ((value) << PEVC_VERSION_VARIANT_Pos))
+#define PEVC_VERSION_MASK           _U(0x000F0FFF) /**< \brief (PEVC_VERSION) MASK Register */
+
+/** \brief PevcChmx hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __IO PEVC_CHMX_Type            CHMX;        /**< \brief Offset: 0x000 (R/W 32) Channel Multiplexer */
+ } bf;
+ struct {
+  RwReg   PEVC_CHMX;          /**< \brief (PEVC Offset: 0x000) Channel Multiplexer */
+ } reg;
+} PevcChmx;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief PevcEvs hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __IO PEVC_EVS_Type             EVS;         /**< \brief Offset: 0x000 (R/W 32) Event Shaper */
+ } bf;
+ struct {
+  RwReg   PEVC_EVS;           /**< \brief (PEVC Offset: 0x000) Event Shaper */
+ } reg;
+} PevcEvs;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief PEVC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __I  PEVC_CHSR_Type            CHSR;        /**< \brief Offset: 0x000 (R/  32) Channel Status Register */
+  __O  PEVC_CHER_Type            CHER;        /**< \brief Offset: 0x004 ( /W 32) Channel Enable Register */
+  __O  PEVC_CHDR_Type            CHDR;        /**< \brief Offset: 0x008 ( /W 32) Channel Disable Register */
+       RoReg8                    Reserved1[0x4];
+  __O  PEVC_SEV_Type             SEV;         /**< \brief Offset: 0x010 ( /W 32) Software Event */
+  __I  PEVC_BUSY_Type            BUSY;        /**< \brief Offset: 0x014 (R/  32) Channel / User Busy */
+       RoReg8                    Reserved2[0x8];
+  __O  PEVC_TRIER_Type           TRIER;       /**< \brief Offset: 0x020 ( /W 32) Trigger Interrupt Mask Enable Register */
+  __O  PEVC_TRIDR_Type           TRIDR;       /**< \brief Offset: 0x024 ( /W 32) Trigger Interrupt Mask Disable Register */
+  __I  PEVC_TRIMR_Type           TRIMR;       /**< \brief Offset: 0x028 (R/  32) Trigger Interrupt Mask Register */
+       RoReg8                    Reserved3[0x4];
+  __I  PEVC_TRSR_Type            TRSR;        /**< \brief Offset: 0x030 (R/  32) Trigger Status Register */
+  __O  PEVC_TRSCR_Type           TRSCR;       /**< \brief Offset: 0x034 ( /W 32) Trigger Status Clear Register */
+       RoReg8                    Reserved4[0x8];
+  __O  PEVC_OVIER_Type           OVIER;       /**< \brief Offset: 0x040 ( /W 32) Overrun Interrupt Mask Enable Register */
+  __O  PEVC_OVIDR_Type           OVIDR;       /**< \brief Offset: 0x044 ( /W 32) Overrun Interrupt Mask Disable Register */
+  __I  PEVC_OVIMR_Type           OVIMR;       /**< \brief Offset: 0x048 (R/  32) Overrun Interrupt Mask Register */
+       RoReg8                    Reserved5[0x4];
+  __I  PEVC_OVSR_Type            OVSR;        /**< \brief Offset: 0x050 (R/  32) Overrun Status Register */
+  __O  PEVC_OVSCR_Type           OVSCR;       /**< \brief Offset: 0x054 ( /W 32) Overrun Status Clear Register */
+       RoReg8                    Reserved6[0xA8];
+       PevcChmx                  Chmx[19];    /**< \brief Offset: 0x100 PevcChmx groups [TRIGOUT_BITS] */
+       RoReg8                    Reserved7[0xB4];
+       PevcEvs                   Evs[31];     /**< \brief Offset: 0x200 PevcEvs groups [EVIN_BITS] */
+       RoReg8                    Reserved8[0x84];
+  __IO PEVC_IGFDR_Type           IGFDR;       /**< \brief Offset: 0x300 (R/W 32) Input Glitch Filter Divider Register */
+       RoReg8                    Reserved9[0xF4];
+  __I  PEVC_PARAMETER_Type       PARAMETER;   /**< \brief Offset: 0x3F8 (R/  32) Parameter */
+  __I  PEVC_VERSION_Type         VERSION;     /**< \brief Offset: 0x3FC (R/  32) Version */
+ } bf;
+ struct {
+  RoReg   PEVC_CHSR;          /**< \brief (PEVC Offset: 0x000) Channel Status Register */
+  WoReg   PEVC_CHER;          /**< \brief (PEVC Offset: 0x004) Channel Enable Register */
+  WoReg   PEVC_CHDR;          /**< \brief (PEVC Offset: 0x008) Channel Disable Register */
+  RoReg8  Reserved10[0x4];
+  WoReg   PEVC_SEV;           /**< \brief (PEVC Offset: 0x010) Software Event */
+  RoReg   PEVC_BUSY;          /**< \brief (PEVC Offset: 0x014) Channel / User Busy */
+  RoReg8  Reserved11[0x8];
+  WoReg   PEVC_TRIER;         /**< \brief (PEVC Offset: 0x020) Trigger Interrupt Mask Enable Register */
+  WoReg   PEVC_TRIDR;         /**< \brief (PEVC Offset: 0x024) Trigger Interrupt Mask Disable Register */
+  RoReg   PEVC_TRIMR;         /**< \brief (PEVC Offset: 0x028) Trigger Interrupt Mask Register */
+  RoReg8  Reserved12[0x4];
+  RoReg   PEVC_TRSR;          /**< \brief (PEVC Offset: 0x030) Trigger Status Register */
+  WoReg   PEVC_TRSCR;         /**< \brief (PEVC Offset: 0x034) Trigger Status Clear Register */
+  RoReg8  Reserved13[0x8];
+  WoReg   PEVC_OVIER;         /**< \brief (PEVC Offset: 0x040) Overrun Interrupt Mask Enable Register */
+  WoReg   PEVC_OVIDR;         /**< \brief (PEVC Offset: 0x044) Overrun Interrupt Mask Disable Register */
+  RoReg   PEVC_OVIMR;         /**< \brief (PEVC Offset: 0x048) Overrun Interrupt Mask Register */
+  RoReg8  Reserved14[0x4];
+  RoReg   PEVC_OVSR;          /**< \brief (PEVC Offset: 0x050) Overrun Status Register */
+  WoReg   PEVC_OVSCR;         /**< \brief (PEVC Offset: 0x054) Overrun Status Clear Register */
+  RoReg8  Reserved15[0xA8];
+  PevcChmx PEVC_CHMX[19];      /**< \brief (PEVC Offset: 0x100) PevcChmx groups [TRIGOUT_BITS] */
+  RoReg8  Reserved16[0xB4];
+  PevcEvs PEVC_EVS[31];       /**< \brief (PEVC Offset: 0x200) PevcEvs groups [EVIN_BITS] */
+  RoReg8  Reserved17[0x84];
+  RwReg   PEVC_IGFDR;         /**< \brief (PEVC Offset: 0x300) Input Glitch Filter Divider Register */
+  RoReg8  Reserved18[0xF4];
+  RoReg   PEVC_PARAMETER;     /**< \brief (PEVC Offset: 0x3F8) Parameter */
+  RoReg   PEVC_VERSION;       /**< \brief (PEVC Offset: 0x3FC) Version */
+ } reg;
+} Pevc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_PEVC_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/pevc.h
+++ b/asf/sam/include/sam4l/component/pevc.h
@@ -49,16 +49,16 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PEVC_CHSR_OFFSET            0x000        /**< \brief (PEVC_CHSR offset) Channel Status Register */
-#define PEVC_CHSR_RESETVALUE        _U(0x00000000); /**< \brief (PEVC_CHSR reset_value) Channel Status Register */
+#define PEVC_CHSR_RESETVALUE        _U_(0x00000000); /**< \brief (PEVC_CHSR reset_value) Channel Status Register */
 
 #define PEVC_CHSR_CHS_Pos           0            /**< \brief (PEVC_CHSR) Channel Status */
-#define PEVC_CHSR_CHS_Msk           (_U(0xFFFFFFFF) << PEVC_CHSR_CHS_Pos)
+#define PEVC_CHSR_CHS_Msk           (_U_(0xFFFFFFFF) << PEVC_CHSR_CHS_Pos)
 #define PEVC_CHSR_CHS(value)        (PEVC_CHSR_CHS_Msk & ((value) << PEVC_CHSR_CHS_Pos))
-#define   PEVC_CHSR_CHS_0_Val             _U(0x0)   /**< \brief (PEVC_CHSR) Channel j Disabled */
-#define   PEVC_CHSR_CHS_1_Val             _U(0x1)   /**< \brief (PEVC_CHSR) Channel j Enabled */
+#define   PEVC_CHSR_CHS_0_Val             _U_(0x0)   /**< \brief (PEVC_CHSR) Channel j Disabled */
+#define   PEVC_CHSR_CHS_1_Val             _U_(0x1)   /**< \brief (PEVC_CHSR) Channel j Enabled */
 #define PEVC_CHSR_CHS_0             (PEVC_CHSR_CHS_0_Val           << PEVC_CHSR_CHS_Pos)
 #define PEVC_CHSR_CHS_1             (PEVC_CHSR_CHS_1_Val           << PEVC_CHSR_CHS_Pos)
-#define PEVC_CHSR_MASK              _U(0xFFFFFFFF) /**< \brief (PEVC_CHSR) MASK Register */
+#define PEVC_CHSR_MASK              _U_(0xFFFFFFFF) /**< \brief (PEVC_CHSR) MASK Register */
 
 /* -------- PEVC_CHER : (PEVC Offset: 0x004) ( /W 32) Channel Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -71,16 +71,16 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PEVC_CHER_OFFSET            0x004        /**< \brief (PEVC_CHER offset) Channel Enable Register */
-#define PEVC_CHER_RESETVALUE        _U(0x00000000); /**< \brief (PEVC_CHER reset_value) Channel Enable Register */
+#define PEVC_CHER_RESETVALUE        _U_(0x00000000); /**< \brief (PEVC_CHER reset_value) Channel Enable Register */
 
 #define PEVC_CHER_CHE_Pos           0            /**< \brief (PEVC_CHER) Channel Enable */
-#define PEVC_CHER_CHE_Msk           (_U(0xFFFFFFFF) << PEVC_CHER_CHE_Pos)
+#define PEVC_CHER_CHE_Msk           (_U_(0xFFFFFFFF) << PEVC_CHER_CHE_Pos)
 #define PEVC_CHER_CHE(value)        (PEVC_CHER_CHE_Msk & ((value) << PEVC_CHER_CHE_Pos))
-#define   PEVC_CHER_CHE_0_Val             _U(0x0)   /**< \brief (PEVC_CHER) No Action */
-#define   PEVC_CHER_CHE_1_Val             _U(0x1)   /**< \brief (PEVC_CHER) Enable Channel j */
+#define   PEVC_CHER_CHE_0_Val             _U_(0x0)   /**< \brief (PEVC_CHER) No Action */
+#define   PEVC_CHER_CHE_1_Val             _U_(0x1)   /**< \brief (PEVC_CHER) Enable Channel j */
 #define PEVC_CHER_CHE_0             (PEVC_CHER_CHE_0_Val           << PEVC_CHER_CHE_Pos)
 #define PEVC_CHER_CHE_1             (PEVC_CHER_CHE_1_Val           << PEVC_CHER_CHE_Pos)
-#define PEVC_CHER_MASK              _U(0xFFFFFFFF) /**< \brief (PEVC_CHER) MASK Register */
+#define PEVC_CHER_MASK              _U_(0xFFFFFFFF) /**< \brief (PEVC_CHER) MASK Register */
 
 /* -------- PEVC_CHDR : (PEVC Offset: 0x008) ( /W 32) Channel Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -93,16 +93,16 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PEVC_CHDR_OFFSET            0x008        /**< \brief (PEVC_CHDR offset) Channel Disable Register */
-#define PEVC_CHDR_RESETVALUE        _U(0x00000000); /**< \brief (PEVC_CHDR reset_value) Channel Disable Register */
+#define PEVC_CHDR_RESETVALUE        _U_(0x00000000); /**< \brief (PEVC_CHDR reset_value) Channel Disable Register */
 
 #define PEVC_CHDR_CHD_Pos           0            /**< \brief (PEVC_CHDR) Channel Disable */
-#define PEVC_CHDR_CHD_Msk           (_U(0xFFFFFFFF) << PEVC_CHDR_CHD_Pos)
+#define PEVC_CHDR_CHD_Msk           (_U_(0xFFFFFFFF) << PEVC_CHDR_CHD_Pos)
 #define PEVC_CHDR_CHD(value)        (PEVC_CHDR_CHD_Msk & ((value) << PEVC_CHDR_CHD_Pos))
-#define   PEVC_CHDR_CHD_0_Val             _U(0x0)   /**< \brief (PEVC_CHDR) No Action */
-#define   PEVC_CHDR_CHD_1_Val             _U(0x1)   /**< \brief (PEVC_CHDR) Disable Channel j */
+#define   PEVC_CHDR_CHD_0_Val             _U_(0x0)   /**< \brief (PEVC_CHDR) No Action */
+#define   PEVC_CHDR_CHD_1_Val             _U_(0x1)   /**< \brief (PEVC_CHDR) Disable Channel j */
 #define PEVC_CHDR_CHD_0             (PEVC_CHDR_CHD_0_Val           << PEVC_CHDR_CHD_Pos)
 #define PEVC_CHDR_CHD_1             (PEVC_CHDR_CHD_1_Val           << PEVC_CHDR_CHD_Pos)
-#define PEVC_CHDR_MASK              _U(0xFFFFFFFF) /**< \brief (PEVC_CHDR) MASK Register */
+#define PEVC_CHDR_MASK              _U_(0xFFFFFFFF) /**< \brief (PEVC_CHDR) MASK Register */
 
 /* -------- PEVC_SEV : (PEVC Offset: 0x010) ( /W 32) Software Event -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -115,16 +115,16 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PEVC_SEV_OFFSET             0x010        /**< \brief (PEVC_SEV offset) Software Event */
-#define PEVC_SEV_RESETVALUE         _U(0x00000000); /**< \brief (PEVC_SEV reset_value) Software Event */
+#define PEVC_SEV_RESETVALUE         _U_(0x00000000); /**< \brief (PEVC_SEV reset_value) Software Event */
 
 #define PEVC_SEV_SEV_Pos            0            /**< \brief (PEVC_SEV) Software Event */
-#define PEVC_SEV_SEV_Msk            (_U(0xFFFFFFFF) << PEVC_SEV_SEV_Pos)
+#define PEVC_SEV_SEV_Msk            (_U_(0xFFFFFFFF) << PEVC_SEV_SEV_Pos)
 #define PEVC_SEV_SEV(value)         (PEVC_SEV_SEV_Msk & ((value) << PEVC_SEV_SEV_Pos))
-#define   PEVC_SEV_SEV_0_Val              _U(0x0)   /**< \brief (PEVC_SEV) No Action */
-#define   PEVC_SEV_SEV_1_Val              _U(0x1)   /**< \brief (PEVC_SEV) CPU forces software event to channel j */
+#define   PEVC_SEV_SEV_0_Val              _U_(0x0)   /**< \brief (PEVC_SEV) No Action */
+#define   PEVC_SEV_SEV_1_Val              _U_(0x1)   /**< \brief (PEVC_SEV) CPU forces software event to channel j */
 #define PEVC_SEV_SEV_0              (PEVC_SEV_SEV_0_Val            << PEVC_SEV_SEV_Pos)
 #define PEVC_SEV_SEV_1              (PEVC_SEV_SEV_1_Val            << PEVC_SEV_SEV_Pos)
-#define PEVC_SEV_MASK               _U(0xFFFFFFFF) /**< \brief (PEVC_SEV) MASK Register */
+#define PEVC_SEV_MASK               _U_(0xFFFFFFFF) /**< \brief (PEVC_SEV) MASK Register */
 
 /* -------- PEVC_BUSY : (PEVC Offset: 0x014) (R/  32) Channel / User Busy -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -137,16 +137,16 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PEVC_BUSY_OFFSET            0x014        /**< \brief (PEVC_BUSY offset) Channel / User Busy */
-#define PEVC_BUSY_RESETVALUE        _U(0x00000000); /**< \brief (PEVC_BUSY reset_value) Channel / User Busy */
+#define PEVC_BUSY_RESETVALUE        _U_(0x00000000); /**< \brief (PEVC_BUSY reset_value) Channel / User Busy */
 
 #define PEVC_BUSY_BUSY_Pos          0            /**< \brief (PEVC_BUSY) Channel Status */
-#define PEVC_BUSY_BUSY_Msk          (_U(0xFFFFFFFF) << PEVC_BUSY_BUSY_Pos)
+#define PEVC_BUSY_BUSY_Msk          (_U_(0xFFFFFFFF) << PEVC_BUSY_BUSY_Pos)
 #define PEVC_BUSY_BUSY(value)       (PEVC_BUSY_BUSY_Msk & ((value) << PEVC_BUSY_BUSY_Pos))
-#define   PEVC_BUSY_BUSY_0_Val            _U(0x0)   /**< \brief (PEVC_BUSY) No Action */
-#define   PEVC_BUSY_BUSY_1_Val            _U(0x1)   /**< \brief (PEVC_BUSY) Channel j or User j is Busy */
+#define   PEVC_BUSY_BUSY_0_Val            _U_(0x0)   /**< \brief (PEVC_BUSY) No Action */
+#define   PEVC_BUSY_BUSY_1_Val            _U_(0x1)   /**< \brief (PEVC_BUSY) Channel j or User j is Busy */
 #define PEVC_BUSY_BUSY_0            (PEVC_BUSY_BUSY_0_Val          << PEVC_BUSY_BUSY_Pos)
 #define PEVC_BUSY_BUSY_1            (PEVC_BUSY_BUSY_1_Val          << PEVC_BUSY_BUSY_Pos)
-#define PEVC_BUSY_MASK              _U(0xFFFFFFFF) /**< \brief (PEVC_BUSY) MASK Register */
+#define PEVC_BUSY_MASK              _U_(0xFFFFFFFF) /**< \brief (PEVC_BUSY) MASK Register */
 
 /* -------- PEVC_TRIER : (PEVC Offset: 0x020) ( /W 32) Trigger Interrupt Mask Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -159,16 +159,16 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PEVC_TRIER_OFFSET           0x020        /**< \brief (PEVC_TRIER offset) Trigger Interrupt Mask Enable Register */
-#define PEVC_TRIER_RESETVALUE       _U(0x00000000); /**< \brief (PEVC_TRIER reset_value) Trigger Interrupt Mask Enable Register */
+#define PEVC_TRIER_RESETVALUE       _U_(0x00000000); /**< \brief (PEVC_TRIER reset_value) Trigger Interrupt Mask Enable Register */
 
 #define PEVC_TRIER_TRIE_Pos         0            /**< \brief (PEVC_TRIER) Trigger Interrupt Enable */
-#define PEVC_TRIER_TRIE_Msk         (_U(0xFFFFFFFF) << PEVC_TRIER_TRIE_Pos)
+#define PEVC_TRIER_TRIE_Msk         (_U_(0xFFFFFFFF) << PEVC_TRIER_TRIE_Pos)
 #define PEVC_TRIER_TRIE(value)      (PEVC_TRIER_TRIE_Msk & ((value) << PEVC_TRIER_TRIE_Pos))
-#define   PEVC_TRIER_TRIE_0_Val           _U(0x0)   /**< \brief (PEVC_TRIER) No Action */
-#define   PEVC_TRIER_TRIE_1_Val           _U(0x1)   /**< \brief (PEVC_TRIER) Enable Trigger j Interrupt */
+#define   PEVC_TRIER_TRIE_0_Val           _U_(0x0)   /**< \brief (PEVC_TRIER) No Action */
+#define   PEVC_TRIER_TRIE_1_Val           _U_(0x1)   /**< \brief (PEVC_TRIER) Enable Trigger j Interrupt */
 #define PEVC_TRIER_TRIE_0           (PEVC_TRIER_TRIE_0_Val         << PEVC_TRIER_TRIE_Pos)
 #define PEVC_TRIER_TRIE_1           (PEVC_TRIER_TRIE_1_Val         << PEVC_TRIER_TRIE_Pos)
-#define PEVC_TRIER_MASK             _U(0xFFFFFFFF) /**< \brief (PEVC_TRIER) MASK Register */
+#define PEVC_TRIER_MASK             _U_(0xFFFFFFFF) /**< \brief (PEVC_TRIER) MASK Register */
 
 /* -------- PEVC_TRIDR : (PEVC Offset: 0x024) ( /W 32) Trigger Interrupt Mask Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -181,16 +181,16 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PEVC_TRIDR_OFFSET           0x024        /**< \brief (PEVC_TRIDR offset) Trigger Interrupt Mask Disable Register */
-#define PEVC_TRIDR_RESETVALUE       _U(0x00000000); /**< \brief (PEVC_TRIDR reset_value) Trigger Interrupt Mask Disable Register */
+#define PEVC_TRIDR_RESETVALUE       _U_(0x00000000); /**< \brief (PEVC_TRIDR reset_value) Trigger Interrupt Mask Disable Register */
 
 #define PEVC_TRIDR_TRID_Pos         0            /**< \brief (PEVC_TRIDR) Trigger Interrupt Disable */
-#define PEVC_TRIDR_TRID_Msk         (_U(0xFFFFFFFF) << PEVC_TRIDR_TRID_Pos)
+#define PEVC_TRIDR_TRID_Msk         (_U_(0xFFFFFFFF) << PEVC_TRIDR_TRID_Pos)
 #define PEVC_TRIDR_TRID(value)      (PEVC_TRIDR_TRID_Msk & ((value) << PEVC_TRIDR_TRID_Pos))
-#define   PEVC_TRIDR_TRID_0_Val           _U(0x0)   /**< \brief (PEVC_TRIDR) No Action */
-#define   PEVC_TRIDR_TRID_1_Val           _U(0x1)   /**< \brief (PEVC_TRIDR) Disable Trigger j Interrupt */
+#define   PEVC_TRIDR_TRID_0_Val           _U_(0x0)   /**< \brief (PEVC_TRIDR) No Action */
+#define   PEVC_TRIDR_TRID_1_Val           _U_(0x1)   /**< \brief (PEVC_TRIDR) Disable Trigger j Interrupt */
 #define PEVC_TRIDR_TRID_0           (PEVC_TRIDR_TRID_0_Val         << PEVC_TRIDR_TRID_Pos)
 #define PEVC_TRIDR_TRID_1           (PEVC_TRIDR_TRID_1_Val         << PEVC_TRIDR_TRID_Pos)
-#define PEVC_TRIDR_MASK             _U(0xFFFFFFFF) /**< \brief (PEVC_TRIDR) MASK Register */
+#define PEVC_TRIDR_MASK             _U_(0xFFFFFFFF) /**< \brief (PEVC_TRIDR) MASK Register */
 
 /* -------- PEVC_TRIMR : (PEVC Offset: 0x028) (R/  32) Trigger Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -203,16 +203,16 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PEVC_TRIMR_OFFSET           0x028        /**< \brief (PEVC_TRIMR offset) Trigger Interrupt Mask Register */
-#define PEVC_TRIMR_RESETVALUE       _U(0x00000000); /**< \brief (PEVC_TRIMR reset_value) Trigger Interrupt Mask Register */
+#define PEVC_TRIMR_RESETVALUE       _U_(0x00000000); /**< \brief (PEVC_TRIMR reset_value) Trigger Interrupt Mask Register */
 
 #define PEVC_TRIMR_TRIM_Pos         0            /**< \brief (PEVC_TRIMR) Trigger Interrupt Mask */
-#define PEVC_TRIMR_TRIM_Msk         (_U(0xFFFFFFFF) << PEVC_TRIMR_TRIM_Pos)
+#define PEVC_TRIMR_TRIM_Msk         (_U_(0xFFFFFFFF) << PEVC_TRIMR_TRIM_Pos)
 #define PEVC_TRIMR_TRIM(value)      (PEVC_TRIMR_TRIM_Msk & ((value) << PEVC_TRIMR_TRIM_Pos))
-#define   PEVC_TRIMR_TRIM_0_Val           _U(0x0)   /**< \brief (PEVC_TRIMR) Trigger j Interrupt Disabled */
-#define   PEVC_TRIMR_TRIM_1_Val           _U(0x1)   /**< \brief (PEVC_TRIMR) Trigger j Interrupt Enabled */
+#define   PEVC_TRIMR_TRIM_0_Val           _U_(0x0)   /**< \brief (PEVC_TRIMR) Trigger j Interrupt Disabled */
+#define   PEVC_TRIMR_TRIM_1_Val           _U_(0x1)   /**< \brief (PEVC_TRIMR) Trigger j Interrupt Enabled */
 #define PEVC_TRIMR_TRIM_0           (PEVC_TRIMR_TRIM_0_Val         << PEVC_TRIMR_TRIM_Pos)
 #define PEVC_TRIMR_TRIM_1           (PEVC_TRIMR_TRIM_1_Val         << PEVC_TRIMR_TRIM_Pos)
-#define PEVC_TRIMR_MASK             _U(0xFFFFFFFF) /**< \brief (PEVC_TRIMR) MASK Register */
+#define PEVC_TRIMR_MASK             _U_(0xFFFFFFFF) /**< \brief (PEVC_TRIMR) MASK Register */
 
 /* -------- PEVC_TRSR : (PEVC Offset: 0x030) (R/  32) Trigger Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -225,16 +225,16 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PEVC_TRSR_OFFSET            0x030        /**< \brief (PEVC_TRSR offset) Trigger Status Register */
-#define PEVC_TRSR_RESETVALUE        _U(0x00000000); /**< \brief (PEVC_TRSR reset_value) Trigger Status Register */
+#define PEVC_TRSR_RESETVALUE        _U_(0x00000000); /**< \brief (PEVC_TRSR reset_value) Trigger Status Register */
 
 #define PEVC_TRSR_TRS_Pos           0            /**< \brief (PEVC_TRSR) Trigger Interrupt Status */
-#define PEVC_TRSR_TRS_Msk           (_U(0xFFFFFFFF) << PEVC_TRSR_TRS_Pos)
+#define PEVC_TRSR_TRS_Msk           (_U_(0xFFFFFFFF) << PEVC_TRSR_TRS_Pos)
 #define PEVC_TRSR_TRS(value)        (PEVC_TRSR_TRS_Msk & ((value) << PEVC_TRSR_TRS_Pos))
-#define   PEVC_TRSR_TRS_0_Val             _U(0x0)   /**< \brief (PEVC_TRSR) Channel j did not send out an Event in the past */
-#define   PEVC_TRSR_TRS_1_Val             _U(0x1)   /**< \brief (PEVC_TRSR) Channel j did send out an Event in the past */
+#define   PEVC_TRSR_TRS_0_Val             _U_(0x0)   /**< \brief (PEVC_TRSR) Channel j did not send out an Event in the past */
+#define   PEVC_TRSR_TRS_1_Val             _U_(0x1)   /**< \brief (PEVC_TRSR) Channel j did send out an Event in the past */
 #define PEVC_TRSR_TRS_0             (PEVC_TRSR_TRS_0_Val           << PEVC_TRSR_TRS_Pos)
 #define PEVC_TRSR_TRS_1             (PEVC_TRSR_TRS_1_Val           << PEVC_TRSR_TRS_Pos)
-#define PEVC_TRSR_MASK              _U(0xFFFFFFFF) /**< \brief (PEVC_TRSR) MASK Register */
+#define PEVC_TRSR_MASK              _U_(0xFFFFFFFF) /**< \brief (PEVC_TRSR) MASK Register */
 
 /* -------- PEVC_TRSCR : (PEVC Offset: 0x034) ( /W 32) Trigger Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -247,16 +247,16 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PEVC_TRSCR_OFFSET           0x034        /**< \brief (PEVC_TRSCR offset) Trigger Status Clear Register */
-#define PEVC_TRSCR_RESETVALUE       _U(0x00000000); /**< \brief (PEVC_TRSCR reset_value) Trigger Status Clear Register */
+#define PEVC_TRSCR_RESETVALUE       _U_(0x00000000); /**< \brief (PEVC_TRSCR reset_value) Trigger Status Clear Register */
 
 #define PEVC_TRSCR_TRSC_Pos         0            /**< \brief (PEVC_TRSCR) Trigger Interrupt Status Clear */
-#define PEVC_TRSCR_TRSC_Msk         (_U(0xFFFFFFFF) << PEVC_TRSCR_TRSC_Pos)
+#define PEVC_TRSCR_TRSC_Msk         (_U_(0xFFFFFFFF) << PEVC_TRSCR_TRSC_Pos)
 #define PEVC_TRSCR_TRSC(value)      (PEVC_TRSCR_TRSC_Msk & ((value) << PEVC_TRSCR_TRSC_Pos))
-#define   PEVC_TRSCR_TRSC_0_Val           _U(0x0)   /**< \brief (PEVC_TRSCR) No Action */
-#define   PEVC_TRSCR_TRSC_1_Val           _U(0x1)   /**< \brief (PEVC_TRSCR) Clear TRSR[j] */
+#define   PEVC_TRSCR_TRSC_0_Val           _U_(0x0)   /**< \brief (PEVC_TRSCR) No Action */
+#define   PEVC_TRSCR_TRSC_1_Val           _U_(0x1)   /**< \brief (PEVC_TRSCR) Clear TRSR[j] */
 #define PEVC_TRSCR_TRSC_0           (PEVC_TRSCR_TRSC_0_Val         << PEVC_TRSCR_TRSC_Pos)
 #define PEVC_TRSCR_TRSC_1           (PEVC_TRSCR_TRSC_1_Val         << PEVC_TRSCR_TRSC_Pos)
-#define PEVC_TRSCR_MASK             _U(0xFFFFFFFF) /**< \brief (PEVC_TRSCR) MASK Register */
+#define PEVC_TRSCR_MASK             _U_(0xFFFFFFFF) /**< \brief (PEVC_TRSCR) MASK Register */
 
 /* -------- PEVC_OVIER : (PEVC Offset: 0x040) ( /W 32) Overrun Interrupt Mask Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -269,16 +269,16 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PEVC_OVIER_OFFSET           0x040        /**< \brief (PEVC_OVIER offset) Overrun Interrupt Mask Enable Register */
-#define PEVC_OVIER_RESETVALUE       _U(0x00000000); /**< \brief (PEVC_OVIER reset_value) Overrun Interrupt Mask Enable Register */
+#define PEVC_OVIER_RESETVALUE       _U_(0x00000000); /**< \brief (PEVC_OVIER reset_value) Overrun Interrupt Mask Enable Register */
 
 #define PEVC_OVIER_OVIE_Pos         0            /**< \brief (PEVC_OVIER) Overrun Interrupt Enable */
-#define PEVC_OVIER_OVIE_Msk         (_U(0xFFFFFFFF) << PEVC_OVIER_OVIE_Pos)
+#define PEVC_OVIER_OVIE_Msk         (_U_(0xFFFFFFFF) << PEVC_OVIER_OVIE_Pos)
 #define PEVC_OVIER_OVIE(value)      (PEVC_OVIER_OVIE_Msk & ((value) << PEVC_OVIER_OVIE_Pos))
-#define   PEVC_OVIER_OVIE_0_Val           _U(0x0)   /**< \brief (PEVC_OVIER) No Action */
-#define   PEVC_OVIER_OVIE_1_Val           _U(0x1)   /**< \brief (PEVC_OVIER) Enable Overrun Interrupt for Channel j */
+#define   PEVC_OVIER_OVIE_0_Val           _U_(0x0)   /**< \brief (PEVC_OVIER) No Action */
+#define   PEVC_OVIER_OVIE_1_Val           _U_(0x1)   /**< \brief (PEVC_OVIER) Enable Overrun Interrupt for Channel j */
 #define PEVC_OVIER_OVIE_0           (PEVC_OVIER_OVIE_0_Val         << PEVC_OVIER_OVIE_Pos)
 #define PEVC_OVIER_OVIE_1           (PEVC_OVIER_OVIE_1_Val         << PEVC_OVIER_OVIE_Pos)
-#define PEVC_OVIER_MASK             _U(0xFFFFFFFF) /**< \brief (PEVC_OVIER) MASK Register */
+#define PEVC_OVIER_MASK             _U_(0xFFFFFFFF) /**< \brief (PEVC_OVIER) MASK Register */
 
 /* -------- PEVC_OVIDR : (PEVC Offset: 0x044) ( /W 32) Overrun Interrupt Mask Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -291,16 +291,16 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PEVC_OVIDR_OFFSET           0x044        /**< \brief (PEVC_OVIDR offset) Overrun Interrupt Mask Disable Register */
-#define PEVC_OVIDR_RESETVALUE       _U(0x00000000); /**< \brief (PEVC_OVIDR reset_value) Overrun Interrupt Mask Disable Register */
+#define PEVC_OVIDR_RESETVALUE       _U_(0x00000000); /**< \brief (PEVC_OVIDR reset_value) Overrun Interrupt Mask Disable Register */
 
 #define PEVC_OVIDR_OVID_Pos         0            /**< \brief (PEVC_OVIDR) Overrun Interrupt Disable */
-#define PEVC_OVIDR_OVID_Msk         (_U(0xFFFFFFFF) << PEVC_OVIDR_OVID_Pos)
+#define PEVC_OVIDR_OVID_Msk         (_U_(0xFFFFFFFF) << PEVC_OVIDR_OVID_Pos)
 #define PEVC_OVIDR_OVID(value)      (PEVC_OVIDR_OVID_Msk & ((value) << PEVC_OVIDR_OVID_Pos))
-#define   PEVC_OVIDR_OVID_0_Val           _U(0x0)   /**< \brief (PEVC_OVIDR) No Action */
-#define   PEVC_OVIDR_OVID_1_Val           _U(0x1)   /**< \brief (PEVC_OVIDR) Enable Overrun Interrupt for Channel j */
+#define   PEVC_OVIDR_OVID_0_Val           _U_(0x0)   /**< \brief (PEVC_OVIDR) No Action */
+#define   PEVC_OVIDR_OVID_1_Val           _U_(0x1)   /**< \brief (PEVC_OVIDR) Enable Overrun Interrupt for Channel j */
 #define PEVC_OVIDR_OVID_0           (PEVC_OVIDR_OVID_0_Val         << PEVC_OVIDR_OVID_Pos)
 #define PEVC_OVIDR_OVID_1           (PEVC_OVIDR_OVID_1_Val         << PEVC_OVIDR_OVID_Pos)
-#define PEVC_OVIDR_MASK             _U(0xFFFFFFFF) /**< \brief (PEVC_OVIDR) MASK Register */
+#define PEVC_OVIDR_MASK             _U_(0xFFFFFFFF) /**< \brief (PEVC_OVIDR) MASK Register */
 
 /* -------- PEVC_OVIMR : (PEVC Offset: 0x048) (R/  32) Overrun Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -313,16 +313,16 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PEVC_OVIMR_OFFSET           0x048        /**< \brief (PEVC_OVIMR offset) Overrun Interrupt Mask Register */
-#define PEVC_OVIMR_RESETVALUE       _U(0x00000000); /**< \brief (PEVC_OVIMR reset_value) Overrun Interrupt Mask Register */
+#define PEVC_OVIMR_RESETVALUE       _U_(0x00000000); /**< \brief (PEVC_OVIMR reset_value) Overrun Interrupt Mask Register */
 
 #define PEVC_OVIMR_OVIM_Pos         0            /**< \brief (PEVC_OVIMR) Overrun Interrupt Mask */
-#define PEVC_OVIMR_OVIM_Msk         (_U(0xFFFFFFFF) << PEVC_OVIMR_OVIM_Pos)
+#define PEVC_OVIMR_OVIM_Msk         (_U_(0xFFFFFFFF) << PEVC_OVIMR_OVIM_Pos)
 #define PEVC_OVIMR_OVIM(value)      (PEVC_OVIMR_OVIM_Msk & ((value) << PEVC_OVIMR_OVIM_Pos))
-#define   PEVC_OVIMR_OVIM_0_Val           _U(0x0)   /**< \brief (PEVC_OVIMR) Overrun Interrupt for Channel j Disabled */
-#define   PEVC_OVIMR_OVIM_1_Val           _U(0x1)   /**< \brief (PEVC_OVIMR) Overrun Interrupt for Channel j Enabled */
+#define   PEVC_OVIMR_OVIM_0_Val           _U_(0x0)   /**< \brief (PEVC_OVIMR) Overrun Interrupt for Channel j Disabled */
+#define   PEVC_OVIMR_OVIM_1_Val           _U_(0x1)   /**< \brief (PEVC_OVIMR) Overrun Interrupt for Channel j Enabled */
 #define PEVC_OVIMR_OVIM_0           (PEVC_OVIMR_OVIM_0_Val         << PEVC_OVIMR_OVIM_Pos)
 #define PEVC_OVIMR_OVIM_1           (PEVC_OVIMR_OVIM_1_Val         << PEVC_OVIMR_OVIM_Pos)
-#define PEVC_OVIMR_MASK             _U(0xFFFFFFFF) /**< \brief (PEVC_OVIMR) MASK Register */
+#define PEVC_OVIMR_MASK             _U_(0xFFFFFFFF) /**< \brief (PEVC_OVIMR) MASK Register */
 
 /* -------- PEVC_OVSR : (PEVC Offset: 0x050) (R/  32) Overrun Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -335,16 +335,16 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PEVC_OVSR_OFFSET            0x050        /**< \brief (PEVC_OVSR offset) Overrun Status Register */
-#define PEVC_OVSR_RESETVALUE        _U(0x00000000); /**< \brief (PEVC_OVSR reset_value) Overrun Status Register */
+#define PEVC_OVSR_RESETVALUE        _U_(0x00000000); /**< \brief (PEVC_OVSR reset_value) Overrun Status Register */
 
 #define PEVC_OVSR_OVS_Pos           0            /**< \brief (PEVC_OVSR) Overrun Interrupt Status */
-#define PEVC_OVSR_OVS_Msk           (_U(0xFFFFFFFF) << PEVC_OVSR_OVS_Pos)
+#define PEVC_OVSR_OVS_Msk           (_U_(0xFFFFFFFF) << PEVC_OVSR_OVS_Pos)
 #define PEVC_OVSR_OVS(value)        (PEVC_OVSR_OVS_Msk & ((value) << PEVC_OVSR_OVS_Pos))
-#define   PEVC_OVSR_OVS_0_Val             _U(0x0)   /**< \brief (PEVC_OVSR) No Overrun occured on Channel j */
-#define   PEVC_OVSR_OVS_1_Val             _U(0x1)   /**< \brief (PEVC_OVSR) Overrun occured on Channel j */
+#define   PEVC_OVSR_OVS_0_Val             _U_(0x0)   /**< \brief (PEVC_OVSR) No Overrun occured on Channel j */
+#define   PEVC_OVSR_OVS_1_Val             _U_(0x1)   /**< \brief (PEVC_OVSR) Overrun occured on Channel j */
 #define PEVC_OVSR_OVS_0             (PEVC_OVSR_OVS_0_Val           << PEVC_OVSR_OVS_Pos)
 #define PEVC_OVSR_OVS_1             (PEVC_OVSR_OVS_1_Val           << PEVC_OVSR_OVS_Pos)
-#define PEVC_OVSR_MASK              _U(0xFFFFFFFF) /**< \brief (PEVC_OVSR) MASK Register */
+#define PEVC_OVSR_MASK              _U_(0xFFFFFFFF) /**< \brief (PEVC_OVSR) MASK Register */
 
 /* -------- PEVC_OVSCR : (PEVC Offset: 0x054) ( /W 32) Overrun Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -357,16 +357,16 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PEVC_OVSCR_OFFSET           0x054        /**< \brief (PEVC_OVSCR offset) Overrun Status Clear Register */
-#define PEVC_OVSCR_RESETVALUE       _U(0x00000000); /**< \brief (PEVC_OVSCR reset_value) Overrun Status Clear Register */
+#define PEVC_OVSCR_RESETVALUE       _U_(0x00000000); /**< \brief (PEVC_OVSCR reset_value) Overrun Status Clear Register */
 
 #define PEVC_OVSCR_OVSC_Pos         0            /**< \brief (PEVC_OVSCR) Overrun Interrupt Status Clear */
-#define PEVC_OVSCR_OVSC_Msk         (_U(0xFFFFFFFF) << PEVC_OVSCR_OVSC_Pos)
+#define PEVC_OVSCR_OVSC_Msk         (_U_(0xFFFFFFFF) << PEVC_OVSCR_OVSC_Pos)
 #define PEVC_OVSCR_OVSC(value)      (PEVC_OVSCR_OVSC_Msk & ((value) << PEVC_OVSCR_OVSC_Pos))
-#define   PEVC_OVSCR_OVSC_0_Val           _U(0x0)   /**< \brief (PEVC_OVSCR) No Action */
-#define   PEVC_OVSCR_OVSC_1_Val           _U(0x1)   /**< \brief (PEVC_OVSCR) Clear Overrun Status Bit j */
+#define   PEVC_OVSCR_OVSC_0_Val           _U_(0x0)   /**< \brief (PEVC_OVSCR) No Action */
+#define   PEVC_OVSCR_OVSC_1_Val           _U_(0x1)   /**< \brief (PEVC_OVSCR) Clear Overrun Status Bit j */
 #define PEVC_OVSCR_OVSC_0           (PEVC_OVSCR_OVSC_0_Val         << PEVC_OVSCR_OVSC_Pos)
 #define PEVC_OVSCR_OVSC_1           (PEVC_OVSCR_OVSC_1_Val         << PEVC_OVSCR_OVSC_Pos)
-#define PEVC_OVSCR_MASK             _U(0xFFFFFFFF) /**< \brief (PEVC_OVSCR) MASK Register */
+#define PEVC_OVSCR_MASK             _U_(0xFFFFFFFF) /**< \brief (PEVC_OVSCR) MASK Register */
 
 /* -------- PEVC_CHMX : (PEVC Offset: 0x100) (R/W 32) CHMX Channel Multiplexer -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -382,22 +382,22 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PEVC_CHMX_OFFSET            0x100        /**< \brief (PEVC_CHMX offset) Channel Multiplexer */
-#define PEVC_CHMX_RESETVALUE        _U(0x00000000); /**< \brief (PEVC_CHMX reset_value) Channel Multiplexer */
+#define PEVC_CHMX_RESETVALUE        _U_(0x00000000); /**< \brief (PEVC_CHMX reset_value) Channel Multiplexer */
 
 #define PEVC_CHMX_EVMX_Pos          0            /**< \brief (PEVC_CHMX) Event Multiplexer */
-#define PEVC_CHMX_EVMX_Msk          (_U(0x3F) << PEVC_CHMX_EVMX_Pos)
+#define PEVC_CHMX_EVMX_Msk          (_U_(0x3F) << PEVC_CHMX_EVMX_Pos)
 #define PEVC_CHMX_EVMX(value)       (PEVC_CHMX_EVMX_Msk & ((value) << PEVC_CHMX_EVMX_Pos))
-#define   PEVC_CHMX_EVMX_0_Val            _U(0x0)   /**< \brief (PEVC_CHMX) Event 0 */
-#define   PEVC_CHMX_EVMX_1_Val            _U(0x1)   /**< \brief (PEVC_CHMX) Event 1 */
+#define   PEVC_CHMX_EVMX_0_Val            _U_(0x0)   /**< \brief (PEVC_CHMX) Event 0 */
+#define   PEVC_CHMX_EVMX_1_Val            _U_(0x1)   /**< \brief (PEVC_CHMX) Event 1 */
 #define PEVC_CHMX_EVMX_0            (PEVC_CHMX_EVMX_0_Val          << PEVC_CHMX_EVMX_Pos)
 #define PEVC_CHMX_EVMX_1            (PEVC_CHMX_EVMX_1_Val          << PEVC_CHMX_EVMX_Pos)
 #define PEVC_CHMX_SMX_Pos           8            /**< \brief (PEVC_CHMX) Software Event Multiplexer */
-#define PEVC_CHMX_SMX               (_U(0x1) << PEVC_CHMX_SMX_Pos)
-#define   PEVC_CHMX_SMX_0_Val             _U(0x0)   /**< \brief (PEVC_CHMX) Hardware events */
-#define   PEVC_CHMX_SMX_1_Val             _U(0x1)   /**< \brief (PEVC_CHMX) Software event */
+#define PEVC_CHMX_SMX               (_U_(0x1) << PEVC_CHMX_SMX_Pos)
+#define   PEVC_CHMX_SMX_0_Val             _U_(0x0)   /**< \brief (PEVC_CHMX) Hardware events */
+#define   PEVC_CHMX_SMX_1_Val             _U_(0x1)   /**< \brief (PEVC_CHMX) Software event */
 #define PEVC_CHMX_SMX_0             (PEVC_CHMX_SMX_0_Val           << PEVC_CHMX_SMX_Pos)
 #define PEVC_CHMX_SMX_1             (PEVC_CHMX_SMX_1_Val           << PEVC_CHMX_SMX_Pos)
-#define PEVC_CHMX_MASK              _U(0x0000013F) /**< \brief (PEVC_CHMX) MASK Register */
+#define PEVC_CHMX_MASK              _U_(0x0000013F) /**< \brief (PEVC_CHMX) MASK Register */
 
 /* -------- PEVC_EVS : (PEVC Offset: 0x200) (R/W 32) EVS Event Shaper -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -415,29 +415,29 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PEVC_EVS_OFFSET             0x200        /**< \brief (PEVC_EVS offset) Event Shaper */
-#define PEVC_EVS_RESETVALUE         _U(0x00000000); /**< \brief (PEVC_EVS reset_value) Event Shaper */
+#define PEVC_EVS_RESETVALUE         _U_(0x00000000); /**< \brief (PEVC_EVS reset_value) Event Shaper */
 
 #define PEVC_EVS_EN_Pos             0            /**< \brief (PEVC_EVS) Event Shaper Enable */
-#define PEVC_EVS_EN                 (_U(0x1) << PEVC_EVS_EN_Pos)
-#define   PEVC_EVS_EN_0_Val               _U(0x0)   /**< \brief (PEVC_EVS) No Action */
-#define   PEVC_EVS_EN_1_Val               _U(0x1)   /**< \brief (PEVC_EVS) Event Shaper enable */
+#define PEVC_EVS_EN                 (_U_(0x1) << PEVC_EVS_EN_Pos)
+#define   PEVC_EVS_EN_0_Val               _U_(0x0)   /**< \brief (PEVC_EVS) No Action */
+#define   PEVC_EVS_EN_1_Val               _U_(0x1)   /**< \brief (PEVC_EVS) Event Shaper enable */
 #define PEVC_EVS_EN_0               (PEVC_EVS_EN_0_Val             << PEVC_EVS_EN_Pos)
 #define PEVC_EVS_EN_1               (PEVC_EVS_EN_1_Val             << PEVC_EVS_EN_Pos)
 #define PEVC_EVS_IGFR_Pos           16           /**< \brief (PEVC_EVS) Input Glitch Filter Rise */
-#define PEVC_EVS_IGFR               (_U(0x1) << PEVC_EVS_IGFR_Pos)
-#define   PEVC_EVS_IGFR_0_Val             _U(0x0)   /**< \brief (PEVC_EVS) No Action */
-#define   PEVC_EVS_IGFR_1_Val             _U(0x1)   /**< \brief (PEVC_EVS) Input Glitch Filter : a rising edge on event input will raise trigger output */
+#define PEVC_EVS_IGFR               (_U_(0x1) << PEVC_EVS_IGFR_Pos)
+#define   PEVC_EVS_IGFR_0_Val             _U_(0x0)   /**< \brief (PEVC_EVS) No Action */
+#define   PEVC_EVS_IGFR_1_Val             _U_(0x1)   /**< \brief (PEVC_EVS) Input Glitch Filter : a rising edge on event input will raise trigger output */
 #define PEVC_EVS_IGFR_0             (PEVC_EVS_IGFR_0_Val           << PEVC_EVS_IGFR_Pos)
 #define PEVC_EVS_IGFR_1             (PEVC_EVS_IGFR_1_Val           << PEVC_EVS_IGFR_Pos)
 #define PEVC_EVS_IGFF_Pos           17           /**< \brief (PEVC_EVS) Input Glitch Filter Fall */
-#define PEVC_EVS_IGFF               (_U(0x1) << PEVC_EVS_IGFF_Pos)
-#define   PEVC_EVS_IGFF_0_Val             _U(0x0)   /**< \brief (PEVC_EVS) No Action */
-#define   PEVC_EVS_IGFF_1_Val             _U(0x1)   /**< \brief (PEVC_EVS) Input Glitch Filter : a falling edge on event input will raise trigger output */
+#define PEVC_EVS_IGFF               (_U_(0x1) << PEVC_EVS_IGFF_Pos)
+#define   PEVC_EVS_IGFF_0_Val             _U_(0x0)   /**< \brief (PEVC_EVS) No Action */
+#define   PEVC_EVS_IGFF_1_Val             _U_(0x1)   /**< \brief (PEVC_EVS) Input Glitch Filter : a falling edge on event input will raise trigger output */
 #define PEVC_EVS_IGFF_0             (PEVC_EVS_IGFF_0_Val           << PEVC_EVS_IGFF_Pos)
 #define PEVC_EVS_IGFF_1             (PEVC_EVS_IGFF_1_Val           << PEVC_EVS_IGFF_Pos)
 #define PEVC_EVS_IGFON_Pos          18           /**< \brief (PEVC_EVS) Input Glitch Filter Status */
-#define PEVC_EVS_IGFON              (_U(0x1) << PEVC_EVS_IGFON_Pos)
-#define PEVC_EVS_MASK               _U(0x00070001) /**< \brief (PEVC_EVS) MASK Register */
+#define PEVC_EVS_IGFON              (_U_(0x1) << PEVC_EVS_IGFON_Pos)
+#define PEVC_EVS_MASK               _U_(0x00070001) /**< \brief (PEVC_EVS) MASK Register */
 
 /* -------- PEVC_IGFDR : (PEVC Offset: 0x300) (R/W 32) Input Glitch Filter Divider Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -451,12 +451,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PEVC_IGFDR_OFFSET           0x300        /**< \brief (PEVC_IGFDR offset) Input Glitch Filter Divider Register */
-#define PEVC_IGFDR_RESETVALUE       _U(0x00000000); /**< \brief (PEVC_IGFDR reset_value) Input Glitch Filter Divider Register */
+#define PEVC_IGFDR_RESETVALUE       _U_(0x00000000); /**< \brief (PEVC_IGFDR reset_value) Input Glitch Filter Divider Register */
 
 #define PEVC_IGFDR_IGFDR_Pos        0            /**< \brief (PEVC_IGFDR) Input Glitch Filter Divider Register */
-#define PEVC_IGFDR_IGFDR_Msk        (_U(0xF) << PEVC_IGFDR_IGFDR_Pos)
+#define PEVC_IGFDR_IGFDR_Msk        (_U_(0xF) << PEVC_IGFDR_IGFDR_Pos)
 #define PEVC_IGFDR_IGFDR(value)     (PEVC_IGFDR_IGFDR_Msk & ((value) << PEVC_IGFDR_IGFDR_Pos))
-#define PEVC_IGFDR_MASK             _U(0x0000000F) /**< \brief (PEVC_IGFDR) MASK Register */
+#define PEVC_IGFDR_MASK             _U_(0x0000000F) /**< \brief (PEVC_IGFDR) MASK Register */
 
 /* -------- PEVC_PARAMETER : (PEVC Offset: 0x3F8) (R/  32) Parameter -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -472,21 +472,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PEVC_PARAMETER_OFFSET       0x3F8        /**< \brief (PEVC_PARAMETER offset) Parameter */
-#define PEVC_PARAMETER_RESETVALUE   _U(0x14061824); /**< \brief (PEVC_PARAMETER reset_value) Parameter */
+#define PEVC_PARAMETER_RESETVALUE   _U_(0x14061824); /**< \brief (PEVC_PARAMETER reset_value) Parameter */
 
 #define PEVC_PARAMETER_IGF_COUNT_Pos 0            /**< \brief (PEVC_PARAMETER) Number of Input Glitch Filters */
-#define PEVC_PARAMETER_IGF_COUNT_Msk (_U(0xFF) << PEVC_PARAMETER_IGF_COUNT_Pos)
+#define PEVC_PARAMETER_IGF_COUNT_Msk (_U_(0xFF) << PEVC_PARAMETER_IGF_COUNT_Pos)
 #define PEVC_PARAMETER_IGF_COUNT(value) (PEVC_PARAMETER_IGF_COUNT_Msk & ((value) << PEVC_PARAMETER_IGF_COUNT_Pos))
 #define PEVC_PARAMETER_EVS_COUNT_Pos 8            /**< \brief (PEVC_PARAMETER) Number of Event Shapers */
-#define PEVC_PARAMETER_EVS_COUNT_Msk (_U(0xFF) << PEVC_PARAMETER_EVS_COUNT_Pos)
+#define PEVC_PARAMETER_EVS_COUNT_Msk (_U_(0xFF) << PEVC_PARAMETER_EVS_COUNT_Pos)
 #define PEVC_PARAMETER_EVS_COUNT(value) (PEVC_PARAMETER_EVS_COUNT_Msk & ((value) << PEVC_PARAMETER_EVS_COUNT_Pos))
 #define PEVC_PARAMETER_EVIN_Pos     16           /**< \brief (PEVC_PARAMETER) Number of Event Inputs / Generators */
-#define PEVC_PARAMETER_EVIN_Msk     (_U(0xFF) << PEVC_PARAMETER_EVIN_Pos)
+#define PEVC_PARAMETER_EVIN_Msk     (_U_(0xFF) << PEVC_PARAMETER_EVIN_Pos)
 #define PEVC_PARAMETER_EVIN(value)  (PEVC_PARAMETER_EVIN_Msk & ((value) << PEVC_PARAMETER_EVIN_Pos))
 #define PEVC_PARAMETER_TRIGOUT_Pos  24           /**< \brief (PEVC_PARAMETER) Number of Trigger Outputs / Channels / Users */
-#define PEVC_PARAMETER_TRIGOUT_Msk  (_U(0xFF) << PEVC_PARAMETER_TRIGOUT_Pos)
+#define PEVC_PARAMETER_TRIGOUT_Msk  (_U_(0xFF) << PEVC_PARAMETER_TRIGOUT_Pos)
 #define PEVC_PARAMETER_TRIGOUT(value) (PEVC_PARAMETER_TRIGOUT_Msk & ((value) << PEVC_PARAMETER_TRIGOUT_Pos))
-#define PEVC_PARAMETER_MASK         _U(0xFFFFFFFF) /**< \brief (PEVC_PARAMETER) MASK Register */
+#define PEVC_PARAMETER_MASK         _U_(0xFFFFFFFF) /**< \brief (PEVC_PARAMETER) MASK Register */
 
 /* -------- PEVC_VERSION : (PEVC Offset: 0x3FC) (R/  32) Version -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -502,15 +502,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PEVC_VERSION_OFFSET         0x3FC        /**< \brief (PEVC_VERSION offset) Version */
-#define PEVC_VERSION_RESETVALUE     _U(0x00000200); /**< \brief (PEVC_VERSION reset_value) Version */
+#define PEVC_VERSION_RESETVALUE     _U_(0x00000200); /**< \brief (PEVC_VERSION reset_value) Version */
 
 #define PEVC_VERSION_VERSION_Pos    0            /**< \brief (PEVC_VERSION) Version Number */
-#define PEVC_VERSION_VERSION_Msk    (_U(0xFFF) << PEVC_VERSION_VERSION_Pos)
+#define PEVC_VERSION_VERSION_Msk    (_U_(0xFFF) << PEVC_VERSION_VERSION_Pos)
 #define PEVC_VERSION_VERSION(value) (PEVC_VERSION_VERSION_Msk & ((value) << PEVC_VERSION_VERSION_Pos))
 #define PEVC_VERSION_VARIANT_Pos    16           /**< \brief (PEVC_VERSION) Variant Number */
-#define PEVC_VERSION_VARIANT_Msk    (_U(0xF) << PEVC_VERSION_VARIANT_Pos)
+#define PEVC_VERSION_VARIANT_Msk    (_U_(0xF) << PEVC_VERSION_VARIANT_Pos)
 #define PEVC_VERSION_VARIANT(value) (PEVC_VERSION_VARIANT_Msk & ((value) << PEVC_VERSION_VARIANT_Pos))
-#define PEVC_VERSION_MASK           _U(0x000F0FFF) /**< \brief (PEVC_VERSION) MASK Register */
+#define PEVC_VERSION_MASK           _U_(0x000F0FFF) /**< \brief (PEVC_VERSION) MASK Register */
 
 /** \brief PevcChmx hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/picouart.h
+++ b/asf/sam/include/sam4l/component/picouart.h
@@ -151,23 +151,13 @@ typedef union {
 
 /** \brief PICOUART hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __O  PICOUART_CR_Type          CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
-  __IO PICOUART_CFG_Type         CFG;         /**< \brief Offset: 0x04 (R/W 32) Configuration Register */
-  __I  PICOUART_SR_Type          SR;          /**< \brief Offset: 0x08 (R/  32) Status Register */
-  __I  PICOUART_RHR_Type         RHR;         /**< \brief Offset: 0x0C (R/  32) Receive Holding Register */
-       RoReg8                    Reserved1[0x10];
-  __I  PICOUART_VERSION_Type     VERSION;     /**< \brief Offset: 0x20 (R/  32) Version Register */
- } bf;
- struct {
-  WoReg   PICOUART_CR;        /**< \brief (PICOUART Offset: 0x00) Control Register */
-  RwReg   PICOUART_CFG;       /**< \brief (PICOUART Offset: 0x04) Configuration Register */
-  RoReg   PICOUART_SR;        /**< \brief (PICOUART Offset: 0x08) Status Register */
-  RoReg   PICOUART_RHR;       /**< \brief (PICOUART Offset: 0x0C) Receive Holding Register */
-  RoReg8  Reserved2[0x10];
-  RoReg   PICOUART_VERSION;   /**< \brief (PICOUART Offset: 0x20) Version Register */
- } reg;
+typedef struct {
+  __O  uint32_t CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
+  __IO uint32_t CFG;         /**< \brief Offset: 0x04 (R/W 32) Configuration Register */
+  __I  uint32_t SR;          /**< \brief Offset: 0x08 (R/  32) Status Register */
+  __I  uint32_t RHR;         /**< \brief Offset: 0x0C (R/  32) Receive Holding Register */
+       RoReg8   Reserved1[0x10];
+  __I  uint32_t VERSION;     /**< \brief Offset: 0x20 (R/  32) Version Register */
 } Picouart;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/picouart.h
+++ b/asf/sam/include/sam4l/component/picouart.h
@@ -51,13 +51,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PICOUART_CR_OFFSET          0x00         /**< \brief (PICOUART_CR offset) Control Register */
-#define PICOUART_CR_RESETVALUE      _U(0x00000000); /**< \brief (PICOUART_CR reset_value) Control Register */
+#define PICOUART_CR_RESETVALUE      _U_(0x00000000); /**< \brief (PICOUART_CR reset_value) Control Register */
 
 #define PICOUART_CR_EN_Pos          0            /**< \brief (PICOUART_CR) Enable */
-#define PICOUART_CR_EN              (_U(0x1) << PICOUART_CR_EN_Pos)
+#define PICOUART_CR_EN              (_U_(0x1) << PICOUART_CR_EN_Pos)
 #define PICOUART_CR_DIS_Pos         1            /**< \brief (PICOUART_CR) Disable */
-#define PICOUART_CR_DIS             (_U(0x1) << PICOUART_CR_DIS_Pos)
-#define PICOUART_CR_MASK            _U(0x00000003) /**< \brief (PICOUART_CR) MASK Register */
+#define PICOUART_CR_DIS             (_U_(0x1) << PICOUART_CR_DIS_Pos)
+#define PICOUART_CR_MASK            _U_(0x00000003) /**< \brief (PICOUART_CR) MASK Register */
 
 /* -------- PICOUART_CFG : (PICOUART Offset: 0x04) (R/W 32) Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -74,17 +74,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PICOUART_CFG_OFFSET         0x04         /**< \brief (PICOUART_CFG offset) Configuration Register */
-#define PICOUART_CFG_RESETVALUE     _U(0x00000000); /**< \brief (PICOUART_CFG reset_value) Configuration Register */
+#define PICOUART_CFG_RESETVALUE     _U_(0x00000000); /**< \brief (PICOUART_CFG reset_value) Configuration Register */
 
 #define PICOUART_CFG_SOURCE_Pos     0            /**< \brief (PICOUART_CFG) Source Enable Mode */
-#define PICOUART_CFG_SOURCE_Msk     (_U(0x3) << PICOUART_CFG_SOURCE_Pos)
+#define PICOUART_CFG_SOURCE_Msk     (_U_(0x3) << PICOUART_CFG_SOURCE_Pos)
 #define PICOUART_CFG_SOURCE(value)  (PICOUART_CFG_SOURCE_Msk & ((value) << PICOUART_CFG_SOURCE_Pos))
 #define PICOUART_CFG_ACTION_Pos     2            /**< \brief (PICOUART_CFG) Action to perform */
-#define PICOUART_CFG_ACTION         (_U(0x1) << PICOUART_CFG_ACTION_Pos)
+#define PICOUART_CFG_ACTION         (_U_(0x1) << PICOUART_CFG_ACTION_Pos)
 #define PICOUART_CFG_MATCH_Pos      8            /**< \brief (PICOUART_CFG) Data Match */
-#define PICOUART_CFG_MATCH_Msk      (_U(0xFF) << PICOUART_CFG_MATCH_Pos)
+#define PICOUART_CFG_MATCH_Msk      (_U_(0xFF) << PICOUART_CFG_MATCH_Pos)
 #define PICOUART_CFG_MATCH(value)   (PICOUART_CFG_MATCH_Msk & ((value) << PICOUART_CFG_MATCH_Pos))
-#define PICOUART_CFG_MASK           _U(0x0000FF07) /**< \brief (PICOUART_CFG) MASK Register */
+#define PICOUART_CFG_MASK           _U_(0x0000FF07) /**< \brief (PICOUART_CFG) MASK Register */
 
 /* -------- PICOUART_SR : (PICOUART Offset: 0x08) (R/  32) Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -99,13 +99,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PICOUART_SR_OFFSET          0x08         /**< \brief (PICOUART_SR offset) Status Register */
-#define PICOUART_SR_RESETVALUE      _U(0x00000000); /**< \brief (PICOUART_SR reset_value) Status Register */
+#define PICOUART_SR_RESETVALUE      _U_(0x00000000); /**< \brief (PICOUART_SR reset_value) Status Register */
 
 #define PICOUART_SR_EN_Pos          0            /**< \brief (PICOUART_SR) Enable Interrupt Status */
-#define PICOUART_SR_EN              (_U(0x1) << PICOUART_SR_EN_Pos)
+#define PICOUART_SR_EN              (_U_(0x1) << PICOUART_SR_EN_Pos)
 #define PICOUART_SR_DRDY_Pos        1            /**< \brief (PICOUART_SR) Data Ready Interrupt Status */
-#define PICOUART_SR_DRDY            (_U(0x1) << PICOUART_SR_DRDY_Pos)
-#define PICOUART_SR_MASK            _U(0x00000003) /**< \brief (PICOUART_SR) MASK Register */
+#define PICOUART_SR_DRDY            (_U_(0x1) << PICOUART_SR_DRDY_Pos)
+#define PICOUART_SR_MASK            _U_(0x00000003) /**< \brief (PICOUART_SR) MASK Register */
 
 /* -------- PICOUART_RHR : (PICOUART Offset: 0x0C) (R/  32) Receive Holding Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -118,12 +118,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PICOUART_RHR_OFFSET         0x0C         /**< \brief (PICOUART_RHR offset) Receive Holding Register */
-#define PICOUART_RHR_RESETVALUE     _U(0x00000000); /**< \brief (PICOUART_RHR reset_value) Receive Holding Register */
+#define PICOUART_RHR_RESETVALUE     _U_(0x00000000); /**< \brief (PICOUART_RHR reset_value) Receive Holding Register */
 
 #define PICOUART_RHR_CDATA_Pos      0            /**< \brief (PICOUART_RHR) Received Data */
-#define PICOUART_RHR_CDATA_Msk      (_U(0xFFFFFFFF) << PICOUART_RHR_CDATA_Pos)
+#define PICOUART_RHR_CDATA_Msk      (_U_(0xFFFFFFFF) << PICOUART_RHR_CDATA_Pos)
 #define PICOUART_RHR_CDATA(value)   (PICOUART_RHR_CDATA_Msk & ((value) << PICOUART_RHR_CDATA_Pos))
-#define PICOUART_RHR_MASK           _U(0xFFFFFFFF) /**< \brief (PICOUART_RHR) MASK Register */
+#define PICOUART_RHR_MASK           _U_(0xFFFFFFFF) /**< \brief (PICOUART_RHR) MASK Register */
 
 /* -------- PICOUART_VERSION : (PICOUART Offset: 0x20) (R/  32) Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -139,15 +139,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PICOUART_VERSION_OFFSET     0x20         /**< \brief (PICOUART_VERSION offset) Version Register */
-#define PICOUART_VERSION_RESETVALUE _U(0x00000101); /**< \brief (PICOUART_VERSION reset_value) Version Register */
+#define PICOUART_VERSION_RESETVALUE _U_(0x00000101); /**< \brief (PICOUART_VERSION reset_value) Version Register */
 
 #define PICOUART_VERSION_VERSION_Pos 0            /**< \brief (PICOUART_VERSION) Version Number */
-#define PICOUART_VERSION_VERSION_Msk (_U(0xFFF) << PICOUART_VERSION_VERSION_Pos)
+#define PICOUART_VERSION_VERSION_Msk (_U_(0xFFF) << PICOUART_VERSION_VERSION_Pos)
 #define PICOUART_VERSION_VERSION(value) (PICOUART_VERSION_VERSION_Msk & ((value) << PICOUART_VERSION_VERSION_Pos))
 #define PICOUART_VERSION_VARIANT_Pos 16           /**< \brief (PICOUART_VERSION) Variant Number */
-#define PICOUART_VERSION_VARIANT_Msk (_U(0xF) << PICOUART_VERSION_VARIANT_Pos)
+#define PICOUART_VERSION_VARIANT_Msk (_U_(0xF) << PICOUART_VERSION_VARIANT_Pos)
 #define PICOUART_VERSION_VARIANT(value) (PICOUART_VERSION_VARIANT_Msk & ((value) << PICOUART_VERSION_VARIANT_Pos))
-#define PICOUART_VERSION_MASK       _U(0x000F0FFF) /**< \brief (PICOUART_VERSION) MASK Register */
+#define PICOUART_VERSION_MASK       _U_(0x000F0FFF) /**< \brief (PICOUART_VERSION) MASK Register */
 
 /** \brief PICOUART hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/picouart.h
+++ b/asf/sam/include/sam4l/component/picouart.h
@@ -1,0 +1,176 @@
+/**
+ * \file
+ *
+ * \brief Component description for PICOUART
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_PICOUART_COMPONENT_
+#define _SAM4L_PICOUART_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PICOUART */
+/* ========================================================================== */
+/** \addtogroup SAM4L_PICOUART Pico UART */
+/*@{*/
+
+#define PICOUART_I8403
+#define REV_PICOUART                0x101
+
+/* -------- PICOUART_CR : (PICOUART Offset: 0x00) ( /W 32) Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EN:1;             /*!< bit:      0  Enable                             */
+    uint32_t DIS:1;            /*!< bit:      1  Disable                            */
+    uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PICOUART_CR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PICOUART_CR_OFFSET          0x00         /**< \brief (PICOUART_CR offset) Control Register */
+#define PICOUART_CR_RESETVALUE      _U(0x00000000); /**< \brief (PICOUART_CR reset_value) Control Register */
+
+#define PICOUART_CR_EN_Pos          0            /**< \brief (PICOUART_CR) Enable */
+#define PICOUART_CR_EN              (_U(0x1) << PICOUART_CR_EN_Pos)
+#define PICOUART_CR_DIS_Pos         1            /**< \brief (PICOUART_CR) Disable */
+#define PICOUART_CR_DIS             (_U(0x1) << PICOUART_CR_DIS_Pos)
+#define PICOUART_CR_MASK            _U(0x00000003) /**< \brief (PICOUART_CR) MASK Register */
+
+/* -------- PICOUART_CFG : (PICOUART Offset: 0x04) (R/W 32) Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SOURCE:2;         /*!< bit:  0.. 1  Source Enable Mode                 */
+    uint32_t ACTION:1;         /*!< bit:      2  Action to perform                  */
+    uint32_t :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint32_t MATCH:8;          /*!< bit:  8..15  Data Match                         */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PICOUART_CFG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PICOUART_CFG_OFFSET         0x04         /**< \brief (PICOUART_CFG offset) Configuration Register */
+#define PICOUART_CFG_RESETVALUE     _U(0x00000000); /**< \brief (PICOUART_CFG reset_value) Configuration Register */
+
+#define PICOUART_CFG_SOURCE_Pos     0            /**< \brief (PICOUART_CFG) Source Enable Mode */
+#define PICOUART_CFG_SOURCE_Msk     (_U(0x3) << PICOUART_CFG_SOURCE_Pos)
+#define PICOUART_CFG_SOURCE(value)  (PICOUART_CFG_SOURCE_Msk & ((value) << PICOUART_CFG_SOURCE_Pos))
+#define PICOUART_CFG_ACTION_Pos     2            /**< \brief (PICOUART_CFG) Action to perform */
+#define PICOUART_CFG_ACTION         (_U(0x1) << PICOUART_CFG_ACTION_Pos)
+#define PICOUART_CFG_MATCH_Pos      8            /**< \brief (PICOUART_CFG) Data Match */
+#define PICOUART_CFG_MATCH_Msk      (_U(0xFF) << PICOUART_CFG_MATCH_Pos)
+#define PICOUART_CFG_MATCH(value)   (PICOUART_CFG_MATCH_Msk & ((value) << PICOUART_CFG_MATCH_Pos))
+#define PICOUART_CFG_MASK           _U(0x0000FF07) /**< \brief (PICOUART_CFG) MASK Register */
+
+/* -------- PICOUART_SR : (PICOUART Offset: 0x08) (R/  32) Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EN:1;             /*!< bit:      0  Enable Interrupt Status            */
+    uint32_t DRDY:1;           /*!< bit:      1  Data Ready Interrupt Status        */
+    uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PICOUART_SR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PICOUART_SR_OFFSET          0x08         /**< \brief (PICOUART_SR offset) Status Register */
+#define PICOUART_SR_RESETVALUE      _U(0x00000000); /**< \brief (PICOUART_SR reset_value) Status Register */
+
+#define PICOUART_SR_EN_Pos          0            /**< \brief (PICOUART_SR) Enable Interrupt Status */
+#define PICOUART_SR_EN              (_U(0x1) << PICOUART_SR_EN_Pos)
+#define PICOUART_SR_DRDY_Pos        1            /**< \brief (PICOUART_SR) Data Ready Interrupt Status */
+#define PICOUART_SR_DRDY            (_U(0x1) << PICOUART_SR_DRDY_Pos)
+#define PICOUART_SR_MASK            _U(0x00000003) /**< \brief (PICOUART_SR) MASK Register */
+
+/* -------- PICOUART_RHR : (PICOUART Offset: 0x0C) (R/  32) Receive Holding Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CDATA:32;         /*!< bit:  0..31  Received Data                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PICOUART_RHR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PICOUART_RHR_OFFSET         0x0C         /**< \brief (PICOUART_RHR offset) Receive Holding Register */
+#define PICOUART_RHR_RESETVALUE     _U(0x00000000); /**< \brief (PICOUART_RHR reset_value) Receive Holding Register */
+
+#define PICOUART_RHR_CDATA_Pos      0            /**< \brief (PICOUART_RHR) Received Data */
+#define PICOUART_RHR_CDATA_Msk      (_U(0xFFFFFFFF) << PICOUART_RHR_CDATA_Pos)
+#define PICOUART_RHR_CDATA(value)   (PICOUART_RHR_CDATA_Msk & ((value) << PICOUART_RHR_CDATA_Pos))
+#define PICOUART_RHR_MASK           _U(0xFFFFFFFF) /**< \brief (PICOUART_RHR) MASK Register */
+
+/* -------- PICOUART_VERSION : (PICOUART Offset: 0x20) (R/  32) Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version Number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant Number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PICOUART_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PICOUART_VERSION_OFFSET     0x20         /**< \brief (PICOUART_VERSION offset) Version Register */
+#define PICOUART_VERSION_RESETVALUE _U(0x00000101); /**< \brief (PICOUART_VERSION reset_value) Version Register */
+
+#define PICOUART_VERSION_VERSION_Pos 0            /**< \brief (PICOUART_VERSION) Version Number */
+#define PICOUART_VERSION_VERSION_Msk (_U(0xFFF) << PICOUART_VERSION_VERSION_Pos)
+#define PICOUART_VERSION_VERSION(value) (PICOUART_VERSION_VERSION_Msk & ((value) << PICOUART_VERSION_VERSION_Pos))
+#define PICOUART_VERSION_VARIANT_Pos 16           /**< \brief (PICOUART_VERSION) Variant Number */
+#define PICOUART_VERSION_VARIANT_Msk (_U(0xF) << PICOUART_VERSION_VARIANT_Pos)
+#define PICOUART_VERSION_VARIANT(value) (PICOUART_VERSION_VARIANT_Msk & ((value) << PICOUART_VERSION_VARIANT_Pos))
+#define PICOUART_VERSION_MASK       _U(0x000F0FFF) /**< \brief (PICOUART_VERSION) MASK Register */
+
+/** \brief PICOUART hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __O  PICOUART_CR_Type          CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
+  __IO PICOUART_CFG_Type         CFG;         /**< \brief Offset: 0x04 (R/W 32) Configuration Register */
+  __I  PICOUART_SR_Type          SR;          /**< \brief Offset: 0x08 (R/  32) Status Register */
+  __I  PICOUART_RHR_Type         RHR;         /**< \brief Offset: 0x0C (R/  32) Receive Holding Register */
+       RoReg8                    Reserved1[0x10];
+  __I  PICOUART_VERSION_Type     VERSION;     /**< \brief Offset: 0x20 (R/  32) Version Register */
+ } bf;
+ struct {
+  WoReg   PICOUART_CR;        /**< \brief (PICOUART Offset: 0x00) Control Register */
+  RwReg   PICOUART_CFG;       /**< \brief (PICOUART Offset: 0x04) Configuration Register */
+  RoReg   PICOUART_SR;        /**< \brief (PICOUART Offset: 0x08) Status Register */
+  RoReg   PICOUART_RHR;       /**< \brief (PICOUART Offset: 0x0C) Receive Holding Register */
+  RoReg8  Reserved2[0x10];
+  RoReg   PICOUART_VERSION;   /**< \brief (PICOUART Offset: 0x20) Version Register */
+ } reg;
+} Picouart;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_PICOUART_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/pm.h
+++ b/asf/sam/include/sam4l/component/pm.h
@@ -50,12 +50,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_MCCTRL_OFFSET            0x000        /**< \brief (PM_MCCTRL offset) Main Clock Control */
-#define PM_MCCTRL_RESETVALUE        _U(0x00000000); /**< \brief (PM_MCCTRL reset_value) Main Clock Control */
+#define PM_MCCTRL_RESETVALUE        _U_(0x00000000); /**< \brief (PM_MCCTRL reset_value) Main Clock Control */
 
 #define PM_MCCTRL_MCSEL_Pos         0            /**< \brief (PM_MCCTRL) Main Clock Select */
-#define PM_MCCTRL_MCSEL_Msk         (_U(0x7) << PM_MCCTRL_MCSEL_Pos)
+#define PM_MCCTRL_MCSEL_Msk         (_U_(0x7) << PM_MCCTRL_MCSEL_Pos)
 #define PM_MCCTRL_MCSEL(value)      (PM_MCCTRL_MCSEL_Msk & ((value) << PM_MCCTRL_MCSEL_Pos))
-#define PM_MCCTRL_MASK              _U(0x00000007) /**< \brief (PM_MCCTRL) MASK Register */
+#define PM_MCCTRL_MASK              _U_(0x00000007) /**< \brief (PM_MCCTRL) MASK Register */
 
 /* -------- PM_CPUSEL : (PM Offset: 0x004) (R/W 32) CPU Clock Select -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -71,18 +71,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_CPUSEL_OFFSET            0x004        /**< \brief (PM_CPUSEL offset) CPU Clock Select */
-#define PM_CPUSEL_RESETVALUE        _U(0x00000000); /**< \brief (PM_CPUSEL reset_value) CPU Clock Select */
+#define PM_CPUSEL_RESETVALUE        _U_(0x00000000); /**< \brief (PM_CPUSEL reset_value) CPU Clock Select */
 
 #define PM_CPUSEL_CPUSEL_Pos        0            /**< \brief (PM_CPUSEL) CPU Clock Select */
-#define PM_CPUSEL_CPUSEL_Msk        (_U(0x7) << PM_CPUSEL_CPUSEL_Pos)
+#define PM_CPUSEL_CPUSEL_Msk        (_U_(0x7) << PM_CPUSEL_CPUSEL_Pos)
 #define PM_CPUSEL_CPUSEL(value)     (PM_CPUSEL_CPUSEL_Msk & ((value) << PM_CPUSEL_CPUSEL_Pos))
-#define   PM_CPUSEL_CPUSEL_0_Val          _U(0x0)   /**< \brief (PM_CPUSEL) fCPU:fmain. CPUDIV: */
-#define   PM_CPUSEL_CPUSEL_1_Val          _U(0x1)   /**< \brief (PM_CPUSEL) fCPU:fmain / 2^(CPUSEL+1) */
+#define   PM_CPUSEL_CPUSEL_0_Val          _U_(0x0)   /**< \brief (PM_CPUSEL) fCPU:fmain. CPUDIV: */
+#define   PM_CPUSEL_CPUSEL_1_Val          _U_(0x1)   /**< \brief (PM_CPUSEL) fCPU:fmain / 2^(CPUSEL+1) */
 #define PM_CPUSEL_CPUSEL_0          (PM_CPUSEL_CPUSEL_0_Val        << PM_CPUSEL_CPUSEL_Pos)
 #define PM_CPUSEL_CPUSEL_1          (PM_CPUSEL_CPUSEL_1_Val        << PM_CPUSEL_CPUSEL_Pos)
 #define PM_CPUSEL_CPUDIV_Pos        7            /**< \brief (PM_CPUSEL) CPU Division */
-#define PM_CPUSEL_CPUDIV            (_U(0x1) << PM_CPUSEL_CPUDIV_Pos)
-#define PM_CPUSEL_MASK              _U(0x00000087) /**< \brief (PM_CPUSEL) MASK Register */
+#define PM_CPUSEL_CPUDIV            (_U_(0x1) << PM_CPUSEL_CPUDIV_Pos)
+#define PM_CPUSEL_MASK              _U_(0x00000087) /**< \brief (PM_CPUSEL) MASK Register */
 
 /* -------- PM_PBASEL : (PM Offset: 0x00C) (R/W 32) PBA Clock Select -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -98,14 +98,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_PBASEL_OFFSET            0x00C        /**< \brief (PM_PBASEL offset) PBA Clock Select */
-#define PM_PBASEL_RESETVALUE        _U(0x00000000); /**< \brief (PM_PBASEL reset_value) PBA Clock Select */
+#define PM_PBASEL_RESETVALUE        _U_(0x00000000); /**< \brief (PM_PBASEL reset_value) PBA Clock Select */
 
 #define PM_PBASEL_PBSEL_Pos         0            /**< \brief (PM_PBASEL) PBA Clock Select */
-#define PM_PBASEL_PBSEL_Msk         (_U(0x7) << PM_PBASEL_PBSEL_Pos)
+#define PM_PBASEL_PBSEL_Msk         (_U_(0x7) << PM_PBASEL_PBSEL_Pos)
 #define PM_PBASEL_PBSEL(value)      (PM_PBASEL_PBSEL_Msk & ((value) << PM_PBASEL_PBSEL_Pos))
 #define PM_PBASEL_PBDIV_Pos         7            /**< \brief (PM_PBASEL) PBA Division Select */
-#define PM_PBASEL_PBDIV             (_U(0x1) << PM_PBASEL_PBDIV_Pos)
-#define PM_PBASEL_MASK              _U(0x00000087) /**< \brief (PM_PBASEL) MASK Register */
+#define PM_PBASEL_PBDIV             (_U_(0x1) << PM_PBASEL_PBDIV_Pos)
+#define PM_PBASEL_MASK              _U_(0x00000087) /**< \brief (PM_PBASEL) MASK Register */
 
 /* -------- PM_PBBSEL : (PM Offset: 0x010) (R/W 32) PBB Clock Select -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -121,14 +121,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_PBBSEL_OFFSET            0x010        /**< \brief (PM_PBBSEL offset) PBB Clock Select */
-#define PM_PBBSEL_RESETVALUE        _U(0x00000000); /**< \brief (PM_PBBSEL reset_value) PBB Clock Select */
+#define PM_PBBSEL_RESETVALUE        _U_(0x00000000); /**< \brief (PM_PBBSEL reset_value) PBB Clock Select */
 
 #define PM_PBBSEL_PBSEL_Pos         0            /**< \brief (PM_PBBSEL) PBB Clock Select */
-#define PM_PBBSEL_PBSEL_Msk         (_U(0x7) << PM_PBBSEL_PBSEL_Pos)
+#define PM_PBBSEL_PBSEL_Msk         (_U_(0x7) << PM_PBBSEL_PBSEL_Pos)
 #define PM_PBBSEL_PBSEL(value)      (PM_PBBSEL_PBSEL_Msk & ((value) << PM_PBBSEL_PBSEL_Pos))
 #define PM_PBBSEL_PBDIV_Pos         7            /**< \brief (PM_PBBSEL) PBB Division Select */
-#define PM_PBBSEL_PBDIV             (_U(0x1) << PM_PBBSEL_PBDIV_Pos)
-#define PM_PBBSEL_MASK              _U(0x00000087) /**< \brief (PM_PBBSEL) MASK Register */
+#define PM_PBBSEL_PBDIV             (_U_(0x1) << PM_PBBSEL_PBDIV_Pos)
+#define PM_PBBSEL_MASK              _U_(0x00000087) /**< \brief (PM_PBBSEL) MASK Register */
 
 /* -------- PM_PBCSEL : (PM Offset: 0x014) (R/W 32) PBC Clock Select -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -144,14 +144,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_PBCSEL_OFFSET            0x014        /**< \brief (PM_PBCSEL offset) PBC Clock Select */
-#define PM_PBCSEL_RESETVALUE        _U(0x00000000); /**< \brief (PM_PBCSEL reset_value) PBC Clock Select */
+#define PM_PBCSEL_RESETVALUE        _U_(0x00000000); /**< \brief (PM_PBCSEL reset_value) PBC Clock Select */
 
 #define PM_PBCSEL_PBSEL_Pos         0            /**< \brief (PM_PBCSEL) PBC Clock Select */
-#define PM_PBCSEL_PBSEL_Msk         (_U(0x7) << PM_PBCSEL_PBSEL_Pos)
+#define PM_PBCSEL_PBSEL_Msk         (_U_(0x7) << PM_PBCSEL_PBSEL_Pos)
 #define PM_PBCSEL_PBSEL(value)      (PM_PBCSEL_PBSEL_Msk & ((value) << PM_PBCSEL_PBSEL_Pos))
 #define PM_PBCSEL_PBDIV_Pos         7            /**< \brief (PM_PBCSEL) PBC Division Select */
-#define PM_PBCSEL_PBDIV             (_U(0x1) << PM_PBCSEL_PBDIV_Pos)
-#define PM_PBCSEL_MASK              _U(0x00000087) /**< \brief (PM_PBCSEL) MASK Register */
+#define PM_PBCSEL_PBDIV             (_U_(0x1) << PM_PBCSEL_PBDIV_Pos)
+#define PM_PBCSEL_MASK              _U_(0x00000087) /**< \brief (PM_PBCSEL) MASK Register */
 
 /* -------- PM_PBDSEL : (PM Offset: 0x018) (R/W 32) PBD Clock Select -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -167,14 +167,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_PBDSEL_OFFSET            0x018        /**< \brief (PM_PBDSEL offset) PBD Clock Select */
-#define PM_PBDSEL_RESETVALUE        _U(0x00000000); /**< \brief (PM_PBDSEL reset_value) PBD Clock Select */
+#define PM_PBDSEL_RESETVALUE        _U_(0x00000000); /**< \brief (PM_PBDSEL reset_value) PBD Clock Select */
 
 #define PM_PBDSEL_PBSEL_Pos         0            /**< \brief (PM_PBDSEL) PBD Clock Select */
-#define PM_PBDSEL_PBSEL_Msk         (_U(0x7) << PM_PBDSEL_PBSEL_Pos)
+#define PM_PBDSEL_PBSEL_Msk         (_U_(0x7) << PM_PBDSEL_PBSEL_Pos)
 #define PM_PBDSEL_PBSEL(value)      (PM_PBDSEL_PBSEL_Msk & ((value) << PM_PBDSEL_PBSEL_Pos))
 #define PM_PBDSEL_PBDIV_Pos         7            /**< \brief (PM_PBDSEL) PBD Division Select */
-#define PM_PBDSEL_PBDIV             (_U(0x1) << PM_PBDSEL_PBDIV_Pos)
-#define PM_PBDSEL_MASK              _U(0x00000087) /**< \brief (PM_PBDSEL) MASK Register */
+#define PM_PBDSEL_PBDIV             (_U_(0x1) << PM_PBDSEL_PBDIV_Pos)
+#define PM_PBDSEL_MASK              _U_(0x00000087) /**< \brief (PM_PBDSEL) MASK Register */
 
 /* -------- PM_CPUMASK : (PM Offset: 0x020) (R/W 32) CPU Mask -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -188,11 +188,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_CPUMASK_OFFSET           0x020        /**< \brief (PM_CPUMASK offset) CPU Mask */
-#define PM_CPUMASK_RESETVALUE       _U(0x00000001); /**< \brief (PM_CPUMASK reset_value) CPU Mask */
+#define PM_CPUMASK_RESETVALUE       _U_(0x00000001); /**< \brief (PM_CPUMASK reset_value) CPU Mask */
 
 #define PM_CPUMASK_OCD_Pos          0            /**< \brief (PM_CPUMASK) OCD CPU Clock Mask */
-#define PM_CPUMASK_OCD              (_U(0x1) << PM_CPUMASK_OCD_Pos)
-#define PM_CPUMASK_MASK             _U(0x00000001) /**< \brief (PM_CPUMASK) MASK Register */
+#define PM_CPUMASK_OCD              (_U_(0x1) << PM_CPUMASK_OCD_Pos)
+#define PM_CPUMASK_MASK             _U_(0x00000001) /**< \brief (PM_CPUMASK) MASK Register */
 
 /* -------- PM_HSBMASK : (PM Offset: 0x024) (R/W 32) HSB Mask -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -215,29 +215,29 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_HSBMASK_OFFSET           0x024        /**< \brief (PM_HSBMASK offset) HSB Mask */
-#define PM_HSBMASK_RESETVALUE       _U(0x000001E2); /**< \brief (PM_HSBMASK reset_value) HSB Mask */
+#define PM_HSBMASK_RESETVALUE       _U_(0x000001E2); /**< \brief (PM_HSBMASK reset_value) HSB Mask */
 
 #define PM_HSBMASK_PDCA_Pos         0            /**< \brief (PM_HSBMASK) PDCA HSB Clock Mask */
-#define PM_HSBMASK_PDCA             (_U(0x1) << PM_HSBMASK_PDCA_Pos)
+#define PM_HSBMASK_PDCA             (_U_(0x1) << PM_HSBMASK_PDCA_Pos)
 #define PM_HSBMASK_HFLASHC_Pos      1            /**< \brief (PM_HSBMASK) HFLASHC HSB Clock Mask */
-#define PM_HSBMASK_HFLASHC          (_U(0x1) << PM_HSBMASK_HFLASHC_Pos)
+#define PM_HSBMASK_HFLASHC          (_U_(0x1) << PM_HSBMASK_HFLASHC_Pos)
 #define PM_HSBMASK_HRAMC1_Pos       2            /**< \brief (PM_HSBMASK) HRAMC1 HSB Clock Mask */
-#define PM_HSBMASK_HRAMC1           (_U(0x1) << PM_HSBMASK_HRAMC1_Pos)
+#define PM_HSBMASK_HRAMC1           (_U_(0x1) << PM_HSBMASK_HRAMC1_Pos)
 #define PM_HSBMASK_USBC_Pos         3            /**< \brief (PM_HSBMASK) USBC HSB Clock Mask */
-#define PM_HSBMASK_USBC             (_U(0x1) << PM_HSBMASK_USBC_Pos)
+#define PM_HSBMASK_USBC             (_U_(0x1) << PM_HSBMASK_USBC_Pos)
 #define PM_HSBMASK_CRCCU_Pos        4            /**< \brief (PM_HSBMASK) CRCCU HSB Clock Mask */
-#define PM_HSBMASK_CRCCU            (_U(0x1) << PM_HSBMASK_CRCCU_Pos)
+#define PM_HSBMASK_CRCCU            (_U_(0x1) << PM_HSBMASK_CRCCU_Pos)
 #define PM_HSBMASK_HTOP0_Pos        5            /**< \brief (PM_HSBMASK) HTOP0 HSB Clock Mask */
-#define PM_HSBMASK_HTOP0            (_U(0x1) << PM_HSBMASK_HTOP0_Pos)
+#define PM_HSBMASK_HTOP0            (_U_(0x1) << PM_HSBMASK_HTOP0_Pos)
 #define PM_HSBMASK_HTOP1_Pos        6            /**< \brief (PM_HSBMASK) HTOP1 HSB Clock Mask */
-#define PM_HSBMASK_HTOP1            (_U(0x1) << PM_HSBMASK_HTOP1_Pos)
+#define PM_HSBMASK_HTOP1            (_U_(0x1) << PM_HSBMASK_HTOP1_Pos)
 #define PM_HSBMASK_HTOP2_Pos        7            /**< \brief (PM_HSBMASK) HTOP2 HSB Clock Mask */
-#define PM_HSBMASK_HTOP2            (_U(0x1) << PM_HSBMASK_HTOP2_Pos)
+#define PM_HSBMASK_HTOP2            (_U_(0x1) << PM_HSBMASK_HTOP2_Pos)
 #define PM_HSBMASK_HTOP3_Pos        8            /**< \brief (PM_HSBMASK) HTOP3 HSB Clock Mask */
-#define PM_HSBMASK_HTOP3            (_U(0x1) << PM_HSBMASK_HTOP3_Pos)
+#define PM_HSBMASK_HTOP3            (_U_(0x1) << PM_HSBMASK_HTOP3_Pos)
 #define PM_HSBMASK_AESA_Pos         9            /**< \brief (PM_HSBMASK) AESA HSB Clock Mask */
-#define PM_HSBMASK_AESA             (_U(0x1) << PM_HSBMASK_AESA_Pos)
-#define PM_HSBMASK_MASK             _U(0x000003FF) /**< \brief (PM_HSBMASK) MASK Register */
+#define PM_HSBMASK_AESA             (_U_(0x1) << PM_HSBMASK_AESA_Pos)
+#define PM_HSBMASK_MASK             _U_(0x000003FF) /**< \brief (PM_HSBMASK) MASK Register */
 
 /* -------- PM_PBAMASK : (PM Offset: 0x028) (R/W 32) PBA Mask -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -274,55 +274,55 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_PBAMASK_OFFSET           0x028        /**< \brief (PM_PBAMASK offset) PBA Mask */
-#define PM_PBAMASK_RESETVALUE       _U(0x00000000); /**< \brief (PM_PBAMASK reset_value) PBA Mask */
+#define PM_PBAMASK_RESETVALUE       _U_(0x00000000); /**< \brief (PM_PBAMASK reset_value) PBA Mask */
 
 #define PM_PBAMASK_IISC_Pos         0            /**< \brief (PM_PBAMASK) IISC APB Clock Enable */
-#define PM_PBAMASK_IISC             (_U(0x1) << PM_PBAMASK_IISC_Pos)
+#define PM_PBAMASK_IISC             (_U_(0x1) << PM_PBAMASK_IISC_Pos)
 #define PM_PBAMASK_SPI_Pos          1            /**< \brief (PM_PBAMASK) SPI APB Clock Enable */
-#define PM_PBAMASK_SPI              (_U(0x1) << PM_PBAMASK_SPI_Pos)
+#define PM_PBAMASK_SPI              (_U_(0x1) << PM_PBAMASK_SPI_Pos)
 #define PM_PBAMASK_TC0_Pos          2            /**< \brief (PM_PBAMASK) TC0 APB Clock Enable */
-#define PM_PBAMASK_TC0              (_U(0x1) << PM_PBAMASK_TC0_Pos)
+#define PM_PBAMASK_TC0              (_U_(0x1) << PM_PBAMASK_TC0_Pos)
 #define PM_PBAMASK_TC1_Pos          3            /**< \brief (PM_PBAMASK) TC1 APB Clock Enable */
-#define PM_PBAMASK_TC1              (_U(0x1) << PM_PBAMASK_TC1_Pos)
+#define PM_PBAMASK_TC1              (_U_(0x1) << PM_PBAMASK_TC1_Pos)
 #define PM_PBAMASK_TWIM0_Pos        4            /**< \brief (PM_PBAMASK) TWIM0 APB Clock Enable */
-#define PM_PBAMASK_TWIM0            (_U(0x1) << PM_PBAMASK_TWIM0_Pos)
+#define PM_PBAMASK_TWIM0            (_U_(0x1) << PM_PBAMASK_TWIM0_Pos)
 #define PM_PBAMASK_TWIS0_Pos        5            /**< \brief (PM_PBAMASK) TWIS0 APB Clock Enable */
-#define PM_PBAMASK_TWIS0            (_U(0x1) << PM_PBAMASK_TWIS0_Pos)
+#define PM_PBAMASK_TWIS0            (_U_(0x1) << PM_PBAMASK_TWIS0_Pos)
 #define PM_PBAMASK_TWIM1_Pos        6            /**< \brief (PM_PBAMASK) TWIM1 APB Clock Enable */
-#define PM_PBAMASK_TWIM1            (_U(0x1) << PM_PBAMASK_TWIM1_Pos)
+#define PM_PBAMASK_TWIM1            (_U_(0x1) << PM_PBAMASK_TWIM1_Pos)
 #define PM_PBAMASK_TWIS1_Pos        7            /**< \brief (PM_PBAMASK) TWIS1 APB Clock Enable */
-#define PM_PBAMASK_TWIS1            (_U(0x1) << PM_PBAMASK_TWIS1_Pos)
+#define PM_PBAMASK_TWIS1            (_U_(0x1) << PM_PBAMASK_TWIS1_Pos)
 #define PM_PBAMASK_USART0_Pos       8            /**< \brief (PM_PBAMASK) USART0 APB Clock Enable */
-#define PM_PBAMASK_USART0           (_U(0x1) << PM_PBAMASK_USART0_Pos)
+#define PM_PBAMASK_USART0           (_U_(0x1) << PM_PBAMASK_USART0_Pos)
 #define PM_PBAMASK_USART1_Pos       9            /**< \brief (PM_PBAMASK) USART1 APB Clock Enable */
-#define PM_PBAMASK_USART1           (_U(0x1) << PM_PBAMASK_USART1_Pos)
+#define PM_PBAMASK_USART1           (_U_(0x1) << PM_PBAMASK_USART1_Pos)
 #define PM_PBAMASK_USART2_Pos       10           /**< \brief (PM_PBAMASK) USART2 APB Clock Enable */
-#define PM_PBAMASK_USART2           (_U(0x1) << PM_PBAMASK_USART2_Pos)
+#define PM_PBAMASK_USART2           (_U_(0x1) << PM_PBAMASK_USART2_Pos)
 #define PM_PBAMASK_USART3_Pos       11           /**< \brief (PM_PBAMASK) USART3 APB Clock Enable */
-#define PM_PBAMASK_USART3           (_U(0x1) << PM_PBAMASK_USART3_Pos)
+#define PM_PBAMASK_USART3           (_U_(0x1) << PM_PBAMASK_USART3_Pos)
 #define PM_PBAMASK_ADCIFE_Pos       12           /**< \brief (PM_PBAMASK) ADCIFE APB Clock Enable */
-#define PM_PBAMASK_ADCIFE           (_U(0x1) << PM_PBAMASK_ADCIFE_Pos)
+#define PM_PBAMASK_ADCIFE           (_U_(0x1) << PM_PBAMASK_ADCIFE_Pos)
 #define PM_PBAMASK_DACC_Pos         13           /**< \brief (PM_PBAMASK) DACC APB Clock Enable */
-#define PM_PBAMASK_DACC             (_U(0x1) << PM_PBAMASK_DACC_Pos)
+#define PM_PBAMASK_DACC             (_U_(0x1) << PM_PBAMASK_DACC_Pos)
 #define PM_PBAMASK_ACIFC_Pos        14           /**< \brief (PM_PBAMASK) ACIFC APB Clock Enable */
-#define PM_PBAMASK_ACIFC            (_U(0x1) << PM_PBAMASK_ACIFC_Pos)
+#define PM_PBAMASK_ACIFC            (_U_(0x1) << PM_PBAMASK_ACIFC_Pos)
 #define PM_PBAMASK_GLOC_Pos         15           /**< \brief (PM_PBAMASK) GLOC APB Clock Enable */
-#define PM_PBAMASK_GLOC             (_U(0x1) << PM_PBAMASK_GLOC_Pos)
+#define PM_PBAMASK_GLOC             (_U_(0x1) << PM_PBAMASK_GLOC_Pos)
 #define PM_PBAMASK_ABDACB_Pos       16           /**< \brief (PM_PBAMASK) ABDACB APB Clock Enable */
-#define PM_PBAMASK_ABDACB           (_U(0x1) << PM_PBAMASK_ABDACB_Pos)
+#define PM_PBAMASK_ABDACB           (_U_(0x1) << PM_PBAMASK_ABDACB_Pos)
 #define PM_PBAMASK_TRNG_Pos         17           /**< \brief (PM_PBAMASK) TRNG APB Clock Enable */
-#define PM_PBAMASK_TRNG             (_U(0x1) << PM_PBAMASK_TRNG_Pos)
+#define PM_PBAMASK_TRNG             (_U_(0x1) << PM_PBAMASK_TRNG_Pos)
 #define PM_PBAMASK_PARC_Pos         18           /**< \brief (PM_PBAMASK) PARC APB Clock Enable */
-#define PM_PBAMASK_PARC             (_U(0x1) << PM_PBAMASK_PARC_Pos)
+#define PM_PBAMASK_PARC             (_U_(0x1) << PM_PBAMASK_PARC_Pos)
 #define PM_PBAMASK_CATB_Pos         19           /**< \brief (PM_PBAMASK) CATB APB Clock Enable */
-#define PM_PBAMASK_CATB             (_U(0x1) << PM_PBAMASK_CATB_Pos)
+#define PM_PBAMASK_CATB             (_U_(0x1) << PM_PBAMASK_CATB_Pos)
 #define PM_PBAMASK_TWIM2_Pos        21           /**< \brief (PM_PBAMASK) TWIM2 APB Clock Enable */
-#define PM_PBAMASK_TWIM2            (_U(0x1) << PM_PBAMASK_TWIM2_Pos)
+#define PM_PBAMASK_TWIM2            (_U_(0x1) << PM_PBAMASK_TWIM2_Pos)
 #define PM_PBAMASK_TWIM3_Pos        22           /**< \brief (PM_PBAMASK) TWIM3 APB Clock Enable */
-#define PM_PBAMASK_TWIM3            (_U(0x1) << PM_PBAMASK_TWIM3_Pos)
+#define PM_PBAMASK_TWIM3            (_U_(0x1) << PM_PBAMASK_TWIM3_Pos)
 #define PM_PBAMASK_LCDCA_Pos        23           /**< \brief (PM_PBAMASK) LCDCA APB Clock Enable */
-#define PM_PBAMASK_LCDCA            (_U(0x1) << PM_PBAMASK_LCDCA_Pos)
-#define PM_PBAMASK_MASK             _U(0x00EFFFFF) /**< \brief (PM_PBAMASK) MASK Register */
+#define PM_PBAMASK_LCDCA            (_U_(0x1) << PM_PBAMASK_LCDCA_Pos)
+#define PM_PBAMASK_MASK             _U_(0x00EFFFFF) /**< \brief (PM_PBAMASK) MASK Register */
 
 /* -------- PM_PBBMASK : (PM Offset: 0x02C) (R/W 32) PBB Mask -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -342,23 +342,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_PBBMASK_OFFSET           0x02C        /**< \brief (PM_PBBMASK offset) PBB Mask */
-#define PM_PBBMASK_RESETVALUE       _U(0x00000001); /**< \brief (PM_PBBMASK reset_value) PBB Mask */
+#define PM_PBBMASK_RESETVALUE       _U_(0x00000001); /**< \brief (PM_PBBMASK reset_value) PBB Mask */
 
 #define PM_PBBMASK_HFLASHC_Pos      0            /**< \brief (PM_PBBMASK) HFLASHC APB Clock Enable */
-#define PM_PBBMASK_HFLASHC          (_U(0x1) << PM_PBBMASK_HFLASHC_Pos)
+#define PM_PBBMASK_HFLASHC          (_U_(0x1) << PM_PBBMASK_HFLASHC_Pos)
 #define PM_PBBMASK_HCACHE_Pos       1            /**< \brief (PM_PBBMASK) HCACHE APB Clock Enable */
-#define PM_PBBMASK_HCACHE           (_U(0x1) << PM_PBBMASK_HCACHE_Pos)
+#define PM_PBBMASK_HCACHE           (_U_(0x1) << PM_PBBMASK_HCACHE_Pos)
 #define PM_PBBMASK_HMATRIX_Pos      2            /**< \brief (PM_PBBMASK) HMATRIX APB Clock Enable */
-#define PM_PBBMASK_HMATRIX          (_U(0x1) << PM_PBBMASK_HMATRIX_Pos)
+#define PM_PBBMASK_HMATRIX          (_U_(0x1) << PM_PBBMASK_HMATRIX_Pos)
 #define PM_PBBMASK_PDCA_Pos         3            /**< \brief (PM_PBBMASK) PDCA APB Clock Enable */
-#define PM_PBBMASK_PDCA             (_U(0x1) << PM_PBBMASK_PDCA_Pos)
+#define PM_PBBMASK_PDCA             (_U_(0x1) << PM_PBBMASK_PDCA_Pos)
 #define PM_PBBMASK_CRCCU_Pos        4            /**< \brief (PM_PBBMASK) CRCCU APB Clock Enable */
-#define PM_PBBMASK_CRCCU            (_U(0x1) << PM_PBBMASK_CRCCU_Pos)
+#define PM_PBBMASK_CRCCU            (_U_(0x1) << PM_PBBMASK_CRCCU_Pos)
 #define PM_PBBMASK_USBC_Pos         5            /**< \brief (PM_PBBMASK) USBC APB Clock Enable */
-#define PM_PBBMASK_USBC             (_U(0x1) << PM_PBBMASK_USBC_Pos)
+#define PM_PBBMASK_USBC             (_U_(0x1) << PM_PBBMASK_USBC_Pos)
 #define PM_PBBMASK_PEVC_Pos         6            /**< \brief (PM_PBBMASK) PEVC APB Clock Enable */
-#define PM_PBBMASK_PEVC             (_U(0x1) << PM_PBBMASK_PEVC_Pos)
-#define PM_PBBMASK_MASK             _U(0x0000007F) /**< \brief (PM_PBBMASK) MASK Register */
+#define PM_PBBMASK_PEVC             (_U_(0x1) << PM_PBBMASK_PEVC_Pos)
+#define PM_PBBMASK_MASK             _U_(0x0000007F) /**< \brief (PM_PBBMASK) MASK Register */
 
 /* -------- PM_PBCMASK : (PM Offset: 0x030) (R/W 32) PBC Mask -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -376,19 +376,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_PBCMASK_OFFSET           0x030        /**< \brief (PM_PBCMASK offset) PBC Mask */
-#define PM_PBCMASK_RESETVALUE       _U(0x0000001F); /**< \brief (PM_PBCMASK reset_value) PBC Mask */
+#define PM_PBCMASK_RESETVALUE       _U_(0x0000001F); /**< \brief (PM_PBCMASK reset_value) PBC Mask */
 
 #define PM_PBCMASK_PM_Pos           0            /**< \brief (PM_PBCMASK) PM APB Clock Enable */
-#define PM_PBCMASK_PM               (_U(0x1) << PM_PBCMASK_PM_Pos)
+#define PM_PBCMASK_PM               (_U_(0x1) << PM_PBCMASK_PM_Pos)
 #define PM_PBCMASK_CHIPID_Pos       1            /**< \brief (PM_PBCMASK) CHIPID APB Clock Enable */
-#define PM_PBCMASK_CHIPID           (_U(0x1) << PM_PBCMASK_CHIPID_Pos)
+#define PM_PBCMASK_CHIPID           (_U_(0x1) << PM_PBCMASK_CHIPID_Pos)
 #define PM_PBCMASK_SCIF_Pos         2            /**< \brief (PM_PBCMASK) SCIF APB Clock Enable */
-#define PM_PBCMASK_SCIF             (_U(0x1) << PM_PBCMASK_SCIF_Pos)
+#define PM_PBCMASK_SCIF             (_U_(0x1) << PM_PBCMASK_SCIF_Pos)
 #define PM_PBCMASK_FREQM_Pos        3            /**< \brief (PM_PBCMASK) FREQM APB Clock Enable */
-#define PM_PBCMASK_FREQM            (_U(0x1) << PM_PBCMASK_FREQM_Pos)
+#define PM_PBCMASK_FREQM            (_U_(0x1) << PM_PBCMASK_FREQM_Pos)
 #define PM_PBCMASK_GPIO_Pos         4            /**< \brief (PM_PBCMASK) GPIO APB Clock Enable */
-#define PM_PBCMASK_GPIO             (_U(0x1) << PM_PBCMASK_GPIO_Pos)
-#define PM_PBCMASK_MASK             _U(0x0000001F) /**< \brief (PM_PBCMASK) MASK Register */
+#define PM_PBCMASK_GPIO             (_U_(0x1) << PM_PBCMASK_GPIO_Pos)
+#define PM_PBCMASK_MASK             _U_(0x0000001F) /**< \brief (PM_PBCMASK) MASK Register */
 
 /* -------- PM_PBDMASK : (PM Offset: 0x034) (R/W 32) PBD Mask -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -407,21 +407,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_PBDMASK_OFFSET           0x034        /**< \brief (PM_PBDMASK offset) PBD Mask */
-#define PM_PBDMASK_RESETVALUE       _U(0x0000003F); /**< \brief (PM_PBDMASK reset_value) PBD Mask */
+#define PM_PBDMASK_RESETVALUE       _U_(0x0000003F); /**< \brief (PM_PBDMASK reset_value) PBD Mask */
 
 #define PM_PBDMASK_BPM_Pos          0            /**< \brief (PM_PBDMASK) BPM APB Clock Enable */
-#define PM_PBDMASK_BPM              (_U(0x1) << PM_PBDMASK_BPM_Pos)
+#define PM_PBDMASK_BPM              (_U_(0x1) << PM_PBDMASK_BPM_Pos)
 #define PM_PBDMASK_BSCIF_Pos        1            /**< \brief (PM_PBDMASK) BSCIF APB Clock Enable */
-#define PM_PBDMASK_BSCIF            (_U(0x1) << PM_PBDMASK_BSCIF_Pos)
+#define PM_PBDMASK_BSCIF            (_U_(0x1) << PM_PBDMASK_BSCIF_Pos)
 #define PM_PBDMASK_AST_Pos          2            /**< \brief (PM_PBDMASK) AST APB Clock Enable */
-#define PM_PBDMASK_AST              (_U(0x1) << PM_PBDMASK_AST_Pos)
+#define PM_PBDMASK_AST              (_U_(0x1) << PM_PBDMASK_AST_Pos)
 #define PM_PBDMASK_WDT_Pos          3            /**< \brief (PM_PBDMASK) WDT APB Clock Enable */
-#define PM_PBDMASK_WDT              (_U(0x1) << PM_PBDMASK_WDT_Pos)
+#define PM_PBDMASK_WDT              (_U_(0x1) << PM_PBDMASK_WDT_Pos)
 #define PM_PBDMASK_EIC_Pos          4            /**< \brief (PM_PBDMASK) EIC APB Clock Enable */
-#define PM_PBDMASK_EIC              (_U(0x1) << PM_PBDMASK_EIC_Pos)
+#define PM_PBDMASK_EIC              (_U_(0x1) << PM_PBDMASK_EIC_Pos)
 #define PM_PBDMASK_PICOUART_Pos     5            /**< \brief (PM_PBDMASK) PICOUART APB Clock Enable */
-#define PM_PBDMASK_PICOUART         (_U(0x1) << PM_PBDMASK_PICOUART_Pos)
-#define PM_PBDMASK_MASK             _U(0x0000003F) /**< \brief (PM_PBDMASK) MASK Register */
+#define PM_PBDMASK_PICOUART         (_U_(0x1) << PM_PBDMASK_PICOUART_Pos)
+#define PM_PBDMASK_MASK             _U_(0x0000003F) /**< \brief (PM_PBDMASK) MASK Register */
 
 /* -------- PM_PBADIVMASK : (PM Offset: 0x040) (R/W 32) PBA Divided Clock Mask -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -431,8 +431,8 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_PBADIVMASK_OFFSET        0x040        /**< \brief (PM_PBADIVMASK offset) PBA Divided Clock Mask */
-#define PM_PBADIVMASK_RESETVALUE    _U(0x00000000); /**< \brief (PM_PBADIVMASK reset_value) PBA Divided Clock Mask */
-#define PM_PBADIVMASK_MASK          _U(0xFFFFFFFF) /**< \brief (PM_PBADIVMASK) MASK Register */
+#define PM_PBADIVMASK_RESETVALUE    _U_(0x00000000); /**< \brief (PM_PBADIVMASK reset_value) PBA Divided Clock Mask */
+#define PM_PBADIVMASK_MASK          _U_(0xFFFFFFFF) /**< \brief (PM_PBADIVMASK) MASK Register */
 
 /* -------- PM_CFDCTRL : (PM Offset: 0x054) (R/W 32) Clock Failure Detector Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -447,13 +447,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_CFDCTRL_OFFSET           0x054        /**< \brief (PM_CFDCTRL offset) Clock Failure Detector Control */
-#define PM_CFDCTRL_RESETVALUE       _U(0x00000000); /**< \brief (PM_CFDCTRL reset_value) Clock Failure Detector Control */
+#define PM_CFDCTRL_RESETVALUE       _U_(0x00000000); /**< \brief (PM_CFDCTRL reset_value) Clock Failure Detector Control */
 
 #define PM_CFDCTRL_CFDEN_Pos        0            /**< \brief (PM_CFDCTRL) Clock Failure Detection Enable */
-#define PM_CFDCTRL_CFDEN            (_U(0x1) << PM_CFDCTRL_CFDEN_Pos)
+#define PM_CFDCTRL_CFDEN            (_U_(0x1) << PM_CFDCTRL_CFDEN_Pos)
 #define PM_CFDCTRL_SFV_Pos          31           /**< \brief (PM_CFDCTRL) Store Final Value */
-#define PM_CFDCTRL_SFV              (_U(0x1) << PM_CFDCTRL_SFV_Pos)
-#define PM_CFDCTRL_MASK             _U(0x80000001) /**< \brief (PM_CFDCTRL) MASK Register */
+#define PM_CFDCTRL_SFV              (_U_(0x1) << PM_CFDCTRL_SFV_Pos)
+#define PM_CFDCTRL_MASK             _U_(0x80000001) /**< \brief (PM_CFDCTRL) MASK Register */
 
 /* -------- PM_UNLOCK : (PM Offset: 0x058) ( /W 32) Unlock Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -468,15 +468,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_UNLOCK_OFFSET            0x058        /**< \brief (PM_UNLOCK offset) Unlock Register */
-#define PM_UNLOCK_RESETVALUE        _U(0x00000000); /**< \brief (PM_UNLOCK reset_value) Unlock Register */
+#define PM_UNLOCK_RESETVALUE        _U_(0x00000000); /**< \brief (PM_UNLOCK reset_value) Unlock Register */
 
 #define PM_UNLOCK_ADDR_Pos          0            /**< \brief (PM_UNLOCK) Unlock Address */
-#define PM_UNLOCK_ADDR_Msk          (_U(0x3FF) << PM_UNLOCK_ADDR_Pos)
+#define PM_UNLOCK_ADDR_Msk          (_U_(0x3FF) << PM_UNLOCK_ADDR_Pos)
 #define PM_UNLOCK_ADDR(value)       (PM_UNLOCK_ADDR_Msk & ((value) << PM_UNLOCK_ADDR_Pos))
 #define PM_UNLOCK_KEY_Pos           24           /**< \brief (PM_UNLOCK) Unlock Key */
-#define PM_UNLOCK_KEY_Msk           (_U(0xFF) << PM_UNLOCK_KEY_Pos)
+#define PM_UNLOCK_KEY_Msk           (_U_(0xFF) << PM_UNLOCK_KEY_Pos)
 #define PM_UNLOCK_KEY(value)        (PM_UNLOCK_KEY_Msk & ((value) << PM_UNLOCK_KEY_Pos))
-#define PM_UNLOCK_MASK              _U(0xFF0003FF) /**< \brief (PM_UNLOCK) MASK Register */
+#define PM_UNLOCK_MASK              _U_(0xFF0003FF) /**< \brief (PM_UNLOCK) MASK Register */
 
 /* -------- PM_IER : (PM Offset: 0x0C0) ( /W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -495,21 +495,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_IER_OFFSET               0x0C0        /**< \brief (PM_IER offset) Interrupt Enable Register */
-#define PM_IER_RESETVALUE           _U(0x00000000); /**< \brief (PM_IER reset_value) Interrupt Enable Register */
+#define PM_IER_RESETVALUE           _U_(0x00000000); /**< \brief (PM_IER reset_value) Interrupt Enable Register */
 
 #define PM_IER_CFD_Pos              0            /**< \brief (PM_IER) Clock Failure Detected Interrupt Enable */
-#define PM_IER_CFD                  (_U(0x1) << PM_IER_CFD_Pos)
+#define PM_IER_CFD                  (_U_(0x1) << PM_IER_CFD_Pos)
 #define PM_IER_CKRDY_Pos            5            /**< \brief (PM_IER) Clock Ready Interrupt Enable */
-#define PM_IER_CKRDY                (_U(0x1) << PM_IER_CKRDY_Pos)
+#define PM_IER_CKRDY                (_U_(0x1) << PM_IER_CKRDY_Pos)
 #define PM_IER_WAKE_Pos             8            /**< \brief (PM_IER) Wake up Interrupt Enable */
-#define PM_IER_WAKE                 (_U(0x1) << PM_IER_WAKE_Pos)
-#define   PM_IER_WAKE_0_Val               _U(0x0)   /**< \brief (PM_IER) No effect */
-#define   PM_IER_WAKE_1_Val               _U(0x1)   /**< \brief (PM_IER) Disable Interrupt. */
+#define PM_IER_WAKE                 (_U_(0x1) << PM_IER_WAKE_Pos)
+#define   PM_IER_WAKE_0_Val               _U_(0x0)   /**< \brief (PM_IER) No effect */
+#define   PM_IER_WAKE_1_Val               _U_(0x1)   /**< \brief (PM_IER) Disable Interrupt. */
 #define PM_IER_WAKE_0               (PM_IER_WAKE_0_Val             << PM_IER_WAKE_Pos)
 #define PM_IER_WAKE_1               (PM_IER_WAKE_1_Val             << PM_IER_WAKE_Pos)
 #define PM_IER_AE_Pos               31           /**< \brief (PM_IER) Access Error Interrupt Enable */
-#define PM_IER_AE                   (_U(0x1) << PM_IER_AE_Pos)
-#define PM_IER_MASK                 _U(0x80000121) /**< \brief (PM_IER) MASK Register */
+#define PM_IER_AE                   (_U_(0x1) << PM_IER_AE_Pos)
+#define PM_IER_MASK                 _U_(0x80000121) /**< \brief (PM_IER) MASK Register */
 
 /* -------- PM_IDR : (PM Offset: 0x0C4) ( /W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -528,21 +528,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_IDR_OFFSET               0x0C4        /**< \brief (PM_IDR offset) Interrupt Disable Register */
-#define PM_IDR_RESETVALUE           _U(0x00000000); /**< \brief (PM_IDR reset_value) Interrupt Disable Register */
+#define PM_IDR_RESETVALUE           _U_(0x00000000); /**< \brief (PM_IDR reset_value) Interrupt Disable Register */
 
 #define PM_IDR_CFD_Pos              0            /**< \brief (PM_IDR) Clock Failure Detected Interrupt Disable */
-#define PM_IDR_CFD                  (_U(0x1) << PM_IDR_CFD_Pos)
+#define PM_IDR_CFD                  (_U_(0x1) << PM_IDR_CFD_Pos)
 #define PM_IDR_CKRDY_Pos            5            /**< \brief (PM_IDR) Clock Ready Interrupt Disable */
-#define PM_IDR_CKRDY                (_U(0x1) << PM_IDR_CKRDY_Pos)
+#define PM_IDR_CKRDY                (_U_(0x1) << PM_IDR_CKRDY_Pos)
 #define PM_IDR_WAKE_Pos             8            /**< \brief (PM_IDR) Wake up Interrupt Disable */
-#define PM_IDR_WAKE                 (_U(0x1) << PM_IDR_WAKE_Pos)
-#define   PM_IDR_WAKE_0_Val               _U(0x0)   /**< \brief (PM_IDR) No effect */
-#define   PM_IDR_WAKE_1_Val               _U(0x1)   /**< \brief (PM_IDR) Disable Interrupt. */
+#define PM_IDR_WAKE                 (_U_(0x1) << PM_IDR_WAKE_Pos)
+#define   PM_IDR_WAKE_0_Val               _U_(0x0)   /**< \brief (PM_IDR) No effect */
+#define   PM_IDR_WAKE_1_Val               _U_(0x1)   /**< \brief (PM_IDR) Disable Interrupt. */
 #define PM_IDR_WAKE_0               (PM_IDR_WAKE_0_Val             << PM_IDR_WAKE_Pos)
 #define PM_IDR_WAKE_1               (PM_IDR_WAKE_1_Val             << PM_IDR_WAKE_Pos)
 #define PM_IDR_AE_Pos               31           /**< \brief (PM_IDR) Access Error Interrupt Disable */
-#define PM_IDR_AE                   (_U(0x1) << PM_IDR_AE_Pos)
-#define PM_IDR_MASK                 _U(0x80000121) /**< \brief (PM_IDR) MASK Register */
+#define PM_IDR_AE                   (_U_(0x1) << PM_IDR_AE_Pos)
+#define PM_IDR_MASK                 _U_(0x80000121) /**< \brief (PM_IDR) MASK Register */
 
 /* -------- PM_IMR : (PM Offset: 0x0C8) (R/  32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -561,21 +561,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_IMR_OFFSET               0x0C8        /**< \brief (PM_IMR offset) Interrupt Mask Register */
-#define PM_IMR_RESETVALUE           _U(0x00000000); /**< \brief (PM_IMR reset_value) Interrupt Mask Register */
+#define PM_IMR_RESETVALUE           _U_(0x00000000); /**< \brief (PM_IMR reset_value) Interrupt Mask Register */
 
 #define PM_IMR_CFD_Pos              0            /**< \brief (PM_IMR) Clock Failure Detected Interrupt Mask */
-#define PM_IMR_CFD                  (_U(0x1) << PM_IMR_CFD_Pos)
+#define PM_IMR_CFD                  (_U_(0x1) << PM_IMR_CFD_Pos)
 #define PM_IMR_CKRDY_Pos            5            /**< \brief (PM_IMR) Clock Ready Interrupt Mask */
-#define PM_IMR_CKRDY                (_U(0x1) << PM_IMR_CKRDY_Pos)
+#define PM_IMR_CKRDY                (_U_(0x1) << PM_IMR_CKRDY_Pos)
 #define PM_IMR_WAKE_Pos             8            /**< \brief (PM_IMR) Wake up Interrupt Mask */
-#define PM_IMR_WAKE                 (_U(0x1) << PM_IMR_WAKE_Pos)
-#define   PM_IMR_WAKE_0_Val               _U(0x0)   /**< \brief (PM_IMR) No effect */
-#define   PM_IMR_WAKE_1_Val               _U(0x1)   /**< \brief (PM_IMR) Disable Interrupt. */
+#define PM_IMR_WAKE                 (_U_(0x1) << PM_IMR_WAKE_Pos)
+#define   PM_IMR_WAKE_0_Val               _U_(0x0)   /**< \brief (PM_IMR) No effect */
+#define   PM_IMR_WAKE_1_Val               _U_(0x1)   /**< \brief (PM_IMR) Disable Interrupt. */
 #define PM_IMR_WAKE_0               (PM_IMR_WAKE_0_Val             << PM_IMR_WAKE_Pos)
 #define PM_IMR_WAKE_1               (PM_IMR_WAKE_1_Val             << PM_IMR_WAKE_Pos)
 #define PM_IMR_AE_Pos               31           /**< \brief (PM_IMR) Access Error Interrupt Mask */
-#define PM_IMR_AE                   (_U(0x1) << PM_IMR_AE_Pos)
-#define PM_IMR_MASK                 _U(0x80000121) /**< \brief (PM_IMR) MASK Register */
+#define PM_IMR_AE                   (_U_(0x1) << PM_IMR_AE_Pos)
+#define PM_IMR_MASK                 _U_(0x80000121) /**< \brief (PM_IMR) MASK Register */
 
 /* -------- PM_ISR : (PM Offset: 0x0CC) (R/  32) Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -594,21 +594,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_ISR_OFFSET               0x0CC        /**< \brief (PM_ISR offset) Interrupt Status Register */
-#define PM_ISR_RESETVALUE           _U(0x00000000); /**< \brief (PM_ISR reset_value) Interrupt Status Register */
+#define PM_ISR_RESETVALUE           _U_(0x00000000); /**< \brief (PM_ISR reset_value) Interrupt Status Register */
 
 #define PM_ISR_CFD_Pos              0            /**< \brief (PM_ISR) Clock Failure Detected Interrupt Status */
-#define PM_ISR_CFD                  (_U(0x1) << PM_ISR_CFD_Pos)
+#define PM_ISR_CFD                  (_U_(0x1) << PM_ISR_CFD_Pos)
 #define PM_ISR_CKRDY_Pos            5            /**< \brief (PM_ISR) Clock Ready Interrupt Status */
-#define PM_ISR_CKRDY                (_U(0x1) << PM_ISR_CKRDY_Pos)
+#define PM_ISR_CKRDY                (_U_(0x1) << PM_ISR_CKRDY_Pos)
 #define PM_ISR_WAKE_Pos             8            /**< \brief (PM_ISR) Wake up Interrupt Status */
-#define PM_ISR_WAKE                 (_U(0x1) << PM_ISR_WAKE_Pos)
-#define   PM_ISR_WAKE_0_Val               _U(0x0)   /**< \brief (PM_ISR) No effect */
-#define   PM_ISR_WAKE_1_Val               _U(0x1)   /**< \brief (PM_ISR) Disable Interrupt. */
+#define PM_ISR_WAKE                 (_U_(0x1) << PM_ISR_WAKE_Pos)
+#define   PM_ISR_WAKE_0_Val               _U_(0x0)   /**< \brief (PM_ISR) No effect */
+#define   PM_ISR_WAKE_1_Val               _U_(0x1)   /**< \brief (PM_ISR) Disable Interrupt. */
 #define PM_ISR_WAKE_0               (PM_ISR_WAKE_0_Val             << PM_ISR_WAKE_Pos)
 #define PM_ISR_WAKE_1               (PM_ISR_WAKE_1_Val             << PM_ISR_WAKE_Pos)
 #define PM_ISR_AE_Pos               31           /**< \brief (PM_ISR) Access Error Interrupt Status */
-#define PM_ISR_AE                   (_U(0x1) << PM_ISR_AE_Pos)
-#define PM_ISR_MASK                 _U(0x80000121) /**< \brief (PM_ISR) MASK Register */
+#define PM_ISR_AE                   (_U_(0x1) << PM_ISR_AE_Pos)
+#define PM_ISR_MASK                 _U_(0x80000121) /**< \brief (PM_ISR) MASK Register */
 
 /* -------- PM_ICR : (PM Offset: 0x0D0) ( /W 32) Interrupt Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -627,17 +627,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_ICR_OFFSET               0x0D0        /**< \brief (PM_ICR offset) Interrupt Clear Register */
-#define PM_ICR_RESETVALUE           _U(0x00000000); /**< \brief (PM_ICR reset_value) Interrupt Clear Register */
+#define PM_ICR_RESETVALUE           _U_(0x00000000); /**< \brief (PM_ICR reset_value) Interrupt Clear Register */
 
 #define PM_ICR_CFD_Pos              0            /**< \brief (PM_ICR) Clock Failure Detected Interrupt Status Clear */
-#define PM_ICR_CFD                  (_U(0x1) << PM_ICR_CFD_Pos)
+#define PM_ICR_CFD                  (_U_(0x1) << PM_ICR_CFD_Pos)
 #define PM_ICR_CKRDY_Pos            5            /**< \brief (PM_ICR) Clock Ready Interrupt Status Clear */
-#define PM_ICR_CKRDY                (_U(0x1) << PM_ICR_CKRDY_Pos)
+#define PM_ICR_CKRDY                (_U_(0x1) << PM_ICR_CKRDY_Pos)
 #define PM_ICR_WAKE_Pos             8            /**< \brief (PM_ICR) Wake up Interrupt Status Clear */
-#define PM_ICR_WAKE                 (_U(0x1) << PM_ICR_WAKE_Pos)
+#define PM_ICR_WAKE                 (_U_(0x1) << PM_ICR_WAKE_Pos)
 #define PM_ICR_AE_Pos               31           /**< \brief (PM_ICR) Access Error Interrupt Status Clear */
-#define PM_ICR_AE                   (_U(0x1) << PM_ICR_AE_Pos)
-#define PM_ICR_MASK                 _U(0x80000121) /**< \brief (PM_ICR) MASK Register */
+#define PM_ICR_AE                   (_U_(0x1) << PM_ICR_AE_Pos)
+#define PM_ICR_MASK                 _U_(0x80000121) /**< \brief (PM_ICR) MASK Register */
 
 /* -------- PM_SR : (PM Offset: 0x0D4) (R/  32) Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -659,25 +659,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_SR_OFFSET                0x0D4        /**< \brief (PM_SR offset) Status Register */
-#define PM_SR_RESETVALUE            _U(0x00000000); /**< \brief (PM_SR reset_value) Status Register */
+#define PM_SR_RESETVALUE            _U_(0x00000000); /**< \brief (PM_SR reset_value) Status Register */
 
 #define PM_SR_CFD_Pos               0            /**< \brief (PM_SR) Clock Failure Detected */
-#define PM_SR_CFD                   (_U(0x1) << PM_SR_CFD_Pos)
+#define PM_SR_CFD                   (_U_(0x1) << PM_SR_CFD_Pos)
 #define PM_SR_OCP_Pos               1            /**< \brief (PM_SR) Over Clock Detected */
-#define PM_SR_OCP                   (_U(0x1) << PM_SR_OCP_Pos)
+#define PM_SR_OCP                   (_U_(0x1) << PM_SR_OCP_Pos)
 #define PM_SR_CKRDY_Pos             5            /**< \brief (PM_SR) Clock Ready */
-#define PM_SR_CKRDY                 (_U(0x1) << PM_SR_CKRDY_Pos)
+#define PM_SR_CKRDY                 (_U_(0x1) << PM_SR_CKRDY_Pos)
 #define PM_SR_WAKE_Pos              8            /**< \brief (PM_SR) Wake up */
-#define PM_SR_WAKE                  (_U(0x1) << PM_SR_WAKE_Pos)
-#define   PM_SR_WAKE_0_Val                _U(0x0)   /**< \brief (PM_SR) No effect */
-#define   PM_SR_WAKE_1_Val                _U(0x1)   /**< \brief (PM_SR) Disable Interrupt. */
+#define PM_SR_WAKE                  (_U_(0x1) << PM_SR_WAKE_Pos)
+#define   PM_SR_WAKE_0_Val                _U_(0x0)   /**< \brief (PM_SR) No effect */
+#define   PM_SR_WAKE_1_Val                _U_(0x1)   /**< \brief (PM_SR) Disable Interrupt. */
 #define PM_SR_WAKE_0                (PM_SR_WAKE_0_Val              << PM_SR_WAKE_Pos)
 #define PM_SR_WAKE_1                (PM_SR_WAKE_1_Val              << PM_SR_WAKE_Pos)
 #define PM_SR_PERRDY_Pos            28           /**< \brief (PM_SR) Peripheral Ready */
-#define PM_SR_PERRDY                (_U(0x1) << PM_SR_PERRDY_Pos)
+#define PM_SR_PERRDY                (_U_(0x1) << PM_SR_PERRDY_Pos)
 #define PM_SR_AE_Pos                31           /**< \brief (PM_SR) Access Error */
-#define PM_SR_AE                    (_U(0x1) << PM_SR_AE_Pos)
-#define PM_SR_MASK                  _U(0x90000123) /**< \brief (PM_SR) MASK Register */
+#define PM_SR_AE                    (_U_(0x1) << PM_SR_AE_Pos)
+#define PM_SR_MASK                  _U_(0x90000123) /**< \brief (PM_SR) MASK Register */
 
 /* -------- PM_PPCR : (PM Offset: 0x160) (R/W 32) Peripheral Power Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -701,31 +701,31 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_PPCR_OFFSET              0x160        /**< \brief (PM_PPCR offset) Peripheral Power Control Register */
-#define PM_PPCR_RESETVALUE          _U(0x000001FE); /**< \brief (PM_PPCR reset_value) Peripheral Power Control Register */
+#define PM_PPCR_RESETVALUE          _U_(0x000001FE); /**< \brief (PM_PPCR reset_value) Peripheral Power Control Register */
 
 #define PM_PPCR_RSTPUN_Pos          0            /**< \brief (PM_PPCR) Reset Pullup */
-#define PM_PPCR_RSTPUN              (_U(0x1) << PM_PPCR_RSTPUN_Pos)
+#define PM_PPCR_RSTPUN              (_U_(0x1) << PM_PPCR_RSTPUN_Pos)
 #define PM_PPCR_CATBRCMASK_Pos      1            /**< \brief (PM_PPCR) CAT Request Clock Mask */
-#define PM_PPCR_CATBRCMASK          (_U(0x1) << PM_PPCR_CATBRCMASK_Pos)
+#define PM_PPCR_CATBRCMASK          (_U_(0x1) << PM_PPCR_CATBRCMASK_Pos)
 #define PM_PPCR_ACIFCRCMASK_Pos     2            /**< \brief (PM_PPCR) ACIFC Request Clock Mask */
-#define PM_PPCR_ACIFCRCMASK         (_U(0x1) << PM_PPCR_ACIFCRCMASK_Pos)
+#define PM_PPCR_ACIFCRCMASK         (_U_(0x1) << PM_PPCR_ACIFCRCMASK_Pos)
 #define PM_PPCR_ASTRCMASK_Pos       3            /**< \brief (PM_PPCR) AST Request Clock Mask */
-#define PM_PPCR_ASTRCMASK           (_U(0x1) << PM_PPCR_ASTRCMASK_Pos)
+#define PM_PPCR_ASTRCMASK           (_U_(0x1) << PM_PPCR_ASTRCMASK_Pos)
 #define PM_PPCR_TWIS0RCMASK_Pos     4            /**< \brief (PM_PPCR) TWIS0 Request Clock Mask */
-#define PM_PPCR_TWIS0RCMASK         (_U(0x1) << PM_PPCR_TWIS0RCMASK_Pos)
+#define PM_PPCR_TWIS0RCMASK         (_U_(0x1) << PM_PPCR_TWIS0RCMASK_Pos)
 #define PM_PPCR_TWIS1RCMASK_Pos     5            /**< \brief (PM_PPCR) TWIS1 Request Clock Mask */
-#define PM_PPCR_TWIS1RCMASK         (_U(0x1) << PM_PPCR_TWIS1RCMASK_Pos)
+#define PM_PPCR_TWIS1RCMASK         (_U_(0x1) << PM_PPCR_TWIS1RCMASK_Pos)
 #define PM_PPCR_PEVCRCMASK_Pos      6            /**< \brief (PM_PPCR) PEVC Request Clock Mask */
-#define PM_PPCR_PEVCRCMASK          (_U(0x1) << PM_PPCR_PEVCRCMASK_Pos)
+#define PM_PPCR_PEVCRCMASK          (_U_(0x1) << PM_PPCR_PEVCRCMASK_Pos)
 #define PM_PPCR_ADCIFERCMASK_Pos    7            /**< \brief (PM_PPCR) ADCIFE Request Clock Mask */
-#define PM_PPCR_ADCIFERCMASK        (_U(0x1) << PM_PPCR_ADCIFERCMASK_Pos)
+#define PM_PPCR_ADCIFERCMASK        (_U_(0x1) << PM_PPCR_ADCIFERCMASK_Pos)
 #define PM_PPCR_VREGRCMASK_Pos      8            /**< \brief (PM_PPCR) VREG Request Clock Mask */
-#define PM_PPCR_VREGRCMASK          (_U(0x1) << PM_PPCR_VREGRCMASK_Pos)
+#define PM_PPCR_VREGRCMASK          (_U_(0x1) << PM_PPCR_VREGRCMASK_Pos)
 #define PM_PPCR_FWBGREF_Pos         9            /**< \brief (PM_PPCR) Flash Wait BGREF */
-#define PM_PPCR_FWBGREF             (_U(0x1) << PM_PPCR_FWBGREF_Pos)
+#define PM_PPCR_FWBGREF             (_U_(0x1) << PM_PPCR_FWBGREF_Pos)
 #define PM_PPCR_FWBOD18_Pos         10           /**< \brief (PM_PPCR) Flash Wait BOD18 */
-#define PM_PPCR_FWBOD18             (_U(0x1) << PM_PPCR_FWBOD18_Pos)
-#define PM_PPCR_MASK                _U(0x000007FF) /**< \brief (PM_PPCR) MASK Register */
+#define PM_PPCR_FWBOD18             (_U_(0x1) << PM_PPCR_FWBOD18_Pos)
+#define PM_PPCR_MASK                _U_(0x000007FF) /**< \brief (PM_PPCR) MASK Register */
 
 /* -------- PM_RCAUSE : (PM Offset: 0x180) (R/  32) Reset Cause Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -748,23 +748,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_RCAUSE_OFFSET            0x180        /**< \brief (PM_RCAUSE offset) Reset Cause Register */
-#define PM_RCAUSE_RESETVALUE        _U(0x00000000); /**< \brief (PM_RCAUSE reset_value) Reset Cause Register */
+#define PM_RCAUSE_RESETVALUE        _U_(0x00000000); /**< \brief (PM_RCAUSE reset_value) Reset Cause Register */
 
 #define PM_RCAUSE_POR_Pos           0            /**< \brief (PM_RCAUSE) Power-on Reset */
-#define PM_RCAUSE_POR               (_U(0x1) << PM_RCAUSE_POR_Pos)
+#define PM_RCAUSE_POR               (_U_(0x1) << PM_RCAUSE_POR_Pos)
 #define PM_RCAUSE_BOD_Pos           1            /**< \brief (PM_RCAUSE) Brown-out Reset */
-#define PM_RCAUSE_BOD               (_U(0x1) << PM_RCAUSE_BOD_Pos)
+#define PM_RCAUSE_BOD               (_U_(0x1) << PM_RCAUSE_BOD_Pos)
 #define PM_RCAUSE_EXT_Pos           2            /**< \brief (PM_RCAUSE) External Reset Pin */
-#define PM_RCAUSE_EXT               (_U(0x1) << PM_RCAUSE_EXT_Pos)
+#define PM_RCAUSE_EXT               (_U_(0x1) << PM_RCAUSE_EXT_Pos)
 #define PM_RCAUSE_WDT_Pos           3            /**< \brief (PM_RCAUSE) Watchdog Reset */
-#define PM_RCAUSE_WDT               (_U(0x1) << PM_RCAUSE_WDT_Pos)
+#define PM_RCAUSE_WDT               (_U_(0x1) << PM_RCAUSE_WDT_Pos)
 #define PM_RCAUSE_OCDRST_Pos        8            /**< \brief (PM_RCAUSE) OCD Reset */
-#define PM_RCAUSE_OCDRST            (_U(0x1) << PM_RCAUSE_OCDRST_Pos)
+#define PM_RCAUSE_OCDRST            (_U_(0x1) << PM_RCAUSE_OCDRST_Pos)
 #define PM_RCAUSE_POR33_Pos         10           /**< \brief (PM_RCAUSE) Power-on Reset */
-#define PM_RCAUSE_POR33             (_U(0x1) << PM_RCAUSE_POR33_Pos)
+#define PM_RCAUSE_POR33             (_U_(0x1) << PM_RCAUSE_POR33_Pos)
 #define PM_RCAUSE_BOD33_Pos         13           /**< \brief (PM_RCAUSE) Brown-out 3.3V Reset */
-#define PM_RCAUSE_BOD33             (_U(0x1) << PM_RCAUSE_BOD33_Pos)
-#define PM_RCAUSE_MASK              _U(0x0000250F) /**< \brief (PM_RCAUSE) MASK Register */
+#define PM_RCAUSE_BOD33             (_U_(0x1) << PM_RCAUSE_BOD33_Pos)
+#define PM_RCAUSE_MASK              _U_(0x0000250F) /**< \brief (PM_RCAUSE) MASK Register */
 
 /* -------- PM_WCAUSE : (PM Offset: 0x184) (R/  32) Wake Cause Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -788,29 +788,29 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_WCAUSE_OFFSET            0x184        /**< \brief (PM_WCAUSE offset) Wake Cause Register */
-#define PM_WCAUSE_RESETVALUE        _U(0x00000000); /**< \brief (PM_WCAUSE reset_value) Wake Cause Register */
+#define PM_WCAUSE_RESETVALUE        _U_(0x00000000); /**< \brief (PM_WCAUSE reset_value) Wake Cause Register */
 
 #define PM_WCAUSE_TWI_SLAVE_0_Pos   0            /**< \brief (PM_WCAUSE) Two-wire Slave Interface 0 */
-#define PM_WCAUSE_TWI_SLAVE_0       (_U(0x1) << PM_WCAUSE_TWI_SLAVE_0_Pos)
+#define PM_WCAUSE_TWI_SLAVE_0       (_U_(0x1) << PM_WCAUSE_TWI_SLAVE_0_Pos)
 #define PM_WCAUSE_TWI_SLAVE_1_Pos   1            /**< \brief (PM_WCAUSE) Two-wire Slave Interface 1 */
-#define PM_WCAUSE_TWI_SLAVE_1       (_U(0x1) << PM_WCAUSE_TWI_SLAVE_1_Pos)
+#define PM_WCAUSE_TWI_SLAVE_1       (_U_(0x1) << PM_WCAUSE_TWI_SLAVE_1_Pos)
 #define PM_WCAUSE_USBC_Pos          2            /**< \brief (PM_WCAUSE) USB Device and Embedded Host Interface */
-#define PM_WCAUSE_USBC              (_U(0x1) << PM_WCAUSE_USBC_Pos)
+#define PM_WCAUSE_USBC              (_U_(0x1) << PM_WCAUSE_USBC_Pos)
 #define PM_WCAUSE_PSOK_Pos          3            /**< \brief (PM_WCAUSE) Power Scaling OK */
-#define PM_WCAUSE_PSOK              (_U(0x1) << PM_WCAUSE_PSOK_Pos)
+#define PM_WCAUSE_PSOK              (_U_(0x1) << PM_WCAUSE_PSOK_Pos)
 #define PM_WCAUSE_BOD18_IRQ_Pos     4            /**< \brief (PM_WCAUSE) BOD18 Interrupt */
-#define PM_WCAUSE_BOD18_IRQ         (_U(0x1) << PM_WCAUSE_BOD18_IRQ_Pos)
+#define PM_WCAUSE_BOD18_IRQ         (_U_(0x1) << PM_WCAUSE_BOD18_IRQ_Pos)
 #define PM_WCAUSE_BOD33_IRQ_Pos     5            /**< \brief (PM_WCAUSE) BOD33 Interrupt */
-#define PM_WCAUSE_BOD33_IRQ         (_U(0x1) << PM_WCAUSE_BOD33_IRQ_Pos)
+#define PM_WCAUSE_BOD33_IRQ         (_U_(0x1) << PM_WCAUSE_BOD33_IRQ_Pos)
 #define PM_WCAUSE_PICOUART_Pos      6            /**< \brief (PM_WCAUSE) Picopower UART */
-#define PM_WCAUSE_PICOUART          (_U(0x1) << PM_WCAUSE_PICOUART_Pos)
+#define PM_WCAUSE_PICOUART          (_U_(0x1) << PM_WCAUSE_PICOUART_Pos)
 #define PM_WCAUSE_LCDCA_Pos         7            /**< \brief (PM_WCAUSE) LCD Controller */
-#define PM_WCAUSE_LCDCA             (_U(0x1) << PM_WCAUSE_LCDCA_Pos)
+#define PM_WCAUSE_LCDCA             (_U_(0x1) << PM_WCAUSE_LCDCA_Pos)
 #define PM_WCAUSE_EIC_Pos           16           /**< \brief (PM_WCAUSE) External Interrupt Controller */
-#define PM_WCAUSE_EIC               (_U(0x1) << PM_WCAUSE_EIC_Pos)
+#define PM_WCAUSE_EIC               (_U_(0x1) << PM_WCAUSE_EIC_Pos)
 #define PM_WCAUSE_AST_Pos           17           /**< \brief (PM_WCAUSE) Asynchronous Timer */
-#define PM_WCAUSE_AST               (_U(0x1) << PM_WCAUSE_AST_Pos)
-#define PM_WCAUSE_MASK              _U(0x000300FF) /**< \brief (PM_WCAUSE) MASK Register */
+#define PM_WCAUSE_AST               (_U_(0x1) << PM_WCAUSE_AST_Pos)
+#define PM_WCAUSE_MASK              _U_(0x000300FF) /**< \brief (PM_WCAUSE) MASK Register */
 
 /* -------- PM_AWEN : (PM Offset: 0x188) (R/W 32) Asynchronous Wake Enable -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -823,12 +823,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_AWEN_OFFSET              0x188        /**< \brief (PM_AWEN offset) Asynchronous Wake Enable */
-#define PM_AWEN_RESETVALUE          _U(0x00000000); /**< \brief (PM_AWEN reset_value) Asynchronous Wake Enable */
+#define PM_AWEN_RESETVALUE          _U_(0x00000000); /**< \brief (PM_AWEN reset_value) Asynchronous Wake Enable */
 
 #define PM_AWEN_AWEN_Pos            0            /**< \brief (PM_AWEN) Asynchronous Wake Up */
-#define PM_AWEN_AWEN_Msk            (_U(0xFFFFFFFF) << PM_AWEN_AWEN_Pos)
+#define PM_AWEN_AWEN_Msk            (_U_(0xFFFFFFFF) << PM_AWEN_AWEN_Pos)
 #define PM_AWEN_AWEN(value)         (PM_AWEN_AWEN_Msk & ((value) << PM_AWEN_AWEN_Pos))
-#define PM_AWEN_MASK                _U(0xFFFFFFFF) /**< \brief (PM_AWEN) MASK Register */
+#define PM_AWEN_MASK                _U_(0xFFFFFFFF) /**< \brief (PM_AWEN) MASK Register */
 
 /* -------- PM_OBS : (PM Offset: 0x190) (R/W 32) Obsvervability -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -838,9 +838,9 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_OBS_OFFSET               0x190        /**< \brief (PM_OBS offset) Obsvervability */
-#define PM_OBS_RESETVALUE           _U(0x00000000); /**< \brief (PM_OBS reset_value) Obsvervability */
+#define PM_OBS_RESETVALUE           _U_(0x00000000); /**< \brief (PM_OBS reset_value) Obsvervability */
 
-#define PM_OBS_MASK                 _U(0x00000000) /**< \brief (PM_OBS) MASK Register */
+#define PM_OBS_MASK                 _U_(0x00000000) /**< \brief (PM_OBS) MASK Register */
 
 /* -------- PM_FASTSLEEP : (PM Offset: 0x194) (R/W 32) Fast Sleep Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -860,18 +860,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_FASTSLEEP_OFFSET         0x194        /**< \brief (PM_FASTSLEEP offset) Fast Sleep Register */
-#define PM_FASTSLEEP_RESETVALUE     _U(0x00000000); /**< \brief (PM_FASTSLEEP reset_value) Fast Sleep Register */
+#define PM_FASTSLEEP_RESETVALUE     _U_(0x00000000); /**< \brief (PM_FASTSLEEP reset_value) Fast Sleep Register */
 
 #define PM_FASTSLEEP_OSC_Pos        0            /**< \brief (PM_FASTSLEEP) Oscillator */
-#define PM_FASTSLEEP_OSC            (_U(0x1) << PM_FASTSLEEP_OSC_Pos)
+#define PM_FASTSLEEP_OSC            (_U_(0x1) << PM_FASTSLEEP_OSC_Pos)
 #define PM_FASTSLEEP_PLL_Pos        8            /**< \brief (PM_FASTSLEEP) PLL */
-#define PM_FASTSLEEP_PLL            (_U(0x1) << PM_FASTSLEEP_PLL_Pos)
+#define PM_FASTSLEEP_PLL            (_U_(0x1) << PM_FASTSLEEP_PLL_Pos)
 #define PM_FASTSLEEP_FASTRCOSC_Pos  16           /**< \brief (PM_FASTSLEEP) RC80 or FLO */
-#define PM_FASTSLEEP_FASTRCOSC_Msk  (_U(0x1F) << PM_FASTSLEEP_FASTRCOSC_Pos)
+#define PM_FASTSLEEP_FASTRCOSC_Msk  (_U_(0x1F) << PM_FASTSLEEP_FASTRCOSC_Pos)
 #define PM_FASTSLEEP_FASTRCOSC(value) (PM_FASTSLEEP_FASTRCOSC_Msk & ((value) << PM_FASTSLEEP_FASTRCOSC_Pos))
 #define PM_FASTSLEEP_DFLL_Pos       24           /**< \brief (PM_FASTSLEEP) DFLL */
-#define PM_FASTSLEEP_DFLL           (_U(0x1) << PM_FASTSLEEP_DFLL_Pos)
-#define PM_FASTSLEEP_MASK           _U(0x011F0101) /**< \brief (PM_FASTSLEEP) MASK Register */
+#define PM_FASTSLEEP_DFLL           (_U_(0x1) << PM_FASTSLEEP_DFLL_Pos)
+#define PM_FASTSLEEP_MASK           _U_(0x011F0101) /**< \brief (PM_FASTSLEEP) MASK Register */
 
 /* -------- PM_CONFIG : (PM Offset: 0x3F8) (R/  32) Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -890,19 +890,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_CONFIG_OFFSET            0x3F8        /**< \brief (PM_CONFIG offset) Configuration Register */
-#define PM_CONFIG_RESETVALUE        _U(0x0000000F); /**< \brief (PM_CONFIG reset_value) Configuration Register */
+#define PM_CONFIG_RESETVALUE        _U_(0x0000000F); /**< \brief (PM_CONFIG reset_value) Configuration Register */
 
 #define PM_CONFIG_PBA_Pos           0            /**< \brief (PM_CONFIG) APBA Implemented */
-#define PM_CONFIG_PBA               (_U(0x1) << PM_CONFIG_PBA_Pos)
+#define PM_CONFIG_PBA               (_U_(0x1) << PM_CONFIG_PBA_Pos)
 #define PM_CONFIG_PBB_Pos           1            /**< \brief (PM_CONFIG) APBB Implemented */
-#define PM_CONFIG_PBB               (_U(0x1) << PM_CONFIG_PBB_Pos)
+#define PM_CONFIG_PBB               (_U_(0x1) << PM_CONFIG_PBB_Pos)
 #define PM_CONFIG_PBC_Pos           2            /**< \brief (PM_CONFIG) APBC Implemented */
-#define PM_CONFIG_PBC               (_U(0x1) << PM_CONFIG_PBC_Pos)
+#define PM_CONFIG_PBC               (_U_(0x1) << PM_CONFIG_PBC_Pos)
 #define PM_CONFIG_PBD_Pos           3            /**< \brief (PM_CONFIG) APBD Implemented */
-#define PM_CONFIG_PBD               (_U(0x1) << PM_CONFIG_PBD_Pos)
+#define PM_CONFIG_PBD               (_U_(0x1) << PM_CONFIG_PBD_Pos)
 #define PM_CONFIG_HSBPEVC_Pos       7            /**< \brief (PM_CONFIG) HSB PEVC Clock Implemented */
-#define PM_CONFIG_HSBPEVC           (_U(0x1) << PM_CONFIG_HSBPEVC_Pos)
-#define PM_CONFIG_MASK              _U(0x0000008F) /**< \brief (PM_CONFIG) MASK Register */
+#define PM_CONFIG_HSBPEVC           (_U_(0x1) << PM_CONFIG_HSBPEVC_Pos)
+#define PM_CONFIG_MASK              _U_(0x0000008F) /**< \brief (PM_CONFIG) MASK Register */
 
 /* -------- PM_VERSION : (PM Offset: 0x3FC) (R/  32) Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -918,15 +918,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PM_VERSION_OFFSET           0x3FC        /**< \brief (PM_VERSION offset) Version Register */
-#define PM_VERSION_RESETVALUE       _U(0x00000441); /**< \brief (PM_VERSION reset_value) Version Register */
+#define PM_VERSION_RESETVALUE       _U_(0x00000441); /**< \brief (PM_VERSION reset_value) Version Register */
 
 #define PM_VERSION_VERSION_Pos      0            /**< \brief (PM_VERSION) Version number */
-#define PM_VERSION_VERSION_Msk      (_U(0xFFF) << PM_VERSION_VERSION_Pos)
+#define PM_VERSION_VERSION_Msk      (_U_(0xFFF) << PM_VERSION_VERSION_Pos)
 #define PM_VERSION_VERSION(value)   (PM_VERSION_VERSION_Msk & ((value) << PM_VERSION_VERSION_Pos))
 #define PM_VERSION_VARIANT_Pos      16           /**< \brief (PM_VERSION) Variant number */
-#define PM_VERSION_VARIANT_Msk      (_U(0xF) << PM_VERSION_VARIANT_Pos)
+#define PM_VERSION_VARIANT_Msk      (_U_(0xF) << PM_VERSION_VARIANT_Pos)
 #define PM_VERSION_VARIANT(value)   (PM_VERSION_VARIANT_Msk & ((value) << PM_VERSION_VARIANT_Pos))
-#define PM_VERSION_MASK             _U(0x000F0FFF) /**< \brief (PM_VERSION) MASK Register */
+#define PM_VERSION_MASK             _U_(0x000F0FFF) /**< \brief (PM_VERSION) MASK Register */
 
 /** \brief PM hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/pm.h
+++ b/asf/sam/include/sam4l/component/pm.h
@@ -930,87 +930,45 @@ typedef union {
 
 /** \brief PM hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __IO PM_MCCTRL_Type            MCCTRL;      /**< \brief Offset: 0x000 (R/W 32) Main Clock Control */
-  __IO PM_CPUSEL_Type            CPUSEL;      /**< \brief Offset: 0x004 (R/W 32) CPU Clock Select */
-       RoReg8                    Reserved1[0x4];
-  __IO PM_PBASEL_Type            PBASEL;      /**< \brief Offset: 0x00C (R/W 32) PBA Clock Select */
-  __IO PM_PBBSEL_Type            PBBSEL;      /**< \brief Offset: 0x010 (R/W 32) PBB Clock Select */
-  __IO PM_PBCSEL_Type            PBCSEL;      /**< \brief Offset: 0x014 (R/W 32) PBC Clock Select */
-  __IO PM_PBDSEL_Type            PBDSEL;      /**< \brief Offset: 0x018 (R/W 32) PBD Clock Select */
-       RoReg8                    Reserved2[0x4];
-  __IO PM_CPUMASK_Type           CPUMASK;     /**< \brief Offset: 0x020 (R/W 32) CPU Mask */
-  __IO PM_HSBMASK_Type           HSBMASK;     /**< \brief Offset: 0x024 (R/W 32) HSB Mask */
-  __IO PM_PBAMASK_Type           PBAMASK;     /**< \brief Offset: 0x028 (R/W 32) PBA Mask */
-  __IO PM_PBBMASK_Type           PBBMASK;     /**< \brief Offset: 0x02C (R/W 32) PBB Mask */
-  __IO PM_PBCMASK_Type           PBCMASK;     /**< \brief Offset: 0x030 (R/W 32) PBC Mask */
-  __IO PM_PBDMASK_Type           PBDMASK;     /**< \brief Offset: 0x034 (R/W 32) PBD Mask */
-       RoReg8                    Reserved3[0x8];
-  __IO PM_PBADIVMASK_Type        PBADIVMASK;  /**< \brief Offset: 0x040 (R/W 32) PBA Divided Clock Mask */
-       RoReg8                    Reserved4[0x10];
-  __IO PM_CFDCTRL_Type           CFDCTRL;     /**< \brief Offset: 0x054 (R/W 32) Clock Failure Detector Control */
-  __O  PM_UNLOCK_Type            UNLOCK;      /**< \brief Offset: 0x058 ( /W 32) Unlock Register */
-       RoReg8                    Reserved5[0x64];
-  __O  PM_IER_Type               IER;         /**< \brief Offset: 0x0C0 ( /W 32) Interrupt Enable Register */
-  __O  PM_IDR_Type               IDR;         /**< \brief Offset: 0x0C4 ( /W 32) Interrupt Disable Register */
-  __I  PM_IMR_Type               IMR;         /**< \brief Offset: 0x0C8 (R/  32) Interrupt Mask Register */
-  __I  PM_ISR_Type               ISR;         /**< \brief Offset: 0x0CC (R/  32) Interrupt Status Register */
-  __O  PM_ICR_Type               ICR;         /**< \brief Offset: 0x0D0 ( /W 32) Interrupt Clear Register */
-  __I  PM_SR_Type                SR;          /**< \brief Offset: 0x0D4 (R/  32) Status Register */
-       RoReg8                    Reserved6[0x88];
-  __IO PM_PPCR_Type              PPCR;        /**< \brief Offset: 0x160 (R/W 32) Peripheral Power Control Register */
-       RoReg8                    Reserved7[0x1C];
-  __I  PM_RCAUSE_Type            RCAUSE;      /**< \brief Offset: 0x180 (R/  32) Reset Cause Register */
-  __I  PM_WCAUSE_Type            WCAUSE;      /**< \brief Offset: 0x184 (R/  32) Wake Cause Register */
-  __IO PM_AWEN_Type              AWEN;        /**< \brief Offset: 0x188 (R/W 32) Asynchronous Wake Enable */
-       RoReg8                    Reserved8[0x4];
-  __IO PM_OBS_Type               OBS;         /**< \brief Offset: 0x190 (R/W 32) Obsvervability */
-  __IO PM_FASTSLEEP_Type         FASTSLEEP;   /**< \brief Offset: 0x194 (R/W 32) Fast Sleep Register */
-       RoReg8                    Reserved9[0x260];
-  __I  PM_CONFIG_Type            CONFIG;      /**< \brief Offset: 0x3F8 (R/  32) Configuration Register */
-  __I  PM_VERSION_Type           VERSION;     /**< \brief Offset: 0x3FC (R/  32) Version Register */
- } bf;
- struct {
-  RwReg   PM_MCCTRL;          /**< \brief (PM Offset: 0x000) Main Clock Control */
-  RwReg   PM_CPUSEL;          /**< \brief (PM Offset: 0x004) CPU Clock Select */
-  RoReg8  Reserved10[0x4];
-  RwReg   PM_PBASEL;          /**< \brief (PM Offset: 0x00C) PBA Clock Select */
-  RwReg   PM_PBBSEL;          /**< \brief (PM Offset: 0x010) PBB Clock Select */
-  RwReg   PM_PBCSEL;          /**< \brief (PM Offset: 0x014) PBC Clock Select */
-  RwReg   PM_PBDSEL;          /**< \brief (PM Offset: 0x018) PBD Clock Select */
-  RoReg8  Reserved11[0x4];
-  RwReg   PM_CPUMASK;         /**< \brief (PM Offset: 0x020) CPU Mask */
-  RwReg   PM_HSBMASK;         /**< \brief (PM Offset: 0x024) HSB Mask */
-  RwReg   PM_PBAMASK;         /**< \brief (PM Offset: 0x028) PBA Mask */
-  RwReg   PM_PBBMASK;         /**< \brief (PM Offset: 0x02C) PBB Mask */
-  RwReg   PM_PBCMASK;         /**< \brief (PM Offset: 0x030) PBC Mask */
-  RwReg   PM_PBDMASK;         /**< \brief (PM Offset: 0x034) PBD Mask */
-  RoReg8  Reserved12[0x8];
-  RwReg   PM_PBADIVMASK;      /**< \brief (PM Offset: 0x040) PBA Divided Clock Mask */
-  RoReg8  Reserved13[0x10];
-  RwReg   PM_CFDCTRL;         /**< \brief (PM Offset: 0x054) Clock Failure Detector Control */
-  WoReg   PM_UNLOCK;          /**< \brief (PM Offset: 0x058) Unlock Register */
-  RoReg8  Reserved14[0x64];
-  WoReg   PM_IER;             /**< \brief (PM Offset: 0x0C0) Interrupt Enable Register */
-  WoReg   PM_IDR;             /**< \brief (PM Offset: 0x0C4) Interrupt Disable Register */
-  RoReg   PM_IMR;             /**< \brief (PM Offset: 0x0C8) Interrupt Mask Register */
-  RoReg   PM_ISR;             /**< \brief (PM Offset: 0x0CC) Interrupt Status Register */
-  WoReg   PM_ICR;             /**< \brief (PM Offset: 0x0D0) Interrupt Clear Register */
-  RoReg   PM_SR;              /**< \brief (PM Offset: 0x0D4) Status Register */
-  RoReg8  Reserved15[0x88];
-  RwReg   PM_PPCR;            /**< \brief (PM Offset: 0x160) Peripheral Power Control Register */
-  RoReg8  Reserved16[0x1C];
-  RoReg   PM_RCAUSE;          /**< \brief (PM Offset: 0x180) Reset Cause Register */
-  RoReg   PM_WCAUSE;          /**< \brief (PM Offset: 0x184) Wake Cause Register */
-  RwReg   PM_AWEN;            /**< \brief (PM Offset: 0x188) Asynchronous Wake Enable */
-  RoReg8  Reserved17[0x4];
-  RwReg   PM_OBS;             /**< \brief (PM Offset: 0x190) Obsvervability */
-  RwReg   PM_FASTSLEEP;       /**< \brief (PM Offset: 0x194) Fast Sleep Register */
-  RoReg8  Reserved18[0x260];
-  RoReg   PM_CONFIG;          /**< \brief (PM Offset: 0x3F8) Configuration Register */
-  RoReg   PM_VERSION;         /**< \brief (PM Offset: 0x3FC) Version Register */
- } reg;
+typedef struct {
+  __IO uint32_t MCCTRL;      /**< \brief Offset: 0x000 (R/W 32) Main Clock Control */
+  __IO uint32_t CPUSEL;      /**< \brief Offset: 0x004 (R/W 32) CPU Clock Select */
+       RoReg8   Reserved1[0x4];
+  __IO uint32_t PBASEL;      /**< \brief Offset: 0x00C (R/W 32) PBA Clock Select */
+  __IO uint32_t PBBSEL;      /**< \brief Offset: 0x010 (R/W 32) PBB Clock Select */
+  __IO uint32_t PBCSEL;      /**< \brief Offset: 0x014 (R/W 32) PBC Clock Select */
+  __IO uint32_t PBDSEL;      /**< \brief Offset: 0x018 (R/W 32) PBD Clock Select */
+       RoReg8   Reserved2[0x4];
+  __IO uint32_t CPUMASK;     /**< \brief Offset: 0x020 (R/W 32) CPU Mask */
+  __IO uint32_t HSBMASK;     /**< \brief Offset: 0x024 (R/W 32) HSB Mask */
+  __IO uint32_t PBAMASK;     /**< \brief Offset: 0x028 (R/W 32) PBA Mask */
+  __IO uint32_t PBBMASK;     /**< \brief Offset: 0x02C (R/W 32) PBB Mask */
+  __IO uint32_t PBCMASK;     /**< \brief Offset: 0x030 (R/W 32) PBC Mask */
+  __IO uint32_t PBDMASK;     /**< \brief Offset: 0x034 (R/W 32) PBD Mask */
+       RoReg8   Reserved3[0x8];
+  __IO uint32_t PBADIVMASK;  /**< \brief Offset: 0x040 (R/W 32) PBA Divided Clock Mask */
+       RoReg8   Reserved4[0x10];
+  __IO uint32_t CFDCTRL;     /**< \brief Offset: 0x054 (R/W 32) Clock Failure Detector Control */
+  __O  uint32_t UNLOCK;      /**< \brief Offset: 0x058 ( /W 32) Unlock Register */
+       RoReg8   Reserved5[0x64];
+  __O  uint32_t IER;         /**< \brief Offset: 0x0C0 ( /W 32) Interrupt Enable Register */
+  __O  uint32_t IDR;         /**< \brief Offset: 0x0C4 ( /W 32) Interrupt Disable Register */
+  __I  uint32_t IMR;         /**< \brief Offset: 0x0C8 (R/  32) Interrupt Mask Register */
+  __I  uint32_t ISR;         /**< \brief Offset: 0x0CC (R/  32) Interrupt Status Register */
+  __O  uint32_t ICR;         /**< \brief Offset: 0x0D0 ( /W 32) Interrupt Clear Register */
+  __I  uint32_t SR;          /**< \brief Offset: 0x0D4 (R/  32) Status Register */
+       RoReg8   Reserved6[0x88];
+  __IO uint32_t PPCR;        /**< \brief Offset: 0x160 (R/W 32) Peripheral Power Control Register */
+       RoReg8   Reserved7[0x1C];
+  __I  uint32_t RCAUSE;      /**< \brief Offset: 0x180 (R/  32) Reset Cause Register */
+  __I  uint32_t WCAUSE;      /**< \brief Offset: 0x184 (R/  32) Wake Cause Register */
+  __IO uint32_t AWEN;        /**< \brief Offset: 0x188 (R/W 32) Asynchronous Wake Enable */
+       RoReg8   Reserved8[0x4];
+  __IO uint32_t OBS;         /**< \brief Offset: 0x190 (R/W 32) Obsvervability */
+  __IO uint32_t FASTSLEEP;   /**< \brief Offset: 0x194 (R/W 32) Fast Sleep Register */
+       RoReg8   Reserved9[0x260];
+  __I  uint32_t CONFIG;      /**< \brief Offset: 0x3F8 (R/  32) Configuration Register */
+  __I  uint32_t VERSION;     /**< \brief Offset: 0x3FC (R/  32) Version Register */
 } Pm;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/pm.h
+++ b/asf/sam/include/sam4l/component/pm.h
@@ -1,0 +1,1019 @@
+/**
+ * \file
+ *
+ * \brief Component description for PM
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_PM_COMPONENT_
+#define _SAM4L_PM_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PM */
+/* ========================================================================== */
+/** \addtogroup SAM4L_PM Power Manager */
+/*@{*/
+
+#define PM_I7146
+#define REV_PM                      0x441
+
+/* -------- PM_MCCTRL : (PM Offset: 0x000) (R/W 32) Main Clock Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t MCSEL:3;          /*!< bit:  0.. 2  Main Clock Select                  */
+    uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_MCCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_MCCTRL_OFFSET            0x000        /**< \brief (PM_MCCTRL offset) Main Clock Control */
+#define PM_MCCTRL_RESETVALUE        _U(0x00000000); /**< \brief (PM_MCCTRL reset_value) Main Clock Control */
+
+#define PM_MCCTRL_MCSEL_Pos         0            /**< \brief (PM_MCCTRL) Main Clock Select */
+#define PM_MCCTRL_MCSEL_Msk         (_U(0x7) << PM_MCCTRL_MCSEL_Pos)
+#define PM_MCCTRL_MCSEL(value)      (PM_MCCTRL_MCSEL_Msk & ((value) << PM_MCCTRL_MCSEL_Pos))
+#define PM_MCCTRL_MASK              _U(0x00000007) /**< \brief (PM_MCCTRL) MASK Register */
+
+/* -------- PM_CPUSEL : (PM Offset: 0x004) (R/W 32) CPU Clock Select -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CPUSEL:3;         /*!< bit:  0.. 2  CPU Clock Select                   */
+    uint32_t :4;               /*!< bit:  3.. 6  Reserved                           */
+    uint32_t CPUDIV:1;         /*!< bit:      7  CPU Division                       */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_CPUSEL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_CPUSEL_OFFSET            0x004        /**< \brief (PM_CPUSEL offset) CPU Clock Select */
+#define PM_CPUSEL_RESETVALUE        _U(0x00000000); /**< \brief (PM_CPUSEL reset_value) CPU Clock Select */
+
+#define PM_CPUSEL_CPUSEL_Pos        0            /**< \brief (PM_CPUSEL) CPU Clock Select */
+#define PM_CPUSEL_CPUSEL_Msk        (_U(0x7) << PM_CPUSEL_CPUSEL_Pos)
+#define PM_CPUSEL_CPUSEL(value)     (PM_CPUSEL_CPUSEL_Msk & ((value) << PM_CPUSEL_CPUSEL_Pos))
+#define   PM_CPUSEL_CPUSEL_0_Val          _U(0x0)   /**< \brief (PM_CPUSEL) fCPU:fmain. CPUDIV: */
+#define   PM_CPUSEL_CPUSEL_1_Val          _U(0x1)   /**< \brief (PM_CPUSEL) fCPU:fmain / 2^(CPUSEL+1) */
+#define PM_CPUSEL_CPUSEL_0          (PM_CPUSEL_CPUSEL_0_Val        << PM_CPUSEL_CPUSEL_Pos)
+#define PM_CPUSEL_CPUSEL_1          (PM_CPUSEL_CPUSEL_1_Val        << PM_CPUSEL_CPUSEL_Pos)
+#define PM_CPUSEL_CPUDIV_Pos        7            /**< \brief (PM_CPUSEL) CPU Division */
+#define PM_CPUSEL_CPUDIV            (_U(0x1) << PM_CPUSEL_CPUDIV_Pos)
+#define PM_CPUSEL_MASK              _U(0x00000087) /**< \brief (PM_CPUSEL) MASK Register */
+
+/* -------- PM_PBASEL : (PM Offset: 0x00C) (R/W 32) PBA Clock Select -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PBSEL:3;          /*!< bit:  0.. 2  PBA Clock Select                   */
+    uint32_t :4;               /*!< bit:  3.. 6  Reserved                           */
+    uint32_t PBDIV:1;          /*!< bit:      7  PBA Division Select                */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_PBASEL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_PBASEL_OFFSET            0x00C        /**< \brief (PM_PBASEL offset) PBA Clock Select */
+#define PM_PBASEL_RESETVALUE        _U(0x00000000); /**< \brief (PM_PBASEL reset_value) PBA Clock Select */
+
+#define PM_PBASEL_PBSEL_Pos         0            /**< \brief (PM_PBASEL) PBA Clock Select */
+#define PM_PBASEL_PBSEL_Msk         (_U(0x7) << PM_PBASEL_PBSEL_Pos)
+#define PM_PBASEL_PBSEL(value)      (PM_PBASEL_PBSEL_Msk & ((value) << PM_PBASEL_PBSEL_Pos))
+#define PM_PBASEL_PBDIV_Pos         7            /**< \brief (PM_PBASEL) PBA Division Select */
+#define PM_PBASEL_PBDIV             (_U(0x1) << PM_PBASEL_PBDIV_Pos)
+#define PM_PBASEL_MASK              _U(0x00000087) /**< \brief (PM_PBASEL) MASK Register */
+
+/* -------- PM_PBBSEL : (PM Offset: 0x010) (R/W 32) PBB Clock Select -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PBSEL:3;          /*!< bit:  0.. 2  PBB Clock Select                   */
+    uint32_t :4;               /*!< bit:  3.. 6  Reserved                           */
+    uint32_t PBDIV:1;          /*!< bit:      7  PBB Division Select                */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_PBBSEL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_PBBSEL_OFFSET            0x010        /**< \brief (PM_PBBSEL offset) PBB Clock Select */
+#define PM_PBBSEL_RESETVALUE        _U(0x00000000); /**< \brief (PM_PBBSEL reset_value) PBB Clock Select */
+
+#define PM_PBBSEL_PBSEL_Pos         0            /**< \brief (PM_PBBSEL) PBB Clock Select */
+#define PM_PBBSEL_PBSEL_Msk         (_U(0x7) << PM_PBBSEL_PBSEL_Pos)
+#define PM_PBBSEL_PBSEL(value)      (PM_PBBSEL_PBSEL_Msk & ((value) << PM_PBBSEL_PBSEL_Pos))
+#define PM_PBBSEL_PBDIV_Pos         7            /**< \brief (PM_PBBSEL) PBB Division Select */
+#define PM_PBBSEL_PBDIV             (_U(0x1) << PM_PBBSEL_PBDIV_Pos)
+#define PM_PBBSEL_MASK              _U(0x00000087) /**< \brief (PM_PBBSEL) MASK Register */
+
+/* -------- PM_PBCSEL : (PM Offset: 0x014) (R/W 32) PBC Clock Select -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PBSEL:3;          /*!< bit:  0.. 2  PBC Clock Select                   */
+    uint32_t :4;               /*!< bit:  3.. 6  Reserved                           */
+    uint32_t PBDIV:1;          /*!< bit:      7  PBC Division Select                */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_PBCSEL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_PBCSEL_OFFSET            0x014        /**< \brief (PM_PBCSEL offset) PBC Clock Select */
+#define PM_PBCSEL_RESETVALUE        _U(0x00000000); /**< \brief (PM_PBCSEL reset_value) PBC Clock Select */
+
+#define PM_PBCSEL_PBSEL_Pos         0            /**< \brief (PM_PBCSEL) PBC Clock Select */
+#define PM_PBCSEL_PBSEL_Msk         (_U(0x7) << PM_PBCSEL_PBSEL_Pos)
+#define PM_PBCSEL_PBSEL(value)      (PM_PBCSEL_PBSEL_Msk & ((value) << PM_PBCSEL_PBSEL_Pos))
+#define PM_PBCSEL_PBDIV_Pos         7            /**< \brief (PM_PBCSEL) PBC Division Select */
+#define PM_PBCSEL_PBDIV             (_U(0x1) << PM_PBCSEL_PBDIV_Pos)
+#define PM_PBCSEL_MASK              _U(0x00000087) /**< \brief (PM_PBCSEL) MASK Register */
+
+/* -------- PM_PBDSEL : (PM Offset: 0x018) (R/W 32) PBD Clock Select -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PBSEL:3;          /*!< bit:  0.. 2  PBD Clock Select                   */
+    uint32_t :4;               /*!< bit:  3.. 6  Reserved                           */
+    uint32_t PBDIV:1;          /*!< bit:      7  PBD Division Select                */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_PBDSEL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_PBDSEL_OFFSET            0x018        /**< \brief (PM_PBDSEL offset) PBD Clock Select */
+#define PM_PBDSEL_RESETVALUE        _U(0x00000000); /**< \brief (PM_PBDSEL reset_value) PBD Clock Select */
+
+#define PM_PBDSEL_PBSEL_Pos         0            /**< \brief (PM_PBDSEL) PBD Clock Select */
+#define PM_PBDSEL_PBSEL_Msk         (_U(0x7) << PM_PBDSEL_PBSEL_Pos)
+#define PM_PBDSEL_PBSEL(value)      (PM_PBDSEL_PBSEL_Msk & ((value) << PM_PBDSEL_PBSEL_Pos))
+#define PM_PBDSEL_PBDIV_Pos         7            /**< \brief (PM_PBDSEL) PBD Division Select */
+#define PM_PBDSEL_PBDIV             (_U(0x1) << PM_PBDSEL_PBDIV_Pos)
+#define PM_PBDSEL_MASK              _U(0x00000087) /**< \brief (PM_PBDSEL) MASK Register */
+
+/* -------- PM_CPUMASK : (PM Offset: 0x020) (R/W 32) CPU Mask -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OCD:1;            /*!< bit:      0  OCD CPU Clock Mask                 */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_CPUMASK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_CPUMASK_OFFSET           0x020        /**< \brief (PM_CPUMASK offset) CPU Mask */
+#define PM_CPUMASK_RESETVALUE       _U(0x00000001); /**< \brief (PM_CPUMASK reset_value) CPU Mask */
+
+#define PM_CPUMASK_OCD_Pos          0            /**< \brief (PM_CPUMASK) OCD CPU Clock Mask */
+#define PM_CPUMASK_OCD              (_U(0x1) << PM_CPUMASK_OCD_Pos)
+#define PM_CPUMASK_MASK             _U(0x00000001) /**< \brief (PM_CPUMASK) MASK Register */
+
+/* -------- PM_HSBMASK : (PM Offset: 0x024) (R/W 32) HSB Mask -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PDCA_:1;          /*!< bit:      0  PDCA HSB Clock Mask                */
+    uint32_t HFLASHC_:1;       /*!< bit:      1  HFLASHC HSB Clock Mask             */
+    uint32_t HRAMC1_:1;        /*!< bit:      2  HRAMC1 HSB Clock Mask              */
+    uint32_t USBC_:1;          /*!< bit:      3  USBC HSB Clock Mask                */
+    uint32_t CRCCU_:1;         /*!< bit:      4  CRCCU HSB Clock Mask               */
+    uint32_t HTOP0_:1;         /*!< bit:      5  HTOP0 HSB Clock Mask               */
+    uint32_t HTOP1_:1;         /*!< bit:      6  HTOP1 HSB Clock Mask               */
+    uint32_t HTOP2_:1;         /*!< bit:      7  HTOP2 HSB Clock Mask               */
+    uint32_t HTOP3_:1;         /*!< bit:      8  HTOP3 HSB Clock Mask               */
+    uint32_t AESA_:1;          /*!< bit:      9  AESA HSB Clock Mask                */
+    uint32_t :22;              /*!< bit: 10..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_HSBMASK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_HSBMASK_OFFSET           0x024        /**< \brief (PM_HSBMASK offset) HSB Mask */
+#define PM_HSBMASK_RESETVALUE       _U(0x000001E2); /**< \brief (PM_HSBMASK reset_value) HSB Mask */
+
+#define PM_HSBMASK_PDCA_Pos         0            /**< \brief (PM_HSBMASK) PDCA HSB Clock Mask */
+#define PM_HSBMASK_PDCA             (_U(0x1) << PM_HSBMASK_PDCA_Pos)
+#define PM_HSBMASK_HFLASHC_Pos      1            /**< \brief (PM_HSBMASK) HFLASHC HSB Clock Mask */
+#define PM_HSBMASK_HFLASHC          (_U(0x1) << PM_HSBMASK_HFLASHC_Pos)
+#define PM_HSBMASK_HRAMC1_Pos       2            /**< \brief (PM_HSBMASK) HRAMC1 HSB Clock Mask */
+#define PM_HSBMASK_HRAMC1           (_U(0x1) << PM_HSBMASK_HRAMC1_Pos)
+#define PM_HSBMASK_USBC_Pos         3            /**< \brief (PM_HSBMASK) USBC HSB Clock Mask */
+#define PM_HSBMASK_USBC             (_U(0x1) << PM_HSBMASK_USBC_Pos)
+#define PM_HSBMASK_CRCCU_Pos        4            /**< \brief (PM_HSBMASK) CRCCU HSB Clock Mask */
+#define PM_HSBMASK_CRCCU            (_U(0x1) << PM_HSBMASK_CRCCU_Pos)
+#define PM_HSBMASK_HTOP0_Pos        5            /**< \brief (PM_HSBMASK) HTOP0 HSB Clock Mask */
+#define PM_HSBMASK_HTOP0            (_U(0x1) << PM_HSBMASK_HTOP0_Pos)
+#define PM_HSBMASK_HTOP1_Pos        6            /**< \brief (PM_HSBMASK) HTOP1 HSB Clock Mask */
+#define PM_HSBMASK_HTOP1            (_U(0x1) << PM_HSBMASK_HTOP1_Pos)
+#define PM_HSBMASK_HTOP2_Pos        7            /**< \brief (PM_HSBMASK) HTOP2 HSB Clock Mask */
+#define PM_HSBMASK_HTOP2            (_U(0x1) << PM_HSBMASK_HTOP2_Pos)
+#define PM_HSBMASK_HTOP3_Pos        8            /**< \brief (PM_HSBMASK) HTOP3 HSB Clock Mask */
+#define PM_HSBMASK_HTOP3            (_U(0x1) << PM_HSBMASK_HTOP3_Pos)
+#define PM_HSBMASK_AESA_Pos         9            /**< \brief (PM_HSBMASK) AESA HSB Clock Mask */
+#define PM_HSBMASK_AESA             (_U(0x1) << PM_HSBMASK_AESA_Pos)
+#define PM_HSBMASK_MASK             _U(0x000003FF) /**< \brief (PM_HSBMASK) MASK Register */
+
+/* -------- PM_PBAMASK : (PM Offset: 0x028) (R/W 32) PBA Mask -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t IISC_:1;          /*!< bit:      0  IISC APB Clock Enable              */
+    uint32_t SPI_:1;           /*!< bit:      1  SPI APB Clock Enable               */
+    uint32_t TC0_:1;           /*!< bit:      2  TC0 APB Clock Enable               */
+    uint32_t TC1_:1;           /*!< bit:      3  TC1 APB Clock Enable               */
+    uint32_t TWIM0_:1;         /*!< bit:      4  TWIM0 APB Clock Enable             */
+    uint32_t TWIS0_:1;         /*!< bit:      5  TWIS0 APB Clock Enable             */
+    uint32_t TWIM1_:1;         /*!< bit:      6  TWIM1 APB Clock Enable             */
+    uint32_t TWIS1_:1;         /*!< bit:      7  TWIS1 APB Clock Enable             */
+    uint32_t USART0_:1;        /*!< bit:      8  USART0 APB Clock Enable            */
+    uint32_t USART1_:1;        /*!< bit:      9  USART1 APB Clock Enable            */
+    uint32_t USART2_:1;        /*!< bit:     10  USART2 APB Clock Enable            */
+    uint32_t USART3_:1;        /*!< bit:     11  USART3 APB Clock Enable            */
+    uint32_t ADCIFE_:1;        /*!< bit:     12  ADCIFE APB Clock Enable            */
+    uint32_t DACC_:1;          /*!< bit:     13  DACC APB Clock Enable              */
+    uint32_t ACIFC_:1;         /*!< bit:     14  ACIFC APB Clock Enable             */
+    uint32_t GLOC_:1;          /*!< bit:     15  GLOC APB Clock Enable              */
+    uint32_t ABDACB_:1;        /*!< bit:     16  ABDACB APB Clock Enable            */
+    uint32_t TRNG_:1;          /*!< bit:     17  TRNG APB Clock Enable              */
+    uint32_t PARC_:1;          /*!< bit:     18  PARC APB Clock Enable              */
+    uint32_t CATB_:1;          /*!< bit:     19  CATB APB Clock Enable              */
+    uint32_t :1;               /*!< bit:     20  Reserved                           */
+    uint32_t TWIM2_:1;         /*!< bit:     21  TWIM2 APB Clock Enable             */
+    uint32_t TWIM3_:1;         /*!< bit:     22  TWIM3 APB Clock Enable             */
+    uint32_t LCDCA_:1;         /*!< bit:     23  LCDCA APB Clock Enable             */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_PBAMASK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_PBAMASK_OFFSET           0x028        /**< \brief (PM_PBAMASK offset) PBA Mask */
+#define PM_PBAMASK_RESETVALUE       _U(0x00000000); /**< \brief (PM_PBAMASK reset_value) PBA Mask */
+
+#define PM_PBAMASK_IISC_Pos         0            /**< \brief (PM_PBAMASK) IISC APB Clock Enable */
+#define PM_PBAMASK_IISC             (_U(0x1) << PM_PBAMASK_IISC_Pos)
+#define PM_PBAMASK_SPI_Pos          1            /**< \brief (PM_PBAMASK) SPI APB Clock Enable */
+#define PM_PBAMASK_SPI              (_U(0x1) << PM_PBAMASK_SPI_Pos)
+#define PM_PBAMASK_TC0_Pos          2            /**< \brief (PM_PBAMASK) TC0 APB Clock Enable */
+#define PM_PBAMASK_TC0              (_U(0x1) << PM_PBAMASK_TC0_Pos)
+#define PM_PBAMASK_TC1_Pos          3            /**< \brief (PM_PBAMASK) TC1 APB Clock Enable */
+#define PM_PBAMASK_TC1              (_U(0x1) << PM_PBAMASK_TC1_Pos)
+#define PM_PBAMASK_TWIM0_Pos        4            /**< \brief (PM_PBAMASK) TWIM0 APB Clock Enable */
+#define PM_PBAMASK_TWIM0            (_U(0x1) << PM_PBAMASK_TWIM0_Pos)
+#define PM_PBAMASK_TWIS0_Pos        5            /**< \brief (PM_PBAMASK) TWIS0 APB Clock Enable */
+#define PM_PBAMASK_TWIS0            (_U(0x1) << PM_PBAMASK_TWIS0_Pos)
+#define PM_PBAMASK_TWIM1_Pos        6            /**< \brief (PM_PBAMASK) TWIM1 APB Clock Enable */
+#define PM_PBAMASK_TWIM1            (_U(0x1) << PM_PBAMASK_TWIM1_Pos)
+#define PM_PBAMASK_TWIS1_Pos        7            /**< \brief (PM_PBAMASK) TWIS1 APB Clock Enable */
+#define PM_PBAMASK_TWIS1            (_U(0x1) << PM_PBAMASK_TWIS1_Pos)
+#define PM_PBAMASK_USART0_Pos       8            /**< \brief (PM_PBAMASK) USART0 APB Clock Enable */
+#define PM_PBAMASK_USART0           (_U(0x1) << PM_PBAMASK_USART0_Pos)
+#define PM_PBAMASK_USART1_Pos       9            /**< \brief (PM_PBAMASK) USART1 APB Clock Enable */
+#define PM_PBAMASK_USART1           (_U(0x1) << PM_PBAMASK_USART1_Pos)
+#define PM_PBAMASK_USART2_Pos       10           /**< \brief (PM_PBAMASK) USART2 APB Clock Enable */
+#define PM_PBAMASK_USART2           (_U(0x1) << PM_PBAMASK_USART2_Pos)
+#define PM_PBAMASK_USART3_Pos       11           /**< \brief (PM_PBAMASK) USART3 APB Clock Enable */
+#define PM_PBAMASK_USART3           (_U(0x1) << PM_PBAMASK_USART3_Pos)
+#define PM_PBAMASK_ADCIFE_Pos       12           /**< \brief (PM_PBAMASK) ADCIFE APB Clock Enable */
+#define PM_PBAMASK_ADCIFE           (_U(0x1) << PM_PBAMASK_ADCIFE_Pos)
+#define PM_PBAMASK_DACC_Pos         13           /**< \brief (PM_PBAMASK) DACC APB Clock Enable */
+#define PM_PBAMASK_DACC             (_U(0x1) << PM_PBAMASK_DACC_Pos)
+#define PM_PBAMASK_ACIFC_Pos        14           /**< \brief (PM_PBAMASK) ACIFC APB Clock Enable */
+#define PM_PBAMASK_ACIFC            (_U(0x1) << PM_PBAMASK_ACIFC_Pos)
+#define PM_PBAMASK_GLOC_Pos         15           /**< \brief (PM_PBAMASK) GLOC APB Clock Enable */
+#define PM_PBAMASK_GLOC             (_U(0x1) << PM_PBAMASK_GLOC_Pos)
+#define PM_PBAMASK_ABDACB_Pos       16           /**< \brief (PM_PBAMASK) ABDACB APB Clock Enable */
+#define PM_PBAMASK_ABDACB           (_U(0x1) << PM_PBAMASK_ABDACB_Pos)
+#define PM_PBAMASK_TRNG_Pos         17           /**< \brief (PM_PBAMASK) TRNG APB Clock Enable */
+#define PM_PBAMASK_TRNG             (_U(0x1) << PM_PBAMASK_TRNG_Pos)
+#define PM_PBAMASK_PARC_Pos         18           /**< \brief (PM_PBAMASK) PARC APB Clock Enable */
+#define PM_PBAMASK_PARC             (_U(0x1) << PM_PBAMASK_PARC_Pos)
+#define PM_PBAMASK_CATB_Pos         19           /**< \brief (PM_PBAMASK) CATB APB Clock Enable */
+#define PM_PBAMASK_CATB             (_U(0x1) << PM_PBAMASK_CATB_Pos)
+#define PM_PBAMASK_TWIM2_Pos        21           /**< \brief (PM_PBAMASK) TWIM2 APB Clock Enable */
+#define PM_PBAMASK_TWIM2            (_U(0x1) << PM_PBAMASK_TWIM2_Pos)
+#define PM_PBAMASK_TWIM3_Pos        22           /**< \brief (PM_PBAMASK) TWIM3 APB Clock Enable */
+#define PM_PBAMASK_TWIM3            (_U(0x1) << PM_PBAMASK_TWIM3_Pos)
+#define PM_PBAMASK_LCDCA_Pos        23           /**< \brief (PM_PBAMASK) LCDCA APB Clock Enable */
+#define PM_PBAMASK_LCDCA            (_U(0x1) << PM_PBAMASK_LCDCA_Pos)
+#define PM_PBAMASK_MASK             _U(0x00EFFFFF) /**< \brief (PM_PBAMASK) MASK Register */
+
+/* -------- PM_PBBMASK : (PM Offset: 0x02C) (R/W 32) PBB Mask -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t HFLASHC_:1;       /*!< bit:      0  HFLASHC APB Clock Enable           */
+    uint32_t HCACHE_:1;        /*!< bit:      1  HCACHE APB Clock Enable            */
+    uint32_t HMATRIX_:1;       /*!< bit:      2  HMATRIX APB Clock Enable           */
+    uint32_t PDCA_:1;          /*!< bit:      3  PDCA APB Clock Enable              */
+    uint32_t CRCCU_:1;         /*!< bit:      4  CRCCU APB Clock Enable             */
+    uint32_t USBC_:1;          /*!< bit:      5  USBC APB Clock Enable              */
+    uint32_t PEVC_:1;          /*!< bit:      6  PEVC APB Clock Enable              */
+    uint32_t :25;              /*!< bit:  7..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_PBBMASK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_PBBMASK_OFFSET           0x02C        /**< \brief (PM_PBBMASK offset) PBB Mask */
+#define PM_PBBMASK_RESETVALUE       _U(0x00000001); /**< \brief (PM_PBBMASK reset_value) PBB Mask */
+
+#define PM_PBBMASK_HFLASHC_Pos      0            /**< \brief (PM_PBBMASK) HFLASHC APB Clock Enable */
+#define PM_PBBMASK_HFLASHC          (_U(0x1) << PM_PBBMASK_HFLASHC_Pos)
+#define PM_PBBMASK_HCACHE_Pos       1            /**< \brief (PM_PBBMASK) HCACHE APB Clock Enable */
+#define PM_PBBMASK_HCACHE           (_U(0x1) << PM_PBBMASK_HCACHE_Pos)
+#define PM_PBBMASK_HMATRIX_Pos      2            /**< \brief (PM_PBBMASK) HMATRIX APB Clock Enable */
+#define PM_PBBMASK_HMATRIX          (_U(0x1) << PM_PBBMASK_HMATRIX_Pos)
+#define PM_PBBMASK_PDCA_Pos         3            /**< \brief (PM_PBBMASK) PDCA APB Clock Enable */
+#define PM_PBBMASK_PDCA             (_U(0x1) << PM_PBBMASK_PDCA_Pos)
+#define PM_PBBMASK_CRCCU_Pos        4            /**< \brief (PM_PBBMASK) CRCCU APB Clock Enable */
+#define PM_PBBMASK_CRCCU            (_U(0x1) << PM_PBBMASK_CRCCU_Pos)
+#define PM_PBBMASK_USBC_Pos         5            /**< \brief (PM_PBBMASK) USBC APB Clock Enable */
+#define PM_PBBMASK_USBC             (_U(0x1) << PM_PBBMASK_USBC_Pos)
+#define PM_PBBMASK_PEVC_Pos         6            /**< \brief (PM_PBBMASK) PEVC APB Clock Enable */
+#define PM_PBBMASK_PEVC             (_U(0x1) << PM_PBBMASK_PEVC_Pos)
+#define PM_PBBMASK_MASK             _U(0x0000007F) /**< \brief (PM_PBBMASK) MASK Register */
+
+/* -------- PM_PBCMASK : (PM Offset: 0x030) (R/W 32) PBC Mask -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PM_:1;            /*!< bit:      0  PM APB Clock Enable                */
+    uint32_t CHIPID_:1;        /*!< bit:      1  CHIPID APB Clock Enable            */
+    uint32_t SCIF_:1;          /*!< bit:      2  SCIF APB Clock Enable              */
+    uint32_t FREQM_:1;         /*!< bit:      3  FREQM APB Clock Enable             */
+    uint32_t GPIO_:1;          /*!< bit:      4  GPIO APB Clock Enable              */
+    uint32_t :27;              /*!< bit:  5..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_PBCMASK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_PBCMASK_OFFSET           0x030        /**< \brief (PM_PBCMASK offset) PBC Mask */
+#define PM_PBCMASK_RESETVALUE       _U(0x0000001F); /**< \brief (PM_PBCMASK reset_value) PBC Mask */
+
+#define PM_PBCMASK_PM_Pos           0            /**< \brief (PM_PBCMASK) PM APB Clock Enable */
+#define PM_PBCMASK_PM               (_U(0x1) << PM_PBCMASK_PM_Pos)
+#define PM_PBCMASK_CHIPID_Pos       1            /**< \brief (PM_PBCMASK) CHIPID APB Clock Enable */
+#define PM_PBCMASK_CHIPID           (_U(0x1) << PM_PBCMASK_CHIPID_Pos)
+#define PM_PBCMASK_SCIF_Pos         2            /**< \brief (PM_PBCMASK) SCIF APB Clock Enable */
+#define PM_PBCMASK_SCIF             (_U(0x1) << PM_PBCMASK_SCIF_Pos)
+#define PM_PBCMASK_FREQM_Pos        3            /**< \brief (PM_PBCMASK) FREQM APB Clock Enable */
+#define PM_PBCMASK_FREQM            (_U(0x1) << PM_PBCMASK_FREQM_Pos)
+#define PM_PBCMASK_GPIO_Pos         4            /**< \brief (PM_PBCMASK) GPIO APB Clock Enable */
+#define PM_PBCMASK_GPIO             (_U(0x1) << PM_PBCMASK_GPIO_Pos)
+#define PM_PBCMASK_MASK             _U(0x0000001F) /**< \brief (PM_PBCMASK) MASK Register */
+
+/* -------- PM_PBDMASK : (PM Offset: 0x034) (R/W 32) PBD Mask -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t BPM_:1;           /*!< bit:      0  BPM APB Clock Enable               */
+    uint32_t BSCIF_:1;         /*!< bit:      1  BSCIF APB Clock Enable             */
+    uint32_t AST_:1;           /*!< bit:      2  AST APB Clock Enable               */
+    uint32_t WDT_:1;           /*!< bit:      3  WDT APB Clock Enable               */
+    uint32_t EIC_:1;           /*!< bit:      4  EIC APB Clock Enable               */
+    uint32_t PICOUART_:1;      /*!< bit:      5  PICOUART APB Clock Enable          */
+    uint32_t :26;              /*!< bit:  6..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_PBDMASK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_PBDMASK_OFFSET           0x034        /**< \brief (PM_PBDMASK offset) PBD Mask */
+#define PM_PBDMASK_RESETVALUE       _U(0x0000003F); /**< \brief (PM_PBDMASK reset_value) PBD Mask */
+
+#define PM_PBDMASK_BPM_Pos          0            /**< \brief (PM_PBDMASK) BPM APB Clock Enable */
+#define PM_PBDMASK_BPM              (_U(0x1) << PM_PBDMASK_BPM_Pos)
+#define PM_PBDMASK_BSCIF_Pos        1            /**< \brief (PM_PBDMASK) BSCIF APB Clock Enable */
+#define PM_PBDMASK_BSCIF            (_U(0x1) << PM_PBDMASK_BSCIF_Pos)
+#define PM_PBDMASK_AST_Pos          2            /**< \brief (PM_PBDMASK) AST APB Clock Enable */
+#define PM_PBDMASK_AST              (_U(0x1) << PM_PBDMASK_AST_Pos)
+#define PM_PBDMASK_WDT_Pos          3            /**< \brief (PM_PBDMASK) WDT APB Clock Enable */
+#define PM_PBDMASK_WDT              (_U(0x1) << PM_PBDMASK_WDT_Pos)
+#define PM_PBDMASK_EIC_Pos          4            /**< \brief (PM_PBDMASK) EIC APB Clock Enable */
+#define PM_PBDMASK_EIC              (_U(0x1) << PM_PBDMASK_EIC_Pos)
+#define PM_PBDMASK_PICOUART_Pos     5            /**< \brief (PM_PBDMASK) PICOUART APB Clock Enable */
+#define PM_PBDMASK_PICOUART         (_U(0x1) << PM_PBDMASK_PICOUART_Pos)
+#define PM_PBDMASK_MASK             _U(0x0000003F) /**< \brief (PM_PBDMASK) MASK Register */
+
+/* -------- PM_PBADIVMASK : (PM Offset: 0x040) (R/W 32) PBA Divided Clock Mask -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_PBADIVMASK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_PBADIVMASK_OFFSET        0x040        /**< \brief (PM_PBADIVMASK offset) PBA Divided Clock Mask */
+#define PM_PBADIVMASK_RESETVALUE    _U(0x00000000); /**< \brief (PM_PBADIVMASK reset_value) PBA Divided Clock Mask */
+#define PM_PBADIVMASK_MASK          _U(0xFFFFFFFF) /**< \brief (PM_PBADIVMASK) MASK Register */
+
+/* -------- PM_CFDCTRL : (PM Offset: 0x054) (R/W 32) Clock Failure Detector Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CFDEN:1;          /*!< bit:      0  Clock Failure Detection Enable     */
+    uint32_t :30;              /*!< bit:  1..30  Reserved                           */
+    uint32_t SFV:1;            /*!< bit:     31  Store Final Value                  */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_CFDCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_CFDCTRL_OFFSET           0x054        /**< \brief (PM_CFDCTRL offset) Clock Failure Detector Control */
+#define PM_CFDCTRL_RESETVALUE       _U(0x00000000); /**< \brief (PM_CFDCTRL reset_value) Clock Failure Detector Control */
+
+#define PM_CFDCTRL_CFDEN_Pos        0            /**< \brief (PM_CFDCTRL) Clock Failure Detection Enable */
+#define PM_CFDCTRL_CFDEN            (_U(0x1) << PM_CFDCTRL_CFDEN_Pos)
+#define PM_CFDCTRL_SFV_Pos          31           /**< \brief (PM_CFDCTRL) Store Final Value */
+#define PM_CFDCTRL_SFV              (_U(0x1) << PM_CFDCTRL_SFV_Pos)
+#define PM_CFDCTRL_MASK             _U(0x80000001) /**< \brief (PM_CFDCTRL) MASK Register */
+
+/* -------- PM_UNLOCK : (PM Offset: 0x058) ( /W 32) Unlock Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ADDR:10;          /*!< bit:  0.. 9  Unlock Address                     */
+    uint32_t :14;              /*!< bit: 10..23  Reserved                           */
+    uint32_t KEY:8;            /*!< bit: 24..31  Unlock Key                         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_UNLOCK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_UNLOCK_OFFSET            0x058        /**< \brief (PM_UNLOCK offset) Unlock Register */
+#define PM_UNLOCK_RESETVALUE        _U(0x00000000); /**< \brief (PM_UNLOCK reset_value) Unlock Register */
+
+#define PM_UNLOCK_ADDR_Pos          0            /**< \brief (PM_UNLOCK) Unlock Address */
+#define PM_UNLOCK_ADDR_Msk          (_U(0x3FF) << PM_UNLOCK_ADDR_Pos)
+#define PM_UNLOCK_ADDR(value)       (PM_UNLOCK_ADDR_Msk & ((value) << PM_UNLOCK_ADDR_Pos))
+#define PM_UNLOCK_KEY_Pos           24           /**< \brief (PM_UNLOCK) Unlock Key */
+#define PM_UNLOCK_KEY_Msk           (_U(0xFF) << PM_UNLOCK_KEY_Pos)
+#define PM_UNLOCK_KEY(value)        (PM_UNLOCK_KEY_Msk & ((value) << PM_UNLOCK_KEY_Pos))
+#define PM_UNLOCK_MASK              _U(0xFF0003FF) /**< \brief (PM_UNLOCK) MASK Register */
+
+/* -------- PM_IER : (PM Offset: 0x0C0) ( /W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CFD:1;            /*!< bit:      0  Clock Failure Detected Interrupt Enable */
+    uint32_t :4;               /*!< bit:  1.. 4  Reserved                           */
+    uint32_t CKRDY:1;          /*!< bit:      5  Clock Ready Interrupt Enable       */
+    uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t WAKE:1;           /*!< bit:      8  Wake up Interrupt Enable           */
+    uint32_t :22;              /*!< bit:  9..30  Reserved                           */
+    uint32_t AE:1;             /*!< bit:     31  Access Error Interrupt Enable      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_IER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_IER_OFFSET               0x0C0        /**< \brief (PM_IER offset) Interrupt Enable Register */
+#define PM_IER_RESETVALUE           _U(0x00000000); /**< \brief (PM_IER reset_value) Interrupt Enable Register */
+
+#define PM_IER_CFD_Pos              0            /**< \brief (PM_IER) Clock Failure Detected Interrupt Enable */
+#define PM_IER_CFD                  (_U(0x1) << PM_IER_CFD_Pos)
+#define PM_IER_CKRDY_Pos            5            /**< \brief (PM_IER) Clock Ready Interrupt Enable */
+#define PM_IER_CKRDY                (_U(0x1) << PM_IER_CKRDY_Pos)
+#define PM_IER_WAKE_Pos             8            /**< \brief (PM_IER) Wake up Interrupt Enable */
+#define PM_IER_WAKE                 (_U(0x1) << PM_IER_WAKE_Pos)
+#define   PM_IER_WAKE_0_Val               _U(0x0)   /**< \brief (PM_IER) No effect */
+#define   PM_IER_WAKE_1_Val               _U(0x1)   /**< \brief (PM_IER) Disable Interrupt. */
+#define PM_IER_WAKE_0               (PM_IER_WAKE_0_Val             << PM_IER_WAKE_Pos)
+#define PM_IER_WAKE_1               (PM_IER_WAKE_1_Val             << PM_IER_WAKE_Pos)
+#define PM_IER_AE_Pos               31           /**< \brief (PM_IER) Access Error Interrupt Enable */
+#define PM_IER_AE                   (_U(0x1) << PM_IER_AE_Pos)
+#define PM_IER_MASK                 _U(0x80000121) /**< \brief (PM_IER) MASK Register */
+
+/* -------- PM_IDR : (PM Offset: 0x0C4) ( /W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CFD:1;            /*!< bit:      0  Clock Failure Detected Interrupt Disable */
+    uint32_t :4;               /*!< bit:  1.. 4  Reserved                           */
+    uint32_t CKRDY:1;          /*!< bit:      5  Clock Ready Interrupt Disable      */
+    uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t WAKE:1;           /*!< bit:      8  Wake up Interrupt Disable          */
+    uint32_t :22;              /*!< bit:  9..30  Reserved                           */
+    uint32_t AE:1;             /*!< bit:     31  Access Error Interrupt Disable     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_IDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_IDR_OFFSET               0x0C4        /**< \brief (PM_IDR offset) Interrupt Disable Register */
+#define PM_IDR_RESETVALUE           _U(0x00000000); /**< \brief (PM_IDR reset_value) Interrupt Disable Register */
+
+#define PM_IDR_CFD_Pos              0            /**< \brief (PM_IDR) Clock Failure Detected Interrupt Disable */
+#define PM_IDR_CFD                  (_U(0x1) << PM_IDR_CFD_Pos)
+#define PM_IDR_CKRDY_Pos            5            /**< \brief (PM_IDR) Clock Ready Interrupt Disable */
+#define PM_IDR_CKRDY                (_U(0x1) << PM_IDR_CKRDY_Pos)
+#define PM_IDR_WAKE_Pos             8            /**< \brief (PM_IDR) Wake up Interrupt Disable */
+#define PM_IDR_WAKE                 (_U(0x1) << PM_IDR_WAKE_Pos)
+#define   PM_IDR_WAKE_0_Val               _U(0x0)   /**< \brief (PM_IDR) No effect */
+#define   PM_IDR_WAKE_1_Val               _U(0x1)   /**< \brief (PM_IDR) Disable Interrupt. */
+#define PM_IDR_WAKE_0               (PM_IDR_WAKE_0_Val             << PM_IDR_WAKE_Pos)
+#define PM_IDR_WAKE_1               (PM_IDR_WAKE_1_Val             << PM_IDR_WAKE_Pos)
+#define PM_IDR_AE_Pos               31           /**< \brief (PM_IDR) Access Error Interrupt Disable */
+#define PM_IDR_AE                   (_U(0x1) << PM_IDR_AE_Pos)
+#define PM_IDR_MASK                 _U(0x80000121) /**< \brief (PM_IDR) MASK Register */
+
+/* -------- PM_IMR : (PM Offset: 0x0C8) (R/  32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CFD:1;            /*!< bit:      0  Clock Failure Detected Interrupt Mask */
+    uint32_t :4;               /*!< bit:  1.. 4  Reserved                           */
+    uint32_t CKRDY:1;          /*!< bit:      5  Clock Ready Interrupt Mask         */
+    uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t WAKE:1;           /*!< bit:      8  Wake up Interrupt Mask             */
+    uint32_t :22;              /*!< bit:  9..30  Reserved                           */
+    uint32_t AE:1;             /*!< bit:     31  Access Error Interrupt Mask        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_IMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_IMR_OFFSET               0x0C8        /**< \brief (PM_IMR offset) Interrupt Mask Register */
+#define PM_IMR_RESETVALUE           _U(0x00000000); /**< \brief (PM_IMR reset_value) Interrupt Mask Register */
+
+#define PM_IMR_CFD_Pos              0            /**< \brief (PM_IMR) Clock Failure Detected Interrupt Mask */
+#define PM_IMR_CFD                  (_U(0x1) << PM_IMR_CFD_Pos)
+#define PM_IMR_CKRDY_Pos            5            /**< \brief (PM_IMR) Clock Ready Interrupt Mask */
+#define PM_IMR_CKRDY                (_U(0x1) << PM_IMR_CKRDY_Pos)
+#define PM_IMR_WAKE_Pos             8            /**< \brief (PM_IMR) Wake up Interrupt Mask */
+#define PM_IMR_WAKE                 (_U(0x1) << PM_IMR_WAKE_Pos)
+#define   PM_IMR_WAKE_0_Val               _U(0x0)   /**< \brief (PM_IMR) No effect */
+#define   PM_IMR_WAKE_1_Val               _U(0x1)   /**< \brief (PM_IMR) Disable Interrupt. */
+#define PM_IMR_WAKE_0               (PM_IMR_WAKE_0_Val             << PM_IMR_WAKE_Pos)
+#define PM_IMR_WAKE_1               (PM_IMR_WAKE_1_Val             << PM_IMR_WAKE_Pos)
+#define PM_IMR_AE_Pos               31           /**< \brief (PM_IMR) Access Error Interrupt Mask */
+#define PM_IMR_AE                   (_U(0x1) << PM_IMR_AE_Pos)
+#define PM_IMR_MASK                 _U(0x80000121) /**< \brief (PM_IMR) MASK Register */
+
+/* -------- PM_ISR : (PM Offset: 0x0CC) (R/  32) Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CFD:1;            /*!< bit:      0  Clock Failure Detected Interrupt Status */
+    uint32_t :4;               /*!< bit:  1.. 4  Reserved                           */
+    uint32_t CKRDY:1;          /*!< bit:      5  Clock Ready Interrupt Status       */
+    uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t WAKE:1;           /*!< bit:      8  Wake up Interrupt Status           */
+    uint32_t :22;              /*!< bit:  9..30  Reserved                           */
+    uint32_t AE:1;             /*!< bit:     31  Access Error Interrupt Status      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_ISR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_ISR_OFFSET               0x0CC        /**< \brief (PM_ISR offset) Interrupt Status Register */
+#define PM_ISR_RESETVALUE           _U(0x00000000); /**< \brief (PM_ISR reset_value) Interrupt Status Register */
+
+#define PM_ISR_CFD_Pos              0            /**< \brief (PM_ISR) Clock Failure Detected Interrupt Status */
+#define PM_ISR_CFD                  (_U(0x1) << PM_ISR_CFD_Pos)
+#define PM_ISR_CKRDY_Pos            5            /**< \brief (PM_ISR) Clock Ready Interrupt Status */
+#define PM_ISR_CKRDY                (_U(0x1) << PM_ISR_CKRDY_Pos)
+#define PM_ISR_WAKE_Pos             8            /**< \brief (PM_ISR) Wake up Interrupt Status */
+#define PM_ISR_WAKE                 (_U(0x1) << PM_ISR_WAKE_Pos)
+#define   PM_ISR_WAKE_0_Val               _U(0x0)   /**< \brief (PM_ISR) No effect */
+#define   PM_ISR_WAKE_1_Val               _U(0x1)   /**< \brief (PM_ISR) Disable Interrupt. */
+#define PM_ISR_WAKE_0               (PM_ISR_WAKE_0_Val             << PM_ISR_WAKE_Pos)
+#define PM_ISR_WAKE_1               (PM_ISR_WAKE_1_Val             << PM_ISR_WAKE_Pos)
+#define PM_ISR_AE_Pos               31           /**< \brief (PM_ISR) Access Error Interrupt Status */
+#define PM_ISR_AE                   (_U(0x1) << PM_ISR_AE_Pos)
+#define PM_ISR_MASK                 _U(0x80000121) /**< \brief (PM_ISR) MASK Register */
+
+/* -------- PM_ICR : (PM Offset: 0x0D0) ( /W 32) Interrupt Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CFD:1;            /*!< bit:      0  Clock Failure Detected Interrupt Status Clear */
+    uint32_t :4;               /*!< bit:  1.. 4  Reserved                           */
+    uint32_t CKRDY:1;          /*!< bit:      5  Clock Ready Interrupt Status Clear */
+    uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t WAKE:1;           /*!< bit:      8  Wake up Interrupt Status Clear     */
+    uint32_t :22;              /*!< bit:  9..30  Reserved                           */
+    uint32_t AE:1;             /*!< bit:     31  Access Error Interrupt Status Clear */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_ICR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_ICR_OFFSET               0x0D0        /**< \brief (PM_ICR offset) Interrupt Clear Register */
+#define PM_ICR_RESETVALUE           _U(0x00000000); /**< \brief (PM_ICR reset_value) Interrupt Clear Register */
+
+#define PM_ICR_CFD_Pos              0            /**< \brief (PM_ICR) Clock Failure Detected Interrupt Status Clear */
+#define PM_ICR_CFD                  (_U(0x1) << PM_ICR_CFD_Pos)
+#define PM_ICR_CKRDY_Pos            5            /**< \brief (PM_ICR) Clock Ready Interrupt Status Clear */
+#define PM_ICR_CKRDY                (_U(0x1) << PM_ICR_CKRDY_Pos)
+#define PM_ICR_WAKE_Pos             8            /**< \brief (PM_ICR) Wake up Interrupt Status Clear */
+#define PM_ICR_WAKE                 (_U(0x1) << PM_ICR_WAKE_Pos)
+#define PM_ICR_AE_Pos               31           /**< \brief (PM_ICR) Access Error Interrupt Status Clear */
+#define PM_ICR_AE                   (_U(0x1) << PM_ICR_AE_Pos)
+#define PM_ICR_MASK                 _U(0x80000121) /**< \brief (PM_ICR) MASK Register */
+
+/* -------- PM_SR : (PM Offset: 0x0D4) (R/  32) Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CFD:1;            /*!< bit:      0  Clock Failure Detected             */
+    uint32_t OCP:1;            /*!< bit:      1  Over Clock Detected                */
+    uint32_t :3;               /*!< bit:  2.. 4  Reserved                           */
+    uint32_t CKRDY:1;          /*!< bit:      5  Clock Ready                        */
+    uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t WAKE:1;           /*!< bit:      8  Wake up                            */
+    uint32_t :19;              /*!< bit:  9..27  Reserved                           */
+    uint32_t PERRDY:1;         /*!< bit:     28  Peripheral Ready                   */
+    uint32_t :2;               /*!< bit: 29..30  Reserved                           */
+    uint32_t AE:1;             /*!< bit:     31  Access Error                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_SR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_SR_OFFSET                0x0D4        /**< \brief (PM_SR offset) Status Register */
+#define PM_SR_RESETVALUE            _U(0x00000000); /**< \brief (PM_SR reset_value) Status Register */
+
+#define PM_SR_CFD_Pos               0            /**< \brief (PM_SR) Clock Failure Detected */
+#define PM_SR_CFD                   (_U(0x1) << PM_SR_CFD_Pos)
+#define PM_SR_OCP_Pos               1            /**< \brief (PM_SR) Over Clock Detected */
+#define PM_SR_OCP                   (_U(0x1) << PM_SR_OCP_Pos)
+#define PM_SR_CKRDY_Pos             5            /**< \brief (PM_SR) Clock Ready */
+#define PM_SR_CKRDY                 (_U(0x1) << PM_SR_CKRDY_Pos)
+#define PM_SR_WAKE_Pos              8            /**< \brief (PM_SR) Wake up */
+#define PM_SR_WAKE                  (_U(0x1) << PM_SR_WAKE_Pos)
+#define   PM_SR_WAKE_0_Val                _U(0x0)   /**< \brief (PM_SR) No effect */
+#define   PM_SR_WAKE_1_Val                _U(0x1)   /**< \brief (PM_SR) Disable Interrupt. */
+#define PM_SR_WAKE_0                (PM_SR_WAKE_0_Val              << PM_SR_WAKE_Pos)
+#define PM_SR_WAKE_1                (PM_SR_WAKE_1_Val              << PM_SR_WAKE_Pos)
+#define PM_SR_PERRDY_Pos            28           /**< \brief (PM_SR) Peripheral Ready */
+#define PM_SR_PERRDY                (_U(0x1) << PM_SR_PERRDY_Pos)
+#define PM_SR_AE_Pos                31           /**< \brief (PM_SR) Access Error */
+#define PM_SR_AE                    (_U(0x1) << PM_SR_AE_Pos)
+#define PM_SR_MASK                  _U(0x90000123) /**< \brief (PM_SR) MASK Register */
+
+/* -------- PM_PPCR : (PM Offset: 0x160) (R/W 32) Peripheral Power Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RSTPUN:1;         /*!< bit:      0  Reset Pullup                       */
+    uint32_t CATBRCMASK:1;     /*!< bit:      1  CAT Request Clock Mask             */
+    uint32_t ACIFCRCMASK:1;    /*!< bit:      2  ACIFC Request Clock Mask           */
+    uint32_t ASTRCMASK:1;      /*!< bit:      3  AST Request Clock Mask             */
+    uint32_t TWIS0RCMASK:1;    /*!< bit:      4  TWIS0 Request Clock Mask           */
+    uint32_t TWIS1RCMASK:1;    /*!< bit:      5  TWIS1 Request Clock Mask           */
+    uint32_t PEVCRCMASK:1;     /*!< bit:      6  PEVC Request Clock Mask            */
+    uint32_t ADCIFERCMASK:1;   /*!< bit:      7  ADCIFE Request Clock Mask          */
+    uint32_t VREGRCMASK:1;     /*!< bit:      8  VREG Request Clock Mask            */
+    uint32_t FWBGREF:1;        /*!< bit:      9  Flash Wait BGREF                   */
+    uint32_t FWBOD18:1;        /*!< bit:     10  Flash Wait BOD18                   */
+    uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_PPCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_PPCR_OFFSET              0x160        /**< \brief (PM_PPCR offset) Peripheral Power Control Register */
+#define PM_PPCR_RESETVALUE          _U(0x000001FE); /**< \brief (PM_PPCR reset_value) Peripheral Power Control Register */
+
+#define PM_PPCR_RSTPUN_Pos          0            /**< \brief (PM_PPCR) Reset Pullup */
+#define PM_PPCR_RSTPUN              (_U(0x1) << PM_PPCR_RSTPUN_Pos)
+#define PM_PPCR_CATBRCMASK_Pos      1            /**< \brief (PM_PPCR) CAT Request Clock Mask */
+#define PM_PPCR_CATBRCMASK          (_U(0x1) << PM_PPCR_CATBRCMASK_Pos)
+#define PM_PPCR_ACIFCRCMASK_Pos     2            /**< \brief (PM_PPCR) ACIFC Request Clock Mask */
+#define PM_PPCR_ACIFCRCMASK         (_U(0x1) << PM_PPCR_ACIFCRCMASK_Pos)
+#define PM_PPCR_ASTRCMASK_Pos       3            /**< \brief (PM_PPCR) AST Request Clock Mask */
+#define PM_PPCR_ASTRCMASK           (_U(0x1) << PM_PPCR_ASTRCMASK_Pos)
+#define PM_PPCR_TWIS0RCMASK_Pos     4            /**< \brief (PM_PPCR) TWIS0 Request Clock Mask */
+#define PM_PPCR_TWIS0RCMASK         (_U(0x1) << PM_PPCR_TWIS0RCMASK_Pos)
+#define PM_PPCR_TWIS1RCMASK_Pos     5            /**< \brief (PM_PPCR) TWIS1 Request Clock Mask */
+#define PM_PPCR_TWIS1RCMASK         (_U(0x1) << PM_PPCR_TWIS1RCMASK_Pos)
+#define PM_PPCR_PEVCRCMASK_Pos      6            /**< \brief (PM_PPCR) PEVC Request Clock Mask */
+#define PM_PPCR_PEVCRCMASK          (_U(0x1) << PM_PPCR_PEVCRCMASK_Pos)
+#define PM_PPCR_ADCIFERCMASK_Pos    7            /**< \brief (PM_PPCR) ADCIFE Request Clock Mask */
+#define PM_PPCR_ADCIFERCMASK        (_U(0x1) << PM_PPCR_ADCIFERCMASK_Pos)
+#define PM_PPCR_VREGRCMASK_Pos      8            /**< \brief (PM_PPCR) VREG Request Clock Mask */
+#define PM_PPCR_VREGRCMASK          (_U(0x1) << PM_PPCR_VREGRCMASK_Pos)
+#define PM_PPCR_FWBGREF_Pos         9            /**< \brief (PM_PPCR) Flash Wait BGREF */
+#define PM_PPCR_FWBGREF             (_U(0x1) << PM_PPCR_FWBGREF_Pos)
+#define PM_PPCR_FWBOD18_Pos         10           /**< \brief (PM_PPCR) Flash Wait BOD18 */
+#define PM_PPCR_FWBOD18             (_U(0x1) << PM_PPCR_FWBOD18_Pos)
+#define PM_PPCR_MASK                _U(0x000007FF) /**< \brief (PM_PPCR) MASK Register */
+
+/* -------- PM_RCAUSE : (PM Offset: 0x180) (R/  32) Reset Cause Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t POR:1;            /*!< bit:      0  Power-on Reset                     */
+    uint32_t BOD:1;            /*!< bit:      1  Brown-out Reset                    */
+    uint32_t EXT:1;            /*!< bit:      2  External Reset Pin                 */
+    uint32_t WDT:1;            /*!< bit:      3  Watchdog Reset                     */
+    uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint32_t OCDRST:1;         /*!< bit:      8  OCD Reset                          */
+    uint32_t :1;               /*!< bit:      9  Reserved                           */
+    uint32_t POR33:1;          /*!< bit:     10  Power-on Reset                     */
+    uint32_t :2;               /*!< bit: 11..12  Reserved                           */
+    uint32_t BOD33:1;          /*!< bit:     13  Brown-out 3.3V Reset               */
+    uint32_t :18;              /*!< bit: 14..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_RCAUSE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_RCAUSE_OFFSET            0x180        /**< \brief (PM_RCAUSE offset) Reset Cause Register */
+#define PM_RCAUSE_RESETVALUE        _U(0x00000000); /**< \brief (PM_RCAUSE reset_value) Reset Cause Register */
+
+#define PM_RCAUSE_POR_Pos           0            /**< \brief (PM_RCAUSE) Power-on Reset */
+#define PM_RCAUSE_POR               (_U(0x1) << PM_RCAUSE_POR_Pos)
+#define PM_RCAUSE_BOD_Pos           1            /**< \brief (PM_RCAUSE) Brown-out Reset */
+#define PM_RCAUSE_BOD               (_U(0x1) << PM_RCAUSE_BOD_Pos)
+#define PM_RCAUSE_EXT_Pos           2            /**< \brief (PM_RCAUSE) External Reset Pin */
+#define PM_RCAUSE_EXT               (_U(0x1) << PM_RCAUSE_EXT_Pos)
+#define PM_RCAUSE_WDT_Pos           3            /**< \brief (PM_RCAUSE) Watchdog Reset */
+#define PM_RCAUSE_WDT               (_U(0x1) << PM_RCAUSE_WDT_Pos)
+#define PM_RCAUSE_OCDRST_Pos        8            /**< \brief (PM_RCAUSE) OCD Reset */
+#define PM_RCAUSE_OCDRST            (_U(0x1) << PM_RCAUSE_OCDRST_Pos)
+#define PM_RCAUSE_POR33_Pos         10           /**< \brief (PM_RCAUSE) Power-on Reset */
+#define PM_RCAUSE_POR33             (_U(0x1) << PM_RCAUSE_POR33_Pos)
+#define PM_RCAUSE_BOD33_Pos         13           /**< \brief (PM_RCAUSE) Brown-out 3.3V Reset */
+#define PM_RCAUSE_BOD33             (_U(0x1) << PM_RCAUSE_BOD33_Pos)
+#define PM_RCAUSE_MASK              _U(0x0000250F) /**< \brief (PM_RCAUSE) MASK Register */
+
+/* -------- PM_WCAUSE : (PM Offset: 0x184) (R/  32) Wake Cause Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TWI_SLAVE_0:1;    /*!< bit:      0  Two-wire Slave Interface 0         */
+    uint32_t TWI_SLAVE_1:1;    /*!< bit:      1  Two-wire Slave Interface 1         */
+    uint32_t USBC:1;           /*!< bit:      2  USB Device and Embedded Host Interface */
+    uint32_t PSOK:1;           /*!< bit:      3  Power Scaling OK                   */
+    uint32_t BOD18_IRQ:1;      /*!< bit:      4  BOD18 Interrupt                    */
+    uint32_t BOD33_IRQ:1;      /*!< bit:      5  BOD33 Interrupt                    */
+    uint32_t PICOUART:1;       /*!< bit:      6  Picopower UART                     */
+    uint32_t LCDCA:1;          /*!< bit:      7  LCD Controller                     */
+    uint32_t :8;               /*!< bit:  8..15  Reserved                           */
+    uint32_t EIC:1;            /*!< bit:     16  External Interrupt Controller      */
+    uint32_t AST:1;            /*!< bit:     17  Asynchronous Timer                 */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_WCAUSE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_WCAUSE_OFFSET            0x184        /**< \brief (PM_WCAUSE offset) Wake Cause Register */
+#define PM_WCAUSE_RESETVALUE        _U(0x00000000); /**< \brief (PM_WCAUSE reset_value) Wake Cause Register */
+
+#define PM_WCAUSE_TWI_SLAVE_0_Pos   0            /**< \brief (PM_WCAUSE) Two-wire Slave Interface 0 */
+#define PM_WCAUSE_TWI_SLAVE_0       (_U(0x1) << PM_WCAUSE_TWI_SLAVE_0_Pos)
+#define PM_WCAUSE_TWI_SLAVE_1_Pos   1            /**< \brief (PM_WCAUSE) Two-wire Slave Interface 1 */
+#define PM_WCAUSE_TWI_SLAVE_1       (_U(0x1) << PM_WCAUSE_TWI_SLAVE_1_Pos)
+#define PM_WCAUSE_USBC_Pos          2            /**< \brief (PM_WCAUSE) USB Device and Embedded Host Interface */
+#define PM_WCAUSE_USBC              (_U(0x1) << PM_WCAUSE_USBC_Pos)
+#define PM_WCAUSE_PSOK_Pos          3            /**< \brief (PM_WCAUSE) Power Scaling OK */
+#define PM_WCAUSE_PSOK              (_U(0x1) << PM_WCAUSE_PSOK_Pos)
+#define PM_WCAUSE_BOD18_IRQ_Pos     4            /**< \brief (PM_WCAUSE) BOD18 Interrupt */
+#define PM_WCAUSE_BOD18_IRQ         (_U(0x1) << PM_WCAUSE_BOD18_IRQ_Pos)
+#define PM_WCAUSE_BOD33_IRQ_Pos     5            /**< \brief (PM_WCAUSE) BOD33 Interrupt */
+#define PM_WCAUSE_BOD33_IRQ         (_U(0x1) << PM_WCAUSE_BOD33_IRQ_Pos)
+#define PM_WCAUSE_PICOUART_Pos      6            /**< \brief (PM_WCAUSE) Picopower UART */
+#define PM_WCAUSE_PICOUART          (_U(0x1) << PM_WCAUSE_PICOUART_Pos)
+#define PM_WCAUSE_LCDCA_Pos         7            /**< \brief (PM_WCAUSE) LCD Controller */
+#define PM_WCAUSE_LCDCA             (_U(0x1) << PM_WCAUSE_LCDCA_Pos)
+#define PM_WCAUSE_EIC_Pos           16           /**< \brief (PM_WCAUSE) External Interrupt Controller */
+#define PM_WCAUSE_EIC               (_U(0x1) << PM_WCAUSE_EIC_Pos)
+#define PM_WCAUSE_AST_Pos           17           /**< \brief (PM_WCAUSE) Asynchronous Timer */
+#define PM_WCAUSE_AST               (_U(0x1) << PM_WCAUSE_AST_Pos)
+#define PM_WCAUSE_MASK              _U(0x000300FF) /**< \brief (PM_WCAUSE) MASK Register */
+
+/* -------- PM_AWEN : (PM Offset: 0x188) (R/W 32) Asynchronous Wake Enable -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t AWEN:32;          /*!< bit:  0..31  Asynchronous Wake Up               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_AWEN_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_AWEN_OFFSET              0x188        /**< \brief (PM_AWEN offset) Asynchronous Wake Enable */
+#define PM_AWEN_RESETVALUE          _U(0x00000000); /**< \brief (PM_AWEN reset_value) Asynchronous Wake Enable */
+
+#define PM_AWEN_AWEN_Pos            0            /**< \brief (PM_AWEN) Asynchronous Wake Up */
+#define PM_AWEN_AWEN_Msk            (_U(0xFFFFFFFF) << PM_AWEN_AWEN_Pos)
+#define PM_AWEN_AWEN(value)         (PM_AWEN_AWEN_Msk & ((value) << PM_AWEN_AWEN_Pos))
+#define PM_AWEN_MASK                _U(0xFFFFFFFF) /**< \brief (PM_AWEN) MASK Register */
+
+/* -------- PM_OBS : (PM Offset: 0x190) (R/W 32) Obsvervability -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_OBS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_OBS_OFFSET               0x190        /**< \brief (PM_OBS offset) Obsvervability */
+#define PM_OBS_RESETVALUE           _U(0x00000000); /**< \brief (PM_OBS reset_value) Obsvervability */
+
+#define PM_OBS_MASK                 _U(0x00000000) /**< \brief (PM_OBS) MASK Register */
+
+/* -------- PM_FASTSLEEP : (PM Offset: 0x194) (R/W 32) Fast Sleep Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OSC:1;            /*!< bit:      0  Oscillator                         */
+    uint32_t :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint32_t PLL:1;            /*!< bit:      8  PLL                                */
+    uint32_t :7;               /*!< bit:  9..15  Reserved                           */
+    uint32_t FASTRCOSC:5;      /*!< bit: 16..20  RC80 or FLO                        */
+    uint32_t :3;               /*!< bit: 21..23  Reserved                           */
+    uint32_t DFLL:1;           /*!< bit:     24  DFLL                               */
+    uint32_t :7;               /*!< bit: 25..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_FASTSLEEP_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_FASTSLEEP_OFFSET         0x194        /**< \brief (PM_FASTSLEEP offset) Fast Sleep Register */
+#define PM_FASTSLEEP_RESETVALUE     _U(0x00000000); /**< \brief (PM_FASTSLEEP reset_value) Fast Sleep Register */
+
+#define PM_FASTSLEEP_OSC_Pos        0            /**< \brief (PM_FASTSLEEP) Oscillator */
+#define PM_FASTSLEEP_OSC            (_U(0x1) << PM_FASTSLEEP_OSC_Pos)
+#define PM_FASTSLEEP_PLL_Pos        8            /**< \brief (PM_FASTSLEEP) PLL */
+#define PM_FASTSLEEP_PLL            (_U(0x1) << PM_FASTSLEEP_PLL_Pos)
+#define PM_FASTSLEEP_FASTRCOSC_Pos  16           /**< \brief (PM_FASTSLEEP) RC80 or FLO */
+#define PM_FASTSLEEP_FASTRCOSC_Msk  (_U(0x1F) << PM_FASTSLEEP_FASTRCOSC_Pos)
+#define PM_FASTSLEEP_FASTRCOSC(value) (PM_FASTSLEEP_FASTRCOSC_Msk & ((value) << PM_FASTSLEEP_FASTRCOSC_Pos))
+#define PM_FASTSLEEP_DFLL_Pos       24           /**< \brief (PM_FASTSLEEP) DFLL */
+#define PM_FASTSLEEP_DFLL           (_U(0x1) << PM_FASTSLEEP_DFLL_Pos)
+#define PM_FASTSLEEP_MASK           _U(0x011F0101) /**< \brief (PM_FASTSLEEP) MASK Register */
+
+/* -------- PM_CONFIG : (PM Offset: 0x3F8) (R/  32) Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PBA:1;            /*!< bit:      0  APBA Implemented                   */
+    uint32_t PBB:1;            /*!< bit:      1  APBB Implemented                   */
+    uint32_t PBC:1;            /*!< bit:      2  APBC Implemented                   */
+    uint32_t PBD:1;            /*!< bit:      3  APBD Implemented                   */
+    uint32_t :3;               /*!< bit:  4.. 6  Reserved                           */
+    uint32_t HSBPEVC:1;        /*!< bit:      7  HSB PEVC Clock Implemented         */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_CONFIG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_CONFIG_OFFSET            0x3F8        /**< \brief (PM_CONFIG offset) Configuration Register */
+#define PM_CONFIG_RESETVALUE        _U(0x0000000F); /**< \brief (PM_CONFIG reset_value) Configuration Register */
+
+#define PM_CONFIG_PBA_Pos           0            /**< \brief (PM_CONFIG) APBA Implemented */
+#define PM_CONFIG_PBA               (_U(0x1) << PM_CONFIG_PBA_Pos)
+#define PM_CONFIG_PBB_Pos           1            /**< \brief (PM_CONFIG) APBB Implemented */
+#define PM_CONFIG_PBB               (_U(0x1) << PM_CONFIG_PBB_Pos)
+#define PM_CONFIG_PBC_Pos           2            /**< \brief (PM_CONFIG) APBC Implemented */
+#define PM_CONFIG_PBC               (_U(0x1) << PM_CONFIG_PBC_Pos)
+#define PM_CONFIG_PBD_Pos           3            /**< \brief (PM_CONFIG) APBD Implemented */
+#define PM_CONFIG_PBD               (_U(0x1) << PM_CONFIG_PBD_Pos)
+#define PM_CONFIG_HSBPEVC_Pos       7            /**< \brief (PM_CONFIG) HSB PEVC Clock Implemented */
+#define PM_CONFIG_HSBPEVC           (_U(0x1) << PM_CONFIG_HSBPEVC_Pos)
+#define PM_CONFIG_MASK              _U(0x0000008F) /**< \brief (PM_CONFIG) MASK Register */
+
+/* -------- PM_VERSION : (PM Offset: 0x3FC) (R/  32) Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_VERSION_OFFSET           0x3FC        /**< \brief (PM_VERSION offset) Version Register */
+#define PM_VERSION_RESETVALUE       _U(0x00000441); /**< \brief (PM_VERSION reset_value) Version Register */
+
+#define PM_VERSION_VERSION_Pos      0            /**< \brief (PM_VERSION) Version number */
+#define PM_VERSION_VERSION_Msk      (_U(0xFFF) << PM_VERSION_VERSION_Pos)
+#define PM_VERSION_VERSION(value)   (PM_VERSION_VERSION_Msk & ((value) << PM_VERSION_VERSION_Pos))
+#define PM_VERSION_VARIANT_Pos      16           /**< \brief (PM_VERSION) Variant number */
+#define PM_VERSION_VARIANT_Msk      (_U(0xF) << PM_VERSION_VARIANT_Pos)
+#define PM_VERSION_VARIANT(value)   (PM_VERSION_VARIANT_Msk & ((value) << PM_VERSION_VARIANT_Pos))
+#define PM_VERSION_MASK             _U(0x000F0FFF) /**< \brief (PM_VERSION) MASK Register */
+
+/** \brief PM hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __IO PM_MCCTRL_Type            MCCTRL;      /**< \brief Offset: 0x000 (R/W 32) Main Clock Control */
+  __IO PM_CPUSEL_Type            CPUSEL;      /**< \brief Offset: 0x004 (R/W 32) CPU Clock Select */
+       RoReg8                    Reserved1[0x4];
+  __IO PM_PBASEL_Type            PBASEL;      /**< \brief Offset: 0x00C (R/W 32) PBA Clock Select */
+  __IO PM_PBBSEL_Type            PBBSEL;      /**< \brief Offset: 0x010 (R/W 32) PBB Clock Select */
+  __IO PM_PBCSEL_Type            PBCSEL;      /**< \brief Offset: 0x014 (R/W 32) PBC Clock Select */
+  __IO PM_PBDSEL_Type            PBDSEL;      /**< \brief Offset: 0x018 (R/W 32) PBD Clock Select */
+       RoReg8                    Reserved2[0x4];
+  __IO PM_CPUMASK_Type           CPUMASK;     /**< \brief Offset: 0x020 (R/W 32) CPU Mask */
+  __IO PM_HSBMASK_Type           HSBMASK;     /**< \brief Offset: 0x024 (R/W 32) HSB Mask */
+  __IO PM_PBAMASK_Type           PBAMASK;     /**< \brief Offset: 0x028 (R/W 32) PBA Mask */
+  __IO PM_PBBMASK_Type           PBBMASK;     /**< \brief Offset: 0x02C (R/W 32) PBB Mask */
+  __IO PM_PBCMASK_Type           PBCMASK;     /**< \brief Offset: 0x030 (R/W 32) PBC Mask */
+  __IO PM_PBDMASK_Type           PBDMASK;     /**< \brief Offset: 0x034 (R/W 32) PBD Mask */
+       RoReg8                    Reserved3[0x8];
+  __IO PM_PBADIVMASK_Type        PBADIVMASK;  /**< \brief Offset: 0x040 (R/W 32) PBA Divided Clock Mask */
+       RoReg8                    Reserved4[0x10];
+  __IO PM_CFDCTRL_Type           CFDCTRL;     /**< \brief Offset: 0x054 (R/W 32) Clock Failure Detector Control */
+  __O  PM_UNLOCK_Type            UNLOCK;      /**< \brief Offset: 0x058 ( /W 32) Unlock Register */
+       RoReg8                    Reserved5[0x64];
+  __O  PM_IER_Type               IER;         /**< \brief Offset: 0x0C0 ( /W 32) Interrupt Enable Register */
+  __O  PM_IDR_Type               IDR;         /**< \brief Offset: 0x0C4 ( /W 32) Interrupt Disable Register */
+  __I  PM_IMR_Type               IMR;         /**< \brief Offset: 0x0C8 (R/  32) Interrupt Mask Register */
+  __I  PM_ISR_Type               ISR;         /**< \brief Offset: 0x0CC (R/  32) Interrupt Status Register */
+  __O  PM_ICR_Type               ICR;         /**< \brief Offset: 0x0D0 ( /W 32) Interrupt Clear Register */
+  __I  PM_SR_Type                SR;          /**< \brief Offset: 0x0D4 (R/  32) Status Register */
+       RoReg8                    Reserved6[0x88];
+  __IO PM_PPCR_Type              PPCR;        /**< \brief Offset: 0x160 (R/W 32) Peripheral Power Control Register */
+       RoReg8                    Reserved7[0x1C];
+  __I  PM_RCAUSE_Type            RCAUSE;      /**< \brief Offset: 0x180 (R/  32) Reset Cause Register */
+  __I  PM_WCAUSE_Type            WCAUSE;      /**< \brief Offset: 0x184 (R/  32) Wake Cause Register */
+  __IO PM_AWEN_Type              AWEN;        /**< \brief Offset: 0x188 (R/W 32) Asynchronous Wake Enable */
+       RoReg8                    Reserved8[0x4];
+  __IO PM_OBS_Type               OBS;         /**< \brief Offset: 0x190 (R/W 32) Obsvervability */
+  __IO PM_FASTSLEEP_Type         FASTSLEEP;   /**< \brief Offset: 0x194 (R/W 32) Fast Sleep Register */
+       RoReg8                    Reserved9[0x260];
+  __I  PM_CONFIG_Type            CONFIG;      /**< \brief Offset: 0x3F8 (R/  32) Configuration Register */
+  __I  PM_VERSION_Type           VERSION;     /**< \brief Offset: 0x3FC (R/  32) Version Register */
+ } bf;
+ struct {
+  RwReg   PM_MCCTRL;          /**< \brief (PM Offset: 0x000) Main Clock Control */
+  RwReg   PM_CPUSEL;          /**< \brief (PM Offset: 0x004) CPU Clock Select */
+  RoReg8  Reserved10[0x4];
+  RwReg   PM_PBASEL;          /**< \brief (PM Offset: 0x00C) PBA Clock Select */
+  RwReg   PM_PBBSEL;          /**< \brief (PM Offset: 0x010) PBB Clock Select */
+  RwReg   PM_PBCSEL;          /**< \brief (PM Offset: 0x014) PBC Clock Select */
+  RwReg   PM_PBDSEL;          /**< \brief (PM Offset: 0x018) PBD Clock Select */
+  RoReg8  Reserved11[0x4];
+  RwReg   PM_CPUMASK;         /**< \brief (PM Offset: 0x020) CPU Mask */
+  RwReg   PM_HSBMASK;         /**< \brief (PM Offset: 0x024) HSB Mask */
+  RwReg   PM_PBAMASK;         /**< \brief (PM Offset: 0x028) PBA Mask */
+  RwReg   PM_PBBMASK;         /**< \brief (PM Offset: 0x02C) PBB Mask */
+  RwReg   PM_PBCMASK;         /**< \brief (PM Offset: 0x030) PBC Mask */
+  RwReg   PM_PBDMASK;         /**< \brief (PM Offset: 0x034) PBD Mask */
+  RoReg8  Reserved12[0x8];
+  RwReg   PM_PBADIVMASK;      /**< \brief (PM Offset: 0x040) PBA Divided Clock Mask */
+  RoReg8  Reserved13[0x10];
+  RwReg   PM_CFDCTRL;         /**< \brief (PM Offset: 0x054) Clock Failure Detector Control */
+  WoReg   PM_UNLOCK;          /**< \brief (PM Offset: 0x058) Unlock Register */
+  RoReg8  Reserved14[0x64];
+  WoReg   PM_IER;             /**< \brief (PM Offset: 0x0C0) Interrupt Enable Register */
+  WoReg   PM_IDR;             /**< \brief (PM Offset: 0x0C4) Interrupt Disable Register */
+  RoReg   PM_IMR;             /**< \brief (PM Offset: 0x0C8) Interrupt Mask Register */
+  RoReg   PM_ISR;             /**< \brief (PM Offset: 0x0CC) Interrupt Status Register */
+  WoReg   PM_ICR;             /**< \brief (PM Offset: 0x0D0) Interrupt Clear Register */
+  RoReg   PM_SR;              /**< \brief (PM Offset: 0x0D4) Status Register */
+  RoReg8  Reserved15[0x88];
+  RwReg   PM_PPCR;            /**< \brief (PM Offset: 0x160) Peripheral Power Control Register */
+  RoReg8  Reserved16[0x1C];
+  RoReg   PM_RCAUSE;          /**< \brief (PM Offset: 0x180) Reset Cause Register */
+  RoReg   PM_WCAUSE;          /**< \brief (PM Offset: 0x184) Wake Cause Register */
+  RwReg   PM_AWEN;            /**< \brief (PM Offset: 0x188) Asynchronous Wake Enable */
+  RoReg8  Reserved17[0x4];
+  RwReg   PM_OBS;             /**< \brief (PM Offset: 0x190) Obsvervability */
+  RwReg   PM_FASTSLEEP;       /**< \brief (PM Offset: 0x194) Fast Sleep Register */
+  RoReg8  Reserved18[0x260];
+  RoReg   PM_CONFIG;          /**< \brief (PM Offset: 0x3F8) Configuration Register */
+  RoReg   PM_VERSION;         /**< \brief (PM Offset: 0x3FC) Version Register */
+ } reg;
+} Pm;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_PM_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/scif.h
+++ b/asf/sam/include/sam4l/component/scif.h
@@ -1096,111 +1096,59 @@ typedef union {
 
 /** \brief ScifGcctrl hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __IO SCIF_GCCTRL_Type          GCCTRL;      /**< \brief Offset: 0x000 (R/W 32) Generic Clock Control */
- } bf;
- struct {
-  RwReg   SCIF_GCCTRL;        /**< \brief (SCIF Offset: 0x000) Generic Clock Control */
- } reg;
+typedef struct {
+  __IO uint32_t   GCCTRL;      /**< \brief Offset: 0x000 (R/W 32) Generic Clock Control */
 } ScifGcctrl;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /** \brief ScifPll hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __IO SCIF_PLL_Type             PLL;         /**< \brief Offset: 0x000 (R/W 32) PLL0 Control Register */
- } bf;
- struct {
-  RwReg   SCIF_PLL;           /**< \brief (SCIF Offset: 0x000) PLL0 Control Register */
- } reg;
+typedef struct {
+  __IO uint32_t   PLL;         /**< \brief Offset: 0x000 (R/W 32) PLL0 Control Register */
 } ScifPll;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /** \brief SCIF hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __O  SCIF_IER_Type             IER;         /**< \brief Offset: 0x000 ( /W 32) Interrupt Enable Register */
-  __O  SCIF_IDR_Type             IDR;         /**< \brief Offset: 0x004 ( /W 32) Interrupt Disable Register */
-  __I  SCIF_IMR_Type             IMR;         /**< \brief Offset: 0x008 (R/  32) Interrupt Mask Register */
-  __I  SCIF_ISR_Type             ISR;         /**< \brief Offset: 0x00C (R/  32) Interrupt Status Register */
-  __O  SCIF_ICR_Type             ICR;         /**< \brief Offset: 0x010 ( /W 32) Interrupt Clear Register */
-  __I  SCIF_PCLKSR_Type          PCLKSR;      /**< \brief Offset: 0x014 (R/  32) Power and Clocks Status Register */
-  __O  SCIF_UNLOCK_Type          UNLOCK;      /**< \brief Offset: 0x018 ( /W 32) Unlock Register */
-  __IO SCIF_CSCR_Type            CSCR;        /**< \brief Offset: 0x01C (R/W 32) Chip Specific Configuration Register */
-  __IO SCIF_OSCCTRL0_Type        OSCCTRL0;    /**< \brief Offset: 0x020 (R/W 32) Oscillator Control Register */
-       ScifPll                   Pll[1];      /**< \brief Offset: 0x024 ScifPll groups */
-  __IO SCIF_DFLL0CONF_Type       DFLL0CONF;   /**< \brief Offset: 0x028 (R/W 32) DFLL0 Config Register */
-  __IO SCIF_DFLL0VAL_Type        DFLL0VAL;    /**< \brief Offset: 0x02C (R/W 32) DFLL Value Register */
-  __IO SCIF_DFLL0MUL_Type        DFLL0MUL;    /**< \brief Offset: 0x030 (R/W 32) DFLL0 Multiplier Register */
-  __IO SCIF_DFLL0STEP_Type       DFLL0STEP;   /**< \brief Offset: 0x034 (R/W 32) DFLL0 Step Register */
-  __IO SCIF_DFLL0SSG_Type        DFLL0SSG;    /**< \brief Offset: 0x038 (R/W 32) DFLL0 Spread Spectrum Generator Control Register */
-  __I  SCIF_DFLL0RATIO_Type      DFLL0RATIO;  /**< \brief Offset: 0x03C (R/  32) DFLL0 Ratio Registe */
-  __O  SCIF_DFLL0SYNC_Type       DFLL0SYNC;   /**< \brief Offset: 0x040 ( /W 32) DFLL0 Synchronization Register */
-  __IO SCIF_RCCR_Type            RCCR;        /**< \brief Offset: 0x044 (R/W 32) System RC Oscillator Calibration Register */
-  __IO SCIF_RCFASTCFG_Type       RCFASTCFG;   /**< \brief Offset: 0x048 (R/W 32) 4/8/12 MHz RC Oscillator Configuration Register */
-  __IO SCIF_RCFASTSR_Type        RCFASTSR;    /**< \brief Offset: 0x04C (R/W 32) 4/8/12 MHz RC Oscillator Status Register */
-  __IO SCIF_RC80MCR_Type         RC80MCR;     /**< \brief Offset: 0x050 (R/W 32) 80 MHz RC Oscillator Register */
-       RoReg8                    Reserved1[0x10];
-  __IO SCIF_HRPCR_Type           HRPCR;       /**< \brief Offset: 0x064 (R/W 32) High Resolution Prescaler Control Register */
-  __IO SCIF_FPCR_Type            FPCR;        /**< \brief Offset: 0x068 (R/W 32) Fractional Prescaler Control Register */
-  __IO SCIF_FPMUL_Type           FPMUL;       /**< \brief Offset: 0x06C (R/W 32) Fractional Prescaler Multiplier Register */
-  __IO SCIF_FPDIV_Type           FPDIV;       /**< \brief Offset: 0x070 (R/W 32) Fractional Prescaler DIVIDER Register */
-       ScifGcctrl                Gcctrl[12];  /**< \brief Offset: 0x074 ScifGcctrl groups */
-       RoReg8                    Reserved2[0x334];
-  __I  SCIF_RCFASTVERSION_Type   RCFASTVERSION; /**< \brief Offset: 0x3D8 (R/  32) 4/8/12 MHz RC Oscillator Version Register */
-  __I  SCIF_GCLKPRESCVERSION_Type GCLKPRESCVERSION; /**< \brief Offset: 0x3DC (R/  32) Generic Clock Prescaler Version Register */
-  __I  SCIF_PLLIFAVERSION_Type   PLLIFAVERSION; /**< \brief Offset: 0x3E0 (R/  32) PLL Version Register */
-  __I  SCIF_OSCIFAVERSION_Type   OSCIFAVERSION; /**< \brief Offset: 0x3E4 (R/  32) Oscillator 0 Version Register */
-  __I  SCIF_DFLLIFBVERSION_Type  DFLLIFBVERSION; /**< \brief Offset: 0x3E8 (R/  32) DFLL Version Register */
-  __I  SCIF_RCOSCIFAVERSION_Type RCOSCIFAVERSION; /**< \brief Offset: 0x3EC (R/  32) System RC Oscillator Version Register */
-  __I  SCIF_FLOVERSION_Type      FLOVERSION;  /**< \brief Offset: 0x3F0 (R/  32) Frequency Locked Oscillator Version Register */
-  __I  SCIF_RC80MVERSION_Type    RC80MVERSION; /**< \brief Offset: 0x3F4 (R/  32) 80MHz RC Oscillator Version Register */
-  __I  SCIF_GCLKIFVERSION_Type   GCLKIFVERSION; /**< \brief Offset: 0x3F8 (R/  32) Generic Clock Version Register */
-  __I  SCIF_VERSION_Type         VERSION;     /**< \brief Offset: 0x3FC (R/  32) SCIF Version Register */
- } bf;
- struct {
-  WoReg   SCIF_IER;           /**< \brief (SCIF Offset: 0x000) Interrupt Enable Register */
-  WoReg   SCIF_IDR;           /**< \brief (SCIF Offset: 0x004) Interrupt Disable Register */
-  RoReg   SCIF_IMR;           /**< \brief (SCIF Offset: 0x008) Interrupt Mask Register */
-  RoReg   SCIF_ISR;           /**< \brief (SCIF Offset: 0x00C) Interrupt Status Register */
-  WoReg   SCIF_ICR;           /**< \brief (SCIF Offset: 0x010) Interrupt Clear Register */
-  RoReg   SCIF_PCLKSR;        /**< \brief (SCIF Offset: 0x014) Power and Clocks Status Register */
-  WoReg   SCIF_UNLOCK;        /**< \brief (SCIF Offset: 0x018) Unlock Register */
-  RwReg   SCIF_CSCR;          /**< \brief (SCIF Offset: 0x01C) Chip Specific Configuration Register */
-  RwReg   SCIF_OSCCTRL0;      /**< \brief (SCIF Offset: 0x020) Oscillator Control Register */
-  ScifPll SCIF_PLL[1];        /**< \brief (SCIF Offset: 0x024) ScifPll groups */
-  RwReg   SCIF_DFLL0CONF;     /**< \brief (SCIF Offset: 0x028) DFLL0 Config Register */
-  RwReg   SCIF_DFLL0VAL;      /**< \brief (SCIF Offset: 0x02C) DFLL Value Register */
-  RwReg   SCIF_DFLL0MUL;      /**< \brief (SCIF Offset: 0x030) DFLL0 Multiplier Register */
-  RwReg   SCIF_DFLL0STEP;     /**< \brief (SCIF Offset: 0x034) DFLL0 Step Register */
-  RwReg   SCIF_DFLL0SSG;      /**< \brief (SCIF Offset: 0x038) DFLL0 Spread Spectrum Generator Control Register */
-  RoReg   SCIF_DFLL0RATIO;    /**< \brief (SCIF Offset: 0x03C) DFLL0 Ratio Registe */
-  WoReg   SCIF_DFLL0SYNC;     /**< \brief (SCIF Offset: 0x040) DFLL0 Synchronization Register */
-  RwReg   SCIF_RCCR;          /**< \brief (SCIF Offset: 0x044) System RC Oscillator Calibration Register */
-  RwReg   SCIF_RCFASTCFG;     /**< \brief (SCIF Offset: 0x048) 4/8/12 MHz RC Oscillator Configuration Register */
-  RwReg   SCIF_RCFASTSR;      /**< \brief (SCIF Offset: 0x04C) 4/8/12 MHz RC Oscillator Status Register */
-  RwReg   SCIF_RC80MCR;       /**< \brief (SCIF Offset: 0x050) 80 MHz RC Oscillator Register */
-  RoReg8  Reserved3[0x10];
-  RwReg   SCIF_HRPCR;         /**< \brief (SCIF Offset: 0x064) High Resolution Prescaler Control Register */
-  RwReg   SCIF_FPCR;          /**< \brief (SCIF Offset: 0x068) Fractional Prescaler Control Register */
-  RwReg   SCIF_FPMUL;         /**< \brief (SCIF Offset: 0x06C) Fractional Prescaler Multiplier Register */
-  RwReg   SCIF_FPDIV;         /**< \brief (SCIF Offset: 0x070) Fractional Prescaler DIVIDER Register */
-  ScifGcctrl SCIF_GCCTRL[12];    /**< \brief (SCIF Offset: 0x074) ScifGcctrl groups */
-  RoReg8  Reserved4[0x334];
-  RoReg   SCIF_RCFASTVERSION; /**< \brief (SCIF Offset: 0x3D8) 4/8/12 MHz RC Oscillator Version Register */
-  RoReg   SCIF_GCLKPRESCVERSION; /**< \brief (SCIF Offset: 0x3DC) Generic Clock Prescaler Version Register */
-  RoReg   SCIF_PLLIFAVERSION; /**< \brief (SCIF Offset: 0x3E0) PLL Version Register */
-  RoReg   SCIF_OSCIFAVERSION; /**< \brief (SCIF Offset: 0x3E4) Oscillator 0 Version Register */
-  RoReg   SCIF_DFLLIFBVERSION; /**< \brief (SCIF Offset: 0x3E8) DFLL Version Register */
-  RoReg   SCIF_RCOSCIFAVERSION; /**< \brief (SCIF Offset: 0x3EC) System RC Oscillator Version Register */
-  RoReg   SCIF_FLOVERSION;    /**< \brief (SCIF Offset: 0x3F0) Frequency Locked Oscillator Version Register */
-  RoReg   SCIF_RC80MVERSION;  /**< \brief (SCIF Offset: 0x3F4) 80MHz RC Oscillator Version Register */
-  RoReg   SCIF_GCLKIFVERSION; /**< \brief (SCIF Offset: 0x3F8) Generic Clock Version Register */
-  RoReg   SCIF_VERSION;       /**< \brief (SCIF Offset: 0x3FC) SCIF Version Register */
- } reg;
+typedef struct {
+  __O  uint32_t IER;              /**< \brief Offset: 0x000 ( /W 32) Interrupt Enable Register */
+  __O  uint32_t IDR;              /**< \brief Offset: 0x004 ( /W 32) Interrupt Disable Register */
+  __I  uint32_t IMR;              /**< \brief Offset: 0x008 (R/  32) Interrupt Mask Register */
+  __I  uint32_t ISR;              /**< \brief Offset: 0x00C (R/  32) Interrupt Status Register */
+  __O  uint32_t ICR;              /**< \brief Offset: 0x010 ( /W 32) Interrupt Clear Register */
+  __I  uint32_t PCLKSR;           /**< \brief Offset: 0x014 (R/  32) Power and Clocks Status Register */
+  __O  uint32_t UNLOCK;           /**< \brief Offset: 0x018 ( /W 32) Unlock Register */
+  __IO uint32_t CSCR;             /**< \brief Offset: 0x01C (R/W 32) Chip Specific Configuration Register */
+  __IO uint32_t OSCCTRL0;         /**< \brief Offset: 0x020 (R/W 32) Oscillator Control Register */
+       uint32_t PLL[1];           /**< \brief Offset: 0x024 ScifPll groups */
+  __IO uint32_t DFLL0CONF;        /**< \brief Offset: 0x028 (R/W 32) DFLL0 Config Register */
+  __IO uint32_t DFLL0VAL;         /**< \brief Offset: 0x02C (R/W 32) DFLL Value Register */
+  __IO uint32_t DFLL0MUL;         /**< \brief Offset: 0x030 (R/W 32) DFLL0 Multiplier Register */
+  __IO uint32_t DFLL0STEP;        /**< \brief Offset: 0x034 (R/W 32) DFLL0 Step Register */
+  __IO uint32_t DFLL0SSG;         /**< \brief Offset: 0x038 (R/W 32) DFLL0 Spread Spectrum Generator Control Register */
+  __I  uint32_t DFLL0RATIO;       /**< \brief Offset: 0x03C (R/  32) DFLL0 Ratio Registe */
+  __O  uint32_t DFLL0SYNC;        /**< \brief Offset: 0x040 ( /W 32) DFLL0 Synchronization Register */
+  __IO uint32_t RCCR;             /**< \brief Offset: 0x044 (R/W 32) System RC Oscillator Calibration Register */
+  __IO uint32_t RCFASTCFG;        /**< \brief Offset: 0x048 (R/W 32) 4/8/12 MHz RC Oscillator Configuration Register */
+  __IO uint32_t RCFASTSR;         /**< \brief Offset: 0x04C (R/W 32) 4/8/12 MHz RC Oscillator Status Register */
+  __IO uint32_t RC80MCR;          /**< \brief Offset: 0x050 (R/W 32) 80 MHz RC Oscillator Register */
+       RoReg8   Reserved1[0x10];
+  __IO uint32_t HRPCR;            /**< \brief Offset: 0x064 (R/W 32) High Resolution Prescaler Control Register */
+  __IO uint32_t FPCR;             /**< \brief Offset: 0x068 (R/W 32) Fractional Prescaler Control Register */
+  __IO uint32_t FPMUL;            /**< \brief Offset: 0x06C (R/W 32) Fractional Prescaler Multiplier Register */
+  __IO uint32_t FPDIV;            /**< \brief Offset: 0x070 (R/W 32) Fractional Prescaler DIVIDER Register */
+       uint32_t GCCTRL[12];       /**< \brief Offset: 0x074 Generic Clock Control */
+       RoReg8   Reserved2[0x334];
+  __I  uint32_t RCFASTVERSION;    /**< \brief Offset: 0x3D8 (R/  32) 4/8/12 MHz RC Oscillator Version Register */
+  __I  uint32_t GCLKPRESCVERSION; /**< \brief Offset: 0x3DC (R/  32) Generic Clock Prescaler Version Register */
+  __I  uint32_t PLLIFAVERSION;    /**< \brief Offset: 0x3E0 (R/  32) PLL Version Register */
+  __I  uint32_t OSCIFAVERSION;    /**< \brief Offset: 0x3E4 (R/  32) Oscillator 0 Version Register */
+  __I  uint32_t DFLLIFBVERSION;   /**< \brief Offset: 0x3E8 (R/  32) DFLL Version Register */
+  __I  uint32_t RCOSCIFAVERSION;  /**< \brief Offset: 0x3EC (R/  32) System RC Oscillator Version Register */
+  __I  uint32_t FLOVERSION;       /**< \brief Offset: 0x3F0 (R/  32) Frequency Locked Oscillator Version Register */
+  __I  uint32_t RC80MVERSION;     /**< \brief Offset: 0x3F4 (R/  32) 80MHz RC Oscillator Version Register */
+  __I  uint32_t GCLKIFVERSION;    /**< \brief Offset: 0x3F8 (R/  32) Generic Clock Version Register */
+  __I  uint32_t VERSION;          /**< \brief Offset: 0x3FC (R/  32) SCIF Version Register */
 } Scif;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/scif.h
+++ b/asf/sam/include/sam4l/component/scif.h
@@ -1,0 +1,1209 @@
+/**
+ * \file
+ *
+ * \brief Component description for SCIF
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_SCIF_COMPONENT_
+#define _SAM4L_SCIF_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR SCIF */
+/* ========================================================================== */
+/** \addtogroup SAM4L_SCIF System Control Interface */
+/*@{*/
+
+#define SCIF_I7149
+#define REV_SCIF                    0x130
+
+/* -------- SCIF_IER : (SCIF Offset: 0x000) ( /W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OSC0RDY:1;        /*!< bit:      0  OSC0 Ready                         */
+    uint32_t DFLL0LOCKC:1;     /*!< bit:      1  DFLL0 Lock Coarse                  */
+    uint32_t DFLL0LOCKF:1;     /*!< bit:      2  DFLL0 Lock Fine                    */
+    uint32_t DFLL0RDY:1;       /*!< bit:      3  DFLL0 Ready                        */
+    uint32_t DFLL0RCS:1;       /*!< bit:      4  DFLL0 Reference Clock Stopped      */
+    uint32_t DFLL0OOB:1;       /*!< bit:      5  DFLL0 Out Of Bounds                */
+    uint32_t PLL0LOCK:1;       /*!< bit:      6  PLL0 Lock                          */
+    uint32_t PLL0LOCKLOST:1;   /*!< bit:      7  PLL0 Lock Lost                     */
+    uint32_t :5;               /*!< bit:  8..12  Reserved                           */
+    uint32_t RCFASTLOCK:1;     /*!< bit:     13  RCFAST Lock                        */
+    uint32_t RCFASTLOCKLOST:1; /*!< bit:     14  RCFAST Lock Lost                   */
+    uint32_t :16;              /*!< bit: 15..30  Reserved                           */
+    uint32_t AE:1;             /*!< bit:     31  Access Error                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_IER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_IER_OFFSET             0x000        /**< \brief (SCIF_IER offset) Interrupt Enable Register */
+#define SCIF_IER_RESETVALUE         _U(0x00000000); /**< \brief (SCIF_IER reset_value) Interrupt Enable Register */
+
+#define SCIF_IER_OSC0RDY_Pos        0            /**< \brief (SCIF_IER) OSC0 Ready */
+#define SCIF_IER_OSC0RDY            (_U(0x1) << SCIF_IER_OSC0RDY_Pos)
+#define SCIF_IER_DFLL0LOCKC_Pos     1            /**< \brief (SCIF_IER) DFLL0 Lock Coarse */
+#define SCIF_IER_DFLL0LOCKC         (_U(0x1) << SCIF_IER_DFLL0LOCKC_Pos)
+#define SCIF_IER_DFLL0LOCKF_Pos     2            /**< \brief (SCIF_IER) DFLL0 Lock Fine */
+#define SCIF_IER_DFLL0LOCKF         (_U(0x1) << SCIF_IER_DFLL0LOCKF_Pos)
+#define SCIF_IER_DFLL0RDY_Pos       3            /**< \brief (SCIF_IER) DFLL0 Ready */
+#define SCIF_IER_DFLL0RDY           (_U(0x1) << SCIF_IER_DFLL0RDY_Pos)
+#define SCIF_IER_DFLL0RCS_Pos       4            /**< \brief (SCIF_IER) DFLL0 Reference Clock Stopped */
+#define SCIF_IER_DFLL0RCS           (_U(0x1) << SCIF_IER_DFLL0RCS_Pos)
+#define SCIF_IER_DFLL0OOB_Pos       5            /**< \brief (SCIF_IER) DFLL0 Out Of Bounds */
+#define SCIF_IER_DFLL0OOB           (_U(0x1) << SCIF_IER_DFLL0OOB_Pos)
+#define SCIF_IER_PLL0LOCK_Pos       6            /**< \brief (SCIF_IER) PLL0 Lock */
+#define SCIF_IER_PLL0LOCK           (_U(0x1) << SCIF_IER_PLL0LOCK_Pos)
+#define SCIF_IER_PLL0LOCKLOST_Pos   7            /**< \brief (SCIF_IER) PLL0 Lock Lost */
+#define SCIF_IER_PLL0LOCKLOST       (_U(0x1) << SCIF_IER_PLL0LOCKLOST_Pos)
+#define SCIF_IER_RCFASTLOCK_Pos     13           /**< \brief (SCIF_IER) RCFAST Lock */
+#define SCIF_IER_RCFASTLOCK         (_U(0x1) << SCIF_IER_RCFASTLOCK_Pos)
+#define SCIF_IER_RCFASTLOCKLOST_Pos 14           /**< \brief (SCIF_IER) RCFAST Lock Lost */
+#define SCIF_IER_RCFASTLOCKLOST     (_U(0x1) << SCIF_IER_RCFASTLOCKLOST_Pos)
+#define SCIF_IER_AE_Pos             31           /**< \brief (SCIF_IER) Access Error */
+#define SCIF_IER_AE                 (_U(0x1) << SCIF_IER_AE_Pos)
+#define SCIF_IER_MASK               _U(0x800060FF) /**< \brief (SCIF_IER) MASK Register */
+
+/* -------- SCIF_IDR : (SCIF Offset: 0x004) ( /W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OSC0RDY:1;        /*!< bit:      0  OSC0 Ready                         */
+    uint32_t DFLL0LOCKC:1;     /*!< bit:      1  DFLL0 Lock Coarse                  */
+    uint32_t DFLL0LOCKF:1;     /*!< bit:      2  DFLL0 Lock Fine                    */
+    uint32_t DFLL0RDY:1;       /*!< bit:      3  DFLL0 Ready                        */
+    uint32_t DFLL0RCS:1;       /*!< bit:      4  DFLL0 Reference Clock Stopped      */
+    uint32_t DFLL0OOB:1;       /*!< bit:      5  DFLL0 Out Of Bounds                */
+    uint32_t PLL0LOCK:1;       /*!< bit:      6  PLL0 Lock                          */
+    uint32_t PLL0LOCKLOST:1;   /*!< bit:      7  PLL0 Lock Lost                     */
+    uint32_t :5;               /*!< bit:  8..12  Reserved                           */
+    uint32_t RCFASTLOCK:1;     /*!< bit:     13  RCFAST Lock                        */
+    uint32_t RCFASTLOCKLOST:1; /*!< bit:     14  RCFAST Lock Lost                   */
+    uint32_t :16;              /*!< bit: 15..30  Reserved                           */
+    uint32_t AE:1;             /*!< bit:     31  Access Error                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_IDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_IDR_OFFSET             0x004        /**< \brief (SCIF_IDR offset) Interrupt Disable Register */
+#define SCIF_IDR_RESETVALUE         _U(0x00000000); /**< \brief (SCIF_IDR reset_value) Interrupt Disable Register */
+
+#define SCIF_IDR_OSC0RDY_Pos        0            /**< \brief (SCIF_IDR) OSC0 Ready */
+#define SCIF_IDR_OSC0RDY            (_U(0x1) << SCIF_IDR_OSC0RDY_Pos)
+#define SCIF_IDR_DFLL0LOCKC_Pos     1            /**< \brief (SCIF_IDR) DFLL0 Lock Coarse */
+#define SCIF_IDR_DFLL0LOCKC         (_U(0x1) << SCIF_IDR_DFLL0LOCKC_Pos)
+#define SCIF_IDR_DFLL0LOCKF_Pos     2            /**< \brief (SCIF_IDR) DFLL0 Lock Fine */
+#define SCIF_IDR_DFLL0LOCKF         (_U(0x1) << SCIF_IDR_DFLL0LOCKF_Pos)
+#define SCIF_IDR_DFLL0RDY_Pos       3            /**< \brief (SCIF_IDR) DFLL0 Ready */
+#define SCIF_IDR_DFLL0RDY           (_U(0x1) << SCIF_IDR_DFLL0RDY_Pos)
+#define SCIF_IDR_DFLL0RCS_Pos       4            /**< \brief (SCIF_IDR) DFLL0 Reference Clock Stopped */
+#define SCIF_IDR_DFLL0RCS           (_U(0x1) << SCIF_IDR_DFLL0RCS_Pos)
+#define SCIF_IDR_DFLL0OOB_Pos       5            /**< \brief (SCIF_IDR) DFLL0 Out Of Bounds */
+#define SCIF_IDR_DFLL0OOB           (_U(0x1) << SCIF_IDR_DFLL0OOB_Pos)
+#define SCIF_IDR_PLL0LOCK_Pos       6            /**< \brief (SCIF_IDR) PLL0 Lock */
+#define SCIF_IDR_PLL0LOCK           (_U(0x1) << SCIF_IDR_PLL0LOCK_Pos)
+#define SCIF_IDR_PLL0LOCKLOST_Pos   7            /**< \brief (SCIF_IDR) PLL0 Lock Lost */
+#define SCIF_IDR_PLL0LOCKLOST       (_U(0x1) << SCIF_IDR_PLL0LOCKLOST_Pos)
+#define SCIF_IDR_RCFASTLOCK_Pos     13           /**< \brief (SCIF_IDR) RCFAST Lock */
+#define SCIF_IDR_RCFASTLOCK         (_U(0x1) << SCIF_IDR_RCFASTLOCK_Pos)
+#define SCIF_IDR_RCFASTLOCKLOST_Pos 14           /**< \brief (SCIF_IDR) RCFAST Lock Lost */
+#define SCIF_IDR_RCFASTLOCKLOST     (_U(0x1) << SCIF_IDR_RCFASTLOCKLOST_Pos)
+#define SCIF_IDR_AE_Pos             31           /**< \brief (SCIF_IDR) Access Error */
+#define SCIF_IDR_AE                 (_U(0x1) << SCIF_IDR_AE_Pos)
+#define SCIF_IDR_MASK               _U(0x800060FF) /**< \brief (SCIF_IDR) MASK Register */
+
+/* -------- SCIF_IMR : (SCIF Offset: 0x008) (R/  32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OSC0RDY:1;        /*!< bit:      0  OSC0 Ready                         */
+    uint32_t DFLL0LOCKC:1;     /*!< bit:      1  DFLL0 Lock Coarse                  */
+    uint32_t DFLL0LOCKF:1;     /*!< bit:      2  DFLL0 Lock Fine                    */
+    uint32_t DFLL0RDY:1;       /*!< bit:      3  DFLL0 Ready                        */
+    uint32_t DFLL0RCS:1;       /*!< bit:      4  DFLL0 Reference Clock Stopped      */
+    uint32_t DFLL0OOB:1;       /*!< bit:      5  DFLL0 Out Of Bounds                */
+    uint32_t PLL0LOCK:1;       /*!< bit:      6  PLL0 Lock                          */
+    uint32_t PLL0LOCKLOST:1;   /*!< bit:      7  PLL0 Lock Lost                     */
+    uint32_t :5;               /*!< bit:  8..12  Reserved                           */
+    uint32_t RCFASTLOCK:1;     /*!< bit:     13  RCFAST Lock                        */
+    uint32_t RCFASTLOCKLOST:1; /*!< bit:     14  RCFAST Lock Lost                   */
+    uint32_t :16;              /*!< bit: 15..30  Reserved                           */
+    uint32_t AE:1;             /*!< bit:     31  Access Error                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_IMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_IMR_OFFSET             0x008        /**< \brief (SCIF_IMR offset) Interrupt Mask Register */
+#define SCIF_IMR_RESETVALUE         _U(0x00000000); /**< \brief (SCIF_IMR reset_value) Interrupt Mask Register */
+
+#define SCIF_IMR_OSC0RDY_Pos        0            /**< \brief (SCIF_IMR) OSC0 Ready */
+#define SCIF_IMR_OSC0RDY            (_U(0x1) << SCIF_IMR_OSC0RDY_Pos)
+#define SCIF_IMR_DFLL0LOCKC_Pos     1            /**< \brief (SCIF_IMR) DFLL0 Lock Coarse */
+#define SCIF_IMR_DFLL0LOCKC         (_U(0x1) << SCIF_IMR_DFLL0LOCKC_Pos)
+#define SCIF_IMR_DFLL0LOCKF_Pos     2            /**< \brief (SCIF_IMR) DFLL0 Lock Fine */
+#define SCIF_IMR_DFLL0LOCKF         (_U(0x1) << SCIF_IMR_DFLL0LOCKF_Pos)
+#define SCIF_IMR_DFLL0RDY_Pos       3            /**< \brief (SCIF_IMR) DFLL0 Ready */
+#define SCIF_IMR_DFLL0RDY           (_U(0x1) << SCIF_IMR_DFLL0RDY_Pos)
+#define SCIF_IMR_DFLL0RCS_Pos       4            /**< \brief (SCIF_IMR) DFLL0 Reference Clock Stopped */
+#define SCIF_IMR_DFLL0RCS           (_U(0x1) << SCIF_IMR_DFLL0RCS_Pos)
+#define SCIF_IMR_DFLL0OOB_Pos       5            /**< \brief (SCIF_IMR) DFLL0 Out Of Bounds */
+#define SCIF_IMR_DFLL0OOB           (_U(0x1) << SCIF_IMR_DFLL0OOB_Pos)
+#define SCIF_IMR_PLL0LOCK_Pos       6            /**< \brief (SCIF_IMR) PLL0 Lock */
+#define SCIF_IMR_PLL0LOCK           (_U(0x1) << SCIF_IMR_PLL0LOCK_Pos)
+#define SCIF_IMR_PLL0LOCKLOST_Pos   7            /**< \brief (SCIF_IMR) PLL0 Lock Lost */
+#define SCIF_IMR_PLL0LOCKLOST       (_U(0x1) << SCIF_IMR_PLL0LOCKLOST_Pos)
+#define SCIF_IMR_RCFASTLOCK_Pos     13           /**< \brief (SCIF_IMR) RCFAST Lock */
+#define SCIF_IMR_RCFASTLOCK         (_U(0x1) << SCIF_IMR_RCFASTLOCK_Pos)
+#define SCIF_IMR_RCFASTLOCKLOST_Pos 14           /**< \brief (SCIF_IMR) RCFAST Lock Lost */
+#define SCIF_IMR_RCFASTLOCKLOST     (_U(0x1) << SCIF_IMR_RCFASTLOCKLOST_Pos)
+#define SCIF_IMR_AE_Pos             31           /**< \brief (SCIF_IMR) Access Error */
+#define SCIF_IMR_AE                 (_U(0x1) << SCIF_IMR_AE_Pos)
+#define SCIF_IMR_MASK               _U(0x800060FF) /**< \brief (SCIF_IMR) MASK Register */
+
+/* -------- SCIF_ISR : (SCIF Offset: 0x00C) (R/  32) Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OSC0RDY:1;        /*!< bit:      0  OSC0 Ready                         */
+    uint32_t DFLL0LOCKC:1;     /*!< bit:      1  DFLL0 Lock Coarse                  */
+    uint32_t DFLL0LOCKF:1;     /*!< bit:      2  DFLL0 Lock Fine                    */
+    uint32_t DFLL0RDY:1;       /*!< bit:      3  DFLL0 Ready                        */
+    uint32_t DFLL0RCS:1;       /*!< bit:      4  DFLL0 Reference Clock Stopped      */
+    uint32_t DFLL0OOB:1;       /*!< bit:      5  DFLL0 Out Of Bounds                */
+    uint32_t PLL0LOCK:1;       /*!< bit:      6  PLL0 Lock                          */
+    uint32_t PLL0LOCKLOST:1;   /*!< bit:      7  PLL0 Lock Lost                     */
+    uint32_t :5;               /*!< bit:  8..12  Reserved                           */
+    uint32_t RCFASTLOCK:1;     /*!< bit:     13  RCFAST Lock                        */
+    uint32_t RCFASTLOCKLOST:1; /*!< bit:     14  RCFAST Lock Lost                   */
+    uint32_t :16;              /*!< bit: 15..30  Reserved                           */
+    uint32_t AE:1;             /*!< bit:     31  Access Error                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_ISR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_ISR_OFFSET             0x00C        /**< \brief (SCIF_ISR offset) Interrupt Status Register */
+#define SCIF_ISR_RESETVALUE         _U(0x00000000); /**< \brief (SCIF_ISR reset_value) Interrupt Status Register */
+
+#define SCIF_ISR_OSC0RDY_Pos        0            /**< \brief (SCIF_ISR) OSC0 Ready */
+#define SCIF_ISR_OSC0RDY            (_U(0x1) << SCIF_ISR_OSC0RDY_Pos)
+#define SCIF_ISR_DFLL0LOCKC_Pos     1            /**< \brief (SCIF_ISR) DFLL0 Lock Coarse */
+#define SCIF_ISR_DFLL0LOCKC         (_U(0x1) << SCIF_ISR_DFLL0LOCKC_Pos)
+#define SCIF_ISR_DFLL0LOCKF_Pos     2            /**< \brief (SCIF_ISR) DFLL0 Lock Fine */
+#define SCIF_ISR_DFLL0LOCKF         (_U(0x1) << SCIF_ISR_DFLL0LOCKF_Pos)
+#define SCIF_ISR_DFLL0RDY_Pos       3            /**< \brief (SCIF_ISR) DFLL0 Ready */
+#define SCIF_ISR_DFLL0RDY           (_U(0x1) << SCIF_ISR_DFLL0RDY_Pos)
+#define SCIF_ISR_DFLL0RCS_Pos       4            /**< \brief (SCIF_ISR) DFLL0 Reference Clock Stopped */
+#define SCIF_ISR_DFLL0RCS           (_U(0x1) << SCIF_ISR_DFLL0RCS_Pos)
+#define SCIF_ISR_DFLL0OOB_Pos       5            /**< \brief (SCIF_ISR) DFLL0 Out Of Bounds */
+#define SCIF_ISR_DFLL0OOB           (_U(0x1) << SCIF_ISR_DFLL0OOB_Pos)
+#define SCIF_ISR_PLL0LOCK_Pos       6            /**< \brief (SCIF_ISR) PLL0 Lock */
+#define SCIF_ISR_PLL0LOCK           (_U(0x1) << SCIF_ISR_PLL0LOCK_Pos)
+#define SCIF_ISR_PLL0LOCKLOST_Pos   7            /**< \brief (SCIF_ISR) PLL0 Lock Lost */
+#define SCIF_ISR_PLL0LOCKLOST       (_U(0x1) << SCIF_ISR_PLL0LOCKLOST_Pos)
+#define SCIF_ISR_RCFASTLOCK_Pos     13           /**< \brief (SCIF_ISR) RCFAST Lock */
+#define SCIF_ISR_RCFASTLOCK         (_U(0x1) << SCIF_ISR_RCFASTLOCK_Pos)
+#define SCIF_ISR_RCFASTLOCKLOST_Pos 14           /**< \brief (SCIF_ISR) RCFAST Lock Lost */
+#define SCIF_ISR_RCFASTLOCKLOST     (_U(0x1) << SCIF_ISR_RCFASTLOCKLOST_Pos)
+#define SCIF_ISR_AE_Pos             31           /**< \brief (SCIF_ISR) Access Error */
+#define SCIF_ISR_AE                 (_U(0x1) << SCIF_ISR_AE_Pos)
+#define SCIF_ISR_MASK               _U(0x800060FF) /**< \brief (SCIF_ISR) MASK Register */
+
+/* -------- SCIF_ICR : (SCIF Offset: 0x010) ( /W 32) Interrupt Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OSC0RDY:1;        /*!< bit:      0  OSC0 Ready                         */
+    uint32_t DFLL0LOCKC:1;     /*!< bit:      1  DFLL0 Lock Coarse                  */
+    uint32_t DFLL0LOCKF:1;     /*!< bit:      2  DFLL0 Lock Fine                    */
+    uint32_t DFLL0RDY:1;       /*!< bit:      3  DFLL0 Ready                        */
+    uint32_t DFLL0RCS:1;       /*!< bit:      4  DFLL0 Reference Clock Stopped      */
+    uint32_t DFLL0OOB:1;       /*!< bit:      5  DFLL0 Out Of Bounds                */
+    uint32_t PLL0LOCK:1;       /*!< bit:      6  PLL0 Lock                          */
+    uint32_t PLL0LOCKLOST:1;   /*!< bit:      7  PLL0 Lock Lost                     */
+    uint32_t :5;               /*!< bit:  8..12  Reserved                           */
+    uint32_t RCFASTLOCK:1;     /*!< bit:     13  RCFAST Lock                        */
+    uint32_t RCFASTLOCKLOST:1; /*!< bit:     14  RCFAST Lock Lost                   */
+    uint32_t :16;              /*!< bit: 15..30  Reserved                           */
+    uint32_t AE:1;             /*!< bit:     31  Access Error                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_ICR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_ICR_OFFSET             0x010        /**< \brief (SCIF_ICR offset) Interrupt Clear Register */
+#define SCIF_ICR_RESETVALUE         _U(0x00000000); /**< \brief (SCIF_ICR reset_value) Interrupt Clear Register */
+
+#define SCIF_ICR_OSC0RDY_Pos        0            /**< \brief (SCIF_ICR) OSC0 Ready */
+#define SCIF_ICR_OSC0RDY            (_U(0x1) << SCIF_ICR_OSC0RDY_Pos)
+#define SCIF_ICR_DFLL0LOCKC_Pos     1            /**< \brief (SCIF_ICR) DFLL0 Lock Coarse */
+#define SCIF_ICR_DFLL0LOCKC         (_U(0x1) << SCIF_ICR_DFLL0LOCKC_Pos)
+#define SCIF_ICR_DFLL0LOCKF_Pos     2            /**< \brief (SCIF_ICR) DFLL0 Lock Fine */
+#define SCIF_ICR_DFLL0LOCKF         (_U(0x1) << SCIF_ICR_DFLL0LOCKF_Pos)
+#define SCIF_ICR_DFLL0RDY_Pos       3            /**< \brief (SCIF_ICR) DFLL0 Ready */
+#define SCIF_ICR_DFLL0RDY           (_U(0x1) << SCIF_ICR_DFLL0RDY_Pos)
+#define SCIF_ICR_DFLL0RCS_Pos       4            /**< \brief (SCIF_ICR) DFLL0 Reference Clock Stopped */
+#define SCIF_ICR_DFLL0RCS           (_U(0x1) << SCIF_ICR_DFLL0RCS_Pos)
+#define SCIF_ICR_DFLL0OOB_Pos       5            /**< \brief (SCIF_ICR) DFLL0 Out Of Bounds */
+#define SCIF_ICR_DFLL0OOB           (_U(0x1) << SCIF_ICR_DFLL0OOB_Pos)
+#define SCIF_ICR_PLL0LOCK_Pos       6            /**< \brief (SCIF_ICR) PLL0 Lock */
+#define SCIF_ICR_PLL0LOCK           (_U(0x1) << SCIF_ICR_PLL0LOCK_Pos)
+#define SCIF_ICR_PLL0LOCKLOST_Pos   7            /**< \brief (SCIF_ICR) PLL0 Lock Lost */
+#define SCIF_ICR_PLL0LOCKLOST       (_U(0x1) << SCIF_ICR_PLL0LOCKLOST_Pos)
+#define SCIF_ICR_RCFASTLOCK_Pos     13           /**< \brief (SCIF_ICR) RCFAST Lock */
+#define SCIF_ICR_RCFASTLOCK         (_U(0x1) << SCIF_ICR_RCFASTLOCK_Pos)
+#define SCIF_ICR_RCFASTLOCKLOST_Pos 14           /**< \brief (SCIF_ICR) RCFAST Lock Lost */
+#define SCIF_ICR_RCFASTLOCKLOST     (_U(0x1) << SCIF_ICR_RCFASTLOCKLOST_Pos)
+#define SCIF_ICR_AE_Pos             31           /**< \brief (SCIF_ICR) Access Error */
+#define SCIF_ICR_AE                 (_U(0x1) << SCIF_ICR_AE_Pos)
+#define SCIF_ICR_MASK               _U(0x800060FF) /**< \brief (SCIF_ICR) MASK Register */
+
+/* -------- SCIF_PCLKSR : (SCIF Offset: 0x014) (R/  32) Power and Clocks Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OSC0RDY:1;        /*!< bit:      0  OSC0 Ready                         */
+    uint32_t DFLL0LOCKC:1;     /*!< bit:      1  DFLL0 Locked on Coarse Value       */
+    uint32_t DFLL0LOCKF:1;     /*!< bit:      2  DFLL0 Locked on Fine Value         */
+    uint32_t DFLL0RDY:1;       /*!< bit:      3  DFLL0 Synchronization Ready        */
+    uint32_t DFLL0RCS:1;       /*!< bit:      4  DFLL0 Reference Clock Stopped      */
+    uint32_t DFLL0OOB:1;       /*!< bit:      5  DFLL0 Track Out Of Bounds          */
+    uint32_t PLL0LOCK:1;       /*!< bit:      6  PLL0 Locked on Accurate value      */
+    uint32_t PLL0LOCKLOST:1;   /*!< bit:      7  PLL0 lock lost value               */
+    uint32_t :5;               /*!< bit:  8..12  Reserved                           */
+    uint32_t RCFASTLOCK:1;     /*!< bit:     13  RCFAST Locked on Accurate value    */
+    uint32_t RCFASTLOCKLOST:1; /*!< bit:     14  RCFAST lock lost value             */
+    uint32_t :17;              /*!< bit: 15..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_PCLKSR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_PCLKSR_OFFSET          0x014        /**< \brief (SCIF_PCLKSR offset) Power and Clocks Status Register */
+#define SCIF_PCLKSR_RESETVALUE      _U(0x00000000); /**< \brief (SCIF_PCLKSR reset_value) Power and Clocks Status Register */
+
+#define SCIF_PCLKSR_OSC0RDY_Pos     0            /**< \brief (SCIF_PCLKSR) OSC0 Ready */
+#define SCIF_PCLKSR_OSC0RDY         (_U(0x1) << SCIF_PCLKSR_OSC0RDY_Pos)
+#define SCIF_PCLKSR_DFLL0LOCKC_Pos  1            /**< \brief (SCIF_PCLKSR) DFLL0 Locked on Coarse Value */
+#define SCIF_PCLKSR_DFLL0LOCKC      (_U(0x1) << SCIF_PCLKSR_DFLL0LOCKC_Pos)
+#define SCIF_PCLKSR_DFLL0LOCKF_Pos  2            /**< \brief (SCIF_PCLKSR) DFLL0 Locked on Fine Value */
+#define SCIF_PCLKSR_DFLL0LOCKF      (_U(0x1) << SCIF_PCLKSR_DFLL0LOCKF_Pos)
+#define SCIF_PCLKSR_DFLL0RDY_Pos    3            /**< \brief (SCIF_PCLKSR) DFLL0 Synchronization Ready */
+#define SCIF_PCLKSR_DFLL0RDY        (_U(0x1) << SCIF_PCLKSR_DFLL0RDY_Pos)
+#define SCIF_PCLKSR_DFLL0RCS_Pos    4            /**< \brief (SCIF_PCLKSR) DFLL0 Reference Clock Stopped */
+#define SCIF_PCLKSR_DFLL0RCS        (_U(0x1) << SCIF_PCLKSR_DFLL0RCS_Pos)
+#define SCIF_PCLKSR_DFLL0OOB_Pos    5            /**< \brief (SCIF_PCLKSR) DFLL0 Track Out Of Bounds */
+#define SCIF_PCLKSR_DFLL0OOB        (_U(0x1) << SCIF_PCLKSR_DFLL0OOB_Pos)
+#define SCIF_PCLKSR_PLL0LOCK_Pos    6            /**< \brief (SCIF_PCLKSR) PLL0 Locked on Accurate value */
+#define SCIF_PCLKSR_PLL0LOCK        (_U(0x1) << SCIF_PCLKSR_PLL0LOCK_Pos)
+#define SCIF_PCLKSR_PLL0LOCKLOST_Pos 7            /**< \brief (SCIF_PCLKSR) PLL0 lock lost value */
+#define SCIF_PCLKSR_PLL0LOCKLOST    (_U(0x1) << SCIF_PCLKSR_PLL0LOCKLOST_Pos)
+#define SCIF_PCLKSR_RCFASTLOCK_Pos  13           /**< \brief (SCIF_PCLKSR) RCFAST Locked on Accurate value */
+#define SCIF_PCLKSR_RCFASTLOCK      (_U(0x1) << SCIF_PCLKSR_RCFASTLOCK_Pos)
+#define SCIF_PCLKSR_RCFASTLOCKLOST_Pos 14           /**< \brief (SCIF_PCLKSR) RCFAST lock lost value */
+#define SCIF_PCLKSR_RCFASTLOCKLOST  (_U(0x1) << SCIF_PCLKSR_RCFASTLOCKLOST_Pos)
+#define SCIF_PCLKSR_MASK            _U(0x000060FF) /**< \brief (SCIF_PCLKSR) MASK Register */
+
+/* -------- SCIF_UNLOCK : (SCIF Offset: 0x018) ( /W 32) Unlock Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ADDR:10;          /*!< bit:  0.. 9  Unlock Address                     */
+    uint32_t :14;              /*!< bit: 10..23  Reserved                           */
+    uint32_t KEY:8;            /*!< bit: 24..31  Unlock Key                         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_UNLOCK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_UNLOCK_OFFSET          0x018        /**< \brief (SCIF_UNLOCK offset) Unlock Register */
+#define SCIF_UNLOCK_RESETVALUE      _U(0x00000000); /**< \brief (SCIF_UNLOCK reset_value) Unlock Register */
+
+#define SCIF_UNLOCK_ADDR_Pos        0            /**< \brief (SCIF_UNLOCK) Unlock Address */
+#define SCIF_UNLOCK_ADDR_Msk        (_U(0x3FF) << SCIF_UNLOCK_ADDR_Pos)
+#define SCIF_UNLOCK_ADDR(value)     (SCIF_UNLOCK_ADDR_Msk & ((value) << SCIF_UNLOCK_ADDR_Pos))
+#define SCIF_UNLOCK_KEY_Pos         24           /**< \brief (SCIF_UNLOCK) Unlock Key */
+#define SCIF_UNLOCK_KEY_Msk         (_U(0xFF) << SCIF_UNLOCK_KEY_Pos)
+#define SCIF_UNLOCK_KEY(value)      (SCIF_UNLOCK_KEY_Msk & ((value) << SCIF_UNLOCK_KEY_Pos))
+#define SCIF_UNLOCK_MASK            _U(0xFF0003FF) /**< \brief (SCIF_UNLOCK) MASK Register */
+
+/* -------- SCIF_CSCR : (SCIF Offset: 0x01C) (R/W 32) Chip Specific Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_CSCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_CSCR_OFFSET            0x01C        /**< \brief (SCIF_CSCR offset) Chip Specific Configuration Register */
+#define SCIF_CSCR_RESETVALUE        _U(0x00000000); /**< \brief (SCIF_CSCR reset_value) Chip Specific Configuration Register */
+#define SCIF_CSCR_MASK              _U(0xFFFFFFFF) /**< \brief (SCIF_CSCR) MASK Register */
+
+/* -------- SCIF_OSCCTRL0 : (SCIF Offset: 0x020) (R/W 32) Oscillator Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t MODE:1;           /*!< bit:      0  Oscillator Mode                    */
+    uint32_t GAIN:2;           /*!< bit:  1.. 2  Gain                               */
+    uint32_t AGC:1;            /*!< bit:      3  Automatic Gain Control             */
+    uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint32_t STARTUP:4;        /*!< bit:  8..11  Oscillator Start-up Time           */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t OSCEN:1;          /*!< bit:     16  Oscillator Enable                  */
+    uint32_t :15;              /*!< bit: 17..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_OSCCTRL0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_OSCCTRL0_OFFSET        0x020        /**< \brief (SCIF_OSCCTRL0 offset) Oscillator Control Register */
+#define SCIF_OSCCTRL0_RESETVALUE    _U(0x00000000); /**< \brief (SCIF_OSCCTRL0 reset_value) Oscillator Control Register */
+
+#define SCIF_OSCCTRL0_MODE_Pos      0            /**< \brief (SCIF_OSCCTRL0) Oscillator Mode */
+#define SCIF_OSCCTRL0_MODE          (_U(0x1) << SCIF_OSCCTRL0_MODE_Pos)
+#define SCIF_OSCCTRL0_GAIN_Pos      1            /**< \brief (SCIF_OSCCTRL0) Gain */
+#define SCIF_OSCCTRL0_GAIN_Msk      (_U(0x3) << SCIF_OSCCTRL0_GAIN_Pos)
+#define SCIF_OSCCTRL0_GAIN(value)   (SCIF_OSCCTRL0_GAIN_Msk & ((value) << SCIF_OSCCTRL0_GAIN_Pos))
+#define SCIF_OSCCTRL0_AGC_Pos       3            /**< \brief (SCIF_OSCCTRL0) Automatic Gain Control */
+#define SCIF_OSCCTRL0_AGC           (_U(0x1) << SCIF_OSCCTRL0_AGC_Pos)
+#define SCIF_OSCCTRL0_STARTUP_Pos   8            /**< \brief (SCIF_OSCCTRL0) Oscillator Start-up Time */
+#define SCIF_OSCCTRL0_STARTUP_Msk   (_U(0xF) << SCIF_OSCCTRL0_STARTUP_Pos)
+#define SCIF_OSCCTRL0_STARTUP(value) (SCIF_OSCCTRL0_STARTUP_Msk & ((value) << SCIF_OSCCTRL0_STARTUP_Pos))
+#define SCIF_OSCCTRL0_OSCEN_Pos     16           /**< \brief (SCIF_OSCCTRL0) Oscillator Enable */
+#define SCIF_OSCCTRL0_OSCEN         (_U(0x1) << SCIF_OSCCTRL0_OSCEN_Pos)
+#define SCIF_OSCCTRL0_MASK          _U(0x00010F0F) /**< \brief (SCIF_OSCCTRL0) MASK Register */
+
+/* -------- SCIF_PLL : (SCIF Offset: 0x024) (R/W 32) pll PLL0 Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PLLEN:1;          /*!< bit:      0  PLL Enable                         */
+    uint32_t PLLOSC:2;         /*!< bit:  1.. 2  PLL Oscillator Select              */
+    uint32_t PLLOPT:3;         /*!< bit:  3.. 5  PLL Option                         */
+    uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t PLLDIV:4;         /*!< bit:  8..11  PLL Division Factor                */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t PLLMUL:4;         /*!< bit: 16..19  PLL Multiply Factor                */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t PLLCOUNT:6;       /*!< bit: 24..29  PLL Count                          */
+    uint32_t :2;               /*!< bit: 30..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_PLL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_PLL_OFFSET             0x024        /**< \brief (SCIF_PLL offset) PLL0 Control Register */
+#define SCIF_PLL_RESETVALUE         _U(0x00000000); /**< \brief (SCIF_PLL reset_value) PLL0 Control Register */
+
+#define SCIF_PLL_PLLEN_Pos          0            /**< \brief (SCIF_PLL) PLL Enable */
+#define SCIF_PLL_PLLEN              (_U(0x1) << SCIF_PLL_PLLEN_Pos)
+#define SCIF_PLL_PLLOSC_Pos         1            /**< \brief (SCIF_PLL) PLL Oscillator Select */
+#define SCIF_PLL_PLLOSC_Msk         (_U(0x3) << SCIF_PLL_PLLOSC_Pos)
+#define SCIF_PLL_PLLOSC(value)      (SCIF_PLL_PLLOSC_Msk & ((value) << SCIF_PLL_PLLOSC_Pos))
+#define SCIF_PLL_PLLOPT_Pos         3            /**< \brief (SCIF_PLL) PLL Option */
+#define SCIF_PLL_PLLOPT_Msk         (_U(0x7) << SCIF_PLL_PLLOPT_Pos)
+#define SCIF_PLL_PLLOPT(value)      (SCIF_PLL_PLLOPT_Msk & ((value) << SCIF_PLL_PLLOPT_Pos))
+#define SCIF_PLL_PLLDIV_Pos         8            /**< \brief (SCIF_PLL) PLL Division Factor */
+#define SCIF_PLL_PLLDIV_Msk         (_U(0xF) << SCIF_PLL_PLLDIV_Pos)
+#define SCIF_PLL_PLLDIV(value)      (SCIF_PLL_PLLDIV_Msk & ((value) << SCIF_PLL_PLLDIV_Pos))
+#define SCIF_PLL_PLLMUL_Pos         16           /**< \brief (SCIF_PLL) PLL Multiply Factor */
+#define SCIF_PLL_PLLMUL_Msk         (_U(0xF) << SCIF_PLL_PLLMUL_Pos)
+#define SCIF_PLL_PLLMUL(value)      (SCIF_PLL_PLLMUL_Msk & ((value) << SCIF_PLL_PLLMUL_Pos))
+#define SCIF_PLL_PLLCOUNT_Pos       24           /**< \brief (SCIF_PLL) PLL Count */
+#define SCIF_PLL_PLLCOUNT_Msk       (_U(0x3F) << SCIF_PLL_PLLCOUNT_Pos)
+#define SCIF_PLL_PLLCOUNT(value)    (SCIF_PLL_PLLCOUNT_Msk & ((value) << SCIF_PLL_PLLCOUNT_Pos))
+#define SCIF_PLL_MASK               _U(0x3F0F0F3F) /**< \brief (SCIF_PLL) MASK Register */
+
+/* -------- SCIF_DFLL0CONF : (SCIF Offset: 0x028) (R/W 32) DFLL0 Config Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EN:1;             /*!< bit:      0  Enable                             */
+    uint32_t MODE:1;           /*!< bit:      1  Mode Selection                     */
+    uint32_t STABLE:1;         /*!< bit:      2  Stable DFLL Frequency              */
+    uint32_t LLAW:1;           /*!< bit:      3  Lose Lock After Wake               */
+    uint32_t :1;               /*!< bit:      4  Reserved                           */
+    uint32_t CCDIS:1;          /*!< bit:      5  Chill Cycle Disable                */
+    uint32_t QLDIS:1;          /*!< bit:      6  Quick Lock Disable                 */
+    uint32_t :9;               /*!< bit:  7..15  Reserved                           */
+    uint32_t RANGE:2;          /*!< bit: 16..17  Range Value                        */
+    uint32_t :5;               /*!< bit: 18..22  Reserved                           */
+    uint32_t FCD:1;            /*!< bit:     23  Fuse Calibration Done              */
+    uint32_t CALIB:4;          /*!< bit: 24..27  Calibration Value                  */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_DFLL0CONF_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_DFLL0CONF_OFFSET       0x028        /**< \brief (SCIF_DFLL0CONF offset) DFLL0 Config Register */
+#define SCIF_DFLL0CONF_RESETVALUE   _U(0x00000000); /**< \brief (SCIF_DFLL0CONF reset_value) DFLL0 Config Register */
+
+#define SCIF_DFLL0CONF_EN_Pos       0            /**< \brief (SCIF_DFLL0CONF) Enable */
+#define SCIF_DFLL0CONF_EN           (_U(0x1) << SCIF_DFLL0CONF_EN_Pos)
+#define SCIF_DFLL0CONF_MODE_Pos     1            /**< \brief (SCIF_DFLL0CONF) Mode Selection */
+#define SCIF_DFLL0CONF_MODE         (_U(0x1) << SCIF_DFLL0CONF_MODE_Pos)
+#define SCIF_DFLL0CONF_STABLE_Pos   2            /**< \brief (SCIF_DFLL0CONF) Stable DFLL Frequency */
+#define SCIF_DFLL0CONF_STABLE       (_U(0x1) << SCIF_DFLL0CONF_STABLE_Pos)
+#define SCIF_DFLL0CONF_LLAW_Pos     3            /**< \brief (SCIF_DFLL0CONF) Lose Lock After Wake */
+#define SCIF_DFLL0CONF_LLAW         (_U(0x1) << SCIF_DFLL0CONF_LLAW_Pos)
+#define SCIF_DFLL0CONF_CCDIS_Pos    5            /**< \brief (SCIF_DFLL0CONF) Chill Cycle Disable */
+#define SCIF_DFLL0CONF_CCDIS        (_U(0x1) << SCIF_DFLL0CONF_CCDIS_Pos)
+#define SCIF_DFLL0CONF_QLDIS_Pos    6            /**< \brief (SCIF_DFLL0CONF) Quick Lock Disable */
+#define SCIF_DFLL0CONF_QLDIS        (_U(0x1) << SCIF_DFLL0CONF_QLDIS_Pos)
+#define SCIF_DFLL0CONF_RANGE_Pos    16           /**< \brief (SCIF_DFLL0CONF) Range Value */
+#define SCIF_DFLL0CONF_RANGE_Msk    (_U(0x3) << SCIF_DFLL0CONF_RANGE_Pos)
+#define SCIF_DFLL0CONF_RANGE(value) (SCIF_DFLL0CONF_RANGE_Msk & ((value) << SCIF_DFLL0CONF_RANGE_Pos))
+#define SCIF_DFLL0CONF_FCD_Pos      23           /**< \brief (SCIF_DFLL0CONF) Fuse Calibration Done */
+#define SCIF_DFLL0CONF_FCD          (_U(0x1) << SCIF_DFLL0CONF_FCD_Pos)
+#define SCIF_DFLL0CONF_CALIB_Pos    24           /**< \brief (SCIF_DFLL0CONF) Calibration Value */
+#define SCIF_DFLL0CONF_CALIB_Msk    (_U(0xF) << SCIF_DFLL0CONF_CALIB_Pos)
+#define SCIF_DFLL0CONF_CALIB(value) (SCIF_DFLL0CONF_CALIB_Msk & ((value) << SCIF_DFLL0CONF_CALIB_Pos))
+#define SCIF_DFLL0CONF_MASK         _U(0x0F83006F) /**< \brief (SCIF_DFLL0CONF) MASK Register */
+
+/* -------- SCIF_DFLL0VAL : (SCIF Offset: 0x02C) (R/W 32) DFLL Value Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t FINE:8;           /*!< bit:  0.. 7  Fine Value                         */
+    uint32_t :8;               /*!< bit:  8..15  Reserved                           */
+    uint32_t COARSE:5;         /*!< bit: 16..20  Coarse Value                       */
+    uint32_t :11;              /*!< bit: 21..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_DFLL0VAL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_DFLL0VAL_OFFSET        0x02C        /**< \brief (SCIF_DFLL0VAL offset) DFLL Value Register */
+#define SCIF_DFLL0VAL_RESETVALUE    _U(0x00000000); /**< \brief (SCIF_DFLL0VAL reset_value) DFLL Value Register */
+
+#define SCIF_DFLL0VAL_FINE_Pos      0            /**< \brief (SCIF_DFLL0VAL) Fine Value */
+#define SCIF_DFLL0VAL_FINE_Msk      (_U(0xFF) << SCIF_DFLL0VAL_FINE_Pos)
+#define SCIF_DFLL0VAL_FINE(value)   (SCIF_DFLL0VAL_FINE_Msk & ((value) << SCIF_DFLL0VAL_FINE_Pos))
+#define SCIF_DFLL0VAL_COARSE_Pos    16           /**< \brief (SCIF_DFLL0VAL) Coarse Value */
+#define SCIF_DFLL0VAL_COARSE_Msk    (_U(0x1F) << SCIF_DFLL0VAL_COARSE_Pos)
+#define SCIF_DFLL0VAL_COARSE(value) (SCIF_DFLL0VAL_COARSE_Msk & ((value) << SCIF_DFLL0VAL_COARSE_Pos))
+#define SCIF_DFLL0VAL_MASK          _U(0x001F00FF) /**< \brief (SCIF_DFLL0VAL) MASK Register */
+
+/* -------- SCIF_DFLL0MUL : (SCIF Offset: 0x030) (R/W 32) DFLL0 Multiplier Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t MUL:16;           /*!< bit:  0..15  DFLL Multiply Factor               */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_DFLL0MUL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_DFLL0MUL_OFFSET        0x030        /**< \brief (SCIF_DFLL0MUL offset) DFLL0 Multiplier Register */
+#define SCIF_DFLL0MUL_RESETVALUE    _U(0x00000000); /**< \brief (SCIF_DFLL0MUL reset_value) DFLL0 Multiplier Register */
+
+#define SCIF_DFLL0MUL_MUL_Pos       0            /**< \brief (SCIF_DFLL0MUL) DFLL Multiply Factor */
+#define SCIF_DFLL0MUL_MUL_Msk       (_U(0xFFFF) << SCIF_DFLL0MUL_MUL_Pos)
+#define SCIF_DFLL0MUL_MUL(value)    (SCIF_DFLL0MUL_MUL_Msk & ((value) << SCIF_DFLL0MUL_MUL_Pos))
+#define SCIF_DFLL0MUL_MASK          _U(0x0000FFFF) /**< \brief (SCIF_DFLL0MUL) MASK Register */
+
+/* -------- SCIF_DFLL0STEP : (SCIF Offset: 0x034) (R/W 32) DFLL0 Step Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t FSTEP:8;          /*!< bit:  0.. 7  Fine Maximum Step                  */
+    uint32_t :8;               /*!< bit:  8..15  Reserved                           */
+    uint32_t CSTEP:5;          /*!< bit: 16..20  Coarse Maximum Step                */
+    uint32_t :11;              /*!< bit: 21..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_DFLL0STEP_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_DFLL0STEP_OFFSET       0x034        /**< \brief (SCIF_DFLL0STEP offset) DFLL0 Step Register */
+#define SCIF_DFLL0STEP_RESETVALUE   _U(0x00000000); /**< \brief (SCIF_DFLL0STEP reset_value) DFLL0 Step Register */
+
+#define SCIF_DFLL0STEP_FSTEP_Pos    0            /**< \brief (SCIF_DFLL0STEP) Fine Maximum Step */
+#define SCIF_DFLL0STEP_FSTEP_Msk    (_U(0xFF) << SCIF_DFLL0STEP_FSTEP_Pos)
+#define SCIF_DFLL0STEP_FSTEP(value) (SCIF_DFLL0STEP_FSTEP_Msk & ((value) << SCIF_DFLL0STEP_FSTEP_Pos))
+#define SCIF_DFLL0STEP_CSTEP_Pos    16           /**< \brief (SCIF_DFLL0STEP) Coarse Maximum Step */
+#define SCIF_DFLL0STEP_CSTEP_Msk    (_U(0x1F) << SCIF_DFLL0STEP_CSTEP_Pos)
+#define SCIF_DFLL0STEP_CSTEP(value) (SCIF_DFLL0STEP_CSTEP_Msk & ((value) << SCIF_DFLL0STEP_CSTEP_Pos))
+#define SCIF_DFLL0STEP_MASK         _U(0x001F00FF) /**< \brief (SCIF_DFLL0STEP) MASK Register */
+
+/* -------- SCIF_DFLL0SSG : (SCIF Offset: 0x038) (R/W 32) DFLL0 Spread Spectrum Generator Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EN:1;             /*!< bit:      0  Enable                             */
+    uint32_t PRBS:1;           /*!< bit:      1  Pseudo Random Bit Sequence         */
+    uint32_t :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint32_t AMPLITUDE:5;      /*!< bit:  8..12  SSG Amplitude                      */
+    uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t STEPSIZE:5;       /*!< bit: 16..20  SSG Step Size                      */
+    uint32_t :11;              /*!< bit: 21..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_DFLL0SSG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_DFLL0SSG_OFFSET        0x038        /**< \brief (SCIF_DFLL0SSG offset) DFLL0 Spread Spectrum Generator Control Register */
+#define SCIF_DFLL0SSG_RESETVALUE    _U(0x00000000); /**< \brief (SCIF_DFLL0SSG reset_value) DFLL0 Spread Spectrum Generator Control Register */
+
+#define SCIF_DFLL0SSG_EN_Pos        0            /**< \brief (SCIF_DFLL0SSG) Enable */
+#define SCIF_DFLL0SSG_EN            (_U(0x1) << SCIF_DFLL0SSG_EN_Pos)
+#define SCIF_DFLL0SSG_PRBS_Pos      1            /**< \brief (SCIF_DFLL0SSG) Pseudo Random Bit Sequence */
+#define SCIF_DFLL0SSG_PRBS          (_U(0x1) << SCIF_DFLL0SSG_PRBS_Pos)
+#define SCIF_DFLL0SSG_AMPLITUDE_Pos 8            /**< \brief (SCIF_DFLL0SSG) SSG Amplitude */
+#define SCIF_DFLL0SSG_AMPLITUDE_Msk (_U(0x1F) << SCIF_DFLL0SSG_AMPLITUDE_Pos)
+#define SCIF_DFLL0SSG_AMPLITUDE(value) (SCIF_DFLL0SSG_AMPLITUDE_Msk & ((value) << SCIF_DFLL0SSG_AMPLITUDE_Pos))
+#define SCIF_DFLL0SSG_STEPSIZE_Pos  16           /**< \brief (SCIF_DFLL0SSG) SSG Step Size */
+#define SCIF_DFLL0SSG_STEPSIZE_Msk  (_U(0x1F) << SCIF_DFLL0SSG_STEPSIZE_Pos)
+#define SCIF_DFLL0SSG_STEPSIZE(value) (SCIF_DFLL0SSG_STEPSIZE_Msk & ((value) << SCIF_DFLL0SSG_STEPSIZE_Pos))
+#define SCIF_DFLL0SSG_MASK          _U(0x001F1F03) /**< \brief (SCIF_DFLL0SSG) MASK Register */
+
+/* -------- SCIF_DFLL0RATIO : (SCIF Offset: 0x03C) (R/  32) DFLL0 Ratio Registe -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RATIODIFF:16;     /*!< bit:  0..15  Multiplication Ratio Difference    */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_DFLL0RATIO_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_DFLL0RATIO_OFFSET      0x03C        /**< \brief (SCIF_DFLL0RATIO offset) DFLL0 Ratio Registe */
+#define SCIF_DFLL0RATIO_RESETVALUE  _U(0x00000000); /**< \brief (SCIF_DFLL0RATIO reset_value) DFLL0 Ratio Registe */
+
+#define SCIF_DFLL0RATIO_RATIODIFF_Pos 0            /**< \brief (SCIF_DFLL0RATIO) Multiplication Ratio Difference */
+#define SCIF_DFLL0RATIO_RATIODIFF_Msk (_U(0xFFFF) << SCIF_DFLL0RATIO_RATIODIFF_Pos)
+#define SCIF_DFLL0RATIO_RATIODIFF(value) (SCIF_DFLL0RATIO_RATIODIFF_Msk & ((value) << SCIF_DFLL0RATIO_RATIODIFF_Pos))
+#define SCIF_DFLL0RATIO_MASK        _U(0x0000FFFF) /**< \brief (SCIF_DFLL0RATIO) MASK Register */
+
+/* -------- SCIF_DFLL0SYNC : (SCIF Offset: 0x040) ( /W 32) DFLL0 Synchronization Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SYNC:1;           /*!< bit:      0  Synchronization                    */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_DFLL0SYNC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_DFLL0SYNC_OFFSET       0x040        /**< \brief (SCIF_DFLL0SYNC offset) DFLL0 Synchronization Register */
+#define SCIF_DFLL0SYNC_RESETVALUE   _U(0x00000000); /**< \brief (SCIF_DFLL0SYNC reset_value) DFLL0 Synchronization Register */
+
+#define SCIF_DFLL0SYNC_SYNC_Pos     0            /**< \brief (SCIF_DFLL0SYNC) Synchronization */
+#define SCIF_DFLL0SYNC_SYNC         (_U(0x1) << SCIF_DFLL0SYNC_SYNC_Pos)
+#define SCIF_DFLL0SYNC_MASK         _U(0x00000001) /**< \brief (SCIF_DFLL0SYNC) MASK Register */
+
+/* -------- SCIF_RCCR : (SCIF Offset: 0x044) (R/W 32) System RC Oscillator Calibration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CALIB:10;         /*!< bit:  0.. 9  Calibration Value                  */
+    uint32_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint32_t FCD:1;            /*!< bit:     16  Flash Calibration Done             */
+    uint32_t :15;              /*!< bit: 17..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_RCCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_RCCR_OFFSET            0x044        /**< \brief (SCIF_RCCR offset) System RC Oscillator Calibration Register */
+
+#define SCIF_RCCR_CALIB_Pos         0            /**< \brief (SCIF_RCCR) Calibration Value */
+#define SCIF_RCCR_CALIB_Msk         (_U(0x3FF) << SCIF_RCCR_CALIB_Pos)
+#define SCIF_RCCR_CALIB(value)      (SCIF_RCCR_CALIB_Msk & ((value) << SCIF_RCCR_CALIB_Pos))
+#define SCIF_RCCR_FCD_Pos           16           /**< \brief (SCIF_RCCR) Flash Calibration Done */
+#define SCIF_RCCR_FCD               (_U(0x1) << SCIF_RCCR_FCD_Pos)
+#define SCIF_RCCR_MASK              _U(0x000103FF) /**< \brief (SCIF_RCCR) MASK Register */
+
+/* -------- SCIF_RCFASTCFG : (SCIF Offset: 0x048) (R/W 32) 4/8/12 MHz RC Oscillator Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EN:1;             /*!< bit:      0  Oscillator Enable                  */
+    uint32_t TUNEEN:1;         /*!< bit:      1  Tuner Enable                       */
+    uint32_t JITMODE:1;        /*!< bit:      2  Jitter Mode                        */
+    uint32_t :1;               /*!< bit:      3  Reserved                           */
+    uint32_t NBPERIODS:3;      /*!< bit:  4.. 6  Number of 32kHz Periods            */
+    uint32_t FCD:1;            /*!< bit:      7  RCFAST Fuse Calibration Done       */
+    uint32_t FRANGE:2;         /*!< bit:  8.. 9  Frequency Range                    */
+    uint32_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint32_t LOCKMARGIN:4;     /*!< bit: 12..15  Accepted Count Error for Lock      */
+    uint32_t CALIB:7;          /*!< bit: 16..22  Oscillator Calibration Value       */
+    uint32_t :9;               /*!< bit: 23..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_RCFASTCFG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_RCFASTCFG_OFFSET       0x048        /**< \brief (SCIF_RCFASTCFG offset) 4/8/12 MHz RC Oscillator Configuration Register */
+#define SCIF_RCFASTCFG_RESETVALUE   _U(0x00000000); /**< \brief (SCIF_RCFASTCFG reset_value) 4/8/12 MHz RC Oscillator Configuration Register */
+
+#define SCIF_RCFASTCFG_EN_Pos       0            /**< \brief (SCIF_RCFASTCFG) Oscillator Enable */
+#define SCIF_RCFASTCFG_EN           (_U(0x1) << SCIF_RCFASTCFG_EN_Pos)
+#define SCIF_RCFASTCFG_TUNEEN_Pos   1            /**< \brief (SCIF_RCFASTCFG) Tuner Enable */
+#define SCIF_RCFASTCFG_TUNEEN       (_U(0x1) << SCIF_RCFASTCFG_TUNEEN_Pos)
+#define SCIF_RCFASTCFG_JITMODE_Pos  2            /**< \brief (SCIF_RCFASTCFG) Jitter Mode */
+#define SCIF_RCFASTCFG_JITMODE      (_U(0x1) << SCIF_RCFASTCFG_JITMODE_Pos)
+#define SCIF_RCFASTCFG_NBPERIODS_Pos 4            /**< \brief (SCIF_RCFASTCFG) Number of 32kHz Periods */
+#define SCIF_RCFASTCFG_NBPERIODS_Msk (_U(0x7) << SCIF_RCFASTCFG_NBPERIODS_Pos)
+#define SCIF_RCFASTCFG_NBPERIODS(value) (SCIF_RCFASTCFG_NBPERIODS_Msk & ((value) << SCIF_RCFASTCFG_NBPERIODS_Pos))
+#define SCIF_RCFASTCFG_FCD_Pos      7            /**< \brief (SCIF_RCFASTCFG) RCFAST Fuse Calibration Done */
+#define SCIF_RCFASTCFG_FCD          (_U(0x1) << SCIF_RCFASTCFG_FCD_Pos)
+#define SCIF_RCFASTCFG_FRANGE_Pos   8            /**< \brief (SCIF_RCFASTCFG) Frequency Range */
+#define SCIF_RCFASTCFG_FRANGE_Msk   (_U(0x3) << SCIF_RCFASTCFG_FRANGE_Pos)
+#define SCIF_RCFASTCFG_FRANGE(value) (SCIF_RCFASTCFG_FRANGE_Msk & ((value) << SCIF_RCFASTCFG_FRANGE_Pos))
+#define SCIF_RCFASTCFG_LOCKMARGIN_Pos 12           /**< \brief (SCIF_RCFASTCFG) Accepted Count Error for Lock */
+#define SCIF_RCFASTCFG_LOCKMARGIN_Msk (_U(0xF) << SCIF_RCFASTCFG_LOCKMARGIN_Pos)
+#define SCIF_RCFASTCFG_LOCKMARGIN(value) (SCIF_RCFASTCFG_LOCKMARGIN_Msk & ((value) << SCIF_RCFASTCFG_LOCKMARGIN_Pos))
+#define SCIF_RCFASTCFG_CALIB_Pos    16           /**< \brief (SCIF_RCFASTCFG) Oscillator Calibration Value */
+#define SCIF_RCFASTCFG_CALIB_Msk    (_U(0x7F) << SCIF_RCFASTCFG_CALIB_Pos)
+#define SCIF_RCFASTCFG_CALIB(value) (SCIF_RCFASTCFG_CALIB_Msk & ((value) << SCIF_RCFASTCFG_CALIB_Pos))
+#define SCIF_RCFASTCFG_MASK         _U(0x007FF3F7) /**< \brief (SCIF_RCFASTCFG) MASK Register */
+
+/* -------- SCIF_RCFASTSR : (SCIF Offset: 0x04C) (R/W 32) 4/8/12 MHz RC Oscillator Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CURTRIM:7;        /*!< bit:  0.. 6  Current Trim Value                 */
+    uint32_t :9;               /*!< bit:  7..15  Reserved                           */
+    uint32_t CNTERR:5;         /*!< bit: 16..20  Current Count Error                */
+    uint32_t SIGN:1;           /*!< bit:     21  Sign of Current Count Error        */
+    uint32_t :2;               /*!< bit: 22..23  Reserved                           */
+    uint32_t LOCK:1;           /*!< bit:     24  Lock                               */
+    uint32_t LOCKLOST:1;       /*!< bit:     25  Lock Lost                          */
+    uint32_t :5;               /*!< bit: 26..30  Reserved                           */
+    uint32_t UPDATED:1;        /*!< bit:     31  Current Trim Value Updated         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_RCFASTSR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_RCFASTSR_OFFSET        0x04C        /**< \brief (SCIF_RCFASTSR offset) 4/8/12 MHz RC Oscillator Status Register */
+#define SCIF_RCFASTSR_RESETVALUE    _U(0x00000000); /**< \brief (SCIF_RCFASTSR reset_value) 4/8/12 MHz RC Oscillator Status Register */
+
+#define SCIF_RCFASTSR_CURTRIM_Pos   0            /**< \brief (SCIF_RCFASTSR) Current Trim Value */
+#define SCIF_RCFASTSR_CURTRIM_Msk   (_U(0x7F) << SCIF_RCFASTSR_CURTRIM_Pos)
+#define SCIF_RCFASTSR_CURTRIM(value) (SCIF_RCFASTSR_CURTRIM_Msk & ((value) << SCIF_RCFASTSR_CURTRIM_Pos))
+#define SCIF_RCFASTSR_CNTERR_Pos    16           /**< \brief (SCIF_RCFASTSR) Current Count Error */
+#define SCIF_RCFASTSR_CNTERR_Msk    (_U(0x1F) << SCIF_RCFASTSR_CNTERR_Pos)
+#define SCIF_RCFASTSR_CNTERR(value) (SCIF_RCFASTSR_CNTERR_Msk & ((value) << SCIF_RCFASTSR_CNTERR_Pos))
+#define SCIF_RCFASTSR_SIGN_Pos      21           /**< \brief (SCIF_RCFASTSR) Sign of Current Count Error */
+#define SCIF_RCFASTSR_SIGN          (_U(0x1) << SCIF_RCFASTSR_SIGN_Pos)
+#define SCIF_RCFASTSR_LOCK_Pos      24           /**< \brief (SCIF_RCFASTSR) Lock */
+#define SCIF_RCFASTSR_LOCK          (_U(0x1) << SCIF_RCFASTSR_LOCK_Pos)
+#define SCIF_RCFASTSR_LOCKLOST_Pos  25           /**< \brief (SCIF_RCFASTSR) Lock Lost */
+#define SCIF_RCFASTSR_LOCKLOST      (_U(0x1) << SCIF_RCFASTSR_LOCKLOST_Pos)
+#define SCIF_RCFASTSR_UPDATED_Pos   31           /**< \brief (SCIF_RCFASTSR) Current Trim Value Updated */
+#define SCIF_RCFASTSR_UPDATED       (_U(0x1) << SCIF_RCFASTSR_UPDATED_Pos)
+#define SCIF_RCFASTSR_MASK          _U(0x833F007F) /**< \brief (SCIF_RCFASTSR) MASK Register */
+
+/* -------- SCIF_RC80MCR : (SCIF Offset: 0x050) (R/W 32) 80 MHz RC Oscillator Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EN:1;             /*!< bit:      0  Enable                             */
+    uint32_t :6;               /*!< bit:  1.. 6  Reserved                           */
+    uint32_t FCD:1;            /*!< bit:      7  Flash Calibration Done             */
+    uint32_t :8;               /*!< bit:  8..15  Reserved                           */
+    uint32_t CALIB:2;          /*!< bit: 16..17  Calibration Value                  */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_RC80MCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_RC80MCR_OFFSET         0x050        /**< \brief (SCIF_RC80MCR offset) 80 MHz RC Oscillator Register */
+#define SCIF_RC80MCR_RESETVALUE     _U(0x00000000); /**< \brief (SCIF_RC80MCR reset_value) 80 MHz RC Oscillator Register */
+
+#define SCIF_RC80MCR_EN_Pos         0            /**< \brief (SCIF_RC80MCR) Enable */
+#define SCIF_RC80MCR_EN             (_U(0x1) << SCIF_RC80MCR_EN_Pos)
+#define SCIF_RC80MCR_FCD_Pos        7            /**< \brief (SCIF_RC80MCR) Flash Calibration Done */
+#define SCIF_RC80MCR_FCD            (_U(0x1) << SCIF_RC80MCR_FCD_Pos)
+#define SCIF_RC80MCR_CALIB_Pos      16           /**< \brief (SCIF_RC80MCR) Calibration Value */
+#define SCIF_RC80MCR_CALIB_Msk      (_U(0x3) << SCIF_RC80MCR_CALIB_Pos)
+#define SCIF_RC80MCR_CALIB(value)   (SCIF_RC80MCR_CALIB_Msk & ((value) << SCIF_RC80MCR_CALIB_Pos))
+#define SCIF_RC80MCR_MASK           _U(0x00030081) /**< \brief (SCIF_RC80MCR) MASK Register */
+
+/* -------- SCIF_HRPCR : (SCIF Offset: 0x064) (R/W 32) High Resolution Prescaler Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t HRPEN:1;          /*!< bit:      0  High Resolution Prescaler Enable   */
+    uint32_t CKSEL:3;          /*!< bit:  1.. 3  Clock Input Selection              */
+    uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint32_t HRCOUNT:24;       /*!< bit:  8..31  High Resolution Counter            */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_HRPCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_HRPCR_OFFSET           0x064        /**< \brief (SCIF_HRPCR offset) High Resolution Prescaler Control Register */
+
+#define SCIF_HRPCR_HRPEN_Pos        0            /**< \brief (SCIF_HRPCR) High Resolution Prescaler Enable */
+#define SCIF_HRPCR_HRPEN            (_U(0x1) << SCIF_HRPCR_HRPEN_Pos)
+#define SCIF_HRPCR_CKSEL_Pos        1            /**< \brief (SCIF_HRPCR) Clock Input Selection */
+#define SCIF_HRPCR_CKSEL_Msk        (_U(0x7) << SCIF_HRPCR_CKSEL_Pos)
+#define SCIF_HRPCR_CKSEL(value)     (SCIF_HRPCR_CKSEL_Msk & ((value) << SCIF_HRPCR_CKSEL_Pos))
+#define SCIF_HRPCR_HRCOUNT_Pos      8            /**< \brief (SCIF_HRPCR) High Resolution Counter */
+#define SCIF_HRPCR_HRCOUNT_Msk      (_U(0xFFFFFF) << SCIF_HRPCR_HRCOUNT_Pos)
+#define SCIF_HRPCR_HRCOUNT(value)   (SCIF_HRPCR_HRCOUNT_Msk & ((value) << SCIF_HRPCR_HRCOUNT_Pos))
+#define SCIF_HRPCR_MASK             _U(0xFFFFFF0F) /**< \brief (SCIF_HRPCR) MASK Register */
+
+/* -------- SCIF_FPCR : (SCIF Offset: 0x068) (R/W 32) Fractional Prescaler Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t FPEN:1;           /*!< bit:      0  High Resolution Prescaler Enable   */
+    uint32_t CKSEL:3;          /*!< bit:  1.. 3  Clock Input Selection              */
+    uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_FPCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_FPCR_OFFSET            0x068        /**< \brief (SCIF_FPCR offset) Fractional Prescaler Control Register */
+
+#define SCIF_FPCR_FPEN_Pos          0            /**< \brief (SCIF_FPCR) High Resolution Prescaler Enable */
+#define SCIF_FPCR_FPEN              (_U(0x1) << SCIF_FPCR_FPEN_Pos)
+#define SCIF_FPCR_CKSEL_Pos         1            /**< \brief (SCIF_FPCR) Clock Input Selection */
+#define SCIF_FPCR_CKSEL_Msk         (_U(0x7) << SCIF_FPCR_CKSEL_Pos)
+#define SCIF_FPCR_CKSEL(value)      (SCIF_FPCR_CKSEL_Msk & ((value) << SCIF_FPCR_CKSEL_Pos))
+#define SCIF_FPCR_MASK              _U(0x0000000F) /**< \brief (SCIF_FPCR) MASK Register */
+
+/* -------- SCIF_FPMUL : (SCIF Offset: 0x06C) (R/W 32) Fractional Prescaler Multiplier Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t FPMUL:16;         /*!< bit:  0..15  Fractional Prescaler Multiplication Factor */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_FPMUL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_FPMUL_OFFSET           0x06C        /**< \brief (SCIF_FPMUL offset) Fractional Prescaler Multiplier Register */
+
+#define SCIF_FPMUL_FPMUL_Pos        0            /**< \brief (SCIF_FPMUL) Fractional Prescaler Multiplication Factor */
+#define SCIF_FPMUL_FPMUL_Msk        (_U(0xFFFF) << SCIF_FPMUL_FPMUL_Pos)
+#define SCIF_FPMUL_FPMUL(value)     (SCIF_FPMUL_FPMUL_Msk & ((value) << SCIF_FPMUL_FPMUL_Pos))
+#define SCIF_FPMUL_MASK             _U(0x0000FFFF) /**< \brief (SCIF_FPMUL) MASK Register */
+
+/* -------- SCIF_FPDIV : (SCIF Offset: 0x070) (R/W 32) Fractional Prescaler DIVIDER Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t FPDIV:16;         /*!< bit:  0..15  Fractional Prescaler Division Factor */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_FPDIV_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_FPDIV_OFFSET           0x070        /**< \brief (SCIF_FPDIV offset) Fractional Prescaler DIVIDER Register */
+
+#define SCIF_FPDIV_FPDIV_Pos        0            /**< \brief (SCIF_FPDIV) Fractional Prescaler Division Factor */
+#define SCIF_FPDIV_FPDIV_Msk        (_U(0xFFFF) << SCIF_FPDIV_FPDIV_Pos)
+#define SCIF_FPDIV_FPDIV(value)     (SCIF_FPDIV_FPDIV_Msk & ((value) << SCIF_FPDIV_FPDIV_Pos))
+#define SCIF_FPDIV_MASK             _U(0x0000FFFF) /**< \brief (SCIF_FPDIV) MASK Register */
+
+/* -------- SCIF_GCCTRL : (SCIF Offset: 0x074) (R/W 32) gcctrl Generic Clock Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CEN:1;            /*!< bit:      0  Clock Enable                       */
+    uint32_t DIVEN:1;          /*!< bit:      1  Divide Enable                      */
+    uint32_t :6;               /*!< bit:  2.. 7  Reserved                           */
+    uint32_t OSCSEL:5;         /*!< bit:  8..12  Clock Select                       */
+    uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t DIV:16;           /*!< bit: 16..31  Division Factor                    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_GCCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_GCCTRL_OFFSET          0x074        /**< \brief (SCIF_GCCTRL offset) Generic Clock Control */
+#define SCIF_GCCTRL_RESETVALUE      _U(0x00000000); /**< \brief (SCIF_GCCTRL reset_value) Generic Clock Control */
+
+#define SCIF_GCCTRL_CEN_Pos         0            /**< \brief (SCIF_GCCTRL) Clock Enable */
+#define SCIF_GCCTRL_CEN             (_U(0x1) << SCIF_GCCTRL_CEN_Pos)
+#define SCIF_GCCTRL_DIVEN_Pos       1            /**< \brief (SCIF_GCCTRL) Divide Enable */
+#define SCIF_GCCTRL_DIVEN           (_U(0x1) << SCIF_GCCTRL_DIVEN_Pos)
+#define SCIF_GCCTRL_OSCSEL_Pos      8            /**< \brief (SCIF_GCCTRL) Clock Select */
+#define SCIF_GCCTRL_OSCSEL_Msk      (_U(0x1F) << SCIF_GCCTRL_OSCSEL_Pos)
+#define SCIF_GCCTRL_OSCSEL(value)   (SCIF_GCCTRL_OSCSEL_Msk & ((value) << SCIF_GCCTRL_OSCSEL_Pos))
+#define SCIF_GCCTRL_DIV_Pos         16           /**< \brief (SCIF_GCCTRL) Division Factor */
+#define SCIF_GCCTRL_DIV_Msk         (_U(0xFFFF) << SCIF_GCCTRL_DIV_Pos)
+#define SCIF_GCCTRL_DIV(value)      (SCIF_GCCTRL_DIV_Msk & ((value) << SCIF_GCCTRL_DIV_Pos))
+#define SCIF_GCCTRL_MASK            _U(0xFFFF1F03) /**< \brief (SCIF_GCCTRL) MASK Register */
+
+/* -------- SCIF_RCFASTVERSION : (SCIF Offset: 0x3D8) (R/  32) 4/8/12 MHz RC Oscillator Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_RCFASTVERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_RCFASTVERSION_OFFSET   0x3D8        /**< \brief (SCIF_RCFASTVERSION offset) 4/8/12 MHz RC Oscillator Version Register */
+
+#define SCIF_RCFASTVERSION_VERSION_Pos 0            /**< \brief (SCIF_RCFASTVERSION) Version number */
+#define SCIF_RCFASTVERSION_VERSION_Msk (_U(0xFFF) << SCIF_RCFASTVERSION_VERSION_Pos)
+#define SCIF_RCFASTVERSION_VERSION(value) (SCIF_RCFASTVERSION_VERSION_Msk & ((value) << SCIF_RCFASTVERSION_VERSION_Pos))
+#define SCIF_RCFASTVERSION_VARIANT_Pos 16           /**< \brief (SCIF_RCFASTVERSION) Variant number */
+#define SCIF_RCFASTVERSION_VARIANT_Msk (_U(0xF) << SCIF_RCFASTVERSION_VARIANT_Pos)
+#define SCIF_RCFASTVERSION_VARIANT(value) (SCIF_RCFASTVERSION_VARIANT_Msk & ((value) << SCIF_RCFASTVERSION_VARIANT_Pos))
+#define SCIF_RCFASTVERSION_MASK     _U(0x000F0FFF) /**< \brief (SCIF_RCFASTVERSION) MASK Register */
+
+/* -------- SCIF_GCLKPRESCVERSION : (SCIF Offset: 0x3DC) (R/  32) Generic Clock Prescaler Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_GCLKPRESCVERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_GCLKPRESCVERSION_OFFSET 0x3DC        /**< \brief (SCIF_GCLKPRESCVERSION offset) Generic Clock Prescaler Version Register */
+
+#define SCIF_GCLKPRESCVERSION_VERSION_Pos 0            /**< \brief (SCIF_GCLKPRESCVERSION) Version number */
+#define SCIF_GCLKPRESCVERSION_VERSION_Msk (_U(0xFFF) << SCIF_GCLKPRESCVERSION_VERSION_Pos)
+#define SCIF_GCLKPRESCVERSION_VERSION(value) (SCIF_GCLKPRESCVERSION_VERSION_Msk & ((value) << SCIF_GCLKPRESCVERSION_VERSION_Pos))
+#define SCIF_GCLKPRESCVERSION_VARIANT_Pos 16           /**< \brief (SCIF_GCLKPRESCVERSION) Variant number */
+#define SCIF_GCLKPRESCVERSION_VARIANT_Msk (_U(0xF) << SCIF_GCLKPRESCVERSION_VARIANT_Pos)
+#define SCIF_GCLKPRESCVERSION_VARIANT(value) (SCIF_GCLKPRESCVERSION_VARIANT_Msk & ((value) << SCIF_GCLKPRESCVERSION_VARIANT_Pos))
+#define SCIF_GCLKPRESCVERSION_MASK  _U(0x000F0FFF) /**< \brief (SCIF_GCLKPRESCVERSION) MASK Register */
+
+/* -------- SCIF_PLLIFAVERSION : (SCIF Offset: 0x3E0) (R/  32) PLL Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant nubmer                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_PLLIFAVERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_PLLIFAVERSION_OFFSET   0x3E0        /**< \brief (SCIF_PLLIFAVERSION offset) PLL Version Register */
+
+#define SCIF_PLLIFAVERSION_VERSION_Pos 0            /**< \brief (SCIF_PLLIFAVERSION) Version number */
+#define SCIF_PLLIFAVERSION_VERSION_Msk (_U(0xFFF) << SCIF_PLLIFAVERSION_VERSION_Pos)
+#define SCIF_PLLIFAVERSION_VERSION(value) (SCIF_PLLIFAVERSION_VERSION_Msk & ((value) << SCIF_PLLIFAVERSION_VERSION_Pos))
+#define SCIF_PLLIFAVERSION_VARIANT_Pos 16           /**< \brief (SCIF_PLLIFAVERSION) Variant nubmer */
+#define SCIF_PLLIFAVERSION_VARIANT_Msk (_U(0xF) << SCIF_PLLIFAVERSION_VARIANT_Pos)
+#define SCIF_PLLIFAVERSION_VARIANT(value) (SCIF_PLLIFAVERSION_VARIANT_Msk & ((value) << SCIF_PLLIFAVERSION_VARIANT_Pos))
+#define SCIF_PLLIFAVERSION_MASK     _U(0x000F0FFF) /**< \brief (SCIF_PLLIFAVERSION) MASK Register */
+
+/* -------- SCIF_OSCIFAVERSION : (SCIF Offset: 0x3E4) (R/  32) Oscillator 0 Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant nubmer                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_OSCIFAVERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_OSCIFAVERSION_OFFSET   0x3E4        /**< \brief (SCIF_OSCIFAVERSION offset) Oscillator 0 Version Register */
+
+#define SCIF_OSCIFAVERSION_VERSION_Pos 0            /**< \brief (SCIF_OSCIFAVERSION) Version number */
+#define SCIF_OSCIFAVERSION_VERSION_Msk (_U(0xFFF) << SCIF_OSCIFAVERSION_VERSION_Pos)
+#define SCIF_OSCIFAVERSION_VERSION(value) (SCIF_OSCIFAVERSION_VERSION_Msk & ((value) << SCIF_OSCIFAVERSION_VERSION_Pos))
+#define SCIF_OSCIFAVERSION_VARIANT_Pos 16           /**< \brief (SCIF_OSCIFAVERSION) Variant nubmer */
+#define SCIF_OSCIFAVERSION_VARIANT_Msk (_U(0xF) << SCIF_OSCIFAVERSION_VARIANT_Pos)
+#define SCIF_OSCIFAVERSION_VARIANT(value) (SCIF_OSCIFAVERSION_VARIANT_Msk & ((value) << SCIF_OSCIFAVERSION_VARIANT_Pos))
+#define SCIF_OSCIFAVERSION_MASK     _U(0x000F0FFF) /**< \brief (SCIF_OSCIFAVERSION) MASK Register */
+
+/* -------- SCIF_DFLLIFBVERSION : (SCIF Offset: 0x3E8) (R/  32) DFLL Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_DFLLIFBVERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_DFLLIFBVERSION_OFFSET  0x3E8        /**< \brief (SCIF_DFLLIFBVERSION offset) DFLL Version Register */
+
+#define SCIF_DFLLIFBVERSION_VERSION_Pos 0            /**< \brief (SCIF_DFLLIFBVERSION) Version number */
+#define SCIF_DFLLIFBVERSION_VERSION_Msk (_U(0xFFF) << SCIF_DFLLIFBVERSION_VERSION_Pos)
+#define SCIF_DFLLIFBVERSION_VERSION(value) (SCIF_DFLLIFBVERSION_VERSION_Msk & ((value) << SCIF_DFLLIFBVERSION_VERSION_Pos))
+#define SCIF_DFLLIFBVERSION_VARIANT_Pos 16           /**< \brief (SCIF_DFLLIFBVERSION) Variant number */
+#define SCIF_DFLLIFBVERSION_VARIANT_Msk (_U(0xF) << SCIF_DFLLIFBVERSION_VARIANT_Pos)
+#define SCIF_DFLLIFBVERSION_VARIANT(value) (SCIF_DFLLIFBVERSION_VARIANT_Msk & ((value) << SCIF_DFLLIFBVERSION_VARIANT_Pos))
+#define SCIF_DFLLIFBVERSION_MASK    _U(0x000F0FFF) /**< \brief (SCIF_DFLLIFBVERSION) MASK Register */
+
+/* -------- SCIF_RCOSCIFAVERSION : (SCIF Offset: 0x3EC) (R/  32) System RC Oscillator Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_RCOSCIFAVERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_RCOSCIFAVERSION_OFFSET 0x3EC        /**< \brief (SCIF_RCOSCIFAVERSION offset) System RC Oscillator Version Register */
+
+#define SCIF_RCOSCIFAVERSION_VERSION_Pos 0            /**< \brief (SCIF_RCOSCIFAVERSION) Version number */
+#define SCIF_RCOSCIFAVERSION_VERSION_Msk (_U(0xFFF) << SCIF_RCOSCIFAVERSION_VERSION_Pos)
+#define SCIF_RCOSCIFAVERSION_VERSION(value) (SCIF_RCOSCIFAVERSION_VERSION_Msk & ((value) << SCIF_RCOSCIFAVERSION_VERSION_Pos))
+#define SCIF_RCOSCIFAVERSION_VARIANT_Pos 16           /**< \brief (SCIF_RCOSCIFAVERSION) Variant number */
+#define SCIF_RCOSCIFAVERSION_VARIANT_Msk (_U(0xF) << SCIF_RCOSCIFAVERSION_VARIANT_Pos)
+#define SCIF_RCOSCIFAVERSION_VARIANT(value) (SCIF_RCOSCIFAVERSION_VARIANT_Msk & ((value) << SCIF_RCOSCIFAVERSION_VARIANT_Pos))
+#define SCIF_RCOSCIFAVERSION_MASK   _U(0x000F0FFF) /**< \brief (SCIF_RCOSCIFAVERSION) MASK Register */
+
+/* -------- SCIF_FLOVERSION : (SCIF Offset: 0x3F0) (R/  32) Frequency Locked Oscillator Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_FLOVERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_FLOVERSION_OFFSET      0x3F0        /**< \brief (SCIF_FLOVERSION offset) Frequency Locked Oscillator Version Register */
+
+#define SCIF_FLOVERSION_VERSION_Pos 0            /**< \brief (SCIF_FLOVERSION) Version number */
+#define SCIF_FLOVERSION_VERSION_Msk (_U(0xFFF) << SCIF_FLOVERSION_VERSION_Pos)
+#define SCIF_FLOVERSION_VERSION(value) (SCIF_FLOVERSION_VERSION_Msk & ((value) << SCIF_FLOVERSION_VERSION_Pos))
+#define SCIF_FLOVERSION_VARIANT_Pos 16           /**< \brief (SCIF_FLOVERSION) Variant number */
+#define SCIF_FLOVERSION_VARIANT_Msk (_U(0xF) << SCIF_FLOVERSION_VARIANT_Pos)
+#define SCIF_FLOVERSION_VARIANT(value) (SCIF_FLOVERSION_VARIANT_Msk & ((value) << SCIF_FLOVERSION_VARIANT_Pos))
+#define SCIF_FLOVERSION_MASK        _U(0x000F0FFF) /**< \brief (SCIF_FLOVERSION) MASK Register */
+
+/* -------- SCIF_RC80MVERSION : (SCIF Offset: 0x3F4) (R/  32) 80MHz RC Oscillator Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_RC80MVERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_RC80MVERSION_OFFSET    0x3F4        /**< \brief (SCIF_RC80MVERSION offset) 80MHz RC Oscillator Version Register */
+
+#define SCIF_RC80MVERSION_VERSION_Pos 0            /**< \brief (SCIF_RC80MVERSION) Version number */
+#define SCIF_RC80MVERSION_VERSION_Msk (_U(0xFFF) << SCIF_RC80MVERSION_VERSION_Pos)
+#define SCIF_RC80MVERSION_VERSION(value) (SCIF_RC80MVERSION_VERSION_Msk & ((value) << SCIF_RC80MVERSION_VERSION_Pos))
+#define SCIF_RC80MVERSION_VARIANT_Pos 16           /**< \brief (SCIF_RC80MVERSION) Variant number */
+#define SCIF_RC80MVERSION_VARIANT_Msk (_U(0xF) << SCIF_RC80MVERSION_VARIANT_Pos)
+#define SCIF_RC80MVERSION_VARIANT(value) (SCIF_RC80MVERSION_VARIANT_Msk & ((value) << SCIF_RC80MVERSION_VARIANT_Pos))
+#define SCIF_RC80MVERSION_MASK      _U(0x000F0FFF) /**< \brief (SCIF_RC80MVERSION) MASK Register */
+
+/* -------- SCIF_GCLKIFVERSION : (SCIF Offset: 0x3F8) (R/  32) Generic Clock Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_GCLKIFVERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_GCLKIFVERSION_OFFSET   0x3F8        /**< \brief (SCIF_GCLKIFVERSION offset) Generic Clock Version Register */
+
+#define SCIF_GCLKIFVERSION_VERSION_Pos 0            /**< \brief (SCIF_GCLKIFVERSION) Version number */
+#define SCIF_GCLKIFVERSION_VERSION_Msk (_U(0xFFF) << SCIF_GCLKIFVERSION_VERSION_Pos)
+#define SCIF_GCLKIFVERSION_VERSION(value) (SCIF_GCLKIFVERSION_VERSION_Msk & ((value) << SCIF_GCLKIFVERSION_VERSION_Pos))
+#define SCIF_GCLKIFVERSION_VARIANT_Pos 16           /**< \brief (SCIF_GCLKIFVERSION) Variant number */
+#define SCIF_GCLKIFVERSION_VARIANT_Msk (_U(0xF) << SCIF_GCLKIFVERSION_VARIANT_Pos)
+#define SCIF_GCLKIFVERSION_VARIANT(value) (SCIF_GCLKIFVERSION_VARIANT_Msk & ((value) << SCIF_GCLKIFVERSION_VARIANT_Pos))
+#define SCIF_GCLKIFVERSION_MASK     _U(0x000F0FFF) /**< \brief (SCIF_GCLKIFVERSION) MASK Register */
+
+/* -------- SCIF_VERSION : (SCIF Offset: 0x3FC) (R/  32) SCIF Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SCIF_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SCIF_VERSION_OFFSET         0x3FC        /**< \brief (SCIF_VERSION offset) SCIF Version Register */
+#define SCIF_VERSION_RESETVALUE     _U(0x00000130); /**< \brief (SCIF_VERSION reset_value) SCIF Version Register */
+
+#define SCIF_VERSION_VERSION_Pos    0            /**< \brief (SCIF_VERSION) Version number */
+#define SCIF_VERSION_VERSION_Msk    (_U(0xFFF) << SCIF_VERSION_VERSION_Pos)
+#define SCIF_VERSION_VERSION(value) (SCIF_VERSION_VERSION_Msk & ((value) << SCIF_VERSION_VERSION_Pos))
+#define SCIF_VERSION_VARIANT_Pos    16           /**< \brief (SCIF_VERSION) Variant number */
+#define SCIF_VERSION_VARIANT_Msk    (_U(0xF) << SCIF_VERSION_VARIANT_Pos)
+#define SCIF_VERSION_VARIANT(value) (SCIF_VERSION_VARIANT_Msk & ((value) << SCIF_VERSION_VARIANT_Pos))
+#define SCIF_VERSION_MASK           _U(0x000F0FFF) /**< \brief (SCIF_VERSION) MASK Register */
+
+/** \brief ScifGcctrl hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __IO SCIF_GCCTRL_Type          GCCTRL;      /**< \brief Offset: 0x000 (R/W 32) Generic Clock Control */
+ } bf;
+ struct {
+  RwReg   SCIF_GCCTRL;        /**< \brief (SCIF Offset: 0x000) Generic Clock Control */
+ } reg;
+} ScifGcctrl;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief ScifPll hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __IO SCIF_PLL_Type             PLL;         /**< \brief Offset: 0x000 (R/W 32) PLL0 Control Register */
+ } bf;
+ struct {
+  RwReg   SCIF_PLL;           /**< \brief (SCIF Offset: 0x000) PLL0 Control Register */
+ } reg;
+} ScifPll;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief SCIF hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __O  SCIF_IER_Type             IER;         /**< \brief Offset: 0x000 ( /W 32) Interrupt Enable Register */
+  __O  SCIF_IDR_Type             IDR;         /**< \brief Offset: 0x004 ( /W 32) Interrupt Disable Register */
+  __I  SCIF_IMR_Type             IMR;         /**< \brief Offset: 0x008 (R/  32) Interrupt Mask Register */
+  __I  SCIF_ISR_Type             ISR;         /**< \brief Offset: 0x00C (R/  32) Interrupt Status Register */
+  __O  SCIF_ICR_Type             ICR;         /**< \brief Offset: 0x010 ( /W 32) Interrupt Clear Register */
+  __I  SCIF_PCLKSR_Type          PCLKSR;      /**< \brief Offset: 0x014 (R/  32) Power and Clocks Status Register */
+  __O  SCIF_UNLOCK_Type          UNLOCK;      /**< \brief Offset: 0x018 ( /W 32) Unlock Register */
+  __IO SCIF_CSCR_Type            CSCR;        /**< \brief Offset: 0x01C (R/W 32) Chip Specific Configuration Register */
+  __IO SCIF_OSCCTRL0_Type        OSCCTRL0;    /**< \brief Offset: 0x020 (R/W 32) Oscillator Control Register */
+       ScifPll                   Pll[1];      /**< \brief Offset: 0x024 ScifPll groups */
+  __IO SCIF_DFLL0CONF_Type       DFLL0CONF;   /**< \brief Offset: 0x028 (R/W 32) DFLL0 Config Register */
+  __IO SCIF_DFLL0VAL_Type        DFLL0VAL;    /**< \brief Offset: 0x02C (R/W 32) DFLL Value Register */
+  __IO SCIF_DFLL0MUL_Type        DFLL0MUL;    /**< \brief Offset: 0x030 (R/W 32) DFLL0 Multiplier Register */
+  __IO SCIF_DFLL0STEP_Type       DFLL0STEP;   /**< \brief Offset: 0x034 (R/W 32) DFLL0 Step Register */
+  __IO SCIF_DFLL0SSG_Type        DFLL0SSG;    /**< \brief Offset: 0x038 (R/W 32) DFLL0 Spread Spectrum Generator Control Register */
+  __I  SCIF_DFLL0RATIO_Type      DFLL0RATIO;  /**< \brief Offset: 0x03C (R/  32) DFLL0 Ratio Registe */
+  __O  SCIF_DFLL0SYNC_Type       DFLL0SYNC;   /**< \brief Offset: 0x040 ( /W 32) DFLL0 Synchronization Register */
+  __IO SCIF_RCCR_Type            RCCR;        /**< \brief Offset: 0x044 (R/W 32) System RC Oscillator Calibration Register */
+  __IO SCIF_RCFASTCFG_Type       RCFASTCFG;   /**< \brief Offset: 0x048 (R/W 32) 4/8/12 MHz RC Oscillator Configuration Register */
+  __IO SCIF_RCFASTSR_Type        RCFASTSR;    /**< \brief Offset: 0x04C (R/W 32) 4/8/12 MHz RC Oscillator Status Register */
+  __IO SCIF_RC80MCR_Type         RC80MCR;     /**< \brief Offset: 0x050 (R/W 32) 80 MHz RC Oscillator Register */
+       RoReg8                    Reserved1[0x10];
+  __IO SCIF_HRPCR_Type           HRPCR;       /**< \brief Offset: 0x064 (R/W 32) High Resolution Prescaler Control Register */
+  __IO SCIF_FPCR_Type            FPCR;        /**< \brief Offset: 0x068 (R/W 32) Fractional Prescaler Control Register */
+  __IO SCIF_FPMUL_Type           FPMUL;       /**< \brief Offset: 0x06C (R/W 32) Fractional Prescaler Multiplier Register */
+  __IO SCIF_FPDIV_Type           FPDIV;       /**< \brief Offset: 0x070 (R/W 32) Fractional Prescaler DIVIDER Register */
+       ScifGcctrl                Gcctrl[12];  /**< \brief Offset: 0x074 ScifGcctrl groups */
+       RoReg8                    Reserved2[0x334];
+  __I  SCIF_RCFASTVERSION_Type   RCFASTVERSION; /**< \brief Offset: 0x3D8 (R/  32) 4/8/12 MHz RC Oscillator Version Register */
+  __I  SCIF_GCLKPRESCVERSION_Type GCLKPRESCVERSION; /**< \brief Offset: 0x3DC (R/  32) Generic Clock Prescaler Version Register */
+  __I  SCIF_PLLIFAVERSION_Type   PLLIFAVERSION; /**< \brief Offset: 0x3E0 (R/  32) PLL Version Register */
+  __I  SCIF_OSCIFAVERSION_Type   OSCIFAVERSION; /**< \brief Offset: 0x3E4 (R/  32) Oscillator 0 Version Register */
+  __I  SCIF_DFLLIFBVERSION_Type  DFLLIFBVERSION; /**< \brief Offset: 0x3E8 (R/  32) DFLL Version Register */
+  __I  SCIF_RCOSCIFAVERSION_Type RCOSCIFAVERSION; /**< \brief Offset: 0x3EC (R/  32) System RC Oscillator Version Register */
+  __I  SCIF_FLOVERSION_Type      FLOVERSION;  /**< \brief Offset: 0x3F0 (R/  32) Frequency Locked Oscillator Version Register */
+  __I  SCIF_RC80MVERSION_Type    RC80MVERSION; /**< \brief Offset: 0x3F4 (R/  32) 80MHz RC Oscillator Version Register */
+  __I  SCIF_GCLKIFVERSION_Type   GCLKIFVERSION; /**< \brief Offset: 0x3F8 (R/  32) Generic Clock Version Register */
+  __I  SCIF_VERSION_Type         VERSION;     /**< \brief Offset: 0x3FC (R/  32) SCIF Version Register */
+ } bf;
+ struct {
+  WoReg   SCIF_IER;           /**< \brief (SCIF Offset: 0x000) Interrupt Enable Register */
+  WoReg   SCIF_IDR;           /**< \brief (SCIF Offset: 0x004) Interrupt Disable Register */
+  RoReg   SCIF_IMR;           /**< \brief (SCIF Offset: 0x008) Interrupt Mask Register */
+  RoReg   SCIF_ISR;           /**< \brief (SCIF Offset: 0x00C) Interrupt Status Register */
+  WoReg   SCIF_ICR;           /**< \brief (SCIF Offset: 0x010) Interrupt Clear Register */
+  RoReg   SCIF_PCLKSR;        /**< \brief (SCIF Offset: 0x014) Power and Clocks Status Register */
+  WoReg   SCIF_UNLOCK;        /**< \brief (SCIF Offset: 0x018) Unlock Register */
+  RwReg   SCIF_CSCR;          /**< \brief (SCIF Offset: 0x01C) Chip Specific Configuration Register */
+  RwReg   SCIF_OSCCTRL0;      /**< \brief (SCIF Offset: 0x020) Oscillator Control Register */
+  ScifPll SCIF_PLL[1];        /**< \brief (SCIF Offset: 0x024) ScifPll groups */
+  RwReg   SCIF_DFLL0CONF;     /**< \brief (SCIF Offset: 0x028) DFLL0 Config Register */
+  RwReg   SCIF_DFLL0VAL;      /**< \brief (SCIF Offset: 0x02C) DFLL Value Register */
+  RwReg   SCIF_DFLL0MUL;      /**< \brief (SCIF Offset: 0x030) DFLL0 Multiplier Register */
+  RwReg   SCIF_DFLL0STEP;     /**< \brief (SCIF Offset: 0x034) DFLL0 Step Register */
+  RwReg   SCIF_DFLL0SSG;      /**< \brief (SCIF Offset: 0x038) DFLL0 Spread Spectrum Generator Control Register */
+  RoReg   SCIF_DFLL0RATIO;    /**< \brief (SCIF Offset: 0x03C) DFLL0 Ratio Registe */
+  WoReg   SCIF_DFLL0SYNC;     /**< \brief (SCIF Offset: 0x040) DFLL0 Synchronization Register */
+  RwReg   SCIF_RCCR;          /**< \brief (SCIF Offset: 0x044) System RC Oscillator Calibration Register */
+  RwReg   SCIF_RCFASTCFG;     /**< \brief (SCIF Offset: 0x048) 4/8/12 MHz RC Oscillator Configuration Register */
+  RwReg   SCIF_RCFASTSR;      /**< \brief (SCIF Offset: 0x04C) 4/8/12 MHz RC Oscillator Status Register */
+  RwReg   SCIF_RC80MCR;       /**< \brief (SCIF Offset: 0x050) 80 MHz RC Oscillator Register */
+  RoReg8  Reserved3[0x10];
+  RwReg   SCIF_HRPCR;         /**< \brief (SCIF Offset: 0x064) High Resolution Prescaler Control Register */
+  RwReg   SCIF_FPCR;          /**< \brief (SCIF Offset: 0x068) Fractional Prescaler Control Register */
+  RwReg   SCIF_FPMUL;         /**< \brief (SCIF Offset: 0x06C) Fractional Prescaler Multiplier Register */
+  RwReg   SCIF_FPDIV;         /**< \brief (SCIF Offset: 0x070) Fractional Prescaler DIVIDER Register */
+  ScifGcctrl SCIF_GCCTRL[12];    /**< \brief (SCIF Offset: 0x074) ScifGcctrl groups */
+  RoReg8  Reserved4[0x334];
+  RoReg   SCIF_RCFASTVERSION; /**< \brief (SCIF Offset: 0x3D8) 4/8/12 MHz RC Oscillator Version Register */
+  RoReg   SCIF_GCLKPRESCVERSION; /**< \brief (SCIF Offset: 0x3DC) Generic Clock Prescaler Version Register */
+  RoReg   SCIF_PLLIFAVERSION; /**< \brief (SCIF Offset: 0x3E0) PLL Version Register */
+  RoReg   SCIF_OSCIFAVERSION; /**< \brief (SCIF Offset: 0x3E4) Oscillator 0 Version Register */
+  RoReg   SCIF_DFLLIFBVERSION; /**< \brief (SCIF Offset: 0x3E8) DFLL Version Register */
+  RoReg   SCIF_RCOSCIFAVERSION; /**< \brief (SCIF Offset: 0x3EC) System RC Oscillator Version Register */
+  RoReg   SCIF_FLOVERSION;    /**< \brief (SCIF Offset: 0x3F0) Frequency Locked Oscillator Version Register */
+  RoReg   SCIF_RC80MVERSION;  /**< \brief (SCIF Offset: 0x3F4) 80MHz RC Oscillator Version Register */
+  RoReg   SCIF_GCLKIFVERSION; /**< \brief (SCIF Offset: 0x3F8) Generic Clock Version Register */
+  RoReg   SCIF_VERSION;       /**< \brief (SCIF Offset: 0x3FC) SCIF Version Register */
+ } reg;
+} Scif;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_SCIF_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/scif.h
+++ b/asf/sam/include/sam4l/component/scif.h
@@ -61,31 +61,31 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SCIF_IER_OFFSET             0x000        /**< \brief (SCIF_IER offset) Interrupt Enable Register */
-#define SCIF_IER_RESETVALUE         _U(0x00000000); /**< \brief (SCIF_IER reset_value) Interrupt Enable Register */
+#define SCIF_IER_RESETVALUE         _U_(0x00000000); /**< \brief (SCIF_IER reset_value) Interrupt Enable Register */
 
 #define SCIF_IER_OSC0RDY_Pos        0            /**< \brief (SCIF_IER) OSC0 Ready */
-#define SCIF_IER_OSC0RDY            (_U(0x1) << SCIF_IER_OSC0RDY_Pos)
+#define SCIF_IER_OSC0RDY            (_U_(0x1) << SCIF_IER_OSC0RDY_Pos)
 #define SCIF_IER_DFLL0LOCKC_Pos     1            /**< \brief (SCIF_IER) DFLL0 Lock Coarse */
-#define SCIF_IER_DFLL0LOCKC         (_U(0x1) << SCIF_IER_DFLL0LOCKC_Pos)
+#define SCIF_IER_DFLL0LOCKC         (_U_(0x1) << SCIF_IER_DFLL0LOCKC_Pos)
 #define SCIF_IER_DFLL0LOCKF_Pos     2            /**< \brief (SCIF_IER) DFLL0 Lock Fine */
-#define SCIF_IER_DFLL0LOCKF         (_U(0x1) << SCIF_IER_DFLL0LOCKF_Pos)
+#define SCIF_IER_DFLL0LOCKF         (_U_(0x1) << SCIF_IER_DFLL0LOCKF_Pos)
 #define SCIF_IER_DFLL0RDY_Pos       3            /**< \brief (SCIF_IER) DFLL0 Ready */
-#define SCIF_IER_DFLL0RDY           (_U(0x1) << SCIF_IER_DFLL0RDY_Pos)
+#define SCIF_IER_DFLL0RDY           (_U_(0x1) << SCIF_IER_DFLL0RDY_Pos)
 #define SCIF_IER_DFLL0RCS_Pos       4            /**< \brief (SCIF_IER) DFLL0 Reference Clock Stopped */
-#define SCIF_IER_DFLL0RCS           (_U(0x1) << SCIF_IER_DFLL0RCS_Pos)
+#define SCIF_IER_DFLL0RCS           (_U_(0x1) << SCIF_IER_DFLL0RCS_Pos)
 #define SCIF_IER_DFLL0OOB_Pos       5            /**< \brief (SCIF_IER) DFLL0 Out Of Bounds */
-#define SCIF_IER_DFLL0OOB           (_U(0x1) << SCIF_IER_DFLL0OOB_Pos)
+#define SCIF_IER_DFLL0OOB           (_U_(0x1) << SCIF_IER_DFLL0OOB_Pos)
 #define SCIF_IER_PLL0LOCK_Pos       6            /**< \brief (SCIF_IER) PLL0 Lock */
-#define SCIF_IER_PLL0LOCK           (_U(0x1) << SCIF_IER_PLL0LOCK_Pos)
+#define SCIF_IER_PLL0LOCK           (_U_(0x1) << SCIF_IER_PLL0LOCK_Pos)
 #define SCIF_IER_PLL0LOCKLOST_Pos   7            /**< \brief (SCIF_IER) PLL0 Lock Lost */
-#define SCIF_IER_PLL0LOCKLOST       (_U(0x1) << SCIF_IER_PLL0LOCKLOST_Pos)
+#define SCIF_IER_PLL0LOCKLOST       (_U_(0x1) << SCIF_IER_PLL0LOCKLOST_Pos)
 #define SCIF_IER_RCFASTLOCK_Pos     13           /**< \brief (SCIF_IER) RCFAST Lock */
-#define SCIF_IER_RCFASTLOCK         (_U(0x1) << SCIF_IER_RCFASTLOCK_Pos)
+#define SCIF_IER_RCFASTLOCK         (_U_(0x1) << SCIF_IER_RCFASTLOCK_Pos)
 #define SCIF_IER_RCFASTLOCKLOST_Pos 14           /**< \brief (SCIF_IER) RCFAST Lock Lost */
-#define SCIF_IER_RCFASTLOCKLOST     (_U(0x1) << SCIF_IER_RCFASTLOCKLOST_Pos)
+#define SCIF_IER_RCFASTLOCKLOST     (_U_(0x1) << SCIF_IER_RCFASTLOCKLOST_Pos)
 #define SCIF_IER_AE_Pos             31           /**< \brief (SCIF_IER) Access Error */
-#define SCIF_IER_AE                 (_U(0x1) << SCIF_IER_AE_Pos)
-#define SCIF_IER_MASK               _U(0x800060FF) /**< \brief (SCIF_IER) MASK Register */
+#define SCIF_IER_AE                 (_U_(0x1) << SCIF_IER_AE_Pos)
+#define SCIF_IER_MASK               _U_(0x800060FF) /**< \brief (SCIF_IER) MASK Register */
 
 /* -------- SCIF_IDR : (SCIF Offset: 0x004) ( /W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -110,31 +110,31 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SCIF_IDR_OFFSET             0x004        /**< \brief (SCIF_IDR offset) Interrupt Disable Register */
-#define SCIF_IDR_RESETVALUE         _U(0x00000000); /**< \brief (SCIF_IDR reset_value) Interrupt Disable Register */
+#define SCIF_IDR_RESETVALUE         _U_(0x00000000); /**< \brief (SCIF_IDR reset_value) Interrupt Disable Register */
 
 #define SCIF_IDR_OSC0RDY_Pos        0            /**< \brief (SCIF_IDR) OSC0 Ready */
-#define SCIF_IDR_OSC0RDY            (_U(0x1) << SCIF_IDR_OSC0RDY_Pos)
+#define SCIF_IDR_OSC0RDY            (_U_(0x1) << SCIF_IDR_OSC0RDY_Pos)
 #define SCIF_IDR_DFLL0LOCKC_Pos     1            /**< \brief (SCIF_IDR) DFLL0 Lock Coarse */
-#define SCIF_IDR_DFLL0LOCKC         (_U(0x1) << SCIF_IDR_DFLL0LOCKC_Pos)
+#define SCIF_IDR_DFLL0LOCKC         (_U_(0x1) << SCIF_IDR_DFLL0LOCKC_Pos)
 #define SCIF_IDR_DFLL0LOCKF_Pos     2            /**< \brief (SCIF_IDR) DFLL0 Lock Fine */
-#define SCIF_IDR_DFLL0LOCKF         (_U(0x1) << SCIF_IDR_DFLL0LOCKF_Pos)
+#define SCIF_IDR_DFLL0LOCKF         (_U_(0x1) << SCIF_IDR_DFLL0LOCKF_Pos)
 #define SCIF_IDR_DFLL0RDY_Pos       3            /**< \brief (SCIF_IDR) DFLL0 Ready */
-#define SCIF_IDR_DFLL0RDY           (_U(0x1) << SCIF_IDR_DFLL0RDY_Pos)
+#define SCIF_IDR_DFLL0RDY           (_U_(0x1) << SCIF_IDR_DFLL0RDY_Pos)
 #define SCIF_IDR_DFLL0RCS_Pos       4            /**< \brief (SCIF_IDR) DFLL0 Reference Clock Stopped */
-#define SCIF_IDR_DFLL0RCS           (_U(0x1) << SCIF_IDR_DFLL0RCS_Pos)
+#define SCIF_IDR_DFLL0RCS           (_U_(0x1) << SCIF_IDR_DFLL0RCS_Pos)
 #define SCIF_IDR_DFLL0OOB_Pos       5            /**< \brief (SCIF_IDR) DFLL0 Out Of Bounds */
-#define SCIF_IDR_DFLL0OOB           (_U(0x1) << SCIF_IDR_DFLL0OOB_Pos)
+#define SCIF_IDR_DFLL0OOB           (_U_(0x1) << SCIF_IDR_DFLL0OOB_Pos)
 #define SCIF_IDR_PLL0LOCK_Pos       6            /**< \brief (SCIF_IDR) PLL0 Lock */
-#define SCIF_IDR_PLL0LOCK           (_U(0x1) << SCIF_IDR_PLL0LOCK_Pos)
+#define SCIF_IDR_PLL0LOCK           (_U_(0x1) << SCIF_IDR_PLL0LOCK_Pos)
 #define SCIF_IDR_PLL0LOCKLOST_Pos   7            /**< \brief (SCIF_IDR) PLL0 Lock Lost */
-#define SCIF_IDR_PLL0LOCKLOST       (_U(0x1) << SCIF_IDR_PLL0LOCKLOST_Pos)
+#define SCIF_IDR_PLL0LOCKLOST       (_U_(0x1) << SCIF_IDR_PLL0LOCKLOST_Pos)
 #define SCIF_IDR_RCFASTLOCK_Pos     13           /**< \brief (SCIF_IDR) RCFAST Lock */
-#define SCIF_IDR_RCFASTLOCK         (_U(0x1) << SCIF_IDR_RCFASTLOCK_Pos)
+#define SCIF_IDR_RCFASTLOCK         (_U_(0x1) << SCIF_IDR_RCFASTLOCK_Pos)
 #define SCIF_IDR_RCFASTLOCKLOST_Pos 14           /**< \brief (SCIF_IDR) RCFAST Lock Lost */
-#define SCIF_IDR_RCFASTLOCKLOST     (_U(0x1) << SCIF_IDR_RCFASTLOCKLOST_Pos)
+#define SCIF_IDR_RCFASTLOCKLOST     (_U_(0x1) << SCIF_IDR_RCFASTLOCKLOST_Pos)
 #define SCIF_IDR_AE_Pos             31           /**< \brief (SCIF_IDR) Access Error */
-#define SCIF_IDR_AE                 (_U(0x1) << SCIF_IDR_AE_Pos)
-#define SCIF_IDR_MASK               _U(0x800060FF) /**< \brief (SCIF_IDR) MASK Register */
+#define SCIF_IDR_AE                 (_U_(0x1) << SCIF_IDR_AE_Pos)
+#define SCIF_IDR_MASK               _U_(0x800060FF) /**< \brief (SCIF_IDR) MASK Register */
 
 /* -------- SCIF_IMR : (SCIF Offset: 0x008) (R/  32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -159,31 +159,31 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SCIF_IMR_OFFSET             0x008        /**< \brief (SCIF_IMR offset) Interrupt Mask Register */
-#define SCIF_IMR_RESETVALUE         _U(0x00000000); /**< \brief (SCIF_IMR reset_value) Interrupt Mask Register */
+#define SCIF_IMR_RESETVALUE         _U_(0x00000000); /**< \brief (SCIF_IMR reset_value) Interrupt Mask Register */
 
 #define SCIF_IMR_OSC0RDY_Pos        0            /**< \brief (SCIF_IMR) OSC0 Ready */
-#define SCIF_IMR_OSC0RDY            (_U(0x1) << SCIF_IMR_OSC0RDY_Pos)
+#define SCIF_IMR_OSC0RDY            (_U_(0x1) << SCIF_IMR_OSC0RDY_Pos)
 #define SCIF_IMR_DFLL0LOCKC_Pos     1            /**< \brief (SCIF_IMR) DFLL0 Lock Coarse */
-#define SCIF_IMR_DFLL0LOCKC         (_U(0x1) << SCIF_IMR_DFLL0LOCKC_Pos)
+#define SCIF_IMR_DFLL0LOCKC         (_U_(0x1) << SCIF_IMR_DFLL0LOCKC_Pos)
 #define SCIF_IMR_DFLL0LOCKF_Pos     2            /**< \brief (SCIF_IMR) DFLL0 Lock Fine */
-#define SCIF_IMR_DFLL0LOCKF         (_U(0x1) << SCIF_IMR_DFLL0LOCKF_Pos)
+#define SCIF_IMR_DFLL0LOCKF         (_U_(0x1) << SCIF_IMR_DFLL0LOCKF_Pos)
 #define SCIF_IMR_DFLL0RDY_Pos       3            /**< \brief (SCIF_IMR) DFLL0 Ready */
-#define SCIF_IMR_DFLL0RDY           (_U(0x1) << SCIF_IMR_DFLL0RDY_Pos)
+#define SCIF_IMR_DFLL0RDY           (_U_(0x1) << SCIF_IMR_DFLL0RDY_Pos)
 #define SCIF_IMR_DFLL0RCS_Pos       4            /**< \brief (SCIF_IMR) DFLL0 Reference Clock Stopped */
-#define SCIF_IMR_DFLL0RCS           (_U(0x1) << SCIF_IMR_DFLL0RCS_Pos)
+#define SCIF_IMR_DFLL0RCS           (_U_(0x1) << SCIF_IMR_DFLL0RCS_Pos)
 #define SCIF_IMR_DFLL0OOB_Pos       5            /**< \brief (SCIF_IMR) DFLL0 Out Of Bounds */
-#define SCIF_IMR_DFLL0OOB           (_U(0x1) << SCIF_IMR_DFLL0OOB_Pos)
+#define SCIF_IMR_DFLL0OOB           (_U_(0x1) << SCIF_IMR_DFLL0OOB_Pos)
 #define SCIF_IMR_PLL0LOCK_Pos       6            /**< \brief (SCIF_IMR) PLL0 Lock */
-#define SCIF_IMR_PLL0LOCK           (_U(0x1) << SCIF_IMR_PLL0LOCK_Pos)
+#define SCIF_IMR_PLL0LOCK           (_U_(0x1) << SCIF_IMR_PLL0LOCK_Pos)
 #define SCIF_IMR_PLL0LOCKLOST_Pos   7            /**< \brief (SCIF_IMR) PLL0 Lock Lost */
-#define SCIF_IMR_PLL0LOCKLOST       (_U(0x1) << SCIF_IMR_PLL0LOCKLOST_Pos)
+#define SCIF_IMR_PLL0LOCKLOST       (_U_(0x1) << SCIF_IMR_PLL0LOCKLOST_Pos)
 #define SCIF_IMR_RCFASTLOCK_Pos     13           /**< \brief (SCIF_IMR) RCFAST Lock */
-#define SCIF_IMR_RCFASTLOCK         (_U(0x1) << SCIF_IMR_RCFASTLOCK_Pos)
+#define SCIF_IMR_RCFASTLOCK         (_U_(0x1) << SCIF_IMR_RCFASTLOCK_Pos)
 #define SCIF_IMR_RCFASTLOCKLOST_Pos 14           /**< \brief (SCIF_IMR) RCFAST Lock Lost */
-#define SCIF_IMR_RCFASTLOCKLOST     (_U(0x1) << SCIF_IMR_RCFASTLOCKLOST_Pos)
+#define SCIF_IMR_RCFASTLOCKLOST     (_U_(0x1) << SCIF_IMR_RCFASTLOCKLOST_Pos)
 #define SCIF_IMR_AE_Pos             31           /**< \brief (SCIF_IMR) Access Error */
-#define SCIF_IMR_AE                 (_U(0x1) << SCIF_IMR_AE_Pos)
-#define SCIF_IMR_MASK               _U(0x800060FF) /**< \brief (SCIF_IMR) MASK Register */
+#define SCIF_IMR_AE                 (_U_(0x1) << SCIF_IMR_AE_Pos)
+#define SCIF_IMR_MASK               _U_(0x800060FF) /**< \brief (SCIF_IMR) MASK Register */
 
 /* -------- SCIF_ISR : (SCIF Offset: 0x00C) (R/  32) Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -208,31 +208,31 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SCIF_ISR_OFFSET             0x00C        /**< \brief (SCIF_ISR offset) Interrupt Status Register */
-#define SCIF_ISR_RESETVALUE         _U(0x00000000); /**< \brief (SCIF_ISR reset_value) Interrupt Status Register */
+#define SCIF_ISR_RESETVALUE         _U_(0x00000000); /**< \brief (SCIF_ISR reset_value) Interrupt Status Register */
 
 #define SCIF_ISR_OSC0RDY_Pos        0            /**< \brief (SCIF_ISR) OSC0 Ready */
-#define SCIF_ISR_OSC0RDY            (_U(0x1) << SCIF_ISR_OSC0RDY_Pos)
+#define SCIF_ISR_OSC0RDY            (_U_(0x1) << SCIF_ISR_OSC0RDY_Pos)
 #define SCIF_ISR_DFLL0LOCKC_Pos     1            /**< \brief (SCIF_ISR) DFLL0 Lock Coarse */
-#define SCIF_ISR_DFLL0LOCKC         (_U(0x1) << SCIF_ISR_DFLL0LOCKC_Pos)
+#define SCIF_ISR_DFLL0LOCKC         (_U_(0x1) << SCIF_ISR_DFLL0LOCKC_Pos)
 #define SCIF_ISR_DFLL0LOCKF_Pos     2            /**< \brief (SCIF_ISR) DFLL0 Lock Fine */
-#define SCIF_ISR_DFLL0LOCKF         (_U(0x1) << SCIF_ISR_DFLL0LOCKF_Pos)
+#define SCIF_ISR_DFLL0LOCKF         (_U_(0x1) << SCIF_ISR_DFLL0LOCKF_Pos)
 #define SCIF_ISR_DFLL0RDY_Pos       3            /**< \brief (SCIF_ISR) DFLL0 Ready */
-#define SCIF_ISR_DFLL0RDY           (_U(0x1) << SCIF_ISR_DFLL0RDY_Pos)
+#define SCIF_ISR_DFLL0RDY           (_U_(0x1) << SCIF_ISR_DFLL0RDY_Pos)
 #define SCIF_ISR_DFLL0RCS_Pos       4            /**< \brief (SCIF_ISR) DFLL0 Reference Clock Stopped */
-#define SCIF_ISR_DFLL0RCS           (_U(0x1) << SCIF_ISR_DFLL0RCS_Pos)
+#define SCIF_ISR_DFLL0RCS           (_U_(0x1) << SCIF_ISR_DFLL0RCS_Pos)
 #define SCIF_ISR_DFLL0OOB_Pos       5            /**< \brief (SCIF_ISR) DFLL0 Out Of Bounds */
-#define SCIF_ISR_DFLL0OOB           (_U(0x1) << SCIF_ISR_DFLL0OOB_Pos)
+#define SCIF_ISR_DFLL0OOB           (_U_(0x1) << SCIF_ISR_DFLL0OOB_Pos)
 #define SCIF_ISR_PLL0LOCK_Pos       6            /**< \brief (SCIF_ISR) PLL0 Lock */
-#define SCIF_ISR_PLL0LOCK           (_U(0x1) << SCIF_ISR_PLL0LOCK_Pos)
+#define SCIF_ISR_PLL0LOCK           (_U_(0x1) << SCIF_ISR_PLL0LOCK_Pos)
 #define SCIF_ISR_PLL0LOCKLOST_Pos   7            /**< \brief (SCIF_ISR) PLL0 Lock Lost */
-#define SCIF_ISR_PLL0LOCKLOST       (_U(0x1) << SCIF_ISR_PLL0LOCKLOST_Pos)
+#define SCIF_ISR_PLL0LOCKLOST       (_U_(0x1) << SCIF_ISR_PLL0LOCKLOST_Pos)
 #define SCIF_ISR_RCFASTLOCK_Pos     13           /**< \brief (SCIF_ISR) RCFAST Lock */
-#define SCIF_ISR_RCFASTLOCK         (_U(0x1) << SCIF_ISR_RCFASTLOCK_Pos)
+#define SCIF_ISR_RCFASTLOCK         (_U_(0x1) << SCIF_ISR_RCFASTLOCK_Pos)
 #define SCIF_ISR_RCFASTLOCKLOST_Pos 14           /**< \brief (SCIF_ISR) RCFAST Lock Lost */
-#define SCIF_ISR_RCFASTLOCKLOST     (_U(0x1) << SCIF_ISR_RCFASTLOCKLOST_Pos)
+#define SCIF_ISR_RCFASTLOCKLOST     (_U_(0x1) << SCIF_ISR_RCFASTLOCKLOST_Pos)
 #define SCIF_ISR_AE_Pos             31           /**< \brief (SCIF_ISR) Access Error */
-#define SCIF_ISR_AE                 (_U(0x1) << SCIF_ISR_AE_Pos)
-#define SCIF_ISR_MASK               _U(0x800060FF) /**< \brief (SCIF_ISR) MASK Register */
+#define SCIF_ISR_AE                 (_U_(0x1) << SCIF_ISR_AE_Pos)
+#define SCIF_ISR_MASK               _U_(0x800060FF) /**< \brief (SCIF_ISR) MASK Register */
 
 /* -------- SCIF_ICR : (SCIF Offset: 0x010) ( /W 32) Interrupt Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -257,31 +257,31 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SCIF_ICR_OFFSET             0x010        /**< \brief (SCIF_ICR offset) Interrupt Clear Register */
-#define SCIF_ICR_RESETVALUE         _U(0x00000000); /**< \brief (SCIF_ICR reset_value) Interrupt Clear Register */
+#define SCIF_ICR_RESETVALUE         _U_(0x00000000); /**< \brief (SCIF_ICR reset_value) Interrupt Clear Register */
 
 #define SCIF_ICR_OSC0RDY_Pos        0            /**< \brief (SCIF_ICR) OSC0 Ready */
-#define SCIF_ICR_OSC0RDY            (_U(0x1) << SCIF_ICR_OSC0RDY_Pos)
+#define SCIF_ICR_OSC0RDY            (_U_(0x1) << SCIF_ICR_OSC0RDY_Pos)
 #define SCIF_ICR_DFLL0LOCKC_Pos     1            /**< \brief (SCIF_ICR) DFLL0 Lock Coarse */
-#define SCIF_ICR_DFLL0LOCKC         (_U(0x1) << SCIF_ICR_DFLL0LOCKC_Pos)
+#define SCIF_ICR_DFLL0LOCKC         (_U_(0x1) << SCIF_ICR_DFLL0LOCKC_Pos)
 #define SCIF_ICR_DFLL0LOCKF_Pos     2            /**< \brief (SCIF_ICR) DFLL0 Lock Fine */
-#define SCIF_ICR_DFLL0LOCKF         (_U(0x1) << SCIF_ICR_DFLL0LOCKF_Pos)
+#define SCIF_ICR_DFLL0LOCKF         (_U_(0x1) << SCIF_ICR_DFLL0LOCKF_Pos)
 #define SCIF_ICR_DFLL0RDY_Pos       3            /**< \brief (SCIF_ICR) DFLL0 Ready */
-#define SCIF_ICR_DFLL0RDY           (_U(0x1) << SCIF_ICR_DFLL0RDY_Pos)
+#define SCIF_ICR_DFLL0RDY           (_U_(0x1) << SCIF_ICR_DFLL0RDY_Pos)
 #define SCIF_ICR_DFLL0RCS_Pos       4            /**< \brief (SCIF_ICR) DFLL0 Reference Clock Stopped */
-#define SCIF_ICR_DFLL0RCS           (_U(0x1) << SCIF_ICR_DFLL0RCS_Pos)
+#define SCIF_ICR_DFLL0RCS           (_U_(0x1) << SCIF_ICR_DFLL0RCS_Pos)
 #define SCIF_ICR_DFLL0OOB_Pos       5            /**< \brief (SCIF_ICR) DFLL0 Out Of Bounds */
-#define SCIF_ICR_DFLL0OOB           (_U(0x1) << SCIF_ICR_DFLL0OOB_Pos)
+#define SCIF_ICR_DFLL0OOB           (_U_(0x1) << SCIF_ICR_DFLL0OOB_Pos)
 #define SCIF_ICR_PLL0LOCK_Pos       6            /**< \brief (SCIF_ICR) PLL0 Lock */
-#define SCIF_ICR_PLL0LOCK           (_U(0x1) << SCIF_ICR_PLL0LOCK_Pos)
+#define SCIF_ICR_PLL0LOCK           (_U_(0x1) << SCIF_ICR_PLL0LOCK_Pos)
 #define SCIF_ICR_PLL0LOCKLOST_Pos   7            /**< \brief (SCIF_ICR) PLL0 Lock Lost */
-#define SCIF_ICR_PLL0LOCKLOST       (_U(0x1) << SCIF_ICR_PLL0LOCKLOST_Pos)
+#define SCIF_ICR_PLL0LOCKLOST       (_U_(0x1) << SCIF_ICR_PLL0LOCKLOST_Pos)
 #define SCIF_ICR_RCFASTLOCK_Pos     13           /**< \brief (SCIF_ICR) RCFAST Lock */
-#define SCIF_ICR_RCFASTLOCK         (_U(0x1) << SCIF_ICR_RCFASTLOCK_Pos)
+#define SCIF_ICR_RCFASTLOCK         (_U_(0x1) << SCIF_ICR_RCFASTLOCK_Pos)
 #define SCIF_ICR_RCFASTLOCKLOST_Pos 14           /**< \brief (SCIF_ICR) RCFAST Lock Lost */
-#define SCIF_ICR_RCFASTLOCKLOST     (_U(0x1) << SCIF_ICR_RCFASTLOCKLOST_Pos)
+#define SCIF_ICR_RCFASTLOCKLOST     (_U_(0x1) << SCIF_ICR_RCFASTLOCKLOST_Pos)
 #define SCIF_ICR_AE_Pos             31           /**< \brief (SCIF_ICR) Access Error */
-#define SCIF_ICR_AE                 (_U(0x1) << SCIF_ICR_AE_Pos)
-#define SCIF_ICR_MASK               _U(0x800060FF) /**< \brief (SCIF_ICR) MASK Register */
+#define SCIF_ICR_AE                 (_U_(0x1) << SCIF_ICR_AE_Pos)
+#define SCIF_ICR_MASK               _U_(0x800060FF) /**< \brief (SCIF_ICR) MASK Register */
 
 /* -------- SCIF_PCLKSR : (SCIF Offset: 0x014) (R/  32) Power and Clocks Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -305,29 +305,29 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SCIF_PCLKSR_OFFSET          0x014        /**< \brief (SCIF_PCLKSR offset) Power and Clocks Status Register */
-#define SCIF_PCLKSR_RESETVALUE      _U(0x00000000); /**< \brief (SCIF_PCLKSR reset_value) Power and Clocks Status Register */
+#define SCIF_PCLKSR_RESETVALUE      _U_(0x00000000); /**< \brief (SCIF_PCLKSR reset_value) Power and Clocks Status Register */
 
 #define SCIF_PCLKSR_OSC0RDY_Pos     0            /**< \brief (SCIF_PCLKSR) OSC0 Ready */
-#define SCIF_PCLKSR_OSC0RDY         (_U(0x1) << SCIF_PCLKSR_OSC0RDY_Pos)
+#define SCIF_PCLKSR_OSC0RDY         (_U_(0x1) << SCIF_PCLKSR_OSC0RDY_Pos)
 #define SCIF_PCLKSR_DFLL0LOCKC_Pos  1            /**< \brief (SCIF_PCLKSR) DFLL0 Locked on Coarse Value */
-#define SCIF_PCLKSR_DFLL0LOCKC      (_U(0x1) << SCIF_PCLKSR_DFLL0LOCKC_Pos)
+#define SCIF_PCLKSR_DFLL0LOCKC      (_U_(0x1) << SCIF_PCLKSR_DFLL0LOCKC_Pos)
 #define SCIF_PCLKSR_DFLL0LOCKF_Pos  2            /**< \brief (SCIF_PCLKSR) DFLL0 Locked on Fine Value */
-#define SCIF_PCLKSR_DFLL0LOCKF      (_U(0x1) << SCIF_PCLKSR_DFLL0LOCKF_Pos)
+#define SCIF_PCLKSR_DFLL0LOCKF      (_U_(0x1) << SCIF_PCLKSR_DFLL0LOCKF_Pos)
 #define SCIF_PCLKSR_DFLL0RDY_Pos    3            /**< \brief (SCIF_PCLKSR) DFLL0 Synchronization Ready */
-#define SCIF_PCLKSR_DFLL0RDY        (_U(0x1) << SCIF_PCLKSR_DFLL0RDY_Pos)
+#define SCIF_PCLKSR_DFLL0RDY        (_U_(0x1) << SCIF_PCLKSR_DFLL0RDY_Pos)
 #define SCIF_PCLKSR_DFLL0RCS_Pos    4            /**< \brief (SCIF_PCLKSR) DFLL0 Reference Clock Stopped */
-#define SCIF_PCLKSR_DFLL0RCS        (_U(0x1) << SCIF_PCLKSR_DFLL0RCS_Pos)
+#define SCIF_PCLKSR_DFLL0RCS        (_U_(0x1) << SCIF_PCLKSR_DFLL0RCS_Pos)
 #define SCIF_PCLKSR_DFLL0OOB_Pos    5            /**< \brief (SCIF_PCLKSR) DFLL0 Track Out Of Bounds */
-#define SCIF_PCLKSR_DFLL0OOB        (_U(0x1) << SCIF_PCLKSR_DFLL0OOB_Pos)
+#define SCIF_PCLKSR_DFLL0OOB        (_U_(0x1) << SCIF_PCLKSR_DFLL0OOB_Pos)
 #define SCIF_PCLKSR_PLL0LOCK_Pos    6            /**< \brief (SCIF_PCLKSR) PLL0 Locked on Accurate value */
-#define SCIF_PCLKSR_PLL0LOCK        (_U(0x1) << SCIF_PCLKSR_PLL0LOCK_Pos)
+#define SCIF_PCLKSR_PLL0LOCK        (_U_(0x1) << SCIF_PCLKSR_PLL0LOCK_Pos)
 #define SCIF_PCLKSR_PLL0LOCKLOST_Pos 7            /**< \brief (SCIF_PCLKSR) PLL0 lock lost value */
-#define SCIF_PCLKSR_PLL0LOCKLOST    (_U(0x1) << SCIF_PCLKSR_PLL0LOCKLOST_Pos)
+#define SCIF_PCLKSR_PLL0LOCKLOST    (_U_(0x1) << SCIF_PCLKSR_PLL0LOCKLOST_Pos)
 #define SCIF_PCLKSR_RCFASTLOCK_Pos  13           /**< \brief (SCIF_PCLKSR) RCFAST Locked on Accurate value */
-#define SCIF_PCLKSR_RCFASTLOCK      (_U(0x1) << SCIF_PCLKSR_RCFASTLOCK_Pos)
+#define SCIF_PCLKSR_RCFASTLOCK      (_U_(0x1) << SCIF_PCLKSR_RCFASTLOCK_Pos)
 #define SCIF_PCLKSR_RCFASTLOCKLOST_Pos 14           /**< \brief (SCIF_PCLKSR) RCFAST lock lost value */
-#define SCIF_PCLKSR_RCFASTLOCKLOST  (_U(0x1) << SCIF_PCLKSR_RCFASTLOCKLOST_Pos)
-#define SCIF_PCLKSR_MASK            _U(0x000060FF) /**< \brief (SCIF_PCLKSR) MASK Register */
+#define SCIF_PCLKSR_RCFASTLOCKLOST  (_U_(0x1) << SCIF_PCLKSR_RCFASTLOCKLOST_Pos)
+#define SCIF_PCLKSR_MASK            _U_(0x000060FF) /**< \brief (SCIF_PCLKSR) MASK Register */
 
 /* -------- SCIF_UNLOCK : (SCIF Offset: 0x018) ( /W 32) Unlock Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -342,15 +342,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SCIF_UNLOCK_OFFSET          0x018        /**< \brief (SCIF_UNLOCK offset) Unlock Register */
-#define SCIF_UNLOCK_RESETVALUE      _U(0x00000000); /**< \brief (SCIF_UNLOCK reset_value) Unlock Register */
+#define SCIF_UNLOCK_RESETVALUE      _U_(0x00000000); /**< \brief (SCIF_UNLOCK reset_value) Unlock Register */
 
 #define SCIF_UNLOCK_ADDR_Pos        0            /**< \brief (SCIF_UNLOCK) Unlock Address */
-#define SCIF_UNLOCK_ADDR_Msk        (_U(0x3FF) << SCIF_UNLOCK_ADDR_Pos)
+#define SCIF_UNLOCK_ADDR_Msk        (_U_(0x3FF) << SCIF_UNLOCK_ADDR_Pos)
 #define SCIF_UNLOCK_ADDR(value)     (SCIF_UNLOCK_ADDR_Msk & ((value) << SCIF_UNLOCK_ADDR_Pos))
 #define SCIF_UNLOCK_KEY_Pos         24           /**< \brief (SCIF_UNLOCK) Unlock Key */
-#define SCIF_UNLOCK_KEY_Msk         (_U(0xFF) << SCIF_UNLOCK_KEY_Pos)
+#define SCIF_UNLOCK_KEY_Msk         (_U_(0xFF) << SCIF_UNLOCK_KEY_Pos)
 #define SCIF_UNLOCK_KEY(value)      (SCIF_UNLOCK_KEY_Msk & ((value) << SCIF_UNLOCK_KEY_Pos))
-#define SCIF_UNLOCK_MASK            _U(0xFF0003FF) /**< \brief (SCIF_UNLOCK) MASK Register */
+#define SCIF_UNLOCK_MASK            _U_(0xFF0003FF) /**< \brief (SCIF_UNLOCK) MASK Register */
 
 /* -------- SCIF_CSCR : (SCIF Offset: 0x01C) (R/W 32) Chip Specific Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -360,8 +360,8 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SCIF_CSCR_OFFSET            0x01C        /**< \brief (SCIF_CSCR offset) Chip Specific Configuration Register */
-#define SCIF_CSCR_RESETVALUE        _U(0x00000000); /**< \brief (SCIF_CSCR reset_value) Chip Specific Configuration Register */
-#define SCIF_CSCR_MASK              _U(0xFFFFFFFF) /**< \brief (SCIF_CSCR) MASK Register */
+#define SCIF_CSCR_RESETVALUE        _U_(0x00000000); /**< \brief (SCIF_CSCR reset_value) Chip Specific Configuration Register */
+#define SCIF_CSCR_MASK              _U_(0xFFFFFFFF) /**< \brief (SCIF_CSCR) MASK Register */
 
 /* -------- SCIF_OSCCTRL0 : (SCIF Offset: 0x020) (R/W 32) Oscillator Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -381,21 +381,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SCIF_OSCCTRL0_OFFSET        0x020        /**< \brief (SCIF_OSCCTRL0 offset) Oscillator Control Register */
-#define SCIF_OSCCTRL0_RESETVALUE    _U(0x00000000); /**< \brief (SCIF_OSCCTRL0 reset_value) Oscillator Control Register */
+#define SCIF_OSCCTRL0_RESETVALUE    _U_(0x00000000); /**< \brief (SCIF_OSCCTRL0 reset_value) Oscillator Control Register */
 
 #define SCIF_OSCCTRL0_MODE_Pos      0            /**< \brief (SCIF_OSCCTRL0) Oscillator Mode */
-#define SCIF_OSCCTRL0_MODE          (_U(0x1) << SCIF_OSCCTRL0_MODE_Pos)
+#define SCIF_OSCCTRL0_MODE          (_U_(0x1) << SCIF_OSCCTRL0_MODE_Pos)
 #define SCIF_OSCCTRL0_GAIN_Pos      1            /**< \brief (SCIF_OSCCTRL0) Gain */
-#define SCIF_OSCCTRL0_GAIN_Msk      (_U(0x3) << SCIF_OSCCTRL0_GAIN_Pos)
+#define SCIF_OSCCTRL0_GAIN_Msk      (_U_(0x3) << SCIF_OSCCTRL0_GAIN_Pos)
 #define SCIF_OSCCTRL0_GAIN(value)   (SCIF_OSCCTRL0_GAIN_Msk & ((value) << SCIF_OSCCTRL0_GAIN_Pos))
 #define SCIF_OSCCTRL0_AGC_Pos       3            /**< \brief (SCIF_OSCCTRL0) Automatic Gain Control */
-#define SCIF_OSCCTRL0_AGC           (_U(0x1) << SCIF_OSCCTRL0_AGC_Pos)
+#define SCIF_OSCCTRL0_AGC           (_U_(0x1) << SCIF_OSCCTRL0_AGC_Pos)
 #define SCIF_OSCCTRL0_STARTUP_Pos   8            /**< \brief (SCIF_OSCCTRL0) Oscillator Start-up Time */
-#define SCIF_OSCCTRL0_STARTUP_Msk   (_U(0xF) << SCIF_OSCCTRL0_STARTUP_Pos)
+#define SCIF_OSCCTRL0_STARTUP_Msk   (_U_(0xF) << SCIF_OSCCTRL0_STARTUP_Pos)
 #define SCIF_OSCCTRL0_STARTUP(value) (SCIF_OSCCTRL0_STARTUP_Msk & ((value) << SCIF_OSCCTRL0_STARTUP_Pos))
 #define SCIF_OSCCTRL0_OSCEN_Pos     16           /**< \brief (SCIF_OSCCTRL0) Oscillator Enable */
-#define SCIF_OSCCTRL0_OSCEN         (_U(0x1) << SCIF_OSCCTRL0_OSCEN_Pos)
-#define SCIF_OSCCTRL0_MASK          _U(0x00010F0F) /**< \brief (SCIF_OSCCTRL0) MASK Register */
+#define SCIF_OSCCTRL0_OSCEN         (_U_(0x1) << SCIF_OSCCTRL0_OSCEN_Pos)
+#define SCIF_OSCCTRL0_MASK          _U_(0x00010F0F) /**< \brief (SCIF_OSCCTRL0) MASK Register */
 
 /* -------- SCIF_PLL : (SCIF Offset: 0x024) (R/W 32) pll PLL0 Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -417,26 +417,26 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SCIF_PLL_OFFSET             0x024        /**< \brief (SCIF_PLL offset) PLL0 Control Register */
-#define SCIF_PLL_RESETVALUE         _U(0x00000000); /**< \brief (SCIF_PLL reset_value) PLL0 Control Register */
+#define SCIF_PLL_RESETVALUE         _U_(0x00000000); /**< \brief (SCIF_PLL reset_value) PLL0 Control Register */
 
 #define SCIF_PLL_PLLEN_Pos          0            /**< \brief (SCIF_PLL) PLL Enable */
-#define SCIF_PLL_PLLEN              (_U(0x1) << SCIF_PLL_PLLEN_Pos)
+#define SCIF_PLL_PLLEN              (_U_(0x1) << SCIF_PLL_PLLEN_Pos)
 #define SCIF_PLL_PLLOSC_Pos         1            /**< \brief (SCIF_PLL) PLL Oscillator Select */
-#define SCIF_PLL_PLLOSC_Msk         (_U(0x3) << SCIF_PLL_PLLOSC_Pos)
+#define SCIF_PLL_PLLOSC_Msk         (_U_(0x3) << SCIF_PLL_PLLOSC_Pos)
 #define SCIF_PLL_PLLOSC(value)      (SCIF_PLL_PLLOSC_Msk & ((value) << SCIF_PLL_PLLOSC_Pos))
 #define SCIF_PLL_PLLOPT_Pos         3            /**< \brief (SCIF_PLL) PLL Option */
-#define SCIF_PLL_PLLOPT_Msk         (_U(0x7) << SCIF_PLL_PLLOPT_Pos)
+#define SCIF_PLL_PLLOPT_Msk         (_U_(0x7) << SCIF_PLL_PLLOPT_Pos)
 #define SCIF_PLL_PLLOPT(value)      (SCIF_PLL_PLLOPT_Msk & ((value) << SCIF_PLL_PLLOPT_Pos))
 #define SCIF_PLL_PLLDIV_Pos         8            /**< \brief (SCIF_PLL) PLL Division Factor */
-#define SCIF_PLL_PLLDIV_Msk         (_U(0xF) << SCIF_PLL_PLLDIV_Pos)
+#define SCIF_PLL_PLLDIV_Msk         (_U_(0xF) << SCIF_PLL_PLLDIV_Pos)
 #define SCIF_PLL_PLLDIV(value)      (SCIF_PLL_PLLDIV_Msk & ((value) << SCIF_PLL_PLLDIV_Pos))
 #define SCIF_PLL_PLLMUL_Pos         16           /**< \brief (SCIF_PLL) PLL Multiply Factor */
-#define SCIF_PLL_PLLMUL_Msk         (_U(0xF) << SCIF_PLL_PLLMUL_Pos)
+#define SCIF_PLL_PLLMUL_Msk         (_U_(0xF) << SCIF_PLL_PLLMUL_Pos)
 #define SCIF_PLL_PLLMUL(value)      (SCIF_PLL_PLLMUL_Msk & ((value) << SCIF_PLL_PLLMUL_Pos))
 #define SCIF_PLL_PLLCOUNT_Pos       24           /**< \brief (SCIF_PLL) PLL Count */
-#define SCIF_PLL_PLLCOUNT_Msk       (_U(0x3F) << SCIF_PLL_PLLCOUNT_Pos)
+#define SCIF_PLL_PLLCOUNT_Msk       (_U_(0x3F) << SCIF_PLL_PLLCOUNT_Pos)
 #define SCIF_PLL_PLLCOUNT(value)    (SCIF_PLL_PLLCOUNT_Msk & ((value) << SCIF_PLL_PLLCOUNT_Pos))
-#define SCIF_PLL_MASK               _U(0x3F0F0F3F) /**< \brief (SCIF_PLL) MASK Register */
+#define SCIF_PLL_MASK               _U_(0x3F0F0F3F) /**< \brief (SCIF_PLL) MASK Register */
 
 /* -------- SCIF_DFLL0CONF : (SCIF Offset: 0x028) (R/W 32) DFLL0 Config Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -461,29 +461,29 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SCIF_DFLL0CONF_OFFSET       0x028        /**< \brief (SCIF_DFLL0CONF offset) DFLL0 Config Register */
-#define SCIF_DFLL0CONF_RESETVALUE   _U(0x00000000); /**< \brief (SCIF_DFLL0CONF reset_value) DFLL0 Config Register */
+#define SCIF_DFLL0CONF_RESETVALUE   _U_(0x00000000); /**< \brief (SCIF_DFLL0CONF reset_value) DFLL0 Config Register */
 
 #define SCIF_DFLL0CONF_EN_Pos       0            /**< \brief (SCIF_DFLL0CONF) Enable */
-#define SCIF_DFLL0CONF_EN           (_U(0x1) << SCIF_DFLL0CONF_EN_Pos)
+#define SCIF_DFLL0CONF_EN           (_U_(0x1) << SCIF_DFLL0CONF_EN_Pos)
 #define SCIF_DFLL0CONF_MODE_Pos     1            /**< \brief (SCIF_DFLL0CONF) Mode Selection */
-#define SCIF_DFLL0CONF_MODE         (_U(0x1) << SCIF_DFLL0CONF_MODE_Pos)
+#define SCIF_DFLL0CONF_MODE         (_U_(0x1) << SCIF_DFLL0CONF_MODE_Pos)
 #define SCIF_DFLL0CONF_STABLE_Pos   2            /**< \brief (SCIF_DFLL0CONF) Stable DFLL Frequency */
-#define SCIF_DFLL0CONF_STABLE       (_U(0x1) << SCIF_DFLL0CONF_STABLE_Pos)
+#define SCIF_DFLL0CONF_STABLE       (_U_(0x1) << SCIF_DFLL0CONF_STABLE_Pos)
 #define SCIF_DFLL0CONF_LLAW_Pos     3            /**< \brief (SCIF_DFLL0CONF) Lose Lock After Wake */
-#define SCIF_DFLL0CONF_LLAW         (_U(0x1) << SCIF_DFLL0CONF_LLAW_Pos)
+#define SCIF_DFLL0CONF_LLAW         (_U_(0x1) << SCIF_DFLL0CONF_LLAW_Pos)
 #define SCIF_DFLL0CONF_CCDIS_Pos    5            /**< \brief (SCIF_DFLL0CONF) Chill Cycle Disable */
-#define SCIF_DFLL0CONF_CCDIS        (_U(0x1) << SCIF_DFLL0CONF_CCDIS_Pos)
+#define SCIF_DFLL0CONF_CCDIS        (_U_(0x1) << SCIF_DFLL0CONF_CCDIS_Pos)
 #define SCIF_DFLL0CONF_QLDIS_Pos    6            /**< \brief (SCIF_DFLL0CONF) Quick Lock Disable */
-#define SCIF_DFLL0CONF_QLDIS        (_U(0x1) << SCIF_DFLL0CONF_QLDIS_Pos)
+#define SCIF_DFLL0CONF_QLDIS        (_U_(0x1) << SCIF_DFLL0CONF_QLDIS_Pos)
 #define SCIF_DFLL0CONF_RANGE_Pos    16           /**< \brief (SCIF_DFLL0CONF) Range Value */
-#define SCIF_DFLL0CONF_RANGE_Msk    (_U(0x3) << SCIF_DFLL0CONF_RANGE_Pos)
+#define SCIF_DFLL0CONF_RANGE_Msk    (_U_(0x3) << SCIF_DFLL0CONF_RANGE_Pos)
 #define SCIF_DFLL0CONF_RANGE(value) (SCIF_DFLL0CONF_RANGE_Msk & ((value) << SCIF_DFLL0CONF_RANGE_Pos))
 #define SCIF_DFLL0CONF_FCD_Pos      23           /**< \brief (SCIF_DFLL0CONF) Fuse Calibration Done */
-#define SCIF_DFLL0CONF_FCD          (_U(0x1) << SCIF_DFLL0CONF_FCD_Pos)
+#define SCIF_DFLL0CONF_FCD          (_U_(0x1) << SCIF_DFLL0CONF_FCD_Pos)
 #define SCIF_DFLL0CONF_CALIB_Pos    24           /**< \brief (SCIF_DFLL0CONF) Calibration Value */
-#define SCIF_DFLL0CONF_CALIB_Msk    (_U(0xF) << SCIF_DFLL0CONF_CALIB_Pos)
+#define SCIF_DFLL0CONF_CALIB_Msk    (_U_(0xF) << SCIF_DFLL0CONF_CALIB_Pos)
 #define SCIF_DFLL0CONF_CALIB(value) (SCIF_DFLL0CONF_CALIB_Msk & ((value) << SCIF_DFLL0CONF_CALIB_Pos))
-#define SCIF_DFLL0CONF_MASK         _U(0x0F83006F) /**< \brief (SCIF_DFLL0CONF) MASK Register */
+#define SCIF_DFLL0CONF_MASK         _U_(0x0F83006F) /**< \brief (SCIF_DFLL0CONF) MASK Register */
 
 /* -------- SCIF_DFLL0VAL : (SCIF Offset: 0x02C) (R/W 32) DFLL Value Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -499,15 +499,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SCIF_DFLL0VAL_OFFSET        0x02C        /**< \brief (SCIF_DFLL0VAL offset) DFLL Value Register */
-#define SCIF_DFLL0VAL_RESETVALUE    _U(0x00000000); /**< \brief (SCIF_DFLL0VAL reset_value) DFLL Value Register */
+#define SCIF_DFLL0VAL_RESETVALUE    _U_(0x00000000); /**< \brief (SCIF_DFLL0VAL reset_value) DFLL Value Register */
 
 #define SCIF_DFLL0VAL_FINE_Pos      0            /**< \brief (SCIF_DFLL0VAL) Fine Value */
-#define SCIF_DFLL0VAL_FINE_Msk      (_U(0xFF) << SCIF_DFLL0VAL_FINE_Pos)
+#define SCIF_DFLL0VAL_FINE_Msk      (_U_(0xFF) << SCIF_DFLL0VAL_FINE_Pos)
 #define SCIF_DFLL0VAL_FINE(value)   (SCIF_DFLL0VAL_FINE_Msk & ((value) << SCIF_DFLL0VAL_FINE_Pos))
 #define SCIF_DFLL0VAL_COARSE_Pos    16           /**< \brief (SCIF_DFLL0VAL) Coarse Value */
-#define SCIF_DFLL0VAL_COARSE_Msk    (_U(0x1F) << SCIF_DFLL0VAL_COARSE_Pos)
+#define SCIF_DFLL0VAL_COARSE_Msk    (_U_(0x1F) << SCIF_DFLL0VAL_COARSE_Pos)
 #define SCIF_DFLL0VAL_COARSE(value) (SCIF_DFLL0VAL_COARSE_Msk & ((value) << SCIF_DFLL0VAL_COARSE_Pos))
-#define SCIF_DFLL0VAL_MASK          _U(0x001F00FF) /**< \brief (SCIF_DFLL0VAL) MASK Register */
+#define SCIF_DFLL0VAL_MASK          _U_(0x001F00FF) /**< \brief (SCIF_DFLL0VAL) MASK Register */
 
 /* -------- SCIF_DFLL0MUL : (SCIF Offset: 0x030) (R/W 32) DFLL0 Multiplier Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -521,12 +521,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SCIF_DFLL0MUL_OFFSET        0x030        /**< \brief (SCIF_DFLL0MUL offset) DFLL0 Multiplier Register */
-#define SCIF_DFLL0MUL_RESETVALUE    _U(0x00000000); /**< \brief (SCIF_DFLL0MUL reset_value) DFLL0 Multiplier Register */
+#define SCIF_DFLL0MUL_RESETVALUE    _U_(0x00000000); /**< \brief (SCIF_DFLL0MUL reset_value) DFLL0 Multiplier Register */
 
 #define SCIF_DFLL0MUL_MUL_Pos       0            /**< \brief (SCIF_DFLL0MUL) DFLL Multiply Factor */
-#define SCIF_DFLL0MUL_MUL_Msk       (_U(0xFFFF) << SCIF_DFLL0MUL_MUL_Pos)
+#define SCIF_DFLL0MUL_MUL_Msk       (_U_(0xFFFF) << SCIF_DFLL0MUL_MUL_Pos)
 #define SCIF_DFLL0MUL_MUL(value)    (SCIF_DFLL0MUL_MUL_Msk & ((value) << SCIF_DFLL0MUL_MUL_Pos))
-#define SCIF_DFLL0MUL_MASK          _U(0x0000FFFF) /**< \brief (SCIF_DFLL0MUL) MASK Register */
+#define SCIF_DFLL0MUL_MASK          _U_(0x0000FFFF) /**< \brief (SCIF_DFLL0MUL) MASK Register */
 
 /* -------- SCIF_DFLL0STEP : (SCIF Offset: 0x034) (R/W 32) DFLL0 Step Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -542,15 +542,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SCIF_DFLL0STEP_OFFSET       0x034        /**< \brief (SCIF_DFLL0STEP offset) DFLL0 Step Register */
-#define SCIF_DFLL0STEP_RESETVALUE   _U(0x00000000); /**< \brief (SCIF_DFLL0STEP reset_value) DFLL0 Step Register */
+#define SCIF_DFLL0STEP_RESETVALUE   _U_(0x00000000); /**< \brief (SCIF_DFLL0STEP reset_value) DFLL0 Step Register */
 
 #define SCIF_DFLL0STEP_FSTEP_Pos    0            /**< \brief (SCIF_DFLL0STEP) Fine Maximum Step */
-#define SCIF_DFLL0STEP_FSTEP_Msk    (_U(0xFF) << SCIF_DFLL0STEP_FSTEP_Pos)
+#define SCIF_DFLL0STEP_FSTEP_Msk    (_U_(0xFF) << SCIF_DFLL0STEP_FSTEP_Pos)
 #define SCIF_DFLL0STEP_FSTEP(value) (SCIF_DFLL0STEP_FSTEP_Msk & ((value) << SCIF_DFLL0STEP_FSTEP_Pos))
 #define SCIF_DFLL0STEP_CSTEP_Pos    16           /**< \brief (SCIF_DFLL0STEP) Coarse Maximum Step */
-#define SCIF_DFLL0STEP_CSTEP_Msk    (_U(0x1F) << SCIF_DFLL0STEP_CSTEP_Pos)
+#define SCIF_DFLL0STEP_CSTEP_Msk    (_U_(0x1F) << SCIF_DFLL0STEP_CSTEP_Pos)
 #define SCIF_DFLL0STEP_CSTEP(value) (SCIF_DFLL0STEP_CSTEP_Msk & ((value) << SCIF_DFLL0STEP_CSTEP_Pos))
-#define SCIF_DFLL0STEP_MASK         _U(0x001F00FF) /**< \brief (SCIF_DFLL0STEP) MASK Register */
+#define SCIF_DFLL0STEP_MASK         _U_(0x001F00FF) /**< \brief (SCIF_DFLL0STEP) MASK Register */
 
 /* -------- SCIF_DFLL0SSG : (SCIF Offset: 0x038) (R/W 32) DFLL0 Spread Spectrum Generator Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -569,19 +569,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SCIF_DFLL0SSG_OFFSET        0x038        /**< \brief (SCIF_DFLL0SSG offset) DFLL0 Spread Spectrum Generator Control Register */
-#define SCIF_DFLL0SSG_RESETVALUE    _U(0x00000000); /**< \brief (SCIF_DFLL0SSG reset_value) DFLL0 Spread Spectrum Generator Control Register */
+#define SCIF_DFLL0SSG_RESETVALUE    _U_(0x00000000); /**< \brief (SCIF_DFLL0SSG reset_value) DFLL0 Spread Spectrum Generator Control Register */
 
 #define SCIF_DFLL0SSG_EN_Pos        0            /**< \brief (SCIF_DFLL0SSG) Enable */
-#define SCIF_DFLL0SSG_EN            (_U(0x1) << SCIF_DFLL0SSG_EN_Pos)
+#define SCIF_DFLL0SSG_EN            (_U_(0x1) << SCIF_DFLL0SSG_EN_Pos)
 #define SCIF_DFLL0SSG_PRBS_Pos      1            /**< \brief (SCIF_DFLL0SSG) Pseudo Random Bit Sequence */
-#define SCIF_DFLL0SSG_PRBS          (_U(0x1) << SCIF_DFLL0SSG_PRBS_Pos)
+#define SCIF_DFLL0SSG_PRBS          (_U_(0x1) << SCIF_DFLL0SSG_PRBS_Pos)
 #define SCIF_DFLL0SSG_AMPLITUDE_Pos 8            /**< \brief (SCIF_DFLL0SSG) SSG Amplitude */
-#define SCIF_DFLL0SSG_AMPLITUDE_Msk (_U(0x1F) << SCIF_DFLL0SSG_AMPLITUDE_Pos)
+#define SCIF_DFLL0SSG_AMPLITUDE_Msk (_U_(0x1F) << SCIF_DFLL0SSG_AMPLITUDE_Pos)
 #define SCIF_DFLL0SSG_AMPLITUDE(value) (SCIF_DFLL0SSG_AMPLITUDE_Msk & ((value) << SCIF_DFLL0SSG_AMPLITUDE_Pos))
 #define SCIF_DFLL0SSG_STEPSIZE_Pos  16           /**< \brief (SCIF_DFLL0SSG) SSG Step Size */
-#define SCIF_DFLL0SSG_STEPSIZE_Msk  (_U(0x1F) << SCIF_DFLL0SSG_STEPSIZE_Pos)
+#define SCIF_DFLL0SSG_STEPSIZE_Msk  (_U_(0x1F) << SCIF_DFLL0SSG_STEPSIZE_Pos)
 #define SCIF_DFLL0SSG_STEPSIZE(value) (SCIF_DFLL0SSG_STEPSIZE_Msk & ((value) << SCIF_DFLL0SSG_STEPSIZE_Pos))
-#define SCIF_DFLL0SSG_MASK          _U(0x001F1F03) /**< \brief (SCIF_DFLL0SSG) MASK Register */
+#define SCIF_DFLL0SSG_MASK          _U_(0x001F1F03) /**< \brief (SCIF_DFLL0SSG) MASK Register */
 
 /* -------- SCIF_DFLL0RATIO : (SCIF Offset: 0x03C) (R/  32) DFLL0 Ratio Registe -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -595,12 +595,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SCIF_DFLL0RATIO_OFFSET      0x03C        /**< \brief (SCIF_DFLL0RATIO offset) DFLL0 Ratio Registe */
-#define SCIF_DFLL0RATIO_RESETVALUE  _U(0x00000000); /**< \brief (SCIF_DFLL0RATIO reset_value) DFLL0 Ratio Registe */
+#define SCIF_DFLL0RATIO_RESETVALUE  _U_(0x00000000); /**< \brief (SCIF_DFLL0RATIO reset_value) DFLL0 Ratio Registe */
 
 #define SCIF_DFLL0RATIO_RATIODIFF_Pos 0            /**< \brief (SCIF_DFLL0RATIO) Multiplication Ratio Difference */
-#define SCIF_DFLL0RATIO_RATIODIFF_Msk (_U(0xFFFF) << SCIF_DFLL0RATIO_RATIODIFF_Pos)
+#define SCIF_DFLL0RATIO_RATIODIFF_Msk (_U_(0xFFFF) << SCIF_DFLL0RATIO_RATIODIFF_Pos)
 #define SCIF_DFLL0RATIO_RATIODIFF(value) (SCIF_DFLL0RATIO_RATIODIFF_Msk & ((value) << SCIF_DFLL0RATIO_RATIODIFF_Pos))
-#define SCIF_DFLL0RATIO_MASK        _U(0x0000FFFF) /**< \brief (SCIF_DFLL0RATIO) MASK Register */
+#define SCIF_DFLL0RATIO_MASK        _U_(0x0000FFFF) /**< \brief (SCIF_DFLL0RATIO) MASK Register */
 
 /* -------- SCIF_DFLL0SYNC : (SCIF Offset: 0x040) ( /W 32) DFLL0 Synchronization Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -614,11 +614,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SCIF_DFLL0SYNC_OFFSET       0x040        /**< \brief (SCIF_DFLL0SYNC offset) DFLL0 Synchronization Register */
-#define SCIF_DFLL0SYNC_RESETVALUE   _U(0x00000000); /**< \brief (SCIF_DFLL0SYNC reset_value) DFLL0 Synchronization Register */
+#define SCIF_DFLL0SYNC_RESETVALUE   _U_(0x00000000); /**< \brief (SCIF_DFLL0SYNC reset_value) DFLL0 Synchronization Register */
 
 #define SCIF_DFLL0SYNC_SYNC_Pos     0            /**< \brief (SCIF_DFLL0SYNC) Synchronization */
-#define SCIF_DFLL0SYNC_SYNC         (_U(0x1) << SCIF_DFLL0SYNC_SYNC_Pos)
-#define SCIF_DFLL0SYNC_MASK         _U(0x00000001) /**< \brief (SCIF_DFLL0SYNC) MASK Register */
+#define SCIF_DFLL0SYNC_SYNC         (_U_(0x1) << SCIF_DFLL0SYNC_SYNC_Pos)
+#define SCIF_DFLL0SYNC_MASK         _U_(0x00000001) /**< \brief (SCIF_DFLL0SYNC) MASK Register */
 
 /* -------- SCIF_RCCR : (SCIF Offset: 0x044) (R/W 32) System RC Oscillator Calibration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -636,11 +636,11 @@ typedef union {
 #define SCIF_RCCR_OFFSET            0x044        /**< \brief (SCIF_RCCR offset) System RC Oscillator Calibration Register */
 
 #define SCIF_RCCR_CALIB_Pos         0            /**< \brief (SCIF_RCCR) Calibration Value */
-#define SCIF_RCCR_CALIB_Msk         (_U(0x3FF) << SCIF_RCCR_CALIB_Pos)
+#define SCIF_RCCR_CALIB_Msk         (_U_(0x3FF) << SCIF_RCCR_CALIB_Pos)
 #define SCIF_RCCR_CALIB(value)      (SCIF_RCCR_CALIB_Msk & ((value) << SCIF_RCCR_CALIB_Pos))
 #define SCIF_RCCR_FCD_Pos           16           /**< \brief (SCIF_RCCR) Flash Calibration Done */
-#define SCIF_RCCR_FCD               (_U(0x1) << SCIF_RCCR_FCD_Pos)
-#define SCIF_RCCR_MASK              _U(0x000103FF) /**< \brief (SCIF_RCCR) MASK Register */
+#define SCIF_RCCR_FCD               (_U_(0x1) << SCIF_RCCR_FCD_Pos)
+#define SCIF_RCCR_MASK              _U_(0x000103FF) /**< \brief (SCIF_RCCR) MASK Register */
 
 /* -------- SCIF_RCFASTCFG : (SCIF Offset: 0x048) (R/W 32) 4/8/12 MHz RC Oscillator Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -663,29 +663,29 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SCIF_RCFASTCFG_OFFSET       0x048        /**< \brief (SCIF_RCFASTCFG offset) 4/8/12 MHz RC Oscillator Configuration Register */
-#define SCIF_RCFASTCFG_RESETVALUE   _U(0x00000000); /**< \brief (SCIF_RCFASTCFG reset_value) 4/8/12 MHz RC Oscillator Configuration Register */
+#define SCIF_RCFASTCFG_RESETVALUE   _U_(0x00000000); /**< \brief (SCIF_RCFASTCFG reset_value) 4/8/12 MHz RC Oscillator Configuration Register */
 
 #define SCIF_RCFASTCFG_EN_Pos       0            /**< \brief (SCIF_RCFASTCFG) Oscillator Enable */
-#define SCIF_RCFASTCFG_EN           (_U(0x1) << SCIF_RCFASTCFG_EN_Pos)
+#define SCIF_RCFASTCFG_EN           (_U_(0x1) << SCIF_RCFASTCFG_EN_Pos)
 #define SCIF_RCFASTCFG_TUNEEN_Pos   1            /**< \brief (SCIF_RCFASTCFG) Tuner Enable */
-#define SCIF_RCFASTCFG_TUNEEN       (_U(0x1) << SCIF_RCFASTCFG_TUNEEN_Pos)
+#define SCIF_RCFASTCFG_TUNEEN       (_U_(0x1) << SCIF_RCFASTCFG_TUNEEN_Pos)
 #define SCIF_RCFASTCFG_JITMODE_Pos  2            /**< \brief (SCIF_RCFASTCFG) Jitter Mode */
-#define SCIF_RCFASTCFG_JITMODE      (_U(0x1) << SCIF_RCFASTCFG_JITMODE_Pos)
+#define SCIF_RCFASTCFG_JITMODE      (_U_(0x1) << SCIF_RCFASTCFG_JITMODE_Pos)
 #define SCIF_RCFASTCFG_NBPERIODS_Pos 4            /**< \brief (SCIF_RCFASTCFG) Number of 32kHz Periods */
-#define SCIF_RCFASTCFG_NBPERIODS_Msk (_U(0x7) << SCIF_RCFASTCFG_NBPERIODS_Pos)
+#define SCIF_RCFASTCFG_NBPERIODS_Msk (_U_(0x7) << SCIF_RCFASTCFG_NBPERIODS_Pos)
 #define SCIF_RCFASTCFG_NBPERIODS(value) (SCIF_RCFASTCFG_NBPERIODS_Msk & ((value) << SCIF_RCFASTCFG_NBPERIODS_Pos))
 #define SCIF_RCFASTCFG_FCD_Pos      7            /**< \brief (SCIF_RCFASTCFG) RCFAST Fuse Calibration Done */
-#define SCIF_RCFASTCFG_FCD          (_U(0x1) << SCIF_RCFASTCFG_FCD_Pos)
+#define SCIF_RCFASTCFG_FCD          (_U_(0x1) << SCIF_RCFASTCFG_FCD_Pos)
 #define SCIF_RCFASTCFG_FRANGE_Pos   8            /**< \brief (SCIF_RCFASTCFG) Frequency Range */
-#define SCIF_RCFASTCFG_FRANGE_Msk   (_U(0x3) << SCIF_RCFASTCFG_FRANGE_Pos)
+#define SCIF_RCFASTCFG_FRANGE_Msk   (_U_(0x3) << SCIF_RCFASTCFG_FRANGE_Pos)
 #define SCIF_RCFASTCFG_FRANGE(value) (SCIF_RCFASTCFG_FRANGE_Msk & ((value) << SCIF_RCFASTCFG_FRANGE_Pos))
 #define SCIF_RCFASTCFG_LOCKMARGIN_Pos 12           /**< \brief (SCIF_RCFASTCFG) Accepted Count Error for Lock */
-#define SCIF_RCFASTCFG_LOCKMARGIN_Msk (_U(0xF) << SCIF_RCFASTCFG_LOCKMARGIN_Pos)
+#define SCIF_RCFASTCFG_LOCKMARGIN_Msk (_U_(0xF) << SCIF_RCFASTCFG_LOCKMARGIN_Pos)
 #define SCIF_RCFASTCFG_LOCKMARGIN(value) (SCIF_RCFASTCFG_LOCKMARGIN_Msk & ((value) << SCIF_RCFASTCFG_LOCKMARGIN_Pos))
 #define SCIF_RCFASTCFG_CALIB_Pos    16           /**< \brief (SCIF_RCFASTCFG) Oscillator Calibration Value */
-#define SCIF_RCFASTCFG_CALIB_Msk    (_U(0x7F) << SCIF_RCFASTCFG_CALIB_Pos)
+#define SCIF_RCFASTCFG_CALIB_Msk    (_U_(0x7F) << SCIF_RCFASTCFG_CALIB_Pos)
 #define SCIF_RCFASTCFG_CALIB(value) (SCIF_RCFASTCFG_CALIB_Msk & ((value) << SCIF_RCFASTCFG_CALIB_Pos))
-#define SCIF_RCFASTCFG_MASK         _U(0x007FF3F7) /**< \brief (SCIF_RCFASTCFG) MASK Register */
+#define SCIF_RCFASTCFG_MASK         _U_(0x007FF3F7) /**< \brief (SCIF_RCFASTCFG) MASK Register */
 
 /* -------- SCIF_RCFASTSR : (SCIF Offset: 0x04C) (R/W 32) 4/8/12 MHz RC Oscillator Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -706,23 +706,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SCIF_RCFASTSR_OFFSET        0x04C        /**< \brief (SCIF_RCFASTSR offset) 4/8/12 MHz RC Oscillator Status Register */
-#define SCIF_RCFASTSR_RESETVALUE    _U(0x00000000); /**< \brief (SCIF_RCFASTSR reset_value) 4/8/12 MHz RC Oscillator Status Register */
+#define SCIF_RCFASTSR_RESETVALUE    _U_(0x00000000); /**< \brief (SCIF_RCFASTSR reset_value) 4/8/12 MHz RC Oscillator Status Register */
 
 #define SCIF_RCFASTSR_CURTRIM_Pos   0            /**< \brief (SCIF_RCFASTSR) Current Trim Value */
-#define SCIF_RCFASTSR_CURTRIM_Msk   (_U(0x7F) << SCIF_RCFASTSR_CURTRIM_Pos)
+#define SCIF_RCFASTSR_CURTRIM_Msk   (_U_(0x7F) << SCIF_RCFASTSR_CURTRIM_Pos)
 #define SCIF_RCFASTSR_CURTRIM(value) (SCIF_RCFASTSR_CURTRIM_Msk & ((value) << SCIF_RCFASTSR_CURTRIM_Pos))
 #define SCIF_RCFASTSR_CNTERR_Pos    16           /**< \brief (SCIF_RCFASTSR) Current Count Error */
-#define SCIF_RCFASTSR_CNTERR_Msk    (_U(0x1F) << SCIF_RCFASTSR_CNTERR_Pos)
+#define SCIF_RCFASTSR_CNTERR_Msk    (_U_(0x1F) << SCIF_RCFASTSR_CNTERR_Pos)
 #define SCIF_RCFASTSR_CNTERR(value) (SCIF_RCFASTSR_CNTERR_Msk & ((value) << SCIF_RCFASTSR_CNTERR_Pos))
 #define SCIF_RCFASTSR_SIGN_Pos      21           /**< \brief (SCIF_RCFASTSR) Sign of Current Count Error */
-#define SCIF_RCFASTSR_SIGN          (_U(0x1) << SCIF_RCFASTSR_SIGN_Pos)
+#define SCIF_RCFASTSR_SIGN          (_U_(0x1) << SCIF_RCFASTSR_SIGN_Pos)
 #define SCIF_RCFASTSR_LOCK_Pos      24           /**< \brief (SCIF_RCFASTSR) Lock */
-#define SCIF_RCFASTSR_LOCK          (_U(0x1) << SCIF_RCFASTSR_LOCK_Pos)
+#define SCIF_RCFASTSR_LOCK          (_U_(0x1) << SCIF_RCFASTSR_LOCK_Pos)
 #define SCIF_RCFASTSR_LOCKLOST_Pos  25           /**< \brief (SCIF_RCFASTSR) Lock Lost */
-#define SCIF_RCFASTSR_LOCKLOST      (_U(0x1) << SCIF_RCFASTSR_LOCKLOST_Pos)
+#define SCIF_RCFASTSR_LOCKLOST      (_U_(0x1) << SCIF_RCFASTSR_LOCKLOST_Pos)
 #define SCIF_RCFASTSR_UPDATED_Pos   31           /**< \brief (SCIF_RCFASTSR) Current Trim Value Updated */
-#define SCIF_RCFASTSR_UPDATED       (_U(0x1) << SCIF_RCFASTSR_UPDATED_Pos)
-#define SCIF_RCFASTSR_MASK          _U(0x833F007F) /**< \brief (SCIF_RCFASTSR) MASK Register */
+#define SCIF_RCFASTSR_UPDATED       (_U_(0x1) << SCIF_RCFASTSR_UPDATED_Pos)
+#define SCIF_RCFASTSR_MASK          _U_(0x833F007F) /**< \brief (SCIF_RCFASTSR) MASK Register */
 
 /* -------- SCIF_RC80MCR : (SCIF Offset: 0x050) (R/W 32) 80 MHz RC Oscillator Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -740,16 +740,16 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SCIF_RC80MCR_OFFSET         0x050        /**< \brief (SCIF_RC80MCR offset) 80 MHz RC Oscillator Register */
-#define SCIF_RC80MCR_RESETVALUE     _U(0x00000000); /**< \brief (SCIF_RC80MCR reset_value) 80 MHz RC Oscillator Register */
+#define SCIF_RC80MCR_RESETVALUE     _U_(0x00000000); /**< \brief (SCIF_RC80MCR reset_value) 80 MHz RC Oscillator Register */
 
 #define SCIF_RC80MCR_EN_Pos         0            /**< \brief (SCIF_RC80MCR) Enable */
-#define SCIF_RC80MCR_EN             (_U(0x1) << SCIF_RC80MCR_EN_Pos)
+#define SCIF_RC80MCR_EN             (_U_(0x1) << SCIF_RC80MCR_EN_Pos)
 #define SCIF_RC80MCR_FCD_Pos        7            /**< \brief (SCIF_RC80MCR) Flash Calibration Done */
-#define SCIF_RC80MCR_FCD            (_U(0x1) << SCIF_RC80MCR_FCD_Pos)
+#define SCIF_RC80MCR_FCD            (_U_(0x1) << SCIF_RC80MCR_FCD_Pos)
 #define SCIF_RC80MCR_CALIB_Pos      16           /**< \brief (SCIF_RC80MCR) Calibration Value */
-#define SCIF_RC80MCR_CALIB_Msk      (_U(0x3) << SCIF_RC80MCR_CALIB_Pos)
+#define SCIF_RC80MCR_CALIB_Msk      (_U_(0x3) << SCIF_RC80MCR_CALIB_Pos)
 #define SCIF_RC80MCR_CALIB(value)   (SCIF_RC80MCR_CALIB_Msk & ((value) << SCIF_RC80MCR_CALIB_Pos))
-#define SCIF_RC80MCR_MASK           _U(0x00030081) /**< \brief (SCIF_RC80MCR) MASK Register */
+#define SCIF_RC80MCR_MASK           _U_(0x00030081) /**< \brief (SCIF_RC80MCR) MASK Register */
 
 /* -------- SCIF_HRPCR : (SCIF Offset: 0x064) (R/W 32) High Resolution Prescaler Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -767,14 +767,14 @@ typedef union {
 #define SCIF_HRPCR_OFFSET           0x064        /**< \brief (SCIF_HRPCR offset) High Resolution Prescaler Control Register */
 
 #define SCIF_HRPCR_HRPEN_Pos        0            /**< \brief (SCIF_HRPCR) High Resolution Prescaler Enable */
-#define SCIF_HRPCR_HRPEN            (_U(0x1) << SCIF_HRPCR_HRPEN_Pos)
+#define SCIF_HRPCR_HRPEN            (_U_(0x1) << SCIF_HRPCR_HRPEN_Pos)
 #define SCIF_HRPCR_CKSEL_Pos        1            /**< \brief (SCIF_HRPCR) Clock Input Selection */
-#define SCIF_HRPCR_CKSEL_Msk        (_U(0x7) << SCIF_HRPCR_CKSEL_Pos)
+#define SCIF_HRPCR_CKSEL_Msk        (_U_(0x7) << SCIF_HRPCR_CKSEL_Pos)
 #define SCIF_HRPCR_CKSEL(value)     (SCIF_HRPCR_CKSEL_Msk & ((value) << SCIF_HRPCR_CKSEL_Pos))
 #define SCIF_HRPCR_HRCOUNT_Pos      8            /**< \brief (SCIF_HRPCR) High Resolution Counter */
-#define SCIF_HRPCR_HRCOUNT_Msk      (_U(0xFFFFFF) << SCIF_HRPCR_HRCOUNT_Pos)
+#define SCIF_HRPCR_HRCOUNT_Msk      (_U_(0xFFFFFF) << SCIF_HRPCR_HRCOUNT_Pos)
 #define SCIF_HRPCR_HRCOUNT(value)   (SCIF_HRPCR_HRCOUNT_Msk & ((value) << SCIF_HRPCR_HRCOUNT_Pos))
-#define SCIF_HRPCR_MASK             _U(0xFFFFFF0F) /**< \brief (SCIF_HRPCR) MASK Register */
+#define SCIF_HRPCR_MASK             _U_(0xFFFFFF0F) /**< \brief (SCIF_HRPCR) MASK Register */
 
 /* -------- SCIF_FPCR : (SCIF Offset: 0x068) (R/W 32) Fractional Prescaler Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -791,11 +791,11 @@ typedef union {
 #define SCIF_FPCR_OFFSET            0x068        /**< \brief (SCIF_FPCR offset) Fractional Prescaler Control Register */
 
 #define SCIF_FPCR_FPEN_Pos          0            /**< \brief (SCIF_FPCR) High Resolution Prescaler Enable */
-#define SCIF_FPCR_FPEN              (_U(0x1) << SCIF_FPCR_FPEN_Pos)
+#define SCIF_FPCR_FPEN              (_U_(0x1) << SCIF_FPCR_FPEN_Pos)
 #define SCIF_FPCR_CKSEL_Pos         1            /**< \brief (SCIF_FPCR) Clock Input Selection */
-#define SCIF_FPCR_CKSEL_Msk         (_U(0x7) << SCIF_FPCR_CKSEL_Pos)
+#define SCIF_FPCR_CKSEL_Msk         (_U_(0x7) << SCIF_FPCR_CKSEL_Pos)
 #define SCIF_FPCR_CKSEL(value)      (SCIF_FPCR_CKSEL_Msk & ((value) << SCIF_FPCR_CKSEL_Pos))
-#define SCIF_FPCR_MASK              _U(0x0000000F) /**< \brief (SCIF_FPCR) MASK Register */
+#define SCIF_FPCR_MASK              _U_(0x0000000F) /**< \brief (SCIF_FPCR) MASK Register */
 
 /* -------- SCIF_FPMUL : (SCIF Offset: 0x06C) (R/W 32) Fractional Prescaler Multiplier Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -811,9 +811,9 @@ typedef union {
 #define SCIF_FPMUL_OFFSET           0x06C        /**< \brief (SCIF_FPMUL offset) Fractional Prescaler Multiplier Register */
 
 #define SCIF_FPMUL_FPMUL_Pos        0            /**< \brief (SCIF_FPMUL) Fractional Prescaler Multiplication Factor */
-#define SCIF_FPMUL_FPMUL_Msk        (_U(0xFFFF) << SCIF_FPMUL_FPMUL_Pos)
+#define SCIF_FPMUL_FPMUL_Msk        (_U_(0xFFFF) << SCIF_FPMUL_FPMUL_Pos)
 #define SCIF_FPMUL_FPMUL(value)     (SCIF_FPMUL_FPMUL_Msk & ((value) << SCIF_FPMUL_FPMUL_Pos))
-#define SCIF_FPMUL_MASK             _U(0x0000FFFF) /**< \brief (SCIF_FPMUL) MASK Register */
+#define SCIF_FPMUL_MASK             _U_(0x0000FFFF) /**< \brief (SCIF_FPMUL) MASK Register */
 
 /* -------- SCIF_FPDIV : (SCIF Offset: 0x070) (R/W 32) Fractional Prescaler DIVIDER Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -829,9 +829,9 @@ typedef union {
 #define SCIF_FPDIV_OFFSET           0x070        /**< \brief (SCIF_FPDIV offset) Fractional Prescaler DIVIDER Register */
 
 #define SCIF_FPDIV_FPDIV_Pos        0            /**< \brief (SCIF_FPDIV) Fractional Prescaler Division Factor */
-#define SCIF_FPDIV_FPDIV_Msk        (_U(0xFFFF) << SCIF_FPDIV_FPDIV_Pos)
+#define SCIF_FPDIV_FPDIV_Msk        (_U_(0xFFFF) << SCIF_FPDIV_FPDIV_Pos)
 #define SCIF_FPDIV_FPDIV(value)     (SCIF_FPDIV_FPDIV_Msk & ((value) << SCIF_FPDIV_FPDIV_Pos))
-#define SCIF_FPDIV_MASK             _U(0x0000FFFF) /**< \brief (SCIF_FPDIV) MASK Register */
+#define SCIF_FPDIV_MASK             _U_(0x0000FFFF) /**< \brief (SCIF_FPDIV) MASK Register */
 
 /* -------- SCIF_GCCTRL : (SCIF Offset: 0x074) (R/W 32) gcctrl Generic Clock Control -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -849,19 +849,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SCIF_GCCTRL_OFFSET          0x074        /**< \brief (SCIF_GCCTRL offset) Generic Clock Control */
-#define SCIF_GCCTRL_RESETVALUE      _U(0x00000000); /**< \brief (SCIF_GCCTRL reset_value) Generic Clock Control */
+#define SCIF_GCCTRL_RESETVALUE      _U_(0x00000000); /**< \brief (SCIF_GCCTRL reset_value) Generic Clock Control */
 
 #define SCIF_GCCTRL_CEN_Pos         0            /**< \brief (SCIF_GCCTRL) Clock Enable */
-#define SCIF_GCCTRL_CEN             (_U(0x1) << SCIF_GCCTRL_CEN_Pos)
+#define SCIF_GCCTRL_CEN             (_U_(0x1) << SCIF_GCCTRL_CEN_Pos)
 #define SCIF_GCCTRL_DIVEN_Pos       1            /**< \brief (SCIF_GCCTRL) Divide Enable */
-#define SCIF_GCCTRL_DIVEN           (_U(0x1) << SCIF_GCCTRL_DIVEN_Pos)
+#define SCIF_GCCTRL_DIVEN           (_U_(0x1) << SCIF_GCCTRL_DIVEN_Pos)
 #define SCIF_GCCTRL_OSCSEL_Pos      8            /**< \brief (SCIF_GCCTRL) Clock Select */
-#define SCIF_GCCTRL_OSCSEL_Msk      (_U(0x1F) << SCIF_GCCTRL_OSCSEL_Pos)
+#define SCIF_GCCTRL_OSCSEL_Msk      (_U_(0x1F) << SCIF_GCCTRL_OSCSEL_Pos)
 #define SCIF_GCCTRL_OSCSEL(value)   (SCIF_GCCTRL_OSCSEL_Msk & ((value) << SCIF_GCCTRL_OSCSEL_Pos))
 #define SCIF_GCCTRL_DIV_Pos         16           /**< \brief (SCIF_GCCTRL) Division Factor */
-#define SCIF_GCCTRL_DIV_Msk         (_U(0xFFFF) << SCIF_GCCTRL_DIV_Pos)
+#define SCIF_GCCTRL_DIV_Msk         (_U_(0xFFFF) << SCIF_GCCTRL_DIV_Pos)
 #define SCIF_GCCTRL_DIV(value)      (SCIF_GCCTRL_DIV_Msk & ((value) << SCIF_GCCTRL_DIV_Pos))
-#define SCIF_GCCTRL_MASK            _U(0xFFFF1F03) /**< \brief (SCIF_GCCTRL) MASK Register */
+#define SCIF_GCCTRL_MASK            _U_(0xFFFF1F03) /**< \brief (SCIF_GCCTRL) MASK Register */
 
 /* -------- SCIF_RCFASTVERSION : (SCIF Offset: 0x3D8) (R/  32) 4/8/12 MHz RC Oscillator Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -879,12 +879,12 @@ typedef union {
 #define SCIF_RCFASTVERSION_OFFSET   0x3D8        /**< \brief (SCIF_RCFASTVERSION offset) 4/8/12 MHz RC Oscillator Version Register */
 
 #define SCIF_RCFASTVERSION_VERSION_Pos 0            /**< \brief (SCIF_RCFASTVERSION) Version number */
-#define SCIF_RCFASTVERSION_VERSION_Msk (_U(0xFFF) << SCIF_RCFASTVERSION_VERSION_Pos)
+#define SCIF_RCFASTVERSION_VERSION_Msk (_U_(0xFFF) << SCIF_RCFASTVERSION_VERSION_Pos)
 #define SCIF_RCFASTVERSION_VERSION(value) (SCIF_RCFASTVERSION_VERSION_Msk & ((value) << SCIF_RCFASTVERSION_VERSION_Pos))
 #define SCIF_RCFASTVERSION_VARIANT_Pos 16           /**< \brief (SCIF_RCFASTVERSION) Variant number */
-#define SCIF_RCFASTVERSION_VARIANT_Msk (_U(0xF) << SCIF_RCFASTVERSION_VARIANT_Pos)
+#define SCIF_RCFASTVERSION_VARIANT_Msk (_U_(0xF) << SCIF_RCFASTVERSION_VARIANT_Pos)
 #define SCIF_RCFASTVERSION_VARIANT(value) (SCIF_RCFASTVERSION_VARIANT_Msk & ((value) << SCIF_RCFASTVERSION_VARIANT_Pos))
-#define SCIF_RCFASTVERSION_MASK     _U(0x000F0FFF) /**< \brief (SCIF_RCFASTVERSION) MASK Register */
+#define SCIF_RCFASTVERSION_MASK     _U_(0x000F0FFF) /**< \brief (SCIF_RCFASTVERSION) MASK Register */
 
 /* -------- SCIF_GCLKPRESCVERSION : (SCIF Offset: 0x3DC) (R/  32) Generic Clock Prescaler Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -902,12 +902,12 @@ typedef union {
 #define SCIF_GCLKPRESCVERSION_OFFSET 0x3DC        /**< \brief (SCIF_GCLKPRESCVERSION offset) Generic Clock Prescaler Version Register */
 
 #define SCIF_GCLKPRESCVERSION_VERSION_Pos 0            /**< \brief (SCIF_GCLKPRESCVERSION) Version number */
-#define SCIF_GCLKPRESCVERSION_VERSION_Msk (_U(0xFFF) << SCIF_GCLKPRESCVERSION_VERSION_Pos)
+#define SCIF_GCLKPRESCVERSION_VERSION_Msk (_U_(0xFFF) << SCIF_GCLKPRESCVERSION_VERSION_Pos)
 #define SCIF_GCLKPRESCVERSION_VERSION(value) (SCIF_GCLKPRESCVERSION_VERSION_Msk & ((value) << SCIF_GCLKPRESCVERSION_VERSION_Pos))
 #define SCIF_GCLKPRESCVERSION_VARIANT_Pos 16           /**< \brief (SCIF_GCLKPRESCVERSION) Variant number */
-#define SCIF_GCLKPRESCVERSION_VARIANT_Msk (_U(0xF) << SCIF_GCLKPRESCVERSION_VARIANT_Pos)
+#define SCIF_GCLKPRESCVERSION_VARIANT_Msk (_U_(0xF) << SCIF_GCLKPRESCVERSION_VARIANT_Pos)
 #define SCIF_GCLKPRESCVERSION_VARIANT(value) (SCIF_GCLKPRESCVERSION_VARIANT_Msk & ((value) << SCIF_GCLKPRESCVERSION_VARIANT_Pos))
-#define SCIF_GCLKPRESCVERSION_MASK  _U(0x000F0FFF) /**< \brief (SCIF_GCLKPRESCVERSION) MASK Register */
+#define SCIF_GCLKPRESCVERSION_MASK  _U_(0x000F0FFF) /**< \brief (SCIF_GCLKPRESCVERSION) MASK Register */
 
 /* -------- SCIF_PLLIFAVERSION : (SCIF Offset: 0x3E0) (R/  32) PLL Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -925,12 +925,12 @@ typedef union {
 #define SCIF_PLLIFAVERSION_OFFSET   0x3E0        /**< \brief (SCIF_PLLIFAVERSION offset) PLL Version Register */
 
 #define SCIF_PLLIFAVERSION_VERSION_Pos 0            /**< \brief (SCIF_PLLIFAVERSION) Version number */
-#define SCIF_PLLIFAVERSION_VERSION_Msk (_U(0xFFF) << SCIF_PLLIFAVERSION_VERSION_Pos)
+#define SCIF_PLLIFAVERSION_VERSION_Msk (_U_(0xFFF) << SCIF_PLLIFAVERSION_VERSION_Pos)
 #define SCIF_PLLIFAVERSION_VERSION(value) (SCIF_PLLIFAVERSION_VERSION_Msk & ((value) << SCIF_PLLIFAVERSION_VERSION_Pos))
 #define SCIF_PLLIFAVERSION_VARIANT_Pos 16           /**< \brief (SCIF_PLLIFAVERSION) Variant nubmer */
-#define SCIF_PLLIFAVERSION_VARIANT_Msk (_U(0xF) << SCIF_PLLIFAVERSION_VARIANT_Pos)
+#define SCIF_PLLIFAVERSION_VARIANT_Msk (_U_(0xF) << SCIF_PLLIFAVERSION_VARIANT_Pos)
 #define SCIF_PLLIFAVERSION_VARIANT(value) (SCIF_PLLIFAVERSION_VARIANT_Msk & ((value) << SCIF_PLLIFAVERSION_VARIANT_Pos))
-#define SCIF_PLLIFAVERSION_MASK     _U(0x000F0FFF) /**< \brief (SCIF_PLLIFAVERSION) MASK Register */
+#define SCIF_PLLIFAVERSION_MASK     _U_(0x000F0FFF) /**< \brief (SCIF_PLLIFAVERSION) MASK Register */
 
 /* -------- SCIF_OSCIFAVERSION : (SCIF Offset: 0x3E4) (R/  32) Oscillator 0 Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -948,12 +948,12 @@ typedef union {
 #define SCIF_OSCIFAVERSION_OFFSET   0x3E4        /**< \brief (SCIF_OSCIFAVERSION offset) Oscillator 0 Version Register */
 
 #define SCIF_OSCIFAVERSION_VERSION_Pos 0            /**< \brief (SCIF_OSCIFAVERSION) Version number */
-#define SCIF_OSCIFAVERSION_VERSION_Msk (_U(0xFFF) << SCIF_OSCIFAVERSION_VERSION_Pos)
+#define SCIF_OSCIFAVERSION_VERSION_Msk (_U_(0xFFF) << SCIF_OSCIFAVERSION_VERSION_Pos)
 #define SCIF_OSCIFAVERSION_VERSION(value) (SCIF_OSCIFAVERSION_VERSION_Msk & ((value) << SCIF_OSCIFAVERSION_VERSION_Pos))
 #define SCIF_OSCIFAVERSION_VARIANT_Pos 16           /**< \brief (SCIF_OSCIFAVERSION) Variant nubmer */
-#define SCIF_OSCIFAVERSION_VARIANT_Msk (_U(0xF) << SCIF_OSCIFAVERSION_VARIANT_Pos)
+#define SCIF_OSCIFAVERSION_VARIANT_Msk (_U_(0xF) << SCIF_OSCIFAVERSION_VARIANT_Pos)
 #define SCIF_OSCIFAVERSION_VARIANT(value) (SCIF_OSCIFAVERSION_VARIANT_Msk & ((value) << SCIF_OSCIFAVERSION_VARIANT_Pos))
-#define SCIF_OSCIFAVERSION_MASK     _U(0x000F0FFF) /**< \brief (SCIF_OSCIFAVERSION) MASK Register */
+#define SCIF_OSCIFAVERSION_MASK     _U_(0x000F0FFF) /**< \brief (SCIF_OSCIFAVERSION) MASK Register */
 
 /* -------- SCIF_DFLLIFBVERSION : (SCIF Offset: 0x3E8) (R/  32) DFLL Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -971,12 +971,12 @@ typedef union {
 #define SCIF_DFLLIFBVERSION_OFFSET  0x3E8        /**< \brief (SCIF_DFLLIFBVERSION offset) DFLL Version Register */
 
 #define SCIF_DFLLIFBVERSION_VERSION_Pos 0            /**< \brief (SCIF_DFLLIFBVERSION) Version number */
-#define SCIF_DFLLIFBVERSION_VERSION_Msk (_U(0xFFF) << SCIF_DFLLIFBVERSION_VERSION_Pos)
+#define SCIF_DFLLIFBVERSION_VERSION_Msk (_U_(0xFFF) << SCIF_DFLLIFBVERSION_VERSION_Pos)
 #define SCIF_DFLLIFBVERSION_VERSION(value) (SCIF_DFLLIFBVERSION_VERSION_Msk & ((value) << SCIF_DFLLIFBVERSION_VERSION_Pos))
 #define SCIF_DFLLIFBVERSION_VARIANT_Pos 16           /**< \brief (SCIF_DFLLIFBVERSION) Variant number */
-#define SCIF_DFLLIFBVERSION_VARIANT_Msk (_U(0xF) << SCIF_DFLLIFBVERSION_VARIANT_Pos)
+#define SCIF_DFLLIFBVERSION_VARIANT_Msk (_U_(0xF) << SCIF_DFLLIFBVERSION_VARIANT_Pos)
 #define SCIF_DFLLIFBVERSION_VARIANT(value) (SCIF_DFLLIFBVERSION_VARIANT_Msk & ((value) << SCIF_DFLLIFBVERSION_VARIANT_Pos))
-#define SCIF_DFLLIFBVERSION_MASK    _U(0x000F0FFF) /**< \brief (SCIF_DFLLIFBVERSION) MASK Register */
+#define SCIF_DFLLIFBVERSION_MASK    _U_(0x000F0FFF) /**< \brief (SCIF_DFLLIFBVERSION) MASK Register */
 
 /* -------- SCIF_RCOSCIFAVERSION : (SCIF Offset: 0x3EC) (R/  32) System RC Oscillator Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -994,12 +994,12 @@ typedef union {
 #define SCIF_RCOSCIFAVERSION_OFFSET 0x3EC        /**< \brief (SCIF_RCOSCIFAVERSION offset) System RC Oscillator Version Register */
 
 #define SCIF_RCOSCIFAVERSION_VERSION_Pos 0            /**< \brief (SCIF_RCOSCIFAVERSION) Version number */
-#define SCIF_RCOSCIFAVERSION_VERSION_Msk (_U(0xFFF) << SCIF_RCOSCIFAVERSION_VERSION_Pos)
+#define SCIF_RCOSCIFAVERSION_VERSION_Msk (_U_(0xFFF) << SCIF_RCOSCIFAVERSION_VERSION_Pos)
 #define SCIF_RCOSCIFAVERSION_VERSION(value) (SCIF_RCOSCIFAVERSION_VERSION_Msk & ((value) << SCIF_RCOSCIFAVERSION_VERSION_Pos))
 #define SCIF_RCOSCIFAVERSION_VARIANT_Pos 16           /**< \brief (SCIF_RCOSCIFAVERSION) Variant number */
-#define SCIF_RCOSCIFAVERSION_VARIANT_Msk (_U(0xF) << SCIF_RCOSCIFAVERSION_VARIANT_Pos)
+#define SCIF_RCOSCIFAVERSION_VARIANT_Msk (_U_(0xF) << SCIF_RCOSCIFAVERSION_VARIANT_Pos)
 #define SCIF_RCOSCIFAVERSION_VARIANT(value) (SCIF_RCOSCIFAVERSION_VARIANT_Msk & ((value) << SCIF_RCOSCIFAVERSION_VARIANT_Pos))
-#define SCIF_RCOSCIFAVERSION_MASK   _U(0x000F0FFF) /**< \brief (SCIF_RCOSCIFAVERSION) MASK Register */
+#define SCIF_RCOSCIFAVERSION_MASK   _U_(0x000F0FFF) /**< \brief (SCIF_RCOSCIFAVERSION) MASK Register */
 
 /* -------- SCIF_FLOVERSION : (SCIF Offset: 0x3F0) (R/  32) Frequency Locked Oscillator Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1017,12 +1017,12 @@ typedef union {
 #define SCIF_FLOVERSION_OFFSET      0x3F0        /**< \brief (SCIF_FLOVERSION offset) Frequency Locked Oscillator Version Register */
 
 #define SCIF_FLOVERSION_VERSION_Pos 0            /**< \brief (SCIF_FLOVERSION) Version number */
-#define SCIF_FLOVERSION_VERSION_Msk (_U(0xFFF) << SCIF_FLOVERSION_VERSION_Pos)
+#define SCIF_FLOVERSION_VERSION_Msk (_U_(0xFFF) << SCIF_FLOVERSION_VERSION_Pos)
 #define SCIF_FLOVERSION_VERSION(value) (SCIF_FLOVERSION_VERSION_Msk & ((value) << SCIF_FLOVERSION_VERSION_Pos))
 #define SCIF_FLOVERSION_VARIANT_Pos 16           /**< \brief (SCIF_FLOVERSION) Variant number */
-#define SCIF_FLOVERSION_VARIANT_Msk (_U(0xF) << SCIF_FLOVERSION_VARIANT_Pos)
+#define SCIF_FLOVERSION_VARIANT_Msk (_U_(0xF) << SCIF_FLOVERSION_VARIANT_Pos)
 #define SCIF_FLOVERSION_VARIANT(value) (SCIF_FLOVERSION_VARIANT_Msk & ((value) << SCIF_FLOVERSION_VARIANT_Pos))
-#define SCIF_FLOVERSION_MASK        _U(0x000F0FFF) /**< \brief (SCIF_FLOVERSION) MASK Register */
+#define SCIF_FLOVERSION_MASK        _U_(0x000F0FFF) /**< \brief (SCIF_FLOVERSION) MASK Register */
 
 /* -------- SCIF_RC80MVERSION : (SCIF Offset: 0x3F4) (R/  32) 80MHz RC Oscillator Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1040,12 +1040,12 @@ typedef union {
 #define SCIF_RC80MVERSION_OFFSET    0x3F4        /**< \brief (SCIF_RC80MVERSION offset) 80MHz RC Oscillator Version Register */
 
 #define SCIF_RC80MVERSION_VERSION_Pos 0            /**< \brief (SCIF_RC80MVERSION) Version number */
-#define SCIF_RC80MVERSION_VERSION_Msk (_U(0xFFF) << SCIF_RC80MVERSION_VERSION_Pos)
+#define SCIF_RC80MVERSION_VERSION_Msk (_U_(0xFFF) << SCIF_RC80MVERSION_VERSION_Pos)
 #define SCIF_RC80MVERSION_VERSION(value) (SCIF_RC80MVERSION_VERSION_Msk & ((value) << SCIF_RC80MVERSION_VERSION_Pos))
 #define SCIF_RC80MVERSION_VARIANT_Pos 16           /**< \brief (SCIF_RC80MVERSION) Variant number */
-#define SCIF_RC80MVERSION_VARIANT_Msk (_U(0xF) << SCIF_RC80MVERSION_VARIANT_Pos)
+#define SCIF_RC80MVERSION_VARIANT_Msk (_U_(0xF) << SCIF_RC80MVERSION_VARIANT_Pos)
 #define SCIF_RC80MVERSION_VARIANT(value) (SCIF_RC80MVERSION_VARIANT_Msk & ((value) << SCIF_RC80MVERSION_VARIANT_Pos))
-#define SCIF_RC80MVERSION_MASK      _U(0x000F0FFF) /**< \brief (SCIF_RC80MVERSION) MASK Register */
+#define SCIF_RC80MVERSION_MASK      _U_(0x000F0FFF) /**< \brief (SCIF_RC80MVERSION) MASK Register */
 
 /* -------- SCIF_GCLKIFVERSION : (SCIF Offset: 0x3F8) (R/  32) Generic Clock Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1063,12 +1063,12 @@ typedef union {
 #define SCIF_GCLKIFVERSION_OFFSET   0x3F8        /**< \brief (SCIF_GCLKIFVERSION offset) Generic Clock Version Register */
 
 #define SCIF_GCLKIFVERSION_VERSION_Pos 0            /**< \brief (SCIF_GCLKIFVERSION) Version number */
-#define SCIF_GCLKIFVERSION_VERSION_Msk (_U(0xFFF) << SCIF_GCLKIFVERSION_VERSION_Pos)
+#define SCIF_GCLKIFVERSION_VERSION_Msk (_U_(0xFFF) << SCIF_GCLKIFVERSION_VERSION_Pos)
 #define SCIF_GCLKIFVERSION_VERSION(value) (SCIF_GCLKIFVERSION_VERSION_Msk & ((value) << SCIF_GCLKIFVERSION_VERSION_Pos))
 #define SCIF_GCLKIFVERSION_VARIANT_Pos 16           /**< \brief (SCIF_GCLKIFVERSION) Variant number */
-#define SCIF_GCLKIFVERSION_VARIANT_Msk (_U(0xF) << SCIF_GCLKIFVERSION_VARIANT_Pos)
+#define SCIF_GCLKIFVERSION_VARIANT_Msk (_U_(0xF) << SCIF_GCLKIFVERSION_VARIANT_Pos)
 #define SCIF_GCLKIFVERSION_VARIANT(value) (SCIF_GCLKIFVERSION_VARIANT_Msk & ((value) << SCIF_GCLKIFVERSION_VARIANT_Pos))
-#define SCIF_GCLKIFVERSION_MASK     _U(0x000F0FFF) /**< \brief (SCIF_GCLKIFVERSION) MASK Register */
+#define SCIF_GCLKIFVERSION_MASK     _U_(0x000F0FFF) /**< \brief (SCIF_GCLKIFVERSION) MASK Register */
 
 /* -------- SCIF_VERSION : (SCIF Offset: 0x3FC) (R/  32) SCIF Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1084,15 +1084,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SCIF_VERSION_OFFSET         0x3FC        /**< \brief (SCIF_VERSION offset) SCIF Version Register */
-#define SCIF_VERSION_RESETVALUE     _U(0x00000130); /**< \brief (SCIF_VERSION reset_value) SCIF Version Register */
+#define SCIF_VERSION_RESETVALUE     _U_(0x00000130); /**< \brief (SCIF_VERSION reset_value) SCIF Version Register */
 
 #define SCIF_VERSION_VERSION_Pos    0            /**< \brief (SCIF_VERSION) Version number */
-#define SCIF_VERSION_VERSION_Msk    (_U(0xFFF) << SCIF_VERSION_VERSION_Pos)
+#define SCIF_VERSION_VERSION_Msk    (_U_(0xFFF) << SCIF_VERSION_VERSION_Pos)
 #define SCIF_VERSION_VERSION(value) (SCIF_VERSION_VERSION_Msk & ((value) << SCIF_VERSION_VERSION_Pos))
 #define SCIF_VERSION_VARIANT_Pos    16           /**< \brief (SCIF_VERSION) Variant number */
-#define SCIF_VERSION_VARIANT_Msk    (_U(0xF) << SCIF_VERSION_VARIANT_Pos)
+#define SCIF_VERSION_VARIANT_Msk    (_U_(0xF) << SCIF_VERSION_VARIANT_Pos)
 #define SCIF_VERSION_VARIANT(value) (SCIF_VERSION_VARIANT_Msk & ((value) << SCIF_VERSION_VARIANT_Pos))
-#define SCIF_VERSION_MASK           _U(0x000F0FFF) /**< \brief (SCIF_VERSION) MASK Register */
+#define SCIF_VERSION_MASK           _U_(0x000F0FFF) /**< \brief (SCIF_VERSION) MASK Register */
 
 /** \brief ScifGcctrl hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/smap.h
+++ b/asf/sam/include/sam4l/component/smap.h
@@ -324,37 +324,20 @@ typedef union {
 
 /** \brief SMAP hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __O  SMAP_CR_Type              CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
-  __I  SMAP_SR_Type              SR;          /**< \brief Offset: 0x04 (R/  32) Status Register */
-  __O  SMAP_SCR_Type             SCR;         /**< \brief Offset: 0x08 ( /W 32) Status Clear Register */
-  __IO SMAP_ADDR_Type            ADDR;        /**< \brief Offset: 0x0C (R/W 32) Address Register */
-  __IO SMAP_LENGTH_Type          LENGTH;      /**< \brief Offset: 0x10 (R/W 32) Length Register */
-  __IO SMAP_DATA_Type            DATA;        /**< \brief Offset: 0x14 (R/W 32) Data Register */
-       RoReg8                    Reserved1[0x10];
-  __I  SMAP_VERSION_Type         VERSION;     /**< \brief Offset: 0x28 (R/  32) VERSION register */
-       RoReg8                    Reserved2[0xC4];
-  __I  SMAP_CIDR_Type            CIDR;        /**< \brief Offset: 0xF0 (R/  32) Chip ID Register */
-  __I  SMAP_EXID_Type            EXID;        /**< \brief Offset: 0xF4 (R/  32) Chip ID Extension Register */
-       RoReg8                    Reserved3[0x4];
-  __I  SMAP_IDR_Type             IDR;         /**< \brief Offset: 0xFC (R/  32) AP Identification register */
- } bf;
- struct {
-  WoReg   SMAP_CR;            /**< \brief (SMAP Offset: 0x00) Control Register */
-  RoReg   SMAP_SR;            /**< \brief (SMAP Offset: 0x04) Status Register */
-  WoReg   SMAP_SCR;           /**< \brief (SMAP Offset: 0x08) Status Clear Register */
-  RwReg   SMAP_ADDR;          /**< \brief (SMAP Offset: 0x0C) Address Register */
-  RwReg   SMAP_LENGTH;        /**< \brief (SMAP Offset: 0x10) Length Register */
-  RwReg   SMAP_DATA;          /**< \brief (SMAP Offset: 0x14) Data Register */
-  RoReg8  Reserved4[0x10];
-  RoReg   SMAP_VERSION;       /**< \brief (SMAP Offset: 0x28) VERSION register */
-  RoReg8  Reserved5[0xC4];
-  RoReg   SMAP_CIDR;          /**< \brief (SMAP Offset: 0xF0) Chip ID Register */
-  RoReg   SMAP_EXID;          /**< \brief (SMAP Offset: 0xF4) Chip ID Extension Register */
-  RoReg8  Reserved6[0x4];
-  RoReg   SMAP_IDR;           /**< \brief (SMAP Offset: 0xFC) AP Identification register */
- } reg;
+typedef struct {
+  __O  uint32_t CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
+  __I  uint32_t SR;          /**< \brief Offset: 0x04 (R/  32) Status Register */
+  __O  uint32_t SCR;         /**< \brief Offset: 0x08 ( /W 32) Status Clear Register */
+  __IO uint32_t ADDR;        /**< \brief Offset: 0x0C (R/W 32) Address Register */
+  __IO uint32_t LENGTH;      /**< \brief Offset: 0x10 (R/W 32) Length Register */
+  __IO uint32_t DATA;        /**< \brief Offset: 0x14 (R/W 32) Data Register */
+       RoReg8   Reserved1[0x10];
+  __I  uint32_t VERSION;     /**< \brief Offset: 0x28 (R/  32) VERSION register */
+       RoReg8   Reserved2[0xC4];
+  __I  uint32_t CIDR;        /**< \brief Offset: 0xF0 (R/  32) Chip ID Register */
+  __I  uint32_t EXID;        /**< \brief Offset: 0xF4 (R/  32) Chip ID Extension Register */
+       RoReg8   Reserved3[0x4];
+  __I  uint32_t IDR;         /**< \brief Offset: 0xFC (R/  32) AP Identification register */
 } Smap;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/smap.h
+++ b/asf/sam/include/sam4l/component/smap.h
@@ -1,0 +1,363 @@
+/**
+ * \file
+ *
+ * \brief Component description for SMAP
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_SMAP_COMPONENT_
+#define _SAM4L_SMAP_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR SMAP */
+/* ========================================================================== */
+/** \addtogroup SAM4L_SMAP System Manager Access Port */
+/*@{*/
+
+#define SMAP_I8321
+#define REV_SMAP                    0x100
+
+/* -------- SMAP_CR : (SMAP Offset: 0x00) ( /W 32) Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EN:1;             /*!< bit:      0  Enable                             */
+    uint32_t DIS:1;            /*!< bit:      1  Disable                            */
+    uint32_t CRC:1;            /*!< bit:      2  User Page Read                     */
+    uint32_t FSPR:1;           /*!< bit:      3  Flash Supplementary Page Read      */
+    uint32_t CE:1;             /*!< bit:      4  Chip Erase                         */
+    uint32_t :27;              /*!< bit:  5..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SMAP_CR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMAP_CR_OFFSET              0x00         /**< \brief (SMAP_CR offset) Control Register */
+#define SMAP_CR_RESETVALUE          _U(0x00000000); /**< \brief (SMAP_CR reset_value) Control Register */
+
+#define SMAP_CR_EN_Pos              0            /**< \brief (SMAP_CR) Enable */
+#define SMAP_CR_EN                  (_U(0x1) << SMAP_CR_EN_Pos)
+#define SMAP_CR_DIS_Pos             1            /**< \brief (SMAP_CR) Disable */
+#define SMAP_CR_DIS                 (_U(0x1) << SMAP_CR_DIS_Pos)
+#define SMAP_CR_CRC_Pos             2            /**< \brief (SMAP_CR) User Page Read */
+#define SMAP_CR_CRC                 (_U(0x1) << SMAP_CR_CRC_Pos)
+#define SMAP_CR_FSPR_Pos            3            /**< \brief (SMAP_CR) Flash Supplementary Page Read */
+#define SMAP_CR_FSPR                (_U(0x1) << SMAP_CR_FSPR_Pos)
+#define SMAP_CR_CE_Pos              4            /**< \brief (SMAP_CR) Chip Erase */
+#define SMAP_CR_CE                  (_U(0x1) << SMAP_CR_CE_Pos)
+#define SMAP_CR_MASK                _U(0x0000001F) /**< \brief (SMAP_CR) MASK Register */
+
+/* -------- SMAP_SR : (SMAP Offset: 0x04) (R/  32) Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DONE:1;           /*!< bit:      0  Operation done                     */
+    uint32_t HCR:1;            /*!< bit:      1  Hold Core reset                    */
+    uint32_t BERR:1;           /*!< bit:      2  Bus error                          */
+    uint32_t FAIL:1;           /*!< bit:      3  Failure                            */
+    uint32_t LCK:1;            /*!< bit:      4  Lock                               */
+    uint32_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint32_t EN:1;             /*!< bit:      8  Enabled                            */
+    uint32_t PROT:1;           /*!< bit:      9  Protected                          */
+    uint32_t DBGP:1;           /*!< bit:     10  Debugger Present                   */
+    uint32_t :13;              /*!< bit: 11..23  Reserved                           */
+    uint32_t STATE:3;          /*!< bit: 24..26  State                              */
+    uint32_t :5;               /*!< bit: 27..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SMAP_SR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMAP_SR_OFFSET              0x04         /**< \brief (SMAP_SR offset) Status Register */
+#define SMAP_SR_RESETVALUE          _U(0x00000000); /**< \brief (SMAP_SR reset_value) Status Register */
+
+#define SMAP_SR_DONE_Pos            0            /**< \brief (SMAP_SR) Operation done */
+#define SMAP_SR_DONE                (_U(0x1) << SMAP_SR_DONE_Pos)
+#define SMAP_SR_HCR_Pos             1            /**< \brief (SMAP_SR) Hold Core reset */
+#define SMAP_SR_HCR                 (_U(0x1) << SMAP_SR_HCR_Pos)
+#define SMAP_SR_BERR_Pos            2            /**< \brief (SMAP_SR) Bus error */
+#define SMAP_SR_BERR                (_U(0x1) << SMAP_SR_BERR_Pos)
+#define SMAP_SR_FAIL_Pos            3            /**< \brief (SMAP_SR) Failure */
+#define SMAP_SR_FAIL                (_U(0x1) << SMAP_SR_FAIL_Pos)
+#define SMAP_SR_LCK_Pos             4            /**< \brief (SMAP_SR) Lock */
+#define SMAP_SR_LCK                 (_U(0x1) << SMAP_SR_LCK_Pos)
+#define SMAP_SR_EN_Pos              8            /**< \brief (SMAP_SR) Enabled */
+#define SMAP_SR_EN                  (_U(0x1) << SMAP_SR_EN_Pos)
+#define SMAP_SR_PROT_Pos            9            /**< \brief (SMAP_SR) Protected */
+#define SMAP_SR_PROT                (_U(0x1) << SMAP_SR_PROT_Pos)
+#define SMAP_SR_DBGP_Pos            10           /**< \brief (SMAP_SR) Debugger Present */
+#define SMAP_SR_DBGP                (_U(0x1) << SMAP_SR_DBGP_Pos)
+#define SMAP_SR_STATE_Pos           24           /**< \brief (SMAP_SR) State */
+#define SMAP_SR_STATE_Msk           (_U(0x7) << SMAP_SR_STATE_Pos)
+#define SMAP_SR_STATE(value)        (SMAP_SR_STATE_Msk & ((value) << SMAP_SR_STATE_Pos))
+#define SMAP_SR_MASK                _U(0x0700071F) /**< \brief (SMAP_SR) MASK Register */
+
+/* -------- SMAP_SCR : (SMAP Offset: 0x08) ( /W 32) Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DONE:1;           /*!< bit:      0  Done                               */
+    uint32_t HCR:1;            /*!< bit:      1  Hold Core Register                 */
+    uint32_t BERR:1;           /*!< bit:      2  Bus error                          */
+    uint32_t FAIL:1;           /*!< bit:      3  Failure                            */
+    uint32_t LCK:1;            /*!< bit:      4  Lock error                         */
+    uint32_t :27;              /*!< bit:  5..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SMAP_SCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMAP_SCR_OFFSET             0x08         /**< \brief (SMAP_SCR offset) Status Clear Register */
+#define SMAP_SCR_RESETVALUE         _U(0x00000000); /**< \brief (SMAP_SCR reset_value) Status Clear Register */
+
+#define SMAP_SCR_DONE_Pos           0            /**< \brief (SMAP_SCR) Done */
+#define SMAP_SCR_DONE               (_U(0x1) << SMAP_SCR_DONE_Pos)
+#define SMAP_SCR_HCR_Pos            1            /**< \brief (SMAP_SCR) Hold Core Register */
+#define SMAP_SCR_HCR                (_U(0x1) << SMAP_SCR_HCR_Pos)
+#define SMAP_SCR_BERR_Pos           2            /**< \brief (SMAP_SCR) Bus error */
+#define SMAP_SCR_BERR               (_U(0x1) << SMAP_SCR_BERR_Pos)
+#define SMAP_SCR_FAIL_Pos           3            /**< \brief (SMAP_SCR) Failure */
+#define SMAP_SCR_FAIL               (_U(0x1) << SMAP_SCR_FAIL_Pos)
+#define SMAP_SCR_LCK_Pos            4            /**< \brief (SMAP_SCR) Lock error */
+#define SMAP_SCR_LCK                (_U(0x1) << SMAP_SCR_LCK_Pos)
+#define SMAP_SCR_MASK               _U(0x0000001F) /**< \brief (SMAP_SCR) MASK Register */
+
+/* -------- SMAP_ADDR : (SMAP Offset: 0x0C) (R/W 32) Address Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t ADDR:30;          /*!< bit:  2..31  Address Value                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SMAP_ADDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMAP_ADDR_OFFSET            0x0C         /**< \brief (SMAP_ADDR offset) Address Register */
+#define SMAP_ADDR_RESETVALUE        _U(0x00000000); /**< \brief (SMAP_ADDR reset_value) Address Register */
+
+#define SMAP_ADDR_ADDR_Pos          2            /**< \brief (SMAP_ADDR) Address Value */
+#define SMAP_ADDR_ADDR_Msk          (_U(0x3FFFFFFF) << SMAP_ADDR_ADDR_Pos)
+#define SMAP_ADDR_ADDR(value)       (SMAP_ADDR_ADDR_Msk & ((value) << SMAP_ADDR_ADDR_Pos))
+#define SMAP_ADDR_MASK              _U(0xFFFFFFFC) /**< \brief (SMAP_ADDR) MASK Register */
+
+/* -------- SMAP_LENGTH : (SMAP Offset: 0x10) (R/W 32) Length Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t LENGTH:30;        /*!< bit:  2..31  Length Register                    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SMAP_LENGTH_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMAP_LENGTH_OFFSET          0x10         /**< \brief (SMAP_LENGTH offset) Length Register */
+#define SMAP_LENGTH_RESETVALUE      _U(0x00000000); /**< \brief (SMAP_LENGTH reset_value) Length Register */
+
+#define SMAP_LENGTH_LENGTH_Pos      2            /**< \brief (SMAP_LENGTH) Length Register */
+#define SMAP_LENGTH_LENGTH_Msk      (_U(0x3FFFFFFF) << SMAP_LENGTH_LENGTH_Pos)
+#define SMAP_LENGTH_LENGTH(value)   (SMAP_LENGTH_LENGTH_Msk & ((value) << SMAP_LENGTH_LENGTH_Pos))
+#define SMAP_LENGTH_MASK            _U(0xFFFFFFFC) /**< \brief (SMAP_LENGTH) MASK Register */
+
+/* -------- SMAP_DATA : (SMAP Offset: 0x14) (R/W 32) Data Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATA:32;          /*!< bit:  0..31  Generic data register              */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SMAP_DATA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMAP_DATA_OFFSET            0x14         /**< \brief (SMAP_DATA offset) Data Register */
+#define SMAP_DATA_RESETVALUE        _U(0x00000000); /**< \brief (SMAP_DATA reset_value) Data Register */
+
+#define SMAP_DATA_DATA_Pos          0            /**< \brief (SMAP_DATA) Generic data register */
+#define SMAP_DATA_DATA_Msk          (_U(0xFFFFFFFF) << SMAP_DATA_DATA_Pos)
+#define SMAP_DATA_DATA(value)       (SMAP_DATA_DATA_Msk & ((value) << SMAP_DATA_DATA_Pos))
+#define SMAP_DATA_MASK              _U(0xFFFFFFFF) /**< \brief (SMAP_DATA) MASK Register */
+
+/* -------- SMAP_VERSION : (SMAP Offset: 0x28) (R/  32) VERSION register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SMAP_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMAP_VERSION_OFFSET         0x28         /**< \brief (SMAP_VERSION offset) VERSION register */
+#define SMAP_VERSION_RESETVALUE     _U(0x00000100); /**< \brief (SMAP_VERSION reset_value) VERSION register */
+
+#define SMAP_VERSION_VERSION_Pos    0            /**< \brief (SMAP_VERSION) Version number */
+#define SMAP_VERSION_VERSION_Msk    (_U(0xFFF) << SMAP_VERSION_VERSION_Pos)
+#define SMAP_VERSION_VERSION(value) (SMAP_VERSION_VERSION_Msk & ((value) << SMAP_VERSION_VERSION_Pos))
+#define SMAP_VERSION_VARIANT_Pos    16           /**< \brief (SMAP_VERSION) Variant number */
+#define SMAP_VERSION_VARIANT_Msk    (_U(0xF) << SMAP_VERSION_VARIANT_Pos)
+#define SMAP_VERSION_VARIANT(value) (SMAP_VERSION_VARIANT_Msk & ((value) << SMAP_VERSION_VARIANT_Pos))
+#define SMAP_VERSION_MASK           _U(0x000F0FFF) /**< \brief (SMAP_VERSION) MASK Register */
+
+/* -------- SMAP_CIDR : (SMAP Offset: 0xF0) (R/  32) Chip ID Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:5;        /*!< bit:  0.. 4  Version of the Device              */
+    uint32_t EPROC:3;          /*!< bit:  5.. 7  Embedded Processor                 */
+    uint32_t NVPSIZ:4;         /*!< bit:  8..11  Nonvolatile Program Memory Size    */
+    uint32_t NVPSIZ2:4;        /*!< bit: 12..15  Second Nonvolatile Program Memory Size */
+    uint32_t SRAMSIZ:5;        /*!< bit: 16..20  Internal SRAM Size                 */
+    uint32_t ARCH:7;           /*!< bit: 21..27  Architecture Identifier            */
+    uint32_t NVPTYP:3;         /*!< bit: 28..30  Nonvolatile Program Memory Type    */
+    uint32_t EXT:1;            /*!< bit:     31  Extension Flag                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SMAP_CIDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMAP_CIDR_OFFSET            0xF0         /**< \brief (SMAP_CIDR offset) Chip ID Register */
+
+#define SMAP_CIDR_VERSION_Pos       0            /**< \brief (SMAP_CIDR) Version of the Device */
+#define SMAP_CIDR_VERSION_Msk       (_U(0x1F) << SMAP_CIDR_VERSION_Pos)
+#define SMAP_CIDR_VERSION(value)    (SMAP_CIDR_VERSION_Msk & ((value) << SMAP_CIDR_VERSION_Pos))
+#define SMAP_CIDR_EPROC_Pos         5            /**< \brief (SMAP_CIDR) Embedded Processor */
+#define SMAP_CIDR_EPROC_Msk         (_U(0x7) << SMAP_CIDR_EPROC_Pos)
+#define SMAP_CIDR_EPROC(value)      (SMAP_CIDR_EPROC_Msk & ((value) << SMAP_CIDR_EPROC_Pos))
+#define SMAP_CIDR_NVPSIZ_Pos        8            /**< \brief (SMAP_CIDR) Nonvolatile Program Memory Size */
+#define SMAP_CIDR_NVPSIZ_Msk        (_U(0xF) << SMAP_CIDR_NVPSIZ_Pos)
+#define SMAP_CIDR_NVPSIZ(value)     (SMAP_CIDR_NVPSIZ_Msk & ((value) << SMAP_CIDR_NVPSIZ_Pos))
+#define SMAP_CIDR_NVPSIZ2_Pos       12           /**< \brief (SMAP_CIDR) Second Nonvolatile Program Memory Size */
+#define SMAP_CIDR_NVPSIZ2_Msk       (_U(0xF) << SMAP_CIDR_NVPSIZ2_Pos)
+#define SMAP_CIDR_NVPSIZ2(value)    (SMAP_CIDR_NVPSIZ2_Msk & ((value) << SMAP_CIDR_NVPSIZ2_Pos))
+#define SMAP_CIDR_SRAMSIZ_Pos       16           /**< \brief (SMAP_CIDR) Internal SRAM Size */
+#define SMAP_CIDR_SRAMSIZ_Msk       (_U(0x1F) << SMAP_CIDR_SRAMSIZ_Pos)
+#define SMAP_CIDR_SRAMSIZ(value)    (SMAP_CIDR_SRAMSIZ_Msk & ((value) << SMAP_CIDR_SRAMSIZ_Pos))
+#define SMAP_CIDR_ARCH_Pos          21           /**< \brief (SMAP_CIDR) Architecture Identifier */
+#define SMAP_CIDR_ARCH_Msk          (_U(0x7F) << SMAP_CIDR_ARCH_Pos)
+#define SMAP_CIDR_ARCH(value)       (SMAP_CIDR_ARCH_Msk & ((value) << SMAP_CIDR_ARCH_Pos))
+#define SMAP_CIDR_NVPTYP_Pos        28           /**< \brief (SMAP_CIDR) Nonvolatile Program Memory Type */
+#define SMAP_CIDR_NVPTYP_Msk        (_U(0x7) << SMAP_CIDR_NVPTYP_Pos)
+#define SMAP_CIDR_NVPTYP(value)     (SMAP_CIDR_NVPTYP_Msk & ((value) << SMAP_CIDR_NVPTYP_Pos))
+#define SMAP_CIDR_EXT_Pos           31           /**< \brief (SMAP_CIDR) Extension Flag */
+#define SMAP_CIDR_EXT               (_U(0x1) << SMAP_CIDR_EXT_Pos)
+#define SMAP_CIDR_MASK              _U(0xFFFFFFFF) /**< \brief (SMAP_CIDR) MASK Register */
+
+/* -------- SMAP_EXID : (SMAP Offset: 0xF4) (R/  32) Chip ID Extension Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EXID:32;          /*!< bit:  0..31  Chip ID Extension                  */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SMAP_EXID_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMAP_EXID_OFFSET            0xF4         /**< \brief (SMAP_EXID offset) Chip ID Extension Register */
+
+#define SMAP_EXID_EXID_Pos          0            /**< \brief (SMAP_EXID) Chip ID Extension */
+#define SMAP_EXID_EXID_Msk          (_U(0xFFFFFFFF) << SMAP_EXID_EXID_Pos)
+#define SMAP_EXID_EXID(value)       (SMAP_EXID_EXID_Msk & ((value) << SMAP_EXID_EXID_Pos))
+#define SMAP_EXID_MASK              _U(0xFFFFFFFF) /**< \brief (SMAP_EXID) MASK Register */
+
+/* -------- SMAP_IDR : (SMAP Offset: 0xFC) (R/  32) AP Identification register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t APIDV:4;          /*!< bit:  0.. 3  AP Identification Variant          */
+    uint32_t APID:4;           /*!< bit:  4.. 7  AP Identification                  */
+    uint32_t :8;               /*!< bit:  8..15  Reserved                           */
+    uint32_t CLSS:1;           /*!< bit:     16  Class                              */
+    uint32_t IC:7;             /*!< bit: 17..23  JEP-106 Identity Code              */
+    uint32_t CC:4;             /*!< bit: 24..27  JEP-106 Continuation Code          */
+    uint32_t REVISION:4;       /*!< bit: 28..31  Revision                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SMAP_IDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SMAP_IDR_OFFSET             0xFC         /**< \brief (SMAP_IDR offset) AP Identification register */
+#define SMAP_IDR_RESETVALUE         _U(0x003E0000); /**< \brief (SMAP_IDR reset_value) AP Identification register */
+
+#define SMAP_IDR_APIDV_Pos          0            /**< \brief (SMAP_IDR) AP Identification Variant */
+#define SMAP_IDR_APIDV_Msk          (_U(0xF) << SMAP_IDR_APIDV_Pos)
+#define SMAP_IDR_APIDV(value)       (SMAP_IDR_APIDV_Msk & ((value) << SMAP_IDR_APIDV_Pos))
+#define SMAP_IDR_APID_Pos           4            /**< \brief (SMAP_IDR) AP Identification */
+#define SMAP_IDR_APID_Msk           (_U(0xF) << SMAP_IDR_APID_Pos)
+#define SMAP_IDR_APID(value)        (SMAP_IDR_APID_Msk & ((value) << SMAP_IDR_APID_Pos))
+#define SMAP_IDR_CLSS_Pos           16           /**< \brief (SMAP_IDR) Class */
+#define SMAP_IDR_CLSS               (_U(0x1) << SMAP_IDR_CLSS_Pos)
+#define SMAP_IDR_IC_Pos             17           /**< \brief (SMAP_IDR) JEP-106 Identity Code */
+#define SMAP_IDR_IC_Msk             (_U(0x7F) << SMAP_IDR_IC_Pos)
+#define SMAP_IDR_IC(value)          (SMAP_IDR_IC_Msk & ((value) << SMAP_IDR_IC_Pos))
+#define SMAP_IDR_CC_Pos             24           /**< \brief (SMAP_IDR) JEP-106 Continuation Code */
+#define SMAP_IDR_CC_Msk             (_U(0xF) << SMAP_IDR_CC_Pos)
+#define SMAP_IDR_CC(value)          (SMAP_IDR_CC_Msk & ((value) << SMAP_IDR_CC_Pos))
+#define SMAP_IDR_REVISION_Pos       28           /**< \brief (SMAP_IDR) Revision */
+#define SMAP_IDR_REVISION_Msk       (_U(0xF) << SMAP_IDR_REVISION_Pos)
+#define SMAP_IDR_REVISION(value)    (SMAP_IDR_REVISION_Msk & ((value) << SMAP_IDR_REVISION_Pos))
+#define SMAP_IDR_MASK               _U(0xFFFF00FF) /**< \brief (SMAP_IDR) MASK Register */
+
+/** \brief SMAP hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __O  SMAP_CR_Type              CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
+  __I  SMAP_SR_Type              SR;          /**< \brief Offset: 0x04 (R/  32) Status Register */
+  __O  SMAP_SCR_Type             SCR;         /**< \brief Offset: 0x08 ( /W 32) Status Clear Register */
+  __IO SMAP_ADDR_Type            ADDR;        /**< \brief Offset: 0x0C (R/W 32) Address Register */
+  __IO SMAP_LENGTH_Type          LENGTH;      /**< \brief Offset: 0x10 (R/W 32) Length Register */
+  __IO SMAP_DATA_Type            DATA;        /**< \brief Offset: 0x14 (R/W 32) Data Register */
+       RoReg8                    Reserved1[0x10];
+  __I  SMAP_VERSION_Type         VERSION;     /**< \brief Offset: 0x28 (R/  32) VERSION register */
+       RoReg8                    Reserved2[0xC4];
+  __I  SMAP_CIDR_Type            CIDR;        /**< \brief Offset: 0xF0 (R/  32) Chip ID Register */
+  __I  SMAP_EXID_Type            EXID;        /**< \brief Offset: 0xF4 (R/  32) Chip ID Extension Register */
+       RoReg8                    Reserved3[0x4];
+  __I  SMAP_IDR_Type             IDR;         /**< \brief Offset: 0xFC (R/  32) AP Identification register */
+ } bf;
+ struct {
+  WoReg   SMAP_CR;            /**< \brief (SMAP Offset: 0x00) Control Register */
+  RoReg   SMAP_SR;            /**< \brief (SMAP Offset: 0x04) Status Register */
+  WoReg   SMAP_SCR;           /**< \brief (SMAP Offset: 0x08) Status Clear Register */
+  RwReg   SMAP_ADDR;          /**< \brief (SMAP Offset: 0x0C) Address Register */
+  RwReg   SMAP_LENGTH;        /**< \brief (SMAP Offset: 0x10) Length Register */
+  RwReg   SMAP_DATA;          /**< \brief (SMAP Offset: 0x14) Data Register */
+  RoReg8  Reserved4[0x10];
+  RoReg   SMAP_VERSION;       /**< \brief (SMAP Offset: 0x28) VERSION register */
+  RoReg8  Reserved5[0xC4];
+  RoReg   SMAP_CIDR;          /**< \brief (SMAP Offset: 0xF0) Chip ID Register */
+  RoReg   SMAP_EXID;          /**< \brief (SMAP Offset: 0xF4) Chip ID Extension Register */
+  RoReg8  Reserved6[0x4];
+  RoReg   SMAP_IDR;           /**< \brief (SMAP Offset: 0xFC) AP Identification register */
+ } reg;
+} Smap;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_SMAP_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/smap.h
+++ b/asf/sam/include/sam4l/component/smap.h
@@ -54,19 +54,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SMAP_CR_OFFSET              0x00         /**< \brief (SMAP_CR offset) Control Register */
-#define SMAP_CR_RESETVALUE          _U(0x00000000); /**< \brief (SMAP_CR reset_value) Control Register */
+#define SMAP_CR_RESETVALUE          _U_(0x00000000); /**< \brief (SMAP_CR reset_value) Control Register */
 
 #define SMAP_CR_EN_Pos              0            /**< \brief (SMAP_CR) Enable */
-#define SMAP_CR_EN                  (_U(0x1) << SMAP_CR_EN_Pos)
+#define SMAP_CR_EN                  (_U_(0x1) << SMAP_CR_EN_Pos)
 #define SMAP_CR_DIS_Pos             1            /**< \brief (SMAP_CR) Disable */
-#define SMAP_CR_DIS                 (_U(0x1) << SMAP_CR_DIS_Pos)
+#define SMAP_CR_DIS                 (_U_(0x1) << SMAP_CR_DIS_Pos)
 #define SMAP_CR_CRC_Pos             2            /**< \brief (SMAP_CR) User Page Read */
-#define SMAP_CR_CRC                 (_U(0x1) << SMAP_CR_CRC_Pos)
+#define SMAP_CR_CRC                 (_U_(0x1) << SMAP_CR_CRC_Pos)
 #define SMAP_CR_FSPR_Pos            3            /**< \brief (SMAP_CR) Flash Supplementary Page Read */
-#define SMAP_CR_FSPR                (_U(0x1) << SMAP_CR_FSPR_Pos)
+#define SMAP_CR_FSPR                (_U_(0x1) << SMAP_CR_FSPR_Pos)
 #define SMAP_CR_CE_Pos              4            /**< \brief (SMAP_CR) Chip Erase */
-#define SMAP_CR_CE                  (_U(0x1) << SMAP_CR_CE_Pos)
-#define SMAP_CR_MASK                _U(0x0000001F) /**< \brief (SMAP_CR) MASK Register */
+#define SMAP_CR_CE                  (_U_(0x1) << SMAP_CR_CE_Pos)
+#define SMAP_CR_MASK                _U_(0x0000001F) /**< \brief (SMAP_CR) MASK Register */
 
 /* -------- SMAP_SR : (SMAP Offset: 0x04) (R/  32) Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -90,28 +90,28 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SMAP_SR_OFFSET              0x04         /**< \brief (SMAP_SR offset) Status Register */
-#define SMAP_SR_RESETVALUE          _U(0x00000000); /**< \brief (SMAP_SR reset_value) Status Register */
+#define SMAP_SR_RESETVALUE          _U_(0x00000000); /**< \brief (SMAP_SR reset_value) Status Register */
 
 #define SMAP_SR_DONE_Pos            0            /**< \brief (SMAP_SR) Operation done */
-#define SMAP_SR_DONE                (_U(0x1) << SMAP_SR_DONE_Pos)
+#define SMAP_SR_DONE                (_U_(0x1) << SMAP_SR_DONE_Pos)
 #define SMAP_SR_HCR_Pos             1            /**< \brief (SMAP_SR) Hold Core reset */
-#define SMAP_SR_HCR                 (_U(0x1) << SMAP_SR_HCR_Pos)
+#define SMAP_SR_HCR                 (_U_(0x1) << SMAP_SR_HCR_Pos)
 #define SMAP_SR_BERR_Pos            2            /**< \brief (SMAP_SR) Bus error */
-#define SMAP_SR_BERR                (_U(0x1) << SMAP_SR_BERR_Pos)
+#define SMAP_SR_BERR                (_U_(0x1) << SMAP_SR_BERR_Pos)
 #define SMAP_SR_FAIL_Pos            3            /**< \brief (SMAP_SR) Failure */
-#define SMAP_SR_FAIL                (_U(0x1) << SMAP_SR_FAIL_Pos)
+#define SMAP_SR_FAIL                (_U_(0x1) << SMAP_SR_FAIL_Pos)
 #define SMAP_SR_LCK_Pos             4            /**< \brief (SMAP_SR) Lock */
-#define SMAP_SR_LCK                 (_U(0x1) << SMAP_SR_LCK_Pos)
+#define SMAP_SR_LCK                 (_U_(0x1) << SMAP_SR_LCK_Pos)
 #define SMAP_SR_EN_Pos              8            /**< \brief (SMAP_SR) Enabled */
-#define SMAP_SR_EN                  (_U(0x1) << SMAP_SR_EN_Pos)
+#define SMAP_SR_EN                  (_U_(0x1) << SMAP_SR_EN_Pos)
 #define SMAP_SR_PROT_Pos            9            /**< \brief (SMAP_SR) Protected */
-#define SMAP_SR_PROT                (_U(0x1) << SMAP_SR_PROT_Pos)
+#define SMAP_SR_PROT                (_U_(0x1) << SMAP_SR_PROT_Pos)
 #define SMAP_SR_DBGP_Pos            10           /**< \brief (SMAP_SR) Debugger Present */
-#define SMAP_SR_DBGP                (_U(0x1) << SMAP_SR_DBGP_Pos)
+#define SMAP_SR_DBGP                (_U_(0x1) << SMAP_SR_DBGP_Pos)
 #define SMAP_SR_STATE_Pos           24           /**< \brief (SMAP_SR) State */
-#define SMAP_SR_STATE_Msk           (_U(0x7) << SMAP_SR_STATE_Pos)
+#define SMAP_SR_STATE_Msk           (_U_(0x7) << SMAP_SR_STATE_Pos)
 #define SMAP_SR_STATE(value)        (SMAP_SR_STATE_Msk & ((value) << SMAP_SR_STATE_Pos))
-#define SMAP_SR_MASK                _U(0x0700071F) /**< \brief (SMAP_SR) MASK Register */
+#define SMAP_SR_MASK                _U_(0x0700071F) /**< \brief (SMAP_SR) MASK Register */
 
 /* -------- SMAP_SCR : (SMAP Offset: 0x08) ( /W 32) Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -129,19 +129,19 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SMAP_SCR_OFFSET             0x08         /**< \brief (SMAP_SCR offset) Status Clear Register */
-#define SMAP_SCR_RESETVALUE         _U(0x00000000); /**< \brief (SMAP_SCR reset_value) Status Clear Register */
+#define SMAP_SCR_RESETVALUE         _U_(0x00000000); /**< \brief (SMAP_SCR reset_value) Status Clear Register */
 
 #define SMAP_SCR_DONE_Pos           0            /**< \brief (SMAP_SCR) Done */
-#define SMAP_SCR_DONE               (_U(0x1) << SMAP_SCR_DONE_Pos)
+#define SMAP_SCR_DONE               (_U_(0x1) << SMAP_SCR_DONE_Pos)
 #define SMAP_SCR_HCR_Pos            1            /**< \brief (SMAP_SCR) Hold Core Register */
-#define SMAP_SCR_HCR                (_U(0x1) << SMAP_SCR_HCR_Pos)
+#define SMAP_SCR_HCR                (_U_(0x1) << SMAP_SCR_HCR_Pos)
 #define SMAP_SCR_BERR_Pos           2            /**< \brief (SMAP_SCR) Bus error */
-#define SMAP_SCR_BERR               (_U(0x1) << SMAP_SCR_BERR_Pos)
+#define SMAP_SCR_BERR               (_U_(0x1) << SMAP_SCR_BERR_Pos)
 #define SMAP_SCR_FAIL_Pos           3            /**< \brief (SMAP_SCR) Failure */
-#define SMAP_SCR_FAIL               (_U(0x1) << SMAP_SCR_FAIL_Pos)
+#define SMAP_SCR_FAIL               (_U_(0x1) << SMAP_SCR_FAIL_Pos)
 #define SMAP_SCR_LCK_Pos            4            /**< \brief (SMAP_SCR) Lock error */
-#define SMAP_SCR_LCK                (_U(0x1) << SMAP_SCR_LCK_Pos)
-#define SMAP_SCR_MASK               _U(0x0000001F) /**< \brief (SMAP_SCR) MASK Register */
+#define SMAP_SCR_LCK                (_U_(0x1) << SMAP_SCR_LCK_Pos)
+#define SMAP_SCR_MASK               _U_(0x0000001F) /**< \brief (SMAP_SCR) MASK Register */
 
 /* -------- SMAP_ADDR : (SMAP Offset: 0x0C) (R/W 32) Address Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -155,12 +155,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SMAP_ADDR_OFFSET            0x0C         /**< \brief (SMAP_ADDR offset) Address Register */
-#define SMAP_ADDR_RESETVALUE        _U(0x00000000); /**< \brief (SMAP_ADDR reset_value) Address Register */
+#define SMAP_ADDR_RESETVALUE        _U_(0x00000000); /**< \brief (SMAP_ADDR reset_value) Address Register */
 
 #define SMAP_ADDR_ADDR_Pos          2            /**< \brief (SMAP_ADDR) Address Value */
-#define SMAP_ADDR_ADDR_Msk          (_U(0x3FFFFFFF) << SMAP_ADDR_ADDR_Pos)
+#define SMAP_ADDR_ADDR_Msk          (_U_(0x3FFFFFFF) << SMAP_ADDR_ADDR_Pos)
 #define SMAP_ADDR_ADDR(value)       (SMAP_ADDR_ADDR_Msk & ((value) << SMAP_ADDR_ADDR_Pos))
-#define SMAP_ADDR_MASK              _U(0xFFFFFFFC) /**< \brief (SMAP_ADDR) MASK Register */
+#define SMAP_ADDR_MASK              _U_(0xFFFFFFFC) /**< \brief (SMAP_ADDR) MASK Register */
 
 /* -------- SMAP_LENGTH : (SMAP Offset: 0x10) (R/W 32) Length Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -174,12 +174,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SMAP_LENGTH_OFFSET          0x10         /**< \brief (SMAP_LENGTH offset) Length Register */
-#define SMAP_LENGTH_RESETVALUE      _U(0x00000000); /**< \brief (SMAP_LENGTH reset_value) Length Register */
+#define SMAP_LENGTH_RESETVALUE      _U_(0x00000000); /**< \brief (SMAP_LENGTH reset_value) Length Register */
 
 #define SMAP_LENGTH_LENGTH_Pos      2            /**< \brief (SMAP_LENGTH) Length Register */
-#define SMAP_LENGTH_LENGTH_Msk      (_U(0x3FFFFFFF) << SMAP_LENGTH_LENGTH_Pos)
+#define SMAP_LENGTH_LENGTH_Msk      (_U_(0x3FFFFFFF) << SMAP_LENGTH_LENGTH_Pos)
 #define SMAP_LENGTH_LENGTH(value)   (SMAP_LENGTH_LENGTH_Msk & ((value) << SMAP_LENGTH_LENGTH_Pos))
-#define SMAP_LENGTH_MASK            _U(0xFFFFFFFC) /**< \brief (SMAP_LENGTH) MASK Register */
+#define SMAP_LENGTH_MASK            _U_(0xFFFFFFFC) /**< \brief (SMAP_LENGTH) MASK Register */
 
 /* -------- SMAP_DATA : (SMAP Offset: 0x14) (R/W 32) Data Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -192,12 +192,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SMAP_DATA_OFFSET            0x14         /**< \brief (SMAP_DATA offset) Data Register */
-#define SMAP_DATA_RESETVALUE        _U(0x00000000); /**< \brief (SMAP_DATA reset_value) Data Register */
+#define SMAP_DATA_RESETVALUE        _U_(0x00000000); /**< \brief (SMAP_DATA reset_value) Data Register */
 
 #define SMAP_DATA_DATA_Pos          0            /**< \brief (SMAP_DATA) Generic data register */
-#define SMAP_DATA_DATA_Msk          (_U(0xFFFFFFFF) << SMAP_DATA_DATA_Pos)
+#define SMAP_DATA_DATA_Msk          (_U_(0xFFFFFFFF) << SMAP_DATA_DATA_Pos)
 #define SMAP_DATA_DATA(value)       (SMAP_DATA_DATA_Msk & ((value) << SMAP_DATA_DATA_Pos))
-#define SMAP_DATA_MASK              _U(0xFFFFFFFF) /**< \brief (SMAP_DATA) MASK Register */
+#define SMAP_DATA_MASK              _U_(0xFFFFFFFF) /**< \brief (SMAP_DATA) MASK Register */
 
 /* -------- SMAP_VERSION : (SMAP Offset: 0x28) (R/  32) VERSION register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -213,15 +213,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SMAP_VERSION_OFFSET         0x28         /**< \brief (SMAP_VERSION offset) VERSION register */
-#define SMAP_VERSION_RESETVALUE     _U(0x00000100); /**< \brief (SMAP_VERSION reset_value) VERSION register */
+#define SMAP_VERSION_RESETVALUE     _U_(0x00000100); /**< \brief (SMAP_VERSION reset_value) VERSION register */
 
 #define SMAP_VERSION_VERSION_Pos    0            /**< \brief (SMAP_VERSION) Version number */
-#define SMAP_VERSION_VERSION_Msk    (_U(0xFFF) << SMAP_VERSION_VERSION_Pos)
+#define SMAP_VERSION_VERSION_Msk    (_U_(0xFFF) << SMAP_VERSION_VERSION_Pos)
 #define SMAP_VERSION_VERSION(value) (SMAP_VERSION_VERSION_Msk & ((value) << SMAP_VERSION_VERSION_Pos))
 #define SMAP_VERSION_VARIANT_Pos    16           /**< \brief (SMAP_VERSION) Variant number */
-#define SMAP_VERSION_VARIANT_Msk    (_U(0xF) << SMAP_VERSION_VARIANT_Pos)
+#define SMAP_VERSION_VARIANT_Msk    (_U_(0xF) << SMAP_VERSION_VARIANT_Pos)
 #define SMAP_VERSION_VARIANT(value) (SMAP_VERSION_VARIANT_Msk & ((value) << SMAP_VERSION_VARIANT_Pos))
-#define SMAP_VERSION_MASK           _U(0x000F0FFF) /**< \brief (SMAP_VERSION) MASK Register */
+#define SMAP_VERSION_MASK           _U_(0x000F0FFF) /**< \brief (SMAP_VERSION) MASK Register */
 
 /* -------- SMAP_CIDR : (SMAP Offset: 0xF0) (R/  32) Chip ID Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -243,29 +243,29 @@ typedef union {
 #define SMAP_CIDR_OFFSET            0xF0         /**< \brief (SMAP_CIDR offset) Chip ID Register */
 
 #define SMAP_CIDR_VERSION_Pos       0            /**< \brief (SMAP_CIDR) Version of the Device */
-#define SMAP_CIDR_VERSION_Msk       (_U(0x1F) << SMAP_CIDR_VERSION_Pos)
+#define SMAP_CIDR_VERSION_Msk       (_U_(0x1F) << SMAP_CIDR_VERSION_Pos)
 #define SMAP_CIDR_VERSION(value)    (SMAP_CIDR_VERSION_Msk & ((value) << SMAP_CIDR_VERSION_Pos))
 #define SMAP_CIDR_EPROC_Pos         5            /**< \brief (SMAP_CIDR) Embedded Processor */
-#define SMAP_CIDR_EPROC_Msk         (_U(0x7) << SMAP_CIDR_EPROC_Pos)
+#define SMAP_CIDR_EPROC_Msk         (_U_(0x7) << SMAP_CIDR_EPROC_Pos)
 #define SMAP_CIDR_EPROC(value)      (SMAP_CIDR_EPROC_Msk & ((value) << SMAP_CIDR_EPROC_Pos))
 #define SMAP_CIDR_NVPSIZ_Pos        8            /**< \brief (SMAP_CIDR) Nonvolatile Program Memory Size */
-#define SMAP_CIDR_NVPSIZ_Msk        (_U(0xF) << SMAP_CIDR_NVPSIZ_Pos)
+#define SMAP_CIDR_NVPSIZ_Msk        (_U_(0xF) << SMAP_CIDR_NVPSIZ_Pos)
 #define SMAP_CIDR_NVPSIZ(value)     (SMAP_CIDR_NVPSIZ_Msk & ((value) << SMAP_CIDR_NVPSIZ_Pos))
 #define SMAP_CIDR_NVPSIZ2_Pos       12           /**< \brief (SMAP_CIDR) Second Nonvolatile Program Memory Size */
-#define SMAP_CIDR_NVPSIZ2_Msk       (_U(0xF) << SMAP_CIDR_NVPSIZ2_Pos)
+#define SMAP_CIDR_NVPSIZ2_Msk       (_U_(0xF) << SMAP_CIDR_NVPSIZ2_Pos)
 #define SMAP_CIDR_NVPSIZ2(value)    (SMAP_CIDR_NVPSIZ2_Msk & ((value) << SMAP_CIDR_NVPSIZ2_Pos))
 #define SMAP_CIDR_SRAMSIZ_Pos       16           /**< \brief (SMAP_CIDR) Internal SRAM Size */
-#define SMAP_CIDR_SRAMSIZ_Msk       (_U(0x1F) << SMAP_CIDR_SRAMSIZ_Pos)
+#define SMAP_CIDR_SRAMSIZ_Msk       (_U_(0x1F) << SMAP_CIDR_SRAMSIZ_Pos)
 #define SMAP_CIDR_SRAMSIZ(value)    (SMAP_CIDR_SRAMSIZ_Msk & ((value) << SMAP_CIDR_SRAMSIZ_Pos))
 #define SMAP_CIDR_ARCH_Pos          21           /**< \brief (SMAP_CIDR) Architecture Identifier */
-#define SMAP_CIDR_ARCH_Msk          (_U(0x7F) << SMAP_CIDR_ARCH_Pos)
+#define SMAP_CIDR_ARCH_Msk          (_U_(0x7F) << SMAP_CIDR_ARCH_Pos)
 #define SMAP_CIDR_ARCH(value)       (SMAP_CIDR_ARCH_Msk & ((value) << SMAP_CIDR_ARCH_Pos))
 #define SMAP_CIDR_NVPTYP_Pos        28           /**< \brief (SMAP_CIDR) Nonvolatile Program Memory Type */
-#define SMAP_CIDR_NVPTYP_Msk        (_U(0x7) << SMAP_CIDR_NVPTYP_Pos)
+#define SMAP_CIDR_NVPTYP_Msk        (_U_(0x7) << SMAP_CIDR_NVPTYP_Pos)
 #define SMAP_CIDR_NVPTYP(value)     (SMAP_CIDR_NVPTYP_Msk & ((value) << SMAP_CIDR_NVPTYP_Pos))
 #define SMAP_CIDR_EXT_Pos           31           /**< \brief (SMAP_CIDR) Extension Flag */
-#define SMAP_CIDR_EXT               (_U(0x1) << SMAP_CIDR_EXT_Pos)
-#define SMAP_CIDR_MASK              _U(0xFFFFFFFF) /**< \brief (SMAP_CIDR) MASK Register */
+#define SMAP_CIDR_EXT               (_U_(0x1) << SMAP_CIDR_EXT_Pos)
+#define SMAP_CIDR_MASK              _U_(0xFFFFFFFF) /**< \brief (SMAP_CIDR) MASK Register */
 
 /* -------- SMAP_EXID : (SMAP Offset: 0xF4) (R/  32) Chip ID Extension Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -280,9 +280,9 @@ typedef union {
 #define SMAP_EXID_OFFSET            0xF4         /**< \brief (SMAP_EXID offset) Chip ID Extension Register */
 
 #define SMAP_EXID_EXID_Pos          0            /**< \brief (SMAP_EXID) Chip ID Extension */
-#define SMAP_EXID_EXID_Msk          (_U(0xFFFFFFFF) << SMAP_EXID_EXID_Pos)
+#define SMAP_EXID_EXID_Msk          (_U_(0xFFFFFFFF) << SMAP_EXID_EXID_Pos)
 #define SMAP_EXID_EXID(value)       (SMAP_EXID_EXID_Msk & ((value) << SMAP_EXID_EXID_Pos))
-#define SMAP_EXID_MASK              _U(0xFFFFFFFF) /**< \brief (SMAP_EXID) MASK Register */
+#define SMAP_EXID_MASK              _U_(0xFFFFFFFF) /**< \brief (SMAP_EXID) MASK Register */
 
 /* -------- SMAP_IDR : (SMAP Offset: 0xFC) (R/  32) AP Identification register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -301,26 +301,26 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SMAP_IDR_OFFSET             0xFC         /**< \brief (SMAP_IDR offset) AP Identification register */
-#define SMAP_IDR_RESETVALUE         _U(0x003E0000); /**< \brief (SMAP_IDR reset_value) AP Identification register */
+#define SMAP_IDR_RESETVALUE         _U_(0x003E0000); /**< \brief (SMAP_IDR reset_value) AP Identification register */
 
 #define SMAP_IDR_APIDV_Pos          0            /**< \brief (SMAP_IDR) AP Identification Variant */
-#define SMAP_IDR_APIDV_Msk          (_U(0xF) << SMAP_IDR_APIDV_Pos)
+#define SMAP_IDR_APIDV_Msk          (_U_(0xF) << SMAP_IDR_APIDV_Pos)
 #define SMAP_IDR_APIDV(value)       (SMAP_IDR_APIDV_Msk & ((value) << SMAP_IDR_APIDV_Pos))
 #define SMAP_IDR_APID_Pos           4            /**< \brief (SMAP_IDR) AP Identification */
-#define SMAP_IDR_APID_Msk           (_U(0xF) << SMAP_IDR_APID_Pos)
+#define SMAP_IDR_APID_Msk           (_U_(0xF) << SMAP_IDR_APID_Pos)
 #define SMAP_IDR_APID(value)        (SMAP_IDR_APID_Msk & ((value) << SMAP_IDR_APID_Pos))
 #define SMAP_IDR_CLSS_Pos           16           /**< \brief (SMAP_IDR) Class */
-#define SMAP_IDR_CLSS               (_U(0x1) << SMAP_IDR_CLSS_Pos)
+#define SMAP_IDR_CLSS               (_U_(0x1) << SMAP_IDR_CLSS_Pos)
 #define SMAP_IDR_IC_Pos             17           /**< \brief (SMAP_IDR) JEP-106 Identity Code */
-#define SMAP_IDR_IC_Msk             (_U(0x7F) << SMAP_IDR_IC_Pos)
+#define SMAP_IDR_IC_Msk             (_U_(0x7F) << SMAP_IDR_IC_Pos)
 #define SMAP_IDR_IC(value)          (SMAP_IDR_IC_Msk & ((value) << SMAP_IDR_IC_Pos))
 #define SMAP_IDR_CC_Pos             24           /**< \brief (SMAP_IDR) JEP-106 Continuation Code */
-#define SMAP_IDR_CC_Msk             (_U(0xF) << SMAP_IDR_CC_Pos)
+#define SMAP_IDR_CC_Msk             (_U_(0xF) << SMAP_IDR_CC_Pos)
 #define SMAP_IDR_CC(value)          (SMAP_IDR_CC_Msk & ((value) << SMAP_IDR_CC_Pos))
 #define SMAP_IDR_REVISION_Pos       28           /**< \brief (SMAP_IDR) Revision */
-#define SMAP_IDR_REVISION_Msk       (_U(0xF) << SMAP_IDR_REVISION_Pos)
+#define SMAP_IDR_REVISION_Msk       (_U_(0xF) << SMAP_IDR_REVISION_Pos)
 #define SMAP_IDR_REVISION(value)    (SMAP_IDR_REVISION_Msk & ((value) << SMAP_IDR_REVISION_Pos))
-#define SMAP_IDR_MASK               _U(0xFFFF00FF) /**< \brief (SMAP_IDR) MASK Register */
+#define SMAP_IDR_MASK               _U_(0xFFFF00FF) /**< \brief (SMAP_IDR) MASK Register */
 
 /** \brief SMAP hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/spi.h
+++ b/asf/sam/include/sam4l/component/spi.h
@@ -1,0 +1,815 @@
+/**
+ * \file
+ *
+ * \brief Component description for SPI
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_SPI_COMPONENT_
+#define _SAM4L_SPI_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR SPI */
+/* ========================================================================== */
+/** \addtogroup SAM4L_SPI Serial Peripheral Interface */
+/*@{*/
+
+#define SPI_I7602
+#define REV_SPI                     0x211
+
+/* -------- SPI_CR : (SPI Offset: 0x00) ( /W 32) Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SPIEN:1;          /*!< bit:      0  SPI Enable                         */
+    uint32_t SPIDIS:1;         /*!< bit:      1  SPI Disable                        */
+    uint32_t :5;               /*!< bit:  2.. 6  Reserved                           */
+    uint32_t SWRST:1;          /*!< bit:      7  SPI Software Reset                 */
+    uint32_t FLUSHFIFO:1;      /*!< bit:      8  Flush FIFO command                 */
+    uint32_t :15;              /*!< bit:  9..23  Reserved                           */
+    uint32_t LASTXFER:1;       /*!< bit:     24  Last Transfer                      */
+    uint32_t :7;               /*!< bit: 25..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SPI_CR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_CR_OFFSET               0x00         /**< \brief (SPI_CR offset) Control Register */
+#define SPI_CR_RESETVALUE           _U(0x00000000); /**< \brief (SPI_CR reset_value) Control Register */
+
+#define SPI_CR_SPIEN_Pos            0            /**< \brief (SPI_CR) SPI Enable */
+#define SPI_CR_SPIEN                (_U(0x1) << SPI_CR_SPIEN_Pos)
+#define   SPI_CR_SPIEN_0_Val              _U(0x0)   /**< \brief (SPI_CR) No effect. */
+#define   SPI_CR_SPIEN_1_Val              _U(0x1)   /**< \brief (SPI_CR) Enables the SPI to transfer and receive data. */
+#define SPI_CR_SPIEN_0              (SPI_CR_SPIEN_0_Val            << SPI_CR_SPIEN_Pos)
+#define SPI_CR_SPIEN_1              (SPI_CR_SPIEN_1_Val            << SPI_CR_SPIEN_Pos)
+#define SPI_CR_SPIDIS_Pos           1            /**< \brief (SPI_CR) SPI Disable */
+#define SPI_CR_SPIDIS               (_U(0x1) << SPI_CR_SPIDIS_Pos)
+#define   SPI_CR_SPIDIS_0_Val             _U(0x0)   /**< \brief (SPI_CR) No effect. */
+#define   SPI_CR_SPIDIS_1_Val             _U(0x1)   /**< \brief (SPI_CR) Disables the SPI.All pins are set in input mode and no data is received or transmitted.If a transfer is in progress, the transfer is finished before the SPI is disabled.If both SPIEN and SPIDIS are equal to one when the control register is written, the SPI is disabled. */
+#define SPI_CR_SPIDIS_0             (SPI_CR_SPIDIS_0_Val           << SPI_CR_SPIDIS_Pos)
+#define SPI_CR_SPIDIS_1             (SPI_CR_SPIDIS_1_Val           << SPI_CR_SPIDIS_Pos)
+#define SPI_CR_SWRST_Pos            7            /**< \brief (SPI_CR) SPI Software Reset */
+#define SPI_CR_SWRST                (_U(0x1) << SPI_CR_SWRST_Pos)
+#define   SPI_CR_SWRST_0_Val              _U(0x0)   /**< \brief (SPI_CR) No effect. */
+#define   SPI_CR_SWRST_1_Val              _U(0x1)   /**< \brief (SPI_CR) Reset the SPI. A software-triggered hardware reset of the SPI interface is performed. */
+#define SPI_CR_SWRST_0              (SPI_CR_SWRST_0_Val            << SPI_CR_SWRST_Pos)
+#define SPI_CR_SWRST_1              (SPI_CR_SWRST_1_Val            << SPI_CR_SWRST_Pos)
+#define SPI_CR_FLUSHFIFO_Pos        8            /**< \brief (SPI_CR) Flush FIFO command */
+#define SPI_CR_FLUSHFIFO            (_U(0x1) << SPI_CR_FLUSHFIFO_Pos)
+#define SPI_CR_LASTXFER_Pos         24           /**< \brief (SPI_CR) Last Transfer */
+#define SPI_CR_LASTXFER             (_U(0x1) << SPI_CR_LASTXFER_Pos)
+#define   SPI_CR_LASTXFER_0_Val           _U(0x0)   /**< \brief (SPI_CR) No effect. */
+#define   SPI_CR_LASTXFER_1_Val           _U(0x1)   /**< \brief (SPI_CR) The current NPCS will be deasserted after the character written in TD has been transferred. When CSAAT is set, thisallows to close the communication with the current serial peripheral by raising the corresponding NPCS line as soon as TDtransfer has completed. */
+#define SPI_CR_LASTXFER_0           (SPI_CR_LASTXFER_0_Val         << SPI_CR_LASTXFER_Pos)
+#define SPI_CR_LASTXFER_1           (SPI_CR_LASTXFER_1_Val         << SPI_CR_LASTXFER_Pos)
+#define SPI_CR_MASK                 _U(0x01000183) /**< \brief (SPI_CR) MASK Register */
+
+/* -------- SPI_MR : (SPI Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t MSTR:1;           /*!< bit:      0  Master/Slave Mode                  */
+    uint32_t PS:1;             /*!< bit:      1  Peripheral Select                  */
+    uint32_t PCSDEC:1;         /*!< bit:      2  Chip Select Decode                 */
+    uint32_t :1;               /*!< bit:      3  Reserved                           */
+    uint32_t MODFDIS:1;        /*!< bit:      4  Mode Fault Detection               */
+    uint32_t WDRBT:1;          /*!< bit:      5  wait data read before transfer     */
+    uint32_t RXFIFOEN:1;       /*!< bit:      6  FIFO in Reception Enable           */
+    uint32_t LLB:1;            /*!< bit:      7  Local Loopback Enable              */
+    uint32_t :8;               /*!< bit:  8..15  Reserved                           */
+    uint32_t PCS:4;            /*!< bit: 16..19  Peripheral Chip Select             */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t DLYBCS:8;         /*!< bit: 24..31  Delay Between Chip Selects         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SPI_MR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_MR_OFFSET               0x04         /**< \brief (SPI_MR offset) Mode Register */
+#define SPI_MR_RESETVALUE           _U(0x00000000); /**< \brief (SPI_MR reset_value) Mode Register */
+
+#define SPI_MR_MSTR_Pos             0            /**< \brief (SPI_MR) Master/Slave Mode */
+#define SPI_MR_MSTR                 (_U(0x1) << SPI_MR_MSTR_Pos)
+#define   SPI_MR_MSTR_0_Val               _U(0x0)   /**< \brief (SPI_MR) SPI is in Slave mode. */
+#define   SPI_MR_MSTR_1_Val               _U(0x1)   /**< \brief (SPI_MR) SPI is in Master mode. */
+#define SPI_MR_MSTR_0               (SPI_MR_MSTR_0_Val             << SPI_MR_MSTR_Pos)
+#define SPI_MR_MSTR_1               (SPI_MR_MSTR_1_Val             << SPI_MR_MSTR_Pos)
+#define SPI_MR_PS_Pos               1            /**< \brief (SPI_MR) Peripheral Select */
+#define SPI_MR_PS                   (_U(0x1) << SPI_MR_PS_Pos)
+#define   SPI_MR_PS_0_Val                 _U(0x0)   /**< \brief (SPI_MR) Fixed Peripheral Select. */
+#define   SPI_MR_PS_1_Val                 _U(0x1)   /**< \brief (SPI_MR) Variable Peripheral Select. */
+#define SPI_MR_PS_0                 (SPI_MR_PS_0_Val               << SPI_MR_PS_Pos)
+#define SPI_MR_PS_1                 (SPI_MR_PS_1_Val               << SPI_MR_PS_Pos)
+#define SPI_MR_PCSDEC_Pos           2            /**< \brief (SPI_MR) Chip Select Decode */
+#define SPI_MR_PCSDEC               (_U(0x1) << SPI_MR_PCSDEC_Pos)
+#define   SPI_MR_PCSDEC_0_Val             _U(0x0)   /**< \brief (SPI_MR) The chip selects are directly connected to a peripheral device. */
+#define   SPI_MR_PCSDEC_1_Val             _U(0x1)   /**< \brief (SPI_MR) The four chip select lines are connected to a 4- to 16-bit decoder.When PCSDEC equals one, up to 15 Chip Select signals can be generated with the four lines using an external 4- to 16-bitdecoder. The Chip Select Registers define the characteristics of the 16 chip selects according to the following rules:CSR0 defines peripheral chip select signals 0 to 3.CSR1 defines peripheral chip select signals 4 to 7.CSR2 defines peripheral chip select signals 8 to 11.CSR3 defines peripheral chip select signals 12 to 15. */
+#define SPI_MR_PCSDEC_0             (SPI_MR_PCSDEC_0_Val           << SPI_MR_PCSDEC_Pos)
+#define SPI_MR_PCSDEC_1             (SPI_MR_PCSDEC_1_Val           << SPI_MR_PCSDEC_Pos)
+#define SPI_MR_MODFDIS_Pos          4            /**< \brief (SPI_MR) Mode Fault Detection */
+#define SPI_MR_MODFDIS              (_U(0x1) << SPI_MR_MODFDIS_Pos)
+#define   SPI_MR_MODFDIS_0_Val            _U(0x0)   /**< \brief (SPI_MR) Mode fault detection is enabled. */
+#define   SPI_MR_MODFDIS_1_Val            _U(0x1)   /**< \brief (SPI_MR) Mode fault detection is disabled. */
+#define SPI_MR_MODFDIS_0            (SPI_MR_MODFDIS_0_Val          << SPI_MR_MODFDIS_Pos)
+#define SPI_MR_MODFDIS_1            (SPI_MR_MODFDIS_1_Val          << SPI_MR_MODFDIS_Pos)
+#define SPI_MR_WDRBT_Pos            5            /**< \brief (SPI_MR) wait data read before transfer */
+#define SPI_MR_WDRBT                (_U(0x1) << SPI_MR_WDRBT_Pos)
+#define SPI_MR_RXFIFOEN_Pos         6            /**< \brief (SPI_MR) FIFO in Reception Enable */
+#define SPI_MR_RXFIFOEN             (_U(0x1) << SPI_MR_RXFIFOEN_Pos)
+#define SPI_MR_LLB_Pos              7            /**< \brief (SPI_MR) Local Loopback Enable */
+#define SPI_MR_LLB                  (_U(0x1) << SPI_MR_LLB_Pos)
+#define   SPI_MR_LLB_0_Val                _U(0x0)   /**< \brief (SPI_MR) Local loopback path disabled. */
+#define   SPI_MR_LLB_1_Val                _U(0x1)   /**< \brief (SPI_MR) Local loopback path enabled.LLB controls the local loopback on the data serializer for testing in Master Mode only. */
+#define SPI_MR_LLB_0                (SPI_MR_LLB_0_Val              << SPI_MR_LLB_Pos)
+#define SPI_MR_LLB_1                (SPI_MR_LLB_1_Val              << SPI_MR_LLB_Pos)
+#define SPI_MR_PCS_Pos              16           /**< \brief (SPI_MR) Peripheral Chip Select */
+#define SPI_MR_PCS_Msk              (_U(0xF) << SPI_MR_PCS_Pos)
+#define SPI_MR_PCS(value)           (SPI_MR_PCS_Msk & ((value) << SPI_MR_PCS_Pos))
+#define SPI_MR_DLYBCS_Pos           24           /**< \brief (SPI_MR) Delay Between Chip Selects */
+#define SPI_MR_DLYBCS_Msk           (_U(0xFF) << SPI_MR_DLYBCS_Pos)
+#define SPI_MR_DLYBCS(value)        (SPI_MR_DLYBCS_Msk & ((value) << SPI_MR_DLYBCS_Pos))
+#define SPI_MR_MASK                 _U(0xFF0F00F7) /**< \brief (SPI_MR) MASK Register */
+
+/* -------- SPI_RDR : (SPI Offset: 0x08) (R/  32) Receive Data Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RD:16;            /*!< bit:  0..15  Receive Data                       */
+    uint32_t PCS:4;            /*!< bit: 16..19  Peripheral Chip Select             */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SPI_RDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_RDR_OFFSET              0x08         /**< \brief (SPI_RDR offset) Receive Data Register */
+#define SPI_RDR_RESETVALUE          _U(0x00000000); /**< \brief (SPI_RDR reset_value) Receive Data Register */
+
+#define SPI_RDR_RD_Pos              0            /**< \brief (SPI_RDR) Receive Data */
+#define SPI_RDR_RD_Msk              (_U(0xFFFF) << SPI_RDR_RD_Pos)
+#define SPI_RDR_RD(value)           (SPI_RDR_RD_Msk & ((value) << SPI_RDR_RD_Pos))
+#define SPI_RDR_PCS_Pos             16           /**< \brief (SPI_RDR) Peripheral Chip Select */
+#define SPI_RDR_PCS_Msk             (_U(0xF) << SPI_RDR_PCS_Pos)
+#define SPI_RDR_PCS(value)          (SPI_RDR_PCS_Msk & ((value) << SPI_RDR_PCS_Pos))
+#define SPI_RDR_MASK                _U(0x000FFFFF) /**< \brief (SPI_RDR) MASK Register */
+
+/* -------- SPI_TDR : (SPI Offset: 0x0C) ( /W 32) Transmit Data Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TD:16;            /*!< bit:  0..15  Transmit Data                      */
+    uint32_t PCS:4;            /*!< bit: 16..19  Peripheral Chip Select             */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t LASTXFER:1;       /*!< bit:     24  Last Transfer                      */
+    uint32_t :7;               /*!< bit: 25..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SPI_TDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_TDR_OFFSET              0x0C         /**< \brief (SPI_TDR offset) Transmit Data Register */
+#define SPI_TDR_RESETVALUE          _U(0x00000000); /**< \brief (SPI_TDR reset_value) Transmit Data Register */
+
+#define SPI_TDR_TD_Pos              0            /**< \brief (SPI_TDR) Transmit Data */
+#define SPI_TDR_TD_Msk              (_U(0xFFFF) << SPI_TDR_TD_Pos)
+#define SPI_TDR_TD(value)           (SPI_TDR_TD_Msk & ((value) << SPI_TDR_TD_Pos))
+#define SPI_TDR_PCS_Pos             16           /**< \brief (SPI_TDR) Peripheral Chip Select */
+#define SPI_TDR_PCS_Msk             (_U(0xF) << SPI_TDR_PCS_Pos)
+#define SPI_TDR_PCS(value)          (SPI_TDR_PCS_Msk & ((value) << SPI_TDR_PCS_Pos))
+#define SPI_TDR_LASTXFER_Pos        24           /**< \brief (SPI_TDR) Last Transfer */
+#define SPI_TDR_LASTXFER            (_U(0x1) << SPI_TDR_LASTXFER_Pos)
+#define   SPI_TDR_LASTXFER_0_Val          _U(0x0)   /**< \brief (SPI_TDR) No effect. */
+#define   SPI_TDR_LASTXFER_1_Val          _U(0x1)   /**< \brief (SPI_TDR) The current NPCS will be deasserted after the character written in TD has been transferred. When CSAAT is set, thisallows to close the communication with the current serial peripheral by raising the corresponding NPCS line as soon as TDtransfer has completed. */
+#define SPI_TDR_LASTXFER_0          (SPI_TDR_LASTXFER_0_Val        << SPI_TDR_LASTXFER_Pos)
+#define SPI_TDR_LASTXFER_1          (SPI_TDR_LASTXFER_1_Val        << SPI_TDR_LASTXFER_Pos)
+#define SPI_TDR_MASK                _U(0x010FFFFF) /**< \brief (SPI_TDR) MASK Register */
+
+/* -------- SPI_SR : (SPI Offset: 0x10) (R/  32) Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RDRF:1;           /*!< bit:      0  Receive Data Register Full         */
+    uint32_t TDRE:1;           /*!< bit:      1  Transmit Data Register Empty       */
+    uint32_t MODF:1;           /*!< bit:      2  Mode Fault Error                   */
+    uint32_t OVRES:1;          /*!< bit:      3  Overrun Error Status               */
+    uint32_t ENDRX:1;          /*!< bit:      4  End of RX buffer                   */
+    uint32_t ENDTX:1;          /*!< bit:      5  End of TX buffer                   */
+    uint32_t RXBUFF:1;         /*!< bit:      6  RX Buffer Full                     */
+    uint32_t TXBUFE:1;         /*!< bit:      7  TX Buffer Empty                    */
+    uint32_t NSSR:1;           /*!< bit:      8  NSS Rising                         */
+    uint32_t TXEMPTY:1;        /*!< bit:      9  Transmission Registers Empty       */
+    uint32_t UNDES:1;          /*!< bit:     10  Underrun Error Status (Slave Mode Only) */
+    uint32_t :5;               /*!< bit: 11..15  Reserved                           */
+    uint32_t SPIENS:1;         /*!< bit:     16  SPI Enable Status                  */
+    uint32_t :15;              /*!< bit: 17..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SPI_SR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_SR_OFFSET               0x10         /**< \brief (SPI_SR offset) Status Register */
+#define SPI_SR_RESETVALUE           _U(0x000000F0); /**< \brief (SPI_SR reset_value) Status Register */
+
+#define SPI_SR_RDRF_Pos             0            /**< \brief (SPI_SR) Receive Data Register Full */
+#define SPI_SR_RDRF                 (_U(0x1) << SPI_SR_RDRF_Pos)
+#define   SPI_SR_RDRF_0_Val               _U(0x0)   /**< \brief (SPI_SR) No data has been received since the last read of RDR */
+#define   SPI_SR_RDRF_1_Val               _U(0x1)   /**< \brief (SPI_SR) Data has been received and the received data has been transferred from the serializer to RDR since the last readof RDR. */
+#define SPI_SR_RDRF_0               (SPI_SR_RDRF_0_Val             << SPI_SR_RDRF_Pos)
+#define SPI_SR_RDRF_1               (SPI_SR_RDRF_1_Val             << SPI_SR_RDRF_Pos)
+#define SPI_SR_TDRE_Pos             1            /**< \brief (SPI_SR) Transmit Data Register Empty */
+#define SPI_SR_TDRE                 (_U(0x1) << SPI_SR_TDRE_Pos)
+#define   SPI_SR_TDRE_0_Val               _U(0x0)   /**< \brief (SPI_SR) Data has been written to TDR and not yet transferred to the serializer. */
+#define   SPI_SR_TDRE_1_Val               _U(0x1)   /**< \brief (SPI_SR) The last data written in the Transmit Data Register has been transferred to the serializer.TDRE equals zero when the SPI is disabled or at reset. The SPI enable command sets this bit to one. */
+#define SPI_SR_TDRE_0               (SPI_SR_TDRE_0_Val             << SPI_SR_TDRE_Pos)
+#define SPI_SR_TDRE_1               (SPI_SR_TDRE_1_Val             << SPI_SR_TDRE_Pos)
+#define SPI_SR_MODF_Pos             2            /**< \brief (SPI_SR) Mode Fault Error */
+#define SPI_SR_MODF                 (_U(0x1) << SPI_SR_MODF_Pos)
+#define   SPI_SR_MODF_0_Val               _U(0x0)   /**< \brief (SPI_SR) No Mode Fault has been detected since the last read of SR. */
+#define   SPI_SR_MODF_1_Val               _U(0x1)   /**< \brief (SPI_SR) A Mode Fault occurred since the last read of the SR. */
+#define SPI_SR_MODF_0               (SPI_SR_MODF_0_Val             << SPI_SR_MODF_Pos)
+#define SPI_SR_MODF_1               (SPI_SR_MODF_1_Val             << SPI_SR_MODF_Pos)
+#define SPI_SR_OVRES_Pos            3            /**< \brief (SPI_SR) Overrun Error Status */
+#define SPI_SR_OVRES                (_U(0x1) << SPI_SR_OVRES_Pos)
+#define   SPI_SR_OVRES_0_Val              _U(0x0)   /**< \brief (SPI_SR) No overrun has been detected since the last read of SR. */
+#define   SPI_SR_OVRES_1_Val              _U(0x1)   /**< \brief (SPI_SR) An overrun has occurred since the last read of SR. */
+#define SPI_SR_OVRES_0              (SPI_SR_OVRES_0_Val            << SPI_SR_OVRES_Pos)
+#define SPI_SR_OVRES_1              (SPI_SR_OVRES_1_Val            << SPI_SR_OVRES_Pos)
+#define SPI_SR_ENDRX_Pos            4            /**< \brief (SPI_SR) End of RX buffer */
+#define SPI_SR_ENDRX                (_U(0x1) << SPI_SR_ENDRX_Pos)
+#define   SPI_SR_ENDRX_0_Val              _U(0x0)   /**< \brief (SPI_SR) The Receive Counter Register has not reached 0 since the last write in RCR or RNCR. */
+#define   SPI_SR_ENDRX_1_Val              _U(0x1)   /**< \brief (SPI_SR) The Receive Counter Register has reached 0 since the last write in RCR or RNCR. */
+#define SPI_SR_ENDRX_0              (SPI_SR_ENDRX_0_Val            << SPI_SR_ENDRX_Pos)
+#define SPI_SR_ENDRX_1              (SPI_SR_ENDRX_1_Val            << SPI_SR_ENDRX_Pos)
+#define SPI_SR_ENDTX_Pos            5            /**< \brief (SPI_SR) End of TX buffer */
+#define SPI_SR_ENDTX                (_U(0x1) << SPI_SR_ENDTX_Pos)
+#define   SPI_SR_ENDTX_0_Val              _U(0x0)   /**< \brief (SPI_SR) The Transmit Counter Register has not reached 0 since the last write in TCR or TNCR. */
+#define   SPI_SR_ENDTX_1_Val              _U(0x1)   /**< \brief (SPI_SR) The Transmit Counter Register has reached 0 since the last write in TCR or TNCR. */
+#define SPI_SR_ENDTX_0              (SPI_SR_ENDTX_0_Val            << SPI_SR_ENDTX_Pos)
+#define SPI_SR_ENDTX_1              (SPI_SR_ENDTX_1_Val            << SPI_SR_ENDTX_Pos)
+#define SPI_SR_RXBUFF_Pos           6            /**< \brief (SPI_SR) RX Buffer Full */
+#define SPI_SR_RXBUFF               (_U(0x1) << SPI_SR_RXBUFF_Pos)
+#define   SPI_SR_RXBUFF_0_Val             _U(0x0)   /**< \brief (SPI_SR) RCR or RNCR has a value other than 0. */
+#define   SPI_SR_RXBUFF_1_Val             _U(0x1)   /**< \brief (SPI_SR) Both RCR and RNCR has a value of 0. */
+#define SPI_SR_RXBUFF_0             (SPI_SR_RXBUFF_0_Val           << SPI_SR_RXBUFF_Pos)
+#define SPI_SR_RXBUFF_1             (SPI_SR_RXBUFF_1_Val           << SPI_SR_RXBUFF_Pos)
+#define SPI_SR_TXBUFE_Pos           7            /**< \brief (SPI_SR) TX Buffer Empty */
+#define SPI_SR_TXBUFE               (_U(0x1) << SPI_SR_TXBUFE_Pos)
+#define   SPI_SR_TXBUFE_0_Val             _U(0x0)   /**< \brief (SPI_SR) TCR or TNCR has a value other than 0. */
+#define   SPI_SR_TXBUFE_1_Val             _U(0x1)   /**< \brief (SPI_SR) Both TCR and TNCR has a value of 0. */
+#define SPI_SR_TXBUFE_0             (SPI_SR_TXBUFE_0_Val           << SPI_SR_TXBUFE_Pos)
+#define SPI_SR_TXBUFE_1             (SPI_SR_TXBUFE_1_Val           << SPI_SR_TXBUFE_Pos)
+#define SPI_SR_NSSR_Pos             8            /**< \brief (SPI_SR) NSS Rising */
+#define SPI_SR_NSSR                 (_U(0x1) << SPI_SR_NSSR_Pos)
+#define   SPI_SR_NSSR_0_Val               _U(0x0)   /**< \brief (SPI_SR) No rising edge detected on NSS pin since last read. */
+#define   SPI_SR_NSSR_1_Val               _U(0x1)   /**< \brief (SPI_SR) A rising edge occurred on NSS pin since last read. */
+#define SPI_SR_NSSR_0               (SPI_SR_NSSR_0_Val             << SPI_SR_NSSR_Pos)
+#define SPI_SR_NSSR_1               (SPI_SR_NSSR_1_Val             << SPI_SR_NSSR_Pos)
+#define SPI_SR_TXEMPTY_Pos          9            /**< \brief (SPI_SR) Transmission Registers Empty */
+#define SPI_SR_TXEMPTY              (_U(0x1) << SPI_SR_TXEMPTY_Pos)
+#define   SPI_SR_TXEMPTY_0_Val            _U(0x0)   /**< \brief (SPI_SR) As soon as data is written in TDR. */
+#define   SPI_SR_TXEMPTY_1_Val            _U(0x1)   /**< \brief (SPI_SR) TDR and internal shifter are empty. If a transfer delay has been defined, TXEMPTY is set after the completion ofsuch delay. */
+#define SPI_SR_TXEMPTY_0            (SPI_SR_TXEMPTY_0_Val          << SPI_SR_TXEMPTY_Pos)
+#define SPI_SR_TXEMPTY_1            (SPI_SR_TXEMPTY_1_Val          << SPI_SR_TXEMPTY_Pos)
+#define SPI_SR_UNDES_Pos            10           /**< \brief (SPI_SR) Underrun Error Status (Slave Mode Only) */
+#define SPI_SR_UNDES                (_U(0x1) << SPI_SR_UNDES_Pos)
+#define SPI_SR_SPIENS_Pos           16           /**< \brief (SPI_SR) SPI Enable Status */
+#define SPI_SR_SPIENS               (_U(0x1) << SPI_SR_SPIENS_Pos)
+#define   SPI_SR_SPIENS_0_Val             _U(0x0)   /**< \brief (SPI_SR) SPI is disabled. */
+#define   SPI_SR_SPIENS_1_Val             _U(0x1)   /**< \brief (SPI_SR) SPI is enabled. */
+#define SPI_SR_SPIENS_0             (SPI_SR_SPIENS_0_Val           << SPI_SR_SPIENS_Pos)
+#define SPI_SR_SPIENS_1             (SPI_SR_SPIENS_1_Val           << SPI_SR_SPIENS_Pos)
+#define SPI_SR_MASK                 _U(0x000107FF) /**< \brief (SPI_SR) MASK Register */
+
+/* -------- SPI_IER : (SPI Offset: 0x14) ( /W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RDRF:1;           /*!< bit:      0  Receive Data Register Full Interrupt Enable */
+    uint32_t TDRE:1;           /*!< bit:      1  Transmit Data Register Empty Interrupt Enable */
+    uint32_t MODF:1;           /*!< bit:      2  Mode Fault Error Interrupt Enable  */
+    uint32_t OVRES:1;          /*!< bit:      3  Overrun Error Interrupt Enable     */
+    uint32_t ENDRX:1;          /*!< bit:      4  End of Receive Buffer Interrupt Enable */
+    uint32_t ENDTX:1;          /*!< bit:      5  End of Transmit Buffer Interrupt Enable */
+    uint32_t RXBUFF:1;         /*!< bit:      6  Receive Buffer Full Interrupt Enable */
+    uint32_t TXBUFE:1;         /*!< bit:      7  Transmit Buffer Empty Interrupt Enable */
+    uint32_t NSSR:1;           /*!< bit:      8  NSS Rising Interrupt Enable        */
+    uint32_t TXEMPTY:1;        /*!< bit:      9  Transmission Registers Empty Enable */
+    uint32_t UNDES:1;          /*!< bit:     10  Underrun Error Interrupt Enable    */
+    uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SPI_IER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_IER_OFFSET              0x14         /**< \brief (SPI_IER offset) Interrupt Enable Register */
+#define SPI_IER_RESETVALUE          _U(0x00000000); /**< \brief (SPI_IER reset_value) Interrupt Enable Register */
+
+#define SPI_IER_RDRF_Pos            0            /**< \brief (SPI_IER) Receive Data Register Full Interrupt Enable */
+#define SPI_IER_RDRF                (_U(0x1) << SPI_IER_RDRF_Pos)
+#define   SPI_IER_RDRF_0_Val              _U(0x0)   /**< \brief (SPI_IER) No effect. */
+#define   SPI_IER_RDRF_1_Val              _U(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
+#define SPI_IER_RDRF_0              (SPI_IER_RDRF_0_Val            << SPI_IER_RDRF_Pos)
+#define SPI_IER_RDRF_1              (SPI_IER_RDRF_1_Val            << SPI_IER_RDRF_Pos)
+#define SPI_IER_TDRE_Pos            1            /**< \brief (SPI_IER) Transmit Data Register Empty Interrupt Enable */
+#define SPI_IER_TDRE                (_U(0x1) << SPI_IER_TDRE_Pos)
+#define   SPI_IER_TDRE_0_Val              _U(0x0)   /**< \brief (SPI_IER) No effect. */
+#define   SPI_IER_TDRE_1_Val              _U(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
+#define SPI_IER_TDRE_0              (SPI_IER_TDRE_0_Val            << SPI_IER_TDRE_Pos)
+#define SPI_IER_TDRE_1              (SPI_IER_TDRE_1_Val            << SPI_IER_TDRE_Pos)
+#define SPI_IER_MODF_Pos            2            /**< \brief (SPI_IER) Mode Fault Error Interrupt Enable */
+#define SPI_IER_MODF                (_U(0x1) << SPI_IER_MODF_Pos)
+#define   SPI_IER_MODF_0_Val              _U(0x0)   /**< \brief (SPI_IER) No effect. */
+#define   SPI_IER_MODF_1_Val              _U(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
+#define SPI_IER_MODF_0              (SPI_IER_MODF_0_Val            << SPI_IER_MODF_Pos)
+#define SPI_IER_MODF_1              (SPI_IER_MODF_1_Val            << SPI_IER_MODF_Pos)
+#define SPI_IER_OVRES_Pos           3            /**< \brief (SPI_IER) Overrun Error Interrupt Enable */
+#define SPI_IER_OVRES               (_U(0x1) << SPI_IER_OVRES_Pos)
+#define   SPI_IER_OVRES_0_Val             _U(0x0)   /**< \brief (SPI_IER) No effect. */
+#define   SPI_IER_OVRES_1_Val             _U(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
+#define SPI_IER_OVRES_0             (SPI_IER_OVRES_0_Val           << SPI_IER_OVRES_Pos)
+#define SPI_IER_OVRES_1             (SPI_IER_OVRES_1_Val           << SPI_IER_OVRES_Pos)
+#define SPI_IER_ENDRX_Pos           4            /**< \brief (SPI_IER) End of Receive Buffer Interrupt Enable */
+#define SPI_IER_ENDRX               (_U(0x1) << SPI_IER_ENDRX_Pos)
+#define   SPI_IER_ENDRX_0_Val             _U(0x0)   /**< \brief (SPI_IER) No effect. */
+#define   SPI_IER_ENDRX_1_Val             _U(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
+#define SPI_IER_ENDRX_0             (SPI_IER_ENDRX_0_Val           << SPI_IER_ENDRX_Pos)
+#define SPI_IER_ENDRX_1             (SPI_IER_ENDRX_1_Val           << SPI_IER_ENDRX_Pos)
+#define SPI_IER_ENDTX_Pos           5            /**< \brief (SPI_IER) End of Transmit Buffer Interrupt Enable */
+#define SPI_IER_ENDTX               (_U(0x1) << SPI_IER_ENDTX_Pos)
+#define   SPI_IER_ENDTX_0_Val             _U(0x0)   /**< \brief (SPI_IER) No effect. */
+#define   SPI_IER_ENDTX_1_Val             _U(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
+#define SPI_IER_ENDTX_0             (SPI_IER_ENDTX_0_Val           << SPI_IER_ENDTX_Pos)
+#define SPI_IER_ENDTX_1             (SPI_IER_ENDTX_1_Val           << SPI_IER_ENDTX_Pos)
+#define SPI_IER_RXBUFF_Pos          6            /**< \brief (SPI_IER) Receive Buffer Full Interrupt Enable */
+#define SPI_IER_RXBUFF              (_U(0x1) << SPI_IER_RXBUFF_Pos)
+#define   SPI_IER_RXBUFF_0_Val            _U(0x0)   /**< \brief (SPI_IER) No effect. */
+#define   SPI_IER_RXBUFF_1_Val            _U(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
+#define SPI_IER_RXBUFF_0            (SPI_IER_RXBUFF_0_Val          << SPI_IER_RXBUFF_Pos)
+#define SPI_IER_RXBUFF_1            (SPI_IER_RXBUFF_1_Val          << SPI_IER_RXBUFF_Pos)
+#define SPI_IER_TXBUFE_Pos          7            /**< \brief (SPI_IER) Transmit Buffer Empty Interrupt Enable */
+#define SPI_IER_TXBUFE              (_U(0x1) << SPI_IER_TXBUFE_Pos)
+#define   SPI_IER_TXBUFE_0_Val            _U(0x0)   /**< \brief (SPI_IER) No effect. */
+#define   SPI_IER_TXBUFE_1_Val            _U(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
+#define SPI_IER_TXBUFE_0            (SPI_IER_TXBUFE_0_Val          << SPI_IER_TXBUFE_Pos)
+#define SPI_IER_TXBUFE_1            (SPI_IER_TXBUFE_1_Val          << SPI_IER_TXBUFE_Pos)
+#define SPI_IER_NSSR_Pos            8            /**< \brief (SPI_IER) NSS Rising Interrupt Enable */
+#define SPI_IER_NSSR                (_U(0x1) << SPI_IER_NSSR_Pos)
+#define   SPI_IER_NSSR_0_Val              _U(0x0)   /**< \brief (SPI_IER) No effect. */
+#define   SPI_IER_NSSR_1_Val              _U(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
+#define SPI_IER_NSSR_0              (SPI_IER_NSSR_0_Val            << SPI_IER_NSSR_Pos)
+#define SPI_IER_NSSR_1              (SPI_IER_NSSR_1_Val            << SPI_IER_NSSR_Pos)
+#define SPI_IER_TXEMPTY_Pos         9            /**< \brief (SPI_IER) Transmission Registers Empty Enable */
+#define SPI_IER_TXEMPTY             (_U(0x1) << SPI_IER_TXEMPTY_Pos)
+#define   SPI_IER_TXEMPTY_0_Val           _U(0x0)   /**< \brief (SPI_IER) No effect. */
+#define   SPI_IER_TXEMPTY_1_Val           _U(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
+#define SPI_IER_TXEMPTY_0           (SPI_IER_TXEMPTY_0_Val         << SPI_IER_TXEMPTY_Pos)
+#define SPI_IER_TXEMPTY_1           (SPI_IER_TXEMPTY_1_Val         << SPI_IER_TXEMPTY_Pos)
+#define SPI_IER_UNDES_Pos           10           /**< \brief (SPI_IER) Underrun Error Interrupt Enable */
+#define SPI_IER_UNDES               (_U(0x1) << SPI_IER_UNDES_Pos)
+#define SPI_IER_MASK                _U(0x000007FF) /**< \brief (SPI_IER) MASK Register */
+
+/* -------- SPI_IDR : (SPI Offset: 0x18) ( /W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RDRF:1;           /*!< bit:      0  Receive Data Register Full Interrupt Disable */
+    uint32_t TDRE:1;           /*!< bit:      1  Transmit Data Register Empty Interrupt Disable */
+    uint32_t MODF:1;           /*!< bit:      2  Mode Fault Error Interrupt Disable */
+    uint32_t OVRES:1;          /*!< bit:      3  Overrun Error Interrupt Disable    */
+    uint32_t ENDRX:1;          /*!< bit:      4  End of Receive Buffer Interrupt Disable */
+    uint32_t ENDTX:1;          /*!< bit:      5  End of Transmit Buffer Interrupt Disable */
+    uint32_t RXBUFF:1;         /*!< bit:      6  Receive Buffer Full Interrupt Disable */
+    uint32_t TXBUFE:1;         /*!< bit:      7  Transmit Buffer Empty Interrupt Disable */
+    uint32_t NSSR:1;           /*!< bit:      8  NSS Rising Interrupt Disable       */
+    uint32_t TXEMPTY:1;        /*!< bit:      9  Transmission Registers Empty Disable */
+    uint32_t UNDES:1;          /*!< bit:     10  Underrun Error Interrupt Disable   */
+    uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SPI_IDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_IDR_OFFSET              0x18         /**< \brief (SPI_IDR offset) Interrupt Disable Register */
+#define SPI_IDR_RESETVALUE          _U(0x00000000); /**< \brief (SPI_IDR reset_value) Interrupt Disable Register */
+
+#define SPI_IDR_RDRF_Pos            0            /**< \brief (SPI_IDR) Receive Data Register Full Interrupt Disable */
+#define SPI_IDR_RDRF                (_U(0x1) << SPI_IDR_RDRF_Pos)
+#define   SPI_IDR_RDRF_0_Val              _U(0x0)   /**< \brief (SPI_IDR) No effect. */
+#define   SPI_IDR_RDRF_1_Val              _U(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
+#define SPI_IDR_RDRF_0              (SPI_IDR_RDRF_0_Val            << SPI_IDR_RDRF_Pos)
+#define SPI_IDR_RDRF_1              (SPI_IDR_RDRF_1_Val            << SPI_IDR_RDRF_Pos)
+#define SPI_IDR_TDRE_Pos            1            /**< \brief (SPI_IDR) Transmit Data Register Empty Interrupt Disable */
+#define SPI_IDR_TDRE                (_U(0x1) << SPI_IDR_TDRE_Pos)
+#define   SPI_IDR_TDRE_0_Val              _U(0x0)   /**< \brief (SPI_IDR) No effect. */
+#define   SPI_IDR_TDRE_1_Val              _U(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
+#define SPI_IDR_TDRE_0              (SPI_IDR_TDRE_0_Val            << SPI_IDR_TDRE_Pos)
+#define SPI_IDR_TDRE_1              (SPI_IDR_TDRE_1_Val            << SPI_IDR_TDRE_Pos)
+#define SPI_IDR_MODF_Pos            2            /**< \brief (SPI_IDR) Mode Fault Error Interrupt Disable */
+#define SPI_IDR_MODF                (_U(0x1) << SPI_IDR_MODF_Pos)
+#define   SPI_IDR_MODF_0_Val              _U(0x0)   /**< \brief (SPI_IDR) No effect. */
+#define   SPI_IDR_MODF_1_Val              _U(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
+#define SPI_IDR_MODF_0              (SPI_IDR_MODF_0_Val            << SPI_IDR_MODF_Pos)
+#define SPI_IDR_MODF_1              (SPI_IDR_MODF_1_Val            << SPI_IDR_MODF_Pos)
+#define SPI_IDR_OVRES_Pos           3            /**< \brief (SPI_IDR) Overrun Error Interrupt Disable */
+#define SPI_IDR_OVRES               (_U(0x1) << SPI_IDR_OVRES_Pos)
+#define   SPI_IDR_OVRES_0_Val             _U(0x0)   /**< \brief (SPI_IDR) No effect. */
+#define   SPI_IDR_OVRES_1_Val             _U(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
+#define SPI_IDR_OVRES_0             (SPI_IDR_OVRES_0_Val           << SPI_IDR_OVRES_Pos)
+#define SPI_IDR_OVRES_1             (SPI_IDR_OVRES_1_Val           << SPI_IDR_OVRES_Pos)
+#define SPI_IDR_ENDRX_Pos           4            /**< \brief (SPI_IDR) End of Receive Buffer Interrupt Disable */
+#define SPI_IDR_ENDRX               (_U(0x1) << SPI_IDR_ENDRX_Pos)
+#define   SPI_IDR_ENDRX_0_Val             _U(0x0)   /**< \brief (SPI_IDR) No effect. */
+#define   SPI_IDR_ENDRX_1_Val             _U(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
+#define SPI_IDR_ENDRX_0             (SPI_IDR_ENDRX_0_Val           << SPI_IDR_ENDRX_Pos)
+#define SPI_IDR_ENDRX_1             (SPI_IDR_ENDRX_1_Val           << SPI_IDR_ENDRX_Pos)
+#define SPI_IDR_ENDTX_Pos           5            /**< \brief (SPI_IDR) End of Transmit Buffer Interrupt Disable */
+#define SPI_IDR_ENDTX               (_U(0x1) << SPI_IDR_ENDTX_Pos)
+#define   SPI_IDR_ENDTX_0_Val             _U(0x0)   /**< \brief (SPI_IDR) No effect. */
+#define   SPI_IDR_ENDTX_1_Val             _U(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
+#define SPI_IDR_ENDTX_0             (SPI_IDR_ENDTX_0_Val           << SPI_IDR_ENDTX_Pos)
+#define SPI_IDR_ENDTX_1             (SPI_IDR_ENDTX_1_Val           << SPI_IDR_ENDTX_Pos)
+#define SPI_IDR_RXBUFF_Pos          6            /**< \brief (SPI_IDR) Receive Buffer Full Interrupt Disable */
+#define SPI_IDR_RXBUFF              (_U(0x1) << SPI_IDR_RXBUFF_Pos)
+#define   SPI_IDR_RXBUFF_0_Val            _U(0x0)   /**< \brief (SPI_IDR) No effect. */
+#define   SPI_IDR_RXBUFF_1_Val            _U(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
+#define SPI_IDR_RXBUFF_0            (SPI_IDR_RXBUFF_0_Val          << SPI_IDR_RXBUFF_Pos)
+#define SPI_IDR_RXBUFF_1            (SPI_IDR_RXBUFF_1_Val          << SPI_IDR_RXBUFF_Pos)
+#define SPI_IDR_TXBUFE_Pos          7            /**< \brief (SPI_IDR) Transmit Buffer Empty Interrupt Disable */
+#define SPI_IDR_TXBUFE              (_U(0x1) << SPI_IDR_TXBUFE_Pos)
+#define   SPI_IDR_TXBUFE_0_Val            _U(0x0)   /**< \brief (SPI_IDR) No effect. */
+#define   SPI_IDR_TXBUFE_1_Val            _U(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
+#define SPI_IDR_TXBUFE_0            (SPI_IDR_TXBUFE_0_Val          << SPI_IDR_TXBUFE_Pos)
+#define SPI_IDR_TXBUFE_1            (SPI_IDR_TXBUFE_1_Val          << SPI_IDR_TXBUFE_Pos)
+#define SPI_IDR_NSSR_Pos            8            /**< \brief (SPI_IDR) NSS Rising Interrupt Disable */
+#define SPI_IDR_NSSR                (_U(0x1) << SPI_IDR_NSSR_Pos)
+#define   SPI_IDR_NSSR_0_Val              _U(0x0)   /**< \brief (SPI_IDR) No effect. */
+#define   SPI_IDR_NSSR_1_Val              _U(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
+#define SPI_IDR_NSSR_0              (SPI_IDR_NSSR_0_Val            << SPI_IDR_NSSR_Pos)
+#define SPI_IDR_NSSR_1              (SPI_IDR_NSSR_1_Val            << SPI_IDR_NSSR_Pos)
+#define SPI_IDR_TXEMPTY_Pos         9            /**< \brief (SPI_IDR) Transmission Registers Empty Disable */
+#define SPI_IDR_TXEMPTY             (_U(0x1) << SPI_IDR_TXEMPTY_Pos)
+#define   SPI_IDR_TXEMPTY_0_Val           _U(0x0)   /**< \brief (SPI_IDR) No effect. */
+#define   SPI_IDR_TXEMPTY_1_Val           _U(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
+#define SPI_IDR_TXEMPTY_0           (SPI_IDR_TXEMPTY_0_Val         << SPI_IDR_TXEMPTY_Pos)
+#define SPI_IDR_TXEMPTY_1           (SPI_IDR_TXEMPTY_1_Val         << SPI_IDR_TXEMPTY_Pos)
+#define SPI_IDR_UNDES_Pos           10           /**< \brief (SPI_IDR) Underrun Error Interrupt Disable */
+#define SPI_IDR_UNDES               (_U(0x1) << SPI_IDR_UNDES_Pos)
+#define SPI_IDR_MASK                _U(0x000007FF) /**< \brief (SPI_IDR) MASK Register */
+
+/* -------- SPI_IMR : (SPI Offset: 0x1C) (R/  32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RDRF:1;           /*!< bit:      0  Receive Data Register Full Interrupt Mask */
+    uint32_t TDRE:1;           /*!< bit:      1  Transmit Data Register Empty Interrupt Mask */
+    uint32_t MODF:1;           /*!< bit:      2  Mode Fault Error Interrupt Mask    */
+    uint32_t OVRES:1;          /*!< bit:      3  Overrun Error Interrupt Mask       */
+    uint32_t ENDRX:1;          /*!< bit:      4  End of Receive Buffer Interrupt Mask */
+    uint32_t ENDTX:1;          /*!< bit:      5  End of Transmit Buffer Interrupt Mask */
+    uint32_t RXBUFF:1;         /*!< bit:      6  Receive Buffer Full Interrupt Mask */
+    uint32_t TXBUFE:1;         /*!< bit:      7  Transmit Buffer Empty Interrupt Mask */
+    uint32_t NSSR:1;           /*!< bit:      8  NSS Rising Interrupt Mask          */
+    uint32_t TXEMPTY:1;        /*!< bit:      9  Transmission Registers Empty Mask  */
+    uint32_t UNDES:1;          /*!< bit:     10  Underrun Error Interrupt Mask      */
+    uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SPI_IMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_IMR_OFFSET              0x1C         /**< \brief (SPI_IMR offset) Interrupt Mask Register */
+#define SPI_IMR_RESETVALUE          _U(0x00000000); /**< \brief (SPI_IMR reset_value) Interrupt Mask Register */
+
+#define SPI_IMR_RDRF_Pos            0            /**< \brief (SPI_IMR) Receive Data Register Full Interrupt Mask */
+#define SPI_IMR_RDRF                (_U(0x1) << SPI_IMR_RDRF_Pos)
+#define   SPI_IMR_RDRF_0_Val              _U(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
+#define   SPI_IMR_RDRF_1_Val              _U(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
+#define SPI_IMR_RDRF_0              (SPI_IMR_RDRF_0_Val            << SPI_IMR_RDRF_Pos)
+#define SPI_IMR_RDRF_1              (SPI_IMR_RDRF_1_Val            << SPI_IMR_RDRF_Pos)
+#define SPI_IMR_TDRE_Pos            1            /**< \brief (SPI_IMR) Transmit Data Register Empty Interrupt Mask */
+#define SPI_IMR_TDRE                (_U(0x1) << SPI_IMR_TDRE_Pos)
+#define   SPI_IMR_TDRE_0_Val              _U(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
+#define   SPI_IMR_TDRE_1_Val              _U(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
+#define SPI_IMR_TDRE_0              (SPI_IMR_TDRE_0_Val            << SPI_IMR_TDRE_Pos)
+#define SPI_IMR_TDRE_1              (SPI_IMR_TDRE_1_Val            << SPI_IMR_TDRE_Pos)
+#define SPI_IMR_MODF_Pos            2            /**< \brief (SPI_IMR) Mode Fault Error Interrupt Mask */
+#define SPI_IMR_MODF                (_U(0x1) << SPI_IMR_MODF_Pos)
+#define   SPI_IMR_MODF_0_Val              _U(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
+#define   SPI_IMR_MODF_1_Val              _U(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
+#define SPI_IMR_MODF_0              (SPI_IMR_MODF_0_Val            << SPI_IMR_MODF_Pos)
+#define SPI_IMR_MODF_1              (SPI_IMR_MODF_1_Val            << SPI_IMR_MODF_Pos)
+#define SPI_IMR_OVRES_Pos           3            /**< \brief (SPI_IMR) Overrun Error Interrupt Mask */
+#define SPI_IMR_OVRES               (_U(0x1) << SPI_IMR_OVRES_Pos)
+#define   SPI_IMR_OVRES_0_Val             _U(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
+#define   SPI_IMR_OVRES_1_Val             _U(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
+#define SPI_IMR_OVRES_0             (SPI_IMR_OVRES_0_Val           << SPI_IMR_OVRES_Pos)
+#define SPI_IMR_OVRES_1             (SPI_IMR_OVRES_1_Val           << SPI_IMR_OVRES_Pos)
+#define SPI_IMR_ENDRX_Pos           4            /**< \brief (SPI_IMR) End of Receive Buffer Interrupt Mask */
+#define SPI_IMR_ENDRX               (_U(0x1) << SPI_IMR_ENDRX_Pos)
+#define   SPI_IMR_ENDRX_0_Val             _U(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
+#define   SPI_IMR_ENDRX_1_Val             _U(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
+#define SPI_IMR_ENDRX_0             (SPI_IMR_ENDRX_0_Val           << SPI_IMR_ENDRX_Pos)
+#define SPI_IMR_ENDRX_1             (SPI_IMR_ENDRX_1_Val           << SPI_IMR_ENDRX_Pos)
+#define SPI_IMR_ENDTX_Pos           5            /**< \brief (SPI_IMR) End of Transmit Buffer Interrupt Mask */
+#define SPI_IMR_ENDTX               (_U(0x1) << SPI_IMR_ENDTX_Pos)
+#define   SPI_IMR_ENDTX_0_Val             _U(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
+#define   SPI_IMR_ENDTX_1_Val             _U(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
+#define SPI_IMR_ENDTX_0             (SPI_IMR_ENDTX_0_Val           << SPI_IMR_ENDTX_Pos)
+#define SPI_IMR_ENDTX_1             (SPI_IMR_ENDTX_1_Val           << SPI_IMR_ENDTX_Pos)
+#define SPI_IMR_RXBUFF_Pos          6            /**< \brief (SPI_IMR) Receive Buffer Full Interrupt Mask */
+#define SPI_IMR_RXBUFF              (_U(0x1) << SPI_IMR_RXBUFF_Pos)
+#define   SPI_IMR_RXBUFF_0_Val            _U(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
+#define   SPI_IMR_RXBUFF_1_Val            _U(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
+#define SPI_IMR_RXBUFF_0            (SPI_IMR_RXBUFF_0_Val          << SPI_IMR_RXBUFF_Pos)
+#define SPI_IMR_RXBUFF_1            (SPI_IMR_RXBUFF_1_Val          << SPI_IMR_RXBUFF_Pos)
+#define SPI_IMR_TXBUFE_Pos          7            /**< \brief (SPI_IMR) Transmit Buffer Empty Interrupt Mask */
+#define SPI_IMR_TXBUFE              (_U(0x1) << SPI_IMR_TXBUFE_Pos)
+#define   SPI_IMR_TXBUFE_0_Val            _U(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
+#define   SPI_IMR_TXBUFE_1_Val            _U(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
+#define SPI_IMR_TXBUFE_0            (SPI_IMR_TXBUFE_0_Val          << SPI_IMR_TXBUFE_Pos)
+#define SPI_IMR_TXBUFE_1            (SPI_IMR_TXBUFE_1_Val          << SPI_IMR_TXBUFE_Pos)
+#define SPI_IMR_NSSR_Pos            8            /**< \brief (SPI_IMR) NSS Rising Interrupt Mask */
+#define SPI_IMR_NSSR                (_U(0x1) << SPI_IMR_NSSR_Pos)
+#define   SPI_IMR_NSSR_0_Val              _U(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
+#define   SPI_IMR_NSSR_1_Val              _U(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
+#define SPI_IMR_NSSR_0              (SPI_IMR_NSSR_0_Val            << SPI_IMR_NSSR_Pos)
+#define SPI_IMR_NSSR_1              (SPI_IMR_NSSR_1_Val            << SPI_IMR_NSSR_Pos)
+#define SPI_IMR_TXEMPTY_Pos         9            /**< \brief (SPI_IMR) Transmission Registers Empty Mask */
+#define SPI_IMR_TXEMPTY             (_U(0x1) << SPI_IMR_TXEMPTY_Pos)
+#define   SPI_IMR_TXEMPTY_0_Val           _U(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
+#define   SPI_IMR_TXEMPTY_1_Val           _U(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
+#define SPI_IMR_TXEMPTY_0           (SPI_IMR_TXEMPTY_0_Val         << SPI_IMR_TXEMPTY_Pos)
+#define SPI_IMR_TXEMPTY_1           (SPI_IMR_TXEMPTY_1_Val         << SPI_IMR_TXEMPTY_Pos)
+#define SPI_IMR_UNDES_Pos           10           /**< \brief (SPI_IMR) Underrun Error Interrupt Mask */
+#define SPI_IMR_UNDES               (_U(0x1) << SPI_IMR_UNDES_Pos)
+#define SPI_IMR_MASK                _U(0x000007FF) /**< \brief (SPI_IMR) MASK Register */
+
+/* -------- SPI_CSR : (SPI Offset: 0x30) (R/W 32) Chip Select Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CPOL:1;           /*!< bit:      0  Clock Polarity                     */
+    uint32_t NCPHA:1;          /*!< bit:      1  Clock Phase                        */
+    uint32_t CSNAAT:1;         /*!< bit:      2  Chip Select Not Active After Transfer */
+    uint32_t CSAAT:1;          /*!< bit:      3  Chip Select Active After Transfer  */
+    uint32_t BITS:4;           /*!< bit:  4.. 7  Bits Per Transfer                  */
+    uint32_t SCBR:8;           /*!< bit:  8..15  Serial Clock Baud Rate             */
+    uint32_t DLYBS:8;          /*!< bit: 16..23  Delay Before SPCK                  */
+    uint32_t DLYBCT:8;         /*!< bit: 24..31  Delay Between Consecutive Transfers */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SPI_CSR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_CSR_OFFSET              0x30         /**< \brief (SPI_CSR offset) Chip Select Register */
+#define SPI_CSR_RESETVALUE          _U(0x00000000); /**< \brief (SPI_CSR reset_value) Chip Select Register */
+
+#define SPI_CSR_CPOL_Pos            0            /**< \brief (SPI_CSR) Clock Polarity */
+#define SPI_CSR_CPOL                (_U(0x1) << SPI_CSR_CPOL_Pos)
+#define   SPI_CSR_CPOL_0_Val              _U(0x0)   /**< \brief (SPI_CSR) The inactive state value of SPCK is logic level zero. */
+#define   SPI_CSR_CPOL_1_Val              _U(0x1)   /**< \brief (SPI_CSR) The inactive state value of SPCK is logic level one.CPOL is used to determine the inactive state value of the serial clock (SPCK). It is used with NCPHA to produce therequired clock/data relationship between master and slave devices. */
+#define SPI_CSR_CPOL_0              (SPI_CSR_CPOL_0_Val            << SPI_CSR_CPOL_Pos)
+#define SPI_CSR_CPOL_1              (SPI_CSR_CPOL_1_Val            << SPI_CSR_CPOL_Pos)
+#define SPI_CSR_NCPHA_Pos           1            /**< \brief (SPI_CSR) Clock Phase */
+#define SPI_CSR_NCPHA               (_U(0x1) << SPI_CSR_NCPHA_Pos)
+#define   SPI_CSR_NCPHA_0_Val             _U(0x0)   /**< \brief (SPI_CSR) Data is changed on the leading edge of SPCK and captured on the following edge of SPCK. */
+#define   SPI_CSR_NCPHA_1_Val             _U(0x1)   /**< \brief (SPI_CSR) Data is captured on the leading edge of SPCK and changed on the following edge of SPCK.NCPHA determines which edge of SPCK causes data to change and which edge causes data to be captured. NCPHA isused with CPOL to produce the required clock/data relationship between master and slave devices. */
+#define SPI_CSR_NCPHA_0             (SPI_CSR_NCPHA_0_Val           << SPI_CSR_NCPHA_Pos)
+#define SPI_CSR_NCPHA_1             (SPI_CSR_NCPHA_1_Val           << SPI_CSR_NCPHA_Pos)
+#define SPI_CSR_CSNAAT_Pos          2            /**< \brief (SPI_CSR) Chip Select Not Active After Transfer */
+#define SPI_CSR_CSNAAT              (_U(0x1) << SPI_CSR_CSNAAT_Pos)
+#define SPI_CSR_CSAAT_Pos           3            /**< \brief (SPI_CSR) Chip Select Active After Transfer */
+#define SPI_CSR_CSAAT               (_U(0x1) << SPI_CSR_CSAAT_Pos)
+#define   SPI_CSR_CSAAT_0_Val             _U(0x0)   /**< \brief (SPI_CSR) The Peripheral Chip Select Line rises as soon as the last transfer is achieved. */
+#define   SPI_CSR_CSAAT_1_Val             _U(0x1)   /**< \brief (SPI_CSR) The Peripheral Chip Select does not rise after the last transfer is achieved. It remains active until a new transfer isrequested on a different chip select. */
+#define SPI_CSR_CSAAT_0             (SPI_CSR_CSAAT_0_Val           << SPI_CSR_CSAAT_Pos)
+#define SPI_CSR_CSAAT_1             (SPI_CSR_CSAAT_1_Val           << SPI_CSR_CSAAT_Pos)
+#define SPI_CSR_BITS_Pos            4            /**< \brief (SPI_CSR) Bits Per Transfer */
+#define SPI_CSR_BITS_Msk            (_U(0xF) << SPI_CSR_BITS_Pos)
+#define SPI_CSR_BITS(value)         (SPI_CSR_BITS_Msk & ((value) << SPI_CSR_BITS_Pos))
+#define   SPI_CSR_BITS_8_BPT_Val          _U(0x0)   /**< \brief (SPI_CSR) 8 bits per transfer */
+#define   SPI_CSR_BITS_9_BPT_Val          _U(0x1)   /**< \brief (SPI_CSR) 9 bits per transfer */
+#define   SPI_CSR_BITS_10_BPT_Val         _U(0x2)   /**< \brief (SPI_CSR) 10 bits per transfer */
+#define   SPI_CSR_BITS_11_BPT_Val         _U(0x3)   /**< \brief (SPI_CSR) 11 bits per transfer */
+#define   SPI_CSR_BITS_12_BPT_Val         _U(0x4)   /**< \brief (SPI_CSR) 12 bits per transfer */
+#define   SPI_CSR_BITS_13_BPT_Val         _U(0x5)   /**< \brief (SPI_CSR) 13 bits per transfer */
+#define   SPI_CSR_BITS_14_BPT_Val         _U(0x6)   /**< \brief (SPI_CSR) 14 bits per transfer */
+#define   SPI_CSR_BITS_15_BPT_Val         _U(0x7)   /**< \brief (SPI_CSR) 15 bits per transfer */
+#define   SPI_CSR_BITS_16_BPT_Val         _U(0x8)   /**< \brief (SPI_CSR) 16 bits per transfer */
+#define SPI_CSR_BITS_8_BPT          (SPI_CSR_BITS_8_BPT_Val        << SPI_CSR_BITS_Pos)
+#define SPI_CSR_BITS_9_BPT          (SPI_CSR_BITS_9_BPT_Val        << SPI_CSR_BITS_Pos)
+#define SPI_CSR_BITS_10_BPT         (SPI_CSR_BITS_10_BPT_Val       << SPI_CSR_BITS_Pos)
+#define SPI_CSR_BITS_11_BPT         (SPI_CSR_BITS_11_BPT_Val       << SPI_CSR_BITS_Pos)
+#define SPI_CSR_BITS_12_BPT         (SPI_CSR_BITS_12_BPT_Val       << SPI_CSR_BITS_Pos)
+#define SPI_CSR_BITS_13_BPT         (SPI_CSR_BITS_13_BPT_Val       << SPI_CSR_BITS_Pos)
+#define SPI_CSR_BITS_14_BPT         (SPI_CSR_BITS_14_BPT_Val       << SPI_CSR_BITS_Pos)
+#define SPI_CSR_BITS_15_BPT         (SPI_CSR_BITS_15_BPT_Val       << SPI_CSR_BITS_Pos)
+#define SPI_CSR_BITS_16_BPT         (SPI_CSR_BITS_16_BPT_Val       << SPI_CSR_BITS_Pos)
+#define SPI_CSR_SCBR_Pos            8            /**< \brief (SPI_CSR) Serial Clock Baud Rate */
+#define SPI_CSR_SCBR_Msk            (_U(0xFF) << SPI_CSR_SCBR_Pos)
+#define SPI_CSR_SCBR(value)         (SPI_CSR_SCBR_Msk & ((value) << SPI_CSR_SCBR_Pos))
+#define SPI_CSR_DLYBS_Pos           16           /**< \brief (SPI_CSR) Delay Before SPCK */
+#define SPI_CSR_DLYBS_Msk           (_U(0xFF) << SPI_CSR_DLYBS_Pos)
+#define SPI_CSR_DLYBS(value)        (SPI_CSR_DLYBS_Msk & ((value) << SPI_CSR_DLYBS_Pos))
+#define SPI_CSR_DLYBCT_Pos          24           /**< \brief (SPI_CSR) Delay Between Consecutive Transfers */
+#define SPI_CSR_DLYBCT_Msk          (_U(0xFF) << SPI_CSR_DLYBCT_Pos)
+#define SPI_CSR_DLYBCT(value)       (SPI_CSR_DLYBCT_Msk & ((value) << SPI_CSR_DLYBCT_Pos))
+#define SPI_CSR_MASK                _U(0xFFFFFFFF) /**< \brief (SPI_CSR) MASK Register */
+
+/* -------- SPI_WPCR : (SPI Offset: 0xE4) (R/W 32) Write Protection control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t WPEN:1;           /*!< bit:      0  Write Protection Enable            */
+    uint32_t :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint32_t WPKEY:24;         /*!< bit:  8..31  Write Protection Key Password      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SPI_WPCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_WPCR_OFFSET             0xE4         /**< \brief (SPI_WPCR offset) Write Protection control Register */
+#define SPI_WPCR_RESETVALUE         _U(0x00000000); /**< \brief (SPI_WPCR reset_value) Write Protection control Register */
+
+#define SPI_WPCR_WPEN_Pos           0            /**< \brief (SPI_WPCR) Write Protection Enable */
+#define SPI_WPCR_WPEN               (_U(0x1) << SPI_WPCR_WPEN_Pos)
+#define SPI_WPCR_WPKEY_Pos          8            /**< \brief (SPI_WPCR) Write Protection Key Password */
+#define SPI_WPCR_WPKEY_Msk          (_U(0xFFFFFF) << SPI_WPCR_WPKEY_Pos)
+#define SPI_WPCR_WPKEY(value)       (SPI_WPCR_WPKEY_Msk & ((value) << SPI_WPCR_WPKEY_Pos))
+#define   SPI_WPCR_WPKEY_VALUE_Val        _U(0x535049)   /**< \brief (SPI_WPCR) SPI Write Protection Key Password */
+#define SPI_WPCR_WPKEY_VALUE        (SPI_WPCR_WPKEY_VALUE_Val      << SPI_WPCR_WPKEY_Pos)
+#define SPI_WPCR_MASK               _U(0xFFFFFF01) /**< \brief (SPI_WPCR) MASK Register */
+
+/* -------- SPI_WPSR : (SPI Offset: 0xE8) (R/  32) Write Protection status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t WPVS:3;           /*!< bit:  0.. 2  Write Protection Violation Status  */
+    uint32_t :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint32_t WPVSRC:8;         /*!< bit:  8..15  Write Protection Violation Source  */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SPI_WPSR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_WPSR_OFFSET             0xE8         /**< \brief (SPI_WPSR offset) Write Protection status Register */
+#define SPI_WPSR_RESETVALUE         _U(0x00000000); /**< \brief (SPI_WPSR reset_value) Write Protection status Register */
+
+#define SPI_WPSR_WPVS_Pos           0            /**< \brief (SPI_WPSR) Write Protection Violation Status */
+#define SPI_WPSR_WPVS_Msk           (_U(0x7) << SPI_WPSR_WPVS_Pos)
+#define SPI_WPSR_WPVS(value)        (SPI_WPSR_WPVS_Msk & ((value) << SPI_WPSR_WPVS_Pos))
+#define   SPI_WPSR_WPVS_WRITE_WITH_WP_Val _U(0x1)   /**< \brief (SPI_WPSR) The Write Protection has blocked a Write access to a protected register (since the last read). */
+#define   SPI_WPSR_WPVS_SWRST_WITH_WP_Val _U(0x2)   /**< \brief (SPI_WPSR) Software Reset has been performed while Write Protection was enabled (since the last read or since the last write access on MR, IER, IDR or CSRx). */
+#define   SPI_WPSR_WPVS_UNEXPECTED_WRITE_Val _U(0x4)   /**< \brief (SPI_WPSR) Write accesses have been detected on MR (while a chip select was active) or on CSRi (while the Chip Select “i” was active) since the last read. */
+#define SPI_WPSR_WPVS_WRITE_WITH_WP (SPI_WPSR_WPVS_WRITE_WITH_WP_Val << SPI_WPSR_WPVS_Pos)
+#define SPI_WPSR_WPVS_SWRST_WITH_WP (SPI_WPSR_WPVS_SWRST_WITH_WP_Val << SPI_WPSR_WPVS_Pos)
+#define SPI_WPSR_WPVS_UNEXPECTED_WRITE (SPI_WPSR_WPVS_UNEXPECTED_WRITE_Val << SPI_WPSR_WPVS_Pos)
+#define SPI_WPSR_WPVSRC_Pos         8            /**< \brief (SPI_WPSR) Write Protection Violation Source */
+#define SPI_WPSR_WPVSRC_Msk         (_U(0xFF) << SPI_WPSR_WPVSRC_Pos)
+#define SPI_WPSR_WPVSRC(value)      (SPI_WPSR_WPVSRC_Msk & ((value) << SPI_WPSR_WPVSRC_Pos))
+#define SPI_WPSR_MASK               _U(0x0000FF07) /**< \brief (SPI_WPSR) MASK Register */
+
+/* -------- SPI_FEATURES : (SPI Offset: 0xF8) (R/  32) Features Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t NCS:4;            /*!< bit:  0.. 3  Number of Chip Selects             */
+    uint32_t PCONF:1;          /*!< bit:      4  Polarity is Configurable           */
+    uint32_t PPNCONF:1;        /*!< bit:      5  Polarity is Positive if Polarity is not Configurable */
+    uint32_t PHCONF:1;         /*!< bit:      6  Phase is Configurable              */
+    uint32_t PHZNCONF:1;       /*!< bit:      7  Phase is Zero if Phase is not Configurable */
+    uint32_t LENCONF:1;        /*!< bit:      8  Character Length is Configurable   */
+    uint32_t LENNCONF:7;       /*!< bit:  9..15  Character Length if not Configurable */
+    uint32_t EXTDEC:1;         /*!< bit:     16  External Decoder is True           */
+    uint32_t CSNAATIMPL:1;     /*!< bit:     17  CSNAAT Features are Implemented    */
+    uint32_t BRPBHSB:1;        /*!< bit:     18  Bridge Type is PB to HSB           */
+    uint32_t FIFORIMPL:1;      /*!< bit:     19  FIFO in Reception is Implemented   */
+    uint32_t SWPIMPL:1;        /*!< bit:     20  Spurious Write Protection is Implemented */
+    uint32_t :11;              /*!< bit: 21..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SPI_FEATURES_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_FEATURES_OFFSET         0xF8         /**< \brief (SPI_FEATURES offset) Features Register */
+
+#define SPI_FEATURES_NCS_Pos        0            /**< \brief (SPI_FEATURES) Number of Chip Selects */
+#define SPI_FEATURES_NCS_Msk        (_U(0xF) << SPI_FEATURES_NCS_Pos)
+#define SPI_FEATURES_NCS(value)     (SPI_FEATURES_NCS_Msk & ((value) << SPI_FEATURES_NCS_Pos))
+#define SPI_FEATURES_PCONF_Pos      4            /**< \brief (SPI_FEATURES) Polarity is Configurable */
+#define SPI_FEATURES_PCONF          (_U(0x1) << SPI_FEATURES_PCONF_Pos)
+#define SPI_FEATURES_PPNCONF_Pos    5            /**< \brief (SPI_FEATURES) Polarity is Positive if Polarity is not Configurable */
+#define SPI_FEATURES_PPNCONF        (_U(0x1) << SPI_FEATURES_PPNCONF_Pos)
+#define SPI_FEATURES_PHCONF_Pos     6            /**< \brief (SPI_FEATURES) Phase is Configurable */
+#define SPI_FEATURES_PHCONF         (_U(0x1) << SPI_FEATURES_PHCONF_Pos)
+#define SPI_FEATURES_PHZNCONF_Pos   7            /**< \brief (SPI_FEATURES) Phase is Zero if Phase is not Configurable */
+#define SPI_FEATURES_PHZNCONF       (_U(0x1) << SPI_FEATURES_PHZNCONF_Pos)
+#define SPI_FEATURES_LENCONF_Pos    8            /**< \brief (SPI_FEATURES) Character Length is Configurable */
+#define SPI_FEATURES_LENCONF        (_U(0x1) << SPI_FEATURES_LENCONF_Pos)
+#define SPI_FEATURES_LENNCONF_Pos   9            /**< \brief (SPI_FEATURES) Character Length if not Configurable */
+#define SPI_FEATURES_LENNCONF_Msk   (_U(0x7F) << SPI_FEATURES_LENNCONF_Pos)
+#define SPI_FEATURES_LENNCONF(value) (SPI_FEATURES_LENNCONF_Msk & ((value) << SPI_FEATURES_LENNCONF_Pos))
+#define SPI_FEATURES_EXTDEC_Pos     16           /**< \brief (SPI_FEATURES) External Decoder is True */
+#define SPI_FEATURES_EXTDEC         (_U(0x1) << SPI_FEATURES_EXTDEC_Pos)
+#define SPI_FEATURES_CSNAATIMPL_Pos 17           /**< \brief (SPI_FEATURES) CSNAAT Features are Implemented */
+#define SPI_FEATURES_CSNAATIMPL     (_U(0x1) << SPI_FEATURES_CSNAATIMPL_Pos)
+#define SPI_FEATURES_BRPBHSB_Pos    18           /**< \brief (SPI_FEATURES) Bridge Type is PB to HSB */
+#define SPI_FEATURES_BRPBHSB        (_U(0x1) << SPI_FEATURES_BRPBHSB_Pos)
+#define SPI_FEATURES_FIFORIMPL_Pos  19           /**< \brief (SPI_FEATURES) FIFO in Reception is Implemented */
+#define SPI_FEATURES_FIFORIMPL      (_U(0x1) << SPI_FEATURES_FIFORIMPL_Pos)
+#define SPI_FEATURES_SWPIMPL_Pos    20           /**< \brief (SPI_FEATURES) Spurious Write Protection is Implemented */
+#define SPI_FEATURES_SWPIMPL        (_U(0x1) << SPI_FEATURES_SWPIMPL_Pos)
+#define SPI_FEATURES_MASK           _U(0x001FFFFF) /**< \brief (SPI_FEATURES) MASK Register */
+
+/* -------- SPI_VERSION : (SPI Offset: 0xFC) (R/  32) Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version                            */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t MFN:3;            /*!< bit: 16..18  mfn                                */
+    uint32_t :13;              /*!< bit: 19..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SPI_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SPI_VERSION_OFFSET          0xFC         /**< \brief (SPI_VERSION offset) Version Register */
+#define SPI_VERSION_RESETVALUE      _U(0x00000211); /**< \brief (SPI_VERSION reset_value) Version Register */
+
+#define SPI_VERSION_VERSION_Pos     0            /**< \brief (SPI_VERSION) Version */
+#define SPI_VERSION_VERSION_Msk     (_U(0xFFF) << SPI_VERSION_VERSION_Pos)
+#define SPI_VERSION_VERSION(value)  (SPI_VERSION_VERSION_Msk & ((value) << SPI_VERSION_VERSION_Pos))
+#define SPI_VERSION_MFN_Pos         16           /**< \brief (SPI_VERSION) mfn */
+#define SPI_VERSION_MFN_Msk         (_U(0x7) << SPI_VERSION_MFN_Pos)
+#define SPI_VERSION_MFN(value)      (SPI_VERSION_MFN_Msk & ((value) << SPI_VERSION_MFN_Pos))
+#define SPI_VERSION_MASK            _U(0x00070FFF) /**< \brief (SPI_VERSION) MASK Register */
+
+/** \brief SPI hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __O  SPI_CR_Type               CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
+  __IO SPI_MR_Type               MR;          /**< \brief Offset: 0x04 (R/W 32) Mode Register */
+  __I  SPI_RDR_Type              RDR;         /**< \brief Offset: 0x08 (R/  32) Receive Data Register */
+  __O  SPI_TDR_Type              TDR;         /**< \brief Offset: 0x0C ( /W 32) Transmit Data Register */
+  __I  SPI_SR_Type               SR;          /**< \brief Offset: 0x10 (R/  32) Status Register */
+  __O  SPI_IER_Type              IER;         /**< \brief Offset: 0x14 ( /W 32) Interrupt Enable Register */
+  __O  SPI_IDR_Type              IDR;         /**< \brief Offset: 0x18 ( /W 32) Interrupt Disable Register */
+  __I  SPI_IMR_Type              IMR;         /**< \brief Offset: 0x1C (R/  32) Interrupt Mask Register */
+       RoReg8                    Reserved1[0x10];
+  __IO SPI_CSR_Type              CSR[4];      /**< \brief Offset: 0x30 (R/W 32) Chip Select Register */
+       RoReg8                    Reserved2[0xA4];
+  __IO SPI_WPCR_Type             WPCR;        /**< \brief Offset: 0xE4 (R/W 32) Write Protection control Register */
+  __I  SPI_WPSR_Type             WPSR;        /**< \brief Offset: 0xE8 (R/  32) Write Protection status Register */
+       RoReg8                    Reserved3[0xC];
+  __I  SPI_FEATURES_Type         FEATURES;    /**< \brief Offset: 0xF8 (R/  32) Features Register */
+  __I  SPI_VERSION_Type          VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
+ } bf;
+ struct {
+  WoReg   SPI_CR;             /**< \brief (SPI Offset: 0x00) Control Register */
+  RwReg   SPI_MR;             /**< \brief (SPI Offset: 0x04) Mode Register */
+  RoReg   SPI_RDR;            /**< \brief (SPI Offset: 0x08) Receive Data Register */
+  WoReg   SPI_TDR;            /**< \brief (SPI Offset: 0x0C) Transmit Data Register */
+  RoReg   SPI_SR;             /**< \brief (SPI Offset: 0x10) Status Register */
+  WoReg   SPI_IER;            /**< \brief (SPI Offset: 0x14) Interrupt Enable Register */
+  WoReg   SPI_IDR;            /**< \brief (SPI Offset: 0x18) Interrupt Disable Register */
+  RoReg   SPI_IMR;            /**< \brief (SPI Offset: 0x1C) Interrupt Mask Register */
+  RoReg8  Reserved4[0x10];
+  RwReg   SPI_CSR[4];         /**< \brief (SPI Offset: 0x30) Chip Select Register */
+  RoReg8  Reserved5[0xA4];
+  RwReg   SPI_WPCR;           /**< \brief (SPI Offset: 0xE4) Write Protection control Register */
+  RoReg   SPI_WPSR;           /**< \brief (SPI Offset: 0xE8) Write Protection status Register */
+  RoReg8  Reserved6[0xC];
+  RoReg   SPI_FEATURES;       /**< \brief (SPI Offset: 0xF8) Features Register */
+  RoReg   SPI_VERSION;        /**< \brief (SPI Offset: 0xFC) Version Register */
+ } reg;
+} Spi;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_SPI_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/spi.h
+++ b/asf/sam/include/sam4l/component/spi.h
@@ -56,35 +56,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_CR_OFFSET               0x00         /**< \brief (SPI_CR offset) Control Register */
-#define SPI_CR_RESETVALUE           _U(0x00000000); /**< \brief (SPI_CR reset_value) Control Register */
+#define SPI_CR_RESETVALUE           _U_(0x00000000); /**< \brief (SPI_CR reset_value) Control Register */
 
 #define SPI_CR_SPIEN_Pos            0            /**< \brief (SPI_CR) SPI Enable */
-#define SPI_CR_SPIEN                (_U(0x1) << SPI_CR_SPIEN_Pos)
-#define   SPI_CR_SPIEN_0_Val              _U(0x0)   /**< \brief (SPI_CR) No effect. */
-#define   SPI_CR_SPIEN_1_Val              _U(0x1)   /**< \brief (SPI_CR) Enables the SPI to transfer and receive data. */
+#define SPI_CR_SPIEN                (_U_(0x1) << SPI_CR_SPIEN_Pos)
+#define   SPI_CR_SPIEN_0_Val              _U_(0x0)   /**< \brief (SPI_CR) No effect. */
+#define   SPI_CR_SPIEN_1_Val              _U_(0x1)   /**< \brief (SPI_CR) Enables the SPI to transfer and receive data. */
 #define SPI_CR_SPIEN_0              (SPI_CR_SPIEN_0_Val            << SPI_CR_SPIEN_Pos)
 #define SPI_CR_SPIEN_1              (SPI_CR_SPIEN_1_Val            << SPI_CR_SPIEN_Pos)
 #define SPI_CR_SPIDIS_Pos           1            /**< \brief (SPI_CR) SPI Disable */
-#define SPI_CR_SPIDIS               (_U(0x1) << SPI_CR_SPIDIS_Pos)
-#define   SPI_CR_SPIDIS_0_Val             _U(0x0)   /**< \brief (SPI_CR) No effect. */
-#define   SPI_CR_SPIDIS_1_Val             _U(0x1)   /**< \brief (SPI_CR) Disables the SPI.All pins are set in input mode and no data is received or transmitted.If a transfer is in progress, the transfer is finished before the SPI is disabled.If both SPIEN and SPIDIS are equal to one when the control register is written, the SPI is disabled. */
+#define SPI_CR_SPIDIS               (_U_(0x1) << SPI_CR_SPIDIS_Pos)
+#define   SPI_CR_SPIDIS_0_Val             _U_(0x0)   /**< \brief (SPI_CR) No effect. */
+#define   SPI_CR_SPIDIS_1_Val             _U_(0x1)   /**< \brief (SPI_CR) Disables the SPI.All pins are set in input mode and no data is received or transmitted.If a transfer is in progress, the transfer is finished before the SPI is disabled.If both SPIEN and SPIDIS are equal to one when the control register is written, the SPI is disabled. */
 #define SPI_CR_SPIDIS_0             (SPI_CR_SPIDIS_0_Val           << SPI_CR_SPIDIS_Pos)
 #define SPI_CR_SPIDIS_1             (SPI_CR_SPIDIS_1_Val           << SPI_CR_SPIDIS_Pos)
 #define SPI_CR_SWRST_Pos            7            /**< \brief (SPI_CR) SPI Software Reset */
-#define SPI_CR_SWRST                (_U(0x1) << SPI_CR_SWRST_Pos)
-#define   SPI_CR_SWRST_0_Val              _U(0x0)   /**< \brief (SPI_CR) No effect. */
-#define   SPI_CR_SWRST_1_Val              _U(0x1)   /**< \brief (SPI_CR) Reset the SPI. A software-triggered hardware reset of the SPI interface is performed. */
+#define SPI_CR_SWRST                (_U_(0x1) << SPI_CR_SWRST_Pos)
+#define   SPI_CR_SWRST_0_Val              _U_(0x0)   /**< \brief (SPI_CR) No effect. */
+#define   SPI_CR_SWRST_1_Val              _U_(0x1)   /**< \brief (SPI_CR) Reset the SPI. A software-triggered hardware reset of the SPI interface is performed. */
 #define SPI_CR_SWRST_0              (SPI_CR_SWRST_0_Val            << SPI_CR_SWRST_Pos)
 #define SPI_CR_SWRST_1              (SPI_CR_SWRST_1_Val            << SPI_CR_SWRST_Pos)
 #define SPI_CR_FLUSHFIFO_Pos        8            /**< \brief (SPI_CR) Flush FIFO command */
-#define SPI_CR_FLUSHFIFO            (_U(0x1) << SPI_CR_FLUSHFIFO_Pos)
+#define SPI_CR_FLUSHFIFO            (_U_(0x1) << SPI_CR_FLUSHFIFO_Pos)
 #define SPI_CR_LASTXFER_Pos         24           /**< \brief (SPI_CR) Last Transfer */
-#define SPI_CR_LASTXFER             (_U(0x1) << SPI_CR_LASTXFER_Pos)
-#define   SPI_CR_LASTXFER_0_Val           _U(0x0)   /**< \brief (SPI_CR) No effect. */
-#define   SPI_CR_LASTXFER_1_Val           _U(0x1)   /**< \brief (SPI_CR) The current NPCS will be deasserted after the character written in TD has been transferred. When CSAAT is set, thisallows to close the communication with the current serial peripheral by raising the corresponding NPCS line as soon as TDtransfer has completed. */
+#define SPI_CR_LASTXFER             (_U_(0x1) << SPI_CR_LASTXFER_Pos)
+#define   SPI_CR_LASTXFER_0_Val           _U_(0x0)   /**< \brief (SPI_CR) No effect. */
+#define   SPI_CR_LASTXFER_1_Val           _U_(0x1)   /**< \brief (SPI_CR) The current NPCS will be deasserted after the character written in TD has been transferred. When CSAAT is set, thisallows to close the communication with the current serial peripheral by raising the corresponding NPCS line as soon as TDtransfer has completed. */
 #define SPI_CR_LASTXFER_0           (SPI_CR_LASTXFER_0_Val         << SPI_CR_LASTXFER_Pos)
 #define SPI_CR_LASTXFER_1           (SPI_CR_LASTXFER_1_Val         << SPI_CR_LASTXFER_Pos)
-#define SPI_CR_MASK                 _U(0x01000183) /**< \brief (SPI_CR) MASK Register */
+#define SPI_CR_MASK                 _U_(0x01000183) /**< \brief (SPI_CR) MASK Register */
 
 /* -------- SPI_MR : (SPI Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -108,49 +108,49 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_MR_OFFSET               0x04         /**< \brief (SPI_MR offset) Mode Register */
-#define SPI_MR_RESETVALUE           _U(0x00000000); /**< \brief (SPI_MR reset_value) Mode Register */
+#define SPI_MR_RESETVALUE           _U_(0x00000000); /**< \brief (SPI_MR reset_value) Mode Register */
 
 #define SPI_MR_MSTR_Pos             0            /**< \brief (SPI_MR) Master/Slave Mode */
-#define SPI_MR_MSTR                 (_U(0x1) << SPI_MR_MSTR_Pos)
-#define   SPI_MR_MSTR_0_Val               _U(0x0)   /**< \brief (SPI_MR) SPI is in Slave mode. */
-#define   SPI_MR_MSTR_1_Val               _U(0x1)   /**< \brief (SPI_MR) SPI is in Master mode. */
+#define SPI_MR_MSTR                 (_U_(0x1) << SPI_MR_MSTR_Pos)
+#define   SPI_MR_MSTR_0_Val               _U_(0x0)   /**< \brief (SPI_MR) SPI is in Slave mode. */
+#define   SPI_MR_MSTR_1_Val               _U_(0x1)   /**< \brief (SPI_MR) SPI is in Master mode. */
 #define SPI_MR_MSTR_0               (SPI_MR_MSTR_0_Val             << SPI_MR_MSTR_Pos)
 #define SPI_MR_MSTR_1               (SPI_MR_MSTR_1_Val             << SPI_MR_MSTR_Pos)
 #define SPI_MR_PS_Pos               1            /**< \brief (SPI_MR) Peripheral Select */
-#define SPI_MR_PS                   (_U(0x1) << SPI_MR_PS_Pos)
-#define   SPI_MR_PS_0_Val                 _U(0x0)   /**< \brief (SPI_MR) Fixed Peripheral Select. */
-#define   SPI_MR_PS_1_Val                 _U(0x1)   /**< \brief (SPI_MR) Variable Peripheral Select. */
+#define SPI_MR_PS                   (_U_(0x1) << SPI_MR_PS_Pos)
+#define   SPI_MR_PS_0_Val                 _U_(0x0)   /**< \brief (SPI_MR) Fixed Peripheral Select. */
+#define   SPI_MR_PS_1_Val                 _U_(0x1)   /**< \brief (SPI_MR) Variable Peripheral Select. */
 #define SPI_MR_PS_0                 (SPI_MR_PS_0_Val               << SPI_MR_PS_Pos)
 #define SPI_MR_PS_1                 (SPI_MR_PS_1_Val               << SPI_MR_PS_Pos)
 #define SPI_MR_PCSDEC_Pos           2            /**< \brief (SPI_MR) Chip Select Decode */
-#define SPI_MR_PCSDEC               (_U(0x1) << SPI_MR_PCSDEC_Pos)
-#define   SPI_MR_PCSDEC_0_Val             _U(0x0)   /**< \brief (SPI_MR) The chip selects are directly connected to a peripheral device. */
-#define   SPI_MR_PCSDEC_1_Val             _U(0x1)   /**< \brief (SPI_MR) The four chip select lines are connected to a 4- to 16-bit decoder.When PCSDEC equals one, up to 15 Chip Select signals can be generated with the four lines using an external 4- to 16-bitdecoder. The Chip Select Registers define the characteristics of the 16 chip selects according to the following rules:CSR0 defines peripheral chip select signals 0 to 3.CSR1 defines peripheral chip select signals 4 to 7.CSR2 defines peripheral chip select signals 8 to 11.CSR3 defines peripheral chip select signals 12 to 15. */
+#define SPI_MR_PCSDEC               (_U_(0x1) << SPI_MR_PCSDEC_Pos)
+#define   SPI_MR_PCSDEC_0_Val             _U_(0x0)   /**< \brief (SPI_MR) The chip selects are directly connected to a peripheral device. */
+#define   SPI_MR_PCSDEC_1_Val             _U_(0x1)   /**< \brief (SPI_MR) The four chip select lines are connected to a 4- to 16-bit decoder.When PCSDEC equals one, up to 15 Chip Select signals can be generated with the four lines using an external 4- to 16-bitdecoder. The Chip Select Registers define the characteristics of the 16 chip selects according to the following rules:CSR0 defines peripheral chip select signals 0 to 3.CSR1 defines peripheral chip select signals 4 to 7.CSR2 defines peripheral chip select signals 8 to 11.CSR3 defines peripheral chip select signals 12 to 15. */
 #define SPI_MR_PCSDEC_0             (SPI_MR_PCSDEC_0_Val           << SPI_MR_PCSDEC_Pos)
 #define SPI_MR_PCSDEC_1             (SPI_MR_PCSDEC_1_Val           << SPI_MR_PCSDEC_Pos)
 #define SPI_MR_MODFDIS_Pos          4            /**< \brief (SPI_MR) Mode Fault Detection */
-#define SPI_MR_MODFDIS              (_U(0x1) << SPI_MR_MODFDIS_Pos)
-#define   SPI_MR_MODFDIS_0_Val            _U(0x0)   /**< \brief (SPI_MR) Mode fault detection is enabled. */
-#define   SPI_MR_MODFDIS_1_Val            _U(0x1)   /**< \brief (SPI_MR) Mode fault detection is disabled. */
+#define SPI_MR_MODFDIS              (_U_(0x1) << SPI_MR_MODFDIS_Pos)
+#define   SPI_MR_MODFDIS_0_Val            _U_(0x0)   /**< \brief (SPI_MR) Mode fault detection is enabled. */
+#define   SPI_MR_MODFDIS_1_Val            _U_(0x1)   /**< \brief (SPI_MR) Mode fault detection is disabled. */
 #define SPI_MR_MODFDIS_0            (SPI_MR_MODFDIS_0_Val          << SPI_MR_MODFDIS_Pos)
 #define SPI_MR_MODFDIS_1            (SPI_MR_MODFDIS_1_Val          << SPI_MR_MODFDIS_Pos)
 #define SPI_MR_WDRBT_Pos            5            /**< \brief (SPI_MR) wait data read before transfer */
-#define SPI_MR_WDRBT                (_U(0x1) << SPI_MR_WDRBT_Pos)
+#define SPI_MR_WDRBT                (_U_(0x1) << SPI_MR_WDRBT_Pos)
 #define SPI_MR_RXFIFOEN_Pos         6            /**< \brief (SPI_MR) FIFO in Reception Enable */
-#define SPI_MR_RXFIFOEN             (_U(0x1) << SPI_MR_RXFIFOEN_Pos)
+#define SPI_MR_RXFIFOEN             (_U_(0x1) << SPI_MR_RXFIFOEN_Pos)
 #define SPI_MR_LLB_Pos              7            /**< \brief (SPI_MR) Local Loopback Enable */
-#define SPI_MR_LLB                  (_U(0x1) << SPI_MR_LLB_Pos)
-#define   SPI_MR_LLB_0_Val                _U(0x0)   /**< \brief (SPI_MR) Local loopback path disabled. */
-#define   SPI_MR_LLB_1_Val                _U(0x1)   /**< \brief (SPI_MR) Local loopback path enabled.LLB controls the local loopback on the data serializer for testing in Master Mode only. */
+#define SPI_MR_LLB                  (_U_(0x1) << SPI_MR_LLB_Pos)
+#define   SPI_MR_LLB_0_Val                _U_(0x0)   /**< \brief (SPI_MR) Local loopback path disabled. */
+#define   SPI_MR_LLB_1_Val                _U_(0x1)   /**< \brief (SPI_MR) Local loopback path enabled.LLB controls the local loopback on the data serializer for testing in Master Mode only. */
 #define SPI_MR_LLB_0                (SPI_MR_LLB_0_Val              << SPI_MR_LLB_Pos)
 #define SPI_MR_LLB_1                (SPI_MR_LLB_1_Val              << SPI_MR_LLB_Pos)
 #define SPI_MR_PCS_Pos              16           /**< \brief (SPI_MR) Peripheral Chip Select */
-#define SPI_MR_PCS_Msk              (_U(0xF) << SPI_MR_PCS_Pos)
+#define SPI_MR_PCS_Msk              (_U_(0xF) << SPI_MR_PCS_Pos)
 #define SPI_MR_PCS(value)           (SPI_MR_PCS_Msk & ((value) << SPI_MR_PCS_Pos))
 #define SPI_MR_DLYBCS_Pos           24           /**< \brief (SPI_MR) Delay Between Chip Selects */
-#define SPI_MR_DLYBCS_Msk           (_U(0xFF) << SPI_MR_DLYBCS_Pos)
+#define SPI_MR_DLYBCS_Msk           (_U_(0xFF) << SPI_MR_DLYBCS_Pos)
 #define SPI_MR_DLYBCS(value)        (SPI_MR_DLYBCS_Msk & ((value) << SPI_MR_DLYBCS_Pos))
-#define SPI_MR_MASK                 _U(0xFF0F00F7) /**< \brief (SPI_MR) MASK Register */
+#define SPI_MR_MASK                 _U_(0xFF0F00F7) /**< \brief (SPI_MR) MASK Register */
 
 /* -------- SPI_RDR : (SPI Offset: 0x08) (R/  32) Receive Data Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -165,15 +165,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_RDR_OFFSET              0x08         /**< \brief (SPI_RDR offset) Receive Data Register */
-#define SPI_RDR_RESETVALUE          _U(0x00000000); /**< \brief (SPI_RDR reset_value) Receive Data Register */
+#define SPI_RDR_RESETVALUE          _U_(0x00000000); /**< \brief (SPI_RDR reset_value) Receive Data Register */
 
 #define SPI_RDR_RD_Pos              0            /**< \brief (SPI_RDR) Receive Data */
-#define SPI_RDR_RD_Msk              (_U(0xFFFF) << SPI_RDR_RD_Pos)
+#define SPI_RDR_RD_Msk              (_U_(0xFFFF) << SPI_RDR_RD_Pos)
 #define SPI_RDR_RD(value)           (SPI_RDR_RD_Msk & ((value) << SPI_RDR_RD_Pos))
 #define SPI_RDR_PCS_Pos             16           /**< \brief (SPI_RDR) Peripheral Chip Select */
-#define SPI_RDR_PCS_Msk             (_U(0xF) << SPI_RDR_PCS_Pos)
+#define SPI_RDR_PCS_Msk             (_U_(0xF) << SPI_RDR_PCS_Pos)
 #define SPI_RDR_PCS(value)          (SPI_RDR_PCS_Msk & ((value) << SPI_RDR_PCS_Pos))
-#define SPI_RDR_MASK                _U(0x000FFFFF) /**< \brief (SPI_RDR) MASK Register */
+#define SPI_RDR_MASK                _U_(0x000FFFFF) /**< \brief (SPI_RDR) MASK Register */
 
 /* -------- SPI_TDR : (SPI Offset: 0x0C) ( /W 32) Transmit Data Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -190,21 +190,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_TDR_OFFSET              0x0C         /**< \brief (SPI_TDR offset) Transmit Data Register */
-#define SPI_TDR_RESETVALUE          _U(0x00000000); /**< \brief (SPI_TDR reset_value) Transmit Data Register */
+#define SPI_TDR_RESETVALUE          _U_(0x00000000); /**< \brief (SPI_TDR reset_value) Transmit Data Register */
 
 #define SPI_TDR_TD_Pos              0            /**< \brief (SPI_TDR) Transmit Data */
-#define SPI_TDR_TD_Msk              (_U(0xFFFF) << SPI_TDR_TD_Pos)
+#define SPI_TDR_TD_Msk              (_U_(0xFFFF) << SPI_TDR_TD_Pos)
 #define SPI_TDR_TD(value)           (SPI_TDR_TD_Msk & ((value) << SPI_TDR_TD_Pos))
 #define SPI_TDR_PCS_Pos             16           /**< \brief (SPI_TDR) Peripheral Chip Select */
-#define SPI_TDR_PCS_Msk             (_U(0xF) << SPI_TDR_PCS_Pos)
+#define SPI_TDR_PCS_Msk             (_U_(0xF) << SPI_TDR_PCS_Pos)
 #define SPI_TDR_PCS(value)          (SPI_TDR_PCS_Msk & ((value) << SPI_TDR_PCS_Pos))
 #define SPI_TDR_LASTXFER_Pos        24           /**< \brief (SPI_TDR) Last Transfer */
-#define SPI_TDR_LASTXFER            (_U(0x1) << SPI_TDR_LASTXFER_Pos)
-#define   SPI_TDR_LASTXFER_0_Val          _U(0x0)   /**< \brief (SPI_TDR) No effect. */
-#define   SPI_TDR_LASTXFER_1_Val          _U(0x1)   /**< \brief (SPI_TDR) The current NPCS will be deasserted after the character written in TD has been transferred. When CSAAT is set, thisallows to close the communication with the current serial peripheral by raising the corresponding NPCS line as soon as TDtransfer has completed. */
+#define SPI_TDR_LASTXFER            (_U_(0x1) << SPI_TDR_LASTXFER_Pos)
+#define   SPI_TDR_LASTXFER_0_Val          _U_(0x0)   /**< \brief (SPI_TDR) No effect. */
+#define   SPI_TDR_LASTXFER_1_Val          _U_(0x1)   /**< \brief (SPI_TDR) The current NPCS will be deasserted after the character written in TD has been transferred. When CSAAT is set, thisallows to close the communication with the current serial peripheral by raising the corresponding NPCS line as soon as TDtransfer has completed. */
 #define SPI_TDR_LASTXFER_0          (SPI_TDR_LASTXFER_0_Val        << SPI_TDR_LASTXFER_Pos)
 #define SPI_TDR_LASTXFER_1          (SPI_TDR_LASTXFER_1_Val        << SPI_TDR_LASTXFER_Pos)
-#define SPI_TDR_MASK                _U(0x010FFFFF) /**< \brief (SPI_TDR) MASK Register */
+#define SPI_TDR_MASK                _U_(0x010FFFFF) /**< \brief (SPI_TDR) MASK Register */
 
 /* -------- SPI_SR : (SPI Offset: 0x10) (R/  32) Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -230,77 +230,77 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_SR_OFFSET               0x10         /**< \brief (SPI_SR offset) Status Register */
-#define SPI_SR_RESETVALUE           _U(0x000000F0); /**< \brief (SPI_SR reset_value) Status Register */
+#define SPI_SR_RESETVALUE           _U_(0x000000F0); /**< \brief (SPI_SR reset_value) Status Register */
 
 #define SPI_SR_RDRF_Pos             0            /**< \brief (SPI_SR) Receive Data Register Full */
-#define SPI_SR_RDRF                 (_U(0x1) << SPI_SR_RDRF_Pos)
-#define   SPI_SR_RDRF_0_Val               _U(0x0)   /**< \brief (SPI_SR) No data has been received since the last read of RDR */
-#define   SPI_SR_RDRF_1_Val               _U(0x1)   /**< \brief (SPI_SR) Data has been received and the received data has been transferred from the serializer to RDR since the last readof RDR. */
+#define SPI_SR_RDRF                 (_U_(0x1) << SPI_SR_RDRF_Pos)
+#define   SPI_SR_RDRF_0_Val               _U_(0x0)   /**< \brief (SPI_SR) No data has been received since the last read of RDR */
+#define   SPI_SR_RDRF_1_Val               _U_(0x1)   /**< \brief (SPI_SR) Data has been received and the received data has been transferred from the serializer to RDR since the last readof RDR. */
 #define SPI_SR_RDRF_0               (SPI_SR_RDRF_0_Val             << SPI_SR_RDRF_Pos)
 #define SPI_SR_RDRF_1               (SPI_SR_RDRF_1_Val             << SPI_SR_RDRF_Pos)
 #define SPI_SR_TDRE_Pos             1            /**< \brief (SPI_SR) Transmit Data Register Empty */
-#define SPI_SR_TDRE                 (_U(0x1) << SPI_SR_TDRE_Pos)
-#define   SPI_SR_TDRE_0_Val               _U(0x0)   /**< \brief (SPI_SR) Data has been written to TDR and not yet transferred to the serializer. */
-#define   SPI_SR_TDRE_1_Val               _U(0x1)   /**< \brief (SPI_SR) The last data written in the Transmit Data Register has been transferred to the serializer.TDRE equals zero when the SPI is disabled or at reset. The SPI enable command sets this bit to one. */
+#define SPI_SR_TDRE                 (_U_(0x1) << SPI_SR_TDRE_Pos)
+#define   SPI_SR_TDRE_0_Val               _U_(0x0)   /**< \brief (SPI_SR) Data has been written to TDR and not yet transferred to the serializer. */
+#define   SPI_SR_TDRE_1_Val               _U_(0x1)   /**< \brief (SPI_SR) The last data written in the Transmit Data Register has been transferred to the serializer.TDRE equals zero when the SPI is disabled or at reset. The SPI enable command sets this bit to one. */
 #define SPI_SR_TDRE_0               (SPI_SR_TDRE_0_Val             << SPI_SR_TDRE_Pos)
 #define SPI_SR_TDRE_1               (SPI_SR_TDRE_1_Val             << SPI_SR_TDRE_Pos)
 #define SPI_SR_MODF_Pos             2            /**< \brief (SPI_SR) Mode Fault Error */
-#define SPI_SR_MODF                 (_U(0x1) << SPI_SR_MODF_Pos)
-#define   SPI_SR_MODF_0_Val               _U(0x0)   /**< \brief (SPI_SR) No Mode Fault has been detected since the last read of SR. */
-#define   SPI_SR_MODF_1_Val               _U(0x1)   /**< \brief (SPI_SR) A Mode Fault occurred since the last read of the SR. */
+#define SPI_SR_MODF                 (_U_(0x1) << SPI_SR_MODF_Pos)
+#define   SPI_SR_MODF_0_Val               _U_(0x0)   /**< \brief (SPI_SR) No Mode Fault has been detected since the last read of SR. */
+#define   SPI_SR_MODF_1_Val               _U_(0x1)   /**< \brief (SPI_SR) A Mode Fault occurred since the last read of the SR. */
 #define SPI_SR_MODF_0               (SPI_SR_MODF_0_Val             << SPI_SR_MODF_Pos)
 #define SPI_SR_MODF_1               (SPI_SR_MODF_1_Val             << SPI_SR_MODF_Pos)
 #define SPI_SR_OVRES_Pos            3            /**< \brief (SPI_SR) Overrun Error Status */
-#define SPI_SR_OVRES                (_U(0x1) << SPI_SR_OVRES_Pos)
-#define   SPI_SR_OVRES_0_Val              _U(0x0)   /**< \brief (SPI_SR) No overrun has been detected since the last read of SR. */
-#define   SPI_SR_OVRES_1_Val              _U(0x1)   /**< \brief (SPI_SR) An overrun has occurred since the last read of SR. */
+#define SPI_SR_OVRES                (_U_(0x1) << SPI_SR_OVRES_Pos)
+#define   SPI_SR_OVRES_0_Val              _U_(0x0)   /**< \brief (SPI_SR) No overrun has been detected since the last read of SR. */
+#define   SPI_SR_OVRES_1_Val              _U_(0x1)   /**< \brief (SPI_SR) An overrun has occurred since the last read of SR. */
 #define SPI_SR_OVRES_0              (SPI_SR_OVRES_0_Val            << SPI_SR_OVRES_Pos)
 #define SPI_SR_OVRES_1              (SPI_SR_OVRES_1_Val            << SPI_SR_OVRES_Pos)
 #define SPI_SR_ENDRX_Pos            4            /**< \brief (SPI_SR) End of RX buffer */
-#define SPI_SR_ENDRX                (_U(0x1) << SPI_SR_ENDRX_Pos)
-#define   SPI_SR_ENDRX_0_Val              _U(0x0)   /**< \brief (SPI_SR) The Receive Counter Register has not reached 0 since the last write in RCR or RNCR. */
-#define   SPI_SR_ENDRX_1_Val              _U(0x1)   /**< \brief (SPI_SR) The Receive Counter Register has reached 0 since the last write in RCR or RNCR. */
+#define SPI_SR_ENDRX                (_U_(0x1) << SPI_SR_ENDRX_Pos)
+#define   SPI_SR_ENDRX_0_Val              _U_(0x0)   /**< \brief (SPI_SR) The Receive Counter Register has not reached 0 since the last write in RCR or RNCR. */
+#define   SPI_SR_ENDRX_1_Val              _U_(0x1)   /**< \brief (SPI_SR) The Receive Counter Register has reached 0 since the last write in RCR or RNCR. */
 #define SPI_SR_ENDRX_0              (SPI_SR_ENDRX_0_Val            << SPI_SR_ENDRX_Pos)
 #define SPI_SR_ENDRX_1              (SPI_SR_ENDRX_1_Val            << SPI_SR_ENDRX_Pos)
 #define SPI_SR_ENDTX_Pos            5            /**< \brief (SPI_SR) End of TX buffer */
-#define SPI_SR_ENDTX                (_U(0x1) << SPI_SR_ENDTX_Pos)
-#define   SPI_SR_ENDTX_0_Val              _U(0x0)   /**< \brief (SPI_SR) The Transmit Counter Register has not reached 0 since the last write in TCR or TNCR. */
-#define   SPI_SR_ENDTX_1_Val              _U(0x1)   /**< \brief (SPI_SR) The Transmit Counter Register has reached 0 since the last write in TCR or TNCR. */
+#define SPI_SR_ENDTX                (_U_(0x1) << SPI_SR_ENDTX_Pos)
+#define   SPI_SR_ENDTX_0_Val              _U_(0x0)   /**< \brief (SPI_SR) The Transmit Counter Register has not reached 0 since the last write in TCR or TNCR. */
+#define   SPI_SR_ENDTX_1_Val              _U_(0x1)   /**< \brief (SPI_SR) The Transmit Counter Register has reached 0 since the last write in TCR or TNCR. */
 #define SPI_SR_ENDTX_0              (SPI_SR_ENDTX_0_Val            << SPI_SR_ENDTX_Pos)
 #define SPI_SR_ENDTX_1              (SPI_SR_ENDTX_1_Val            << SPI_SR_ENDTX_Pos)
 #define SPI_SR_RXBUFF_Pos           6            /**< \brief (SPI_SR) RX Buffer Full */
-#define SPI_SR_RXBUFF               (_U(0x1) << SPI_SR_RXBUFF_Pos)
-#define   SPI_SR_RXBUFF_0_Val             _U(0x0)   /**< \brief (SPI_SR) RCR or RNCR has a value other than 0. */
-#define   SPI_SR_RXBUFF_1_Val             _U(0x1)   /**< \brief (SPI_SR) Both RCR and RNCR has a value of 0. */
+#define SPI_SR_RXBUFF               (_U_(0x1) << SPI_SR_RXBUFF_Pos)
+#define   SPI_SR_RXBUFF_0_Val             _U_(0x0)   /**< \brief (SPI_SR) RCR or RNCR has a value other than 0. */
+#define   SPI_SR_RXBUFF_1_Val             _U_(0x1)   /**< \brief (SPI_SR) Both RCR and RNCR has a value of 0. */
 #define SPI_SR_RXBUFF_0             (SPI_SR_RXBUFF_0_Val           << SPI_SR_RXBUFF_Pos)
 #define SPI_SR_RXBUFF_1             (SPI_SR_RXBUFF_1_Val           << SPI_SR_RXBUFF_Pos)
 #define SPI_SR_TXBUFE_Pos           7            /**< \brief (SPI_SR) TX Buffer Empty */
-#define SPI_SR_TXBUFE               (_U(0x1) << SPI_SR_TXBUFE_Pos)
-#define   SPI_SR_TXBUFE_0_Val             _U(0x0)   /**< \brief (SPI_SR) TCR or TNCR has a value other than 0. */
-#define   SPI_SR_TXBUFE_1_Val             _U(0x1)   /**< \brief (SPI_SR) Both TCR and TNCR has a value of 0. */
+#define SPI_SR_TXBUFE               (_U_(0x1) << SPI_SR_TXBUFE_Pos)
+#define   SPI_SR_TXBUFE_0_Val             _U_(0x0)   /**< \brief (SPI_SR) TCR or TNCR has a value other than 0. */
+#define   SPI_SR_TXBUFE_1_Val             _U_(0x1)   /**< \brief (SPI_SR) Both TCR and TNCR has a value of 0. */
 #define SPI_SR_TXBUFE_0             (SPI_SR_TXBUFE_0_Val           << SPI_SR_TXBUFE_Pos)
 #define SPI_SR_TXBUFE_1             (SPI_SR_TXBUFE_1_Val           << SPI_SR_TXBUFE_Pos)
 #define SPI_SR_NSSR_Pos             8            /**< \brief (SPI_SR) NSS Rising */
-#define SPI_SR_NSSR                 (_U(0x1) << SPI_SR_NSSR_Pos)
-#define   SPI_SR_NSSR_0_Val               _U(0x0)   /**< \brief (SPI_SR) No rising edge detected on NSS pin since last read. */
-#define   SPI_SR_NSSR_1_Val               _U(0x1)   /**< \brief (SPI_SR) A rising edge occurred on NSS pin since last read. */
+#define SPI_SR_NSSR                 (_U_(0x1) << SPI_SR_NSSR_Pos)
+#define   SPI_SR_NSSR_0_Val               _U_(0x0)   /**< \brief (SPI_SR) No rising edge detected on NSS pin since last read. */
+#define   SPI_SR_NSSR_1_Val               _U_(0x1)   /**< \brief (SPI_SR) A rising edge occurred on NSS pin since last read. */
 #define SPI_SR_NSSR_0               (SPI_SR_NSSR_0_Val             << SPI_SR_NSSR_Pos)
 #define SPI_SR_NSSR_1               (SPI_SR_NSSR_1_Val             << SPI_SR_NSSR_Pos)
 #define SPI_SR_TXEMPTY_Pos          9            /**< \brief (SPI_SR) Transmission Registers Empty */
-#define SPI_SR_TXEMPTY              (_U(0x1) << SPI_SR_TXEMPTY_Pos)
-#define   SPI_SR_TXEMPTY_0_Val            _U(0x0)   /**< \brief (SPI_SR) As soon as data is written in TDR. */
-#define   SPI_SR_TXEMPTY_1_Val            _U(0x1)   /**< \brief (SPI_SR) TDR and internal shifter are empty. If a transfer delay has been defined, TXEMPTY is set after the completion ofsuch delay. */
+#define SPI_SR_TXEMPTY              (_U_(0x1) << SPI_SR_TXEMPTY_Pos)
+#define   SPI_SR_TXEMPTY_0_Val            _U_(0x0)   /**< \brief (SPI_SR) As soon as data is written in TDR. */
+#define   SPI_SR_TXEMPTY_1_Val            _U_(0x1)   /**< \brief (SPI_SR) TDR and internal shifter are empty. If a transfer delay has been defined, TXEMPTY is set after the completion ofsuch delay. */
 #define SPI_SR_TXEMPTY_0            (SPI_SR_TXEMPTY_0_Val          << SPI_SR_TXEMPTY_Pos)
 #define SPI_SR_TXEMPTY_1            (SPI_SR_TXEMPTY_1_Val          << SPI_SR_TXEMPTY_Pos)
 #define SPI_SR_UNDES_Pos            10           /**< \brief (SPI_SR) Underrun Error Status (Slave Mode Only) */
-#define SPI_SR_UNDES                (_U(0x1) << SPI_SR_UNDES_Pos)
+#define SPI_SR_UNDES                (_U_(0x1) << SPI_SR_UNDES_Pos)
 #define SPI_SR_SPIENS_Pos           16           /**< \brief (SPI_SR) SPI Enable Status */
-#define SPI_SR_SPIENS               (_U(0x1) << SPI_SR_SPIENS_Pos)
-#define   SPI_SR_SPIENS_0_Val             _U(0x0)   /**< \brief (SPI_SR) SPI is disabled. */
-#define   SPI_SR_SPIENS_1_Val             _U(0x1)   /**< \brief (SPI_SR) SPI is enabled. */
+#define SPI_SR_SPIENS               (_U_(0x1) << SPI_SR_SPIENS_Pos)
+#define   SPI_SR_SPIENS_0_Val             _U_(0x0)   /**< \brief (SPI_SR) SPI is disabled. */
+#define   SPI_SR_SPIENS_1_Val             _U_(0x1)   /**< \brief (SPI_SR) SPI is enabled. */
 #define SPI_SR_SPIENS_0             (SPI_SR_SPIENS_0_Val           << SPI_SR_SPIENS_Pos)
 #define SPI_SR_SPIENS_1             (SPI_SR_SPIENS_1_Val           << SPI_SR_SPIENS_Pos)
-#define SPI_SR_MASK                 _U(0x000107FF) /**< \brief (SPI_SR) MASK Register */
+#define SPI_SR_MASK                 _U_(0x000107FF) /**< \brief (SPI_SR) MASK Register */
 
 /* -------- SPI_IER : (SPI Offset: 0x14) ( /W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -324,71 +324,71 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_IER_OFFSET              0x14         /**< \brief (SPI_IER offset) Interrupt Enable Register */
-#define SPI_IER_RESETVALUE          _U(0x00000000); /**< \brief (SPI_IER reset_value) Interrupt Enable Register */
+#define SPI_IER_RESETVALUE          _U_(0x00000000); /**< \brief (SPI_IER reset_value) Interrupt Enable Register */
 
 #define SPI_IER_RDRF_Pos            0            /**< \brief (SPI_IER) Receive Data Register Full Interrupt Enable */
-#define SPI_IER_RDRF                (_U(0x1) << SPI_IER_RDRF_Pos)
-#define   SPI_IER_RDRF_0_Val              _U(0x0)   /**< \brief (SPI_IER) No effect. */
-#define   SPI_IER_RDRF_1_Val              _U(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
+#define SPI_IER_RDRF                (_U_(0x1) << SPI_IER_RDRF_Pos)
+#define   SPI_IER_RDRF_0_Val              _U_(0x0)   /**< \brief (SPI_IER) No effect. */
+#define   SPI_IER_RDRF_1_Val              _U_(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
 #define SPI_IER_RDRF_0              (SPI_IER_RDRF_0_Val            << SPI_IER_RDRF_Pos)
 #define SPI_IER_RDRF_1              (SPI_IER_RDRF_1_Val            << SPI_IER_RDRF_Pos)
 #define SPI_IER_TDRE_Pos            1            /**< \brief (SPI_IER) Transmit Data Register Empty Interrupt Enable */
-#define SPI_IER_TDRE                (_U(0x1) << SPI_IER_TDRE_Pos)
-#define   SPI_IER_TDRE_0_Val              _U(0x0)   /**< \brief (SPI_IER) No effect. */
-#define   SPI_IER_TDRE_1_Val              _U(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
+#define SPI_IER_TDRE                (_U_(0x1) << SPI_IER_TDRE_Pos)
+#define   SPI_IER_TDRE_0_Val              _U_(0x0)   /**< \brief (SPI_IER) No effect. */
+#define   SPI_IER_TDRE_1_Val              _U_(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
 #define SPI_IER_TDRE_0              (SPI_IER_TDRE_0_Val            << SPI_IER_TDRE_Pos)
 #define SPI_IER_TDRE_1              (SPI_IER_TDRE_1_Val            << SPI_IER_TDRE_Pos)
 #define SPI_IER_MODF_Pos            2            /**< \brief (SPI_IER) Mode Fault Error Interrupt Enable */
-#define SPI_IER_MODF                (_U(0x1) << SPI_IER_MODF_Pos)
-#define   SPI_IER_MODF_0_Val              _U(0x0)   /**< \brief (SPI_IER) No effect. */
-#define   SPI_IER_MODF_1_Val              _U(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
+#define SPI_IER_MODF                (_U_(0x1) << SPI_IER_MODF_Pos)
+#define   SPI_IER_MODF_0_Val              _U_(0x0)   /**< \brief (SPI_IER) No effect. */
+#define   SPI_IER_MODF_1_Val              _U_(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
 #define SPI_IER_MODF_0              (SPI_IER_MODF_0_Val            << SPI_IER_MODF_Pos)
 #define SPI_IER_MODF_1              (SPI_IER_MODF_1_Val            << SPI_IER_MODF_Pos)
 #define SPI_IER_OVRES_Pos           3            /**< \brief (SPI_IER) Overrun Error Interrupt Enable */
-#define SPI_IER_OVRES               (_U(0x1) << SPI_IER_OVRES_Pos)
-#define   SPI_IER_OVRES_0_Val             _U(0x0)   /**< \brief (SPI_IER) No effect. */
-#define   SPI_IER_OVRES_1_Val             _U(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
+#define SPI_IER_OVRES               (_U_(0x1) << SPI_IER_OVRES_Pos)
+#define   SPI_IER_OVRES_0_Val             _U_(0x0)   /**< \brief (SPI_IER) No effect. */
+#define   SPI_IER_OVRES_1_Val             _U_(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
 #define SPI_IER_OVRES_0             (SPI_IER_OVRES_0_Val           << SPI_IER_OVRES_Pos)
 #define SPI_IER_OVRES_1             (SPI_IER_OVRES_1_Val           << SPI_IER_OVRES_Pos)
 #define SPI_IER_ENDRX_Pos           4            /**< \brief (SPI_IER) End of Receive Buffer Interrupt Enable */
-#define SPI_IER_ENDRX               (_U(0x1) << SPI_IER_ENDRX_Pos)
-#define   SPI_IER_ENDRX_0_Val             _U(0x0)   /**< \brief (SPI_IER) No effect. */
-#define   SPI_IER_ENDRX_1_Val             _U(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
+#define SPI_IER_ENDRX               (_U_(0x1) << SPI_IER_ENDRX_Pos)
+#define   SPI_IER_ENDRX_0_Val             _U_(0x0)   /**< \brief (SPI_IER) No effect. */
+#define   SPI_IER_ENDRX_1_Val             _U_(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
 #define SPI_IER_ENDRX_0             (SPI_IER_ENDRX_0_Val           << SPI_IER_ENDRX_Pos)
 #define SPI_IER_ENDRX_1             (SPI_IER_ENDRX_1_Val           << SPI_IER_ENDRX_Pos)
 #define SPI_IER_ENDTX_Pos           5            /**< \brief (SPI_IER) End of Transmit Buffer Interrupt Enable */
-#define SPI_IER_ENDTX               (_U(0x1) << SPI_IER_ENDTX_Pos)
-#define   SPI_IER_ENDTX_0_Val             _U(0x0)   /**< \brief (SPI_IER) No effect. */
-#define   SPI_IER_ENDTX_1_Val             _U(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
+#define SPI_IER_ENDTX               (_U_(0x1) << SPI_IER_ENDTX_Pos)
+#define   SPI_IER_ENDTX_0_Val             _U_(0x0)   /**< \brief (SPI_IER) No effect. */
+#define   SPI_IER_ENDTX_1_Val             _U_(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
 #define SPI_IER_ENDTX_0             (SPI_IER_ENDTX_0_Val           << SPI_IER_ENDTX_Pos)
 #define SPI_IER_ENDTX_1             (SPI_IER_ENDTX_1_Val           << SPI_IER_ENDTX_Pos)
 #define SPI_IER_RXBUFF_Pos          6            /**< \brief (SPI_IER) Receive Buffer Full Interrupt Enable */
-#define SPI_IER_RXBUFF              (_U(0x1) << SPI_IER_RXBUFF_Pos)
-#define   SPI_IER_RXBUFF_0_Val            _U(0x0)   /**< \brief (SPI_IER) No effect. */
-#define   SPI_IER_RXBUFF_1_Val            _U(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
+#define SPI_IER_RXBUFF              (_U_(0x1) << SPI_IER_RXBUFF_Pos)
+#define   SPI_IER_RXBUFF_0_Val            _U_(0x0)   /**< \brief (SPI_IER) No effect. */
+#define   SPI_IER_RXBUFF_1_Val            _U_(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
 #define SPI_IER_RXBUFF_0            (SPI_IER_RXBUFF_0_Val          << SPI_IER_RXBUFF_Pos)
 #define SPI_IER_RXBUFF_1            (SPI_IER_RXBUFF_1_Val          << SPI_IER_RXBUFF_Pos)
 #define SPI_IER_TXBUFE_Pos          7            /**< \brief (SPI_IER) Transmit Buffer Empty Interrupt Enable */
-#define SPI_IER_TXBUFE              (_U(0x1) << SPI_IER_TXBUFE_Pos)
-#define   SPI_IER_TXBUFE_0_Val            _U(0x0)   /**< \brief (SPI_IER) No effect. */
-#define   SPI_IER_TXBUFE_1_Val            _U(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
+#define SPI_IER_TXBUFE              (_U_(0x1) << SPI_IER_TXBUFE_Pos)
+#define   SPI_IER_TXBUFE_0_Val            _U_(0x0)   /**< \brief (SPI_IER) No effect. */
+#define   SPI_IER_TXBUFE_1_Val            _U_(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
 #define SPI_IER_TXBUFE_0            (SPI_IER_TXBUFE_0_Val          << SPI_IER_TXBUFE_Pos)
 #define SPI_IER_TXBUFE_1            (SPI_IER_TXBUFE_1_Val          << SPI_IER_TXBUFE_Pos)
 #define SPI_IER_NSSR_Pos            8            /**< \brief (SPI_IER) NSS Rising Interrupt Enable */
-#define SPI_IER_NSSR                (_U(0x1) << SPI_IER_NSSR_Pos)
-#define   SPI_IER_NSSR_0_Val              _U(0x0)   /**< \brief (SPI_IER) No effect. */
-#define   SPI_IER_NSSR_1_Val              _U(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
+#define SPI_IER_NSSR                (_U_(0x1) << SPI_IER_NSSR_Pos)
+#define   SPI_IER_NSSR_0_Val              _U_(0x0)   /**< \brief (SPI_IER) No effect. */
+#define   SPI_IER_NSSR_1_Val              _U_(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
 #define SPI_IER_NSSR_0              (SPI_IER_NSSR_0_Val            << SPI_IER_NSSR_Pos)
 #define SPI_IER_NSSR_1              (SPI_IER_NSSR_1_Val            << SPI_IER_NSSR_Pos)
 #define SPI_IER_TXEMPTY_Pos         9            /**< \brief (SPI_IER) Transmission Registers Empty Enable */
-#define SPI_IER_TXEMPTY             (_U(0x1) << SPI_IER_TXEMPTY_Pos)
-#define   SPI_IER_TXEMPTY_0_Val           _U(0x0)   /**< \brief (SPI_IER) No effect. */
-#define   SPI_IER_TXEMPTY_1_Val           _U(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
+#define SPI_IER_TXEMPTY             (_U_(0x1) << SPI_IER_TXEMPTY_Pos)
+#define   SPI_IER_TXEMPTY_0_Val           _U_(0x0)   /**< \brief (SPI_IER) No effect. */
+#define   SPI_IER_TXEMPTY_1_Val           _U_(0x1)   /**< \brief (SPI_IER) Enables the corresponding interrupt. */
 #define SPI_IER_TXEMPTY_0           (SPI_IER_TXEMPTY_0_Val         << SPI_IER_TXEMPTY_Pos)
 #define SPI_IER_TXEMPTY_1           (SPI_IER_TXEMPTY_1_Val         << SPI_IER_TXEMPTY_Pos)
 #define SPI_IER_UNDES_Pos           10           /**< \brief (SPI_IER) Underrun Error Interrupt Enable */
-#define SPI_IER_UNDES               (_U(0x1) << SPI_IER_UNDES_Pos)
-#define SPI_IER_MASK                _U(0x000007FF) /**< \brief (SPI_IER) MASK Register */
+#define SPI_IER_UNDES               (_U_(0x1) << SPI_IER_UNDES_Pos)
+#define SPI_IER_MASK                _U_(0x000007FF) /**< \brief (SPI_IER) MASK Register */
 
 /* -------- SPI_IDR : (SPI Offset: 0x18) ( /W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -412,71 +412,71 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_IDR_OFFSET              0x18         /**< \brief (SPI_IDR offset) Interrupt Disable Register */
-#define SPI_IDR_RESETVALUE          _U(0x00000000); /**< \brief (SPI_IDR reset_value) Interrupt Disable Register */
+#define SPI_IDR_RESETVALUE          _U_(0x00000000); /**< \brief (SPI_IDR reset_value) Interrupt Disable Register */
 
 #define SPI_IDR_RDRF_Pos            0            /**< \brief (SPI_IDR) Receive Data Register Full Interrupt Disable */
-#define SPI_IDR_RDRF                (_U(0x1) << SPI_IDR_RDRF_Pos)
-#define   SPI_IDR_RDRF_0_Val              _U(0x0)   /**< \brief (SPI_IDR) No effect. */
-#define   SPI_IDR_RDRF_1_Val              _U(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
+#define SPI_IDR_RDRF                (_U_(0x1) << SPI_IDR_RDRF_Pos)
+#define   SPI_IDR_RDRF_0_Val              _U_(0x0)   /**< \brief (SPI_IDR) No effect. */
+#define   SPI_IDR_RDRF_1_Val              _U_(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
 #define SPI_IDR_RDRF_0              (SPI_IDR_RDRF_0_Val            << SPI_IDR_RDRF_Pos)
 #define SPI_IDR_RDRF_1              (SPI_IDR_RDRF_1_Val            << SPI_IDR_RDRF_Pos)
 #define SPI_IDR_TDRE_Pos            1            /**< \brief (SPI_IDR) Transmit Data Register Empty Interrupt Disable */
-#define SPI_IDR_TDRE                (_U(0x1) << SPI_IDR_TDRE_Pos)
-#define   SPI_IDR_TDRE_0_Val              _U(0x0)   /**< \brief (SPI_IDR) No effect. */
-#define   SPI_IDR_TDRE_1_Val              _U(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
+#define SPI_IDR_TDRE                (_U_(0x1) << SPI_IDR_TDRE_Pos)
+#define   SPI_IDR_TDRE_0_Val              _U_(0x0)   /**< \brief (SPI_IDR) No effect. */
+#define   SPI_IDR_TDRE_1_Val              _U_(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
 #define SPI_IDR_TDRE_0              (SPI_IDR_TDRE_0_Val            << SPI_IDR_TDRE_Pos)
 #define SPI_IDR_TDRE_1              (SPI_IDR_TDRE_1_Val            << SPI_IDR_TDRE_Pos)
 #define SPI_IDR_MODF_Pos            2            /**< \brief (SPI_IDR) Mode Fault Error Interrupt Disable */
-#define SPI_IDR_MODF                (_U(0x1) << SPI_IDR_MODF_Pos)
-#define   SPI_IDR_MODF_0_Val              _U(0x0)   /**< \brief (SPI_IDR) No effect. */
-#define   SPI_IDR_MODF_1_Val              _U(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
+#define SPI_IDR_MODF                (_U_(0x1) << SPI_IDR_MODF_Pos)
+#define   SPI_IDR_MODF_0_Val              _U_(0x0)   /**< \brief (SPI_IDR) No effect. */
+#define   SPI_IDR_MODF_1_Val              _U_(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
 #define SPI_IDR_MODF_0              (SPI_IDR_MODF_0_Val            << SPI_IDR_MODF_Pos)
 #define SPI_IDR_MODF_1              (SPI_IDR_MODF_1_Val            << SPI_IDR_MODF_Pos)
 #define SPI_IDR_OVRES_Pos           3            /**< \brief (SPI_IDR) Overrun Error Interrupt Disable */
-#define SPI_IDR_OVRES               (_U(0x1) << SPI_IDR_OVRES_Pos)
-#define   SPI_IDR_OVRES_0_Val             _U(0x0)   /**< \brief (SPI_IDR) No effect. */
-#define   SPI_IDR_OVRES_1_Val             _U(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
+#define SPI_IDR_OVRES               (_U_(0x1) << SPI_IDR_OVRES_Pos)
+#define   SPI_IDR_OVRES_0_Val             _U_(0x0)   /**< \brief (SPI_IDR) No effect. */
+#define   SPI_IDR_OVRES_1_Val             _U_(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
 #define SPI_IDR_OVRES_0             (SPI_IDR_OVRES_0_Val           << SPI_IDR_OVRES_Pos)
 #define SPI_IDR_OVRES_1             (SPI_IDR_OVRES_1_Val           << SPI_IDR_OVRES_Pos)
 #define SPI_IDR_ENDRX_Pos           4            /**< \brief (SPI_IDR) End of Receive Buffer Interrupt Disable */
-#define SPI_IDR_ENDRX               (_U(0x1) << SPI_IDR_ENDRX_Pos)
-#define   SPI_IDR_ENDRX_0_Val             _U(0x0)   /**< \brief (SPI_IDR) No effect. */
-#define   SPI_IDR_ENDRX_1_Val             _U(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
+#define SPI_IDR_ENDRX               (_U_(0x1) << SPI_IDR_ENDRX_Pos)
+#define   SPI_IDR_ENDRX_0_Val             _U_(0x0)   /**< \brief (SPI_IDR) No effect. */
+#define   SPI_IDR_ENDRX_1_Val             _U_(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
 #define SPI_IDR_ENDRX_0             (SPI_IDR_ENDRX_0_Val           << SPI_IDR_ENDRX_Pos)
 #define SPI_IDR_ENDRX_1             (SPI_IDR_ENDRX_1_Val           << SPI_IDR_ENDRX_Pos)
 #define SPI_IDR_ENDTX_Pos           5            /**< \brief (SPI_IDR) End of Transmit Buffer Interrupt Disable */
-#define SPI_IDR_ENDTX               (_U(0x1) << SPI_IDR_ENDTX_Pos)
-#define   SPI_IDR_ENDTX_0_Val             _U(0x0)   /**< \brief (SPI_IDR) No effect. */
-#define   SPI_IDR_ENDTX_1_Val             _U(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
+#define SPI_IDR_ENDTX               (_U_(0x1) << SPI_IDR_ENDTX_Pos)
+#define   SPI_IDR_ENDTX_0_Val             _U_(0x0)   /**< \brief (SPI_IDR) No effect. */
+#define   SPI_IDR_ENDTX_1_Val             _U_(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
 #define SPI_IDR_ENDTX_0             (SPI_IDR_ENDTX_0_Val           << SPI_IDR_ENDTX_Pos)
 #define SPI_IDR_ENDTX_1             (SPI_IDR_ENDTX_1_Val           << SPI_IDR_ENDTX_Pos)
 #define SPI_IDR_RXBUFF_Pos          6            /**< \brief (SPI_IDR) Receive Buffer Full Interrupt Disable */
-#define SPI_IDR_RXBUFF              (_U(0x1) << SPI_IDR_RXBUFF_Pos)
-#define   SPI_IDR_RXBUFF_0_Val            _U(0x0)   /**< \brief (SPI_IDR) No effect. */
-#define   SPI_IDR_RXBUFF_1_Val            _U(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
+#define SPI_IDR_RXBUFF              (_U_(0x1) << SPI_IDR_RXBUFF_Pos)
+#define   SPI_IDR_RXBUFF_0_Val            _U_(0x0)   /**< \brief (SPI_IDR) No effect. */
+#define   SPI_IDR_RXBUFF_1_Val            _U_(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
 #define SPI_IDR_RXBUFF_0            (SPI_IDR_RXBUFF_0_Val          << SPI_IDR_RXBUFF_Pos)
 #define SPI_IDR_RXBUFF_1            (SPI_IDR_RXBUFF_1_Val          << SPI_IDR_RXBUFF_Pos)
 #define SPI_IDR_TXBUFE_Pos          7            /**< \brief (SPI_IDR) Transmit Buffer Empty Interrupt Disable */
-#define SPI_IDR_TXBUFE              (_U(0x1) << SPI_IDR_TXBUFE_Pos)
-#define   SPI_IDR_TXBUFE_0_Val            _U(0x0)   /**< \brief (SPI_IDR) No effect. */
-#define   SPI_IDR_TXBUFE_1_Val            _U(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
+#define SPI_IDR_TXBUFE              (_U_(0x1) << SPI_IDR_TXBUFE_Pos)
+#define   SPI_IDR_TXBUFE_0_Val            _U_(0x0)   /**< \brief (SPI_IDR) No effect. */
+#define   SPI_IDR_TXBUFE_1_Val            _U_(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
 #define SPI_IDR_TXBUFE_0            (SPI_IDR_TXBUFE_0_Val          << SPI_IDR_TXBUFE_Pos)
 #define SPI_IDR_TXBUFE_1            (SPI_IDR_TXBUFE_1_Val          << SPI_IDR_TXBUFE_Pos)
 #define SPI_IDR_NSSR_Pos            8            /**< \brief (SPI_IDR) NSS Rising Interrupt Disable */
-#define SPI_IDR_NSSR                (_U(0x1) << SPI_IDR_NSSR_Pos)
-#define   SPI_IDR_NSSR_0_Val              _U(0x0)   /**< \brief (SPI_IDR) No effect. */
-#define   SPI_IDR_NSSR_1_Val              _U(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
+#define SPI_IDR_NSSR                (_U_(0x1) << SPI_IDR_NSSR_Pos)
+#define   SPI_IDR_NSSR_0_Val              _U_(0x0)   /**< \brief (SPI_IDR) No effect. */
+#define   SPI_IDR_NSSR_1_Val              _U_(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
 #define SPI_IDR_NSSR_0              (SPI_IDR_NSSR_0_Val            << SPI_IDR_NSSR_Pos)
 #define SPI_IDR_NSSR_1              (SPI_IDR_NSSR_1_Val            << SPI_IDR_NSSR_Pos)
 #define SPI_IDR_TXEMPTY_Pos         9            /**< \brief (SPI_IDR) Transmission Registers Empty Disable */
-#define SPI_IDR_TXEMPTY             (_U(0x1) << SPI_IDR_TXEMPTY_Pos)
-#define   SPI_IDR_TXEMPTY_0_Val           _U(0x0)   /**< \brief (SPI_IDR) No effect. */
-#define   SPI_IDR_TXEMPTY_1_Val           _U(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
+#define SPI_IDR_TXEMPTY             (_U_(0x1) << SPI_IDR_TXEMPTY_Pos)
+#define   SPI_IDR_TXEMPTY_0_Val           _U_(0x0)   /**< \brief (SPI_IDR) No effect. */
+#define   SPI_IDR_TXEMPTY_1_Val           _U_(0x1)   /**< \brief (SPI_IDR) Disables the corresponding interrupt. */
 #define SPI_IDR_TXEMPTY_0           (SPI_IDR_TXEMPTY_0_Val         << SPI_IDR_TXEMPTY_Pos)
 #define SPI_IDR_TXEMPTY_1           (SPI_IDR_TXEMPTY_1_Val         << SPI_IDR_TXEMPTY_Pos)
 #define SPI_IDR_UNDES_Pos           10           /**< \brief (SPI_IDR) Underrun Error Interrupt Disable */
-#define SPI_IDR_UNDES               (_U(0x1) << SPI_IDR_UNDES_Pos)
-#define SPI_IDR_MASK                _U(0x000007FF) /**< \brief (SPI_IDR) MASK Register */
+#define SPI_IDR_UNDES               (_U_(0x1) << SPI_IDR_UNDES_Pos)
+#define SPI_IDR_MASK                _U_(0x000007FF) /**< \brief (SPI_IDR) MASK Register */
 
 /* -------- SPI_IMR : (SPI Offset: 0x1C) (R/  32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -500,71 +500,71 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_IMR_OFFSET              0x1C         /**< \brief (SPI_IMR offset) Interrupt Mask Register */
-#define SPI_IMR_RESETVALUE          _U(0x00000000); /**< \brief (SPI_IMR reset_value) Interrupt Mask Register */
+#define SPI_IMR_RESETVALUE          _U_(0x00000000); /**< \brief (SPI_IMR reset_value) Interrupt Mask Register */
 
 #define SPI_IMR_RDRF_Pos            0            /**< \brief (SPI_IMR) Receive Data Register Full Interrupt Mask */
-#define SPI_IMR_RDRF                (_U(0x1) << SPI_IMR_RDRF_Pos)
-#define   SPI_IMR_RDRF_0_Val              _U(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
-#define   SPI_IMR_RDRF_1_Val              _U(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
+#define SPI_IMR_RDRF                (_U_(0x1) << SPI_IMR_RDRF_Pos)
+#define   SPI_IMR_RDRF_0_Val              _U_(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
+#define   SPI_IMR_RDRF_1_Val              _U_(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
 #define SPI_IMR_RDRF_0              (SPI_IMR_RDRF_0_Val            << SPI_IMR_RDRF_Pos)
 #define SPI_IMR_RDRF_1              (SPI_IMR_RDRF_1_Val            << SPI_IMR_RDRF_Pos)
 #define SPI_IMR_TDRE_Pos            1            /**< \brief (SPI_IMR) Transmit Data Register Empty Interrupt Mask */
-#define SPI_IMR_TDRE                (_U(0x1) << SPI_IMR_TDRE_Pos)
-#define   SPI_IMR_TDRE_0_Val              _U(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
-#define   SPI_IMR_TDRE_1_Val              _U(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
+#define SPI_IMR_TDRE                (_U_(0x1) << SPI_IMR_TDRE_Pos)
+#define   SPI_IMR_TDRE_0_Val              _U_(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
+#define   SPI_IMR_TDRE_1_Val              _U_(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
 #define SPI_IMR_TDRE_0              (SPI_IMR_TDRE_0_Val            << SPI_IMR_TDRE_Pos)
 #define SPI_IMR_TDRE_1              (SPI_IMR_TDRE_1_Val            << SPI_IMR_TDRE_Pos)
 #define SPI_IMR_MODF_Pos            2            /**< \brief (SPI_IMR) Mode Fault Error Interrupt Mask */
-#define SPI_IMR_MODF                (_U(0x1) << SPI_IMR_MODF_Pos)
-#define   SPI_IMR_MODF_0_Val              _U(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
-#define   SPI_IMR_MODF_1_Val              _U(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
+#define SPI_IMR_MODF                (_U_(0x1) << SPI_IMR_MODF_Pos)
+#define   SPI_IMR_MODF_0_Val              _U_(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
+#define   SPI_IMR_MODF_1_Val              _U_(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
 #define SPI_IMR_MODF_0              (SPI_IMR_MODF_0_Val            << SPI_IMR_MODF_Pos)
 #define SPI_IMR_MODF_1              (SPI_IMR_MODF_1_Val            << SPI_IMR_MODF_Pos)
 #define SPI_IMR_OVRES_Pos           3            /**< \brief (SPI_IMR) Overrun Error Interrupt Mask */
-#define SPI_IMR_OVRES               (_U(0x1) << SPI_IMR_OVRES_Pos)
-#define   SPI_IMR_OVRES_0_Val             _U(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
-#define   SPI_IMR_OVRES_1_Val             _U(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
+#define SPI_IMR_OVRES               (_U_(0x1) << SPI_IMR_OVRES_Pos)
+#define   SPI_IMR_OVRES_0_Val             _U_(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
+#define   SPI_IMR_OVRES_1_Val             _U_(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
 #define SPI_IMR_OVRES_0             (SPI_IMR_OVRES_0_Val           << SPI_IMR_OVRES_Pos)
 #define SPI_IMR_OVRES_1             (SPI_IMR_OVRES_1_Val           << SPI_IMR_OVRES_Pos)
 #define SPI_IMR_ENDRX_Pos           4            /**< \brief (SPI_IMR) End of Receive Buffer Interrupt Mask */
-#define SPI_IMR_ENDRX               (_U(0x1) << SPI_IMR_ENDRX_Pos)
-#define   SPI_IMR_ENDRX_0_Val             _U(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
-#define   SPI_IMR_ENDRX_1_Val             _U(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
+#define SPI_IMR_ENDRX               (_U_(0x1) << SPI_IMR_ENDRX_Pos)
+#define   SPI_IMR_ENDRX_0_Val             _U_(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
+#define   SPI_IMR_ENDRX_1_Val             _U_(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
 #define SPI_IMR_ENDRX_0             (SPI_IMR_ENDRX_0_Val           << SPI_IMR_ENDRX_Pos)
 #define SPI_IMR_ENDRX_1             (SPI_IMR_ENDRX_1_Val           << SPI_IMR_ENDRX_Pos)
 #define SPI_IMR_ENDTX_Pos           5            /**< \brief (SPI_IMR) End of Transmit Buffer Interrupt Mask */
-#define SPI_IMR_ENDTX               (_U(0x1) << SPI_IMR_ENDTX_Pos)
-#define   SPI_IMR_ENDTX_0_Val             _U(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
-#define   SPI_IMR_ENDTX_1_Val             _U(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
+#define SPI_IMR_ENDTX               (_U_(0x1) << SPI_IMR_ENDTX_Pos)
+#define   SPI_IMR_ENDTX_0_Val             _U_(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
+#define   SPI_IMR_ENDTX_1_Val             _U_(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
 #define SPI_IMR_ENDTX_0             (SPI_IMR_ENDTX_0_Val           << SPI_IMR_ENDTX_Pos)
 #define SPI_IMR_ENDTX_1             (SPI_IMR_ENDTX_1_Val           << SPI_IMR_ENDTX_Pos)
 #define SPI_IMR_RXBUFF_Pos          6            /**< \brief (SPI_IMR) Receive Buffer Full Interrupt Mask */
-#define SPI_IMR_RXBUFF              (_U(0x1) << SPI_IMR_RXBUFF_Pos)
-#define   SPI_IMR_RXBUFF_0_Val            _U(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
-#define   SPI_IMR_RXBUFF_1_Val            _U(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
+#define SPI_IMR_RXBUFF              (_U_(0x1) << SPI_IMR_RXBUFF_Pos)
+#define   SPI_IMR_RXBUFF_0_Val            _U_(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
+#define   SPI_IMR_RXBUFF_1_Val            _U_(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
 #define SPI_IMR_RXBUFF_0            (SPI_IMR_RXBUFF_0_Val          << SPI_IMR_RXBUFF_Pos)
 #define SPI_IMR_RXBUFF_1            (SPI_IMR_RXBUFF_1_Val          << SPI_IMR_RXBUFF_Pos)
 #define SPI_IMR_TXBUFE_Pos          7            /**< \brief (SPI_IMR) Transmit Buffer Empty Interrupt Mask */
-#define SPI_IMR_TXBUFE              (_U(0x1) << SPI_IMR_TXBUFE_Pos)
-#define   SPI_IMR_TXBUFE_0_Val            _U(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
-#define   SPI_IMR_TXBUFE_1_Val            _U(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
+#define SPI_IMR_TXBUFE              (_U_(0x1) << SPI_IMR_TXBUFE_Pos)
+#define   SPI_IMR_TXBUFE_0_Val            _U_(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
+#define   SPI_IMR_TXBUFE_1_Val            _U_(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
 #define SPI_IMR_TXBUFE_0            (SPI_IMR_TXBUFE_0_Val          << SPI_IMR_TXBUFE_Pos)
 #define SPI_IMR_TXBUFE_1            (SPI_IMR_TXBUFE_1_Val          << SPI_IMR_TXBUFE_Pos)
 #define SPI_IMR_NSSR_Pos            8            /**< \brief (SPI_IMR) NSS Rising Interrupt Mask */
-#define SPI_IMR_NSSR                (_U(0x1) << SPI_IMR_NSSR_Pos)
-#define   SPI_IMR_NSSR_0_Val              _U(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
-#define   SPI_IMR_NSSR_1_Val              _U(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
+#define SPI_IMR_NSSR                (_U_(0x1) << SPI_IMR_NSSR_Pos)
+#define   SPI_IMR_NSSR_0_Val              _U_(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
+#define   SPI_IMR_NSSR_1_Val              _U_(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
 #define SPI_IMR_NSSR_0              (SPI_IMR_NSSR_0_Val            << SPI_IMR_NSSR_Pos)
 #define SPI_IMR_NSSR_1              (SPI_IMR_NSSR_1_Val            << SPI_IMR_NSSR_Pos)
 #define SPI_IMR_TXEMPTY_Pos         9            /**< \brief (SPI_IMR) Transmission Registers Empty Mask */
-#define SPI_IMR_TXEMPTY             (_U(0x1) << SPI_IMR_TXEMPTY_Pos)
-#define   SPI_IMR_TXEMPTY_0_Val           _U(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
-#define   SPI_IMR_TXEMPTY_1_Val           _U(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
+#define SPI_IMR_TXEMPTY             (_U_(0x1) << SPI_IMR_TXEMPTY_Pos)
+#define   SPI_IMR_TXEMPTY_0_Val           _U_(0x0)   /**< \brief (SPI_IMR) The corresponding interrupt is not enabled. */
+#define   SPI_IMR_TXEMPTY_1_Val           _U_(0x1)   /**< \brief (SPI_IMR) The corresponding interrupt is enabled. */
 #define SPI_IMR_TXEMPTY_0           (SPI_IMR_TXEMPTY_0_Val         << SPI_IMR_TXEMPTY_Pos)
 #define SPI_IMR_TXEMPTY_1           (SPI_IMR_TXEMPTY_1_Val         << SPI_IMR_TXEMPTY_Pos)
 #define SPI_IMR_UNDES_Pos           10           /**< \brief (SPI_IMR) Underrun Error Interrupt Mask */
-#define SPI_IMR_UNDES               (_U(0x1) << SPI_IMR_UNDES_Pos)
-#define SPI_IMR_MASK                _U(0x000007FF) /**< \brief (SPI_IMR) MASK Register */
+#define SPI_IMR_UNDES               (_U_(0x1) << SPI_IMR_UNDES_Pos)
+#define SPI_IMR_MASK                _U_(0x000007FF) /**< \brief (SPI_IMR) MASK Register */
 
 /* -------- SPI_CSR : (SPI Offset: 0x30) (R/W 32) Chip Select Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -584,40 +584,40 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_CSR_OFFSET              0x30         /**< \brief (SPI_CSR offset) Chip Select Register */
-#define SPI_CSR_RESETVALUE          _U(0x00000000); /**< \brief (SPI_CSR reset_value) Chip Select Register */
+#define SPI_CSR_RESETVALUE          _U_(0x00000000); /**< \brief (SPI_CSR reset_value) Chip Select Register */
 
 #define SPI_CSR_CPOL_Pos            0            /**< \brief (SPI_CSR) Clock Polarity */
-#define SPI_CSR_CPOL                (_U(0x1) << SPI_CSR_CPOL_Pos)
-#define   SPI_CSR_CPOL_0_Val              _U(0x0)   /**< \brief (SPI_CSR) The inactive state value of SPCK is logic level zero. */
-#define   SPI_CSR_CPOL_1_Val              _U(0x1)   /**< \brief (SPI_CSR) The inactive state value of SPCK is logic level one.CPOL is used to determine the inactive state value of the serial clock (SPCK). It is used with NCPHA to produce therequired clock/data relationship between master and slave devices. */
+#define SPI_CSR_CPOL                (_U_(0x1) << SPI_CSR_CPOL_Pos)
+#define   SPI_CSR_CPOL_0_Val              _U_(0x0)   /**< \brief (SPI_CSR) The inactive state value of SPCK is logic level zero. */
+#define   SPI_CSR_CPOL_1_Val              _U_(0x1)   /**< \brief (SPI_CSR) The inactive state value of SPCK is logic level one.CPOL is used to determine the inactive state value of the serial clock (SPCK). It is used with NCPHA to produce therequired clock/data relationship between master and slave devices. */
 #define SPI_CSR_CPOL_0              (SPI_CSR_CPOL_0_Val            << SPI_CSR_CPOL_Pos)
 #define SPI_CSR_CPOL_1              (SPI_CSR_CPOL_1_Val            << SPI_CSR_CPOL_Pos)
 #define SPI_CSR_NCPHA_Pos           1            /**< \brief (SPI_CSR) Clock Phase */
-#define SPI_CSR_NCPHA               (_U(0x1) << SPI_CSR_NCPHA_Pos)
-#define   SPI_CSR_NCPHA_0_Val             _U(0x0)   /**< \brief (SPI_CSR) Data is changed on the leading edge of SPCK and captured on the following edge of SPCK. */
-#define   SPI_CSR_NCPHA_1_Val             _U(0x1)   /**< \brief (SPI_CSR) Data is captured on the leading edge of SPCK and changed on the following edge of SPCK.NCPHA determines which edge of SPCK causes data to change and which edge causes data to be captured. NCPHA isused with CPOL to produce the required clock/data relationship between master and slave devices. */
+#define SPI_CSR_NCPHA               (_U_(0x1) << SPI_CSR_NCPHA_Pos)
+#define   SPI_CSR_NCPHA_0_Val             _U_(0x0)   /**< \brief (SPI_CSR) Data is changed on the leading edge of SPCK and captured on the following edge of SPCK. */
+#define   SPI_CSR_NCPHA_1_Val             _U_(0x1)   /**< \brief (SPI_CSR) Data is captured on the leading edge of SPCK and changed on the following edge of SPCK.NCPHA determines which edge of SPCK causes data to change and which edge causes data to be captured. NCPHA isused with CPOL to produce the required clock/data relationship between master and slave devices. */
 #define SPI_CSR_NCPHA_0             (SPI_CSR_NCPHA_0_Val           << SPI_CSR_NCPHA_Pos)
 #define SPI_CSR_NCPHA_1             (SPI_CSR_NCPHA_1_Val           << SPI_CSR_NCPHA_Pos)
 #define SPI_CSR_CSNAAT_Pos          2            /**< \brief (SPI_CSR) Chip Select Not Active After Transfer */
-#define SPI_CSR_CSNAAT              (_U(0x1) << SPI_CSR_CSNAAT_Pos)
+#define SPI_CSR_CSNAAT              (_U_(0x1) << SPI_CSR_CSNAAT_Pos)
 #define SPI_CSR_CSAAT_Pos           3            /**< \brief (SPI_CSR) Chip Select Active After Transfer */
-#define SPI_CSR_CSAAT               (_U(0x1) << SPI_CSR_CSAAT_Pos)
-#define   SPI_CSR_CSAAT_0_Val             _U(0x0)   /**< \brief (SPI_CSR) The Peripheral Chip Select Line rises as soon as the last transfer is achieved. */
-#define   SPI_CSR_CSAAT_1_Val             _U(0x1)   /**< \brief (SPI_CSR) The Peripheral Chip Select does not rise after the last transfer is achieved. It remains active until a new transfer isrequested on a different chip select. */
+#define SPI_CSR_CSAAT               (_U_(0x1) << SPI_CSR_CSAAT_Pos)
+#define   SPI_CSR_CSAAT_0_Val             _U_(0x0)   /**< \brief (SPI_CSR) The Peripheral Chip Select Line rises as soon as the last transfer is achieved. */
+#define   SPI_CSR_CSAAT_1_Val             _U_(0x1)   /**< \brief (SPI_CSR) The Peripheral Chip Select does not rise after the last transfer is achieved. It remains active until a new transfer isrequested on a different chip select. */
 #define SPI_CSR_CSAAT_0             (SPI_CSR_CSAAT_0_Val           << SPI_CSR_CSAAT_Pos)
 #define SPI_CSR_CSAAT_1             (SPI_CSR_CSAAT_1_Val           << SPI_CSR_CSAAT_Pos)
 #define SPI_CSR_BITS_Pos            4            /**< \brief (SPI_CSR) Bits Per Transfer */
-#define SPI_CSR_BITS_Msk            (_U(0xF) << SPI_CSR_BITS_Pos)
+#define SPI_CSR_BITS_Msk            (_U_(0xF) << SPI_CSR_BITS_Pos)
 #define SPI_CSR_BITS(value)         (SPI_CSR_BITS_Msk & ((value) << SPI_CSR_BITS_Pos))
-#define   SPI_CSR_BITS_8_BPT_Val          _U(0x0)   /**< \brief (SPI_CSR) 8 bits per transfer */
-#define   SPI_CSR_BITS_9_BPT_Val          _U(0x1)   /**< \brief (SPI_CSR) 9 bits per transfer */
-#define   SPI_CSR_BITS_10_BPT_Val         _U(0x2)   /**< \brief (SPI_CSR) 10 bits per transfer */
-#define   SPI_CSR_BITS_11_BPT_Val         _U(0x3)   /**< \brief (SPI_CSR) 11 bits per transfer */
-#define   SPI_CSR_BITS_12_BPT_Val         _U(0x4)   /**< \brief (SPI_CSR) 12 bits per transfer */
-#define   SPI_CSR_BITS_13_BPT_Val         _U(0x5)   /**< \brief (SPI_CSR) 13 bits per transfer */
-#define   SPI_CSR_BITS_14_BPT_Val         _U(0x6)   /**< \brief (SPI_CSR) 14 bits per transfer */
-#define   SPI_CSR_BITS_15_BPT_Val         _U(0x7)   /**< \brief (SPI_CSR) 15 bits per transfer */
-#define   SPI_CSR_BITS_16_BPT_Val         _U(0x8)   /**< \brief (SPI_CSR) 16 bits per transfer */
+#define   SPI_CSR_BITS_8_BPT_Val          _U_(0x0)   /**< \brief (SPI_CSR) 8 bits per transfer */
+#define   SPI_CSR_BITS_9_BPT_Val          _U_(0x1)   /**< \brief (SPI_CSR) 9 bits per transfer */
+#define   SPI_CSR_BITS_10_BPT_Val         _U_(0x2)   /**< \brief (SPI_CSR) 10 bits per transfer */
+#define   SPI_CSR_BITS_11_BPT_Val         _U_(0x3)   /**< \brief (SPI_CSR) 11 bits per transfer */
+#define   SPI_CSR_BITS_12_BPT_Val         _U_(0x4)   /**< \brief (SPI_CSR) 12 bits per transfer */
+#define   SPI_CSR_BITS_13_BPT_Val         _U_(0x5)   /**< \brief (SPI_CSR) 13 bits per transfer */
+#define   SPI_CSR_BITS_14_BPT_Val         _U_(0x6)   /**< \brief (SPI_CSR) 14 bits per transfer */
+#define   SPI_CSR_BITS_15_BPT_Val         _U_(0x7)   /**< \brief (SPI_CSR) 15 bits per transfer */
+#define   SPI_CSR_BITS_16_BPT_Val         _U_(0x8)   /**< \brief (SPI_CSR) 16 bits per transfer */
 #define SPI_CSR_BITS_8_BPT          (SPI_CSR_BITS_8_BPT_Val        << SPI_CSR_BITS_Pos)
 #define SPI_CSR_BITS_9_BPT          (SPI_CSR_BITS_9_BPT_Val        << SPI_CSR_BITS_Pos)
 #define SPI_CSR_BITS_10_BPT         (SPI_CSR_BITS_10_BPT_Val       << SPI_CSR_BITS_Pos)
@@ -628,15 +628,15 @@ typedef union {
 #define SPI_CSR_BITS_15_BPT         (SPI_CSR_BITS_15_BPT_Val       << SPI_CSR_BITS_Pos)
 #define SPI_CSR_BITS_16_BPT         (SPI_CSR_BITS_16_BPT_Val       << SPI_CSR_BITS_Pos)
 #define SPI_CSR_SCBR_Pos            8            /**< \brief (SPI_CSR) Serial Clock Baud Rate */
-#define SPI_CSR_SCBR_Msk            (_U(0xFF) << SPI_CSR_SCBR_Pos)
+#define SPI_CSR_SCBR_Msk            (_U_(0xFF) << SPI_CSR_SCBR_Pos)
 #define SPI_CSR_SCBR(value)         (SPI_CSR_SCBR_Msk & ((value) << SPI_CSR_SCBR_Pos))
 #define SPI_CSR_DLYBS_Pos           16           /**< \brief (SPI_CSR) Delay Before SPCK */
-#define SPI_CSR_DLYBS_Msk           (_U(0xFF) << SPI_CSR_DLYBS_Pos)
+#define SPI_CSR_DLYBS_Msk           (_U_(0xFF) << SPI_CSR_DLYBS_Pos)
 #define SPI_CSR_DLYBS(value)        (SPI_CSR_DLYBS_Msk & ((value) << SPI_CSR_DLYBS_Pos))
 #define SPI_CSR_DLYBCT_Pos          24           /**< \brief (SPI_CSR) Delay Between Consecutive Transfers */
-#define SPI_CSR_DLYBCT_Msk          (_U(0xFF) << SPI_CSR_DLYBCT_Pos)
+#define SPI_CSR_DLYBCT_Msk          (_U_(0xFF) << SPI_CSR_DLYBCT_Pos)
 #define SPI_CSR_DLYBCT(value)       (SPI_CSR_DLYBCT_Msk & ((value) << SPI_CSR_DLYBCT_Pos))
-#define SPI_CSR_MASK                _U(0xFFFFFFFF) /**< \brief (SPI_CSR) MASK Register */
+#define SPI_CSR_MASK                _U_(0xFFFFFFFF) /**< \brief (SPI_CSR) MASK Register */
 
 /* -------- SPI_WPCR : (SPI Offset: 0xE4) (R/W 32) Write Protection control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -651,16 +651,16 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_WPCR_OFFSET             0xE4         /**< \brief (SPI_WPCR offset) Write Protection control Register */
-#define SPI_WPCR_RESETVALUE         _U(0x00000000); /**< \brief (SPI_WPCR reset_value) Write Protection control Register */
+#define SPI_WPCR_RESETVALUE         _U_(0x00000000); /**< \brief (SPI_WPCR reset_value) Write Protection control Register */
 
 #define SPI_WPCR_WPEN_Pos           0            /**< \brief (SPI_WPCR) Write Protection Enable */
-#define SPI_WPCR_WPEN               (_U(0x1) << SPI_WPCR_WPEN_Pos)
+#define SPI_WPCR_WPEN               (_U_(0x1) << SPI_WPCR_WPEN_Pos)
 #define SPI_WPCR_WPKEY_Pos          8            /**< \brief (SPI_WPCR) Write Protection Key Password */
-#define SPI_WPCR_WPKEY_Msk          (_U(0xFFFFFF) << SPI_WPCR_WPKEY_Pos)
+#define SPI_WPCR_WPKEY_Msk          (_U_(0xFFFFFF) << SPI_WPCR_WPKEY_Pos)
 #define SPI_WPCR_WPKEY(value)       (SPI_WPCR_WPKEY_Msk & ((value) << SPI_WPCR_WPKEY_Pos))
-#define   SPI_WPCR_WPKEY_VALUE_Val        _U(0x535049)   /**< \brief (SPI_WPCR) SPI Write Protection Key Password */
+#define   SPI_WPCR_WPKEY_VALUE_Val        _U_(0x535049)   /**< \brief (SPI_WPCR) SPI Write Protection Key Password */
 #define SPI_WPCR_WPKEY_VALUE        (SPI_WPCR_WPKEY_VALUE_Val      << SPI_WPCR_WPKEY_Pos)
-#define SPI_WPCR_MASK               _U(0xFFFFFF01) /**< \brief (SPI_WPCR) MASK Register */
+#define SPI_WPCR_MASK               _U_(0xFFFFFF01) /**< \brief (SPI_WPCR) MASK Register */
 
 /* -------- SPI_WPSR : (SPI Offset: 0xE8) (R/  32) Write Protection status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -676,21 +676,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_WPSR_OFFSET             0xE8         /**< \brief (SPI_WPSR offset) Write Protection status Register */
-#define SPI_WPSR_RESETVALUE         _U(0x00000000); /**< \brief (SPI_WPSR reset_value) Write Protection status Register */
+#define SPI_WPSR_RESETVALUE         _U_(0x00000000); /**< \brief (SPI_WPSR reset_value) Write Protection status Register */
 
 #define SPI_WPSR_WPVS_Pos           0            /**< \brief (SPI_WPSR) Write Protection Violation Status */
-#define SPI_WPSR_WPVS_Msk           (_U(0x7) << SPI_WPSR_WPVS_Pos)
+#define SPI_WPSR_WPVS_Msk           (_U_(0x7) << SPI_WPSR_WPVS_Pos)
 #define SPI_WPSR_WPVS(value)        (SPI_WPSR_WPVS_Msk & ((value) << SPI_WPSR_WPVS_Pos))
-#define   SPI_WPSR_WPVS_WRITE_WITH_WP_Val _U(0x1)   /**< \brief (SPI_WPSR) The Write Protection has blocked a Write access to a protected register (since the last read). */
-#define   SPI_WPSR_WPVS_SWRST_WITH_WP_Val _U(0x2)   /**< \brief (SPI_WPSR) Software Reset has been performed while Write Protection was enabled (since the last read or since the last write access on MR, IER, IDR or CSRx). */
-#define   SPI_WPSR_WPVS_UNEXPECTED_WRITE_Val _U(0x4)   /**< \brief (SPI_WPSR) Write accesses have been detected on MR (while a chip select was active) or on CSRi (while the Chip Select “i” was active) since the last read. */
+#define   SPI_WPSR_WPVS_WRITE_WITH_WP_Val _U_(0x1)   /**< \brief (SPI_WPSR) The Write Protection has blocked a Write access to a protected register (since the last read). */
+#define   SPI_WPSR_WPVS_SWRST_WITH_WP_Val _U_(0x2)   /**< \brief (SPI_WPSR) Software Reset has been performed while Write Protection was enabled (since the last read or since the last write access on MR, IER, IDR or CSRx). */
+#define   SPI_WPSR_WPVS_UNEXPECTED_WRITE_Val _U_(0x4)   /**< \brief (SPI_WPSR) Write accesses have been detected on MR (while a chip select was active) or on CSRi (while the Chip Select “i” was active) since the last read. */
 #define SPI_WPSR_WPVS_WRITE_WITH_WP (SPI_WPSR_WPVS_WRITE_WITH_WP_Val << SPI_WPSR_WPVS_Pos)
 #define SPI_WPSR_WPVS_SWRST_WITH_WP (SPI_WPSR_WPVS_SWRST_WITH_WP_Val << SPI_WPSR_WPVS_Pos)
 #define SPI_WPSR_WPVS_UNEXPECTED_WRITE (SPI_WPSR_WPVS_UNEXPECTED_WRITE_Val << SPI_WPSR_WPVS_Pos)
 #define SPI_WPSR_WPVSRC_Pos         8            /**< \brief (SPI_WPSR) Write Protection Violation Source */
-#define SPI_WPSR_WPVSRC_Msk         (_U(0xFF) << SPI_WPSR_WPVSRC_Pos)
+#define SPI_WPSR_WPVSRC_Msk         (_U_(0xFF) << SPI_WPSR_WPVSRC_Pos)
 #define SPI_WPSR_WPVSRC(value)      (SPI_WPSR_WPVSRC_Msk & ((value) << SPI_WPSR_WPVSRC_Pos))
-#define SPI_WPSR_MASK               _U(0x0000FF07) /**< \brief (SPI_WPSR) MASK Register */
+#define SPI_WPSR_MASK               _U_(0x0000FF07) /**< \brief (SPI_WPSR) MASK Register */
 
 /* -------- SPI_FEATURES : (SPI Offset: 0xF8) (R/  32) Features Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -717,32 +717,32 @@ typedef union {
 #define SPI_FEATURES_OFFSET         0xF8         /**< \brief (SPI_FEATURES offset) Features Register */
 
 #define SPI_FEATURES_NCS_Pos        0            /**< \brief (SPI_FEATURES) Number of Chip Selects */
-#define SPI_FEATURES_NCS_Msk        (_U(0xF) << SPI_FEATURES_NCS_Pos)
+#define SPI_FEATURES_NCS_Msk        (_U_(0xF) << SPI_FEATURES_NCS_Pos)
 #define SPI_FEATURES_NCS(value)     (SPI_FEATURES_NCS_Msk & ((value) << SPI_FEATURES_NCS_Pos))
 #define SPI_FEATURES_PCONF_Pos      4            /**< \brief (SPI_FEATURES) Polarity is Configurable */
-#define SPI_FEATURES_PCONF          (_U(0x1) << SPI_FEATURES_PCONF_Pos)
+#define SPI_FEATURES_PCONF          (_U_(0x1) << SPI_FEATURES_PCONF_Pos)
 #define SPI_FEATURES_PPNCONF_Pos    5            /**< \brief (SPI_FEATURES) Polarity is Positive if Polarity is not Configurable */
-#define SPI_FEATURES_PPNCONF        (_U(0x1) << SPI_FEATURES_PPNCONF_Pos)
+#define SPI_FEATURES_PPNCONF        (_U_(0x1) << SPI_FEATURES_PPNCONF_Pos)
 #define SPI_FEATURES_PHCONF_Pos     6            /**< \brief (SPI_FEATURES) Phase is Configurable */
-#define SPI_FEATURES_PHCONF         (_U(0x1) << SPI_FEATURES_PHCONF_Pos)
+#define SPI_FEATURES_PHCONF         (_U_(0x1) << SPI_FEATURES_PHCONF_Pos)
 #define SPI_FEATURES_PHZNCONF_Pos   7            /**< \brief (SPI_FEATURES) Phase is Zero if Phase is not Configurable */
-#define SPI_FEATURES_PHZNCONF       (_U(0x1) << SPI_FEATURES_PHZNCONF_Pos)
+#define SPI_FEATURES_PHZNCONF       (_U_(0x1) << SPI_FEATURES_PHZNCONF_Pos)
 #define SPI_FEATURES_LENCONF_Pos    8            /**< \brief (SPI_FEATURES) Character Length is Configurable */
-#define SPI_FEATURES_LENCONF        (_U(0x1) << SPI_FEATURES_LENCONF_Pos)
+#define SPI_FEATURES_LENCONF        (_U_(0x1) << SPI_FEATURES_LENCONF_Pos)
 #define SPI_FEATURES_LENNCONF_Pos   9            /**< \brief (SPI_FEATURES) Character Length if not Configurable */
-#define SPI_FEATURES_LENNCONF_Msk   (_U(0x7F) << SPI_FEATURES_LENNCONF_Pos)
+#define SPI_FEATURES_LENNCONF_Msk   (_U_(0x7F) << SPI_FEATURES_LENNCONF_Pos)
 #define SPI_FEATURES_LENNCONF(value) (SPI_FEATURES_LENNCONF_Msk & ((value) << SPI_FEATURES_LENNCONF_Pos))
 #define SPI_FEATURES_EXTDEC_Pos     16           /**< \brief (SPI_FEATURES) External Decoder is True */
-#define SPI_FEATURES_EXTDEC         (_U(0x1) << SPI_FEATURES_EXTDEC_Pos)
+#define SPI_FEATURES_EXTDEC         (_U_(0x1) << SPI_FEATURES_EXTDEC_Pos)
 #define SPI_FEATURES_CSNAATIMPL_Pos 17           /**< \brief (SPI_FEATURES) CSNAAT Features are Implemented */
-#define SPI_FEATURES_CSNAATIMPL     (_U(0x1) << SPI_FEATURES_CSNAATIMPL_Pos)
+#define SPI_FEATURES_CSNAATIMPL     (_U_(0x1) << SPI_FEATURES_CSNAATIMPL_Pos)
 #define SPI_FEATURES_BRPBHSB_Pos    18           /**< \brief (SPI_FEATURES) Bridge Type is PB to HSB */
-#define SPI_FEATURES_BRPBHSB        (_U(0x1) << SPI_FEATURES_BRPBHSB_Pos)
+#define SPI_FEATURES_BRPBHSB        (_U_(0x1) << SPI_FEATURES_BRPBHSB_Pos)
 #define SPI_FEATURES_FIFORIMPL_Pos  19           /**< \brief (SPI_FEATURES) FIFO in Reception is Implemented */
-#define SPI_FEATURES_FIFORIMPL      (_U(0x1) << SPI_FEATURES_FIFORIMPL_Pos)
+#define SPI_FEATURES_FIFORIMPL      (_U_(0x1) << SPI_FEATURES_FIFORIMPL_Pos)
 #define SPI_FEATURES_SWPIMPL_Pos    20           /**< \brief (SPI_FEATURES) Spurious Write Protection is Implemented */
-#define SPI_FEATURES_SWPIMPL        (_U(0x1) << SPI_FEATURES_SWPIMPL_Pos)
-#define SPI_FEATURES_MASK           _U(0x001FFFFF) /**< \brief (SPI_FEATURES) MASK Register */
+#define SPI_FEATURES_SWPIMPL        (_U_(0x1) << SPI_FEATURES_SWPIMPL_Pos)
+#define SPI_FEATURES_MASK           _U_(0x001FFFFF) /**< \brief (SPI_FEATURES) MASK Register */
 
 /* -------- SPI_VERSION : (SPI Offset: 0xFC) (R/  32) Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -758,15 +758,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_VERSION_OFFSET          0xFC         /**< \brief (SPI_VERSION offset) Version Register */
-#define SPI_VERSION_RESETVALUE      _U(0x00000211); /**< \brief (SPI_VERSION reset_value) Version Register */
+#define SPI_VERSION_RESETVALUE      _U_(0x00000211); /**< \brief (SPI_VERSION reset_value) Version Register */
 
 #define SPI_VERSION_VERSION_Pos     0            /**< \brief (SPI_VERSION) Version */
-#define SPI_VERSION_VERSION_Msk     (_U(0xFFF) << SPI_VERSION_VERSION_Pos)
+#define SPI_VERSION_VERSION_Msk     (_U_(0xFFF) << SPI_VERSION_VERSION_Pos)
 #define SPI_VERSION_VERSION(value)  (SPI_VERSION_VERSION_Msk & ((value) << SPI_VERSION_VERSION_Pos))
 #define SPI_VERSION_MFN_Pos         16           /**< \brief (SPI_VERSION) mfn */
-#define SPI_VERSION_MFN_Msk         (_U(0x7) << SPI_VERSION_MFN_Pos)
+#define SPI_VERSION_MFN_Msk         (_U_(0x7) << SPI_VERSION_MFN_Pos)
 #define SPI_VERSION_MFN(value)      (SPI_VERSION_MFN_Msk & ((value) << SPI_VERSION_MFN_Pos))
-#define SPI_VERSION_MASK            _U(0x00070FFF) /**< \brief (SPI_VERSION) MASK Register */
+#define SPI_VERSION_MASK            _U_(0x00070FFF) /**< \brief (SPI_VERSION) MASK Register */
 
 /** \brief SPI hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/spi.h
+++ b/asf/sam/include/sam4l/component/spi.h
@@ -770,43 +770,23 @@ typedef union {
 
 /** \brief SPI hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __O  SPI_CR_Type               CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
-  __IO SPI_MR_Type               MR;          /**< \brief Offset: 0x04 (R/W 32) Mode Register */
-  __I  SPI_RDR_Type              RDR;         /**< \brief Offset: 0x08 (R/  32) Receive Data Register */
-  __O  SPI_TDR_Type              TDR;         /**< \brief Offset: 0x0C ( /W 32) Transmit Data Register */
-  __I  SPI_SR_Type               SR;          /**< \brief Offset: 0x10 (R/  32) Status Register */
-  __O  SPI_IER_Type              IER;         /**< \brief Offset: 0x14 ( /W 32) Interrupt Enable Register */
-  __O  SPI_IDR_Type              IDR;         /**< \brief Offset: 0x18 ( /W 32) Interrupt Disable Register */
-  __I  SPI_IMR_Type              IMR;         /**< \brief Offset: 0x1C (R/  32) Interrupt Mask Register */
-       RoReg8                    Reserved1[0x10];
-  __IO SPI_CSR_Type              CSR[4];      /**< \brief Offset: 0x30 (R/W 32) Chip Select Register */
-       RoReg8                    Reserved2[0xA4];
-  __IO SPI_WPCR_Type             WPCR;        /**< \brief Offset: 0xE4 (R/W 32) Write Protection control Register */
-  __I  SPI_WPSR_Type             WPSR;        /**< \brief Offset: 0xE8 (R/  32) Write Protection status Register */
-       RoReg8                    Reserved3[0xC];
-  __I  SPI_FEATURES_Type         FEATURES;    /**< \brief Offset: 0xF8 (R/  32) Features Register */
-  __I  SPI_VERSION_Type          VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
- } bf;
- struct {
-  WoReg   SPI_CR;             /**< \brief (SPI Offset: 0x00) Control Register */
-  RwReg   SPI_MR;             /**< \brief (SPI Offset: 0x04) Mode Register */
-  RoReg   SPI_RDR;            /**< \brief (SPI Offset: 0x08) Receive Data Register */
-  WoReg   SPI_TDR;            /**< \brief (SPI Offset: 0x0C) Transmit Data Register */
-  RoReg   SPI_SR;             /**< \brief (SPI Offset: 0x10) Status Register */
-  WoReg   SPI_IER;            /**< \brief (SPI Offset: 0x14) Interrupt Enable Register */
-  WoReg   SPI_IDR;            /**< \brief (SPI Offset: 0x18) Interrupt Disable Register */
-  RoReg   SPI_IMR;            /**< \brief (SPI Offset: 0x1C) Interrupt Mask Register */
-  RoReg8  Reserved4[0x10];
-  RwReg   SPI_CSR[4];         /**< \brief (SPI Offset: 0x30) Chip Select Register */
-  RoReg8  Reserved5[0xA4];
-  RwReg   SPI_WPCR;           /**< \brief (SPI Offset: 0xE4) Write Protection control Register */
-  RoReg   SPI_WPSR;           /**< \brief (SPI Offset: 0xE8) Write Protection status Register */
-  RoReg8  Reserved6[0xC];
-  RoReg   SPI_FEATURES;       /**< \brief (SPI Offset: 0xF8) Features Register */
-  RoReg   SPI_VERSION;        /**< \brief (SPI Offset: 0xFC) Version Register */
- } reg;
+typedef struct {
+  __O  uint32_t           SPI_CR;	/**< \brief Offset: 0x00 ( /W 32) Control Register */
+  __IO uint32_t           SPI_MR;	/**< \brief Offset: 0x04 (R/W 32) Mode Register */
+  __I  uint32_t          SPI_RDR;	/**< \brief Offset: 0x08 (R/  32) Receive Data Register */
+  __O  uint32_t          SPI_TDR;	/**< \brief Offset: 0x0C ( /W 32) Transmit Data Register */
+  __I  uint32_t           SPI_SR;	/**< \brief Offset: 0x10 (R/  32) Status Register */
+  __O  uint32_t          SPI_IER;	/**< \brief Offset: 0x14 ( /W 32) Interrupt Enable Register */
+  __O  uint32_t          SPI_IDR;	/**< \brief Offset: 0x18 ( /W 32) Interrupt Disable Register */
+  __I  uint32_t          SPI_IMR;	/**< \brief Offset: 0x1C (R/  32) Interrupt Mask Register */
+  __I  uint8_t   Reserved1[0x10];
+  __IO uint32_t       SPI_CSR[4];	/**< \brief Offset: 0x30 (R/W 32) Chip Select Register */
+  __I  uint8_t   Reserved2[0xA4];
+  __IO uint32_t         SPI_WPCR;	/**< \brief Offset: 0xE4 (R/W 32) Write Protection control Register */
+  __I  uint32_t         SPI_WPSR;	/**< \brief Offset: 0xE8 (R/  32) Write Protection status Register */
+  __I  uint8_t    Reserved3[0xC];
+  __I  uint32_t     SPI_FEATURES;	/**< \brief Offset: 0xF8 (R/  32) Features Register */
+  __I  uint32_t      SPI_VERSION;	/**< \brief Offset: 0xFC (R/  32) Version Register */
 } Spi;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/tc.h
+++ b/asf/sam/include/sam4l/component/tc.h
@@ -1,0 +1,1259 @@
+/**
+ * \file
+ *
+ * \brief Component description for TC
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_TC_COMPONENT_
+#define _SAM4L_TC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR TC */
+/* ========================================================================== */
+/** \addtogroup SAM4L_TC Timer/Counter */
+/*@{*/
+
+#define TC_I7604
+#define REV_TC                      0x402
+
+/* -------- TC_CCR : (TC Offset: 0x00) ( /W 32) channel Channel Control Register Channel -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CLKEN:1;          /*!< bit:      0  Counter Clock Enable Command       */
+    uint32_t CLKDIS:1;         /*!< bit:      1  Counter Clock Disable Command      */
+    uint32_t SWTRG:1;          /*!< bit:      2  Software Trigger Command           */
+    uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TC_CCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_CCR_OFFSET               0x00         /**< \brief (TC_CCR offset) Channel Control Register Channel */
+#define TC_CCR_RESETVALUE           _U(0x00000000); /**< \brief (TC_CCR reset_value) Channel Control Register Channel */
+
+#define TC_CCR_CLKEN_Pos            0            /**< \brief (TC_CCR) Counter Clock Enable Command */
+#define TC_CCR_CLKEN                (_U(0x1) << TC_CCR_CLKEN_Pos)
+#define   TC_CCR_CLKEN_0_Val              _U(0x0)   /**< \brief (TC_CCR) No effect. */
+#define   TC_CCR_CLKEN_1_Val              _U(0x1)   /**< \brief (TC_CCR) Enables the clock if CLKDIS is not 1. */
+#define TC_CCR_CLKEN_0              (TC_CCR_CLKEN_0_Val            << TC_CCR_CLKEN_Pos)
+#define TC_CCR_CLKEN_1              (TC_CCR_CLKEN_1_Val            << TC_CCR_CLKEN_Pos)
+#define TC_CCR_CLKDIS_Pos           1            /**< \brief (TC_CCR) Counter Clock Disable Command */
+#define TC_CCR_CLKDIS               (_U(0x1) << TC_CCR_CLKDIS_Pos)
+#define   TC_CCR_CLKDIS_0_Val             _U(0x0)   /**< \brief (TC_CCR) No effect. */
+#define   TC_CCR_CLKDIS_1_Val             _U(0x1)   /**< \brief (TC_CCR) Disables the clock. */
+#define TC_CCR_CLKDIS_0             (TC_CCR_CLKDIS_0_Val           << TC_CCR_CLKDIS_Pos)
+#define TC_CCR_CLKDIS_1             (TC_CCR_CLKDIS_1_Val           << TC_CCR_CLKDIS_Pos)
+#define TC_CCR_SWTRG_Pos            2            /**< \brief (TC_CCR) Software Trigger Command */
+#define TC_CCR_SWTRG                (_U(0x1) << TC_CCR_SWTRG_Pos)
+#define   TC_CCR_SWTRG_0_Val              _U(0x0)   /**< \brief (TC_CCR) No effect. */
+#define   TC_CCR_SWTRG_1_Val              _U(0x1)   /**< \brief (TC_CCR) A software trigger is performed:the counter is reset and clock is started. */
+#define TC_CCR_SWTRG_0              (TC_CCR_SWTRG_0_Val            << TC_CCR_SWTRG_Pos)
+#define TC_CCR_SWTRG_1              (TC_CCR_SWTRG_1_Val            << TC_CCR_SWTRG_Pos)
+#define TC_CCR_MASK                 _U(0x00000007) /**< \brief (TC_CCR) MASK Register */
+
+/* -------- TC_CMR : (TC Offset: 0x04) (R/W 32) channel Channel Mode Register Channel -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct { // CAPTURE mode
+    uint32_t TCCLKS:3;         /*!< bit:  0.. 2  Clock Selection                    */
+    uint32_t CLKI:1;           /*!< bit:      3  Clock Invert                       */
+    uint32_t BURST:2;          /*!< bit:  4.. 5  Burst Signal Selection             */
+    uint32_t LDBSTOP:1;        /*!< bit:      6  Counter Clock Stopped with RB Loading */
+    uint32_t LDBDIS:1;         /*!< bit:      7  Counter Clock Disable with RB Loading */
+    uint32_t ETRGEDG:2;        /*!< bit:  8.. 9  External Trigger Edge Selection    */
+    uint32_t ABETRG:1;         /*!< bit:     10  TIOA or TIOB External Trigger Selection */
+    uint32_t :3;               /*!< bit: 11..13  Reserved                           */
+    uint32_t CPCTRG:1;         /*!< bit:     14  RC Compare Trigger Enable          */
+    uint32_t WAVE:1;           /*!< bit:     15  Wave                               */
+    uint32_t LDRA:2;           /*!< bit: 16..17  RA Loading Selection               */
+    uint32_t LDRB:2;           /*!< bit: 18..19  RB Loading Selection               */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } CAPTURE;                   /*!< Structure used for CAPTURE                      */
+  struct { // WAVEFORM mode
+    uint32_t TCCLKS:3;         /*!< bit:  0.. 2  Clock Selection                    */
+    uint32_t CLKI:1;           /*!< bit:      3  Clock Invert                       */
+    uint32_t BURST:2;          /*!< bit:  4.. 5  Burst Signal Selection             */
+    uint32_t CPCSTOP:1;        /*!< bit:      6  Counter Clock Stopped with RC Compare */
+    uint32_t CPCDIS:1;         /*!< bit:      7  Counter Clock Disable with RC Compare */
+    uint32_t EEVTEDG:2;        /*!< bit:  8.. 9  External Event Edge Selection      */
+    uint32_t EEVT:2;           /*!< bit: 10..11  External Event Selection           */
+    uint32_t ENETRG:1;         /*!< bit:     12  External Event Trigger Enable      */
+    uint32_t WAVSEL:2;         /*!< bit: 13..14  Waveform Selection                 */
+    uint32_t WAVE:1;           /*!< bit:     15  WAVE                               */
+    uint32_t ACPA:2;           /*!< bit: 16..17  RA Compare Effect on TIOA          */
+    uint32_t ACPC:2;           /*!< bit: 18..19  RC Compare Effect on TIOA          */
+    uint32_t AEEVT:2;          /*!< bit: 20..21  External Event Effect on TIOA      */
+    uint32_t ASWTRG:2;         /*!< bit: 22..23  Software Trigger Effect on TIOA    */
+    uint32_t BCPB:2;           /*!< bit: 24..25  RB Compare Effect on TIOB          */
+    uint32_t BCPC:2;           /*!< bit: 26..27  RC Compare Effect on TIOB          */
+    uint32_t BEEVT:2;          /*!< bit: 28..29  External Event Effect on TIOB      */
+    uint32_t BSWTRG:2;         /*!< bit: 30..31  Software Trigger Effect on TIOB    */
+  } WAVEFORM;                  /*!< Structure used for WAVEFORM                     */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TC_CMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_CMR_OFFSET               0x04         /**< \brief (TC_CMR offset) Channel Mode Register Channel */
+#define TC_CMR_RESETVALUE           _U(0x00000000); /**< \brief (TC_CMR reset_value) Channel Mode Register Channel */
+
+// CAPTURE mode
+#define TC_CMR_CAPTURE_TCCLKS_Pos   0            /**< \brief (TC_CMR_CAPTURE) Clock Selection */
+#define TC_CMR_CAPTURE_TCCLKS_Msk   (_U(0x7) << TC_CMR_CAPTURE_TCCLKS_Pos)
+#define TC_CMR_CAPTURE_TCCLKS(value) (TC_CMR_CAPTURE_TCCLKS_Msk & ((value) << TC_CMR_CAPTURE_TCCLKS_Pos))
+#define   TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK1_Val _U(0x0)   /**< \brief (TC_CMR_CAPTURE) TIMER_CLOCK1 */
+#define   TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK2_Val _U(0x1)   /**< \brief (TC_CMR_CAPTURE) TIMER_CLOCK2 */
+#define   TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK3_Val _U(0x2)   /**< \brief (TC_CMR_CAPTURE) TIMER_CLOCK3 */
+#define   TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK4_Val _U(0x3)   /**< \brief (TC_CMR_CAPTURE) TIMER_CLOCK4 */
+#define   TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK5_Val _U(0x4)   /**< \brief (TC_CMR_CAPTURE) TIMER_CLOCK5 */
+#define   TC_CMR_CAPTURE_TCCLKS_XC0_Val   _U(0x5)   /**< \brief (TC_CMR_CAPTURE) XC0 */
+#define   TC_CMR_CAPTURE_TCCLKS_XC1_Val   _U(0x6)   /**< \brief (TC_CMR_CAPTURE) XC1 */
+#define   TC_CMR_CAPTURE_TCCLKS_XC2_Val   _U(0x7)   /**< \brief (TC_CMR_CAPTURE) XC2 */
+#define TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK1 (TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK1_Val << TC_CMR_CAPTURE_TCCLKS_Pos)
+#define TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK2 (TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK2_Val << TC_CMR_CAPTURE_TCCLKS_Pos)
+#define TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK3 (TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK3_Val << TC_CMR_CAPTURE_TCCLKS_Pos)
+#define TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK4 (TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK4_Val << TC_CMR_CAPTURE_TCCLKS_Pos)
+#define TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK5 (TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK5_Val << TC_CMR_CAPTURE_TCCLKS_Pos)
+#define TC_CMR_CAPTURE_TCCLKS_XC0   (TC_CMR_CAPTURE_TCCLKS_XC0_Val << TC_CMR_CAPTURE_TCCLKS_Pos)
+#define TC_CMR_CAPTURE_TCCLKS_XC1   (TC_CMR_CAPTURE_TCCLKS_XC1_Val << TC_CMR_CAPTURE_TCCLKS_Pos)
+#define TC_CMR_CAPTURE_TCCLKS_XC2   (TC_CMR_CAPTURE_TCCLKS_XC2_Val << TC_CMR_CAPTURE_TCCLKS_Pos)
+#define TC_CMR_CAPTURE_CLKI_Pos     3            /**< \brief (TC_CMR_CAPTURE) Clock Invert */
+#define TC_CMR_CAPTURE_CLKI         (_U(0x1) << TC_CMR_CAPTURE_CLKI_Pos)
+#define   TC_CMR_CAPTURE_CLKI_0_Val       _U(0x0)   /**< \brief (TC_CMR_CAPTURE) Counter is incremented on rising edge of the clock. */
+#define   TC_CMR_CAPTURE_CLKI_1_Val       _U(0x1)   /**< \brief (TC_CMR_CAPTURE) Counter is incremented on falling edge of the clock. */
+#define TC_CMR_CAPTURE_CLKI_0       (TC_CMR_CAPTURE_CLKI_0_Val     << TC_CMR_CAPTURE_CLKI_Pos)
+#define TC_CMR_CAPTURE_CLKI_1       (TC_CMR_CAPTURE_CLKI_1_Val     << TC_CMR_CAPTURE_CLKI_Pos)
+#define TC_CMR_CAPTURE_BURST_Pos    4            /**< \brief (TC_CMR_CAPTURE) Burst Signal Selection */
+#define TC_CMR_CAPTURE_BURST_Msk    (_U(0x3) << TC_CMR_CAPTURE_BURST_Pos)
+#define TC_CMR_CAPTURE_BURST(value) (TC_CMR_CAPTURE_BURST_Msk & ((value) << TC_CMR_CAPTURE_BURST_Pos))
+#define   TC_CMR_CAPTURE_BURST_NOT_GATED_Val _U(0x0)   /**< \brief (TC_CMR_CAPTURE) The clock is not gated by an external signal. */
+#define   TC_CMR_CAPTURE_BURST_CLK_AND_XC0_Val _U(0x1)   /**< \brief (TC_CMR_CAPTURE) XC0 is ANDed with the selected clock. */
+#define   TC_CMR_CAPTURE_BURST_CLK_AND_XC1_Val _U(0x2)   /**< \brief (TC_CMR_CAPTURE) XC1 is ANDed with the selected clock. */
+#define   TC_CMR_CAPTURE_BURST_CLK_AND_XC2_Val _U(0x3)   /**< \brief (TC_CMR_CAPTURE) XC2 is ANDed with the selected clock. */
+#define TC_CMR_CAPTURE_BURST_NOT_GATED (TC_CMR_CAPTURE_BURST_NOT_GATED_Val << TC_CMR_CAPTURE_BURST_Pos)
+#define TC_CMR_CAPTURE_BURST_CLK_AND_XC0 (TC_CMR_CAPTURE_BURST_CLK_AND_XC0_Val << TC_CMR_CAPTURE_BURST_Pos)
+#define TC_CMR_CAPTURE_BURST_CLK_AND_XC1 (TC_CMR_CAPTURE_BURST_CLK_AND_XC1_Val << TC_CMR_CAPTURE_BURST_Pos)
+#define TC_CMR_CAPTURE_BURST_CLK_AND_XC2 (TC_CMR_CAPTURE_BURST_CLK_AND_XC2_Val << TC_CMR_CAPTURE_BURST_Pos)
+#define TC_CMR_CAPTURE_LDBSTOP_Pos  6            /**< \brief (TC_CMR_CAPTURE) Counter Clock Stopped with RB Loading */
+#define TC_CMR_CAPTURE_LDBSTOP      (_U(0x1) << TC_CMR_CAPTURE_LDBSTOP_Pos)
+#define   TC_CMR_CAPTURE_LDBSTOP_0_Val    _U(0x0)   /**< \brief (TC_CMR_CAPTURE) Counter clock is not stopped when RB loading occurs. */
+#define   TC_CMR_CAPTURE_LDBSTOP_1_Val    _U(0x1)   /**< \brief (TC_CMR_CAPTURE) Counter clock is stopped when RB loading occurs. */
+#define TC_CMR_CAPTURE_LDBSTOP_0    (TC_CMR_CAPTURE_LDBSTOP_0_Val  << TC_CMR_CAPTURE_LDBSTOP_Pos)
+#define TC_CMR_CAPTURE_LDBSTOP_1    (TC_CMR_CAPTURE_LDBSTOP_1_Val  << TC_CMR_CAPTURE_LDBSTOP_Pos)
+#define TC_CMR_CAPTURE_LDBDIS_Pos   7            /**< \brief (TC_CMR_CAPTURE) Counter Clock Disable with RB Loading */
+#define TC_CMR_CAPTURE_LDBDIS       (_U(0x1) << TC_CMR_CAPTURE_LDBDIS_Pos)
+#define   TC_CMR_CAPTURE_LDBDIS_0_Val     _U(0x0)   /**< \brief (TC_CMR_CAPTURE) Counter clock is not disabled when RB loading occurs. */
+#define   TC_CMR_CAPTURE_LDBDIS_1_Val     _U(0x1)   /**< \brief (TC_CMR_CAPTURE) Counter clock is disabled when RB loading occurs. */
+#define TC_CMR_CAPTURE_LDBDIS_0     (TC_CMR_CAPTURE_LDBDIS_0_Val   << TC_CMR_CAPTURE_LDBDIS_Pos)
+#define TC_CMR_CAPTURE_LDBDIS_1     (TC_CMR_CAPTURE_LDBDIS_1_Val   << TC_CMR_CAPTURE_LDBDIS_Pos)
+#define TC_CMR_CAPTURE_ETRGEDG_Pos  8            /**< \brief (TC_CMR_CAPTURE) External Trigger Edge Selection */
+#define TC_CMR_CAPTURE_ETRGEDG_Msk  (_U(0x3) << TC_CMR_CAPTURE_ETRGEDG_Pos)
+#define TC_CMR_CAPTURE_ETRGEDG(value) (TC_CMR_CAPTURE_ETRGEDG_Msk & ((value) << TC_CMR_CAPTURE_ETRGEDG_Pos))
+#define   TC_CMR_CAPTURE_ETRGEDG_NO_EDGE_Val _U(0x0)   /**< \brief (TC_CMR_CAPTURE) none */
+#define   TC_CMR_CAPTURE_ETRGEDG_POS_EDGE_Val _U(0x1)   /**< \brief (TC_CMR_CAPTURE) rising edge */
+#define   TC_CMR_CAPTURE_ETRGEDG_NEG_EDGE_Val _U(0x2)   /**< \brief (TC_CMR_CAPTURE) falling edge */
+#define   TC_CMR_CAPTURE_ETRGEDG_BOTH_EDGES_Val _U(0x3)   /**< \brief (TC_CMR_CAPTURE) each edge */
+#define TC_CMR_CAPTURE_ETRGEDG_NO_EDGE (TC_CMR_CAPTURE_ETRGEDG_NO_EDGE_Val << TC_CMR_CAPTURE_ETRGEDG_Pos)
+#define TC_CMR_CAPTURE_ETRGEDG_POS_EDGE (TC_CMR_CAPTURE_ETRGEDG_POS_EDGE_Val << TC_CMR_CAPTURE_ETRGEDG_Pos)
+#define TC_CMR_CAPTURE_ETRGEDG_NEG_EDGE (TC_CMR_CAPTURE_ETRGEDG_NEG_EDGE_Val << TC_CMR_CAPTURE_ETRGEDG_Pos)
+#define TC_CMR_CAPTURE_ETRGEDG_BOTH_EDGES (TC_CMR_CAPTURE_ETRGEDG_BOTH_EDGES_Val << TC_CMR_CAPTURE_ETRGEDG_Pos)
+#define TC_CMR_CAPTURE_ABETRG_Pos   10           /**< \brief (TC_CMR_CAPTURE) TIOA or TIOB External Trigger Selection */
+#define TC_CMR_CAPTURE_ABETRG       (_U(0x1) << TC_CMR_CAPTURE_ABETRG_Pos)
+#define   TC_CMR_CAPTURE_ABETRG_0_Val     _U(0x0)   /**< \brief (TC_CMR_CAPTURE) TIOB is used as an external trigger. */
+#define   TC_CMR_CAPTURE_ABETRG_1_Val     _U(0x1)   /**< \brief (TC_CMR_CAPTURE) TIOA is used as an external trigger. */
+#define TC_CMR_CAPTURE_ABETRG_0     (TC_CMR_CAPTURE_ABETRG_0_Val   << TC_CMR_CAPTURE_ABETRG_Pos)
+#define TC_CMR_CAPTURE_ABETRG_1     (TC_CMR_CAPTURE_ABETRG_1_Val   << TC_CMR_CAPTURE_ABETRG_Pos)
+#define TC_CMR_CAPTURE_CPCTRG_Pos   14           /**< \brief (TC_CMR_CAPTURE) RC Compare Trigger Enable */
+#define TC_CMR_CAPTURE_CPCTRG       (_U(0x1) << TC_CMR_CAPTURE_CPCTRG_Pos)
+#define   TC_CMR_CAPTURE_CPCTRG_0_Val     _U(0x0)   /**< \brief (TC_CMR_CAPTURE) RC Compare has no effect on the counter and its clock. */
+#define   TC_CMR_CAPTURE_CPCTRG_1_Val     _U(0x1)   /**< \brief (TC_CMR_CAPTURE) RC Compare resets the counter and starts the counter clock. */
+#define TC_CMR_CAPTURE_CPCTRG_0     (TC_CMR_CAPTURE_CPCTRG_0_Val   << TC_CMR_CAPTURE_CPCTRG_Pos)
+#define TC_CMR_CAPTURE_CPCTRG_1     (TC_CMR_CAPTURE_CPCTRG_1_Val   << TC_CMR_CAPTURE_CPCTRG_Pos)
+#define TC_CMR_CAPTURE_WAVE_Pos     15           /**< \brief (TC_CMR_CAPTURE) Wave */
+#define TC_CMR_CAPTURE_WAVE         (_U(0x1) << TC_CMR_CAPTURE_WAVE_Pos)
+#define   TC_CMR_CAPTURE_WAVE_0_Val       _U(0x0)   /**< \brief (TC_CMR_CAPTURE) Capture Mode is enabled. */
+#define   TC_CMR_CAPTURE_WAVE_1_Val       _U(0x1)   /**< \brief (TC_CMR_CAPTURE) Capture Mode is disabled (Waveform Mode is enabled). */
+#define TC_CMR_CAPTURE_WAVE_0       (TC_CMR_CAPTURE_WAVE_0_Val     << TC_CMR_CAPTURE_WAVE_Pos)
+#define TC_CMR_CAPTURE_WAVE_1       (TC_CMR_CAPTURE_WAVE_1_Val     << TC_CMR_CAPTURE_WAVE_Pos)
+#define TC_CMR_CAPTURE_LDRA_Pos     16           /**< \brief (TC_CMR_CAPTURE) RA Loading Selection */
+#define TC_CMR_CAPTURE_LDRA_Msk     (_U(0x3) << TC_CMR_CAPTURE_LDRA_Pos)
+#define TC_CMR_CAPTURE_LDRA(value)  (TC_CMR_CAPTURE_LDRA_Msk & ((value) << TC_CMR_CAPTURE_LDRA_Pos))
+#define   TC_CMR_CAPTURE_LDRA_NO_EDGE_Val _U(0x0)   /**< \brief (TC_CMR_CAPTURE) none */
+#define   TC_CMR_CAPTURE_LDRA_POS_EDGE_TIOA_Val _U(0x1)   /**< \brief (TC_CMR_CAPTURE) rising edge of TIOA */
+#define   TC_CMR_CAPTURE_LDRA_NEG_EDGE_TIOA_Val _U(0x2)   /**< \brief (TC_CMR_CAPTURE) falling edge of TIOA */
+#define   TC_CMR_CAPTURE_LDRA_BOTH_EDGES_TIOA_Val _U(0x3)   /**< \brief (TC_CMR_CAPTURE) each edge of TIOA */
+#define TC_CMR_CAPTURE_LDRA_NO_EDGE (TC_CMR_CAPTURE_LDRA_NO_EDGE_Val << TC_CMR_CAPTURE_LDRA_Pos)
+#define TC_CMR_CAPTURE_LDRA_POS_EDGE_TIOA (TC_CMR_CAPTURE_LDRA_POS_EDGE_TIOA_Val << TC_CMR_CAPTURE_LDRA_Pos)
+#define TC_CMR_CAPTURE_LDRA_NEG_EDGE_TIOA (TC_CMR_CAPTURE_LDRA_NEG_EDGE_TIOA_Val << TC_CMR_CAPTURE_LDRA_Pos)
+#define TC_CMR_CAPTURE_LDRA_BOTH_EDGES_TIOA (TC_CMR_CAPTURE_LDRA_BOTH_EDGES_TIOA_Val << TC_CMR_CAPTURE_LDRA_Pos)
+#define TC_CMR_CAPTURE_LDRB_Pos     18           /**< \brief (TC_CMR_CAPTURE) RB Loading Selection */
+#define TC_CMR_CAPTURE_LDRB_Msk     (_U(0x3) << TC_CMR_CAPTURE_LDRB_Pos)
+#define TC_CMR_CAPTURE_LDRB(value)  (TC_CMR_CAPTURE_LDRB_Msk & ((value) << TC_CMR_CAPTURE_LDRB_Pos))
+#define   TC_CMR_CAPTURE_LDRB_NO_EDGE_Val _U(0x0)   /**< \brief (TC_CMR_CAPTURE) none */
+#define   TC_CMR_CAPTURE_LDRB_POS_EDGE_TIOA_Val _U(0x1)   /**< \brief (TC_CMR_CAPTURE) rising edge of TIOA */
+#define   TC_CMR_CAPTURE_LDRB_NEG_EDGE_TIOA_Val _U(0x2)   /**< \brief (TC_CMR_CAPTURE) falling edge of TIOA */
+#define   TC_CMR_CAPTURE_LDRB_BOTH_EDGES_TIOA_Val _U(0x3)   /**< \brief (TC_CMR_CAPTURE) each edge of TIOA */
+#define TC_CMR_CAPTURE_LDRB_NO_EDGE (TC_CMR_CAPTURE_LDRB_NO_EDGE_Val << TC_CMR_CAPTURE_LDRB_Pos)
+#define TC_CMR_CAPTURE_LDRB_POS_EDGE_TIOA (TC_CMR_CAPTURE_LDRB_POS_EDGE_TIOA_Val << TC_CMR_CAPTURE_LDRB_Pos)
+#define TC_CMR_CAPTURE_LDRB_NEG_EDGE_TIOA (TC_CMR_CAPTURE_LDRB_NEG_EDGE_TIOA_Val << TC_CMR_CAPTURE_LDRB_Pos)
+#define TC_CMR_CAPTURE_LDRB_BOTH_EDGES_TIOA (TC_CMR_CAPTURE_LDRB_BOTH_EDGES_TIOA_Val << TC_CMR_CAPTURE_LDRB_Pos)
+#define TC_CMR_CAPTURE_MASK         _U(0x000FC7FF) /**< \brief (TC_CMR_CAPTURE) MASK Register */
+
+// WAVEFORM mode
+#define TC_CMR_WAVEFORM_TCCLKS_Pos  0            /**< \brief (TC_CMR_WAVEFORM) Clock Selection */
+#define TC_CMR_WAVEFORM_TCCLKS_Msk  (_U(0x7) << TC_CMR_WAVEFORM_TCCLKS_Pos)
+#define TC_CMR_WAVEFORM_TCCLKS(value) (TC_CMR_WAVEFORM_TCCLKS_Msk & ((value) << TC_CMR_WAVEFORM_TCCLKS_Pos))
+#define   TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV1_CLOCK_Val _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) TIMER_DIV1_CLOCK */
+#define   TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV2_CLOCK_Val _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) TIMER_DIV2_CLOCK */
+#define   TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV3_CLOCK_Val _U(0x2)   /**< \brief (TC_CMR_WAVEFORM) TIMER_DIV3_CLOCK */
+#define   TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV4_CLOCK_Val _U(0x3)   /**< \brief (TC_CMR_WAVEFORM) TIMER_DIV4_CLOCK */
+#define   TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV5_CLOCK_Val _U(0x4)   /**< \brief (TC_CMR_WAVEFORM) TIMER_DIV5_CLOCK */
+#define   TC_CMR_WAVEFORM_TCCLKS_XC0_Val  _U(0x5)   /**< \brief (TC_CMR_WAVEFORM) XC0 */
+#define   TC_CMR_WAVEFORM_TCCLKS_XC1_Val  _U(0x6)   /**< \brief (TC_CMR_WAVEFORM) XC1 */
+#define   TC_CMR_WAVEFORM_TCCLKS_XC2_Val  _U(0x7)   /**< \brief (TC_CMR_WAVEFORM) XC2 */
+#define TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV1_CLOCK (TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV1_CLOCK_Val << TC_CMR_WAVEFORM_TCCLKS_Pos)
+#define TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV2_CLOCK (TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV2_CLOCK_Val << TC_CMR_WAVEFORM_TCCLKS_Pos)
+#define TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV3_CLOCK (TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV3_CLOCK_Val << TC_CMR_WAVEFORM_TCCLKS_Pos)
+#define TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV4_CLOCK (TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV4_CLOCK_Val << TC_CMR_WAVEFORM_TCCLKS_Pos)
+#define TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV5_CLOCK (TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV5_CLOCK_Val << TC_CMR_WAVEFORM_TCCLKS_Pos)
+#define TC_CMR_WAVEFORM_TCCLKS_XC0  (TC_CMR_WAVEFORM_TCCLKS_XC0_Val << TC_CMR_WAVEFORM_TCCLKS_Pos)
+#define TC_CMR_WAVEFORM_TCCLKS_XC1  (TC_CMR_WAVEFORM_TCCLKS_XC1_Val << TC_CMR_WAVEFORM_TCCLKS_Pos)
+#define TC_CMR_WAVEFORM_TCCLKS_XC2  (TC_CMR_WAVEFORM_TCCLKS_XC2_Val << TC_CMR_WAVEFORM_TCCLKS_Pos)
+#define TC_CMR_WAVEFORM_CLKI_Pos    3            /**< \brief (TC_CMR_WAVEFORM) Clock Invert */
+#define TC_CMR_WAVEFORM_CLKI        (_U(0x1) << TC_CMR_WAVEFORM_CLKI_Pos)
+#define   TC_CMR_WAVEFORM_CLKI_0_Val      _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) Counter is incremented on rising edge of the clock. */
+#define   TC_CMR_WAVEFORM_CLKI_1_Val      _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) Counter is incremented on falling edge of the clock. */
+#define TC_CMR_WAVEFORM_CLKI_0      (TC_CMR_WAVEFORM_CLKI_0_Val    << TC_CMR_WAVEFORM_CLKI_Pos)
+#define TC_CMR_WAVEFORM_CLKI_1      (TC_CMR_WAVEFORM_CLKI_1_Val    << TC_CMR_WAVEFORM_CLKI_Pos)
+#define TC_CMR_WAVEFORM_BURST_Pos   4            /**< \brief (TC_CMR_WAVEFORM) Burst Signal Selection */
+#define TC_CMR_WAVEFORM_BURST_Msk   (_U(0x3) << TC_CMR_WAVEFORM_BURST_Pos)
+#define TC_CMR_WAVEFORM_BURST(value) (TC_CMR_WAVEFORM_BURST_Msk & ((value) << TC_CMR_WAVEFORM_BURST_Pos))
+#define   TC_CMR_WAVEFORM_BURST_NOT_GATED_Val _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) The clock is not gated by an external signal. */
+#define   TC_CMR_WAVEFORM_BURST_CLK_AND_XC0_Val _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) XC0 is ANDed with the selected clock. */
+#define   TC_CMR_WAVEFORM_BURST_CLK_AND_XC1_Val _U(0x2)   /**< \brief (TC_CMR_WAVEFORM) XC1 is ANDed with the selected clock. */
+#define   TC_CMR_WAVEFORM_BURST_CLK_AND_XC2_Val _U(0x3)   /**< \brief (TC_CMR_WAVEFORM) XC2 is ANDed with the selected clock. */
+#define TC_CMR_WAVEFORM_BURST_NOT_GATED (TC_CMR_WAVEFORM_BURST_NOT_GATED_Val << TC_CMR_WAVEFORM_BURST_Pos)
+#define TC_CMR_WAVEFORM_BURST_CLK_AND_XC0 (TC_CMR_WAVEFORM_BURST_CLK_AND_XC0_Val << TC_CMR_WAVEFORM_BURST_Pos)
+#define TC_CMR_WAVEFORM_BURST_CLK_AND_XC1 (TC_CMR_WAVEFORM_BURST_CLK_AND_XC1_Val << TC_CMR_WAVEFORM_BURST_Pos)
+#define TC_CMR_WAVEFORM_BURST_CLK_AND_XC2 (TC_CMR_WAVEFORM_BURST_CLK_AND_XC2_Val << TC_CMR_WAVEFORM_BURST_Pos)
+#define TC_CMR_WAVEFORM_CPCSTOP_Pos 6            /**< \brief (TC_CMR_WAVEFORM) Counter Clock Stopped with RC Compare */
+#define TC_CMR_WAVEFORM_CPCSTOP     (_U(0x1) << TC_CMR_WAVEFORM_CPCSTOP_Pos)
+#define   TC_CMR_WAVEFORM_CPCSTOP_0_Val   _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) Counter clock is not stopped when counter reaches RC. */
+#define   TC_CMR_WAVEFORM_CPCSTOP_1_Val   _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) Counter clock is stopped when counter reaches RC. */
+#define TC_CMR_WAVEFORM_CPCSTOP_0   (TC_CMR_WAVEFORM_CPCSTOP_0_Val << TC_CMR_WAVEFORM_CPCSTOP_Pos)
+#define TC_CMR_WAVEFORM_CPCSTOP_1   (TC_CMR_WAVEFORM_CPCSTOP_1_Val << TC_CMR_WAVEFORM_CPCSTOP_Pos)
+#define TC_CMR_WAVEFORM_CPCDIS_Pos  7            /**< \brief (TC_CMR_WAVEFORM) Counter Clock Disable with RC Compare */
+#define TC_CMR_WAVEFORM_CPCDIS      (_U(0x1) << TC_CMR_WAVEFORM_CPCDIS_Pos)
+#define   TC_CMR_WAVEFORM_CPCDIS_0_Val    _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) Counter clock is not disabled when counter reaches RC. */
+#define   TC_CMR_WAVEFORM_CPCDIS_1_Val    _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) Counter clock is disabled when counter reaches RC. */
+#define TC_CMR_WAVEFORM_CPCDIS_0    (TC_CMR_WAVEFORM_CPCDIS_0_Val  << TC_CMR_WAVEFORM_CPCDIS_Pos)
+#define TC_CMR_WAVEFORM_CPCDIS_1    (TC_CMR_WAVEFORM_CPCDIS_1_Val  << TC_CMR_WAVEFORM_CPCDIS_Pos)
+#define TC_CMR_WAVEFORM_EEVTEDG_Pos 8            /**< \brief (TC_CMR_WAVEFORM) External Event Edge Selection */
+#define TC_CMR_WAVEFORM_EEVTEDG_Msk (_U(0x3) << TC_CMR_WAVEFORM_EEVTEDG_Pos)
+#define TC_CMR_WAVEFORM_EEVTEDG(value) (TC_CMR_WAVEFORM_EEVTEDG_Msk & ((value) << TC_CMR_WAVEFORM_EEVTEDG_Pos))
+#define   TC_CMR_WAVEFORM_EEVTEDG_NO_EDGE_Val _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) none */
+#define   TC_CMR_WAVEFORM_EEVTEDG_POS_EDGE_Val _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) rising edge */
+#define   TC_CMR_WAVEFORM_EEVTEDG_NEG_EDGE_Val _U(0x2)   /**< \brief (TC_CMR_WAVEFORM) falling edge */
+#define   TC_CMR_WAVEFORM_EEVTEDG_BOTH_EDGES_Val _U(0x3)   /**< \brief (TC_CMR_WAVEFORM) each edge */
+#define TC_CMR_WAVEFORM_EEVTEDG_NO_EDGE (TC_CMR_WAVEFORM_EEVTEDG_NO_EDGE_Val << TC_CMR_WAVEFORM_EEVTEDG_Pos)
+#define TC_CMR_WAVEFORM_EEVTEDG_POS_EDGE (TC_CMR_WAVEFORM_EEVTEDG_POS_EDGE_Val << TC_CMR_WAVEFORM_EEVTEDG_Pos)
+#define TC_CMR_WAVEFORM_EEVTEDG_NEG_EDGE (TC_CMR_WAVEFORM_EEVTEDG_NEG_EDGE_Val << TC_CMR_WAVEFORM_EEVTEDG_Pos)
+#define TC_CMR_WAVEFORM_EEVTEDG_BOTH_EDGES (TC_CMR_WAVEFORM_EEVTEDG_BOTH_EDGES_Val << TC_CMR_WAVEFORM_EEVTEDG_Pos)
+#define TC_CMR_WAVEFORM_EEVT_Pos    10           /**< \brief (TC_CMR_WAVEFORM) External Event Selection */
+#define TC_CMR_WAVEFORM_EEVT_Msk    (_U(0x3) << TC_CMR_WAVEFORM_EEVT_Pos)
+#define TC_CMR_WAVEFORM_EEVT(value) (TC_CMR_WAVEFORM_EEVT_Msk & ((value) << TC_CMR_WAVEFORM_EEVT_Pos))
+#define   TC_CMR_WAVEFORM_EEVT_TIOB_INPUT_Val _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) TIOB input. If TIOB is chosen as the external event signal, it is configured as an input and no longer generates waveforms. */
+#define   TC_CMR_WAVEFORM_EEVT_XC0_OUTPUT_Val _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) XC0 output */
+#define   TC_CMR_WAVEFORM_EEVT_XC1_OUTPUT_Val _U(0x2)   /**< \brief (TC_CMR_WAVEFORM) XC1 output */
+#define   TC_CMR_WAVEFORM_EEVT_XC2_OUTPUT_Val _U(0x3)   /**< \brief (TC_CMR_WAVEFORM) XC2 output */
+#define TC_CMR_WAVEFORM_EEVT_TIOB_INPUT (TC_CMR_WAVEFORM_EEVT_TIOB_INPUT_Val << TC_CMR_WAVEFORM_EEVT_Pos)
+#define TC_CMR_WAVEFORM_EEVT_XC0_OUTPUT (TC_CMR_WAVEFORM_EEVT_XC0_OUTPUT_Val << TC_CMR_WAVEFORM_EEVT_Pos)
+#define TC_CMR_WAVEFORM_EEVT_XC1_OUTPUT (TC_CMR_WAVEFORM_EEVT_XC1_OUTPUT_Val << TC_CMR_WAVEFORM_EEVT_Pos)
+#define TC_CMR_WAVEFORM_EEVT_XC2_OUTPUT (TC_CMR_WAVEFORM_EEVT_XC2_OUTPUT_Val << TC_CMR_WAVEFORM_EEVT_Pos)
+#define TC_CMR_WAVEFORM_ENETRG_Pos  12           /**< \brief (TC_CMR_WAVEFORM) External Event Trigger Enable */
+#define TC_CMR_WAVEFORM_ENETRG      (_U(0x1) << TC_CMR_WAVEFORM_ENETRG_Pos)
+#define   TC_CMR_WAVEFORM_ENETRG_0_Val    _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) The external event has no effect on the counter and its clock. In this case, the selected external event only controls the TIOA output. */
+#define   TC_CMR_WAVEFORM_ENETRG_1_Val    _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) The external event resets the counter and starts the counter clock. */
+#define TC_CMR_WAVEFORM_ENETRG_0    (TC_CMR_WAVEFORM_ENETRG_0_Val  << TC_CMR_WAVEFORM_ENETRG_Pos)
+#define TC_CMR_WAVEFORM_ENETRG_1    (TC_CMR_WAVEFORM_ENETRG_1_Val  << TC_CMR_WAVEFORM_ENETRG_Pos)
+#define TC_CMR_WAVEFORM_WAVSEL_Pos  13           /**< \brief (TC_CMR_WAVEFORM) Waveform Selection */
+#define TC_CMR_WAVEFORM_WAVSEL_Msk  (_U(0x3) << TC_CMR_WAVEFORM_WAVSEL_Pos)
+#define TC_CMR_WAVEFORM_WAVSEL(value) (TC_CMR_WAVEFORM_WAVSEL_Msk & ((value) << TC_CMR_WAVEFORM_WAVSEL_Pos))
+#define   TC_CMR_WAVEFORM_WAVSEL_UP_NO_AUTO_Val _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) UP mode without automatic trigger on RC Compare */
+#define   TC_CMR_WAVEFORM_WAVSEL_UPDOWN_NO_AUTO_Val _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) UPDOWN mode without automatic trigger on RC Compare */
+#define   TC_CMR_WAVEFORM_WAVSEL_UP_AUTO_Val _U(0x2)   /**< \brief (TC_CMR_WAVEFORM) UP mode with automatic trigger on RC Compare */
+#define   TC_CMR_WAVEFORM_WAVSEL_UPDOWN_AUTO_Val _U(0x3)   /**< \brief (TC_CMR_WAVEFORM) UPDOWN mode with automatic trigger on RC Compare */
+#define TC_CMR_WAVEFORM_WAVSEL_UP_NO_AUTO (TC_CMR_WAVEFORM_WAVSEL_UP_NO_AUTO_Val << TC_CMR_WAVEFORM_WAVSEL_Pos)
+#define TC_CMR_WAVEFORM_WAVSEL_UPDOWN_NO_AUTO (TC_CMR_WAVEFORM_WAVSEL_UPDOWN_NO_AUTO_Val << TC_CMR_WAVEFORM_WAVSEL_Pos)
+#define TC_CMR_WAVEFORM_WAVSEL_UP_AUTO (TC_CMR_WAVEFORM_WAVSEL_UP_AUTO_Val << TC_CMR_WAVEFORM_WAVSEL_Pos)
+#define TC_CMR_WAVEFORM_WAVSEL_UPDOWN_AUTO (TC_CMR_WAVEFORM_WAVSEL_UPDOWN_AUTO_Val << TC_CMR_WAVEFORM_WAVSEL_Pos)
+#define TC_CMR_WAVEFORM_WAVE_Pos    15           /**< \brief (TC_CMR_WAVEFORM) WAVE */
+#define TC_CMR_WAVEFORM_WAVE        (_U(0x1) << TC_CMR_WAVEFORM_WAVE_Pos)
+#define   TC_CMR_WAVEFORM_WAVE_0_Val      _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) Waveform Mode is disabled (Capture Mode is enabled). */
+#define   TC_CMR_WAVEFORM_WAVE_1_Val      _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) Waveform Mode is enabled. */
+#define TC_CMR_WAVEFORM_WAVE_0      (TC_CMR_WAVEFORM_WAVE_0_Val    << TC_CMR_WAVEFORM_WAVE_Pos)
+#define TC_CMR_WAVEFORM_WAVE_1      (TC_CMR_WAVEFORM_WAVE_1_Val    << TC_CMR_WAVEFORM_WAVE_Pos)
+#define TC_CMR_WAVEFORM_ACPA_Pos    16           /**< \brief (TC_CMR_WAVEFORM) RA Compare Effect on TIOA */
+#define TC_CMR_WAVEFORM_ACPA_Msk    (_U(0x3) << TC_CMR_WAVEFORM_ACPA_Pos)
+#define TC_CMR_WAVEFORM_ACPA(value) (TC_CMR_WAVEFORM_ACPA_Msk & ((value) << TC_CMR_WAVEFORM_ACPA_Pos))
+#define   TC_CMR_WAVEFORM_ACPA_NONE_Val   _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) none */
+#define   TC_CMR_WAVEFORM_ACPA_SET_Val    _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) set */
+#define   TC_CMR_WAVEFORM_ACPA_CLEAR_Val  _U(0x2)   /**< \brief (TC_CMR_WAVEFORM) clear */
+#define   TC_CMR_WAVEFORM_ACPA_TOGGLE_Val _U(0x3)   /**< \brief (TC_CMR_WAVEFORM) toggle */
+#define TC_CMR_WAVEFORM_ACPA_NONE   (TC_CMR_WAVEFORM_ACPA_NONE_Val << TC_CMR_WAVEFORM_ACPA_Pos)
+#define TC_CMR_WAVEFORM_ACPA_SET    (TC_CMR_WAVEFORM_ACPA_SET_Val  << TC_CMR_WAVEFORM_ACPA_Pos)
+#define TC_CMR_WAVEFORM_ACPA_CLEAR  (TC_CMR_WAVEFORM_ACPA_CLEAR_Val << TC_CMR_WAVEFORM_ACPA_Pos)
+#define TC_CMR_WAVEFORM_ACPA_TOGGLE (TC_CMR_WAVEFORM_ACPA_TOGGLE_Val << TC_CMR_WAVEFORM_ACPA_Pos)
+#define TC_CMR_WAVEFORM_ACPC_Pos    18           /**< \brief (TC_CMR_WAVEFORM) RC Compare Effect on TIOA */
+#define TC_CMR_WAVEFORM_ACPC_Msk    (_U(0x3) << TC_CMR_WAVEFORM_ACPC_Pos)
+#define TC_CMR_WAVEFORM_ACPC(value) (TC_CMR_WAVEFORM_ACPC_Msk & ((value) << TC_CMR_WAVEFORM_ACPC_Pos))
+#define   TC_CMR_WAVEFORM_ACPC_NONE_Val   _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) none */
+#define   TC_CMR_WAVEFORM_ACPC_SET_Val    _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) set */
+#define   TC_CMR_WAVEFORM_ACPC_CLEAR_Val  _U(0x2)   /**< \brief (TC_CMR_WAVEFORM) clear */
+#define   TC_CMR_WAVEFORM_ACPC_TOGGLE_Val _U(0x3)   /**< \brief (TC_CMR_WAVEFORM) toggle */
+#define TC_CMR_WAVEFORM_ACPC_NONE   (TC_CMR_WAVEFORM_ACPC_NONE_Val << TC_CMR_WAVEFORM_ACPC_Pos)
+#define TC_CMR_WAVEFORM_ACPC_SET    (TC_CMR_WAVEFORM_ACPC_SET_Val  << TC_CMR_WAVEFORM_ACPC_Pos)
+#define TC_CMR_WAVEFORM_ACPC_CLEAR  (TC_CMR_WAVEFORM_ACPC_CLEAR_Val << TC_CMR_WAVEFORM_ACPC_Pos)
+#define TC_CMR_WAVEFORM_ACPC_TOGGLE (TC_CMR_WAVEFORM_ACPC_TOGGLE_Val << TC_CMR_WAVEFORM_ACPC_Pos)
+#define TC_CMR_WAVEFORM_AEEVT_Pos   20           /**< \brief (TC_CMR_WAVEFORM) External Event Effect on TIOA */
+#define TC_CMR_WAVEFORM_AEEVT_Msk   (_U(0x3) << TC_CMR_WAVEFORM_AEEVT_Pos)
+#define TC_CMR_WAVEFORM_AEEVT(value) (TC_CMR_WAVEFORM_AEEVT_Msk & ((value) << TC_CMR_WAVEFORM_AEEVT_Pos))
+#define   TC_CMR_WAVEFORM_AEEVT_NONE_Val  _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) none */
+#define   TC_CMR_WAVEFORM_AEEVT_SET_Val   _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) set */
+#define   TC_CMR_WAVEFORM_AEEVT_CLEAR_Val _U(0x2)   /**< \brief (TC_CMR_WAVEFORM) clear */
+#define   TC_CMR_WAVEFORM_AEEVT_TOGGLE_Val _U(0x3)   /**< \brief (TC_CMR_WAVEFORM) toggle */
+#define TC_CMR_WAVEFORM_AEEVT_NONE  (TC_CMR_WAVEFORM_AEEVT_NONE_Val << TC_CMR_WAVEFORM_AEEVT_Pos)
+#define TC_CMR_WAVEFORM_AEEVT_SET   (TC_CMR_WAVEFORM_AEEVT_SET_Val << TC_CMR_WAVEFORM_AEEVT_Pos)
+#define TC_CMR_WAVEFORM_AEEVT_CLEAR (TC_CMR_WAVEFORM_AEEVT_CLEAR_Val << TC_CMR_WAVEFORM_AEEVT_Pos)
+#define TC_CMR_WAVEFORM_AEEVT_TOGGLE (TC_CMR_WAVEFORM_AEEVT_TOGGLE_Val << TC_CMR_WAVEFORM_AEEVT_Pos)
+#define TC_CMR_WAVEFORM_ASWTRG_Pos  22           /**< \brief (TC_CMR_WAVEFORM) Software Trigger Effect on TIOA */
+#define TC_CMR_WAVEFORM_ASWTRG_Msk  (_U(0x3) << TC_CMR_WAVEFORM_ASWTRG_Pos)
+#define TC_CMR_WAVEFORM_ASWTRG(value) (TC_CMR_WAVEFORM_ASWTRG_Msk & ((value) << TC_CMR_WAVEFORM_ASWTRG_Pos))
+#define   TC_CMR_WAVEFORM_ASWTRG_NONE_Val _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) none */
+#define   TC_CMR_WAVEFORM_ASWTRG_SET_Val  _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) set */
+#define   TC_CMR_WAVEFORM_ASWTRG_CLEAR_Val _U(0x2)   /**< \brief (TC_CMR_WAVEFORM) clear */
+#define   TC_CMR_WAVEFORM_ASWTRG_TOGGLE_Val _U(0x3)   /**< \brief (TC_CMR_WAVEFORM) toggle */
+#define TC_CMR_WAVEFORM_ASWTRG_NONE (TC_CMR_WAVEFORM_ASWTRG_NONE_Val << TC_CMR_WAVEFORM_ASWTRG_Pos)
+#define TC_CMR_WAVEFORM_ASWTRG_SET  (TC_CMR_WAVEFORM_ASWTRG_SET_Val << TC_CMR_WAVEFORM_ASWTRG_Pos)
+#define TC_CMR_WAVEFORM_ASWTRG_CLEAR (TC_CMR_WAVEFORM_ASWTRG_CLEAR_Val << TC_CMR_WAVEFORM_ASWTRG_Pos)
+#define TC_CMR_WAVEFORM_ASWTRG_TOGGLE (TC_CMR_WAVEFORM_ASWTRG_TOGGLE_Val << TC_CMR_WAVEFORM_ASWTRG_Pos)
+#define TC_CMR_WAVEFORM_BCPB_Pos    24           /**< \brief (TC_CMR_WAVEFORM) RB Compare Effect on TIOB */
+#define TC_CMR_WAVEFORM_BCPB_Msk    (_U(0x3) << TC_CMR_WAVEFORM_BCPB_Pos)
+#define TC_CMR_WAVEFORM_BCPB(value) (TC_CMR_WAVEFORM_BCPB_Msk & ((value) << TC_CMR_WAVEFORM_BCPB_Pos))
+#define   TC_CMR_WAVEFORM_BCPB_NONE_Val   _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) none */
+#define   TC_CMR_WAVEFORM_BCPB_SET_Val    _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) set */
+#define   TC_CMR_WAVEFORM_BCPB_CLEAR_Val  _U(0x2)   /**< \brief (TC_CMR_WAVEFORM) clear */
+#define   TC_CMR_WAVEFORM_BCPB_TOGGLE_Val _U(0x3)   /**< \brief (TC_CMR_WAVEFORM) toggle */
+#define TC_CMR_WAVEFORM_BCPB_NONE   (TC_CMR_WAVEFORM_BCPB_NONE_Val << TC_CMR_WAVEFORM_BCPB_Pos)
+#define TC_CMR_WAVEFORM_BCPB_SET    (TC_CMR_WAVEFORM_BCPB_SET_Val  << TC_CMR_WAVEFORM_BCPB_Pos)
+#define TC_CMR_WAVEFORM_BCPB_CLEAR  (TC_CMR_WAVEFORM_BCPB_CLEAR_Val << TC_CMR_WAVEFORM_BCPB_Pos)
+#define TC_CMR_WAVEFORM_BCPB_TOGGLE (TC_CMR_WAVEFORM_BCPB_TOGGLE_Val << TC_CMR_WAVEFORM_BCPB_Pos)
+#define TC_CMR_WAVEFORM_BCPC_Pos    26           /**< \brief (TC_CMR_WAVEFORM) RC Compare Effect on TIOB */
+#define TC_CMR_WAVEFORM_BCPC_Msk    (_U(0x3) << TC_CMR_WAVEFORM_BCPC_Pos)
+#define TC_CMR_WAVEFORM_BCPC(value) (TC_CMR_WAVEFORM_BCPC_Msk & ((value) << TC_CMR_WAVEFORM_BCPC_Pos))
+#define   TC_CMR_WAVEFORM_BCPC_NONE_Val   _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) none */
+#define   TC_CMR_WAVEFORM_BCPC_SET_Val    _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) set */
+#define   TC_CMR_WAVEFORM_BCPC_CLEAR_Val  _U(0x2)   /**< \brief (TC_CMR_WAVEFORM) clear */
+#define   TC_CMR_WAVEFORM_BCPC_TOGGLE_Val _U(0x3)   /**< \brief (TC_CMR_WAVEFORM) toggle */
+#define TC_CMR_WAVEFORM_BCPC_NONE   (TC_CMR_WAVEFORM_BCPC_NONE_Val << TC_CMR_WAVEFORM_BCPC_Pos)
+#define TC_CMR_WAVEFORM_BCPC_SET    (TC_CMR_WAVEFORM_BCPC_SET_Val  << TC_CMR_WAVEFORM_BCPC_Pos)
+#define TC_CMR_WAVEFORM_BCPC_CLEAR  (TC_CMR_WAVEFORM_BCPC_CLEAR_Val << TC_CMR_WAVEFORM_BCPC_Pos)
+#define TC_CMR_WAVEFORM_BCPC_TOGGLE (TC_CMR_WAVEFORM_BCPC_TOGGLE_Val << TC_CMR_WAVEFORM_BCPC_Pos)
+#define TC_CMR_WAVEFORM_BEEVT_Pos   28           /**< \brief (TC_CMR_WAVEFORM) External Event Effect on TIOB */
+#define TC_CMR_WAVEFORM_BEEVT_Msk   (_U(0x3) << TC_CMR_WAVEFORM_BEEVT_Pos)
+#define TC_CMR_WAVEFORM_BEEVT(value) (TC_CMR_WAVEFORM_BEEVT_Msk & ((value) << TC_CMR_WAVEFORM_BEEVT_Pos))
+#define   TC_CMR_WAVEFORM_BEEVT_NONE_Val  _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) none */
+#define   TC_CMR_WAVEFORM_BEEVT_SET_Val   _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) set */
+#define   TC_CMR_WAVEFORM_BEEVT_CLEAR_Val _U(0x2)   /**< \brief (TC_CMR_WAVEFORM) clear */
+#define   TC_CMR_WAVEFORM_BEEVT_TOGGLE_Val _U(0x3)   /**< \brief (TC_CMR_WAVEFORM) toggle */
+#define TC_CMR_WAVEFORM_BEEVT_NONE  (TC_CMR_WAVEFORM_BEEVT_NONE_Val << TC_CMR_WAVEFORM_BEEVT_Pos)
+#define TC_CMR_WAVEFORM_BEEVT_SET   (TC_CMR_WAVEFORM_BEEVT_SET_Val << TC_CMR_WAVEFORM_BEEVT_Pos)
+#define TC_CMR_WAVEFORM_BEEVT_CLEAR (TC_CMR_WAVEFORM_BEEVT_CLEAR_Val << TC_CMR_WAVEFORM_BEEVT_Pos)
+#define TC_CMR_WAVEFORM_BEEVT_TOGGLE (TC_CMR_WAVEFORM_BEEVT_TOGGLE_Val << TC_CMR_WAVEFORM_BEEVT_Pos)
+#define TC_CMR_WAVEFORM_BSWTRG_Pos  30           /**< \brief (TC_CMR_WAVEFORM) Software Trigger Effect on TIOB */
+#define TC_CMR_WAVEFORM_BSWTRG_Msk  (_U(0x3) << TC_CMR_WAVEFORM_BSWTRG_Pos)
+#define TC_CMR_WAVEFORM_BSWTRG(value) (TC_CMR_WAVEFORM_BSWTRG_Msk & ((value) << TC_CMR_WAVEFORM_BSWTRG_Pos))
+#define   TC_CMR_WAVEFORM_BSWTRG_NONE_Val _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) none */
+#define   TC_CMR_WAVEFORM_BSWTRG_SET_Val  _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) set */
+#define   TC_CMR_WAVEFORM_BSWTRG_CLEAR_Val _U(0x2)   /**< \brief (TC_CMR_WAVEFORM) clear */
+#define   TC_CMR_WAVEFORM_BSWTRG_TOGGLE_Val _U(0x3)   /**< \brief (TC_CMR_WAVEFORM) toggle */
+#define TC_CMR_WAVEFORM_BSWTRG_NONE (TC_CMR_WAVEFORM_BSWTRG_NONE_Val << TC_CMR_WAVEFORM_BSWTRG_Pos)
+#define TC_CMR_WAVEFORM_BSWTRG_SET  (TC_CMR_WAVEFORM_BSWTRG_SET_Val << TC_CMR_WAVEFORM_BSWTRG_Pos)
+#define TC_CMR_WAVEFORM_BSWTRG_CLEAR (TC_CMR_WAVEFORM_BSWTRG_CLEAR_Val << TC_CMR_WAVEFORM_BSWTRG_Pos)
+#define TC_CMR_WAVEFORM_BSWTRG_TOGGLE (TC_CMR_WAVEFORM_BSWTRG_TOGGLE_Val << TC_CMR_WAVEFORM_BSWTRG_Pos)
+#define TC_CMR_WAVEFORM_MASK        _U(0xFFFFFFFF) /**< \brief (TC_CMR_WAVEFORM) MASK Register */
+
+// Any mode
+#define TC_CMR_TCCLKS_Pos           0            /**< \brief (TC_CMR) Clock Selection */
+#define TC_CMR_TCCLKS_Msk           (_U(0x7) << TC_CMR_TCCLKS_Pos)
+#define TC_CMR_TCCLKS(value)        (TC_CMR_TCCLKS_Msk & ((value) << TC_CMR_TCCLKS_Pos))
+#define   TC_CMR_TCCLKS_TIMER_CLOCK1_Val  _U(0x0)   /**< \brief (TC_CMR) TIMER_CLOCK1 */
+#define   TC_CMR_TCCLKS_TIMER_CLOCK2_Val  _U(0x1)   /**< \brief (TC_CMR) TIMER_CLOCK2 */
+#define   TC_CMR_TCCLKS_TIMER_CLOCK3_Val  _U(0x2)   /**< \brief (TC_CMR) TIMER_CLOCK3 */
+#define   TC_CMR_TCCLKS_TIMER_CLOCK4_Val  _U(0x3)   /**< \brief (TC_CMR) TIMER_CLOCK4 */
+#define   TC_CMR_TCCLKS_TIMER_CLOCK5_Val  _U(0x4)   /**< \brief (TC_CMR) TIMER_CLOCK5 */
+#define   TC_CMR_TCCLKS_XC0_Val           _U(0x5)   /**< \brief (TC_CMR) XC0 */
+#define   TC_CMR_TCCLKS_XC1_Val           _U(0x6)   /**< \brief (TC_CMR) XC1 */
+#define   TC_CMR_TCCLKS_XC2_Val           _U(0x7)   /**< \brief (TC_CMR) XC2 */
+#define TC_CMR_TCCLKS_TIMER_CLOCK1  (TC_CMR_TCCLKS_TIMER_CLOCK1_Val << TC_CMR_TCCLKS_Pos)
+#define TC_CMR_TCCLKS_TIMER_CLOCK2  (TC_CMR_TCCLKS_TIMER_CLOCK2_Val << TC_CMR_TCCLKS_Pos)
+#define TC_CMR_TCCLKS_TIMER_CLOCK3  (TC_CMR_TCCLKS_TIMER_CLOCK3_Val << TC_CMR_TCCLKS_Pos)
+#define TC_CMR_TCCLKS_TIMER_CLOCK4  (TC_CMR_TCCLKS_TIMER_CLOCK4_Val << TC_CMR_TCCLKS_Pos)
+#define TC_CMR_TCCLKS_TIMER_CLOCK5  (TC_CMR_TCCLKS_TIMER_CLOCK5_Val << TC_CMR_TCCLKS_Pos)
+#define TC_CMR_TCCLKS_XC0           (TC_CMR_TCCLKS_XC0_Val         << TC_CMR_TCCLKS_Pos)
+#define TC_CMR_TCCLKS_XC1           (TC_CMR_TCCLKS_XC1_Val         << TC_CMR_TCCLKS_Pos)
+#define TC_CMR_TCCLKS_XC2           (TC_CMR_TCCLKS_XC2_Val         << TC_CMR_TCCLKS_Pos)
+#define TC_CMR_CLKI_Pos             3            /**< \brief (TC_CMR) Clock Invert */
+#define TC_CMR_CLKI                 (_U(0x1) << TC_CMR_CLKI_Pos)
+#define   TC_CMR_CLKI_0_Val               _U(0x0)   /**< \brief (TC_CMR) Counter is incremented on rising edge of the clock. */
+#define   TC_CMR_CLKI_1_Val               _U(0x1)   /**< \brief (TC_CMR) Counter is incremented on falling edge of the clock. */
+#define TC_CMR_CLKI_0               (TC_CMR_CLKI_0_Val             << TC_CMR_CLKI_Pos)
+#define TC_CMR_CLKI_1               (TC_CMR_CLKI_1_Val             << TC_CMR_CLKI_Pos)
+#define TC_CMR_BURST_Pos            4            /**< \brief (TC_CMR) Burst Signal Selection */
+#define TC_CMR_BURST_Msk            (_U(0x3) << TC_CMR_BURST_Pos)
+#define TC_CMR_BURST(value)         (TC_CMR_BURST_Msk & ((value) << TC_CMR_BURST_Pos))
+#define   TC_CMR_BURST_NOT_GATED_Val      _U(0x0)   /**< \brief (TC_CMR) The clock is not gated by an external signal. */
+#define   TC_CMR_BURST_CLK_AND_XC0_Val    _U(0x1)   /**< \brief (TC_CMR) XC0 is ANDed with the selected clock. */
+#define   TC_CMR_BURST_CLK_AND_XC1_Val    _U(0x2)   /**< \brief (TC_CMR) XC1 is ANDed with the selected clock. */
+#define   TC_CMR_BURST_CLK_AND_XC2_Val    _U(0x3)   /**< \brief (TC_CMR) XC2 is ANDed with the selected clock. */
+#define TC_CMR_BURST_NOT_GATED      (TC_CMR_BURST_NOT_GATED_Val    << TC_CMR_BURST_Pos)
+#define TC_CMR_BURST_CLK_AND_XC0    (TC_CMR_BURST_CLK_AND_XC0_Val  << TC_CMR_BURST_Pos)
+#define TC_CMR_BURST_CLK_AND_XC1    (TC_CMR_BURST_CLK_AND_XC1_Val  << TC_CMR_BURST_Pos)
+#define TC_CMR_BURST_CLK_AND_XC2    (TC_CMR_BURST_CLK_AND_XC2_Val  << TC_CMR_BURST_Pos)
+#define TC_CMR_LDBSTOP_Pos          6            /**< \brief (TC_CMR) Counter Clock Stopped with RB Loading */
+#define TC_CMR_LDBSTOP              (_U(0x1) << TC_CMR_LDBSTOP_Pos)
+#define   TC_CMR_LDBSTOP_0_Val            _U(0x0)   /**< \brief (TC_CMR) Counter clock is not stopped when RB loading occurs. */
+#define   TC_CMR_LDBSTOP_1_Val            _U(0x1)   /**< \brief (TC_CMR) Counter clock is stopped when RB loading occurs. */
+#define TC_CMR_LDBSTOP_0            (TC_CMR_LDBSTOP_0_Val          << TC_CMR_LDBSTOP_Pos)
+#define TC_CMR_LDBSTOP_1            (TC_CMR_LDBSTOP_1_Val          << TC_CMR_LDBSTOP_Pos)
+#define TC_CMR_CPCSTOP_Pos          6            /**< \brief (TC_CMR) Counter Clock Stopped with RC Compare */
+#define TC_CMR_CPCSTOP              (_U(0x1) << TC_CMR_CPCSTOP_Pos)
+#define   TC_CMR_CPCSTOP_0_Val            _U(0x0)   /**< \brief (TC_CMR) Counter clock is not stopped when counter reaches RC. */
+#define   TC_CMR_CPCSTOP_1_Val            _U(0x1)   /**< \brief (TC_CMR) Counter clock is stopped when counter reaches RC. */
+#define TC_CMR_CPCSTOP_0            (TC_CMR_CPCSTOP_0_Val          << TC_CMR_CPCSTOP_Pos)
+#define TC_CMR_CPCSTOP_1            (TC_CMR_CPCSTOP_1_Val          << TC_CMR_CPCSTOP_Pos)
+#define TC_CMR_LDBDIS_Pos           7            /**< \brief (TC_CMR) Counter Clock Disable with RB Loading */
+#define TC_CMR_LDBDIS               (_U(0x1) << TC_CMR_LDBDIS_Pos)
+#define   TC_CMR_LDBDIS_0_Val             _U(0x0)   /**< \brief (TC_CMR) Counter clock is not disabled when RB loading occurs. */
+#define   TC_CMR_LDBDIS_1_Val             _U(0x1)   /**< \brief (TC_CMR) Counter clock is disabled when RB loading occurs. */
+#define TC_CMR_LDBDIS_0             (TC_CMR_LDBDIS_0_Val           << TC_CMR_LDBDIS_Pos)
+#define TC_CMR_LDBDIS_1             (TC_CMR_LDBDIS_1_Val           << TC_CMR_LDBDIS_Pos)
+#define TC_CMR_CPCDIS_Pos           7            /**< \brief (TC_CMR) Counter Clock Disable with RC Compare */
+#define TC_CMR_CPCDIS               (_U(0x1) << TC_CMR_CPCDIS_Pos)
+#define   TC_CMR_CPCDIS_0_Val             _U(0x0)   /**< \brief (TC_CMR) Counter clock is not disabled when counter reaches RC. */
+#define   TC_CMR_CPCDIS_1_Val             _U(0x1)   /**< \brief (TC_CMR) Counter clock is disabled when counter reaches RC. */
+#define TC_CMR_CPCDIS_0             (TC_CMR_CPCDIS_0_Val           << TC_CMR_CPCDIS_Pos)
+#define TC_CMR_CPCDIS_1             (TC_CMR_CPCDIS_1_Val           << TC_CMR_CPCDIS_Pos)
+#define TC_CMR_ETRGEDG_Pos          8            /**< \brief (TC_CMR) External Trigger Edge Selection */
+#define TC_CMR_ETRGEDG_Msk          (_U(0x3) << TC_CMR_ETRGEDG_Pos)
+#define TC_CMR_ETRGEDG(value)       (TC_CMR_ETRGEDG_Msk & ((value) << TC_CMR_ETRGEDG_Pos))
+#define   TC_CMR_ETRGEDG_NO_EDGE_Val      _U(0x0)   /**< \brief (TC_CMR) none */
+#define   TC_CMR_ETRGEDG_POS_EDGE_Val     _U(0x1)   /**< \brief (TC_CMR) rising edge */
+#define   TC_CMR_ETRGEDG_NEG_EDGE_Val     _U(0x2)   /**< \brief (TC_CMR) falling edge */
+#define   TC_CMR_ETRGEDG_BOTH_EDGES_Val   _U(0x3)   /**< \brief (TC_CMR) each edge */
+#define TC_CMR_ETRGEDG_NO_EDGE      (TC_CMR_ETRGEDG_NO_EDGE_Val    << TC_CMR_ETRGEDG_Pos)
+#define TC_CMR_ETRGEDG_POS_EDGE     (TC_CMR_ETRGEDG_POS_EDGE_Val   << TC_CMR_ETRGEDG_Pos)
+#define TC_CMR_ETRGEDG_NEG_EDGE     (TC_CMR_ETRGEDG_NEG_EDGE_Val   << TC_CMR_ETRGEDG_Pos)
+#define TC_CMR_ETRGEDG_BOTH_EDGES   (TC_CMR_ETRGEDG_BOTH_EDGES_Val << TC_CMR_ETRGEDG_Pos)
+#define TC_CMR_EEVTEDG_Pos          8            /**< \brief (TC_CMR) External Event Edge Selection */
+#define TC_CMR_EEVTEDG_Msk          (_U(0x3) << TC_CMR_EEVTEDG_Pos)
+#define TC_CMR_EEVTEDG(value)       (TC_CMR_EEVTEDG_Msk & ((value) << TC_CMR_EEVTEDG_Pos))
+#define   TC_CMR_EEVTEDG_NO_EDGE_Val      _U(0x0)   /**< \brief (TC_CMR) none */
+#define   TC_CMR_EEVTEDG_POS_EDGE_Val     _U(0x1)   /**< \brief (TC_CMR) rising edge */
+#define   TC_CMR_EEVTEDG_NEG_EDGE_Val     _U(0x2)   /**< \brief (TC_CMR) falling edge */
+#define   TC_CMR_EEVTEDG_BOTH_EDGES_Val   _U(0x3)   /**< \brief (TC_CMR) each edge */
+#define TC_CMR_EEVTEDG_NO_EDGE      (TC_CMR_EEVTEDG_NO_EDGE_Val    << TC_CMR_EEVTEDG_Pos)
+#define TC_CMR_EEVTEDG_POS_EDGE     (TC_CMR_EEVTEDG_POS_EDGE_Val   << TC_CMR_EEVTEDG_Pos)
+#define TC_CMR_EEVTEDG_NEG_EDGE     (TC_CMR_EEVTEDG_NEG_EDGE_Val   << TC_CMR_EEVTEDG_Pos)
+#define TC_CMR_EEVTEDG_BOTH_EDGES   (TC_CMR_EEVTEDG_BOTH_EDGES_Val << TC_CMR_EEVTEDG_Pos)
+#define TC_CMR_ABETRG_Pos           10           /**< \brief (TC_CMR) TIOA or TIOB External Trigger Selection */
+#define TC_CMR_ABETRG               (_U(0x1) << TC_CMR_ABETRG_Pos)
+#define   TC_CMR_ABETRG_0_Val             _U(0x0)   /**< \brief (TC_CMR) TIOB is used as an external trigger. */
+#define   TC_CMR_ABETRG_1_Val             _U(0x1)   /**< \brief (TC_CMR) TIOA is used as an external trigger. */
+#define TC_CMR_ABETRG_0             (TC_CMR_ABETRG_0_Val           << TC_CMR_ABETRG_Pos)
+#define TC_CMR_ABETRG_1             (TC_CMR_ABETRG_1_Val           << TC_CMR_ABETRG_Pos)
+#define TC_CMR_EEVT_Pos             10           /**< \brief (TC_CMR) External Event Selection */
+#define TC_CMR_EEVT_Msk             (_U(0x3) << TC_CMR_EEVT_Pos)
+#define TC_CMR_EEVT(value)          (TC_CMR_EEVT_Msk & ((value) << TC_CMR_EEVT_Pos))
+#define   TC_CMR_EEVT_TIOB_INPUT_Val      _U(0x0)   /**< \brief (TC_CMR) TIOB input. If TIOB is chosen as the external event signal, it is configured as an input and no longer generates waveforms. */
+#define   TC_CMR_EEVT_XC0_OUTPUT_Val      _U(0x1)   /**< \brief (TC_CMR) XC0 output */
+#define   TC_CMR_EEVT_XC1_OUTPUT_Val      _U(0x2)   /**< \brief (TC_CMR) XC1 output */
+#define   TC_CMR_EEVT_XC2_OUTPUT_Val      _U(0x3)   /**< \brief (TC_CMR) XC2 output */
+#define TC_CMR_EEVT_TIOB_INPUT      (TC_CMR_EEVT_TIOB_INPUT_Val    << TC_CMR_EEVT_Pos)
+#define TC_CMR_EEVT_XC0_OUTPUT      (TC_CMR_EEVT_XC0_OUTPUT_Val    << TC_CMR_EEVT_Pos)
+#define TC_CMR_EEVT_XC1_OUTPUT      (TC_CMR_EEVT_XC1_OUTPUT_Val    << TC_CMR_EEVT_Pos)
+#define TC_CMR_EEVT_XC2_OUTPUT      (TC_CMR_EEVT_XC2_OUTPUT_Val    << TC_CMR_EEVT_Pos)
+#define TC_CMR_ENETRG_Pos           12           /**< \brief (TC_CMR) External Event Trigger Enable */
+#define TC_CMR_ENETRG               (_U(0x1) << TC_CMR_ENETRG_Pos)
+#define   TC_CMR_ENETRG_0_Val             _U(0x0)   /**< \brief (TC_CMR) The external event has no effect on the counter and its clock. In this case, the selected external event only controls the TIOA output. */
+#define   TC_CMR_ENETRG_1_Val             _U(0x1)   /**< \brief (TC_CMR) The external event resets the counter and starts the counter clock. */
+#define TC_CMR_ENETRG_0             (TC_CMR_ENETRG_0_Val           << TC_CMR_ENETRG_Pos)
+#define TC_CMR_ENETRG_1             (TC_CMR_ENETRG_1_Val           << TC_CMR_ENETRG_Pos)
+#define TC_CMR_WAVSEL_Pos           13           /**< \brief (TC_CMR) Waveform Selection */
+#define TC_CMR_WAVSEL_Msk           (_U(0x3) << TC_CMR_WAVSEL_Pos)
+#define TC_CMR_WAVSEL(value)        (TC_CMR_WAVSEL_Msk & ((value) << TC_CMR_WAVSEL_Pos))
+#define   TC_CMR_WAVSEL_UP_NO_AUTO_Val    _U(0x0)   /**< \brief (TC_CMR) UP mode without automatic trigger on RC Compare */
+#define   TC_CMR_WAVSEL_UPDOWN_NO_AUTO_Val _U(0x1)   /**< \brief (TC_CMR) UPDOWN mode without automatic trigger on RC Compare */
+#define   TC_CMR_WAVSEL_UP_AUTO_Val       _U(0x2)   /**< \brief (TC_CMR) UP mode with automatic trigger on RC Compare */
+#define   TC_CMR_WAVSEL_UPDOWN_AUTO_Val   _U(0x3)   /**< \brief (TC_CMR) UPDOWN mode with automatic trigger on RC Compare */
+#define TC_CMR_WAVSEL_UP_NO_AUTO    (TC_CMR_WAVSEL_UP_NO_AUTO_Val  << TC_CMR_WAVSEL_Pos)
+#define TC_CMR_WAVSEL_UPDOWN_NO_AUTO (TC_CMR_WAVSEL_UPDOWN_NO_AUTO_Val << TC_CMR_WAVSEL_Pos)
+#define TC_CMR_WAVSEL_UP_AUTO       (TC_CMR_WAVSEL_UP_AUTO_Val     << TC_CMR_WAVSEL_Pos)
+#define TC_CMR_WAVSEL_UPDOWN_AUTO   (TC_CMR_WAVSEL_UPDOWN_AUTO_Val << TC_CMR_WAVSEL_Pos)
+#define TC_CMR_CPCTRG_Pos           14           /**< \brief (TC_CMR) RC Compare Trigger Enable */
+#define TC_CMR_CPCTRG               (_U(0x1) << TC_CMR_CPCTRG_Pos)
+#define   TC_CMR_CPCTRG_0_Val             _U(0x0)   /**< \brief (TC_CMR) RC Compare has no effect on the counter and its clock. */
+#define   TC_CMR_CPCTRG_1_Val             _U(0x1)   /**< \brief (TC_CMR) RC Compare resets the counter and starts the counter clock. */
+#define TC_CMR_CPCTRG_0             (TC_CMR_CPCTRG_0_Val           << TC_CMR_CPCTRG_Pos)
+#define TC_CMR_CPCTRG_1             (TC_CMR_CPCTRG_1_Val           << TC_CMR_CPCTRG_Pos)
+#define TC_CMR_WAVE_Pos             15           /**< \brief (TC_CMR) Wave */
+#define TC_CMR_WAVE                 (_U(0x1) << TC_CMR_WAVE_Pos)
+#define   TC_CMR_WAVE_0_Val               _U(0x0)   /**< \brief (TC_CMR) Capture Mode is enabled. */
+#define   TC_CMR_WAVE_1_Val               _U(0x1)   /**< \brief (TC_CMR) Capture Mode is disabled (Waveform Mode is enabled). */
+#define TC_CMR_WAVE_0               (TC_CMR_WAVE_0_Val             << TC_CMR_WAVE_Pos)
+#define TC_CMR_WAVE_1               (TC_CMR_WAVE_1_Val             << TC_CMR_WAVE_Pos)
+#define TC_CMR_LDRA_Pos             16           /**< \brief (TC_CMR) RA Loading Selection */
+#define TC_CMR_LDRA_Msk             (_U(0x3) << TC_CMR_LDRA_Pos)
+#define TC_CMR_LDRA(value)          (TC_CMR_LDRA_Msk & ((value) << TC_CMR_LDRA_Pos))
+#define   TC_CMR_LDRA_NO_EDGE_Val         _U(0x0)   /**< \brief (TC_CMR) none */
+#define   TC_CMR_LDRA_POS_EDGE_TIOA_Val   _U(0x1)   /**< \brief (TC_CMR) rising edge of TIOA */
+#define   TC_CMR_LDRA_NEG_EDGE_TIOA_Val   _U(0x2)   /**< \brief (TC_CMR) falling edge of TIOA */
+#define   TC_CMR_LDRA_BOTH_EDGES_TIOA_Val _U(0x3)   /**< \brief (TC_CMR) each edge of TIOA */
+#define TC_CMR_LDRA_NO_EDGE         (TC_CMR_LDRA_NO_EDGE_Val       << TC_CMR_LDRA_Pos)
+#define TC_CMR_LDRA_POS_EDGE_TIOA   (TC_CMR_LDRA_POS_EDGE_TIOA_Val << TC_CMR_LDRA_Pos)
+#define TC_CMR_LDRA_NEG_EDGE_TIOA   (TC_CMR_LDRA_NEG_EDGE_TIOA_Val << TC_CMR_LDRA_Pos)
+#define TC_CMR_LDRA_BOTH_EDGES_TIOA (TC_CMR_LDRA_BOTH_EDGES_TIOA_Val << TC_CMR_LDRA_Pos)
+#define TC_CMR_ACPA_Pos             16           /**< \brief (TC_CMR) RA Compare Effect on TIOA */
+#define TC_CMR_ACPA_Msk             (_U(0x3) << TC_CMR_ACPA_Pos)
+#define TC_CMR_ACPA(value)          (TC_CMR_ACPA_Msk & ((value) << TC_CMR_ACPA_Pos))
+#define   TC_CMR_ACPA_NONE_Val            _U(0x0)   /**< \brief (TC_CMR) none */
+#define   TC_CMR_ACPA_SET_Val             _U(0x1)   /**< \brief (TC_CMR) set */
+#define   TC_CMR_ACPA_CLEAR_Val           _U(0x2)   /**< \brief (TC_CMR) clear */
+#define   TC_CMR_ACPA_TOGGLE_Val          _U(0x3)   /**< \brief (TC_CMR) toggle */
+#define TC_CMR_ACPA_NONE            (TC_CMR_ACPA_NONE_Val          << TC_CMR_ACPA_Pos)
+#define TC_CMR_ACPA_SET             (TC_CMR_ACPA_SET_Val           << TC_CMR_ACPA_Pos)
+#define TC_CMR_ACPA_CLEAR           (TC_CMR_ACPA_CLEAR_Val         << TC_CMR_ACPA_Pos)
+#define TC_CMR_ACPA_TOGGLE          (TC_CMR_ACPA_TOGGLE_Val        << TC_CMR_ACPA_Pos)
+#define TC_CMR_LDRB_Pos             18           /**< \brief (TC_CMR) RB Loading Selection */
+#define TC_CMR_LDRB_Msk             (_U(0x3) << TC_CMR_LDRB_Pos)
+#define TC_CMR_LDRB(value)          (TC_CMR_LDRB_Msk & ((value) << TC_CMR_LDRB_Pos))
+#define   TC_CMR_LDRB_NO_EDGE_Val         _U(0x0)   /**< \brief (TC_CMR) none */
+#define   TC_CMR_LDRB_POS_EDGE_TIOA_Val   _U(0x1)   /**< \brief (TC_CMR) rising edge of TIOA */
+#define   TC_CMR_LDRB_NEG_EDGE_TIOA_Val   _U(0x2)   /**< \brief (TC_CMR) falling edge of TIOA */
+#define   TC_CMR_LDRB_BOTH_EDGES_TIOA_Val _U(0x3)   /**< \brief (TC_CMR) each edge of TIOA */
+#define TC_CMR_LDRB_NO_EDGE         (TC_CMR_LDRB_NO_EDGE_Val       << TC_CMR_LDRB_Pos)
+#define TC_CMR_LDRB_POS_EDGE_TIOA   (TC_CMR_LDRB_POS_EDGE_TIOA_Val << TC_CMR_LDRB_Pos)
+#define TC_CMR_LDRB_NEG_EDGE_TIOA   (TC_CMR_LDRB_NEG_EDGE_TIOA_Val << TC_CMR_LDRB_Pos)
+#define TC_CMR_LDRB_BOTH_EDGES_TIOA (TC_CMR_LDRB_BOTH_EDGES_TIOA_Val << TC_CMR_LDRB_Pos)
+#define TC_CMR_ACPC_Pos             18           /**< \brief (TC_CMR) RC Compare Effect on TIOA */
+#define TC_CMR_ACPC_Msk             (_U(0x3) << TC_CMR_ACPC_Pos)
+#define TC_CMR_ACPC(value)          (TC_CMR_ACPC_Msk & ((value) << TC_CMR_ACPC_Pos))
+#define   TC_CMR_ACPC_NONE_Val            _U(0x0)   /**< \brief (TC_CMR) none */
+#define   TC_CMR_ACPC_SET_Val             _U(0x1)   /**< \brief (TC_CMR) set */
+#define   TC_CMR_ACPC_CLEAR_Val           _U(0x2)   /**< \brief (TC_CMR) clear */
+#define   TC_CMR_ACPC_TOGGLE_Val          _U(0x3)   /**< \brief (TC_CMR) toggle */
+#define TC_CMR_ACPC_NONE            (TC_CMR_ACPC_NONE_Val          << TC_CMR_ACPC_Pos)
+#define TC_CMR_ACPC_SET             (TC_CMR_ACPC_SET_Val           << TC_CMR_ACPC_Pos)
+#define TC_CMR_ACPC_CLEAR           (TC_CMR_ACPC_CLEAR_Val         << TC_CMR_ACPC_Pos)
+#define TC_CMR_ACPC_TOGGLE          (TC_CMR_ACPC_TOGGLE_Val        << TC_CMR_ACPC_Pos)
+#define TC_CMR_AEEVT_Pos            20           /**< \brief (TC_CMR) External Event Effect on TIOA */
+#define TC_CMR_AEEVT_Msk            (_U(0x3) << TC_CMR_AEEVT_Pos)
+#define TC_CMR_AEEVT(value)         (TC_CMR_AEEVT_Msk & ((value) << TC_CMR_AEEVT_Pos))
+#define   TC_CMR_AEEVT_NONE_Val           _U(0x0)   /**< \brief (TC_CMR) none */
+#define   TC_CMR_AEEVT_SET_Val            _U(0x1)   /**< \brief (TC_CMR) set */
+#define   TC_CMR_AEEVT_CLEAR_Val          _U(0x2)   /**< \brief (TC_CMR) clear */
+#define   TC_CMR_AEEVT_TOGGLE_Val         _U(0x3)   /**< \brief (TC_CMR) toggle */
+#define TC_CMR_AEEVT_NONE           (TC_CMR_AEEVT_NONE_Val         << TC_CMR_AEEVT_Pos)
+#define TC_CMR_AEEVT_SET            (TC_CMR_AEEVT_SET_Val          << TC_CMR_AEEVT_Pos)
+#define TC_CMR_AEEVT_CLEAR          (TC_CMR_AEEVT_CLEAR_Val        << TC_CMR_AEEVT_Pos)
+#define TC_CMR_AEEVT_TOGGLE         (TC_CMR_AEEVT_TOGGLE_Val       << TC_CMR_AEEVT_Pos)
+#define TC_CMR_ASWTRG_Pos           22           /**< \brief (TC_CMR) Software Trigger Effect on TIOA */
+#define TC_CMR_ASWTRG_Msk           (_U(0x3) << TC_CMR_ASWTRG_Pos)
+#define TC_CMR_ASWTRG(value)        (TC_CMR_ASWTRG_Msk & ((value) << TC_CMR_ASWTRG_Pos))
+#define   TC_CMR_ASWTRG_NONE_Val          _U(0x0)   /**< \brief (TC_CMR) none */
+#define   TC_CMR_ASWTRG_SET_Val           _U(0x1)   /**< \brief (TC_CMR) set */
+#define   TC_CMR_ASWTRG_CLEAR_Val         _U(0x2)   /**< \brief (TC_CMR) clear */
+#define   TC_CMR_ASWTRG_TOGGLE_Val        _U(0x3)   /**< \brief (TC_CMR) toggle */
+#define TC_CMR_ASWTRG_NONE          (TC_CMR_ASWTRG_NONE_Val        << TC_CMR_ASWTRG_Pos)
+#define TC_CMR_ASWTRG_SET           (TC_CMR_ASWTRG_SET_Val         << TC_CMR_ASWTRG_Pos)
+#define TC_CMR_ASWTRG_CLEAR         (TC_CMR_ASWTRG_CLEAR_Val       << TC_CMR_ASWTRG_Pos)
+#define TC_CMR_ASWTRG_TOGGLE        (TC_CMR_ASWTRG_TOGGLE_Val      << TC_CMR_ASWTRG_Pos)
+#define TC_CMR_BCPB_Pos             24           /**< \brief (TC_CMR) RB Compare Effect on TIOB */
+#define TC_CMR_BCPB_Msk             (_U(0x3) << TC_CMR_BCPB_Pos)
+#define TC_CMR_BCPB(value)          (TC_CMR_BCPB_Msk & ((value) << TC_CMR_BCPB_Pos))
+#define   TC_CMR_BCPB_NONE_Val            _U(0x0)   /**< \brief (TC_CMR) none */
+#define   TC_CMR_BCPB_SET_Val             _U(0x1)   /**< \brief (TC_CMR) set */
+#define   TC_CMR_BCPB_CLEAR_Val           _U(0x2)   /**< \brief (TC_CMR) clear */
+#define   TC_CMR_BCPB_TOGGLE_Val          _U(0x3)   /**< \brief (TC_CMR) toggle */
+#define TC_CMR_BCPB_NONE            (TC_CMR_BCPB_NONE_Val          << TC_CMR_BCPB_Pos)
+#define TC_CMR_BCPB_SET             (TC_CMR_BCPB_SET_Val           << TC_CMR_BCPB_Pos)
+#define TC_CMR_BCPB_CLEAR           (TC_CMR_BCPB_CLEAR_Val         << TC_CMR_BCPB_Pos)
+#define TC_CMR_BCPB_TOGGLE          (TC_CMR_BCPB_TOGGLE_Val        << TC_CMR_BCPB_Pos)
+#define TC_CMR_BCPC_Pos             26           /**< \brief (TC_CMR) RC Compare Effect on TIOB */
+#define TC_CMR_BCPC_Msk             (_U(0x3) << TC_CMR_BCPC_Pos)
+#define TC_CMR_BCPC(value)          (TC_CMR_BCPC_Msk & ((value) << TC_CMR_BCPC_Pos))
+#define   TC_CMR_BCPC_NONE_Val            _U(0x0)   /**< \brief (TC_CMR) none */
+#define   TC_CMR_BCPC_SET_Val             _U(0x1)   /**< \brief (TC_CMR) set */
+#define   TC_CMR_BCPC_CLEAR_Val           _U(0x2)   /**< \brief (TC_CMR) clear */
+#define   TC_CMR_BCPC_TOGGLE_Val          _U(0x3)   /**< \brief (TC_CMR) toggle */
+#define TC_CMR_BCPC_NONE            (TC_CMR_BCPC_NONE_Val          << TC_CMR_BCPC_Pos)
+#define TC_CMR_BCPC_SET             (TC_CMR_BCPC_SET_Val           << TC_CMR_BCPC_Pos)
+#define TC_CMR_BCPC_CLEAR           (TC_CMR_BCPC_CLEAR_Val         << TC_CMR_BCPC_Pos)
+#define TC_CMR_BCPC_TOGGLE          (TC_CMR_BCPC_TOGGLE_Val        << TC_CMR_BCPC_Pos)
+#define TC_CMR_BEEVT_Pos            28           /**< \brief (TC_CMR) External Event Effect on TIOB */
+#define TC_CMR_BEEVT_Msk            (_U(0x3) << TC_CMR_BEEVT_Pos)
+#define TC_CMR_BEEVT(value)         (TC_CMR_BEEVT_Msk & ((value) << TC_CMR_BEEVT_Pos))
+#define   TC_CMR_BEEVT_NONE_Val           _U(0x0)   /**< \brief (TC_CMR) none */
+#define   TC_CMR_BEEVT_SET_Val            _U(0x1)   /**< \brief (TC_CMR) set */
+#define   TC_CMR_BEEVT_CLEAR_Val          _U(0x2)   /**< \brief (TC_CMR) clear */
+#define   TC_CMR_BEEVT_TOGGLE_Val         _U(0x3)   /**< \brief (TC_CMR) toggle */
+#define TC_CMR_BEEVT_NONE           (TC_CMR_BEEVT_NONE_Val         << TC_CMR_BEEVT_Pos)
+#define TC_CMR_BEEVT_SET            (TC_CMR_BEEVT_SET_Val          << TC_CMR_BEEVT_Pos)
+#define TC_CMR_BEEVT_CLEAR          (TC_CMR_BEEVT_CLEAR_Val        << TC_CMR_BEEVT_Pos)
+#define TC_CMR_BEEVT_TOGGLE         (TC_CMR_BEEVT_TOGGLE_Val       << TC_CMR_BEEVT_Pos)
+#define TC_CMR_BSWTRG_Pos           30           /**< \brief (TC_CMR) Software Trigger Effect on TIOB */
+#define TC_CMR_BSWTRG_Msk           (_U(0x3) << TC_CMR_BSWTRG_Pos)
+#define TC_CMR_BSWTRG(value)        (TC_CMR_BSWTRG_Msk & ((value) << TC_CMR_BSWTRG_Pos))
+#define   TC_CMR_BSWTRG_NONE_Val          _U(0x0)   /**< \brief (TC_CMR) none */
+#define   TC_CMR_BSWTRG_SET_Val           _U(0x1)   /**< \brief (TC_CMR) set */
+#define   TC_CMR_BSWTRG_CLEAR_Val         _U(0x2)   /**< \brief (TC_CMR) clear */
+#define   TC_CMR_BSWTRG_TOGGLE_Val        _U(0x3)   /**< \brief (TC_CMR) toggle */
+#define TC_CMR_BSWTRG_NONE          (TC_CMR_BSWTRG_NONE_Val        << TC_CMR_BSWTRG_Pos)
+#define TC_CMR_BSWTRG_SET           (TC_CMR_BSWTRG_SET_Val         << TC_CMR_BSWTRG_Pos)
+#define TC_CMR_BSWTRG_CLEAR         (TC_CMR_BSWTRG_CLEAR_Val       << TC_CMR_BSWTRG_Pos)
+#define TC_CMR_BSWTRG_TOGGLE        (TC_CMR_BSWTRG_TOGGLE_Val      << TC_CMR_BSWTRG_Pos)
+#define TC_CMR_MASK                 _U(0xFFFFFFFF) /**< \brief (TC_CMR) MASK Register */
+
+/* -------- TC_SMMR : (TC Offset: 0x08) (R/W 32) channel Stepper Motor Mode Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t GCEN:1;           /*!< bit:      0  Gray Count Enable                  */
+    uint32_t DOWN:1;           /*!< bit:      1  Down Count                         */
+    uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TC_SMMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_SMMR_OFFSET              0x08         /**< \brief (TC_SMMR offset) Stepper Motor Mode Register */
+#define TC_SMMR_RESETVALUE          _U(0x00000000); /**< \brief (TC_SMMR reset_value) Stepper Motor Mode Register */
+
+#define TC_SMMR_GCEN_Pos            0            /**< \brief (TC_SMMR) Gray Count Enable */
+#define TC_SMMR_GCEN                (_U(0x1) << TC_SMMR_GCEN_Pos)
+#define TC_SMMR_DOWN_Pos            1            /**< \brief (TC_SMMR) Down Count */
+#define TC_SMMR_DOWN                (_U(0x1) << TC_SMMR_DOWN_Pos)
+#define TC_SMMR_MASK                _U(0x00000003) /**< \brief (TC_SMMR) MASK Register */
+
+/* -------- TC_CV : (TC Offset: 0x10) (R/  32) channel Counter Value Channel -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CV:16;            /*!< bit:  0..15  Counter Value                      */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TC_CV_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_CV_OFFSET                0x10         /**< \brief (TC_CV offset) Counter Value Channel */
+#define TC_CV_RESETVALUE            _U(0x00000000); /**< \brief (TC_CV reset_value) Counter Value Channel */
+
+#define TC_CV_CV_Pos                0            /**< \brief (TC_CV) Counter Value */
+#define TC_CV_CV_Msk                (_U(0xFFFF) << TC_CV_CV_Pos)
+#define TC_CV_CV(value)             (TC_CV_CV_Msk & ((value) << TC_CV_CV_Pos))
+#define TC_CV_MASK                  _U(0x0000FFFF) /**< \brief (TC_CV) MASK Register */
+
+/* -------- TC_RA : (TC Offset: 0x14) (R/W 32) channel Register A Channel -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RA:16;            /*!< bit:  0..15  Register A                         */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TC_RA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_RA_OFFSET                0x14         /**< \brief (TC_RA offset) Register A Channel */
+#define TC_RA_RESETVALUE            _U(0x00000000); /**< \brief (TC_RA reset_value) Register A Channel */
+
+#define TC_RA_RA_Pos                0            /**< \brief (TC_RA) Register A */
+#define TC_RA_RA_Msk                (_U(0xFFFF) << TC_RA_RA_Pos)
+#define TC_RA_RA(value)             (TC_RA_RA_Msk & ((value) << TC_RA_RA_Pos))
+#define TC_RA_MASK                  _U(0x0000FFFF) /**< \brief (TC_RA) MASK Register */
+
+/* -------- TC_RB : (TC Offset: 0x18) (R/W 32) channel Register B Channel -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RB:16;            /*!< bit:  0..15  Register B                         */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TC_RB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_RB_OFFSET                0x18         /**< \brief (TC_RB offset) Register B Channel */
+#define TC_RB_RESETVALUE            _U(0x00000000); /**< \brief (TC_RB reset_value) Register B Channel */
+
+#define TC_RB_RB_Pos                0            /**< \brief (TC_RB) Register B */
+#define TC_RB_RB_Msk                (_U(0xFFFF) << TC_RB_RB_Pos)
+#define TC_RB_RB(value)             (TC_RB_RB_Msk & ((value) << TC_RB_RB_Pos))
+#define TC_RB_MASK                  _U(0x0000FFFF) /**< \brief (TC_RB) MASK Register */
+
+/* -------- TC_RC : (TC Offset: 0x1C) (R/W 32) channel Register C Channel -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RC:16;            /*!< bit:  0..15  Register C                         */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TC_RC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_RC_OFFSET                0x1C         /**< \brief (TC_RC offset) Register C Channel */
+#define TC_RC_RESETVALUE            _U(0x00000000); /**< \brief (TC_RC reset_value) Register C Channel */
+
+#define TC_RC_RC_Pos                0            /**< \brief (TC_RC) Register C */
+#define TC_RC_RC_Msk                (_U(0xFFFF) << TC_RC_RC_Pos)
+#define TC_RC_RC(value)             (TC_RC_RC_Msk & ((value) << TC_RC_RC_Pos))
+#define TC_RC_MASK                  _U(0x0000FFFF) /**< \brief (TC_RC) MASK Register */
+
+/* -------- TC_SR : (TC Offset: 0x20) (R/  32) channel Status Register Channel -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t COVFS:1;          /*!< bit:      0  Counter Overflow Status            */
+    uint32_t LOVRS:1;          /*!< bit:      1  Load Overrun Status                */
+    uint32_t CPAS:1;           /*!< bit:      2  RA Compare Status                  */
+    uint32_t CPBS:1;           /*!< bit:      3  RB Compare Status                  */
+    uint32_t CPCS:1;           /*!< bit:      4  RC Compare Status                  */
+    uint32_t LDRAS:1;          /*!< bit:      5  RA Loading Status                  */
+    uint32_t LDRBS:1;          /*!< bit:      6  RB Loading Status                  */
+    uint32_t ETRGS:1;          /*!< bit:      7  External Trigger Status            */
+    uint32_t :8;               /*!< bit:  8..15  Reserved                           */
+    uint32_t CLKSTA:1;         /*!< bit:     16  Clock Enabling Status              */
+    uint32_t MTIOA:1;          /*!< bit:     17  TIOA Mirror                        */
+    uint32_t MTIOB:1;          /*!< bit:     18  TIOB Mirror                        */
+    uint32_t :13;              /*!< bit: 19..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TC_SR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_SR_OFFSET                0x20         /**< \brief (TC_SR offset) Status Register Channel */
+#define TC_SR_RESETVALUE            _U(0x00000000); /**< \brief (TC_SR reset_value) Status Register Channel */
+
+#define TC_SR_COVFS_Pos             0            /**< \brief (TC_SR) Counter Overflow Status */
+#define TC_SR_COVFS                 (_U(0x1) << TC_SR_COVFS_Pos)
+#define   TC_SR_COVFS_0_Val               _U(0x0)   /**< \brief (TC_SR) No counter overflow has occurred since the last read of the Status Register. */
+#define   TC_SR_COVFS_1_Val               _U(0x1)   /**< \brief (TC_SR) A counter overflow has occurred since the last read of the Status Register. */
+#define TC_SR_COVFS_0               (TC_SR_COVFS_0_Val             << TC_SR_COVFS_Pos)
+#define TC_SR_COVFS_1               (TC_SR_COVFS_1_Val             << TC_SR_COVFS_Pos)
+#define TC_SR_LOVRS_Pos             1            /**< \brief (TC_SR) Load Overrun Status */
+#define TC_SR_LOVRS                 (_U(0x1) << TC_SR_LOVRS_Pos)
+#define   TC_SR_LOVRS_0_Val               _U(0x0)   /**< \brief (TC_SR) Load overrun has not occurred since the last read of the Status Register or WAVE:1. */
+#define   TC_SR_LOVRS_1_Val               _U(0x1)   /**< \brief (TC_SR) RA or RB have been loaded at least twice without any read of the corresponding register since the last read of the StatusRegister, if WAVE:0. */
+#define TC_SR_LOVRS_0               (TC_SR_LOVRS_0_Val             << TC_SR_LOVRS_Pos)
+#define TC_SR_LOVRS_1               (TC_SR_LOVRS_1_Val             << TC_SR_LOVRS_Pos)
+#define TC_SR_CPAS_Pos              2            /**< \brief (TC_SR) RA Compare Status */
+#define TC_SR_CPAS                  (_U(0x1) << TC_SR_CPAS_Pos)
+#define   TC_SR_CPAS_0_Val                _U(0x0)   /**< \brief (TC_SR) RA Compare has not occurred since the last read of the Status Register or WAVE:0. */
+#define   TC_SR_CPAS_1_Val                _U(0x1)   /**< \brief (TC_SR) RA Compare has occurred since the last read of the Status Register, if WAVE:1. */
+#define TC_SR_CPAS_0                (TC_SR_CPAS_0_Val              << TC_SR_CPAS_Pos)
+#define TC_SR_CPAS_1                (TC_SR_CPAS_1_Val              << TC_SR_CPAS_Pos)
+#define TC_SR_CPBS_Pos              3            /**< \brief (TC_SR) RB Compare Status */
+#define TC_SR_CPBS                  (_U(0x1) << TC_SR_CPBS_Pos)
+#define   TC_SR_CPBS_0_Val                _U(0x0)   /**< \brief (TC_SR) RB Compare has not occurred since the last read of the Status Register or WAVE:0. */
+#define   TC_SR_CPBS_1_Val                _U(0x1)   /**< \brief (TC_SR) RB Compare has occurred since the last read of the Status Register, if WAVE:1. */
+#define TC_SR_CPBS_0                (TC_SR_CPBS_0_Val              << TC_SR_CPBS_Pos)
+#define TC_SR_CPBS_1                (TC_SR_CPBS_1_Val              << TC_SR_CPBS_Pos)
+#define TC_SR_CPCS_Pos              4            /**< \brief (TC_SR) RC Compare Status */
+#define TC_SR_CPCS                  (_U(0x1) << TC_SR_CPCS_Pos)
+#define   TC_SR_CPCS_0_Val                _U(0x0)   /**< \brief (TC_SR) RC Compare has not occurred since the last read of the Status Register. */
+#define   TC_SR_CPCS_1_Val                _U(0x1)   /**< \brief (TC_SR) RC Compare has occurred since the last read of the Status Register. */
+#define TC_SR_CPCS_0                (TC_SR_CPCS_0_Val              << TC_SR_CPCS_Pos)
+#define TC_SR_CPCS_1                (TC_SR_CPCS_1_Val              << TC_SR_CPCS_Pos)
+#define TC_SR_LDRAS_Pos             5            /**< \brief (TC_SR) RA Loading Status */
+#define TC_SR_LDRAS                 (_U(0x1) << TC_SR_LDRAS_Pos)
+#define   TC_SR_LDRAS_0_Val               _U(0x0)   /**< \brief (TC_SR) RA Load has not occurred since the last read of the Status Register or WAVE:1. */
+#define   TC_SR_LDRAS_1_Val               _U(0x1)   /**< \brief (TC_SR) RA Load has occurred since the last read of the Status Register, if WAVE:0. */
+#define TC_SR_LDRAS_0               (TC_SR_LDRAS_0_Val             << TC_SR_LDRAS_Pos)
+#define TC_SR_LDRAS_1               (TC_SR_LDRAS_1_Val             << TC_SR_LDRAS_Pos)
+#define TC_SR_LDRBS_Pos             6            /**< \brief (TC_SR) RB Loading Status */
+#define TC_SR_LDRBS                 (_U(0x1) << TC_SR_LDRBS_Pos)
+#define   TC_SR_LDRBS_0_Val               _U(0x0)   /**< \brief (TC_SR) RB Load has not occurred since the last read of the Status Register or WAVE:1. */
+#define   TC_SR_LDRBS_1_Val               _U(0x1)   /**< \brief (TC_SR) RB Load has occurred since the last read of the Status Register, if WAVE:0. */
+#define TC_SR_LDRBS_0               (TC_SR_LDRBS_0_Val             << TC_SR_LDRBS_Pos)
+#define TC_SR_LDRBS_1               (TC_SR_LDRBS_1_Val             << TC_SR_LDRBS_Pos)
+#define TC_SR_ETRGS_Pos             7            /**< \brief (TC_SR) External Trigger Status */
+#define TC_SR_ETRGS                 (_U(0x1) << TC_SR_ETRGS_Pos)
+#define   TC_SR_ETRGS_0_Val               _U(0x0)   /**< \brief (TC_SR) External trigger has not occurred since the last read of the Status Register. */
+#define   TC_SR_ETRGS_1_Val               _U(0x1)   /**< \brief (TC_SR) External trigger has occurred since the last read of the Status Register. */
+#define TC_SR_ETRGS_0               (TC_SR_ETRGS_0_Val             << TC_SR_ETRGS_Pos)
+#define TC_SR_ETRGS_1               (TC_SR_ETRGS_1_Val             << TC_SR_ETRGS_Pos)
+#define TC_SR_CLKSTA_Pos            16           /**< \brief (TC_SR) Clock Enabling Status */
+#define TC_SR_CLKSTA                (_U(0x1) << TC_SR_CLKSTA_Pos)
+#define   TC_SR_CLKSTA_0_Val              _U(0x0)   /**< \brief (TC_SR) Clock is disabled. */
+#define   TC_SR_CLKSTA_1_Val              _U(0x1)   /**< \brief (TC_SR) Clock is enabled. */
+#define TC_SR_CLKSTA_0              (TC_SR_CLKSTA_0_Val            << TC_SR_CLKSTA_Pos)
+#define TC_SR_CLKSTA_1              (TC_SR_CLKSTA_1_Val            << TC_SR_CLKSTA_Pos)
+#define TC_SR_MTIOA_Pos             17           /**< \brief (TC_SR) TIOA Mirror */
+#define TC_SR_MTIOA                 (_U(0x1) << TC_SR_MTIOA_Pos)
+#define   TC_SR_MTIOA_0_Val               _U(0x0)   /**< \brief (TC_SR) TIOA is low. If WAVE:0, this means that TIOA pin is low. If WAVE:1, this means that TIOA is driven low. */
+#define   TC_SR_MTIOA_1_Val               _U(0x1)   /**< \brief (TC_SR) TIOA is high. If WAVE:0, this means that TIOA pin is high. If WAVE:1, this means that TIOA is driven high. */
+#define TC_SR_MTIOA_0               (TC_SR_MTIOA_0_Val             << TC_SR_MTIOA_Pos)
+#define TC_SR_MTIOA_1               (TC_SR_MTIOA_1_Val             << TC_SR_MTIOA_Pos)
+#define TC_SR_MTIOB_Pos             18           /**< \brief (TC_SR) TIOB Mirror */
+#define TC_SR_MTIOB                 (_U(0x1) << TC_SR_MTIOB_Pos)
+#define   TC_SR_MTIOB_0_Val               _U(0x0)   /**< \brief (TC_SR) TIOB is low. If WAVE:0, this means that TIOB pin is low. If WAVE:1, this means that TIOB is driven low. */
+#define   TC_SR_MTIOB_1_Val               _U(0x1)   /**< \brief (TC_SR) TIOB is high. If WAVE:0, this means that TIOB pin is high. If WAVE:1, this means that TIOB is driven high. */
+#define TC_SR_MTIOB_0               (TC_SR_MTIOB_0_Val             << TC_SR_MTIOB_Pos)
+#define TC_SR_MTIOB_1               (TC_SR_MTIOB_1_Val             << TC_SR_MTIOB_Pos)
+#define TC_SR_MASK                  _U(0x000700FF) /**< \brief (TC_SR) MASK Register */
+
+/* -------- TC_IER : (TC Offset: 0x24) ( /W 32) channel Interrupt Enable Register Channel -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t COVFS:1;          /*!< bit:      0  Counter Overflow                   */
+    uint32_t LOVRS:1;          /*!< bit:      1  Load Overrun                       */
+    uint32_t CPAS:1;           /*!< bit:      2  RA Compare                         */
+    uint32_t CPBS:1;           /*!< bit:      3  RB Compare                         */
+    uint32_t CPCS:1;           /*!< bit:      4  RC Compare                         */
+    uint32_t LDRAS:1;          /*!< bit:      5  RA Loading                         */
+    uint32_t LDRBS:1;          /*!< bit:      6  RB Loading                         */
+    uint32_t ETRGS:1;          /*!< bit:      7  External Trigger                   */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TC_IER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_IER_OFFSET               0x24         /**< \brief (TC_IER offset) Interrupt Enable Register Channel */
+#define TC_IER_RESETVALUE           _U(0x00000000); /**< \brief (TC_IER reset_value) Interrupt Enable Register Channel */
+
+#define TC_IER_COVFS_Pos            0            /**< \brief (TC_IER) Counter Overflow */
+#define TC_IER_COVFS                (_U(0x1) << TC_IER_COVFS_Pos)
+#define   TC_IER_COVFS_0_Val              _U(0x0)   /**< \brief (TC_IER) No effect. */
+#define   TC_IER_COVFS_1_Val              _U(0x1)   /**< \brief (TC_IER) Enables the Counter Overflow Interrupt. */
+#define TC_IER_COVFS_0              (TC_IER_COVFS_0_Val            << TC_IER_COVFS_Pos)
+#define TC_IER_COVFS_1              (TC_IER_COVFS_1_Val            << TC_IER_COVFS_Pos)
+#define TC_IER_LOVRS_Pos            1            /**< \brief (TC_IER) Load Overrun */
+#define TC_IER_LOVRS                (_U(0x1) << TC_IER_LOVRS_Pos)
+#define   TC_IER_LOVRS_0_Val              _U(0x0)   /**< \brief (TC_IER) No effect. */
+#define   TC_IER_LOVRS_1_Val              _U(0x1)   /**< \brief (TC_IER) Enables the Load Overrun Interrupt. */
+#define TC_IER_LOVRS_0              (TC_IER_LOVRS_0_Val            << TC_IER_LOVRS_Pos)
+#define TC_IER_LOVRS_1              (TC_IER_LOVRS_1_Val            << TC_IER_LOVRS_Pos)
+#define TC_IER_CPAS_Pos             2            /**< \brief (TC_IER) RA Compare */
+#define TC_IER_CPAS                 (_U(0x1) << TC_IER_CPAS_Pos)
+#define   TC_IER_CPAS_0_Val               _U(0x0)   /**< \brief (TC_IER) No effect. */
+#define   TC_IER_CPAS_1_Val               _U(0x1)   /**< \brief (TC_IER) Enables the RA Compare Interrupt. */
+#define TC_IER_CPAS_0               (TC_IER_CPAS_0_Val             << TC_IER_CPAS_Pos)
+#define TC_IER_CPAS_1               (TC_IER_CPAS_1_Val             << TC_IER_CPAS_Pos)
+#define TC_IER_CPBS_Pos             3            /**< \brief (TC_IER) RB Compare */
+#define TC_IER_CPBS                 (_U(0x1) << TC_IER_CPBS_Pos)
+#define   TC_IER_CPBS_0_Val               _U(0x0)   /**< \brief (TC_IER) No effect. */
+#define   TC_IER_CPBS_1_Val               _U(0x1)   /**< \brief (TC_IER) Enables the RB Compare Interrupt. */
+#define TC_IER_CPBS_0               (TC_IER_CPBS_0_Val             << TC_IER_CPBS_Pos)
+#define TC_IER_CPBS_1               (TC_IER_CPBS_1_Val             << TC_IER_CPBS_Pos)
+#define TC_IER_CPCS_Pos             4            /**< \brief (TC_IER) RC Compare */
+#define TC_IER_CPCS                 (_U(0x1) << TC_IER_CPCS_Pos)
+#define   TC_IER_CPCS_0_Val               _U(0x0)   /**< \brief (TC_IER) No effect. */
+#define   TC_IER_CPCS_1_Val               _U(0x1)   /**< \brief (TC_IER) Enables the RC Compare Interrupt. */
+#define TC_IER_CPCS_0               (TC_IER_CPCS_0_Val             << TC_IER_CPCS_Pos)
+#define TC_IER_CPCS_1               (TC_IER_CPCS_1_Val             << TC_IER_CPCS_Pos)
+#define TC_IER_LDRAS_Pos            5            /**< \brief (TC_IER) RA Loading */
+#define TC_IER_LDRAS                (_U(0x1) << TC_IER_LDRAS_Pos)
+#define   TC_IER_LDRAS_0_Val              _U(0x0)   /**< \brief (TC_IER) No effect. */
+#define   TC_IER_LDRAS_1_Val              _U(0x1)   /**< \brief (TC_IER) Enables the RA Load Interrupt. */
+#define TC_IER_LDRAS_0              (TC_IER_LDRAS_0_Val            << TC_IER_LDRAS_Pos)
+#define TC_IER_LDRAS_1              (TC_IER_LDRAS_1_Val            << TC_IER_LDRAS_Pos)
+#define TC_IER_LDRBS_Pos            6            /**< \brief (TC_IER) RB Loading */
+#define TC_IER_LDRBS                (_U(0x1) << TC_IER_LDRBS_Pos)
+#define   TC_IER_LDRBS_0_Val              _U(0x0)   /**< \brief (TC_IER) No effect. */
+#define   TC_IER_LDRBS_1_Val              _U(0x1)   /**< \brief (TC_IER) Enables the RB Load Interrupt. */
+#define TC_IER_LDRBS_0              (TC_IER_LDRBS_0_Val            << TC_IER_LDRBS_Pos)
+#define TC_IER_LDRBS_1              (TC_IER_LDRBS_1_Val            << TC_IER_LDRBS_Pos)
+#define TC_IER_ETRGS_Pos            7            /**< \brief (TC_IER) External Trigger */
+#define TC_IER_ETRGS                (_U(0x1) << TC_IER_ETRGS_Pos)
+#define   TC_IER_ETRGS_0_Val              _U(0x0)   /**< \brief (TC_IER) No effect. */
+#define   TC_IER_ETRGS_1_Val              _U(0x1)   /**< \brief (TC_IER) Enables the External Trigger Interrupt. */
+#define TC_IER_ETRGS_0              (TC_IER_ETRGS_0_Val            << TC_IER_ETRGS_Pos)
+#define TC_IER_ETRGS_1              (TC_IER_ETRGS_1_Val            << TC_IER_ETRGS_Pos)
+#define TC_IER_MASK                 _U(0x000000FF) /**< \brief (TC_IER) MASK Register */
+
+/* -------- TC_IDR : (TC Offset: 0x28) ( /W 32) channel Interrupt Disable Register Channel -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t COVFS:1;          /*!< bit:      0  Counter Overflow                   */
+    uint32_t LOVRS:1;          /*!< bit:      1  Load Overrun                       */
+    uint32_t CPAS:1;           /*!< bit:      2  RA Compare                         */
+    uint32_t CPBS:1;           /*!< bit:      3  RB Compare                         */
+    uint32_t CPCS:1;           /*!< bit:      4  RC Compare                         */
+    uint32_t LDRAS:1;          /*!< bit:      5  RA Loading                         */
+    uint32_t LDRBS:1;          /*!< bit:      6  RB Loading                         */
+    uint32_t ETRGS:1;          /*!< bit:      7  External Trigger                   */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TC_IDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_IDR_OFFSET               0x28         /**< \brief (TC_IDR offset) Interrupt Disable Register Channel */
+#define TC_IDR_RESETVALUE           _U(0x00000000); /**< \brief (TC_IDR reset_value) Interrupt Disable Register Channel */
+
+#define TC_IDR_COVFS_Pos            0            /**< \brief (TC_IDR) Counter Overflow */
+#define TC_IDR_COVFS                (_U(0x1) << TC_IDR_COVFS_Pos)
+#define   TC_IDR_COVFS_0_Val              _U(0x0)   /**< \brief (TC_IDR) No effect. */
+#define   TC_IDR_COVFS_1_Val              _U(0x1)   /**< \brief (TC_IDR) Disables the Counter Overflow Interrupt. */
+#define TC_IDR_COVFS_0              (TC_IDR_COVFS_0_Val            << TC_IDR_COVFS_Pos)
+#define TC_IDR_COVFS_1              (TC_IDR_COVFS_1_Val            << TC_IDR_COVFS_Pos)
+#define TC_IDR_LOVRS_Pos            1            /**< \brief (TC_IDR) Load Overrun */
+#define TC_IDR_LOVRS                (_U(0x1) << TC_IDR_LOVRS_Pos)
+#define   TC_IDR_LOVRS_0_Val              _U(0x0)   /**< \brief (TC_IDR) No effect. */
+#define   TC_IDR_LOVRS_1_Val              _U(0x1)   /**< \brief (TC_IDR) Disables the Load Overrun Interrupt (if WAVE:0). */
+#define TC_IDR_LOVRS_0              (TC_IDR_LOVRS_0_Val            << TC_IDR_LOVRS_Pos)
+#define TC_IDR_LOVRS_1              (TC_IDR_LOVRS_1_Val            << TC_IDR_LOVRS_Pos)
+#define TC_IDR_CPAS_Pos             2            /**< \brief (TC_IDR) RA Compare */
+#define TC_IDR_CPAS                 (_U(0x1) << TC_IDR_CPAS_Pos)
+#define   TC_IDR_CPAS_0_Val               _U(0x0)   /**< \brief (TC_IDR) No effect. */
+#define   TC_IDR_CPAS_1_Val               _U(0x1)   /**< \brief (TC_IDR) Disables the RA Compare Interrupt (if WAVE:1). */
+#define TC_IDR_CPAS_0               (TC_IDR_CPAS_0_Val             << TC_IDR_CPAS_Pos)
+#define TC_IDR_CPAS_1               (TC_IDR_CPAS_1_Val             << TC_IDR_CPAS_Pos)
+#define TC_IDR_CPBS_Pos             3            /**< \brief (TC_IDR) RB Compare */
+#define TC_IDR_CPBS                 (_U(0x1) << TC_IDR_CPBS_Pos)
+#define   TC_IDR_CPBS_0_Val               _U(0x0)   /**< \brief (TC_IDR) No effect. */
+#define   TC_IDR_CPBS_1_Val               _U(0x1)   /**< \brief (TC_IDR) Disables the RB Compare Interrupt (if WAVE:1). */
+#define TC_IDR_CPBS_0               (TC_IDR_CPBS_0_Val             << TC_IDR_CPBS_Pos)
+#define TC_IDR_CPBS_1               (TC_IDR_CPBS_1_Val             << TC_IDR_CPBS_Pos)
+#define TC_IDR_CPCS_Pos             4            /**< \brief (TC_IDR) RC Compare */
+#define TC_IDR_CPCS                 (_U(0x1) << TC_IDR_CPCS_Pos)
+#define   TC_IDR_CPCS_0_Val               _U(0x0)   /**< \brief (TC_IDR) No effect. */
+#define   TC_IDR_CPCS_1_Val               _U(0x1)   /**< \brief (TC_IDR) Disables the RC Compare Interrupt. */
+#define TC_IDR_CPCS_0               (TC_IDR_CPCS_0_Val             << TC_IDR_CPCS_Pos)
+#define TC_IDR_CPCS_1               (TC_IDR_CPCS_1_Val             << TC_IDR_CPCS_Pos)
+#define TC_IDR_LDRAS_Pos            5            /**< \brief (TC_IDR) RA Loading */
+#define TC_IDR_LDRAS                (_U(0x1) << TC_IDR_LDRAS_Pos)
+#define   TC_IDR_LDRAS_0_Val              _U(0x0)   /**< \brief (TC_IDR) No effect. */
+#define   TC_IDR_LDRAS_1_Val              _U(0x1)   /**< \brief (TC_IDR) Disables the RA Load Interrupt (if WAVE:0). */
+#define TC_IDR_LDRAS_0              (TC_IDR_LDRAS_0_Val            << TC_IDR_LDRAS_Pos)
+#define TC_IDR_LDRAS_1              (TC_IDR_LDRAS_1_Val            << TC_IDR_LDRAS_Pos)
+#define TC_IDR_LDRBS_Pos            6            /**< \brief (TC_IDR) RB Loading */
+#define TC_IDR_LDRBS                (_U(0x1) << TC_IDR_LDRBS_Pos)
+#define   TC_IDR_LDRBS_0_Val              _U(0x0)   /**< \brief (TC_IDR) No effect. */
+#define   TC_IDR_LDRBS_1_Val              _U(0x1)   /**< \brief (TC_IDR) Disables the RB Load Interrupt (if WAVE:0). */
+#define TC_IDR_LDRBS_0              (TC_IDR_LDRBS_0_Val            << TC_IDR_LDRBS_Pos)
+#define TC_IDR_LDRBS_1              (TC_IDR_LDRBS_1_Val            << TC_IDR_LDRBS_Pos)
+#define TC_IDR_ETRGS_Pos            7            /**< \brief (TC_IDR) External Trigger */
+#define TC_IDR_ETRGS                (_U(0x1) << TC_IDR_ETRGS_Pos)
+#define   TC_IDR_ETRGS_0_Val              _U(0x0)   /**< \brief (TC_IDR) No effect. */
+#define   TC_IDR_ETRGS_1_Val              _U(0x1)   /**< \brief (TC_IDR) Disables the External Trigger Interrupt. */
+#define TC_IDR_ETRGS_0              (TC_IDR_ETRGS_0_Val            << TC_IDR_ETRGS_Pos)
+#define TC_IDR_ETRGS_1              (TC_IDR_ETRGS_1_Val            << TC_IDR_ETRGS_Pos)
+#define TC_IDR_MASK                 _U(0x000000FF) /**< \brief (TC_IDR) MASK Register */
+
+/* -------- TC_IMR : (TC Offset: 0x2C) (R/  32) channel Interrupt Mask Register Channel -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t COVFS:1;          /*!< bit:      0  Counter Overflow                   */
+    uint32_t LOVRS:1;          /*!< bit:      1  Load Overrun                       */
+    uint32_t CPAS:1;           /*!< bit:      2  RA Compare                         */
+    uint32_t CPBS:1;           /*!< bit:      3  RB Compare                         */
+    uint32_t CPCS:1;           /*!< bit:      4  RC Compare                         */
+    uint32_t LDRAS:1;          /*!< bit:      5  RA Loading                         */
+    uint32_t LDRBS:1;          /*!< bit:      6  RB Loading                         */
+    uint32_t ETRGS:1;          /*!< bit:      7  External Trigger                   */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TC_IMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_IMR_OFFSET               0x2C         /**< \brief (TC_IMR offset) Interrupt Mask Register Channel */
+#define TC_IMR_RESETVALUE           _U(0x00000000); /**< \brief (TC_IMR reset_value) Interrupt Mask Register Channel */
+
+#define TC_IMR_COVFS_Pos            0            /**< \brief (TC_IMR) Counter Overflow */
+#define TC_IMR_COVFS                (_U(0x1) << TC_IMR_COVFS_Pos)
+#define   TC_IMR_COVFS_0_Val              _U(0x0)   /**< \brief (TC_IMR) The Counter Overflow Interrupt is disabled. */
+#define   TC_IMR_COVFS_1_Val              _U(0x1)   /**< \brief (TC_IMR) The Counter Overflow Interrupt is enabled. */
+#define TC_IMR_COVFS_0              (TC_IMR_COVFS_0_Val            << TC_IMR_COVFS_Pos)
+#define TC_IMR_COVFS_1              (TC_IMR_COVFS_1_Val            << TC_IMR_COVFS_Pos)
+#define TC_IMR_LOVRS_Pos            1            /**< \brief (TC_IMR) Load Overrun */
+#define TC_IMR_LOVRS                (_U(0x1) << TC_IMR_LOVRS_Pos)
+#define   TC_IMR_LOVRS_0_Val              _U(0x0)   /**< \brief (TC_IMR) The Load Overrun Interrupt is disabled. */
+#define   TC_IMR_LOVRS_1_Val              _U(0x1)   /**< \brief (TC_IMR) The Load Overrun Interrupt is enabled. */
+#define TC_IMR_LOVRS_0              (TC_IMR_LOVRS_0_Val            << TC_IMR_LOVRS_Pos)
+#define TC_IMR_LOVRS_1              (TC_IMR_LOVRS_1_Val            << TC_IMR_LOVRS_Pos)
+#define TC_IMR_CPAS_Pos             2            /**< \brief (TC_IMR) RA Compare */
+#define TC_IMR_CPAS                 (_U(0x1) << TC_IMR_CPAS_Pos)
+#define   TC_IMR_CPAS_0_Val               _U(0x0)   /**< \brief (TC_IMR) The RA Compare Interrupt is disabled. */
+#define   TC_IMR_CPAS_1_Val               _U(0x1)   /**< \brief (TC_IMR) The RA Compare Interrupt is enabled. */
+#define TC_IMR_CPAS_0               (TC_IMR_CPAS_0_Val             << TC_IMR_CPAS_Pos)
+#define TC_IMR_CPAS_1               (TC_IMR_CPAS_1_Val             << TC_IMR_CPAS_Pos)
+#define TC_IMR_CPBS_Pos             3            /**< \brief (TC_IMR) RB Compare */
+#define TC_IMR_CPBS                 (_U(0x1) << TC_IMR_CPBS_Pos)
+#define   TC_IMR_CPBS_0_Val               _U(0x0)   /**< \brief (TC_IMR) The RB Compare Interrupt is disabled. */
+#define   TC_IMR_CPBS_1_Val               _U(0x1)   /**< \brief (TC_IMR) The RB Compare Interrupt is enabled. */
+#define TC_IMR_CPBS_0               (TC_IMR_CPBS_0_Val             << TC_IMR_CPBS_Pos)
+#define TC_IMR_CPBS_1               (TC_IMR_CPBS_1_Val             << TC_IMR_CPBS_Pos)
+#define TC_IMR_CPCS_Pos             4            /**< \brief (TC_IMR) RC Compare */
+#define TC_IMR_CPCS                 (_U(0x1) << TC_IMR_CPCS_Pos)
+#define   TC_IMR_CPCS_0_Val               _U(0x0)   /**< \brief (TC_IMR) The RC Compare Interrupt is disabled. */
+#define   TC_IMR_CPCS_1_Val               _U(0x1)   /**< \brief (TC_IMR) The RC Compare Interrupt is enabled. */
+#define TC_IMR_CPCS_0               (TC_IMR_CPCS_0_Val             << TC_IMR_CPCS_Pos)
+#define TC_IMR_CPCS_1               (TC_IMR_CPCS_1_Val             << TC_IMR_CPCS_Pos)
+#define TC_IMR_LDRAS_Pos            5            /**< \brief (TC_IMR) RA Loading */
+#define TC_IMR_LDRAS                (_U(0x1) << TC_IMR_LDRAS_Pos)
+#define   TC_IMR_LDRAS_0_Val              _U(0x0)   /**< \brief (TC_IMR) The Load RA Interrupt is disabled. */
+#define   TC_IMR_LDRAS_1_Val              _U(0x1)   /**< \brief (TC_IMR) The Load RA Interrupt is enabled. */
+#define TC_IMR_LDRAS_0              (TC_IMR_LDRAS_0_Val            << TC_IMR_LDRAS_Pos)
+#define TC_IMR_LDRAS_1              (TC_IMR_LDRAS_1_Val            << TC_IMR_LDRAS_Pos)
+#define TC_IMR_LDRBS_Pos            6            /**< \brief (TC_IMR) RB Loading */
+#define TC_IMR_LDRBS                (_U(0x1) << TC_IMR_LDRBS_Pos)
+#define   TC_IMR_LDRBS_0_Val              _U(0x0)   /**< \brief (TC_IMR) The Load RB Interrupt is disabled. */
+#define   TC_IMR_LDRBS_1_Val              _U(0x1)   /**< \brief (TC_IMR) The Load RB Interrupt is enabled. */
+#define TC_IMR_LDRBS_0              (TC_IMR_LDRBS_0_Val            << TC_IMR_LDRBS_Pos)
+#define TC_IMR_LDRBS_1              (TC_IMR_LDRBS_1_Val            << TC_IMR_LDRBS_Pos)
+#define TC_IMR_ETRGS_Pos            7            /**< \brief (TC_IMR) External Trigger */
+#define TC_IMR_ETRGS                (_U(0x1) << TC_IMR_ETRGS_Pos)
+#define   TC_IMR_ETRGS_0_Val              _U(0x0)   /**< \brief (TC_IMR) The External Trigger Interrupt is disabled. */
+#define   TC_IMR_ETRGS_1_Val              _U(0x1)   /**< \brief (TC_IMR) The External Trigger Interrupt is enabled. */
+#define TC_IMR_ETRGS_0              (TC_IMR_ETRGS_0_Val            << TC_IMR_ETRGS_Pos)
+#define TC_IMR_ETRGS_1              (TC_IMR_ETRGS_1_Val            << TC_IMR_ETRGS_Pos)
+#define TC_IMR_MASK                 _U(0x000000FF) /**< \brief (TC_IMR) MASK Register */
+
+/* -------- TC_BCR : (TC Offset: 0xC0) ( /W 32) TC Block Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SYNC:1;           /*!< bit:      0  Synchro Command                    */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TC_BCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_BCR_OFFSET               0xC0         /**< \brief (TC_BCR offset) TC Block Control Register */
+#define TC_BCR_RESETVALUE           _U(0x00000000); /**< \brief (TC_BCR reset_value) TC Block Control Register */
+
+#define TC_BCR_SYNC_Pos             0            /**< \brief (TC_BCR) Synchro Command */
+#define TC_BCR_SYNC                 (_U(0x1) << TC_BCR_SYNC_Pos)
+#define   TC_BCR_SYNC_0_Val               _U(0x0)   /**< \brief (TC_BCR) No effect. */
+#define   TC_BCR_SYNC_1_Val               _U(0x1)   /**< \brief (TC_BCR) Asserts the SYNC signal which generates a software trigger simultaneously for each of the channels. */
+#define TC_BCR_SYNC_0               (TC_BCR_SYNC_0_Val             << TC_BCR_SYNC_Pos)
+#define TC_BCR_SYNC_1               (TC_BCR_SYNC_1_Val             << TC_BCR_SYNC_Pos)
+#define TC_BCR_MASK                 _U(0x00000001) /**< \brief (TC_BCR) MASK Register */
+
+/* -------- TC_BMR : (TC Offset: 0xC4) (R/W 32) TC Block Mode Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TC0XC0S:2;        /*!< bit:  0.. 1  External Clock Signal 0 Selection  */
+    uint32_t TC1XC1S:2;        /*!< bit:  2.. 3  External Clock Signal 1 Selection  */
+    uint32_t TC2XC2S:2;        /*!< bit:  4.. 5  External Clock Signal 2 Selection  */
+    uint32_t :26;              /*!< bit:  6..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TC_BMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_BMR_OFFSET               0xC4         /**< \brief (TC_BMR offset) TC Block Mode Register */
+#define TC_BMR_RESETVALUE           _U(0x00000000); /**< \brief (TC_BMR reset_value) TC Block Mode Register */
+
+#define TC_BMR_TC0XC0S_Pos          0            /**< \brief (TC_BMR) External Clock Signal 0 Selection */
+#define TC_BMR_TC0XC0S_Msk          (_U(0x3) << TC_BMR_TC0XC0S_Pos)
+#define TC_BMR_TC0XC0S(value)       (TC_BMR_TC0XC0S_Msk & ((value) << TC_BMR_TC0XC0S_Pos))
+#define   TC_BMR_TC0XC0S_TCLK0_Val        _U(0x0)   /**< \brief (TC_BMR) Select TCLK0 as clock signal 0. */
+#define   TC_BMR_TC0XC0S_NO_CLK_Val       _U(0x1)   /**< \brief (TC_BMR) Select no clock as clock signal 0. */
+#define   TC_BMR_TC0XC0S_TIOA1_Val        _U(0x2)   /**< \brief (TC_BMR) Select TIOA1 as clock signal 0. */
+#define   TC_BMR_TC0XC0S_TIOA2_Val        _U(0x3)   /**< \brief (TC_BMR) Select TIOA2 as clock signal 0. */
+#define TC_BMR_TC0XC0S_TCLK0        (TC_BMR_TC0XC0S_TCLK0_Val      << TC_BMR_TC0XC0S_Pos)
+#define TC_BMR_TC0XC0S_NO_CLK       (TC_BMR_TC0XC0S_NO_CLK_Val     << TC_BMR_TC0XC0S_Pos)
+#define TC_BMR_TC0XC0S_TIOA1        (TC_BMR_TC0XC0S_TIOA1_Val      << TC_BMR_TC0XC0S_Pos)
+#define TC_BMR_TC0XC0S_TIOA2        (TC_BMR_TC0XC0S_TIOA2_Val      << TC_BMR_TC0XC0S_Pos)
+#define TC_BMR_TC1XC1S_Pos          2            /**< \brief (TC_BMR) External Clock Signal 1 Selection */
+#define TC_BMR_TC1XC1S_Msk          (_U(0x3) << TC_BMR_TC1XC1S_Pos)
+#define TC_BMR_TC1XC1S(value)       (TC_BMR_TC1XC1S_Msk & ((value) << TC_BMR_TC1XC1S_Pos))
+#define   TC_BMR_TC1XC1S_TCLK1_Val        _U(0x0)   /**< \brief (TC_BMR) Select TCLK1 as clock signal 1. */
+#define   TC_BMR_TC1XC1S_NO_CLK_Val       _U(0x1)   /**< \brief (TC_BMR) Select no clock as clock signal 1. */
+#define   TC_BMR_TC1XC1S_TIOA0_Val        _U(0x2)   /**< \brief (TC_BMR) Select TIOA0 as clock signal 1. */
+#define   TC_BMR_TC1XC1S_TIOA2_Val        _U(0x3)   /**< \brief (TC_BMR) Select TIOA2 as clock signal 1. */
+#define TC_BMR_TC1XC1S_TCLK1        (TC_BMR_TC1XC1S_TCLK1_Val      << TC_BMR_TC1XC1S_Pos)
+#define TC_BMR_TC1XC1S_NO_CLK       (TC_BMR_TC1XC1S_NO_CLK_Val     << TC_BMR_TC1XC1S_Pos)
+#define TC_BMR_TC1XC1S_TIOA0        (TC_BMR_TC1XC1S_TIOA0_Val      << TC_BMR_TC1XC1S_Pos)
+#define TC_BMR_TC1XC1S_TIOA2        (TC_BMR_TC1XC1S_TIOA2_Val      << TC_BMR_TC1XC1S_Pos)
+#define TC_BMR_TC2XC2S_Pos          4            /**< \brief (TC_BMR) External Clock Signal 2 Selection */
+#define TC_BMR_TC2XC2S_Msk          (_U(0x3) << TC_BMR_TC2XC2S_Pos)
+#define TC_BMR_TC2XC2S(value)       (TC_BMR_TC2XC2S_Msk & ((value) << TC_BMR_TC2XC2S_Pos))
+#define   TC_BMR_TC2XC2S_TCLK2_Val        _U(0x0)   /**< \brief (TC_BMR) Select TCLK2 as clock signal 2. */
+#define   TC_BMR_TC2XC2S_NO_CLK_Val       _U(0x1)   /**< \brief (TC_BMR) Select no clock as clock signal 2. */
+#define   TC_BMR_TC2XC2S_TIOA0_Val        _U(0x2)   /**< \brief (TC_BMR) Select TIOA0 as clock signal 2. */
+#define   TC_BMR_TC2XC2S_TIOA1_Val        _U(0x3)   /**< \brief (TC_BMR) Select TIOA1 as clock signal 2. */
+#define TC_BMR_TC2XC2S_TCLK2        (TC_BMR_TC2XC2S_TCLK2_Val      << TC_BMR_TC2XC2S_Pos)
+#define TC_BMR_TC2XC2S_NO_CLK       (TC_BMR_TC2XC2S_NO_CLK_Val     << TC_BMR_TC2XC2S_Pos)
+#define TC_BMR_TC2XC2S_TIOA0        (TC_BMR_TC2XC2S_TIOA0_Val      << TC_BMR_TC2XC2S_Pos)
+#define TC_BMR_TC2XC2S_TIOA1        (TC_BMR_TC2XC2S_TIOA1_Val      << TC_BMR_TC2XC2S_Pos)
+#define TC_BMR_MASK                 _U(0x0000003F) /**< \brief (TC_BMR) MASK Register */
+
+/* -------- TC_WPMR : (TC Offset: 0xE4) (R/W 32) Write Protect Mode Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t WPEN:1;           /*!< bit:      0  Write Protect Enable               */
+    uint32_t :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint32_t WPKEY:24;         /*!< bit:  8..31  Write Protect Key                  */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TC_WPMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_WPMR_OFFSET              0xE4         /**< \brief (TC_WPMR offset) Write Protect Mode Register */
+#define TC_WPMR_RESETVALUE          _U(0x00000000); /**< \brief (TC_WPMR reset_value) Write Protect Mode Register */
+
+#define TC_WPMR_WPEN_Pos            0            /**< \brief (TC_WPMR) Write Protect Enable */
+#define TC_WPMR_WPEN                (_U(0x1) << TC_WPMR_WPEN_Pos)
+#define TC_WPMR_WPKEY_Pos           8            /**< \brief (TC_WPMR) Write Protect Key */
+#define TC_WPMR_WPKEY_Msk           (_U(0xFFFFFF) << TC_WPMR_WPKEY_Pos)
+#define TC_WPMR_WPKEY(value)        (TC_WPMR_WPKEY_Msk & ((value) << TC_WPMR_WPKEY_Pos))
+#define TC_WPMR_MASK                _U(0xFFFFFF01) /**< \brief (TC_WPMR) MASK Register */
+
+/* -------- TC_FEATURES : (TC Offset: 0xF8) (R/  32) Features Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CTRSIZE:8;        /*!< bit:  0.. 7  Counter Size                       */
+    uint32_t UPDNIMPL:1;       /*!< bit:      8  Up Down is Implemented             */
+    uint32_t BRPBHSB:1;        /*!< bit:      9  Bridge Type is PB to HSB           */
+    uint32_t :22;              /*!< bit: 10..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TC_FEATURES_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_FEATURES_OFFSET          0xF8         /**< \brief (TC_FEATURES offset) Features Register */
+
+#define TC_FEATURES_CTRSIZE_Pos     0            /**< \brief (TC_FEATURES) Counter Size */
+#define TC_FEATURES_CTRSIZE_Msk     (_U(0xFF) << TC_FEATURES_CTRSIZE_Pos)
+#define TC_FEATURES_CTRSIZE(value)  (TC_FEATURES_CTRSIZE_Msk & ((value) << TC_FEATURES_CTRSIZE_Pos))
+#define TC_FEATURES_UPDNIMPL_Pos    8            /**< \brief (TC_FEATURES) Up Down is Implemented */
+#define TC_FEATURES_UPDNIMPL        (_U(0x1) << TC_FEATURES_UPDNIMPL_Pos)
+#define TC_FEATURES_BRPBHSB_Pos     9            /**< \brief (TC_FEATURES) Bridge Type is PB to HSB */
+#define TC_FEATURES_BRPBHSB         (_U(0x1) << TC_FEATURES_BRPBHSB_Pos)
+#define TC_FEATURES_MASK            _U(0x000003FF) /**< \brief (TC_FEATURES) MASK Register */
+
+/* -------- TC_VERSION : (TC Offset: 0xFC) (R/  32) Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Reserved. Value subject to change. No functionality associated. This is the Atmel internal version of the macrocell. */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Reserved.  Value subject to change.  No functionality associated. */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TC_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_VERSION_OFFSET           0xFC         /**< \brief (TC_VERSION offset) Version Register */
+#define TC_VERSION_RESETVALUE       _U(0x00000402); /**< \brief (TC_VERSION reset_value) Version Register */
+
+#define TC_VERSION_VERSION_Pos      0            /**< \brief (TC_VERSION) Reserved. Value subject to change. No functionality associated. This is the Atmel internal version of the macrocell. */
+#define TC_VERSION_VERSION_Msk      (_U(0xFFF) << TC_VERSION_VERSION_Pos)
+#define TC_VERSION_VERSION(value)   (TC_VERSION_VERSION_Msk & ((value) << TC_VERSION_VERSION_Pos))
+#define TC_VERSION_VARIANT_Pos      16           /**< \brief (TC_VERSION) Reserved.  Value subject to change.  No functionality associated. */
+#define TC_VERSION_VARIANT_Msk      (_U(0xF) << TC_VERSION_VARIANT_Pos)
+#define TC_VERSION_VARIANT(value)   (TC_VERSION_VARIANT_Msk & ((value) << TC_VERSION_VARIANT_Pos))
+#define TC_VERSION_MASK             _U(0x000F0FFF) /**< \brief (TC_VERSION) MASK Register */
+
+/** \brief TcChannel hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __O  TC_CCR_Type               CCR;         /**< \brief Offset: 0x00 ( /W 32) Channel Control Register Channel */
+  __IO TC_CMR_Type               CMR;         /**< \brief Offset: 0x04 (R/W 32) Channel Mode Register Channel */
+  __IO TC_SMMR_Type              SMMR;        /**< \brief Offset: 0x08 (R/W 32) Stepper Motor Mode Register */
+       RoReg8                    Reserved1[0x4];
+  __I  TC_CV_Type                CV;          /**< \brief Offset: 0x10 (R/  32) Counter Value Channel */
+  __IO TC_RA_Type                RA;          /**< \brief Offset: 0x14 (R/W 32) Register A Channel */
+  __IO TC_RB_Type                RB;          /**< \brief Offset: 0x18 (R/W 32) Register B Channel */
+  __IO TC_RC_Type                RC;          /**< \brief Offset: 0x1C (R/W 32) Register C Channel */
+  __I  TC_SR_Type                SR;          /**< \brief Offset: 0x20 (R/  32) Status Register Channel */
+  __O  TC_IER_Type               IER;         /**< \brief Offset: 0x24 ( /W 32) Interrupt Enable Register Channel */
+  __O  TC_IDR_Type               IDR;         /**< \brief Offset: 0x28 ( /W 32) Interrupt Disable Register Channel */
+  __I  TC_IMR_Type               IMR;         /**< \brief Offset: 0x2C (R/  32) Interrupt Mask Register Channel */
+       RoReg8                    Reserved2[0x10];
+ } bf;
+ struct {
+  WoReg   TC_CCR;             /**< \brief (TC Offset: 0x00) Channel Control Register Channel */
+  RwReg   TC_CMR;             /**< \brief (TC Offset: 0x04) Channel Mode Register Channel */
+  RwReg   TC_SMMR;            /**< \brief (TC Offset: 0x08) Stepper Motor Mode Register */
+  RoReg8  Reserved3[0x4];
+  RoReg   TC_CV;              /**< \brief (TC Offset: 0x10) Counter Value Channel */
+  RwReg   TC_RA;              /**< \brief (TC Offset: 0x14) Register A Channel */
+  RwReg   TC_RB;              /**< \brief (TC Offset: 0x18) Register B Channel */
+  RwReg   TC_RC;              /**< \brief (TC Offset: 0x1C) Register C Channel */
+  RoReg   TC_SR;              /**< \brief (TC Offset: 0x20) Status Register Channel */
+  WoReg   TC_IER;             /**< \brief (TC Offset: 0x24) Interrupt Enable Register Channel */
+  WoReg   TC_IDR;             /**< \brief (TC Offset: 0x28) Interrupt Disable Register Channel */
+  RoReg   TC_IMR;             /**< \brief (TC Offset: 0x2C) Interrupt Mask Register Channel */
+  RoReg8  Reserved4[0x10];
+ } reg;
+} TcChannel;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief TC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+       TcChannel                 Channel[3];  /**< \brief Offset: 0x00 TcChannel groups */
+  __O  TC_BCR_Type               BCR;         /**< \brief Offset: 0xC0 ( /W 32) TC Block Control Register */
+  __IO TC_BMR_Type               BMR;         /**< \brief Offset: 0xC4 (R/W 32) TC Block Mode Register */
+       RoReg8                    Reserved1[0x1C];
+  __IO TC_WPMR_Type              WPMR;        /**< \brief Offset: 0xE4 (R/W 32) Write Protect Mode Register */
+       RoReg8                    Reserved2[0x10];
+  __I  TC_FEATURES_Type          FEATURES;    /**< \brief Offset: 0xF8 (R/  32) Features Register */
+  __I  TC_VERSION_Type           VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
+ } bf;
+ struct {
+  TcChannel TC_CHANNEL[3];      /**< \brief (TC Offset: 0x00) TcChannel groups */
+  WoReg   TC_BCR;             /**< \brief (TC Offset: 0xC0) TC Block Control Register */
+  RwReg   TC_BMR;             /**< \brief (TC Offset: 0xC4) TC Block Mode Register */
+  RoReg8  Reserved3[0x1C];
+  RwReg   TC_WPMR;            /**< \brief (TC Offset: 0xE4) Write Protect Mode Register */
+  RoReg8  Reserved4[0x10];
+  RoReg   TC_FEATURES;        /**< \brief (TC Offset: 0xF8) Features Register */
+  RoReg   TC_VERSION;         /**< \brief (TC Offset: 0xFC) Version Register */
+ } reg;
+} Tc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_TC_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/tc.h
+++ b/asf/sam/include/sam4l/component/tc.h
@@ -1230,27 +1230,15 @@ typedef union {
 
 /** \brief TC hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-       TcChannel                 Channel[3];  /**< \brief Offset: 0x00 TcChannel groups */
-  __O  TC_BCR_Type               BCR;         /**< \brief Offset: 0xC0 ( /W 32) TC Block Control Register */
-  __IO TC_BMR_Type               BMR;         /**< \brief Offset: 0xC4 (R/W 32) TC Block Mode Register */
-       RoReg8                    Reserved1[0x1C];
-  __IO TC_WPMR_Type              WPMR;        /**< \brief Offset: 0xE4 (R/W 32) Write Protect Mode Register */
-       RoReg8                    Reserved2[0x10];
-  __I  TC_FEATURES_Type          FEATURES;    /**< \brief Offset: 0xF8 (R/  32) Features Register */
-  __I  TC_VERSION_Type           VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
- } bf;
- struct {
-  TcChannel TC_CHANNEL[3];      /**< \brief (TC Offset: 0x00) TcChannel groups */
-  WoReg   TC_BCR;             /**< \brief (TC Offset: 0xC0) TC Block Control Register */
-  RwReg   TC_BMR;             /**< \brief (TC Offset: 0xC4) TC Block Mode Register */
-  RoReg8  Reserved3[0x1C];
-  RwReg   TC_WPMR;            /**< \brief (TC Offset: 0xE4) Write Protect Mode Register */
-  RoReg8  Reserved4[0x10];
-  RoReg   TC_FEATURES;        /**< \brief (TC Offset: 0xF8) Features Register */
-  RoReg   TC_VERSION;         /**< \brief (TC Offset: 0xFC) Version Register */
- } reg;
+typedef struct {
+  __IO uint32_t Channel[3];  /**< \brief Offset: 0x00 TcChannel groups */
+  __O  uint32_t BCR;         /**< \brief Offset: 0xC0 ( /W 32) TC Block Control Register */
+  __IO uint32_t BMR;         /**< \brief Offset: 0xC4 (R/W 32) TC Block Mode Register */
+       RoReg8   Reserved1[0x1C];
+  __IO uint32_t WPMR;        /**< \brief Offset: 0xE4 (R/W 32) Write Protect Mode Register */
+       RoReg8   Reserved2[0x10];
+  __I  uint32_t FEATURES;    /**< \brief Offset: 0xF8 (R/  32) Features Register */
+  __I  uint32_t VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
 } Tc;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/tc.h
+++ b/asf/sam/include/sam4l/component/tc.h
@@ -52,27 +52,27 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_CCR_OFFSET               0x00         /**< \brief (TC_CCR offset) Channel Control Register Channel */
-#define TC_CCR_RESETVALUE           _U(0x00000000); /**< \brief (TC_CCR reset_value) Channel Control Register Channel */
+#define TC_CCR_RESETVALUE           _U_(0x00000000); /**< \brief (TC_CCR reset_value) Channel Control Register Channel */
 
 #define TC_CCR_CLKEN_Pos            0            /**< \brief (TC_CCR) Counter Clock Enable Command */
-#define TC_CCR_CLKEN                (_U(0x1) << TC_CCR_CLKEN_Pos)
-#define   TC_CCR_CLKEN_0_Val              _U(0x0)   /**< \brief (TC_CCR) No effect. */
-#define   TC_CCR_CLKEN_1_Val              _U(0x1)   /**< \brief (TC_CCR) Enables the clock if CLKDIS is not 1. */
+#define TC_CCR_CLKEN                (_U_(0x1) << TC_CCR_CLKEN_Pos)
+#define   TC_CCR_CLKEN_0_Val              _U_(0x0)   /**< \brief (TC_CCR) No effect. */
+#define   TC_CCR_CLKEN_1_Val              _U_(0x1)   /**< \brief (TC_CCR) Enables the clock if CLKDIS is not 1. */
 #define TC_CCR_CLKEN_0              (TC_CCR_CLKEN_0_Val            << TC_CCR_CLKEN_Pos)
 #define TC_CCR_CLKEN_1              (TC_CCR_CLKEN_1_Val            << TC_CCR_CLKEN_Pos)
 #define TC_CCR_CLKDIS_Pos           1            /**< \brief (TC_CCR) Counter Clock Disable Command */
-#define TC_CCR_CLKDIS               (_U(0x1) << TC_CCR_CLKDIS_Pos)
-#define   TC_CCR_CLKDIS_0_Val             _U(0x0)   /**< \brief (TC_CCR) No effect. */
-#define   TC_CCR_CLKDIS_1_Val             _U(0x1)   /**< \brief (TC_CCR) Disables the clock. */
+#define TC_CCR_CLKDIS               (_U_(0x1) << TC_CCR_CLKDIS_Pos)
+#define   TC_CCR_CLKDIS_0_Val             _U_(0x0)   /**< \brief (TC_CCR) No effect. */
+#define   TC_CCR_CLKDIS_1_Val             _U_(0x1)   /**< \brief (TC_CCR) Disables the clock. */
 #define TC_CCR_CLKDIS_0             (TC_CCR_CLKDIS_0_Val           << TC_CCR_CLKDIS_Pos)
 #define TC_CCR_CLKDIS_1             (TC_CCR_CLKDIS_1_Val           << TC_CCR_CLKDIS_Pos)
 #define TC_CCR_SWTRG_Pos            2            /**< \brief (TC_CCR) Software Trigger Command */
-#define TC_CCR_SWTRG                (_U(0x1) << TC_CCR_SWTRG_Pos)
-#define   TC_CCR_SWTRG_0_Val              _U(0x0)   /**< \brief (TC_CCR) No effect. */
-#define   TC_CCR_SWTRG_1_Val              _U(0x1)   /**< \brief (TC_CCR) A software trigger is performed:the counter is reset and clock is started. */
+#define TC_CCR_SWTRG                (_U_(0x1) << TC_CCR_SWTRG_Pos)
+#define   TC_CCR_SWTRG_0_Val              _U_(0x0)   /**< \brief (TC_CCR) No effect. */
+#define   TC_CCR_SWTRG_1_Val              _U_(0x1)   /**< \brief (TC_CCR) A software trigger is performed:the counter is reset and clock is started. */
 #define TC_CCR_SWTRG_0              (TC_CCR_SWTRG_0_Val            << TC_CCR_SWTRG_Pos)
 #define TC_CCR_SWTRG_1              (TC_CCR_SWTRG_1_Val            << TC_CCR_SWTRG_Pos)
-#define TC_CCR_MASK                 _U(0x00000007) /**< \brief (TC_CCR) MASK Register */
+#define TC_CCR_MASK                 _U_(0x00000007) /**< \brief (TC_CCR) MASK Register */
 
 /* -------- TC_CMR : (TC Offset: 0x04) (R/W 32) channel Channel Mode Register Channel -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -117,20 +117,20 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_CMR_OFFSET               0x04         /**< \brief (TC_CMR offset) Channel Mode Register Channel */
-#define TC_CMR_RESETVALUE           _U(0x00000000); /**< \brief (TC_CMR reset_value) Channel Mode Register Channel */
+#define TC_CMR_RESETVALUE           _U_(0x00000000); /**< \brief (TC_CMR reset_value) Channel Mode Register Channel */
 
 // CAPTURE mode
 #define TC_CMR_CAPTURE_TCCLKS_Pos   0            /**< \brief (TC_CMR_CAPTURE) Clock Selection */
-#define TC_CMR_CAPTURE_TCCLKS_Msk   (_U(0x7) << TC_CMR_CAPTURE_TCCLKS_Pos)
+#define TC_CMR_CAPTURE_TCCLKS_Msk   (_U_(0x7) << TC_CMR_CAPTURE_TCCLKS_Pos)
 #define TC_CMR_CAPTURE_TCCLKS(value) (TC_CMR_CAPTURE_TCCLKS_Msk & ((value) << TC_CMR_CAPTURE_TCCLKS_Pos))
-#define   TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK1_Val _U(0x0)   /**< \brief (TC_CMR_CAPTURE) TIMER_CLOCK1 */
-#define   TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK2_Val _U(0x1)   /**< \brief (TC_CMR_CAPTURE) TIMER_CLOCK2 */
-#define   TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK3_Val _U(0x2)   /**< \brief (TC_CMR_CAPTURE) TIMER_CLOCK3 */
-#define   TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK4_Val _U(0x3)   /**< \brief (TC_CMR_CAPTURE) TIMER_CLOCK4 */
-#define   TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK5_Val _U(0x4)   /**< \brief (TC_CMR_CAPTURE) TIMER_CLOCK5 */
-#define   TC_CMR_CAPTURE_TCCLKS_XC0_Val   _U(0x5)   /**< \brief (TC_CMR_CAPTURE) XC0 */
-#define   TC_CMR_CAPTURE_TCCLKS_XC1_Val   _U(0x6)   /**< \brief (TC_CMR_CAPTURE) XC1 */
-#define   TC_CMR_CAPTURE_TCCLKS_XC2_Val   _U(0x7)   /**< \brief (TC_CMR_CAPTURE) XC2 */
+#define   TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK1_Val _U_(0x0)   /**< \brief (TC_CMR_CAPTURE) TIMER_CLOCK1 */
+#define   TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK2_Val _U_(0x1)   /**< \brief (TC_CMR_CAPTURE) TIMER_CLOCK2 */
+#define   TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK3_Val _U_(0x2)   /**< \brief (TC_CMR_CAPTURE) TIMER_CLOCK3 */
+#define   TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK4_Val _U_(0x3)   /**< \brief (TC_CMR_CAPTURE) TIMER_CLOCK4 */
+#define   TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK5_Val _U_(0x4)   /**< \brief (TC_CMR_CAPTURE) TIMER_CLOCK5 */
+#define   TC_CMR_CAPTURE_TCCLKS_XC0_Val   _U_(0x5)   /**< \brief (TC_CMR_CAPTURE) XC0 */
+#define   TC_CMR_CAPTURE_TCCLKS_XC1_Val   _U_(0x6)   /**< \brief (TC_CMR_CAPTURE) XC1 */
+#define   TC_CMR_CAPTURE_TCCLKS_XC2_Val   _U_(0x7)   /**< \brief (TC_CMR_CAPTURE) XC2 */
 #define TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK1 (TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK1_Val << TC_CMR_CAPTURE_TCCLKS_Pos)
 #define TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK2 (TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK2_Val << TC_CMR_CAPTURE_TCCLKS_Pos)
 #define TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK3 (TC_CMR_CAPTURE_TCCLKS_TIMER_CLOCK3_Val << TC_CMR_CAPTURE_TCCLKS_Pos)
@@ -140,99 +140,99 @@ typedef union {
 #define TC_CMR_CAPTURE_TCCLKS_XC1   (TC_CMR_CAPTURE_TCCLKS_XC1_Val << TC_CMR_CAPTURE_TCCLKS_Pos)
 #define TC_CMR_CAPTURE_TCCLKS_XC2   (TC_CMR_CAPTURE_TCCLKS_XC2_Val << TC_CMR_CAPTURE_TCCLKS_Pos)
 #define TC_CMR_CAPTURE_CLKI_Pos     3            /**< \brief (TC_CMR_CAPTURE) Clock Invert */
-#define TC_CMR_CAPTURE_CLKI         (_U(0x1) << TC_CMR_CAPTURE_CLKI_Pos)
-#define   TC_CMR_CAPTURE_CLKI_0_Val       _U(0x0)   /**< \brief (TC_CMR_CAPTURE) Counter is incremented on rising edge of the clock. */
-#define   TC_CMR_CAPTURE_CLKI_1_Val       _U(0x1)   /**< \brief (TC_CMR_CAPTURE) Counter is incremented on falling edge of the clock. */
+#define TC_CMR_CAPTURE_CLKI         (_U_(0x1) << TC_CMR_CAPTURE_CLKI_Pos)
+#define   TC_CMR_CAPTURE_CLKI_0_Val       _U_(0x0)   /**< \brief (TC_CMR_CAPTURE) Counter is incremented on rising edge of the clock. */
+#define   TC_CMR_CAPTURE_CLKI_1_Val       _U_(0x1)   /**< \brief (TC_CMR_CAPTURE) Counter is incremented on falling edge of the clock. */
 #define TC_CMR_CAPTURE_CLKI_0       (TC_CMR_CAPTURE_CLKI_0_Val     << TC_CMR_CAPTURE_CLKI_Pos)
 #define TC_CMR_CAPTURE_CLKI_1       (TC_CMR_CAPTURE_CLKI_1_Val     << TC_CMR_CAPTURE_CLKI_Pos)
 #define TC_CMR_CAPTURE_BURST_Pos    4            /**< \brief (TC_CMR_CAPTURE) Burst Signal Selection */
-#define TC_CMR_CAPTURE_BURST_Msk    (_U(0x3) << TC_CMR_CAPTURE_BURST_Pos)
+#define TC_CMR_CAPTURE_BURST_Msk    (_U_(0x3) << TC_CMR_CAPTURE_BURST_Pos)
 #define TC_CMR_CAPTURE_BURST(value) (TC_CMR_CAPTURE_BURST_Msk & ((value) << TC_CMR_CAPTURE_BURST_Pos))
-#define   TC_CMR_CAPTURE_BURST_NOT_GATED_Val _U(0x0)   /**< \brief (TC_CMR_CAPTURE) The clock is not gated by an external signal. */
-#define   TC_CMR_CAPTURE_BURST_CLK_AND_XC0_Val _U(0x1)   /**< \brief (TC_CMR_CAPTURE) XC0 is ANDed with the selected clock. */
-#define   TC_CMR_CAPTURE_BURST_CLK_AND_XC1_Val _U(0x2)   /**< \brief (TC_CMR_CAPTURE) XC1 is ANDed with the selected clock. */
-#define   TC_CMR_CAPTURE_BURST_CLK_AND_XC2_Val _U(0x3)   /**< \brief (TC_CMR_CAPTURE) XC2 is ANDed with the selected clock. */
+#define   TC_CMR_CAPTURE_BURST_NOT_GATED_Val _U_(0x0)   /**< \brief (TC_CMR_CAPTURE) The clock is not gated by an external signal. */
+#define   TC_CMR_CAPTURE_BURST_CLK_AND_XC0_Val _U_(0x1)   /**< \brief (TC_CMR_CAPTURE) XC0 is ANDed with the selected clock. */
+#define   TC_CMR_CAPTURE_BURST_CLK_AND_XC1_Val _U_(0x2)   /**< \brief (TC_CMR_CAPTURE) XC1 is ANDed with the selected clock. */
+#define   TC_CMR_CAPTURE_BURST_CLK_AND_XC2_Val _U_(0x3)   /**< \brief (TC_CMR_CAPTURE) XC2 is ANDed with the selected clock. */
 #define TC_CMR_CAPTURE_BURST_NOT_GATED (TC_CMR_CAPTURE_BURST_NOT_GATED_Val << TC_CMR_CAPTURE_BURST_Pos)
 #define TC_CMR_CAPTURE_BURST_CLK_AND_XC0 (TC_CMR_CAPTURE_BURST_CLK_AND_XC0_Val << TC_CMR_CAPTURE_BURST_Pos)
 #define TC_CMR_CAPTURE_BURST_CLK_AND_XC1 (TC_CMR_CAPTURE_BURST_CLK_AND_XC1_Val << TC_CMR_CAPTURE_BURST_Pos)
 #define TC_CMR_CAPTURE_BURST_CLK_AND_XC2 (TC_CMR_CAPTURE_BURST_CLK_AND_XC2_Val << TC_CMR_CAPTURE_BURST_Pos)
 #define TC_CMR_CAPTURE_LDBSTOP_Pos  6            /**< \brief (TC_CMR_CAPTURE) Counter Clock Stopped with RB Loading */
-#define TC_CMR_CAPTURE_LDBSTOP      (_U(0x1) << TC_CMR_CAPTURE_LDBSTOP_Pos)
-#define   TC_CMR_CAPTURE_LDBSTOP_0_Val    _U(0x0)   /**< \brief (TC_CMR_CAPTURE) Counter clock is not stopped when RB loading occurs. */
-#define   TC_CMR_CAPTURE_LDBSTOP_1_Val    _U(0x1)   /**< \brief (TC_CMR_CAPTURE) Counter clock is stopped when RB loading occurs. */
+#define TC_CMR_CAPTURE_LDBSTOP      (_U_(0x1) << TC_CMR_CAPTURE_LDBSTOP_Pos)
+#define   TC_CMR_CAPTURE_LDBSTOP_0_Val    _U_(0x0)   /**< \brief (TC_CMR_CAPTURE) Counter clock is not stopped when RB loading occurs. */
+#define   TC_CMR_CAPTURE_LDBSTOP_1_Val    _U_(0x1)   /**< \brief (TC_CMR_CAPTURE) Counter clock is stopped when RB loading occurs. */
 #define TC_CMR_CAPTURE_LDBSTOP_0    (TC_CMR_CAPTURE_LDBSTOP_0_Val  << TC_CMR_CAPTURE_LDBSTOP_Pos)
 #define TC_CMR_CAPTURE_LDBSTOP_1    (TC_CMR_CAPTURE_LDBSTOP_1_Val  << TC_CMR_CAPTURE_LDBSTOP_Pos)
 #define TC_CMR_CAPTURE_LDBDIS_Pos   7            /**< \brief (TC_CMR_CAPTURE) Counter Clock Disable with RB Loading */
-#define TC_CMR_CAPTURE_LDBDIS       (_U(0x1) << TC_CMR_CAPTURE_LDBDIS_Pos)
-#define   TC_CMR_CAPTURE_LDBDIS_0_Val     _U(0x0)   /**< \brief (TC_CMR_CAPTURE) Counter clock is not disabled when RB loading occurs. */
-#define   TC_CMR_CAPTURE_LDBDIS_1_Val     _U(0x1)   /**< \brief (TC_CMR_CAPTURE) Counter clock is disabled when RB loading occurs. */
+#define TC_CMR_CAPTURE_LDBDIS       (_U_(0x1) << TC_CMR_CAPTURE_LDBDIS_Pos)
+#define   TC_CMR_CAPTURE_LDBDIS_0_Val     _U_(0x0)   /**< \brief (TC_CMR_CAPTURE) Counter clock is not disabled when RB loading occurs. */
+#define   TC_CMR_CAPTURE_LDBDIS_1_Val     _U_(0x1)   /**< \brief (TC_CMR_CAPTURE) Counter clock is disabled when RB loading occurs. */
 #define TC_CMR_CAPTURE_LDBDIS_0     (TC_CMR_CAPTURE_LDBDIS_0_Val   << TC_CMR_CAPTURE_LDBDIS_Pos)
 #define TC_CMR_CAPTURE_LDBDIS_1     (TC_CMR_CAPTURE_LDBDIS_1_Val   << TC_CMR_CAPTURE_LDBDIS_Pos)
 #define TC_CMR_CAPTURE_ETRGEDG_Pos  8            /**< \brief (TC_CMR_CAPTURE) External Trigger Edge Selection */
-#define TC_CMR_CAPTURE_ETRGEDG_Msk  (_U(0x3) << TC_CMR_CAPTURE_ETRGEDG_Pos)
+#define TC_CMR_CAPTURE_ETRGEDG_Msk  (_U_(0x3) << TC_CMR_CAPTURE_ETRGEDG_Pos)
 #define TC_CMR_CAPTURE_ETRGEDG(value) (TC_CMR_CAPTURE_ETRGEDG_Msk & ((value) << TC_CMR_CAPTURE_ETRGEDG_Pos))
-#define   TC_CMR_CAPTURE_ETRGEDG_NO_EDGE_Val _U(0x0)   /**< \brief (TC_CMR_CAPTURE) none */
-#define   TC_CMR_CAPTURE_ETRGEDG_POS_EDGE_Val _U(0x1)   /**< \brief (TC_CMR_CAPTURE) rising edge */
-#define   TC_CMR_CAPTURE_ETRGEDG_NEG_EDGE_Val _U(0x2)   /**< \brief (TC_CMR_CAPTURE) falling edge */
-#define   TC_CMR_CAPTURE_ETRGEDG_BOTH_EDGES_Val _U(0x3)   /**< \brief (TC_CMR_CAPTURE) each edge */
+#define   TC_CMR_CAPTURE_ETRGEDG_NO_EDGE_Val _U_(0x0)   /**< \brief (TC_CMR_CAPTURE) none */
+#define   TC_CMR_CAPTURE_ETRGEDG_POS_EDGE_Val _U_(0x1)   /**< \brief (TC_CMR_CAPTURE) rising edge */
+#define   TC_CMR_CAPTURE_ETRGEDG_NEG_EDGE_Val _U_(0x2)   /**< \brief (TC_CMR_CAPTURE) falling edge */
+#define   TC_CMR_CAPTURE_ETRGEDG_BOTH_EDGES_Val _U_(0x3)   /**< \brief (TC_CMR_CAPTURE) each edge */
 #define TC_CMR_CAPTURE_ETRGEDG_NO_EDGE (TC_CMR_CAPTURE_ETRGEDG_NO_EDGE_Val << TC_CMR_CAPTURE_ETRGEDG_Pos)
 #define TC_CMR_CAPTURE_ETRGEDG_POS_EDGE (TC_CMR_CAPTURE_ETRGEDG_POS_EDGE_Val << TC_CMR_CAPTURE_ETRGEDG_Pos)
 #define TC_CMR_CAPTURE_ETRGEDG_NEG_EDGE (TC_CMR_CAPTURE_ETRGEDG_NEG_EDGE_Val << TC_CMR_CAPTURE_ETRGEDG_Pos)
 #define TC_CMR_CAPTURE_ETRGEDG_BOTH_EDGES (TC_CMR_CAPTURE_ETRGEDG_BOTH_EDGES_Val << TC_CMR_CAPTURE_ETRGEDG_Pos)
 #define TC_CMR_CAPTURE_ABETRG_Pos   10           /**< \brief (TC_CMR_CAPTURE) TIOA or TIOB External Trigger Selection */
-#define TC_CMR_CAPTURE_ABETRG       (_U(0x1) << TC_CMR_CAPTURE_ABETRG_Pos)
-#define   TC_CMR_CAPTURE_ABETRG_0_Val     _U(0x0)   /**< \brief (TC_CMR_CAPTURE) TIOB is used as an external trigger. */
-#define   TC_CMR_CAPTURE_ABETRG_1_Val     _U(0x1)   /**< \brief (TC_CMR_CAPTURE) TIOA is used as an external trigger. */
+#define TC_CMR_CAPTURE_ABETRG       (_U_(0x1) << TC_CMR_CAPTURE_ABETRG_Pos)
+#define   TC_CMR_CAPTURE_ABETRG_0_Val     _U_(0x0)   /**< \brief (TC_CMR_CAPTURE) TIOB is used as an external trigger. */
+#define   TC_CMR_CAPTURE_ABETRG_1_Val     _U_(0x1)   /**< \brief (TC_CMR_CAPTURE) TIOA is used as an external trigger. */
 #define TC_CMR_CAPTURE_ABETRG_0     (TC_CMR_CAPTURE_ABETRG_0_Val   << TC_CMR_CAPTURE_ABETRG_Pos)
 #define TC_CMR_CAPTURE_ABETRG_1     (TC_CMR_CAPTURE_ABETRG_1_Val   << TC_CMR_CAPTURE_ABETRG_Pos)
 #define TC_CMR_CAPTURE_CPCTRG_Pos   14           /**< \brief (TC_CMR_CAPTURE) RC Compare Trigger Enable */
-#define TC_CMR_CAPTURE_CPCTRG       (_U(0x1) << TC_CMR_CAPTURE_CPCTRG_Pos)
-#define   TC_CMR_CAPTURE_CPCTRG_0_Val     _U(0x0)   /**< \brief (TC_CMR_CAPTURE) RC Compare has no effect on the counter and its clock. */
-#define   TC_CMR_CAPTURE_CPCTRG_1_Val     _U(0x1)   /**< \brief (TC_CMR_CAPTURE) RC Compare resets the counter and starts the counter clock. */
+#define TC_CMR_CAPTURE_CPCTRG       (_U_(0x1) << TC_CMR_CAPTURE_CPCTRG_Pos)
+#define   TC_CMR_CAPTURE_CPCTRG_0_Val     _U_(0x0)   /**< \brief (TC_CMR_CAPTURE) RC Compare has no effect on the counter and its clock. */
+#define   TC_CMR_CAPTURE_CPCTRG_1_Val     _U_(0x1)   /**< \brief (TC_CMR_CAPTURE) RC Compare resets the counter and starts the counter clock. */
 #define TC_CMR_CAPTURE_CPCTRG_0     (TC_CMR_CAPTURE_CPCTRG_0_Val   << TC_CMR_CAPTURE_CPCTRG_Pos)
 #define TC_CMR_CAPTURE_CPCTRG_1     (TC_CMR_CAPTURE_CPCTRG_1_Val   << TC_CMR_CAPTURE_CPCTRG_Pos)
 #define TC_CMR_CAPTURE_WAVE_Pos     15           /**< \brief (TC_CMR_CAPTURE) Wave */
-#define TC_CMR_CAPTURE_WAVE         (_U(0x1) << TC_CMR_CAPTURE_WAVE_Pos)
-#define   TC_CMR_CAPTURE_WAVE_0_Val       _U(0x0)   /**< \brief (TC_CMR_CAPTURE) Capture Mode is enabled. */
-#define   TC_CMR_CAPTURE_WAVE_1_Val       _U(0x1)   /**< \brief (TC_CMR_CAPTURE) Capture Mode is disabled (Waveform Mode is enabled). */
+#define TC_CMR_CAPTURE_WAVE         (_U_(0x1) << TC_CMR_CAPTURE_WAVE_Pos)
+#define   TC_CMR_CAPTURE_WAVE_0_Val       _U_(0x0)   /**< \brief (TC_CMR_CAPTURE) Capture Mode is enabled. */
+#define   TC_CMR_CAPTURE_WAVE_1_Val       _U_(0x1)   /**< \brief (TC_CMR_CAPTURE) Capture Mode is disabled (Waveform Mode is enabled). */
 #define TC_CMR_CAPTURE_WAVE_0       (TC_CMR_CAPTURE_WAVE_0_Val     << TC_CMR_CAPTURE_WAVE_Pos)
 #define TC_CMR_CAPTURE_WAVE_1       (TC_CMR_CAPTURE_WAVE_1_Val     << TC_CMR_CAPTURE_WAVE_Pos)
 #define TC_CMR_CAPTURE_LDRA_Pos     16           /**< \brief (TC_CMR_CAPTURE) RA Loading Selection */
-#define TC_CMR_CAPTURE_LDRA_Msk     (_U(0x3) << TC_CMR_CAPTURE_LDRA_Pos)
+#define TC_CMR_CAPTURE_LDRA_Msk     (_U_(0x3) << TC_CMR_CAPTURE_LDRA_Pos)
 #define TC_CMR_CAPTURE_LDRA(value)  (TC_CMR_CAPTURE_LDRA_Msk & ((value) << TC_CMR_CAPTURE_LDRA_Pos))
-#define   TC_CMR_CAPTURE_LDRA_NO_EDGE_Val _U(0x0)   /**< \brief (TC_CMR_CAPTURE) none */
-#define   TC_CMR_CAPTURE_LDRA_POS_EDGE_TIOA_Val _U(0x1)   /**< \brief (TC_CMR_CAPTURE) rising edge of TIOA */
-#define   TC_CMR_CAPTURE_LDRA_NEG_EDGE_TIOA_Val _U(0x2)   /**< \brief (TC_CMR_CAPTURE) falling edge of TIOA */
-#define   TC_CMR_CAPTURE_LDRA_BOTH_EDGES_TIOA_Val _U(0x3)   /**< \brief (TC_CMR_CAPTURE) each edge of TIOA */
+#define   TC_CMR_CAPTURE_LDRA_NO_EDGE_Val _U_(0x0)   /**< \brief (TC_CMR_CAPTURE) none */
+#define   TC_CMR_CAPTURE_LDRA_POS_EDGE_TIOA_Val _U_(0x1)   /**< \brief (TC_CMR_CAPTURE) rising edge of TIOA */
+#define   TC_CMR_CAPTURE_LDRA_NEG_EDGE_TIOA_Val _U_(0x2)   /**< \brief (TC_CMR_CAPTURE) falling edge of TIOA */
+#define   TC_CMR_CAPTURE_LDRA_BOTH_EDGES_TIOA_Val _U_(0x3)   /**< \brief (TC_CMR_CAPTURE) each edge of TIOA */
 #define TC_CMR_CAPTURE_LDRA_NO_EDGE (TC_CMR_CAPTURE_LDRA_NO_EDGE_Val << TC_CMR_CAPTURE_LDRA_Pos)
 #define TC_CMR_CAPTURE_LDRA_POS_EDGE_TIOA (TC_CMR_CAPTURE_LDRA_POS_EDGE_TIOA_Val << TC_CMR_CAPTURE_LDRA_Pos)
 #define TC_CMR_CAPTURE_LDRA_NEG_EDGE_TIOA (TC_CMR_CAPTURE_LDRA_NEG_EDGE_TIOA_Val << TC_CMR_CAPTURE_LDRA_Pos)
 #define TC_CMR_CAPTURE_LDRA_BOTH_EDGES_TIOA (TC_CMR_CAPTURE_LDRA_BOTH_EDGES_TIOA_Val << TC_CMR_CAPTURE_LDRA_Pos)
 #define TC_CMR_CAPTURE_LDRB_Pos     18           /**< \brief (TC_CMR_CAPTURE) RB Loading Selection */
-#define TC_CMR_CAPTURE_LDRB_Msk     (_U(0x3) << TC_CMR_CAPTURE_LDRB_Pos)
+#define TC_CMR_CAPTURE_LDRB_Msk     (_U_(0x3) << TC_CMR_CAPTURE_LDRB_Pos)
 #define TC_CMR_CAPTURE_LDRB(value)  (TC_CMR_CAPTURE_LDRB_Msk & ((value) << TC_CMR_CAPTURE_LDRB_Pos))
-#define   TC_CMR_CAPTURE_LDRB_NO_EDGE_Val _U(0x0)   /**< \brief (TC_CMR_CAPTURE) none */
-#define   TC_CMR_CAPTURE_LDRB_POS_EDGE_TIOA_Val _U(0x1)   /**< \brief (TC_CMR_CAPTURE) rising edge of TIOA */
-#define   TC_CMR_CAPTURE_LDRB_NEG_EDGE_TIOA_Val _U(0x2)   /**< \brief (TC_CMR_CAPTURE) falling edge of TIOA */
-#define   TC_CMR_CAPTURE_LDRB_BOTH_EDGES_TIOA_Val _U(0x3)   /**< \brief (TC_CMR_CAPTURE) each edge of TIOA */
+#define   TC_CMR_CAPTURE_LDRB_NO_EDGE_Val _U_(0x0)   /**< \brief (TC_CMR_CAPTURE) none */
+#define   TC_CMR_CAPTURE_LDRB_POS_EDGE_TIOA_Val _U_(0x1)   /**< \brief (TC_CMR_CAPTURE) rising edge of TIOA */
+#define   TC_CMR_CAPTURE_LDRB_NEG_EDGE_TIOA_Val _U_(0x2)   /**< \brief (TC_CMR_CAPTURE) falling edge of TIOA */
+#define   TC_CMR_CAPTURE_LDRB_BOTH_EDGES_TIOA_Val _U_(0x3)   /**< \brief (TC_CMR_CAPTURE) each edge of TIOA */
 #define TC_CMR_CAPTURE_LDRB_NO_EDGE (TC_CMR_CAPTURE_LDRB_NO_EDGE_Val << TC_CMR_CAPTURE_LDRB_Pos)
 #define TC_CMR_CAPTURE_LDRB_POS_EDGE_TIOA (TC_CMR_CAPTURE_LDRB_POS_EDGE_TIOA_Val << TC_CMR_CAPTURE_LDRB_Pos)
 #define TC_CMR_CAPTURE_LDRB_NEG_EDGE_TIOA (TC_CMR_CAPTURE_LDRB_NEG_EDGE_TIOA_Val << TC_CMR_CAPTURE_LDRB_Pos)
 #define TC_CMR_CAPTURE_LDRB_BOTH_EDGES_TIOA (TC_CMR_CAPTURE_LDRB_BOTH_EDGES_TIOA_Val << TC_CMR_CAPTURE_LDRB_Pos)
-#define TC_CMR_CAPTURE_MASK         _U(0x000FC7FF) /**< \brief (TC_CMR_CAPTURE) MASK Register */
+#define TC_CMR_CAPTURE_MASK         _U_(0x000FC7FF) /**< \brief (TC_CMR_CAPTURE) MASK Register */
 
 // WAVEFORM mode
 #define TC_CMR_WAVEFORM_TCCLKS_Pos  0            /**< \brief (TC_CMR_WAVEFORM) Clock Selection */
-#define TC_CMR_WAVEFORM_TCCLKS_Msk  (_U(0x7) << TC_CMR_WAVEFORM_TCCLKS_Pos)
+#define TC_CMR_WAVEFORM_TCCLKS_Msk  (_U_(0x7) << TC_CMR_WAVEFORM_TCCLKS_Pos)
 #define TC_CMR_WAVEFORM_TCCLKS(value) (TC_CMR_WAVEFORM_TCCLKS_Msk & ((value) << TC_CMR_WAVEFORM_TCCLKS_Pos))
-#define   TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV1_CLOCK_Val _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) TIMER_DIV1_CLOCK */
-#define   TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV2_CLOCK_Val _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) TIMER_DIV2_CLOCK */
-#define   TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV3_CLOCK_Val _U(0x2)   /**< \brief (TC_CMR_WAVEFORM) TIMER_DIV3_CLOCK */
-#define   TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV4_CLOCK_Val _U(0x3)   /**< \brief (TC_CMR_WAVEFORM) TIMER_DIV4_CLOCK */
-#define   TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV5_CLOCK_Val _U(0x4)   /**< \brief (TC_CMR_WAVEFORM) TIMER_DIV5_CLOCK */
-#define   TC_CMR_WAVEFORM_TCCLKS_XC0_Val  _U(0x5)   /**< \brief (TC_CMR_WAVEFORM) XC0 */
-#define   TC_CMR_WAVEFORM_TCCLKS_XC1_Val  _U(0x6)   /**< \brief (TC_CMR_WAVEFORM) XC1 */
-#define   TC_CMR_WAVEFORM_TCCLKS_XC2_Val  _U(0x7)   /**< \brief (TC_CMR_WAVEFORM) XC2 */
+#define   TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV1_CLOCK_Val _U_(0x0)   /**< \brief (TC_CMR_WAVEFORM) TIMER_DIV1_CLOCK */
+#define   TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV2_CLOCK_Val _U_(0x1)   /**< \brief (TC_CMR_WAVEFORM) TIMER_DIV2_CLOCK */
+#define   TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV3_CLOCK_Val _U_(0x2)   /**< \brief (TC_CMR_WAVEFORM) TIMER_DIV3_CLOCK */
+#define   TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV4_CLOCK_Val _U_(0x3)   /**< \brief (TC_CMR_WAVEFORM) TIMER_DIV4_CLOCK */
+#define   TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV5_CLOCK_Val _U_(0x4)   /**< \brief (TC_CMR_WAVEFORM) TIMER_DIV5_CLOCK */
+#define   TC_CMR_WAVEFORM_TCCLKS_XC0_Val  _U_(0x5)   /**< \brief (TC_CMR_WAVEFORM) XC0 */
+#define   TC_CMR_WAVEFORM_TCCLKS_XC1_Val  _U_(0x6)   /**< \brief (TC_CMR_WAVEFORM) XC1 */
+#define   TC_CMR_WAVEFORM_TCCLKS_XC2_Val  _U_(0x7)   /**< \brief (TC_CMR_WAVEFORM) XC2 */
 #define TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV1_CLOCK (TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV1_CLOCK_Val << TC_CMR_WAVEFORM_TCCLKS_Pos)
 #define TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV2_CLOCK (TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV2_CLOCK_Val << TC_CMR_WAVEFORM_TCCLKS_Pos)
 #define TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV3_CLOCK (TC_CMR_WAVEFORM_TCCLKS_TIMER_DIV3_CLOCK_Val << TC_CMR_WAVEFORM_TCCLKS_Pos)
@@ -242,181 +242,181 @@ typedef union {
 #define TC_CMR_WAVEFORM_TCCLKS_XC1  (TC_CMR_WAVEFORM_TCCLKS_XC1_Val << TC_CMR_WAVEFORM_TCCLKS_Pos)
 #define TC_CMR_WAVEFORM_TCCLKS_XC2  (TC_CMR_WAVEFORM_TCCLKS_XC2_Val << TC_CMR_WAVEFORM_TCCLKS_Pos)
 #define TC_CMR_WAVEFORM_CLKI_Pos    3            /**< \brief (TC_CMR_WAVEFORM) Clock Invert */
-#define TC_CMR_WAVEFORM_CLKI        (_U(0x1) << TC_CMR_WAVEFORM_CLKI_Pos)
-#define   TC_CMR_WAVEFORM_CLKI_0_Val      _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) Counter is incremented on rising edge of the clock. */
-#define   TC_CMR_WAVEFORM_CLKI_1_Val      _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) Counter is incremented on falling edge of the clock. */
+#define TC_CMR_WAVEFORM_CLKI        (_U_(0x1) << TC_CMR_WAVEFORM_CLKI_Pos)
+#define   TC_CMR_WAVEFORM_CLKI_0_Val      _U_(0x0)   /**< \brief (TC_CMR_WAVEFORM) Counter is incremented on rising edge of the clock. */
+#define   TC_CMR_WAVEFORM_CLKI_1_Val      _U_(0x1)   /**< \brief (TC_CMR_WAVEFORM) Counter is incremented on falling edge of the clock. */
 #define TC_CMR_WAVEFORM_CLKI_0      (TC_CMR_WAVEFORM_CLKI_0_Val    << TC_CMR_WAVEFORM_CLKI_Pos)
 #define TC_CMR_WAVEFORM_CLKI_1      (TC_CMR_WAVEFORM_CLKI_1_Val    << TC_CMR_WAVEFORM_CLKI_Pos)
 #define TC_CMR_WAVEFORM_BURST_Pos   4            /**< \brief (TC_CMR_WAVEFORM) Burst Signal Selection */
-#define TC_CMR_WAVEFORM_BURST_Msk   (_U(0x3) << TC_CMR_WAVEFORM_BURST_Pos)
+#define TC_CMR_WAVEFORM_BURST_Msk   (_U_(0x3) << TC_CMR_WAVEFORM_BURST_Pos)
 #define TC_CMR_WAVEFORM_BURST(value) (TC_CMR_WAVEFORM_BURST_Msk & ((value) << TC_CMR_WAVEFORM_BURST_Pos))
-#define   TC_CMR_WAVEFORM_BURST_NOT_GATED_Val _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) The clock is not gated by an external signal. */
-#define   TC_CMR_WAVEFORM_BURST_CLK_AND_XC0_Val _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) XC0 is ANDed with the selected clock. */
-#define   TC_CMR_WAVEFORM_BURST_CLK_AND_XC1_Val _U(0x2)   /**< \brief (TC_CMR_WAVEFORM) XC1 is ANDed with the selected clock. */
-#define   TC_CMR_WAVEFORM_BURST_CLK_AND_XC2_Val _U(0x3)   /**< \brief (TC_CMR_WAVEFORM) XC2 is ANDed with the selected clock. */
+#define   TC_CMR_WAVEFORM_BURST_NOT_GATED_Val _U_(0x0)   /**< \brief (TC_CMR_WAVEFORM) The clock is not gated by an external signal. */
+#define   TC_CMR_WAVEFORM_BURST_CLK_AND_XC0_Val _U_(0x1)   /**< \brief (TC_CMR_WAVEFORM) XC0 is ANDed with the selected clock. */
+#define   TC_CMR_WAVEFORM_BURST_CLK_AND_XC1_Val _U_(0x2)   /**< \brief (TC_CMR_WAVEFORM) XC1 is ANDed with the selected clock. */
+#define   TC_CMR_WAVEFORM_BURST_CLK_AND_XC2_Val _U_(0x3)   /**< \brief (TC_CMR_WAVEFORM) XC2 is ANDed with the selected clock. */
 #define TC_CMR_WAVEFORM_BURST_NOT_GATED (TC_CMR_WAVEFORM_BURST_NOT_GATED_Val << TC_CMR_WAVEFORM_BURST_Pos)
 #define TC_CMR_WAVEFORM_BURST_CLK_AND_XC0 (TC_CMR_WAVEFORM_BURST_CLK_AND_XC0_Val << TC_CMR_WAVEFORM_BURST_Pos)
 #define TC_CMR_WAVEFORM_BURST_CLK_AND_XC1 (TC_CMR_WAVEFORM_BURST_CLK_AND_XC1_Val << TC_CMR_WAVEFORM_BURST_Pos)
 #define TC_CMR_WAVEFORM_BURST_CLK_AND_XC2 (TC_CMR_WAVEFORM_BURST_CLK_AND_XC2_Val << TC_CMR_WAVEFORM_BURST_Pos)
 #define TC_CMR_WAVEFORM_CPCSTOP_Pos 6            /**< \brief (TC_CMR_WAVEFORM) Counter Clock Stopped with RC Compare */
-#define TC_CMR_WAVEFORM_CPCSTOP     (_U(0x1) << TC_CMR_WAVEFORM_CPCSTOP_Pos)
-#define   TC_CMR_WAVEFORM_CPCSTOP_0_Val   _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) Counter clock is not stopped when counter reaches RC. */
-#define   TC_CMR_WAVEFORM_CPCSTOP_1_Val   _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) Counter clock is stopped when counter reaches RC. */
+#define TC_CMR_WAVEFORM_CPCSTOP     (_U_(0x1) << TC_CMR_WAVEFORM_CPCSTOP_Pos)
+#define   TC_CMR_WAVEFORM_CPCSTOP_0_Val   _U_(0x0)   /**< \brief (TC_CMR_WAVEFORM) Counter clock is not stopped when counter reaches RC. */
+#define   TC_CMR_WAVEFORM_CPCSTOP_1_Val   _U_(0x1)   /**< \brief (TC_CMR_WAVEFORM) Counter clock is stopped when counter reaches RC. */
 #define TC_CMR_WAVEFORM_CPCSTOP_0   (TC_CMR_WAVEFORM_CPCSTOP_0_Val << TC_CMR_WAVEFORM_CPCSTOP_Pos)
 #define TC_CMR_WAVEFORM_CPCSTOP_1   (TC_CMR_WAVEFORM_CPCSTOP_1_Val << TC_CMR_WAVEFORM_CPCSTOP_Pos)
 #define TC_CMR_WAVEFORM_CPCDIS_Pos  7            /**< \brief (TC_CMR_WAVEFORM) Counter Clock Disable with RC Compare */
-#define TC_CMR_WAVEFORM_CPCDIS      (_U(0x1) << TC_CMR_WAVEFORM_CPCDIS_Pos)
-#define   TC_CMR_WAVEFORM_CPCDIS_0_Val    _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) Counter clock is not disabled when counter reaches RC. */
-#define   TC_CMR_WAVEFORM_CPCDIS_1_Val    _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) Counter clock is disabled when counter reaches RC. */
+#define TC_CMR_WAVEFORM_CPCDIS      (_U_(0x1) << TC_CMR_WAVEFORM_CPCDIS_Pos)
+#define   TC_CMR_WAVEFORM_CPCDIS_0_Val    _U_(0x0)   /**< \brief (TC_CMR_WAVEFORM) Counter clock is not disabled when counter reaches RC. */
+#define   TC_CMR_WAVEFORM_CPCDIS_1_Val    _U_(0x1)   /**< \brief (TC_CMR_WAVEFORM) Counter clock is disabled when counter reaches RC. */
 #define TC_CMR_WAVEFORM_CPCDIS_0    (TC_CMR_WAVEFORM_CPCDIS_0_Val  << TC_CMR_WAVEFORM_CPCDIS_Pos)
 #define TC_CMR_WAVEFORM_CPCDIS_1    (TC_CMR_WAVEFORM_CPCDIS_1_Val  << TC_CMR_WAVEFORM_CPCDIS_Pos)
 #define TC_CMR_WAVEFORM_EEVTEDG_Pos 8            /**< \brief (TC_CMR_WAVEFORM) External Event Edge Selection */
-#define TC_CMR_WAVEFORM_EEVTEDG_Msk (_U(0x3) << TC_CMR_WAVEFORM_EEVTEDG_Pos)
+#define TC_CMR_WAVEFORM_EEVTEDG_Msk (_U_(0x3) << TC_CMR_WAVEFORM_EEVTEDG_Pos)
 #define TC_CMR_WAVEFORM_EEVTEDG(value) (TC_CMR_WAVEFORM_EEVTEDG_Msk & ((value) << TC_CMR_WAVEFORM_EEVTEDG_Pos))
-#define   TC_CMR_WAVEFORM_EEVTEDG_NO_EDGE_Val _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) none */
-#define   TC_CMR_WAVEFORM_EEVTEDG_POS_EDGE_Val _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) rising edge */
-#define   TC_CMR_WAVEFORM_EEVTEDG_NEG_EDGE_Val _U(0x2)   /**< \brief (TC_CMR_WAVEFORM) falling edge */
-#define   TC_CMR_WAVEFORM_EEVTEDG_BOTH_EDGES_Val _U(0x3)   /**< \brief (TC_CMR_WAVEFORM) each edge */
+#define   TC_CMR_WAVEFORM_EEVTEDG_NO_EDGE_Val _U_(0x0)   /**< \brief (TC_CMR_WAVEFORM) none */
+#define   TC_CMR_WAVEFORM_EEVTEDG_POS_EDGE_Val _U_(0x1)   /**< \brief (TC_CMR_WAVEFORM) rising edge */
+#define   TC_CMR_WAVEFORM_EEVTEDG_NEG_EDGE_Val _U_(0x2)   /**< \brief (TC_CMR_WAVEFORM) falling edge */
+#define   TC_CMR_WAVEFORM_EEVTEDG_BOTH_EDGES_Val _U_(0x3)   /**< \brief (TC_CMR_WAVEFORM) each edge */
 #define TC_CMR_WAVEFORM_EEVTEDG_NO_EDGE (TC_CMR_WAVEFORM_EEVTEDG_NO_EDGE_Val << TC_CMR_WAVEFORM_EEVTEDG_Pos)
 #define TC_CMR_WAVEFORM_EEVTEDG_POS_EDGE (TC_CMR_WAVEFORM_EEVTEDG_POS_EDGE_Val << TC_CMR_WAVEFORM_EEVTEDG_Pos)
 #define TC_CMR_WAVEFORM_EEVTEDG_NEG_EDGE (TC_CMR_WAVEFORM_EEVTEDG_NEG_EDGE_Val << TC_CMR_WAVEFORM_EEVTEDG_Pos)
 #define TC_CMR_WAVEFORM_EEVTEDG_BOTH_EDGES (TC_CMR_WAVEFORM_EEVTEDG_BOTH_EDGES_Val << TC_CMR_WAVEFORM_EEVTEDG_Pos)
 #define TC_CMR_WAVEFORM_EEVT_Pos    10           /**< \brief (TC_CMR_WAVEFORM) External Event Selection */
-#define TC_CMR_WAVEFORM_EEVT_Msk    (_U(0x3) << TC_CMR_WAVEFORM_EEVT_Pos)
+#define TC_CMR_WAVEFORM_EEVT_Msk    (_U_(0x3) << TC_CMR_WAVEFORM_EEVT_Pos)
 #define TC_CMR_WAVEFORM_EEVT(value) (TC_CMR_WAVEFORM_EEVT_Msk & ((value) << TC_CMR_WAVEFORM_EEVT_Pos))
-#define   TC_CMR_WAVEFORM_EEVT_TIOB_INPUT_Val _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) TIOB input. If TIOB is chosen as the external event signal, it is configured as an input and no longer generates waveforms. */
-#define   TC_CMR_WAVEFORM_EEVT_XC0_OUTPUT_Val _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) XC0 output */
-#define   TC_CMR_WAVEFORM_EEVT_XC1_OUTPUT_Val _U(0x2)   /**< \brief (TC_CMR_WAVEFORM) XC1 output */
-#define   TC_CMR_WAVEFORM_EEVT_XC2_OUTPUT_Val _U(0x3)   /**< \brief (TC_CMR_WAVEFORM) XC2 output */
+#define   TC_CMR_WAVEFORM_EEVT_TIOB_INPUT_Val _U_(0x0)   /**< \brief (TC_CMR_WAVEFORM) TIOB input. If TIOB is chosen as the external event signal, it is configured as an input and no longer generates waveforms. */
+#define   TC_CMR_WAVEFORM_EEVT_XC0_OUTPUT_Val _U_(0x1)   /**< \brief (TC_CMR_WAVEFORM) XC0 output */
+#define   TC_CMR_WAVEFORM_EEVT_XC1_OUTPUT_Val _U_(0x2)   /**< \brief (TC_CMR_WAVEFORM) XC1 output */
+#define   TC_CMR_WAVEFORM_EEVT_XC2_OUTPUT_Val _U_(0x3)   /**< \brief (TC_CMR_WAVEFORM) XC2 output */
 #define TC_CMR_WAVEFORM_EEVT_TIOB_INPUT (TC_CMR_WAVEFORM_EEVT_TIOB_INPUT_Val << TC_CMR_WAVEFORM_EEVT_Pos)
 #define TC_CMR_WAVEFORM_EEVT_XC0_OUTPUT (TC_CMR_WAVEFORM_EEVT_XC0_OUTPUT_Val << TC_CMR_WAVEFORM_EEVT_Pos)
 #define TC_CMR_WAVEFORM_EEVT_XC1_OUTPUT (TC_CMR_WAVEFORM_EEVT_XC1_OUTPUT_Val << TC_CMR_WAVEFORM_EEVT_Pos)
 #define TC_CMR_WAVEFORM_EEVT_XC2_OUTPUT (TC_CMR_WAVEFORM_EEVT_XC2_OUTPUT_Val << TC_CMR_WAVEFORM_EEVT_Pos)
 #define TC_CMR_WAVEFORM_ENETRG_Pos  12           /**< \brief (TC_CMR_WAVEFORM) External Event Trigger Enable */
-#define TC_CMR_WAVEFORM_ENETRG      (_U(0x1) << TC_CMR_WAVEFORM_ENETRG_Pos)
-#define   TC_CMR_WAVEFORM_ENETRG_0_Val    _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) The external event has no effect on the counter and its clock. In this case, the selected external event only controls the TIOA output. */
-#define   TC_CMR_WAVEFORM_ENETRG_1_Val    _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) The external event resets the counter and starts the counter clock. */
+#define TC_CMR_WAVEFORM_ENETRG      (_U_(0x1) << TC_CMR_WAVEFORM_ENETRG_Pos)
+#define   TC_CMR_WAVEFORM_ENETRG_0_Val    _U_(0x0)   /**< \brief (TC_CMR_WAVEFORM) The external event has no effect on the counter and its clock. In this case, the selected external event only controls the TIOA output. */
+#define   TC_CMR_WAVEFORM_ENETRG_1_Val    _U_(0x1)   /**< \brief (TC_CMR_WAVEFORM) The external event resets the counter and starts the counter clock. */
 #define TC_CMR_WAVEFORM_ENETRG_0    (TC_CMR_WAVEFORM_ENETRG_0_Val  << TC_CMR_WAVEFORM_ENETRG_Pos)
 #define TC_CMR_WAVEFORM_ENETRG_1    (TC_CMR_WAVEFORM_ENETRG_1_Val  << TC_CMR_WAVEFORM_ENETRG_Pos)
 #define TC_CMR_WAVEFORM_WAVSEL_Pos  13           /**< \brief (TC_CMR_WAVEFORM) Waveform Selection */
-#define TC_CMR_WAVEFORM_WAVSEL_Msk  (_U(0x3) << TC_CMR_WAVEFORM_WAVSEL_Pos)
+#define TC_CMR_WAVEFORM_WAVSEL_Msk  (_U_(0x3) << TC_CMR_WAVEFORM_WAVSEL_Pos)
 #define TC_CMR_WAVEFORM_WAVSEL(value) (TC_CMR_WAVEFORM_WAVSEL_Msk & ((value) << TC_CMR_WAVEFORM_WAVSEL_Pos))
-#define   TC_CMR_WAVEFORM_WAVSEL_UP_NO_AUTO_Val _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) UP mode without automatic trigger on RC Compare */
-#define   TC_CMR_WAVEFORM_WAVSEL_UPDOWN_NO_AUTO_Val _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) UPDOWN mode without automatic trigger on RC Compare */
-#define   TC_CMR_WAVEFORM_WAVSEL_UP_AUTO_Val _U(0x2)   /**< \brief (TC_CMR_WAVEFORM) UP mode with automatic trigger on RC Compare */
-#define   TC_CMR_WAVEFORM_WAVSEL_UPDOWN_AUTO_Val _U(0x3)   /**< \brief (TC_CMR_WAVEFORM) UPDOWN mode with automatic trigger on RC Compare */
+#define   TC_CMR_WAVEFORM_WAVSEL_UP_NO_AUTO_Val _U_(0x0)   /**< \brief (TC_CMR_WAVEFORM) UP mode without automatic trigger on RC Compare */
+#define   TC_CMR_WAVEFORM_WAVSEL_UPDOWN_NO_AUTO_Val _U_(0x1)   /**< \brief (TC_CMR_WAVEFORM) UPDOWN mode without automatic trigger on RC Compare */
+#define   TC_CMR_WAVEFORM_WAVSEL_UP_AUTO_Val _U_(0x2)   /**< \brief (TC_CMR_WAVEFORM) UP mode with automatic trigger on RC Compare */
+#define   TC_CMR_WAVEFORM_WAVSEL_UPDOWN_AUTO_Val _U_(0x3)   /**< \brief (TC_CMR_WAVEFORM) UPDOWN mode with automatic trigger on RC Compare */
 #define TC_CMR_WAVEFORM_WAVSEL_UP_NO_AUTO (TC_CMR_WAVEFORM_WAVSEL_UP_NO_AUTO_Val << TC_CMR_WAVEFORM_WAVSEL_Pos)
 #define TC_CMR_WAVEFORM_WAVSEL_UPDOWN_NO_AUTO (TC_CMR_WAVEFORM_WAVSEL_UPDOWN_NO_AUTO_Val << TC_CMR_WAVEFORM_WAVSEL_Pos)
 #define TC_CMR_WAVEFORM_WAVSEL_UP_AUTO (TC_CMR_WAVEFORM_WAVSEL_UP_AUTO_Val << TC_CMR_WAVEFORM_WAVSEL_Pos)
 #define TC_CMR_WAVEFORM_WAVSEL_UPDOWN_AUTO (TC_CMR_WAVEFORM_WAVSEL_UPDOWN_AUTO_Val << TC_CMR_WAVEFORM_WAVSEL_Pos)
 #define TC_CMR_WAVEFORM_WAVE_Pos    15           /**< \brief (TC_CMR_WAVEFORM) WAVE */
-#define TC_CMR_WAVEFORM_WAVE        (_U(0x1) << TC_CMR_WAVEFORM_WAVE_Pos)
-#define   TC_CMR_WAVEFORM_WAVE_0_Val      _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) Waveform Mode is disabled (Capture Mode is enabled). */
-#define   TC_CMR_WAVEFORM_WAVE_1_Val      _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) Waveform Mode is enabled. */
+#define TC_CMR_WAVEFORM_WAVE        (_U_(0x1) << TC_CMR_WAVEFORM_WAVE_Pos)
+#define   TC_CMR_WAVEFORM_WAVE_0_Val      _U_(0x0)   /**< \brief (TC_CMR_WAVEFORM) Waveform Mode is disabled (Capture Mode is enabled). */
+#define   TC_CMR_WAVEFORM_WAVE_1_Val      _U_(0x1)   /**< \brief (TC_CMR_WAVEFORM) Waveform Mode is enabled. */
 #define TC_CMR_WAVEFORM_WAVE_0      (TC_CMR_WAVEFORM_WAVE_0_Val    << TC_CMR_WAVEFORM_WAVE_Pos)
 #define TC_CMR_WAVEFORM_WAVE_1      (TC_CMR_WAVEFORM_WAVE_1_Val    << TC_CMR_WAVEFORM_WAVE_Pos)
 #define TC_CMR_WAVEFORM_ACPA_Pos    16           /**< \brief (TC_CMR_WAVEFORM) RA Compare Effect on TIOA */
-#define TC_CMR_WAVEFORM_ACPA_Msk    (_U(0x3) << TC_CMR_WAVEFORM_ACPA_Pos)
+#define TC_CMR_WAVEFORM_ACPA_Msk    (_U_(0x3) << TC_CMR_WAVEFORM_ACPA_Pos)
 #define TC_CMR_WAVEFORM_ACPA(value) (TC_CMR_WAVEFORM_ACPA_Msk & ((value) << TC_CMR_WAVEFORM_ACPA_Pos))
-#define   TC_CMR_WAVEFORM_ACPA_NONE_Val   _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) none */
-#define   TC_CMR_WAVEFORM_ACPA_SET_Val    _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) set */
-#define   TC_CMR_WAVEFORM_ACPA_CLEAR_Val  _U(0x2)   /**< \brief (TC_CMR_WAVEFORM) clear */
-#define   TC_CMR_WAVEFORM_ACPA_TOGGLE_Val _U(0x3)   /**< \brief (TC_CMR_WAVEFORM) toggle */
+#define   TC_CMR_WAVEFORM_ACPA_NONE_Val   _U_(0x0)   /**< \brief (TC_CMR_WAVEFORM) none */
+#define   TC_CMR_WAVEFORM_ACPA_SET_Val    _U_(0x1)   /**< \brief (TC_CMR_WAVEFORM) set */
+#define   TC_CMR_WAVEFORM_ACPA_CLEAR_Val  _U_(0x2)   /**< \brief (TC_CMR_WAVEFORM) clear */
+#define   TC_CMR_WAVEFORM_ACPA_TOGGLE_Val _U_(0x3)   /**< \brief (TC_CMR_WAVEFORM) toggle */
 #define TC_CMR_WAVEFORM_ACPA_NONE   (TC_CMR_WAVEFORM_ACPA_NONE_Val << TC_CMR_WAVEFORM_ACPA_Pos)
 #define TC_CMR_WAVEFORM_ACPA_SET    (TC_CMR_WAVEFORM_ACPA_SET_Val  << TC_CMR_WAVEFORM_ACPA_Pos)
 #define TC_CMR_WAVEFORM_ACPA_CLEAR  (TC_CMR_WAVEFORM_ACPA_CLEAR_Val << TC_CMR_WAVEFORM_ACPA_Pos)
 #define TC_CMR_WAVEFORM_ACPA_TOGGLE (TC_CMR_WAVEFORM_ACPA_TOGGLE_Val << TC_CMR_WAVEFORM_ACPA_Pos)
 #define TC_CMR_WAVEFORM_ACPC_Pos    18           /**< \brief (TC_CMR_WAVEFORM) RC Compare Effect on TIOA */
-#define TC_CMR_WAVEFORM_ACPC_Msk    (_U(0x3) << TC_CMR_WAVEFORM_ACPC_Pos)
+#define TC_CMR_WAVEFORM_ACPC_Msk    (_U_(0x3) << TC_CMR_WAVEFORM_ACPC_Pos)
 #define TC_CMR_WAVEFORM_ACPC(value) (TC_CMR_WAVEFORM_ACPC_Msk & ((value) << TC_CMR_WAVEFORM_ACPC_Pos))
-#define   TC_CMR_WAVEFORM_ACPC_NONE_Val   _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) none */
-#define   TC_CMR_WAVEFORM_ACPC_SET_Val    _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) set */
-#define   TC_CMR_WAVEFORM_ACPC_CLEAR_Val  _U(0x2)   /**< \brief (TC_CMR_WAVEFORM) clear */
-#define   TC_CMR_WAVEFORM_ACPC_TOGGLE_Val _U(0x3)   /**< \brief (TC_CMR_WAVEFORM) toggle */
+#define   TC_CMR_WAVEFORM_ACPC_NONE_Val   _U_(0x0)   /**< \brief (TC_CMR_WAVEFORM) none */
+#define   TC_CMR_WAVEFORM_ACPC_SET_Val    _U_(0x1)   /**< \brief (TC_CMR_WAVEFORM) set */
+#define   TC_CMR_WAVEFORM_ACPC_CLEAR_Val  _U_(0x2)   /**< \brief (TC_CMR_WAVEFORM) clear */
+#define   TC_CMR_WAVEFORM_ACPC_TOGGLE_Val _U_(0x3)   /**< \brief (TC_CMR_WAVEFORM) toggle */
 #define TC_CMR_WAVEFORM_ACPC_NONE   (TC_CMR_WAVEFORM_ACPC_NONE_Val << TC_CMR_WAVEFORM_ACPC_Pos)
 #define TC_CMR_WAVEFORM_ACPC_SET    (TC_CMR_WAVEFORM_ACPC_SET_Val  << TC_CMR_WAVEFORM_ACPC_Pos)
 #define TC_CMR_WAVEFORM_ACPC_CLEAR  (TC_CMR_WAVEFORM_ACPC_CLEAR_Val << TC_CMR_WAVEFORM_ACPC_Pos)
 #define TC_CMR_WAVEFORM_ACPC_TOGGLE (TC_CMR_WAVEFORM_ACPC_TOGGLE_Val << TC_CMR_WAVEFORM_ACPC_Pos)
 #define TC_CMR_WAVEFORM_AEEVT_Pos   20           /**< \brief (TC_CMR_WAVEFORM) External Event Effect on TIOA */
-#define TC_CMR_WAVEFORM_AEEVT_Msk   (_U(0x3) << TC_CMR_WAVEFORM_AEEVT_Pos)
+#define TC_CMR_WAVEFORM_AEEVT_Msk   (_U_(0x3) << TC_CMR_WAVEFORM_AEEVT_Pos)
 #define TC_CMR_WAVEFORM_AEEVT(value) (TC_CMR_WAVEFORM_AEEVT_Msk & ((value) << TC_CMR_WAVEFORM_AEEVT_Pos))
-#define   TC_CMR_WAVEFORM_AEEVT_NONE_Val  _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) none */
-#define   TC_CMR_WAVEFORM_AEEVT_SET_Val   _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) set */
-#define   TC_CMR_WAVEFORM_AEEVT_CLEAR_Val _U(0x2)   /**< \brief (TC_CMR_WAVEFORM) clear */
-#define   TC_CMR_WAVEFORM_AEEVT_TOGGLE_Val _U(0x3)   /**< \brief (TC_CMR_WAVEFORM) toggle */
+#define   TC_CMR_WAVEFORM_AEEVT_NONE_Val  _U_(0x0)   /**< \brief (TC_CMR_WAVEFORM) none */
+#define   TC_CMR_WAVEFORM_AEEVT_SET_Val   _U_(0x1)   /**< \brief (TC_CMR_WAVEFORM) set */
+#define   TC_CMR_WAVEFORM_AEEVT_CLEAR_Val _U_(0x2)   /**< \brief (TC_CMR_WAVEFORM) clear */
+#define   TC_CMR_WAVEFORM_AEEVT_TOGGLE_Val _U_(0x3)   /**< \brief (TC_CMR_WAVEFORM) toggle */
 #define TC_CMR_WAVEFORM_AEEVT_NONE  (TC_CMR_WAVEFORM_AEEVT_NONE_Val << TC_CMR_WAVEFORM_AEEVT_Pos)
 #define TC_CMR_WAVEFORM_AEEVT_SET   (TC_CMR_WAVEFORM_AEEVT_SET_Val << TC_CMR_WAVEFORM_AEEVT_Pos)
 #define TC_CMR_WAVEFORM_AEEVT_CLEAR (TC_CMR_WAVEFORM_AEEVT_CLEAR_Val << TC_CMR_WAVEFORM_AEEVT_Pos)
 #define TC_CMR_WAVEFORM_AEEVT_TOGGLE (TC_CMR_WAVEFORM_AEEVT_TOGGLE_Val << TC_CMR_WAVEFORM_AEEVT_Pos)
 #define TC_CMR_WAVEFORM_ASWTRG_Pos  22           /**< \brief (TC_CMR_WAVEFORM) Software Trigger Effect on TIOA */
-#define TC_CMR_WAVEFORM_ASWTRG_Msk  (_U(0x3) << TC_CMR_WAVEFORM_ASWTRG_Pos)
+#define TC_CMR_WAVEFORM_ASWTRG_Msk  (_U_(0x3) << TC_CMR_WAVEFORM_ASWTRG_Pos)
 #define TC_CMR_WAVEFORM_ASWTRG(value) (TC_CMR_WAVEFORM_ASWTRG_Msk & ((value) << TC_CMR_WAVEFORM_ASWTRG_Pos))
-#define   TC_CMR_WAVEFORM_ASWTRG_NONE_Val _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) none */
-#define   TC_CMR_WAVEFORM_ASWTRG_SET_Val  _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) set */
-#define   TC_CMR_WAVEFORM_ASWTRG_CLEAR_Val _U(0x2)   /**< \brief (TC_CMR_WAVEFORM) clear */
-#define   TC_CMR_WAVEFORM_ASWTRG_TOGGLE_Val _U(0x3)   /**< \brief (TC_CMR_WAVEFORM) toggle */
+#define   TC_CMR_WAVEFORM_ASWTRG_NONE_Val _U_(0x0)   /**< \brief (TC_CMR_WAVEFORM) none */
+#define   TC_CMR_WAVEFORM_ASWTRG_SET_Val  _U_(0x1)   /**< \brief (TC_CMR_WAVEFORM) set */
+#define   TC_CMR_WAVEFORM_ASWTRG_CLEAR_Val _U_(0x2)   /**< \brief (TC_CMR_WAVEFORM) clear */
+#define   TC_CMR_WAVEFORM_ASWTRG_TOGGLE_Val _U_(0x3)   /**< \brief (TC_CMR_WAVEFORM) toggle */
 #define TC_CMR_WAVEFORM_ASWTRG_NONE (TC_CMR_WAVEFORM_ASWTRG_NONE_Val << TC_CMR_WAVEFORM_ASWTRG_Pos)
 #define TC_CMR_WAVEFORM_ASWTRG_SET  (TC_CMR_WAVEFORM_ASWTRG_SET_Val << TC_CMR_WAVEFORM_ASWTRG_Pos)
 #define TC_CMR_WAVEFORM_ASWTRG_CLEAR (TC_CMR_WAVEFORM_ASWTRG_CLEAR_Val << TC_CMR_WAVEFORM_ASWTRG_Pos)
 #define TC_CMR_WAVEFORM_ASWTRG_TOGGLE (TC_CMR_WAVEFORM_ASWTRG_TOGGLE_Val << TC_CMR_WAVEFORM_ASWTRG_Pos)
 #define TC_CMR_WAVEFORM_BCPB_Pos    24           /**< \brief (TC_CMR_WAVEFORM) RB Compare Effect on TIOB */
-#define TC_CMR_WAVEFORM_BCPB_Msk    (_U(0x3) << TC_CMR_WAVEFORM_BCPB_Pos)
+#define TC_CMR_WAVEFORM_BCPB_Msk    (_U_(0x3) << TC_CMR_WAVEFORM_BCPB_Pos)
 #define TC_CMR_WAVEFORM_BCPB(value) (TC_CMR_WAVEFORM_BCPB_Msk & ((value) << TC_CMR_WAVEFORM_BCPB_Pos))
-#define   TC_CMR_WAVEFORM_BCPB_NONE_Val   _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) none */
-#define   TC_CMR_WAVEFORM_BCPB_SET_Val    _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) set */
-#define   TC_CMR_WAVEFORM_BCPB_CLEAR_Val  _U(0x2)   /**< \brief (TC_CMR_WAVEFORM) clear */
-#define   TC_CMR_WAVEFORM_BCPB_TOGGLE_Val _U(0x3)   /**< \brief (TC_CMR_WAVEFORM) toggle */
+#define   TC_CMR_WAVEFORM_BCPB_NONE_Val   _U_(0x0)   /**< \brief (TC_CMR_WAVEFORM) none */
+#define   TC_CMR_WAVEFORM_BCPB_SET_Val    _U_(0x1)   /**< \brief (TC_CMR_WAVEFORM) set */
+#define   TC_CMR_WAVEFORM_BCPB_CLEAR_Val  _U_(0x2)   /**< \brief (TC_CMR_WAVEFORM) clear */
+#define   TC_CMR_WAVEFORM_BCPB_TOGGLE_Val _U_(0x3)   /**< \brief (TC_CMR_WAVEFORM) toggle */
 #define TC_CMR_WAVEFORM_BCPB_NONE   (TC_CMR_WAVEFORM_BCPB_NONE_Val << TC_CMR_WAVEFORM_BCPB_Pos)
 #define TC_CMR_WAVEFORM_BCPB_SET    (TC_CMR_WAVEFORM_BCPB_SET_Val  << TC_CMR_WAVEFORM_BCPB_Pos)
 #define TC_CMR_WAVEFORM_BCPB_CLEAR  (TC_CMR_WAVEFORM_BCPB_CLEAR_Val << TC_CMR_WAVEFORM_BCPB_Pos)
 #define TC_CMR_WAVEFORM_BCPB_TOGGLE (TC_CMR_WAVEFORM_BCPB_TOGGLE_Val << TC_CMR_WAVEFORM_BCPB_Pos)
 #define TC_CMR_WAVEFORM_BCPC_Pos    26           /**< \brief (TC_CMR_WAVEFORM) RC Compare Effect on TIOB */
-#define TC_CMR_WAVEFORM_BCPC_Msk    (_U(0x3) << TC_CMR_WAVEFORM_BCPC_Pos)
+#define TC_CMR_WAVEFORM_BCPC_Msk    (_U_(0x3) << TC_CMR_WAVEFORM_BCPC_Pos)
 #define TC_CMR_WAVEFORM_BCPC(value) (TC_CMR_WAVEFORM_BCPC_Msk & ((value) << TC_CMR_WAVEFORM_BCPC_Pos))
-#define   TC_CMR_WAVEFORM_BCPC_NONE_Val   _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) none */
-#define   TC_CMR_WAVEFORM_BCPC_SET_Val    _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) set */
-#define   TC_CMR_WAVEFORM_BCPC_CLEAR_Val  _U(0x2)   /**< \brief (TC_CMR_WAVEFORM) clear */
-#define   TC_CMR_WAVEFORM_BCPC_TOGGLE_Val _U(0x3)   /**< \brief (TC_CMR_WAVEFORM) toggle */
+#define   TC_CMR_WAVEFORM_BCPC_NONE_Val   _U_(0x0)   /**< \brief (TC_CMR_WAVEFORM) none */
+#define   TC_CMR_WAVEFORM_BCPC_SET_Val    _U_(0x1)   /**< \brief (TC_CMR_WAVEFORM) set */
+#define   TC_CMR_WAVEFORM_BCPC_CLEAR_Val  _U_(0x2)   /**< \brief (TC_CMR_WAVEFORM) clear */
+#define   TC_CMR_WAVEFORM_BCPC_TOGGLE_Val _U_(0x3)   /**< \brief (TC_CMR_WAVEFORM) toggle */
 #define TC_CMR_WAVEFORM_BCPC_NONE   (TC_CMR_WAVEFORM_BCPC_NONE_Val << TC_CMR_WAVEFORM_BCPC_Pos)
 #define TC_CMR_WAVEFORM_BCPC_SET    (TC_CMR_WAVEFORM_BCPC_SET_Val  << TC_CMR_WAVEFORM_BCPC_Pos)
 #define TC_CMR_WAVEFORM_BCPC_CLEAR  (TC_CMR_WAVEFORM_BCPC_CLEAR_Val << TC_CMR_WAVEFORM_BCPC_Pos)
 #define TC_CMR_WAVEFORM_BCPC_TOGGLE (TC_CMR_WAVEFORM_BCPC_TOGGLE_Val << TC_CMR_WAVEFORM_BCPC_Pos)
 #define TC_CMR_WAVEFORM_BEEVT_Pos   28           /**< \brief (TC_CMR_WAVEFORM) External Event Effect on TIOB */
-#define TC_CMR_WAVEFORM_BEEVT_Msk   (_U(0x3) << TC_CMR_WAVEFORM_BEEVT_Pos)
+#define TC_CMR_WAVEFORM_BEEVT_Msk   (_U_(0x3) << TC_CMR_WAVEFORM_BEEVT_Pos)
 #define TC_CMR_WAVEFORM_BEEVT(value) (TC_CMR_WAVEFORM_BEEVT_Msk & ((value) << TC_CMR_WAVEFORM_BEEVT_Pos))
-#define   TC_CMR_WAVEFORM_BEEVT_NONE_Val  _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) none */
-#define   TC_CMR_WAVEFORM_BEEVT_SET_Val   _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) set */
-#define   TC_CMR_WAVEFORM_BEEVT_CLEAR_Val _U(0x2)   /**< \brief (TC_CMR_WAVEFORM) clear */
-#define   TC_CMR_WAVEFORM_BEEVT_TOGGLE_Val _U(0x3)   /**< \brief (TC_CMR_WAVEFORM) toggle */
+#define   TC_CMR_WAVEFORM_BEEVT_NONE_Val  _U_(0x0)   /**< \brief (TC_CMR_WAVEFORM) none */
+#define   TC_CMR_WAVEFORM_BEEVT_SET_Val   _U_(0x1)   /**< \brief (TC_CMR_WAVEFORM) set */
+#define   TC_CMR_WAVEFORM_BEEVT_CLEAR_Val _U_(0x2)   /**< \brief (TC_CMR_WAVEFORM) clear */
+#define   TC_CMR_WAVEFORM_BEEVT_TOGGLE_Val _U_(0x3)   /**< \brief (TC_CMR_WAVEFORM) toggle */
 #define TC_CMR_WAVEFORM_BEEVT_NONE  (TC_CMR_WAVEFORM_BEEVT_NONE_Val << TC_CMR_WAVEFORM_BEEVT_Pos)
 #define TC_CMR_WAVEFORM_BEEVT_SET   (TC_CMR_WAVEFORM_BEEVT_SET_Val << TC_CMR_WAVEFORM_BEEVT_Pos)
 #define TC_CMR_WAVEFORM_BEEVT_CLEAR (TC_CMR_WAVEFORM_BEEVT_CLEAR_Val << TC_CMR_WAVEFORM_BEEVT_Pos)
 #define TC_CMR_WAVEFORM_BEEVT_TOGGLE (TC_CMR_WAVEFORM_BEEVT_TOGGLE_Val << TC_CMR_WAVEFORM_BEEVT_Pos)
 #define TC_CMR_WAVEFORM_BSWTRG_Pos  30           /**< \brief (TC_CMR_WAVEFORM) Software Trigger Effect on TIOB */
-#define TC_CMR_WAVEFORM_BSWTRG_Msk  (_U(0x3) << TC_CMR_WAVEFORM_BSWTRG_Pos)
+#define TC_CMR_WAVEFORM_BSWTRG_Msk  (_U_(0x3) << TC_CMR_WAVEFORM_BSWTRG_Pos)
 #define TC_CMR_WAVEFORM_BSWTRG(value) (TC_CMR_WAVEFORM_BSWTRG_Msk & ((value) << TC_CMR_WAVEFORM_BSWTRG_Pos))
-#define   TC_CMR_WAVEFORM_BSWTRG_NONE_Val _U(0x0)   /**< \brief (TC_CMR_WAVEFORM) none */
-#define   TC_CMR_WAVEFORM_BSWTRG_SET_Val  _U(0x1)   /**< \brief (TC_CMR_WAVEFORM) set */
-#define   TC_CMR_WAVEFORM_BSWTRG_CLEAR_Val _U(0x2)   /**< \brief (TC_CMR_WAVEFORM) clear */
-#define   TC_CMR_WAVEFORM_BSWTRG_TOGGLE_Val _U(0x3)   /**< \brief (TC_CMR_WAVEFORM) toggle */
+#define   TC_CMR_WAVEFORM_BSWTRG_NONE_Val _U_(0x0)   /**< \brief (TC_CMR_WAVEFORM) none */
+#define   TC_CMR_WAVEFORM_BSWTRG_SET_Val  _U_(0x1)   /**< \brief (TC_CMR_WAVEFORM) set */
+#define   TC_CMR_WAVEFORM_BSWTRG_CLEAR_Val _U_(0x2)   /**< \brief (TC_CMR_WAVEFORM) clear */
+#define   TC_CMR_WAVEFORM_BSWTRG_TOGGLE_Val _U_(0x3)   /**< \brief (TC_CMR_WAVEFORM) toggle */
 #define TC_CMR_WAVEFORM_BSWTRG_NONE (TC_CMR_WAVEFORM_BSWTRG_NONE_Val << TC_CMR_WAVEFORM_BSWTRG_Pos)
 #define TC_CMR_WAVEFORM_BSWTRG_SET  (TC_CMR_WAVEFORM_BSWTRG_SET_Val << TC_CMR_WAVEFORM_BSWTRG_Pos)
 #define TC_CMR_WAVEFORM_BSWTRG_CLEAR (TC_CMR_WAVEFORM_BSWTRG_CLEAR_Val << TC_CMR_WAVEFORM_BSWTRG_Pos)
 #define TC_CMR_WAVEFORM_BSWTRG_TOGGLE (TC_CMR_WAVEFORM_BSWTRG_TOGGLE_Val << TC_CMR_WAVEFORM_BSWTRG_Pos)
-#define TC_CMR_WAVEFORM_MASK        _U(0xFFFFFFFF) /**< \brief (TC_CMR_WAVEFORM) MASK Register */
+#define TC_CMR_WAVEFORM_MASK        _U_(0xFFFFFFFF) /**< \brief (TC_CMR_WAVEFORM) MASK Register */
 
 // Any mode
 #define TC_CMR_TCCLKS_Pos           0            /**< \brief (TC_CMR) Clock Selection */
-#define TC_CMR_TCCLKS_Msk           (_U(0x7) << TC_CMR_TCCLKS_Pos)
+#define TC_CMR_TCCLKS_Msk           (_U_(0x7) << TC_CMR_TCCLKS_Pos)
 #define TC_CMR_TCCLKS(value)        (TC_CMR_TCCLKS_Msk & ((value) << TC_CMR_TCCLKS_Pos))
-#define   TC_CMR_TCCLKS_TIMER_CLOCK1_Val  _U(0x0)   /**< \brief (TC_CMR) TIMER_CLOCK1 */
-#define   TC_CMR_TCCLKS_TIMER_CLOCK2_Val  _U(0x1)   /**< \brief (TC_CMR) TIMER_CLOCK2 */
-#define   TC_CMR_TCCLKS_TIMER_CLOCK3_Val  _U(0x2)   /**< \brief (TC_CMR) TIMER_CLOCK3 */
-#define   TC_CMR_TCCLKS_TIMER_CLOCK4_Val  _U(0x3)   /**< \brief (TC_CMR) TIMER_CLOCK4 */
-#define   TC_CMR_TCCLKS_TIMER_CLOCK5_Val  _U(0x4)   /**< \brief (TC_CMR) TIMER_CLOCK5 */
-#define   TC_CMR_TCCLKS_XC0_Val           _U(0x5)   /**< \brief (TC_CMR) XC0 */
-#define   TC_CMR_TCCLKS_XC1_Val           _U(0x6)   /**< \brief (TC_CMR) XC1 */
-#define   TC_CMR_TCCLKS_XC2_Val           _U(0x7)   /**< \brief (TC_CMR) XC2 */
+#define   TC_CMR_TCCLKS_TIMER_CLOCK1_Val  _U_(0x0)   /**< \brief (TC_CMR) TIMER_CLOCK1 */
+#define   TC_CMR_TCCLKS_TIMER_CLOCK2_Val  _U_(0x1)   /**< \brief (TC_CMR) TIMER_CLOCK2 */
+#define   TC_CMR_TCCLKS_TIMER_CLOCK3_Val  _U_(0x2)   /**< \brief (TC_CMR) TIMER_CLOCK3 */
+#define   TC_CMR_TCCLKS_TIMER_CLOCK4_Val  _U_(0x3)   /**< \brief (TC_CMR) TIMER_CLOCK4 */
+#define   TC_CMR_TCCLKS_TIMER_CLOCK5_Val  _U_(0x4)   /**< \brief (TC_CMR) TIMER_CLOCK5 */
+#define   TC_CMR_TCCLKS_XC0_Val           _U_(0x5)   /**< \brief (TC_CMR) XC0 */
+#define   TC_CMR_TCCLKS_XC1_Val           _U_(0x6)   /**< \brief (TC_CMR) XC1 */
+#define   TC_CMR_TCCLKS_XC2_Val           _U_(0x7)   /**< \brief (TC_CMR) XC2 */
 #define TC_CMR_TCCLKS_TIMER_CLOCK1  (TC_CMR_TCCLKS_TIMER_CLOCK1_Val << TC_CMR_TCCLKS_Pos)
 #define TC_CMR_TCCLKS_TIMER_CLOCK2  (TC_CMR_TCCLKS_TIMER_CLOCK2_Val << TC_CMR_TCCLKS_Pos)
 #define TC_CMR_TCCLKS_TIMER_CLOCK3  (TC_CMR_TCCLKS_TIMER_CLOCK3_Val << TC_CMR_TCCLKS_Pos)
@@ -426,225 +426,225 @@ typedef union {
 #define TC_CMR_TCCLKS_XC1           (TC_CMR_TCCLKS_XC1_Val         << TC_CMR_TCCLKS_Pos)
 #define TC_CMR_TCCLKS_XC2           (TC_CMR_TCCLKS_XC2_Val         << TC_CMR_TCCLKS_Pos)
 #define TC_CMR_CLKI_Pos             3            /**< \brief (TC_CMR) Clock Invert */
-#define TC_CMR_CLKI                 (_U(0x1) << TC_CMR_CLKI_Pos)
-#define   TC_CMR_CLKI_0_Val               _U(0x0)   /**< \brief (TC_CMR) Counter is incremented on rising edge of the clock. */
-#define   TC_CMR_CLKI_1_Val               _U(0x1)   /**< \brief (TC_CMR) Counter is incremented on falling edge of the clock. */
+#define TC_CMR_CLKI                 (_U_(0x1) << TC_CMR_CLKI_Pos)
+#define   TC_CMR_CLKI_0_Val               _U_(0x0)   /**< \brief (TC_CMR) Counter is incremented on rising edge of the clock. */
+#define   TC_CMR_CLKI_1_Val               _U_(0x1)   /**< \brief (TC_CMR) Counter is incremented on falling edge of the clock. */
 #define TC_CMR_CLKI_0               (TC_CMR_CLKI_0_Val             << TC_CMR_CLKI_Pos)
 #define TC_CMR_CLKI_1               (TC_CMR_CLKI_1_Val             << TC_CMR_CLKI_Pos)
 #define TC_CMR_BURST_Pos            4            /**< \brief (TC_CMR) Burst Signal Selection */
-#define TC_CMR_BURST_Msk            (_U(0x3) << TC_CMR_BURST_Pos)
+#define TC_CMR_BURST_Msk            (_U_(0x3) << TC_CMR_BURST_Pos)
 #define TC_CMR_BURST(value)         (TC_CMR_BURST_Msk & ((value) << TC_CMR_BURST_Pos))
-#define   TC_CMR_BURST_NOT_GATED_Val      _U(0x0)   /**< \brief (TC_CMR) The clock is not gated by an external signal. */
-#define   TC_CMR_BURST_CLK_AND_XC0_Val    _U(0x1)   /**< \brief (TC_CMR) XC0 is ANDed with the selected clock. */
-#define   TC_CMR_BURST_CLK_AND_XC1_Val    _U(0x2)   /**< \brief (TC_CMR) XC1 is ANDed with the selected clock. */
-#define   TC_CMR_BURST_CLK_AND_XC2_Val    _U(0x3)   /**< \brief (TC_CMR) XC2 is ANDed with the selected clock. */
+#define   TC_CMR_BURST_NOT_GATED_Val      _U_(0x0)   /**< \brief (TC_CMR) The clock is not gated by an external signal. */
+#define   TC_CMR_BURST_CLK_AND_XC0_Val    _U_(0x1)   /**< \brief (TC_CMR) XC0 is ANDed with the selected clock. */
+#define   TC_CMR_BURST_CLK_AND_XC1_Val    _U_(0x2)   /**< \brief (TC_CMR) XC1 is ANDed with the selected clock. */
+#define   TC_CMR_BURST_CLK_AND_XC2_Val    _U_(0x3)   /**< \brief (TC_CMR) XC2 is ANDed with the selected clock. */
 #define TC_CMR_BURST_NOT_GATED      (TC_CMR_BURST_NOT_GATED_Val    << TC_CMR_BURST_Pos)
 #define TC_CMR_BURST_CLK_AND_XC0    (TC_CMR_BURST_CLK_AND_XC0_Val  << TC_CMR_BURST_Pos)
 #define TC_CMR_BURST_CLK_AND_XC1    (TC_CMR_BURST_CLK_AND_XC1_Val  << TC_CMR_BURST_Pos)
 #define TC_CMR_BURST_CLK_AND_XC2    (TC_CMR_BURST_CLK_AND_XC2_Val  << TC_CMR_BURST_Pos)
 #define TC_CMR_LDBSTOP_Pos          6            /**< \brief (TC_CMR) Counter Clock Stopped with RB Loading */
-#define TC_CMR_LDBSTOP              (_U(0x1) << TC_CMR_LDBSTOP_Pos)
-#define   TC_CMR_LDBSTOP_0_Val            _U(0x0)   /**< \brief (TC_CMR) Counter clock is not stopped when RB loading occurs. */
-#define   TC_CMR_LDBSTOP_1_Val            _U(0x1)   /**< \brief (TC_CMR) Counter clock is stopped when RB loading occurs. */
+#define TC_CMR_LDBSTOP              (_U_(0x1) << TC_CMR_LDBSTOP_Pos)
+#define   TC_CMR_LDBSTOP_0_Val            _U_(0x0)   /**< \brief (TC_CMR) Counter clock is not stopped when RB loading occurs. */
+#define   TC_CMR_LDBSTOP_1_Val            _U_(0x1)   /**< \brief (TC_CMR) Counter clock is stopped when RB loading occurs. */
 #define TC_CMR_LDBSTOP_0            (TC_CMR_LDBSTOP_0_Val          << TC_CMR_LDBSTOP_Pos)
 #define TC_CMR_LDBSTOP_1            (TC_CMR_LDBSTOP_1_Val          << TC_CMR_LDBSTOP_Pos)
 #define TC_CMR_CPCSTOP_Pos          6            /**< \brief (TC_CMR) Counter Clock Stopped with RC Compare */
-#define TC_CMR_CPCSTOP              (_U(0x1) << TC_CMR_CPCSTOP_Pos)
-#define   TC_CMR_CPCSTOP_0_Val            _U(0x0)   /**< \brief (TC_CMR) Counter clock is not stopped when counter reaches RC. */
-#define   TC_CMR_CPCSTOP_1_Val            _U(0x1)   /**< \brief (TC_CMR) Counter clock is stopped when counter reaches RC. */
+#define TC_CMR_CPCSTOP              (_U_(0x1) << TC_CMR_CPCSTOP_Pos)
+#define   TC_CMR_CPCSTOP_0_Val            _U_(0x0)   /**< \brief (TC_CMR) Counter clock is not stopped when counter reaches RC. */
+#define   TC_CMR_CPCSTOP_1_Val            _U_(0x1)   /**< \brief (TC_CMR) Counter clock is stopped when counter reaches RC. */
 #define TC_CMR_CPCSTOP_0            (TC_CMR_CPCSTOP_0_Val          << TC_CMR_CPCSTOP_Pos)
 #define TC_CMR_CPCSTOP_1            (TC_CMR_CPCSTOP_1_Val          << TC_CMR_CPCSTOP_Pos)
 #define TC_CMR_LDBDIS_Pos           7            /**< \brief (TC_CMR) Counter Clock Disable with RB Loading */
-#define TC_CMR_LDBDIS               (_U(0x1) << TC_CMR_LDBDIS_Pos)
-#define   TC_CMR_LDBDIS_0_Val             _U(0x0)   /**< \brief (TC_CMR) Counter clock is not disabled when RB loading occurs. */
-#define   TC_CMR_LDBDIS_1_Val             _U(0x1)   /**< \brief (TC_CMR) Counter clock is disabled when RB loading occurs. */
+#define TC_CMR_LDBDIS               (_U_(0x1) << TC_CMR_LDBDIS_Pos)
+#define   TC_CMR_LDBDIS_0_Val             _U_(0x0)   /**< \brief (TC_CMR) Counter clock is not disabled when RB loading occurs. */
+#define   TC_CMR_LDBDIS_1_Val             _U_(0x1)   /**< \brief (TC_CMR) Counter clock is disabled when RB loading occurs. */
 #define TC_CMR_LDBDIS_0             (TC_CMR_LDBDIS_0_Val           << TC_CMR_LDBDIS_Pos)
 #define TC_CMR_LDBDIS_1             (TC_CMR_LDBDIS_1_Val           << TC_CMR_LDBDIS_Pos)
 #define TC_CMR_CPCDIS_Pos           7            /**< \brief (TC_CMR) Counter Clock Disable with RC Compare */
-#define TC_CMR_CPCDIS               (_U(0x1) << TC_CMR_CPCDIS_Pos)
-#define   TC_CMR_CPCDIS_0_Val             _U(0x0)   /**< \brief (TC_CMR) Counter clock is not disabled when counter reaches RC. */
-#define   TC_CMR_CPCDIS_1_Val             _U(0x1)   /**< \brief (TC_CMR) Counter clock is disabled when counter reaches RC. */
+#define TC_CMR_CPCDIS               (_U_(0x1) << TC_CMR_CPCDIS_Pos)
+#define   TC_CMR_CPCDIS_0_Val             _U_(0x0)   /**< \brief (TC_CMR) Counter clock is not disabled when counter reaches RC. */
+#define   TC_CMR_CPCDIS_1_Val             _U_(0x1)   /**< \brief (TC_CMR) Counter clock is disabled when counter reaches RC. */
 #define TC_CMR_CPCDIS_0             (TC_CMR_CPCDIS_0_Val           << TC_CMR_CPCDIS_Pos)
 #define TC_CMR_CPCDIS_1             (TC_CMR_CPCDIS_1_Val           << TC_CMR_CPCDIS_Pos)
 #define TC_CMR_ETRGEDG_Pos          8            /**< \brief (TC_CMR) External Trigger Edge Selection */
-#define TC_CMR_ETRGEDG_Msk          (_U(0x3) << TC_CMR_ETRGEDG_Pos)
+#define TC_CMR_ETRGEDG_Msk          (_U_(0x3) << TC_CMR_ETRGEDG_Pos)
 #define TC_CMR_ETRGEDG(value)       (TC_CMR_ETRGEDG_Msk & ((value) << TC_CMR_ETRGEDG_Pos))
-#define   TC_CMR_ETRGEDG_NO_EDGE_Val      _U(0x0)   /**< \brief (TC_CMR) none */
-#define   TC_CMR_ETRGEDG_POS_EDGE_Val     _U(0x1)   /**< \brief (TC_CMR) rising edge */
-#define   TC_CMR_ETRGEDG_NEG_EDGE_Val     _U(0x2)   /**< \brief (TC_CMR) falling edge */
-#define   TC_CMR_ETRGEDG_BOTH_EDGES_Val   _U(0x3)   /**< \brief (TC_CMR) each edge */
+#define   TC_CMR_ETRGEDG_NO_EDGE_Val      _U_(0x0)   /**< \brief (TC_CMR) none */
+#define   TC_CMR_ETRGEDG_POS_EDGE_Val     _U_(0x1)   /**< \brief (TC_CMR) rising edge */
+#define   TC_CMR_ETRGEDG_NEG_EDGE_Val     _U_(0x2)   /**< \brief (TC_CMR) falling edge */
+#define   TC_CMR_ETRGEDG_BOTH_EDGES_Val   _U_(0x3)   /**< \brief (TC_CMR) each edge */
 #define TC_CMR_ETRGEDG_NO_EDGE      (TC_CMR_ETRGEDG_NO_EDGE_Val    << TC_CMR_ETRGEDG_Pos)
 #define TC_CMR_ETRGEDG_POS_EDGE     (TC_CMR_ETRGEDG_POS_EDGE_Val   << TC_CMR_ETRGEDG_Pos)
 #define TC_CMR_ETRGEDG_NEG_EDGE     (TC_CMR_ETRGEDG_NEG_EDGE_Val   << TC_CMR_ETRGEDG_Pos)
 #define TC_CMR_ETRGEDG_BOTH_EDGES   (TC_CMR_ETRGEDG_BOTH_EDGES_Val << TC_CMR_ETRGEDG_Pos)
 #define TC_CMR_EEVTEDG_Pos          8            /**< \brief (TC_CMR) External Event Edge Selection */
-#define TC_CMR_EEVTEDG_Msk          (_U(0x3) << TC_CMR_EEVTEDG_Pos)
+#define TC_CMR_EEVTEDG_Msk          (_U_(0x3) << TC_CMR_EEVTEDG_Pos)
 #define TC_CMR_EEVTEDG(value)       (TC_CMR_EEVTEDG_Msk & ((value) << TC_CMR_EEVTEDG_Pos))
-#define   TC_CMR_EEVTEDG_NO_EDGE_Val      _U(0x0)   /**< \brief (TC_CMR) none */
-#define   TC_CMR_EEVTEDG_POS_EDGE_Val     _U(0x1)   /**< \brief (TC_CMR) rising edge */
-#define   TC_CMR_EEVTEDG_NEG_EDGE_Val     _U(0x2)   /**< \brief (TC_CMR) falling edge */
-#define   TC_CMR_EEVTEDG_BOTH_EDGES_Val   _U(0x3)   /**< \brief (TC_CMR) each edge */
+#define   TC_CMR_EEVTEDG_NO_EDGE_Val      _U_(0x0)   /**< \brief (TC_CMR) none */
+#define   TC_CMR_EEVTEDG_POS_EDGE_Val     _U_(0x1)   /**< \brief (TC_CMR) rising edge */
+#define   TC_CMR_EEVTEDG_NEG_EDGE_Val     _U_(0x2)   /**< \brief (TC_CMR) falling edge */
+#define   TC_CMR_EEVTEDG_BOTH_EDGES_Val   _U_(0x3)   /**< \brief (TC_CMR) each edge */
 #define TC_CMR_EEVTEDG_NO_EDGE      (TC_CMR_EEVTEDG_NO_EDGE_Val    << TC_CMR_EEVTEDG_Pos)
 #define TC_CMR_EEVTEDG_POS_EDGE     (TC_CMR_EEVTEDG_POS_EDGE_Val   << TC_CMR_EEVTEDG_Pos)
 #define TC_CMR_EEVTEDG_NEG_EDGE     (TC_CMR_EEVTEDG_NEG_EDGE_Val   << TC_CMR_EEVTEDG_Pos)
 #define TC_CMR_EEVTEDG_BOTH_EDGES   (TC_CMR_EEVTEDG_BOTH_EDGES_Val << TC_CMR_EEVTEDG_Pos)
 #define TC_CMR_ABETRG_Pos           10           /**< \brief (TC_CMR) TIOA or TIOB External Trigger Selection */
-#define TC_CMR_ABETRG               (_U(0x1) << TC_CMR_ABETRG_Pos)
-#define   TC_CMR_ABETRG_0_Val             _U(0x0)   /**< \brief (TC_CMR) TIOB is used as an external trigger. */
-#define   TC_CMR_ABETRG_1_Val             _U(0x1)   /**< \brief (TC_CMR) TIOA is used as an external trigger. */
+#define TC_CMR_ABETRG               (_U_(0x1) << TC_CMR_ABETRG_Pos)
+#define   TC_CMR_ABETRG_0_Val             _U_(0x0)   /**< \brief (TC_CMR) TIOB is used as an external trigger. */
+#define   TC_CMR_ABETRG_1_Val             _U_(0x1)   /**< \brief (TC_CMR) TIOA is used as an external trigger. */
 #define TC_CMR_ABETRG_0             (TC_CMR_ABETRG_0_Val           << TC_CMR_ABETRG_Pos)
 #define TC_CMR_ABETRG_1             (TC_CMR_ABETRG_1_Val           << TC_CMR_ABETRG_Pos)
 #define TC_CMR_EEVT_Pos             10           /**< \brief (TC_CMR) External Event Selection */
-#define TC_CMR_EEVT_Msk             (_U(0x3) << TC_CMR_EEVT_Pos)
+#define TC_CMR_EEVT_Msk             (_U_(0x3) << TC_CMR_EEVT_Pos)
 #define TC_CMR_EEVT(value)          (TC_CMR_EEVT_Msk & ((value) << TC_CMR_EEVT_Pos))
-#define   TC_CMR_EEVT_TIOB_INPUT_Val      _U(0x0)   /**< \brief (TC_CMR) TIOB input. If TIOB is chosen as the external event signal, it is configured as an input and no longer generates waveforms. */
-#define   TC_CMR_EEVT_XC0_OUTPUT_Val      _U(0x1)   /**< \brief (TC_CMR) XC0 output */
-#define   TC_CMR_EEVT_XC1_OUTPUT_Val      _U(0x2)   /**< \brief (TC_CMR) XC1 output */
-#define   TC_CMR_EEVT_XC2_OUTPUT_Val      _U(0x3)   /**< \brief (TC_CMR) XC2 output */
+#define   TC_CMR_EEVT_TIOB_INPUT_Val      _U_(0x0)   /**< \brief (TC_CMR) TIOB input. If TIOB is chosen as the external event signal, it is configured as an input and no longer generates waveforms. */
+#define   TC_CMR_EEVT_XC0_OUTPUT_Val      _U_(0x1)   /**< \brief (TC_CMR) XC0 output */
+#define   TC_CMR_EEVT_XC1_OUTPUT_Val      _U_(0x2)   /**< \brief (TC_CMR) XC1 output */
+#define   TC_CMR_EEVT_XC2_OUTPUT_Val      _U_(0x3)   /**< \brief (TC_CMR) XC2 output */
 #define TC_CMR_EEVT_TIOB_INPUT      (TC_CMR_EEVT_TIOB_INPUT_Val    << TC_CMR_EEVT_Pos)
 #define TC_CMR_EEVT_XC0_OUTPUT      (TC_CMR_EEVT_XC0_OUTPUT_Val    << TC_CMR_EEVT_Pos)
 #define TC_CMR_EEVT_XC1_OUTPUT      (TC_CMR_EEVT_XC1_OUTPUT_Val    << TC_CMR_EEVT_Pos)
 #define TC_CMR_EEVT_XC2_OUTPUT      (TC_CMR_EEVT_XC2_OUTPUT_Val    << TC_CMR_EEVT_Pos)
 #define TC_CMR_ENETRG_Pos           12           /**< \brief (TC_CMR) External Event Trigger Enable */
-#define TC_CMR_ENETRG               (_U(0x1) << TC_CMR_ENETRG_Pos)
-#define   TC_CMR_ENETRG_0_Val             _U(0x0)   /**< \brief (TC_CMR) The external event has no effect on the counter and its clock. In this case, the selected external event only controls the TIOA output. */
-#define   TC_CMR_ENETRG_1_Val             _U(0x1)   /**< \brief (TC_CMR) The external event resets the counter and starts the counter clock. */
+#define TC_CMR_ENETRG               (_U_(0x1) << TC_CMR_ENETRG_Pos)
+#define   TC_CMR_ENETRG_0_Val             _U_(0x0)   /**< \brief (TC_CMR) The external event has no effect on the counter and its clock. In this case, the selected external event only controls the TIOA output. */
+#define   TC_CMR_ENETRG_1_Val             _U_(0x1)   /**< \brief (TC_CMR) The external event resets the counter and starts the counter clock. */
 #define TC_CMR_ENETRG_0             (TC_CMR_ENETRG_0_Val           << TC_CMR_ENETRG_Pos)
 #define TC_CMR_ENETRG_1             (TC_CMR_ENETRG_1_Val           << TC_CMR_ENETRG_Pos)
 #define TC_CMR_WAVSEL_Pos           13           /**< \brief (TC_CMR) Waveform Selection */
-#define TC_CMR_WAVSEL_Msk           (_U(0x3) << TC_CMR_WAVSEL_Pos)
+#define TC_CMR_WAVSEL_Msk           (_U_(0x3) << TC_CMR_WAVSEL_Pos)
 #define TC_CMR_WAVSEL(value)        (TC_CMR_WAVSEL_Msk & ((value) << TC_CMR_WAVSEL_Pos))
-#define   TC_CMR_WAVSEL_UP_NO_AUTO_Val    _U(0x0)   /**< \brief (TC_CMR) UP mode without automatic trigger on RC Compare */
-#define   TC_CMR_WAVSEL_UPDOWN_NO_AUTO_Val _U(0x1)   /**< \brief (TC_CMR) UPDOWN mode without automatic trigger on RC Compare */
-#define   TC_CMR_WAVSEL_UP_AUTO_Val       _U(0x2)   /**< \brief (TC_CMR) UP mode with automatic trigger on RC Compare */
-#define   TC_CMR_WAVSEL_UPDOWN_AUTO_Val   _U(0x3)   /**< \brief (TC_CMR) UPDOWN mode with automatic trigger on RC Compare */
+#define   TC_CMR_WAVSEL_UP_NO_AUTO_Val    _U_(0x0)   /**< \brief (TC_CMR) UP mode without automatic trigger on RC Compare */
+#define   TC_CMR_WAVSEL_UPDOWN_NO_AUTO_Val _U_(0x1)   /**< \brief (TC_CMR) UPDOWN mode without automatic trigger on RC Compare */
+#define   TC_CMR_WAVSEL_UP_AUTO_Val       _U_(0x2)   /**< \brief (TC_CMR) UP mode with automatic trigger on RC Compare */
+#define   TC_CMR_WAVSEL_UPDOWN_AUTO_Val   _U_(0x3)   /**< \brief (TC_CMR) UPDOWN mode with automatic trigger on RC Compare */
 #define TC_CMR_WAVSEL_UP_NO_AUTO    (TC_CMR_WAVSEL_UP_NO_AUTO_Val  << TC_CMR_WAVSEL_Pos)
 #define TC_CMR_WAVSEL_UPDOWN_NO_AUTO (TC_CMR_WAVSEL_UPDOWN_NO_AUTO_Val << TC_CMR_WAVSEL_Pos)
 #define TC_CMR_WAVSEL_UP_AUTO       (TC_CMR_WAVSEL_UP_AUTO_Val     << TC_CMR_WAVSEL_Pos)
 #define TC_CMR_WAVSEL_UPDOWN_AUTO   (TC_CMR_WAVSEL_UPDOWN_AUTO_Val << TC_CMR_WAVSEL_Pos)
 #define TC_CMR_CPCTRG_Pos           14           /**< \brief (TC_CMR) RC Compare Trigger Enable */
-#define TC_CMR_CPCTRG               (_U(0x1) << TC_CMR_CPCTRG_Pos)
-#define   TC_CMR_CPCTRG_0_Val             _U(0x0)   /**< \brief (TC_CMR) RC Compare has no effect on the counter and its clock. */
-#define   TC_CMR_CPCTRG_1_Val             _U(0x1)   /**< \brief (TC_CMR) RC Compare resets the counter and starts the counter clock. */
+#define TC_CMR_CPCTRG               (_U_(0x1) << TC_CMR_CPCTRG_Pos)
+#define   TC_CMR_CPCTRG_0_Val             _U_(0x0)   /**< \brief (TC_CMR) RC Compare has no effect on the counter and its clock. */
+#define   TC_CMR_CPCTRG_1_Val             _U_(0x1)   /**< \brief (TC_CMR) RC Compare resets the counter and starts the counter clock. */
 #define TC_CMR_CPCTRG_0             (TC_CMR_CPCTRG_0_Val           << TC_CMR_CPCTRG_Pos)
 #define TC_CMR_CPCTRG_1             (TC_CMR_CPCTRG_1_Val           << TC_CMR_CPCTRG_Pos)
 #define TC_CMR_WAVE_Pos             15           /**< \brief (TC_CMR) Wave */
-#define TC_CMR_WAVE                 (_U(0x1) << TC_CMR_WAVE_Pos)
-#define   TC_CMR_WAVE_0_Val               _U(0x0)   /**< \brief (TC_CMR) Capture Mode is enabled. */
-#define   TC_CMR_WAVE_1_Val               _U(0x1)   /**< \brief (TC_CMR) Capture Mode is disabled (Waveform Mode is enabled). */
+#define TC_CMR_WAVE                 (_U_(0x1) << TC_CMR_WAVE_Pos)
+#define   TC_CMR_WAVE_0_Val               _U_(0x0)   /**< \brief (TC_CMR) Capture Mode is enabled. */
+#define   TC_CMR_WAVE_1_Val               _U_(0x1)   /**< \brief (TC_CMR) Capture Mode is disabled (Waveform Mode is enabled). */
 #define TC_CMR_WAVE_0               (TC_CMR_WAVE_0_Val             << TC_CMR_WAVE_Pos)
 #define TC_CMR_WAVE_1               (TC_CMR_WAVE_1_Val             << TC_CMR_WAVE_Pos)
 #define TC_CMR_LDRA_Pos             16           /**< \brief (TC_CMR) RA Loading Selection */
-#define TC_CMR_LDRA_Msk             (_U(0x3) << TC_CMR_LDRA_Pos)
+#define TC_CMR_LDRA_Msk             (_U_(0x3) << TC_CMR_LDRA_Pos)
 #define TC_CMR_LDRA(value)          (TC_CMR_LDRA_Msk & ((value) << TC_CMR_LDRA_Pos))
-#define   TC_CMR_LDRA_NO_EDGE_Val         _U(0x0)   /**< \brief (TC_CMR) none */
-#define   TC_CMR_LDRA_POS_EDGE_TIOA_Val   _U(0x1)   /**< \brief (TC_CMR) rising edge of TIOA */
-#define   TC_CMR_LDRA_NEG_EDGE_TIOA_Val   _U(0x2)   /**< \brief (TC_CMR) falling edge of TIOA */
-#define   TC_CMR_LDRA_BOTH_EDGES_TIOA_Val _U(0x3)   /**< \brief (TC_CMR) each edge of TIOA */
+#define   TC_CMR_LDRA_NO_EDGE_Val         _U_(0x0)   /**< \brief (TC_CMR) none */
+#define   TC_CMR_LDRA_POS_EDGE_TIOA_Val   _U_(0x1)   /**< \brief (TC_CMR) rising edge of TIOA */
+#define   TC_CMR_LDRA_NEG_EDGE_TIOA_Val   _U_(0x2)   /**< \brief (TC_CMR) falling edge of TIOA */
+#define   TC_CMR_LDRA_BOTH_EDGES_TIOA_Val _U_(0x3)   /**< \brief (TC_CMR) each edge of TIOA */
 #define TC_CMR_LDRA_NO_EDGE         (TC_CMR_LDRA_NO_EDGE_Val       << TC_CMR_LDRA_Pos)
 #define TC_CMR_LDRA_POS_EDGE_TIOA   (TC_CMR_LDRA_POS_EDGE_TIOA_Val << TC_CMR_LDRA_Pos)
 #define TC_CMR_LDRA_NEG_EDGE_TIOA   (TC_CMR_LDRA_NEG_EDGE_TIOA_Val << TC_CMR_LDRA_Pos)
 #define TC_CMR_LDRA_BOTH_EDGES_TIOA (TC_CMR_LDRA_BOTH_EDGES_TIOA_Val << TC_CMR_LDRA_Pos)
 #define TC_CMR_ACPA_Pos             16           /**< \brief (TC_CMR) RA Compare Effect on TIOA */
-#define TC_CMR_ACPA_Msk             (_U(0x3) << TC_CMR_ACPA_Pos)
+#define TC_CMR_ACPA_Msk             (_U_(0x3) << TC_CMR_ACPA_Pos)
 #define TC_CMR_ACPA(value)          (TC_CMR_ACPA_Msk & ((value) << TC_CMR_ACPA_Pos))
-#define   TC_CMR_ACPA_NONE_Val            _U(0x0)   /**< \brief (TC_CMR) none */
-#define   TC_CMR_ACPA_SET_Val             _U(0x1)   /**< \brief (TC_CMR) set */
-#define   TC_CMR_ACPA_CLEAR_Val           _U(0x2)   /**< \brief (TC_CMR) clear */
-#define   TC_CMR_ACPA_TOGGLE_Val          _U(0x3)   /**< \brief (TC_CMR) toggle */
+#define   TC_CMR_ACPA_NONE_Val            _U_(0x0)   /**< \brief (TC_CMR) none */
+#define   TC_CMR_ACPA_SET_Val             _U_(0x1)   /**< \brief (TC_CMR) set */
+#define   TC_CMR_ACPA_CLEAR_Val           _U_(0x2)   /**< \brief (TC_CMR) clear */
+#define   TC_CMR_ACPA_TOGGLE_Val          _U_(0x3)   /**< \brief (TC_CMR) toggle */
 #define TC_CMR_ACPA_NONE            (TC_CMR_ACPA_NONE_Val          << TC_CMR_ACPA_Pos)
 #define TC_CMR_ACPA_SET             (TC_CMR_ACPA_SET_Val           << TC_CMR_ACPA_Pos)
 #define TC_CMR_ACPA_CLEAR           (TC_CMR_ACPA_CLEAR_Val         << TC_CMR_ACPA_Pos)
 #define TC_CMR_ACPA_TOGGLE          (TC_CMR_ACPA_TOGGLE_Val        << TC_CMR_ACPA_Pos)
 #define TC_CMR_LDRB_Pos             18           /**< \brief (TC_CMR) RB Loading Selection */
-#define TC_CMR_LDRB_Msk             (_U(0x3) << TC_CMR_LDRB_Pos)
+#define TC_CMR_LDRB_Msk             (_U_(0x3) << TC_CMR_LDRB_Pos)
 #define TC_CMR_LDRB(value)          (TC_CMR_LDRB_Msk & ((value) << TC_CMR_LDRB_Pos))
-#define   TC_CMR_LDRB_NO_EDGE_Val         _U(0x0)   /**< \brief (TC_CMR) none */
-#define   TC_CMR_LDRB_POS_EDGE_TIOA_Val   _U(0x1)   /**< \brief (TC_CMR) rising edge of TIOA */
-#define   TC_CMR_LDRB_NEG_EDGE_TIOA_Val   _U(0x2)   /**< \brief (TC_CMR) falling edge of TIOA */
-#define   TC_CMR_LDRB_BOTH_EDGES_TIOA_Val _U(0x3)   /**< \brief (TC_CMR) each edge of TIOA */
+#define   TC_CMR_LDRB_NO_EDGE_Val         _U_(0x0)   /**< \brief (TC_CMR) none */
+#define   TC_CMR_LDRB_POS_EDGE_TIOA_Val   _U_(0x1)   /**< \brief (TC_CMR) rising edge of TIOA */
+#define   TC_CMR_LDRB_NEG_EDGE_TIOA_Val   _U_(0x2)   /**< \brief (TC_CMR) falling edge of TIOA */
+#define   TC_CMR_LDRB_BOTH_EDGES_TIOA_Val _U_(0x3)   /**< \brief (TC_CMR) each edge of TIOA */
 #define TC_CMR_LDRB_NO_EDGE         (TC_CMR_LDRB_NO_EDGE_Val       << TC_CMR_LDRB_Pos)
 #define TC_CMR_LDRB_POS_EDGE_TIOA   (TC_CMR_LDRB_POS_EDGE_TIOA_Val << TC_CMR_LDRB_Pos)
 #define TC_CMR_LDRB_NEG_EDGE_TIOA   (TC_CMR_LDRB_NEG_EDGE_TIOA_Val << TC_CMR_LDRB_Pos)
 #define TC_CMR_LDRB_BOTH_EDGES_TIOA (TC_CMR_LDRB_BOTH_EDGES_TIOA_Val << TC_CMR_LDRB_Pos)
 #define TC_CMR_ACPC_Pos             18           /**< \brief (TC_CMR) RC Compare Effect on TIOA */
-#define TC_CMR_ACPC_Msk             (_U(0x3) << TC_CMR_ACPC_Pos)
+#define TC_CMR_ACPC_Msk             (_U_(0x3) << TC_CMR_ACPC_Pos)
 #define TC_CMR_ACPC(value)          (TC_CMR_ACPC_Msk & ((value) << TC_CMR_ACPC_Pos))
-#define   TC_CMR_ACPC_NONE_Val            _U(0x0)   /**< \brief (TC_CMR) none */
-#define   TC_CMR_ACPC_SET_Val             _U(0x1)   /**< \brief (TC_CMR) set */
-#define   TC_CMR_ACPC_CLEAR_Val           _U(0x2)   /**< \brief (TC_CMR) clear */
-#define   TC_CMR_ACPC_TOGGLE_Val          _U(0x3)   /**< \brief (TC_CMR) toggle */
+#define   TC_CMR_ACPC_NONE_Val            _U_(0x0)   /**< \brief (TC_CMR) none */
+#define   TC_CMR_ACPC_SET_Val             _U_(0x1)   /**< \brief (TC_CMR) set */
+#define   TC_CMR_ACPC_CLEAR_Val           _U_(0x2)   /**< \brief (TC_CMR) clear */
+#define   TC_CMR_ACPC_TOGGLE_Val          _U_(0x3)   /**< \brief (TC_CMR) toggle */
 #define TC_CMR_ACPC_NONE            (TC_CMR_ACPC_NONE_Val          << TC_CMR_ACPC_Pos)
 #define TC_CMR_ACPC_SET             (TC_CMR_ACPC_SET_Val           << TC_CMR_ACPC_Pos)
 #define TC_CMR_ACPC_CLEAR           (TC_CMR_ACPC_CLEAR_Val         << TC_CMR_ACPC_Pos)
 #define TC_CMR_ACPC_TOGGLE          (TC_CMR_ACPC_TOGGLE_Val        << TC_CMR_ACPC_Pos)
 #define TC_CMR_AEEVT_Pos            20           /**< \brief (TC_CMR) External Event Effect on TIOA */
-#define TC_CMR_AEEVT_Msk            (_U(0x3) << TC_CMR_AEEVT_Pos)
+#define TC_CMR_AEEVT_Msk            (_U_(0x3) << TC_CMR_AEEVT_Pos)
 #define TC_CMR_AEEVT(value)         (TC_CMR_AEEVT_Msk & ((value) << TC_CMR_AEEVT_Pos))
-#define   TC_CMR_AEEVT_NONE_Val           _U(0x0)   /**< \brief (TC_CMR) none */
-#define   TC_CMR_AEEVT_SET_Val            _U(0x1)   /**< \brief (TC_CMR) set */
-#define   TC_CMR_AEEVT_CLEAR_Val          _U(0x2)   /**< \brief (TC_CMR) clear */
-#define   TC_CMR_AEEVT_TOGGLE_Val         _U(0x3)   /**< \brief (TC_CMR) toggle */
+#define   TC_CMR_AEEVT_NONE_Val           _U_(0x0)   /**< \brief (TC_CMR) none */
+#define   TC_CMR_AEEVT_SET_Val            _U_(0x1)   /**< \brief (TC_CMR) set */
+#define   TC_CMR_AEEVT_CLEAR_Val          _U_(0x2)   /**< \brief (TC_CMR) clear */
+#define   TC_CMR_AEEVT_TOGGLE_Val         _U_(0x3)   /**< \brief (TC_CMR) toggle */
 #define TC_CMR_AEEVT_NONE           (TC_CMR_AEEVT_NONE_Val         << TC_CMR_AEEVT_Pos)
 #define TC_CMR_AEEVT_SET            (TC_CMR_AEEVT_SET_Val          << TC_CMR_AEEVT_Pos)
 #define TC_CMR_AEEVT_CLEAR          (TC_CMR_AEEVT_CLEAR_Val        << TC_CMR_AEEVT_Pos)
 #define TC_CMR_AEEVT_TOGGLE         (TC_CMR_AEEVT_TOGGLE_Val       << TC_CMR_AEEVT_Pos)
 #define TC_CMR_ASWTRG_Pos           22           /**< \brief (TC_CMR) Software Trigger Effect on TIOA */
-#define TC_CMR_ASWTRG_Msk           (_U(0x3) << TC_CMR_ASWTRG_Pos)
+#define TC_CMR_ASWTRG_Msk           (_U_(0x3) << TC_CMR_ASWTRG_Pos)
 #define TC_CMR_ASWTRG(value)        (TC_CMR_ASWTRG_Msk & ((value) << TC_CMR_ASWTRG_Pos))
-#define   TC_CMR_ASWTRG_NONE_Val          _U(0x0)   /**< \brief (TC_CMR) none */
-#define   TC_CMR_ASWTRG_SET_Val           _U(0x1)   /**< \brief (TC_CMR) set */
-#define   TC_CMR_ASWTRG_CLEAR_Val         _U(0x2)   /**< \brief (TC_CMR) clear */
-#define   TC_CMR_ASWTRG_TOGGLE_Val        _U(0x3)   /**< \brief (TC_CMR) toggle */
+#define   TC_CMR_ASWTRG_NONE_Val          _U_(0x0)   /**< \brief (TC_CMR) none */
+#define   TC_CMR_ASWTRG_SET_Val           _U_(0x1)   /**< \brief (TC_CMR) set */
+#define   TC_CMR_ASWTRG_CLEAR_Val         _U_(0x2)   /**< \brief (TC_CMR) clear */
+#define   TC_CMR_ASWTRG_TOGGLE_Val        _U_(0x3)   /**< \brief (TC_CMR) toggle */
 #define TC_CMR_ASWTRG_NONE          (TC_CMR_ASWTRG_NONE_Val        << TC_CMR_ASWTRG_Pos)
 #define TC_CMR_ASWTRG_SET           (TC_CMR_ASWTRG_SET_Val         << TC_CMR_ASWTRG_Pos)
 #define TC_CMR_ASWTRG_CLEAR         (TC_CMR_ASWTRG_CLEAR_Val       << TC_CMR_ASWTRG_Pos)
 #define TC_CMR_ASWTRG_TOGGLE        (TC_CMR_ASWTRG_TOGGLE_Val      << TC_CMR_ASWTRG_Pos)
 #define TC_CMR_BCPB_Pos             24           /**< \brief (TC_CMR) RB Compare Effect on TIOB */
-#define TC_CMR_BCPB_Msk             (_U(0x3) << TC_CMR_BCPB_Pos)
+#define TC_CMR_BCPB_Msk             (_U_(0x3) << TC_CMR_BCPB_Pos)
 #define TC_CMR_BCPB(value)          (TC_CMR_BCPB_Msk & ((value) << TC_CMR_BCPB_Pos))
-#define   TC_CMR_BCPB_NONE_Val            _U(0x0)   /**< \brief (TC_CMR) none */
-#define   TC_CMR_BCPB_SET_Val             _U(0x1)   /**< \brief (TC_CMR) set */
-#define   TC_CMR_BCPB_CLEAR_Val           _U(0x2)   /**< \brief (TC_CMR) clear */
-#define   TC_CMR_BCPB_TOGGLE_Val          _U(0x3)   /**< \brief (TC_CMR) toggle */
+#define   TC_CMR_BCPB_NONE_Val            _U_(0x0)   /**< \brief (TC_CMR) none */
+#define   TC_CMR_BCPB_SET_Val             _U_(0x1)   /**< \brief (TC_CMR) set */
+#define   TC_CMR_BCPB_CLEAR_Val           _U_(0x2)   /**< \brief (TC_CMR) clear */
+#define   TC_CMR_BCPB_TOGGLE_Val          _U_(0x3)   /**< \brief (TC_CMR) toggle */
 #define TC_CMR_BCPB_NONE            (TC_CMR_BCPB_NONE_Val          << TC_CMR_BCPB_Pos)
 #define TC_CMR_BCPB_SET             (TC_CMR_BCPB_SET_Val           << TC_CMR_BCPB_Pos)
 #define TC_CMR_BCPB_CLEAR           (TC_CMR_BCPB_CLEAR_Val         << TC_CMR_BCPB_Pos)
 #define TC_CMR_BCPB_TOGGLE          (TC_CMR_BCPB_TOGGLE_Val        << TC_CMR_BCPB_Pos)
 #define TC_CMR_BCPC_Pos             26           /**< \brief (TC_CMR) RC Compare Effect on TIOB */
-#define TC_CMR_BCPC_Msk             (_U(0x3) << TC_CMR_BCPC_Pos)
+#define TC_CMR_BCPC_Msk             (_U_(0x3) << TC_CMR_BCPC_Pos)
 #define TC_CMR_BCPC(value)          (TC_CMR_BCPC_Msk & ((value) << TC_CMR_BCPC_Pos))
-#define   TC_CMR_BCPC_NONE_Val            _U(0x0)   /**< \brief (TC_CMR) none */
-#define   TC_CMR_BCPC_SET_Val             _U(0x1)   /**< \brief (TC_CMR) set */
-#define   TC_CMR_BCPC_CLEAR_Val           _U(0x2)   /**< \brief (TC_CMR) clear */
-#define   TC_CMR_BCPC_TOGGLE_Val          _U(0x3)   /**< \brief (TC_CMR) toggle */
+#define   TC_CMR_BCPC_NONE_Val            _U_(0x0)   /**< \brief (TC_CMR) none */
+#define   TC_CMR_BCPC_SET_Val             _U_(0x1)   /**< \brief (TC_CMR) set */
+#define   TC_CMR_BCPC_CLEAR_Val           _U_(0x2)   /**< \brief (TC_CMR) clear */
+#define   TC_CMR_BCPC_TOGGLE_Val          _U_(0x3)   /**< \brief (TC_CMR) toggle */
 #define TC_CMR_BCPC_NONE            (TC_CMR_BCPC_NONE_Val          << TC_CMR_BCPC_Pos)
 #define TC_CMR_BCPC_SET             (TC_CMR_BCPC_SET_Val           << TC_CMR_BCPC_Pos)
 #define TC_CMR_BCPC_CLEAR           (TC_CMR_BCPC_CLEAR_Val         << TC_CMR_BCPC_Pos)
 #define TC_CMR_BCPC_TOGGLE          (TC_CMR_BCPC_TOGGLE_Val        << TC_CMR_BCPC_Pos)
 #define TC_CMR_BEEVT_Pos            28           /**< \brief (TC_CMR) External Event Effect on TIOB */
-#define TC_CMR_BEEVT_Msk            (_U(0x3) << TC_CMR_BEEVT_Pos)
+#define TC_CMR_BEEVT_Msk            (_U_(0x3) << TC_CMR_BEEVT_Pos)
 #define TC_CMR_BEEVT(value)         (TC_CMR_BEEVT_Msk & ((value) << TC_CMR_BEEVT_Pos))
-#define   TC_CMR_BEEVT_NONE_Val           _U(0x0)   /**< \brief (TC_CMR) none */
-#define   TC_CMR_BEEVT_SET_Val            _U(0x1)   /**< \brief (TC_CMR) set */
-#define   TC_CMR_BEEVT_CLEAR_Val          _U(0x2)   /**< \brief (TC_CMR) clear */
-#define   TC_CMR_BEEVT_TOGGLE_Val         _U(0x3)   /**< \brief (TC_CMR) toggle */
+#define   TC_CMR_BEEVT_NONE_Val           _U_(0x0)   /**< \brief (TC_CMR) none */
+#define   TC_CMR_BEEVT_SET_Val            _U_(0x1)   /**< \brief (TC_CMR) set */
+#define   TC_CMR_BEEVT_CLEAR_Val          _U_(0x2)   /**< \brief (TC_CMR) clear */
+#define   TC_CMR_BEEVT_TOGGLE_Val         _U_(0x3)   /**< \brief (TC_CMR) toggle */
 #define TC_CMR_BEEVT_NONE           (TC_CMR_BEEVT_NONE_Val         << TC_CMR_BEEVT_Pos)
 #define TC_CMR_BEEVT_SET            (TC_CMR_BEEVT_SET_Val          << TC_CMR_BEEVT_Pos)
 #define TC_CMR_BEEVT_CLEAR          (TC_CMR_BEEVT_CLEAR_Val        << TC_CMR_BEEVT_Pos)
 #define TC_CMR_BEEVT_TOGGLE         (TC_CMR_BEEVT_TOGGLE_Val       << TC_CMR_BEEVT_Pos)
 #define TC_CMR_BSWTRG_Pos           30           /**< \brief (TC_CMR) Software Trigger Effect on TIOB */
-#define TC_CMR_BSWTRG_Msk           (_U(0x3) << TC_CMR_BSWTRG_Pos)
+#define TC_CMR_BSWTRG_Msk           (_U_(0x3) << TC_CMR_BSWTRG_Pos)
 #define TC_CMR_BSWTRG(value)        (TC_CMR_BSWTRG_Msk & ((value) << TC_CMR_BSWTRG_Pos))
-#define   TC_CMR_BSWTRG_NONE_Val          _U(0x0)   /**< \brief (TC_CMR) none */
-#define   TC_CMR_BSWTRG_SET_Val           _U(0x1)   /**< \brief (TC_CMR) set */
-#define   TC_CMR_BSWTRG_CLEAR_Val         _U(0x2)   /**< \brief (TC_CMR) clear */
-#define   TC_CMR_BSWTRG_TOGGLE_Val        _U(0x3)   /**< \brief (TC_CMR) toggle */
+#define   TC_CMR_BSWTRG_NONE_Val          _U_(0x0)   /**< \brief (TC_CMR) none */
+#define   TC_CMR_BSWTRG_SET_Val           _U_(0x1)   /**< \brief (TC_CMR) set */
+#define   TC_CMR_BSWTRG_CLEAR_Val         _U_(0x2)   /**< \brief (TC_CMR) clear */
+#define   TC_CMR_BSWTRG_TOGGLE_Val        _U_(0x3)   /**< \brief (TC_CMR) toggle */
 #define TC_CMR_BSWTRG_NONE          (TC_CMR_BSWTRG_NONE_Val        << TC_CMR_BSWTRG_Pos)
 #define TC_CMR_BSWTRG_SET           (TC_CMR_BSWTRG_SET_Val         << TC_CMR_BSWTRG_Pos)
 #define TC_CMR_BSWTRG_CLEAR         (TC_CMR_BSWTRG_CLEAR_Val       << TC_CMR_BSWTRG_Pos)
 #define TC_CMR_BSWTRG_TOGGLE        (TC_CMR_BSWTRG_TOGGLE_Val      << TC_CMR_BSWTRG_Pos)
-#define TC_CMR_MASK                 _U(0xFFFFFFFF) /**< \brief (TC_CMR) MASK Register */
+#define TC_CMR_MASK                 _U_(0xFFFFFFFF) /**< \brief (TC_CMR) MASK Register */
 
 /* -------- TC_SMMR : (TC Offset: 0x08) (R/W 32) channel Stepper Motor Mode Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -659,13 +659,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_SMMR_OFFSET              0x08         /**< \brief (TC_SMMR offset) Stepper Motor Mode Register */
-#define TC_SMMR_RESETVALUE          _U(0x00000000); /**< \brief (TC_SMMR reset_value) Stepper Motor Mode Register */
+#define TC_SMMR_RESETVALUE          _U_(0x00000000); /**< \brief (TC_SMMR reset_value) Stepper Motor Mode Register */
 
 #define TC_SMMR_GCEN_Pos            0            /**< \brief (TC_SMMR) Gray Count Enable */
-#define TC_SMMR_GCEN                (_U(0x1) << TC_SMMR_GCEN_Pos)
+#define TC_SMMR_GCEN                (_U_(0x1) << TC_SMMR_GCEN_Pos)
 #define TC_SMMR_DOWN_Pos            1            /**< \brief (TC_SMMR) Down Count */
-#define TC_SMMR_DOWN                (_U(0x1) << TC_SMMR_DOWN_Pos)
-#define TC_SMMR_MASK                _U(0x00000003) /**< \brief (TC_SMMR) MASK Register */
+#define TC_SMMR_DOWN                (_U_(0x1) << TC_SMMR_DOWN_Pos)
+#define TC_SMMR_MASK                _U_(0x00000003) /**< \brief (TC_SMMR) MASK Register */
 
 /* -------- TC_CV : (TC Offset: 0x10) (R/  32) channel Counter Value Channel -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -679,12 +679,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_CV_OFFSET                0x10         /**< \brief (TC_CV offset) Counter Value Channel */
-#define TC_CV_RESETVALUE            _U(0x00000000); /**< \brief (TC_CV reset_value) Counter Value Channel */
+#define TC_CV_RESETVALUE            _U_(0x00000000); /**< \brief (TC_CV reset_value) Counter Value Channel */
 
 #define TC_CV_CV_Pos                0            /**< \brief (TC_CV) Counter Value */
-#define TC_CV_CV_Msk                (_U(0xFFFF) << TC_CV_CV_Pos)
+#define TC_CV_CV_Msk                (_U_(0xFFFF) << TC_CV_CV_Pos)
 #define TC_CV_CV(value)             (TC_CV_CV_Msk & ((value) << TC_CV_CV_Pos))
-#define TC_CV_MASK                  _U(0x0000FFFF) /**< \brief (TC_CV) MASK Register */
+#define TC_CV_MASK                  _U_(0x0000FFFF) /**< \brief (TC_CV) MASK Register */
 
 /* -------- TC_RA : (TC Offset: 0x14) (R/W 32) channel Register A Channel -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -698,12 +698,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_RA_OFFSET                0x14         /**< \brief (TC_RA offset) Register A Channel */
-#define TC_RA_RESETVALUE            _U(0x00000000); /**< \brief (TC_RA reset_value) Register A Channel */
+#define TC_RA_RESETVALUE            _U_(0x00000000); /**< \brief (TC_RA reset_value) Register A Channel */
 
 #define TC_RA_RA_Pos                0            /**< \brief (TC_RA) Register A */
-#define TC_RA_RA_Msk                (_U(0xFFFF) << TC_RA_RA_Pos)
+#define TC_RA_RA_Msk                (_U_(0xFFFF) << TC_RA_RA_Pos)
 #define TC_RA_RA(value)             (TC_RA_RA_Msk & ((value) << TC_RA_RA_Pos))
-#define TC_RA_MASK                  _U(0x0000FFFF) /**< \brief (TC_RA) MASK Register */
+#define TC_RA_MASK                  _U_(0x0000FFFF) /**< \brief (TC_RA) MASK Register */
 
 /* -------- TC_RB : (TC Offset: 0x18) (R/W 32) channel Register B Channel -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -717,12 +717,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_RB_OFFSET                0x18         /**< \brief (TC_RB offset) Register B Channel */
-#define TC_RB_RESETVALUE            _U(0x00000000); /**< \brief (TC_RB reset_value) Register B Channel */
+#define TC_RB_RESETVALUE            _U_(0x00000000); /**< \brief (TC_RB reset_value) Register B Channel */
 
 #define TC_RB_RB_Pos                0            /**< \brief (TC_RB) Register B */
-#define TC_RB_RB_Msk                (_U(0xFFFF) << TC_RB_RB_Pos)
+#define TC_RB_RB_Msk                (_U_(0xFFFF) << TC_RB_RB_Pos)
 #define TC_RB_RB(value)             (TC_RB_RB_Msk & ((value) << TC_RB_RB_Pos))
-#define TC_RB_MASK                  _U(0x0000FFFF) /**< \brief (TC_RB) MASK Register */
+#define TC_RB_MASK                  _U_(0x0000FFFF) /**< \brief (TC_RB) MASK Register */
 
 /* -------- TC_RC : (TC Offset: 0x1C) (R/W 32) channel Register C Channel -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -736,12 +736,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_RC_OFFSET                0x1C         /**< \brief (TC_RC offset) Register C Channel */
-#define TC_RC_RESETVALUE            _U(0x00000000); /**< \brief (TC_RC reset_value) Register C Channel */
+#define TC_RC_RESETVALUE            _U_(0x00000000); /**< \brief (TC_RC reset_value) Register C Channel */
 
 #define TC_RC_RC_Pos                0            /**< \brief (TC_RC) Register C */
-#define TC_RC_RC_Msk                (_U(0xFFFF) << TC_RC_RC_Pos)
+#define TC_RC_RC_Msk                (_U_(0xFFFF) << TC_RC_RC_Pos)
 #define TC_RC_RC(value)             (TC_RC_RC_Msk & ((value) << TC_RC_RC_Pos))
-#define TC_RC_MASK                  _U(0x0000FFFF) /**< \brief (TC_RC) MASK Register */
+#define TC_RC_MASK                  _U_(0x0000FFFF) /**< \brief (TC_RC) MASK Register */
 
 /* -------- TC_SR : (TC Offset: 0x20) (R/  32) channel Status Register Channel -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -766,75 +766,75 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_SR_OFFSET                0x20         /**< \brief (TC_SR offset) Status Register Channel */
-#define TC_SR_RESETVALUE            _U(0x00000000); /**< \brief (TC_SR reset_value) Status Register Channel */
+#define TC_SR_RESETVALUE            _U_(0x00000000); /**< \brief (TC_SR reset_value) Status Register Channel */
 
 #define TC_SR_COVFS_Pos             0            /**< \brief (TC_SR) Counter Overflow Status */
-#define TC_SR_COVFS                 (_U(0x1) << TC_SR_COVFS_Pos)
-#define   TC_SR_COVFS_0_Val               _U(0x0)   /**< \brief (TC_SR) No counter overflow has occurred since the last read of the Status Register. */
-#define   TC_SR_COVFS_1_Val               _U(0x1)   /**< \brief (TC_SR) A counter overflow has occurred since the last read of the Status Register. */
+#define TC_SR_COVFS                 (_U_(0x1) << TC_SR_COVFS_Pos)
+#define   TC_SR_COVFS_0_Val               _U_(0x0)   /**< \brief (TC_SR) No counter overflow has occurred since the last read of the Status Register. */
+#define   TC_SR_COVFS_1_Val               _U_(0x1)   /**< \brief (TC_SR) A counter overflow has occurred since the last read of the Status Register. */
 #define TC_SR_COVFS_0               (TC_SR_COVFS_0_Val             << TC_SR_COVFS_Pos)
 #define TC_SR_COVFS_1               (TC_SR_COVFS_1_Val             << TC_SR_COVFS_Pos)
 #define TC_SR_LOVRS_Pos             1            /**< \brief (TC_SR) Load Overrun Status */
-#define TC_SR_LOVRS                 (_U(0x1) << TC_SR_LOVRS_Pos)
-#define   TC_SR_LOVRS_0_Val               _U(0x0)   /**< \brief (TC_SR) Load overrun has not occurred since the last read of the Status Register or WAVE:1. */
-#define   TC_SR_LOVRS_1_Val               _U(0x1)   /**< \brief (TC_SR) RA or RB have been loaded at least twice without any read of the corresponding register since the last read of the StatusRegister, if WAVE:0. */
+#define TC_SR_LOVRS                 (_U_(0x1) << TC_SR_LOVRS_Pos)
+#define   TC_SR_LOVRS_0_Val               _U_(0x0)   /**< \brief (TC_SR) Load overrun has not occurred since the last read of the Status Register or WAVE:1. */
+#define   TC_SR_LOVRS_1_Val               _U_(0x1)   /**< \brief (TC_SR) RA or RB have been loaded at least twice without any read of the corresponding register since the last read of the StatusRegister, if WAVE:0. */
 #define TC_SR_LOVRS_0               (TC_SR_LOVRS_0_Val             << TC_SR_LOVRS_Pos)
 #define TC_SR_LOVRS_1               (TC_SR_LOVRS_1_Val             << TC_SR_LOVRS_Pos)
 #define TC_SR_CPAS_Pos              2            /**< \brief (TC_SR) RA Compare Status */
-#define TC_SR_CPAS                  (_U(0x1) << TC_SR_CPAS_Pos)
-#define   TC_SR_CPAS_0_Val                _U(0x0)   /**< \brief (TC_SR) RA Compare has not occurred since the last read of the Status Register or WAVE:0. */
-#define   TC_SR_CPAS_1_Val                _U(0x1)   /**< \brief (TC_SR) RA Compare has occurred since the last read of the Status Register, if WAVE:1. */
+#define TC_SR_CPAS                  (_U_(0x1) << TC_SR_CPAS_Pos)
+#define   TC_SR_CPAS_0_Val                _U_(0x0)   /**< \brief (TC_SR) RA Compare has not occurred since the last read of the Status Register or WAVE:0. */
+#define   TC_SR_CPAS_1_Val                _U_(0x1)   /**< \brief (TC_SR) RA Compare has occurred since the last read of the Status Register, if WAVE:1. */
 #define TC_SR_CPAS_0                (TC_SR_CPAS_0_Val              << TC_SR_CPAS_Pos)
 #define TC_SR_CPAS_1                (TC_SR_CPAS_1_Val              << TC_SR_CPAS_Pos)
 #define TC_SR_CPBS_Pos              3            /**< \brief (TC_SR) RB Compare Status */
-#define TC_SR_CPBS                  (_U(0x1) << TC_SR_CPBS_Pos)
-#define   TC_SR_CPBS_0_Val                _U(0x0)   /**< \brief (TC_SR) RB Compare has not occurred since the last read of the Status Register or WAVE:0. */
-#define   TC_SR_CPBS_1_Val                _U(0x1)   /**< \brief (TC_SR) RB Compare has occurred since the last read of the Status Register, if WAVE:1. */
+#define TC_SR_CPBS                  (_U_(0x1) << TC_SR_CPBS_Pos)
+#define   TC_SR_CPBS_0_Val                _U_(0x0)   /**< \brief (TC_SR) RB Compare has not occurred since the last read of the Status Register or WAVE:0. */
+#define   TC_SR_CPBS_1_Val                _U_(0x1)   /**< \brief (TC_SR) RB Compare has occurred since the last read of the Status Register, if WAVE:1. */
 #define TC_SR_CPBS_0                (TC_SR_CPBS_0_Val              << TC_SR_CPBS_Pos)
 #define TC_SR_CPBS_1                (TC_SR_CPBS_1_Val              << TC_SR_CPBS_Pos)
 #define TC_SR_CPCS_Pos              4            /**< \brief (TC_SR) RC Compare Status */
-#define TC_SR_CPCS                  (_U(0x1) << TC_SR_CPCS_Pos)
-#define   TC_SR_CPCS_0_Val                _U(0x0)   /**< \brief (TC_SR) RC Compare has not occurred since the last read of the Status Register. */
-#define   TC_SR_CPCS_1_Val                _U(0x1)   /**< \brief (TC_SR) RC Compare has occurred since the last read of the Status Register. */
+#define TC_SR_CPCS                  (_U_(0x1) << TC_SR_CPCS_Pos)
+#define   TC_SR_CPCS_0_Val                _U_(0x0)   /**< \brief (TC_SR) RC Compare has not occurred since the last read of the Status Register. */
+#define   TC_SR_CPCS_1_Val                _U_(0x1)   /**< \brief (TC_SR) RC Compare has occurred since the last read of the Status Register. */
 #define TC_SR_CPCS_0                (TC_SR_CPCS_0_Val              << TC_SR_CPCS_Pos)
 #define TC_SR_CPCS_1                (TC_SR_CPCS_1_Val              << TC_SR_CPCS_Pos)
 #define TC_SR_LDRAS_Pos             5            /**< \brief (TC_SR) RA Loading Status */
-#define TC_SR_LDRAS                 (_U(0x1) << TC_SR_LDRAS_Pos)
-#define   TC_SR_LDRAS_0_Val               _U(0x0)   /**< \brief (TC_SR) RA Load has not occurred since the last read of the Status Register or WAVE:1. */
-#define   TC_SR_LDRAS_1_Val               _U(0x1)   /**< \brief (TC_SR) RA Load has occurred since the last read of the Status Register, if WAVE:0. */
+#define TC_SR_LDRAS                 (_U_(0x1) << TC_SR_LDRAS_Pos)
+#define   TC_SR_LDRAS_0_Val               _U_(0x0)   /**< \brief (TC_SR) RA Load has not occurred since the last read of the Status Register or WAVE:1. */
+#define   TC_SR_LDRAS_1_Val               _U_(0x1)   /**< \brief (TC_SR) RA Load has occurred since the last read of the Status Register, if WAVE:0. */
 #define TC_SR_LDRAS_0               (TC_SR_LDRAS_0_Val             << TC_SR_LDRAS_Pos)
 #define TC_SR_LDRAS_1               (TC_SR_LDRAS_1_Val             << TC_SR_LDRAS_Pos)
 #define TC_SR_LDRBS_Pos             6            /**< \brief (TC_SR) RB Loading Status */
-#define TC_SR_LDRBS                 (_U(0x1) << TC_SR_LDRBS_Pos)
-#define   TC_SR_LDRBS_0_Val               _U(0x0)   /**< \brief (TC_SR) RB Load has not occurred since the last read of the Status Register or WAVE:1. */
-#define   TC_SR_LDRBS_1_Val               _U(0x1)   /**< \brief (TC_SR) RB Load has occurred since the last read of the Status Register, if WAVE:0. */
+#define TC_SR_LDRBS                 (_U_(0x1) << TC_SR_LDRBS_Pos)
+#define   TC_SR_LDRBS_0_Val               _U_(0x0)   /**< \brief (TC_SR) RB Load has not occurred since the last read of the Status Register or WAVE:1. */
+#define   TC_SR_LDRBS_1_Val               _U_(0x1)   /**< \brief (TC_SR) RB Load has occurred since the last read of the Status Register, if WAVE:0. */
 #define TC_SR_LDRBS_0               (TC_SR_LDRBS_0_Val             << TC_SR_LDRBS_Pos)
 #define TC_SR_LDRBS_1               (TC_SR_LDRBS_1_Val             << TC_SR_LDRBS_Pos)
 #define TC_SR_ETRGS_Pos             7            /**< \brief (TC_SR) External Trigger Status */
-#define TC_SR_ETRGS                 (_U(0x1) << TC_SR_ETRGS_Pos)
-#define   TC_SR_ETRGS_0_Val               _U(0x0)   /**< \brief (TC_SR) External trigger has not occurred since the last read of the Status Register. */
-#define   TC_SR_ETRGS_1_Val               _U(0x1)   /**< \brief (TC_SR) External trigger has occurred since the last read of the Status Register. */
+#define TC_SR_ETRGS                 (_U_(0x1) << TC_SR_ETRGS_Pos)
+#define   TC_SR_ETRGS_0_Val               _U_(0x0)   /**< \brief (TC_SR) External trigger has not occurred since the last read of the Status Register. */
+#define   TC_SR_ETRGS_1_Val               _U_(0x1)   /**< \brief (TC_SR) External trigger has occurred since the last read of the Status Register. */
 #define TC_SR_ETRGS_0               (TC_SR_ETRGS_0_Val             << TC_SR_ETRGS_Pos)
 #define TC_SR_ETRGS_1               (TC_SR_ETRGS_1_Val             << TC_SR_ETRGS_Pos)
 #define TC_SR_CLKSTA_Pos            16           /**< \brief (TC_SR) Clock Enabling Status */
-#define TC_SR_CLKSTA                (_U(0x1) << TC_SR_CLKSTA_Pos)
-#define   TC_SR_CLKSTA_0_Val              _U(0x0)   /**< \brief (TC_SR) Clock is disabled. */
-#define   TC_SR_CLKSTA_1_Val              _U(0x1)   /**< \brief (TC_SR) Clock is enabled. */
+#define TC_SR_CLKSTA                (_U_(0x1) << TC_SR_CLKSTA_Pos)
+#define   TC_SR_CLKSTA_0_Val              _U_(0x0)   /**< \brief (TC_SR) Clock is disabled. */
+#define   TC_SR_CLKSTA_1_Val              _U_(0x1)   /**< \brief (TC_SR) Clock is enabled. */
 #define TC_SR_CLKSTA_0              (TC_SR_CLKSTA_0_Val            << TC_SR_CLKSTA_Pos)
 #define TC_SR_CLKSTA_1              (TC_SR_CLKSTA_1_Val            << TC_SR_CLKSTA_Pos)
 #define TC_SR_MTIOA_Pos             17           /**< \brief (TC_SR) TIOA Mirror */
-#define TC_SR_MTIOA                 (_U(0x1) << TC_SR_MTIOA_Pos)
-#define   TC_SR_MTIOA_0_Val               _U(0x0)   /**< \brief (TC_SR) TIOA is low. If WAVE:0, this means that TIOA pin is low. If WAVE:1, this means that TIOA is driven low. */
-#define   TC_SR_MTIOA_1_Val               _U(0x1)   /**< \brief (TC_SR) TIOA is high. If WAVE:0, this means that TIOA pin is high. If WAVE:1, this means that TIOA is driven high. */
+#define TC_SR_MTIOA                 (_U_(0x1) << TC_SR_MTIOA_Pos)
+#define   TC_SR_MTIOA_0_Val               _U_(0x0)   /**< \brief (TC_SR) TIOA is low. If WAVE:0, this means that TIOA pin is low. If WAVE:1, this means that TIOA is driven low. */
+#define   TC_SR_MTIOA_1_Val               _U_(0x1)   /**< \brief (TC_SR) TIOA is high. If WAVE:0, this means that TIOA pin is high. If WAVE:1, this means that TIOA is driven high. */
 #define TC_SR_MTIOA_0               (TC_SR_MTIOA_0_Val             << TC_SR_MTIOA_Pos)
 #define TC_SR_MTIOA_1               (TC_SR_MTIOA_1_Val             << TC_SR_MTIOA_Pos)
 #define TC_SR_MTIOB_Pos             18           /**< \brief (TC_SR) TIOB Mirror */
-#define TC_SR_MTIOB                 (_U(0x1) << TC_SR_MTIOB_Pos)
-#define   TC_SR_MTIOB_0_Val               _U(0x0)   /**< \brief (TC_SR) TIOB is low. If WAVE:0, this means that TIOB pin is low. If WAVE:1, this means that TIOB is driven low. */
-#define   TC_SR_MTIOB_1_Val               _U(0x1)   /**< \brief (TC_SR) TIOB is high. If WAVE:0, this means that TIOB pin is high. If WAVE:1, this means that TIOB is driven high. */
+#define TC_SR_MTIOB                 (_U_(0x1) << TC_SR_MTIOB_Pos)
+#define   TC_SR_MTIOB_0_Val               _U_(0x0)   /**< \brief (TC_SR) TIOB is low. If WAVE:0, this means that TIOB pin is low. If WAVE:1, this means that TIOB is driven low. */
+#define   TC_SR_MTIOB_1_Val               _U_(0x1)   /**< \brief (TC_SR) TIOB is high. If WAVE:0, this means that TIOB pin is high. If WAVE:1, this means that TIOB is driven high. */
 #define TC_SR_MTIOB_0               (TC_SR_MTIOB_0_Val             << TC_SR_MTIOB_Pos)
 #define TC_SR_MTIOB_1               (TC_SR_MTIOB_1_Val             << TC_SR_MTIOB_Pos)
-#define TC_SR_MASK                  _U(0x000700FF) /**< \brief (TC_SR) MASK Register */
+#define TC_SR_MASK                  _U_(0x000700FF) /**< \brief (TC_SR) MASK Register */
 
 /* -------- TC_IER : (TC Offset: 0x24) ( /W 32) channel Interrupt Enable Register Channel -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -855,57 +855,57 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_IER_OFFSET               0x24         /**< \brief (TC_IER offset) Interrupt Enable Register Channel */
-#define TC_IER_RESETVALUE           _U(0x00000000); /**< \brief (TC_IER reset_value) Interrupt Enable Register Channel */
+#define TC_IER_RESETVALUE           _U_(0x00000000); /**< \brief (TC_IER reset_value) Interrupt Enable Register Channel */
 
 #define TC_IER_COVFS_Pos            0            /**< \brief (TC_IER) Counter Overflow */
-#define TC_IER_COVFS                (_U(0x1) << TC_IER_COVFS_Pos)
-#define   TC_IER_COVFS_0_Val              _U(0x0)   /**< \brief (TC_IER) No effect. */
-#define   TC_IER_COVFS_1_Val              _U(0x1)   /**< \brief (TC_IER) Enables the Counter Overflow Interrupt. */
+#define TC_IER_COVFS                (_U_(0x1) << TC_IER_COVFS_Pos)
+#define   TC_IER_COVFS_0_Val              _U_(0x0)   /**< \brief (TC_IER) No effect. */
+#define   TC_IER_COVFS_1_Val              _U_(0x1)   /**< \brief (TC_IER) Enables the Counter Overflow Interrupt. */
 #define TC_IER_COVFS_0              (TC_IER_COVFS_0_Val            << TC_IER_COVFS_Pos)
 #define TC_IER_COVFS_1              (TC_IER_COVFS_1_Val            << TC_IER_COVFS_Pos)
 #define TC_IER_LOVRS_Pos            1            /**< \brief (TC_IER) Load Overrun */
-#define TC_IER_LOVRS                (_U(0x1) << TC_IER_LOVRS_Pos)
-#define   TC_IER_LOVRS_0_Val              _U(0x0)   /**< \brief (TC_IER) No effect. */
-#define   TC_IER_LOVRS_1_Val              _U(0x1)   /**< \brief (TC_IER) Enables the Load Overrun Interrupt. */
+#define TC_IER_LOVRS                (_U_(0x1) << TC_IER_LOVRS_Pos)
+#define   TC_IER_LOVRS_0_Val              _U_(0x0)   /**< \brief (TC_IER) No effect. */
+#define   TC_IER_LOVRS_1_Val              _U_(0x1)   /**< \brief (TC_IER) Enables the Load Overrun Interrupt. */
 #define TC_IER_LOVRS_0              (TC_IER_LOVRS_0_Val            << TC_IER_LOVRS_Pos)
 #define TC_IER_LOVRS_1              (TC_IER_LOVRS_1_Val            << TC_IER_LOVRS_Pos)
 #define TC_IER_CPAS_Pos             2            /**< \brief (TC_IER) RA Compare */
-#define TC_IER_CPAS                 (_U(0x1) << TC_IER_CPAS_Pos)
-#define   TC_IER_CPAS_0_Val               _U(0x0)   /**< \brief (TC_IER) No effect. */
-#define   TC_IER_CPAS_1_Val               _U(0x1)   /**< \brief (TC_IER) Enables the RA Compare Interrupt. */
+#define TC_IER_CPAS                 (_U_(0x1) << TC_IER_CPAS_Pos)
+#define   TC_IER_CPAS_0_Val               _U_(0x0)   /**< \brief (TC_IER) No effect. */
+#define   TC_IER_CPAS_1_Val               _U_(0x1)   /**< \brief (TC_IER) Enables the RA Compare Interrupt. */
 #define TC_IER_CPAS_0               (TC_IER_CPAS_0_Val             << TC_IER_CPAS_Pos)
 #define TC_IER_CPAS_1               (TC_IER_CPAS_1_Val             << TC_IER_CPAS_Pos)
 #define TC_IER_CPBS_Pos             3            /**< \brief (TC_IER) RB Compare */
-#define TC_IER_CPBS                 (_U(0x1) << TC_IER_CPBS_Pos)
-#define   TC_IER_CPBS_0_Val               _U(0x0)   /**< \brief (TC_IER) No effect. */
-#define   TC_IER_CPBS_1_Val               _U(0x1)   /**< \brief (TC_IER) Enables the RB Compare Interrupt. */
+#define TC_IER_CPBS                 (_U_(0x1) << TC_IER_CPBS_Pos)
+#define   TC_IER_CPBS_0_Val               _U_(0x0)   /**< \brief (TC_IER) No effect. */
+#define   TC_IER_CPBS_1_Val               _U_(0x1)   /**< \brief (TC_IER) Enables the RB Compare Interrupt. */
 #define TC_IER_CPBS_0               (TC_IER_CPBS_0_Val             << TC_IER_CPBS_Pos)
 #define TC_IER_CPBS_1               (TC_IER_CPBS_1_Val             << TC_IER_CPBS_Pos)
 #define TC_IER_CPCS_Pos             4            /**< \brief (TC_IER) RC Compare */
-#define TC_IER_CPCS                 (_U(0x1) << TC_IER_CPCS_Pos)
-#define   TC_IER_CPCS_0_Val               _U(0x0)   /**< \brief (TC_IER) No effect. */
-#define   TC_IER_CPCS_1_Val               _U(0x1)   /**< \brief (TC_IER) Enables the RC Compare Interrupt. */
+#define TC_IER_CPCS                 (_U_(0x1) << TC_IER_CPCS_Pos)
+#define   TC_IER_CPCS_0_Val               _U_(0x0)   /**< \brief (TC_IER) No effect. */
+#define   TC_IER_CPCS_1_Val               _U_(0x1)   /**< \brief (TC_IER) Enables the RC Compare Interrupt. */
 #define TC_IER_CPCS_0               (TC_IER_CPCS_0_Val             << TC_IER_CPCS_Pos)
 #define TC_IER_CPCS_1               (TC_IER_CPCS_1_Val             << TC_IER_CPCS_Pos)
 #define TC_IER_LDRAS_Pos            5            /**< \brief (TC_IER) RA Loading */
-#define TC_IER_LDRAS                (_U(0x1) << TC_IER_LDRAS_Pos)
-#define   TC_IER_LDRAS_0_Val              _U(0x0)   /**< \brief (TC_IER) No effect. */
-#define   TC_IER_LDRAS_1_Val              _U(0x1)   /**< \brief (TC_IER) Enables the RA Load Interrupt. */
+#define TC_IER_LDRAS                (_U_(0x1) << TC_IER_LDRAS_Pos)
+#define   TC_IER_LDRAS_0_Val              _U_(0x0)   /**< \brief (TC_IER) No effect. */
+#define   TC_IER_LDRAS_1_Val              _U_(0x1)   /**< \brief (TC_IER) Enables the RA Load Interrupt. */
 #define TC_IER_LDRAS_0              (TC_IER_LDRAS_0_Val            << TC_IER_LDRAS_Pos)
 #define TC_IER_LDRAS_1              (TC_IER_LDRAS_1_Val            << TC_IER_LDRAS_Pos)
 #define TC_IER_LDRBS_Pos            6            /**< \brief (TC_IER) RB Loading */
-#define TC_IER_LDRBS                (_U(0x1) << TC_IER_LDRBS_Pos)
-#define   TC_IER_LDRBS_0_Val              _U(0x0)   /**< \brief (TC_IER) No effect. */
-#define   TC_IER_LDRBS_1_Val              _U(0x1)   /**< \brief (TC_IER) Enables the RB Load Interrupt. */
+#define TC_IER_LDRBS                (_U_(0x1) << TC_IER_LDRBS_Pos)
+#define   TC_IER_LDRBS_0_Val              _U_(0x0)   /**< \brief (TC_IER) No effect. */
+#define   TC_IER_LDRBS_1_Val              _U_(0x1)   /**< \brief (TC_IER) Enables the RB Load Interrupt. */
 #define TC_IER_LDRBS_0              (TC_IER_LDRBS_0_Val            << TC_IER_LDRBS_Pos)
 #define TC_IER_LDRBS_1              (TC_IER_LDRBS_1_Val            << TC_IER_LDRBS_Pos)
 #define TC_IER_ETRGS_Pos            7            /**< \brief (TC_IER) External Trigger */
-#define TC_IER_ETRGS                (_U(0x1) << TC_IER_ETRGS_Pos)
-#define   TC_IER_ETRGS_0_Val              _U(0x0)   /**< \brief (TC_IER) No effect. */
-#define   TC_IER_ETRGS_1_Val              _U(0x1)   /**< \brief (TC_IER) Enables the External Trigger Interrupt. */
+#define TC_IER_ETRGS                (_U_(0x1) << TC_IER_ETRGS_Pos)
+#define   TC_IER_ETRGS_0_Val              _U_(0x0)   /**< \brief (TC_IER) No effect. */
+#define   TC_IER_ETRGS_1_Val              _U_(0x1)   /**< \brief (TC_IER) Enables the External Trigger Interrupt. */
 #define TC_IER_ETRGS_0              (TC_IER_ETRGS_0_Val            << TC_IER_ETRGS_Pos)
 #define TC_IER_ETRGS_1              (TC_IER_ETRGS_1_Val            << TC_IER_ETRGS_Pos)
-#define TC_IER_MASK                 _U(0x000000FF) /**< \brief (TC_IER) MASK Register */
+#define TC_IER_MASK                 _U_(0x000000FF) /**< \brief (TC_IER) MASK Register */
 
 /* -------- TC_IDR : (TC Offset: 0x28) ( /W 32) channel Interrupt Disable Register Channel -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -926,57 +926,57 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_IDR_OFFSET               0x28         /**< \brief (TC_IDR offset) Interrupt Disable Register Channel */
-#define TC_IDR_RESETVALUE           _U(0x00000000); /**< \brief (TC_IDR reset_value) Interrupt Disable Register Channel */
+#define TC_IDR_RESETVALUE           _U_(0x00000000); /**< \brief (TC_IDR reset_value) Interrupt Disable Register Channel */
 
 #define TC_IDR_COVFS_Pos            0            /**< \brief (TC_IDR) Counter Overflow */
-#define TC_IDR_COVFS                (_U(0x1) << TC_IDR_COVFS_Pos)
-#define   TC_IDR_COVFS_0_Val              _U(0x0)   /**< \brief (TC_IDR) No effect. */
-#define   TC_IDR_COVFS_1_Val              _U(0x1)   /**< \brief (TC_IDR) Disables the Counter Overflow Interrupt. */
+#define TC_IDR_COVFS                (_U_(0x1) << TC_IDR_COVFS_Pos)
+#define   TC_IDR_COVFS_0_Val              _U_(0x0)   /**< \brief (TC_IDR) No effect. */
+#define   TC_IDR_COVFS_1_Val              _U_(0x1)   /**< \brief (TC_IDR) Disables the Counter Overflow Interrupt. */
 #define TC_IDR_COVFS_0              (TC_IDR_COVFS_0_Val            << TC_IDR_COVFS_Pos)
 #define TC_IDR_COVFS_1              (TC_IDR_COVFS_1_Val            << TC_IDR_COVFS_Pos)
 #define TC_IDR_LOVRS_Pos            1            /**< \brief (TC_IDR) Load Overrun */
-#define TC_IDR_LOVRS                (_U(0x1) << TC_IDR_LOVRS_Pos)
-#define   TC_IDR_LOVRS_0_Val              _U(0x0)   /**< \brief (TC_IDR) No effect. */
-#define   TC_IDR_LOVRS_1_Val              _U(0x1)   /**< \brief (TC_IDR) Disables the Load Overrun Interrupt (if WAVE:0). */
+#define TC_IDR_LOVRS                (_U_(0x1) << TC_IDR_LOVRS_Pos)
+#define   TC_IDR_LOVRS_0_Val              _U_(0x0)   /**< \brief (TC_IDR) No effect. */
+#define   TC_IDR_LOVRS_1_Val              _U_(0x1)   /**< \brief (TC_IDR) Disables the Load Overrun Interrupt (if WAVE:0). */
 #define TC_IDR_LOVRS_0              (TC_IDR_LOVRS_0_Val            << TC_IDR_LOVRS_Pos)
 #define TC_IDR_LOVRS_1              (TC_IDR_LOVRS_1_Val            << TC_IDR_LOVRS_Pos)
 #define TC_IDR_CPAS_Pos             2            /**< \brief (TC_IDR) RA Compare */
-#define TC_IDR_CPAS                 (_U(0x1) << TC_IDR_CPAS_Pos)
-#define   TC_IDR_CPAS_0_Val               _U(0x0)   /**< \brief (TC_IDR) No effect. */
-#define   TC_IDR_CPAS_1_Val               _U(0x1)   /**< \brief (TC_IDR) Disables the RA Compare Interrupt (if WAVE:1). */
+#define TC_IDR_CPAS                 (_U_(0x1) << TC_IDR_CPAS_Pos)
+#define   TC_IDR_CPAS_0_Val               _U_(0x0)   /**< \brief (TC_IDR) No effect. */
+#define   TC_IDR_CPAS_1_Val               _U_(0x1)   /**< \brief (TC_IDR) Disables the RA Compare Interrupt (if WAVE:1). */
 #define TC_IDR_CPAS_0               (TC_IDR_CPAS_0_Val             << TC_IDR_CPAS_Pos)
 #define TC_IDR_CPAS_1               (TC_IDR_CPAS_1_Val             << TC_IDR_CPAS_Pos)
 #define TC_IDR_CPBS_Pos             3            /**< \brief (TC_IDR) RB Compare */
-#define TC_IDR_CPBS                 (_U(0x1) << TC_IDR_CPBS_Pos)
-#define   TC_IDR_CPBS_0_Val               _U(0x0)   /**< \brief (TC_IDR) No effect. */
-#define   TC_IDR_CPBS_1_Val               _U(0x1)   /**< \brief (TC_IDR) Disables the RB Compare Interrupt (if WAVE:1). */
+#define TC_IDR_CPBS                 (_U_(0x1) << TC_IDR_CPBS_Pos)
+#define   TC_IDR_CPBS_0_Val               _U_(0x0)   /**< \brief (TC_IDR) No effect. */
+#define   TC_IDR_CPBS_1_Val               _U_(0x1)   /**< \brief (TC_IDR) Disables the RB Compare Interrupt (if WAVE:1). */
 #define TC_IDR_CPBS_0               (TC_IDR_CPBS_0_Val             << TC_IDR_CPBS_Pos)
 #define TC_IDR_CPBS_1               (TC_IDR_CPBS_1_Val             << TC_IDR_CPBS_Pos)
 #define TC_IDR_CPCS_Pos             4            /**< \brief (TC_IDR) RC Compare */
-#define TC_IDR_CPCS                 (_U(0x1) << TC_IDR_CPCS_Pos)
-#define   TC_IDR_CPCS_0_Val               _U(0x0)   /**< \brief (TC_IDR) No effect. */
-#define   TC_IDR_CPCS_1_Val               _U(0x1)   /**< \brief (TC_IDR) Disables the RC Compare Interrupt. */
+#define TC_IDR_CPCS                 (_U_(0x1) << TC_IDR_CPCS_Pos)
+#define   TC_IDR_CPCS_0_Val               _U_(0x0)   /**< \brief (TC_IDR) No effect. */
+#define   TC_IDR_CPCS_1_Val               _U_(0x1)   /**< \brief (TC_IDR) Disables the RC Compare Interrupt. */
 #define TC_IDR_CPCS_0               (TC_IDR_CPCS_0_Val             << TC_IDR_CPCS_Pos)
 #define TC_IDR_CPCS_1               (TC_IDR_CPCS_1_Val             << TC_IDR_CPCS_Pos)
 #define TC_IDR_LDRAS_Pos            5            /**< \brief (TC_IDR) RA Loading */
-#define TC_IDR_LDRAS                (_U(0x1) << TC_IDR_LDRAS_Pos)
-#define   TC_IDR_LDRAS_0_Val              _U(0x0)   /**< \brief (TC_IDR) No effect. */
-#define   TC_IDR_LDRAS_1_Val              _U(0x1)   /**< \brief (TC_IDR) Disables the RA Load Interrupt (if WAVE:0). */
+#define TC_IDR_LDRAS                (_U_(0x1) << TC_IDR_LDRAS_Pos)
+#define   TC_IDR_LDRAS_0_Val              _U_(0x0)   /**< \brief (TC_IDR) No effect. */
+#define   TC_IDR_LDRAS_1_Val              _U_(0x1)   /**< \brief (TC_IDR) Disables the RA Load Interrupt (if WAVE:0). */
 #define TC_IDR_LDRAS_0              (TC_IDR_LDRAS_0_Val            << TC_IDR_LDRAS_Pos)
 #define TC_IDR_LDRAS_1              (TC_IDR_LDRAS_1_Val            << TC_IDR_LDRAS_Pos)
 #define TC_IDR_LDRBS_Pos            6            /**< \brief (TC_IDR) RB Loading */
-#define TC_IDR_LDRBS                (_U(0x1) << TC_IDR_LDRBS_Pos)
-#define   TC_IDR_LDRBS_0_Val              _U(0x0)   /**< \brief (TC_IDR) No effect. */
-#define   TC_IDR_LDRBS_1_Val              _U(0x1)   /**< \brief (TC_IDR) Disables the RB Load Interrupt (if WAVE:0). */
+#define TC_IDR_LDRBS                (_U_(0x1) << TC_IDR_LDRBS_Pos)
+#define   TC_IDR_LDRBS_0_Val              _U_(0x0)   /**< \brief (TC_IDR) No effect. */
+#define   TC_IDR_LDRBS_1_Val              _U_(0x1)   /**< \brief (TC_IDR) Disables the RB Load Interrupt (if WAVE:0). */
 #define TC_IDR_LDRBS_0              (TC_IDR_LDRBS_0_Val            << TC_IDR_LDRBS_Pos)
 #define TC_IDR_LDRBS_1              (TC_IDR_LDRBS_1_Val            << TC_IDR_LDRBS_Pos)
 #define TC_IDR_ETRGS_Pos            7            /**< \brief (TC_IDR) External Trigger */
-#define TC_IDR_ETRGS                (_U(0x1) << TC_IDR_ETRGS_Pos)
-#define   TC_IDR_ETRGS_0_Val              _U(0x0)   /**< \brief (TC_IDR) No effect. */
-#define   TC_IDR_ETRGS_1_Val              _U(0x1)   /**< \brief (TC_IDR) Disables the External Trigger Interrupt. */
+#define TC_IDR_ETRGS                (_U_(0x1) << TC_IDR_ETRGS_Pos)
+#define   TC_IDR_ETRGS_0_Val              _U_(0x0)   /**< \brief (TC_IDR) No effect. */
+#define   TC_IDR_ETRGS_1_Val              _U_(0x1)   /**< \brief (TC_IDR) Disables the External Trigger Interrupt. */
 #define TC_IDR_ETRGS_0              (TC_IDR_ETRGS_0_Val            << TC_IDR_ETRGS_Pos)
 #define TC_IDR_ETRGS_1              (TC_IDR_ETRGS_1_Val            << TC_IDR_ETRGS_Pos)
-#define TC_IDR_MASK                 _U(0x000000FF) /**< \brief (TC_IDR) MASK Register */
+#define TC_IDR_MASK                 _U_(0x000000FF) /**< \brief (TC_IDR) MASK Register */
 
 /* -------- TC_IMR : (TC Offset: 0x2C) (R/  32) channel Interrupt Mask Register Channel -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -997,57 +997,57 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_IMR_OFFSET               0x2C         /**< \brief (TC_IMR offset) Interrupt Mask Register Channel */
-#define TC_IMR_RESETVALUE           _U(0x00000000); /**< \brief (TC_IMR reset_value) Interrupt Mask Register Channel */
+#define TC_IMR_RESETVALUE           _U_(0x00000000); /**< \brief (TC_IMR reset_value) Interrupt Mask Register Channel */
 
 #define TC_IMR_COVFS_Pos            0            /**< \brief (TC_IMR) Counter Overflow */
-#define TC_IMR_COVFS                (_U(0x1) << TC_IMR_COVFS_Pos)
-#define   TC_IMR_COVFS_0_Val              _U(0x0)   /**< \brief (TC_IMR) The Counter Overflow Interrupt is disabled. */
-#define   TC_IMR_COVFS_1_Val              _U(0x1)   /**< \brief (TC_IMR) The Counter Overflow Interrupt is enabled. */
+#define TC_IMR_COVFS                (_U_(0x1) << TC_IMR_COVFS_Pos)
+#define   TC_IMR_COVFS_0_Val              _U_(0x0)   /**< \brief (TC_IMR) The Counter Overflow Interrupt is disabled. */
+#define   TC_IMR_COVFS_1_Val              _U_(0x1)   /**< \brief (TC_IMR) The Counter Overflow Interrupt is enabled. */
 #define TC_IMR_COVFS_0              (TC_IMR_COVFS_0_Val            << TC_IMR_COVFS_Pos)
 #define TC_IMR_COVFS_1              (TC_IMR_COVFS_1_Val            << TC_IMR_COVFS_Pos)
 #define TC_IMR_LOVRS_Pos            1            /**< \brief (TC_IMR) Load Overrun */
-#define TC_IMR_LOVRS                (_U(0x1) << TC_IMR_LOVRS_Pos)
-#define   TC_IMR_LOVRS_0_Val              _U(0x0)   /**< \brief (TC_IMR) The Load Overrun Interrupt is disabled. */
-#define   TC_IMR_LOVRS_1_Val              _U(0x1)   /**< \brief (TC_IMR) The Load Overrun Interrupt is enabled. */
+#define TC_IMR_LOVRS                (_U_(0x1) << TC_IMR_LOVRS_Pos)
+#define   TC_IMR_LOVRS_0_Val              _U_(0x0)   /**< \brief (TC_IMR) The Load Overrun Interrupt is disabled. */
+#define   TC_IMR_LOVRS_1_Val              _U_(0x1)   /**< \brief (TC_IMR) The Load Overrun Interrupt is enabled. */
 #define TC_IMR_LOVRS_0              (TC_IMR_LOVRS_0_Val            << TC_IMR_LOVRS_Pos)
 #define TC_IMR_LOVRS_1              (TC_IMR_LOVRS_1_Val            << TC_IMR_LOVRS_Pos)
 #define TC_IMR_CPAS_Pos             2            /**< \brief (TC_IMR) RA Compare */
-#define TC_IMR_CPAS                 (_U(0x1) << TC_IMR_CPAS_Pos)
-#define   TC_IMR_CPAS_0_Val               _U(0x0)   /**< \brief (TC_IMR) The RA Compare Interrupt is disabled. */
-#define   TC_IMR_CPAS_1_Val               _U(0x1)   /**< \brief (TC_IMR) The RA Compare Interrupt is enabled. */
+#define TC_IMR_CPAS                 (_U_(0x1) << TC_IMR_CPAS_Pos)
+#define   TC_IMR_CPAS_0_Val               _U_(0x0)   /**< \brief (TC_IMR) The RA Compare Interrupt is disabled. */
+#define   TC_IMR_CPAS_1_Val               _U_(0x1)   /**< \brief (TC_IMR) The RA Compare Interrupt is enabled. */
 #define TC_IMR_CPAS_0               (TC_IMR_CPAS_0_Val             << TC_IMR_CPAS_Pos)
 #define TC_IMR_CPAS_1               (TC_IMR_CPAS_1_Val             << TC_IMR_CPAS_Pos)
 #define TC_IMR_CPBS_Pos             3            /**< \brief (TC_IMR) RB Compare */
-#define TC_IMR_CPBS                 (_U(0x1) << TC_IMR_CPBS_Pos)
-#define   TC_IMR_CPBS_0_Val               _U(0x0)   /**< \brief (TC_IMR) The RB Compare Interrupt is disabled. */
-#define   TC_IMR_CPBS_1_Val               _U(0x1)   /**< \brief (TC_IMR) The RB Compare Interrupt is enabled. */
+#define TC_IMR_CPBS                 (_U_(0x1) << TC_IMR_CPBS_Pos)
+#define   TC_IMR_CPBS_0_Val               _U_(0x0)   /**< \brief (TC_IMR) The RB Compare Interrupt is disabled. */
+#define   TC_IMR_CPBS_1_Val               _U_(0x1)   /**< \brief (TC_IMR) The RB Compare Interrupt is enabled. */
 #define TC_IMR_CPBS_0               (TC_IMR_CPBS_0_Val             << TC_IMR_CPBS_Pos)
 #define TC_IMR_CPBS_1               (TC_IMR_CPBS_1_Val             << TC_IMR_CPBS_Pos)
 #define TC_IMR_CPCS_Pos             4            /**< \brief (TC_IMR) RC Compare */
-#define TC_IMR_CPCS                 (_U(0x1) << TC_IMR_CPCS_Pos)
-#define   TC_IMR_CPCS_0_Val               _U(0x0)   /**< \brief (TC_IMR) The RC Compare Interrupt is disabled. */
-#define   TC_IMR_CPCS_1_Val               _U(0x1)   /**< \brief (TC_IMR) The RC Compare Interrupt is enabled. */
+#define TC_IMR_CPCS                 (_U_(0x1) << TC_IMR_CPCS_Pos)
+#define   TC_IMR_CPCS_0_Val               _U_(0x0)   /**< \brief (TC_IMR) The RC Compare Interrupt is disabled. */
+#define   TC_IMR_CPCS_1_Val               _U_(0x1)   /**< \brief (TC_IMR) The RC Compare Interrupt is enabled. */
 #define TC_IMR_CPCS_0               (TC_IMR_CPCS_0_Val             << TC_IMR_CPCS_Pos)
 #define TC_IMR_CPCS_1               (TC_IMR_CPCS_1_Val             << TC_IMR_CPCS_Pos)
 #define TC_IMR_LDRAS_Pos            5            /**< \brief (TC_IMR) RA Loading */
-#define TC_IMR_LDRAS                (_U(0x1) << TC_IMR_LDRAS_Pos)
-#define   TC_IMR_LDRAS_0_Val              _U(0x0)   /**< \brief (TC_IMR) The Load RA Interrupt is disabled. */
-#define   TC_IMR_LDRAS_1_Val              _U(0x1)   /**< \brief (TC_IMR) The Load RA Interrupt is enabled. */
+#define TC_IMR_LDRAS                (_U_(0x1) << TC_IMR_LDRAS_Pos)
+#define   TC_IMR_LDRAS_0_Val              _U_(0x0)   /**< \brief (TC_IMR) The Load RA Interrupt is disabled. */
+#define   TC_IMR_LDRAS_1_Val              _U_(0x1)   /**< \brief (TC_IMR) The Load RA Interrupt is enabled. */
 #define TC_IMR_LDRAS_0              (TC_IMR_LDRAS_0_Val            << TC_IMR_LDRAS_Pos)
 #define TC_IMR_LDRAS_1              (TC_IMR_LDRAS_1_Val            << TC_IMR_LDRAS_Pos)
 #define TC_IMR_LDRBS_Pos            6            /**< \brief (TC_IMR) RB Loading */
-#define TC_IMR_LDRBS                (_U(0x1) << TC_IMR_LDRBS_Pos)
-#define   TC_IMR_LDRBS_0_Val              _U(0x0)   /**< \brief (TC_IMR) The Load RB Interrupt is disabled. */
-#define   TC_IMR_LDRBS_1_Val              _U(0x1)   /**< \brief (TC_IMR) The Load RB Interrupt is enabled. */
+#define TC_IMR_LDRBS                (_U_(0x1) << TC_IMR_LDRBS_Pos)
+#define   TC_IMR_LDRBS_0_Val              _U_(0x0)   /**< \brief (TC_IMR) The Load RB Interrupt is disabled. */
+#define   TC_IMR_LDRBS_1_Val              _U_(0x1)   /**< \brief (TC_IMR) The Load RB Interrupt is enabled. */
 #define TC_IMR_LDRBS_0              (TC_IMR_LDRBS_0_Val            << TC_IMR_LDRBS_Pos)
 #define TC_IMR_LDRBS_1              (TC_IMR_LDRBS_1_Val            << TC_IMR_LDRBS_Pos)
 #define TC_IMR_ETRGS_Pos            7            /**< \brief (TC_IMR) External Trigger */
-#define TC_IMR_ETRGS                (_U(0x1) << TC_IMR_ETRGS_Pos)
-#define   TC_IMR_ETRGS_0_Val              _U(0x0)   /**< \brief (TC_IMR) The External Trigger Interrupt is disabled. */
-#define   TC_IMR_ETRGS_1_Val              _U(0x1)   /**< \brief (TC_IMR) The External Trigger Interrupt is enabled. */
+#define TC_IMR_ETRGS                (_U_(0x1) << TC_IMR_ETRGS_Pos)
+#define   TC_IMR_ETRGS_0_Val              _U_(0x0)   /**< \brief (TC_IMR) The External Trigger Interrupt is disabled. */
+#define   TC_IMR_ETRGS_1_Val              _U_(0x1)   /**< \brief (TC_IMR) The External Trigger Interrupt is enabled. */
 #define TC_IMR_ETRGS_0              (TC_IMR_ETRGS_0_Val            << TC_IMR_ETRGS_Pos)
 #define TC_IMR_ETRGS_1              (TC_IMR_ETRGS_1_Val            << TC_IMR_ETRGS_Pos)
-#define TC_IMR_MASK                 _U(0x000000FF) /**< \brief (TC_IMR) MASK Register */
+#define TC_IMR_MASK                 _U_(0x000000FF) /**< \brief (TC_IMR) MASK Register */
 
 /* -------- TC_BCR : (TC Offset: 0xC0) ( /W 32) TC Block Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1061,15 +1061,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_BCR_OFFSET               0xC0         /**< \brief (TC_BCR offset) TC Block Control Register */
-#define TC_BCR_RESETVALUE           _U(0x00000000); /**< \brief (TC_BCR reset_value) TC Block Control Register */
+#define TC_BCR_RESETVALUE           _U_(0x00000000); /**< \brief (TC_BCR reset_value) TC Block Control Register */
 
 #define TC_BCR_SYNC_Pos             0            /**< \brief (TC_BCR) Synchro Command */
-#define TC_BCR_SYNC                 (_U(0x1) << TC_BCR_SYNC_Pos)
-#define   TC_BCR_SYNC_0_Val               _U(0x0)   /**< \brief (TC_BCR) No effect. */
-#define   TC_BCR_SYNC_1_Val               _U(0x1)   /**< \brief (TC_BCR) Asserts the SYNC signal which generates a software trigger simultaneously for each of the channels. */
+#define TC_BCR_SYNC                 (_U_(0x1) << TC_BCR_SYNC_Pos)
+#define   TC_BCR_SYNC_0_Val               _U_(0x0)   /**< \brief (TC_BCR) No effect. */
+#define   TC_BCR_SYNC_1_Val               _U_(0x1)   /**< \brief (TC_BCR) Asserts the SYNC signal which generates a software trigger simultaneously for each of the channels. */
 #define TC_BCR_SYNC_0               (TC_BCR_SYNC_0_Val             << TC_BCR_SYNC_Pos)
 #define TC_BCR_SYNC_1               (TC_BCR_SYNC_1_Val             << TC_BCR_SYNC_Pos)
-#define TC_BCR_MASK                 _U(0x00000001) /**< \brief (TC_BCR) MASK Register */
+#define TC_BCR_MASK                 _U_(0x00000001) /**< \brief (TC_BCR) MASK Register */
 
 /* -------- TC_BMR : (TC Offset: 0xC4) (R/W 32) TC Block Mode Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1085,42 +1085,42 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_BMR_OFFSET               0xC4         /**< \brief (TC_BMR offset) TC Block Mode Register */
-#define TC_BMR_RESETVALUE           _U(0x00000000); /**< \brief (TC_BMR reset_value) TC Block Mode Register */
+#define TC_BMR_RESETVALUE           _U_(0x00000000); /**< \brief (TC_BMR reset_value) TC Block Mode Register */
 
 #define TC_BMR_TC0XC0S_Pos          0            /**< \brief (TC_BMR) External Clock Signal 0 Selection */
-#define TC_BMR_TC0XC0S_Msk          (_U(0x3) << TC_BMR_TC0XC0S_Pos)
+#define TC_BMR_TC0XC0S_Msk          (_U_(0x3) << TC_BMR_TC0XC0S_Pos)
 #define TC_BMR_TC0XC0S(value)       (TC_BMR_TC0XC0S_Msk & ((value) << TC_BMR_TC0XC0S_Pos))
-#define   TC_BMR_TC0XC0S_TCLK0_Val        _U(0x0)   /**< \brief (TC_BMR) Select TCLK0 as clock signal 0. */
-#define   TC_BMR_TC0XC0S_NO_CLK_Val       _U(0x1)   /**< \brief (TC_BMR) Select no clock as clock signal 0. */
-#define   TC_BMR_TC0XC0S_TIOA1_Val        _U(0x2)   /**< \brief (TC_BMR) Select TIOA1 as clock signal 0. */
-#define   TC_BMR_TC0XC0S_TIOA2_Val        _U(0x3)   /**< \brief (TC_BMR) Select TIOA2 as clock signal 0. */
+#define   TC_BMR_TC0XC0S_TCLK0_Val        _U_(0x0)   /**< \brief (TC_BMR) Select TCLK0 as clock signal 0. */
+#define   TC_BMR_TC0XC0S_NO_CLK_Val       _U_(0x1)   /**< \brief (TC_BMR) Select no clock as clock signal 0. */
+#define   TC_BMR_TC0XC0S_TIOA1_Val        _U_(0x2)   /**< \brief (TC_BMR) Select TIOA1 as clock signal 0. */
+#define   TC_BMR_TC0XC0S_TIOA2_Val        _U_(0x3)   /**< \brief (TC_BMR) Select TIOA2 as clock signal 0. */
 #define TC_BMR_TC0XC0S_TCLK0        (TC_BMR_TC0XC0S_TCLK0_Val      << TC_BMR_TC0XC0S_Pos)
 #define TC_BMR_TC0XC0S_NO_CLK       (TC_BMR_TC0XC0S_NO_CLK_Val     << TC_BMR_TC0XC0S_Pos)
 #define TC_BMR_TC0XC0S_TIOA1        (TC_BMR_TC0XC0S_TIOA1_Val      << TC_BMR_TC0XC0S_Pos)
 #define TC_BMR_TC0XC0S_TIOA2        (TC_BMR_TC0XC0S_TIOA2_Val      << TC_BMR_TC0XC0S_Pos)
 #define TC_BMR_TC1XC1S_Pos          2            /**< \brief (TC_BMR) External Clock Signal 1 Selection */
-#define TC_BMR_TC1XC1S_Msk          (_U(0x3) << TC_BMR_TC1XC1S_Pos)
+#define TC_BMR_TC1XC1S_Msk          (_U_(0x3) << TC_BMR_TC1XC1S_Pos)
 #define TC_BMR_TC1XC1S(value)       (TC_BMR_TC1XC1S_Msk & ((value) << TC_BMR_TC1XC1S_Pos))
-#define   TC_BMR_TC1XC1S_TCLK1_Val        _U(0x0)   /**< \brief (TC_BMR) Select TCLK1 as clock signal 1. */
-#define   TC_BMR_TC1XC1S_NO_CLK_Val       _U(0x1)   /**< \brief (TC_BMR) Select no clock as clock signal 1. */
-#define   TC_BMR_TC1XC1S_TIOA0_Val        _U(0x2)   /**< \brief (TC_BMR) Select TIOA0 as clock signal 1. */
-#define   TC_BMR_TC1XC1S_TIOA2_Val        _U(0x3)   /**< \brief (TC_BMR) Select TIOA2 as clock signal 1. */
+#define   TC_BMR_TC1XC1S_TCLK1_Val        _U_(0x0)   /**< \brief (TC_BMR) Select TCLK1 as clock signal 1. */
+#define   TC_BMR_TC1XC1S_NO_CLK_Val       _U_(0x1)   /**< \brief (TC_BMR) Select no clock as clock signal 1. */
+#define   TC_BMR_TC1XC1S_TIOA0_Val        _U_(0x2)   /**< \brief (TC_BMR) Select TIOA0 as clock signal 1. */
+#define   TC_BMR_TC1XC1S_TIOA2_Val        _U_(0x3)   /**< \brief (TC_BMR) Select TIOA2 as clock signal 1. */
 #define TC_BMR_TC1XC1S_TCLK1        (TC_BMR_TC1XC1S_TCLK1_Val      << TC_BMR_TC1XC1S_Pos)
 #define TC_BMR_TC1XC1S_NO_CLK       (TC_BMR_TC1XC1S_NO_CLK_Val     << TC_BMR_TC1XC1S_Pos)
 #define TC_BMR_TC1XC1S_TIOA0        (TC_BMR_TC1XC1S_TIOA0_Val      << TC_BMR_TC1XC1S_Pos)
 #define TC_BMR_TC1XC1S_TIOA2        (TC_BMR_TC1XC1S_TIOA2_Val      << TC_BMR_TC1XC1S_Pos)
 #define TC_BMR_TC2XC2S_Pos          4            /**< \brief (TC_BMR) External Clock Signal 2 Selection */
-#define TC_BMR_TC2XC2S_Msk          (_U(0x3) << TC_BMR_TC2XC2S_Pos)
+#define TC_BMR_TC2XC2S_Msk          (_U_(0x3) << TC_BMR_TC2XC2S_Pos)
 #define TC_BMR_TC2XC2S(value)       (TC_BMR_TC2XC2S_Msk & ((value) << TC_BMR_TC2XC2S_Pos))
-#define   TC_BMR_TC2XC2S_TCLK2_Val        _U(0x0)   /**< \brief (TC_BMR) Select TCLK2 as clock signal 2. */
-#define   TC_BMR_TC2XC2S_NO_CLK_Val       _U(0x1)   /**< \brief (TC_BMR) Select no clock as clock signal 2. */
-#define   TC_BMR_TC2XC2S_TIOA0_Val        _U(0x2)   /**< \brief (TC_BMR) Select TIOA0 as clock signal 2. */
-#define   TC_BMR_TC2XC2S_TIOA1_Val        _U(0x3)   /**< \brief (TC_BMR) Select TIOA1 as clock signal 2. */
+#define   TC_BMR_TC2XC2S_TCLK2_Val        _U_(0x0)   /**< \brief (TC_BMR) Select TCLK2 as clock signal 2. */
+#define   TC_BMR_TC2XC2S_NO_CLK_Val       _U_(0x1)   /**< \brief (TC_BMR) Select no clock as clock signal 2. */
+#define   TC_BMR_TC2XC2S_TIOA0_Val        _U_(0x2)   /**< \brief (TC_BMR) Select TIOA0 as clock signal 2. */
+#define   TC_BMR_TC2XC2S_TIOA1_Val        _U_(0x3)   /**< \brief (TC_BMR) Select TIOA1 as clock signal 2. */
 #define TC_BMR_TC2XC2S_TCLK2        (TC_BMR_TC2XC2S_TCLK2_Val      << TC_BMR_TC2XC2S_Pos)
 #define TC_BMR_TC2XC2S_NO_CLK       (TC_BMR_TC2XC2S_NO_CLK_Val     << TC_BMR_TC2XC2S_Pos)
 #define TC_BMR_TC2XC2S_TIOA0        (TC_BMR_TC2XC2S_TIOA0_Val      << TC_BMR_TC2XC2S_Pos)
 #define TC_BMR_TC2XC2S_TIOA1        (TC_BMR_TC2XC2S_TIOA1_Val      << TC_BMR_TC2XC2S_Pos)
-#define TC_BMR_MASK                 _U(0x0000003F) /**< \brief (TC_BMR) MASK Register */
+#define TC_BMR_MASK                 _U_(0x0000003F) /**< \brief (TC_BMR) MASK Register */
 
 /* -------- TC_WPMR : (TC Offset: 0xE4) (R/W 32) Write Protect Mode Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1135,14 +1135,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_WPMR_OFFSET              0xE4         /**< \brief (TC_WPMR offset) Write Protect Mode Register */
-#define TC_WPMR_RESETVALUE          _U(0x00000000); /**< \brief (TC_WPMR reset_value) Write Protect Mode Register */
+#define TC_WPMR_RESETVALUE          _U_(0x00000000); /**< \brief (TC_WPMR reset_value) Write Protect Mode Register */
 
 #define TC_WPMR_WPEN_Pos            0            /**< \brief (TC_WPMR) Write Protect Enable */
-#define TC_WPMR_WPEN                (_U(0x1) << TC_WPMR_WPEN_Pos)
+#define TC_WPMR_WPEN                (_U_(0x1) << TC_WPMR_WPEN_Pos)
 #define TC_WPMR_WPKEY_Pos           8            /**< \brief (TC_WPMR) Write Protect Key */
-#define TC_WPMR_WPKEY_Msk           (_U(0xFFFFFF) << TC_WPMR_WPKEY_Pos)
+#define TC_WPMR_WPKEY_Msk           (_U_(0xFFFFFF) << TC_WPMR_WPKEY_Pos)
 #define TC_WPMR_WPKEY(value)        (TC_WPMR_WPKEY_Msk & ((value) << TC_WPMR_WPKEY_Pos))
-#define TC_WPMR_MASK                _U(0xFFFFFF01) /**< \brief (TC_WPMR) MASK Register */
+#define TC_WPMR_MASK                _U_(0xFFFFFF01) /**< \brief (TC_WPMR) MASK Register */
 
 /* -------- TC_FEATURES : (TC Offset: 0xF8) (R/  32) Features Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1160,13 +1160,13 @@ typedef union {
 #define TC_FEATURES_OFFSET          0xF8         /**< \brief (TC_FEATURES offset) Features Register */
 
 #define TC_FEATURES_CTRSIZE_Pos     0            /**< \brief (TC_FEATURES) Counter Size */
-#define TC_FEATURES_CTRSIZE_Msk     (_U(0xFF) << TC_FEATURES_CTRSIZE_Pos)
+#define TC_FEATURES_CTRSIZE_Msk     (_U_(0xFF) << TC_FEATURES_CTRSIZE_Pos)
 #define TC_FEATURES_CTRSIZE(value)  (TC_FEATURES_CTRSIZE_Msk & ((value) << TC_FEATURES_CTRSIZE_Pos))
 #define TC_FEATURES_UPDNIMPL_Pos    8            /**< \brief (TC_FEATURES) Up Down is Implemented */
-#define TC_FEATURES_UPDNIMPL        (_U(0x1) << TC_FEATURES_UPDNIMPL_Pos)
+#define TC_FEATURES_UPDNIMPL        (_U_(0x1) << TC_FEATURES_UPDNIMPL_Pos)
 #define TC_FEATURES_BRPBHSB_Pos     9            /**< \brief (TC_FEATURES) Bridge Type is PB to HSB */
-#define TC_FEATURES_BRPBHSB         (_U(0x1) << TC_FEATURES_BRPBHSB_Pos)
-#define TC_FEATURES_MASK            _U(0x000003FF) /**< \brief (TC_FEATURES) MASK Register */
+#define TC_FEATURES_BRPBHSB         (_U_(0x1) << TC_FEATURES_BRPBHSB_Pos)
+#define TC_FEATURES_MASK            _U_(0x000003FF) /**< \brief (TC_FEATURES) MASK Register */
 
 /* -------- TC_VERSION : (TC Offset: 0xFC) (R/  32) Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1182,15 +1182,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_VERSION_OFFSET           0xFC         /**< \brief (TC_VERSION offset) Version Register */
-#define TC_VERSION_RESETVALUE       _U(0x00000402); /**< \brief (TC_VERSION reset_value) Version Register */
+#define TC_VERSION_RESETVALUE       _U_(0x00000402); /**< \brief (TC_VERSION reset_value) Version Register */
 
 #define TC_VERSION_VERSION_Pos      0            /**< \brief (TC_VERSION) Reserved. Value subject to change. No functionality associated. This is the Atmel internal version of the macrocell. */
-#define TC_VERSION_VERSION_Msk      (_U(0xFFF) << TC_VERSION_VERSION_Pos)
+#define TC_VERSION_VERSION_Msk      (_U_(0xFFF) << TC_VERSION_VERSION_Pos)
 #define TC_VERSION_VERSION(value)   (TC_VERSION_VERSION_Msk & ((value) << TC_VERSION_VERSION_Pos))
 #define TC_VERSION_VARIANT_Pos      16           /**< \brief (TC_VERSION) Reserved.  Value subject to change.  No functionality associated. */
-#define TC_VERSION_VARIANT_Msk      (_U(0xF) << TC_VERSION_VARIANT_Pos)
+#define TC_VERSION_VARIANT_Msk      (_U_(0xF) << TC_VERSION_VARIANT_Pos)
 #define TC_VERSION_VARIANT(value)   (TC_VERSION_VARIANT_Msk & ((value) << TC_VERSION_VARIANT_Pos))
-#define TC_VERSION_MASK             _U(0x000F0FFF) /**< \brief (TC_VERSION) MASK Register */
+#define TC_VERSION_MASK             _U_(0x000F0FFF) /**< \brief (TC_VERSION) MASK Register */
 
 /** \brief TcChannel hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/trng.h
+++ b/asf/sam/include/sam4l/component/trng.h
@@ -50,15 +50,18 @@ typedef union {
 } TRNG_CR_Type;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define TRNG_CR_OFFSET              0x00         /**< \brief (TRNG_CR offset) Control Register */
-#define TRNG_CR_RESETVALUE          _U(0x00000000); /**< \brief (TRNG_CR reset_value) Control Register */
+#define TRNG_CR_OFFSET              0x00            /**< \brief (TRNG_CR offset) Control Register */
+#define TRNG_CR_RESETVALUE          _U_(0x00000000); /**< \brief (TRNG_CR reset_value) Control Register */
 
-#define TRNG_CR_ENABLE_Pos          0            /**< \brief (TRNG_CR) Enables the TRNG to provide random values */
-#define TRNG_CR_ENABLE              (_U(0x1) << TRNG_CR_ENABLE_Pos)
-#define TRNG_CR_KEY_Pos             8            /**< \brief (TRNG_CR) Security Key */
-#define TRNG_CR_KEY_Msk             (_U(0xFFFFFF) << TRNG_CR_KEY_Pos)
+#define TRNG_CR_ENABLE_Pos          0               /**< \brief (TRNG_CR) Enables the TRNG to provide random values */
+#define TRNG_CR_ENABLE              (_U_(0x1) << TRNG_CR_ENABLE_Pos)
+#define TRNG_CR_KEY_Pos             8               /**< \brief (TRNG_CR) Security Key */
+#define TRNG_CR_KEY_Msk             (_U_(0xFFFFFF) << TRNG_CR_KEY_Pos)
 #define TRNG_CR_KEY(value)          (TRNG_CR_KEY_Msk & ((value) << TRNG_CR_KEY_Pos))
-#define TRNG_CR_MASK                _U(0xFFFFFF01) /**< \brief (TRNG_CR) MASK Register */
+#define   TRNG_CR_KEY_PASSWD_Val    _U_(0x524E47)    /**< (TRNG_CR) Writing any other value in this field aborts the write operation.  */
+#define TRNG_CR_KEY_PASSWD          (TRNG_CR_KEY_PASSWD_Val << TRNG_CR_KEY_Pos) /**< (TRNG_CR) Writing any other value in this field aborts the write operation. Position  */
+#define TRNG_CR_MASK                _U_(0xFFFFFF01)  /**< \deprecated (TRNG_CR) Register MASK  (Use TRNG_CR_Msk instead)  */
+#define TRNG_CR_Msk                 _U_(0xFFFFFF01)  /**< (TRNG_CR) Register Mask  */
 
 /* -------- TRNG_IER : (TRNG Offset: 0x10) ( /W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -72,11 +75,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TRNG_IER_OFFSET             0x10         /**< \brief (TRNG_IER offset) Interrupt Enable Register */
-#define TRNG_IER_RESETVALUE         _U(0x00000000); /**< \brief (TRNG_IER reset_value) Interrupt Enable Register */
+#define TRNG_IER_RESETVALUE         _U_(0x00000000); /**< \brief (TRNG_IER reset_value) Interrupt Enable Register */
 
 #define TRNG_IER_DATRDY_Pos         0            /**< \brief (TRNG_IER) Data Ready Interrupt Enable */
-#define TRNG_IER_DATRDY             (_U(0x1) << TRNG_IER_DATRDY_Pos)
-#define TRNG_IER_MASK               _U(0x00000001) /**< \brief (TRNG_IER) MASK Register */
+#define TRNG_IER_DATRDY             (_U_(0x1) << TRNG_IER_DATRDY_Pos)
+#define TRNG_IER_MASK               _U_(0x00000001) /**< \brief (TRNG_IER) MASK Register */
 
 /* -------- TRNG_IDR : (TRNG Offset: 0x14) ( /W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -90,11 +93,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TRNG_IDR_OFFSET             0x14         /**< \brief (TRNG_IDR offset) Interrupt Disable Register */
-#define TRNG_IDR_RESETVALUE         _U(0x00000000); /**< \brief (TRNG_IDR reset_value) Interrupt Disable Register */
+#define TRNG_IDR_RESETVALUE         _U_(0x00000000); /**< \brief (TRNG_IDR reset_value) Interrupt Disable Register */
 
 #define TRNG_IDR_DATRDY_Pos         0            /**< \brief (TRNG_IDR) Data Ready Interrupt Disable */
-#define TRNG_IDR_DATRDY             (_U(0x1) << TRNG_IDR_DATRDY_Pos)
-#define TRNG_IDR_MASK               _U(0x00000001) /**< \brief (TRNG_IDR) MASK Register */
+#define TRNG_IDR_DATRDY             (_U_(0x1) << TRNG_IDR_DATRDY_Pos)
+#define TRNG_IDR_MASK               _U_(0x00000001) /**< \brief (TRNG_IDR) MASK Register */
 
 /* -------- TRNG_IMR : (TRNG Offset: 0x18) (R/  32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -108,11 +111,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TRNG_IMR_OFFSET             0x18         /**< \brief (TRNG_IMR offset) Interrupt Mask Register */
-#define TRNG_IMR_RESETVALUE         _U(0x00000000); /**< \brief (TRNG_IMR reset_value) Interrupt Mask Register */
+#define TRNG_IMR_RESETVALUE         _U_(0x00000000); /**< \brief (TRNG_IMR reset_value) Interrupt Mask Register */
 
 #define TRNG_IMR_DATRDY_Pos         0            /**< \brief (TRNG_IMR) Data Ready Interrupt Mask */
-#define TRNG_IMR_DATRDY             (_U(0x1) << TRNG_IMR_DATRDY_Pos)
-#define TRNG_IMR_MASK               _U(0x00000001) /**< \brief (TRNG_IMR) MASK Register */
+#define TRNG_IMR_DATRDY             (_U_(0x1) << TRNG_IMR_DATRDY_Pos)
+#define TRNG_IMR_MASK               _U_(0x00000001) /**< \brief (TRNG_IMR) MASK Register */
 
 /* -------- TRNG_ISR : (TRNG Offset: 0x1C) (R/  32) Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -126,11 +129,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TRNG_ISR_OFFSET             0x1C         /**< \brief (TRNG_ISR offset) Interrupt Status Register */
-#define TRNG_ISR_RESETVALUE         _U(0x00000000); /**< \brief (TRNG_ISR reset_value) Interrupt Status Register */
+#define TRNG_ISR_RESETVALUE         _U_(0x00000000); /**< \brief (TRNG_ISR reset_value) Interrupt Status Register */
 
 #define TRNG_ISR_DATRDY_Pos         0            /**< \brief (TRNG_ISR) Data Ready Interrupt Status */
-#define TRNG_ISR_DATRDY             (_U(0x1) << TRNG_ISR_DATRDY_Pos)
-#define TRNG_ISR_MASK               _U(0x00000001) /**< \brief (TRNG_ISR) MASK Register */
+#define TRNG_ISR_DATRDY             (_U_(0x1) << TRNG_ISR_DATRDY_Pos)
+#define TRNG_ISR_MASK               _U_(0x00000001) /**< \brief (TRNG_ISR) MASK Register */
 
 /* -------- TRNG_ODATA : (TRNG Offset: 0x50) (R/  32) Output Data Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -144,11 +147,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TRNG_ODATA_OFFSET           0x50         /**< \brief (TRNG_ODATA offset) Output Data Register */
-#define TRNG_ODATA_RESETVALUE       _U(0x00000000); /**< \brief (TRNG_ODATA reset_value) Output Data Register */
+#define TRNG_ODATA_RESETVALUE       _U_(0x00000000); /**< \brief (TRNG_ODATA reset_value) Output Data Register */
 
 #define TRNG_ODATA_ODATA_Pos        0            /**< \brief (TRNG_ODATA) Output Data */
-#define TRNG_ODATA_ODATA            (_U(0x1) << TRNG_ODATA_ODATA_Pos)
-#define TRNG_ODATA_MASK             _U(0x00000001) /**< \brief (TRNG_ODATA) MASK Register */
+#define TRNG_ODATA_ODATA            (_U_(0x1) << TRNG_ODATA_ODATA_Pos)
+#define TRNG_ODATA_MASK             _U_(0x00000001) /**< \brief (TRNG_ODATA) MASK Register */
 
 /* -------- TRNG_VERSION : (TRNG Offset: 0xFC) (R/  32) Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -164,15 +167,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TRNG_VERSION_OFFSET         0xFC         /**< \brief (TRNG_VERSION offset) Version Register */
-#define TRNG_VERSION_RESETVALUE     _U(0x00000103); /**< \brief (TRNG_VERSION reset_value) Version Register */
+#define TRNG_VERSION_RESETVALUE     _U_(0x00000103); /**< \brief (TRNG_VERSION reset_value) Version Register */
 
 #define TRNG_VERSION_VERSION_Pos    0            /**< \brief (TRNG_VERSION) Version Number */
-#define TRNG_VERSION_VERSION_Msk    (_U(0xFFF) << TRNG_VERSION_VERSION_Pos)
+#define TRNG_VERSION_VERSION_Msk    (_U_(0xFFF) << TRNG_VERSION_VERSION_Pos)
 #define TRNG_VERSION_VERSION(value) (TRNG_VERSION_VERSION_Msk & ((value) << TRNG_VERSION_VERSION_Pos))
 #define TRNG_VERSION_VARIANT_Pos    16           /**< \brief (TRNG_VERSION) Variant Number */
-#define TRNG_VERSION_VARIANT_Msk    (_U(0x7) << TRNG_VERSION_VARIANT_Pos)
+#define TRNG_VERSION_VARIANT_Msk    (_U_(0x7) << TRNG_VERSION_VARIANT_Pos)
 #define TRNG_VERSION_VARIANT(value) (TRNG_VERSION_VARIANT_Msk & ((value) << TRNG_VERSION_VARIANT_Pos))
-#define TRNG_VERSION_MASK           _U(0x00070FFF) /**< \brief (TRNG_VERSION) MASK Register */
+#define TRNG_VERSION_MASK           _U_(0x00070FFF) /**< \brief (TRNG_VERSION) MASK Register */
 
 /** \brief TRNG hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/trng.h
+++ b/asf/sam/include/sam4l/component/trng.h
@@ -1,0 +1,209 @@
+/**
+ * \file
+ *
+ * \brief Component description for TRNG
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_TRNG_COMPONENT_
+#define _SAM4L_TRNG_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR TRNG */
+/* ========================================================================== */
+/** \addtogroup SAM4L_TRNG True Random Number Generator */
+/*@{*/
+
+#define TRNG_I7643
+#define REV_TRNG                    0x103
+
+/* -------- TRNG_CR : (TRNG Offset: 0x00) ( /W 32) Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ENABLE:1;         /*!< bit:      0  Enables the TRNG to provide random values */
+    uint32_t :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint32_t KEY:24;           /*!< bit:  8..31  Security Key                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TRNG_CR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_CR_OFFSET              0x00         /**< \brief (TRNG_CR offset) Control Register */
+#define TRNG_CR_RESETVALUE          _U(0x00000000); /**< \brief (TRNG_CR reset_value) Control Register */
+
+#define TRNG_CR_ENABLE_Pos          0            /**< \brief (TRNG_CR) Enables the TRNG to provide random values */
+#define TRNG_CR_ENABLE              (_U(0x1) << TRNG_CR_ENABLE_Pos)
+#define TRNG_CR_KEY_Pos             8            /**< \brief (TRNG_CR) Security Key */
+#define TRNG_CR_KEY_Msk             (_U(0xFFFFFF) << TRNG_CR_KEY_Pos)
+#define TRNG_CR_KEY(value)          (TRNG_CR_KEY_Msk & ((value) << TRNG_CR_KEY_Pos))
+#define TRNG_CR_MASK                _U(0xFFFFFF01) /**< \brief (TRNG_CR) MASK Register */
+
+/* -------- TRNG_IER : (TRNG Offset: 0x10) ( /W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATRDY:1;         /*!< bit:      0  Data Ready Interrupt Enable        */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TRNG_IER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_IER_OFFSET             0x10         /**< \brief (TRNG_IER offset) Interrupt Enable Register */
+#define TRNG_IER_RESETVALUE         _U(0x00000000); /**< \brief (TRNG_IER reset_value) Interrupt Enable Register */
+
+#define TRNG_IER_DATRDY_Pos         0            /**< \brief (TRNG_IER) Data Ready Interrupt Enable */
+#define TRNG_IER_DATRDY             (_U(0x1) << TRNG_IER_DATRDY_Pos)
+#define TRNG_IER_MASK               _U(0x00000001) /**< \brief (TRNG_IER) MASK Register */
+
+/* -------- TRNG_IDR : (TRNG Offset: 0x14) ( /W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATRDY:1;         /*!< bit:      0  Data Ready Interrupt Disable       */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TRNG_IDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_IDR_OFFSET             0x14         /**< \brief (TRNG_IDR offset) Interrupt Disable Register */
+#define TRNG_IDR_RESETVALUE         _U(0x00000000); /**< \brief (TRNG_IDR reset_value) Interrupt Disable Register */
+
+#define TRNG_IDR_DATRDY_Pos         0            /**< \brief (TRNG_IDR) Data Ready Interrupt Disable */
+#define TRNG_IDR_DATRDY             (_U(0x1) << TRNG_IDR_DATRDY_Pos)
+#define TRNG_IDR_MASK               _U(0x00000001) /**< \brief (TRNG_IDR) MASK Register */
+
+/* -------- TRNG_IMR : (TRNG Offset: 0x18) (R/  32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATRDY:1;         /*!< bit:      0  Data Ready Interrupt Mask          */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TRNG_IMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_IMR_OFFSET             0x18         /**< \brief (TRNG_IMR offset) Interrupt Mask Register */
+#define TRNG_IMR_RESETVALUE         _U(0x00000000); /**< \brief (TRNG_IMR reset_value) Interrupt Mask Register */
+
+#define TRNG_IMR_DATRDY_Pos         0            /**< \brief (TRNG_IMR) Data Ready Interrupt Mask */
+#define TRNG_IMR_DATRDY             (_U(0x1) << TRNG_IMR_DATRDY_Pos)
+#define TRNG_IMR_MASK               _U(0x00000001) /**< \brief (TRNG_IMR) MASK Register */
+
+/* -------- TRNG_ISR : (TRNG Offset: 0x1C) (R/  32) Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATRDY:1;         /*!< bit:      0  Data Ready Interrupt Status        */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TRNG_ISR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_ISR_OFFSET             0x1C         /**< \brief (TRNG_ISR offset) Interrupt Status Register */
+#define TRNG_ISR_RESETVALUE         _U(0x00000000); /**< \brief (TRNG_ISR reset_value) Interrupt Status Register */
+
+#define TRNG_ISR_DATRDY_Pos         0            /**< \brief (TRNG_ISR) Data Ready Interrupt Status */
+#define TRNG_ISR_DATRDY             (_U(0x1) << TRNG_ISR_DATRDY_Pos)
+#define TRNG_ISR_MASK               _U(0x00000001) /**< \brief (TRNG_ISR) MASK Register */
+
+/* -------- TRNG_ODATA : (TRNG Offset: 0x50) (R/  32) Output Data Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ODATA:1;          /*!< bit:      0  Output Data                        */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TRNG_ODATA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_ODATA_OFFSET           0x50         /**< \brief (TRNG_ODATA offset) Output Data Register */
+#define TRNG_ODATA_RESETVALUE       _U(0x00000000); /**< \brief (TRNG_ODATA reset_value) Output Data Register */
+
+#define TRNG_ODATA_ODATA_Pos        0            /**< \brief (TRNG_ODATA) Output Data */
+#define TRNG_ODATA_ODATA            (_U(0x1) << TRNG_ODATA_ODATA_Pos)
+#define TRNG_ODATA_MASK             _U(0x00000001) /**< \brief (TRNG_ODATA) MASK Register */
+
+/* -------- TRNG_VERSION : (TRNG Offset: 0xFC) (R/  32) Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version Number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:3;        /*!< bit: 16..18  Variant Number                     */
+    uint32_t :13;              /*!< bit: 19..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TRNG_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TRNG_VERSION_OFFSET         0xFC         /**< \brief (TRNG_VERSION offset) Version Register */
+#define TRNG_VERSION_RESETVALUE     _U(0x00000103); /**< \brief (TRNG_VERSION reset_value) Version Register */
+
+#define TRNG_VERSION_VERSION_Pos    0            /**< \brief (TRNG_VERSION) Version Number */
+#define TRNG_VERSION_VERSION_Msk    (_U(0xFFF) << TRNG_VERSION_VERSION_Pos)
+#define TRNG_VERSION_VERSION(value) (TRNG_VERSION_VERSION_Msk & ((value) << TRNG_VERSION_VERSION_Pos))
+#define TRNG_VERSION_VARIANT_Pos    16           /**< \brief (TRNG_VERSION) Variant Number */
+#define TRNG_VERSION_VARIANT_Msk    (_U(0x7) << TRNG_VERSION_VARIANT_Pos)
+#define TRNG_VERSION_VARIANT(value) (TRNG_VERSION_VARIANT_Msk & ((value) << TRNG_VERSION_VARIANT_Pos))
+#define TRNG_VERSION_MASK           _U(0x00070FFF) /**< \brief (TRNG_VERSION) MASK Register */
+
+/** \brief TRNG hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __O  TRNG_CR_Type              CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
+       RoReg8                    Reserved1[0xC];
+  __O  TRNG_IER_Type             IER;         /**< \brief Offset: 0x10 ( /W 32) Interrupt Enable Register */
+  __O  TRNG_IDR_Type             IDR;         /**< \brief Offset: 0x14 ( /W 32) Interrupt Disable Register */
+  __I  TRNG_IMR_Type             IMR;         /**< \brief Offset: 0x18 (R/  32) Interrupt Mask Register */
+  __I  TRNG_ISR_Type             ISR;         /**< \brief Offset: 0x1C (R/  32) Interrupt Status Register */
+       RoReg8                    Reserved2[0x30];
+  __I  TRNG_ODATA_Type           ODATA;       /**< \brief Offset: 0x50 (R/  32) Output Data Register */
+       RoReg8                    Reserved3[0xA8];
+  __I  TRNG_VERSION_Type         VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
+ } bf;
+ struct {
+  WoReg   TRNG_CR;            /**< \brief (TRNG Offset: 0x00) Control Register */
+  RoReg8  Reserved4[0xC];
+  WoReg   TRNG_IER;           /**< \brief (TRNG Offset: 0x10) Interrupt Enable Register */
+  WoReg   TRNG_IDR;           /**< \brief (TRNG Offset: 0x14) Interrupt Disable Register */
+  RoReg   TRNG_IMR;           /**< \brief (TRNG Offset: 0x18) Interrupt Mask Register */
+  RoReg   TRNG_ISR;           /**< \brief (TRNG Offset: 0x1C) Interrupt Status Register */
+  RoReg8  Reserved5[0x30];
+  RoReg   TRNG_ODATA;         /**< \brief (TRNG Offset: 0x50) Output Data Register */
+  RoReg8  Reserved6[0xA8];
+  RoReg   TRNG_VERSION;       /**< \brief (TRNG Offset: 0xFC) Version Register */
+ } reg;
+} Trng;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_TRNG_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/trng.h
+++ b/asf/sam/include/sam4l/component/trng.h
@@ -179,31 +179,17 @@ typedef union {
 
 /** \brief TRNG hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __O  TRNG_CR_Type              CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
-       RoReg8                    Reserved1[0xC];
-  __O  TRNG_IER_Type             IER;         /**< \brief Offset: 0x10 ( /W 32) Interrupt Enable Register */
-  __O  TRNG_IDR_Type             IDR;         /**< \brief Offset: 0x14 ( /W 32) Interrupt Disable Register */
-  __I  TRNG_IMR_Type             IMR;         /**< \brief Offset: 0x18 (R/  32) Interrupt Mask Register */
-  __I  TRNG_ISR_Type             ISR;         /**< \brief Offset: 0x1C (R/  32) Interrupt Status Register */
-       RoReg8                    Reserved2[0x30];
-  __I  TRNG_ODATA_Type           ODATA;       /**< \brief Offset: 0x50 (R/  32) Output Data Register */
-       RoReg8                    Reserved3[0xA8];
-  __I  TRNG_VERSION_Type         VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
- } bf;
- struct {
-  WoReg   TRNG_CR;            /**< \brief (TRNG Offset: 0x00) Control Register */
-  RoReg8  Reserved4[0xC];
-  WoReg   TRNG_IER;           /**< \brief (TRNG Offset: 0x10) Interrupt Enable Register */
-  WoReg   TRNG_IDR;           /**< \brief (TRNG Offset: 0x14) Interrupt Disable Register */
-  RoReg   TRNG_IMR;           /**< \brief (TRNG Offset: 0x18) Interrupt Mask Register */
-  RoReg   TRNG_ISR;           /**< \brief (TRNG Offset: 0x1C) Interrupt Status Register */
-  RoReg8  Reserved5[0x30];
-  RoReg   TRNG_ODATA;         /**< \brief (TRNG Offset: 0x50) Output Data Register */
-  RoReg8  Reserved6[0xA8];
-  RoReg   TRNG_VERSION;       /**< \brief (TRNG Offset: 0xFC) Version Register */
- } reg;
+typedef struct {
+  __O  uint32_t CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
+       RoReg8   Reserved1[0xC];
+  __O  uint32_t IER;         /**< \brief Offset: 0x10 ( /W 32) Interrupt Enable Register */
+  __O  uint32_t IDR;         /**< \brief Offset: 0x14 ( /W 32) Interrupt Disable Register */
+  __I  uint32_t IMR;         /**< \brief Offset: 0x18 (R/  32) Interrupt Mask Register */
+  __I  uint32_t ISR;         /**< \brief Offset: 0x1C (R/  32) Interrupt Status Register */
+       RoReg8   Reserved2[0x30];
+  __I  uint32_t ODATA;       /**< \brief Offset: 0x50 (R/  32) Output Data Register */
+       RoReg8   Reserved3[0xA8];
+  __I  uint32_t VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
 } Trng;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/trng.h
+++ b/asf/sam/include/sam4l/component/trng.h
@@ -50,12 +50,12 @@ typedef union {
 } TRNG_CR_Type;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define TRNG_CR_OFFSET              0x00            /**< \brief (TRNG_CR offset) Control Register */
+#define TRNG_CR_OFFSET              0x00             /**< \brief (TRNG_CR offset) Control Register */
 #define TRNG_CR_RESETVALUE          _U_(0x00000000); /**< \brief (TRNG_CR reset_value) Control Register */
 
-#define TRNG_CR_ENABLE_Pos          0               /**< \brief (TRNG_CR) Enables the TRNG to provide random values */
+#define TRNG_CR_ENABLE_Pos          0                /**< \brief (TRNG_CR) Enables the TRNG to provide random values */
 #define TRNG_CR_ENABLE              (_U_(0x1) << TRNG_CR_ENABLE_Pos)
-#define TRNG_CR_KEY_Pos             8               /**< \brief (TRNG_CR) Security Key */
+#define TRNG_CR_KEY_Pos             8                /**< \brief (TRNG_CR) Security Key */
 #define TRNG_CR_KEY_Msk             (_U_(0xFFFFFF) << TRNG_CR_KEY_Pos)
 #define TRNG_CR_KEY(value)          (TRNG_CR_KEY_Msk & ((value) << TRNG_CR_KEY_Pos))
 #define   TRNG_CR_KEY_PASSWD_Val    _U_(0x524E47)    /**< (TRNG_CR) Writing any other value in this field aborts the write operation.  */
@@ -180,16 +180,16 @@ typedef union {
 /** \brief TRNG hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 typedef struct {
-  __O  uint32_t CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
+  __O  uint32_t TRNG_CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
        RoReg8   Reserved1[0xC];
-  __O  uint32_t IER;         /**< \brief Offset: 0x10 ( /W 32) Interrupt Enable Register */
-  __O  uint32_t IDR;         /**< \brief Offset: 0x14 ( /W 32) Interrupt Disable Register */
-  __I  uint32_t IMR;         /**< \brief Offset: 0x18 (R/  32) Interrupt Mask Register */
-  __I  uint32_t ISR;         /**< \brief Offset: 0x1C (R/  32) Interrupt Status Register */
+  __O  uint32_t TRNG_IER;         /**< \brief Offset: 0x10 ( /W 32) Interrupt Enable Register */
+  __O  uint32_t TRNG_IDR;         /**< \brief Offset: 0x14 ( /W 32) Interrupt Disable Register */
+  __I  uint32_t TRNG_IMR;         /**< \brief Offset: 0x18 (R/  32) Interrupt Mask Register */
+  __I  uint32_t TRNG_ISR;         /**< \brief Offset: 0x1C (R/  32) Interrupt Status Register */
        RoReg8   Reserved2[0x30];
-  __I  uint32_t ODATA;       /**< \brief Offset: 0x50 (R/  32) Output Data Register */
+  __I  uint32_t TRNG_ODATA;       /**< \brief Offset: 0x50 (R/  32) Output Data Register */
        RoReg8   Reserved3[0xA8];
-  __I  uint32_t VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
+  __I  uint32_t TRNG_VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
 } Trng;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/twim.h
+++ b/asf/sam/include/sam4l/component/twim.h
@@ -57,21 +57,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIM_CR_OFFSET              0x00         /**< \brief (TWIM_CR offset) Control Register */
-#define TWIM_CR_RESETVALUE          _U(0x00000000); /**< \brief (TWIM_CR reset_value) Control Register */
+#define TWIM_CR_RESETVALUE          _U_(0x00000000); /**< \brief (TWIM_CR reset_value) Control Register */
 
 #define TWIM_CR_MEN_Pos             0            /**< \brief (TWIM_CR) Master Enable */
-#define TWIM_CR_MEN                 (_U(0x1) << TWIM_CR_MEN_Pos)
+#define TWIM_CR_MEN                 (_U_(0x1) << TWIM_CR_MEN_Pos)
 #define TWIM_CR_MDIS_Pos            1            /**< \brief (TWIM_CR) Master Disable */
-#define TWIM_CR_MDIS                (_U(0x1) << TWIM_CR_MDIS_Pos)
+#define TWIM_CR_MDIS                (_U_(0x1) << TWIM_CR_MDIS_Pos)
 #define TWIM_CR_SMEN_Pos            4            /**< \brief (TWIM_CR) SMBus Enable */
-#define TWIM_CR_SMEN                (_U(0x1) << TWIM_CR_SMEN_Pos)
+#define TWIM_CR_SMEN                (_U_(0x1) << TWIM_CR_SMEN_Pos)
 #define TWIM_CR_SMDIS_Pos           5            /**< \brief (TWIM_CR) SMBus Disable */
-#define TWIM_CR_SMDIS               (_U(0x1) << TWIM_CR_SMDIS_Pos)
+#define TWIM_CR_SMDIS               (_U_(0x1) << TWIM_CR_SMDIS_Pos)
 #define TWIM_CR_SWRST_Pos           7            /**< \brief (TWIM_CR) Software Reset */
-#define TWIM_CR_SWRST               (_U(0x1) << TWIM_CR_SWRST_Pos)
+#define TWIM_CR_SWRST               (_U_(0x1) << TWIM_CR_SWRST_Pos)
 #define TWIM_CR_STOP_Pos            8            /**< \brief (TWIM_CR) Stop the current transfer */
-#define TWIM_CR_STOP                (_U(0x1) << TWIM_CR_STOP_Pos)
-#define TWIM_CR_MASK                _U(0x000001B3) /**< \brief (TWIM_CR) MASK Register */
+#define TWIM_CR_STOP                (_U_(0x1) << TWIM_CR_STOP_Pos)
+#define TWIM_CR_MASK                _U_(0x000001B3) /**< \brief (TWIM_CR) MASK Register */
 
 /* -------- TWIM_CWGR : (TWIM Offset: 0x04) (R/W 32) Clock Waveform Generator Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -89,24 +89,24 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIM_CWGR_OFFSET            0x04         /**< \brief (TWIM_CWGR offset) Clock Waveform Generator Register */
-#define TWIM_CWGR_RESETVALUE        _U(0x00000000); /**< \brief (TWIM_CWGR reset_value) Clock Waveform Generator Register */
+#define TWIM_CWGR_RESETVALUE        _U_(0x00000000); /**< \brief (TWIM_CWGR reset_value) Clock Waveform Generator Register */
 
 #define TWIM_CWGR_LOW_Pos           0            /**< \brief (TWIM_CWGR) Clock Low Cycles */
-#define TWIM_CWGR_LOW_Msk           (_U(0xFF) << TWIM_CWGR_LOW_Pos)
+#define TWIM_CWGR_LOW_Msk           (_U_(0xFF) << TWIM_CWGR_LOW_Pos)
 #define TWIM_CWGR_LOW(value)        (TWIM_CWGR_LOW_Msk & ((value) << TWIM_CWGR_LOW_Pos))
 #define TWIM_CWGR_HIGH_Pos          8            /**< \brief (TWIM_CWGR) Clock High Cycles */
-#define TWIM_CWGR_HIGH_Msk          (_U(0xFF) << TWIM_CWGR_HIGH_Pos)
+#define TWIM_CWGR_HIGH_Msk          (_U_(0xFF) << TWIM_CWGR_HIGH_Pos)
 #define TWIM_CWGR_HIGH(value)       (TWIM_CWGR_HIGH_Msk & ((value) << TWIM_CWGR_HIGH_Pos))
 #define TWIM_CWGR_STASTO_Pos        16           /**< \brief (TWIM_CWGR) START and STOP Cycles */
-#define TWIM_CWGR_STASTO_Msk        (_U(0xFF) << TWIM_CWGR_STASTO_Pos)
+#define TWIM_CWGR_STASTO_Msk        (_U_(0xFF) << TWIM_CWGR_STASTO_Pos)
 #define TWIM_CWGR_STASTO(value)     (TWIM_CWGR_STASTO_Msk & ((value) << TWIM_CWGR_STASTO_Pos))
 #define TWIM_CWGR_DATA_Pos          24           /**< \brief (TWIM_CWGR) Data Setup and Hold Cycles */
-#define TWIM_CWGR_DATA_Msk          (_U(0xF) << TWIM_CWGR_DATA_Pos)
+#define TWIM_CWGR_DATA_Msk          (_U_(0xF) << TWIM_CWGR_DATA_Pos)
 #define TWIM_CWGR_DATA(value)       (TWIM_CWGR_DATA_Msk & ((value) << TWIM_CWGR_DATA_Pos))
 #define TWIM_CWGR_EXP_Pos           28           /**< \brief (TWIM_CWGR) Clock Prescaler */
-#define TWIM_CWGR_EXP_Msk           (_U(0x7) << TWIM_CWGR_EXP_Pos)
+#define TWIM_CWGR_EXP_Msk           (_U_(0x7) << TWIM_CWGR_EXP_Pos)
 #define TWIM_CWGR_EXP(value)        (TWIM_CWGR_EXP_Msk & ((value) << TWIM_CWGR_EXP_Pos))
-#define TWIM_CWGR_MASK              _U(0x7FFFFFFF) /**< \brief (TWIM_CWGR) MASK Register */
+#define TWIM_CWGR_MASK              _U_(0x7FFFFFFF) /**< \brief (TWIM_CWGR) MASK Register */
 
 /* -------- TWIM_SMBTR : (TWIM Offset: 0x08) (R/W 32) SMBus Timing Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -123,21 +123,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIM_SMBTR_OFFSET           0x08         /**< \brief (TWIM_SMBTR offset) SMBus Timing Register */
-#define TWIM_SMBTR_RESETVALUE       _U(0x00000000); /**< \brief (TWIM_SMBTR reset_value) SMBus Timing Register */
+#define TWIM_SMBTR_RESETVALUE       _U_(0x00000000); /**< \brief (TWIM_SMBTR reset_value) SMBus Timing Register */
 
 #define TWIM_SMBTR_TLOWS_Pos        0            /**< \brief (TWIM_SMBTR) Slave Clock stretch maximum cycles */
-#define TWIM_SMBTR_TLOWS_Msk        (_U(0xFF) << TWIM_SMBTR_TLOWS_Pos)
+#define TWIM_SMBTR_TLOWS_Msk        (_U_(0xFF) << TWIM_SMBTR_TLOWS_Pos)
 #define TWIM_SMBTR_TLOWS(value)     (TWIM_SMBTR_TLOWS_Msk & ((value) << TWIM_SMBTR_TLOWS_Pos))
 #define TWIM_SMBTR_TLOWM_Pos        8            /**< \brief (TWIM_SMBTR) Master Clock stretch maximum cycles */
-#define TWIM_SMBTR_TLOWM_Msk        (_U(0xFF) << TWIM_SMBTR_TLOWM_Pos)
+#define TWIM_SMBTR_TLOWM_Msk        (_U_(0xFF) << TWIM_SMBTR_TLOWM_Pos)
 #define TWIM_SMBTR_TLOWM(value)     (TWIM_SMBTR_TLOWM_Msk & ((value) << TWIM_SMBTR_TLOWM_Pos))
 #define TWIM_SMBTR_THMAX_Pos        16           /**< \brief (TWIM_SMBTR) Clock High maximum cycles */
-#define TWIM_SMBTR_THMAX_Msk        (_U(0xFF) << TWIM_SMBTR_THMAX_Pos)
+#define TWIM_SMBTR_THMAX_Msk        (_U_(0xFF) << TWIM_SMBTR_THMAX_Pos)
 #define TWIM_SMBTR_THMAX(value)     (TWIM_SMBTR_THMAX_Msk & ((value) << TWIM_SMBTR_THMAX_Pos))
 #define TWIM_SMBTR_EXP_Pos          28           /**< \brief (TWIM_SMBTR) SMBus Timeout Clock prescaler */
-#define TWIM_SMBTR_EXP_Msk          (_U(0xF) << TWIM_SMBTR_EXP_Pos)
+#define TWIM_SMBTR_EXP_Msk          (_U_(0xF) << TWIM_SMBTR_EXP_Pos)
 #define TWIM_SMBTR_EXP(value)       (TWIM_SMBTR_EXP_Msk & ((value) << TWIM_SMBTR_EXP_Pos))
-#define TWIM_SMBTR_MASK             _U(0xF0FFFFFF) /**< \brief (TWIM_SMBTR) MASK Register */
+#define TWIM_SMBTR_MASK             _U_(0xF0FFFFFF) /**< \brief (TWIM_SMBTR) MASK Register */
 
 /* -------- TWIM_CMDR : (TWIM Offset: 0x0C) (R/W 32) Command Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -163,36 +163,36 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIM_CMDR_OFFSET            0x0C         /**< \brief (TWIM_CMDR offset) Command Register */
-#define TWIM_CMDR_RESETVALUE        _U(0x00000000); /**< \brief (TWIM_CMDR reset_value) Command Register */
+#define TWIM_CMDR_RESETVALUE        _U_(0x00000000); /**< \brief (TWIM_CMDR reset_value) Command Register */
 
 #define TWIM_CMDR_READ_Pos          0            /**< \brief (TWIM_CMDR) Transfer Direction */
-#define TWIM_CMDR_READ              (_U(0x1) << TWIM_CMDR_READ_Pos)
+#define TWIM_CMDR_READ              (_U_(0x1) << TWIM_CMDR_READ_Pos)
 #define TWIM_CMDR_SADR_Pos          1            /**< \brief (TWIM_CMDR) Slave Address */
-#define TWIM_CMDR_SADR_Msk          (_U(0x3FF) << TWIM_CMDR_SADR_Pos)
+#define TWIM_CMDR_SADR_Msk          (_U_(0x3FF) << TWIM_CMDR_SADR_Pos)
 #define TWIM_CMDR_SADR(value)       (TWIM_CMDR_SADR_Msk & ((value) << TWIM_CMDR_SADR_Pos))
 #define TWIM_CMDR_TENBIT_Pos        11           /**< \brief (TWIM_CMDR) Ten Bit Addressing Mode */
-#define TWIM_CMDR_TENBIT            (_U(0x1) << TWIM_CMDR_TENBIT_Pos)
+#define TWIM_CMDR_TENBIT            (_U_(0x1) << TWIM_CMDR_TENBIT_Pos)
 #define TWIM_CMDR_REPSAME_Pos       12           /**< \brief (TWIM_CMDR) Transfer is to same address as previous address */
-#define TWIM_CMDR_REPSAME           (_U(0x1) << TWIM_CMDR_REPSAME_Pos)
+#define TWIM_CMDR_REPSAME           (_U_(0x1) << TWIM_CMDR_REPSAME_Pos)
 #define TWIM_CMDR_START_Pos         13           /**< \brief (TWIM_CMDR) Send START condition */
-#define TWIM_CMDR_START             (_U(0x1) << TWIM_CMDR_START_Pos)
+#define TWIM_CMDR_START             (_U_(0x1) << TWIM_CMDR_START_Pos)
 #define TWIM_CMDR_STOP_Pos          14           /**< \brief (TWIM_CMDR) Send STOP condition */
-#define TWIM_CMDR_STOP              (_U(0x1) << TWIM_CMDR_STOP_Pos)
+#define TWIM_CMDR_STOP              (_U_(0x1) << TWIM_CMDR_STOP_Pos)
 #define TWIM_CMDR_VALID_Pos         15           /**< \brief (TWIM_CMDR) CMDR Valid */
-#define TWIM_CMDR_VALID             (_U(0x1) << TWIM_CMDR_VALID_Pos)
+#define TWIM_CMDR_VALID             (_U_(0x1) << TWIM_CMDR_VALID_Pos)
 #define TWIM_CMDR_NBYTES_Pos        16           /**< \brief (TWIM_CMDR) Number of data bytes in transfer */
-#define TWIM_CMDR_NBYTES_Msk        (_U(0xFF) << TWIM_CMDR_NBYTES_Pos)
+#define TWIM_CMDR_NBYTES_Msk        (_U_(0xFF) << TWIM_CMDR_NBYTES_Pos)
 #define TWIM_CMDR_NBYTES(value)     (TWIM_CMDR_NBYTES_Msk & ((value) << TWIM_CMDR_NBYTES_Pos))
 #define TWIM_CMDR_PECEN_Pos         24           /**< \brief (TWIM_CMDR) Packet Error Checking Enable */
-#define TWIM_CMDR_PECEN             (_U(0x1) << TWIM_CMDR_PECEN_Pos)
+#define TWIM_CMDR_PECEN             (_U_(0x1) << TWIM_CMDR_PECEN_Pos)
 #define TWIM_CMDR_ACKLAST_Pos       25           /**< \brief (TWIM_CMDR) ACK Last Master RX Byte */
-#define TWIM_CMDR_ACKLAST           (_U(0x1) << TWIM_CMDR_ACKLAST_Pos)
+#define TWIM_CMDR_ACKLAST           (_U_(0x1) << TWIM_CMDR_ACKLAST_Pos)
 #define TWIM_CMDR_HS_Pos            26           /**< \brief (TWIM_CMDR) HS-mode */
-#define TWIM_CMDR_HS                (_U(0x1) << TWIM_CMDR_HS_Pos)
+#define TWIM_CMDR_HS                (_U_(0x1) << TWIM_CMDR_HS_Pos)
 #define TWIM_CMDR_HSMCODE_Pos       28           /**< \brief (TWIM_CMDR) HS-mode Master Code */
-#define TWIM_CMDR_HSMCODE_Msk       (_U(0x7) << TWIM_CMDR_HSMCODE_Pos)
+#define TWIM_CMDR_HSMCODE_Msk       (_U_(0x7) << TWIM_CMDR_HSMCODE_Pos)
 #define TWIM_CMDR_HSMCODE(value)    (TWIM_CMDR_HSMCODE_Msk & ((value) << TWIM_CMDR_HSMCODE_Pos))
-#define TWIM_CMDR_MASK              _U(0x77FFFFFF) /**< \brief (TWIM_CMDR) MASK Register */
+#define TWIM_CMDR_MASK              _U_(0x77FFFFFF) /**< \brief (TWIM_CMDR) MASK Register */
 
 /* -------- TWIM_NCMDR : (TWIM Offset: 0x10) (R/W 32) Next Command Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -218,36 +218,36 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIM_NCMDR_OFFSET           0x10         /**< \brief (TWIM_NCMDR offset) Next Command Register */
-#define TWIM_NCMDR_RESETVALUE       _U(0x00000000); /**< \brief (TWIM_NCMDR reset_value) Next Command Register */
+#define TWIM_NCMDR_RESETVALUE       _U_(0x00000000); /**< \brief (TWIM_NCMDR reset_value) Next Command Register */
 
 #define TWIM_NCMDR_READ_Pos         0            /**< \brief (TWIM_NCMDR) Transfer Direction */
-#define TWIM_NCMDR_READ             (_U(0x1) << TWIM_NCMDR_READ_Pos)
+#define TWIM_NCMDR_READ             (_U_(0x1) << TWIM_NCMDR_READ_Pos)
 #define TWIM_NCMDR_SADR_Pos         1            /**< \brief (TWIM_NCMDR) Slave Address */
-#define TWIM_NCMDR_SADR_Msk         (_U(0x3FF) << TWIM_NCMDR_SADR_Pos)
+#define TWIM_NCMDR_SADR_Msk         (_U_(0x3FF) << TWIM_NCMDR_SADR_Pos)
 #define TWIM_NCMDR_SADR(value)      (TWIM_NCMDR_SADR_Msk & ((value) << TWIM_NCMDR_SADR_Pos))
 #define TWIM_NCMDR_TENBIT_Pos       11           /**< \brief (TWIM_NCMDR) Ten Bit Addressing Mode */
-#define TWIM_NCMDR_TENBIT           (_U(0x1) << TWIM_NCMDR_TENBIT_Pos)
+#define TWIM_NCMDR_TENBIT           (_U_(0x1) << TWIM_NCMDR_TENBIT_Pos)
 #define TWIM_NCMDR_REPSAME_Pos      12           /**< \brief (TWIM_NCMDR) Transfer is to same address as previous address */
-#define TWIM_NCMDR_REPSAME          (_U(0x1) << TWIM_NCMDR_REPSAME_Pos)
+#define TWIM_NCMDR_REPSAME          (_U_(0x1) << TWIM_NCMDR_REPSAME_Pos)
 #define TWIM_NCMDR_START_Pos        13           /**< \brief (TWIM_NCMDR) Send START condition */
-#define TWIM_NCMDR_START            (_U(0x1) << TWIM_NCMDR_START_Pos)
+#define TWIM_NCMDR_START            (_U_(0x1) << TWIM_NCMDR_START_Pos)
 #define TWIM_NCMDR_STOP_Pos         14           /**< \brief (TWIM_NCMDR) Send STOP condition */
-#define TWIM_NCMDR_STOP             (_U(0x1) << TWIM_NCMDR_STOP_Pos)
+#define TWIM_NCMDR_STOP             (_U_(0x1) << TWIM_NCMDR_STOP_Pos)
 #define TWIM_NCMDR_VALID_Pos        15           /**< \brief (TWIM_NCMDR) CMDR Valid */
-#define TWIM_NCMDR_VALID            (_U(0x1) << TWIM_NCMDR_VALID_Pos)
+#define TWIM_NCMDR_VALID            (_U_(0x1) << TWIM_NCMDR_VALID_Pos)
 #define TWIM_NCMDR_NBYTES_Pos       16           /**< \brief (TWIM_NCMDR) Number of data bytes in transfer */
-#define TWIM_NCMDR_NBYTES_Msk       (_U(0xFF) << TWIM_NCMDR_NBYTES_Pos)
+#define TWIM_NCMDR_NBYTES_Msk       (_U_(0xFF) << TWIM_NCMDR_NBYTES_Pos)
 #define TWIM_NCMDR_NBYTES(value)    (TWIM_NCMDR_NBYTES_Msk & ((value) << TWIM_NCMDR_NBYTES_Pos))
 #define TWIM_NCMDR_PECEN_Pos        24           /**< \brief (TWIM_NCMDR) Packet Error Checking Enable */
-#define TWIM_NCMDR_PECEN            (_U(0x1) << TWIM_NCMDR_PECEN_Pos)
+#define TWIM_NCMDR_PECEN            (_U_(0x1) << TWIM_NCMDR_PECEN_Pos)
 #define TWIM_NCMDR_ACKLAST_Pos      25           /**< \brief (TWIM_NCMDR) ACK Last Master RX Byte */
-#define TWIM_NCMDR_ACKLAST          (_U(0x1) << TWIM_NCMDR_ACKLAST_Pos)
+#define TWIM_NCMDR_ACKLAST          (_U_(0x1) << TWIM_NCMDR_ACKLAST_Pos)
 #define TWIM_NCMDR_HS_Pos           26           /**< \brief (TWIM_NCMDR) HS-mode */
-#define TWIM_NCMDR_HS               (_U(0x1) << TWIM_NCMDR_HS_Pos)
+#define TWIM_NCMDR_HS               (_U_(0x1) << TWIM_NCMDR_HS_Pos)
 #define TWIM_NCMDR_HSMCODE_Pos      28           /**< \brief (TWIM_NCMDR) HS-mode Master Code */
-#define TWIM_NCMDR_HSMCODE_Msk      (_U(0x7) << TWIM_NCMDR_HSMCODE_Pos)
+#define TWIM_NCMDR_HSMCODE_Msk      (_U_(0x7) << TWIM_NCMDR_HSMCODE_Pos)
 #define TWIM_NCMDR_HSMCODE(value)   (TWIM_NCMDR_HSMCODE_Msk & ((value) << TWIM_NCMDR_HSMCODE_Pos))
-#define TWIM_NCMDR_MASK             _U(0x77FFFFFF) /**< \brief (TWIM_NCMDR) MASK Register */
+#define TWIM_NCMDR_MASK             _U_(0x77FFFFFF) /**< \brief (TWIM_NCMDR) MASK Register */
 
 /* -------- TWIM_RHR : (TWIM Offset: 0x14) (R/  32) Receive Holding Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -261,12 +261,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIM_RHR_OFFSET             0x14         /**< \brief (TWIM_RHR offset) Receive Holding Register */
-#define TWIM_RHR_RESETVALUE         _U(0x00000000); /**< \brief (TWIM_RHR reset_value) Receive Holding Register */
+#define TWIM_RHR_RESETVALUE         _U_(0x00000000); /**< \brief (TWIM_RHR reset_value) Receive Holding Register */
 
 #define TWIM_RHR_RXDATA_Pos         0            /**< \brief (TWIM_RHR) Received Data */
-#define TWIM_RHR_RXDATA_Msk         (_U(0xFF) << TWIM_RHR_RXDATA_Pos)
+#define TWIM_RHR_RXDATA_Msk         (_U_(0xFF) << TWIM_RHR_RXDATA_Pos)
 #define TWIM_RHR_RXDATA(value)      (TWIM_RHR_RXDATA_Msk & ((value) << TWIM_RHR_RXDATA_Pos))
-#define TWIM_RHR_MASK               _U(0x000000FF) /**< \brief (TWIM_RHR) MASK Register */
+#define TWIM_RHR_MASK               _U_(0x000000FF) /**< \brief (TWIM_RHR) MASK Register */
 
 /* -------- TWIM_THR : (TWIM Offset: 0x18) ( /W 32) Transmit Holding Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -280,12 +280,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIM_THR_OFFSET             0x18         /**< \brief (TWIM_THR offset) Transmit Holding Register */
-#define TWIM_THR_RESETVALUE         _U(0x00000000); /**< \brief (TWIM_THR reset_value) Transmit Holding Register */
+#define TWIM_THR_RESETVALUE         _U_(0x00000000); /**< \brief (TWIM_THR reset_value) Transmit Holding Register */
 
 #define TWIM_THR_TXDATA_Pos         0            /**< \brief (TWIM_THR) Data to Transmit */
-#define TWIM_THR_TXDATA_Msk         (_U(0xFF) << TWIM_THR_TXDATA_Pos)
+#define TWIM_THR_TXDATA_Msk         (_U_(0xFF) << TWIM_THR_TXDATA_Pos)
 #define TWIM_THR_TXDATA(value)      (TWIM_THR_TXDATA_Msk & ((value) << TWIM_THR_TXDATA_Pos))
-#define TWIM_THR_MASK               _U(0x000000FF) /**< \brief (TWIM_THR) MASK Register */
+#define TWIM_THR_MASK               _U_(0x000000FF) /**< \brief (TWIM_THR) MASK Register */
 
 /* -------- TWIM_SR : (TWIM Offset: 0x1C) (R/  32) Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -315,39 +315,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIM_SR_OFFSET              0x1C         /**< \brief (TWIM_SR offset) Status Register */
-#define TWIM_SR_RESETVALUE          _U(0x00000002); /**< \brief (TWIM_SR reset_value) Status Register */
+#define TWIM_SR_RESETVALUE          _U_(0x00000002); /**< \brief (TWIM_SR reset_value) Status Register */
 
 #define TWIM_SR_RXRDY_Pos           0            /**< \brief (TWIM_SR) RHR Data Ready */
-#define TWIM_SR_RXRDY               (_U(0x1) << TWIM_SR_RXRDY_Pos)
+#define TWIM_SR_RXRDY               (_U_(0x1) << TWIM_SR_RXRDY_Pos)
 #define TWIM_SR_TXRDY_Pos           1            /**< \brief (TWIM_SR) THR Data Ready */
-#define TWIM_SR_TXRDY               (_U(0x1) << TWIM_SR_TXRDY_Pos)
+#define TWIM_SR_TXRDY               (_U_(0x1) << TWIM_SR_TXRDY_Pos)
 #define TWIM_SR_CRDY_Pos            2            /**< \brief (TWIM_SR) Ready for More Commands */
-#define TWIM_SR_CRDY                (_U(0x1) << TWIM_SR_CRDY_Pos)
+#define TWIM_SR_CRDY                (_U_(0x1) << TWIM_SR_CRDY_Pos)
 #define TWIM_SR_CCOMP_Pos           3            /**< \brief (TWIM_SR) Command Complete */
-#define TWIM_SR_CCOMP               (_U(0x1) << TWIM_SR_CCOMP_Pos)
+#define TWIM_SR_CCOMP               (_U_(0x1) << TWIM_SR_CCOMP_Pos)
 #define TWIM_SR_IDLE_Pos            4            /**< \brief (TWIM_SR) Master Interface is Idle */
-#define TWIM_SR_IDLE                (_U(0x1) << TWIM_SR_IDLE_Pos)
+#define TWIM_SR_IDLE                (_U_(0x1) << TWIM_SR_IDLE_Pos)
 #define TWIM_SR_BUSFREE_Pos         5            /**< \brief (TWIM_SR) Two-wire Bus is Free */
-#define TWIM_SR_BUSFREE             (_U(0x1) << TWIM_SR_BUSFREE_Pos)
+#define TWIM_SR_BUSFREE             (_U_(0x1) << TWIM_SR_BUSFREE_Pos)
 #define TWIM_SR_ANAK_Pos            8            /**< \brief (TWIM_SR) NAK in Address Phase Received */
-#define TWIM_SR_ANAK                (_U(0x1) << TWIM_SR_ANAK_Pos)
+#define TWIM_SR_ANAK                (_U_(0x1) << TWIM_SR_ANAK_Pos)
 #define TWIM_SR_DNAK_Pos            9            /**< \brief (TWIM_SR) NAK in Data Phase Received */
-#define TWIM_SR_DNAK                (_U(0x1) << TWIM_SR_DNAK_Pos)
+#define TWIM_SR_DNAK                (_U_(0x1) << TWIM_SR_DNAK_Pos)
 #define TWIM_SR_ARBLST_Pos          10           /**< \brief (TWIM_SR) Arbitration Lost */
-#define TWIM_SR_ARBLST              (_U(0x1) << TWIM_SR_ARBLST_Pos)
+#define TWIM_SR_ARBLST              (_U_(0x1) << TWIM_SR_ARBLST_Pos)
 #define TWIM_SR_SMBALERT_Pos        11           /**< \brief (TWIM_SR) SMBus Alert */
-#define TWIM_SR_SMBALERT            (_U(0x1) << TWIM_SR_SMBALERT_Pos)
+#define TWIM_SR_SMBALERT            (_U_(0x1) << TWIM_SR_SMBALERT_Pos)
 #define TWIM_SR_TOUT_Pos            12           /**< \brief (TWIM_SR) Timeout */
-#define TWIM_SR_TOUT                (_U(0x1) << TWIM_SR_TOUT_Pos)
+#define TWIM_SR_TOUT                (_U_(0x1) << TWIM_SR_TOUT_Pos)
 #define TWIM_SR_PECERR_Pos          13           /**< \brief (TWIM_SR) PEC Error */
-#define TWIM_SR_PECERR              (_U(0x1) << TWIM_SR_PECERR_Pos)
+#define TWIM_SR_PECERR              (_U_(0x1) << TWIM_SR_PECERR_Pos)
 #define TWIM_SR_STOP_Pos            14           /**< \brief (TWIM_SR) Stop Request Accepted */
-#define TWIM_SR_STOP                (_U(0x1) << TWIM_SR_STOP_Pos)
+#define TWIM_SR_STOP                (_U_(0x1) << TWIM_SR_STOP_Pos)
 #define TWIM_SR_MENB_Pos            16           /**< \brief (TWIM_SR) Master Interface Enable */
-#define TWIM_SR_MENB                (_U(0x1) << TWIM_SR_MENB_Pos)
+#define TWIM_SR_MENB                (_U_(0x1) << TWIM_SR_MENB_Pos)
 #define TWIM_SR_HSMCACK_Pos         17           /**< \brief (TWIM_SR) ACK in HS-mode Master Code Phase Received */
-#define TWIM_SR_HSMCACK             (_U(0x1) << TWIM_SR_HSMCACK_Pos)
-#define TWIM_SR_MASK                _U(0x00037F3F) /**< \brief (TWIM_SR) MASK Register */
+#define TWIM_SR_HSMCACK             (_U_(0x1) << TWIM_SR_HSMCACK_Pos)
+#define TWIM_SR_MASK                _U_(0x00037F3F) /**< \brief (TWIM_SR) MASK Register */
 
 /* -------- TWIM_IER : (TWIM Offset: 0x20) ( /W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -376,37 +376,37 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIM_IER_OFFSET             0x20         /**< \brief (TWIM_IER offset) Interrupt Enable Register */
-#define TWIM_IER_RESETVALUE         _U(0x00000000); /**< \brief (TWIM_IER reset_value) Interrupt Enable Register */
+#define TWIM_IER_RESETVALUE         _U_(0x00000000); /**< \brief (TWIM_IER reset_value) Interrupt Enable Register */
 
 #define TWIM_IER_RXRDY_Pos          0            /**< \brief (TWIM_IER) RHR Data Ready */
-#define TWIM_IER_RXRDY              (_U(0x1) << TWIM_IER_RXRDY_Pos)
+#define TWIM_IER_RXRDY              (_U_(0x1) << TWIM_IER_RXRDY_Pos)
 #define TWIM_IER_TXRDY_Pos          1            /**< \brief (TWIM_IER) THR Data Ready */
-#define TWIM_IER_TXRDY              (_U(0x1) << TWIM_IER_TXRDY_Pos)
+#define TWIM_IER_TXRDY              (_U_(0x1) << TWIM_IER_TXRDY_Pos)
 #define TWIM_IER_CRDY_Pos           2            /**< \brief (TWIM_IER) Ready for More Commands */
-#define TWIM_IER_CRDY               (_U(0x1) << TWIM_IER_CRDY_Pos)
+#define TWIM_IER_CRDY               (_U_(0x1) << TWIM_IER_CRDY_Pos)
 #define TWIM_IER_CCOMP_Pos          3            /**< \brief (TWIM_IER) Command Complete */
-#define TWIM_IER_CCOMP              (_U(0x1) << TWIM_IER_CCOMP_Pos)
+#define TWIM_IER_CCOMP              (_U_(0x1) << TWIM_IER_CCOMP_Pos)
 #define TWIM_IER_IDLE_Pos           4            /**< \brief (TWIM_IER) Master Interface is Idle */
-#define TWIM_IER_IDLE               (_U(0x1) << TWIM_IER_IDLE_Pos)
+#define TWIM_IER_IDLE               (_U_(0x1) << TWIM_IER_IDLE_Pos)
 #define TWIM_IER_BUSFREE_Pos        5            /**< \brief (TWIM_IER) Two-wire Bus is Free */
-#define TWIM_IER_BUSFREE            (_U(0x1) << TWIM_IER_BUSFREE_Pos)
+#define TWIM_IER_BUSFREE            (_U_(0x1) << TWIM_IER_BUSFREE_Pos)
 #define TWIM_IER_ANAK_Pos           8            /**< \brief (TWIM_IER) NAK in Address Phase Received */
-#define TWIM_IER_ANAK               (_U(0x1) << TWIM_IER_ANAK_Pos)
+#define TWIM_IER_ANAK               (_U_(0x1) << TWIM_IER_ANAK_Pos)
 #define TWIM_IER_DNAK_Pos           9            /**< \brief (TWIM_IER) NAK in Data Phase Received */
-#define TWIM_IER_DNAK               (_U(0x1) << TWIM_IER_DNAK_Pos)
+#define TWIM_IER_DNAK               (_U_(0x1) << TWIM_IER_DNAK_Pos)
 #define TWIM_IER_ARBLST_Pos         10           /**< \brief (TWIM_IER) Arbitration Lost */
-#define TWIM_IER_ARBLST             (_U(0x1) << TWIM_IER_ARBLST_Pos)
+#define TWIM_IER_ARBLST             (_U_(0x1) << TWIM_IER_ARBLST_Pos)
 #define TWIM_IER_SMBALERT_Pos       11           /**< \brief (TWIM_IER) SMBus Alert */
-#define TWIM_IER_SMBALERT           (_U(0x1) << TWIM_IER_SMBALERT_Pos)
+#define TWIM_IER_SMBALERT           (_U_(0x1) << TWIM_IER_SMBALERT_Pos)
 #define TWIM_IER_TOUT_Pos           12           /**< \brief (TWIM_IER) Timeout */
-#define TWIM_IER_TOUT               (_U(0x1) << TWIM_IER_TOUT_Pos)
+#define TWIM_IER_TOUT               (_U_(0x1) << TWIM_IER_TOUT_Pos)
 #define TWIM_IER_PECERR_Pos         13           /**< \brief (TWIM_IER) PEC Error */
-#define TWIM_IER_PECERR             (_U(0x1) << TWIM_IER_PECERR_Pos)
+#define TWIM_IER_PECERR             (_U_(0x1) << TWIM_IER_PECERR_Pos)
 #define TWIM_IER_STOP_Pos           14           /**< \brief (TWIM_IER) Stop Request Accepted */
-#define TWIM_IER_STOP               (_U(0x1) << TWIM_IER_STOP_Pos)
+#define TWIM_IER_STOP               (_U_(0x1) << TWIM_IER_STOP_Pos)
 #define TWIM_IER_HSMCACK_Pos        17           /**< \brief (TWIM_IER) ACK in HS-mode Master Code Phase Received */
-#define TWIM_IER_HSMCACK            (_U(0x1) << TWIM_IER_HSMCACK_Pos)
-#define TWIM_IER_MASK               _U(0x00027F3F) /**< \brief (TWIM_IER) MASK Register */
+#define TWIM_IER_HSMCACK            (_U_(0x1) << TWIM_IER_HSMCACK_Pos)
+#define TWIM_IER_MASK               _U_(0x00027F3F) /**< \brief (TWIM_IER) MASK Register */
 
 /* -------- TWIM_IDR : (TWIM Offset: 0x24) ( /W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -435,37 +435,37 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIM_IDR_OFFSET             0x24         /**< \brief (TWIM_IDR offset) Interrupt Disable Register */
-#define TWIM_IDR_RESETVALUE         _U(0x00000000); /**< \brief (TWIM_IDR reset_value) Interrupt Disable Register */
+#define TWIM_IDR_RESETVALUE         _U_(0x00000000); /**< \brief (TWIM_IDR reset_value) Interrupt Disable Register */
 
 #define TWIM_IDR_RXRDY_Pos          0            /**< \brief (TWIM_IDR) RHR Data Ready */
-#define TWIM_IDR_RXRDY              (_U(0x1) << TWIM_IDR_RXRDY_Pos)
+#define TWIM_IDR_RXRDY              (_U_(0x1) << TWIM_IDR_RXRDY_Pos)
 #define TWIM_IDR_TXRDY_Pos          1            /**< \brief (TWIM_IDR) THR Data Ready */
-#define TWIM_IDR_TXRDY              (_U(0x1) << TWIM_IDR_TXRDY_Pos)
+#define TWIM_IDR_TXRDY              (_U_(0x1) << TWIM_IDR_TXRDY_Pos)
 #define TWIM_IDR_CRDY_Pos           2            /**< \brief (TWIM_IDR) Ready for More Commands */
-#define TWIM_IDR_CRDY               (_U(0x1) << TWIM_IDR_CRDY_Pos)
+#define TWIM_IDR_CRDY               (_U_(0x1) << TWIM_IDR_CRDY_Pos)
 #define TWIM_IDR_CCOMP_Pos          3            /**< \brief (TWIM_IDR) Command Complete */
-#define TWIM_IDR_CCOMP              (_U(0x1) << TWIM_IDR_CCOMP_Pos)
+#define TWIM_IDR_CCOMP              (_U_(0x1) << TWIM_IDR_CCOMP_Pos)
 #define TWIM_IDR_IDLE_Pos           4            /**< \brief (TWIM_IDR) Master Interface is Idle */
-#define TWIM_IDR_IDLE               (_U(0x1) << TWIM_IDR_IDLE_Pos)
+#define TWIM_IDR_IDLE               (_U_(0x1) << TWIM_IDR_IDLE_Pos)
 #define TWIM_IDR_BUSFREE_Pos        5            /**< \brief (TWIM_IDR) Two-wire Bus is Free */
-#define TWIM_IDR_BUSFREE            (_U(0x1) << TWIM_IDR_BUSFREE_Pos)
+#define TWIM_IDR_BUSFREE            (_U_(0x1) << TWIM_IDR_BUSFREE_Pos)
 #define TWIM_IDR_ANAK_Pos           8            /**< \brief (TWIM_IDR) NAK in Address Phase Received */
-#define TWIM_IDR_ANAK               (_U(0x1) << TWIM_IDR_ANAK_Pos)
+#define TWIM_IDR_ANAK               (_U_(0x1) << TWIM_IDR_ANAK_Pos)
 #define TWIM_IDR_DNAK_Pos           9            /**< \brief (TWIM_IDR) NAK in Data Phase Received */
-#define TWIM_IDR_DNAK               (_U(0x1) << TWIM_IDR_DNAK_Pos)
+#define TWIM_IDR_DNAK               (_U_(0x1) << TWIM_IDR_DNAK_Pos)
 #define TWIM_IDR_ARBLST_Pos         10           /**< \brief (TWIM_IDR) Arbitration Lost */
-#define TWIM_IDR_ARBLST             (_U(0x1) << TWIM_IDR_ARBLST_Pos)
+#define TWIM_IDR_ARBLST             (_U_(0x1) << TWIM_IDR_ARBLST_Pos)
 #define TWIM_IDR_SMBALERT_Pos       11           /**< \brief (TWIM_IDR) SMBus Alert */
-#define TWIM_IDR_SMBALERT           (_U(0x1) << TWIM_IDR_SMBALERT_Pos)
+#define TWIM_IDR_SMBALERT           (_U_(0x1) << TWIM_IDR_SMBALERT_Pos)
 #define TWIM_IDR_TOUT_Pos           12           /**< \brief (TWIM_IDR) Timeout */
-#define TWIM_IDR_TOUT               (_U(0x1) << TWIM_IDR_TOUT_Pos)
+#define TWIM_IDR_TOUT               (_U_(0x1) << TWIM_IDR_TOUT_Pos)
 #define TWIM_IDR_PECERR_Pos         13           /**< \brief (TWIM_IDR) PEC Error */
-#define TWIM_IDR_PECERR             (_U(0x1) << TWIM_IDR_PECERR_Pos)
+#define TWIM_IDR_PECERR             (_U_(0x1) << TWIM_IDR_PECERR_Pos)
 #define TWIM_IDR_STOP_Pos           14           /**< \brief (TWIM_IDR) Stop Request Accepted */
-#define TWIM_IDR_STOP               (_U(0x1) << TWIM_IDR_STOP_Pos)
+#define TWIM_IDR_STOP               (_U_(0x1) << TWIM_IDR_STOP_Pos)
 #define TWIM_IDR_HSMCACK_Pos        17           /**< \brief (TWIM_IDR) ACK in HS-mode Master Code Phase Received */
-#define TWIM_IDR_HSMCACK            (_U(0x1) << TWIM_IDR_HSMCACK_Pos)
-#define TWIM_IDR_MASK               _U(0x00027F3F) /**< \brief (TWIM_IDR) MASK Register */
+#define TWIM_IDR_HSMCACK            (_U_(0x1) << TWIM_IDR_HSMCACK_Pos)
+#define TWIM_IDR_MASK               _U_(0x00027F3F) /**< \brief (TWIM_IDR) MASK Register */
 
 /* -------- TWIM_IMR : (TWIM Offset: 0x28) (R/  32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -494,37 +494,37 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIM_IMR_OFFSET             0x28         /**< \brief (TWIM_IMR offset) Interrupt Mask Register */
-#define TWIM_IMR_RESETVALUE         _U(0x00000000); /**< \brief (TWIM_IMR reset_value) Interrupt Mask Register */
+#define TWIM_IMR_RESETVALUE         _U_(0x00000000); /**< \brief (TWIM_IMR reset_value) Interrupt Mask Register */
 
 #define TWIM_IMR_RXRDY_Pos          0            /**< \brief (TWIM_IMR) RHR Data Ready */
-#define TWIM_IMR_RXRDY              (_U(0x1) << TWIM_IMR_RXRDY_Pos)
+#define TWIM_IMR_RXRDY              (_U_(0x1) << TWIM_IMR_RXRDY_Pos)
 #define TWIM_IMR_TXRDY_Pos          1            /**< \brief (TWIM_IMR) THR Data Ready */
-#define TWIM_IMR_TXRDY              (_U(0x1) << TWIM_IMR_TXRDY_Pos)
+#define TWIM_IMR_TXRDY              (_U_(0x1) << TWIM_IMR_TXRDY_Pos)
 #define TWIM_IMR_CRDY_Pos           2            /**< \brief (TWIM_IMR) Ready for More Commands */
-#define TWIM_IMR_CRDY               (_U(0x1) << TWIM_IMR_CRDY_Pos)
+#define TWIM_IMR_CRDY               (_U_(0x1) << TWIM_IMR_CRDY_Pos)
 #define TWIM_IMR_CCOMP_Pos          3            /**< \brief (TWIM_IMR) Command Complete */
-#define TWIM_IMR_CCOMP              (_U(0x1) << TWIM_IMR_CCOMP_Pos)
+#define TWIM_IMR_CCOMP              (_U_(0x1) << TWIM_IMR_CCOMP_Pos)
 #define TWIM_IMR_IDLE_Pos           4            /**< \brief (TWIM_IMR) Master Interface is Idle */
-#define TWIM_IMR_IDLE               (_U(0x1) << TWIM_IMR_IDLE_Pos)
+#define TWIM_IMR_IDLE               (_U_(0x1) << TWIM_IMR_IDLE_Pos)
 #define TWIM_IMR_BUSFREE_Pos        5            /**< \brief (TWIM_IMR) Two-wire Bus is Free */
-#define TWIM_IMR_BUSFREE            (_U(0x1) << TWIM_IMR_BUSFREE_Pos)
+#define TWIM_IMR_BUSFREE            (_U_(0x1) << TWIM_IMR_BUSFREE_Pos)
 #define TWIM_IMR_ANAK_Pos           8            /**< \brief (TWIM_IMR) NAK in Address Phase Received */
-#define TWIM_IMR_ANAK               (_U(0x1) << TWIM_IMR_ANAK_Pos)
+#define TWIM_IMR_ANAK               (_U_(0x1) << TWIM_IMR_ANAK_Pos)
 #define TWIM_IMR_DNAK_Pos           9            /**< \brief (TWIM_IMR) NAK in Data Phase Received */
-#define TWIM_IMR_DNAK               (_U(0x1) << TWIM_IMR_DNAK_Pos)
+#define TWIM_IMR_DNAK               (_U_(0x1) << TWIM_IMR_DNAK_Pos)
 #define TWIM_IMR_ARBLST_Pos         10           /**< \brief (TWIM_IMR) Arbitration Lost */
-#define TWIM_IMR_ARBLST             (_U(0x1) << TWIM_IMR_ARBLST_Pos)
+#define TWIM_IMR_ARBLST             (_U_(0x1) << TWIM_IMR_ARBLST_Pos)
 #define TWIM_IMR_SMBALERT_Pos       11           /**< \brief (TWIM_IMR) SMBus Alert */
-#define TWIM_IMR_SMBALERT           (_U(0x1) << TWIM_IMR_SMBALERT_Pos)
+#define TWIM_IMR_SMBALERT           (_U_(0x1) << TWIM_IMR_SMBALERT_Pos)
 #define TWIM_IMR_TOUT_Pos           12           /**< \brief (TWIM_IMR) Timeout */
-#define TWIM_IMR_TOUT               (_U(0x1) << TWIM_IMR_TOUT_Pos)
+#define TWIM_IMR_TOUT               (_U_(0x1) << TWIM_IMR_TOUT_Pos)
 #define TWIM_IMR_PECERR_Pos         13           /**< \brief (TWIM_IMR) PEC Error */
-#define TWIM_IMR_PECERR             (_U(0x1) << TWIM_IMR_PECERR_Pos)
+#define TWIM_IMR_PECERR             (_U_(0x1) << TWIM_IMR_PECERR_Pos)
 #define TWIM_IMR_STOP_Pos           14           /**< \brief (TWIM_IMR) Stop Request Accepted */
-#define TWIM_IMR_STOP               (_U(0x1) << TWIM_IMR_STOP_Pos)
+#define TWIM_IMR_STOP               (_U_(0x1) << TWIM_IMR_STOP_Pos)
 #define TWIM_IMR_HSMCACK_Pos        17           /**< \brief (TWIM_IMR) ACK in HS-mode Master Code Phase Received */
-#define TWIM_IMR_HSMCACK            (_U(0x1) << TWIM_IMR_HSMCACK_Pos)
-#define TWIM_IMR_MASK               _U(0x00027F3F) /**< \brief (TWIM_IMR) MASK Register */
+#define TWIM_IMR_HSMCACK            (_U_(0x1) << TWIM_IMR_HSMCACK_Pos)
+#define TWIM_IMR_MASK               _U_(0x00027F3F) /**< \brief (TWIM_IMR) MASK Register */
 
 /* -------- TWIM_SCR : (TWIM Offset: 0x2C) ( /W 32) Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -549,27 +549,27 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIM_SCR_OFFSET             0x2C         /**< \brief (TWIM_SCR offset) Status Clear Register */
-#define TWIM_SCR_RESETVALUE         _U(0x00000000); /**< \brief (TWIM_SCR reset_value) Status Clear Register */
+#define TWIM_SCR_RESETVALUE         _U_(0x00000000); /**< \brief (TWIM_SCR reset_value) Status Clear Register */
 
 #define TWIM_SCR_CCOMP_Pos          3            /**< \brief (TWIM_SCR) Command Complete */
-#define TWIM_SCR_CCOMP              (_U(0x1) << TWIM_SCR_CCOMP_Pos)
+#define TWIM_SCR_CCOMP              (_U_(0x1) << TWIM_SCR_CCOMP_Pos)
 #define TWIM_SCR_ANAK_Pos           8            /**< \brief (TWIM_SCR) NAK in Address Phase Received */
-#define TWIM_SCR_ANAK               (_U(0x1) << TWIM_SCR_ANAK_Pos)
+#define TWIM_SCR_ANAK               (_U_(0x1) << TWIM_SCR_ANAK_Pos)
 #define TWIM_SCR_DNAK_Pos           9            /**< \brief (TWIM_SCR) NAK in Data Phase Received */
-#define TWIM_SCR_DNAK               (_U(0x1) << TWIM_SCR_DNAK_Pos)
+#define TWIM_SCR_DNAK               (_U_(0x1) << TWIM_SCR_DNAK_Pos)
 #define TWIM_SCR_ARBLST_Pos         10           /**< \brief (TWIM_SCR) Arbitration Lost */
-#define TWIM_SCR_ARBLST             (_U(0x1) << TWIM_SCR_ARBLST_Pos)
+#define TWIM_SCR_ARBLST             (_U_(0x1) << TWIM_SCR_ARBLST_Pos)
 #define TWIM_SCR_SMBALERT_Pos       11           /**< \brief (TWIM_SCR) SMBus Alert */
-#define TWIM_SCR_SMBALERT           (_U(0x1) << TWIM_SCR_SMBALERT_Pos)
+#define TWIM_SCR_SMBALERT           (_U_(0x1) << TWIM_SCR_SMBALERT_Pos)
 #define TWIM_SCR_TOUT_Pos           12           /**< \brief (TWIM_SCR) Timeout */
-#define TWIM_SCR_TOUT               (_U(0x1) << TWIM_SCR_TOUT_Pos)
+#define TWIM_SCR_TOUT               (_U_(0x1) << TWIM_SCR_TOUT_Pos)
 #define TWIM_SCR_PECERR_Pos         13           /**< \brief (TWIM_SCR) PEC Error */
-#define TWIM_SCR_PECERR             (_U(0x1) << TWIM_SCR_PECERR_Pos)
+#define TWIM_SCR_PECERR             (_U_(0x1) << TWIM_SCR_PECERR_Pos)
 #define TWIM_SCR_STOP_Pos           14           /**< \brief (TWIM_SCR) Stop Request Accepted */
-#define TWIM_SCR_STOP               (_U(0x1) << TWIM_SCR_STOP_Pos)
+#define TWIM_SCR_STOP               (_U_(0x1) << TWIM_SCR_STOP_Pos)
 #define TWIM_SCR_HSMCACK_Pos        17           /**< \brief (TWIM_SCR) ACK in HS-mode Master Code Phase Received */
-#define TWIM_SCR_HSMCACK            (_U(0x1) << TWIM_SCR_HSMCACK_Pos)
-#define TWIM_SCR_MASK               _U(0x00027F08) /**< \brief (TWIM_SCR) MASK Register */
+#define TWIM_SCR_HSMCACK            (_U_(0x1) << TWIM_SCR_HSMCACK_Pos)
+#define TWIM_SCR_MASK               _U_(0x00027F08) /**< \brief (TWIM_SCR) MASK Register */
 
 /* -------- TWIM_PR : (TWIM Offset: 0x30) (R/  32) Parameter Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -583,11 +583,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIM_PR_OFFSET              0x30         /**< \brief (TWIM_PR offset) Parameter Register */
-#define TWIM_PR_RESETVALUE          _U(0x00000001); /**< \brief (TWIM_PR reset_value) Parameter Register */
+#define TWIM_PR_RESETVALUE          _U_(0x00000001); /**< \brief (TWIM_PR reset_value) Parameter Register */
 
 #define TWIM_PR_HS_Pos              0            /**< \brief (TWIM_PR) HS-mode */
-#define TWIM_PR_HS                  (_U(0x1) << TWIM_PR_HS_Pos)
-#define TWIM_PR_MASK                _U(0x00000001) /**< \brief (TWIM_PR) MASK Register */
+#define TWIM_PR_HS                  (_U_(0x1) << TWIM_PR_HS_Pos)
+#define TWIM_PR_MASK                _U_(0x00000001) /**< \brief (TWIM_PR) MASK Register */
 
 /* -------- TWIM_VR : (TWIM Offset: 0x34) (R/  32) Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -603,15 +603,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIM_VR_OFFSET              0x34         /**< \brief (TWIM_VR offset) Version Register */
-#define TWIM_VR_RESETVALUE          _U(0x00000120); /**< \brief (TWIM_VR reset_value) Version Register */
+#define TWIM_VR_RESETVALUE          _U_(0x00000120); /**< \brief (TWIM_VR reset_value) Version Register */
 
 #define TWIM_VR_VERSION_Pos         0            /**< \brief (TWIM_VR) Version number */
-#define TWIM_VR_VERSION_Msk         (_U(0xFFF) << TWIM_VR_VERSION_Pos)
+#define TWIM_VR_VERSION_Msk         (_U_(0xFFF) << TWIM_VR_VERSION_Pos)
 #define TWIM_VR_VERSION(value)      (TWIM_VR_VERSION_Msk & ((value) << TWIM_VR_VERSION_Pos))
 #define TWIM_VR_VARIANT_Pos         16           /**< \brief (TWIM_VR) Variant number */
-#define TWIM_VR_VARIANT_Msk         (_U(0xF) << TWIM_VR_VARIANT_Pos)
+#define TWIM_VR_VARIANT_Msk         (_U_(0xF) << TWIM_VR_VARIANT_Pos)
 #define TWIM_VR_VARIANT(value)      (TWIM_VR_VARIANT_Msk & ((value) << TWIM_VR_VARIANT_Pos))
-#define TWIM_VR_MASK                _U(0x000F0FFF) /**< \brief (TWIM_VR) MASK Register */
+#define TWIM_VR_MASK                _U_(0x000F0FFF) /**< \brief (TWIM_VR) MASK Register */
 
 /* -------- TWIM_HSCWGR : (TWIM Offset: 0x38) (R/W 32) HS-mode Clock Waveform Generator -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -629,24 +629,24 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIM_HSCWGR_OFFSET          0x38         /**< \brief (TWIM_HSCWGR offset) HS-mode Clock Waveform Generator */
-#define TWIM_HSCWGR_RESETVALUE      _U(0x00000000); /**< \brief (TWIM_HSCWGR reset_value) HS-mode Clock Waveform Generator */
+#define TWIM_HSCWGR_RESETVALUE      _U_(0x00000000); /**< \brief (TWIM_HSCWGR reset_value) HS-mode Clock Waveform Generator */
 
 #define TWIM_HSCWGR_LOW_Pos         0            /**< \brief (TWIM_HSCWGR) Clock Low Cycles */
-#define TWIM_HSCWGR_LOW_Msk         (_U(0xFF) << TWIM_HSCWGR_LOW_Pos)
+#define TWIM_HSCWGR_LOW_Msk         (_U_(0xFF) << TWIM_HSCWGR_LOW_Pos)
 #define TWIM_HSCWGR_LOW(value)      (TWIM_HSCWGR_LOW_Msk & ((value) << TWIM_HSCWGR_LOW_Pos))
 #define TWIM_HSCWGR_HIGH_Pos        8            /**< \brief (TWIM_HSCWGR) Clock High Cycles */
-#define TWIM_HSCWGR_HIGH_Msk        (_U(0xFF) << TWIM_HSCWGR_HIGH_Pos)
+#define TWIM_HSCWGR_HIGH_Msk        (_U_(0xFF) << TWIM_HSCWGR_HIGH_Pos)
 #define TWIM_HSCWGR_HIGH(value)     (TWIM_HSCWGR_HIGH_Msk & ((value) << TWIM_HSCWGR_HIGH_Pos))
 #define TWIM_HSCWGR_STASTO_Pos      16           /**< \brief (TWIM_HSCWGR) START and STOP Cycles */
-#define TWIM_HSCWGR_STASTO_Msk      (_U(0xFF) << TWIM_HSCWGR_STASTO_Pos)
+#define TWIM_HSCWGR_STASTO_Msk      (_U_(0xFF) << TWIM_HSCWGR_STASTO_Pos)
 #define TWIM_HSCWGR_STASTO(value)   (TWIM_HSCWGR_STASTO_Msk & ((value) << TWIM_HSCWGR_STASTO_Pos))
 #define TWIM_HSCWGR_DATA_Pos        24           /**< \brief (TWIM_HSCWGR) Data Setup and Hold Cycles */
-#define TWIM_HSCWGR_DATA_Msk        (_U(0xF) << TWIM_HSCWGR_DATA_Pos)
+#define TWIM_HSCWGR_DATA_Msk        (_U_(0xF) << TWIM_HSCWGR_DATA_Pos)
 #define TWIM_HSCWGR_DATA(value)     (TWIM_HSCWGR_DATA_Msk & ((value) << TWIM_HSCWGR_DATA_Pos))
 #define TWIM_HSCWGR_EXP_Pos         28           /**< \brief (TWIM_HSCWGR) Clock Prescaler */
-#define TWIM_HSCWGR_EXP_Msk         (_U(0x7) << TWIM_HSCWGR_EXP_Pos)
+#define TWIM_HSCWGR_EXP_Msk         (_U_(0x7) << TWIM_HSCWGR_EXP_Pos)
 #define TWIM_HSCWGR_EXP(value)      (TWIM_HSCWGR_EXP_Msk & ((value) << TWIM_HSCWGR_EXP_Pos))
-#define TWIM_HSCWGR_MASK            _U(0x7FFFFFFF) /**< \brief (TWIM_HSCWGR) MASK Register */
+#define TWIM_HSCWGR_MASK            _U_(0x7FFFFFFF) /**< \brief (TWIM_HSCWGR) MASK Register */
 
 /* -------- TWIM_SRR : (TWIM Offset: 0x3C) (R/W 32) Slew Rate Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -668,24 +668,24 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIM_SRR_OFFSET             0x3C         /**< \brief (TWIM_SRR offset) Slew Rate Register */
-#define TWIM_SRR_RESETVALUE         _U(0x00000000); /**< \brief (TWIM_SRR reset_value) Slew Rate Register */
+#define TWIM_SRR_RESETVALUE         _U_(0x00000000); /**< \brief (TWIM_SRR reset_value) Slew Rate Register */
 
 #define TWIM_SRR_DADRIVEL_Pos       0            /**< \brief (TWIM_SRR) Data Drive Strength LOW */
-#define TWIM_SRR_DADRIVEL_Msk       (_U(0x7) << TWIM_SRR_DADRIVEL_Pos)
+#define TWIM_SRR_DADRIVEL_Msk       (_U_(0x7) << TWIM_SRR_DADRIVEL_Pos)
 #define TWIM_SRR_DADRIVEL(value)    (TWIM_SRR_DADRIVEL_Msk & ((value) << TWIM_SRR_DADRIVEL_Pos))
 #define TWIM_SRR_DASLEW_Pos         8            /**< \brief (TWIM_SRR) Data Slew Limit */
-#define TWIM_SRR_DASLEW_Msk         (_U(0x3) << TWIM_SRR_DASLEW_Pos)
+#define TWIM_SRR_DASLEW_Msk         (_U_(0x3) << TWIM_SRR_DASLEW_Pos)
 #define TWIM_SRR_DASLEW(value)      (TWIM_SRR_DASLEW_Msk & ((value) << TWIM_SRR_DASLEW_Pos))
 #define TWIM_SRR_CLDRIVEL_Pos       16           /**< \brief (TWIM_SRR) Clock Drive Strength LOW */
-#define TWIM_SRR_CLDRIVEL_Msk       (_U(0x7) << TWIM_SRR_CLDRIVEL_Pos)
+#define TWIM_SRR_CLDRIVEL_Msk       (_U_(0x7) << TWIM_SRR_CLDRIVEL_Pos)
 #define TWIM_SRR_CLDRIVEL(value)    (TWIM_SRR_CLDRIVEL_Msk & ((value) << TWIM_SRR_CLDRIVEL_Pos))
 #define TWIM_SRR_CLSLEW_Pos         24           /**< \brief (TWIM_SRR) Clock Slew Limit */
-#define TWIM_SRR_CLSLEW_Msk         (_U(0x3) << TWIM_SRR_CLSLEW_Pos)
+#define TWIM_SRR_CLSLEW_Msk         (_U_(0x3) << TWIM_SRR_CLSLEW_Pos)
 #define TWIM_SRR_CLSLEW(value)      (TWIM_SRR_CLSLEW_Msk & ((value) << TWIM_SRR_CLSLEW_Pos))
 #define TWIM_SRR_FILTER_Pos         28           /**< \brief (TWIM_SRR) Input Spike Filter Control */
-#define TWIM_SRR_FILTER_Msk         (_U(0x3) << TWIM_SRR_FILTER_Pos)
+#define TWIM_SRR_FILTER_Msk         (_U_(0x3) << TWIM_SRR_FILTER_Pos)
 #define TWIM_SRR_FILTER(value)      (TWIM_SRR_FILTER_Msk & ((value) << TWIM_SRR_FILTER_Pos))
-#define TWIM_SRR_MASK               _U(0x33070307) /**< \brief (TWIM_SRR) MASK Register */
+#define TWIM_SRR_MASK               _U_(0x33070307) /**< \brief (TWIM_SRR) MASK Register */
 
 /* -------- TWIM_HSSRR : (TWIM Offset: 0x40) (R/W 32) HS-mode Slew Rate Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -709,27 +709,27 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIM_HSSRR_OFFSET           0x40         /**< \brief (TWIM_HSSRR offset) HS-mode Slew Rate Register */
-#define TWIM_HSSRR_RESETVALUE       _U(0x00000000); /**< \brief (TWIM_HSSRR reset_value) HS-mode Slew Rate Register */
+#define TWIM_HSSRR_RESETVALUE       _U_(0x00000000); /**< \brief (TWIM_HSSRR reset_value) HS-mode Slew Rate Register */
 
 #define TWIM_HSSRR_DADRIVEL_Pos     0            /**< \brief (TWIM_HSSRR) Data Drive Strength LOW */
-#define TWIM_HSSRR_DADRIVEL_Msk     (_U(0x7) << TWIM_HSSRR_DADRIVEL_Pos)
+#define TWIM_HSSRR_DADRIVEL_Msk     (_U_(0x7) << TWIM_HSSRR_DADRIVEL_Pos)
 #define TWIM_HSSRR_DADRIVEL(value)  (TWIM_HSSRR_DADRIVEL_Msk & ((value) << TWIM_HSSRR_DADRIVEL_Pos))
 #define TWIM_HSSRR_DASLEW_Pos       8            /**< \brief (TWIM_HSSRR) Data Slew Limit */
-#define TWIM_HSSRR_DASLEW_Msk       (_U(0x3) << TWIM_HSSRR_DASLEW_Pos)
+#define TWIM_HSSRR_DASLEW_Msk       (_U_(0x3) << TWIM_HSSRR_DASLEW_Pos)
 #define TWIM_HSSRR_DASLEW(value)    (TWIM_HSSRR_DASLEW_Msk & ((value) << TWIM_HSSRR_DASLEW_Pos))
 #define TWIM_HSSRR_CLDRIVEL_Pos     16           /**< \brief (TWIM_HSSRR) Clock Drive Strength LOW */
-#define TWIM_HSSRR_CLDRIVEL_Msk     (_U(0x7) << TWIM_HSSRR_CLDRIVEL_Pos)
+#define TWIM_HSSRR_CLDRIVEL_Msk     (_U_(0x7) << TWIM_HSSRR_CLDRIVEL_Pos)
 #define TWIM_HSSRR_CLDRIVEL(value)  (TWIM_HSSRR_CLDRIVEL_Msk & ((value) << TWIM_HSSRR_CLDRIVEL_Pos))
 #define TWIM_HSSRR_CLDRIVEH_Pos     20           /**< \brief (TWIM_HSSRR) Clock Drive Strength HIGH */
-#define TWIM_HSSRR_CLDRIVEH_Msk     (_U(0x3) << TWIM_HSSRR_CLDRIVEH_Pos)
+#define TWIM_HSSRR_CLDRIVEH_Msk     (_U_(0x3) << TWIM_HSSRR_CLDRIVEH_Pos)
 #define TWIM_HSSRR_CLDRIVEH(value)  (TWIM_HSSRR_CLDRIVEH_Msk & ((value) << TWIM_HSSRR_CLDRIVEH_Pos))
 #define TWIM_HSSRR_CLSLEW_Pos       24           /**< \brief (TWIM_HSSRR) Clock Slew Limit */
-#define TWIM_HSSRR_CLSLEW_Msk       (_U(0x3) << TWIM_HSSRR_CLSLEW_Pos)
+#define TWIM_HSSRR_CLSLEW_Msk       (_U_(0x3) << TWIM_HSSRR_CLSLEW_Pos)
 #define TWIM_HSSRR_CLSLEW(value)    (TWIM_HSSRR_CLSLEW_Msk & ((value) << TWIM_HSSRR_CLSLEW_Pos))
 #define TWIM_HSSRR_FILTER_Pos       28           /**< \brief (TWIM_HSSRR) Input Spike Filter Control */
-#define TWIM_HSSRR_FILTER_Msk       (_U(0x3) << TWIM_HSSRR_FILTER_Pos)
+#define TWIM_HSSRR_FILTER_Msk       (_U_(0x3) << TWIM_HSSRR_FILTER_Pos)
 #define TWIM_HSSRR_FILTER(value)    (TWIM_HSSRR_FILTER_Msk & ((value) << TWIM_HSSRR_FILTER_Pos))
-#define TWIM_HSSRR_MASK             _U(0x33370307) /**< \brief (TWIM_HSSRR) MASK Register */
+#define TWIM_HSSRR_MASK             _U_(0x33370307) /**< \brief (TWIM_HSSRR) MASK Register */
 
 /** \brief TWIM hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/twim.h
+++ b/asf/sam/include/sam4l/component/twim.h
@@ -733,45 +733,24 @@ typedef union {
 
 /** \brief TWIM hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __O  TWIM_CR_Type              CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
-  __IO TWIM_CWGR_Type            CWGR;        /**< \brief Offset: 0x04 (R/W 32) Clock Waveform Generator Register */
-  __IO TWIM_SMBTR_Type           SMBTR;       /**< \brief Offset: 0x08 (R/W 32) SMBus Timing Register */
-  __IO TWIM_CMDR_Type            CMDR;        /**< \brief Offset: 0x0C (R/W 32) Command Register */
-  __IO TWIM_NCMDR_Type           NCMDR;       /**< \brief Offset: 0x10 (R/W 32) Next Command Register */
-  __I  TWIM_RHR_Type             RHR;         /**< \brief Offset: 0x14 (R/  32) Receive Holding Register */
-  __O  TWIM_THR_Type             THR;         /**< \brief Offset: 0x18 ( /W 32) Transmit Holding Register */
-  __I  TWIM_SR_Type              SR;          /**< \brief Offset: 0x1C (R/  32) Status Register */
-  __O  TWIM_IER_Type             IER;         /**< \brief Offset: 0x20 ( /W 32) Interrupt Enable Register */
-  __O  TWIM_IDR_Type             IDR;         /**< \brief Offset: 0x24 ( /W 32) Interrupt Disable Register */
-  __I  TWIM_IMR_Type             IMR;         /**< \brief Offset: 0x28 (R/  32) Interrupt Mask Register */
-  __O  TWIM_SCR_Type             SCR;         /**< \brief Offset: 0x2C ( /W 32) Status Clear Register */
-  __I  TWIM_PR_Type              PR;          /**< \brief Offset: 0x30 (R/  32) Parameter Register */
-  __I  TWIM_VR_Type              VR;          /**< \brief Offset: 0x34 (R/  32) Version Register */
-  __IO TWIM_HSCWGR_Type          HSCWGR;      /**< \brief Offset: 0x38 (R/W 32) HS-mode Clock Waveform Generator */
-  __IO TWIM_SRR_Type             SRR;         /**< \brief Offset: 0x3C (R/W 32) Slew Rate Register */
-  __IO TWIM_HSSRR_Type           HSSRR;       /**< \brief Offset: 0x40 (R/W 32) HS-mode Slew Rate Register */
- } bf;
- struct {
-  WoReg   TWIM_CR;            /**< \brief (TWIM Offset: 0x00) Control Register */
-  RwReg   TWIM_CWGR;          /**< \brief (TWIM Offset: 0x04) Clock Waveform Generator Register */
-  RwReg   TWIM_SMBTR;         /**< \brief (TWIM Offset: 0x08) SMBus Timing Register */
-  RwReg   TWIM_CMDR;          /**< \brief (TWIM Offset: 0x0C) Command Register */
-  RwReg   TWIM_NCMDR;         /**< \brief (TWIM Offset: 0x10) Next Command Register */
-  RoReg   TWIM_RHR;           /**< \brief (TWIM Offset: 0x14) Receive Holding Register */
-  WoReg   TWIM_THR;           /**< \brief (TWIM Offset: 0x18) Transmit Holding Register */
-  RoReg   TWIM_SR;            /**< \brief (TWIM Offset: 0x1C) Status Register */
-  WoReg   TWIM_IER;           /**< \brief (TWIM Offset: 0x20) Interrupt Enable Register */
-  WoReg   TWIM_IDR;           /**< \brief (TWIM Offset: 0x24) Interrupt Disable Register */
-  RoReg   TWIM_IMR;           /**< \brief (TWIM Offset: 0x28) Interrupt Mask Register */
-  WoReg   TWIM_SCR;           /**< \brief (TWIM Offset: 0x2C) Status Clear Register */
-  RoReg   TWIM_PR;            /**< \brief (TWIM Offset: 0x30) Parameter Register */
-  RoReg   TWIM_VR;            /**< \brief (TWIM Offset: 0x34) Version Register */
-  RwReg   TWIM_HSCWGR;        /**< \brief (TWIM Offset: 0x38) HS-mode Clock Waveform Generator */
-  RwReg   TWIM_SRR;           /**< \brief (TWIM Offset: 0x3C) Slew Rate Register */
-  RwReg   TWIM_HSSRR;         /**< \brief (TWIM Offset: 0x40) HS-mode Slew Rate Register */
- } reg;
+typedef struct {
+  __O  uint32_t CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
+  __IO uint32_t CWGR;        /**< \brief Offset: 0x04 (R/W 32) Clock Waveform Generator Register */
+  __IO uint32_t SMBTR;       /**< \brief Offset: 0x08 (R/W 32) SMBus Timing Register */
+  __IO uint32_t CMDR;        /**< \brief Offset: 0x0C (R/W 32) Command Register */
+  __IO uint32_t NCMDR;       /**< \brief Offset: 0x10 (R/W 32) Next Command Register */
+  __I  uint32_t RHR;         /**< \brief Offset: 0x14 (R/  32) Receive Holding Register */
+  __O  uint32_t THR;         /**< \brief Offset: 0x18 ( /W 32) Transmit Holding Register */
+  __I  uint32_t SR;          /**< \brief Offset: 0x1C (R/  32) Status Register */
+  __O  uint32_t IER;         /**< \brief Offset: 0x20 ( /W 32) Interrupt Enable Register */
+  __O  uint32_t IDR;         /**< \brief Offset: 0x24 ( /W 32) Interrupt Disable Register */
+  __I  uint32_t IMR;         /**< \brief Offset: 0x28 (R/  32) Interrupt Mask Register */
+  __O  uint32_t SCR;         /**< \brief Offset: 0x2C ( /W 32) Status Clear Register */
+  __I  uint32_t PR;          /**< \brief Offset: 0x30 (R/  32) Parameter Register */
+  __I  uint32_t VR;          /**< \brief Offset: 0x34 (R/  32) Version Register */
+  __IO uint32_t HSCWGR;      /**< \brief Offset: 0x38 (R/W 32) HS-mode Clock Waveform Generator */
+  __IO uint32_t SRR;         /**< \brief Offset: 0x3C (R/W 32) Slew Rate Register */
+  __IO uint32_t HSSRR;       /**< \brief Offset: 0x40 (R/W 32) HS-mode Slew Rate Register */
 } Twim;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/twim.h
+++ b/asf/sam/include/sam4l/component/twim.h
@@ -1,0 +1,780 @@
+/**
+ * \file
+ *
+ * \brief Component description for TWIM
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_TWIM_COMPONENT_
+#define _SAM4L_TWIM_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR TWIM */
+/* ========================================================================== */
+/** \addtogroup SAM4L_TWIM Two-wire Master Interface */
+/*@{*/
+
+#define TWIM_I7535
+#define REV_TWIM                    0x120
+
+/* -------- TWIM_CR : (TWIM Offset: 0x00) ( /W 32) Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t MEN:1;            /*!< bit:      0  Master Enable                      */
+    uint32_t MDIS:1;           /*!< bit:      1  Master Disable                     */
+    uint32_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint32_t SMEN:1;           /*!< bit:      4  SMBus Enable                       */
+    uint32_t SMDIS:1;          /*!< bit:      5  SMBus Disable                      */
+    uint32_t :1;               /*!< bit:      6  Reserved                           */
+    uint32_t SWRST:1;          /*!< bit:      7  Software Reset                     */
+    uint32_t STOP:1;           /*!< bit:      8  Stop the current transfer          */
+    uint32_t :23;              /*!< bit:  9..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIM_CR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIM_CR_OFFSET              0x00         /**< \brief (TWIM_CR offset) Control Register */
+#define TWIM_CR_RESETVALUE          _U(0x00000000); /**< \brief (TWIM_CR reset_value) Control Register */
+
+#define TWIM_CR_MEN_Pos             0            /**< \brief (TWIM_CR) Master Enable */
+#define TWIM_CR_MEN                 (_U(0x1) << TWIM_CR_MEN_Pos)
+#define TWIM_CR_MDIS_Pos            1            /**< \brief (TWIM_CR) Master Disable */
+#define TWIM_CR_MDIS                (_U(0x1) << TWIM_CR_MDIS_Pos)
+#define TWIM_CR_SMEN_Pos            4            /**< \brief (TWIM_CR) SMBus Enable */
+#define TWIM_CR_SMEN                (_U(0x1) << TWIM_CR_SMEN_Pos)
+#define TWIM_CR_SMDIS_Pos           5            /**< \brief (TWIM_CR) SMBus Disable */
+#define TWIM_CR_SMDIS               (_U(0x1) << TWIM_CR_SMDIS_Pos)
+#define TWIM_CR_SWRST_Pos           7            /**< \brief (TWIM_CR) Software Reset */
+#define TWIM_CR_SWRST               (_U(0x1) << TWIM_CR_SWRST_Pos)
+#define TWIM_CR_STOP_Pos            8            /**< \brief (TWIM_CR) Stop the current transfer */
+#define TWIM_CR_STOP                (_U(0x1) << TWIM_CR_STOP_Pos)
+#define TWIM_CR_MASK                _U(0x000001B3) /**< \brief (TWIM_CR) MASK Register */
+
+/* -------- TWIM_CWGR : (TWIM Offset: 0x04) (R/W 32) Clock Waveform Generator Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t LOW:8;            /*!< bit:  0.. 7  Clock Low Cycles                   */
+    uint32_t HIGH:8;           /*!< bit:  8..15  Clock High Cycles                  */
+    uint32_t STASTO:8;         /*!< bit: 16..23  START and STOP Cycles              */
+    uint32_t DATA:4;           /*!< bit: 24..27  Data Setup and Hold Cycles         */
+    uint32_t EXP:3;            /*!< bit: 28..30  Clock Prescaler                    */
+    uint32_t :1;               /*!< bit:     31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIM_CWGR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIM_CWGR_OFFSET            0x04         /**< \brief (TWIM_CWGR offset) Clock Waveform Generator Register */
+#define TWIM_CWGR_RESETVALUE        _U(0x00000000); /**< \brief (TWIM_CWGR reset_value) Clock Waveform Generator Register */
+
+#define TWIM_CWGR_LOW_Pos           0            /**< \brief (TWIM_CWGR) Clock Low Cycles */
+#define TWIM_CWGR_LOW_Msk           (_U(0xFF) << TWIM_CWGR_LOW_Pos)
+#define TWIM_CWGR_LOW(value)        (TWIM_CWGR_LOW_Msk & ((value) << TWIM_CWGR_LOW_Pos))
+#define TWIM_CWGR_HIGH_Pos          8            /**< \brief (TWIM_CWGR) Clock High Cycles */
+#define TWIM_CWGR_HIGH_Msk          (_U(0xFF) << TWIM_CWGR_HIGH_Pos)
+#define TWIM_CWGR_HIGH(value)       (TWIM_CWGR_HIGH_Msk & ((value) << TWIM_CWGR_HIGH_Pos))
+#define TWIM_CWGR_STASTO_Pos        16           /**< \brief (TWIM_CWGR) START and STOP Cycles */
+#define TWIM_CWGR_STASTO_Msk        (_U(0xFF) << TWIM_CWGR_STASTO_Pos)
+#define TWIM_CWGR_STASTO(value)     (TWIM_CWGR_STASTO_Msk & ((value) << TWIM_CWGR_STASTO_Pos))
+#define TWIM_CWGR_DATA_Pos          24           /**< \brief (TWIM_CWGR) Data Setup and Hold Cycles */
+#define TWIM_CWGR_DATA_Msk          (_U(0xF) << TWIM_CWGR_DATA_Pos)
+#define TWIM_CWGR_DATA(value)       (TWIM_CWGR_DATA_Msk & ((value) << TWIM_CWGR_DATA_Pos))
+#define TWIM_CWGR_EXP_Pos           28           /**< \brief (TWIM_CWGR) Clock Prescaler */
+#define TWIM_CWGR_EXP_Msk           (_U(0x7) << TWIM_CWGR_EXP_Pos)
+#define TWIM_CWGR_EXP(value)        (TWIM_CWGR_EXP_Msk & ((value) << TWIM_CWGR_EXP_Pos))
+#define TWIM_CWGR_MASK              _U(0x7FFFFFFF) /**< \brief (TWIM_CWGR) MASK Register */
+
+/* -------- TWIM_SMBTR : (TWIM Offset: 0x08) (R/W 32) SMBus Timing Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TLOWS:8;          /*!< bit:  0.. 7  Slave Clock stretch maximum cycles */
+    uint32_t TLOWM:8;          /*!< bit:  8..15  Master Clock stretch maximum cycles */
+    uint32_t THMAX:8;          /*!< bit: 16..23  Clock High maximum cycles          */
+    uint32_t :4;               /*!< bit: 24..27  Reserved                           */
+    uint32_t EXP:4;            /*!< bit: 28..31  SMBus Timeout Clock prescaler      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIM_SMBTR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIM_SMBTR_OFFSET           0x08         /**< \brief (TWIM_SMBTR offset) SMBus Timing Register */
+#define TWIM_SMBTR_RESETVALUE       _U(0x00000000); /**< \brief (TWIM_SMBTR reset_value) SMBus Timing Register */
+
+#define TWIM_SMBTR_TLOWS_Pos        0            /**< \brief (TWIM_SMBTR) Slave Clock stretch maximum cycles */
+#define TWIM_SMBTR_TLOWS_Msk        (_U(0xFF) << TWIM_SMBTR_TLOWS_Pos)
+#define TWIM_SMBTR_TLOWS(value)     (TWIM_SMBTR_TLOWS_Msk & ((value) << TWIM_SMBTR_TLOWS_Pos))
+#define TWIM_SMBTR_TLOWM_Pos        8            /**< \brief (TWIM_SMBTR) Master Clock stretch maximum cycles */
+#define TWIM_SMBTR_TLOWM_Msk        (_U(0xFF) << TWIM_SMBTR_TLOWM_Pos)
+#define TWIM_SMBTR_TLOWM(value)     (TWIM_SMBTR_TLOWM_Msk & ((value) << TWIM_SMBTR_TLOWM_Pos))
+#define TWIM_SMBTR_THMAX_Pos        16           /**< \brief (TWIM_SMBTR) Clock High maximum cycles */
+#define TWIM_SMBTR_THMAX_Msk        (_U(0xFF) << TWIM_SMBTR_THMAX_Pos)
+#define TWIM_SMBTR_THMAX(value)     (TWIM_SMBTR_THMAX_Msk & ((value) << TWIM_SMBTR_THMAX_Pos))
+#define TWIM_SMBTR_EXP_Pos          28           /**< \brief (TWIM_SMBTR) SMBus Timeout Clock prescaler */
+#define TWIM_SMBTR_EXP_Msk          (_U(0xF) << TWIM_SMBTR_EXP_Pos)
+#define TWIM_SMBTR_EXP(value)       (TWIM_SMBTR_EXP_Msk & ((value) << TWIM_SMBTR_EXP_Pos))
+#define TWIM_SMBTR_MASK             _U(0xF0FFFFFF) /**< \brief (TWIM_SMBTR) MASK Register */
+
+/* -------- TWIM_CMDR : (TWIM Offset: 0x0C) (R/W 32) Command Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t READ:1;           /*!< bit:      0  Transfer Direction                 */
+    uint32_t SADR:10;          /*!< bit:  1..10  Slave Address                      */
+    uint32_t TENBIT:1;         /*!< bit:     11  Ten Bit Addressing Mode            */
+    uint32_t REPSAME:1;        /*!< bit:     12  Transfer is to same address as previous address */
+    uint32_t START:1;          /*!< bit:     13  Send START condition               */
+    uint32_t STOP:1;           /*!< bit:     14  Send STOP condition                */
+    uint32_t VALID:1;          /*!< bit:     15  CMDR Valid                         */
+    uint32_t NBYTES:8;         /*!< bit: 16..23  Number of data bytes in transfer   */
+    uint32_t PECEN:1;          /*!< bit:     24  Packet Error Checking Enable       */
+    uint32_t ACKLAST:1;        /*!< bit:     25  ACK Last Master RX Byte            */
+    uint32_t HS:1;             /*!< bit:     26  HS-mode                            */
+    uint32_t :1;               /*!< bit:     27  Reserved                           */
+    uint32_t HSMCODE:3;        /*!< bit: 28..30  HS-mode Master Code                */
+    uint32_t :1;               /*!< bit:     31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIM_CMDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIM_CMDR_OFFSET            0x0C         /**< \brief (TWIM_CMDR offset) Command Register */
+#define TWIM_CMDR_RESETVALUE        _U(0x00000000); /**< \brief (TWIM_CMDR reset_value) Command Register */
+
+#define TWIM_CMDR_READ_Pos          0            /**< \brief (TWIM_CMDR) Transfer Direction */
+#define TWIM_CMDR_READ              (_U(0x1) << TWIM_CMDR_READ_Pos)
+#define TWIM_CMDR_SADR_Pos          1            /**< \brief (TWIM_CMDR) Slave Address */
+#define TWIM_CMDR_SADR_Msk          (_U(0x3FF) << TWIM_CMDR_SADR_Pos)
+#define TWIM_CMDR_SADR(value)       (TWIM_CMDR_SADR_Msk & ((value) << TWIM_CMDR_SADR_Pos))
+#define TWIM_CMDR_TENBIT_Pos        11           /**< \brief (TWIM_CMDR) Ten Bit Addressing Mode */
+#define TWIM_CMDR_TENBIT            (_U(0x1) << TWIM_CMDR_TENBIT_Pos)
+#define TWIM_CMDR_REPSAME_Pos       12           /**< \brief (TWIM_CMDR) Transfer is to same address as previous address */
+#define TWIM_CMDR_REPSAME           (_U(0x1) << TWIM_CMDR_REPSAME_Pos)
+#define TWIM_CMDR_START_Pos         13           /**< \brief (TWIM_CMDR) Send START condition */
+#define TWIM_CMDR_START             (_U(0x1) << TWIM_CMDR_START_Pos)
+#define TWIM_CMDR_STOP_Pos          14           /**< \brief (TWIM_CMDR) Send STOP condition */
+#define TWIM_CMDR_STOP              (_U(0x1) << TWIM_CMDR_STOP_Pos)
+#define TWIM_CMDR_VALID_Pos         15           /**< \brief (TWIM_CMDR) CMDR Valid */
+#define TWIM_CMDR_VALID             (_U(0x1) << TWIM_CMDR_VALID_Pos)
+#define TWIM_CMDR_NBYTES_Pos        16           /**< \brief (TWIM_CMDR) Number of data bytes in transfer */
+#define TWIM_CMDR_NBYTES_Msk        (_U(0xFF) << TWIM_CMDR_NBYTES_Pos)
+#define TWIM_CMDR_NBYTES(value)     (TWIM_CMDR_NBYTES_Msk & ((value) << TWIM_CMDR_NBYTES_Pos))
+#define TWIM_CMDR_PECEN_Pos         24           /**< \brief (TWIM_CMDR) Packet Error Checking Enable */
+#define TWIM_CMDR_PECEN             (_U(0x1) << TWIM_CMDR_PECEN_Pos)
+#define TWIM_CMDR_ACKLAST_Pos       25           /**< \brief (TWIM_CMDR) ACK Last Master RX Byte */
+#define TWIM_CMDR_ACKLAST           (_U(0x1) << TWIM_CMDR_ACKLAST_Pos)
+#define TWIM_CMDR_HS_Pos            26           /**< \brief (TWIM_CMDR) HS-mode */
+#define TWIM_CMDR_HS                (_U(0x1) << TWIM_CMDR_HS_Pos)
+#define TWIM_CMDR_HSMCODE_Pos       28           /**< \brief (TWIM_CMDR) HS-mode Master Code */
+#define TWIM_CMDR_HSMCODE_Msk       (_U(0x7) << TWIM_CMDR_HSMCODE_Pos)
+#define TWIM_CMDR_HSMCODE(value)    (TWIM_CMDR_HSMCODE_Msk & ((value) << TWIM_CMDR_HSMCODE_Pos))
+#define TWIM_CMDR_MASK              _U(0x77FFFFFF) /**< \brief (TWIM_CMDR) MASK Register */
+
+/* -------- TWIM_NCMDR : (TWIM Offset: 0x10) (R/W 32) Next Command Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t READ:1;           /*!< bit:      0  Transfer Direction                 */
+    uint32_t SADR:10;          /*!< bit:  1..10  Slave Address                      */
+    uint32_t TENBIT:1;         /*!< bit:     11  Ten Bit Addressing Mode            */
+    uint32_t REPSAME:1;        /*!< bit:     12  Transfer is to same address as previous address */
+    uint32_t START:1;          /*!< bit:     13  Send START condition               */
+    uint32_t STOP:1;           /*!< bit:     14  Send STOP condition                */
+    uint32_t VALID:1;          /*!< bit:     15  CMDR Valid                         */
+    uint32_t NBYTES:8;         /*!< bit: 16..23  Number of data bytes in transfer   */
+    uint32_t PECEN:1;          /*!< bit:     24  Packet Error Checking Enable       */
+    uint32_t ACKLAST:1;        /*!< bit:     25  ACK Last Master RX Byte            */
+    uint32_t HS:1;             /*!< bit:     26  HS-mode                            */
+    uint32_t :1;               /*!< bit:     27  Reserved                           */
+    uint32_t HSMCODE:3;        /*!< bit: 28..30  HS-mode Master Code                */
+    uint32_t :1;               /*!< bit:     31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIM_NCMDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIM_NCMDR_OFFSET           0x10         /**< \brief (TWIM_NCMDR offset) Next Command Register */
+#define TWIM_NCMDR_RESETVALUE       _U(0x00000000); /**< \brief (TWIM_NCMDR reset_value) Next Command Register */
+
+#define TWIM_NCMDR_READ_Pos         0            /**< \brief (TWIM_NCMDR) Transfer Direction */
+#define TWIM_NCMDR_READ             (_U(0x1) << TWIM_NCMDR_READ_Pos)
+#define TWIM_NCMDR_SADR_Pos         1            /**< \brief (TWIM_NCMDR) Slave Address */
+#define TWIM_NCMDR_SADR_Msk         (_U(0x3FF) << TWIM_NCMDR_SADR_Pos)
+#define TWIM_NCMDR_SADR(value)      (TWIM_NCMDR_SADR_Msk & ((value) << TWIM_NCMDR_SADR_Pos))
+#define TWIM_NCMDR_TENBIT_Pos       11           /**< \brief (TWIM_NCMDR) Ten Bit Addressing Mode */
+#define TWIM_NCMDR_TENBIT           (_U(0x1) << TWIM_NCMDR_TENBIT_Pos)
+#define TWIM_NCMDR_REPSAME_Pos      12           /**< \brief (TWIM_NCMDR) Transfer is to same address as previous address */
+#define TWIM_NCMDR_REPSAME          (_U(0x1) << TWIM_NCMDR_REPSAME_Pos)
+#define TWIM_NCMDR_START_Pos        13           /**< \brief (TWIM_NCMDR) Send START condition */
+#define TWIM_NCMDR_START            (_U(0x1) << TWIM_NCMDR_START_Pos)
+#define TWIM_NCMDR_STOP_Pos         14           /**< \brief (TWIM_NCMDR) Send STOP condition */
+#define TWIM_NCMDR_STOP             (_U(0x1) << TWIM_NCMDR_STOP_Pos)
+#define TWIM_NCMDR_VALID_Pos        15           /**< \brief (TWIM_NCMDR) CMDR Valid */
+#define TWIM_NCMDR_VALID            (_U(0x1) << TWIM_NCMDR_VALID_Pos)
+#define TWIM_NCMDR_NBYTES_Pos       16           /**< \brief (TWIM_NCMDR) Number of data bytes in transfer */
+#define TWIM_NCMDR_NBYTES_Msk       (_U(0xFF) << TWIM_NCMDR_NBYTES_Pos)
+#define TWIM_NCMDR_NBYTES(value)    (TWIM_NCMDR_NBYTES_Msk & ((value) << TWIM_NCMDR_NBYTES_Pos))
+#define TWIM_NCMDR_PECEN_Pos        24           /**< \brief (TWIM_NCMDR) Packet Error Checking Enable */
+#define TWIM_NCMDR_PECEN            (_U(0x1) << TWIM_NCMDR_PECEN_Pos)
+#define TWIM_NCMDR_ACKLAST_Pos      25           /**< \brief (TWIM_NCMDR) ACK Last Master RX Byte */
+#define TWIM_NCMDR_ACKLAST          (_U(0x1) << TWIM_NCMDR_ACKLAST_Pos)
+#define TWIM_NCMDR_HS_Pos           26           /**< \brief (TWIM_NCMDR) HS-mode */
+#define TWIM_NCMDR_HS               (_U(0x1) << TWIM_NCMDR_HS_Pos)
+#define TWIM_NCMDR_HSMCODE_Pos      28           /**< \brief (TWIM_NCMDR) HS-mode Master Code */
+#define TWIM_NCMDR_HSMCODE_Msk      (_U(0x7) << TWIM_NCMDR_HSMCODE_Pos)
+#define TWIM_NCMDR_HSMCODE(value)   (TWIM_NCMDR_HSMCODE_Msk & ((value) << TWIM_NCMDR_HSMCODE_Pos))
+#define TWIM_NCMDR_MASK             _U(0x77FFFFFF) /**< \brief (TWIM_NCMDR) MASK Register */
+
+/* -------- TWIM_RHR : (TWIM Offset: 0x14) (R/  32) Receive Holding Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXDATA:8;         /*!< bit:  0.. 7  Received Data                      */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIM_RHR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIM_RHR_OFFSET             0x14         /**< \brief (TWIM_RHR offset) Receive Holding Register */
+#define TWIM_RHR_RESETVALUE         _U(0x00000000); /**< \brief (TWIM_RHR reset_value) Receive Holding Register */
+
+#define TWIM_RHR_RXDATA_Pos         0            /**< \brief (TWIM_RHR) Received Data */
+#define TWIM_RHR_RXDATA_Msk         (_U(0xFF) << TWIM_RHR_RXDATA_Pos)
+#define TWIM_RHR_RXDATA(value)      (TWIM_RHR_RXDATA_Msk & ((value) << TWIM_RHR_RXDATA_Pos))
+#define TWIM_RHR_MASK               _U(0x000000FF) /**< \brief (TWIM_RHR) MASK Register */
+
+/* -------- TWIM_THR : (TWIM Offset: 0x18) ( /W 32) Transmit Holding Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXDATA:8;         /*!< bit:  0.. 7  Data to Transmit                   */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIM_THR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIM_THR_OFFSET             0x18         /**< \brief (TWIM_THR offset) Transmit Holding Register */
+#define TWIM_THR_RESETVALUE         _U(0x00000000); /**< \brief (TWIM_THR reset_value) Transmit Holding Register */
+
+#define TWIM_THR_TXDATA_Pos         0            /**< \brief (TWIM_THR) Data to Transmit */
+#define TWIM_THR_TXDATA_Msk         (_U(0xFF) << TWIM_THR_TXDATA_Pos)
+#define TWIM_THR_TXDATA(value)      (TWIM_THR_TXDATA_Msk & ((value) << TWIM_THR_TXDATA_Pos))
+#define TWIM_THR_MASK               _U(0x000000FF) /**< \brief (TWIM_THR) MASK Register */
+
+/* -------- TWIM_SR : (TWIM Offset: 0x1C) (R/  32) Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXRDY:1;          /*!< bit:      0  RHR Data Ready                     */
+    uint32_t TXRDY:1;          /*!< bit:      1  THR Data Ready                     */
+    uint32_t CRDY:1;           /*!< bit:      2  Ready for More Commands            */
+    uint32_t CCOMP:1;          /*!< bit:      3  Command Complete                   */
+    uint32_t IDLE:1;           /*!< bit:      4  Master Interface is Idle           */
+    uint32_t BUSFREE:1;        /*!< bit:      5  Two-wire Bus is Free               */
+    uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t ANAK:1;           /*!< bit:      8  NAK in Address Phase Received      */
+    uint32_t DNAK:1;           /*!< bit:      9  NAK in Data Phase Received         */
+    uint32_t ARBLST:1;         /*!< bit:     10  Arbitration Lost                   */
+    uint32_t SMBALERT:1;       /*!< bit:     11  SMBus Alert                        */
+    uint32_t TOUT:1;           /*!< bit:     12  Timeout                            */
+    uint32_t PECERR:1;         /*!< bit:     13  PEC Error                          */
+    uint32_t STOP:1;           /*!< bit:     14  Stop Request Accepted              */
+    uint32_t :1;               /*!< bit:     15  Reserved                           */
+    uint32_t MENB:1;           /*!< bit:     16  Master Interface Enable            */
+    uint32_t HSMCACK:1;        /*!< bit:     17  ACK in HS-mode Master Code Phase Received */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIM_SR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIM_SR_OFFSET              0x1C         /**< \brief (TWIM_SR offset) Status Register */
+#define TWIM_SR_RESETVALUE          _U(0x00000002); /**< \brief (TWIM_SR reset_value) Status Register */
+
+#define TWIM_SR_RXRDY_Pos           0            /**< \brief (TWIM_SR) RHR Data Ready */
+#define TWIM_SR_RXRDY               (_U(0x1) << TWIM_SR_RXRDY_Pos)
+#define TWIM_SR_TXRDY_Pos           1            /**< \brief (TWIM_SR) THR Data Ready */
+#define TWIM_SR_TXRDY               (_U(0x1) << TWIM_SR_TXRDY_Pos)
+#define TWIM_SR_CRDY_Pos            2            /**< \brief (TWIM_SR) Ready for More Commands */
+#define TWIM_SR_CRDY                (_U(0x1) << TWIM_SR_CRDY_Pos)
+#define TWIM_SR_CCOMP_Pos           3            /**< \brief (TWIM_SR) Command Complete */
+#define TWIM_SR_CCOMP               (_U(0x1) << TWIM_SR_CCOMP_Pos)
+#define TWIM_SR_IDLE_Pos            4            /**< \brief (TWIM_SR) Master Interface is Idle */
+#define TWIM_SR_IDLE                (_U(0x1) << TWIM_SR_IDLE_Pos)
+#define TWIM_SR_BUSFREE_Pos         5            /**< \brief (TWIM_SR) Two-wire Bus is Free */
+#define TWIM_SR_BUSFREE             (_U(0x1) << TWIM_SR_BUSFREE_Pos)
+#define TWIM_SR_ANAK_Pos            8            /**< \brief (TWIM_SR) NAK in Address Phase Received */
+#define TWIM_SR_ANAK                (_U(0x1) << TWIM_SR_ANAK_Pos)
+#define TWIM_SR_DNAK_Pos            9            /**< \brief (TWIM_SR) NAK in Data Phase Received */
+#define TWIM_SR_DNAK                (_U(0x1) << TWIM_SR_DNAK_Pos)
+#define TWIM_SR_ARBLST_Pos          10           /**< \brief (TWIM_SR) Arbitration Lost */
+#define TWIM_SR_ARBLST              (_U(0x1) << TWIM_SR_ARBLST_Pos)
+#define TWIM_SR_SMBALERT_Pos        11           /**< \brief (TWIM_SR) SMBus Alert */
+#define TWIM_SR_SMBALERT            (_U(0x1) << TWIM_SR_SMBALERT_Pos)
+#define TWIM_SR_TOUT_Pos            12           /**< \brief (TWIM_SR) Timeout */
+#define TWIM_SR_TOUT                (_U(0x1) << TWIM_SR_TOUT_Pos)
+#define TWIM_SR_PECERR_Pos          13           /**< \brief (TWIM_SR) PEC Error */
+#define TWIM_SR_PECERR              (_U(0x1) << TWIM_SR_PECERR_Pos)
+#define TWIM_SR_STOP_Pos            14           /**< \brief (TWIM_SR) Stop Request Accepted */
+#define TWIM_SR_STOP                (_U(0x1) << TWIM_SR_STOP_Pos)
+#define TWIM_SR_MENB_Pos            16           /**< \brief (TWIM_SR) Master Interface Enable */
+#define TWIM_SR_MENB                (_U(0x1) << TWIM_SR_MENB_Pos)
+#define TWIM_SR_HSMCACK_Pos         17           /**< \brief (TWIM_SR) ACK in HS-mode Master Code Phase Received */
+#define TWIM_SR_HSMCACK             (_U(0x1) << TWIM_SR_HSMCACK_Pos)
+#define TWIM_SR_MASK                _U(0x00037F3F) /**< \brief (TWIM_SR) MASK Register */
+
+/* -------- TWIM_IER : (TWIM Offset: 0x20) ( /W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXRDY:1;          /*!< bit:      0  RHR Data Ready                     */
+    uint32_t TXRDY:1;          /*!< bit:      1  THR Data Ready                     */
+    uint32_t CRDY:1;           /*!< bit:      2  Ready for More Commands            */
+    uint32_t CCOMP:1;          /*!< bit:      3  Command Complete                   */
+    uint32_t IDLE:1;           /*!< bit:      4  Master Interface is Idle           */
+    uint32_t BUSFREE:1;        /*!< bit:      5  Two-wire Bus is Free               */
+    uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t ANAK:1;           /*!< bit:      8  NAK in Address Phase Received      */
+    uint32_t DNAK:1;           /*!< bit:      9  NAK in Data Phase Received         */
+    uint32_t ARBLST:1;         /*!< bit:     10  Arbitration Lost                   */
+    uint32_t SMBALERT:1;       /*!< bit:     11  SMBus Alert                        */
+    uint32_t TOUT:1;           /*!< bit:     12  Timeout                            */
+    uint32_t PECERR:1;         /*!< bit:     13  PEC Error                          */
+    uint32_t STOP:1;           /*!< bit:     14  Stop Request Accepted              */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t HSMCACK:1;        /*!< bit:     17  ACK in HS-mode Master Code Phase Received */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIM_IER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIM_IER_OFFSET             0x20         /**< \brief (TWIM_IER offset) Interrupt Enable Register */
+#define TWIM_IER_RESETVALUE         _U(0x00000000); /**< \brief (TWIM_IER reset_value) Interrupt Enable Register */
+
+#define TWIM_IER_RXRDY_Pos          0            /**< \brief (TWIM_IER) RHR Data Ready */
+#define TWIM_IER_RXRDY              (_U(0x1) << TWIM_IER_RXRDY_Pos)
+#define TWIM_IER_TXRDY_Pos          1            /**< \brief (TWIM_IER) THR Data Ready */
+#define TWIM_IER_TXRDY              (_U(0x1) << TWIM_IER_TXRDY_Pos)
+#define TWIM_IER_CRDY_Pos           2            /**< \brief (TWIM_IER) Ready for More Commands */
+#define TWIM_IER_CRDY               (_U(0x1) << TWIM_IER_CRDY_Pos)
+#define TWIM_IER_CCOMP_Pos          3            /**< \brief (TWIM_IER) Command Complete */
+#define TWIM_IER_CCOMP              (_U(0x1) << TWIM_IER_CCOMP_Pos)
+#define TWIM_IER_IDLE_Pos           4            /**< \brief (TWIM_IER) Master Interface is Idle */
+#define TWIM_IER_IDLE               (_U(0x1) << TWIM_IER_IDLE_Pos)
+#define TWIM_IER_BUSFREE_Pos        5            /**< \brief (TWIM_IER) Two-wire Bus is Free */
+#define TWIM_IER_BUSFREE            (_U(0x1) << TWIM_IER_BUSFREE_Pos)
+#define TWIM_IER_ANAK_Pos           8            /**< \brief (TWIM_IER) NAK in Address Phase Received */
+#define TWIM_IER_ANAK               (_U(0x1) << TWIM_IER_ANAK_Pos)
+#define TWIM_IER_DNAK_Pos           9            /**< \brief (TWIM_IER) NAK in Data Phase Received */
+#define TWIM_IER_DNAK               (_U(0x1) << TWIM_IER_DNAK_Pos)
+#define TWIM_IER_ARBLST_Pos         10           /**< \brief (TWIM_IER) Arbitration Lost */
+#define TWIM_IER_ARBLST             (_U(0x1) << TWIM_IER_ARBLST_Pos)
+#define TWIM_IER_SMBALERT_Pos       11           /**< \brief (TWIM_IER) SMBus Alert */
+#define TWIM_IER_SMBALERT           (_U(0x1) << TWIM_IER_SMBALERT_Pos)
+#define TWIM_IER_TOUT_Pos           12           /**< \brief (TWIM_IER) Timeout */
+#define TWIM_IER_TOUT               (_U(0x1) << TWIM_IER_TOUT_Pos)
+#define TWIM_IER_PECERR_Pos         13           /**< \brief (TWIM_IER) PEC Error */
+#define TWIM_IER_PECERR             (_U(0x1) << TWIM_IER_PECERR_Pos)
+#define TWIM_IER_STOP_Pos           14           /**< \brief (TWIM_IER) Stop Request Accepted */
+#define TWIM_IER_STOP               (_U(0x1) << TWIM_IER_STOP_Pos)
+#define TWIM_IER_HSMCACK_Pos        17           /**< \brief (TWIM_IER) ACK in HS-mode Master Code Phase Received */
+#define TWIM_IER_HSMCACK            (_U(0x1) << TWIM_IER_HSMCACK_Pos)
+#define TWIM_IER_MASK               _U(0x00027F3F) /**< \brief (TWIM_IER) MASK Register */
+
+/* -------- TWIM_IDR : (TWIM Offset: 0x24) ( /W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXRDY:1;          /*!< bit:      0  RHR Data Ready                     */
+    uint32_t TXRDY:1;          /*!< bit:      1  THR Data Ready                     */
+    uint32_t CRDY:1;           /*!< bit:      2  Ready for More Commands            */
+    uint32_t CCOMP:1;          /*!< bit:      3  Command Complete                   */
+    uint32_t IDLE:1;           /*!< bit:      4  Master Interface is Idle           */
+    uint32_t BUSFREE:1;        /*!< bit:      5  Two-wire Bus is Free               */
+    uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t ANAK:1;           /*!< bit:      8  NAK in Address Phase Received      */
+    uint32_t DNAK:1;           /*!< bit:      9  NAK in Data Phase Received         */
+    uint32_t ARBLST:1;         /*!< bit:     10  Arbitration Lost                   */
+    uint32_t SMBALERT:1;       /*!< bit:     11  SMBus Alert                        */
+    uint32_t TOUT:1;           /*!< bit:     12  Timeout                            */
+    uint32_t PECERR:1;         /*!< bit:     13  PEC Error                          */
+    uint32_t STOP:1;           /*!< bit:     14  Stop Request Accepted              */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t HSMCACK:1;        /*!< bit:     17  ACK in HS-mode Master Code Phase Received */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIM_IDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIM_IDR_OFFSET             0x24         /**< \brief (TWIM_IDR offset) Interrupt Disable Register */
+#define TWIM_IDR_RESETVALUE         _U(0x00000000); /**< \brief (TWIM_IDR reset_value) Interrupt Disable Register */
+
+#define TWIM_IDR_RXRDY_Pos          0            /**< \brief (TWIM_IDR) RHR Data Ready */
+#define TWIM_IDR_RXRDY              (_U(0x1) << TWIM_IDR_RXRDY_Pos)
+#define TWIM_IDR_TXRDY_Pos          1            /**< \brief (TWIM_IDR) THR Data Ready */
+#define TWIM_IDR_TXRDY              (_U(0x1) << TWIM_IDR_TXRDY_Pos)
+#define TWIM_IDR_CRDY_Pos           2            /**< \brief (TWIM_IDR) Ready for More Commands */
+#define TWIM_IDR_CRDY               (_U(0x1) << TWIM_IDR_CRDY_Pos)
+#define TWIM_IDR_CCOMP_Pos          3            /**< \brief (TWIM_IDR) Command Complete */
+#define TWIM_IDR_CCOMP              (_U(0x1) << TWIM_IDR_CCOMP_Pos)
+#define TWIM_IDR_IDLE_Pos           4            /**< \brief (TWIM_IDR) Master Interface is Idle */
+#define TWIM_IDR_IDLE               (_U(0x1) << TWIM_IDR_IDLE_Pos)
+#define TWIM_IDR_BUSFREE_Pos        5            /**< \brief (TWIM_IDR) Two-wire Bus is Free */
+#define TWIM_IDR_BUSFREE            (_U(0x1) << TWIM_IDR_BUSFREE_Pos)
+#define TWIM_IDR_ANAK_Pos           8            /**< \brief (TWIM_IDR) NAK in Address Phase Received */
+#define TWIM_IDR_ANAK               (_U(0x1) << TWIM_IDR_ANAK_Pos)
+#define TWIM_IDR_DNAK_Pos           9            /**< \brief (TWIM_IDR) NAK in Data Phase Received */
+#define TWIM_IDR_DNAK               (_U(0x1) << TWIM_IDR_DNAK_Pos)
+#define TWIM_IDR_ARBLST_Pos         10           /**< \brief (TWIM_IDR) Arbitration Lost */
+#define TWIM_IDR_ARBLST             (_U(0x1) << TWIM_IDR_ARBLST_Pos)
+#define TWIM_IDR_SMBALERT_Pos       11           /**< \brief (TWIM_IDR) SMBus Alert */
+#define TWIM_IDR_SMBALERT           (_U(0x1) << TWIM_IDR_SMBALERT_Pos)
+#define TWIM_IDR_TOUT_Pos           12           /**< \brief (TWIM_IDR) Timeout */
+#define TWIM_IDR_TOUT               (_U(0x1) << TWIM_IDR_TOUT_Pos)
+#define TWIM_IDR_PECERR_Pos         13           /**< \brief (TWIM_IDR) PEC Error */
+#define TWIM_IDR_PECERR             (_U(0x1) << TWIM_IDR_PECERR_Pos)
+#define TWIM_IDR_STOP_Pos           14           /**< \brief (TWIM_IDR) Stop Request Accepted */
+#define TWIM_IDR_STOP               (_U(0x1) << TWIM_IDR_STOP_Pos)
+#define TWIM_IDR_HSMCACK_Pos        17           /**< \brief (TWIM_IDR) ACK in HS-mode Master Code Phase Received */
+#define TWIM_IDR_HSMCACK            (_U(0x1) << TWIM_IDR_HSMCACK_Pos)
+#define TWIM_IDR_MASK               _U(0x00027F3F) /**< \brief (TWIM_IDR) MASK Register */
+
+/* -------- TWIM_IMR : (TWIM Offset: 0x28) (R/  32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXRDY:1;          /*!< bit:      0  RHR Data Ready                     */
+    uint32_t TXRDY:1;          /*!< bit:      1  THR Data Ready                     */
+    uint32_t CRDY:1;           /*!< bit:      2  Ready for More Commands            */
+    uint32_t CCOMP:1;          /*!< bit:      3  Command Complete                   */
+    uint32_t IDLE:1;           /*!< bit:      4  Master Interface is Idle           */
+    uint32_t BUSFREE:1;        /*!< bit:      5  Two-wire Bus is Free               */
+    uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint32_t ANAK:1;           /*!< bit:      8  NAK in Address Phase Received      */
+    uint32_t DNAK:1;           /*!< bit:      9  NAK in Data Phase Received         */
+    uint32_t ARBLST:1;         /*!< bit:     10  Arbitration Lost                   */
+    uint32_t SMBALERT:1;       /*!< bit:     11  SMBus Alert                        */
+    uint32_t TOUT:1;           /*!< bit:     12  Timeout                            */
+    uint32_t PECERR:1;         /*!< bit:     13  PEC Error                          */
+    uint32_t STOP:1;           /*!< bit:     14  Stop Request Accepted              */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t HSMCACK:1;        /*!< bit:     17  ACK in HS-mode Master Code Phase Received */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIM_IMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIM_IMR_OFFSET             0x28         /**< \brief (TWIM_IMR offset) Interrupt Mask Register */
+#define TWIM_IMR_RESETVALUE         _U(0x00000000); /**< \brief (TWIM_IMR reset_value) Interrupt Mask Register */
+
+#define TWIM_IMR_RXRDY_Pos          0            /**< \brief (TWIM_IMR) RHR Data Ready */
+#define TWIM_IMR_RXRDY              (_U(0x1) << TWIM_IMR_RXRDY_Pos)
+#define TWIM_IMR_TXRDY_Pos          1            /**< \brief (TWIM_IMR) THR Data Ready */
+#define TWIM_IMR_TXRDY              (_U(0x1) << TWIM_IMR_TXRDY_Pos)
+#define TWIM_IMR_CRDY_Pos           2            /**< \brief (TWIM_IMR) Ready for More Commands */
+#define TWIM_IMR_CRDY               (_U(0x1) << TWIM_IMR_CRDY_Pos)
+#define TWIM_IMR_CCOMP_Pos          3            /**< \brief (TWIM_IMR) Command Complete */
+#define TWIM_IMR_CCOMP              (_U(0x1) << TWIM_IMR_CCOMP_Pos)
+#define TWIM_IMR_IDLE_Pos           4            /**< \brief (TWIM_IMR) Master Interface is Idle */
+#define TWIM_IMR_IDLE               (_U(0x1) << TWIM_IMR_IDLE_Pos)
+#define TWIM_IMR_BUSFREE_Pos        5            /**< \brief (TWIM_IMR) Two-wire Bus is Free */
+#define TWIM_IMR_BUSFREE            (_U(0x1) << TWIM_IMR_BUSFREE_Pos)
+#define TWIM_IMR_ANAK_Pos           8            /**< \brief (TWIM_IMR) NAK in Address Phase Received */
+#define TWIM_IMR_ANAK               (_U(0x1) << TWIM_IMR_ANAK_Pos)
+#define TWIM_IMR_DNAK_Pos           9            /**< \brief (TWIM_IMR) NAK in Data Phase Received */
+#define TWIM_IMR_DNAK               (_U(0x1) << TWIM_IMR_DNAK_Pos)
+#define TWIM_IMR_ARBLST_Pos         10           /**< \brief (TWIM_IMR) Arbitration Lost */
+#define TWIM_IMR_ARBLST             (_U(0x1) << TWIM_IMR_ARBLST_Pos)
+#define TWIM_IMR_SMBALERT_Pos       11           /**< \brief (TWIM_IMR) SMBus Alert */
+#define TWIM_IMR_SMBALERT           (_U(0x1) << TWIM_IMR_SMBALERT_Pos)
+#define TWIM_IMR_TOUT_Pos           12           /**< \brief (TWIM_IMR) Timeout */
+#define TWIM_IMR_TOUT               (_U(0x1) << TWIM_IMR_TOUT_Pos)
+#define TWIM_IMR_PECERR_Pos         13           /**< \brief (TWIM_IMR) PEC Error */
+#define TWIM_IMR_PECERR             (_U(0x1) << TWIM_IMR_PECERR_Pos)
+#define TWIM_IMR_STOP_Pos           14           /**< \brief (TWIM_IMR) Stop Request Accepted */
+#define TWIM_IMR_STOP               (_U(0x1) << TWIM_IMR_STOP_Pos)
+#define TWIM_IMR_HSMCACK_Pos        17           /**< \brief (TWIM_IMR) ACK in HS-mode Master Code Phase Received */
+#define TWIM_IMR_HSMCACK            (_U(0x1) << TWIM_IMR_HSMCACK_Pos)
+#define TWIM_IMR_MASK               _U(0x00027F3F) /**< \brief (TWIM_IMR) MASK Register */
+
+/* -------- TWIM_SCR : (TWIM Offset: 0x2C) ( /W 32) Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :3;               /*!< bit:  0.. 2  Reserved                           */
+    uint32_t CCOMP:1;          /*!< bit:      3  Command Complete                   */
+    uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint32_t ANAK:1;           /*!< bit:      8  NAK in Address Phase Received      */
+    uint32_t DNAK:1;           /*!< bit:      9  NAK in Data Phase Received         */
+    uint32_t ARBLST:1;         /*!< bit:     10  Arbitration Lost                   */
+    uint32_t SMBALERT:1;       /*!< bit:     11  SMBus Alert                        */
+    uint32_t TOUT:1;           /*!< bit:     12  Timeout                            */
+    uint32_t PECERR:1;         /*!< bit:     13  PEC Error                          */
+    uint32_t STOP:1;           /*!< bit:     14  Stop Request Accepted              */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t HSMCACK:1;        /*!< bit:     17  ACK in HS-mode Master Code Phase Received */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIM_SCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIM_SCR_OFFSET             0x2C         /**< \brief (TWIM_SCR offset) Status Clear Register */
+#define TWIM_SCR_RESETVALUE         _U(0x00000000); /**< \brief (TWIM_SCR reset_value) Status Clear Register */
+
+#define TWIM_SCR_CCOMP_Pos          3            /**< \brief (TWIM_SCR) Command Complete */
+#define TWIM_SCR_CCOMP              (_U(0x1) << TWIM_SCR_CCOMP_Pos)
+#define TWIM_SCR_ANAK_Pos           8            /**< \brief (TWIM_SCR) NAK in Address Phase Received */
+#define TWIM_SCR_ANAK               (_U(0x1) << TWIM_SCR_ANAK_Pos)
+#define TWIM_SCR_DNAK_Pos           9            /**< \brief (TWIM_SCR) NAK in Data Phase Received */
+#define TWIM_SCR_DNAK               (_U(0x1) << TWIM_SCR_DNAK_Pos)
+#define TWIM_SCR_ARBLST_Pos         10           /**< \brief (TWIM_SCR) Arbitration Lost */
+#define TWIM_SCR_ARBLST             (_U(0x1) << TWIM_SCR_ARBLST_Pos)
+#define TWIM_SCR_SMBALERT_Pos       11           /**< \brief (TWIM_SCR) SMBus Alert */
+#define TWIM_SCR_SMBALERT           (_U(0x1) << TWIM_SCR_SMBALERT_Pos)
+#define TWIM_SCR_TOUT_Pos           12           /**< \brief (TWIM_SCR) Timeout */
+#define TWIM_SCR_TOUT               (_U(0x1) << TWIM_SCR_TOUT_Pos)
+#define TWIM_SCR_PECERR_Pos         13           /**< \brief (TWIM_SCR) PEC Error */
+#define TWIM_SCR_PECERR             (_U(0x1) << TWIM_SCR_PECERR_Pos)
+#define TWIM_SCR_STOP_Pos           14           /**< \brief (TWIM_SCR) Stop Request Accepted */
+#define TWIM_SCR_STOP               (_U(0x1) << TWIM_SCR_STOP_Pos)
+#define TWIM_SCR_HSMCACK_Pos        17           /**< \brief (TWIM_SCR) ACK in HS-mode Master Code Phase Received */
+#define TWIM_SCR_HSMCACK            (_U(0x1) << TWIM_SCR_HSMCACK_Pos)
+#define TWIM_SCR_MASK               _U(0x00027F08) /**< \brief (TWIM_SCR) MASK Register */
+
+/* -------- TWIM_PR : (TWIM Offset: 0x30) (R/  32) Parameter Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t HS:1;             /*!< bit:      0  HS-mode                            */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIM_PR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIM_PR_OFFSET              0x30         /**< \brief (TWIM_PR offset) Parameter Register */
+#define TWIM_PR_RESETVALUE          _U(0x00000001); /**< \brief (TWIM_PR reset_value) Parameter Register */
+
+#define TWIM_PR_HS_Pos              0            /**< \brief (TWIM_PR) HS-mode */
+#define TWIM_PR_HS                  (_U(0x1) << TWIM_PR_HS_Pos)
+#define TWIM_PR_MASK                _U(0x00000001) /**< \brief (TWIM_PR) MASK Register */
+
+/* -------- TWIM_VR : (TWIM Offset: 0x34) (R/  32) Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIM_VR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIM_VR_OFFSET              0x34         /**< \brief (TWIM_VR offset) Version Register */
+#define TWIM_VR_RESETVALUE          _U(0x00000120); /**< \brief (TWIM_VR reset_value) Version Register */
+
+#define TWIM_VR_VERSION_Pos         0            /**< \brief (TWIM_VR) Version number */
+#define TWIM_VR_VERSION_Msk         (_U(0xFFF) << TWIM_VR_VERSION_Pos)
+#define TWIM_VR_VERSION(value)      (TWIM_VR_VERSION_Msk & ((value) << TWIM_VR_VERSION_Pos))
+#define TWIM_VR_VARIANT_Pos         16           /**< \brief (TWIM_VR) Variant number */
+#define TWIM_VR_VARIANT_Msk         (_U(0xF) << TWIM_VR_VARIANT_Pos)
+#define TWIM_VR_VARIANT(value)      (TWIM_VR_VARIANT_Msk & ((value) << TWIM_VR_VARIANT_Pos))
+#define TWIM_VR_MASK                _U(0x000F0FFF) /**< \brief (TWIM_VR) MASK Register */
+
+/* -------- TWIM_HSCWGR : (TWIM Offset: 0x38) (R/W 32) HS-mode Clock Waveform Generator -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t LOW:8;            /*!< bit:  0.. 7  Clock Low Cycles                   */
+    uint32_t HIGH:8;           /*!< bit:  8..15  Clock High Cycles                  */
+    uint32_t STASTO:8;         /*!< bit: 16..23  START and STOP Cycles              */
+    uint32_t DATA:4;           /*!< bit: 24..27  Data Setup and Hold Cycles         */
+    uint32_t EXP:3;            /*!< bit: 28..30  Clock Prescaler                    */
+    uint32_t :1;               /*!< bit:     31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIM_HSCWGR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIM_HSCWGR_OFFSET          0x38         /**< \brief (TWIM_HSCWGR offset) HS-mode Clock Waveform Generator */
+#define TWIM_HSCWGR_RESETVALUE      _U(0x00000000); /**< \brief (TWIM_HSCWGR reset_value) HS-mode Clock Waveform Generator */
+
+#define TWIM_HSCWGR_LOW_Pos         0            /**< \brief (TWIM_HSCWGR) Clock Low Cycles */
+#define TWIM_HSCWGR_LOW_Msk         (_U(0xFF) << TWIM_HSCWGR_LOW_Pos)
+#define TWIM_HSCWGR_LOW(value)      (TWIM_HSCWGR_LOW_Msk & ((value) << TWIM_HSCWGR_LOW_Pos))
+#define TWIM_HSCWGR_HIGH_Pos        8            /**< \brief (TWIM_HSCWGR) Clock High Cycles */
+#define TWIM_HSCWGR_HIGH_Msk        (_U(0xFF) << TWIM_HSCWGR_HIGH_Pos)
+#define TWIM_HSCWGR_HIGH(value)     (TWIM_HSCWGR_HIGH_Msk & ((value) << TWIM_HSCWGR_HIGH_Pos))
+#define TWIM_HSCWGR_STASTO_Pos      16           /**< \brief (TWIM_HSCWGR) START and STOP Cycles */
+#define TWIM_HSCWGR_STASTO_Msk      (_U(0xFF) << TWIM_HSCWGR_STASTO_Pos)
+#define TWIM_HSCWGR_STASTO(value)   (TWIM_HSCWGR_STASTO_Msk & ((value) << TWIM_HSCWGR_STASTO_Pos))
+#define TWIM_HSCWGR_DATA_Pos        24           /**< \brief (TWIM_HSCWGR) Data Setup and Hold Cycles */
+#define TWIM_HSCWGR_DATA_Msk        (_U(0xF) << TWIM_HSCWGR_DATA_Pos)
+#define TWIM_HSCWGR_DATA(value)     (TWIM_HSCWGR_DATA_Msk & ((value) << TWIM_HSCWGR_DATA_Pos))
+#define TWIM_HSCWGR_EXP_Pos         28           /**< \brief (TWIM_HSCWGR) Clock Prescaler */
+#define TWIM_HSCWGR_EXP_Msk         (_U(0x7) << TWIM_HSCWGR_EXP_Pos)
+#define TWIM_HSCWGR_EXP(value)      (TWIM_HSCWGR_EXP_Msk & ((value) << TWIM_HSCWGR_EXP_Pos))
+#define TWIM_HSCWGR_MASK            _U(0x7FFFFFFF) /**< \brief (TWIM_HSCWGR) MASK Register */
+
+/* -------- TWIM_SRR : (TWIM Offset: 0x3C) (R/W 32) Slew Rate Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DADRIVEL:3;       /*!< bit:  0.. 2  Data Drive Strength LOW            */
+    uint32_t :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint32_t DASLEW:2;         /*!< bit:  8.. 9  Data Slew Limit                    */
+    uint32_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint32_t CLDRIVEL:3;       /*!< bit: 16..18  Clock Drive Strength LOW           */
+    uint32_t :5;               /*!< bit: 19..23  Reserved                           */
+    uint32_t CLSLEW:2;         /*!< bit: 24..25  Clock Slew Limit                   */
+    uint32_t :2;               /*!< bit: 26..27  Reserved                           */
+    uint32_t FILTER:2;         /*!< bit: 28..29  Input Spike Filter Control         */
+    uint32_t :2;               /*!< bit: 30..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIM_SRR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIM_SRR_OFFSET             0x3C         /**< \brief (TWIM_SRR offset) Slew Rate Register */
+#define TWIM_SRR_RESETVALUE         _U(0x00000000); /**< \brief (TWIM_SRR reset_value) Slew Rate Register */
+
+#define TWIM_SRR_DADRIVEL_Pos       0            /**< \brief (TWIM_SRR) Data Drive Strength LOW */
+#define TWIM_SRR_DADRIVEL_Msk       (_U(0x7) << TWIM_SRR_DADRIVEL_Pos)
+#define TWIM_SRR_DADRIVEL(value)    (TWIM_SRR_DADRIVEL_Msk & ((value) << TWIM_SRR_DADRIVEL_Pos))
+#define TWIM_SRR_DASLEW_Pos         8            /**< \brief (TWIM_SRR) Data Slew Limit */
+#define TWIM_SRR_DASLEW_Msk         (_U(0x3) << TWIM_SRR_DASLEW_Pos)
+#define TWIM_SRR_DASLEW(value)      (TWIM_SRR_DASLEW_Msk & ((value) << TWIM_SRR_DASLEW_Pos))
+#define TWIM_SRR_CLDRIVEL_Pos       16           /**< \brief (TWIM_SRR) Clock Drive Strength LOW */
+#define TWIM_SRR_CLDRIVEL_Msk       (_U(0x7) << TWIM_SRR_CLDRIVEL_Pos)
+#define TWIM_SRR_CLDRIVEL(value)    (TWIM_SRR_CLDRIVEL_Msk & ((value) << TWIM_SRR_CLDRIVEL_Pos))
+#define TWIM_SRR_CLSLEW_Pos         24           /**< \brief (TWIM_SRR) Clock Slew Limit */
+#define TWIM_SRR_CLSLEW_Msk         (_U(0x3) << TWIM_SRR_CLSLEW_Pos)
+#define TWIM_SRR_CLSLEW(value)      (TWIM_SRR_CLSLEW_Msk & ((value) << TWIM_SRR_CLSLEW_Pos))
+#define TWIM_SRR_FILTER_Pos         28           /**< \brief (TWIM_SRR) Input Spike Filter Control */
+#define TWIM_SRR_FILTER_Msk         (_U(0x3) << TWIM_SRR_FILTER_Pos)
+#define TWIM_SRR_FILTER(value)      (TWIM_SRR_FILTER_Msk & ((value) << TWIM_SRR_FILTER_Pos))
+#define TWIM_SRR_MASK               _U(0x33070307) /**< \brief (TWIM_SRR) MASK Register */
+
+/* -------- TWIM_HSSRR : (TWIM Offset: 0x40) (R/W 32) HS-mode Slew Rate Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DADRIVEL:3;       /*!< bit:  0.. 2  Data Drive Strength LOW            */
+    uint32_t :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint32_t DASLEW:2;         /*!< bit:  8.. 9  Data Slew Limit                    */
+    uint32_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint32_t CLDRIVEL:3;       /*!< bit: 16..18  Clock Drive Strength LOW           */
+    uint32_t :1;               /*!< bit:     19  Reserved                           */
+    uint32_t CLDRIVEH:2;       /*!< bit: 20..21  Clock Drive Strength HIGH          */
+    uint32_t :2;               /*!< bit: 22..23  Reserved                           */
+    uint32_t CLSLEW:2;         /*!< bit: 24..25  Clock Slew Limit                   */
+    uint32_t :2;               /*!< bit: 26..27  Reserved                           */
+    uint32_t FILTER:2;         /*!< bit: 28..29  Input Spike Filter Control         */
+    uint32_t :2;               /*!< bit: 30..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIM_HSSRR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIM_HSSRR_OFFSET           0x40         /**< \brief (TWIM_HSSRR offset) HS-mode Slew Rate Register */
+#define TWIM_HSSRR_RESETVALUE       _U(0x00000000); /**< \brief (TWIM_HSSRR reset_value) HS-mode Slew Rate Register */
+
+#define TWIM_HSSRR_DADRIVEL_Pos     0            /**< \brief (TWIM_HSSRR) Data Drive Strength LOW */
+#define TWIM_HSSRR_DADRIVEL_Msk     (_U(0x7) << TWIM_HSSRR_DADRIVEL_Pos)
+#define TWIM_HSSRR_DADRIVEL(value)  (TWIM_HSSRR_DADRIVEL_Msk & ((value) << TWIM_HSSRR_DADRIVEL_Pos))
+#define TWIM_HSSRR_DASLEW_Pos       8            /**< \brief (TWIM_HSSRR) Data Slew Limit */
+#define TWIM_HSSRR_DASLEW_Msk       (_U(0x3) << TWIM_HSSRR_DASLEW_Pos)
+#define TWIM_HSSRR_DASLEW(value)    (TWIM_HSSRR_DASLEW_Msk & ((value) << TWIM_HSSRR_DASLEW_Pos))
+#define TWIM_HSSRR_CLDRIVEL_Pos     16           /**< \brief (TWIM_HSSRR) Clock Drive Strength LOW */
+#define TWIM_HSSRR_CLDRIVEL_Msk     (_U(0x7) << TWIM_HSSRR_CLDRIVEL_Pos)
+#define TWIM_HSSRR_CLDRIVEL(value)  (TWIM_HSSRR_CLDRIVEL_Msk & ((value) << TWIM_HSSRR_CLDRIVEL_Pos))
+#define TWIM_HSSRR_CLDRIVEH_Pos     20           /**< \brief (TWIM_HSSRR) Clock Drive Strength HIGH */
+#define TWIM_HSSRR_CLDRIVEH_Msk     (_U(0x3) << TWIM_HSSRR_CLDRIVEH_Pos)
+#define TWIM_HSSRR_CLDRIVEH(value)  (TWIM_HSSRR_CLDRIVEH_Msk & ((value) << TWIM_HSSRR_CLDRIVEH_Pos))
+#define TWIM_HSSRR_CLSLEW_Pos       24           /**< \brief (TWIM_HSSRR) Clock Slew Limit */
+#define TWIM_HSSRR_CLSLEW_Msk       (_U(0x3) << TWIM_HSSRR_CLSLEW_Pos)
+#define TWIM_HSSRR_CLSLEW(value)    (TWIM_HSSRR_CLSLEW_Msk & ((value) << TWIM_HSSRR_CLSLEW_Pos))
+#define TWIM_HSSRR_FILTER_Pos       28           /**< \brief (TWIM_HSSRR) Input Spike Filter Control */
+#define TWIM_HSSRR_FILTER_Msk       (_U(0x3) << TWIM_HSSRR_FILTER_Pos)
+#define TWIM_HSSRR_FILTER(value)    (TWIM_HSSRR_FILTER_Msk & ((value) << TWIM_HSSRR_FILTER_Pos))
+#define TWIM_HSSRR_MASK             _U(0x33370307) /**< \brief (TWIM_HSSRR) MASK Register */
+
+/** \brief TWIM hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __O  TWIM_CR_Type              CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
+  __IO TWIM_CWGR_Type            CWGR;        /**< \brief Offset: 0x04 (R/W 32) Clock Waveform Generator Register */
+  __IO TWIM_SMBTR_Type           SMBTR;       /**< \brief Offset: 0x08 (R/W 32) SMBus Timing Register */
+  __IO TWIM_CMDR_Type            CMDR;        /**< \brief Offset: 0x0C (R/W 32) Command Register */
+  __IO TWIM_NCMDR_Type           NCMDR;       /**< \brief Offset: 0x10 (R/W 32) Next Command Register */
+  __I  TWIM_RHR_Type             RHR;         /**< \brief Offset: 0x14 (R/  32) Receive Holding Register */
+  __O  TWIM_THR_Type             THR;         /**< \brief Offset: 0x18 ( /W 32) Transmit Holding Register */
+  __I  TWIM_SR_Type              SR;          /**< \brief Offset: 0x1C (R/  32) Status Register */
+  __O  TWIM_IER_Type             IER;         /**< \brief Offset: 0x20 ( /W 32) Interrupt Enable Register */
+  __O  TWIM_IDR_Type             IDR;         /**< \brief Offset: 0x24 ( /W 32) Interrupt Disable Register */
+  __I  TWIM_IMR_Type             IMR;         /**< \brief Offset: 0x28 (R/  32) Interrupt Mask Register */
+  __O  TWIM_SCR_Type             SCR;         /**< \brief Offset: 0x2C ( /W 32) Status Clear Register */
+  __I  TWIM_PR_Type              PR;          /**< \brief Offset: 0x30 (R/  32) Parameter Register */
+  __I  TWIM_VR_Type              VR;          /**< \brief Offset: 0x34 (R/  32) Version Register */
+  __IO TWIM_HSCWGR_Type          HSCWGR;      /**< \brief Offset: 0x38 (R/W 32) HS-mode Clock Waveform Generator */
+  __IO TWIM_SRR_Type             SRR;         /**< \brief Offset: 0x3C (R/W 32) Slew Rate Register */
+  __IO TWIM_HSSRR_Type           HSSRR;       /**< \brief Offset: 0x40 (R/W 32) HS-mode Slew Rate Register */
+ } bf;
+ struct {
+  WoReg   TWIM_CR;            /**< \brief (TWIM Offset: 0x00) Control Register */
+  RwReg   TWIM_CWGR;          /**< \brief (TWIM Offset: 0x04) Clock Waveform Generator Register */
+  RwReg   TWIM_SMBTR;         /**< \brief (TWIM Offset: 0x08) SMBus Timing Register */
+  RwReg   TWIM_CMDR;          /**< \brief (TWIM Offset: 0x0C) Command Register */
+  RwReg   TWIM_NCMDR;         /**< \brief (TWIM Offset: 0x10) Next Command Register */
+  RoReg   TWIM_RHR;           /**< \brief (TWIM Offset: 0x14) Receive Holding Register */
+  WoReg   TWIM_THR;           /**< \brief (TWIM Offset: 0x18) Transmit Holding Register */
+  RoReg   TWIM_SR;            /**< \brief (TWIM Offset: 0x1C) Status Register */
+  WoReg   TWIM_IER;           /**< \brief (TWIM Offset: 0x20) Interrupt Enable Register */
+  WoReg   TWIM_IDR;           /**< \brief (TWIM Offset: 0x24) Interrupt Disable Register */
+  RoReg   TWIM_IMR;           /**< \brief (TWIM Offset: 0x28) Interrupt Mask Register */
+  WoReg   TWIM_SCR;           /**< \brief (TWIM Offset: 0x2C) Status Clear Register */
+  RoReg   TWIM_PR;            /**< \brief (TWIM Offset: 0x30) Parameter Register */
+  RoReg   TWIM_VR;            /**< \brief (TWIM Offset: 0x34) Version Register */
+  RwReg   TWIM_HSCWGR;        /**< \brief (TWIM Offset: 0x38) HS-mode Clock Waveform Generator */
+  RwReg   TWIM_SRR;           /**< \brief (TWIM Offset: 0x3C) Slew Rate Register */
+  RwReg   TWIM_HSSRR;         /**< \brief (TWIM Offset: 0x40) HS-mode Slew Rate Register */
+ } reg;
+} Twim;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_TWIM_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/twis.h
+++ b/asf/sam/include/sam4l/component/twis.h
@@ -1,0 +1,729 @@
+/**
+ * \file
+ *
+ * \brief Component description for TWIS
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_TWIS_COMPONENT_
+#define _SAM4L_TWIS_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR TWIS */
+/* ========================================================================== */
+/** \addtogroup SAM4L_TWIS Two-wire Slave Interface */
+/*@{*/
+
+#define TWIS_I7537
+#define REV_TWIS                    0x140
+
+/* -------- TWIS_CR : (TWIS Offset: 0x00) (R/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SEN:1;            /*!< bit:      0  Slave Enable                       */
+    uint32_t SMEN:1;           /*!< bit:      1  SMBus Mode Enable                  */
+    uint32_t SMATCH:1;         /*!< bit:      2  Slave Address Match                */
+    uint32_t GCMATCH:1;        /*!< bit:      3  General Call Address Match         */
+    uint32_t STREN:1;          /*!< bit:      4  Clock Stretch Enable               */
+    uint32_t :2;               /*!< bit:  5.. 6  Reserved                           */
+    uint32_t SWRST:1;          /*!< bit:      7  Software Reset                     */
+    uint32_t SMBALERT:1;       /*!< bit:      8  SMBus Alert                        */
+    uint32_t SMDA:1;           /*!< bit:      9  SMBus Default Address              */
+    uint32_t SMHH:1;           /*!< bit:     10  SMBus Host Header                  */
+    uint32_t PECEN:1;          /*!< bit:     11  Packet Error Checking Enable       */
+    uint32_t ACK:1;            /*!< bit:     12  Slave Receiver Data Phase ACK Value */
+    uint32_t CUP:1;            /*!< bit:     13  NBYTES Count Up                    */
+    uint32_t SOAM:1;           /*!< bit:     14  Stretch Clock on Address Match     */
+    uint32_t SODR:1;           /*!< bit:     15  Stretch Clock on Data Byte Reception */
+    uint32_t ADR:10;           /*!< bit: 16..25  Slave Address                      */
+    uint32_t TENBIT:1;         /*!< bit:     26  Ten Bit Address Match              */
+    uint32_t BRIDGE:1;         /*!< bit:     27  Bridge Control Enable              */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIS_CR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIS_CR_OFFSET              0x00         /**< \brief (TWIS_CR offset) Control Register */
+#define TWIS_CR_RESETVALUE          _U(0x00000000); /**< \brief (TWIS_CR reset_value) Control Register */
+
+#define TWIS_CR_SEN_Pos             0            /**< \brief (TWIS_CR) Slave Enable */
+#define TWIS_CR_SEN                 (_U(0x1) << TWIS_CR_SEN_Pos)
+#define TWIS_CR_SMEN_Pos            1            /**< \brief (TWIS_CR) SMBus Mode Enable */
+#define TWIS_CR_SMEN                (_U(0x1) << TWIS_CR_SMEN_Pos)
+#define TWIS_CR_SMATCH_Pos          2            /**< \brief (TWIS_CR) Slave Address Match */
+#define TWIS_CR_SMATCH              (_U(0x1) << TWIS_CR_SMATCH_Pos)
+#define TWIS_CR_GCMATCH_Pos         3            /**< \brief (TWIS_CR) General Call Address Match */
+#define TWIS_CR_GCMATCH             (_U(0x1) << TWIS_CR_GCMATCH_Pos)
+#define TWIS_CR_STREN_Pos           4            /**< \brief (TWIS_CR) Clock Stretch Enable */
+#define TWIS_CR_STREN               (_U(0x1) << TWIS_CR_STREN_Pos)
+#define TWIS_CR_SWRST_Pos           7            /**< \brief (TWIS_CR) Software Reset */
+#define TWIS_CR_SWRST               (_U(0x1) << TWIS_CR_SWRST_Pos)
+#define TWIS_CR_SMBALERT_Pos        8            /**< \brief (TWIS_CR) SMBus Alert */
+#define TWIS_CR_SMBALERT            (_U(0x1) << TWIS_CR_SMBALERT_Pos)
+#define TWIS_CR_SMDA_Pos            9            /**< \brief (TWIS_CR) SMBus Default Address */
+#define TWIS_CR_SMDA                (_U(0x1) << TWIS_CR_SMDA_Pos)
+#define TWIS_CR_SMHH_Pos            10           /**< \brief (TWIS_CR) SMBus Host Header */
+#define TWIS_CR_SMHH                (_U(0x1) << TWIS_CR_SMHH_Pos)
+#define TWIS_CR_PECEN_Pos           11           /**< \brief (TWIS_CR) Packet Error Checking Enable */
+#define TWIS_CR_PECEN               (_U(0x1) << TWIS_CR_PECEN_Pos)
+#define TWIS_CR_ACK_Pos             12           /**< \brief (TWIS_CR) Slave Receiver Data Phase ACK Value */
+#define TWIS_CR_ACK                 (_U(0x1) << TWIS_CR_ACK_Pos)
+#define TWIS_CR_CUP_Pos             13           /**< \brief (TWIS_CR) NBYTES Count Up */
+#define TWIS_CR_CUP                 (_U(0x1) << TWIS_CR_CUP_Pos)
+#define TWIS_CR_SOAM_Pos            14           /**< \brief (TWIS_CR) Stretch Clock on Address Match */
+#define TWIS_CR_SOAM                (_U(0x1) << TWIS_CR_SOAM_Pos)
+#define TWIS_CR_SODR_Pos            15           /**< \brief (TWIS_CR) Stretch Clock on Data Byte Reception */
+#define TWIS_CR_SODR                (_U(0x1) << TWIS_CR_SODR_Pos)
+#define TWIS_CR_ADR_Pos             16           /**< \brief (TWIS_CR) Slave Address */
+#define TWIS_CR_ADR_Msk             (_U(0x3FF) << TWIS_CR_ADR_Pos)
+#define TWIS_CR_ADR(value)          (TWIS_CR_ADR_Msk & ((value) << TWIS_CR_ADR_Pos))
+#define TWIS_CR_TENBIT_Pos          26           /**< \brief (TWIS_CR) Ten Bit Address Match */
+#define TWIS_CR_TENBIT              (_U(0x1) << TWIS_CR_TENBIT_Pos)
+#define TWIS_CR_BRIDGE_Pos          27           /**< \brief (TWIS_CR) Bridge Control Enable */
+#define TWIS_CR_BRIDGE              (_U(0x1) << TWIS_CR_BRIDGE_Pos)
+#define TWIS_CR_MASK                _U(0x0FFFFF9F) /**< \brief (TWIS_CR) MASK Register */
+
+/* -------- TWIS_NBYTES : (TWIS Offset: 0x04) (R/W 32) NBYTES Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t NBYTES:8;         /*!< bit:  0.. 7  Number of Bytes to Transfer        */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIS_NBYTES_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIS_NBYTES_OFFSET          0x04         /**< \brief (TWIS_NBYTES offset) NBYTES Register */
+#define TWIS_NBYTES_RESETVALUE      _U(0x00000000); /**< \brief (TWIS_NBYTES reset_value) NBYTES Register */
+
+#define TWIS_NBYTES_NBYTES_Pos      0            /**< \brief (TWIS_NBYTES) Number of Bytes to Transfer */
+#define TWIS_NBYTES_NBYTES_Msk      (_U(0xFF) << TWIS_NBYTES_NBYTES_Pos)
+#define TWIS_NBYTES_NBYTES(value)   (TWIS_NBYTES_NBYTES_Msk & ((value) << TWIS_NBYTES_NBYTES_Pos))
+#define TWIS_NBYTES_MASK            _U(0x000000FF) /**< \brief (TWIS_NBYTES) MASK Register */
+
+/* -------- TWIS_TR : (TWIS Offset: 0x08) (R/W 32) Timing Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TLOWS:8;          /*!< bit:  0.. 7  SMBus Tlow:sext Cycles             */
+    uint32_t TTOUT:8;          /*!< bit:  8..15  SMBus Ttimeout Cycles              */
+    uint32_t SUDAT:8;          /*!< bit: 16..23  Data Setup Cycles                  */
+    uint32_t :4;               /*!< bit: 24..27  Reserved                           */
+    uint32_t EXP:4;            /*!< bit: 28..31  Clock Prescaler                    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIS_TR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIS_TR_OFFSET              0x08         /**< \brief (TWIS_TR offset) Timing Register */
+#define TWIS_TR_RESETVALUE          _U(0x00000000); /**< \brief (TWIS_TR reset_value) Timing Register */
+
+#define TWIS_TR_TLOWS_Pos           0            /**< \brief (TWIS_TR) SMBus Tlow:sext Cycles */
+#define TWIS_TR_TLOWS_Msk           (_U(0xFF) << TWIS_TR_TLOWS_Pos)
+#define TWIS_TR_TLOWS(value)        (TWIS_TR_TLOWS_Msk & ((value) << TWIS_TR_TLOWS_Pos))
+#define TWIS_TR_TTOUT_Pos           8            /**< \brief (TWIS_TR) SMBus Ttimeout Cycles */
+#define TWIS_TR_TTOUT_Msk           (_U(0xFF) << TWIS_TR_TTOUT_Pos)
+#define TWIS_TR_TTOUT(value)        (TWIS_TR_TTOUT_Msk & ((value) << TWIS_TR_TTOUT_Pos))
+#define TWIS_TR_SUDAT_Pos           16           /**< \brief (TWIS_TR) Data Setup Cycles */
+#define TWIS_TR_SUDAT_Msk           (_U(0xFF) << TWIS_TR_SUDAT_Pos)
+#define TWIS_TR_SUDAT(value)        (TWIS_TR_SUDAT_Msk & ((value) << TWIS_TR_SUDAT_Pos))
+#define TWIS_TR_EXP_Pos             28           /**< \brief (TWIS_TR) Clock Prescaler */
+#define TWIS_TR_EXP_Msk             (_U(0xF) << TWIS_TR_EXP_Pos)
+#define TWIS_TR_EXP(value)          (TWIS_TR_EXP_Msk & ((value) << TWIS_TR_EXP_Pos))
+#define TWIS_TR_MASK                _U(0xF0FFFFFF) /**< \brief (TWIS_TR) MASK Register */
+
+/* -------- TWIS_RHR : (TWIS Offset: 0x0C) (R/  32) Receive Holding Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXDATA:8;         /*!< bit:  0.. 7  Received Data Byte                 */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIS_RHR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIS_RHR_OFFSET             0x0C         /**< \brief (TWIS_RHR offset) Receive Holding Register */
+#define TWIS_RHR_RESETVALUE         _U(0x00000000); /**< \brief (TWIS_RHR reset_value) Receive Holding Register */
+
+#define TWIS_RHR_RXDATA_Pos         0            /**< \brief (TWIS_RHR) Received Data Byte */
+#define TWIS_RHR_RXDATA_Msk         (_U(0xFF) << TWIS_RHR_RXDATA_Pos)
+#define TWIS_RHR_RXDATA(value)      (TWIS_RHR_RXDATA_Msk & ((value) << TWIS_RHR_RXDATA_Pos))
+#define TWIS_RHR_MASK               _U(0x000000FF) /**< \brief (TWIS_RHR) MASK Register */
+
+/* -------- TWIS_THR : (TWIS Offset: 0x10) ( /W 32) Transmit Holding Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXDATA:8;         /*!< bit:  0.. 7  Data Byte to Transmit              */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIS_THR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIS_THR_OFFSET             0x10         /**< \brief (TWIS_THR offset) Transmit Holding Register */
+#define TWIS_THR_RESETVALUE         _U(0x00000000); /**< \brief (TWIS_THR reset_value) Transmit Holding Register */
+
+#define TWIS_THR_TXDATA_Pos         0            /**< \brief (TWIS_THR) Data Byte to Transmit */
+#define TWIS_THR_TXDATA_Msk         (_U(0xFF) << TWIS_THR_TXDATA_Pos)
+#define TWIS_THR_TXDATA(value)      (TWIS_THR_TXDATA_Msk & ((value) << TWIS_THR_TXDATA_Pos))
+#define TWIS_THR_MASK               _U(0x000000FF) /**< \brief (TWIS_THR) MASK Register */
+
+/* -------- TWIS_PECR : (TWIS Offset: 0x14) (R/  32) Packet Error Check Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PEC:8;            /*!< bit:  0.. 7  Calculated PEC Value               */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIS_PECR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIS_PECR_OFFSET            0x14         /**< \brief (TWIS_PECR offset) Packet Error Check Register */
+#define TWIS_PECR_RESETVALUE        _U(0x00000000); /**< \brief (TWIS_PECR reset_value) Packet Error Check Register */
+
+#define TWIS_PECR_PEC_Pos           0            /**< \brief (TWIS_PECR) Calculated PEC Value */
+#define TWIS_PECR_PEC_Msk           (_U(0xFF) << TWIS_PECR_PEC_Pos)
+#define TWIS_PECR_PEC(value)        (TWIS_PECR_PEC_Msk & ((value) << TWIS_PECR_PEC_Pos))
+#define TWIS_PECR_MASK              _U(0x000000FF) /**< \brief (TWIS_PECR) MASK Register */
+
+/* -------- TWIS_SR : (TWIS Offset: 0x18) (R/  32) Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXRDY:1;          /*!< bit:      0  RX Buffer Ready                    */
+    uint32_t TXRDY:1;          /*!< bit:      1  TX Buffer Ready                    */
+    uint32_t SEN:1;            /*!< bit:      2  Slave Enabled                      */
+    uint32_t TCOMP:1;          /*!< bit:      3  Transmission Complete              */
+    uint32_t :1;               /*!< bit:      4  Reserved                           */
+    uint32_t TRA:1;            /*!< bit:      5  Transmitter Mode                   */
+    uint32_t URUN:1;           /*!< bit:      6  Underrun                           */
+    uint32_t ORUN:1;           /*!< bit:      7  Overrun                            */
+    uint32_t NAK:1;            /*!< bit:      8  NAK Received                       */
+    uint32_t :3;               /*!< bit:  9..11  Reserved                           */
+    uint32_t SMBTOUT:1;        /*!< bit:     12  SMBus Timeout                      */
+    uint32_t SMBPECERR:1;      /*!< bit:     13  SMBus PEC Error                    */
+    uint32_t BUSERR:1;         /*!< bit:     14  Bus Error                          */
+    uint32_t :1;               /*!< bit:     15  Reserved                           */
+    uint32_t SAM:1;            /*!< bit:     16  Slave Address Match                */
+    uint32_t GCM:1;            /*!< bit:     17  General Call Match                 */
+    uint32_t SMBALERTM:1;      /*!< bit:     18  SMBus Alert Response Address Match */
+    uint32_t SMBHHM:1;         /*!< bit:     19  SMBus Host Header Address Match    */
+    uint32_t SMBDAM:1;         /*!< bit:     20  SMBus Default Address Match        */
+    uint32_t STO:1;            /*!< bit:     21  Stop Received                      */
+    uint32_t REP:1;            /*!< bit:     22  Repeated Start Received            */
+    uint32_t BTF:1;            /*!< bit:     23  Byte Transfer Finished             */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIS_SR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIS_SR_OFFSET              0x18         /**< \brief (TWIS_SR offset) Status Register */
+#define TWIS_SR_RESETVALUE          _U(0x00000002); /**< \brief (TWIS_SR reset_value) Status Register */
+
+#define TWIS_SR_RXRDY_Pos           0            /**< \brief (TWIS_SR) RX Buffer Ready */
+#define TWIS_SR_RXRDY               (_U(0x1) << TWIS_SR_RXRDY_Pos)
+#define TWIS_SR_TXRDY_Pos           1            /**< \brief (TWIS_SR) TX Buffer Ready */
+#define TWIS_SR_TXRDY               (_U(0x1) << TWIS_SR_TXRDY_Pos)
+#define TWIS_SR_SEN_Pos             2            /**< \brief (TWIS_SR) Slave Enabled */
+#define TWIS_SR_SEN                 (_U(0x1) << TWIS_SR_SEN_Pos)
+#define TWIS_SR_TCOMP_Pos           3            /**< \brief (TWIS_SR) Transmission Complete */
+#define TWIS_SR_TCOMP               (_U(0x1) << TWIS_SR_TCOMP_Pos)
+#define TWIS_SR_TRA_Pos             5            /**< \brief (TWIS_SR) Transmitter Mode */
+#define TWIS_SR_TRA                 (_U(0x1) << TWIS_SR_TRA_Pos)
+#define TWIS_SR_URUN_Pos            6            /**< \brief (TWIS_SR) Underrun */
+#define TWIS_SR_URUN                (_U(0x1) << TWIS_SR_URUN_Pos)
+#define TWIS_SR_ORUN_Pos            7            /**< \brief (TWIS_SR) Overrun */
+#define TWIS_SR_ORUN                (_U(0x1) << TWIS_SR_ORUN_Pos)
+#define TWIS_SR_NAK_Pos             8            /**< \brief (TWIS_SR) NAK Received */
+#define TWIS_SR_NAK                 (_U(0x1) << TWIS_SR_NAK_Pos)
+#define TWIS_SR_SMBTOUT_Pos         12           /**< \brief (TWIS_SR) SMBus Timeout */
+#define TWIS_SR_SMBTOUT             (_U(0x1) << TWIS_SR_SMBTOUT_Pos)
+#define TWIS_SR_SMBPECERR_Pos       13           /**< \brief (TWIS_SR) SMBus PEC Error */
+#define TWIS_SR_SMBPECERR           (_U(0x1) << TWIS_SR_SMBPECERR_Pos)
+#define TWIS_SR_BUSERR_Pos          14           /**< \brief (TWIS_SR) Bus Error */
+#define TWIS_SR_BUSERR              (_U(0x1) << TWIS_SR_BUSERR_Pos)
+#define TWIS_SR_SAM_Pos             16           /**< \brief (TWIS_SR) Slave Address Match */
+#define TWIS_SR_SAM                 (_U(0x1) << TWIS_SR_SAM_Pos)
+#define TWIS_SR_GCM_Pos             17           /**< \brief (TWIS_SR) General Call Match */
+#define TWIS_SR_GCM                 (_U(0x1) << TWIS_SR_GCM_Pos)
+#define TWIS_SR_SMBALERTM_Pos       18           /**< \brief (TWIS_SR) SMBus Alert Response Address Match */
+#define TWIS_SR_SMBALERTM           (_U(0x1) << TWIS_SR_SMBALERTM_Pos)
+#define TWIS_SR_SMBHHM_Pos          19           /**< \brief (TWIS_SR) SMBus Host Header Address Match */
+#define TWIS_SR_SMBHHM              (_U(0x1) << TWIS_SR_SMBHHM_Pos)
+#define TWIS_SR_SMBDAM_Pos          20           /**< \brief (TWIS_SR) SMBus Default Address Match */
+#define TWIS_SR_SMBDAM              (_U(0x1) << TWIS_SR_SMBDAM_Pos)
+#define TWIS_SR_STO_Pos             21           /**< \brief (TWIS_SR) Stop Received */
+#define TWIS_SR_STO                 (_U(0x1) << TWIS_SR_STO_Pos)
+#define TWIS_SR_REP_Pos             22           /**< \brief (TWIS_SR) Repeated Start Received */
+#define TWIS_SR_REP                 (_U(0x1) << TWIS_SR_REP_Pos)
+#define TWIS_SR_BTF_Pos             23           /**< \brief (TWIS_SR) Byte Transfer Finished */
+#define TWIS_SR_BTF                 (_U(0x1) << TWIS_SR_BTF_Pos)
+#define TWIS_SR_MASK                _U(0x00FF71EF) /**< \brief (TWIS_SR) MASK Register */
+
+/* -------- TWIS_IER : (TWIS Offset: 0x1C) ( /W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXRDY:1;          /*!< bit:      0  RX Buffer Ready                    */
+    uint32_t TXRDY:1;          /*!< bit:      1  TX Buffer Ready                    */
+    uint32_t :1;               /*!< bit:      2  Reserved                           */
+    uint32_t TCOMP:1;          /*!< bit:      3  Transmission Complete              */
+    uint32_t :2;               /*!< bit:  4.. 5  Reserved                           */
+    uint32_t URUN:1;           /*!< bit:      6  Underrun                           */
+    uint32_t ORUN:1;           /*!< bit:      7  Overrun                            */
+    uint32_t NAK:1;            /*!< bit:      8  NAK Received                       */
+    uint32_t :3;               /*!< bit:  9..11  Reserved                           */
+    uint32_t SMBTOUT:1;        /*!< bit:     12  SMBus Timeout                      */
+    uint32_t SMBPECERR:1;      /*!< bit:     13  SMBus PEC Error                    */
+    uint32_t BUSERR:1;         /*!< bit:     14  Bus Error                          */
+    uint32_t :1;               /*!< bit:     15  Reserved                           */
+    uint32_t SAM:1;            /*!< bit:     16  Slave Address Match                */
+    uint32_t GCM:1;            /*!< bit:     17  General Call Match                 */
+    uint32_t SMBALERTM:1;      /*!< bit:     18  SMBus Alert Response Address Match */
+    uint32_t SMBHHM:1;         /*!< bit:     19  SMBus Host Header Address Match    */
+    uint32_t SMBDAM:1;         /*!< bit:     20  SMBus Default Address Match        */
+    uint32_t STO:1;            /*!< bit:     21  Stop Received                      */
+    uint32_t REP:1;            /*!< bit:     22  Repeated Start Received            */
+    uint32_t BTF:1;            /*!< bit:     23  Byte Transfer Finished             */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIS_IER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIS_IER_OFFSET             0x1C         /**< \brief (TWIS_IER offset) Interrupt Enable Register */
+#define TWIS_IER_RESETVALUE         _U(0x00000000); /**< \brief (TWIS_IER reset_value) Interrupt Enable Register */
+
+#define TWIS_IER_RXRDY_Pos          0            /**< \brief (TWIS_IER) RX Buffer Ready */
+#define TWIS_IER_RXRDY              (_U(0x1) << TWIS_IER_RXRDY_Pos)
+#define TWIS_IER_TXRDY_Pos          1            /**< \brief (TWIS_IER) TX Buffer Ready */
+#define TWIS_IER_TXRDY              (_U(0x1) << TWIS_IER_TXRDY_Pos)
+#define TWIS_IER_TCOMP_Pos          3            /**< \brief (TWIS_IER) Transmission Complete */
+#define TWIS_IER_TCOMP              (_U(0x1) << TWIS_IER_TCOMP_Pos)
+#define TWIS_IER_URUN_Pos           6            /**< \brief (TWIS_IER) Underrun */
+#define TWIS_IER_URUN               (_U(0x1) << TWIS_IER_URUN_Pos)
+#define TWIS_IER_ORUN_Pos           7            /**< \brief (TWIS_IER) Overrun */
+#define TWIS_IER_ORUN               (_U(0x1) << TWIS_IER_ORUN_Pos)
+#define TWIS_IER_NAK_Pos            8            /**< \brief (TWIS_IER) NAK Received */
+#define TWIS_IER_NAK                (_U(0x1) << TWIS_IER_NAK_Pos)
+#define TWIS_IER_SMBTOUT_Pos        12           /**< \brief (TWIS_IER) SMBus Timeout */
+#define TWIS_IER_SMBTOUT            (_U(0x1) << TWIS_IER_SMBTOUT_Pos)
+#define TWIS_IER_SMBPECERR_Pos      13           /**< \brief (TWIS_IER) SMBus PEC Error */
+#define TWIS_IER_SMBPECERR          (_U(0x1) << TWIS_IER_SMBPECERR_Pos)
+#define TWIS_IER_BUSERR_Pos         14           /**< \brief (TWIS_IER) Bus Error */
+#define TWIS_IER_BUSERR             (_U(0x1) << TWIS_IER_BUSERR_Pos)
+#define TWIS_IER_SAM_Pos            16           /**< \brief (TWIS_IER) Slave Address Match */
+#define TWIS_IER_SAM                (_U(0x1) << TWIS_IER_SAM_Pos)
+#define TWIS_IER_GCM_Pos            17           /**< \brief (TWIS_IER) General Call Match */
+#define TWIS_IER_GCM                (_U(0x1) << TWIS_IER_GCM_Pos)
+#define TWIS_IER_SMBALERTM_Pos      18           /**< \brief (TWIS_IER) SMBus Alert Response Address Match */
+#define TWIS_IER_SMBALERTM          (_U(0x1) << TWIS_IER_SMBALERTM_Pos)
+#define TWIS_IER_SMBHHM_Pos         19           /**< \brief (TWIS_IER) SMBus Host Header Address Match */
+#define TWIS_IER_SMBHHM             (_U(0x1) << TWIS_IER_SMBHHM_Pos)
+#define TWIS_IER_SMBDAM_Pos         20           /**< \brief (TWIS_IER) SMBus Default Address Match */
+#define TWIS_IER_SMBDAM             (_U(0x1) << TWIS_IER_SMBDAM_Pos)
+#define TWIS_IER_STO_Pos            21           /**< \brief (TWIS_IER) Stop Received */
+#define TWIS_IER_STO                (_U(0x1) << TWIS_IER_STO_Pos)
+#define TWIS_IER_REP_Pos            22           /**< \brief (TWIS_IER) Repeated Start Received */
+#define TWIS_IER_REP                (_U(0x1) << TWIS_IER_REP_Pos)
+#define TWIS_IER_BTF_Pos            23           /**< \brief (TWIS_IER) Byte Transfer Finished */
+#define TWIS_IER_BTF                (_U(0x1) << TWIS_IER_BTF_Pos)
+#define TWIS_IER_MASK               _U(0x00FF71CB) /**< \brief (TWIS_IER) MASK Register */
+
+/* -------- TWIS_IDR : (TWIS Offset: 0x20) ( /W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXRDY:1;          /*!< bit:      0  RX Buffer Ready                    */
+    uint32_t TXRDY:1;          /*!< bit:      1  TX Buffer Ready                    */
+    uint32_t :1;               /*!< bit:      2  Reserved                           */
+    uint32_t TCOMP:1;          /*!< bit:      3  Transmission Complete              */
+    uint32_t :2;               /*!< bit:  4.. 5  Reserved                           */
+    uint32_t URUN:1;           /*!< bit:      6  Underrun                           */
+    uint32_t ORUN:1;           /*!< bit:      7  Overrun                            */
+    uint32_t NAK:1;            /*!< bit:      8  NAK Received                       */
+    uint32_t :3;               /*!< bit:  9..11  Reserved                           */
+    uint32_t SMBTOUT:1;        /*!< bit:     12  SMBus Timeout                      */
+    uint32_t SMBPECERR:1;      /*!< bit:     13  SMBus PEC Error                    */
+    uint32_t BUSERR:1;         /*!< bit:     14  Bus Error                          */
+    uint32_t :1;               /*!< bit:     15  Reserved                           */
+    uint32_t SAM:1;            /*!< bit:     16  Slave Address Match                */
+    uint32_t GCM:1;            /*!< bit:     17  General Call Match                 */
+    uint32_t SMBALERTM:1;      /*!< bit:     18  SMBus Alert Response Address Match */
+    uint32_t SMBHHM:1;         /*!< bit:     19  SMBus Host Header Address Match    */
+    uint32_t SMBDAM:1;         /*!< bit:     20  SMBus Default Address Match        */
+    uint32_t STO:1;            /*!< bit:     21  Stop Received                      */
+    uint32_t REP:1;            /*!< bit:     22  Repeated Start Received            */
+    uint32_t BTF:1;            /*!< bit:     23  Byte Transfer Finished             */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIS_IDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIS_IDR_OFFSET             0x20         /**< \brief (TWIS_IDR offset) Interrupt Disable Register */
+#define TWIS_IDR_RESETVALUE         _U(0x00000000); /**< \brief (TWIS_IDR reset_value) Interrupt Disable Register */
+
+#define TWIS_IDR_RXRDY_Pos          0            /**< \brief (TWIS_IDR) RX Buffer Ready */
+#define TWIS_IDR_RXRDY              (_U(0x1) << TWIS_IDR_RXRDY_Pos)
+#define TWIS_IDR_TXRDY_Pos          1            /**< \brief (TWIS_IDR) TX Buffer Ready */
+#define TWIS_IDR_TXRDY              (_U(0x1) << TWIS_IDR_TXRDY_Pos)
+#define TWIS_IDR_TCOMP_Pos          3            /**< \brief (TWIS_IDR) Transmission Complete */
+#define TWIS_IDR_TCOMP              (_U(0x1) << TWIS_IDR_TCOMP_Pos)
+#define TWIS_IDR_URUN_Pos           6            /**< \brief (TWIS_IDR) Underrun */
+#define TWIS_IDR_URUN               (_U(0x1) << TWIS_IDR_URUN_Pos)
+#define TWIS_IDR_ORUN_Pos           7            /**< \brief (TWIS_IDR) Overrun */
+#define TWIS_IDR_ORUN               (_U(0x1) << TWIS_IDR_ORUN_Pos)
+#define TWIS_IDR_NAK_Pos            8            /**< \brief (TWIS_IDR) NAK Received */
+#define TWIS_IDR_NAK                (_U(0x1) << TWIS_IDR_NAK_Pos)
+#define TWIS_IDR_SMBTOUT_Pos        12           /**< \brief (TWIS_IDR) SMBus Timeout */
+#define TWIS_IDR_SMBTOUT            (_U(0x1) << TWIS_IDR_SMBTOUT_Pos)
+#define TWIS_IDR_SMBPECERR_Pos      13           /**< \brief (TWIS_IDR) SMBus PEC Error */
+#define TWIS_IDR_SMBPECERR          (_U(0x1) << TWIS_IDR_SMBPECERR_Pos)
+#define TWIS_IDR_BUSERR_Pos         14           /**< \brief (TWIS_IDR) Bus Error */
+#define TWIS_IDR_BUSERR             (_U(0x1) << TWIS_IDR_BUSERR_Pos)
+#define TWIS_IDR_SAM_Pos            16           /**< \brief (TWIS_IDR) Slave Address Match */
+#define TWIS_IDR_SAM                (_U(0x1) << TWIS_IDR_SAM_Pos)
+#define TWIS_IDR_GCM_Pos            17           /**< \brief (TWIS_IDR) General Call Match */
+#define TWIS_IDR_GCM                (_U(0x1) << TWIS_IDR_GCM_Pos)
+#define TWIS_IDR_SMBALERTM_Pos      18           /**< \brief (TWIS_IDR) SMBus Alert Response Address Match */
+#define TWIS_IDR_SMBALERTM          (_U(0x1) << TWIS_IDR_SMBALERTM_Pos)
+#define TWIS_IDR_SMBHHM_Pos         19           /**< \brief (TWIS_IDR) SMBus Host Header Address Match */
+#define TWIS_IDR_SMBHHM             (_U(0x1) << TWIS_IDR_SMBHHM_Pos)
+#define TWIS_IDR_SMBDAM_Pos         20           /**< \brief (TWIS_IDR) SMBus Default Address Match */
+#define TWIS_IDR_SMBDAM             (_U(0x1) << TWIS_IDR_SMBDAM_Pos)
+#define TWIS_IDR_STO_Pos            21           /**< \brief (TWIS_IDR) Stop Received */
+#define TWIS_IDR_STO                (_U(0x1) << TWIS_IDR_STO_Pos)
+#define TWIS_IDR_REP_Pos            22           /**< \brief (TWIS_IDR) Repeated Start Received */
+#define TWIS_IDR_REP                (_U(0x1) << TWIS_IDR_REP_Pos)
+#define TWIS_IDR_BTF_Pos            23           /**< \brief (TWIS_IDR) Byte Transfer Finished */
+#define TWIS_IDR_BTF                (_U(0x1) << TWIS_IDR_BTF_Pos)
+#define TWIS_IDR_MASK               _U(0x00FF71CB) /**< \brief (TWIS_IDR) MASK Register */
+
+/* -------- TWIS_IMR : (TWIS Offset: 0x24) (R/  32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXRDY:1;          /*!< bit:      0  RX Buffer Ready                    */
+    uint32_t TXRDY:1;          /*!< bit:      1  TX Buffer Ready                    */
+    uint32_t :1;               /*!< bit:      2  Reserved                           */
+    uint32_t TCOMP:1;          /*!< bit:      3  Transmission Complete              */
+    uint32_t :2;               /*!< bit:  4.. 5  Reserved                           */
+    uint32_t URUN:1;           /*!< bit:      6  Underrun                           */
+    uint32_t ORUN:1;           /*!< bit:      7  Overrun                            */
+    uint32_t NAK:1;            /*!< bit:      8  NAK Received                       */
+    uint32_t :3;               /*!< bit:  9..11  Reserved                           */
+    uint32_t SMBTOUT:1;        /*!< bit:     12  SMBus Timeout                      */
+    uint32_t SMBPECERR:1;      /*!< bit:     13  SMBus PEC Error                    */
+    uint32_t BUSERR:1;         /*!< bit:     14  Bus Error                          */
+    uint32_t :1;               /*!< bit:     15  Reserved                           */
+    uint32_t SAM:1;            /*!< bit:     16  Slave Address Match                */
+    uint32_t GCM:1;            /*!< bit:     17  General Call Match                 */
+    uint32_t SMBALERTM:1;      /*!< bit:     18  SMBus Alert Response Address Match */
+    uint32_t SMBHHM:1;         /*!< bit:     19  SMBus Host Header Address Match    */
+    uint32_t SMBDAM:1;         /*!< bit:     20  SMBus Default Address Match        */
+    uint32_t STO:1;            /*!< bit:     21  Stop Received                      */
+    uint32_t REP:1;            /*!< bit:     22  Repeated Start Received            */
+    uint32_t BTF:1;            /*!< bit:     23  Byte Transfer Finished             */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIS_IMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIS_IMR_OFFSET             0x24         /**< \brief (TWIS_IMR offset) Interrupt Mask Register */
+#define TWIS_IMR_RESETVALUE         _U(0x00000000); /**< \brief (TWIS_IMR reset_value) Interrupt Mask Register */
+
+#define TWIS_IMR_RXRDY_Pos          0            /**< \brief (TWIS_IMR) RX Buffer Ready */
+#define TWIS_IMR_RXRDY              (_U(0x1) << TWIS_IMR_RXRDY_Pos)
+#define TWIS_IMR_TXRDY_Pos          1            /**< \brief (TWIS_IMR) TX Buffer Ready */
+#define TWIS_IMR_TXRDY              (_U(0x1) << TWIS_IMR_TXRDY_Pos)
+#define TWIS_IMR_TCOMP_Pos          3            /**< \brief (TWIS_IMR) Transmission Complete */
+#define TWIS_IMR_TCOMP              (_U(0x1) << TWIS_IMR_TCOMP_Pos)
+#define TWIS_IMR_URUN_Pos           6            /**< \brief (TWIS_IMR) Underrun */
+#define TWIS_IMR_URUN               (_U(0x1) << TWIS_IMR_URUN_Pos)
+#define TWIS_IMR_ORUN_Pos           7            /**< \brief (TWIS_IMR) Overrun */
+#define TWIS_IMR_ORUN               (_U(0x1) << TWIS_IMR_ORUN_Pos)
+#define TWIS_IMR_NAK_Pos            8            /**< \brief (TWIS_IMR) NAK Received */
+#define TWIS_IMR_NAK                (_U(0x1) << TWIS_IMR_NAK_Pos)
+#define TWIS_IMR_SMBTOUT_Pos        12           /**< \brief (TWIS_IMR) SMBus Timeout */
+#define TWIS_IMR_SMBTOUT            (_U(0x1) << TWIS_IMR_SMBTOUT_Pos)
+#define TWIS_IMR_SMBPECERR_Pos      13           /**< \brief (TWIS_IMR) SMBus PEC Error */
+#define TWIS_IMR_SMBPECERR          (_U(0x1) << TWIS_IMR_SMBPECERR_Pos)
+#define TWIS_IMR_BUSERR_Pos         14           /**< \brief (TWIS_IMR) Bus Error */
+#define TWIS_IMR_BUSERR             (_U(0x1) << TWIS_IMR_BUSERR_Pos)
+#define TWIS_IMR_SAM_Pos            16           /**< \brief (TWIS_IMR) Slave Address Match */
+#define TWIS_IMR_SAM                (_U(0x1) << TWIS_IMR_SAM_Pos)
+#define TWIS_IMR_GCM_Pos            17           /**< \brief (TWIS_IMR) General Call Match */
+#define TWIS_IMR_GCM                (_U(0x1) << TWIS_IMR_GCM_Pos)
+#define TWIS_IMR_SMBALERTM_Pos      18           /**< \brief (TWIS_IMR) SMBus Alert Response Address Match */
+#define TWIS_IMR_SMBALERTM          (_U(0x1) << TWIS_IMR_SMBALERTM_Pos)
+#define TWIS_IMR_SMBHHM_Pos         19           /**< \brief (TWIS_IMR) SMBus Host Header Address Match */
+#define TWIS_IMR_SMBHHM             (_U(0x1) << TWIS_IMR_SMBHHM_Pos)
+#define TWIS_IMR_SMBDAM_Pos         20           /**< \brief (TWIS_IMR) SMBus Default Address Match */
+#define TWIS_IMR_SMBDAM             (_U(0x1) << TWIS_IMR_SMBDAM_Pos)
+#define TWIS_IMR_STO_Pos            21           /**< \brief (TWIS_IMR) Stop Received */
+#define TWIS_IMR_STO                (_U(0x1) << TWIS_IMR_STO_Pos)
+#define TWIS_IMR_REP_Pos            22           /**< \brief (TWIS_IMR) Repeated Start Received */
+#define TWIS_IMR_REP                (_U(0x1) << TWIS_IMR_REP_Pos)
+#define TWIS_IMR_BTF_Pos            23           /**< \brief (TWIS_IMR) Byte Transfer Finished */
+#define TWIS_IMR_BTF                (_U(0x1) << TWIS_IMR_BTF_Pos)
+#define TWIS_IMR_MASK               _U(0x00FF71CB) /**< \brief (TWIS_IMR) MASK Register */
+
+/* -------- TWIS_SCR : (TWIS Offset: 0x28) ( /W 32) Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :3;               /*!< bit:  0.. 2  Reserved                           */
+    uint32_t TCOMP:1;          /*!< bit:      3  Transmission Complete              */
+    uint32_t :2;               /*!< bit:  4.. 5  Reserved                           */
+    uint32_t URUN:1;           /*!< bit:      6  Underrun                           */
+    uint32_t ORUN:1;           /*!< bit:      7  Overrun                            */
+    uint32_t NAK:1;            /*!< bit:      8  NAK Received                       */
+    uint32_t :3;               /*!< bit:  9..11  Reserved                           */
+    uint32_t SMBTOUT:1;        /*!< bit:     12  SMBus Timeout                      */
+    uint32_t SMBPECERR:1;      /*!< bit:     13  SMBus PEC Error                    */
+    uint32_t BUSERR:1;         /*!< bit:     14  Bus Error                          */
+    uint32_t :1;               /*!< bit:     15  Reserved                           */
+    uint32_t SAM:1;            /*!< bit:     16  Slave Address Match                */
+    uint32_t GCM:1;            /*!< bit:     17  General Call Match                 */
+    uint32_t SMBALERTM:1;      /*!< bit:     18  SMBus Alert Response Address Match */
+    uint32_t SMBHHM:1;         /*!< bit:     19  SMBus Host Header Address Match    */
+    uint32_t SMBDAM:1;         /*!< bit:     20  SMBus Default Address Match        */
+    uint32_t STO:1;            /*!< bit:     21  Stop Received                      */
+    uint32_t REP:1;            /*!< bit:     22  Repeated Start Received            */
+    uint32_t BTF:1;            /*!< bit:     23  Byte Transfer Finished             */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIS_SCR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIS_SCR_OFFSET             0x28         /**< \brief (TWIS_SCR offset) Status Clear Register */
+#define TWIS_SCR_RESETVALUE         _U(0x00000000); /**< \brief (TWIS_SCR reset_value) Status Clear Register */
+
+#define TWIS_SCR_TCOMP_Pos          3            /**< \brief (TWIS_SCR) Transmission Complete */
+#define TWIS_SCR_TCOMP              (_U(0x1) << TWIS_SCR_TCOMP_Pos)
+#define TWIS_SCR_URUN_Pos           6            /**< \brief (TWIS_SCR) Underrun */
+#define TWIS_SCR_URUN               (_U(0x1) << TWIS_SCR_URUN_Pos)
+#define TWIS_SCR_ORUN_Pos           7            /**< \brief (TWIS_SCR) Overrun */
+#define TWIS_SCR_ORUN               (_U(0x1) << TWIS_SCR_ORUN_Pos)
+#define TWIS_SCR_NAK_Pos            8            /**< \brief (TWIS_SCR) NAK Received */
+#define TWIS_SCR_NAK                (_U(0x1) << TWIS_SCR_NAK_Pos)
+#define TWIS_SCR_SMBTOUT_Pos        12           /**< \brief (TWIS_SCR) SMBus Timeout */
+#define TWIS_SCR_SMBTOUT            (_U(0x1) << TWIS_SCR_SMBTOUT_Pos)
+#define TWIS_SCR_SMBPECERR_Pos      13           /**< \brief (TWIS_SCR) SMBus PEC Error */
+#define TWIS_SCR_SMBPECERR          (_U(0x1) << TWIS_SCR_SMBPECERR_Pos)
+#define TWIS_SCR_BUSERR_Pos         14           /**< \brief (TWIS_SCR) Bus Error */
+#define TWIS_SCR_BUSERR             (_U(0x1) << TWIS_SCR_BUSERR_Pos)
+#define TWIS_SCR_SAM_Pos            16           /**< \brief (TWIS_SCR) Slave Address Match */
+#define TWIS_SCR_SAM                (_U(0x1) << TWIS_SCR_SAM_Pos)
+#define TWIS_SCR_GCM_Pos            17           /**< \brief (TWIS_SCR) General Call Match */
+#define TWIS_SCR_GCM                (_U(0x1) << TWIS_SCR_GCM_Pos)
+#define TWIS_SCR_SMBALERTM_Pos      18           /**< \brief (TWIS_SCR) SMBus Alert Response Address Match */
+#define TWIS_SCR_SMBALERTM          (_U(0x1) << TWIS_SCR_SMBALERTM_Pos)
+#define TWIS_SCR_SMBHHM_Pos         19           /**< \brief (TWIS_SCR) SMBus Host Header Address Match */
+#define TWIS_SCR_SMBHHM             (_U(0x1) << TWIS_SCR_SMBHHM_Pos)
+#define TWIS_SCR_SMBDAM_Pos         20           /**< \brief (TWIS_SCR) SMBus Default Address Match */
+#define TWIS_SCR_SMBDAM             (_U(0x1) << TWIS_SCR_SMBDAM_Pos)
+#define TWIS_SCR_STO_Pos            21           /**< \brief (TWIS_SCR) Stop Received */
+#define TWIS_SCR_STO                (_U(0x1) << TWIS_SCR_STO_Pos)
+#define TWIS_SCR_REP_Pos            22           /**< \brief (TWIS_SCR) Repeated Start Received */
+#define TWIS_SCR_REP                (_U(0x1) << TWIS_SCR_REP_Pos)
+#define TWIS_SCR_BTF_Pos            23           /**< \brief (TWIS_SCR) Byte Transfer Finished */
+#define TWIS_SCR_BTF                (_U(0x1) << TWIS_SCR_BTF_Pos)
+#define TWIS_SCR_MASK               _U(0x00FF71C8) /**< \brief (TWIS_SCR) MASK Register */
+
+/* -------- TWIS_PR : (TWIS Offset: 0x2C) (R/  32) Parameter Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t HS:1;             /*!< bit:      0  HS-mode                            */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIS_PR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIS_PR_OFFSET              0x2C         /**< \brief (TWIS_PR offset) Parameter Register */
+#define TWIS_PR_RESETVALUE          _U(0x00000001); /**< \brief (TWIS_PR reset_value) Parameter Register */
+
+#define TWIS_PR_HS_Pos              0            /**< \brief (TWIS_PR) HS-mode */
+#define TWIS_PR_HS                  (_U(0x1) << TWIS_PR_HS_Pos)
+#define TWIS_PR_MASK                _U(0x00000001) /**< \brief (TWIS_PR) MASK Register */
+
+/* -------- TWIS_VR : (TWIS Offset: 0x30) (R/  32) Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version Number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant Number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIS_VR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIS_VR_OFFSET              0x30         /**< \brief (TWIS_VR offset) Version Register */
+#define TWIS_VR_RESETVALUE          _U(0x00000140); /**< \brief (TWIS_VR reset_value) Version Register */
+
+#define TWIS_VR_VERSION_Pos         0            /**< \brief (TWIS_VR) Version Number */
+#define TWIS_VR_VERSION_Msk         (_U(0xFFF) << TWIS_VR_VERSION_Pos)
+#define TWIS_VR_VERSION(value)      (TWIS_VR_VERSION_Msk & ((value) << TWIS_VR_VERSION_Pos))
+#define TWIS_VR_VARIANT_Pos         16           /**< \brief (TWIS_VR) Variant Number */
+#define TWIS_VR_VARIANT_Msk         (_U(0xF) << TWIS_VR_VARIANT_Pos)
+#define TWIS_VR_VARIANT(value)      (TWIS_VR_VARIANT_Msk & ((value) << TWIS_VR_VARIANT_Pos))
+#define TWIS_VR_MASK                _U(0x000F0FFF) /**< \brief (TWIS_VR) MASK Register */
+
+/* -------- TWIS_HSTR : (TWIS Offset: 0x34) (R/W 32) HS-mode Timing Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    uint32_t HDDAT:8;          /*!< bit: 16..23  Data Hold Cycles                   */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIS_HSTR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIS_HSTR_OFFSET            0x34         /**< \brief (TWIS_HSTR offset) HS-mode Timing Register */
+#define TWIS_HSTR_RESETVALUE        _U(0x00000000); /**< \brief (TWIS_HSTR reset_value) HS-mode Timing Register */
+
+#define TWIS_HSTR_HDDAT_Pos         16           /**< \brief (TWIS_HSTR) Data Hold Cycles */
+#define TWIS_HSTR_HDDAT_Msk         (_U(0xFF) << TWIS_HSTR_HDDAT_Pos)
+#define TWIS_HSTR_HDDAT(value)      (TWIS_HSTR_HDDAT_Msk & ((value) << TWIS_HSTR_HDDAT_Pos))
+#define TWIS_HSTR_MASK              _U(0x00FF0000) /**< \brief (TWIS_HSTR) MASK Register */
+
+/* -------- TWIS_SRR : (TWIS Offset: 0x38) (R/W 32) Slew Rate Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DADRIVEL:3;       /*!< bit:  0.. 2  Data Drive Strength LOW            */
+    uint32_t :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint32_t DASLEW:2;         /*!< bit:  8.. 9  Data Slew Limit                    */
+    uint32_t :18;              /*!< bit: 10..27  Reserved                           */
+    uint32_t FILTER:2;         /*!< bit: 28..29  Input Spike Filter Control         */
+    uint32_t :2;               /*!< bit: 30..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIS_SRR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIS_SRR_OFFSET             0x38         /**< \brief (TWIS_SRR offset) Slew Rate Register */
+#define TWIS_SRR_RESETVALUE         _U(0x00000000); /**< \brief (TWIS_SRR reset_value) Slew Rate Register */
+
+#define TWIS_SRR_DADRIVEL_Pos       0            /**< \brief (TWIS_SRR) Data Drive Strength LOW */
+#define TWIS_SRR_DADRIVEL_Msk       (_U(0x7) << TWIS_SRR_DADRIVEL_Pos)
+#define TWIS_SRR_DADRIVEL(value)    (TWIS_SRR_DADRIVEL_Msk & ((value) << TWIS_SRR_DADRIVEL_Pos))
+#define TWIS_SRR_DASLEW_Pos         8            /**< \brief (TWIS_SRR) Data Slew Limit */
+#define TWIS_SRR_DASLEW_Msk         (_U(0x3) << TWIS_SRR_DASLEW_Pos)
+#define TWIS_SRR_DASLEW(value)      (TWIS_SRR_DASLEW_Msk & ((value) << TWIS_SRR_DASLEW_Pos))
+#define TWIS_SRR_FILTER_Pos         28           /**< \brief (TWIS_SRR) Input Spike Filter Control */
+#define TWIS_SRR_FILTER_Msk         (_U(0x3) << TWIS_SRR_FILTER_Pos)
+#define TWIS_SRR_FILTER(value)      (TWIS_SRR_FILTER_Msk & ((value) << TWIS_SRR_FILTER_Pos))
+#define TWIS_SRR_MASK               _U(0x30000307) /**< \brief (TWIS_SRR) MASK Register */
+
+/* -------- TWIS_HSSRR : (TWIS Offset: 0x3C) (R/W 32) HS-mode Slew Rate Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DADRIVEL:3;       /*!< bit:  0.. 2  Data Drive Strength LOW            */
+    uint32_t :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint32_t DASLEW:2;         /*!< bit:  8.. 9  Data Slew Limit                    */
+    uint32_t :18;              /*!< bit: 10..27  Reserved                           */
+    uint32_t FILTER:2;         /*!< bit: 28..29  Input Spike Filter Control         */
+    uint32_t :2;               /*!< bit: 30..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TWIS_HSSRR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TWIS_HSSRR_OFFSET           0x3C         /**< \brief (TWIS_HSSRR offset) HS-mode Slew Rate Register */
+#define TWIS_HSSRR_RESETVALUE       _U(0x00000000); /**< \brief (TWIS_HSSRR reset_value) HS-mode Slew Rate Register */
+
+#define TWIS_HSSRR_DADRIVEL_Pos     0            /**< \brief (TWIS_HSSRR) Data Drive Strength LOW */
+#define TWIS_HSSRR_DADRIVEL_Msk     (_U(0x7) << TWIS_HSSRR_DADRIVEL_Pos)
+#define TWIS_HSSRR_DADRIVEL(value)  (TWIS_HSSRR_DADRIVEL_Msk & ((value) << TWIS_HSSRR_DADRIVEL_Pos))
+#define TWIS_HSSRR_DASLEW_Pos       8            /**< \brief (TWIS_HSSRR) Data Slew Limit */
+#define TWIS_HSSRR_DASLEW_Msk       (_U(0x3) << TWIS_HSSRR_DASLEW_Pos)
+#define TWIS_HSSRR_DASLEW(value)    (TWIS_HSSRR_DASLEW_Msk & ((value) << TWIS_HSSRR_DASLEW_Pos))
+#define TWIS_HSSRR_FILTER_Pos       28           /**< \brief (TWIS_HSSRR) Input Spike Filter Control */
+#define TWIS_HSSRR_FILTER_Msk       (_U(0x3) << TWIS_HSSRR_FILTER_Pos)
+#define TWIS_HSSRR_FILTER(value)    (TWIS_HSSRR_FILTER_Msk & ((value) << TWIS_HSSRR_FILTER_Pos))
+#define TWIS_HSSRR_MASK             _U(0x30000307) /**< \brief (TWIS_HSSRR) MASK Register */
+
+/** \brief TWIS hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __IO TWIS_CR_Type              CR;          /**< \brief Offset: 0x00 (R/W 32) Control Register */
+  __IO TWIS_NBYTES_Type          NBYTES;      /**< \brief Offset: 0x04 (R/W 32) NBYTES Register */
+  __IO TWIS_TR_Type              TR;          /**< \brief Offset: 0x08 (R/W 32) Timing Register */
+  __I  TWIS_RHR_Type             RHR;         /**< \brief Offset: 0x0C (R/  32) Receive Holding Register */
+  __O  TWIS_THR_Type             THR;         /**< \brief Offset: 0x10 ( /W 32) Transmit Holding Register */
+  __I  TWIS_PECR_Type            PECR;        /**< \brief Offset: 0x14 (R/  32) Packet Error Check Register */
+  __I  TWIS_SR_Type              SR;          /**< \brief Offset: 0x18 (R/  32) Status Register */
+  __O  TWIS_IER_Type             IER;         /**< \brief Offset: 0x1C ( /W 32) Interrupt Enable Register */
+  __O  TWIS_IDR_Type             IDR;         /**< \brief Offset: 0x20 ( /W 32) Interrupt Disable Register */
+  __I  TWIS_IMR_Type             IMR;         /**< \brief Offset: 0x24 (R/  32) Interrupt Mask Register */
+  __O  TWIS_SCR_Type             SCR;         /**< \brief Offset: 0x28 ( /W 32) Status Clear Register */
+  __I  TWIS_PR_Type              PR;          /**< \brief Offset: 0x2C (R/  32) Parameter Register */
+  __I  TWIS_VR_Type              VR;          /**< \brief Offset: 0x30 (R/  32) Version Register */
+  __IO TWIS_HSTR_Type            HSTR;        /**< \brief Offset: 0x34 (R/W 32) HS-mode Timing Register */
+  __IO TWIS_SRR_Type             SRR;         /**< \brief Offset: 0x38 (R/W 32) Slew Rate Register */
+  __IO TWIS_HSSRR_Type           HSSRR;       /**< \brief Offset: 0x3C (R/W 32) HS-mode Slew Rate Register */
+ } bf;
+ struct {
+  RwReg   TWIS_CR;            /**< \brief (TWIS Offset: 0x00) Control Register */
+  RwReg   TWIS_NBYTES;        /**< \brief (TWIS Offset: 0x04) NBYTES Register */
+  RwReg   TWIS_TR;            /**< \brief (TWIS Offset: 0x08) Timing Register */
+  RoReg   TWIS_RHR;           /**< \brief (TWIS Offset: 0x0C) Receive Holding Register */
+  WoReg   TWIS_THR;           /**< \brief (TWIS Offset: 0x10) Transmit Holding Register */
+  RoReg   TWIS_PECR;          /**< \brief (TWIS Offset: 0x14) Packet Error Check Register */
+  RoReg   TWIS_SR;            /**< \brief (TWIS Offset: 0x18) Status Register */
+  WoReg   TWIS_IER;           /**< \brief (TWIS Offset: 0x1C) Interrupt Enable Register */
+  WoReg   TWIS_IDR;           /**< \brief (TWIS Offset: 0x20) Interrupt Disable Register */
+  RoReg   TWIS_IMR;           /**< \brief (TWIS Offset: 0x24) Interrupt Mask Register */
+  WoReg   TWIS_SCR;           /**< \brief (TWIS Offset: 0x28) Status Clear Register */
+  RoReg   TWIS_PR;            /**< \brief (TWIS Offset: 0x2C) Parameter Register */
+  RoReg   TWIS_VR;            /**< \brief (TWIS Offset: 0x30) Version Register */
+  RwReg   TWIS_HSTR;          /**< \brief (TWIS Offset: 0x34) HS-mode Timing Register */
+  RwReg   TWIS_SRR;           /**< \brief (TWIS Offset: 0x38) Slew Rate Register */
+  RwReg   TWIS_HSSRR;         /**< \brief (TWIS Offset: 0x3C) HS-mode Slew Rate Register */
+ } reg;
+} Twis;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_TWIS_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/twis.h
+++ b/asf/sam/include/sam4l/component/twis.h
@@ -684,43 +684,23 @@ typedef union {
 
 /** \brief TWIS hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __IO TWIS_CR_Type              CR;          /**< \brief Offset: 0x00 (R/W 32) Control Register */
-  __IO TWIS_NBYTES_Type          NBYTES;      /**< \brief Offset: 0x04 (R/W 32) NBYTES Register */
-  __IO TWIS_TR_Type              TR;          /**< \brief Offset: 0x08 (R/W 32) Timing Register */
-  __I  TWIS_RHR_Type             RHR;         /**< \brief Offset: 0x0C (R/  32) Receive Holding Register */
-  __O  TWIS_THR_Type             THR;         /**< \brief Offset: 0x10 ( /W 32) Transmit Holding Register */
-  __I  TWIS_PECR_Type            PECR;        /**< \brief Offset: 0x14 (R/  32) Packet Error Check Register */
-  __I  TWIS_SR_Type              SR;          /**< \brief Offset: 0x18 (R/  32) Status Register */
-  __O  TWIS_IER_Type             IER;         /**< \brief Offset: 0x1C ( /W 32) Interrupt Enable Register */
-  __O  TWIS_IDR_Type             IDR;         /**< \brief Offset: 0x20 ( /W 32) Interrupt Disable Register */
-  __I  TWIS_IMR_Type             IMR;         /**< \brief Offset: 0x24 (R/  32) Interrupt Mask Register */
-  __O  TWIS_SCR_Type             SCR;         /**< \brief Offset: 0x28 ( /W 32) Status Clear Register */
-  __I  TWIS_PR_Type              PR;          /**< \brief Offset: 0x2C (R/  32) Parameter Register */
-  __I  TWIS_VR_Type              VR;          /**< \brief Offset: 0x30 (R/  32) Version Register */
-  __IO TWIS_HSTR_Type            HSTR;        /**< \brief Offset: 0x34 (R/W 32) HS-mode Timing Register */
-  __IO TWIS_SRR_Type             SRR;         /**< \brief Offset: 0x38 (R/W 32) Slew Rate Register */
-  __IO TWIS_HSSRR_Type           HSSRR;       /**< \brief Offset: 0x3C (R/W 32) HS-mode Slew Rate Register */
- } bf;
- struct {
-  RwReg   TWIS_CR;            /**< \brief (TWIS Offset: 0x00) Control Register */
-  RwReg   TWIS_NBYTES;        /**< \brief (TWIS Offset: 0x04) NBYTES Register */
-  RwReg   TWIS_TR;            /**< \brief (TWIS Offset: 0x08) Timing Register */
-  RoReg   TWIS_RHR;           /**< \brief (TWIS Offset: 0x0C) Receive Holding Register */
-  WoReg   TWIS_THR;           /**< \brief (TWIS Offset: 0x10) Transmit Holding Register */
-  RoReg   TWIS_PECR;          /**< \brief (TWIS Offset: 0x14) Packet Error Check Register */
-  RoReg   TWIS_SR;            /**< \brief (TWIS Offset: 0x18) Status Register */
-  WoReg   TWIS_IER;           /**< \brief (TWIS Offset: 0x1C) Interrupt Enable Register */
-  WoReg   TWIS_IDR;           /**< \brief (TWIS Offset: 0x20) Interrupt Disable Register */
-  RoReg   TWIS_IMR;           /**< \brief (TWIS Offset: 0x24) Interrupt Mask Register */
-  WoReg   TWIS_SCR;           /**< \brief (TWIS Offset: 0x28) Status Clear Register */
-  RoReg   TWIS_PR;            /**< \brief (TWIS Offset: 0x2C) Parameter Register */
-  RoReg   TWIS_VR;            /**< \brief (TWIS Offset: 0x30) Version Register */
-  RwReg   TWIS_HSTR;          /**< \brief (TWIS Offset: 0x34) HS-mode Timing Register */
-  RwReg   TWIS_SRR;           /**< \brief (TWIS Offset: 0x38) Slew Rate Register */
-  RwReg   TWIS_HSSRR;         /**< \brief (TWIS Offset: 0x3C) HS-mode Slew Rate Register */
- } reg;
+typedef struct {
+  __IO uint32_t CR;          /**< \brief Offset: 0x00 (R/W 32) Control Register */
+  __IO uint32_t NBYTES;      /**< \brief Offset: 0x04 (R/W 32) NBYTES Register */
+  __IO uint32_t TR;          /**< \brief Offset: 0x08 (R/W 32) Timing Register */
+  __I  uint32_t RHR;         /**< \brief Offset: 0x0C (R/  32) Receive Holding Register */
+  __O  uint32_t THR;         /**< \brief Offset: 0x10 ( /W 32) Transmit Holding Register */
+  __I  uint32_t PECR;        /**< \brief Offset: 0x14 (R/  32) Packet Error Check Register */
+  __I  uint32_t SR;          /**< \brief Offset: 0x18 (R/  32) Status Register */
+  __O  uint32_t IER;         /**< \brief Offset: 0x1C ( /W 32) Interrupt Enable Register */
+  __O  uint32_t IDR;         /**< \brief Offset: 0x20 ( /W 32) Interrupt Disable Register */
+  __I  uint32_t IMR;         /**< \brief Offset: 0x24 (R/  32) Interrupt Mask Register */
+  __O  uint32_t SCR;         /**< \brief Offset: 0x28 ( /W 32) Status Clear Register */
+  __I  uint32_t PR;          /**< \brief Offset: 0x2C (R/  32) Parameter Register */
+  __I  uint32_t VR;          /**< \brief Offset: 0x30 (R/  32) Version Register */
+  __IO uint32_t HSTR;        /**< \brief Offset: 0x34 (R/W 32) HS-mode Timing Register */
+  __IO uint32_t SRR;         /**< \brief Offset: 0x38 (R/W 32) Slew Rate Register */
+  __IO uint32_t HSSRR;       /**< \brief Offset: 0x3C (R/W 32) HS-mode Slew Rate Register */
 } Twis;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/twis.h
+++ b/asf/sam/include/sam4l/component/twis.h
@@ -67,44 +67,44 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIS_CR_OFFSET              0x00         /**< \brief (TWIS_CR offset) Control Register */
-#define TWIS_CR_RESETVALUE          _U(0x00000000); /**< \brief (TWIS_CR reset_value) Control Register */
+#define TWIS_CR_RESETVALUE          _U_(0x00000000); /**< \brief (TWIS_CR reset_value) Control Register */
 
 #define TWIS_CR_SEN_Pos             0            /**< \brief (TWIS_CR) Slave Enable */
-#define TWIS_CR_SEN                 (_U(0x1) << TWIS_CR_SEN_Pos)
+#define TWIS_CR_SEN                 (_U_(0x1) << TWIS_CR_SEN_Pos)
 #define TWIS_CR_SMEN_Pos            1            /**< \brief (TWIS_CR) SMBus Mode Enable */
-#define TWIS_CR_SMEN                (_U(0x1) << TWIS_CR_SMEN_Pos)
+#define TWIS_CR_SMEN                (_U_(0x1) << TWIS_CR_SMEN_Pos)
 #define TWIS_CR_SMATCH_Pos          2            /**< \brief (TWIS_CR) Slave Address Match */
-#define TWIS_CR_SMATCH              (_U(0x1) << TWIS_CR_SMATCH_Pos)
+#define TWIS_CR_SMATCH              (_U_(0x1) << TWIS_CR_SMATCH_Pos)
 #define TWIS_CR_GCMATCH_Pos         3            /**< \brief (TWIS_CR) General Call Address Match */
-#define TWIS_CR_GCMATCH             (_U(0x1) << TWIS_CR_GCMATCH_Pos)
+#define TWIS_CR_GCMATCH             (_U_(0x1) << TWIS_CR_GCMATCH_Pos)
 #define TWIS_CR_STREN_Pos           4            /**< \brief (TWIS_CR) Clock Stretch Enable */
-#define TWIS_CR_STREN               (_U(0x1) << TWIS_CR_STREN_Pos)
+#define TWIS_CR_STREN               (_U_(0x1) << TWIS_CR_STREN_Pos)
 #define TWIS_CR_SWRST_Pos           7            /**< \brief (TWIS_CR) Software Reset */
-#define TWIS_CR_SWRST               (_U(0x1) << TWIS_CR_SWRST_Pos)
+#define TWIS_CR_SWRST               (_U_(0x1) << TWIS_CR_SWRST_Pos)
 #define TWIS_CR_SMBALERT_Pos        8            /**< \brief (TWIS_CR) SMBus Alert */
-#define TWIS_CR_SMBALERT            (_U(0x1) << TWIS_CR_SMBALERT_Pos)
+#define TWIS_CR_SMBALERT            (_U_(0x1) << TWIS_CR_SMBALERT_Pos)
 #define TWIS_CR_SMDA_Pos            9            /**< \brief (TWIS_CR) SMBus Default Address */
-#define TWIS_CR_SMDA                (_U(0x1) << TWIS_CR_SMDA_Pos)
+#define TWIS_CR_SMDA                (_U_(0x1) << TWIS_CR_SMDA_Pos)
 #define TWIS_CR_SMHH_Pos            10           /**< \brief (TWIS_CR) SMBus Host Header */
-#define TWIS_CR_SMHH                (_U(0x1) << TWIS_CR_SMHH_Pos)
+#define TWIS_CR_SMHH                (_U_(0x1) << TWIS_CR_SMHH_Pos)
 #define TWIS_CR_PECEN_Pos           11           /**< \brief (TWIS_CR) Packet Error Checking Enable */
-#define TWIS_CR_PECEN               (_U(0x1) << TWIS_CR_PECEN_Pos)
+#define TWIS_CR_PECEN               (_U_(0x1) << TWIS_CR_PECEN_Pos)
 #define TWIS_CR_ACK_Pos             12           /**< \brief (TWIS_CR) Slave Receiver Data Phase ACK Value */
-#define TWIS_CR_ACK                 (_U(0x1) << TWIS_CR_ACK_Pos)
+#define TWIS_CR_ACK                 (_U_(0x1) << TWIS_CR_ACK_Pos)
 #define TWIS_CR_CUP_Pos             13           /**< \brief (TWIS_CR) NBYTES Count Up */
-#define TWIS_CR_CUP                 (_U(0x1) << TWIS_CR_CUP_Pos)
+#define TWIS_CR_CUP                 (_U_(0x1) << TWIS_CR_CUP_Pos)
 #define TWIS_CR_SOAM_Pos            14           /**< \brief (TWIS_CR) Stretch Clock on Address Match */
-#define TWIS_CR_SOAM                (_U(0x1) << TWIS_CR_SOAM_Pos)
+#define TWIS_CR_SOAM                (_U_(0x1) << TWIS_CR_SOAM_Pos)
 #define TWIS_CR_SODR_Pos            15           /**< \brief (TWIS_CR) Stretch Clock on Data Byte Reception */
-#define TWIS_CR_SODR                (_U(0x1) << TWIS_CR_SODR_Pos)
+#define TWIS_CR_SODR                (_U_(0x1) << TWIS_CR_SODR_Pos)
 #define TWIS_CR_ADR_Pos             16           /**< \brief (TWIS_CR) Slave Address */
-#define TWIS_CR_ADR_Msk             (_U(0x3FF) << TWIS_CR_ADR_Pos)
+#define TWIS_CR_ADR_Msk             (_U_(0x3FF) << TWIS_CR_ADR_Pos)
 #define TWIS_CR_ADR(value)          (TWIS_CR_ADR_Msk & ((value) << TWIS_CR_ADR_Pos))
 #define TWIS_CR_TENBIT_Pos          26           /**< \brief (TWIS_CR) Ten Bit Address Match */
-#define TWIS_CR_TENBIT              (_U(0x1) << TWIS_CR_TENBIT_Pos)
+#define TWIS_CR_TENBIT              (_U_(0x1) << TWIS_CR_TENBIT_Pos)
 #define TWIS_CR_BRIDGE_Pos          27           /**< \brief (TWIS_CR) Bridge Control Enable */
-#define TWIS_CR_BRIDGE              (_U(0x1) << TWIS_CR_BRIDGE_Pos)
-#define TWIS_CR_MASK                _U(0x0FFFFF9F) /**< \brief (TWIS_CR) MASK Register */
+#define TWIS_CR_BRIDGE              (_U_(0x1) << TWIS_CR_BRIDGE_Pos)
+#define TWIS_CR_MASK                _U_(0x0FFFFF9F) /**< \brief (TWIS_CR) MASK Register */
 
 /* -------- TWIS_NBYTES : (TWIS Offset: 0x04) (R/W 32) NBYTES Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -118,12 +118,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIS_NBYTES_OFFSET          0x04         /**< \brief (TWIS_NBYTES offset) NBYTES Register */
-#define TWIS_NBYTES_RESETVALUE      _U(0x00000000); /**< \brief (TWIS_NBYTES reset_value) NBYTES Register */
+#define TWIS_NBYTES_RESETVALUE      _U_(0x00000000); /**< \brief (TWIS_NBYTES reset_value) NBYTES Register */
 
 #define TWIS_NBYTES_NBYTES_Pos      0            /**< \brief (TWIS_NBYTES) Number of Bytes to Transfer */
-#define TWIS_NBYTES_NBYTES_Msk      (_U(0xFF) << TWIS_NBYTES_NBYTES_Pos)
+#define TWIS_NBYTES_NBYTES_Msk      (_U_(0xFF) << TWIS_NBYTES_NBYTES_Pos)
 #define TWIS_NBYTES_NBYTES(value)   (TWIS_NBYTES_NBYTES_Msk & ((value) << TWIS_NBYTES_NBYTES_Pos))
-#define TWIS_NBYTES_MASK            _U(0x000000FF) /**< \brief (TWIS_NBYTES) MASK Register */
+#define TWIS_NBYTES_MASK            _U_(0x000000FF) /**< \brief (TWIS_NBYTES) MASK Register */
 
 /* -------- TWIS_TR : (TWIS Offset: 0x08) (R/W 32) Timing Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -140,21 +140,21 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIS_TR_OFFSET              0x08         /**< \brief (TWIS_TR offset) Timing Register */
-#define TWIS_TR_RESETVALUE          _U(0x00000000); /**< \brief (TWIS_TR reset_value) Timing Register */
+#define TWIS_TR_RESETVALUE          _U_(0x00000000); /**< \brief (TWIS_TR reset_value) Timing Register */
 
 #define TWIS_TR_TLOWS_Pos           0            /**< \brief (TWIS_TR) SMBus Tlow:sext Cycles */
-#define TWIS_TR_TLOWS_Msk           (_U(0xFF) << TWIS_TR_TLOWS_Pos)
+#define TWIS_TR_TLOWS_Msk           (_U_(0xFF) << TWIS_TR_TLOWS_Pos)
 #define TWIS_TR_TLOWS(value)        (TWIS_TR_TLOWS_Msk & ((value) << TWIS_TR_TLOWS_Pos))
 #define TWIS_TR_TTOUT_Pos           8            /**< \brief (TWIS_TR) SMBus Ttimeout Cycles */
-#define TWIS_TR_TTOUT_Msk           (_U(0xFF) << TWIS_TR_TTOUT_Pos)
+#define TWIS_TR_TTOUT_Msk           (_U_(0xFF) << TWIS_TR_TTOUT_Pos)
 #define TWIS_TR_TTOUT(value)        (TWIS_TR_TTOUT_Msk & ((value) << TWIS_TR_TTOUT_Pos))
 #define TWIS_TR_SUDAT_Pos           16           /**< \brief (TWIS_TR) Data Setup Cycles */
-#define TWIS_TR_SUDAT_Msk           (_U(0xFF) << TWIS_TR_SUDAT_Pos)
+#define TWIS_TR_SUDAT_Msk           (_U_(0xFF) << TWIS_TR_SUDAT_Pos)
 #define TWIS_TR_SUDAT(value)        (TWIS_TR_SUDAT_Msk & ((value) << TWIS_TR_SUDAT_Pos))
 #define TWIS_TR_EXP_Pos             28           /**< \brief (TWIS_TR) Clock Prescaler */
-#define TWIS_TR_EXP_Msk             (_U(0xF) << TWIS_TR_EXP_Pos)
+#define TWIS_TR_EXP_Msk             (_U_(0xF) << TWIS_TR_EXP_Pos)
 #define TWIS_TR_EXP(value)          (TWIS_TR_EXP_Msk & ((value) << TWIS_TR_EXP_Pos))
-#define TWIS_TR_MASK                _U(0xF0FFFFFF) /**< \brief (TWIS_TR) MASK Register */
+#define TWIS_TR_MASK                _U_(0xF0FFFFFF) /**< \brief (TWIS_TR) MASK Register */
 
 /* -------- TWIS_RHR : (TWIS Offset: 0x0C) (R/  32) Receive Holding Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -168,12 +168,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIS_RHR_OFFSET             0x0C         /**< \brief (TWIS_RHR offset) Receive Holding Register */
-#define TWIS_RHR_RESETVALUE         _U(0x00000000); /**< \brief (TWIS_RHR reset_value) Receive Holding Register */
+#define TWIS_RHR_RESETVALUE         _U_(0x00000000); /**< \brief (TWIS_RHR reset_value) Receive Holding Register */
 
 #define TWIS_RHR_RXDATA_Pos         0            /**< \brief (TWIS_RHR) Received Data Byte */
-#define TWIS_RHR_RXDATA_Msk         (_U(0xFF) << TWIS_RHR_RXDATA_Pos)
+#define TWIS_RHR_RXDATA_Msk         (_U_(0xFF) << TWIS_RHR_RXDATA_Pos)
 #define TWIS_RHR_RXDATA(value)      (TWIS_RHR_RXDATA_Msk & ((value) << TWIS_RHR_RXDATA_Pos))
-#define TWIS_RHR_MASK               _U(0x000000FF) /**< \brief (TWIS_RHR) MASK Register */
+#define TWIS_RHR_MASK               _U_(0x000000FF) /**< \brief (TWIS_RHR) MASK Register */
 
 /* -------- TWIS_THR : (TWIS Offset: 0x10) ( /W 32) Transmit Holding Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -187,12 +187,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIS_THR_OFFSET             0x10         /**< \brief (TWIS_THR offset) Transmit Holding Register */
-#define TWIS_THR_RESETVALUE         _U(0x00000000); /**< \brief (TWIS_THR reset_value) Transmit Holding Register */
+#define TWIS_THR_RESETVALUE         _U_(0x00000000); /**< \brief (TWIS_THR reset_value) Transmit Holding Register */
 
 #define TWIS_THR_TXDATA_Pos         0            /**< \brief (TWIS_THR) Data Byte to Transmit */
-#define TWIS_THR_TXDATA_Msk         (_U(0xFF) << TWIS_THR_TXDATA_Pos)
+#define TWIS_THR_TXDATA_Msk         (_U_(0xFF) << TWIS_THR_TXDATA_Pos)
 #define TWIS_THR_TXDATA(value)      (TWIS_THR_TXDATA_Msk & ((value) << TWIS_THR_TXDATA_Pos))
-#define TWIS_THR_MASK               _U(0x000000FF) /**< \brief (TWIS_THR) MASK Register */
+#define TWIS_THR_MASK               _U_(0x000000FF) /**< \brief (TWIS_THR) MASK Register */
 
 /* -------- TWIS_PECR : (TWIS Offset: 0x14) (R/  32) Packet Error Check Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -206,12 +206,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIS_PECR_OFFSET            0x14         /**< \brief (TWIS_PECR offset) Packet Error Check Register */
-#define TWIS_PECR_RESETVALUE        _U(0x00000000); /**< \brief (TWIS_PECR reset_value) Packet Error Check Register */
+#define TWIS_PECR_RESETVALUE        _U_(0x00000000); /**< \brief (TWIS_PECR reset_value) Packet Error Check Register */
 
 #define TWIS_PECR_PEC_Pos           0            /**< \brief (TWIS_PECR) Calculated PEC Value */
-#define TWIS_PECR_PEC_Msk           (_U(0xFF) << TWIS_PECR_PEC_Pos)
+#define TWIS_PECR_PEC_Msk           (_U_(0xFF) << TWIS_PECR_PEC_Pos)
 #define TWIS_PECR_PEC(value)        (TWIS_PECR_PEC_Msk & ((value) << TWIS_PECR_PEC_Pos))
-#define TWIS_PECR_MASK              _U(0x000000FF) /**< \brief (TWIS_PECR) MASK Register */
+#define TWIS_PECR_MASK              _U_(0x000000FF) /**< \brief (TWIS_PECR) MASK Register */
 
 /* -------- TWIS_SR : (TWIS Offset: 0x18) (R/  32) Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -246,47 +246,47 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIS_SR_OFFSET              0x18         /**< \brief (TWIS_SR offset) Status Register */
-#define TWIS_SR_RESETVALUE          _U(0x00000002); /**< \brief (TWIS_SR reset_value) Status Register */
+#define TWIS_SR_RESETVALUE          _U_(0x00000002); /**< \brief (TWIS_SR reset_value) Status Register */
 
 #define TWIS_SR_RXRDY_Pos           0            /**< \brief (TWIS_SR) RX Buffer Ready */
-#define TWIS_SR_RXRDY               (_U(0x1) << TWIS_SR_RXRDY_Pos)
+#define TWIS_SR_RXRDY               (_U_(0x1) << TWIS_SR_RXRDY_Pos)
 #define TWIS_SR_TXRDY_Pos           1            /**< \brief (TWIS_SR) TX Buffer Ready */
-#define TWIS_SR_TXRDY               (_U(0x1) << TWIS_SR_TXRDY_Pos)
+#define TWIS_SR_TXRDY               (_U_(0x1) << TWIS_SR_TXRDY_Pos)
 #define TWIS_SR_SEN_Pos             2            /**< \brief (TWIS_SR) Slave Enabled */
-#define TWIS_SR_SEN                 (_U(0x1) << TWIS_SR_SEN_Pos)
+#define TWIS_SR_SEN                 (_U_(0x1) << TWIS_SR_SEN_Pos)
 #define TWIS_SR_TCOMP_Pos           3            /**< \brief (TWIS_SR) Transmission Complete */
-#define TWIS_SR_TCOMP               (_U(0x1) << TWIS_SR_TCOMP_Pos)
+#define TWIS_SR_TCOMP               (_U_(0x1) << TWIS_SR_TCOMP_Pos)
 #define TWIS_SR_TRA_Pos             5            /**< \brief (TWIS_SR) Transmitter Mode */
-#define TWIS_SR_TRA                 (_U(0x1) << TWIS_SR_TRA_Pos)
+#define TWIS_SR_TRA                 (_U_(0x1) << TWIS_SR_TRA_Pos)
 #define TWIS_SR_URUN_Pos            6            /**< \brief (TWIS_SR) Underrun */
-#define TWIS_SR_URUN                (_U(0x1) << TWIS_SR_URUN_Pos)
+#define TWIS_SR_URUN                (_U_(0x1) << TWIS_SR_URUN_Pos)
 #define TWIS_SR_ORUN_Pos            7            /**< \brief (TWIS_SR) Overrun */
-#define TWIS_SR_ORUN                (_U(0x1) << TWIS_SR_ORUN_Pos)
+#define TWIS_SR_ORUN                (_U_(0x1) << TWIS_SR_ORUN_Pos)
 #define TWIS_SR_NAK_Pos             8            /**< \brief (TWIS_SR) NAK Received */
-#define TWIS_SR_NAK                 (_U(0x1) << TWIS_SR_NAK_Pos)
+#define TWIS_SR_NAK                 (_U_(0x1) << TWIS_SR_NAK_Pos)
 #define TWIS_SR_SMBTOUT_Pos         12           /**< \brief (TWIS_SR) SMBus Timeout */
-#define TWIS_SR_SMBTOUT             (_U(0x1) << TWIS_SR_SMBTOUT_Pos)
+#define TWIS_SR_SMBTOUT             (_U_(0x1) << TWIS_SR_SMBTOUT_Pos)
 #define TWIS_SR_SMBPECERR_Pos       13           /**< \brief (TWIS_SR) SMBus PEC Error */
-#define TWIS_SR_SMBPECERR           (_U(0x1) << TWIS_SR_SMBPECERR_Pos)
+#define TWIS_SR_SMBPECERR           (_U_(0x1) << TWIS_SR_SMBPECERR_Pos)
 #define TWIS_SR_BUSERR_Pos          14           /**< \brief (TWIS_SR) Bus Error */
-#define TWIS_SR_BUSERR              (_U(0x1) << TWIS_SR_BUSERR_Pos)
+#define TWIS_SR_BUSERR              (_U_(0x1) << TWIS_SR_BUSERR_Pos)
 #define TWIS_SR_SAM_Pos             16           /**< \brief (TWIS_SR) Slave Address Match */
-#define TWIS_SR_SAM                 (_U(0x1) << TWIS_SR_SAM_Pos)
+#define TWIS_SR_SAM                 (_U_(0x1) << TWIS_SR_SAM_Pos)
 #define TWIS_SR_GCM_Pos             17           /**< \brief (TWIS_SR) General Call Match */
-#define TWIS_SR_GCM                 (_U(0x1) << TWIS_SR_GCM_Pos)
+#define TWIS_SR_GCM                 (_U_(0x1) << TWIS_SR_GCM_Pos)
 #define TWIS_SR_SMBALERTM_Pos       18           /**< \brief (TWIS_SR) SMBus Alert Response Address Match */
-#define TWIS_SR_SMBALERTM           (_U(0x1) << TWIS_SR_SMBALERTM_Pos)
+#define TWIS_SR_SMBALERTM           (_U_(0x1) << TWIS_SR_SMBALERTM_Pos)
 #define TWIS_SR_SMBHHM_Pos          19           /**< \brief (TWIS_SR) SMBus Host Header Address Match */
-#define TWIS_SR_SMBHHM              (_U(0x1) << TWIS_SR_SMBHHM_Pos)
+#define TWIS_SR_SMBHHM              (_U_(0x1) << TWIS_SR_SMBHHM_Pos)
 #define TWIS_SR_SMBDAM_Pos          20           /**< \brief (TWIS_SR) SMBus Default Address Match */
-#define TWIS_SR_SMBDAM              (_U(0x1) << TWIS_SR_SMBDAM_Pos)
+#define TWIS_SR_SMBDAM              (_U_(0x1) << TWIS_SR_SMBDAM_Pos)
 #define TWIS_SR_STO_Pos             21           /**< \brief (TWIS_SR) Stop Received */
-#define TWIS_SR_STO                 (_U(0x1) << TWIS_SR_STO_Pos)
+#define TWIS_SR_STO                 (_U_(0x1) << TWIS_SR_STO_Pos)
 #define TWIS_SR_REP_Pos             22           /**< \brief (TWIS_SR) Repeated Start Received */
-#define TWIS_SR_REP                 (_U(0x1) << TWIS_SR_REP_Pos)
+#define TWIS_SR_REP                 (_U_(0x1) << TWIS_SR_REP_Pos)
 #define TWIS_SR_BTF_Pos             23           /**< \brief (TWIS_SR) Byte Transfer Finished */
-#define TWIS_SR_BTF                 (_U(0x1) << TWIS_SR_BTF_Pos)
-#define TWIS_SR_MASK                _U(0x00FF71EF) /**< \brief (TWIS_SR) MASK Register */
+#define TWIS_SR_BTF                 (_U_(0x1) << TWIS_SR_BTF_Pos)
+#define TWIS_SR_MASK                _U_(0x00FF71EF) /**< \brief (TWIS_SR) MASK Register */
 
 /* -------- TWIS_IER : (TWIS Offset: 0x1C) ( /W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -320,43 +320,43 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIS_IER_OFFSET             0x1C         /**< \brief (TWIS_IER offset) Interrupt Enable Register */
-#define TWIS_IER_RESETVALUE         _U(0x00000000); /**< \brief (TWIS_IER reset_value) Interrupt Enable Register */
+#define TWIS_IER_RESETVALUE         _U_(0x00000000); /**< \brief (TWIS_IER reset_value) Interrupt Enable Register */
 
 #define TWIS_IER_RXRDY_Pos          0            /**< \brief (TWIS_IER) RX Buffer Ready */
-#define TWIS_IER_RXRDY              (_U(0x1) << TWIS_IER_RXRDY_Pos)
+#define TWIS_IER_RXRDY              (_U_(0x1) << TWIS_IER_RXRDY_Pos)
 #define TWIS_IER_TXRDY_Pos          1            /**< \brief (TWIS_IER) TX Buffer Ready */
-#define TWIS_IER_TXRDY              (_U(0x1) << TWIS_IER_TXRDY_Pos)
+#define TWIS_IER_TXRDY              (_U_(0x1) << TWIS_IER_TXRDY_Pos)
 #define TWIS_IER_TCOMP_Pos          3            /**< \brief (TWIS_IER) Transmission Complete */
-#define TWIS_IER_TCOMP              (_U(0x1) << TWIS_IER_TCOMP_Pos)
+#define TWIS_IER_TCOMP              (_U_(0x1) << TWIS_IER_TCOMP_Pos)
 #define TWIS_IER_URUN_Pos           6            /**< \brief (TWIS_IER) Underrun */
-#define TWIS_IER_URUN               (_U(0x1) << TWIS_IER_URUN_Pos)
+#define TWIS_IER_URUN               (_U_(0x1) << TWIS_IER_URUN_Pos)
 #define TWIS_IER_ORUN_Pos           7            /**< \brief (TWIS_IER) Overrun */
-#define TWIS_IER_ORUN               (_U(0x1) << TWIS_IER_ORUN_Pos)
+#define TWIS_IER_ORUN               (_U_(0x1) << TWIS_IER_ORUN_Pos)
 #define TWIS_IER_NAK_Pos            8            /**< \brief (TWIS_IER) NAK Received */
-#define TWIS_IER_NAK                (_U(0x1) << TWIS_IER_NAK_Pos)
+#define TWIS_IER_NAK                (_U_(0x1) << TWIS_IER_NAK_Pos)
 #define TWIS_IER_SMBTOUT_Pos        12           /**< \brief (TWIS_IER) SMBus Timeout */
-#define TWIS_IER_SMBTOUT            (_U(0x1) << TWIS_IER_SMBTOUT_Pos)
+#define TWIS_IER_SMBTOUT            (_U_(0x1) << TWIS_IER_SMBTOUT_Pos)
 #define TWIS_IER_SMBPECERR_Pos      13           /**< \brief (TWIS_IER) SMBus PEC Error */
-#define TWIS_IER_SMBPECERR          (_U(0x1) << TWIS_IER_SMBPECERR_Pos)
+#define TWIS_IER_SMBPECERR          (_U_(0x1) << TWIS_IER_SMBPECERR_Pos)
 #define TWIS_IER_BUSERR_Pos         14           /**< \brief (TWIS_IER) Bus Error */
-#define TWIS_IER_BUSERR             (_U(0x1) << TWIS_IER_BUSERR_Pos)
+#define TWIS_IER_BUSERR             (_U_(0x1) << TWIS_IER_BUSERR_Pos)
 #define TWIS_IER_SAM_Pos            16           /**< \brief (TWIS_IER) Slave Address Match */
-#define TWIS_IER_SAM                (_U(0x1) << TWIS_IER_SAM_Pos)
+#define TWIS_IER_SAM                (_U_(0x1) << TWIS_IER_SAM_Pos)
 #define TWIS_IER_GCM_Pos            17           /**< \brief (TWIS_IER) General Call Match */
-#define TWIS_IER_GCM                (_U(0x1) << TWIS_IER_GCM_Pos)
+#define TWIS_IER_GCM                (_U_(0x1) << TWIS_IER_GCM_Pos)
 #define TWIS_IER_SMBALERTM_Pos      18           /**< \brief (TWIS_IER) SMBus Alert Response Address Match */
-#define TWIS_IER_SMBALERTM          (_U(0x1) << TWIS_IER_SMBALERTM_Pos)
+#define TWIS_IER_SMBALERTM          (_U_(0x1) << TWIS_IER_SMBALERTM_Pos)
 #define TWIS_IER_SMBHHM_Pos         19           /**< \brief (TWIS_IER) SMBus Host Header Address Match */
-#define TWIS_IER_SMBHHM             (_U(0x1) << TWIS_IER_SMBHHM_Pos)
+#define TWIS_IER_SMBHHM             (_U_(0x1) << TWIS_IER_SMBHHM_Pos)
 #define TWIS_IER_SMBDAM_Pos         20           /**< \brief (TWIS_IER) SMBus Default Address Match */
-#define TWIS_IER_SMBDAM             (_U(0x1) << TWIS_IER_SMBDAM_Pos)
+#define TWIS_IER_SMBDAM             (_U_(0x1) << TWIS_IER_SMBDAM_Pos)
 #define TWIS_IER_STO_Pos            21           /**< \brief (TWIS_IER) Stop Received */
-#define TWIS_IER_STO                (_U(0x1) << TWIS_IER_STO_Pos)
+#define TWIS_IER_STO                (_U_(0x1) << TWIS_IER_STO_Pos)
 #define TWIS_IER_REP_Pos            22           /**< \brief (TWIS_IER) Repeated Start Received */
-#define TWIS_IER_REP                (_U(0x1) << TWIS_IER_REP_Pos)
+#define TWIS_IER_REP                (_U_(0x1) << TWIS_IER_REP_Pos)
 #define TWIS_IER_BTF_Pos            23           /**< \brief (TWIS_IER) Byte Transfer Finished */
-#define TWIS_IER_BTF                (_U(0x1) << TWIS_IER_BTF_Pos)
-#define TWIS_IER_MASK               _U(0x00FF71CB) /**< \brief (TWIS_IER) MASK Register */
+#define TWIS_IER_BTF                (_U_(0x1) << TWIS_IER_BTF_Pos)
+#define TWIS_IER_MASK               _U_(0x00FF71CB) /**< \brief (TWIS_IER) MASK Register */
 
 /* -------- TWIS_IDR : (TWIS Offset: 0x20) ( /W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -390,43 +390,43 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIS_IDR_OFFSET             0x20         /**< \brief (TWIS_IDR offset) Interrupt Disable Register */
-#define TWIS_IDR_RESETVALUE         _U(0x00000000); /**< \brief (TWIS_IDR reset_value) Interrupt Disable Register */
+#define TWIS_IDR_RESETVALUE         _U_(0x00000000); /**< \brief (TWIS_IDR reset_value) Interrupt Disable Register */
 
 #define TWIS_IDR_RXRDY_Pos          0            /**< \brief (TWIS_IDR) RX Buffer Ready */
-#define TWIS_IDR_RXRDY              (_U(0x1) << TWIS_IDR_RXRDY_Pos)
+#define TWIS_IDR_RXRDY              (_U_(0x1) << TWIS_IDR_RXRDY_Pos)
 #define TWIS_IDR_TXRDY_Pos          1            /**< \brief (TWIS_IDR) TX Buffer Ready */
-#define TWIS_IDR_TXRDY              (_U(0x1) << TWIS_IDR_TXRDY_Pos)
+#define TWIS_IDR_TXRDY              (_U_(0x1) << TWIS_IDR_TXRDY_Pos)
 #define TWIS_IDR_TCOMP_Pos          3            /**< \brief (TWIS_IDR) Transmission Complete */
-#define TWIS_IDR_TCOMP              (_U(0x1) << TWIS_IDR_TCOMP_Pos)
+#define TWIS_IDR_TCOMP              (_U_(0x1) << TWIS_IDR_TCOMP_Pos)
 #define TWIS_IDR_URUN_Pos           6            /**< \brief (TWIS_IDR) Underrun */
-#define TWIS_IDR_URUN               (_U(0x1) << TWIS_IDR_URUN_Pos)
+#define TWIS_IDR_URUN               (_U_(0x1) << TWIS_IDR_URUN_Pos)
 #define TWIS_IDR_ORUN_Pos           7            /**< \brief (TWIS_IDR) Overrun */
-#define TWIS_IDR_ORUN               (_U(0x1) << TWIS_IDR_ORUN_Pos)
+#define TWIS_IDR_ORUN               (_U_(0x1) << TWIS_IDR_ORUN_Pos)
 #define TWIS_IDR_NAK_Pos            8            /**< \brief (TWIS_IDR) NAK Received */
-#define TWIS_IDR_NAK                (_U(0x1) << TWIS_IDR_NAK_Pos)
+#define TWIS_IDR_NAK                (_U_(0x1) << TWIS_IDR_NAK_Pos)
 #define TWIS_IDR_SMBTOUT_Pos        12           /**< \brief (TWIS_IDR) SMBus Timeout */
-#define TWIS_IDR_SMBTOUT            (_U(0x1) << TWIS_IDR_SMBTOUT_Pos)
+#define TWIS_IDR_SMBTOUT            (_U_(0x1) << TWIS_IDR_SMBTOUT_Pos)
 #define TWIS_IDR_SMBPECERR_Pos      13           /**< \brief (TWIS_IDR) SMBus PEC Error */
-#define TWIS_IDR_SMBPECERR          (_U(0x1) << TWIS_IDR_SMBPECERR_Pos)
+#define TWIS_IDR_SMBPECERR          (_U_(0x1) << TWIS_IDR_SMBPECERR_Pos)
 #define TWIS_IDR_BUSERR_Pos         14           /**< \brief (TWIS_IDR) Bus Error */
-#define TWIS_IDR_BUSERR             (_U(0x1) << TWIS_IDR_BUSERR_Pos)
+#define TWIS_IDR_BUSERR             (_U_(0x1) << TWIS_IDR_BUSERR_Pos)
 #define TWIS_IDR_SAM_Pos            16           /**< \brief (TWIS_IDR) Slave Address Match */
-#define TWIS_IDR_SAM                (_U(0x1) << TWIS_IDR_SAM_Pos)
+#define TWIS_IDR_SAM                (_U_(0x1) << TWIS_IDR_SAM_Pos)
 #define TWIS_IDR_GCM_Pos            17           /**< \brief (TWIS_IDR) General Call Match */
-#define TWIS_IDR_GCM                (_U(0x1) << TWIS_IDR_GCM_Pos)
+#define TWIS_IDR_GCM                (_U_(0x1) << TWIS_IDR_GCM_Pos)
 #define TWIS_IDR_SMBALERTM_Pos      18           /**< \brief (TWIS_IDR) SMBus Alert Response Address Match */
-#define TWIS_IDR_SMBALERTM          (_U(0x1) << TWIS_IDR_SMBALERTM_Pos)
+#define TWIS_IDR_SMBALERTM          (_U_(0x1) << TWIS_IDR_SMBALERTM_Pos)
 #define TWIS_IDR_SMBHHM_Pos         19           /**< \brief (TWIS_IDR) SMBus Host Header Address Match */
-#define TWIS_IDR_SMBHHM             (_U(0x1) << TWIS_IDR_SMBHHM_Pos)
+#define TWIS_IDR_SMBHHM             (_U_(0x1) << TWIS_IDR_SMBHHM_Pos)
 #define TWIS_IDR_SMBDAM_Pos         20           /**< \brief (TWIS_IDR) SMBus Default Address Match */
-#define TWIS_IDR_SMBDAM             (_U(0x1) << TWIS_IDR_SMBDAM_Pos)
+#define TWIS_IDR_SMBDAM             (_U_(0x1) << TWIS_IDR_SMBDAM_Pos)
 #define TWIS_IDR_STO_Pos            21           /**< \brief (TWIS_IDR) Stop Received */
-#define TWIS_IDR_STO                (_U(0x1) << TWIS_IDR_STO_Pos)
+#define TWIS_IDR_STO                (_U_(0x1) << TWIS_IDR_STO_Pos)
 #define TWIS_IDR_REP_Pos            22           /**< \brief (TWIS_IDR) Repeated Start Received */
-#define TWIS_IDR_REP                (_U(0x1) << TWIS_IDR_REP_Pos)
+#define TWIS_IDR_REP                (_U_(0x1) << TWIS_IDR_REP_Pos)
 #define TWIS_IDR_BTF_Pos            23           /**< \brief (TWIS_IDR) Byte Transfer Finished */
-#define TWIS_IDR_BTF                (_U(0x1) << TWIS_IDR_BTF_Pos)
-#define TWIS_IDR_MASK               _U(0x00FF71CB) /**< \brief (TWIS_IDR) MASK Register */
+#define TWIS_IDR_BTF                (_U_(0x1) << TWIS_IDR_BTF_Pos)
+#define TWIS_IDR_MASK               _U_(0x00FF71CB) /**< \brief (TWIS_IDR) MASK Register */
 
 /* -------- TWIS_IMR : (TWIS Offset: 0x24) (R/  32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -460,43 +460,43 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIS_IMR_OFFSET             0x24         /**< \brief (TWIS_IMR offset) Interrupt Mask Register */
-#define TWIS_IMR_RESETVALUE         _U(0x00000000); /**< \brief (TWIS_IMR reset_value) Interrupt Mask Register */
+#define TWIS_IMR_RESETVALUE         _U_(0x00000000); /**< \brief (TWIS_IMR reset_value) Interrupt Mask Register */
 
 #define TWIS_IMR_RXRDY_Pos          0            /**< \brief (TWIS_IMR) RX Buffer Ready */
-#define TWIS_IMR_RXRDY              (_U(0x1) << TWIS_IMR_RXRDY_Pos)
+#define TWIS_IMR_RXRDY              (_U_(0x1) << TWIS_IMR_RXRDY_Pos)
 #define TWIS_IMR_TXRDY_Pos          1            /**< \brief (TWIS_IMR) TX Buffer Ready */
-#define TWIS_IMR_TXRDY              (_U(0x1) << TWIS_IMR_TXRDY_Pos)
+#define TWIS_IMR_TXRDY              (_U_(0x1) << TWIS_IMR_TXRDY_Pos)
 #define TWIS_IMR_TCOMP_Pos          3            /**< \brief (TWIS_IMR) Transmission Complete */
-#define TWIS_IMR_TCOMP              (_U(0x1) << TWIS_IMR_TCOMP_Pos)
+#define TWIS_IMR_TCOMP              (_U_(0x1) << TWIS_IMR_TCOMP_Pos)
 #define TWIS_IMR_URUN_Pos           6            /**< \brief (TWIS_IMR) Underrun */
-#define TWIS_IMR_URUN               (_U(0x1) << TWIS_IMR_URUN_Pos)
+#define TWIS_IMR_URUN               (_U_(0x1) << TWIS_IMR_URUN_Pos)
 #define TWIS_IMR_ORUN_Pos           7            /**< \brief (TWIS_IMR) Overrun */
-#define TWIS_IMR_ORUN               (_U(0x1) << TWIS_IMR_ORUN_Pos)
+#define TWIS_IMR_ORUN               (_U_(0x1) << TWIS_IMR_ORUN_Pos)
 #define TWIS_IMR_NAK_Pos            8            /**< \brief (TWIS_IMR) NAK Received */
-#define TWIS_IMR_NAK                (_U(0x1) << TWIS_IMR_NAK_Pos)
+#define TWIS_IMR_NAK                (_U_(0x1) << TWIS_IMR_NAK_Pos)
 #define TWIS_IMR_SMBTOUT_Pos        12           /**< \brief (TWIS_IMR) SMBus Timeout */
-#define TWIS_IMR_SMBTOUT            (_U(0x1) << TWIS_IMR_SMBTOUT_Pos)
+#define TWIS_IMR_SMBTOUT            (_U_(0x1) << TWIS_IMR_SMBTOUT_Pos)
 #define TWIS_IMR_SMBPECERR_Pos      13           /**< \brief (TWIS_IMR) SMBus PEC Error */
-#define TWIS_IMR_SMBPECERR          (_U(0x1) << TWIS_IMR_SMBPECERR_Pos)
+#define TWIS_IMR_SMBPECERR          (_U_(0x1) << TWIS_IMR_SMBPECERR_Pos)
 #define TWIS_IMR_BUSERR_Pos         14           /**< \brief (TWIS_IMR) Bus Error */
-#define TWIS_IMR_BUSERR             (_U(0x1) << TWIS_IMR_BUSERR_Pos)
+#define TWIS_IMR_BUSERR             (_U_(0x1) << TWIS_IMR_BUSERR_Pos)
 #define TWIS_IMR_SAM_Pos            16           /**< \brief (TWIS_IMR) Slave Address Match */
-#define TWIS_IMR_SAM                (_U(0x1) << TWIS_IMR_SAM_Pos)
+#define TWIS_IMR_SAM                (_U_(0x1) << TWIS_IMR_SAM_Pos)
 #define TWIS_IMR_GCM_Pos            17           /**< \brief (TWIS_IMR) General Call Match */
-#define TWIS_IMR_GCM                (_U(0x1) << TWIS_IMR_GCM_Pos)
+#define TWIS_IMR_GCM                (_U_(0x1) << TWIS_IMR_GCM_Pos)
 #define TWIS_IMR_SMBALERTM_Pos      18           /**< \brief (TWIS_IMR) SMBus Alert Response Address Match */
-#define TWIS_IMR_SMBALERTM          (_U(0x1) << TWIS_IMR_SMBALERTM_Pos)
+#define TWIS_IMR_SMBALERTM          (_U_(0x1) << TWIS_IMR_SMBALERTM_Pos)
 #define TWIS_IMR_SMBHHM_Pos         19           /**< \brief (TWIS_IMR) SMBus Host Header Address Match */
-#define TWIS_IMR_SMBHHM             (_U(0x1) << TWIS_IMR_SMBHHM_Pos)
+#define TWIS_IMR_SMBHHM             (_U_(0x1) << TWIS_IMR_SMBHHM_Pos)
 #define TWIS_IMR_SMBDAM_Pos         20           /**< \brief (TWIS_IMR) SMBus Default Address Match */
-#define TWIS_IMR_SMBDAM             (_U(0x1) << TWIS_IMR_SMBDAM_Pos)
+#define TWIS_IMR_SMBDAM             (_U_(0x1) << TWIS_IMR_SMBDAM_Pos)
 #define TWIS_IMR_STO_Pos            21           /**< \brief (TWIS_IMR) Stop Received */
-#define TWIS_IMR_STO                (_U(0x1) << TWIS_IMR_STO_Pos)
+#define TWIS_IMR_STO                (_U_(0x1) << TWIS_IMR_STO_Pos)
 #define TWIS_IMR_REP_Pos            22           /**< \brief (TWIS_IMR) Repeated Start Received */
-#define TWIS_IMR_REP                (_U(0x1) << TWIS_IMR_REP_Pos)
+#define TWIS_IMR_REP                (_U_(0x1) << TWIS_IMR_REP_Pos)
 #define TWIS_IMR_BTF_Pos            23           /**< \brief (TWIS_IMR) Byte Transfer Finished */
-#define TWIS_IMR_BTF                (_U(0x1) << TWIS_IMR_BTF_Pos)
-#define TWIS_IMR_MASK               _U(0x00FF71CB) /**< \brief (TWIS_IMR) MASK Register */
+#define TWIS_IMR_BTF                (_U_(0x1) << TWIS_IMR_BTF_Pos)
+#define TWIS_IMR_MASK               _U_(0x00FF71CB) /**< \brief (TWIS_IMR) MASK Register */
 
 /* -------- TWIS_SCR : (TWIS Offset: 0x28) ( /W 32) Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -528,39 +528,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIS_SCR_OFFSET             0x28         /**< \brief (TWIS_SCR offset) Status Clear Register */
-#define TWIS_SCR_RESETVALUE         _U(0x00000000); /**< \brief (TWIS_SCR reset_value) Status Clear Register */
+#define TWIS_SCR_RESETVALUE         _U_(0x00000000); /**< \brief (TWIS_SCR reset_value) Status Clear Register */
 
 #define TWIS_SCR_TCOMP_Pos          3            /**< \brief (TWIS_SCR) Transmission Complete */
-#define TWIS_SCR_TCOMP              (_U(0x1) << TWIS_SCR_TCOMP_Pos)
+#define TWIS_SCR_TCOMP              (_U_(0x1) << TWIS_SCR_TCOMP_Pos)
 #define TWIS_SCR_URUN_Pos           6            /**< \brief (TWIS_SCR) Underrun */
-#define TWIS_SCR_URUN               (_U(0x1) << TWIS_SCR_URUN_Pos)
+#define TWIS_SCR_URUN               (_U_(0x1) << TWIS_SCR_URUN_Pos)
 #define TWIS_SCR_ORUN_Pos           7            /**< \brief (TWIS_SCR) Overrun */
-#define TWIS_SCR_ORUN               (_U(0x1) << TWIS_SCR_ORUN_Pos)
+#define TWIS_SCR_ORUN               (_U_(0x1) << TWIS_SCR_ORUN_Pos)
 #define TWIS_SCR_NAK_Pos            8            /**< \brief (TWIS_SCR) NAK Received */
-#define TWIS_SCR_NAK                (_U(0x1) << TWIS_SCR_NAK_Pos)
+#define TWIS_SCR_NAK                (_U_(0x1) << TWIS_SCR_NAK_Pos)
 #define TWIS_SCR_SMBTOUT_Pos        12           /**< \brief (TWIS_SCR) SMBus Timeout */
-#define TWIS_SCR_SMBTOUT            (_U(0x1) << TWIS_SCR_SMBTOUT_Pos)
+#define TWIS_SCR_SMBTOUT            (_U_(0x1) << TWIS_SCR_SMBTOUT_Pos)
 #define TWIS_SCR_SMBPECERR_Pos      13           /**< \brief (TWIS_SCR) SMBus PEC Error */
-#define TWIS_SCR_SMBPECERR          (_U(0x1) << TWIS_SCR_SMBPECERR_Pos)
+#define TWIS_SCR_SMBPECERR          (_U_(0x1) << TWIS_SCR_SMBPECERR_Pos)
 #define TWIS_SCR_BUSERR_Pos         14           /**< \brief (TWIS_SCR) Bus Error */
-#define TWIS_SCR_BUSERR             (_U(0x1) << TWIS_SCR_BUSERR_Pos)
+#define TWIS_SCR_BUSERR             (_U_(0x1) << TWIS_SCR_BUSERR_Pos)
 #define TWIS_SCR_SAM_Pos            16           /**< \brief (TWIS_SCR) Slave Address Match */
-#define TWIS_SCR_SAM                (_U(0x1) << TWIS_SCR_SAM_Pos)
+#define TWIS_SCR_SAM                (_U_(0x1) << TWIS_SCR_SAM_Pos)
 #define TWIS_SCR_GCM_Pos            17           /**< \brief (TWIS_SCR) General Call Match */
-#define TWIS_SCR_GCM                (_U(0x1) << TWIS_SCR_GCM_Pos)
+#define TWIS_SCR_GCM                (_U_(0x1) << TWIS_SCR_GCM_Pos)
 #define TWIS_SCR_SMBALERTM_Pos      18           /**< \brief (TWIS_SCR) SMBus Alert Response Address Match */
-#define TWIS_SCR_SMBALERTM          (_U(0x1) << TWIS_SCR_SMBALERTM_Pos)
+#define TWIS_SCR_SMBALERTM          (_U_(0x1) << TWIS_SCR_SMBALERTM_Pos)
 #define TWIS_SCR_SMBHHM_Pos         19           /**< \brief (TWIS_SCR) SMBus Host Header Address Match */
-#define TWIS_SCR_SMBHHM             (_U(0x1) << TWIS_SCR_SMBHHM_Pos)
+#define TWIS_SCR_SMBHHM             (_U_(0x1) << TWIS_SCR_SMBHHM_Pos)
 #define TWIS_SCR_SMBDAM_Pos         20           /**< \brief (TWIS_SCR) SMBus Default Address Match */
-#define TWIS_SCR_SMBDAM             (_U(0x1) << TWIS_SCR_SMBDAM_Pos)
+#define TWIS_SCR_SMBDAM             (_U_(0x1) << TWIS_SCR_SMBDAM_Pos)
 #define TWIS_SCR_STO_Pos            21           /**< \brief (TWIS_SCR) Stop Received */
-#define TWIS_SCR_STO                (_U(0x1) << TWIS_SCR_STO_Pos)
+#define TWIS_SCR_STO                (_U_(0x1) << TWIS_SCR_STO_Pos)
 #define TWIS_SCR_REP_Pos            22           /**< \brief (TWIS_SCR) Repeated Start Received */
-#define TWIS_SCR_REP                (_U(0x1) << TWIS_SCR_REP_Pos)
+#define TWIS_SCR_REP                (_U_(0x1) << TWIS_SCR_REP_Pos)
 #define TWIS_SCR_BTF_Pos            23           /**< \brief (TWIS_SCR) Byte Transfer Finished */
-#define TWIS_SCR_BTF                (_U(0x1) << TWIS_SCR_BTF_Pos)
-#define TWIS_SCR_MASK               _U(0x00FF71C8) /**< \brief (TWIS_SCR) MASK Register */
+#define TWIS_SCR_BTF                (_U_(0x1) << TWIS_SCR_BTF_Pos)
+#define TWIS_SCR_MASK               _U_(0x00FF71C8) /**< \brief (TWIS_SCR) MASK Register */
 
 /* -------- TWIS_PR : (TWIS Offset: 0x2C) (R/  32) Parameter Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -574,11 +574,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIS_PR_OFFSET              0x2C         /**< \brief (TWIS_PR offset) Parameter Register */
-#define TWIS_PR_RESETVALUE          _U(0x00000001); /**< \brief (TWIS_PR reset_value) Parameter Register */
+#define TWIS_PR_RESETVALUE          _U_(0x00000001); /**< \brief (TWIS_PR reset_value) Parameter Register */
 
 #define TWIS_PR_HS_Pos              0            /**< \brief (TWIS_PR) HS-mode */
-#define TWIS_PR_HS                  (_U(0x1) << TWIS_PR_HS_Pos)
-#define TWIS_PR_MASK                _U(0x00000001) /**< \brief (TWIS_PR) MASK Register */
+#define TWIS_PR_HS                  (_U_(0x1) << TWIS_PR_HS_Pos)
+#define TWIS_PR_MASK                _U_(0x00000001) /**< \brief (TWIS_PR) MASK Register */
 
 /* -------- TWIS_VR : (TWIS Offset: 0x30) (R/  32) Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -594,15 +594,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIS_VR_OFFSET              0x30         /**< \brief (TWIS_VR offset) Version Register */
-#define TWIS_VR_RESETVALUE          _U(0x00000140); /**< \brief (TWIS_VR reset_value) Version Register */
+#define TWIS_VR_RESETVALUE          _U_(0x00000140); /**< \brief (TWIS_VR reset_value) Version Register */
 
 #define TWIS_VR_VERSION_Pos         0            /**< \brief (TWIS_VR) Version Number */
-#define TWIS_VR_VERSION_Msk         (_U(0xFFF) << TWIS_VR_VERSION_Pos)
+#define TWIS_VR_VERSION_Msk         (_U_(0xFFF) << TWIS_VR_VERSION_Pos)
 #define TWIS_VR_VERSION(value)      (TWIS_VR_VERSION_Msk & ((value) << TWIS_VR_VERSION_Pos))
 #define TWIS_VR_VARIANT_Pos         16           /**< \brief (TWIS_VR) Variant Number */
-#define TWIS_VR_VARIANT_Msk         (_U(0xF) << TWIS_VR_VARIANT_Pos)
+#define TWIS_VR_VARIANT_Msk         (_U_(0xF) << TWIS_VR_VARIANT_Pos)
 #define TWIS_VR_VARIANT(value)      (TWIS_VR_VARIANT_Msk & ((value) << TWIS_VR_VARIANT_Pos))
-#define TWIS_VR_MASK                _U(0x000F0FFF) /**< \brief (TWIS_VR) MASK Register */
+#define TWIS_VR_MASK                _U_(0x000F0FFF) /**< \brief (TWIS_VR) MASK Register */
 
 /* -------- TWIS_HSTR : (TWIS Offset: 0x34) (R/W 32) HS-mode Timing Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -617,12 +617,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIS_HSTR_OFFSET            0x34         /**< \brief (TWIS_HSTR offset) HS-mode Timing Register */
-#define TWIS_HSTR_RESETVALUE        _U(0x00000000); /**< \brief (TWIS_HSTR reset_value) HS-mode Timing Register */
+#define TWIS_HSTR_RESETVALUE        _U_(0x00000000); /**< \brief (TWIS_HSTR reset_value) HS-mode Timing Register */
 
 #define TWIS_HSTR_HDDAT_Pos         16           /**< \brief (TWIS_HSTR) Data Hold Cycles */
-#define TWIS_HSTR_HDDAT_Msk         (_U(0xFF) << TWIS_HSTR_HDDAT_Pos)
+#define TWIS_HSTR_HDDAT_Msk         (_U_(0xFF) << TWIS_HSTR_HDDAT_Pos)
 #define TWIS_HSTR_HDDAT(value)      (TWIS_HSTR_HDDAT_Msk & ((value) << TWIS_HSTR_HDDAT_Pos))
-#define TWIS_HSTR_MASK              _U(0x00FF0000) /**< \brief (TWIS_HSTR) MASK Register */
+#define TWIS_HSTR_MASK              _U_(0x00FF0000) /**< \brief (TWIS_HSTR) MASK Register */
 
 /* -------- TWIS_SRR : (TWIS Offset: 0x38) (R/W 32) Slew Rate Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -640,18 +640,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIS_SRR_OFFSET             0x38         /**< \brief (TWIS_SRR offset) Slew Rate Register */
-#define TWIS_SRR_RESETVALUE         _U(0x00000000); /**< \brief (TWIS_SRR reset_value) Slew Rate Register */
+#define TWIS_SRR_RESETVALUE         _U_(0x00000000); /**< \brief (TWIS_SRR reset_value) Slew Rate Register */
 
 #define TWIS_SRR_DADRIVEL_Pos       0            /**< \brief (TWIS_SRR) Data Drive Strength LOW */
-#define TWIS_SRR_DADRIVEL_Msk       (_U(0x7) << TWIS_SRR_DADRIVEL_Pos)
+#define TWIS_SRR_DADRIVEL_Msk       (_U_(0x7) << TWIS_SRR_DADRIVEL_Pos)
 #define TWIS_SRR_DADRIVEL(value)    (TWIS_SRR_DADRIVEL_Msk & ((value) << TWIS_SRR_DADRIVEL_Pos))
 #define TWIS_SRR_DASLEW_Pos         8            /**< \brief (TWIS_SRR) Data Slew Limit */
-#define TWIS_SRR_DASLEW_Msk         (_U(0x3) << TWIS_SRR_DASLEW_Pos)
+#define TWIS_SRR_DASLEW_Msk         (_U_(0x3) << TWIS_SRR_DASLEW_Pos)
 #define TWIS_SRR_DASLEW(value)      (TWIS_SRR_DASLEW_Msk & ((value) << TWIS_SRR_DASLEW_Pos))
 #define TWIS_SRR_FILTER_Pos         28           /**< \brief (TWIS_SRR) Input Spike Filter Control */
-#define TWIS_SRR_FILTER_Msk         (_U(0x3) << TWIS_SRR_FILTER_Pos)
+#define TWIS_SRR_FILTER_Msk         (_U_(0x3) << TWIS_SRR_FILTER_Pos)
 #define TWIS_SRR_FILTER(value)      (TWIS_SRR_FILTER_Msk & ((value) << TWIS_SRR_FILTER_Pos))
-#define TWIS_SRR_MASK               _U(0x30000307) /**< \brief (TWIS_SRR) MASK Register */
+#define TWIS_SRR_MASK               _U_(0x30000307) /**< \brief (TWIS_SRR) MASK Register */
 
 /* -------- TWIS_HSSRR : (TWIS Offset: 0x3C) (R/W 32) HS-mode Slew Rate Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -669,18 +669,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIS_HSSRR_OFFSET           0x3C         /**< \brief (TWIS_HSSRR offset) HS-mode Slew Rate Register */
-#define TWIS_HSSRR_RESETVALUE       _U(0x00000000); /**< \brief (TWIS_HSSRR reset_value) HS-mode Slew Rate Register */
+#define TWIS_HSSRR_RESETVALUE       _U_(0x00000000); /**< \brief (TWIS_HSSRR reset_value) HS-mode Slew Rate Register */
 
 #define TWIS_HSSRR_DADRIVEL_Pos     0            /**< \brief (TWIS_HSSRR) Data Drive Strength LOW */
-#define TWIS_HSSRR_DADRIVEL_Msk     (_U(0x7) << TWIS_HSSRR_DADRIVEL_Pos)
+#define TWIS_HSSRR_DADRIVEL_Msk     (_U_(0x7) << TWIS_HSSRR_DADRIVEL_Pos)
 #define TWIS_HSSRR_DADRIVEL(value)  (TWIS_HSSRR_DADRIVEL_Msk & ((value) << TWIS_HSSRR_DADRIVEL_Pos))
 #define TWIS_HSSRR_DASLEW_Pos       8            /**< \brief (TWIS_HSSRR) Data Slew Limit */
-#define TWIS_HSSRR_DASLEW_Msk       (_U(0x3) << TWIS_HSSRR_DASLEW_Pos)
+#define TWIS_HSSRR_DASLEW_Msk       (_U_(0x3) << TWIS_HSSRR_DASLEW_Pos)
 #define TWIS_HSSRR_DASLEW(value)    (TWIS_HSSRR_DASLEW_Msk & ((value) << TWIS_HSSRR_DASLEW_Pos))
 #define TWIS_HSSRR_FILTER_Pos       28           /**< \brief (TWIS_HSSRR) Input Spike Filter Control */
-#define TWIS_HSSRR_FILTER_Msk       (_U(0x3) << TWIS_HSSRR_FILTER_Pos)
+#define TWIS_HSSRR_FILTER_Msk       (_U_(0x3) << TWIS_HSSRR_FILTER_Pos)
 #define TWIS_HSSRR_FILTER(value)    (TWIS_HSSRR_FILTER_Msk & ((value) << TWIS_HSSRR_FILTER_Pos))
-#define TWIS_HSSRR_MASK             _U(0x30000307) /**< \brief (TWIS_HSSRR) MASK Register */
+#define TWIS_HSSRR_MASK             _U_(0x30000307) /**< \brief (TWIS_HSSRR) MASK Register */
 
 /** \brief TWIS hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/usart.h
+++ b/asf/sam/include/sam4l/component/usart.h
@@ -1,0 +1,3986 @@
+/**
+ * \file
+ *
+ * \brief Component description for USART
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_USART_COMPONENT_
+#define _SAM4L_USART_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR USART */
+/* ========================================================================== */
+/** \addtogroup SAM4L_USART Universal Synchronous Asynchronous Receiver Transmitter */
+/*@{*/
+
+#define USART_I7601
+#define REV_USART                   0x6021
+
+/* -------- US_CR : (USART Offset: 0x00) ( /W 32) Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct { // LIN mode
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t RSTRX:1;          /*!< bit:      2  Reset Receiver                     */
+    uint32_t RSTTX:1;          /*!< bit:      3  Reset Transmitter                  */
+    uint32_t RXEN:1;           /*!< bit:      4  Receiver Enable                    */
+    uint32_t RXDIS:1;          /*!< bit:      5  Receiver Disable                   */
+    uint32_t TXEN:1;           /*!< bit:      6  Transmitter Enable                 */
+    uint32_t TXDIS:1;          /*!< bit:      7  Transmitter Disable                */
+    uint32_t RSTSTA:1;         /*!< bit:      8  Reset Status Bits                  */
+    uint32_t STTBRK:1;         /*!< bit:      9  Start Break                        */
+    uint32_t STPBRK:1;         /*!< bit:     10  Stop Break                         */
+    uint32_t STTTO:1;          /*!< bit:     11  Start Time-out                     */
+    uint32_t SENDA:1;          /*!< bit:     12  Send Address                       */
+    uint32_t RSTIT:1;          /*!< bit:     13  Reset Iterations                   */
+    uint32_t RSTNACK:1;        /*!< bit:     14  Reset Non Acknowledge              */
+    uint32_t RETTO:1;          /*!< bit:     15  Rearm Time-out                     */
+    uint32_t DTREN:1;          /*!< bit:     16  Data Terminal Ready Enable         */
+    uint32_t DTRDIS:1;         /*!< bit:     17  Data Terminal Ready Disable        */
+    uint32_t RTSEN:1;          /*!< bit:     18  Request to Send Enable             */
+    uint32_t RTSDIS:1;         /*!< bit:     19  Request to Send Disable            */
+    uint32_t LINABT:1;         /*!< bit:     20  Abort the current LIN transmission */
+    uint32_t LINWKUP:1;        /*!< bit:     21  Sends a wakeup signal on the LIN bus */
+    uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+  } LIN;                       /*!< Structure used for LIN                          */
+  struct { // SPI_MASTER mode
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t RSTRX:1;          /*!< bit:      2  Reset Receiver                     */
+    uint32_t RSTTX:1;          /*!< bit:      3  Reset Transmitter                  */
+    uint32_t RXEN:1;           /*!< bit:      4  Receiver Enable                    */
+    uint32_t RXDIS:1;          /*!< bit:      5  Receiver Disable                   */
+    uint32_t TXEN:1;           /*!< bit:      6  Transmitter Enable                 */
+    uint32_t TXDIS:1;          /*!< bit:      7  Transmitter Disable                */
+    uint32_t RSTSTA:1;         /*!< bit:      8  Reset Status Bits                  */
+    uint32_t STTBRK:1;         /*!< bit:      9  Start Break                        */
+    uint32_t STPBRK:1;         /*!< bit:     10  Stop Break                         */
+    uint32_t STTTO:1;          /*!< bit:     11  Start Time-out                     */
+    uint32_t SENDA:1;          /*!< bit:     12  Send Address                       */
+    uint32_t RSTIT:1;          /*!< bit:     13  Reset Iterations                   */
+    uint32_t RSTNACK:1;        /*!< bit:     14  Reset Non Acknowledge              */
+    uint32_t RETTO:1;          /*!< bit:     15  Rearm Time-out                     */
+    uint32_t DTREN:1;          /*!< bit:     16  Data Terminal Ready Enable         */
+    uint32_t DTRDIS:1;         /*!< bit:     17  Data Terminal Ready Disable        */
+    uint32_t FCS:1;            /*!< bit:     18  Force SPI Chip Select              */
+    uint32_t RCS:1;            /*!< bit:     19  Release SPI Chip Select            */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } SPI_MASTER;                /*!< Structure used for SPI_MASTER                   */
+  struct { // USART mode
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t RSTRX:1;          /*!< bit:      2  Reset Receiver                     */
+    uint32_t RSTTX:1;          /*!< bit:      3  Reset Transmitter                  */
+    uint32_t RXEN:1;           /*!< bit:      4  Receiver Enable                    */
+    uint32_t RXDIS:1;          /*!< bit:      5  Receiver Disable                   */
+    uint32_t TXEN:1;           /*!< bit:      6  Transmitter Enable                 */
+    uint32_t TXDIS:1;          /*!< bit:      7  Transmitter Disable                */
+    uint32_t RSTSTA:1;         /*!< bit:      8  Reset Status Bits                  */
+    uint32_t STTBRK:1;         /*!< bit:      9  Start Break                        */
+    uint32_t STPBRK:1;         /*!< bit:     10  Stop Break                         */
+    uint32_t STTTO:1;          /*!< bit:     11  Start Time-out                     */
+    uint32_t SENDA:1;          /*!< bit:     12  Send Address                       */
+    uint32_t RSTIT:1;          /*!< bit:     13  Reset Iterations                   */
+    uint32_t RSTNACK:1;        /*!< bit:     14  Reset Non Acknowledge              */
+    uint32_t RETTO:1;          /*!< bit:     15  Rearm Time-out                     */
+    uint32_t DTREN:1;          /*!< bit:     16  Data Terminal Ready Enable         */
+    uint32_t DTRDIS:1;         /*!< bit:     17  Data Terminal Ready Disable        */
+    uint32_t RTSEN:1;          /*!< bit:     18  Request to Send Enable             */
+    uint32_t RTSDIS:1;         /*!< bit:     19  Request to Send Disable            */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } USART;                     /*!< Structure used for USART                        */
+  uint32_t reg;                /*!< Type      used for register access              */
+} US_CR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_CR_OFFSET                0x00         /**< \brief (US_CR offset) Control Register */
+
+// LIN mode
+#define US_CR_LIN_RSTRX_Pos         2            /**< \brief (US_CR_LIN) Reset Receiver */
+#define US_CR_LIN_RSTRX             (_U(0x1) << US_CR_LIN_RSTRX_Pos)
+#define   US_CR_LIN_RSTRX_0_Val           _U(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_RSTRX_1_Val           _U(0x1)   /**< \brief (US_CR_LIN) Resets the receiver */
+#define US_CR_LIN_RSTRX_0           (US_CR_LIN_RSTRX_0_Val         << US_CR_LIN_RSTRX_Pos)
+#define US_CR_LIN_RSTRX_1           (US_CR_LIN_RSTRX_1_Val         << US_CR_LIN_RSTRX_Pos)
+#define US_CR_LIN_RSTTX_Pos         3            /**< \brief (US_CR_LIN) Reset Transmitter */
+#define US_CR_LIN_RSTTX             (_U(0x1) << US_CR_LIN_RSTTX_Pos)
+#define   US_CR_LIN_RSTTX_0_Val           _U(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_RSTTX_1_Val           _U(0x1)   /**< \brief (US_CR_LIN) Resets the transmitter */
+#define US_CR_LIN_RSTTX_0           (US_CR_LIN_RSTTX_0_Val         << US_CR_LIN_RSTTX_Pos)
+#define US_CR_LIN_RSTTX_1           (US_CR_LIN_RSTTX_1_Val         << US_CR_LIN_RSTTX_Pos)
+#define US_CR_LIN_RXEN_Pos          4            /**< \brief (US_CR_LIN) Receiver Enable */
+#define US_CR_LIN_RXEN              (_U(0x1) << US_CR_LIN_RXEN_Pos)
+#define   US_CR_LIN_RXEN_0_Val            _U(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_RXEN_1_Val            _U(0x1)   /**< \brief (US_CR_LIN) Enables the receiver, if RXDIS is 0 */
+#define US_CR_LIN_RXEN_0            (US_CR_LIN_RXEN_0_Val          << US_CR_LIN_RXEN_Pos)
+#define US_CR_LIN_RXEN_1            (US_CR_LIN_RXEN_1_Val          << US_CR_LIN_RXEN_Pos)
+#define US_CR_LIN_RXDIS_Pos         5            /**< \brief (US_CR_LIN) Receiver Disable */
+#define US_CR_LIN_RXDIS             (_U(0x1) << US_CR_LIN_RXDIS_Pos)
+#define   US_CR_LIN_RXDIS_0_Val           _U(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_RXDIS_1_Val           _U(0x1)   /**< \brief (US_CR_LIN) Disables the receiver */
+#define US_CR_LIN_RXDIS_0           (US_CR_LIN_RXDIS_0_Val         << US_CR_LIN_RXDIS_Pos)
+#define US_CR_LIN_RXDIS_1           (US_CR_LIN_RXDIS_1_Val         << US_CR_LIN_RXDIS_Pos)
+#define US_CR_LIN_TXEN_Pos          6            /**< \brief (US_CR_LIN) Transmitter Enable */
+#define US_CR_LIN_TXEN              (_U(0x1) << US_CR_LIN_TXEN_Pos)
+#define   US_CR_LIN_TXEN_0_Val            _U(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_TXEN_1_Val            _U(0x1)   /**< \brief (US_CR_LIN) Enables the transmitter if TXDIS is 0 */
+#define US_CR_LIN_TXEN_0            (US_CR_LIN_TXEN_0_Val          << US_CR_LIN_TXEN_Pos)
+#define US_CR_LIN_TXEN_1            (US_CR_LIN_TXEN_1_Val          << US_CR_LIN_TXEN_Pos)
+#define US_CR_LIN_TXDIS_Pos         7            /**< \brief (US_CR_LIN) Transmitter Disable */
+#define US_CR_LIN_TXDIS             (_U(0x1) << US_CR_LIN_TXDIS_Pos)
+#define   US_CR_LIN_TXDIS_0_Val           _U(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_TXDIS_1_Val           _U(0x1)   /**< \brief (US_CR_LIN) Disables the transmitter */
+#define US_CR_LIN_TXDIS_0           (US_CR_LIN_TXDIS_0_Val         << US_CR_LIN_TXDIS_Pos)
+#define US_CR_LIN_TXDIS_1           (US_CR_LIN_TXDIS_1_Val         << US_CR_LIN_TXDIS_Pos)
+#define US_CR_LIN_RSTSTA_Pos        8            /**< \brief (US_CR_LIN) Reset Status Bits */
+#define US_CR_LIN_RSTSTA            (_U(0x1) << US_CR_LIN_RSTSTA_Pos)
+#define   US_CR_LIN_RSTSTA_0_Val          _U(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_RSTSTA_1_Val          _U(0x1)   /**< \brief (US_CR_LIN) Resets the status bits PARE, FRAME, OVRE and RXBRK in the CSR */
+#define US_CR_LIN_RSTSTA_0          (US_CR_LIN_RSTSTA_0_Val        << US_CR_LIN_RSTSTA_Pos)
+#define US_CR_LIN_RSTSTA_1          (US_CR_LIN_RSTSTA_1_Val        << US_CR_LIN_RSTSTA_Pos)
+#define US_CR_LIN_STTBRK_Pos        9            /**< \brief (US_CR_LIN) Start Break */
+#define US_CR_LIN_STTBRK            (_U(0x1) << US_CR_LIN_STTBRK_Pos)
+#define   US_CR_LIN_STTBRK_0_Val          _U(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_STTBRK_1_Val          _U(0x1)   /**< \brief (US_CR_LIN) Starts transmission of a break after the characters present in THR and the Transmit Shift Register have been transmitted. No effect if a break is already being transmitted */
+#define US_CR_LIN_STTBRK_0          (US_CR_LIN_STTBRK_0_Val        << US_CR_LIN_STTBRK_Pos)
+#define US_CR_LIN_STTBRK_1          (US_CR_LIN_STTBRK_1_Val        << US_CR_LIN_STTBRK_Pos)
+#define US_CR_LIN_STPBRK_Pos        10           /**< \brief (US_CR_LIN) Stop Break */
+#define US_CR_LIN_STPBRK            (_U(0x1) << US_CR_LIN_STPBRK_Pos)
+#define   US_CR_LIN_STPBRK_0_Val          _U(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_STPBRK_1_Val          _U(0x1)   /**< \brief (US_CR_LIN) Stops transmission of the break after a minimum of one character length and transmits a high level during 12-bit periods.No effect if no break is being transmitted */
+#define US_CR_LIN_STPBRK_0          (US_CR_LIN_STPBRK_0_Val        << US_CR_LIN_STPBRK_Pos)
+#define US_CR_LIN_STPBRK_1          (US_CR_LIN_STPBRK_1_Val        << US_CR_LIN_STPBRK_Pos)
+#define US_CR_LIN_STTTO_Pos         11           /**< \brief (US_CR_LIN) Start Time-out */
+#define US_CR_LIN_STTTO             (_U(0x1) << US_CR_LIN_STTTO_Pos)
+#define   US_CR_LIN_STTTO_0_Val           _U(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_STTTO_1_Val           _U(0x1)   /**< \brief (US_CR_LIN) Starts waiting for a character before clocking the time-out counter */
+#define US_CR_LIN_STTTO_0           (US_CR_LIN_STTTO_0_Val         << US_CR_LIN_STTTO_Pos)
+#define US_CR_LIN_STTTO_1           (US_CR_LIN_STTTO_1_Val         << US_CR_LIN_STTTO_Pos)
+#define US_CR_LIN_SENDA_Pos         12           /**< \brief (US_CR_LIN) Send Address */
+#define US_CR_LIN_SENDA             (_U(0x1) << US_CR_LIN_SENDA_Pos)
+#define   US_CR_LIN_SENDA_0_Val           _U(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_SENDA_1_Val           _U(0x1)   /**< \brief (US_CR_LIN) In Multi-drop Mode only, the next character written to the THR is sent with the address bit set */
+#define US_CR_LIN_SENDA_0           (US_CR_LIN_SENDA_0_Val         << US_CR_LIN_SENDA_Pos)
+#define US_CR_LIN_SENDA_1           (US_CR_LIN_SENDA_1_Val         << US_CR_LIN_SENDA_Pos)
+#define US_CR_LIN_RSTIT_Pos         13           /**< \brief (US_CR_LIN) Reset Iterations */
+#define US_CR_LIN_RSTIT             (_U(0x1) << US_CR_LIN_RSTIT_Pos)
+#define   US_CR_LIN_RSTIT_0_Val           _U(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_RSTIT_1_Val           _U(0x1)   /**< \brief (US_CR_LIN) Resets ITERATION in CSR. No effect if the ISO7816 is not enabled */
+#define US_CR_LIN_RSTIT_0           (US_CR_LIN_RSTIT_0_Val         << US_CR_LIN_RSTIT_Pos)
+#define US_CR_LIN_RSTIT_1           (US_CR_LIN_RSTIT_1_Val         << US_CR_LIN_RSTIT_Pos)
+#define US_CR_LIN_RSTNACK_Pos       14           /**< \brief (US_CR_LIN) Reset Non Acknowledge */
+#define US_CR_LIN_RSTNACK           (_U(0x1) << US_CR_LIN_RSTNACK_Pos)
+#define   US_CR_LIN_RSTNACK_0_Val         _U(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_RSTNACK_1_Val         _U(0x1)   /**< \brief (US_CR_LIN) Resets NACK in CSR */
+#define US_CR_LIN_RSTNACK_0         (US_CR_LIN_RSTNACK_0_Val       << US_CR_LIN_RSTNACK_Pos)
+#define US_CR_LIN_RSTNACK_1         (US_CR_LIN_RSTNACK_1_Val       << US_CR_LIN_RSTNACK_Pos)
+#define US_CR_LIN_RETTO_Pos         15           /**< \brief (US_CR_LIN) Rearm Time-out */
+#define US_CR_LIN_RETTO             (_U(0x1) << US_CR_LIN_RETTO_Pos)
+#define   US_CR_LIN_RETTO_0_Val           _U(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_RETTO_1_Val           _U(0x1)   /**< \brief (US_CR_LIN) Restart Time-out */
+#define US_CR_LIN_RETTO_0           (US_CR_LIN_RETTO_0_Val         << US_CR_LIN_RETTO_Pos)
+#define US_CR_LIN_RETTO_1           (US_CR_LIN_RETTO_1_Val         << US_CR_LIN_RETTO_Pos)
+#define US_CR_LIN_DTREN_Pos         16           /**< \brief (US_CR_LIN) Data Terminal Ready Enable */
+#define US_CR_LIN_DTREN             (_U(0x1) << US_CR_LIN_DTREN_Pos)
+#define   US_CR_LIN_DTREN_0_Val           _U(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_DTREN_1_Val           _U(0x1)   /**< \brief (US_CR_LIN) Drives the pin DTR at 0 */
+#define US_CR_LIN_DTREN_0           (US_CR_LIN_DTREN_0_Val         << US_CR_LIN_DTREN_Pos)
+#define US_CR_LIN_DTREN_1           (US_CR_LIN_DTREN_1_Val         << US_CR_LIN_DTREN_Pos)
+#define US_CR_LIN_DTRDIS_Pos        17           /**< \brief (US_CR_LIN) Data Terminal Ready Disable */
+#define US_CR_LIN_DTRDIS            (_U(0x1) << US_CR_LIN_DTRDIS_Pos)
+#define   US_CR_LIN_DTRDIS_0_Val          _U(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_DTRDIS_1_Val          _U(0x1)   /**< \brief (US_CR_LIN) Drives the pin DTR to 1 */
+#define US_CR_LIN_DTRDIS_0          (US_CR_LIN_DTRDIS_0_Val        << US_CR_LIN_DTRDIS_Pos)
+#define US_CR_LIN_DTRDIS_1          (US_CR_LIN_DTRDIS_1_Val        << US_CR_LIN_DTRDIS_Pos)
+#define US_CR_LIN_RTSEN_Pos         18           /**< \brief (US_CR_LIN) Request to Send Enable */
+#define US_CR_LIN_RTSEN             (_U(0x1) << US_CR_LIN_RTSEN_Pos)
+#define   US_CR_LIN_RTSEN_0_Val           _U(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_RTSEN_1_Val           _U(0x1)   /**< \brief (US_CR_LIN) Drives the pin RTS to 0 */
+#define US_CR_LIN_RTSEN_0           (US_CR_LIN_RTSEN_0_Val         << US_CR_LIN_RTSEN_Pos)
+#define US_CR_LIN_RTSEN_1           (US_CR_LIN_RTSEN_1_Val         << US_CR_LIN_RTSEN_Pos)
+#define US_CR_LIN_RTSDIS_Pos        19           /**< \brief (US_CR_LIN) Request to Send Disable */
+#define US_CR_LIN_RTSDIS            (_U(0x1) << US_CR_LIN_RTSDIS_Pos)
+#define   US_CR_LIN_RTSDIS_0_Val          _U(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_RTSDIS_1_Val          _U(0x1)   /**< \brief (US_CR_LIN) Drives the pin RTS to 1 */
+#define US_CR_LIN_RTSDIS_0          (US_CR_LIN_RTSDIS_0_Val        << US_CR_LIN_RTSDIS_Pos)
+#define US_CR_LIN_RTSDIS_1          (US_CR_LIN_RTSDIS_1_Val        << US_CR_LIN_RTSDIS_Pos)
+#define US_CR_LIN_LINABT_Pos        20           /**< \brief (US_CR_LIN) Abort the current LIN transmission */
+#define US_CR_LIN_LINABT            (_U(0x1) << US_CR_LIN_LINABT_Pos)
+#define US_CR_LIN_LINWKUP_Pos       21           /**< \brief (US_CR_LIN) Sends a wakeup signal on the LIN bus */
+#define US_CR_LIN_LINWKUP           (_U(0x1) << US_CR_LIN_LINWKUP_Pos)
+#define US_CR_LIN_MASK              _U(0x003FFFFC) /**< \brief (US_CR_LIN) MASK Register */
+
+// SPI_MASTER mode
+#define US_CR_SPI_MASTER_RSTRX_Pos  2            /**< \brief (US_CR_SPI_MASTER) Reset Receiver */
+#define US_CR_SPI_MASTER_RSTRX      (_U(0x1) << US_CR_SPI_MASTER_RSTRX_Pos)
+#define   US_CR_SPI_MASTER_RSTRX_0_Val    _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_RSTRX_1_Val    _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Resets the receiver */
+#define US_CR_SPI_MASTER_RSTRX_0    (US_CR_SPI_MASTER_RSTRX_0_Val  << US_CR_SPI_MASTER_RSTRX_Pos)
+#define US_CR_SPI_MASTER_RSTRX_1    (US_CR_SPI_MASTER_RSTRX_1_Val  << US_CR_SPI_MASTER_RSTRX_Pos)
+#define US_CR_SPI_MASTER_RSTTX_Pos  3            /**< \brief (US_CR_SPI_MASTER) Reset Transmitter */
+#define US_CR_SPI_MASTER_RSTTX      (_U(0x1) << US_CR_SPI_MASTER_RSTTX_Pos)
+#define   US_CR_SPI_MASTER_RSTTX_0_Val    _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_RSTTX_1_Val    _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Resets the transmitter */
+#define US_CR_SPI_MASTER_RSTTX_0    (US_CR_SPI_MASTER_RSTTX_0_Val  << US_CR_SPI_MASTER_RSTTX_Pos)
+#define US_CR_SPI_MASTER_RSTTX_1    (US_CR_SPI_MASTER_RSTTX_1_Val  << US_CR_SPI_MASTER_RSTTX_Pos)
+#define US_CR_SPI_MASTER_RXEN_Pos   4            /**< \brief (US_CR_SPI_MASTER) Receiver Enable */
+#define US_CR_SPI_MASTER_RXEN       (_U(0x1) << US_CR_SPI_MASTER_RXEN_Pos)
+#define   US_CR_SPI_MASTER_RXEN_0_Val     _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_RXEN_1_Val     _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Enables the receiver, if RXDIS is 0 */
+#define US_CR_SPI_MASTER_RXEN_0     (US_CR_SPI_MASTER_RXEN_0_Val   << US_CR_SPI_MASTER_RXEN_Pos)
+#define US_CR_SPI_MASTER_RXEN_1     (US_CR_SPI_MASTER_RXEN_1_Val   << US_CR_SPI_MASTER_RXEN_Pos)
+#define US_CR_SPI_MASTER_RXDIS_Pos  5            /**< \brief (US_CR_SPI_MASTER) Receiver Disable */
+#define US_CR_SPI_MASTER_RXDIS      (_U(0x1) << US_CR_SPI_MASTER_RXDIS_Pos)
+#define   US_CR_SPI_MASTER_RXDIS_0_Val    _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_RXDIS_1_Val    _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Disables the receiver */
+#define US_CR_SPI_MASTER_RXDIS_0    (US_CR_SPI_MASTER_RXDIS_0_Val  << US_CR_SPI_MASTER_RXDIS_Pos)
+#define US_CR_SPI_MASTER_RXDIS_1    (US_CR_SPI_MASTER_RXDIS_1_Val  << US_CR_SPI_MASTER_RXDIS_Pos)
+#define US_CR_SPI_MASTER_TXEN_Pos   6            /**< \brief (US_CR_SPI_MASTER) Transmitter Enable */
+#define US_CR_SPI_MASTER_TXEN       (_U(0x1) << US_CR_SPI_MASTER_TXEN_Pos)
+#define   US_CR_SPI_MASTER_TXEN_0_Val     _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_TXEN_1_Val     _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Enables the transmitter if TXDIS is 0 */
+#define US_CR_SPI_MASTER_TXEN_0     (US_CR_SPI_MASTER_TXEN_0_Val   << US_CR_SPI_MASTER_TXEN_Pos)
+#define US_CR_SPI_MASTER_TXEN_1     (US_CR_SPI_MASTER_TXEN_1_Val   << US_CR_SPI_MASTER_TXEN_Pos)
+#define US_CR_SPI_MASTER_TXDIS_Pos  7            /**< \brief (US_CR_SPI_MASTER) Transmitter Disable */
+#define US_CR_SPI_MASTER_TXDIS      (_U(0x1) << US_CR_SPI_MASTER_TXDIS_Pos)
+#define   US_CR_SPI_MASTER_TXDIS_0_Val    _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_TXDIS_1_Val    _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Disables the transmitter */
+#define US_CR_SPI_MASTER_TXDIS_0    (US_CR_SPI_MASTER_TXDIS_0_Val  << US_CR_SPI_MASTER_TXDIS_Pos)
+#define US_CR_SPI_MASTER_TXDIS_1    (US_CR_SPI_MASTER_TXDIS_1_Val  << US_CR_SPI_MASTER_TXDIS_Pos)
+#define US_CR_SPI_MASTER_RSTSTA_Pos 8            /**< \brief (US_CR_SPI_MASTER) Reset Status Bits */
+#define US_CR_SPI_MASTER_RSTSTA     (_U(0x1) << US_CR_SPI_MASTER_RSTSTA_Pos)
+#define   US_CR_SPI_MASTER_RSTSTA_0_Val   _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_RSTSTA_1_Val   _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Resets the status bits PARE, FRAME, OVRE and RXBRK in the CSR */
+#define US_CR_SPI_MASTER_RSTSTA_0   (US_CR_SPI_MASTER_RSTSTA_0_Val << US_CR_SPI_MASTER_RSTSTA_Pos)
+#define US_CR_SPI_MASTER_RSTSTA_1   (US_CR_SPI_MASTER_RSTSTA_1_Val << US_CR_SPI_MASTER_RSTSTA_Pos)
+#define US_CR_SPI_MASTER_STTBRK_Pos 9            /**< \brief (US_CR_SPI_MASTER) Start Break */
+#define US_CR_SPI_MASTER_STTBRK     (_U(0x1) << US_CR_SPI_MASTER_STTBRK_Pos)
+#define   US_CR_SPI_MASTER_STTBRK_0_Val   _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_STTBRK_1_Val   _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Starts transmission of a break after the characters present in THR and the Transmit Shift Register have been transmitted. No effect if a break is already being transmitted */
+#define US_CR_SPI_MASTER_STTBRK_0   (US_CR_SPI_MASTER_STTBRK_0_Val << US_CR_SPI_MASTER_STTBRK_Pos)
+#define US_CR_SPI_MASTER_STTBRK_1   (US_CR_SPI_MASTER_STTBRK_1_Val << US_CR_SPI_MASTER_STTBRK_Pos)
+#define US_CR_SPI_MASTER_STPBRK_Pos 10           /**< \brief (US_CR_SPI_MASTER) Stop Break */
+#define US_CR_SPI_MASTER_STPBRK     (_U(0x1) << US_CR_SPI_MASTER_STPBRK_Pos)
+#define   US_CR_SPI_MASTER_STPBRK_0_Val   _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_STPBRK_1_Val   _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Stops transmission of the break after a minimum of one character length and transmits a high level during 12-bit periods.No effect if no break is being transmitted */
+#define US_CR_SPI_MASTER_STPBRK_0   (US_CR_SPI_MASTER_STPBRK_0_Val << US_CR_SPI_MASTER_STPBRK_Pos)
+#define US_CR_SPI_MASTER_STPBRK_1   (US_CR_SPI_MASTER_STPBRK_1_Val << US_CR_SPI_MASTER_STPBRK_Pos)
+#define US_CR_SPI_MASTER_STTTO_Pos  11           /**< \brief (US_CR_SPI_MASTER) Start Time-out */
+#define US_CR_SPI_MASTER_STTTO      (_U(0x1) << US_CR_SPI_MASTER_STTTO_Pos)
+#define   US_CR_SPI_MASTER_STTTO_0_Val    _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_STTTO_1_Val    _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Starts waiting for a character before clocking the time-out counter */
+#define US_CR_SPI_MASTER_STTTO_0    (US_CR_SPI_MASTER_STTTO_0_Val  << US_CR_SPI_MASTER_STTTO_Pos)
+#define US_CR_SPI_MASTER_STTTO_1    (US_CR_SPI_MASTER_STTTO_1_Val  << US_CR_SPI_MASTER_STTTO_Pos)
+#define US_CR_SPI_MASTER_SENDA_Pos  12           /**< \brief (US_CR_SPI_MASTER) Send Address */
+#define US_CR_SPI_MASTER_SENDA      (_U(0x1) << US_CR_SPI_MASTER_SENDA_Pos)
+#define   US_CR_SPI_MASTER_SENDA_0_Val    _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_SENDA_1_Val    _U(0x1)   /**< \brief (US_CR_SPI_MASTER) In Multi-drop Mode only, the next character written to the THR is sent with the address bit set */
+#define US_CR_SPI_MASTER_SENDA_0    (US_CR_SPI_MASTER_SENDA_0_Val  << US_CR_SPI_MASTER_SENDA_Pos)
+#define US_CR_SPI_MASTER_SENDA_1    (US_CR_SPI_MASTER_SENDA_1_Val  << US_CR_SPI_MASTER_SENDA_Pos)
+#define US_CR_SPI_MASTER_RSTIT_Pos  13           /**< \brief (US_CR_SPI_MASTER) Reset Iterations */
+#define US_CR_SPI_MASTER_RSTIT      (_U(0x1) << US_CR_SPI_MASTER_RSTIT_Pos)
+#define   US_CR_SPI_MASTER_RSTIT_0_Val    _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_RSTIT_1_Val    _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Resets ITERATION in CSR. No effect if the ISO7816 is not enabled */
+#define US_CR_SPI_MASTER_RSTIT_0    (US_CR_SPI_MASTER_RSTIT_0_Val  << US_CR_SPI_MASTER_RSTIT_Pos)
+#define US_CR_SPI_MASTER_RSTIT_1    (US_CR_SPI_MASTER_RSTIT_1_Val  << US_CR_SPI_MASTER_RSTIT_Pos)
+#define US_CR_SPI_MASTER_RSTNACK_Pos 14           /**< \brief (US_CR_SPI_MASTER) Reset Non Acknowledge */
+#define US_CR_SPI_MASTER_RSTNACK    (_U(0x1) << US_CR_SPI_MASTER_RSTNACK_Pos)
+#define   US_CR_SPI_MASTER_RSTNACK_0_Val  _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_RSTNACK_1_Val  _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Resets NACK in CSR */
+#define US_CR_SPI_MASTER_RSTNACK_0  (US_CR_SPI_MASTER_RSTNACK_0_Val << US_CR_SPI_MASTER_RSTNACK_Pos)
+#define US_CR_SPI_MASTER_RSTNACK_1  (US_CR_SPI_MASTER_RSTNACK_1_Val << US_CR_SPI_MASTER_RSTNACK_Pos)
+#define US_CR_SPI_MASTER_RETTO_Pos  15           /**< \brief (US_CR_SPI_MASTER) Rearm Time-out */
+#define US_CR_SPI_MASTER_RETTO      (_U(0x1) << US_CR_SPI_MASTER_RETTO_Pos)
+#define   US_CR_SPI_MASTER_RETTO_0_Val    _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_RETTO_1_Val    _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Restart Time-out */
+#define US_CR_SPI_MASTER_RETTO_0    (US_CR_SPI_MASTER_RETTO_0_Val  << US_CR_SPI_MASTER_RETTO_Pos)
+#define US_CR_SPI_MASTER_RETTO_1    (US_CR_SPI_MASTER_RETTO_1_Val  << US_CR_SPI_MASTER_RETTO_Pos)
+#define US_CR_SPI_MASTER_DTREN_Pos  16           /**< \brief (US_CR_SPI_MASTER) Data Terminal Ready Enable */
+#define US_CR_SPI_MASTER_DTREN      (_U(0x1) << US_CR_SPI_MASTER_DTREN_Pos)
+#define   US_CR_SPI_MASTER_DTREN_0_Val    _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_DTREN_1_Val    _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Drives the pin DTR at 0 */
+#define US_CR_SPI_MASTER_DTREN_0    (US_CR_SPI_MASTER_DTREN_0_Val  << US_CR_SPI_MASTER_DTREN_Pos)
+#define US_CR_SPI_MASTER_DTREN_1    (US_CR_SPI_MASTER_DTREN_1_Val  << US_CR_SPI_MASTER_DTREN_Pos)
+#define US_CR_SPI_MASTER_DTRDIS_Pos 17           /**< \brief (US_CR_SPI_MASTER) Data Terminal Ready Disable */
+#define US_CR_SPI_MASTER_DTRDIS     (_U(0x1) << US_CR_SPI_MASTER_DTRDIS_Pos)
+#define   US_CR_SPI_MASTER_DTRDIS_0_Val   _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_DTRDIS_1_Val   _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Drives the pin DTR to 1 */
+#define US_CR_SPI_MASTER_DTRDIS_0   (US_CR_SPI_MASTER_DTRDIS_0_Val << US_CR_SPI_MASTER_DTRDIS_Pos)
+#define US_CR_SPI_MASTER_DTRDIS_1   (US_CR_SPI_MASTER_DTRDIS_1_Val << US_CR_SPI_MASTER_DTRDIS_Pos)
+#define US_CR_SPI_MASTER_FCS_Pos    18           /**< \brief (US_CR_SPI_MASTER) Force SPI Chip Select */
+#define US_CR_SPI_MASTER_FCS        (_U(0x1) << US_CR_SPI_MASTER_FCS_Pos)
+#define   US_CR_SPI_MASTER_FCS_0_Val      _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_FCS_1_Val      _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Forces the Slave Select Line NSS (RTS pin) to 0, even if USART is no transmitting, in order to address SPI slave devices supporting the CSAAT Mode (Chip Select Active After Transfer) */
+#define US_CR_SPI_MASTER_FCS_0      (US_CR_SPI_MASTER_FCS_0_Val    << US_CR_SPI_MASTER_FCS_Pos)
+#define US_CR_SPI_MASTER_FCS_1      (US_CR_SPI_MASTER_FCS_1_Val    << US_CR_SPI_MASTER_FCS_Pos)
+#define US_CR_SPI_MASTER_RCS_Pos    19           /**< \brief (US_CR_SPI_MASTER) Release SPI Chip Select */
+#define US_CR_SPI_MASTER_RCS        (_U(0x1) << US_CR_SPI_MASTER_RCS_Pos)
+#define   US_CR_SPI_MASTER_RCS_0_Val      _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_RCS_1_Val      _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Releases the Slave Select Line NSS (RTS pin) */
+#define US_CR_SPI_MASTER_RCS_0      (US_CR_SPI_MASTER_RCS_0_Val    << US_CR_SPI_MASTER_RCS_Pos)
+#define US_CR_SPI_MASTER_RCS_1      (US_CR_SPI_MASTER_RCS_1_Val    << US_CR_SPI_MASTER_RCS_Pos)
+#define US_CR_SPI_MASTER_MASK       _U(0x000FFFFC) /**< \brief (US_CR_SPI_MASTER) MASK Register */
+
+// USART mode
+#define US_CR_USART_RSTRX_Pos       2            /**< \brief (US_CR_USART) Reset Receiver */
+#define US_CR_USART_RSTRX           (_U(0x1) << US_CR_USART_RSTRX_Pos)
+#define   US_CR_USART_RSTRX_0_Val         _U(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_RSTRX_1_Val         _U(0x1)   /**< \brief (US_CR_USART) Resets the receiver */
+#define US_CR_USART_RSTRX_0         (US_CR_USART_RSTRX_0_Val       << US_CR_USART_RSTRX_Pos)
+#define US_CR_USART_RSTRX_1         (US_CR_USART_RSTRX_1_Val       << US_CR_USART_RSTRX_Pos)
+#define US_CR_USART_RSTTX_Pos       3            /**< \brief (US_CR_USART) Reset Transmitter */
+#define US_CR_USART_RSTTX           (_U(0x1) << US_CR_USART_RSTTX_Pos)
+#define   US_CR_USART_RSTTX_0_Val         _U(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_RSTTX_1_Val         _U(0x1)   /**< \brief (US_CR_USART) Resets the transmitter */
+#define US_CR_USART_RSTTX_0         (US_CR_USART_RSTTX_0_Val       << US_CR_USART_RSTTX_Pos)
+#define US_CR_USART_RSTTX_1         (US_CR_USART_RSTTX_1_Val       << US_CR_USART_RSTTX_Pos)
+#define US_CR_USART_RXEN_Pos        4            /**< \brief (US_CR_USART) Receiver Enable */
+#define US_CR_USART_RXEN            (_U(0x1) << US_CR_USART_RXEN_Pos)
+#define   US_CR_USART_RXEN_0_Val          _U(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_RXEN_1_Val          _U(0x1)   /**< \brief (US_CR_USART) Enables the receiver, if RXDIS is 0 */
+#define US_CR_USART_RXEN_0          (US_CR_USART_RXEN_0_Val        << US_CR_USART_RXEN_Pos)
+#define US_CR_USART_RXEN_1          (US_CR_USART_RXEN_1_Val        << US_CR_USART_RXEN_Pos)
+#define US_CR_USART_RXDIS_Pos       5            /**< \brief (US_CR_USART) Receiver Disable */
+#define US_CR_USART_RXDIS           (_U(0x1) << US_CR_USART_RXDIS_Pos)
+#define   US_CR_USART_RXDIS_0_Val         _U(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_RXDIS_1_Val         _U(0x1)   /**< \brief (US_CR_USART) Disables the receiver */
+#define US_CR_USART_RXDIS_0         (US_CR_USART_RXDIS_0_Val       << US_CR_USART_RXDIS_Pos)
+#define US_CR_USART_RXDIS_1         (US_CR_USART_RXDIS_1_Val       << US_CR_USART_RXDIS_Pos)
+#define US_CR_USART_TXEN_Pos        6            /**< \brief (US_CR_USART) Transmitter Enable */
+#define US_CR_USART_TXEN            (_U(0x1) << US_CR_USART_TXEN_Pos)
+#define   US_CR_USART_TXEN_0_Val          _U(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_TXEN_1_Val          _U(0x1)   /**< \brief (US_CR_USART) Enables the transmitter if TXDIS is 0 */
+#define US_CR_USART_TXEN_0          (US_CR_USART_TXEN_0_Val        << US_CR_USART_TXEN_Pos)
+#define US_CR_USART_TXEN_1          (US_CR_USART_TXEN_1_Val        << US_CR_USART_TXEN_Pos)
+#define US_CR_USART_TXDIS_Pos       7            /**< \brief (US_CR_USART) Transmitter Disable */
+#define US_CR_USART_TXDIS           (_U(0x1) << US_CR_USART_TXDIS_Pos)
+#define   US_CR_USART_TXDIS_0_Val         _U(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_TXDIS_1_Val         _U(0x1)   /**< \brief (US_CR_USART) Disables the transmitter */
+#define US_CR_USART_TXDIS_0         (US_CR_USART_TXDIS_0_Val       << US_CR_USART_TXDIS_Pos)
+#define US_CR_USART_TXDIS_1         (US_CR_USART_TXDIS_1_Val       << US_CR_USART_TXDIS_Pos)
+#define US_CR_USART_RSTSTA_Pos      8            /**< \brief (US_CR_USART) Reset Status Bits */
+#define US_CR_USART_RSTSTA          (_U(0x1) << US_CR_USART_RSTSTA_Pos)
+#define   US_CR_USART_RSTSTA_0_Val        _U(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_RSTSTA_1_Val        _U(0x1)   /**< \brief (US_CR_USART) Resets the status bits PARE, FRAME, OVRE and RXBRK in the CSR */
+#define US_CR_USART_RSTSTA_0        (US_CR_USART_RSTSTA_0_Val      << US_CR_USART_RSTSTA_Pos)
+#define US_CR_USART_RSTSTA_1        (US_CR_USART_RSTSTA_1_Val      << US_CR_USART_RSTSTA_Pos)
+#define US_CR_USART_STTBRK_Pos      9            /**< \brief (US_CR_USART) Start Break */
+#define US_CR_USART_STTBRK          (_U(0x1) << US_CR_USART_STTBRK_Pos)
+#define   US_CR_USART_STTBRK_0_Val        _U(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_STTBRK_1_Val        _U(0x1)   /**< \brief (US_CR_USART) Starts transmission of a break after the characters present in THR and the Transmit Shift Register have been transmitted. No effect if a break is already being transmitted */
+#define US_CR_USART_STTBRK_0        (US_CR_USART_STTBRK_0_Val      << US_CR_USART_STTBRK_Pos)
+#define US_CR_USART_STTBRK_1        (US_CR_USART_STTBRK_1_Val      << US_CR_USART_STTBRK_Pos)
+#define US_CR_USART_STPBRK_Pos      10           /**< \brief (US_CR_USART) Stop Break */
+#define US_CR_USART_STPBRK          (_U(0x1) << US_CR_USART_STPBRK_Pos)
+#define   US_CR_USART_STPBRK_0_Val        _U(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_STPBRK_1_Val        _U(0x1)   /**< \brief (US_CR_USART) Stops transmission of the break after a minimum of one character length and transmits a high level during 12-bit periods.No effect if no break is being transmitted */
+#define US_CR_USART_STPBRK_0        (US_CR_USART_STPBRK_0_Val      << US_CR_USART_STPBRK_Pos)
+#define US_CR_USART_STPBRK_1        (US_CR_USART_STPBRK_1_Val      << US_CR_USART_STPBRK_Pos)
+#define US_CR_USART_STTTO_Pos       11           /**< \brief (US_CR_USART) Start Time-out */
+#define US_CR_USART_STTTO           (_U(0x1) << US_CR_USART_STTTO_Pos)
+#define   US_CR_USART_STTTO_0_Val         _U(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_STTTO_1_Val         _U(0x1)   /**< \brief (US_CR_USART) Starts waiting for a character before clocking the time-out counter */
+#define US_CR_USART_STTTO_0         (US_CR_USART_STTTO_0_Val       << US_CR_USART_STTTO_Pos)
+#define US_CR_USART_STTTO_1         (US_CR_USART_STTTO_1_Val       << US_CR_USART_STTTO_Pos)
+#define US_CR_USART_SENDA_Pos       12           /**< \brief (US_CR_USART) Send Address */
+#define US_CR_USART_SENDA           (_U(0x1) << US_CR_USART_SENDA_Pos)
+#define   US_CR_USART_SENDA_0_Val         _U(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_SENDA_1_Val         _U(0x1)   /**< \brief (US_CR_USART) In Multi-drop Mode only, the next character written to the THR is sent with the address bit set */
+#define US_CR_USART_SENDA_0         (US_CR_USART_SENDA_0_Val       << US_CR_USART_SENDA_Pos)
+#define US_CR_USART_SENDA_1         (US_CR_USART_SENDA_1_Val       << US_CR_USART_SENDA_Pos)
+#define US_CR_USART_RSTIT_Pos       13           /**< \brief (US_CR_USART) Reset Iterations */
+#define US_CR_USART_RSTIT           (_U(0x1) << US_CR_USART_RSTIT_Pos)
+#define   US_CR_USART_RSTIT_0_Val         _U(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_RSTIT_1_Val         _U(0x1)   /**< \brief (US_CR_USART) Resets ITERATION in CSR. No effect if the ISO7816 is not enabled */
+#define US_CR_USART_RSTIT_0         (US_CR_USART_RSTIT_0_Val       << US_CR_USART_RSTIT_Pos)
+#define US_CR_USART_RSTIT_1         (US_CR_USART_RSTIT_1_Val       << US_CR_USART_RSTIT_Pos)
+#define US_CR_USART_RSTNACK_Pos     14           /**< \brief (US_CR_USART) Reset Non Acknowledge */
+#define US_CR_USART_RSTNACK         (_U(0x1) << US_CR_USART_RSTNACK_Pos)
+#define   US_CR_USART_RSTNACK_0_Val       _U(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_RSTNACK_1_Val       _U(0x1)   /**< \brief (US_CR_USART) Resets NACK in CSR */
+#define US_CR_USART_RSTNACK_0       (US_CR_USART_RSTNACK_0_Val     << US_CR_USART_RSTNACK_Pos)
+#define US_CR_USART_RSTNACK_1       (US_CR_USART_RSTNACK_1_Val     << US_CR_USART_RSTNACK_Pos)
+#define US_CR_USART_RETTO_Pos       15           /**< \brief (US_CR_USART) Rearm Time-out */
+#define US_CR_USART_RETTO           (_U(0x1) << US_CR_USART_RETTO_Pos)
+#define   US_CR_USART_RETTO_0_Val         _U(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_RETTO_1_Val         _U(0x1)   /**< \brief (US_CR_USART) Restart Time-out */
+#define US_CR_USART_RETTO_0         (US_CR_USART_RETTO_0_Val       << US_CR_USART_RETTO_Pos)
+#define US_CR_USART_RETTO_1         (US_CR_USART_RETTO_1_Val       << US_CR_USART_RETTO_Pos)
+#define US_CR_USART_DTREN_Pos       16           /**< \brief (US_CR_USART) Data Terminal Ready Enable */
+#define US_CR_USART_DTREN           (_U(0x1) << US_CR_USART_DTREN_Pos)
+#define   US_CR_USART_DTREN_0_Val         _U(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_DTREN_1_Val         _U(0x1)   /**< \brief (US_CR_USART) Drives the pin DTR at 0 */
+#define US_CR_USART_DTREN_0         (US_CR_USART_DTREN_0_Val       << US_CR_USART_DTREN_Pos)
+#define US_CR_USART_DTREN_1         (US_CR_USART_DTREN_1_Val       << US_CR_USART_DTREN_Pos)
+#define US_CR_USART_DTRDIS_Pos      17           /**< \brief (US_CR_USART) Data Terminal Ready Disable */
+#define US_CR_USART_DTRDIS          (_U(0x1) << US_CR_USART_DTRDIS_Pos)
+#define   US_CR_USART_DTRDIS_0_Val        _U(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_DTRDIS_1_Val        _U(0x1)   /**< \brief (US_CR_USART) Drives the pin DTR to 1 */
+#define US_CR_USART_DTRDIS_0        (US_CR_USART_DTRDIS_0_Val      << US_CR_USART_DTRDIS_Pos)
+#define US_CR_USART_DTRDIS_1        (US_CR_USART_DTRDIS_1_Val      << US_CR_USART_DTRDIS_Pos)
+#define US_CR_USART_RTSEN_Pos       18           /**< \brief (US_CR_USART) Request to Send Enable */
+#define US_CR_USART_RTSEN           (_U(0x1) << US_CR_USART_RTSEN_Pos)
+#define   US_CR_USART_RTSEN_0_Val         _U(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_RTSEN_1_Val         _U(0x1)   /**< \brief (US_CR_USART) Drives the pin RTS to 0 */
+#define US_CR_USART_RTSEN_0         (US_CR_USART_RTSEN_0_Val       << US_CR_USART_RTSEN_Pos)
+#define US_CR_USART_RTSEN_1         (US_CR_USART_RTSEN_1_Val       << US_CR_USART_RTSEN_Pos)
+#define US_CR_USART_RTSDIS_Pos      19           /**< \brief (US_CR_USART) Request to Send Disable */
+#define US_CR_USART_RTSDIS          (_U(0x1) << US_CR_USART_RTSDIS_Pos)
+#define   US_CR_USART_RTSDIS_0_Val        _U(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_RTSDIS_1_Val        _U(0x1)   /**< \brief (US_CR_USART) Drives the pin RTS to 1 */
+#define US_CR_USART_RTSDIS_0        (US_CR_USART_RTSDIS_0_Val      << US_CR_USART_RTSDIS_Pos)
+#define US_CR_USART_RTSDIS_1        (US_CR_USART_RTSDIS_1_Val      << US_CR_USART_RTSDIS_Pos)
+#define US_CR_USART_MASK            _U(0x000FFFFC) /**< \brief (US_CR_USART) MASK Register */
+
+// Any mode
+#define US_CR_RSTRX_Pos             2            /**< \brief (US_CR) Reset Receiver */
+#define US_CR_RSTRX                 (_U(0x1) << US_CR_RSTRX_Pos)
+#define   US_CR_RSTRX_0_Val               _U(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_RSTRX_1_Val               _U(0x1)   /**< \brief (US_CR) Resets the receiver */
+#define US_CR_RSTRX_0               (US_CR_RSTRX_0_Val             << US_CR_RSTRX_Pos)
+#define US_CR_RSTRX_1               (US_CR_RSTRX_1_Val             << US_CR_RSTRX_Pos)
+#define US_CR_RSTTX_Pos             3            /**< \brief (US_CR) Reset Transmitter */
+#define US_CR_RSTTX                 (_U(0x1) << US_CR_RSTTX_Pos)
+#define   US_CR_RSTTX_0_Val               _U(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_RSTTX_1_Val               _U(0x1)   /**< \brief (US_CR) Resets the transmitter */
+#define US_CR_RSTTX_0               (US_CR_RSTTX_0_Val             << US_CR_RSTTX_Pos)
+#define US_CR_RSTTX_1               (US_CR_RSTTX_1_Val             << US_CR_RSTTX_Pos)
+#define US_CR_RXEN_Pos              4            /**< \brief (US_CR) Receiver Enable */
+#define US_CR_RXEN                  (_U(0x1) << US_CR_RXEN_Pos)
+#define   US_CR_RXEN_0_Val                _U(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_RXEN_1_Val                _U(0x1)   /**< \brief (US_CR) Enables the receiver, if RXDIS is 0 */
+#define US_CR_RXEN_0                (US_CR_RXEN_0_Val              << US_CR_RXEN_Pos)
+#define US_CR_RXEN_1                (US_CR_RXEN_1_Val              << US_CR_RXEN_Pos)
+#define US_CR_RXDIS_Pos             5            /**< \brief (US_CR) Receiver Disable */
+#define US_CR_RXDIS                 (_U(0x1) << US_CR_RXDIS_Pos)
+#define   US_CR_RXDIS_0_Val               _U(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_RXDIS_1_Val               _U(0x1)   /**< \brief (US_CR) Disables the receiver */
+#define US_CR_RXDIS_0               (US_CR_RXDIS_0_Val             << US_CR_RXDIS_Pos)
+#define US_CR_RXDIS_1               (US_CR_RXDIS_1_Val             << US_CR_RXDIS_Pos)
+#define US_CR_TXEN_Pos              6            /**< \brief (US_CR) Transmitter Enable */
+#define US_CR_TXEN                  (_U(0x1) << US_CR_TXEN_Pos)
+#define   US_CR_TXEN_0_Val                _U(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_TXEN_1_Val                _U(0x1)   /**< \brief (US_CR) Enables the transmitter if TXDIS is 0 */
+#define US_CR_TXEN_0                (US_CR_TXEN_0_Val              << US_CR_TXEN_Pos)
+#define US_CR_TXEN_1                (US_CR_TXEN_1_Val              << US_CR_TXEN_Pos)
+#define US_CR_TXDIS_Pos             7            /**< \brief (US_CR) Transmitter Disable */
+#define US_CR_TXDIS                 (_U(0x1) << US_CR_TXDIS_Pos)
+#define   US_CR_TXDIS_0_Val               _U(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_TXDIS_1_Val               _U(0x1)   /**< \brief (US_CR) Disables the transmitter */
+#define US_CR_TXDIS_0               (US_CR_TXDIS_0_Val             << US_CR_TXDIS_Pos)
+#define US_CR_TXDIS_1               (US_CR_TXDIS_1_Val             << US_CR_TXDIS_Pos)
+#define US_CR_RSTSTA_Pos            8            /**< \brief (US_CR) Reset Status Bits */
+#define US_CR_RSTSTA                (_U(0x1) << US_CR_RSTSTA_Pos)
+#define   US_CR_RSTSTA_0_Val              _U(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_RSTSTA_1_Val              _U(0x1)   /**< \brief (US_CR) Resets the status bits PARE, FRAME, OVRE and RXBRK in the CSR */
+#define US_CR_RSTSTA_0              (US_CR_RSTSTA_0_Val            << US_CR_RSTSTA_Pos)
+#define US_CR_RSTSTA_1              (US_CR_RSTSTA_1_Val            << US_CR_RSTSTA_Pos)
+#define US_CR_STTBRK_Pos            9            /**< \brief (US_CR) Start Break */
+#define US_CR_STTBRK                (_U(0x1) << US_CR_STTBRK_Pos)
+#define   US_CR_STTBRK_0_Val              _U(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_STTBRK_1_Val              _U(0x1)   /**< \brief (US_CR) Starts transmission of a break after the characters present in THR and the Transmit Shift Register have been transmitted. No effect if a break is already being transmitted */
+#define US_CR_STTBRK_0              (US_CR_STTBRK_0_Val            << US_CR_STTBRK_Pos)
+#define US_CR_STTBRK_1              (US_CR_STTBRK_1_Val            << US_CR_STTBRK_Pos)
+#define US_CR_STPBRK_Pos            10           /**< \brief (US_CR) Stop Break */
+#define US_CR_STPBRK                (_U(0x1) << US_CR_STPBRK_Pos)
+#define   US_CR_STPBRK_0_Val              _U(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_STPBRK_1_Val              _U(0x1)   /**< \brief (US_CR) Stops transmission of the break after a minimum of one character length and transmits a high level during 12-bit periods.No effect if no break is being transmitted */
+#define US_CR_STPBRK_0              (US_CR_STPBRK_0_Val            << US_CR_STPBRK_Pos)
+#define US_CR_STPBRK_1              (US_CR_STPBRK_1_Val            << US_CR_STPBRK_Pos)
+#define US_CR_STTTO_Pos             11           /**< \brief (US_CR) Start Time-out */
+#define US_CR_STTTO                 (_U(0x1) << US_CR_STTTO_Pos)
+#define   US_CR_STTTO_0_Val               _U(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_STTTO_1_Val               _U(0x1)   /**< \brief (US_CR) Starts waiting for a character before clocking the time-out counter */
+#define US_CR_STTTO_0               (US_CR_STTTO_0_Val             << US_CR_STTTO_Pos)
+#define US_CR_STTTO_1               (US_CR_STTTO_1_Val             << US_CR_STTTO_Pos)
+#define US_CR_SENDA_Pos             12           /**< \brief (US_CR) Send Address */
+#define US_CR_SENDA                 (_U(0x1) << US_CR_SENDA_Pos)
+#define   US_CR_SENDA_0_Val               _U(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_SENDA_1_Val               _U(0x1)   /**< \brief (US_CR) In Multi-drop Mode only, the next character written to the THR is sent with the address bit set */
+#define US_CR_SENDA_0               (US_CR_SENDA_0_Val             << US_CR_SENDA_Pos)
+#define US_CR_SENDA_1               (US_CR_SENDA_1_Val             << US_CR_SENDA_Pos)
+#define US_CR_RSTIT_Pos             13           /**< \brief (US_CR) Reset Iterations */
+#define US_CR_RSTIT                 (_U(0x1) << US_CR_RSTIT_Pos)
+#define   US_CR_RSTIT_0_Val               _U(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_RSTIT_1_Val               _U(0x1)   /**< \brief (US_CR) Resets ITERATION in CSR. No effect if the ISO7816 is not enabled */
+#define US_CR_RSTIT_0               (US_CR_RSTIT_0_Val             << US_CR_RSTIT_Pos)
+#define US_CR_RSTIT_1               (US_CR_RSTIT_1_Val             << US_CR_RSTIT_Pos)
+#define US_CR_RSTNACK_Pos           14           /**< \brief (US_CR) Reset Non Acknowledge */
+#define US_CR_RSTNACK               (_U(0x1) << US_CR_RSTNACK_Pos)
+#define   US_CR_RSTNACK_0_Val             _U(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_RSTNACK_1_Val             _U(0x1)   /**< \brief (US_CR) Resets NACK in CSR */
+#define US_CR_RSTNACK_0             (US_CR_RSTNACK_0_Val           << US_CR_RSTNACK_Pos)
+#define US_CR_RSTNACK_1             (US_CR_RSTNACK_1_Val           << US_CR_RSTNACK_Pos)
+#define US_CR_RETTO_Pos             15           /**< \brief (US_CR) Rearm Time-out */
+#define US_CR_RETTO                 (_U(0x1) << US_CR_RETTO_Pos)
+#define   US_CR_RETTO_0_Val               _U(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_RETTO_1_Val               _U(0x1)   /**< \brief (US_CR) Restart Time-out */
+#define US_CR_RETTO_0               (US_CR_RETTO_0_Val             << US_CR_RETTO_Pos)
+#define US_CR_RETTO_1               (US_CR_RETTO_1_Val             << US_CR_RETTO_Pos)
+#define US_CR_DTREN_Pos             16           /**< \brief (US_CR) Data Terminal Ready Enable */
+#define US_CR_DTREN                 (_U(0x1) << US_CR_DTREN_Pos)
+#define   US_CR_DTREN_0_Val               _U(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_DTREN_1_Val               _U(0x1)   /**< \brief (US_CR) Drives the pin DTR at 0 */
+#define US_CR_DTREN_0               (US_CR_DTREN_0_Val             << US_CR_DTREN_Pos)
+#define US_CR_DTREN_1               (US_CR_DTREN_1_Val             << US_CR_DTREN_Pos)
+#define US_CR_DTRDIS_Pos            17           /**< \brief (US_CR) Data Terminal Ready Disable */
+#define US_CR_DTRDIS                (_U(0x1) << US_CR_DTRDIS_Pos)
+#define   US_CR_DTRDIS_0_Val              _U(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_DTRDIS_1_Val              _U(0x1)   /**< \brief (US_CR) Drives the pin DTR to 1 */
+#define US_CR_DTRDIS_0              (US_CR_DTRDIS_0_Val            << US_CR_DTRDIS_Pos)
+#define US_CR_DTRDIS_1              (US_CR_DTRDIS_1_Val            << US_CR_DTRDIS_Pos)
+#define US_CR_RTSEN_Pos             18           /**< \brief (US_CR) Request to Send Enable */
+#define US_CR_RTSEN                 (_U(0x1) << US_CR_RTSEN_Pos)
+#define   US_CR_RTSEN_0_Val               _U(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_RTSEN_1_Val               _U(0x1)   /**< \brief (US_CR) Drives the pin RTS to 0 */
+#define US_CR_RTSEN_0               (US_CR_RTSEN_0_Val             << US_CR_RTSEN_Pos)
+#define US_CR_RTSEN_1               (US_CR_RTSEN_1_Val             << US_CR_RTSEN_Pos)
+#define US_CR_FCS_Pos               18           /**< \brief (US_CR) Force SPI Chip Select */
+#define US_CR_FCS                   (_U(0x1) << US_CR_FCS_Pos)
+#define   US_CR_FCS_0_Val                 _U(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_FCS_1_Val                 _U(0x1)   /**< \brief (US_CR) Forces the Slave Select Line NSS (RTS pin) to 0, even if USART is no transmitting, in order to address SPI slave devices supporting the CSAAT Mode (Chip Select Active After Transfer) */
+#define US_CR_FCS_0                 (US_CR_FCS_0_Val               << US_CR_FCS_Pos)
+#define US_CR_FCS_1                 (US_CR_FCS_1_Val               << US_CR_FCS_Pos)
+#define US_CR_RTSEN_Pos             18           /**< \brief (US_CR) Request to Send Enable */
+#define US_CR_RTSEN                 (_U(0x1) << US_CR_RTSEN_Pos)
+#define   US_CR_RTSEN_0_Val               _U(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_RTSEN_1_Val               _U(0x1)   /**< \brief (US_CR) Drives the pin RTS to 0 */
+#define US_CR_RTSEN_0               (US_CR_RTSEN_0_Val             << US_CR_RTSEN_Pos)
+#define US_CR_RTSEN_1               (US_CR_RTSEN_1_Val             << US_CR_RTSEN_Pos)
+#define US_CR_RTSDIS_Pos            19           /**< \brief (US_CR) Request to Send Disable */
+#define US_CR_RTSDIS                (_U(0x1) << US_CR_RTSDIS_Pos)
+#define   US_CR_RTSDIS_0_Val              _U(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_RTSDIS_1_Val              _U(0x1)   /**< \brief (US_CR) Drives the pin RTS to 1 */
+#define US_CR_RTSDIS_0              (US_CR_RTSDIS_0_Val            << US_CR_RTSDIS_Pos)
+#define US_CR_RTSDIS_1              (US_CR_RTSDIS_1_Val            << US_CR_RTSDIS_Pos)
+#define US_CR_RCS_Pos               19           /**< \brief (US_CR) Release SPI Chip Select */
+#define US_CR_RCS                   (_U(0x1) << US_CR_RCS_Pos)
+#define   US_CR_RCS_0_Val                 _U(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_RCS_1_Val                 _U(0x1)   /**< \brief (US_CR) Releases the Slave Select Line NSS (RTS pin) */
+#define US_CR_RCS_0                 (US_CR_RCS_0_Val               << US_CR_RCS_Pos)
+#define US_CR_RCS_1                 (US_CR_RCS_1_Val               << US_CR_RCS_Pos)
+#define US_CR_RTSDIS_Pos            19           /**< \brief (US_CR) Request to Send Disable */
+#define US_CR_RTSDIS                (_U(0x1) << US_CR_RTSDIS_Pos)
+#define   US_CR_RTSDIS_0_Val              _U(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_RTSDIS_1_Val              _U(0x1)   /**< \brief (US_CR) Drives the pin RTS to 1 */
+#define US_CR_RTSDIS_0              (US_CR_RTSDIS_0_Val            << US_CR_RTSDIS_Pos)
+#define US_CR_RTSDIS_1              (US_CR_RTSDIS_1_Val            << US_CR_RTSDIS_Pos)
+#define US_CR_LINABT_Pos            20           /**< \brief (US_CR) Abort the current LIN transmission */
+#define US_CR_LINABT                (_U(0x1) << US_CR_LINABT_Pos)
+#define US_CR_LINWKUP_Pos           21           /**< \brief (US_CR) Sends a wakeup signal on the LIN bus */
+#define US_CR_LINWKUP               (_U(0x1) << US_CR_LINWKUP_Pos)
+#define US_CR_MASK                  _U(0x003FFFFC) /**< \brief (US_CR) MASK Register */
+
+/* -------- US_MR : (USART Offset: 0x04) (R/W 32) Mode Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct { // SPI mode
+    uint32_t MODE:4;           /*!< bit:  0.. 3  Usart Mode                         */
+    uint32_t USCLKS:2;         /*!< bit:  4.. 5  Clock Selection                    */
+    uint32_t CHRL:2;           /*!< bit:  6.. 7  Character Length.                  */
+    uint32_t CPHA:1;           /*!< bit:      8  SPI CLock Phase                    */
+    uint32_t PAR:3;            /*!< bit:  9..11  Parity Type                        */
+    uint32_t NBSTOP:2;         /*!< bit: 12..13  Number of Stop Bits                */
+    uint32_t CHMODE:2;         /*!< bit: 14..15  Channel Mode                       */
+    uint32_t CPOL:1;           /*!< bit:     16  SPI Clock Polarity                 */
+    uint32_t MODE9:1;          /*!< bit:     17  9-bit Character Length             */
+    uint32_t CLKO:1;           /*!< bit:     18  Clock Output Select                */
+    uint32_t OVER:1;           /*!< bit:     19  Oversampling Mode                  */
+    uint32_t INACK:1;          /*!< bit:     20  Inhibit Non Acknowledge            */
+    uint32_t DSNACK:1;         /*!< bit:     21  Disable Successive NACK            */
+    uint32_t :1;               /*!< bit:     22  Reserved                           */
+    uint32_t INVDATA:1;        /*!< bit:     23  Inverted data                      */
+    uint32_t MAX_ITERATION:3;  /*!< bit: 24..26  Max interation                     */
+    uint32_t :1;               /*!< bit:     27  Reserved                           */
+    uint32_t FILTER:1;         /*!< bit:     28  Infrared Receive Line Filter       */
+    uint32_t :3;               /*!< bit: 29..31  Reserved                           */
+  } SPI;                       /*!< Structure used for SPI                          */
+  struct { // USART mode
+    uint32_t MODE:4;           /*!< bit:  0.. 3  Usart Mode                         */
+    uint32_t USCLKS:2;         /*!< bit:  4.. 5  Clock Selection                    */
+    uint32_t CHRL:2;           /*!< bit:  6.. 7  Character Length.                  */
+    uint32_t SYNC:1;           /*!< bit:      8  Synchronous Mode Select            */
+    uint32_t PAR:3;            /*!< bit:  9..11  Parity Type                        */
+    uint32_t NBSTOP:2;         /*!< bit: 12..13  Number of Stop Bits                */
+    uint32_t CHMODE:2;         /*!< bit: 14..15  Channel Mode                       */
+    uint32_t MSBF:1;           /*!< bit:     16  Bit Order                          */
+    uint32_t MODE9:1;          /*!< bit:     17  9-bit Character Length             */
+    uint32_t CLKO:1;           /*!< bit:     18  Clock Output Select                */
+    uint32_t OVER:1;           /*!< bit:     19  Oversampling Mode                  */
+    uint32_t INACK:1;          /*!< bit:     20  Inhibit Non Acknowledge            */
+    uint32_t DSNACK:1;         /*!< bit:     21  Disable Successive NACK            */
+    uint32_t VAR_SYNC:1;       /*!< bit:     22  Variable synchronization of command/data sync Start Frame Delimiter */
+    uint32_t INVDATA:1;        /*!< bit:     23  Inverted data                      */
+    uint32_t MAX_ITERATION:3;  /*!< bit: 24..26  Max interation                     */
+    uint32_t :1;               /*!< bit:     27  Reserved                           */
+    uint32_t FILTER:1;         /*!< bit:     28  Infrared Receive Line Filter       */
+    uint32_t MAN:1;            /*!< bit:     29  Manchester Encoder/Decoder Enable  */
+    uint32_t MODSYNC:1;        /*!< bit:     30  Manchester Synchronization Mode    */
+    uint32_t ONEBIT:1;         /*!< bit:     31  Start Frame Delimiter selector     */
+  } USART;                     /*!< Structure used for USART                        */
+  uint32_t reg;                /*!< Type      used for register access              */
+} US_MR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_MR_OFFSET                0x04         /**< \brief (US_MR offset) Mode Register */
+#define US_MR_RESETVALUE            _U(0x00000000); /**< \brief (US_MR reset_value) Mode Register */
+
+// SPI mode
+#define US_MR_SPI_MODE_Pos          0            /**< \brief (US_MR_SPI) Usart Mode */
+#define US_MR_SPI_MODE_Msk          (_U(0xF) << US_MR_SPI_MODE_Pos)
+#define US_MR_SPI_MODE(value)       (US_MR_SPI_MODE_Msk & ((value) << US_MR_SPI_MODE_Pos))
+#define   US_MR_SPI_MODE_NORMAL_Val       _U(0x0)   /**< \brief (US_MR_SPI) Normal */
+#define   US_MR_SPI_MODE_RS485_Val        _U(0x1)   /**< \brief (US_MR_SPI) RS485 */
+#define   US_MR_SPI_MODE_HARDWARE_Val     _U(0x2)   /**< \brief (US_MR_SPI) Hardware Handshaking */
+#define   US_MR_SPI_MODE_MODEM_Val        _U(0x3)   /**< \brief (US_MR_SPI) Modem */
+#define   US_MR_SPI_MODE_ISO7816_T0_Val   _U(0x4)   /**< \brief (US_MR_SPI) IS07816 Protocol: T = 0 */
+#define   US_MR_SPI_MODE_ISO7816_T1_Val   _U(0x6)   /**< \brief (US_MR_SPI) IS07816 Protocol: T = 1 */
+#define   US_MR_SPI_MODE_IRDA_Val         _U(0x8)   /**< \brief (US_MR_SPI) IrDA */
+#define   US_MR_SPI_MODE_LIN_MASTER_Val   _U(0xA)   /**< \brief (US_MR_SPI) LIN Master */
+#define   US_MR_SPI_MODE_LIN_SLAVE_Val    _U(0xB)   /**< \brief (US_MR_SPI) LIN Slave */
+#define   US_MR_SPI_MODE_SPI_MASTER_Val   _U(0xE)   /**< \brief (US_MR_SPI) SPI Master */
+#define   US_MR_SPI_MODE_SPI_SLAVE_Val    _U(0xF)   /**< \brief (US_MR_SPI) SPI Slave */
+#define US_MR_SPI_MODE_NORMAL       (US_MR_SPI_MODE_NORMAL_Val     << US_MR_SPI_MODE_Pos)
+#define US_MR_SPI_MODE_RS485        (US_MR_SPI_MODE_RS485_Val      << US_MR_SPI_MODE_Pos)
+#define US_MR_SPI_MODE_HARDWARE     (US_MR_SPI_MODE_HARDWARE_Val   << US_MR_SPI_MODE_Pos)
+#define US_MR_SPI_MODE_MODEM        (US_MR_SPI_MODE_MODEM_Val      << US_MR_SPI_MODE_Pos)
+#define US_MR_SPI_MODE_ISO7816_T0   (US_MR_SPI_MODE_ISO7816_T0_Val << US_MR_SPI_MODE_Pos)
+#define US_MR_SPI_MODE_ISO7816_T1   (US_MR_SPI_MODE_ISO7816_T1_Val << US_MR_SPI_MODE_Pos)
+#define US_MR_SPI_MODE_IRDA         (US_MR_SPI_MODE_IRDA_Val       << US_MR_SPI_MODE_Pos)
+#define US_MR_SPI_MODE_LIN_MASTER   (US_MR_SPI_MODE_LIN_MASTER_Val << US_MR_SPI_MODE_Pos)
+#define US_MR_SPI_MODE_LIN_SLAVE    (US_MR_SPI_MODE_LIN_SLAVE_Val  << US_MR_SPI_MODE_Pos)
+#define US_MR_SPI_MODE_SPI_MASTER   (US_MR_SPI_MODE_SPI_MASTER_Val << US_MR_SPI_MODE_Pos)
+#define US_MR_SPI_MODE_SPI_SLAVE    (US_MR_SPI_MODE_SPI_SLAVE_Val  << US_MR_SPI_MODE_Pos)
+#define US_MR_SPI_USCLKS_Pos        4            /**< \brief (US_MR_SPI) Clock Selection */
+#define US_MR_SPI_USCLKS_Msk        (_U(0x3) << US_MR_SPI_USCLKS_Pos)
+#define US_MR_SPI_USCLKS(value)     (US_MR_SPI_USCLKS_Msk & ((value) << US_MR_SPI_USCLKS_Pos))
+#define   US_MR_SPI_USCLKS_MCK_Val        _U(0x0)   /**< \brief (US_MR_SPI) MCK */
+#define   US_MR_SPI_USCLKS_MCK_DIV_Val    _U(0x1)   /**< \brief (US_MR_SPI) MCK / DIV */
+#define   US_MR_SPI_USCLKS_2_Val          _U(0x2)   /**< \brief (US_MR_SPI) Reserved */
+#define   US_MR_SPI_USCLKS_SCK_Val        _U(0x3)   /**< \brief (US_MR_SPI) SCK */
+#define US_MR_SPI_USCLKS_MCK        (US_MR_SPI_USCLKS_MCK_Val      << US_MR_SPI_USCLKS_Pos)
+#define US_MR_SPI_USCLKS_MCK_DIV    (US_MR_SPI_USCLKS_MCK_DIV_Val  << US_MR_SPI_USCLKS_Pos)
+#define US_MR_SPI_USCLKS_2          (US_MR_SPI_USCLKS_2_Val        << US_MR_SPI_USCLKS_Pos)
+#define US_MR_SPI_USCLKS_SCK        (US_MR_SPI_USCLKS_SCK_Val      << US_MR_SPI_USCLKS_Pos)
+#define US_MR_SPI_CHRL_Pos          6            /**< \brief (US_MR_SPI) Character Length. */
+#define US_MR_SPI_CHRL_Msk          (_U(0x3) << US_MR_SPI_CHRL_Pos)
+#define US_MR_SPI_CHRL(value)       (US_MR_SPI_CHRL_Msk & ((value) << US_MR_SPI_CHRL_Pos))
+#define   US_MR_SPI_CHRL_5_Val            _U(0x0)   /**< \brief (US_MR_SPI) 5 bits */
+#define   US_MR_SPI_CHRL_6_Val            _U(0x1)   /**< \brief (US_MR_SPI) 6 bits */
+#define   US_MR_SPI_CHRL_7_Val            _U(0x2)   /**< \brief (US_MR_SPI) 7 bits */
+#define   US_MR_SPI_CHRL_8_Val            _U(0x3)   /**< \brief (US_MR_SPI) 8 bits */
+#define US_MR_SPI_CHRL_5            (US_MR_SPI_CHRL_5_Val          << US_MR_SPI_CHRL_Pos)
+#define US_MR_SPI_CHRL_6            (US_MR_SPI_CHRL_6_Val          << US_MR_SPI_CHRL_Pos)
+#define US_MR_SPI_CHRL_7            (US_MR_SPI_CHRL_7_Val          << US_MR_SPI_CHRL_Pos)
+#define US_MR_SPI_CHRL_8            (US_MR_SPI_CHRL_8_Val          << US_MR_SPI_CHRL_Pos)
+#define US_MR_SPI_CPHA_Pos          8            /**< \brief (US_MR_SPI) SPI CLock Phase */
+#define US_MR_SPI_CPHA              (_U(0x1) << US_MR_SPI_CPHA_Pos)
+#define   US_MR_SPI_CPHA_0_Val            _U(0x0)   /**< \brief (US_MR_SPI) Data is changed on the leading edge of SPCK and captured on the following edge of SPCK */
+#define   US_MR_SPI_CPHA_1_Val            _U(0x1)   /**< \brief (US_MR_SPI) Data is captured on the leading edge of SPCK and changed on the following edge of SPCK */
+#define US_MR_SPI_CPHA_0            (US_MR_SPI_CPHA_0_Val          << US_MR_SPI_CPHA_Pos)
+#define US_MR_SPI_CPHA_1            (US_MR_SPI_CPHA_1_Val          << US_MR_SPI_CPHA_Pos)
+#define US_MR_SPI_PAR_Pos           9            /**< \brief (US_MR_SPI) Parity Type */
+#define US_MR_SPI_PAR_Msk           (_U(0x7) << US_MR_SPI_PAR_Pos)
+#define US_MR_SPI_PAR(value)        (US_MR_SPI_PAR_Msk & ((value) << US_MR_SPI_PAR_Pos))
+#define   US_MR_SPI_PAR_EVEN_Val          _U(0x0)   /**< \brief (US_MR_SPI) Even parity */
+#define   US_MR_SPI_PAR_ODD_Val           _U(0x1)   /**< \brief (US_MR_SPI) Odd parity */
+#define   US_MR_SPI_PAR_SPACE_Val         _U(0x2)   /**< \brief (US_MR_SPI) Parity forced to 0 (Space) */
+#define   US_MR_SPI_PAR_MARK_Val          _U(0x3)   /**< \brief (US_MR_SPI) Parity forced to 1 (Mark) */
+#define   US_MR_SPI_PAR_NONE_Val          _U(0x4)   /**< \brief (US_MR_SPI) No Parity */
+#define   US_MR_SPI_PAR_5_Val             _U(0x5)   /**< \brief (US_MR_SPI) No Parity */
+#define   US_MR_SPI_PAR_MULTI_Val         _U(0x6)   /**< \brief (US_MR_SPI) Multi-drop mode */
+#define   US_MR_SPI_PAR_7_Val             _U(0x7)   /**< \brief (US_MR_SPI) Multi-drop mode */
+#define US_MR_SPI_PAR_EVEN          (US_MR_SPI_PAR_EVEN_Val        << US_MR_SPI_PAR_Pos)
+#define US_MR_SPI_PAR_ODD           (US_MR_SPI_PAR_ODD_Val         << US_MR_SPI_PAR_Pos)
+#define US_MR_SPI_PAR_SPACE         (US_MR_SPI_PAR_SPACE_Val       << US_MR_SPI_PAR_Pos)
+#define US_MR_SPI_PAR_MARK          (US_MR_SPI_PAR_MARK_Val        << US_MR_SPI_PAR_Pos)
+#define US_MR_SPI_PAR_NONE          (US_MR_SPI_PAR_NONE_Val        << US_MR_SPI_PAR_Pos)
+#define US_MR_SPI_PAR_5             (US_MR_SPI_PAR_5_Val           << US_MR_SPI_PAR_Pos)
+#define US_MR_SPI_PAR_MULTI         (US_MR_SPI_PAR_MULTI_Val       << US_MR_SPI_PAR_Pos)
+#define US_MR_SPI_PAR_7             (US_MR_SPI_PAR_7_Val           << US_MR_SPI_PAR_Pos)
+#define US_MR_SPI_NBSTOP_Pos        12           /**< \brief (US_MR_SPI) Number of Stop Bits */
+#define US_MR_SPI_NBSTOP_Msk        (_U(0x3) << US_MR_SPI_NBSTOP_Pos)
+#define US_MR_SPI_NBSTOP(value)     (US_MR_SPI_NBSTOP_Msk & ((value) << US_MR_SPI_NBSTOP_Pos))
+#define   US_MR_SPI_NBSTOP_1_Val          _U(0x0)   /**< \brief (US_MR_SPI) 1 stop bit */
+#define   US_MR_SPI_NBSTOP_1_5_Val        _U(0x1)   /**< \brief (US_MR_SPI) 1.5 stop bits (Only valid if SYNC=0) */
+#define   US_MR_SPI_NBSTOP_2_Val          _U(0x2)   /**< \brief (US_MR_SPI) 2 stop bits */
+#define   US_MR_SPI_NBSTOP_3_Val          _U(0x3)   /**< \brief (US_MR_SPI) Reserved */
+#define US_MR_SPI_NBSTOP_1          (US_MR_SPI_NBSTOP_1_Val        << US_MR_SPI_NBSTOP_Pos)
+#define US_MR_SPI_NBSTOP_1_5        (US_MR_SPI_NBSTOP_1_5_Val      << US_MR_SPI_NBSTOP_Pos)
+#define US_MR_SPI_NBSTOP_2          (US_MR_SPI_NBSTOP_2_Val        << US_MR_SPI_NBSTOP_Pos)
+#define US_MR_SPI_NBSTOP_3          (US_MR_SPI_NBSTOP_3_Val        << US_MR_SPI_NBSTOP_Pos)
+#define US_MR_SPI_CHMODE_Pos        14           /**< \brief (US_MR_SPI) Channel Mode */
+#define US_MR_SPI_CHMODE_Msk        (_U(0x3) << US_MR_SPI_CHMODE_Pos)
+#define US_MR_SPI_CHMODE(value)     (US_MR_SPI_CHMODE_Msk & ((value) << US_MR_SPI_CHMODE_Pos))
+#define   US_MR_SPI_CHMODE_NORMAL_Val     _U(0x0)   /**< \brief (US_MR_SPI) Normal Mode */
+#define   US_MR_SPI_CHMODE_ECHO_Val       _U(0x1)   /**< \brief (US_MR_SPI) Automatic Echo. Receiver input is connected to the TXD pin */
+#define   US_MR_SPI_CHMODE_LOCAL_LOOP_Val _U(0x2)   /**< \brief (US_MR_SPI) Local Loopback. Transmitter output is connected to the Receiver Input */
+#define   US_MR_SPI_CHMODE_REMOTE_LOOP_Val _U(0x3)   /**< \brief (US_MR_SPI) Remote Loopback. RXD pin is internally connected to the TXD pin */
+#define US_MR_SPI_CHMODE_NORMAL     (US_MR_SPI_CHMODE_NORMAL_Val   << US_MR_SPI_CHMODE_Pos)
+#define US_MR_SPI_CHMODE_ECHO       (US_MR_SPI_CHMODE_ECHO_Val     << US_MR_SPI_CHMODE_Pos)
+#define US_MR_SPI_CHMODE_LOCAL_LOOP (US_MR_SPI_CHMODE_LOCAL_LOOP_Val << US_MR_SPI_CHMODE_Pos)
+#define US_MR_SPI_CHMODE_REMOTE_LOOP (US_MR_SPI_CHMODE_REMOTE_LOOP_Val << US_MR_SPI_CHMODE_Pos)
+#define US_MR_SPI_CPOL_Pos          16           /**< \brief (US_MR_SPI) SPI Clock Polarity */
+#define US_MR_SPI_CPOL              (_U(0x1) << US_MR_SPI_CPOL_Pos)
+#define   US_MR_SPI_CPOL_ZERO_Val         _U(0x0)   /**< \brief (US_MR_SPI) The inactive state value of SPCK is logic level zero */
+#define   US_MR_SPI_CPOL_ONE_Val          _U(0x1)   /**< \brief (US_MR_SPI) The inactive state value of SPCK is logic level one */
+#define US_MR_SPI_CPOL_ZERO         (US_MR_SPI_CPOL_ZERO_Val       << US_MR_SPI_CPOL_Pos)
+#define US_MR_SPI_CPOL_ONE          (US_MR_SPI_CPOL_ONE_Val        << US_MR_SPI_CPOL_Pos)
+#define US_MR_SPI_MODE9_Pos         17           /**< \brief (US_MR_SPI) 9-bit Character Length */
+#define US_MR_SPI_MODE9             (_U(0x1) << US_MR_SPI_MODE9_Pos)
+#define   US_MR_SPI_MODE9_0_Val           _U(0x0)   /**< \brief (US_MR_SPI) CHRL defines character length */
+#define   US_MR_SPI_MODE9_1_Val           _U(0x1)   /**< \brief (US_MR_SPI) 9-bit character length */
+#define US_MR_SPI_MODE9_0           (US_MR_SPI_MODE9_0_Val         << US_MR_SPI_MODE9_Pos)
+#define US_MR_SPI_MODE9_1           (US_MR_SPI_MODE9_1_Val         << US_MR_SPI_MODE9_Pos)
+#define US_MR_SPI_CLKO_Pos          18           /**< \brief (US_MR_SPI) Clock Output Select */
+#define US_MR_SPI_CLKO              (_U(0x1) << US_MR_SPI_CLKO_Pos)
+#define   US_MR_SPI_CLKO_0_Val            _U(0x0)   /**< \brief (US_MR_SPI) The USART does not drive the SCK pin */
+#define   US_MR_SPI_CLKO_1_Val            _U(0x1)   /**< \brief (US_MR_SPI) The USART drives the SCK pin if USCLKS does not select the external clock SCK */
+#define US_MR_SPI_CLKO_0            (US_MR_SPI_CLKO_0_Val          << US_MR_SPI_CLKO_Pos)
+#define US_MR_SPI_CLKO_1            (US_MR_SPI_CLKO_1_Val          << US_MR_SPI_CLKO_Pos)
+#define US_MR_SPI_OVER_Pos          19           /**< \brief (US_MR_SPI) Oversampling Mode */
+#define US_MR_SPI_OVER              (_U(0x1) << US_MR_SPI_OVER_Pos)
+#define   US_MR_SPI_OVER_X16_Val          _U(0x0)   /**< \brief (US_MR_SPI) 16x Oversampling */
+#define   US_MR_SPI_OVER_X8_Val           _U(0x1)   /**< \brief (US_MR_SPI) 8x Oversampling */
+#define US_MR_SPI_OVER_X16          (US_MR_SPI_OVER_X16_Val        << US_MR_SPI_OVER_Pos)
+#define US_MR_SPI_OVER_X8           (US_MR_SPI_OVER_X8_Val         << US_MR_SPI_OVER_Pos)
+#define US_MR_SPI_INACK_Pos         20           /**< \brief (US_MR_SPI) Inhibit Non Acknowledge */
+#define US_MR_SPI_INACK             (_U(0x1) << US_MR_SPI_INACK_Pos)
+#define   US_MR_SPI_INACK_0_Val           _U(0x0)   /**< \brief (US_MR_SPI) The NACK is generated */
+#define   US_MR_SPI_INACK_1_Val           _U(0x1)   /**< \brief (US_MR_SPI) The NACK is not generated */
+#define US_MR_SPI_INACK_0           (US_MR_SPI_INACK_0_Val         << US_MR_SPI_INACK_Pos)
+#define US_MR_SPI_INACK_1           (US_MR_SPI_INACK_1_Val         << US_MR_SPI_INACK_Pos)
+#define US_MR_SPI_DSNACK_Pos        21           /**< \brief (US_MR_SPI) Disable Successive NACK */
+#define US_MR_SPI_DSNACK            (_U(0x1) << US_MR_SPI_DSNACK_Pos)
+#define   US_MR_SPI_DSNACK_0_Val          _U(0x0)   /**< \brief (US_MR_SPI) NACK is sent on the ISO line as soon as a parity error occurs in the received character (unless INACK is set) */
+#define   US_MR_SPI_DSNACK_1_Val          _U(0x1)   /**< \brief (US_MR_SPI) Successive parity errors are counted up to the value specified in the MAX_ITERATION field. These parity errors generatea NACK on the ISO line. As soon as this value is reached, no additional NACK is sent on the ISO line. The flag ITERATION is asserted */
+#define US_MR_SPI_DSNACK_0          (US_MR_SPI_DSNACK_0_Val        << US_MR_SPI_DSNACK_Pos)
+#define US_MR_SPI_DSNACK_1          (US_MR_SPI_DSNACK_1_Val        << US_MR_SPI_DSNACK_Pos)
+#define US_MR_SPI_INVDATA_Pos       23           /**< \brief (US_MR_SPI) Inverted data */
+#define US_MR_SPI_INVDATA           (_U(0x1) << US_MR_SPI_INVDATA_Pos)
+#define US_MR_SPI_MAX_ITERATION_Pos 24           /**< \brief (US_MR_SPI) Max interation */
+#define US_MR_SPI_MAX_ITERATION_Msk (_U(0x7) << US_MR_SPI_MAX_ITERATION_Pos)
+#define US_MR_SPI_MAX_ITERATION(value) (US_MR_SPI_MAX_ITERATION_Msk & ((value) << US_MR_SPI_MAX_ITERATION_Pos))
+#define US_MR_SPI_FILTER_Pos        28           /**< \brief (US_MR_SPI) Infrared Receive Line Filter */
+#define US_MR_SPI_FILTER            (_U(0x1) << US_MR_SPI_FILTER_Pos)
+#define   US_MR_SPI_FILTER_0_Val          _U(0x0)   /**< \brief (US_MR_SPI) The USART does not filter the receive line */
+#define   US_MR_SPI_FILTER_1_Val          _U(0x1)   /**< \brief (US_MR_SPI) The USART filters the receive line using a three-sample filter (1/16-bit clock) (2 over 3 majority) */
+#define US_MR_SPI_FILTER_0          (US_MR_SPI_FILTER_0_Val        << US_MR_SPI_FILTER_Pos)
+#define US_MR_SPI_FILTER_1          (US_MR_SPI_FILTER_1_Val        << US_MR_SPI_FILTER_Pos)
+#define US_MR_SPI_MASK              _U(0x17BFFFFF) /**< \brief (US_MR_SPI) MASK Register */
+
+// USART mode
+#define US_MR_USART_MODE_Pos        0            /**< \brief (US_MR_USART) Usart Mode */
+#define US_MR_USART_MODE_Msk        (_U(0xF) << US_MR_USART_MODE_Pos)
+#define US_MR_USART_MODE(value)     (US_MR_USART_MODE_Msk & ((value) << US_MR_USART_MODE_Pos))
+#define   US_MR_USART_MODE_NORMAL_Val     _U(0x0)   /**< \brief (US_MR_USART) Normal */
+#define   US_MR_USART_MODE_RS485_Val      _U(0x1)   /**< \brief (US_MR_USART) RS485 */
+#define   US_MR_USART_MODE_HARDWARE_Val   _U(0x2)   /**< \brief (US_MR_USART) Hardware Handshaking */
+#define   US_MR_USART_MODE_MODEM_Val      _U(0x3)   /**< \brief (US_MR_USART) Modem */
+#define   US_MR_USART_MODE_ISO7816_T0_Val _U(0x4)   /**< \brief (US_MR_USART) IS07816 Protocol: T = 0 */
+#define   US_MR_USART_MODE_ISO7816_T1_Val _U(0x6)   /**< \brief (US_MR_USART) IS07816 Protocol: T = 1 */
+#define   US_MR_USART_MODE_IRDA_Val       _U(0x8)   /**< \brief (US_MR_USART) IrDA */
+#define   US_MR_USART_MODE_LIN_MASTER_Val _U(0xA)   /**< \brief (US_MR_USART) LIN Master */
+#define   US_MR_USART_MODE_LIN_SLAVE_Val  _U(0xB)   /**< \brief (US_MR_USART) LIN Slave */
+#define   US_MR_USART_MODE_SPI_MASTER_Val _U(0xE)   /**< \brief (US_MR_USART) SPI Master */
+#define   US_MR_USART_MODE_SPI_SLAVE_Val  _U(0xF)   /**< \brief (US_MR_USART) SPI Slave */
+#define US_MR_USART_MODE_NORMAL     (US_MR_USART_MODE_NORMAL_Val   << US_MR_USART_MODE_Pos)
+#define US_MR_USART_MODE_RS485      (US_MR_USART_MODE_RS485_Val    << US_MR_USART_MODE_Pos)
+#define US_MR_USART_MODE_HARDWARE   (US_MR_USART_MODE_HARDWARE_Val << US_MR_USART_MODE_Pos)
+#define US_MR_USART_MODE_MODEM      (US_MR_USART_MODE_MODEM_Val    << US_MR_USART_MODE_Pos)
+#define US_MR_USART_MODE_ISO7816_T0 (US_MR_USART_MODE_ISO7816_T0_Val << US_MR_USART_MODE_Pos)
+#define US_MR_USART_MODE_ISO7816_T1 (US_MR_USART_MODE_ISO7816_T1_Val << US_MR_USART_MODE_Pos)
+#define US_MR_USART_MODE_IRDA       (US_MR_USART_MODE_IRDA_Val     << US_MR_USART_MODE_Pos)
+#define US_MR_USART_MODE_LIN_MASTER (US_MR_USART_MODE_LIN_MASTER_Val << US_MR_USART_MODE_Pos)
+#define US_MR_USART_MODE_LIN_SLAVE  (US_MR_USART_MODE_LIN_SLAVE_Val << US_MR_USART_MODE_Pos)
+#define US_MR_USART_MODE_SPI_MASTER (US_MR_USART_MODE_SPI_MASTER_Val << US_MR_USART_MODE_Pos)
+#define US_MR_USART_MODE_SPI_SLAVE  (US_MR_USART_MODE_SPI_SLAVE_Val << US_MR_USART_MODE_Pos)
+#define US_MR_USART_USCLKS_Pos      4            /**< \brief (US_MR_USART) Clock Selection */
+#define US_MR_USART_USCLKS_Msk      (_U(0x3) << US_MR_USART_USCLKS_Pos)
+#define US_MR_USART_USCLKS(value)   (US_MR_USART_USCLKS_Msk & ((value) << US_MR_USART_USCLKS_Pos))
+#define   US_MR_USART_USCLKS_MCK_Val      _U(0x0)   /**< \brief (US_MR_USART) MCK */
+#define   US_MR_USART_USCLKS_MCK_DIV_Val  _U(0x1)   /**< \brief (US_MR_USART) MCK / DIV */
+#define   US_MR_USART_USCLKS_2_Val        _U(0x2)   /**< \brief (US_MR_USART) Reserved */
+#define   US_MR_USART_USCLKS_SCK_Val      _U(0x3)   /**< \brief (US_MR_USART) SCK */
+#define US_MR_USART_USCLKS_MCK      (US_MR_USART_USCLKS_MCK_Val    << US_MR_USART_USCLKS_Pos)
+#define US_MR_USART_USCLKS_MCK_DIV  (US_MR_USART_USCLKS_MCK_DIV_Val << US_MR_USART_USCLKS_Pos)
+#define US_MR_USART_USCLKS_2        (US_MR_USART_USCLKS_2_Val      << US_MR_USART_USCLKS_Pos)
+#define US_MR_USART_USCLKS_SCK      (US_MR_USART_USCLKS_SCK_Val    << US_MR_USART_USCLKS_Pos)
+#define US_MR_USART_CHRL_Pos        6            /**< \brief (US_MR_USART) Character Length. */
+#define US_MR_USART_CHRL_Msk        (_U(0x3) << US_MR_USART_CHRL_Pos)
+#define US_MR_USART_CHRL(value)     (US_MR_USART_CHRL_Msk & ((value) << US_MR_USART_CHRL_Pos))
+#define   US_MR_USART_CHRL_5_Val          _U(0x0)   /**< \brief (US_MR_USART) 5 bits */
+#define   US_MR_USART_CHRL_6_Val          _U(0x1)   /**< \brief (US_MR_USART) 6 bits */
+#define   US_MR_USART_CHRL_7_Val          _U(0x2)   /**< \brief (US_MR_USART) 7 bits */
+#define   US_MR_USART_CHRL_8_Val          _U(0x3)   /**< \brief (US_MR_USART) 8 bits */
+#define US_MR_USART_CHRL_5          (US_MR_USART_CHRL_5_Val        << US_MR_USART_CHRL_Pos)
+#define US_MR_USART_CHRL_6          (US_MR_USART_CHRL_6_Val        << US_MR_USART_CHRL_Pos)
+#define US_MR_USART_CHRL_7          (US_MR_USART_CHRL_7_Val        << US_MR_USART_CHRL_Pos)
+#define US_MR_USART_CHRL_8          (US_MR_USART_CHRL_8_Val        << US_MR_USART_CHRL_Pos)
+#define US_MR_USART_SYNC_Pos        8            /**< \brief (US_MR_USART) Synchronous Mode Select */
+#define US_MR_USART_SYNC            (_U(0x1) << US_MR_USART_SYNC_Pos)
+#define   US_MR_USART_SYNC_0_Val          _U(0x0)   /**< \brief (US_MR_USART) USART operates in Synchronous Mode */
+#define   US_MR_USART_SYNC_1_Val          _U(0x1)   /**< \brief (US_MR_USART) USART operates in Asynchronous Mode */
+#define US_MR_USART_SYNC_0          (US_MR_USART_SYNC_0_Val        << US_MR_USART_SYNC_Pos)
+#define US_MR_USART_SYNC_1          (US_MR_USART_SYNC_1_Val        << US_MR_USART_SYNC_Pos)
+#define US_MR_USART_PAR_Pos         9            /**< \brief (US_MR_USART) Parity Type */
+#define US_MR_USART_PAR_Msk         (_U(0x7) << US_MR_USART_PAR_Pos)
+#define US_MR_USART_PAR(value)      (US_MR_USART_PAR_Msk & ((value) << US_MR_USART_PAR_Pos))
+#define   US_MR_USART_PAR_EVEN_Val        _U(0x0)   /**< \brief (US_MR_USART) Even parity */
+#define   US_MR_USART_PAR_ODD_Val         _U(0x1)   /**< \brief (US_MR_USART) Odd parity */
+#define   US_MR_USART_PAR_SPACE_Val       _U(0x2)   /**< \brief (US_MR_USART) Parity forced to 0 (Space) */
+#define   US_MR_USART_PAR_MARK_Val        _U(0x3)   /**< \brief (US_MR_USART) Parity forced to 1 (Mark) */
+#define   US_MR_USART_PAR_NONE_Val        _U(0x4)   /**< \brief (US_MR_USART) No Parity */
+#define   US_MR_USART_PAR_5_Val           _U(0x5)   /**< \brief (US_MR_USART) No Parity */
+#define   US_MR_USART_PAR_MULTI_Val       _U(0x6)   /**< \brief (US_MR_USART) Multi-drop mode */
+#define   US_MR_USART_PAR_7_Val           _U(0x7)   /**< \brief (US_MR_USART) Multi-drop mode */
+#define US_MR_USART_PAR_EVEN        (US_MR_USART_PAR_EVEN_Val      << US_MR_USART_PAR_Pos)
+#define US_MR_USART_PAR_ODD         (US_MR_USART_PAR_ODD_Val       << US_MR_USART_PAR_Pos)
+#define US_MR_USART_PAR_SPACE       (US_MR_USART_PAR_SPACE_Val     << US_MR_USART_PAR_Pos)
+#define US_MR_USART_PAR_MARK        (US_MR_USART_PAR_MARK_Val      << US_MR_USART_PAR_Pos)
+#define US_MR_USART_PAR_NONE        (US_MR_USART_PAR_NONE_Val      << US_MR_USART_PAR_Pos)
+#define US_MR_USART_PAR_5           (US_MR_USART_PAR_5_Val         << US_MR_USART_PAR_Pos)
+#define US_MR_USART_PAR_MULTI       (US_MR_USART_PAR_MULTI_Val     << US_MR_USART_PAR_Pos)
+#define US_MR_USART_PAR_7           (US_MR_USART_PAR_7_Val         << US_MR_USART_PAR_Pos)
+#define US_MR_USART_NBSTOP_Pos      12           /**< \brief (US_MR_USART) Number of Stop Bits */
+#define US_MR_USART_NBSTOP_Msk      (_U(0x3) << US_MR_USART_NBSTOP_Pos)
+#define US_MR_USART_NBSTOP(value)   (US_MR_USART_NBSTOP_Msk & ((value) << US_MR_USART_NBSTOP_Pos))
+#define   US_MR_USART_NBSTOP_1_Val        _U(0x0)   /**< \brief (US_MR_USART) 1 stop bit */
+#define   US_MR_USART_NBSTOP_1_5_Val      _U(0x1)   /**< \brief (US_MR_USART) 1.5 stop bits (Only valid if SYNC=0) */
+#define   US_MR_USART_NBSTOP_2_Val        _U(0x2)   /**< \brief (US_MR_USART) 2 stop bits */
+#define   US_MR_USART_NBSTOP_3_Val        _U(0x3)   /**< \brief (US_MR_USART) Reserved */
+#define US_MR_USART_NBSTOP_1        (US_MR_USART_NBSTOP_1_Val      << US_MR_USART_NBSTOP_Pos)
+#define US_MR_USART_NBSTOP_1_5      (US_MR_USART_NBSTOP_1_5_Val    << US_MR_USART_NBSTOP_Pos)
+#define US_MR_USART_NBSTOP_2        (US_MR_USART_NBSTOP_2_Val      << US_MR_USART_NBSTOP_Pos)
+#define US_MR_USART_NBSTOP_3        (US_MR_USART_NBSTOP_3_Val      << US_MR_USART_NBSTOP_Pos)
+#define US_MR_USART_CHMODE_Pos      14           /**< \brief (US_MR_USART) Channel Mode */
+#define US_MR_USART_CHMODE_Msk      (_U(0x3) << US_MR_USART_CHMODE_Pos)
+#define US_MR_USART_CHMODE(value)   (US_MR_USART_CHMODE_Msk & ((value) << US_MR_USART_CHMODE_Pos))
+#define   US_MR_USART_CHMODE_NORMAL_Val   _U(0x0)   /**< \brief (US_MR_USART) Normal Mode */
+#define   US_MR_USART_CHMODE_ECHO_Val     _U(0x1)   /**< \brief (US_MR_USART) Automatic Echo. Receiver input is connected to the TXD pin */
+#define   US_MR_USART_CHMODE_LOCAL_LOOP_Val _U(0x2)   /**< \brief (US_MR_USART) Local Loopback. Transmitter output is connected to the Receiver Input */
+#define   US_MR_USART_CHMODE_REMOTE_LOOP_Val _U(0x3)   /**< \brief (US_MR_USART) Remote Loopback. RXD pin is internally connected to the TXD pin */
+#define US_MR_USART_CHMODE_NORMAL   (US_MR_USART_CHMODE_NORMAL_Val << US_MR_USART_CHMODE_Pos)
+#define US_MR_USART_CHMODE_ECHO     (US_MR_USART_CHMODE_ECHO_Val   << US_MR_USART_CHMODE_Pos)
+#define US_MR_USART_CHMODE_LOCAL_LOOP (US_MR_USART_CHMODE_LOCAL_LOOP_Val << US_MR_USART_CHMODE_Pos)
+#define US_MR_USART_CHMODE_REMOTE_LOOP (US_MR_USART_CHMODE_REMOTE_LOOP_Val << US_MR_USART_CHMODE_Pos)
+#define US_MR_USART_MSBF_Pos        16           /**< \brief (US_MR_USART) Bit Order */
+#define US_MR_USART_MSBF            (_U(0x1) << US_MR_USART_MSBF_Pos)
+#define   US_MR_USART_MSBF_LSBF_Val       _U(0x0)   /**< \brief (US_MR_USART) Least Significant Bit first */
+#define   US_MR_USART_MSBF_MSBF_Val       _U(0x1)   /**< \brief (US_MR_USART) Most Significant Bit first */
+#define US_MR_USART_MSBF_LSBF       (US_MR_USART_MSBF_LSBF_Val     << US_MR_USART_MSBF_Pos)
+#define US_MR_USART_MSBF_MSBF       (US_MR_USART_MSBF_MSBF_Val     << US_MR_USART_MSBF_Pos)
+#define US_MR_USART_MODE9_Pos       17           /**< \brief (US_MR_USART) 9-bit Character Length */
+#define US_MR_USART_MODE9           (_U(0x1) << US_MR_USART_MODE9_Pos)
+#define   US_MR_USART_MODE9_0_Val         _U(0x0)   /**< \brief (US_MR_USART) CHRL defines character length */
+#define   US_MR_USART_MODE9_1_Val         _U(0x1)   /**< \brief (US_MR_USART) 9-bit character length */
+#define US_MR_USART_MODE9_0         (US_MR_USART_MODE9_0_Val       << US_MR_USART_MODE9_Pos)
+#define US_MR_USART_MODE9_1         (US_MR_USART_MODE9_1_Val       << US_MR_USART_MODE9_Pos)
+#define US_MR_USART_CLKO_Pos        18           /**< \brief (US_MR_USART) Clock Output Select */
+#define US_MR_USART_CLKO            (_U(0x1) << US_MR_USART_CLKO_Pos)
+#define   US_MR_USART_CLKO_0_Val          _U(0x0)   /**< \brief (US_MR_USART) The USART does not drive the SCK pin */
+#define   US_MR_USART_CLKO_1_Val          _U(0x1)   /**< \brief (US_MR_USART) The USART drives the SCK pin if USCLKS does not select the external clock SCK */
+#define US_MR_USART_CLKO_0          (US_MR_USART_CLKO_0_Val        << US_MR_USART_CLKO_Pos)
+#define US_MR_USART_CLKO_1          (US_MR_USART_CLKO_1_Val        << US_MR_USART_CLKO_Pos)
+#define US_MR_USART_OVER_Pos        19           /**< \brief (US_MR_USART) Oversampling Mode */
+#define US_MR_USART_OVER            (_U(0x1) << US_MR_USART_OVER_Pos)
+#define   US_MR_USART_OVER_X16_Val        _U(0x0)   /**< \brief (US_MR_USART) 16x Oversampling */
+#define   US_MR_USART_OVER_X8_Val         _U(0x1)   /**< \brief (US_MR_USART) 8x Oversampling */
+#define US_MR_USART_OVER_X16        (US_MR_USART_OVER_X16_Val      << US_MR_USART_OVER_Pos)
+#define US_MR_USART_OVER_X8         (US_MR_USART_OVER_X8_Val       << US_MR_USART_OVER_Pos)
+#define US_MR_USART_INACK_Pos       20           /**< \brief (US_MR_USART) Inhibit Non Acknowledge */
+#define US_MR_USART_INACK           (_U(0x1) << US_MR_USART_INACK_Pos)
+#define   US_MR_USART_INACK_0_Val         _U(0x0)   /**< \brief (US_MR_USART) The NACK is generated */
+#define   US_MR_USART_INACK_1_Val         _U(0x1)   /**< \brief (US_MR_USART) The NACK is not generated */
+#define US_MR_USART_INACK_0         (US_MR_USART_INACK_0_Val       << US_MR_USART_INACK_Pos)
+#define US_MR_USART_INACK_1         (US_MR_USART_INACK_1_Val       << US_MR_USART_INACK_Pos)
+#define US_MR_USART_DSNACK_Pos      21           /**< \brief (US_MR_USART) Disable Successive NACK */
+#define US_MR_USART_DSNACK          (_U(0x1) << US_MR_USART_DSNACK_Pos)
+#define   US_MR_USART_DSNACK_0_Val        _U(0x0)   /**< \brief (US_MR_USART) NACK is sent on the ISO line as soon as a parity error occurs in the received character (unless INACK is set) */
+#define   US_MR_USART_DSNACK_1_Val        _U(0x1)   /**< \brief (US_MR_USART) Successive parity errors are counted up to the value specified in the MAX_ITERATION field. These parity errors generatea NACK on the ISO line. As soon as this value is reached, no additional NACK is sent on the ISO line. The flag ITERATION is asserted */
+#define US_MR_USART_DSNACK_0        (US_MR_USART_DSNACK_0_Val      << US_MR_USART_DSNACK_Pos)
+#define US_MR_USART_DSNACK_1        (US_MR_USART_DSNACK_1_Val      << US_MR_USART_DSNACK_Pos)
+#define US_MR_USART_VAR_SYNC_Pos    22           /**< \brief (US_MR_USART) Variable synchronization of command/data sync Start Frame Delimiter */
+#define US_MR_USART_VAR_SYNC        (_U(0x1) << US_MR_USART_VAR_SYNC_Pos)
+#define   US_MR_USART_VAR_SYNC_0_Val      _U(0x0)   /**< \brief (US_MR_USART) User defined configuration of command or data sync field depending on SYNC value */
+#define   US_MR_USART_VAR_SYNC_1_Val      _U(0x1)   /**< \brief (US_MR_USART) The sync field is updated when a character is written into THR register */
+#define US_MR_USART_VAR_SYNC_0      (US_MR_USART_VAR_SYNC_0_Val    << US_MR_USART_VAR_SYNC_Pos)
+#define US_MR_USART_VAR_SYNC_1      (US_MR_USART_VAR_SYNC_1_Val    << US_MR_USART_VAR_SYNC_Pos)
+#define US_MR_USART_INVDATA_Pos     23           /**< \brief (US_MR_USART) Inverted data */
+#define US_MR_USART_INVDATA         (_U(0x1) << US_MR_USART_INVDATA_Pos)
+#define US_MR_USART_MAX_ITERATION_Pos 24           /**< \brief (US_MR_USART) Max interation */
+#define US_MR_USART_MAX_ITERATION_Msk (_U(0x7) << US_MR_USART_MAX_ITERATION_Pos)
+#define US_MR_USART_MAX_ITERATION(value) (US_MR_USART_MAX_ITERATION_Msk & ((value) << US_MR_USART_MAX_ITERATION_Pos))
+#define US_MR_USART_FILTER_Pos      28           /**< \brief (US_MR_USART) Infrared Receive Line Filter */
+#define US_MR_USART_FILTER          (_U(0x1) << US_MR_USART_FILTER_Pos)
+#define   US_MR_USART_FILTER_0_Val        _U(0x0)   /**< \brief (US_MR_USART) The USART does not filter the receive line */
+#define   US_MR_USART_FILTER_1_Val        _U(0x1)   /**< \brief (US_MR_USART) The USART filters the receive line using a three-sample filter (1/16-bit clock) (2 over 3 majority) */
+#define US_MR_USART_FILTER_0        (US_MR_USART_FILTER_0_Val      << US_MR_USART_FILTER_Pos)
+#define US_MR_USART_FILTER_1        (US_MR_USART_FILTER_1_Val      << US_MR_USART_FILTER_Pos)
+#define US_MR_USART_MAN_Pos         29           /**< \brief (US_MR_USART) Manchester Encoder/Decoder Enable */
+#define US_MR_USART_MAN             (_U(0x1) << US_MR_USART_MAN_Pos)
+#define   US_MR_USART_MAN_0_Val           _U(0x0)   /**< \brief (US_MR_USART) Manchester Encoder/Decoder is disabled */
+#define   US_MR_USART_MAN_1_Val           _U(0x1)   /**< \brief (US_MR_USART) Manchester Encoder/Decoder is enabled */
+#define US_MR_USART_MAN_0           (US_MR_USART_MAN_0_Val         << US_MR_USART_MAN_Pos)
+#define US_MR_USART_MAN_1           (US_MR_USART_MAN_1_Val         << US_MR_USART_MAN_Pos)
+#define US_MR_USART_MODSYNC_Pos     30           /**< \brief (US_MR_USART) Manchester Synchronization Mode */
+#define US_MR_USART_MODSYNC         (_U(0x1) << US_MR_USART_MODSYNC_Pos)
+#define   US_MR_USART_MODSYNC_0_Val       _U(0x0)   /**< \brief (US_MR_USART) The Manchester Start bit is a 0 to 1 transition */
+#define   US_MR_USART_MODSYNC_1_Val       _U(0x1)   /**< \brief (US_MR_USART) The Manchester Start bit is a 1 to 0 transition */
+#define US_MR_USART_MODSYNC_0       (US_MR_USART_MODSYNC_0_Val     << US_MR_USART_MODSYNC_Pos)
+#define US_MR_USART_MODSYNC_1       (US_MR_USART_MODSYNC_1_Val     << US_MR_USART_MODSYNC_Pos)
+#define US_MR_USART_ONEBIT_Pos      31           /**< \brief (US_MR_USART) Start Frame Delimiter selector */
+#define US_MR_USART_ONEBIT          (_U(0x1) << US_MR_USART_ONEBIT_Pos)
+#define   US_MR_USART_ONEBIT_0_Val        _U(0x0)   /**< \brief (US_MR_USART) Start Frame delimiter is COMMAND or DATA SYNC */
+#define   US_MR_USART_ONEBIT_1_Val        _U(0x1)   /**< \brief (US_MR_USART) Start Frame delimiter is One Bit */
+#define US_MR_USART_ONEBIT_0        (US_MR_USART_ONEBIT_0_Val      << US_MR_USART_ONEBIT_Pos)
+#define US_MR_USART_ONEBIT_1        (US_MR_USART_ONEBIT_1_Val      << US_MR_USART_ONEBIT_Pos)
+#define US_MR_USART_MASK            _U(0xF7FFFFFF) /**< \brief (US_MR_USART) MASK Register */
+
+// Any mode
+#define US_MR_MODE_Pos              0            /**< \brief (US_MR) Usart Mode */
+#define US_MR_MODE_Msk              (_U(0xF) << US_MR_MODE_Pos)
+#define US_MR_MODE(value)           (US_MR_MODE_Msk & ((value) << US_MR_MODE_Pos))
+#define   US_MR_MODE_NORMAL_Val           _U(0x0)   /**< \brief (US_MR) Normal */
+#define   US_MR_MODE_RS485_Val            _U(0x1)   /**< \brief (US_MR) RS485 */
+#define   US_MR_MODE_HARDWARE_Val         _U(0x2)   /**< \brief (US_MR) Hardware Handshaking */
+#define   US_MR_MODE_MODEM_Val            _U(0x3)   /**< \brief (US_MR) Modem */
+#define   US_MR_MODE_ISO7816_T0_Val       _U(0x4)   /**< \brief (US_MR) IS07816 Protocol: T = 0 */
+#define   US_MR_MODE_ISO7816_T1_Val       _U(0x6)   /**< \brief (US_MR) IS07816 Protocol: T = 1 */
+#define   US_MR_MODE_IRDA_Val             _U(0x8)   /**< \brief (US_MR) IrDA */
+#define   US_MR_MODE_LIN_MASTER_Val       _U(0xA)   /**< \brief (US_MR) LIN Master */
+#define   US_MR_MODE_LIN_SLAVE_Val        _U(0xB)   /**< \brief (US_MR) LIN Slave */
+#define   US_MR_MODE_SPI_MASTER_Val       _U(0xE)   /**< \brief (US_MR) SPI Master */
+#define   US_MR_MODE_SPI_SLAVE_Val        _U(0xF)   /**< \brief (US_MR) SPI Slave */
+#define US_MR_MODE_NORMAL           (US_MR_MODE_NORMAL_Val         << US_MR_MODE_Pos)
+#define US_MR_MODE_RS485            (US_MR_MODE_RS485_Val          << US_MR_MODE_Pos)
+#define US_MR_MODE_HARDWARE         (US_MR_MODE_HARDWARE_Val       << US_MR_MODE_Pos)
+#define US_MR_MODE_MODEM            (US_MR_MODE_MODEM_Val          << US_MR_MODE_Pos)
+#define US_MR_MODE_ISO7816_T0       (US_MR_MODE_ISO7816_T0_Val     << US_MR_MODE_Pos)
+#define US_MR_MODE_ISO7816_T1       (US_MR_MODE_ISO7816_T1_Val     << US_MR_MODE_Pos)
+#define US_MR_MODE_IRDA             (US_MR_MODE_IRDA_Val           << US_MR_MODE_Pos)
+#define US_MR_MODE_LIN_MASTER       (US_MR_MODE_LIN_MASTER_Val     << US_MR_MODE_Pos)
+#define US_MR_MODE_LIN_SLAVE        (US_MR_MODE_LIN_SLAVE_Val      << US_MR_MODE_Pos)
+#define US_MR_MODE_SPI_MASTER       (US_MR_MODE_SPI_MASTER_Val     << US_MR_MODE_Pos)
+#define US_MR_MODE_SPI_SLAVE        (US_MR_MODE_SPI_SLAVE_Val      << US_MR_MODE_Pos)
+#define US_MR_USCLKS_Pos            4            /**< \brief (US_MR) Clock Selection */
+#define US_MR_USCLKS_Msk            (_U(0x3) << US_MR_USCLKS_Pos)
+#define US_MR_USCLKS(value)         (US_MR_USCLKS_Msk & ((value) << US_MR_USCLKS_Pos))
+#define   US_MR_USCLKS_MCK_Val            _U(0x0)   /**< \brief (US_MR) MCK */
+#define   US_MR_USCLKS_MCK_DIV_Val        _U(0x1)   /**< \brief (US_MR) MCK / DIV */
+#define   US_MR_USCLKS_2_Val              _U(0x2)   /**< \brief (US_MR) Reserved */
+#define   US_MR_USCLKS_SCK_Val            _U(0x3)   /**< \brief (US_MR) SCK */
+#define US_MR_USCLKS_MCK            (US_MR_USCLKS_MCK_Val          << US_MR_USCLKS_Pos)
+#define US_MR_USCLKS_MCK_DIV        (US_MR_USCLKS_MCK_DIV_Val      << US_MR_USCLKS_Pos)
+#define US_MR_USCLKS_2              (US_MR_USCLKS_2_Val            << US_MR_USCLKS_Pos)
+#define US_MR_USCLKS_SCK            (US_MR_USCLKS_SCK_Val          << US_MR_USCLKS_Pos)
+#define US_MR_CHRL_Pos              6            /**< \brief (US_MR) Character Length. */
+#define US_MR_CHRL_Msk              (_U(0x3) << US_MR_CHRL_Pos)
+#define US_MR_CHRL(value)           (US_MR_CHRL_Msk & ((value) << US_MR_CHRL_Pos))
+#define   US_MR_CHRL_5_Val                _U(0x0)   /**< \brief (US_MR) 5 bits */
+#define   US_MR_CHRL_6_Val                _U(0x1)   /**< \brief (US_MR) 6 bits */
+#define   US_MR_CHRL_7_Val                _U(0x2)   /**< \brief (US_MR) 7 bits */
+#define   US_MR_CHRL_8_Val                _U(0x3)   /**< \brief (US_MR) 8 bits */
+#define US_MR_CHRL_5                (US_MR_CHRL_5_Val              << US_MR_CHRL_Pos)
+#define US_MR_CHRL_6                (US_MR_CHRL_6_Val              << US_MR_CHRL_Pos)
+#define US_MR_CHRL_7                (US_MR_CHRL_7_Val              << US_MR_CHRL_Pos)
+#define US_MR_CHRL_8                (US_MR_CHRL_8_Val              << US_MR_CHRL_Pos)
+#define US_MR_CPHA_Pos              8            /**< \brief (US_MR) SPI CLock Phase */
+#define US_MR_CPHA                  (_U(0x1) << US_MR_CPHA_Pos)
+#define   US_MR_CPHA_0_Val                _U(0x0)   /**< \brief (US_MR) Data is changed on the leading edge of SPCK and captured on the following edge of SPCK */
+#define   US_MR_CPHA_1_Val                _U(0x1)   /**< \brief (US_MR) Data is captured on the leading edge of SPCK and changed on the following edge of SPCK */
+#define US_MR_CPHA_0                (US_MR_CPHA_0_Val              << US_MR_CPHA_Pos)
+#define US_MR_CPHA_1                (US_MR_CPHA_1_Val              << US_MR_CPHA_Pos)
+#define US_MR_SYNC_Pos              8            /**< \brief (US_MR) Synchronous Mode Select */
+#define US_MR_SYNC                  (_U(0x1) << US_MR_SYNC_Pos)
+#define   US_MR_SYNC_0_Val                _U(0x0)   /**< \brief (US_MR) USART operates in Synchronous Mode */
+#define   US_MR_SYNC_1_Val                _U(0x1)   /**< \brief (US_MR) USART operates in Asynchronous Mode */
+#define US_MR_SYNC_0                (US_MR_SYNC_0_Val              << US_MR_SYNC_Pos)
+#define US_MR_SYNC_1                (US_MR_SYNC_1_Val              << US_MR_SYNC_Pos)
+#define US_MR_PAR_Pos               9            /**< \brief (US_MR) Parity Type */
+#define US_MR_PAR_Msk               (_U(0x7) << US_MR_PAR_Pos)
+#define US_MR_PAR(value)            (US_MR_PAR_Msk & ((value) << US_MR_PAR_Pos))
+#define   US_MR_PAR_EVEN_Val              _U(0x0)   /**< \brief (US_MR) Even parity */
+#define   US_MR_PAR_ODD_Val               _U(0x1)   /**< \brief (US_MR) Odd parity */
+#define   US_MR_PAR_SPACE_Val             _U(0x2)   /**< \brief (US_MR) Parity forced to 0 (Space) */
+#define   US_MR_PAR_MARK_Val              _U(0x3)   /**< \brief (US_MR) Parity forced to 1 (Mark) */
+#define   US_MR_PAR_NONE_Val              _U(0x4)   /**< \brief (US_MR) No Parity */
+#define   US_MR_PAR_5_Val                 _U(0x5)   /**< \brief (US_MR) No Parity */
+#define   US_MR_PAR_MULTI_Val             _U(0x6)   /**< \brief (US_MR) Multi-drop mode */
+#define   US_MR_PAR_7_Val                 _U(0x7)   /**< \brief (US_MR) Multi-drop mode */
+#define US_MR_PAR_EVEN              (US_MR_PAR_EVEN_Val            << US_MR_PAR_Pos)
+#define US_MR_PAR_ODD               (US_MR_PAR_ODD_Val             << US_MR_PAR_Pos)
+#define US_MR_PAR_SPACE             (US_MR_PAR_SPACE_Val           << US_MR_PAR_Pos)
+#define US_MR_PAR_MARK              (US_MR_PAR_MARK_Val            << US_MR_PAR_Pos)
+#define US_MR_PAR_NONE              (US_MR_PAR_NONE_Val            << US_MR_PAR_Pos)
+#define US_MR_PAR_5                 (US_MR_PAR_5_Val               << US_MR_PAR_Pos)
+#define US_MR_PAR_MULTI             (US_MR_PAR_MULTI_Val           << US_MR_PAR_Pos)
+#define US_MR_PAR_7                 (US_MR_PAR_7_Val               << US_MR_PAR_Pos)
+#define US_MR_NBSTOP_Pos            12           /**< \brief (US_MR) Number of Stop Bits */
+#define US_MR_NBSTOP_Msk            (_U(0x3) << US_MR_NBSTOP_Pos)
+#define US_MR_NBSTOP(value)         (US_MR_NBSTOP_Msk & ((value) << US_MR_NBSTOP_Pos))
+#define   US_MR_NBSTOP_1_Val              _U(0x0)   /**< \brief (US_MR) 1 stop bit */
+#define   US_MR_NBSTOP_1_5_Val            _U(0x1)   /**< \brief (US_MR) 1.5 stop bits (Only valid if SYNC=0) */
+#define   US_MR_NBSTOP_2_Val              _U(0x2)   /**< \brief (US_MR) 2 stop bits */
+#define   US_MR_NBSTOP_3_Val              _U(0x3)   /**< \brief (US_MR) Reserved */
+#define US_MR_NBSTOP_1              (US_MR_NBSTOP_1_Val            << US_MR_NBSTOP_Pos)
+#define US_MR_NBSTOP_1_5            (US_MR_NBSTOP_1_5_Val          << US_MR_NBSTOP_Pos)
+#define US_MR_NBSTOP_2              (US_MR_NBSTOP_2_Val            << US_MR_NBSTOP_Pos)
+#define US_MR_NBSTOP_3              (US_MR_NBSTOP_3_Val            << US_MR_NBSTOP_Pos)
+#define US_MR_CHMODE_Pos            14           /**< \brief (US_MR) Channel Mode */
+#define US_MR_CHMODE_Msk            (_U(0x3) << US_MR_CHMODE_Pos)
+#define US_MR_CHMODE(value)         (US_MR_CHMODE_Msk & ((value) << US_MR_CHMODE_Pos))
+#define   US_MR_CHMODE_NORMAL_Val         _U(0x0)   /**< \brief (US_MR) Normal Mode */
+#define   US_MR_CHMODE_ECHO_Val           _U(0x1)   /**< \brief (US_MR) Automatic Echo. Receiver input is connected to the TXD pin */
+#define   US_MR_CHMODE_LOCAL_LOOP_Val     _U(0x2)   /**< \brief (US_MR) Local Loopback. Transmitter output is connected to the Receiver Input */
+#define   US_MR_CHMODE_REMOTE_LOOP_Val    _U(0x3)   /**< \brief (US_MR) Remote Loopback. RXD pin is internally connected to the TXD pin */
+#define US_MR_CHMODE_NORMAL         (US_MR_CHMODE_NORMAL_Val       << US_MR_CHMODE_Pos)
+#define US_MR_CHMODE_ECHO           (US_MR_CHMODE_ECHO_Val         << US_MR_CHMODE_Pos)
+#define US_MR_CHMODE_LOCAL_LOOP     (US_MR_CHMODE_LOCAL_LOOP_Val   << US_MR_CHMODE_Pos)
+#define US_MR_CHMODE_REMOTE_LOOP    (US_MR_CHMODE_REMOTE_LOOP_Val  << US_MR_CHMODE_Pos)
+#define US_MR_CPOL_Pos              16           /**< \brief (US_MR) SPI Clock Polarity */
+#define US_MR_CPOL                  (_U(0x1) << US_MR_CPOL_Pos)
+#define   US_MR_CPOL_ZERO_Val             _U(0x0)   /**< \brief (US_MR) The inactive state value of SPCK is logic level zero */
+#define   US_MR_CPOL_ONE_Val              _U(0x1)   /**< \brief (US_MR) The inactive state value of SPCK is logic level one */
+#define US_MR_CPOL_ZERO             (US_MR_CPOL_ZERO_Val           << US_MR_CPOL_Pos)
+#define US_MR_CPOL_ONE              (US_MR_CPOL_ONE_Val            << US_MR_CPOL_Pos)
+#define US_MR_MSBF_Pos              16           /**< \brief (US_MR) Bit Order */
+#define US_MR_MSBF                  (_U(0x1) << US_MR_MSBF_Pos)
+#define   US_MR_MSBF_LSBF_Val             _U(0x0)   /**< \brief (US_MR) Least Significant Bit first */
+#define   US_MR_MSBF_MSBF_Val             _U(0x1)   /**< \brief (US_MR) Most Significant Bit first */
+#define US_MR_MSBF_LSBF             (US_MR_MSBF_LSBF_Val           << US_MR_MSBF_Pos)
+#define US_MR_MSBF_MSBF             (US_MR_MSBF_MSBF_Val           << US_MR_MSBF_Pos)
+#define US_MR_MODE9_Pos             17           /**< \brief (US_MR) 9-bit Character Length */
+#define US_MR_MODE9                 (_U(0x1) << US_MR_MODE9_Pos)
+#define   US_MR_MODE9_0_Val               _U(0x0)   /**< \brief (US_MR) CHRL defines character length */
+#define   US_MR_MODE9_1_Val               _U(0x1)   /**< \brief (US_MR) 9-bit character length */
+#define US_MR_MODE9_0               (US_MR_MODE9_0_Val             << US_MR_MODE9_Pos)
+#define US_MR_MODE9_1               (US_MR_MODE9_1_Val             << US_MR_MODE9_Pos)
+#define US_MR_CLKO_Pos              18           /**< \brief (US_MR) Clock Output Select */
+#define US_MR_CLKO                  (_U(0x1) << US_MR_CLKO_Pos)
+#define   US_MR_CLKO_0_Val                _U(0x0)   /**< \brief (US_MR) The USART does not drive the SCK pin */
+#define   US_MR_CLKO_1_Val                _U(0x1)   /**< \brief (US_MR) The USART drives the SCK pin if USCLKS does not select the external clock SCK */
+#define US_MR_CLKO_0                (US_MR_CLKO_0_Val              << US_MR_CLKO_Pos)
+#define US_MR_CLKO_1                (US_MR_CLKO_1_Val              << US_MR_CLKO_Pos)
+#define US_MR_OVER_Pos              19           /**< \brief (US_MR) Oversampling Mode */
+#define US_MR_OVER                  (_U(0x1) << US_MR_OVER_Pos)
+#define   US_MR_OVER_X16_Val              _U(0x0)   /**< \brief (US_MR) 16x Oversampling */
+#define   US_MR_OVER_X8_Val               _U(0x1)   /**< \brief (US_MR) 8x Oversampling */
+#define US_MR_OVER_X16              (US_MR_OVER_X16_Val            << US_MR_OVER_Pos)
+#define US_MR_OVER_X8               (US_MR_OVER_X8_Val             << US_MR_OVER_Pos)
+#define US_MR_INACK_Pos             20           /**< \brief (US_MR) Inhibit Non Acknowledge */
+#define US_MR_INACK                 (_U(0x1) << US_MR_INACK_Pos)
+#define   US_MR_INACK_0_Val               _U(0x0)   /**< \brief (US_MR) The NACK is generated */
+#define   US_MR_INACK_1_Val               _U(0x1)   /**< \brief (US_MR) The NACK is not generated */
+#define US_MR_INACK_0               (US_MR_INACK_0_Val             << US_MR_INACK_Pos)
+#define US_MR_INACK_1               (US_MR_INACK_1_Val             << US_MR_INACK_Pos)
+#define US_MR_DSNACK_Pos            21           /**< \brief (US_MR) Disable Successive NACK */
+#define US_MR_DSNACK                (_U(0x1) << US_MR_DSNACK_Pos)
+#define   US_MR_DSNACK_0_Val              _U(0x0)   /**< \brief (US_MR) NACK is sent on the ISO line as soon as a parity error occurs in the received character (unless INACK is set) */
+#define   US_MR_DSNACK_1_Val              _U(0x1)   /**< \brief (US_MR) Successive parity errors are counted up to the value specified in the MAX_ITERATION field. These parity errors generatea NACK on the ISO line. As soon as this value is reached, no additional NACK is sent on the ISO line. The flag ITERATION is asserted */
+#define US_MR_DSNACK_0              (US_MR_DSNACK_0_Val            << US_MR_DSNACK_Pos)
+#define US_MR_DSNACK_1              (US_MR_DSNACK_1_Val            << US_MR_DSNACK_Pos)
+#define US_MR_VAR_SYNC_Pos          22           /**< \brief (US_MR) Variable synchronization of command/data sync Start Frame Delimiter */
+#define US_MR_VAR_SYNC              (_U(0x1) << US_MR_VAR_SYNC_Pos)
+#define   US_MR_VAR_SYNC_0_Val            _U(0x0)   /**< \brief (US_MR) User defined configuration of command or data sync field depending on SYNC value */
+#define   US_MR_VAR_SYNC_1_Val            _U(0x1)   /**< \brief (US_MR) The sync field is updated when a character is written into THR register */
+#define US_MR_VAR_SYNC_0            (US_MR_VAR_SYNC_0_Val          << US_MR_VAR_SYNC_Pos)
+#define US_MR_VAR_SYNC_1            (US_MR_VAR_SYNC_1_Val          << US_MR_VAR_SYNC_Pos)
+#define US_MR_INVDATA_Pos           23           /**< \brief (US_MR) Inverted data */
+#define US_MR_INVDATA               (_U(0x1) << US_MR_INVDATA_Pos)
+#define US_MR_MAX_ITERATION_Pos     24           /**< \brief (US_MR) Max interation */
+#define US_MR_MAX_ITERATION_Msk     (_U(0x7) << US_MR_MAX_ITERATION_Pos)
+#define US_MR_MAX_ITERATION(value)  (US_MR_MAX_ITERATION_Msk & ((value) << US_MR_MAX_ITERATION_Pos))
+#define US_MR_FILTER_Pos            28           /**< \brief (US_MR) Infrared Receive Line Filter */
+#define US_MR_FILTER                (_U(0x1) << US_MR_FILTER_Pos)
+#define   US_MR_FILTER_0_Val              _U(0x0)   /**< \brief (US_MR) The USART does not filter the receive line */
+#define   US_MR_FILTER_1_Val              _U(0x1)   /**< \brief (US_MR) The USART filters the receive line using a three-sample filter (1/16-bit clock) (2 over 3 majority) */
+#define US_MR_FILTER_0              (US_MR_FILTER_0_Val            << US_MR_FILTER_Pos)
+#define US_MR_FILTER_1              (US_MR_FILTER_1_Val            << US_MR_FILTER_Pos)
+#define US_MR_MAN_Pos               29           /**< \brief (US_MR) Manchester Encoder/Decoder Enable */
+#define US_MR_MAN                   (_U(0x1) << US_MR_MAN_Pos)
+#define   US_MR_MAN_0_Val                 _U(0x0)   /**< \brief (US_MR) Manchester Encoder/Decoder is disabled */
+#define   US_MR_MAN_1_Val                 _U(0x1)   /**< \brief (US_MR) Manchester Encoder/Decoder is enabled */
+#define US_MR_MAN_0                 (US_MR_MAN_0_Val               << US_MR_MAN_Pos)
+#define US_MR_MAN_1                 (US_MR_MAN_1_Val               << US_MR_MAN_Pos)
+#define US_MR_MODSYNC_Pos           30           /**< \brief (US_MR) Manchester Synchronization Mode */
+#define US_MR_MODSYNC               (_U(0x1) << US_MR_MODSYNC_Pos)
+#define   US_MR_MODSYNC_0_Val             _U(0x0)   /**< \brief (US_MR) The Manchester Start bit is a 0 to 1 transition */
+#define   US_MR_MODSYNC_1_Val             _U(0x1)   /**< \brief (US_MR) The Manchester Start bit is a 1 to 0 transition */
+#define US_MR_MODSYNC_0             (US_MR_MODSYNC_0_Val           << US_MR_MODSYNC_Pos)
+#define US_MR_MODSYNC_1             (US_MR_MODSYNC_1_Val           << US_MR_MODSYNC_Pos)
+#define US_MR_ONEBIT_Pos            31           /**< \brief (US_MR) Start Frame Delimiter selector */
+#define US_MR_ONEBIT                (_U(0x1) << US_MR_ONEBIT_Pos)
+#define   US_MR_ONEBIT_0_Val              _U(0x0)   /**< \brief (US_MR) Start Frame delimiter is COMMAND or DATA SYNC */
+#define   US_MR_ONEBIT_1_Val              _U(0x1)   /**< \brief (US_MR) Start Frame delimiter is One Bit */
+#define US_MR_ONEBIT_0              (US_MR_ONEBIT_0_Val            << US_MR_ONEBIT_Pos)
+#define US_MR_ONEBIT_1              (US_MR_ONEBIT_1_Val            << US_MR_ONEBIT_Pos)
+#define US_MR_MASK                  _U(0xF7FFFFFF) /**< \brief (US_MR) MASK Register */
+
+/* -------- US_IER : (USART Offset: 0x08) ( /W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct { // LIN mode
+    uint32_t RXRDY:1;          /*!< bit:      0  Receiver Ready Interrupt Enable    */
+    uint32_t TXRDY:1;          /*!< bit:      1  Transmitter Ready Interrupt Enable */
+    uint32_t RXBRK:1;          /*!< bit:      2  Receiver Break Interrupt Enable    */
+    uint32_t :2;               /*!< bit:  3.. 4  Reserved                           */
+    uint32_t OVRE:1;           /*!< bit:      5  Overrun Error Interrupt Enable     */
+    uint32_t FRAME:1;          /*!< bit:      6  Framing Error Interrupt Enable     */
+    uint32_t PARE:1;           /*!< bit:      7  Parity Error Interrupt Enable      */
+    uint32_t TIMEOUT:1;        /*!< bit:      8  Time-out Interrupt Enable          */
+    uint32_t TXEMPTY:1;        /*!< bit:      9  Transmitter Empty Interrupt Enable */
+    uint32_t ITER:1;           /*!< bit:     10  Iteration Interrupt Enable         */
+    uint32_t TXBUFE:1;         /*!< bit:     11  Buffer Empty Interrupt Enable      */
+    uint32_t RXBUFF:1;         /*!< bit:     12  Buffer Full Interrupt Enable       */
+    uint32_t NACK:1;           /*!< bit:     13  Non Acknowledge  or LIN Break Sent or LIN Break Received Interrupt Enable */
+    uint32_t LINID:1;          /*!< bit:     14  LIN Identifier Sent or LIN Identifier Received Interrupt Enable */
+    uint32_t LINTC:1;          /*!< bit:     15  LIN Transfer Conpleted Interrupt Enable */
+    uint32_t RIIC:1;           /*!< bit:     16  Ring Indicator Input Change Enable */
+    uint32_t DSRIC:1;          /*!< bit:     17  Data Set Ready Input Change Enable */
+    uint32_t DCDIC:1;          /*!< bit:     18  Data Carrier Detect Input Change Interrupt Enable */
+    uint32_t CTSIC:1;          /*!< bit:     19  Clear to Send Input Change Interrupt Enable */
+    uint32_t :5;               /*!< bit: 20..24  Reserved                           */
+    uint32_t LINBE:1;          /*!< bit:     25  LIN Bus Error Interrupt Enable     */
+    uint32_t LINISFE:1;        /*!< bit:     26  LIN Inconsistent Synch Field Error Interrupt Enable */
+    uint32_t LINIPE:1;         /*!< bit:     27  LIN Identifier Parity Interrupt Enable */
+    uint32_t LINCE:1;          /*!< bit:     28  LIN Checksum Error Interrupt Enable */
+    uint32_t LINSNRE:1;        /*!< bit:     29  LIN Slave Not Responding Error Interrupt Enable */
+    uint32_t LINSTE:1;         /*!< bit:     30  LIN Synch Tolerance Error Interrupt Enable */
+    uint32_t LINHTE:1;         /*!< bit:     31  LIN Header Timeout Error Interrupt Enable */
+  } LIN;                       /*!< Structure used for LIN                          */
+  struct { // SPI_SLAVE mode
+    uint32_t RXRDY:1;          /*!< bit:      0  Receiver Ready Interrupt Enable    */
+    uint32_t TXRDY:1;          /*!< bit:      1  Transmitter Ready Interrupt Enable */
+    uint32_t RXBRK:1;          /*!< bit:      2  Receiver Break Interrupt Enable    */
+    uint32_t :2;               /*!< bit:  3.. 4  Reserved                           */
+    uint32_t OVRE:1;           /*!< bit:      5  Overrun Error Interrupt Enable     */
+    uint32_t FRAME:1;          /*!< bit:      6  Framing Error Interrupt Enable     */
+    uint32_t PARE:1;           /*!< bit:      7  Parity Error Interrupt Enable      */
+    uint32_t TIMEOUT:1;        /*!< bit:      8  Time-out Interrupt Enable          */
+    uint32_t TXEMPTY:1;        /*!< bit:      9  Transmitter Empty Interrupt Enable */
+    uint32_t UNRE:1;           /*!< bit:     10  SPI Underrun Error Interrupt Enable */
+    uint32_t TXBUFE:1;         /*!< bit:     11  Buffer Empty Interrupt Enable      */
+    uint32_t RXBUFF:1;         /*!< bit:     12  Buffer Full Interrupt Enable       */
+    uint32_t NACK:1;           /*!< bit:     13  Non Acknowledge Interrupt Enable   */
+    uint32_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint32_t RIIC:1;           /*!< bit:     16  Ring Indicator Input Change Enable */
+    uint32_t DSRIC:1;          /*!< bit:     17  Data Set Ready Input Change Enable */
+    uint32_t DCDIC:1;          /*!< bit:     18  Data Carrier Detect Input Change Interrupt Enable */
+    uint32_t CTSIC:1;          /*!< bit:     19  Clear to Send Input Change Interrupt Enable */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } SPI_SLAVE;                 /*!< Structure used for SPI_SLAVE                    */
+  struct { // USART mode
+    uint32_t RXRDY:1;          /*!< bit:      0  Receiver Ready Interrupt Enable    */
+    uint32_t TXRDY:1;          /*!< bit:      1  Transmitter Ready Interrupt Enable */
+    uint32_t RXBRK:1;          /*!< bit:      2  Receiver Break Interrupt Enable    */
+    uint32_t :2;               /*!< bit:  3.. 4  Reserved                           */
+    uint32_t OVRE:1;           /*!< bit:      5  Overrun Error Interrupt Enable     */
+    uint32_t FRAME:1;          /*!< bit:      6  Framing Error Interrupt Enable     */
+    uint32_t PARE:1;           /*!< bit:      7  Parity Error Interrupt Enable      */
+    uint32_t TIMEOUT:1;        /*!< bit:      8  Time-out Interrupt Enable          */
+    uint32_t TXEMPTY:1;        /*!< bit:      9  Transmitter Empty Interrupt Enable */
+    uint32_t ITER:1;           /*!< bit:     10  Iteration Interrupt Enable         */
+    uint32_t TXBUFE:1;         /*!< bit:     11  Buffer Empty Interrupt Enable      */
+    uint32_t RXBUFF:1;         /*!< bit:     12  Buffer Full Interrupt Enable       */
+    uint32_t NACK:1;           /*!< bit:     13  Non Acknowledge Interrupt Enable   */
+    uint32_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint32_t RIIC:1;           /*!< bit:     16  Ring Indicator Input Change Enable */
+    uint32_t DSRIC:1;          /*!< bit:     17  Data Set Ready Input Change Enable */
+    uint32_t DCDIC:1;          /*!< bit:     18  Data Carrier Detect Input Change Interrupt Enable */
+    uint32_t CTSIC:1;          /*!< bit:     19  Clear to Send Input Change Interrupt Enable */
+    uint32_t MANE:1;           /*!< bit:     20  Manchester Error Interrupt Enable  */
+    uint32_t :3;               /*!< bit: 21..23  Reserved                           */
+    uint32_t MANEA:1;          /*!< bit:     24  Manchester Error Interrupt Enable  */
+    uint32_t :7;               /*!< bit: 25..31  Reserved                           */
+  } USART;                     /*!< Structure used for USART                        */
+  uint32_t reg;                /*!< Type      used for register access              */
+} US_IER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_IER_OFFSET               0x08         /**< \brief (US_IER offset) Interrupt Enable Register */
+#define US_IER_RESETVALUE           _U(0x00000000); /**< \brief (US_IER reset_value) Interrupt Enable Register */
+
+// LIN mode
+#define US_IER_LIN_RXRDY_Pos        0            /**< \brief (US_IER_LIN) Receiver Ready Interrupt Enable */
+#define US_IER_LIN_RXRDY            (_U(0x1) << US_IER_LIN_RXRDY_Pos)
+#define   US_IER_LIN_RXRDY_0_Val          _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_RXRDY_1_Val          _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_RXRDY_0          (US_IER_LIN_RXRDY_0_Val        << US_IER_LIN_RXRDY_Pos)
+#define US_IER_LIN_RXRDY_1          (US_IER_LIN_RXRDY_1_Val        << US_IER_LIN_RXRDY_Pos)
+#define US_IER_LIN_TXRDY_Pos        1            /**< \brief (US_IER_LIN) Transmitter Ready Interrupt Enable */
+#define US_IER_LIN_TXRDY            (_U(0x1) << US_IER_LIN_TXRDY_Pos)
+#define   US_IER_LIN_TXRDY_0_Val          _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_TXRDY_1_Val          _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_TXRDY_0          (US_IER_LIN_TXRDY_0_Val        << US_IER_LIN_TXRDY_Pos)
+#define US_IER_LIN_TXRDY_1          (US_IER_LIN_TXRDY_1_Val        << US_IER_LIN_TXRDY_Pos)
+#define US_IER_LIN_RXBRK_Pos        2            /**< \brief (US_IER_LIN) Receiver Break Interrupt Enable */
+#define US_IER_LIN_RXBRK            (_U(0x1) << US_IER_LIN_RXBRK_Pos)
+#define   US_IER_LIN_RXBRK_0_Val          _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_RXBRK_1_Val          _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_RXBRK_0          (US_IER_LIN_RXBRK_0_Val        << US_IER_LIN_RXBRK_Pos)
+#define US_IER_LIN_RXBRK_1          (US_IER_LIN_RXBRK_1_Val        << US_IER_LIN_RXBRK_Pos)
+#define US_IER_LIN_OVRE_Pos         5            /**< \brief (US_IER_LIN) Overrun Error Interrupt Enable */
+#define US_IER_LIN_OVRE             (_U(0x1) << US_IER_LIN_OVRE_Pos)
+#define   US_IER_LIN_OVRE_0_Val           _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_OVRE_1_Val           _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_OVRE_0           (US_IER_LIN_OVRE_0_Val         << US_IER_LIN_OVRE_Pos)
+#define US_IER_LIN_OVRE_1           (US_IER_LIN_OVRE_1_Val         << US_IER_LIN_OVRE_Pos)
+#define US_IER_LIN_FRAME_Pos        6            /**< \brief (US_IER_LIN) Framing Error Interrupt Enable */
+#define US_IER_LIN_FRAME            (_U(0x1) << US_IER_LIN_FRAME_Pos)
+#define   US_IER_LIN_FRAME_0_Val          _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_FRAME_1_Val          _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_FRAME_0          (US_IER_LIN_FRAME_0_Val        << US_IER_LIN_FRAME_Pos)
+#define US_IER_LIN_FRAME_1          (US_IER_LIN_FRAME_1_Val        << US_IER_LIN_FRAME_Pos)
+#define US_IER_LIN_PARE_Pos         7            /**< \brief (US_IER_LIN) Parity Error Interrupt Enable */
+#define US_IER_LIN_PARE             (_U(0x1) << US_IER_LIN_PARE_Pos)
+#define   US_IER_LIN_PARE_0_Val           _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_PARE_1_Val           _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_PARE_0           (US_IER_LIN_PARE_0_Val         << US_IER_LIN_PARE_Pos)
+#define US_IER_LIN_PARE_1           (US_IER_LIN_PARE_1_Val         << US_IER_LIN_PARE_Pos)
+#define US_IER_LIN_TIMEOUT_Pos      8            /**< \brief (US_IER_LIN) Time-out Interrupt Enable */
+#define US_IER_LIN_TIMEOUT          (_U(0x1) << US_IER_LIN_TIMEOUT_Pos)
+#define   US_IER_LIN_TIMEOUT_0_Val        _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_TIMEOUT_1_Val        _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_TIMEOUT_0        (US_IER_LIN_TIMEOUT_0_Val      << US_IER_LIN_TIMEOUT_Pos)
+#define US_IER_LIN_TIMEOUT_1        (US_IER_LIN_TIMEOUT_1_Val      << US_IER_LIN_TIMEOUT_Pos)
+#define US_IER_LIN_TXEMPTY_Pos      9            /**< \brief (US_IER_LIN) Transmitter Empty Interrupt Enable */
+#define US_IER_LIN_TXEMPTY          (_U(0x1) << US_IER_LIN_TXEMPTY_Pos)
+#define   US_IER_LIN_TXEMPTY_0_Val        _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_TXEMPTY_1_Val        _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_TXEMPTY_0        (US_IER_LIN_TXEMPTY_0_Val      << US_IER_LIN_TXEMPTY_Pos)
+#define US_IER_LIN_TXEMPTY_1        (US_IER_LIN_TXEMPTY_1_Val      << US_IER_LIN_TXEMPTY_Pos)
+#define US_IER_LIN_ITER_Pos         10           /**< \brief (US_IER_LIN) Iteration Interrupt Enable */
+#define US_IER_LIN_ITER             (_U(0x1) << US_IER_LIN_ITER_Pos)
+#define   US_IER_LIN_ITER_0_Val           _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_ITER_1_Val           _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_ITER_0           (US_IER_LIN_ITER_0_Val         << US_IER_LIN_ITER_Pos)
+#define US_IER_LIN_ITER_1           (US_IER_LIN_ITER_1_Val         << US_IER_LIN_ITER_Pos)
+#define US_IER_LIN_TXBUFE_Pos       11           /**< \brief (US_IER_LIN) Buffer Empty Interrupt Enable */
+#define US_IER_LIN_TXBUFE           (_U(0x1) << US_IER_LIN_TXBUFE_Pos)
+#define   US_IER_LIN_TXBUFE_0_Val         _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_TXBUFE_1_Val         _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_TXBUFE_0         (US_IER_LIN_TXBUFE_0_Val       << US_IER_LIN_TXBUFE_Pos)
+#define US_IER_LIN_TXBUFE_1         (US_IER_LIN_TXBUFE_1_Val       << US_IER_LIN_TXBUFE_Pos)
+#define US_IER_LIN_RXBUFF_Pos       12           /**< \brief (US_IER_LIN) Buffer Full Interrupt Enable */
+#define US_IER_LIN_RXBUFF           (_U(0x1) << US_IER_LIN_RXBUFF_Pos)
+#define   US_IER_LIN_RXBUFF_0_Val         _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_RXBUFF_1_Val         _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_RXBUFF_0         (US_IER_LIN_RXBUFF_0_Val       << US_IER_LIN_RXBUFF_Pos)
+#define US_IER_LIN_RXBUFF_1         (US_IER_LIN_RXBUFF_1_Val       << US_IER_LIN_RXBUFF_Pos)
+#define US_IER_LIN_NACK_Pos         13           /**< \brief (US_IER_LIN) Non Acknowledge  or LIN Break Sent or LIN Break Received Interrupt Enable */
+#define US_IER_LIN_NACK             (_U(0x1) << US_IER_LIN_NACK_Pos)
+#define   US_IER_LIN_NACK_0_Val           _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_NACK_1_Val           _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_NACK_0           (US_IER_LIN_NACK_0_Val         << US_IER_LIN_NACK_Pos)
+#define US_IER_LIN_NACK_1           (US_IER_LIN_NACK_1_Val         << US_IER_LIN_NACK_Pos)
+#define US_IER_LIN_LINID_Pos        14           /**< \brief (US_IER_LIN) LIN Identifier Sent or LIN Identifier Received Interrupt Enable */
+#define US_IER_LIN_LINID            (_U(0x1) << US_IER_LIN_LINID_Pos)
+#define US_IER_LIN_LINTC_Pos        15           /**< \brief (US_IER_LIN) LIN Transfer Conpleted Interrupt Enable */
+#define US_IER_LIN_LINTC            (_U(0x1) << US_IER_LIN_LINTC_Pos)
+#define US_IER_LIN_RIIC_Pos         16           /**< \brief (US_IER_LIN) Ring Indicator Input Change Enable */
+#define US_IER_LIN_RIIC             (_U(0x1) << US_IER_LIN_RIIC_Pos)
+#define   US_IER_LIN_RIIC_0_Val           _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_RIIC_1_Val           _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_RIIC_0           (US_IER_LIN_RIIC_0_Val         << US_IER_LIN_RIIC_Pos)
+#define US_IER_LIN_RIIC_1           (US_IER_LIN_RIIC_1_Val         << US_IER_LIN_RIIC_Pos)
+#define US_IER_LIN_DSRIC_Pos        17           /**< \brief (US_IER_LIN) Data Set Ready Input Change Enable */
+#define US_IER_LIN_DSRIC            (_U(0x1) << US_IER_LIN_DSRIC_Pos)
+#define   US_IER_LIN_DSRIC_0_Val          _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_DSRIC_1_Val          _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_DSRIC_0          (US_IER_LIN_DSRIC_0_Val        << US_IER_LIN_DSRIC_Pos)
+#define US_IER_LIN_DSRIC_1          (US_IER_LIN_DSRIC_1_Val        << US_IER_LIN_DSRIC_Pos)
+#define US_IER_LIN_DCDIC_Pos        18           /**< \brief (US_IER_LIN) Data Carrier Detect Input Change Interrupt Enable */
+#define US_IER_LIN_DCDIC            (_U(0x1) << US_IER_LIN_DCDIC_Pos)
+#define   US_IER_LIN_DCDIC_0_Val          _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_DCDIC_1_Val          _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_DCDIC_0          (US_IER_LIN_DCDIC_0_Val        << US_IER_LIN_DCDIC_Pos)
+#define US_IER_LIN_DCDIC_1          (US_IER_LIN_DCDIC_1_Val        << US_IER_LIN_DCDIC_Pos)
+#define US_IER_LIN_CTSIC_Pos        19           /**< \brief (US_IER_LIN) Clear to Send Input Change Interrupt Enable */
+#define US_IER_LIN_CTSIC            (_U(0x1) << US_IER_LIN_CTSIC_Pos)
+#define   US_IER_LIN_CTSIC_0_Val          _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_CTSIC_1_Val          _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_CTSIC_0          (US_IER_LIN_CTSIC_0_Val        << US_IER_LIN_CTSIC_Pos)
+#define US_IER_LIN_CTSIC_1          (US_IER_LIN_CTSIC_1_Val        << US_IER_LIN_CTSIC_Pos)
+#define US_IER_LIN_LINBE_Pos        25           /**< \brief (US_IER_LIN) LIN Bus Error Interrupt Enable */
+#define US_IER_LIN_LINBE            (_U(0x1) << US_IER_LIN_LINBE_Pos)
+#define US_IER_LIN_LINISFE_Pos      26           /**< \brief (US_IER_LIN) LIN Inconsistent Synch Field Error Interrupt Enable */
+#define US_IER_LIN_LINISFE          (_U(0x1) << US_IER_LIN_LINISFE_Pos)
+#define US_IER_LIN_LINIPE_Pos       27           /**< \brief (US_IER_LIN) LIN Identifier Parity Interrupt Enable */
+#define US_IER_LIN_LINIPE           (_U(0x1) << US_IER_LIN_LINIPE_Pos)
+#define US_IER_LIN_LINCE_Pos        28           /**< \brief (US_IER_LIN) LIN Checksum Error Interrupt Enable */
+#define US_IER_LIN_LINCE            (_U(0x1) << US_IER_LIN_LINCE_Pos)
+#define US_IER_LIN_LINSNRE_Pos      29           /**< \brief (US_IER_LIN) LIN Slave Not Responding Error Interrupt Enable */
+#define US_IER_LIN_LINSNRE          (_U(0x1) << US_IER_LIN_LINSNRE_Pos)
+#define US_IER_LIN_LINSTE_Pos       30           /**< \brief (US_IER_LIN) LIN Synch Tolerance Error Interrupt Enable */
+#define US_IER_LIN_LINSTE           (_U(0x1) << US_IER_LIN_LINSTE_Pos)
+#define   US_IER_LIN_LINSTE_0_Val         _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_LINSTE_1_Val         _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_LINSTE_0         (US_IER_LIN_LINSTE_0_Val       << US_IER_LIN_LINSTE_Pos)
+#define US_IER_LIN_LINSTE_1         (US_IER_LIN_LINSTE_1_Val       << US_IER_LIN_LINSTE_Pos)
+#define US_IER_LIN_LINHTE_Pos       31           /**< \brief (US_IER_LIN) LIN Header Timeout Error Interrupt Enable */
+#define US_IER_LIN_LINHTE           (_U(0x1) << US_IER_LIN_LINHTE_Pos)
+#define   US_IER_LIN_LINHTE_0_Val         _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_LINHTE_1_Val         _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_LINHTE_0         (US_IER_LIN_LINHTE_0_Val       << US_IER_LIN_LINHTE_Pos)
+#define US_IER_LIN_LINHTE_1         (US_IER_LIN_LINHTE_1_Val       << US_IER_LIN_LINHTE_Pos)
+#define US_IER_LIN_MASK             _U(0xFE0FFFE7) /**< \brief (US_IER_LIN) MASK Register */
+
+// SPI_SLAVE mode
+#define US_IER_SPI_SLAVE_RXRDY_Pos  0            /**< \brief (US_IER_SPI_SLAVE) Receiver Ready Interrupt Enable */
+#define US_IER_SPI_SLAVE_RXRDY      (_U(0x1) << US_IER_SPI_SLAVE_RXRDY_Pos)
+#define   US_IER_SPI_SLAVE_RXRDY_0_Val    _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_RXRDY_1_Val    _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_RXRDY_0    (US_IER_SPI_SLAVE_RXRDY_0_Val  << US_IER_SPI_SLAVE_RXRDY_Pos)
+#define US_IER_SPI_SLAVE_RXRDY_1    (US_IER_SPI_SLAVE_RXRDY_1_Val  << US_IER_SPI_SLAVE_RXRDY_Pos)
+#define US_IER_SPI_SLAVE_TXRDY_Pos  1            /**< \brief (US_IER_SPI_SLAVE) Transmitter Ready Interrupt Enable */
+#define US_IER_SPI_SLAVE_TXRDY      (_U(0x1) << US_IER_SPI_SLAVE_TXRDY_Pos)
+#define   US_IER_SPI_SLAVE_TXRDY_0_Val    _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_TXRDY_1_Val    _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_TXRDY_0    (US_IER_SPI_SLAVE_TXRDY_0_Val  << US_IER_SPI_SLAVE_TXRDY_Pos)
+#define US_IER_SPI_SLAVE_TXRDY_1    (US_IER_SPI_SLAVE_TXRDY_1_Val  << US_IER_SPI_SLAVE_TXRDY_Pos)
+#define US_IER_SPI_SLAVE_RXBRK_Pos  2            /**< \brief (US_IER_SPI_SLAVE) Receiver Break Interrupt Enable */
+#define US_IER_SPI_SLAVE_RXBRK      (_U(0x1) << US_IER_SPI_SLAVE_RXBRK_Pos)
+#define   US_IER_SPI_SLAVE_RXBRK_0_Val    _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_RXBRK_1_Val    _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_RXBRK_0    (US_IER_SPI_SLAVE_RXBRK_0_Val  << US_IER_SPI_SLAVE_RXBRK_Pos)
+#define US_IER_SPI_SLAVE_RXBRK_1    (US_IER_SPI_SLAVE_RXBRK_1_Val  << US_IER_SPI_SLAVE_RXBRK_Pos)
+#define US_IER_SPI_SLAVE_OVRE_Pos   5            /**< \brief (US_IER_SPI_SLAVE) Overrun Error Interrupt Enable */
+#define US_IER_SPI_SLAVE_OVRE       (_U(0x1) << US_IER_SPI_SLAVE_OVRE_Pos)
+#define   US_IER_SPI_SLAVE_OVRE_0_Val     _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_OVRE_1_Val     _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_OVRE_0     (US_IER_SPI_SLAVE_OVRE_0_Val   << US_IER_SPI_SLAVE_OVRE_Pos)
+#define US_IER_SPI_SLAVE_OVRE_1     (US_IER_SPI_SLAVE_OVRE_1_Val   << US_IER_SPI_SLAVE_OVRE_Pos)
+#define US_IER_SPI_SLAVE_FRAME_Pos  6            /**< \brief (US_IER_SPI_SLAVE) Framing Error Interrupt Enable */
+#define US_IER_SPI_SLAVE_FRAME      (_U(0x1) << US_IER_SPI_SLAVE_FRAME_Pos)
+#define   US_IER_SPI_SLAVE_FRAME_0_Val    _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_FRAME_1_Val    _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_FRAME_0    (US_IER_SPI_SLAVE_FRAME_0_Val  << US_IER_SPI_SLAVE_FRAME_Pos)
+#define US_IER_SPI_SLAVE_FRAME_1    (US_IER_SPI_SLAVE_FRAME_1_Val  << US_IER_SPI_SLAVE_FRAME_Pos)
+#define US_IER_SPI_SLAVE_PARE_Pos   7            /**< \brief (US_IER_SPI_SLAVE) Parity Error Interrupt Enable */
+#define US_IER_SPI_SLAVE_PARE       (_U(0x1) << US_IER_SPI_SLAVE_PARE_Pos)
+#define   US_IER_SPI_SLAVE_PARE_0_Val     _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_PARE_1_Val     _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_PARE_0     (US_IER_SPI_SLAVE_PARE_0_Val   << US_IER_SPI_SLAVE_PARE_Pos)
+#define US_IER_SPI_SLAVE_PARE_1     (US_IER_SPI_SLAVE_PARE_1_Val   << US_IER_SPI_SLAVE_PARE_Pos)
+#define US_IER_SPI_SLAVE_TIMEOUT_Pos 8            /**< \brief (US_IER_SPI_SLAVE) Time-out Interrupt Enable */
+#define US_IER_SPI_SLAVE_TIMEOUT    (_U(0x1) << US_IER_SPI_SLAVE_TIMEOUT_Pos)
+#define   US_IER_SPI_SLAVE_TIMEOUT_0_Val  _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_TIMEOUT_1_Val  _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_TIMEOUT_0  (US_IER_SPI_SLAVE_TIMEOUT_0_Val << US_IER_SPI_SLAVE_TIMEOUT_Pos)
+#define US_IER_SPI_SLAVE_TIMEOUT_1  (US_IER_SPI_SLAVE_TIMEOUT_1_Val << US_IER_SPI_SLAVE_TIMEOUT_Pos)
+#define US_IER_SPI_SLAVE_TXEMPTY_Pos 9            /**< \brief (US_IER_SPI_SLAVE) Transmitter Empty Interrupt Enable */
+#define US_IER_SPI_SLAVE_TXEMPTY    (_U(0x1) << US_IER_SPI_SLAVE_TXEMPTY_Pos)
+#define   US_IER_SPI_SLAVE_TXEMPTY_0_Val  _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_TXEMPTY_1_Val  _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_TXEMPTY_0  (US_IER_SPI_SLAVE_TXEMPTY_0_Val << US_IER_SPI_SLAVE_TXEMPTY_Pos)
+#define US_IER_SPI_SLAVE_TXEMPTY_1  (US_IER_SPI_SLAVE_TXEMPTY_1_Val << US_IER_SPI_SLAVE_TXEMPTY_Pos)
+#define US_IER_SPI_SLAVE_UNRE_Pos   10           /**< \brief (US_IER_SPI_SLAVE) SPI Underrun Error Interrupt Enable */
+#define US_IER_SPI_SLAVE_UNRE       (_U(0x1) << US_IER_SPI_SLAVE_UNRE_Pos)
+#define   US_IER_SPI_SLAVE_UNRE_0_Val     _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_UNRE_1_Val     _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_UNRE_0     (US_IER_SPI_SLAVE_UNRE_0_Val   << US_IER_SPI_SLAVE_UNRE_Pos)
+#define US_IER_SPI_SLAVE_UNRE_1     (US_IER_SPI_SLAVE_UNRE_1_Val   << US_IER_SPI_SLAVE_UNRE_Pos)
+#define US_IER_SPI_SLAVE_TXBUFE_Pos 11           /**< \brief (US_IER_SPI_SLAVE) Buffer Empty Interrupt Enable */
+#define US_IER_SPI_SLAVE_TXBUFE     (_U(0x1) << US_IER_SPI_SLAVE_TXBUFE_Pos)
+#define   US_IER_SPI_SLAVE_TXBUFE_0_Val   _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_TXBUFE_1_Val   _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_TXBUFE_0   (US_IER_SPI_SLAVE_TXBUFE_0_Val << US_IER_SPI_SLAVE_TXBUFE_Pos)
+#define US_IER_SPI_SLAVE_TXBUFE_1   (US_IER_SPI_SLAVE_TXBUFE_1_Val << US_IER_SPI_SLAVE_TXBUFE_Pos)
+#define US_IER_SPI_SLAVE_RXBUFF_Pos 12           /**< \brief (US_IER_SPI_SLAVE) Buffer Full Interrupt Enable */
+#define US_IER_SPI_SLAVE_RXBUFF     (_U(0x1) << US_IER_SPI_SLAVE_RXBUFF_Pos)
+#define   US_IER_SPI_SLAVE_RXBUFF_0_Val   _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_RXBUFF_1_Val   _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_RXBUFF_0   (US_IER_SPI_SLAVE_RXBUFF_0_Val << US_IER_SPI_SLAVE_RXBUFF_Pos)
+#define US_IER_SPI_SLAVE_RXBUFF_1   (US_IER_SPI_SLAVE_RXBUFF_1_Val << US_IER_SPI_SLAVE_RXBUFF_Pos)
+#define US_IER_SPI_SLAVE_NACK_Pos   13           /**< \brief (US_IER_SPI_SLAVE) Non Acknowledge Interrupt Enable */
+#define US_IER_SPI_SLAVE_NACK       (_U(0x1) << US_IER_SPI_SLAVE_NACK_Pos)
+#define   US_IER_SPI_SLAVE_NACK_0_Val     _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_NACK_1_Val     _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_NACK_0     (US_IER_SPI_SLAVE_NACK_0_Val   << US_IER_SPI_SLAVE_NACK_Pos)
+#define US_IER_SPI_SLAVE_NACK_1     (US_IER_SPI_SLAVE_NACK_1_Val   << US_IER_SPI_SLAVE_NACK_Pos)
+#define US_IER_SPI_SLAVE_RIIC_Pos   16           /**< \brief (US_IER_SPI_SLAVE) Ring Indicator Input Change Enable */
+#define US_IER_SPI_SLAVE_RIIC       (_U(0x1) << US_IER_SPI_SLAVE_RIIC_Pos)
+#define   US_IER_SPI_SLAVE_RIIC_0_Val     _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_RIIC_1_Val     _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_RIIC_0     (US_IER_SPI_SLAVE_RIIC_0_Val   << US_IER_SPI_SLAVE_RIIC_Pos)
+#define US_IER_SPI_SLAVE_RIIC_1     (US_IER_SPI_SLAVE_RIIC_1_Val   << US_IER_SPI_SLAVE_RIIC_Pos)
+#define US_IER_SPI_SLAVE_DSRIC_Pos  17           /**< \brief (US_IER_SPI_SLAVE) Data Set Ready Input Change Enable */
+#define US_IER_SPI_SLAVE_DSRIC      (_U(0x1) << US_IER_SPI_SLAVE_DSRIC_Pos)
+#define   US_IER_SPI_SLAVE_DSRIC_0_Val    _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_DSRIC_1_Val    _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_DSRIC_0    (US_IER_SPI_SLAVE_DSRIC_0_Val  << US_IER_SPI_SLAVE_DSRIC_Pos)
+#define US_IER_SPI_SLAVE_DSRIC_1    (US_IER_SPI_SLAVE_DSRIC_1_Val  << US_IER_SPI_SLAVE_DSRIC_Pos)
+#define US_IER_SPI_SLAVE_DCDIC_Pos  18           /**< \brief (US_IER_SPI_SLAVE) Data Carrier Detect Input Change Interrupt Enable */
+#define US_IER_SPI_SLAVE_DCDIC      (_U(0x1) << US_IER_SPI_SLAVE_DCDIC_Pos)
+#define   US_IER_SPI_SLAVE_DCDIC_0_Val    _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_DCDIC_1_Val    _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_DCDIC_0    (US_IER_SPI_SLAVE_DCDIC_0_Val  << US_IER_SPI_SLAVE_DCDIC_Pos)
+#define US_IER_SPI_SLAVE_DCDIC_1    (US_IER_SPI_SLAVE_DCDIC_1_Val  << US_IER_SPI_SLAVE_DCDIC_Pos)
+#define US_IER_SPI_SLAVE_CTSIC_Pos  19           /**< \brief (US_IER_SPI_SLAVE) Clear to Send Input Change Interrupt Enable */
+#define US_IER_SPI_SLAVE_CTSIC      (_U(0x1) << US_IER_SPI_SLAVE_CTSIC_Pos)
+#define   US_IER_SPI_SLAVE_CTSIC_0_Val    _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_CTSIC_1_Val    _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_CTSIC_0    (US_IER_SPI_SLAVE_CTSIC_0_Val  << US_IER_SPI_SLAVE_CTSIC_Pos)
+#define US_IER_SPI_SLAVE_CTSIC_1    (US_IER_SPI_SLAVE_CTSIC_1_Val  << US_IER_SPI_SLAVE_CTSIC_Pos)
+#define US_IER_SPI_SLAVE_MASK       _U(0x000F3FE7) /**< \brief (US_IER_SPI_SLAVE) MASK Register */
+
+// USART mode
+#define US_IER_USART_RXRDY_Pos      0            /**< \brief (US_IER_USART) Receiver Ready Interrupt Enable */
+#define US_IER_USART_RXRDY          (_U(0x1) << US_IER_USART_RXRDY_Pos)
+#define   US_IER_USART_RXRDY_0_Val        _U(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_RXRDY_1_Val        _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_RXRDY_0        (US_IER_USART_RXRDY_0_Val      << US_IER_USART_RXRDY_Pos)
+#define US_IER_USART_RXRDY_1        (US_IER_USART_RXRDY_1_Val      << US_IER_USART_RXRDY_Pos)
+#define US_IER_USART_TXRDY_Pos      1            /**< \brief (US_IER_USART) Transmitter Ready Interrupt Enable */
+#define US_IER_USART_TXRDY          (_U(0x1) << US_IER_USART_TXRDY_Pos)
+#define   US_IER_USART_TXRDY_0_Val        _U(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_TXRDY_1_Val        _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_TXRDY_0        (US_IER_USART_TXRDY_0_Val      << US_IER_USART_TXRDY_Pos)
+#define US_IER_USART_TXRDY_1        (US_IER_USART_TXRDY_1_Val      << US_IER_USART_TXRDY_Pos)
+#define US_IER_USART_RXBRK_Pos      2            /**< \brief (US_IER_USART) Receiver Break Interrupt Enable */
+#define US_IER_USART_RXBRK          (_U(0x1) << US_IER_USART_RXBRK_Pos)
+#define   US_IER_USART_RXBRK_0_Val        _U(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_RXBRK_1_Val        _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_RXBRK_0        (US_IER_USART_RXBRK_0_Val      << US_IER_USART_RXBRK_Pos)
+#define US_IER_USART_RXBRK_1        (US_IER_USART_RXBRK_1_Val      << US_IER_USART_RXBRK_Pos)
+#define US_IER_USART_OVRE_Pos       5            /**< \brief (US_IER_USART) Overrun Error Interrupt Enable */
+#define US_IER_USART_OVRE           (_U(0x1) << US_IER_USART_OVRE_Pos)
+#define   US_IER_USART_OVRE_0_Val         _U(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_OVRE_1_Val         _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_OVRE_0         (US_IER_USART_OVRE_0_Val       << US_IER_USART_OVRE_Pos)
+#define US_IER_USART_OVRE_1         (US_IER_USART_OVRE_1_Val       << US_IER_USART_OVRE_Pos)
+#define US_IER_USART_FRAME_Pos      6            /**< \brief (US_IER_USART) Framing Error Interrupt Enable */
+#define US_IER_USART_FRAME          (_U(0x1) << US_IER_USART_FRAME_Pos)
+#define   US_IER_USART_FRAME_0_Val        _U(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_FRAME_1_Val        _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_FRAME_0        (US_IER_USART_FRAME_0_Val      << US_IER_USART_FRAME_Pos)
+#define US_IER_USART_FRAME_1        (US_IER_USART_FRAME_1_Val      << US_IER_USART_FRAME_Pos)
+#define US_IER_USART_PARE_Pos       7            /**< \brief (US_IER_USART) Parity Error Interrupt Enable */
+#define US_IER_USART_PARE           (_U(0x1) << US_IER_USART_PARE_Pos)
+#define   US_IER_USART_PARE_0_Val         _U(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_PARE_1_Val         _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_PARE_0         (US_IER_USART_PARE_0_Val       << US_IER_USART_PARE_Pos)
+#define US_IER_USART_PARE_1         (US_IER_USART_PARE_1_Val       << US_IER_USART_PARE_Pos)
+#define US_IER_USART_TIMEOUT_Pos    8            /**< \brief (US_IER_USART) Time-out Interrupt Enable */
+#define US_IER_USART_TIMEOUT        (_U(0x1) << US_IER_USART_TIMEOUT_Pos)
+#define   US_IER_USART_TIMEOUT_0_Val      _U(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_TIMEOUT_1_Val      _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_TIMEOUT_0      (US_IER_USART_TIMEOUT_0_Val    << US_IER_USART_TIMEOUT_Pos)
+#define US_IER_USART_TIMEOUT_1      (US_IER_USART_TIMEOUT_1_Val    << US_IER_USART_TIMEOUT_Pos)
+#define US_IER_USART_TXEMPTY_Pos    9            /**< \brief (US_IER_USART) Transmitter Empty Interrupt Enable */
+#define US_IER_USART_TXEMPTY        (_U(0x1) << US_IER_USART_TXEMPTY_Pos)
+#define   US_IER_USART_TXEMPTY_0_Val      _U(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_TXEMPTY_1_Val      _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_TXEMPTY_0      (US_IER_USART_TXEMPTY_0_Val    << US_IER_USART_TXEMPTY_Pos)
+#define US_IER_USART_TXEMPTY_1      (US_IER_USART_TXEMPTY_1_Val    << US_IER_USART_TXEMPTY_Pos)
+#define US_IER_USART_ITER_Pos       10           /**< \brief (US_IER_USART) Iteration Interrupt Enable */
+#define US_IER_USART_ITER           (_U(0x1) << US_IER_USART_ITER_Pos)
+#define   US_IER_USART_ITER_0_Val         _U(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_ITER_1_Val         _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_ITER_0         (US_IER_USART_ITER_0_Val       << US_IER_USART_ITER_Pos)
+#define US_IER_USART_ITER_1         (US_IER_USART_ITER_1_Val       << US_IER_USART_ITER_Pos)
+#define US_IER_USART_TXBUFE_Pos     11           /**< \brief (US_IER_USART) Buffer Empty Interrupt Enable */
+#define US_IER_USART_TXBUFE         (_U(0x1) << US_IER_USART_TXBUFE_Pos)
+#define   US_IER_USART_TXBUFE_0_Val       _U(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_TXBUFE_1_Val       _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_TXBUFE_0       (US_IER_USART_TXBUFE_0_Val     << US_IER_USART_TXBUFE_Pos)
+#define US_IER_USART_TXBUFE_1       (US_IER_USART_TXBUFE_1_Val     << US_IER_USART_TXBUFE_Pos)
+#define US_IER_USART_RXBUFF_Pos     12           /**< \brief (US_IER_USART) Buffer Full Interrupt Enable */
+#define US_IER_USART_RXBUFF         (_U(0x1) << US_IER_USART_RXBUFF_Pos)
+#define   US_IER_USART_RXBUFF_0_Val       _U(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_RXBUFF_1_Val       _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_RXBUFF_0       (US_IER_USART_RXBUFF_0_Val     << US_IER_USART_RXBUFF_Pos)
+#define US_IER_USART_RXBUFF_1       (US_IER_USART_RXBUFF_1_Val     << US_IER_USART_RXBUFF_Pos)
+#define US_IER_USART_NACK_Pos       13           /**< \brief (US_IER_USART) Non Acknowledge Interrupt Enable */
+#define US_IER_USART_NACK           (_U(0x1) << US_IER_USART_NACK_Pos)
+#define   US_IER_USART_NACK_0_Val         _U(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_NACK_1_Val         _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_NACK_0         (US_IER_USART_NACK_0_Val       << US_IER_USART_NACK_Pos)
+#define US_IER_USART_NACK_1         (US_IER_USART_NACK_1_Val       << US_IER_USART_NACK_Pos)
+#define US_IER_USART_RIIC_Pos       16           /**< \brief (US_IER_USART) Ring Indicator Input Change Enable */
+#define US_IER_USART_RIIC           (_U(0x1) << US_IER_USART_RIIC_Pos)
+#define   US_IER_USART_RIIC_0_Val         _U(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_RIIC_1_Val         _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_RIIC_0         (US_IER_USART_RIIC_0_Val       << US_IER_USART_RIIC_Pos)
+#define US_IER_USART_RIIC_1         (US_IER_USART_RIIC_1_Val       << US_IER_USART_RIIC_Pos)
+#define US_IER_USART_DSRIC_Pos      17           /**< \brief (US_IER_USART) Data Set Ready Input Change Enable */
+#define US_IER_USART_DSRIC          (_U(0x1) << US_IER_USART_DSRIC_Pos)
+#define   US_IER_USART_DSRIC_0_Val        _U(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_DSRIC_1_Val        _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_DSRIC_0        (US_IER_USART_DSRIC_0_Val      << US_IER_USART_DSRIC_Pos)
+#define US_IER_USART_DSRIC_1        (US_IER_USART_DSRIC_1_Val      << US_IER_USART_DSRIC_Pos)
+#define US_IER_USART_DCDIC_Pos      18           /**< \brief (US_IER_USART) Data Carrier Detect Input Change Interrupt Enable */
+#define US_IER_USART_DCDIC          (_U(0x1) << US_IER_USART_DCDIC_Pos)
+#define   US_IER_USART_DCDIC_0_Val        _U(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_DCDIC_1_Val        _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_DCDIC_0        (US_IER_USART_DCDIC_0_Val      << US_IER_USART_DCDIC_Pos)
+#define US_IER_USART_DCDIC_1        (US_IER_USART_DCDIC_1_Val      << US_IER_USART_DCDIC_Pos)
+#define US_IER_USART_CTSIC_Pos      19           /**< \brief (US_IER_USART) Clear to Send Input Change Interrupt Enable */
+#define US_IER_USART_CTSIC          (_U(0x1) << US_IER_USART_CTSIC_Pos)
+#define   US_IER_USART_CTSIC_0_Val        _U(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_CTSIC_1_Val        _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_CTSIC_0        (US_IER_USART_CTSIC_0_Val      << US_IER_USART_CTSIC_Pos)
+#define US_IER_USART_CTSIC_1        (US_IER_USART_CTSIC_1_Val      << US_IER_USART_CTSIC_Pos)
+#define US_IER_USART_MANE_Pos       20           /**< \brief (US_IER_USART) Manchester Error Interrupt Enable */
+#define US_IER_USART_MANE           (_U(0x1) << US_IER_USART_MANE_Pos)
+#define US_IER_USART_MANEA_Pos      24           /**< \brief (US_IER_USART) Manchester Error Interrupt Enable */
+#define US_IER_USART_MANEA          (_U(0x1) << US_IER_USART_MANEA_Pos)
+#define   US_IER_USART_MANEA_0_Val        _U(0x0)   /**< \brief (US_IER_USART) No effect */
+#define   US_IER_USART_MANEA_1_Val        _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_MANEA_0        (US_IER_USART_MANEA_0_Val      << US_IER_USART_MANEA_Pos)
+#define US_IER_USART_MANEA_1        (US_IER_USART_MANEA_1_Val      << US_IER_USART_MANEA_Pos)
+#define US_IER_USART_MASK           _U(0x011F3FE7) /**< \brief (US_IER_USART) MASK Register */
+
+// Any mode
+#define US_IER_RXRDY_Pos            0            /**< \brief (US_IER) Receiver Ready Interrupt Enable */
+#define US_IER_RXRDY                (_U(0x1) << US_IER_RXRDY_Pos)
+#define   US_IER_RXRDY_0_Val              _U(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_RXRDY_1_Val              _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_RXRDY_0              (US_IER_RXRDY_0_Val            << US_IER_RXRDY_Pos)
+#define US_IER_RXRDY_1              (US_IER_RXRDY_1_Val            << US_IER_RXRDY_Pos)
+#define US_IER_TXRDY_Pos            1            /**< \brief (US_IER) Transmitter Ready Interrupt Enable */
+#define US_IER_TXRDY                (_U(0x1) << US_IER_TXRDY_Pos)
+#define   US_IER_TXRDY_0_Val              _U(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_TXRDY_1_Val              _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_TXRDY_0              (US_IER_TXRDY_0_Val            << US_IER_TXRDY_Pos)
+#define US_IER_TXRDY_1              (US_IER_TXRDY_1_Val            << US_IER_TXRDY_Pos)
+#define US_IER_RXBRK_Pos            2            /**< \brief (US_IER) Receiver Break Interrupt Enable */
+#define US_IER_RXBRK                (_U(0x1) << US_IER_RXBRK_Pos)
+#define   US_IER_RXBRK_0_Val              _U(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_RXBRK_1_Val              _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_RXBRK_0              (US_IER_RXBRK_0_Val            << US_IER_RXBRK_Pos)
+#define US_IER_RXBRK_1              (US_IER_RXBRK_1_Val            << US_IER_RXBRK_Pos)
+#define US_IER_OVRE_Pos             5            /**< \brief (US_IER) Overrun Error Interrupt Enable */
+#define US_IER_OVRE                 (_U(0x1) << US_IER_OVRE_Pos)
+#define   US_IER_OVRE_0_Val               _U(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_OVRE_1_Val               _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_OVRE_0               (US_IER_OVRE_0_Val             << US_IER_OVRE_Pos)
+#define US_IER_OVRE_1               (US_IER_OVRE_1_Val             << US_IER_OVRE_Pos)
+#define US_IER_FRAME_Pos            6            /**< \brief (US_IER) Framing Error Interrupt Enable */
+#define US_IER_FRAME                (_U(0x1) << US_IER_FRAME_Pos)
+#define   US_IER_FRAME_0_Val              _U(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_FRAME_1_Val              _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_FRAME_0              (US_IER_FRAME_0_Val            << US_IER_FRAME_Pos)
+#define US_IER_FRAME_1              (US_IER_FRAME_1_Val            << US_IER_FRAME_Pos)
+#define US_IER_PARE_Pos             7            /**< \brief (US_IER) Parity Error Interrupt Enable */
+#define US_IER_PARE                 (_U(0x1) << US_IER_PARE_Pos)
+#define   US_IER_PARE_0_Val               _U(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_PARE_1_Val               _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_PARE_0               (US_IER_PARE_0_Val             << US_IER_PARE_Pos)
+#define US_IER_PARE_1               (US_IER_PARE_1_Val             << US_IER_PARE_Pos)
+#define US_IER_TIMEOUT_Pos          8            /**< \brief (US_IER) Time-out Interrupt Enable */
+#define US_IER_TIMEOUT              (_U(0x1) << US_IER_TIMEOUT_Pos)
+#define   US_IER_TIMEOUT_0_Val            _U(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_TIMEOUT_1_Val            _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_TIMEOUT_0            (US_IER_TIMEOUT_0_Val          << US_IER_TIMEOUT_Pos)
+#define US_IER_TIMEOUT_1            (US_IER_TIMEOUT_1_Val          << US_IER_TIMEOUT_Pos)
+#define US_IER_TXEMPTY_Pos          9            /**< \brief (US_IER) Transmitter Empty Interrupt Enable */
+#define US_IER_TXEMPTY              (_U(0x1) << US_IER_TXEMPTY_Pos)
+#define   US_IER_TXEMPTY_0_Val            _U(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_TXEMPTY_1_Val            _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_TXEMPTY_0            (US_IER_TXEMPTY_0_Val          << US_IER_TXEMPTY_Pos)
+#define US_IER_TXEMPTY_1            (US_IER_TXEMPTY_1_Val          << US_IER_TXEMPTY_Pos)
+#define US_IER_ITER_Pos             10           /**< \brief (US_IER) Iteration Interrupt Enable */
+#define US_IER_ITER                 (_U(0x1) << US_IER_ITER_Pos)
+#define   US_IER_ITER_0_Val               _U(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_ITER_1_Val               _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_ITER_0               (US_IER_ITER_0_Val             << US_IER_ITER_Pos)
+#define US_IER_ITER_1               (US_IER_ITER_1_Val             << US_IER_ITER_Pos)
+#define US_IER_UNRE_Pos             10           /**< \brief (US_IER) SPI Underrun Error Interrupt Enable */
+#define US_IER_UNRE                 (_U(0x1) << US_IER_UNRE_Pos)
+#define   US_IER_UNRE_0_Val               _U(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_UNRE_1_Val               _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_UNRE_0               (US_IER_UNRE_0_Val             << US_IER_UNRE_Pos)
+#define US_IER_UNRE_1               (US_IER_UNRE_1_Val             << US_IER_UNRE_Pos)
+#define US_IER_ITER_Pos             10           /**< \brief (US_IER) Iteration Interrupt Enable */
+#define US_IER_ITER                 (_U(0x1) << US_IER_ITER_Pos)
+#define   US_IER_ITER_0_Val               _U(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_ITER_1_Val               _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_ITER_0               (US_IER_ITER_0_Val             << US_IER_ITER_Pos)
+#define US_IER_ITER_1               (US_IER_ITER_1_Val             << US_IER_ITER_Pos)
+#define US_IER_TXBUFE_Pos           11           /**< \brief (US_IER) Buffer Empty Interrupt Enable */
+#define US_IER_TXBUFE               (_U(0x1) << US_IER_TXBUFE_Pos)
+#define   US_IER_TXBUFE_0_Val             _U(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_TXBUFE_1_Val             _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_TXBUFE_0             (US_IER_TXBUFE_0_Val           << US_IER_TXBUFE_Pos)
+#define US_IER_TXBUFE_1             (US_IER_TXBUFE_1_Val           << US_IER_TXBUFE_Pos)
+#define US_IER_RXBUFF_Pos           12           /**< \brief (US_IER) Buffer Full Interrupt Enable */
+#define US_IER_RXBUFF               (_U(0x1) << US_IER_RXBUFF_Pos)
+#define   US_IER_RXBUFF_0_Val             _U(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_RXBUFF_1_Val             _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_RXBUFF_0             (US_IER_RXBUFF_0_Val           << US_IER_RXBUFF_Pos)
+#define US_IER_RXBUFF_1             (US_IER_RXBUFF_1_Val           << US_IER_RXBUFF_Pos)
+#define US_IER_NACK_Pos             13           /**< \brief (US_IER) Non Acknowledge  or LIN Break Sent or LIN Break Received Interrupt Enable */
+#define US_IER_NACK                 (_U(0x1) << US_IER_NACK_Pos)
+#define   US_IER_NACK_0_Val               _U(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_NACK_1_Val               _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_NACK_0               (US_IER_NACK_0_Val             << US_IER_NACK_Pos)
+#define US_IER_NACK_1               (US_IER_NACK_1_Val             << US_IER_NACK_Pos)
+#define US_IER_LINID_Pos            14           /**< \brief (US_IER) LIN Identifier Sent or LIN Identifier Received Interrupt Enable */
+#define US_IER_LINID                (_U(0x1) << US_IER_LINID_Pos)
+#define US_IER_LINTC_Pos            15           /**< \brief (US_IER) LIN Transfer Conpleted Interrupt Enable */
+#define US_IER_LINTC                (_U(0x1) << US_IER_LINTC_Pos)
+#define US_IER_RIIC_Pos             16           /**< \brief (US_IER) Ring Indicator Input Change Enable */
+#define US_IER_RIIC                 (_U(0x1) << US_IER_RIIC_Pos)
+#define   US_IER_RIIC_0_Val               _U(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_RIIC_1_Val               _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_RIIC_0               (US_IER_RIIC_0_Val             << US_IER_RIIC_Pos)
+#define US_IER_RIIC_1               (US_IER_RIIC_1_Val             << US_IER_RIIC_Pos)
+#define US_IER_DSRIC_Pos            17           /**< \brief (US_IER) Data Set Ready Input Change Enable */
+#define US_IER_DSRIC                (_U(0x1) << US_IER_DSRIC_Pos)
+#define   US_IER_DSRIC_0_Val              _U(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_DSRIC_1_Val              _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_DSRIC_0              (US_IER_DSRIC_0_Val            << US_IER_DSRIC_Pos)
+#define US_IER_DSRIC_1              (US_IER_DSRIC_1_Val            << US_IER_DSRIC_Pos)
+#define US_IER_DCDIC_Pos            18           /**< \brief (US_IER) Data Carrier Detect Input Change Interrupt Enable */
+#define US_IER_DCDIC                (_U(0x1) << US_IER_DCDIC_Pos)
+#define   US_IER_DCDIC_0_Val              _U(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_DCDIC_1_Val              _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_DCDIC_0              (US_IER_DCDIC_0_Val            << US_IER_DCDIC_Pos)
+#define US_IER_DCDIC_1              (US_IER_DCDIC_1_Val            << US_IER_DCDIC_Pos)
+#define US_IER_CTSIC_Pos            19           /**< \brief (US_IER) Clear to Send Input Change Interrupt Enable */
+#define US_IER_CTSIC                (_U(0x1) << US_IER_CTSIC_Pos)
+#define   US_IER_CTSIC_0_Val              _U(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_CTSIC_1_Val              _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_CTSIC_0              (US_IER_CTSIC_0_Val            << US_IER_CTSIC_Pos)
+#define US_IER_CTSIC_1              (US_IER_CTSIC_1_Val            << US_IER_CTSIC_Pos)
+#define US_IER_MANE_Pos             20           /**< \brief (US_IER) Manchester Error Interrupt Enable */
+#define US_IER_MANE                 (_U(0x1) << US_IER_MANE_Pos)
+#define US_IER_MANEA_Pos            24           /**< \brief (US_IER) Manchester Error Interrupt Enable */
+#define US_IER_MANEA                (_U(0x1) << US_IER_MANEA_Pos)
+#define   US_IER_MANEA_0_Val              _U(0x0)   /**< \brief (US_IER) No effect */
+#define   US_IER_MANEA_1_Val              _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_MANEA_0              (US_IER_MANEA_0_Val            << US_IER_MANEA_Pos)
+#define US_IER_MANEA_1              (US_IER_MANEA_1_Val            << US_IER_MANEA_Pos)
+#define US_IER_LINBE_Pos            25           /**< \brief (US_IER) LIN Bus Error Interrupt Enable */
+#define US_IER_LINBE                (_U(0x1) << US_IER_LINBE_Pos)
+#define US_IER_LINISFE_Pos          26           /**< \brief (US_IER) LIN Inconsistent Synch Field Error Interrupt Enable */
+#define US_IER_LINISFE              (_U(0x1) << US_IER_LINISFE_Pos)
+#define US_IER_LINIPE_Pos           27           /**< \brief (US_IER) LIN Identifier Parity Interrupt Enable */
+#define US_IER_LINIPE               (_U(0x1) << US_IER_LINIPE_Pos)
+#define US_IER_LINCE_Pos            28           /**< \brief (US_IER) LIN Checksum Error Interrupt Enable */
+#define US_IER_LINCE                (_U(0x1) << US_IER_LINCE_Pos)
+#define US_IER_LINSNRE_Pos          29           /**< \brief (US_IER) LIN Slave Not Responding Error Interrupt Enable */
+#define US_IER_LINSNRE              (_U(0x1) << US_IER_LINSNRE_Pos)
+#define US_IER_LINSTE_Pos           30           /**< \brief (US_IER) LIN Synch Tolerance Error Interrupt Enable */
+#define US_IER_LINSTE               (_U(0x1) << US_IER_LINSTE_Pos)
+#define   US_IER_LINSTE_0_Val             _U(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_LINSTE_1_Val             _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_LINSTE_0             (US_IER_LINSTE_0_Val           << US_IER_LINSTE_Pos)
+#define US_IER_LINSTE_1             (US_IER_LINSTE_1_Val           << US_IER_LINSTE_Pos)
+#define US_IER_LINHTE_Pos           31           /**< \brief (US_IER) LIN Header Timeout Error Interrupt Enable */
+#define US_IER_LINHTE               (_U(0x1) << US_IER_LINHTE_Pos)
+#define   US_IER_LINHTE_0_Val             _U(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_LINHTE_1_Val             _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_LINHTE_0             (US_IER_LINHTE_0_Val           << US_IER_LINHTE_Pos)
+#define US_IER_LINHTE_1             (US_IER_LINHTE_1_Val           << US_IER_LINHTE_Pos)
+#define US_IER_MASK                 _U(0xFF1FFFE7) /**< \brief (US_IER) MASK Register */
+
+/* -------- US_IDR : (USART Offset: 0x0C) ( /W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct { // LIN mode
+    uint32_t RXRDY:1;          /*!< bit:      0  Receiver Ready Interrupt Disable   */
+    uint32_t TXRDY:1;          /*!< bit:      1  Transmitter Ready Interrupt Disable */
+    uint32_t RXBRK:1;          /*!< bit:      2  Receiver Break Interrupt Disable   */
+    uint32_t :2;               /*!< bit:  3.. 4  Reserved                           */
+    uint32_t OVRE:1;           /*!< bit:      5  Overrun Error Interrupt Disable    */
+    uint32_t FRAME:1;          /*!< bit:      6  Framing Error Interrupt Disable    */
+    uint32_t PARE:1;           /*!< bit:      7  Parity Error Interrupt Disable     */
+    uint32_t TIMEOUT:1;        /*!< bit:      8  Time-out Interrupt Disable         */
+    uint32_t TXEMPTY:1;        /*!< bit:      9  Transmitter Empty Interrupt Disable */
+    uint32_t ITER:1;           /*!< bit:     10  Iteration Interrupt Disable        */
+    uint32_t TXBUFE:1;         /*!< bit:     11  Buffer Empty Interrupt Disable     */
+    uint32_t RXBUFF:1;         /*!< bit:     12  Buffer Full Interrupt Disable      */
+    uint32_t NACK:1;           /*!< bit:     13  Non Acknowledge  or LIN Break Sent or LIN Break Received Interrupt Disable */
+    uint32_t LINID:1;          /*!< bit:     14  LIN Identifier Sent or LIN Identifier Received Interrupt Disable */
+    uint32_t LINTC:1;          /*!< bit:     15  LIN Transfer Conpleted Interrupt Disable */
+    uint32_t RIIC:1;           /*!< bit:     16  Ring Indicator Input Change Disable */
+    uint32_t DSRIC:1;          /*!< bit:     17  Data Set Ready Input Change Disable */
+    uint32_t DCDIC:1;          /*!< bit:     18  Data Carrier Detect Input Change Interrupt Disable */
+    uint32_t CTSIC:1;          /*!< bit:     19  Clear to Send Input Change Interrupt Disable */
+    uint32_t :5;               /*!< bit: 20..24  Reserved                           */
+    uint32_t LINBE:1;          /*!< bit:     25  LIN Bus Error Interrupt Disable    */
+    uint32_t LINISFE:1;        /*!< bit:     26  LIN Inconsistent Synch Field Error Interrupt Disable */
+    uint32_t LINIPE:1;         /*!< bit:     27  LIN Identifier Parity Interrupt Disable */
+    uint32_t LINCE:1;          /*!< bit:     28  LIN Checksum Error Interrupt Disable */
+    uint32_t LINSNRE:1;        /*!< bit:     29  LIN Slave Not Responding Error Interrupt Disable */
+    uint32_t LINSTE:1;         /*!< bit:     30  LIN Synch Tolerance Error Interrupt Disable */
+    uint32_t LINHTE:1;         /*!< bit:     31  LIN Header Timeout Error Interrupt Disable */
+  } LIN;                       /*!< Structure used for LIN                          */
+  struct { // SPI_SLAVE mode
+    uint32_t RXRDY:1;          /*!< bit:      0  Receiver Ready Interrupt Disable   */
+    uint32_t TXRDY:1;          /*!< bit:      1  Transmitter Ready Interrupt Disable */
+    uint32_t RXBRK:1;          /*!< bit:      2  Receiver Break Interrupt Disable   */
+    uint32_t :2;               /*!< bit:  3.. 4  Reserved                           */
+    uint32_t OVRE:1;           /*!< bit:      5  Overrun Error Interrupt Disable    */
+    uint32_t FRAME:1;          /*!< bit:      6  Framing Error Interrupt Disable    */
+    uint32_t PARE:1;           /*!< bit:      7  Parity Error Interrupt Disable     */
+    uint32_t TIMEOUT:1;        /*!< bit:      8  Time-out Interrupt Disable         */
+    uint32_t TXEMPTY:1;        /*!< bit:      9  Transmitter Empty Interrupt Disable */
+    uint32_t UNRE:1;           /*!< bit:     10  SPI Underrun Error Interrupt Disable */
+    uint32_t TXBUFE:1;         /*!< bit:     11  Buffer Empty Interrupt Disable     */
+    uint32_t RXBUFF:1;         /*!< bit:     12  Buffer Full Interrupt Disable      */
+    uint32_t NACK:1;           /*!< bit:     13  Non Acknowledge Interrupt Disable  */
+    uint32_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint32_t RIIC:1;           /*!< bit:     16  Ring Indicator Input Change Disable */
+    uint32_t DSRIC:1;          /*!< bit:     17  Data Set Ready Input Change Disable */
+    uint32_t DCDIC:1;          /*!< bit:     18  Data Carrier Detect Input Change Interrupt Disable */
+    uint32_t CTSIC:1;          /*!< bit:     19  Clear to Send Input Change Interrupt Disable */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } SPI_SLAVE;                 /*!< Structure used for SPI_SLAVE                    */
+  struct { // USART mode
+    uint32_t RXRDY:1;          /*!< bit:      0  Receiver Ready Interrupt Disable   */
+    uint32_t TXRDY:1;          /*!< bit:      1  Transmitter Ready Interrupt Disable */
+    uint32_t RXBRK:1;          /*!< bit:      2  Receiver Break Interrupt Disable   */
+    uint32_t :2;               /*!< bit:  3.. 4  Reserved                           */
+    uint32_t OVRE:1;           /*!< bit:      5  Overrun Error Interrupt Disable    */
+    uint32_t FRAME:1;          /*!< bit:      6  Framing Error Interrupt Disable    */
+    uint32_t PARE:1;           /*!< bit:      7  Parity Error Interrupt Disable     */
+    uint32_t TIMEOUT:1;        /*!< bit:      8  Time-out Interrupt Disable         */
+    uint32_t TXEMPTY:1;        /*!< bit:      9  Transmitter Empty Interrupt Disable */
+    uint32_t ITER:1;           /*!< bit:     10  Iteration Interrupt Disable        */
+    uint32_t TXBUFE:1;         /*!< bit:     11  Buffer Empty Interrupt Disable     */
+    uint32_t RXBUFF:1;         /*!< bit:     12  Buffer Full Interrupt Disable      */
+    uint32_t NACK:1;           /*!< bit:     13  Non Acknowledge Interrupt Disable  */
+    uint32_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint32_t RIIC:1;           /*!< bit:     16  Ring Indicator Input Change Disable */
+    uint32_t DSRIC:1;          /*!< bit:     17  Data Set Ready Input Change Disable */
+    uint32_t DCDIC:1;          /*!< bit:     18  Data Carrier Detect Input Change Interrupt Disable */
+    uint32_t CTSIC:1;          /*!< bit:     19  Clear to Send Input Change Interrupt Disable */
+    uint32_t MANE:1;           /*!< bit:     20  Manchester Error Interrupt Disable */
+    uint32_t :3;               /*!< bit: 21..23  Reserved                           */
+    uint32_t MANEA:1;          /*!< bit:     24  Manchester Error Interrupt Disable */
+    uint32_t :7;               /*!< bit: 25..31  Reserved                           */
+  } USART;                     /*!< Structure used for USART                        */
+  uint32_t reg;                /*!< Type      used for register access              */
+} US_IDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_IDR_OFFSET               0x0C         /**< \brief (US_IDR offset) Interrupt Disable Register */
+#define US_IDR_RESETVALUE           _U(0x00000000); /**< \brief (US_IDR reset_value) Interrupt Disable Register */
+
+// LIN mode
+#define US_IDR_LIN_RXRDY_Pos        0            /**< \brief (US_IDR_LIN) Receiver Ready Interrupt Disable */
+#define US_IDR_LIN_RXRDY            (_U(0x1) << US_IDR_LIN_RXRDY_Pos)
+#define   US_IDR_LIN_RXRDY_0_Val          _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_RXRDY_1_Val          _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_RXRDY_0          (US_IDR_LIN_RXRDY_0_Val        << US_IDR_LIN_RXRDY_Pos)
+#define US_IDR_LIN_RXRDY_1          (US_IDR_LIN_RXRDY_1_Val        << US_IDR_LIN_RXRDY_Pos)
+#define US_IDR_LIN_TXRDY_Pos        1            /**< \brief (US_IDR_LIN) Transmitter Ready Interrupt Disable */
+#define US_IDR_LIN_TXRDY            (_U(0x1) << US_IDR_LIN_TXRDY_Pos)
+#define   US_IDR_LIN_TXRDY_0_Val          _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_TXRDY_1_Val          _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_TXRDY_0          (US_IDR_LIN_TXRDY_0_Val        << US_IDR_LIN_TXRDY_Pos)
+#define US_IDR_LIN_TXRDY_1          (US_IDR_LIN_TXRDY_1_Val        << US_IDR_LIN_TXRDY_Pos)
+#define US_IDR_LIN_RXBRK_Pos        2            /**< \brief (US_IDR_LIN) Receiver Break Interrupt Disable */
+#define US_IDR_LIN_RXBRK            (_U(0x1) << US_IDR_LIN_RXBRK_Pos)
+#define   US_IDR_LIN_RXBRK_0_Val          _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_RXBRK_1_Val          _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_RXBRK_0          (US_IDR_LIN_RXBRK_0_Val        << US_IDR_LIN_RXBRK_Pos)
+#define US_IDR_LIN_RXBRK_1          (US_IDR_LIN_RXBRK_1_Val        << US_IDR_LIN_RXBRK_Pos)
+#define US_IDR_LIN_OVRE_Pos         5            /**< \brief (US_IDR_LIN) Overrun Error Interrupt Disable */
+#define US_IDR_LIN_OVRE             (_U(0x1) << US_IDR_LIN_OVRE_Pos)
+#define   US_IDR_LIN_OVRE_0_Val           _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_OVRE_1_Val           _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_OVRE_0           (US_IDR_LIN_OVRE_0_Val         << US_IDR_LIN_OVRE_Pos)
+#define US_IDR_LIN_OVRE_1           (US_IDR_LIN_OVRE_1_Val         << US_IDR_LIN_OVRE_Pos)
+#define US_IDR_LIN_FRAME_Pos        6            /**< \brief (US_IDR_LIN) Framing Error Interrupt Disable */
+#define US_IDR_LIN_FRAME            (_U(0x1) << US_IDR_LIN_FRAME_Pos)
+#define   US_IDR_LIN_FRAME_0_Val          _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_FRAME_1_Val          _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_FRAME_0          (US_IDR_LIN_FRAME_0_Val        << US_IDR_LIN_FRAME_Pos)
+#define US_IDR_LIN_FRAME_1          (US_IDR_LIN_FRAME_1_Val        << US_IDR_LIN_FRAME_Pos)
+#define US_IDR_LIN_PARE_Pos         7            /**< \brief (US_IDR_LIN) Parity Error Interrupt Disable */
+#define US_IDR_LIN_PARE             (_U(0x1) << US_IDR_LIN_PARE_Pos)
+#define   US_IDR_LIN_PARE_0_Val           _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_PARE_1_Val           _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_PARE_0           (US_IDR_LIN_PARE_0_Val         << US_IDR_LIN_PARE_Pos)
+#define US_IDR_LIN_PARE_1           (US_IDR_LIN_PARE_1_Val         << US_IDR_LIN_PARE_Pos)
+#define US_IDR_LIN_TIMEOUT_Pos      8            /**< \brief (US_IDR_LIN) Time-out Interrupt Disable */
+#define US_IDR_LIN_TIMEOUT          (_U(0x1) << US_IDR_LIN_TIMEOUT_Pos)
+#define   US_IDR_LIN_TIMEOUT_0_Val        _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_TIMEOUT_1_Val        _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_TIMEOUT_0        (US_IDR_LIN_TIMEOUT_0_Val      << US_IDR_LIN_TIMEOUT_Pos)
+#define US_IDR_LIN_TIMEOUT_1        (US_IDR_LIN_TIMEOUT_1_Val      << US_IDR_LIN_TIMEOUT_Pos)
+#define US_IDR_LIN_TXEMPTY_Pos      9            /**< \brief (US_IDR_LIN) Transmitter Empty Interrupt Disable */
+#define US_IDR_LIN_TXEMPTY          (_U(0x1) << US_IDR_LIN_TXEMPTY_Pos)
+#define   US_IDR_LIN_TXEMPTY_0_Val        _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_TXEMPTY_1_Val        _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_TXEMPTY_0        (US_IDR_LIN_TXEMPTY_0_Val      << US_IDR_LIN_TXEMPTY_Pos)
+#define US_IDR_LIN_TXEMPTY_1        (US_IDR_LIN_TXEMPTY_1_Val      << US_IDR_LIN_TXEMPTY_Pos)
+#define US_IDR_LIN_ITER_Pos         10           /**< \brief (US_IDR_LIN) Iteration Interrupt Disable */
+#define US_IDR_LIN_ITER             (_U(0x1) << US_IDR_LIN_ITER_Pos)
+#define   US_IDR_LIN_ITER_0_Val           _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_ITER_1_Val           _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_ITER_0           (US_IDR_LIN_ITER_0_Val         << US_IDR_LIN_ITER_Pos)
+#define US_IDR_LIN_ITER_1           (US_IDR_LIN_ITER_1_Val         << US_IDR_LIN_ITER_Pos)
+#define US_IDR_LIN_TXBUFE_Pos       11           /**< \brief (US_IDR_LIN) Buffer Empty Interrupt Disable */
+#define US_IDR_LIN_TXBUFE           (_U(0x1) << US_IDR_LIN_TXBUFE_Pos)
+#define   US_IDR_LIN_TXBUFE_0_Val         _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_TXBUFE_1_Val         _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_TXBUFE_0         (US_IDR_LIN_TXBUFE_0_Val       << US_IDR_LIN_TXBUFE_Pos)
+#define US_IDR_LIN_TXBUFE_1         (US_IDR_LIN_TXBUFE_1_Val       << US_IDR_LIN_TXBUFE_Pos)
+#define US_IDR_LIN_RXBUFF_Pos       12           /**< \brief (US_IDR_LIN) Buffer Full Interrupt Disable */
+#define US_IDR_LIN_RXBUFF           (_U(0x1) << US_IDR_LIN_RXBUFF_Pos)
+#define   US_IDR_LIN_RXBUFF_0_Val         _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_RXBUFF_1_Val         _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_RXBUFF_0         (US_IDR_LIN_RXBUFF_0_Val       << US_IDR_LIN_RXBUFF_Pos)
+#define US_IDR_LIN_RXBUFF_1         (US_IDR_LIN_RXBUFF_1_Val       << US_IDR_LIN_RXBUFF_Pos)
+#define US_IDR_LIN_NACK_Pos         13           /**< \brief (US_IDR_LIN) Non Acknowledge  or LIN Break Sent or LIN Break Received Interrupt Disable */
+#define US_IDR_LIN_NACK             (_U(0x1) << US_IDR_LIN_NACK_Pos)
+#define   US_IDR_LIN_NACK_0_Val           _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_NACK_1_Val           _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_NACK_0           (US_IDR_LIN_NACK_0_Val         << US_IDR_LIN_NACK_Pos)
+#define US_IDR_LIN_NACK_1           (US_IDR_LIN_NACK_1_Val         << US_IDR_LIN_NACK_Pos)
+#define US_IDR_LIN_LINID_Pos        14           /**< \brief (US_IDR_LIN) LIN Identifier Sent or LIN Identifier Received Interrupt Disable */
+#define US_IDR_LIN_LINID            (_U(0x1) << US_IDR_LIN_LINID_Pos)
+#define US_IDR_LIN_LINTC_Pos        15           /**< \brief (US_IDR_LIN) LIN Transfer Conpleted Interrupt Disable */
+#define US_IDR_LIN_LINTC            (_U(0x1) << US_IDR_LIN_LINTC_Pos)
+#define US_IDR_LIN_RIIC_Pos         16           /**< \brief (US_IDR_LIN) Ring Indicator Input Change Disable */
+#define US_IDR_LIN_RIIC             (_U(0x1) << US_IDR_LIN_RIIC_Pos)
+#define   US_IDR_LIN_RIIC_0_Val           _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_RIIC_1_Val           _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_RIIC_0           (US_IDR_LIN_RIIC_0_Val         << US_IDR_LIN_RIIC_Pos)
+#define US_IDR_LIN_RIIC_1           (US_IDR_LIN_RIIC_1_Val         << US_IDR_LIN_RIIC_Pos)
+#define US_IDR_LIN_DSRIC_Pos        17           /**< \brief (US_IDR_LIN) Data Set Ready Input Change Disable */
+#define US_IDR_LIN_DSRIC            (_U(0x1) << US_IDR_LIN_DSRIC_Pos)
+#define   US_IDR_LIN_DSRIC_0_Val          _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_DSRIC_1_Val          _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_DSRIC_0          (US_IDR_LIN_DSRIC_0_Val        << US_IDR_LIN_DSRIC_Pos)
+#define US_IDR_LIN_DSRIC_1          (US_IDR_LIN_DSRIC_1_Val        << US_IDR_LIN_DSRIC_Pos)
+#define US_IDR_LIN_DCDIC_Pos        18           /**< \brief (US_IDR_LIN) Data Carrier Detect Input Change Interrupt Disable */
+#define US_IDR_LIN_DCDIC            (_U(0x1) << US_IDR_LIN_DCDIC_Pos)
+#define   US_IDR_LIN_DCDIC_0_Val          _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_DCDIC_1_Val          _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_DCDIC_0          (US_IDR_LIN_DCDIC_0_Val        << US_IDR_LIN_DCDIC_Pos)
+#define US_IDR_LIN_DCDIC_1          (US_IDR_LIN_DCDIC_1_Val        << US_IDR_LIN_DCDIC_Pos)
+#define US_IDR_LIN_CTSIC_Pos        19           /**< \brief (US_IDR_LIN) Clear to Send Input Change Interrupt Disable */
+#define US_IDR_LIN_CTSIC            (_U(0x1) << US_IDR_LIN_CTSIC_Pos)
+#define   US_IDR_LIN_CTSIC_0_Val          _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_CTSIC_1_Val          _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_CTSIC_0          (US_IDR_LIN_CTSIC_0_Val        << US_IDR_LIN_CTSIC_Pos)
+#define US_IDR_LIN_CTSIC_1          (US_IDR_LIN_CTSIC_1_Val        << US_IDR_LIN_CTSIC_Pos)
+#define US_IDR_LIN_LINBE_Pos        25           /**< \brief (US_IDR_LIN) LIN Bus Error Interrupt Disable */
+#define US_IDR_LIN_LINBE            (_U(0x1) << US_IDR_LIN_LINBE_Pos)
+#define US_IDR_LIN_LINISFE_Pos      26           /**< \brief (US_IDR_LIN) LIN Inconsistent Synch Field Error Interrupt Disable */
+#define US_IDR_LIN_LINISFE          (_U(0x1) << US_IDR_LIN_LINISFE_Pos)
+#define US_IDR_LIN_LINIPE_Pos       27           /**< \brief (US_IDR_LIN) LIN Identifier Parity Interrupt Disable */
+#define US_IDR_LIN_LINIPE           (_U(0x1) << US_IDR_LIN_LINIPE_Pos)
+#define US_IDR_LIN_LINCE_Pos        28           /**< \brief (US_IDR_LIN) LIN Checksum Error Interrupt Disable */
+#define US_IDR_LIN_LINCE            (_U(0x1) << US_IDR_LIN_LINCE_Pos)
+#define US_IDR_LIN_LINSNRE_Pos      29           /**< \brief (US_IDR_LIN) LIN Slave Not Responding Error Interrupt Disable */
+#define US_IDR_LIN_LINSNRE          (_U(0x1) << US_IDR_LIN_LINSNRE_Pos)
+#define US_IDR_LIN_LINSTE_Pos       30           /**< \brief (US_IDR_LIN) LIN Synch Tolerance Error Interrupt Disable */
+#define US_IDR_LIN_LINSTE           (_U(0x1) << US_IDR_LIN_LINSTE_Pos)
+#define   US_IDR_LIN_LINSTE_0_Val         _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_LINSTE_1_Val         _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_LINSTE_0         (US_IDR_LIN_LINSTE_0_Val       << US_IDR_LIN_LINSTE_Pos)
+#define US_IDR_LIN_LINSTE_1         (US_IDR_LIN_LINSTE_1_Val       << US_IDR_LIN_LINSTE_Pos)
+#define US_IDR_LIN_LINHTE_Pos       31           /**< \brief (US_IDR_LIN) LIN Header Timeout Error Interrupt Disable */
+#define US_IDR_LIN_LINHTE           (_U(0x1) << US_IDR_LIN_LINHTE_Pos)
+#define   US_IDR_LIN_LINHTE_0_Val         _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_LINHTE_1_Val         _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_LINHTE_0         (US_IDR_LIN_LINHTE_0_Val       << US_IDR_LIN_LINHTE_Pos)
+#define US_IDR_LIN_LINHTE_1         (US_IDR_LIN_LINHTE_1_Val       << US_IDR_LIN_LINHTE_Pos)
+#define US_IDR_LIN_MASK             _U(0xFE0FFFE7) /**< \brief (US_IDR_LIN) MASK Register */
+
+// SPI_SLAVE mode
+#define US_IDR_SPI_SLAVE_RXRDY_Pos  0            /**< \brief (US_IDR_SPI_SLAVE) Receiver Ready Interrupt Disable */
+#define US_IDR_SPI_SLAVE_RXRDY      (_U(0x1) << US_IDR_SPI_SLAVE_RXRDY_Pos)
+#define   US_IDR_SPI_SLAVE_RXRDY_0_Val    _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_RXRDY_1_Val    _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_RXRDY_0    (US_IDR_SPI_SLAVE_RXRDY_0_Val  << US_IDR_SPI_SLAVE_RXRDY_Pos)
+#define US_IDR_SPI_SLAVE_RXRDY_1    (US_IDR_SPI_SLAVE_RXRDY_1_Val  << US_IDR_SPI_SLAVE_RXRDY_Pos)
+#define US_IDR_SPI_SLAVE_TXRDY_Pos  1            /**< \brief (US_IDR_SPI_SLAVE) Transmitter Ready Interrupt Disable */
+#define US_IDR_SPI_SLAVE_TXRDY      (_U(0x1) << US_IDR_SPI_SLAVE_TXRDY_Pos)
+#define   US_IDR_SPI_SLAVE_TXRDY_0_Val    _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_TXRDY_1_Val    _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_TXRDY_0    (US_IDR_SPI_SLAVE_TXRDY_0_Val  << US_IDR_SPI_SLAVE_TXRDY_Pos)
+#define US_IDR_SPI_SLAVE_TXRDY_1    (US_IDR_SPI_SLAVE_TXRDY_1_Val  << US_IDR_SPI_SLAVE_TXRDY_Pos)
+#define US_IDR_SPI_SLAVE_RXBRK_Pos  2            /**< \brief (US_IDR_SPI_SLAVE) Receiver Break Interrupt Disable */
+#define US_IDR_SPI_SLAVE_RXBRK      (_U(0x1) << US_IDR_SPI_SLAVE_RXBRK_Pos)
+#define   US_IDR_SPI_SLAVE_RXBRK_0_Val    _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_RXBRK_1_Val    _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_RXBRK_0    (US_IDR_SPI_SLAVE_RXBRK_0_Val  << US_IDR_SPI_SLAVE_RXBRK_Pos)
+#define US_IDR_SPI_SLAVE_RXBRK_1    (US_IDR_SPI_SLAVE_RXBRK_1_Val  << US_IDR_SPI_SLAVE_RXBRK_Pos)
+#define US_IDR_SPI_SLAVE_OVRE_Pos   5            /**< \brief (US_IDR_SPI_SLAVE) Overrun Error Interrupt Disable */
+#define US_IDR_SPI_SLAVE_OVRE       (_U(0x1) << US_IDR_SPI_SLAVE_OVRE_Pos)
+#define   US_IDR_SPI_SLAVE_OVRE_0_Val     _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_OVRE_1_Val     _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_OVRE_0     (US_IDR_SPI_SLAVE_OVRE_0_Val   << US_IDR_SPI_SLAVE_OVRE_Pos)
+#define US_IDR_SPI_SLAVE_OVRE_1     (US_IDR_SPI_SLAVE_OVRE_1_Val   << US_IDR_SPI_SLAVE_OVRE_Pos)
+#define US_IDR_SPI_SLAVE_FRAME_Pos  6            /**< \brief (US_IDR_SPI_SLAVE) Framing Error Interrupt Disable */
+#define US_IDR_SPI_SLAVE_FRAME      (_U(0x1) << US_IDR_SPI_SLAVE_FRAME_Pos)
+#define   US_IDR_SPI_SLAVE_FRAME_0_Val    _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_FRAME_1_Val    _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_FRAME_0    (US_IDR_SPI_SLAVE_FRAME_0_Val  << US_IDR_SPI_SLAVE_FRAME_Pos)
+#define US_IDR_SPI_SLAVE_FRAME_1    (US_IDR_SPI_SLAVE_FRAME_1_Val  << US_IDR_SPI_SLAVE_FRAME_Pos)
+#define US_IDR_SPI_SLAVE_PARE_Pos   7            /**< \brief (US_IDR_SPI_SLAVE) Parity Error Interrupt Disable */
+#define US_IDR_SPI_SLAVE_PARE       (_U(0x1) << US_IDR_SPI_SLAVE_PARE_Pos)
+#define   US_IDR_SPI_SLAVE_PARE_0_Val     _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_PARE_1_Val     _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_PARE_0     (US_IDR_SPI_SLAVE_PARE_0_Val   << US_IDR_SPI_SLAVE_PARE_Pos)
+#define US_IDR_SPI_SLAVE_PARE_1     (US_IDR_SPI_SLAVE_PARE_1_Val   << US_IDR_SPI_SLAVE_PARE_Pos)
+#define US_IDR_SPI_SLAVE_TIMEOUT_Pos 8            /**< \brief (US_IDR_SPI_SLAVE) Time-out Interrupt Disable */
+#define US_IDR_SPI_SLAVE_TIMEOUT    (_U(0x1) << US_IDR_SPI_SLAVE_TIMEOUT_Pos)
+#define   US_IDR_SPI_SLAVE_TIMEOUT_0_Val  _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_TIMEOUT_1_Val  _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_TIMEOUT_0  (US_IDR_SPI_SLAVE_TIMEOUT_0_Val << US_IDR_SPI_SLAVE_TIMEOUT_Pos)
+#define US_IDR_SPI_SLAVE_TIMEOUT_1  (US_IDR_SPI_SLAVE_TIMEOUT_1_Val << US_IDR_SPI_SLAVE_TIMEOUT_Pos)
+#define US_IDR_SPI_SLAVE_TXEMPTY_Pos 9            /**< \brief (US_IDR_SPI_SLAVE) Transmitter Empty Interrupt Disable */
+#define US_IDR_SPI_SLAVE_TXEMPTY    (_U(0x1) << US_IDR_SPI_SLAVE_TXEMPTY_Pos)
+#define   US_IDR_SPI_SLAVE_TXEMPTY_0_Val  _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_TXEMPTY_1_Val  _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_TXEMPTY_0  (US_IDR_SPI_SLAVE_TXEMPTY_0_Val << US_IDR_SPI_SLAVE_TXEMPTY_Pos)
+#define US_IDR_SPI_SLAVE_TXEMPTY_1  (US_IDR_SPI_SLAVE_TXEMPTY_1_Val << US_IDR_SPI_SLAVE_TXEMPTY_Pos)
+#define US_IDR_SPI_SLAVE_UNRE_Pos   10           /**< \brief (US_IDR_SPI_SLAVE) SPI Underrun Error Interrupt Disable */
+#define US_IDR_SPI_SLAVE_UNRE       (_U(0x1) << US_IDR_SPI_SLAVE_UNRE_Pos)
+#define   US_IDR_SPI_SLAVE_UNRE_0_Val     _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_UNRE_1_Val     _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_UNRE_0     (US_IDR_SPI_SLAVE_UNRE_0_Val   << US_IDR_SPI_SLAVE_UNRE_Pos)
+#define US_IDR_SPI_SLAVE_UNRE_1     (US_IDR_SPI_SLAVE_UNRE_1_Val   << US_IDR_SPI_SLAVE_UNRE_Pos)
+#define US_IDR_SPI_SLAVE_TXBUFE_Pos 11           /**< \brief (US_IDR_SPI_SLAVE) Buffer Empty Interrupt Disable */
+#define US_IDR_SPI_SLAVE_TXBUFE     (_U(0x1) << US_IDR_SPI_SLAVE_TXBUFE_Pos)
+#define   US_IDR_SPI_SLAVE_TXBUFE_0_Val   _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_TXBUFE_1_Val   _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_TXBUFE_0   (US_IDR_SPI_SLAVE_TXBUFE_0_Val << US_IDR_SPI_SLAVE_TXBUFE_Pos)
+#define US_IDR_SPI_SLAVE_TXBUFE_1   (US_IDR_SPI_SLAVE_TXBUFE_1_Val << US_IDR_SPI_SLAVE_TXBUFE_Pos)
+#define US_IDR_SPI_SLAVE_RXBUFF_Pos 12           /**< \brief (US_IDR_SPI_SLAVE) Buffer Full Interrupt Disable */
+#define US_IDR_SPI_SLAVE_RXBUFF     (_U(0x1) << US_IDR_SPI_SLAVE_RXBUFF_Pos)
+#define   US_IDR_SPI_SLAVE_RXBUFF_0_Val   _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_RXBUFF_1_Val   _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_RXBUFF_0   (US_IDR_SPI_SLAVE_RXBUFF_0_Val << US_IDR_SPI_SLAVE_RXBUFF_Pos)
+#define US_IDR_SPI_SLAVE_RXBUFF_1   (US_IDR_SPI_SLAVE_RXBUFF_1_Val << US_IDR_SPI_SLAVE_RXBUFF_Pos)
+#define US_IDR_SPI_SLAVE_NACK_Pos   13           /**< \brief (US_IDR_SPI_SLAVE) Non Acknowledge Interrupt Disable */
+#define US_IDR_SPI_SLAVE_NACK       (_U(0x1) << US_IDR_SPI_SLAVE_NACK_Pos)
+#define   US_IDR_SPI_SLAVE_NACK_0_Val     _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_NACK_1_Val     _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_NACK_0     (US_IDR_SPI_SLAVE_NACK_0_Val   << US_IDR_SPI_SLAVE_NACK_Pos)
+#define US_IDR_SPI_SLAVE_NACK_1     (US_IDR_SPI_SLAVE_NACK_1_Val   << US_IDR_SPI_SLAVE_NACK_Pos)
+#define US_IDR_SPI_SLAVE_RIIC_Pos   16           /**< \brief (US_IDR_SPI_SLAVE) Ring Indicator Input Change Disable */
+#define US_IDR_SPI_SLAVE_RIIC       (_U(0x1) << US_IDR_SPI_SLAVE_RIIC_Pos)
+#define   US_IDR_SPI_SLAVE_RIIC_0_Val     _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_RIIC_1_Val     _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_RIIC_0     (US_IDR_SPI_SLAVE_RIIC_0_Val   << US_IDR_SPI_SLAVE_RIIC_Pos)
+#define US_IDR_SPI_SLAVE_RIIC_1     (US_IDR_SPI_SLAVE_RIIC_1_Val   << US_IDR_SPI_SLAVE_RIIC_Pos)
+#define US_IDR_SPI_SLAVE_DSRIC_Pos  17           /**< \brief (US_IDR_SPI_SLAVE) Data Set Ready Input Change Disable */
+#define US_IDR_SPI_SLAVE_DSRIC      (_U(0x1) << US_IDR_SPI_SLAVE_DSRIC_Pos)
+#define   US_IDR_SPI_SLAVE_DSRIC_0_Val    _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_DSRIC_1_Val    _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_DSRIC_0    (US_IDR_SPI_SLAVE_DSRIC_0_Val  << US_IDR_SPI_SLAVE_DSRIC_Pos)
+#define US_IDR_SPI_SLAVE_DSRIC_1    (US_IDR_SPI_SLAVE_DSRIC_1_Val  << US_IDR_SPI_SLAVE_DSRIC_Pos)
+#define US_IDR_SPI_SLAVE_DCDIC_Pos  18           /**< \brief (US_IDR_SPI_SLAVE) Data Carrier Detect Input Change Interrupt Disable */
+#define US_IDR_SPI_SLAVE_DCDIC      (_U(0x1) << US_IDR_SPI_SLAVE_DCDIC_Pos)
+#define   US_IDR_SPI_SLAVE_DCDIC_0_Val    _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_DCDIC_1_Val    _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_DCDIC_0    (US_IDR_SPI_SLAVE_DCDIC_0_Val  << US_IDR_SPI_SLAVE_DCDIC_Pos)
+#define US_IDR_SPI_SLAVE_DCDIC_1    (US_IDR_SPI_SLAVE_DCDIC_1_Val  << US_IDR_SPI_SLAVE_DCDIC_Pos)
+#define US_IDR_SPI_SLAVE_CTSIC_Pos  19           /**< \brief (US_IDR_SPI_SLAVE) Clear to Send Input Change Interrupt Disable */
+#define US_IDR_SPI_SLAVE_CTSIC      (_U(0x1) << US_IDR_SPI_SLAVE_CTSIC_Pos)
+#define   US_IDR_SPI_SLAVE_CTSIC_0_Val    _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_CTSIC_1_Val    _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_CTSIC_0    (US_IDR_SPI_SLAVE_CTSIC_0_Val  << US_IDR_SPI_SLAVE_CTSIC_Pos)
+#define US_IDR_SPI_SLAVE_CTSIC_1    (US_IDR_SPI_SLAVE_CTSIC_1_Val  << US_IDR_SPI_SLAVE_CTSIC_Pos)
+#define US_IDR_SPI_SLAVE_MASK       _U(0x000F3FE7) /**< \brief (US_IDR_SPI_SLAVE) MASK Register */
+
+// USART mode
+#define US_IDR_USART_RXRDY_Pos      0            /**< \brief (US_IDR_USART) Receiver Ready Interrupt Disable */
+#define US_IDR_USART_RXRDY          (_U(0x1) << US_IDR_USART_RXRDY_Pos)
+#define   US_IDR_USART_RXRDY_0_Val        _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_RXRDY_1_Val        _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_RXRDY_0        (US_IDR_USART_RXRDY_0_Val      << US_IDR_USART_RXRDY_Pos)
+#define US_IDR_USART_RXRDY_1        (US_IDR_USART_RXRDY_1_Val      << US_IDR_USART_RXRDY_Pos)
+#define US_IDR_USART_TXRDY_Pos      1            /**< \brief (US_IDR_USART) Transmitter Ready Interrupt Disable */
+#define US_IDR_USART_TXRDY          (_U(0x1) << US_IDR_USART_TXRDY_Pos)
+#define   US_IDR_USART_TXRDY_0_Val        _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_TXRDY_1_Val        _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_TXRDY_0        (US_IDR_USART_TXRDY_0_Val      << US_IDR_USART_TXRDY_Pos)
+#define US_IDR_USART_TXRDY_1        (US_IDR_USART_TXRDY_1_Val      << US_IDR_USART_TXRDY_Pos)
+#define US_IDR_USART_RXBRK_Pos      2            /**< \brief (US_IDR_USART) Receiver Break Interrupt Disable */
+#define US_IDR_USART_RXBRK          (_U(0x1) << US_IDR_USART_RXBRK_Pos)
+#define   US_IDR_USART_RXBRK_0_Val        _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_RXBRK_1_Val        _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_RXBRK_0        (US_IDR_USART_RXBRK_0_Val      << US_IDR_USART_RXBRK_Pos)
+#define US_IDR_USART_RXBRK_1        (US_IDR_USART_RXBRK_1_Val      << US_IDR_USART_RXBRK_Pos)
+#define US_IDR_USART_OVRE_Pos       5            /**< \brief (US_IDR_USART) Overrun Error Interrupt Disable */
+#define US_IDR_USART_OVRE           (_U(0x1) << US_IDR_USART_OVRE_Pos)
+#define   US_IDR_USART_OVRE_0_Val         _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_OVRE_1_Val         _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_OVRE_0         (US_IDR_USART_OVRE_0_Val       << US_IDR_USART_OVRE_Pos)
+#define US_IDR_USART_OVRE_1         (US_IDR_USART_OVRE_1_Val       << US_IDR_USART_OVRE_Pos)
+#define US_IDR_USART_FRAME_Pos      6            /**< \brief (US_IDR_USART) Framing Error Interrupt Disable */
+#define US_IDR_USART_FRAME          (_U(0x1) << US_IDR_USART_FRAME_Pos)
+#define   US_IDR_USART_FRAME_0_Val        _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_FRAME_1_Val        _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_FRAME_0        (US_IDR_USART_FRAME_0_Val      << US_IDR_USART_FRAME_Pos)
+#define US_IDR_USART_FRAME_1        (US_IDR_USART_FRAME_1_Val      << US_IDR_USART_FRAME_Pos)
+#define US_IDR_USART_PARE_Pos       7            /**< \brief (US_IDR_USART) Parity Error Interrupt Disable */
+#define US_IDR_USART_PARE           (_U(0x1) << US_IDR_USART_PARE_Pos)
+#define   US_IDR_USART_PARE_0_Val         _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_PARE_1_Val         _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_PARE_0         (US_IDR_USART_PARE_0_Val       << US_IDR_USART_PARE_Pos)
+#define US_IDR_USART_PARE_1         (US_IDR_USART_PARE_1_Val       << US_IDR_USART_PARE_Pos)
+#define US_IDR_USART_TIMEOUT_Pos    8            /**< \brief (US_IDR_USART) Time-out Interrupt Disable */
+#define US_IDR_USART_TIMEOUT        (_U(0x1) << US_IDR_USART_TIMEOUT_Pos)
+#define   US_IDR_USART_TIMEOUT_0_Val      _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_TIMEOUT_1_Val      _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_TIMEOUT_0      (US_IDR_USART_TIMEOUT_0_Val    << US_IDR_USART_TIMEOUT_Pos)
+#define US_IDR_USART_TIMEOUT_1      (US_IDR_USART_TIMEOUT_1_Val    << US_IDR_USART_TIMEOUT_Pos)
+#define US_IDR_USART_TXEMPTY_Pos    9            /**< \brief (US_IDR_USART) Transmitter Empty Interrupt Disable */
+#define US_IDR_USART_TXEMPTY        (_U(0x1) << US_IDR_USART_TXEMPTY_Pos)
+#define   US_IDR_USART_TXEMPTY_0_Val      _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_TXEMPTY_1_Val      _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_TXEMPTY_0      (US_IDR_USART_TXEMPTY_0_Val    << US_IDR_USART_TXEMPTY_Pos)
+#define US_IDR_USART_TXEMPTY_1      (US_IDR_USART_TXEMPTY_1_Val    << US_IDR_USART_TXEMPTY_Pos)
+#define US_IDR_USART_ITER_Pos       10           /**< \brief (US_IDR_USART) Iteration Interrupt Disable */
+#define US_IDR_USART_ITER           (_U(0x1) << US_IDR_USART_ITER_Pos)
+#define   US_IDR_USART_ITER_0_Val         _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_ITER_1_Val         _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_ITER_0         (US_IDR_USART_ITER_0_Val       << US_IDR_USART_ITER_Pos)
+#define US_IDR_USART_ITER_1         (US_IDR_USART_ITER_1_Val       << US_IDR_USART_ITER_Pos)
+#define US_IDR_USART_TXBUFE_Pos     11           /**< \brief (US_IDR_USART) Buffer Empty Interrupt Disable */
+#define US_IDR_USART_TXBUFE         (_U(0x1) << US_IDR_USART_TXBUFE_Pos)
+#define   US_IDR_USART_TXBUFE_0_Val       _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_TXBUFE_1_Val       _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_TXBUFE_0       (US_IDR_USART_TXBUFE_0_Val     << US_IDR_USART_TXBUFE_Pos)
+#define US_IDR_USART_TXBUFE_1       (US_IDR_USART_TXBUFE_1_Val     << US_IDR_USART_TXBUFE_Pos)
+#define US_IDR_USART_RXBUFF_Pos     12           /**< \brief (US_IDR_USART) Buffer Full Interrupt Disable */
+#define US_IDR_USART_RXBUFF         (_U(0x1) << US_IDR_USART_RXBUFF_Pos)
+#define   US_IDR_USART_RXBUFF_0_Val       _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_RXBUFF_1_Val       _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_RXBUFF_0       (US_IDR_USART_RXBUFF_0_Val     << US_IDR_USART_RXBUFF_Pos)
+#define US_IDR_USART_RXBUFF_1       (US_IDR_USART_RXBUFF_1_Val     << US_IDR_USART_RXBUFF_Pos)
+#define US_IDR_USART_NACK_Pos       13           /**< \brief (US_IDR_USART) Non Acknowledge Interrupt Disable */
+#define US_IDR_USART_NACK           (_U(0x1) << US_IDR_USART_NACK_Pos)
+#define   US_IDR_USART_NACK_0_Val         _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_NACK_1_Val         _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_NACK_0         (US_IDR_USART_NACK_0_Val       << US_IDR_USART_NACK_Pos)
+#define US_IDR_USART_NACK_1         (US_IDR_USART_NACK_1_Val       << US_IDR_USART_NACK_Pos)
+#define US_IDR_USART_RIIC_Pos       16           /**< \brief (US_IDR_USART) Ring Indicator Input Change Disable */
+#define US_IDR_USART_RIIC           (_U(0x1) << US_IDR_USART_RIIC_Pos)
+#define   US_IDR_USART_RIIC_0_Val         _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_RIIC_1_Val         _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_RIIC_0         (US_IDR_USART_RIIC_0_Val       << US_IDR_USART_RIIC_Pos)
+#define US_IDR_USART_RIIC_1         (US_IDR_USART_RIIC_1_Val       << US_IDR_USART_RIIC_Pos)
+#define US_IDR_USART_DSRIC_Pos      17           /**< \brief (US_IDR_USART) Data Set Ready Input Change Disable */
+#define US_IDR_USART_DSRIC          (_U(0x1) << US_IDR_USART_DSRIC_Pos)
+#define   US_IDR_USART_DSRIC_0_Val        _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_DSRIC_1_Val        _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_DSRIC_0        (US_IDR_USART_DSRIC_0_Val      << US_IDR_USART_DSRIC_Pos)
+#define US_IDR_USART_DSRIC_1        (US_IDR_USART_DSRIC_1_Val      << US_IDR_USART_DSRIC_Pos)
+#define US_IDR_USART_DCDIC_Pos      18           /**< \brief (US_IDR_USART) Data Carrier Detect Input Change Interrupt Disable */
+#define US_IDR_USART_DCDIC          (_U(0x1) << US_IDR_USART_DCDIC_Pos)
+#define   US_IDR_USART_DCDIC_0_Val        _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_DCDIC_1_Val        _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_DCDIC_0        (US_IDR_USART_DCDIC_0_Val      << US_IDR_USART_DCDIC_Pos)
+#define US_IDR_USART_DCDIC_1        (US_IDR_USART_DCDIC_1_Val      << US_IDR_USART_DCDIC_Pos)
+#define US_IDR_USART_CTSIC_Pos      19           /**< \brief (US_IDR_USART) Clear to Send Input Change Interrupt Disable */
+#define US_IDR_USART_CTSIC          (_U(0x1) << US_IDR_USART_CTSIC_Pos)
+#define   US_IDR_USART_CTSIC_0_Val        _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_CTSIC_1_Val        _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_CTSIC_0        (US_IDR_USART_CTSIC_0_Val      << US_IDR_USART_CTSIC_Pos)
+#define US_IDR_USART_CTSIC_1        (US_IDR_USART_CTSIC_1_Val      << US_IDR_USART_CTSIC_Pos)
+#define US_IDR_USART_MANE_Pos       20           /**< \brief (US_IDR_USART) Manchester Error Interrupt Disable */
+#define US_IDR_USART_MANE           (_U(0x1) << US_IDR_USART_MANE_Pos)
+#define US_IDR_USART_MANEA_Pos      24           /**< \brief (US_IDR_USART) Manchester Error Interrupt Disable */
+#define US_IDR_USART_MANEA          (_U(0x1) << US_IDR_USART_MANEA_Pos)
+#define   US_IDR_USART_MANEA_0_Val        _U(0x0)   /**< \brief (US_IDR_USART) No effect */
+#define   US_IDR_USART_MANEA_1_Val        _U(0x1)   /**< \brief (US_IDR_USART) Disables the corresponding interrupt */
+#define US_IDR_USART_MANEA_0        (US_IDR_USART_MANEA_0_Val      << US_IDR_USART_MANEA_Pos)
+#define US_IDR_USART_MANEA_1        (US_IDR_USART_MANEA_1_Val      << US_IDR_USART_MANEA_Pos)
+#define US_IDR_USART_MASK           _U(0x011F3FE7) /**< \brief (US_IDR_USART) MASK Register */
+
+// Any mode
+#define US_IDR_RXRDY_Pos            0            /**< \brief (US_IDR) Receiver Ready Interrupt Disable */
+#define US_IDR_RXRDY                (_U(0x1) << US_IDR_RXRDY_Pos)
+#define   US_IDR_RXRDY_0_Val              _U(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_RXRDY_1_Val              _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_RXRDY_0              (US_IDR_RXRDY_0_Val            << US_IDR_RXRDY_Pos)
+#define US_IDR_RXRDY_1              (US_IDR_RXRDY_1_Val            << US_IDR_RXRDY_Pos)
+#define US_IDR_TXRDY_Pos            1            /**< \brief (US_IDR) Transmitter Ready Interrupt Disable */
+#define US_IDR_TXRDY                (_U(0x1) << US_IDR_TXRDY_Pos)
+#define   US_IDR_TXRDY_0_Val              _U(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_TXRDY_1_Val              _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_TXRDY_0              (US_IDR_TXRDY_0_Val            << US_IDR_TXRDY_Pos)
+#define US_IDR_TXRDY_1              (US_IDR_TXRDY_1_Val            << US_IDR_TXRDY_Pos)
+#define US_IDR_RXBRK_Pos            2            /**< \brief (US_IDR) Receiver Break Interrupt Disable */
+#define US_IDR_RXBRK                (_U(0x1) << US_IDR_RXBRK_Pos)
+#define   US_IDR_RXBRK_0_Val              _U(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_RXBRK_1_Val              _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_RXBRK_0              (US_IDR_RXBRK_0_Val            << US_IDR_RXBRK_Pos)
+#define US_IDR_RXBRK_1              (US_IDR_RXBRK_1_Val            << US_IDR_RXBRK_Pos)
+#define US_IDR_OVRE_Pos             5            /**< \brief (US_IDR) Overrun Error Interrupt Disable */
+#define US_IDR_OVRE                 (_U(0x1) << US_IDR_OVRE_Pos)
+#define   US_IDR_OVRE_0_Val               _U(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_OVRE_1_Val               _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_OVRE_0               (US_IDR_OVRE_0_Val             << US_IDR_OVRE_Pos)
+#define US_IDR_OVRE_1               (US_IDR_OVRE_1_Val             << US_IDR_OVRE_Pos)
+#define US_IDR_FRAME_Pos            6            /**< \brief (US_IDR) Framing Error Interrupt Disable */
+#define US_IDR_FRAME                (_U(0x1) << US_IDR_FRAME_Pos)
+#define   US_IDR_FRAME_0_Val              _U(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_FRAME_1_Val              _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_FRAME_0              (US_IDR_FRAME_0_Val            << US_IDR_FRAME_Pos)
+#define US_IDR_FRAME_1              (US_IDR_FRAME_1_Val            << US_IDR_FRAME_Pos)
+#define US_IDR_PARE_Pos             7            /**< \brief (US_IDR) Parity Error Interrupt Disable */
+#define US_IDR_PARE                 (_U(0x1) << US_IDR_PARE_Pos)
+#define   US_IDR_PARE_0_Val               _U(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_PARE_1_Val               _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_PARE_0               (US_IDR_PARE_0_Val             << US_IDR_PARE_Pos)
+#define US_IDR_PARE_1               (US_IDR_PARE_1_Val             << US_IDR_PARE_Pos)
+#define US_IDR_TIMEOUT_Pos          8            /**< \brief (US_IDR) Time-out Interrupt Disable */
+#define US_IDR_TIMEOUT              (_U(0x1) << US_IDR_TIMEOUT_Pos)
+#define   US_IDR_TIMEOUT_0_Val            _U(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_TIMEOUT_1_Val            _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_TIMEOUT_0            (US_IDR_TIMEOUT_0_Val          << US_IDR_TIMEOUT_Pos)
+#define US_IDR_TIMEOUT_1            (US_IDR_TIMEOUT_1_Val          << US_IDR_TIMEOUT_Pos)
+#define US_IDR_TXEMPTY_Pos          9            /**< \brief (US_IDR) Transmitter Empty Interrupt Disable */
+#define US_IDR_TXEMPTY              (_U(0x1) << US_IDR_TXEMPTY_Pos)
+#define   US_IDR_TXEMPTY_0_Val            _U(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_TXEMPTY_1_Val            _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_TXEMPTY_0            (US_IDR_TXEMPTY_0_Val          << US_IDR_TXEMPTY_Pos)
+#define US_IDR_TXEMPTY_1            (US_IDR_TXEMPTY_1_Val          << US_IDR_TXEMPTY_Pos)
+#define US_IDR_ITER_Pos             10           /**< \brief (US_IDR) Iteration Interrupt Disable */
+#define US_IDR_ITER                 (_U(0x1) << US_IDR_ITER_Pos)
+#define   US_IDR_ITER_0_Val               _U(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_ITER_1_Val               _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_ITER_0               (US_IDR_ITER_0_Val             << US_IDR_ITER_Pos)
+#define US_IDR_ITER_1               (US_IDR_ITER_1_Val             << US_IDR_ITER_Pos)
+#define US_IDR_UNRE_Pos             10           /**< \brief (US_IDR) SPI Underrun Error Interrupt Disable */
+#define US_IDR_UNRE                 (_U(0x1) << US_IDR_UNRE_Pos)
+#define   US_IDR_UNRE_0_Val               _U(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_UNRE_1_Val               _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_UNRE_0               (US_IDR_UNRE_0_Val             << US_IDR_UNRE_Pos)
+#define US_IDR_UNRE_1               (US_IDR_UNRE_1_Val             << US_IDR_UNRE_Pos)
+#define US_IDR_ITER_Pos             10           /**< \brief (US_IDR) Iteration Interrupt Disable */
+#define US_IDR_ITER                 (_U(0x1) << US_IDR_ITER_Pos)
+#define   US_IDR_ITER_0_Val               _U(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_ITER_1_Val               _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_ITER_0               (US_IDR_ITER_0_Val             << US_IDR_ITER_Pos)
+#define US_IDR_ITER_1               (US_IDR_ITER_1_Val             << US_IDR_ITER_Pos)
+#define US_IDR_TXBUFE_Pos           11           /**< \brief (US_IDR) Buffer Empty Interrupt Disable */
+#define US_IDR_TXBUFE               (_U(0x1) << US_IDR_TXBUFE_Pos)
+#define   US_IDR_TXBUFE_0_Val             _U(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_TXBUFE_1_Val             _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_TXBUFE_0             (US_IDR_TXBUFE_0_Val           << US_IDR_TXBUFE_Pos)
+#define US_IDR_TXBUFE_1             (US_IDR_TXBUFE_1_Val           << US_IDR_TXBUFE_Pos)
+#define US_IDR_RXBUFF_Pos           12           /**< \brief (US_IDR) Buffer Full Interrupt Disable */
+#define US_IDR_RXBUFF               (_U(0x1) << US_IDR_RXBUFF_Pos)
+#define   US_IDR_RXBUFF_0_Val             _U(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_RXBUFF_1_Val             _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_RXBUFF_0             (US_IDR_RXBUFF_0_Val           << US_IDR_RXBUFF_Pos)
+#define US_IDR_RXBUFF_1             (US_IDR_RXBUFF_1_Val           << US_IDR_RXBUFF_Pos)
+#define US_IDR_NACK_Pos             13           /**< \brief (US_IDR) Non Acknowledge  or LIN Break Sent or LIN Break Received Interrupt Disable */
+#define US_IDR_NACK                 (_U(0x1) << US_IDR_NACK_Pos)
+#define   US_IDR_NACK_0_Val               _U(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_NACK_1_Val               _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_NACK_0               (US_IDR_NACK_0_Val             << US_IDR_NACK_Pos)
+#define US_IDR_NACK_1               (US_IDR_NACK_1_Val             << US_IDR_NACK_Pos)
+#define US_IDR_LINID_Pos            14           /**< \brief (US_IDR) LIN Identifier Sent or LIN Identifier Received Interrupt Disable */
+#define US_IDR_LINID                (_U(0x1) << US_IDR_LINID_Pos)
+#define US_IDR_LINTC_Pos            15           /**< \brief (US_IDR) LIN Transfer Conpleted Interrupt Disable */
+#define US_IDR_LINTC                (_U(0x1) << US_IDR_LINTC_Pos)
+#define US_IDR_RIIC_Pos             16           /**< \brief (US_IDR) Ring Indicator Input Change Disable */
+#define US_IDR_RIIC                 (_U(0x1) << US_IDR_RIIC_Pos)
+#define   US_IDR_RIIC_0_Val               _U(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_RIIC_1_Val               _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_RIIC_0               (US_IDR_RIIC_0_Val             << US_IDR_RIIC_Pos)
+#define US_IDR_RIIC_1               (US_IDR_RIIC_1_Val             << US_IDR_RIIC_Pos)
+#define US_IDR_DSRIC_Pos            17           /**< \brief (US_IDR) Data Set Ready Input Change Disable */
+#define US_IDR_DSRIC                (_U(0x1) << US_IDR_DSRIC_Pos)
+#define   US_IDR_DSRIC_0_Val              _U(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_DSRIC_1_Val              _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_DSRIC_0              (US_IDR_DSRIC_0_Val            << US_IDR_DSRIC_Pos)
+#define US_IDR_DSRIC_1              (US_IDR_DSRIC_1_Val            << US_IDR_DSRIC_Pos)
+#define US_IDR_DCDIC_Pos            18           /**< \brief (US_IDR) Data Carrier Detect Input Change Interrupt Disable */
+#define US_IDR_DCDIC                (_U(0x1) << US_IDR_DCDIC_Pos)
+#define   US_IDR_DCDIC_0_Val              _U(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_DCDIC_1_Val              _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_DCDIC_0              (US_IDR_DCDIC_0_Val            << US_IDR_DCDIC_Pos)
+#define US_IDR_DCDIC_1              (US_IDR_DCDIC_1_Val            << US_IDR_DCDIC_Pos)
+#define US_IDR_CTSIC_Pos            19           /**< \brief (US_IDR) Clear to Send Input Change Interrupt Disable */
+#define US_IDR_CTSIC                (_U(0x1) << US_IDR_CTSIC_Pos)
+#define   US_IDR_CTSIC_0_Val              _U(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_CTSIC_1_Val              _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_CTSIC_0              (US_IDR_CTSIC_0_Val            << US_IDR_CTSIC_Pos)
+#define US_IDR_CTSIC_1              (US_IDR_CTSIC_1_Val            << US_IDR_CTSIC_Pos)
+#define US_IDR_MANE_Pos             20           /**< \brief (US_IDR) Manchester Error Interrupt Disable */
+#define US_IDR_MANE                 (_U(0x1) << US_IDR_MANE_Pos)
+#define US_IDR_MANEA_Pos            24           /**< \brief (US_IDR) Manchester Error Interrupt Disable */
+#define US_IDR_MANEA                (_U(0x1) << US_IDR_MANEA_Pos)
+#define   US_IDR_MANEA_0_Val              _U(0x0)   /**< \brief (US_IDR) No effect */
+#define   US_IDR_MANEA_1_Val              _U(0x1)   /**< \brief (US_IDR) Disables the corresponding interrupt */
+#define US_IDR_MANEA_0              (US_IDR_MANEA_0_Val            << US_IDR_MANEA_Pos)
+#define US_IDR_MANEA_1              (US_IDR_MANEA_1_Val            << US_IDR_MANEA_Pos)
+#define US_IDR_LINBE_Pos            25           /**< \brief (US_IDR) LIN Bus Error Interrupt Disable */
+#define US_IDR_LINBE                (_U(0x1) << US_IDR_LINBE_Pos)
+#define US_IDR_LINISFE_Pos          26           /**< \brief (US_IDR) LIN Inconsistent Synch Field Error Interrupt Disable */
+#define US_IDR_LINISFE              (_U(0x1) << US_IDR_LINISFE_Pos)
+#define US_IDR_LINIPE_Pos           27           /**< \brief (US_IDR) LIN Identifier Parity Interrupt Disable */
+#define US_IDR_LINIPE               (_U(0x1) << US_IDR_LINIPE_Pos)
+#define US_IDR_LINCE_Pos            28           /**< \brief (US_IDR) LIN Checksum Error Interrupt Disable */
+#define US_IDR_LINCE                (_U(0x1) << US_IDR_LINCE_Pos)
+#define US_IDR_LINSNRE_Pos          29           /**< \brief (US_IDR) LIN Slave Not Responding Error Interrupt Disable */
+#define US_IDR_LINSNRE              (_U(0x1) << US_IDR_LINSNRE_Pos)
+#define US_IDR_LINSTE_Pos           30           /**< \brief (US_IDR) LIN Synch Tolerance Error Interrupt Disable */
+#define US_IDR_LINSTE               (_U(0x1) << US_IDR_LINSTE_Pos)
+#define   US_IDR_LINSTE_0_Val             _U(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_LINSTE_1_Val             _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_LINSTE_0             (US_IDR_LINSTE_0_Val           << US_IDR_LINSTE_Pos)
+#define US_IDR_LINSTE_1             (US_IDR_LINSTE_1_Val           << US_IDR_LINSTE_Pos)
+#define US_IDR_LINHTE_Pos           31           /**< \brief (US_IDR) LIN Header Timeout Error Interrupt Disable */
+#define US_IDR_LINHTE               (_U(0x1) << US_IDR_LINHTE_Pos)
+#define   US_IDR_LINHTE_0_Val             _U(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_LINHTE_1_Val             _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_LINHTE_0             (US_IDR_LINHTE_0_Val           << US_IDR_LINHTE_Pos)
+#define US_IDR_LINHTE_1             (US_IDR_LINHTE_1_Val           << US_IDR_LINHTE_Pos)
+#define US_IDR_MASK                 _U(0xFF1FFFE7) /**< \brief (US_IDR) MASK Register */
+
+/* -------- US_IMR : (USART Offset: 0x10) (R/  32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct { // LIN mode
+    uint32_t RXRDY:1;          /*!< bit:      0  RXRDY Interrupt Mask               */
+    uint32_t TXRDY:1;          /*!< bit:      1  TXRDY Interrupt Mask               */
+    uint32_t RXBRK:1;          /*!< bit:      2  Receiver Break Interrupt Mask      */
+    uint32_t :2;               /*!< bit:  3.. 4  Reserved                           */
+    uint32_t OVRE:1;           /*!< bit:      5  Overrun Error Interrupt Mask       */
+    uint32_t FRAME:1;          /*!< bit:      6  Framing Error Interrupt Mask       */
+    uint32_t PARE:1;           /*!< bit:      7  Parity Error Interrupt Mask        */
+    uint32_t TIMEOUT:1;        /*!< bit:      8  Time-out Interrupt Mask            */
+    uint32_t TXEMPTY:1;        /*!< bit:      9  TXEMPTY Interrupt Mask             */
+    uint32_t ITER:1;           /*!< bit:     10  Iteration Interrupt Mask           */
+    uint32_t TXBUFE:1;         /*!< bit:     11  Buffer Empty Interrupt Mask        */
+    uint32_t RXBUFF:1;         /*!< bit:     12  Buffer Full Interrupt Mask         */
+    uint32_t NACK:1;           /*!< bit:     13  Non Acknowledge  or LIN Break Sent or LIN Break Received Interrupt Mask */
+    uint32_t LINID:1;          /*!< bit:     14  LIN Identifier Sent or LIN Received Interrupt Mask */
+    uint32_t LINTC:1;          /*!< bit:     15  LIN Transfer Conpleted Interrupt Mask */
+    uint32_t RIIC:1;           /*!< bit:     16  Ring Indicator Input Change Mask   */
+    uint32_t DSRIC:1;          /*!< bit:     17  Data Set Ready Input Change Mask   */
+    uint32_t DCDIC:1;          /*!< bit:     18  Data Carrier Detect Input Change Interrupt Mask */
+    uint32_t CTSIC:1;          /*!< bit:     19  Clear to Send Input Change Interrupt Mask */
+    uint32_t :5;               /*!< bit: 20..24  Reserved                           */
+    uint32_t LINBE:1;          /*!< bit:     25  LIN Bus Error Interrupt Mask       */
+    uint32_t LINISFE:1;        /*!< bit:     26  LIN Inconsistent Synch Field Error Interrupt Mask */
+    uint32_t LINIPE:1;         /*!< bit:     27  LIN Identifier Parity Interrupt Mask */
+    uint32_t LINCE:1;          /*!< bit:     28  LIN Checksum Error Interrupt Mask  */
+    uint32_t LINSNRE:1;        /*!< bit:     29  LIN Slave Not Responding Error Interrupt Mask */
+    uint32_t LINSTE:1;         /*!< bit:     30  LIN Synch Tolerance Error Interrupt Mask */
+    uint32_t LINHTE:1;         /*!< bit:     31  LIN Header Timeout Error Interrupt Mask */
+  } LIN;                       /*!< Structure used for LIN                          */
+  struct { // SPI_SLAVE mode
+    uint32_t RXRDY:1;          /*!< bit:      0  RXRDY Interrupt Mask               */
+    uint32_t TXRDY:1;          /*!< bit:      1  TXRDY Interrupt Mask               */
+    uint32_t RXBRK:1;          /*!< bit:      2  Receiver Break Interrupt Mask      */
+    uint32_t :2;               /*!< bit:  3.. 4  Reserved                           */
+    uint32_t OVRE:1;           /*!< bit:      5  Overrun Error Interrupt Mask       */
+    uint32_t FRAME:1;          /*!< bit:      6  Framing Error Interrupt Mask       */
+    uint32_t PARE:1;           /*!< bit:      7  Parity Error Interrupt Mask        */
+    uint32_t TIMEOUT:1;        /*!< bit:      8  Time-out Interrupt Mask            */
+    uint32_t TXEMPTY:1;        /*!< bit:      9  TXEMPTY Interrupt Mask             */
+    uint32_t UNRE:1;           /*!< bit:     10  SPI Underrun Error Interrupt Mask  */
+    uint32_t TXBUFE:1;         /*!< bit:     11  Buffer Empty Interrupt Mask        */
+    uint32_t RXBUFF:1;         /*!< bit:     12  Buffer Full Interrupt Mask         */
+    uint32_t NACK:1;           /*!< bit:     13  Non Acknowledge Interrupt Mask     */
+    uint32_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint32_t RIIC:1;           /*!< bit:     16  Ring Indicator Input Change Mask   */
+    uint32_t DSRIC:1;          /*!< bit:     17  Data Set Ready Input Change Mask   */
+    uint32_t DCDIC:1;          /*!< bit:     18  Data Carrier Detect Input Change Interrupt Mask */
+    uint32_t CTSIC:1;          /*!< bit:     19  Clear to Send Input Change Interrupt Mask */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } SPI_SLAVE;                 /*!< Structure used for SPI_SLAVE                    */
+  struct { // USART mode
+    uint32_t RXRDY:1;          /*!< bit:      0  RXRDY Interrupt Mask               */
+    uint32_t TXRDY:1;          /*!< bit:      1  TXRDY Interrupt Mask               */
+    uint32_t RXBRK:1;          /*!< bit:      2  Receiver Break Interrupt Mask      */
+    uint32_t :2;               /*!< bit:  3.. 4  Reserved                           */
+    uint32_t OVRE:1;           /*!< bit:      5  Overrun Error Interrupt Mask       */
+    uint32_t FRAME:1;          /*!< bit:      6  Framing Error Interrupt Mask       */
+    uint32_t PARE:1;           /*!< bit:      7  Parity Error Interrupt Mask        */
+    uint32_t TIMEOUT:1;        /*!< bit:      8  Time-out Interrupt Mask            */
+    uint32_t TXEMPTY:1;        /*!< bit:      9  TXEMPTY Interrupt Mask             */
+    uint32_t ITER:1;           /*!< bit:     10  Iteration Interrupt Mask           */
+    uint32_t TXBUFE:1;         /*!< bit:     11  Buffer Empty Interrupt Mask        */
+    uint32_t RXBUFF:1;         /*!< bit:     12  Buffer Full Interrupt Mask         */
+    uint32_t NACK:1;           /*!< bit:     13  Non Acknowledge Interrupt Mask     */
+    uint32_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint32_t RIIC:1;           /*!< bit:     16  Ring Indicator Input Change Mask   */
+    uint32_t DSRIC:1;          /*!< bit:     17  Data Set Ready Input Change Mask   */
+    uint32_t DCDIC:1;          /*!< bit:     18  Data Carrier Detect Input Change Interrupt Mask */
+    uint32_t CTSIC:1;          /*!< bit:     19  Clear to Send Input Change Interrupt Mask */
+    uint32_t MANE:1;           /*!< bit:     20  Manchester Error Interrupt Mask    */
+    uint32_t :3;               /*!< bit: 21..23  Reserved                           */
+    uint32_t MANEA:1;          /*!< bit:     24  Manchester Error Interrupt Mask    */
+    uint32_t :7;               /*!< bit: 25..31  Reserved                           */
+  } USART;                     /*!< Structure used for USART                        */
+  uint32_t reg;                /*!< Type      used for register access              */
+} US_IMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_IMR_OFFSET               0x10         /**< \brief (US_IMR offset) Interrupt Mask Register */
+#define US_IMR_RESETVALUE           _U(0x00000000); /**< \brief (US_IMR reset_value) Interrupt Mask Register */
+
+// LIN mode
+#define US_IMR_LIN_RXRDY_Pos        0            /**< \brief (US_IMR_LIN) RXRDY Interrupt Mask */
+#define US_IMR_LIN_RXRDY            (_U(0x1) << US_IMR_LIN_RXRDY_Pos)
+#define   US_IMR_LIN_RXRDY_0_Val          _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_RXRDY_1_Val          _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_RXRDY_0          (US_IMR_LIN_RXRDY_0_Val        << US_IMR_LIN_RXRDY_Pos)
+#define US_IMR_LIN_RXRDY_1          (US_IMR_LIN_RXRDY_1_Val        << US_IMR_LIN_RXRDY_Pos)
+#define US_IMR_LIN_TXRDY_Pos        1            /**< \brief (US_IMR_LIN) TXRDY Interrupt Mask */
+#define US_IMR_LIN_TXRDY            (_U(0x1) << US_IMR_LIN_TXRDY_Pos)
+#define   US_IMR_LIN_TXRDY_0_Val          _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_TXRDY_1_Val          _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_TXRDY_0          (US_IMR_LIN_TXRDY_0_Val        << US_IMR_LIN_TXRDY_Pos)
+#define US_IMR_LIN_TXRDY_1          (US_IMR_LIN_TXRDY_1_Val        << US_IMR_LIN_TXRDY_Pos)
+#define US_IMR_LIN_RXBRK_Pos        2            /**< \brief (US_IMR_LIN) Receiver Break Interrupt Mask */
+#define US_IMR_LIN_RXBRK            (_U(0x1) << US_IMR_LIN_RXBRK_Pos)
+#define   US_IMR_LIN_RXBRK_0_Val          _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_RXBRK_1_Val          _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_RXBRK_0          (US_IMR_LIN_RXBRK_0_Val        << US_IMR_LIN_RXBRK_Pos)
+#define US_IMR_LIN_RXBRK_1          (US_IMR_LIN_RXBRK_1_Val        << US_IMR_LIN_RXBRK_Pos)
+#define US_IMR_LIN_OVRE_Pos         5            /**< \brief (US_IMR_LIN) Overrun Error Interrupt Mask */
+#define US_IMR_LIN_OVRE             (_U(0x1) << US_IMR_LIN_OVRE_Pos)
+#define   US_IMR_LIN_OVRE_0_Val           _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_OVRE_1_Val           _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_OVRE_0           (US_IMR_LIN_OVRE_0_Val         << US_IMR_LIN_OVRE_Pos)
+#define US_IMR_LIN_OVRE_1           (US_IMR_LIN_OVRE_1_Val         << US_IMR_LIN_OVRE_Pos)
+#define US_IMR_LIN_FRAME_Pos        6            /**< \brief (US_IMR_LIN) Framing Error Interrupt Mask */
+#define US_IMR_LIN_FRAME            (_U(0x1) << US_IMR_LIN_FRAME_Pos)
+#define   US_IMR_LIN_FRAME_0_Val          _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_FRAME_1_Val          _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_FRAME_0          (US_IMR_LIN_FRAME_0_Val        << US_IMR_LIN_FRAME_Pos)
+#define US_IMR_LIN_FRAME_1          (US_IMR_LIN_FRAME_1_Val        << US_IMR_LIN_FRAME_Pos)
+#define US_IMR_LIN_PARE_Pos         7            /**< \brief (US_IMR_LIN) Parity Error Interrupt Mask */
+#define US_IMR_LIN_PARE             (_U(0x1) << US_IMR_LIN_PARE_Pos)
+#define   US_IMR_LIN_PARE_0_Val           _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_PARE_1_Val           _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_PARE_0           (US_IMR_LIN_PARE_0_Val         << US_IMR_LIN_PARE_Pos)
+#define US_IMR_LIN_PARE_1           (US_IMR_LIN_PARE_1_Val         << US_IMR_LIN_PARE_Pos)
+#define US_IMR_LIN_TIMEOUT_Pos      8            /**< \brief (US_IMR_LIN) Time-out Interrupt Mask */
+#define US_IMR_LIN_TIMEOUT          (_U(0x1) << US_IMR_LIN_TIMEOUT_Pos)
+#define   US_IMR_LIN_TIMEOUT_0_Val        _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_TIMEOUT_1_Val        _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_TIMEOUT_0        (US_IMR_LIN_TIMEOUT_0_Val      << US_IMR_LIN_TIMEOUT_Pos)
+#define US_IMR_LIN_TIMEOUT_1        (US_IMR_LIN_TIMEOUT_1_Val      << US_IMR_LIN_TIMEOUT_Pos)
+#define US_IMR_LIN_TXEMPTY_Pos      9            /**< \brief (US_IMR_LIN) TXEMPTY Interrupt Mask */
+#define US_IMR_LIN_TXEMPTY          (_U(0x1) << US_IMR_LIN_TXEMPTY_Pos)
+#define   US_IMR_LIN_TXEMPTY_0_Val        _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_TXEMPTY_1_Val        _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_TXEMPTY_0        (US_IMR_LIN_TXEMPTY_0_Val      << US_IMR_LIN_TXEMPTY_Pos)
+#define US_IMR_LIN_TXEMPTY_1        (US_IMR_LIN_TXEMPTY_1_Val      << US_IMR_LIN_TXEMPTY_Pos)
+#define US_IMR_LIN_ITER_Pos         10           /**< \brief (US_IMR_LIN) Iteration Interrupt Mask */
+#define US_IMR_LIN_ITER             (_U(0x1) << US_IMR_LIN_ITER_Pos)
+#define   US_IMR_LIN_ITER_0_Val           _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_ITER_1_Val           _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_ITER_0           (US_IMR_LIN_ITER_0_Val         << US_IMR_LIN_ITER_Pos)
+#define US_IMR_LIN_ITER_1           (US_IMR_LIN_ITER_1_Val         << US_IMR_LIN_ITER_Pos)
+#define US_IMR_LIN_TXBUFE_Pos       11           /**< \brief (US_IMR_LIN) Buffer Empty Interrupt Mask */
+#define US_IMR_LIN_TXBUFE           (_U(0x1) << US_IMR_LIN_TXBUFE_Pos)
+#define   US_IMR_LIN_TXBUFE_0_Val         _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_TXBUFE_1_Val         _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_TXBUFE_0         (US_IMR_LIN_TXBUFE_0_Val       << US_IMR_LIN_TXBUFE_Pos)
+#define US_IMR_LIN_TXBUFE_1         (US_IMR_LIN_TXBUFE_1_Val       << US_IMR_LIN_TXBUFE_Pos)
+#define US_IMR_LIN_RXBUFF_Pos       12           /**< \brief (US_IMR_LIN) Buffer Full Interrupt Mask */
+#define US_IMR_LIN_RXBUFF           (_U(0x1) << US_IMR_LIN_RXBUFF_Pos)
+#define   US_IMR_LIN_RXBUFF_0_Val         _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_RXBUFF_1_Val         _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_RXBUFF_0         (US_IMR_LIN_RXBUFF_0_Val       << US_IMR_LIN_RXBUFF_Pos)
+#define US_IMR_LIN_RXBUFF_1         (US_IMR_LIN_RXBUFF_1_Val       << US_IMR_LIN_RXBUFF_Pos)
+#define US_IMR_LIN_NACK_Pos         13           /**< \brief (US_IMR_LIN) Non Acknowledge  or LIN Break Sent or LIN Break Received Interrupt Mask */
+#define US_IMR_LIN_NACK             (_U(0x1) << US_IMR_LIN_NACK_Pos)
+#define   US_IMR_LIN_NACK_0_Val           _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_NACK_1_Val           _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_NACK_0           (US_IMR_LIN_NACK_0_Val         << US_IMR_LIN_NACK_Pos)
+#define US_IMR_LIN_NACK_1           (US_IMR_LIN_NACK_1_Val         << US_IMR_LIN_NACK_Pos)
+#define US_IMR_LIN_LINID_Pos        14           /**< \brief (US_IMR_LIN) LIN Identifier Sent or LIN Received Interrupt Mask */
+#define US_IMR_LIN_LINID            (_U(0x1) << US_IMR_LIN_LINID_Pos)
+#define US_IMR_LIN_LINTC_Pos        15           /**< \brief (US_IMR_LIN) LIN Transfer Conpleted Interrupt Mask */
+#define US_IMR_LIN_LINTC            (_U(0x1) << US_IMR_LIN_LINTC_Pos)
+#define US_IMR_LIN_RIIC_Pos         16           /**< \brief (US_IMR_LIN) Ring Indicator Input Change Mask */
+#define US_IMR_LIN_RIIC             (_U(0x1) << US_IMR_LIN_RIIC_Pos)
+#define   US_IMR_LIN_RIIC_0_Val           _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_RIIC_1_Val           _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_RIIC_0           (US_IMR_LIN_RIIC_0_Val         << US_IMR_LIN_RIIC_Pos)
+#define US_IMR_LIN_RIIC_1           (US_IMR_LIN_RIIC_1_Val         << US_IMR_LIN_RIIC_Pos)
+#define US_IMR_LIN_DSRIC_Pos        17           /**< \brief (US_IMR_LIN) Data Set Ready Input Change Mask */
+#define US_IMR_LIN_DSRIC            (_U(0x1) << US_IMR_LIN_DSRIC_Pos)
+#define   US_IMR_LIN_DSRIC_0_Val          _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_DSRIC_1_Val          _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_DSRIC_0          (US_IMR_LIN_DSRIC_0_Val        << US_IMR_LIN_DSRIC_Pos)
+#define US_IMR_LIN_DSRIC_1          (US_IMR_LIN_DSRIC_1_Val        << US_IMR_LIN_DSRIC_Pos)
+#define US_IMR_LIN_DCDIC_Pos        18           /**< \brief (US_IMR_LIN) Data Carrier Detect Input Change Interrupt Mask */
+#define US_IMR_LIN_DCDIC            (_U(0x1) << US_IMR_LIN_DCDIC_Pos)
+#define   US_IMR_LIN_DCDIC_0_Val          _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_DCDIC_1_Val          _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_DCDIC_0          (US_IMR_LIN_DCDIC_0_Val        << US_IMR_LIN_DCDIC_Pos)
+#define US_IMR_LIN_DCDIC_1          (US_IMR_LIN_DCDIC_1_Val        << US_IMR_LIN_DCDIC_Pos)
+#define US_IMR_LIN_CTSIC_Pos        19           /**< \brief (US_IMR_LIN) Clear to Send Input Change Interrupt Mask */
+#define US_IMR_LIN_CTSIC            (_U(0x1) << US_IMR_LIN_CTSIC_Pos)
+#define   US_IMR_LIN_CTSIC_0_Val          _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_CTSIC_1_Val          _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_CTSIC_0          (US_IMR_LIN_CTSIC_0_Val        << US_IMR_LIN_CTSIC_Pos)
+#define US_IMR_LIN_CTSIC_1          (US_IMR_LIN_CTSIC_1_Val        << US_IMR_LIN_CTSIC_Pos)
+#define US_IMR_LIN_LINBE_Pos        25           /**< \brief (US_IMR_LIN) LIN Bus Error Interrupt Mask */
+#define US_IMR_LIN_LINBE            (_U(0x1) << US_IMR_LIN_LINBE_Pos)
+#define US_IMR_LIN_LINISFE_Pos      26           /**< \brief (US_IMR_LIN) LIN Inconsistent Synch Field Error Interrupt Mask */
+#define US_IMR_LIN_LINISFE          (_U(0x1) << US_IMR_LIN_LINISFE_Pos)
+#define US_IMR_LIN_LINIPE_Pos       27           /**< \brief (US_IMR_LIN) LIN Identifier Parity Interrupt Mask */
+#define US_IMR_LIN_LINIPE           (_U(0x1) << US_IMR_LIN_LINIPE_Pos)
+#define US_IMR_LIN_LINCE_Pos        28           /**< \brief (US_IMR_LIN) LIN Checksum Error Interrupt Mask */
+#define US_IMR_LIN_LINCE            (_U(0x1) << US_IMR_LIN_LINCE_Pos)
+#define US_IMR_LIN_LINSNRE_Pos      29           /**< \brief (US_IMR_LIN) LIN Slave Not Responding Error Interrupt Mask */
+#define US_IMR_LIN_LINSNRE          (_U(0x1) << US_IMR_LIN_LINSNRE_Pos)
+#define US_IMR_LIN_LINSTE_Pos       30           /**< \brief (US_IMR_LIN) LIN Synch Tolerance Error Interrupt Mask */
+#define US_IMR_LIN_LINSTE           (_U(0x1) << US_IMR_LIN_LINSTE_Pos)
+#define   US_IMR_LIN_LINSTE_0_Val         _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_LINSTE_1_Val         _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_LINSTE_0         (US_IMR_LIN_LINSTE_0_Val       << US_IMR_LIN_LINSTE_Pos)
+#define US_IMR_LIN_LINSTE_1         (US_IMR_LIN_LINSTE_1_Val       << US_IMR_LIN_LINSTE_Pos)
+#define US_IMR_LIN_LINHTE_Pos       31           /**< \brief (US_IMR_LIN) LIN Header Timeout Error Interrupt Mask */
+#define US_IMR_LIN_LINHTE           (_U(0x1) << US_IMR_LIN_LINHTE_Pos)
+#define   US_IMR_LIN_LINHTE_0_Val         _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_LINHTE_1_Val         _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_LINHTE_0         (US_IMR_LIN_LINHTE_0_Val       << US_IMR_LIN_LINHTE_Pos)
+#define US_IMR_LIN_LINHTE_1         (US_IMR_LIN_LINHTE_1_Val       << US_IMR_LIN_LINHTE_Pos)
+#define US_IMR_LIN_MASK             _U(0xFE0FFFE7) /**< \brief (US_IMR_LIN) MASK Register */
+
+// SPI_SLAVE mode
+#define US_IMR_SPI_SLAVE_RXRDY_Pos  0            /**< \brief (US_IMR_SPI_SLAVE) RXRDY Interrupt Mask */
+#define US_IMR_SPI_SLAVE_RXRDY      (_U(0x1) << US_IMR_SPI_SLAVE_RXRDY_Pos)
+#define   US_IMR_SPI_SLAVE_RXRDY_0_Val    _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_RXRDY_1_Val    _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_RXRDY_0    (US_IMR_SPI_SLAVE_RXRDY_0_Val  << US_IMR_SPI_SLAVE_RXRDY_Pos)
+#define US_IMR_SPI_SLAVE_RXRDY_1    (US_IMR_SPI_SLAVE_RXRDY_1_Val  << US_IMR_SPI_SLAVE_RXRDY_Pos)
+#define US_IMR_SPI_SLAVE_TXRDY_Pos  1            /**< \brief (US_IMR_SPI_SLAVE) TXRDY Interrupt Mask */
+#define US_IMR_SPI_SLAVE_TXRDY      (_U(0x1) << US_IMR_SPI_SLAVE_TXRDY_Pos)
+#define   US_IMR_SPI_SLAVE_TXRDY_0_Val    _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_TXRDY_1_Val    _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_TXRDY_0    (US_IMR_SPI_SLAVE_TXRDY_0_Val  << US_IMR_SPI_SLAVE_TXRDY_Pos)
+#define US_IMR_SPI_SLAVE_TXRDY_1    (US_IMR_SPI_SLAVE_TXRDY_1_Val  << US_IMR_SPI_SLAVE_TXRDY_Pos)
+#define US_IMR_SPI_SLAVE_RXBRK_Pos  2            /**< \brief (US_IMR_SPI_SLAVE) Receiver Break Interrupt Mask */
+#define US_IMR_SPI_SLAVE_RXBRK      (_U(0x1) << US_IMR_SPI_SLAVE_RXBRK_Pos)
+#define   US_IMR_SPI_SLAVE_RXBRK_0_Val    _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_RXBRK_1_Val    _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_RXBRK_0    (US_IMR_SPI_SLAVE_RXBRK_0_Val  << US_IMR_SPI_SLAVE_RXBRK_Pos)
+#define US_IMR_SPI_SLAVE_RXBRK_1    (US_IMR_SPI_SLAVE_RXBRK_1_Val  << US_IMR_SPI_SLAVE_RXBRK_Pos)
+#define US_IMR_SPI_SLAVE_OVRE_Pos   5            /**< \brief (US_IMR_SPI_SLAVE) Overrun Error Interrupt Mask */
+#define US_IMR_SPI_SLAVE_OVRE       (_U(0x1) << US_IMR_SPI_SLAVE_OVRE_Pos)
+#define   US_IMR_SPI_SLAVE_OVRE_0_Val     _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_OVRE_1_Val     _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_OVRE_0     (US_IMR_SPI_SLAVE_OVRE_0_Val   << US_IMR_SPI_SLAVE_OVRE_Pos)
+#define US_IMR_SPI_SLAVE_OVRE_1     (US_IMR_SPI_SLAVE_OVRE_1_Val   << US_IMR_SPI_SLAVE_OVRE_Pos)
+#define US_IMR_SPI_SLAVE_FRAME_Pos  6            /**< \brief (US_IMR_SPI_SLAVE) Framing Error Interrupt Mask */
+#define US_IMR_SPI_SLAVE_FRAME      (_U(0x1) << US_IMR_SPI_SLAVE_FRAME_Pos)
+#define   US_IMR_SPI_SLAVE_FRAME_0_Val    _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_FRAME_1_Val    _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_FRAME_0    (US_IMR_SPI_SLAVE_FRAME_0_Val  << US_IMR_SPI_SLAVE_FRAME_Pos)
+#define US_IMR_SPI_SLAVE_FRAME_1    (US_IMR_SPI_SLAVE_FRAME_1_Val  << US_IMR_SPI_SLAVE_FRAME_Pos)
+#define US_IMR_SPI_SLAVE_PARE_Pos   7            /**< \brief (US_IMR_SPI_SLAVE) Parity Error Interrupt Mask */
+#define US_IMR_SPI_SLAVE_PARE       (_U(0x1) << US_IMR_SPI_SLAVE_PARE_Pos)
+#define   US_IMR_SPI_SLAVE_PARE_0_Val     _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_PARE_1_Val     _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_PARE_0     (US_IMR_SPI_SLAVE_PARE_0_Val   << US_IMR_SPI_SLAVE_PARE_Pos)
+#define US_IMR_SPI_SLAVE_PARE_1     (US_IMR_SPI_SLAVE_PARE_1_Val   << US_IMR_SPI_SLAVE_PARE_Pos)
+#define US_IMR_SPI_SLAVE_TIMEOUT_Pos 8            /**< \brief (US_IMR_SPI_SLAVE) Time-out Interrupt Mask */
+#define US_IMR_SPI_SLAVE_TIMEOUT    (_U(0x1) << US_IMR_SPI_SLAVE_TIMEOUT_Pos)
+#define   US_IMR_SPI_SLAVE_TIMEOUT_0_Val  _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_TIMEOUT_1_Val  _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_TIMEOUT_0  (US_IMR_SPI_SLAVE_TIMEOUT_0_Val << US_IMR_SPI_SLAVE_TIMEOUT_Pos)
+#define US_IMR_SPI_SLAVE_TIMEOUT_1  (US_IMR_SPI_SLAVE_TIMEOUT_1_Val << US_IMR_SPI_SLAVE_TIMEOUT_Pos)
+#define US_IMR_SPI_SLAVE_TXEMPTY_Pos 9            /**< \brief (US_IMR_SPI_SLAVE) TXEMPTY Interrupt Mask */
+#define US_IMR_SPI_SLAVE_TXEMPTY    (_U(0x1) << US_IMR_SPI_SLAVE_TXEMPTY_Pos)
+#define   US_IMR_SPI_SLAVE_TXEMPTY_0_Val  _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_TXEMPTY_1_Val  _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_TXEMPTY_0  (US_IMR_SPI_SLAVE_TXEMPTY_0_Val << US_IMR_SPI_SLAVE_TXEMPTY_Pos)
+#define US_IMR_SPI_SLAVE_TXEMPTY_1  (US_IMR_SPI_SLAVE_TXEMPTY_1_Val << US_IMR_SPI_SLAVE_TXEMPTY_Pos)
+#define US_IMR_SPI_SLAVE_UNRE_Pos   10           /**< \brief (US_IMR_SPI_SLAVE) SPI Underrun Error Interrupt Mask */
+#define US_IMR_SPI_SLAVE_UNRE       (_U(0x1) << US_IMR_SPI_SLAVE_UNRE_Pos)
+#define   US_IMR_SPI_SLAVE_UNRE_0_Val     _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_UNRE_1_Val     _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_UNRE_0     (US_IMR_SPI_SLAVE_UNRE_0_Val   << US_IMR_SPI_SLAVE_UNRE_Pos)
+#define US_IMR_SPI_SLAVE_UNRE_1     (US_IMR_SPI_SLAVE_UNRE_1_Val   << US_IMR_SPI_SLAVE_UNRE_Pos)
+#define US_IMR_SPI_SLAVE_TXBUFE_Pos 11           /**< \brief (US_IMR_SPI_SLAVE) Buffer Empty Interrupt Mask */
+#define US_IMR_SPI_SLAVE_TXBUFE     (_U(0x1) << US_IMR_SPI_SLAVE_TXBUFE_Pos)
+#define   US_IMR_SPI_SLAVE_TXBUFE_0_Val   _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_TXBUFE_1_Val   _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_TXBUFE_0   (US_IMR_SPI_SLAVE_TXBUFE_0_Val << US_IMR_SPI_SLAVE_TXBUFE_Pos)
+#define US_IMR_SPI_SLAVE_TXBUFE_1   (US_IMR_SPI_SLAVE_TXBUFE_1_Val << US_IMR_SPI_SLAVE_TXBUFE_Pos)
+#define US_IMR_SPI_SLAVE_RXBUFF_Pos 12           /**< \brief (US_IMR_SPI_SLAVE) Buffer Full Interrupt Mask */
+#define US_IMR_SPI_SLAVE_RXBUFF     (_U(0x1) << US_IMR_SPI_SLAVE_RXBUFF_Pos)
+#define   US_IMR_SPI_SLAVE_RXBUFF_0_Val   _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_RXBUFF_1_Val   _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_RXBUFF_0   (US_IMR_SPI_SLAVE_RXBUFF_0_Val << US_IMR_SPI_SLAVE_RXBUFF_Pos)
+#define US_IMR_SPI_SLAVE_RXBUFF_1   (US_IMR_SPI_SLAVE_RXBUFF_1_Val << US_IMR_SPI_SLAVE_RXBUFF_Pos)
+#define US_IMR_SPI_SLAVE_NACK_Pos   13           /**< \brief (US_IMR_SPI_SLAVE) Non Acknowledge Interrupt Mask */
+#define US_IMR_SPI_SLAVE_NACK       (_U(0x1) << US_IMR_SPI_SLAVE_NACK_Pos)
+#define   US_IMR_SPI_SLAVE_NACK_0_Val     _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_NACK_1_Val     _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_NACK_0     (US_IMR_SPI_SLAVE_NACK_0_Val   << US_IMR_SPI_SLAVE_NACK_Pos)
+#define US_IMR_SPI_SLAVE_NACK_1     (US_IMR_SPI_SLAVE_NACK_1_Val   << US_IMR_SPI_SLAVE_NACK_Pos)
+#define US_IMR_SPI_SLAVE_RIIC_Pos   16           /**< \brief (US_IMR_SPI_SLAVE) Ring Indicator Input Change Mask */
+#define US_IMR_SPI_SLAVE_RIIC       (_U(0x1) << US_IMR_SPI_SLAVE_RIIC_Pos)
+#define   US_IMR_SPI_SLAVE_RIIC_0_Val     _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_RIIC_1_Val     _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_RIIC_0     (US_IMR_SPI_SLAVE_RIIC_0_Val   << US_IMR_SPI_SLAVE_RIIC_Pos)
+#define US_IMR_SPI_SLAVE_RIIC_1     (US_IMR_SPI_SLAVE_RIIC_1_Val   << US_IMR_SPI_SLAVE_RIIC_Pos)
+#define US_IMR_SPI_SLAVE_DSRIC_Pos  17           /**< \brief (US_IMR_SPI_SLAVE) Data Set Ready Input Change Mask */
+#define US_IMR_SPI_SLAVE_DSRIC      (_U(0x1) << US_IMR_SPI_SLAVE_DSRIC_Pos)
+#define   US_IMR_SPI_SLAVE_DSRIC_0_Val    _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_DSRIC_1_Val    _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_DSRIC_0    (US_IMR_SPI_SLAVE_DSRIC_0_Val  << US_IMR_SPI_SLAVE_DSRIC_Pos)
+#define US_IMR_SPI_SLAVE_DSRIC_1    (US_IMR_SPI_SLAVE_DSRIC_1_Val  << US_IMR_SPI_SLAVE_DSRIC_Pos)
+#define US_IMR_SPI_SLAVE_DCDIC_Pos  18           /**< \brief (US_IMR_SPI_SLAVE) Data Carrier Detect Input Change Interrupt Mask */
+#define US_IMR_SPI_SLAVE_DCDIC      (_U(0x1) << US_IMR_SPI_SLAVE_DCDIC_Pos)
+#define   US_IMR_SPI_SLAVE_DCDIC_0_Val    _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_DCDIC_1_Val    _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_DCDIC_0    (US_IMR_SPI_SLAVE_DCDIC_0_Val  << US_IMR_SPI_SLAVE_DCDIC_Pos)
+#define US_IMR_SPI_SLAVE_DCDIC_1    (US_IMR_SPI_SLAVE_DCDIC_1_Val  << US_IMR_SPI_SLAVE_DCDIC_Pos)
+#define US_IMR_SPI_SLAVE_CTSIC_Pos  19           /**< \brief (US_IMR_SPI_SLAVE) Clear to Send Input Change Interrupt Mask */
+#define US_IMR_SPI_SLAVE_CTSIC      (_U(0x1) << US_IMR_SPI_SLAVE_CTSIC_Pos)
+#define   US_IMR_SPI_SLAVE_CTSIC_0_Val    _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_CTSIC_1_Val    _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_CTSIC_0    (US_IMR_SPI_SLAVE_CTSIC_0_Val  << US_IMR_SPI_SLAVE_CTSIC_Pos)
+#define US_IMR_SPI_SLAVE_CTSIC_1    (US_IMR_SPI_SLAVE_CTSIC_1_Val  << US_IMR_SPI_SLAVE_CTSIC_Pos)
+#define US_IMR_SPI_SLAVE_MASK       _U(0x000F3FE7) /**< \brief (US_IMR_SPI_SLAVE) MASK Register */
+
+// USART mode
+#define US_IMR_USART_RXRDY_Pos      0            /**< \brief (US_IMR_USART) RXRDY Interrupt Mask */
+#define US_IMR_USART_RXRDY          (_U(0x1) << US_IMR_USART_RXRDY_Pos)
+#define   US_IMR_USART_RXRDY_0_Val        _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_RXRDY_1_Val        _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_RXRDY_0        (US_IMR_USART_RXRDY_0_Val      << US_IMR_USART_RXRDY_Pos)
+#define US_IMR_USART_RXRDY_1        (US_IMR_USART_RXRDY_1_Val      << US_IMR_USART_RXRDY_Pos)
+#define US_IMR_USART_TXRDY_Pos      1            /**< \brief (US_IMR_USART) TXRDY Interrupt Mask */
+#define US_IMR_USART_TXRDY          (_U(0x1) << US_IMR_USART_TXRDY_Pos)
+#define   US_IMR_USART_TXRDY_0_Val        _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_TXRDY_1_Val        _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_TXRDY_0        (US_IMR_USART_TXRDY_0_Val      << US_IMR_USART_TXRDY_Pos)
+#define US_IMR_USART_TXRDY_1        (US_IMR_USART_TXRDY_1_Val      << US_IMR_USART_TXRDY_Pos)
+#define US_IMR_USART_RXBRK_Pos      2            /**< \brief (US_IMR_USART) Receiver Break Interrupt Mask */
+#define US_IMR_USART_RXBRK          (_U(0x1) << US_IMR_USART_RXBRK_Pos)
+#define   US_IMR_USART_RXBRK_0_Val        _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_RXBRK_1_Val        _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_RXBRK_0        (US_IMR_USART_RXBRK_0_Val      << US_IMR_USART_RXBRK_Pos)
+#define US_IMR_USART_RXBRK_1        (US_IMR_USART_RXBRK_1_Val      << US_IMR_USART_RXBRK_Pos)
+#define US_IMR_USART_OVRE_Pos       5            /**< \brief (US_IMR_USART) Overrun Error Interrupt Mask */
+#define US_IMR_USART_OVRE           (_U(0x1) << US_IMR_USART_OVRE_Pos)
+#define   US_IMR_USART_OVRE_0_Val         _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_OVRE_1_Val         _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_OVRE_0         (US_IMR_USART_OVRE_0_Val       << US_IMR_USART_OVRE_Pos)
+#define US_IMR_USART_OVRE_1         (US_IMR_USART_OVRE_1_Val       << US_IMR_USART_OVRE_Pos)
+#define US_IMR_USART_FRAME_Pos      6            /**< \brief (US_IMR_USART) Framing Error Interrupt Mask */
+#define US_IMR_USART_FRAME          (_U(0x1) << US_IMR_USART_FRAME_Pos)
+#define   US_IMR_USART_FRAME_0_Val        _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_FRAME_1_Val        _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_FRAME_0        (US_IMR_USART_FRAME_0_Val      << US_IMR_USART_FRAME_Pos)
+#define US_IMR_USART_FRAME_1        (US_IMR_USART_FRAME_1_Val      << US_IMR_USART_FRAME_Pos)
+#define US_IMR_USART_PARE_Pos       7            /**< \brief (US_IMR_USART) Parity Error Interrupt Mask */
+#define US_IMR_USART_PARE           (_U(0x1) << US_IMR_USART_PARE_Pos)
+#define   US_IMR_USART_PARE_0_Val         _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_PARE_1_Val         _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_PARE_0         (US_IMR_USART_PARE_0_Val       << US_IMR_USART_PARE_Pos)
+#define US_IMR_USART_PARE_1         (US_IMR_USART_PARE_1_Val       << US_IMR_USART_PARE_Pos)
+#define US_IMR_USART_TIMEOUT_Pos    8            /**< \brief (US_IMR_USART) Time-out Interrupt Mask */
+#define US_IMR_USART_TIMEOUT        (_U(0x1) << US_IMR_USART_TIMEOUT_Pos)
+#define   US_IMR_USART_TIMEOUT_0_Val      _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_TIMEOUT_1_Val      _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_TIMEOUT_0      (US_IMR_USART_TIMEOUT_0_Val    << US_IMR_USART_TIMEOUT_Pos)
+#define US_IMR_USART_TIMEOUT_1      (US_IMR_USART_TIMEOUT_1_Val    << US_IMR_USART_TIMEOUT_Pos)
+#define US_IMR_USART_TXEMPTY_Pos    9            /**< \brief (US_IMR_USART) TXEMPTY Interrupt Mask */
+#define US_IMR_USART_TXEMPTY        (_U(0x1) << US_IMR_USART_TXEMPTY_Pos)
+#define   US_IMR_USART_TXEMPTY_0_Val      _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_TXEMPTY_1_Val      _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_TXEMPTY_0      (US_IMR_USART_TXEMPTY_0_Val    << US_IMR_USART_TXEMPTY_Pos)
+#define US_IMR_USART_TXEMPTY_1      (US_IMR_USART_TXEMPTY_1_Val    << US_IMR_USART_TXEMPTY_Pos)
+#define US_IMR_USART_ITER_Pos       10           /**< \brief (US_IMR_USART) Iteration Interrupt Mask */
+#define US_IMR_USART_ITER           (_U(0x1) << US_IMR_USART_ITER_Pos)
+#define   US_IMR_USART_ITER_0_Val         _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_ITER_1_Val         _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_ITER_0         (US_IMR_USART_ITER_0_Val       << US_IMR_USART_ITER_Pos)
+#define US_IMR_USART_ITER_1         (US_IMR_USART_ITER_1_Val       << US_IMR_USART_ITER_Pos)
+#define US_IMR_USART_TXBUFE_Pos     11           /**< \brief (US_IMR_USART) Buffer Empty Interrupt Mask */
+#define US_IMR_USART_TXBUFE         (_U(0x1) << US_IMR_USART_TXBUFE_Pos)
+#define   US_IMR_USART_TXBUFE_0_Val       _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_TXBUFE_1_Val       _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_TXBUFE_0       (US_IMR_USART_TXBUFE_0_Val     << US_IMR_USART_TXBUFE_Pos)
+#define US_IMR_USART_TXBUFE_1       (US_IMR_USART_TXBUFE_1_Val     << US_IMR_USART_TXBUFE_Pos)
+#define US_IMR_USART_RXBUFF_Pos     12           /**< \brief (US_IMR_USART) Buffer Full Interrupt Mask */
+#define US_IMR_USART_RXBUFF         (_U(0x1) << US_IMR_USART_RXBUFF_Pos)
+#define   US_IMR_USART_RXBUFF_0_Val       _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_RXBUFF_1_Val       _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_RXBUFF_0       (US_IMR_USART_RXBUFF_0_Val     << US_IMR_USART_RXBUFF_Pos)
+#define US_IMR_USART_RXBUFF_1       (US_IMR_USART_RXBUFF_1_Val     << US_IMR_USART_RXBUFF_Pos)
+#define US_IMR_USART_NACK_Pos       13           /**< \brief (US_IMR_USART) Non Acknowledge Interrupt Mask */
+#define US_IMR_USART_NACK           (_U(0x1) << US_IMR_USART_NACK_Pos)
+#define   US_IMR_USART_NACK_0_Val         _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_NACK_1_Val         _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_NACK_0         (US_IMR_USART_NACK_0_Val       << US_IMR_USART_NACK_Pos)
+#define US_IMR_USART_NACK_1         (US_IMR_USART_NACK_1_Val       << US_IMR_USART_NACK_Pos)
+#define US_IMR_USART_RIIC_Pos       16           /**< \brief (US_IMR_USART) Ring Indicator Input Change Mask */
+#define US_IMR_USART_RIIC           (_U(0x1) << US_IMR_USART_RIIC_Pos)
+#define   US_IMR_USART_RIIC_0_Val         _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_RIIC_1_Val         _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_RIIC_0         (US_IMR_USART_RIIC_0_Val       << US_IMR_USART_RIIC_Pos)
+#define US_IMR_USART_RIIC_1         (US_IMR_USART_RIIC_1_Val       << US_IMR_USART_RIIC_Pos)
+#define US_IMR_USART_DSRIC_Pos      17           /**< \brief (US_IMR_USART) Data Set Ready Input Change Mask */
+#define US_IMR_USART_DSRIC          (_U(0x1) << US_IMR_USART_DSRIC_Pos)
+#define   US_IMR_USART_DSRIC_0_Val        _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_DSRIC_1_Val        _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_DSRIC_0        (US_IMR_USART_DSRIC_0_Val      << US_IMR_USART_DSRIC_Pos)
+#define US_IMR_USART_DSRIC_1        (US_IMR_USART_DSRIC_1_Val      << US_IMR_USART_DSRIC_Pos)
+#define US_IMR_USART_DCDIC_Pos      18           /**< \brief (US_IMR_USART) Data Carrier Detect Input Change Interrupt Mask */
+#define US_IMR_USART_DCDIC          (_U(0x1) << US_IMR_USART_DCDIC_Pos)
+#define   US_IMR_USART_DCDIC_0_Val        _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_DCDIC_1_Val        _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_DCDIC_0        (US_IMR_USART_DCDIC_0_Val      << US_IMR_USART_DCDIC_Pos)
+#define US_IMR_USART_DCDIC_1        (US_IMR_USART_DCDIC_1_Val      << US_IMR_USART_DCDIC_Pos)
+#define US_IMR_USART_CTSIC_Pos      19           /**< \brief (US_IMR_USART) Clear to Send Input Change Interrupt Mask */
+#define US_IMR_USART_CTSIC          (_U(0x1) << US_IMR_USART_CTSIC_Pos)
+#define   US_IMR_USART_CTSIC_0_Val        _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_CTSIC_1_Val        _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_CTSIC_0        (US_IMR_USART_CTSIC_0_Val      << US_IMR_USART_CTSIC_Pos)
+#define US_IMR_USART_CTSIC_1        (US_IMR_USART_CTSIC_1_Val      << US_IMR_USART_CTSIC_Pos)
+#define US_IMR_USART_MANE_Pos       20           /**< \brief (US_IMR_USART) Manchester Error Interrupt Mask */
+#define US_IMR_USART_MANE           (_U(0x1) << US_IMR_USART_MANE_Pos)
+#define US_IMR_USART_MANEA_Pos      24           /**< \brief (US_IMR_USART) Manchester Error Interrupt Mask */
+#define US_IMR_USART_MANEA          (_U(0x1) << US_IMR_USART_MANEA_Pos)
+#define   US_IMR_USART_MANEA_0_Val        _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_MANEA_1_Val        _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_MANEA_0        (US_IMR_USART_MANEA_0_Val      << US_IMR_USART_MANEA_Pos)
+#define US_IMR_USART_MANEA_1        (US_IMR_USART_MANEA_1_Val      << US_IMR_USART_MANEA_Pos)
+#define US_IMR_USART_MASK           _U(0x011F3FE7) /**< \brief (US_IMR_USART) MASK Register */
+
+// Any mode
+#define US_IMR_RXRDY_Pos            0            /**< \brief (US_IMR) RXRDY Interrupt Mask */
+#define US_IMR_RXRDY                (_U(0x1) << US_IMR_RXRDY_Pos)
+#define   US_IMR_RXRDY_0_Val              _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_RXRDY_1_Val              _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_RXRDY_0              (US_IMR_RXRDY_0_Val            << US_IMR_RXRDY_Pos)
+#define US_IMR_RXRDY_1              (US_IMR_RXRDY_1_Val            << US_IMR_RXRDY_Pos)
+#define US_IMR_TXRDY_Pos            1            /**< \brief (US_IMR) TXRDY Interrupt Mask */
+#define US_IMR_TXRDY                (_U(0x1) << US_IMR_TXRDY_Pos)
+#define   US_IMR_TXRDY_0_Val              _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_TXRDY_1_Val              _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_TXRDY_0              (US_IMR_TXRDY_0_Val            << US_IMR_TXRDY_Pos)
+#define US_IMR_TXRDY_1              (US_IMR_TXRDY_1_Val            << US_IMR_TXRDY_Pos)
+#define US_IMR_RXBRK_Pos            2            /**< \brief (US_IMR) Receiver Break Interrupt Mask */
+#define US_IMR_RXBRK                (_U(0x1) << US_IMR_RXBRK_Pos)
+#define   US_IMR_RXBRK_0_Val              _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_RXBRK_1_Val              _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_RXBRK_0              (US_IMR_RXBRK_0_Val            << US_IMR_RXBRK_Pos)
+#define US_IMR_RXBRK_1              (US_IMR_RXBRK_1_Val            << US_IMR_RXBRK_Pos)
+#define US_IMR_OVRE_Pos             5            /**< \brief (US_IMR) Overrun Error Interrupt Mask */
+#define US_IMR_OVRE                 (_U(0x1) << US_IMR_OVRE_Pos)
+#define   US_IMR_OVRE_0_Val               _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_OVRE_1_Val               _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_OVRE_0               (US_IMR_OVRE_0_Val             << US_IMR_OVRE_Pos)
+#define US_IMR_OVRE_1               (US_IMR_OVRE_1_Val             << US_IMR_OVRE_Pos)
+#define US_IMR_FRAME_Pos            6            /**< \brief (US_IMR) Framing Error Interrupt Mask */
+#define US_IMR_FRAME                (_U(0x1) << US_IMR_FRAME_Pos)
+#define   US_IMR_FRAME_0_Val              _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_FRAME_1_Val              _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_FRAME_0              (US_IMR_FRAME_0_Val            << US_IMR_FRAME_Pos)
+#define US_IMR_FRAME_1              (US_IMR_FRAME_1_Val            << US_IMR_FRAME_Pos)
+#define US_IMR_PARE_Pos             7            /**< \brief (US_IMR) Parity Error Interrupt Mask */
+#define US_IMR_PARE                 (_U(0x1) << US_IMR_PARE_Pos)
+#define   US_IMR_PARE_0_Val               _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_PARE_1_Val               _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_PARE_0               (US_IMR_PARE_0_Val             << US_IMR_PARE_Pos)
+#define US_IMR_PARE_1               (US_IMR_PARE_1_Val             << US_IMR_PARE_Pos)
+#define US_IMR_TIMEOUT_Pos          8            /**< \brief (US_IMR) Time-out Interrupt Mask */
+#define US_IMR_TIMEOUT              (_U(0x1) << US_IMR_TIMEOUT_Pos)
+#define   US_IMR_TIMEOUT_0_Val            _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_TIMEOUT_1_Val            _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_TIMEOUT_0            (US_IMR_TIMEOUT_0_Val          << US_IMR_TIMEOUT_Pos)
+#define US_IMR_TIMEOUT_1            (US_IMR_TIMEOUT_1_Val          << US_IMR_TIMEOUT_Pos)
+#define US_IMR_TXEMPTY_Pos          9            /**< \brief (US_IMR) TXEMPTY Interrupt Mask */
+#define US_IMR_TXEMPTY              (_U(0x1) << US_IMR_TXEMPTY_Pos)
+#define   US_IMR_TXEMPTY_0_Val            _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_TXEMPTY_1_Val            _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_TXEMPTY_0            (US_IMR_TXEMPTY_0_Val          << US_IMR_TXEMPTY_Pos)
+#define US_IMR_TXEMPTY_1            (US_IMR_TXEMPTY_1_Val          << US_IMR_TXEMPTY_Pos)
+#define US_IMR_ITER_Pos             10           /**< \brief (US_IMR) Iteration Interrupt Mask */
+#define US_IMR_ITER                 (_U(0x1) << US_IMR_ITER_Pos)
+#define   US_IMR_ITER_0_Val               _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_ITER_1_Val               _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_ITER_0               (US_IMR_ITER_0_Val             << US_IMR_ITER_Pos)
+#define US_IMR_ITER_1               (US_IMR_ITER_1_Val             << US_IMR_ITER_Pos)
+#define US_IMR_UNRE_Pos             10           /**< \brief (US_IMR) SPI Underrun Error Interrupt Mask */
+#define US_IMR_UNRE                 (_U(0x1) << US_IMR_UNRE_Pos)
+#define   US_IMR_UNRE_0_Val               _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_UNRE_1_Val               _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_UNRE_0               (US_IMR_UNRE_0_Val             << US_IMR_UNRE_Pos)
+#define US_IMR_UNRE_1               (US_IMR_UNRE_1_Val             << US_IMR_UNRE_Pos)
+#define US_IMR_ITER_Pos             10           /**< \brief (US_IMR) Iteration Interrupt Mask */
+#define US_IMR_ITER                 (_U(0x1) << US_IMR_ITER_Pos)
+#define   US_IMR_ITER_0_Val               _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_ITER_1_Val               _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_ITER_0               (US_IMR_ITER_0_Val             << US_IMR_ITER_Pos)
+#define US_IMR_ITER_1               (US_IMR_ITER_1_Val             << US_IMR_ITER_Pos)
+#define US_IMR_TXBUFE_Pos           11           /**< \brief (US_IMR) Buffer Empty Interrupt Mask */
+#define US_IMR_TXBUFE               (_U(0x1) << US_IMR_TXBUFE_Pos)
+#define   US_IMR_TXBUFE_0_Val             _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_TXBUFE_1_Val             _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_TXBUFE_0             (US_IMR_TXBUFE_0_Val           << US_IMR_TXBUFE_Pos)
+#define US_IMR_TXBUFE_1             (US_IMR_TXBUFE_1_Val           << US_IMR_TXBUFE_Pos)
+#define US_IMR_RXBUFF_Pos           12           /**< \brief (US_IMR) Buffer Full Interrupt Mask */
+#define US_IMR_RXBUFF               (_U(0x1) << US_IMR_RXBUFF_Pos)
+#define   US_IMR_RXBUFF_0_Val             _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_RXBUFF_1_Val             _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_RXBUFF_0             (US_IMR_RXBUFF_0_Val           << US_IMR_RXBUFF_Pos)
+#define US_IMR_RXBUFF_1             (US_IMR_RXBUFF_1_Val           << US_IMR_RXBUFF_Pos)
+#define US_IMR_NACK_Pos             13           /**< \brief (US_IMR) Non Acknowledge  or LIN Break Sent or LIN Break Received Interrupt Mask */
+#define US_IMR_NACK                 (_U(0x1) << US_IMR_NACK_Pos)
+#define   US_IMR_NACK_0_Val               _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_NACK_1_Val               _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_NACK_0               (US_IMR_NACK_0_Val             << US_IMR_NACK_Pos)
+#define US_IMR_NACK_1               (US_IMR_NACK_1_Val             << US_IMR_NACK_Pos)
+#define US_IMR_LINID_Pos            14           /**< \brief (US_IMR) LIN Identifier Sent or LIN Received Interrupt Mask */
+#define US_IMR_LINID                (_U(0x1) << US_IMR_LINID_Pos)
+#define US_IMR_LINTC_Pos            15           /**< \brief (US_IMR) LIN Transfer Conpleted Interrupt Mask */
+#define US_IMR_LINTC                (_U(0x1) << US_IMR_LINTC_Pos)
+#define US_IMR_RIIC_Pos             16           /**< \brief (US_IMR) Ring Indicator Input Change Mask */
+#define US_IMR_RIIC                 (_U(0x1) << US_IMR_RIIC_Pos)
+#define   US_IMR_RIIC_0_Val               _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_RIIC_1_Val               _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_RIIC_0               (US_IMR_RIIC_0_Val             << US_IMR_RIIC_Pos)
+#define US_IMR_RIIC_1               (US_IMR_RIIC_1_Val             << US_IMR_RIIC_Pos)
+#define US_IMR_DSRIC_Pos            17           /**< \brief (US_IMR) Data Set Ready Input Change Mask */
+#define US_IMR_DSRIC                (_U(0x1) << US_IMR_DSRIC_Pos)
+#define   US_IMR_DSRIC_0_Val              _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_DSRIC_1_Val              _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_DSRIC_0              (US_IMR_DSRIC_0_Val            << US_IMR_DSRIC_Pos)
+#define US_IMR_DSRIC_1              (US_IMR_DSRIC_1_Val            << US_IMR_DSRIC_Pos)
+#define US_IMR_DCDIC_Pos            18           /**< \brief (US_IMR) Data Carrier Detect Input Change Interrupt Mask */
+#define US_IMR_DCDIC                (_U(0x1) << US_IMR_DCDIC_Pos)
+#define   US_IMR_DCDIC_0_Val              _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_DCDIC_1_Val              _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_DCDIC_0              (US_IMR_DCDIC_0_Val            << US_IMR_DCDIC_Pos)
+#define US_IMR_DCDIC_1              (US_IMR_DCDIC_1_Val            << US_IMR_DCDIC_Pos)
+#define US_IMR_CTSIC_Pos            19           /**< \brief (US_IMR) Clear to Send Input Change Interrupt Mask */
+#define US_IMR_CTSIC                (_U(0x1) << US_IMR_CTSIC_Pos)
+#define   US_IMR_CTSIC_0_Val              _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_CTSIC_1_Val              _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_CTSIC_0              (US_IMR_CTSIC_0_Val            << US_IMR_CTSIC_Pos)
+#define US_IMR_CTSIC_1              (US_IMR_CTSIC_1_Val            << US_IMR_CTSIC_Pos)
+#define US_IMR_MANE_Pos             20           /**< \brief (US_IMR) Manchester Error Interrupt Mask */
+#define US_IMR_MANE                 (_U(0x1) << US_IMR_MANE_Pos)
+#define US_IMR_MANEA_Pos            24           /**< \brief (US_IMR) Manchester Error Interrupt Mask */
+#define US_IMR_MANEA                (_U(0x1) << US_IMR_MANEA_Pos)
+#define   US_IMR_MANEA_0_Val              _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_MANEA_1_Val              _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_MANEA_0              (US_IMR_MANEA_0_Val            << US_IMR_MANEA_Pos)
+#define US_IMR_MANEA_1              (US_IMR_MANEA_1_Val            << US_IMR_MANEA_Pos)
+#define US_IMR_LINBE_Pos            25           /**< \brief (US_IMR) LIN Bus Error Interrupt Mask */
+#define US_IMR_LINBE                (_U(0x1) << US_IMR_LINBE_Pos)
+#define US_IMR_LINISFE_Pos          26           /**< \brief (US_IMR) LIN Inconsistent Synch Field Error Interrupt Mask */
+#define US_IMR_LINISFE              (_U(0x1) << US_IMR_LINISFE_Pos)
+#define US_IMR_LINIPE_Pos           27           /**< \brief (US_IMR) LIN Identifier Parity Interrupt Mask */
+#define US_IMR_LINIPE               (_U(0x1) << US_IMR_LINIPE_Pos)
+#define US_IMR_LINCE_Pos            28           /**< \brief (US_IMR) LIN Checksum Error Interrupt Mask */
+#define US_IMR_LINCE                (_U(0x1) << US_IMR_LINCE_Pos)
+#define US_IMR_LINSNRE_Pos          29           /**< \brief (US_IMR) LIN Slave Not Responding Error Interrupt Mask */
+#define US_IMR_LINSNRE              (_U(0x1) << US_IMR_LINSNRE_Pos)
+#define US_IMR_LINSTE_Pos           30           /**< \brief (US_IMR) LIN Synch Tolerance Error Interrupt Mask */
+#define US_IMR_LINSTE               (_U(0x1) << US_IMR_LINSTE_Pos)
+#define   US_IMR_LINSTE_0_Val             _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_LINSTE_1_Val             _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_LINSTE_0             (US_IMR_LINSTE_0_Val           << US_IMR_LINSTE_Pos)
+#define US_IMR_LINSTE_1             (US_IMR_LINSTE_1_Val           << US_IMR_LINSTE_Pos)
+#define US_IMR_LINHTE_Pos           31           /**< \brief (US_IMR) LIN Header Timeout Error Interrupt Mask */
+#define US_IMR_LINHTE               (_U(0x1) << US_IMR_LINHTE_Pos)
+#define   US_IMR_LINHTE_0_Val             _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_LINHTE_1_Val             _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_LINHTE_0             (US_IMR_LINHTE_0_Val           << US_IMR_LINHTE_Pos)
+#define US_IMR_LINHTE_1             (US_IMR_LINHTE_1_Val           << US_IMR_LINHTE_Pos)
+#define US_IMR_MASK                 _U(0xFF1FFFE7) /**< \brief (US_IMR) MASK Register */
+
+/* -------- US_CSR : (USART Offset: 0x14) (R/  32) Channel Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct { // LIN mode
+    uint32_t RXRDY:1;          /*!< bit:      0  Receiver Ready                     */
+    uint32_t TXRDY:1;          /*!< bit:      1  Transmitter Ready                  */
+    uint32_t RXBRK:1;          /*!< bit:      2  Break Received/End of Break        */
+    uint32_t :2;               /*!< bit:  3.. 4  Reserved                           */
+    uint32_t OVRE:1;           /*!< bit:      5  Overrun Error                      */
+    uint32_t FRAME:1;          /*!< bit:      6  Framing Error                      */
+    uint32_t PARE:1;           /*!< bit:      7  Parity Error                       */
+    uint32_t TIMEOUT:1;        /*!< bit:      8  Receiver Time-out                  */
+    uint32_t TXEMPTY:1;        /*!< bit:      9  Transmitter Empty                  */
+    uint32_t ITER:1;           /*!< bit:     10  Max number of Repetitions Reached  */
+    uint32_t TXBUFE:1;         /*!< bit:     11  Transmission Buffer Empty          */
+    uint32_t RXBUFF:1;         /*!< bit:     12  Reception Buffer Full              */
+    uint32_t NACK:1;           /*!< bit:     13  Non Acknowledge or LIN Break Sent or LIN Break Received */
+    uint32_t LINID:1;          /*!< bit:     14  LIN Identifier Sent or LIN Identifier Received */
+    uint32_t LINTC:1;          /*!< bit:     15  LIN Transfer Conpleted             */
+    uint32_t RIIC:1;           /*!< bit:     16  Ring Indicator Input Change Flag   */
+    uint32_t DSRIC:1;          /*!< bit:     17  Data Set Ready Input Change Flag   */
+    uint32_t DCDIC:1;          /*!< bit:     18  Data Carrier Detect Input Change Flag */
+    uint32_t CTSIC:1;          /*!< bit:     19  Clear to Send Input Change Flag    */
+    uint32_t RI:1;             /*!< bit:     20  Image of RI Input                  */
+    uint32_t DSR:1;            /*!< bit:     21  Image of DSR Input                 */
+    uint32_t DCD:1;            /*!< bit:     22  Image of DCD Input                 */
+    uint32_t LINBLS:1;         /*!< bit:     23  LIN Bus Line Status                */
+    uint32_t :1;               /*!< bit:     24  Reserved                           */
+    uint32_t LINBE:1;          /*!< bit:     25  LIN Bit Error                      */
+    uint32_t LINISFE:1;        /*!< bit:     26  LIN Inconsistent Synch Field Error */
+    uint32_t LINIPE:1;         /*!< bit:     27  LIN Identifier Parity Error        */
+    uint32_t LINCE:1;          /*!< bit:     28  LIN Checksum Error                 */
+    uint32_t LINSNRE:1;        /*!< bit:     29  LIN Slave Not Responding Error     */
+    uint32_t LINSTE:1;         /*!< bit:     30  LIN Synch Tolerance Error          */
+    uint32_t LINHTE:1;         /*!< bit:     31  LIN Header Timeout Error           */
+  } LIN;                       /*!< Structure used for LIN                          */
+  struct { // SPI_SLAVE mode
+    uint32_t RXRDY:1;          /*!< bit:      0  Receiver Ready                     */
+    uint32_t TXRDY:1;          /*!< bit:      1  Transmitter Ready                  */
+    uint32_t RXBRK:1;          /*!< bit:      2  Break Received/End of Break        */
+    uint32_t :2;               /*!< bit:  3.. 4  Reserved                           */
+    uint32_t OVRE:1;           /*!< bit:      5  Overrun Error                      */
+    uint32_t FRAME:1;          /*!< bit:      6  Framing Error                      */
+    uint32_t PARE:1;           /*!< bit:      7  Parity Error                       */
+    uint32_t TIMEOUT:1;        /*!< bit:      8  Receiver Time-out                  */
+    uint32_t TXEMPTY:1;        /*!< bit:      9  Transmitter Empty                  */
+    uint32_t UNRE:1;           /*!< bit:     10  SPI Underrun Error                 */
+    uint32_t TXBUFE:1;         /*!< bit:     11  Transmission Buffer Empty          */
+    uint32_t RXBUFF:1;         /*!< bit:     12  Reception Buffer Full              */
+    uint32_t NACK:1;           /*!< bit:     13  Non Acknowledge                    */
+    uint32_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint32_t RIIC:1;           /*!< bit:     16  Ring Indicator Input Change Flag   */
+    uint32_t DSRIC:1;          /*!< bit:     17  Data Set Ready Input Change Flag   */
+    uint32_t DCDIC:1;          /*!< bit:     18  Data Carrier Detect Input Change Flag */
+    uint32_t CTSIC:1;          /*!< bit:     19  Clear to Send Input Change Flag    */
+    uint32_t RI:1;             /*!< bit:     20  Image of RI Input                  */
+    uint32_t DSR:1;            /*!< bit:     21  Image of DSR Input                 */
+    uint32_t DCD:1;            /*!< bit:     22  Image of DCD Input                 */
+    uint32_t CTS:1;            /*!< bit:     23  Image of CTS Input                 */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } SPI_SLAVE;                 /*!< Structure used for SPI_SLAVE                    */
+  struct { // USART mode
+    uint32_t RXRDY:1;          /*!< bit:      0  Receiver Ready                     */
+    uint32_t TXRDY:1;          /*!< bit:      1  Transmitter Ready                  */
+    uint32_t RXBRK:1;          /*!< bit:      2  Break Received/End of Break        */
+    uint32_t :2;               /*!< bit:  3.. 4  Reserved                           */
+    uint32_t OVRE:1;           /*!< bit:      5  Overrun Error                      */
+    uint32_t FRAME:1;          /*!< bit:      6  Framing Error                      */
+    uint32_t PARE:1;           /*!< bit:      7  Parity Error                       */
+    uint32_t TIMEOUT:1;        /*!< bit:      8  Receiver Time-out                  */
+    uint32_t TXEMPTY:1;        /*!< bit:      9  Transmitter Empty                  */
+    uint32_t ITER:1;           /*!< bit:     10  Max number of Repetitions Reached  */
+    uint32_t TXBUFE:1;         /*!< bit:     11  Transmission Buffer Empty          */
+    uint32_t RXBUFF:1;         /*!< bit:     12  Reception Buffer Full              */
+    uint32_t NACK:1;           /*!< bit:     13  Non Acknowledge                    */
+    uint32_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint32_t RIIC:1;           /*!< bit:     16  Ring Indicator Input Change Flag   */
+    uint32_t DSRIC:1;          /*!< bit:     17  Data Set Ready Input Change Flag   */
+    uint32_t DCDIC:1;          /*!< bit:     18  Data Carrier Detect Input Change Flag */
+    uint32_t CTSIC:1;          /*!< bit:     19  Clear to Send Input Change Flag    */
+    uint32_t RI:1;             /*!< bit:     20  Image of RI Input                  */
+    uint32_t DSR:1;            /*!< bit:     21  Image of DSR Input                 */
+    uint32_t DCD:1;            /*!< bit:     22  Image of DCD Input                 */
+    uint32_t CTS:1;            /*!< bit:     23  Image of CTS Input                 */
+    uint32_t MANERR:1;         /*!< bit:     24  Manchester Error                   */
+    uint32_t :7;               /*!< bit: 25..31  Reserved                           */
+  } USART;                     /*!< Structure used for USART                        */
+  uint32_t reg;                /*!< Type      used for register access              */
+} US_CSR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_CSR_OFFSET               0x14         /**< \brief (US_CSR offset) Channel Status Register */
+#define US_CSR_RESETVALUE           _U(0x00000000); /**< \brief (US_CSR reset_value) Channel Status Register */
+
+// LIN mode
+#define US_CSR_LIN_RXRDY_Pos        0            /**< \brief (US_CSR_LIN) Receiver Ready */
+#define US_CSR_LIN_RXRDY            (_U(0x1) << US_CSR_LIN_RXRDY_Pos)
+#define   US_CSR_LIN_RXRDY_0_Val          _U(0x0)   /**< \brief (US_CSR_LIN) No complete character has been received since the last read of RHR or the receiver is disabled. If characters werebeing received when the receiver was disabled, RXRDY changes to 1 when the receiver is enabled */
+#define   US_CSR_LIN_RXRDY_1_Val          _U(0x1)   /**< \brief (US_CSR_LIN) At least one complete character has been received and RHR has not yet been read */
+#define US_CSR_LIN_RXRDY_0          (US_CSR_LIN_RXRDY_0_Val        << US_CSR_LIN_RXRDY_Pos)
+#define US_CSR_LIN_RXRDY_1          (US_CSR_LIN_RXRDY_1_Val        << US_CSR_LIN_RXRDY_Pos)
+#define US_CSR_LIN_TXRDY_Pos        1            /**< \brief (US_CSR_LIN) Transmitter Ready */
+#define US_CSR_LIN_TXRDY            (_U(0x1) << US_CSR_LIN_TXRDY_Pos)
+#define   US_CSR_LIN_TXRDY_0_Val          _U(0x0)   /**< \brief (US_CSR_LIN) A character is in the THR waiting to be transferred to the Transmit Shift Register, or an STTBRK command has been requested, or the transmitter is disabled. As soon as the transmitter is enabled, TXRDY becomes 1 */
+#define   US_CSR_LIN_TXRDY_1_Val          _U(0x1)   /**< \brief (US_CSR_LIN) There is no character in the THR */
+#define US_CSR_LIN_TXRDY_0          (US_CSR_LIN_TXRDY_0_Val        << US_CSR_LIN_TXRDY_Pos)
+#define US_CSR_LIN_TXRDY_1          (US_CSR_LIN_TXRDY_1_Val        << US_CSR_LIN_TXRDY_Pos)
+#define US_CSR_LIN_RXBRK_Pos        2            /**< \brief (US_CSR_LIN) Break Received/End of Break */
+#define US_CSR_LIN_RXBRK            (_U(0x1) << US_CSR_LIN_RXBRK_Pos)
+#define   US_CSR_LIN_RXBRK_0_Val          _U(0x0)   /**< \brief (US_CSR_LIN) No Break received or End of Break detected since the last RSTSTA */
+#define   US_CSR_LIN_RXBRK_1_Val          _U(0x1)   /**< \brief (US_CSR_LIN) Break Received or End of Break detected since the last RSTSTA */
+#define US_CSR_LIN_RXBRK_0          (US_CSR_LIN_RXBRK_0_Val        << US_CSR_LIN_RXBRK_Pos)
+#define US_CSR_LIN_RXBRK_1          (US_CSR_LIN_RXBRK_1_Val        << US_CSR_LIN_RXBRK_Pos)
+#define US_CSR_LIN_OVRE_Pos         5            /**< \brief (US_CSR_LIN) Overrun Error */
+#define US_CSR_LIN_OVRE             (_U(0x1) << US_CSR_LIN_OVRE_Pos)
+#define   US_CSR_LIN_OVRE_0_Val           _U(0x0)   /**< \brief (US_CSR_LIN) No overrun error has occurred since since the last RSTSTA */
+#define   US_CSR_LIN_OVRE_1_Val           _U(0x1)   /**< \brief (US_CSR_LIN) At least one overrun error has occurred since the last RSTSTA */
+#define US_CSR_LIN_OVRE_0           (US_CSR_LIN_OVRE_0_Val         << US_CSR_LIN_OVRE_Pos)
+#define US_CSR_LIN_OVRE_1           (US_CSR_LIN_OVRE_1_Val         << US_CSR_LIN_OVRE_Pos)
+#define US_CSR_LIN_FRAME_Pos        6            /**< \brief (US_CSR_LIN) Framing Error */
+#define US_CSR_LIN_FRAME            (_U(0x1) << US_CSR_LIN_FRAME_Pos)
+#define   US_CSR_LIN_FRAME_0_Val          _U(0x0)   /**< \brief (US_CSR_LIN) No stop bit has been detected low since the last RSTSTA */
+#define   US_CSR_LIN_FRAME_1_Val          _U(0x1)   /**< \brief (US_CSR_LIN) At least one stop bit has been detected low since the last RSTSTA */
+#define US_CSR_LIN_FRAME_0          (US_CSR_LIN_FRAME_0_Val        << US_CSR_LIN_FRAME_Pos)
+#define US_CSR_LIN_FRAME_1          (US_CSR_LIN_FRAME_1_Val        << US_CSR_LIN_FRAME_Pos)
+#define US_CSR_LIN_PARE_Pos         7            /**< \brief (US_CSR_LIN) Parity Error */
+#define US_CSR_LIN_PARE             (_U(0x1) << US_CSR_LIN_PARE_Pos)
+#define   US_CSR_LIN_PARE_0_Val           _U(0x0)   /**< \brief (US_CSR_LIN) No parity error has been detected since the last RSTSTA */
+#define   US_CSR_LIN_PARE_1_Val           _U(0x1)   /**< \brief (US_CSR_LIN) At least one parity error has been detected since the last RSTSTA */
+#define US_CSR_LIN_PARE_0           (US_CSR_LIN_PARE_0_Val         << US_CSR_LIN_PARE_Pos)
+#define US_CSR_LIN_PARE_1           (US_CSR_LIN_PARE_1_Val         << US_CSR_LIN_PARE_Pos)
+#define US_CSR_LIN_TIMEOUT_Pos      8            /**< \brief (US_CSR_LIN) Receiver Time-out */
+#define US_CSR_LIN_TIMEOUT          (_U(0x1) << US_CSR_LIN_TIMEOUT_Pos)
+#define   US_CSR_LIN_TIMEOUT_0_Val        _U(0x0)   /**< \brief (US_CSR_LIN) There has not been a time-out since the last Start Time-out command or the Time-out Register is 0 */
+#define   US_CSR_LIN_TIMEOUT_1_Val        _U(0x1)   /**< \brief (US_CSR_LIN) There has been a time-out since the last Start Time-out command */
+#define US_CSR_LIN_TIMEOUT_0        (US_CSR_LIN_TIMEOUT_0_Val      << US_CSR_LIN_TIMEOUT_Pos)
+#define US_CSR_LIN_TIMEOUT_1        (US_CSR_LIN_TIMEOUT_1_Val      << US_CSR_LIN_TIMEOUT_Pos)
+#define US_CSR_LIN_TXEMPTY_Pos      9            /**< \brief (US_CSR_LIN) Transmitter Empty */
+#define US_CSR_LIN_TXEMPTY          (_U(0x1) << US_CSR_LIN_TXEMPTY_Pos)
+#define   US_CSR_LIN_TXEMPTY_0_Val        _U(0x0)   /**< \brief (US_CSR_LIN) There are characters in either THR or the Transmit Shift Register, or the transmitter is disabled */
+#define   US_CSR_LIN_TXEMPTY_1_Val        _U(0x1)   /**< \brief (US_CSR_LIN) There is at least one character in either THR or the Transmit Shift Register */
+#define US_CSR_LIN_TXEMPTY_0        (US_CSR_LIN_TXEMPTY_0_Val      << US_CSR_LIN_TXEMPTY_Pos)
+#define US_CSR_LIN_TXEMPTY_1        (US_CSR_LIN_TXEMPTY_1_Val      << US_CSR_LIN_TXEMPTY_Pos)
+#define US_CSR_LIN_ITER_Pos         10           /**< \brief (US_CSR_LIN) Max number of Repetitions Reached */
+#define US_CSR_LIN_ITER             (_U(0x1) << US_CSR_LIN_ITER_Pos)
+#define   US_CSR_LIN_ITER_0_Val           _U(0x0)   /**< \brief (US_CSR_LIN) Maximum number of repetitions has not been reached since the last RSIT */
+#define   US_CSR_LIN_ITER_1_Val           _U(0x1)   /**< \brief (US_CSR_LIN) Maximum number of repetitions has been reached since the last RSIT */
+#define US_CSR_LIN_ITER_0           (US_CSR_LIN_ITER_0_Val         << US_CSR_LIN_ITER_Pos)
+#define US_CSR_LIN_ITER_1           (US_CSR_LIN_ITER_1_Val         << US_CSR_LIN_ITER_Pos)
+#define US_CSR_LIN_TXBUFE_Pos       11           /**< \brief (US_CSR_LIN) Transmission Buffer Empty */
+#define US_CSR_LIN_TXBUFE           (_U(0x1) << US_CSR_LIN_TXBUFE_Pos)
+#define   US_CSR_LIN_TXBUFE_0_Val         _U(0x0)   /**< \brief (US_CSR_LIN) The signal Buffer Empty from the Transmit PDC channel is inactive */
+#define   US_CSR_LIN_TXBUFE_1_Val         _U(0x1)   /**< \brief (US_CSR_LIN) The signal Buffer Empty from the Transmit PDC channel is active */
+#define US_CSR_LIN_TXBUFE_0         (US_CSR_LIN_TXBUFE_0_Val       << US_CSR_LIN_TXBUFE_Pos)
+#define US_CSR_LIN_TXBUFE_1         (US_CSR_LIN_TXBUFE_1_Val       << US_CSR_LIN_TXBUFE_Pos)
+#define US_CSR_LIN_RXBUFF_Pos       12           /**< \brief (US_CSR_LIN) Reception Buffer Full */
+#define US_CSR_LIN_RXBUFF           (_U(0x1) << US_CSR_LIN_RXBUFF_Pos)
+#define   US_CSR_LIN_RXBUFF_0_Val         _U(0x0)   /**< \brief (US_CSR_LIN) The signal Buffer Full from the Receive PDC channel is inactive */
+#define   US_CSR_LIN_RXBUFF_1_Val         _U(0x1)   /**< \brief (US_CSR_LIN) The signal Buffer Full from the Receive PDC channel is active */
+#define US_CSR_LIN_RXBUFF_0         (US_CSR_LIN_RXBUFF_0_Val       << US_CSR_LIN_RXBUFF_Pos)
+#define US_CSR_LIN_RXBUFF_1         (US_CSR_LIN_RXBUFF_1_Val       << US_CSR_LIN_RXBUFF_Pos)
+#define US_CSR_LIN_NACK_Pos         13           /**< \brief (US_CSR_LIN) Non Acknowledge or LIN Break Sent or LIN Break Received */
+#define US_CSR_LIN_NACK             (_U(0x1) << US_CSR_LIN_NACK_Pos)
+#define   US_CSR_LIN_NACK_0_Val           _U(0x0)   /**< \brief (US_CSR_LIN) No Non Acknowledge has not been detected since the last RSTNACK */
+#define   US_CSR_LIN_NACK_1_Val           _U(0x1)   /**< \brief (US_CSR_LIN) At least one Non Acknowledge has been detected since the last RSTNACK */
+#define US_CSR_LIN_NACK_0           (US_CSR_LIN_NACK_0_Val         << US_CSR_LIN_NACK_Pos)
+#define US_CSR_LIN_NACK_1           (US_CSR_LIN_NACK_1_Val         << US_CSR_LIN_NACK_Pos)
+#define US_CSR_LIN_LINID_Pos        14           /**< \brief (US_CSR_LIN) LIN Identifier Sent or LIN Identifier Received */
+#define US_CSR_LIN_LINID            (_U(0x1) << US_CSR_LIN_LINID_Pos)
+#define US_CSR_LIN_LINTC_Pos        15           /**< \brief (US_CSR_LIN) LIN Transfer Conpleted */
+#define US_CSR_LIN_LINTC            (_U(0x1) << US_CSR_LIN_LINTC_Pos)
+#define US_CSR_LIN_RIIC_Pos         16           /**< \brief (US_CSR_LIN) Ring Indicator Input Change Flag */
+#define US_CSR_LIN_RIIC             (_U(0x1) << US_CSR_LIN_RIIC_Pos)
+#define   US_CSR_LIN_RIIC_0_Val           _U(0x0)   /**< \brief (US_CSR_LIN) No input change has been detected on the RI pin since the last read of CSR */
+#define   US_CSR_LIN_RIIC_1_Val           _U(0x1)   /**< \brief (US_CSR_LIN) At least one input change has been detected on the RI pin since the last read of CSR */
+#define US_CSR_LIN_RIIC_0           (US_CSR_LIN_RIIC_0_Val         << US_CSR_LIN_RIIC_Pos)
+#define US_CSR_LIN_RIIC_1           (US_CSR_LIN_RIIC_1_Val         << US_CSR_LIN_RIIC_Pos)
+#define US_CSR_LIN_DSRIC_Pos        17           /**< \brief (US_CSR_LIN) Data Set Ready Input Change Flag */
+#define US_CSR_LIN_DSRIC            (_U(0x1) << US_CSR_LIN_DSRIC_Pos)
+#define   US_CSR_LIN_DSRIC_0_Val          _U(0x0)   /**< \brief (US_CSR_LIN) No input change has been detected on the DSR pin since the last read of CSR */
+#define   US_CSR_LIN_DSRIC_1_Val          _U(0x1)   /**< \brief (US_CSR_LIN) At least one input change has been detected on the DSR pin since the last read of CSR */
+#define US_CSR_LIN_DSRIC_0          (US_CSR_LIN_DSRIC_0_Val        << US_CSR_LIN_DSRIC_Pos)
+#define US_CSR_LIN_DSRIC_1          (US_CSR_LIN_DSRIC_1_Val        << US_CSR_LIN_DSRIC_Pos)
+#define US_CSR_LIN_DCDIC_Pos        18           /**< \brief (US_CSR_LIN) Data Carrier Detect Input Change Flag */
+#define US_CSR_LIN_DCDIC            (_U(0x1) << US_CSR_LIN_DCDIC_Pos)
+#define   US_CSR_LIN_DCDIC_0_Val          _U(0x0)   /**< \brief (US_CSR_LIN) No input change has been detected on the DCD pin since the last read of CSR */
+#define   US_CSR_LIN_DCDIC_1_Val          _U(0x1)   /**< \brief (US_CSR_LIN) At least one input change has been detected on the DCD pin since the last read of CSR */
+#define US_CSR_LIN_DCDIC_0          (US_CSR_LIN_DCDIC_0_Val        << US_CSR_LIN_DCDIC_Pos)
+#define US_CSR_LIN_DCDIC_1          (US_CSR_LIN_DCDIC_1_Val        << US_CSR_LIN_DCDIC_Pos)
+#define US_CSR_LIN_CTSIC_Pos        19           /**< \brief (US_CSR_LIN) Clear to Send Input Change Flag */
+#define US_CSR_LIN_CTSIC            (_U(0x1) << US_CSR_LIN_CTSIC_Pos)
+#define   US_CSR_LIN_CTSIC_0_Val          _U(0x0)   /**< \brief (US_CSR_LIN) No input change has been detected on the CTS pin since the last read of CSR */
+#define   US_CSR_LIN_CTSIC_1_Val          _U(0x1)   /**< \brief (US_CSR_LIN) At least one input change has been detected on the CTS pin since the last read of CSR */
+#define US_CSR_LIN_CTSIC_0          (US_CSR_LIN_CTSIC_0_Val        << US_CSR_LIN_CTSIC_Pos)
+#define US_CSR_LIN_CTSIC_1          (US_CSR_LIN_CTSIC_1_Val        << US_CSR_LIN_CTSIC_Pos)
+#define US_CSR_LIN_RI_Pos           20           /**< \brief (US_CSR_LIN) Image of RI Input */
+#define US_CSR_LIN_RI               (_U(0x1) << US_CSR_LIN_RI_Pos)
+#define   US_CSR_LIN_RI_0_Val             _U(0x0)   /**< \brief (US_CSR_LIN) RI is at 0 */
+#define   US_CSR_LIN_RI_1_Val             _U(0x1)   /**< \brief (US_CSR_LIN) RI is at 1 */
+#define US_CSR_LIN_RI_0             (US_CSR_LIN_RI_0_Val           << US_CSR_LIN_RI_Pos)
+#define US_CSR_LIN_RI_1             (US_CSR_LIN_RI_1_Val           << US_CSR_LIN_RI_Pos)
+#define US_CSR_LIN_DSR_Pos          21           /**< \brief (US_CSR_LIN) Image of DSR Input */
+#define US_CSR_LIN_DSR              (_U(0x1) << US_CSR_LIN_DSR_Pos)
+#define   US_CSR_LIN_DSR_0_Val            _U(0x0)   /**< \brief (US_CSR_LIN) DSR is at 0 */
+#define   US_CSR_LIN_DSR_1_Val            _U(0x1)   /**< \brief (US_CSR_LIN) DSR is at 1 */
+#define US_CSR_LIN_DSR_0            (US_CSR_LIN_DSR_0_Val          << US_CSR_LIN_DSR_Pos)
+#define US_CSR_LIN_DSR_1            (US_CSR_LIN_DSR_1_Val          << US_CSR_LIN_DSR_Pos)
+#define US_CSR_LIN_DCD_Pos          22           /**< \brief (US_CSR_LIN) Image of DCD Input */
+#define US_CSR_LIN_DCD              (_U(0x1) << US_CSR_LIN_DCD_Pos)
+#define   US_CSR_LIN_DCD_0_Val            _U(0x0)   /**< \brief (US_CSR_LIN) DCD is at 0 */
+#define   US_CSR_LIN_DCD_1_Val            _U(0x1)   /**< \brief (US_CSR_LIN) DCD is at 1 */
+#define US_CSR_LIN_DCD_0            (US_CSR_LIN_DCD_0_Val          << US_CSR_LIN_DCD_Pos)
+#define US_CSR_LIN_DCD_1            (US_CSR_LIN_DCD_1_Val          << US_CSR_LIN_DCD_Pos)
+#define US_CSR_LIN_LINBLS_Pos       23           /**< \brief (US_CSR_LIN) LIN Bus Line Status */
+#define US_CSR_LIN_LINBLS           (_U(0x1) << US_CSR_LIN_LINBLS_Pos)
+#define   US_CSR_LIN_LINBLS_0_Val         _U(0x0)   /**< \brief (US_CSR_LIN) CTS is at 0 */
+#define   US_CSR_LIN_LINBLS_1_Val         _U(0x1)   /**< \brief (US_CSR_LIN) CTS is at 1 */
+#define US_CSR_LIN_LINBLS_0         (US_CSR_LIN_LINBLS_0_Val       << US_CSR_LIN_LINBLS_Pos)
+#define US_CSR_LIN_LINBLS_1         (US_CSR_LIN_LINBLS_1_Val       << US_CSR_LIN_LINBLS_Pos)
+#define US_CSR_LIN_LINBE_Pos        25           /**< \brief (US_CSR_LIN) LIN Bit Error */
+#define US_CSR_LIN_LINBE            (_U(0x1) << US_CSR_LIN_LINBE_Pos)
+#define US_CSR_LIN_LINISFE_Pos      26           /**< \brief (US_CSR_LIN) LIN Inconsistent Synch Field Error */
+#define US_CSR_LIN_LINISFE          (_U(0x1) << US_CSR_LIN_LINISFE_Pos)
+#define US_CSR_LIN_LINIPE_Pos       27           /**< \brief (US_CSR_LIN) LIN Identifier Parity Error */
+#define US_CSR_LIN_LINIPE           (_U(0x1) << US_CSR_LIN_LINIPE_Pos)
+#define US_CSR_LIN_LINCE_Pos        28           /**< \brief (US_CSR_LIN) LIN Checksum Error */
+#define US_CSR_LIN_LINCE            (_U(0x1) << US_CSR_LIN_LINCE_Pos)
+#define US_CSR_LIN_LINSNRE_Pos      29           /**< \brief (US_CSR_LIN) LIN Slave Not Responding Error */
+#define US_CSR_LIN_LINSNRE          (_U(0x1) << US_CSR_LIN_LINSNRE_Pos)
+#define US_CSR_LIN_LINSTE_Pos       30           /**< \brief (US_CSR_LIN) LIN Synch Tolerance Error */
+#define US_CSR_LIN_LINSTE           (_U(0x1) << US_CSR_LIN_LINSTE_Pos)
+#define   US_CSR_LIN_LINSTE_0_Val         _U(0x0)   /**< \brief (US_CSR_LIN) COMM_TX is at 0 */
+#define   US_CSR_LIN_LINSTE_1_Val         _U(0x1)   /**< \brief (US_CSR_LIN) COMM_TX is at 1 */
+#define US_CSR_LIN_LINSTE_0         (US_CSR_LIN_LINSTE_0_Val       << US_CSR_LIN_LINSTE_Pos)
+#define US_CSR_LIN_LINSTE_1         (US_CSR_LIN_LINSTE_1_Val       << US_CSR_LIN_LINSTE_Pos)
+#define US_CSR_LIN_LINHTE_Pos       31           /**< \brief (US_CSR_LIN) LIN Header Timeout Error */
+#define US_CSR_LIN_LINHTE           (_U(0x1) << US_CSR_LIN_LINHTE_Pos)
+#define   US_CSR_LIN_LINHTE_0_Val         _U(0x0)   /**< \brief (US_CSR_LIN) COMM_RX is at 0 */
+#define   US_CSR_LIN_LINHTE_1_Val         _U(0x1)   /**< \brief (US_CSR_LIN) COMM_RX is at 1 */
+#define US_CSR_LIN_LINHTE_0         (US_CSR_LIN_LINHTE_0_Val       << US_CSR_LIN_LINHTE_Pos)
+#define US_CSR_LIN_LINHTE_1         (US_CSR_LIN_LINHTE_1_Val       << US_CSR_LIN_LINHTE_Pos)
+#define US_CSR_LIN_MASK             _U(0xFEFFFFE7) /**< \brief (US_CSR_LIN) MASK Register */
+
+// SPI_SLAVE mode
+#define US_CSR_SPI_SLAVE_RXRDY_Pos  0            /**< \brief (US_CSR_SPI_SLAVE) Receiver Ready */
+#define US_CSR_SPI_SLAVE_RXRDY      (_U(0x1) << US_CSR_SPI_SLAVE_RXRDY_Pos)
+#define   US_CSR_SPI_SLAVE_RXRDY_0_Val    _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No complete character has been received since the last read of RHR or the receiver is disabled. If characters werebeing received when the receiver was disabled, RXRDY changes to 1 when the receiver is enabled */
+#define   US_CSR_SPI_SLAVE_RXRDY_1_Val    _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one complete character has been received and RHR has not yet been read */
+#define US_CSR_SPI_SLAVE_RXRDY_0    (US_CSR_SPI_SLAVE_RXRDY_0_Val  << US_CSR_SPI_SLAVE_RXRDY_Pos)
+#define US_CSR_SPI_SLAVE_RXRDY_1    (US_CSR_SPI_SLAVE_RXRDY_1_Val  << US_CSR_SPI_SLAVE_RXRDY_Pos)
+#define US_CSR_SPI_SLAVE_TXRDY_Pos  1            /**< \brief (US_CSR_SPI_SLAVE) Transmitter Ready */
+#define US_CSR_SPI_SLAVE_TXRDY      (_U(0x1) << US_CSR_SPI_SLAVE_TXRDY_Pos)
+#define   US_CSR_SPI_SLAVE_TXRDY_0_Val    _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) A character is in the THR waiting to be transferred to the Transmit Shift Register, or an STTBRK command has been requested, or the transmitter is disabled. As soon as the transmitter is enabled, TXRDY becomes 1 */
+#define   US_CSR_SPI_SLAVE_TXRDY_1_Val    _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) There is no character in the THR */
+#define US_CSR_SPI_SLAVE_TXRDY_0    (US_CSR_SPI_SLAVE_TXRDY_0_Val  << US_CSR_SPI_SLAVE_TXRDY_Pos)
+#define US_CSR_SPI_SLAVE_TXRDY_1    (US_CSR_SPI_SLAVE_TXRDY_1_Val  << US_CSR_SPI_SLAVE_TXRDY_Pos)
+#define US_CSR_SPI_SLAVE_RXBRK_Pos  2            /**< \brief (US_CSR_SPI_SLAVE) Break Received/End of Break */
+#define US_CSR_SPI_SLAVE_RXBRK      (_U(0x1) << US_CSR_SPI_SLAVE_RXBRK_Pos)
+#define   US_CSR_SPI_SLAVE_RXBRK_0_Val    _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No Break received or End of Break detected since the last RSTSTA */
+#define   US_CSR_SPI_SLAVE_RXBRK_1_Val    _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) Break Received or End of Break detected since the last RSTSTA */
+#define US_CSR_SPI_SLAVE_RXBRK_0    (US_CSR_SPI_SLAVE_RXBRK_0_Val  << US_CSR_SPI_SLAVE_RXBRK_Pos)
+#define US_CSR_SPI_SLAVE_RXBRK_1    (US_CSR_SPI_SLAVE_RXBRK_1_Val  << US_CSR_SPI_SLAVE_RXBRK_Pos)
+#define US_CSR_SPI_SLAVE_OVRE_Pos   5            /**< \brief (US_CSR_SPI_SLAVE) Overrun Error */
+#define US_CSR_SPI_SLAVE_OVRE       (_U(0x1) << US_CSR_SPI_SLAVE_OVRE_Pos)
+#define   US_CSR_SPI_SLAVE_OVRE_0_Val     _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No overrun error has occurred since since the last RSTSTA */
+#define   US_CSR_SPI_SLAVE_OVRE_1_Val     _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one overrun error has occurred since the last RSTSTA */
+#define US_CSR_SPI_SLAVE_OVRE_0     (US_CSR_SPI_SLAVE_OVRE_0_Val   << US_CSR_SPI_SLAVE_OVRE_Pos)
+#define US_CSR_SPI_SLAVE_OVRE_1     (US_CSR_SPI_SLAVE_OVRE_1_Val   << US_CSR_SPI_SLAVE_OVRE_Pos)
+#define US_CSR_SPI_SLAVE_FRAME_Pos  6            /**< \brief (US_CSR_SPI_SLAVE) Framing Error */
+#define US_CSR_SPI_SLAVE_FRAME      (_U(0x1) << US_CSR_SPI_SLAVE_FRAME_Pos)
+#define   US_CSR_SPI_SLAVE_FRAME_0_Val    _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No stop bit has been detected low since the last RSTSTA */
+#define   US_CSR_SPI_SLAVE_FRAME_1_Val    _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one stop bit has been detected low since the last RSTSTA */
+#define US_CSR_SPI_SLAVE_FRAME_0    (US_CSR_SPI_SLAVE_FRAME_0_Val  << US_CSR_SPI_SLAVE_FRAME_Pos)
+#define US_CSR_SPI_SLAVE_FRAME_1    (US_CSR_SPI_SLAVE_FRAME_1_Val  << US_CSR_SPI_SLAVE_FRAME_Pos)
+#define US_CSR_SPI_SLAVE_PARE_Pos   7            /**< \brief (US_CSR_SPI_SLAVE) Parity Error */
+#define US_CSR_SPI_SLAVE_PARE       (_U(0x1) << US_CSR_SPI_SLAVE_PARE_Pos)
+#define   US_CSR_SPI_SLAVE_PARE_0_Val     _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No parity error has been detected since the last RSTSTA */
+#define   US_CSR_SPI_SLAVE_PARE_1_Val     _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one parity error has been detected since the last RSTSTA */
+#define US_CSR_SPI_SLAVE_PARE_0     (US_CSR_SPI_SLAVE_PARE_0_Val   << US_CSR_SPI_SLAVE_PARE_Pos)
+#define US_CSR_SPI_SLAVE_PARE_1     (US_CSR_SPI_SLAVE_PARE_1_Val   << US_CSR_SPI_SLAVE_PARE_Pos)
+#define US_CSR_SPI_SLAVE_TIMEOUT_Pos 8            /**< \brief (US_CSR_SPI_SLAVE) Receiver Time-out */
+#define US_CSR_SPI_SLAVE_TIMEOUT    (_U(0x1) << US_CSR_SPI_SLAVE_TIMEOUT_Pos)
+#define   US_CSR_SPI_SLAVE_TIMEOUT_0_Val  _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) There has not been a time-out since the last Start Time-out command or the Time-out Register is 0 */
+#define   US_CSR_SPI_SLAVE_TIMEOUT_1_Val  _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) There has been a time-out since the last Start Time-out command */
+#define US_CSR_SPI_SLAVE_TIMEOUT_0  (US_CSR_SPI_SLAVE_TIMEOUT_0_Val << US_CSR_SPI_SLAVE_TIMEOUT_Pos)
+#define US_CSR_SPI_SLAVE_TIMEOUT_1  (US_CSR_SPI_SLAVE_TIMEOUT_1_Val << US_CSR_SPI_SLAVE_TIMEOUT_Pos)
+#define US_CSR_SPI_SLAVE_TXEMPTY_Pos 9            /**< \brief (US_CSR_SPI_SLAVE) Transmitter Empty */
+#define US_CSR_SPI_SLAVE_TXEMPTY    (_U(0x1) << US_CSR_SPI_SLAVE_TXEMPTY_Pos)
+#define   US_CSR_SPI_SLAVE_TXEMPTY_0_Val  _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) There are characters in either THR or the Transmit Shift Register, or the transmitter is disabled */
+#define   US_CSR_SPI_SLAVE_TXEMPTY_1_Val  _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) There is at least one character in either THR or the Transmit Shift Register */
+#define US_CSR_SPI_SLAVE_TXEMPTY_0  (US_CSR_SPI_SLAVE_TXEMPTY_0_Val << US_CSR_SPI_SLAVE_TXEMPTY_Pos)
+#define US_CSR_SPI_SLAVE_TXEMPTY_1  (US_CSR_SPI_SLAVE_TXEMPTY_1_Val << US_CSR_SPI_SLAVE_TXEMPTY_Pos)
+#define US_CSR_SPI_SLAVE_UNRE_Pos   10           /**< \brief (US_CSR_SPI_SLAVE) SPI Underrun Error */
+#define US_CSR_SPI_SLAVE_UNRE       (_U(0x1) << US_CSR_SPI_SLAVE_UNRE_Pos)
+#define   US_CSR_SPI_SLAVE_UNRE_0_Val     _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No SPI underrun error has occurred since the last RSTSTA */
+#define   US_CSR_SPI_SLAVE_UNRE_1_Val     _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one SPI underrun error has occurred since the last RSTSTA */
+#define US_CSR_SPI_SLAVE_UNRE_0     (US_CSR_SPI_SLAVE_UNRE_0_Val   << US_CSR_SPI_SLAVE_UNRE_Pos)
+#define US_CSR_SPI_SLAVE_UNRE_1     (US_CSR_SPI_SLAVE_UNRE_1_Val   << US_CSR_SPI_SLAVE_UNRE_Pos)
+#define US_CSR_SPI_SLAVE_TXBUFE_Pos 11           /**< \brief (US_CSR_SPI_SLAVE) Transmission Buffer Empty */
+#define US_CSR_SPI_SLAVE_TXBUFE     (_U(0x1) << US_CSR_SPI_SLAVE_TXBUFE_Pos)
+#define   US_CSR_SPI_SLAVE_TXBUFE_0_Val   _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) The signal Buffer Empty from the Transmit PDC channel is inactive */
+#define   US_CSR_SPI_SLAVE_TXBUFE_1_Val   _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) The signal Buffer Empty from the Transmit PDC channel is active */
+#define US_CSR_SPI_SLAVE_TXBUFE_0   (US_CSR_SPI_SLAVE_TXBUFE_0_Val << US_CSR_SPI_SLAVE_TXBUFE_Pos)
+#define US_CSR_SPI_SLAVE_TXBUFE_1   (US_CSR_SPI_SLAVE_TXBUFE_1_Val << US_CSR_SPI_SLAVE_TXBUFE_Pos)
+#define US_CSR_SPI_SLAVE_RXBUFF_Pos 12           /**< \brief (US_CSR_SPI_SLAVE) Reception Buffer Full */
+#define US_CSR_SPI_SLAVE_RXBUFF     (_U(0x1) << US_CSR_SPI_SLAVE_RXBUFF_Pos)
+#define   US_CSR_SPI_SLAVE_RXBUFF_0_Val   _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) The signal Buffer Full from the Receive PDC channel is inactive */
+#define   US_CSR_SPI_SLAVE_RXBUFF_1_Val   _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) The signal Buffer Full from the Receive PDC channel is active */
+#define US_CSR_SPI_SLAVE_RXBUFF_0   (US_CSR_SPI_SLAVE_RXBUFF_0_Val << US_CSR_SPI_SLAVE_RXBUFF_Pos)
+#define US_CSR_SPI_SLAVE_RXBUFF_1   (US_CSR_SPI_SLAVE_RXBUFF_1_Val << US_CSR_SPI_SLAVE_RXBUFF_Pos)
+#define US_CSR_SPI_SLAVE_NACK_Pos   13           /**< \brief (US_CSR_SPI_SLAVE) Non Acknowledge */
+#define US_CSR_SPI_SLAVE_NACK       (_U(0x1) << US_CSR_SPI_SLAVE_NACK_Pos)
+#define   US_CSR_SPI_SLAVE_NACK_0_Val     _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No Non Acknowledge has not been detected since the last RSTNACK */
+#define   US_CSR_SPI_SLAVE_NACK_1_Val     _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one Non Acknowledge has been detected since the last RSTNACK */
+#define US_CSR_SPI_SLAVE_NACK_0     (US_CSR_SPI_SLAVE_NACK_0_Val   << US_CSR_SPI_SLAVE_NACK_Pos)
+#define US_CSR_SPI_SLAVE_NACK_1     (US_CSR_SPI_SLAVE_NACK_1_Val   << US_CSR_SPI_SLAVE_NACK_Pos)
+#define US_CSR_SPI_SLAVE_RIIC_Pos   16           /**< \brief (US_CSR_SPI_SLAVE) Ring Indicator Input Change Flag */
+#define US_CSR_SPI_SLAVE_RIIC       (_U(0x1) << US_CSR_SPI_SLAVE_RIIC_Pos)
+#define   US_CSR_SPI_SLAVE_RIIC_0_Val     _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No input change has been detected on the RI pin since the last read of CSR */
+#define   US_CSR_SPI_SLAVE_RIIC_1_Val     _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one input change has been detected on the RI pin since the last read of CSR */
+#define US_CSR_SPI_SLAVE_RIIC_0     (US_CSR_SPI_SLAVE_RIIC_0_Val   << US_CSR_SPI_SLAVE_RIIC_Pos)
+#define US_CSR_SPI_SLAVE_RIIC_1     (US_CSR_SPI_SLAVE_RIIC_1_Val   << US_CSR_SPI_SLAVE_RIIC_Pos)
+#define US_CSR_SPI_SLAVE_DSRIC_Pos  17           /**< \brief (US_CSR_SPI_SLAVE) Data Set Ready Input Change Flag */
+#define US_CSR_SPI_SLAVE_DSRIC      (_U(0x1) << US_CSR_SPI_SLAVE_DSRIC_Pos)
+#define   US_CSR_SPI_SLAVE_DSRIC_0_Val    _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No input change has been detected on the DSR pin since the last read of CSR */
+#define   US_CSR_SPI_SLAVE_DSRIC_1_Val    _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one input change has been detected on the DSR pin since the last read of CSR */
+#define US_CSR_SPI_SLAVE_DSRIC_0    (US_CSR_SPI_SLAVE_DSRIC_0_Val  << US_CSR_SPI_SLAVE_DSRIC_Pos)
+#define US_CSR_SPI_SLAVE_DSRIC_1    (US_CSR_SPI_SLAVE_DSRIC_1_Val  << US_CSR_SPI_SLAVE_DSRIC_Pos)
+#define US_CSR_SPI_SLAVE_DCDIC_Pos  18           /**< \brief (US_CSR_SPI_SLAVE) Data Carrier Detect Input Change Flag */
+#define US_CSR_SPI_SLAVE_DCDIC      (_U(0x1) << US_CSR_SPI_SLAVE_DCDIC_Pos)
+#define   US_CSR_SPI_SLAVE_DCDIC_0_Val    _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No input change has been detected on the DCD pin since the last read of CSR */
+#define   US_CSR_SPI_SLAVE_DCDIC_1_Val    _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one input change has been detected on the DCD pin since the last read of CSR */
+#define US_CSR_SPI_SLAVE_DCDIC_0    (US_CSR_SPI_SLAVE_DCDIC_0_Val  << US_CSR_SPI_SLAVE_DCDIC_Pos)
+#define US_CSR_SPI_SLAVE_DCDIC_1    (US_CSR_SPI_SLAVE_DCDIC_1_Val  << US_CSR_SPI_SLAVE_DCDIC_Pos)
+#define US_CSR_SPI_SLAVE_CTSIC_Pos  19           /**< \brief (US_CSR_SPI_SLAVE) Clear to Send Input Change Flag */
+#define US_CSR_SPI_SLAVE_CTSIC      (_U(0x1) << US_CSR_SPI_SLAVE_CTSIC_Pos)
+#define   US_CSR_SPI_SLAVE_CTSIC_0_Val    _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No input change has been detected on the CTS pin since the last read of CSR */
+#define   US_CSR_SPI_SLAVE_CTSIC_1_Val    _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one input change has been detected on the CTS pin since the last read of CSR */
+#define US_CSR_SPI_SLAVE_CTSIC_0    (US_CSR_SPI_SLAVE_CTSIC_0_Val  << US_CSR_SPI_SLAVE_CTSIC_Pos)
+#define US_CSR_SPI_SLAVE_CTSIC_1    (US_CSR_SPI_SLAVE_CTSIC_1_Val  << US_CSR_SPI_SLAVE_CTSIC_Pos)
+#define US_CSR_SPI_SLAVE_RI_Pos     20           /**< \brief (US_CSR_SPI_SLAVE) Image of RI Input */
+#define US_CSR_SPI_SLAVE_RI         (_U(0x1) << US_CSR_SPI_SLAVE_RI_Pos)
+#define   US_CSR_SPI_SLAVE_RI_0_Val       _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) RI is at 0 */
+#define   US_CSR_SPI_SLAVE_RI_1_Val       _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) RI is at 1 */
+#define US_CSR_SPI_SLAVE_RI_0       (US_CSR_SPI_SLAVE_RI_0_Val     << US_CSR_SPI_SLAVE_RI_Pos)
+#define US_CSR_SPI_SLAVE_RI_1       (US_CSR_SPI_SLAVE_RI_1_Val     << US_CSR_SPI_SLAVE_RI_Pos)
+#define US_CSR_SPI_SLAVE_DSR_Pos    21           /**< \brief (US_CSR_SPI_SLAVE) Image of DSR Input */
+#define US_CSR_SPI_SLAVE_DSR        (_U(0x1) << US_CSR_SPI_SLAVE_DSR_Pos)
+#define   US_CSR_SPI_SLAVE_DSR_0_Val      _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) DSR is at 0 */
+#define   US_CSR_SPI_SLAVE_DSR_1_Val      _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) DSR is at 1 */
+#define US_CSR_SPI_SLAVE_DSR_0      (US_CSR_SPI_SLAVE_DSR_0_Val    << US_CSR_SPI_SLAVE_DSR_Pos)
+#define US_CSR_SPI_SLAVE_DSR_1      (US_CSR_SPI_SLAVE_DSR_1_Val    << US_CSR_SPI_SLAVE_DSR_Pos)
+#define US_CSR_SPI_SLAVE_DCD_Pos    22           /**< \brief (US_CSR_SPI_SLAVE) Image of DCD Input */
+#define US_CSR_SPI_SLAVE_DCD        (_U(0x1) << US_CSR_SPI_SLAVE_DCD_Pos)
+#define   US_CSR_SPI_SLAVE_DCD_0_Val      _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) DCD is at 0 */
+#define   US_CSR_SPI_SLAVE_DCD_1_Val      _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) DCD is at 1 */
+#define US_CSR_SPI_SLAVE_DCD_0      (US_CSR_SPI_SLAVE_DCD_0_Val    << US_CSR_SPI_SLAVE_DCD_Pos)
+#define US_CSR_SPI_SLAVE_DCD_1      (US_CSR_SPI_SLAVE_DCD_1_Val    << US_CSR_SPI_SLAVE_DCD_Pos)
+#define US_CSR_SPI_SLAVE_CTS_Pos    23           /**< \brief (US_CSR_SPI_SLAVE) Image of CTS Input */
+#define US_CSR_SPI_SLAVE_CTS        (_U(0x1) << US_CSR_SPI_SLAVE_CTS_Pos)
+#define   US_CSR_SPI_SLAVE_CTS_0_Val      _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) CTS is at 0 */
+#define   US_CSR_SPI_SLAVE_CTS_1_Val      _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) CTS is at 1 */
+#define US_CSR_SPI_SLAVE_CTS_0      (US_CSR_SPI_SLAVE_CTS_0_Val    << US_CSR_SPI_SLAVE_CTS_Pos)
+#define US_CSR_SPI_SLAVE_CTS_1      (US_CSR_SPI_SLAVE_CTS_1_Val    << US_CSR_SPI_SLAVE_CTS_Pos)
+#define US_CSR_SPI_SLAVE_MASK       _U(0x00FF3FE7) /**< \brief (US_CSR_SPI_SLAVE) MASK Register */
+
+// USART mode
+#define US_CSR_USART_RXRDY_Pos      0            /**< \brief (US_CSR_USART) Receiver Ready */
+#define US_CSR_USART_RXRDY          (_U(0x1) << US_CSR_USART_RXRDY_Pos)
+#define   US_CSR_USART_RXRDY_0_Val        _U(0x0)   /**< \brief (US_CSR_USART) No complete character has been received since the last read of RHR or the receiver is disabled. If characters werebeing received when the receiver was disabled, RXRDY changes to 1 when the receiver is enabled */
+#define   US_CSR_USART_RXRDY_1_Val        _U(0x1)   /**< \brief (US_CSR_USART) At least one complete character has been received and RHR has not yet been read */
+#define US_CSR_USART_RXRDY_0        (US_CSR_USART_RXRDY_0_Val      << US_CSR_USART_RXRDY_Pos)
+#define US_CSR_USART_RXRDY_1        (US_CSR_USART_RXRDY_1_Val      << US_CSR_USART_RXRDY_Pos)
+#define US_CSR_USART_TXRDY_Pos      1            /**< \brief (US_CSR_USART) Transmitter Ready */
+#define US_CSR_USART_TXRDY          (_U(0x1) << US_CSR_USART_TXRDY_Pos)
+#define   US_CSR_USART_TXRDY_0_Val        _U(0x0)   /**< \brief (US_CSR_USART) A character is in the THR waiting to be transferred to the Transmit Shift Register, or an STTBRK command has been requested, or the transmitter is disabled. As soon as the transmitter is enabled, TXRDY becomes 1 */
+#define   US_CSR_USART_TXRDY_1_Val        _U(0x1)   /**< \brief (US_CSR_USART) There is no character in the THR */
+#define US_CSR_USART_TXRDY_0        (US_CSR_USART_TXRDY_0_Val      << US_CSR_USART_TXRDY_Pos)
+#define US_CSR_USART_TXRDY_1        (US_CSR_USART_TXRDY_1_Val      << US_CSR_USART_TXRDY_Pos)
+#define US_CSR_USART_RXBRK_Pos      2            /**< \brief (US_CSR_USART) Break Received/End of Break */
+#define US_CSR_USART_RXBRK          (_U(0x1) << US_CSR_USART_RXBRK_Pos)
+#define   US_CSR_USART_RXBRK_0_Val        _U(0x0)   /**< \brief (US_CSR_USART) No Break received or End of Break detected since the last RSTSTA */
+#define   US_CSR_USART_RXBRK_1_Val        _U(0x1)   /**< \brief (US_CSR_USART) Break Received or End of Break detected since the last RSTSTA */
+#define US_CSR_USART_RXBRK_0        (US_CSR_USART_RXBRK_0_Val      << US_CSR_USART_RXBRK_Pos)
+#define US_CSR_USART_RXBRK_1        (US_CSR_USART_RXBRK_1_Val      << US_CSR_USART_RXBRK_Pos)
+#define US_CSR_USART_OVRE_Pos       5            /**< \brief (US_CSR_USART) Overrun Error */
+#define US_CSR_USART_OVRE           (_U(0x1) << US_CSR_USART_OVRE_Pos)
+#define   US_CSR_USART_OVRE_0_Val         _U(0x0)   /**< \brief (US_CSR_USART) No overrun error has occurred since since the last RSTSTA */
+#define   US_CSR_USART_OVRE_1_Val         _U(0x1)   /**< \brief (US_CSR_USART) At least one overrun error has occurred since the last RSTSTA */
+#define US_CSR_USART_OVRE_0         (US_CSR_USART_OVRE_0_Val       << US_CSR_USART_OVRE_Pos)
+#define US_CSR_USART_OVRE_1         (US_CSR_USART_OVRE_1_Val       << US_CSR_USART_OVRE_Pos)
+#define US_CSR_USART_FRAME_Pos      6            /**< \brief (US_CSR_USART) Framing Error */
+#define US_CSR_USART_FRAME          (_U(0x1) << US_CSR_USART_FRAME_Pos)
+#define   US_CSR_USART_FRAME_0_Val        _U(0x0)   /**< \brief (US_CSR_USART) No stop bit has been detected low since the last RSTSTA */
+#define   US_CSR_USART_FRAME_1_Val        _U(0x1)   /**< \brief (US_CSR_USART) At least one stop bit has been detected low since the last RSTSTA */
+#define US_CSR_USART_FRAME_0        (US_CSR_USART_FRAME_0_Val      << US_CSR_USART_FRAME_Pos)
+#define US_CSR_USART_FRAME_1        (US_CSR_USART_FRAME_1_Val      << US_CSR_USART_FRAME_Pos)
+#define US_CSR_USART_PARE_Pos       7            /**< \brief (US_CSR_USART) Parity Error */
+#define US_CSR_USART_PARE           (_U(0x1) << US_CSR_USART_PARE_Pos)
+#define   US_CSR_USART_PARE_0_Val         _U(0x0)   /**< \brief (US_CSR_USART) No parity error has been detected since the last RSTSTA */
+#define   US_CSR_USART_PARE_1_Val         _U(0x1)   /**< \brief (US_CSR_USART) At least one parity error has been detected since the last RSTSTA */
+#define US_CSR_USART_PARE_0         (US_CSR_USART_PARE_0_Val       << US_CSR_USART_PARE_Pos)
+#define US_CSR_USART_PARE_1         (US_CSR_USART_PARE_1_Val       << US_CSR_USART_PARE_Pos)
+#define US_CSR_USART_TIMEOUT_Pos    8            /**< \brief (US_CSR_USART) Receiver Time-out */
+#define US_CSR_USART_TIMEOUT        (_U(0x1) << US_CSR_USART_TIMEOUT_Pos)
+#define   US_CSR_USART_TIMEOUT_0_Val      _U(0x0)   /**< \brief (US_CSR_USART) There has not been a time-out since the last Start Time-out command or the Time-out Register is 0 */
+#define   US_CSR_USART_TIMEOUT_1_Val      _U(0x1)   /**< \brief (US_CSR_USART) There has been a time-out since the last Start Time-out command */
+#define US_CSR_USART_TIMEOUT_0      (US_CSR_USART_TIMEOUT_0_Val    << US_CSR_USART_TIMEOUT_Pos)
+#define US_CSR_USART_TIMEOUT_1      (US_CSR_USART_TIMEOUT_1_Val    << US_CSR_USART_TIMEOUT_Pos)
+#define US_CSR_USART_TXEMPTY_Pos    9            /**< \brief (US_CSR_USART) Transmitter Empty */
+#define US_CSR_USART_TXEMPTY        (_U(0x1) << US_CSR_USART_TXEMPTY_Pos)
+#define   US_CSR_USART_TXEMPTY_0_Val      _U(0x0)   /**< \brief (US_CSR_USART) There are characters in either THR or the Transmit Shift Register, or the transmitter is disabled */
+#define   US_CSR_USART_TXEMPTY_1_Val      _U(0x1)   /**< \brief (US_CSR_USART) There is at least one character in either THR or the Transmit Shift Register */
+#define US_CSR_USART_TXEMPTY_0      (US_CSR_USART_TXEMPTY_0_Val    << US_CSR_USART_TXEMPTY_Pos)
+#define US_CSR_USART_TXEMPTY_1      (US_CSR_USART_TXEMPTY_1_Val    << US_CSR_USART_TXEMPTY_Pos)
+#define US_CSR_USART_ITER_Pos       10           /**< \brief (US_CSR_USART) Max number of Repetitions Reached */
+#define US_CSR_USART_ITER           (_U(0x1) << US_CSR_USART_ITER_Pos)
+#define   US_CSR_USART_ITER_0_Val         _U(0x0)   /**< \brief (US_CSR_USART) Maximum number of repetitions has not been reached since the last RSIT */
+#define   US_CSR_USART_ITER_1_Val         _U(0x1)   /**< \brief (US_CSR_USART) Maximum number of repetitions has been reached since the last RSIT */
+#define US_CSR_USART_ITER_0         (US_CSR_USART_ITER_0_Val       << US_CSR_USART_ITER_Pos)
+#define US_CSR_USART_ITER_1         (US_CSR_USART_ITER_1_Val       << US_CSR_USART_ITER_Pos)
+#define US_CSR_USART_TXBUFE_Pos     11           /**< \brief (US_CSR_USART) Transmission Buffer Empty */
+#define US_CSR_USART_TXBUFE         (_U(0x1) << US_CSR_USART_TXBUFE_Pos)
+#define   US_CSR_USART_TXBUFE_0_Val       _U(0x0)   /**< \brief (US_CSR_USART) The signal Buffer Empty from the Transmit PDC channel is inactive */
+#define   US_CSR_USART_TXBUFE_1_Val       _U(0x1)   /**< \brief (US_CSR_USART) The signal Buffer Empty from the Transmit PDC channel is active */
+#define US_CSR_USART_TXBUFE_0       (US_CSR_USART_TXBUFE_0_Val     << US_CSR_USART_TXBUFE_Pos)
+#define US_CSR_USART_TXBUFE_1       (US_CSR_USART_TXBUFE_1_Val     << US_CSR_USART_TXBUFE_Pos)
+#define US_CSR_USART_RXBUFF_Pos     12           /**< \brief (US_CSR_USART) Reception Buffer Full */
+#define US_CSR_USART_RXBUFF         (_U(0x1) << US_CSR_USART_RXBUFF_Pos)
+#define   US_CSR_USART_RXBUFF_0_Val       _U(0x0)   /**< \brief (US_CSR_USART) The signal Buffer Full from the Receive PDC channel is inactive */
+#define   US_CSR_USART_RXBUFF_1_Val       _U(0x1)   /**< \brief (US_CSR_USART) The signal Buffer Full from the Receive PDC channel is active */
+#define US_CSR_USART_RXBUFF_0       (US_CSR_USART_RXBUFF_0_Val     << US_CSR_USART_RXBUFF_Pos)
+#define US_CSR_USART_RXBUFF_1       (US_CSR_USART_RXBUFF_1_Val     << US_CSR_USART_RXBUFF_Pos)
+#define US_CSR_USART_NACK_Pos       13           /**< \brief (US_CSR_USART) Non Acknowledge */
+#define US_CSR_USART_NACK           (_U(0x1) << US_CSR_USART_NACK_Pos)
+#define   US_CSR_USART_NACK_0_Val         _U(0x0)   /**< \brief (US_CSR_USART) No Non Acknowledge has not been detected since the last RSTNACK */
+#define   US_CSR_USART_NACK_1_Val         _U(0x1)   /**< \brief (US_CSR_USART) At least one Non Acknowledge has been detected since the last RSTNACK */
+#define US_CSR_USART_NACK_0         (US_CSR_USART_NACK_0_Val       << US_CSR_USART_NACK_Pos)
+#define US_CSR_USART_NACK_1         (US_CSR_USART_NACK_1_Val       << US_CSR_USART_NACK_Pos)
+#define US_CSR_USART_RIIC_Pos       16           /**< \brief (US_CSR_USART) Ring Indicator Input Change Flag */
+#define US_CSR_USART_RIIC           (_U(0x1) << US_CSR_USART_RIIC_Pos)
+#define   US_CSR_USART_RIIC_0_Val         _U(0x0)   /**< \brief (US_CSR_USART) No input change has been detected on the RI pin since the last read of CSR */
+#define   US_CSR_USART_RIIC_1_Val         _U(0x1)   /**< \brief (US_CSR_USART) At least one input change has been detected on the RI pin since the last read of CSR */
+#define US_CSR_USART_RIIC_0         (US_CSR_USART_RIIC_0_Val       << US_CSR_USART_RIIC_Pos)
+#define US_CSR_USART_RIIC_1         (US_CSR_USART_RIIC_1_Val       << US_CSR_USART_RIIC_Pos)
+#define US_CSR_USART_DSRIC_Pos      17           /**< \brief (US_CSR_USART) Data Set Ready Input Change Flag */
+#define US_CSR_USART_DSRIC          (_U(0x1) << US_CSR_USART_DSRIC_Pos)
+#define   US_CSR_USART_DSRIC_0_Val        _U(0x0)   /**< \brief (US_CSR_USART) No input change has been detected on the DSR pin since the last read of CSR */
+#define   US_CSR_USART_DSRIC_1_Val        _U(0x1)   /**< \brief (US_CSR_USART) At least one input change has been detected on the DSR pin since the last read of CSR */
+#define US_CSR_USART_DSRIC_0        (US_CSR_USART_DSRIC_0_Val      << US_CSR_USART_DSRIC_Pos)
+#define US_CSR_USART_DSRIC_1        (US_CSR_USART_DSRIC_1_Val      << US_CSR_USART_DSRIC_Pos)
+#define US_CSR_USART_DCDIC_Pos      18           /**< \brief (US_CSR_USART) Data Carrier Detect Input Change Flag */
+#define US_CSR_USART_DCDIC          (_U(0x1) << US_CSR_USART_DCDIC_Pos)
+#define   US_CSR_USART_DCDIC_0_Val        _U(0x0)   /**< \brief (US_CSR_USART) No input change has been detected on the DCD pin since the last read of CSR */
+#define   US_CSR_USART_DCDIC_1_Val        _U(0x1)   /**< \brief (US_CSR_USART) At least one input change has been detected on the DCD pin since the last read of CSR */
+#define US_CSR_USART_DCDIC_0        (US_CSR_USART_DCDIC_0_Val      << US_CSR_USART_DCDIC_Pos)
+#define US_CSR_USART_DCDIC_1        (US_CSR_USART_DCDIC_1_Val      << US_CSR_USART_DCDIC_Pos)
+#define US_CSR_USART_CTSIC_Pos      19           /**< \brief (US_CSR_USART) Clear to Send Input Change Flag */
+#define US_CSR_USART_CTSIC          (_U(0x1) << US_CSR_USART_CTSIC_Pos)
+#define   US_CSR_USART_CTSIC_0_Val        _U(0x0)   /**< \brief (US_CSR_USART) No input change has been detected on the CTS pin since the last read of CSR */
+#define   US_CSR_USART_CTSIC_1_Val        _U(0x1)   /**< \brief (US_CSR_USART) At least one input change has been detected on the CTS pin since the last read of CSR */
+#define US_CSR_USART_CTSIC_0        (US_CSR_USART_CTSIC_0_Val      << US_CSR_USART_CTSIC_Pos)
+#define US_CSR_USART_CTSIC_1        (US_CSR_USART_CTSIC_1_Val      << US_CSR_USART_CTSIC_Pos)
+#define US_CSR_USART_RI_Pos         20           /**< \brief (US_CSR_USART) Image of RI Input */
+#define US_CSR_USART_RI             (_U(0x1) << US_CSR_USART_RI_Pos)
+#define   US_CSR_USART_RI_0_Val           _U(0x0)   /**< \brief (US_CSR_USART) RI is at 0 */
+#define   US_CSR_USART_RI_1_Val           _U(0x1)   /**< \brief (US_CSR_USART) RI is at 1 */
+#define US_CSR_USART_RI_0           (US_CSR_USART_RI_0_Val         << US_CSR_USART_RI_Pos)
+#define US_CSR_USART_RI_1           (US_CSR_USART_RI_1_Val         << US_CSR_USART_RI_Pos)
+#define US_CSR_USART_DSR_Pos        21           /**< \brief (US_CSR_USART) Image of DSR Input */
+#define US_CSR_USART_DSR            (_U(0x1) << US_CSR_USART_DSR_Pos)
+#define   US_CSR_USART_DSR_0_Val          _U(0x0)   /**< \brief (US_CSR_USART) DSR is at 0 */
+#define   US_CSR_USART_DSR_1_Val          _U(0x1)   /**< \brief (US_CSR_USART) DSR is at 1 */
+#define US_CSR_USART_DSR_0          (US_CSR_USART_DSR_0_Val        << US_CSR_USART_DSR_Pos)
+#define US_CSR_USART_DSR_1          (US_CSR_USART_DSR_1_Val        << US_CSR_USART_DSR_Pos)
+#define US_CSR_USART_DCD_Pos        22           /**< \brief (US_CSR_USART) Image of DCD Input */
+#define US_CSR_USART_DCD            (_U(0x1) << US_CSR_USART_DCD_Pos)
+#define   US_CSR_USART_DCD_0_Val          _U(0x0)   /**< \brief (US_CSR_USART) DCD is at 0 */
+#define   US_CSR_USART_DCD_1_Val          _U(0x1)   /**< \brief (US_CSR_USART) DCD is at 1 */
+#define US_CSR_USART_DCD_0          (US_CSR_USART_DCD_0_Val        << US_CSR_USART_DCD_Pos)
+#define US_CSR_USART_DCD_1          (US_CSR_USART_DCD_1_Val        << US_CSR_USART_DCD_Pos)
+#define US_CSR_USART_CTS_Pos        23           /**< \brief (US_CSR_USART) Image of CTS Input */
+#define US_CSR_USART_CTS            (_U(0x1) << US_CSR_USART_CTS_Pos)
+#define   US_CSR_USART_CTS_0_Val          _U(0x0)   /**< \brief (US_CSR_USART) CTS is at 0 */
+#define   US_CSR_USART_CTS_1_Val          _U(0x1)   /**< \brief (US_CSR_USART) CTS is at 1 */
+#define US_CSR_USART_CTS_0          (US_CSR_USART_CTS_0_Val        << US_CSR_USART_CTS_Pos)
+#define US_CSR_USART_CTS_1          (US_CSR_USART_CTS_1_Val        << US_CSR_USART_CTS_Pos)
+#define US_CSR_USART_MANERR_Pos     24           /**< \brief (US_CSR_USART) Manchester Error */
+#define US_CSR_USART_MANERR         (_U(0x1) << US_CSR_USART_MANERR_Pos)
+#define   US_CSR_USART_MANERR_0_Val       _U(0x0)   /**< \brief (US_CSR_USART) No Manchester error has been detected since the last RSTSTA */
+#define   US_CSR_USART_MANERR_1_Val       _U(0x1)   /**< \brief (US_CSR_USART) At least one Manchester error has been detected since the last RSTSTA */
+#define US_CSR_USART_MANERR_0       (US_CSR_USART_MANERR_0_Val     << US_CSR_USART_MANERR_Pos)
+#define US_CSR_USART_MANERR_1       (US_CSR_USART_MANERR_1_Val     << US_CSR_USART_MANERR_Pos)
+#define US_CSR_USART_MASK           _U(0x01FF3FE7) /**< \brief (US_CSR_USART) MASK Register */
+
+// Any mode
+#define US_CSR_RXRDY_Pos            0            /**< \brief (US_CSR) Receiver Ready */
+#define US_CSR_RXRDY                (_U(0x1) << US_CSR_RXRDY_Pos)
+#define   US_CSR_RXRDY_0_Val              _U(0x0)   /**< \brief (US_CSR) No complete character has been received since the last read of RHR or the receiver is disabled. If characters werebeing received when the receiver was disabled, RXRDY changes to 1 when the receiver is enabled */
+#define   US_CSR_RXRDY_1_Val              _U(0x1)   /**< \brief (US_CSR) At least one complete character has been received and RHR has not yet been read */
+#define US_CSR_RXRDY_0              (US_CSR_RXRDY_0_Val            << US_CSR_RXRDY_Pos)
+#define US_CSR_RXRDY_1              (US_CSR_RXRDY_1_Val            << US_CSR_RXRDY_Pos)
+#define US_CSR_TXRDY_Pos            1            /**< \brief (US_CSR) Transmitter Ready */
+#define US_CSR_TXRDY                (_U(0x1) << US_CSR_TXRDY_Pos)
+#define   US_CSR_TXRDY_0_Val              _U(0x0)   /**< \brief (US_CSR) A character is in the THR waiting to be transferred to the Transmit Shift Register, or an STTBRK command has been requested, or the transmitter is disabled. As soon as the transmitter is enabled, TXRDY becomes 1 */
+#define   US_CSR_TXRDY_1_Val              _U(0x1)   /**< \brief (US_CSR) There is no character in the THR */
+#define US_CSR_TXRDY_0              (US_CSR_TXRDY_0_Val            << US_CSR_TXRDY_Pos)
+#define US_CSR_TXRDY_1              (US_CSR_TXRDY_1_Val            << US_CSR_TXRDY_Pos)
+#define US_CSR_RXBRK_Pos            2            /**< \brief (US_CSR) Break Received/End of Break */
+#define US_CSR_RXBRK                (_U(0x1) << US_CSR_RXBRK_Pos)
+#define   US_CSR_RXBRK_0_Val              _U(0x0)   /**< \brief (US_CSR) No Break received or End of Break detected since the last RSTSTA */
+#define   US_CSR_RXBRK_1_Val              _U(0x1)   /**< \brief (US_CSR) Break Received or End of Break detected since the last RSTSTA */
+#define US_CSR_RXBRK_0              (US_CSR_RXBRK_0_Val            << US_CSR_RXBRK_Pos)
+#define US_CSR_RXBRK_1              (US_CSR_RXBRK_1_Val            << US_CSR_RXBRK_Pos)
+#define US_CSR_OVRE_Pos             5            /**< \brief (US_CSR) Overrun Error */
+#define US_CSR_OVRE                 (_U(0x1) << US_CSR_OVRE_Pos)
+#define   US_CSR_OVRE_0_Val               _U(0x0)   /**< \brief (US_CSR) No overrun error has occurred since since the last RSTSTA */
+#define   US_CSR_OVRE_1_Val               _U(0x1)   /**< \brief (US_CSR) At least one overrun error has occurred since the last RSTSTA */
+#define US_CSR_OVRE_0               (US_CSR_OVRE_0_Val             << US_CSR_OVRE_Pos)
+#define US_CSR_OVRE_1               (US_CSR_OVRE_1_Val             << US_CSR_OVRE_Pos)
+#define US_CSR_FRAME_Pos            6            /**< \brief (US_CSR) Framing Error */
+#define US_CSR_FRAME                (_U(0x1) << US_CSR_FRAME_Pos)
+#define   US_CSR_FRAME_0_Val              _U(0x0)   /**< \brief (US_CSR) No stop bit has been detected low since the last RSTSTA */
+#define   US_CSR_FRAME_1_Val              _U(0x1)   /**< \brief (US_CSR) At least one stop bit has been detected low since the last RSTSTA */
+#define US_CSR_FRAME_0              (US_CSR_FRAME_0_Val            << US_CSR_FRAME_Pos)
+#define US_CSR_FRAME_1              (US_CSR_FRAME_1_Val            << US_CSR_FRAME_Pos)
+#define US_CSR_PARE_Pos             7            /**< \brief (US_CSR) Parity Error */
+#define US_CSR_PARE                 (_U(0x1) << US_CSR_PARE_Pos)
+#define   US_CSR_PARE_0_Val               _U(0x0)   /**< \brief (US_CSR) No parity error has been detected since the last RSTSTA */
+#define   US_CSR_PARE_1_Val               _U(0x1)   /**< \brief (US_CSR) At least one parity error has been detected since the last RSTSTA */
+#define US_CSR_PARE_0               (US_CSR_PARE_0_Val             << US_CSR_PARE_Pos)
+#define US_CSR_PARE_1               (US_CSR_PARE_1_Val             << US_CSR_PARE_Pos)
+#define US_CSR_TIMEOUT_Pos          8            /**< \brief (US_CSR) Receiver Time-out */
+#define US_CSR_TIMEOUT              (_U(0x1) << US_CSR_TIMEOUT_Pos)
+#define   US_CSR_TIMEOUT_0_Val            _U(0x0)   /**< \brief (US_CSR) There has not been a time-out since the last Start Time-out command or the Time-out Register is 0 */
+#define   US_CSR_TIMEOUT_1_Val            _U(0x1)   /**< \brief (US_CSR) There has been a time-out since the last Start Time-out command */
+#define US_CSR_TIMEOUT_0            (US_CSR_TIMEOUT_0_Val          << US_CSR_TIMEOUT_Pos)
+#define US_CSR_TIMEOUT_1            (US_CSR_TIMEOUT_1_Val          << US_CSR_TIMEOUT_Pos)
+#define US_CSR_TXEMPTY_Pos          9            /**< \brief (US_CSR) Transmitter Empty */
+#define US_CSR_TXEMPTY              (_U(0x1) << US_CSR_TXEMPTY_Pos)
+#define   US_CSR_TXEMPTY_0_Val            _U(0x0)   /**< \brief (US_CSR) There are characters in either THR or the Transmit Shift Register, or the transmitter is disabled */
+#define   US_CSR_TXEMPTY_1_Val            _U(0x1)   /**< \brief (US_CSR) There is at least one character in either THR or the Transmit Shift Register */
+#define US_CSR_TXEMPTY_0            (US_CSR_TXEMPTY_0_Val          << US_CSR_TXEMPTY_Pos)
+#define US_CSR_TXEMPTY_1            (US_CSR_TXEMPTY_1_Val          << US_CSR_TXEMPTY_Pos)
+#define US_CSR_ITER_Pos             10           /**< \brief (US_CSR) Max number of Repetitions Reached */
+#define US_CSR_ITER                 (_U(0x1) << US_CSR_ITER_Pos)
+#define   US_CSR_ITER_0_Val               _U(0x0)   /**< \brief (US_CSR) Maximum number of repetitions has not been reached since the last RSIT */
+#define   US_CSR_ITER_1_Val               _U(0x1)   /**< \brief (US_CSR) Maximum number of repetitions has been reached since the last RSIT */
+#define US_CSR_ITER_0               (US_CSR_ITER_0_Val             << US_CSR_ITER_Pos)
+#define US_CSR_ITER_1               (US_CSR_ITER_1_Val             << US_CSR_ITER_Pos)
+#define US_CSR_UNRE_Pos             10           /**< \brief (US_CSR) SPI Underrun Error */
+#define US_CSR_UNRE                 (_U(0x1) << US_CSR_UNRE_Pos)
+#define   US_CSR_UNRE_0_Val               _U(0x0)   /**< \brief (US_CSR) No SPI underrun error has occurred since the last RSTSTA */
+#define   US_CSR_UNRE_1_Val               _U(0x1)   /**< \brief (US_CSR) At least one SPI underrun error has occurred since the last RSTSTA */
+#define US_CSR_UNRE_0               (US_CSR_UNRE_0_Val             << US_CSR_UNRE_Pos)
+#define US_CSR_UNRE_1               (US_CSR_UNRE_1_Val             << US_CSR_UNRE_Pos)
+#define US_CSR_ITER_Pos             10           /**< \brief (US_CSR) Max number of Repetitions Reached */
+#define US_CSR_ITER                 (_U(0x1) << US_CSR_ITER_Pos)
+#define   US_CSR_ITER_0_Val               _U(0x0)   /**< \brief (US_CSR) Maximum number of repetitions has not been reached since the last RSIT */
+#define   US_CSR_ITER_1_Val               _U(0x1)   /**< \brief (US_CSR) Maximum number of repetitions has been reached since the last RSIT */
+#define US_CSR_ITER_0               (US_CSR_ITER_0_Val             << US_CSR_ITER_Pos)
+#define US_CSR_ITER_1               (US_CSR_ITER_1_Val             << US_CSR_ITER_Pos)
+#define US_CSR_TXBUFE_Pos           11           /**< \brief (US_CSR) Transmission Buffer Empty */
+#define US_CSR_TXBUFE               (_U(0x1) << US_CSR_TXBUFE_Pos)
+#define   US_CSR_TXBUFE_0_Val             _U(0x0)   /**< \brief (US_CSR) The signal Buffer Empty from the Transmit PDC channel is inactive */
+#define   US_CSR_TXBUFE_1_Val             _U(0x1)   /**< \brief (US_CSR) The signal Buffer Empty from the Transmit PDC channel is active */
+#define US_CSR_TXBUFE_0             (US_CSR_TXBUFE_0_Val           << US_CSR_TXBUFE_Pos)
+#define US_CSR_TXBUFE_1             (US_CSR_TXBUFE_1_Val           << US_CSR_TXBUFE_Pos)
+#define US_CSR_RXBUFF_Pos           12           /**< \brief (US_CSR) Reception Buffer Full */
+#define US_CSR_RXBUFF               (_U(0x1) << US_CSR_RXBUFF_Pos)
+#define   US_CSR_RXBUFF_0_Val             _U(0x0)   /**< \brief (US_CSR) The signal Buffer Full from the Receive PDC channel is inactive */
+#define   US_CSR_RXBUFF_1_Val             _U(0x1)   /**< \brief (US_CSR) The signal Buffer Full from the Receive PDC channel is active */
+#define US_CSR_RXBUFF_0             (US_CSR_RXBUFF_0_Val           << US_CSR_RXBUFF_Pos)
+#define US_CSR_RXBUFF_1             (US_CSR_RXBUFF_1_Val           << US_CSR_RXBUFF_Pos)
+#define US_CSR_NACK_Pos             13           /**< \brief (US_CSR) Non Acknowledge or LIN Break Sent or LIN Break Received */
+#define US_CSR_NACK                 (_U(0x1) << US_CSR_NACK_Pos)
+#define   US_CSR_NACK_0_Val               _U(0x0)   /**< \brief (US_CSR) No Non Acknowledge has not been detected since the last RSTNACK */
+#define   US_CSR_NACK_1_Val               _U(0x1)   /**< \brief (US_CSR) At least one Non Acknowledge has been detected since the last RSTNACK */
+#define US_CSR_NACK_0               (US_CSR_NACK_0_Val             << US_CSR_NACK_Pos)
+#define US_CSR_NACK_1               (US_CSR_NACK_1_Val             << US_CSR_NACK_Pos)
+#define US_CSR_LINID_Pos            14           /**< \brief (US_CSR) LIN Identifier Sent or LIN Identifier Received */
+#define US_CSR_LINID                (_U(0x1) << US_CSR_LINID_Pos)
+#define US_CSR_LINTC_Pos            15           /**< \brief (US_CSR) LIN Transfer Conpleted */
+#define US_CSR_LINTC                (_U(0x1) << US_CSR_LINTC_Pos)
+#define US_CSR_RIIC_Pos             16           /**< \brief (US_CSR) Ring Indicator Input Change Flag */
+#define US_CSR_RIIC                 (_U(0x1) << US_CSR_RIIC_Pos)
+#define   US_CSR_RIIC_0_Val               _U(0x0)   /**< \brief (US_CSR) No input change has been detected on the RI pin since the last read of CSR */
+#define   US_CSR_RIIC_1_Val               _U(0x1)   /**< \brief (US_CSR) At least one input change has been detected on the RI pin since the last read of CSR */
+#define US_CSR_RIIC_0               (US_CSR_RIIC_0_Val             << US_CSR_RIIC_Pos)
+#define US_CSR_RIIC_1               (US_CSR_RIIC_1_Val             << US_CSR_RIIC_Pos)
+#define US_CSR_DSRIC_Pos            17           /**< \brief (US_CSR) Data Set Ready Input Change Flag */
+#define US_CSR_DSRIC                (_U(0x1) << US_CSR_DSRIC_Pos)
+#define   US_CSR_DSRIC_0_Val              _U(0x0)   /**< \brief (US_CSR) No input change has been detected on the DSR pin since the last read of CSR */
+#define   US_CSR_DSRIC_1_Val              _U(0x1)   /**< \brief (US_CSR) At least one input change has been detected on the DSR pin since the last read of CSR */
+#define US_CSR_DSRIC_0              (US_CSR_DSRIC_0_Val            << US_CSR_DSRIC_Pos)
+#define US_CSR_DSRIC_1              (US_CSR_DSRIC_1_Val            << US_CSR_DSRIC_Pos)
+#define US_CSR_DCDIC_Pos            18           /**< \brief (US_CSR) Data Carrier Detect Input Change Flag */
+#define US_CSR_DCDIC                (_U(0x1) << US_CSR_DCDIC_Pos)
+#define   US_CSR_DCDIC_0_Val              _U(0x0)   /**< \brief (US_CSR) No input change has been detected on the DCD pin since the last read of CSR */
+#define   US_CSR_DCDIC_1_Val              _U(0x1)   /**< \brief (US_CSR) At least one input change has been detected on the DCD pin since the last read of CSR */
+#define US_CSR_DCDIC_0              (US_CSR_DCDIC_0_Val            << US_CSR_DCDIC_Pos)
+#define US_CSR_DCDIC_1              (US_CSR_DCDIC_1_Val            << US_CSR_DCDIC_Pos)
+#define US_CSR_CTSIC_Pos            19           /**< \brief (US_CSR) Clear to Send Input Change Flag */
+#define US_CSR_CTSIC                (_U(0x1) << US_CSR_CTSIC_Pos)
+#define   US_CSR_CTSIC_0_Val              _U(0x0)   /**< \brief (US_CSR) No input change has been detected on the CTS pin since the last read of CSR */
+#define   US_CSR_CTSIC_1_Val              _U(0x1)   /**< \brief (US_CSR) At least one input change has been detected on the CTS pin since the last read of CSR */
+#define US_CSR_CTSIC_0              (US_CSR_CTSIC_0_Val            << US_CSR_CTSIC_Pos)
+#define US_CSR_CTSIC_1              (US_CSR_CTSIC_1_Val            << US_CSR_CTSIC_Pos)
+#define US_CSR_RI_Pos               20           /**< \brief (US_CSR) Image of RI Input */
+#define US_CSR_RI                   (_U(0x1) << US_CSR_RI_Pos)
+#define   US_CSR_RI_0_Val                 _U(0x0)   /**< \brief (US_CSR) RI is at 0 */
+#define   US_CSR_RI_1_Val                 _U(0x1)   /**< \brief (US_CSR) RI is at 1 */
+#define US_CSR_RI_0                 (US_CSR_RI_0_Val               << US_CSR_RI_Pos)
+#define US_CSR_RI_1                 (US_CSR_RI_1_Val               << US_CSR_RI_Pos)
+#define US_CSR_DSR_Pos              21           /**< \brief (US_CSR) Image of DSR Input */
+#define US_CSR_DSR                  (_U(0x1) << US_CSR_DSR_Pos)
+#define   US_CSR_DSR_0_Val                _U(0x0)   /**< \brief (US_CSR) DSR is at 0 */
+#define   US_CSR_DSR_1_Val                _U(0x1)   /**< \brief (US_CSR) DSR is at 1 */
+#define US_CSR_DSR_0                (US_CSR_DSR_0_Val              << US_CSR_DSR_Pos)
+#define US_CSR_DSR_1                (US_CSR_DSR_1_Val              << US_CSR_DSR_Pos)
+#define US_CSR_DCD_Pos              22           /**< \brief (US_CSR) Image of DCD Input */
+#define US_CSR_DCD                  (_U(0x1) << US_CSR_DCD_Pos)
+#define   US_CSR_DCD_0_Val                _U(0x0)   /**< \brief (US_CSR) DCD is at 0 */
+#define   US_CSR_DCD_1_Val                _U(0x1)   /**< \brief (US_CSR) DCD is at 1 */
+#define US_CSR_DCD_0                (US_CSR_DCD_0_Val              << US_CSR_DCD_Pos)
+#define US_CSR_DCD_1                (US_CSR_DCD_1_Val              << US_CSR_DCD_Pos)
+#define US_CSR_LINBLS_Pos           23           /**< \brief (US_CSR) LIN Bus Line Status */
+#define US_CSR_LINBLS               (_U(0x1) << US_CSR_LINBLS_Pos)
+#define   US_CSR_LINBLS_0_Val             _U(0x0)   /**< \brief (US_CSR) CTS is at 0 */
+#define   US_CSR_LINBLS_1_Val             _U(0x1)   /**< \brief (US_CSR) CTS is at 1 */
+#define US_CSR_LINBLS_0             (US_CSR_LINBLS_0_Val           << US_CSR_LINBLS_Pos)
+#define US_CSR_LINBLS_1             (US_CSR_LINBLS_1_Val           << US_CSR_LINBLS_Pos)
+#define US_CSR_CTS_Pos              23           /**< \brief (US_CSR) Image of CTS Input */
+#define US_CSR_CTS                  (_U(0x1) << US_CSR_CTS_Pos)
+#define   US_CSR_CTS_0_Val                _U(0x0)   /**< \brief (US_CSR) CTS is at 0 */
+#define   US_CSR_CTS_1_Val                _U(0x1)   /**< \brief (US_CSR) CTS is at 1 */
+#define US_CSR_CTS_0                (US_CSR_CTS_0_Val              << US_CSR_CTS_Pos)
+#define US_CSR_CTS_1                (US_CSR_CTS_1_Val              << US_CSR_CTS_Pos)
+#define US_CSR_MANERR_Pos           24           /**< \brief (US_CSR) Manchester Error */
+#define US_CSR_MANERR               (_U(0x1) << US_CSR_MANERR_Pos)
+#define   US_CSR_MANERR_0_Val             _U(0x0)   /**< \brief (US_CSR) No Manchester error has been detected since the last RSTSTA */
+#define   US_CSR_MANERR_1_Val             _U(0x1)   /**< \brief (US_CSR) At least one Manchester error has been detected since the last RSTSTA */
+#define US_CSR_MANERR_0             (US_CSR_MANERR_0_Val           << US_CSR_MANERR_Pos)
+#define US_CSR_MANERR_1             (US_CSR_MANERR_1_Val           << US_CSR_MANERR_Pos)
+#define US_CSR_LINBE_Pos            25           /**< \brief (US_CSR) LIN Bit Error */
+#define US_CSR_LINBE                (_U(0x1) << US_CSR_LINBE_Pos)
+#define US_CSR_LINISFE_Pos          26           /**< \brief (US_CSR) LIN Inconsistent Synch Field Error */
+#define US_CSR_LINISFE              (_U(0x1) << US_CSR_LINISFE_Pos)
+#define US_CSR_LINIPE_Pos           27           /**< \brief (US_CSR) LIN Identifier Parity Error */
+#define US_CSR_LINIPE               (_U(0x1) << US_CSR_LINIPE_Pos)
+#define US_CSR_LINCE_Pos            28           /**< \brief (US_CSR) LIN Checksum Error */
+#define US_CSR_LINCE                (_U(0x1) << US_CSR_LINCE_Pos)
+#define US_CSR_LINSNRE_Pos          29           /**< \brief (US_CSR) LIN Slave Not Responding Error */
+#define US_CSR_LINSNRE              (_U(0x1) << US_CSR_LINSNRE_Pos)
+#define US_CSR_LINSTE_Pos           30           /**< \brief (US_CSR) LIN Synch Tolerance Error */
+#define US_CSR_LINSTE               (_U(0x1) << US_CSR_LINSTE_Pos)
+#define   US_CSR_LINSTE_0_Val             _U(0x0)   /**< \brief (US_CSR) COMM_TX is at 0 */
+#define   US_CSR_LINSTE_1_Val             _U(0x1)   /**< \brief (US_CSR) COMM_TX is at 1 */
+#define US_CSR_LINSTE_0             (US_CSR_LINSTE_0_Val           << US_CSR_LINSTE_Pos)
+#define US_CSR_LINSTE_1             (US_CSR_LINSTE_1_Val           << US_CSR_LINSTE_Pos)
+#define US_CSR_LINHTE_Pos           31           /**< \brief (US_CSR) LIN Header Timeout Error */
+#define US_CSR_LINHTE               (_U(0x1) << US_CSR_LINHTE_Pos)
+#define   US_CSR_LINHTE_0_Val             _U(0x0)   /**< \brief (US_CSR) COMM_RX is at 0 */
+#define   US_CSR_LINHTE_1_Val             _U(0x1)   /**< \brief (US_CSR) COMM_RX is at 1 */
+#define US_CSR_LINHTE_0             (US_CSR_LINHTE_0_Val           << US_CSR_LINHTE_Pos)
+#define US_CSR_LINHTE_1             (US_CSR_LINHTE_1_Val           << US_CSR_LINHTE_Pos)
+#define US_CSR_MASK                 _U(0xFFFFFFE7) /**< \brief (US_CSR) MASK Register */
+
+/* -------- US_RHR : (USART Offset: 0x18) (R/  32) Receiver Holding Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXCHR:9;          /*!< bit:  0.. 8  Received Character                 */
+    uint32_t :6;               /*!< bit:  9..14  Reserved                           */
+    uint32_t RXSYNH:1;         /*!< bit:     15  Received Sync                      */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} US_RHR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_RHR_OFFSET               0x18         /**< \brief (US_RHR offset) Receiver Holding Register */
+#define US_RHR_RESETVALUE           _U(0x00000000); /**< \brief (US_RHR reset_value) Receiver Holding Register */
+
+#define US_RHR_RXCHR_Pos            0            /**< \brief (US_RHR) Received Character */
+#define US_RHR_RXCHR_Msk            (_U(0x1FF) << US_RHR_RXCHR_Pos)
+#define US_RHR_RXCHR(value)         (US_RHR_RXCHR_Msk & ((value) << US_RHR_RXCHR_Pos))
+#define US_RHR_RXSYNH_Pos           15           /**< \brief (US_RHR) Received Sync */
+#define US_RHR_RXSYNH               (_U(0x1) << US_RHR_RXSYNH_Pos)
+#define   US_RHR_RXSYNH_0_Val             _U(0x0)   /**< \brief (US_RHR) Last character received is a Data */
+#define   US_RHR_RXSYNH_1_Val             _U(0x1)   /**< \brief (US_RHR) Last character received is a Command */
+#define US_RHR_RXSYNH_0             (US_RHR_RXSYNH_0_Val           << US_RHR_RXSYNH_Pos)
+#define US_RHR_RXSYNH_1             (US_RHR_RXSYNH_1_Val           << US_RHR_RXSYNH_Pos)
+#define US_RHR_MASK                 _U(0x000081FF) /**< \brief (US_RHR) MASK Register */
+
+/* -------- US_THR : (USART Offset: 0x1C) ( /W 32) Transmitter Holding Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXCHR:9;          /*!< bit:  0.. 8  Character to be Transmitted        */
+    uint32_t :6;               /*!< bit:  9..14  Reserved                           */
+    uint32_t TXSYNH:1;         /*!< bit:     15  Sync Field to be transmitted       */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} US_THR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_THR_OFFSET               0x1C         /**< \brief (US_THR offset) Transmitter Holding Register */
+#define US_THR_RESETVALUE           _U(0x00000000); /**< \brief (US_THR reset_value) Transmitter Holding Register */
+
+#define US_THR_TXCHR_Pos            0            /**< \brief (US_THR) Character to be Transmitted */
+#define US_THR_TXCHR_Msk            (_U(0x1FF) << US_THR_TXCHR_Pos)
+#define US_THR_TXCHR(value)         (US_THR_TXCHR_Msk & ((value) << US_THR_TXCHR_Pos))
+#define US_THR_TXSYNH_Pos           15           /**< \brief (US_THR) Sync Field to be transmitted */
+#define US_THR_TXSYNH               (_U(0x1) << US_THR_TXSYNH_Pos)
+#define   US_THR_TXSYNH_0_Val             _U(0x0)   /**< \brief (US_THR) The next character sent is encoded as a data. Start Frame Delimiter is DATA SYNC */
+#define   US_THR_TXSYNH_1_Val             _U(0x1)   /**< \brief (US_THR) The next character sent is encoded as a command. Start Frame Delimiter is COMMAND SYNC */
+#define US_THR_TXSYNH_0             (US_THR_TXSYNH_0_Val           << US_THR_TXSYNH_Pos)
+#define US_THR_TXSYNH_1             (US_THR_TXSYNH_1_Val           << US_THR_TXSYNH_Pos)
+#define US_THR_MASK                 _U(0x000081FF) /**< \brief (US_THR) MASK Register */
+
+/* -------- US_BRGR : (USART Offset: 0x20) (R/W 32) Baud Rate Generator Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CD:16;            /*!< bit:  0..15  Clock Divisor                      */
+    uint32_t FP:3;             /*!< bit: 16..18  Fractional Part                    */
+    uint32_t :13;              /*!< bit: 19..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} US_BRGR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_BRGR_OFFSET              0x20         /**< \brief (US_BRGR offset) Baud Rate Generator Register */
+#define US_BRGR_RESETVALUE          _U(0x00000000); /**< \brief (US_BRGR reset_value) Baud Rate Generator Register */
+
+#define US_BRGR_CD_Pos              0            /**< \brief (US_BRGR) Clock Divisor */
+#define US_BRGR_CD_Msk              (_U(0xFFFF) << US_BRGR_CD_Pos)
+#define US_BRGR_CD(value)           (US_BRGR_CD_Msk & ((value) << US_BRGR_CD_Pos))
+#define   US_BRGR_CD_DISABLE_Val          _U(0x0)   /**< \brief (US_BRGR) Disables the clock */
+#define   US_BRGR_CD_BYPASS_Val           _U(0x1)   /**< \brief (US_BRGR) Clock Divisor Bypass */
+#define   US_BRGR_CD_2_Val                _U(0x2)   /**< \brief (US_BRGR) Baud Rate (Asynchronous Mode) = Selected Clock/(16 x CD) or (8 x CD); Baud Rate (Synchronous Mode) = Selected Clock/CD; */
+#define US_BRGR_CD_DISABLE          (US_BRGR_CD_DISABLE_Val        << US_BRGR_CD_Pos)
+#define US_BRGR_CD_BYPASS           (US_BRGR_CD_BYPASS_Val         << US_BRGR_CD_Pos)
+#define US_BRGR_CD_2                (US_BRGR_CD_2_Val              << US_BRGR_CD_Pos)
+#define US_BRGR_FP_Pos              16           /**< \brief (US_BRGR) Fractional Part */
+#define US_BRGR_FP_Msk              (_U(0x7) << US_BRGR_FP_Pos)
+#define US_BRGR_FP(value)           (US_BRGR_FP_Msk & ((value) << US_BRGR_FP_Pos))
+#define   US_BRGR_FP_0_Val                _U(0x0)   /**< \brief (US_BRGR) Fractional divider is disabled */
+#define US_BRGR_FP_0                (US_BRGR_FP_0_Val              << US_BRGR_FP_Pos)
+#define US_BRGR_MASK                _U(0x0007FFFF) /**< \brief (US_BRGR) MASK Register */
+
+/* -------- US_RTOR : (USART Offset: 0x24) (R/W 32) Receiver Time-out Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TO:17;            /*!< bit:  0..16  Time-out Value                     */
+    uint32_t :15;              /*!< bit: 17..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} US_RTOR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_RTOR_OFFSET              0x24         /**< \brief (US_RTOR offset) Receiver Time-out Register */
+#define US_RTOR_RESETVALUE          _U(0x00000000); /**< \brief (US_RTOR reset_value) Receiver Time-out Register */
+
+#define US_RTOR_TO_Pos              0            /**< \brief (US_RTOR) Time-out Value */
+#define US_RTOR_TO_Msk              (_U(0x1FFFF) << US_RTOR_TO_Pos)
+#define US_RTOR_TO(value)           (US_RTOR_TO_Msk & ((value) << US_RTOR_TO_Pos))
+#define   US_RTOR_TO_DISABLE_Val          _U(0x0)   /**< \brief (US_RTOR) Disables the RX Time-out function */
+#define US_RTOR_TO_DISABLE          (US_RTOR_TO_DISABLE_Val        << US_RTOR_TO_Pos)
+#define US_RTOR_MASK                _U(0x0001FFFF) /**< \brief (US_RTOR) MASK Register */
+
+/* -------- US_TTGR : (USART Offset: 0x28) (R/W 32) Transmitter Timeguard Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TG:8;             /*!< bit:  0.. 7  Timeguard Value                    */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} US_TTGR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_TTGR_OFFSET              0x28         /**< \brief (US_TTGR offset) Transmitter Timeguard Register */
+#define US_TTGR_RESETVALUE          _U(0x00000000); /**< \brief (US_TTGR reset_value) Transmitter Timeguard Register */
+
+#define US_TTGR_TG_Pos              0            /**< \brief (US_TTGR) Timeguard Value */
+#define US_TTGR_TG_Msk              (_U(0xFF) << US_TTGR_TG_Pos)
+#define US_TTGR_TG(value)           (US_TTGR_TG_Msk & ((value) << US_TTGR_TG_Pos))
+#define   US_TTGR_TG_DISABLE_Val          _U(0x0)   /**< \brief (US_TTGR) Disables the TX Timeguard function. */
+#define US_TTGR_TG_DISABLE          (US_TTGR_TG_DISABLE_Val        << US_TTGR_TG_Pos)
+#define US_TTGR_MASK                _U(0x000000FF) /**< \brief (US_TTGR) MASK Register */
+
+/* -------- US_FIDI : (USART Offset: 0x40) (R/W 32) FI DI Ratio Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t FI_DI_RATIO:11;   /*!< bit:  0..10  FI Over DI Ratio Value             */
+    uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} US_FIDI_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_FIDI_OFFSET              0x40         /**< \brief (US_FIDI offset) FI DI Ratio Register */
+#define US_FIDI_RESETVALUE          _U(0x00000174); /**< \brief (US_FIDI reset_value) FI DI Ratio Register */
+
+#define US_FIDI_FI_DI_RATIO_Pos     0            /**< \brief (US_FIDI) FI Over DI Ratio Value */
+#define US_FIDI_FI_DI_RATIO_Msk     (_U(0x7FF) << US_FIDI_FI_DI_RATIO_Pos)
+#define US_FIDI_FI_DI_RATIO(value)  (US_FIDI_FI_DI_RATIO_Msk & ((value) << US_FIDI_FI_DI_RATIO_Pos))
+#define   US_FIDI_FI_DI_RATIO_DISABLE_Val _U(0x0)   /**< \brief (US_FIDI) Baud Rate = 0 */
+#define US_FIDI_FI_DI_RATIO_DISABLE (US_FIDI_FI_DI_RATIO_DISABLE_Val << US_FIDI_FI_DI_RATIO_Pos)
+#define US_FIDI_MASK                _U(0x000007FF) /**< \brief (US_FIDI) MASK Register */
+
+/* -------- US_NER : (USART Offset: 0x44) (R/  32) Number of Errors Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t NB_ERRORS:8;      /*!< bit:  0.. 7  Error number during ISO7816 transfers */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} US_NER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_NER_OFFSET               0x44         /**< \brief (US_NER offset) Number of Errors Register */
+#define US_NER_RESETVALUE           _U(0x00000000); /**< \brief (US_NER reset_value) Number of Errors Register */
+
+#define US_NER_NB_ERRORS_Pos        0            /**< \brief (US_NER) Error number during ISO7816 transfers */
+#define US_NER_NB_ERRORS_Msk        (_U(0xFF) << US_NER_NB_ERRORS_Pos)
+#define US_NER_NB_ERRORS(value)     (US_NER_NB_ERRORS_Msk & ((value) << US_NER_NB_ERRORS_Pos))
+#define US_NER_MASK                 _U(0x000000FF) /**< \brief (US_NER) MASK Register */
+
+/* -------- US_IFR : (USART Offset: 0x4C) (R/W 32) IrDA Filter Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t IRDA_FILTER:8;    /*!< bit:  0.. 7  Irda filter                        */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} US_IFR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_IFR_OFFSET               0x4C         /**< \brief (US_IFR offset) IrDA Filter Register */
+#define US_IFR_RESETVALUE           _U(0x00000000); /**< \brief (US_IFR reset_value) IrDA Filter Register */
+
+#define US_IFR_IRDA_FILTER_Pos      0            /**< \brief (US_IFR) Irda filter */
+#define US_IFR_IRDA_FILTER_Msk      (_U(0xFF) << US_IFR_IRDA_FILTER_Pos)
+#define US_IFR_IRDA_FILTER(value)   (US_IFR_IRDA_FILTER_Msk & ((value) << US_IFR_IRDA_FILTER_Pos))
+#define US_IFR_MASK                 _U(0x000000FF) /**< \brief (US_IFR) MASK Register */
+
+/* -------- US_MAN : (USART Offset: 0x50) (R/W 32) Manchester Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TX_PL:4;          /*!< bit:  0.. 3  Transmitter Preamble Length        */
+    uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint32_t TX_PP:2;          /*!< bit:  8.. 9  Transmitter Preamble Pattern       */
+    uint32_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint32_t TX_MPOL:1;        /*!< bit:     12  Transmitter Manchester Polarity    */
+    uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t RX_PL:4;          /*!< bit: 16..19  Receiver Preamble Length           */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t RX_PP:2;          /*!< bit: 24..25  Receiver Preamble Pattern detected */
+    uint32_t :2;               /*!< bit: 26..27  Reserved                           */
+    uint32_t RX_MPOL:1;        /*!< bit:     28  Receiver Manchester Polarity       */
+    uint32_t :1;               /*!< bit:     29  Reserved                           */
+    uint32_t DRIFT:1;          /*!< bit:     30  Drift compensation                 */
+    uint32_t :1;               /*!< bit:     31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} US_MAN_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_MAN_OFFSET               0x50         /**< \brief (US_MAN offset) Manchester Configuration Register */
+#define US_MAN_RESETVALUE           _U(0x30011004); /**< \brief (US_MAN reset_value) Manchester Configuration Register */
+
+#define US_MAN_TX_PL_Pos            0            /**< \brief (US_MAN) Transmitter Preamble Length */
+#define US_MAN_TX_PL_Msk            (_U(0xF) << US_MAN_TX_PL_Pos)
+#define US_MAN_TX_PL(value)         (US_MAN_TX_PL_Msk & ((value) << US_MAN_TX_PL_Pos))
+#define   US_MAN_TX_PL_0_Val              _U(0x0)   /**< \brief (US_MAN) The Transmitter Preamble pattern generation is disabled */
+#define US_MAN_TX_PL_0              (US_MAN_TX_PL_0_Val            << US_MAN_TX_PL_Pos)
+#define US_MAN_TX_PP_Pos            8            /**< \brief (US_MAN) Transmitter Preamble Pattern */
+#define US_MAN_TX_PP_Msk            (_U(0x3) << US_MAN_TX_PP_Pos)
+#define US_MAN_TX_PP(value)         (US_MAN_TX_PP_Msk & ((value) << US_MAN_TX_PP_Pos))
+#define   US_MAN_TX_PP_0_Val              _U(0x0)   /**< \brief (US_MAN) ALL_ONE */
+#define   US_MAN_TX_PP_1_Val              _U(0x1)   /**< \brief (US_MAN) ALL_ZERO */
+#define   US_MAN_TX_PP_2_Val              _U(0x2)   /**< \brief (US_MAN) ZERO_ONE */
+#define   US_MAN_TX_PP_3_Val              _U(0x3)   /**< \brief (US_MAN) ONE_ZERO */
+#define US_MAN_TX_PP_0              (US_MAN_TX_PP_0_Val            << US_MAN_TX_PP_Pos)
+#define US_MAN_TX_PP_1              (US_MAN_TX_PP_1_Val            << US_MAN_TX_PP_Pos)
+#define US_MAN_TX_PP_2              (US_MAN_TX_PP_2_Val            << US_MAN_TX_PP_Pos)
+#define US_MAN_TX_PP_3              (US_MAN_TX_PP_3_Val            << US_MAN_TX_PP_Pos)
+#define US_MAN_TX_MPOL_Pos          12           /**< \brief (US_MAN) Transmitter Manchester Polarity */
+#define US_MAN_TX_MPOL              (_U(0x1) << US_MAN_TX_MPOL_Pos)
+#define   US_MAN_TX_MPOL_0_Val            _U(0x0)   /**< \brief (US_MAN) Logic Zero is coded as a zero-to-one transition, Logic One is coded as a one-to-zero transition */
+#define   US_MAN_TX_MPOL_1_Val            _U(0x1)   /**< \brief (US_MAN) Logic Zero is coded as a one-to-zero transition, Logic One is coded as a zero-to-one transition */
+#define US_MAN_TX_MPOL_0            (US_MAN_TX_MPOL_0_Val          << US_MAN_TX_MPOL_Pos)
+#define US_MAN_TX_MPOL_1            (US_MAN_TX_MPOL_1_Val          << US_MAN_TX_MPOL_Pos)
+#define US_MAN_RX_PL_Pos            16           /**< \brief (US_MAN) Receiver Preamble Length */
+#define US_MAN_RX_PL_Msk            (_U(0xF) << US_MAN_RX_PL_Pos)
+#define US_MAN_RX_PL(value)         (US_MAN_RX_PL_Msk & ((value) << US_MAN_RX_PL_Pos))
+#define   US_MAN_RX_PL_0_Val              _U(0x0)   /**< \brief (US_MAN) The receiver preamble pattern detection is disabled */
+#define US_MAN_RX_PL_0              (US_MAN_RX_PL_0_Val            << US_MAN_RX_PL_Pos)
+#define US_MAN_RX_PP_Pos            24           /**< \brief (US_MAN) Receiver Preamble Pattern detected */
+#define US_MAN_RX_PP_Msk            (_U(0x3) << US_MAN_RX_PP_Pos)
+#define US_MAN_RX_PP(value)         (US_MAN_RX_PP_Msk & ((value) << US_MAN_RX_PP_Pos))
+#define   US_MAN_RX_PP_0_Val              _U(0x0)   /**< \brief (US_MAN) ALL_ONE */
+#define   US_MAN_RX_PP_1_Val              _U(0x1)   /**< \brief (US_MAN) ALL_ZERO */
+#define   US_MAN_RX_PP_2_Val              _U(0x2)   /**< \brief (US_MAN) ZERO_ONE */
+#define   US_MAN_RX_PP_3_Val              _U(0x3)   /**< \brief (US_MAN) ONE_ZERO */
+#define US_MAN_RX_PP_0              (US_MAN_RX_PP_0_Val            << US_MAN_RX_PP_Pos)
+#define US_MAN_RX_PP_1              (US_MAN_RX_PP_1_Val            << US_MAN_RX_PP_Pos)
+#define US_MAN_RX_PP_2              (US_MAN_RX_PP_2_Val            << US_MAN_RX_PP_Pos)
+#define US_MAN_RX_PP_3              (US_MAN_RX_PP_3_Val            << US_MAN_RX_PP_Pos)
+#define US_MAN_RX_MPOL_Pos          28           /**< \brief (US_MAN) Receiver Manchester Polarity */
+#define US_MAN_RX_MPOL              (_U(0x1) << US_MAN_RX_MPOL_Pos)
+#define   US_MAN_RX_MPOL_0_Val            _U(0x0)   /**< \brief (US_MAN) Logic Zero is coded as a zero-to-one transition, Logic One is coded as a one-to-zero transition */
+#define   US_MAN_RX_MPOL_1_Val            _U(0x1)   /**< \brief (US_MAN) Logic Zero is coded as a one-to-zero transition, Logic One is coded as a zero-to-one transition */
+#define US_MAN_RX_MPOL_0            (US_MAN_RX_MPOL_0_Val          << US_MAN_RX_MPOL_Pos)
+#define US_MAN_RX_MPOL_1            (US_MAN_RX_MPOL_1_Val          << US_MAN_RX_MPOL_Pos)
+#define US_MAN_DRIFT_Pos            30           /**< \brief (US_MAN) Drift compensation */
+#define US_MAN_DRIFT                (_U(0x1) << US_MAN_DRIFT_Pos)
+#define   US_MAN_DRIFT_0_Val              _U(0x0)   /**< \brief (US_MAN) The USART can not recover from an important clock drift */
+#define   US_MAN_DRIFT_1_Val              _U(0x1)   /**< \brief (US_MAN) The USART can recover from clock drift. The 16X clock mode must be enabled */
+#define US_MAN_DRIFT_0              (US_MAN_DRIFT_0_Val            << US_MAN_DRIFT_Pos)
+#define US_MAN_DRIFT_1              (US_MAN_DRIFT_1_Val            << US_MAN_DRIFT_Pos)
+#define US_MAN_MASK                 _U(0x530F130F) /**< \brief (US_MAN) MASK Register */
+
+/* -------- US_LINMR : (USART Offset: 0x54) (R/W 32) LIN Mode Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t NACT:2;           /*!< bit:  0.. 1  LIN Node Action                    */
+    uint32_t PARDIS:1;         /*!< bit:      2  Parity Disable                     */
+    uint32_t CHKDIS:1;         /*!< bit:      3  Checksum Disable                   */
+    uint32_t CHKTYP:1;         /*!< bit:      4  Checksum Type                      */
+    uint32_t DLM:1;            /*!< bit:      5  Data Length Mode                   */
+    uint32_t FSDIS:1;          /*!< bit:      6  Frame Slot Mode Disable            */
+    uint32_t WKUPTYP:1;        /*!< bit:      7  Wakeup Signal Type                 */
+    uint32_t DLC:8;            /*!< bit:  8..15  Data Length Control                */
+    uint32_t PDCM:1;           /*!< bit:     16  PDC Mode                           */
+    uint32_t SYNCDIS:1;        /*!< bit:     17  Synchronization Disable            */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} US_LINMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_LINMR_OFFSET             0x54         /**< \brief (US_LINMR offset) LIN Mode Register */
+#define US_LINMR_RESETVALUE         _U(0x00000000); /**< \brief (US_LINMR reset_value) LIN Mode Register */
+
+#define US_LINMR_NACT_Pos           0            /**< \brief (US_LINMR) LIN Node Action */
+#define US_LINMR_NACT_Msk           (_U(0x3) << US_LINMR_NACT_Pos)
+#define US_LINMR_NACT(value)        (US_LINMR_NACT_Msk & ((value) << US_LINMR_NACT_Pos))
+#define   US_LINMR_NACT_PUBLISH_Val       _U(0x0)   /**< \brief (US_LINMR) The LIN Controller transmits the response */
+#define   US_LINMR_NACT_SUBSCRIBE_Val     _U(0x1)   /**< \brief (US_LINMR) The LIN Controller receives the response */
+#define   US_LINMR_NACT_IGNORE_Val        _U(0x2)   /**< \brief (US_LINMR) The LIN Controller doesn't transmit and doesn't receive the response */
+#define US_LINMR_NACT_PUBLISH       (US_LINMR_NACT_PUBLISH_Val     << US_LINMR_NACT_Pos)
+#define US_LINMR_NACT_SUBSCRIBE     (US_LINMR_NACT_SUBSCRIBE_Val   << US_LINMR_NACT_Pos)
+#define US_LINMR_NACT_IGNORE        (US_LINMR_NACT_IGNORE_Val      << US_LINMR_NACT_Pos)
+#define US_LINMR_PARDIS_Pos         2            /**< \brief (US_LINMR) Parity Disable */
+#define US_LINMR_PARDIS             (_U(0x1) << US_LINMR_PARDIS_Pos)
+#define US_LINMR_CHKDIS_Pos         3            /**< \brief (US_LINMR) Checksum Disable */
+#define US_LINMR_CHKDIS             (_U(0x1) << US_LINMR_CHKDIS_Pos)
+#define US_LINMR_CHKTYP_Pos         4            /**< \brief (US_LINMR) Checksum Type */
+#define US_LINMR_CHKTYP             (_U(0x1) << US_LINMR_CHKTYP_Pos)
+#define US_LINMR_DLM_Pos            5            /**< \brief (US_LINMR) Data Length Mode */
+#define US_LINMR_DLM                (_U(0x1) << US_LINMR_DLM_Pos)
+#define US_LINMR_FSDIS_Pos          6            /**< \brief (US_LINMR) Frame Slot Mode Disable */
+#define US_LINMR_FSDIS              (_U(0x1) << US_LINMR_FSDIS_Pos)
+#define US_LINMR_WKUPTYP_Pos        7            /**< \brief (US_LINMR) Wakeup Signal Type */
+#define US_LINMR_WKUPTYP            (_U(0x1) << US_LINMR_WKUPTYP_Pos)
+#define US_LINMR_DLC_Pos            8            /**< \brief (US_LINMR) Data Length Control */
+#define US_LINMR_DLC_Msk            (_U(0xFF) << US_LINMR_DLC_Pos)
+#define US_LINMR_DLC(value)         (US_LINMR_DLC_Msk & ((value) << US_LINMR_DLC_Pos))
+#define US_LINMR_PDCM_Pos           16           /**< \brief (US_LINMR) PDC Mode */
+#define US_LINMR_PDCM               (_U(0x1) << US_LINMR_PDCM_Pos)
+#define US_LINMR_SYNCDIS_Pos        17           /**< \brief (US_LINMR) Synchronization Disable */
+#define US_LINMR_SYNCDIS            (_U(0x1) << US_LINMR_SYNCDIS_Pos)
+#define US_LINMR_MASK               _U(0x0003FFFF) /**< \brief (US_LINMR) MASK Register */
+
+/* -------- US_LINIR : (USART Offset: 0x58) (R/W 32) LIN Identifier Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t IDCHR:8;          /*!< bit:  0.. 7  Identifier Character               */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} US_LINIR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_LINIR_OFFSET             0x58         /**< \brief (US_LINIR offset) LIN Identifier Register */
+#define US_LINIR_RESETVALUE         _U(0x00000000); /**< \brief (US_LINIR reset_value) LIN Identifier Register */
+
+#define US_LINIR_IDCHR_Pos          0            /**< \brief (US_LINIR) Identifier Character */
+#define US_LINIR_IDCHR_Msk          (_U(0xFF) << US_LINIR_IDCHR_Pos)
+#define US_LINIR_IDCHR(value)       (US_LINIR_IDCHR_Msk & ((value) << US_LINIR_IDCHR_Pos))
+#define US_LINIR_MASK               _U(0x000000FF) /**< \brief (US_LINIR) MASK Register */
+
+/* -------- US_LINBRR : (USART Offset: 0x5C) (R/  32) LIN Baud Rate Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t LINCD:16;         /*!< bit:  0..15  Clock Divider after Synchronization */
+    uint32_t LINFP:3;          /*!< bit: 16..18  Fractional Part after Synchronization */
+    uint32_t :13;              /*!< bit: 19..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} US_LINBRR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_LINBRR_OFFSET            0x5C         /**< \brief (US_LINBRR offset) LIN Baud Rate Register */
+#define US_LINBRR_RESETVALUE        _U(0x00000000); /**< \brief (US_LINBRR reset_value) LIN Baud Rate Register */
+
+#define US_LINBRR_LINCD_Pos         0            /**< \brief (US_LINBRR) Clock Divider after Synchronization */
+#define US_LINBRR_LINCD_Msk         (_U(0xFFFF) << US_LINBRR_LINCD_Pos)
+#define US_LINBRR_LINCD(value)      (US_LINBRR_LINCD_Msk & ((value) << US_LINBRR_LINCD_Pos))
+#define US_LINBRR_LINFP_Pos         16           /**< \brief (US_LINBRR) Fractional Part after Synchronization */
+#define US_LINBRR_LINFP_Msk         (_U(0x7) << US_LINBRR_LINFP_Pos)
+#define US_LINBRR_LINFP(value)      (US_LINBRR_LINFP_Msk & ((value) << US_LINBRR_LINFP_Pos))
+#define US_LINBRR_MASK              _U(0x0007FFFF) /**< \brief (US_LINBRR) MASK Register */
+
+/* -------- US_WPMR : (USART Offset: 0xE4) (R/W 32) Write Protect Mode Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t WPEN:1;           /*!< bit:      0  Write Protect Enable               */
+    uint32_t :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint32_t WPKEY:24;         /*!< bit:  8..31  Write Protect Key                  */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} US_WPMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_WPMR_OFFSET              0xE4         /**< \brief (US_WPMR offset) Write Protect Mode Register */
+#define US_WPMR_RESETVALUE          _U(0x00000000); /**< \brief (US_WPMR reset_value) Write Protect Mode Register */
+
+#define US_WPMR_WPEN_Pos            0            /**< \brief (US_WPMR) Write Protect Enable */
+#define US_WPMR_WPEN                (_U(0x1) << US_WPMR_WPEN_Pos)
+#define   US_WPMR_WPEN_0_Val              _U(0x0)   /**< \brief (US_WPMR) Disables the Write Protect if WPKEY corresponds to 0x858365 ("USA" in ACII) */
+#define   US_WPMR_WPEN_1_Val              _U(0x1)   /**< \brief (US_WPMR) Enables the Write Protect if WPKEY corresponds to 0x858365 ("USA" in ACII) */
+#define US_WPMR_WPEN_0              (US_WPMR_WPEN_0_Val            << US_WPMR_WPEN_Pos)
+#define US_WPMR_WPEN_1              (US_WPMR_WPEN_1_Val            << US_WPMR_WPEN_Pos)
+#define US_WPMR_WPKEY_Pos           8            /**< \brief (US_WPMR) Write Protect Key */
+#define US_WPMR_WPKEY_Msk           (_U(0xFFFFFF) << US_WPMR_WPKEY_Pos)
+#define US_WPMR_WPKEY(value)        (US_WPMR_WPKEY_Msk & ((value) << US_WPMR_WPKEY_Pos))
+#define US_WPMR_MASK                _U(0xFFFFFF01) /**< \brief (US_WPMR) MASK Register */
+
+/* -------- US_WPSR : (USART Offset: 0xE8) (R/  32) Write Protect Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t WPV:1;            /*!< bit:      0  Write Protect Violation Status     */
+    uint32_t :7;               /*!< bit:  1.. 7  Reserved                           */
+    uint32_t WPVSRC:16;        /*!< bit:  8..23  Write Protect Violation Source     */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} US_WPSR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_WPSR_OFFSET              0xE8         /**< \brief (US_WPSR offset) Write Protect Status Register */
+#define US_WPSR_RESETVALUE          _U(0x00000000); /**< \brief (US_WPSR reset_value) Write Protect Status Register */
+
+#define US_WPSR_WPV_Pos             0            /**< \brief (US_WPSR) Write Protect Violation Status */
+#define US_WPSR_WPV                 (_U(0x1) << US_WPSR_WPV_Pos)
+#define   US_WPSR_WPV_0_Val               _U(0x0)   /**< \brief (US_WPSR) No Write Protect Violation has occurred since the last read of the WPSR register */
+#define   US_WPSR_WPV_1_Val               _U(0x1)   /**< \brief (US_WPSR) A Write Protect Violation has occurred since the last read of the WPSR register. If this violation is an unauthorized attempt to write a protected register, the associated violation is reported into field WPVSRC */
+#define US_WPSR_WPV_0               (US_WPSR_WPV_0_Val             << US_WPSR_WPV_Pos)
+#define US_WPSR_WPV_1               (US_WPSR_WPV_1_Val             << US_WPSR_WPV_Pos)
+#define US_WPSR_WPVSRC_Pos          8            /**< \brief (US_WPSR) Write Protect Violation Source */
+#define US_WPSR_WPVSRC_Msk          (_U(0xFFFF) << US_WPSR_WPVSRC_Pos)
+#define US_WPSR_WPVSRC(value)       (US_WPSR_WPVSRC_Msk & ((value) << US_WPSR_WPVSRC_Pos))
+#define US_WPSR_MASK                _U(0x00FFFF01) /**< \brief (US_WPSR) MASK Register */
+
+/* -------- US_VERSION : (USART Offset: 0xFC) (R/  32) Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version                            */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t MFN:4;            /*!< bit: 16..19  MFN                                */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} US_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define US_VERSION_OFFSET           0xFC         /**< \brief (US_VERSION offset) Version Register */
+#define US_VERSION_RESETVALUE       _U(0x00000602); /**< \brief (US_VERSION reset_value) Version Register */
+
+#define US_VERSION_VERSION_Pos      0            /**< \brief (US_VERSION) Version */
+#define US_VERSION_VERSION_Msk      (_U(0xFFF) << US_VERSION_VERSION_Pos)
+#define US_VERSION_VERSION(value)   (US_VERSION_VERSION_Msk & ((value) << US_VERSION_VERSION_Pos))
+#define US_VERSION_MFN_Pos          16           /**< \brief (US_VERSION) MFN */
+#define US_VERSION_MFN_Msk          (_U(0xF) << US_VERSION_MFN_Pos)
+#define US_VERSION_MFN(value)       (US_VERSION_MFN_Msk & ((value) << US_VERSION_MFN_Pos))
+#define US_VERSION_MASK             _U(0x000F0FFF) /**< \brief (US_VERSION) MASK Register */
+
+/** \brief USART hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __O  US_CR_Type                CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
+  __IO US_MR_Type                MR;          /**< \brief Offset: 0x04 (R/W 32) Mode Register */
+  __O  US_IER_Type               IER;         /**< \brief Offset: 0x08 ( /W 32) Interrupt Enable Register */
+  __O  US_IDR_Type               IDR;         /**< \brief Offset: 0x0C ( /W 32) Interrupt Disable Register */
+  __I  US_IMR_Type               IMR;         /**< \brief Offset: 0x10 (R/  32) Interrupt Mask Register */
+  __I  US_CSR_Type               CSR;         /**< \brief Offset: 0x14 (R/  32) Channel Status Register */
+  __I  US_RHR_Type               RHR;         /**< \brief Offset: 0x18 (R/  32) Receiver Holding Register */
+  __O  US_THR_Type               THR;         /**< \brief Offset: 0x1C ( /W 32) Transmitter Holding Register */
+  __IO US_BRGR_Type              BRGR;        /**< \brief Offset: 0x20 (R/W 32) Baud Rate Generator Register */
+  __IO US_RTOR_Type              RTOR;        /**< \brief Offset: 0x24 (R/W 32) Receiver Time-out Register */
+  __IO US_TTGR_Type              TTGR;        /**< \brief Offset: 0x28 (R/W 32) Transmitter Timeguard Register */
+       RoReg8                    Reserved1[0x14];
+  __IO US_FIDI_Type              FIDI;        /**< \brief Offset: 0x40 (R/W 32) FI DI Ratio Register */
+  __I  US_NER_Type               NER;         /**< \brief Offset: 0x44 (R/  32) Number of Errors Register */
+       RoReg8                    Reserved2[0x4];
+  __IO US_IFR_Type               IFR;         /**< \brief Offset: 0x4C (R/W 32) IrDA Filter Register */
+  __IO US_MAN_Type               MAN;         /**< \brief Offset: 0x50 (R/W 32) Manchester Configuration Register */
+  __IO US_LINMR_Type             LINMR;       /**< \brief Offset: 0x54 (R/W 32) LIN Mode Register */
+  __IO US_LINIR_Type             LINIR;       /**< \brief Offset: 0x58 (R/W 32) LIN Identifier Register */
+  __I  US_LINBRR_Type            LINBRR;      /**< \brief Offset: 0x5C (R/  32) LIN Baud Rate Register */
+       RoReg8                    Reserved3[0x84];
+  __IO US_WPMR_Type              WPMR;        /**< \brief Offset: 0xE4 (R/W 32) Write Protect Mode Register */
+  __I  US_WPSR_Type              WPSR;        /**< \brief Offset: 0xE8 (R/  32) Write Protect Status Register */
+       RoReg8                    Reserved4[0x10];
+  __I  US_VERSION_Type           VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
+ } bf;
+ struct {
+  WoReg   US_CR;              /**< \brief (USART Offset: 0x00) Control Register */
+  RwReg   US_MR;              /**< \brief (USART Offset: 0x04) Mode Register */
+  WoReg   US_IER;             /**< \brief (USART Offset: 0x08) Interrupt Enable Register */
+  WoReg   US_IDR;             /**< \brief (USART Offset: 0x0C) Interrupt Disable Register */
+  RoReg   US_IMR;             /**< \brief (USART Offset: 0x10) Interrupt Mask Register */
+  RoReg   US_CSR;             /**< \brief (USART Offset: 0x14) Channel Status Register */
+  RoReg   US_RHR;             /**< \brief (USART Offset: 0x18) Receiver Holding Register */
+  WoReg   US_THR;             /**< \brief (USART Offset: 0x1C) Transmitter Holding Register */
+  RwReg   US_BRGR;            /**< \brief (USART Offset: 0x20) Baud Rate Generator Register */
+  RwReg   US_RTOR;            /**< \brief (USART Offset: 0x24) Receiver Time-out Register */
+  RwReg   US_TTGR;            /**< \brief (USART Offset: 0x28) Transmitter Timeguard Register */
+  RoReg8  Reserved5[0x14];
+  RwReg   US_FIDI;            /**< \brief (USART Offset: 0x40) FI DI Ratio Register */
+  RoReg   US_NER;             /**< \brief (USART Offset: 0x44) Number of Errors Register */
+  RoReg8  Reserved6[0x4];
+  RwReg   US_IFR;             /**< \brief (USART Offset: 0x4C) IrDA Filter Register */
+  RwReg   US_MAN;             /**< \brief (USART Offset: 0x50) Manchester Configuration Register */
+  RwReg   US_LINMR;           /**< \brief (USART Offset: 0x54) LIN Mode Register */
+  RwReg   US_LINIR;           /**< \brief (USART Offset: 0x58) LIN Identifier Register */
+  RoReg   US_LINBRR;          /**< \brief (USART Offset: 0x5C) LIN Baud Rate Register */
+  RoReg8  Reserved7[0x84];
+  RwReg   US_WPMR;            /**< \brief (USART Offset: 0xE4) Write Protect Mode Register */
+  RoReg   US_WPSR;            /**< \brief (USART Offset: 0xE8) Write Protect Status Register */
+  RoReg8  Reserved8[0x10];
+  RoReg   US_VERSION;         /**< \brief (USART Offset: 0xFC) Version Register */
+ } reg;
+} Usart;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_USART_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/usart.h
+++ b/asf/sam/include/sam4l/component/usart.h
@@ -117,479 +117,479 @@ typedef union {
 
 // LIN mode
 #define US_CR_LIN_RSTRX_Pos         2            /**< \brief (US_CR_LIN) Reset Receiver */
-#define US_CR_LIN_RSTRX             (_U(0x1) << US_CR_LIN_RSTRX_Pos)
-#define   US_CR_LIN_RSTRX_0_Val           _U(0x0)   /**< \brief (US_CR_LIN) No effect */
-#define   US_CR_LIN_RSTRX_1_Val           _U(0x1)   /**< \brief (US_CR_LIN) Resets the receiver */
+#define US_CR_LIN_RSTRX             (_U_(0x1) << US_CR_LIN_RSTRX_Pos)
+#define   US_CR_LIN_RSTRX_0_Val           _U_(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_RSTRX_1_Val           _U_(0x1)   /**< \brief (US_CR_LIN) Resets the receiver */
 #define US_CR_LIN_RSTRX_0           (US_CR_LIN_RSTRX_0_Val         << US_CR_LIN_RSTRX_Pos)
 #define US_CR_LIN_RSTRX_1           (US_CR_LIN_RSTRX_1_Val         << US_CR_LIN_RSTRX_Pos)
 #define US_CR_LIN_RSTTX_Pos         3            /**< \brief (US_CR_LIN) Reset Transmitter */
-#define US_CR_LIN_RSTTX             (_U(0x1) << US_CR_LIN_RSTTX_Pos)
-#define   US_CR_LIN_RSTTX_0_Val           _U(0x0)   /**< \brief (US_CR_LIN) No effect */
-#define   US_CR_LIN_RSTTX_1_Val           _U(0x1)   /**< \brief (US_CR_LIN) Resets the transmitter */
+#define US_CR_LIN_RSTTX             (_U_(0x1) << US_CR_LIN_RSTTX_Pos)
+#define   US_CR_LIN_RSTTX_0_Val           _U_(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_RSTTX_1_Val           _U_(0x1)   /**< \brief (US_CR_LIN) Resets the transmitter */
 #define US_CR_LIN_RSTTX_0           (US_CR_LIN_RSTTX_0_Val         << US_CR_LIN_RSTTX_Pos)
 #define US_CR_LIN_RSTTX_1           (US_CR_LIN_RSTTX_1_Val         << US_CR_LIN_RSTTX_Pos)
 #define US_CR_LIN_RXEN_Pos          4            /**< \brief (US_CR_LIN) Receiver Enable */
-#define US_CR_LIN_RXEN              (_U(0x1) << US_CR_LIN_RXEN_Pos)
-#define   US_CR_LIN_RXEN_0_Val            _U(0x0)   /**< \brief (US_CR_LIN) No effect */
-#define   US_CR_LIN_RXEN_1_Val            _U(0x1)   /**< \brief (US_CR_LIN) Enables the receiver, if RXDIS is 0 */
+#define US_CR_LIN_RXEN              (_U_(0x1) << US_CR_LIN_RXEN_Pos)
+#define   US_CR_LIN_RXEN_0_Val            _U_(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_RXEN_1_Val            _U_(0x1)   /**< \brief (US_CR_LIN) Enables the receiver, if RXDIS is 0 */
 #define US_CR_LIN_RXEN_0            (US_CR_LIN_RXEN_0_Val          << US_CR_LIN_RXEN_Pos)
 #define US_CR_LIN_RXEN_1            (US_CR_LIN_RXEN_1_Val          << US_CR_LIN_RXEN_Pos)
 #define US_CR_LIN_RXDIS_Pos         5            /**< \brief (US_CR_LIN) Receiver Disable */
-#define US_CR_LIN_RXDIS             (_U(0x1) << US_CR_LIN_RXDIS_Pos)
-#define   US_CR_LIN_RXDIS_0_Val           _U(0x0)   /**< \brief (US_CR_LIN) No effect */
-#define   US_CR_LIN_RXDIS_1_Val           _U(0x1)   /**< \brief (US_CR_LIN) Disables the receiver */
+#define US_CR_LIN_RXDIS             (_U_(0x1) << US_CR_LIN_RXDIS_Pos)
+#define   US_CR_LIN_RXDIS_0_Val           _U_(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_RXDIS_1_Val           _U_(0x1)   /**< \brief (US_CR_LIN) Disables the receiver */
 #define US_CR_LIN_RXDIS_0           (US_CR_LIN_RXDIS_0_Val         << US_CR_LIN_RXDIS_Pos)
 #define US_CR_LIN_RXDIS_1           (US_CR_LIN_RXDIS_1_Val         << US_CR_LIN_RXDIS_Pos)
 #define US_CR_LIN_TXEN_Pos          6            /**< \brief (US_CR_LIN) Transmitter Enable */
-#define US_CR_LIN_TXEN              (_U(0x1) << US_CR_LIN_TXEN_Pos)
-#define   US_CR_LIN_TXEN_0_Val            _U(0x0)   /**< \brief (US_CR_LIN) No effect */
-#define   US_CR_LIN_TXEN_1_Val            _U(0x1)   /**< \brief (US_CR_LIN) Enables the transmitter if TXDIS is 0 */
+#define US_CR_LIN_TXEN              (_U_(0x1) << US_CR_LIN_TXEN_Pos)
+#define   US_CR_LIN_TXEN_0_Val            _U_(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_TXEN_1_Val            _U_(0x1)   /**< \brief (US_CR_LIN) Enables the transmitter if TXDIS is 0 */
 #define US_CR_LIN_TXEN_0            (US_CR_LIN_TXEN_0_Val          << US_CR_LIN_TXEN_Pos)
 #define US_CR_LIN_TXEN_1            (US_CR_LIN_TXEN_1_Val          << US_CR_LIN_TXEN_Pos)
 #define US_CR_LIN_TXDIS_Pos         7            /**< \brief (US_CR_LIN) Transmitter Disable */
-#define US_CR_LIN_TXDIS             (_U(0x1) << US_CR_LIN_TXDIS_Pos)
-#define   US_CR_LIN_TXDIS_0_Val           _U(0x0)   /**< \brief (US_CR_LIN) No effect */
-#define   US_CR_LIN_TXDIS_1_Val           _U(0x1)   /**< \brief (US_CR_LIN) Disables the transmitter */
+#define US_CR_LIN_TXDIS             (_U_(0x1) << US_CR_LIN_TXDIS_Pos)
+#define   US_CR_LIN_TXDIS_0_Val           _U_(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_TXDIS_1_Val           _U_(0x1)   /**< \brief (US_CR_LIN) Disables the transmitter */
 #define US_CR_LIN_TXDIS_0           (US_CR_LIN_TXDIS_0_Val         << US_CR_LIN_TXDIS_Pos)
 #define US_CR_LIN_TXDIS_1           (US_CR_LIN_TXDIS_1_Val         << US_CR_LIN_TXDIS_Pos)
 #define US_CR_LIN_RSTSTA_Pos        8            /**< \brief (US_CR_LIN) Reset Status Bits */
-#define US_CR_LIN_RSTSTA            (_U(0x1) << US_CR_LIN_RSTSTA_Pos)
-#define   US_CR_LIN_RSTSTA_0_Val          _U(0x0)   /**< \brief (US_CR_LIN) No effect */
-#define   US_CR_LIN_RSTSTA_1_Val          _U(0x1)   /**< \brief (US_CR_LIN) Resets the status bits PARE, FRAME, OVRE and RXBRK in the CSR */
+#define US_CR_LIN_RSTSTA            (_U_(0x1) << US_CR_LIN_RSTSTA_Pos)
+#define   US_CR_LIN_RSTSTA_0_Val          _U_(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_RSTSTA_1_Val          _U_(0x1)   /**< \brief (US_CR_LIN) Resets the status bits PARE, FRAME, OVRE and RXBRK in the CSR */
 #define US_CR_LIN_RSTSTA_0          (US_CR_LIN_RSTSTA_0_Val        << US_CR_LIN_RSTSTA_Pos)
 #define US_CR_LIN_RSTSTA_1          (US_CR_LIN_RSTSTA_1_Val        << US_CR_LIN_RSTSTA_Pos)
 #define US_CR_LIN_STTBRK_Pos        9            /**< \brief (US_CR_LIN) Start Break */
-#define US_CR_LIN_STTBRK            (_U(0x1) << US_CR_LIN_STTBRK_Pos)
-#define   US_CR_LIN_STTBRK_0_Val          _U(0x0)   /**< \brief (US_CR_LIN) No effect */
-#define   US_CR_LIN_STTBRK_1_Val          _U(0x1)   /**< \brief (US_CR_LIN) Starts transmission of a break after the characters present in THR and the Transmit Shift Register have been transmitted. No effect if a break is already being transmitted */
+#define US_CR_LIN_STTBRK            (_U_(0x1) << US_CR_LIN_STTBRK_Pos)
+#define   US_CR_LIN_STTBRK_0_Val          _U_(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_STTBRK_1_Val          _U_(0x1)   /**< \brief (US_CR_LIN) Starts transmission of a break after the characters present in THR and the Transmit Shift Register have been transmitted. No effect if a break is already being transmitted */
 #define US_CR_LIN_STTBRK_0          (US_CR_LIN_STTBRK_0_Val        << US_CR_LIN_STTBRK_Pos)
 #define US_CR_LIN_STTBRK_1          (US_CR_LIN_STTBRK_1_Val        << US_CR_LIN_STTBRK_Pos)
 #define US_CR_LIN_STPBRK_Pos        10           /**< \brief (US_CR_LIN) Stop Break */
-#define US_CR_LIN_STPBRK            (_U(0x1) << US_CR_LIN_STPBRK_Pos)
-#define   US_CR_LIN_STPBRK_0_Val          _U(0x0)   /**< \brief (US_CR_LIN) No effect */
-#define   US_CR_LIN_STPBRK_1_Val          _U(0x1)   /**< \brief (US_CR_LIN) Stops transmission of the break after a minimum of one character length and transmits a high level during 12-bit periods.No effect if no break is being transmitted */
+#define US_CR_LIN_STPBRK            (_U_(0x1) << US_CR_LIN_STPBRK_Pos)
+#define   US_CR_LIN_STPBRK_0_Val          _U_(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_STPBRK_1_Val          _U_(0x1)   /**< \brief (US_CR_LIN) Stops transmission of the break after a minimum of one character length and transmits a high level during 12-bit periods.No effect if no break is being transmitted */
 #define US_CR_LIN_STPBRK_0          (US_CR_LIN_STPBRK_0_Val        << US_CR_LIN_STPBRK_Pos)
 #define US_CR_LIN_STPBRK_1          (US_CR_LIN_STPBRK_1_Val        << US_CR_LIN_STPBRK_Pos)
 #define US_CR_LIN_STTTO_Pos         11           /**< \brief (US_CR_LIN) Start Time-out */
-#define US_CR_LIN_STTTO             (_U(0x1) << US_CR_LIN_STTTO_Pos)
-#define   US_CR_LIN_STTTO_0_Val           _U(0x0)   /**< \brief (US_CR_LIN) No effect */
-#define   US_CR_LIN_STTTO_1_Val           _U(0x1)   /**< \brief (US_CR_LIN) Starts waiting for a character before clocking the time-out counter */
+#define US_CR_LIN_STTTO             (_U_(0x1) << US_CR_LIN_STTTO_Pos)
+#define   US_CR_LIN_STTTO_0_Val           _U_(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_STTTO_1_Val           _U_(0x1)   /**< \brief (US_CR_LIN) Starts waiting for a character before clocking the time-out counter */
 #define US_CR_LIN_STTTO_0           (US_CR_LIN_STTTO_0_Val         << US_CR_LIN_STTTO_Pos)
 #define US_CR_LIN_STTTO_1           (US_CR_LIN_STTTO_1_Val         << US_CR_LIN_STTTO_Pos)
 #define US_CR_LIN_SENDA_Pos         12           /**< \brief (US_CR_LIN) Send Address */
-#define US_CR_LIN_SENDA             (_U(0x1) << US_CR_LIN_SENDA_Pos)
-#define   US_CR_LIN_SENDA_0_Val           _U(0x0)   /**< \brief (US_CR_LIN) No effect */
-#define   US_CR_LIN_SENDA_1_Val           _U(0x1)   /**< \brief (US_CR_LIN) In Multi-drop Mode only, the next character written to the THR is sent with the address bit set */
+#define US_CR_LIN_SENDA             (_U_(0x1) << US_CR_LIN_SENDA_Pos)
+#define   US_CR_LIN_SENDA_0_Val           _U_(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_SENDA_1_Val           _U_(0x1)   /**< \brief (US_CR_LIN) In Multi-drop Mode only, the next character written to the THR is sent with the address bit set */
 #define US_CR_LIN_SENDA_0           (US_CR_LIN_SENDA_0_Val         << US_CR_LIN_SENDA_Pos)
 #define US_CR_LIN_SENDA_1           (US_CR_LIN_SENDA_1_Val         << US_CR_LIN_SENDA_Pos)
 #define US_CR_LIN_RSTIT_Pos         13           /**< \brief (US_CR_LIN) Reset Iterations */
-#define US_CR_LIN_RSTIT             (_U(0x1) << US_CR_LIN_RSTIT_Pos)
-#define   US_CR_LIN_RSTIT_0_Val           _U(0x0)   /**< \brief (US_CR_LIN) No effect */
-#define   US_CR_LIN_RSTIT_1_Val           _U(0x1)   /**< \brief (US_CR_LIN) Resets ITERATION in CSR. No effect if the ISO7816 is not enabled */
+#define US_CR_LIN_RSTIT             (_U_(0x1) << US_CR_LIN_RSTIT_Pos)
+#define   US_CR_LIN_RSTIT_0_Val           _U_(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_RSTIT_1_Val           _U_(0x1)   /**< \brief (US_CR_LIN) Resets ITERATION in CSR. No effect if the ISO7816 is not enabled */
 #define US_CR_LIN_RSTIT_0           (US_CR_LIN_RSTIT_0_Val         << US_CR_LIN_RSTIT_Pos)
 #define US_CR_LIN_RSTIT_1           (US_CR_LIN_RSTIT_1_Val         << US_CR_LIN_RSTIT_Pos)
 #define US_CR_LIN_RSTNACK_Pos       14           /**< \brief (US_CR_LIN) Reset Non Acknowledge */
-#define US_CR_LIN_RSTNACK           (_U(0x1) << US_CR_LIN_RSTNACK_Pos)
-#define   US_CR_LIN_RSTNACK_0_Val         _U(0x0)   /**< \brief (US_CR_LIN) No effect */
-#define   US_CR_LIN_RSTNACK_1_Val         _U(0x1)   /**< \brief (US_CR_LIN) Resets NACK in CSR */
+#define US_CR_LIN_RSTNACK           (_U_(0x1) << US_CR_LIN_RSTNACK_Pos)
+#define   US_CR_LIN_RSTNACK_0_Val         _U_(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_RSTNACK_1_Val         _U_(0x1)   /**< \brief (US_CR_LIN) Resets NACK in CSR */
 #define US_CR_LIN_RSTNACK_0         (US_CR_LIN_RSTNACK_0_Val       << US_CR_LIN_RSTNACK_Pos)
 #define US_CR_LIN_RSTNACK_1         (US_CR_LIN_RSTNACK_1_Val       << US_CR_LIN_RSTNACK_Pos)
 #define US_CR_LIN_RETTO_Pos         15           /**< \brief (US_CR_LIN) Rearm Time-out */
-#define US_CR_LIN_RETTO             (_U(0x1) << US_CR_LIN_RETTO_Pos)
-#define   US_CR_LIN_RETTO_0_Val           _U(0x0)   /**< \brief (US_CR_LIN) No effect */
-#define   US_CR_LIN_RETTO_1_Val           _U(0x1)   /**< \brief (US_CR_LIN) Restart Time-out */
+#define US_CR_LIN_RETTO             (_U_(0x1) << US_CR_LIN_RETTO_Pos)
+#define   US_CR_LIN_RETTO_0_Val           _U_(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_RETTO_1_Val           _U_(0x1)   /**< \brief (US_CR_LIN) Restart Time-out */
 #define US_CR_LIN_RETTO_0           (US_CR_LIN_RETTO_0_Val         << US_CR_LIN_RETTO_Pos)
 #define US_CR_LIN_RETTO_1           (US_CR_LIN_RETTO_1_Val         << US_CR_LIN_RETTO_Pos)
 #define US_CR_LIN_DTREN_Pos         16           /**< \brief (US_CR_LIN) Data Terminal Ready Enable */
-#define US_CR_LIN_DTREN             (_U(0x1) << US_CR_LIN_DTREN_Pos)
-#define   US_CR_LIN_DTREN_0_Val           _U(0x0)   /**< \brief (US_CR_LIN) No effect */
-#define   US_CR_LIN_DTREN_1_Val           _U(0x1)   /**< \brief (US_CR_LIN) Drives the pin DTR at 0 */
+#define US_CR_LIN_DTREN             (_U_(0x1) << US_CR_LIN_DTREN_Pos)
+#define   US_CR_LIN_DTREN_0_Val           _U_(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_DTREN_1_Val           _U_(0x1)   /**< \brief (US_CR_LIN) Drives the pin DTR at 0 */
 #define US_CR_LIN_DTREN_0           (US_CR_LIN_DTREN_0_Val         << US_CR_LIN_DTREN_Pos)
 #define US_CR_LIN_DTREN_1           (US_CR_LIN_DTREN_1_Val         << US_CR_LIN_DTREN_Pos)
 #define US_CR_LIN_DTRDIS_Pos        17           /**< \brief (US_CR_LIN) Data Terminal Ready Disable */
-#define US_CR_LIN_DTRDIS            (_U(0x1) << US_CR_LIN_DTRDIS_Pos)
-#define   US_CR_LIN_DTRDIS_0_Val          _U(0x0)   /**< \brief (US_CR_LIN) No effect */
-#define   US_CR_LIN_DTRDIS_1_Val          _U(0x1)   /**< \brief (US_CR_LIN) Drives the pin DTR to 1 */
+#define US_CR_LIN_DTRDIS            (_U_(0x1) << US_CR_LIN_DTRDIS_Pos)
+#define   US_CR_LIN_DTRDIS_0_Val          _U_(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_DTRDIS_1_Val          _U_(0x1)   /**< \brief (US_CR_LIN) Drives the pin DTR to 1 */
 #define US_CR_LIN_DTRDIS_0          (US_CR_LIN_DTRDIS_0_Val        << US_CR_LIN_DTRDIS_Pos)
 #define US_CR_LIN_DTRDIS_1          (US_CR_LIN_DTRDIS_1_Val        << US_CR_LIN_DTRDIS_Pos)
 #define US_CR_LIN_RTSEN_Pos         18           /**< \brief (US_CR_LIN) Request to Send Enable */
-#define US_CR_LIN_RTSEN             (_U(0x1) << US_CR_LIN_RTSEN_Pos)
-#define   US_CR_LIN_RTSEN_0_Val           _U(0x0)   /**< \brief (US_CR_LIN) No effect */
-#define   US_CR_LIN_RTSEN_1_Val           _U(0x1)   /**< \brief (US_CR_LIN) Drives the pin RTS to 0 */
+#define US_CR_LIN_RTSEN             (_U_(0x1) << US_CR_LIN_RTSEN_Pos)
+#define   US_CR_LIN_RTSEN_0_Val           _U_(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_RTSEN_1_Val           _U_(0x1)   /**< \brief (US_CR_LIN) Drives the pin RTS to 0 */
 #define US_CR_LIN_RTSEN_0           (US_CR_LIN_RTSEN_0_Val         << US_CR_LIN_RTSEN_Pos)
 #define US_CR_LIN_RTSEN_1           (US_CR_LIN_RTSEN_1_Val         << US_CR_LIN_RTSEN_Pos)
 #define US_CR_LIN_RTSDIS_Pos        19           /**< \brief (US_CR_LIN) Request to Send Disable */
-#define US_CR_LIN_RTSDIS            (_U(0x1) << US_CR_LIN_RTSDIS_Pos)
-#define   US_CR_LIN_RTSDIS_0_Val          _U(0x0)   /**< \brief (US_CR_LIN) No effect */
-#define   US_CR_LIN_RTSDIS_1_Val          _U(0x1)   /**< \brief (US_CR_LIN) Drives the pin RTS to 1 */
+#define US_CR_LIN_RTSDIS            (_U_(0x1) << US_CR_LIN_RTSDIS_Pos)
+#define   US_CR_LIN_RTSDIS_0_Val          _U_(0x0)   /**< \brief (US_CR_LIN) No effect */
+#define   US_CR_LIN_RTSDIS_1_Val          _U_(0x1)   /**< \brief (US_CR_LIN) Drives the pin RTS to 1 */
 #define US_CR_LIN_RTSDIS_0          (US_CR_LIN_RTSDIS_0_Val        << US_CR_LIN_RTSDIS_Pos)
 #define US_CR_LIN_RTSDIS_1          (US_CR_LIN_RTSDIS_1_Val        << US_CR_LIN_RTSDIS_Pos)
 #define US_CR_LIN_LINABT_Pos        20           /**< \brief (US_CR_LIN) Abort the current LIN transmission */
-#define US_CR_LIN_LINABT            (_U(0x1) << US_CR_LIN_LINABT_Pos)
+#define US_CR_LIN_LINABT            (_U_(0x1) << US_CR_LIN_LINABT_Pos)
 #define US_CR_LIN_LINWKUP_Pos       21           /**< \brief (US_CR_LIN) Sends a wakeup signal on the LIN bus */
-#define US_CR_LIN_LINWKUP           (_U(0x1) << US_CR_LIN_LINWKUP_Pos)
-#define US_CR_LIN_MASK              _U(0x003FFFFC) /**< \brief (US_CR_LIN) MASK Register */
+#define US_CR_LIN_LINWKUP           (_U_(0x1) << US_CR_LIN_LINWKUP_Pos)
+#define US_CR_LIN_MASK              _U_(0x003FFFFC) /**< \brief (US_CR_LIN) MASK Register */
 
 // SPI_MASTER mode
 #define US_CR_SPI_MASTER_RSTRX_Pos  2            /**< \brief (US_CR_SPI_MASTER) Reset Receiver */
-#define US_CR_SPI_MASTER_RSTRX      (_U(0x1) << US_CR_SPI_MASTER_RSTRX_Pos)
-#define   US_CR_SPI_MASTER_RSTRX_0_Val    _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
-#define   US_CR_SPI_MASTER_RSTRX_1_Val    _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Resets the receiver */
+#define US_CR_SPI_MASTER_RSTRX      (_U_(0x1) << US_CR_SPI_MASTER_RSTRX_Pos)
+#define   US_CR_SPI_MASTER_RSTRX_0_Val    _U_(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_RSTRX_1_Val    _U_(0x1)   /**< \brief (US_CR_SPI_MASTER) Resets the receiver */
 #define US_CR_SPI_MASTER_RSTRX_0    (US_CR_SPI_MASTER_RSTRX_0_Val  << US_CR_SPI_MASTER_RSTRX_Pos)
 #define US_CR_SPI_MASTER_RSTRX_1    (US_CR_SPI_MASTER_RSTRX_1_Val  << US_CR_SPI_MASTER_RSTRX_Pos)
 #define US_CR_SPI_MASTER_RSTTX_Pos  3            /**< \brief (US_CR_SPI_MASTER) Reset Transmitter */
-#define US_CR_SPI_MASTER_RSTTX      (_U(0x1) << US_CR_SPI_MASTER_RSTTX_Pos)
-#define   US_CR_SPI_MASTER_RSTTX_0_Val    _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
-#define   US_CR_SPI_MASTER_RSTTX_1_Val    _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Resets the transmitter */
+#define US_CR_SPI_MASTER_RSTTX      (_U_(0x1) << US_CR_SPI_MASTER_RSTTX_Pos)
+#define   US_CR_SPI_MASTER_RSTTX_0_Val    _U_(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_RSTTX_1_Val    _U_(0x1)   /**< \brief (US_CR_SPI_MASTER) Resets the transmitter */
 #define US_CR_SPI_MASTER_RSTTX_0    (US_CR_SPI_MASTER_RSTTX_0_Val  << US_CR_SPI_MASTER_RSTTX_Pos)
 #define US_CR_SPI_MASTER_RSTTX_1    (US_CR_SPI_MASTER_RSTTX_1_Val  << US_CR_SPI_MASTER_RSTTX_Pos)
 #define US_CR_SPI_MASTER_RXEN_Pos   4            /**< \brief (US_CR_SPI_MASTER) Receiver Enable */
-#define US_CR_SPI_MASTER_RXEN       (_U(0x1) << US_CR_SPI_MASTER_RXEN_Pos)
-#define   US_CR_SPI_MASTER_RXEN_0_Val     _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
-#define   US_CR_SPI_MASTER_RXEN_1_Val     _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Enables the receiver, if RXDIS is 0 */
+#define US_CR_SPI_MASTER_RXEN       (_U_(0x1) << US_CR_SPI_MASTER_RXEN_Pos)
+#define   US_CR_SPI_MASTER_RXEN_0_Val     _U_(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_RXEN_1_Val     _U_(0x1)   /**< \brief (US_CR_SPI_MASTER) Enables the receiver, if RXDIS is 0 */
 #define US_CR_SPI_MASTER_RXEN_0     (US_CR_SPI_MASTER_RXEN_0_Val   << US_CR_SPI_MASTER_RXEN_Pos)
 #define US_CR_SPI_MASTER_RXEN_1     (US_CR_SPI_MASTER_RXEN_1_Val   << US_CR_SPI_MASTER_RXEN_Pos)
 #define US_CR_SPI_MASTER_RXDIS_Pos  5            /**< \brief (US_CR_SPI_MASTER) Receiver Disable */
-#define US_CR_SPI_MASTER_RXDIS      (_U(0x1) << US_CR_SPI_MASTER_RXDIS_Pos)
-#define   US_CR_SPI_MASTER_RXDIS_0_Val    _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
-#define   US_CR_SPI_MASTER_RXDIS_1_Val    _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Disables the receiver */
+#define US_CR_SPI_MASTER_RXDIS      (_U_(0x1) << US_CR_SPI_MASTER_RXDIS_Pos)
+#define   US_CR_SPI_MASTER_RXDIS_0_Val    _U_(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_RXDIS_1_Val    _U_(0x1)   /**< \brief (US_CR_SPI_MASTER) Disables the receiver */
 #define US_CR_SPI_MASTER_RXDIS_0    (US_CR_SPI_MASTER_RXDIS_0_Val  << US_CR_SPI_MASTER_RXDIS_Pos)
 #define US_CR_SPI_MASTER_RXDIS_1    (US_CR_SPI_MASTER_RXDIS_1_Val  << US_CR_SPI_MASTER_RXDIS_Pos)
 #define US_CR_SPI_MASTER_TXEN_Pos   6            /**< \brief (US_CR_SPI_MASTER) Transmitter Enable */
-#define US_CR_SPI_MASTER_TXEN       (_U(0x1) << US_CR_SPI_MASTER_TXEN_Pos)
-#define   US_CR_SPI_MASTER_TXEN_0_Val     _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
-#define   US_CR_SPI_MASTER_TXEN_1_Val     _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Enables the transmitter if TXDIS is 0 */
+#define US_CR_SPI_MASTER_TXEN       (_U_(0x1) << US_CR_SPI_MASTER_TXEN_Pos)
+#define   US_CR_SPI_MASTER_TXEN_0_Val     _U_(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_TXEN_1_Val     _U_(0x1)   /**< \brief (US_CR_SPI_MASTER) Enables the transmitter if TXDIS is 0 */
 #define US_CR_SPI_MASTER_TXEN_0     (US_CR_SPI_MASTER_TXEN_0_Val   << US_CR_SPI_MASTER_TXEN_Pos)
 #define US_CR_SPI_MASTER_TXEN_1     (US_CR_SPI_MASTER_TXEN_1_Val   << US_CR_SPI_MASTER_TXEN_Pos)
 #define US_CR_SPI_MASTER_TXDIS_Pos  7            /**< \brief (US_CR_SPI_MASTER) Transmitter Disable */
-#define US_CR_SPI_MASTER_TXDIS      (_U(0x1) << US_CR_SPI_MASTER_TXDIS_Pos)
-#define   US_CR_SPI_MASTER_TXDIS_0_Val    _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
-#define   US_CR_SPI_MASTER_TXDIS_1_Val    _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Disables the transmitter */
+#define US_CR_SPI_MASTER_TXDIS      (_U_(0x1) << US_CR_SPI_MASTER_TXDIS_Pos)
+#define   US_CR_SPI_MASTER_TXDIS_0_Val    _U_(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_TXDIS_1_Val    _U_(0x1)   /**< \brief (US_CR_SPI_MASTER) Disables the transmitter */
 #define US_CR_SPI_MASTER_TXDIS_0    (US_CR_SPI_MASTER_TXDIS_0_Val  << US_CR_SPI_MASTER_TXDIS_Pos)
 #define US_CR_SPI_MASTER_TXDIS_1    (US_CR_SPI_MASTER_TXDIS_1_Val  << US_CR_SPI_MASTER_TXDIS_Pos)
 #define US_CR_SPI_MASTER_RSTSTA_Pos 8            /**< \brief (US_CR_SPI_MASTER) Reset Status Bits */
-#define US_CR_SPI_MASTER_RSTSTA     (_U(0x1) << US_CR_SPI_MASTER_RSTSTA_Pos)
-#define   US_CR_SPI_MASTER_RSTSTA_0_Val   _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
-#define   US_CR_SPI_MASTER_RSTSTA_1_Val   _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Resets the status bits PARE, FRAME, OVRE and RXBRK in the CSR */
+#define US_CR_SPI_MASTER_RSTSTA     (_U_(0x1) << US_CR_SPI_MASTER_RSTSTA_Pos)
+#define   US_CR_SPI_MASTER_RSTSTA_0_Val   _U_(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_RSTSTA_1_Val   _U_(0x1)   /**< \brief (US_CR_SPI_MASTER) Resets the status bits PARE, FRAME, OVRE and RXBRK in the CSR */
 #define US_CR_SPI_MASTER_RSTSTA_0   (US_CR_SPI_MASTER_RSTSTA_0_Val << US_CR_SPI_MASTER_RSTSTA_Pos)
 #define US_CR_SPI_MASTER_RSTSTA_1   (US_CR_SPI_MASTER_RSTSTA_1_Val << US_CR_SPI_MASTER_RSTSTA_Pos)
 #define US_CR_SPI_MASTER_STTBRK_Pos 9            /**< \brief (US_CR_SPI_MASTER) Start Break */
-#define US_CR_SPI_MASTER_STTBRK     (_U(0x1) << US_CR_SPI_MASTER_STTBRK_Pos)
-#define   US_CR_SPI_MASTER_STTBRK_0_Val   _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
-#define   US_CR_SPI_MASTER_STTBRK_1_Val   _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Starts transmission of a break after the characters present in THR and the Transmit Shift Register have been transmitted. No effect if a break is already being transmitted */
+#define US_CR_SPI_MASTER_STTBRK     (_U_(0x1) << US_CR_SPI_MASTER_STTBRK_Pos)
+#define   US_CR_SPI_MASTER_STTBRK_0_Val   _U_(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_STTBRK_1_Val   _U_(0x1)   /**< \brief (US_CR_SPI_MASTER) Starts transmission of a break after the characters present in THR and the Transmit Shift Register have been transmitted. No effect if a break is already being transmitted */
 #define US_CR_SPI_MASTER_STTBRK_0   (US_CR_SPI_MASTER_STTBRK_0_Val << US_CR_SPI_MASTER_STTBRK_Pos)
 #define US_CR_SPI_MASTER_STTBRK_1   (US_CR_SPI_MASTER_STTBRK_1_Val << US_CR_SPI_MASTER_STTBRK_Pos)
 #define US_CR_SPI_MASTER_STPBRK_Pos 10           /**< \brief (US_CR_SPI_MASTER) Stop Break */
-#define US_CR_SPI_MASTER_STPBRK     (_U(0x1) << US_CR_SPI_MASTER_STPBRK_Pos)
-#define   US_CR_SPI_MASTER_STPBRK_0_Val   _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
-#define   US_CR_SPI_MASTER_STPBRK_1_Val   _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Stops transmission of the break after a minimum of one character length and transmits a high level during 12-bit periods.No effect if no break is being transmitted */
+#define US_CR_SPI_MASTER_STPBRK     (_U_(0x1) << US_CR_SPI_MASTER_STPBRK_Pos)
+#define   US_CR_SPI_MASTER_STPBRK_0_Val   _U_(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_STPBRK_1_Val   _U_(0x1)   /**< \brief (US_CR_SPI_MASTER) Stops transmission of the break after a minimum of one character length and transmits a high level during 12-bit periods.No effect if no break is being transmitted */
 #define US_CR_SPI_MASTER_STPBRK_0   (US_CR_SPI_MASTER_STPBRK_0_Val << US_CR_SPI_MASTER_STPBRK_Pos)
 #define US_CR_SPI_MASTER_STPBRK_1   (US_CR_SPI_MASTER_STPBRK_1_Val << US_CR_SPI_MASTER_STPBRK_Pos)
 #define US_CR_SPI_MASTER_STTTO_Pos  11           /**< \brief (US_CR_SPI_MASTER) Start Time-out */
-#define US_CR_SPI_MASTER_STTTO      (_U(0x1) << US_CR_SPI_MASTER_STTTO_Pos)
-#define   US_CR_SPI_MASTER_STTTO_0_Val    _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
-#define   US_CR_SPI_MASTER_STTTO_1_Val    _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Starts waiting for a character before clocking the time-out counter */
+#define US_CR_SPI_MASTER_STTTO      (_U_(0x1) << US_CR_SPI_MASTER_STTTO_Pos)
+#define   US_CR_SPI_MASTER_STTTO_0_Val    _U_(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_STTTO_1_Val    _U_(0x1)   /**< \brief (US_CR_SPI_MASTER) Starts waiting for a character before clocking the time-out counter */
 #define US_CR_SPI_MASTER_STTTO_0    (US_CR_SPI_MASTER_STTTO_0_Val  << US_CR_SPI_MASTER_STTTO_Pos)
 #define US_CR_SPI_MASTER_STTTO_1    (US_CR_SPI_MASTER_STTTO_1_Val  << US_CR_SPI_MASTER_STTTO_Pos)
 #define US_CR_SPI_MASTER_SENDA_Pos  12           /**< \brief (US_CR_SPI_MASTER) Send Address */
-#define US_CR_SPI_MASTER_SENDA      (_U(0x1) << US_CR_SPI_MASTER_SENDA_Pos)
-#define   US_CR_SPI_MASTER_SENDA_0_Val    _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
-#define   US_CR_SPI_MASTER_SENDA_1_Val    _U(0x1)   /**< \brief (US_CR_SPI_MASTER) In Multi-drop Mode only, the next character written to the THR is sent with the address bit set */
+#define US_CR_SPI_MASTER_SENDA      (_U_(0x1) << US_CR_SPI_MASTER_SENDA_Pos)
+#define   US_CR_SPI_MASTER_SENDA_0_Val    _U_(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_SENDA_1_Val    _U_(0x1)   /**< \brief (US_CR_SPI_MASTER) In Multi-drop Mode only, the next character written to the THR is sent with the address bit set */
 #define US_CR_SPI_MASTER_SENDA_0    (US_CR_SPI_MASTER_SENDA_0_Val  << US_CR_SPI_MASTER_SENDA_Pos)
 #define US_CR_SPI_MASTER_SENDA_1    (US_CR_SPI_MASTER_SENDA_1_Val  << US_CR_SPI_MASTER_SENDA_Pos)
 #define US_CR_SPI_MASTER_RSTIT_Pos  13           /**< \brief (US_CR_SPI_MASTER) Reset Iterations */
-#define US_CR_SPI_MASTER_RSTIT      (_U(0x1) << US_CR_SPI_MASTER_RSTIT_Pos)
-#define   US_CR_SPI_MASTER_RSTIT_0_Val    _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
-#define   US_CR_SPI_MASTER_RSTIT_1_Val    _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Resets ITERATION in CSR. No effect if the ISO7816 is not enabled */
+#define US_CR_SPI_MASTER_RSTIT      (_U_(0x1) << US_CR_SPI_MASTER_RSTIT_Pos)
+#define   US_CR_SPI_MASTER_RSTIT_0_Val    _U_(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_RSTIT_1_Val    _U_(0x1)   /**< \brief (US_CR_SPI_MASTER) Resets ITERATION in CSR. No effect if the ISO7816 is not enabled */
 #define US_CR_SPI_MASTER_RSTIT_0    (US_CR_SPI_MASTER_RSTIT_0_Val  << US_CR_SPI_MASTER_RSTIT_Pos)
 #define US_CR_SPI_MASTER_RSTIT_1    (US_CR_SPI_MASTER_RSTIT_1_Val  << US_CR_SPI_MASTER_RSTIT_Pos)
 #define US_CR_SPI_MASTER_RSTNACK_Pos 14           /**< \brief (US_CR_SPI_MASTER) Reset Non Acknowledge */
-#define US_CR_SPI_MASTER_RSTNACK    (_U(0x1) << US_CR_SPI_MASTER_RSTNACK_Pos)
-#define   US_CR_SPI_MASTER_RSTNACK_0_Val  _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
-#define   US_CR_SPI_MASTER_RSTNACK_1_Val  _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Resets NACK in CSR */
+#define US_CR_SPI_MASTER_RSTNACK    (_U_(0x1) << US_CR_SPI_MASTER_RSTNACK_Pos)
+#define   US_CR_SPI_MASTER_RSTNACK_0_Val  _U_(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_RSTNACK_1_Val  _U_(0x1)   /**< \brief (US_CR_SPI_MASTER) Resets NACK in CSR */
 #define US_CR_SPI_MASTER_RSTNACK_0  (US_CR_SPI_MASTER_RSTNACK_0_Val << US_CR_SPI_MASTER_RSTNACK_Pos)
 #define US_CR_SPI_MASTER_RSTNACK_1  (US_CR_SPI_MASTER_RSTNACK_1_Val << US_CR_SPI_MASTER_RSTNACK_Pos)
 #define US_CR_SPI_MASTER_RETTO_Pos  15           /**< \brief (US_CR_SPI_MASTER) Rearm Time-out */
-#define US_CR_SPI_MASTER_RETTO      (_U(0x1) << US_CR_SPI_MASTER_RETTO_Pos)
-#define   US_CR_SPI_MASTER_RETTO_0_Val    _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
-#define   US_CR_SPI_MASTER_RETTO_1_Val    _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Restart Time-out */
+#define US_CR_SPI_MASTER_RETTO      (_U_(0x1) << US_CR_SPI_MASTER_RETTO_Pos)
+#define   US_CR_SPI_MASTER_RETTO_0_Val    _U_(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_RETTO_1_Val    _U_(0x1)   /**< \brief (US_CR_SPI_MASTER) Restart Time-out */
 #define US_CR_SPI_MASTER_RETTO_0    (US_CR_SPI_MASTER_RETTO_0_Val  << US_CR_SPI_MASTER_RETTO_Pos)
 #define US_CR_SPI_MASTER_RETTO_1    (US_CR_SPI_MASTER_RETTO_1_Val  << US_CR_SPI_MASTER_RETTO_Pos)
 #define US_CR_SPI_MASTER_DTREN_Pos  16           /**< \brief (US_CR_SPI_MASTER) Data Terminal Ready Enable */
-#define US_CR_SPI_MASTER_DTREN      (_U(0x1) << US_CR_SPI_MASTER_DTREN_Pos)
-#define   US_CR_SPI_MASTER_DTREN_0_Val    _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
-#define   US_CR_SPI_MASTER_DTREN_1_Val    _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Drives the pin DTR at 0 */
+#define US_CR_SPI_MASTER_DTREN      (_U_(0x1) << US_CR_SPI_MASTER_DTREN_Pos)
+#define   US_CR_SPI_MASTER_DTREN_0_Val    _U_(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_DTREN_1_Val    _U_(0x1)   /**< \brief (US_CR_SPI_MASTER) Drives the pin DTR at 0 */
 #define US_CR_SPI_MASTER_DTREN_0    (US_CR_SPI_MASTER_DTREN_0_Val  << US_CR_SPI_MASTER_DTREN_Pos)
 #define US_CR_SPI_MASTER_DTREN_1    (US_CR_SPI_MASTER_DTREN_1_Val  << US_CR_SPI_MASTER_DTREN_Pos)
 #define US_CR_SPI_MASTER_DTRDIS_Pos 17           /**< \brief (US_CR_SPI_MASTER) Data Terminal Ready Disable */
-#define US_CR_SPI_MASTER_DTRDIS     (_U(0x1) << US_CR_SPI_MASTER_DTRDIS_Pos)
-#define   US_CR_SPI_MASTER_DTRDIS_0_Val   _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
-#define   US_CR_SPI_MASTER_DTRDIS_1_Val   _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Drives the pin DTR to 1 */
+#define US_CR_SPI_MASTER_DTRDIS     (_U_(0x1) << US_CR_SPI_MASTER_DTRDIS_Pos)
+#define   US_CR_SPI_MASTER_DTRDIS_0_Val   _U_(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_DTRDIS_1_Val   _U_(0x1)   /**< \brief (US_CR_SPI_MASTER) Drives the pin DTR to 1 */
 #define US_CR_SPI_MASTER_DTRDIS_0   (US_CR_SPI_MASTER_DTRDIS_0_Val << US_CR_SPI_MASTER_DTRDIS_Pos)
 #define US_CR_SPI_MASTER_DTRDIS_1   (US_CR_SPI_MASTER_DTRDIS_1_Val << US_CR_SPI_MASTER_DTRDIS_Pos)
 #define US_CR_SPI_MASTER_FCS_Pos    18           /**< \brief (US_CR_SPI_MASTER) Force SPI Chip Select */
-#define US_CR_SPI_MASTER_FCS        (_U(0x1) << US_CR_SPI_MASTER_FCS_Pos)
-#define   US_CR_SPI_MASTER_FCS_0_Val      _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
-#define   US_CR_SPI_MASTER_FCS_1_Val      _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Forces the Slave Select Line NSS (RTS pin) to 0, even if USART is no transmitting, in order to address SPI slave devices supporting the CSAAT Mode (Chip Select Active After Transfer) */
+#define US_CR_SPI_MASTER_FCS        (_U_(0x1) << US_CR_SPI_MASTER_FCS_Pos)
+#define   US_CR_SPI_MASTER_FCS_0_Val      _U_(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_FCS_1_Val      _U_(0x1)   /**< \brief (US_CR_SPI_MASTER) Forces the Slave Select Line NSS (RTS pin) to 0, even if USART is no transmitting, in order to address SPI slave devices supporting the CSAAT Mode (Chip Select Active After Transfer) */
 #define US_CR_SPI_MASTER_FCS_0      (US_CR_SPI_MASTER_FCS_0_Val    << US_CR_SPI_MASTER_FCS_Pos)
 #define US_CR_SPI_MASTER_FCS_1      (US_CR_SPI_MASTER_FCS_1_Val    << US_CR_SPI_MASTER_FCS_Pos)
 #define US_CR_SPI_MASTER_RCS_Pos    19           /**< \brief (US_CR_SPI_MASTER) Release SPI Chip Select */
-#define US_CR_SPI_MASTER_RCS        (_U(0x1) << US_CR_SPI_MASTER_RCS_Pos)
-#define   US_CR_SPI_MASTER_RCS_0_Val      _U(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
-#define   US_CR_SPI_MASTER_RCS_1_Val      _U(0x1)   /**< \brief (US_CR_SPI_MASTER) Releases the Slave Select Line NSS (RTS pin) */
+#define US_CR_SPI_MASTER_RCS        (_U_(0x1) << US_CR_SPI_MASTER_RCS_Pos)
+#define   US_CR_SPI_MASTER_RCS_0_Val      _U_(0x0)   /**< \brief (US_CR_SPI_MASTER) No effect */
+#define   US_CR_SPI_MASTER_RCS_1_Val      _U_(0x1)   /**< \brief (US_CR_SPI_MASTER) Releases the Slave Select Line NSS (RTS pin) */
 #define US_CR_SPI_MASTER_RCS_0      (US_CR_SPI_MASTER_RCS_0_Val    << US_CR_SPI_MASTER_RCS_Pos)
 #define US_CR_SPI_MASTER_RCS_1      (US_CR_SPI_MASTER_RCS_1_Val    << US_CR_SPI_MASTER_RCS_Pos)
-#define US_CR_SPI_MASTER_MASK       _U(0x000FFFFC) /**< \brief (US_CR_SPI_MASTER) MASK Register */
+#define US_CR_SPI_MASTER_MASK       _U_(0x000FFFFC) /**< \brief (US_CR_SPI_MASTER) MASK Register */
 
 // USART mode
 #define US_CR_USART_RSTRX_Pos       2            /**< \brief (US_CR_USART) Reset Receiver */
-#define US_CR_USART_RSTRX           (_U(0x1) << US_CR_USART_RSTRX_Pos)
-#define   US_CR_USART_RSTRX_0_Val         _U(0x0)   /**< \brief (US_CR_USART) No effect */
-#define   US_CR_USART_RSTRX_1_Val         _U(0x1)   /**< \brief (US_CR_USART) Resets the receiver */
+#define US_CR_USART_RSTRX           (_U_(0x1) << US_CR_USART_RSTRX_Pos)
+#define   US_CR_USART_RSTRX_0_Val         _U_(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_RSTRX_1_Val         _U_(0x1)   /**< \brief (US_CR_USART) Resets the receiver */
 #define US_CR_USART_RSTRX_0         (US_CR_USART_RSTRX_0_Val       << US_CR_USART_RSTRX_Pos)
 #define US_CR_USART_RSTRX_1         (US_CR_USART_RSTRX_1_Val       << US_CR_USART_RSTRX_Pos)
 #define US_CR_USART_RSTTX_Pos       3            /**< \brief (US_CR_USART) Reset Transmitter */
-#define US_CR_USART_RSTTX           (_U(0x1) << US_CR_USART_RSTTX_Pos)
-#define   US_CR_USART_RSTTX_0_Val         _U(0x0)   /**< \brief (US_CR_USART) No effect */
-#define   US_CR_USART_RSTTX_1_Val         _U(0x1)   /**< \brief (US_CR_USART) Resets the transmitter */
+#define US_CR_USART_RSTTX           (_U_(0x1) << US_CR_USART_RSTTX_Pos)
+#define   US_CR_USART_RSTTX_0_Val         _U_(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_RSTTX_1_Val         _U_(0x1)   /**< \brief (US_CR_USART) Resets the transmitter */
 #define US_CR_USART_RSTTX_0         (US_CR_USART_RSTTX_0_Val       << US_CR_USART_RSTTX_Pos)
 #define US_CR_USART_RSTTX_1         (US_CR_USART_RSTTX_1_Val       << US_CR_USART_RSTTX_Pos)
 #define US_CR_USART_RXEN_Pos        4            /**< \brief (US_CR_USART) Receiver Enable */
-#define US_CR_USART_RXEN            (_U(0x1) << US_CR_USART_RXEN_Pos)
-#define   US_CR_USART_RXEN_0_Val          _U(0x0)   /**< \brief (US_CR_USART) No effect */
-#define   US_CR_USART_RXEN_1_Val          _U(0x1)   /**< \brief (US_CR_USART) Enables the receiver, if RXDIS is 0 */
+#define US_CR_USART_RXEN            (_U_(0x1) << US_CR_USART_RXEN_Pos)
+#define   US_CR_USART_RXEN_0_Val          _U_(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_RXEN_1_Val          _U_(0x1)   /**< \brief (US_CR_USART) Enables the receiver, if RXDIS is 0 */
 #define US_CR_USART_RXEN_0          (US_CR_USART_RXEN_0_Val        << US_CR_USART_RXEN_Pos)
 #define US_CR_USART_RXEN_1          (US_CR_USART_RXEN_1_Val        << US_CR_USART_RXEN_Pos)
 #define US_CR_USART_RXDIS_Pos       5            /**< \brief (US_CR_USART) Receiver Disable */
-#define US_CR_USART_RXDIS           (_U(0x1) << US_CR_USART_RXDIS_Pos)
-#define   US_CR_USART_RXDIS_0_Val         _U(0x0)   /**< \brief (US_CR_USART) No effect */
-#define   US_CR_USART_RXDIS_1_Val         _U(0x1)   /**< \brief (US_CR_USART) Disables the receiver */
+#define US_CR_USART_RXDIS           (_U_(0x1) << US_CR_USART_RXDIS_Pos)
+#define   US_CR_USART_RXDIS_0_Val         _U_(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_RXDIS_1_Val         _U_(0x1)   /**< \brief (US_CR_USART) Disables the receiver */
 #define US_CR_USART_RXDIS_0         (US_CR_USART_RXDIS_0_Val       << US_CR_USART_RXDIS_Pos)
 #define US_CR_USART_RXDIS_1         (US_CR_USART_RXDIS_1_Val       << US_CR_USART_RXDIS_Pos)
 #define US_CR_USART_TXEN_Pos        6            /**< \brief (US_CR_USART) Transmitter Enable */
-#define US_CR_USART_TXEN            (_U(0x1) << US_CR_USART_TXEN_Pos)
-#define   US_CR_USART_TXEN_0_Val          _U(0x0)   /**< \brief (US_CR_USART) No effect */
-#define   US_CR_USART_TXEN_1_Val          _U(0x1)   /**< \brief (US_CR_USART) Enables the transmitter if TXDIS is 0 */
+#define US_CR_USART_TXEN            (_U_(0x1) << US_CR_USART_TXEN_Pos)
+#define   US_CR_USART_TXEN_0_Val          _U_(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_TXEN_1_Val          _U_(0x1)   /**< \brief (US_CR_USART) Enables the transmitter if TXDIS is 0 */
 #define US_CR_USART_TXEN_0          (US_CR_USART_TXEN_0_Val        << US_CR_USART_TXEN_Pos)
 #define US_CR_USART_TXEN_1          (US_CR_USART_TXEN_1_Val        << US_CR_USART_TXEN_Pos)
 #define US_CR_USART_TXDIS_Pos       7            /**< \brief (US_CR_USART) Transmitter Disable */
-#define US_CR_USART_TXDIS           (_U(0x1) << US_CR_USART_TXDIS_Pos)
-#define   US_CR_USART_TXDIS_0_Val         _U(0x0)   /**< \brief (US_CR_USART) No effect */
-#define   US_CR_USART_TXDIS_1_Val         _U(0x1)   /**< \brief (US_CR_USART) Disables the transmitter */
+#define US_CR_USART_TXDIS           (_U_(0x1) << US_CR_USART_TXDIS_Pos)
+#define   US_CR_USART_TXDIS_0_Val         _U_(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_TXDIS_1_Val         _U_(0x1)   /**< \brief (US_CR_USART) Disables the transmitter */
 #define US_CR_USART_TXDIS_0         (US_CR_USART_TXDIS_0_Val       << US_CR_USART_TXDIS_Pos)
 #define US_CR_USART_TXDIS_1         (US_CR_USART_TXDIS_1_Val       << US_CR_USART_TXDIS_Pos)
 #define US_CR_USART_RSTSTA_Pos      8            /**< \brief (US_CR_USART) Reset Status Bits */
-#define US_CR_USART_RSTSTA          (_U(0x1) << US_CR_USART_RSTSTA_Pos)
-#define   US_CR_USART_RSTSTA_0_Val        _U(0x0)   /**< \brief (US_CR_USART) No effect */
-#define   US_CR_USART_RSTSTA_1_Val        _U(0x1)   /**< \brief (US_CR_USART) Resets the status bits PARE, FRAME, OVRE and RXBRK in the CSR */
+#define US_CR_USART_RSTSTA          (_U_(0x1) << US_CR_USART_RSTSTA_Pos)
+#define   US_CR_USART_RSTSTA_0_Val        _U_(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_RSTSTA_1_Val        _U_(0x1)   /**< \brief (US_CR_USART) Resets the status bits PARE, FRAME, OVRE and RXBRK in the CSR */
 #define US_CR_USART_RSTSTA_0        (US_CR_USART_RSTSTA_0_Val      << US_CR_USART_RSTSTA_Pos)
 #define US_CR_USART_RSTSTA_1        (US_CR_USART_RSTSTA_1_Val      << US_CR_USART_RSTSTA_Pos)
 #define US_CR_USART_STTBRK_Pos      9            /**< \brief (US_CR_USART) Start Break */
-#define US_CR_USART_STTBRK          (_U(0x1) << US_CR_USART_STTBRK_Pos)
-#define   US_CR_USART_STTBRK_0_Val        _U(0x0)   /**< \brief (US_CR_USART) No effect */
-#define   US_CR_USART_STTBRK_1_Val        _U(0x1)   /**< \brief (US_CR_USART) Starts transmission of a break after the characters present in THR and the Transmit Shift Register have been transmitted. No effect if a break is already being transmitted */
+#define US_CR_USART_STTBRK          (_U_(0x1) << US_CR_USART_STTBRK_Pos)
+#define   US_CR_USART_STTBRK_0_Val        _U_(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_STTBRK_1_Val        _U_(0x1)   /**< \brief (US_CR_USART) Starts transmission of a break after the characters present in THR and the Transmit Shift Register have been transmitted. No effect if a break is already being transmitted */
 #define US_CR_USART_STTBRK_0        (US_CR_USART_STTBRK_0_Val      << US_CR_USART_STTBRK_Pos)
 #define US_CR_USART_STTBRK_1        (US_CR_USART_STTBRK_1_Val      << US_CR_USART_STTBRK_Pos)
 #define US_CR_USART_STPBRK_Pos      10           /**< \brief (US_CR_USART) Stop Break */
-#define US_CR_USART_STPBRK          (_U(0x1) << US_CR_USART_STPBRK_Pos)
-#define   US_CR_USART_STPBRK_0_Val        _U(0x0)   /**< \brief (US_CR_USART) No effect */
-#define   US_CR_USART_STPBRK_1_Val        _U(0x1)   /**< \brief (US_CR_USART) Stops transmission of the break after a minimum of one character length and transmits a high level during 12-bit periods.No effect if no break is being transmitted */
+#define US_CR_USART_STPBRK          (_U_(0x1) << US_CR_USART_STPBRK_Pos)
+#define   US_CR_USART_STPBRK_0_Val        _U_(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_STPBRK_1_Val        _U_(0x1)   /**< \brief (US_CR_USART) Stops transmission of the break after a minimum of one character length and transmits a high level during 12-bit periods.No effect if no break is being transmitted */
 #define US_CR_USART_STPBRK_0        (US_CR_USART_STPBRK_0_Val      << US_CR_USART_STPBRK_Pos)
 #define US_CR_USART_STPBRK_1        (US_CR_USART_STPBRK_1_Val      << US_CR_USART_STPBRK_Pos)
 #define US_CR_USART_STTTO_Pos       11           /**< \brief (US_CR_USART) Start Time-out */
-#define US_CR_USART_STTTO           (_U(0x1) << US_CR_USART_STTTO_Pos)
-#define   US_CR_USART_STTTO_0_Val         _U(0x0)   /**< \brief (US_CR_USART) No effect */
-#define   US_CR_USART_STTTO_1_Val         _U(0x1)   /**< \brief (US_CR_USART) Starts waiting for a character before clocking the time-out counter */
+#define US_CR_USART_STTTO           (_U_(0x1) << US_CR_USART_STTTO_Pos)
+#define   US_CR_USART_STTTO_0_Val         _U_(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_STTTO_1_Val         _U_(0x1)   /**< \brief (US_CR_USART) Starts waiting for a character before clocking the time-out counter */
 #define US_CR_USART_STTTO_0         (US_CR_USART_STTTO_0_Val       << US_CR_USART_STTTO_Pos)
 #define US_CR_USART_STTTO_1         (US_CR_USART_STTTO_1_Val       << US_CR_USART_STTTO_Pos)
 #define US_CR_USART_SENDA_Pos       12           /**< \brief (US_CR_USART) Send Address */
-#define US_CR_USART_SENDA           (_U(0x1) << US_CR_USART_SENDA_Pos)
-#define   US_CR_USART_SENDA_0_Val         _U(0x0)   /**< \brief (US_CR_USART) No effect */
-#define   US_CR_USART_SENDA_1_Val         _U(0x1)   /**< \brief (US_CR_USART) In Multi-drop Mode only, the next character written to the THR is sent with the address bit set */
+#define US_CR_USART_SENDA           (_U_(0x1) << US_CR_USART_SENDA_Pos)
+#define   US_CR_USART_SENDA_0_Val         _U_(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_SENDA_1_Val         _U_(0x1)   /**< \brief (US_CR_USART) In Multi-drop Mode only, the next character written to the THR is sent with the address bit set */
 #define US_CR_USART_SENDA_0         (US_CR_USART_SENDA_0_Val       << US_CR_USART_SENDA_Pos)
 #define US_CR_USART_SENDA_1         (US_CR_USART_SENDA_1_Val       << US_CR_USART_SENDA_Pos)
 #define US_CR_USART_RSTIT_Pos       13           /**< \brief (US_CR_USART) Reset Iterations */
-#define US_CR_USART_RSTIT           (_U(0x1) << US_CR_USART_RSTIT_Pos)
-#define   US_CR_USART_RSTIT_0_Val         _U(0x0)   /**< \brief (US_CR_USART) No effect */
-#define   US_CR_USART_RSTIT_1_Val         _U(0x1)   /**< \brief (US_CR_USART) Resets ITERATION in CSR. No effect if the ISO7816 is not enabled */
+#define US_CR_USART_RSTIT           (_U_(0x1) << US_CR_USART_RSTIT_Pos)
+#define   US_CR_USART_RSTIT_0_Val         _U_(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_RSTIT_1_Val         _U_(0x1)   /**< \brief (US_CR_USART) Resets ITERATION in CSR. No effect if the ISO7816 is not enabled */
 #define US_CR_USART_RSTIT_0         (US_CR_USART_RSTIT_0_Val       << US_CR_USART_RSTIT_Pos)
 #define US_CR_USART_RSTIT_1         (US_CR_USART_RSTIT_1_Val       << US_CR_USART_RSTIT_Pos)
 #define US_CR_USART_RSTNACK_Pos     14           /**< \brief (US_CR_USART) Reset Non Acknowledge */
-#define US_CR_USART_RSTNACK         (_U(0x1) << US_CR_USART_RSTNACK_Pos)
-#define   US_CR_USART_RSTNACK_0_Val       _U(0x0)   /**< \brief (US_CR_USART) No effect */
-#define   US_CR_USART_RSTNACK_1_Val       _U(0x1)   /**< \brief (US_CR_USART) Resets NACK in CSR */
+#define US_CR_USART_RSTNACK         (_U_(0x1) << US_CR_USART_RSTNACK_Pos)
+#define   US_CR_USART_RSTNACK_0_Val       _U_(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_RSTNACK_1_Val       _U_(0x1)   /**< \brief (US_CR_USART) Resets NACK in CSR */
 #define US_CR_USART_RSTNACK_0       (US_CR_USART_RSTNACK_0_Val     << US_CR_USART_RSTNACK_Pos)
 #define US_CR_USART_RSTNACK_1       (US_CR_USART_RSTNACK_1_Val     << US_CR_USART_RSTNACK_Pos)
 #define US_CR_USART_RETTO_Pos       15           /**< \brief (US_CR_USART) Rearm Time-out */
-#define US_CR_USART_RETTO           (_U(0x1) << US_CR_USART_RETTO_Pos)
-#define   US_CR_USART_RETTO_0_Val         _U(0x0)   /**< \brief (US_CR_USART) No effect */
-#define   US_CR_USART_RETTO_1_Val         _U(0x1)   /**< \brief (US_CR_USART) Restart Time-out */
+#define US_CR_USART_RETTO           (_U_(0x1) << US_CR_USART_RETTO_Pos)
+#define   US_CR_USART_RETTO_0_Val         _U_(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_RETTO_1_Val         _U_(0x1)   /**< \brief (US_CR_USART) Restart Time-out */
 #define US_CR_USART_RETTO_0         (US_CR_USART_RETTO_0_Val       << US_CR_USART_RETTO_Pos)
 #define US_CR_USART_RETTO_1         (US_CR_USART_RETTO_1_Val       << US_CR_USART_RETTO_Pos)
 #define US_CR_USART_DTREN_Pos       16           /**< \brief (US_CR_USART) Data Terminal Ready Enable */
-#define US_CR_USART_DTREN           (_U(0x1) << US_CR_USART_DTREN_Pos)
-#define   US_CR_USART_DTREN_0_Val         _U(0x0)   /**< \brief (US_CR_USART) No effect */
-#define   US_CR_USART_DTREN_1_Val         _U(0x1)   /**< \brief (US_CR_USART) Drives the pin DTR at 0 */
+#define US_CR_USART_DTREN           (_U_(0x1) << US_CR_USART_DTREN_Pos)
+#define   US_CR_USART_DTREN_0_Val         _U_(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_DTREN_1_Val         _U_(0x1)   /**< \brief (US_CR_USART) Drives the pin DTR at 0 */
 #define US_CR_USART_DTREN_0         (US_CR_USART_DTREN_0_Val       << US_CR_USART_DTREN_Pos)
 #define US_CR_USART_DTREN_1         (US_CR_USART_DTREN_1_Val       << US_CR_USART_DTREN_Pos)
 #define US_CR_USART_DTRDIS_Pos      17           /**< \brief (US_CR_USART) Data Terminal Ready Disable */
-#define US_CR_USART_DTRDIS          (_U(0x1) << US_CR_USART_DTRDIS_Pos)
-#define   US_CR_USART_DTRDIS_0_Val        _U(0x0)   /**< \brief (US_CR_USART) No effect */
-#define   US_CR_USART_DTRDIS_1_Val        _U(0x1)   /**< \brief (US_CR_USART) Drives the pin DTR to 1 */
+#define US_CR_USART_DTRDIS          (_U_(0x1) << US_CR_USART_DTRDIS_Pos)
+#define   US_CR_USART_DTRDIS_0_Val        _U_(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_DTRDIS_1_Val        _U_(0x1)   /**< \brief (US_CR_USART) Drives the pin DTR to 1 */
 #define US_CR_USART_DTRDIS_0        (US_CR_USART_DTRDIS_0_Val      << US_CR_USART_DTRDIS_Pos)
 #define US_CR_USART_DTRDIS_1        (US_CR_USART_DTRDIS_1_Val      << US_CR_USART_DTRDIS_Pos)
 #define US_CR_USART_RTSEN_Pos       18           /**< \brief (US_CR_USART) Request to Send Enable */
-#define US_CR_USART_RTSEN           (_U(0x1) << US_CR_USART_RTSEN_Pos)
-#define   US_CR_USART_RTSEN_0_Val         _U(0x0)   /**< \brief (US_CR_USART) No effect */
-#define   US_CR_USART_RTSEN_1_Val         _U(0x1)   /**< \brief (US_CR_USART) Drives the pin RTS to 0 */
+#define US_CR_USART_RTSEN           (_U_(0x1) << US_CR_USART_RTSEN_Pos)
+#define   US_CR_USART_RTSEN_0_Val         _U_(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_RTSEN_1_Val         _U_(0x1)   /**< \brief (US_CR_USART) Drives the pin RTS to 0 */
 #define US_CR_USART_RTSEN_0         (US_CR_USART_RTSEN_0_Val       << US_CR_USART_RTSEN_Pos)
 #define US_CR_USART_RTSEN_1         (US_CR_USART_RTSEN_1_Val       << US_CR_USART_RTSEN_Pos)
 #define US_CR_USART_RTSDIS_Pos      19           /**< \brief (US_CR_USART) Request to Send Disable */
-#define US_CR_USART_RTSDIS          (_U(0x1) << US_CR_USART_RTSDIS_Pos)
-#define   US_CR_USART_RTSDIS_0_Val        _U(0x0)   /**< \brief (US_CR_USART) No effect */
-#define   US_CR_USART_RTSDIS_1_Val        _U(0x1)   /**< \brief (US_CR_USART) Drives the pin RTS to 1 */
+#define US_CR_USART_RTSDIS          (_U_(0x1) << US_CR_USART_RTSDIS_Pos)
+#define   US_CR_USART_RTSDIS_0_Val        _U_(0x0)   /**< \brief (US_CR_USART) No effect */
+#define   US_CR_USART_RTSDIS_1_Val        _U_(0x1)   /**< \brief (US_CR_USART) Drives the pin RTS to 1 */
 #define US_CR_USART_RTSDIS_0        (US_CR_USART_RTSDIS_0_Val      << US_CR_USART_RTSDIS_Pos)
 #define US_CR_USART_RTSDIS_1        (US_CR_USART_RTSDIS_1_Val      << US_CR_USART_RTSDIS_Pos)
-#define US_CR_USART_MASK            _U(0x000FFFFC) /**< \brief (US_CR_USART) MASK Register */
+#define US_CR_USART_MASK            _U_(0x000FFFFC) /**< \brief (US_CR_USART) MASK Register */
 
 // Any mode
 #define US_CR_RSTRX_Pos             2            /**< \brief (US_CR) Reset Receiver */
-#define US_CR_RSTRX                 (_U(0x1) << US_CR_RSTRX_Pos)
-#define   US_CR_RSTRX_0_Val               _U(0x0)   /**< \brief (US_CR) No effect */
-#define   US_CR_RSTRX_1_Val               _U(0x1)   /**< \brief (US_CR) Resets the receiver */
+#define US_CR_RSTRX                 (_U_(0x1) << US_CR_RSTRX_Pos)
+#define   US_CR_RSTRX_0_Val               _U_(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_RSTRX_1_Val               _U_(0x1)   /**< \brief (US_CR) Resets the receiver */
 #define US_CR_RSTRX_0               (US_CR_RSTRX_0_Val             << US_CR_RSTRX_Pos)
 #define US_CR_RSTRX_1               (US_CR_RSTRX_1_Val             << US_CR_RSTRX_Pos)
 #define US_CR_RSTTX_Pos             3            /**< \brief (US_CR) Reset Transmitter */
-#define US_CR_RSTTX                 (_U(0x1) << US_CR_RSTTX_Pos)
-#define   US_CR_RSTTX_0_Val               _U(0x0)   /**< \brief (US_CR) No effect */
-#define   US_CR_RSTTX_1_Val               _U(0x1)   /**< \brief (US_CR) Resets the transmitter */
+#define US_CR_RSTTX                 (_U_(0x1) << US_CR_RSTTX_Pos)
+#define   US_CR_RSTTX_0_Val               _U_(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_RSTTX_1_Val               _U_(0x1)   /**< \brief (US_CR) Resets the transmitter */
 #define US_CR_RSTTX_0               (US_CR_RSTTX_0_Val             << US_CR_RSTTX_Pos)
 #define US_CR_RSTTX_1               (US_CR_RSTTX_1_Val             << US_CR_RSTTX_Pos)
 #define US_CR_RXEN_Pos              4            /**< \brief (US_CR) Receiver Enable */
-#define US_CR_RXEN                  (_U(0x1) << US_CR_RXEN_Pos)
-#define   US_CR_RXEN_0_Val                _U(0x0)   /**< \brief (US_CR) No effect */
-#define   US_CR_RXEN_1_Val                _U(0x1)   /**< \brief (US_CR) Enables the receiver, if RXDIS is 0 */
+#define US_CR_RXEN                  (_U_(0x1) << US_CR_RXEN_Pos)
+#define   US_CR_RXEN_0_Val                _U_(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_RXEN_1_Val                _U_(0x1)   /**< \brief (US_CR) Enables the receiver, if RXDIS is 0 */
 #define US_CR_RXEN_0                (US_CR_RXEN_0_Val              << US_CR_RXEN_Pos)
 #define US_CR_RXEN_1                (US_CR_RXEN_1_Val              << US_CR_RXEN_Pos)
 #define US_CR_RXDIS_Pos             5            /**< \brief (US_CR) Receiver Disable */
-#define US_CR_RXDIS                 (_U(0x1) << US_CR_RXDIS_Pos)
-#define   US_CR_RXDIS_0_Val               _U(0x0)   /**< \brief (US_CR) No effect */
-#define   US_CR_RXDIS_1_Val               _U(0x1)   /**< \brief (US_CR) Disables the receiver */
+#define US_CR_RXDIS                 (_U_(0x1) << US_CR_RXDIS_Pos)
+#define   US_CR_RXDIS_0_Val               _U_(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_RXDIS_1_Val               _U_(0x1)   /**< \brief (US_CR) Disables the receiver */
 #define US_CR_RXDIS_0               (US_CR_RXDIS_0_Val             << US_CR_RXDIS_Pos)
 #define US_CR_RXDIS_1               (US_CR_RXDIS_1_Val             << US_CR_RXDIS_Pos)
 #define US_CR_TXEN_Pos              6            /**< \brief (US_CR) Transmitter Enable */
-#define US_CR_TXEN                  (_U(0x1) << US_CR_TXEN_Pos)
-#define   US_CR_TXEN_0_Val                _U(0x0)   /**< \brief (US_CR) No effect */
-#define   US_CR_TXEN_1_Val                _U(0x1)   /**< \brief (US_CR) Enables the transmitter if TXDIS is 0 */
+#define US_CR_TXEN                  (_U_(0x1) << US_CR_TXEN_Pos)
+#define   US_CR_TXEN_0_Val                _U_(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_TXEN_1_Val                _U_(0x1)   /**< \brief (US_CR) Enables the transmitter if TXDIS is 0 */
 #define US_CR_TXEN_0                (US_CR_TXEN_0_Val              << US_CR_TXEN_Pos)
 #define US_CR_TXEN_1                (US_CR_TXEN_1_Val              << US_CR_TXEN_Pos)
 #define US_CR_TXDIS_Pos             7            /**< \brief (US_CR) Transmitter Disable */
-#define US_CR_TXDIS                 (_U(0x1) << US_CR_TXDIS_Pos)
-#define   US_CR_TXDIS_0_Val               _U(0x0)   /**< \brief (US_CR) No effect */
-#define   US_CR_TXDIS_1_Val               _U(0x1)   /**< \brief (US_CR) Disables the transmitter */
+#define US_CR_TXDIS                 (_U_(0x1) << US_CR_TXDIS_Pos)
+#define   US_CR_TXDIS_0_Val               _U_(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_TXDIS_1_Val               _U_(0x1)   /**< \brief (US_CR) Disables the transmitter */
 #define US_CR_TXDIS_0               (US_CR_TXDIS_0_Val             << US_CR_TXDIS_Pos)
 #define US_CR_TXDIS_1               (US_CR_TXDIS_1_Val             << US_CR_TXDIS_Pos)
 #define US_CR_RSTSTA_Pos            8            /**< \brief (US_CR) Reset Status Bits */
-#define US_CR_RSTSTA                (_U(0x1) << US_CR_RSTSTA_Pos)
-#define   US_CR_RSTSTA_0_Val              _U(0x0)   /**< \brief (US_CR) No effect */
-#define   US_CR_RSTSTA_1_Val              _U(0x1)   /**< \brief (US_CR) Resets the status bits PARE, FRAME, OVRE and RXBRK in the CSR */
+#define US_CR_RSTSTA                (_U_(0x1) << US_CR_RSTSTA_Pos)
+#define   US_CR_RSTSTA_0_Val              _U_(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_RSTSTA_1_Val              _U_(0x1)   /**< \brief (US_CR) Resets the status bits PARE, FRAME, OVRE and RXBRK in the CSR */
 #define US_CR_RSTSTA_0              (US_CR_RSTSTA_0_Val            << US_CR_RSTSTA_Pos)
 #define US_CR_RSTSTA_1              (US_CR_RSTSTA_1_Val            << US_CR_RSTSTA_Pos)
 #define US_CR_STTBRK_Pos            9            /**< \brief (US_CR) Start Break */
-#define US_CR_STTBRK                (_U(0x1) << US_CR_STTBRK_Pos)
-#define   US_CR_STTBRK_0_Val              _U(0x0)   /**< \brief (US_CR) No effect */
-#define   US_CR_STTBRK_1_Val              _U(0x1)   /**< \brief (US_CR) Starts transmission of a break after the characters present in THR and the Transmit Shift Register have been transmitted. No effect if a break is already being transmitted */
+#define US_CR_STTBRK                (_U_(0x1) << US_CR_STTBRK_Pos)
+#define   US_CR_STTBRK_0_Val              _U_(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_STTBRK_1_Val              _U_(0x1)   /**< \brief (US_CR) Starts transmission of a break after the characters present in THR and the Transmit Shift Register have been transmitted. No effect if a break is already being transmitted */
 #define US_CR_STTBRK_0              (US_CR_STTBRK_0_Val            << US_CR_STTBRK_Pos)
 #define US_CR_STTBRK_1              (US_CR_STTBRK_1_Val            << US_CR_STTBRK_Pos)
 #define US_CR_STPBRK_Pos            10           /**< \brief (US_CR) Stop Break */
-#define US_CR_STPBRK                (_U(0x1) << US_CR_STPBRK_Pos)
-#define   US_CR_STPBRK_0_Val              _U(0x0)   /**< \brief (US_CR) No effect */
-#define   US_CR_STPBRK_1_Val              _U(0x1)   /**< \brief (US_CR) Stops transmission of the break after a minimum of one character length and transmits a high level during 12-bit periods.No effect if no break is being transmitted */
+#define US_CR_STPBRK                (_U_(0x1) << US_CR_STPBRK_Pos)
+#define   US_CR_STPBRK_0_Val              _U_(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_STPBRK_1_Val              _U_(0x1)   /**< \brief (US_CR) Stops transmission of the break after a minimum of one character length and transmits a high level during 12-bit periods.No effect if no break is being transmitted */
 #define US_CR_STPBRK_0              (US_CR_STPBRK_0_Val            << US_CR_STPBRK_Pos)
 #define US_CR_STPBRK_1              (US_CR_STPBRK_1_Val            << US_CR_STPBRK_Pos)
 #define US_CR_STTTO_Pos             11           /**< \brief (US_CR) Start Time-out */
-#define US_CR_STTTO                 (_U(0x1) << US_CR_STTTO_Pos)
-#define   US_CR_STTTO_0_Val               _U(0x0)   /**< \brief (US_CR) No effect */
-#define   US_CR_STTTO_1_Val               _U(0x1)   /**< \brief (US_CR) Starts waiting for a character before clocking the time-out counter */
+#define US_CR_STTTO                 (_U_(0x1) << US_CR_STTTO_Pos)
+#define   US_CR_STTTO_0_Val               _U_(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_STTTO_1_Val               _U_(0x1)   /**< \brief (US_CR) Starts waiting for a character before clocking the time-out counter */
 #define US_CR_STTTO_0               (US_CR_STTTO_0_Val             << US_CR_STTTO_Pos)
 #define US_CR_STTTO_1               (US_CR_STTTO_1_Val             << US_CR_STTTO_Pos)
 #define US_CR_SENDA_Pos             12           /**< \brief (US_CR) Send Address */
-#define US_CR_SENDA                 (_U(0x1) << US_CR_SENDA_Pos)
-#define   US_CR_SENDA_0_Val               _U(0x0)   /**< \brief (US_CR) No effect */
-#define   US_CR_SENDA_1_Val               _U(0x1)   /**< \brief (US_CR) In Multi-drop Mode only, the next character written to the THR is sent with the address bit set */
+#define US_CR_SENDA                 (_U_(0x1) << US_CR_SENDA_Pos)
+#define   US_CR_SENDA_0_Val               _U_(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_SENDA_1_Val               _U_(0x1)   /**< \brief (US_CR) In Multi-drop Mode only, the next character written to the THR is sent with the address bit set */
 #define US_CR_SENDA_0               (US_CR_SENDA_0_Val             << US_CR_SENDA_Pos)
 #define US_CR_SENDA_1               (US_CR_SENDA_1_Val             << US_CR_SENDA_Pos)
 #define US_CR_RSTIT_Pos             13           /**< \brief (US_CR) Reset Iterations */
-#define US_CR_RSTIT                 (_U(0x1) << US_CR_RSTIT_Pos)
-#define   US_CR_RSTIT_0_Val               _U(0x0)   /**< \brief (US_CR) No effect */
-#define   US_CR_RSTIT_1_Val               _U(0x1)   /**< \brief (US_CR) Resets ITERATION in CSR. No effect if the ISO7816 is not enabled */
+#define US_CR_RSTIT                 (_U_(0x1) << US_CR_RSTIT_Pos)
+#define   US_CR_RSTIT_0_Val               _U_(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_RSTIT_1_Val               _U_(0x1)   /**< \brief (US_CR) Resets ITERATION in CSR. No effect if the ISO7816 is not enabled */
 #define US_CR_RSTIT_0               (US_CR_RSTIT_0_Val             << US_CR_RSTIT_Pos)
 #define US_CR_RSTIT_1               (US_CR_RSTIT_1_Val             << US_CR_RSTIT_Pos)
 #define US_CR_RSTNACK_Pos           14           /**< \brief (US_CR) Reset Non Acknowledge */
-#define US_CR_RSTNACK               (_U(0x1) << US_CR_RSTNACK_Pos)
-#define   US_CR_RSTNACK_0_Val             _U(0x0)   /**< \brief (US_CR) No effect */
-#define   US_CR_RSTNACK_1_Val             _U(0x1)   /**< \brief (US_CR) Resets NACK in CSR */
+#define US_CR_RSTNACK               (_U_(0x1) << US_CR_RSTNACK_Pos)
+#define   US_CR_RSTNACK_0_Val             _U_(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_RSTNACK_1_Val             _U_(0x1)   /**< \brief (US_CR) Resets NACK in CSR */
 #define US_CR_RSTNACK_0             (US_CR_RSTNACK_0_Val           << US_CR_RSTNACK_Pos)
 #define US_CR_RSTNACK_1             (US_CR_RSTNACK_1_Val           << US_CR_RSTNACK_Pos)
 #define US_CR_RETTO_Pos             15           /**< \brief (US_CR) Rearm Time-out */
-#define US_CR_RETTO                 (_U(0x1) << US_CR_RETTO_Pos)
-#define   US_CR_RETTO_0_Val               _U(0x0)   /**< \brief (US_CR) No effect */
-#define   US_CR_RETTO_1_Val               _U(0x1)   /**< \brief (US_CR) Restart Time-out */
+#define US_CR_RETTO                 (_U_(0x1) << US_CR_RETTO_Pos)
+#define   US_CR_RETTO_0_Val               _U_(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_RETTO_1_Val               _U_(0x1)   /**< \brief (US_CR) Restart Time-out */
 #define US_CR_RETTO_0               (US_CR_RETTO_0_Val             << US_CR_RETTO_Pos)
 #define US_CR_RETTO_1               (US_CR_RETTO_1_Val             << US_CR_RETTO_Pos)
 #define US_CR_DTREN_Pos             16           /**< \brief (US_CR) Data Terminal Ready Enable */
-#define US_CR_DTREN                 (_U(0x1) << US_CR_DTREN_Pos)
-#define   US_CR_DTREN_0_Val               _U(0x0)   /**< \brief (US_CR) No effect */
-#define   US_CR_DTREN_1_Val               _U(0x1)   /**< \brief (US_CR) Drives the pin DTR at 0 */
+#define US_CR_DTREN                 (_U_(0x1) << US_CR_DTREN_Pos)
+#define   US_CR_DTREN_0_Val               _U_(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_DTREN_1_Val               _U_(0x1)   /**< \brief (US_CR) Drives the pin DTR at 0 */
 #define US_CR_DTREN_0               (US_CR_DTREN_0_Val             << US_CR_DTREN_Pos)
 #define US_CR_DTREN_1               (US_CR_DTREN_1_Val             << US_CR_DTREN_Pos)
 #define US_CR_DTRDIS_Pos            17           /**< \brief (US_CR) Data Terminal Ready Disable */
-#define US_CR_DTRDIS                (_U(0x1) << US_CR_DTRDIS_Pos)
-#define   US_CR_DTRDIS_0_Val              _U(0x0)   /**< \brief (US_CR) No effect */
-#define   US_CR_DTRDIS_1_Val              _U(0x1)   /**< \brief (US_CR) Drives the pin DTR to 1 */
+#define US_CR_DTRDIS                (_U_(0x1) << US_CR_DTRDIS_Pos)
+#define   US_CR_DTRDIS_0_Val              _U_(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_DTRDIS_1_Val              _U_(0x1)   /**< \brief (US_CR) Drives the pin DTR to 1 */
 #define US_CR_DTRDIS_0              (US_CR_DTRDIS_0_Val            << US_CR_DTRDIS_Pos)
 #define US_CR_DTRDIS_1              (US_CR_DTRDIS_1_Val            << US_CR_DTRDIS_Pos)
 #define US_CR_RTSEN_Pos             18           /**< \brief (US_CR) Request to Send Enable */
-#define US_CR_RTSEN                 (_U(0x1) << US_CR_RTSEN_Pos)
-#define   US_CR_RTSEN_0_Val               _U(0x0)   /**< \brief (US_CR) No effect */
-#define   US_CR_RTSEN_1_Val               _U(0x1)   /**< \brief (US_CR) Drives the pin RTS to 0 */
+#define US_CR_RTSEN                 (_U_(0x1) << US_CR_RTSEN_Pos)
+#define   US_CR_RTSEN_0_Val               _U_(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_RTSEN_1_Val               _U_(0x1)   /**< \brief (US_CR) Drives the pin RTS to 0 */
 #define US_CR_RTSEN_0               (US_CR_RTSEN_0_Val             << US_CR_RTSEN_Pos)
 #define US_CR_RTSEN_1               (US_CR_RTSEN_1_Val             << US_CR_RTSEN_Pos)
 #define US_CR_FCS_Pos               18           /**< \brief (US_CR) Force SPI Chip Select */
-#define US_CR_FCS                   (_U(0x1) << US_CR_FCS_Pos)
-#define   US_CR_FCS_0_Val                 _U(0x0)   /**< \brief (US_CR) No effect */
-#define   US_CR_FCS_1_Val                 _U(0x1)   /**< \brief (US_CR) Forces the Slave Select Line NSS (RTS pin) to 0, even if USART is no transmitting, in order to address SPI slave devices supporting the CSAAT Mode (Chip Select Active After Transfer) */
+#define US_CR_FCS                   (_U_(0x1) << US_CR_FCS_Pos)
+#define   US_CR_FCS_0_Val                 _U_(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_FCS_1_Val                 _U_(0x1)   /**< \brief (US_CR) Forces the Slave Select Line NSS (RTS pin) to 0, even if USART is no transmitting, in order to address SPI slave devices supporting the CSAAT Mode (Chip Select Active After Transfer) */
 #define US_CR_FCS_0                 (US_CR_FCS_0_Val               << US_CR_FCS_Pos)
 #define US_CR_FCS_1                 (US_CR_FCS_1_Val               << US_CR_FCS_Pos)
 #define US_CR_RTSEN_Pos             18           /**< \brief (US_CR) Request to Send Enable */
-#define US_CR_RTSEN                 (_U(0x1) << US_CR_RTSEN_Pos)
-#define   US_CR_RTSEN_0_Val               _U(0x0)   /**< \brief (US_CR) No effect */
-#define   US_CR_RTSEN_1_Val               _U(0x1)   /**< \brief (US_CR) Drives the pin RTS to 0 */
+#define US_CR_RTSEN                 (_U_(0x1) << US_CR_RTSEN_Pos)
+#define   US_CR_RTSEN_0_Val               _U_(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_RTSEN_1_Val               _U_(0x1)   /**< \brief (US_CR) Drives the pin RTS to 0 */
 #define US_CR_RTSEN_0               (US_CR_RTSEN_0_Val             << US_CR_RTSEN_Pos)
 #define US_CR_RTSEN_1               (US_CR_RTSEN_1_Val             << US_CR_RTSEN_Pos)
 #define US_CR_RTSDIS_Pos            19           /**< \brief (US_CR) Request to Send Disable */
-#define US_CR_RTSDIS                (_U(0x1) << US_CR_RTSDIS_Pos)
-#define   US_CR_RTSDIS_0_Val              _U(0x0)   /**< \brief (US_CR) No effect */
-#define   US_CR_RTSDIS_1_Val              _U(0x1)   /**< \brief (US_CR) Drives the pin RTS to 1 */
+#define US_CR_RTSDIS                (_U_(0x1) << US_CR_RTSDIS_Pos)
+#define   US_CR_RTSDIS_0_Val              _U_(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_RTSDIS_1_Val              _U_(0x1)   /**< \brief (US_CR) Drives the pin RTS to 1 */
 #define US_CR_RTSDIS_0              (US_CR_RTSDIS_0_Val            << US_CR_RTSDIS_Pos)
 #define US_CR_RTSDIS_1              (US_CR_RTSDIS_1_Val            << US_CR_RTSDIS_Pos)
 #define US_CR_RCS_Pos               19           /**< \brief (US_CR) Release SPI Chip Select */
-#define US_CR_RCS                   (_U(0x1) << US_CR_RCS_Pos)
-#define   US_CR_RCS_0_Val                 _U(0x0)   /**< \brief (US_CR) No effect */
-#define   US_CR_RCS_1_Val                 _U(0x1)   /**< \brief (US_CR) Releases the Slave Select Line NSS (RTS pin) */
+#define US_CR_RCS                   (_U_(0x1) << US_CR_RCS_Pos)
+#define   US_CR_RCS_0_Val                 _U_(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_RCS_1_Val                 _U_(0x1)   /**< \brief (US_CR) Releases the Slave Select Line NSS (RTS pin) */
 #define US_CR_RCS_0                 (US_CR_RCS_0_Val               << US_CR_RCS_Pos)
 #define US_CR_RCS_1                 (US_CR_RCS_1_Val               << US_CR_RCS_Pos)
 #define US_CR_RTSDIS_Pos            19           /**< \brief (US_CR) Request to Send Disable */
-#define US_CR_RTSDIS                (_U(0x1) << US_CR_RTSDIS_Pos)
-#define   US_CR_RTSDIS_0_Val              _U(0x0)   /**< \brief (US_CR) No effect */
-#define   US_CR_RTSDIS_1_Val              _U(0x1)   /**< \brief (US_CR) Drives the pin RTS to 1 */
+#define US_CR_RTSDIS                (_U_(0x1) << US_CR_RTSDIS_Pos)
+#define   US_CR_RTSDIS_0_Val              _U_(0x0)   /**< \brief (US_CR) No effect */
+#define   US_CR_RTSDIS_1_Val              _U_(0x1)   /**< \brief (US_CR) Drives the pin RTS to 1 */
 #define US_CR_RTSDIS_0              (US_CR_RTSDIS_0_Val            << US_CR_RTSDIS_Pos)
 #define US_CR_RTSDIS_1              (US_CR_RTSDIS_1_Val            << US_CR_RTSDIS_Pos)
 #define US_CR_LINABT_Pos            20           /**< \brief (US_CR) Abort the current LIN transmission */
-#define US_CR_LINABT                (_U(0x1) << US_CR_LINABT_Pos)
+#define US_CR_LINABT                (_U_(0x1) << US_CR_LINABT_Pos)
 #define US_CR_LINWKUP_Pos           21           /**< \brief (US_CR) Sends a wakeup signal on the LIN bus */
-#define US_CR_LINWKUP               (_U(0x1) << US_CR_LINWKUP_Pos)
-#define US_CR_MASK                  _U(0x003FFFFC) /**< \brief (US_CR) MASK Register */
+#define US_CR_LINWKUP               (_U_(0x1) << US_CR_LINWKUP_Pos)
+#define US_CR_MASK                  _U_(0x003FFFFC) /**< \brief (US_CR) MASK Register */
 
 /* -------- US_MR : (USART Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -643,23 +643,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_MR_OFFSET                0x04         /**< \brief (US_MR offset) Mode Register */
-#define US_MR_RESETVALUE            _U(0x00000000); /**< \brief (US_MR reset_value) Mode Register */
+#define US_MR_RESETVALUE            _U_(0x00000000); /**< \brief (US_MR reset_value) Mode Register */
 
 // SPI mode
 #define US_MR_SPI_MODE_Pos          0            /**< \brief (US_MR_SPI) Usart Mode */
-#define US_MR_SPI_MODE_Msk          (_U(0xF) << US_MR_SPI_MODE_Pos)
+#define US_MR_SPI_MODE_Msk          (_U_(0xF) << US_MR_SPI_MODE_Pos)
 #define US_MR_SPI_MODE(value)       (US_MR_SPI_MODE_Msk & ((value) << US_MR_SPI_MODE_Pos))
-#define   US_MR_SPI_MODE_NORMAL_Val       _U(0x0)   /**< \brief (US_MR_SPI) Normal */
-#define   US_MR_SPI_MODE_RS485_Val        _U(0x1)   /**< \brief (US_MR_SPI) RS485 */
-#define   US_MR_SPI_MODE_HARDWARE_Val     _U(0x2)   /**< \brief (US_MR_SPI) Hardware Handshaking */
-#define   US_MR_SPI_MODE_MODEM_Val        _U(0x3)   /**< \brief (US_MR_SPI) Modem */
-#define   US_MR_SPI_MODE_ISO7816_T0_Val   _U(0x4)   /**< \brief (US_MR_SPI) IS07816 Protocol: T = 0 */
-#define   US_MR_SPI_MODE_ISO7816_T1_Val   _U(0x6)   /**< \brief (US_MR_SPI) IS07816 Protocol: T = 1 */
-#define   US_MR_SPI_MODE_IRDA_Val         _U(0x8)   /**< \brief (US_MR_SPI) IrDA */
-#define   US_MR_SPI_MODE_LIN_MASTER_Val   _U(0xA)   /**< \brief (US_MR_SPI) LIN Master */
-#define   US_MR_SPI_MODE_LIN_SLAVE_Val    _U(0xB)   /**< \brief (US_MR_SPI) LIN Slave */
-#define   US_MR_SPI_MODE_SPI_MASTER_Val   _U(0xE)   /**< \brief (US_MR_SPI) SPI Master */
-#define   US_MR_SPI_MODE_SPI_SLAVE_Val    _U(0xF)   /**< \brief (US_MR_SPI) SPI Slave */
+#define   US_MR_SPI_MODE_NORMAL_Val       _U_(0x0)   /**< \brief (US_MR_SPI) Normal */
+#define   US_MR_SPI_MODE_RS485_Val        _U_(0x1)   /**< \brief (US_MR_SPI) RS485 */
+#define   US_MR_SPI_MODE_HARDWARE_Val     _U_(0x2)   /**< \brief (US_MR_SPI) Hardware Handshaking */
+#define   US_MR_SPI_MODE_MODEM_Val        _U_(0x3)   /**< \brief (US_MR_SPI) Modem */
+#define   US_MR_SPI_MODE_ISO7816_T0_Val   _U_(0x4)   /**< \brief (US_MR_SPI) IS07816 Protocol: T = 0 */
+#define   US_MR_SPI_MODE_ISO7816_T1_Val   _U_(0x6)   /**< \brief (US_MR_SPI) IS07816 Protocol: T = 1 */
+#define   US_MR_SPI_MODE_IRDA_Val         _U_(0x8)   /**< \brief (US_MR_SPI) IrDA */
+#define   US_MR_SPI_MODE_LIN_MASTER_Val   _U_(0xA)   /**< \brief (US_MR_SPI) LIN Master */
+#define   US_MR_SPI_MODE_LIN_SLAVE_Val    _U_(0xB)   /**< \brief (US_MR_SPI) LIN Slave */
+#define   US_MR_SPI_MODE_SPI_MASTER_Val   _U_(0xE)   /**< \brief (US_MR_SPI) SPI Master */
+#define   US_MR_SPI_MODE_SPI_SLAVE_Val    _U_(0xF)   /**< \brief (US_MR_SPI) SPI Slave */
 #define US_MR_SPI_MODE_NORMAL       (US_MR_SPI_MODE_NORMAL_Val     << US_MR_SPI_MODE_Pos)
 #define US_MR_SPI_MODE_RS485        (US_MR_SPI_MODE_RS485_Val      << US_MR_SPI_MODE_Pos)
 #define US_MR_SPI_MODE_HARDWARE     (US_MR_SPI_MODE_HARDWARE_Val   << US_MR_SPI_MODE_Pos)
@@ -672,44 +672,44 @@ typedef union {
 #define US_MR_SPI_MODE_SPI_MASTER   (US_MR_SPI_MODE_SPI_MASTER_Val << US_MR_SPI_MODE_Pos)
 #define US_MR_SPI_MODE_SPI_SLAVE    (US_MR_SPI_MODE_SPI_SLAVE_Val  << US_MR_SPI_MODE_Pos)
 #define US_MR_SPI_USCLKS_Pos        4            /**< \brief (US_MR_SPI) Clock Selection */
-#define US_MR_SPI_USCLKS_Msk        (_U(0x3) << US_MR_SPI_USCLKS_Pos)
+#define US_MR_SPI_USCLKS_Msk        (_U_(0x3) << US_MR_SPI_USCLKS_Pos)
 #define US_MR_SPI_USCLKS(value)     (US_MR_SPI_USCLKS_Msk & ((value) << US_MR_SPI_USCLKS_Pos))
-#define   US_MR_SPI_USCLKS_MCK_Val        _U(0x0)   /**< \brief (US_MR_SPI) MCK */
-#define   US_MR_SPI_USCLKS_MCK_DIV_Val    _U(0x1)   /**< \brief (US_MR_SPI) MCK / DIV */
-#define   US_MR_SPI_USCLKS_2_Val          _U(0x2)   /**< \brief (US_MR_SPI) Reserved */
-#define   US_MR_SPI_USCLKS_SCK_Val        _U(0x3)   /**< \brief (US_MR_SPI) SCK */
+#define   US_MR_SPI_USCLKS_MCK_Val        _U_(0x0)   /**< \brief (US_MR_SPI) MCK */
+#define   US_MR_SPI_USCLKS_MCK_DIV_Val    _U_(0x1)   /**< \brief (US_MR_SPI) MCK / DIV */
+#define   US_MR_SPI_USCLKS_2_Val          _U_(0x2)   /**< \brief (US_MR_SPI) Reserved */
+#define   US_MR_SPI_USCLKS_SCK_Val        _U_(0x3)   /**< \brief (US_MR_SPI) SCK */
 #define US_MR_SPI_USCLKS_MCK        (US_MR_SPI_USCLKS_MCK_Val      << US_MR_SPI_USCLKS_Pos)
 #define US_MR_SPI_USCLKS_MCK_DIV    (US_MR_SPI_USCLKS_MCK_DIV_Val  << US_MR_SPI_USCLKS_Pos)
 #define US_MR_SPI_USCLKS_2          (US_MR_SPI_USCLKS_2_Val        << US_MR_SPI_USCLKS_Pos)
 #define US_MR_SPI_USCLKS_SCK        (US_MR_SPI_USCLKS_SCK_Val      << US_MR_SPI_USCLKS_Pos)
 #define US_MR_SPI_CHRL_Pos          6            /**< \brief (US_MR_SPI) Character Length. */
-#define US_MR_SPI_CHRL_Msk          (_U(0x3) << US_MR_SPI_CHRL_Pos)
+#define US_MR_SPI_CHRL_Msk          (_U_(0x3) << US_MR_SPI_CHRL_Pos)
 #define US_MR_SPI_CHRL(value)       (US_MR_SPI_CHRL_Msk & ((value) << US_MR_SPI_CHRL_Pos))
-#define   US_MR_SPI_CHRL_5_Val            _U(0x0)   /**< \brief (US_MR_SPI) 5 bits */
-#define   US_MR_SPI_CHRL_6_Val            _U(0x1)   /**< \brief (US_MR_SPI) 6 bits */
-#define   US_MR_SPI_CHRL_7_Val            _U(0x2)   /**< \brief (US_MR_SPI) 7 bits */
-#define   US_MR_SPI_CHRL_8_Val            _U(0x3)   /**< \brief (US_MR_SPI) 8 bits */
+#define   US_MR_SPI_CHRL_5_Val            _U_(0x0)   /**< \brief (US_MR_SPI) 5 bits */
+#define   US_MR_SPI_CHRL_6_Val            _U_(0x1)   /**< \brief (US_MR_SPI) 6 bits */
+#define   US_MR_SPI_CHRL_7_Val            _U_(0x2)   /**< \brief (US_MR_SPI) 7 bits */
+#define   US_MR_SPI_CHRL_8_Val            _U_(0x3)   /**< \brief (US_MR_SPI) 8 bits */
 #define US_MR_SPI_CHRL_5            (US_MR_SPI_CHRL_5_Val          << US_MR_SPI_CHRL_Pos)
 #define US_MR_SPI_CHRL_6            (US_MR_SPI_CHRL_6_Val          << US_MR_SPI_CHRL_Pos)
 #define US_MR_SPI_CHRL_7            (US_MR_SPI_CHRL_7_Val          << US_MR_SPI_CHRL_Pos)
 #define US_MR_SPI_CHRL_8            (US_MR_SPI_CHRL_8_Val          << US_MR_SPI_CHRL_Pos)
 #define US_MR_SPI_CPHA_Pos          8            /**< \brief (US_MR_SPI) SPI CLock Phase */
-#define US_MR_SPI_CPHA              (_U(0x1) << US_MR_SPI_CPHA_Pos)
-#define   US_MR_SPI_CPHA_0_Val            _U(0x0)   /**< \brief (US_MR_SPI) Data is changed on the leading edge of SPCK and captured on the following edge of SPCK */
-#define   US_MR_SPI_CPHA_1_Val            _U(0x1)   /**< \brief (US_MR_SPI) Data is captured on the leading edge of SPCK and changed on the following edge of SPCK */
+#define US_MR_SPI_CPHA              (_U_(0x1) << US_MR_SPI_CPHA_Pos)
+#define   US_MR_SPI_CPHA_0_Val            _U_(0x0)   /**< \brief (US_MR_SPI) Data is changed on the leading edge of SPCK and captured on the following edge of SPCK */
+#define   US_MR_SPI_CPHA_1_Val            _U_(0x1)   /**< \brief (US_MR_SPI) Data is captured on the leading edge of SPCK and changed on the following edge of SPCK */
 #define US_MR_SPI_CPHA_0            (US_MR_SPI_CPHA_0_Val          << US_MR_SPI_CPHA_Pos)
 #define US_MR_SPI_CPHA_1            (US_MR_SPI_CPHA_1_Val          << US_MR_SPI_CPHA_Pos)
 #define US_MR_SPI_PAR_Pos           9            /**< \brief (US_MR_SPI) Parity Type */
-#define US_MR_SPI_PAR_Msk           (_U(0x7) << US_MR_SPI_PAR_Pos)
+#define US_MR_SPI_PAR_Msk           (_U_(0x7) << US_MR_SPI_PAR_Pos)
 #define US_MR_SPI_PAR(value)        (US_MR_SPI_PAR_Msk & ((value) << US_MR_SPI_PAR_Pos))
-#define   US_MR_SPI_PAR_EVEN_Val          _U(0x0)   /**< \brief (US_MR_SPI) Even parity */
-#define   US_MR_SPI_PAR_ODD_Val           _U(0x1)   /**< \brief (US_MR_SPI) Odd parity */
-#define   US_MR_SPI_PAR_SPACE_Val         _U(0x2)   /**< \brief (US_MR_SPI) Parity forced to 0 (Space) */
-#define   US_MR_SPI_PAR_MARK_Val          _U(0x3)   /**< \brief (US_MR_SPI) Parity forced to 1 (Mark) */
-#define   US_MR_SPI_PAR_NONE_Val          _U(0x4)   /**< \brief (US_MR_SPI) No Parity */
-#define   US_MR_SPI_PAR_5_Val             _U(0x5)   /**< \brief (US_MR_SPI) No Parity */
-#define   US_MR_SPI_PAR_MULTI_Val         _U(0x6)   /**< \brief (US_MR_SPI) Multi-drop mode */
-#define   US_MR_SPI_PAR_7_Val             _U(0x7)   /**< \brief (US_MR_SPI) Multi-drop mode */
+#define   US_MR_SPI_PAR_EVEN_Val          _U_(0x0)   /**< \brief (US_MR_SPI) Even parity */
+#define   US_MR_SPI_PAR_ODD_Val           _U_(0x1)   /**< \brief (US_MR_SPI) Odd parity */
+#define   US_MR_SPI_PAR_SPACE_Val         _U_(0x2)   /**< \brief (US_MR_SPI) Parity forced to 0 (Space) */
+#define   US_MR_SPI_PAR_MARK_Val          _U_(0x3)   /**< \brief (US_MR_SPI) Parity forced to 1 (Mark) */
+#define   US_MR_SPI_PAR_NONE_Val          _U_(0x4)   /**< \brief (US_MR_SPI) No Parity */
+#define   US_MR_SPI_PAR_5_Val             _U_(0x5)   /**< \brief (US_MR_SPI) No Parity */
+#define   US_MR_SPI_PAR_MULTI_Val         _U_(0x6)   /**< \brief (US_MR_SPI) Multi-drop mode */
+#define   US_MR_SPI_PAR_7_Val             _U_(0x7)   /**< \brief (US_MR_SPI) Multi-drop mode */
 #define US_MR_SPI_PAR_EVEN          (US_MR_SPI_PAR_EVEN_Val        << US_MR_SPI_PAR_Pos)
 #define US_MR_SPI_PAR_ODD           (US_MR_SPI_PAR_ODD_Val         << US_MR_SPI_PAR_Pos)
 #define US_MR_SPI_PAR_SPACE         (US_MR_SPI_PAR_SPACE_Val       << US_MR_SPI_PAR_Pos)
@@ -719,91 +719,91 @@ typedef union {
 #define US_MR_SPI_PAR_MULTI         (US_MR_SPI_PAR_MULTI_Val       << US_MR_SPI_PAR_Pos)
 #define US_MR_SPI_PAR_7             (US_MR_SPI_PAR_7_Val           << US_MR_SPI_PAR_Pos)
 #define US_MR_SPI_NBSTOP_Pos        12           /**< \brief (US_MR_SPI) Number of Stop Bits */
-#define US_MR_SPI_NBSTOP_Msk        (_U(0x3) << US_MR_SPI_NBSTOP_Pos)
+#define US_MR_SPI_NBSTOP_Msk        (_U_(0x3) << US_MR_SPI_NBSTOP_Pos)
 #define US_MR_SPI_NBSTOP(value)     (US_MR_SPI_NBSTOP_Msk & ((value) << US_MR_SPI_NBSTOP_Pos))
-#define   US_MR_SPI_NBSTOP_1_Val          _U(0x0)   /**< \brief (US_MR_SPI) 1 stop bit */
-#define   US_MR_SPI_NBSTOP_1_5_Val        _U(0x1)   /**< \brief (US_MR_SPI) 1.5 stop bits (Only valid if SYNC=0) */
-#define   US_MR_SPI_NBSTOP_2_Val          _U(0x2)   /**< \brief (US_MR_SPI) 2 stop bits */
-#define   US_MR_SPI_NBSTOP_3_Val          _U(0x3)   /**< \brief (US_MR_SPI) Reserved */
+#define   US_MR_SPI_NBSTOP_1_Val          _U_(0x0)   /**< \brief (US_MR_SPI) 1 stop bit */
+#define   US_MR_SPI_NBSTOP_1_5_Val        _U_(0x1)   /**< \brief (US_MR_SPI) 1.5 stop bits (Only valid if SYNC=0) */
+#define   US_MR_SPI_NBSTOP_2_Val          _U_(0x2)   /**< \brief (US_MR_SPI) 2 stop bits */
+#define   US_MR_SPI_NBSTOP_3_Val          _U_(0x3)   /**< \brief (US_MR_SPI) Reserved */
 #define US_MR_SPI_NBSTOP_1          (US_MR_SPI_NBSTOP_1_Val        << US_MR_SPI_NBSTOP_Pos)
 #define US_MR_SPI_NBSTOP_1_5        (US_MR_SPI_NBSTOP_1_5_Val      << US_MR_SPI_NBSTOP_Pos)
 #define US_MR_SPI_NBSTOP_2          (US_MR_SPI_NBSTOP_2_Val        << US_MR_SPI_NBSTOP_Pos)
 #define US_MR_SPI_NBSTOP_3          (US_MR_SPI_NBSTOP_3_Val        << US_MR_SPI_NBSTOP_Pos)
 #define US_MR_SPI_CHMODE_Pos        14           /**< \brief (US_MR_SPI) Channel Mode */
-#define US_MR_SPI_CHMODE_Msk        (_U(0x3) << US_MR_SPI_CHMODE_Pos)
+#define US_MR_SPI_CHMODE_Msk        (_U_(0x3) << US_MR_SPI_CHMODE_Pos)
 #define US_MR_SPI_CHMODE(value)     (US_MR_SPI_CHMODE_Msk & ((value) << US_MR_SPI_CHMODE_Pos))
-#define   US_MR_SPI_CHMODE_NORMAL_Val     _U(0x0)   /**< \brief (US_MR_SPI) Normal Mode */
-#define   US_MR_SPI_CHMODE_ECHO_Val       _U(0x1)   /**< \brief (US_MR_SPI) Automatic Echo. Receiver input is connected to the TXD pin */
-#define   US_MR_SPI_CHMODE_LOCAL_LOOP_Val _U(0x2)   /**< \brief (US_MR_SPI) Local Loopback. Transmitter output is connected to the Receiver Input */
-#define   US_MR_SPI_CHMODE_REMOTE_LOOP_Val _U(0x3)   /**< \brief (US_MR_SPI) Remote Loopback. RXD pin is internally connected to the TXD pin */
+#define   US_MR_SPI_CHMODE_NORMAL_Val     _U_(0x0)   /**< \brief (US_MR_SPI) Normal Mode */
+#define   US_MR_SPI_CHMODE_ECHO_Val       _U_(0x1)   /**< \brief (US_MR_SPI) Automatic Echo. Receiver input is connected to the TXD pin */
+#define   US_MR_SPI_CHMODE_LOCAL_LOOP_Val _U_(0x2)   /**< \brief (US_MR_SPI) Local Loopback. Transmitter output is connected to the Receiver Input */
+#define   US_MR_SPI_CHMODE_REMOTE_LOOP_Val _U_(0x3)   /**< \brief (US_MR_SPI) Remote Loopback. RXD pin is internally connected to the TXD pin */
 #define US_MR_SPI_CHMODE_NORMAL     (US_MR_SPI_CHMODE_NORMAL_Val   << US_MR_SPI_CHMODE_Pos)
 #define US_MR_SPI_CHMODE_ECHO       (US_MR_SPI_CHMODE_ECHO_Val     << US_MR_SPI_CHMODE_Pos)
 #define US_MR_SPI_CHMODE_LOCAL_LOOP (US_MR_SPI_CHMODE_LOCAL_LOOP_Val << US_MR_SPI_CHMODE_Pos)
 #define US_MR_SPI_CHMODE_REMOTE_LOOP (US_MR_SPI_CHMODE_REMOTE_LOOP_Val << US_MR_SPI_CHMODE_Pos)
 #define US_MR_SPI_CPOL_Pos          16           /**< \brief (US_MR_SPI) SPI Clock Polarity */
-#define US_MR_SPI_CPOL              (_U(0x1) << US_MR_SPI_CPOL_Pos)
-#define   US_MR_SPI_CPOL_ZERO_Val         _U(0x0)   /**< \brief (US_MR_SPI) The inactive state value of SPCK is logic level zero */
-#define   US_MR_SPI_CPOL_ONE_Val          _U(0x1)   /**< \brief (US_MR_SPI) The inactive state value of SPCK is logic level one */
+#define US_MR_SPI_CPOL              (_U_(0x1) << US_MR_SPI_CPOL_Pos)
+#define   US_MR_SPI_CPOL_ZERO_Val         _U_(0x0)   /**< \brief (US_MR_SPI) The inactive state value of SPCK is logic level zero */
+#define   US_MR_SPI_CPOL_ONE_Val          _U_(0x1)   /**< \brief (US_MR_SPI) The inactive state value of SPCK is logic level one */
 #define US_MR_SPI_CPOL_ZERO         (US_MR_SPI_CPOL_ZERO_Val       << US_MR_SPI_CPOL_Pos)
 #define US_MR_SPI_CPOL_ONE          (US_MR_SPI_CPOL_ONE_Val        << US_MR_SPI_CPOL_Pos)
 #define US_MR_SPI_MODE9_Pos         17           /**< \brief (US_MR_SPI) 9-bit Character Length */
-#define US_MR_SPI_MODE9             (_U(0x1) << US_MR_SPI_MODE9_Pos)
-#define   US_MR_SPI_MODE9_0_Val           _U(0x0)   /**< \brief (US_MR_SPI) CHRL defines character length */
-#define   US_MR_SPI_MODE9_1_Val           _U(0x1)   /**< \brief (US_MR_SPI) 9-bit character length */
+#define US_MR_SPI_MODE9             (_U_(0x1) << US_MR_SPI_MODE9_Pos)
+#define   US_MR_SPI_MODE9_0_Val           _U_(0x0)   /**< \brief (US_MR_SPI) CHRL defines character length */
+#define   US_MR_SPI_MODE9_1_Val           _U_(0x1)   /**< \brief (US_MR_SPI) 9-bit character length */
 #define US_MR_SPI_MODE9_0           (US_MR_SPI_MODE9_0_Val         << US_MR_SPI_MODE9_Pos)
 #define US_MR_SPI_MODE9_1           (US_MR_SPI_MODE9_1_Val         << US_MR_SPI_MODE9_Pos)
 #define US_MR_SPI_CLKO_Pos          18           /**< \brief (US_MR_SPI) Clock Output Select */
-#define US_MR_SPI_CLKO              (_U(0x1) << US_MR_SPI_CLKO_Pos)
-#define   US_MR_SPI_CLKO_0_Val            _U(0x0)   /**< \brief (US_MR_SPI) The USART does not drive the SCK pin */
-#define   US_MR_SPI_CLKO_1_Val            _U(0x1)   /**< \brief (US_MR_SPI) The USART drives the SCK pin if USCLKS does not select the external clock SCK */
+#define US_MR_SPI_CLKO              (_U_(0x1) << US_MR_SPI_CLKO_Pos)
+#define   US_MR_SPI_CLKO_0_Val            _U_(0x0)   /**< \brief (US_MR_SPI) The USART does not drive the SCK pin */
+#define   US_MR_SPI_CLKO_1_Val            _U_(0x1)   /**< \brief (US_MR_SPI) The USART drives the SCK pin if USCLKS does not select the external clock SCK */
 #define US_MR_SPI_CLKO_0            (US_MR_SPI_CLKO_0_Val          << US_MR_SPI_CLKO_Pos)
 #define US_MR_SPI_CLKO_1            (US_MR_SPI_CLKO_1_Val          << US_MR_SPI_CLKO_Pos)
 #define US_MR_SPI_OVER_Pos          19           /**< \brief (US_MR_SPI) Oversampling Mode */
-#define US_MR_SPI_OVER              (_U(0x1) << US_MR_SPI_OVER_Pos)
-#define   US_MR_SPI_OVER_X16_Val          _U(0x0)   /**< \brief (US_MR_SPI) 16x Oversampling */
-#define   US_MR_SPI_OVER_X8_Val           _U(0x1)   /**< \brief (US_MR_SPI) 8x Oversampling */
+#define US_MR_SPI_OVER              (_U_(0x1) << US_MR_SPI_OVER_Pos)
+#define   US_MR_SPI_OVER_X16_Val          _U_(0x0)   /**< \brief (US_MR_SPI) 16x Oversampling */
+#define   US_MR_SPI_OVER_X8_Val           _U_(0x1)   /**< \brief (US_MR_SPI) 8x Oversampling */
 #define US_MR_SPI_OVER_X16          (US_MR_SPI_OVER_X16_Val        << US_MR_SPI_OVER_Pos)
 #define US_MR_SPI_OVER_X8           (US_MR_SPI_OVER_X8_Val         << US_MR_SPI_OVER_Pos)
 #define US_MR_SPI_INACK_Pos         20           /**< \brief (US_MR_SPI) Inhibit Non Acknowledge */
-#define US_MR_SPI_INACK             (_U(0x1) << US_MR_SPI_INACK_Pos)
-#define   US_MR_SPI_INACK_0_Val           _U(0x0)   /**< \brief (US_MR_SPI) The NACK is generated */
-#define   US_MR_SPI_INACK_1_Val           _U(0x1)   /**< \brief (US_MR_SPI) The NACK is not generated */
+#define US_MR_SPI_INACK             (_U_(0x1) << US_MR_SPI_INACK_Pos)
+#define   US_MR_SPI_INACK_0_Val           _U_(0x0)   /**< \brief (US_MR_SPI) The NACK is generated */
+#define   US_MR_SPI_INACK_1_Val           _U_(0x1)   /**< \brief (US_MR_SPI) The NACK is not generated */
 #define US_MR_SPI_INACK_0           (US_MR_SPI_INACK_0_Val         << US_MR_SPI_INACK_Pos)
 #define US_MR_SPI_INACK_1           (US_MR_SPI_INACK_1_Val         << US_MR_SPI_INACK_Pos)
 #define US_MR_SPI_DSNACK_Pos        21           /**< \brief (US_MR_SPI) Disable Successive NACK */
-#define US_MR_SPI_DSNACK            (_U(0x1) << US_MR_SPI_DSNACK_Pos)
-#define   US_MR_SPI_DSNACK_0_Val          _U(0x0)   /**< \brief (US_MR_SPI) NACK is sent on the ISO line as soon as a parity error occurs in the received character (unless INACK is set) */
-#define   US_MR_SPI_DSNACK_1_Val          _U(0x1)   /**< \brief (US_MR_SPI) Successive parity errors are counted up to the value specified in the MAX_ITERATION field. These parity errors generatea NACK on the ISO line. As soon as this value is reached, no additional NACK is sent on the ISO line. The flag ITERATION is asserted */
+#define US_MR_SPI_DSNACK            (_U_(0x1) << US_MR_SPI_DSNACK_Pos)
+#define   US_MR_SPI_DSNACK_0_Val          _U_(0x0)   /**< \brief (US_MR_SPI) NACK is sent on the ISO line as soon as a parity error occurs in the received character (unless INACK is set) */
+#define   US_MR_SPI_DSNACK_1_Val          _U_(0x1)   /**< \brief (US_MR_SPI) Successive parity errors are counted up to the value specified in the MAX_ITERATION field. These parity errors generatea NACK on the ISO line. As soon as this value is reached, no additional NACK is sent on the ISO line. The flag ITERATION is asserted */
 #define US_MR_SPI_DSNACK_0          (US_MR_SPI_DSNACK_0_Val        << US_MR_SPI_DSNACK_Pos)
 #define US_MR_SPI_DSNACK_1          (US_MR_SPI_DSNACK_1_Val        << US_MR_SPI_DSNACK_Pos)
 #define US_MR_SPI_INVDATA_Pos       23           /**< \brief (US_MR_SPI) Inverted data */
-#define US_MR_SPI_INVDATA           (_U(0x1) << US_MR_SPI_INVDATA_Pos)
+#define US_MR_SPI_INVDATA           (_U_(0x1) << US_MR_SPI_INVDATA_Pos)
 #define US_MR_SPI_MAX_ITERATION_Pos 24           /**< \brief (US_MR_SPI) Max interation */
-#define US_MR_SPI_MAX_ITERATION_Msk (_U(0x7) << US_MR_SPI_MAX_ITERATION_Pos)
+#define US_MR_SPI_MAX_ITERATION_Msk (_U_(0x7) << US_MR_SPI_MAX_ITERATION_Pos)
 #define US_MR_SPI_MAX_ITERATION(value) (US_MR_SPI_MAX_ITERATION_Msk & ((value) << US_MR_SPI_MAX_ITERATION_Pos))
 #define US_MR_SPI_FILTER_Pos        28           /**< \brief (US_MR_SPI) Infrared Receive Line Filter */
-#define US_MR_SPI_FILTER            (_U(0x1) << US_MR_SPI_FILTER_Pos)
-#define   US_MR_SPI_FILTER_0_Val          _U(0x0)   /**< \brief (US_MR_SPI) The USART does not filter the receive line */
-#define   US_MR_SPI_FILTER_1_Val          _U(0x1)   /**< \brief (US_MR_SPI) The USART filters the receive line using a three-sample filter (1/16-bit clock) (2 over 3 majority) */
+#define US_MR_SPI_FILTER            (_U_(0x1) << US_MR_SPI_FILTER_Pos)
+#define   US_MR_SPI_FILTER_0_Val          _U_(0x0)   /**< \brief (US_MR_SPI) The USART does not filter the receive line */
+#define   US_MR_SPI_FILTER_1_Val          _U_(0x1)   /**< \brief (US_MR_SPI) The USART filters the receive line using a three-sample filter (1/16-bit clock) (2 over 3 majority) */
 #define US_MR_SPI_FILTER_0          (US_MR_SPI_FILTER_0_Val        << US_MR_SPI_FILTER_Pos)
 #define US_MR_SPI_FILTER_1          (US_MR_SPI_FILTER_1_Val        << US_MR_SPI_FILTER_Pos)
-#define US_MR_SPI_MASK              _U(0x17BFFFFF) /**< \brief (US_MR_SPI) MASK Register */
+#define US_MR_SPI_MASK              _U_(0x17BFFFFF) /**< \brief (US_MR_SPI) MASK Register */
 
 // USART mode
 #define US_MR_USART_MODE_Pos        0            /**< \brief (US_MR_USART) Usart Mode */
-#define US_MR_USART_MODE_Msk        (_U(0xF) << US_MR_USART_MODE_Pos)
+#define US_MR_USART_MODE_Msk        (_U_(0xF) << US_MR_USART_MODE_Pos)
 #define US_MR_USART_MODE(value)     (US_MR_USART_MODE_Msk & ((value) << US_MR_USART_MODE_Pos))
-#define   US_MR_USART_MODE_NORMAL_Val     _U(0x0)   /**< \brief (US_MR_USART) Normal */
-#define   US_MR_USART_MODE_RS485_Val      _U(0x1)   /**< \brief (US_MR_USART) RS485 */
-#define   US_MR_USART_MODE_HARDWARE_Val   _U(0x2)   /**< \brief (US_MR_USART) Hardware Handshaking */
-#define   US_MR_USART_MODE_MODEM_Val      _U(0x3)   /**< \brief (US_MR_USART) Modem */
-#define   US_MR_USART_MODE_ISO7816_T0_Val _U(0x4)   /**< \brief (US_MR_USART) IS07816 Protocol: T = 0 */
-#define   US_MR_USART_MODE_ISO7816_T1_Val _U(0x6)   /**< \brief (US_MR_USART) IS07816 Protocol: T = 1 */
-#define   US_MR_USART_MODE_IRDA_Val       _U(0x8)   /**< \brief (US_MR_USART) IrDA */
-#define   US_MR_USART_MODE_LIN_MASTER_Val _U(0xA)   /**< \brief (US_MR_USART) LIN Master */
-#define   US_MR_USART_MODE_LIN_SLAVE_Val  _U(0xB)   /**< \brief (US_MR_USART) LIN Slave */
-#define   US_MR_USART_MODE_SPI_MASTER_Val _U(0xE)   /**< \brief (US_MR_USART) SPI Master */
-#define   US_MR_USART_MODE_SPI_SLAVE_Val  _U(0xF)   /**< \brief (US_MR_USART) SPI Slave */
+#define   US_MR_USART_MODE_NORMAL_Val     _U_(0x0)   /**< \brief (US_MR_USART) Normal */
+#define   US_MR_USART_MODE_RS485_Val      _U_(0x1)   /**< \brief (US_MR_USART) RS485 */
+#define   US_MR_USART_MODE_HARDWARE_Val   _U_(0x2)   /**< \brief (US_MR_USART) Hardware Handshaking */
+#define   US_MR_USART_MODE_MODEM_Val      _U_(0x3)   /**< \brief (US_MR_USART) Modem */
+#define   US_MR_USART_MODE_ISO7816_T0_Val _U_(0x4)   /**< \brief (US_MR_USART) IS07816 Protocol: T = 0 */
+#define   US_MR_USART_MODE_ISO7816_T1_Val _U_(0x6)   /**< \brief (US_MR_USART) IS07816 Protocol: T = 1 */
+#define   US_MR_USART_MODE_IRDA_Val       _U_(0x8)   /**< \brief (US_MR_USART) IrDA */
+#define   US_MR_USART_MODE_LIN_MASTER_Val _U_(0xA)   /**< \brief (US_MR_USART) LIN Master */
+#define   US_MR_USART_MODE_LIN_SLAVE_Val  _U_(0xB)   /**< \brief (US_MR_USART) LIN Slave */
+#define   US_MR_USART_MODE_SPI_MASTER_Val _U_(0xE)   /**< \brief (US_MR_USART) SPI Master */
+#define   US_MR_USART_MODE_SPI_SLAVE_Val  _U_(0xF)   /**< \brief (US_MR_USART) SPI Slave */
 #define US_MR_USART_MODE_NORMAL     (US_MR_USART_MODE_NORMAL_Val   << US_MR_USART_MODE_Pos)
 #define US_MR_USART_MODE_RS485      (US_MR_USART_MODE_RS485_Val    << US_MR_USART_MODE_Pos)
 #define US_MR_USART_MODE_HARDWARE   (US_MR_USART_MODE_HARDWARE_Val << US_MR_USART_MODE_Pos)
@@ -816,44 +816,44 @@ typedef union {
 #define US_MR_USART_MODE_SPI_MASTER (US_MR_USART_MODE_SPI_MASTER_Val << US_MR_USART_MODE_Pos)
 #define US_MR_USART_MODE_SPI_SLAVE  (US_MR_USART_MODE_SPI_SLAVE_Val << US_MR_USART_MODE_Pos)
 #define US_MR_USART_USCLKS_Pos      4            /**< \brief (US_MR_USART) Clock Selection */
-#define US_MR_USART_USCLKS_Msk      (_U(0x3) << US_MR_USART_USCLKS_Pos)
+#define US_MR_USART_USCLKS_Msk      (_U_(0x3) << US_MR_USART_USCLKS_Pos)
 #define US_MR_USART_USCLKS(value)   (US_MR_USART_USCLKS_Msk & ((value) << US_MR_USART_USCLKS_Pos))
-#define   US_MR_USART_USCLKS_MCK_Val      _U(0x0)   /**< \brief (US_MR_USART) MCK */
-#define   US_MR_USART_USCLKS_MCK_DIV_Val  _U(0x1)   /**< \brief (US_MR_USART) MCK / DIV */
-#define   US_MR_USART_USCLKS_2_Val        _U(0x2)   /**< \brief (US_MR_USART) Reserved */
-#define   US_MR_USART_USCLKS_SCK_Val      _U(0x3)   /**< \brief (US_MR_USART) SCK */
+#define   US_MR_USART_USCLKS_MCK_Val      _U_(0x0)   /**< \brief (US_MR_USART) MCK */
+#define   US_MR_USART_USCLKS_MCK_DIV_Val  _U_(0x1)   /**< \brief (US_MR_USART) MCK / DIV */
+#define   US_MR_USART_USCLKS_2_Val        _U_(0x2)   /**< \brief (US_MR_USART) Reserved */
+#define   US_MR_USART_USCLKS_SCK_Val      _U_(0x3)   /**< \brief (US_MR_USART) SCK */
 #define US_MR_USART_USCLKS_MCK      (US_MR_USART_USCLKS_MCK_Val    << US_MR_USART_USCLKS_Pos)
 #define US_MR_USART_USCLKS_MCK_DIV  (US_MR_USART_USCLKS_MCK_DIV_Val << US_MR_USART_USCLKS_Pos)
 #define US_MR_USART_USCLKS_2        (US_MR_USART_USCLKS_2_Val      << US_MR_USART_USCLKS_Pos)
 #define US_MR_USART_USCLKS_SCK      (US_MR_USART_USCLKS_SCK_Val    << US_MR_USART_USCLKS_Pos)
 #define US_MR_USART_CHRL_Pos        6            /**< \brief (US_MR_USART) Character Length. */
-#define US_MR_USART_CHRL_Msk        (_U(0x3) << US_MR_USART_CHRL_Pos)
+#define US_MR_USART_CHRL_Msk        (_U_(0x3) << US_MR_USART_CHRL_Pos)
 #define US_MR_USART_CHRL(value)     (US_MR_USART_CHRL_Msk & ((value) << US_MR_USART_CHRL_Pos))
-#define   US_MR_USART_CHRL_5_Val          _U(0x0)   /**< \brief (US_MR_USART) 5 bits */
-#define   US_MR_USART_CHRL_6_Val          _U(0x1)   /**< \brief (US_MR_USART) 6 bits */
-#define   US_MR_USART_CHRL_7_Val          _U(0x2)   /**< \brief (US_MR_USART) 7 bits */
-#define   US_MR_USART_CHRL_8_Val          _U(0x3)   /**< \brief (US_MR_USART) 8 bits */
+#define   US_MR_USART_CHRL_5_Val          _U_(0x0)   /**< \brief (US_MR_USART) 5 bits */
+#define   US_MR_USART_CHRL_6_Val          _U_(0x1)   /**< \brief (US_MR_USART) 6 bits */
+#define   US_MR_USART_CHRL_7_Val          _U_(0x2)   /**< \brief (US_MR_USART) 7 bits */
+#define   US_MR_USART_CHRL_8_Val          _U_(0x3)   /**< \brief (US_MR_USART) 8 bits */
 #define US_MR_USART_CHRL_5          (US_MR_USART_CHRL_5_Val        << US_MR_USART_CHRL_Pos)
 #define US_MR_USART_CHRL_6          (US_MR_USART_CHRL_6_Val        << US_MR_USART_CHRL_Pos)
 #define US_MR_USART_CHRL_7          (US_MR_USART_CHRL_7_Val        << US_MR_USART_CHRL_Pos)
 #define US_MR_USART_CHRL_8          (US_MR_USART_CHRL_8_Val        << US_MR_USART_CHRL_Pos)
 #define US_MR_USART_SYNC_Pos        8            /**< \brief (US_MR_USART) Synchronous Mode Select */
-#define US_MR_USART_SYNC            (_U(0x1) << US_MR_USART_SYNC_Pos)
-#define   US_MR_USART_SYNC_0_Val          _U(0x0)   /**< \brief (US_MR_USART) USART operates in Synchronous Mode */
-#define   US_MR_USART_SYNC_1_Val          _U(0x1)   /**< \brief (US_MR_USART) USART operates in Asynchronous Mode */
+#define US_MR_USART_SYNC            (_U_(0x1) << US_MR_USART_SYNC_Pos)
+#define   US_MR_USART_SYNC_0_Val          _U_(0x0)   /**< \brief (US_MR_USART) USART operates in Synchronous Mode */
+#define   US_MR_USART_SYNC_1_Val          _U_(0x1)   /**< \brief (US_MR_USART) USART operates in Asynchronous Mode */
 #define US_MR_USART_SYNC_0          (US_MR_USART_SYNC_0_Val        << US_MR_USART_SYNC_Pos)
 #define US_MR_USART_SYNC_1          (US_MR_USART_SYNC_1_Val        << US_MR_USART_SYNC_Pos)
 #define US_MR_USART_PAR_Pos         9            /**< \brief (US_MR_USART) Parity Type */
-#define US_MR_USART_PAR_Msk         (_U(0x7) << US_MR_USART_PAR_Pos)
+#define US_MR_USART_PAR_Msk         (_U_(0x7) << US_MR_USART_PAR_Pos)
 #define US_MR_USART_PAR(value)      (US_MR_USART_PAR_Msk & ((value) << US_MR_USART_PAR_Pos))
-#define   US_MR_USART_PAR_EVEN_Val        _U(0x0)   /**< \brief (US_MR_USART) Even parity */
-#define   US_MR_USART_PAR_ODD_Val         _U(0x1)   /**< \brief (US_MR_USART) Odd parity */
-#define   US_MR_USART_PAR_SPACE_Val       _U(0x2)   /**< \brief (US_MR_USART) Parity forced to 0 (Space) */
-#define   US_MR_USART_PAR_MARK_Val        _U(0x3)   /**< \brief (US_MR_USART) Parity forced to 1 (Mark) */
-#define   US_MR_USART_PAR_NONE_Val        _U(0x4)   /**< \brief (US_MR_USART) No Parity */
-#define   US_MR_USART_PAR_5_Val           _U(0x5)   /**< \brief (US_MR_USART) No Parity */
-#define   US_MR_USART_PAR_MULTI_Val       _U(0x6)   /**< \brief (US_MR_USART) Multi-drop mode */
-#define   US_MR_USART_PAR_7_Val           _U(0x7)   /**< \brief (US_MR_USART) Multi-drop mode */
+#define   US_MR_USART_PAR_EVEN_Val        _U_(0x0)   /**< \brief (US_MR_USART) Even parity */
+#define   US_MR_USART_PAR_ODD_Val         _U_(0x1)   /**< \brief (US_MR_USART) Odd parity */
+#define   US_MR_USART_PAR_SPACE_Val       _U_(0x2)   /**< \brief (US_MR_USART) Parity forced to 0 (Space) */
+#define   US_MR_USART_PAR_MARK_Val        _U_(0x3)   /**< \brief (US_MR_USART) Parity forced to 1 (Mark) */
+#define   US_MR_USART_PAR_NONE_Val        _U_(0x4)   /**< \brief (US_MR_USART) No Parity */
+#define   US_MR_USART_PAR_5_Val           _U_(0x5)   /**< \brief (US_MR_USART) No Parity */
+#define   US_MR_USART_PAR_MULTI_Val       _U_(0x6)   /**< \brief (US_MR_USART) Multi-drop mode */
+#define   US_MR_USART_PAR_7_Val           _U_(0x7)   /**< \brief (US_MR_USART) Multi-drop mode */
 #define US_MR_USART_PAR_EVEN        (US_MR_USART_PAR_EVEN_Val      << US_MR_USART_PAR_Pos)
 #define US_MR_USART_PAR_ODD         (US_MR_USART_PAR_ODD_Val       << US_MR_USART_PAR_Pos)
 #define US_MR_USART_PAR_SPACE       (US_MR_USART_PAR_SPACE_Val     << US_MR_USART_PAR_Pos)
@@ -863,115 +863,115 @@ typedef union {
 #define US_MR_USART_PAR_MULTI       (US_MR_USART_PAR_MULTI_Val     << US_MR_USART_PAR_Pos)
 #define US_MR_USART_PAR_7           (US_MR_USART_PAR_7_Val         << US_MR_USART_PAR_Pos)
 #define US_MR_USART_NBSTOP_Pos      12           /**< \brief (US_MR_USART) Number of Stop Bits */
-#define US_MR_USART_NBSTOP_Msk      (_U(0x3) << US_MR_USART_NBSTOP_Pos)
+#define US_MR_USART_NBSTOP_Msk      (_U_(0x3) << US_MR_USART_NBSTOP_Pos)
 #define US_MR_USART_NBSTOP(value)   (US_MR_USART_NBSTOP_Msk & ((value) << US_MR_USART_NBSTOP_Pos))
-#define   US_MR_USART_NBSTOP_1_Val        _U(0x0)   /**< \brief (US_MR_USART) 1 stop bit */
-#define   US_MR_USART_NBSTOP_1_5_Val      _U(0x1)   /**< \brief (US_MR_USART) 1.5 stop bits (Only valid if SYNC=0) */
-#define   US_MR_USART_NBSTOP_2_Val        _U(0x2)   /**< \brief (US_MR_USART) 2 stop bits */
-#define   US_MR_USART_NBSTOP_3_Val        _U(0x3)   /**< \brief (US_MR_USART) Reserved */
+#define   US_MR_USART_NBSTOP_1_Val        _U_(0x0)   /**< \brief (US_MR_USART) 1 stop bit */
+#define   US_MR_USART_NBSTOP_1_5_Val      _U_(0x1)   /**< \brief (US_MR_USART) 1.5 stop bits (Only valid if SYNC=0) */
+#define   US_MR_USART_NBSTOP_2_Val        _U_(0x2)   /**< \brief (US_MR_USART) 2 stop bits */
+#define   US_MR_USART_NBSTOP_3_Val        _U_(0x3)   /**< \brief (US_MR_USART) Reserved */
 #define US_MR_USART_NBSTOP_1        (US_MR_USART_NBSTOP_1_Val      << US_MR_USART_NBSTOP_Pos)
 #define US_MR_USART_NBSTOP_1_5      (US_MR_USART_NBSTOP_1_5_Val    << US_MR_USART_NBSTOP_Pos)
 #define US_MR_USART_NBSTOP_2        (US_MR_USART_NBSTOP_2_Val      << US_MR_USART_NBSTOP_Pos)
 #define US_MR_USART_NBSTOP_3        (US_MR_USART_NBSTOP_3_Val      << US_MR_USART_NBSTOP_Pos)
 #define US_MR_USART_CHMODE_Pos      14           /**< \brief (US_MR_USART) Channel Mode */
-#define US_MR_USART_CHMODE_Msk      (_U(0x3) << US_MR_USART_CHMODE_Pos)
+#define US_MR_USART_CHMODE_Msk      (_U_(0x3) << US_MR_USART_CHMODE_Pos)
 #define US_MR_USART_CHMODE(value)   (US_MR_USART_CHMODE_Msk & ((value) << US_MR_USART_CHMODE_Pos))
-#define   US_MR_USART_CHMODE_NORMAL_Val   _U(0x0)   /**< \brief (US_MR_USART) Normal Mode */
-#define   US_MR_USART_CHMODE_ECHO_Val     _U(0x1)   /**< \brief (US_MR_USART) Automatic Echo. Receiver input is connected to the TXD pin */
-#define   US_MR_USART_CHMODE_LOCAL_LOOP_Val _U(0x2)   /**< \brief (US_MR_USART) Local Loopback. Transmitter output is connected to the Receiver Input */
-#define   US_MR_USART_CHMODE_REMOTE_LOOP_Val _U(0x3)   /**< \brief (US_MR_USART) Remote Loopback. RXD pin is internally connected to the TXD pin */
+#define   US_MR_USART_CHMODE_NORMAL_Val   _U_(0x0)   /**< \brief (US_MR_USART) Normal Mode */
+#define   US_MR_USART_CHMODE_ECHO_Val     _U_(0x1)   /**< \brief (US_MR_USART) Automatic Echo. Receiver input is connected to the TXD pin */
+#define   US_MR_USART_CHMODE_LOCAL_LOOP_Val _U_(0x2)   /**< \brief (US_MR_USART) Local Loopback. Transmitter output is connected to the Receiver Input */
+#define   US_MR_USART_CHMODE_REMOTE_LOOP_Val _U_(0x3)   /**< \brief (US_MR_USART) Remote Loopback. RXD pin is internally connected to the TXD pin */
 #define US_MR_USART_CHMODE_NORMAL   (US_MR_USART_CHMODE_NORMAL_Val << US_MR_USART_CHMODE_Pos)
 #define US_MR_USART_CHMODE_ECHO     (US_MR_USART_CHMODE_ECHO_Val   << US_MR_USART_CHMODE_Pos)
 #define US_MR_USART_CHMODE_LOCAL_LOOP (US_MR_USART_CHMODE_LOCAL_LOOP_Val << US_MR_USART_CHMODE_Pos)
 #define US_MR_USART_CHMODE_REMOTE_LOOP (US_MR_USART_CHMODE_REMOTE_LOOP_Val << US_MR_USART_CHMODE_Pos)
 #define US_MR_USART_MSBF_Pos        16           /**< \brief (US_MR_USART) Bit Order */
-#define US_MR_USART_MSBF            (_U(0x1) << US_MR_USART_MSBF_Pos)
-#define   US_MR_USART_MSBF_LSBF_Val       _U(0x0)   /**< \brief (US_MR_USART) Least Significant Bit first */
-#define   US_MR_USART_MSBF_MSBF_Val       _U(0x1)   /**< \brief (US_MR_USART) Most Significant Bit first */
+#define US_MR_USART_MSBF            (_U_(0x1) << US_MR_USART_MSBF_Pos)
+#define   US_MR_USART_MSBF_LSBF_Val       _U_(0x0)   /**< \brief (US_MR_USART) Least Significant Bit first */
+#define   US_MR_USART_MSBF_MSBF_Val       _U_(0x1)   /**< \brief (US_MR_USART) Most Significant Bit first */
 #define US_MR_USART_MSBF_LSBF       (US_MR_USART_MSBF_LSBF_Val     << US_MR_USART_MSBF_Pos)
 #define US_MR_USART_MSBF_MSBF       (US_MR_USART_MSBF_MSBF_Val     << US_MR_USART_MSBF_Pos)
 #define US_MR_USART_MODE9_Pos       17           /**< \brief (US_MR_USART) 9-bit Character Length */
-#define US_MR_USART_MODE9           (_U(0x1) << US_MR_USART_MODE9_Pos)
-#define   US_MR_USART_MODE9_0_Val         _U(0x0)   /**< \brief (US_MR_USART) CHRL defines character length */
-#define   US_MR_USART_MODE9_1_Val         _U(0x1)   /**< \brief (US_MR_USART) 9-bit character length */
+#define US_MR_USART_MODE9           (_U_(0x1) << US_MR_USART_MODE9_Pos)
+#define   US_MR_USART_MODE9_0_Val         _U_(0x0)   /**< \brief (US_MR_USART) CHRL defines character length */
+#define   US_MR_USART_MODE9_1_Val         _U_(0x1)   /**< \brief (US_MR_USART) 9-bit character length */
 #define US_MR_USART_MODE9_0         (US_MR_USART_MODE9_0_Val       << US_MR_USART_MODE9_Pos)
 #define US_MR_USART_MODE9_1         (US_MR_USART_MODE9_1_Val       << US_MR_USART_MODE9_Pos)
 #define US_MR_USART_CLKO_Pos        18           /**< \brief (US_MR_USART) Clock Output Select */
-#define US_MR_USART_CLKO            (_U(0x1) << US_MR_USART_CLKO_Pos)
-#define   US_MR_USART_CLKO_0_Val          _U(0x0)   /**< \brief (US_MR_USART) The USART does not drive the SCK pin */
-#define   US_MR_USART_CLKO_1_Val          _U(0x1)   /**< \brief (US_MR_USART) The USART drives the SCK pin if USCLKS does not select the external clock SCK */
+#define US_MR_USART_CLKO            (_U_(0x1) << US_MR_USART_CLKO_Pos)
+#define   US_MR_USART_CLKO_0_Val          _U_(0x0)   /**< \brief (US_MR_USART) The USART does not drive the SCK pin */
+#define   US_MR_USART_CLKO_1_Val          _U_(0x1)   /**< \brief (US_MR_USART) The USART drives the SCK pin if USCLKS does not select the external clock SCK */
 #define US_MR_USART_CLKO_0          (US_MR_USART_CLKO_0_Val        << US_MR_USART_CLKO_Pos)
 #define US_MR_USART_CLKO_1          (US_MR_USART_CLKO_1_Val        << US_MR_USART_CLKO_Pos)
 #define US_MR_USART_OVER_Pos        19           /**< \brief (US_MR_USART) Oversampling Mode */
-#define US_MR_USART_OVER            (_U(0x1) << US_MR_USART_OVER_Pos)
-#define   US_MR_USART_OVER_X16_Val        _U(0x0)   /**< \brief (US_MR_USART) 16x Oversampling */
-#define   US_MR_USART_OVER_X8_Val         _U(0x1)   /**< \brief (US_MR_USART) 8x Oversampling */
+#define US_MR_USART_OVER            (_U_(0x1) << US_MR_USART_OVER_Pos)
+#define   US_MR_USART_OVER_X16_Val        _U_(0x0)   /**< \brief (US_MR_USART) 16x Oversampling */
+#define   US_MR_USART_OVER_X8_Val         _U_(0x1)   /**< \brief (US_MR_USART) 8x Oversampling */
 #define US_MR_USART_OVER_X16        (US_MR_USART_OVER_X16_Val      << US_MR_USART_OVER_Pos)
 #define US_MR_USART_OVER_X8         (US_MR_USART_OVER_X8_Val       << US_MR_USART_OVER_Pos)
 #define US_MR_USART_INACK_Pos       20           /**< \brief (US_MR_USART) Inhibit Non Acknowledge */
-#define US_MR_USART_INACK           (_U(0x1) << US_MR_USART_INACK_Pos)
-#define   US_MR_USART_INACK_0_Val         _U(0x0)   /**< \brief (US_MR_USART) The NACK is generated */
-#define   US_MR_USART_INACK_1_Val         _U(0x1)   /**< \brief (US_MR_USART) The NACK is not generated */
+#define US_MR_USART_INACK           (_U_(0x1) << US_MR_USART_INACK_Pos)
+#define   US_MR_USART_INACK_0_Val         _U_(0x0)   /**< \brief (US_MR_USART) The NACK is generated */
+#define   US_MR_USART_INACK_1_Val         _U_(0x1)   /**< \brief (US_MR_USART) The NACK is not generated */
 #define US_MR_USART_INACK_0         (US_MR_USART_INACK_0_Val       << US_MR_USART_INACK_Pos)
 #define US_MR_USART_INACK_1         (US_MR_USART_INACK_1_Val       << US_MR_USART_INACK_Pos)
 #define US_MR_USART_DSNACK_Pos      21           /**< \brief (US_MR_USART) Disable Successive NACK */
-#define US_MR_USART_DSNACK          (_U(0x1) << US_MR_USART_DSNACK_Pos)
-#define   US_MR_USART_DSNACK_0_Val        _U(0x0)   /**< \brief (US_MR_USART) NACK is sent on the ISO line as soon as a parity error occurs in the received character (unless INACK is set) */
-#define   US_MR_USART_DSNACK_1_Val        _U(0x1)   /**< \brief (US_MR_USART) Successive parity errors are counted up to the value specified in the MAX_ITERATION field. These parity errors generatea NACK on the ISO line. As soon as this value is reached, no additional NACK is sent on the ISO line. The flag ITERATION is asserted */
+#define US_MR_USART_DSNACK          (_U_(0x1) << US_MR_USART_DSNACK_Pos)
+#define   US_MR_USART_DSNACK_0_Val        _U_(0x0)   /**< \brief (US_MR_USART) NACK is sent on the ISO line as soon as a parity error occurs in the received character (unless INACK is set) */
+#define   US_MR_USART_DSNACK_1_Val        _U_(0x1)   /**< \brief (US_MR_USART) Successive parity errors are counted up to the value specified in the MAX_ITERATION field. These parity errors generatea NACK on the ISO line. As soon as this value is reached, no additional NACK is sent on the ISO line. The flag ITERATION is asserted */
 #define US_MR_USART_DSNACK_0        (US_MR_USART_DSNACK_0_Val      << US_MR_USART_DSNACK_Pos)
 #define US_MR_USART_DSNACK_1        (US_MR_USART_DSNACK_1_Val      << US_MR_USART_DSNACK_Pos)
 #define US_MR_USART_VAR_SYNC_Pos    22           /**< \brief (US_MR_USART) Variable synchronization of command/data sync Start Frame Delimiter */
-#define US_MR_USART_VAR_SYNC        (_U(0x1) << US_MR_USART_VAR_SYNC_Pos)
-#define   US_MR_USART_VAR_SYNC_0_Val      _U(0x0)   /**< \brief (US_MR_USART) User defined configuration of command or data sync field depending on SYNC value */
-#define   US_MR_USART_VAR_SYNC_1_Val      _U(0x1)   /**< \brief (US_MR_USART) The sync field is updated when a character is written into THR register */
+#define US_MR_USART_VAR_SYNC        (_U_(0x1) << US_MR_USART_VAR_SYNC_Pos)
+#define   US_MR_USART_VAR_SYNC_0_Val      _U_(0x0)   /**< \brief (US_MR_USART) User defined configuration of command or data sync field depending on SYNC value */
+#define   US_MR_USART_VAR_SYNC_1_Val      _U_(0x1)   /**< \brief (US_MR_USART) The sync field is updated when a character is written into THR register */
 #define US_MR_USART_VAR_SYNC_0      (US_MR_USART_VAR_SYNC_0_Val    << US_MR_USART_VAR_SYNC_Pos)
 #define US_MR_USART_VAR_SYNC_1      (US_MR_USART_VAR_SYNC_1_Val    << US_MR_USART_VAR_SYNC_Pos)
 #define US_MR_USART_INVDATA_Pos     23           /**< \brief (US_MR_USART) Inverted data */
-#define US_MR_USART_INVDATA         (_U(0x1) << US_MR_USART_INVDATA_Pos)
+#define US_MR_USART_INVDATA         (_U_(0x1) << US_MR_USART_INVDATA_Pos)
 #define US_MR_USART_MAX_ITERATION_Pos 24           /**< \brief (US_MR_USART) Max interation */
-#define US_MR_USART_MAX_ITERATION_Msk (_U(0x7) << US_MR_USART_MAX_ITERATION_Pos)
+#define US_MR_USART_MAX_ITERATION_Msk (_U_(0x7) << US_MR_USART_MAX_ITERATION_Pos)
 #define US_MR_USART_MAX_ITERATION(value) (US_MR_USART_MAX_ITERATION_Msk & ((value) << US_MR_USART_MAX_ITERATION_Pos))
 #define US_MR_USART_FILTER_Pos      28           /**< \brief (US_MR_USART) Infrared Receive Line Filter */
-#define US_MR_USART_FILTER          (_U(0x1) << US_MR_USART_FILTER_Pos)
-#define   US_MR_USART_FILTER_0_Val        _U(0x0)   /**< \brief (US_MR_USART) The USART does not filter the receive line */
-#define   US_MR_USART_FILTER_1_Val        _U(0x1)   /**< \brief (US_MR_USART) The USART filters the receive line using a three-sample filter (1/16-bit clock) (2 over 3 majority) */
+#define US_MR_USART_FILTER          (_U_(0x1) << US_MR_USART_FILTER_Pos)
+#define   US_MR_USART_FILTER_0_Val        _U_(0x0)   /**< \brief (US_MR_USART) The USART does not filter the receive line */
+#define   US_MR_USART_FILTER_1_Val        _U_(0x1)   /**< \brief (US_MR_USART) The USART filters the receive line using a three-sample filter (1/16-bit clock) (2 over 3 majority) */
 #define US_MR_USART_FILTER_0        (US_MR_USART_FILTER_0_Val      << US_MR_USART_FILTER_Pos)
 #define US_MR_USART_FILTER_1        (US_MR_USART_FILTER_1_Val      << US_MR_USART_FILTER_Pos)
 #define US_MR_USART_MAN_Pos         29           /**< \brief (US_MR_USART) Manchester Encoder/Decoder Enable */
-#define US_MR_USART_MAN             (_U(0x1) << US_MR_USART_MAN_Pos)
-#define   US_MR_USART_MAN_0_Val           _U(0x0)   /**< \brief (US_MR_USART) Manchester Encoder/Decoder is disabled */
-#define   US_MR_USART_MAN_1_Val           _U(0x1)   /**< \brief (US_MR_USART) Manchester Encoder/Decoder is enabled */
+#define US_MR_USART_MAN             (_U_(0x1) << US_MR_USART_MAN_Pos)
+#define   US_MR_USART_MAN_0_Val           _U_(0x0)   /**< \brief (US_MR_USART) Manchester Encoder/Decoder is disabled */
+#define   US_MR_USART_MAN_1_Val           _U_(0x1)   /**< \brief (US_MR_USART) Manchester Encoder/Decoder is enabled */
 #define US_MR_USART_MAN_0           (US_MR_USART_MAN_0_Val         << US_MR_USART_MAN_Pos)
 #define US_MR_USART_MAN_1           (US_MR_USART_MAN_1_Val         << US_MR_USART_MAN_Pos)
 #define US_MR_USART_MODSYNC_Pos     30           /**< \brief (US_MR_USART) Manchester Synchronization Mode */
-#define US_MR_USART_MODSYNC         (_U(0x1) << US_MR_USART_MODSYNC_Pos)
-#define   US_MR_USART_MODSYNC_0_Val       _U(0x0)   /**< \brief (US_MR_USART) The Manchester Start bit is a 0 to 1 transition */
-#define   US_MR_USART_MODSYNC_1_Val       _U(0x1)   /**< \brief (US_MR_USART) The Manchester Start bit is a 1 to 0 transition */
+#define US_MR_USART_MODSYNC         (_U_(0x1) << US_MR_USART_MODSYNC_Pos)
+#define   US_MR_USART_MODSYNC_0_Val       _U_(0x0)   /**< \brief (US_MR_USART) The Manchester Start bit is a 0 to 1 transition */
+#define   US_MR_USART_MODSYNC_1_Val       _U_(0x1)   /**< \brief (US_MR_USART) The Manchester Start bit is a 1 to 0 transition */
 #define US_MR_USART_MODSYNC_0       (US_MR_USART_MODSYNC_0_Val     << US_MR_USART_MODSYNC_Pos)
 #define US_MR_USART_MODSYNC_1       (US_MR_USART_MODSYNC_1_Val     << US_MR_USART_MODSYNC_Pos)
 #define US_MR_USART_ONEBIT_Pos      31           /**< \brief (US_MR_USART) Start Frame Delimiter selector */
-#define US_MR_USART_ONEBIT          (_U(0x1) << US_MR_USART_ONEBIT_Pos)
-#define   US_MR_USART_ONEBIT_0_Val        _U(0x0)   /**< \brief (US_MR_USART) Start Frame delimiter is COMMAND or DATA SYNC */
-#define   US_MR_USART_ONEBIT_1_Val        _U(0x1)   /**< \brief (US_MR_USART) Start Frame delimiter is One Bit */
+#define US_MR_USART_ONEBIT          (_U_(0x1) << US_MR_USART_ONEBIT_Pos)
+#define   US_MR_USART_ONEBIT_0_Val        _U_(0x0)   /**< \brief (US_MR_USART) Start Frame delimiter is COMMAND or DATA SYNC */
+#define   US_MR_USART_ONEBIT_1_Val        _U_(0x1)   /**< \brief (US_MR_USART) Start Frame delimiter is One Bit */
 #define US_MR_USART_ONEBIT_0        (US_MR_USART_ONEBIT_0_Val      << US_MR_USART_ONEBIT_Pos)
 #define US_MR_USART_ONEBIT_1        (US_MR_USART_ONEBIT_1_Val      << US_MR_USART_ONEBIT_Pos)
-#define US_MR_USART_MASK            _U(0xF7FFFFFF) /**< \brief (US_MR_USART) MASK Register */
+#define US_MR_USART_MASK            _U_(0xF7FFFFFF) /**< \brief (US_MR_USART) MASK Register */
 
 // Any mode
 #define US_MR_MODE_Pos              0            /**< \brief (US_MR) Usart Mode */
-#define US_MR_MODE_Msk              (_U(0xF) << US_MR_MODE_Pos)
+#define US_MR_MODE_Msk              (_U_(0xF) << US_MR_MODE_Pos)
 #define US_MR_MODE(value)           (US_MR_MODE_Msk & ((value) << US_MR_MODE_Pos))
-#define   US_MR_MODE_NORMAL_Val           _U(0x0)   /**< \brief (US_MR) Normal */
-#define   US_MR_MODE_RS485_Val            _U(0x1)   /**< \brief (US_MR) RS485 */
-#define   US_MR_MODE_HARDWARE_Val         _U(0x2)   /**< \brief (US_MR) Hardware Handshaking */
-#define   US_MR_MODE_MODEM_Val            _U(0x3)   /**< \brief (US_MR) Modem */
-#define   US_MR_MODE_ISO7816_T0_Val       _U(0x4)   /**< \brief (US_MR) IS07816 Protocol: T = 0 */
-#define   US_MR_MODE_ISO7816_T1_Val       _U(0x6)   /**< \brief (US_MR) IS07816 Protocol: T = 1 */
-#define   US_MR_MODE_IRDA_Val             _U(0x8)   /**< \brief (US_MR) IrDA */
-#define   US_MR_MODE_LIN_MASTER_Val       _U(0xA)   /**< \brief (US_MR) LIN Master */
-#define   US_MR_MODE_LIN_SLAVE_Val        _U(0xB)   /**< \brief (US_MR) LIN Slave */
-#define   US_MR_MODE_SPI_MASTER_Val       _U(0xE)   /**< \brief (US_MR) SPI Master */
-#define   US_MR_MODE_SPI_SLAVE_Val        _U(0xF)   /**< \brief (US_MR) SPI Slave */
+#define   US_MR_MODE_NORMAL_Val           _U_(0x0)   /**< \brief (US_MR) Normal */
+#define   US_MR_MODE_RS485_Val            _U_(0x1)   /**< \brief (US_MR) RS485 */
+#define   US_MR_MODE_HARDWARE_Val         _U_(0x2)   /**< \brief (US_MR) Hardware Handshaking */
+#define   US_MR_MODE_MODEM_Val            _U_(0x3)   /**< \brief (US_MR) Modem */
+#define   US_MR_MODE_ISO7816_T0_Val       _U_(0x4)   /**< \brief (US_MR) IS07816 Protocol: T = 0 */
+#define   US_MR_MODE_ISO7816_T1_Val       _U_(0x6)   /**< \brief (US_MR) IS07816 Protocol: T = 1 */
+#define   US_MR_MODE_IRDA_Val             _U_(0x8)   /**< \brief (US_MR) IrDA */
+#define   US_MR_MODE_LIN_MASTER_Val       _U_(0xA)   /**< \brief (US_MR) LIN Master */
+#define   US_MR_MODE_LIN_SLAVE_Val        _U_(0xB)   /**< \brief (US_MR) LIN Slave */
+#define   US_MR_MODE_SPI_MASTER_Val       _U_(0xE)   /**< \brief (US_MR) SPI Master */
+#define   US_MR_MODE_SPI_SLAVE_Val        _U_(0xF)   /**< \brief (US_MR) SPI Slave */
 #define US_MR_MODE_NORMAL           (US_MR_MODE_NORMAL_Val         << US_MR_MODE_Pos)
 #define US_MR_MODE_RS485            (US_MR_MODE_RS485_Val          << US_MR_MODE_Pos)
 #define US_MR_MODE_HARDWARE         (US_MR_MODE_HARDWARE_Val       << US_MR_MODE_Pos)
@@ -984,50 +984,50 @@ typedef union {
 #define US_MR_MODE_SPI_MASTER       (US_MR_MODE_SPI_MASTER_Val     << US_MR_MODE_Pos)
 #define US_MR_MODE_SPI_SLAVE        (US_MR_MODE_SPI_SLAVE_Val      << US_MR_MODE_Pos)
 #define US_MR_USCLKS_Pos            4            /**< \brief (US_MR) Clock Selection */
-#define US_MR_USCLKS_Msk            (_U(0x3) << US_MR_USCLKS_Pos)
+#define US_MR_USCLKS_Msk            (_U_(0x3) << US_MR_USCLKS_Pos)
 #define US_MR_USCLKS(value)         (US_MR_USCLKS_Msk & ((value) << US_MR_USCLKS_Pos))
-#define   US_MR_USCLKS_MCK_Val            _U(0x0)   /**< \brief (US_MR) MCK */
-#define   US_MR_USCLKS_MCK_DIV_Val        _U(0x1)   /**< \brief (US_MR) MCK / DIV */
-#define   US_MR_USCLKS_2_Val              _U(0x2)   /**< \brief (US_MR) Reserved */
-#define   US_MR_USCLKS_SCK_Val            _U(0x3)   /**< \brief (US_MR) SCK */
+#define   US_MR_USCLKS_MCK_Val            _U_(0x0)   /**< \brief (US_MR) MCK */
+#define   US_MR_USCLKS_MCK_DIV_Val        _U_(0x1)   /**< \brief (US_MR) MCK / DIV */
+#define   US_MR_USCLKS_2_Val              _U_(0x2)   /**< \brief (US_MR) Reserved */
+#define   US_MR_USCLKS_SCK_Val            _U_(0x3)   /**< \brief (US_MR) SCK */
 #define US_MR_USCLKS_MCK            (US_MR_USCLKS_MCK_Val          << US_MR_USCLKS_Pos)
 #define US_MR_USCLKS_MCK_DIV        (US_MR_USCLKS_MCK_DIV_Val      << US_MR_USCLKS_Pos)
 #define US_MR_USCLKS_2              (US_MR_USCLKS_2_Val            << US_MR_USCLKS_Pos)
 #define US_MR_USCLKS_SCK            (US_MR_USCLKS_SCK_Val          << US_MR_USCLKS_Pos)
 #define US_MR_CHRL_Pos              6            /**< \brief (US_MR) Character Length. */
-#define US_MR_CHRL_Msk              (_U(0x3) << US_MR_CHRL_Pos)
+#define US_MR_CHRL_Msk              (_U_(0x3) << US_MR_CHRL_Pos)
 #define US_MR_CHRL(value)           (US_MR_CHRL_Msk & ((value) << US_MR_CHRL_Pos))
-#define   US_MR_CHRL_5_Val                _U(0x0)   /**< \brief (US_MR) 5 bits */
-#define   US_MR_CHRL_6_Val                _U(0x1)   /**< \brief (US_MR) 6 bits */
-#define   US_MR_CHRL_7_Val                _U(0x2)   /**< \brief (US_MR) 7 bits */
-#define   US_MR_CHRL_8_Val                _U(0x3)   /**< \brief (US_MR) 8 bits */
+#define   US_MR_CHRL_5_Val                _U_(0x0)   /**< \brief (US_MR) 5 bits */
+#define   US_MR_CHRL_6_Val                _U_(0x1)   /**< \brief (US_MR) 6 bits */
+#define   US_MR_CHRL_7_Val                _U_(0x2)   /**< \brief (US_MR) 7 bits */
+#define   US_MR_CHRL_8_Val                _U_(0x3)   /**< \brief (US_MR) 8 bits */
 #define US_MR_CHRL_5                (US_MR_CHRL_5_Val              << US_MR_CHRL_Pos)
 #define US_MR_CHRL_6                (US_MR_CHRL_6_Val              << US_MR_CHRL_Pos)
 #define US_MR_CHRL_7                (US_MR_CHRL_7_Val              << US_MR_CHRL_Pos)
 #define US_MR_CHRL_8                (US_MR_CHRL_8_Val              << US_MR_CHRL_Pos)
 #define US_MR_CPHA_Pos              8            /**< \brief (US_MR) SPI CLock Phase */
-#define US_MR_CPHA                  (_U(0x1) << US_MR_CPHA_Pos)
-#define   US_MR_CPHA_0_Val                _U(0x0)   /**< \brief (US_MR) Data is changed on the leading edge of SPCK and captured on the following edge of SPCK */
-#define   US_MR_CPHA_1_Val                _U(0x1)   /**< \brief (US_MR) Data is captured on the leading edge of SPCK and changed on the following edge of SPCK */
+#define US_MR_CPHA                  (_U_(0x1) << US_MR_CPHA_Pos)
+#define   US_MR_CPHA_0_Val                _U_(0x0)   /**< \brief (US_MR) Data is changed on the leading edge of SPCK and captured on the following edge of SPCK */
+#define   US_MR_CPHA_1_Val                _U_(0x1)   /**< \brief (US_MR) Data is captured on the leading edge of SPCK and changed on the following edge of SPCK */
 #define US_MR_CPHA_0                (US_MR_CPHA_0_Val              << US_MR_CPHA_Pos)
 #define US_MR_CPHA_1                (US_MR_CPHA_1_Val              << US_MR_CPHA_Pos)
 #define US_MR_SYNC_Pos              8            /**< \brief (US_MR) Synchronous Mode Select */
-#define US_MR_SYNC                  (_U(0x1) << US_MR_SYNC_Pos)
-#define   US_MR_SYNC_0_Val                _U(0x0)   /**< \brief (US_MR) USART operates in Synchronous Mode */
-#define   US_MR_SYNC_1_Val                _U(0x1)   /**< \brief (US_MR) USART operates in Asynchronous Mode */
+#define US_MR_SYNC                  (_U_(0x1) << US_MR_SYNC_Pos)
+#define   US_MR_SYNC_0_Val                _U_(0x0)   /**< \brief (US_MR) USART operates in Synchronous Mode */
+#define   US_MR_SYNC_1_Val                _U_(0x1)   /**< \brief (US_MR) USART operates in Asynchronous Mode */
 #define US_MR_SYNC_0                (US_MR_SYNC_0_Val              << US_MR_SYNC_Pos)
 #define US_MR_SYNC_1                (US_MR_SYNC_1_Val              << US_MR_SYNC_Pos)
 #define US_MR_PAR_Pos               9            /**< \brief (US_MR) Parity Type */
-#define US_MR_PAR_Msk               (_U(0x7) << US_MR_PAR_Pos)
+#define US_MR_PAR_Msk               (_U_(0x7) << US_MR_PAR_Pos)
 #define US_MR_PAR(value)            (US_MR_PAR_Msk & ((value) << US_MR_PAR_Pos))
-#define   US_MR_PAR_EVEN_Val              _U(0x0)   /**< \brief (US_MR) Even parity */
-#define   US_MR_PAR_ODD_Val               _U(0x1)   /**< \brief (US_MR) Odd parity */
-#define   US_MR_PAR_SPACE_Val             _U(0x2)   /**< \brief (US_MR) Parity forced to 0 (Space) */
-#define   US_MR_PAR_MARK_Val              _U(0x3)   /**< \brief (US_MR) Parity forced to 1 (Mark) */
-#define   US_MR_PAR_NONE_Val              _U(0x4)   /**< \brief (US_MR) No Parity */
-#define   US_MR_PAR_5_Val                 _U(0x5)   /**< \brief (US_MR) No Parity */
-#define   US_MR_PAR_MULTI_Val             _U(0x6)   /**< \brief (US_MR) Multi-drop mode */
-#define   US_MR_PAR_7_Val                 _U(0x7)   /**< \brief (US_MR) Multi-drop mode */
+#define   US_MR_PAR_EVEN_Val              _U_(0x0)   /**< \brief (US_MR) Even parity */
+#define   US_MR_PAR_ODD_Val               _U_(0x1)   /**< \brief (US_MR) Odd parity */
+#define   US_MR_PAR_SPACE_Val             _U_(0x2)   /**< \brief (US_MR) Parity forced to 0 (Space) */
+#define   US_MR_PAR_MARK_Val              _U_(0x3)   /**< \brief (US_MR) Parity forced to 1 (Mark) */
+#define   US_MR_PAR_NONE_Val              _U_(0x4)   /**< \brief (US_MR) No Parity */
+#define   US_MR_PAR_5_Val                 _U_(0x5)   /**< \brief (US_MR) No Parity */
+#define   US_MR_PAR_MULTI_Val             _U_(0x6)   /**< \brief (US_MR) Multi-drop mode */
+#define   US_MR_PAR_7_Val                 _U_(0x7)   /**< \brief (US_MR) Multi-drop mode */
 #define US_MR_PAR_EVEN              (US_MR_PAR_EVEN_Val            << US_MR_PAR_Pos)
 #define US_MR_PAR_ODD               (US_MR_PAR_ODD_Val             << US_MR_PAR_Pos)
 #define US_MR_PAR_SPACE             (US_MR_PAR_SPACE_Val           << US_MR_PAR_Pos)
@@ -1037,105 +1037,105 @@ typedef union {
 #define US_MR_PAR_MULTI             (US_MR_PAR_MULTI_Val           << US_MR_PAR_Pos)
 #define US_MR_PAR_7                 (US_MR_PAR_7_Val               << US_MR_PAR_Pos)
 #define US_MR_NBSTOP_Pos            12           /**< \brief (US_MR) Number of Stop Bits */
-#define US_MR_NBSTOP_Msk            (_U(0x3) << US_MR_NBSTOP_Pos)
+#define US_MR_NBSTOP_Msk            (_U_(0x3) << US_MR_NBSTOP_Pos)
 #define US_MR_NBSTOP(value)         (US_MR_NBSTOP_Msk & ((value) << US_MR_NBSTOP_Pos))
-#define   US_MR_NBSTOP_1_Val              _U(0x0)   /**< \brief (US_MR) 1 stop bit */
-#define   US_MR_NBSTOP_1_5_Val            _U(0x1)   /**< \brief (US_MR) 1.5 stop bits (Only valid if SYNC=0) */
-#define   US_MR_NBSTOP_2_Val              _U(0x2)   /**< \brief (US_MR) 2 stop bits */
-#define   US_MR_NBSTOP_3_Val              _U(0x3)   /**< \brief (US_MR) Reserved */
+#define   US_MR_NBSTOP_1_Val              _U_(0x0)   /**< \brief (US_MR) 1 stop bit */
+#define   US_MR_NBSTOP_1_5_Val            _U_(0x1)   /**< \brief (US_MR) 1.5 stop bits (Only valid if SYNC=0) */
+#define   US_MR_NBSTOP_2_Val              _U_(0x2)   /**< \brief (US_MR) 2 stop bits */
+#define   US_MR_NBSTOP_3_Val              _U_(0x3)   /**< \brief (US_MR) Reserved */
 #define US_MR_NBSTOP_1              (US_MR_NBSTOP_1_Val            << US_MR_NBSTOP_Pos)
 #define US_MR_NBSTOP_1_5            (US_MR_NBSTOP_1_5_Val          << US_MR_NBSTOP_Pos)
 #define US_MR_NBSTOP_2              (US_MR_NBSTOP_2_Val            << US_MR_NBSTOP_Pos)
 #define US_MR_NBSTOP_3              (US_MR_NBSTOP_3_Val            << US_MR_NBSTOP_Pos)
 #define US_MR_CHMODE_Pos            14           /**< \brief (US_MR) Channel Mode */
-#define US_MR_CHMODE_Msk            (_U(0x3) << US_MR_CHMODE_Pos)
+#define US_MR_CHMODE_Msk            (_U_(0x3) << US_MR_CHMODE_Pos)
 #define US_MR_CHMODE(value)         (US_MR_CHMODE_Msk & ((value) << US_MR_CHMODE_Pos))
-#define   US_MR_CHMODE_NORMAL_Val         _U(0x0)   /**< \brief (US_MR) Normal Mode */
-#define   US_MR_CHMODE_ECHO_Val           _U(0x1)   /**< \brief (US_MR) Automatic Echo. Receiver input is connected to the TXD pin */
-#define   US_MR_CHMODE_LOCAL_LOOP_Val     _U(0x2)   /**< \brief (US_MR) Local Loopback. Transmitter output is connected to the Receiver Input */
-#define   US_MR_CHMODE_REMOTE_LOOP_Val    _U(0x3)   /**< \brief (US_MR) Remote Loopback. RXD pin is internally connected to the TXD pin */
+#define   US_MR_CHMODE_NORMAL_Val         _U_(0x0)   /**< \brief (US_MR) Normal Mode */
+#define   US_MR_CHMODE_ECHO_Val           _U_(0x1)   /**< \brief (US_MR) Automatic Echo. Receiver input is connected to the TXD pin */
+#define   US_MR_CHMODE_LOCAL_LOOP_Val     _U_(0x2)   /**< \brief (US_MR) Local Loopback. Transmitter output is connected to the Receiver Input */
+#define   US_MR_CHMODE_REMOTE_LOOP_Val    _U_(0x3)   /**< \brief (US_MR) Remote Loopback. RXD pin is internally connected to the TXD pin */
 #define US_MR_CHMODE_NORMAL         (US_MR_CHMODE_NORMAL_Val       << US_MR_CHMODE_Pos)
 #define US_MR_CHMODE_ECHO           (US_MR_CHMODE_ECHO_Val         << US_MR_CHMODE_Pos)
 #define US_MR_CHMODE_LOCAL_LOOP     (US_MR_CHMODE_LOCAL_LOOP_Val   << US_MR_CHMODE_Pos)
 #define US_MR_CHMODE_REMOTE_LOOP    (US_MR_CHMODE_REMOTE_LOOP_Val  << US_MR_CHMODE_Pos)
 #define US_MR_CPOL_Pos              16           /**< \brief (US_MR) SPI Clock Polarity */
-#define US_MR_CPOL                  (_U(0x1) << US_MR_CPOL_Pos)
-#define   US_MR_CPOL_ZERO_Val             _U(0x0)   /**< \brief (US_MR) The inactive state value of SPCK is logic level zero */
-#define   US_MR_CPOL_ONE_Val              _U(0x1)   /**< \brief (US_MR) The inactive state value of SPCK is logic level one */
+#define US_MR_CPOL                  (_U_(0x1) << US_MR_CPOL_Pos)
+#define   US_MR_CPOL_ZERO_Val             _U_(0x0)   /**< \brief (US_MR) The inactive state value of SPCK is logic level zero */
+#define   US_MR_CPOL_ONE_Val              _U_(0x1)   /**< \brief (US_MR) The inactive state value of SPCK is logic level one */
 #define US_MR_CPOL_ZERO             (US_MR_CPOL_ZERO_Val           << US_MR_CPOL_Pos)
 #define US_MR_CPOL_ONE              (US_MR_CPOL_ONE_Val            << US_MR_CPOL_Pos)
 #define US_MR_MSBF_Pos              16           /**< \brief (US_MR) Bit Order */
-#define US_MR_MSBF                  (_U(0x1) << US_MR_MSBF_Pos)
-#define   US_MR_MSBF_LSBF_Val             _U(0x0)   /**< \brief (US_MR) Least Significant Bit first */
-#define   US_MR_MSBF_MSBF_Val             _U(0x1)   /**< \brief (US_MR) Most Significant Bit first */
+#define US_MR_MSBF                  (_U_(0x1) << US_MR_MSBF_Pos)
+#define   US_MR_MSBF_LSBF_Val             _U_(0x0)   /**< \brief (US_MR) Least Significant Bit first */
+#define   US_MR_MSBF_MSBF_Val             _U_(0x1)   /**< \brief (US_MR) Most Significant Bit first */
 #define US_MR_MSBF_LSBF             (US_MR_MSBF_LSBF_Val           << US_MR_MSBF_Pos)
 #define US_MR_MSBF_MSBF             (US_MR_MSBF_MSBF_Val           << US_MR_MSBF_Pos)
 #define US_MR_MODE9_Pos             17           /**< \brief (US_MR) 9-bit Character Length */
-#define US_MR_MODE9                 (_U(0x1) << US_MR_MODE9_Pos)
-#define   US_MR_MODE9_0_Val               _U(0x0)   /**< \brief (US_MR) CHRL defines character length */
-#define   US_MR_MODE9_1_Val               _U(0x1)   /**< \brief (US_MR) 9-bit character length */
+#define US_MR_MODE9                 (_U_(0x1) << US_MR_MODE9_Pos)
+#define   US_MR_MODE9_0_Val               _U_(0x0)   /**< \brief (US_MR) CHRL defines character length */
+#define   US_MR_MODE9_1_Val               _U_(0x1)   /**< \brief (US_MR) 9-bit character length */
 #define US_MR_MODE9_0               (US_MR_MODE9_0_Val             << US_MR_MODE9_Pos)
 #define US_MR_MODE9_1               (US_MR_MODE9_1_Val             << US_MR_MODE9_Pos)
 #define US_MR_CLKO_Pos              18           /**< \brief (US_MR) Clock Output Select */
-#define US_MR_CLKO                  (_U(0x1) << US_MR_CLKO_Pos)
-#define   US_MR_CLKO_0_Val                _U(0x0)   /**< \brief (US_MR) The USART does not drive the SCK pin */
-#define   US_MR_CLKO_1_Val                _U(0x1)   /**< \brief (US_MR) The USART drives the SCK pin if USCLKS does not select the external clock SCK */
+#define US_MR_CLKO                  (_U_(0x1) << US_MR_CLKO_Pos)
+#define   US_MR_CLKO_0_Val                _U_(0x0)   /**< \brief (US_MR) The USART does not drive the SCK pin */
+#define   US_MR_CLKO_1_Val                _U_(0x1)   /**< \brief (US_MR) The USART drives the SCK pin if USCLKS does not select the external clock SCK */
 #define US_MR_CLKO_0                (US_MR_CLKO_0_Val              << US_MR_CLKO_Pos)
 #define US_MR_CLKO_1                (US_MR_CLKO_1_Val              << US_MR_CLKO_Pos)
 #define US_MR_OVER_Pos              19           /**< \brief (US_MR) Oversampling Mode */
-#define US_MR_OVER                  (_U(0x1) << US_MR_OVER_Pos)
-#define   US_MR_OVER_X16_Val              _U(0x0)   /**< \brief (US_MR) 16x Oversampling */
-#define   US_MR_OVER_X8_Val               _U(0x1)   /**< \brief (US_MR) 8x Oversampling */
+#define US_MR_OVER                  (_U_(0x1) << US_MR_OVER_Pos)
+#define   US_MR_OVER_X16_Val              _U_(0x0)   /**< \brief (US_MR) 16x Oversampling */
+#define   US_MR_OVER_X8_Val               _U_(0x1)   /**< \brief (US_MR) 8x Oversampling */
 #define US_MR_OVER_X16              (US_MR_OVER_X16_Val            << US_MR_OVER_Pos)
 #define US_MR_OVER_X8               (US_MR_OVER_X8_Val             << US_MR_OVER_Pos)
 #define US_MR_INACK_Pos             20           /**< \brief (US_MR) Inhibit Non Acknowledge */
-#define US_MR_INACK                 (_U(0x1) << US_MR_INACK_Pos)
-#define   US_MR_INACK_0_Val               _U(0x0)   /**< \brief (US_MR) The NACK is generated */
-#define   US_MR_INACK_1_Val               _U(0x1)   /**< \brief (US_MR) The NACK is not generated */
+#define US_MR_INACK                 (_U_(0x1) << US_MR_INACK_Pos)
+#define   US_MR_INACK_0_Val               _U_(0x0)   /**< \brief (US_MR) The NACK is generated */
+#define   US_MR_INACK_1_Val               _U_(0x1)   /**< \brief (US_MR) The NACK is not generated */
 #define US_MR_INACK_0               (US_MR_INACK_0_Val             << US_MR_INACK_Pos)
 #define US_MR_INACK_1               (US_MR_INACK_1_Val             << US_MR_INACK_Pos)
 #define US_MR_DSNACK_Pos            21           /**< \brief (US_MR) Disable Successive NACK */
-#define US_MR_DSNACK                (_U(0x1) << US_MR_DSNACK_Pos)
-#define   US_MR_DSNACK_0_Val              _U(0x0)   /**< \brief (US_MR) NACK is sent on the ISO line as soon as a parity error occurs in the received character (unless INACK is set) */
-#define   US_MR_DSNACK_1_Val              _U(0x1)   /**< \brief (US_MR) Successive parity errors are counted up to the value specified in the MAX_ITERATION field. These parity errors generatea NACK on the ISO line. As soon as this value is reached, no additional NACK is sent on the ISO line. The flag ITERATION is asserted */
+#define US_MR_DSNACK                (_U_(0x1) << US_MR_DSNACK_Pos)
+#define   US_MR_DSNACK_0_Val              _U_(0x0)   /**< \brief (US_MR) NACK is sent on the ISO line as soon as a parity error occurs in the received character (unless INACK is set) */
+#define   US_MR_DSNACK_1_Val              _U_(0x1)   /**< \brief (US_MR) Successive parity errors are counted up to the value specified in the MAX_ITERATION field. These parity errors generatea NACK on the ISO line. As soon as this value is reached, no additional NACK is sent on the ISO line. The flag ITERATION is asserted */
 #define US_MR_DSNACK_0              (US_MR_DSNACK_0_Val            << US_MR_DSNACK_Pos)
 #define US_MR_DSNACK_1              (US_MR_DSNACK_1_Val            << US_MR_DSNACK_Pos)
 #define US_MR_VAR_SYNC_Pos          22           /**< \brief (US_MR) Variable synchronization of command/data sync Start Frame Delimiter */
-#define US_MR_VAR_SYNC              (_U(0x1) << US_MR_VAR_SYNC_Pos)
-#define   US_MR_VAR_SYNC_0_Val            _U(0x0)   /**< \brief (US_MR) User defined configuration of command or data sync field depending on SYNC value */
-#define   US_MR_VAR_SYNC_1_Val            _U(0x1)   /**< \brief (US_MR) The sync field is updated when a character is written into THR register */
+#define US_MR_VAR_SYNC              (_U_(0x1) << US_MR_VAR_SYNC_Pos)
+#define   US_MR_VAR_SYNC_0_Val            _U_(0x0)   /**< \brief (US_MR) User defined configuration of command or data sync field depending on SYNC value */
+#define   US_MR_VAR_SYNC_1_Val            _U_(0x1)   /**< \brief (US_MR) The sync field is updated when a character is written into THR register */
 #define US_MR_VAR_SYNC_0            (US_MR_VAR_SYNC_0_Val          << US_MR_VAR_SYNC_Pos)
 #define US_MR_VAR_SYNC_1            (US_MR_VAR_SYNC_1_Val          << US_MR_VAR_SYNC_Pos)
 #define US_MR_INVDATA_Pos           23           /**< \brief (US_MR) Inverted data */
-#define US_MR_INVDATA               (_U(0x1) << US_MR_INVDATA_Pos)
+#define US_MR_INVDATA               (_U_(0x1) << US_MR_INVDATA_Pos)
 #define US_MR_MAX_ITERATION_Pos     24           /**< \brief (US_MR) Max interation */
-#define US_MR_MAX_ITERATION_Msk     (_U(0x7) << US_MR_MAX_ITERATION_Pos)
+#define US_MR_MAX_ITERATION_Msk     (_U_(0x7) << US_MR_MAX_ITERATION_Pos)
 #define US_MR_MAX_ITERATION(value)  (US_MR_MAX_ITERATION_Msk & ((value) << US_MR_MAX_ITERATION_Pos))
 #define US_MR_FILTER_Pos            28           /**< \brief (US_MR) Infrared Receive Line Filter */
-#define US_MR_FILTER                (_U(0x1) << US_MR_FILTER_Pos)
-#define   US_MR_FILTER_0_Val              _U(0x0)   /**< \brief (US_MR) The USART does not filter the receive line */
-#define   US_MR_FILTER_1_Val              _U(0x1)   /**< \brief (US_MR) The USART filters the receive line using a three-sample filter (1/16-bit clock) (2 over 3 majority) */
+#define US_MR_FILTER                (_U_(0x1) << US_MR_FILTER_Pos)
+#define   US_MR_FILTER_0_Val              _U_(0x0)   /**< \brief (US_MR) The USART does not filter the receive line */
+#define   US_MR_FILTER_1_Val              _U_(0x1)   /**< \brief (US_MR) The USART filters the receive line using a three-sample filter (1/16-bit clock) (2 over 3 majority) */
 #define US_MR_FILTER_0              (US_MR_FILTER_0_Val            << US_MR_FILTER_Pos)
 #define US_MR_FILTER_1              (US_MR_FILTER_1_Val            << US_MR_FILTER_Pos)
 #define US_MR_MAN_Pos               29           /**< \brief (US_MR) Manchester Encoder/Decoder Enable */
-#define US_MR_MAN                   (_U(0x1) << US_MR_MAN_Pos)
-#define   US_MR_MAN_0_Val                 _U(0x0)   /**< \brief (US_MR) Manchester Encoder/Decoder is disabled */
-#define   US_MR_MAN_1_Val                 _U(0x1)   /**< \brief (US_MR) Manchester Encoder/Decoder is enabled */
+#define US_MR_MAN                   (_U_(0x1) << US_MR_MAN_Pos)
+#define   US_MR_MAN_0_Val                 _U_(0x0)   /**< \brief (US_MR) Manchester Encoder/Decoder is disabled */
+#define   US_MR_MAN_1_Val                 _U_(0x1)   /**< \brief (US_MR) Manchester Encoder/Decoder is enabled */
 #define US_MR_MAN_0                 (US_MR_MAN_0_Val               << US_MR_MAN_Pos)
 #define US_MR_MAN_1                 (US_MR_MAN_1_Val               << US_MR_MAN_Pos)
 #define US_MR_MODSYNC_Pos           30           /**< \brief (US_MR) Manchester Synchronization Mode */
-#define US_MR_MODSYNC               (_U(0x1) << US_MR_MODSYNC_Pos)
-#define   US_MR_MODSYNC_0_Val             _U(0x0)   /**< \brief (US_MR) The Manchester Start bit is a 0 to 1 transition */
-#define   US_MR_MODSYNC_1_Val             _U(0x1)   /**< \brief (US_MR) The Manchester Start bit is a 1 to 0 transition */
+#define US_MR_MODSYNC               (_U_(0x1) << US_MR_MODSYNC_Pos)
+#define   US_MR_MODSYNC_0_Val             _U_(0x0)   /**< \brief (US_MR) The Manchester Start bit is a 0 to 1 transition */
+#define   US_MR_MODSYNC_1_Val             _U_(0x1)   /**< \brief (US_MR) The Manchester Start bit is a 1 to 0 transition */
 #define US_MR_MODSYNC_0             (US_MR_MODSYNC_0_Val           << US_MR_MODSYNC_Pos)
 #define US_MR_MODSYNC_1             (US_MR_MODSYNC_1_Val           << US_MR_MODSYNC_Pos)
 #define US_MR_ONEBIT_Pos            31           /**< \brief (US_MR) Start Frame Delimiter selector */
-#define US_MR_ONEBIT                (_U(0x1) << US_MR_ONEBIT_Pos)
-#define   US_MR_ONEBIT_0_Val              _U(0x0)   /**< \brief (US_MR) Start Frame delimiter is COMMAND or DATA SYNC */
-#define   US_MR_ONEBIT_1_Val              _U(0x1)   /**< \brief (US_MR) Start Frame delimiter is One Bit */
+#define US_MR_ONEBIT                (_U_(0x1) << US_MR_ONEBIT_Pos)
+#define   US_MR_ONEBIT_0_Val              _U_(0x0)   /**< \brief (US_MR) Start Frame delimiter is COMMAND or DATA SYNC */
+#define   US_MR_ONEBIT_1_Val              _U_(0x1)   /**< \brief (US_MR) Start Frame delimiter is One Bit */
 #define US_MR_ONEBIT_0              (US_MR_ONEBIT_0_Val            << US_MR_ONEBIT_Pos)
 #define US_MR_ONEBIT_1              (US_MR_ONEBIT_1_Val            << US_MR_ONEBIT_Pos)
-#define US_MR_MASK                  _U(0xF7FFFFFF) /**< \brief (US_MR) MASK Register */
+#define US_MR_MASK                  _U_(0xF7FFFFFF) /**< \brief (US_MR) MASK Register */
 
 /* -------- US_IER : (USART Offset: 0x08) ( /W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1219,483 +1219,483 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_IER_OFFSET               0x08         /**< \brief (US_IER offset) Interrupt Enable Register */
-#define US_IER_RESETVALUE           _U(0x00000000); /**< \brief (US_IER reset_value) Interrupt Enable Register */
+#define US_IER_RESETVALUE           _U_(0x00000000); /**< \brief (US_IER reset_value) Interrupt Enable Register */
 
 // LIN mode
 #define US_IER_LIN_RXRDY_Pos        0            /**< \brief (US_IER_LIN) Receiver Ready Interrupt Enable */
-#define US_IER_LIN_RXRDY            (_U(0x1) << US_IER_LIN_RXRDY_Pos)
-#define   US_IER_LIN_RXRDY_0_Val          _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
-#define   US_IER_LIN_RXRDY_1_Val          _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_RXRDY            (_U_(0x1) << US_IER_LIN_RXRDY_Pos)
+#define   US_IER_LIN_RXRDY_0_Val          _U_(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_RXRDY_1_Val          _U_(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
 #define US_IER_LIN_RXRDY_0          (US_IER_LIN_RXRDY_0_Val        << US_IER_LIN_RXRDY_Pos)
 #define US_IER_LIN_RXRDY_1          (US_IER_LIN_RXRDY_1_Val        << US_IER_LIN_RXRDY_Pos)
 #define US_IER_LIN_TXRDY_Pos        1            /**< \brief (US_IER_LIN) Transmitter Ready Interrupt Enable */
-#define US_IER_LIN_TXRDY            (_U(0x1) << US_IER_LIN_TXRDY_Pos)
-#define   US_IER_LIN_TXRDY_0_Val          _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
-#define   US_IER_LIN_TXRDY_1_Val          _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_TXRDY            (_U_(0x1) << US_IER_LIN_TXRDY_Pos)
+#define   US_IER_LIN_TXRDY_0_Val          _U_(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_TXRDY_1_Val          _U_(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
 #define US_IER_LIN_TXRDY_0          (US_IER_LIN_TXRDY_0_Val        << US_IER_LIN_TXRDY_Pos)
 #define US_IER_LIN_TXRDY_1          (US_IER_LIN_TXRDY_1_Val        << US_IER_LIN_TXRDY_Pos)
 #define US_IER_LIN_RXBRK_Pos        2            /**< \brief (US_IER_LIN) Receiver Break Interrupt Enable */
-#define US_IER_LIN_RXBRK            (_U(0x1) << US_IER_LIN_RXBRK_Pos)
-#define   US_IER_LIN_RXBRK_0_Val          _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
-#define   US_IER_LIN_RXBRK_1_Val          _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_RXBRK            (_U_(0x1) << US_IER_LIN_RXBRK_Pos)
+#define   US_IER_LIN_RXBRK_0_Val          _U_(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_RXBRK_1_Val          _U_(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
 #define US_IER_LIN_RXBRK_0          (US_IER_LIN_RXBRK_0_Val        << US_IER_LIN_RXBRK_Pos)
 #define US_IER_LIN_RXBRK_1          (US_IER_LIN_RXBRK_1_Val        << US_IER_LIN_RXBRK_Pos)
 #define US_IER_LIN_OVRE_Pos         5            /**< \brief (US_IER_LIN) Overrun Error Interrupt Enable */
-#define US_IER_LIN_OVRE             (_U(0x1) << US_IER_LIN_OVRE_Pos)
-#define   US_IER_LIN_OVRE_0_Val           _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
-#define   US_IER_LIN_OVRE_1_Val           _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_OVRE             (_U_(0x1) << US_IER_LIN_OVRE_Pos)
+#define   US_IER_LIN_OVRE_0_Val           _U_(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_OVRE_1_Val           _U_(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
 #define US_IER_LIN_OVRE_0           (US_IER_LIN_OVRE_0_Val         << US_IER_LIN_OVRE_Pos)
 #define US_IER_LIN_OVRE_1           (US_IER_LIN_OVRE_1_Val         << US_IER_LIN_OVRE_Pos)
 #define US_IER_LIN_FRAME_Pos        6            /**< \brief (US_IER_LIN) Framing Error Interrupt Enable */
-#define US_IER_LIN_FRAME            (_U(0x1) << US_IER_LIN_FRAME_Pos)
-#define   US_IER_LIN_FRAME_0_Val          _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
-#define   US_IER_LIN_FRAME_1_Val          _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_FRAME            (_U_(0x1) << US_IER_LIN_FRAME_Pos)
+#define   US_IER_LIN_FRAME_0_Val          _U_(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_FRAME_1_Val          _U_(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
 #define US_IER_LIN_FRAME_0          (US_IER_LIN_FRAME_0_Val        << US_IER_LIN_FRAME_Pos)
 #define US_IER_LIN_FRAME_1          (US_IER_LIN_FRAME_1_Val        << US_IER_LIN_FRAME_Pos)
 #define US_IER_LIN_PARE_Pos         7            /**< \brief (US_IER_LIN) Parity Error Interrupt Enable */
-#define US_IER_LIN_PARE             (_U(0x1) << US_IER_LIN_PARE_Pos)
-#define   US_IER_LIN_PARE_0_Val           _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
-#define   US_IER_LIN_PARE_1_Val           _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_PARE             (_U_(0x1) << US_IER_LIN_PARE_Pos)
+#define   US_IER_LIN_PARE_0_Val           _U_(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_PARE_1_Val           _U_(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
 #define US_IER_LIN_PARE_0           (US_IER_LIN_PARE_0_Val         << US_IER_LIN_PARE_Pos)
 #define US_IER_LIN_PARE_1           (US_IER_LIN_PARE_1_Val         << US_IER_LIN_PARE_Pos)
 #define US_IER_LIN_TIMEOUT_Pos      8            /**< \brief (US_IER_LIN) Time-out Interrupt Enable */
-#define US_IER_LIN_TIMEOUT          (_U(0x1) << US_IER_LIN_TIMEOUT_Pos)
-#define   US_IER_LIN_TIMEOUT_0_Val        _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
-#define   US_IER_LIN_TIMEOUT_1_Val        _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_TIMEOUT          (_U_(0x1) << US_IER_LIN_TIMEOUT_Pos)
+#define   US_IER_LIN_TIMEOUT_0_Val        _U_(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_TIMEOUT_1_Val        _U_(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
 #define US_IER_LIN_TIMEOUT_0        (US_IER_LIN_TIMEOUT_0_Val      << US_IER_LIN_TIMEOUT_Pos)
 #define US_IER_LIN_TIMEOUT_1        (US_IER_LIN_TIMEOUT_1_Val      << US_IER_LIN_TIMEOUT_Pos)
 #define US_IER_LIN_TXEMPTY_Pos      9            /**< \brief (US_IER_LIN) Transmitter Empty Interrupt Enable */
-#define US_IER_LIN_TXEMPTY          (_U(0x1) << US_IER_LIN_TXEMPTY_Pos)
-#define   US_IER_LIN_TXEMPTY_0_Val        _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
-#define   US_IER_LIN_TXEMPTY_1_Val        _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_TXEMPTY          (_U_(0x1) << US_IER_LIN_TXEMPTY_Pos)
+#define   US_IER_LIN_TXEMPTY_0_Val        _U_(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_TXEMPTY_1_Val        _U_(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
 #define US_IER_LIN_TXEMPTY_0        (US_IER_LIN_TXEMPTY_0_Val      << US_IER_LIN_TXEMPTY_Pos)
 #define US_IER_LIN_TXEMPTY_1        (US_IER_LIN_TXEMPTY_1_Val      << US_IER_LIN_TXEMPTY_Pos)
 #define US_IER_LIN_ITER_Pos         10           /**< \brief (US_IER_LIN) Iteration Interrupt Enable */
-#define US_IER_LIN_ITER             (_U(0x1) << US_IER_LIN_ITER_Pos)
-#define   US_IER_LIN_ITER_0_Val           _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
-#define   US_IER_LIN_ITER_1_Val           _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_ITER             (_U_(0x1) << US_IER_LIN_ITER_Pos)
+#define   US_IER_LIN_ITER_0_Val           _U_(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_ITER_1_Val           _U_(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
 #define US_IER_LIN_ITER_0           (US_IER_LIN_ITER_0_Val         << US_IER_LIN_ITER_Pos)
 #define US_IER_LIN_ITER_1           (US_IER_LIN_ITER_1_Val         << US_IER_LIN_ITER_Pos)
 #define US_IER_LIN_TXBUFE_Pos       11           /**< \brief (US_IER_LIN) Buffer Empty Interrupt Enable */
-#define US_IER_LIN_TXBUFE           (_U(0x1) << US_IER_LIN_TXBUFE_Pos)
-#define   US_IER_LIN_TXBUFE_0_Val         _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
-#define   US_IER_LIN_TXBUFE_1_Val         _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_TXBUFE           (_U_(0x1) << US_IER_LIN_TXBUFE_Pos)
+#define   US_IER_LIN_TXBUFE_0_Val         _U_(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_TXBUFE_1_Val         _U_(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
 #define US_IER_LIN_TXBUFE_0         (US_IER_LIN_TXBUFE_0_Val       << US_IER_LIN_TXBUFE_Pos)
 #define US_IER_LIN_TXBUFE_1         (US_IER_LIN_TXBUFE_1_Val       << US_IER_LIN_TXBUFE_Pos)
 #define US_IER_LIN_RXBUFF_Pos       12           /**< \brief (US_IER_LIN) Buffer Full Interrupt Enable */
-#define US_IER_LIN_RXBUFF           (_U(0x1) << US_IER_LIN_RXBUFF_Pos)
-#define   US_IER_LIN_RXBUFF_0_Val         _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
-#define   US_IER_LIN_RXBUFF_1_Val         _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_RXBUFF           (_U_(0x1) << US_IER_LIN_RXBUFF_Pos)
+#define   US_IER_LIN_RXBUFF_0_Val         _U_(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_RXBUFF_1_Val         _U_(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
 #define US_IER_LIN_RXBUFF_0         (US_IER_LIN_RXBUFF_0_Val       << US_IER_LIN_RXBUFF_Pos)
 #define US_IER_LIN_RXBUFF_1         (US_IER_LIN_RXBUFF_1_Val       << US_IER_LIN_RXBUFF_Pos)
 #define US_IER_LIN_NACK_Pos         13           /**< \brief (US_IER_LIN) Non Acknowledge  or LIN Break Sent or LIN Break Received Interrupt Enable */
-#define US_IER_LIN_NACK             (_U(0x1) << US_IER_LIN_NACK_Pos)
-#define   US_IER_LIN_NACK_0_Val           _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
-#define   US_IER_LIN_NACK_1_Val           _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_NACK             (_U_(0x1) << US_IER_LIN_NACK_Pos)
+#define   US_IER_LIN_NACK_0_Val           _U_(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_NACK_1_Val           _U_(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
 #define US_IER_LIN_NACK_0           (US_IER_LIN_NACK_0_Val         << US_IER_LIN_NACK_Pos)
 #define US_IER_LIN_NACK_1           (US_IER_LIN_NACK_1_Val         << US_IER_LIN_NACK_Pos)
 #define US_IER_LIN_LINID_Pos        14           /**< \brief (US_IER_LIN) LIN Identifier Sent or LIN Identifier Received Interrupt Enable */
-#define US_IER_LIN_LINID            (_U(0x1) << US_IER_LIN_LINID_Pos)
+#define US_IER_LIN_LINID            (_U_(0x1) << US_IER_LIN_LINID_Pos)
 #define US_IER_LIN_LINTC_Pos        15           /**< \brief (US_IER_LIN) LIN Transfer Conpleted Interrupt Enable */
-#define US_IER_LIN_LINTC            (_U(0x1) << US_IER_LIN_LINTC_Pos)
+#define US_IER_LIN_LINTC            (_U_(0x1) << US_IER_LIN_LINTC_Pos)
 #define US_IER_LIN_RIIC_Pos         16           /**< \brief (US_IER_LIN) Ring Indicator Input Change Enable */
-#define US_IER_LIN_RIIC             (_U(0x1) << US_IER_LIN_RIIC_Pos)
-#define   US_IER_LIN_RIIC_0_Val           _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
-#define   US_IER_LIN_RIIC_1_Val           _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_RIIC             (_U_(0x1) << US_IER_LIN_RIIC_Pos)
+#define   US_IER_LIN_RIIC_0_Val           _U_(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_RIIC_1_Val           _U_(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
 #define US_IER_LIN_RIIC_0           (US_IER_LIN_RIIC_0_Val         << US_IER_LIN_RIIC_Pos)
 #define US_IER_LIN_RIIC_1           (US_IER_LIN_RIIC_1_Val         << US_IER_LIN_RIIC_Pos)
 #define US_IER_LIN_DSRIC_Pos        17           /**< \brief (US_IER_LIN) Data Set Ready Input Change Enable */
-#define US_IER_LIN_DSRIC            (_U(0x1) << US_IER_LIN_DSRIC_Pos)
-#define   US_IER_LIN_DSRIC_0_Val          _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
-#define   US_IER_LIN_DSRIC_1_Val          _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_DSRIC            (_U_(0x1) << US_IER_LIN_DSRIC_Pos)
+#define   US_IER_LIN_DSRIC_0_Val          _U_(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_DSRIC_1_Val          _U_(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
 #define US_IER_LIN_DSRIC_0          (US_IER_LIN_DSRIC_0_Val        << US_IER_LIN_DSRIC_Pos)
 #define US_IER_LIN_DSRIC_1          (US_IER_LIN_DSRIC_1_Val        << US_IER_LIN_DSRIC_Pos)
 #define US_IER_LIN_DCDIC_Pos        18           /**< \brief (US_IER_LIN) Data Carrier Detect Input Change Interrupt Enable */
-#define US_IER_LIN_DCDIC            (_U(0x1) << US_IER_LIN_DCDIC_Pos)
-#define   US_IER_LIN_DCDIC_0_Val          _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
-#define   US_IER_LIN_DCDIC_1_Val          _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_DCDIC            (_U_(0x1) << US_IER_LIN_DCDIC_Pos)
+#define   US_IER_LIN_DCDIC_0_Val          _U_(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_DCDIC_1_Val          _U_(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
 #define US_IER_LIN_DCDIC_0          (US_IER_LIN_DCDIC_0_Val        << US_IER_LIN_DCDIC_Pos)
 #define US_IER_LIN_DCDIC_1          (US_IER_LIN_DCDIC_1_Val        << US_IER_LIN_DCDIC_Pos)
 #define US_IER_LIN_CTSIC_Pos        19           /**< \brief (US_IER_LIN) Clear to Send Input Change Interrupt Enable */
-#define US_IER_LIN_CTSIC            (_U(0x1) << US_IER_LIN_CTSIC_Pos)
-#define   US_IER_LIN_CTSIC_0_Val          _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
-#define   US_IER_LIN_CTSIC_1_Val          _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_CTSIC            (_U_(0x1) << US_IER_LIN_CTSIC_Pos)
+#define   US_IER_LIN_CTSIC_0_Val          _U_(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_CTSIC_1_Val          _U_(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
 #define US_IER_LIN_CTSIC_0          (US_IER_LIN_CTSIC_0_Val        << US_IER_LIN_CTSIC_Pos)
 #define US_IER_LIN_CTSIC_1          (US_IER_LIN_CTSIC_1_Val        << US_IER_LIN_CTSIC_Pos)
 #define US_IER_LIN_LINBE_Pos        25           /**< \brief (US_IER_LIN) LIN Bus Error Interrupt Enable */
-#define US_IER_LIN_LINBE            (_U(0x1) << US_IER_LIN_LINBE_Pos)
+#define US_IER_LIN_LINBE            (_U_(0x1) << US_IER_LIN_LINBE_Pos)
 #define US_IER_LIN_LINISFE_Pos      26           /**< \brief (US_IER_LIN) LIN Inconsistent Synch Field Error Interrupt Enable */
-#define US_IER_LIN_LINISFE          (_U(0x1) << US_IER_LIN_LINISFE_Pos)
+#define US_IER_LIN_LINISFE          (_U_(0x1) << US_IER_LIN_LINISFE_Pos)
 #define US_IER_LIN_LINIPE_Pos       27           /**< \brief (US_IER_LIN) LIN Identifier Parity Interrupt Enable */
-#define US_IER_LIN_LINIPE           (_U(0x1) << US_IER_LIN_LINIPE_Pos)
+#define US_IER_LIN_LINIPE           (_U_(0x1) << US_IER_LIN_LINIPE_Pos)
 #define US_IER_LIN_LINCE_Pos        28           /**< \brief (US_IER_LIN) LIN Checksum Error Interrupt Enable */
-#define US_IER_LIN_LINCE            (_U(0x1) << US_IER_LIN_LINCE_Pos)
+#define US_IER_LIN_LINCE            (_U_(0x1) << US_IER_LIN_LINCE_Pos)
 #define US_IER_LIN_LINSNRE_Pos      29           /**< \brief (US_IER_LIN) LIN Slave Not Responding Error Interrupt Enable */
-#define US_IER_LIN_LINSNRE          (_U(0x1) << US_IER_LIN_LINSNRE_Pos)
+#define US_IER_LIN_LINSNRE          (_U_(0x1) << US_IER_LIN_LINSNRE_Pos)
 #define US_IER_LIN_LINSTE_Pos       30           /**< \brief (US_IER_LIN) LIN Synch Tolerance Error Interrupt Enable */
-#define US_IER_LIN_LINSTE           (_U(0x1) << US_IER_LIN_LINSTE_Pos)
-#define   US_IER_LIN_LINSTE_0_Val         _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
-#define   US_IER_LIN_LINSTE_1_Val         _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_LINSTE           (_U_(0x1) << US_IER_LIN_LINSTE_Pos)
+#define   US_IER_LIN_LINSTE_0_Val         _U_(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_LINSTE_1_Val         _U_(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
 #define US_IER_LIN_LINSTE_0         (US_IER_LIN_LINSTE_0_Val       << US_IER_LIN_LINSTE_Pos)
 #define US_IER_LIN_LINSTE_1         (US_IER_LIN_LINSTE_1_Val       << US_IER_LIN_LINSTE_Pos)
 #define US_IER_LIN_LINHTE_Pos       31           /**< \brief (US_IER_LIN) LIN Header Timeout Error Interrupt Enable */
-#define US_IER_LIN_LINHTE           (_U(0x1) << US_IER_LIN_LINHTE_Pos)
-#define   US_IER_LIN_LINHTE_0_Val         _U(0x0)   /**< \brief (US_IER_LIN) No Effect */
-#define   US_IER_LIN_LINHTE_1_Val         _U(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
+#define US_IER_LIN_LINHTE           (_U_(0x1) << US_IER_LIN_LINHTE_Pos)
+#define   US_IER_LIN_LINHTE_0_Val         _U_(0x0)   /**< \brief (US_IER_LIN) No Effect */
+#define   US_IER_LIN_LINHTE_1_Val         _U_(0x1)   /**< \brief (US_IER_LIN) Enables the interrupt */
 #define US_IER_LIN_LINHTE_0         (US_IER_LIN_LINHTE_0_Val       << US_IER_LIN_LINHTE_Pos)
 #define US_IER_LIN_LINHTE_1         (US_IER_LIN_LINHTE_1_Val       << US_IER_LIN_LINHTE_Pos)
-#define US_IER_LIN_MASK             _U(0xFE0FFFE7) /**< \brief (US_IER_LIN) MASK Register */
+#define US_IER_LIN_MASK             _U_(0xFE0FFFE7) /**< \brief (US_IER_LIN) MASK Register */
 
 // SPI_SLAVE mode
 #define US_IER_SPI_SLAVE_RXRDY_Pos  0            /**< \brief (US_IER_SPI_SLAVE) Receiver Ready Interrupt Enable */
-#define US_IER_SPI_SLAVE_RXRDY      (_U(0x1) << US_IER_SPI_SLAVE_RXRDY_Pos)
-#define   US_IER_SPI_SLAVE_RXRDY_0_Val    _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
-#define   US_IER_SPI_SLAVE_RXRDY_1_Val    _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_RXRDY      (_U_(0x1) << US_IER_SPI_SLAVE_RXRDY_Pos)
+#define   US_IER_SPI_SLAVE_RXRDY_0_Val    _U_(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_RXRDY_1_Val    _U_(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
 #define US_IER_SPI_SLAVE_RXRDY_0    (US_IER_SPI_SLAVE_RXRDY_0_Val  << US_IER_SPI_SLAVE_RXRDY_Pos)
 #define US_IER_SPI_SLAVE_RXRDY_1    (US_IER_SPI_SLAVE_RXRDY_1_Val  << US_IER_SPI_SLAVE_RXRDY_Pos)
 #define US_IER_SPI_SLAVE_TXRDY_Pos  1            /**< \brief (US_IER_SPI_SLAVE) Transmitter Ready Interrupt Enable */
-#define US_IER_SPI_SLAVE_TXRDY      (_U(0x1) << US_IER_SPI_SLAVE_TXRDY_Pos)
-#define   US_IER_SPI_SLAVE_TXRDY_0_Val    _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
-#define   US_IER_SPI_SLAVE_TXRDY_1_Val    _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_TXRDY      (_U_(0x1) << US_IER_SPI_SLAVE_TXRDY_Pos)
+#define   US_IER_SPI_SLAVE_TXRDY_0_Val    _U_(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_TXRDY_1_Val    _U_(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
 #define US_IER_SPI_SLAVE_TXRDY_0    (US_IER_SPI_SLAVE_TXRDY_0_Val  << US_IER_SPI_SLAVE_TXRDY_Pos)
 #define US_IER_SPI_SLAVE_TXRDY_1    (US_IER_SPI_SLAVE_TXRDY_1_Val  << US_IER_SPI_SLAVE_TXRDY_Pos)
 #define US_IER_SPI_SLAVE_RXBRK_Pos  2            /**< \brief (US_IER_SPI_SLAVE) Receiver Break Interrupt Enable */
-#define US_IER_SPI_SLAVE_RXBRK      (_U(0x1) << US_IER_SPI_SLAVE_RXBRK_Pos)
-#define   US_IER_SPI_SLAVE_RXBRK_0_Val    _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
-#define   US_IER_SPI_SLAVE_RXBRK_1_Val    _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_RXBRK      (_U_(0x1) << US_IER_SPI_SLAVE_RXBRK_Pos)
+#define   US_IER_SPI_SLAVE_RXBRK_0_Val    _U_(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_RXBRK_1_Val    _U_(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
 #define US_IER_SPI_SLAVE_RXBRK_0    (US_IER_SPI_SLAVE_RXBRK_0_Val  << US_IER_SPI_SLAVE_RXBRK_Pos)
 #define US_IER_SPI_SLAVE_RXBRK_1    (US_IER_SPI_SLAVE_RXBRK_1_Val  << US_IER_SPI_SLAVE_RXBRK_Pos)
 #define US_IER_SPI_SLAVE_OVRE_Pos   5            /**< \brief (US_IER_SPI_SLAVE) Overrun Error Interrupt Enable */
-#define US_IER_SPI_SLAVE_OVRE       (_U(0x1) << US_IER_SPI_SLAVE_OVRE_Pos)
-#define   US_IER_SPI_SLAVE_OVRE_0_Val     _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
-#define   US_IER_SPI_SLAVE_OVRE_1_Val     _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_OVRE       (_U_(0x1) << US_IER_SPI_SLAVE_OVRE_Pos)
+#define   US_IER_SPI_SLAVE_OVRE_0_Val     _U_(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_OVRE_1_Val     _U_(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
 #define US_IER_SPI_SLAVE_OVRE_0     (US_IER_SPI_SLAVE_OVRE_0_Val   << US_IER_SPI_SLAVE_OVRE_Pos)
 #define US_IER_SPI_SLAVE_OVRE_1     (US_IER_SPI_SLAVE_OVRE_1_Val   << US_IER_SPI_SLAVE_OVRE_Pos)
 #define US_IER_SPI_SLAVE_FRAME_Pos  6            /**< \brief (US_IER_SPI_SLAVE) Framing Error Interrupt Enable */
-#define US_IER_SPI_SLAVE_FRAME      (_U(0x1) << US_IER_SPI_SLAVE_FRAME_Pos)
-#define   US_IER_SPI_SLAVE_FRAME_0_Val    _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
-#define   US_IER_SPI_SLAVE_FRAME_1_Val    _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_FRAME      (_U_(0x1) << US_IER_SPI_SLAVE_FRAME_Pos)
+#define   US_IER_SPI_SLAVE_FRAME_0_Val    _U_(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_FRAME_1_Val    _U_(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
 #define US_IER_SPI_SLAVE_FRAME_0    (US_IER_SPI_SLAVE_FRAME_0_Val  << US_IER_SPI_SLAVE_FRAME_Pos)
 #define US_IER_SPI_SLAVE_FRAME_1    (US_IER_SPI_SLAVE_FRAME_1_Val  << US_IER_SPI_SLAVE_FRAME_Pos)
 #define US_IER_SPI_SLAVE_PARE_Pos   7            /**< \brief (US_IER_SPI_SLAVE) Parity Error Interrupt Enable */
-#define US_IER_SPI_SLAVE_PARE       (_U(0x1) << US_IER_SPI_SLAVE_PARE_Pos)
-#define   US_IER_SPI_SLAVE_PARE_0_Val     _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
-#define   US_IER_SPI_SLAVE_PARE_1_Val     _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_PARE       (_U_(0x1) << US_IER_SPI_SLAVE_PARE_Pos)
+#define   US_IER_SPI_SLAVE_PARE_0_Val     _U_(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_PARE_1_Val     _U_(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
 #define US_IER_SPI_SLAVE_PARE_0     (US_IER_SPI_SLAVE_PARE_0_Val   << US_IER_SPI_SLAVE_PARE_Pos)
 #define US_IER_SPI_SLAVE_PARE_1     (US_IER_SPI_SLAVE_PARE_1_Val   << US_IER_SPI_SLAVE_PARE_Pos)
 #define US_IER_SPI_SLAVE_TIMEOUT_Pos 8            /**< \brief (US_IER_SPI_SLAVE) Time-out Interrupt Enable */
-#define US_IER_SPI_SLAVE_TIMEOUT    (_U(0x1) << US_IER_SPI_SLAVE_TIMEOUT_Pos)
-#define   US_IER_SPI_SLAVE_TIMEOUT_0_Val  _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
-#define   US_IER_SPI_SLAVE_TIMEOUT_1_Val  _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_TIMEOUT    (_U_(0x1) << US_IER_SPI_SLAVE_TIMEOUT_Pos)
+#define   US_IER_SPI_SLAVE_TIMEOUT_0_Val  _U_(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_TIMEOUT_1_Val  _U_(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
 #define US_IER_SPI_SLAVE_TIMEOUT_0  (US_IER_SPI_SLAVE_TIMEOUT_0_Val << US_IER_SPI_SLAVE_TIMEOUT_Pos)
 #define US_IER_SPI_SLAVE_TIMEOUT_1  (US_IER_SPI_SLAVE_TIMEOUT_1_Val << US_IER_SPI_SLAVE_TIMEOUT_Pos)
 #define US_IER_SPI_SLAVE_TXEMPTY_Pos 9            /**< \brief (US_IER_SPI_SLAVE) Transmitter Empty Interrupt Enable */
-#define US_IER_SPI_SLAVE_TXEMPTY    (_U(0x1) << US_IER_SPI_SLAVE_TXEMPTY_Pos)
-#define   US_IER_SPI_SLAVE_TXEMPTY_0_Val  _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
-#define   US_IER_SPI_SLAVE_TXEMPTY_1_Val  _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_TXEMPTY    (_U_(0x1) << US_IER_SPI_SLAVE_TXEMPTY_Pos)
+#define   US_IER_SPI_SLAVE_TXEMPTY_0_Val  _U_(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_TXEMPTY_1_Val  _U_(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
 #define US_IER_SPI_SLAVE_TXEMPTY_0  (US_IER_SPI_SLAVE_TXEMPTY_0_Val << US_IER_SPI_SLAVE_TXEMPTY_Pos)
 #define US_IER_SPI_SLAVE_TXEMPTY_1  (US_IER_SPI_SLAVE_TXEMPTY_1_Val << US_IER_SPI_SLAVE_TXEMPTY_Pos)
 #define US_IER_SPI_SLAVE_UNRE_Pos   10           /**< \brief (US_IER_SPI_SLAVE) SPI Underrun Error Interrupt Enable */
-#define US_IER_SPI_SLAVE_UNRE       (_U(0x1) << US_IER_SPI_SLAVE_UNRE_Pos)
-#define   US_IER_SPI_SLAVE_UNRE_0_Val     _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
-#define   US_IER_SPI_SLAVE_UNRE_1_Val     _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_UNRE       (_U_(0x1) << US_IER_SPI_SLAVE_UNRE_Pos)
+#define   US_IER_SPI_SLAVE_UNRE_0_Val     _U_(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_UNRE_1_Val     _U_(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
 #define US_IER_SPI_SLAVE_UNRE_0     (US_IER_SPI_SLAVE_UNRE_0_Val   << US_IER_SPI_SLAVE_UNRE_Pos)
 #define US_IER_SPI_SLAVE_UNRE_1     (US_IER_SPI_SLAVE_UNRE_1_Val   << US_IER_SPI_SLAVE_UNRE_Pos)
 #define US_IER_SPI_SLAVE_TXBUFE_Pos 11           /**< \brief (US_IER_SPI_SLAVE) Buffer Empty Interrupt Enable */
-#define US_IER_SPI_SLAVE_TXBUFE     (_U(0x1) << US_IER_SPI_SLAVE_TXBUFE_Pos)
-#define   US_IER_SPI_SLAVE_TXBUFE_0_Val   _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
-#define   US_IER_SPI_SLAVE_TXBUFE_1_Val   _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_TXBUFE     (_U_(0x1) << US_IER_SPI_SLAVE_TXBUFE_Pos)
+#define   US_IER_SPI_SLAVE_TXBUFE_0_Val   _U_(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_TXBUFE_1_Val   _U_(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
 #define US_IER_SPI_SLAVE_TXBUFE_0   (US_IER_SPI_SLAVE_TXBUFE_0_Val << US_IER_SPI_SLAVE_TXBUFE_Pos)
 #define US_IER_SPI_SLAVE_TXBUFE_1   (US_IER_SPI_SLAVE_TXBUFE_1_Val << US_IER_SPI_SLAVE_TXBUFE_Pos)
 #define US_IER_SPI_SLAVE_RXBUFF_Pos 12           /**< \brief (US_IER_SPI_SLAVE) Buffer Full Interrupt Enable */
-#define US_IER_SPI_SLAVE_RXBUFF     (_U(0x1) << US_IER_SPI_SLAVE_RXBUFF_Pos)
-#define   US_IER_SPI_SLAVE_RXBUFF_0_Val   _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
-#define   US_IER_SPI_SLAVE_RXBUFF_1_Val   _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_RXBUFF     (_U_(0x1) << US_IER_SPI_SLAVE_RXBUFF_Pos)
+#define   US_IER_SPI_SLAVE_RXBUFF_0_Val   _U_(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_RXBUFF_1_Val   _U_(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
 #define US_IER_SPI_SLAVE_RXBUFF_0   (US_IER_SPI_SLAVE_RXBUFF_0_Val << US_IER_SPI_SLAVE_RXBUFF_Pos)
 #define US_IER_SPI_SLAVE_RXBUFF_1   (US_IER_SPI_SLAVE_RXBUFF_1_Val << US_IER_SPI_SLAVE_RXBUFF_Pos)
 #define US_IER_SPI_SLAVE_NACK_Pos   13           /**< \brief (US_IER_SPI_SLAVE) Non Acknowledge Interrupt Enable */
-#define US_IER_SPI_SLAVE_NACK       (_U(0x1) << US_IER_SPI_SLAVE_NACK_Pos)
-#define   US_IER_SPI_SLAVE_NACK_0_Val     _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
-#define   US_IER_SPI_SLAVE_NACK_1_Val     _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_NACK       (_U_(0x1) << US_IER_SPI_SLAVE_NACK_Pos)
+#define   US_IER_SPI_SLAVE_NACK_0_Val     _U_(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_NACK_1_Val     _U_(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
 #define US_IER_SPI_SLAVE_NACK_0     (US_IER_SPI_SLAVE_NACK_0_Val   << US_IER_SPI_SLAVE_NACK_Pos)
 #define US_IER_SPI_SLAVE_NACK_1     (US_IER_SPI_SLAVE_NACK_1_Val   << US_IER_SPI_SLAVE_NACK_Pos)
 #define US_IER_SPI_SLAVE_RIIC_Pos   16           /**< \brief (US_IER_SPI_SLAVE) Ring Indicator Input Change Enable */
-#define US_IER_SPI_SLAVE_RIIC       (_U(0x1) << US_IER_SPI_SLAVE_RIIC_Pos)
-#define   US_IER_SPI_SLAVE_RIIC_0_Val     _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
-#define   US_IER_SPI_SLAVE_RIIC_1_Val     _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_RIIC       (_U_(0x1) << US_IER_SPI_SLAVE_RIIC_Pos)
+#define   US_IER_SPI_SLAVE_RIIC_0_Val     _U_(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_RIIC_1_Val     _U_(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
 #define US_IER_SPI_SLAVE_RIIC_0     (US_IER_SPI_SLAVE_RIIC_0_Val   << US_IER_SPI_SLAVE_RIIC_Pos)
 #define US_IER_SPI_SLAVE_RIIC_1     (US_IER_SPI_SLAVE_RIIC_1_Val   << US_IER_SPI_SLAVE_RIIC_Pos)
 #define US_IER_SPI_SLAVE_DSRIC_Pos  17           /**< \brief (US_IER_SPI_SLAVE) Data Set Ready Input Change Enable */
-#define US_IER_SPI_SLAVE_DSRIC      (_U(0x1) << US_IER_SPI_SLAVE_DSRIC_Pos)
-#define   US_IER_SPI_SLAVE_DSRIC_0_Val    _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
-#define   US_IER_SPI_SLAVE_DSRIC_1_Val    _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_DSRIC      (_U_(0x1) << US_IER_SPI_SLAVE_DSRIC_Pos)
+#define   US_IER_SPI_SLAVE_DSRIC_0_Val    _U_(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_DSRIC_1_Val    _U_(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
 #define US_IER_SPI_SLAVE_DSRIC_0    (US_IER_SPI_SLAVE_DSRIC_0_Val  << US_IER_SPI_SLAVE_DSRIC_Pos)
 #define US_IER_SPI_SLAVE_DSRIC_1    (US_IER_SPI_SLAVE_DSRIC_1_Val  << US_IER_SPI_SLAVE_DSRIC_Pos)
 #define US_IER_SPI_SLAVE_DCDIC_Pos  18           /**< \brief (US_IER_SPI_SLAVE) Data Carrier Detect Input Change Interrupt Enable */
-#define US_IER_SPI_SLAVE_DCDIC      (_U(0x1) << US_IER_SPI_SLAVE_DCDIC_Pos)
-#define   US_IER_SPI_SLAVE_DCDIC_0_Val    _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
-#define   US_IER_SPI_SLAVE_DCDIC_1_Val    _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_DCDIC      (_U_(0x1) << US_IER_SPI_SLAVE_DCDIC_Pos)
+#define   US_IER_SPI_SLAVE_DCDIC_0_Val    _U_(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_DCDIC_1_Val    _U_(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
 #define US_IER_SPI_SLAVE_DCDIC_0    (US_IER_SPI_SLAVE_DCDIC_0_Val  << US_IER_SPI_SLAVE_DCDIC_Pos)
 #define US_IER_SPI_SLAVE_DCDIC_1    (US_IER_SPI_SLAVE_DCDIC_1_Val  << US_IER_SPI_SLAVE_DCDIC_Pos)
 #define US_IER_SPI_SLAVE_CTSIC_Pos  19           /**< \brief (US_IER_SPI_SLAVE) Clear to Send Input Change Interrupt Enable */
-#define US_IER_SPI_SLAVE_CTSIC      (_U(0x1) << US_IER_SPI_SLAVE_CTSIC_Pos)
-#define   US_IER_SPI_SLAVE_CTSIC_0_Val    _U(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
-#define   US_IER_SPI_SLAVE_CTSIC_1_Val    _U(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
+#define US_IER_SPI_SLAVE_CTSIC      (_U_(0x1) << US_IER_SPI_SLAVE_CTSIC_Pos)
+#define   US_IER_SPI_SLAVE_CTSIC_0_Val    _U_(0x0)   /**< \brief (US_IER_SPI_SLAVE) No Effect */
+#define   US_IER_SPI_SLAVE_CTSIC_1_Val    _U_(0x1)   /**< \brief (US_IER_SPI_SLAVE) Enables the interrupt */
 #define US_IER_SPI_SLAVE_CTSIC_0    (US_IER_SPI_SLAVE_CTSIC_0_Val  << US_IER_SPI_SLAVE_CTSIC_Pos)
 #define US_IER_SPI_SLAVE_CTSIC_1    (US_IER_SPI_SLAVE_CTSIC_1_Val  << US_IER_SPI_SLAVE_CTSIC_Pos)
-#define US_IER_SPI_SLAVE_MASK       _U(0x000F3FE7) /**< \brief (US_IER_SPI_SLAVE) MASK Register */
+#define US_IER_SPI_SLAVE_MASK       _U_(0x000F3FE7) /**< \brief (US_IER_SPI_SLAVE) MASK Register */
 
 // USART mode
 #define US_IER_USART_RXRDY_Pos      0            /**< \brief (US_IER_USART) Receiver Ready Interrupt Enable */
-#define US_IER_USART_RXRDY          (_U(0x1) << US_IER_USART_RXRDY_Pos)
-#define   US_IER_USART_RXRDY_0_Val        _U(0x0)   /**< \brief (US_IER_USART) No Effect */
-#define   US_IER_USART_RXRDY_1_Val        _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_RXRDY          (_U_(0x1) << US_IER_USART_RXRDY_Pos)
+#define   US_IER_USART_RXRDY_0_Val        _U_(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_RXRDY_1_Val        _U_(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
 #define US_IER_USART_RXRDY_0        (US_IER_USART_RXRDY_0_Val      << US_IER_USART_RXRDY_Pos)
 #define US_IER_USART_RXRDY_1        (US_IER_USART_RXRDY_1_Val      << US_IER_USART_RXRDY_Pos)
 #define US_IER_USART_TXRDY_Pos      1            /**< \brief (US_IER_USART) Transmitter Ready Interrupt Enable */
-#define US_IER_USART_TXRDY          (_U(0x1) << US_IER_USART_TXRDY_Pos)
-#define   US_IER_USART_TXRDY_0_Val        _U(0x0)   /**< \brief (US_IER_USART) No Effect */
-#define   US_IER_USART_TXRDY_1_Val        _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_TXRDY          (_U_(0x1) << US_IER_USART_TXRDY_Pos)
+#define   US_IER_USART_TXRDY_0_Val        _U_(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_TXRDY_1_Val        _U_(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
 #define US_IER_USART_TXRDY_0        (US_IER_USART_TXRDY_0_Val      << US_IER_USART_TXRDY_Pos)
 #define US_IER_USART_TXRDY_1        (US_IER_USART_TXRDY_1_Val      << US_IER_USART_TXRDY_Pos)
 #define US_IER_USART_RXBRK_Pos      2            /**< \brief (US_IER_USART) Receiver Break Interrupt Enable */
-#define US_IER_USART_RXBRK          (_U(0x1) << US_IER_USART_RXBRK_Pos)
-#define   US_IER_USART_RXBRK_0_Val        _U(0x0)   /**< \brief (US_IER_USART) No Effect */
-#define   US_IER_USART_RXBRK_1_Val        _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_RXBRK          (_U_(0x1) << US_IER_USART_RXBRK_Pos)
+#define   US_IER_USART_RXBRK_0_Val        _U_(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_RXBRK_1_Val        _U_(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
 #define US_IER_USART_RXBRK_0        (US_IER_USART_RXBRK_0_Val      << US_IER_USART_RXBRK_Pos)
 #define US_IER_USART_RXBRK_1        (US_IER_USART_RXBRK_1_Val      << US_IER_USART_RXBRK_Pos)
 #define US_IER_USART_OVRE_Pos       5            /**< \brief (US_IER_USART) Overrun Error Interrupt Enable */
-#define US_IER_USART_OVRE           (_U(0x1) << US_IER_USART_OVRE_Pos)
-#define   US_IER_USART_OVRE_0_Val         _U(0x0)   /**< \brief (US_IER_USART) No Effect */
-#define   US_IER_USART_OVRE_1_Val         _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_OVRE           (_U_(0x1) << US_IER_USART_OVRE_Pos)
+#define   US_IER_USART_OVRE_0_Val         _U_(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_OVRE_1_Val         _U_(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
 #define US_IER_USART_OVRE_0         (US_IER_USART_OVRE_0_Val       << US_IER_USART_OVRE_Pos)
 #define US_IER_USART_OVRE_1         (US_IER_USART_OVRE_1_Val       << US_IER_USART_OVRE_Pos)
 #define US_IER_USART_FRAME_Pos      6            /**< \brief (US_IER_USART) Framing Error Interrupt Enable */
-#define US_IER_USART_FRAME          (_U(0x1) << US_IER_USART_FRAME_Pos)
-#define   US_IER_USART_FRAME_0_Val        _U(0x0)   /**< \brief (US_IER_USART) No Effect */
-#define   US_IER_USART_FRAME_1_Val        _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_FRAME          (_U_(0x1) << US_IER_USART_FRAME_Pos)
+#define   US_IER_USART_FRAME_0_Val        _U_(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_FRAME_1_Val        _U_(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
 #define US_IER_USART_FRAME_0        (US_IER_USART_FRAME_0_Val      << US_IER_USART_FRAME_Pos)
 #define US_IER_USART_FRAME_1        (US_IER_USART_FRAME_1_Val      << US_IER_USART_FRAME_Pos)
 #define US_IER_USART_PARE_Pos       7            /**< \brief (US_IER_USART) Parity Error Interrupt Enable */
-#define US_IER_USART_PARE           (_U(0x1) << US_IER_USART_PARE_Pos)
-#define   US_IER_USART_PARE_0_Val         _U(0x0)   /**< \brief (US_IER_USART) No Effect */
-#define   US_IER_USART_PARE_1_Val         _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_PARE           (_U_(0x1) << US_IER_USART_PARE_Pos)
+#define   US_IER_USART_PARE_0_Val         _U_(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_PARE_1_Val         _U_(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
 #define US_IER_USART_PARE_0         (US_IER_USART_PARE_0_Val       << US_IER_USART_PARE_Pos)
 #define US_IER_USART_PARE_1         (US_IER_USART_PARE_1_Val       << US_IER_USART_PARE_Pos)
 #define US_IER_USART_TIMEOUT_Pos    8            /**< \brief (US_IER_USART) Time-out Interrupt Enable */
-#define US_IER_USART_TIMEOUT        (_U(0x1) << US_IER_USART_TIMEOUT_Pos)
-#define   US_IER_USART_TIMEOUT_0_Val      _U(0x0)   /**< \brief (US_IER_USART) No Effect */
-#define   US_IER_USART_TIMEOUT_1_Val      _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_TIMEOUT        (_U_(0x1) << US_IER_USART_TIMEOUT_Pos)
+#define   US_IER_USART_TIMEOUT_0_Val      _U_(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_TIMEOUT_1_Val      _U_(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
 #define US_IER_USART_TIMEOUT_0      (US_IER_USART_TIMEOUT_0_Val    << US_IER_USART_TIMEOUT_Pos)
 #define US_IER_USART_TIMEOUT_1      (US_IER_USART_TIMEOUT_1_Val    << US_IER_USART_TIMEOUT_Pos)
 #define US_IER_USART_TXEMPTY_Pos    9            /**< \brief (US_IER_USART) Transmitter Empty Interrupt Enable */
-#define US_IER_USART_TXEMPTY        (_U(0x1) << US_IER_USART_TXEMPTY_Pos)
-#define   US_IER_USART_TXEMPTY_0_Val      _U(0x0)   /**< \brief (US_IER_USART) No Effect */
-#define   US_IER_USART_TXEMPTY_1_Val      _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_TXEMPTY        (_U_(0x1) << US_IER_USART_TXEMPTY_Pos)
+#define   US_IER_USART_TXEMPTY_0_Val      _U_(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_TXEMPTY_1_Val      _U_(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
 #define US_IER_USART_TXEMPTY_0      (US_IER_USART_TXEMPTY_0_Val    << US_IER_USART_TXEMPTY_Pos)
 #define US_IER_USART_TXEMPTY_1      (US_IER_USART_TXEMPTY_1_Val    << US_IER_USART_TXEMPTY_Pos)
 #define US_IER_USART_ITER_Pos       10           /**< \brief (US_IER_USART) Iteration Interrupt Enable */
-#define US_IER_USART_ITER           (_U(0x1) << US_IER_USART_ITER_Pos)
-#define   US_IER_USART_ITER_0_Val         _U(0x0)   /**< \brief (US_IER_USART) No Effect */
-#define   US_IER_USART_ITER_1_Val         _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_ITER           (_U_(0x1) << US_IER_USART_ITER_Pos)
+#define   US_IER_USART_ITER_0_Val         _U_(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_ITER_1_Val         _U_(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
 #define US_IER_USART_ITER_0         (US_IER_USART_ITER_0_Val       << US_IER_USART_ITER_Pos)
 #define US_IER_USART_ITER_1         (US_IER_USART_ITER_1_Val       << US_IER_USART_ITER_Pos)
 #define US_IER_USART_TXBUFE_Pos     11           /**< \brief (US_IER_USART) Buffer Empty Interrupt Enable */
-#define US_IER_USART_TXBUFE         (_U(0x1) << US_IER_USART_TXBUFE_Pos)
-#define   US_IER_USART_TXBUFE_0_Val       _U(0x0)   /**< \brief (US_IER_USART) No Effect */
-#define   US_IER_USART_TXBUFE_1_Val       _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_TXBUFE         (_U_(0x1) << US_IER_USART_TXBUFE_Pos)
+#define   US_IER_USART_TXBUFE_0_Val       _U_(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_TXBUFE_1_Val       _U_(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
 #define US_IER_USART_TXBUFE_0       (US_IER_USART_TXBUFE_0_Val     << US_IER_USART_TXBUFE_Pos)
 #define US_IER_USART_TXBUFE_1       (US_IER_USART_TXBUFE_1_Val     << US_IER_USART_TXBUFE_Pos)
 #define US_IER_USART_RXBUFF_Pos     12           /**< \brief (US_IER_USART) Buffer Full Interrupt Enable */
-#define US_IER_USART_RXBUFF         (_U(0x1) << US_IER_USART_RXBUFF_Pos)
-#define   US_IER_USART_RXBUFF_0_Val       _U(0x0)   /**< \brief (US_IER_USART) No Effect */
-#define   US_IER_USART_RXBUFF_1_Val       _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_RXBUFF         (_U_(0x1) << US_IER_USART_RXBUFF_Pos)
+#define   US_IER_USART_RXBUFF_0_Val       _U_(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_RXBUFF_1_Val       _U_(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
 #define US_IER_USART_RXBUFF_0       (US_IER_USART_RXBUFF_0_Val     << US_IER_USART_RXBUFF_Pos)
 #define US_IER_USART_RXBUFF_1       (US_IER_USART_RXBUFF_1_Val     << US_IER_USART_RXBUFF_Pos)
 #define US_IER_USART_NACK_Pos       13           /**< \brief (US_IER_USART) Non Acknowledge Interrupt Enable */
-#define US_IER_USART_NACK           (_U(0x1) << US_IER_USART_NACK_Pos)
-#define   US_IER_USART_NACK_0_Val         _U(0x0)   /**< \brief (US_IER_USART) No Effect */
-#define   US_IER_USART_NACK_1_Val         _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_NACK           (_U_(0x1) << US_IER_USART_NACK_Pos)
+#define   US_IER_USART_NACK_0_Val         _U_(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_NACK_1_Val         _U_(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
 #define US_IER_USART_NACK_0         (US_IER_USART_NACK_0_Val       << US_IER_USART_NACK_Pos)
 #define US_IER_USART_NACK_1         (US_IER_USART_NACK_1_Val       << US_IER_USART_NACK_Pos)
 #define US_IER_USART_RIIC_Pos       16           /**< \brief (US_IER_USART) Ring Indicator Input Change Enable */
-#define US_IER_USART_RIIC           (_U(0x1) << US_IER_USART_RIIC_Pos)
-#define   US_IER_USART_RIIC_0_Val         _U(0x0)   /**< \brief (US_IER_USART) No Effect */
-#define   US_IER_USART_RIIC_1_Val         _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_RIIC           (_U_(0x1) << US_IER_USART_RIIC_Pos)
+#define   US_IER_USART_RIIC_0_Val         _U_(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_RIIC_1_Val         _U_(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
 #define US_IER_USART_RIIC_0         (US_IER_USART_RIIC_0_Val       << US_IER_USART_RIIC_Pos)
 #define US_IER_USART_RIIC_1         (US_IER_USART_RIIC_1_Val       << US_IER_USART_RIIC_Pos)
 #define US_IER_USART_DSRIC_Pos      17           /**< \brief (US_IER_USART) Data Set Ready Input Change Enable */
-#define US_IER_USART_DSRIC          (_U(0x1) << US_IER_USART_DSRIC_Pos)
-#define   US_IER_USART_DSRIC_0_Val        _U(0x0)   /**< \brief (US_IER_USART) No Effect */
-#define   US_IER_USART_DSRIC_1_Val        _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_DSRIC          (_U_(0x1) << US_IER_USART_DSRIC_Pos)
+#define   US_IER_USART_DSRIC_0_Val        _U_(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_DSRIC_1_Val        _U_(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
 #define US_IER_USART_DSRIC_0        (US_IER_USART_DSRIC_0_Val      << US_IER_USART_DSRIC_Pos)
 #define US_IER_USART_DSRIC_1        (US_IER_USART_DSRIC_1_Val      << US_IER_USART_DSRIC_Pos)
 #define US_IER_USART_DCDIC_Pos      18           /**< \brief (US_IER_USART) Data Carrier Detect Input Change Interrupt Enable */
-#define US_IER_USART_DCDIC          (_U(0x1) << US_IER_USART_DCDIC_Pos)
-#define   US_IER_USART_DCDIC_0_Val        _U(0x0)   /**< \brief (US_IER_USART) No Effect */
-#define   US_IER_USART_DCDIC_1_Val        _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_DCDIC          (_U_(0x1) << US_IER_USART_DCDIC_Pos)
+#define   US_IER_USART_DCDIC_0_Val        _U_(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_DCDIC_1_Val        _U_(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
 #define US_IER_USART_DCDIC_0        (US_IER_USART_DCDIC_0_Val      << US_IER_USART_DCDIC_Pos)
 #define US_IER_USART_DCDIC_1        (US_IER_USART_DCDIC_1_Val      << US_IER_USART_DCDIC_Pos)
 #define US_IER_USART_CTSIC_Pos      19           /**< \brief (US_IER_USART) Clear to Send Input Change Interrupt Enable */
-#define US_IER_USART_CTSIC          (_U(0x1) << US_IER_USART_CTSIC_Pos)
-#define   US_IER_USART_CTSIC_0_Val        _U(0x0)   /**< \brief (US_IER_USART) No Effect */
-#define   US_IER_USART_CTSIC_1_Val        _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_CTSIC          (_U_(0x1) << US_IER_USART_CTSIC_Pos)
+#define   US_IER_USART_CTSIC_0_Val        _U_(0x0)   /**< \brief (US_IER_USART) No Effect */
+#define   US_IER_USART_CTSIC_1_Val        _U_(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
 #define US_IER_USART_CTSIC_0        (US_IER_USART_CTSIC_0_Val      << US_IER_USART_CTSIC_Pos)
 #define US_IER_USART_CTSIC_1        (US_IER_USART_CTSIC_1_Val      << US_IER_USART_CTSIC_Pos)
 #define US_IER_USART_MANE_Pos       20           /**< \brief (US_IER_USART) Manchester Error Interrupt Enable */
-#define US_IER_USART_MANE           (_U(0x1) << US_IER_USART_MANE_Pos)
+#define US_IER_USART_MANE           (_U_(0x1) << US_IER_USART_MANE_Pos)
 #define US_IER_USART_MANEA_Pos      24           /**< \brief (US_IER_USART) Manchester Error Interrupt Enable */
-#define US_IER_USART_MANEA          (_U(0x1) << US_IER_USART_MANEA_Pos)
-#define   US_IER_USART_MANEA_0_Val        _U(0x0)   /**< \brief (US_IER_USART) No effect */
-#define   US_IER_USART_MANEA_1_Val        _U(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
+#define US_IER_USART_MANEA          (_U_(0x1) << US_IER_USART_MANEA_Pos)
+#define   US_IER_USART_MANEA_0_Val        _U_(0x0)   /**< \brief (US_IER_USART) No effect */
+#define   US_IER_USART_MANEA_1_Val        _U_(0x1)   /**< \brief (US_IER_USART) Enables the interrupt */
 #define US_IER_USART_MANEA_0        (US_IER_USART_MANEA_0_Val      << US_IER_USART_MANEA_Pos)
 #define US_IER_USART_MANEA_1        (US_IER_USART_MANEA_1_Val      << US_IER_USART_MANEA_Pos)
-#define US_IER_USART_MASK           _U(0x011F3FE7) /**< \brief (US_IER_USART) MASK Register */
+#define US_IER_USART_MASK           _U_(0x011F3FE7) /**< \brief (US_IER_USART) MASK Register */
 
 // Any mode
 #define US_IER_RXRDY_Pos            0            /**< \brief (US_IER) Receiver Ready Interrupt Enable */
-#define US_IER_RXRDY                (_U(0x1) << US_IER_RXRDY_Pos)
-#define   US_IER_RXRDY_0_Val              _U(0x0)   /**< \brief (US_IER) No Effect */
-#define   US_IER_RXRDY_1_Val              _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_RXRDY                (_U_(0x1) << US_IER_RXRDY_Pos)
+#define   US_IER_RXRDY_0_Val              _U_(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_RXRDY_1_Val              _U_(0x1)   /**< \brief (US_IER) Enables the interrupt */
 #define US_IER_RXRDY_0              (US_IER_RXRDY_0_Val            << US_IER_RXRDY_Pos)
 #define US_IER_RXRDY_1              (US_IER_RXRDY_1_Val            << US_IER_RXRDY_Pos)
 #define US_IER_TXRDY_Pos            1            /**< \brief (US_IER) Transmitter Ready Interrupt Enable */
-#define US_IER_TXRDY                (_U(0x1) << US_IER_TXRDY_Pos)
-#define   US_IER_TXRDY_0_Val              _U(0x0)   /**< \brief (US_IER) No Effect */
-#define   US_IER_TXRDY_1_Val              _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_TXRDY                (_U_(0x1) << US_IER_TXRDY_Pos)
+#define   US_IER_TXRDY_0_Val              _U_(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_TXRDY_1_Val              _U_(0x1)   /**< \brief (US_IER) Enables the interrupt */
 #define US_IER_TXRDY_0              (US_IER_TXRDY_0_Val            << US_IER_TXRDY_Pos)
 #define US_IER_TXRDY_1              (US_IER_TXRDY_1_Val            << US_IER_TXRDY_Pos)
 #define US_IER_RXBRK_Pos            2            /**< \brief (US_IER) Receiver Break Interrupt Enable */
-#define US_IER_RXBRK                (_U(0x1) << US_IER_RXBRK_Pos)
-#define   US_IER_RXBRK_0_Val              _U(0x0)   /**< \brief (US_IER) No Effect */
-#define   US_IER_RXBRK_1_Val              _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_RXBRK                (_U_(0x1) << US_IER_RXBRK_Pos)
+#define   US_IER_RXBRK_0_Val              _U_(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_RXBRK_1_Val              _U_(0x1)   /**< \brief (US_IER) Enables the interrupt */
 #define US_IER_RXBRK_0              (US_IER_RXBRK_0_Val            << US_IER_RXBRK_Pos)
 #define US_IER_RXBRK_1              (US_IER_RXBRK_1_Val            << US_IER_RXBRK_Pos)
 #define US_IER_OVRE_Pos             5            /**< \brief (US_IER) Overrun Error Interrupt Enable */
-#define US_IER_OVRE                 (_U(0x1) << US_IER_OVRE_Pos)
-#define   US_IER_OVRE_0_Val               _U(0x0)   /**< \brief (US_IER) No Effect */
-#define   US_IER_OVRE_1_Val               _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_OVRE                 (_U_(0x1) << US_IER_OVRE_Pos)
+#define   US_IER_OVRE_0_Val               _U_(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_OVRE_1_Val               _U_(0x1)   /**< \brief (US_IER) Enables the interrupt */
 #define US_IER_OVRE_0               (US_IER_OVRE_0_Val             << US_IER_OVRE_Pos)
 #define US_IER_OVRE_1               (US_IER_OVRE_1_Val             << US_IER_OVRE_Pos)
 #define US_IER_FRAME_Pos            6            /**< \brief (US_IER) Framing Error Interrupt Enable */
-#define US_IER_FRAME                (_U(0x1) << US_IER_FRAME_Pos)
-#define   US_IER_FRAME_0_Val              _U(0x0)   /**< \brief (US_IER) No Effect */
-#define   US_IER_FRAME_1_Val              _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_FRAME                (_U_(0x1) << US_IER_FRAME_Pos)
+#define   US_IER_FRAME_0_Val              _U_(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_FRAME_1_Val              _U_(0x1)   /**< \brief (US_IER) Enables the interrupt */
 #define US_IER_FRAME_0              (US_IER_FRAME_0_Val            << US_IER_FRAME_Pos)
 #define US_IER_FRAME_1              (US_IER_FRAME_1_Val            << US_IER_FRAME_Pos)
 #define US_IER_PARE_Pos             7            /**< \brief (US_IER) Parity Error Interrupt Enable */
-#define US_IER_PARE                 (_U(0x1) << US_IER_PARE_Pos)
-#define   US_IER_PARE_0_Val               _U(0x0)   /**< \brief (US_IER) No Effect */
-#define   US_IER_PARE_1_Val               _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_PARE                 (_U_(0x1) << US_IER_PARE_Pos)
+#define   US_IER_PARE_0_Val               _U_(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_PARE_1_Val               _U_(0x1)   /**< \brief (US_IER) Enables the interrupt */
 #define US_IER_PARE_0               (US_IER_PARE_0_Val             << US_IER_PARE_Pos)
 #define US_IER_PARE_1               (US_IER_PARE_1_Val             << US_IER_PARE_Pos)
 #define US_IER_TIMEOUT_Pos          8            /**< \brief (US_IER) Time-out Interrupt Enable */
-#define US_IER_TIMEOUT              (_U(0x1) << US_IER_TIMEOUT_Pos)
-#define   US_IER_TIMEOUT_0_Val            _U(0x0)   /**< \brief (US_IER) No Effect */
-#define   US_IER_TIMEOUT_1_Val            _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_TIMEOUT              (_U_(0x1) << US_IER_TIMEOUT_Pos)
+#define   US_IER_TIMEOUT_0_Val            _U_(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_TIMEOUT_1_Val            _U_(0x1)   /**< \brief (US_IER) Enables the interrupt */
 #define US_IER_TIMEOUT_0            (US_IER_TIMEOUT_0_Val          << US_IER_TIMEOUT_Pos)
 #define US_IER_TIMEOUT_1            (US_IER_TIMEOUT_1_Val          << US_IER_TIMEOUT_Pos)
 #define US_IER_TXEMPTY_Pos          9            /**< \brief (US_IER) Transmitter Empty Interrupt Enable */
-#define US_IER_TXEMPTY              (_U(0x1) << US_IER_TXEMPTY_Pos)
-#define   US_IER_TXEMPTY_0_Val            _U(0x0)   /**< \brief (US_IER) No Effect */
-#define   US_IER_TXEMPTY_1_Val            _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_TXEMPTY              (_U_(0x1) << US_IER_TXEMPTY_Pos)
+#define   US_IER_TXEMPTY_0_Val            _U_(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_TXEMPTY_1_Val            _U_(0x1)   /**< \brief (US_IER) Enables the interrupt */
 #define US_IER_TXEMPTY_0            (US_IER_TXEMPTY_0_Val          << US_IER_TXEMPTY_Pos)
 #define US_IER_TXEMPTY_1            (US_IER_TXEMPTY_1_Val          << US_IER_TXEMPTY_Pos)
 #define US_IER_ITER_Pos             10           /**< \brief (US_IER) Iteration Interrupt Enable */
-#define US_IER_ITER                 (_U(0x1) << US_IER_ITER_Pos)
-#define   US_IER_ITER_0_Val               _U(0x0)   /**< \brief (US_IER) No Effect */
-#define   US_IER_ITER_1_Val               _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_ITER                 (_U_(0x1) << US_IER_ITER_Pos)
+#define   US_IER_ITER_0_Val               _U_(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_ITER_1_Val               _U_(0x1)   /**< \brief (US_IER) Enables the interrupt */
 #define US_IER_ITER_0               (US_IER_ITER_0_Val             << US_IER_ITER_Pos)
 #define US_IER_ITER_1               (US_IER_ITER_1_Val             << US_IER_ITER_Pos)
 #define US_IER_UNRE_Pos             10           /**< \brief (US_IER) SPI Underrun Error Interrupt Enable */
-#define US_IER_UNRE                 (_U(0x1) << US_IER_UNRE_Pos)
-#define   US_IER_UNRE_0_Val               _U(0x0)   /**< \brief (US_IER) No Effect */
-#define   US_IER_UNRE_1_Val               _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_UNRE                 (_U_(0x1) << US_IER_UNRE_Pos)
+#define   US_IER_UNRE_0_Val               _U_(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_UNRE_1_Val               _U_(0x1)   /**< \brief (US_IER) Enables the interrupt */
 #define US_IER_UNRE_0               (US_IER_UNRE_0_Val             << US_IER_UNRE_Pos)
 #define US_IER_UNRE_1               (US_IER_UNRE_1_Val             << US_IER_UNRE_Pos)
 #define US_IER_ITER_Pos             10           /**< \brief (US_IER) Iteration Interrupt Enable */
-#define US_IER_ITER                 (_U(0x1) << US_IER_ITER_Pos)
-#define   US_IER_ITER_0_Val               _U(0x0)   /**< \brief (US_IER) No Effect */
-#define   US_IER_ITER_1_Val               _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_ITER                 (_U_(0x1) << US_IER_ITER_Pos)
+#define   US_IER_ITER_0_Val               _U_(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_ITER_1_Val               _U_(0x1)   /**< \brief (US_IER) Enables the interrupt */
 #define US_IER_ITER_0               (US_IER_ITER_0_Val             << US_IER_ITER_Pos)
 #define US_IER_ITER_1               (US_IER_ITER_1_Val             << US_IER_ITER_Pos)
 #define US_IER_TXBUFE_Pos           11           /**< \brief (US_IER) Buffer Empty Interrupt Enable */
-#define US_IER_TXBUFE               (_U(0x1) << US_IER_TXBUFE_Pos)
-#define   US_IER_TXBUFE_0_Val             _U(0x0)   /**< \brief (US_IER) No Effect */
-#define   US_IER_TXBUFE_1_Val             _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_TXBUFE               (_U_(0x1) << US_IER_TXBUFE_Pos)
+#define   US_IER_TXBUFE_0_Val             _U_(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_TXBUFE_1_Val             _U_(0x1)   /**< \brief (US_IER) Enables the interrupt */
 #define US_IER_TXBUFE_0             (US_IER_TXBUFE_0_Val           << US_IER_TXBUFE_Pos)
 #define US_IER_TXBUFE_1             (US_IER_TXBUFE_1_Val           << US_IER_TXBUFE_Pos)
 #define US_IER_RXBUFF_Pos           12           /**< \brief (US_IER) Buffer Full Interrupt Enable */
-#define US_IER_RXBUFF               (_U(0x1) << US_IER_RXBUFF_Pos)
-#define   US_IER_RXBUFF_0_Val             _U(0x0)   /**< \brief (US_IER) No Effect */
-#define   US_IER_RXBUFF_1_Val             _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_RXBUFF               (_U_(0x1) << US_IER_RXBUFF_Pos)
+#define   US_IER_RXBUFF_0_Val             _U_(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_RXBUFF_1_Val             _U_(0x1)   /**< \brief (US_IER) Enables the interrupt */
 #define US_IER_RXBUFF_0             (US_IER_RXBUFF_0_Val           << US_IER_RXBUFF_Pos)
 #define US_IER_RXBUFF_1             (US_IER_RXBUFF_1_Val           << US_IER_RXBUFF_Pos)
 #define US_IER_NACK_Pos             13           /**< \brief (US_IER) Non Acknowledge  or LIN Break Sent or LIN Break Received Interrupt Enable */
-#define US_IER_NACK                 (_U(0x1) << US_IER_NACK_Pos)
-#define   US_IER_NACK_0_Val               _U(0x0)   /**< \brief (US_IER) No Effect */
-#define   US_IER_NACK_1_Val               _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_NACK                 (_U_(0x1) << US_IER_NACK_Pos)
+#define   US_IER_NACK_0_Val               _U_(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_NACK_1_Val               _U_(0x1)   /**< \brief (US_IER) Enables the interrupt */
 #define US_IER_NACK_0               (US_IER_NACK_0_Val             << US_IER_NACK_Pos)
 #define US_IER_NACK_1               (US_IER_NACK_1_Val             << US_IER_NACK_Pos)
 #define US_IER_LINID_Pos            14           /**< \brief (US_IER) LIN Identifier Sent or LIN Identifier Received Interrupt Enable */
-#define US_IER_LINID                (_U(0x1) << US_IER_LINID_Pos)
+#define US_IER_LINID                (_U_(0x1) << US_IER_LINID_Pos)
 #define US_IER_LINTC_Pos            15           /**< \brief (US_IER) LIN Transfer Conpleted Interrupt Enable */
-#define US_IER_LINTC                (_U(0x1) << US_IER_LINTC_Pos)
+#define US_IER_LINTC                (_U_(0x1) << US_IER_LINTC_Pos)
 #define US_IER_RIIC_Pos             16           /**< \brief (US_IER) Ring Indicator Input Change Enable */
-#define US_IER_RIIC                 (_U(0x1) << US_IER_RIIC_Pos)
-#define   US_IER_RIIC_0_Val               _U(0x0)   /**< \brief (US_IER) No Effect */
-#define   US_IER_RIIC_1_Val               _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_RIIC                 (_U_(0x1) << US_IER_RIIC_Pos)
+#define   US_IER_RIIC_0_Val               _U_(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_RIIC_1_Val               _U_(0x1)   /**< \brief (US_IER) Enables the interrupt */
 #define US_IER_RIIC_0               (US_IER_RIIC_0_Val             << US_IER_RIIC_Pos)
 #define US_IER_RIIC_1               (US_IER_RIIC_1_Val             << US_IER_RIIC_Pos)
 #define US_IER_DSRIC_Pos            17           /**< \brief (US_IER) Data Set Ready Input Change Enable */
-#define US_IER_DSRIC                (_U(0x1) << US_IER_DSRIC_Pos)
-#define   US_IER_DSRIC_0_Val              _U(0x0)   /**< \brief (US_IER) No Effect */
-#define   US_IER_DSRIC_1_Val              _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_DSRIC                (_U_(0x1) << US_IER_DSRIC_Pos)
+#define   US_IER_DSRIC_0_Val              _U_(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_DSRIC_1_Val              _U_(0x1)   /**< \brief (US_IER) Enables the interrupt */
 #define US_IER_DSRIC_0              (US_IER_DSRIC_0_Val            << US_IER_DSRIC_Pos)
 #define US_IER_DSRIC_1              (US_IER_DSRIC_1_Val            << US_IER_DSRIC_Pos)
 #define US_IER_DCDIC_Pos            18           /**< \brief (US_IER) Data Carrier Detect Input Change Interrupt Enable */
-#define US_IER_DCDIC                (_U(0x1) << US_IER_DCDIC_Pos)
-#define   US_IER_DCDIC_0_Val              _U(0x0)   /**< \brief (US_IER) No Effect */
-#define   US_IER_DCDIC_1_Val              _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_DCDIC                (_U_(0x1) << US_IER_DCDIC_Pos)
+#define   US_IER_DCDIC_0_Val              _U_(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_DCDIC_1_Val              _U_(0x1)   /**< \brief (US_IER) Enables the interrupt */
 #define US_IER_DCDIC_0              (US_IER_DCDIC_0_Val            << US_IER_DCDIC_Pos)
 #define US_IER_DCDIC_1              (US_IER_DCDIC_1_Val            << US_IER_DCDIC_Pos)
 #define US_IER_CTSIC_Pos            19           /**< \brief (US_IER) Clear to Send Input Change Interrupt Enable */
-#define US_IER_CTSIC                (_U(0x1) << US_IER_CTSIC_Pos)
-#define   US_IER_CTSIC_0_Val              _U(0x0)   /**< \brief (US_IER) No Effect */
-#define   US_IER_CTSIC_1_Val              _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_CTSIC                (_U_(0x1) << US_IER_CTSIC_Pos)
+#define   US_IER_CTSIC_0_Val              _U_(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_CTSIC_1_Val              _U_(0x1)   /**< \brief (US_IER) Enables the interrupt */
 #define US_IER_CTSIC_0              (US_IER_CTSIC_0_Val            << US_IER_CTSIC_Pos)
 #define US_IER_CTSIC_1              (US_IER_CTSIC_1_Val            << US_IER_CTSIC_Pos)
 #define US_IER_MANE_Pos             20           /**< \brief (US_IER) Manchester Error Interrupt Enable */
-#define US_IER_MANE                 (_U(0x1) << US_IER_MANE_Pos)
+#define US_IER_MANE                 (_U_(0x1) << US_IER_MANE_Pos)
 #define US_IER_MANEA_Pos            24           /**< \brief (US_IER) Manchester Error Interrupt Enable */
-#define US_IER_MANEA                (_U(0x1) << US_IER_MANEA_Pos)
-#define   US_IER_MANEA_0_Val              _U(0x0)   /**< \brief (US_IER) No effect */
-#define   US_IER_MANEA_1_Val              _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_MANEA                (_U_(0x1) << US_IER_MANEA_Pos)
+#define   US_IER_MANEA_0_Val              _U_(0x0)   /**< \brief (US_IER) No effect */
+#define   US_IER_MANEA_1_Val              _U_(0x1)   /**< \brief (US_IER) Enables the interrupt */
 #define US_IER_MANEA_0              (US_IER_MANEA_0_Val            << US_IER_MANEA_Pos)
 #define US_IER_MANEA_1              (US_IER_MANEA_1_Val            << US_IER_MANEA_Pos)
 #define US_IER_LINBE_Pos            25           /**< \brief (US_IER) LIN Bus Error Interrupt Enable */
-#define US_IER_LINBE                (_U(0x1) << US_IER_LINBE_Pos)
+#define US_IER_LINBE                (_U_(0x1) << US_IER_LINBE_Pos)
 #define US_IER_LINISFE_Pos          26           /**< \brief (US_IER) LIN Inconsistent Synch Field Error Interrupt Enable */
-#define US_IER_LINISFE              (_U(0x1) << US_IER_LINISFE_Pos)
+#define US_IER_LINISFE              (_U_(0x1) << US_IER_LINISFE_Pos)
 #define US_IER_LINIPE_Pos           27           /**< \brief (US_IER) LIN Identifier Parity Interrupt Enable */
-#define US_IER_LINIPE               (_U(0x1) << US_IER_LINIPE_Pos)
+#define US_IER_LINIPE               (_U_(0x1) << US_IER_LINIPE_Pos)
 #define US_IER_LINCE_Pos            28           /**< \brief (US_IER) LIN Checksum Error Interrupt Enable */
-#define US_IER_LINCE                (_U(0x1) << US_IER_LINCE_Pos)
+#define US_IER_LINCE                (_U_(0x1) << US_IER_LINCE_Pos)
 #define US_IER_LINSNRE_Pos          29           /**< \brief (US_IER) LIN Slave Not Responding Error Interrupt Enable */
-#define US_IER_LINSNRE              (_U(0x1) << US_IER_LINSNRE_Pos)
+#define US_IER_LINSNRE              (_U_(0x1) << US_IER_LINSNRE_Pos)
 #define US_IER_LINSTE_Pos           30           /**< \brief (US_IER) LIN Synch Tolerance Error Interrupt Enable */
-#define US_IER_LINSTE               (_U(0x1) << US_IER_LINSTE_Pos)
-#define   US_IER_LINSTE_0_Val             _U(0x0)   /**< \brief (US_IER) No Effect */
-#define   US_IER_LINSTE_1_Val             _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_LINSTE               (_U_(0x1) << US_IER_LINSTE_Pos)
+#define   US_IER_LINSTE_0_Val             _U_(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_LINSTE_1_Val             _U_(0x1)   /**< \brief (US_IER) Enables the interrupt */
 #define US_IER_LINSTE_0             (US_IER_LINSTE_0_Val           << US_IER_LINSTE_Pos)
 #define US_IER_LINSTE_1             (US_IER_LINSTE_1_Val           << US_IER_LINSTE_Pos)
 #define US_IER_LINHTE_Pos           31           /**< \brief (US_IER) LIN Header Timeout Error Interrupt Enable */
-#define US_IER_LINHTE               (_U(0x1) << US_IER_LINHTE_Pos)
-#define   US_IER_LINHTE_0_Val             _U(0x0)   /**< \brief (US_IER) No Effect */
-#define   US_IER_LINHTE_1_Val             _U(0x1)   /**< \brief (US_IER) Enables the interrupt */
+#define US_IER_LINHTE               (_U_(0x1) << US_IER_LINHTE_Pos)
+#define   US_IER_LINHTE_0_Val             _U_(0x0)   /**< \brief (US_IER) No Effect */
+#define   US_IER_LINHTE_1_Val             _U_(0x1)   /**< \brief (US_IER) Enables the interrupt */
 #define US_IER_LINHTE_0             (US_IER_LINHTE_0_Val           << US_IER_LINHTE_Pos)
 #define US_IER_LINHTE_1             (US_IER_LINHTE_1_Val           << US_IER_LINHTE_Pos)
-#define US_IER_MASK                 _U(0xFF1FFFE7) /**< \brief (US_IER) MASK Register */
+#define US_IER_MASK                 _U_(0xFF1FFFE7) /**< \brief (US_IER) MASK Register */
 
 /* -------- US_IDR : (USART Offset: 0x0C) ( /W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1779,483 +1779,483 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_IDR_OFFSET               0x0C         /**< \brief (US_IDR offset) Interrupt Disable Register */
-#define US_IDR_RESETVALUE           _U(0x00000000); /**< \brief (US_IDR reset_value) Interrupt Disable Register */
+#define US_IDR_RESETVALUE           _U_(0x00000000); /**< \brief (US_IDR reset_value) Interrupt Disable Register */
 
 // LIN mode
 #define US_IDR_LIN_RXRDY_Pos        0            /**< \brief (US_IDR_LIN) Receiver Ready Interrupt Disable */
-#define US_IDR_LIN_RXRDY            (_U(0x1) << US_IDR_LIN_RXRDY_Pos)
-#define   US_IDR_LIN_RXRDY_0_Val          _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
-#define   US_IDR_LIN_RXRDY_1_Val          _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_RXRDY            (_U_(0x1) << US_IDR_LIN_RXRDY_Pos)
+#define   US_IDR_LIN_RXRDY_0_Val          _U_(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_RXRDY_1_Val          _U_(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
 #define US_IDR_LIN_RXRDY_0          (US_IDR_LIN_RXRDY_0_Val        << US_IDR_LIN_RXRDY_Pos)
 #define US_IDR_LIN_RXRDY_1          (US_IDR_LIN_RXRDY_1_Val        << US_IDR_LIN_RXRDY_Pos)
 #define US_IDR_LIN_TXRDY_Pos        1            /**< \brief (US_IDR_LIN) Transmitter Ready Interrupt Disable */
-#define US_IDR_LIN_TXRDY            (_U(0x1) << US_IDR_LIN_TXRDY_Pos)
-#define   US_IDR_LIN_TXRDY_0_Val          _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
-#define   US_IDR_LIN_TXRDY_1_Val          _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_TXRDY            (_U_(0x1) << US_IDR_LIN_TXRDY_Pos)
+#define   US_IDR_LIN_TXRDY_0_Val          _U_(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_TXRDY_1_Val          _U_(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
 #define US_IDR_LIN_TXRDY_0          (US_IDR_LIN_TXRDY_0_Val        << US_IDR_LIN_TXRDY_Pos)
 #define US_IDR_LIN_TXRDY_1          (US_IDR_LIN_TXRDY_1_Val        << US_IDR_LIN_TXRDY_Pos)
 #define US_IDR_LIN_RXBRK_Pos        2            /**< \brief (US_IDR_LIN) Receiver Break Interrupt Disable */
-#define US_IDR_LIN_RXBRK            (_U(0x1) << US_IDR_LIN_RXBRK_Pos)
-#define   US_IDR_LIN_RXBRK_0_Val          _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
-#define   US_IDR_LIN_RXBRK_1_Val          _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_RXBRK            (_U_(0x1) << US_IDR_LIN_RXBRK_Pos)
+#define   US_IDR_LIN_RXBRK_0_Val          _U_(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_RXBRK_1_Val          _U_(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
 #define US_IDR_LIN_RXBRK_0          (US_IDR_LIN_RXBRK_0_Val        << US_IDR_LIN_RXBRK_Pos)
 #define US_IDR_LIN_RXBRK_1          (US_IDR_LIN_RXBRK_1_Val        << US_IDR_LIN_RXBRK_Pos)
 #define US_IDR_LIN_OVRE_Pos         5            /**< \brief (US_IDR_LIN) Overrun Error Interrupt Disable */
-#define US_IDR_LIN_OVRE             (_U(0x1) << US_IDR_LIN_OVRE_Pos)
-#define   US_IDR_LIN_OVRE_0_Val           _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
-#define   US_IDR_LIN_OVRE_1_Val           _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_OVRE             (_U_(0x1) << US_IDR_LIN_OVRE_Pos)
+#define   US_IDR_LIN_OVRE_0_Val           _U_(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_OVRE_1_Val           _U_(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
 #define US_IDR_LIN_OVRE_0           (US_IDR_LIN_OVRE_0_Val         << US_IDR_LIN_OVRE_Pos)
 #define US_IDR_LIN_OVRE_1           (US_IDR_LIN_OVRE_1_Val         << US_IDR_LIN_OVRE_Pos)
 #define US_IDR_LIN_FRAME_Pos        6            /**< \brief (US_IDR_LIN) Framing Error Interrupt Disable */
-#define US_IDR_LIN_FRAME            (_U(0x1) << US_IDR_LIN_FRAME_Pos)
-#define   US_IDR_LIN_FRAME_0_Val          _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
-#define   US_IDR_LIN_FRAME_1_Val          _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_FRAME            (_U_(0x1) << US_IDR_LIN_FRAME_Pos)
+#define   US_IDR_LIN_FRAME_0_Val          _U_(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_FRAME_1_Val          _U_(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
 #define US_IDR_LIN_FRAME_0          (US_IDR_LIN_FRAME_0_Val        << US_IDR_LIN_FRAME_Pos)
 #define US_IDR_LIN_FRAME_1          (US_IDR_LIN_FRAME_1_Val        << US_IDR_LIN_FRAME_Pos)
 #define US_IDR_LIN_PARE_Pos         7            /**< \brief (US_IDR_LIN) Parity Error Interrupt Disable */
-#define US_IDR_LIN_PARE             (_U(0x1) << US_IDR_LIN_PARE_Pos)
-#define   US_IDR_LIN_PARE_0_Val           _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
-#define   US_IDR_LIN_PARE_1_Val           _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_PARE             (_U_(0x1) << US_IDR_LIN_PARE_Pos)
+#define   US_IDR_LIN_PARE_0_Val           _U_(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_PARE_1_Val           _U_(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
 #define US_IDR_LIN_PARE_0           (US_IDR_LIN_PARE_0_Val         << US_IDR_LIN_PARE_Pos)
 #define US_IDR_LIN_PARE_1           (US_IDR_LIN_PARE_1_Val         << US_IDR_LIN_PARE_Pos)
 #define US_IDR_LIN_TIMEOUT_Pos      8            /**< \brief (US_IDR_LIN) Time-out Interrupt Disable */
-#define US_IDR_LIN_TIMEOUT          (_U(0x1) << US_IDR_LIN_TIMEOUT_Pos)
-#define   US_IDR_LIN_TIMEOUT_0_Val        _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
-#define   US_IDR_LIN_TIMEOUT_1_Val        _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_TIMEOUT          (_U_(0x1) << US_IDR_LIN_TIMEOUT_Pos)
+#define   US_IDR_LIN_TIMEOUT_0_Val        _U_(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_TIMEOUT_1_Val        _U_(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
 #define US_IDR_LIN_TIMEOUT_0        (US_IDR_LIN_TIMEOUT_0_Val      << US_IDR_LIN_TIMEOUT_Pos)
 #define US_IDR_LIN_TIMEOUT_1        (US_IDR_LIN_TIMEOUT_1_Val      << US_IDR_LIN_TIMEOUT_Pos)
 #define US_IDR_LIN_TXEMPTY_Pos      9            /**< \brief (US_IDR_LIN) Transmitter Empty Interrupt Disable */
-#define US_IDR_LIN_TXEMPTY          (_U(0x1) << US_IDR_LIN_TXEMPTY_Pos)
-#define   US_IDR_LIN_TXEMPTY_0_Val        _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
-#define   US_IDR_LIN_TXEMPTY_1_Val        _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_TXEMPTY          (_U_(0x1) << US_IDR_LIN_TXEMPTY_Pos)
+#define   US_IDR_LIN_TXEMPTY_0_Val        _U_(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_TXEMPTY_1_Val        _U_(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
 #define US_IDR_LIN_TXEMPTY_0        (US_IDR_LIN_TXEMPTY_0_Val      << US_IDR_LIN_TXEMPTY_Pos)
 #define US_IDR_LIN_TXEMPTY_1        (US_IDR_LIN_TXEMPTY_1_Val      << US_IDR_LIN_TXEMPTY_Pos)
 #define US_IDR_LIN_ITER_Pos         10           /**< \brief (US_IDR_LIN) Iteration Interrupt Disable */
-#define US_IDR_LIN_ITER             (_U(0x1) << US_IDR_LIN_ITER_Pos)
-#define   US_IDR_LIN_ITER_0_Val           _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
-#define   US_IDR_LIN_ITER_1_Val           _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_ITER             (_U_(0x1) << US_IDR_LIN_ITER_Pos)
+#define   US_IDR_LIN_ITER_0_Val           _U_(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_ITER_1_Val           _U_(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
 #define US_IDR_LIN_ITER_0           (US_IDR_LIN_ITER_0_Val         << US_IDR_LIN_ITER_Pos)
 #define US_IDR_LIN_ITER_1           (US_IDR_LIN_ITER_1_Val         << US_IDR_LIN_ITER_Pos)
 #define US_IDR_LIN_TXBUFE_Pos       11           /**< \brief (US_IDR_LIN) Buffer Empty Interrupt Disable */
-#define US_IDR_LIN_TXBUFE           (_U(0x1) << US_IDR_LIN_TXBUFE_Pos)
-#define   US_IDR_LIN_TXBUFE_0_Val         _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
-#define   US_IDR_LIN_TXBUFE_1_Val         _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_TXBUFE           (_U_(0x1) << US_IDR_LIN_TXBUFE_Pos)
+#define   US_IDR_LIN_TXBUFE_0_Val         _U_(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_TXBUFE_1_Val         _U_(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
 #define US_IDR_LIN_TXBUFE_0         (US_IDR_LIN_TXBUFE_0_Val       << US_IDR_LIN_TXBUFE_Pos)
 #define US_IDR_LIN_TXBUFE_1         (US_IDR_LIN_TXBUFE_1_Val       << US_IDR_LIN_TXBUFE_Pos)
 #define US_IDR_LIN_RXBUFF_Pos       12           /**< \brief (US_IDR_LIN) Buffer Full Interrupt Disable */
-#define US_IDR_LIN_RXBUFF           (_U(0x1) << US_IDR_LIN_RXBUFF_Pos)
-#define   US_IDR_LIN_RXBUFF_0_Val         _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
-#define   US_IDR_LIN_RXBUFF_1_Val         _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_RXBUFF           (_U_(0x1) << US_IDR_LIN_RXBUFF_Pos)
+#define   US_IDR_LIN_RXBUFF_0_Val         _U_(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_RXBUFF_1_Val         _U_(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
 #define US_IDR_LIN_RXBUFF_0         (US_IDR_LIN_RXBUFF_0_Val       << US_IDR_LIN_RXBUFF_Pos)
 #define US_IDR_LIN_RXBUFF_1         (US_IDR_LIN_RXBUFF_1_Val       << US_IDR_LIN_RXBUFF_Pos)
 #define US_IDR_LIN_NACK_Pos         13           /**< \brief (US_IDR_LIN) Non Acknowledge  or LIN Break Sent or LIN Break Received Interrupt Disable */
-#define US_IDR_LIN_NACK             (_U(0x1) << US_IDR_LIN_NACK_Pos)
-#define   US_IDR_LIN_NACK_0_Val           _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
-#define   US_IDR_LIN_NACK_1_Val           _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_NACK             (_U_(0x1) << US_IDR_LIN_NACK_Pos)
+#define   US_IDR_LIN_NACK_0_Val           _U_(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_NACK_1_Val           _U_(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
 #define US_IDR_LIN_NACK_0           (US_IDR_LIN_NACK_0_Val         << US_IDR_LIN_NACK_Pos)
 #define US_IDR_LIN_NACK_1           (US_IDR_LIN_NACK_1_Val         << US_IDR_LIN_NACK_Pos)
 #define US_IDR_LIN_LINID_Pos        14           /**< \brief (US_IDR_LIN) LIN Identifier Sent or LIN Identifier Received Interrupt Disable */
-#define US_IDR_LIN_LINID            (_U(0x1) << US_IDR_LIN_LINID_Pos)
+#define US_IDR_LIN_LINID            (_U_(0x1) << US_IDR_LIN_LINID_Pos)
 #define US_IDR_LIN_LINTC_Pos        15           /**< \brief (US_IDR_LIN) LIN Transfer Conpleted Interrupt Disable */
-#define US_IDR_LIN_LINTC            (_U(0x1) << US_IDR_LIN_LINTC_Pos)
+#define US_IDR_LIN_LINTC            (_U_(0x1) << US_IDR_LIN_LINTC_Pos)
 #define US_IDR_LIN_RIIC_Pos         16           /**< \brief (US_IDR_LIN) Ring Indicator Input Change Disable */
-#define US_IDR_LIN_RIIC             (_U(0x1) << US_IDR_LIN_RIIC_Pos)
-#define   US_IDR_LIN_RIIC_0_Val           _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
-#define   US_IDR_LIN_RIIC_1_Val           _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_RIIC             (_U_(0x1) << US_IDR_LIN_RIIC_Pos)
+#define   US_IDR_LIN_RIIC_0_Val           _U_(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_RIIC_1_Val           _U_(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
 #define US_IDR_LIN_RIIC_0           (US_IDR_LIN_RIIC_0_Val         << US_IDR_LIN_RIIC_Pos)
 #define US_IDR_LIN_RIIC_1           (US_IDR_LIN_RIIC_1_Val         << US_IDR_LIN_RIIC_Pos)
 #define US_IDR_LIN_DSRIC_Pos        17           /**< \brief (US_IDR_LIN) Data Set Ready Input Change Disable */
-#define US_IDR_LIN_DSRIC            (_U(0x1) << US_IDR_LIN_DSRIC_Pos)
-#define   US_IDR_LIN_DSRIC_0_Val          _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
-#define   US_IDR_LIN_DSRIC_1_Val          _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_DSRIC            (_U_(0x1) << US_IDR_LIN_DSRIC_Pos)
+#define   US_IDR_LIN_DSRIC_0_Val          _U_(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_DSRIC_1_Val          _U_(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
 #define US_IDR_LIN_DSRIC_0          (US_IDR_LIN_DSRIC_0_Val        << US_IDR_LIN_DSRIC_Pos)
 #define US_IDR_LIN_DSRIC_1          (US_IDR_LIN_DSRIC_1_Val        << US_IDR_LIN_DSRIC_Pos)
 #define US_IDR_LIN_DCDIC_Pos        18           /**< \brief (US_IDR_LIN) Data Carrier Detect Input Change Interrupt Disable */
-#define US_IDR_LIN_DCDIC            (_U(0x1) << US_IDR_LIN_DCDIC_Pos)
-#define   US_IDR_LIN_DCDIC_0_Val          _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
-#define   US_IDR_LIN_DCDIC_1_Val          _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_DCDIC            (_U_(0x1) << US_IDR_LIN_DCDIC_Pos)
+#define   US_IDR_LIN_DCDIC_0_Val          _U_(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_DCDIC_1_Val          _U_(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
 #define US_IDR_LIN_DCDIC_0          (US_IDR_LIN_DCDIC_0_Val        << US_IDR_LIN_DCDIC_Pos)
 #define US_IDR_LIN_DCDIC_1          (US_IDR_LIN_DCDIC_1_Val        << US_IDR_LIN_DCDIC_Pos)
 #define US_IDR_LIN_CTSIC_Pos        19           /**< \brief (US_IDR_LIN) Clear to Send Input Change Interrupt Disable */
-#define US_IDR_LIN_CTSIC            (_U(0x1) << US_IDR_LIN_CTSIC_Pos)
-#define   US_IDR_LIN_CTSIC_0_Val          _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
-#define   US_IDR_LIN_CTSIC_1_Val          _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_CTSIC            (_U_(0x1) << US_IDR_LIN_CTSIC_Pos)
+#define   US_IDR_LIN_CTSIC_0_Val          _U_(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_CTSIC_1_Val          _U_(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
 #define US_IDR_LIN_CTSIC_0          (US_IDR_LIN_CTSIC_0_Val        << US_IDR_LIN_CTSIC_Pos)
 #define US_IDR_LIN_CTSIC_1          (US_IDR_LIN_CTSIC_1_Val        << US_IDR_LIN_CTSIC_Pos)
 #define US_IDR_LIN_LINBE_Pos        25           /**< \brief (US_IDR_LIN) LIN Bus Error Interrupt Disable */
-#define US_IDR_LIN_LINBE            (_U(0x1) << US_IDR_LIN_LINBE_Pos)
+#define US_IDR_LIN_LINBE            (_U_(0x1) << US_IDR_LIN_LINBE_Pos)
 #define US_IDR_LIN_LINISFE_Pos      26           /**< \brief (US_IDR_LIN) LIN Inconsistent Synch Field Error Interrupt Disable */
-#define US_IDR_LIN_LINISFE          (_U(0x1) << US_IDR_LIN_LINISFE_Pos)
+#define US_IDR_LIN_LINISFE          (_U_(0x1) << US_IDR_LIN_LINISFE_Pos)
 #define US_IDR_LIN_LINIPE_Pos       27           /**< \brief (US_IDR_LIN) LIN Identifier Parity Interrupt Disable */
-#define US_IDR_LIN_LINIPE           (_U(0x1) << US_IDR_LIN_LINIPE_Pos)
+#define US_IDR_LIN_LINIPE           (_U_(0x1) << US_IDR_LIN_LINIPE_Pos)
 #define US_IDR_LIN_LINCE_Pos        28           /**< \brief (US_IDR_LIN) LIN Checksum Error Interrupt Disable */
-#define US_IDR_LIN_LINCE            (_U(0x1) << US_IDR_LIN_LINCE_Pos)
+#define US_IDR_LIN_LINCE            (_U_(0x1) << US_IDR_LIN_LINCE_Pos)
 #define US_IDR_LIN_LINSNRE_Pos      29           /**< \brief (US_IDR_LIN) LIN Slave Not Responding Error Interrupt Disable */
-#define US_IDR_LIN_LINSNRE          (_U(0x1) << US_IDR_LIN_LINSNRE_Pos)
+#define US_IDR_LIN_LINSNRE          (_U_(0x1) << US_IDR_LIN_LINSNRE_Pos)
 #define US_IDR_LIN_LINSTE_Pos       30           /**< \brief (US_IDR_LIN) LIN Synch Tolerance Error Interrupt Disable */
-#define US_IDR_LIN_LINSTE           (_U(0x1) << US_IDR_LIN_LINSTE_Pos)
-#define   US_IDR_LIN_LINSTE_0_Val         _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
-#define   US_IDR_LIN_LINSTE_1_Val         _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_LINSTE           (_U_(0x1) << US_IDR_LIN_LINSTE_Pos)
+#define   US_IDR_LIN_LINSTE_0_Val         _U_(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_LINSTE_1_Val         _U_(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
 #define US_IDR_LIN_LINSTE_0         (US_IDR_LIN_LINSTE_0_Val       << US_IDR_LIN_LINSTE_Pos)
 #define US_IDR_LIN_LINSTE_1         (US_IDR_LIN_LINSTE_1_Val       << US_IDR_LIN_LINSTE_Pos)
 #define US_IDR_LIN_LINHTE_Pos       31           /**< \brief (US_IDR_LIN) LIN Header Timeout Error Interrupt Disable */
-#define US_IDR_LIN_LINHTE           (_U(0x1) << US_IDR_LIN_LINHTE_Pos)
-#define   US_IDR_LIN_LINHTE_0_Val         _U(0x0)   /**< \brief (US_IDR_LIN) No Effect */
-#define   US_IDR_LIN_LINHTE_1_Val         _U(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
+#define US_IDR_LIN_LINHTE           (_U_(0x1) << US_IDR_LIN_LINHTE_Pos)
+#define   US_IDR_LIN_LINHTE_0_Val         _U_(0x0)   /**< \brief (US_IDR_LIN) No Effect */
+#define   US_IDR_LIN_LINHTE_1_Val         _U_(0x1)   /**< \brief (US_IDR_LIN) Disables the interrupt */
 #define US_IDR_LIN_LINHTE_0         (US_IDR_LIN_LINHTE_0_Val       << US_IDR_LIN_LINHTE_Pos)
 #define US_IDR_LIN_LINHTE_1         (US_IDR_LIN_LINHTE_1_Val       << US_IDR_LIN_LINHTE_Pos)
-#define US_IDR_LIN_MASK             _U(0xFE0FFFE7) /**< \brief (US_IDR_LIN) MASK Register */
+#define US_IDR_LIN_MASK             _U_(0xFE0FFFE7) /**< \brief (US_IDR_LIN) MASK Register */
 
 // SPI_SLAVE mode
 #define US_IDR_SPI_SLAVE_RXRDY_Pos  0            /**< \brief (US_IDR_SPI_SLAVE) Receiver Ready Interrupt Disable */
-#define US_IDR_SPI_SLAVE_RXRDY      (_U(0x1) << US_IDR_SPI_SLAVE_RXRDY_Pos)
-#define   US_IDR_SPI_SLAVE_RXRDY_0_Val    _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
-#define   US_IDR_SPI_SLAVE_RXRDY_1_Val    _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_RXRDY      (_U_(0x1) << US_IDR_SPI_SLAVE_RXRDY_Pos)
+#define   US_IDR_SPI_SLAVE_RXRDY_0_Val    _U_(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_RXRDY_1_Val    _U_(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
 #define US_IDR_SPI_SLAVE_RXRDY_0    (US_IDR_SPI_SLAVE_RXRDY_0_Val  << US_IDR_SPI_SLAVE_RXRDY_Pos)
 #define US_IDR_SPI_SLAVE_RXRDY_1    (US_IDR_SPI_SLAVE_RXRDY_1_Val  << US_IDR_SPI_SLAVE_RXRDY_Pos)
 #define US_IDR_SPI_SLAVE_TXRDY_Pos  1            /**< \brief (US_IDR_SPI_SLAVE) Transmitter Ready Interrupt Disable */
-#define US_IDR_SPI_SLAVE_TXRDY      (_U(0x1) << US_IDR_SPI_SLAVE_TXRDY_Pos)
-#define   US_IDR_SPI_SLAVE_TXRDY_0_Val    _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
-#define   US_IDR_SPI_SLAVE_TXRDY_1_Val    _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_TXRDY      (_U_(0x1) << US_IDR_SPI_SLAVE_TXRDY_Pos)
+#define   US_IDR_SPI_SLAVE_TXRDY_0_Val    _U_(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_TXRDY_1_Val    _U_(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
 #define US_IDR_SPI_SLAVE_TXRDY_0    (US_IDR_SPI_SLAVE_TXRDY_0_Val  << US_IDR_SPI_SLAVE_TXRDY_Pos)
 #define US_IDR_SPI_SLAVE_TXRDY_1    (US_IDR_SPI_SLAVE_TXRDY_1_Val  << US_IDR_SPI_SLAVE_TXRDY_Pos)
 #define US_IDR_SPI_SLAVE_RXBRK_Pos  2            /**< \brief (US_IDR_SPI_SLAVE) Receiver Break Interrupt Disable */
-#define US_IDR_SPI_SLAVE_RXBRK      (_U(0x1) << US_IDR_SPI_SLAVE_RXBRK_Pos)
-#define   US_IDR_SPI_SLAVE_RXBRK_0_Val    _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
-#define   US_IDR_SPI_SLAVE_RXBRK_1_Val    _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_RXBRK      (_U_(0x1) << US_IDR_SPI_SLAVE_RXBRK_Pos)
+#define   US_IDR_SPI_SLAVE_RXBRK_0_Val    _U_(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_RXBRK_1_Val    _U_(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
 #define US_IDR_SPI_SLAVE_RXBRK_0    (US_IDR_SPI_SLAVE_RXBRK_0_Val  << US_IDR_SPI_SLAVE_RXBRK_Pos)
 #define US_IDR_SPI_SLAVE_RXBRK_1    (US_IDR_SPI_SLAVE_RXBRK_1_Val  << US_IDR_SPI_SLAVE_RXBRK_Pos)
 #define US_IDR_SPI_SLAVE_OVRE_Pos   5            /**< \brief (US_IDR_SPI_SLAVE) Overrun Error Interrupt Disable */
-#define US_IDR_SPI_SLAVE_OVRE       (_U(0x1) << US_IDR_SPI_SLAVE_OVRE_Pos)
-#define   US_IDR_SPI_SLAVE_OVRE_0_Val     _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
-#define   US_IDR_SPI_SLAVE_OVRE_1_Val     _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_OVRE       (_U_(0x1) << US_IDR_SPI_SLAVE_OVRE_Pos)
+#define   US_IDR_SPI_SLAVE_OVRE_0_Val     _U_(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_OVRE_1_Val     _U_(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
 #define US_IDR_SPI_SLAVE_OVRE_0     (US_IDR_SPI_SLAVE_OVRE_0_Val   << US_IDR_SPI_SLAVE_OVRE_Pos)
 #define US_IDR_SPI_SLAVE_OVRE_1     (US_IDR_SPI_SLAVE_OVRE_1_Val   << US_IDR_SPI_SLAVE_OVRE_Pos)
 #define US_IDR_SPI_SLAVE_FRAME_Pos  6            /**< \brief (US_IDR_SPI_SLAVE) Framing Error Interrupt Disable */
-#define US_IDR_SPI_SLAVE_FRAME      (_U(0x1) << US_IDR_SPI_SLAVE_FRAME_Pos)
-#define   US_IDR_SPI_SLAVE_FRAME_0_Val    _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
-#define   US_IDR_SPI_SLAVE_FRAME_1_Val    _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_FRAME      (_U_(0x1) << US_IDR_SPI_SLAVE_FRAME_Pos)
+#define   US_IDR_SPI_SLAVE_FRAME_0_Val    _U_(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_FRAME_1_Val    _U_(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
 #define US_IDR_SPI_SLAVE_FRAME_0    (US_IDR_SPI_SLAVE_FRAME_0_Val  << US_IDR_SPI_SLAVE_FRAME_Pos)
 #define US_IDR_SPI_SLAVE_FRAME_1    (US_IDR_SPI_SLAVE_FRAME_1_Val  << US_IDR_SPI_SLAVE_FRAME_Pos)
 #define US_IDR_SPI_SLAVE_PARE_Pos   7            /**< \brief (US_IDR_SPI_SLAVE) Parity Error Interrupt Disable */
-#define US_IDR_SPI_SLAVE_PARE       (_U(0x1) << US_IDR_SPI_SLAVE_PARE_Pos)
-#define   US_IDR_SPI_SLAVE_PARE_0_Val     _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
-#define   US_IDR_SPI_SLAVE_PARE_1_Val     _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_PARE       (_U_(0x1) << US_IDR_SPI_SLAVE_PARE_Pos)
+#define   US_IDR_SPI_SLAVE_PARE_0_Val     _U_(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_PARE_1_Val     _U_(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
 #define US_IDR_SPI_SLAVE_PARE_0     (US_IDR_SPI_SLAVE_PARE_0_Val   << US_IDR_SPI_SLAVE_PARE_Pos)
 #define US_IDR_SPI_SLAVE_PARE_1     (US_IDR_SPI_SLAVE_PARE_1_Val   << US_IDR_SPI_SLAVE_PARE_Pos)
 #define US_IDR_SPI_SLAVE_TIMEOUT_Pos 8            /**< \brief (US_IDR_SPI_SLAVE) Time-out Interrupt Disable */
-#define US_IDR_SPI_SLAVE_TIMEOUT    (_U(0x1) << US_IDR_SPI_SLAVE_TIMEOUT_Pos)
-#define   US_IDR_SPI_SLAVE_TIMEOUT_0_Val  _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
-#define   US_IDR_SPI_SLAVE_TIMEOUT_1_Val  _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_TIMEOUT    (_U_(0x1) << US_IDR_SPI_SLAVE_TIMEOUT_Pos)
+#define   US_IDR_SPI_SLAVE_TIMEOUT_0_Val  _U_(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_TIMEOUT_1_Val  _U_(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
 #define US_IDR_SPI_SLAVE_TIMEOUT_0  (US_IDR_SPI_SLAVE_TIMEOUT_0_Val << US_IDR_SPI_SLAVE_TIMEOUT_Pos)
 #define US_IDR_SPI_SLAVE_TIMEOUT_1  (US_IDR_SPI_SLAVE_TIMEOUT_1_Val << US_IDR_SPI_SLAVE_TIMEOUT_Pos)
 #define US_IDR_SPI_SLAVE_TXEMPTY_Pos 9            /**< \brief (US_IDR_SPI_SLAVE) Transmitter Empty Interrupt Disable */
-#define US_IDR_SPI_SLAVE_TXEMPTY    (_U(0x1) << US_IDR_SPI_SLAVE_TXEMPTY_Pos)
-#define   US_IDR_SPI_SLAVE_TXEMPTY_0_Val  _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
-#define   US_IDR_SPI_SLAVE_TXEMPTY_1_Val  _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_TXEMPTY    (_U_(0x1) << US_IDR_SPI_SLAVE_TXEMPTY_Pos)
+#define   US_IDR_SPI_SLAVE_TXEMPTY_0_Val  _U_(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_TXEMPTY_1_Val  _U_(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
 #define US_IDR_SPI_SLAVE_TXEMPTY_0  (US_IDR_SPI_SLAVE_TXEMPTY_0_Val << US_IDR_SPI_SLAVE_TXEMPTY_Pos)
 #define US_IDR_SPI_SLAVE_TXEMPTY_1  (US_IDR_SPI_SLAVE_TXEMPTY_1_Val << US_IDR_SPI_SLAVE_TXEMPTY_Pos)
 #define US_IDR_SPI_SLAVE_UNRE_Pos   10           /**< \brief (US_IDR_SPI_SLAVE) SPI Underrun Error Interrupt Disable */
-#define US_IDR_SPI_SLAVE_UNRE       (_U(0x1) << US_IDR_SPI_SLAVE_UNRE_Pos)
-#define   US_IDR_SPI_SLAVE_UNRE_0_Val     _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
-#define   US_IDR_SPI_SLAVE_UNRE_1_Val     _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_UNRE       (_U_(0x1) << US_IDR_SPI_SLAVE_UNRE_Pos)
+#define   US_IDR_SPI_SLAVE_UNRE_0_Val     _U_(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_UNRE_1_Val     _U_(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
 #define US_IDR_SPI_SLAVE_UNRE_0     (US_IDR_SPI_SLAVE_UNRE_0_Val   << US_IDR_SPI_SLAVE_UNRE_Pos)
 #define US_IDR_SPI_SLAVE_UNRE_1     (US_IDR_SPI_SLAVE_UNRE_1_Val   << US_IDR_SPI_SLAVE_UNRE_Pos)
 #define US_IDR_SPI_SLAVE_TXBUFE_Pos 11           /**< \brief (US_IDR_SPI_SLAVE) Buffer Empty Interrupt Disable */
-#define US_IDR_SPI_SLAVE_TXBUFE     (_U(0x1) << US_IDR_SPI_SLAVE_TXBUFE_Pos)
-#define   US_IDR_SPI_SLAVE_TXBUFE_0_Val   _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
-#define   US_IDR_SPI_SLAVE_TXBUFE_1_Val   _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_TXBUFE     (_U_(0x1) << US_IDR_SPI_SLAVE_TXBUFE_Pos)
+#define   US_IDR_SPI_SLAVE_TXBUFE_0_Val   _U_(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_TXBUFE_1_Val   _U_(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
 #define US_IDR_SPI_SLAVE_TXBUFE_0   (US_IDR_SPI_SLAVE_TXBUFE_0_Val << US_IDR_SPI_SLAVE_TXBUFE_Pos)
 #define US_IDR_SPI_SLAVE_TXBUFE_1   (US_IDR_SPI_SLAVE_TXBUFE_1_Val << US_IDR_SPI_SLAVE_TXBUFE_Pos)
 #define US_IDR_SPI_SLAVE_RXBUFF_Pos 12           /**< \brief (US_IDR_SPI_SLAVE) Buffer Full Interrupt Disable */
-#define US_IDR_SPI_SLAVE_RXBUFF     (_U(0x1) << US_IDR_SPI_SLAVE_RXBUFF_Pos)
-#define   US_IDR_SPI_SLAVE_RXBUFF_0_Val   _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
-#define   US_IDR_SPI_SLAVE_RXBUFF_1_Val   _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_RXBUFF     (_U_(0x1) << US_IDR_SPI_SLAVE_RXBUFF_Pos)
+#define   US_IDR_SPI_SLAVE_RXBUFF_0_Val   _U_(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_RXBUFF_1_Val   _U_(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
 #define US_IDR_SPI_SLAVE_RXBUFF_0   (US_IDR_SPI_SLAVE_RXBUFF_0_Val << US_IDR_SPI_SLAVE_RXBUFF_Pos)
 #define US_IDR_SPI_SLAVE_RXBUFF_1   (US_IDR_SPI_SLAVE_RXBUFF_1_Val << US_IDR_SPI_SLAVE_RXBUFF_Pos)
 #define US_IDR_SPI_SLAVE_NACK_Pos   13           /**< \brief (US_IDR_SPI_SLAVE) Non Acknowledge Interrupt Disable */
-#define US_IDR_SPI_SLAVE_NACK       (_U(0x1) << US_IDR_SPI_SLAVE_NACK_Pos)
-#define   US_IDR_SPI_SLAVE_NACK_0_Val     _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
-#define   US_IDR_SPI_SLAVE_NACK_1_Val     _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_NACK       (_U_(0x1) << US_IDR_SPI_SLAVE_NACK_Pos)
+#define   US_IDR_SPI_SLAVE_NACK_0_Val     _U_(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_NACK_1_Val     _U_(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
 #define US_IDR_SPI_SLAVE_NACK_0     (US_IDR_SPI_SLAVE_NACK_0_Val   << US_IDR_SPI_SLAVE_NACK_Pos)
 #define US_IDR_SPI_SLAVE_NACK_1     (US_IDR_SPI_SLAVE_NACK_1_Val   << US_IDR_SPI_SLAVE_NACK_Pos)
 #define US_IDR_SPI_SLAVE_RIIC_Pos   16           /**< \brief (US_IDR_SPI_SLAVE) Ring Indicator Input Change Disable */
-#define US_IDR_SPI_SLAVE_RIIC       (_U(0x1) << US_IDR_SPI_SLAVE_RIIC_Pos)
-#define   US_IDR_SPI_SLAVE_RIIC_0_Val     _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
-#define   US_IDR_SPI_SLAVE_RIIC_1_Val     _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_RIIC       (_U_(0x1) << US_IDR_SPI_SLAVE_RIIC_Pos)
+#define   US_IDR_SPI_SLAVE_RIIC_0_Val     _U_(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_RIIC_1_Val     _U_(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
 #define US_IDR_SPI_SLAVE_RIIC_0     (US_IDR_SPI_SLAVE_RIIC_0_Val   << US_IDR_SPI_SLAVE_RIIC_Pos)
 #define US_IDR_SPI_SLAVE_RIIC_1     (US_IDR_SPI_SLAVE_RIIC_1_Val   << US_IDR_SPI_SLAVE_RIIC_Pos)
 #define US_IDR_SPI_SLAVE_DSRIC_Pos  17           /**< \brief (US_IDR_SPI_SLAVE) Data Set Ready Input Change Disable */
-#define US_IDR_SPI_SLAVE_DSRIC      (_U(0x1) << US_IDR_SPI_SLAVE_DSRIC_Pos)
-#define   US_IDR_SPI_SLAVE_DSRIC_0_Val    _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
-#define   US_IDR_SPI_SLAVE_DSRIC_1_Val    _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_DSRIC      (_U_(0x1) << US_IDR_SPI_SLAVE_DSRIC_Pos)
+#define   US_IDR_SPI_SLAVE_DSRIC_0_Val    _U_(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_DSRIC_1_Val    _U_(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
 #define US_IDR_SPI_SLAVE_DSRIC_0    (US_IDR_SPI_SLAVE_DSRIC_0_Val  << US_IDR_SPI_SLAVE_DSRIC_Pos)
 #define US_IDR_SPI_SLAVE_DSRIC_1    (US_IDR_SPI_SLAVE_DSRIC_1_Val  << US_IDR_SPI_SLAVE_DSRIC_Pos)
 #define US_IDR_SPI_SLAVE_DCDIC_Pos  18           /**< \brief (US_IDR_SPI_SLAVE) Data Carrier Detect Input Change Interrupt Disable */
-#define US_IDR_SPI_SLAVE_DCDIC      (_U(0x1) << US_IDR_SPI_SLAVE_DCDIC_Pos)
-#define   US_IDR_SPI_SLAVE_DCDIC_0_Val    _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
-#define   US_IDR_SPI_SLAVE_DCDIC_1_Val    _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_DCDIC      (_U_(0x1) << US_IDR_SPI_SLAVE_DCDIC_Pos)
+#define   US_IDR_SPI_SLAVE_DCDIC_0_Val    _U_(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_DCDIC_1_Val    _U_(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
 #define US_IDR_SPI_SLAVE_DCDIC_0    (US_IDR_SPI_SLAVE_DCDIC_0_Val  << US_IDR_SPI_SLAVE_DCDIC_Pos)
 #define US_IDR_SPI_SLAVE_DCDIC_1    (US_IDR_SPI_SLAVE_DCDIC_1_Val  << US_IDR_SPI_SLAVE_DCDIC_Pos)
 #define US_IDR_SPI_SLAVE_CTSIC_Pos  19           /**< \brief (US_IDR_SPI_SLAVE) Clear to Send Input Change Interrupt Disable */
-#define US_IDR_SPI_SLAVE_CTSIC      (_U(0x1) << US_IDR_SPI_SLAVE_CTSIC_Pos)
-#define   US_IDR_SPI_SLAVE_CTSIC_0_Val    _U(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
-#define   US_IDR_SPI_SLAVE_CTSIC_1_Val    _U(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
+#define US_IDR_SPI_SLAVE_CTSIC      (_U_(0x1) << US_IDR_SPI_SLAVE_CTSIC_Pos)
+#define   US_IDR_SPI_SLAVE_CTSIC_0_Val    _U_(0x0)   /**< \brief (US_IDR_SPI_SLAVE) No Effect */
+#define   US_IDR_SPI_SLAVE_CTSIC_1_Val    _U_(0x1)   /**< \brief (US_IDR_SPI_SLAVE) Disables the interrupt */
 #define US_IDR_SPI_SLAVE_CTSIC_0    (US_IDR_SPI_SLAVE_CTSIC_0_Val  << US_IDR_SPI_SLAVE_CTSIC_Pos)
 #define US_IDR_SPI_SLAVE_CTSIC_1    (US_IDR_SPI_SLAVE_CTSIC_1_Val  << US_IDR_SPI_SLAVE_CTSIC_Pos)
-#define US_IDR_SPI_SLAVE_MASK       _U(0x000F3FE7) /**< \brief (US_IDR_SPI_SLAVE) MASK Register */
+#define US_IDR_SPI_SLAVE_MASK       _U_(0x000F3FE7) /**< \brief (US_IDR_SPI_SLAVE) MASK Register */
 
 // USART mode
 #define US_IDR_USART_RXRDY_Pos      0            /**< \brief (US_IDR_USART) Receiver Ready Interrupt Disable */
-#define US_IDR_USART_RXRDY          (_U(0x1) << US_IDR_USART_RXRDY_Pos)
-#define   US_IDR_USART_RXRDY_0_Val        _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
-#define   US_IDR_USART_RXRDY_1_Val        _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_RXRDY          (_U_(0x1) << US_IDR_USART_RXRDY_Pos)
+#define   US_IDR_USART_RXRDY_0_Val        _U_(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_RXRDY_1_Val        _U_(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
 #define US_IDR_USART_RXRDY_0        (US_IDR_USART_RXRDY_0_Val      << US_IDR_USART_RXRDY_Pos)
 #define US_IDR_USART_RXRDY_1        (US_IDR_USART_RXRDY_1_Val      << US_IDR_USART_RXRDY_Pos)
 #define US_IDR_USART_TXRDY_Pos      1            /**< \brief (US_IDR_USART) Transmitter Ready Interrupt Disable */
-#define US_IDR_USART_TXRDY          (_U(0x1) << US_IDR_USART_TXRDY_Pos)
-#define   US_IDR_USART_TXRDY_0_Val        _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
-#define   US_IDR_USART_TXRDY_1_Val        _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_TXRDY          (_U_(0x1) << US_IDR_USART_TXRDY_Pos)
+#define   US_IDR_USART_TXRDY_0_Val        _U_(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_TXRDY_1_Val        _U_(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
 #define US_IDR_USART_TXRDY_0        (US_IDR_USART_TXRDY_0_Val      << US_IDR_USART_TXRDY_Pos)
 #define US_IDR_USART_TXRDY_1        (US_IDR_USART_TXRDY_1_Val      << US_IDR_USART_TXRDY_Pos)
 #define US_IDR_USART_RXBRK_Pos      2            /**< \brief (US_IDR_USART) Receiver Break Interrupt Disable */
-#define US_IDR_USART_RXBRK          (_U(0x1) << US_IDR_USART_RXBRK_Pos)
-#define   US_IDR_USART_RXBRK_0_Val        _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
-#define   US_IDR_USART_RXBRK_1_Val        _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_RXBRK          (_U_(0x1) << US_IDR_USART_RXBRK_Pos)
+#define   US_IDR_USART_RXBRK_0_Val        _U_(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_RXBRK_1_Val        _U_(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
 #define US_IDR_USART_RXBRK_0        (US_IDR_USART_RXBRK_0_Val      << US_IDR_USART_RXBRK_Pos)
 #define US_IDR_USART_RXBRK_1        (US_IDR_USART_RXBRK_1_Val      << US_IDR_USART_RXBRK_Pos)
 #define US_IDR_USART_OVRE_Pos       5            /**< \brief (US_IDR_USART) Overrun Error Interrupt Disable */
-#define US_IDR_USART_OVRE           (_U(0x1) << US_IDR_USART_OVRE_Pos)
-#define   US_IDR_USART_OVRE_0_Val         _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
-#define   US_IDR_USART_OVRE_1_Val         _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_OVRE           (_U_(0x1) << US_IDR_USART_OVRE_Pos)
+#define   US_IDR_USART_OVRE_0_Val         _U_(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_OVRE_1_Val         _U_(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
 #define US_IDR_USART_OVRE_0         (US_IDR_USART_OVRE_0_Val       << US_IDR_USART_OVRE_Pos)
 #define US_IDR_USART_OVRE_1         (US_IDR_USART_OVRE_1_Val       << US_IDR_USART_OVRE_Pos)
 #define US_IDR_USART_FRAME_Pos      6            /**< \brief (US_IDR_USART) Framing Error Interrupt Disable */
-#define US_IDR_USART_FRAME          (_U(0x1) << US_IDR_USART_FRAME_Pos)
-#define   US_IDR_USART_FRAME_0_Val        _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
-#define   US_IDR_USART_FRAME_1_Val        _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_FRAME          (_U_(0x1) << US_IDR_USART_FRAME_Pos)
+#define   US_IDR_USART_FRAME_0_Val        _U_(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_FRAME_1_Val        _U_(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
 #define US_IDR_USART_FRAME_0        (US_IDR_USART_FRAME_0_Val      << US_IDR_USART_FRAME_Pos)
 #define US_IDR_USART_FRAME_1        (US_IDR_USART_FRAME_1_Val      << US_IDR_USART_FRAME_Pos)
 #define US_IDR_USART_PARE_Pos       7            /**< \brief (US_IDR_USART) Parity Error Interrupt Disable */
-#define US_IDR_USART_PARE           (_U(0x1) << US_IDR_USART_PARE_Pos)
-#define   US_IDR_USART_PARE_0_Val         _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
-#define   US_IDR_USART_PARE_1_Val         _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_PARE           (_U_(0x1) << US_IDR_USART_PARE_Pos)
+#define   US_IDR_USART_PARE_0_Val         _U_(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_PARE_1_Val         _U_(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
 #define US_IDR_USART_PARE_0         (US_IDR_USART_PARE_0_Val       << US_IDR_USART_PARE_Pos)
 #define US_IDR_USART_PARE_1         (US_IDR_USART_PARE_1_Val       << US_IDR_USART_PARE_Pos)
 #define US_IDR_USART_TIMEOUT_Pos    8            /**< \brief (US_IDR_USART) Time-out Interrupt Disable */
-#define US_IDR_USART_TIMEOUT        (_U(0x1) << US_IDR_USART_TIMEOUT_Pos)
-#define   US_IDR_USART_TIMEOUT_0_Val      _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
-#define   US_IDR_USART_TIMEOUT_1_Val      _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_TIMEOUT        (_U_(0x1) << US_IDR_USART_TIMEOUT_Pos)
+#define   US_IDR_USART_TIMEOUT_0_Val      _U_(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_TIMEOUT_1_Val      _U_(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
 #define US_IDR_USART_TIMEOUT_0      (US_IDR_USART_TIMEOUT_0_Val    << US_IDR_USART_TIMEOUT_Pos)
 #define US_IDR_USART_TIMEOUT_1      (US_IDR_USART_TIMEOUT_1_Val    << US_IDR_USART_TIMEOUT_Pos)
 #define US_IDR_USART_TXEMPTY_Pos    9            /**< \brief (US_IDR_USART) Transmitter Empty Interrupt Disable */
-#define US_IDR_USART_TXEMPTY        (_U(0x1) << US_IDR_USART_TXEMPTY_Pos)
-#define   US_IDR_USART_TXEMPTY_0_Val      _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
-#define   US_IDR_USART_TXEMPTY_1_Val      _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_TXEMPTY        (_U_(0x1) << US_IDR_USART_TXEMPTY_Pos)
+#define   US_IDR_USART_TXEMPTY_0_Val      _U_(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_TXEMPTY_1_Val      _U_(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
 #define US_IDR_USART_TXEMPTY_0      (US_IDR_USART_TXEMPTY_0_Val    << US_IDR_USART_TXEMPTY_Pos)
 #define US_IDR_USART_TXEMPTY_1      (US_IDR_USART_TXEMPTY_1_Val    << US_IDR_USART_TXEMPTY_Pos)
 #define US_IDR_USART_ITER_Pos       10           /**< \brief (US_IDR_USART) Iteration Interrupt Disable */
-#define US_IDR_USART_ITER           (_U(0x1) << US_IDR_USART_ITER_Pos)
-#define   US_IDR_USART_ITER_0_Val         _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
-#define   US_IDR_USART_ITER_1_Val         _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_ITER           (_U_(0x1) << US_IDR_USART_ITER_Pos)
+#define   US_IDR_USART_ITER_0_Val         _U_(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_ITER_1_Val         _U_(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
 #define US_IDR_USART_ITER_0         (US_IDR_USART_ITER_0_Val       << US_IDR_USART_ITER_Pos)
 #define US_IDR_USART_ITER_1         (US_IDR_USART_ITER_1_Val       << US_IDR_USART_ITER_Pos)
 #define US_IDR_USART_TXBUFE_Pos     11           /**< \brief (US_IDR_USART) Buffer Empty Interrupt Disable */
-#define US_IDR_USART_TXBUFE         (_U(0x1) << US_IDR_USART_TXBUFE_Pos)
-#define   US_IDR_USART_TXBUFE_0_Val       _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
-#define   US_IDR_USART_TXBUFE_1_Val       _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_TXBUFE         (_U_(0x1) << US_IDR_USART_TXBUFE_Pos)
+#define   US_IDR_USART_TXBUFE_0_Val       _U_(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_TXBUFE_1_Val       _U_(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
 #define US_IDR_USART_TXBUFE_0       (US_IDR_USART_TXBUFE_0_Val     << US_IDR_USART_TXBUFE_Pos)
 #define US_IDR_USART_TXBUFE_1       (US_IDR_USART_TXBUFE_1_Val     << US_IDR_USART_TXBUFE_Pos)
 #define US_IDR_USART_RXBUFF_Pos     12           /**< \brief (US_IDR_USART) Buffer Full Interrupt Disable */
-#define US_IDR_USART_RXBUFF         (_U(0x1) << US_IDR_USART_RXBUFF_Pos)
-#define   US_IDR_USART_RXBUFF_0_Val       _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
-#define   US_IDR_USART_RXBUFF_1_Val       _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_RXBUFF         (_U_(0x1) << US_IDR_USART_RXBUFF_Pos)
+#define   US_IDR_USART_RXBUFF_0_Val       _U_(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_RXBUFF_1_Val       _U_(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
 #define US_IDR_USART_RXBUFF_0       (US_IDR_USART_RXBUFF_0_Val     << US_IDR_USART_RXBUFF_Pos)
 #define US_IDR_USART_RXBUFF_1       (US_IDR_USART_RXBUFF_1_Val     << US_IDR_USART_RXBUFF_Pos)
 #define US_IDR_USART_NACK_Pos       13           /**< \brief (US_IDR_USART) Non Acknowledge Interrupt Disable */
-#define US_IDR_USART_NACK           (_U(0x1) << US_IDR_USART_NACK_Pos)
-#define   US_IDR_USART_NACK_0_Val         _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
-#define   US_IDR_USART_NACK_1_Val         _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_NACK           (_U_(0x1) << US_IDR_USART_NACK_Pos)
+#define   US_IDR_USART_NACK_0_Val         _U_(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_NACK_1_Val         _U_(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
 #define US_IDR_USART_NACK_0         (US_IDR_USART_NACK_0_Val       << US_IDR_USART_NACK_Pos)
 #define US_IDR_USART_NACK_1         (US_IDR_USART_NACK_1_Val       << US_IDR_USART_NACK_Pos)
 #define US_IDR_USART_RIIC_Pos       16           /**< \brief (US_IDR_USART) Ring Indicator Input Change Disable */
-#define US_IDR_USART_RIIC           (_U(0x1) << US_IDR_USART_RIIC_Pos)
-#define   US_IDR_USART_RIIC_0_Val         _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
-#define   US_IDR_USART_RIIC_1_Val         _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_RIIC           (_U_(0x1) << US_IDR_USART_RIIC_Pos)
+#define   US_IDR_USART_RIIC_0_Val         _U_(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_RIIC_1_Val         _U_(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
 #define US_IDR_USART_RIIC_0         (US_IDR_USART_RIIC_0_Val       << US_IDR_USART_RIIC_Pos)
 #define US_IDR_USART_RIIC_1         (US_IDR_USART_RIIC_1_Val       << US_IDR_USART_RIIC_Pos)
 #define US_IDR_USART_DSRIC_Pos      17           /**< \brief (US_IDR_USART) Data Set Ready Input Change Disable */
-#define US_IDR_USART_DSRIC          (_U(0x1) << US_IDR_USART_DSRIC_Pos)
-#define   US_IDR_USART_DSRIC_0_Val        _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
-#define   US_IDR_USART_DSRIC_1_Val        _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_DSRIC          (_U_(0x1) << US_IDR_USART_DSRIC_Pos)
+#define   US_IDR_USART_DSRIC_0_Val        _U_(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_DSRIC_1_Val        _U_(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
 #define US_IDR_USART_DSRIC_0        (US_IDR_USART_DSRIC_0_Val      << US_IDR_USART_DSRIC_Pos)
 #define US_IDR_USART_DSRIC_1        (US_IDR_USART_DSRIC_1_Val      << US_IDR_USART_DSRIC_Pos)
 #define US_IDR_USART_DCDIC_Pos      18           /**< \brief (US_IDR_USART) Data Carrier Detect Input Change Interrupt Disable */
-#define US_IDR_USART_DCDIC          (_U(0x1) << US_IDR_USART_DCDIC_Pos)
-#define   US_IDR_USART_DCDIC_0_Val        _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
-#define   US_IDR_USART_DCDIC_1_Val        _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_DCDIC          (_U_(0x1) << US_IDR_USART_DCDIC_Pos)
+#define   US_IDR_USART_DCDIC_0_Val        _U_(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_DCDIC_1_Val        _U_(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
 #define US_IDR_USART_DCDIC_0        (US_IDR_USART_DCDIC_0_Val      << US_IDR_USART_DCDIC_Pos)
 #define US_IDR_USART_DCDIC_1        (US_IDR_USART_DCDIC_1_Val      << US_IDR_USART_DCDIC_Pos)
 #define US_IDR_USART_CTSIC_Pos      19           /**< \brief (US_IDR_USART) Clear to Send Input Change Interrupt Disable */
-#define US_IDR_USART_CTSIC          (_U(0x1) << US_IDR_USART_CTSIC_Pos)
-#define   US_IDR_USART_CTSIC_0_Val        _U(0x0)   /**< \brief (US_IDR_USART) No Effect */
-#define   US_IDR_USART_CTSIC_1_Val        _U(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
+#define US_IDR_USART_CTSIC          (_U_(0x1) << US_IDR_USART_CTSIC_Pos)
+#define   US_IDR_USART_CTSIC_0_Val        _U_(0x0)   /**< \brief (US_IDR_USART) No Effect */
+#define   US_IDR_USART_CTSIC_1_Val        _U_(0x1)   /**< \brief (US_IDR_USART) Disables the interrupt */
 #define US_IDR_USART_CTSIC_0        (US_IDR_USART_CTSIC_0_Val      << US_IDR_USART_CTSIC_Pos)
 #define US_IDR_USART_CTSIC_1        (US_IDR_USART_CTSIC_1_Val      << US_IDR_USART_CTSIC_Pos)
 #define US_IDR_USART_MANE_Pos       20           /**< \brief (US_IDR_USART) Manchester Error Interrupt Disable */
-#define US_IDR_USART_MANE           (_U(0x1) << US_IDR_USART_MANE_Pos)
+#define US_IDR_USART_MANE           (_U_(0x1) << US_IDR_USART_MANE_Pos)
 #define US_IDR_USART_MANEA_Pos      24           /**< \brief (US_IDR_USART) Manchester Error Interrupt Disable */
-#define US_IDR_USART_MANEA          (_U(0x1) << US_IDR_USART_MANEA_Pos)
-#define   US_IDR_USART_MANEA_0_Val        _U(0x0)   /**< \brief (US_IDR_USART) No effect */
-#define   US_IDR_USART_MANEA_1_Val        _U(0x1)   /**< \brief (US_IDR_USART) Disables the corresponding interrupt */
+#define US_IDR_USART_MANEA          (_U_(0x1) << US_IDR_USART_MANEA_Pos)
+#define   US_IDR_USART_MANEA_0_Val        _U_(0x0)   /**< \brief (US_IDR_USART) No effect */
+#define   US_IDR_USART_MANEA_1_Val        _U_(0x1)   /**< \brief (US_IDR_USART) Disables the corresponding interrupt */
 #define US_IDR_USART_MANEA_0        (US_IDR_USART_MANEA_0_Val      << US_IDR_USART_MANEA_Pos)
 #define US_IDR_USART_MANEA_1        (US_IDR_USART_MANEA_1_Val      << US_IDR_USART_MANEA_Pos)
-#define US_IDR_USART_MASK           _U(0x011F3FE7) /**< \brief (US_IDR_USART) MASK Register */
+#define US_IDR_USART_MASK           _U_(0x011F3FE7) /**< \brief (US_IDR_USART) MASK Register */
 
 // Any mode
 #define US_IDR_RXRDY_Pos            0            /**< \brief (US_IDR) Receiver Ready Interrupt Disable */
-#define US_IDR_RXRDY                (_U(0x1) << US_IDR_RXRDY_Pos)
-#define   US_IDR_RXRDY_0_Val              _U(0x0)   /**< \brief (US_IDR) No Effect */
-#define   US_IDR_RXRDY_1_Val              _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_RXRDY                (_U_(0x1) << US_IDR_RXRDY_Pos)
+#define   US_IDR_RXRDY_0_Val              _U_(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_RXRDY_1_Val              _U_(0x1)   /**< \brief (US_IDR) Disables the interrupt */
 #define US_IDR_RXRDY_0              (US_IDR_RXRDY_0_Val            << US_IDR_RXRDY_Pos)
 #define US_IDR_RXRDY_1              (US_IDR_RXRDY_1_Val            << US_IDR_RXRDY_Pos)
 #define US_IDR_TXRDY_Pos            1            /**< \brief (US_IDR) Transmitter Ready Interrupt Disable */
-#define US_IDR_TXRDY                (_U(0x1) << US_IDR_TXRDY_Pos)
-#define   US_IDR_TXRDY_0_Val              _U(0x0)   /**< \brief (US_IDR) No Effect */
-#define   US_IDR_TXRDY_1_Val              _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_TXRDY                (_U_(0x1) << US_IDR_TXRDY_Pos)
+#define   US_IDR_TXRDY_0_Val              _U_(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_TXRDY_1_Val              _U_(0x1)   /**< \brief (US_IDR) Disables the interrupt */
 #define US_IDR_TXRDY_0              (US_IDR_TXRDY_0_Val            << US_IDR_TXRDY_Pos)
 #define US_IDR_TXRDY_1              (US_IDR_TXRDY_1_Val            << US_IDR_TXRDY_Pos)
 #define US_IDR_RXBRK_Pos            2            /**< \brief (US_IDR) Receiver Break Interrupt Disable */
-#define US_IDR_RXBRK                (_U(0x1) << US_IDR_RXBRK_Pos)
-#define   US_IDR_RXBRK_0_Val              _U(0x0)   /**< \brief (US_IDR) No Effect */
-#define   US_IDR_RXBRK_1_Val              _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_RXBRK                (_U_(0x1) << US_IDR_RXBRK_Pos)
+#define   US_IDR_RXBRK_0_Val              _U_(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_RXBRK_1_Val              _U_(0x1)   /**< \brief (US_IDR) Disables the interrupt */
 #define US_IDR_RXBRK_0              (US_IDR_RXBRK_0_Val            << US_IDR_RXBRK_Pos)
 #define US_IDR_RXBRK_1              (US_IDR_RXBRK_1_Val            << US_IDR_RXBRK_Pos)
 #define US_IDR_OVRE_Pos             5            /**< \brief (US_IDR) Overrun Error Interrupt Disable */
-#define US_IDR_OVRE                 (_U(0x1) << US_IDR_OVRE_Pos)
-#define   US_IDR_OVRE_0_Val               _U(0x0)   /**< \brief (US_IDR) No Effect */
-#define   US_IDR_OVRE_1_Val               _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_OVRE                 (_U_(0x1) << US_IDR_OVRE_Pos)
+#define   US_IDR_OVRE_0_Val               _U_(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_OVRE_1_Val               _U_(0x1)   /**< \brief (US_IDR) Disables the interrupt */
 #define US_IDR_OVRE_0               (US_IDR_OVRE_0_Val             << US_IDR_OVRE_Pos)
 #define US_IDR_OVRE_1               (US_IDR_OVRE_1_Val             << US_IDR_OVRE_Pos)
 #define US_IDR_FRAME_Pos            6            /**< \brief (US_IDR) Framing Error Interrupt Disable */
-#define US_IDR_FRAME                (_U(0x1) << US_IDR_FRAME_Pos)
-#define   US_IDR_FRAME_0_Val              _U(0x0)   /**< \brief (US_IDR) No Effect */
-#define   US_IDR_FRAME_1_Val              _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_FRAME                (_U_(0x1) << US_IDR_FRAME_Pos)
+#define   US_IDR_FRAME_0_Val              _U_(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_FRAME_1_Val              _U_(0x1)   /**< \brief (US_IDR) Disables the interrupt */
 #define US_IDR_FRAME_0              (US_IDR_FRAME_0_Val            << US_IDR_FRAME_Pos)
 #define US_IDR_FRAME_1              (US_IDR_FRAME_1_Val            << US_IDR_FRAME_Pos)
 #define US_IDR_PARE_Pos             7            /**< \brief (US_IDR) Parity Error Interrupt Disable */
-#define US_IDR_PARE                 (_U(0x1) << US_IDR_PARE_Pos)
-#define   US_IDR_PARE_0_Val               _U(0x0)   /**< \brief (US_IDR) No Effect */
-#define   US_IDR_PARE_1_Val               _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_PARE                 (_U_(0x1) << US_IDR_PARE_Pos)
+#define   US_IDR_PARE_0_Val               _U_(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_PARE_1_Val               _U_(0x1)   /**< \brief (US_IDR) Disables the interrupt */
 #define US_IDR_PARE_0               (US_IDR_PARE_0_Val             << US_IDR_PARE_Pos)
 #define US_IDR_PARE_1               (US_IDR_PARE_1_Val             << US_IDR_PARE_Pos)
 #define US_IDR_TIMEOUT_Pos          8            /**< \brief (US_IDR) Time-out Interrupt Disable */
-#define US_IDR_TIMEOUT              (_U(0x1) << US_IDR_TIMEOUT_Pos)
-#define   US_IDR_TIMEOUT_0_Val            _U(0x0)   /**< \brief (US_IDR) No Effect */
-#define   US_IDR_TIMEOUT_1_Val            _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_TIMEOUT              (_U_(0x1) << US_IDR_TIMEOUT_Pos)
+#define   US_IDR_TIMEOUT_0_Val            _U_(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_TIMEOUT_1_Val            _U_(0x1)   /**< \brief (US_IDR) Disables the interrupt */
 #define US_IDR_TIMEOUT_0            (US_IDR_TIMEOUT_0_Val          << US_IDR_TIMEOUT_Pos)
 #define US_IDR_TIMEOUT_1            (US_IDR_TIMEOUT_1_Val          << US_IDR_TIMEOUT_Pos)
 #define US_IDR_TXEMPTY_Pos          9            /**< \brief (US_IDR) Transmitter Empty Interrupt Disable */
-#define US_IDR_TXEMPTY              (_U(0x1) << US_IDR_TXEMPTY_Pos)
-#define   US_IDR_TXEMPTY_0_Val            _U(0x0)   /**< \brief (US_IDR) No Effect */
-#define   US_IDR_TXEMPTY_1_Val            _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_TXEMPTY              (_U_(0x1) << US_IDR_TXEMPTY_Pos)
+#define   US_IDR_TXEMPTY_0_Val            _U_(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_TXEMPTY_1_Val            _U_(0x1)   /**< \brief (US_IDR) Disables the interrupt */
 #define US_IDR_TXEMPTY_0            (US_IDR_TXEMPTY_0_Val          << US_IDR_TXEMPTY_Pos)
 #define US_IDR_TXEMPTY_1            (US_IDR_TXEMPTY_1_Val          << US_IDR_TXEMPTY_Pos)
 #define US_IDR_ITER_Pos             10           /**< \brief (US_IDR) Iteration Interrupt Disable */
-#define US_IDR_ITER                 (_U(0x1) << US_IDR_ITER_Pos)
-#define   US_IDR_ITER_0_Val               _U(0x0)   /**< \brief (US_IDR) No Effect */
-#define   US_IDR_ITER_1_Val               _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_ITER                 (_U_(0x1) << US_IDR_ITER_Pos)
+#define   US_IDR_ITER_0_Val               _U_(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_ITER_1_Val               _U_(0x1)   /**< \brief (US_IDR) Disables the interrupt */
 #define US_IDR_ITER_0               (US_IDR_ITER_0_Val             << US_IDR_ITER_Pos)
 #define US_IDR_ITER_1               (US_IDR_ITER_1_Val             << US_IDR_ITER_Pos)
 #define US_IDR_UNRE_Pos             10           /**< \brief (US_IDR) SPI Underrun Error Interrupt Disable */
-#define US_IDR_UNRE                 (_U(0x1) << US_IDR_UNRE_Pos)
-#define   US_IDR_UNRE_0_Val               _U(0x0)   /**< \brief (US_IDR) No Effect */
-#define   US_IDR_UNRE_1_Val               _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_UNRE                 (_U_(0x1) << US_IDR_UNRE_Pos)
+#define   US_IDR_UNRE_0_Val               _U_(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_UNRE_1_Val               _U_(0x1)   /**< \brief (US_IDR) Disables the interrupt */
 #define US_IDR_UNRE_0               (US_IDR_UNRE_0_Val             << US_IDR_UNRE_Pos)
 #define US_IDR_UNRE_1               (US_IDR_UNRE_1_Val             << US_IDR_UNRE_Pos)
 #define US_IDR_ITER_Pos             10           /**< \brief (US_IDR) Iteration Interrupt Disable */
-#define US_IDR_ITER                 (_U(0x1) << US_IDR_ITER_Pos)
-#define   US_IDR_ITER_0_Val               _U(0x0)   /**< \brief (US_IDR) No Effect */
-#define   US_IDR_ITER_1_Val               _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_ITER                 (_U_(0x1) << US_IDR_ITER_Pos)
+#define   US_IDR_ITER_0_Val               _U_(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_ITER_1_Val               _U_(0x1)   /**< \brief (US_IDR) Disables the interrupt */
 #define US_IDR_ITER_0               (US_IDR_ITER_0_Val             << US_IDR_ITER_Pos)
 #define US_IDR_ITER_1               (US_IDR_ITER_1_Val             << US_IDR_ITER_Pos)
 #define US_IDR_TXBUFE_Pos           11           /**< \brief (US_IDR) Buffer Empty Interrupt Disable */
-#define US_IDR_TXBUFE               (_U(0x1) << US_IDR_TXBUFE_Pos)
-#define   US_IDR_TXBUFE_0_Val             _U(0x0)   /**< \brief (US_IDR) No Effect */
-#define   US_IDR_TXBUFE_1_Val             _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_TXBUFE               (_U_(0x1) << US_IDR_TXBUFE_Pos)
+#define   US_IDR_TXBUFE_0_Val             _U_(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_TXBUFE_1_Val             _U_(0x1)   /**< \brief (US_IDR) Disables the interrupt */
 #define US_IDR_TXBUFE_0             (US_IDR_TXBUFE_0_Val           << US_IDR_TXBUFE_Pos)
 #define US_IDR_TXBUFE_1             (US_IDR_TXBUFE_1_Val           << US_IDR_TXBUFE_Pos)
 #define US_IDR_RXBUFF_Pos           12           /**< \brief (US_IDR) Buffer Full Interrupt Disable */
-#define US_IDR_RXBUFF               (_U(0x1) << US_IDR_RXBUFF_Pos)
-#define   US_IDR_RXBUFF_0_Val             _U(0x0)   /**< \brief (US_IDR) No Effect */
-#define   US_IDR_RXBUFF_1_Val             _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_RXBUFF               (_U_(0x1) << US_IDR_RXBUFF_Pos)
+#define   US_IDR_RXBUFF_0_Val             _U_(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_RXBUFF_1_Val             _U_(0x1)   /**< \brief (US_IDR) Disables the interrupt */
 #define US_IDR_RXBUFF_0             (US_IDR_RXBUFF_0_Val           << US_IDR_RXBUFF_Pos)
 #define US_IDR_RXBUFF_1             (US_IDR_RXBUFF_1_Val           << US_IDR_RXBUFF_Pos)
 #define US_IDR_NACK_Pos             13           /**< \brief (US_IDR) Non Acknowledge  or LIN Break Sent or LIN Break Received Interrupt Disable */
-#define US_IDR_NACK                 (_U(0x1) << US_IDR_NACK_Pos)
-#define   US_IDR_NACK_0_Val               _U(0x0)   /**< \brief (US_IDR) No Effect */
-#define   US_IDR_NACK_1_Val               _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_NACK                 (_U_(0x1) << US_IDR_NACK_Pos)
+#define   US_IDR_NACK_0_Val               _U_(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_NACK_1_Val               _U_(0x1)   /**< \brief (US_IDR) Disables the interrupt */
 #define US_IDR_NACK_0               (US_IDR_NACK_0_Val             << US_IDR_NACK_Pos)
 #define US_IDR_NACK_1               (US_IDR_NACK_1_Val             << US_IDR_NACK_Pos)
 #define US_IDR_LINID_Pos            14           /**< \brief (US_IDR) LIN Identifier Sent or LIN Identifier Received Interrupt Disable */
-#define US_IDR_LINID                (_U(0x1) << US_IDR_LINID_Pos)
+#define US_IDR_LINID                (_U_(0x1) << US_IDR_LINID_Pos)
 #define US_IDR_LINTC_Pos            15           /**< \brief (US_IDR) LIN Transfer Conpleted Interrupt Disable */
-#define US_IDR_LINTC                (_U(0x1) << US_IDR_LINTC_Pos)
+#define US_IDR_LINTC                (_U_(0x1) << US_IDR_LINTC_Pos)
 #define US_IDR_RIIC_Pos             16           /**< \brief (US_IDR) Ring Indicator Input Change Disable */
-#define US_IDR_RIIC                 (_U(0x1) << US_IDR_RIIC_Pos)
-#define   US_IDR_RIIC_0_Val               _U(0x0)   /**< \brief (US_IDR) No Effect */
-#define   US_IDR_RIIC_1_Val               _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_RIIC                 (_U_(0x1) << US_IDR_RIIC_Pos)
+#define   US_IDR_RIIC_0_Val               _U_(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_RIIC_1_Val               _U_(0x1)   /**< \brief (US_IDR) Disables the interrupt */
 #define US_IDR_RIIC_0               (US_IDR_RIIC_0_Val             << US_IDR_RIIC_Pos)
 #define US_IDR_RIIC_1               (US_IDR_RIIC_1_Val             << US_IDR_RIIC_Pos)
 #define US_IDR_DSRIC_Pos            17           /**< \brief (US_IDR) Data Set Ready Input Change Disable */
-#define US_IDR_DSRIC                (_U(0x1) << US_IDR_DSRIC_Pos)
-#define   US_IDR_DSRIC_0_Val              _U(0x0)   /**< \brief (US_IDR) No Effect */
-#define   US_IDR_DSRIC_1_Val              _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_DSRIC                (_U_(0x1) << US_IDR_DSRIC_Pos)
+#define   US_IDR_DSRIC_0_Val              _U_(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_DSRIC_1_Val              _U_(0x1)   /**< \brief (US_IDR) Disables the interrupt */
 #define US_IDR_DSRIC_0              (US_IDR_DSRIC_0_Val            << US_IDR_DSRIC_Pos)
 #define US_IDR_DSRIC_1              (US_IDR_DSRIC_1_Val            << US_IDR_DSRIC_Pos)
 #define US_IDR_DCDIC_Pos            18           /**< \brief (US_IDR) Data Carrier Detect Input Change Interrupt Disable */
-#define US_IDR_DCDIC                (_U(0x1) << US_IDR_DCDIC_Pos)
-#define   US_IDR_DCDIC_0_Val              _U(0x0)   /**< \brief (US_IDR) No Effect */
-#define   US_IDR_DCDIC_1_Val              _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_DCDIC                (_U_(0x1) << US_IDR_DCDIC_Pos)
+#define   US_IDR_DCDIC_0_Val              _U_(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_DCDIC_1_Val              _U_(0x1)   /**< \brief (US_IDR) Disables the interrupt */
 #define US_IDR_DCDIC_0              (US_IDR_DCDIC_0_Val            << US_IDR_DCDIC_Pos)
 #define US_IDR_DCDIC_1              (US_IDR_DCDIC_1_Val            << US_IDR_DCDIC_Pos)
 #define US_IDR_CTSIC_Pos            19           /**< \brief (US_IDR) Clear to Send Input Change Interrupt Disable */
-#define US_IDR_CTSIC                (_U(0x1) << US_IDR_CTSIC_Pos)
-#define   US_IDR_CTSIC_0_Val              _U(0x0)   /**< \brief (US_IDR) No Effect */
-#define   US_IDR_CTSIC_1_Val              _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_CTSIC                (_U_(0x1) << US_IDR_CTSIC_Pos)
+#define   US_IDR_CTSIC_0_Val              _U_(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_CTSIC_1_Val              _U_(0x1)   /**< \brief (US_IDR) Disables the interrupt */
 #define US_IDR_CTSIC_0              (US_IDR_CTSIC_0_Val            << US_IDR_CTSIC_Pos)
 #define US_IDR_CTSIC_1              (US_IDR_CTSIC_1_Val            << US_IDR_CTSIC_Pos)
 #define US_IDR_MANE_Pos             20           /**< \brief (US_IDR) Manchester Error Interrupt Disable */
-#define US_IDR_MANE                 (_U(0x1) << US_IDR_MANE_Pos)
+#define US_IDR_MANE                 (_U_(0x1) << US_IDR_MANE_Pos)
 #define US_IDR_MANEA_Pos            24           /**< \brief (US_IDR) Manchester Error Interrupt Disable */
-#define US_IDR_MANEA                (_U(0x1) << US_IDR_MANEA_Pos)
-#define   US_IDR_MANEA_0_Val              _U(0x0)   /**< \brief (US_IDR) No effect */
-#define   US_IDR_MANEA_1_Val              _U(0x1)   /**< \brief (US_IDR) Disables the corresponding interrupt */
+#define US_IDR_MANEA                (_U_(0x1) << US_IDR_MANEA_Pos)
+#define   US_IDR_MANEA_0_Val              _U_(0x0)   /**< \brief (US_IDR) No effect */
+#define   US_IDR_MANEA_1_Val              _U_(0x1)   /**< \brief (US_IDR) Disables the corresponding interrupt */
 #define US_IDR_MANEA_0              (US_IDR_MANEA_0_Val            << US_IDR_MANEA_Pos)
 #define US_IDR_MANEA_1              (US_IDR_MANEA_1_Val            << US_IDR_MANEA_Pos)
 #define US_IDR_LINBE_Pos            25           /**< \brief (US_IDR) LIN Bus Error Interrupt Disable */
-#define US_IDR_LINBE                (_U(0x1) << US_IDR_LINBE_Pos)
+#define US_IDR_LINBE                (_U_(0x1) << US_IDR_LINBE_Pos)
 #define US_IDR_LINISFE_Pos          26           /**< \brief (US_IDR) LIN Inconsistent Synch Field Error Interrupt Disable */
-#define US_IDR_LINISFE              (_U(0x1) << US_IDR_LINISFE_Pos)
+#define US_IDR_LINISFE              (_U_(0x1) << US_IDR_LINISFE_Pos)
 #define US_IDR_LINIPE_Pos           27           /**< \brief (US_IDR) LIN Identifier Parity Interrupt Disable */
-#define US_IDR_LINIPE               (_U(0x1) << US_IDR_LINIPE_Pos)
+#define US_IDR_LINIPE               (_U_(0x1) << US_IDR_LINIPE_Pos)
 #define US_IDR_LINCE_Pos            28           /**< \brief (US_IDR) LIN Checksum Error Interrupt Disable */
-#define US_IDR_LINCE                (_U(0x1) << US_IDR_LINCE_Pos)
+#define US_IDR_LINCE                (_U_(0x1) << US_IDR_LINCE_Pos)
 #define US_IDR_LINSNRE_Pos          29           /**< \brief (US_IDR) LIN Slave Not Responding Error Interrupt Disable */
-#define US_IDR_LINSNRE              (_U(0x1) << US_IDR_LINSNRE_Pos)
+#define US_IDR_LINSNRE              (_U_(0x1) << US_IDR_LINSNRE_Pos)
 #define US_IDR_LINSTE_Pos           30           /**< \brief (US_IDR) LIN Synch Tolerance Error Interrupt Disable */
-#define US_IDR_LINSTE               (_U(0x1) << US_IDR_LINSTE_Pos)
-#define   US_IDR_LINSTE_0_Val             _U(0x0)   /**< \brief (US_IDR) No Effect */
-#define   US_IDR_LINSTE_1_Val             _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_LINSTE               (_U_(0x1) << US_IDR_LINSTE_Pos)
+#define   US_IDR_LINSTE_0_Val             _U_(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_LINSTE_1_Val             _U_(0x1)   /**< \brief (US_IDR) Disables the interrupt */
 #define US_IDR_LINSTE_0             (US_IDR_LINSTE_0_Val           << US_IDR_LINSTE_Pos)
 #define US_IDR_LINSTE_1             (US_IDR_LINSTE_1_Val           << US_IDR_LINSTE_Pos)
 #define US_IDR_LINHTE_Pos           31           /**< \brief (US_IDR) LIN Header Timeout Error Interrupt Disable */
-#define US_IDR_LINHTE               (_U(0x1) << US_IDR_LINHTE_Pos)
-#define   US_IDR_LINHTE_0_Val             _U(0x0)   /**< \brief (US_IDR) No Effect */
-#define   US_IDR_LINHTE_1_Val             _U(0x1)   /**< \brief (US_IDR) Disables the interrupt */
+#define US_IDR_LINHTE               (_U_(0x1) << US_IDR_LINHTE_Pos)
+#define   US_IDR_LINHTE_0_Val             _U_(0x0)   /**< \brief (US_IDR) No Effect */
+#define   US_IDR_LINHTE_1_Val             _U_(0x1)   /**< \brief (US_IDR) Disables the interrupt */
 #define US_IDR_LINHTE_0             (US_IDR_LINHTE_0_Val           << US_IDR_LINHTE_Pos)
 #define US_IDR_LINHTE_1             (US_IDR_LINHTE_1_Val           << US_IDR_LINHTE_Pos)
-#define US_IDR_MASK                 _U(0xFF1FFFE7) /**< \brief (US_IDR) MASK Register */
+#define US_IDR_MASK                 _U_(0xFF1FFFE7) /**< \brief (US_IDR) MASK Register */
 
 /* -------- US_IMR : (USART Offset: 0x10) (R/  32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -2339,483 +2339,483 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_IMR_OFFSET               0x10         /**< \brief (US_IMR offset) Interrupt Mask Register */
-#define US_IMR_RESETVALUE           _U(0x00000000); /**< \brief (US_IMR reset_value) Interrupt Mask Register */
+#define US_IMR_RESETVALUE           _U_(0x00000000); /**< \brief (US_IMR reset_value) Interrupt Mask Register */
 
 // LIN mode
 #define US_IMR_LIN_RXRDY_Pos        0            /**< \brief (US_IMR_LIN) RXRDY Interrupt Mask */
-#define US_IMR_LIN_RXRDY            (_U(0x1) << US_IMR_LIN_RXRDY_Pos)
-#define   US_IMR_LIN_RXRDY_0_Val          _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
-#define   US_IMR_LIN_RXRDY_1_Val          _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_RXRDY            (_U_(0x1) << US_IMR_LIN_RXRDY_Pos)
+#define   US_IMR_LIN_RXRDY_0_Val          _U_(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_RXRDY_1_Val          _U_(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
 #define US_IMR_LIN_RXRDY_0          (US_IMR_LIN_RXRDY_0_Val        << US_IMR_LIN_RXRDY_Pos)
 #define US_IMR_LIN_RXRDY_1          (US_IMR_LIN_RXRDY_1_Val        << US_IMR_LIN_RXRDY_Pos)
 #define US_IMR_LIN_TXRDY_Pos        1            /**< \brief (US_IMR_LIN) TXRDY Interrupt Mask */
-#define US_IMR_LIN_TXRDY            (_U(0x1) << US_IMR_LIN_TXRDY_Pos)
-#define   US_IMR_LIN_TXRDY_0_Val          _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
-#define   US_IMR_LIN_TXRDY_1_Val          _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_TXRDY            (_U_(0x1) << US_IMR_LIN_TXRDY_Pos)
+#define   US_IMR_LIN_TXRDY_0_Val          _U_(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_TXRDY_1_Val          _U_(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
 #define US_IMR_LIN_TXRDY_0          (US_IMR_LIN_TXRDY_0_Val        << US_IMR_LIN_TXRDY_Pos)
 #define US_IMR_LIN_TXRDY_1          (US_IMR_LIN_TXRDY_1_Val        << US_IMR_LIN_TXRDY_Pos)
 #define US_IMR_LIN_RXBRK_Pos        2            /**< \brief (US_IMR_LIN) Receiver Break Interrupt Mask */
-#define US_IMR_LIN_RXBRK            (_U(0x1) << US_IMR_LIN_RXBRK_Pos)
-#define   US_IMR_LIN_RXBRK_0_Val          _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
-#define   US_IMR_LIN_RXBRK_1_Val          _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_RXBRK            (_U_(0x1) << US_IMR_LIN_RXBRK_Pos)
+#define   US_IMR_LIN_RXBRK_0_Val          _U_(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_RXBRK_1_Val          _U_(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
 #define US_IMR_LIN_RXBRK_0          (US_IMR_LIN_RXBRK_0_Val        << US_IMR_LIN_RXBRK_Pos)
 #define US_IMR_LIN_RXBRK_1          (US_IMR_LIN_RXBRK_1_Val        << US_IMR_LIN_RXBRK_Pos)
 #define US_IMR_LIN_OVRE_Pos         5            /**< \brief (US_IMR_LIN) Overrun Error Interrupt Mask */
-#define US_IMR_LIN_OVRE             (_U(0x1) << US_IMR_LIN_OVRE_Pos)
-#define   US_IMR_LIN_OVRE_0_Val           _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
-#define   US_IMR_LIN_OVRE_1_Val           _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_OVRE             (_U_(0x1) << US_IMR_LIN_OVRE_Pos)
+#define   US_IMR_LIN_OVRE_0_Val           _U_(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_OVRE_1_Val           _U_(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
 #define US_IMR_LIN_OVRE_0           (US_IMR_LIN_OVRE_0_Val         << US_IMR_LIN_OVRE_Pos)
 #define US_IMR_LIN_OVRE_1           (US_IMR_LIN_OVRE_1_Val         << US_IMR_LIN_OVRE_Pos)
 #define US_IMR_LIN_FRAME_Pos        6            /**< \brief (US_IMR_LIN) Framing Error Interrupt Mask */
-#define US_IMR_LIN_FRAME            (_U(0x1) << US_IMR_LIN_FRAME_Pos)
-#define   US_IMR_LIN_FRAME_0_Val          _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
-#define   US_IMR_LIN_FRAME_1_Val          _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_FRAME            (_U_(0x1) << US_IMR_LIN_FRAME_Pos)
+#define   US_IMR_LIN_FRAME_0_Val          _U_(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_FRAME_1_Val          _U_(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
 #define US_IMR_LIN_FRAME_0          (US_IMR_LIN_FRAME_0_Val        << US_IMR_LIN_FRAME_Pos)
 #define US_IMR_LIN_FRAME_1          (US_IMR_LIN_FRAME_1_Val        << US_IMR_LIN_FRAME_Pos)
 #define US_IMR_LIN_PARE_Pos         7            /**< \brief (US_IMR_LIN) Parity Error Interrupt Mask */
-#define US_IMR_LIN_PARE             (_U(0x1) << US_IMR_LIN_PARE_Pos)
-#define   US_IMR_LIN_PARE_0_Val           _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
-#define   US_IMR_LIN_PARE_1_Val           _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_PARE             (_U_(0x1) << US_IMR_LIN_PARE_Pos)
+#define   US_IMR_LIN_PARE_0_Val           _U_(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_PARE_1_Val           _U_(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
 #define US_IMR_LIN_PARE_0           (US_IMR_LIN_PARE_0_Val         << US_IMR_LIN_PARE_Pos)
 #define US_IMR_LIN_PARE_1           (US_IMR_LIN_PARE_1_Val         << US_IMR_LIN_PARE_Pos)
 #define US_IMR_LIN_TIMEOUT_Pos      8            /**< \brief (US_IMR_LIN) Time-out Interrupt Mask */
-#define US_IMR_LIN_TIMEOUT          (_U(0x1) << US_IMR_LIN_TIMEOUT_Pos)
-#define   US_IMR_LIN_TIMEOUT_0_Val        _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
-#define   US_IMR_LIN_TIMEOUT_1_Val        _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_TIMEOUT          (_U_(0x1) << US_IMR_LIN_TIMEOUT_Pos)
+#define   US_IMR_LIN_TIMEOUT_0_Val        _U_(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_TIMEOUT_1_Val        _U_(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
 #define US_IMR_LIN_TIMEOUT_0        (US_IMR_LIN_TIMEOUT_0_Val      << US_IMR_LIN_TIMEOUT_Pos)
 #define US_IMR_LIN_TIMEOUT_1        (US_IMR_LIN_TIMEOUT_1_Val      << US_IMR_LIN_TIMEOUT_Pos)
 #define US_IMR_LIN_TXEMPTY_Pos      9            /**< \brief (US_IMR_LIN) TXEMPTY Interrupt Mask */
-#define US_IMR_LIN_TXEMPTY          (_U(0x1) << US_IMR_LIN_TXEMPTY_Pos)
-#define   US_IMR_LIN_TXEMPTY_0_Val        _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
-#define   US_IMR_LIN_TXEMPTY_1_Val        _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_TXEMPTY          (_U_(0x1) << US_IMR_LIN_TXEMPTY_Pos)
+#define   US_IMR_LIN_TXEMPTY_0_Val        _U_(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_TXEMPTY_1_Val        _U_(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
 #define US_IMR_LIN_TXEMPTY_0        (US_IMR_LIN_TXEMPTY_0_Val      << US_IMR_LIN_TXEMPTY_Pos)
 #define US_IMR_LIN_TXEMPTY_1        (US_IMR_LIN_TXEMPTY_1_Val      << US_IMR_LIN_TXEMPTY_Pos)
 #define US_IMR_LIN_ITER_Pos         10           /**< \brief (US_IMR_LIN) Iteration Interrupt Mask */
-#define US_IMR_LIN_ITER             (_U(0x1) << US_IMR_LIN_ITER_Pos)
-#define   US_IMR_LIN_ITER_0_Val           _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
-#define   US_IMR_LIN_ITER_1_Val           _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_ITER             (_U_(0x1) << US_IMR_LIN_ITER_Pos)
+#define   US_IMR_LIN_ITER_0_Val           _U_(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_ITER_1_Val           _U_(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
 #define US_IMR_LIN_ITER_0           (US_IMR_LIN_ITER_0_Val         << US_IMR_LIN_ITER_Pos)
 #define US_IMR_LIN_ITER_1           (US_IMR_LIN_ITER_1_Val         << US_IMR_LIN_ITER_Pos)
 #define US_IMR_LIN_TXBUFE_Pos       11           /**< \brief (US_IMR_LIN) Buffer Empty Interrupt Mask */
-#define US_IMR_LIN_TXBUFE           (_U(0x1) << US_IMR_LIN_TXBUFE_Pos)
-#define   US_IMR_LIN_TXBUFE_0_Val         _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
-#define   US_IMR_LIN_TXBUFE_1_Val         _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_TXBUFE           (_U_(0x1) << US_IMR_LIN_TXBUFE_Pos)
+#define   US_IMR_LIN_TXBUFE_0_Val         _U_(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_TXBUFE_1_Val         _U_(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
 #define US_IMR_LIN_TXBUFE_0         (US_IMR_LIN_TXBUFE_0_Val       << US_IMR_LIN_TXBUFE_Pos)
 #define US_IMR_LIN_TXBUFE_1         (US_IMR_LIN_TXBUFE_1_Val       << US_IMR_LIN_TXBUFE_Pos)
 #define US_IMR_LIN_RXBUFF_Pos       12           /**< \brief (US_IMR_LIN) Buffer Full Interrupt Mask */
-#define US_IMR_LIN_RXBUFF           (_U(0x1) << US_IMR_LIN_RXBUFF_Pos)
-#define   US_IMR_LIN_RXBUFF_0_Val         _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
-#define   US_IMR_LIN_RXBUFF_1_Val         _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_RXBUFF           (_U_(0x1) << US_IMR_LIN_RXBUFF_Pos)
+#define   US_IMR_LIN_RXBUFF_0_Val         _U_(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_RXBUFF_1_Val         _U_(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
 #define US_IMR_LIN_RXBUFF_0         (US_IMR_LIN_RXBUFF_0_Val       << US_IMR_LIN_RXBUFF_Pos)
 #define US_IMR_LIN_RXBUFF_1         (US_IMR_LIN_RXBUFF_1_Val       << US_IMR_LIN_RXBUFF_Pos)
 #define US_IMR_LIN_NACK_Pos         13           /**< \brief (US_IMR_LIN) Non Acknowledge  or LIN Break Sent or LIN Break Received Interrupt Mask */
-#define US_IMR_LIN_NACK             (_U(0x1) << US_IMR_LIN_NACK_Pos)
-#define   US_IMR_LIN_NACK_0_Val           _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
-#define   US_IMR_LIN_NACK_1_Val           _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_NACK             (_U_(0x1) << US_IMR_LIN_NACK_Pos)
+#define   US_IMR_LIN_NACK_0_Val           _U_(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_NACK_1_Val           _U_(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
 #define US_IMR_LIN_NACK_0           (US_IMR_LIN_NACK_0_Val         << US_IMR_LIN_NACK_Pos)
 #define US_IMR_LIN_NACK_1           (US_IMR_LIN_NACK_1_Val         << US_IMR_LIN_NACK_Pos)
 #define US_IMR_LIN_LINID_Pos        14           /**< \brief (US_IMR_LIN) LIN Identifier Sent or LIN Received Interrupt Mask */
-#define US_IMR_LIN_LINID            (_U(0x1) << US_IMR_LIN_LINID_Pos)
+#define US_IMR_LIN_LINID            (_U_(0x1) << US_IMR_LIN_LINID_Pos)
 #define US_IMR_LIN_LINTC_Pos        15           /**< \brief (US_IMR_LIN) LIN Transfer Conpleted Interrupt Mask */
-#define US_IMR_LIN_LINTC            (_U(0x1) << US_IMR_LIN_LINTC_Pos)
+#define US_IMR_LIN_LINTC            (_U_(0x1) << US_IMR_LIN_LINTC_Pos)
 #define US_IMR_LIN_RIIC_Pos         16           /**< \brief (US_IMR_LIN) Ring Indicator Input Change Mask */
-#define US_IMR_LIN_RIIC             (_U(0x1) << US_IMR_LIN_RIIC_Pos)
-#define   US_IMR_LIN_RIIC_0_Val           _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
-#define   US_IMR_LIN_RIIC_1_Val           _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_RIIC             (_U_(0x1) << US_IMR_LIN_RIIC_Pos)
+#define   US_IMR_LIN_RIIC_0_Val           _U_(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_RIIC_1_Val           _U_(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
 #define US_IMR_LIN_RIIC_0           (US_IMR_LIN_RIIC_0_Val         << US_IMR_LIN_RIIC_Pos)
 #define US_IMR_LIN_RIIC_1           (US_IMR_LIN_RIIC_1_Val         << US_IMR_LIN_RIIC_Pos)
 #define US_IMR_LIN_DSRIC_Pos        17           /**< \brief (US_IMR_LIN) Data Set Ready Input Change Mask */
-#define US_IMR_LIN_DSRIC            (_U(0x1) << US_IMR_LIN_DSRIC_Pos)
-#define   US_IMR_LIN_DSRIC_0_Val          _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
-#define   US_IMR_LIN_DSRIC_1_Val          _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_DSRIC            (_U_(0x1) << US_IMR_LIN_DSRIC_Pos)
+#define   US_IMR_LIN_DSRIC_0_Val          _U_(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_DSRIC_1_Val          _U_(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
 #define US_IMR_LIN_DSRIC_0          (US_IMR_LIN_DSRIC_0_Val        << US_IMR_LIN_DSRIC_Pos)
 #define US_IMR_LIN_DSRIC_1          (US_IMR_LIN_DSRIC_1_Val        << US_IMR_LIN_DSRIC_Pos)
 #define US_IMR_LIN_DCDIC_Pos        18           /**< \brief (US_IMR_LIN) Data Carrier Detect Input Change Interrupt Mask */
-#define US_IMR_LIN_DCDIC            (_U(0x1) << US_IMR_LIN_DCDIC_Pos)
-#define   US_IMR_LIN_DCDIC_0_Val          _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
-#define   US_IMR_LIN_DCDIC_1_Val          _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_DCDIC            (_U_(0x1) << US_IMR_LIN_DCDIC_Pos)
+#define   US_IMR_LIN_DCDIC_0_Val          _U_(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_DCDIC_1_Val          _U_(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
 #define US_IMR_LIN_DCDIC_0          (US_IMR_LIN_DCDIC_0_Val        << US_IMR_LIN_DCDIC_Pos)
 #define US_IMR_LIN_DCDIC_1          (US_IMR_LIN_DCDIC_1_Val        << US_IMR_LIN_DCDIC_Pos)
 #define US_IMR_LIN_CTSIC_Pos        19           /**< \brief (US_IMR_LIN) Clear to Send Input Change Interrupt Mask */
-#define US_IMR_LIN_CTSIC            (_U(0x1) << US_IMR_LIN_CTSIC_Pos)
-#define   US_IMR_LIN_CTSIC_0_Val          _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
-#define   US_IMR_LIN_CTSIC_1_Val          _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_CTSIC            (_U_(0x1) << US_IMR_LIN_CTSIC_Pos)
+#define   US_IMR_LIN_CTSIC_0_Val          _U_(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_CTSIC_1_Val          _U_(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
 #define US_IMR_LIN_CTSIC_0          (US_IMR_LIN_CTSIC_0_Val        << US_IMR_LIN_CTSIC_Pos)
 #define US_IMR_LIN_CTSIC_1          (US_IMR_LIN_CTSIC_1_Val        << US_IMR_LIN_CTSIC_Pos)
 #define US_IMR_LIN_LINBE_Pos        25           /**< \brief (US_IMR_LIN) LIN Bus Error Interrupt Mask */
-#define US_IMR_LIN_LINBE            (_U(0x1) << US_IMR_LIN_LINBE_Pos)
+#define US_IMR_LIN_LINBE            (_U_(0x1) << US_IMR_LIN_LINBE_Pos)
 #define US_IMR_LIN_LINISFE_Pos      26           /**< \brief (US_IMR_LIN) LIN Inconsistent Synch Field Error Interrupt Mask */
-#define US_IMR_LIN_LINISFE          (_U(0x1) << US_IMR_LIN_LINISFE_Pos)
+#define US_IMR_LIN_LINISFE          (_U_(0x1) << US_IMR_LIN_LINISFE_Pos)
 #define US_IMR_LIN_LINIPE_Pos       27           /**< \brief (US_IMR_LIN) LIN Identifier Parity Interrupt Mask */
-#define US_IMR_LIN_LINIPE           (_U(0x1) << US_IMR_LIN_LINIPE_Pos)
+#define US_IMR_LIN_LINIPE           (_U_(0x1) << US_IMR_LIN_LINIPE_Pos)
 #define US_IMR_LIN_LINCE_Pos        28           /**< \brief (US_IMR_LIN) LIN Checksum Error Interrupt Mask */
-#define US_IMR_LIN_LINCE            (_U(0x1) << US_IMR_LIN_LINCE_Pos)
+#define US_IMR_LIN_LINCE            (_U_(0x1) << US_IMR_LIN_LINCE_Pos)
 #define US_IMR_LIN_LINSNRE_Pos      29           /**< \brief (US_IMR_LIN) LIN Slave Not Responding Error Interrupt Mask */
-#define US_IMR_LIN_LINSNRE          (_U(0x1) << US_IMR_LIN_LINSNRE_Pos)
+#define US_IMR_LIN_LINSNRE          (_U_(0x1) << US_IMR_LIN_LINSNRE_Pos)
 #define US_IMR_LIN_LINSTE_Pos       30           /**< \brief (US_IMR_LIN) LIN Synch Tolerance Error Interrupt Mask */
-#define US_IMR_LIN_LINSTE           (_U(0x1) << US_IMR_LIN_LINSTE_Pos)
-#define   US_IMR_LIN_LINSTE_0_Val         _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
-#define   US_IMR_LIN_LINSTE_1_Val         _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_LINSTE           (_U_(0x1) << US_IMR_LIN_LINSTE_Pos)
+#define   US_IMR_LIN_LINSTE_0_Val         _U_(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_LINSTE_1_Val         _U_(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
 #define US_IMR_LIN_LINSTE_0         (US_IMR_LIN_LINSTE_0_Val       << US_IMR_LIN_LINSTE_Pos)
 #define US_IMR_LIN_LINSTE_1         (US_IMR_LIN_LINSTE_1_Val       << US_IMR_LIN_LINSTE_Pos)
 #define US_IMR_LIN_LINHTE_Pos       31           /**< \brief (US_IMR_LIN) LIN Header Timeout Error Interrupt Mask */
-#define US_IMR_LIN_LINHTE           (_U(0x1) << US_IMR_LIN_LINHTE_Pos)
-#define   US_IMR_LIN_LINHTE_0_Val         _U(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
-#define   US_IMR_LIN_LINHTE_1_Val         _U(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
+#define US_IMR_LIN_LINHTE           (_U_(0x1) << US_IMR_LIN_LINHTE_Pos)
+#define   US_IMR_LIN_LINHTE_0_Val         _U_(0x0)   /**< \brief (US_IMR_LIN) The interrupt is disabled */
+#define   US_IMR_LIN_LINHTE_1_Val         _U_(0x1)   /**< \brief (US_IMR_LIN) The interrupt is enabled */
 #define US_IMR_LIN_LINHTE_0         (US_IMR_LIN_LINHTE_0_Val       << US_IMR_LIN_LINHTE_Pos)
 #define US_IMR_LIN_LINHTE_1         (US_IMR_LIN_LINHTE_1_Val       << US_IMR_LIN_LINHTE_Pos)
-#define US_IMR_LIN_MASK             _U(0xFE0FFFE7) /**< \brief (US_IMR_LIN) MASK Register */
+#define US_IMR_LIN_MASK             _U_(0xFE0FFFE7) /**< \brief (US_IMR_LIN) MASK Register */
 
 // SPI_SLAVE mode
 #define US_IMR_SPI_SLAVE_RXRDY_Pos  0            /**< \brief (US_IMR_SPI_SLAVE) RXRDY Interrupt Mask */
-#define US_IMR_SPI_SLAVE_RXRDY      (_U(0x1) << US_IMR_SPI_SLAVE_RXRDY_Pos)
-#define   US_IMR_SPI_SLAVE_RXRDY_0_Val    _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
-#define   US_IMR_SPI_SLAVE_RXRDY_1_Val    _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_RXRDY      (_U_(0x1) << US_IMR_SPI_SLAVE_RXRDY_Pos)
+#define   US_IMR_SPI_SLAVE_RXRDY_0_Val    _U_(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_RXRDY_1_Val    _U_(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
 #define US_IMR_SPI_SLAVE_RXRDY_0    (US_IMR_SPI_SLAVE_RXRDY_0_Val  << US_IMR_SPI_SLAVE_RXRDY_Pos)
 #define US_IMR_SPI_SLAVE_RXRDY_1    (US_IMR_SPI_SLAVE_RXRDY_1_Val  << US_IMR_SPI_SLAVE_RXRDY_Pos)
 #define US_IMR_SPI_SLAVE_TXRDY_Pos  1            /**< \brief (US_IMR_SPI_SLAVE) TXRDY Interrupt Mask */
-#define US_IMR_SPI_SLAVE_TXRDY      (_U(0x1) << US_IMR_SPI_SLAVE_TXRDY_Pos)
-#define   US_IMR_SPI_SLAVE_TXRDY_0_Val    _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
-#define   US_IMR_SPI_SLAVE_TXRDY_1_Val    _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_TXRDY      (_U_(0x1) << US_IMR_SPI_SLAVE_TXRDY_Pos)
+#define   US_IMR_SPI_SLAVE_TXRDY_0_Val    _U_(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_TXRDY_1_Val    _U_(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
 #define US_IMR_SPI_SLAVE_TXRDY_0    (US_IMR_SPI_SLAVE_TXRDY_0_Val  << US_IMR_SPI_SLAVE_TXRDY_Pos)
 #define US_IMR_SPI_SLAVE_TXRDY_1    (US_IMR_SPI_SLAVE_TXRDY_1_Val  << US_IMR_SPI_SLAVE_TXRDY_Pos)
 #define US_IMR_SPI_SLAVE_RXBRK_Pos  2            /**< \brief (US_IMR_SPI_SLAVE) Receiver Break Interrupt Mask */
-#define US_IMR_SPI_SLAVE_RXBRK      (_U(0x1) << US_IMR_SPI_SLAVE_RXBRK_Pos)
-#define   US_IMR_SPI_SLAVE_RXBRK_0_Val    _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
-#define   US_IMR_SPI_SLAVE_RXBRK_1_Val    _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_RXBRK      (_U_(0x1) << US_IMR_SPI_SLAVE_RXBRK_Pos)
+#define   US_IMR_SPI_SLAVE_RXBRK_0_Val    _U_(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_RXBRK_1_Val    _U_(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
 #define US_IMR_SPI_SLAVE_RXBRK_0    (US_IMR_SPI_SLAVE_RXBRK_0_Val  << US_IMR_SPI_SLAVE_RXBRK_Pos)
 #define US_IMR_SPI_SLAVE_RXBRK_1    (US_IMR_SPI_SLAVE_RXBRK_1_Val  << US_IMR_SPI_SLAVE_RXBRK_Pos)
 #define US_IMR_SPI_SLAVE_OVRE_Pos   5            /**< \brief (US_IMR_SPI_SLAVE) Overrun Error Interrupt Mask */
-#define US_IMR_SPI_SLAVE_OVRE       (_U(0x1) << US_IMR_SPI_SLAVE_OVRE_Pos)
-#define   US_IMR_SPI_SLAVE_OVRE_0_Val     _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
-#define   US_IMR_SPI_SLAVE_OVRE_1_Val     _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_OVRE       (_U_(0x1) << US_IMR_SPI_SLAVE_OVRE_Pos)
+#define   US_IMR_SPI_SLAVE_OVRE_0_Val     _U_(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_OVRE_1_Val     _U_(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
 #define US_IMR_SPI_SLAVE_OVRE_0     (US_IMR_SPI_SLAVE_OVRE_0_Val   << US_IMR_SPI_SLAVE_OVRE_Pos)
 #define US_IMR_SPI_SLAVE_OVRE_1     (US_IMR_SPI_SLAVE_OVRE_1_Val   << US_IMR_SPI_SLAVE_OVRE_Pos)
 #define US_IMR_SPI_SLAVE_FRAME_Pos  6            /**< \brief (US_IMR_SPI_SLAVE) Framing Error Interrupt Mask */
-#define US_IMR_SPI_SLAVE_FRAME      (_U(0x1) << US_IMR_SPI_SLAVE_FRAME_Pos)
-#define   US_IMR_SPI_SLAVE_FRAME_0_Val    _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
-#define   US_IMR_SPI_SLAVE_FRAME_1_Val    _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_FRAME      (_U_(0x1) << US_IMR_SPI_SLAVE_FRAME_Pos)
+#define   US_IMR_SPI_SLAVE_FRAME_0_Val    _U_(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_FRAME_1_Val    _U_(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
 #define US_IMR_SPI_SLAVE_FRAME_0    (US_IMR_SPI_SLAVE_FRAME_0_Val  << US_IMR_SPI_SLAVE_FRAME_Pos)
 #define US_IMR_SPI_SLAVE_FRAME_1    (US_IMR_SPI_SLAVE_FRAME_1_Val  << US_IMR_SPI_SLAVE_FRAME_Pos)
 #define US_IMR_SPI_SLAVE_PARE_Pos   7            /**< \brief (US_IMR_SPI_SLAVE) Parity Error Interrupt Mask */
-#define US_IMR_SPI_SLAVE_PARE       (_U(0x1) << US_IMR_SPI_SLAVE_PARE_Pos)
-#define   US_IMR_SPI_SLAVE_PARE_0_Val     _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
-#define   US_IMR_SPI_SLAVE_PARE_1_Val     _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_PARE       (_U_(0x1) << US_IMR_SPI_SLAVE_PARE_Pos)
+#define   US_IMR_SPI_SLAVE_PARE_0_Val     _U_(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_PARE_1_Val     _U_(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
 #define US_IMR_SPI_SLAVE_PARE_0     (US_IMR_SPI_SLAVE_PARE_0_Val   << US_IMR_SPI_SLAVE_PARE_Pos)
 #define US_IMR_SPI_SLAVE_PARE_1     (US_IMR_SPI_SLAVE_PARE_1_Val   << US_IMR_SPI_SLAVE_PARE_Pos)
 #define US_IMR_SPI_SLAVE_TIMEOUT_Pos 8            /**< \brief (US_IMR_SPI_SLAVE) Time-out Interrupt Mask */
-#define US_IMR_SPI_SLAVE_TIMEOUT    (_U(0x1) << US_IMR_SPI_SLAVE_TIMEOUT_Pos)
-#define   US_IMR_SPI_SLAVE_TIMEOUT_0_Val  _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
-#define   US_IMR_SPI_SLAVE_TIMEOUT_1_Val  _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_TIMEOUT    (_U_(0x1) << US_IMR_SPI_SLAVE_TIMEOUT_Pos)
+#define   US_IMR_SPI_SLAVE_TIMEOUT_0_Val  _U_(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_TIMEOUT_1_Val  _U_(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
 #define US_IMR_SPI_SLAVE_TIMEOUT_0  (US_IMR_SPI_SLAVE_TIMEOUT_0_Val << US_IMR_SPI_SLAVE_TIMEOUT_Pos)
 #define US_IMR_SPI_SLAVE_TIMEOUT_1  (US_IMR_SPI_SLAVE_TIMEOUT_1_Val << US_IMR_SPI_SLAVE_TIMEOUT_Pos)
 #define US_IMR_SPI_SLAVE_TXEMPTY_Pos 9            /**< \brief (US_IMR_SPI_SLAVE) TXEMPTY Interrupt Mask */
-#define US_IMR_SPI_SLAVE_TXEMPTY    (_U(0x1) << US_IMR_SPI_SLAVE_TXEMPTY_Pos)
-#define   US_IMR_SPI_SLAVE_TXEMPTY_0_Val  _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
-#define   US_IMR_SPI_SLAVE_TXEMPTY_1_Val  _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_TXEMPTY    (_U_(0x1) << US_IMR_SPI_SLAVE_TXEMPTY_Pos)
+#define   US_IMR_SPI_SLAVE_TXEMPTY_0_Val  _U_(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_TXEMPTY_1_Val  _U_(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
 #define US_IMR_SPI_SLAVE_TXEMPTY_0  (US_IMR_SPI_SLAVE_TXEMPTY_0_Val << US_IMR_SPI_SLAVE_TXEMPTY_Pos)
 #define US_IMR_SPI_SLAVE_TXEMPTY_1  (US_IMR_SPI_SLAVE_TXEMPTY_1_Val << US_IMR_SPI_SLAVE_TXEMPTY_Pos)
 #define US_IMR_SPI_SLAVE_UNRE_Pos   10           /**< \brief (US_IMR_SPI_SLAVE) SPI Underrun Error Interrupt Mask */
-#define US_IMR_SPI_SLAVE_UNRE       (_U(0x1) << US_IMR_SPI_SLAVE_UNRE_Pos)
-#define   US_IMR_SPI_SLAVE_UNRE_0_Val     _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
-#define   US_IMR_SPI_SLAVE_UNRE_1_Val     _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_UNRE       (_U_(0x1) << US_IMR_SPI_SLAVE_UNRE_Pos)
+#define   US_IMR_SPI_SLAVE_UNRE_0_Val     _U_(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_UNRE_1_Val     _U_(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
 #define US_IMR_SPI_SLAVE_UNRE_0     (US_IMR_SPI_SLAVE_UNRE_0_Val   << US_IMR_SPI_SLAVE_UNRE_Pos)
 #define US_IMR_SPI_SLAVE_UNRE_1     (US_IMR_SPI_SLAVE_UNRE_1_Val   << US_IMR_SPI_SLAVE_UNRE_Pos)
 #define US_IMR_SPI_SLAVE_TXBUFE_Pos 11           /**< \brief (US_IMR_SPI_SLAVE) Buffer Empty Interrupt Mask */
-#define US_IMR_SPI_SLAVE_TXBUFE     (_U(0x1) << US_IMR_SPI_SLAVE_TXBUFE_Pos)
-#define   US_IMR_SPI_SLAVE_TXBUFE_0_Val   _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
-#define   US_IMR_SPI_SLAVE_TXBUFE_1_Val   _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_TXBUFE     (_U_(0x1) << US_IMR_SPI_SLAVE_TXBUFE_Pos)
+#define   US_IMR_SPI_SLAVE_TXBUFE_0_Val   _U_(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_TXBUFE_1_Val   _U_(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
 #define US_IMR_SPI_SLAVE_TXBUFE_0   (US_IMR_SPI_SLAVE_TXBUFE_0_Val << US_IMR_SPI_SLAVE_TXBUFE_Pos)
 #define US_IMR_SPI_SLAVE_TXBUFE_1   (US_IMR_SPI_SLAVE_TXBUFE_1_Val << US_IMR_SPI_SLAVE_TXBUFE_Pos)
 #define US_IMR_SPI_SLAVE_RXBUFF_Pos 12           /**< \brief (US_IMR_SPI_SLAVE) Buffer Full Interrupt Mask */
-#define US_IMR_SPI_SLAVE_RXBUFF     (_U(0x1) << US_IMR_SPI_SLAVE_RXBUFF_Pos)
-#define   US_IMR_SPI_SLAVE_RXBUFF_0_Val   _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
-#define   US_IMR_SPI_SLAVE_RXBUFF_1_Val   _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_RXBUFF     (_U_(0x1) << US_IMR_SPI_SLAVE_RXBUFF_Pos)
+#define   US_IMR_SPI_SLAVE_RXBUFF_0_Val   _U_(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_RXBUFF_1_Val   _U_(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
 #define US_IMR_SPI_SLAVE_RXBUFF_0   (US_IMR_SPI_SLAVE_RXBUFF_0_Val << US_IMR_SPI_SLAVE_RXBUFF_Pos)
 #define US_IMR_SPI_SLAVE_RXBUFF_1   (US_IMR_SPI_SLAVE_RXBUFF_1_Val << US_IMR_SPI_SLAVE_RXBUFF_Pos)
 #define US_IMR_SPI_SLAVE_NACK_Pos   13           /**< \brief (US_IMR_SPI_SLAVE) Non Acknowledge Interrupt Mask */
-#define US_IMR_SPI_SLAVE_NACK       (_U(0x1) << US_IMR_SPI_SLAVE_NACK_Pos)
-#define   US_IMR_SPI_SLAVE_NACK_0_Val     _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
-#define   US_IMR_SPI_SLAVE_NACK_1_Val     _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_NACK       (_U_(0x1) << US_IMR_SPI_SLAVE_NACK_Pos)
+#define   US_IMR_SPI_SLAVE_NACK_0_Val     _U_(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_NACK_1_Val     _U_(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
 #define US_IMR_SPI_SLAVE_NACK_0     (US_IMR_SPI_SLAVE_NACK_0_Val   << US_IMR_SPI_SLAVE_NACK_Pos)
 #define US_IMR_SPI_SLAVE_NACK_1     (US_IMR_SPI_SLAVE_NACK_1_Val   << US_IMR_SPI_SLAVE_NACK_Pos)
 #define US_IMR_SPI_SLAVE_RIIC_Pos   16           /**< \brief (US_IMR_SPI_SLAVE) Ring Indicator Input Change Mask */
-#define US_IMR_SPI_SLAVE_RIIC       (_U(0x1) << US_IMR_SPI_SLAVE_RIIC_Pos)
-#define   US_IMR_SPI_SLAVE_RIIC_0_Val     _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
-#define   US_IMR_SPI_SLAVE_RIIC_1_Val     _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_RIIC       (_U_(0x1) << US_IMR_SPI_SLAVE_RIIC_Pos)
+#define   US_IMR_SPI_SLAVE_RIIC_0_Val     _U_(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_RIIC_1_Val     _U_(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
 #define US_IMR_SPI_SLAVE_RIIC_0     (US_IMR_SPI_SLAVE_RIIC_0_Val   << US_IMR_SPI_SLAVE_RIIC_Pos)
 #define US_IMR_SPI_SLAVE_RIIC_1     (US_IMR_SPI_SLAVE_RIIC_1_Val   << US_IMR_SPI_SLAVE_RIIC_Pos)
 #define US_IMR_SPI_SLAVE_DSRIC_Pos  17           /**< \brief (US_IMR_SPI_SLAVE) Data Set Ready Input Change Mask */
-#define US_IMR_SPI_SLAVE_DSRIC      (_U(0x1) << US_IMR_SPI_SLAVE_DSRIC_Pos)
-#define   US_IMR_SPI_SLAVE_DSRIC_0_Val    _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
-#define   US_IMR_SPI_SLAVE_DSRIC_1_Val    _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_DSRIC      (_U_(0x1) << US_IMR_SPI_SLAVE_DSRIC_Pos)
+#define   US_IMR_SPI_SLAVE_DSRIC_0_Val    _U_(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_DSRIC_1_Val    _U_(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
 #define US_IMR_SPI_SLAVE_DSRIC_0    (US_IMR_SPI_SLAVE_DSRIC_0_Val  << US_IMR_SPI_SLAVE_DSRIC_Pos)
 #define US_IMR_SPI_SLAVE_DSRIC_1    (US_IMR_SPI_SLAVE_DSRIC_1_Val  << US_IMR_SPI_SLAVE_DSRIC_Pos)
 #define US_IMR_SPI_SLAVE_DCDIC_Pos  18           /**< \brief (US_IMR_SPI_SLAVE) Data Carrier Detect Input Change Interrupt Mask */
-#define US_IMR_SPI_SLAVE_DCDIC      (_U(0x1) << US_IMR_SPI_SLAVE_DCDIC_Pos)
-#define   US_IMR_SPI_SLAVE_DCDIC_0_Val    _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
-#define   US_IMR_SPI_SLAVE_DCDIC_1_Val    _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_DCDIC      (_U_(0x1) << US_IMR_SPI_SLAVE_DCDIC_Pos)
+#define   US_IMR_SPI_SLAVE_DCDIC_0_Val    _U_(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_DCDIC_1_Val    _U_(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
 #define US_IMR_SPI_SLAVE_DCDIC_0    (US_IMR_SPI_SLAVE_DCDIC_0_Val  << US_IMR_SPI_SLAVE_DCDIC_Pos)
 #define US_IMR_SPI_SLAVE_DCDIC_1    (US_IMR_SPI_SLAVE_DCDIC_1_Val  << US_IMR_SPI_SLAVE_DCDIC_Pos)
 #define US_IMR_SPI_SLAVE_CTSIC_Pos  19           /**< \brief (US_IMR_SPI_SLAVE) Clear to Send Input Change Interrupt Mask */
-#define US_IMR_SPI_SLAVE_CTSIC      (_U(0x1) << US_IMR_SPI_SLAVE_CTSIC_Pos)
-#define   US_IMR_SPI_SLAVE_CTSIC_0_Val    _U(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
-#define   US_IMR_SPI_SLAVE_CTSIC_1_Val    _U(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
+#define US_IMR_SPI_SLAVE_CTSIC      (_U_(0x1) << US_IMR_SPI_SLAVE_CTSIC_Pos)
+#define   US_IMR_SPI_SLAVE_CTSIC_0_Val    _U_(0x0)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is disabled */
+#define   US_IMR_SPI_SLAVE_CTSIC_1_Val    _U_(0x1)   /**< \brief (US_IMR_SPI_SLAVE) The interrupt is enabled */
 #define US_IMR_SPI_SLAVE_CTSIC_0    (US_IMR_SPI_SLAVE_CTSIC_0_Val  << US_IMR_SPI_SLAVE_CTSIC_Pos)
 #define US_IMR_SPI_SLAVE_CTSIC_1    (US_IMR_SPI_SLAVE_CTSIC_1_Val  << US_IMR_SPI_SLAVE_CTSIC_Pos)
-#define US_IMR_SPI_SLAVE_MASK       _U(0x000F3FE7) /**< \brief (US_IMR_SPI_SLAVE) MASK Register */
+#define US_IMR_SPI_SLAVE_MASK       _U_(0x000F3FE7) /**< \brief (US_IMR_SPI_SLAVE) MASK Register */
 
 // USART mode
 #define US_IMR_USART_RXRDY_Pos      0            /**< \brief (US_IMR_USART) RXRDY Interrupt Mask */
-#define US_IMR_USART_RXRDY          (_U(0x1) << US_IMR_USART_RXRDY_Pos)
-#define   US_IMR_USART_RXRDY_0_Val        _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
-#define   US_IMR_USART_RXRDY_1_Val        _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_RXRDY          (_U_(0x1) << US_IMR_USART_RXRDY_Pos)
+#define   US_IMR_USART_RXRDY_0_Val        _U_(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_RXRDY_1_Val        _U_(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
 #define US_IMR_USART_RXRDY_0        (US_IMR_USART_RXRDY_0_Val      << US_IMR_USART_RXRDY_Pos)
 #define US_IMR_USART_RXRDY_1        (US_IMR_USART_RXRDY_1_Val      << US_IMR_USART_RXRDY_Pos)
 #define US_IMR_USART_TXRDY_Pos      1            /**< \brief (US_IMR_USART) TXRDY Interrupt Mask */
-#define US_IMR_USART_TXRDY          (_U(0x1) << US_IMR_USART_TXRDY_Pos)
-#define   US_IMR_USART_TXRDY_0_Val        _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
-#define   US_IMR_USART_TXRDY_1_Val        _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_TXRDY          (_U_(0x1) << US_IMR_USART_TXRDY_Pos)
+#define   US_IMR_USART_TXRDY_0_Val        _U_(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_TXRDY_1_Val        _U_(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
 #define US_IMR_USART_TXRDY_0        (US_IMR_USART_TXRDY_0_Val      << US_IMR_USART_TXRDY_Pos)
 #define US_IMR_USART_TXRDY_1        (US_IMR_USART_TXRDY_1_Val      << US_IMR_USART_TXRDY_Pos)
 #define US_IMR_USART_RXBRK_Pos      2            /**< \brief (US_IMR_USART) Receiver Break Interrupt Mask */
-#define US_IMR_USART_RXBRK          (_U(0x1) << US_IMR_USART_RXBRK_Pos)
-#define   US_IMR_USART_RXBRK_0_Val        _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
-#define   US_IMR_USART_RXBRK_1_Val        _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_RXBRK          (_U_(0x1) << US_IMR_USART_RXBRK_Pos)
+#define   US_IMR_USART_RXBRK_0_Val        _U_(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_RXBRK_1_Val        _U_(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
 #define US_IMR_USART_RXBRK_0        (US_IMR_USART_RXBRK_0_Val      << US_IMR_USART_RXBRK_Pos)
 #define US_IMR_USART_RXBRK_1        (US_IMR_USART_RXBRK_1_Val      << US_IMR_USART_RXBRK_Pos)
 #define US_IMR_USART_OVRE_Pos       5            /**< \brief (US_IMR_USART) Overrun Error Interrupt Mask */
-#define US_IMR_USART_OVRE           (_U(0x1) << US_IMR_USART_OVRE_Pos)
-#define   US_IMR_USART_OVRE_0_Val         _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
-#define   US_IMR_USART_OVRE_1_Val         _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_OVRE           (_U_(0x1) << US_IMR_USART_OVRE_Pos)
+#define   US_IMR_USART_OVRE_0_Val         _U_(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_OVRE_1_Val         _U_(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
 #define US_IMR_USART_OVRE_0         (US_IMR_USART_OVRE_0_Val       << US_IMR_USART_OVRE_Pos)
 #define US_IMR_USART_OVRE_1         (US_IMR_USART_OVRE_1_Val       << US_IMR_USART_OVRE_Pos)
 #define US_IMR_USART_FRAME_Pos      6            /**< \brief (US_IMR_USART) Framing Error Interrupt Mask */
-#define US_IMR_USART_FRAME          (_U(0x1) << US_IMR_USART_FRAME_Pos)
-#define   US_IMR_USART_FRAME_0_Val        _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
-#define   US_IMR_USART_FRAME_1_Val        _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_FRAME          (_U_(0x1) << US_IMR_USART_FRAME_Pos)
+#define   US_IMR_USART_FRAME_0_Val        _U_(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_FRAME_1_Val        _U_(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
 #define US_IMR_USART_FRAME_0        (US_IMR_USART_FRAME_0_Val      << US_IMR_USART_FRAME_Pos)
 #define US_IMR_USART_FRAME_1        (US_IMR_USART_FRAME_1_Val      << US_IMR_USART_FRAME_Pos)
 #define US_IMR_USART_PARE_Pos       7            /**< \brief (US_IMR_USART) Parity Error Interrupt Mask */
-#define US_IMR_USART_PARE           (_U(0x1) << US_IMR_USART_PARE_Pos)
-#define   US_IMR_USART_PARE_0_Val         _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
-#define   US_IMR_USART_PARE_1_Val         _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_PARE           (_U_(0x1) << US_IMR_USART_PARE_Pos)
+#define   US_IMR_USART_PARE_0_Val         _U_(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_PARE_1_Val         _U_(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
 #define US_IMR_USART_PARE_0         (US_IMR_USART_PARE_0_Val       << US_IMR_USART_PARE_Pos)
 #define US_IMR_USART_PARE_1         (US_IMR_USART_PARE_1_Val       << US_IMR_USART_PARE_Pos)
 #define US_IMR_USART_TIMEOUT_Pos    8            /**< \brief (US_IMR_USART) Time-out Interrupt Mask */
-#define US_IMR_USART_TIMEOUT        (_U(0x1) << US_IMR_USART_TIMEOUT_Pos)
-#define   US_IMR_USART_TIMEOUT_0_Val      _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
-#define   US_IMR_USART_TIMEOUT_1_Val      _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_TIMEOUT        (_U_(0x1) << US_IMR_USART_TIMEOUT_Pos)
+#define   US_IMR_USART_TIMEOUT_0_Val      _U_(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_TIMEOUT_1_Val      _U_(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
 #define US_IMR_USART_TIMEOUT_0      (US_IMR_USART_TIMEOUT_0_Val    << US_IMR_USART_TIMEOUT_Pos)
 #define US_IMR_USART_TIMEOUT_1      (US_IMR_USART_TIMEOUT_1_Val    << US_IMR_USART_TIMEOUT_Pos)
 #define US_IMR_USART_TXEMPTY_Pos    9            /**< \brief (US_IMR_USART) TXEMPTY Interrupt Mask */
-#define US_IMR_USART_TXEMPTY        (_U(0x1) << US_IMR_USART_TXEMPTY_Pos)
-#define   US_IMR_USART_TXEMPTY_0_Val      _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
-#define   US_IMR_USART_TXEMPTY_1_Val      _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_TXEMPTY        (_U_(0x1) << US_IMR_USART_TXEMPTY_Pos)
+#define   US_IMR_USART_TXEMPTY_0_Val      _U_(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_TXEMPTY_1_Val      _U_(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
 #define US_IMR_USART_TXEMPTY_0      (US_IMR_USART_TXEMPTY_0_Val    << US_IMR_USART_TXEMPTY_Pos)
 #define US_IMR_USART_TXEMPTY_1      (US_IMR_USART_TXEMPTY_1_Val    << US_IMR_USART_TXEMPTY_Pos)
 #define US_IMR_USART_ITER_Pos       10           /**< \brief (US_IMR_USART) Iteration Interrupt Mask */
-#define US_IMR_USART_ITER           (_U(0x1) << US_IMR_USART_ITER_Pos)
-#define   US_IMR_USART_ITER_0_Val         _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
-#define   US_IMR_USART_ITER_1_Val         _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_ITER           (_U_(0x1) << US_IMR_USART_ITER_Pos)
+#define   US_IMR_USART_ITER_0_Val         _U_(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_ITER_1_Val         _U_(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
 #define US_IMR_USART_ITER_0         (US_IMR_USART_ITER_0_Val       << US_IMR_USART_ITER_Pos)
 #define US_IMR_USART_ITER_1         (US_IMR_USART_ITER_1_Val       << US_IMR_USART_ITER_Pos)
 #define US_IMR_USART_TXBUFE_Pos     11           /**< \brief (US_IMR_USART) Buffer Empty Interrupt Mask */
-#define US_IMR_USART_TXBUFE         (_U(0x1) << US_IMR_USART_TXBUFE_Pos)
-#define   US_IMR_USART_TXBUFE_0_Val       _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
-#define   US_IMR_USART_TXBUFE_1_Val       _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_TXBUFE         (_U_(0x1) << US_IMR_USART_TXBUFE_Pos)
+#define   US_IMR_USART_TXBUFE_0_Val       _U_(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_TXBUFE_1_Val       _U_(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
 #define US_IMR_USART_TXBUFE_0       (US_IMR_USART_TXBUFE_0_Val     << US_IMR_USART_TXBUFE_Pos)
 #define US_IMR_USART_TXBUFE_1       (US_IMR_USART_TXBUFE_1_Val     << US_IMR_USART_TXBUFE_Pos)
 #define US_IMR_USART_RXBUFF_Pos     12           /**< \brief (US_IMR_USART) Buffer Full Interrupt Mask */
-#define US_IMR_USART_RXBUFF         (_U(0x1) << US_IMR_USART_RXBUFF_Pos)
-#define   US_IMR_USART_RXBUFF_0_Val       _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
-#define   US_IMR_USART_RXBUFF_1_Val       _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_RXBUFF         (_U_(0x1) << US_IMR_USART_RXBUFF_Pos)
+#define   US_IMR_USART_RXBUFF_0_Val       _U_(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_RXBUFF_1_Val       _U_(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
 #define US_IMR_USART_RXBUFF_0       (US_IMR_USART_RXBUFF_0_Val     << US_IMR_USART_RXBUFF_Pos)
 #define US_IMR_USART_RXBUFF_1       (US_IMR_USART_RXBUFF_1_Val     << US_IMR_USART_RXBUFF_Pos)
 #define US_IMR_USART_NACK_Pos       13           /**< \brief (US_IMR_USART) Non Acknowledge Interrupt Mask */
-#define US_IMR_USART_NACK           (_U(0x1) << US_IMR_USART_NACK_Pos)
-#define   US_IMR_USART_NACK_0_Val         _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
-#define   US_IMR_USART_NACK_1_Val         _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_NACK           (_U_(0x1) << US_IMR_USART_NACK_Pos)
+#define   US_IMR_USART_NACK_0_Val         _U_(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_NACK_1_Val         _U_(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
 #define US_IMR_USART_NACK_0         (US_IMR_USART_NACK_0_Val       << US_IMR_USART_NACK_Pos)
 #define US_IMR_USART_NACK_1         (US_IMR_USART_NACK_1_Val       << US_IMR_USART_NACK_Pos)
 #define US_IMR_USART_RIIC_Pos       16           /**< \brief (US_IMR_USART) Ring Indicator Input Change Mask */
-#define US_IMR_USART_RIIC           (_U(0x1) << US_IMR_USART_RIIC_Pos)
-#define   US_IMR_USART_RIIC_0_Val         _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
-#define   US_IMR_USART_RIIC_1_Val         _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_RIIC           (_U_(0x1) << US_IMR_USART_RIIC_Pos)
+#define   US_IMR_USART_RIIC_0_Val         _U_(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_RIIC_1_Val         _U_(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
 #define US_IMR_USART_RIIC_0         (US_IMR_USART_RIIC_0_Val       << US_IMR_USART_RIIC_Pos)
 #define US_IMR_USART_RIIC_1         (US_IMR_USART_RIIC_1_Val       << US_IMR_USART_RIIC_Pos)
 #define US_IMR_USART_DSRIC_Pos      17           /**< \brief (US_IMR_USART) Data Set Ready Input Change Mask */
-#define US_IMR_USART_DSRIC          (_U(0x1) << US_IMR_USART_DSRIC_Pos)
-#define   US_IMR_USART_DSRIC_0_Val        _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
-#define   US_IMR_USART_DSRIC_1_Val        _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_DSRIC          (_U_(0x1) << US_IMR_USART_DSRIC_Pos)
+#define   US_IMR_USART_DSRIC_0_Val        _U_(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_DSRIC_1_Val        _U_(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
 #define US_IMR_USART_DSRIC_0        (US_IMR_USART_DSRIC_0_Val      << US_IMR_USART_DSRIC_Pos)
 #define US_IMR_USART_DSRIC_1        (US_IMR_USART_DSRIC_1_Val      << US_IMR_USART_DSRIC_Pos)
 #define US_IMR_USART_DCDIC_Pos      18           /**< \brief (US_IMR_USART) Data Carrier Detect Input Change Interrupt Mask */
-#define US_IMR_USART_DCDIC          (_U(0x1) << US_IMR_USART_DCDIC_Pos)
-#define   US_IMR_USART_DCDIC_0_Val        _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
-#define   US_IMR_USART_DCDIC_1_Val        _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_DCDIC          (_U_(0x1) << US_IMR_USART_DCDIC_Pos)
+#define   US_IMR_USART_DCDIC_0_Val        _U_(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_DCDIC_1_Val        _U_(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
 #define US_IMR_USART_DCDIC_0        (US_IMR_USART_DCDIC_0_Val      << US_IMR_USART_DCDIC_Pos)
 #define US_IMR_USART_DCDIC_1        (US_IMR_USART_DCDIC_1_Val      << US_IMR_USART_DCDIC_Pos)
 #define US_IMR_USART_CTSIC_Pos      19           /**< \brief (US_IMR_USART) Clear to Send Input Change Interrupt Mask */
-#define US_IMR_USART_CTSIC          (_U(0x1) << US_IMR_USART_CTSIC_Pos)
-#define   US_IMR_USART_CTSIC_0_Val        _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
-#define   US_IMR_USART_CTSIC_1_Val        _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_CTSIC          (_U_(0x1) << US_IMR_USART_CTSIC_Pos)
+#define   US_IMR_USART_CTSIC_0_Val        _U_(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_CTSIC_1_Val        _U_(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
 #define US_IMR_USART_CTSIC_0        (US_IMR_USART_CTSIC_0_Val      << US_IMR_USART_CTSIC_Pos)
 #define US_IMR_USART_CTSIC_1        (US_IMR_USART_CTSIC_1_Val      << US_IMR_USART_CTSIC_Pos)
 #define US_IMR_USART_MANE_Pos       20           /**< \brief (US_IMR_USART) Manchester Error Interrupt Mask */
-#define US_IMR_USART_MANE           (_U(0x1) << US_IMR_USART_MANE_Pos)
+#define US_IMR_USART_MANE           (_U_(0x1) << US_IMR_USART_MANE_Pos)
 #define US_IMR_USART_MANEA_Pos      24           /**< \brief (US_IMR_USART) Manchester Error Interrupt Mask */
-#define US_IMR_USART_MANEA          (_U(0x1) << US_IMR_USART_MANEA_Pos)
-#define   US_IMR_USART_MANEA_0_Val        _U(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
-#define   US_IMR_USART_MANEA_1_Val        _U(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
+#define US_IMR_USART_MANEA          (_U_(0x1) << US_IMR_USART_MANEA_Pos)
+#define   US_IMR_USART_MANEA_0_Val        _U_(0x0)   /**< \brief (US_IMR_USART) The interrupt is disabled */
+#define   US_IMR_USART_MANEA_1_Val        _U_(0x1)   /**< \brief (US_IMR_USART) The interrupt is enabled */
 #define US_IMR_USART_MANEA_0        (US_IMR_USART_MANEA_0_Val      << US_IMR_USART_MANEA_Pos)
 #define US_IMR_USART_MANEA_1        (US_IMR_USART_MANEA_1_Val      << US_IMR_USART_MANEA_Pos)
-#define US_IMR_USART_MASK           _U(0x011F3FE7) /**< \brief (US_IMR_USART) MASK Register */
+#define US_IMR_USART_MASK           _U_(0x011F3FE7) /**< \brief (US_IMR_USART) MASK Register */
 
 // Any mode
 #define US_IMR_RXRDY_Pos            0            /**< \brief (US_IMR) RXRDY Interrupt Mask */
-#define US_IMR_RXRDY                (_U(0x1) << US_IMR_RXRDY_Pos)
-#define   US_IMR_RXRDY_0_Val              _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
-#define   US_IMR_RXRDY_1_Val              _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_RXRDY                (_U_(0x1) << US_IMR_RXRDY_Pos)
+#define   US_IMR_RXRDY_0_Val              _U_(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_RXRDY_1_Val              _U_(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
 #define US_IMR_RXRDY_0              (US_IMR_RXRDY_0_Val            << US_IMR_RXRDY_Pos)
 #define US_IMR_RXRDY_1              (US_IMR_RXRDY_1_Val            << US_IMR_RXRDY_Pos)
 #define US_IMR_TXRDY_Pos            1            /**< \brief (US_IMR) TXRDY Interrupt Mask */
-#define US_IMR_TXRDY                (_U(0x1) << US_IMR_TXRDY_Pos)
-#define   US_IMR_TXRDY_0_Val              _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
-#define   US_IMR_TXRDY_1_Val              _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_TXRDY                (_U_(0x1) << US_IMR_TXRDY_Pos)
+#define   US_IMR_TXRDY_0_Val              _U_(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_TXRDY_1_Val              _U_(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
 #define US_IMR_TXRDY_0              (US_IMR_TXRDY_0_Val            << US_IMR_TXRDY_Pos)
 #define US_IMR_TXRDY_1              (US_IMR_TXRDY_1_Val            << US_IMR_TXRDY_Pos)
 #define US_IMR_RXBRK_Pos            2            /**< \brief (US_IMR) Receiver Break Interrupt Mask */
-#define US_IMR_RXBRK                (_U(0x1) << US_IMR_RXBRK_Pos)
-#define   US_IMR_RXBRK_0_Val              _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
-#define   US_IMR_RXBRK_1_Val              _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_RXBRK                (_U_(0x1) << US_IMR_RXBRK_Pos)
+#define   US_IMR_RXBRK_0_Val              _U_(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_RXBRK_1_Val              _U_(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
 #define US_IMR_RXBRK_0              (US_IMR_RXBRK_0_Val            << US_IMR_RXBRK_Pos)
 #define US_IMR_RXBRK_1              (US_IMR_RXBRK_1_Val            << US_IMR_RXBRK_Pos)
 #define US_IMR_OVRE_Pos             5            /**< \brief (US_IMR) Overrun Error Interrupt Mask */
-#define US_IMR_OVRE                 (_U(0x1) << US_IMR_OVRE_Pos)
-#define   US_IMR_OVRE_0_Val               _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
-#define   US_IMR_OVRE_1_Val               _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_OVRE                 (_U_(0x1) << US_IMR_OVRE_Pos)
+#define   US_IMR_OVRE_0_Val               _U_(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_OVRE_1_Val               _U_(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
 #define US_IMR_OVRE_0               (US_IMR_OVRE_0_Val             << US_IMR_OVRE_Pos)
 #define US_IMR_OVRE_1               (US_IMR_OVRE_1_Val             << US_IMR_OVRE_Pos)
 #define US_IMR_FRAME_Pos            6            /**< \brief (US_IMR) Framing Error Interrupt Mask */
-#define US_IMR_FRAME                (_U(0x1) << US_IMR_FRAME_Pos)
-#define   US_IMR_FRAME_0_Val              _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
-#define   US_IMR_FRAME_1_Val              _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_FRAME                (_U_(0x1) << US_IMR_FRAME_Pos)
+#define   US_IMR_FRAME_0_Val              _U_(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_FRAME_1_Val              _U_(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
 #define US_IMR_FRAME_0              (US_IMR_FRAME_0_Val            << US_IMR_FRAME_Pos)
 #define US_IMR_FRAME_1              (US_IMR_FRAME_1_Val            << US_IMR_FRAME_Pos)
 #define US_IMR_PARE_Pos             7            /**< \brief (US_IMR) Parity Error Interrupt Mask */
-#define US_IMR_PARE                 (_U(0x1) << US_IMR_PARE_Pos)
-#define   US_IMR_PARE_0_Val               _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
-#define   US_IMR_PARE_1_Val               _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_PARE                 (_U_(0x1) << US_IMR_PARE_Pos)
+#define   US_IMR_PARE_0_Val               _U_(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_PARE_1_Val               _U_(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
 #define US_IMR_PARE_0               (US_IMR_PARE_0_Val             << US_IMR_PARE_Pos)
 #define US_IMR_PARE_1               (US_IMR_PARE_1_Val             << US_IMR_PARE_Pos)
 #define US_IMR_TIMEOUT_Pos          8            /**< \brief (US_IMR) Time-out Interrupt Mask */
-#define US_IMR_TIMEOUT              (_U(0x1) << US_IMR_TIMEOUT_Pos)
-#define   US_IMR_TIMEOUT_0_Val            _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
-#define   US_IMR_TIMEOUT_1_Val            _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_TIMEOUT              (_U_(0x1) << US_IMR_TIMEOUT_Pos)
+#define   US_IMR_TIMEOUT_0_Val            _U_(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_TIMEOUT_1_Val            _U_(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
 #define US_IMR_TIMEOUT_0            (US_IMR_TIMEOUT_0_Val          << US_IMR_TIMEOUT_Pos)
 #define US_IMR_TIMEOUT_1            (US_IMR_TIMEOUT_1_Val          << US_IMR_TIMEOUT_Pos)
 #define US_IMR_TXEMPTY_Pos          9            /**< \brief (US_IMR) TXEMPTY Interrupt Mask */
-#define US_IMR_TXEMPTY              (_U(0x1) << US_IMR_TXEMPTY_Pos)
-#define   US_IMR_TXEMPTY_0_Val            _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
-#define   US_IMR_TXEMPTY_1_Val            _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_TXEMPTY              (_U_(0x1) << US_IMR_TXEMPTY_Pos)
+#define   US_IMR_TXEMPTY_0_Val            _U_(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_TXEMPTY_1_Val            _U_(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
 #define US_IMR_TXEMPTY_0            (US_IMR_TXEMPTY_0_Val          << US_IMR_TXEMPTY_Pos)
 #define US_IMR_TXEMPTY_1            (US_IMR_TXEMPTY_1_Val          << US_IMR_TXEMPTY_Pos)
 #define US_IMR_ITER_Pos             10           /**< \brief (US_IMR) Iteration Interrupt Mask */
-#define US_IMR_ITER                 (_U(0x1) << US_IMR_ITER_Pos)
-#define   US_IMR_ITER_0_Val               _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
-#define   US_IMR_ITER_1_Val               _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_ITER                 (_U_(0x1) << US_IMR_ITER_Pos)
+#define   US_IMR_ITER_0_Val               _U_(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_ITER_1_Val               _U_(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
 #define US_IMR_ITER_0               (US_IMR_ITER_0_Val             << US_IMR_ITER_Pos)
 #define US_IMR_ITER_1               (US_IMR_ITER_1_Val             << US_IMR_ITER_Pos)
 #define US_IMR_UNRE_Pos             10           /**< \brief (US_IMR) SPI Underrun Error Interrupt Mask */
-#define US_IMR_UNRE                 (_U(0x1) << US_IMR_UNRE_Pos)
-#define   US_IMR_UNRE_0_Val               _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
-#define   US_IMR_UNRE_1_Val               _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_UNRE                 (_U_(0x1) << US_IMR_UNRE_Pos)
+#define   US_IMR_UNRE_0_Val               _U_(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_UNRE_1_Val               _U_(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
 #define US_IMR_UNRE_0               (US_IMR_UNRE_0_Val             << US_IMR_UNRE_Pos)
 #define US_IMR_UNRE_1               (US_IMR_UNRE_1_Val             << US_IMR_UNRE_Pos)
 #define US_IMR_ITER_Pos             10           /**< \brief (US_IMR) Iteration Interrupt Mask */
-#define US_IMR_ITER                 (_U(0x1) << US_IMR_ITER_Pos)
-#define   US_IMR_ITER_0_Val               _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
-#define   US_IMR_ITER_1_Val               _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_ITER                 (_U_(0x1) << US_IMR_ITER_Pos)
+#define   US_IMR_ITER_0_Val               _U_(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_ITER_1_Val               _U_(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
 #define US_IMR_ITER_0               (US_IMR_ITER_0_Val             << US_IMR_ITER_Pos)
 #define US_IMR_ITER_1               (US_IMR_ITER_1_Val             << US_IMR_ITER_Pos)
 #define US_IMR_TXBUFE_Pos           11           /**< \brief (US_IMR) Buffer Empty Interrupt Mask */
-#define US_IMR_TXBUFE               (_U(0x1) << US_IMR_TXBUFE_Pos)
-#define   US_IMR_TXBUFE_0_Val             _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
-#define   US_IMR_TXBUFE_1_Val             _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_TXBUFE               (_U_(0x1) << US_IMR_TXBUFE_Pos)
+#define   US_IMR_TXBUFE_0_Val             _U_(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_TXBUFE_1_Val             _U_(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
 #define US_IMR_TXBUFE_0             (US_IMR_TXBUFE_0_Val           << US_IMR_TXBUFE_Pos)
 #define US_IMR_TXBUFE_1             (US_IMR_TXBUFE_1_Val           << US_IMR_TXBUFE_Pos)
 #define US_IMR_RXBUFF_Pos           12           /**< \brief (US_IMR) Buffer Full Interrupt Mask */
-#define US_IMR_RXBUFF               (_U(0x1) << US_IMR_RXBUFF_Pos)
-#define   US_IMR_RXBUFF_0_Val             _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
-#define   US_IMR_RXBUFF_1_Val             _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_RXBUFF               (_U_(0x1) << US_IMR_RXBUFF_Pos)
+#define   US_IMR_RXBUFF_0_Val             _U_(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_RXBUFF_1_Val             _U_(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
 #define US_IMR_RXBUFF_0             (US_IMR_RXBUFF_0_Val           << US_IMR_RXBUFF_Pos)
 #define US_IMR_RXBUFF_1             (US_IMR_RXBUFF_1_Val           << US_IMR_RXBUFF_Pos)
 #define US_IMR_NACK_Pos             13           /**< \brief (US_IMR) Non Acknowledge  or LIN Break Sent or LIN Break Received Interrupt Mask */
-#define US_IMR_NACK                 (_U(0x1) << US_IMR_NACK_Pos)
-#define   US_IMR_NACK_0_Val               _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
-#define   US_IMR_NACK_1_Val               _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_NACK                 (_U_(0x1) << US_IMR_NACK_Pos)
+#define   US_IMR_NACK_0_Val               _U_(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_NACK_1_Val               _U_(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
 #define US_IMR_NACK_0               (US_IMR_NACK_0_Val             << US_IMR_NACK_Pos)
 #define US_IMR_NACK_1               (US_IMR_NACK_1_Val             << US_IMR_NACK_Pos)
 #define US_IMR_LINID_Pos            14           /**< \brief (US_IMR) LIN Identifier Sent or LIN Received Interrupt Mask */
-#define US_IMR_LINID                (_U(0x1) << US_IMR_LINID_Pos)
+#define US_IMR_LINID                (_U_(0x1) << US_IMR_LINID_Pos)
 #define US_IMR_LINTC_Pos            15           /**< \brief (US_IMR) LIN Transfer Conpleted Interrupt Mask */
-#define US_IMR_LINTC                (_U(0x1) << US_IMR_LINTC_Pos)
+#define US_IMR_LINTC                (_U_(0x1) << US_IMR_LINTC_Pos)
 #define US_IMR_RIIC_Pos             16           /**< \brief (US_IMR) Ring Indicator Input Change Mask */
-#define US_IMR_RIIC                 (_U(0x1) << US_IMR_RIIC_Pos)
-#define   US_IMR_RIIC_0_Val               _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
-#define   US_IMR_RIIC_1_Val               _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_RIIC                 (_U_(0x1) << US_IMR_RIIC_Pos)
+#define   US_IMR_RIIC_0_Val               _U_(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_RIIC_1_Val               _U_(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
 #define US_IMR_RIIC_0               (US_IMR_RIIC_0_Val             << US_IMR_RIIC_Pos)
 #define US_IMR_RIIC_1               (US_IMR_RIIC_1_Val             << US_IMR_RIIC_Pos)
 #define US_IMR_DSRIC_Pos            17           /**< \brief (US_IMR) Data Set Ready Input Change Mask */
-#define US_IMR_DSRIC                (_U(0x1) << US_IMR_DSRIC_Pos)
-#define   US_IMR_DSRIC_0_Val              _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
-#define   US_IMR_DSRIC_1_Val              _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_DSRIC                (_U_(0x1) << US_IMR_DSRIC_Pos)
+#define   US_IMR_DSRIC_0_Val              _U_(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_DSRIC_1_Val              _U_(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
 #define US_IMR_DSRIC_0              (US_IMR_DSRIC_0_Val            << US_IMR_DSRIC_Pos)
 #define US_IMR_DSRIC_1              (US_IMR_DSRIC_1_Val            << US_IMR_DSRIC_Pos)
 #define US_IMR_DCDIC_Pos            18           /**< \brief (US_IMR) Data Carrier Detect Input Change Interrupt Mask */
-#define US_IMR_DCDIC                (_U(0x1) << US_IMR_DCDIC_Pos)
-#define   US_IMR_DCDIC_0_Val              _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
-#define   US_IMR_DCDIC_1_Val              _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_DCDIC                (_U_(0x1) << US_IMR_DCDIC_Pos)
+#define   US_IMR_DCDIC_0_Val              _U_(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_DCDIC_1_Val              _U_(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
 #define US_IMR_DCDIC_0              (US_IMR_DCDIC_0_Val            << US_IMR_DCDIC_Pos)
 #define US_IMR_DCDIC_1              (US_IMR_DCDIC_1_Val            << US_IMR_DCDIC_Pos)
 #define US_IMR_CTSIC_Pos            19           /**< \brief (US_IMR) Clear to Send Input Change Interrupt Mask */
-#define US_IMR_CTSIC                (_U(0x1) << US_IMR_CTSIC_Pos)
-#define   US_IMR_CTSIC_0_Val              _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
-#define   US_IMR_CTSIC_1_Val              _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_CTSIC                (_U_(0x1) << US_IMR_CTSIC_Pos)
+#define   US_IMR_CTSIC_0_Val              _U_(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_CTSIC_1_Val              _U_(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
 #define US_IMR_CTSIC_0              (US_IMR_CTSIC_0_Val            << US_IMR_CTSIC_Pos)
 #define US_IMR_CTSIC_1              (US_IMR_CTSIC_1_Val            << US_IMR_CTSIC_Pos)
 #define US_IMR_MANE_Pos             20           /**< \brief (US_IMR) Manchester Error Interrupt Mask */
-#define US_IMR_MANE                 (_U(0x1) << US_IMR_MANE_Pos)
+#define US_IMR_MANE                 (_U_(0x1) << US_IMR_MANE_Pos)
 #define US_IMR_MANEA_Pos            24           /**< \brief (US_IMR) Manchester Error Interrupt Mask */
-#define US_IMR_MANEA                (_U(0x1) << US_IMR_MANEA_Pos)
-#define   US_IMR_MANEA_0_Val              _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
-#define   US_IMR_MANEA_1_Val              _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_MANEA                (_U_(0x1) << US_IMR_MANEA_Pos)
+#define   US_IMR_MANEA_0_Val              _U_(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_MANEA_1_Val              _U_(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
 #define US_IMR_MANEA_0              (US_IMR_MANEA_0_Val            << US_IMR_MANEA_Pos)
 #define US_IMR_MANEA_1              (US_IMR_MANEA_1_Val            << US_IMR_MANEA_Pos)
 #define US_IMR_LINBE_Pos            25           /**< \brief (US_IMR) LIN Bus Error Interrupt Mask */
-#define US_IMR_LINBE                (_U(0x1) << US_IMR_LINBE_Pos)
+#define US_IMR_LINBE                (_U_(0x1) << US_IMR_LINBE_Pos)
 #define US_IMR_LINISFE_Pos          26           /**< \brief (US_IMR) LIN Inconsistent Synch Field Error Interrupt Mask */
-#define US_IMR_LINISFE              (_U(0x1) << US_IMR_LINISFE_Pos)
+#define US_IMR_LINISFE              (_U_(0x1) << US_IMR_LINISFE_Pos)
 #define US_IMR_LINIPE_Pos           27           /**< \brief (US_IMR) LIN Identifier Parity Interrupt Mask */
-#define US_IMR_LINIPE               (_U(0x1) << US_IMR_LINIPE_Pos)
+#define US_IMR_LINIPE               (_U_(0x1) << US_IMR_LINIPE_Pos)
 #define US_IMR_LINCE_Pos            28           /**< \brief (US_IMR) LIN Checksum Error Interrupt Mask */
-#define US_IMR_LINCE                (_U(0x1) << US_IMR_LINCE_Pos)
+#define US_IMR_LINCE                (_U_(0x1) << US_IMR_LINCE_Pos)
 #define US_IMR_LINSNRE_Pos          29           /**< \brief (US_IMR) LIN Slave Not Responding Error Interrupt Mask */
-#define US_IMR_LINSNRE              (_U(0x1) << US_IMR_LINSNRE_Pos)
+#define US_IMR_LINSNRE              (_U_(0x1) << US_IMR_LINSNRE_Pos)
 #define US_IMR_LINSTE_Pos           30           /**< \brief (US_IMR) LIN Synch Tolerance Error Interrupt Mask */
-#define US_IMR_LINSTE               (_U(0x1) << US_IMR_LINSTE_Pos)
-#define   US_IMR_LINSTE_0_Val             _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
-#define   US_IMR_LINSTE_1_Val             _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_LINSTE               (_U_(0x1) << US_IMR_LINSTE_Pos)
+#define   US_IMR_LINSTE_0_Val             _U_(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_LINSTE_1_Val             _U_(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
 #define US_IMR_LINSTE_0             (US_IMR_LINSTE_0_Val           << US_IMR_LINSTE_Pos)
 #define US_IMR_LINSTE_1             (US_IMR_LINSTE_1_Val           << US_IMR_LINSTE_Pos)
 #define US_IMR_LINHTE_Pos           31           /**< \brief (US_IMR) LIN Header Timeout Error Interrupt Mask */
-#define US_IMR_LINHTE               (_U(0x1) << US_IMR_LINHTE_Pos)
-#define   US_IMR_LINHTE_0_Val             _U(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
-#define   US_IMR_LINHTE_1_Val             _U(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
+#define US_IMR_LINHTE               (_U_(0x1) << US_IMR_LINHTE_Pos)
+#define   US_IMR_LINHTE_0_Val             _U_(0x0)   /**< \brief (US_IMR) The interrupt is disabled */
+#define   US_IMR_LINHTE_1_Val             _U_(0x1)   /**< \brief (US_IMR) The interrupt is enabled */
 #define US_IMR_LINHTE_0             (US_IMR_LINHTE_0_Val           << US_IMR_LINHTE_Pos)
 #define US_IMR_LINHTE_1             (US_IMR_LINHTE_1_Val           << US_IMR_LINHTE_Pos)
-#define US_IMR_MASK                 _U(0xFF1FFFE7) /**< \brief (US_IMR) MASK Register */
+#define US_IMR_MASK                 _U_(0xFF1FFFE7) /**< \brief (US_IMR) MASK Register */
 
 /* -------- US_CSR : (USART Offset: 0x14) (R/  32) Channel Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -2909,581 +2909,581 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_CSR_OFFSET               0x14         /**< \brief (US_CSR offset) Channel Status Register */
-#define US_CSR_RESETVALUE           _U(0x00000000); /**< \brief (US_CSR reset_value) Channel Status Register */
+#define US_CSR_RESETVALUE           _U_(0x00000000); /**< \brief (US_CSR reset_value) Channel Status Register */
 
 // LIN mode
 #define US_CSR_LIN_RXRDY_Pos        0            /**< \brief (US_CSR_LIN) Receiver Ready */
-#define US_CSR_LIN_RXRDY            (_U(0x1) << US_CSR_LIN_RXRDY_Pos)
-#define   US_CSR_LIN_RXRDY_0_Val          _U(0x0)   /**< \brief (US_CSR_LIN) No complete character has been received since the last read of RHR or the receiver is disabled. If characters werebeing received when the receiver was disabled, RXRDY changes to 1 when the receiver is enabled */
-#define   US_CSR_LIN_RXRDY_1_Val          _U(0x1)   /**< \brief (US_CSR_LIN) At least one complete character has been received and RHR has not yet been read */
+#define US_CSR_LIN_RXRDY            (_U_(0x1) << US_CSR_LIN_RXRDY_Pos)
+#define   US_CSR_LIN_RXRDY_0_Val          _U_(0x0)   /**< \brief (US_CSR_LIN) No complete character has been received since the last read of RHR or the receiver is disabled. If characters werebeing received when the receiver was disabled, RXRDY changes to 1 when the receiver is enabled */
+#define   US_CSR_LIN_RXRDY_1_Val          _U_(0x1)   /**< \brief (US_CSR_LIN) At least one complete character has been received and RHR has not yet been read */
 #define US_CSR_LIN_RXRDY_0          (US_CSR_LIN_RXRDY_0_Val        << US_CSR_LIN_RXRDY_Pos)
 #define US_CSR_LIN_RXRDY_1          (US_CSR_LIN_RXRDY_1_Val        << US_CSR_LIN_RXRDY_Pos)
 #define US_CSR_LIN_TXRDY_Pos        1            /**< \brief (US_CSR_LIN) Transmitter Ready */
-#define US_CSR_LIN_TXRDY            (_U(0x1) << US_CSR_LIN_TXRDY_Pos)
-#define   US_CSR_LIN_TXRDY_0_Val          _U(0x0)   /**< \brief (US_CSR_LIN) A character is in the THR waiting to be transferred to the Transmit Shift Register, or an STTBRK command has been requested, or the transmitter is disabled. As soon as the transmitter is enabled, TXRDY becomes 1 */
-#define   US_CSR_LIN_TXRDY_1_Val          _U(0x1)   /**< \brief (US_CSR_LIN) There is no character in the THR */
+#define US_CSR_LIN_TXRDY            (_U_(0x1) << US_CSR_LIN_TXRDY_Pos)
+#define   US_CSR_LIN_TXRDY_0_Val          _U_(0x0)   /**< \brief (US_CSR_LIN) A character is in the THR waiting to be transferred to the Transmit Shift Register, or an STTBRK command has been requested, or the transmitter is disabled. As soon as the transmitter is enabled, TXRDY becomes 1 */
+#define   US_CSR_LIN_TXRDY_1_Val          _U_(0x1)   /**< \brief (US_CSR_LIN) There is no character in the THR */
 #define US_CSR_LIN_TXRDY_0          (US_CSR_LIN_TXRDY_0_Val        << US_CSR_LIN_TXRDY_Pos)
 #define US_CSR_LIN_TXRDY_1          (US_CSR_LIN_TXRDY_1_Val        << US_CSR_LIN_TXRDY_Pos)
 #define US_CSR_LIN_RXBRK_Pos        2            /**< \brief (US_CSR_LIN) Break Received/End of Break */
-#define US_CSR_LIN_RXBRK            (_U(0x1) << US_CSR_LIN_RXBRK_Pos)
-#define   US_CSR_LIN_RXBRK_0_Val          _U(0x0)   /**< \brief (US_CSR_LIN) No Break received or End of Break detected since the last RSTSTA */
-#define   US_CSR_LIN_RXBRK_1_Val          _U(0x1)   /**< \brief (US_CSR_LIN) Break Received or End of Break detected since the last RSTSTA */
+#define US_CSR_LIN_RXBRK            (_U_(0x1) << US_CSR_LIN_RXBRK_Pos)
+#define   US_CSR_LIN_RXBRK_0_Val          _U_(0x0)   /**< \brief (US_CSR_LIN) No Break received or End of Break detected since the last RSTSTA */
+#define   US_CSR_LIN_RXBRK_1_Val          _U_(0x1)   /**< \brief (US_CSR_LIN) Break Received or End of Break detected since the last RSTSTA */
 #define US_CSR_LIN_RXBRK_0          (US_CSR_LIN_RXBRK_0_Val        << US_CSR_LIN_RXBRK_Pos)
 #define US_CSR_LIN_RXBRK_1          (US_CSR_LIN_RXBRK_1_Val        << US_CSR_LIN_RXBRK_Pos)
 #define US_CSR_LIN_OVRE_Pos         5            /**< \brief (US_CSR_LIN) Overrun Error */
-#define US_CSR_LIN_OVRE             (_U(0x1) << US_CSR_LIN_OVRE_Pos)
-#define   US_CSR_LIN_OVRE_0_Val           _U(0x0)   /**< \brief (US_CSR_LIN) No overrun error has occurred since since the last RSTSTA */
-#define   US_CSR_LIN_OVRE_1_Val           _U(0x1)   /**< \brief (US_CSR_LIN) At least one overrun error has occurred since the last RSTSTA */
+#define US_CSR_LIN_OVRE             (_U_(0x1) << US_CSR_LIN_OVRE_Pos)
+#define   US_CSR_LIN_OVRE_0_Val           _U_(0x0)   /**< \brief (US_CSR_LIN) No overrun error has occurred since since the last RSTSTA */
+#define   US_CSR_LIN_OVRE_1_Val           _U_(0x1)   /**< \brief (US_CSR_LIN) At least one overrun error has occurred since the last RSTSTA */
 #define US_CSR_LIN_OVRE_0           (US_CSR_LIN_OVRE_0_Val         << US_CSR_LIN_OVRE_Pos)
 #define US_CSR_LIN_OVRE_1           (US_CSR_LIN_OVRE_1_Val         << US_CSR_LIN_OVRE_Pos)
 #define US_CSR_LIN_FRAME_Pos        6            /**< \brief (US_CSR_LIN) Framing Error */
-#define US_CSR_LIN_FRAME            (_U(0x1) << US_CSR_LIN_FRAME_Pos)
-#define   US_CSR_LIN_FRAME_0_Val          _U(0x0)   /**< \brief (US_CSR_LIN) No stop bit has been detected low since the last RSTSTA */
-#define   US_CSR_LIN_FRAME_1_Val          _U(0x1)   /**< \brief (US_CSR_LIN) At least one stop bit has been detected low since the last RSTSTA */
+#define US_CSR_LIN_FRAME            (_U_(0x1) << US_CSR_LIN_FRAME_Pos)
+#define   US_CSR_LIN_FRAME_0_Val          _U_(0x0)   /**< \brief (US_CSR_LIN) No stop bit has been detected low since the last RSTSTA */
+#define   US_CSR_LIN_FRAME_1_Val          _U_(0x1)   /**< \brief (US_CSR_LIN) At least one stop bit has been detected low since the last RSTSTA */
 #define US_CSR_LIN_FRAME_0          (US_CSR_LIN_FRAME_0_Val        << US_CSR_LIN_FRAME_Pos)
 #define US_CSR_LIN_FRAME_1          (US_CSR_LIN_FRAME_1_Val        << US_CSR_LIN_FRAME_Pos)
 #define US_CSR_LIN_PARE_Pos         7            /**< \brief (US_CSR_LIN) Parity Error */
-#define US_CSR_LIN_PARE             (_U(0x1) << US_CSR_LIN_PARE_Pos)
-#define   US_CSR_LIN_PARE_0_Val           _U(0x0)   /**< \brief (US_CSR_LIN) No parity error has been detected since the last RSTSTA */
-#define   US_CSR_LIN_PARE_1_Val           _U(0x1)   /**< \brief (US_CSR_LIN) At least one parity error has been detected since the last RSTSTA */
+#define US_CSR_LIN_PARE             (_U_(0x1) << US_CSR_LIN_PARE_Pos)
+#define   US_CSR_LIN_PARE_0_Val           _U_(0x0)   /**< \brief (US_CSR_LIN) No parity error has been detected since the last RSTSTA */
+#define   US_CSR_LIN_PARE_1_Val           _U_(0x1)   /**< \brief (US_CSR_LIN) At least one parity error has been detected since the last RSTSTA */
 #define US_CSR_LIN_PARE_0           (US_CSR_LIN_PARE_0_Val         << US_CSR_LIN_PARE_Pos)
 #define US_CSR_LIN_PARE_1           (US_CSR_LIN_PARE_1_Val         << US_CSR_LIN_PARE_Pos)
 #define US_CSR_LIN_TIMEOUT_Pos      8            /**< \brief (US_CSR_LIN) Receiver Time-out */
-#define US_CSR_LIN_TIMEOUT          (_U(0x1) << US_CSR_LIN_TIMEOUT_Pos)
-#define   US_CSR_LIN_TIMEOUT_0_Val        _U(0x0)   /**< \brief (US_CSR_LIN) There has not been a time-out since the last Start Time-out command or the Time-out Register is 0 */
-#define   US_CSR_LIN_TIMEOUT_1_Val        _U(0x1)   /**< \brief (US_CSR_LIN) There has been a time-out since the last Start Time-out command */
+#define US_CSR_LIN_TIMEOUT          (_U_(0x1) << US_CSR_LIN_TIMEOUT_Pos)
+#define   US_CSR_LIN_TIMEOUT_0_Val        _U_(0x0)   /**< \brief (US_CSR_LIN) There has not been a time-out since the last Start Time-out command or the Time-out Register is 0 */
+#define   US_CSR_LIN_TIMEOUT_1_Val        _U_(0x1)   /**< \brief (US_CSR_LIN) There has been a time-out since the last Start Time-out command */
 #define US_CSR_LIN_TIMEOUT_0        (US_CSR_LIN_TIMEOUT_0_Val      << US_CSR_LIN_TIMEOUT_Pos)
 #define US_CSR_LIN_TIMEOUT_1        (US_CSR_LIN_TIMEOUT_1_Val      << US_CSR_LIN_TIMEOUT_Pos)
 #define US_CSR_LIN_TXEMPTY_Pos      9            /**< \brief (US_CSR_LIN) Transmitter Empty */
-#define US_CSR_LIN_TXEMPTY          (_U(0x1) << US_CSR_LIN_TXEMPTY_Pos)
-#define   US_CSR_LIN_TXEMPTY_0_Val        _U(0x0)   /**< \brief (US_CSR_LIN) There are characters in either THR or the Transmit Shift Register, or the transmitter is disabled */
-#define   US_CSR_LIN_TXEMPTY_1_Val        _U(0x1)   /**< \brief (US_CSR_LIN) There is at least one character in either THR or the Transmit Shift Register */
+#define US_CSR_LIN_TXEMPTY          (_U_(0x1) << US_CSR_LIN_TXEMPTY_Pos)
+#define   US_CSR_LIN_TXEMPTY_0_Val        _U_(0x0)   /**< \brief (US_CSR_LIN) There are characters in either THR or the Transmit Shift Register, or the transmitter is disabled */
+#define   US_CSR_LIN_TXEMPTY_1_Val        _U_(0x1)   /**< \brief (US_CSR_LIN) There is at least one character in either THR or the Transmit Shift Register */
 #define US_CSR_LIN_TXEMPTY_0        (US_CSR_LIN_TXEMPTY_0_Val      << US_CSR_LIN_TXEMPTY_Pos)
 #define US_CSR_LIN_TXEMPTY_1        (US_CSR_LIN_TXEMPTY_1_Val      << US_CSR_LIN_TXEMPTY_Pos)
 #define US_CSR_LIN_ITER_Pos         10           /**< \brief (US_CSR_LIN) Max number of Repetitions Reached */
-#define US_CSR_LIN_ITER             (_U(0x1) << US_CSR_LIN_ITER_Pos)
-#define   US_CSR_LIN_ITER_0_Val           _U(0x0)   /**< \brief (US_CSR_LIN) Maximum number of repetitions has not been reached since the last RSIT */
-#define   US_CSR_LIN_ITER_1_Val           _U(0x1)   /**< \brief (US_CSR_LIN) Maximum number of repetitions has been reached since the last RSIT */
+#define US_CSR_LIN_ITER             (_U_(0x1) << US_CSR_LIN_ITER_Pos)
+#define   US_CSR_LIN_ITER_0_Val           _U_(0x0)   /**< \brief (US_CSR_LIN) Maximum number of repetitions has not been reached since the last RSIT */
+#define   US_CSR_LIN_ITER_1_Val           _U_(0x1)   /**< \brief (US_CSR_LIN) Maximum number of repetitions has been reached since the last RSIT */
 #define US_CSR_LIN_ITER_0           (US_CSR_LIN_ITER_0_Val         << US_CSR_LIN_ITER_Pos)
 #define US_CSR_LIN_ITER_1           (US_CSR_LIN_ITER_1_Val         << US_CSR_LIN_ITER_Pos)
 #define US_CSR_LIN_TXBUFE_Pos       11           /**< \brief (US_CSR_LIN) Transmission Buffer Empty */
-#define US_CSR_LIN_TXBUFE           (_U(0x1) << US_CSR_LIN_TXBUFE_Pos)
-#define   US_CSR_LIN_TXBUFE_0_Val         _U(0x0)   /**< \brief (US_CSR_LIN) The signal Buffer Empty from the Transmit PDC channel is inactive */
-#define   US_CSR_LIN_TXBUFE_1_Val         _U(0x1)   /**< \brief (US_CSR_LIN) The signal Buffer Empty from the Transmit PDC channel is active */
+#define US_CSR_LIN_TXBUFE           (_U_(0x1) << US_CSR_LIN_TXBUFE_Pos)
+#define   US_CSR_LIN_TXBUFE_0_Val         _U_(0x0)   /**< \brief (US_CSR_LIN) The signal Buffer Empty from the Transmit PDC channel is inactive */
+#define   US_CSR_LIN_TXBUFE_1_Val         _U_(0x1)   /**< \brief (US_CSR_LIN) The signal Buffer Empty from the Transmit PDC channel is active */
 #define US_CSR_LIN_TXBUFE_0         (US_CSR_LIN_TXBUFE_0_Val       << US_CSR_LIN_TXBUFE_Pos)
 #define US_CSR_LIN_TXBUFE_1         (US_CSR_LIN_TXBUFE_1_Val       << US_CSR_LIN_TXBUFE_Pos)
 #define US_CSR_LIN_RXBUFF_Pos       12           /**< \brief (US_CSR_LIN) Reception Buffer Full */
-#define US_CSR_LIN_RXBUFF           (_U(0x1) << US_CSR_LIN_RXBUFF_Pos)
-#define   US_CSR_LIN_RXBUFF_0_Val         _U(0x0)   /**< \brief (US_CSR_LIN) The signal Buffer Full from the Receive PDC channel is inactive */
-#define   US_CSR_LIN_RXBUFF_1_Val         _U(0x1)   /**< \brief (US_CSR_LIN) The signal Buffer Full from the Receive PDC channel is active */
+#define US_CSR_LIN_RXBUFF           (_U_(0x1) << US_CSR_LIN_RXBUFF_Pos)
+#define   US_CSR_LIN_RXBUFF_0_Val         _U_(0x0)   /**< \brief (US_CSR_LIN) The signal Buffer Full from the Receive PDC channel is inactive */
+#define   US_CSR_LIN_RXBUFF_1_Val         _U_(0x1)   /**< \brief (US_CSR_LIN) The signal Buffer Full from the Receive PDC channel is active */
 #define US_CSR_LIN_RXBUFF_0         (US_CSR_LIN_RXBUFF_0_Val       << US_CSR_LIN_RXBUFF_Pos)
 #define US_CSR_LIN_RXBUFF_1         (US_CSR_LIN_RXBUFF_1_Val       << US_CSR_LIN_RXBUFF_Pos)
 #define US_CSR_LIN_NACK_Pos         13           /**< \brief (US_CSR_LIN) Non Acknowledge or LIN Break Sent or LIN Break Received */
-#define US_CSR_LIN_NACK             (_U(0x1) << US_CSR_LIN_NACK_Pos)
-#define   US_CSR_LIN_NACK_0_Val           _U(0x0)   /**< \brief (US_CSR_LIN) No Non Acknowledge has not been detected since the last RSTNACK */
-#define   US_CSR_LIN_NACK_1_Val           _U(0x1)   /**< \brief (US_CSR_LIN) At least one Non Acknowledge has been detected since the last RSTNACK */
+#define US_CSR_LIN_NACK             (_U_(0x1) << US_CSR_LIN_NACK_Pos)
+#define   US_CSR_LIN_NACK_0_Val           _U_(0x0)   /**< \brief (US_CSR_LIN) No Non Acknowledge has not been detected since the last RSTNACK */
+#define   US_CSR_LIN_NACK_1_Val           _U_(0x1)   /**< \brief (US_CSR_LIN) At least one Non Acknowledge has been detected since the last RSTNACK */
 #define US_CSR_LIN_NACK_0           (US_CSR_LIN_NACK_0_Val         << US_CSR_LIN_NACK_Pos)
 #define US_CSR_LIN_NACK_1           (US_CSR_LIN_NACK_1_Val         << US_CSR_LIN_NACK_Pos)
 #define US_CSR_LIN_LINID_Pos        14           /**< \brief (US_CSR_LIN) LIN Identifier Sent or LIN Identifier Received */
-#define US_CSR_LIN_LINID            (_U(0x1) << US_CSR_LIN_LINID_Pos)
+#define US_CSR_LIN_LINID            (_U_(0x1) << US_CSR_LIN_LINID_Pos)
 #define US_CSR_LIN_LINTC_Pos        15           /**< \brief (US_CSR_LIN) LIN Transfer Conpleted */
-#define US_CSR_LIN_LINTC            (_U(0x1) << US_CSR_LIN_LINTC_Pos)
+#define US_CSR_LIN_LINTC            (_U_(0x1) << US_CSR_LIN_LINTC_Pos)
 #define US_CSR_LIN_RIIC_Pos         16           /**< \brief (US_CSR_LIN) Ring Indicator Input Change Flag */
-#define US_CSR_LIN_RIIC             (_U(0x1) << US_CSR_LIN_RIIC_Pos)
-#define   US_CSR_LIN_RIIC_0_Val           _U(0x0)   /**< \brief (US_CSR_LIN) No input change has been detected on the RI pin since the last read of CSR */
-#define   US_CSR_LIN_RIIC_1_Val           _U(0x1)   /**< \brief (US_CSR_LIN) At least one input change has been detected on the RI pin since the last read of CSR */
+#define US_CSR_LIN_RIIC             (_U_(0x1) << US_CSR_LIN_RIIC_Pos)
+#define   US_CSR_LIN_RIIC_0_Val           _U_(0x0)   /**< \brief (US_CSR_LIN) No input change has been detected on the RI pin since the last read of CSR */
+#define   US_CSR_LIN_RIIC_1_Val           _U_(0x1)   /**< \brief (US_CSR_LIN) At least one input change has been detected on the RI pin since the last read of CSR */
 #define US_CSR_LIN_RIIC_0           (US_CSR_LIN_RIIC_0_Val         << US_CSR_LIN_RIIC_Pos)
 #define US_CSR_LIN_RIIC_1           (US_CSR_LIN_RIIC_1_Val         << US_CSR_LIN_RIIC_Pos)
 #define US_CSR_LIN_DSRIC_Pos        17           /**< \brief (US_CSR_LIN) Data Set Ready Input Change Flag */
-#define US_CSR_LIN_DSRIC            (_U(0x1) << US_CSR_LIN_DSRIC_Pos)
-#define   US_CSR_LIN_DSRIC_0_Val          _U(0x0)   /**< \brief (US_CSR_LIN) No input change has been detected on the DSR pin since the last read of CSR */
-#define   US_CSR_LIN_DSRIC_1_Val          _U(0x1)   /**< \brief (US_CSR_LIN) At least one input change has been detected on the DSR pin since the last read of CSR */
+#define US_CSR_LIN_DSRIC            (_U_(0x1) << US_CSR_LIN_DSRIC_Pos)
+#define   US_CSR_LIN_DSRIC_0_Val          _U_(0x0)   /**< \brief (US_CSR_LIN) No input change has been detected on the DSR pin since the last read of CSR */
+#define   US_CSR_LIN_DSRIC_1_Val          _U_(0x1)   /**< \brief (US_CSR_LIN) At least one input change has been detected on the DSR pin since the last read of CSR */
 #define US_CSR_LIN_DSRIC_0          (US_CSR_LIN_DSRIC_0_Val        << US_CSR_LIN_DSRIC_Pos)
 #define US_CSR_LIN_DSRIC_1          (US_CSR_LIN_DSRIC_1_Val        << US_CSR_LIN_DSRIC_Pos)
 #define US_CSR_LIN_DCDIC_Pos        18           /**< \brief (US_CSR_LIN) Data Carrier Detect Input Change Flag */
-#define US_CSR_LIN_DCDIC            (_U(0x1) << US_CSR_LIN_DCDIC_Pos)
-#define   US_CSR_LIN_DCDIC_0_Val          _U(0x0)   /**< \brief (US_CSR_LIN) No input change has been detected on the DCD pin since the last read of CSR */
-#define   US_CSR_LIN_DCDIC_1_Val          _U(0x1)   /**< \brief (US_CSR_LIN) At least one input change has been detected on the DCD pin since the last read of CSR */
+#define US_CSR_LIN_DCDIC            (_U_(0x1) << US_CSR_LIN_DCDIC_Pos)
+#define   US_CSR_LIN_DCDIC_0_Val          _U_(0x0)   /**< \brief (US_CSR_LIN) No input change has been detected on the DCD pin since the last read of CSR */
+#define   US_CSR_LIN_DCDIC_1_Val          _U_(0x1)   /**< \brief (US_CSR_LIN) At least one input change has been detected on the DCD pin since the last read of CSR */
 #define US_CSR_LIN_DCDIC_0          (US_CSR_LIN_DCDIC_0_Val        << US_CSR_LIN_DCDIC_Pos)
 #define US_CSR_LIN_DCDIC_1          (US_CSR_LIN_DCDIC_1_Val        << US_CSR_LIN_DCDIC_Pos)
 #define US_CSR_LIN_CTSIC_Pos        19           /**< \brief (US_CSR_LIN) Clear to Send Input Change Flag */
-#define US_CSR_LIN_CTSIC            (_U(0x1) << US_CSR_LIN_CTSIC_Pos)
-#define   US_CSR_LIN_CTSIC_0_Val          _U(0x0)   /**< \brief (US_CSR_LIN) No input change has been detected on the CTS pin since the last read of CSR */
-#define   US_CSR_LIN_CTSIC_1_Val          _U(0x1)   /**< \brief (US_CSR_LIN) At least one input change has been detected on the CTS pin since the last read of CSR */
+#define US_CSR_LIN_CTSIC            (_U_(0x1) << US_CSR_LIN_CTSIC_Pos)
+#define   US_CSR_LIN_CTSIC_0_Val          _U_(0x0)   /**< \brief (US_CSR_LIN) No input change has been detected on the CTS pin since the last read of CSR */
+#define   US_CSR_LIN_CTSIC_1_Val          _U_(0x1)   /**< \brief (US_CSR_LIN) At least one input change has been detected on the CTS pin since the last read of CSR */
 #define US_CSR_LIN_CTSIC_0          (US_CSR_LIN_CTSIC_0_Val        << US_CSR_LIN_CTSIC_Pos)
 #define US_CSR_LIN_CTSIC_1          (US_CSR_LIN_CTSIC_1_Val        << US_CSR_LIN_CTSIC_Pos)
 #define US_CSR_LIN_RI_Pos           20           /**< \brief (US_CSR_LIN) Image of RI Input */
-#define US_CSR_LIN_RI               (_U(0x1) << US_CSR_LIN_RI_Pos)
-#define   US_CSR_LIN_RI_0_Val             _U(0x0)   /**< \brief (US_CSR_LIN) RI is at 0 */
-#define   US_CSR_LIN_RI_1_Val             _U(0x1)   /**< \brief (US_CSR_LIN) RI is at 1 */
+#define US_CSR_LIN_RI               (_U_(0x1) << US_CSR_LIN_RI_Pos)
+#define   US_CSR_LIN_RI_0_Val             _U_(0x0)   /**< \brief (US_CSR_LIN) RI is at 0 */
+#define   US_CSR_LIN_RI_1_Val             _U_(0x1)   /**< \brief (US_CSR_LIN) RI is at 1 */
 #define US_CSR_LIN_RI_0             (US_CSR_LIN_RI_0_Val           << US_CSR_LIN_RI_Pos)
 #define US_CSR_LIN_RI_1             (US_CSR_LIN_RI_1_Val           << US_CSR_LIN_RI_Pos)
 #define US_CSR_LIN_DSR_Pos          21           /**< \brief (US_CSR_LIN) Image of DSR Input */
-#define US_CSR_LIN_DSR              (_U(0x1) << US_CSR_LIN_DSR_Pos)
-#define   US_CSR_LIN_DSR_0_Val            _U(0x0)   /**< \brief (US_CSR_LIN) DSR is at 0 */
-#define   US_CSR_LIN_DSR_1_Val            _U(0x1)   /**< \brief (US_CSR_LIN) DSR is at 1 */
+#define US_CSR_LIN_DSR              (_U_(0x1) << US_CSR_LIN_DSR_Pos)
+#define   US_CSR_LIN_DSR_0_Val            _U_(0x0)   /**< \brief (US_CSR_LIN) DSR is at 0 */
+#define   US_CSR_LIN_DSR_1_Val            _U_(0x1)   /**< \brief (US_CSR_LIN) DSR is at 1 */
 #define US_CSR_LIN_DSR_0            (US_CSR_LIN_DSR_0_Val          << US_CSR_LIN_DSR_Pos)
 #define US_CSR_LIN_DSR_1            (US_CSR_LIN_DSR_1_Val          << US_CSR_LIN_DSR_Pos)
 #define US_CSR_LIN_DCD_Pos          22           /**< \brief (US_CSR_LIN) Image of DCD Input */
-#define US_CSR_LIN_DCD              (_U(0x1) << US_CSR_LIN_DCD_Pos)
-#define   US_CSR_LIN_DCD_0_Val            _U(0x0)   /**< \brief (US_CSR_LIN) DCD is at 0 */
-#define   US_CSR_LIN_DCD_1_Val            _U(0x1)   /**< \brief (US_CSR_LIN) DCD is at 1 */
+#define US_CSR_LIN_DCD              (_U_(0x1) << US_CSR_LIN_DCD_Pos)
+#define   US_CSR_LIN_DCD_0_Val            _U_(0x0)   /**< \brief (US_CSR_LIN) DCD is at 0 */
+#define   US_CSR_LIN_DCD_1_Val            _U_(0x1)   /**< \brief (US_CSR_LIN) DCD is at 1 */
 #define US_CSR_LIN_DCD_0            (US_CSR_LIN_DCD_0_Val          << US_CSR_LIN_DCD_Pos)
 #define US_CSR_LIN_DCD_1            (US_CSR_LIN_DCD_1_Val          << US_CSR_LIN_DCD_Pos)
 #define US_CSR_LIN_LINBLS_Pos       23           /**< \brief (US_CSR_LIN) LIN Bus Line Status */
-#define US_CSR_LIN_LINBLS           (_U(0x1) << US_CSR_LIN_LINBLS_Pos)
-#define   US_CSR_LIN_LINBLS_0_Val         _U(0x0)   /**< \brief (US_CSR_LIN) CTS is at 0 */
-#define   US_CSR_LIN_LINBLS_1_Val         _U(0x1)   /**< \brief (US_CSR_LIN) CTS is at 1 */
+#define US_CSR_LIN_LINBLS           (_U_(0x1) << US_CSR_LIN_LINBLS_Pos)
+#define   US_CSR_LIN_LINBLS_0_Val         _U_(0x0)   /**< \brief (US_CSR_LIN) CTS is at 0 */
+#define   US_CSR_LIN_LINBLS_1_Val         _U_(0x1)   /**< \brief (US_CSR_LIN) CTS is at 1 */
 #define US_CSR_LIN_LINBLS_0         (US_CSR_LIN_LINBLS_0_Val       << US_CSR_LIN_LINBLS_Pos)
 #define US_CSR_LIN_LINBLS_1         (US_CSR_LIN_LINBLS_1_Val       << US_CSR_LIN_LINBLS_Pos)
 #define US_CSR_LIN_LINBE_Pos        25           /**< \brief (US_CSR_LIN) LIN Bit Error */
-#define US_CSR_LIN_LINBE            (_U(0x1) << US_CSR_LIN_LINBE_Pos)
+#define US_CSR_LIN_LINBE            (_U_(0x1) << US_CSR_LIN_LINBE_Pos)
 #define US_CSR_LIN_LINISFE_Pos      26           /**< \brief (US_CSR_LIN) LIN Inconsistent Synch Field Error */
-#define US_CSR_LIN_LINISFE          (_U(0x1) << US_CSR_LIN_LINISFE_Pos)
+#define US_CSR_LIN_LINISFE          (_U_(0x1) << US_CSR_LIN_LINISFE_Pos)
 #define US_CSR_LIN_LINIPE_Pos       27           /**< \brief (US_CSR_LIN) LIN Identifier Parity Error */
-#define US_CSR_LIN_LINIPE           (_U(0x1) << US_CSR_LIN_LINIPE_Pos)
+#define US_CSR_LIN_LINIPE           (_U_(0x1) << US_CSR_LIN_LINIPE_Pos)
 #define US_CSR_LIN_LINCE_Pos        28           /**< \brief (US_CSR_LIN) LIN Checksum Error */
-#define US_CSR_LIN_LINCE            (_U(0x1) << US_CSR_LIN_LINCE_Pos)
+#define US_CSR_LIN_LINCE            (_U_(0x1) << US_CSR_LIN_LINCE_Pos)
 #define US_CSR_LIN_LINSNRE_Pos      29           /**< \brief (US_CSR_LIN) LIN Slave Not Responding Error */
-#define US_CSR_LIN_LINSNRE          (_U(0x1) << US_CSR_LIN_LINSNRE_Pos)
+#define US_CSR_LIN_LINSNRE          (_U_(0x1) << US_CSR_LIN_LINSNRE_Pos)
 #define US_CSR_LIN_LINSTE_Pos       30           /**< \brief (US_CSR_LIN) LIN Synch Tolerance Error */
-#define US_CSR_LIN_LINSTE           (_U(0x1) << US_CSR_LIN_LINSTE_Pos)
-#define   US_CSR_LIN_LINSTE_0_Val         _U(0x0)   /**< \brief (US_CSR_LIN) COMM_TX is at 0 */
-#define   US_CSR_LIN_LINSTE_1_Val         _U(0x1)   /**< \brief (US_CSR_LIN) COMM_TX is at 1 */
+#define US_CSR_LIN_LINSTE           (_U_(0x1) << US_CSR_LIN_LINSTE_Pos)
+#define   US_CSR_LIN_LINSTE_0_Val         _U_(0x0)   /**< \brief (US_CSR_LIN) COMM_TX is at 0 */
+#define   US_CSR_LIN_LINSTE_1_Val         _U_(0x1)   /**< \brief (US_CSR_LIN) COMM_TX is at 1 */
 #define US_CSR_LIN_LINSTE_0         (US_CSR_LIN_LINSTE_0_Val       << US_CSR_LIN_LINSTE_Pos)
 #define US_CSR_LIN_LINSTE_1         (US_CSR_LIN_LINSTE_1_Val       << US_CSR_LIN_LINSTE_Pos)
 #define US_CSR_LIN_LINHTE_Pos       31           /**< \brief (US_CSR_LIN) LIN Header Timeout Error */
-#define US_CSR_LIN_LINHTE           (_U(0x1) << US_CSR_LIN_LINHTE_Pos)
-#define   US_CSR_LIN_LINHTE_0_Val         _U(0x0)   /**< \brief (US_CSR_LIN) COMM_RX is at 0 */
-#define   US_CSR_LIN_LINHTE_1_Val         _U(0x1)   /**< \brief (US_CSR_LIN) COMM_RX is at 1 */
+#define US_CSR_LIN_LINHTE           (_U_(0x1) << US_CSR_LIN_LINHTE_Pos)
+#define   US_CSR_LIN_LINHTE_0_Val         _U_(0x0)   /**< \brief (US_CSR_LIN) COMM_RX is at 0 */
+#define   US_CSR_LIN_LINHTE_1_Val         _U_(0x1)   /**< \brief (US_CSR_LIN) COMM_RX is at 1 */
 #define US_CSR_LIN_LINHTE_0         (US_CSR_LIN_LINHTE_0_Val       << US_CSR_LIN_LINHTE_Pos)
 #define US_CSR_LIN_LINHTE_1         (US_CSR_LIN_LINHTE_1_Val       << US_CSR_LIN_LINHTE_Pos)
-#define US_CSR_LIN_MASK             _U(0xFEFFFFE7) /**< \brief (US_CSR_LIN) MASK Register */
+#define US_CSR_LIN_MASK             _U_(0xFEFFFFE7) /**< \brief (US_CSR_LIN) MASK Register */
 
 // SPI_SLAVE mode
 #define US_CSR_SPI_SLAVE_RXRDY_Pos  0            /**< \brief (US_CSR_SPI_SLAVE) Receiver Ready */
-#define US_CSR_SPI_SLAVE_RXRDY      (_U(0x1) << US_CSR_SPI_SLAVE_RXRDY_Pos)
-#define   US_CSR_SPI_SLAVE_RXRDY_0_Val    _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No complete character has been received since the last read of RHR or the receiver is disabled. If characters werebeing received when the receiver was disabled, RXRDY changes to 1 when the receiver is enabled */
-#define   US_CSR_SPI_SLAVE_RXRDY_1_Val    _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one complete character has been received and RHR has not yet been read */
+#define US_CSR_SPI_SLAVE_RXRDY      (_U_(0x1) << US_CSR_SPI_SLAVE_RXRDY_Pos)
+#define   US_CSR_SPI_SLAVE_RXRDY_0_Val    _U_(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No complete character has been received since the last read of RHR or the receiver is disabled. If characters werebeing received when the receiver was disabled, RXRDY changes to 1 when the receiver is enabled */
+#define   US_CSR_SPI_SLAVE_RXRDY_1_Val    _U_(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one complete character has been received and RHR has not yet been read */
 #define US_CSR_SPI_SLAVE_RXRDY_0    (US_CSR_SPI_SLAVE_RXRDY_0_Val  << US_CSR_SPI_SLAVE_RXRDY_Pos)
 #define US_CSR_SPI_SLAVE_RXRDY_1    (US_CSR_SPI_SLAVE_RXRDY_1_Val  << US_CSR_SPI_SLAVE_RXRDY_Pos)
 #define US_CSR_SPI_SLAVE_TXRDY_Pos  1            /**< \brief (US_CSR_SPI_SLAVE) Transmitter Ready */
-#define US_CSR_SPI_SLAVE_TXRDY      (_U(0x1) << US_CSR_SPI_SLAVE_TXRDY_Pos)
-#define   US_CSR_SPI_SLAVE_TXRDY_0_Val    _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) A character is in the THR waiting to be transferred to the Transmit Shift Register, or an STTBRK command has been requested, or the transmitter is disabled. As soon as the transmitter is enabled, TXRDY becomes 1 */
-#define   US_CSR_SPI_SLAVE_TXRDY_1_Val    _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) There is no character in the THR */
+#define US_CSR_SPI_SLAVE_TXRDY      (_U_(0x1) << US_CSR_SPI_SLAVE_TXRDY_Pos)
+#define   US_CSR_SPI_SLAVE_TXRDY_0_Val    _U_(0x0)   /**< \brief (US_CSR_SPI_SLAVE) A character is in the THR waiting to be transferred to the Transmit Shift Register, or an STTBRK command has been requested, or the transmitter is disabled. As soon as the transmitter is enabled, TXRDY becomes 1 */
+#define   US_CSR_SPI_SLAVE_TXRDY_1_Val    _U_(0x1)   /**< \brief (US_CSR_SPI_SLAVE) There is no character in the THR */
 #define US_CSR_SPI_SLAVE_TXRDY_0    (US_CSR_SPI_SLAVE_TXRDY_0_Val  << US_CSR_SPI_SLAVE_TXRDY_Pos)
 #define US_CSR_SPI_SLAVE_TXRDY_1    (US_CSR_SPI_SLAVE_TXRDY_1_Val  << US_CSR_SPI_SLAVE_TXRDY_Pos)
 #define US_CSR_SPI_SLAVE_RXBRK_Pos  2            /**< \brief (US_CSR_SPI_SLAVE) Break Received/End of Break */
-#define US_CSR_SPI_SLAVE_RXBRK      (_U(0x1) << US_CSR_SPI_SLAVE_RXBRK_Pos)
-#define   US_CSR_SPI_SLAVE_RXBRK_0_Val    _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No Break received or End of Break detected since the last RSTSTA */
-#define   US_CSR_SPI_SLAVE_RXBRK_1_Val    _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) Break Received or End of Break detected since the last RSTSTA */
+#define US_CSR_SPI_SLAVE_RXBRK      (_U_(0x1) << US_CSR_SPI_SLAVE_RXBRK_Pos)
+#define   US_CSR_SPI_SLAVE_RXBRK_0_Val    _U_(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No Break received or End of Break detected since the last RSTSTA */
+#define   US_CSR_SPI_SLAVE_RXBRK_1_Val    _U_(0x1)   /**< \brief (US_CSR_SPI_SLAVE) Break Received or End of Break detected since the last RSTSTA */
 #define US_CSR_SPI_SLAVE_RXBRK_0    (US_CSR_SPI_SLAVE_RXBRK_0_Val  << US_CSR_SPI_SLAVE_RXBRK_Pos)
 #define US_CSR_SPI_SLAVE_RXBRK_1    (US_CSR_SPI_SLAVE_RXBRK_1_Val  << US_CSR_SPI_SLAVE_RXBRK_Pos)
 #define US_CSR_SPI_SLAVE_OVRE_Pos   5            /**< \brief (US_CSR_SPI_SLAVE) Overrun Error */
-#define US_CSR_SPI_SLAVE_OVRE       (_U(0x1) << US_CSR_SPI_SLAVE_OVRE_Pos)
-#define   US_CSR_SPI_SLAVE_OVRE_0_Val     _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No overrun error has occurred since since the last RSTSTA */
-#define   US_CSR_SPI_SLAVE_OVRE_1_Val     _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one overrun error has occurred since the last RSTSTA */
+#define US_CSR_SPI_SLAVE_OVRE       (_U_(0x1) << US_CSR_SPI_SLAVE_OVRE_Pos)
+#define   US_CSR_SPI_SLAVE_OVRE_0_Val     _U_(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No overrun error has occurred since since the last RSTSTA */
+#define   US_CSR_SPI_SLAVE_OVRE_1_Val     _U_(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one overrun error has occurred since the last RSTSTA */
 #define US_CSR_SPI_SLAVE_OVRE_0     (US_CSR_SPI_SLAVE_OVRE_0_Val   << US_CSR_SPI_SLAVE_OVRE_Pos)
 #define US_CSR_SPI_SLAVE_OVRE_1     (US_CSR_SPI_SLAVE_OVRE_1_Val   << US_CSR_SPI_SLAVE_OVRE_Pos)
 #define US_CSR_SPI_SLAVE_FRAME_Pos  6            /**< \brief (US_CSR_SPI_SLAVE) Framing Error */
-#define US_CSR_SPI_SLAVE_FRAME      (_U(0x1) << US_CSR_SPI_SLAVE_FRAME_Pos)
-#define   US_CSR_SPI_SLAVE_FRAME_0_Val    _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No stop bit has been detected low since the last RSTSTA */
-#define   US_CSR_SPI_SLAVE_FRAME_1_Val    _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one stop bit has been detected low since the last RSTSTA */
+#define US_CSR_SPI_SLAVE_FRAME      (_U_(0x1) << US_CSR_SPI_SLAVE_FRAME_Pos)
+#define   US_CSR_SPI_SLAVE_FRAME_0_Val    _U_(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No stop bit has been detected low since the last RSTSTA */
+#define   US_CSR_SPI_SLAVE_FRAME_1_Val    _U_(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one stop bit has been detected low since the last RSTSTA */
 #define US_CSR_SPI_SLAVE_FRAME_0    (US_CSR_SPI_SLAVE_FRAME_0_Val  << US_CSR_SPI_SLAVE_FRAME_Pos)
 #define US_CSR_SPI_SLAVE_FRAME_1    (US_CSR_SPI_SLAVE_FRAME_1_Val  << US_CSR_SPI_SLAVE_FRAME_Pos)
 #define US_CSR_SPI_SLAVE_PARE_Pos   7            /**< \brief (US_CSR_SPI_SLAVE) Parity Error */
-#define US_CSR_SPI_SLAVE_PARE       (_U(0x1) << US_CSR_SPI_SLAVE_PARE_Pos)
-#define   US_CSR_SPI_SLAVE_PARE_0_Val     _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No parity error has been detected since the last RSTSTA */
-#define   US_CSR_SPI_SLAVE_PARE_1_Val     _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one parity error has been detected since the last RSTSTA */
+#define US_CSR_SPI_SLAVE_PARE       (_U_(0x1) << US_CSR_SPI_SLAVE_PARE_Pos)
+#define   US_CSR_SPI_SLAVE_PARE_0_Val     _U_(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No parity error has been detected since the last RSTSTA */
+#define   US_CSR_SPI_SLAVE_PARE_1_Val     _U_(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one parity error has been detected since the last RSTSTA */
 #define US_CSR_SPI_SLAVE_PARE_0     (US_CSR_SPI_SLAVE_PARE_0_Val   << US_CSR_SPI_SLAVE_PARE_Pos)
 #define US_CSR_SPI_SLAVE_PARE_1     (US_CSR_SPI_SLAVE_PARE_1_Val   << US_CSR_SPI_SLAVE_PARE_Pos)
 #define US_CSR_SPI_SLAVE_TIMEOUT_Pos 8            /**< \brief (US_CSR_SPI_SLAVE) Receiver Time-out */
-#define US_CSR_SPI_SLAVE_TIMEOUT    (_U(0x1) << US_CSR_SPI_SLAVE_TIMEOUT_Pos)
-#define   US_CSR_SPI_SLAVE_TIMEOUT_0_Val  _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) There has not been a time-out since the last Start Time-out command or the Time-out Register is 0 */
-#define   US_CSR_SPI_SLAVE_TIMEOUT_1_Val  _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) There has been a time-out since the last Start Time-out command */
+#define US_CSR_SPI_SLAVE_TIMEOUT    (_U_(0x1) << US_CSR_SPI_SLAVE_TIMEOUT_Pos)
+#define   US_CSR_SPI_SLAVE_TIMEOUT_0_Val  _U_(0x0)   /**< \brief (US_CSR_SPI_SLAVE) There has not been a time-out since the last Start Time-out command or the Time-out Register is 0 */
+#define   US_CSR_SPI_SLAVE_TIMEOUT_1_Val  _U_(0x1)   /**< \brief (US_CSR_SPI_SLAVE) There has been a time-out since the last Start Time-out command */
 #define US_CSR_SPI_SLAVE_TIMEOUT_0  (US_CSR_SPI_SLAVE_TIMEOUT_0_Val << US_CSR_SPI_SLAVE_TIMEOUT_Pos)
 #define US_CSR_SPI_SLAVE_TIMEOUT_1  (US_CSR_SPI_SLAVE_TIMEOUT_1_Val << US_CSR_SPI_SLAVE_TIMEOUT_Pos)
 #define US_CSR_SPI_SLAVE_TXEMPTY_Pos 9            /**< \brief (US_CSR_SPI_SLAVE) Transmitter Empty */
-#define US_CSR_SPI_SLAVE_TXEMPTY    (_U(0x1) << US_CSR_SPI_SLAVE_TXEMPTY_Pos)
-#define   US_CSR_SPI_SLAVE_TXEMPTY_0_Val  _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) There are characters in either THR or the Transmit Shift Register, or the transmitter is disabled */
-#define   US_CSR_SPI_SLAVE_TXEMPTY_1_Val  _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) There is at least one character in either THR or the Transmit Shift Register */
+#define US_CSR_SPI_SLAVE_TXEMPTY    (_U_(0x1) << US_CSR_SPI_SLAVE_TXEMPTY_Pos)
+#define   US_CSR_SPI_SLAVE_TXEMPTY_0_Val  _U_(0x0)   /**< \brief (US_CSR_SPI_SLAVE) There are characters in either THR or the Transmit Shift Register, or the transmitter is disabled */
+#define   US_CSR_SPI_SLAVE_TXEMPTY_1_Val  _U_(0x1)   /**< \brief (US_CSR_SPI_SLAVE) There is at least one character in either THR or the Transmit Shift Register */
 #define US_CSR_SPI_SLAVE_TXEMPTY_0  (US_CSR_SPI_SLAVE_TXEMPTY_0_Val << US_CSR_SPI_SLAVE_TXEMPTY_Pos)
 #define US_CSR_SPI_SLAVE_TXEMPTY_1  (US_CSR_SPI_SLAVE_TXEMPTY_1_Val << US_CSR_SPI_SLAVE_TXEMPTY_Pos)
 #define US_CSR_SPI_SLAVE_UNRE_Pos   10           /**< \brief (US_CSR_SPI_SLAVE) SPI Underrun Error */
-#define US_CSR_SPI_SLAVE_UNRE       (_U(0x1) << US_CSR_SPI_SLAVE_UNRE_Pos)
-#define   US_CSR_SPI_SLAVE_UNRE_0_Val     _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No SPI underrun error has occurred since the last RSTSTA */
-#define   US_CSR_SPI_SLAVE_UNRE_1_Val     _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one SPI underrun error has occurred since the last RSTSTA */
+#define US_CSR_SPI_SLAVE_UNRE       (_U_(0x1) << US_CSR_SPI_SLAVE_UNRE_Pos)
+#define   US_CSR_SPI_SLAVE_UNRE_0_Val     _U_(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No SPI underrun error has occurred since the last RSTSTA */
+#define   US_CSR_SPI_SLAVE_UNRE_1_Val     _U_(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one SPI underrun error has occurred since the last RSTSTA */
 #define US_CSR_SPI_SLAVE_UNRE_0     (US_CSR_SPI_SLAVE_UNRE_0_Val   << US_CSR_SPI_SLAVE_UNRE_Pos)
 #define US_CSR_SPI_SLAVE_UNRE_1     (US_CSR_SPI_SLAVE_UNRE_1_Val   << US_CSR_SPI_SLAVE_UNRE_Pos)
 #define US_CSR_SPI_SLAVE_TXBUFE_Pos 11           /**< \brief (US_CSR_SPI_SLAVE) Transmission Buffer Empty */
-#define US_CSR_SPI_SLAVE_TXBUFE     (_U(0x1) << US_CSR_SPI_SLAVE_TXBUFE_Pos)
-#define   US_CSR_SPI_SLAVE_TXBUFE_0_Val   _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) The signal Buffer Empty from the Transmit PDC channel is inactive */
-#define   US_CSR_SPI_SLAVE_TXBUFE_1_Val   _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) The signal Buffer Empty from the Transmit PDC channel is active */
+#define US_CSR_SPI_SLAVE_TXBUFE     (_U_(0x1) << US_CSR_SPI_SLAVE_TXBUFE_Pos)
+#define   US_CSR_SPI_SLAVE_TXBUFE_0_Val   _U_(0x0)   /**< \brief (US_CSR_SPI_SLAVE) The signal Buffer Empty from the Transmit PDC channel is inactive */
+#define   US_CSR_SPI_SLAVE_TXBUFE_1_Val   _U_(0x1)   /**< \brief (US_CSR_SPI_SLAVE) The signal Buffer Empty from the Transmit PDC channel is active */
 #define US_CSR_SPI_SLAVE_TXBUFE_0   (US_CSR_SPI_SLAVE_TXBUFE_0_Val << US_CSR_SPI_SLAVE_TXBUFE_Pos)
 #define US_CSR_SPI_SLAVE_TXBUFE_1   (US_CSR_SPI_SLAVE_TXBUFE_1_Val << US_CSR_SPI_SLAVE_TXBUFE_Pos)
 #define US_CSR_SPI_SLAVE_RXBUFF_Pos 12           /**< \brief (US_CSR_SPI_SLAVE) Reception Buffer Full */
-#define US_CSR_SPI_SLAVE_RXBUFF     (_U(0x1) << US_CSR_SPI_SLAVE_RXBUFF_Pos)
-#define   US_CSR_SPI_SLAVE_RXBUFF_0_Val   _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) The signal Buffer Full from the Receive PDC channel is inactive */
-#define   US_CSR_SPI_SLAVE_RXBUFF_1_Val   _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) The signal Buffer Full from the Receive PDC channel is active */
+#define US_CSR_SPI_SLAVE_RXBUFF     (_U_(0x1) << US_CSR_SPI_SLAVE_RXBUFF_Pos)
+#define   US_CSR_SPI_SLAVE_RXBUFF_0_Val   _U_(0x0)   /**< \brief (US_CSR_SPI_SLAVE) The signal Buffer Full from the Receive PDC channel is inactive */
+#define   US_CSR_SPI_SLAVE_RXBUFF_1_Val   _U_(0x1)   /**< \brief (US_CSR_SPI_SLAVE) The signal Buffer Full from the Receive PDC channel is active */
 #define US_CSR_SPI_SLAVE_RXBUFF_0   (US_CSR_SPI_SLAVE_RXBUFF_0_Val << US_CSR_SPI_SLAVE_RXBUFF_Pos)
 #define US_CSR_SPI_SLAVE_RXBUFF_1   (US_CSR_SPI_SLAVE_RXBUFF_1_Val << US_CSR_SPI_SLAVE_RXBUFF_Pos)
 #define US_CSR_SPI_SLAVE_NACK_Pos   13           /**< \brief (US_CSR_SPI_SLAVE) Non Acknowledge */
-#define US_CSR_SPI_SLAVE_NACK       (_U(0x1) << US_CSR_SPI_SLAVE_NACK_Pos)
-#define   US_CSR_SPI_SLAVE_NACK_0_Val     _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No Non Acknowledge has not been detected since the last RSTNACK */
-#define   US_CSR_SPI_SLAVE_NACK_1_Val     _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one Non Acknowledge has been detected since the last RSTNACK */
+#define US_CSR_SPI_SLAVE_NACK       (_U_(0x1) << US_CSR_SPI_SLAVE_NACK_Pos)
+#define   US_CSR_SPI_SLAVE_NACK_0_Val     _U_(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No Non Acknowledge has not been detected since the last RSTNACK */
+#define   US_CSR_SPI_SLAVE_NACK_1_Val     _U_(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one Non Acknowledge has been detected since the last RSTNACK */
 #define US_CSR_SPI_SLAVE_NACK_0     (US_CSR_SPI_SLAVE_NACK_0_Val   << US_CSR_SPI_SLAVE_NACK_Pos)
 #define US_CSR_SPI_SLAVE_NACK_1     (US_CSR_SPI_SLAVE_NACK_1_Val   << US_CSR_SPI_SLAVE_NACK_Pos)
 #define US_CSR_SPI_SLAVE_RIIC_Pos   16           /**< \brief (US_CSR_SPI_SLAVE) Ring Indicator Input Change Flag */
-#define US_CSR_SPI_SLAVE_RIIC       (_U(0x1) << US_CSR_SPI_SLAVE_RIIC_Pos)
-#define   US_CSR_SPI_SLAVE_RIIC_0_Val     _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No input change has been detected on the RI pin since the last read of CSR */
-#define   US_CSR_SPI_SLAVE_RIIC_1_Val     _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one input change has been detected on the RI pin since the last read of CSR */
+#define US_CSR_SPI_SLAVE_RIIC       (_U_(0x1) << US_CSR_SPI_SLAVE_RIIC_Pos)
+#define   US_CSR_SPI_SLAVE_RIIC_0_Val     _U_(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No input change has been detected on the RI pin since the last read of CSR */
+#define   US_CSR_SPI_SLAVE_RIIC_1_Val     _U_(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one input change has been detected on the RI pin since the last read of CSR */
 #define US_CSR_SPI_SLAVE_RIIC_0     (US_CSR_SPI_SLAVE_RIIC_0_Val   << US_CSR_SPI_SLAVE_RIIC_Pos)
 #define US_CSR_SPI_SLAVE_RIIC_1     (US_CSR_SPI_SLAVE_RIIC_1_Val   << US_CSR_SPI_SLAVE_RIIC_Pos)
 #define US_CSR_SPI_SLAVE_DSRIC_Pos  17           /**< \brief (US_CSR_SPI_SLAVE) Data Set Ready Input Change Flag */
-#define US_CSR_SPI_SLAVE_DSRIC      (_U(0x1) << US_CSR_SPI_SLAVE_DSRIC_Pos)
-#define   US_CSR_SPI_SLAVE_DSRIC_0_Val    _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No input change has been detected on the DSR pin since the last read of CSR */
-#define   US_CSR_SPI_SLAVE_DSRIC_1_Val    _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one input change has been detected on the DSR pin since the last read of CSR */
+#define US_CSR_SPI_SLAVE_DSRIC      (_U_(0x1) << US_CSR_SPI_SLAVE_DSRIC_Pos)
+#define   US_CSR_SPI_SLAVE_DSRIC_0_Val    _U_(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No input change has been detected on the DSR pin since the last read of CSR */
+#define   US_CSR_SPI_SLAVE_DSRIC_1_Val    _U_(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one input change has been detected on the DSR pin since the last read of CSR */
 #define US_CSR_SPI_SLAVE_DSRIC_0    (US_CSR_SPI_SLAVE_DSRIC_0_Val  << US_CSR_SPI_SLAVE_DSRIC_Pos)
 #define US_CSR_SPI_SLAVE_DSRIC_1    (US_CSR_SPI_SLAVE_DSRIC_1_Val  << US_CSR_SPI_SLAVE_DSRIC_Pos)
 #define US_CSR_SPI_SLAVE_DCDIC_Pos  18           /**< \brief (US_CSR_SPI_SLAVE) Data Carrier Detect Input Change Flag */
-#define US_CSR_SPI_SLAVE_DCDIC      (_U(0x1) << US_CSR_SPI_SLAVE_DCDIC_Pos)
-#define   US_CSR_SPI_SLAVE_DCDIC_0_Val    _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No input change has been detected on the DCD pin since the last read of CSR */
-#define   US_CSR_SPI_SLAVE_DCDIC_1_Val    _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one input change has been detected on the DCD pin since the last read of CSR */
+#define US_CSR_SPI_SLAVE_DCDIC      (_U_(0x1) << US_CSR_SPI_SLAVE_DCDIC_Pos)
+#define   US_CSR_SPI_SLAVE_DCDIC_0_Val    _U_(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No input change has been detected on the DCD pin since the last read of CSR */
+#define   US_CSR_SPI_SLAVE_DCDIC_1_Val    _U_(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one input change has been detected on the DCD pin since the last read of CSR */
 #define US_CSR_SPI_SLAVE_DCDIC_0    (US_CSR_SPI_SLAVE_DCDIC_0_Val  << US_CSR_SPI_SLAVE_DCDIC_Pos)
 #define US_CSR_SPI_SLAVE_DCDIC_1    (US_CSR_SPI_SLAVE_DCDIC_1_Val  << US_CSR_SPI_SLAVE_DCDIC_Pos)
 #define US_CSR_SPI_SLAVE_CTSIC_Pos  19           /**< \brief (US_CSR_SPI_SLAVE) Clear to Send Input Change Flag */
-#define US_CSR_SPI_SLAVE_CTSIC      (_U(0x1) << US_CSR_SPI_SLAVE_CTSIC_Pos)
-#define   US_CSR_SPI_SLAVE_CTSIC_0_Val    _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No input change has been detected on the CTS pin since the last read of CSR */
-#define   US_CSR_SPI_SLAVE_CTSIC_1_Val    _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one input change has been detected on the CTS pin since the last read of CSR */
+#define US_CSR_SPI_SLAVE_CTSIC      (_U_(0x1) << US_CSR_SPI_SLAVE_CTSIC_Pos)
+#define   US_CSR_SPI_SLAVE_CTSIC_0_Val    _U_(0x0)   /**< \brief (US_CSR_SPI_SLAVE) No input change has been detected on the CTS pin since the last read of CSR */
+#define   US_CSR_SPI_SLAVE_CTSIC_1_Val    _U_(0x1)   /**< \brief (US_CSR_SPI_SLAVE) At least one input change has been detected on the CTS pin since the last read of CSR */
 #define US_CSR_SPI_SLAVE_CTSIC_0    (US_CSR_SPI_SLAVE_CTSIC_0_Val  << US_CSR_SPI_SLAVE_CTSIC_Pos)
 #define US_CSR_SPI_SLAVE_CTSIC_1    (US_CSR_SPI_SLAVE_CTSIC_1_Val  << US_CSR_SPI_SLAVE_CTSIC_Pos)
 #define US_CSR_SPI_SLAVE_RI_Pos     20           /**< \brief (US_CSR_SPI_SLAVE) Image of RI Input */
-#define US_CSR_SPI_SLAVE_RI         (_U(0x1) << US_CSR_SPI_SLAVE_RI_Pos)
-#define   US_CSR_SPI_SLAVE_RI_0_Val       _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) RI is at 0 */
-#define   US_CSR_SPI_SLAVE_RI_1_Val       _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) RI is at 1 */
+#define US_CSR_SPI_SLAVE_RI         (_U_(0x1) << US_CSR_SPI_SLAVE_RI_Pos)
+#define   US_CSR_SPI_SLAVE_RI_0_Val       _U_(0x0)   /**< \brief (US_CSR_SPI_SLAVE) RI is at 0 */
+#define   US_CSR_SPI_SLAVE_RI_1_Val       _U_(0x1)   /**< \brief (US_CSR_SPI_SLAVE) RI is at 1 */
 #define US_CSR_SPI_SLAVE_RI_0       (US_CSR_SPI_SLAVE_RI_0_Val     << US_CSR_SPI_SLAVE_RI_Pos)
 #define US_CSR_SPI_SLAVE_RI_1       (US_CSR_SPI_SLAVE_RI_1_Val     << US_CSR_SPI_SLAVE_RI_Pos)
 #define US_CSR_SPI_SLAVE_DSR_Pos    21           /**< \brief (US_CSR_SPI_SLAVE) Image of DSR Input */
-#define US_CSR_SPI_SLAVE_DSR        (_U(0x1) << US_CSR_SPI_SLAVE_DSR_Pos)
-#define   US_CSR_SPI_SLAVE_DSR_0_Val      _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) DSR is at 0 */
-#define   US_CSR_SPI_SLAVE_DSR_1_Val      _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) DSR is at 1 */
+#define US_CSR_SPI_SLAVE_DSR        (_U_(0x1) << US_CSR_SPI_SLAVE_DSR_Pos)
+#define   US_CSR_SPI_SLAVE_DSR_0_Val      _U_(0x0)   /**< \brief (US_CSR_SPI_SLAVE) DSR is at 0 */
+#define   US_CSR_SPI_SLAVE_DSR_1_Val      _U_(0x1)   /**< \brief (US_CSR_SPI_SLAVE) DSR is at 1 */
 #define US_CSR_SPI_SLAVE_DSR_0      (US_CSR_SPI_SLAVE_DSR_0_Val    << US_CSR_SPI_SLAVE_DSR_Pos)
 #define US_CSR_SPI_SLAVE_DSR_1      (US_CSR_SPI_SLAVE_DSR_1_Val    << US_CSR_SPI_SLAVE_DSR_Pos)
 #define US_CSR_SPI_SLAVE_DCD_Pos    22           /**< \brief (US_CSR_SPI_SLAVE) Image of DCD Input */
-#define US_CSR_SPI_SLAVE_DCD        (_U(0x1) << US_CSR_SPI_SLAVE_DCD_Pos)
-#define   US_CSR_SPI_SLAVE_DCD_0_Val      _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) DCD is at 0 */
-#define   US_CSR_SPI_SLAVE_DCD_1_Val      _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) DCD is at 1 */
+#define US_CSR_SPI_SLAVE_DCD        (_U_(0x1) << US_CSR_SPI_SLAVE_DCD_Pos)
+#define   US_CSR_SPI_SLAVE_DCD_0_Val      _U_(0x0)   /**< \brief (US_CSR_SPI_SLAVE) DCD is at 0 */
+#define   US_CSR_SPI_SLAVE_DCD_1_Val      _U_(0x1)   /**< \brief (US_CSR_SPI_SLAVE) DCD is at 1 */
 #define US_CSR_SPI_SLAVE_DCD_0      (US_CSR_SPI_SLAVE_DCD_0_Val    << US_CSR_SPI_SLAVE_DCD_Pos)
 #define US_CSR_SPI_SLAVE_DCD_1      (US_CSR_SPI_SLAVE_DCD_1_Val    << US_CSR_SPI_SLAVE_DCD_Pos)
 #define US_CSR_SPI_SLAVE_CTS_Pos    23           /**< \brief (US_CSR_SPI_SLAVE) Image of CTS Input */
-#define US_CSR_SPI_SLAVE_CTS        (_U(0x1) << US_CSR_SPI_SLAVE_CTS_Pos)
-#define   US_CSR_SPI_SLAVE_CTS_0_Val      _U(0x0)   /**< \brief (US_CSR_SPI_SLAVE) CTS is at 0 */
-#define   US_CSR_SPI_SLAVE_CTS_1_Val      _U(0x1)   /**< \brief (US_CSR_SPI_SLAVE) CTS is at 1 */
+#define US_CSR_SPI_SLAVE_CTS        (_U_(0x1) << US_CSR_SPI_SLAVE_CTS_Pos)
+#define   US_CSR_SPI_SLAVE_CTS_0_Val      _U_(0x0)   /**< \brief (US_CSR_SPI_SLAVE) CTS is at 0 */
+#define   US_CSR_SPI_SLAVE_CTS_1_Val      _U_(0x1)   /**< \brief (US_CSR_SPI_SLAVE) CTS is at 1 */
 #define US_CSR_SPI_SLAVE_CTS_0      (US_CSR_SPI_SLAVE_CTS_0_Val    << US_CSR_SPI_SLAVE_CTS_Pos)
 #define US_CSR_SPI_SLAVE_CTS_1      (US_CSR_SPI_SLAVE_CTS_1_Val    << US_CSR_SPI_SLAVE_CTS_Pos)
-#define US_CSR_SPI_SLAVE_MASK       _U(0x00FF3FE7) /**< \brief (US_CSR_SPI_SLAVE) MASK Register */
+#define US_CSR_SPI_SLAVE_MASK       _U_(0x00FF3FE7) /**< \brief (US_CSR_SPI_SLAVE) MASK Register */
 
 // USART mode
 #define US_CSR_USART_RXRDY_Pos      0            /**< \brief (US_CSR_USART) Receiver Ready */
-#define US_CSR_USART_RXRDY          (_U(0x1) << US_CSR_USART_RXRDY_Pos)
-#define   US_CSR_USART_RXRDY_0_Val        _U(0x0)   /**< \brief (US_CSR_USART) No complete character has been received since the last read of RHR or the receiver is disabled. If characters werebeing received when the receiver was disabled, RXRDY changes to 1 when the receiver is enabled */
-#define   US_CSR_USART_RXRDY_1_Val        _U(0x1)   /**< \brief (US_CSR_USART) At least one complete character has been received and RHR has not yet been read */
+#define US_CSR_USART_RXRDY          (_U_(0x1) << US_CSR_USART_RXRDY_Pos)
+#define   US_CSR_USART_RXRDY_0_Val        _U_(0x0)   /**< \brief (US_CSR_USART) No complete character has been received since the last read of RHR or the receiver is disabled. If characters werebeing received when the receiver was disabled, RXRDY changes to 1 when the receiver is enabled */
+#define   US_CSR_USART_RXRDY_1_Val        _U_(0x1)   /**< \brief (US_CSR_USART) At least one complete character has been received and RHR has not yet been read */
 #define US_CSR_USART_RXRDY_0        (US_CSR_USART_RXRDY_0_Val      << US_CSR_USART_RXRDY_Pos)
 #define US_CSR_USART_RXRDY_1        (US_CSR_USART_RXRDY_1_Val      << US_CSR_USART_RXRDY_Pos)
 #define US_CSR_USART_TXRDY_Pos      1            /**< \brief (US_CSR_USART) Transmitter Ready */
-#define US_CSR_USART_TXRDY          (_U(0x1) << US_CSR_USART_TXRDY_Pos)
-#define   US_CSR_USART_TXRDY_0_Val        _U(0x0)   /**< \brief (US_CSR_USART) A character is in the THR waiting to be transferred to the Transmit Shift Register, or an STTBRK command has been requested, or the transmitter is disabled. As soon as the transmitter is enabled, TXRDY becomes 1 */
-#define   US_CSR_USART_TXRDY_1_Val        _U(0x1)   /**< \brief (US_CSR_USART) There is no character in the THR */
+#define US_CSR_USART_TXRDY          (_U_(0x1) << US_CSR_USART_TXRDY_Pos)
+#define   US_CSR_USART_TXRDY_0_Val        _U_(0x0)   /**< \brief (US_CSR_USART) A character is in the THR waiting to be transferred to the Transmit Shift Register, or an STTBRK command has been requested, or the transmitter is disabled. As soon as the transmitter is enabled, TXRDY becomes 1 */
+#define   US_CSR_USART_TXRDY_1_Val        _U_(0x1)   /**< \brief (US_CSR_USART) There is no character in the THR */
 #define US_CSR_USART_TXRDY_0        (US_CSR_USART_TXRDY_0_Val      << US_CSR_USART_TXRDY_Pos)
 #define US_CSR_USART_TXRDY_1        (US_CSR_USART_TXRDY_1_Val      << US_CSR_USART_TXRDY_Pos)
 #define US_CSR_USART_RXBRK_Pos      2            /**< \brief (US_CSR_USART) Break Received/End of Break */
-#define US_CSR_USART_RXBRK          (_U(0x1) << US_CSR_USART_RXBRK_Pos)
-#define   US_CSR_USART_RXBRK_0_Val        _U(0x0)   /**< \brief (US_CSR_USART) No Break received or End of Break detected since the last RSTSTA */
-#define   US_CSR_USART_RXBRK_1_Val        _U(0x1)   /**< \brief (US_CSR_USART) Break Received or End of Break detected since the last RSTSTA */
+#define US_CSR_USART_RXBRK          (_U_(0x1) << US_CSR_USART_RXBRK_Pos)
+#define   US_CSR_USART_RXBRK_0_Val        _U_(0x0)   /**< \brief (US_CSR_USART) No Break received or End of Break detected since the last RSTSTA */
+#define   US_CSR_USART_RXBRK_1_Val        _U_(0x1)   /**< \brief (US_CSR_USART) Break Received or End of Break detected since the last RSTSTA */
 #define US_CSR_USART_RXBRK_0        (US_CSR_USART_RXBRK_0_Val      << US_CSR_USART_RXBRK_Pos)
 #define US_CSR_USART_RXBRK_1        (US_CSR_USART_RXBRK_1_Val      << US_CSR_USART_RXBRK_Pos)
 #define US_CSR_USART_OVRE_Pos       5            /**< \brief (US_CSR_USART) Overrun Error */
-#define US_CSR_USART_OVRE           (_U(0x1) << US_CSR_USART_OVRE_Pos)
-#define   US_CSR_USART_OVRE_0_Val         _U(0x0)   /**< \brief (US_CSR_USART) No overrun error has occurred since since the last RSTSTA */
-#define   US_CSR_USART_OVRE_1_Val         _U(0x1)   /**< \brief (US_CSR_USART) At least one overrun error has occurred since the last RSTSTA */
+#define US_CSR_USART_OVRE           (_U_(0x1) << US_CSR_USART_OVRE_Pos)
+#define   US_CSR_USART_OVRE_0_Val         _U_(0x0)   /**< \brief (US_CSR_USART) No overrun error has occurred since since the last RSTSTA */
+#define   US_CSR_USART_OVRE_1_Val         _U_(0x1)   /**< \brief (US_CSR_USART) At least one overrun error has occurred since the last RSTSTA */
 #define US_CSR_USART_OVRE_0         (US_CSR_USART_OVRE_0_Val       << US_CSR_USART_OVRE_Pos)
 #define US_CSR_USART_OVRE_1         (US_CSR_USART_OVRE_1_Val       << US_CSR_USART_OVRE_Pos)
 #define US_CSR_USART_FRAME_Pos      6            /**< \brief (US_CSR_USART) Framing Error */
-#define US_CSR_USART_FRAME          (_U(0x1) << US_CSR_USART_FRAME_Pos)
-#define   US_CSR_USART_FRAME_0_Val        _U(0x0)   /**< \brief (US_CSR_USART) No stop bit has been detected low since the last RSTSTA */
-#define   US_CSR_USART_FRAME_1_Val        _U(0x1)   /**< \brief (US_CSR_USART) At least one stop bit has been detected low since the last RSTSTA */
+#define US_CSR_USART_FRAME          (_U_(0x1) << US_CSR_USART_FRAME_Pos)
+#define   US_CSR_USART_FRAME_0_Val        _U_(0x0)   /**< \brief (US_CSR_USART) No stop bit has been detected low since the last RSTSTA */
+#define   US_CSR_USART_FRAME_1_Val        _U_(0x1)   /**< \brief (US_CSR_USART) At least one stop bit has been detected low since the last RSTSTA */
 #define US_CSR_USART_FRAME_0        (US_CSR_USART_FRAME_0_Val      << US_CSR_USART_FRAME_Pos)
 #define US_CSR_USART_FRAME_1        (US_CSR_USART_FRAME_1_Val      << US_CSR_USART_FRAME_Pos)
 #define US_CSR_USART_PARE_Pos       7            /**< \brief (US_CSR_USART) Parity Error */
-#define US_CSR_USART_PARE           (_U(0x1) << US_CSR_USART_PARE_Pos)
-#define   US_CSR_USART_PARE_0_Val         _U(0x0)   /**< \brief (US_CSR_USART) No parity error has been detected since the last RSTSTA */
-#define   US_CSR_USART_PARE_1_Val         _U(0x1)   /**< \brief (US_CSR_USART) At least one parity error has been detected since the last RSTSTA */
+#define US_CSR_USART_PARE           (_U_(0x1) << US_CSR_USART_PARE_Pos)
+#define   US_CSR_USART_PARE_0_Val         _U_(0x0)   /**< \brief (US_CSR_USART) No parity error has been detected since the last RSTSTA */
+#define   US_CSR_USART_PARE_1_Val         _U_(0x1)   /**< \brief (US_CSR_USART) At least one parity error has been detected since the last RSTSTA */
 #define US_CSR_USART_PARE_0         (US_CSR_USART_PARE_0_Val       << US_CSR_USART_PARE_Pos)
 #define US_CSR_USART_PARE_1         (US_CSR_USART_PARE_1_Val       << US_CSR_USART_PARE_Pos)
 #define US_CSR_USART_TIMEOUT_Pos    8            /**< \brief (US_CSR_USART) Receiver Time-out */
-#define US_CSR_USART_TIMEOUT        (_U(0x1) << US_CSR_USART_TIMEOUT_Pos)
-#define   US_CSR_USART_TIMEOUT_0_Val      _U(0x0)   /**< \brief (US_CSR_USART) There has not been a time-out since the last Start Time-out command or the Time-out Register is 0 */
-#define   US_CSR_USART_TIMEOUT_1_Val      _U(0x1)   /**< \brief (US_CSR_USART) There has been a time-out since the last Start Time-out command */
+#define US_CSR_USART_TIMEOUT        (_U_(0x1) << US_CSR_USART_TIMEOUT_Pos)
+#define   US_CSR_USART_TIMEOUT_0_Val      _U_(0x0)   /**< \brief (US_CSR_USART) There has not been a time-out since the last Start Time-out command or the Time-out Register is 0 */
+#define   US_CSR_USART_TIMEOUT_1_Val      _U_(0x1)   /**< \brief (US_CSR_USART) There has been a time-out since the last Start Time-out command */
 #define US_CSR_USART_TIMEOUT_0      (US_CSR_USART_TIMEOUT_0_Val    << US_CSR_USART_TIMEOUT_Pos)
 #define US_CSR_USART_TIMEOUT_1      (US_CSR_USART_TIMEOUT_1_Val    << US_CSR_USART_TIMEOUT_Pos)
 #define US_CSR_USART_TXEMPTY_Pos    9            /**< \brief (US_CSR_USART) Transmitter Empty */
-#define US_CSR_USART_TXEMPTY        (_U(0x1) << US_CSR_USART_TXEMPTY_Pos)
-#define   US_CSR_USART_TXEMPTY_0_Val      _U(0x0)   /**< \brief (US_CSR_USART) There are characters in either THR or the Transmit Shift Register, or the transmitter is disabled */
-#define   US_CSR_USART_TXEMPTY_1_Val      _U(0x1)   /**< \brief (US_CSR_USART) There is at least one character in either THR or the Transmit Shift Register */
+#define US_CSR_USART_TXEMPTY        (_U_(0x1) << US_CSR_USART_TXEMPTY_Pos)
+#define   US_CSR_USART_TXEMPTY_0_Val      _U_(0x0)   /**< \brief (US_CSR_USART) There are characters in either THR or the Transmit Shift Register, or the transmitter is disabled */
+#define   US_CSR_USART_TXEMPTY_1_Val      _U_(0x1)   /**< \brief (US_CSR_USART) There is at least one character in either THR or the Transmit Shift Register */
 #define US_CSR_USART_TXEMPTY_0      (US_CSR_USART_TXEMPTY_0_Val    << US_CSR_USART_TXEMPTY_Pos)
 #define US_CSR_USART_TXEMPTY_1      (US_CSR_USART_TXEMPTY_1_Val    << US_CSR_USART_TXEMPTY_Pos)
 #define US_CSR_USART_ITER_Pos       10           /**< \brief (US_CSR_USART) Max number of Repetitions Reached */
-#define US_CSR_USART_ITER           (_U(0x1) << US_CSR_USART_ITER_Pos)
-#define   US_CSR_USART_ITER_0_Val         _U(0x0)   /**< \brief (US_CSR_USART) Maximum number of repetitions has not been reached since the last RSIT */
-#define   US_CSR_USART_ITER_1_Val         _U(0x1)   /**< \brief (US_CSR_USART) Maximum number of repetitions has been reached since the last RSIT */
+#define US_CSR_USART_ITER           (_U_(0x1) << US_CSR_USART_ITER_Pos)
+#define   US_CSR_USART_ITER_0_Val         _U_(0x0)   /**< \brief (US_CSR_USART) Maximum number of repetitions has not been reached since the last RSIT */
+#define   US_CSR_USART_ITER_1_Val         _U_(0x1)   /**< \brief (US_CSR_USART) Maximum number of repetitions has been reached since the last RSIT */
 #define US_CSR_USART_ITER_0         (US_CSR_USART_ITER_0_Val       << US_CSR_USART_ITER_Pos)
 #define US_CSR_USART_ITER_1         (US_CSR_USART_ITER_1_Val       << US_CSR_USART_ITER_Pos)
 #define US_CSR_USART_TXBUFE_Pos     11           /**< \brief (US_CSR_USART) Transmission Buffer Empty */
-#define US_CSR_USART_TXBUFE         (_U(0x1) << US_CSR_USART_TXBUFE_Pos)
-#define   US_CSR_USART_TXBUFE_0_Val       _U(0x0)   /**< \brief (US_CSR_USART) The signal Buffer Empty from the Transmit PDC channel is inactive */
-#define   US_CSR_USART_TXBUFE_1_Val       _U(0x1)   /**< \brief (US_CSR_USART) The signal Buffer Empty from the Transmit PDC channel is active */
+#define US_CSR_USART_TXBUFE         (_U_(0x1) << US_CSR_USART_TXBUFE_Pos)
+#define   US_CSR_USART_TXBUFE_0_Val       _U_(0x0)   /**< \brief (US_CSR_USART) The signal Buffer Empty from the Transmit PDC channel is inactive */
+#define   US_CSR_USART_TXBUFE_1_Val       _U_(0x1)   /**< \brief (US_CSR_USART) The signal Buffer Empty from the Transmit PDC channel is active */
 #define US_CSR_USART_TXBUFE_0       (US_CSR_USART_TXBUFE_0_Val     << US_CSR_USART_TXBUFE_Pos)
 #define US_CSR_USART_TXBUFE_1       (US_CSR_USART_TXBUFE_1_Val     << US_CSR_USART_TXBUFE_Pos)
 #define US_CSR_USART_RXBUFF_Pos     12           /**< \brief (US_CSR_USART) Reception Buffer Full */
-#define US_CSR_USART_RXBUFF         (_U(0x1) << US_CSR_USART_RXBUFF_Pos)
-#define   US_CSR_USART_RXBUFF_0_Val       _U(0x0)   /**< \brief (US_CSR_USART) The signal Buffer Full from the Receive PDC channel is inactive */
-#define   US_CSR_USART_RXBUFF_1_Val       _U(0x1)   /**< \brief (US_CSR_USART) The signal Buffer Full from the Receive PDC channel is active */
+#define US_CSR_USART_RXBUFF         (_U_(0x1) << US_CSR_USART_RXBUFF_Pos)
+#define   US_CSR_USART_RXBUFF_0_Val       _U_(0x0)   /**< \brief (US_CSR_USART) The signal Buffer Full from the Receive PDC channel is inactive */
+#define   US_CSR_USART_RXBUFF_1_Val       _U_(0x1)   /**< \brief (US_CSR_USART) The signal Buffer Full from the Receive PDC channel is active */
 #define US_CSR_USART_RXBUFF_0       (US_CSR_USART_RXBUFF_0_Val     << US_CSR_USART_RXBUFF_Pos)
 #define US_CSR_USART_RXBUFF_1       (US_CSR_USART_RXBUFF_1_Val     << US_CSR_USART_RXBUFF_Pos)
 #define US_CSR_USART_NACK_Pos       13           /**< \brief (US_CSR_USART) Non Acknowledge */
-#define US_CSR_USART_NACK           (_U(0x1) << US_CSR_USART_NACK_Pos)
-#define   US_CSR_USART_NACK_0_Val         _U(0x0)   /**< \brief (US_CSR_USART) No Non Acknowledge has not been detected since the last RSTNACK */
-#define   US_CSR_USART_NACK_1_Val         _U(0x1)   /**< \brief (US_CSR_USART) At least one Non Acknowledge has been detected since the last RSTNACK */
+#define US_CSR_USART_NACK           (_U_(0x1) << US_CSR_USART_NACK_Pos)
+#define   US_CSR_USART_NACK_0_Val         _U_(0x0)   /**< \brief (US_CSR_USART) No Non Acknowledge has not been detected since the last RSTNACK */
+#define   US_CSR_USART_NACK_1_Val         _U_(0x1)   /**< \brief (US_CSR_USART) At least one Non Acknowledge has been detected since the last RSTNACK */
 #define US_CSR_USART_NACK_0         (US_CSR_USART_NACK_0_Val       << US_CSR_USART_NACK_Pos)
 #define US_CSR_USART_NACK_1         (US_CSR_USART_NACK_1_Val       << US_CSR_USART_NACK_Pos)
 #define US_CSR_USART_RIIC_Pos       16           /**< \brief (US_CSR_USART) Ring Indicator Input Change Flag */
-#define US_CSR_USART_RIIC           (_U(0x1) << US_CSR_USART_RIIC_Pos)
-#define   US_CSR_USART_RIIC_0_Val         _U(0x0)   /**< \brief (US_CSR_USART) No input change has been detected on the RI pin since the last read of CSR */
-#define   US_CSR_USART_RIIC_1_Val         _U(0x1)   /**< \brief (US_CSR_USART) At least one input change has been detected on the RI pin since the last read of CSR */
+#define US_CSR_USART_RIIC           (_U_(0x1) << US_CSR_USART_RIIC_Pos)
+#define   US_CSR_USART_RIIC_0_Val         _U_(0x0)   /**< \brief (US_CSR_USART) No input change has been detected on the RI pin since the last read of CSR */
+#define   US_CSR_USART_RIIC_1_Val         _U_(0x1)   /**< \brief (US_CSR_USART) At least one input change has been detected on the RI pin since the last read of CSR */
 #define US_CSR_USART_RIIC_0         (US_CSR_USART_RIIC_0_Val       << US_CSR_USART_RIIC_Pos)
 #define US_CSR_USART_RIIC_1         (US_CSR_USART_RIIC_1_Val       << US_CSR_USART_RIIC_Pos)
 #define US_CSR_USART_DSRIC_Pos      17           /**< \brief (US_CSR_USART) Data Set Ready Input Change Flag */
-#define US_CSR_USART_DSRIC          (_U(0x1) << US_CSR_USART_DSRIC_Pos)
-#define   US_CSR_USART_DSRIC_0_Val        _U(0x0)   /**< \brief (US_CSR_USART) No input change has been detected on the DSR pin since the last read of CSR */
-#define   US_CSR_USART_DSRIC_1_Val        _U(0x1)   /**< \brief (US_CSR_USART) At least one input change has been detected on the DSR pin since the last read of CSR */
+#define US_CSR_USART_DSRIC          (_U_(0x1) << US_CSR_USART_DSRIC_Pos)
+#define   US_CSR_USART_DSRIC_0_Val        _U_(0x0)   /**< \brief (US_CSR_USART) No input change has been detected on the DSR pin since the last read of CSR */
+#define   US_CSR_USART_DSRIC_1_Val        _U_(0x1)   /**< \brief (US_CSR_USART) At least one input change has been detected on the DSR pin since the last read of CSR */
 #define US_CSR_USART_DSRIC_0        (US_CSR_USART_DSRIC_0_Val      << US_CSR_USART_DSRIC_Pos)
 #define US_CSR_USART_DSRIC_1        (US_CSR_USART_DSRIC_1_Val      << US_CSR_USART_DSRIC_Pos)
 #define US_CSR_USART_DCDIC_Pos      18           /**< \brief (US_CSR_USART) Data Carrier Detect Input Change Flag */
-#define US_CSR_USART_DCDIC          (_U(0x1) << US_CSR_USART_DCDIC_Pos)
-#define   US_CSR_USART_DCDIC_0_Val        _U(0x0)   /**< \brief (US_CSR_USART) No input change has been detected on the DCD pin since the last read of CSR */
-#define   US_CSR_USART_DCDIC_1_Val        _U(0x1)   /**< \brief (US_CSR_USART) At least one input change has been detected on the DCD pin since the last read of CSR */
+#define US_CSR_USART_DCDIC          (_U_(0x1) << US_CSR_USART_DCDIC_Pos)
+#define   US_CSR_USART_DCDIC_0_Val        _U_(0x0)   /**< \brief (US_CSR_USART) No input change has been detected on the DCD pin since the last read of CSR */
+#define   US_CSR_USART_DCDIC_1_Val        _U_(0x1)   /**< \brief (US_CSR_USART) At least one input change has been detected on the DCD pin since the last read of CSR */
 #define US_CSR_USART_DCDIC_0        (US_CSR_USART_DCDIC_0_Val      << US_CSR_USART_DCDIC_Pos)
 #define US_CSR_USART_DCDIC_1        (US_CSR_USART_DCDIC_1_Val      << US_CSR_USART_DCDIC_Pos)
 #define US_CSR_USART_CTSIC_Pos      19           /**< \brief (US_CSR_USART) Clear to Send Input Change Flag */
-#define US_CSR_USART_CTSIC          (_U(0x1) << US_CSR_USART_CTSIC_Pos)
-#define   US_CSR_USART_CTSIC_0_Val        _U(0x0)   /**< \brief (US_CSR_USART) No input change has been detected on the CTS pin since the last read of CSR */
-#define   US_CSR_USART_CTSIC_1_Val        _U(0x1)   /**< \brief (US_CSR_USART) At least one input change has been detected on the CTS pin since the last read of CSR */
+#define US_CSR_USART_CTSIC          (_U_(0x1) << US_CSR_USART_CTSIC_Pos)
+#define   US_CSR_USART_CTSIC_0_Val        _U_(0x0)   /**< \brief (US_CSR_USART) No input change has been detected on the CTS pin since the last read of CSR */
+#define   US_CSR_USART_CTSIC_1_Val        _U_(0x1)   /**< \brief (US_CSR_USART) At least one input change has been detected on the CTS pin since the last read of CSR */
 #define US_CSR_USART_CTSIC_0        (US_CSR_USART_CTSIC_0_Val      << US_CSR_USART_CTSIC_Pos)
 #define US_CSR_USART_CTSIC_1        (US_CSR_USART_CTSIC_1_Val      << US_CSR_USART_CTSIC_Pos)
 #define US_CSR_USART_RI_Pos         20           /**< \brief (US_CSR_USART) Image of RI Input */
-#define US_CSR_USART_RI             (_U(0x1) << US_CSR_USART_RI_Pos)
-#define   US_CSR_USART_RI_0_Val           _U(0x0)   /**< \brief (US_CSR_USART) RI is at 0 */
-#define   US_CSR_USART_RI_1_Val           _U(0x1)   /**< \brief (US_CSR_USART) RI is at 1 */
+#define US_CSR_USART_RI             (_U_(0x1) << US_CSR_USART_RI_Pos)
+#define   US_CSR_USART_RI_0_Val           _U_(0x0)   /**< \brief (US_CSR_USART) RI is at 0 */
+#define   US_CSR_USART_RI_1_Val           _U_(0x1)   /**< \brief (US_CSR_USART) RI is at 1 */
 #define US_CSR_USART_RI_0           (US_CSR_USART_RI_0_Val         << US_CSR_USART_RI_Pos)
 #define US_CSR_USART_RI_1           (US_CSR_USART_RI_1_Val         << US_CSR_USART_RI_Pos)
 #define US_CSR_USART_DSR_Pos        21           /**< \brief (US_CSR_USART) Image of DSR Input */
-#define US_CSR_USART_DSR            (_U(0x1) << US_CSR_USART_DSR_Pos)
-#define   US_CSR_USART_DSR_0_Val          _U(0x0)   /**< \brief (US_CSR_USART) DSR is at 0 */
-#define   US_CSR_USART_DSR_1_Val          _U(0x1)   /**< \brief (US_CSR_USART) DSR is at 1 */
+#define US_CSR_USART_DSR            (_U_(0x1) << US_CSR_USART_DSR_Pos)
+#define   US_CSR_USART_DSR_0_Val          _U_(0x0)   /**< \brief (US_CSR_USART) DSR is at 0 */
+#define   US_CSR_USART_DSR_1_Val          _U_(0x1)   /**< \brief (US_CSR_USART) DSR is at 1 */
 #define US_CSR_USART_DSR_0          (US_CSR_USART_DSR_0_Val        << US_CSR_USART_DSR_Pos)
 #define US_CSR_USART_DSR_1          (US_CSR_USART_DSR_1_Val        << US_CSR_USART_DSR_Pos)
 #define US_CSR_USART_DCD_Pos        22           /**< \brief (US_CSR_USART) Image of DCD Input */
-#define US_CSR_USART_DCD            (_U(0x1) << US_CSR_USART_DCD_Pos)
-#define   US_CSR_USART_DCD_0_Val          _U(0x0)   /**< \brief (US_CSR_USART) DCD is at 0 */
-#define   US_CSR_USART_DCD_1_Val          _U(0x1)   /**< \brief (US_CSR_USART) DCD is at 1 */
+#define US_CSR_USART_DCD            (_U_(0x1) << US_CSR_USART_DCD_Pos)
+#define   US_CSR_USART_DCD_0_Val          _U_(0x0)   /**< \brief (US_CSR_USART) DCD is at 0 */
+#define   US_CSR_USART_DCD_1_Val          _U_(0x1)   /**< \brief (US_CSR_USART) DCD is at 1 */
 #define US_CSR_USART_DCD_0          (US_CSR_USART_DCD_0_Val        << US_CSR_USART_DCD_Pos)
 #define US_CSR_USART_DCD_1          (US_CSR_USART_DCD_1_Val        << US_CSR_USART_DCD_Pos)
 #define US_CSR_USART_CTS_Pos        23           /**< \brief (US_CSR_USART) Image of CTS Input */
-#define US_CSR_USART_CTS            (_U(0x1) << US_CSR_USART_CTS_Pos)
-#define   US_CSR_USART_CTS_0_Val          _U(0x0)   /**< \brief (US_CSR_USART) CTS is at 0 */
-#define   US_CSR_USART_CTS_1_Val          _U(0x1)   /**< \brief (US_CSR_USART) CTS is at 1 */
+#define US_CSR_USART_CTS            (_U_(0x1) << US_CSR_USART_CTS_Pos)
+#define   US_CSR_USART_CTS_0_Val          _U_(0x0)   /**< \brief (US_CSR_USART) CTS is at 0 */
+#define   US_CSR_USART_CTS_1_Val          _U_(0x1)   /**< \brief (US_CSR_USART) CTS is at 1 */
 #define US_CSR_USART_CTS_0          (US_CSR_USART_CTS_0_Val        << US_CSR_USART_CTS_Pos)
 #define US_CSR_USART_CTS_1          (US_CSR_USART_CTS_1_Val        << US_CSR_USART_CTS_Pos)
 #define US_CSR_USART_MANERR_Pos     24           /**< \brief (US_CSR_USART) Manchester Error */
-#define US_CSR_USART_MANERR         (_U(0x1) << US_CSR_USART_MANERR_Pos)
-#define   US_CSR_USART_MANERR_0_Val       _U(0x0)   /**< \brief (US_CSR_USART) No Manchester error has been detected since the last RSTSTA */
-#define   US_CSR_USART_MANERR_1_Val       _U(0x1)   /**< \brief (US_CSR_USART) At least one Manchester error has been detected since the last RSTSTA */
+#define US_CSR_USART_MANERR         (_U_(0x1) << US_CSR_USART_MANERR_Pos)
+#define   US_CSR_USART_MANERR_0_Val       _U_(0x0)   /**< \brief (US_CSR_USART) No Manchester error has been detected since the last RSTSTA */
+#define   US_CSR_USART_MANERR_1_Val       _U_(0x1)   /**< \brief (US_CSR_USART) At least one Manchester error has been detected since the last RSTSTA */
 #define US_CSR_USART_MANERR_0       (US_CSR_USART_MANERR_0_Val     << US_CSR_USART_MANERR_Pos)
 #define US_CSR_USART_MANERR_1       (US_CSR_USART_MANERR_1_Val     << US_CSR_USART_MANERR_Pos)
-#define US_CSR_USART_MASK           _U(0x01FF3FE7) /**< \brief (US_CSR_USART) MASK Register */
+#define US_CSR_USART_MASK           _U_(0x01FF3FE7) /**< \brief (US_CSR_USART) MASK Register */
 
 // Any mode
 #define US_CSR_RXRDY_Pos            0            /**< \brief (US_CSR) Receiver Ready */
-#define US_CSR_RXRDY                (_U(0x1) << US_CSR_RXRDY_Pos)
-#define   US_CSR_RXRDY_0_Val              _U(0x0)   /**< \brief (US_CSR) No complete character has been received since the last read of RHR or the receiver is disabled. If characters werebeing received when the receiver was disabled, RXRDY changes to 1 when the receiver is enabled */
-#define   US_CSR_RXRDY_1_Val              _U(0x1)   /**< \brief (US_CSR) At least one complete character has been received and RHR has not yet been read */
+#define US_CSR_RXRDY                (_U_(0x1) << US_CSR_RXRDY_Pos)
+#define   US_CSR_RXRDY_0_Val              _U_(0x0)   /**< \brief (US_CSR) No complete character has been received since the last read of RHR or the receiver is disabled. If characters werebeing received when the receiver was disabled, RXRDY changes to 1 when the receiver is enabled */
+#define   US_CSR_RXRDY_1_Val              _U_(0x1)   /**< \brief (US_CSR) At least one complete character has been received and RHR has not yet been read */
 #define US_CSR_RXRDY_0              (US_CSR_RXRDY_0_Val            << US_CSR_RXRDY_Pos)
 #define US_CSR_RXRDY_1              (US_CSR_RXRDY_1_Val            << US_CSR_RXRDY_Pos)
 #define US_CSR_TXRDY_Pos            1            /**< \brief (US_CSR) Transmitter Ready */
-#define US_CSR_TXRDY                (_U(0x1) << US_CSR_TXRDY_Pos)
-#define   US_CSR_TXRDY_0_Val              _U(0x0)   /**< \brief (US_CSR) A character is in the THR waiting to be transferred to the Transmit Shift Register, or an STTBRK command has been requested, or the transmitter is disabled. As soon as the transmitter is enabled, TXRDY becomes 1 */
-#define   US_CSR_TXRDY_1_Val              _U(0x1)   /**< \brief (US_CSR) There is no character in the THR */
+#define US_CSR_TXRDY                (_U_(0x1) << US_CSR_TXRDY_Pos)
+#define   US_CSR_TXRDY_0_Val              _U_(0x0)   /**< \brief (US_CSR) A character is in the THR waiting to be transferred to the Transmit Shift Register, or an STTBRK command has been requested, or the transmitter is disabled. As soon as the transmitter is enabled, TXRDY becomes 1 */
+#define   US_CSR_TXRDY_1_Val              _U_(0x1)   /**< \brief (US_CSR) There is no character in the THR */
 #define US_CSR_TXRDY_0              (US_CSR_TXRDY_0_Val            << US_CSR_TXRDY_Pos)
 #define US_CSR_TXRDY_1              (US_CSR_TXRDY_1_Val            << US_CSR_TXRDY_Pos)
 #define US_CSR_RXBRK_Pos            2            /**< \brief (US_CSR) Break Received/End of Break */
-#define US_CSR_RXBRK                (_U(0x1) << US_CSR_RXBRK_Pos)
-#define   US_CSR_RXBRK_0_Val              _U(0x0)   /**< \brief (US_CSR) No Break received or End of Break detected since the last RSTSTA */
-#define   US_CSR_RXBRK_1_Val              _U(0x1)   /**< \brief (US_CSR) Break Received or End of Break detected since the last RSTSTA */
+#define US_CSR_RXBRK                (_U_(0x1) << US_CSR_RXBRK_Pos)
+#define   US_CSR_RXBRK_0_Val              _U_(0x0)   /**< \brief (US_CSR) No Break received or End of Break detected since the last RSTSTA */
+#define   US_CSR_RXBRK_1_Val              _U_(0x1)   /**< \brief (US_CSR) Break Received or End of Break detected since the last RSTSTA */
 #define US_CSR_RXBRK_0              (US_CSR_RXBRK_0_Val            << US_CSR_RXBRK_Pos)
 #define US_CSR_RXBRK_1              (US_CSR_RXBRK_1_Val            << US_CSR_RXBRK_Pos)
 #define US_CSR_OVRE_Pos             5            /**< \brief (US_CSR) Overrun Error */
-#define US_CSR_OVRE                 (_U(0x1) << US_CSR_OVRE_Pos)
-#define   US_CSR_OVRE_0_Val               _U(0x0)   /**< \brief (US_CSR) No overrun error has occurred since since the last RSTSTA */
-#define   US_CSR_OVRE_1_Val               _U(0x1)   /**< \brief (US_CSR) At least one overrun error has occurred since the last RSTSTA */
+#define US_CSR_OVRE                 (_U_(0x1) << US_CSR_OVRE_Pos)
+#define   US_CSR_OVRE_0_Val               _U_(0x0)   /**< \brief (US_CSR) No overrun error has occurred since since the last RSTSTA */
+#define   US_CSR_OVRE_1_Val               _U_(0x1)   /**< \brief (US_CSR) At least one overrun error has occurred since the last RSTSTA */
 #define US_CSR_OVRE_0               (US_CSR_OVRE_0_Val             << US_CSR_OVRE_Pos)
 #define US_CSR_OVRE_1               (US_CSR_OVRE_1_Val             << US_CSR_OVRE_Pos)
 #define US_CSR_FRAME_Pos            6            /**< \brief (US_CSR) Framing Error */
-#define US_CSR_FRAME                (_U(0x1) << US_CSR_FRAME_Pos)
-#define   US_CSR_FRAME_0_Val              _U(0x0)   /**< \brief (US_CSR) No stop bit has been detected low since the last RSTSTA */
-#define   US_CSR_FRAME_1_Val              _U(0x1)   /**< \brief (US_CSR) At least one stop bit has been detected low since the last RSTSTA */
+#define US_CSR_FRAME                (_U_(0x1) << US_CSR_FRAME_Pos)
+#define   US_CSR_FRAME_0_Val              _U_(0x0)   /**< \brief (US_CSR) No stop bit has been detected low since the last RSTSTA */
+#define   US_CSR_FRAME_1_Val              _U_(0x1)   /**< \brief (US_CSR) At least one stop bit has been detected low since the last RSTSTA */
 #define US_CSR_FRAME_0              (US_CSR_FRAME_0_Val            << US_CSR_FRAME_Pos)
 #define US_CSR_FRAME_1              (US_CSR_FRAME_1_Val            << US_CSR_FRAME_Pos)
 #define US_CSR_PARE_Pos             7            /**< \brief (US_CSR) Parity Error */
-#define US_CSR_PARE                 (_U(0x1) << US_CSR_PARE_Pos)
-#define   US_CSR_PARE_0_Val               _U(0x0)   /**< \brief (US_CSR) No parity error has been detected since the last RSTSTA */
-#define   US_CSR_PARE_1_Val               _U(0x1)   /**< \brief (US_CSR) At least one parity error has been detected since the last RSTSTA */
+#define US_CSR_PARE                 (_U_(0x1) << US_CSR_PARE_Pos)
+#define   US_CSR_PARE_0_Val               _U_(0x0)   /**< \brief (US_CSR) No parity error has been detected since the last RSTSTA */
+#define   US_CSR_PARE_1_Val               _U_(0x1)   /**< \brief (US_CSR) At least one parity error has been detected since the last RSTSTA */
 #define US_CSR_PARE_0               (US_CSR_PARE_0_Val             << US_CSR_PARE_Pos)
 #define US_CSR_PARE_1               (US_CSR_PARE_1_Val             << US_CSR_PARE_Pos)
 #define US_CSR_TIMEOUT_Pos          8            /**< \brief (US_CSR) Receiver Time-out */
-#define US_CSR_TIMEOUT              (_U(0x1) << US_CSR_TIMEOUT_Pos)
-#define   US_CSR_TIMEOUT_0_Val            _U(0x0)   /**< \brief (US_CSR) There has not been a time-out since the last Start Time-out command or the Time-out Register is 0 */
-#define   US_CSR_TIMEOUT_1_Val            _U(0x1)   /**< \brief (US_CSR) There has been a time-out since the last Start Time-out command */
+#define US_CSR_TIMEOUT              (_U_(0x1) << US_CSR_TIMEOUT_Pos)
+#define   US_CSR_TIMEOUT_0_Val            _U_(0x0)   /**< \brief (US_CSR) There has not been a time-out since the last Start Time-out command or the Time-out Register is 0 */
+#define   US_CSR_TIMEOUT_1_Val            _U_(0x1)   /**< \brief (US_CSR) There has been a time-out since the last Start Time-out command */
 #define US_CSR_TIMEOUT_0            (US_CSR_TIMEOUT_0_Val          << US_CSR_TIMEOUT_Pos)
 #define US_CSR_TIMEOUT_1            (US_CSR_TIMEOUT_1_Val          << US_CSR_TIMEOUT_Pos)
 #define US_CSR_TXEMPTY_Pos          9            /**< \brief (US_CSR) Transmitter Empty */
-#define US_CSR_TXEMPTY              (_U(0x1) << US_CSR_TXEMPTY_Pos)
-#define   US_CSR_TXEMPTY_0_Val            _U(0x0)   /**< \brief (US_CSR) There are characters in either THR or the Transmit Shift Register, or the transmitter is disabled */
-#define   US_CSR_TXEMPTY_1_Val            _U(0x1)   /**< \brief (US_CSR) There is at least one character in either THR or the Transmit Shift Register */
+#define US_CSR_TXEMPTY              (_U_(0x1) << US_CSR_TXEMPTY_Pos)
+#define   US_CSR_TXEMPTY_0_Val            _U_(0x0)   /**< \brief (US_CSR) There are characters in either THR or the Transmit Shift Register, or the transmitter is disabled */
+#define   US_CSR_TXEMPTY_1_Val            _U_(0x1)   /**< \brief (US_CSR) There is at least one character in either THR or the Transmit Shift Register */
 #define US_CSR_TXEMPTY_0            (US_CSR_TXEMPTY_0_Val          << US_CSR_TXEMPTY_Pos)
 #define US_CSR_TXEMPTY_1            (US_CSR_TXEMPTY_1_Val          << US_CSR_TXEMPTY_Pos)
 #define US_CSR_ITER_Pos             10           /**< \brief (US_CSR) Max number of Repetitions Reached */
-#define US_CSR_ITER                 (_U(0x1) << US_CSR_ITER_Pos)
-#define   US_CSR_ITER_0_Val               _U(0x0)   /**< \brief (US_CSR) Maximum number of repetitions has not been reached since the last RSIT */
-#define   US_CSR_ITER_1_Val               _U(0x1)   /**< \brief (US_CSR) Maximum number of repetitions has been reached since the last RSIT */
+#define US_CSR_ITER                 (_U_(0x1) << US_CSR_ITER_Pos)
+#define   US_CSR_ITER_0_Val               _U_(0x0)   /**< \brief (US_CSR) Maximum number of repetitions has not been reached since the last RSIT */
+#define   US_CSR_ITER_1_Val               _U_(0x1)   /**< \brief (US_CSR) Maximum number of repetitions has been reached since the last RSIT */
 #define US_CSR_ITER_0               (US_CSR_ITER_0_Val             << US_CSR_ITER_Pos)
 #define US_CSR_ITER_1               (US_CSR_ITER_1_Val             << US_CSR_ITER_Pos)
 #define US_CSR_UNRE_Pos             10           /**< \brief (US_CSR) SPI Underrun Error */
-#define US_CSR_UNRE                 (_U(0x1) << US_CSR_UNRE_Pos)
-#define   US_CSR_UNRE_0_Val               _U(0x0)   /**< \brief (US_CSR) No SPI underrun error has occurred since the last RSTSTA */
-#define   US_CSR_UNRE_1_Val               _U(0x1)   /**< \brief (US_CSR) At least one SPI underrun error has occurred since the last RSTSTA */
+#define US_CSR_UNRE                 (_U_(0x1) << US_CSR_UNRE_Pos)
+#define   US_CSR_UNRE_0_Val               _U_(0x0)   /**< \brief (US_CSR) No SPI underrun error has occurred since the last RSTSTA */
+#define   US_CSR_UNRE_1_Val               _U_(0x1)   /**< \brief (US_CSR) At least one SPI underrun error has occurred since the last RSTSTA */
 #define US_CSR_UNRE_0               (US_CSR_UNRE_0_Val             << US_CSR_UNRE_Pos)
 #define US_CSR_UNRE_1               (US_CSR_UNRE_1_Val             << US_CSR_UNRE_Pos)
 #define US_CSR_ITER_Pos             10           /**< \brief (US_CSR) Max number of Repetitions Reached */
-#define US_CSR_ITER                 (_U(0x1) << US_CSR_ITER_Pos)
-#define   US_CSR_ITER_0_Val               _U(0x0)   /**< \brief (US_CSR) Maximum number of repetitions has not been reached since the last RSIT */
-#define   US_CSR_ITER_1_Val               _U(0x1)   /**< \brief (US_CSR) Maximum number of repetitions has been reached since the last RSIT */
+#define US_CSR_ITER                 (_U_(0x1) << US_CSR_ITER_Pos)
+#define   US_CSR_ITER_0_Val               _U_(0x0)   /**< \brief (US_CSR) Maximum number of repetitions has not been reached since the last RSIT */
+#define   US_CSR_ITER_1_Val               _U_(0x1)   /**< \brief (US_CSR) Maximum number of repetitions has been reached since the last RSIT */
 #define US_CSR_ITER_0               (US_CSR_ITER_0_Val             << US_CSR_ITER_Pos)
 #define US_CSR_ITER_1               (US_CSR_ITER_1_Val             << US_CSR_ITER_Pos)
 #define US_CSR_TXBUFE_Pos           11           /**< \brief (US_CSR) Transmission Buffer Empty */
-#define US_CSR_TXBUFE               (_U(0x1) << US_CSR_TXBUFE_Pos)
-#define   US_CSR_TXBUFE_0_Val             _U(0x0)   /**< \brief (US_CSR) The signal Buffer Empty from the Transmit PDC channel is inactive */
-#define   US_CSR_TXBUFE_1_Val             _U(0x1)   /**< \brief (US_CSR) The signal Buffer Empty from the Transmit PDC channel is active */
+#define US_CSR_TXBUFE               (_U_(0x1) << US_CSR_TXBUFE_Pos)
+#define   US_CSR_TXBUFE_0_Val             _U_(0x0)   /**< \brief (US_CSR) The signal Buffer Empty from the Transmit PDC channel is inactive */
+#define   US_CSR_TXBUFE_1_Val             _U_(0x1)   /**< \brief (US_CSR) The signal Buffer Empty from the Transmit PDC channel is active */
 #define US_CSR_TXBUFE_0             (US_CSR_TXBUFE_0_Val           << US_CSR_TXBUFE_Pos)
 #define US_CSR_TXBUFE_1             (US_CSR_TXBUFE_1_Val           << US_CSR_TXBUFE_Pos)
 #define US_CSR_RXBUFF_Pos           12           /**< \brief (US_CSR) Reception Buffer Full */
-#define US_CSR_RXBUFF               (_U(0x1) << US_CSR_RXBUFF_Pos)
-#define   US_CSR_RXBUFF_0_Val             _U(0x0)   /**< \brief (US_CSR) The signal Buffer Full from the Receive PDC channel is inactive */
-#define   US_CSR_RXBUFF_1_Val             _U(0x1)   /**< \brief (US_CSR) The signal Buffer Full from the Receive PDC channel is active */
+#define US_CSR_RXBUFF               (_U_(0x1) << US_CSR_RXBUFF_Pos)
+#define   US_CSR_RXBUFF_0_Val             _U_(0x0)   /**< \brief (US_CSR) The signal Buffer Full from the Receive PDC channel is inactive */
+#define   US_CSR_RXBUFF_1_Val             _U_(0x1)   /**< \brief (US_CSR) The signal Buffer Full from the Receive PDC channel is active */
 #define US_CSR_RXBUFF_0             (US_CSR_RXBUFF_0_Val           << US_CSR_RXBUFF_Pos)
 #define US_CSR_RXBUFF_1             (US_CSR_RXBUFF_1_Val           << US_CSR_RXBUFF_Pos)
 #define US_CSR_NACK_Pos             13           /**< \brief (US_CSR) Non Acknowledge or LIN Break Sent or LIN Break Received */
-#define US_CSR_NACK                 (_U(0x1) << US_CSR_NACK_Pos)
-#define   US_CSR_NACK_0_Val               _U(0x0)   /**< \brief (US_CSR) No Non Acknowledge has not been detected since the last RSTNACK */
-#define   US_CSR_NACK_1_Val               _U(0x1)   /**< \brief (US_CSR) At least one Non Acknowledge has been detected since the last RSTNACK */
+#define US_CSR_NACK                 (_U_(0x1) << US_CSR_NACK_Pos)
+#define   US_CSR_NACK_0_Val               _U_(0x0)   /**< \brief (US_CSR) No Non Acknowledge has not been detected since the last RSTNACK */
+#define   US_CSR_NACK_1_Val               _U_(0x1)   /**< \brief (US_CSR) At least one Non Acknowledge has been detected since the last RSTNACK */
 #define US_CSR_NACK_0               (US_CSR_NACK_0_Val             << US_CSR_NACK_Pos)
 #define US_CSR_NACK_1               (US_CSR_NACK_1_Val             << US_CSR_NACK_Pos)
 #define US_CSR_LINID_Pos            14           /**< \brief (US_CSR) LIN Identifier Sent or LIN Identifier Received */
-#define US_CSR_LINID                (_U(0x1) << US_CSR_LINID_Pos)
+#define US_CSR_LINID                (_U_(0x1) << US_CSR_LINID_Pos)
 #define US_CSR_LINTC_Pos            15           /**< \brief (US_CSR) LIN Transfer Conpleted */
-#define US_CSR_LINTC                (_U(0x1) << US_CSR_LINTC_Pos)
+#define US_CSR_LINTC                (_U_(0x1) << US_CSR_LINTC_Pos)
 #define US_CSR_RIIC_Pos             16           /**< \brief (US_CSR) Ring Indicator Input Change Flag */
-#define US_CSR_RIIC                 (_U(0x1) << US_CSR_RIIC_Pos)
-#define   US_CSR_RIIC_0_Val               _U(0x0)   /**< \brief (US_CSR) No input change has been detected on the RI pin since the last read of CSR */
-#define   US_CSR_RIIC_1_Val               _U(0x1)   /**< \brief (US_CSR) At least one input change has been detected on the RI pin since the last read of CSR */
+#define US_CSR_RIIC                 (_U_(0x1) << US_CSR_RIIC_Pos)
+#define   US_CSR_RIIC_0_Val               _U_(0x0)   /**< \brief (US_CSR) No input change has been detected on the RI pin since the last read of CSR */
+#define   US_CSR_RIIC_1_Val               _U_(0x1)   /**< \brief (US_CSR) At least one input change has been detected on the RI pin since the last read of CSR */
 #define US_CSR_RIIC_0               (US_CSR_RIIC_0_Val             << US_CSR_RIIC_Pos)
 #define US_CSR_RIIC_1               (US_CSR_RIIC_1_Val             << US_CSR_RIIC_Pos)
 #define US_CSR_DSRIC_Pos            17           /**< \brief (US_CSR) Data Set Ready Input Change Flag */
-#define US_CSR_DSRIC                (_U(0x1) << US_CSR_DSRIC_Pos)
-#define   US_CSR_DSRIC_0_Val              _U(0x0)   /**< \brief (US_CSR) No input change has been detected on the DSR pin since the last read of CSR */
-#define   US_CSR_DSRIC_1_Val              _U(0x1)   /**< \brief (US_CSR) At least one input change has been detected on the DSR pin since the last read of CSR */
+#define US_CSR_DSRIC                (_U_(0x1) << US_CSR_DSRIC_Pos)
+#define   US_CSR_DSRIC_0_Val              _U_(0x0)   /**< \brief (US_CSR) No input change has been detected on the DSR pin since the last read of CSR */
+#define   US_CSR_DSRIC_1_Val              _U_(0x1)   /**< \brief (US_CSR) At least one input change has been detected on the DSR pin since the last read of CSR */
 #define US_CSR_DSRIC_0              (US_CSR_DSRIC_0_Val            << US_CSR_DSRIC_Pos)
 #define US_CSR_DSRIC_1              (US_CSR_DSRIC_1_Val            << US_CSR_DSRIC_Pos)
 #define US_CSR_DCDIC_Pos            18           /**< \brief (US_CSR) Data Carrier Detect Input Change Flag */
-#define US_CSR_DCDIC                (_U(0x1) << US_CSR_DCDIC_Pos)
-#define   US_CSR_DCDIC_0_Val              _U(0x0)   /**< \brief (US_CSR) No input change has been detected on the DCD pin since the last read of CSR */
-#define   US_CSR_DCDIC_1_Val              _U(0x1)   /**< \brief (US_CSR) At least one input change has been detected on the DCD pin since the last read of CSR */
+#define US_CSR_DCDIC                (_U_(0x1) << US_CSR_DCDIC_Pos)
+#define   US_CSR_DCDIC_0_Val              _U_(0x0)   /**< \brief (US_CSR) No input change has been detected on the DCD pin since the last read of CSR */
+#define   US_CSR_DCDIC_1_Val              _U_(0x1)   /**< \brief (US_CSR) At least one input change has been detected on the DCD pin since the last read of CSR */
 #define US_CSR_DCDIC_0              (US_CSR_DCDIC_0_Val            << US_CSR_DCDIC_Pos)
 #define US_CSR_DCDIC_1              (US_CSR_DCDIC_1_Val            << US_CSR_DCDIC_Pos)
 #define US_CSR_CTSIC_Pos            19           /**< \brief (US_CSR) Clear to Send Input Change Flag */
-#define US_CSR_CTSIC                (_U(0x1) << US_CSR_CTSIC_Pos)
-#define   US_CSR_CTSIC_0_Val              _U(0x0)   /**< \brief (US_CSR) No input change has been detected on the CTS pin since the last read of CSR */
-#define   US_CSR_CTSIC_1_Val              _U(0x1)   /**< \brief (US_CSR) At least one input change has been detected on the CTS pin since the last read of CSR */
+#define US_CSR_CTSIC                (_U_(0x1) << US_CSR_CTSIC_Pos)
+#define   US_CSR_CTSIC_0_Val              _U_(0x0)   /**< \brief (US_CSR) No input change has been detected on the CTS pin since the last read of CSR */
+#define   US_CSR_CTSIC_1_Val              _U_(0x1)   /**< \brief (US_CSR) At least one input change has been detected on the CTS pin since the last read of CSR */
 #define US_CSR_CTSIC_0              (US_CSR_CTSIC_0_Val            << US_CSR_CTSIC_Pos)
 #define US_CSR_CTSIC_1              (US_CSR_CTSIC_1_Val            << US_CSR_CTSIC_Pos)
 #define US_CSR_RI_Pos               20           /**< \brief (US_CSR) Image of RI Input */
-#define US_CSR_RI                   (_U(0x1) << US_CSR_RI_Pos)
-#define   US_CSR_RI_0_Val                 _U(0x0)   /**< \brief (US_CSR) RI is at 0 */
-#define   US_CSR_RI_1_Val                 _U(0x1)   /**< \brief (US_CSR) RI is at 1 */
+#define US_CSR_RI                   (_U_(0x1) << US_CSR_RI_Pos)
+#define   US_CSR_RI_0_Val                 _U_(0x0)   /**< \brief (US_CSR) RI is at 0 */
+#define   US_CSR_RI_1_Val                 _U_(0x1)   /**< \brief (US_CSR) RI is at 1 */
 #define US_CSR_RI_0                 (US_CSR_RI_0_Val               << US_CSR_RI_Pos)
 #define US_CSR_RI_1                 (US_CSR_RI_1_Val               << US_CSR_RI_Pos)
 #define US_CSR_DSR_Pos              21           /**< \brief (US_CSR) Image of DSR Input */
-#define US_CSR_DSR                  (_U(0x1) << US_CSR_DSR_Pos)
-#define   US_CSR_DSR_0_Val                _U(0x0)   /**< \brief (US_CSR) DSR is at 0 */
-#define   US_CSR_DSR_1_Val                _U(0x1)   /**< \brief (US_CSR) DSR is at 1 */
+#define US_CSR_DSR                  (_U_(0x1) << US_CSR_DSR_Pos)
+#define   US_CSR_DSR_0_Val                _U_(0x0)   /**< \brief (US_CSR) DSR is at 0 */
+#define   US_CSR_DSR_1_Val                _U_(0x1)   /**< \brief (US_CSR) DSR is at 1 */
 #define US_CSR_DSR_0                (US_CSR_DSR_0_Val              << US_CSR_DSR_Pos)
 #define US_CSR_DSR_1                (US_CSR_DSR_1_Val              << US_CSR_DSR_Pos)
 #define US_CSR_DCD_Pos              22           /**< \brief (US_CSR) Image of DCD Input */
-#define US_CSR_DCD                  (_U(0x1) << US_CSR_DCD_Pos)
-#define   US_CSR_DCD_0_Val                _U(0x0)   /**< \brief (US_CSR) DCD is at 0 */
-#define   US_CSR_DCD_1_Val                _U(0x1)   /**< \brief (US_CSR) DCD is at 1 */
+#define US_CSR_DCD                  (_U_(0x1) << US_CSR_DCD_Pos)
+#define   US_CSR_DCD_0_Val                _U_(0x0)   /**< \brief (US_CSR) DCD is at 0 */
+#define   US_CSR_DCD_1_Val                _U_(0x1)   /**< \brief (US_CSR) DCD is at 1 */
 #define US_CSR_DCD_0                (US_CSR_DCD_0_Val              << US_CSR_DCD_Pos)
 #define US_CSR_DCD_1                (US_CSR_DCD_1_Val              << US_CSR_DCD_Pos)
 #define US_CSR_LINBLS_Pos           23           /**< \brief (US_CSR) LIN Bus Line Status */
-#define US_CSR_LINBLS               (_U(0x1) << US_CSR_LINBLS_Pos)
-#define   US_CSR_LINBLS_0_Val             _U(0x0)   /**< \brief (US_CSR) CTS is at 0 */
-#define   US_CSR_LINBLS_1_Val             _U(0x1)   /**< \brief (US_CSR) CTS is at 1 */
+#define US_CSR_LINBLS               (_U_(0x1) << US_CSR_LINBLS_Pos)
+#define   US_CSR_LINBLS_0_Val             _U_(0x0)   /**< \brief (US_CSR) CTS is at 0 */
+#define   US_CSR_LINBLS_1_Val             _U_(0x1)   /**< \brief (US_CSR) CTS is at 1 */
 #define US_CSR_LINBLS_0             (US_CSR_LINBLS_0_Val           << US_CSR_LINBLS_Pos)
 #define US_CSR_LINBLS_1             (US_CSR_LINBLS_1_Val           << US_CSR_LINBLS_Pos)
 #define US_CSR_CTS_Pos              23           /**< \brief (US_CSR) Image of CTS Input */
-#define US_CSR_CTS                  (_U(0x1) << US_CSR_CTS_Pos)
-#define   US_CSR_CTS_0_Val                _U(0x0)   /**< \brief (US_CSR) CTS is at 0 */
-#define   US_CSR_CTS_1_Val                _U(0x1)   /**< \brief (US_CSR) CTS is at 1 */
+#define US_CSR_CTS                  (_U_(0x1) << US_CSR_CTS_Pos)
+#define   US_CSR_CTS_0_Val                _U_(0x0)   /**< \brief (US_CSR) CTS is at 0 */
+#define   US_CSR_CTS_1_Val                _U_(0x1)   /**< \brief (US_CSR) CTS is at 1 */
 #define US_CSR_CTS_0                (US_CSR_CTS_0_Val              << US_CSR_CTS_Pos)
 #define US_CSR_CTS_1                (US_CSR_CTS_1_Val              << US_CSR_CTS_Pos)
 #define US_CSR_MANERR_Pos           24           /**< \brief (US_CSR) Manchester Error */
-#define US_CSR_MANERR               (_U(0x1) << US_CSR_MANERR_Pos)
-#define   US_CSR_MANERR_0_Val             _U(0x0)   /**< \brief (US_CSR) No Manchester error has been detected since the last RSTSTA */
-#define   US_CSR_MANERR_1_Val             _U(0x1)   /**< \brief (US_CSR) At least one Manchester error has been detected since the last RSTSTA */
+#define US_CSR_MANERR               (_U_(0x1) << US_CSR_MANERR_Pos)
+#define   US_CSR_MANERR_0_Val             _U_(0x0)   /**< \brief (US_CSR) No Manchester error has been detected since the last RSTSTA */
+#define   US_CSR_MANERR_1_Val             _U_(0x1)   /**< \brief (US_CSR) At least one Manchester error has been detected since the last RSTSTA */
 #define US_CSR_MANERR_0             (US_CSR_MANERR_0_Val           << US_CSR_MANERR_Pos)
 #define US_CSR_MANERR_1             (US_CSR_MANERR_1_Val           << US_CSR_MANERR_Pos)
 #define US_CSR_LINBE_Pos            25           /**< \brief (US_CSR) LIN Bit Error */
-#define US_CSR_LINBE                (_U(0x1) << US_CSR_LINBE_Pos)
+#define US_CSR_LINBE                (_U_(0x1) << US_CSR_LINBE_Pos)
 #define US_CSR_LINISFE_Pos          26           /**< \brief (US_CSR) LIN Inconsistent Synch Field Error */
-#define US_CSR_LINISFE              (_U(0x1) << US_CSR_LINISFE_Pos)
+#define US_CSR_LINISFE              (_U_(0x1) << US_CSR_LINISFE_Pos)
 #define US_CSR_LINIPE_Pos           27           /**< \brief (US_CSR) LIN Identifier Parity Error */
-#define US_CSR_LINIPE               (_U(0x1) << US_CSR_LINIPE_Pos)
+#define US_CSR_LINIPE               (_U_(0x1) << US_CSR_LINIPE_Pos)
 #define US_CSR_LINCE_Pos            28           /**< \brief (US_CSR) LIN Checksum Error */
-#define US_CSR_LINCE                (_U(0x1) << US_CSR_LINCE_Pos)
+#define US_CSR_LINCE                (_U_(0x1) << US_CSR_LINCE_Pos)
 #define US_CSR_LINSNRE_Pos          29           /**< \brief (US_CSR) LIN Slave Not Responding Error */
-#define US_CSR_LINSNRE              (_U(0x1) << US_CSR_LINSNRE_Pos)
+#define US_CSR_LINSNRE              (_U_(0x1) << US_CSR_LINSNRE_Pos)
 #define US_CSR_LINSTE_Pos           30           /**< \brief (US_CSR) LIN Synch Tolerance Error */
-#define US_CSR_LINSTE               (_U(0x1) << US_CSR_LINSTE_Pos)
-#define   US_CSR_LINSTE_0_Val             _U(0x0)   /**< \brief (US_CSR) COMM_TX is at 0 */
-#define   US_CSR_LINSTE_1_Val             _U(0x1)   /**< \brief (US_CSR) COMM_TX is at 1 */
+#define US_CSR_LINSTE               (_U_(0x1) << US_CSR_LINSTE_Pos)
+#define   US_CSR_LINSTE_0_Val             _U_(0x0)   /**< \brief (US_CSR) COMM_TX is at 0 */
+#define   US_CSR_LINSTE_1_Val             _U_(0x1)   /**< \brief (US_CSR) COMM_TX is at 1 */
 #define US_CSR_LINSTE_0             (US_CSR_LINSTE_0_Val           << US_CSR_LINSTE_Pos)
 #define US_CSR_LINSTE_1             (US_CSR_LINSTE_1_Val           << US_CSR_LINSTE_Pos)
 #define US_CSR_LINHTE_Pos           31           /**< \brief (US_CSR) LIN Header Timeout Error */
-#define US_CSR_LINHTE               (_U(0x1) << US_CSR_LINHTE_Pos)
-#define   US_CSR_LINHTE_0_Val             _U(0x0)   /**< \brief (US_CSR) COMM_RX is at 0 */
-#define   US_CSR_LINHTE_1_Val             _U(0x1)   /**< \brief (US_CSR) COMM_RX is at 1 */
+#define US_CSR_LINHTE               (_U_(0x1) << US_CSR_LINHTE_Pos)
+#define   US_CSR_LINHTE_0_Val             _U_(0x0)   /**< \brief (US_CSR) COMM_RX is at 0 */
+#define   US_CSR_LINHTE_1_Val             _U_(0x1)   /**< \brief (US_CSR) COMM_RX is at 1 */
 #define US_CSR_LINHTE_0             (US_CSR_LINHTE_0_Val           << US_CSR_LINHTE_Pos)
 #define US_CSR_LINHTE_1             (US_CSR_LINHTE_1_Val           << US_CSR_LINHTE_Pos)
-#define US_CSR_MASK                 _U(0xFFFFFFE7) /**< \brief (US_CSR) MASK Register */
+#define US_CSR_MASK                 _U_(0xFFFFFFE7) /**< \brief (US_CSR) MASK Register */
 
 /* -------- US_RHR : (USART Offset: 0x18) (R/  32) Receiver Holding Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3499,18 +3499,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_RHR_OFFSET               0x18         /**< \brief (US_RHR offset) Receiver Holding Register */
-#define US_RHR_RESETVALUE           _U(0x00000000); /**< \brief (US_RHR reset_value) Receiver Holding Register */
+#define US_RHR_RESETVALUE           _U_(0x00000000); /**< \brief (US_RHR reset_value) Receiver Holding Register */
 
 #define US_RHR_RXCHR_Pos            0            /**< \brief (US_RHR) Received Character */
-#define US_RHR_RXCHR_Msk            (_U(0x1FF) << US_RHR_RXCHR_Pos)
+#define US_RHR_RXCHR_Msk            (_U_(0x1FF) << US_RHR_RXCHR_Pos)
 #define US_RHR_RXCHR(value)         (US_RHR_RXCHR_Msk & ((value) << US_RHR_RXCHR_Pos))
 #define US_RHR_RXSYNH_Pos           15           /**< \brief (US_RHR) Received Sync */
-#define US_RHR_RXSYNH               (_U(0x1) << US_RHR_RXSYNH_Pos)
-#define   US_RHR_RXSYNH_0_Val             _U(0x0)   /**< \brief (US_RHR) Last character received is a Data */
-#define   US_RHR_RXSYNH_1_Val             _U(0x1)   /**< \brief (US_RHR) Last character received is a Command */
+#define US_RHR_RXSYNH               (_U_(0x1) << US_RHR_RXSYNH_Pos)
+#define   US_RHR_RXSYNH_0_Val             _U_(0x0)   /**< \brief (US_RHR) Last character received is a Data */
+#define   US_RHR_RXSYNH_1_Val             _U_(0x1)   /**< \brief (US_RHR) Last character received is a Command */
 #define US_RHR_RXSYNH_0             (US_RHR_RXSYNH_0_Val           << US_RHR_RXSYNH_Pos)
 #define US_RHR_RXSYNH_1             (US_RHR_RXSYNH_1_Val           << US_RHR_RXSYNH_Pos)
-#define US_RHR_MASK                 _U(0x000081FF) /**< \brief (US_RHR) MASK Register */
+#define US_RHR_MASK                 _U_(0x000081FF) /**< \brief (US_RHR) MASK Register */
 
 /* -------- US_THR : (USART Offset: 0x1C) ( /W 32) Transmitter Holding Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3526,18 +3526,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_THR_OFFSET               0x1C         /**< \brief (US_THR offset) Transmitter Holding Register */
-#define US_THR_RESETVALUE           _U(0x00000000); /**< \brief (US_THR reset_value) Transmitter Holding Register */
+#define US_THR_RESETVALUE           _U_(0x00000000); /**< \brief (US_THR reset_value) Transmitter Holding Register */
 
 #define US_THR_TXCHR_Pos            0            /**< \brief (US_THR) Character to be Transmitted */
-#define US_THR_TXCHR_Msk            (_U(0x1FF) << US_THR_TXCHR_Pos)
+#define US_THR_TXCHR_Msk            (_U_(0x1FF) << US_THR_TXCHR_Pos)
 #define US_THR_TXCHR(value)         (US_THR_TXCHR_Msk & ((value) << US_THR_TXCHR_Pos))
 #define US_THR_TXSYNH_Pos           15           /**< \brief (US_THR) Sync Field to be transmitted */
-#define US_THR_TXSYNH               (_U(0x1) << US_THR_TXSYNH_Pos)
-#define   US_THR_TXSYNH_0_Val             _U(0x0)   /**< \brief (US_THR) The next character sent is encoded as a data. Start Frame Delimiter is DATA SYNC */
-#define   US_THR_TXSYNH_1_Val             _U(0x1)   /**< \brief (US_THR) The next character sent is encoded as a command. Start Frame Delimiter is COMMAND SYNC */
+#define US_THR_TXSYNH               (_U_(0x1) << US_THR_TXSYNH_Pos)
+#define   US_THR_TXSYNH_0_Val             _U_(0x0)   /**< \brief (US_THR) The next character sent is encoded as a data. Start Frame Delimiter is DATA SYNC */
+#define   US_THR_TXSYNH_1_Val             _U_(0x1)   /**< \brief (US_THR) The next character sent is encoded as a command. Start Frame Delimiter is COMMAND SYNC */
 #define US_THR_TXSYNH_0             (US_THR_TXSYNH_0_Val           << US_THR_TXSYNH_Pos)
 #define US_THR_TXSYNH_1             (US_THR_TXSYNH_1_Val           << US_THR_TXSYNH_Pos)
-#define US_THR_MASK                 _U(0x000081FF) /**< \brief (US_THR) MASK Register */
+#define US_THR_MASK                 _U_(0x000081FF) /**< \brief (US_THR) MASK Register */
 
 /* -------- US_BRGR : (USART Offset: 0x20) (R/W 32) Baud Rate Generator Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3552,23 +3552,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_BRGR_OFFSET              0x20         /**< \brief (US_BRGR offset) Baud Rate Generator Register */
-#define US_BRGR_RESETVALUE          _U(0x00000000); /**< \brief (US_BRGR reset_value) Baud Rate Generator Register */
+#define US_BRGR_RESETVALUE          _U_(0x00000000); /**< \brief (US_BRGR reset_value) Baud Rate Generator Register */
 
 #define US_BRGR_CD_Pos              0            /**< \brief (US_BRGR) Clock Divisor */
-#define US_BRGR_CD_Msk              (_U(0xFFFF) << US_BRGR_CD_Pos)
+#define US_BRGR_CD_Msk              (_U_(0xFFFF) << US_BRGR_CD_Pos)
 #define US_BRGR_CD(value)           (US_BRGR_CD_Msk & ((value) << US_BRGR_CD_Pos))
-#define   US_BRGR_CD_DISABLE_Val          _U(0x0)   /**< \brief (US_BRGR) Disables the clock */
-#define   US_BRGR_CD_BYPASS_Val           _U(0x1)   /**< \brief (US_BRGR) Clock Divisor Bypass */
-#define   US_BRGR_CD_2_Val                _U(0x2)   /**< \brief (US_BRGR) Baud Rate (Asynchronous Mode) = Selected Clock/(16 x CD) or (8 x CD); Baud Rate (Synchronous Mode) = Selected Clock/CD; */
+#define   US_BRGR_CD_DISABLE_Val          _U_(0x0)   /**< \brief (US_BRGR) Disables the clock */
+#define   US_BRGR_CD_BYPASS_Val           _U_(0x1)   /**< \brief (US_BRGR) Clock Divisor Bypass */
+#define   US_BRGR_CD_2_Val                _U_(0x2)   /**< \brief (US_BRGR) Baud Rate (Asynchronous Mode) = Selected Clock/(16 x CD) or (8 x CD); Baud Rate (Synchronous Mode) = Selected Clock/CD; */
 #define US_BRGR_CD_DISABLE          (US_BRGR_CD_DISABLE_Val        << US_BRGR_CD_Pos)
 #define US_BRGR_CD_BYPASS           (US_BRGR_CD_BYPASS_Val         << US_BRGR_CD_Pos)
 #define US_BRGR_CD_2                (US_BRGR_CD_2_Val              << US_BRGR_CD_Pos)
 #define US_BRGR_FP_Pos              16           /**< \brief (US_BRGR) Fractional Part */
-#define US_BRGR_FP_Msk              (_U(0x7) << US_BRGR_FP_Pos)
+#define US_BRGR_FP_Msk              (_U_(0x7) << US_BRGR_FP_Pos)
 #define US_BRGR_FP(value)           (US_BRGR_FP_Msk & ((value) << US_BRGR_FP_Pos))
-#define   US_BRGR_FP_0_Val                _U(0x0)   /**< \brief (US_BRGR) Fractional divider is disabled */
+#define   US_BRGR_FP_0_Val                _U_(0x0)   /**< \brief (US_BRGR) Fractional divider is disabled */
 #define US_BRGR_FP_0                (US_BRGR_FP_0_Val              << US_BRGR_FP_Pos)
-#define US_BRGR_MASK                _U(0x0007FFFF) /**< \brief (US_BRGR) MASK Register */
+#define US_BRGR_MASK                _U_(0x0007FFFF) /**< \brief (US_BRGR) MASK Register */
 
 /* -------- US_RTOR : (USART Offset: 0x24) (R/W 32) Receiver Time-out Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3582,14 +3582,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_RTOR_OFFSET              0x24         /**< \brief (US_RTOR offset) Receiver Time-out Register */
-#define US_RTOR_RESETVALUE          _U(0x00000000); /**< \brief (US_RTOR reset_value) Receiver Time-out Register */
+#define US_RTOR_RESETVALUE          _U_(0x00000000); /**< \brief (US_RTOR reset_value) Receiver Time-out Register */
 
 #define US_RTOR_TO_Pos              0            /**< \brief (US_RTOR) Time-out Value */
-#define US_RTOR_TO_Msk              (_U(0x1FFFF) << US_RTOR_TO_Pos)
+#define US_RTOR_TO_Msk              (_U_(0x1FFFF) << US_RTOR_TO_Pos)
 #define US_RTOR_TO(value)           (US_RTOR_TO_Msk & ((value) << US_RTOR_TO_Pos))
-#define   US_RTOR_TO_DISABLE_Val          _U(0x0)   /**< \brief (US_RTOR) Disables the RX Time-out function */
+#define   US_RTOR_TO_DISABLE_Val          _U_(0x0)   /**< \brief (US_RTOR) Disables the RX Time-out function */
 #define US_RTOR_TO_DISABLE          (US_RTOR_TO_DISABLE_Val        << US_RTOR_TO_Pos)
-#define US_RTOR_MASK                _U(0x0001FFFF) /**< \brief (US_RTOR) MASK Register */
+#define US_RTOR_MASK                _U_(0x0001FFFF) /**< \brief (US_RTOR) MASK Register */
 
 /* -------- US_TTGR : (USART Offset: 0x28) (R/W 32) Transmitter Timeguard Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3603,14 +3603,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_TTGR_OFFSET              0x28         /**< \brief (US_TTGR offset) Transmitter Timeguard Register */
-#define US_TTGR_RESETVALUE          _U(0x00000000); /**< \brief (US_TTGR reset_value) Transmitter Timeguard Register */
+#define US_TTGR_RESETVALUE          _U_(0x00000000); /**< \brief (US_TTGR reset_value) Transmitter Timeguard Register */
 
 #define US_TTGR_TG_Pos              0            /**< \brief (US_TTGR) Timeguard Value */
-#define US_TTGR_TG_Msk              (_U(0xFF) << US_TTGR_TG_Pos)
+#define US_TTGR_TG_Msk              (_U_(0xFF) << US_TTGR_TG_Pos)
 #define US_TTGR_TG(value)           (US_TTGR_TG_Msk & ((value) << US_TTGR_TG_Pos))
-#define   US_TTGR_TG_DISABLE_Val          _U(0x0)   /**< \brief (US_TTGR) Disables the TX Timeguard function. */
+#define   US_TTGR_TG_DISABLE_Val          _U_(0x0)   /**< \brief (US_TTGR) Disables the TX Timeguard function. */
 #define US_TTGR_TG_DISABLE          (US_TTGR_TG_DISABLE_Val        << US_TTGR_TG_Pos)
-#define US_TTGR_MASK                _U(0x000000FF) /**< \brief (US_TTGR) MASK Register */
+#define US_TTGR_MASK                _U_(0x000000FF) /**< \brief (US_TTGR) MASK Register */
 
 /* -------- US_FIDI : (USART Offset: 0x40) (R/W 32) FI DI Ratio Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3624,14 +3624,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_FIDI_OFFSET              0x40         /**< \brief (US_FIDI offset) FI DI Ratio Register */
-#define US_FIDI_RESETVALUE          _U(0x00000174); /**< \brief (US_FIDI reset_value) FI DI Ratio Register */
+#define US_FIDI_RESETVALUE          _U_(0x00000174); /**< \brief (US_FIDI reset_value) FI DI Ratio Register */
 
 #define US_FIDI_FI_DI_RATIO_Pos     0            /**< \brief (US_FIDI) FI Over DI Ratio Value */
-#define US_FIDI_FI_DI_RATIO_Msk     (_U(0x7FF) << US_FIDI_FI_DI_RATIO_Pos)
+#define US_FIDI_FI_DI_RATIO_Msk     (_U_(0x7FF) << US_FIDI_FI_DI_RATIO_Pos)
 #define US_FIDI_FI_DI_RATIO(value)  (US_FIDI_FI_DI_RATIO_Msk & ((value) << US_FIDI_FI_DI_RATIO_Pos))
-#define   US_FIDI_FI_DI_RATIO_DISABLE_Val _U(0x0)   /**< \brief (US_FIDI) Baud Rate = 0 */
+#define   US_FIDI_FI_DI_RATIO_DISABLE_Val _U_(0x0)   /**< \brief (US_FIDI) Baud Rate = 0 */
 #define US_FIDI_FI_DI_RATIO_DISABLE (US_FIDI_FI_DI_RATIO_DISABLE_Val << US_FIDI_FI_DI_RATIO_Pos)
-#define US_FIDI_MASK                _U(0x000007FF) /**< \brief (US_FIDI) MASK Register */
+#define US_FIDI_MASK                _U_(0x000007FF) /**< \brief (US_FIDI) MASK Register */
 
 /* -------- US_NER : (USART Offset: 0x44) (R/  32) Number of Errors Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3645,12 +3645,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_NER_OFFSET               0x44         /**< \brief (US_NER offset) Number of Errors Register */
-#define US_NER_RESETVALUE           _U(0x00000000); /**< \brief (US_NER reset_value) Number of Errors Register */
+#define US_NER_RESETVALUE           _U_(0x00000000); /**< \brief (US_NER reset_value) Number of Errors Register */
 
 #define US_NER_NB_ERRORS_Pos        0            /**< \brief (US_NER) Error number during ISO7816 transfers */
-#define US_NER_NB_ERRORS_Msk        (_U(0xFF) << US_NER_NB_ERRORS_Pos)
+#define US_NER_NB_ERRORS_Msk        (_U_(0xFF) << US_NER_NB_ERRORS_Pos)
 #define US_NER_NB_ERRORS(value)     (US_NER_NB_ERRORS_Msk & ((value) << US_NER_NB_ERRORS_Pos))
-#define US_NER_MASK                 _U(0x000000FF) /**< \brief (US_NER) MASK Register */
+#define US_NER_MASK                 _U_(0x000000FF) /**< \brief (US_NER) MASK Register */
 
 /* -------- US_IFR : (USART Offset: 0x4C) (R/W 32) IrDA Filter Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3664,12 +3664,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_IFR_OFFSET               0x4C         /**< \brief (US_IFR offset) IrDA Filter Register */
-#define US_IFR_RESETVALUE           _U(0x00000000); /**< \brief (US_IFR reset_value) IrDA Filter Register */
+#define US_IFR_RESETVALUE           _U_(0x00000000); /**< \brief (US_IFR reset_value) IrDA Filter Register */
 
 #define US_IFR_IRDA_FILTER_Pos      0            /**< \brief (US_IFR) Irda filter */
-#define US_IFR_IRDA_FILTER_Msk      (_U(0xFF) << US_IFR_IRDA_FILTER_Pos)
+#define US_IFR_IRDA_FILTER_Msk      (_U_(0xFF) << US_IFR_IRDA_FILTER_Pos)
 #define US_IFR_IRDA_FILTER(value)   (US_IFR_IRDA_FILTER_Msk & ((value) << US_IFR_IRDA_FILTER_Pos))
-#define US_IFR_MASK                 _U(0x000000FF) /**< \brief (US_IFR) MASK Register */
+#define US_IFR_MASK                 _U_(0x000000FF) /**< \brief (US_IFR) MASK Register */
 
 /* -------- US_MAN : (USART Offset: 0x50) (R/W 32) Manchester Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3695,59 +3695,59 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_MAN_OFFSET               0x50         /**< \brief (US_MAN offset) Manchester Configuration Register */
-#define US_MAN_RESETVALUE           _U(0x30011004); /**< \brief (US_MAN reset_value) Manchester Configuration Register */
+#define US_MAN_RESETVALUE           _U_(0x30011004); /**< \brief (US_MAN reset_value) Manchester Configuration Register */
 
 #define US_MAN_TX_PL_Pos            0            /**< \brief (US_MAN) Transmitter Preamble Length */
-#define US_MAN_TX_PL_Msk            (_U(0xF) << US_MAN_TX_PL_Pos)
+#define US_MAN_TX_PL_Msk            (_U_(0xF) << US_MAN_TX_PL_Pos)
 #define US_MAN_TX_PL(value)         (US_MAN_TX_PL_Msk & ((value) << US_MAN_TX_PL_Pos))
-#define   US_MAN_TX_PL_0_Val              _U(0x0)   /**< \brief (US_MAN) The Transmitter Preamble pattern generation is disabled */
+#define   US_MAN_TX_PL_0_Val              _U_(0x0)   /**< \brief (US_MAN) The Transmitter Preamble pattern generation is disabled */
 #define US_MAN_TX_PL_0              (US_MAN_TX_PL_0_Val            << US_MAN_TX_PL_Pos)
 #define US_MAN_TX_PP_Pos            8            /**< \brief (US_MAN) Transmitter Preamble Pattern */
-#define US_MAN_TX_PP_Msk            (_U(0x3) << US_MAN_TX_PP_Pos)
+#define US_MAN_TX_PP_Msk            (_U_(0x3) << US_MAN_TX_PP_Pos)
 #define US_MAN_TX_PP(value)         (US_MAN_TX_PP_Msk & ((value) << US_MAN_TX_PP_Pos))
-#define   US_MAN_TX_PP_0_Val              _U(0x0)   /**< \brief (US_MAN) ALL_ONE */
-#define   US_MAN_TX_PP_1_Val              _U(0x1)   /**< \brief (US_MAN) ALL_ZERO */
-#define   US_MAN_TX_PP_2_Val              _U(0x2)   /**< \brief (US_MAN) ZERO_ONE */
-#define   US_MAN_TX_PP_3_Val              _U(0x3)   /**< \brief (US_MAN) ONE_ZERO */
+#define   US_MAN_TX_PP_0_Val              _U_(0x0)   /**< \brief (US_MAN) ALL_ONE */
+#define   US_MAN_TX_PP_1_Val              _U_(0x1)   /**< \brief (US_MAN) ALL_ZERO */
+#define   US_MAN_TX_PP_2_Val              _U_(0x2)   /**< \brief (US_MAN) ZERO_ONE */
+#define   US_MAN_TX_PP_3_Val              _U_(0x3)   /**< \brief (US_MAN) ONE_ZERO */
 #define US_MAN_TX_PP_0              (US_MAN_TX_PP_0_Val            << US_MAN_TX_PP_Pos)
 #define US_MAN_TX_PP_1              (US_MAN_TX_PP_1_Val            << US_MAN_TX_PP_Pos)
 #define US_MAN_TX_PP_2              (US_MAN_TX_PP_2_Val            << US_MAN_TX_PP_Pos)
 #define US_MAN_TX_PP_3              (US_MAN_TX_PP_3_Val            << US_MAN_TX_PP_Pos)
 #define US_MAN_TX_MPOL_Pos          12           /**< \brief (US_MAN) Transmitter Manchester Polarity */
-#define US_MAN_TX_MPOL              (_U(0x1) << US_MAN_TX_MPOL_Pos)
-#define   US_MAN_TX_MPOL_0_Val            _U(0x0)   /**< \brief (US_MAN) Logic Zero is coded as a zero-to-one transition, Logic One is coded as a one-to-zero transition */
-#define   US_MAN_TX_MPOL_1_Val            _U(0x1)   /**< \brief (US_MAN) Logic Zero is coded as a one-to-zero transition, Logic One is coded as a zero-to-one transition */
+#define US_MAN_TX_MPOL              (_U_(0x1) << US_MAN_TX_MPOL_Pos)
+#define   US_MAN_TX_MPOL_0_Val            _U_(0x0)   /**< \brief (US_MAN) Logic Zero is coded as a zero-to-one transition, Logic One is coded as a one-to-zero transition */
+#define   US_MAN_TX_MPOL_1_Val            _U_(0x1)   /**< \brief (US_MAN) Logic Zero is coded as a one-to-zero transition, Logic One is coded as a zero-to-one transition */
 #define US_MAN_TX_MPOL_0            (US_MAN_TX_MPOL_0_Val          << US_MAN_TX_MPOL_Pos)
 #define US_MAN_TX_MPOL_1            (US_MAN_TX_MPOL_1_Val          << US_MAN_TX_MPOL_Pos)
 #define US_MAN_RX_PL_Pos            16           /**< \brief (US_MAN) Receiver Preamble Length */
-#define US_MAN_RX_PL_Msk            (_U(0xF) << US_MAN_RX_PL_Pos)
+#define US_MAN_RX_PL_Msk            (_U_(0xF) << US_MAN_RX_PL_Pos)
 #define US_MAN_RX_PL(value)         (US_MAN_RX_PL_Msk & ((value) << US_MAN_RX_PL_Pos))
-#define   US_MAN_RX_PL_0_Val              _U(0x0)   /**< \brief (US_MAN) The receiver preamble pattern detection is disabled */
+#define   US_MAN_RX_PL_0_Val              _U_(0x0)   /**< \brief (US_MAN) The receiver preamble pattern detection is disabled */
 #define US_MAN_RX_PL_0              (US_MAN_RX_PL_0_Val            << US_MAN_RX_PL_Pos)
 #define US_MAN_RX_PP_Pos            24           /**< \brief (US_MAN) Receiver Preamble Pattern detected */
-#define US_MAN_RX_PP_Msk            (_U(0x3) << US_MAN_RX_PP_Pos)
+#define US_MAN_RX_PP_Msk            (_U_(0x3) << US_MAN_RX_PP_Pos)
 #define US_MAN_RX_PP(value)         (US_MAN_RX_PP_Msk & ((value) << US_MAN_RX_PP_Pos))
-#define   US_MAN_RX_PP_0_Val              _U(0x0)   /**< \brief (US_MAN) ALL_ONE */
-#define   US_MAN_RX_PP_1_Val              _U(0x1)   /**< \brief (US_MAN) ALL_ZERO */
-#define   US_MAN_RX_PP_2_Val              _U(0x2)   /**< \brief (US_MAN) ZERO_ONE */
-#define   US_MAN_RX_PP_3_Val              _U(0x3)   /**< \brief (US_MAN) ONE_ZERO */
+#define   US_MAN_RX_PP_0_Val              _U_(0x0)   /**< \brief (US_MAN) ALL_ONE */
+#define   US_MAN_RX_PP_1_Val              _U_(0x1)   /**< \brief (US_MAN) ALL_ZERO */
+#define   US_MAN_RX_PP_2_Val              _U_(0x2)   /**< \brief (US_MAN) ZERO_ONE */
+#define   US_MAN_RX_PP_3_Val              _U_(0x3)   /**< \brief (US_MAN) ONE_ZERO */
 #define US_MAN_RX_PP_0              (US_MAN_RX_PP_0_Val            << US_MAN_RX_PP_Pos)
 #define US_MAN_RX_PP_1              (US_MAN_RX_PP_1_Val            << US_MAN_RX_PP_Pos)
 #define US_MAN_RX_PP_2              (US_MAN_RX_PP_2_Val            << US_MAN_RX_PP_Pos)
 #define US_MAN_RX_PP_3              (US_MAN_RX_PP_3_Val            << US_MAN_RX_PP_Pos)
 #define US_MAN_RX_MPOL_Pos          28           /**< \brief (US_MAN) Receiver Manchester Polarity */
-#define US_MAN_RX_MPOL              (_U(0x1) << US_MAN_RX_MPOL_Pos)
-#define   US_MAN_RX_MPOL_0_Val            _U(0x0)   /**< \brief (US_MAN) Logic Zero is coded as a zero-to-one transition, Logic One is coded as a one-to-zero transition */
-#define   US_MAN_RX_MPOL_1_Val            _U(0x1)   /**< \brief (US_MAN) Logic Zero is coded as a one-to-zero transition, Logic One is coded as a zero-to-one transition */
+#define US_MAN_RX_MPOL              (_U_(0x1) << US_MAN_RX_MPOL_Pos)
+#define   US_MAN_RX_MPOL_0_Val            _U_(0x0)   /**< \brief (US_MAN) Logic Zero is coded as a zero-to-one transition, Logic One is coded as a one-to-zero transition */
+#define   US_MAN_RX_MPOL_1_Val            _U_(0x1)   /**< \brief (US_MAN) Logic Zero is coded as a one-to-zero transition, Logic One is coded as a zero-to-one transition */
 #define US_MAN_RX_MPOL_0            (US_MAN_RX_MPOL_0_Val          << US_MAN_RX_MPOL_Pos)
 #define US_MAN_RX_MPOL_1            (US_MAN_RX_MPOL_1_Val          << US_MAN_RX_MPOL_Pos)
 #define US_MAN_DRIFT_Pos            30           /**< \brief (US_MAN) Drift compensation */
-#define US_MAN_DRIFT                (_U(0x1) << US_MAN_DRIFT_Pos)
-#define   US_MAN_DRIFT_0_Val              _U(0x0)   /**< \brief (US_MAN) The USART can not recover from an important clock drift */
-#define   US_MAN_DRIFT_1_Val              _U(0x1)   /**< \brief (US_MAN) The USART can recover from clock drift. The 16X clock mode must be enabled */
+#define US_MAN_DRIFT                (_U_(0x1) << US_MAN_DRIFT_Pos)
+#define   US_MAN_DRIFT_0_Val              _U_(0x0)   /**< \brief (US_MAN) The USART can not recover from an important clock drift */
+#define   US_MAN_DRIFT_1_Val              _U_(0x1)   /**< \brief (US_MAN) The USART can recover from clock drift. The 16X clock mode must be enabled */
 #define US_MAN_DRIFT_0              (US_MAN_DRIFT_0_Val            << US_MAN_DRIFT_Pos)
 #define US_MAN_DRIFT_1              (US_MAN_DRIFT_1_Val            << US_MAN_DRIFT_Pos)
-#define US_MAN_MASK                 _U(0x530F130F) /**< \brief (US_MAN) MASK Register */
+#define US_MAN_MASK                 _U_(0x530F130F) /**< \brief (US_MAN) MASK Register */
 
 /* -------- US_LINMR : (USART Offset: 0x54) (R/W 32) LIN Mode Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3770,37 +3770,37 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_LINMR_OFFSET             0x54         /**< \brief (US_LINMR offset) LIN Mode Register */
-#define US_LINMR_RESETVALUE         _U(0x00000000); /**< \brief (US_LINMR reset_value) LIN Mode Register */
+#define US_LINMR_RESETVALUE         _U_(0x00000000); /**< \brief (US_LINMR reset_value) LIN Mode Register */
 
 #define US_LINMR_NACT_Pos           0            /**< \brief (US_LINMR) LIN Node Action */
-#define US_LINMR_NACT_Msk           (_U(0x3) << US_LINMR_NACT_Pos)
+#define US_LINMR_NACT_Msk           (_U_(0x3) << US_LINMR_NACT_Pos)
 #define US_LINMR_NACT(value)        (US_LINMR_NACT_Msk & ((value) << US_LINMR_NACT_Pos))
-#define   US_LINMR_NACT_PUBLISH_Val       _U(0x0)   /**< \brief (US_LINMR) The LIN Controller transmits the response */
-#define   US_LINMR_NACT_SUBSCRIBE_Val     _U(0x1)   /**< \brief (US_LINMR) The LIN Controller receives the response */
-#define   US_LINMR_NACT_IGNORE_Val        _U(0x2)   /**< \brief (US_LINMR) The LIN Controller doesn't transmit and doesn't receive the response */
+#define   US_LINMR_NACT_PUBLISH_Val       _U_(0x0)   /**< \brief (US_LINMR) The LIN Controller transmits the response */
+#define   US_LINMR_NACT_SUBSCRIBE_Val     _U_(0x1)   /**< \brief (US_LINMR) The LIN Controller receives the response */
+#define   US_LINMR_NACT_IGNORE_Val        _U_(0x2)   /**< \brief (US_LINMR) The LIN Controller doesn't transmit and doesn't receive the response */
 #define US_LINMR_NACT_PUBLISH       (US_LINMR_NACT_PUBLISH_Val     << US_LINMR_NACT_Pos)
 #define US_LINMR_NACT_SUBSCRIBE     (US_LINMR_NACT_SUBSCRIBE_Val   << US_LINMR_NACT_Pos)
 #define US_LINMR_NACT_IGNORE        (US_LINMR_NACT_IGNORE_Val      << US_LINMR_NACT_Pos)
 #define US_LINMR_PARDIS_Pos         2            /**< \brief (US_LINMR) Parity Disable */
-#define US_LINMR_PARDIS             (_U(0x1) << US_LINMR_PARDIS_Pos)
+#define US_LINMR_PARDIS             (_U_(0x1) << US_LINMR_PARDIS_Pos)
 #define US_LINMR_CHKDIS_Pos         3            /**< \brief (US_LINMR) Checksum Disable */
-#define US_LINMR_CHKDIS             (_U(0x1) << US_LINMR_CHKDIS_Pos)
+#define US_LINMR_CHKDIS             (_U_(0x1) << US_LINMR_CHKDIS_Pos)
 #define US_LINMR_CHKTYP_Pos         4            /**< \brief (US_LINMR) Checksum Type */
-#define US_LINMR_CHKTYP             (_U(0x1) << US_LINMR_CHKTYP_Pos)
+#define US_LINMR_CHKTYP             (_U_(0x1) << US_LINMR_CHKTYP_Pos)
 #define US_LINMR_DLM_Pos            5            /**< \brief (US_LINMR) Data Length Mode */
-#define US_LINMR_DLM                (_U(0x1) << US_LINMR_DLM_Pos)
+#define US_LINMR_DLM                (_U_(0x1) << US_LINMR_DLM_Pos)
 #define US_LINMR_FSDIS_Pos          6            /**< \brief (US_LINMR) Frame Slot Mode Disable */
-#define US_LINMR_FSDIS              (_U(0x1) << US_LINMR_FSDIS_Pos)
+#define US_LINMR_FSDIS              (_U_(0x1) << US_LINMR_FSDIS_Pos)
 #define US_LINMR_WKUPTYP_Pos        7            /**< \brief (US_LINMR) Wakeup Signal Type */
-#define US_LINMR_WKUPTYP            (_U(0x1) << US_LINMR_WKUPTYP_Pos)
+#define US_LINMR_WKUPTYP            (_U_(0x1) << US_LINMR_WKUPTYP_Pos)
 #define US_LINMR_DLC_Pos            8            /**< \brief (US_LINMR) Data Length Control */
-#define US_LINMR_DLC_Msk            (_U(0xFF) << US_LINMR_DLC_Pos)
+#define US_LINMR_DLC_Msk            (_U_(0xFF) << US_LINMR_DLC_Pos)
 #define US_LINMR_DLC(value)         (US_LINMR_DLC_Msk & ((value) << US_LINMR_DLC_Pos))
 #define US_LINMR_PDCM_Pos           16           /**< \brief (US_LINMR) PDC Mode */
-#define US_LINMR_PDCM               (_U(0x1) << US_LINMR_PDCM_Pos)
+#define US_LINMR_PDCM               (_U_(0x1) << US_LINMR_PDCM_Pos)
 #define US_LINMR_SYNCDIS_Pos        17           /**< \brief (US_LINMR) Synchronization Disable */
-#define US_LINMR_SYNCDIS            (_U(0x1) << US_LINMR_SYNCDIS_Pos)
-#define US_LINMR_MASK               _U(0x0003FFFF) /**< \brief (US_LINMR) MASK Register */
+#define US_LINMR_SYNCDIS            (_U_(0x1) << US_LINMR_SYNCDIS_Pos)
+#define US_LINMR_MASK               _U_(0x0003FFFF) /**< \brief (US_LINMR) MASK Register */
 
 /* -------- US_LINIR : (USART Offset: 0x58) (R/W 32) LIN Identifier Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3814,12 +3814,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_LINIR_OFFSET             0x58         /**< \brief (US_LINIR offset) LIN Identifier Register */
-#define US_LINIR_RESETVALUE         _U(0x00000000); /**< \brief (US_LINIR reset_value) LIN Identifier Register */
+#define US_LINIR_RESETVALUE         _U_(0x00000000); /**< \brief (US_LINIR reset_value) LIN Identifier Register */
 
 #define US_LINIR_IDCHR_Pos          0            /**< \brief (US_LINIR) Identifier Character */
-#define US_LINIR_IDCHR_Msk          (_U(0xFF) << US_LINIR_IDCHR_Pos)
+#define US_LINIR_IDCHR_Msk          (_U_(0xFF) << US_LINIR_IDCHR_Pos)
 #define US_LINIR_IDCHR(value)       (US_LINIR_IDCHR_Msk & ((value) << US_LINIR_IDCHR_Pos))
-#define US_LINIR_MASK               _U(0x000000FF) /**< \brief (US_LINIR) MASK Register */
+#define US_LINIR_MASK               _U_(0x000000FF) /**< \brief (US_LINIR) MASK Register */
 
 /* -------- US_LINBRR : (USART Offset: 0x5C) (R/  32) LIN Baud Rate Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3834,15 +3834,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_LINBRR_OFFSET            0x5C         /**< \brief (US_LINBRR offset) LIN Baud Rate Register */
-#define US_LINBRR_RESETVALUE        _U(0x00000000); /**< \brief (US_LINBRR reset_value) LIN Baud Rate Register */
+#define US_LINBRR_RESETVALUE        _U_(0x00000000); /**< \brief (US_LINBRR reset_value) LIN Baud Rate Register */
 
 #define US_LINBRR_LINCD_Pos         0            /**< \brief (US_LINBRR) Clock Divider after Synchronization */
-#define US_LINBRR_LINCD_Msk         (_U(0xFFFF) << US_LINBRR_LINCD_Pos)
+#define US_LINBRR_LINCD_Msk         (_U_(0xFFFF) << US_LINBRR_LINCD_Pos)
 #define US_LINBRR_LINCD(value)      (US_LINBRR_LINCD_Msk & ((value) << US_LINBRR_LINCD_Pos))
 #define US_LINBRR_LINFP_Pos         16           /**< \brief (US_LINBRR) Fractional Part after Synchronization */
-#define US_LINBRR_LINFP_Msk         (_U(0x7) << US_LINBRR_LINFP_Pos)
+#define US_LINBRR_LINFP_Msk         (_U_(0x7) << US_LINBRR_LINFP_Pos)
 #define US_LINBRR_LINFP(value)      (US_LINBRR_LINFP_Msk & ((value) << US_LINBRR_LINFP_Pos))
-#define US_LINBRR_MASK              _U(0x0007FFFF) /**< \brief (US_LINBRR) MASK Register */
+#define US_LINBRR_MASK              _U_(0x0007FFFF) /**< \brief (US_LINBRR) MASK Register */
 
 /* -------- US_WPMR : (USART Offset: 0xE4) (R/W 32) Write Protect Mode Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3857,18 +3857,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_WPMR_OFFSET              0xE4         /**< \brief (US_WPMR offset) Write Protect Mode Register */
-#define US_WPMR_RESETVALUE          _U(0x00000000); /**< \brief (US_WPMR reset_value) Write Protect Mode Register */
+#define US_WPMR_RESETVALUE          _U_(0x00000000); /**< \brief (US_WPMR reset_value) Write Protect Mode Register */
 
 #define US_WPMR_WPEN_Pos            0            /**< \brief (US_WPMR) Write Protect Enable */
-#define US_WPMR_WPEN                (_U(0x1) << US_WPMR_WPEN_Pos)
-#define   US_WPMR_WPEN_0_Val              _U(0x0)   /**< \brief (US_WPMR) Disables the Write Protect if WPKEY corresponds to 0x858365 ("USA" in ACII) */
-#define   US_WPMR_WPEN_1_Val              _U(0x1)   /**< \brief (US_WPMR) Enables the Write Protect if WPKEY corresponds to 0x858365 ("USA" in ACII) */
+#define US_WPMR_WPEN                (_U_(0x1) << US_WPMR_WPEN_Pos)
+#define   US_WPMR_WPEN_0_Val              _U_(0x0)   /**< \brief (US_WPMR) Disables the Write Protect if WPKEY corresponds to 0x858365 ("USA" in ACII) */
+#define   US_WPMR_WPEN_1_Val              _U_(0x1)   /**< \brief (US_WPMR) Enables the Write Protect if WPKEY corresponds to 0x858365 ("USA" in ACII) */
 #define US_WPMR_WPEN_0              (US_WPMR_WPEN_0_Val            << US_WPMR_WPEN_Pos)
 #define US_WPMR_WPEN_1              (US_WPMR_WPEN_1_Val            << US_WPMR_WPEN_Pos)
 #define US_WPMR_WPKEY_Pos           8            /**< \brief (US_WPMR) Write Protect Key */
-#define US_WPMR_WPKEY_Msk           (_U(0xFFFFFF) << US_WPMR_WPKEY_Pos)
+#define US_WPMR_WPKEY_Msk           (_U_(0xFFFFFF) << US_WPMR_WPKEY_Pos)
 #define US_WPMR_WPKEY(value)        (US_WPMR_WPKEY_Msk & ((value) << US_WPMR_WPKEY_Pos))
-#define US_WPMR_MASK                _U(0xFFFFFF01) /**< \brief (US_WPMR) MASK Register */
+#define US_WPMR_MASK                _U_(0xFFFFFF01) /**< \brief (US_WPMR) MASK Register */
 
 /* -------- US_WPSR : (USART Offset: 0xE8) (R/  32) Write Protect Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3884,18 +3884,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_WPSR_OFFSET              0xE8         /**< \brief (US_WPSR offset) Write Protect Status Register */
-#define US_WPSR_RESETVALUE          _U(0x00000000); /**< \brief (US_WPSR reset_value) Write Protect Status Register */
+#define US_WPSR_RESETVALUE          _U_(0x00000000); /**< \brief (US_WPSR reset_value) Write Protect Status Register */
 
 #define US_WPSR_WPV_Pos             0            /**< \brief (US_WPSR) Write Protect Violation Status */
-#define US_WPSR_WPV                 (_U(0x1) << US_WPSR_WPV_Pos)
-#define   US_WPSR_WPV_0_Val               _U(0x0)   /**< \brief (US_WPSR) No Write Protect Violation has occurred since the last read of the WPSR register */
-#define   US_WPSR_WPV_1_Val               _U(0x1)   /**< \brief (US_WPSR) A Write Protect Violation has occurred since the last read of the WPSR register. If this violation is an unauthorized attempt to write a protected register, the associated violation is reported into field WPVSRC */
+#define US_WPSR_WPV                 (_U_(0x1) << US_WPSR_WPV_Pos)
+#define   US_WPSR_WPV_0_Val               _U_(0x0)   /**< \brief (US_WPSR) No Write Protect Violation has occurred since the last read of the WPSR register */
+#define   US_WPSR_WPV_1_Val               _U_(0x1)   /**< \brief (US_WPSR) A Write Protect Violation has occurred since the last read of the WPSR register. If this violation is an unauthorized attempt to write a protected register, the associated violation is reported into field WPVSRC */
 #define US_WPSR_WPV_0               (US_WPSR_WPV_0_Val             << US_WPSR_WPV_Pos)
 #define US_WPSR_WPV_1               (US_WPSR_WPV_1_Val             << US_WPSR_WPV_Pos)
 #define US_WPSR_WPVSRC_Pos          8            /**< \brief (US_WPSR) Write Protect Violation Source */
-#define US_WPSR_WPVSRC_Msk          (_U(0xFFFF) << US_WPSR_WPVSRC_Pos)
+#define US_WPSR_WPVSRC_Msk          (_U_(0xFFFF) << US_WPSR_WPVSRC_Pos)
 #define US_WPSR_WPVSRC(value)       (US_WPSR_WPVSRC_Msk & ((value) << US_WPSR_WPVSRC_Pos))
-#define US_WPSR_MASK                _U(0x00FFFF01) /**< \brief (US_WPSR) MASK Register */
+#define US_WPSR_MASK                _U_(0x00FFFF01) /**< \brief (US_WPSR) MASK Register */
 
 /* -------- US_VERSION : (USART Offset: 0xFC) (R/  32) Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3911,15 +3911,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_VERSION_OFFSET           0xFC         /**< \brief (US_VERSION offset) Version Register */
-#define US_VERSION_RESETVALUE       _U(0x00000602); /**< \brief (US_VERSION reset_value) Version Register */
+#define US_VERSION_RESETVALUE       _U_(0x00000602); /**< \brief (US_VERSION reset_value) Version Register */
 
 #define US_VERSION_VERSION_Pos      0            /**< \brief (US_VERSION) Version */
-#define US_VERSION_VERSION_Msk      (_U(0xFFF) << US_VERSION_VERSION_Pos)
+#define US_VERSION_VERSION_Msk      (_U_(0xFFF) << US_VERSION_VERSION_Pos)
 #define US_VERSION_VERSION(value)   (US_VERSION_VERSION_Msk & ((value) << US_VERSION_VERSION_Pos))
 #define US_VERSION_MFN_Pos          16           /**< \brief (US_VERSION) MFN */
-#define US_VERSION_MFN_Msk          (_U(0xF) << US_VERSION_MFN_Pos)
+#define US_VERSION_MFN_Msk          (_U_(0xF) << US_VERSION_MFN_Pos)
 #define US_VERSION_MFN(value)       (US_VERSION_MFN_Msk & ((value) << US_VERSION_MFN_Pos))
-#define US_VERSION_MASK             _U(0x000F0FFF) /**< \brief (US_VERSION) MASK Register */
+#define US_VERSION_MASK             _U_(0x000F0FFF) /**< \brief (US_VERSION) MASK Register */
 
 /** \brief USART hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/usart.h
+++ b/asf/sam/include/sam4l/component/usart.h
@@ -3923,61 +3923,32 @@ typedef union {
 
 /** \brief USART hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __O  US_CR_Type                CR;          /**< \brief Offset: 0x00 ( /W 32) Control Register */
-  __IO US_MR_Type                MR;          /**< \brief Offset: 0x04 (R/W 32) Mode Register */
-  __O  US_IER_Type               IER;         /**< \brief Offset: 0x08 ( /W 32) Interrupt Enable Register */
-  __O  US_IDR_Type               IDR;         /**< \brief Offset: 0x0C ( /W 32) Interrupt Disable Register */
-  __I  US_IMR_Type               IMR;         /**< \brief Offset: 0x10 (R/  32) Interrupt Mask Register */
-  __I  US_CSR_Type               CSR;         /**< \brief Offset: 0x14 (R/  32) Channel Status Register */
-  __I  US_RHR_Type               RHR;         /**< \brief Offset: 0x18 (R/  32) Receiver Holding Register */
-  __O  US_THR_Type               THR;         /**< \brief Offset: 0x1C ( /W 32) Transmitter Holding Register */
-  __IO US_BRGR_Type              BRGR;        /**< \brief Offset: 0x20 (R/W 32) Baud Rate Generator Register */
-  __IO US_RTOR_Type              RTOR;        /**< \brief Offset: 0x24 (R/W 32) Receiver Time-out Register */
-  __IO US_TTGR_Type              TTGR;        /**< \brief Offset: 0x28 (R/W 32) Transmitter Timeguard Register */
-       RoReg8                    Reserved1[0x14];
-  __IO US_FIDI_Type              FIDI;        /**< \brief Offset: 0x40 (R/W 32) FI DI Ratio Register */
-  __I  US_NER_Type               NER;         /**< \brief Offset: 0x44 (R/  32) Number of Errors Register */
-       RoReg8                    Reserved2[0x4];
-  __IO US_IFR_Type               IFR;         /**< \brief Offset: 0x4C (R/W 32) IrDA Filter Register */
-  __IO US_MAN_Type               MAN;         /**< \brief Offset: 0x50 (R/W 32) Manchester Configuration Register */
-  __IO US_LINMR_Type             LINMR;       /**< \brief Offset: 0x54 (R/W 32) LIN Mode Register */
-  __IO US_LINIR_Type             LINIR;       /**< \brief Offset: 0x58 (R/W 32) LIN Identifier Register */
-  __I  US_LINBRR_Type            LINBRR;      /**< \brief Offset: 0x5C (R/  32) LIN Baud Rate Register */
-       RoReg8                    Reserved3[0x84];
-  __IO US_WPMR_Type              WPMR;        /**< \brief Offset: 0xE4 (R/W 32) Write Protect Mode Register */
-  __I  US_WPSR_Type              WPSR;        /**< \brief Offset: 0xE8 (R/  32) Write Protect Status Register */
-       RoReg8                    Reserved4[0x10];
-  __I  US_VERSION_Type           VERSION;     /**< \brief Offset: 0xFC (R/  32) Version Register */
- } bf;
- struct {
-  WoReg   US_CR;              /**< \brief (USART Offset: 0x00) Control Register */
-  RwReg   US_MR;              /**< \brief (USART Offset: 0x04) Mode Register */
-  WoReg   US_IER;             /**< \brief (USART Offset: 0x08) Interrupt Enable Register */
-  WoReg   US_IDR;             /**< \brief (USART Offset: 0x0C) Interrupt Disable Register */
-  RoReg   US_IMR;             /**< \brief (USART Offset: 0x10) Interrupt Mask Register */
-  RoReg   US_CSR;             /**< \brief (USART Offset: 0x14) Channel Status Register */
-  RoReg   US_RHR;             /**< \brief (USART Offset: 0x18) Receiver Holding Register */
-  WoReg   US_THR;             /**< \brief (USART Offset: 0x1C) Transmitter Holding Register */
-  RwReg   US_BRGR;            /**< \brief (USART Offset: 0x20) Baud Rate Generator Register */
-  RwReg   US_RTOR;            /**< \brief (USART Offset: 0x24) Receiver Time-out Register */
-  RwReg   US_TTGR;            /**< \brief (USART Offset: 0x28) Transmitter Timeguard Register */
-  RoReg8  Reserved5[0x14];
-  RwReg   US_FIDI;            /**< \brief (USART Offset: 0x40) FI DI Ratio Register */
-  RoReg   US_NER;             /**< \brief (USART Offset: 0x44) Number of Errors Register */
-  RoReg8  Reserved6[0x4];
-  RwReg   US_IFR;             /**< \brief (USART Offset: 0x4C) IrDA Filter Register */
-  RwReg   US_MAN;             /**< \brief (USART Offset: 0x50) Manchester Configuration Register */
-  RwReg   US_LINMR;           /**< \brief (USART Offset: 0x54) LIN Mode Register */
-  RwReg   US_LINIR;           /**< \brief (USART Offset: 0x58) LIN Identifier Register */
-  RoReg   US_LINBRR;          /**< \brief (USART Offset: 0x5C) LIN Baud Rate Register */
-  RoReg8  Reserved7[0x84];
-  RwReg   US_WPMR;            /**< \brief (USART Offset: 0xE4) Write Protect Mode Register */
-  RoReg   US_WPSR;            /**< \brief (USART Offset: 0xE8) Write Protect Status Register */
-  RoReg8  Reserved8[0x10];
-  RoReg   US_VERSION;         /**< \brief (USART Offset: 0xFC) Version Register */
- } reg;
+typedef struct {
+  __O  uint32_t US_CR;          /**< (USART Offset: 0x00) Control Register */
+  __IO uint32_t US_MR;          /**< (USART Offset: 0x04) Mode Register */
+  __O  uint32_t US_IER;         /**< (USART Offset: 0x08) Interrupt Enable Register */
+  __O  uint32_t US_IDR;         /**< (USART Offset: 0x0C) Interrupt Disable Register */
+  __I  uint32_t US_IMR;         /**< (USART Offset: 0x10) Interrupt Mask Register */
+  __I  uint32_t US_CSR;         /**< (USART Offset: 0x14) Channel Status Register */
+  __I  uint32_t US_RHR;         /**< (USART Offset: 0x18) Receive Holding Register */
+  __O  uint32_t US_THR;         /**< (USART Offset: 0x1C) Transmit Holding Register */
+  __IO uint32_t US_BRGR;        /**< (USART Offset: 0x20) Baud Rate Generator Register */
+  __IO uint32_t US_RTOR;        /**< (USART Offset: 0x24) Receiver Timeout Register */
+  __IO uint32_t US_TTGR;        /**< (USART Offset: 0x28) Transmitter Timeguard Register */
+  __I  uint8_t  Reserved1[20];
+  __IO uint32_t US_FIDI;        /**< (USART Offset: 0x40) FI DI Ratio Register */
+  __I  uint32_t US_NER;         /**< (USART Offset: 0x44) Number of Errors Register */
+  __I  uint8_t  Reserved2[4];
+  __IO uint32_t US_IF;          /**< (USART Offset: 0x4C) IrDA Filter Register */
+  __IO uint32_t US_MAN;         /**< (USART Offset: 0x50) Manchester Configuration Register */
+  __IO uint32_t US_LINMR;       /**< (USART Offset: 0x54) LIN Mode Register */
+  __IO uint32_t US_LINIR;       /**< (USART Offset: 0x58) LIN Identifier Register */
+  __I  uint32_t US_LINBRR;      /**< (USART Offset: 0x5C) LIN Baud Rate Register */
+  __I  uint8_t  Reserved3[132];
+  __IO uint32_t US_WPMR;        /**< (USART Offset: 0xE4) Write Protection Mode Register */
+  __I  uint32_t US_WPSR;        /**< (USART Offset: 0xE8) Write Protection Status Register */
+  __I  uint8_t  Reserved4[16];
+  __I  uint32_t US_VERSION;     /**< (USART Offset: 0xFC) Version Register */
 } Usart;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/usbc.h
+++ b/asf/sam/include/sam4l/component/usbc.h
@@ -7680,68 +7680,19 @@ typedef struct {
   __IO uint32_t UERST;       /**< \brief Offset: 0x01C (R/W 32) Endpoint Enable/Reset Register */
   __I  uint32_t UDFNUM;      /**< \brief Offset: 0x020 (R/  32) Device Frame Number Register */
        RoReg8   Reserved1[0xDC];
-  __IO uint32_t UECFG0;      /**< \brief Offset: 0x100 (R/W 32) Endpoint Configuration Register */
-  __IO uint32_t UECFG1;      /**< \brief Offset: 0x104 (R/W 32) Endpoint Configuration Register */
-  __IO uint32_t UECFG2;      /**< \brief Offset: 0x108 (R/W 32) Endpoint Configuration Register */
-  __IO uint32_t UECFG3;      /**< \brief Offset: 0x10C (R/W 32) Endpoint Configuration Register */
-  __IO uint32_t UECFG4;      /**< \brief Offset: 0x110 (R/W 32) Endpoint Configuration Register */
-  __IO uint32_t UECFG5;      /**< \brief Offset: 0x114 (R/W 32) Endpoint Configuration Register */
-  __IO uint32_t UECFG6;      /**< \brief Offset: 0x118 (R/W 32) Endpoint Configuration Register */
-  __IO uint32_t UECFG7;      /**< \brief Offset: 0x11C (R/W 32) Endpoint Configuration Register */
+  __IO uint32_t UECFG[8];    /**< \brief Offset: 0x100 (R/W 32) Endpoint Configuration Register */
        RoReg8   Reserved2[0x10];
-  __I  uint32_t UESTA0;      /**< \brief Offset: 0x130 (R/  32) Endpoint Status Register */
-  __I  uint32_t UESTA1;      /**< \brief Offset: 0x134 (R/  32) Endpoint Status Register */
-  __I  uint32_t UESTA2;      /**< \brief Offset: 0x138 (R/  32) Endpoint Status Register */
-  __I  uint32_t UESTA3;      /**< \brief Offset: 0x13C (R/  32) Endpoint Status Register */
-  __I  uint32_t UESTA4;      /**< \brief Offset: 0x140 (R/  32) Endpoint Status Register */
-  __I  uint32_t UESTA5;      /**< \brief Offset: 0x144 (R/  32) Endpoint Status Register */
-  __I  uint32_t UESTA6;      /**< \brief Offset: 0x148 (R/  32) Endpoint Status Register */
-  __I  uint32_t UESTA7;      /**< \brief Offset: 0x14C (R/  32) Endpoint Status Register */
+  __I  uint32_t UESTA[8];    /**< \brief Offset: 0x130 (R/  32) Endpoint Status Register */
        RoReg8   Reserved3[0x10];
-  __O  uint32_t UESTA0CLR;   /**< \brief Offset: 0x160 ( /W 32) Endpoint Status Clear Register */
-  __O  uint32_t UESTA1CLR;   /**< \brief Offset: 0x164 ( /W 32) Endpoint Status Clear Register */
-  __O  uint32_t UESTA2CLR;   /**< \brief Offset: 0x168 ( /W 32) Endpoint Status Clear Register */
-  __O  uint32_t UESTA3CLR;   /**< \brief Offset: 0x16C ( /W 32) Endpoint Status Clear Register */
-  __O  uint32_t UESTA4CLR;   /**< \brief Offset: 0x170 ( /W 32) Endpoint Status Clear Register */
-  __O  uint32_t UESTA5CLR;   /**< \brief Offset: 0x174 ( /W 32) Endpoint Status Clear Register */
-  __O  uint32_t UESTA6CLR;   /**< \brief Offset: 0x178 ( /W 32) Endpoint Status Clear Register */
-  __O  uint32_t UESTA7CLR;   /**< \brief Offset: 0x17C ( /W 32) Endpoint Status Clear Register */
+  __O  uint32_t UESTACLR[8]; /**< \brief Offset: 0x160 ( /W 32) Endpoint Status Clear Register */
        RoReg8   Reserved4[0x10];
-  __O  uint32_t UESTA0SET;   /**< \brief Offset: 0x190 ( /W 32) Endpoint Status Set Register */
-  __O  uint32_t UESTA1SET;   /**< \brief Offset: 0x194 ( /W 32) Endpoint Status Set Register */
-  __O  uint32_t UESTA2SET;   /**< \brief Offset: 0x198 ( /W 32) Endpoint Status Set Register */
-  __O  uint32_t UESTA3SET;   /**< \brief Offset: 0x19C ( /W 32) Endpoint Status Set Register */
-  __O  uint32_t UESTA4SET;   /**< \brief Offset: 0x1A0 ( /W 32) Endpoint Status Set Register */
-  __O  uint32_t UESTA5SET;   /**< \brief Offset: 0x1A4 ( /W 32) Endpoint Status Set Register */
-  __O  uint32_t UESTA6SET;   /**< \brief Offset: 0x1A8 ( /W 32) Endpoint Status Set Register */
-  __O  uint32_t UESTA7SET;   /**< \brief Offset: 0x1AC ( /W 32) Endpoint Status Set Register */
+  __O  uint32_t UESTASET[8]; /**< \brief Offset: 0x190 ( /W 32) Endpoint Status Set Register */
        RoReg8   Reserved5[0x10];
-  __I  uint32_t UECON0;      /**< \brief Offset: 0x1C0 (R/  32) Endpoint Control Register */
-  __I  uint32_t UECON1;      /**< \brief Offset: 0x1C4 (R/  32) Endpoint Control Register */
-  __I  uint32_t UECON2;      /**< \brief Offset: 0x1C8 (R/  32) Endpoint Control Register */
-  __I  uint32_t UECON3;      /**< \brief Offset: 0x1CC (R/  32) Endpoint Control Register */
-  __I  uint32_t UECON4;      /**< \brief Offset: 0x1D0 (R/  32) Endpoint Control Register */
-  __I  uint32_t UECON5;      /**< \brief Offset: 0x1D4 (R/  32) Endpoint Control Register */
-  __I  uint32_t UECON6;      /**< \brief Offset: 0x1D8 (R/  32) Endpoint Control Register */
-  __I  uint32_t UECON7;      /**< \brief Offset: 0x1DC (R/  32) Endpoint Control Register */
+  __I  uint32_t UECON[8];    /**< \brief Offset: 0x1C0 (R/  32) Endpoint Control Register */
        RoReg8   Reserved6[0x10];
-  __O  uint32_t UECON0SET;   /**< \brief Offset: 0x1F0 ( /W 32) Endpoint Control Set Register */
-  __O  uint32_t UECON1SET;   /**< \brief Offset: 0x1F4 ( /W 32) Endpoint Control Set Register */
-  __O  uint32_t UECON2SET;   /**< \brief Offset: 0x1F8 ( /W 32) Endpoint Control Set Register */
-  __O  uint32_t UECON3SET;   /**< \brief Offset: 0x1FC ( /W 32) Endpoint Control Set Register */
-  __O  uint32_t UECON4SET;   /**< \brief Offset: 0x200 ( /W 32) Endpoint Control Set Register */
-  __O  uint32_t UECON5SET;   /**< \brief Offset: 0x204 ( /W 32) Endpoint Control Set Register */
-  __O  uint32_t UECON6SET;   /**< \brief Offset: 0x208 ( /W 32) Endpoint Control Set Register */
-  __O  uint32_t UECON7SET;   /**< \brief Offset: 0x20C ( /W 32) Endpoint Control Set Register */
+  __O  uint32_t UECONSET[8]; /**< \brief Offset: 0x1F0 ( /W 32) Endpoint Control Set Register */
        RoReg8   Reserved7[0x10];
-  __O  uint32_t UECON0CLR;   /**< \brief Offset: 0x220 ( /W 32) Endpoint Control Clear Register */
-  __O  uint32_t UECON1CLR;   /**< \brief Offset: 0x224 ( /W 32) TXINE Clear */
-  __O  uint32_t UECON2CLR;   /**< \brief Offset: 0x228 ( /W 32) TXINE Clear */
-  __O  uint32_t UECON3CLR;   /**< \brief Offset: 0x22C ( /W 32) TXINE Clear */
-  __O  uint32_t UECON4CLR;   /**< \brief Offset: 0x230 ( /W 32) TXINE Clear */
-  __O  uint32_t UECON5CLR;   /**< \brief Offset: 0x234 ( /W 32) TXINE Clear */
-  __O  uint32_t UECON6CLR;   /**< \brief Offset: 0x238 ( /W 32) TXINE Clear */
-  __O  uint32_t UECON7CLR;   /**< \brief Offset: 0x23C ( /W 32) TXINE Clear */
+  __O  uint32_t UECONCLR[8]; /**< \brief Offset: 0x220 ( /W 32) Endpoint Control Clear Register */
        RoReg8   Reserved8[0x1C0];
   __IO uint32_t UHCON;       /**< \brief Offset: 0x400 (R/W 32) Host General Control Register */
   __I  uint32_t UHINT;       /**< \brief Offset: 0x404 (R/  32) Host Global Interrupt Register */
@@ -7754,77 +7705,21 @@ typedef struct {
   __IO uint32_t UHFNUM;      /**< \brief Offset: 0x420 (R/W 32) Host Frame Number Register */
   __IO uint32_t UHSOFC;      /**< \brief Offset: 0x424 (R/W 32) Host Start of Frame Control Register */
        RoReg8   Reserved9[0xD8];
-  __IO uint32_t UPCFG0;      /**< \brief Offset: 0x500 (R/W 32) Pipe Configuration Register */
-  __IO uint32_t UPCFG1;      /**< \brief Offset: 0x504 (R/W 32) Pipe Configuration Register */
-  __IO uint32_t UPCFG2;      /**< \brief Offset: 0x508 (R/W 32) Pipe Configuration Register */
-  __IO uint32_t UPCFG3;      /**< \brief Offset: 0x50C (R/W 32) Pipe Configuration Register */
-  __IO uint32_t UPCFG4;      /**< \brief Offset: 0x510 (R/W 32) Pipe Configuration Register */
-  __IO uint32_t UPCFG5;      /**< \brief Offset: 0x514 (R/W 32) Pipe Configuration Register */
-  __IO uint32_t UPCFG6;      /**< \brief Offset: 0x518 (R/W 32) Pipe Configuration Register */
-  __IO uint32_t UPCFG7;      /**< \brief Offset: 0x51C (R/W 32) Pipe Configuration Register */
+  __IO uint32_t UPCFG[8];    /**< \brief Offset: 0x500 (R/W 32) Pipe Configuration Register */
        RoReg8   Reserved10[0x10];
-  __I  uint32_t UPSTA0;      /**< \brief Offset: 0x530 (R/  32) Pipe Status Register */
-  __I  uint32_t UPSTA1;      /**< \brief Offset: 0x534 (R/  32) Pipe Status Register */
-  __I  uint32_t UPSTA2;      /**< \brief Offset: 0x538 (R/  32) Pipe Status Register */
-  __I  uint32_t UPSTA3;      /**< \brief Offset: 0x53C (R/  32) Pipe Status Register */
-  __I  uint32_t UPSTA4;      /**< \brief Offset: 0x540 (R/  32) Pipe Status Register */
-  __I  uint32_t UPSTA5;      /**< \brief Offset: 0x544 (R/  32) Pipe Status Register */
-  __I  uint32_t UPSTA6;      /**< \brief Offset: 0x548 (R/  32) Pipe Status Register */
-  __I  uint32_t UPSTA7;      /**< \brief Offset: 0x54C (R/  32) Pipe Status Register */
+  __I  uint32_t UPSTA[8];    /**< \brief Offset: 0x530 (R/  32) Pipe Status Register */
        RoReg8   Reserved11[0x10];
-  __O  uint32_t UPSTA0CLR;   /**< \brief Offset: 0x560 ( /W 32) Pipe Status Clear Register */
-  __O  uint32_t UPSTA1CLR;   /**< \brief Offset: 0x564 ( /W 32) Pipe Status Clear Register */
-  __O  uint32_t UPSTA2CLR;   /**< \brief Offset: 0x568 ( /W 32) Pipe Status Clear Register */
-  __O  uint32_t UPSTA3CLR;   /**< \brief Offset: 0x56C ( /W 32) Pipe Status Clear Register */
-  __O  uint32_t UPSTA4CLR;   /**< \brief Offset: 0x570 ( /W 32) Pipe Status Clear Register */
-  __O  uint32_t UPSTA5CLR;   /**< \brief Offset: 0x574 ( /W 32) Pipe Status Clear Register */
-  __O  uint32_t UPSTA6CLR;   /**< \brief Offset: 0x578 ( /W 32) Pipe Status Clear Register */
-  __O  uint32_t UPSTA7CLR;   /**< \brief Offset: 0x57C ( /W 32) Pipe Status Clear Register */
+  __O  uint32_t UPSTACLR[8]; /**< \brief Offset: 0x560 ( /W 32) Pipe Status Clear Register */
        RoReg8   Reserved12[0x10];
-  __O  uint32_t UPSTA0SET;   /**< \brief Offset: 0x590 ( /W 32) Pipe Status Set Register */
-  __O  uint32_t UPSTA1SET;   /**< \brief Offset: 0x594 ( /W 32) Pipe Status Set Register */
-  __O  uint32_t UPSTA2SET;   /**< \brief Offset: 0x598 ( /W 32) Pipe Status Set Register */
-  __O  uint32_t UPSTA3SET;   /**< \brief Offset: 0x59C ( /W 32) Pipe Status Set Register */
-  __O  uint32_t UPSTA4SET;   /**< \brief Offset: 0x5A0 ( /W 32) Pipe Status Set Register */
-  __O  uint32_t UPSTA5SET;   /**< \brief Offset: 0x5A4 ( /W 32) Pipe Status Set Register */
-  __O  uint32_t UPSTA6SET;   /**< \brief Offset: 0x5A8 ( /W 32) Pipe Status Set Register */
-  __O  uint32_t UPSTA7SET;   /**< \brief Offset: 0x5AC ( /W 32) Pipe Status Set Register */
+  __O  uint32_t UPSTASET[8]; /**< \brief Offset: 0x590 ( /W 32) Pipe Status Set Register */
        RoReg8   Reserved13[0x10];
-  __I  uint32_t UPCON0;      /**< \brief Offset: 0x5C0 (R/  32) Pipe Control Register */
-  __I  uint32_t UPCON1;      /**< \brief Offset: 0x5C4 (R/  32) Pipe Control Register */
-  __I  uint32_t UPCON2;      /**< \brief Offset: 0x5C8 (R/  32) Pipe Control Register */
-  __I  uint32_t UPCON3;      /**< \brief Offset: 0x5CC (R/  32) Pipe Control Register */
-  __I  uint32_t UPCON4;      /**< \brief Offset: 0x5D0 (R/  32) Pipe Control Register */
-  __I  uint32_t UPCON5;      /**< \brief Offset: 0x5D4 (R/  32) Pipe Control Register */
-  __I  uint32_t UPCON6;      /**< \brief Offset: 0x5D8 (R/  32) Pipe Control Register */
-  __I  uint32_t UPCON7;      /**< \brief Offset: 0x5DC (R/  32) Pipe Control Register */
+  __I  uint32_t UPCON[8];    /**< \brief Offset: 0x5C0 (R/  32) Pipe Control Register */
        RoReg8   Reserved14[0x10];
-  __O  uint32_t UPCON0SET;   /**< \brief Offset: 0x5F0 ( /W 32) Pipe Control Set Register */
-  __O  uint32_t UPCON1SET;   /**< \brief Offset: 0x5F4 ( /W 32) Pipe Control Set Register */
-  __O  uint32_t UPCON2SET;   /**< \brief Offset: 0x5F8 ( /W 32) Pipe Control Set Register */
-  __O  uint32_t UPCON3SET;   /**< \brief Offset: 0x5FC ( /W 32) Pipe Control Set Register */
-  __O  uint32_t UPCON4SET;   /**< \brief Offset: 0x600 ( /W 32) Pipe Control Set Register */
-  __O  uint32_t UPCON5SET;   /**< \brief Offset: 0x604 ( /W 32) Pipe Control Set Register */
-  __O  uint32_t UPCON6SET;   /**< \brief Offset: 0x608 ( /W 32) Pipe Control Set Register */
-  __O  uint32_t UPCON7SET;   /**< \brief Offset: 0x60C ( /W 32) Pipe Control Set Register */
+  __O  uint32_t UPCONSET[8]; /**< \brief Offset: 0x5F0 ( /W 32) Pipe Control Set Register */
        RoReg8   Reserved15[0x10];
-  __O  uint32_t UPCON0CLR;   /**< \brief Offset: 0x620 ( /W 32) Pipe Control Clear Register */
-  __O  uint32_t UPCON1CLR;   /**< \brief Offset: 0x624 ( /W 32) Pipe Control Clear Register */
-  __O  uint32_t UPCON2CLR;   /**< \brief Offset: 0x628 ( /W 32) Pipe Control Clear Register */
-  __O  uint32_t UPCON3CLR;   /**< \brief Offset: 0x62C ( /W 32) Pipe Control Clear Register */
-  __O  uint32_t UPCON4CLR;   /**< \brief Offset: 0x630 ( /W 32) Pipe Control Clear Register */
-  __O  uint32_t UPCON5CLR;   /**< \brief Offset: 0x634 ( /W 32) Pipe Control Clear Register */
-  __O  uint32_t UPCON6CLR;   /**< \brief Offset: 0x638 ( /W 32) Pipe Control Clear Register */
-  __O  uint32_t UPCON7CLR;   /**< \brief Offset: 0x63C ( /W 32) Pipe Control Clear Register */
+  __O  uint32_t UPCONCLR[8]; /**< \brief Offset: 0x620 ( /W 32) Pipe Control Clear Register */
        RoReg8   Reserved16[0x10];
-  __IO uint32_t UPINRQ0;     /**< \brief Offset: 0x650 (R/W 32) Pipe In Request */
-  __IO uint32_t UPINRQ1;     /**< \brief Offset: 0x654 (R/W 32) Pipe In Request */
-  __IO uint32_t UPINRQ2;     /**< \brief Offset: 0x658 (R/W 32) Pipe In Request */
-  __IO uint32_t UPINRQ3;     /**< \brief Offset: 0x65C (R/W 32) Pipe In Request */
-  __IO uint32_t UPINRQ4;     /**< \brief Offset: 0x660 (R/W 32) Pipe In Request */
-  __IO uint32_t UPINRQ5;     /**< \brief Offset: 0x664 (R/W 32) Pipe In Request */
-  __IO uint32_t UPINRQ6;     /**< \brief Offset: 0x668 (R/W 32) Pipe In Request */
-  __IO uint32_t UPINRQ7;     /**< \brief Offset: 0x66C (R/W 32) Pipe In Request */
+  __IO uint32_t UPINRQ[8];   /**< \brief Offset: 0x650 (R/W 32) Pipe In Request */
        RoReg8   Reserved17[0x190];
   __IO uint32_t USBCON;      /**< \brief Offset: 0x800 (R/W 32) General Control Register */
   __I  uint32_t USBSTA;      /**< \brief Offset: 0x804 (R/  32) General Status Register */

--- a/asf/sam/include/sam4l/component/usbc.h
+++ b/asf/sam/include/sam4l/component/usbc.h
@@ -7669,347 +7669,175 @@ typedef union {
 
 /** \brief USBC hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __IO USBC_UDCON_Type           UDCON;       /**< \brief Offset: 0x000 (R/W 32) Device General Control Register */
-  __I  USBC_UDINT_Type           UDINT;       /**< \brief Offset: 0x004 (R/  32) Device Global Interupt Register */
-  __O  USBC_UDINTCLR_Type        UDINTCLR;    /**< \brief Offset: 0x008 ( /W 32) Device Global Interrupt Clear Register */
-  __O  USBC_UDINTSET_Type        UDINTSET;    /**< \brief Offset: 0x00C ( /W 32) Device Global Interrupt Set Regsiter */
-  __I  USBC_UDINTE_Type          UDINTE;      /**< \brief Offset: 0x010 (R/  32) Device Global Interrupt Enable Register */
-  __O  USBC_UDINTECLR_Type       UDINTECLR;   /**< \brief Offset: 0x014 ( /W 32) Device Global Interrupt Enable Clear Register */
-  __O  USBC_UDINTESET_Type       UDINTESET;   /**< \brief Offset: 0x018 ( /W 32) Device Global Interrupt Enable Set Register */
-  __IO USBC_UERST_Type           UERST;       /**< \brief Offset: 0x01C (R/W 32) Endpoint Enable/Reset Register */
-  __I  USBC_UDFNUM_Type          UDFNUM;      /**< \brief Offset: 0x020 (R/  32) Device Frame Number Register */
-       RoReg8                    Reserved1[0xDC];
-  __IO USBC_UECFG0_Type          UECFG0;      /**< \brief Offset: 0x100 (R/W 32) Endpoint Configuration Register */
-  __IO USBC_UECFG1_Type          UECFG1;      /**< \brief Offset: 0x104 (R/W 32) Endpoint Configuration Register */
-  __IO USBC_UECFG2_Type          UECFG2;      /**< \brief Offset: 0x108 (R/W 32) Endpoint Configuration Register */
-  __IO USBC_UECFG3_Type          UECFG3;      /**< \brief Offset: 0x10C (R/W 32) Endpoint Configuration Register */
-  __IO USBC_UECFG4_Type          UECFG4;      /**< \brief Offset: 0x110 (R/W 32) Endpoint Configuration Register */
-  __IO USBC_UECFG5_Type          UECFG5;      /**< \brief Offset: 0x114 (R/W 32) Endpoint Configuration Register */
-  __IO USBC_UECFG6_Type          UECFG6;      /**< \brief Offset: 0x118 (R/W 32) Endpoint Configuration Register */
-  __IO USBC_UECFG7_Type          UECFG7;      /**< \brief Offset: 0x11C (R/W 32) Endpoint Configuration Register */
-       RoReg8                    Reserved2[0x10];
-  __I  USBC_UESTA0_Type          UESTA0;      /**< \brief Offset: 0x130 (R/  32) Endpoint Status Register */
-  __I  USBC_UESTA1_Type          UESTA1;      /**< \brief Offset: 0x134 (R/  32) Endpoint Status Register */
-  __I  USBC_UESTA2_Type          UESTA2;      /**< \brief Offset: 0x138 (R/  32) Endpoint Status Register */
-  __I  USBC_UESTA3_Type          UESTA3;      /**< \brief Offset: 0x13C (R/  32) Endpoint Status Register */
-  __I  USBC_UESTA4_Type          UESTA4;      /**< \brief Offset: 0x140 (R/  32) Endpoint Status Register */
-  __I  USBC_UESTA5_Type          UESTA5;      /**< \brief Offset: 0x144 (R/  32) Endpoint Status Register */
-  __I  USBC_UESTA6_Type          UESTA6;      /**< \brief Offset: 0x148 (R/  32) Endpoint Status Register */
-  __I  USBC_UESTA7_Type          UESTA7;      /**< \brief Offset: 0x14C (R/  32) Endpoint Status Register */
-       RoReg8                    Reserved3[0x10];
-  __O  USBC_UESTA0CLR_Type       UESTA0CLR;   /**< \brief Offset: 0x160 ( /W 32) Endpoint Status Clear Register */
-  __O  USBC_UESTA1CLR_Type       UESTA1CLR;   /**< \brief Offset: 0x164 ( /W 32) Endpoint Status Clear Register */
-  __O  USBC_UESTA2CLR_Type       UESTA2CLR;   /**< \brief Offset: 0x168 ( /W 32) Endpoint Status Clear Register */
-  __O  USBC_UESTA3CLR_Type       UESTA3CLR;   /**< \brief Offset: 0x16C ( /W 32) Endpoint Status Clear Register */
-  __O  USBC_UESTA4CLR_Type       UESTA4CLR;   /**< \brief Offset: 0x170 ( /W 32) Endpoint Status Clear Register */
-  __O  USBC_UESTA5CLR_Type       UESTA5CLR;   /**< \brief Offset: 0x174 ( /W 32) Endpoint Status Clear Register */
-  __O  USBC_UESTA6CLR_Type       UESTA6CLR;   /**< \brief Offset: 0x178 ( /W 32) Endpoint Status Clear Register */
-  __O  USBC_UESTA7CLR_Type       UESTA7CLR;   /**< \brief Offset: 0x17C ( /W 32) Endpoint Status Clear Register */
-       RoReg8                    Reserved4[0x10];
-  __O  USBC_UESTA0SET_Type       UESTA0SET;   /**< \brief Offset: 0x190 ( /W 32) Endpoint Status Set Register */
-  __O  USBC_UESTA1SET_Type       UESTA1SET;   /**< \brief Offset: 0x194 ( /W 32) Endpoint Status Set Register */
-  __O  USBC_UESTA2SET_Type       UESTA2SET;   /**< \brief Offset: 0x198 ( /W 32) Endpoint Status Set Register */
-  __O  USBC_UESTA3SET_Type       UESTA3SET;   /**< \brief Offset: 0x19C ( /W 32) Endpoint Status Set Register */
-  __O  USBC_UESTA4SET_Type       UESTA4SET;   /**< \brief Offset: 0x1A0 ( /W 32) Endpoint Status Set Register */
-  __O  USBC_UESTA5SET_Type       UESTA5SET;   /**< \brief Offset: 0x1A4 ( /W 32) Endpoint Status Set Register */
-  __O  USBC_UESTA6SET_Type       UESTA6SET;   /**< \brief Offset: 0x1A8 ( /W 32) Endpoint Status Set Register */
-  __O  USBC_UESTA7SET_Type       UESTA7SET;   /**< \brief Offset: 0x1AC ( /W 32) Endpoint Status Set Register */
-       RoReg8                    Reserved5[0x10];
-  __I  USBC_UECON0_Type          UECON0;      /**< \brief Offset: 0x1C0 (R/  32) Endpoint Control Register */
-  __I  USBC_UECON1_Type          UECON1;      /**< \brief Offset: 0x1C4 (R/  32) Endpoint Control Register */
-  __I  USBC_UECON2_Type          UECON2;      /**< \brief Offset: 0x1C8 (R/  32) Endpoint Control Register */
-  __I  USBC_UECON3_Type          UECON3;      /**< \brief Offset: 0x1CC (R/  32) Endpoint Control Register */
-  __I  USBC_UECON4_Type          UECON4;      /**< \brief Offset: 0x1D0 (R/  32) Endpoint Control Register */
-  __I  USBC_UECON5_Type          UECON5;      /**< \brief Offset: 0x1D4 (R/  32) Endpoint Control Register */
-  __I  USBC_UECON6_Type          UECON6;      /**< \brief Offset: 0x1D8 (R/  32) Endpoint Control Register */
-  __I  USBC_UECON7_Type          UECON7;      /**< \brief Offset: 0x1DC (R/  32) Endpoint Control Register */
-       RoReg8                    Reserved6[0x10];
-  __O  USBC_UECON0SET_Type       UECON0SET;   /**< \brief Offset: 0x1F0 ( /W 32) Endpoint Control Set Register */
-  __O  USBC_UECON1SET_Type       UECON1SET;   /**< \brief Offset: 0x1F4 ( /W 32) Endpoint Control Set Register */
-  __O  USBC_UECON2SET_Type       UECON2SET;   /**< \brief Offset: 0x1F8 ( /W 32) Endpoint Control Set Register */
-  __O  USBC_UECON3SET_Type       UECON3SET;   /**< \brief Offset: 0x1FC ( /W 32) Endpoint Control Set Register */
-  __O  USBC_UECON4SET_Type       UECON4SET;   /**< \brief Offset: 0x200 ( /W 32) Endpoint Control Set Register */
-  __O  USBC_UECON5SET_Type       UECON5SET;   /**< \brief Offset: 0x204 ( /W 32) Endpoint Control Set Register */
-  __O  USBC_UECON6SET_Type       UECON6SET;   /**< \brief Offset: 0x208 ( /W 32) Endpoint Control Set Register */
-  __O  USBC_UECON7SET_Type       UECON7SET;   /**< \brief Offset: 0x20C ( /W 32) Endpoint Control Set Register */
-       RoReg8                    Reserved7[0x10];
-  __O  USBC_UECON0CLR_Type       UECON0CLR;   /**< \brief Offset: 0x220 ( /W 32) Endpoint Control Clear Register */
-  __O  USBC_UECON1CLR_Type       UECON1CLR;   /**< \brief Offset: 0x224 ( /W 32) TXINE Clear */
-  __O  USBC_UECON2CLR_Type       UECON2CLR;   /**< \brief Offset: 0x228 ( /W 32) TXINE Clear */
-  __O  USBC_UECON3CLR_Type       UECON3CLR;   /**< \brief Offset: 0x22C ( /W 32) TXINE Clear */
-  __O  USBC_UECON4CLR_Type       UECON4CLR;   /**< \brief Offset: 0x230 ( /W 32) TXINE Clear */
-  __O  USBC_UECON5CLR_Type       UECON5CLR;   /**< \brief Offset: 0x234 ( /W 32) TXINE Clear */
-  __O  USBC_UECON6CLR_Type       UECON6CLR;   /**< \brief Offset: 0x238 ( /W 32) TXINE Clear */
-  __O  USBC_UECON7CLR_Type       UECON7CLR;   /**< \brief Offset: 0x23C ( /W 32) TXINE Clear */
-       RoReg8                    Reserved8[0x1C0];
-  __IO USBC_UHCON_Type           UHCON;       /**< \brief Offset: 0x400 (R/W 32) Host General Control Register */
-  __I  USBC_UHINT_Type           UHINT;       /**< \brief Offset: 0x404 (R/  32) Host Global Interrupt Register */
-  __O  USBC_UHINTCLR_Type        UHINTCLR;    /**< \brief Offset: 0x408 ( /W 32) Host Global Interrrupt Clear Register */
-  __O  USBC_UHINTSET_Type        UHINTSET;    /**< \brief Offset: 0x40C ( /W 32) Host Global Interrupt Set Register */
-  __I  USBC_UHINTE_Type          UHINTE;      /**< \brief Offset: 0x410 (R/  32) Host Global Interrupt Enable Register */
-  __O  USBC_UHINTECLR_Type       UHINTECLR;   /**< \brief Offset: 0x414 ( /W 32) Host Global Interrupt Enable Clear Register */
-  __O  USBC_UHINTESET_Type       UHINTESET;   /**< \brief Offset: 0x418 ( /W 32) Host Global Interrupt Enable Set Register */
-  __IO USBC_UPRST_Type           UPRST;       /**< \brief Offset: 0x41C (R/W 32) Pipe Reset Register */
-  __IO USBC_UHFNUM_Type          UHFNUM;      /**< \brief Offset: 0x420 (R/W 32) Host Frame Number Register */
-  __IO USBC_UHSOFC_Type          UHSOFC;      /**< \brief Offset: 0x424 (R/W 32) Host Start of Frame Control Register */
-       RoReg8                    Reserved9[0xD8];
-  __IO USBC_UPCFG0_Type          UPCFG0;      /**< \brief Offset: 0x500 (R/W 32) Pipe Configuration Register */
-  __IO USBC_UPCFG1_Type          UPCFG1;      /**< \brief Offset: 0x504 (R/W 32) Pipe Configuration Register */
-  __IO USBC_UPCFG2_Type          UPCFG2;      /**< \brief Offset: 0x508 (R/W 32) Pipe Configuration Register */
-  __IO USBC_UPCFG3_Type          UPCFG3;      /**< \brief Offset: 0x50C (R/W 32) Pipe Configuration Register */
-  __IO USBC_UPCFG4_Type          UPCFG4;      /**< \brief Offset: 0x510 (R/W 32) Pipe Configuration Register */
-  __IO USBC_UPCFG5_Type          UPCFG5;      /**< \brief Offset: 0x514 (R/W 32) Pipe Configuration Register */
-  __IO USBC_UPCFG6_Type          UPCFG6;      /**< \brief Offset: 0x518 (R/W 32) Pipe Configuration Register */
-  __IO USBC_UPCFG7_Type          UPCFG7;      /**< \brief Offset: 0x51C (R/W 32) Pipe Configuration Register */
-       RoReg8                    Reserved10[0x10];
-  __I  USBC_UPSTA0_Type          UPSTA0;      /**< \brief Offset: 0x530 (R/  32) Pipe Status Register */
-  __I  USBC_UPSTA1_Type          UPSTA1;      /**< \brief Offset: 0x534 (R/  32) Pipe Status Register */
-  __I  USBC_UPSTA2_Type          UPSTA2;      /**< \brief Offset: 0x538 (R/  32) Pipe Status Register */
-  __I  USBC_UPSTA3_Type          UPSTA3;      /**< \brief Offset: 0x53C (R/  32) Pipe Status Register */
-  __I  USBC_UPSTA4_Type          UPSTA4;      /**< \brief Offset: 0x540 (R/  32) Pipe Status Register */
-  __I  USBC_UPSTA5_Type          UPSTA5;      /**< \brief Offset: 0x544 (R/  32) Pipe Status Register */
-  __I  USBC_UPSTA6_Type          UPSTA6;      /**< \brief Offset: 0x548 (R/  32) Pipe Status Register */
-  __I  USBC_UPSTA7_Type          UPSTA7;      /**< \brief Offset: 0x54C (R/  32) Pipe Status Register */
-       RoReg8                    Reserved11[0x10];
-  __O  USBC_UPSTA0CLR_Type       UPSTA0CLR;   /**< \brief Offset: 0x560 ( /W 32) Pipe Status Clear Register */
-  __O  USBC_UPSTA1CLR_Type       UPSTA1CLR;   /**< \brief Offset: 0x564 ( /W 32) Pipe Status Clear Register */
-  __O  USBC_UPSTA2CLR_Type       UPSTA2CLR;   /**< \brief Offset: 0x568 ( /W 32) Pipe Status Clear Register */
-  __O  USBC_UPSTA3CLR_Type       UPSTA3CLR;   /**< \brief Offset: 0x56C ( /W 32) Pipe Status Clear Register */
-  __O  USBC_UPSTA4CLR_Type       UPSTA4CLR;   /**< \brief Offset: 0x570 ( /W 32) Pipe Status Clear Register */
-  __O  USBC_UPSTA5CLR_Type       UPSTA5CLR;   /**< \brief Offset: 0x574 ( /W 32) Pipe Status Clear Register */
-  __O  USBC_UPSTA6CLR_Type       UPSTA6CLR;   /**< \brief Offset: 0x578 ( /W 32) Pipe Status Clear Register */
-  __O  USBC_UPSTA7CLR_Type       UPSTA7CLR;   /**< \brief Offset: 0x57C ( /W 32) Pipe Status Clear Register */
-       RoReg8                    Reserved12[0x10];
-  __O  USBC_UPSTA0SET_Type       UPSTA0SET;   /**< \brief Offset: 0x590 ( /W 32) Pipe Status Set Register */
-  __O  USBC_UPSTA1SET_Type       UPSTA1SET;   /**< \brief Offset: 0x594 ( /W 32) Pipe Status Set Register */
-  __O  USBC_UPSTA2SET_Type       UPSTA2SET;   /**< \brief Offset: 0x598 ( /W 32) Pipe Status Set Register */
-  __O  USBC_UPSTA3SET_Type       UPSTA3SET;   /**< \brief Offset: 0x59C ( /W 32) Pipe Status Set Register */
-  __O  USBC_UPSTA4SET_Type       UPSTA4SET;   /**< \brief Offset: 0x5A0 ( /W 32) Pipe Status Set Register */
-  __O  USBC_UPSTA5SET_Type       UPSTA5SET;   /**< \brief Offset: 0x5A4 ( /W 32) Pipe Status Set Register */
-  __O  USBC_UPSTA6SET_Type       UPSTA6SET;   /**< \brief Offset: 0x5A8 ( /W 32) Pipe Status Set Register */
-  __O  USBC_UPSTA7SET_Type       UPSTA7SET;   /**< \brief Offset: 0x5AC ( /W 32) Pipe Status Set Register */
-       RoReg8                    Reserved13[0x10];
-  __I  USBC_UPCON0_Type          UPCON0;      /**< \brief Offset: 0x5C0 (R/  32) Pipe Control Register */
-  __I  USBC_UPCON1_Type          UPCON1;      /**< \brief Offset: 0x5C4 (R/  32) Pipe Control Register */
-  __I  USBC_UPCON2_Type          UPCON2;      /**< \brief Offset: 0x5C8 (R/  32) Pipe Control Register */
-  __I  USBC_UPCON3_Type          UPCON3;      /**< \brief Offset: 0x5CC (R/  32) Pipe Control Register */
-  __I  USBC_UPCON4_Type          UPCON4;      /**< \brief Offset: 0x5D0 (R/  32) Pipe Control Register */
-  __I  USBC_UPCON5_Type          UPCON5;      /**< \brief Offset: 0x5D4 (R/  32) Pipe Control Register */
-  __I  USBC_UPCON6_Type          UPCON6;      /**< \brief Offset: 0x5D8 (R/  32) Pipe Control Register */
-  __I  USBC_UPCON7_Type          UPCON7;      /**< \brief Offset: 0x5DC (R/  32) Pipe Control Register */
-       RoReg8                    Reserved14[0x10];
-  __O  USBC_UPCON0SET_Type       UPCON0SET;   /**< \brief Offset: 0x5F0 ( /W 32) Pipe Control Set Register */
-  __O  USBC_UPCON1SET_Type       UPCON1SET;   /**< \brief Offset: 0x5F4 ( /W 32) Pipe Control Set Register */
-  __O  USBC_UPCON2SET_Type       UPCON2SET;   /**< \brief Offset: 0x5F8 ( /W 32) Pipe Control Set Register */
-  __O  USBC_UPCON3SET_Type       UPCON3SET;   /**< \brief Offset: 0x5FC ( /W 32) Pipe Control Set Register */
-  __O  USBC_UPCON4SET_Type       UPCON4SET;   /**< \brief Offset: 0x600 ( /W 32) Pipe Control Set Register */
-  __O  USBC_UPCON5SET_Type       UPCON5SET;   /**< \brief Offset: 0x604 ( /W 32) Pipe Control Set Register */
-  __O  USBC_UPCON6SET_Type       UPCON6SET;   /**< \brief Offset: 0x608 ( /W 32) Pipe Control Set Register */
-  __O  USBC_UPCON7SET_Type       UPCON7SET;   /**< \brief Offset: 0x60C ( /W 32) Pipe Control Set Register */
-       RoReg8                    Reserved15[0x10];
-  __O  USBC_UPCON0CLR_Type       UPCON0CLR;   /**< \brief Offset: 0x620 ( /W 32) Pipe Control Clear Register */
-  __O  USBC_UPCON1CLR_Type       UPCON1CLR;   /**< \brief Offset: 0x624 ( /W 32) Pipe Control Clear Register */
-  __O  USBC_UPCON2CLR_Type       UPCON2CLR;   /**< \brief Offset: 0x628 ( /W 32) Pipe Control Clear Register */
-  __O  USBC_UPCON3CLR_Type       UPCON3CLR;   /**< \brief Offset: 0x62C ( /W 32) Pipe Control Clear Register */
-  __O  USBC_UPCON4CLR_Type       UPCON4CLR;   /**< \brief Offset: 0x630 ( /W 32) Pipe Control Clear Register */
-  __O  USBC_UPCON5CLR_Type       UPCON5CLR;   /**< \brief Offset: 0x634 ( /W 32) Pipe Control Clear Register */
-  __O  USBC_UPCON6CLR_Type       UPCON6CLR;   /**< \brief Offset: 0x638 ( /W 32) Pipe Control Clear Register */
-  __O  USBC_UPCON7CLR_Type       UPCON7CLR;   /**< \brief Offset: 0x63C ( /W 32) Pipe Control Clear Register */
-       RoReg8                    Reserved16[0x10];
-  __IO USBC_UPINRQ0_Type         UPINRQ0;     /**< \brief Offset: 0x650 (R/W 32) Pipe In Request */
-  __IO USBC_UPINRQ1_Type         UPINRQ1;     /**< \brief Offset: 0x654 (R/W 32) Pipe In Request */
-  __IO USBC_UPINRQ2_Type         UPINRQ2;     /**< \brief Offset: 0x658 (R/W 32) Pipe In Request */
-  __IO USBC_UPINRQ3_Type         UPINRQ3;     /**< \brief Offset: 0x65C (R/W 32) Pipe In Request */
-  __IO USBC_UPINRQ4_Type         UPINRQ4;     /**< \brief Offset: 0x660 (R/W 32) Pipe In Request */
-  __IO USBC_UPINRQ5_Type         UPINRQ5;     /**< \brief Offset: 0x664 (R/W 32) Pipe In Request */
-  __IO USBC_UPINRQ6_Type         UPINRQ6;     /**< \brief Offset: 0x668 (R/W 32) Pipe In Request */
-  __IO USBC_UPINRQ7_Type         UPINRQ7;     /**< \brief Offset: 0x66C (R/W 32) Pipe In Request */
-       RoReg8                    Reserved17[0x190];
-  __IO USBC_USBCON_Type          USBCON;      /**< \brief Offset: 0x800 (R/W 32) General Control Register */
-  __I  USBC_USBSTA_Type          USBSTA;      /**< \brief Offset: 0x804 (R/  32) General Status Register */
-  __O  USBC_USBSTACLR_Type       USBSTACLR;   /**< \brief Offset: 0x808 ( /W 32) General Status Clear Register */
-  __O  USBC_USBSTASET_Type       USBSTASET;   /**< \brief Offset: 0x80C ( /W 32) General Status Set Register */
-       RoReg8                    Reserved18[0x8];
-  __I  USBC_UVERS_Type           UVERS;       /**< \brief Offset: 0x818 (R/  32) IP Version Register */
-  __I  USBC_UFEATURES_Type       UFEATURES;   /**< \brief Offset: 0x81C (R/  32) IP Features Register */
-  __I  USBC_UADDRSIZE_Type       UADDRSIZE;   /**< \brief Offset: 0x820 (R/  32) IP PB address size Register */
-  __I  USBC_UNAME1_Type          UNAME1;      /**< \brief Offset: 0x824 (R/  32) IP Name Part One: HUSB */
-  __I  USBC_UNAME2_Type          UNAME2;      /**< \brief Offset: 0x828 (R/  32) IP Name Part Two: HOST */
-  __I  USBC_USBFSM_Type          USBFSM;      /**< \brief Offset: 0x82C (R/  32) USB internal finite state machine */
-  __IO USBC_UDESC_Type           UDESC;       /**< \brief Offset: 0x830 (R/W 32) Endpoint descriptor table */
- } bf;
- struct {
-  RwReg   USBC_UDCON;         /**< \brief (USBC Offset: 0x000) Device General Control Register */
-  RoReg   USBC_UDINT;         /**< \brief (USBC Offset: 0x004) Device Global Interupt Register */
-  WoReg   USBC_UDINTCLR;      /**< \brief (USBC Offset: 0x008) Device Global Interrupt Clear Register */
-  WoReg   USBC_UDINTSET;      /**< \brief (USBC Offset: 0x00C) Device Global Interrupt Set Regsiter */
-  RoReg   USBC_UDINTE;        /**< \brief (USBC Offset: 0x010) Device Global Interrupt Enable Register */
-  WoReg   USBC_UDINTECLR;     /**< \brief (USBC Offset: 0x014) Device Global Interrupt Enable Clear Register */
-  WoReg   USBC_UDINTESET;     /**< \brief (USBC Offset: 0x018) Device Global Interrupt Enable Set Register */
-  RwReg   USBC_UERST;         /**< \brief (USBC Offset: 0x01C) Endpoint Enable/Reset Register */
-  RoReg   USBC_UDFNUM;        /**< \brief (USBC Offset: 0x020) Device Frame Number Register */
-  RoReg8  Reserved19[0xDC];
-  RwReg   USBC_UECFG0;        /**< \brief (USBC Offset: 0x100) Endpoint Configuration Register */
-  RwReg   USBC_UECFG1;        /**< \brief (USBC Offset: 0x104) Endpoint Configuration Register */
-  RwReg   USBC_UECFG2;        /**< \brief (USBC Offset: 0x108) Endpoint Configuration Register */
-  RwReg   USBC_UECFG3;        /**< \brief (USBC Offset: 0x10C) Endpoint Configuration Register */
-  RwReg   USBC_UECFG4;        /**< \brief (USBC Offset: 0x110) Endpoint Configuration Register */
-  RwReg   USBC_UECFG5;        /**< \brief (USBC Offset: 0x114) Endpoint Configuration Register */
-  RwReg   USBC_UECFG6;        /**< \brief (USBC Offset: 0x118) Endpoint Configuration Register */
-  RwReg   USBC_UECFG7;        /**< \brief (USBC Offset: 0x11C) Endpoint Configuration Register */
-  RoReg8  Reserved20[0x10];
-  RoReg   USBC_UESTA0;        /**< \brief (USBC Offset: 0x130) Endpoint Status Register */
-  RoReg   USBC_UESTA1;        /**< \brief (USBC Offset: 0x134) Endpoint Status Register */
-  RoReg   USBC_UESTA2;        /**< \brief (USBC Offset: 0x138) Endpoint Status Register */
-  RoReg   USBC_UESTA3;        /**< \brief (USBC Offset: 0x13C) Endpoint Status Register */
-  RoReg   USBC_UESTA4;        /**< \brief (USBC Offset: 0x140) Endpoint Status Register */
-  RoReg   USBC_UESTA5;        /**< \brief (USBC Offset: 0x144) Endpoint Status Register */
-  RoReg   USBC_UESTA6;        /**< \brief (USBC Offset: 0x148) Endpoint Status Register */
-  RoReg   USBC_UESTA7;        /**< \brief (USBC Offset: 0x14C) Endpoint Status Register */
-  RoReg8  Reserved21[0x10];
-  WoReg   USBC_UESTA0CLR;     /**< \brief (USBC Offset: 0x160) Endpoint Status Clear Register */
-  WoReg   USBC_UESTA1CLR;     /**< \brief (USBC Offset: 0x164) Endpoint Status Clear Register */
-  WoReg   USBC_UESTA2CLR;     /**< \brief (USBC Offset: 0x168) Endpoint Status Clear Register */
-  WoReg   USBC_UESTA3CLR;     /**< \brief (USBC Offset: 0x16C) Endpoint Status Clear Register */
-  WoReg   USBC_UESTA4CLR;     /**< \brief (USBC Offset: 0x170) Endpoint Status Clear Register */
-  WoReg   USBC_UESTA5CLR;     /**< \brief (USBC Offset: 0x174) Endpoint Status Clear Register */
-  WoReg   USBC_UESTA6CLR;     /**< \brief (USBC Offset: 0x178) Endpoint Status Clear Register */
-  WoReg   USBC_UESTA7CLR;     /**< \brief (USBC Offset: 0x17C) Endpoint Status Clear Register */
-  RoReg8  Reserved22[0x10];
-  WoReg   USBC_UESTA0SET;     /**< \brief (USBC Offset: 0x190) Endpoint Status Set Register */
-  WoReg   USBC_UESTA1SET;     /**< \brief (USBC Offset: 0x194) Endpoint Status Set Register */
-  WoReg   USBC_UESTA2SET;     /**< \brief (USBC Offset: 0x198) Endpoint Status Set Register */
-  WoReg   USBC_UESTA3SET;     /**< \brief (USBC Offset: 0x19C) Endpoint Status Set Register */
-  WoReg   USBC_UESTA4SET;     /**< \brief (USBC Offset: 0x1A0) Endpoint Status Set Register */
-  WoReg   USBC_UESTA5SET;     /**< \brief (USBC Offset: 0x1A4) Endpoint Status Set Register */
-  WoReg   USBC_UESTA6SET;     /**< \brief (USBC Offset: 0x1A8) Endpoint Status Set Register */
-  WoReg   USBC_UESTA7SET;     /**< \brief (USBC Offset: 0x1AC) Endpoint Status Set Register */
-  RoReg8  Reserved23[0x10];
-  RoReg   USBC_UECON0;        /**< \brief (USBC Offset: 0x1C0) Endpoint Control Register */
-  RoReg   USBC_UECON1;        /**< \brief (USBC Offset: 0x1C4) Endpoint Control Register */
-  RoReg   USBC_UECON2;        /**< \brief (USBC Offset: 0x1C8) Endpoint Control Register */
-  RoReg   USBC_UECON3;        /**< \brief (USBC Offset: 0x1CC) Endpoint Control Register */
-  RoReg   USBC_UECON4;        /**< \brief (USBC Offset: 0x1D0) Endpoint Control Register */
-  RoReg   USBC_UECON5;        /**< \brief (USBC Offset: 0x1D4) Endpoint Control Register */
-  RoReg   USBC_UECON6;        /**< \brief (USBC Offset: 0x1D8) Endpoint Control Register */
-  RoReg   USBC_UECON7;        /**< \brief (USBC Offset: 0x1DC) Endpoint Control Register */
-  RoReg8  Reserved24[0x10];
-  WoReg   USBC_UECON0SET;     /**< \brief (USBC Offset: 0x1F0) Endpoint Control Set Register */
-  WoReg   USBC_UECON1SET;     /**< \brief (USBC Offset: 0x1F4) Endpoint Control Set Register */
-  WoReg   USBC_UECON2SET;     /**< \brief (USBC Offset: 0x1F8) Endpoint Control Set Register */
-  WoReg   USBC_UECON3SET;     /**< \brief (USBC Offset: 0x1FC) Endpoint Control Set Register */
-  WoReg   USBC_UECON4SET;     /**< \brief (USBC Offset: 0x200) Endpoint Control Set Register */
-  WoReg   USBC_UECON5SET;     /**< \brief (USBC Offset: 0x204) Endpoint Control Set Register */
-  WoReg   USBC_UECON6SET;     /**< \brief (USBC Offset: 0x208) Endpoint Control Set Register */
-  WoReg   USBC_UECON7SET;     /**< \brief (USBC Offset: 0x20C) Endpoint Control Set Register */
-  RoReg8  Reserved25[0x10];
-  WoReg   USBC_UECON0CLR;     /**< \brief (USBC Offset: 0x220) Endpoint Control Clear Register */
-  WoReg   USBC_UECON1CLR;     /**< \brief (USBC Offset: 0x224) TXINE Clear */
-  WoReg   USBC_UECON2CLR;     /**< \brief (USBC Offset: 0x228) TXINE Clear */
-  WoReg   USBC_UECON3CLR;     /**< \brief (USBC Offset: 0x22C) TXINE Clear */
-  WoReg   USBC_UECON4CLR;     /**< \brief (USBC Offset: 0x230) TXINE Clear */
-  WoReg   USBC_UECON5CLR;     /**< \brief (USBC Offset: 0x234) TXINE Clear */
-  WoReg   USBC_UECON6CLR;     /**< \brief (USBC Offset: 0x238) TXINE Clear */
-  WoReg   USBC_UECON7CLR;     /**< \brief (USBC Offset: 0x23C) TXINE Clear */
-  RoReg8  Reserved26[0x1C0];
-  RwReg   USBC_UHCON;         /**< \brief (USBC Offset: 0x400) Host General Control Register */
-  RoReg   USBC_UHINT;         /**< \brief (USBC Offset: 0x404) Host Global Interrupt Register */
-  WoReg   USBC_UHINTCLR;      /**< \brief (USBC Offset: 0x408) Host Global Interrrupt Clear Register */
-  WoReg   USBC_UHINTSET;      /**< \brief (USBC Offset: 0x40C) Host Global Interrupt Set Register */
-  RoReg   USBC_UHINTE;        /**< \brief (USBC Offset: 0x410) Host Global Interrupt Enable Register */
-  WoReg   USBC_UHINTECLR;     /**< \brief (USBC Offset: 0x414) Host Global Interrupt Enable Clear Register */
-  WoReg   USBC_UHINTESET;     /**< \brief (USBC Offset: 0x418) Host Global Interrupt Enable Set Register */
-  RwReg   USBC_UPRST;         /**< \brief (USBC Offset: 0x41C) Pipe Reset Register */
-  RwReg   USBC_UHFNUM;        /**< \brief (USBC Offset: 0x420) Host Frame Number Register */
-  RwReg   USBC_UHSOFC;        /**< \brief (USBC Offset: 0x424) Host Start of Frame Control Register */
-  RoReg8  Reserved27[0xD8];
-  RwReg   USBC_UPCFG0;        /**< \brief (USBC Offset: 0x500) Pipe Configuration Register */
-  RwReg   USBC_UPCFG1;        /**< \brief (USBC Offset: 0x504) Pipe Configuration Register */
-  RwReg   USBC_UPCFG2;        /**< \brief (USBC Offset: 0x508) Pipe Configuration Register */
-  RwReg   USBC_UPCFG3;        /**< \brief (USBC Offset: 0x50C) Pipe Configuration Register */
-  RwReg   USBC_UPCFG4;        /**< \brief (USBC Offset: 0x510) Pipe Configuration Register */
-  RwReg   USBC_UPCFG5;        /**< \brief (USBC Offset: 0x514) Pipe Configuration Register */
-  RwReg   USBC_UPCFG6;        /**< \brief (USBC Offset: 0x518) Pipe Configuration Register */
-  RwReg   USBC_UPCFG7;        /**< \brief (USBC Offset: 0x51C) Pipe Configuration Register */
-  RoReg8  Reserved28[0x10];
-  RoReg   USBC_UPSTA0;        /**< \brief (USBC Offset: 0x530) Pipe Status Register */
-  RoReg   USBC_UPSTA1;        /**< \brief (USBC Offset: 0x534) Pipe Status Register */
-  RoReg   USBC_UPSTA2;        /**< \brief (USBC Offset: 0x538) Pipe Status Register */
-  RoReg   USBC_UPSTA3;        /**< \brief (USBC Offset: 0x53C) Pipe Status Register */
-  RoReg   USBC_UPSTA4;        /**< \brief (USBC Offset: 0x540) Pipe Status Register */
-  RoReg   USBC_UPSTA5;        /**< \brief (USBC Offset: 0x544) Pipe Status Register */
-  RoReg   USBC_UPSTA6;        /**< \brief (USBC Offset: 0x548) Pipe Status Register */
-  RoReg   USBC_UPSTA7;        /**< \brief (USBC Offset: 0x54C) Pipe Status Register */
-  RoReg8  Reserved29[0x10];
-  WoReg   USBC_UPSTA0CLR;     /**< \brief (USBC Offset: 0x560) Pipe Status Clear Register */
-  WoReg   USBC_UPSTA1CLR;     /**< \brief (USBC Offset: 0x564) Pipe Status Clear Register */
-  WoReg   USBC_UPSTA2CLR;     /**< \brief (USBC Offset: 0x568) Pipe Status Clear Register */
-  WoReg   USBC_UPSTA3CLR;     /**< \brief (USBC Offset: 0x56C) Pipe Status Clear Register */
-  WoReg   USBC_UPSTA4CLR;     /**< \brief (USBC Offset: 0x570) Pipe Status Clear Register */
-  WoReg   USBC_UPSTA5CLR;     /**< \brief (USBC Offset: 0x574) Pipe Status Clear Register */
-  WoReg   USBC_UPSTA6CLR;     /**< \brief (USBC Offset: 0x578) Pipe Status Clear Register */
-  WoReg   USBC_UPSTA7CLR;     /**< \brief (USBC Offset: 0x57C) Pipe Status Clear Register */
-  RoReg8  Reserved30[0x10];
-  WoReg   USBC_UPSTA0SET;     /**< \brief (USBC Offset: 0x590) Pipe Status Set Register */
-  WoReg   USBC_UPSTA1SET;     /**< \brief (USBC Offset: 0x594) Pipe Status Set Register */
-  WoReg   USBC_UPSTA2SET;     /**< \brief (USBC Offset: 0x598) Pipe Status Set Register */
-  WoReg   USBC_UPSTA3SET;     /**< \brief (USBC Offset: 0x59C) Pipe Status Set Register */
-  WoReg   USBC_UPSTA4SET;     /**< \brief (USBC Offset: 0x5A0) Pipe Status Set Register */
-  WoReg   USBC_UPSTA5SET;     /**< \brief (USBC Offset: 0x5A4) Pipe Status Set Register */
-  WoReg   USBC_UPSTA6SET;     /**< \brief (USBC Offset: 0x5A8) Pipe Status Set Register */
-  WoReg   USBC_UPSTA7SET;     /**< \brief (USBC Offset: 0x5AC) Pipe Status Set Register */
-  RoReg8  Reserved31[0x10];
-  RoReg   USBC_UPCON0;        /**< \brief (USBC Offset: 0x5C0) Pipe Control Register */
-  RoReg   USBC_UPCON1;        /**< \brief (USBC Offset: 0x5C4) Pipe Control Register */
-  RoReg   USBC_UPCON2;        /**< \brief (USBC Offset: 0x5C8) Pipe Control Register */
-  RoReg   USBC_UPCON3;        /**< \brief (USBC Offset: 0x5CC) Pipe Control Register */
-  RoReg   USBC_UPCON4;        /**< \brief (USBC Offset: 0x5D0) Pipe Control Register */
-  RoReg   USBC_UPCON5;        /**< \brief (USBC Offset: 0x5D4) Pipe Control Register */
-  RoReg   USBC_UPCON6;        /**< \brief (USBC Offset: 0x5D8) Pipe Control Register */
-  RoReg   USBC_UPCON7;        /**< \brief (USBC Offset: 0x5DC) Pipe Control Register */
-  RoReg8  Reserved32[0x10];
-  WoReg   USBC_UPCON0SET;     /**< \brief (USBC Offset: 0x5F0) Pipe Control Set Register */
-  WoReg   USBC_UPCON1SET;     /**< \brief (USBC Offset: 0x5F4) Pipe Control Set Register */
-  WoReg   USBC_UPCON2SET;     /**< \brief (USBC Offset: 0x5F8) Pipe Control Set Register */
-  WoReg   USBC_UPCON3SET;     /**< \brief (USBC Offset: 0x5FC) Pipe Control Set Register */
-  WoReg   USBC_UPCON4SET;     /**< \brief (USBC Offset: 0x600) Pipe Control Set Register */
-  WoReg   USBC_UPCON5SET;     /**< \brief (USBC Offset: 0x604) Pipe Control Set Register */
-  WoReg   USBC_UPCON6SET;     /**< \brief (USBC Offset: 0x608) Pipe Control Set Register */
-  WoReg   USBC_UPCON7SET;     /**< \brief (USBC Offset: 0x60C) Pipe Control Set Register */
-  RoReg8  Reserved33[0x10];
-  WoReg   USBC_UPCON0CLR;     /**< \brief (USBC Offset: 0x620) Pipe Control Clear Register */
-  WoReg   USBC_UPCON1CLR;     /**< \brief (USBC Offset: 0x624) Pipe Control Clear Register */
-  WoReg   USBC_UPCON2CLR;     /**< \brief (USBC Offset: 0x628) Pipe Control Clear Register */
-  WoReg   USBC_UPCON3CLR;     /**< \brief (USBC Offset: 0x62C) Pipe Control Clear Register */
-  WoReg   USBC_UPCON4CLR;     /**< \brief (USBC Offset: 0x630) Pipe Control Clear Register */
-  WoReg   USBC_UPCON5CLR;     /**< \brief (USBC Offset: 0x634) Pipe Control Clear Register */
-  WoReg   USBC_UPCON6CLR;     /**< \brief (USBC Offset: 0x638) Pipe Control Clear Register */
-  WoReg   USBC_UPCON7CLR;     /**< \brief (USBC Offset: 0x63C) Pipe Control Clear Register */
-  RoReg8  Reserved34[0x10];
-  RwReg   USBC_UPINRQ0;       /**< \brief (USBC Offset: 0x650) Pipe In Request */
-  RwReg   USBC_UPINRQ1;       /**< \brief (USBC Offset: 0x654) Pipe In Request */
-  RwReg   USBC_UPINRQ2;       /**< \brief (USBC Offset: 0x658) Pipe In Request */
-  RwReg   USBC_UPINRQ3;       /**< \brief (USBC Offset: 0x65C) Pipe In Request */
-  RwReg   USBC_UPINRQ4;       /**< \brief (USBC Offset: 0x660) Pipe In Request */
-  RwReg   USBC_UPINRQ5;       /**< \brief (USBC Offset: 0x664) Pipe In Request */
-  RwReg   USBC_UPINRQ6;       /**< \brief (USBC Offset: 0x668) Pipe In Request */
-  RwReg   USBC_UPINRQ7;       /**< \brief (USBC Offset: 0x66C) Pipe In Request */
-  RoReg8  Reserved35[0x190];
-  RwReg   USBC_USBCON;        /**< \brief (USBC Offset: 0x800) General Control Register */
-  RoReg   USBC_USBSTA;        /**< \brief (USBC Offset: 0x804) General Status Register */
-  WoReg   USBC_USBSTACLR;     /**< \brief (USBC Offset: 0x808) General Status Clear Register */
-  WoReg   USBC_USBSTASET;     /**< \brief (USBC Offset: 0x80C) General Status Set Register */
-  RoReg8  Reserved36[0x8];
-  RoReg   USBC_UVERS;         /**< \brief (USBC Offset: 0x818) IP Version Register */
-  RoReg   USBC_UFEATURES;     /**< \brief (USBC Offset: 0x81C) IP Features Register */
-  RoReg   USBC_UADDRSIZE;     /**< \brief (USBC Offset: 0x820) IP PB address size Register */
-  RoReg   USBC_UNAME1;        /**< \brief (USBC Offset: 0x824) IP Name Part One: HUSB */
-  RoReg   USBC_UNAME2;        /**< \brief (USBC Offset: 0x828) IP Name Part Two: HOST */
-  RoReg   USBC_USBFSM;        /**< \brief (USBC Offset: 0x82C) USB internal finite state machine */
-  RwReg   USBC_UDESC;         /**< \brief (USBC Offset: 0x830) Endpoint descriptor table */
- } reg;
+typedef struct {
+  __IO uint32_t UDCON;       /**< \brief Offset: 0x000 (R/W 32) Device General Control Register */
+  __I  uint32_t UDINT;       /**< \brief Offset: 0x004 (R/  32) Device Global Interupt Register */
+  __O  uint32_t UDINTCLR;    /**< \brief Offset: 0x008 ( /W 32) Device Global Interrupt Clear Register */
+  __O  uint32_t UDINTSET;    /**< \brief Offset: 0x00C ( /W 32) Device Global Interrupt Set Regsiter */
+  __I  uint32_t UDINTE;      /**< \brief Offset: 0x010 (R/  32) Device Global Interrupt Enable Register */
+  __O  uint32_t UDINTECLR;   /**< \brief Offset: 0x014 ( /W 32) Device Global Interrupt Enable Clear Register */
+  __O  uint32_t UDINTESET;   /**< \brief Offset: 0x018 ( /W 32) Device Global Interrupt Enable Set Register */
+  __IO uint32_t UERST;       /**< \brief Offset: 0x01C (R/W 32) Endpoint Enable/Reset Register */
+  __I  uint32_t UDFNUM;      /**< \brief Offset: 0x020 (R/  32) Device Frame Number Register */
+       RoReg8   Reserved1[0xDC];
+  __IO uint32_t UECFG0;      /**< \brief Offset: 0x100 (R/W 32) Endpoint Configuration Register */
+  __IO uint32_t UECFG1;      /**< \brief Offset: 0x104 (R/W 32) Endpoint Configuration Register */
+  __IO uint32_t UECFG2;      /**< \brief Offset: 0x108 (R/W 32) Endpoint Configuration Register */
+  __IO uint32_t UECFG3;      /**< \brief Offset: 0x10C (R/W 32) Endpoint Configuration Register */
+  __IO uint32_t UECFG4;      /**< \brief Offset: 0x110 (R/W 32) Endpoint Configuration Register */
+  __IO uint32_t UECFG5;      /**< \brief Offset: 0x114 (R/W 32) Endpoint Configuration Register */
+  __IO uint32_t UECFG6;      /**< \brief Offset: 0x118 (R/W 32) Endpoint Configuration Register */
+  __IO uint32_t UECFG7;      /**< \brief Offset: 0x11C (R/W 32) Endpoint Configuration Register */
+       RoReg8   Reserved2[0x10];
+  __I  uint32_t UESTA0;      /**< \brief Offset: 0x130 (R/  32) Endpoint Status Register */
+  __I  uint32_t UESTA1;      /**< \brief Offset: 0x134 (R/  32) Endpoint Status Register */
+  __I  uint32_t UESTA2;      /**< \brief Offset: 0x138 (R/  32) Endpoint Status Register */
+  __I  uint32_t UESTA3;      /**< \brief Offset: 0x13C (R/  32) Endpoint Status Register */
+  __I  uint32_t UESTA4;      /**< \brief Offset: 0x140 (R/  32) Endpoint Status Register */
+  __I  uint32_t UESTA5;      /**< \brief Offset: 0x144 (R/  32) Endpoint Status Register */
+  __I  uint32_t UESTA6;      /**< \brief Offset: 0x148 (R/  32) Endpoint Status Register */
+  __I  uint32_t UESTA7;      /**< \brief Offset: 0x14C (R/  32) Endpoint Status Register */
+       RoReg8   Reserved3[0x10];
+  __O  uint32_t UESTA0CLR;   /**< \brief Offset: 0x160 ( /W 32) Endpoint Status Clear Register */
+  __O  uint32_t UESTA1CLR;   /**< \brief Offset: 0x164 ( /W 32) Endpoint Status Clear Register */
+  __O  uint32_t UESTA2CLR;   /**< \brief Offset: 0x168 ( /W 32) Endpoint Status Clear Register */
+  __O  uint32_t UESTA3CLR;   /**< \brief Offset: 0x16C ( /W 32) Endpoint Status Clear Register */
+  __O  uint32_t UESTA4CLR;   /**< \brief Offset: 0x170 ( /W 32) Endpoint Status Clear Register */
+  __O  uint32_t UESTA5CLR;   /**< \brief Offset: 0x174 ( /W 32) Endpoint Status Clear Register */
+  __O  uint32_t UESTA6CLR;   /**< \brief Offset: 0x178 ( /W 32) Endpoint Status Clear Register */
+  __O  uint32_t UESTA7CLR;   /**< \brief Offset: 0x17C ( /W 32) Endpoint Status Clear Register */
+       RoReg8   Reserved4[0x10];
+  __O  uint32_t UESTA0SET;   /**< \brief Offset: 0x190 ( /W 32) Endpoint Status Set Register */
+  __O  uint32_t UESTA1SET;   /**< \brief Offset: 0x194 ( /W 32) Endpoint Status Set Register */
+  __O  uint32_t UESTA2SET;   /**< \brief Offset: 0x198 ( /W 32) Endpoint Status Set Register */
+  __O  uint32_t UESTA3SET;   /**< \brief Offset: 0x19C ( /W 32) Endpoint Status Set Register */
+  __O  uint32_t UESTA4SET;   /**< \brief Offset: 0x1A0 ( /W 32) Endpoint Status Set Register */
+  __O  uint32_t UESTA5SET;   /**< \brief Offset: 0x1A4 ( /W 32) Endpoint Status Set Register */
+  __O  uint32_t UESTA6SET;   /**< \brief Offset: 0x1A8 ( /W 32) Endpoint Status Set Register */
+  __O  uint32_t UESTA7SET;   /**< \brief Offset: 0x1AC ( /W 32) Endpoint Status Set Register */
+       RoReg8   Reserved5[0x10];
+  __I  uint32_t UECON0;      /**< \brief Offset: 0x1C0 (R/  32) Endpoint Control Register */
+  __I  uint32_t UECON1;      /**< \brief Offset: 0x1C4 (R/  32) Endpoint Control Register */
+  __I  uint32_t UECON2;      /**< \brief Offset: 0x1C8 (R/  32) Endpoint Control Register */
+  __I  uint32_t UECON3;      /**< \brief Offset: 0x1CC (R/  32) Endpoint Control Register */
+  __I  uint32_t UECON4;      /**< \brief Offset: 0x1D0 (R/  32) Endpoint Control Register */
+  __I  uint32_t UECON5;      /**< \brief Offset: 0x1D4 (R/  32) Endpoint Control Register */
+  __I  uint32_t UECON6;      /**< \brief Offset: 0x1D8 (R/  32) Endpoint Control Register */
+  __I  uint32_t UECON7;      /**< \brief Offset: 0x1DC (R/  32) Endpoint Control Register */
+       RoReg8   Reserved6[0x10];
+  __O  uint32_t UECON0SET;   /**< \brief Offset: 0x1F0 ( /W 32) Endpoint Control Set Register */
+  __O  uint32_t UECON1SET;   /**< \brief Offset: 0x1F4 ( /W 32) Endpoint Control Set Register */
+  __O  uint32_t UECON2SET;   /**< \brief Offset: 0x1F8 ( /W 32) Endpoint Control Set Register */
+  __O  uint32_t UECON3SET;   /**< \brief Offset: 0x1FC ( /W 32) Endpoint Control Set Register */
+  __O  uint32_t UECON4SET;   /**< \brief Offset: 0x200 ( /W 32) Endpoint Control Set Register */
+  __O  uint32_t UECON5SET;   /**< \brief Offset: 0x204 ( /W 32) Endpoint Control Set Register */
+  __O  uint32_t UECON6SET;   /**< \brief Offset: 0x208 ( /W 32) Endpoint Control Set Register */
+  __O  uint32_t UECON7SET;   /**< \brief Offset: 0x20C ( /W 32) Endpoint Control Set Register */
+       RoReg8   Reserved7[0x10];
+  __O  uint32_t UECON0CLR;   /**< \brief Offset: 0x220 ( /W 32) Endpoint Control Clear Register */
+  __O  uint32_t UECON1CLR;   /**< \brief Offset: 0x224 ( /W 32) TXINE Clear */
+  __O  uint32_t UECON2CLR;   /**< \brief Offset: 0x228 ( /W 32) TXINE Clear */
+  __O  uint32_t UECON3CLR;   /**< \brief Offset: 0x22C ( /W 32) TXINE Clear */
+  __O  uint32_t UECON4CLR;   /**< \brief Offset: 0x230 ( /W 32) TXINE Clear */
+  __O  uint32_t UECON5CLR;   /**< \brief Offset: 0x234 ( /W 32) TXINE Clear */
+  __O  uint32_t UECON6CLR;   /**< \brief Offset: 0x238 ( /W 32) TXINE Clear */
+  __O  uint32_t UECON7CLR;   /**< \brief Offset: 0x23C ( /W 32) TXINE Clear */
+       RoReg8   Reserved8[0x1C0];
+  __IO uint32_t UHCON;       /**< \brief Offset: 0x400 (R/W 32) Host General Control Register */
+  __I  uint32_t UHINT;       /**< \brief Offset: 0x404 (R/  32) Host Global Interrupt Register */
+  __O  uint32_t UHINTCLR;    /**< \brief Offset: 0x408 ( /W 32) Host Global Interrrupt Clear Register */
+  __O  uint32_t UHINTSET;    /**< \brief Offset: 0x40C ( /W 32) Host Global Interrupt Set Register */
+  __I  uint32_t UHINTE;      /**< \brief Offset: 0x410 (R/  32) Host Global Interrupt Enable Register */
+  __O  uint32_t UHINTECLR;   /**< \brief Offset: 0x414 ( /W 32) Host Global Interrupt Enable Clear Register */
+  __O  uint32_t UHINTESET;   /**< \brief Offset: 0x418 ( /W 32) Host Global Interrupt Enable Set Register */
+  __IO uint32_t UPRST;       /**< \brief Offset: 0x41C (R/W 32) Pipe Reset Register */
+  __IO uint32_t UHFNUM;      /**< \brief Offset: 0x420 (R/W 32) Host Frame Number Register */
+  __IO uint32_t UHSOFC;      /**< \brief Offset: 0x424 (R/W 32) Host Start of Frame Control Register */
+       RoReg8   Reserved9[0xD8];
+  __IO uint32_t UPCFG0;      /**< \brief Offset: 0x500 (R/W 32) Pipe Configuration Register */
+  __IO uint32_t UPCFG1;      /**< \brief Offset: 0x504 (R/W 32) Pipe Configuration Register */
+  __IO uint32_t UPCFG2;      /**< \brief Offset: 0x508 (R/W 32) Pipe Configuration Register */
+  __IO uint32_t UPCFG3;      /**< \brief Offset: 0x50C (R/W 32) Pipe Configuration Register */
+  __IO uint32_t UPCFG4;      /**< \brief Offset: 0x510 (R/W 32) Pipe Configuration Register */
+  __IO uint32_t UPCFG5;      /**< \brief Offset: 0x514 (R/W 32) Pipe Configuration Register */
+  __IO uint32_t UPCFG6;      /**< \brief Offset: 0x518 (R/W 32) Pipe Configuration Register */
+  __IO uint32_t UPCFG7;      /**< \brief Offset: 0x51C (R/W 32) Pipe Configuration Register */
+       RoReg8   Reserved10[0x10];
+  __I  uint32_t UPSTA0;      /**< \brief Offset: 0x530 (R/  32) Pipe Status Register */
+  __I  uint32_t UPSTA1;      /**< \brief Offset: 0x534 (R/  32) Pipe Status Register */
+  __I  uint32_t UPSTA2;      /**< \brief Offset: 0x538 (R/  32) Pipe Status Register */
+  __I  uint32_t UPSTA3;      /**< \brief Offset: 0x53C (R/  32) Pipe Status Register */
+  __I  uint32_t UPSTA4;      /**< \brief Offset: 0x540 (R/  32) Pipe Status Register */
+  __I  uint32_t UPSTA5;      /**< \brief Offset: 0x544 (R/  32) Pipe Status Register */
+  __I  uint32_t UPSTA6;      /**< \brief Offset: 0x548 (R/  32) Pipe Status Register */
+  __I  uint32_t UPSTA7;      /**< \brief Offset: 0x54C (R/  32) Pipe Status Register */
+       RoReg8   Reserved11[0x10];
+  __O  uint32_t UPSTA0CLR;   /**< \brief Offset: 0x560 ( /W 32) Pipe Status Clear Register */
+  __O  uint32_t UPSTA1CLR;   /**< \brief Offset: 0x564 ( /W 32) Pipe Status Clear Register */
+  __O  uint32_t UPSTA2CLR;   /**< \brief Offset: 0x568 ( /W 32) Pipe Status Clear Register */
+  __O  uint32_t UPSTA3CLR;   /**< \brief Offset: 0x56C ( /W 32) Pipe Status Clear Register */
+  __O  uint32_t UPSTA4CLR;   /**< \brief Offset: 0x570 ( /W 32) Pipe Status Clear Register */
+  __O  uint32_t UPSTA5CLR;   /**< \brief Offset: 0x574 ( /W 32) Pipe Status Clear Register */
+  __O  uint32_t UPSTA6CLR;   /**< \brief Offset: 0x578 ( /W 32) Pipe Status Clear Register */
+  __O  uint32_t UPSTA7CLR;   /**< \brief Offset: 0x57C ( /W 32) Pipe Status Clear Register */
+       RoReg8   Reserved12[0x10];
+  __O  uint32_t UPSTA0SET;   /**< \brief Offset: 0x590 ( /W 32) Pipe Status Set Register */
+  __O  uint32_t UPSTA1SET;   /**< \brief Offset: 0x594 ( /W 32) Pipe Status Set Register */
+  __O  uint32_t UPSTA2SET;   /**< \brief Offset: 0x598 ( /W 32) Pipe Status Set Register */
+  __O  uint32_t UPSTA3SET;   /**< \brief Offset: 0x59C ( /W 32) Pipe Status Set Register */
+  __O  uint32_t UPSTA4SET;   /**< \brief Offset: 0x5A0 ( /W 32) Pipe Status Set Register */
+  __O  uint32_t UPSTA5SET;   /**< \brief Offset: 0x5A4 ( /W 32) Pipe Status Set Register */
+  __O  uint32_t UPSTA6SET;   /**< \brief Offset: 0x5A8 ( /W 32) Pipe Status Set Register */
+  __O  uint32_t UPSTA7SET;   /**< \brief Offset: 0x5AC ( /W 32) Pipe Status Set Register */
+       RoReg8   Reserved13[0x10];
+  __I  uint32_t UPCON0;      /**< \brief Offset: 0x5C0 (R/  32) Pipe Control Register */
+  __I  uint32_t UPCON1;      /**< \brief Offset: 0x5C4 (R/  32) Pipe Control Register */
+  __I  uint32_t UPCON2;      /**< \brief Offset: 0x5C8 (R/  32) Pipe Control Register */
+  __I  uint32_t UPCON3;      /**< \brief Offset: 0x5CC (R/  32) Pipe Control Register */
+  __I  uint32_t UPCON4;      /**< \brief Offset: 0x5D0 (R/  32) Pipe Control Register */
+  __I  uint32_t UPCON5;      /**< \brief Offset: 0x5D4 (R/  32) Pipe Control Register */
+  __I  uint32_t UPCON6;      /**< \brief Offset: 0x5D8 (R/  32) Pipe Control Register */
+  __I  uint32_t UPCON7;      /**< \brief Offset: 0x5DC (R/  32) Pipe Control Register */
+       RoReg8   Reserved14[0x10];
+  __O  uint32_t UPCON0SET;   /**< \brief Offset: 0x5F0 ( /W 32) Pipe Control Set Register */
+  __O  uint32_t UPCON1SET;   /**< \brief Offset: 0x5F4 ( /W 32) Pipe Control Set Register */
+  __O  uint32_t UPCON2SET;   /**< \brief Offset: 0x5F8 ( /W 32) Pipe Control Set Register */
+  __O  uint32_t UPCON3SET;   /**< \brief Offset: 0x5FC ( /W 32) Pipe Control Set Register */
+  __O  uint32_t UPCON4SET;   /**< \brief Offset: 0x600 ( /W 32) Pipe Control Set Register */
+  __O  uint32_t UPCON5SET;   /**< \brief Offset: 0x604 ( /W 32) Pipe Control Set Register */
+  __O  uint32_t UPCON6SET;   /**< \brief Offset: 0x608 ( /W 32) Pipe Control Set Register */
+  __O  uint32_t UPCON7SET;   /**< \brief Offset: 0x60C ( /W 32) Pipe Control Set Register */
+       RoReg8   Reserved15[0x10];
+  __O  uint32_t UPCON0CLR;   /**< \brief Offset: 0x620 ( /W 32) Pipe Control Clear Register */
+  __O  uint32_t UPCON1CLR;   /**< \brief Offset: 0x624 ( /W 32) Pipe Control Clear Register */
+  __O  uint32_t UPCON2CLR;   /**< \brief Offset: 0x628 ( /W 32) Pipe Control Clear Register */
+  __O  uint32_t UPCON3CLR;   /**< \brief Offset: 0x62C ( /W 32) Pipe Control Clear Register */
+  __O  uint32_t UPCON4CLR;   /**< \brief Offset: 0x630 ( /W 32) Pipe Control Clear Register */
+  __O  uint32_t UPCON5CLR;   /**< \brief Offset: 0x634 ( /W 32) Pipe Control Clear Register */
+  __O  uint32_t UPCON6CLR;   /**< \brief Offset: 0x638 ( /W 32) Pipe Control Clear Register */
+  __O  uint32_t UPCON7CLR;   /**< \brief Offset: 0x63C ( /W 32) Pipe Control Clear Register */
+       RoReg8   Reserved16[0x10];
+  __IO uint32_t UPINRQ0;     /**< \brief Offset: 0x650 (R/W 32) Pipe In Request */
+  __IO uint32_t UPINRQ1;     /**< \brief Offset: 0x654 (R/W 32) Pipe In Request */
+  __IO uint32_t UPINRQ2;     /**< \brief Offset: 0x658 (R/W 32) Pipe In Request */
+  __IO uint32_t UPINRQ3;     /**< \brief Offset: 0x65C (R/W 32) Pipe In Request */
+  __IO uint32_t UPINRQ4;     /**< \brief Offset: 0x660 (R/W 32) Pipe In Request */
+  __IO uint32_t UPINRQ5;     /**< \brief Offset: 0x664 (R/W 32) Pipe In Request */
+  __IO uint32_t UPINRQ6;     /**< \brief Offset: 0x668 (R/W 32) Pipe In Request */
+  __IO uint32_t UPINRQ7;     /**< \brief Offset: 0x66C (R/W 32) Pipe In Request */
+       RoReg8   Reserved17[0x190];
+  __IO uint32_t USBCON;      /**< \brief Offset: 0x800 (R/W 32) General Control Register */
+  __I  uint32_t USBSTA;      /**< \brief Offset: 0x804 (R/  32) General Status Register */
+  __O  uint32_t USBSTACLR;   /**< \brief Offset: 0x808 ( /W 32) General Status Clear Register */
+  __O  uint32_t USBSTASET;   /**< \brief Offset: 0x80C ( /W 32) General Status Set Register */
+       RoReg8   Reserved18[0x8];
+  __I  uint32_t UVERS;       /**< \brief Offset: 0x818 (R/  32) IP Version Register */
+  __I  uint32_t UFEATURES;   /**< \brief Offset: 0x81C (R/  32) IP Features Register */
+  __I  uint32_t UADDRSIZE;   /**< \brief Offset: 0x820 (R/  32) IP PB address size Register */
+  __I  uint32_t UNAME1;      /**< \brief Offset: 0x824 (R/  32) IP Name Part One: HUSB */
+  __I  uint32_t UNAME2;      /**< \brief Offset: 0x828 (R/  32) IP Name Part Two: HOST */
+  __I  uint32_t USBFSM;      /**< \brief Offset: 0x82C (R/  32) USB internal finite state machine */
+  __IO uint32_t UDESC;       /**< \brief Offset: 0x830 (R/W 32) Endpoint descriptor table */
 } Usbc;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/usbc.h
+++ b/asf/sam/include/sam4l/component/usbc.h
@@ -60,33 +60,33 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UDCON_OFFSET           0x000        /**< \brief (USBC_UDCON offset) Device General Control Register */
-#define USBC_UDCON_RESETVALUE       _U(0x00000100); /**< \brief (USBC_UDCON reset_value) Device General Control Register */
+#define USBC_UDCON_RESETVALUE       _U_(0x00000100); /**< \brief (USBC_UDCON reset_value) Device General Control Register */
 
 #define USBC_UDCON_UADD_Pos         0            /**< \brief (USBC_UDCON) USB Address */
-#define USBC_UDCON_UADD_Msk         (_U(0x7F) << USBC_UDCON_UADD_Pos)
+#define USBC_UDCON_UADD_Msk         (_U_(0x7F) << USBC_UDCON_UADD_Pos)
 #define USBC_UDCON_UADD(value)      (USBC_UDCON_UADD_Msk & ((value) << USBC_UDCON_UADD_Pos))
 #define USBC_UDCON_ADDEN_Pos        7            /**< \brief (USBC_UDCON) Address Enable */
-#define USBC_UDCON_ADDEN            (_U(0x1) << USBC_UDCON_ADDEN_Pos)
+#define USBC_UDCON_ADDEN            (_U_(0x1) << USBC_UDCON_ADDEN_Pos)
 #define USBC_UDCON_DETACH_Pos       8            /**< \brief (USBC_UDCON) Detach */
-#define USBC_UDCON_DETACH           (_U(0x1) << USBC_UDCON_DETACH_Pos)
+#define USBC_UDCON_DETACH           (_U_(0x1) << USBC_UDCON_DETACH_Pos)
 #define USBC_UDCON_RMWKUP_Pos       9            /**< \brief (USBC_UDCON) Remote Wake-Up */
-#define USBC_UDCON_RMWKUP           (_U(0x1) << USBC_UDCON_RMWKUP_Pos)
+#define USBC_UDCON_RMWKUP           (_U_(0x1) << USBC_UDCON_RMWKUP_Pos)
 #define USBC_UDCON_SPDCONF_Pos      10           /**< \brief (USBC_UDCON) Speed configuration */
-#define USBC_UDCON_SPDCONF_Msk      (_U(0x3) << USBC_UDCON_SPDCONF_Pos)
+#define USBC_UDCON_SPDCONF_Msk      (_U_(0x3) << USBC_UDCON_SPDCONF_Pos)
 #define USBC_UDCON_SPDCONF(value)   (USBC_UDCON_SPDCONF_Msk & ((value) << USBC_UDCON_SPDCONF_Pos))
 #define USBC_UDCON_LS_Pos           12           /**< \brief (USBC_UDCON) Low Speed Mode Force */
-#define USBC_UDCON_LS               (_U(0x1) << USBC_UDCON_LS_Pos)
+#define USBC_UDCON_LS               (_U_(0x1) << USBC_UDCON_LS_Pos)
 #define USBC_UDCON_TSTJ_Pos         13           /**< \brief (USBC_UDCON) Test mode J */
-#define USBC_UDCON_TSTJ             (_U(0x1) << USBC_UDCON_TSTJ_Pos)
+#define USBC_UDCON_TSTJ             (_U_(0x1) << USBC_UDCON_TSTJ_Pos)
 #define USBC_UDCON_TSTK_Pos         14           /**< \brief (USBC_UDCON) Test mode K */
-#define USBC_UDCON_TSTK             (_U(0x1) << USBC_UDCON_TSTK_Pos)
+#define USBC_UDCON_TSTK             (_U_(0x1) << USBC_UDCON_TSTK_Pos)
 #define USBC_UDCON_TSTPCKT_Pos      15           /**< \brief (USBC_UDCON) Test Packet mode */
-#define USBC_UDCON_TSTPCKT          (_U(0x1) << USBC_UDCON_TSTPCKT_Pos)
+#define USBC_UDCON_TSTPCKT          (_U_(0x1) << USBC_UDCON_TSTPCKT_Pos)
 #define USBC_UDCON_OPMODE2_Pos      16           /**< \brief (USBC_UDCON) Specific Operational mode */
-#define USBC_UDCON_OPMODE2          (_U(0x1) << USBC_UDCON_OPMODE2_Pos)
+#define USBC_UDCON_OPMODE2          (_U_(0x1) << USBC_UDCON_OPMODE2_Pos)
 #define USBC_UDCON_GNAK_Pos         17           /**< \brief (USBC_UDCON) Global NAK */
-#define USBC_UDCON_GNAK             (_U(0x1) << USBC_UDCON_GNAK_Pos)
-#define USBC_UDCON_MASK             _U(0x0003FFFF) /**< \brief (USBC_UDCON) MASK Register */
+#define USBC_UDCON_GNAK             (_U_(0x1) << USBC_UDCON_GNAK_Pos)
+#define USBC_UDCON_MASK             _U_(0x0003FFFF) /**< \brief (USBC_UDCON) MASK Register */
 
 /* -------- USBC_UDINT : (USBC Offset: 0x004) (R/  32) Device Global Interupt Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -115,39 +115,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UDINT_OFFSET           0x004        /**< \brief (USBC_UDINT offset) Device Global Interupt Register */
-#define USBC_UDINT_RESETVALUE       _U(0x00000000); /**< \brief (USBC_UDINT reset_value) Device Global Interupt Register */
+#define USBC_UDINT_RESETVALUE       _U_(0x00000000); /**< \brief (USBC_UDINT reset_value) Device Global Interupt Register */
 
 #define USBC_UDINT_SUSP_Pos         0            /**< \brief (USBC_UDINT) Suspend Interrupt */
-#define USBC_UDINT_SUSP             (_U(0x1) << USBC_UDINT_SUSP_Pos)
+#define USBC_UDINT_SUSP             (_U_(0x1) << USBC_UDINT_SUSP_Pos)
 #define USBC_UDINT_MSOF_Pos         1            /**< \brief (USBC_UDINT) Micro Start of Frame Interrupt */
-#define USBC_UDINT_MSOF             (_U(0x1) << USBC_UDINT_MSOF_Pos)
+#define USBC_UDINT_MSOF             (_U_(0x1) << USBC_UDINT_MSOF_Pos)
 #define USBC_UDINT_SOF_Pos          2            /**< \brief (USBC_UDINT) Start of Frame Interrupt */
-#define USBC_UDINT_SOF              (_U(0x1) << USBC_UDINT_SOF_Pos)
+#define USBC_UDINT_SOF              (_U_(0x1) << USBC_UDINT_SOF_Pos)
 #define USBC_UDINT_EORST_Pos        3            /**< \brief (USBC_UDINT) End of Reset Interrupt */
-#define USBC_UDINT_EORST            (_U(0x1) << USBC_UDINT_EORST_Pos)
+#define USBC_UDINT_EORST            (_U_(0x1) << USBC_UDINT_EORST_Pos)
 #define USBC_UDINT_WAKEUP_Pos       4            /**< \brief (USBC_UDINT) Wake-Up Interrupt */
-#define USBC_UDINT_WAKEUP           (_U(0x1) << USBC_UDINT_WAKEUP_Pos)
+#define USBC_UDINT_WAKEUP           (_U_(0x1) << USBC_UDINT_WAKEUP_Pos)
 #define USBC_UDINT_EORSM_Pos        5            /**< \brief (USBC_UDINT) End Of Resume Interrupt */
-#define USBC_UDINT_EORSM            (_U(0x1) << USBC_UDINT_EORSM_Pos)
+#define USBC_UDINT_EORSM            (_U_(0x1) << USBC_UDINT_EORSM_Pos)
 #define USBC_UDINT_UPRSM_Pos        6            /**< \brief (USBC_UDINT) Upstream Resume Interrupt */
-#define USBC_UDINT_UPRSM            (_U(0x1) << USBC_UDINT_UPRSM_Pos)
+#define USBC_UDINT_UPRSM            (_U_(0x1) << USBC_UDINT_UPRSM_Pos)
 #define USBC_UDINT_EP0INT_Pos       12           /**< \brief (USBC_UDINT) Endpoint 0 Interrupt */
-#define USBC_UDINT_EP0INT           (_U(0x1) << USBC_UDINT_EP0INT_Pos)
+#define USBC_UDINT_EP0INT           (_U_(0x1) << USBC_UDINT_EP0INT_Pos)
 #define USBC_UDINT_EP1INT_Pos       13           /**< \brief (USBC_UDINT) Endpoint 1 Interrupt */
-#define USBC_UDINT_EP1INT           (_U(0x1) << USBC_UDINT_EP1INT_Pos)
+#define USBC_UDINT_EP1INT           (_U_(0x1) << USBC_UDINT_EP1INT_Pos)
 #define USBC_UDINT_EP2INT_Pos       14           /**< \brief (USBC_UDINT) Endpoint 2 Interrupt */
-#define USBC_UDINT_EP2INT           (_U(0x1) << USBC_UDINT_EP2INT_Pos)
+#define USBC_UDINT_EP2INT           (_U_(0x1) << USBC_UDINT_EP2INT_Pos)
 #define USBC_UDINT_EP3INT_Pos       15           /**< \brief (USBC_UDINT) Endpoint 3 Interrupt */
-#define USBC_UDINT_EP3INT           (_U(0x1) << USBC_UDINT_EP3INT_Pos)
+#define USBC_UDINT_EP3INT           (_U_(0x1) << USBC_UDINT_EP3INT_Pos)
 #define USBC_UDINT_EP4INT_Pos       16           /**< \brief (USBC_UDINT) Endpoint 4 Interrupt */
-#define USBC_UDINT_EP4INT           (_U(0x1) << USBC_UDINT_EP4INT_Pos)
+#define USBC_UDINT_EP4INT           (_U_(0x1) << USBC_UDINT_EP4INT_Pos)
 #define USBC_UDINT_EP5INT_Pos       17           /**< \brief (USBC_UDINT) Endpoint 5 Interrupt */
-#define USBC_UDINT_EP5INT           (_U(0x1) << USBC_UDINT_EP5INT_Pos)
+#define USBC_UDINT_EP5INT           (_U_(0x1) << USBC_UDINT_EP5INT_Pos)
 #define USBC_UDINT_EP6INT_Pos       18           /**< \brief (USBC_UDINT) Endpoint 6 Interrupt */
-#define USBC_UDINT_EP6INT           (_U(0x1) << USBC_UDINT_EP6INT_Pos)
+#define USBC_UDINT_EP6INT           (_U_(0x1) << USBC_UDINT_EP6INT_Pos)
 #define USBC_UDINT_EP7INT_Pos       19           /**< \brief (USBC_UDINT) Endpoint 7 Interrupt */
-#define USBC_UDINT_EP7INT           (_U(0x1) << USBC_UDINT_EP7INT_Pos)
-#define USBC_UDINT_MASK             _U(0x000FF07F) /**< \brief (USBC_UDINT) MASK Register */
+#define USBC_UDINT_EP7INT           (_U_(0x1) << USBC_UDINT_EP7INT_Pos)
+#define USBC_UDINT_MASK             _U_(0x000FF07F) /**< \brief (USBC_UDINT) MASK Register */
 
 /* -------- USBC_UDINTCLR : (USBC Offset: 0x008) ( /W 32) Device Global Interrupt Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -167,23 +167,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UDINTCLR_OFFSET        0x008        /**< \brief (USBC_UDINTCLR offset) Device Global Interrupt Clear Register */
-#define USBC_UDINTCLR_RESETVALUE    _U(0x00000000); /**< \brief (USBC_UDINTCLR reset_value) Device Global Interrupt Clear Register */
+#define USBC_UDINTCLR_RESETVALUE    _U_(0x00000000); /**< \brief (USBC_UDINTCLR reset_value) Device Global Interrupt Clear Register */
 
 #define USBC_UDINTCLR_SUSPC_Pos     0            /**< \brief (USBC_UDINTCLR) SUSP Interrupt Clear */
-#define USBC_UDINTCLR_SUSPC         (_U(0x1) << USBC_UDINTCLR_SUSPC_Pos)
+#define USBC_UDINTCLR_SUSPC         (_U_(0x1) << USBC_UDINTCLR_SUSPC_Pos)
 #define USBC_UDINTCLR_MSOFC_Pos     1            /**< \brief (USBC_UDINTCLR) MSOF Interrupt Clear */
-#define USBC_UDINTCLR_MSOFC         (_U(0x1) << USBC_UDINTCLR_MSOFC_Pos)
+#define USBC_UDINTCLR_MSOFC         (_U_(0x1) << USBC_UDINTCLR_MSOFC_Pos)
 #define USBC_UDINTCLR_SOFC_Pos      2            /**< \brief (USBC_UDINTCLR) SOF Interrupt Clear */
-#define USBC_UDINTCLR_SOFC          (_U(0x1) << USBC_UDINTCLR_SOFC_Pos)
+#define USBC_UDINTCLR_SOFC          (_U_(0x1) << USBC_UDINTCLR_SOFC_Pos)
 #define USBC_UDINTCLR_EORSTC_Pos    3            /**< \brief (USBC_UDINTCLR) EORST Interrupt Clear */
-#define USBC_UDINTCLR_EORSTC        (_U(0x1) << USBC_UDINTCLR_EORSTC_Pos)
+#define USBC_UDINTCLR_EORSTC        (_U_(0x1) << USBC_UDINTCLR_EORSTC_Pos)
 #define USBC_UDINTCLR_WAKEUPC_Pos   4            /**< \brief (USBC_UDINTCLR) WAKEUP Interrupt Clear */
-#define USBC_UDINTCLR_WAKEUPC       (_U(0x1) << USBC_UDINTCLR_WAKEUPC_Pos)
+#define USBC_UDINTCLR_WAKEUPC       (_U_(0x1) << USBC_UDINTCLR_WAKEUPC_Pos)
 #define USBC_UDINTCLR_EORSMC_Pos    5            /**< \brief (USBC_UDINTCLR) EORSM Interrupt Clear */
-#define USBC_UDINTCLR_EORSMC        (_U(0x1) << USBC_UDINTCLR_EORSMC_Pos)
+#define USBC_UDINTCLR_EORSMC        (_U_(0x1) << USBC_UDINTCLR_EORSMC_Pos)
 #define USBC_UDINTCLR_UPRSMC_Pos    6            /**< \brief (USBC_UDINTCLR) UPRSM Interrupt Clear */
-#define USBC_UDINTCLR_UPRSMC        (_U(0x1) << USBC_UDINTCLR_UPRSMC_Pos)
-#define USBC_UDINTCLR_MASK          _U(0x0000007F) /**< \brief (USBC_UDINTCLR) MASK Register */
+#define USBC_UDINTCLR_UPRSMC        (_U_(0x1) << USBC_UDINTCLR_UPRSMC_Pos)
+#define USBC_UDINTCLR_MASK          _U_(0x0000007F) /**< \brief (USBC_UDINTCLR) MASK Register */
 
 /* -------- USBC_UDINTSET : (USBC Offset: 0x00C) ( /W 32) Device Global Interrupt Set Regsiter -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -203,23 +203,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UDINTSET_OFFSET        0x00C        /**< \brief (USBC_UDINTSET offset) Device Global Interrupt Set Regsiter */
-#define USBC_UDINTSET_RESETVALUE    _U(0x00000000); /**< \brief (USBC_UDINTSET reset_value) Device Global Interrupt Set Regsiter */
+#define USBC_UDINTSET_RESETVALUE    _U_(0x00000000); /**< \brief (USBC_UDINTSET reset_value) Device Global Interrupt Set Regsiter */
 
 #define USBC_UDINTSET_SUSPS_Pos     0            /**< \brief (USBC_UDINTSET) SUSP Interrupt Set */
-#define USBC_UDINTSET_SUSPS         (_U(0x1) << USBC_UDINTSET_SUSPS_Pos)
+#define USBC_UDINTSET_SUSPS         (_U_(0x1) << USBC_UDINTSET_SUSPS_Pos)
 #define USBC_UDINTSET_MSOFS_Pos     1            /**< \brief (USBC_UDINTSET) MSOF Interrupt Set */
-#define USBC_UDINTSET_MSOFS         (_U(0x1) << USBC_UDINTSET_MSOFS_Pos)
+#define USBC_UDINTSET_MSOFS         (_U_(0x1) << USBC_UDINTSET_MSOFS_Pos)
 #define USBC_UDINTSET_SOFS_Pos      2            /**< \brief (USBC_UDINTSET) SOF Interrupt Set */
-#define USBC_UDINTSET_SOFS          (_U(0x1) << USBC_UDINTSET_SOFS_Pos)
+#define USBC_UDINTSET_SOFS          (_U_(0x1) << USBC_UDINTSET_SOFS_Pos)
 #define USBC_UDINTSET_EORSTS_Pos    3            /**< \brief (USBC_UDINTSET) EORST Interrupt Set */
-#define USBC_UDINTSET_EORSTS        (_U(0x1) << USBC_UDINTSET_EORSTS_Pos)
+#define USBC_UDINTSET_EORSTS        (_U_(0x1) << USBC_UDINTSET_EORSTS_Pos)
 #define USBC_UDINTSET_WAKEUPS_Pos   4            /**< \brief (USBC_UDINTSET) WAKEUP Interrupt Set */
-#define USBC_UDINTSET_WAKEUPS       (_U(0x1) << USBC_UDINTSET_WAKEUPS_Pos)
+#define USBC_UDINTSET_WAKEUPS       (_U_(0x1) << USBC_UDINTSET_WAKEUPS_Pos)
 #define USBC_UDINTSET_EORSMS_Pos    5            /**< \brief (USBC_UDINTSET) EORSM Interrupt Set */
-#define USBC_UDINTSET_EORSMS        (_U(0x1) << USBC_UDINTSET_EORSMS_Pos)
+#define USBC_UDINTSET_EORSMS        (_U_(0x1) << USBC_UDINTSET_EORSMS_Pos)
 #define USBC_UDINTSET_UPRSMS_Pos    6            /**< \brief (USBC_UDINTSET) UPRSM Interrupt Set */
-#define USBC_UDINTSET_UPRSMS        (_U(0x1) << USBC_UDINTSET_UPRSMS_Pos)
-#define USBC_UDINTSET_MASK          _U(0x0000007F) /**< \brief (USBC_UDINTSET) MASK Register */
+#define USBC_UDINTSET_UPRSMS        (_U_(0x1) << USBC_UDINTSET_UPRSMS_Pos)
+#define USBC_UDINTSET_MASK          _U_(0x0000007F) /**< \brief (USBC_UDINTSET) MASK Register */
 
 /* -------- USBC_UDINTE : (USBC Offset: 0x010) (R/  32) Device Global Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -248,39 +248,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UDINTE_OFFSET          0x010        /**< \brief (USBC_UDINTE offset) Device Global Interrupt Enable Register */
-#define USBC_UDINTE_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UDINTE reset_value) Device Global Interrupt Enable Register */
+#define USBC_UDINTE_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UDINTE reset_value) Device Global Interrupt Enable Register */
 
 #define USBC_UDINTE_SUSPE_Pos       0            /**< \brief (USBC_UDINTE) SUSP Interrupt Enable */
-#define USBC_UDINTE_SUSPE           (_U(0x1) << USBC_UDINTE_SUSPE_Pos)
+#define USBC_UDINTE_SUSPE           (_U_(0x1) << USBC_UDINTE_SUSPE_Pos)
 #define USBC_UDINTE_MSOFE_Pos       1            /**< \brief (USBC_UDINTE) MSOF Interrupt Enable */
-#define USBC_UDINTE_MSOFE           (_U(0x1) << USBC_UDINTE_MSOFE_Pos)
+#define USBC_UDINTE_MSOFE           (_U_(0x1) << USBC_UDINTE_MSOFE_Pos)
 #define USBC_UDINTE_SOFE_Pos        2            /**< \brief (USBC_UDINTE) SOF Interrupt Enable */
-#define USBC_UDINTE_SOFE            (_U(0x1) << USBC_UDINTE_SOFE_Pos)
+#define USBC_UDINTE_SOFE            (_U_(0x1) << USBC_UDINTE_SOFE_Pos)
 #define USBC_UDINTE_EORSTE_Pos      3            /**< \brief (USBC_UDINTE) EORST Interrupt Enable */
-#define USBC_UDINTE_EORSTE          (_U(0x1) << USBC_UDINTE_EORSTE_Pos)
+#define USBC_UDINTE_EORSTE          (_U_(0x1) << USBC_UDINTE_EORSTE_Pos)
 #define USBC_UDINTE_WAKEUPE_Pos     4            /**< \brief (USBC_UDINTE) WAKEUP Interrupt Enable */
-#define USBC_UDINTE_WAKEUPE         (_U(0x1) << USBC_UDINTE_WAKEUPE_Pos)
+#define USBC_UDINTE_WAKEUPE         (_U_(0x1) << USBC_UDINTE_WAKEUPE_Pos)
 #define USBC_UDINTE_EORSME_Pos      5            /**< \brief (USBC_UDINTE) EORSM Interrupt Enable */
-#define USBC_UDINTE_EORSME          (_U(0x1) << USBC_UDINTE_EORSME_Pos)
+#define USBC_UDINTE_EORSME          (_U_(0x1) << USBC_UDINTE_EORSME_Pos)
 #define USBC_UDINTE_UPRSME_Pos      6            /**< \brief (USBC_UDINTE) UPRSM Interrupt Enable */
-#define USBC_UDINTE_UPRSME          (_U(0x1) << USBC_UDINTE_UPRSME_Pos)
+#define USBC_UDINTE_UPRSME          (_U_(0x1) << USBC_UDINTE_UPRSME_Pos)
 #define USBC_UDINTE_EP0INTE_Pos     12           /**< \brief (USBC_UDINTE) EP0INT Interrupt Enable */
-#define USBC_UDINTE_EP0INTE         (_U(0x1) << USBC_UDINTE_EP0INTE_Pos)
+#define USBC_UDINTE_EP0INTE         (_U_(0x1) << USBC_UDINTE_EP0INTE_Pos)
 #define USBC_UDINTE_EP1INTE_Pos     13           /**< \brief (USBC_UDINTE) EP1INT Interrupt Enable */
-#define USBC_UDINTE_EP1INTE         (_U(0x1) << USBC_UDINTE_EP1INTE_Pos)
+#define USBC_UDINTE_EP1INTE         (_U_(0x1) << USBC_UDINTE_EP1INTE_Pos)
 #define USBC_UDINTE_EP2INTE_Pos     14           /**< \brief (USBC_UDINTE) EP2INT Interrupt Enable */
-#define USBC_UDINTE_EP2INTE         (_U(0x1) << USBC_UDINTE_EP2INTE_Pos)
+#define USBC_UDINTE_EP2INTE         (_U_(0x1) << USBC_UDINTE_EP2INTE_Pos)
 #define USBC_UDINTE_EP3INTE_Pos     15           /**< \brief (USBC_UDINTE) EP3INT Interrupt Enable */
-#define USBC_UDINTE_EP3INTE         (_U(0x1) << USBC_UDINTE_EP3INTE_Pos)
+#define USBC_UDINTE_EP3INTE         (_U_(0x1) << USBC_UDINTE_EP3INTE_Pos)
 #define USBC_UDINTE_EP4INTE_Pos     16           /**< \brief (USBC_UDINTE) EP4INT Interrupt Enable */
-#define USBC_UDINTE_EP4INTE         (_U(0x1) << USBC_UDINTE_EP4INTE_Pos)
+#define USBC_UDINTE_EP4INTE         (_U_(0x1) << USBC_UDINTE_EP4INTE_Pos)
 #define USBC_UDINTE_EP5INTE_Pos     17           /**< \brief (USBC_UDINTE) EP5INT Interrupt Enable */
-#define USBC_UDINTE_EP5INTE         (_U(0x1) << USBC_UDINTE_EP5INTE_Pos)
+#define USBC_UDINTE_EP5INTE         (_U_(0x1) << USBC_UDINTE_EP5INTE_Pos)
 #define USBC_UDINTE_EP6INTE_Pos     18           /**< \brief (USBC_UDINTE) EP6INT Interrupt Enable */
-#define USBC_UDINTE_EP6INTE         (_U(0x1) << USBC_UDINTE_EP6INTE_Pos)
+#define USBC_UDINTE_EP6INTE         (_U_(0x1) << USBC_UDINTE_EP6INTE_Pos)
 #define USBC_UDINTE_EP7INTE_Pos     19           /**< \brief (USBC_UDINTE) EP7INT Interrupt Enable */
-#define USBC_UDINTE_EP7INTE         (_U(0x1) << USBC_UDINTE_EP7INTE_Pos)
-#define USBC_UDINTE_MASK            _U(0x000FF07F) /**< \brief (USBC_UDINTE) MASK Register */
+#define USBC_UDINTE_EP7INTE         (_U_(0x1) << USBC_UDINTE_EP7INTE_Pos)
+#define USBC_UDINTE_MASK            _U_(0x000FF07F) /**< \brief (USBC_UDINTE) MASK Register */
 
 /* -------- USBC_UDINTECLR : (USBC Offset: 0x014) ( /W 32) Device Global Interrupt Enable Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -309,39 +309,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UDINTECLR_OFFSET       0x014        /**< \brief (USBC_UDINTECLR offset) Device Global Interrupt Enable Clear Register */
-#define USBC_UDINTECLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UDINTECLR reset_value) Device Global Interrupt Enable Clear Register */
+#define USBC_UDINTECLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UDINTECLR reset_value) Device Global Interrupt Enable Clear Register */
 
 #define USBC_UDINTECLR_SUSPEC_Pos   0            /**< \brief (USBC_UDINTECLR) SUSP Interrupt Enable Clear */
-#define USBC_UDINTECLR_SUSPEC       (_U(0x1) << USBC_UDINTECLR_SUSPEC_Pos)
+#define USBC_UDINTECLR_SUSPEC       (_U_(0x1) << USBC_UDINTECLR_SUSPEC_Pos)
 #define USBC_UDINTECLR_MSOFEC_Pos   1            /**< \brief (USBC_UDINTECLR) MSOF Interrupt Enable Clear */
-#define USBC_UDINTECLR_MSOFEC       (_U(0x1) << USBC_UDINTECLR_MSOFEC_Pos)
+#define USBC_UDINTECLR_MSOFEC       (_U_(0x1) << USBC_UDINTECLR_MSOFEC_Pos)
 #define USBC_UDINTECLR_SOFEC_Pos    2            /**< \brief (USBC_UDINTECLR) SOF Interrupt Enable Clear */
-#define USBC_UDINTECLR_SOFEC        (_U(0x1) << USBC_UDINTECLR_SOFEC_Pos)
+#define USBC_UDINTECLR_SOFEC        (_U_(0x1) << USBC_UDINTECLR_SOFEC_Pos)
 #define USBC_UDINTECLR_EORSTEC_Pos  3            /**< \brief (USBC_UDINTECLR) EORST Interrupt Enable Clear */
-#define USBC_UDINTECLR_EORSTEC      (_U(0x1) << USBC_UDINTECLR_EORSTEC_Pos)
+#define USBC_UDINTECLR_EORSTEC      (_U_(0x1) << USBC_UDINTECLR_EORSTEC_Pos)
 #define USBC_UDINTECLR_WAKEUPEC_Pos 4            /**< \brief (USBC_UDINTECLR) WAKEUP Interrupt Enable Clear */
-#define USBC_UDINTECLR_WAKEUPEC     (_U(0x1) << USBC_UDINTECLR_WAKEUPEC_Pos)
+#define USBC_UDINTECLR_WAKEUPEC     (_U_(0x1) << USBC_UDINTECLR_WAKEUPEC_Pos)
 #define USBC_UDINTECLR_EORSMEC_Pos  5            /**< \brief (USBC_UDINTECLR) EORSM Interrupt Enable Clear */
-#define USBC_UDINTECLR_EORSMEC      (_U(0x1) << USBC_UDINTECLR_EORSMEC_Pos)
+#define USBC_UDINTECLR_EORSMEC      (_U_(0x1) << USBC_UDINTECLR_EORSMEC_Pos)
 #define USBC_UDINTECLR_UPRSMEC_Pos  6            /**< \brief (USBC_UDINTECLR) UPRSM Interrupt Enable Clear */
-#define USBC_UDINTECLR_UPRSMEC      (_U(0x1) << USBC_UDINTECLR_UPRSMEC_Pos)
+#define USBC_UDINTECLR_UPRSMEC      (_U_(0x1) << USBC_UDINTECLR_UPRSMEC_Pos)
 #define USBC_UDINTECLR_EP0INTEC_Pos 12           /**< \brief (USBC_UDINTECLR) EP0INT Interrupt Enable Clear */
-#define USBC_UDINTECLR_EP0INTEC     (_U(0x1) << USBC_UDINTECLR_EP0INTEC_Pos)
+#define USBC_UDINTECLR_EP0INTEC     (_U_(0x1) << USBC_UDINTECLR_EP0INTEC_Pos)
 #define USBC_UDINTECLR_EP1INTEC_Pos 13           /**< \brief (USBC_UDINTECLR) EP1INT Interrupt Enable Clear */
-#define USBC_UDINTECLR_EP1INTEC     (_U(0x1) << USBC_UDINTECLR_EP1INTEC_Pos)
+#define USBC_UDINTECLR_EP1INTEC     (_U_(0x1) << USBC_UDINTECLR_EP1INTEC_Pos)
 #define USBC_UDINTECLR_EP2INTEC_Pos 14           /**< \brief (USBC_UDINTECLR) EP2INT Interrupt Enable Clear */
-#define USBC_UDINTECLR_EP2INTEC     (_U(0x1) << USBC_UDINTECLR_EP2INTEC_Pos)
+#define USBC_UDINTECLR_EP2INTEC     (_U_(0x1) << USBC_UDINTECLR_EP2INTEC_Pos)
 #define USBC_UDINTECLR_EP3INTEC_Pos 15           /**< \brief (USBC_UDINTECLR) EP3INT Interrupt Enable Clear */
-#define USBC_UDINTECLR_EP3INTEC     (_U(0x1) << USBC_UDINTECLR_EP3INTEC_Pos)
+#define USBC_UDINTECLR_EP3INTEC     (_U_(0x1) << USBC_UDINTECLR_EP3INTEC_Pos)
 #define USBC_UDINTECLR_EP4INTEC_Pos 16           /**< \brief (USBC_UDINTECLR) EP4INT Interrupt Enable Clear */
-#define USBC_UDINTECLR_EP4INTEC     (_U(0x1) << USBC_UDINTECLR_EP4INTEC_Pos)
+#define USBC_UDINTECLR_EP4INTEC     (_U_(0x1) << USBC_UDINTECLR_EP4INTEC_Pos)
 #define USBC_UDINTECLR_EP5INTEC_Pos 17           /**< \brief (USBC_UDINTECLR) EP5INT Interrupt Enable Clear */
-#define USBC_UDINTECLR_EP5INTEC     (_U(0x1) << USBC_UDINTECLR_EP5INTEC_Pos)
+#define USBC_UDINTECLR_EP5INTEC     (_U_(0x1) << USBC_UDINTECLR_EP5INTEC_Pos)
 #define USBC_UDINTECLR_EP6INTEC_Pos 18           /**< \brief (USBC_UDINTECLR) EP6INT Interrupt Enable Clear */
-#define USBC_UDINTECLR_EP6INTEC     (_U(0x1) << USBC_UDINTECLR_EP6INTEC_Pos)
+#define USBC_UDINTECLR_EP6INTEC     (_U_(0x1) << USBC_UDINTECLR_EP6INTEC_Pos)
 #define USBC_UDINTECLR_EP7INTEC_Pos 19           /**< \brief (USBC_UDINTECLR) EP7INT Interrupt Enable Clear */
-#define USBC_UDINTECLR_EP7INTEC     (_U(0x1) << USBC_UDINTECLR_EP7INTEC_Pos)
-#define USBC_UDINTECLR_MASK         _U(0x000FF07F) /**< \brief (USBC_UDINTECLR) MASK Register */
+#define USBC_UDINTECLR_EP7INTEC     (_U_(0x1) << USBC_UDINTECLR_EP7INTEC_Pos)
+#define USBC_UDINTECLR_MASK         _U_(0x000FF07F) /**< \brief (USBC_UDINTECLR) MASK Register */
 
 /* -------- USBC_UDINTESET : (USBC Offset: 0x018) ( /W 32) Device Global Interrupt Enable Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -370,39 +370,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UDINTESET_OFFSET       0x018        /**< \brief (USBC_UDINTESET offset) Device Global Interrupt Enable Set Register */
-#define USBC_UDINTESET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UDINTESET reset_value) Device Global Interrupt Enable Set Register */
+#define USBC_UDINTESET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UDINTESET reset_value) Device Global Interrupt Enable Set Register */
 
 #define USBC_UDINTESET_SUSPES_Pos   0            /**< \brief (USBC_UDINTESET) SUSP Interrupt Enable Set */
-#define USBC_UDINTESET_SUSPES       (_U(0x1) << USBC_UDINTESET_SUSPES_Pos)
+#define USBC_UDINTESET_SUSPES       (_U_(0x1) << USBC_UDINTESET_SUSPES_Pos)
 #define USBC_UDINTESET_MSOFES_Pos   1            /**< \brief (USBC_UDINTESET) MSOF Interrupt Enable Set */
-#define USBC_UDINTESET_MSOFES       (_U(0x1) << USBC_UDINTESET_MSOFES_Pos)
+#define USBC_UDINTESET_MSOFES       (_U_(0x1) << USBC_UDINTESET_MSOFES_Pos)
 #define USBC_UDINTESET_SOFES_Pos    2            /**< \brief (USBC_UDINTESET) SOF Interrupt Enable Set */
-#define USBC_UDINTESET_SOFES        (_U(0x1) << USBC_UDINTESET_SOFES_Pos)
+#define USBC_UDINTESET_SOFES        (_U_(0x1) << USBC_UDINTESET_SOFES_Pos)
 #define USBC_UDINTESET_EORSTES_Pos  3            /**< \brief (USBC_UDINTESET) EORST Interrupt Enable Set */
-#define USBC_UDINTESET_EORSTES      (_U(0x1) << USBC_UDINTESET_EORSTES_Pos)
+#define USBC_UDINTESET_EORSTES      (_U_(0x1) << USBC_UDINTESET_EORSTES_Pos)
 #define USBC_UDINTESET_WAKEUPES_Pos 4            /**< \brief (USBC_UDINTESET) WAKEUP Interrupt Enable Set */
-#define USBC_UDINTESET_WAKEUPES     (_U(0x1) << USBC_UDINTESET_WAKEUPES_Pos)
+#define USBC_UDINTESET_WAKEUPES     (_U_(0x1) << USBC_UDINTESET_WAKEUPES_Pos)
 #define USBC_UDINTESET_EORSMES_Pos  5            /**< \brief (USBC_UDINTESET) EORSM Interrupt Enable Set */
-#define USBC_UDINTESET_EORSMES      (_U(0x1) << USBC_UDINTESET_EORSMES_Pos)
+#define USBC_UDINTESET_EORSMES      (_U_(0x1) << USBC_UDINTESET_EORSMES_Pos)
 #define USBC_UDINTESET_UPRSMES_Pos  6            /**< \brief (USBC_UDINTESET) UPRSM Interrupt Enable Set */
-#define USBC_UDINTESET_UPRSMES      (_U(0x1) << USBC_UDINTESET_UPRSMES_Pos)
+#define USBC_UDINTESET_UPRSMES      (_U_(0x1) << USBC_UDINTESET_UPRSMES_Pos)
 #define USBC_UDINTESET_EP0INTES_Pos 12           /**< \brief (USBC_UDINTESET) EP0INT Interrupt Enable Set */
-#define USBC_UDINTESET_EP0INTES     (_U(0x1) << USBC_UDINTESET_EP0INTES_Pos)
+#define USBC_UDINTESET_EP0INTES     (_U_(0x1) << USBC_UDINTESET_EP0INTES_Pos)
 #define USBC_UDINTESET_EP1INTES_Pos 13           /**< \brief (USBC_UDINTESET) EP1INT Interrupt Enable Set */
-#define USBC_UDINTESET_EP1INTES     (_U(0x1) << USBC_UDINTESET_EP1INTES_Pos)
+#define USBC_UDINTESET_EP1INTES     (_U_(0x1) << USBC_UDINTESET_EP1INTES_Pos)
 #define USBC_UDINTESET_EP2INTES_Pos 14           /**< \brief (USBC_UDINTESET) EP2INT Interrupt Enable Set */
-#define USBC_UDINTESET_EP2INTES     (_U(0x1) << USBC_UDINTESET_EP2INTES_Pos)
+#define USBC_UDINTESET_EP2INTES     (_U_(0x1) << USBC_UDINTESET_EP2INTES_Pos)
 #define USBC_UDINTESET_EP3INTES_Pos 15           /**< \brief (USBC_UDINTESET) EP3INT Interrupt Enable Set */
-#define USBC_UDINTESET_EP3INTES     (_U(0x1) << USBC_UDINTESET_EP3INTES_Pos)
+#define USBC_UDINTESET_EP3INTES     (_U_(0x1) << USBC_UDINTESET_EP3INTES_Pos)
 #define USBC_UDINTESET_EP4INTES_Pos 16           /**< \brief (USBC_UDINTESET) EP4INT Interrupt Enable Set */
-#define USBC_UDINTESET_EP4INTES     (_U(0x1) << USBC_UDINTESET_EP4INTES_Pos)
+#define USBC_UDINTESET_EP4INTES     (_U_(0x1) << USBC_UDINTESET_EP4INTES_Pos)
 #define USBC_UDINTESET_EP5INTES_Pos 17           /**< \brief (USBC_UDINTESET) EP5INT Interrupt Enable Set */
-#define USBC_UDINTESET_EP5INTES     (_U(0x1) << USBC_UDINTESET_EP5INTES_Pos)
+#define USBC_UDINTESET_EP5INTES     (_U_(0x1) << USBC_UDINTESET_EP5INTES_Pos)
 #define USBC_UDINTESET_EP6INTES_Pos 18           /**< \brief (USBC_UDINTESET) EP6INT Interrupt Enable Set */
-#define USBC_UDINTESET_EP6INTES     (_U(0x1) << USBC_UDINTESET_EP6INTES_Pos)
+#define USBC_UDINTESET_EP6INTES     (_U_(0x1) << USBC_UDINTESET_EP6INTES_Pos)
 #define USBC_UDINTESET_EP7INTES_Pos 19           /**< \brief (USBC_UDINTESET) EP7INT Interrupt Enable Set */
-#define USBC_UDINTESET_EP7INTES     (_U(0x1) << USBC_UDINTESET_EP7INTES_Pos)
-#define USBC_UDINTESET_MASK         _U(0x000FF07F) /**< \brief (USBC_UDINTESET) MASK Register */
+#define USBC_UDINTESET_EP7INTES     (_U_(0x1) << USBC_UDINTESET_EP7INTES_Pos)
+#define USBC_UDINTESET_MASK         _U_(0x000FF07F) /**< \brief (USBC_UDINTESET) MASK Register */
 
 /* -------- USBC_UERST : (USBC Offset: 0x01C) (R/W 32) Endpoint Enable/Reset Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -423,25 +423,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UERST_OFFSET           0x01C        /**< \brief (USBC_UERST offset) Endpoint Enable/Reset Register */
-#define USBC_UERST_RESETVALUE       _U(0x00000000); /**< \brief (USBC_UERST reset_value) Endpoint Enable/Reset Register */
+#define USBC_UERST_RESETVALUE       _U_(0x00000000); /**< \brief (USBC_UERST reset_value) Endpoint Enable/Reset Register */
 
 #define USBC_UERST_EPEN0_Pos        0            /**< \brief (USBC_UERST) Endpoint0 Enable */
-#define USBC_UERST_EPEN0            (_U(0x1) << USBC_UERST_EPEN0_Pos)
+#define USBC_UERST_EPEN0            (_U_(0x1) << USBC_UERST_EPEN0_Pos)
 #define USBC_UERST_EPEN1_Pos        1            /**< \brief (USBC_UERST) Endpoint1 Enable */
-#define USBC_UERST_EPEN1            (_U(0x1) << USBC_UERST_EPEN1_Pos)
+#define USBC_UERST_EPEN1            (_U_(0x1) << USBC_UERST_EPEN1_Pos)
 #define USBC_UERST_EPEN2_Pos        2            /**< \brief (USBC_UERST) Endpoint2 Enable */
-#define USBC_UERST_EPEN2            (_U(0x1) << USBC_UERST_EPEN2_Pos)
+#define USBC_UERST_EPEN2            (_U_(0x1) << USBC_UERST_EPEN2_Pos)
 #define USBC_UERST_EPEN3_Pos        3            /**< \brief (USBC_UERST) Endpoint3 Enable */
-#define USBC_UERST_EPEN3            (_U(0x1) << USBC_UERST_EPEN3_Pos)
+#define USBC_UERST_EPEN3            (_U_(0x1) << USBC_UERST_EPEN3_Pos)
 #define USBC_UERST_EPEN4_Pos        4            /**< \brief (USBC_UERST) Endpoint4 Enable */
-#define USBC_UERST_EPEN4            (_U(0x1) << USBC_UERST_EPEN4_Pos)
+#define USBC_UERST_EPEN4            (_U_(0x1) << USBC_UERST_EPEN4_Pos)
 #define USBC_UERST_EPEN5_Pos        5            /**< \brief (USBC_UERST) Endpoint5 Enable */
-#define USBC_UERST_EPEN5            (_U(0x1) << USBC_UERST_EPEN5_Pos)
+#define USBC_UERST_EPEN5            (_U_(0x1) << USBC_UERST_EPEN5_Pos)
 #define USBC_UERST_EPEN6_Pos        6            /**< \brief (USBC_UERST) Endpoint6 Enable */
-#define USBC_UERST_EPEN6            (_U(0x1) << USBC_UERST_EPEN6_Pos)
+#define USBC_UERST_EPEN6            (_U_(0x1) << USBC_UERST_EPEN6_Pos)
 #define USBC_UERST_EPEN7_Pos        7            /**< \brief (USBC_UERST) Endpoint7 Enable */
-#define USBC_UERST_EPEN7            (_U(0x1) << USBC_UERST_EPEN7_Pos)
-#define USBC_UERST_MASK             _U(0x000000FF) /**< \brief (USBC_UERST) MASK Register */
+#define USBC_UERST_EPEN7            (_U_(0x1) << USBC_UERST_EPEN7_Pos)
+#define USBC_UERST_MASK             _U_(0x000000FF) /**< \brief (USBC_UERST) MASK Register */
 
 /* -------- USBC_UDFNUM : (USBC Offset: 0x020) (R/  32) Device Frame Number Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -458,17 +458,17 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UDFNUM_OFFSET          0x020        /**< \brief (USBC_UDFNUM offset) Device Frame Number Register */
-#define USBC_UDFNUM_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UDFNUM reset_value) Device Frame Number Register */
+#define USBC_UDFNUM_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UDFNUM reset_value) Device Frame Number Register */
 
 #define USBC_UDFNUM_MFNUM_Pos       0            /**< \brief (USBC_UDFNUM) Micro Frame Number */
-#define USBC_UDFNUM_MFNUM_Msk       (_U(0x7) << USBC_UDFNUM_MFNUM_Pos)
+#define USBC_UDFNUM_MFNUM_Msk       (_U_(0x7) << USBC_UDFNUM_MFNUM_Pos)
 #define USBC_UDFNUM_MFNUM(value)    (USBC_UDFNUM_MFNUM_Msk & ((value) << USBC_UDFNUM_MFNUM_Pos))
 #define USBC_UDFNUM_FNUM_Pos        3            /**< \brief (USBC_UDFNUM) Frame Number */
-#define USBC_UDFNUM_FNUM_Msk        (_U(0x7FF) << USBC_UDFNUM_FNUM_Pos)
+#define USBC_UDFNUM_FNUM_Msk        (_U_(0x7FF) << USBC_UDFNUM_FNUM_Pos)
 #define USBC_UDFNUM_FNUM(value)     (USBC_UDFNUM_FNUM_Msk & ((value) << USBC_UDFNUM_FNUM_Pos))
 #define USBC_UDFNUM_FNCERR_Pos      15           /**< \brief (USBC_UDFNUM) Frame Number CRC Error */
-#define USBC_UDFNUM_FNCERR          (_U(0x1) << USBC_UDFNUM_FNCERR_Pos)
-#define USBC_UDFNUM_MASK            _U(0x0000BFFF) /**< \brief (USBC_UDFNUM) MASK Register */
+#define USBC_UDFNUM_FNCERR          (_U_(0x1) << USBC_UDFNUM_FNCERR_Pos)
+#define USBC_UDFNUM_MASK            _U_(0x0000BFFF) /**< \brief (USBC_UDFNUM) MASK Register */
 
 /* -------- USBC_UECFG0 : (USBC Offset: 0x100) (R/W 32) Endpoint Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -491,25 +491,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECFG0_OFFSET          0x100        /**< \brief (USBC_UECFG0 offset) Endpoint Configuration Register */
-#define USBC_UECFG0_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECFG0 reset_value) Endpoint Configuration Register */
+#define USBC_UECFG0_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UECFG0 reset_value) Endpoint Configuration Register */
 
 #define USBC_UECFG0_EPBK_Pos        2            /**< \brief (USBC_UECFG0) Endpoint Bank */
-#define USBC_UECFG0_EPBK            (_U(0x1) << USBC_UECFG0_EPBK_Pos)
-#define   USBC_UECFG0_EPBK_SINGLE_Val     _U(0x0)   /**< \brief (USBC_UECFG0)  */
-#define   USBC_UECFG0_EPBK_DOUBLE_Val     _U(0x1)   /**< \brief (USBC_UECFG0)  */
+#define USBC_UECFG0_EPBK            (_U_(0x1) << USBC_UECFG0_EPBK_Pos)
+#define   USBC_UECFG0_EPBK_SINGLE_Val     _U_(0x0)   /**< \brief (USBC_UECFG0)  */
+#define   USBC_UECFG0_EPBK_DOUBLE_Val     _U_(0x1)   /**< \brief (USBC_UECFG0)  */
 #define USBC_UECFG0_EPBK_SINGLE     (USBC_UECFG0_EPBK_SINGLE_Val   << USBC_UECFG0_EPBK_Pos)
 #define USBC_UECFG0_EPBK_DOUBLE     (USBC_UECFG0_EPBK_DOUBLE_Val   << USBC_UECFG0_EPBK_Pos)
 #define USBC_UECFG0_EPSIZE_Pos      4            /**< \brief (USBC_UECFG0) Endpoint Size */
-#define USBC_UECFG0_EPSIZE_Msk      (_U(0x7) << USBC_UECFG0_EPSIZE_Pos)
+#define USBC_UECFG0_EPSIZE_Msk      (_U_(0x7) << USBC_UECFG0_EPSIZE_Pos)
 #define USBC_UECFG0_EPSIZE(value)   (USBC_UECFG0_EPSIZE_Msk & ((value) << USBC_UECFG0_EPSIZE_Pos))
-#define   USBC_UECFG0_EPSIZE_8_Val        _U(0x0)   /**< \brief (USBC_UECFG0)  */
-#define   USBC_UECFG0_EPSIZE_16_Val       _U(0x1)   /**< \brief (USBC_UECFG0)  */
-#define   USBC_UECFG0_EPSIZE_32_Val       _U(0x2)   /**< \brief (USBC_UECFG0)  */
-#define   USBC_UECFG0_EPSIZE_64_Val       _U(0x3)   /**< \brief (USBC_UECFG0)  */
-#define   USBC_UECFG0_EPSIZE_128_Val      _U(0x4)   /**< \brief (USBC_UECFG0)  */
-#define   USBC_UECFG0_EPSIZE_256_Val      _U(0x5)   /**< \brief (USBC_UECFG0)  */
-#define   USBC_UECFG0_EPSIZE_512_Val      _U(0x6)   /**< \brief (USBC_UECFG0)  */
-#define   USBC_UECFG0_EPSIZE_1024_Val     _U(0x7)   /**< \brief (USBC_UECFG0)  */
+#define   USBC_UECFG0_EPSIZE_8_Val        _U_(0x0)   /**< \brief (USBC_UECFG0)  */
+#define   USBC_UECFG0_EPSIZE_16_Val       _U_(0x1)   /**< \brief (USBC_UECFG0)  */
+#define   USBC_UECFG0_EPSIZE_32_Val       _U_(0x2)   /**< \brief (USBC_UECFG0)  */
+#define   USBC_UECFG0_EPSIZE_64_Val       _U_(0x3)   /**< \brief (USBC_UECFG0)  */
+#define   USBC_UECFG0_EPSIZE_128_Val      _U_(0x4)   /**< \brief (USBC_UECFG0)  */
+#define   USBC_UECFG0_EPSIZE_256_Val      _U_(0x5)   /**< \brief (USBC_UECFG0)  */
+#define   USBC_UECFG0_EPSIZE_512_Val      _U_(0x6)   /**< \brief (USBC_UECFG0)  */
+#define   USBC_UECFG0_EPSIZE_1024_Val     _U_(0x7)   /**< \brief (USBC_UECFG0)  */
 #define USBC_UECFG0_EPSIZE_8        (USBC_UECFG0_EPSIZE_8_Val      << USBC_UECFG0_EPSIZE_Pos)
 #define USBC_UECFG0_EPSIZE_16       (USBC_UECFG0_EPSIZE_16_Val     << USBC_UECFG0_EPSIZE_Pos)
 #define USBC_UECFG0_EPSIZE_32       (USBC_UECFG0_EPSIZE_32_Val     << USBC_UECFG0_EPSIZE_Pos)
@@ -519,26 +519,26 @@ typedef union {
 #define USBC_UECFG0_EPSIZE_512      (USBC_UECFG0_EPSIZE_512_Val    << USBC_UECFG0_EPSIZE_Pos)
 #define USBC_UECFG0_EPSIZE_1024     (USBC_UECFG0_EPSIZE_1024_Val   << USBC_UECFG0_EPSIZE_Pos)
 #define USBC_UECFG0_EPDIR_Pos       8            /**< \brief (USBC_UECFG0) Endpoint Direction */
-#define USBC_UECFG0_EPDIR           (_U(0x1) << USBC_UECFG0_EPDIR_Pos)
-#define   USBC_UECFG0_EPDIR_OUT_Val       _U(0x0)   /**< \brief (USBC_UECFG0)  */
-#define   USBC_UECFG0_EPDIR_IN_Val        _U(0x1)   /**< \brief (USBC_UECFG0)  */
+#define USBC_UECFG0_EPDIR           (_U_(0x1) << USBC_UECFG0_EPDIR_Pos)
+#define   USBC_UECFG0_EPDIR_OUT_Val       _U_(0x0)   /**< \brief (USBC_UECFG0)  */
+#define   USBC_UECFG0_EPDIR_IN_Val        _U_(0x1)   /**< \brief (USBC_UECFG0)  */
 #define USBC_UECFG0_EPDIR_OUT       (USBC_UECFG0_EPDIR_OUT_Val     << USBC_UECFG0_EPDIR_Pos)
 #define USBC_UECFG0_EPDIR_IN        (USBC_UECFG0_EPDIR_IN_Val      << USBC_UECFG0_EPDIR_Pos)
 #define USBC_UECFG0_EPTYPE_Pos      11           /**< \brief (USBC_UECFG0) Endpoint Type */
-#define USBC_UECFG0_EPTYPE_Msk      (_U(0x3) << USBC_UECFG0_EPTYPE_Pos)
+#define USBC_UECFG0_EPTYPE_Msk      (_U_(0x3) << USBC_UECFG0_EPTYPE_Pos)
 #define USBC_UECFG0_EPTYPE(value)   (USBC_UECFG0_EPTYPE_Msk & ((value) << USBC_UECFG0_EPTYPE_Pos))
-#define   USBC_UECFG0_EPTYPE_CONTROL_Val  _U(0x0)   /**< \brief (USBC_UECFG0)  */
-#define   USBC_UECFG0_EPTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UECFG0)  */
-#define   USBC_UECFG0_EPTYPE_BULK_Val     _U(0x2)   /**< \brief (USBC_UECFG0)  */
-#define   USBC_UECFG0_EPTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UECFG0)  */
+#define   USBC_UECFG0_EPTYPE_CONTROL_Val  _U_(0x0)   /**< \brief (USBC_UECFG0)  */
+#define   USBC_UECFG0_EPTYPE_ISOCHRONOUS_Val _U_(0x1)   /**< \brief (USBC_UECFG0)  */
+#define   USBC_UECFG0_EPTYPE_BULK_Val     _U_(0x2)   /**< \brief (USBC_UECFG0)  */
+#define   USBC_UECFG0_EPTYPE_INTERRUPT_Val _U_(0x3)   /**< \brief (USBC_UECFG0)  */
 #define USBC_UECFG0_EPTYPE_CONTROL  (USBC_UECFG0_EPTYPE_CONTROL_Val << USBC_UECFG0_EPTYPE_Pos)
 #define USBC_UECFG0_EPTYPE_ISOCHRONOUS (USBC_UECFG0_EPTYPE_ISOCHRONOUS_Val << USBC_UECFG0_EPTYPE_Pos)
 #define USBC_UECFG0_EPTYPE_BULK     (USBC_UECFG0_EPTYPE_BULK_Val   << USBC_UECFG0_EPTYPE_Pos)
 #define USBC_UECFG0_EPTYPE_INTERRUPT (USBC_UECFG0_EPTYPE_INTERRUPT_Val << USBC_UECFG0_EPTYPE_Pos)
 #define USBC_UECFG0_REPNB_Pos       16           /**< \brief (USBC_UECFG0) Redirected Endpoint Number */
-#define USBC_UECFG0_REPNB_Msk       (_U(0xF) << USBC_UECFG0_REPNB_Pos)
+#define USBC_UECFG0_REPNB_Msk       (_U_(0xF) << USBC_UECFG0_REPNB_Pos)
 #define USBC_UECFG0_REPNB(value)    (USBC_UECFG0_REPNB_Msk & ((value) << USBC_UECFG0_REPNB_Pos))
-#define USBC_UECFG0_MASK            _U(0x000F1974) /**< \brief (USBC_UECFG0) MASK Register */
+#define USBC_UECFG0_MASK            _U_(0x000F1974) /**< \brief (USBC_UECFG0) MASK Register */
 
 /* -------- USBC_UECFG1 : (USBC Offset: 0x104) (R/W 32) Endpoint Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -561,25 +561,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECFG1_OFFSET          0x104        /**< \brief (USBC_UECFG1 offset) Endpoint Configuration Register */
-#define USBC_UECFG1_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECFG1 reset_value) Endpoint Configuration Register */
+#define USBC_UECFG1_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UECFG1 reset_value) Endpoint Configuration Register */
 
 #define USBC_UECFG1_EPBK_Pos        2            /**< \brief (USBC_UECFG1) Endpoint Bank */
-#define USBC_UECFG1_EPBK            (_U(0x1) << USBC_UECFG1_EPBK_Pos)
-#define   USBC_UECFG1_EPBK_SINGLE_Val     _U(0x0)   /**< \brief (USBC_UECFG1)  */
-#define   USBC_UECFG1_EPBK_DOUBLE_Val     _U(0x1)   /**< \brief (USBC_UECFG1)  */
+#define USBC_UECFG1_EPBK            (_U_(0x1) << USBC_UECFG1_EPBK_Pos)
+#define   USBC_UECFG1_EPBK_SINGLE_Val     _U_(0x0)   /**< \brief (USBC_UECFG1)  */
+#define   USBC_UECFG1_EPBK_DOUBLE_Val     _U_(0x1)   /**< \brief (USBC_UECFG1)  */
 #define USBC_UECFG1_EPBK_SINGLE     (USBC_UECFG1_EPBK_SINGLE_Val   << USBC_UECFG1_EPBK_Pos)
 #define USBC_UECFG1_EPBK_DOUBLE     (USBC_UECFG1_EPBK_DOUBLE_Val   << USBC_UECFG1_EPBK_Pos)
 #define USBC_UECFG1_EPSIZE_Pos      4            /**< \brief (USBC_UECFG1) Endpoint Size */
-#define USBC_UECFG1_EPSIZE_Msk      (_U(0x7) << USBC_UECFG1_EPSIZE_Pos)
+#define USBC_UECFG1_EPSIZE_Msk      (_U_(0x7) << USBC_UECFG1_EPSIZE_Pos)
 #define USBC_UECFG1_EPSIZE(value)   (USBC_UECFG1_EPSIZE_Msk & ((value) << USBC_UECFG1_EPSIZE_Pos))
-#define   USBC_UECFG1_EPSIZE_8_Val        _U(0x0)   /**< \brief (USBC_UECFG1)  */
-#define   USBC_UECFG1_EPSIZE_16_Val       _U(0x1)   /**< \brief (USBC_UECFG1)  */
-#define   USBC_UECFG1_EPSIZE_32_Val       _U(0x2)   /**< \brief (USBC_UECFG1)  */
-#define   USBC_UECFG1_EPSIZE_64_Val       _U(0x3)   /**< \brief (USBC_UECFG1)  */
-#define   USBC_UECFG1_EPSIZE_128_Val      _U(0x4)   /**< \brief (USBC_UECFG1)  */
-#define   USBC_UECFG1_EPSIZE_256_Val      _U(0x5)   /**< \brief (USBC_UECFG1)  */
-#define   USBC_UECFG1_EPSIZE_512_Val      _U(0x6)   /**< \brief (USBC_UECFG1)  */
-#define   USBC_UECFG1_EPSIZE_1024_Val     _U(0x7)   /**< \brief (USBC_UECFG1)  */
+#define   USBC_UECFG1_EPSIZE_8_Val        _U_(0x0)   /**< \brief (USBC_UECFG1)  */
+#define   USBC_UECFG1_EPSIZE_16_Val       _U_(0x1)   /**< \brief (USBC_UECFG1)  */
+#define   USBC_UECFG1_EPSIZE_32_Val       _U_(0x2)   /**< \brief (USBC_UECFG1)  */
+#define   USBC_UECFG1_EPSIZE_64_Val       _U_(0x3)   /**< \brief (USBC_UECFG1)  */
+#define   USBC_UECFG1_EPSIZE_128_Val      _U_(0x4)   /**< \brief (USBC_UECFG1)  */
+#define   USBC_UECFG1_EPSIZE_256_Val      _U_(0x5)   /**< \brief (USBC_UECFG1)  */
+#define   USBC_UECFG1_EPSIZE_512_Val      _U_(0x6)   /**< \brief (USBC_UECFG1)  */
+#define   USBC_UECFG1_EPSIZE_1024_Val     _U_(0x7)   /**< \brief (USBC_UECFG1)  */
 #define USBC_UECFG1_EPSIZE_8        (USBC_UECFG1_EPSIZE_8_Val      << USBC_UECFG1_EPSIZE_Pos)
 #define USBC_UECFG1_EPSIZE_16       (USBC_UECFG1_EPSIZE_16_Val     << USBC_UECFG1_EPSIZE_Pos)
 #define USBC_UECFG1_EPSIZE_32       (USBC_UECFG1_EPSIZE_32_Val     << USBC_UECFG1_EPSIZE_Pos)
@@ -589,26 +589,26 @@ typedef union {
 #define USBC_UECFG1_EPSIZE_512      (USBC_UECFG1_EPSIZE_512_Val    << USBC_UECFG1_EPSIZE_Pos)
 #define USBC_UECFG1_EPSIZE_1024     (USBC_UECFG1_EPSIZE_1024_Val   << USBC_UECFG1_EPSIZE_Pos)
 #define USBC_UECFG1_EPDIR_Pos       8            /**< \brief (USBC_UECFG1) Endpoint Direction */
-#define USBC_UECFG1_EPDIR           (_U(0x1) << USBC_UECFG1_EPDIR_Pos)
-#define   USBC_UECFG1_EPDIR_OUT_Val       _U(0x0)   /**< \brief (USBC_UECFG1)  */
-#define   USBC_UECFG1_EPDIR_IN_Val        _U(0x1)   /**< \brief (USBC_UECFG1)  */
+#define USBC_UECFG1_EPDIR           (_U_(0x1) << USBC_UECFG1_EPDIR_Pos)
+#define   USBC_UECFG1_EPDIR_OUT_Val       _U_(0x0)   /**< \brief (USBC_UECFG1)  */
+#define   USBC_UECFG1_EPDIR_IN_Val        _U_(0x1)   /**< \brief (USBC_UECFG1)  */
 #define USBC_UECFG1_EPDIR_OUT       (USBC_UECFG1_EPDIR_OUT_Val     << USBC_UECFG1_EPDIR_Pos)
 #define USBC_UECFG1_EPDIR_IN        (USBC_UECFG1_EPDIR_IN_Val      << USBC_UECFG1_EPDIR_Pos)
 #define USBC_UECFG1_EPTYPE_Pos      11           /**< \brief (USBC_UECFG1) Endpoint Type */
-#define USBC_UECFG1_EPTYPE_Msk      (_U(0x3) << USBC_UECFG1_EPTYPE_Pos)
+#define USBC_UECFG1_EPTYPE_Msk      (_U_(0x3) << USBC_UECFG1_EPTYPE_Pos)
 #define USBC_UECFG1_EPTYPE(value)   (USBC_UECFG1_EPTYPE_Msk & ((value) << USBC_UECFG1_EPTYPE_Pos))
-#define   USBC_UECFG1_EPTYPE_CONTROL_Val  _U(0x0)   /**< \brief (USBC_UECFG1)  */
-#define   USBC_UECFG1_EPTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UECFG1)  */
-#define   USBC_UECFG1_EPTYPE_BULK_Val     _U(0x2)   /**< \brief (USBC_UECFG1)  */
-#define   USBC_UECFG1_EPTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UECFG1)  */
+#define   USBC_UECFG1_EPTYPE_CONTROL_Val  _U_(0x0)   /**< \brief (USBC_UECFG1)  */
+#define   USBC_UECFG1_EPTYPE_ISOCHRONOUS_Val _U_(0x1)   /**< \brief (USBC_UECFG1)  */
+#define   USBC_UECFG1_EPTYPE_BULK_Val     _U_(0x2)   /**< \brief (USBC_UECFG1)  */
+#define   USBC_UECFG1_EPTYPE_INTERRUPT_Val _U_(0x3)   /**< \brief (USBC_UECFG1)  */
 #define USBC_UECFG1_EPTYPE_CONTROL  (USBC_UECFG1_EPTYPE_CONTROL_Val << USBC_UECFG1_EPTYPE_Pos)
 #define USBC_UECFG1_EPTYPE_ISOCHRONOUS (USBC_UECFG1_EPTYPE_ISOCHRONOUS_Val << USBC_UECFG1_EPTYPE_Pos)
 #define USBC_UECFG1_EPTYPE_BULK     (USBC_UECFG1_EPTYPE_BULK_Val   << USBC_UECFG1_EPTYPE_Pos)
 #define USBC_UECFG1_EPTYPE_INTERRUPT (USBC_UECFG1_EPTYPE_INTERRUPT_Val << USBC_UECFG1_EPTYPE_Pos)
 #define USBC_UECFG1_REPNB_Pos       16           /**< \brief (USBC_UECFG1) Redirected Endpoint Number */
-#define USBC_UECFG1_REPNB_Msk       (_U(0xF) << USBC_UECFG1_REPNB_Pos)
+#define USBC_UECFG1_REPNB_Msk       (_U_(0xF) << USBC_UECFG1_REPNB_Pos)
 #define USBC_UECFG1_REPNB(value)    (USBC_UECFG1_REPNB_Msk & ((value) << USBC_UECFG1_REPNB_Pos))
-#define USBC_UECFG1_MASK            _U(0x000F1974) /**< \brief (USBC_UECFG1) MASK Register */
+#define USBC_UECFG1_MASK            _U_(0x000F1974) /**< \brief (USBC_UECFG1) MASK Register */
 
 /* -------- USBC_UECFG2 : (USBC Offset: 0x108) (R/W 32) Endpoint Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -631,25 +631,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECFG2_OFFSET          0x108        /**< \brief (USBC_UECFG2 offset) Endpoint Configuration Register */
-#define USBC_UECFG2_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECFG2 reset_value) Endpoint Configuration Register */
+#define USBC_UECFG2_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UECFG2 reset_value) Endpoint Configuration Register */
 
 #define USBC_UECFG2_EPBK_Pos        2            /**< \brief (USBC_UECFG2) Endpoint Bank */
-#define USBC_UECFG2_EPBK            (_U(0x1) << USBC_UECFG2_EPBK_Pos)
-#define   USBC_UECFG2_EPBK_SINGLE_Val     _U(0x0)   /**< \brief (USBC_UECFG2)  */
-#define   USBC_UECFG2_EPBK_DOUBLE_Val     _U(0x1)   /**< \brief (USBC_UECFG2)  */
+#define USBC_UECFG2_EPBK            (_U_(0x1) << USBC_UECFG2_EPBK_Pos)
+#define   USBC_UECFG2_EPBK_SINGLE_Val     _U_(0x0)   /**< \brief (USBC_UECFG2)  */
+#define   USBC_UECFG2_EPBK_DOUBLE_Val     _U_(0x1)   /**< \brief (USBC_UECFG2)  */
 #define USBC_UECFG2_EPBK_SINGLE     (USBC_UECFG2_EPBK_SINGLE_Val   << USBC_UECFG2_EPBK_Pos)
 #define USBC_UECFG2_EPBK_DOUBLE     (USBC_UECFG2_EPBK_DOUBLE_Val   << USBC_UECFG2_EPBK_Pos)
 #define USBC_UECFG2_EPSIZE_Pos      4            /**< \brief (USBC_UECFG2) Endpoint Size */
-#define USBC_UECFG2_EPSIZE_Msk      (_U(0x7) << USBC_UECFG2_EPSIZE_Pos)
+#define USBC_UECFG2_EPSIZE_Msk      (_U_(0x7) << USBC_UECFG2_EPSIZE_Pos)
 #define USBC_UECFG2_EPSIZE(value)   (USBC_UECFG2_EPSIZE_Msk & ((value) << USBC_UECFG2_EPSIZE_Pos))
-#define   USBC_UECFG2_EPSIZE_8_Val        _U(0x0)   /**< \brief (USBC_UECFG2)  */
-#define   USBC_UECFG2_EPSIZE_16_Val       _U(0x1)   /**< \brief (USBC_UECFG2)  */
-#define   USBC_UECFG2_EPSIZE_32_Val       _U(0x2)   /**< \brief (USBC_UECFG2)  */
-#define   USBC_UECFG2_EPSIZE_64_Val       _U(0x3)   /**< \brief (USBC_UECFG2)  */
-#define   USBC_UECFG2_EPSIZE_128_Val      _U(0x4)   /**< \brief (USBC_UECFG2)  */
-#define   USBC_UECFG2_EPSIZE_256_Val      _U(0x5)   /**< \brief (USBC_UECFG2)  */
-#define   USBC_UECFG2_EPSIZE_512_Val      _U(0x6)   /**< \brief (USBC_UECFG2)  */
-#define   USBC_UECFG2_EPSIZE_1024_Val     _U(0x7)   /**< \brief (USBC_UECFG2)  */
+#define   USBC_UECFG2_EPSIZE_8_Val        _U_(0x0)   /**< \brief (USBC_UECFG2)  */
+#define   USBC_UECFG2_EPSIZE_16_Val       _U_(0x1)   /**< \brief (USBC_UECFG2)  */
+#define   USBC_UECFG2_EPSIZE_32_Val       _U_(0x2)   /**< \brief (USBC_UECFG2)  */
+#define   USBC_UECFG2_EPSIZE_64_Val       _U_(0x3)   /**< \brief (USBC_UECFG2)  */
+#define   USBC_UECFG2_EPSIZE_128_Val      _U_(0x4)   /**< \brief (USBC_UECFG2)  */
+#define   USBC_UECFG2_EPSIZE_256_Val      _U_(0x5)   /**< \brief (USBC_UECFG2)  */
+#define   USBC_UECFG2_EPSIZE_512_Val      _U_(0x6)   /**< \brief (USBC_UECFG2)  */
+#define   USBC_UECFG2_EPSIZE_1024_Val     _U_(0x7)   /**< \brief (USBC_UECFG2)  */
 #define USBC_UECFG2_EPSIZE_8        (USBC_UECFG2_EPSIZE_8_Val      << USBC_UECFG2_EPSIZE_Pos)
 #define USBC_UECFG2_EPSIZE_16       (USBC_UECFG2_EPSIZE_16_Val     << USBC_UECFG2_EPSIZE_Pos)
 #define USBC_UECFG2_EPSIZE_32       (USBC_UECFG2_EPSIZE_32_Val     << USBC_UECFG2_EPSIZE_Pos)
@@ -659,26 +659,26 @@ typedef union {
 #define USBC_UECFG2_EPSIZE_512      (USBC_UECFG2_EPSIZE_512_Val    << USBC_UECFG2_EPSIZE_Pos)
 #define USBC_UECFG2_EPSIZE_1024     (USBC_UECFG2_EPSIZE_1024_Val   << USBC_UECFG2_EPSIZE_Pos)
 #define USBC_UECFG2_EPDIR_Pos       8            /**< \brief (USBC_UECFG2) Endpoint Direction */
-#define USBC_UECFG2_EPDIR           (_U(0x1) << USBC_UECFG2_EPDIR_Pos)
-#define   USBC_UECFG2_EPDIR_OUT_Val       _U(0x0)   /**< \brief (USBC_UECFG2)  */
-#define   USBC_UECFG2_EPDIR_IN_Val        _U(0x1)   /**< \brief (USBC_UECFG2)  */
+#define USBC_UECFG2_EPDIR           (_U_(0x1) << USBC_UECFG2_EPDIR_Pos)
+#define   USBC_UECFG2_EPDIR_OUT_Val       _U_(0x0)   /**< \brief (USBC_UECFG2)  */
+#define   USBC_UECFG2_EPDIR_IN_Val        _U_(0x1)   /**< \brief (USBC_UECFG2)  */
 #define USBC_UECFG2_EPDIR_OUT       (USBC_UECFG2_EPDIR_OUT_Val     << USBC_UECFG2_EPDIR_Pos)
 #define USBC_UECFG2_EPDIR_IN        (USBC_UECFG2_EPDIR_IN_Val      << USBC_UECFG2_EPDIR_Pos)
 #define USBC_UECFG2_EPTYPE_Pos      11           /**< \brief (USBC_UECFG2) Endpoint Type */
-#define USBC_UECFG2_EPTYPE_Msk      (_U(0x3) << USBC_UECFG2_EPTYPE_Pos)
+#define USBC_UECFG2_EPTYPE_Msk      (_U_(0x3) << USBC_UECFG2_EPTYPE_Pos)
 #define USBC_UECFG2_EPTYPE(value)   (USBC_UECFG2_EPTYPE_Msk & ((value) << USBC_UECFG2_EPTYPE_Pos))
-#define   USBC_UECFG2_EPTYPE_CONTROL_Val  _U(0x0)   /**< \brief (USBC_UECFG2)  */
-#define   USBC_UECFG2_EPTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UECFG2)  */
-#define   USBC_UECFG2_EPTYPE_BULK_Val     _U(0x2)   /**< \brief (USBC_UECFG2)  */
-#define   USBC_UECFG2_EPTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UECFG2)  */
+#define   USBC_UECFG2_EPTYPE_CONTROL_Val  _U_(0x0)   /**< \brief (USBC_UECFG2)  */
+#define   USBC_UECFG2_EPTYPE_ISOCHRONOUS_Val _U_(0x1)   /**< \brief (USBC_UECFG2)  */
+#define   USBC_UECFG2_EPTYPE_BULK_Val     _U_(0x2)   /**< \brief (USBC_UECFG2)  */
+#define   USBC_UECFG2_EPTYPE_INTERRUPT_Val _U_(0x3)   /**< \brief (USBC_UECFG2)  */
 #define USBC_UECFG2_EPTYPE_CONTROL  (USBC_UECFG2_EPTYPE_CONTROL_Val << USBC_UECFG2_EPTYPE_Pos)
 #define USBC_UECFG2_EPTYPE_ISOCHRONOUS (USBC_UECFG2_EPTYPE_ISOCHRONOUS_Val << USBC_UECFG2_EPTYPE_Pos)
 #define USBC_UECFG2_EPTYPE_BULK     (USBC_UECFG2_EPTYPE_BULK_Val   << USBC_UECFG2_EPTYPE_Pos)
 #define USBC_UECFG2_EPTYPE_INTERRUPT (USBC_UECFG2_EPTYPE_INTERRUPT_Val << USBC_UECFG2_EPTYPE_Pos)
 #define USBC_UECFG2_REPNB_Pos       16           /**< \brief (USBC_UECFG2) Redirected Endpoint Number */
-#define USBC_UECFG2_REPNB_Msk       (_U(0xF) << USBC_UECFG2_REPNB_Pos)
+#define USBC_UECFG2_REPNB_Msk       (_U_(0xF) << USBC_UECFG2_REPNB_Pos)
 #define USBC_UECFG2_REPNB(value)    (USBC_UECFG2_REPNB_Msk & ((value) << USBC_UECFG2_REPNB_Pos))
-#define USBC_UECFG2_MASK            _U(0x000F1974) /**< \brief (USBC_UECFG2) MASK Register */
+#define USBC_UECFG2_MASK            _U_(0x000F1974) /**< \brief (USBC_UECFG2) MASK Register */
 
 /* -------- USBC_UECFG3 : (USBC Offset: 0x10C) (R/W 32) Endpoint Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -701,25 +701,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECFG3_OFFSET          0x10C        /**< \brief (USBC_UECFG3 offset) Endpoint Configuration Register */
-#define USBC_UECFG3_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECFG3 reset_value) Endpoint Configuration Register */
+#define USBC_UECFG3_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UECFG3 reset_value) Endpoint Configuration Register */
 
 #define USBC_UECFG3_EPBK_Pos        2            /**< \brief (USBC_UECFG3) Endpoint Bank */
-#define USBC_UECFG3_EPBK            (_U(0x1) << USBC_UECFG3_EPBK_Pos)
-#define   USBC_UECFG3_EPBK_SINGLE_Val     _U(0x0)   /**< \brief (USBC_UECFG3)  */
-#define   USBC_UECFG3_EPBK_DOUBLE_Val     _U(0x1)   /**< \brief (USBC_UECFG3)  */
+#define USBC_UECFG3_EPBK            (_U_(0x1) << USBC_UECFG3_EPBK_Pos)
+#define   USBC_UECFG3_EPBK_SINGLE_Val     _U_(0x0)   /**< \brief (USBC_UECFG3)  */
+#define   USBC_UECFG3_EPBK_DOUBLE_Val     _U_(0x1)   /**< \brief (USBC_UECFG3)  */
 #define USBC_UECFG3_EPBK_SINGLE     (USBC_UECFG3_EPBK_SINGLE_Val   << USBC_UECFG3_EPBK_Pos)
 #define USBC_UECFG3_EPBK_DOUBLE     (USBC_UECFG3_EPBK_DOUBLE_Val   << USBC_UECFG3_EPBK_Pos)
 #define USBC_UECFG3_EPSIZE_Pos      4            /**< \brief (USBC_UECFG3) Endpoint Size */
-#define USBC_UECFG3_EPSIZE_Msk      (_U(0x7) << USBC_UECFG3_EPSIZE_Pos)
+#define USBC_UECFG3_EPSIZE_Msk      (_U_(0x7) << USBC_UECFG3_EPSIZE_Pos)
 #define USBC_UECFG3_EPSIZE(value)   (USBC_UECFG3_EPSIZE_Msk & ((value) << USBC_UECFG3_EPSIZE_Pos))
-#define   USBC_UECFG3_EPSIZE_8_Val        _U(0x0)   /**< \brief (USBC_UECFG3)  */
-#define   USBC_UECFG3_EPSIZE_16_Val       _U(0x1)   /**< \brief (USBC_UECFG3)  */
-#define   USBC_UECFG3_EPSIZE_32_Val       _U(0x2)   /**< \brief (USBC_UECFG3)  */
-#define   USBC_UECFG3_EPSIZE_64_Val       _U(0x3)   /**< \brief (USBC_UECFG3)  */
-#define   USBC_UECFG3_EPSIZE_128_Val      _U(0x4)   /**< \brief (USBC_UECFG3)  */
-#define   USBC_UECFG3_EPSIZE_256_Val      _U(0x5)   /**< \brief (USBC_UECFG3)  */
-#define   USBC_UECFG3_EPSIZE_512_Val      _U(0x6)   /**< \brief (USBC_UECFG3)  */
-#define   USBC_UECFG3_EPSIZE_1024_Val     _U(0x7)   /**< \brief (USBC_UECFG3)  */
+#define   USBC_UECFG3_EPSIZE_8_Val        _U_(0x0)   /**< \brief (USBC_UECFG3)  */
+#define   USBC_UECFG3_EPSIZE_16_Val       _U_(0x1)   /**< \brief (USBC_UECFG3)  */
+#define   USBC_UECFG3_EPSIZE_32_Val       _U_(0x2)   /**< \brief (USBC_UECFG3)  */
+#define   USBC_UECFG3_EPSIZE_64_Val       _U_(0x3)   /**< \brief (USBC_UECFG3)  */
+#define   USBC_UECFG3_EPSIZE_128_Val      _U_(0x4)   /**< \brief (USBC_UECFG3)  */
+#define   USBC_UECFG3_EPSIZE_256_Val      _U_(0x5)   /**< \brief (USBC_UECFG3)  */
+#define   USBC_UECFG3_EPSIZE_512_Val      _U_(0x6)   /**< \brief (USBC_UECFG3)  */
+#define   USBC_UECFG3_EPSIZE_1024_Val     _U_(0x7)   /**< \brief (USBC_UECFG3)  */
 #define USBC_UECFG3_EPSIZE_8        (USBC_UECFG3_EPSIZE_8_Val      << USBC_UECFG3_EPSIZE_Pos)
 #define USBC_UECFG3_EPSIZE_16       (USBC_UECFG3_EPSIZE_16_Val     << USBC_UECFG3_EPSIZE_Pos)
 #define USBC_UECFG3_EPSIZE_32       (USBC_UECFG3_EPSIZE_32_Val     << USBC_UECFG3_EPSIZE_Pos)
@@ -729,26 +729,26 @@ typedef union {
 #define USBC_UECFG3_EPSIZE_512      (USBC_UECFG3_EPSIZE_512_Val    << USBC_UECFG3_EPSIZE_Pos)
 #define USBC_UECFG3_EPSIZE_1024     (USBC_UECFG3_EPSIZE_1024_Val   << USBC_UECFG3_EPSIZE_Pos)
 #define USBC_UECFG3_EPDIR_Pos       8            /**< \brief (USBC_UECFG3) Endpoint Direction */
-#define USBC_UECFG3_EPDIR           (_U(0x1) << USBC_UECFG3_EPDIR_Pos)
-#define   USBC_UECFG3_EPDIR_OUT_Val       _U(0x0)   /**< \brief (USBC_UECFG3)  */
-#define   USBC_UECFG3_EPDIR_IN_Val        _U(0x1)   /**< \brief (USBC_UECFG3)  */
+#define USBC_UECFG3_EPDIR           (_U_(0x1) << USBC_UECFG3_EPDIR_Pos)
+#define   USBC_UECFG3_EPDIR_OUT_Val       _U_(0x0)   /**< \brief (USBC_UECFG3)  */
+#define   USBC_UECFG3_EPDIR_IN_Val        _U_(0x1)   /**< \brief (USBC_UECFG3)  */
 #define USBC_UECFG3_EPDIR_OUT       (USBC_UECFG3_EPDIR_OUT_Val     << USBC_UECFG3_EPDIR_Pos)
 #define USBC_UECFG3_EPDIR_IN        (USBC_UECFG3_EPDIR_IN_Val      << USBC_UECFG3_EPDIR_Pos)
 #define USBC_UECFG3_EPTYPE_Pos      11           /**< \brief (USBC_UECFG3) Endpoint Type */
-#define USBC_UECFG3_EPTYPE_Msk      (_U(0x3) << USBC_UECFG3_EPTYPE_Pos)
+#define USBC_UECFG3_EPTYPE_Msk      (_U_(0x3) << USBC_UECFG3_EPTYPE_Pos)
 #define USBC_UECFG3_EPTYPE(value)   (USBC_UECFG3_EPTYPE_Msk & ((value) << USBC_UECFG3_EPTYPE_Pos))
-#define   USBC_UECFG3_EPTYPE_CONTROL_Val  _U(0x0)   /**< \brief (USBC_UECFG3)  */
-#define   USBC_UECFG3_EPTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UECFG3)  */
-#define   USBC_UECFG3_EPTYPE_BULK_Val     _U(0x2)   /**< \brief (USBC_UECFG3)  */
-#define   USBC_UECFG3_EPTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UECFG3)  */
+#define   USBC_UECFG3_EPTYPE_CONTROL_Val  _U_(0x0)   /**< \brief (USBC_UECFG3)  */
+#define   USBC_UECFG3_EPTYPE_ISOCHRONOUS_Val _U_(0x1)   /**< \brief (USBC_UECFG3)  */
+#define   USBC_UECFG3_EPTYPE_BULK_Val     _U_(0x2)   /**< \brief (USBC_UECFG3)  */
+#define   USBC_UECFG3_EPTYPE_INTERRUPT_Val _U_(0x3)   /**< \brief (USBC_UECFG3)  */
 #define USBC_UECFG3_EPTYPE_CONTROL  (USBC_UECFG3_EPTYPE_CONTROL_Val << USBC_UECFG3_EPTYPE_Pos)
 #define USBC_UECFG3_EPTYPE_ISOCHRONOUS (USBC_UECFG3_EPTYPE_ISOCHRONOUS_Val << USBC_UECFG3_EPTYPE_Pos)
 #define USBC_UECFG3_EPTYPE_BULK     (USBC_UECFG3_EPTYPE_BULK_Val   << USBC_UECFG3_EPTYPE_Pos)
 #define USBC_UECFG3_EPTYPE_INTERRUPT (USBC_UECFG3_EPTYPE_INTERRUPT_Val << USBC_UECFG3_EPTYPE_Pos)
 #define USBC_UECFG3_REPNB_Pos       16           /**< \brief (USBC_UECFG3) Redirected Endpoint Number */
-#define USBC_UECFG3_REPNB_Msk       (_U(0xF) << USBC_UECFG3_REPNB_Pos)
+#define USBC_UECFG3_REPNB_Msk       (_U_(0xF) << USBC_UECFG3_REPNB_Pos)
 #define USBC_UECFG3_REPNB(value)    (USBC_UECFG3_REPNB_Msk & ((value) << USBC_UECFG3_REPNB_Pos))
-#define USBC_UECFG3_MASK            _U(0x000F1974) /**< \brief (USBC_UECFG3) MASK Register */
+#define USBC_UECFG3_MASK            _U_(0x000F1974) /**< \brief (USBC_UECFG3) MASK Register */
 
 /* -------- USBC_UECFG4 : (USBC Offset: 0x110) (R/W 32) Endpoint Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -771,25 +771,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECFG4_OFFSET          0x110        /**< \brief (USBC_UECFG4 offset) Endpoint Configuration Register */
-#define USBC_UECFG4_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECFG4 reset_value) Endpoint Configuration Register */
+#define USBC_UECFG4_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UECFG4 reset_value) Endpoint Configuration Register */
 
 #define USBC_UECFG4_EPBK_Pos        2            /**< \brief (USBC_UECFG4) Endpoint Bank */
-#define USBC_UECFG4_EPBK            (_U(0x1) << USBC_UECFG4_EPBK_Pos)
-#define   USBC_UECFG4_EPBK_SINGLE_Val     _U(0x0)   /**< \brief (USBC_UECFG4)  */
-#define   USBC_UECFG4_EPBK_DOUBLE_Val     _U(0x1)   /**< \brief (USBC_UECFG4)  */
+#define USBC_UECFG4_EPBK            (_U_(0x1) << USBC_UECFG4_EPBK_Pos)
+#define   USBC_UECFG4_EPBK_SINGLE_Val     _U_(0x0)   /**< \brief (USBC_UECFG4)  */
+#define   USBC_UECFG4_EPBK_DOUBLE_Val     _U_(0x1)   /**< \brief (USBC_UECFG4)  */
 #define USBC_UECFG4_EPBK_SINGLE     (USBC_UECFG4_EPBK_SINGLE_Val   << USBC_UECFG4_EPBK_Pos)
 #define USBC_UECFG4_EPBK_DOUBLE     (USBC_UECFG4_EPBK_DOUBLE_Val   << USBC_UECFG4_EPBK_Pos)
 #define USBC_UECFG4_EPSIZE_Pos      4            /**< \brief (USBC_UECFG4) Endpoint Size */
-#define USBC_UECFG4_EPSIZE_Msk      (_U(0x7) << USBC_UECFG4_EPSIZE_Pos)
+#define USBC_UECFG4_EPSIZE_Msk      (_U_(0x7) << USBC_UECFG4_EPSIZE_Pos)
 #define USBC_UECFG4_EPSIZE(value)   (USBC_UECFG4_EPSIZE_Msk & ((value) << USBC_UECFG4_EPSIZE_Pos))
-#define   USBC_UECFG4_EPSIZE_8_Val        _U(0x0)   /**< \brief (USBC_UECFG4)  */
-#define   USBC_UECFG4_EPSIZE_16_Val       _U(0x1)   /**< \brief (USBC_UECFG4)  */
-#define   USBC_UECFG4_EPSIZE_32_Val       _U(0x2)   /**< \brief (USBC_UECFG4)  */
-#define   USBC_UECFG4_EPSIZE_64_Val       _U(0x3)   /**< \brief (USBC_UECFG4)  */
-#define   USBC_UECFG4_EPSIZE_128_Val      _U(0x4)   /**< \brief (USBC_UECFG4)  */
-#define   USBC_UECFG4_EPSIZE_256_Val      _U(0x5)   /**< \brief (USBC_UECFG4)  */
-#define   USBC_UECFG4_EPSIZE_512_Val      _U(0x6)   /**< \brief (USBC_UECFG4)  */
-#define   USBC_UECFG4_EPSIZE_1024_Val     _U(0x7)   /**< \brief (USBC_UECFG4)  */
+#define   USBC_UECFG4_EPSIZE_8_Val        _U_(0x0)   /**< \brief (USBC_UECFG4)  */
+#define   USBC_UECFG4_EPSIZE_16_Val       _U_(0x1)   /**< \brief (USBC_UECFG4)  */
+#define   USBC_UECFG4_EPSIZE_32_Val       _U_(0x2)   /**< \brief (USBC_UECFG4)  */
+#define   USBC_UECFG4_EPSIZE_64_Val       _U_(0x3)   /**< \brief (USBC_UECFG4)  */
+#define   USBC_UECFG4_EPSIZE_128_Val      _U_(0x4)   /**< \brief (USBC_UECFG4)  */
+#define   USBC_UECFG4_EPSIZE_256_Val      _U_(0x5)   /**< \brief (USBC_UECFG4)  */
+#define   USBC_UECFG4_EPSIZE_512_Val      _U_(0x6)   /**< \brief (USBC_UECFG4)  */
+#define   USBC_UECFG4_EPSIZE_1024_Val     _U_(0x7)   /**< \brief (USBC_UECFG4)  */
 #define USBC_UECFG4_EPSIZE_8        (USBC_UECFG4_EPSIZE_8_Val      << USBC_UECFG4_EPSIZE_Pos)
 #define USBC_UECFG4_EPSIZE_16       (USBC_UECFG4_EPSIZE_16_Val     << USBC_UECFG4_EPSIZE_Pos)
 #define USBC_UECFG4_EPSIZE_32       (USBC_UECFG4_EPSIZE_32_Val     << USBC_UECFG4_EPSIZE_Pos)
@@ -799,26 +799,26 @@ typedef union {
 #define USBC_UECFG4_EPSIZE_512      (USBC_UECFG4_EPSIZE_512_Val    << USBC_UECFG4_EPSIZE_Pos)
 #define USBC_UECFG4_EPSIZE_1024     (USBC_UECFG4_EPSIZE_1024_Val   << USBC_UECFG4_EPSIZE_Pos)
 #define USBC_UECFG4_EPDIR_Pos       8            /**< \brief (USBC_UECFG4) Endpoint Direction */
-#define USBC_UECFG4_EPDIR           (_U(0x1) << USBC_UECFG4_EPDIR_Pos)
-#define   USBC_UECFG4_EPDIR_OUT_Val       _U(0x0)   /**< \brief (USBC_UECFG4)  */
-#define   USBC_UECFG4_EPDIR_IN_Val        _U(0x1)   /**< \brief (USBC_UECFG4)  */
+#define USBC_UECFG4_EPDIR           (_U_(0x1) << USBC_UECFG4_EPDIR_Pos)
+#define   USBC_UECFG4_EPDIR_OUT_Val       _U_(0x0)   /**< \brief (USBC_UECFG4)  */
+#define   USBC_UECFG4_EPDIR_IN_Val        _U_(0x1)   /**< \brief (USBC_UECFG4)  */
 #define USBC_UECFG4_EPDIR_OUT       (USBC_UECFG4_EPDIR_OUT_Val     << USBC_UECFG4_EPDIR_Pos)
 #define USBC_UECFG4_EPDIR_IN        (USBC_UECFG4_EPDIR_IN_Val      << USBC_UECFG4_EPDIR_Pos)
 #define USBC_UECFG4_EPTYPE_Pos      11           /**< \brief (USBC_UECFG4) Endpoint Type */
-#define USBC_UECFG4_EPTYPE_Msk      (_U(0x3) << USBC_UECFG4_EPTYPE_Pos)
+#define USBC_UECFG4_EPTYPE_Msk      (_U_(0x3) << USBC_UECFG4_EPTYPE_Pos)
 #define USBC_UECFG4_EPTYPE(value)   (USBC_UECFG4_EPTYPE_Msk & ((value) << USBC_UECFG4_EPTYPE_Pos))
-#define   USBC_UECFG4_EPTYPE_CONTROL_Val  _U(0x0)   /**< \brief (USBC_UECFG4)  */
-#define   USBC_UECFG4_EPTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UECFG4)  */
-#define   USBC_UECFG4_EPTYPE_BULK_Val     _U(0x2)   /**< \brief (USBC_UECFG4)  */
-#define   USBC_UECFG4_EPTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UECFG4)  */
+#define   USBC_UECFG4_EPTYPE_CONTROL_Val  _U_(0x0)   /**< \brief (USBC_UECFG4)  */
+#define   USBC_UECFG4_EPTYPE_ISOCHRONOUS_Val _U_(0x1)   /**< \brief (USBC_UECFG4)  */
+#define   USBC_UECFG4_EPTYPE_BULK_Val     _U_(0x2)   /**< \brief (USBC_UECFG4)  */
+#define   USBC_UECFG4_EPTYPE_INTERRUPT_Val _U_(0x3)   /**< \brief (USBC_UECFG4)  */
 #define USBC_UECFG4_EPTYPE_CONTROL  (USBC_UECFG4_EPTYPE_CONTROL_Val << USBC_UECFG4_EPTYPE_Pos)
 #define USBC_UECFG4_EPTYPE_ISOCHRONOUS (USBC_UECFG4_EPTYPE_ISOCHRONOUS_Val << USBC_UECFG4_EPTYPE_Pos)
 #define USBC_UECFG4_EPTYPE_BULK     (USBC_UECFG4_EPTYPE_BULK_Val   << USBC_UECFG4_EPTYPE_Pos)
 #define USBC_UECFG4_EPTYPE_INTERRUPT (USBC_UECFG4_EPTYPE_INTERRUPT_Val << USBC_UECFG4_EPTYPE_Pos)
 #define USBC_UECFG4_REPNB_Pos       16           /**< \brief (USBC_UECFG4) Redirected Endpoint Number */
-#define USBC_UECFG4_REPNB_Msk       (_U(0xF) << USBC_UECFG4_REPNB_Pos)
+#define USBC_UECFG4_REPNB_Msk       (_U_(0xF) << USBC_UECFG4_REPNB_Pos)
 #define USBC_UECFG4_REPNB(value)    (USBC_UECFG4_REPNB_Msk & ((value) << USBC_UECFG4_REPNB_Pos))
-#define USBC_UECFG4_MASK            _U(0x000F1974) /**< \brief (USBC_UECFG4) MASK Register */
+#define USBC_UECFG4_MASK            _U_(0x000F1974) /**< \brief (USBC_UECFG4) MASK Register */
 
 /* -------- USBC_UECFG5 : (USBC Offset: 0x114) (R/W 32) Endpoint Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -841,25 +841,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECFG5_OFFSET          0x114        /**< \brief (USBC_UECFG5 offset) Endpoint Configuration Register */
-#define USBC_UECFG5_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECFG5 reset_value) Endpoint Configuration Register */
+#define USBC_UECFG5_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UECFG5 reset_value) Endpoint Configuration Register */
 
 #define USBC_UECFG5_EPBK_Pos        2            /**< \brief (USBC_UECFG5) Endpoint Bank */
-#define USBC_UECFG5_EPBK            (_U(0x1) << USBC_UECFG5_EPBK_Pos)
-#define   USBC_UECFG5_EPBK_SINGLE_Val     _U(0x0)   /**< \brief (USBC_UECFG5)  */
-#define   USBC_UECFG5_EPBK_DOUBLE_Val     _U(0x1)   /**< \brief (USBC_UECFG5)  */
+#define USBC_UECFG5_EPBK            (_U_(0x1) << USBC_UECFG5_EPBK_Pos)
+#define   USBC_UECFG5_EPBK_SINGLE_Val     _U_(0x0)   /**< \brief (USBC_UECFG5)  */
+#define   USBC_UECFG5_EPBK_DOUBLE_Val     _U_(0x1)   /**< \brief (USBC_UECFG5)  */
 #define USBC_UECFG5_EPBK_SINGLE     (USBC_UECFG5_EPBK_SINGLE_Val   << USBC_UECFG5_EPBK_Pos)
 #define USBC_UECFG5_EPBK_DOUBLE     (USBC_UECFG5_EPBK_DOUBLE_Val   << USBC_UECFG5_EPBK_Pos)
 #define USBC_UECFG5_EPSIZE_Pos      4            /**< \brief (USBC_UECFG5) Endpoint Size */
-#define USBC_UECFG5_EPSIZE_Msk      (_U(0x7) << USBC_UECFG5_EPSIZE_Pos)
+#define USBC_UECFG5_EPSIZE_Msk      (_U_(0x7) << USBC_UECFG5_EPSIZE_Pos)
 #define USBC_UECFG5_EPSIZE(value)   (USBC_UECFG5_EPSIZE_Msk & ((value) << USBC_UECFG5_EPSIZE_Pos))
-#define   USBC_UECFG5_EPSIZE_8_Val        _U(0x0)   /**< \brief (USBC_UECFG5)  */
-#define   USBC_UECFG5_EPSIZE_16_Val       _U(0x1)   /**< \brief (USBC_UECFG5)  */
-#define   USBC_UECFG5_EPSIZE_32_Val       _U(0x2)   /**< \brief (USBC_UECFG5)  */
-#define   USBC_UECFG5_EPSIZE_64_Val       _U(0x3)   /**< \brief (USBC_UECFG5)  */
-#define   USBC_UECFG5_EPSIZE_128_Val      _U(0x4)   /**< \brief (USBC_UECFG5)  */
-#define   USBC_UECFG5_EPSIZE_256_Val      _U(0x5)   /**< \brief (USBC_UECFG5)  */
-#define   USBC_UECFG5_EPSIZE_512_Val      _U(0x6)   /**< \brief (USBC_UECFG5)  */
-#define   USBC_UECFG5_EPSIZE_1024_Val     _U(0x7)   /**< \brief (USBC_UECFG5)  */
+#define   USBC_UECFG5_EPSIZE_8_Val        _U_(0x0)   /**< \brief (USBC_UECFG5)  */
+#define   USBC_UECFG5_EPSIZE_16_Val       _U_(0x1)   /**< \brief (USBC_UECFG5)  */
+#define   USBC_UECFG5_EPSIZE_32_Val       _U_(0x2)   /**< \brief (USBC_UECFG5)  */
+#define   USBC_UECFG5_EPSIZE_64_Val       _U_(0x3)   /**< \brief (USBC_UECFG5)  */
+#define   USBC_UECFG5_EPSIZE_128_Val      _U_(0x4)   /**< \brief (USBC_UECFG5)  */
+#define   USBC_UECFG5_EPSIZE_256_Val      _U_(0x5)   /**< \brief (USBC_UECFG5)  */
+#define   USBC_UECFG5_EPSIZE_512_Val      _U_(0x6)   /**< \brief (USBC_UECFG5)  */
+#define   USBC_UECFG5_EPSIZE_1024_Val     _U_(0x7)   /**< \brief (USBC_UECFG5)  */
 #define USBC_UECFG5_EPSIZE_8        (USBC_UECFG5_EPSIZE_8_Val      << USBC_UECFG5_EPSIZE_Pos)
 #define USBC_UECFG5_EPSIZE_16       (USBC_UECFG5_EPSIZE_16_Val     << USBC_UECFG5_EPSIZE_Pos)
 #define USBC_UECFG5_EPSIZE_32       (USBC_UECFG5_EPSIZE_32_Val     << USBC_UECFG5_EPSIZE_Pos)
@@ -869,26 +869,26 @@ typedef union {
 #define USBC_UECFG5_EPSIZE_512      (USBC_UECFG5_EPSIZE_512_Val    << USBC_UECFG5_EPSIZE_Pos)
 #define USBC_UECFG5_EPSIZE_1024     (USBC_UECFG5_EPSIZE_1024_Val   << USBC_UECFG5_EPSIZE_Pos)
 #define USBC_UECFG5_EPDIR_Pos       8            /**< \brief (USBC_UECFG5) Endpoint Direction */
-#define USBC_UECFG5_EPDIR           (_U(0x1) << USBC_UECFG5_EPDIR_Pos)
-#define   USBC_UECFG5_EPDIR_OUT_Val       _U(0x0)   /**< \brief (USBC_UECFG5)  */
-#define   USBC_UECFG5_EPDIR_IN_Val        _U(0x1)   /**< \brief (USBC_UECFG5)  */
+#define USBC_UECFG5_EPDIR           (_U_(0x1) << USBC_UECFG5_EPDIR_Pos)
+#define   USBC_UECFG5_EPDIR_OUT_Val       _U_(0x0)   /**< \brief (USBC_UECFG5)  */
+#define   USBC_UECFG5_EPDIR_IN_Val        _U_(0x1)   /**< \brief (USBC_UECFG5)  */
 #define USBC_UECFG5_EPDIR_OUT       (USBC_UECFG5_EPDIR_OUT_Val     << USBC_UECFG5_EPDIR_Pos)
 #define USBC_UECFG5_EPDIR_IN        (USBC_UECFG5_EPDIR_IN_Val      << USBC_UECFG5_EPDIR_Pos)
 #define USBC_UECFG5_EPTYPE_Pos      11           /**< \brief (USBC_UECFG5) Endpoint Type */
-#define USBC_UECFG5_EPTYPE_Msk      (_U(0x3) << USBC_UECFG5_EPTYPE_Pos)
+#define USBC_UECFG5_EPTYPE_Msk      (_U_(0x3) << USBC_UECFG5_EPTYPE_Pos)
 #define USBC_UECFG5_EPTYPE(value)   (USBC_UECFG5_EPTYPE_Msk & ((value) << USBC_UECFG5_EPTYPE_Pos))
-#define   USBC_UECFG5_EPTYPE_CONTROL_Val  _U(0x0)   /**< \brief (USBC_UECFG5)  */
-#define   USBC_UECFG5_EPTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UECFG5)  */
-#define   USBC_UECFG5_EPTYPE_BULK_Val     _U(0x2)   /**< \brief (USBC_UECFG5)  */
-#define   USBC_UECFG5_EPTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UECFG5)  */
+#define   USBC_UECFG5_EPTYPE_CONTROL_Val  _U_(0x0)   /**< \brief (USBC_UECFG5)  */
+#define   USBC_UECFG5_EPTYPE_ISOCHRONOUS_Val _U_(0x1)   /**< \brief (USBC_UECFG5)  */
+#define   USBC_UECFG5_EPTYPE_BULK_Val     _U_(0x2)   /**< \brief (USBC_UECFG5)  */
+#define   USBC_UECFG5_EPTYPE_INTERRUPT_Val _U_(0x3)   /**< \brief (USBC_UECFG5)  */
 #define USBC_UECFG5_EPTYPE_CONTROL  (USBC_UECFG5_EPTYPE_CONTROL_Val << USBC_UECFG5_EPTYPE_Pos)
 #define USBC_UECFG5_EPTYPE_ISOCHRONOUS (USBC_UECFG5_EPTYPE_ISOCHRONOUS_Val << USBC_UECFG5_EPTYPE_Pos)
 #define USBC_UECFG5_EPTYPE_BULK     (USBC_UECFG5_EPTYPE_BULK_Val   << USBC_UECFG5_EPTYPE_Pos)
 #define USBC_UECFG5_EPTYPE_INTERRUPT (USBC_UECFG5_EPTYPE_INTERRUPT_Val << USBC_UECFG5_EPTYPE_Pos)
 #define USBC_UECFG5_REPNB_Pos       16           /**< \brief (USBC_UECFG5) Redirected Endpoint Number */
-#define USBC_UECFG5_REPNB_Msk       (_U(0xF) << USBC_UECFG5_REPNB_Pos)
+#define USBC_UECFG5_REPNB_Msk       (_U_(0xF) << USBC_UECFG5_REPNB_Pos)
 #define USBC_UECFG5_REPNB(value)    (USBC_UECFG5_REPNB_Msk & ((value) << USBC_UECFG5_REPNB_Pos))
-#define USBC_UECFG5_MASK            _U(0x000F1974) /**< \brief (USBC_UECFG5) MASK Register */
+#define USBC_UECFG5_MASK            _U_(0x000F1974) /**< \brief (USBC_UECFG5) MASK Register */
 
 /* -------- USBC_UECFG6 : (USBC Offset: 0x118) (R/W 32) Endpoint Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -911,25 +911,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECFG6_OFFSET          0x118        /**< \brief (USBC_UECFG6 offset) Endpoint Configuration Register */
-#define USBC_UECFG6_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECFG6 reset_value) Endpoint Configuration Register */
+#define USBC_UECFG6_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UECFG6 reset_value) Endpoint Configuration Register */
 
 #define USBC_UECFG6_EPBK_Pos        2            /**< \brief (USBC_UECFG6) Endpoint Bank */
-#define USBC_UECFG6_EPBK            (_U(0x1) << USBC_UECFG6_EPBK_Pos)
-#define   USBC_UECFG6_EPBK_SINGLE_Val     _U(0x0)   /**< \brief (USBC_UECFG6)  */
-#define   USBC_UECFG6_EPBK_DOUBLE_Val     _U(0x1)   /**< \brief (USBC_UECFG6)  */
+#define USBC_UECFG6_EPBK            (_U_(0x1) << USBC_UECFG6_EPBK_Pos)
+#define   USBC_UECFG6_EPBK_SINGLE_Val     _U_(0x0)   /**< \brief (USBC_UECFG6)  */
+#define   USBC_UECFG6_EPBK_DOUBLE_Val     _U_(0x1)   /**< \brief (USBC_UECFG6)  */
 #define USBC_UECFG6_EPBK_SINGLE     (USBC_UECFG6_EPBK_SINGLE_Val   << USBC_UECFG6_EPBK_Pos)
 #define USBC_UECFG6_EPBK_DOUBLE     (USBC_UECFG6_EPBK_DOUBLE_Val   << USBC_UECFG6_EPBK_Pos)
 #define USBC_UECFG6_EPSIZE_Pos      4            /**< \brief (USBC_UECFG6) Endpoint Size */
-#define USBC_UECFG6_EPSIZE_Msk      (_U(0x7) << USBC_UECFG6_EPSIZE_Pos)
+#define USBC_UECFG6_EPSIZE_Msk      (_U_(0x7) << USBC_UECFG6_EPSIZE_Pos)
 #define USBC_UECFG6_EPSIZE(value)   (USBC_UECFG6_EPSIZE_Msk & ((value) << USBC_UECFG6_EPSIZE_Pos))
-#define   USBC_UECFG6_EPSIZE_8_Val        _U(0x0)   /**< \brief (USBC_UECFG6)  */
-#define   USBC_UECFG6_EPSIZE_16_Val       _U(0x1)   /**< \brief (USBC_UECFG6)  */
-#define   USBC_UECFG6_EPSIZE_32_Val       _U(0x2)   /**< \brief (USBC_UECFG6)  */
-#define   USBC_UECFG6_EPSIZE_64_Val       _U(0x3)   /**< \brief (USBC_UECFG6)  */
-#define   USBC_UECFG6_EPSIZE_128_Val      _U(0x4)   /**< \brief (USBC_UECFG6)  */
-#define   USBC_UECFG6_EPSIZE_256_Val      _U(0x5)   /**< \brief (USBC_UECFG6)  */
-#define   USBC_UECFG6_EPSIZE_512_Val      _U(0x6)   /**< \brief (USBC_UECFG6)  */
-#define   USBC_UECFG6_EPSIZE_1024_Val     _U(0x7)   /**< \brief (USBC_UECFG6)  */
+#define   USBC_UECFG6_EPSIZE_8_Val        _U_(0x0)   /**< \brief (USBC_UECFG6)  */
+#define   USBC_UECFG6_EPSIZE_16_Val       _U_(0x1)   /**< \brief (USBC_UECFG6)  */
+#define   USBC_UECFG6_EPSIZE_32_Val       _U_(0x2)   /**< \brief (USBC_UECFG6)  */
+#define   USBC_UECFG6_EPSIZE_64_Val       _U_(0x3)   /**< \brief (USBC_UECFG6)  */
+#define   USBC_UECFG6_EPSIZE_128_Val      _U_(0x4)   /**< \brief (USBC_UECFG6)  */
+#define   USBC_UECFG6_EPSIZE_256_Val      _U_(0x5)   /**< \brief (USBC_UECFG6)  */
+#define   USBC_UECFG6_EPSIZE_512_Val      _U_(0x6)   /**< \brief (USBC_UECFG6)  */
+#define   USBC_UECFG6_EPSIZE_1024_Val     _U_(0x7)   /**< \brief (USBC_UECFG6)  */
 #define USBC_UECFG6_EPSIZE_8        (USBC_UECFG6_EPSIZE_8_Val      << USBC_UECFG6_EPSIZE_Pos)
 #define USBC_UECFG6_EPSIZE_16       (USBC_UECFG6_EPSIZE_16_Val     << USBC_UECFG6_EPSIZE_Pos)
 #define USBC_UECFG6_EPSIZE_32       (USBC_UECFG6_EPSIZE_32_Val     << USBC_UECFG6_EPSIZE_Pos)
@@ -939,26 +939,26 @@ typedef union {
 #define USBC_UECFG6_EPSIZE_512      (USBC_UECFG6_EPSIZE_512_Val    << USBC_UECFG6_EPSIZE_Pos)
 #define USBC_UECFG6_EPSIZE_1024     (USBC_UECFG6_EPSIZE_1024_Val   << USBC_UECFG6_EPSIZE_Pos)
 #define USBC_UECFG6_EPDIR_Pos       8            /**< \brief (USBC_UECFG6) Endpoint Direction */
-#define USBC_UECFG6_EPDIR           (_U(0x1) << USBC_UECFG6_EPDIR_Pos)
-#define   USBC_UECFG6_EPDIR_OUT_Val       _U(0x0)   /**< \brief (USBC_UECFG6)  */
-#define   USBC_UECFG6_EPDIR_IN_Val        _U(0x1)   /**< \brief (USBC_UECFG6)  */
+#define USBC_UECFG6_EPDIR           (_U_(0x1) << USBC_UECFG6_EPDIR_Pos)
+#define   USBC_UECFG6_EPDIR_OUT_Val       _U_(0x0)   /**< \brief (USBC_UECFG6)  */
+#define   USBC_UECFG6_EPDIR_IN_Val        _U_(0x1)   /**< \brief (USBC_UECFG6)  */
 #define USBC_UECFG6_EPDIR_OUT       (USBC_UECFG6_EPDIR_OUT_Val     << USBC_UECFG6_EPDIR_Pos)
 #define USBC_UECFG6_EPDIR_IN        (USBC_UECFG6_EPDIR_IN_Val      << USBC_UECFG6_EPDIR_Pos)
 #define USBC_UECFG6_EPTYPE_Pos      11           /**< \brief (USBC_UECFG6) Endpoint Type */
-#define USBC_UECFG6_EPTYPE_Msk      (_U(0x3) << USBC_UECFG6_EPTYPE_Pos)
+#define USBC_UECFG6_EPTYPE_Msk      (_U_(0x3) << USBC_UECFG6_EPTYPE_Pos)
 #define USBC_UECFG6_EPTYPE(value)   (USBC_UECFG6_EPTYPE_Msk & ((value) << USBC_UECFG6_EPTYPE_Pos))
-#define   USBC_UECFG6_EPTYPE_CONTROL_Val  _U(0x0)   /**< \brief (USBC_UECFG6)  */
-#define   USBC_UECFG6_EPTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UECFG6)  */
-#define   USBC_UECFG6_EPTYPE_BULK_Val     _U(0x2)   /**< \brief (USBC_UECFG6)  */
-#define   USBC_UECFG6_EPTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UECFG6)  */
+#define   USBC_UECFG6_EPTYPE_CONTROL_Val  _U_(0x0)   /**< \brief (USBC_UECFG6)  */
+#define   USBC_UECFG6_EPTYPE_ISOCHRONOUS_Val _U_(0x1)   /**< \brief (USBC_UECFG6)  */
+#define   USBC_UECFG6_EPTYPE_BULK_Val     _U_(0x2)   /**< \brief (USBC_UECFG6)  */
+#define   USBC_UECFG6_EPTYPE_INTERRUPT_Val _U_(0x3)   /**< \brief (USBC_UECFG6)  */
 #define USBC_UECFG6_EPTYPE_CONTROL  (USBC_UECFG6_EPTYPE_CONTROL_Val << USBC_UECFG6_EPTYPE_Pos)
 #define USBC_UECFG6_EPTYPE_ISOCHRONOUS (USBC_UECFG6_EPTYPE_ISOCHRONOUS_Val << USBC_UECFG6_EPTYPE_Pos)
 #define USBC_UECFG6_EPTYPE_BULK     (USBC_UECFG6_EPTYPE_BULK_Val   << USBC_UECFG6_EPTYPE_Pos)
 #define USBC_UECFG6_EPTYPE_INTERRUPT (USBC_UECFG6_EPTYPE_INTERRUPT_Val << USBC_UECFG6_EPTYPE_Pos)
 #define USBC_UECFG6_REPNB_Pos       16           /**< \brief (USBC_UECFG6) Redirected Endpoint Number */
-#define USBC_UECFG6_REPNB_Msk       (_U(0xF) << USBC_UECFG6_REPNB_Pos)
+#define USBC_UECFG6_REPNB_Msk       (_U_(0xF) << USBC_UECFG6_REPNB_Pos)
 #define USBC_UECFG6_REPNB(value)    (USBC_UECFG6_REPNB_Msk & ((value) << USBC_UECFG6_REPNB_Pos))
-#define USBC_UECFG6_MASK            _U(0x000F1974) /**< \brief (USBC_UECFG6) MASK Register */
+#define USBC_UECFG6_MASK            _U_(0x000F1974) /**< \brief (USBC_UECFG6) MASK Register */
 
 /* -------- USBC_UECFG7 : (USBC Offset: 0x11C) (R/W 32) Endpoint Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -981,25 +981,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECFG7_OFFSET          0x11C        /**< \brief (USBC_UECFG7 offset) Endpoint Configuration Register */
-#define USBC_UECFG7_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECFG7 reset_value) Endpoint Configuration Register */
+#define USBC_UECFG7_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UECFG7 reset_value) Endpoint Configuration Register */
 
 #define USBC_UECFG7_EPBK_Pos        2            /**< \brief (USBC_UECFG7) Endpoint Bank */
-#define USBC_UECFG7_EPBK            (_U(0x1) << USBC_UECFG7_EPBK_Pos)
-#define   USBC_UECFG7_EPBK_SINGLE_Val     _U(0x0)   /**< \brief (USBC_UECFG7)  */
-#define   USBC_UECFG7_EPBK_DOUBLE_Val     _U(0x1)   /**< \brief (USBC_UECFG7)  */
+#define USBC_UECFG7_EPBK            (_U_(0x1) << USBC_UECFG7_EPBK_Pos)
+#define   USBC_UECFG7_EPBK_SINGLE_Val     _U_(0x0)   /**< \brief (USBC_UECFG7)  */
+#define   USBC_UECFG7_EPBK_DOUBLE_Val     _U_(0x1)   /**< \brief (USBC_UECFG7)  */
 #define USBC_UECFG7_EPBK_SINGLE     (USBC_UECFG7_EPBK_SINGLE_Val   << USBC_UECFG7_EPBK_Pos)
 #define USBC_UECFG7_EPBK_DOUBLE     (USBC_UECFG7_EPBK_DOUBLE_Val   << USBC_UECFG7_EPBK_Pos)
 #define USBC_UECFG7_EPSIZE_Pos      4            /**< \brief (USBC_UECFG7) Endpoint Size */
-#define USBC_UECFG7_EPSIZE_Msk      (_U(0x7) << USBC_UECFG7_EPSIZE_Pos)
+#define USBC_UECFG7_EPSIZE_Msk      (_U_(0x7) << USBC_UECFG7_EPSIZE_Pos)
 #define USBC_UECFG7_EPSIZE(value)   (USBC_UECFG7_EPSIZE_Msk & ((value) << USBC_UECFG7_EPSIZE_Pos))
-#define   USBC_UECFG7_EPSIZE_8_Val        _U(0x0)   /**< \brief (USBC_UECFG7)  */
-#define   USBC_UECFG7_EPSIZE_16_Val       _U(0x1)   /**< \brief (USBC_UECFG7)  */
-#define   USBC_UECFG7_EPSIZE_32_Val       _U(0x2)   /**< \brief (USBC_UECFG7)  */
-#define   USBC_UECFG7_EPSIZE_64_Val       _U(0x3)   /**< \brief (USBC_UECFG7)  */
-#define   USBC_UECFG7_EPSIZE_128_Val      _U(0x4)   /**< \brief (USBC_UECFG7)  */
-#define   USBC_UECFG7_EPSIZE_256_Val      _U(0x5)   /**< \brief (USBC_UECFG7)  */
-#define   USBC_UECFG7_EPSIZE_512_Val      _U(0x6)   /**< \brief (USBC_UECFG7)  */
-#define   USBC_UECFG7_EPSIZE_1024_Val     _U(0x7)   /**< \brief (USBC_UECFG7)  */
+#define   USBC_UECFG7_EPSIZE_8_Val        _U_(0x0)   /**< \brief (USBC_UECFG7)  */
+#define   USBC_UECFG7_EPSIZE_16_Val       _U_(0x1)   /**< \brief (USBC_UECFG7)  */
+#define   USBC_UECFG7_EPSIZE_32_Val       _U_(0x2)   /**< \brief (USBC_UECFG7)  */
+#define   USBC_UECFG7_EPSIZE_64_Val       _U_(0x3)   /**< \brief (USBC_UECFG7)  */
+#define   USBC_UECFG7_EPSIZE_128_Val      _U_(0x4)   /**< \brief (USBC_UECFG7)  */
+#define   USBC_UECFG7_EPSIZE_256_Val      _U_(0x5)   /**< \brief (USBC_UECFG7)  */
+#define   USBC_UECFG7_EPSIZE_512_Val      _U_(0x6)   /**< \brief (USBC_UECFG7)  */
+#define   USBC_UECFG7_EPSIZE_1024_Val     _U_(0x7)   /**< \brief (USBC_UECFG7)  */
 #define USBC_UECFG7_EPSIZE_8        (USBC_UECFG7_EPSIZE_8_Val      << USBC_UECFG7_EPSIZE_Pos)
 #define USBC_UECFG7_EPSIZE_16       (USBC_UECFG7_EPSIZE_16_Val     << USBC_UECFG7_EPSIZE_Pos)
 #define USBC_UECFG7_EPSIZE_32       (USBC_UECFG7_EPSIZE_32_Val     << USBC_UECFG7_EPSIZE_Pos)
@@ -1009,26 +1009,26 @@ typedef union {
 #define USBC_UECFG7_EPSIZE_512      (USBC_UECFG7_EPSIZE_512_Val    << USBC_UECFG7_EPSIZE_Pos)
 #define USBC_UECFG7_EPSIZE_1024     (USBC_UECFG7_EPSIZE_1024_Val   << USBC_UECFG7_EPSIZE_Pos)
 #define USBC_UECFG7_EPDIR_Pos       8            /**< \brief (USBC_UECFG7) Endpoint Direction */
-#define USBC_UECFG7_EPDIR           (_U(0x1) << USBC_UECFG7_EPDIR_Pos)
-#define   USBC_UECFG7_EPDIR_OUT_Val       _U(0x0)   /**< \brief (USBC_UECFG7)  */
-#define   USBC_UECFG7_EPDIR_IN_Val        _U(0x1)   /**< \brief (USBC_UECFG7)  */
+#define USBC_UECFG7_EPDIR           (_U_(0x1) << USBC_UECFG7_EPDIR_Pos)
+#define   USBC_UECFG7_EPDIR_OUT_Val       _U_(0x0)   /**< \brief (USBC_UECFG7)  */
+#define   USBC_UECFG7_EPDIR_IN_Val        _U_(0x1)   /**< \brief (USBC_UECFG7)  */
 #define USBC_UECFG7_EPDIR_OUT       (USBC_UECFG7_EPDIR_OUT_Val     << USBC_UECFG7_EPDIR_Pos)
 #define USBC_UECFG7_EPDIR_IN        (USBC_UECFG7_EPDIR_IN_Val      << USBC_UECFG7_EPDIR_Pos)
 #define USBC_UECFG7_EPTYPE_Pos      11           /**< \brief (USBC_UECFG7) Endpoint Type */
-#define USBC_UECFG7_EPTYPE_Msk      (_U(0x3) << USBC_UECFG7_EPTYPE_Pos)
+#define USBC_UECFG7_EPTYPE_Msk      (_U_(0x3) << USBC_UECFG7_EPTYPE_Pos)
 #define USBC_UECFG7_EPTYPE(value)   (USBC_UECFG7_EPTYPE_Msk & ((value) << USBC_UECFG7_EPTYPE_Pos))
-#define   USBC_UECFG7_EPTYPE_CONTROL_Val  _U(0x0)   /**< \brief (USBC_UECFG7)  */
-#define   USBC_UECFG7_EPTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UECFG7)  */
-#define   USBC_UECFG7_EPTYPE_BULK_Val     _U(0x2)   /**< \brief (USBC_UECFG7)  */
-#define   USBC_UECFG7_EPTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UECFG7)  */
+#define   USBC_UECFG7_EPTYPE_CONTROL_Val  _U_(0x0)   /**< \brief (USBC_UECFG7)  */
+#define   USBC_UECFG7_EPTYPE_ISOCHRONOUS_Val _U_(0x1)   /**< \brief (USBC_UECFG7)  */
+#define   USBC_UECFG7_EPTYPE_BULK_Val     _U_(0x2)   /**< \brief (USBC_UECFG7)  */
+#define   USBC_UECFG7_EPTYPE_INTERRUPT_Val _U_(0x3)   /**< \brief (USBC_UECFG7)  */
 #define USBC_UECFG7_EPTYPE_CONTROL  (USBC_UECFG7_EPTYPE_CONTROL_Val << USBC_UECFG7_EPTYPE_Pos)
 #define USBC_UECFG7_EPTYPE_ISOCHRONOUS (USBC_UECFG7_EPTYPE_ISOCHRONOUS_Val << USBC_UECFG7_EPTYPE_Pos)
 #define USBC_UECFG7_EPTYPE_BULK     (USBC_UECFG7_EPTYPE_BULK_Val   << USBC_UECFG7_EPTYPE_Pos)
 #define USBC_UECFG7_EPTYPE_INTERRUPT (USBC_UECFG7_EPTYPE_INTERRUPT_Val << USBC_UECFG7_EPTYPE_Pos)
 #define USBC_UECFG7_REPNB_Pos       16           /**< \brief (USBC_UECFG7) Redirected Endpoint Number */
-#define USBC_UECFG7_REPNB_Msk       (_U(0xF) << USBC_UECFG7_REPNB_Pos)
+#define USBC_UECFG7_REPNB_Msk       (_U_(0xF) << USBC_UECFG7_REPNB_Pos)
 #define USBC_UECFG7_REPNB(value)    (USBC_UECFG7_REPNB_Msk & ((value) << USBC_UECFG7_REPNB_Pos))
-#define USBC_UECFG7_MASK            _U(0x000F1974) /**< \brief (USBC_UECFG7) MASK Register */
+#define USBC_UECFG7_MASK            _U_(0x000F1974) /**< \brief (USBC_UECFG7) MASK Register */
 
 /* -------- USBC_UESTA0 : (USBC Offset: 0x130) (R/  32) Endpoint Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1056,38 +1056,38 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UESTA0_OFFSET          0x130        /**< \brief (USBC_UESTA0 offset) Endpoint Status Register */
-#define USBC_UESTA0_RESETVALUE      _U(0x00000100); /**< \brief (USBC_UESTA0 reset_value) Endpoint Status Register */
+#define USBC_UESTA0_RESETVALUE      _U_(0x00000100); /**< \brief (USBC_UESTA0 reset_value) Endpoint Status Register */
 
 #define USBC_UESTA0_TXINI_Pos       0            /**< \brief (USBC_UESTA0) Transmitted IN Data Interrupt */
-#define USBC_UESTA0_TXINI           (_U(0x1) << USBC_UESTA0_TXINI_Pos)
+#define USBC_UESTA0_TXINI           (_U_(0x1) << USBC_UESTA0_TXINI_Pos)
 #define USBC_UESTA0_RXOUTI_Pos      1            /**< \brief (USBC_UESTA0) Received OUT Data Interrupt */
-#define USBC_UESTA0_RXOUTI          (_U(0x1) << USBC_UESTA0_RXOUTI_Pos)
+#define USBC_UESTA0_RXOUTI          (_U_(0x1) << USBC_UESTA0_RXOUTI_Pos)
 #define USBC_UESTA0_RXSTPI_Pos      2            /**< \brief (USBC_UESTA0) Received SETUP Interrupt */
-#define USBC_UESTA0_RXSTPI          (_U(0x1) << USBC_UESTA0_RXSTPI_Pos)
+#define USBC_UESTA0_RXSTPI          (_U_(0x1) << USBC_UESTA0_RXSTPI_Pos)
 #define USBC_UESTA0_NAKOUTI_Pos     3            /**< \brief (USBC_UESTA0) NAKed OUT Interrupt */
-#define USBC_UESTA0_NAKOUTI         (_U(0x1) << USBC_UESTA0_NAKOUTI_Pos)
+#define USBC_UESTA0_NAKOUTI         (_U_(0x1) << USBC_UESTA0_NAKOUTI_Pos)
 #define USBC_UESTA0_NAKINI_Pos      4            /**< \brief (USBC_UESTA0) NAKed IN Interrupt */
-#define USBC_UESTA0_NAKINI          (_U(0x1) << USBC_UESTA0_NAKINI_Pos)
+#define USBC_UESTA0_NAKINI          (_U_(0x1) << USBC_UESTA0_NAKINI_Pos)
 #define USBC_UESTA0_STALLEDI_Pos    6            /**< \brief (USBC_UESTA0) STALLed Interrupt */
-#define USBC_UESTA0_STALLEDI        (_U(0x1) << USBC_UESTA0_STALLEDI_Pos)
+#define USBC_UESTA0_STALLEDI        (_U_(0x1) << USBC_UESTA0_STALLEDI_Pos)
 #define USBC_UESTA0_DTSEQ_Pos       8            /**< \brief (USBC_UESTA0) Data Toggle Sequence */
-#define USBC_UESTA0_DTSEQ_Msk       (_U(0x3) << USBC_UESTA0_DTSEQ_Pos)
+#define USBC_UESTA0_DTSEQ_Msk       (_U_(0x3) << USBC_UESTA0_DTSEQ_Pos)
 #define USBC_UESTA0_DTSEQ(value)    (USBC_UESTA0_DTSEQ_Msk & ((value) << USBC_UESTA0_DTSEQ_Pos))
 #define USBC_UESTA0_RAMACERI_Pos    11           /**< \brief (USBC_UESTA0) Ram Access Error Interrupt */
-#define USBC_UESTA0_RAMACERI        (_U(0x1) << USBC_UESTA0_RAMACERI_Pos)
+#define USBC_UESTA0_RAMACERI        (_U_(0x1) << USBC_UESTA0_RAMACERI_Pos)
 #define USBC_UESTA0_NBUSYBK_Pos     12           /**< \brief (USBC_UESTA0) Number Of Busy Banks */
-#define USBC_UESTA0_NBUSYBK_Msk     (_U(0x3) << USBC_UESTA0_NBUSYBK_Pos)
+#define USBC_UESTA0_NBUSYBK_Msk     (_U_(0x3) << USBC_UESTA0_NBUSYBK_Pos)
 #define USBC_UESTA0_NBUSYBK(value)  (USBC_UESTA0_NBUSYBK_Msk & ((value) << USBC_UESTA0_NBUSYBK_Pos))
 #define USBC_UESTA0_CURRBK_Pos      14           /**< \brief (USBC_UESTA0) Current Bank */
-#define USBC_UESTA0_CURRBK_Msk      (_U(0x3) << USBC_UESTA0_CURRBK_Pos)
+#define USBC_UESTA0_CURRBK_Msk      (_U_(0x3) << USBC_UESTA0_CURRBK_Pos)
 #define USBC_UESTA0_CURRBK(value)   (USBC_UESTA0_CURRBK_Msk & ((value) << USBC_UESTA0_CURRBK_Pos))
 #define USBC_UESTA0_CTRLDIR_Pos     17           /**< \brief (USBC_UESTA0) Control Direction */
-#define USBC_UESTA0_CTRLDIR         (_U(0x1) << USBC_UESTA0_CTRLDIR_Pos)
-#define   USBC_UESTA0_CTRLDIR_OUT_Val     _U(0x0)   /**< \brief (USBC_UESTA0)  */
-#define   USBC_UESTA0_CTRLDIR_IN_Val      _U(0x1)   /**< \brief (USBC_UESTA0)  */
+#define USBC_UESTA0_CTRLDIR         (_U_(0x1) << USBC_UESTA0_CTRLDIR_Pos)
+#define   USBC_UESTA0_CTRLDIR_OUT_Val     _U_(0x0)   /**< \brief (USBC_UESTA0)  */
+#define   USBC_UESTA0_CTRLDIR_IN_Val      _U_(0x1)   /**< \brief (USBC_UESTA0)  */
 #define USBC_UESTA0_CTRLDIR_OUT     (USBC_UESTA0_CTRLDIR_OUT_Val   << USBC_UESTA0_CTRLDIR_Pos)
 #define USBC_UESTA0_CTRLDIR_IN      (USBC_UESTA0_CTRLDIR_IN_Val    << USBC_UESTA0_CTRLDIR_Pos)
-#define USBC_UESTA0_MASK            _U(0x0002FB5F) /**< \brief (USBC_UESTA0) MASK Register */
+#define USBC_UESTA0_MASK            _U_(0x0002FB5F) /**< \brief (USBC_UESTA0) MASK Register */
 
 /* -------- USBC_UESTA1 : (USBC Offset: 0x134) (R/  32) Endpoint Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1115,38 +1115,38 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UESTA1_OFFSET          0x134        /**< \brief (USBC_UESTA1 offset) Endpoint Status Register */
-#define USBC_UESTA1_RESETVALUE      _U(0x00000100); /**< \brief (USBC_UESTA1 reset_value) Endpoint Status Register */
+#define USBC_UESTA1_RESETVALUE      _U_(0x00000100); /**< \brief (USBC_UESTA1 reset_value) Endpoint Status Register */
 
 #define USBC_UESTA1_TXINI_Pos       0            /**< \brief (USBC_UESTA1) Transmitted IN Data Interrupt */
-#define USBC_UESTA1_TXINI           (_U(0x1) << USBC_UESTA1_TXINI_Pos)
+#define USBC_UESTA1_TXINI           (_U_(0x1) << USBC_UESTA1_TXINI_Pos)
 #define USBC_UESTA1_RXOUTI_Pos      1            /**< \brief (USBC_UESTA1) Received OUT Data Interrupt */
-#define USBC_UESTA1_RXOUTI          (_U(0x1) << USBC_UESTA1_RXOUTI_Pos)
+#define USBC_UESTA1_RXOUTI          (_U_(0x1) << USBC_UESTA1_RXOUTI_Pos)
 #define USBC_UESTA1_RXSTPI_Pos      2            /**< \brief (USBC_UESTA1) Received SETUP Interrupt */
-#define USBC_UESTA1_RXSTPI          (_U(0x1) << USBC_UESTA1_RXSTPI_Pos)
+#define USBC_UESTA1_RXSTPI          (_U_(0x1) << USBC_UESTA1_RXSTPI_Pos)
 #define USBC_UESTA1_NAKOUTI_Pos     3            /**< \brief (USBC_UESTA1) NAKed OUT Interrupt */
-#define USBC_UESTA1_NAKOUTI         (_U(0x1) << USBC_UESTA1_NAKOUTI_Pos)
+#define USBC_UESTA1_NAKOUTI         (_U_(0x1) << USBC_UESTA1_NAKOUTI_Pos)
 #define USBC_UESTA1_NAKINI_Pos      4            /**< \brief (USBC_UESTA1) NAKed IN Interrupt */
-#define USBC_UESTA1_NAKINI          (_U(0x1) << USBC_UESTA1_NAKINI_Pos)
+#define USBC_UESTA1_NAKINI          (_U_(0x1) << USBC_UESTA1_NAKINI_Pos)
 #define USBC_UESTA1_STALLEDI_Pos    6            /**< \brief (USBC_UESTA1) STALLed Interrupt */
-#define USBC_UESTA1_STALLEDI        (_U(0x1) << USBC_UESTA1_STALLEDI_Pos)
+#define USBC_UESTA1_STALLEDI        (_U_(0x1) << USBC_UESTA1_STALLEDI_Pos)
 #define USBC_UESTA1_DTSEQ_Pos       8            /**< \brief (USBC_UESTA1) Data Toggle Sequence */
-#define USBC_UESTA1_DTSEQ_Msk       (_U(0x3) << USBC_UESTA1_DTSEQ_Pos)
+#define USBC_UESTA1_DTSEQ_Msk       (_U_(0x3) << USBC_UESTA1_DTSEQ_Pos)
 #define USBC_UESTA1_DTSEQ(value)    (USBC_UESTA1_DTSEQ_Msk & ((value) << USBC_UESTA1_DTSEQ_Pos))
 #define USBC_UESTA1_RAMACERI_Pos    11           /**< \brief (USBC_UESTA1) Ram Access Error Interrupt */
-#define USBC_UESTA1_RAMACERI        (_U(0x1) << USBC_UESTA1_RAMACERI_Pos)
+#define USBC_UESTA1_RAMACERI        (_U_(0x1) << USBC_UESTA1_RAMACERI_Pos)
 #define USBC_UESTA1_NBUSYBK_Pos     12           /**< \brief (USBC_UESTA1) Number Of Busy Banks */
-#define USBC_UESTA1_NBUSYBK_Msk     (_U(0x3) << USBC_UESTA1_NBUSYBK_Pos)
+#define USBC_UESTA1_NBUSYBK_Msk     (_U_(0x3) << USBC_UESTA1_NBUSYBK_Pos)
 #define USBC_UESTA1_NBUSYBK(value)  (USBC_UESTA1_NBUSYBK_Msk & ((value) << USBC_UESTA1_NBUSYBK_Pos))
 #define USBC_UESTA1_CURRBK_Pos      14           /**< \brief (USBC_UESTA1) Current Bank */
-#define USBC_UESTA1_CURRBK_Msk      (_U(0x3) << USBC_UESTA1_CURRBK_Pos)
+#define USBC_UESTA1_CURRBK_Msk      (_U_(0x3) << USBC_UESTA1_CURRBK_Pos)
 #define USBC_UESTA1_CURRBK(value)   (USBC_UESTA1_CURRBK_Msk & ((value) << USBC_UESTA1_CURRBK_Pos))
 #define USBC_UESTA1_CTRLDIR_Pos     17           /**< \brief (USBC_UESTA1) Control Direction */
-#define USBC_UESTA1_CTRLDIR         (_U(0x1) << USBC_UESTA1_CTRLDIR_Pos)
-#define   USBC_UESTA1_CTRLDIR_OUT_Val     _U(0x0)   /**< \brief (USBC_UESTA1)  */
-#define   USBC_UESTA1_CTRLDIR_IN_Val      _U(0x1)   /**< \brief (USBC_UESTA1)  */
+#define USBC_UESTA1_CTRLDIR         (_U_(0x1) << USBC_UESTA1_CTRLDIR_Pos)
+#define   USBC_UESTA1_CTRLDIR_OUT_Val     _U_(0x0)   /**< \brief (USBC_UESTA1)  */
+#define   USBC_UESTA1_CTRLDIR_IN_Val      _U_(0x1)   /**< \brief (USBC_UESTA1)  */
 #define USBC_UESTA1_CTRLDIR_OUT     (USBC_UESTA1_CTRLDIR_OUT_Val   << USBC_UESTA1_CTRLDIR_Pos)
 #define USBC_UESTA1_CTRLDIR_IN      (USBC_UESTA1_CTRLDIR_IN_Val    << USBC_UESTA1_CTRLDIR_Pos)
-#define USBC_UESTA1_MASK            _U(0x0002FB5F) /**< \brief (USBC_UESTA1) MASK Register */
+#define USBC_UESTA1_MASK            _U_(0x0002FB5F) /**< \brief (USBC_UESTA1) MASK Register */
 
 /* -------- USBC_UESTA2 : (USBC Offset: 0x138) (R/  32) Endpoint Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1174,38 +1174,38 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UESTA2_OFFSET          0x138        /**< \brief (USBC_UESTA2 offset) Endpoint Status Register */
-#define USBC_UESTA2_RESETVALUE      _U(0x00000100); /**< \brief (USBC_UESTA2 reset_value) Endpoint Status Register */
+#define USBC_UESTA2_RESETVALUE      _U_(0x00000100); /**< \brief (USBC_UESTA2 reset_value) Endpoint Status Register */
 
 #define USBC_UESTA2_TXINI_Pos       0            /**< \brief (USBC_UESTA2) Transmitted IN Data Interrupt */
-#define USBC_UESTA2_TXINI           (_U(0x1) << USBC_UESTA2_TXINI_Pos)
+#define USBC_UESTA2_TXINI           (_U_(0x1) << USBC_UESTA2_TXINI_Pos)
 #define USBC_UESTA2_RXOUTI_Pos      1            /**< \brief (USBC_UESTA2) Received OUT Data Interrupt */
-#define USBC_UESTA2_RXOUTI          (_U(0x1) << USBC_UESTA2_RXOUTI_Pos)
+#define USBC_UESTA2_RXOUTI          (_U_(0x1) << USBC_UESTA2_RXOUTI_Pos)
 #define USBC_UESTA2_RXSTPI_Pos      2            /**< \brief (USBC_UESTA2) Received SETUP Interrupt */
-#define USBC_UESTA2_RXSTPI          (_U(0x1) << USBC_UESTA2_RXSTPI_Pos)
+#define USBC_UESTA2_RXSTPI          (_U_(0x1) << USBC_UESTA2_RXSTPI_Pos)
 #define USBC_UESTA2_NAKOUTI_Pos     3            /**< \brief (USBC_UESTA2) NAKed OUT Interrupt */
-#define USBC_UESTA2_NAKOUTI         (_U(0x1) << USBC_UESTA2_NAKOUTI_Pos)
+#define USBC_UESTA2_NAKOUTI         (_U_(0x1) << USBC_UESTA2_NAKOUTI_Pos)
 #define USBC_UESTA2_NAKINI_Pos      4            /**< \brief (USBC_UESTA2) NAKed IN Interrupt */
-#define USBC_UESTA2_NAKINI          (_U(0x1) << USBC_UESTA2_NAKINI_Pos)
+#define USBC_UESTA2_NAKINI          (_U_(0x1) << USBC_UESTA2_NAKINI_Pos)
 #define USBC_UESTA2_STALLEDI_Pos    6            /**< \brief (USBC_UESTA2) STALLed Interrupt */
-#define USBC_UESTA2_STALLEDI        (_U(0x1) << USBC_UESTA2_STALLEDI_Pos)
+#define USBC_UESTA2_STALLEDI        (_U_(0x1) << USBC_UESTA2_STALLEDI_Pos)
 #define USBC_UESTA2_DTSEQ_Pos       8            /**< \brief (USBC_UESTA2) Data Toggle Sequence */
-#define USBC_UESTA2_DTSEQ_Msk       (_U(0x3) << USBC_UESTA2_DTSEQ_Pos)
+#define USBC_UESTA2_DTSEQ_Msk       (_U_(0x3) << USBC_UESTA2_DTSEQ_Pos)
 #define USBC_UESTA2_DTSEQ(value)    (USBC_UESTA2_DTSEQ_Msk & ((value) << USBC_UESTA2_DTSEQ_Pos))
 #define USBC_UESTA2_RAMACERI_Pos    11           /**< \brief (USBC_UESTA2) Ram Access Error Interrupt */
-#define USBC_UESTA2_RAMACERI        (_U(0x1) << USBC_UESTA2_RAMACERI_Pos)
+#define USBC_UESTA2_RAMACERI        (_U_(0x1) << USBC_UESTA2_RAMACERI_Pos)
 #define USBC_UESTA2_NBUSYBK_Pos     12           /**< \brief (USBC_UESTA2) Number Of Busy Banks */
-#define USBC_UESTA2_NBUSYBK_Msk     (_U(0x3) << USBC_UESTA2_NBUSYBK_Pos)
+#define USBC_UESTA2_NBUSYBK_Msk     (_U_(0x3) << USBC_UESTA2_NBUSYBK_Pos)
 #define USBC_UESTA2_NBUSYBK(value)  (USBC_UESTA2_NBUSYBK_Msk & ((value) << USBC_UESTA2_NBUSYBK_Pos))
 #define USBC_UESTA2_CURRBK_Pos      14           /**< \brief (USBC_UESTA2) Current Bank */
-#define USBC_UESTA2_CURRBK_Msk      (_U(0x3) << USBC_UESTA2_CURRBK_Pos)
+#define USBC_UESTA2_CURRBK_Msk      (_U_(0x3) << USBC_UESTA2_CURRBK_Pos)
 #define USBC_UESTA2_CURRBK(value)   (USBC_UESTA2_CURRBK_Msk & ((value) << USBC_UESTA2_CURRBK_Pos))
 #define USBC_UESTA2_CTRLDIR_Pos     17           /**< \brief (USBC_UESTA2) Control Direction */
-#define USBC_UESTA2_CTRLDIR         (_U(0x1) << USBC_UESTA2_CTRLDIR_Pos)
-#define   USBC_UESTA2_CTRLDIR_OUT_Val     _U(0x0)   /**< \brief (USBC_UESTA2)  */
-#define   USBC_UESTA2_CTRLDIR_IN_Val      _U(0x1)   /**< \brief (USBC_UESTA2)  */
+#define USBC_UESTA2_CTRLDIR         (_U_(0x1) << USBC_UESTA2_CTRLDIR_Pos)
+#define   USBC_UESTA2_CTRLDIR_OUT_Val     _U_(0x0)   /**< \brief (USBC_UESTA2)  */
+#define   USBC_UESTA2_CTRLDIR_IN_Val      _U_(0x1)   /**< \brief (USBC_UESTA2)  */
 #define USBC_UESTA2_CTRLDIR_OUT     (USBC_UESTA2_CTRLDIR_OUT_Val   << USBC_UESTA2_CTRLDIR_Pos)
 #define USBC_UESTA2_CTRLDIR_IN      (USBC_UESTA2_CTRLDIR_IN_Val    << USBC_UESTA2_CTRLDIR_Pos)
-#define USBC_UESTA2_MASK            _U(0x0002FB5F) /**< \brief (USBC_UESTA2) MASK Register */
+#define USBC_UESTA2_MASK            _U_(0x0002FB5F) /**< \brief (USBC_UESTA2) MASK Register */
 
 /* -------- USBC_UESTA3 : (USBC Offset: 0x13C) (R/  32) Endpoint Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1233,38 +1233,38 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UESTA3_OFFSET          0x13C        /**< \brief (USBC_UESTA3 offset) Endpoint Status Register */
-#define USBC_UESTA3_RESETVALUE      _U(0x00000100); /**< \brief (USBC_UESTA3 reset_value) Endpoint Status Register */
+#define USBC_UESTA3_RESETVALUE      _U_(0x00000100); /**< \brief (USBC_UESTA3 reset_value) Endpoint Status Register */
 
 #define USBC_UESTA3_TXINI_Pos       0            /**< \brief (USBC_UESTA3) Transmitted IN Data Interrupt */
-#define USBC_UESTA3_TXINI           (_U(0x1) << USBC_UESTA3_TXINI_Pos)
+#define USBC_UESTA3_TXINI           (_U_(0x1) << USBC_UESTA3_TXINI_Pos)
 #define USBC_UESTA3_RXOUTI_Pos      1            /**< \brief (USBC_UESTA3) Received OUT Data Interrupt */
-#define USBC_UESTA3_RXOUTI          (_U(0x1) << USBC_UESTA3_RXOUTI_Pos)
+#define USBC_UESTA3_RXOUTI          (_U_(0x1) << USBC_UESTA3_RXOUTI_Pos)
 #define USBC_UESTA3_RXSTPI_Pos      2            /**< \brief (USBC_UESTA3) Received SETUP Interrupt */
-#define USBC_UESTA3_RXSTPI          (_U(0x1) << USBC_UESTA3_RXSTPI_Pos)
+#define USBC_UESTA3_RXSTPI          (_U_(0x1) << USBC_UESTA3_RXSTPI_Pos)
 #define USBC_UESTA3_NAKOUTI_Pos     3            /**< \brief (USBC_UESTA3) NAKed OUT Interrupt */
-#define USBC_UESTA3_NAKOUTI         (_U(0x1) << USBC_UESTA3_NAKOUTI_Pos)
+#define USBC_UESTA3_NAKOUTI         (_U_(0x1) << USBC_UESTA3_NAKOUTI_Pos)
 #define USBC_UESTA3_NAKINI_Pos      4            /**< \brief (USBC_UESTA3) NAKed IN Interrupt */
-#define USBC_UESTA3_NAKINI          (_U(0x1) << USBC_UESTA3_NAKINI_Pos)
+#define USBC_UESTA3_NAKINI          (_U_(0x1) << USBC_UESTA3_NAKINI_Pos)
 #define USBC_UESTA3_STALLEDI_Pos    6            /**< \brief (USBC_UESTA3) STALLed Interrupt */
-#define USBC_UESTA3_STALLEDI        (_U(0x1) << USBC_UESTA3_STALLEDI_Pos)
+#define USBC_UESTA3_STALLEDI        (_U_(0x1) << USBC_UESTA3_STALLEDI_Pos)
 #define USBC_UESTA3_DTSEQ_Pos       8            /**< \brief (USBC_UESTA3) Data Toggle Sequence */
-#define USBC_UESTA3_DTSEQ_Msk       (_U(0x3) << USBC_UESTA3_DTSEQ_Pos)
+#define USBC_UESTA3_DTSEQ_Msk       (_U_(0x3) << USBC_UESTA3_DTSEQ_Pos)
 #define USBC_UESTA3_DTSEQ(value)    (USBC_UESTA3_DTSEQ_Msk & ((value) << USBC_UESTA3_DTSEQ_Pos))
 #define USBC_UESTA3_RAMACERI_Pos    11           /**< \brief (USBC_UESTA3) Ram Access Error Interrupt */
-#define USBC_UESTA3_RAMACERI        (_U(0x1) << USBC_UESTA3_RAMACERI_Pos)
+#define USBC_UESTA3_RAMACERI        (_U_(0x1) << USBC_UESTA3_RAMACERI_Pos)
 #define USBC_UESTA3_NBUSYBK_Pos     12           /**< \brief (USBC_UESTA3) Number Of Busy Banks */
-#define USBC_UESTA3_NBUSYBK_Msk     (_U(0x3) << USBC_UESTA3_NBUSYBK_Pos)
+#define USBC_UESTA3_NBUSYBK_Msk     (_U_(0x3) << USBC_UESTA3_NBUSYBK_Pos)
 #define USBC_UESTA3_NBUSYBK(value)  (USBC_UESTA3_NBUSYBK_Msk & ((value) << USBC_UESTA3_NBUSYBK_Pos))
 #define USBC_UESTA3_CURRBK_Pos      14           /**< \brief (USBC_UESTA3) Current Bank */
-#define USBC_UESTA3_CURRBK_Msk      (_U(0x3) << USBC_UESTA3_CURRBK_Pos)
+#define USBC_UESTA3_CURRBK_Msk      (_U_(0x3) << USBC_UESTA3_CURRBK_Pos)
 #define USBC_UESTA3_CURRBK(value)   (USBC_UESTA3_CURRBK_Msk & ((value) << USBC_UESTA3_CURRBK_Pos))
 #define USBC_UESTA3_CTRLDIR_Pos     17           /**< \brief (USBC_UESTA3) Control Direction */
-#define USBC_UESTA3_CTRLDIR         (_U(0x1) << USBC_UESTA3_CTRLDIR_Pos)
-#define   USBC_UESTA3_CTRLDIR_OUT_Val     _U(0x0)   /**< \brief (USBC_UESTA3)  */
-#define   USBC_UESTA3_CTRLDIR_IN_Val      _U(0x1)   /**< \brief (USBC_UESTA3)  */
+#define USBC_UESTA3_CTRLDIR         (_U_(0x1) << USBC_UESTA3_CTRLDIR_Pos)
+#define   USBC_UESTA3_CTRLDIR_OUT_Val     _U_(0x0)   /**< \brief (USBC_UESTA3)  */
+#define   USBC_UESTA3_CTRLDIR_IN_Val      _U_(0x1)   /**< \brief (USBC_UESTA3)  */
 #define USBC_UESTA3_CTRLDIR_OUT     (USBC_UESTA3_CTRLDIR_OUT_Val   << USBC_UESTA3_CTRLDIR_Pos)
 #define USBC_UESTA3_CTRLDIR_IN      (USBC_UESTA3_CTRLDIR_IN_Val    << USBC_UESTA3_CTRLDIR_Pos)
-#define USBC_UESTA3_MASK            _U(0x0002FB5F) /**< \brief (USBC_UESTA3) MASK Register */
+#define USBC_UESTA3_MASK            _U_(0x0002FB5F) /**< \brief (USBC_UESTA3) MASK Register */
 
 /* -------- USBC_UESTA4 : (USBC Offset: 0x140) (R/  32) Endpoint Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1292,38 +1292,38 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UESTA4_OFFSET          0x140        /**< \brief (USBC_UESTA4 offset) Endpoint Status Register */
-#define USBC_UESTA4_RESETVALUE      _U(0x00000100); /**< \brief (USBC_UESTA4 reset_value) Endpoint Status Register */
+#define USBC_UESTA4_RESETVALUE      _U_(0x00000100); /**< \brief (USBC_UESTA4 reset_value) Endpoint Status Register */
 
 #define USBC_UESTA4_TXINI_Pos       0            /**< \brief (USBC_UESTA4) Transmitted IN Data Interrupt */
-#define USBC_UESTA4_TXINI           (_U(0x1) << USBC_UESTA4_TXINI_Pos)
+#define USBC_UESTA4_TXINI           (_U_(0x1) << USBC_UESTA4_TXINI_Pos)
 #define USBC_UESTA4_RXOUTI_Pos      1            /**< \brief (USBC_UESTA4) Received OUT Data Interrupt */
-#define USBC_UESTA4_RXOUTI          (_U(0x1) << USBC_UESTA4_RXOUTI_Pos)
+#define USBC_UESTA4_RXOUTI          (_U_(0x1) << USBC_UESTA4_RXOUTI_Pos)
 #define USBC_UESTA4_RXSTPI_Pos      2            /**< \brief (USBC_UESTA4) Received SETUP Interrupt */
-#define USBC_UESTA4_RXSTPI          (_U(0x1) << USBC_UESTA4_RXSTPI_Pos)
+#define USBC_UESTA4_RXSTPI          (_U_(0x1) << USBC_UESTA4_RXSTPI_Pos)
 #define USBC_UESTA4_NAKOUTI_Pos     3            /**< \brief (USBC_UESTA4) NAKed OUT Interrupt */
-#define USBC_UESTA4_NAKOUTI         (_U(0x1) << USBC_UESTA4_NAKOUTI_Pos)
+#define USBC_UESTA4_NAKOUTI         (_U_(0x1) << USBC_UESTA4_NAKOUTI_Pos)
 #define USBC_UESTA4_NAKINI_Pos      4            /**< \brief (USBC_UESTA4) NAKed IN Interrupt */
-#define USBC_UESTA4_NAKINI          (_U(0x1) << USBC_UESTA4_NAKINI_Pos)
+#define USBC_UESTA4_NAKINI          (_U_(0x1) << USBC_UESTA4_NAKINI_Pos)
 #define USBC_UESTA4_STALLEDI_Pos    6            /**< \brief (USBC_UESTA4) STALLed Interrupt */
-#define USBC_UESTA4_STALLEDI        (_U(0x1) << USBC_UESTA4_STALLEDI_Pos)
+#define USBC_UESTA4_STALLEDI        (_U_(0x1) << USBC_UESTA4_STALLEDI_Pos)
 #define USBC_UESTA4_DTSEQ_Pos       8            /**< \brief (USBC_UESTA4) Data Toggle Sequence */
-#define USBC_UESTA4_DTSEQ_Msk       (_U(0x3) << USBC_UESTA4_DTSEQ_Pos)
+#define USBC_UESTA4_DTSEQ_Msk       (_U_(0x3) << USBC_UESTA4_DTSEQ_Pos)
 #define USBC_UESTA4_DTSEQ(value)    (USBC_UESTA4_DTSEQ_Msk & ((value) << USBC_UESTA4_DTSEQ_Pos))
 #define USBC_UESTA4_RAMACERI_Pos    11           /**< \brief (USBC_UESTA4) Ram Access Error Interrupt */
-#define USBC_UESTA4_RAMACERI        (_U(0x1) << USBC_UESTA4_RAMACERI_Pos)
+#define USBC_UESTA4_RAMACERI        (_U_(0x1) << USBC_UESTA4_RAMACERI_Pos)
 #define USBC_UESTA4_NBUSYBK_Pos     12           /**< \brief (USBC_UESTA4) Number Of Busy Banks */
-#define USBC_UESTA4_NBUSYBK_Msk     (_U(0x3) << USBC_UESTA4_NBUSYBK_Pos)
+#define USBC_UESTA4_NBUSYBK_Msk     (_U_(0x3) << USBC_UESTA4_NBUSYBK_Pos)
 #define USBC_UESTA4_NBUSYBK(value)  (USBC_UESTA4_NBUSYBK_Msk & ((value) << USBC_UESTA4_NBUSYBK_Pos))
 #define USBC_UESTA4_CURRBK_Pos      14           /**< \brief (USBC_UESTA4) Current Bank */
-#define USBC_UESTA4_CURRBK_Msk      (_U(0x3) << USBC_UESTA4_CURRBK_Pos)
+#define USBC_UESTA4_CURRBK_Msk      (_U_(0x3) << USBC_UESTA4_CURRBK_Pos)
 #define USBC_UESTA4_CURRBK(value)   (USBC_UESTA4_CURRBK_Msk & ((value) << USBC_UESTA4_CURRBK_Pos))
 #define USBC_UESTA4_CTRLDIR_Pos     17           /**< \brief (USBC_UESTA4) Control Direction */
-#define USBC_UESTA4_CTRLDIR         (_U(0x1) << USBC_UESTA4_CTRLDIR_Pos)
-#define   USBC_UESTA4_CTRLDIR_OUT_Val     _U(0x0)   /**< \brief (USBC_UESTA4)  */
-#define   USBC_UESTA4_CTRLDIR_IN_Val      _U(0x1)   /**< \brief (USBC_UESTA4)  */
+#define USBC_UESTA4_CTRLDIR         (_U_(0x1) << USBC_UESTA4_CTRLDIR_Pos)
+#define   USBC_UESTA4_CTRLDIR_OUT_Val     _U_(0x0)   /**< \brief (USBC_UESTA4)  */
+#define   USBC_UESTA4_CTRLDIR_IN_Val      _U_(0x1)   /**< \brief (USBC_UESTA4)  */
 #define USBC_UESTA4_CTRLDIR_OUT     (USBC_UESTA4_CTRLDIR_OUT_Val   << USBC_UESTA4_CTRLDIR_Pos)
 #define USBC_UESTA4_CTRLDIR_IN      (USBC_UESTA4_CTRLDIR_IN_Val    << USBC_UESTA4_CTRLDIR_Pos)
-#define USBC_UESTA4_MASK            _U(0x0002FB5F) /**< \brief (USBC_UESTA4) MASK Register */
+#define USBC_UESTA4_MASK            _U_(0x0002FB5F) /**< \brief (USBC_UESTA4) MASK Register */
 
 /* -------- USBC_UESTA5 : (USBC Offset: 0x144) (R/  32) Endpoint Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1351,38 +1351,38 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UESTA5_OFFSET          0x144        /**< \brief (USBC_UESTA5 offset) Endpoint Status Register */
-#define USBC_UESTA5_RESETVALUE      _U(0x00000100); /**< \brief (USBC_UESTA5 reset_value) Endpoint Status Register */
+#define USBC_UESTA5_RESETVALUE      _U_(0x00000100); /**< \brief (USBC_UESTA5 reset_value) Endpoint Status Register */
 
 #define USBC_UESTA5_TXINI_Pos       0            /**< \brief (USBC_UESTA5) Transmitted IN Data Interrupt */
-#define USBC_UESTA5_TXINI           (_U(0x1) << USBC_UESTA5_TXINI_Pos)
+#define USBC_UESTA5_TXINI           (_U_(0x1) << USBC_UESTA5_TXINI_Pos)
 #define USBC_UESTA5_RXOUTI_Pos      1            /**< \brief (USBC_UESTA5) Received OUT Data Interrupt */
-#define USBC_UESTA5_RXOUTI          (_U(0x1) << USBC_UESTA5_RXOUTI_Pos)
+#define USBC_UESTA5_RXOUTI          (_U_(0x1) << USBC_UESTA5_RXOUTI_Pos)
 #define USBC_UESTA5_RXSTPI_Pos      2            /**< \brief (USBC_UESTA5) Received SETUP Interrupt */
-#define USBC_UESTA5_RXSTPI          (_U(0x1) << USBC_UESTA5_RXSTPI_Pos)
+#define USBC_UESTA5_RXSTPI          (_U_(0x1) << USBC_UESTA5_RXSTPI_Pos)
 #define USBC_UESTA5_NAKOUTI_Pos     3            /**< \brief (USBC_UESTA5) NAKed OUT Interrupt */
-#define USBC_UESTA5_NAKOUTI         (_U(0x1) << USBC_UESTA5_NAKOUTI_Pos)
+#define USBC_UESTA5_NAKOUTI         (_U_(0x1) << USBC_UESTA5_NAKOUTI_Pos)
 #define USBC_UESTA5_NAKINI_Pos      4            /**< \brief (USBC_UESTA5) NAKed IN Interrupt */
-#define USBC_UESTA5_NAKINI          (_U(0x1) << USBC_UESTA5_NAKINI_Pos)
+#define USBC_UESTA5_NAKINI          (_U_(0x1) << USBC_UESTA5_NAKINI_Pos)
 #define USBC_UESTA5_STALLEDI_Pos    6            /**< \brief (USBC_UESTA5) STALLed Interrupt */
-#define USBC_UESTA5_STALLEDI        (_U(0x1) << USBC_UESTA5_STALLEDI_Pos)
+#define USBC_UESTA5_STALLEDI        (_U_(0x1) << USBC_UESTA5_STALLEDI_Pos)
 #define USBC_UESTA5_DTSEQ_Pos       8            /**< \brief (USBC_UESTA5) Data Toggle Sequence */
-#define USBC_UESTA5_DTSEQ_Msk       (_U(0x3) << USBC_UESTA5_DTSEQ_Pos)
+#define USBC_UESTA5_DTSEQ_Msk       (_U_(0x3) << USBC_UESTA5_DTSEQ_Pos)
 #define USBC_UESTA5_DTSEQ(value)    (USBC_UESTA5_DTSEQ_Msk & ((value) << USBC_UESTA5_DTSEQ_Pos))
 #define USBC_UESTA5_RAMACERI_Pos    11           /**< \brief (USBC_UESTA5) Ram Access Error Interrupt */
-#define USBC_UESTA5_RAMACERI        (_U(0x1) << USBC_UESTA5_RAMACERI_Pos)
+#define USBC_UESTA5_RAMACERI        (_U_(0x1) << USBC_UESTA5_RAMACERI_Pos)
 #define USBC_UESTA5_NBUSYBK_Pos     12           /**< \brief (USBC_UESTA5) Number Of Busy Banks */
-#define USBC_UESTA5_NBUSYBK_Msk     (_U(0x3) << USBC_UESTA5_NBUSYBK_Pos)
+#define USBC_UESTA5_NBUSYBK_Msk     (_U_(0x3) << USBC_UESTA5_NBUSYBK_Pos)
 #define USBC_UESTA5_NBUSYBK(value)  (USBC_UESTA5_NBUSYBK_Msk & ((value) << USBC_UESTA5_NBUSYBK_Pos))
 #define USBC_UESTA5_CURRBK_Pos      14           /**< \brief (USBC_UESTA5) Current Bank */
-#define USBC_UESTA5_CURRBK_Msk      (_U(0x3) << USBC_UESTA5_CURRBK_Pos)
+#define USBC_UESTA5_CURRBK_Msk      (_U_(0x3) << USBC_UESTA5_CURRBK_Pos)
 #define USBC_UESTA5_CURRBK(value)   (USBC_UESTA5_CURRBK_Msk & ((value) << USBC_UESTA5_CURRBK_Pos))
 #define USBC_UESTA5_CTRLDIR_Pos     17           /**< \brief (USBC_UESTA5) Control Direction */
-#define USBC_UESTA5_CTRLDIR         (_U(0x1) << USBC_UESTA5_CTRLDIR_Pos)
-#define   USBC_UESTA5_CTRLDIR_OUT_Val     _U(0x0)   /**< \brief (USBC_UESTA5)  */
-#define   USBC_UESTA5_CTRLDIR_IN_Val      _U(0x1)   /**< \brief (USBC_UESTA5)  */
+#define USBC_UESTA5_CTRLDIR         (_U_(0x1) << USBC_UESTA5_CTRLDIR_Pos)
+#define   USBC_UESTA5_CTRLDIR_OUT_Val     _U_(0x0)   /**< \brief (USBC_UESTA5)  */
+#define   USBC_UESTA5_CTRLDIR_IN_Val      _U_(0x1)   /**< \brief (USBC_UESTA5)  */
 #define USBC_UESTA5_CTRLDIR_OUT     (USBC_UESTA5_CTRLDIR_OUT_Val   << USBC_UESTA5_CTRLDIR_Pos)
 #define USBC_UESTA5_CTRLDIR_IN      (USBC_UESTA5_CTRLDIR_IN_Val    << USBC_UESTA5_CTRLDIR_Pos)
-#define USBC_UESTA5_MASK            _U(0x0002FB5F) /**< \brief (USBC_UESTA5) MASK Register */
+#define USBC_UESTA5_MASK            _U_(0x0002FB5F) /**< \brief (USBC_UESTA5) MASK Register */
 
 /* -------- USBC_UESTA6 : (USBC Offset: 0x148) (R/  32) Endpoint Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1410,38 +1410,38 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UESTA6_OFFSET          0x148        /**< \brief (USBC_UESTA6 offset) Endpoint Status Register */
-#define USBC_UESTA6_RESETVALUE      _U(0x00000100); /**< \brief (USBC_UESTA6 reset_value) Endpoint Status Register */
+#define USBC_UESTA6_RESETVALUE      _U_(0x00000100); /**< \brief (USBC_UESTA6 reset_value) Endpoint Status Register */
 
 #define USBC_UESTA6_TXINI_Pos       0            /**< \brief (USBC_UESTA6) Transmitted IN Data Interrupt */
-#define USBC_UESTA6_TXINI           (_U(0x1) << USBC_UESTA6_TXINI_Pos)
+#define USBC_UESTA6_TXINI           (_U_(0x1) << USBC_UESTA6_TXINI_Pos)
 #define USBC_UESTA6_RXOUTI_Pos      1            /**< \brief (USBC_UESTA6) Received OUT Data Interrupt */
-#define USBC_UESTA6_RXOUTI          (_U(0x1) << USBC_UESTA6_RXOUTI_Pos)
+#define USBC_UESTA6_RXOUTI          (_U_(0x1) << USBC_UESTA6_RXOUTI_Pos)
 #define USBC_UESTA6_RXSTPI_Pos      2            /**< \brief (USBC_UESTA6) Received SETUP Interrupt */
-#define USBC_UESTA6_RXSTPI          (_U(0x1) << USBC_UESTA6_RXSTPI_Pos)
+#define USBC_UESTA6_RXSTPI          (_U_(0x1) << USBC_UESTA6_RXSTPI_Pos)
 #define USBC_UESTA6_NAKOUTI_Pos     3            /**< \brief (USBC_UESTA6) NAKed OUT Interrupt */
-#define USBC_UESTA6_NAKOUTI         (_U(0x1) << USBC_UESTA6_NAKOUTI_Pos)
+#define USBC_UESTA6_NAKOUTI         (_U_(0x1) << USBC_UESTA6_NAKOUTI_Pos)
 #define USBC_UESTA6_NAKINI_Pos      4            /**< \brief (USBC_UESTA6) NAKed IN Interrupt */
-#define USBC_UESTA6_NAKINI          (_U(0x1) << USBC_UESTA6_NAKINI_Pos)
+#define USBC_UESTA6_NAKINI          (_U_(0x1) << USBC_UESTA6_NAKINI_Pos)
 #define USBC_UESTA6_STALLEDI_Pos    6            /**< \brief (USBC_UESTA6) STALLed Interrupt */
-#define USBC_UESTA6_STALLEDI        (_U(0x1) << USBC_UESTA6_STALLEDI_Pos)
+#define USBC_UESTA6_STALLEDI        (_U_(0x1) << USBC_UESTA6_STALLEDI_Pos)
 #define USBC_UESTA6_DTSEQ_Pos       8            /**< \brief (USBC_UESTA6) Data Toggle Sequence */
-#define USBC_UESTA6_DTSEQ_Msk       (_U(0x3) << USBC_UESTA6_DTSEQ_Pos)
+#define USBC_UESTA6_DTSEQ_Msk       (_U_(0x3) << USBC_UESTA6_DTSEQ_Pos)
 #define USBC_UESTA6_DTSEQ(value)    (USBC_UESTA6_DTSEQ_Msk & ((value) << USBC_UESTA6_DTSEQ_Pos))
 #define USBC_UESTA6_RAMACERI_Pos    11           /**< \brief (USBC_UESTA6) Ram Access Error Interrupt */
-#define USBC_UESTA6_RAMACERI        (_U(0x1) << USBC_UESTA6_RAMACERI_Pos)
+#define USBC_UESTA6_RAMACERI        (_U_(0x1) << USBC_UESTA6_RAMACERI_Pos)
 #define USBC_UESTA6_NBUSYBK_Pos     12           /**< \brief (USBC_UESTA6) Number Of Busy Banks */
-#define USBC_UESTA6_NBUSYBK_Msk     (_U(0x3) << USBC_UESTA6_NBUSYBK_Pos)
+#define USBC_UESTA6_NBUSYBK_Msk     (_U_(0x3) << USBC_UESTA6_NBUSYBK_Pos)
 #define USBC_UESTA6_NBUSYBK(value)  (USBC_UESTA6_NBUSYBK_Msk & ((value) << USBC_UESTA6_NBUSYBK_Pos))
 #define USBC_UESTA6_CURRBK_Pos      14           /**< \brief (USBC_UESTA6) Current Bank */
-#define USBC_UESTA6_CURRBK_Msk      (_U(0x3) << USBC_UESTA6_CURRBK_Pos)
+#define USBC_UESTA6_CURRBK_Msk      (_U_(0x3) << USBC_UESTA6_CURRBK_Pos)
 #define USBC_UESTA6_CURRBK(value)   (USBC_UESTA6_CURRBK_Msk & ((value) << USBC_UESTA6_CURRBK_Pos))
 #define USBC_UESTA6_CTRLDIR_Pos     17           /**< \brief (USBC_UESTA6) Control Direction */
-#define USBC_UESTA6_CTRLDIR         (_U(0x1) << USBC_UESTA6_CTRLDIR_Pos)
-#define   USBC_UESTA6_CTRLDIR_OUT_Val     _U(0x0)   /**< \brief (USBC_UESTA6)  */
-#define   USBC_UESTA6_CTRLDIR_IN_Val      _U(0x1)   /**< \brief (USBC_UESTA6)  */
+#define USBC_UESTA6_CTRLDIR         (_U_(0x1) << USBC_UESTA6_CTRLDIR_Pos)
+#define   USBC_UESTA6_CTRLDIR_OUT_Val     _U_(0x0)   /**< \brief (USBC_UESTA6)  */
+#define   USBC_UESTA6_CTRLDIR_IN_Val      _U_(0x1)   /**< \brief (USBC_UESTA6)  */
 #define USBC_UESTA6_CTRLDIR_OUT     (USBC_UESTA6_CTRLDIR_OUT_Val   << USBC_UESTA6_CTRLDIR_Pos)
 #define USBC_UESTA6_CTRLDIR_IN      (USBC_UESTA6_CTRLDIR_IN_Val    << USBC_UESTA6_CTRLDIR_Pos)
-#define USBC_UESTA6_MASK            _U(0x0002FB5F) /**< \brief (USBC_UESTA6) MASK Register */
+#define USBC_UESTA6_MASK            _U_(0x0002FB5F) /**< \brief (USBC_UESTA6) MASK Register */
 
 /* -------- USBC_UESTA7 : (USBC Offset: 0x14C) (R/  32) Endpoint Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1469,38 +1469,38 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UESTA7_OFFSET          0x14C        /**< \brief (USBC_UESTA7 offset) Endpoint Status Register */
-#define USBC_UESTA7_RESETVALUE      _U(0x00000100); /**< \brief (USBC_UESTA7 reset_value) Endpoint Status Register */
+#define USBC_UESTA7_RESETVALUE      _U_(0x00000100); /**< \brief (USBC_UESTA7 reset_value) Endpoint Status Register */
 
 #define USBC_UESTA7_TXINI_Pos       0            /**< \brief (USBC_UESTA7) Transmitted IN Data Interrupt */
-#define USBC_UESTA7_TXINI           (_U(0x1) << USBC_UESTA7_TXINI_Pos)
+#define USBC_UESTA7_TXINI           (_U_(0x1) << USBC_UESTA7_TXINI_Pos)
 #define USBC_UESTA7_RXOUTI_Pos      1            /**< \brief (USBC_UESTA7) Received OUT Data Interrupt */
-#define USBC_UESTA7_RXOUTI          (_U(0x1) << USBC_UESTA7_RXOUTI_Pos)
+#define USBC_UESTA7_RXOUTI          (_U_(0x1) << USBC_UESTA7_RXOUTI_Pos)
 #define USBC_UESTA7_RXSTPI_Pos      2            /**< \brief (USBC_UESTA7) Received SETUP Interrupt */
-#define USBC_UESTA7_RXSTPI          (_U(0x1) << USBC_UESTA7_RXSTPI_Pos)
+#define USBC_UESTA7_RXSTPI          (_U_(0x1) << USBC_UESTA7_RXSTPI_Pos)
 #define USBC_UESTA7_NAKOUTI_Pos     3            /**< \brief (USBC_UESTA7) NAKed OUT Interrupt */
-#define USBC_UESTA7_NAKOUTI         (_U(0x1) << USBC_UESTA7_NAKOUTI_Pos)
+#define USBC_UESTA7_NAKOUTI         (_U_(0x1) << USBC_UESTA7_NAKOUTI_Pos)
 #define USBC_UESTA7_NAKINI_Pos      4            /**< \brief (USBC_UESTA7) NAKed IN Interrupt */
-#define USBC_UESTA7_NAKINI          (_U(0x1) << USBC_UESTA7_NAKINI_Pos)
+#define USBC_UESTA7_NAKINI          (_U_(0x1) << USBC_UESTA7_NAKINI_Pos)
 #define USBC_UESTA7_STALLEDI_Pos    6            /**< \brief (USBC_UESTA7) STALLed Interrupt */
-#define USBC_UESTA7_STALLEDI        (_U(0x1) << USBC_UESTA7_STALLEDI_Pos)
+#define USBC_UESTA7_STALLEDI        (_U_(0x1) << USBC_UESTA7_STALLEDI_Pos)
 #define USBC_UESTA7_DTSEQ_Pos       8            /**< \brief (USBC_UESTA7) Data Toggle Sequence */
-#define USBC_UESTA7_DTSEQ_Msk       (_U(0x3) << USBC_UESTA7_DTSEQ_Pos)
+#define USBC_UESTA7_DTSEQ_Msk       (_U_(0x3) << USBC_UESTA7_DTSEQ_Pos)
 #define USBC_UESTA7_DTSEQ(value)    (USBC_UESTA7_DTSEQ_Msk & ((value) << USBC_UESTA7_DTSEQ_Pos))
 #define USBC_UESTA7_RAMACERI_Pos    11           /**< \brief (USBC_UESTA7) Ram Access Error Interrupt */
-#define USBC_UESTA7_RAMACERI        (_U(0x1) << USBC_UESTA7_RAMACERI_Pos)
+#define USBC_UESTA7_RAMACERI        (_U_(0x1) << USBC_UESTA7_RAMACERI_Pos)
 #define USBC_UESTA7_NBUSYBK_Pos     12           /**< \brief (USBC_UESTA7) Number Of Busy Banks */
-#define USBC_UESTA7_NBUSYBK_Msk     (_U(0x3) << USBC_UESTA7_NBUSYBK_Pos)
+#define USBC_UESTA7_NBUSYBK_Msk     (_U_(0x3) << USBC_UESTA7_NBUSYBK_Pos)
 #define USBC_UESTA7_NBUSYBK(value)  (USBC_UESTA7_NBUSYBK_Msk & ((value) << USBC_UESTA7_NBUSYBK_Pos))
 #define USBC_UESTA7_CURRBK_Pos      14           /**< \brief (USBC_UESTA7) Current Bank */
-#define USBC_UESTA7_CURRBK_Msk      (_U(0x3) << USBC_UESTA7_CURRBK_Pos)
+#define USBC_UESTA7_CURRBK_Msk      (_U_(0x3) << USBC_UESTA7_CURRBK_Pos)
 #define USBC_UESTA7_CURRBK(value)   (USBC_UESTA7_CURRBK_Msk & ((value) << USBC_UESTA7_CURRBK_Pos))
 #define USBC_UESTA7_CTRLDIR_Pos     17           /**< \brief (USBC_UESTA7) Control Direction */
-#define USBC_UESTA7_CTRLDIR         (_U(0x1) << USBC_UESTA7_CTRLDIR_Pos)
-#define   USBC_UESTA7_CTRLDIR_OUT_Val     _U(0x0)   /**< \brief (USBC_UESTA7)  */
-#define   USBC_UESTA7_CTRLDIR_IN_Val      _U(0x1)   /**< \brief (USBC_UESTA7)  */
+#define USBC_UESTA7_CTRLDIR         (_U_(0x1) << USBC_UESTA7_CTRLDIR_Pos)
+#define   USBC_UESTA7_CTRLDIR_OUT_Val     _U_(0x0)   /**< \brief (USBC_UESTA7)  */
+#define   USBC_UESTA7_CTRLDIR_IN_Val      _U_(0x1)   /**< \brief (USBC_UESTA7)  */
 #define USBC_UESTA7_CTRLDIR_OUT     (USBC_UESTA7_CTRLDIR_OUT_Val   << USBC_UESTA7_CTRLDIR_Pos)
 #define USBC_UESTA7_CTRLDIR_IN      (USBC_UESTA7_CTRLDIR_IN_Val    << USBC_UESTA7_CTRLDIR_Pos)
-#define USBC_UESTA7_MASK            _U(0x0002FB5F) /**< \brief (USBC_UESTA7) MASK Register */
+#define USBC_UESTA7_MASK            _U_(0x0002FB5F) /**< \brief (USBC_UESTA7) MASK Register */
 
 /* -------- USBC_UESTA0CLR : (USBC Offset: 0x160) ( /W 32) Endpoint Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1522,23 +1522,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UESTA0CLR_OFFSET       0x160        /**< \brief (USBC_UESTA0CLR offset) Endpoint Status Clear Register */
-#define USBC_UESTA0CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA0CLR reset_value) Endpoint Status Clear Register */
+#define USBC_UESTA0CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UESTA0CLR reset_value) Endpoint Status Clear Register */
 
 #define USBC_UESTA0CLR_TXINIC_Pos   0            /**< \brief (USBC_UESTA0CLR) TXINI Clear */
-#define USBC_UESTA0CLR_TXINIC       (_U(0x1) << USBC_UESTA0CLR_TXINIC_Pos)
+#define USBC_UESTA0CLR_TXINIC       (_U_(0x1) << USBC_UESTA0CLR_TXINIC_Pos)
 #define USBC_UESTA0CLR_RXOUTIC_Pos  1            /**< \brief (USBC_UESTA0CLR) RXOUTI Clear */
-#define USBC_UESTA0CLR_RXOUTIC      (_U(0x1) << USBC_UESTA0CLR_RXOUTIC_Pos)
+#define USBC_UESTA0CLR_RXOUTIC      (_U_(0x1) << USBC_UESTA0CLR_RXOUTIC_Pos)
 #define USBC_UESTA0CLR_RXSTPIC_Pos  2            /**< \brief (USBC_UESTA0CLR) RXSTPI Clear */
-#define USBC_UESTA0CLR_RXSTPIC      (_U(0x1) << USBC_UESTA0CLR_RXSTPIC_Pos)
+#define USBC_UESTA0CLR_RXSTPIC      (_U_(0x1) << USBC_UESTA0CLR_RXSTPIC_Pos)
 #define USBC_UESTA0CLR_NAKOUTIC_Pos 3            /**< \brief (USBC_UESTA0CLR) NAKOUTI Clear */
-#define USBC_UESTA0CLR_NAKOUTIC     (_U(0x1) << USBC_UESTA0CLR_NAKOUTIC_Pos)
+#define USBC_UESTA0CLR_NAKOUTIC     (_U_(0x1) << USBC_UESTA0CLR_NAKOUTIC_Pos)
 #define USBC_UESTA0CLR_NAKINIC_Pos  4            /**< \brief (USBC_UESTA0CLR) NAKINI Clear */
-#define USBC_UESTA0CLR_NAKINIC      (_U(0x1) << USBC_UESTA0CLR_NAKINIC_Pos)
+#define USBC_UESTA0CLR_NAKINIC      (_U_(0x1) << USBC_UESTA0CLR_NAKINIC_Pos)
 #define USBC_UESTA0CLR_STALLEDIC_Pos 6            /**< \brief (USBC_UESTA0CLR) STALLEDI Clear */
-#define USBC_UESTA0CLR_STALLEDIC    (_U(0x1) << USBC_UESTA0CLR_STALLEDIC_Pos)
+#define USBC_UESTA0CLR_STALLEDIC    (_U_(0x1) << USBC_UESTA0CLR_STALLEDIC_Pos)
 #define USBC_UESTA0CLR_RAMACERIC_Pos 11           /**< \brief (USBC_UESTA0CLR) RAMACERI Clear */
-#define USBC_UESTA0CLR_RAMACERIC    (_U(0x1) << USBC_UESTA0CLR_RAMACERIC_Pos)
-#define USBC_UESTA0CLR_MASK         _U(0x0000085F) /**< \brief (USBC_UESTA0CLR) MASK Register */
+#define USBC_UESTA0CLR_RAMACERIC    (_U_(0x1) << USBC_UESTA0CLR_RAMACERIC_Pos)
+#define USBC_UESTA0CLR_MASK         _U_(0x0000085F) /**< \brief (USBC_UESTA0CLR) MASK Register */
 
 /* -------- USBC_UESTA1CLR : (USBC Offset: 0x164) ( /W 32) Endpoint Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1560,23 +1560,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UESTA1CLR_OFFSET       0x164        /**< \brief (USBC_UESTA1CLR offset) Endpoint Status Clear Register */
-#define USBC_UESTA1CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA1CLR reset_value) Endpoint Status Clear Register */
+#define USBC_UESTA1CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UESTA1CLR reset_value) Endpoint Status Clear Register */
 
 #define USBC_UESTA1CLR_TXINIC_Pos   0            /**< \brief (USBC_UESTA1CLR) TXINI Clear */
-#define USBC_UESTA1CLR_TXINIC       (_U(0x1) << USBC_UESTA1CLR_TXINIC_Pos)
+#define USBC_UESTA1CLR_TXINIC       (_U_(0x1) << USBC_UESTA1CLR_TXINIC_Pos)
 #define USBC_UESTA1CLR_RXOUTIC_Pos  1            /**< \brief (USBC_UESTA1CLR) RXOUTI Clear */
-#define USBC_UESTA1CLR_RXOUTIC      (_U(0x1) << USBC_UESTA1CLR_RXOUTIC_Pos)
+#define USBC_UESTA1CLR_RXOUTIC      (_U_(0x1) << USBC_UESTA1CLR_RXOUTIC_Pos)
 #define USBC_UESTA1CLR_RXSTPIC_Pos  2            /**< \brief (USBC_UESTA1CLR) RXSTPI Clear */
-#define USBC_UESTA1CLR_RXSTPIC      (_U(0x1) << USBC_UESTA1CLR_RXSTPIC_Pos)
+#define USBC_UESTA1CLR_RXSTPIC      (_U_(0x1) << USBC_UESTA1CLR_RXSTPIC_Pos)
 #define USBC_UESTA1CLR_NAKOUTIC_Pos 3            /**< \brief (USBC_UESTA1CLR) NAKOUTI Clear */
-#define USBC_UESTA1CLR_NAKOUTIC     (_U(0x1) << USBC_UESTA1CLR_NAKOUTIC_Pos)
+#define USBC_UESTA1CLR_NAKOUTIC     (_U_(0x1) << USBC_UESTA1CLR_NAKOUTIC_Pos)
 #define USBC_UESTA1CLR_NAKINIC_Pos  4            /**< \brief (USBC_UESTA1CLR) NAKINI Clear */
-#define USBC_UESTA1CLR_NAKINIC      (_U(0x1) << USBC_UESTA1CLR_NAKINIC_Pos)
+#define USBC_UESTA1CLR_NAKINIC      (_U_(0x1) << USBC_UESTA1CLR_NAKINIC_Pos)
 #define USBC_UESTA1CLR_STALLEDIC_Pos 6            /**< \brief (USBC_UESTA1CLR) STALLEDI Clear */
-#define USBC_UESTA1CLR_STALLEDIC    (_U(0x1) << USBC_UESTA1CLR_STALLEDIC_Pos)
+#define USBC_UESTA1CLR_STALLEDIC    (_U_(0x1) << USBC_UESTA1CLR_STALLEDIC_Pos)
 #define USBC_UESTA1CLR_RAMACERIC_Pos 11           /**< \brief (USBC_UESTA1CLR) RAMACERI Clear */
-#define USBC_UESTA1CLR_RAMACERIC    (_U(0x1) << USBC_UESTA1CLR_RAMACERIC_Pos)
-#define USBC_UESTA1CLR_MASK         _U(0x0000085F) /**< \brief (USBC_UESTA1CLR) MASK Register */
+#define USBC_UESTA1CLR_RAMACERIC    (_U_(0x1) << USBC_UESTA1CLR_RAMACERIC_Pos)
+#define USBC_UESTA1CLR_MASK         _U_(0x0000085F) /**< \brief (USBC_UESTA1CLR) MASK Register */
 
 /* -------- USBC_UESTA2CLR : (USBC Offset: 0x168) ( /W 32) Endpoint Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1598,23 +1598,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UESTA2CLR_OFFSET       0x168        /**< \brief (USBC_UESTA2CLR offset) Endpoint Status Clear Register */
-#define USBC_UESTA2CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA2CLR reset_value) Endpoint Status Clear Register */
+#define USBC_UESTA2CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UESTA2CLR reset_value) Endpoint Status Clear Register */
 
 #define USBC_UESTA2CLR_TXINIC_Pos   0            /**< \brief (USBC_UESTA2CLR) TXINI Clear */
-#define USBC_UESTA2CLR_TXINIC       (_U(0x1) << USBC_UESTA2CLR_TXINIC_Pos)
+#define USBC_UESTA2CLR_TXINIC       (_U_(0x1) << USBC_UESTA2CLR_TXINIC_Pos)
 #define USBC_UESTA2CLR_RXOUTIC_Pos  1            /**< \brief (USBC_UESTA2CLR) RXOUTI Clear */
-#define USBC_UESTA2CLR_RXOUTIC      (_U(0x1) << USBC_UESTA2CLR_RXOUTIC_Pos)
+#define USBC_UESTA2CLR_RXOUTIC      (_U_(0x1) << USBC_UESTA2CLR_RXOUTIC_Pos)
 #define USBC_UESTA2CLR_RXSTPIC_Pos  2            /**< \brief (USBC_UESTA2CLR) RXSTPI Clear */
-#define USBC_UESTA2CLR_RXSTPIC      (_U(0x1) << USBC_UESTA2CLR_RXSTPIC_Pos)
+#define USBC_UESTA2CLR_RXSTPIC      (_U_(0x1) << USBC_UESTA2CLR_RXSTPIC_Pos)
 #define USBC_UESTA2CLR_NAKOUTIC_Pos 3            /**< \brief (USBC_UESTA2CLR) NAKOUTI Clear */
-#define USBC_UESTA2CLR_NAKOUTIC     (_U(0x1) << USBC_UESTA2CLR_NAKOUTIC_Pos)
+#define USBC_UESTA2CLR_NAKOUTIC     (_U_(0x1) << USBC_UESTA2CLR_NAKOUTIC_Pos)
 #define USBC_UESTA2CLR_NAKINIC_Pos  4            /**< \brief (USBC_UESTA2CLR) NAKINI Clear */
-#define USBC_UESTA2CLR_NAKINIC      (_U(0x1) << USBC_UESTA2CLR_NAKINIC_Pos)
+#define USBC_UESTA2CLR_NAKINIC      (_U_(0x1) << USBC_UESTA2CLR_NAKINIC_Pos)
 #define USBC_UESTA2CLR_STALLEDIC_Pos 6            /**< \brief (USBC_UESTA2CLR) STALLEDI Clear */
-#define USBC_UESTA2CLR_STALLEDIC    (_U(0x1) << USBC_UESTA2CLR_STALLEDIC_Pos)
+#define USBC_UESTA2CLR_STALLEDIC    (_U_(0x1) << USBC_UESTA2CLR_STALLEDIC_Pos)
 #define USBC_UESTA2CLR_RAMACERIC_Pos 11           /**< \brief (USBC_UESTA2CLR) RAMACERI Clear */
-#define USBC_UESTA2CLR_RAMACERIC    (_U(0x1) << USBC_UESTA2CLR_RAMACERIC_Pos)
-#define USBC_UESTA2CLR_MASK         _U(0x0000085F) /**< \brief (USBC_UESTA2CLR) MASK Register */
+#define USBC_UESTA2CLR_RAMACERIC    (_U_(0x1) << USBC_UESTA2CLR_RAMACERIC_Pos)
+#define USBC_UESTA2CLR_MASK         _U_(0x0000085F) /**< \brief (USBC_UESTA2CLR) MASK Register */
 
 /* -------- USBC_UESTA3CLR : (USBC Offset: 0x16C) ( /W 32) Endpoint Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1636,23 +1636,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UESTA3CLR_OFFSET       0x16C        /**< \brief (USBC_UESTA3CLR offset) Endpoint Status Clear Register */
-#define USBC_UESTA3CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA3CLR reset_value) Endpoint Status Clear Register */
+#define USBC_UESTA3CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UESTA3CLR reset_value) Endpoint Status Clear Register */
 
 #define USBC_UESTA3CLR_TXINIC_Pos   0            /**< \brief (USBC_UESTA3CLR) TXINI Clear */
-#define USBC_UESTA3CLR_TXINIC       (_U(0x1) << USBC_UESTA3CLR_TXINIC_Pos)
+#define USBC_UESTA3CLR_TXINIC       (_U_(0x1) << USBC_UESTA3CLR_TXINIC_Pos)
 #define USBC_UESTA3CLR_RXOUTIC_Pos  1            /**< \brief (USBC_UESTA3CLR) RXOUTI Clear */
-#define USBC_UESTA3CLR_RXOUTIC      (_U(0x1) << USBC_UESTA3CLR_RXOUTIC_Pos)
+#define USBC_UESTA3CLR_RXOUTIC      (_U_(0x1) << USBC_UESTA3CLR_RXOUTIC_Pos)
 #define USBC_UESTA3CLR_RXSTPIC_Pos  2            /**< \brief (USBC_UESTA3CLR) RXSTPI Clear */
-#define USBC_UESTA3CLR_RXSTPIC      (_U(0x1) << USBC_UESTA3CLR_RXSTPIC_Pos)
+#define USBC_UESTA3CLR_RXSTPIC      (_U_(0x1) << USBC_UESTA3CLR_RXSTPIC_Pos)
 #define USBC_UESTA3CLR_NAKOUTIC_Pos 3            /**< \brief (USBC_UESTA3CLR) NAKOUTI Clear */
-#define USBC_UESTA3CLR_NAKOUTIC     (_U(0x1) << USBC_UESTA3CLR_NAKOUTIC_Pos)
+#define USBC_UESTA3CLR_NAKOUTIC     (_U_(0x1) << USBC_UESTA3CLR_NAKOUTIC_Pos)
 #define USBC_UESTA3CLR_NAKINIC_Pos  4            /**< \brief (USBC_UESTA3CLR) NAKINI Clear */
-#define USBC_UESTA3CLR_NAKINIC      (_U(0x1) << USBC_UESTA3CLR_NAKINIC_Pos)
+#define USBC_UESTA3CLR_NAKINIC      (_U_(0x1) << USBC_UESTA3CLR_NAKINIC_Pos)
 #define USBC_UESTA3CLR_STALLEDIC_Pos 6            /**< \brief (USBC_UESTA3CLR) STALLEDI Clear */
-#define USBC_UESTA3CLR_STALLEDIC    (_U(0x1) << USBC_UESTA3CLR_STALLEDIC_Pos)
+#define USBC_UESTA3CLR_STALLEDIC    (_U_(0x1) << USBC_UESTA3CLR_STALLEDIC_Pos)
 #define USBC_UESTA3CLR_RAMACERIC_Pos 11           /**< \brief (USBC_UESTA3CLR) RAMACERI Clear */
-#define USBC_UESTA3CLR_RAMACERIC    (_U(0x1) << USBC_UESTA3CLR_RAMACERIC_Pos)
-#define USBC_UESTA3CLR_MASK         _U(0x0000085F) /**< \brief (USBC_UESTA3CLR) MASK Register */
+#define USBC_UESTA3CLR_RAMACERIC    (_U_(0x1) << USBC_UESTA3CLR_RAMACERIC_Pos)
+#define USBC_UESTA3CLR_MASK         _U_(0x0000085F) /**< \brief (USBC_UESTA3CLR) MASK Register */
 
 /* -------- USBC_UESTA4CLR : (USBC Offset: 0x170) ( /W 32) Endpoint Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1674,23 +1674,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UESTA4CLR_OFFSET       0x170        /**< \brief (USBC_UESTA4CLR offset) Endpoint Status Clear Register */
-#define USBC_UESTA4CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA4CLR reset_value) Endpoint Status Clear Register */
+#define USBC_UESTA4CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UESTA4CLR reset_value) Endpoint Status Clear Register */
 
 #define USBC_UESTA4CLR_TXINIC_Pos   0            /**< \brief (USBC_UESTA4CLR) TXINI Clear */
-#define USBC_UESTA4CLR_TXINIC       (_U(0x1) << USBC_UESTA4CLR_TXINIC_Pos)
+#define USBC_UESTA4CLR_TXINIC       (_U_(0x1) << USBC_UESTA4CLR_TXINIC_Pos)
 #define USBC_UESTA4CLR_RXOUTIC_Pos  1            /**< \brief (USBC_UESTA4CLR) RXOUTI Clear */
-#define USBC_UESTA4CLR_RXOUTIC      (_U(0x1) << USBC_UESTA4CLR_RXOUTIC_Pos)
+#define USBC_UESTA4CLR_RXOUTIC      (_U_(0x1) << USBC_UESTA4CLR_RXOUTIC_Pos)
 #define USBC_UESTA4CLR_RXSTPIC_Pos  2            /**< \brief (USBC_UESTA4CLR) RXSTPI Clear */
-#define USBC_UESTA4CLR_RXSTPIC      (_U(0x1) << USBC_UESTA4CLR_RXSTPIC_Pos)
+#define USBC_UESTA4CLR_RXSTPIC      (_U_(0x1) << USBC_UESTA4CLR_RXSTPIC_Pos)
 #define USBC_UESTA4CLR_NAKOUTIC_Pos 3            /**< \brief (USBC_UESTA4CLR) NAKOUTI Clear */
-#define USBC_UESTA4CLR_NAKOUTIC     (_U(0x1) << USBC_UESTA4CLR_NAKOUTIC_Pos)
+#define USBC_UESTA4CLR_NAKOUTIC     (_U_(0x1) << USBC_UESTA4CLR_NAKOUTIC_Pos)
 #define USBC_UESTA4CLR_NAKINIC_Pos  4            /**< \brief (USBC_UESTA4CLR) NAKINI Clear */
-#define USBC_UESTA4CLR_NAKINIC      (_U(0x1) << USBC_UESTA4CLR_NAKINIC_Pos)
+#define USBC_UESTA4CLR_NAKINIC      (_U_(0x1) << USBC_UESTA4CLR_NAKINIC_Pos)
 #define USBC_UESTA4CLR_STALLEDIC_Pos 6            /**< \brief (USBC_UESTA4CLR) STALLEDI Clear */
-#define USBC_UESTA4CLR_STALLEDIC    (_U(0x1) << USBC_UESTA4CLR_STALLEDIC_Pos)
+#define USBC_UESTA4CLR_STALLEDIC    (_U_(0x1) << USBC_UESTA4CLR_STALLEDIC_Pos)
 #define USBC_UESTA4CLR_RAMACERIC_Pos 11           /**< \brief (USBC_UESTA4CLR) RAMACERI Clear */
-#define USBC_UESTA4CLR_RAMACERIC    (_U(0x1) << USBC_UESTA4CLR_RAMACERIC_Pos)
-#define USBC_UESTA4CLR_MASK         _U(0x0000085F) /**< \brief (USBC_UESTA4CLR) MASK Register */
+#define USBC_UESTA4CLR_RAMACERIC    (_U_(0x1) << USBC_UESTA4CLR_RAMACERIC_Pos)
+#define USBC_UESTA4CLR_MASK         _U_(0x0000085F) /**< \brief (USBC_UESTA4CLR) MASK Register */
 
 /* -------- USBC_UESTA5CLR : (USBC Offset: 0x174) ( /W 32) Endpoint Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1712,23 +1712,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UESTA5CLR_OFFSET       0x174        /**< \brief (USBC_UESTA5CLR offset) Endpoint Status Clear Register */
-#define USBC_UESTA5CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA5CLR reset_value) Endpoint Status Clear Register */
+#define USBC_UESTA5CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UESTA5CLR reset_value) Endpoint Status Clear Register */
 
 #define USBC_UESTA5CLR_TXINIC_Pos   0            /**< \brief (USBC_UESTA5CLR) TXINI Clear */
-#define USBC_UESTA5CLR_TXINIC       (_U(0x1) << USBC_UESTA5CLR_TXINIC_Pos)
+#define USBC_UESTA5CLR_TXINIC       (_U_(0x1) << USBC_UESTA5CLR_TXINIC_Pos)
 #define USBC_UESTA5CLR_RXOUTIC_Pos  1            /**< \brief (USBC_UESTA5CLR) RXOUTI Clear */
-#define USBC_UESTA5CLR_RXOUTIC      (_U(0x1) << USBC_UESTA5CLR_RXOUTIC_Pos)
+#define USBC_UESTA5CLR_RXOUTIC      (_U_(0x1) << USBC_UESTA5CLR_RXOUTIC_Pos)
 #define USBC_UESTA5CLR_RXSTPIC_Pos  2            /**< \brief (USBC_UESTA5CLR) RXSTPI Clear */
-#define USBC_UESTA5CLR_RXSTPIC      (_U(0x1) << USBC_UESTA5CLR_RXSTPIC_Pos)
+#define USBC_UESTA5CLR_RXSTPIC      (_U_(0x1) << USBC_UESTA5CLR_RXSTPIC_Pos)
 #define USBC_UESTA5CLR_NAKOUTIC_Pos 3            /**< \brief (USBC_UESTA5CLR) NAKOUTI Clear */
-#define USBC_UESTA5CLR_NAKOUTIC     (_U(0x1) << USBC_UESTA5CLR_NAKOUTIC_Pos)
+#define USBC_UESTA5CLR_NAKOUTIC     (_U_(0x1) << USBC_UESTA5CLR_NAKOUTIC_Pos)
 #define USBC_UESTA5CLR_NAKINIC_Pos  4            /**< \brief (USBC_UESTA5CLR) NAKINI Clear */
-#define USBC_UESTA5CLR_NAKINIC      (_U(0x1) << USBC_UESTA5CLR_NAKINIC_Pos)
+#define USBC_UESTA5CLR_NAKINIC      (_U_(0x1) << USBC_UESTA5CLR_NAKINIC_Pos)
 #define USBC_UESTA5CLR_STALLEDIC_Pos 6            /**< \brief (USBC_UESTA5CLR) STALLEDI Clear */
-#define USBC_UESTA5CLR_STALLEDIC    (_U(0x1) << USBC_UESTA5CLR_STALLEDIC_Pos)
+#define USBC_UESTA5CLR_STALLEDIC    (_U_(0x1) << USBC_UESTA5CLR_STALLEDIC_Pos)
 #define USBC_UESTA5CLR_RAMACERIC_Pos 11           /**< \brief (USBC_UESTA5CLR) RAMACERI Clear */
-#define USBC_UESTA5CLR_RAMACERIC    (_U(0x1) << USBC_UESTA5CLR_RAMACERIC_Pos)
-#define USBC_UESTA5CLR_MASK         _U(0x0000085F) /**< \brief (USBC_UESTA5CLR) MASK Register */
+#define USBC_UESTA5CLR_RAMACERIC    (_U_(0x1) << USBC_UESTA5CLR_RAMACERIC_Pos)
+#define USBC_UESTA5CLR_MASK         _U_(0x0000085F) /**< \brief (USBC_UESTA5CLR) MASK Register */
 
 /* -------- USBC_UESTA6CLR : (USBC Offset: 0x178) ( /W 32) Endpoint Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1750,23 +1750,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UESTA6CLR_OFFSET       0x178        /**< \brief (USBC_UESTA6CLR offset) Endpoint Status Clear Register */
-#define USBC_UESTA6CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA6CLR reset_value) Endpoint Status Clear Register */
+#define USBC_UESTA6CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UESTA6CLR reset_value) Endpoint Status Clear Register */
 
 #define USBC_UESTA6CLR_TXINIC_Pos   0            /**< \brief (USBC_UESTA6CLR) TXINI Clear */
-#define USBC_UESTA6CLR_TXINIC       (_U(0x1) << USBC_UESTA6CLR_TXINIC_Pos)
+#define USBC_UESTA6CLR_TXINIC       (_U_(0x1) << USBC_UESTA6CLR_TXINIC_Pos)
 #define USBC_UESTA6CLR_RXOUTIC_Pos  1            /**< \brief (USBC_UESTA6CLR) RXOUTI Clear */
-#define USBC_UESTA6CLR_RXOUTIC      (_U(0x1) << USBC_UESTA6CLR_RXOUTIC_Pos)
+#define USBC_UESTA6CLR_RXOUTIC      (_U_(0x1) << USBC_UESTA6CLR_RXOUTIC_Pos)
 #define USBC_UESTA6CLR_RXSTPIC_Pos  2            /**< \brief (USBC_UESTA6CLR) RXSTPI Clear */
-#define USBC_UESTA6CLR_RXSTPIC      (_U(0x1) << USBC_UESTA6CLR_RXSTPIC_Pos)
+#define USBC_UESTA6CLR_RXSTPIC      (_U_(0x1) << USBC_UESTA6CLR_RXSTPIC_Pos)
 #define USBC_UESTA6CLR_NAKOUTIC_Pos 3            /**< \brief (USBC_UESTA6CLR) NAKOUTI Clear */
-#define USBC_UESTA6CLR_NAKOUTIC     (_U(0x1) << USBC_UESTA6CLR_NAKOUTIC_Pos)
+#define USBC_UESTA6CLR_NAKOUTIC     (_U_(0x1) << USBC_UESTA6CLR_NAKOUTIC_Pos)
 #define USBC_UESTA6CLR_NAKINIC_Pos  4            /**< \brief (USBC_UESTA6CLR) NAKINI Clear */
-#define USBC_UESTA6CLR_NAKINIC      (_U(0x1) << USBC_UESTA6CLR_NAKINIC_Pos)
+#define USBC_UESTA6CLR_NAKINIC      (_U_(0x1) << USBC_UESTA6CLR_NAKINIC_Pos)
 #define USBC_UESTA6CLR_STALLEDIC_Pos 6            /**< \brief (USBC_UESTA6CLR) STALLEDI Clear */
-#define USBC_UESTA6CLR_STALLEDIC    (_U(0x1) << USBC_UESTA6CLR_STALLEDIC_Pos)
+#define USBC_UESTA6CLR_STALLEDIC    (_U_(0x1) << USBC_UESTA6CLR_STALLEDIC_Pos)
 #define USBC_UESTA6CLR_RAMACERIC_Pos 11           /**< \brief (USBC_UESTA6CLR) RAMACERI Clear */
-#define USBC_UESTA6CLR_RAMACERIC    (_U(0x1) << USBC_UESTA6CLR_RAMACERIC_Pos)
-#define USBC_UESTA6CLR_MASK         _U(0x0000085F) /**< \brief (USBC_UESTA6CLR) MASK Register */
+#define USBC_UESTA6CLR_RAMACERIC    (_U_(0x1) << USBC_UESTA6CLR_RAMACERIC_Pos)
+#define USBC_UESTA6CLR_MASK         _U_(0x0000085F) /**< \brief (USBC_UESTA6CLR) MASK Register */
 
 /* -------- USBC_UESTA7CLR : (USBC Offset: 0x17C) ( /W 32) Endpoint Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1788,23 +1788,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UESTA7CLR_OFFSET       0x17C        /**< \brief (USBC_UESTA7CLR offset) Endpoint Status Clear Register */
-#define USBC_UESTA7CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA7CLR reset_value) Endpoint Status Clear Register */
+#define USBC_UESTA7CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UESTA7CLR reset_value) Endpoint Status Clear Register */
 
 #define USBC_UESTA7CLR_TXINIC_Pos   0            /**< \brief (USBC_UESTA7CLR) TXINI Clear */
-#define USBC_UESTA7CLR_TXINIC       (_U(0x1) << USBC_UESTA7CLR_TXINIC_Pos)
+#define USBC_UESTA7CLR_TXINIC       (_U_(0x1) << USBC_UESTA7CLR_TXINIC_Pos)
 #define USBC_UESTA7CLR_RXOUTIC_Pos  1            /**< \brief (USBC_UESTA7CLR) RXOUTI Clear */
-#define USBC_UESTA7CLR_RXOUTIC      (_U(0x1) << USBC_UESTA7CLR_RXOUTIC_Pos)
+#define USBC_UESTA7CLR_RXOUTIC      (_U_(0x1) << USBC_UESTA7CLR_RXOUTIC_Pos)
 #define USBC_UESTA7CLR_RXSTPIC_Pos  2            /**< \brief (USBC_UESTA7CLR) RXSTPI Clear */
-#define USBC_UESTA7CLR_RXSTPIC      (_U(0x1) << USBC_UESTA7CLR_RXSTPIC_Pos)
+#define USBC_UESTA7CLR_RXSTPIC      (_U_(0x1) << USBC_UESTA7CLR_RXSTPIC_Pos)
 #define USBC_UESTA7CLR_NAKOUTIC_Pos 3            /**< \brief (USBC_UESTA7CLR) NAKOUTI Clear */
-#define USBC_UESTA7CLR_NAKOUTIC     (_U(0x1) << USBC_UESTA7CLR_NAKOUTIC_Pos)
+#define USBC_UESTA7CLR_NAKOUTIC     (_U_(0x1) << USBC_UESTA7CLR_NAKOUTIC_Pos)
 #define USBC_UESTA7CLR_NAKINIC_Pos  4            /**< \brief (USBC_UESTA7CLR) NAKINI Clear */
-#define USBC_UESTA7CLR_NAKINIC      (_U(0x1) << USBC_UESTA7CLR_NAKINIC_Pos)
+#define USBC_UESTA7CLR_NAKINIC      (_U_(0x1) << USBC_UESTA7CLR_NAKINIC_Pos)
 #define USBC_UESTA7CLR_STALLEDIC_Pos 6            /**< \brief (USBC_UESTA7CLR) STALLEDI Clear */
-#define USBC_UESTA7CLR_STALLEDIC    (_U(0x1) << USBC_UESTA7CLR_STALLEDIC_Pos)
+#define USBC_UESTA7CLR_STALLEDIC    (_U_(0x1) << USBC_UESTA7CLR_STALLEDIC_Pos)
 #define USBC_UESTA7CLR_RAMACERIC_Pos 11           /**< \brief (USBC_UESTA7CLR) RAMACERI Clear */
-#define USBC_UESTA7CLR_RAMACERIC    (_U(0x1) << USBC_UESTA7CLR_RAMACERIC_Pos)
-#define USBC_UESTA7CLR_MASK         _U(0x0000085F) /**< \brief (USBC_UESTA7CLR) MASK Register */
+#define USBC_UESTA7CLR_RAMACERIC    (_U_(0x1) << USBC_UESTA7CLR_RAMACERIC_Pos)
+#define USBC_UESTA7CLR_MASK         _U_(0x0000085F) /**< \brief (USBC_UESTA7CLR) MASK Register */
 
 /* -------- USBC_UESTA0SET : (USBC Offset: 0x190) ( /W 32) Endpoint Status Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1827,25 +1827,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UESTA0SET_OFFSET       0x190        /**< \brief (USBC_UESTA0SET offset) Endpoint Status Set Register */
-#define USBC_UESTA0SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA0SET reset_value) Endpoint Status Set Register */
+#define USBC_UESTA0SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UESTA0SET reset_value) Endpoint Status Set Register */
 
 #define USBC_UESTA0SET_TXINIS_Pos   0            /**< \brief (USBC_UESTA0SET) TXINI Set */
-#define USBC_UESTA0SET_TXINIS       (_U(0x1) << USBC_UESTA0SET_TXINIS_Pos)
+#define USBC_UESTA0SET_TXINIS       (_U_(0x1) << USBC_UESTA0SET_TXINIS_Pos)
 #define USBC_UESTA0SET_RXOUTIS_Pos  1            /**< \brief (USBC_UESTA0SET) RXOUTI Set */
-#define USBC_UESTA0SET_RXOUTIS      (_U(0x1) << USBC_UESTA0SET_RXOUTIS_Pos)
+#define USBC_UESTA0SET_RXOUTIS      (_U_(0x1) << USBC_UESTA0SET_RXOUTIS_Pos)
 #define USBC_UESTA0SET_RXSTPIS_Pos  2            /**< \brief (USBC_UESTA0SET) RXSTPI Set */
-#define USBC_UESTA0SET_RXSTPIS      (_U(0x1) << USBC_UESTA0SET_RXSTPIS_Pos)
+#define USBC_UESTA0SET_RXSTPIS      (_U_(0x1) << USBC_UESTA0SET_RXSTPIS_Pos)
 #define USBC_UESTA0SET_NAKOUTIS_Pos 3            /**< \brief (USBC_UESTA0SET) NAKOUTI Set */
-#define USBC_UESTA0SET_NAKOUTIS     (_U(0x1) << USBC_UESTA0SET_NAKOUTIS_Pos)
+#define USBC_UESTA0SET_NAKOUTIS     (_U_(0x1) << USBC_UESTA0SET_NAKOUTIS_Pos)
 #define USBC_UESTA0SET_NAKINIS_Pos  4            /**< \brief (USBC_UESTA0SET) NAKINI Set */
-#define USBC_UESTA0SET_NAKINIS      (_U(0x1) << USBC_UESTA0SET_NAKINIS_Pos)
+#define USBC_UESTA0SET_NAKINIS      (_U_(0x1) << USBC_UESTA0SET_NAKINIS_Pos)
 #define USBC_UESTA0SET_STALLEDIS_Pos 6            /**< \brief (USBC_UESTA0SET) STALLEDI Set */
-#define USBC_UESTA0SET_STALLEDIS    (_U(0x1) << USBC_UESTA0SET_STALLEDIS_Pos)
+#define USBC_UESTA0SET_STALLEDIS    (_U_(0x1) << USBC_UESTA0SET_STALLEDIS_Pos)
 #define USBC_UESTA0SET_RAMACERIS_Pos 11           /**< \brief (USBC_UESTA0SET) RAMACERI Set */
-#define USBC_UESTA0SET_RAMACERIS    (_U(0x1) << USBC_UESTA0SET_RAMACERIS_Pos)
+#define USBC_UESTA0SET_RAMACERIS    (_U_(0x1) << USBC_UESTA0SET_RAMACERIS_Pos)
 #define USBC_UESTA0SET_NBUSYBKS_Pos 12           /**< \brief (USBC_UESTA0SET) NBUSYBK Set */
-#define USBC_UESTA0SET_NBUSYBKS     (_U(0x1) << USBC_UESTA0SET_NBUSYBKS_Pos)
-#define USBC_UESTA0SET_MASK         _U(0x0000185F) /**< \brief (USBC_UESTA0SET) MASK Register */
+#define USBC_UESTA0SET_NBUSYBKS     (_U_(0x1) << USBC_UESTA0SET_NBUSYBKS_Pos)
+#define USBC_UESTA0SET_MASK         _U_(0x0000185F) /**< \brief (USBC_UESTA0SET) MASK Register */
 
 /* -------- USBC_UESTA1SET : (USBC Offset: 0x194) ( /W 32) Endpoint Status Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1868,25 +1868,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UESTA1SET_OFFSET       0x194        /**< \brief (USBC_UESTA1SET offset) Endpoint Status Set Register */
-#define USBC_UESTA1SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA1SET reset_value) Endpoint Status Set Register */
+#define USBC_UESTA1SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UESTA1SET reset_value) Endpoint Status Set Register */
 
 #define USBC_UESTA1SET_TXINIS_Pos   0            /**< \brief (USBC_UESTA1SET) TXINI Set */
-#define USBC_UESTA1SET_TXINIS       (_U(0x1) << USBC_UESTA1SET_TXINIS_Pos)
+#define USBC_UESTA1SET_TXINIS       (_U_(0x1) << USBC_UESTA1SET_TXINIS_Pos)
 #define USBC_UESTA1SET_RXOUTIS_Pos  1            /**< \brief (USBC_UESTA1SET) RXOUTI Set */
-#define USBC_UESTA1SET_RXOUTIS      (_U(0x1) << USBC_UESTA1SET_RXOUTIS_Pos)
+#define USBC_UESTA1SET_RXOUTIS      (_U_(0x1) << USBC_UESTA1SET_RXOUTIS_Pos)
 #define USBC_UESTA1SET_RXSTPIS_Pos  2            /**< \brief (USBC_UESTA1SET) RXSTPI Set */
-#define USBC_UESTA1SET_RXSTPIS      (_U(0x1) << USBC_UESTA1SET_RXSTPIS_Pos)
+#define USBC_UESTA1SET_RXSTPIS      (_U_(0x1) << USBC_UESTA1SET_RXSTPIS_Pos)
 #define USBC_UESTA1SET_NAKOUTIS_Pos 3            /**< \brief (USBC_UESTA1SET) NAKOUTI Set */
-#define USBC_UESTA1SET_NAKOUTIS     (_U(0x1) << USBC_UESTA1SET_NAKOUTIS_Pos)
+#define USBC_UESTA1SET_NAKOUTIS     (_U_(0x1) << USBC_UESTA1SET_NAKOUTIS_Pos)
 #define USBC_UESTA1SET_NAKINIS_Pos  4            /**< \brief (USBC_UESTA1SET) NAKINI Set */
-#define USBC_UESTA1SET_NAKINIS      (_U(0x1) << USBC_UESTA1SET_NAKINIS_Pos)
+#define USBC_UESTA1SET_NAKINIS      (_U_(0x1) << USBC_UESTA1SET_NAKINIS_Pos)
 #define USBC_UESTA1SET_STALLEDIS_Pos 6            /**< \brief (USBC_UESTA1SET) STALLEDI Set */
-#define USBC_UESTA1SET_STALLEDIS    (_U(0x1) << USBC_UESTA1SET_STALLEDIS_Pos)
+#define USBC_UESTA1SET_STALLEDIS    (_U_(0x1) << USBC_UESTA1SET_STALLEDIS_Pos)
 #define USBC_UESTA1SET_RAMACERIS_Pos 11           /**< \brief (USBC_UESTA1SET) RAMACERI Set */
-#define USBC_UESTA1SET_RAMACERIS    (_U(0x1) << USBC_UESTA1SET_RAMACERIS_Pos)
+#define USBC_UESTA1SET_RAMACERIS    (_U_(0x1) << USBC_UESTA1SET_RAMACERIS_Pos)
 #define USBC_UESTA1SET_NBUSYBKS_Pos 12           /**< \brief (USBC_UESTA1SET) NBUSYBK Set */
-#define USBC_UESTA1SET_NBUSYBKS     (_U(0x1) << USBC_UESTA1SET_NBUSYBKS_Pos)
-#define USBC_UESTA1SET_MASK         _U(0x0000185F) /**< \brief (USBC_UESTA1SET) MASK Register */
+#define USBC_UESTA1SET_NBUSYBKS     (_U_(0x1) << USBC_UESTA1SET_NBUSYBKS_Pos)
+#define USBC_UESTA1SET_MASK         _U_(0x0000185F) /**< \brief (USBC_UESTA1SET) MASK Register */
 
 /* -------- USBC_UESTA2SET : (USBC Offset: 0x198) ( /W 32) Endpoint Status Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1909,25 +1909,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UESTA2SET_OFFSET       0x198        /**< \brief (USBC_UESTA2SET offset) Endpoint Status Set Register */
-#define USBC_UESTA2SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA2SET reset_value) Endpoint Status Set Register */
+#define USBC_UESTA2SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UESTA2SET reset_value) Endpoint Status Set Register */
 
 #define USBC_UESTA2SET_TXINIS_Pos   0            /**< \brief (USBC_UESTA2SET) TXINI Set */
-#define USBC_UESTA2SET_TXINIS       (_U(0x1) << USBC_UESTA2SET_TXINIS_Pos)
+#define USBC_UESTA2SET_TXINIS       (_U_(0x1) << USBC_UESTA2SET_TXINIS_Pos)
 #define USBC_UESTA2SET_RXOUTIS_Pos  1            /**< \brief (USBC_UESTA2SET) RXOUTI Set */
-#define USBC_UESTA2SET_RXOUTIS      (_U(0x1) << USBC_UESTA2SET_RXOUTIS_Pos)
+#define USBC_UESTA2SET_RXOUTIS      (_U_(0x1) << USBC_UESTA2SET_RXOUTIS_Pos)
 #define USBC_UESTA2SET_RXSTPIS_Pos  2            /**< \brief (USBC_UESTA2SET) RXSTPI Set */
-#define USBC_UESTA2SET_RXSTPIS      (_U(0x1) << USBC_UESTA2SET_RXSTPIS_Pos)
+#define USBC_UESTA2SET_RXSTPIS      (_U_(0x1) << USBC_UESTA2SET_RXSTPIS_Pos)
 #define USBC_UESTA2SET_NAKOUTIS_Pos 3            /**< \brief (USBC_UESTA2SET) NAKOUTI Set */
-#define USBC_UESTA2SET_NAKOUTIS     (_U(0x1) << USBC_UESTA2SET_NAKOUTIS_Pos)
+#define USBC_UESTA2SET_NAKOUTIS     (_U_(0x1) << USBC_UESTA2SET_NAKOUTIS_Pos)
 #define USBC_UESTA2SET_NAKINIS_Pos  4            /**< \brief (USBC_UESTA2SET) NAKINI Set */
-#define USBC_UESTA2SET_NAKINIS      (_U(0x1) << USBC_UESTA2SET_NAKINIS_Pos)
+#define USBC_UESTA2SET_NAKINIS      (_U_(0x1) << USBC_UESTA2SET_NAKINIS_Pos)
 #define USBC_UESTA2SET_STALLEDIS_Pos 6            /**< \brief (USBC_UESTA2SET) STALLEDI Set */
-#define USBC_UESTA2SET_STALLEDIS    (_U(0x1) << USBC_UESTA2SET_STALLEDIS_Pos)
+#define USBC_UESTA2SET_STALLEDIS    (_U_(0x1) << USBC_UESTA2SET_STALLEDIS_Pos)
 #define USBC_UESTA2SET_RAMACERIS_Pos 11           /**< \brief (USBC_UESTA2SET) RAMACERI Set */
-#define USBC_UESTA2SET_RAMACERIS    (_U(0x1) << USBC_UESTA2SET_RAMACERIS_Pos)
+#define USBC_UESTA2SET_RAMACERIS    (_U_(0x1) << USBC_UESTA2SET_RAMACERIS_Pos)
 #define USBC_UESTA2SET_NBUSYBKS_Pos 12           /**< \brief (USBC_UESTA2SET) NBUSYBK Set */
-#define USBC_UESTA2SET_NBUSYBKS     (_U(0x1) << USBC_UESTA2SET_NBUSYBKS_Pos)
-#define USBC_UESTA2SET_MASK         _U(0x0000185F) /**< \brief (USBC_UESTA2SET) MASK Register */
+#define USBC_UESTA2SET_NBUSYBKS     (_U_(0x1) << USBC_UESTA2SET_NBUSYBKS_Pos)
+#define USBC_UESTA2SET_MASK         _U_(0x0000185F) /**< \brief (USBC_UESTA2SET) MASK Register */
 
 /* -------- USBC_UESTA3SET : (USBC Offset: 0x19C) ( /W 32) Endpoint Status Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1950,25 +1950,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UESTA3SET_OFFSET       0x19C        /**< \brief (USBC_UESTA3SET offset) Endpoint Status Set Register */
-#define USBC_UESTA3SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA3SET reset_value) Endpoint Status Set Register */
+#define USBC_UESTA3SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UESTA3SET reset_value) Endpoint Status Set Register */
 
 #define USBC_UESTA3SET_TXINIS_Pos   0            /**< \brief (USBC_UESTA3SET) TXINI Set */
-#define USBC_UESTA3SET_TXINIS       (_U(0x1) << USBC_UESTA3SET_TXINIS_Pos)
+#define USBC_UESTA3SET_TXINIS       (_U_(0x1) << USBC_UESTA3SET_TXINIS_Pos)
 #define USBC_UESTA3SET_RXOUTIS_Pos  1            /**< \brief (USBC_UESTA3SET) RXOUTI Set */
-#define USBC_UESTA3SET_RXOUTIS      (_U(0x1) << USBC_UESTA3SET_RXOUTIS_Pos)
+#define USBC_UESTA3SET_RXOUTIS      (_U_(0x1) << USBC_UESTA3SET_RXOUTIS_Pos)
 #define USBC_UESTA3SET_RXSTPIS_Pos  2            /**< \brief (USBC_UESTA3SET) RXSTPI Set */
-#define USBC_UESTA3SET_RXSTPIS      (_U(0x1) << USBC_UESTA3SET_RXSTPIS_Pos)
+#define USBC_UESTA3SET_RXSTPIS      (_U_(0x1) << USBC_UESTA3SET_RXSTPIS_Pos)
 #define USBC_UESTA3SET_NAKOUTIS_Pos 3            /**< \brief (USBC_UESTA3SET) NAKOUTI Set */
-#define USBC_UESTA3SET_NAKOUTIS     (_U(0x1) << USBC_UESTA3SET_NAKOUTIS_Pos)
+#define USBC_UESTA3SET_NAKOUTIS     (_U_(0x1) << USBC_UESTA3SET_NAKOUTIS_Pos)
 #define USBC_UESTA3SET_NAKINIS_Pos  4            /**< \brief (USBC_UESTA3SET) NAKINI Set */
-#define USBC_UESTA3SET_NAKINIS      (_U(0x1) << USBC_UESTA3SET_NAKINIS_Pos)
+#define USBC_UESTA3SET_NAKINIS      (_U_(0x1) << USBC_UESTA3SET_NAKINIS_Pos)
 #define USBC_UESTA3SET_STALLEDIS_Pos 6            /**< \brief (USBC_UESTA3SET) STALLEDI Set */
-#define USBC_UESTA3SET_STALLEDIS    (_U(0x1) << USBC_UESTA3SET_STALLEDIS_Pos)
+#define USBC_UESTA3SET_STALLEDIS    (_U_(0x1) << USBC_UESTA3SET_STALLEDIS_Pos)
 #define USBC_UESTA3SET_RAMACERIS_Pos 11           /**< \brief (USBC_UESTA3SET) RAMACERI Set */
-#define USBC_UESTA3SET_RAMACERIS    (_U(0x1) << USBC_UESTA3SET_RAMACERIS_Pos)
+#define USBC_UESTA3SET_RAMACERIS    (_U_(0x1) << USBC_UESTA3SET_RAMACERIS_Pos)
 #define USBC_UESTA3SET_NBUSYBKS_Pos 12           /**< \brief (USBC_UESTA3SET) NBUSYBK Set */
-#define USBC_UESTA3SET_NBUSYBKS     (_U(0x1) << USBC_UESTA3SET_NBUSYBKS_Pos)
-#define USBC_UESTA3SET_MASK         _U(0x0000185F) /**< \brief (USBC_UESTA3SET) MASK Register */
+#define USBC_UESTA3SET_NBUSYBKS     (_U_(0x1) << USBC_UESTA3SET_NBUSYBKS_Pos)
+#define USBC_UESTA3SET_MASK         _U_(0x0000185F) /**< \brief (USBC_UESTA3SET) MASK Register */
 
 /* -------- USBC_UESTA4SET : (USBC Offset: 0x1A0) ( /W 32) Endpoint Status Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -1991,25 +1991,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UESTA4SET_OFFSET       0x1A0        /**< \brief (USBC_UESTA4SET offset) Endpoint Status Set Register */
-#define USBC_UESTA4SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA4SET reset_value) Endpoint Status Set Register */
+#define USBC_UESTA4SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UESTA4SET reset_value) Endpoint Status Set Register */
 
 #define USBC_UESTA4SET_TXINIS_Pos   0            /**< \brief (USBC_UESTA4SET) TXINI Set */
-#define USBC_UESTA4SET_TXINIS       (_U(0x1) << USBC_UESTA4SET_TXINIS_Pos)
+#define USBC_UESTA4SET_TXINIS       (_U_(0x1) << USBC_UESTA4SET_TXINIS_Pos)
 #define USBC_UESTA4SET_RXOUTIS_Pos  1            /**< \brief (USBC_UESTA4SET) RXOUTI Set */
-#define USBC_UESTA4SET_RXOUTIS      (_U(0x1) << USBC_UESTA4SET_RXOUTIS_Pos)
+#define USBC_UESTA4SET_RXOUTIS      (_U_(0x1) << USBC_UESTA4SET_RXOUTIS_Pos)
 #define USBC_UESTA4SET_RXSTPIS_Pos  2            /**< \brief (USBC_UESTA4SET) RXSTPI Set */
-#define USBC_UESTA4SET_RXSTPIS      (_U(0x1) << USBC_UESTA4SET_RXSTPIS_Pos)
+#define USBC_UESTA4SET_RXSTPIS      (_U_(0x1) << USBC_UESTA4SET_RXSTPIS_Pos)
 #define USBC_UESTA4SET_NAKOUTIS_Pos 3            /**< \brief (USBC_UESTA4SET) NAKOUTI Set */
-#define USBC_UESTA4SET_NAKOUTIS     (_U(0x1) << USBC_UESTA4SET_NAKOUTIS_Pos)
+#define USBC_UESTA4SET_NAKOUTIS     (_U_(0x1) << USBC_UESTA4SET_NAKOUTIS_Pos)
 #define USBC_UESTA4SET_NAKINIS_Pos  4            /**< \brief (USBC_UESTA4SET) NAKINI Set */
-#define USBC_UESTA4SET_NAKINIS      (_U(0x1) << USBC_UESTA4SET_NAKINIS_Pos)
+#define USBC_UESTA4SET_NAKINIS      (_U_(0x1) << USBC_UESTA4SET_NAKINIS_Pos)
 #define USBC_UESTA4SET_STALLEDIS_Pos 6            /**< \brief (USBC_UESTA4SET) STALLEDI Set */
-#define USBC_UESTA4SET_STALLEDIS    (_U(0x1) << USBC_UESTA4SET_STALLEDIS_Pos)
+#define USBC_UESTA4SET_STALLEDIS    (_U_(0x1) << USBC_UESTA4SET_STALLEDIS_Pos)
 #define USBC_UESTA4SET_RAMACERIS_Pos 11           /**< \brief (USBC_UESTA4SET) RAMACERI Set */
-#define USBC_UESTA4SET_RAMACERIS    (_U(0x1) << USBC_UESTA4SET_RAMACERIS_Pos)
+#define USBC_UESTA4SET_RAMACERIS    (_U_(0x1) << USBC_UESTA4SET_RAMACERIS_Pos)
 #define USBC_UESTA4SET_NBUSYBKS_Pos 12           /**< \brief (USBC_UESTA4SET) NBUSYBK Set */
-#define USBC_UESTA4SET_NBUSYBKS     (_U(0x1) << USBC_UESTA4SET_NBUSYBKS_Pos)
-#define USBC_UESTA4SET_MASK         _U(0x0000185F) /**< \brief (USBC_UESTA4SET) MASK Register */
+#define USBC_UESTA4SET_NBUSYBKS     (_U_(0x1) << USBC_UESTA4SET_NBUSYBKS_Pos)
+#define USBC_UESTA4SET_MASK         _U_(0x0000185F) /**< \brief (USBC_UESTA4SET) MASK Register */
 
 /* -------- USBC_UESTA5SET : (USBC Offset: 0x1A4) ( /W 32) Endpoint Status Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -2032,25 +2032,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UESTA5SET_OFFSET       0x1A4        /**< \brief (USBC_UESTA5SET offset) Endpoint Status Set Register */
-#define USBC_UESTA5SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA5SET reset_value) Endpoint Status Set Register */
+#define USBC_UESTA5SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UESTA5SET reset_value) Endpoint Status Set Register */
 
 #define USBC_UESTA5SET_TXINIS_Pos   0            /**< \brief (USBC_UESTA5SET) TXINI Set */
-#define USBC_UESTA5SET_TXINIS       (_U(0x1) << USBC_UESTA5SET_TXINIS_Pos)
+#define USBC_UESTA5SET_TXINIS       (_U_(0x1) << USBC_UESTA5SET_TXINIS_Pos)
 #define USBC_UESTA5SET_RXOUTIS_Pos  1            /**< \brief (USBC_UESTA5SET) RXOUTI Set */
-#define USBC_UESTA5SET_RXOUTIS      (_U(0x1) << USBC_UESTA5SET_RXOUTIS_Pos)
+#define USBC_UESTA5SET_RXOUTIS      (_U_(0x1) << USBC_UESTA5SET_RXOUTIS_Pos)
 #define USBC_UESTA5SET_RXSTPIS_Pos  2            /**< \brief (USBC_UESTA5SET) RXSTPI Set */
-#define USBC_UESTA5SET_RXSTPIS      (_U(0x1) << USBC_UESTA5SET_RXSTPIS_Pos)
+#define USBC_UESTA5SET_RXSTPIS      (_U_(0x1) << USBC_UESTA5SET_RXSTPIS_Pos)
 #define USBC_UESTA5SET_NAKOUTIS_Pos 3            /**< \brief (USBC_UESTA5SET) NAKOUTI Set */
-#define USBC_UESTA5SET_NAKOUTIS     (_U(0x1) << USBC_UESTA5SET_NAKOUTIS_Pos)
+#define USBC_UESTA5SET_NAKOUTIS     (_U_(0x1) << USBC_UESTA5SET_NAKOUTIS_Pos)
 #define USBC_UESTA5SET_NAKINIS_Pos  4            /**< \brief (USBC_UESTA5SET) NAKINI Set */
-#define USBC_UESTA5SET_NAKINIS      (_U(0x1) << USBC_UESTA5SET_NAKINIS_Pos)
+#define USBC_UESTA5SET_NAKINIS      (_U_(0x1) << USBC_UESTA5SET_NAKINIS_Pos)
 #define USBC_UESTA5SET_STALLEDIS_Pos 6            /**< \brief (USBC_UESTA5SET) STALLEDI Set */
-#define USBC_UESTA5SET_STALLEDIS    (_U(0x1) << USBC_UESTA5SET_STALLEDIS_Pos)
+#define USBC_UESTA5SET_STALLEDIS    (_U_(0x1) << USBC_UESTA5SET_STALLEDIS_Pos)
 #define USBC_UESTA5SET_RAMACERIS_Pos 11           /**< \brief (USBC_UESTA5SET) RAMACERI Set */
-#define USBC_UESTA5SET_RAMACERIS    (_U(0x1) << USBC_UESTA5SET_RAMACERIS_Pos)
+#define USBC_UESTA5SET_RAMACERIS    (_U_(0x1) << USBC_UESTA5SET_RAMACERIS_Pos)
 #define USBC_UESTA5SET_NBUSYBKS_Pos 12           /**< \brief (USBC_UESTA5SET) NBUSYBK Set */
-#define USBC_UESTA5SET_NBUSYBKS     (_U(0x1) << USBC_UESTA5SET_NBUSYBKS_Pos)
-#define USBC_UESTA5SET_MASK         _U(0x0000185F) /**< \brief (USBC_UESTA5SET) MASK Register */
+#define USBC_UESTA5SET_NBUSYBKS     (_U_(0x1) << USBC_UESTA5SET_NBUSYBKS_Pos)
+#define USBC_UESTA5SET_MASK         _U_(0x0000185F) /**< \brief (USBC_UESTA5SET) MASK Register */
 
 /* -------- USBC_UESTA6SET : (USBC Offset: 0x1A8) ( /W 32) Endpoint Status Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -2073,25 +2073,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UESTA6SET_OFFSET       0x1A8        /**< \brief (USBC_UESTA6SET offset) Endpoint Status Set Register */
-#define USBC_UESTA6SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA6SET reset_value) Endpoint Status Set Register */
+#define USBC_UESTA6SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UESTA6SET reset_value) Endpoint Status Set Register */
 
 #define USBC_UESTA6SET_TXINIS_Pos   0            /**< \brief (USBC_UESTA6SET) TXINI Set */
-#define USBC_UESTA6SET_TXINIS       (_U(0x1) << USBC_UESTA6SET_TXINIS_Pos)
+#define USBC_UESTA6SET_TXINIS       (_U_(0x1) << USBC_UESTA6SET_TXINIS_Pos)
 #define USBC_UESTA6SET_RXOUTIS_Pos  1            /**< \brief (USBC_UESTA6SET) RXOUTI Set */
-#define USBC_UESTA6SET_RXOUTIS      (_U(0x1) << USBC_UESTA6SET_RXOUTIS_Pos)
+#define USBC_UESTA6SET_RXOUTIS      (_U_(0x1) << USBC_UESTA6SET_RXOUTIS_Pos)
 #define USBC_UESTA6SET_RXSTPIS_Pos  2            /**< \brief (USBC_UESTA6SET) RXSTPI Set */
-#define USBC_UESTA6SET_RXSTPIS      (_U(0x1) << USBC_UESTA6SET_RXSTPIS_Pos)
+#define USBC_UESTA6SET_RXSTPIS      (_U_(0x1) << USBC_UESTA6SET_RXSTPIS_Pos)
 #define USBC_UESTA6SET_NAKOUTIS_Pos 3            /**< \brief (USBC_UESTA6SET) NAKOUTI Set */
-#define USBC_UESTA6SET_NAKOUTIS     (_U(0x1) << USBC_UESTA6SET_NAKOUTIS_Pos)
+#define USBC_UESTA6SET_NAKOUTIS     (_U_(0x1) << USBC_UESTA6SET_NAKOUTIS_Pos)
 #define USBC_UESTA6SET_NAKINIS_Pos  4            /**< \brief (USBC_UESTA6SET) NAKINI Set */
-#define USBC_UESTA6SET_NAKINIS      (_U(0x1) << USBC_UESTA6SET_NAKINIS_Pos)
+#define USBC_UESTA6SET_NAKINIS      (_U_(0x1) << USBC_UESTA6SET_NAKINIS_Pos)
 #define USBC_UESTA6SET_STALLEDIS_Pos 6            /**< \brief (USBC_UESTA6SET) STALLEDI Set */
-#define USBC_UESTA6SET_STALLEDIS    (_U(0x1) << USBC_UESTA6SET_STALLEDIS_Pos)
+#define USBC_UESTA6SET_STALLEDIS    (_U_(0x1) << USBC_UESTA6SET_STALLEDIS_Pos)
 #define USBC_UESTA6SET_RAMACERIS_Pos 11           /**< \brief (USBC_UESTA6SET) RAMACERI Set */
-#define USBC_UESTA6SET_RAMACERIS    (_U(0x1) << USBC_UESTA6SET_RAMACERIS_Pos)
+#define USBC_UESTA6SET_RAMACERIS    (_U_(0x1) << USBC_UESTA6SET_RAMACERIS_Pos)
 #define USBC_UESTA6SET_NBUSYBKS_Pos 12           /**< \brief (USBC_UESTA6SET) NBUSYBK Set */
-#define USBC_UESTA6SET_NBUSYBKS     (_U(0x1) << USBC_UESTA6SET_NBUSYBKS_Pos)
-#define USBC_UESTA6SET_MASK         _U(0x0000185F) /**< \brief (USBC_UESTA6SET) MASK Register */
+#define USBC_UESTA6SET_NBUSYBKS     (_U_(0x1) << USBC_UESTA6SET_NBUSYBKS_Pos)
+#define USBC_UESTA6SET_MASK         _U_(0x0000185F) /**< \brief (USBC_UESTA6SET) MASK Register */
 
 /* -------- USBC_UESTA7SET : (USBC Offset: 0x1AC) ( /W 32) Endpoint Status Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -2114,25 +2114,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UESTA7SET_OFFSET       0x1AC        /**< \brief (USBC_UESTA7SET offset) Endpoint Status Set Register */
-#define USBC_UESTA7SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA7SET reset_value) Endpoint Status Set Register */
+#define USBC_UESTA7SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UESTA7SET reset_value) Endpoint Status Set Register */
 
 #define USBC_UESTA7SET_TXINIS_Pos   0            /**< \brief (USBC_UESTA7SET) TXINI Set */
-#define USBC_UESTA7SET_TXINIS       (_U(0x1) << USBC_UESTA7SET_TXINIS_Pos)
+#define USBC_UESTA7SET_TXINIS       (_U_(0x1) << USBC_UESTA7SET_TXINIS_Pos)
 #define USBC_UESTA7SET_RXOUTIS_Pos  1            /**< \brief (USBC_UESTA7SET) RXOUTI Set */
-#define USBC_UESTA7SET_RXOUTIS      (_U(0x1) << USBC_UESTA7SET_RXOUTIS_Pos)
+#define USBC_UESTA7SET_RXOUTIS      (_U_(0x1) << USBC_UESTA7SET_RXOUTIS_Pos)
 #define USBC_UESTA7SET_RXSTPIS_Pos  2            /**< \brief (USBC_UESTA7SET) RXSTPI Set */
-#define USBC_UESTA7SET_RXSTPIS      (_U(0x1) << USBC_UESTA7SET_RXSTPIS_Pos)
+#define USBC_UESTA7SET_RXSTPIS      (_U_(0x1) << USBC_UESTA7SET_RXSTPIS_Pos)
 #define USBC_UESTA7SET_NAKOUTIS_Pos 3            /**< \brief (USBC_UESTA7SET) NAKOUTI Set */
-#define USBC_UESTA7SET_NAKOUTIS     (_U(0x1) << USBC_UESTA7SET_NAKOUTIS_Pos)
+#define USBC_UESTA7SET_NAKOUTIS     (_U_(0x1) << USBC_UESTA7SET_NAKOUTIS_Pos)
 #define USBC_UESTA7SET_NAKINIS_Pos  4            /**< \brief (USBC_UESTA7SET) NAKINI Set */
-#define USBC_UESTA7SET_NAKINIS      (_U(0x1) << USBC_UESTA7SET_NAKINIS_Pos)
+#define USBC_UESTA7SET_NAKINIS      (_U_(0x1) << USBC_UESTA7SET_NAKINIS_Pos)
 #define USBC_UESTA7SET_STALLEDIS_Pos 6            /**< \brief (USBC_UESTA7SET) STALLEDI Set */
-#define USBC_UESTA7SET_STALLEDIS    (_U(0x1) << USBC_UESTA7SET_STALLEDIS_Pos)
+#define USBC_UESTA7SET_STALLEDIS    (_U_(0x1) << USBC_UESTA7SET_STALLEDIS_Pos)
 #define USBC_UESTA7SET_RAMACERIS_Pos 11           /**< \brief (USBC_UESTA7SET) RAMACERI Set */
-#define USBC_UESTA7SET_RAMACERIS    (_U(0x1) << USBC_UESTA7SET_RAMACERIS_Pos)
+#define USBC_UESTA7SET_RAMACERIS    (_U_(0x1) << USBC_UESTA7SET_RAMACERIS_Pos)
 #define USBC_UESTA7SET_NBUSYBKS_Pos 12           /**< \brief (USBC_UESTA7SET) NBUSYBK Set */
-#define USBC_UESTA7SET_NBUSYBKS     (_U(0x1) << USBC_UESTA7SET_NBUSYBKS_Pos)
-#define USBC_UESTA7SET_MASK         _U(0x0000185F) /**< \brief (USBC_UESTA7SET) MASK Register */
+#define USBC_UESTA7SET_NBUSYBKS     (_U_(0x1) << USBC_UESTA7SET_NBUSYBKS_Pos)
+#define USBC_UESTA7SET_MASK         _U_(0x0000185F) /**< \brief (USBC_UESTA7SET) MASK Register */
 
 /* -------- USBC_UECON0 : (USBC Offset: 0x1C0) (R/  32) Endpoint Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -2166,41 +2166,41 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECON0_OFFSET          0x1C0        /**< \brief (USBC_UECON0 offset) Endpoint Control Register */
-#define USBC_UECON0_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECON0 reset_value) Endpoint Control Register */
+#define USBC_UECON0_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UECON0 reset_value) Endpoint Control Register */
 
 #define USBC_UECON0_TXINE_Pos       0            /**< \brief (USBC_UECON0) TXIN Interrupt Enable */
-#define USBC_UECON0_TXINE           (_U(0x1) << USBC_UECON0_TXINE_Pos)
+#define USBC_UECON0_TXINE           (_U_(0x1) << USBC_UECON0_TXINE_Pos)
 #define USBC_UECON0_RXOUTE_Pos      1            /**< \brief (USBC_UECON0) RXOUT Interrupt Enable */
-#define USBC_UECON0_RXOUTE          (_U(0x1) << USBC_UECON0_RXOUTE_Pos)
+#define USBC_UECON0_RXOUTE          (_U_(0x1) << USBC_UECON0_RXOUTE_Pos)
 #define USBC_UECON0_RXSTPE_Pos      2            /**< \brief (USBC_UECON0) RXSTP Interrupt Enable */
-#define USBC_UECON0_RXSTPE          (_U(0x1) << USBC_UECON0_RXSTPE_Pos)
+#define USBC_UECON0_RXSTPE          (_U_(0x1) << USBC_UECON0_RXSTPE_Pos)
 #define USBC_UECON0_NAKOUTE_Pos     3            /**< \brief (USBC_UECON0) NAKOUT Interrupt Enable */
-#define USBC_UECON0_NAKOUTE         (_U(0x1) << USBC_UECON0_NAKOUTE_Pos)
+#define USBC_UECON0_NAKOUTE         (_U_(0x1) << USBC_UECON0_NAKOUTE_Pos)
 #define USBC_UECON0_NAKINE_Pos      4            /**< \brief (USBC_UECON0) NAKIN Interrupt Enable */
-#define USBC_UECON0_NAKINE          (_U(0x1) << USBC_UECON0_NAKINE_Pos)
+#define USBC_UECON0_NAKINE          (_U_(0x1) << USBC_UECON0_NAKINE_Pos)
 #define USBC_UECON0_STALLEDE_Pos    6            /**< \brief (USBC_UECON0) STALLED Interrupt Enable */
-#define USBC_UECON0_STALLEDE        (_U(0x1) << USBC_UECON0_STALLEDE_Pos)
+#define USBC_UECON0_STALLEDE        (_U_(0x1) << USBC_UECON0_STALLEDE_Pos)
 #define USBC_UECON0_NREPLY_Pos      8            /**< \brief (USBC_UECON0) No Reply */
-#define USBC_UECON0_NREPLY          (_U(0x1) << USBC_UECON0_NREPLY_Pos)
+#define USBC_UECON0_NREPLY          (_U_(0x1) << USBC_UECON0_NREPLY_Pos)
 #define USBC_UECON0_RAMACERE_Pos    11           /**< \brief (USBC_UECON0) RAMACER Interrupt Enable */
-#define USBC_UECON0_RAMACERE        (_U(0x1) << USBC_UECON0_RAMACERE_Pos)
+#define USBC_UECON0_RAMACERE        (_U_(0x1) << USBC_UECON0_RAMACERE_Pos)
 #define USBC_UECON0_NBUSYBKE_Pos    12           /**< \brief (USBC_UECON0) Number of Busy Banks Interrupt Enable */
-#define USBC_UECON0_NBUSYBKE        (_U(0x1) << USBC_UECON0_NBUSYBKE_Pos)
+#define USBC_UECON0_NBUSYBKE        (_U_(0x1) << USBC_UECON0_NBUSYBKE_Pos)
 #define USBC_UECON0_KILLBK_Pos      13           /**< \brief (USBC_UECON0) Kill IN Bank */
-#define USBC_UECON0_KILLBK          (_U(0x1) << USBC_UECON0_KILLBK_Pos)
+#define USBC_UECON0_KILLBK          (_U_(0x1) << USBC_UECON0_KILLBK_Pos)
 #define USBC_UECON0_FIFOCON_Pos     14           /**< \brief (USBC_UECON0) FIFO Control */
-#define USBC_UECON0_FIFOCON         (_U(0x1) << USBC_UECON0_FIFOCON_Pos)
+#define USBC_UECON0_FIFOCON         (_U_(0x1) << USBC_UECON0_FIFOCON_Pos)
 #define USBC_UECON0_NYETDIS_Pos     17           /**< \brief (USBC_UECON0) NYET token disable */
-#define USBC_UECON0_NYETDIS         (_U(0x1) << USBC_UECON0_NYETDIS_Pos)
+#define USBC_UECON0_NYETDIS         (_U_(0x1) << USBC_UECON0_NYETDIS_Pos)
 #define USBC_UECON0_RSTDT_Pos       18           /**< \brief (USBC_UECON0) Reset Data Toggle */
-#define USBC_UECON0_RSTDT           (_U(0x1) << USBC_UECON0_RSTDT_Pos)
+#define USBC_UECON0_RSTDT           (_U_(0x1) << USBC_UECON0_RSTDT_Pos)
 #define USBC_UECON0_STALLRQ_Pos     19           /**< \brief (USBC_UECON0) STALL Request */
-#define USBC_UECON0_STALLRQ         (_U(0x1) << USBC_UECON0_STALLRQ_Pos)
+#define USBC_UECON0_STALLRQ         (_U_(0x1) << USBC_UECON0_STALLRQ_Pos)
 #define USBC_UECON0_BUSY0_Pos       24           /**< \brief (USBC_UECON0) Busy Bank1 Enable */
-#define USBC_UECON0_BUSY0           (_U(0x1) << USBC_UECON0_BUSY0_Pos)
+#define USBC_UECON0_BUSY0           (_U_(0x1) << USBC_UECON0_BUSY0_Pos)
 #define USBC_UECON0_BUSY1_Pos       25           /**< \brief (USBC_UECON0) Busy Bank0 Enable */
-#define USBC_UECON0_BUSY1           (_U(0x1) << USBC_UECON0_BUSY1_Pos)
-#define USBC_UECON0_MASK            _U(0x030E795F) /**< \brief (USBC_UECON0) MASK Register */
+#define USBC_UECON0_BUSY1           (_U_(0x1) << USBC_UECON0_BUSY1_Pos)
+#define USBC_UECON0_MASK            _U_(0x030E795F) /**< \brief (USBC_UECON0) MASK Register */
 
 /* -------- USBC_UECON1 : (USBC Offset: 0x1C4) (R/  32) Endpoint Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -2234,41 +2234,41 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECON1_OFFSET          0x1C4        /**< \brief (USBC_UECON1 offset) Endpoint Control Register */
-#define USBC_UECON1_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECON1 reset_value) Endpoint Control Register */
+#define USBC_UECON1_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UECON1 reset_value) Endpoint Control Register */
 
 #define USBC_UECON1_TXINE_Pos       0            /**< \brief (USBC_UECON1) TXIN Interrupt Enable */
-#define USBC_UECON1_TXINE           (_U(0x1) << USBC_UECON1_TXINE_Pos)
+#define USBC_UECON1_TXINE           (_U_(0x1) << USBC_UECON1_TXINE_Pos)
 #define USBC_UECON1_RXOUTE_Pos      1            /**< \brief (USBC_UECON1) RXOUT Interrupt Enable */
-#define USBC_UECON1_RXOUTE          (_U(0x1) << USBC_UECON1_RXOUTE_Pos)
+#define USBC_UECON1_RXOUTE          (_U_(0x1) << USBC_UECON1_RXOUTE_Pos)
 #define USBC_UECON1_RXSTPE_Pos      2            /**< \brief (USBC_UECON1) RXSTP Interrupt Enable */
-#define USBC_UECON1_RXSTPE          (_U(0x1) << USBC_UECON1_RXSTPE_Pos)
+#define USBC_UECON1_RXSTPE          (_U_(0x1) << USBC_UECON1_RXSTPE_Pos)
 #define USBC_UECON1_NAKOUTE_Pos     3            /**< \brief (USBC_UECON1) NAKOUT Interrupt Enable */
-#define USBC_UECON1_NAKOUTE         (_U(0x1) << USBC_UECON1_NAKOUTE_Pos)
+#define USBC_UECON1_NAKOUTE         (_U_(0x1) << USBC_UECON1_NAKOUTE_Pos)
 #define USBC_UECON1_NAKINE_Pos      4            /**< \brief (USBC_UECON1) NAKIN Interrupt Enable */
-#define USBC_UECON1_NAKINE          (_U(0x1) << USBC_UECON1_NAKINE_Pos)
+#define USBC_UECON1_NAKINE          (_U_(0x1) << USBC_UECON1_NAKINE_Pos)
 #define USBC_UECON1_STALLEDE_Pos    6            /**< \brief (USBC_UECON1) STALLED Interrupt Enable */
-#define USBC_UECON1_STALLEDE        (_U(0x1) << USBC_UECON1_STALLEDE_Pos)
+#define USBC_UECON1_STALLEDE        (_U_(0x1) << USBC_UECON1_STALLEDE_Pos)
 #define USBC_UECON1_NREPLY_Pos      8            /**< \brief (USBC_UECON1) No Reply */
-#define USBC_UECON1_NREPLY          (_U(0x1) << USBC_UECON1_NREPLY_Pos)
+#define USBC_UECON1_NREPLY          (_U_(0x1) << USBC_UECON1_NREPLY_Pos)
 #define USBC_UECON1_RAMACERE_Pos    11           /**< \brief (USBC_UECON1) RAMACER Interrupt Enable */
-#define USBC_UECON1_RAMACERE        (_U(0x1) << USBC_UECON1_RAMACERE_Pos)
+#define USBC_UECON1_RAMACERE        (_U_(0x1) << USBC_UECON1_RAMACERE_Pos)
 #define USBC_UECON1_NBUSYBKE_Pos    12           /**< \brief (USBC_UECON1) Number of Busy Banks Interrupt Enable */
-#define USBC_UECON1_NBUSYBKE        (_U(0x1) << USBC_UECON1_NBUSYBKE_Pos)
+#define USBC_UECON1_NBUSYBKE        (_U_(0x1) << USBC_UECON1_NBUSYBKE_Pos)
 #define USBC_UECON1_KILLBK_Pos      13           /**< \brief (USBC_UECON1) Kill IN Bank */
-#define USBC_UECON1_KILLBK          (_U(0x1) << USBC_UECON1_KILLBK_Pos)
+#define USBC_UECON1_KILLBK          (_U_(0x1) << USBC_UECON1_KILLBK_Pos)
 #define USBC_UECON1_FIFOCON_Pos     14           /**< \brief (USBC_UECON1) FIFO Control */
-#define USBC_UECON1_FIFOCON         (_U(0x1) << USBC_UECON1_FIFOCON_Pos)
+#define USBC_UECON1_FIFOCON         (_U_(0x1) << USBC_UECON1_FIFOCON_Pos)
 #define USBC_UECON1_NYETDIS_Pos     17           /**< \brief (USBC_UECON1) NYET Token Enable */
-#define USBC_UECON1_NYETDIS         (_U(0x1) << USBC_UECON1_NYETDIS_Pos)
+#define USBC_UECON1_NYETDIS         (_U_(0x1) << USBC_UECON1_NYETDIS_Pos)
 #define USBC_UECON1_RSTDT_Pos       18           /**< \brief (USBC_UECON1) Reset Data Toggle */
-#define USBC_UECON1_RSTDT           (_U(0x1) << USBC_UECON1_RSTDT_Pos)
+#define USBC_UECON1_RSTDT           (_U_(0x1) << USBC_UECON1_RSTDT_Pos)
 #define USBC_UECON1_STALLRQ_Pos     19           /**< \brief (USBC_UECON1) STALL Request */
-#define USBC_UECON1_STALLRQ         (_U(0x1) << USBC_UECON1_STALLRQ_Pos)
+#define USBC_UECON1_STALLRQ         (_U_(0x1) << USBC_UECON1_STALLRQ_Pos)
 #define USBC_UECON1_BUSY0_Pos       24           /**< \brief (USBC_UECON1) Busy Bank1 Enable */
-#define USBC_UECON1_BUSY0           (_U(0x1) << USBC_UECON1_BUSY0_Pos)
+#define USBC_UECON1_BUSY0           (_U_(0x1) << USBC_UECON1_BUSY0_Pos)
 #define USBC_UECON1_BUSY1_Pos       25           /**< \brief (USBC_UECON1) Busy Bank0 Enable */
-#define USBC_UECON1_BUSY1           (_U(0x1) << USBC_UECON1_BUSY1_Pos)
-#define USBC_UECON1_MASK            _U(0x030E795F) /**< \brief (USBC_UECON1) MASK Register */
+#define USBC_UECON1_BUSY1           (_U_(0x1) << USBC_UECON1_BUSY1_Pos)
+#define USBC_UECON1_MASK            _U_(0x030E795F) /**< \brief (USBC_UECON1) MASK Register */
 
 /* -------- USBC_UECON2 : (USBC Offset: 0x1C8) (R/  32) Endpoint Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -2302,41 +2302,41 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECON2_OFFSET          0x1C8        /**< \brief (USBC_UECON2 offset) Endpoint Control Register */
-#define USBC_UECON2_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECON2 reset_value) Endpoint Control Register */
+#define USBC_UECON2_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UECON2 reset_value) Endpoint Control Register */
 
 #define USBC_UECON2_TXINE_Pos       0            /**< \brief (USBC_UECON2) TXIN Interrupt Enable */
-#define USBC_UECON2_TXINE           (_U(0x1) << USBC_UECON2_TXINE_Pos)
+#define USBC_UECON2_TXINE           (_U_(0x1) << USBC_UECON2_TXINE_Pos)
 #define USBC_UECON2_RXOUTE_Pos      1            /**< \brief (USBC_UECON2) RXOUT Interrupt Enable */
-#define USBC_UECON2_RXOUTE          (_U(0x1) << USBC_UECON2_RXOUTE_Pos)
+#define USBC_UECON2_RXOUTE          (_U_(0x1) << USBC_UECON2_RXOUTE_Pos)
 #define USBC_UECON2_RXSTPE_Pos      2            /**< \brief (USBC_UECON2) RXSTP Interrupt Enable */
-#define USBC_UECON2_RXSTPE          (_U(0x1) << USBC_UECON2_RXSTPE_Pos)
+#define USBC_UECON2_RXSTPE          (_U_(0x1) << USBC_UECON2_RXSTPE_Pos)
 #define USBC_UECON2_NAKOUTE_Pos     3            /**< \brief (USBC_UECON2) NAKOUT Interrupt Enable */
-#define USBC_UECON2_NAKOUTE         (_U(0x1) << USBC_UECON2_NAKOUTE_Pos)
+#define USBC_UECON2_NAKOUTE         (_U_(0x1) << USBC_UECON2_NAKOUTE_Pos)
 #define USBC_UECON2_NAKINE_Pos      4            /**< \brief (USBC_UECON2) NAKIN Interrupt Enable */
-#define USBC_UECON2_NAKINE          (_U(0x1) << USBC_UECON2_NAKINE_Pos)
+#define USBC_UECON2_NAKINE          (_U_(0x1) << USBC_UECON2_NAKINE_Pos)
 #define USBC_UECON2_STALLEDE_Pos    6            /**< \brief (USBC_UECON2) STALLED Interrupt Enable */
-#define USBC_UECON2_STALLEDE        (_U(0x1) << USBC_UECON2_STALLEDE_Pos)
+#define USBC_UECON2_STALLEDE        (_U_(0x1) << USBC_UECON2_STALLEDE_Pos)
 #define USBC_UECON2_NREPLY_Pos      8            /**< \brief (USBC_UECON2) No Reply */
-#define USBC_UECON2_NREPLY          (_U(0x1) << USBC_UECON2_NREPLY_Pos)
+#define USBC_UECON2_NREPLY          (_U_(0x1) << USBC_UECON2_NREPLY_Pos)
 #define USBC_UECON2_RAMACERE_Pos    11           /**< \brief (USBC_UECON2) RAMACER Interrupt Enable */
-#define USBC_UECON2_RAMACERE        (_U(0x1) << USBC_UECON2_RAMACERE_Pos)
+#define USBC_UECON2_RAMACERE        (_U_(0x1) << USBC_UECON2_RAMACERE_Pos)
 #define USBC_UECON2_NBUSYBKE_Pos    12           /**< \brief (USBC_UECON2) Number of Busy Banks Interrupt Enable */
-#define USBC_UECON2_NBUSYBKE        (_U(0x1) << USBC_UECON2_NBUSYBKE_Pos)
+#define USBC_UECON2_NBUSYBKE        (_U_(0x1) << USBC_UECON2_NBUSYBKE_Pos)
 #define USBC_UECON2_KILLBK_Pos      13           /**< \brief (USBC_UECON2) Kill IN Bank */
-#define USBC_UECON2_KILLBK          (_U(0x1) << USBC_UECON2_KILLBK_Pos)
+#define USBC_UECON2_KILLBK          (_U_(0x1) << USBC_UECON2_KILLBK_Pos)
 #define USBC_UECON2_FIFOCON_Pos     14           /**< \brief (USBC_UECON2) FIFO Control */
-#define USBC_UECON2_FIFOCON         (_U(0x1) << USBC_UECON2_FIFOCON_Pos)
+#define USBC_UECON2_FIFOCON         (_U_(0x1) << USBC_UECON2_FIFOCON_Pos)
 #define USBC_UECON2_NYETDIS_Pos     17           /**< \brief (USBC_UECON2) NYET Token Enable */
-#define USBC_UECON2_NYETDIS         (_U(0x1) << USBC_UECON2_NYETDIS_Pos)
+#define USBC_UECON2_NYETDIS         (_U_(0x1) << USBC_UECON2_NYETDIS_Pos)
 #define USBC_UECON2_RSTDT_Pos       18           /**< \brief (USBC_UECON2) Reset Data Toggle */
-#define USBC_UECON2_RSTDT           (_U(0x1) << USBC_UECON2_RSTDT_Pos)
+#define USBC_UECON2_RSTDT           (_U_(0x1) << USBC_UECON2_RSTDT_Pos)
 #define USBC_UECON2_STALLRQ_Pos     19           /**< \brief (USBC_UECON2) STALL Request */
-#define USBC_UECON2_STALLRQ         (_U(0x1) << USBC_UECON2_STALLRQ_Pos)
+#define USBC_UECON2_STALLRQ         (_U_(0x1) << USBC_UECON2_STALLRQ_Pos)
 #define USBC_UECON2_BUSY0_Pos       24           /**< \brief (USBC_UECON2) Busy Bank1 Enable */
-#define USBC_UECON2_BUSY0           (_U(0x1) << USBC_UECON2_BUSY0_Pos)
+#define USBC_UECON2_BUSY0           (_U_(0x1) << USBC_UECON2_BUSY0_Pos)
 #define USBC_UECON2_BUSY1_Pos       25           /**< \brief (USBC_UECON2) Busy Bank0 Enable */
-#define USBC_UECON2_BUSY1           (_U(0x1) << USBC_UECON2_BUSY1_Pos)
-#define USBC_UECON2_MASK            _U(0x030E795F) /**< \brief (USBC_UECON2) MASK Register */
+#define USBC_UECON2_BUSY1           (_U_(0x1) << USBC_UECON2_BUSY1_Pos)
+#define USBC_UECON2_MASK            _U_(0x030E795F) /**< \brief (USBC_UECON2) MASK Register */
 
 /* -------- USBC_UECON3 : (USBC Offset: 0x1CC) (R/  32) Endpoint Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -2370,41 +2370,41 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECON3_OFFSET          0x1CC        /**< \brief (USBC_UECON3 offset) Endpoint Control Register */
-#define USBC_UECON3_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECON3 reset_value) Endpoint Control Register */
+#define USBC_UECON3_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UECON3 reset_value) Endpoint Control Register */
 
 #define USBC_UECON3_TXINE_Pos       0            /**< \brief (USBC_UECON3) TXIN Interrupt Enable */
-#define USBC_UECON3_TXINE           (_U(0x1) << USBC_UECON3_TXINE_Pos)
+#define USBC_UECON3_TXINE           (_U_(0x1) << USBC_UECON3_TXINE_Pos)
 #define USBC_UECON3_RXOUTE_Pos      1            /**< \brief (USBC_UECON3) RXOUT Interrupt Enable */
-#define USBC_UECON3_RXOUTE          (_U(0x1) << USBC_UECON3_RXOUTE_Pos)
+#define USBC_UECON3_RXOUTE          (_U_(0x1) << USBC_UECON3_RXOUTE_Pos)
 #define USBC_UECON3_RXSTPE_Pos      2            /**< \brief (USBC_UECON3) RXSTP Interrupt Enable */
-#define USBC_UECON3_RXSTPE          (_U(0x1) << USBC_UECON3_RXSTPE_Pos)
+#define USBC_UECON3_RXSTPE          (_U_(0x1) << USBC_UECON3_RXSTPE_Pos)
 #define USBC_UECON3_NAKOUTE_Pos     3            /**< \brief (USBC_UECON3) NAKOUT Interrupt Enable */
-#define USBC_UECON3_NAKOUTE         (_U(0x1) << USBC_UECON3_NAKOUTE_Pos)
+#define USBC_UECON3_NAKOUTE         (_U_(0x1) << USBC_UECON3_NAKOUTE_Pos)
 #define USBC_UECON3_NAKINE_Pos      4            /**< \brief (USBC_UECON3) NAKIN Interrupt Enable */
-#define USBC_UECON3_NAKINE          (_U(0x1) << USBC_UECON3_NAKINE_Pos)
+#define USBC_UECON3_NAKINE          (_U_(0x1) << USBC_UECON3_NAKINE_Pos)
 #define USBC_UECON3_STALLEDE_Pos    6            /**< \brief (USBC_UECON3) STALLED Interrupt Enable */
-#define USBC_UECON3_STALLEDE        (_U(0x1) << USBC_UECON3_STALLEDE_Pos)
+#define USBC_UECON3_STALLEDE        (_U_(0x1) << USBC_UECON3_STALLEDE_Pos)
 #define USBC_UECON3_NREPLY_Pos      8            /**< \brief (USBC_UECON3) No Reply */
-#define USBC_UECON3_NREPLY          (_U(0x1) << USBC_UECON3_NREPLY_Pos)
+#define USBC_UECON3_NREPLY          (_U_(0x1) << USBC_UECON3_NREPLY_Pos)
 #define USBC_UECON3_RAMACERE_Pos    11           /**< \brief (USBC_UECON3) RAMACER Interrupt Enable */
-#define USBC_UECON3_RAMACERE        (_U(0x1) << USBC_UECON3_RAMACERE_Pos)
+#define USBC_UECON3_RAMACERE        (_U_(0x1) << USBC_UECON3_RAMACERE_Pos)
 #define USBC_UECON3_NBUSYBKE_Pos    12           /**< \brief (USBC_UECON3) Number of Busy Banks Interrupt Enable */
-#define USBC_UECON3_NBUSYBKE        (_U(0x1) << USBC_UECON3_NBUSYBKE_Pos)
+#define USBC_UECON3_NBUSYBKE        (_U_(0x1) << USBC_UECON3_NBUSYBKE_Pos)
 #define USBC_UECON3_KILLBK_Pos      13           /**< \brief (USBC_UECON3) Kill IN Bank */
-#define USBC_UECON3_KILLBK          (_U(0x1) << USBC_UECON3_KILLBK_Pos)
+#define USBC_UECON3_KILLBK          (_U_(0x1) << USBC_UECON3_KILLBK_Pos)
 #define USBC_UECON3_FIFOCON_Pos     14           /**< \brief (USBC_UECON3) FIFO Control */
-#define USBC_UECON3_FIFOCON         (_U(0x1) << USBC_UECON3_FIFOCON_Pos)
+#define USBC_UECON3_FIFOCON         (_U_(0x1) << USBC_UECON3_FIFOCON_Pos)
 #define USBC_UECON3_NYETDIS_Pos     17           /**< \brief (USBC_UECON3) NYET Token Enable */
-#define USBC_UECON3_NYETDIS         (_U(0x1) << USBC_UECON3_NYETDIS_Pos)
+#define USBC_UECON3_NYETDIS         (_U_(0x1) << USBC_UECON3_NYETDIS_Pos)
 #define USBC_UECON3_RSTDT_Pos       18           /**< \brief (USBC_UECON3) Reset Data Toggle */
-#define USBC_UECON3_RSTDT           (_U(0x1) << USBC_UECON3_RSTDT_Pos)
+#define USBC_UECON3_RSTDT           (_U_(0x1) << USBC_UECON3_RSTDT_Pos)
 #define USBC_UECON3_STALLRQ_Pos     19           /**< \brief (USBC_UECON3) STALL Request */
-#define USBC_UECON3_STALLRQ         (_U(0x1) << USBC_UECON3_STALLRQ_Pos)
+#define USBC_UECON3_STALLRQ         (_U_(0x1) << USBC_UECON3_STALLRQ_Pos)
 #define USBC_UECON3_BUSY0_Pos       24           /**< \brief (USBC_UECON3) Busy Bank1 Enable */
-#define USBC_UECON3_BUSY0           (_U(0x1) << USBC_UECON3_BUSY0_Pos)
+#define USBC_UECON3_BUSY0           (_U_(0x1) << USBC_UECON3_BUSY0_Pos)
 #define USBC_UECON3_BUSY1_Pos       25           /**< \brief (USBC_UECON3) Busy Bank0 Enable */
-#define USBC_UECON3_BUSY1           (_U(0x1) << USBC_UECON3_BUSY1_Pos)
-#define USBC_UECON3_MASK            _U(0x030E795F) /**< \brief (USBC_UECON3) MASK Register */
+#define USBC_UECON3_BUSY1           (_U_(0x1) << USBC_UECON3_BUSY1_Pos)
+#define USBC_UECON3_MASK            _U_(0x030E795F) /**< \brief (USBC_UECON3) MASK Register */
 
 /* -------- USBC_UECON4 : (USBC Offset: 0x1D0) (R/  32) Endpoint Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -2438,41 +2438,41 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECON4_OFFSET          0x1D0        /**< \brief (USBC_UECON4 offset) Endpoint Control Register */
-#define USBC_UECON4_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECON4 reset_value) Endpoint Control Register */
+#define USBC_UECON4_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UECON4 reset_value) Endpoint Control Register */
 
 #define USBC_UECON4_TXINE_Pos       0            /**< \brief (USBC_UECON4) TXIN Interrupt Enable */
-#define USBC_UECON4_TXINE           (_U(0x1) << USBC_UECON4_TXINE_Pos)
+#define USBC_UECON4_TXINE           (_U_(0x1) << USBC_UECON4_TXINE_Pos)
 #define USBC_UECON4_RXOUTE_Pos      1            /**< \brief (USBC_UECON4) RXOUT Interrupt Enable */
-#define USBC_UECON4_RXOUTE          (_U(0x1) << USBC_UECON4_RXOUTE_Pos)
+#define USBC_UECON4_RXOUTE          (_U_(0x1) << USBC_UECON4_RXOUTE_Pos)
 #define USBC_UECON4_RXSTPE_Pos      2            /**< \brief (USBC_UECON4) RXSTP Interrupt Enable */
-#define USBC_UECON4_RXSTPE          (_U(0x1) << USBC_UECON4_RXSTPE_Pos)
+#define USBC_UECON4_RXSTPE          (_U_(0x1) << USBC_UECON4_RXSTPE_Pos)
 #define USBC_UECON4_NAKOUTE_Pos     3            /**< \brief (USBC_UECON4) NAKOUT Interrupt Enable */
-#define USBC_UECON4_NAKOUTE         (_U(0x1) << USBC_UECON4_NAKOUTE_Pos)
+#define USBC_UECON4_NAKOUTE         (_U_(0x1) << USBC_UECON4_NAKOUTE_Pos)
 #define USBC_UECON4_NAKINE_Pos      4            /**< \brief (USBC_UECON4) NAKIN Interrupt Enable */
-#define USBC_UECON4_NAKINE          (_U(0x1) << USBC_UECON4_NAKINE_Pos)
+#define USBC_UECON4_NAKINE          (_U_(0x1) << USBC_UECON4_NAKINE_Pos)
 #define USBC_UECON4_STALLEDE_Pos    6            /**< \brief (USBC_UECON4) STALLED Interrupt Enable */
-#define USBC_UECON4_STALLEDE        (_U(0x1) << USBC_UECON4_STALLEDE_Pos)
+#define USBC_UECON4_STALLEDE        (_U_(0x1) << USBC_UECON4_STALLEDE_Pos)
 #define USBC_UECON4_NREPLY_Pos      8            /**< \brief (USBC_UECON4) No Reply */
-#define USBC_UECON4_NREPLY          (_U(0x1) << USBC_UECON4_NREPLY_Pos)
+#define USBC_UECON4_NREPLY          (_U_(0x1) << USBC_UECON4_NREPLY_Pos)
 #define USBC_UECON4_RAMACERE_Pos    11           /**< \brief (USBC_UECON4) RAMACER Interrupt Enable */
-#define USBC_UECON4_RAMACERE        (_U(0x1) << USBC_UECON4_RAMACERE_Pos)
+#define USBC_UECON4_RAMACERE        (_U_(0x1) << USBC_UECON4_RAMACERE_Pos)
 #define USBC_UECON4_NBUSYBKE_Pos    12           /**< \brief (USBC_UECON4) Number of Busy Banks Interrupt Enable */
-#define USBC_UECON4_NBUSYBKE        (_U(0x1) << USBC_UECON4_NBUSYBKE_Pos)
+#define USBC_UECON4_NBUSYBKE        (_U_(0x1) << USBC_UECON4_NBUSYBKE_Pos)
 #define USBC_UECON4_KILLBK_Pos      13           /**< \brief (USBC_UECON4) Kill IN Bank */
-#define USBC_UECON4_KILLBK          (_U(0x1) << USBC_UECON4_KILLBK_Pos)
+#define USBC_UECON4_KILLBK          (_U_(0x1) << USBC_UECON4_KILLBK_Pos)
 #define USBC_UECON4_FIFOCON_Pos     14           /**< \brief (USBC_UECON4) FIFO Control */
-#define USBC_UECON4_FIFOCON         (_U(0x1) << USBC_UECON4_FIFOCON_Pos)
+#define USBC_UECON4_FIFOCON         (_U_(0x1) << USBC_UECON4_FIFOCON_Pos)
 #define USBC_UECON4_NYETDIS_Pos     17           /**< \brief (USBC_UECON4) NYET Token Enable */
-#define USBC_UECON4_NYETDIS         (_U(0x1) << USBC_UECON4_NYETDIS_Pos)
+#define USBC_UECON4_NYETDIS         (_U_(0x1) << USBC_UECON4_NYETDIS_Pos)
 #define USBC_UECON4_RSTDT_Pos       18           /**< \brief (USBC_UECON4) Reset Data Toggle */
-#define USBC_UECON4_RSTDT           (_U(0x1) << USBC_UECON4_RSTDT_Pos)
+#define USBC_UECON4_RSTDT           (_U_(0x1) << USBC_UECON4_RSTDT_Pos)
 #define USBC_UECON4_STALLRQ_Pos     19           /**< \brief (USBC_UECON4) STALL Request */
-#define USBC_UECON4_STALLRQ         (_U(0x1) << USBC_UECON4_STALLRQ_Pos)
+#define USBC_UECON4_STALLRQ         (_U_(0x1) << USBC_UECON4_STALLRQ_Pos)
 #define USBC_UECON4_BUSY0_Pos       24           /**< \brief (USBC_UECON4) Busy Bank1 Enable */
-#define USBC_UECON4_BUSY0           (_U(0x1) << USBC_UECON4_BUSY0_Pos)
+#define USBC_UECON4_BUSY0           (_U_(0x1) << USBC_UECON4_BUSY0_Pos)
 #define USBC_UECON4_BUSY1_Pos       25           /**< \brief (USBC_UECON4) Busy Bank0 Enable */
-#define USBC_UECON4_BUSY1           (_U(0x1) << USBC_UECON4_BUSY1_Pos)
-#define USBC_UECON4_MASK            _U(0x030E795F) /**< \brief (USBC_UECON4) MASK Register */
+#define USBC_UECON4_BUSY1           (_U_(0x1) << USBC_UECON4_BUSY1_Pos)
+#define USBC_UECON4_MASK            _U_(0x030E795F) /**< \brief (USBC_UECON4) MASK Register */
 
 /* -------- USBC_UECON5 : (USBC Offset: 0x1D4) (R/  32) Endpoint Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -2506,41 +2506,41 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECON5_OFFSET          0x1D4        /**< \brief (USBC_UECON5 offset) Endpoint Control Register */
-#define USBC_UECON5_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECON5 reset_value) Endpoint Control Register */
+#define USBC_UECON5_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UECON5 reset_value) Endpoint Control Register */
 
 #define USBC_UECON5_TXINE_Pos       0            /**< \brief (USBC_UECON5) TXIN Interrupt Enable */
-#define USBC_UECON5_TXINE           (_U(0x1) << USBC_UECON5_TXINE_Pos)
+#define USBC_UECON5_TXINE           (_U_(0x1) << USBC_UECON5_TXINE_Pos)
 #define USBC_UECON5_RXOUTE_Pos      1            /**< \brief (USBC_UECON5) RXOUT Interrupt Enable */
-#define USBC_UECON5_RXOUTE          (_U(0x1) << USBC_UECON5_RXOUTE_Pos)
+#define USBC_UECON5_RXOUTE          (_U_(0x1) << USBC_UECON5_RXOUTE_Pos)
 #define USBC_UECON5_RXSTPE_Pos      2            /**< \brief (USBC_UECON5) RXSTP Interrupt Enable */
-#define USBC_UECON5_RXSTPE          (_U(0x1) << USBC_UECON5_RXSTPE_Pos)
+#define USBC_UECON5_RXSTPE          (_U_(0x1) << USBC_UECON5_RXSTPE_Pos)
 #define USBC_UECON5_NAKOUTE_Pos     3            /**< \brief (USBC_UECON5) NAKOUT Interrupt Enable */
-#define USBC_UECON5_NAKOUTE         (_U(0x1) << USBC_UECON5_NAKOUTE_Pos)
+#define USBC_UECON5_NAKOUTE         (_U_(0x1) << USBC_UECON5_NAKOUTE_Pos)
 #define USBC_UECON5_NAKINE_Pos      4            /**< \brief (USBC_UECON5) NAKIN Interrupt Enable */
-#define USBC_UECON5_NAKINE          (_U(0x1) << USBC_UECON5_NAKINE_Pos)
+#define USBC_UECON5_NAKINE          (_U_(0x1) << USBC_UECON5_NAKINE_Pos)
 #define USBC_UECON5_STALLEDE_Pos    6            /**< \brief (USBC_UECON5) STALLED Interrupt Enable */
-#define USBC_UECON5_STALLEDE        (_U(0x1) << USBC_UECON5_STALLEDE_Pos)
+#define USBC_UECON5_STALLEDE        (_U_(0x1) << USBC_UECON5_STALLEDE_Pos)
 #define USBC_UECON5_NREPLY_Pos      8            /**< \brief (USBC_UECON5) No Reply */
-#define USBC_UECON5_NREPLY          (_U(0x1) << USBC_UECON5_NREPLY_Pos)
+#define USBC_UECON5_NREPLY          (_U_(0x1) << USBC_UECON5_NREPLY_Pos)
 #define USBC_UECON5_RAMACERE_Pos    11           /**< \brief (USBC_UECON5) RAMACER Interrupt Enable */
-#define USBC_UECON5_RAMACERE        (_U(0x1) << USBC_UECON5_RAMACERE_Pos)
+#define USBC_UECON5_RAMACERE        (_U_(0x1) << USBC_UECON5_RAMACERE_Pos)
 #define USBC_UECON5_NBUSYBKE_Pos    12           /**< \brief (USBC_UECON5) Number of Busy Banks Interrupt Enable */
-#define USBC_UECON5_NBUSYBKE        (_U(0x1) << USBC_UECON5_NBUSYBKE_Pos)
+#define USBC_UECON5_NBUSYBKE        (_U_(0x1) << USBC_UECON5_NBUSYBKE_Pos)
 #define USBC_UECON5_KILLBK_Pos      13           /**< \brief (USBC_UECON5) Kill IN Bank */
-#define USBC_UECON5_KILLBK          (_U(0x1) << USBC_UECON5_KILLBK_Pos)
+#define USBC_UECON5_KILLBK          (_U_(0x1) << USBC_UECON5_KILLBK_Pos)
 #define USBC_UECON5_FIFOCON_Pos     14           /**< \brief (USBC_UECON5) FIFO Control */
-#define USBC_UECON5_FIFOCON         (_U(0x1) << USBC_UECON5_FIFOCON_Pos)
+#define USBC_UECON5_FIFOCON         (_U_(0x1) << USBC_UECON5_FIFOCON_Pos)
 #define USBC_UECON5_NYETDIS_Pos     17           /**< \brief (USBC_UECON5) NYET Token Enable */
-#define USBC_UECON5_NYETDIS         (_U(0x1) << USBC_UECON5_NYETDIS_Pos)
+#define USBC_UECON5_NYETDIS         (_U_(0x1) << USBC_UECON5_NYETDIS_Pos)
 #define USBC_UECON5_RSTDT_Pos       18           /**< \brief (USBC_UECON5) Reset Data Toggle */
-#define USBC_UECON5_RSTDT           (_U(0x1) << USBC_UECON5_RSTDT_Pos)
+#define USBC_UECON5_RSTDT           (_U_(0x1) << USBC_UECON5_RSTDT_Pos)
 #define USBC_UECON5_STALLRQ_Pos     19           /**< \brief (USBC_UECON5) STALL Request */
-#define USBC_UECON5_STALLRQ         (_U(0x1) << USBC_UECON5_STALLRQ_Pos)
+#define USBC_UECON5_STALLRQ         (_U_(0x1) << USBC_UECON5_STALLRQ_Pos)
 #define USBC_UECON5_BUSY0_Pos       24           /**< \brief (USBC_UECON5) Busy Bank1 Enable */
-#define USBC_UECON5_BUSY0           (_U(0x1) << USBC_UECON5_BUSY0_Pos)
+#define USBC_UECON5_BUSY0           (_U_(0x1) << USBC_UECON5_BUSY0_Pos)
 #define USBC_UECON5_BUSY1_Pos       25           /**< \brief (USBC_UECON5) Busy Bank0 Enable */
-#define USBC_UECON5_BUSY1           (_U(0x1) << USBC_UECON5_BUSY1_Pos)
-#define USBC_UECON5_MASK            _U(0x030E795F) /**< \brief (USBC_UECON5) MASK Register */
+#define USBC_UECON5_BUSY1           (_U_(0x1) << USBC_UECON5_BUSY1_Pos)
+#define USBC_UECON5_MASK            _U_(0x030E795F) /**< \brief (USBC_UECON5) MASK Register */
 
 /* -------- USBC_UECON6 : (USBC Offset: 0x1D8) (R/  32) Endpoint Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -2574,41 +2574,41 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECON6_OFFSET          0x1D8        /**< \brief (USBC_UECON6 offset) Endpoint Control Register */
-#define USBC_UECON6_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECON6 reset_value) Endpoint Control Register */
+#define USBC_UECON6_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UECON6 reset_value) Endpoint Control Register */
 
 #define USBC_UECON6_TXINE_Pos       0            /**< \brief (USBC_UECON6) TXIN Interrupt Enable */
-#define USBC_UECON6_TXINE           (_U(0x1) << USBC_UECON6_TXINE_Pos)
+#define USBC_UECON6_TXINE           (_U_(0x1) << USBC_UECON6_TXINE_Pos)
 #define USBC_UECON6_RXOUTE_Pos      1            /**< \brief (USBC_UECON6) RXOUT Interrupt Enable */
-#define USBC_UECON6_RXOUTE          (_U(0x1) << USBC_UECON6_RXOUTE_Pos)
+#define USBC_UECON6_RXOUTE          (_U_(0x1) << USBC_UECON6_RXOUTE_Pos)
 #define USBC_UECON6_RXSTPE_Pos      2            /**< \brief (USBC_UECON6) RXSTP Interrupt Enable */
-#define USBC_UECON6_RXSTPE          (_U(0x1) << USBC_UECON6_RXSTPE_Pos)
+#define USBC_UECON6_RXSTPE          (_U_(0x1) << USBC_UECON6_RXSTPE_Pos)
 #define USBC_UECON6_NAKOUTE_Pos     3            /**< \brief (USBC_UECON6) NAKOUT Interrupt Enable */
-#define USBC_UECON6_NAKOUTE         (_U(0x1) << USBC_UECON6_NAKOUTE_Pos)
+#define USBC_UECON6_NAKOUTE         (_U_(0x1) << USBC_UECON6_NAKOUTE_Pos)
 #define USBC_UECON6_NAKINE_Pos      4            /**< \brief (USBC_UECON6) NAKIN Interrupt Enable */
-#define USBC_UECON6_NAKINE          (_U(0x1) << USBC_UECON6_NAKINE_Pos)
+#define USBC_UECON6_NAKINE          (_U_(0x1) << USBC_UECON6_NAKINE_Pos)
 #define USBC_UECON6_STALLEDE_Pos    6            /**< \brief (USBC_UECON6) STALLED Interrupt Enable */
-#define USBC_UECON6_STALLEDE        (_U(0x1) << USBC_UECON6_STALLEDE_Pos)
+#define USBC_UECON6_STALLEDE        (_U_(0x1) << USBC_UECON6_STALLEDE_Pos)
 #define USBC_UECON6_NREPLY_Pos      8            /**< \brief (USBC_UECON6) No Reply */
-#define USBC_UECON6_NREPLY          (_U(0x1) << USBC_UECON6_NREPLY_Pos)
+#define USBC_UECON6_NREPLY          (_U_(0x1) << USBC_UECON6_NREPLY_Pos)
 #define USBC_UECON6_RAMACERE_Pos    11           /**< \brief (USBC_UECON6) RAMACER Interrupt Enable */
-#define USBC_UECON6_RAMACERE        (_U(0x1) << USBC_UECON6_RAMACERE_Pos)
+#define USBC_UECON6_RAMACERE        (_U_(0x1) << USBC_UECON6_RAMACERE_Pos)
 #define USBC_UECON6_NBUSYBKE_Pos    12           /**< \brief (USBC_UECON6) Number of Busy Banks Interrupt Enable */
-#define USBC_UECON6_NBUSYBKE        (_U(0x1) << USBC_UECON6_NBUSYBKE_Pos)
+#define USBC_UECON6_NBUSYBKE        (_U_(0x1) << USBC_UECON6_NBUSYBKE_Pos)
 #define USBC_UECON6_KILLBK_Pos      13           /**< \brief (USBC_UECON6) Kill IN Bank */
-#define USBC_UECON6_KILLBK          (_U(0x1) << USBC_UECON6_KILLBK_Pos)
+#define USBC_UECON6_KILLBK          (_U_(0x1) << USBC_UECON6_KILLBK_Pos)
 #define USBC_UECON6_FIFOCON_Pos     14           /**< \brief (USBC_UECON6) FIFO Control */
-#define USBC_UECON6_FIFOCON         (_U(0x1) << USBC_UECON6_FIFOCON_Pos)
+#define USBC_UECON6_FIFOCON         (_U_(0x1) << USBC_UECON6_FIFOCON_Pos)
 #define USBC_UECON6_NYETDIS_Pos     17           /**< \brief (USBC_UECON6) NYET Token Enable */
-#define USBC_UECON6_NYETDIS         (_U(0x1) << USBC_UECON6_NYETDIS_Pos)
+#define USBC_UECON6_NYETDIS         (_U_(0x1) << USBC_UECON6_NYETDIS_Pos)
 #define USBC_UECON6_RSTDT_Pos       18           /**< \brief (USBC_UECON6) Reset Data Toggle */
-#define USBC_UECON6_RSTDT           (_U(0x1) << USBC_UECON6_RSTDT_Pos)
+#define USBC_UECON6_RSTDT           (_U_(0x1) << USBC_UECON6_RSTDT_Pos)
 #define USBC_UECON6_STALLRQ_Pos     19           /**< \brief (USBC_UECON6) STALL Request */
-#define USBC_UECON6_STALLRQ         (_U(0x1) << USBC_UECON6_STALLRQ_Pos)
+#define USBC_UECON6_STALLRQ         (_U_(0x1) << USBC_UECON6_STALLRQ_Pos)
 #define USBC_UECON6_BUSY0_Pos       24           /**< \brief (USBC_UECON6) Busy Bank1 Enable */
-#define USBC_UECON6_BUSY0           (_U(0x1) << USBC_UECON6_BUSY0_Pos)
+#define USBC_UECON6_BUSY0           (_U_(0x1) << USBC_UECON6_BUSY0_Pos)
 #define USBC_UECON6_BUSY1_Pos       25           /**< \brief (USBC_UECON6) Busy Bank0 Enable */
-#define USBC_UECON6_BUSY1           (_U(0x1) << USBC_UECON6_BUSY1_Pos)
-#define USBC_UECON6_MASK            _U(0x030E795F) /**< \brief (USBC_UECON6) MASK Register */
+#define USBC_UECON6_BUSY1           (_U_(0x1) << USBC_UECON6_BUSY1_Pos)
+#define USBC_UECON6_MASK            _U_(0x030E795F) /**< \brief (USBC_UECON6) MASK Register */
 
 /* -------- USBC_UECON7 : (USBC Offset: 0x1DC) (R/  32) Endpoint Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -2642,41 +2642,41 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECON7_OFFSET          0x1DC        /**< \brief (USBC_UECON7 offset) Endpoint Control Register */
-#define USBC_UECON7_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECON7 reset_value) Endpoint Control Register */
+#define USBC_UECON7_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UECON7 reset_value) Endpoint Control Register */
 
 #define USBC_UECON7_TXINE_Pos       0            /**< \brief (USBC_UECON7) TXIN Interrupt Enable */
-#define USBC_UECON7_TXINE           (_U(0x1) << USBC_UECON7_TXINE_Pos)
+#define USBC_UECON7_TXINE           (_U_(0x1) << USBC_UECON7_TXINE_Pos)
 #define USBC_UECON7_RXOUTE_Pos      1            /**< \brief (USBC_UECON7) RXOUT Interrupt Enable */
-#define USBC_UECON7_RXOUTE          (_U(0x1) << USBC_UECON7_RXOUTE_Pos)
+#define USBC_UECON7_RXOUTE          (_U_(0x1) << USBC_UECON7_RXOUTE_Pos)
 #define USBC_UECON7_RXSTPE_Pos      2            /**< \brief (USBC_UECON7) RXSTP Interrupt Enable */
-#define USBC_UECON7_RXSTPE          (_U(0x1) << USBC_UECON7_RXSTPE_Pos)
+#define USBC_UECON7_RXSTPE          (_U_(0x1) << USBC_UECON7_RXSTPE_Pos)
 #define USBC_UECON7_NAKOUTE_Pos     3            /**< \brief (USBC_UECON7) NAKOUT Interrupt Enable */
-#define USBC_UECON7_NAKOUTE         (_U(0x1) << USBC_UECON7_NAKOUTE_Pos)
+#define USBC_UECON7_NAKOUTE         (_U_(0x1) << USBC_UECON7_NAKOUTE_Pos)
 #define USBC_UECON7_NAKINE_Pos      4            /**< \brief (USBC_UECON7) NAKIN Interrupt Enable */
-#define USBC_UECON7_NAKINE          (_U(0x1) << USBC_UECON7_NAKINE_Pos)
+#define USBC_UECON7_NAKINE          (_U_(0x1) << USBC_UECON7_NAKINE_Pos)
 #define USBC_UECON7_STALLEDE_Pos    6            /**< \brief (USBC_UECON7) STALLED Interrupt Enable */
-#define USBC_UECON7_STALLEDE        (_U(0x1) << USBC_UECON7_STALLEDE_Pos)
+#define USBC_UECON7_STALLEDE        (_U_(0x1) << USBC_UECON7_STALLEDE_Pos)
 #define USBC_UECON7_NREPLY_Pos      8            /**< \brief (USBC_UECON7) No Reply */
-#define USBC_UECON7_NREPLY          (_U(0x1) << USBC_UECON7_NREPLY_Pos)
+#define USBC_UECON7_NREPLY          (_U_(0x1) << USBC_UECON7_NREPLY_Pos)
 #define USBC_UECON7_RAMACERE_Pos    11           /**< \brief (USBC_UECON7) RAMACER Interrupt Enable */
-#define USBC_UECON7_RAMACERE        (_U(0x1) << USBC_UECON7_RAMACERE_Pos)
+#define USBC_UECON7_RAMACERE        (_U_(0x1) << USBC_UECON7_RAMACERE_Pos)
 #define USBC_UECON7_NBUSYBKE_Pos    12           /**< \brief (USBC_UECON7) Number of Busy Banks Interrupt Enable */
-#define USBC_UECON7_NBUSYBKE        (_U(0x1) << USBC_UECON7_NBUSYBKE_Pos)
+#define USBC_UECON7_NBUSYBKE        (_U_(0x1) << USBC_UECON7_NBUSYBKE_Pos)
 #define USBC_UECON7_KILLBK_Pos      13           /**< \brief (USBC_UECON7) Kill IN Bank */
-#define USBC_UECON7_KILLBK          (_U(0x1) << USBC_UECON7_KILLBK_Pos)
+#define USBC_UECON7_KILLBK          (_U_(0x1) << USBC_UECON7_KILLBK_Pos)
 #define USBC_UECON7_FIFOCON_Pos     14           /**< \brief (USBC_UECON7) FIFO Control */
-#define USBC_UECON7_FIFOCON         (_U(0x1) << USBC_UECON7_FIFOCON_Pos)
+#define USBC_UECON7_FIFOCON         (_U_(0x1) << USBC_UECON7_FIFOCON_Pos)
 #define USBC_UECON7_NYETDIS_Pos     17           /**< \brief (USBC_UECON7) NYET Token Enable */
-#define USBC_UECON7_NYETDIS         (_U(0x1) << USBC_UECON7_NYETDIS_Pos)
+#define USBC_UECON7_NYETDIS         (_U_(0x1) << USBC_UECON7_NYETDIS_Pos)
 #define USBC_UECON7_RSTDT_Pos       18           /**< \brief (USBC_UECON7) Reset Data Toggle */
-#define USBC_UECON7_RSTDT           (_U(0x1) << USBC_UECON7_RSTDT_Pos)
+#define USBC_UECON7_RSTDT           (_U_(0x1) << USBC_UECON7_RSTDT_Pos)
 #define USBC_UECON7_STALLRQ_Pos     19           /**< \brief (USBC_UECON7) STALL Request */
-#define USBC_UECON7_STALLRQ         (_U(0x1) << USBC_UECON7_STALLRQ_Pos)
+#define USBC_UECON7_STALLRQ         (_U_(0x1) << USBC_UECON7_STALLRQ_Pos)
 #define USBC_UECON7_BUSY0_Pos       24           /**< \brief (USBC_UECON7) Busy Bank1 Enable */
-#define USBC_UECON7_BUSY0           (_U(0x1) << USBC_UECON7_BUSY0_Pos)
+#define USBC_UECON7_BUSY0           (_U_(0x1) << USBC_UECON7_BUSY0_Pos)
 #define USBC_UECON7_BUSY1_Pos       25           /**< \brief (USBC_UECON7) Busy Bank0 Enable */
-#define USBC_UECON7_BUSY1           (_U(0x1) << USBC_UECON7_BUSY1_Pos)
-#define USBC_UECON7_MASK            _U(0x030E795F) /**< \brief (USBC_UECON7) MASK Register */
+#define USBC_UECON7_BUSY1           (_U_(0x1) << USBC_UECON7_BUSY1_Pos)
+#define USBC_UECON7_MASK            _U_(0x030E795F) /**< \brief (USBC_UECON7) MASK Register */
 
 /* -------- USBC_UECON0SET : (USBC Offset: 0x1F0) ( /W 32) Endpoint Control Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -2709,39 +2709,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECON0SET_OFFSET       0x1F0        /**< \brief (USBC_UECON0SET offset) Endpoint Control Set Register */
-#define USBC_UECON0SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON0SET reset_value) Endpoint Control Set Register */
+#define USBC_UECON0SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UECON0SET reset_value) Endpoint Control Set Register */
 
 #define USBC_UECON0SET_TXINES_Pos   0            /**< \brief (USBC_UECON0SET) TXINE Set */
-#define USBC_UECON0SET_TXINES       (_U(0x1) << USBC_UECON0SET_TXINES_Pos)
+#define USBC_UECON0SET_TXINES       (_U_(0x1) << USBC_UECON0SET_TXINES_Pos)
 #define USBC_UECON0SET_RXOUTES_Pos  1            /**< \brief (USBC_UECON0SET) RXOUTE Set */
-#define USBC_UECON0SET_RXOUTES      (_U(0x1) << USBC_UECON0SET_RXOUTES_Pos)
+#define USBC_UECON0SET_RXOUTES      (_U_(0x1) << USBC_UECON0SET_RXOUTES_Pos)
 #define USBC_UECON0SET_RXSTPES_Pos  2            /**< \brief (USBC_UECON0SET) RXSTPE Set */
-#define USBC_UECON0SET_RXSTPES      (_U(0x1) << USBC_UECON0SET_RXSTPES_Pos)
+#define USBC_UECON0SET_RXSTPES      (_U_(0x1) << USBC_UECON0SET_RXSTPES_Pos)
 #define USBC_UECON0SET_NAKOUTES_Pos 3            /**< \brief (USBC_UECON0SET) NAKOUTE Set */
-#define USBC_UECON0SET_NAKOUTES     (_U(0x1) << USBC_UECON0SET_NAKOUTES_Pos)
+#define USBC_UECON0SET_NAKOUTES     (_U_(0x1) << USBC_UECON0SET_NAKOUTES_Pos)
 #define USBC_UECON0SET_NAKINES_Pos  4            /**< \brief (USBC_UECON0SET) NAKINE Set */
-#define USBC_UECON0SET_NAKINES      (_U(0x1) << USBC_UECON0SET_NAKINES_Pos)
+#define USBC_UECON0SET_NAKINES      (_U_(0x1) << USBC_UECON0SET_NAKINES_Pos)
 #define USBC_UECON0SET_STALLEDES_Pos 6            /**< \brief (USBC_UECON0SET) STALLEDE Set */
-#define USBC_UECON0SET_STALLEDES    (_U(0x1) << USBC_UECON0SET_STALLEDES_Pos)
+#define USBC_UECON0SET_STALLEDES    (_U_(0x1) << USBC_UECON0SET_STALLEDES_Pos)
 #define USBC_UECON0SET_NREPLYS_Pos  8            /**< \brief (USBC_UECON0SET) NREPLY Set */
-#define USBC_UECON0SET_NREPLYS      (_U(0x1) << USBC_UECON0SET_NREPLYS_Pos)
+#define USBC_UECON0SET_NREPLYS      (_U_(0x1) << USBC_UECON0SET_NREPLYS_Pos)
 #define USBC_UECON0SET_RAMACERES_Pos 11           /**< \brief (USBC_UECON0SET) RAMACERE Set */
-#define USBC_UECON0SET_RAMACERES    (_U(0x1) << USBC_UECON0SET_RAMACERES_Pos)
+#define USBC_UECON0SET_RAMACERES    (_U_(0x1) << USBC_UECON0SET_RAMACERES_Pos)
 #define USBC_UECON0SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UECON0SET) NBUSYBKE Set */
-#define USBC_UECON0SET_NBUSYBKES    (_U(0x1) << USBC_UECON0SET_NBUSYBKES_Pos)
+#define USBC_UECON0SET_NBUSYBKES    (_U_(0x1) << USBC_UECON0SET_NBUSYBKES_Pos)
 #define USBC_UECON0SET_KILLBKS_Pos  13           /**< \brief (USBC_UECON0SET) KILLBK Set */
-#define USBC_UECON0SET_KILLBKS      (_U(0x1) << USBC_UECON0SET_KILLBKS_Pos)
+#define USBC_UECON0SET_KILLBKS      (_U_(0x1) << USBC_UECON0SET_KILLBKS_Pos)
 #define USBC_UECON0SET_NYETDISS_Pos 17           /**< \brief (USBC_UECON0SET) NYETDIS Set */
-#define USBC_UECON0SET_NYETDISS     (_U(0x1) << USBC_UECON0SET_NYETDISS_Pos)
+#define USBC_UECON0SET_NYETDISS     (_U_(0x1) << USBC_UECON0SET_NYETDISS_Pos)
 #define USBC_UECON0SET_RSTDTS_Pos   18           /**< \brief (USBC_UECON0SET) RSTDT Set */
-#define USBC_UECON0SET_RSTDTS       (_U(0x1) << USBC_UECON0SET_RSTDTS_Pos)
+#define USBC_UECON0SET_RSTDTS       (_U_(0x1) << USBC_UECON0SET_RSTDTS_Pos)
 #define USBC_UECON0SET_STALLRQS_Pos 19           /**< \brief (USBC_UECON0SET) STALLRQ Set */
-#define USBC_UECON0SET_STALLRQS     (_U(0x1) << USBC_UECON0SET_STALLRQS_Pos)
+#define USBC_UECON0SET_STALLRQS     (_U_(0x1) << USBC_UECON0SET_STALLRQS_Pos)
 #define USBC_UECON0SET_BUSY0S_Pos   24           /**< \brief (USBC_UECON0SET) BUSY0 Set */
-#define USBC_UECON0SET_BUSY0S       (_U(0x1) << USBC_UECON0SET_BUSY0S_Pos)
+#define USBC_UECON0SET_BUSY0S       (_U_(0x1) << USBC_UECON0SET_BUSY0S_Pos)
 #define USBC_UECON0SET_BUSY1S_Pos   25           /**< \brief (USBC_UECON0SET) BUSY1 Set */
-#define USBC_UECON0SET_BUSY1S       (_U(0x1) << USBC_UECON0SET_BUSY1S_Pos)
-#define USBC_UECON0SET_MASK         _U(0x030E395F) /**< \brief (USBC_UECON0SET) MASK Register */
+#define USBC_UECON0SET_BUSY1S       (_U_(0x1) << USBC_UECON0SET_BUSY1S_Pos)
+#define USBC_UECON0SET_MASK         _U_(0x030E395F) /**< \brief (USBC_UECON0SET) MASK Register */
 
 /* -------- USBC_UECON1SET : (USBC Offset: 0x1F4) ( /W 32) Endpoint Control Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -2774,39 +2774,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECON1SET_OFFSET       0x1F4        /**< \brief (USBC_UECON1SET offset) Endpoint Control Set Register */
-#define USBC_UECON1SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON1SET reset_value) Endpoint Control Set Register */
+#define USBC_UECON1SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UECON1SET reset_value) Endpoint Control Set Register */
 
 #define USBC_UECON1SET_TXINES_Pos   0            /**< \brief (USBC_UECON1SET) TXINE Set */
-#define USBC_UECON1SET_TXINES       (_U(0x1) << USBC_UECON1SET_TXINES_Pos)
+#define USBC_UECON1SET_TXINES       (_U_(0x1) << USBC_UECON1SET_TXINES_Pos)
 #define USBC_UECON1SET_RXOUTES_Pos  1            /**< \brief (USBC_UECON1SET) RXOUTE Set */
-#define USBC_UECON1SET_RXOUTES      (_U(0x1) << USBC_UECON1SET_RXOUTES_Pos)
+#define USBC_UECON1SET_RXOUTES      (_U_(0x1) << USBC_UECON1SET_RXOUTES_Pos)
 #define USBC_UECON1SET_RXSTPES_Pos  2            /**< \brief (USBC_UECON1SET) RXSTPE Set */
-#define USBC_UECON1SET_RXSTPES      (_U(0x1) << USBC_UECON1SET_RXSTPES_Pos)
+#define USBC_UECON1SET_RXSTPES      (_U_(0x1) << USBC_UECON1SET_RXSTPES_Pos)
 #define USBC_UECON1SET_NAKOUTES_Pos 3            /**< \brief (USBC_UECON1SET) NAKOUTE Set */
-#define USBC_UECON1SET_NAKOUTES     (_U(0x1) << USBC_UECON1SET_NAKOUTES_Pos)
+#define USBC_UECON1SET_NAKOUTES     (_U_(0x1) << USBC_UECON1SET_NAKOUTES_Pos)
 #define USBC_UECON1SET_NAKINES_Pos  4            /**< \brief (USBC_UECON1SET) NAKINE Set */
-#define USBC_UECON1SET_NAKINES      (_U(0x1) << USBC_UECON1SET_NAKINES_Pos)
+#define USBC_UECON1SET_NAKINES      (_U_(0x1) << USBC_UECON1SET_NAKINES_Pos)
 #define USBC_UECON1SET_STALLEDES_Pos 6            /**< \brief (USBC_UECON1SET) STALLEDE Set */
-#define USBC_UECON1SET_STALLEDES    (_U(0x1) << USBC_UECON1SET_STALLEDES_Pos)
+#define USBC_UECON1SET_STALLEDES    (_U_(0x1) << USBC_UECON1SET_STALLEDES_Pos)
 #define USBC_UECON1SET_NREPLYS_Pos  8            /**< \brief (USBC_UECON1SET) NREPLY Set */
-#define USBC_UECON1SET_NREPLYS      (_U(0x1) << USBC_UECON1SET_NREPLYS_Pos)
+#define USBC_UECON1SET_NREPLYS      (_U_(0x1) << USBC_UECON1SET_NREPLYS_Pos)
 #define USBC_UECON1SET_RAMACERES_Pos 11           /**< \brief (USBC_UECON1SET) RAMACERE Set */
-#define USBC_UECON1SET_RAMACERES    (_U(0x1) << USBC_UECON1SET_RAMACERES_Pos)
+#define USBC_UECON1SET_RAMACERES    (_U_(0x1) << USBC_UECON1SET_RAMACERES_Pos)
 #define USBC_UECON1SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UECON1SET) NBUSYBKE Set */
-#define USBC_UECON1SET_NBUSYBKES    (_U(0x1) << USBC_UECON1SET_NBUSYBKES_Pos)
+#define USBC_UECON1SET_NBUSYBKES    (_U_(0x1) << USBC_UECON1SET_NBUSYBKES_Pos)
 #define USBC_UECON1SET_KILLBKS_Pos  13           /**< \brief (USBC_UECON1SET) KILLBK Set */
-#define USBC_UECON1SET_KILLBKS      (_U(0x1) << USBC_UECON1SET_KILLBKS_Pos)
+#define USBC_UECON1SET_KILLBKS      (_U_(0x1) << USBC_UECON1SET_KILLBKS_Pos)
 #define USBC_UECON1SET_NYETDISS_Pos 17           /**< \brief (USBC_UECON1SET) NYETDIS Set */
-#define USBC_UECON1SET_NYETDISS     (_U(0x1) << USBC_UECON1SET_NYETDISS_Pos)
+#define USBC_UECON1SET_NYETDISS     (_U_(0x1) << USBC_UECON1SET_NYETDISS_Pos)
 #define USBC_UECON1SET_RSTDTS_Pos   18           /**< \brief (USBC_UECON1SET) RSTDT Set */
-#define USBC_UECON1SET_RSTDTS       (_U(0x1) << USBC_UECON1SET_RSTDTS_Pos)
+#define USBC_UECON1SET_RSTDTS       (_U_(0x1) << USBC_UECON1SET_RSTDTS_Pos)
 #define USBC_UECON1SET_STALLRQS_Pos 19           /**< \brief (USBC_UECON1SET) STALLRQ Set */
-#define USBC_UECON1SET_STALLRQS     (_U(0x1) << USBC_UECON1SET_STALLRQS_Pos)
+#define USBC_UECON1SET_STALLRQS     (_U_(0x1) << USBC_UECON1SET_STALLRQS_Pos)
 #define USBC_UECON1SET_BUSY0S_Pos   24           /**< \brief (USBC_UECON1SET) BUSY0 Set */
-#define USBC_UECON1SET_BUSY0S       (_U(0x1) << USBC_UECON1SET_BUSY0S_Pos)
+#define USBC_UECON1SET_BUSY0S       (_U_(0x1) << USBC_UECON1SET_BUSY0S_Pos)
 #define USBC_UECON1SET_BUSY1S_Pos   25           /**< \brief (USBC_UECON1SET) BUSY1 Set */
-#define USBC_UECON1SET_BUSY1S       (_U(0x1) << USBC_UECON1SET_BUSY1S_Pos)
-#define USBC_UECON1SET_MASK         _U(0x030E395F) /**< \brief (USBC_UECON1SET) MASK Register */
+#define USBC_UECON1SET_BUSY1S       (_U_(0x1) << USBC_UECON1SET_BUSY1S_Pos)
+#define USBC_UECON1SET_MASK         _U_(0x030E395F) /**< \brief (USBC_UECON1SET) MASK Register */
 
 /* -------- USBC_UECON2SET : (USBC Offset: 0x1F8) ( /W 32) Endpoint Control Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -2839,39 +2839,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECON2SET_OFFSET       0x1F8        /**< \brief (USBC_UECON2SET offset) Endpoint Control Set Register */
-#define USBC_UECON2SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON2SET reset_value) Endpoint Control Set Register */
+#define USBC_UECON2SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UECON2SET reset_value) Endpoint Control Set Register */
 
 #define USBC_UECON2SET_TXINES_Pos   0            /**< \brief (USBC_UECON2SET) TXINE Set */
-#define USBC_UECON2SET_TXINES       (_U(0x1) << USBC_UECON2SET_TXINES_Pos)
+#define USBC_UECON2SET_TXINES       (_U_(0x1) << USBC_UECON2SET_TXINES_Pos)
 #define USBC_UECON2SET_RXOUTES_Pos  1            /**< \brief (USBC_UECON2SET) RXOUTE Set */
-#define USBC_UECON2SET_RXOUTES      (_U(0x1) << USBC_UECON2SET_RXOUTES_Pos)
+#define USBC_UECON2SET_RXOUTES      (_U_(0x1) << USBC_UECON2SET_RXOUTES_Pos)
 #define USBC_UECON2SET_RXSTPES_Pos  2            /**< \brief (USBC_UECON2SET) RXSTPE Set */
-#define USBC_UECON2SET_RXSTPES      (_U(0x1) << USBC_UECON2SET_RXSTPES_Pos)
+#define USBC_UECON2SET_RXSTPES      (_U_(0x1) << USBC_UECON2SET_RXSTPES_Pos)
 #define USBC_UECON2SET_NAKOUTES_Pos 3            /**< \brief (USBC_UECON2SET) NAKOUTE Set */
-#define USBC_UECON2SET_NAKOUTES     (_U(0x1) << USBC_UECON2SET_NAKOUTES_Pos)
+#define USBC_UECON2SET_NAKOUTES     (_U_(0x1) << USBC_UECON2SET_NAKOUTES_Pos)
 #define USBC_UECON2SET_NAKINES_Pos  4            /**< \brief (USBC_UECON2SET) NAKINE Set */
-#define USBC_UECON2SET_NAKINES      (_U(0x1) << USBC_UECON2SET_NAKINES_Pos)
+#define USBC_UECON2SET_NAKINES      (_U_(0x1) << USBC_UECON2SET_NAKINES_Pos)
 #define USBC_UECON2SET_STALLEDES_Pos 6            /**< \brief (USBC_UECON2SET) STALLEDE Set */
-#define USBC_UECON2SET_STALLEDES    (_U(0x1) << USBC_UECON2SET_STALLEDES_Pos)
+#define USBC_UECON2SET_STALLEDES    (_U_(0x1) << USBC_UECON2SET_STALLEDES_Pos)
 #define USBC_UECON2SET_NREPLYS_Pos  8            /**< \brief (USBC_UECON2SET) NREPLY Set */
-#define USBC_UECON2SET_NREPLYS      (_U(0x1) << USBC_UECON2SET_NREPLYS_Pos)
+#define USBC_UECON2SET_NREPLYS      (_U_(0x1) << USBC_UECON2SET_NREPLYS_Pos)
 #define USBC_UECON2SET_RAMACERES_Pos 11           /**< \brief (USBC_UECON2SET) RAMACERE Set */
-#define USBC_UECON2SET_RAMACERES    (_U(0x1) << USBC_UECON2SET_RAMACERES_Pos)
+#define USBC_UECON2SET_RAMACERES    (_U_(0x1) << USBC_UECON2SET_RAMACERES_Pos)
 #define USBC_UECON2SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UECON2SET) NBUSYBKE Set */
-#define USBC_UECON2SET_NBUSYBKES    (_U(0x1) << USBC_UECON2SET_NBUSYBKES_Pos)
+#define USBC_UECON2SET_NBUSYBKES    (_U_(0x1) << USBC_UECON2SET_NBUSYBKES_Pos)
 #define USBC_UECON2SET_KILLBKS_Pos  13           /**< \brief (USBC_UECON2SET) KILLBK Set */
-#define USBC_UECON2SET_KILLBKS      (_U(0x1) << USBC_UECON2SET_KILLBKS_Pos)
+#define USBC_UECON2SET_KILLBKS      (_U_(0x1) << USBC_UECON2SET_KILLBKS_Pos)
 #define USBC_UECON2SET_NYETDISS_Pos 17           /**< \brief (USBC_UECON2SET) NYETDIS Set */
-#define USBC_UECON2SET_NYETDISS     (_U(0x1) << USBC_UECON2SET_NYETDISS_Pos)
+#define USBC_UECON2SET_NYETDISS     (_U_(0x1) << USBC_UECON2SET_NYETDISS_Pos)
 #define USBC_UECON2SET_RSTDTS_Pos   18           /**< \brief (USBC_UECON2SET) RSTDT Set */
-#define USBC_UECON2SET_RSTDTS       (_U(0x1) << USBC_UECON2SET_RSTDTS_Pos)
+#define USBC_UECON2SET_RSTDTS       (_U_(0x1) << USBC_UECON2SET_RSTDTS_Pos)
 #define USBC_UECON2SET_STALLRQS_Pos 19           /**< \brief (USBC_UECON2SET) STALLRQ Set */
-#define USBC_UECON2SET_STALLRQS     (_U(0x1) << USBC_UECON2SET_STALLRQS_Pos)
+#define USBC_UECON2SET_STALLRQS     (_U_(0x1) << USBC_UECON2SET_STALLRQS_Pos)
 #define USBC_UECON2SET_BUSY0S_Pos   24           /**< \brief (USBC_UECON2SET) BUSY0 Set */
-#define USBC_UECON2SET_BUSY0S       (_U(0x1) << USBC_UECON2SET_BUSY0S_Pos)
+#define USBC_UECON2SET_BUSY0S       (_U_(0x1) << USBC_UECON2SET_BUSY0S_Pos)
 #define USBC_UECON2SET_BUSY1S_Pos   25           /**< \brief (USBC_UECON2SET) BUSY1 Set */
-#define USBC_UECON2SET_BUSY1S       (_U(0x1) << USBC_UECON2SET_BUSY1S_Pos)
-#define USBC_UECON2SET_MASK         _U(0x030E395F) /**< \brief (USBC_UECON2SET) MASK Register */
+#define USBC_UECON2SET_BUSY1S       (_U_(0x1) << USBC_UECON2SET_BUSY1S_Pos)
+#define USBC_UECON2SET_MASK         _U_(0x030E395F) /**< \brief (USBC_UECON2SET) MASK Register */
 
 /* -------- USBC_UECON3SET : (USBC Offset: 0x1FC) ( /W 32) Endpoint Control Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -2904,39 +2904,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECON3SET_OFFSET       0x1FC        /**< \brief (USBC_UECON3SET offset) Endpoint Control Set Register */
-#define USBC_UECON3SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON3SET reset_value) Endpoint Control Set Register */
+#define USBC_UECON3SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UECON3SET reset_value) Endpoint Control Set Register */
 
 #define USBC_UECON3SET_TXINES_Pos   0            /**< \brief (USBC_UECON3SET) TXINE Set */
-#define USBC_UECON3SET_TXINES       (_U(0x1) << USBC_UECON3SET_TXINES_Pos)
+#define USBC_UECON3SET_TXINES       (_U_(0x1) << USBC_UECON3SET_TXINES_Pos)
 #define USBC_UECON3SET_RXOUTES_Pos  1            /**< \brief (USBC_UECON3SET) RXOUTE Set */
-#define USBC_UECON3SET_RXOUTES      (_U(0x1) << USBC_UECON3SET_RXOUTES_Pos)
+#define USBC_UECON3SET_RXOUTES      (_U_(0x1) << USBC_UECON3SET_RXOUTES_Pos)
 #define USBC_UECON3SET_RXSTPES_Pos  2            /**< \brief (USBC_UECON3SET) RXSTPE Set */
-#define USBC_UECON3SET_RXSTPES      (_U(0x1) << USBC_UECON3SET_RXSTPES_Pos)
+#define USBC_UECON3SET_RXSTPES      (_U_(0x1) << USBC_UECON3SET_RXSTPES_Pos)
 #define USBC_UECON3SET_NAKOUTES_Pos 3            /**< \brief (USBC_UECON3SET) NAKOUTE Set */
-#define USBC_UECON3SET_NAKOUTES     (_U(0x1) << USBC_UECON3SET_NAKOUTES_Pos)
+#define USBC_UECON3SET_NAKOUTES     (_U_(0x1) << USBC_UECON3SET_NAKOUTES_Pos)
 #define USBC_UECON3SET_NAKINES_Pos  4            /**< \brief (USBC_UECON3SET) NAKINE Set */
-#define USBC_UECON3SET_NAKINES      (_U(0x1) << USBC_UECON3SET_NAKINES_Pos)
+#define USBC_UECON3SET_NAKINES      (_U_(0x1) << USBC_UECON3SET_NAKINES_Pos)
 #define USBC_UECON3SET_STALLEDES_Pos 6            /**< \brief (USBC_UECON3SET) STALLEDE Set */
-#define USBC_UECON3SET_STALLEDES    (_U(0x1) << USBC_UECON3SET_STALLEDES_Pos)
+#define USBC_UECON3SET_STALLEDES    (_U_(0x1) << USBC_UECON3SET_STALLEDES_Pos)
 #define USBC_UECON3SET_NREPLYS_Pos  8            /**< \brief (USBC_UECON3SET) NREPLY Set */
-#define USBC_UECON3SET_NREPLYS      (_U(0x1) << USBC_UECON3SET_NREPLYS_Pos)
+#define USBC_UECON3SET_NREPLYS      (_U_(0x1) << USBC_UECON3SET_NREPLYS_Pos)
 #define USBC_UECON3SET_RAMACERES_Pos 11           /**< \brief (USBC_UECON3SET) RAMACERE Set */
-#define USBC_UECON3SET_RAMACERES    (_U(0x1) << USBC_UECON3SET_RAMACERES_Pos)
+#define USBC_UECON3SET_RAMACERES    (_U_(0x1) << USBC_UECON3SET_RAMACERES_Pos)
 #define USBC_UECON3SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UECON3SET) NBUSYBKE Set */
-#define USBC_UECON3SET_NBUSYBKES    (_U(0x1) << USBC_UECON3SET_NBUSYBKES_Pos)
+#define USBC_UECON3SET_NBUSYBKES    (_U_(0x1) << USBC_UECON3SET_NBUSYBKES_Pos)
 #define USBC_UECON3SET_KILLBKS_Pos  13           /**< \brief (USBC_UECON3SET) KILLBK Set */
-#define USBC_UECON3SET_KILLBKS      (_U(0x1) << USBC_UECON3SET_KILLBKS_Pos)
+#define USBC_UECON3SET_KILLBKS      (_U_(0x1) << USBC_UECON3SET_KILLBKS_Pos)
 #define USBC_UECON3SET_NYETDISS_Pos 17           /**< \brief (USBC_UECON3SET) NYETDIS Set */
-#define USBC_UECON3SET_NYETDISS     (_U(0x1) << USBC_UECON3SET_NYETDISS_Pos)
+#define USBC_UECON3SET_NYETDISS     (_U_(0x1) << USBC_UECON3SET_NYETDISS_Pos)
 #define USBC_UECON3SET_RSTDTS_Pos   18           /**< \brief (USBC_UECON3SET) RSTDT Set */
-#define USBC_UECON3SET_RSTDTS       (_U(0x1) << USBC_UECON3SET_RSTDTS_Pos)
+#define USBC_UECON3SET_RSTDTS       (_U_(0x1) << USBC_UECON3SET_RSTDTS_Pos)
 #define USBC_UECON3SET_STALLRQS_Pos 19           /**< \brief (USBC_UECON3SET) STALLRQ Set */
-#define USBC_UECON3SET_STALLRQS     (_U(0x1) << USBC_UECON3SET_STALLRQS_Pos)
+#define USBC_UECON3SET_STALLRQS     (_U_(0x1) << USBC_UECON3SET_STALLRQS_Pos)
 #define USBC_UECON3SET_BUSY0S_Pos   24           /**< \brief (USBC_UECON3SET) BUSY0 Set */
-#define USBC_UECON3SET_BUSY0S       (_U(0x1) << USBC_UECON3SET_BUSY0S_Pos)
+#define USBC_UECON3SET_BUSY0S       (_U_(0x1) << USBC_UECON3SET_BUSY0S_Pos)
 #define USBC_UECON3SET_BUSY1S_Pos   25           /**< \brief (USBC_UECON3SET) BUSY1 Set */
-#define USBC_UECON3SET_BUSY1S       (_U(0x1) << USBC_UECON3SET_BUSY1S_Pos)
-#define USBC_UECON3SET_MASK         _U(0x030E395F) /**< \brief (USBC_UECON3SET) MASK Register */
+#define USBC_UECON3SET_BUSY1S       (_U_(0x1) << USBC_UECON3SET_BUSY1S_Pos)
+#define USBC_UECON3SET_MASK         _U_(0x030E395F) /**< \brief (USBC_UECON3SET) MASK Register */
 
 /* -------- USBC_UECON4SET : (USBC Offset: 0x200) ( /W 32) Endpoint Control Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -2969,39 +2969,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECON4SET_OFFSET       0x200        /**< \brief (USBC_UECON4SET offset) Endpoint Control Set Register */
-#define USBC_UECON4SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON4SET reset_value) Endpoint Control Set Register */
+#define USBC_UECON4SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UECON4SET reset_value) Endpoint Control Set Register */
 
 #define USBC_UECON4SET_TXINES_Pos   0            /**< \brief (USBC_UECON4SET) TXINE Set */
-#define USBC_UECON4SET_TXINES       (_U(0x1) << USBC_UECON4SET_TXINES_Pos)
+#define USBC_UECON4SET_TXINES       (_U_(0x1) << USBC_UECON4SET_TXINES_Pos)
 #define USBC_UECON4SET_RXOUTES_Pos  1            /**< \brief (USBC_UECON4SET) RXOUTE Set */
-#define USBC_UECON4SET_RXOUTES      (_U(0x1) << USBC_UECON4SET_RXOUTES_Pos)
+#define USBC_UECON4SET_RXOUTES      (_U_(0x1) << USBC_UECON4SET_RXOUTES_Pos)
 #define USBC_UECON4SET_RXSTPES_Pos  2            /**< \brief (USBC_UECON4SET) RXSTPE Set */
-#define USBC_UECON4SET_RXSTPES      (_U(0x1) << USBC_UECON4SET_RXSTPES_Pos)
+#define USBC_UECON4SET_RXSTPES      (_U_(0x1) << USBC_UECON4SET_RXSTPES_Pos)
 #define USBC_UECON4SET_NAKOUTES_Pos 3            /**< \brief (USBC_UECON4SET) NAKOUTE Set */
-#define USBC_UECON4SET_NAKOUTES     (_U(0x1) << USBC_UECON4SET_NAKOUTES_Pos)
+#define USBC_UECON4SET_NAKOUTES     (_U_(0x1) << USBC_UECON4SET_NAKOUTES_Pos)
 #define USBC_UECON4SET_NAKINES_Pos  4            /**< \brief (USBC_UECON4SET) NAKINE Set */
-#define USBC_UECON4SET_NAKINES      (_U(0x1) << USBC_UECON4SET_NAKINES_Pos)
+#define USBC_UECON4SET_NAKINES      (_U_(0x1) << USBC_UECON4SET_NAKINES_Pos)
 #define USBC_UECON4SET_STALLEDES_Pos 6            /**< \brief (USBC_UECON4SET) STALLEDE Set */
-#define USBC_UECON4SET_STALLEDES    (_U(0x1) << USBC_UECON4SET_STALLEDES_Pos)
+#define USBC_UECON4SET_STALLEDES    (_U_(0x1) << USBC_UECON4SET_STALLEDES_Pos)
 #define USBC_UECON4SET_NREPLYS_Pos  8            /**< \brief (USBC_UECON4SET) NREPLY Set */
-#define USBC_UECON4SET_NREPLYS      (_U(0x1) << USBC_UECON4SET_NREPLYS_Pos)
+#define USBC_UECON4SET_NREPLYS      (_U_(0x1) << USBC_UECON4SET_NREPLYS_Pos)
 #define USBC_UECON4SET_RAMACERES_Pos 11           /**< \brief (USBC_UECON4SET) RAMACERE Set */
-#define USBC_UECON4SET_RAMACERES    (_U(0x1) << USBC_UECON4SET_RAMACERES_Pos)
+#define USBC_UECON4SET_RAMACERES    (_U_(0x1) << USBC_UECON4SET_RAMACERES_Pos)
 #define USBC_UECON4SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UECON4SET) NBUSYBKE Set */
-#define USBC_UECON4SET_NBUSYBKES    (_U(0x1) << USBC_UECON4SET_NBUSYBKES_Pos)
+#define USBC_UECON4SET_NBUSYBKES    (_U_(0x1) << USBC_UECON4SET_NBUSYBKES_Pos)
 #define USBC_UECON4SET_KILLBKS_Pos  13           /**< \brief (USBC_UECON4SET) KILLBK Set */
-#define USBC_UECON4SET_KILLBKS      (_U(0x1) << USBC_UECON4SET_KILLBKS_Pos)
+#define USBC_UECON4SET_KILLBKS      (_U_(0x1) << USBC_UECON4SET_KILLBKS_Pos)
 #define USBC_UECON4SET_NYETDISS_Pos 17           /**< \brief (USBC_UECON4SET) NYETDIS Set */
-#define USBC_UECON4SET_NYETDISS     (_U(0x1) << USBC_UECON4SET_NYETDISS_Pos)
+#define USBC_UECON4SET_NYETDISS     (_U_(0x1) << USBC_UECON4SET_NYETDISS_Pos)
 #define USBC_UECON4SET_RSTDTS_Pos   18           /**< \brief (USBC_UECON4SET) RSTDT Set */
-#define USBC_UECON4SET_RSTDTS       (_U(0x1) << USBC_UECON4SET_RSTDTS_Pos)
+#define USBC_UECON4SET_RSTDTS       (_U_(0x1) << USBC_UECON4SET_RSTDTS_Pos)
 #define USBC_UECON4SET_STALLRQS_Pos 19           /**< \brief (USBC_UECON4SET) STALLRQ Set */
-#define USBC_UECON4SET_STALLRQS     (_U(0x1) << USBC_UECON4SET_STALLRQS_Pos)
+#define USBC_UECON4SET_STALLRQS     (_U_(0x1) << USBC_UECON4SET_STALLRQS_Pos)
 #define USBC_UECON4SET_BUSY0S_Pos   24           /**< \brief (USBC_UECON4SET) BUSY0 Set */
-#define USBC_UECON4SET_BUSY0S       (_U(0x1) << USBC_UECON4SET_BUSY0S_Pos)
+#define USBC_UECON4SET_BUSY0S       (_U_(0x1) << USBC_UECON4SET_BUSY0S_Pos)
 #define USBC_UECON4SET_BUSY1S_Pos   25           /**< \brief (USBC_UECON4SET) BUSY1 Set */
-#define USBC_UECON4SET_BUSY1S       (_U(0x1) << USBC_UECON4SET_BUSY1S_Pos)
-#define USBC_UECON4SET_MASK         _U(0x030E395F) /**< \brief (USBC_UECON4SET) MASK Register */
+#define USBC_UECON4SET_BUSY1S       (_U_(0x1) << USBC_UECON4SET_BUSY1S_Pos)
+#define USBC_UECON4SET_MASK         _U_(0x030E395F) /**< \brief (USBC_UECON4SET) MASK Register */
 
 /* -------- USBC_UECON5SET : (USBC Offset: 0x204) ( /W 32) Endpoint Control Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3034,39 +3034,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECON5SET_OFFSET       0x204        /**< \brief (USBC_UECON5SET offset) Endpoint Control Set Register */
-#define USBC_UECON5SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON5SET reset_value) Endpoint Control Set Register */
+#define USBC_UECON5SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UECON5SET reset_value) Endpoint Control Set Register */
 
 #define USBC_UECON5SET_TXINES_Pos   0            /**< \brief (USBC_UECON5SET) TXINE Set */
-#define USBC_UECON5SET_TXINES       (_U(0x1) << USBC_UECON5SET_TXINES_Pos)
+#define USBC_UECON5SET_TXINES       (_U_(0x1) << USBC_UECON5SET_TXINES_Pos)
 #define USBC_UECON5SET_RXOUTES_Pos  1            /**< \brief (USBC_UECON5SET) RXOUTE Set */
-#define USBC_UECON5SET_RXOUTES      (_U(0x1) << USBC_UECON5SET_RXOUTES_Pos)
+#define USBC_UECON5SET_RXOUTES      (_U_(0x1) << USBC_UECON5SET_RXOUTES_Pos)
 #define USBC_UECON5SET_RXSTPES_Pos  2            /**< \brief (USBC_UECON5SET) RXSTPE Set */
-#define USBC_UECON5SET_RXSTPES      (_U(0x1) << USBC_UECON5SET_RXSTPES_Pos)
+#define USBC_UECON5SET_RXSTPES      (_U_(0x1) << USBC_UECON5SET_RXSTPES_Pos)
 #define USBC_UECON5SET_NAKOUTES_Pos 3            /**< \brief (USBC_UECON5SET) NAKOUTE Set */
-#define USBC_UECON5SET_NAKOUTES     (_U(0x1) << USBC_UECON5SET_NAKOUTES_Pos)
+#define USBC_UECON5SET_NAKOUTES     (_U_(0x1) << USBC_UECON5SET_NAKOUTES_Pos)
 #define USBC_UECON5SET_NAKINES_Pos  4            /**< \brief (USBC_UECON5SET) NAKINE Set */
-#define USBC_UECON5SET_NAKINES      (_U(0x1) << USBC_UECON5SET_NAKINES_Pos)
+#define USBC_UECON5SET_NAKINES      (_U_(0x1) << USBC_UECON5SET_NAKINES_Pos)
 #define USBC_UECON5SET_STALLEDES_Pos 6            /**< \brief (USBC_UECON5SET) STALLEDE Set */
-#define USBC_UECON5SET_STALLEDES    (_U(0x1) << USBC_UECON5SET_STALLEDES_Pos)
+#define USBC_UECON5SET_STALLEDES    (_U_(0x1) << USBC_UECON5SET_STALLEDES_Pos)
 #define USBC_UECON5SET_NREPLYS_Pos  8            /**< \brief (USBC_UECON5SET) NREPLY Set */
-#define USBC_UECON5SET_NREPLYS      (_U(0x1) << USBC_UECON5SET_NREPLYS_Pos)
+#define USBC_UECON5SET_NREPLYS      (_U_(0x1) << USBC_UECON5SET_NREPLYS_Pos)
 #define USBC_UECON5SET_RAMACERES_Pos 11           /**< \brief (USBC_UECON5SET) RAMACERE Set */
-#define USBC_UECON5SET_RAMACERES    (_U(0x1) << USBC_UECON5SET_RAMACERES_Pos)
+#define USBC_UECON5SET_RAMACERES    (_U_(0x1) << USBC_UECON5SET_RAMACERES_Pos)
 #define USBC_UECON5SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UECON5SET) NBUSYBKE Set */
-#define USBC_UECON5SET_NBUSYBKES    (_U(0x1) << USBC_UECON5SET_NBUSYBKES_Pos)
+#define USBC_UECON5SET_NBUSYBKES    (_U_(0x1) << USBC_UECON5SET_NBUSYBKES_Pos)
 #define USBC_UECON5SET_KILLBKS_Pos  13           /**< \brief (USBC_UECON5SET) KILLBK Set */
-#define USBC_UECON5SET_KILLBKS      (_U(0x1) << USBC_UECON5SET_KILLBKS_Pos)
+#define USBC_UECON5SET_KILLBKS      (_U_(0x1) << USBC_UECON5SET_KILLBKS_Pos)
 #define USBC_UECON5SET_NYETDISS_Pos 17           /**< \brief (USBC_UECON5SET) NYETDIS Set */
-#define USBC_UECON5SET_NYETDISS     (_U(0x1) << USBC_UECON5SET_NYETDISS_Pos)
+#define USBC_UECON5SET_NYETDISS     (_U_(0x1) << USBC_UECON5SET_NYETDISS_Pos)
 #define USBC_UECON5SET_RSTDTS_Pos   18           /**< \brief (USBC_UECON5SET) RSTDT Set */
-#define USBC_UECON5SET_RSTDTS       (_U(0x1) << USBC_UECON5SET_RSTDTS_Pos)
+#define USBC_UECON5SET_RSTDTS       (_U_(0x1) << USBC_UECON5SET_RSTDTS_Pos)
 #define USBC_UECON5SET_STALLRQS_Pos 19           /**< \brief (USBC_UECON5SET) STALLRQ Set */
-#define USBC_UECON5SET_STALLRQS     (_U(0x1) << USBC_UECON5SET_STALLRQS_Pos)
+#define USBC_UECON5SET_STALLRQS     (_U_(0x1) << USBC_UECON5SET_STALLRQS_Pos)
 #define USBC_UECON5SET_BUSY0S_Pos   24           /**< \brief (USBC_UECON5SET) BUSY0 Set */
-#define USBC_UECON5SET_BUSY0S       (_U(0x1) << USBC_UECON5SET_BUSY0S_Pos)
+#define USBC_UECON5SET_BUSY0S       (_U_(0x1) << USBC_UECON5SET_BUSY0S_Pos)
 #define USBC_UECON5SET_BUSY1S_Pos   25           /**< \brief (USBC_UECON5SET) BUSY1 Set */
-#define USBC_UECON5SET_BUSY1S       (_U(0x1) << USBC_UECON5SET_BUSY1S_Pos)
-#define USBC_UECON5SET_MASK         _U(0x030E395F) /**< \brief (USBC_UECON5SET) MASK Register */
+#define USBC_UECON5SET_BUSY1S       (_U_(0x1) << USBC_UECON5SET_BUSY1S_Pos)
+#define USBC_UECON5SET_MASK         _U_(0x030E395F) /**< \brief (USBC_UECON5SET) MASK Register */
 
 /* -------- USBC_UECON6SET : (USBC Offset: 0x208) ( /W 32) Endpoint Control Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3099,39 +3099,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECON6SET_OFFSET       0x208        /**< \brief (USBC_UECON6SET offset) Endpoint Control Set Register */
-#define USBC_UECON6SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON6SET reset_value) Endpoint Control Set Register */
+#define USBC_UECON6SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UECON6SET reset_value) Endpoint Control Set Register */
 
 #define USBC_UECON6SET_TXINES_Pos   0            /**< \brief (USBC_UECON6SET) TXINE Set */
-#define USBC_UECON6SET_TXINES       (_U(0x1) << USBC_UECON6SET_TXINES_Pos)
+#define USBC_UECON6SET_TXINES       (_U_(0x1) << USBC_UECON6SET_TXINES_Pos)
 #define USBC_UECON6SET_RXOUTES_Pos  1            /**< \brief (USBC_UECON6SET) RXOUTE Set */
-#define USBC_UECON6SET_RXOUTES      (_U(0x1) << USBC_UECON6SET_RXOUTES_Pos)
+#define USBC_UECON6SET_RXOUTES      (_U_(0x1) << USBC_UECON6SET_RXOUTES_Pos)
 #define USBC_UECON6SET_RXSTPES_Pos  2            /**< \brief (USBC_UECON6SET) RXSTPE Set */
-#define USBC_UECON6SET_RXSTPES      (_U(0x1) << USBC_UECON6SET_RXSTPES_Pos)
+#define USBC_UECON6SET_RXSTPES      (_U_(0x1) << USBC_UECON6SET_RXSTPES_Pos)
 #define USBC_UECON6SET_NAKOUTES_Pos 3            /**< \brief (USBC_UECON6SET) NAKOUTE Set */
-#define USBC_UECON6SET_NAKOUTES     (_U(0x1) << USBC_UECON6SET_NAKOUTES_Pos)
+#define USBC_UECON6SET_NAKOUTES     (_U_(0x1) << USBC_UECON6SET_NAKOUTES_Pos)
 #define USBC_UECON6SET_NAKINES_Pos  4            /**< \brief (USBC_UECON6SET) NAKINE Set */
-#define USBC_UECON6SET_NAKINES      (_U(0x1) << USBC_UECON6SET_NAKINES_Pos)
+#define USBC_UECON6SET_NAKINES      (_U_(0x1) << USBC_UECON6SET_NAKINES_Pos)
 #define USBC_UECON6SET_STALLEDES_Pos 6            /**< \brief (USBC_UECON6SET) STALLEDE Set */
-#define USBC_UECON6SET_STALLEDES    (_U(0x1) << USBC_UECON6SET_STALLEDES_Pos)
+#define USBC_UECON6SET_STALLEDES    (_U_(0x1) << USBC_UECON6SET_STALLEDES_Pos)
 #define USBC_UECON6SET_NREPLYS_Pos  8            /**< \brief (USBC_UECON6SET) NREPLY Set */
-#define USBC_UECON6SET_NREPLYS      (_U(0x1) << USBC_UECON6SET_NREPLYS_Pos)
+#define USBC_UECON6SET_NREPLYS      (_U_(0x1) << USBC_UECON6SET_NREPLYS_Pos)
 #define USBC_UECON6SET_RAMACERES_Pos 11           /**< \brief (USBC_UECON6SET) RAMACERE Set */
-#define USBC_UECON6SET_RAMACERES    (_U(0x1) << USBC_UECON6SET_RAMACERES_Pos)
+#define USBC_UECON6SET_RAMACERES    (_U_(0x1) << USBC_UECON6SET_RAMACERES_Pos)
 #define USBC_UECON6SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UECON6SET) NBUSYBKE Set */
-#define USBC_UECON6SET_NBUSYBKES    (_U(0x1) << USBC_UECON6SET_NBUSYBKES_Pos)
+#define USBC_UECON6SET_NBUSYBKES    (_U_(0x1) << USBC_UECON6SET_NBUSYBKES_Pos)
 #define USBC_UECON6SET_KILLBKS_Pos  13           /**< \brief (USBC_UECON6SET) KILLBK Set */
-#define USBC_UECON6SET_KILLBKS      (_U(0x1) << USBC_UECON6SET_KILLBKS_Pos)
+#define USBC_UECON6SET_KILLBKS      (_U_(0x1) << USBC_UECON6SET_KILLBKS_Pos)
 #define USBC_UECON6SET_NYETDISS_Pos 17           /**< \brief (USBC_UECON6SET) NYETDIS Set */
-#define USBC_UECON6SET_NYETDISS     (_U(0x1) << USBC_UECON6SET_NYETDISS_Pos)
+#define USBC_UECON6SET_NYETDISS     (_U_(0x1) << USBC_UECON6SET_NYETDISS_Pos)
 #define USBC_UECON6SET_RSTDTS_Pos   18           /**< \brief (USBC_UECON6SET) RSTDT Set */
-#define USBC_UECON6SET_RSTDTS       (_U(0x1) << USBC_UECON6SET_RSTDTS_Pos)
+#define USBC_UECON6SET_RSTDTS       (_U_(0x1) << USBC_UECON6SET_RSTDTS_Pos)
 #define USBC_UECON6SET_STALLRQS_Pos 19           /**< \brief (USBC_UECON6SET) STALLRQ Set */
-#define USBC_UECON6SET_STALLRQS     (_U(0x1) << USBC_UECON6SET_STALLRQS_Pos)
+#define USBC_UECON6SET_STALLRQS     (_U_(0x1) << USBC_UECON6SET_STALLRQS_Pos)
 #define USBC_UECON6SET_BUSY0S_Pos   24           /**< \brief (USBC_UECON6SET) BUSY0 Set */
-#define USBC_UECON6SET_BUSY0S       (_U(0x1) << USBC_UECON6SET_BUSY0S_Pos)
+#define USBC_UECON6SET_BUSY0S       (_U_(0x1) << USBC_UECON6SET_BUSY0S_Pos)
 #define USBC_UECON6SET_BUSY1S_Pos   25           /**< \brief (USBC_UECON6SET) BUSY1 Set */
-#define USBC_UECON6SET_BUSY1S       (_U(0x1) << USBC_UECON6SET_BUSY1S_Pos)
-#define USBC_UECON6SET_MASK         _U(0x030E395F) /**< \brief (USBC_UECON6SET) MASK Register */
+#define USBC_UECON6SET_BUSY1S       (_U_(0x1) << USBC_UECON6SET_BUSY1S_Pos)
+#define USBC_UECON6SET_MASK         _U_(0x030E395F) /**< \brief (USBC_UECON6SET) MASK Register */
 
 /* -------- USBC_UECON7SET : (USBC Offset: 0x20C) ( /W 32) Endpoint Control Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3164,39 +3164,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECON7SET_OFFSET       0x20C        /**< \brief (USBC_UECON7SET offset) Endpoint Control Set Register */
-#define USBC_UECON7SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON7SET reset_value) Endpoint Control Set Register */
+#define USBC_UECON7SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UECON7SET reset_value) Endpoint Control Set Register */
 
 #define USBC_UECON7SET_TXINES_Pos   0            /**< \brief (USBC_UECON7SET) TXINE Set */
-#define USBC_UECON7SET_TXINES       (_U(0x1) << USBC_UECON7SET_TXINES_Pos)
+#define USBC_UECON7SET_TXINES       (_U_(0x1) << USBC_UECON7SET_TXINES_Pos)
 #define USBC_UECON7SET_RXOUTES_Pos  1            /**< \brief (USBC_UECON7SET) RXOUTE Set */
-#define USBC_UECON7SET_RXOUTES      (_U(0x1) << USBC_UECON7SET_RXOUTES_Pos)
+#define USBC_UECON7SET_RXOUTES      (_U_(0x1) << USBC_UECON7SET_RXOUTES_Pos)
 #define USBC_UECON7SET_RXSTPES_Pos  2            /**< \brief (USBC_UECON7SET) RXSTPE Set */
-#define USBC_UECON7SET_RXSTPES      (_U(0x1) << USBC_UECON7SET_RXSTPES_Pos)
+#define USBC_UECON7SET_RXSTPES      (_U_(0x1) << USBC_UECON7SET_RXSTPES_Pos)
 #define USBC_UECON7SET_NAKOUTES_Pos 3            /**< \brief (USBC_UECON7SET) NAKOUTE Set */
-#define USBC_UECON7SET_NAKOUTES     (_U(0x1) << USBC_UECON7SET_NAKOUTES_Pos)
+#define USBC_UECON7SET_NAKOUTES     (_U_(0x1) << USBC_UECON7SET_NAKOUTES_Pos)
 #define USBC_UECON7SET_NAKINES_Pos  4            /**< \brief (USBC_UECON7SET) NAKINE Set */
-#define USBC_UECON7SET_NAKINES      (_U(0x1) << USBC_UECON7SET_NAKINES_Pos)
+#define USBC_UECON7SET_NAKINES      (_U_(0x1) << USBC_UECON7SET_NAKINES_Pos)
 #define USBC_UECON7SET_STALLEDES_Pos 6            /**< \brief (USBC_UECON7SET) STALLEDE Set */
-#define USBC_UECON7SET_STALLEDES    (_U(0x1) << USBC_UECON7SET_STALLEDES_Pos)
+#define USBC_UECON7SET_STALLEDES    (_U_(0x1) << USBC_UECON7SET_STALLEDES_Pos)
 #define USBC_UECON7SET_NREPLYS_Pos  8            /**< \brief (USBC_UECON7SET) NREPLY Set */
-#define USBC_UECON7SET_NREPLYS      (_U(0x1) << USBC_UECON7SET_NREPLYS_Pos)
+#define USBC_UECON7SET_NREPLYS      (_U_(0x1) << USBC_UECON7SET_NREPLYS_Pos)
 #define USBC_UECON7SET_RAMACERES_Pos 11           /**< \brief (USBC_UECON7SET) RAMACERE Set */
-#define USBC_UECON7SET_RAMACERES    (_U(0x1) << USBC_UECON7SET_RAMACERES_Pos)
+#define USBC_UECON7SET_RAMACERES    (_U_(0x1) << USBC_UECON7SET_RAMACERES_Pos)
 #define USBC_UECON7SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UECON7SET) NBUSYBKE Set */
-#define USBC_UECON7SET_NBUSYBKES    (_U(0x1) << USBC_UECON7SET_NBUSYBKES_Pos)
+#define USBC_UECON7SET_NBUSYBKES    (_U_(0x1) << USBC_UECON7SET_NBUSYBKES_Pos)
 #define USBC_UECON7SET_KILLBKS_Pos  13           /**< \brief (USBC_UECON7SET) KILLBK Set */
-#define USBC_UECON7SET_KILLBKS      (_U(0x1) << USBC_UECON7SET_KILLBKS_Pos)
+#define USBC_UECON7SET_KILLBKS      (_U_(0x1) << USBC_UECON7SET_KILLBKS_Pos)
 #define USBC_UECON7SET_NYETDISS_Pos 17           /**< \brief (USBC_UECON7SET) NYETDIS Set */
-#define USBC_UECON7SET_NYETDISS     (_U(0x1) << USBC_UECON7SET_NYETDISS_Pos)
+#define USBC_UECON7SET_NYETDISS     (_U_(0x1) << USBC_UECON7SET_NYETDISS_Pos)
 #define USBC_UECON7SET_RSTDTS_Pos   18           /**< \brief (USBC_UECON7SET) RSTDT Set */
-#define USBC_UECON7SET_RSTDTS       (_U(0x1) << USBC_UECON7SET_RSTDTS_Pos)
+#define USBC_UECON7SET_RSTDTS       (_U_(0x1) << USBC_UECON7SET_RSTDTS_Pos)
 #define USBC_UECON7SET_STALLRQS_Pos 19           /**< \brief (USBC_UECON7SET) STALLRQ Set */
-#define USBC_UECON7SET_STALLRQS     (_U(0x1) << USBC_UECON7SET_STALLRQS_Pos)
+#define USBC_UECON7SET_STALLRQS     (_U_(0x1) << USBC_UECON7SET_STALLRQS_Pos)
 #define USBC_UECON7SET_BUSY0S_Pos   24           /**< \brief (USBC_UECON7SET) BUSY0 Set */
-#define USBC_UECON7SET_BUSY0S       (_U(0x1) << USBC_UECON7SET_BUSY0S_Pos)
+#define USBC_UECON7SET_BUSY0S       (_U_(0x1) << USBC_UECON7SET_BUSY0S_Pos)
 #define USBC_UECON7SET_BUSY1S_Pos   25           /**< \brief (USBC_UECON7SET) BUSY1 Set */
-#define USBC_UECON7SET_BUSY1S       (_U(0x1) << USBC_UECON7SET_BUSY1S_Pos)
-#define USBC_UECON7SET_MASK         _U(0x030E395F) /**< \brief (USBC_UECON7SET) MASK Register */
+#define USBC_UECON7SET_BUSY1S       (_U_(0x1) << USBC_UECON7SET_BUSY1S_Pos)
+#define USBC_UECON7SET_MASK         _U_(0x030E395F) /**< \brief (USBC_UECON7SET) MASK Register */
 
 /* -------- USBC_UECON0CLR : (USBC Offset: 0x220) ( /W 32) Endpoint Control Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3230,37 +3230,37 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECON0CLR_OFFSET       0x220        /**< \brief (USBC_UECON0CLR offset) Endpoint Control Clear Register */
-#define USBC_UECON0CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON0CLR reset_value) Endpoint Control Clear Register */
+#define USBC_UECON0CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UECON0CLR reset_value) Endpoint Control Clear Register */
 
 #define USBC_UECON0CLR_TXINEC_Pos   0            /**< \brief (USBC_UECON0CLR) TXINE Clear */
-#define USBC_UECON0CLR_TXINEC       (_U(0x1) << USBC_UECON0CLR_TXINEC_Pos)
+#define USBC_UECON0CLR_TXINEC       (_U_(0x1) << USBC_UECON0CLR_TXINEC_Pos)
 #define USBC_UECON0CLR_RXOUTEC_Pos  1            /**< \brief (USBC_UECON0CLR) RXOUTE Clear */
-#define USBC_UECON0CLR_RXOUTEC      (_U(0x1) << USBC_UECON0CLR_RXOUTEC_Pos)
+#define USBC_UECON0CLR_RXOUTEC      (_U_(0x1) << USBC_UECON0CLR_RXOUTEC_Pos)
 #define USBC_UECON0CLR_RXSTPEC_Pos  2            /**< \brief (USBC_UECON0CLR) RXSTPE Clear */
-#define USBC_UECON0CLR_RXSTPEC      (_U(0x1) << USBC_UECON0CLR_RXSTPEC_Pos)
+#define USBC_UECON0CLR_RXSTPEC      (_U_(0x1) << USBC_UECON0CLR_RXSTPEC_Pos)
 #define USBC_UECON0CLR_NAKOUTEC_Pos 3            /**< \brief (USBC_UECON0CLR) NAKOUTE Clear */
-#define USBC_UECON0CLR_NAKOUTEC     (_U(0x1) << USBC_UECON0CLR_NAKOUTEC_Pos)
+#define USBC_UECON0CLR_NAKOUTEC     (_U_(0x1) << USBC_UECON0CLR_NAKOUTEC_Pos)
 #define USBC_UECON0CLR_NAKINEC_Pos  4            /**< \brief (USBC_UECON0CLR) NAKINE Clear */
-#define USBC_UECON0CLR_NAKINEC      (_U(0x1) << USBC_UECON0CLR_NAKINEC_Pos)
+#define USBC_UECON0CLR_NAKINEC      (_U_(0x1) << USBC_UECON0CLR_NAKINEC_Pos)
 #define USBC_UECON0CLR_STALLEDEC_Pos 6            /**< \brief (USBC_UECON0CLR) STALLEDE Clear */
-#define USBC_UECON0CLR_STALLEDEC    (_U(0x1) << USBC_UECON0CLR_STALLEDEC_Pos)
+#define USBC_UECON0CLR_STALLEDEC    (_U_(0x1) << USBC_UECON0CLR_STALLEDEC_Pos)
 #define USBC_UECON0CLR_NREPLYC_Pos  8            /**< \brief (USBC_UECON0CLR) NREPLY Clear */
-#define USBC_UECON0CLR_NREPLYC      (_U(0x1) << USBC_UECON0CLR_NREPLYC_Pos)
+#define USBC_UECON0CLR_NREPLYC      (_U_(0x1) << USBC_UECON0CLR_NREPLYC_Pos)
 #define USBC_UECON0CLR_RAMACEREC_Pos 11           /**< \brief (USBC_UECON0CLR) RAMACERE Clear */
-#define USBC_UECON0CLR_RAMACEREC    (_U(0x1) << USBC_UECON0CLR_RAMACEREC_Pos)
+#define USBC_UECON0CLR_RAMACEREC    (_U_(0x1) << USBC_UECON0CLR_RAMACEREC_Pos)
 #define USBC_UECON0CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UECON0CLR) NBUSYBKE Clear */
-#define USBC_UECON0CLR_NBUSYBKEC    (_U(0x1) << USBC_UECON0CLR_NBUSYBKEC_Pos)
+#define USBC_UECON0CLR_NBUSYBKEC    (_U_(0x1) << USBC_UECON0CLR_NBUSYBKEC_Pos)
 #define USBC_UECON0CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UECON0CLR) FIFOCON Clear */
-#define USBC_UECON0CLR_FIFOCONC     (_U(0x1) << USBC_UECON0CLR_FIFOCONC_Pos)
+#define USBC_UECON0CLR_FIFOCONC     (_U_(0x1) << USBC_UECON0CLR_FIFOCONC_Pos)
 #define USBC_UECON0CLR_NYETDISC_Pos 17           /**< \brief (USBC_UECON0CLR) NYETDIS Clear */
-#define USBC_UECON0CLR_NYETDISC     (_U(0x1) << USBC_UECON0CLR_NYETDISC_Pos)
+#define USBC_UECON0CLR_NYETDISC     (_U_(0x1) << USBC_UECON0CLR_NYETDISC_Pos)
 #define USBC_UECON0CLR_STALLRQC_Pos 19           /**< \brief (USBC_UECON0CLR) STALLRQ Clear */
-#define USBC_UECON0CLR_STALLRQC     (_U(0x1) << USBC_UECON0CLR_STALLRQC_Pos)
+#define USBC_UECON0CLR_STALLRQC     (_U_(0x1) << USBC_UECON0CLR_STALLRQC_Pos)
 #define USBC_UECON0CLR_BUSY0C_Pos   24           /**< \brief (USBC_UECON0CLR) BUSY0 Clear */
-#define USBC_UECON0CLR_BUSY0C       (_U(0x1) << USBC_UECON0CLR_BUSY0C_Pos)
+#define USBC_UECON0CLR_BUSY0C       (_U_(0x1) << USBC_UECON0CLR_BUSY0C_Pos)
 #define USBC_UECON0CLR_BUSY1C_Pos   25           /**< \brief (USBC_UECON0CLR) BUSY1 Clear */
-#define USBC_UECON0CLR_BUSY1C       (_U(0x1) << USBC_UECON0CLR_BUSY1C_Pos)
-#define USBC_UECON0CLR_MASK         _U(0x030A595F) /**< \brief (USBC_UECON0CLR) MASK Register */
+#define USBC_UECON0CLR_BUSY1C       (_U_(0x1) << USBC_UECON0CLR_BUSY1C_Pos)
+#define USBC_UECON0CLR_MASK         _U_(0x030A595F) /**< \brief (USBC_UECON0CLR) MASK Register */
 
 /* -------- USBC_UECON1CLR : (USBC Offset: 0x224) ( /W 32) TXINE Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3294,37 +3294,37 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECON1CLR_OFFSET       0x224        /**< \brief (USBC_UECON1CLR offset) TXINE Clear */
-#define USBC_UECON1CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON1CLR reset_value) TXINE Clear */
+#define USBC_UECON1CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UECON1CLR reset_value) TXINE Clear */
 
 #define USBC_UECON1CLR_TXINEC_Pos   0            /**< \brief (USBC_UECON1CLR) TXINE Clear */
-#define USBC_UECON1CLR_TXINEC       (_U(0x1) << USBC_UECON1CLR_TXINEC_Pos)
+#define USBC_UECON1CLR_TXINEC       (_U_(0x1) << USBC_UECON1CLR_TXINEC_Pos)
 #define USBC_UECON1CLR_RXOUTEC_Pos  1            /**< \brief (USBC_UECON1CLR) RXOUTE Clear */
-#define USBC_UECON1CLR_RXOUTEC      (_U(0x1) << USBC_UECON1CLR_RXOUTEC_Pos)
+#define USBC_UECON1CLR_RXOUTEC      (_U_(0x1) << USBC_UECON1CLR_RXOUTEC_Pos)
 #define USBC_UECON1CLR_RXSTPEC_Pos  2            /**< \brief (USBC_UECON1CLR) RXOUTE Clear */
-#define USBC_UECON1CLR_RXSTPEC      (_U(0x1) << USBC_UECON1CLR_RXSTPEC_Pos)
+#define USBC_UECON1CLR_RXSTPEC      (_U_(0x1) << USBC_UECON1CLR_RXSTPEC_Pos)
 #define USBC_UECON1CLR_NAKOUTEC_Pos 3            /**< \brief (USBC_UECON1CLR) NAKOUTE Clear */
-#define USBC_UECON1CLR_NAKOUTEC     (_U(0x1) << USBC_UECON1CLR_NAKOUTEC_Pos)
+#define USBC_UECON1CLR_NAKOUTEC     (_U_(0x1) << USBC_UECON1CLR_NAKOUTEC_Pos)
 #define USBC_UECON1CLR_NAKINEC_Pos  4            /**< \brief (USBC_UECON1CLR) NAKINE Clear */
-#define USBC_UECON1CLR_NAKINEC      (_U(0x1) << USBC_UECON1CLR_NAKINEC_Pos)
+#define USBC_UECON1CLR_NAKINEC      (_U_(0x1) << USBC_UECON1CLR_NAKINEC_Pos)
 #define USBC_UECON1CLR_STALLEDEC_Pos 6            /**< \brief (USBC_UECON1CLR) RXSTPE Clear */
-#define USBC_UECON1CLR_STALLEDEC    (_U(0x1) << USBC_UECON1CLR_STALLEDEC_Pos)
+#define USBC_UECON1CLR_STALLEDEC    (_U_(0x1) << USBC_UECON1CLR_STALLEDEC_Pos)
 #define USBC_UECON1CLR_NREPLYC_Pos  8            /**< \brief (USBC_UECON1CLR) NREPLY Clear */
-#define USBC_UECON1CLR_NREPLYC      (_U(0x1) << USBC_UECON1CLR_NREPLYC_Pos)
+#define USBC_UECON1CLR_NREPLYC      (_U_(0x1) << USBC_UECON1CLR_NREPLYC_Pos)
 #define USBC_UECON1CLR_RAMACEREC_Pos 11           /**< \brief (USBC_UECON1CLR) RAMACERE Clear */
-#define USBC_UECON1CLR_RAMACEREC    (_U(0x1) << USBC_UECON1CLR_RAMACEREC_Pos)
+#define USBC_UECON1CLR_RAMACEREC    (_U_(0x1) << USBC_UECON1CLR_RAMACEREC_Pos)
 #define USBC_UECON1CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UECON1CLR) NBUSYBKE Clear */
-#define USBC_UECON1CLR_NBUSYBKEC    (_U(0x1) << USBC_UECON1CLR_NBUSYBKEC_Pos)
+#define USBC_UECON1CLR_NBUSYBKEC    (_U_(0x1) << USBC_UECON1CLR_NBUSYBKEC_Pos)
 #define USBC_UECON1CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UECON1CLR) FIFOCON Clear */
-#define USBC_UECON1CLR_FIFOCONC     (_U(0x1) << USBC_UECON1CLR_FIFOCONC_Pos)
+#define USBC_UECON1CLR_FIFOCONC     (_U_(0x1) << USBC_UECON1CLR_FIFOCONC_Pos)
 #define USBC_UECON1CLR_NYETDISC_Pos 17           /**< \brief (USBC_UECON1CLR) NYETDIS Clear */
-#define USBC_UECON1CLR_NYETDISC     (_U(0x1) << USBC_UECON1CLR_NYETDISC_Pos)
+#define USBC_UECON1CLR_NYETDISC     (_U_(0x1) << USBC_UECON1CLR_NYETDISC_Pos)
 #define USBC_UECON1CLR_STALLRQC_Pos 19           /**< \brief (USBC_UECON1CLR) STALLEDE Clear */
-#define USBC_UECON1CLR_STALLRQC     (_U(0x1) << USBC_UECON1CLR_STALLRQC_Pos)
+#define USBC_UECON1CLR_STALLRQC     (_U_(0x1) << USBC_UECON1CLR_STALLRQC_Pos)
 #define USBC_UECON1CLR_BUSY0C_Pos   24           /**< \brief (USBC_UECON1CLR) BUSY0 Clear */
-#define USBC_UECON1CLR_BUSY0C       (_U(0x1) << USBC_UECON1CLR_BUSY0C_Pos)
+#define USBC_UECON1CLR_BUSY0C       (_U_(0x1) << USBC_UECON1CLR_BUSY0C_Pos)
 #define USBC_UECON1CLR_BUSY1C_Pos   25           /**< \brief (USBC_UECON1CLR) BUSY1 Clear */
-#define USBC_UECON1CLR_BUSY1C       (_U(0x1) << USBC_UECON1CLR_BUSY1C_Pos)
-#define USBC_UECON1CLR_MASK         _U(0x030A595F) /**< \brief (USBC_UECON1CLR) MASK Register */
+#define USBC_UECON1CLR_BUSY1C       (_U_(0x1) << USBC_UECON1CLR_BUSY1C_Pos)
+#define USBC_UECON1CLR_MASK         _U_(0x030A595F) /**< \brief (USBC_UECON1CLR) MASK Register */
 
 /* -------- USBC_UECON2CLR : (USBC Offset: 0x228) ( /W 32) TXINE Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3358,37 +3358,37 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECON2CLR_OFFSET       0x228        /**< \brief (USBC_UECON2CLR offset) TXINE Clear */
-#define USBC_UECON2CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON2CLR reset_value) TXINE Clear */
+#define USBC_UECON2CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UECON2CLR reset_value) TXINE Clear */
 
 #define USBC_UECON2CLR_TXINEC_Pos   0            /**< \brief (USBC_UECON2CLR) TXINE Clear */
-#define USBC_UECON2CLR_TXINEC       (_U(0x1) << USBC_UECON2CLR_TXINEC_Pos)
+#define USBC_UECON2CLR_TXINEC       (_U_(0x1) << USBC_UECON2CLR_TXINEC_Pos)
 #define USBC_UECON2CLR_RXOUTEC_Pos  1            /**< \brief (USBC_UECON2CLR) RXOUTE Clear */
-#define USBC_UECON2CLR_RXOUTEC      (_U(0x1) << USBC_UECON2CLR_RXOUTEC_Pos)
+#define USBC_UECON2CLR_RXOUTEC      (_U_(0x1) << USBC_UECON2CLR_RXOUTEC_Pos)
 #define USBC_UECON2CLR_RXSTPEC_Pos  2            /**< \brief (USBC_UECON2CLR) RXOUTE Clear */
-#define USBC_UECON2CLR_RXSTPEC      (_U(0x1) << USBC_UECON2CLR_RXSTPEC_Pos)
+#define USBC_UECON2CLR_RXSTPEC      (_U_(0x1) << USBC_UECON2CLR_RXSTPEC_Pos)
 #define USBC_UECON2CLR_NAKOUTEC_Pos 3            /**< \brief (USBC_UECON2CLR) NAKOUTE Clear */
-#define USBC_UECON2CLR_NAKOUTEC     (_U(0x1) << USBC_UECON2CLR_NAKOUTEC_Pos)
+#define USBC_UECON2CLR_NAKOUTEC     (_U_(0x1) << USBC_UECON2CLR_NAKOUTEC_Pos)
 #define USBC_UECON2CLR_NAKINEC_Pos  4            /**< \brief (USBC_UECON2CLR) NAKINE Clear */
-#define USBC_UECON2CLR_NAKINEC      (_U(0x1) << USBC_UECON2CLR_NAKINEC_Pos)
+#define USBC_UECON2CLR_NAKINEC      (_U_(0x1) << USBC_UECON2CLR_NAKINEC_Pos)
 #define USBC_UECON2CLR_STALLEDEC_Pos 6            /**< \brief (USBC_UECON2CLR) RXSTPE Clear */
-#define USBC_UECON2CLR_STALLEDEC    (_U(0x1) << USBC_UECON2CLR_STALLEDEC_Pos)
+#define USBC_UECON2CLR_STALLEDEC    (_U_(0x1) << USBC_UECON2CLR_STALLEDEC_Pos)
 #define USBC_UECON2CLR_NREPLYC_Pos  8            /**< \brief (USBC_UECON2CLR) NREPLY Clear */
-#define USBC_UECON2CLR_NREPLYC      (_U(0x1) << USBC_UECON2CLR_NREPLYC_Pos)
+#define USBC_UECON2CLR_NREPLYC      (_U_(0x1) << USBC_UECON2CLR_NREPLYC_Pos)
 #define USBC_UECON2CLR_RAMACEREC_Pos 11           /**< \brief (USBC_UECON2CLR) RAMACERE Clear */
-#define USBC_UECON2CLR_RAMACEREC    (_U(0x1) << USBC_UECON2CLR_RAMACEREC_Pos)
+#define USBC_UECON2CLR_RAMACEREC    (_U_(0x1) << USBC_UECON2CLR_RAMACEREC_Pos)
 #define USBC_UECON2CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UECON2CLR) NBUSYBKE Clear */
-#define USBC_UECON2CLR_NBUSYBKEC    (_U(0x1) << USBC_UECON2CLR_NBUSYBKEC_Pos)
+#define USBC_UECON2CLR_NBUSYBKEC    (_U_(0x1) << USBC_UECON2CLR_NBUSYBKEC_Pos)
 #define USBC_UECON2CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UECON2CLR) FIFOCON Clear */
-#define USBC_UECON2CLR_FIFOCONC     (_U(0x1) << USBC_UECON2CLR_FIFOCONC_Pos)
+#define USBC_UECON2CLR_FIFOCONC     (_U_(0x1) << USBC_UECON2CLR_FIFOCONC_Pos)
 #define USBC_UECON2CLR_NYETDISC_Pos 17           /**< \brief (USBC_UECON2CLR) NYETDIS Clear */
-#define USBC_UECON2CLR_NYETDISC     (_U(0x1) << USBC_UECON2CLR_NYETDISC_Pos)
+#define USBC_UECON2CLR_NYETDISC     (_U_(0x1) << USBC_UECON2CLR_NYETDISC_Pos)
 #define USBC_UECON2CLR_STALLRQC_Pos 19           /**< \brief (USBC_UECON2CLR) STALLEDE Clear */
-#define USBC_UECON2CLR_STALLRQC     (_U(0x1) << USBC_UECON2CLR_STALLRQC_Pos)
+#define USBC_UECON2CLR_STALLRQC     (_U_(0x1) << USBC_UECON2CLR_STALLRQC_Pos)
 #define USBC_UECON2CLR_BUSY0C_Pos   24           /**< \brief (USBC_UECON2CLR) BUSY0 Clear */
-#define USBC_UECON2CLR_BUSY0C       (_U(0x1) << USBC_UECON2CLR_BUSY0C_Pos)
+#define USBC_UECON2CLR_BUSY0C       (_U_(0x1) << USBC_UECON2CLR_BUSY0C_Pos)
 #define USBC_UECON2CLR_BUSY1C_Pos   25           /**< \brief (USBC_UECON2CLR) BUSY1 Clear */
-#define USBC_UECON2CLR_BUSY1C       (_U(0x1) << USBC_UECON2CLR_BUSY1C_Pos)
-#define USBC_UECON2CLR_MASK         _U(0x030A595F) /**< \brief (USBC_UECON2CLR) MASK Register */
+#define USBC_UECON2CLR_BUSY1C       (_U_(0x1) << USBC_UECON2CLR_BUSY1C_Pos)
+#define USBC_UECON2CLR_MASK         _U_(0x030A595F) /**< \brief (USBC_UECON2CLR) MASK Register */
 
 /* -------- USBC_UECON3CLR : (USBC Offset: 0x22C) ( /W 32) TXINE Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3422,37 +3422,37 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECON3CLR_OFFSET       0x22C        /**< \brief (USBC_UECON3CLR offset) TXINE Clear */
-#define USBC_UECON3CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON3CLR reset_value) TXINE Clear */
+#define USBC_UECON3CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UECON3CLR reset_value) TXINE Clear */
 
 #define USBC_UECON3CLR_TXINEC_Pos   0            /**< \brief (USBC_UECON3CLR) TXINE Clear */
-#define USBC_UECON3CLR_TXINEC       (_U(0x1) << USBC_UECON3CLR_TXINEC_Pos)
+#define USBC_UECON3CLR_TXINEC       (_U_(0x1) << USBC_UECON3CLR_TXINEC_Pos)
 #define USBC_UECON3CLR_RXOUTEC_Pos  1            /**< \brief (USBC_UECON3CLR) RXOUTE Clear */
-#define USBC_UECON3CLR_RXOUTEC      (_U(0x1) << USBC_UECON3CLR_RXOUTEC_Pos)
+#define USBC_UECON3CLR_RXOUTEC      (_U_(0x1) << USBC_UECON3CLR_RXOUTEC_Pos)
 #define USBC_UECON3CLR_RXSTPEC_Pos  2            /**< \brief (USBC_UECON3CLR) RXOUTE Clear */
-#define USBC_UECON3CLR_RXSTPEC      (_U(0x1) << USBC_UECON3CLR_RXSTPEC_Pos)
+#define USBC_UECON3CLR_RXSTPEC      (_U_(0x1) << USBC_UECON3CLR_RXSTPEC_Pos)
 #define USBC_UECON3CLR_NAKOUTEC_Pos 3            /**< \brief (USBC_UECON3CLR) NAKOUTE Clear */
-#define USBC_UECON3CLR_NAKOUTEC     (_U(0x1) << USBC_UECON3CLR_NAKOUTEC_Pos)
+#define USBC_UECON3CLR_NAKOUTEC     (_U_(0x1) << USBC_UECON3CLR_NAKOUTEC_Pos)
 #define USBC_UECON3CLR_NAKINEC_Pos  4            /**< \brief (USBC_UECON3CLR) NAKINE Clear */
-#define USBC_UECON3CLR_NAKINEC      (_U(0x1) << USBC_UECON3CLR_NAKINEC_Pos)
+#define USBC_UECON3CLR_NAKINEC      (_U_(0x1) << USBC_UECON3CLR_NAKINEC_Pos)
 #define USBC_UECON3CLR_STALLEDEC_Pos 6            /**< \brief (USBC_UECON3CLR) RXSTPE Clear */
-#define USBC_UECON3CLR_STALLEDEC    (_U(0x1) << USBC_UECON3CLR_STALLEDEC_Pos)
+#define USBC_UECON3CLR_STALLEDEC    (_U_(0x1) << USBC_UECON3CLR_STALLEDEC_Pos)
 #define USBC_UECON3CLR_NREPLYC_Pos  8            /**< \brief (USBC_UECON3CLR) NREPLY Clear */
-#define USBC_UECON3CLR_NREPLYC      (_U(0x1) << USBC_UECON3CLR_NREPLYC_Pos)
+#define USBC_UECON3CLR_NREPLYC      (_U_(0x1) << USBC_UECON3CLR_NREPLYC_Pos)
 #define USBC_UECON3CLR_RAMACEREC_Pos 11           /**< \brief (USBC_UECON3CLR) RAMACERE Clear */
-#define USBC_UECON3CLR_RAMACEREC    (_U(0x1) << USBC_UECON3CLR_RAMACEREC_Pos)
+#define USBC_UECON3CLR_RAMACEREC    (_U_(0x1) << USBC_UECON3CLR_RAMACEREC_Pos)
 #define USBC_UECON3CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UECON3CLR) NBUSYBKE Clear */
-#define USBC_UECON3CLR_NBUSYBKEC    (_U(0x1) << USBC_UECON3CLR_NBUSYBKEC_Pos)
+#define USBC_UECON3CLR_NBUSYBKEC    (_U_(0x1) << USBC_UECON3CLR_NBUSYBKEC_Pos)
 #define USBC_UECON3CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UECON3CLR) FIFOCON Clear */
-#define USBC_UECON3CLR_FIFOCONC     (_U(0x1) << USBC_UECON3CLR_FIFOCONC_Pos)
+#define USBC_UECON3CLR_FIFOCONC     (_U_(0x1) << USBC_UECON3CLR_FIFOCONC_Pos)
 #define USBC_UECON3CLR_NYETDISC_Pos 17           /**< \brief (USBC_UECON3CLR) NYETDIS Clear */
-#define USBC_UECON3CLR_NYETDISC     (_U(0x1) << USBC_UECON3CLR_NYETDISC_Pos)
+#define USBC_UECON3CLR_NYETDISC     (_U_(0x1) << USBC_UECON3CLR_NYETDISC_Pos)
 #define USBC_UECON3CLR_STALLRQC_Pos 19           /**< \brief (USBC_UECON3CLR) STALLEDE Clear */
-#define USBC_UECON3CLR_STALLRQC     (_U(0x1) << USBC_UECON3CLR_STALLRQC_Pos)
+#define USBC_UECON3CLR_STALLRQC     (_U_(0x1) << USBC_UECON3CLR_STALLRQC_Pos)
 #define USBC_UECON3CLR_BUSY0C_Pos   24           /**< \brief (USBC_UECON3CLR) BUSY0 Clear */
-#define USBC_UECON3CLR_BUSY0C       (_U(0x1) << USBC_UECON3CLR_BUSY0C_Pos)
+#define USBC_UECON3CLR_BUSY0C       (_U_(0x1) << USBC_UECON3CLR_BUSY0C_Pos)
 #define USBC_UECON3CLR_BUSY1C_Pos   25           /**< \brief (USBC_UECON3CLR) BUSY1 Clear */
-#define USBC_UECON3CLR_BUSY1C       (_U(0x1) << USBC_UECON3CLR_BUSY1C_Pos)
-#define USBC_UECON3CLR_MASK         _U(0x030A595F) /**< \brief (USBC_UECON3CLR) MASK Register */
+#define USBC_UECON3CLR_BUSY1C       (_U_(0x1) << USBC_UECON3CLR_BUSY1C_Pos)
+#define USBC_UECON3CLR_MASK         _U_(0x030A595F) /**< \brief (USBC_UECON3CLR) MASK Register */
 
 /* -------- USBC_UECON4CLR : (USBC Offset: 0x230) ( /W 32) TXINE Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3486,37 +3486,37 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECON4CLR_OFFSET       0x230        /**< \brief (USBC_UECON4CLR offset) TXINE Clear */
-#define USBC_UECON4CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON4CLR reset_value) TXINE Clear */
+#define USBC_UECON4CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UECON4CLR reset_value) TXINE Clear */
 
 #define USBC_UECON4CLR_TXINEC_Pos   0            /**< \brief (USBC_UECON4CLR) TXINE Clear */
-#define USBC_UECON4CLR_TXINEC       (_U(0x1) << USBC_UECON4CLR_TXINEC_Pos)
+#define USBC_UECON4CLR_TXINEC       (_U_(0x1) << USBC_UECON4CLR_TXINEC_Pos)
 #define USBC_UECON4CLR_RXOUTEC_Pos  1            /**< \brief (USBC_UECON4CLR) RXOUTE Clear */
-#define USBC_UECON4CLR_RXOUTEC      (_U(0x1) << USBC_UECON4CLR_RXOUTEC_Pos)
+#define USBC_UECON4CLR_RXOUTEC      (_U_(0x1) << USBC_UECON4CLR_RXOUTEC_Pos)
 #define USBC_UECON4CLR_RXSTPEC_Pos  2            /**< \brief (USBC_UECON4CLR) RXOUTE Clear */
-#define USBC_UECON4CLR_RXSTPEC      (_U(0x1) << USBC_UECON4CLR_RXSTPEC_Pos)
+#define USBC_UECON4CLR_RXSTPEC      (_U_(0x1) << USBC_UECON4CLR_RXSTPEC_Pos)
 #define USBC_UECON4CLR_NAKOUTEC_Pos 3            /**< \brief (USBC_UECON4CLR) NAKOUTE Clear */
-#define USBC_UECON4CLR_NAKOUTEC     (_U(0x1) << USBC_UECON4CLR_NAKOUTEC_Pos)
+#define USBC_UECON4CLR_NAKOUTEC     (_U_(0x1) << USBC_UECON4CLR_NAKOUTEC_Pos)
 #define USBC_UECON4CLR_NAKINEC_Pos  4            /**< \brief (USBC_UECON4CLR) NAKINE Clear */
-#define USBC_UECON4CLR_NAKINEC      (_U(0x1) << USBC_UECON4CLR_NAKINEC_Pos)
+#define USBC_UECON4CLR_NAKINEC      (_U_(0x1) << USBC_UECON4CLR_NAKINEC_Pos)
 #define USBC_UECON4CLR_STALLEDEC_Pos 6            /**< \brief (USBC_UECON4CLR) RXSTPE Clear */
-#define USBC_UECON4CLR_STALLEDEC    (_U(0x1) << USBC_UECON4CLR_STALLEDEC_Pos)
+#define USBC_UECON4CLR_STALLEDEC    (_U_(0x1) << USBC_UECON4CLR_STALLEDEC_Pos)
 #define USBC_UECON4CLR_NREPLYC_Pos  8            /**< \brief (USBC_UECON4CLR) NREPLY Clear */
-#define USBC_UECON4CLR_NREPLYC      (_U(0x1) << USBC_UECON4CLR_NREPLYC_Pos)
+#define USBC_UECON4CLR_NREPLYC      (_U_(0x1) << USBC_UECON4CLR_NREPLYC_Pos)
 #define USBC_UECON4CLR_RAMACEREC_Pos 11           /**< \brief (USBC_UECON4CLR) RAMACERE Clear */
-#define USBC_UECON4CLR_RAMACEREC    (_U(0x1) << USBC_UECON4CLR_RAMACEREC_Pos)
+#define USBC_UECON4CLR_RAMACEREC    (_U_(0x1) << USBC_UECON4CLR_RAMACEREC_Pos)
 #define USBC_UECON4CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UECON4CLR) NBUSYBKE Clear */
-#define USBC_UECON4CLR_NBUSYBKEC    (_U(0x1) << USBC_UECON4CLR_NBUSYBKEC_Pos)
+#define USBC_UECON4CLR_NBUSYBKEC    (_U_(0x1) << USBC_UECON4CLR_NBUSYBKEC_Pos)
 #define USBC_UECON4CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UECON4CLR) FIFOCON Clear */
-#define USBC_UECON4CLR_FIFOCONC     (_U(0x1) << USBC_UECON4CLR_FIFOCONC_Pos)
+#define USBC_UECON4CLR_FIFOCONC     (_U_(0x1) << USBC_UECON4CLR_FIFOCONC_Pos)
 #define USBC_UECON4CLR_NYETDISC_Pos 17           /**< \brief (USBC_UECON4CLR) NYETDIS Clear */
-#define USBC_UECON4CLR_NYETDISC     (_U(0x1) << USBC_UECON4CLR_NYETDISC_Pos)
+#define USBC_UECON4CLR_NYETDISC     (_U_(0x1) << USBC_UECON4CLR_NYETDISC_Pos)
 #define USBC_UECON4CLR_STALLRQC_Pos 19           /**< \brief (USBC_UECON4CLR) STALLEDE Clear */
-#define USBC_UECON4CLR_STALLRQC     (_U(0x1) << USBC_UECON4CLR_STALLRQC_Pos)
+#define USBC_UECON4CLR_STALLRQC     (_U_(0x1) << USBC_UECON4CLR_STALLRQC_Pos)
 #define USBC_UECON4CLR_BUSY0C_Pos   24           /**< \brief (USBC_UECON4CLR) BUSY0 Clear */
-#define USBC_UECON4CLR_BUSY0C       (_U(0x1) << USBC_UECON4CLR_BUSY0C_Pos)
+#define USBC_UECON4CLR_BUSY0C       (_U_(0x1) << USBC_UECON4CLR_BUSY0C_Pos)
 #define USBC_UECON4CLR_BUSY1C_Pos   25           /**< \brief (USBC_UECON4CLR) BUSY1 Clear */
-#define USBC_UECON4CLR_BUSY1C       (_U(0x1) << USBC_UECON4CLR_BUSY1C_Pos)
-#define USBC_UECON4CLR_MASK         _U(0x030A595F) /**< \brief (USBC_UECON4CLR) MASK Register */
+#define USBC_UECON4CLR_BUSY1C       (_U_(0x1) << USBC_UECON4CLR_BUSY1C_Pos)
+#define USBC_UECON4CLR_MASK         _U_(0x030A595F) /**< \brief (USBC_UECON4CLR) MASK Register */
 
 /* -------- USBC_UECON5CLR : (USBC Offset: 0x234) ( /W 32) TXINE Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3550,37 +3550,37 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECON5CLR_OFFSET       0x234        /**< \brief (USBC_UECON5CLR offset) TXINE Clear */
-#define USBC_UECON5CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON5CLR reset_value) TXINE Clear */
+#define USBC_UECON5CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UECON5CLR reset_value) TXINE Clear */
 
 #define USBC_UECON5CLR_TXINEC_Pos   0            /**< \brief (USBC_UECON5CLR) TXINE Clear */
-#define USBC_UECON5CLR_TXINEC       (_U(0x1) << USBC_UECON5CLR_TXINEC_Pos)
+#define USBC_UECON5CLR_TXINEC       (_U_(0x1) << USBC_UECON5CLR_TXINEC_Pos)
 #define USBC_UECON5CLR_RXOUTEC_Pos  1            /**< \brief (USBC_UECON5CLR) RXOUTE Clear */
-#define USBC_UECON5CLR_RXOUTEC      (_U(0x1) << USBC_UECON5CLR_RXOUTEC_Pos)
+#define USBC_UECON5CLR_RXOUTEC      (_U_(0x1) << USBC_UECON5CLR_RXOUTEC_Pos)
 #define USBC_UECON5CLR_RXSTPEC_Pos  2            /**< \brief (USBC_UECON5CLR) RXOUTE Clear */
-#define USBC_UECON5CLR_RXSTPEC      (_U(0x1) << USBC_UECON5CLR_RXSTPEC_Pos)
+#define USBC_UECON5CLR_RXSTPEC      (_U_(0x1) << USBC_UECON5CLR_RXSTPEC_Pos)
 #define USBC_UECON5CLR_NAKOUTEC_Pos 3            /**< \brief (USBC_UECON5CLR) NAKOUTE Clear */
-#define USBC_UECON5CLR_NAKOUTEC     (_U(0x1) << USBC_UECON5CLR_NAKOUTEC_Pos)
+#define USBC_UECON5CLR_NAKOUTEC     (_U_(0x1) << USBC_UECON5CLR_NAKOUTEC_Pos)
 #define USBC_UECON5CLR_NAKINEC_Pos  4            /**< \brief (USBC_UECON5CLR) NAKINE Clear */
-#define USBC_UECON5CLR_NAKINEC      (_U(0x1) << USBC_UECON5CLR_NAKINEC_Pos)
+#define USBC_UECON5CLR_NAKINEC      (_U_(0x1) << USBC_UECON5CLR_NAKINEC_Pos)
 #define USBC_UECON5CLR_STALLEDEC_Pos 6            /**< \brief (USBC_UECON5CLR) RXSTPE Clear */
-#define USBC_UECON5CLR_STALLEDEC    (_U(0x1) << USBC_UECON5CLR_STALLEDEC_Pos)
+#define USBC_UECON5CLR_STALLEDEC    (_U_(0x1) << USBC_UECON5CLR_STALLEDEC_Pos)
 #define USBC_UECON5CLR_NREPLYC_Pos  8            /**< \brief (USBC_UECON5CLR) NREPLY Clear */
-#define USBC_UECON5CLR_NREPLYC      (_U(0x1) << USBC_UECON5CLR_NREPLYC_Pos)
+#define USBC_UECON5CLR_NREPLYC      (_U_(0x1) << USBC_UECON5CLR_NREPLYC_Pos)
 #define USBC_UECON5CLR_RAMACEREC_Pos 11           /**< \brief (USBC_UECON5CLR) RAMACERE Clear */
-#define USBC_UECON5CLR_RAMACEREC    (_U(0x1) << USBC_UECON5CLR_RAMACEREC_Pos)
+#define USBC_UECON5CLR_RAMACEREC    (_U_(0x1) << USBC_UECON5CLR_RAMACEREC_Pos)
 #define USBC_UECON5CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UECON5CLR) NBUSYBKE Clear */
-#define USBC_UECON5CLR_NBUSYBKEC    (_U(0x1) << USBC_UECON5CLR_NBUSYBKEC_Pos)
+#define USBC_UECON5CLR_NBUSYBKEC    (_U_(0x1) << USBC_UECON5CLR_NBUSYBKEC_Pos)
 #define USBC_UECON5CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UECON5CLR) FIFOCON Clear */
-#define USBC_UECON5CLR_FIFOCONC     (_U(0x1) << USBC_UECON5CLR_FIFOCONC_Pos)
+#define USBC_UECON5CLR_FIFOCONC     (_U_(0x1) << USBC_UECON5CLR_FIFOCONC_Pos)
 #define USBC_UECON5CLR_NYETDISC_Pos 17           /**< \brief (USBC_UECON5CLR) NYETDIS Clear */
-#define USBC_UECON5CLR_NYETDISC     (_U(0x1) << USBC_UECON5CLR_NYETDISC_Pos)
+#define USBC_UECON5CLR_NYETDISC     (_U_(0x1) << USBC_UECON5CLR_NYETDISC_Pos)
 #define USBC_UECON5CLR_STALLRQC_Pos 19           /**< \brief (USBC_UECON5CLR) STALLEDE Clear */
-#define USBC_UECON5CLR_STALLRQC     (_U(0x1) << USBC_UECON5CLR_STALLRQC_Pos)
+#define USBC_UECON5CLR_STALLRQC     (_U_(0x1) << USBC_UECON5CLR_STALLRQC_Pos)
 #define USBC_UECON5CLR_BUSY0C_Pos   24           /**< \brief (USBC_UECON5CLR) BUSY0 Clear */
-#define USBC_UECON5CLR_BUSY0C       (_U(0x1) << USBC_UECON5CLR_BUSY0C_Pos)
+#define USBC_UECON5CLR_BUSY0C       (_U_(0x1) << USBC_UECON5CLR_BUSY0C_Pos)
 #define USBC_UECON5CLR_BUSY1C_Pos   25           /**< \brief (USBC_UECON5CLR) BUSY1 Clear */
-#define USBC_UECON5CLR_BUSY1C       (_U(0x1) << USBC_UECON5CLR_BUSY1C_Pos)
-#define USBC_UECON5CLR_MASK         _U(0x030A595F) /**< \brief (USBC_UECON5CLR) MASK Register */
+#define USBC_UECON5CLR_BUSY1C       (_U_(0x1) << USBC_UECON5CLR_BUSY1C_Pos)
+#define USBC_UECON5CLR_MASK         _U_(0x030A595F) /**< \brief (USBC_UECON5CLR) MASK Register */
 
 /* -------- USBC_UECON6CLR : (USBC Offset: 0x238) ( /W 32) TXINE Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3614,37 +3614,37 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECON6CLR_OFFSET       0x238        /**< \brief (USBC_UECON6CLR offset) TXINE Clear */
-#define USBC_UECON6CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON6CLR reset_value) TXINE Clear */
+#define USBC_UECON6CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UECON6CLR reset_value) TXINE Clear */
 
 #define USBC_UECON6CLR_TXINEC_Pos   0            /**< \brief (USBC_UECON6CLR) TXINE Clear */
-#define USBC_UECON6CLR_TXINEC       (_U(0x1) << USBC_UECON6CLR_TXINEC_Pos)
+#define USBC_UECON6CLR_TXINEC       (_U_(0x1) << USBC_UECON6CLR_TXINEC_Pos)
 #define USBC_UECON6CLR_RXOUTEC_Pos  1            /**< \brief (USBC_UECON6CLR) RXOUTE Clear */
-#define USBC_UECON6CLR_RXOUTEC      (_U(0x1) << USBC_UECON6CLR_RXOUTEC_Pos)
+#define USBC_UECON6CLR_RXOUTEC      (_U_(0x1) << USBC_UECON6CLR_RXOUTEC_Pos)
 #define USBC_UECON6CLR_RXSTPEC_Pos  2            /**< \brief (USBC_UECON6CLR) RXOUTE Clear */
-#define USBC_UECON6CLR_RXSTPEC      (_U(0x1) << USBC_UECON6CLR_RXSTPEC_Pos)
+#define USBC_UECON6CLR_RXSTPEC      (_U_(0x1) << USBC_UECON6CLR_RXSTPEC_Pos)
 #define USBC_UECON6CLR_NAKOUTEC_Pos 3            /**< \brief (USBC_UECON6CLR) NAKOUTE Clear */
-#define USBC_UECON6CLR_NAKOUTEC     (_U(0x1) << USBC_UECON6CLR_NAKOUTEC_Pos)
+#define USBC_UECON6CLR_NAKOUTEC     (_U_(0x1) << USBC_UECON6CLR_NAKOUTEC_Pos)
 #define USBC_UECON6CLR_NAKINEC_Pos  4            /**< \brief (USBC_UECON6CLR) NAKINE Clear */
-#define USBC_UECON6CLR_NAKINEC      (_U(0x1) << USBC_UECON6CLR_NAKINEC_Pos)
+#define USBC_UECON6CLR_NAKINEC      (_U_(0x1) << USBC_UECON6CLR_NAKINEC_Pos)
 #define USBC_UECON6CLR_STALLEDEC_Pos 6            /**< \brief (USBC_UECON6CLR) RXSTPE Clear */
-#define USBC_UECON6CLR_STALLEDEC    (_U(0x1) << USBC_UECON6CLR_STALLEDEC_Pos)
+#define USBC_UECON6CLR_STALLEDEC    (_U_(0x1) << USBC_UECON6CLR_STALLEDEC_Pos)
 #define USBC_UECON6CLR_NREPLYC_Pos  8            /**< \brief (USBC_UECON6CLR) NREPLY Clear */
-#define USBC_UECON6CLR_NREPLYC      (_U(0x1) << USBC_UECON6CLR_NREPLYC_Pos)
+#define USBC_UECON6CLR_NREPLYC      (_U_(0x1) << USBC_UECON6CLR_NREPLYC_Pos)
 #define USBC_UECON6CLR_RAMACEREC_Pos 11           /**< \brief (USBC_UECON6CLR) RAMACERE Clear */
-#define USBC_UECON6CLR_RAMACEREC    (_U(0x1) << USBC_UECON6CLR_RAMACEREC_Pos)
+#define USBC_UECON6CLR_RAMACEREC    (_U_(0x1) << USBC_UECON6CLR_RAMACEREC_Pos)
 #define USBC_UECON6CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UECON6CLR) NBUSYBKE Clear */
-#define USBC_UECON6CLR_NBUSYBKEC    (_U(0x1) << USBC_UECON6CLR_NBUSYBKEC_Pos)
+#define USBC_UECON6CLR_NBUSYBKEC    (_U_(0x1) << USBC_UECON6CLR_NBUSYBKEC_Pos)
 #define USBC_UECON6CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UECON6CLR) FIFOCON Clear */
-#define USBC_UECON6CLR_FIFOCONC     (_U(0x1) << USBC_UECON6CLR_FIFOCONC_Pos)
+#define USBC_UECON6CLR_FIFOCONC     (_U_(0x1) << USBC_UECON6CLR_FIFOCONC_Pos)
 #define USBC_UECON6CLR_NYETDISC_Pos 17           /**< \brief (USBC_UECON6CLR) NYETDIS Clear */
-#define USBC_UECON6CLR_NYETDISC     (_U(0x1) << USBC_UECON6CLR_NYETDISC_Pos)
+#define USBC_UECON6CLR_NYETDISC     (_U_(0x1) << USBC_UECON6CLR_NYETDISC_Pos)
 #define USBC_UECON6CLR_STALLRQC_Pos 19           /**< \brief (USBC_UECON6CLR) STALLEDE Clear */
-#define USBC_UECON6CLR_STALLRQC     (_U(0x1) << USBC_UECON6CLR_STALLRQC_Pos)
+#define USBC_UECON6CLR_STALLRQC     (_U_(0x1) << USBC_UECON6CLR_STALLRQC_Pos)
 #define USBC_UECON6CLR_BUSY0C_Pos   24           /**< \brief (USBC_UECON6CLR) BUSY0 Clear */
-#define USBC_UECON6CLR_BUSY0C       (_U(0x1) << USBC_UECON6CLR_BUSY0C_Pos)
+#define USBC_UECON6CLR_BUSY0C       (_U_(0x1) << USBC_UECON6CLR_BUSY0C_Pos)
 #define USBC_UECON6CLR_BUSY1C_Pos   25           /**< \brief (USBC_UECON6CLR) BUSY1 Clear */
-#define USBC_UECON6CLR_BUSY1C       (_U(0x1) << USBC_UECON6CLR_BUSY1C_Pos)
-#define USBC_UECON6CLR_MASK         _U(0x030A595F) /**< \brief (USBC_UECON6CLR) MASK Register */
+#define USBC_UECON6CLR_BUSY1C       (_U_(0x1) << USBC_UECON6CLR_BUSY1C_Pos)
+#define USBC_UECON6CLR_MASK         _U_(0x030A595F) /**< \brief (USBC_UECON6CLR) MASK Register */
 
 /* -------- USBC_UECON7CLR : (USBC Offset: 0x23C) ( /W 32) TXINE Clear -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3678,37 +3678,37 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UECON7CLR_OFFSET       0x23C        /**< \brief (USBC_UECON7CLR offset) TXINE Clear */
-#define USBC_UECON7CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON7CLR reset_value) TXINE Clear */
+#define USBC_UECON7CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UECON7CLR reset_value) TXINE Clear */
 
 #define USBC_UECON7CLR_TXINEC_Pos   0            /**< \brief (USBC_UECON7CLR) TXINE Clear */
-#define USBC_UECON7CLR_TXINEC       (_U(0x1) << USBC_UECON7CLR_TXINEC_Pos)
+#define USBC_UECON7CLR_TXINEC       (_U_(0x1) << USBC_UECON7CLR_TXINEC_Pos)
 #define USBC_UECON7CLR_RXOUTEC_Pos  1            /**< \brief (USBC_UECON7CLR) RXOUTE Clear */
-#define USBC_UECON7CLR_RXOUTEC      (_U(0x1) << USBC_UECON7CLR_RXOUTEC_Pos)
+#define USBC_UECON7CLR_RXOUTEC      (_U_(0x1) << USBC_UECON7CLR_RXOUTEC_Pos)
 #define USBC_UECON7CLR_RXSTPEC_Pos  2            /**< \brief (USBC_UECON7CLR) RXOUTE Clear */
-#define USBC_UECON7CLR_RXSTPEC      (_U(0x1) << USBC_UECON7CLR_RXSTPEC_Pos)
+#define USBC_UECON7CLR_RXSTPEC      (_U_(0x1) << USBC_UECON7CLR_RXSTPEC_Pos)
 #define USBC_UECON7CLR_NAKOUTEC_Pos 3            /**< \brief (USBC_UECON7CLR) NAKOUTE Clear */
-#define USBC_UECON7CLR_NAKOUTEC     (_U(0x1) << USBC_UECON7CLR_NAKOUTEC_Pos)
+#define USBC_UECON7CLR_NAKOUTEC     (_U_(0x1) << USBC_UECON7CLR_NAKOUTEC_Pos)
 #define USBC_UECON7CLR_NAKINEC_Pos  4            /**< \brief (USBC_UECON7CLR) NAKINE Clear */
-#define USBC_UECON7CLR_NAKINEC      (_U(0x1) << USBC_UECON7CLR_NAKINEC_Pos)
+#define USBC_UECON7CLR_NAKINEC      (_U_(0x1) << USBC_UECON7CLR_NAKINEC_Pos)
 #define USBC_UECON7CLR_STALLEDEC_Pos 6            /**< \brief (USBC_UECON7CLR) RXSTPE Clear */
-#define USBC_UECON7CLR_STALLEDEC    (_U(0x1) << USBC_UECON7CLR_STALLEDEC_Pos)
+#define USBC_UECON7CLR_STALLEDEC    (_U_(0x1) << USBC_UECON7CLR_STALLEDEC_Pos)
 #define USBC_UECON7CLR_NREPLYC_Pos  8            /**< \brief (USBC_UECON7CLR) NREPLY Clear */
-#define USBC_UECON7CLR_NREPLYC      (_U(0x1) << USBC_UECON7CLR_NREPLYC_Pos)
+#define USBC_UECON7CLR_NREPLYC      (_U_(0x1) << USBC_UECON7CLR_NREPLYC_Pos)
 #define USBC_UECON7CLR_RAMACEREC_Pos 11           /**< \brief (USBC_UECON7CLR) RAMACERE Clear */
-#define USBC_UECON7CLR_RAMACEREC    (_U(0x1) << USBC_UECON7CLR_RAMACEREC_Pos)
+#define USBC_UECON7CLR_RAMACEREC    (_U_(0x1) << USBC_UECON7CLR_RAMACEREC_Pos)
 #define USBC_UECON7CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UECON7CLR) NBUSYBKE Clear */
-#define USBC_UECON7CLR_NBUSYBKEC    (_U(0x1) << USBC_UECON7CLR_NBUSYBKEC_Pos)
+#define USBC_UECON7CLR_NBUSYBKEC    (_U_(0x1) << USBC_UECON7CLR_NBUSYBKEC_Pos)
 #define USBC_UECON7CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UECON7CLR) FIFOCON Clear */
-#define USBC_UECON7CLR_FIFOCONC     (_U(0x1) << USBC_UECON7CLR_FIFOCONC_Pos)
+#define USBC_UECON7CLR_FIFOCONC     (_U_(0x1) << USBC_UECON7CLR_FIFOCONC_Pos)
 #define USBC_UECON7CLR_NYETDISC_Pos 17           /**< \brief (USBC_UECON7CLR) NYETDIS Clear */
-#define USBC_UECON7CLR_NYETDISC     (_U(0x1) << USBC_UECON7CLR_NYETDISC_Pos)
+#define USBC_UECON7CLR_NYETDISC     (_U_(0x1) << USBC_UECON7CLR_NYETDISC_Pos)
 #define USBC_UECON7CLR_STALLRQC_Pos 19           /**< \brief (USBC_UECON7CLR) STALLEDE Clear */
-#define USBC_UECON7CLR_STALLRQC     (_U(0x1) << USBC_UECON7CLR_STALLRQC_Pos)
+#define USBC_UECON7CLR_STALLRQC     (_U_(0x1) << USBC_UECON7CLR_STALLRQC_Pos)
 #define USBC_UECON7CLR_BUSY0C_Pos   24           /**< \brief (USBC_UECON7CLR) BUSY0 Clear */
-#define USBC_UECON7CLR_BUSY0C       (_U(0x1) << USBC_UECON7CLR_BUSY0C_Pos)
+#define USBC_UECON7CLR_BUSY0C       (_U_(0x1) << USBC_UECON7CLR_BUSY0C_Pos)
 #define USBC_UECON7CLR_BUSY1C_Pos   25           /**< \brief (USBC_UECON7CLR) BUSY1 Clear */
-#define USBC_UECON7CLR_BUSY1C       (_U(0x1) << USBC_UECON7CLR_BUSY1C_Pos)
-#define USBC_UECON7CLR_MASK         _U(0x030A595F) /**< \brief (USBC_UECON7CLR) MASK Register */
+#define USBC_UECON7CLR_BUSY1C       (_U_(0x1) << USBC_UECON7CLR_BUSY1C_Pos)
+#define USBC_UECON7CLR_MASK         _U_(0x030A595F) /**< \brief (USBC_UECON7CLR) MASK Register */
 
 /* -------- USBC_UHCON : (USBC Offset: 0x400) (R/W 32) Host General Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3730,22 +3730,22 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UHCON_OFFSET           0x400        /**< \brief (USBC_UHCON offset) Host General Control Register */
-#define USBC_UHCON_RESETVALUE       _U(0x00000000); /**< \brief (USBC_UHCON reset_value) Host General Control Register */
+#define USBC_UHCON_RESETVALUE       _U_(0x00000000); /**< \brief (USBC_UHCON reset_value) Host General Control Register */
 
 #define USBC_UHCON_SOFE_Pos         8            /**< \brief (USBC_UHCON) SOF Enable */
-#define USBC_UHCON_SOFE             (_U(0x1) << USBC_UHCON_SOFE_Pos)
+#define USBC_UHCON_SOFE             (_U_(0x1) << USBC_UHCON_SOFE_Pos)
 #define USBC_UHCON_RESET_Pos        9            /**< \brief (USBC_UHCON) Send USB Reset */
-#define USBC_UHCON_RESET            (_U(0x1) << USBC_UHCON_RESET_Pos)
+#define USBC_UHCON_RESET            (_U_(0x1) << USBC_UHCON_RESET_Pos)
 #define USBC_UHCON_RESUME_Pos       10           /**< \brief (USBC_UHCON) Send USB Resume */
-#define USBC_UHCON_RESUME           (_U(0x1) << USBC_UHCON_RESUME_Pos)
+#define USBC_UHCON_RESUME           (_U_(0x1) << USBC_UHCON_RESUME_Pos)
 #define USBC_UHCON_SPDCONF_Pos      12           /**< \brief (USBC_UHCON) Speed Configuration */
-#define USBC_UHCON_SPDCONF_Msk      (_U(0x3) << USBC_UHCON_SPDCONF_Pos)
+#define USBC_UHCON_SPDCONF_Msk      (_U_(0x3) << USBC_UHCON_SPDCONF_Pos)
 #define USBC_UHCON_SPDCONF(value)   (USBC_UHCON_SPDCONF_Msk & ((value) << USBC_UHCON_SPDCONF_Pos))
 #define USBC_UHCON_TSTJ_Pos         16           /**< \brief (USBC_UHCON) Test J */
-#define USBC_UHCON_TSTJ             (_U(0x1) << USBC_UHCON_TSTJ_Pos)
+#define USBC_UHCON_TSTJ             (_U_(0x1) << USBC_UHCON_TSTJ_Pos)
 #define USBC_UHCON_TSTK_Pos         17           /**< \brief (USBC_UHCON) Test K */
-#define USBC_UHCON_TSTK             (_U(0x1) << USBC_UHCON_TSTK_Pos)
-#define USBC_UHCON_MASK             _U(0x00033700) /**< \brief (USBC_UHCON) MASK Register */
+#define USBC_UHCON_TSTK             (_U_(0x1) << USBC_UHCON_TSTK_Pos)
+#define USBC_UHCON_MASK             _U_(0x00033700) /**< \brief (USBC_UHCON) MASK Register */
 
 /* -------- USBC_UHINT : (USBC Offset: 0x404) (R/  32) Host Global Interrupt Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3773,37 +3773,37 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UHINT_OFFSET           0x404        /**< \brief (USBC_UHINT offset) Host Global Interrupt Register */
-#define USBC_UHINT_RESETVALUE       _U(0x00000000); /**< \brief (USBC_UHINT reset_value) Host Global Interrupt Register */
+#define USBC_UHINT_RESETVALUE       _U_(0x00000000); /**< \brief (USBC_UHINT reset_value) Host Global Interrupt Register */
 
 #define USBC_UHINT_DCONNI_Pos       0            /**< \brief (USBC_UHINT) Device Connection Interrupt */
-#define USBC_UHINT_DCONNI           (_U(0x1) << USBC_UHINT_DCONNI_Pos)
+#define USBC_UHINT_DCONNI           (_U_(0x1) << USBC_UHINT_DCONNI_Pos)
 #define USBC_UHINT_DDISCI_Pos       1            /**< \brief (USBC_UHINT) Device Disconnection Interrupt */
-#define USBC_UHINT_DDISCI           (_U(0x1) << USBC_UHINT_DDISCI_Pos)
+#define USBC_UHINT_DDISCI           (_U_(0x1) << USBC_UHINT_DDISCI_Pos)
 #define USBC_UHINT_RSTI_Pos         2            /**< \brief (USBC_UHINT) USB Reset Sent Interrupt */
-#define USBC_UHINT_RSTI             (_U(0x1) << USBC_UHINT_RSTI_Pos)
+#define USBC_UHINT_RSTI             (_U_(0x1) << USBC_UHINT_RSTI_Pos)
 #define USBC_UHINT_RSMEDI_Pos       3            /**< \brief (USBC_UHINT) Downstream Resume Sent Interrupt */
-#define USBC_UHINT_RSMEDI           (_U(0x1) << USBC_UHINT_RSMEDI_Pos)
+#define USBC_UHINT_RSMEDI           (_U_(0x1) << USBC_UHINT_RSMEDI_Pos)
 #define USBC_UHINT_RXRSMI_Pos       4            /**< \brief (USBC_UHINT) Upstream Resume Received Interrupt */
-#define USBC_UHINT_RXRSMI           (_U(0x1) << USBC_UHINT_RXRSMI_Pos)
+#define USBC_UHINT_RXRSMI           (_U_(0x1) << USBC_UHINT_RXRSMI_Pos)
 #define USBC_UHINT_HSOFI_Pos        5            /**< \brief (USBC_UHINT) Host SOF Interrupt */
-#define USBC_UHINT_HSOFI            (_U(0x1) << USBC_UHINT_HSOFI_Pos)
+#define USBC_UHINT_HSOFI            (_U_(0x1) << USBC_UHINT_HSOFI_Pos)
 #define USBC_UHINT_HWUPI_Pos        6            /**< \brief (USBC_UHINT) Host Wake-Up Interrupt */
-#define USBC_UHINT_HWUPI            (_U(0x1) << USBC_UHINT_HWUPI_Pos)
+#define USBC_UHINT_HWUPI            (_U_(0x1) << USBC_UHINT_HWUPI_Pos)
 #define USBC_UHINT_P0INT_Pos        8            /**< \brief (USBC_UHINT) Pipe 0 Interrupt */
-#define USBC_UHINT_P0INT            (_U(0x1) << USBC_UHINT_P0INT_Pos)
+#define USBC_UHINT_P0INT            (_U_(0x1) << USBC_UHINT_P0INT_Pos)
 #define USBC_UHINT_P1INT_Pos        9            /**< \brief (USBC_UHINT) Pipe 1 Interrupt */
-#define USBC_UHINT_P1INT            (_U(0x1) << USBC_UHINT_P1INT_Pos)
+#define USBC_UHINT_P1INT            (_U_(0x1) << USBC_UHINT_P1INT_Pos)
 #define USBC_UHINT_P2INT_Pos        10           /**< \brief (USBC_UHINT) Pipe 2 Interrupt */
-#define USBC_UHINT_P2INT            (_U(0x1) << USBC_UHINT_P2INT_Pos)
+#define USBC_UHINT_P2INT            (_U_(0x1) << USBC_UHINT_P2INT_Pos)
 #define USBC_UHINT_P3INT_Pos        11           /**< \brief (USBC_UHINT) Pipe 3 Interrupt */
-#define USBC_UHINT_P3INT            (_U(0x1) << USBC_UHINT_P3INT_Pos)
+#define USBC_UHINT_P3INT            (_U_(0x1) << USBC_UHINT_P3INT_Pos)
 #define USBC_UHINT_P4INT_Pos        12           /**< \brief (USBC_UHINT) Pipe 4 Interrupt */
-#define USBC_UHINT_P4INT            (_U(0x1) << USBC_UHINT_P4INT_Pos)
+#define USBC_UHINT_P4INT            (_U_(0x1) << USBC_UHINT_P4INT_Pos)
 #define USBC_UHINT_P5INT_Pos        13           /**< \brief (USBC_UHINT) Pipe 5 Interrupt */
-#define USBC_UHINT_P5INT            (_U(0x1) << USBC_UHINT_P5INT_Pos)
+#define USBC_UHINT_P5INT            (_U_(0x1) << USBC_UHINT_P5INT_Pos)
 #define USBC_UHINT_P6INT_Pos        14           /**< \brief (USBC_UHINT) Pipe 6 Interrupt */
-#define USBC_UHINT_P6INT            (_U(0x1) << USBC_UHINT_P6INT_Pos)
-#define USBC_UHINT_MASK             _U(0x00007F7F) /**< \brief (USBC_UHINT) MASK Register */
+#define USBC_UHINT_P6INT            (_U_(0x1) << USBC_UHINT_P6INT_Pos)
+#define USBC_UHINT_MASK             _U_(0x00007F7F) /**< \brief (USBC_UHINT) MASK Register */
 
 /* -------- USBC_UHINTCLR : (USBC Offset: 0x408) ( /W 32) Host Global Interrrupt Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3823,23 +3823,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UHINTCLR_OFFSET        0x408        /**< \brief (USBC_UHINTCLR offset) Host Global Interrrupt Clear Register */
-#define USBC_UHINTCLR_RESETVALUE    _U(0x00000000); /**< \brief (USBC_UHINTCLR reset_value) Host Global Interrrupt Clear Register */
+#define USBC_UHINTCLR_RESETVALUE    _U_(0x00000000); /**< \brief (USBC_UHINTCLR reset_value) Host Global Interrrupt Clear Register */
 
 #define USBC_UHINTCLR_DCONNIC_Pos   0            /**< \brief (USBC_UHINTCLR) DCONNI Clear */
-#define USBC_UHINTCLR_DCONNIC       (_U(0x1) << USBC_UHINTCLR_DCONNIC_Pos)
+#define USBC_UHINTCLR_DCONNIC       (_U_(0x1) << USBC_UHINTCLR_DCONNIC_Pos)
 #define USBC_UHINTCLR_DDISCIC_Pos   1            /**< \brief (USBC_UHINTCLR) DDISCI Clear */
-#define USBC_UHINTCLR_DDISCIC       (_U(0x1) << USBC_UHINTCLR_DDISCIC_Pos)
+#define USBC_UHINTCLR_DDISCIC       (_U_(0x1) << USBC_UHINTCLR_DDISCIC_Pos)
 #define USBC_UHINTCLR_RSTIC_Pos     2            /**< \brief (USBC_UHINTCLR) RSTI Clear */
-#define USBC_UHINTCLR_RSTIC         (_U(0x1) << USBC_UHINTCLR_RSTIC_Pos)
+#define USBC_UHINTCLR_RSTIC         (_U_(0x1) << USBC_UHINTCLR_RSTIC_Pos)
 #define USBC_UHINTCLR_RSMEDIC_Pos   3            /**< \brief (USBC_UHINTCLR) RSMEDI Clear */
-#define USBC_UHINTCLR_RSMEDIC       (_U(0x1) << USBC_UHINTCLR_RSMEDIC_Pos)
+#define USBC_UHINTCLR_RSMEDIC       (_U_(0x1) << USBC_UHINTCLR_RSMEDIC_Pos)
 #define USBC_UHINTCLR_RXRSMIC_Pos   4            /**< \brief (USBC_UHINTCLR) RXRSMI Clear */
-#define USBC_UHINTCLR_RXRSMIC       (_U(0x1) << USBC_UHINTCLR_RXRSMIC_Pos)
+#define USBC_UHINTCLR_RXRSMIC       (_U_(0x1) << USBC_UHINTCLR_RXRSMIC_Pos)
 #define USBC_UHINTCLR_HSOFIC_Pos    5            /**< \brief (USBC_UHINTCLR) HSOFI Clear */
-#define USBC_UHINTCLR_HSOFIC        (_U(0x1) << USBC_UHINTCLR_HSOFIC_Pos)
+#define USBC_UHINTCLR_HSOFIC        (_U_(0x1) << USBC_UHINTCLR_HSOFIC_Pos)
 #define USBC_UHINTCLR_HWUPIC_Pos    6            /**< \brief (USBC_UHINTCLR) HWUPI Clear */
-#define USBC_UHINTCLR_HWUPIC        (_U(0x1) << USBC_UHINTCLR_HWUPIC_Pos)
-#define USBC_UHINTCLR_MASK          _U(0x0000007F) /**< \brief (USBC_UHINTCLR) MASK Register */
+#define USBC_UHINTCLR_HWUPIC        (_U_(0x1) << USBC_UHINTCLR_HWUPIC_Pos)
+#define USBC_UHINTCLR_MASK          _U_(0x0000007F) /**< \brief (USBC_UHINTCLR) MASK Register */
 
 /* -------- USBC_UHINTSET : (USBC Offset: 0x40C) ( /W 32) Host Global Interrupt Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3859,23 +3859,23 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UHINTSET_OFFSET        0x40C        /**< \brief (USBC_UHINTSET offset) Host Global Interrupt Set Register */
-#define USBC_UHINTSET_RESETVALUE    _U(0x00000000); /**< \brief (USBC_UHINTSET reset_value) Host Global Interrupt Set Register */
+#define USBC_UHINTSET_RESETVALUE    _U_(0x00000000); /**< \brief (USBC_UHINTSET reset_value) Host Global Interrupt Set Register */
 
 #define USBC_UHINTSET_DCONNIS_Pos   0            /**< \brief (USBC_UHINTSET) DCONNI Set */
-#define USBC_UHINTSET_DCONNIS       (_U(0x1) << USBC_UHINTSET_DCONNIS_Pos)
+#define USBC_UHINTSET_DCONNIS       (_U_(0x1) << USBC_UHINTSET_DCONNIS_Pos)
 #define USBC_UHINTSET_DDISCIS_Pos   1            /**< \brief (USBC_UHINTSET) DDISCI Set */
-#define USBC_UHINTSET_DDISCIS       (_U(0x1) << USBC_UHINTSET_DDISCIS_Pos)
+#define USBC_UHINTSET_DDISCIS       (_U_(0x1) << USBC_UHINTSET_DDISCIS_Pos)
 #define USBC_UHINTSET_RSTIS_Pos     2            /**< \brief (USBC_UHINTSET) RSTI Set */
-#define USBC_UHINTSET_RSTIS         (_U(0x1) << USBC_UHINTSET_RSTIS_Pos)
+#define USBC_UHINTSET_RSTIS         (_U_(0x1) << USBC_UHINTSET_RSTIS_Pos)
 #define USBC_UHINTSET_RSMEDIS_Pos   3            /**< \brief (USBC_UHINTSET) RSMEDI Set */
-#define USBC_UHINTSET_RSMEDIS       (_U(0x1) << USBC_UHINTSET_RSMEDIS_Pos)
+#define USBC_UHINTSET_RSMEDIS       (_U_(0x1) << USBC_UHINTSET_RSMEDIS_Pos)
 #define USBC_UHINTSET_RXRSMIS_Pos   4            /**< \brief (USBC_UHINTSET) RXRSMI Set */
-#define USBC_UHINTSET_RXRSMIS       (_U(0x1) << USBC_UHINTSET_RXRSMIS_Pos)
+#define USBC_UHINTSET_RXRSMIS       (_U_(0x1) << USBC_UHINTSET_RXRSMIS_Pos)
 #define USBC_UHINTSET_HSOFIS_Pos    5            /**< \brief (USBC_UHINTSET) HSOFI Set */
-#define USBC_UHINTSET_HSOFIS        (_U(0x1) << USBC_UHINTSET_HSOFIS_Pos)
+#define USBC_UHINTSET_HSOFIS        (_U_(0x1) << USBC_UHINTSET_HSOFIS_Pos)
 #define USBC_UHINTSET_HWUPIS_Pos    6            /**< \brief (USBC_UHINTSET) HWUPI Set */
-#define USBC_UHINTSET_HWUPIS        (_U(0x1) << USBC_UHINTSET_HWUPIS_Pos)
-#define USBC_UHINTSET_MASK          _U(0x0000007F) /**< \brief (USBC_UHINTSET) MASK Register */
+#define USBC_UHINTSET_HWUPIS        (_U_(0x1) << USBC_UHINTSET_HWUPIS_Pos)
+#define USBC_UHINTSET_MASK          _U_(0x0000007F) /**< \brief (USBC_UHINTSET) MASK Register */
 
 /* -------- USBC_UHINTE : (USBC Offset: 0x410) (R/  32) Host Global Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3904,39 +3904,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UHINTE_OFFSET          0x410        /**< \brief (USBC_UHINTE offset) Host Global Interrupt Enable Register */
-#define USBC_UHINTE_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UHINTE reset_value) Host Global Interrupt Enable Register */
+#define USBC_UHINTE_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UHINTE reset_value) Host Global Interrupt Enable Register */
 
 #define USBC_UHINTE_DCONNIE_Pos     0            /**< \brief (USBC_UHINTE) DCONNI Enable */
-#define USBC_UHINTE_DCONNIE         (_U(0x1) << USBC_UHINTE_DCONNIE_Pos)
+#define USBC_UHINTE_DCONNIE         (_U_(0x1) << USBC_UHINTE_DCONNIE_Pos)
 #define USBC_UHINTE_DDISCIE_Pos     1            /**< \brief (USBC_UHINTE) DDISCI Enable */
-#define USBC_UHINTE_DDISCIE         (_U(0x1) << USBC_UHINTE_DDISCIE_Pos)
+#define USBC_UHINTE_DDISCIE         (_U_(0x1) << USBC_UHINTE_DDISCIE_Pos)
 #define USBC_UHINTE_RSTIE_Pos       2            /**< \brief (USBC_UHINTE) RSTI Enable */
-#define USBC_UHINTE_RSTIE           (_U(0x1) << USBC_UHINTE_RSTIE_Pos)
+#define USBC_UHINTE_RSTIE           (_U_(0x1) << USBC_UHINTE_RSTIE_Pos)
 #define USBC_UHINTE_RSMEDIE_Pos     3            /**< \brief (USBC_UHINTE) RSMEDI Enable */
-#define USBC_UHINTE_RSMEDIE         (_U(0x1) << USBC_UHINTE_RSMEDIE_Pos)
+#define USBC_UHINTE_RSMEDIE         (_U_(0x1) << USBC_UHINTE_RSMEDIE_Pos)
 #define USBC_UHINTE_RXRSMIE_Pos     4            /**< \brief (USBC_UHINTE) RXRSMI Enable */
-#define USBC_UHINTE_RXRSMIE         (_U(0x1) << USBC_UHINTE_RXRSMIE_Pos)
+#define USBC_UHINTE_RXRSMIE         (_U_(0x1) << USBC_UHINTE_RXRSMIE_Pos)
 #define USBC_UHINTE_HSOFIE_Pos      5            /**< \brief (USBC_UHINTE) HSOFI Enable */
-#define USBC_UHINTE_HSOFIE          (_U(0x1) << USBC_UHINTE_HSOFIE_Pos)
+#define USBC_UHINTE_HSOFIE          (_U_(0x1) << USBC_UHINTE_HSOFIE_Pos)
 #define USBC_UHINTE_HWUPIE_Pos      6            /**< \brief (USBC_UHINTE) HWUPI Enable */
-#define USBC_UHINTE_HWUPIE          (_U(0x1) << USBC_UHINTE_HWUPIE_Pos)
+#define USBC_UHINTE_HWUPIE          (_U_(0x1) << USBC_UHINTE_HWUPIE_Pos)
 #define USBC_UHINTE_P0INTE_Pos      8            /**< \brief (USBC_UHINTE) P0INT Enable */
-#define USBC_UHINTE_P0INTE          (_U(0x1) << USBC_UHINTE_P0INTE_Pos)
+#define USBC_UHINTE_P0INTE          (_U_(0x1) << USBC_UHINTE_P0INTE_Pos)
 #define USBC_UHINTE_P1INTE_Pos      9            /**< \brief (USBC_UHINTE) P1INT Enable */
-#define USBC_UHINTE_P1INTE          (_U(0x1) << USBC_UHINTE_P1INTE_Pos)
+#define USBC_UHINTE_P1INTE          (_U_(0x1) << USBC_UHINTE_P1INTE_Pos)
 #define USBC_UHINTE_P2INTE_Pos      10           /**< \brief (USBC_UHINTE) P2INT Enable */
-#define USBC_UHINTE_P2INTE          (_U(0x1) << USBC_UHINTE_P2INTE_Pos)
+#define USBC_UHINTE_P2INTE          (_U_(0x1) << USBC_UHINTE_P2INTE_Pos)
 #define USBC_UHINTE_P3INTE_Pos      11           /**< \brief (USBC_UHINTE) P3INT Enable */
-#define USBC_UHINTE_P3INTE          (_U(0x1) << USBC_UHINTE_P3INTE_Pos)
+#define USBC_UHINTE_P3INTE          (_U_(0x1) << USBC_UHINTE_P3INTE_Pos)
 #define USBC_UHINTE_P4INTE_Pos      12           /**< \brief (USBC_UHINTE) P4INT Enable */
-#define USBC_UHINTE_P4INTE          (_U(0x1) << USBC_UHINTE_P4INTE_Pos)
+#define USBC_UHINTE_P4INTE          (_U_(0x1) << USBC_UHINTE_P4INTE_Pos)
 #define USBC_UHINTE_P5INTE_Pos      13           /**< \brief (USBC_UHINTE) P5INT Enable */
-#define USBC_UHINTE_P5INTE          (_U(0x1) << USBC_UHINTE_P5INTE_Pos)
+#define USBC_UHINTE_P5INTE          (_U_(0x1) << USBC_UHINTE_P5INTE_Pos)
 #define USBC_UHINTE_P6INTE_Pos      14           /**< \brief (USBC_UHINTE) P6INT Enable */
-#define USBC_UHINTE_P6INTE          (_U(0x1) << USBC_UHINTE_P6INTE_Pos)
+#define USBC_UHINTE_P6INTE          (_U_(0x1) << USBC_UHINTE_P6INTE_Pos)
 #define USBC_UHINTE_P7INTE_Pos      15           /**< \brief (USBC_UHINTE) P7INT Enable */
-#define USBC_UHINTE_P7INTE          (_U(0x1) << USBC_UHINTE_P7INTE_Pos)
-#define USBC_UHINTE_MASK            _U(0x0000FF7F) /**< \brief (USBC_UHINTE) MASK Register */
+#define USBC_UHINTE_P7INTE          (_U_(0x1) << USBC_UHINTE_P7INTE_Pos)
+#define USBC_UHINTE_MASK            _U_(0x0000FF7F) /**< \brief (USBC_UHINTE) MASK Register */
 
 /* -------- USBC_UHINTECLR : (USBC Offset: 0x414) ( /W 32) Host Global Interrupt Enable Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -3965,39 +3965,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UHINTECLR_OFFSET       0x414        /**< \brief (USBC_UHINTECLR offset) Host Global Interrupt Enable Clear Register */
-#define USBC_UHINTECLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UHINTECLR reset_value) Host Global Interrupt Enable Clear Register */
+#define USBC_UHINTECLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UHINTECLR reset_value) Host Global Interrupt Enable Clear Register */
 
 #define USBC_UHINTECLR_DCONNIEC_Pos 0            /**< \brief (USBC_UHINTECLR) DCONNIE Clear */
-#define USBC_UHINTECLR_DCONNIEC     (_U(0x1) << USBC_UHINTECLR_DCONNIEC_Pos)
+#define USBC_UHINTECLR_DCONNIEC     (_U_(0x1) << USBC_UHINTECLR_DCONNIEC_Pos)
 #define USBC_UHINTECLR_DDISCIEC_Pos 1            /**< \brief (USBC_UHINTECLR) DDISCIE Clear */
-#define USBC_UHINTECLR_DDISCIEC     (_U(0x1) << USBC_UHINTECLR_DDISCIEC_Pos)
+#define USBC_UHINTECLR_DDISCIEC     (_U_(0x1) << USBC_UHINTECLR_DDISCIEC_Pos)
 #define USBC_UHINTECLR_RSTIEC_Pos   2            /**< \brief (USBC_UHINTECLR) RSTIE Clear */
-#define USBC_UHINTECLR_RSTIEC       (_U(0x1) << USBC_UHINTECLR_RSTIEC_Pos)
+#define USBC_UHINTECLR_RSTIEC       (_U_(0x1) << USBC_UHINTECLR_RSTIEC_Pos)
 #define USBC_UHINTECLR_RSMEDIEC_Pos 3            /**< \brief (USBC_UHINTECLR) RSMEDIE Clear */
-#define USBC_UHINTECLR_RSMEDIEC     (_U(0x1) << USBC_UHINTECLR_RSMEDIEC_Pos)
+#define USBC_UHINTECLR_RSMEDIEC     (_U_(0x1) << USBC_UHINTECLR_RSMEDIEC_Pos)
 #define USBC_UHINTECLR_RXRSMIEC_Pos 4            /**< \brief (USBC_UHINTECLR) RXRSMIE Clear */
-#define USBC_UHINTECLR_RXRSMIEC     (_U(0x1) << USBC_UHINTECLR_RXRSMIEC_Pos)
+#define USBC_UHINTECLR_RXRSMIEC     (_U_(0x1) << USBC_UHINTECLR_RXRSMIEC_Pos)
 #define USBC_UHINTECLR_HSOFIEC_Pos  5            /**< \brief (USBC_UHINTECLR) HSOFIE Clear */
-#define USBC_UHINTECLR_HSOFIEC      (_U(0x1) << USBC_UHINTECLR_HSOFIEC_Pos)
+#define USBC_UHINTECLR_HSOFIEC      (_U_(0x1) << USBC_UHINTECLR_HSOFIEC_Pos)
 #define USBC_UHINTECLR_HWUPIEC_Pos  6            /**< \brief (USBC_UHINTECLR) HWUPIE Clear */
-#define USBC_UHINTECLR_HWUPIEC      (_U(0x1) << USBC_UHINTECLR_HWUPIEC_Pos)
+#define USBC_UHINTECLR_HWUPIEC      (_U_(0x1) << USBC_UHINTECLR_HWUPIEC_Pos)
 #define USBC_UHINTECLR_P0INTEC_Pos  8            /**< \brief (USBC_UHINTECLR) P0INTE Clear */
-#define USBC_UHINTECLR_P0INTEC      (_U(0x1) << USBC_UHINTECLR_P0INTEC_Pos)
+#define USBC_UHINTECLR_P0INTEC      (_U_(0x1) << USBC_UHINTECLR_P0INTEC_Pos)
 #define USBC_UHINTECLR_P1INTEC_Pos  9            /**< \brief (USBC_UHINTECLR) P1INTE Clear */
-#define USBC_UHINTECLR_P1INTEC      (_U(0x1) << USBC_UHINTECLR_P1INTEC_Pos)
+#define USBC_UHINTECLR_P1INTEC      (_U_(0x1) << USBC_UHINTECLR_P1INTEC_Pos)
 #define USBC_UHINTECLR_P2INTEC_Pos  10           /**< \brief (USBC_UHINTECLR) P2INTE Clear */
-#define USBC_UHINTECLR_P2INTEC      (_U(0x1) << USBC_UHINTECLR_P2INTEC_Pos)
+#define USBC_UHINTECLR_P2INTEC      (_U_(0x1) << USBC_UHINTECLR_P2INTEC_Pos)
 #define USBC_UHINTECLR_P3INTEC_Pos  11           /**< \brief (USBC_UHINTECLR) P3INTE Clear */
-#define USBC_UHINTECLR_P3INTEC      (_U(0x1) << USBC_UHINTECLR_P3INTEC_Pos)
+#define USBC_UHINTECLR_P3INTEC      (_U_(0x1) << USBC_UHINTECLR_P3INTEC_Pos)
 #define USBC_UHINTECLR_P4INTEC_Pos  12           /**< \brief (USBC_UHINTECLR) P4INTE Clear */
-#define USBC_UHINTECLR_P4INTEC      (_U(0x1) << USBC_UHINTECLR_P4INTEC_Pos)
+#define USBC_UHINTECLR_P4INTEC      (_U_(0x1) << USBC_UHINTECLR_P4INTEC_Pos)
 #define USBC_UHINTECLR_P5INTEC_Pos  13           /**< \brief (USBC_UHINTECLR) P5INTE Clear */
-#define USBC_UHINTECLR_P5INTEC      (_U(0x1) << USBC_UHINTECLR_P5INTEC_Pos)
+#define USBC_UHINTECLR_P5INTEC      (_U_(0x1) << USBC_UHINTECLR_P5INTEC_Pos)
 #define USBC_UHINTECLR_P6INTEC_Pos  14           /**< \brief (USBC_UHINTECLR) P6INTE Clear */
-#define USBC_UHINTECLR_P6INTEC      (_U(0x1) << USBC_UHINTECLR_P6INTEC_Pos)
+#define USBC_UHINTECLR_P6INTEC      (_U_(0x1) << USBC_UHINTECLR_P6INTEC_Pos)
 #define USBC_UHINTECLR_P7INTEC_Pos  15           /**< \brief (USBC_UHINTECLR) P7INTE Clear */
-#define USBC_UHINTECLR_P7INTEC      (_U(0x1) << USBC_UHINTECLR_P7INTEC_Pos)
-#define USBC_UHINTECLR_MASK         _U(0x0000FF7F) /**< \brief (USBC_UHINTECLR) MASK Register */
+#define USBC_UHINTECLR_P7INTEC      (_U_(0x1) << USBC_UHINTECLR_P7INTEC_Pos)
+#define USBC_UHINTECLR_MASK         _U_(0x0000FF7F) /**< \brief (USBC_UHINTECLR) MASK Register */
 
 /* -------- USBC_UHINTESET : (USBC Offset: 0x418) ( /W 32) Host Global Interrupt Enable Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4026,39 +4026,39 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UHINTESET_OFFSET       0x418        /**< \brief (USBC_UHINTESET offset) Host Global Interrupt Enable Set Register */
-#define USBC_UHINTESET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UHINTESET reset_value) Host Global Interrupt Enable Set Register */
+#define USBC_UHINTESET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UHINTESET reset_value) Host Global Interrupt Enable Set Register */
 
 #define USBC_UHINTESET_DCONNIES_Pos 0            /**< \brief (USBC_UHINTESET) DCONNIE Set */
-#define USBC_UHINTESET_DCONNIES     (_U(0x1) << USBC_UHINTESET_DCONNIES_Pos)
+#define USBC_UHINTESET_DCONNIES     (_U_(0x1) << USBC_UHINTESET_DCONNIES_Pos)
 #define USBC_UHINTESET_DDISCIES_Pos 1            /**< \brief (USBC_UHINTESET) DDISCIE Set */
-#define USBC_UHINTESET_DDISCIES     (_U(0x1) << USBC_UHINTESET_DDISCIES_Pos)
+#define USBC_UHINTESET_DDISCIES     (_U_(0x1) << USBC_UHINTESET_DDISCIES_Pos)
 #define USBC_UHINTESET_RSTIES_Pos   2            /**< \brief (USBC_UHINTESET) RSTIE Set */
-#define USBC_UHINTESET_RSTIES       (_U(0x1) << USBC_UHINTESET_RSTIES_Pos)
+#define USBC_UHINTESET_RSTIES       (_U_(0x1) << USBC_UHINTESET_RSTIES_Pos)
 #define USBC_UHINTESET_RSMEDIES_Pos 3            /**< \brief (USBC_UHINTESET) RSMEDIE Set */
-#define USBC_UHINTESET_RSMEDIES     (_U(0x1) << USBC_UHINTESET_RSMEDIES_Pos)
+#define USBC_UHINTESET_RSMEDIES     (_U_(0x1) << USBC_UHINTESET_RSMEDIES_Pos)
 #define USBC_UHINTESET_RXRSMIES_Pos 4            /**< \brief (USBC_UHINTESET) RXRSMIE Set */
-#define USBC_UHINTESET_RXRSMIES     (_U(0x1) << USBC_UHINTESET_RXRSMIES_Pos)
+#define USBC_UHINTESET_RXRSMIES     (_U_(0x1) << USBC_UHINTESET_RXRSMIES_Pos)
 #define USBC_UHINTESET_HSOFIES_Pos  5            /**< \brief (USBC_UHINTESET) HSOFIE Set */
-#define USBC_UHINTESET_HSOFIES      (_U(0x1) << USBC_UHINTESET_HSOFIES_Pos)
+#define USBC_UHINTESET_HSOFIES      (_U_(0x1) << USBC_UHINTESET_HSOFIES_Pos)
 #define USBC_UHINTESET_HWUPIES_Pos  6            /**< \brief (USBC_UHINTESET) HWUPIE Set */
-#define USBC_UHINTESET_HWUPIES      (_U(0x1) << USBC_UHINTESET_HWUPIES_Pos)
+#define USBC_UHINTESET_HWUPIES      (_U_(0x1) << USBC_UHINTESET_HWUPIES_Pos)
 #define USBC_UHINTESET_P0INTES_Pos  8            /**< \brief (USBC_UHINTESET) P0INTE Set */
-#define USBC_UHINTESET_P0INTES      (_U(0x1) << USBC_UHINTESET_P0INTES_Pos)
+#define USBC_UHINTESET_P0INTES      (_U_(0x1) << USBC_UHINTESET_P0INTES_Pos)
 #define USBC_UHINTESET_P1INTES_Pos  9            /**< \brief (USBC_UHINTESET) P1INTE Set */
-#define USBC_UHINTESET_P1INTES      (_U(0x1) << USBC_UHINTESET_P1INTES_Pos)
+#define USBC_UHINTESET_P1INTES      (_U_(0x1) << USBC_UHINTESET_P1INTES_Pos)
 #define USBC_UHINTESET_P2INTES_Pos  10           /**< \brief (USBC_UHINTESET) P2INTE Set */
-#define USBC_UHINTESET_P2INTES      (_U(0x1) << USBC_UHINTESET_P2INTES_Pos)
+#define USBC_UHINTESET_P2INTES      (_U_(0x1) << USBC_UHINTESET_P2INTES_Pos)
 #define USBC_UHINTESET_P3INTES_Pos  11           /**< \brief (USBC_UHINTESET) P3INTE Set */
-#define USBC_UHINTESET_P3INTES      (_U(0x1) << USBC_UHINTESET_P3INTES_Pos)
+#define USBC_UHINTESET_P3INTES      (_U_(0x1) << USBC_UHINTESET_P3INTES_Pos)
 #define USBC_UHINTESET_P4INTES_Pos  12           /**< \brief (USBC_UHINTESET) P4INTE Set */
-#define USBC_UHINTESET_P4INTES      (_U(0x1) << USBC_UHINTESET_P4INTES_Pos)
+#define USBC_UHINTESET_P4INTES      (_U_(0x1) << USBC_UHINTESET_P4INTES_Pos)
 #define USBC_UHINTESET_P5INTES_Pos  13           /**< \brief (USBC_UHINTESET) P5INTE Set */
-#define USBC_UHINTESET_P5INTES      (_U(0x1) << USBC_UHINTESET_P5INTES_Pos)
+#define USBC_UHINTESET_P5INTES      (_U_(0x1) << USBC_UHINTESET_P5INTES_Pos)
 #define USBC_UHINTESET_P6INTES_Pos  14           /**< \brief (USBC_UHINTESET) P6INTE Set */
-#define USBC_UHINTESET_P6INTES      (_U(0x1) << USBC_UHINTESET_P6INTES_Pos)
+#define USBC_UHINTESET_P6INTES      (_U_(0x1) << USBC_UHINTESET_P6INTES_Pos)
 #define USBC_UHINTESET_P7INTES_Pos  15           /**< \brief (USBC_UHINTESET) P7INTE Set */
-#define USBC_UHINTESET_P7INTES      (_U(0x1) << USBC_UHINTESET_P7INTES_Pos)
-#define USBC_UHINTESET_MASK         _U(0x0000FF7F) /**< \brief (USBC_UHINTESET) MASK Register */
+#define USBC_UHINTESET_P7INTES      (_U_(0x1) << USBC_UHINTESET_P7INTES_Pos)
+#define USBC_UHINTESET_MASK         _U_(0x0000FF7F) /**< \brief (USBC_UHINTESET) MASK Register */
 
 /* -------- USBC_UPRST : (USBC Offset: 0x41C) (R/W 32) Pipe Reset Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4079,25 +4079,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPRST_OFFSET           0x41C        /**< \brief (USBC_UPRST offset) Pipe Reset Register */
-#define USBC_UPRST_RESETVALUE       _U(0x00000000); /**< \brief (USBC_UPRST reset_value) Pipe Reset Register */
+#define USBC_UPRST_RESETVALUE       _U_(0x00000000); /**< \brief (USBC_UPRST reset_value) Pipe Reset Register */
 
 #define USBC_UPRST_PEN0_Pos         0            /**< \brief (USBC_UPRST) Pipe0 Enable */
-#define USBC_UPRST_PEN0             (_U(0x1) << USBC_UPRST_PEN0_Pos)
+#define USBC_UPRST_PEN0             (_U_(0x1) << USBC_UPRST_PEN0_Pos)
 #define USBC_UPRST_PEN1_Pos         1            /**< \brief (USBC_UPRST) Pipe1 Enable */
-#define USBC_UPRST_PEN1             (_U(0x1) << USBC_UPRST_PEN1_Pos)
+#define USBC_UPRST_PEN1             (_U_(0x1) << USBC_UPRST_PEN1_Pos)
 #define USBC_UPRST_PEN2_Pos         2            /**< \brief (USBC_UPRST) Pipe2 Enable */
-#define USBC_UPRST_PEN2             (_U(0x1) << USBC_UPRST_PEN2_Pos)
+#define USBC_UPRST_PEN2             (_U_(0x1) << USBC_UPRST_PEN2_Pos)
 #define USBC_UPRST_PEN3_Pos         3            /**< \brief (USBC_UPRST) Pipe3 Enable */
-#define USBC_UPRST_PEN3             (_U(0x1) << USBC_UPRST_PEN3_Pos)
+#define USBC_UPRST_PEN3             (_U_(0x1) << USBC_UPRST_PEN3_Pos)
 #define USBC_UPRST_PEN4_Pos         4            /**< \brief (USBC_UPRST) Pipe4 Enable */
-#define USBC_UPRST_PEN4             (_U(0x1) << USBC_UPRST_PEN4_Pos)
+#define USBC_UPRST_PEN4             (_U_(0x1) << USBC_UPRST_PEN4_Pos)
 #define USBC_UPRST_PEN5_Pos         5            /**< \brief (USBC_UPRST) Pipe5 Enable */
-#define USBC_UPRST_PEN5             (_U(0x1) << USBC_UPRST_PEN5_Pos)
+#define USBC_UPRST_PEN5             (_U_(0x1) << USBC_UPRST_PEN5_Pos)
 #define USBC_UPRST_PEN6_Pos         6            /**< \brief (USBC_UPRST) Pipe6 Enable */
-#define USBC_UPRST_PEN6             (_U(0x1) << USBC_UPRST_PEN6_Pos)
+#define USBC_UPRST_PEN6             (_U_(0x1) << USBC_UPRST_PEN6_Pos)
 #define USBC_UPRST_PEN7_Pos         7            /**< \brief (USBC_UPRST) Pipe7 Enable */
-#define USBC_UPRST_PEN7             (_U(0x1) << USBC_UPRST_PEN7_Pos)
-#define USBC_UPRST_MASK             _U(0x000000FF) /**< \brief (USBC_UPRST) MASK Register */
+#define USBC_UPRST_PEN7             (_U_(0x1) << USBC_UPRST_PEN7_Pos)
+#define USBC_UPRST_MASK             _U_(0x000000FF) /**< \brief (USBC_UPRST) MASK Register */
 
 /* -------- USBC_UHFNUM : (USBC Offset: 0x420) (R/W 32) Host Frame Number Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4114,18 +4114,18 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UHFNUM_OFFSET          0x420        /**< \brief (USBC_UHFNUM offset) Host Frame Number Register */
-#define USBC_UHFNUM_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UHFNUM reset_value) Host Frame Number Register */
+#define USBC_UHFNUM_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UHFNUM reset_value) Host Frame Number Register */
 
 #define USBC_UHFNUM_MFNUM_Pos       0            /**< \brief (USBC_UHFNUM) Micro Frame Number */
-#define USBC_UHFNUM_MFNUM_Msk       (_U(0x7) << USBC_UHFNUM_MFNUM_Pos)
+#define USBC_UHFNUM_MFNUM_Msk       (_U_(0x7) << USBC_UHFNUM_MFNUM_Pos)
 #define USBC_UHFNUM_MFNUM(value)    (USBC_UHFNUM_MFNUM_Msk & ((value) << USBC_UHFNUM_MFNUM_Pos))
 #define USBC_UHFNUM_FNUM_Pos        3            /**< \brief (USBC_UHFNUM) Frame Number */
-#define USBC_UHFNUM_FNUM_Msk        (_U(0x7FF) << USBC_UHFNUM_FNUM_Pos)
+#define USBC_UHFNUM_FNUM_Msk        (_U_(0x7FF) << USBC_UHFNUM_FNUM_Pos)
 #define USBC_UHFNUM_FNUM(value)     (USBC_UHFNUM_FNUM_Msk & ((value) << USBC_UHFNUM_FNUM_Pos))
 #define USBC_UHFNUM_FLENHIGH_Pos    16           /**< \brief (USBC_UHFNUM) Frame Length */
-#define USBC_UHFNUM_FLENHIGH_Msk    (_U(0xFF) << USBC_UHFNUM_FLENHIGH_Pos)
+#define USBC_UHFNUM_FLENHIGH_Msk    (_U_(0xFF) << USBC_UHFNUM_FLENHIGH_Pos)
 #define USBC_UHFNUM_FLENHIGH(value) (USBC_UHFNUM_FLENHIGH_Msk & ((value) << USBC_UHFNUM_FLENHIGH_Pos))
-#define USBC_UHFNUM_MASK            _U(0x00FF3FFF) /**< \brief (USBC_UHFNUM) MASK Register */
+#define USBC_UHFNUM_MASK            _U_(0x00FF3FFF) /**< \brief (USBC_UHFNUM) MASK Register */
 
 /* -------- USBC_UHSOFC : (USBC Offset: 0x424) (R/W 32) Host Start of Frame Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4141,14 +4141,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UHSOFC_OFFSET          0x424        /**< \brief (USBC_UHSOFC offset) Host Start of Frame Control Register */
-#define USBC_UHSOFC_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UHSOFC reset_value) Host Start of Frame Control Register */
+#define USBC_UHSOFC_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UHSOFC reset_value) Host Start of Frame Control Register */
 
 #define USBC_UHSOFC_FLENC_Pos       0            /**< \brief (USBC_UHSOFC) Frame Length Control */
-#define USBC_UHSOFC_FLENC_Msk       (_U(0x3FFF) << USBC_UHSOFC_FLENC_Pos)
+#define USBC_UHSOFC_FLENC_Msk       (_U_(0x3FFF) << USBC_UHSOFC_FLENC_Pos)
 #define USBC_UHSOFC_FLENC(value)    (USBC_UHSOFC_FLENC_Msk & ((value) << USBC_UHSOFC_FLENC_Pos))
 #define USBC_UHSOFC_FLENCE_Pos      16           /**< \brief (USBC_UHSOFC) Frame Length Control Enable */
-#define USBC_UHSOFC_FLENCE          (_U(0x1) << USBC_UHSOFC_FLENCE_Pos)
-#define USBC_UHSOFC_MASK            _U(0x00013FFF) /**< \brief (USBC_UHSOFC) MASK Register */
+#define USBC_UHSOFC_FLENCE          (_U_(0x1) << USBC_UHSOFC_FLENCE_Pos)
+#define USBC_UHSOFC_MASK            _U_(0x00013FFF) /**< \brief (USBC_UHSOFC) MASK Register */
 
 /* -------- USBC_UPCFG0 : (USBC Offset: 0x500) (R/W 32) Pipe Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4172,25 +4172,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCFG0_OFFSET          0x500        /**< \brief (USBC_UPCFG0 offset) Pipe Configuration Register */
-#define USBC_UPCFG0_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCFG0 reset_value) Pipe Configuration Register */
+#define USBC_UPCFG0_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UPCFG0 reset_value) Pipe Configuration Register */
 
 #define USBC_UPCFG0_PBK_Pos         2            /**< \brief (USBC_UPCFG0) Pipe Banks */
-#define USBC_UPCFG0_PBK             (_U(0x1) << USBC_UPCFG0_PBK_Pos)
-#define   USBC_UPCFG0_PBK_SINGLE_Val      _U(0x0)   /**< \brief (USBC_UPCFG0)  */
-#define   USBC_UPCFG0_PBK_DOUBLE_Val      _U(0x1)   /**< \brief (USBC_UPCFG0)  */
+#define USBC_UPCFG0_PBK             (_U_(0x1) << USBC_UPCFG0_PBK_Pos)
+#define   USBC_UPCFG0_PBK_SINGLE_Val      _U_(0x0)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PBK_DOUBLE_Val      _U_(0x1)   /**< \brief (USBC_UPCFG0)  */
 #define USBC_UPCFG0_PBK_SINGLE      (USBC_UPCFG0_PBK_SINGLE_Val    << USBC_UPCFG0_PBK_Pos)
 #define USBC_UPCFG0_PBK_DOUBLE      (USBC_UPCFG0_PBK_DOUBLE_Val    << USBC_UPCFG0_PBK_Pos)
 #define USBC_UPCFG0_PSIZE_Pos       4            /**< \brief (USBC_UPCFG0) Pipe Size */
-#define USBC_UPCFG0_PSIZE_Msk       (_U(0x7) << USBC_UPCFG0_PSIZE_Pos)
+#define USBC_UPCFG0_PSIZE_Msk       (_U_(0x7) << USBC_UPCFG0_PSIZE_Pos)
 #define USBC_UPCFG0_PSIZE(value)    (USBC_UPCFG0_PSIZE_Msk & ((value) << USBC_UPCFG0_PSIZE_Pos))
-#define   USBC_UPCFG0_PSIZE_8_Val         _U(0x0)   /**< \brief (USBC_UPCFG0)  */
-#define   USBC_UPCFG0_PSIZE_16_Val        _U(0x1)   /**< \brief (USBC_UPCFG0)  */
-#define   USBC_UPCFG0_PSIZE_32_Val        _U(0x2)   /**< \brief (USBC_UPCFG0)  */
-#define   USBC_UPCFG0_PSIZE_64_Val        _U(0x3)   /**< \brief (USBC_UPCFG0)  */
-#define   USBC_UPCFG0_PSIZE_128_Val       _U(0x4)   /**< \brief (USBC_UPCFG0)  */
-#define   USBC_UPCFG0_PSIZE_256_Val       _U(0x5)   /**< \brief (USBC_UPCFG0)  */
-#define   USBC_UPCFG0_PSIZE_512_Val       _U(0x6)   /**< \brief (USBC_UPCFG0)  */
-#define   USBC_UPCFG0_PSIZE_1024_Val      _U(0x7)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PSIZE_8_Val         _U_(0x0)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PSIZE_16_Val        _U_(0x1)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PSIZE_32_Val        _U_(0x2)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PSIZE_64_Val        _U_(0x3)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PSIZE_128_Val       _U_(0x4)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PSIZE_256_Val       _U_(0x5)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PSIZE_512_Val       _U_(0x6)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PSIZE_1024_Val      _U_(0x7)   /**< \brief (USBC_UPCFG0)  */
 #define USBC_UPCFG0_PSIZE_8         (USBC_UPCFG0_PSIZE_8_Val       << USBC_UPCFG0_PSIZE_Pos)
 #define USBC_UPCFG0_PSIZE_16        (USBC_UPCFG0_PSIZE_16_Val      << USBC_UPCFG0_PSIZE_Pos)
 #define USBC_UPCFG0_PSIZE_32        (USBC_UPCFG0_PSIZE_32_Val      << USBC_UPCFG0_PSIZE_Pos)
@@ -4200,31 +4200,31 @@ typedef union {
 #define USBC_UPCFG0_PSIZE_512       (USBC_UPCFG0_PSIZE_512_Val     << USBC_UPCFG0_PSIZE_Pos)
 #define USBC_UPCFG0_PSIZE_1024      (USBC_UPCFG0_PSIZE_1024_Val    << USBC_UPCFG0_PSIZE_Pos)
 #define USBC_UPCFG0_PTOKEN_Pos      8            /**< \brief (USBC_UPCFG0) Pipe Token */
-#define USBC_UPCFG0_PTOKEN_Msk      (_U(0x3) << USBC_UPCFG0_PTOKEN_Pos)
+#define USBC_UPCFG0_PTOKEN_Msk      (_U_(0x3) << USBC_UPCFG0_PTOKEN_Pos)
 #define USBC_UPCFG0_PTOKEN(value)   (USBC_UPCFG0_PTOKEN_Msk & ((value) << USBC_UPCFG0_PTOKEN_Pos))
-#define   USBC_UPCFG0_PTOKEN_SETUP_Val    _U(0x0)   /**< \brief (USBC_UPCFG0)  */
-#define   USBC_UPCFG0_PTOKEN_IN_Val       _U(0x1)   /**< \brief (USBC_UPCFG0)  */
-#define   USBC_UPCFG0_PTOKEN_OUT_Val      _U(0x2)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PTOKEN_SETUP_Val    _U_(0x0)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PTOKEN_IN_Val       _U_(0x1)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PTOKEN_OUT_Val      _U_(0x2)   /**< \brief (USBC_UPCFG0)  */
 #define USBC_UPCFG0_PTOKEN_SETUP    (USBC_UPCFG0_PTOKEN_SETUP_Val  << USBC_UPCFG0_PTOKEN_Pos)
 #define USBC_UPCFG0_PTOKEN_IN       (USBC_UPCFG0_PTOKEN_IN_Val     << USBC_UPCFG0_PTOKEN_Pos)
 #define USBC_UPCFG0_PTOKEN_OUT      (USBC_UPCFG0_PTOKEN_OUT_Val    << USBC_UPCFG0_PTOKEN_Pos)
 #define USBC_UPCFG0_PTYPE_Pos       12           /**< \brief (USBC_UPCFG0) Pipe Type */
-#define USBC_UPCFG0_PTYPE_Msk       (_U(0x3) << USBC_UPCFG0_PTYPE_Pos)
+#define USBC_UPCFG0_PTYPE_Msk       (_U_(0x3) << USBC_UPCFG0_PTYPE_Pos)
 #define USBC_UPCFG0_PTYPE(value)    (USBC_UPCFG0_PTYPE_Msk & ((value) << USBC_UPCFG0_PTYPE_Pos))
-#define   USBC_UPCFG0_PTYPE_CONTROL_Val   _U(0x0)   /**< \brief (USBC_UPCFG0)  */
-#define   USBC_UPCFG0_PTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UPCFG0)  */
-#define   USBC_UPCFG0_PTYPE_BULK_Val      _U(0x2)   /**< \brief (USBC_UPCFG0)  */
-#define   USBC_UPCFG0_PTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PTYPE_CONTROL_Val   _U_(0x0)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PTYPE_ISOCHRONOUS_Val _U_(0x1)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PTYPE_BULK_Val      _U_(0x2)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PTYPE_INTERRUPT_Val _U_(0x3)   /**< \brief (USBC_UPCFG0)  */
 #define USBC_UPCFG0_PTYPE_CONTROL   (USBC_UPCFG0_PTYPE_CONTROL_Val << USBC_UPCFG0_PTYPE_Pos)
 #define USBC_UPCFG0_PTYPE_ISOCHRONOUS (USBC_UPCFG0_PTYPE_ISOCHRONOUS_Val << USBC_UPCFG0_PTYPE_Pos)
 #define USBC_UPCFG0_PTYPE_BULK      (USBC_UPCFG0_PTYPE_BULK_Val    << USBC_UPCFG0_PTYPE_Pos)
 #define USBC_UPCFG0_PTYPE_INTERRUPT (USBC_UPCFG0_PTYPE_INTERRUPT_Val << USBC_UPCFG0_PTYPE_Pos)
 #define USBC_UPCFG0_PINGEN_Pos      20           /**< \brief (USBC_UPCFG0) Ping Enable */
-#define USBC_UPCFG0_PINGEN          (_U(0x1) << USBC_UPCFG0_PINGEN_Pos)
+#define USBC_UPCFG0_PINGEN          (_U_(0x1) << USBC_UPCFG0_PINGEN_Pos)
 #define USBC_UPCFG0_BINTERVAL_Pos   24           /**< \brief (USBC_UPCFG0) binterval parameter */
-#define USBC_UPCFG0_BINTERVAL_Msk   (_U(0xFF) << USBC_UPCFG0_BINTERVAL_Pos)
+#define USBC_UPCFG0_BINTERVAL_Msk   (_U_(0xFF) << USBC_UPCFG0_BINTERVAL_Pos)
 #define USBC_UPCFG0_BINTERVAL(value) (USBC_UPCFG0_BINTERVAL_Msk & ((value) << USBC_UPCFG0_BINTERVAL_Pos))
-#define USBC_UPCFG0_MASK            _U(0xFF103374) /**< \brief (USBC_UPCFG0) MASK Register */
+#define USBC_UPCFG0_MASK            _U_(0xFF103374) /**< \brief (USBC_UPCFG0) MASK Register */
 
 /* -------- USBC_UPCFG1 : (USBC Offset: 0x504) (R/W 32) Pipe Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4248,25 +4248,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCFG1_OFFSET          0x504        /**< \brief (USBC_UPCFG1 offset) Pipe Configuration Register */
-#define USBC_UPCFG1_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCFG1 reset_value) Pipe Configuration Register */
+#define USBC_UPCFG1_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UPCFG1 reset_value) Pipe Configuration Register */
 
 #define USBC_UPCFG1_PBK_Pos         2            /**< \brief (USBC_UPCFG1) Pipe Banks */
-#define USBC_UPCFG1_PBK             (_U(0x1) << USBC_UPCFG1_PBK_Pos)
-#define   USBC_UPCFG1_PBK_SINGLE_Val      _U(0x0)   /**< \brief (USBC_UPCFG1)  */
-#define   USBC_UPCFG1_PBK_DOUBLE_Val      _U(0x1)   /**< \brief (USBC_UPCFG1)  */
+#define USBC_UPCFG1_PBK             (_U_(0x1) << USBC_UPCFG1_PBK_Pos)
+#define   USBC_UPCFG1_PBK_SINGLE_Val      _U_(0x0)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PBK_DOUBLE_Val      _U_(0x1)   /**< \brief (USBC_UPCFG1)  */
 #define USBC_UPCFG1_PBK_SINGLE      (USBC_UPCFG1_PBK_SINGLE_Val    << USBC_UPCFG1_PBK_Pos)
 #define USBC_UPCFG1_PBK_DOUBLE      (USBC_UPCFG1_PBK_DOUBLE_Val    << USBC_UPCFG1_PBK_Pos)
 #define USBC_UPCFG1_PSIZE_Pos       4            /**< \brief (USBC_UPCFG1) Pipe Size */
-#define USBC_UPCFG1_PSIZE_Msk       (_U(0x7) << USBC_UPCFG1_PSIZE_Pos)
+#define USBC_UPCFG1_PSIZE_Msk       (_U_(0x7) << USBC_UPCFG1_PSIZE_Pos)
 #define USBC_UPCFG1_PSIZE(value)    (USBC_UPCFG1_PSIZE_Msk & ((value) << USBC_UPCFG1_PSIZE_Pos))
-#define   USBC_UPCFG1_PSIZE_8_Val         _U(0x0)   /**< \brief (USBC_UPCFG1)  */
-#define   USBC_UPCFG1_PSIZE_16_Val        _U(0x1)   /**< \brief (USBC_UPCFG1)  */
-#define   USBC_UPCFG1_PSIZE_32_Val        _U(0x2)   /**< \brief (USBC_UPCFG1)  */
-#define   USBC_UPCFG1_PSIZE_64_Val        _U(0x3)   /**< \brief (USBC_UPCFG1)  */
-#define   USBC_UPCFG1_PSIZE_128_Val       _U(0x4)   /**< \brief (USBC_UPCFG1)  */
-#define   USBC_UPCFG1_PSIZE_256_Val       _U(0x5)   /**< \brief (USBC_UPCFG1)  */
-#define   USBC_UPCFG1_PSIZE_512_Val       _U(0x6)   /**< \brief (USBC_UPCFG1)  */
-#define   USBC_UPCFG1_PSIZE_1024_Val      _U(0x7)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PSIZE_8_Val         _U_(0x0)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PSIZE_16_Val        _U_(0x1)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PSIZE_32_Val        _U_(0x2)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PSIZE_64_Val        _U_(0x3)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PSIZE_128_Val       _U_(0x4)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PSIZE_256_Val       _U_(0x5)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PSIZE_512_Val       _U_(0x6)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PSIZE_1024_Val      _U_(0x7)   /**< \brief (USBC_UPCFG1)  */
 #define USBC_UPCFG1_PSIZE_8         (USBC_UPCFG1_PSIZE_8_Val       << USBC_UPCFG1_PSIZE_Pos)
 #define USBC_UPCFG1_PSIZE_16        (USBC_UPCFG1_PSIZE_16_Val      << USBC_UPCFG1_PSIZE_Pos)
 #define USBC_UPCFG1_PSIZE_32        (USBC_UPCFG1_PSIZE_32_Val      << USBC_UPCFG1_PSIZE_Pos)
@@ -4276,31 +4276,31 @@ typedef union {
 #define USBC_UPCFG1_PSIZE_512       (USBC_UPCFG1_PSIZE_512_Val     << USBC_UPCFG1_PSIZE_Pos)
 #define USBC_UPCFG1_PSIZE_1024      (USBC_UPCFG1_PSIZE_1024_Val    << USBC_UPCFG1_PSIZE_Pos)
 #define USBC_UPCFG1_PTOKEN_Pos      8            /**< \brief (USBC_UPCFG1) Pipe Token */
-#define USBC_UPCFG1_PTOKEN_Msk      (_U(0x3) << USBC_UPCFG1_PTOKEN_Pos)
+#define USBC_UPCFG1_PTOKEN_Msk      (_U_(0x3) << USBC_UPCFG1_PTOKEN_Pos)
 #define USBC_UPCFG1_PTOKEN(value)   (USBC_UPCFG1_PTOKEN_Msk & ((value) << USBC_UPCFG1_PTOKEN_Pos))
-#define   USBC_UPCFG1_PTOKEN_SETUP_Val    _U(0x0)   /**< \brief (USBC_UPCFG1)  */
-#define   USBC_UPCFG1_PTOKEN_IN_Val       _U(0x1)   /**< \brief (USBC_UPCFG1)  */
-#define   USBC_UPCFG1_PTOKEN_OUT_Val      _U(0x2)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PTOKEN_SETUP_Val    _U_(0x0)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PTOKEN_IN_Val       _U_(0x1)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PTOKEN_OUT_Val      _U_(0x2)   /**< \brief (USBC_UPCFG1)  */
 #define USBC_UPCFG1_PTOKEN_SETUP    (USBC_UPCFG1_PTOKEN_SETUP_Val  << USBC_UPCFG1_PTOKEN_Pos)
 #define USBC_UPCFG1_PTOKEN_IN       (USBC_UPCFG1_PTOKEN_IN_Val     << USBC_UPCFG1_PTOKEN_Pos)
 #define USBC_UPCFG1_PTOKEN_OUT      (USBC_UPCFG1_PTOKEN_OUT_Val    << USBC_UPCFG1_PTOKEN_Pos)
 #define USBC_UPCFG1_PTYPE_Pos       12           /**< \brief (USBC_UPCFG1) Pipe Type */
-#define USBC_UPCFG1_PTYPE_Msk       (_U(0x3) << USBC_UPCFG1_PTYPE_Pos)
+#define USBC_UPCFG1_PTYPE_Msk       (_U_(0x3) << USBC_UPCFG1_PTYPE_Pos)
 #define USBC_UPCFG1_PTYPE(value)    (USBC_UPCFG1_PTYPE_Msk & ((value) << USBC_UPCFG1_PTYPE_Pos))
-#define   USBC_UPCFG1_PTYPE_CONTROL_Val   _U(0x0)   /**< \brief (USBC_UPCFG1)  */
-#define   USBC_UPCFG1_PTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UPCFG1)  */
-#define   USBC_UPCFG1_PTYPE_BULK_Val      _U(0x2)   /**< \brief (USBC_UPCFG1)  */
-#define   USBC_UPCFG1_PTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PTYPE_CONTROL_Val   _U_(0x0)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PTYPE_ISOCHRONOUS_Val _U_(0x1)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PTYPE_BULK_Val      _U_(0x2)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PTYPE_INTERRUPT_Val _U_(0x3)   /**< \brief (USBC_UPCFG1)  */
 #define USBC_UPCFG1_PTYPE_CONTROL   (USBC_UPCFG1_PTYPE_CONTROL_Val << USBC_UPCFG1_PTYPE_Pos)
 #define USBC_UPCFG1_PTYPE_ISOCHRONOUS (USBC_UPCFG1_PTYPE_ISOCHRONOUS_Val << USBC_UPCFG1_PTYPE_Pos)
 #define USBC_UPCFG1_PTYPE_BULK      (USBC_UPCFG1_PTYPE_BULK_Val    << USBC_UPCFG1_PTYPE_Pos)
 #define USBC_UPCFG1_PTYPE_INTERRUPT (USBC_UPCFG1_PTYPE_INTERRUPT_Val << USBC_UPCFG1_PTYPE_Pos)
 #define USBC_UPCFG1_PINGEN_Pos      20           /**< \brief (USBC_UPCFG1) Ping Enable */
-#define USBC_UPCFG1_PINGEN          (_U(0x1) << USBC_UPCFG1_PINGEN_Pos)
+#define USBC_UPCFG1_PINGEN          (_U_(0x1) << USBC_UPCFG1_PINGEN_Pos)
 #define USBC_UPCFG1_BINTERVAL_Pos   24           /**< \brief (USBC_UPCFG1) binterval parameter */
-#define USBC_UPCFG1_BINTERVAL_Msk   (_U(0xFF) << USBC_UPCFG1_BINTERVAL_Pos)
+#define USBC_UPCFG1_BINTERVAL_Msk   (_U_(0xFF) << USBC_UPCFG1_BINTERVAL_Pos)
 #define USBC_UPCFG1_BINTERVAL(value) (USBC_UPCFG1_BINTERVAL_Msk & ((value) << USBC_UPCFG1_BINTERVAL_Pos))
-#define USBC_UPCFG1_MASK            _U(0xFF103374) /**< \brief (USBC_UPCFG1) MASK Register */
+#define USBC_UPCFG1_MASK            _U_(0xFF103374) /**< \brief (USBC_UPCFG1) MASK Register */
 
 /* -------- USBC_UPCFG2 : (USBC Offset: 0x508) (R/W 32) Pipe Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4324,25 +4324,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCFG2_OFFSET          0x508        /**< \brief (USBC_UPCFG2 offset) Pipe Configuration Register */
-#define USBC_UPCFG2_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCFG2 reset_value) Pipe Configuration Register */
+#define USBC_UPCFG2_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UPCFG2 reset_value) Pipe Configuration Register */
 
 #define USBC_UPCFG2_PBK_Pos         2            /**< \brief (USBC_UPCFG2) Pipe Banks */
-#define USBC_UPCFG2_PBK             (_U(0x1) << USBC_UPCFG2_PBK_Pos)
-#define   USBC_UPCFG2_PBK_SINGLE_Val      _U(0x0)   /**< \brief (USBC_UPCFG2)  */
-#define   USBC_UPCFG2_PBK_DOUBLE_Val      _U(0x1)   /**< \brief (USBC_UPCFG2)  */
+#define USBC_UPCFG2_PBK             (_U_(0x1) << USBC_UPCFG2_PBK_Pos)
+#define   USBC_UPCFG2_PBK_SINGLE_Val      _U_(0x0)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PBK_DOUBLE_Val      _U_(0x1)   /**< \brief (USBC_UPCFG2)  */
 #define USBC_UPCFG2_PBK_SINGLE      (USBC_UPCFG2_PBK_SINGLE_Val    << USBC_UPCFG2_PBK_Pos)
 #define USBC_UPCFG2_PBK_DOUBLE      (USBC_UPCFG2_PBK_DOUBLE_Val    << USBC_UPCFG2_PBK_Pos)
 #define USBC_UPCFG2_PSIZE_Pos       4            /**< \brief (USBC_UPCFG2) Pipe Size */
-#define USBC_UPCFG2_PSIZE_Msk       (_U(0x7) << USBC_UPCFG2_PSIZE_Pos)
+#define USBC_UPCFG2_PSIZE_Msk       (_U_(0x7) << USBC_UPCFG2_PSIZE_Pos)
 #define USBC_UPCFG2_PSIZE(value)    (USBC_UPCFG2_PSIZE_Msk & ((value) << USBC_UPCFG2_PSIZE_Pos))
-#define   USBC_UPCFG2_PSIZE_8_Val         _U(0x0)   /**< \brief (USBC_UPCFG2)  */
-#define   USBC_UPCFG2_PSIZE_16_Val        _U(0x1)   /**< \brief (USBC_UPCFG2)  */
-#define   USBC_UPCFG2_PSIZE_32_Val        _U(0x2)   /**< \brief (USBC_UPCFG2)  */
-#define   USBC_UPCFG2_PSIZE_64_Val        _U(0x3)   /**< \brief (USBC_UPCFG2)  */
-#define   USBC_UPCFG2_PSIZE_128_Val       _U(0x4)   /**< \brief (USBC_UPCFG2)  */
-#define   USBC_UPCFG2_PSIZE_256_Val       _U(0x5)   /**< \brief (USBC_UPCFG2)  */
-#define   USBC_UPCFG2_PSIZE_512_Val       _U(0x6)   /**< \brief (USBC_UPCFG2)  */
-#define   USBC_UPCFG2_PSIZE_1024_Val      _U(0x7)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PSIZE_8_Val         _U_(0x0)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PSIZE_16_Val        _U_(0x1)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PSIZE_32_Val        _U_(0x2)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PSIZE_64_Val        _U_(0x3)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PSIZE_128_Val       _U_(0x4)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PSIZE_256_Val       _U_(0x5)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PSIZE_512_Val       _U_(0x6)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PSIZE_1024_Val      _U_(0x7)   /**< \brief (USBC_UPCFG2)  */
 #define USBC_UPCFG2_PSIZE_8         (USBC_UPCFG2_PSIZE_8_Val       << USBC_UPCFG2_PSIZE_Pos)
 #define USBC_UPCFG2_PSIZE_16        (USBC_UPCFG2_PSIZE_16_Val      << USBC_UPCFG2_PSIZE_Pos)
 #define USBC_UPCFG2_PSIZE_32        (USBC_UPCFG2_PSIZE_32_Val      << USBC_UPCFG2_PSIZE_Pos)
@@ -4352,31 +4352,31 @@ typedef union {
 #define USBC_UPCFG2_PSIZE_512       (USBC_UPCFG2_PSIZE_512_Val     << USBC_UPCFG2_PSIZE_Pos)
 #define USBC_UPCFG2_PSIZE_1024      (USBC_UPCFG2_PSIZE_1024_Val    << USBC_UPCFG2_PSIZE_Pos)
 #define USBC_UPCFG2_PTOKEN_Pos      8            /**< \brief (USBC_UPCFG2) Pipe Token */
-#define USBC_UPCFG2_PTOKEN_Msk      (_U(0x3) << USBC_UPCFG2_PTOKEN_Pos)
+#define USBC_UPCFG2_PTOKEN_Msk      (_U_(0x3) << USBC_UPCFG2_PTOKEN_Pos)
 #define USBC_UPCFG2_PTOKEN(value)   (USBC_UPCFG2_PTOKEN_Msk & ((value) << USBC_UPCFG2_PTOKEN_Pos))
-#define   USBC_UPCFG2_PTOKEN_SETUP_Val    _U(0x0)   /**< \brief (USBC_UPCFG2)  */
-#define   USBC_UPCFG2_PTOKEN_IN_Val       _U(0x1)   /**< \brief (USBC_UPCFG2)  */
-#define   USBC_UPCFG2_PTOKEN_OUT_Val      _U(0x2)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PTOKEN_SETUP_Val    _U_(0x0)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PTOKEN_IN_Val       _U_(0x1)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PTOKEN_OUT_Val      _U_(0x2)   /**< \brief (USBC_UPCFG2)  */
 #define USBC_UPCFG2_PTOKEN_SETUP    (USBC_UPCFG2_PTOKEN_SETUP_Val  << USBC_UPCFG2_PTOKEN_Pos)
 #define USBC_UPCFG2_PTOKEN_IN       (USBC_UPCFG2_PTOKEN_IN_Val     << USBC_UPCFG2_PTOKEN_Pos)
 #define USBC_UPCFG2_PTOKEN_OUT      (USBC_UPCFG2_PTOKEN_OUT_Val    << USBC_UPCFG2_PTOKEN_Pos)
 #define USBC_UPCFG2_PTYPE_Pos       12           /**< \brief (USBC_UPCFG2) Pipe Type */
-#define USBC_UPCFG2_PTYPE_Msk       (_U(0x3) << USBC_UPCFG2_PTYPE_Pos)
+#define USBC_UPCFG2_PTYPE_Msk       (_U_(0x3) << USBC_UPCFG2_PTYPE_Pos)
 #define USBC_UPCFG2_PTYPE(value)    (USBC_UPCFG2_PTYPE_Msk & ((value) << USBC_UPCFG2_PTYPE_Pos))
-#define   USBC_UPCFG2_PTYPE_CONTROL_Val   _U(0x0)   /**< \brief (USBC_UPCFG2)  */
-#define   USBC_UPCFG2_PTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UPCFG2)  */
-#define   USBC_UPCFG2_PTYPE_BULK_Val      _U(0x2)   /**< \brief (USBC_UPCFG2)  */
-#define   USBC_UPCFG2_PTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PTYPE_CONTROL_Val   _U_(0x0)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PTYPE_ISOCHRONOUS_Val _U_(0x1)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PTYPE_BULK_Val      _U_(0x2)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PTYPE_INTERRUPT_Val _U_(0x3)   /**< \brief (USBC_UPCFG2)  */
 #define USBC_UPCFG2_PTYPE_CONTROL   (USBC_UPCFG2_PTYPE_CONTROL_Val << USBC_UPCFG2_PTYPE_Pos)
 #define USBC_UPCFG2_PTYPE_ISOCHRONOUS (USBC_UPCFG2_PTYPE_ISOCHRONOUS_Val << USBC_UPCFG2_PTYPE_Pos)
 #define USBC_UPCFG2_PTYPE_BULK      (USBC_UPCFG2_PTYPE_BULK_Val    << USBC_UPCFG2_PTYPE_Pos)
 #define USBC_UPCFG2_PTYPE_INTERRUPT (USBC_UPCFG2_PTYPE_INTERRUPT_Val << USBC_UPCFG2_PTYPE_Pos)
 #define USBC_UPCFG2_PINGEN_Pos      20           /**< \brief (USBC_UPCFG2) Ping Enable */
-#define USBC_UPCFG2_PINGEN          (_U(0x1) << USBC_UPCFG2_PINGEN_Pos)
+#define USBC_UPCFG2_PINGEN          (_U_(0x1) << USBC_UPCFG2_PINGEN_Pos)
 #define USBC_UPCFG2_BINTERVAL_Pos   24           /**< \brief (USBC_UPCFG2) binterval parameter */
-#define USBC_UPCFG2_BINTERVAL_Msk   (_U(0xFF) << USBC_UPCFG2_BINTERVAL_Pos)
+#define USBC_UPCFG2_BINTERVAL_Msk   (_U_(0xFF) << USBC_UPCFG2_BINTERVAL_Pos)
 #define USBC_UPCFG2_BINTERVAL(value) (USBC_UPCFG2_BINTERVAL_Msk & ((value) << USBC_UPCFG2_BINTERVAL_Pos))
-#define USBC_UPCFG2_MASK            _U(0xFF103374) /**< \brief (USBC_UPCFG2) MASK Register */
+#define USBC_UPCFG2_MASK            _U_(0xFF103374) /**< \brief (USBC_UPCFG2) MASK Register */
 
 /* -------- USBC_UPCFG3 : (USBC Offset: 0x50C) (R/W 32) Pipe Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4400,25 +4400,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCFG3_OFFSET          0x50C        /**< \brief (USBC_UPCFG3 offset) Pipe Configuration Register */
-#define USBC_UPCFG3_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCFG3 reset_value) Pipe Configuration Register */
+#define USBC_UPCFG3_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UPCFG3 reset_value) Pipe Configuration Register */
 
 #define USBC_UPCFG3_PBK_Pos         2            /**< \brief (USBC_UPCFG3) Pipe Banks */
-#define USBC_UPCFG3_PBK             (_U(0x1) << USBC_UPCFG3_PBK_Pos)
-#define   USBC_UPCFG3_PBK_SINGLE_Val      _U(0x0)   /**< \brief (USBC_UPCFG3)  */
-#define   USBC_UPCFG3_PBK_DOUBLE_Val      _U(0x1)   /**< \brief (USBC_UPCFG3)  */
+#define USBC_UPCFG3_PBK             (_U_(0x1) << USBC_UPCFG3_PBK_Pos)
+#define   USBC_UPCFG3_PBK_SINGLE_Val      _U_(0x0)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PBK_DOUBLE_Val      _U_(0x1)   /**< \brief (USBC_UPCFG3)  */
 #define USBC_UPCFG3_PBK_SINGLE      (USBC_UPCFG3_PBK_SINGLE_Val    << USBC_UPCFG3_PBK_Pos)
 #define USBC_UPCFG3_PBK_DOUBLE      (USBC_UPCFG3_PBK_DOUBLE_Val    << USBC_UPCFG3_PBK_Pos)
 #define USBC_UPCFG3_PSIZE_Pos       4            /**< \brief (USBC_UPCFG3) Pipe Size */
-#define USBC_UPCFG3_PSIZE_Msk       (_U(0x7) << USBC_UPCFG3_PSIZE_Pos)
+#define USBC_UPCFG3_PSIZE_Msk       (_U_(0x7) << USBC_UPCFG3_PSIZE_Pos)
 #define USBC_UPCFG3_PSIZE(value)    (USBC_UPCFG3_PSIZE_Msk & ((value) << USBC_UPCFG3_PSIZE_Pos))
-#define   USBC_UPCFG3_PSIZE_8_Val         _U(0x0)   /**< \brief (USBC_UPCFG3)  */
-#define   USBC_UPCFG3_PSIZE_16_Val        _U(0x1)   /**< \brief (USBC_UPCFG3)  */
-#define   USBC_UPCFG3_PSIZE_32_Val        _U(0x2)   /**< \brief (USBC_UPCFG3)  */
-#define   USBC_UPCFG3_PSIZE_64_Val        _U(0x3)   /**< \brief (USBC_UPCFG3)  */
-#define   USBC_UPCFG3_PSIZE_128_Val       _U(0x4)   /**< \brief (USBC_UPCFG3)  */
-#define   USBC_UPCFG3_PSIZE_256_Val       _U(0x5)   /**< \brief (USBC_UPCFG3)  */
-#define   USBC_UPCFG3_PSIZE_512_Val       _U(0x6)   /**< \brief (USBC_UPCFG3)  */
-#define   USBC_UPCFG3_PSIZE_1024_Val      _U(0x7)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PSIZE_8_Val         _U_(0x0)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PSIZE_16_Val        _U_(0x1)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PSIZE_32_Val        _U_(0x2)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PSIZE_64_Val        _U_(0x3)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PSIZE_128_Val       _U_(0x4)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PSIZE_256_Val       _U_(0x5)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PSIZE_512_Val       _U_(0x6)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PSIZE_1024_Val      _U_(0x7)   /**< \brief (USBC_UPCFG3)  */
 #define USBC_UPCFG3_PSIZE_8         (USBC_UPCFG3_PSIZE_8_Val       << USBC_UPCFG3_PSIZE_Pos)
 #define USBC_UPCFG3_PSIZE_16        (USBC_UPCFG3_PSIZE_16_Val      << USBC_UPCFG3_PSIZE_Pos)
 #define USBC_UPCFG3_PSIZE_32        (USBC_UPCFG3_PSIZE_32_Val      << USBC_UPCFG3_PSIZE_Pos)
@@ -4428,31 +4428,31 @@ typedef union {
 #define USBC_UPCFG3_PSIZE_512       (USBC_UPCFG3_PSIZE_512_Val     << USBC_UPCFG3_PSIZE_Pos)
 #define USBC_UPCFG3_PSIZE_1024      (USBC_UPCFG3_PSIZE_1024_Val    << USBC_UPCFG3_PSIZE_Pos)
 #define USBC_UPCFG3_PTOKEN_Pos      8            /**< \brief (USBC_UPCFG3) Pipe Token */
-#define USBC_UPCFG3_PTOKEN_Msk      (_U(0x3) << USBC_UPCFG3_PTOKEN_Pos)
+#define USBC_UPCFG3_PTOKEN_Msk      (_U_(0x3) << USBC_UPCFG3_PTOKEN_Pos)
 #define USBC_UPCFG3_PTOKEN(value)   (USBC_UPCFG3_PTOKEN_Msk & ((value) << USBC_UPCFG3_PTOKEN_Pos))
-#define   USBC_UPCFG3_PTOKEN_SETUP_Val    _U(0x0)   /**< \brief (USBC_UPCFG3)  */
-#define   USBC_UPCFG3_PTOKEN_IN_Val       _U(0x1)   /**< \brief (USBC_UPCFG3)  */
-#define   USBC_UPCFG3_PTOKEN_OUT_Val      _U(0x2)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PTOKEN_SETUP_Val    _U_(0x0)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PTOKEN_IN_Val       _U_(0x1)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PTOKEN_OUT_Val      _U_(0x2)   /**< \brief (USBC_UPCFG3)  */
 #define USBC_UPCFG3_PTOKEN_SETUP    (USBC_UPCFG3_PTOKEN_SETUP_Val  << USBC_UPCFG3_PTOKEN_Pos)
 #define USBC_UPCFG3_PTOKEN_IN       (USBC_UPCFG3_PTOKEN_IN_Val     << USBC_UPCFG3_PTOKEN_Pos)
 #define USBC_UPCFG3_PTOKEN_OUT      (USBC_UPCFG3_PTOKEN_OUT_Val    << USBC_UPCFG3_PTOKEN_Pos)
 #define USBC_UPCFG3_PTYPE_Pos       12           /**< \brief (USBC_UPCFG3) Pipe Type */
-#define USBC_UPCFG3_PTYPE_Msk       (_U(0x3) << USBC_UPCFG3_PTYPE_Pos)
+#define USBC_UPCFG3_PTYPE_Msk       (_U_(0x3) << USBC_UPCFG3_PTYPE_Pos)
 #define USBC_UPCFG3_PTYPE(value)    (USBC_UPCFG3_PTYPE_Msk & ((value) << USBC_UPCFG3_PTYPE_Pos))
-#define   USBC_UPCFG3_PTYPE_CONTROL_Val   _U(0x0)   /**< \brief (USBC_UPCFG3)  */
-#define   USBC_UPCFG3_PTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UPCFG3)  */
-#define   USBC_UPCFG3_PTYPE_BULK_Val      _U(0x2)   /**< \brief (USBC_UPCFG3)  */
-#define   USBC_UPCFG3_PTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PTYPE_CONTROL_Val   _U_(0x0)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PTYPE_ISOCHRONOUS_Val _U_(0x1)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PTYPE_BULK_Val      _U_(0x2)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PTYPE_INTERRUPT_Val _U_(0x3)   /**< \brief (USBC_UPCFG3)  */
 #define USBC_UPCFG3_PTYPE_CONTROL   (USBC_UPCFG3_PTYPE_CONTROL_Val << USBC_UPCFG3_PTYPE_Pos)
 #define USBC_UPCFG3_PTYPE_ISOCHRONOUS (USBC_UPCFG3_PTYPE_ISOCHRONOUS_Val << USBC_UPCFG3_PTYPE_Pos)
 #define USBC_UPCFG3_PTYPE_BULK      (USBC_UPCFG3_PTYPE_BULK_Val    << USBC_UPCFG3_PTYPE_Pos)
 #define USBC_UPCFG3_PTYPE_INTERRUPT (USBC_UPCFG3_PTYPE_INTERRUPT_Val << USBC_UPCFG3_PTYPE_Pos)
 #define USBC_UPCFG3_PINGEN_Pos      20           /**< \brief (USBC_UPCFG3) Ping Enable */
-#define USBC_UPCFG3_PINGEN          (_U(0x1) << USBC_UPCFG3_PINGEN_Pos)
+#define USBC_UPCFG3_PINGEN          (_U_(0x1) << USBC_UPCFG3_PINGEN_Pos)
 #define USBC_UPCFG3_BINTERVAL_Pos   24           /**< \brief (USBC_UPCFG3) binterval parameter */
-#define USBC_UPCFG3_BINTERVAL_Msk   (_U(0xFF) << USBC_UPCFG3_BINTERVAL_Pos)
+#define USBC_UPCFG3_BINTERVAL_Msk   (_U_(0xFF) << USBC_UPCFG3_BINTERVAL_Pos)
 #define USBC_UPCFG3_BINTERVAL(value) (USBC_UPCFG3_BINTERVAL_Msk & ((value) << USBC_UPCFG3_BINTERVAL_Pos))
-#define USBC_UPCFG3_MASK            _U(0xFF103374) /**< \brief (USBC_UPCFG3) MASK Register */
+#define USBC_UPCFG3_MASK            _U_(0xFF103374) /**< \brief (USBC_UPCFG3) MASK Register */
 
 /* -------- USBC_UPCFG4 : (USBC Offset: 0x510) (R/W 32) Pipe Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4476,25 +4476,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCFG4_OFFSET          0x510        /**< \brief (USBC_UPCFG4 offset) Pipe Configuration Register */
-#define USBC_UPCFG4_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCFG4 reset_value) Pipe Configuration Register */
+#define USBC_UPCFG4_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UPCFG4 reset_value) Pipe Configuration Register */
 
 #define USBC_UPCFG4_PBK_Pos         2            /**< \brief (USBC_UPCFG4) Pipe Banks */
-#define USBC_UPCFG4_PBK             (_U(0x1) << USBC_UPCFG4_PBK_Pos)
-#define   USBC_UPCFG4_PBK_SINGLE_Val      _U(0x0)   /**< \brief (USBC_UPCFG4)  */
-#define   USBC_UPCFG4_PBK_DOUBLE_Val      _U(0x1)   /**< \brief (USBC_UPCFG4)  */
+#define USBC_UPCFG4_PBK             (_U_(0x1) << USBC_UPCFG4_PBK_Pos)
+#define   USBC_UPCFG4_PBK_SINGLE_Val      _U_(0x0)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PBK_DOUBLE_Val      _U_(0x1)   /**< \brief (USBC_UPCFG4)  */
 #define USBC_UPCFG4_PBK_SINGLE      (USBC_UPCFG4_PBK_SINGLE_Val    << USBC_UPCFG4_PBK_Pos)
 #define USBC_UPCFG4_PBK_DOUBLE      (USBC_UPCFG4_PBK_DOUBLE_Val    << USBC_UPCFG4_PBK_Pos)
 #define USBC_UPCFG4_PSIZE_Pos       4            /**< \brief (USBC_UPCFG4) Pipe Size */
-#define USBC_UPCFG4_PSIZE_Msk       (_U(0x7) << USBC_UPCFG4_PSIZE_Pos)
+#define USBC_UPCFG4_PSIZE_Msk       (_U_(0x7) << USBC_UPCFG4_PSIZE_Pos)
 #define USBC_UPCFG4_PSIZE(value)    (USBC_UPCFG4_PSIZE_Msk & ((value) << USBC_UPCFG4_PSIZE_Pos))
-#define   USBC_UPCFG4_PSIZE_8_Val         _U(0x0)   /**< \brief (USBC_UPCFG4)  */
-#define   USBC_UPCFG4_PSIZE_16_Val        _U(0x1)   /**< \brief (USBC_UPCFG4)  */
-#define   USBC_UPCFG4_PSIZE_32_Val        _U(0x2)   /**< \brief (USBC_UPCFG4)  */
-#define   USBC_UPCFG4_PSIZE_64_Val        _U(0x3)   /**< \brief (USBC_UPCFG4)  */
-#define   USBC_UPCFG4_PSIZE_128_Val       _U(0x4)   /**< \brief (USBC_UPCFG4)  */
-#define   USBC_UPCFG4_PSIZE_256_Val       _U(0x5)   /**< \brief (USBC_UPCFG4)  */
-#define   USBC_UPCFG4_PSIZE_512_Val       _U(0x6)   /**< \brief (USBC_UPCFG4)  */
-#define   USBC_UPCFG4_PSIZE_1024_Val      _U(0x7)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PSIZE_8_Val         _U_(0x0)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PSIZE_16_Val        _U_(0x1)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PSIZE_32_Val        _U_(0x2)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PSIZE_64_Val        _U_(0x3)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PSIZE_128_Val       _U_(0x4)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PSIZE_256_Val       _U_(0x5)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PSIZE_512_Val       _U_(0x6)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PSIZE_1024_Val      _U_(0x7)   /**< \brief (USBC_UPCFG4)  */
 #define USBC_UPCFG4_PSIZE_8         (USBC_UPCFG4_PSIZE_8_Val       << USBC_UPCFG4_PSIZE_Pos)
 #define USBC_UPCFG4_PSIZE_16        (USBC_UPCFG4_PSIZE_16_Val      << USBC_UPCFG4_PSIZE_Pos)
 #define USBC_UPCFG4_PSIZE_32        (USBC_UPCFG4_PSIZE_32_Val      << USBC_UPCFG4_PSIZE_Pos)
@@ -4504,31 +4504,31 @@ typedef union {
 #define USBC_UPCFG4_PSIZE_512       (USBC_UPCFG4_PSIZE_512_Val     << USBC_UPCFG4_PSIZE_Pos)
 #define USBC_UPCFG4_PSIZE_1024      (USBC_UPCFG4_PSIZE_1024_Val    << USBC_UPCFG4_PSIZE_Pos)
 #define USBC_UPCFG4_PTOKEN_Pos      8            /**< \brief (USBC_UPCFG4) Pipe Token */
-#define USBC_UPCFG4_PTOKEN_Msk      (_U(0x3) << USBC_UPCFG4_PTOKEN_Pos)
+#define USBC_UPCFG4_PTOKEN_Msk      (_U_(0x3) << USBC_UPCFG4_PTOKEN_Pos)
 #define USBC_UPCFG4_PTOKEN(value)   (USBC_UPCFG4_PTOKEN_Msk & ((value) << USBC_UPCFG4_PTOKEN_Pos))
-#define   USBC_UPCFG4_PTOKEN_SETUP_Val    _U(0x0)   /**< \brief (USBC_UPCFG4)  */
-#define   USBC_UPCFG4_PTOKEN_IN_Val       _U(0x1)   /**< \brief (USBC_UPCFG4)  */
-#define   USBC_UPCFG4_PTOKEN_OUT_Val      _U(0x2)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PTOKEN_SETUP_Val    _U_(0x0)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PTOKEN_IN_Val       _U_(0x1)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PTOKEN_OUT_Val      _U_(0x2)   /**< \brief (USBC_UPCFG4)  */
 #define USBC_UPCFG4_PTOKEN_SETUP    (USBC_UPCFG4_PTOKEN_SETUP_Val  << USBC_UPCFG4_PTOKEN_Pos)
 #define USBC_UPCFG4_PTOKEN_IN       (USBC_UPCFG4_PTOKEN_IN_Val     << USBC_UPCFG4_PTOKEN_Pos)
 #define USBC_UPCFG4_PTOKEN_OUT      (USBC_UPCFG4_PTOKEN_OUT_Val    << USBC_UPCFG4_PTOKEN_Pos)
 #define USBC_UPCFG4_PTYPE_Pos       12           /**< \brief (USBC_UPCFG4) Pipe Type */
-#define USBC_UPCFG4_PTYPE_Msk       (_U(0x3) << USBC_UPCFG4_PTYPE_Pos)
+#define USBC_UPCFG4_PTYPE_Msk       (_U_(0x3) << USBC_UPCFG4_PTYPE_Pos)
 #define USBC_UPCFG4_PTYPE(value)    (USBC_UPCFG4_PTYPE_Msk & ((value) << USBC_UPCFG4_PTYPE_Pos))
-#define   USBC_UPCFG4_PTYPE_CONTROL_Val   _U(0x0)   /**< \brief (USBC_UPCFG4)  */
-#define   USBC_UPCFG4_PTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UPCFG4)  */
-#define   USBC_UPCFG4_PTYPE_BULK_Val      _U(0x2)   /**< \brief (USBC_UPCFG4)  */
-#define   USBC_UPCFG4_PTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PTYPE_CONTROL_Val   _U_(0x0)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PTYPE_ISOCHRONOUS_Val _U_(0x1)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PTYPE_BULK_Val      _U_(0x2)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PTYPE_INTERRUPT_Val _U_(0x3)   /**< \brief (USBC_UPCFG4)  */
 #define USBC_UPCFG4_PTYPE_CONTROL   (USBC_UPCFG4_PTYPE_CONTROL_Val << USBC_UPCFG4_PTYPE_Pos)
 #define USBC_UPCFG4_PTYPE_ISOCHRONOUS (USBC_UPCFG4_PTYPE_ISOCHRONOUS_Val << USBC_UPCFG4_PTYPE_Pos)
 #define USBC_UPCFG4_PTYPE_BULK      (USBC_UPCFG4_PTYPE_BULK_Val    << USBC_UPCFG4_PTYPE_Pos)
 #define USBC_UPCFG4_PTYPE_INTERRUPT (USBC_UPCFG4_PTYPE_INTERRUPT_Val << USBC_UPCFG4_PTYPE_Pos)
 #define USBC_UPCFG4_PINGEN_Pos      20           /**< \brief (USBC_UPCFG4) Ping Enable */
-#define USBC_UPCFG4_PINGEN          (_U(0x1) << USBC_UPCFG4_PINGEN_Pos)
+#define USBC_UPCFG4_PINGEN          (_U_(0x1) << USBC_UPCFG4_PINGEN_Pos)
 #define USBC_UPCFG4_BINTERVAL_Pos   24           /**< \brief (USBC_UPCFG4) binterval parameter */
-#define USBC_UPCFG4_BINTERVAL_Msk   (_U(0xFF) << USBC_UPCFG4_BINTERVAL_Pos)
+#define USBC_UPCFG4_BINTERVAL_Msk   (_U_(0xFF) << USBC_UPCFG4_BINTERVAL_Pos)
 #define USBC_UPCFG4_BINTERVAL(value) (USBC_UPCFG4_BINTERVAL_Msk & ((value) << USBC_UPCFG4_BINTERVAL_Pos))
-#define USBC_UPCFG4_MASK            _U(0xFF103374) /**< \brief (USBC_UPCFG4) MASK Register */
+#define USBC_UPCFG4_MASK            _U_(0xFF103374) /**< \brief (USBC_UPCFG4) MASK Register */
 
 /* -------- USBC_UPCFG5 : (USBC Offset: 0x514) (R/W 32) Pipe Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4552,25 +4552,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCFG5_OFFSET          0x514        /**< \brief (USBC_UPCFG5 offset) Pipe Configuration Register */
-#define USBC_UPCFG5_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCFG5 reset_value) Pipe Configuration Register */
+#define USBC_UPCFG5_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UPCFG5 reset_value) Pipe Configuration Register */
 
 #define USBC_UPCFG5_PBK_Pos         2            /**< \brief (USBC_UPCFG5) Pipe Banks */
-#define USBC_UPCFG5_PBK             (_U(0x1) << USBC_UPCFG5_PBK_Pos)
-#define   USBC_UPCFG5_PBK_SINGLE_Val      _U(0x0)   /**< \brief (USBC_UPCFG5)  */
-#define   USBC_UPCFG5_PBK_DOUBLE_Val      _U(0x1)   /**< \brief (USBC_UPCFG5)  */
+#define USBC_UPCFG5_PBK             (_U_(0x1) << USBC_UPCFG5_PBK_Pos)
+#define   USBC_UPCFG5_PBK_SINGLE_Val      _U_(0x0)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PBK_DOUBLE_Val      _U_(0x1)   /**< \brief (USBC_UPCFG5)  */
 #define USBC_UPCFG5_PBK_SINGLE      (USBC_UPCFG5_PBK_SINGLE_Val    << USBC_UPCFG5_PBK_Pos)
 #define USBC_UPCFG5_PBK_DOUBLE      (USBC_UPCFG5_PBK_DOUBLE_Val    << USBC_UPCFG5_PBK_Pos)
 #define USBC_UPCFG5_PSIZE_Pos       4            /**< \brief (USBC_UPCFG5) Pipe Size */
-#define USBC_UPCFG5_PSIZE_Msk       (_U(0x7) << USBC_UPCFG5_PSIZE_Pos)
+#define USBC_UPCFG5_PSIZE_Msk       (_U_(0x7) << USBC_UPCFG5_PSIZE_Pos)
 #define USBC_UPCFG5_PSIZE(value)    (USBC_UPCFG5_PSIZE_Msk & ((value) << USBC_UPCFG5_PSIZE_Pos))
-#define   USBC_UPCFG5_PSIZE_8_Val         _U(0x0)   /**< \brief (USBC_UPCFG5)  */
-#define   USBC_UPCFG5_PSIZE_16_Val        _U(0x1)   /**< \brief (USBC_UPCFG5)  */
-#define   USBC_UPCFG5_PSIZE_32_Val        _U(0x2)   /**< \brief (USBC_UPCFG5)  */
-#define   USBC_UPCFG5_PSIZE_64_Val        _U(0x3)   /**< \brief (USBC_UPCFG5)  */
-#define   USBC_UPCFG5_PSIZE_128_Val       _U(0x4)   /**< \brief (USBC_UPCFG5)  */
-#define   USBC_UPCFG5_PSIZE_256_Val       _U(0x5)   /**< \brief (USBC_UPCFG5)  */
-#define   USBC_UPCFG5_PSIZE_512_Val       _U(0x6)   /**< \brief (USBC_UPCFG5)  */
-#define   USBC_UPCFG5_PSIZE_1024_Val      _U(0x7)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PSIZE_8_Val         _U_(0x0)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PSIZE_16_Val        _U_(0x1)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PSIZE_32_Val        _U_(0x2)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PSIZE_64_Val        _U_(0x3)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PSIZE_128_Val       _U_(0x4)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PSIZE_256_Val       _U_(0x5)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PSIZE_512_Val       _U_(0x6)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PSIZE_1024_Val      _U_(0x7)   /**< \brief (USBC_UPCFG5)  */
 #define USBC_UPCFG5_PSIZE_8         (USBC_UPCFG5_PSIZE_8_Val       << USBC_UPCFG5_PSIZE_Pos)
 #define USBC_UPCFG5_PSIZE_16        (USBC_UPCFG5_PSIZE_16_Val      << USBC_UPCFG5_PSIZE_Pos)
 #define USBC_UPCFG5_PSIZE_32        (USBC_UPCFG5_PSIZE_32_Val      << USBC_UPCFG5_PSIZE_Pos)
@@ -4580,31 +4580,31 @@ typedef union {
 #define USBC_UPCFG5_PSIZE_512       (USBC_UPCFG5_PSIZE_512_Val     << USBC_UPCFG5_PSIZE_Pos)
 #define USBC_UPCFG5_PSIZE_1024      (USBC_UPCFG5_PSIZE_1024_Val    << USBC_UPCFG5_PSIZE_Pos)
 #define USBC_UPCFG5_PTOKEN_Pos      8            /**< \brief (USBC_UPCFG5) Pipe Token */
-#define USBC_UPCFG5_PTOKEN_Msk      (_U(0x3) << USBC_UPCFG5_PTOKEN_Pos)
+#define USBC_UPCFG5_PTOKEN_Msk      (_U_(0x3) << USBC_UPCFG5_PTOKEN_Pos)
 #define USBC_UPCFG5_PTOKEN(value)   (USBC_UPCFG5_PTOKEN_Msk & ((value) << USBC_UPCFG5_PTOKEN_Pos))
-#define   USBC_UPCFG5_PTOKEN_SETUP_Val    _U(0x0)   /**< \brief (USBC_UPCFG5)  */
-#define   USBC_UPCFG5_PTOKEN_IN_Val       _U(0x1)   /**< \brief (USBC_UPCFG5)  */
-#define   USBC_UPCFG5_PTOKEN_OUT_Val      _U(0x2)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PTOKEN_SETUP_Val    _U_(0x0)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PTOKEN_IN_Val       _U_(0x1)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PTOKEN_OUT_Val      _U_(0x2)   /**< \brief (USBC_UPCFG5)  */
 #define USBC_UPCFG5_PTOKEN_SETUP    (USBC_UPCFG5_PTOKEN_SETUP_Val  << USBC_UPCFG5_PTOKEN_Pos)
 #define USBC_UPCFG5_PTOKEN_IN       (USBC_UPCFG5_PTOKEN_IN_Val     << USBC_UPCFG5_PTOKEN_Pos)
 #define USBC_UPCFG5_PTOKEN_OUT      (USBC_UPCFG5_PTOKEN_OUT_Val    << USBC_UPCFG5_PTOKEN_Pos)
 #define USBC_UPCFG5_PTYPE_Pos       12           /**< \brief (USBC_UPCFG5) Pipe Type */
-#define USBC_UPCFG5_PTYPE_Msk       (_U(0x3) << USBC_UPCFG5_PTYPE_Pos)
+#define USBC_UPCFG5_PTYPE_Msk       (_U_(0x3) << USBC_UPCFG5_PTYPE_Pos)
 #define USBC_UPCFG5_PTYPE(value)    (USBC_UPCFG5_PTYPE_Msk & ((value) << USBC_UPCFG5_PTYPE_Pos))
-#define   USBC_UPCFG5_PTYPE_CONTROL_Val   _U(0x0)   /**< \brief (USBC_UPCFG5)  */
-#define   USBC_UPCFG5_PTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UPCFG5)  */
-#define   USBC_UPCFG5_PTYPE_BULK_Val      _U(0x2)   /**< \brief (USBC_UPCFG5)  */
-#define   USBC_UPCFG5_PTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PTYPE_CONTROL_Val   _U_(0x0)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PTYPE_ISOCHRONOUS_Val _U_(0x1)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PTYPE_BULK_Val      _U_(0x2)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PTYPE_INTERRUPT_Val _U_(0x3)   /**< \brief (USBC_UPCFG5)  */
 #define USBC_UPCFG5_PTYPE_CONTROL   (USBC_UPCFG5_PTYPE_CONTROL_Val << USBC_UPCFG5_PTYPE_Pos)
 #define USBC_UPCFG5_PTYPE_ISOCHRONOUS (USBC_UPCFG5_PTYPE_ISOCHRONOUS_Val << USBC_UPCFG5_PTYPE_Pos)
 #define USBC_UPCFG5_PTYPE_BULK      (USBC_UPCFG5_PTYPE_BULK_Val    << USBC_UPCFG5_PTYPE_Pos)
 #define USBC_UPCFG5_PTYPE_INTERRUPT (USBC_UPCFG5_PTYPE_INTERRUPT_Val << USBC_UPCFG5_PTYPE_Pos)
 #define USBC_UPCFG5_PINGEN_Pos      20           /**< \brief (USBC_UPCFG5) Ping Enable */
-#define USBC_UPCFG5_PINGEN          (_U(0x1) << USBC_UPCFG5_PINGEN_Pos)
+#define USBC_UPCFG5_PINGEN          (_U_(0x1) << USBC_UPCFG5_PINGEN_Pos)
 #define USBC_UPCFG5_BINTERVAL_Pos   24           /**< \brief (USBC_UPCFG5) binterval parameter */
-#define USBC_UPCFG5_BINTERVAL_Msk   (_U(0xFF) << USBC_UPCFG5_BINTERVAL_Pos)
+#define USBC_UPCFG5_BINTERVAL_Msk   (_U_(0xFF) << USBC_UPCFG5_BINTERVAL_Pos)
 #define USBC_UPCFG5_BINTERVAL(value) (USBC_UPCFG5_BINTERVAL_Msk & ((value) << USBC_UPCFG5_BINTERVAL_Pos))
-#define USBC_UPCFG5_MASK            _U(0xFF103374) /**< \brief (USBC_UPCFG5) MASK Register */
+#define USBC_UPCFG5_MASK            _U_(0xFF103374) /**< \brief (USBC_UPCFG5) MASK Register */
 
 /* -------- USBC_UPCFG6 : (USBC Offset: 0x518) (R/W 32) Pipe Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4628,25 +4628,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCFG6_OFFSET          0x518        /**< \brief (USBC_UPCFG6 offset) Pipe Configuration Register */
-#define USBC_UPCFG6_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCFG6 reset_value) Pipe Configuration Register */
+#define USBC_UPCFG6_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UPCFG6 reset_value) Pipe Configuration Register */
 
 #define USBC_UPCFG6_PBK_Pos         2            /**< \brief (USBC_UPCFG6) Pipe Banks */
-#define USBC_UPCFG6_PBK             (_U(0x1) << USBC_UPCFG6_PBK_Pos)
-#define   USBC_UPCFG6_PBK_SINGLE_Val      _U(0x0)   /**< \brief (USBC_UPCFG6)  */
-#define   USBC_UPCFG6_PBK_DOUBLE_Val      _U(0x1)   /**< \brief (USBC_UPCFG6)  */
+#define USBC_UPCFG6_PBK             (_U_(0x1) << USBC_UPCFG6_PBK_Pos)
+#define   USBC_UPCFG6_PBK_SINGLE_Val      _U_(0x0)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PBK_DOUBLE_Val      _U_(0x1)   /**< \brief (USBC_UPCFG6)  */
 #define USBC_UPCFG6_PBK_SINGLE      (USBC_UPCFG6_PBK_SINGLE_Val    << USBC_UPCFG6_PBK_Pos)
 #define USBC_UPCFG6_PBK_DOUBLE      (USBC_UPCFG6_PBK_DOUBLE_Val    << USBC_UPCFG6_PBK_Pos)
 #define USBC_UPCFG6_PSIZE_Pos       4            /**< \brief (USBC_UPCFG6) Pipe Size */
-#define USBC_UPCFG6_PSIZE_Msk       (_U(0x7) << USBC_UPCFG6_PSIZE_Pos)
+#define USBC_UPCFG6_PSIZE_Msk       (_U_(0x7) << USBC_UPCFG6_PSIZE_Pos)
 #define USBC_UPCFG6_PSIZE(value)    (USBC_UPCFG6_PSIZE_Msk & ((value) << USBC_UPCFG6_PSIZE_Pos))
-#define   USBC_UPCFG6_PSIZE_8_Val         _U(0x0)   /**< \brief (USBC_UPCFG6)  */
-#define   USBC_UPCFG6_PSIZE_16_Val        _U(0x1)   /**< \brief (USBC_UPCFG6)  */
-#define   USBC_UPCFG6_PSIZE_32_Val        _U(0x2)   /**< \brief (USBC_UPCFG6)  */
-#define   USBC_UPCFG6_PSIZE_64_Val        _U(0x3)   /**< \brief (USBC_UPCFG6)  */
-#define   USBC_UPCFG6_PSIZE_128_Val       _U(0x4)   /**< \brief (USBC_UPCFG6)  */
-#define   USBC_UPCFG6_PSIZE_256_Val       _U(0x5)   /**< \brief (USBC_UPCFG6)  */
-#define   USBC_UPCFG6_PSIZE_512_Val       _U(0x6)   /**< \brief (USBC_UPCFG6)  */
-#define   USBC_UPCFG6_PSIZE_1024_Val      _U(0x7)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PSIZE_8_Val         _U_(0x0)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PSIZE_16_Val        _U_(0x1)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PSIZE_32_Val        _U_(0x2)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PSIZE_64_Val        _U_(0x3)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PSIZE_128_Val       _U_(0x4)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PSIZE_256_Val       _U_(0x5)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PSIZE_512_Val       _U_(0x6)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PSIZE_1024_Val      _U_(0x7)   /**< \brief (USBC_UPCFG6)  */
 #define USBC_UPCFG6_PSIZE_8         (USBC_UPCFG6_PSIZE_8_Val       << USBC_UPCFG6_PSIZE_Pos)
 #define USBC_UPCFG6_PSIZE_16        (USBC_UPCFG6_PSIZE_16_Val      << USBC_UPCFG6_PSIZE_Pos)
 #define USBC_UPCFG6_PSIZE_32        (USBC_UPCFG6_PSIZE_32_Val      << USBC_UPCFG6_PSIZE_Pos)
@@ -4656,31 +4656,31 @@ typedef union {
 #define USBC_UPCFG6_PSIZE_512       (USBC_UPCFG6_PSIZE_512_Val     << USBC_UPCFG6_PSIZE_Pos)
 #define USBC_UPCFG6_PSIZE_1024      (USBC_UPCFG6_PSIZE_1024_Val    << USBC_UPCFG6_PSIZE_Pos)
 #define USBC_UPCFG6_PTOKEN_Pos      8            /**< \brief (USBC_UPCFG6) Pipe Token */
-#define USBC_UPCFG6_PTOKEN_Msk      (_U(0x3) << USBC_UPCFG6_PTOKEN_Pos)
+#define USBC_UPCFG6_PTOKEN_Msk      (_U_(0x3) << USBC_UPCFG6_PTOKEN_Pos)
 #define USBC_UPCFG6_PTOKEN(value)   (USBC_UPCFG6_PTOKEN_Msk & ((value) << USBC_UPCFG6_PTOKEN_Pos))
-#define   USBC_UPCFG6_PTOKEN_SETUP_Val    _U(0x0)   /**< \brief (USBC_UPCFG6)  */
-#define   USBC_UPCFG6_PTOKEN_IN_Val       _U(0x1)   /**< \brief (USBC_UPCFG6)  */
-#define   USBC_UPCFG6_PTOKEN_OUT_Val      _U(0x2)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PTOKEN_SETUP_Val    _U_(0x0)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PTOKEN_IN_Val       _U_(0x1)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PTOKEN_OUT_Val      _U_(0x2)   /**< \brief (USBC_UPCFG6)  */
 #define USBC_UPCFG6_PTOKEN_SETUP    (USBC_UPCFG6_PTOKEN_SETUP_Val  << USBC_UPCFG6_PTOKEN_Pos)
 #define USBC_UPCFG6_PTOKEN_IN       (USBC_UPCFG6_PTOKEN_IN_Val     << USBC_UPCFG6_PTOKEN_Pos)
 #define USBC_UPCFG6_PTOKEN_OUT      (USBC_UPCFG6_PTOKEN_OUT_Val    << USBC_UPCFG6_PTOKEN_Pos)
 #define USBC_UPCFG6_PTYPE_Pos       12           /**< \brief (USBC_UPCFG6) Pipe Type */
-#define USBC_UPCFG6_PTYPE_Msk       (_U(0x3) << USBC_UPCFG6_PTYPE_Pos)
+#define USBC_UPCFG6_PTYPE_Msk       (_U_(0x3) << USBC_UPCFG6_PTYPE_Pos)
 #define USBC_UPCFG6_PTYPE(value)    (USBC_UPCFG6_PTYPE_Msk & ((value) << USBC_UPCFG6_PTYPE_Pos))
-#define   USBC_UPCFG6_PTYPE_CONTROL_Val   _U(0x0)   /**< \brief (USBC_UPCFG6)  */
-#define   USBC_UPCFG6_PTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UPCFG6)  */
-#define   USBC_UPCFG6_PTYPE_BULK_Val      _U(0x2)   /**< \brief (USBC_UPCFG6)  */
-#define   USBC_UPCFG6_PTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PTYPE_CONTROL_Val   _U_(0x0)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PTYPE_ISOCHRONOUS_Val _U_(0x1)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PTYPE_BULK_Val      _U_(0x2)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PTYPE_INTERRUPT_Val _U_(0x3)   /**< \brief (USBC_UPCFG6)  */
 #define USBC_UPCFG6_PTYPE_CONTROL   (USBC_UPCFG6_PTYPE_CONTROL_Val << USBC_UPCFG6_PTYPE_Pos)
 #define USBC_UPCFG6_PTYPE_ISOCHRONOUS (USBC_UPCFG6_PTYPE_ISOCHRONOUS_Val << USBC_UPCFG6_PTYPE_Pos)
 #define USBC_UPCFG6_PTYPE_BULK      (USBC_UPCFG6_PTYPE_BULK_Val    << USBC_UPCFG6_PTYPE_Pos)
 #define USBC_UPCFG6_PTYPE_INTERRUPT (USBC_UPCFG6_PTYPE_INTERRUPT_Val << USBC_UPCFG6_PTYPE_Pos)
 #define USBC_UPCFG6_PINGEN_Pos      20           /**< \brief (USBC_UPCFG6) Ping Enable */
-#define USBC_UPCFG6_PINGEN          (_U(0x1) << USBC_UPCFG6_PINGEN_Pos)
+#define USBC_UPCFG6_PINGEN          (_U_(0x1) << USBC_UPCFG6_PINGEN_Pos)
 #define USBC_UPCFG6_BINTERVAL_Pos   24           /**< \brief (USBC_UPCFG6) binterval parameter */
-#define USBC_UPCFG6_BINTERVAL_Msk   (_U(0xFF) << USBC_UPCFG6_BINTERVAL_Pos)
+#define USBC_UPCFG6_BINTERVAL_Msk   (_U_(0xFF) << USBC_UPCFG6_BINTERVAL_Pos)
 #define USBC_UPCFG6_BINTERVAL(value) (USBC_UPCFG6_BINTERVAL_Msk & ((value) << USBC_UPCFG6_BINTERVAL_Pos))
-#define USBC_UPCFG6_MASK            _U(0xFF103374) /**< \brief (USBC_UPCFG6) MASK Register */
+#define USBC_UPCFG6_MASK            _U_(0xFF103374) /**< \brief (USBC_UPCFG6) MASK Register */
 
 /* -------- USBC_UPCFG7 : (USBC Offset: 0x51C) (R/W 32) Pipe Configuration Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4704,25 +4704,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCFG7_OFFSET          0x51C        /**< \brief (USBC_UPCFG7 offset) Pipe Configuration Register */
-#define USBC_UPCFG7_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCFG7 reset_value) Pipe Configuration Register */
+#define USBC_UPCFG7_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UPCFG7 reset_value) Pipe Configuration Register */
 
 #define USBC_UPCFG7_PBK_Pos         2            /**< \brief (USBC_UPCFG7) Pipe Banks */
-#define USBC_UPCFG7_PBK             (_U(0x1) << USBC_UPCFG7_PBK_Pos)
-#define   USBC_UPCFG7_PBK_SINGLE_Val      _U(0x0)   /**< \brief (USBC_UPCFG7)  */
-#define   USBC_UPCFG7_PBK_DOUBLE_Val      _U(0x1)   /**< \brief (USBC_UPCFG7)  */
+#define USBC_UPCFG7_PBK             (_U_(0x1) << USBC_UPCFG7_PBK_Pos)
+#define   USBC_UPCFG7_PBK_SINGLE_Val      _U_(0x0)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PBK_DOUBLE_Val      _U_(0x1)   /**< \brief (USBC_UPCFG7)  */
 #define USBC_UPCFG7_PBK_SINGLE      (USBC_UPCFG7_PBK_SINGLE_Val    << USBC_UPCFG7_PBK_Pos)
 #define USBC_UPCFG7_PBK_DOUBLE      (USBC_UPCFG7_PBK_DOUBLE_Val    << USBC_UPCFG7_PBK_Pos)
 #define USBC_UPCFG7_PSIZE_Pos       4            /**< \brief (USBC_UPCFG7) Pipe Size */
-#define USBC_UPCFG7_PSIZE_Msk       (_U(0x7) << USBC_UPCFG7_PSIZE_Pos)
+#define USBC_UPCFG7_PSIZE_Msk       (_U_(0x7) << USBC_UPCFG7_PSIZE_Pos)
 #define USBC_UPCFG7_PSIZE(value)    (USBC_UPCFG7_PSIZE_Msk & ((value) << USBC_UPCFG7_PSIZE_Pos))
-#define   USBC_UPCFG7_PSIZE_8_Val         _U(0x0)   /**< \brief (USBC_UPCFG7)  */
-#define   USBC_UPCFG7_PSIZE_16_Val        _U(0x1)   /**< \brief (USBC_UPCFG7)  */
-#define   USBC_UPCFG7_PSIZE_32_Val        _U(0x2)   /**< \brief (USBC_UPCFG7)  */
-#define   USBC_UPCFG7_PSIZE_64_Val        _U(0x3)   /**< \brief (USBC_UPCFG7)  */
-#define   USBC_UPCFG7_PSIZE_128_Val       _U(0x4)   /**< \brief (USBC_UPCFG7)  */
-#define   USBC_UPCFG7_PSIZE_256_Val       _U(0x5)   /**< \brief (USBC_UPCFG7)  */
-#define   USBC_UPCFG7_PSIZE_512_Val       _U(0x6)   /**< \brief (USBC_UPCFG7)  */
-#define   USBC_UPCFG7_PSIZE_1024_Val      _U(0x7)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PSIZE_8_Val         _U_(0x0)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PSIZE_16_Val        _U_(0x1)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PSIZE_32_Val        _U_(0x2)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PSIZE_64_Val        _U_(0x3)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PSIZE_128_Val       _U_(0x4)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PSIZE_256_Val       _U_(0x5)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PSIZE_512_Val       _U_(0x6)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PSIZE_1024_Val      _U_(0x7)   /**< \brief (USBC_UPCFG7)  */
 #define USBC_UPCFG7_PSIZE_8         (USBC_UPCFG7_PSIZE_8_Val       << USBC_UPCFG7_PSIZE_Pos)
 #define USBC_UPCFG7_PSIZE_16        (USBC_UPCFG7_PSIZE_16_Val      << USBC_UPCFG7_PSIZE_Pos)
 #define USBC_UPCFG7_PSIZE_32        (USBC_UPCFG7_PSIZE_32_Val      << USBC_UPCFG7_PSIZE_Pos)
@@ -4732,31 +4732,31 @@ typedef union {
 #define USBC_UPCFG7_PSIZE_512       (USBC_UPCFG7_PSIZE_512_Val     << USBC_UPCFG7_PSIZE_Pos)
 #define USBC_UPCFG7_PSIZE_1024      (USBC_UPCFG7_PSIZE_1024_Val    << USBC_UPCFG7_PSIZE_Pos)
 #define USBC_UPCFG7_PTOKEN_Pos      8            /**< \brief (USBC_UPCFG7) Pipe Token */
-#define USBC_UPCFG7_PTOKEN_Msk      (_U(0x3) << USBC_UPCFG7_PTOKEN_Pos)
+#define USBC_UPCFG7_PTOKEN_Msk      (_U_(0x3) << USBC_UPCFG7_PTOKEN_Pos)
 #define USBC_UPCFG7_PTOKEN(value)   (USBC_UPCFG7_PTOKEN_Msk & ((value) << USBC_UPCFG7_PTOKEN_Pos))
-#define   USBC_UPCFG7_PTOKEN_SETUP_Val    _U(0x0)   /**< \brief (USBC_UPCFG7)  */
-#define   USBC_UPCFG7_PTOKEN_IN_Val       _U(0x1)   /**< \brief (USBC_UPCFG7)  */
-#define   USBC_UPCFG7_PTOKEN_OUT_Val      _U(0x2)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PTOKEN_SETUP_Val    _U_(0x0)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PTOKEN_IN_Val       _U_(0x1)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PTOKEN_OUT_Val      _U_(0x2)   /**< \brief (USBC_UPCFG7)  */
 #define USBC_UPCFG7_PTOKEN_SETUP    (USBC_UPCFG7_PTOKEN_SETUP_Val  << USBC_UPCFG7_PTOKEN_Pos)
 #define USBC_UPCFG7_PTOKEN_IN       (USBC_UPCFG7_PTOKEN_IN_Val     << USBC_UPCFG7_PTOKEN_Pos)
 #define USBC_UPCFG7_PTOKEN_OUT      (USBC_UPCFG7_PTOKEN_OUT_Val    << USBC_UPCFG7_PTOKEN_Pos)
 #define USBC_UPCFG7_PTYPE_Pos       12           /**< \brief (USBC_UPCFG7) Pipe Type */
-#define USBC_UPCFG7_PTYPE_Msk       (_U(0x3) << USBC_UPCFG7_PTYPE_Pos)
+#define USBC_UPCFG7_PTYPE_Msk       (_U_(0x3) << USBC_UPCFG7_PTYPE_Pos)
 #define USBC_UPCFG7_PTYPE(value)    (USBC_UPCFG7_PTYPE_Msk & ((value) << USBC_UPCFG7_PTYPE_Pos))
-#define   USBC_UPCFG7_PTYPE_CONTROL_Val   _U(0x0)   /**< \brief (USBC_UPCFG7)  */
-#define   USBC_UPCFG7_PTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UPCFG7)  */
-#define   USBC_UPCFG7_PTYPE_BULK_Val      _U(0x2)   /**< \brief (USBC_UPCFG7)  */
-#define   USBC_UPCFG7_PTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PTYPE_CONTROL_Val   _U_(0x0)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PTYPE_ISOCHRONOUS_Val _U_(0x1)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PTYPE_BULK_Val      _U_(0x2)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PTYPE_INTERRUPT_Val _U_(0x3)   /**< \brief (USBC_UPCFG7)  */
 #define USBC_UPCFG7_PTYPE_CONTROL   (USBC_UPCFG7_PTYPE_CONTROL_Val << USBC_UPCFG7_PTYPE_Pos)
 #define USBC_UPCFG7_PTYPE_ISOCHRONOUS (USBC_UPCFG7_PTYPE_ISOCHRONOUS_Val << USBC_UPCFG7_PTYPE_Pos)
 #define USBC_UPCFG7_PTYPE_BULK      (USBC_UPCFG7_PTYPE_BULK_Val    << USBC_UPCFG7_PTYPE_Pos)
 #define USBC_UPCFG7_PTYPE_INTERRUPT (USBC_UPCFG7_PTYPE_INTERRUPT_Val << USBC_UPCFG7_PTYPE_Pos)
 #define USBC_UPCFG7_PINGEN_Pos      20           /**< \brief (USBC_UPCFG7) Ping Enable */
-#define USBC_UPCFG7_PINGEN          (_U(0x1) << USBC_UPCFG7_PINGEN_Pos)
+#define USBC_UPCFG7_PINGEN          (_U_(0x1) << USBC_UPCFG7_PINGEN_Pos)
 #define USBC_UPCFG7_BINTERVAL_Pos   24           /**< \brief (USBC_UPCFG7) binterval parameter */
-#define USBC_UPCFG7_BINTERVAL_Msk   (_U(0xFF) << USBC_UPCFG7_BINTERVAL_Pos)
+#define USBC_UPCFG7_BINTERVAL_Msk   (_U_(0xFF) << USBC_UPCFG7_BINTERVAL_Pos)
 #define USBC_UPCFG7_BINTERVAL(value) (USBC_UPCFG7_BINTERVAL_Msk & ((value) << USBC_UPCFG7_BINTERVAL_Pos))
-#define USBC_UPCFG7_MASK            _U(0xFF103374) /**< \brief (USBC_UPCFG7) MASK Register */
+#define USBC_UPCFG7_MASK            _U_(0xFF103374) /**< \brief (USBC_UPCFG7) MASK Register */
 
 /* -------- USBC_UPSTA0 : (USBC Offset: 0x530) (R/  32) Pipe Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4782,34 +4782,34 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPSTA0_OFFSET          0x530        /**< \brief (USBC_UPSTA0 offset) Pipe Status Register */
-#define USBC_UPSTA0_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPSTA0 reset_value) Pipe Status Register */
+#define USBC_UPSTA0_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UPSTA0 reset_value) Pipe Status Register */
 
 #define USBC_UPSTA0_RXINI_Pos       0            /**< \brief (USBC_UPSTA0) Received IN Data Interrupt */
-#define USBC_UPSTA0_RXINI           (_U(0x1) << USBC_UPSTA0_RXINI_Pos)
+#define USBC_UPSTA0_RXINI           (_U_(0x1) << USBC_UPSTA0_RXINI_Pos)
 #define USBC_UPSTA0_TXOUTI_Pos      1            /**< \brief (USBC_UPSTA0) Transmitted OUT Data Interrupt */
-#define USBC_UPSTA0_TXOUTI          (_U(0x1) << USBC_UPSTA0_TXOUTI_Pos)
+#define USBC_UPSTA0_TXOUTI          (_U_(0x1) << USBC_UPSTA0_TXOUTI_Pos)
 #define USBC_UPSTA0_TXSTPI_Pos      2            /**< \brief (USBC_UPSTA0) Transmitted SETUP Interrupt */
-#define USBC_UPSTA0_TXSTPI          (_U(0x1) << USBC_UPSTA0_TXSTPI_Pos)
+#define USBC_UPSTA0_TXSTPI          (_U_(0x1) << USBC_UPSTA0_TXSTPI_Pos)
 #define USBC_UPSTA0_PERRI_Pos       3            /**< \brief (USBC_UPSTA0) Pipe Error Interrupt */
-#define USBC_UPSTA0_PERRI           (_U(0x1) << USBC_UPSTA0_PERRI_Pos)
+#define USBC_UPSTA0_PERRI           (_U_(0x1) << USBC_UPSTA0_PERRI_Pos)
 #define USBC_UPSTA0_NAKEDI_Pos      4            /**< \brief (USBC_UPSTA0) NAKed Interrupt */
-#define USBC_UPSTA0_NAKEDI          (_U(0x1) << USBC_UPSTA0_NAKEDI_Pos)
+#define USBC_UPSTA0_NAKEDI          (_U_(0x1) << USBC_UPSTA0_NAKEDI_Pos)
 #define USBC_UPSTA0_ERRORFI_Pos     5            /**< \brief (USBC_UPSTA0) Errorflow Interrupt */
-#define USBC_UPSTA0_ERRORFI         (_U(0x1) << USBC_UPSTA0_ERRORFI_Pos)
+#define USBC_UPSTA0_ERRORFI         (_U_(0x1) << USBC_UPSTA0_ERRORFI_Pos)
 #define USBC_UPSTA0_RXSTALLDI_Pos   6            /**< \brief (USBC_UPSTA0) Received STALLed Interrupt */
-#define USBC_UPSTA0_RXSTALLDI       (_U(0x1) << USBC_UPSTA0_RXSTALLDI_Pos)
+#define USBC_UPSTA0_RXSTALLDI       (_U_(0x1) << USBC_UPSTA0_RXSTALLDI_Pos)
 #define USBC_UPSTA0_DTSEQ_Pos       8            /**< \brief (USBC_UPSTA0) Data Toggle Sequence */
-#define USBC_UPSTA0_DTSEQ_Msk       (_U(0x3) << USBC_UPSTA0_DTSEQ_Pos)
+#define USBC_UPSTA0_DTSEQ_Msk       (_U_(0x3) << USBC_UPSTA0_DTSEQ_Pos)
 #define USBC_UPSTA0_DTSEQ(value)    (USBC_UPSTA0_DTSEQ_Msk & ((value) << USBC_UPSTA0_DTSEQ_Pos))
 #define USBC_UPSTA0_RAMACERI_Pos    10           /**< \brief (USBC_UPSTA0) Ram Access Error Interrupt */
-#define USBC_UPSTA0_RAMACERI        (_U(0x1) << USBC_UPSTA0_RAMACERI_Pos)
+#define USBC_UPSTA0_RAMACERI        (_U_(0x1) << USBC_UPSTA0_RAMACERI_Pos)
 #define USBC_UPSTA0_NBUSYBK_Pos     12           /**< \brief (USBC_UPSTA0) Number of Busy Bank */
-#define USBC_UPSTA0_NBUSYBK_Msk     (_U(0x3) << USBC_UPSTA0_NBUSYBK_Pos)
+#define USBC_UPSTA0_NBUSYBK_Msk     (_U_(0x3) << USBC_UPSTA0_NBUSYBK_Pos)
 #define USBC_UPSTA0_NBUSYBK(value)  (USBC_UPSTA0_NBUSYBK_Msk & ((value) << USBC_UPSTA0_NBUSYBK_Pos))
 #define USBC_UPSTA0_CURRBK_Pos      14           /**< \brief (USBC_UPSTA0) Current Bank */
-#define USBC_UPSTA0_CURRBK_Msk      (_U(0x3) << USBC_UPSTA0_CURRBK_Pos)
+#define USBC_UPSTA0_CURRBK_Msk      (_U_(0x3) << USBC_UPSTA0_CURRBK_Pos)
 #define USBC_UPSTA0_CURRBK(value)   (USBC_UPSTA0_CURRBK_Msk & ((value) << USBC_UPSTA0_CURRBK_Pos))
-#define USBC_UPSTA0_MASK            _U(0x0000F77F) /**< \brief (USBC_UPSTA0) MASK Register */
+#define USBC_UPSTA0_MASK            _U_(0x0000F77F) /**< \brief (USBC_UPSTA0) MASK Register */
 
 /* -------- USBC_UPSTA1 : (USBC Offset: 0x534) (R/  32) Pipe Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4835,34 +4835,34 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPSTA1_OFFSET          0x534        /**< \brief (USBC_UPSTA1 offset) Pipe Status Register */
-#define USBC_UPSTA1_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPSTA1 reset_value) Pipe Status Register */
+#define USBC_UPSTA1_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UPSTA1 reset_value) Pipe Status Register */
 
 #define USBC_UPSTA1_RXINI_Pos       0            /**< \brief (USBC_UPSTA1) Received IN Data Interrupt */
-#define USBC_UPSTA1_RXINI           (_U(0x1) << USBC_UPSTA1_RXINI_Pos)
+#define USBC_UPSTA1_RXINI           (_U_(0x1) << USBC_UPSTA1_RXINI_Pos)
 #define USBC_UPSTA1_TXOUTI_Pos      1            /**< \brief (USBC_UPSTA1) Transmitted OUT Data Interrupt */
-#define USBC_UPSTA1_TXOUTI          (_U(0x1) << USBC_UPSTA1_TXOUTI_Pos)
+#define USBC_UPSTA1_TXOUTI          (_U_(0x1) << USBC_UPSTA1_TXOUTI_Pos)
 #define USBC_UPSTA1_TXSTPI_Pos      2            /**< \brief (USBC_UPSTA1) Transmitted SETUP Interrupt */
-#define USBC_UPSTA1_TXSTPI          (_U(0x1) << USBC_UPSTA1_TXSTPI_Pos)
+#define USBC_UPSTA1_TXSTPI          (_U_(0x1) << USBC_UPSTA1_TXSTPI_Pos)
 #define USBC_UPSTA1_PERRI_Pos       3            /**< \brief (USBC_UPSTA1) Pipe Error Interrupt */
-#define USBC_UPSTA1_PERRI           (_U(0x1) << USBC_UPSTA1_PERRI_Pos)
+#define USBC_UPSTA1_PERRI           (_U_(0x1) << USBC_UPSTA1_PERRI_Pos)
 #define USBC_UPSTA1_NAKEDI_Pos      4            /**< \brief (USBC_UPSTA1) NAKed Interrupt */
-#define USBC_UPSTA1_NAKEDI          (_U(0x1) << USBC_UPSTA1_NAKEDI_Pos)
+#define USBC_UPSTA1_NAKEDI          (_U_(0x1) << USBC_UPSTA1_NAKEDI_Pos)
 #define USBC_UPSTA1_ERRORFI_Pos     5            /**< \brief (USBC_UPSTA1) Errorflow Interrupt */
-#define USBC_UPSTA1_ERRORFI         (_U(0x1) << USBC_UPSTA1_ERRORFI_Pos)
+#define USBC_UPSTA1_ERRORFI         (_U_(0x1) << USBC_UPSTA1_ERRORFI_Pos)
 #define USBC_UPSTA1_RXSTALLDI_Pos   6            /**< \brief (USBC_UPSTA1) Received STALLed Interrupt */
-#define USBC_UPSTA1_RXSTALLDI       (_U(0x1) << USBC_UPSTA1_RXSTALLDI_Pos)
+#define USBC_UPSTA1_RXSTALLDI       (_U_(0x1) << USBC_UPSTA1_RXSTALLDI_Pos)
 #define USBC_UPSTA1_DTSEQ_Pos       8            /**< \brief (USBC_UPSTA1) Data Toggle Sequence */
-#define USBC_UPSTA1_DTSEQ_Msk       (_U(0x3) << USBC_UPSTA1_DTSEQ_Pos)
+#define USBC_UPSTA1_DTSEQ_Msk       (_U_(0x3) << USBC_UPSTA1_DTSEQ_Pos)
 #define USBC_UPSTA1_DTSEQ(value)    (USBC_UPSTA1_DTSEQ_Msk & ((value) << USBC_UPSTA1_DTSEQ_Pos))
 #define USBC_UPSTA1_RAMACERI_Pos    10           /**< \brief (USBC_UPSTA1) Ram Access Error Interrupt */
-#define USBC_UPSTA1_RAMACERI        (_U(0x1) << USBC_UPSTA1_RAMACERI_Pos)
+#define USBC_UPSTA1_RAMACERI        (_U_(0x1) << USBC_UPSTA1_RAMACERI_Pos)
 #define USBC_UPSTA1_NBUSYBK_Pos     12           /**< \brief (USBC_UPSTA1) Number of Busy Bank */
-#define USBC_UPSTA1_NBUSYBK_Msk     (_U(0x3) << USBC_UPSTA1_NBUSYBK_Pos)
+#define USBC_UPSTA1_NBUSYBK_Msk     (_U_(0x3) << USBC_UPSTA1_NBUSYBK_Pos)
 #define USBC_UPSTA1_NBUSYBK(value)  (USBC_UPSTA1_NBUSYBK_Msk & ((value) << USBC_UPSTA1_NBUSYBK_Pos))
 #define USBC_UPSTA1_CURRBK_Pos      14           /**< \brief (USBC_UPSTA1) Current Bank */
-#define USBC_UPSTA1_CURRBK_Msk      (_U(0x3) << USBC_UPSTA1_CURRBK_Pos)
+#define USBC_UPSTA1_CURRBK_Msk      (_U_(0x3) << USBC_UPSTA1_CURRBK_Pos)
 #define USBC_UPSTA1_CURRBK(value)   (USBC_UPSTA1_CURRBK_Msk & ((value) << USBC_UPSTA1_CURRBK_Pos))
-#define USBC_UPSTA1_MASK            _U(0x0000F77F) /**< \brief (USBC_UPSTA1) MASK Register */
+#define USBC_UPSTA1_MASK            _U_(0x0000F77F) /**< \brief (USBC_UPSTA1) MASK Register */
 
 /* -------- USBC_UPSTA2 : (USBC Offset: 0x538) (R/  32) Pipe Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4888,34 +4888,34 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPSTA2_OFFSET          0x538        /**< \brief (USBC_UPSTA2 offset) Pipe Status Register */
-#define USBC_UPSTA2_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPSTA2 reset_value) Pipe Status Register */
+#define USBC_UPSTA2_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UPSTA2 reset_value) Pipe Status Register */
 
 #define USBC_UPSTA2_RXINI_Pos       0            /**< \brief (USBC_UPSTA2) Received IN Data Interrupt */
-#define USBC_UPSTA2_RXINI           (_U(0x1) << USBC_UPSTA2_RXINI_Pos)
+#define USBC_UPSTA2_RXINI           (_U_(0x1) << USBC_UPSTA2_RXINI_Pos)
 #define USBC_UPSTA2_TXOUTI_Pos      1            /**< \brief (USBC_UPSTA2) Transmitted OUT Data Interrupt */
-#define USBC_UPSTA2_TXOUTI          (_U(0x1) << USBC_UPSTA2_TXOUTI_Pos)
+#define USBC_UPSTA2_TXOUTI          (_U_(0x1) << USBC_UPSTA2_TXOUTI_Pos)
 #define USBC_UPSTA2_TXSTPI_Pos      2            /**< \brief (USBC_UPSTA2) Transmitted SETUP Interrupt */
-#define USBC_UPSTA2_TXSTPI          (_U(0x1) << USBC_UPSTA2_TXSTPI_Pos)
+#define USBC_UPSTA2_TXSTPI          (_U_(0x1) << USBC_UPSTA2_TXSTPI_Pos)
 #define USBC_UPSTA2_PERRI_Pos       3            /**< \brief (USBC_UPSTA2) Pipe Error Interrupt */
-#define USBC_UPSTA2_PERRI           (_U(0x1) << USBC_UPSTA2_PERRI_Pos)
+#define USBC_UPSTA2_PERRI           (_U_(0x1) << USBC_UPSTA2_PERRI_Pos)
 #define USBC_UPSTA2_NAKEDI_Pos      4            /**< \brief (USBC_UPSTA2) NAKed Interrupt */
-#define USBC_UPSTA2_NAKEDI          (_U(0x1) << USBC_UPSTA2_NAKEDI_Pos)
+#define USBC_UPSTA2_NAKEDI          (_U_(0x1) << USBC_UPSTA2_NAKEDI_Pos)
 #define USBC_UPSTA2_ERRORFI_Pos     5            /**< \brief (USBC_UPSTA2) Errorflow Interrupt */
-#define USBC_UPSTA2_ERRORFI         (_U(0x1) << USBC_UPSTA2_ERRORFI_Pos)
+#define USBC_UPSTA2_ERRORFI         (_U_(0x1) << USBC_UPSTA2_ERRORFI_Pos)
 #define USBC_UPSTA2_RXSTALLDI_Pos   6            /**< \brief (USBC_UPSTA2) Received STALLed Interrupt */
-#define USBC_UPSTA2_RXSTALLDI       (_U(0x1) << USBC_UPSTA2_RXSTALLDI_Pos)
+#define USBC_UPSTA2_RXSTALLDI       (_U_(0x1) << USBC_UPSTA2_RXSTALLDI_Pos)
 #define USBC_UPSTA2_DTSEQ_Pos       8            /**< \brief (USBC_UPSTA2) Data Toggle Sequence */
-#define USBC_UPSTA2_DTSEQ_Msk       (_U(0x3) << USBC_UPSTA2_DTSEQ_Pos)
+#define USBC_UPSTA2_DTSEQ_Msk       (_U_(0x3) << USBC_UPSTA2_DTSEQ_Pos)
 #define USBC_UPSTA2_DTSEQ(value)    (USBC_UPSTA2_DTSEQ_Msk & ((value) << USBC_UPSTA2_DTSEQ_Pos))
 #define USBC_UPSTA2_RAMACERI_Pos    10           /**< \brief (USBC_UPSTA2) Ram Access Error Interrupt */
-#define USBC_UPSTA2_RAMACERI        (_U(0x1) << USBC_UPSTA2_RAMACERI_Pos)
+#define USBC_UPSTA2_RAMACERI        (_U_(0x1) << USBC_UPSTA2_RAMACERI_Pos)
 #define USBC_UPSTA2_NBUSYBK_Pos     12           /**< \brief (USBC_UPSTA2) Number of Busy Bank */
-#define USBC_UPSTA2_NBUSYBK_Msk     (_U(0x3) << USBC_UPSTA2_NBUSYBK_Pos)
+#define USBC_UPSTA2_NBUSYBK_Msk     (_U_(0x3) << USBC_UPSTA2_NBUSYBK_Pos)
 #define USBC_UPSTA2_NBUSYBK(value)  (USBC_UPSTA2_NBUSYBK_Msk & ((value) << USBC_UPSTA2_NBUSYBK_Pos))
 #define USBC_UPSTA2_CURRBK_Pos      14           /**< \brief (USBC_UPSTA2) Current Bank */
-#define USBC_UPSTA2_CURRBK_Msk      (_U(0x3) << USBC_UPSTA2_CURRBK_Pos)
+#define USBC_UPSTA2_CURRBK_Msk      (_U_(0x3) << USBC_UPSTA2_CURRBK_Pos)
 #define USBC_UPSTA2_CURRBK(value)   (USBC_UPSTA2_CURRBK_Msk & ((value) << USBC_UPSTA2_CURRBK_Pos))
-#define USBC_UPSTA2_MASK            _U(0x0000F77F) /**< \brief (USBC_UPSTA2) MASK Register */
+#define USBC_UPSTA2_MASK            _U_(0x0000F77F) /**< \brief (USBC_UPSTA2) MASK Register */
 
 /* -------- USBC_UPSTA3 : (USBC Offset: 0x53C) (R/  32) Pipe Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4941,34 +4941,34 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPSTA3_OFFSET          0x53C        /**< \brief (USBC_UPSTA3 offset) Pipe Status Register */
-#define USBC_UPSTA3_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPSTA3 reset_value) Pipe Status Register */
+#define USBC_UPSTA3_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UPSTA3 reset_value) Pipe Status Register */
 
 #define USBC_UPSTA3_RXINI_Pos       0            /**< \brief (USBC_UPSTA3) Received IN Data Interrupt */
-#define USBC_UPSTA3_RXINI           (_U(0x1) << USBC_UPSTA3_RXINI_Pos)
+#define USBC_UPSTA3_RXINI           (_U_(0x1) << USBC_UPSTA3_RXINI_Pos)
 #define USBC_UPSTA3_TXOUTI_Pos      1            /**< \brief (USBC_UPSTA3) Transmitted OUT Data Interrupt */
-#define USBC_UPSTA3_TXOUTI          (_U(0x1) << USBC_UPSTA3_TXOUTI_Pos)
+#define USBC_UPSTA3_TXOUTI          (_U_(0x1) << USBC_UPSTA3_TXOUTI_Pos)
 #define USBC_UPSTA3_TXSTPI_Pos      2            /**< \brief (USBC_UPSTA3) Transmitted SETUP Interrupt */
-#define USBC_UPSTA3_TXSTPI          (_U(0x1) << USBC_UPSTA3_TXSTPI_Pos)
+#define USBC_UPSTA3_TXSTPI          (_U_(0x1) << USBC_UPSTA3_TXSTPI_Pos)
 #define USBC_UPSTA3_PERRI_Pos       3            /**< \brief (USBC_UPSTA3) Pipe Error Interrupt */
-#define USBC_UPSTA3_PERRI           (_U(0x1) << USBC_UPSTA3_PERRI_Pos)
+#define USBC_UPSTA3_PERRI           (_U_(0x1) << USBC_UPSTA3_PERRI_Pos)
 #define USBC_UPSTA3_NAKEDI_Pos      4            /**< \brief (USBC_UPSTA3) NAKed Interrupt */
-#define USBC_UPSTA3_NAKEDI          (_U(0x1) << USBC_UPSTA3_NAKEDI_Pos)
+#define USBC_UPSTA3_NAKEDI          (_U_(0x1) << USBC_UPSTA3_NAKEDI_Pos)
 #define USBC_UPSTA3_ERRORFI_Pos     5            /**< \brief (USBC_UPSTA3) Errorflow Interrupt */
-#define USBC_UPSTA3_ERRORFI         (_U(0x1) << USBC_UPSTA3_ERRORFI_Pos)
+#define USBC_UPSTA3_ERRORFI         (_U_(0x1) << USBC_UPSTA3_ERRORFI_Pos)
 #define USBC_UPSTA3_RXSTALLDI_Pos   6            /**< \brief (USBC_UPSTA3) Received STALLed Interrupt */
-#define USBC_UPSTA3_RXSTALLDI       (_U(0x1) << USBC_UPSTA3_RXSTALLDI_Pos)
+#define USBC_UPSTA3_RXSTALLDI       (_U_(0x1) << USBC_UPSTA3_RXSTALLDI_Pos)
 #define USBC_UPSTA3_DTSEQ_Pos       8            /**< \brief (USBC_UPSTA3) Data Toggle Sequence */
-#define USBC_UPSTA3_DTSEQ_Msk       (_U(0x3) << USBC_UPSTA3_DTSEQ_Pos)
+#define USBC_UPSTA3_DTSEQ_Msk       (_U_(0x3) << USBC_UPSTA3_DTSEQ_Pos)
 #define USBC_UPSTA3_DTSEQ(value)    (USBC_UPSTA3_DTSEQ_Msk & ((value) << USBC_UPSTA3_DTSEQ_Pos))
 #define USBC_UPSTA3_RAMACERI_Pos    10           /**< \brief (USBC_UPSTA3) Ram Access Error Interrupt */
-#define USBC_UPSTA3_RAMACERI        (_U(0x1) << USBC_UPSTA3_RAMACERI_Pos)
+#define USBC_UPSTA3_RAMACERI        (_U_(0x1) << USBC_UPSTA3_RAMACERI_Pos)
 #define USBC_UPSTA3_NBUSYBK_Pos     12           /**< \brief (USBC_UPSTA3) Number of Busy Bank */
-#define USBC_UPSTA3_NBUSYBK_Msk     (_U(0x3) << USBC_UPSTA3_NBUSYBK_Pos)
+#define USBC_UPSTA3_NBUSYBK_Msk     (_U_(0x3) << USBC_UPSTA3_NBUSYBK_Pos)
 #define USBC_UPSTA3_NBUSYBK(value)  (USBC_UPSTA3_NBUSYBK_Msk & ((value) << USBC_UPSTA3_NBUSYBK_Pos))
 #define USBC_UPSTA3_CURRBK_Pos      14           /**< \brief (USBC_UPSTA3) Current Bank */
-#define USBC_UPSTA3_CURRBK_Msk      (_U(0x3) << USBC_UPSTA3_CURRBK_Pos)
+#define USBC_UPSTA3_CURRBK_Msk      (_U_(0x3) << USBC_UPSTA3_CURRBK_Pos)
 #define USBC_UPSTA3_CURRBK(value)   (USBC_UPSTA3_CURRBK_Msk & ((value) << USBC_UPSTA3_CURRBK_Pos))
-#define USBC_UPSTA3_MASK            _U(0x0000F77F) /**< \brief (USBC_UPSTA3) MASK Register */
+#define USBC_UPSTA3_MASK            _U_(0x0000F77F) /**< \brief (USBC_UPSTA3) MASK Register */
 
 /* -------- USBC_UPSTA4 : (USBC Offset: 0x540) (R/  32) Pipe Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4994,34 +4994,34 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPSTA4_OFFSET          0x540        /**< \brief (USBC_UPSTA4 offset) Pipe Status Register */
-#define USBC_UPSTA4_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPSTA4 reset_value) Pipe Status Register */
+#define USBC_UPSTA4_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UPSTA4 reset_value) Pipe Status Register */
 
 #define USBC_UPSTA4_RXINI_Pos       0            /**< \brief (USBC_UPSTA4) Received IN Data Interrupt */
-#define USBC_UPSTA4_RXINI           (_U(0x1) << USBC_UPSTA4_RXINI_Pos)
+#define USBC_UPSTA4_RXINI           (_U_(0x1) << USBC_UPSTA4_RXINI_Pos)
 #define USBC_UPSTA4_TXOUTI_Pos      1            /**< \brief (USBC_UPSTA4) Transmitted OUT Data Interrupt */
-#define USBC_UPSTA4_TXOUTI          (_U(0x1) << USBC_UPSTA4_TXOUTI_Pos)
+#define USBC_UPSTA4_TXOUTI          (_U_(0x1) << USBC_UPSTA4_TXOUTI_Pos)
 #define USBC_UPSTA4_TXSTPI_Pos      2            /**< \brief (USBC_UPSTA4) Transmitted SETUP Interrupt */
-#define USBC_UPSTA4_TXSTPI          (_U(0x1) << USBC_UPSTA4_TXSTPI_Pos)
+#define USBC_UPSTA4_TXSTPI          (_U_(0x1) << USBC_UPSTA4_TXSTPI_Pos)
 #define USBC_UPSTA4_PERRI_Pos       3            /**< \brief (USBC_UPSTA4) Pipe Error Interrupt */
-#define USBC_UPSTA4_PERRI           (_U(0x1) << USBC_UPSTA4_PERRI_Pos)
+#define USBC_UPSTA4_PERRI           (_U_(0x1) << USBC_UPSTA4_PERRI_Pos)
 #define USBC_UPSTA4_NAKEDI_Pos      4            /**< \brief (USBC_UPSTA4) NAKed Interrupt */
-#define USBC_UPSTA4_NAKEDI          (_U(0x1) << USBC_UPSTA4_NAKEDI_Pos)
+#define USBC_UPSTA4_NAKEDI          (_U_(0x1) << USBC_UPSTA4_NAKEDI_Pos)
 #define USBC_UPSTA4_ERRORFI_Pos     5            /**< \brief (USBC_UPSTA4) Errorflow Interrupt */
-#define USBC_UPSTA4_ERRORFI         (_U(0x1) << USBC_UPSTA4_ERRORFI_Pos)
+#define USBC_UPSTA4_ERRORFI         (_U_(0x1) << USBC_UPSTA4_ERRORFI_Pos)
 #define USBC_UPSTA4_RXSTALLDI_Pos   6            /**< \brief (USBC_UPSTA4) Received STALLed Interrupt */
-#define USBC_UPSTA4_RXSTALLDI       (_U(0x1) << USBC_UPSTA4_RXSTALLDI_Pos)
+#define USBC_UPSTA4_RXSTALLDI       (_U_(0x1) << USBC_UPSTA4_RXSTALLDI_Pos)
 #define USBC_UPSTA4_DTSEQ_Pos       8            /**< \brief (USBC_UPSTA4) Data Toggle Sequence */
-#define USBC_UPSTA4_DTSEQ_Msk       (_U(0x3) << USBC_UPSTA4_DTSEQ_Pos)
+#define USBC_UPSTA4_DTSEQ_Msk       (_U_(0x3) << USBC_UPSTA4_DTSEQ_Pos)
 #define USBC_UPSTA4_DTSEQ(value)    (USBC_UPSTA4_DTSEQ_Msk & ((value) << USBC_UPSTA4_DTSEQ_Pos))
 #define USBC_UPSTA4_RAMACERI_Pos    10           /**< \brief (USBC_UPSTA4) Ram Access Error Interrupt */
-#define USBC_UPSTA4_RAMACERI        (_U(0x1) << USBC_UPSTA4_RAMACERI_Pos)
+#define USBC_UPSTA4_RAMACERI        (_U_(0x1) << USBC_UPSTA4_RAMACERI_Pos)
 #define USBC_UPSTA4_NBUSYBK_Pos     12           /**< \brief (USBC_UPSTA4) Number of Busy Bank */
-#define USBC_UPSTA4_NBUSYBK_Msk     (_U(0x3) << USBC_UPSTA4_NBUSYBK_Pos)
+#define USBC_UPSTA4_NBUSYBK_Msk     (_U_(0x3) << USBC_UPSTA4_NBUSYBK_Pos)
 #define USBC_UPSTA4_NBUSYBK(value)  (USBC_UPSTA4_NBUSYBK_Msk & ((value) << USBC_UPSTA4_NBUSYBK_Pos))
 #define USBC_UPSTA4_CURRBK_Pos      14           /**< \brief (USBC_UPSTA4) Current Bank */
-#define USBC_UPSTA4_CURRBK_Msk      (_U(0x3) << USBC_UPSTA4_CURRBK_Pos)
+#define USBC_UPSTA4_CURRBK_Msk      (_U_(0x3) << USBC_UPSTA4_CURRBK_Pos)
 #define USBC_UPSTA4_CURRBK(value)   (USBC_UPSTA4_CURRBK_Msk & ((value) << USBC_UPSTA4_CURRBK_Pos))
-#define USBC_UPSTA4_MASK            _U(0x0000F77F) /**< \brief (USBC_UPSTA4) MASK Register */
+#define USBC_UPSTA4_MASK            _U_(0x0000F77F) /**< \brief (USBC_UPSTA4) MASK Register */
 
 /* -------- USBC_UPSTA5 : (USBC Offset: 0x544) (R/  32) Pipe Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5047,34 +5047,34 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPSTA5_OFFSET          0x544        /**< \brief (USBC_UPSTA5 offset) Pipe Status Register */
-#define USBC_UPSTA5_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPSTA5 reset_value) Pipe Status Register */
+#define USBC_UPSTA5_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UPSTA5 reset_value) Pipe Status Register */
 
 #define USBC_UPSTA5_RXINI_Pos       0            /**< \brief (USBC_UPSTA5) Received IN Data Interrupt */
-#define USBC_UPSTA5_RXINI           (_U(0x1) << USBC_UPSTA5_RXINI_Pos)
+#define USBC_UPSTA5_RXINI           (_U_(0x1) << USBC_UPSTA5_RXINI_Pos)
 #define USBC_UPSTA5_TXOUTI_Pos      1            /**< \brief (USBC_UPSTA5) Transmitted OUT Data Interrupt */
-#define USBC_UPSTA5_TXOUTI          (_U(0x1) << USBC_UPSTA5_TXOUTI_Pos)
+#define USBC_UPSTA5_TXOUTI          (_U_(0x1) << USBC_UPSTA5_TXOUTI_Pos)
 #define USBC_UPSTA5_TXSTPI_Pos      2            /**< \brief (USBC_UPSTA5) Transmitted SETUP Interrupt */
-#define USBC_UPSTA5_TXSTPI          (_U(0x1) << USBC_UPSTA5_TXSTPI_Pos)
+#define USBC_UPSTA5_TXSTPI          (_U_(0x1) << USBC_UPSTA5_TXSTPI_Pos)
 #define USBC_UPSTA5_PERRI_Pos       3            /**< \brief (USBC_UPSTA5) Pipe Error Interrupt */
-#define USBC_UPSTA5_PERRI           (_U(0x1) << USBC_UPSTA5_PERRI_Pos)
+#define USBC_UPSTA5_PERRI           (_U_(0x1) << USBC_UPSTA5_PERRI_Pos)
 #define USBC_UPSTA5_NAKEDI_Pos      4            /**< \brief (USBC_UPSTA5) NAKed Interrupt */
-#define USBC_UPSTA5_NAKEDI          (_U(0x1) << USBC_UPSTA5_NAKEDI_Pos)
+#define USBC_UPSTA5_NAKEDI          (_U_(0x1) << USBC_UPSTA5_NAKEDI_Pos)
 #define USBC_UPSTA5_ERRORFI_Pos     5            /**< \brief (USBC_UPSTA5) Errorflow Interrupt */
-#define USBC_UPSTA5_ERRORFI         (_U(0x1) << USBC_UPSTA5_ERRORFI_Pos)
+#define USBC_UPSTA5_ERRORFI         (_U_(0x1) << USBC_UPSTA5_ERRORFI_Pos)
 #define USBC_UPSTA5_RXSTALLDI_Pos   6            /**< \brief (USBC_UPSTA5) Received STALLed Interrupt */
-#define USBC_UPSTA5_RXSTALLDI       (_U(0x1) << USBC_UPSTA5_RXSTALLDI_Pos)
+#define USBC_UPSTA5_RXSTALLDI       (_U_(0x1) << USBC_UPSTA5_RXSTALLDI_Pos)
 #define USBC_UPSTA5_DTSEQ_Pos       8            /**< \brief (USBC_UPSTA5) Data Toggle Sequence */
-#define USBC_UPSTA5_DTSEQ_Msk       (_U(0x3) << USBC_UPSTA5_DTSEQ_Pos)
+#define USBC_UPSTA5_DTSEQ_Msk       (_U_(0x3) << USBC_UPSTA5_DTSEQ_Pos)
 #define USBC_UPSTA5_DTSEQ(value)    (USBC_UPSTA5_DTSEQ_Msk & ((value) << USBC_UPSTA5_DTSEQ_Pos))
 #define USBC_UPSTA5_RAMACERI_Pos    10           /**< \brief (USBC_UPSTA5) Ram Access Error Interrupt */
-#define USBC_UPSTA5_RAMACERI        (_U(0x1) << USBC_UPSTA5_RAMACERI_Pos)
+#define USBC_UPSTA5_RAMACERI        (_U_(0x1) << USBC_UPSTA5_RAMACERI_Pos)
 #define USBC_UPSTA5_NBUSYBK_Pos     12           /**< \brief (USBC_UPSTA5) Number of Busy Bank */
-#define USBC_UPSTA5_NBUSYBK_Msk     (_U(0x3) << USBC_UPSTA5_NBUSYBK_Pos)
+#define USBC_UPSTA5_NBUSYBK_Msk     (_U_(0x3) << USBC_UPSTA5_NBUSYBK_Pos)
 #define USBC_UPSTA5_NBUSYBK(value)  (USBC_UPSTA5_NBUSYBK_Msk & ((value) << USBC_UPSTA5_NBUSYBK_Pos))
 #define USBC_UPSTA5_CURRBK_Pos      14           /**< \brief (USBC_UPSTA5) Current Bank */
-#define USBC_UPSTA5_CURRBK_Msk      (_U(0x3) << USBC_UPSTA5_CURRBK_Pos)
+#define USBC_UPSTA5_CURRBK_Msk      (_U_(0x3) << USBC_UPSTA5_CURRBK_Pos)
 #define USBC_UPSTA5_CURRBK(value)   (USBC_UPSTA5_CURRBK_Msk & ((value) << USBC_UPSTA5_CURRBK_Pos))
-#define USBC_UPSTA5_MASK            _U(0x0000F77F) /**< \brief (USBC_UPSTA5) MASK Register */
+#define USBC_UPSTA5_MASK            _U_(0x0000F77F) /**< \brief (USBC_UPSTA5) MASK Register */
 
 /* -------- USBC_UPSTA6 : (USBC Offset: 0x548) (R/  32) Pipe Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5100,34 +5100,34 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPSTA6_OFFSET          0x548        /**< \brief (USBC_UPSTA6 offset) Pipe Status Register */
-#define USBC_UPSTA6_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPSTA6 reset_value) Pipe Status Register */
+#define USBC_UPSTA6_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UPSTA6 reset_value) Pipe Status Register */
 
 #define USBC_UPSTA6_RXINI_Pos       0            /**< \brief (USBC_UPSTA6) Received IN Data Interrupt */
-#define USBC_UPSTA6_RXINI           (_U(0x1) << USBC_UPSTA6_RXINI_Pos)
+#define USBC_UPSTA6_RXINI           (_U_(0x1) << USBC_UPSTA6_RXINI_Pos)
 #define USBC_UPSTA6_TXOUTI_Pos      1            /**< \brief (USBC_UPSTA6) Transmitted OUT Data Interrupt */
-#define USBC_UPSTA6_TXOUTI          (_U(0x1) << USBC_UPSTA6_TXOUTI_Pos)
+#define USBC_UPSTA6_TXOUTI          (_U_(0x1) << USBC_UPSTA6_TXOUTI_Pos)
 #define USBC_UPSTA6_TXSTPI_Pos      2            /**< \brief (USBC_UPSTA6) Transmitted SETUP Interrupt */
-#define USBC_UPSTA6_TXSTPI          (_U(0x1) << USBC_UPSTA6_TXSTPI_Pos)
+#define USBC_UPSTA6_TXSTPI          (_U_(0x1) << USBC_UPSTA6_TXSTPI_Pos)
 #define USBC_UPSTA6_PERRI_Pos       3            /**< \brief (USBC_UPSTA6) Pipe Error Interrupt */
-#define USBC_UPSTA6_PERRI           (_U(0x1) << USBC_UPSTA6_PERRI_Pos)
+#define USBC_UPSTA6_PERRI           (_U_(0x1) << USBC_UPSTA6_PERRI_Pos)
 #define USBC_UPSTA6_NAKEDI_Pos      4            /**< \brief (USBC_UPSTA6) NAKed Interrupt */
-#define USBC_UPSTA6_NAKEDI          (_U(0x1) << USBC_UPSTA6_NAKEDI_Pos)
+#define USBC_UPSTA6_NAKEDI          (_U_(0x1) << USBC_UPSTA6_NAKEDI_Pos)
 #define USBC_UPSTA6_ERRORFI_Pos     5            /**< \brief (USBC_UPSTA6) Errorflow Interrupt */
-#define USBC_UPSTA6_ERRORFI         (_U(0x1) << USBC_UPSTA6_ERRORFI_Pos)
+#define USBC_UPSTA6_ERRORFI         (_U_(0x1) << USBC_UPSTA6_ERRORFI_Pos)
 #define USBC_UPSTA6_RXSTALLDI_Pos   6            /**< \brief (USBC_UPSTA6) Received STALLed Interrupt */
-#define USBC_UPSTA6_RXSTALLDI       (_U(0x1) << USBC_UPSTA6_RXSTALLDI_Pos)
+#define USBC_UPSTA6_RXSTALLDI       (_U_(0x1) << USBC_UPSTA6_RXSTALLDI_Pos)
 #define USBC_UPSTA6_DTSEQ_Pos       8            /**< \brief (USBC_UPSTA6) Data Toggle Sequence */
-#define USBC_UPSTA6_DTSEQ_Msk       (_U(0x3) << USBC_UPSTA6_DTSEQ_Pos)
+#define USBC_UPSTA6_DTSEQ_Msk       (_U_(0x3) << USBC_UPSTA6_DTSEQ_Pos)
 #define USBC_UPSTA6_DTSEQ(value)    (USBC_UPSTA6_DTSEQ_Msk & ((value) << USBC_UPSTA6_DTSEQ_Pos))
 #define USBC_UPSTA6_RAMACERI_Pos    10           /**< \brief (USBC_UPSTA6) Ram Access Error Interrupt */
-#define USBC_UPSTA6_RAMACERI        (_U(0x1) << USBC_UPSTA6_RAMACERI_Pos)
+#define USBC_UPSTA6_RAMACERI        (_U_(0x1) << USBC_UPSTA6_RAMACERI_Pos)
 #define USBC_UPSTA6_NBUSYBK_Pos     12           /**< \brief (USBC_UPSTA6) Number of Busy Bank */
-#define USBC_UPSTA6_NBUSYBK_Msk     (_U(0x3) << USBC_UPSTA6_NBUSYBK_Pos)
+#define USBC_UPSTA6_NBUSYBK_Msk     (_U_(0x3) << USBC_UPSTA6_NBUSYBK_Pos)
 #define USBC_UPSTA6_NBUSYBK(value)  (USBC_UPSTA6_NBUSYBK_Msk & ((value) << USBC_UPSTA6_NBUSYBK_Pos))
 #define USBC_UPSTA6_CURRBK_Pos      14           /**< \brief (USBC_UPSTA6) Current Bank */
-#define USBC_UPSTA6_CURRBK_Msk      (_U(0x3) << USBC_UPSTA6_CURRBK_Pos)
+#define USBC_UPSTA6_CURRBK_Msk      (_U_(0x3) << USBC_UPSTA6_CURRBK_Pos)
 #define USBC_UPSTA6_CURRBK(value)   (USBC_UPSTA6_CURRBK_Msk & ((value) << USBC_UPSTA6_CURRBK_Pos))
-#define USBC_UPSTA6_MASK            _U(0x0000F77F) /**< \brief (USBC_UPSTA6) MASK Register */
+#define USBC_UPSTA6_MASK            _U_(0x0000F77F) /**< \brief (USBC_UPSTA6) MASK Register */
 
 /* -------- USBC_UPSTA7 : (USBC Offset: 0x54C) (R/  32) Pipe Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5153,34 +5153,34 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPSTA7_OFFSET          0x54C        /**< \brief (USBC_UPSTA7 offset) Pipe Status Register */
-#define USBC_UPSTA7_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPSTA7 reset_value) Pipe Status Register */
+#define USBC_UPSTA7_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UPSTA7 reset_value) Pipe Status Register */
 
 #define USBC_UPSTA7_RXINI_Pos       0            /**< \brief (USBC_UPSTA7) Received IN Data Interrupt */
-#define USBC_UPSTA7_RXINI           (_U(0x1) << USBC_UPSTA7_RXINI_Pos)
+#define USBC_UPSTA7_RXINI           (_U_(0x1) << USBC_UPSTA7_RXINI_Pos)
 #define USBC_UPSTA7_TXOUTI_Pos      1            /**< \brief (USBC_UPSTA7) Transmitted OUT Data Interrupt */
-#define USBC_UPSTA7_TXOUTI          (_U(0x1) << USBC_UPSTA7_TXOUTI_Pos)
+#define USBC_UPSTA7_TXOUTI          (_U_(0x1) << USBC_UPSTA7_TXOUTI_Pos)
 #define USBC_UPSTA7_TXSTPI_Pos      2            /**< \brief (USBC_UPSTA7) Transmitted SETUP Interrupt */
-#define USBC_UPSTA7_TXSTPI          (_U(0x1) << USBC_UPSTA7_TXSTPI_Pos)
+#define USBC_UPSTA7_TXSTPI          (_U_(0x1) << USBC_UPSTA7_TXSTPI_Pos)
 #define USBC_UPSTA7_PERRI_Pos       3            /**< \brief (USBC_UPSTA7) Pipe Error Interrupt */
-#define USBC_UPSTA7_PERRI           (_U(0x1) << USBC_UPSTA7_PERRI_Pos)
+#define USBC_UPSTA7_PERRI           (_U_(0x1) << USBC_UPSTA7_PERRI_Pos)
 #define USBC_UPSTA7_NAKEDI_Pos      4            /**< \brief (USBC_UPSTA7) NAKed Interrupt */
-#define USBC_UPSTA7_NAKEDI          (_U(0x1) << USBC_UPSTA7_NAKEDI_Pos)
+#define USBC_UPSTA7_NAKEDI          (_U_(0x1) << USBC_UPSTA7_NAKEDI_Pos)
 #define USBC_UPSTA7_ERRORFI_Pos     5            /**< \brief (USBC_UPSTA7) Errorflow Interrupt */
-#define USBC_UPSTA7_ERRORFI         (_U(0x1) << USBC_UPSTA7_ERRORFI_Pos)
+#define USBC_UPSTA7_ERRORFI         (_U_(0x1) << USBC_UPSTA7_ERRORFI_Pos)
 #define USBC_UPSTA7_RXSTALLDI_Pos   6            /**< \brief (USBC_UPSTA7) Received STALLed Interrupt */
-#define USBC_UPSTA7_RXSTALLDI       (_U(0x1) << USBC_UPSTA7_RXSTALLDI_Pos)
+#define USBC_UPSTA7_RXSTALLDI       (_U_(0x1) << USBC_UPSTA7_RXSTALLDI_Pos)
 #define USBC_UPSTA7_DTSEQ_Pos       8            /**< \brief (USBC_UPSTA7) Data Toggle Sequence */
-#define USBC_UPSTA7_DTSEQ_Msk       (_U(0x3) << USBC_UPSTA7_DTSEQ_Pos)
+#define USBC_UPSTA7_DTSEQ_Msk       (_U_(0x3) << USBC_UPSTA7_DTSEQ_Pos)
 #define USBC_UPSTA7_DTSEQ(value)    (USBC_UPSTA7_DTSEQ_Msk & ((value) << USBC_UPSTA7_DTSEQ_Pos))
 #define USBC_UPSTA7_RAMACERI_Pos    10           /**< \brief (USBC_UPSTA7) Ram Access Error Interrupt */
-#define USBC_UPSTA7_RAMACERI        (_U(0x1) << USBC_UPSTA7_RAMACERI_Pos)
+#define USBC_UPSTA7_RAMACERI        (_U_(0x1) << USBC_UPSTA7_RAMACERI_Pos)
 #define USBC_UPSTA7_NBUSYBK_Pos     12           /**< \brief (USBC_UPSTA7) Number of Busy Bank */
-#define USBC_UPSTA7_NBUSYBK_Msk     (_U(0x3) << USBC_UPSTA7_NBUSYBK_Pos)
+#define USBC_UPSTA7_NBUSYBK_Msk     (_U_(0x3) << USBC_UPSTA7_NBUSYBK_Pos)
 #define USBC_UPSTA7_NBUSYBK(value)  (USBC_UPSTA7_NBUSYBK_Msk & ((value) << USBC_UPSTA7_NBUSYBK_Pos))
 #define USBC_UPSTA7_CURRBK_Pos      14           /**< \brief (USBC_UPSTA7) Current Bank */
-#define USBC_UPSTA7_CURRBK_Msk      (_U(0x3) << USBC_UPSTA7_CURRBK_Pos)
+#define USBC_UPSTA7_CURRBK_Msk      (_U_(0x3) << USBC_UPSTA7_CURRBK_Pos)
 #define USBC_UPSTA7_CURRBK(value)   (USBC_UPSTA7_CURRBK_Msk & ((value) << USBC_UPSTA7_CURRBK_Pos))
-#define USBC_UPSTA7_MASK            _U(0x0000F77F) /**< \brief (USBC_UPSTA7) MASK Register */
+#define USBC_UPSTA7_MASK            _U_(0x0000F77F) /**< \brief (USBC_UPSTA7) MASK Register */
 
 /* -------- USBC_UPSTA0CLR : (USBC Offset: 0x560) ( /W 32) Pipe Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5202,25 +5202,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPSTA0CLR_OFFSET       0x560        /**< \brief (USBC_UPSTA0CLR offset) Pipe Status Clear Register */
-#define USBC_UPSTA0CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA0CLR reset_value) Pipe Status Clear Register */
+#define USBC_UPSTA0CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPSTA0CLR reset_value) Pipe Status Clear Register */
 
 #define USBC_UPSTA0CLR_RXINIC_Pos   0            /**< \brief (USBC_UPSTA0CLR) RXINI Clear */
-#define USBC_UPSTA0CLR_RXINIC       (_U(0x1) << USBC_UPSTA0CLR_RXINIC_Pos)
+#define USBC_UPSTA0CLR_RXINIC       (_U_(0x1) << USBC_UPSTA0CLR_RXINIC_Pos)
 #define USBC_UPSTA0CLR_TXOUTIC_Pos  1            /**< \brief (USBC_UPSTA0CLR) TXOUTI Clear */
-#define USBC_UPSTA0CLR_TXOUTIC      (_U(0x1) << USBC_UPSTA0CLR_TXOUTIC_Pos)
+#define USBC_UPSTA0CLR_TXOUTIC      (_U_(0x1) << USBC_UPSTA0CLR_TXOUTIC_Pos)
 #define USBC_UPSTA0CLR_TXSTPIC_Pos  2            /**< \brief (USBC_UPSTA0CLR) TXSTPI Clear */
-#define USBC_UPSTA0CLR_TXSTPIC      (_U(0x1) << USBC_UPSTA0CLR_TXSTPIC_Pos)
+#define USBC_UPSTA0CLR_TXSTPIC      (_U_(0x1) << USBC_UPSTA0CLR_TXSTPIC_Pos)
 #define USBC_UPSTA0CLR_PERRIC_Pos   3            /**< \brief (USBC_UPSTA0CLR) PERRI Clear */
-#define USBC_UPSTA0CLR_PERRIC       (_U(0x1) << USBC_UPSTA0CLR_PERRIC_Pos)
+#define USBC_UPSTA0CLR_PERRIC       (_U_(0x1) << USBC_UPSTA0CLR_PERRIC_Pos)
 #define USBC_UPSTA0CLR_NAKEDIC_Pos  4            /**< \brief (USBC_UPSTA0CLR) NAKEDI Clear */
-#define USBC_UPSTA0CLR_NAKEDIC      (_U(0x1) << USBC_UPSTA0CLR_NAKEDIC_Pos)
+#define USBC_UPSTA0CLR_NAKEDIC      (_U_(0x1) << USBC_UPSTA0CLR_NAKEDIC_Pos)
 #define USBC_UPSTA0CLR_ERRORFIC_Pos 5            /**< \brief (USBC_UPSTA0CLR) ERRORFI Clear */
-#define USBC_UPSTA0CLR_ERRORFIC     (_U(0x1) << USBC_UPSTA0CLR_ERRORFIC_Pos)
+#define USBC_UPSTA0CLR_ERRORFIC     (_U_(0x1) << USBC_UPSTA0CLR_ERRORFIC_Pos)
 #define USBC_UPSTA0CLR_RXSTALLDIC_Pos 6            /**< \brief (USBC_UPSTA0CLR) RXSTALLDI Clear */
-#define USBC_UPSTA0CLR_RXSTALLDIC   (_U(0x1) << USBC_UPSTA0CLR_RXSTALLDIC_Pos)
+#define USBC_UPSTA0CLR_RXSTALLDIC   (_U_(0x1) << USBC_UPSTA0CLR_RXSTALLDIC_Pos)
 #define USBC_UPSTA0CLR_RAMACERIC_Pos 10           /**< \brief (USBC_UPSTA0CLR) RAMACERI Clear */
-#define USBC_UPSTA0CLR_RAMACERIC    (_U(0x1) << USBC_UPSTA0CLR_RAMACERIC_Pos)
-#define USBC_UPSTA0CLR_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA0CLR) MASK Register */
+#define USBC_UPSTA0CLR_RAMACERIC    (_U_(0x1) << USBC_UPSTA0CLR_RAMACERIC_Pos)
+#define USBC_UPSTA0CLR_MASK         _U_(0x0000047F) /**< \brief (USBC_UPSTA0CLR) MASK Register */
 
 /* -------- USBC_UPSTA1CLR : (USBC Offset: 0x564) ( /W 32) Pipe Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5242,25 +5242,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPSTA1CLR_OFFSET       0x564        /**< \brief (USBC_UPSTA1CLR offset) Pipe Status Clear Register */
-#define USBC_UPSTA1CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA1CLR reset_value) Pipe Status Clear Register */
+#define USBC_UPSTA1CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPSTA1CLR reset_value) Pipe Status Clear Register */
 
 #define USBC_UPSTA1CLR_RXINIC_Pos   0            /**< \brief (USBC_UPSTA1CLR) RXINI Clear */
-#define USBC_UPSTA1CLR_RXINIC       (_U(0x1) << USBC_UPSTA1CLR_RXINIC_Pos)
+#define USBC_UPSTA1CLR_RXINIC       (_U_(0x1) << USBC_UPSTA1CLR_RXINIC_Pos)
 #define USBC_UPSTA1CLR_TXOUTIC_Pos  1            /**< \brief (USBC_UPSTA1CLR) TXOUTI Clear */
-#define USBC_UPSTA1CLR_TXOUTIC      (_U(0x1) << USBC_UPSTA1CLR_TXOUTIC_Pos)
+#define USBC_UPSTA1CLR_TXOUTIC      (_U_(0x1) << USBC_UPSTA1CLR_TXOUTIC_Pos)
 #define USBC_UPSTA1CLR_TXSTPIC_Pos  2            /**< \brief (USBC_UPSTA1CLR) TXSTPI Clear */
-#define USBC_UPSTA1CLR_TXSTPIC      (_U(0x1) << USBC_UPSTA1CLR_TXSTPIC_Pos)
+#define USBC_UPSTA1CLR_TXSTPIC      (_U_(0x1) << USBC_UPSTA1CLR_TXSTPIC_Pos)
 #define USBC_UPSTA1CLR_PERRIC_Pos   3            /**< \brief (USBC_UPSTA1CLR) PERRI Clear */
-#define USBC_UPSTA1CLR_PERRIC       (_U(0x1) << USBC_UPSTA1CLR_PERRIC_Pos)
+#define USBC_UPSTA1CLR_PERRIC       (_U_(0x1) << USBC_UPSTA1CLR_PERRIC_Pos)
 #define USBC_UPSTA1CLR_NAKEDIC_Pos  4            /**< \brief (USBC_UPSTA1CLR) NAKEDI Clear */
-#define USBC_UPSTA1CLR_NAKEDIC      (_U(0x1) << USBC_UPSTA1CLR_NAKEDIC_Pos)
+#define USBC_UPSTA1CLR_NAKEDIC      (_U_(0x1) << USBC_UPSTA1CLR_NAKEDIC_Pos)
 #define USBC_UPSTA1CLR_ERRORFIC_Pos 5            /**< \brief (USBC_UPSTA1CLR) ERRORFI Clear */
-#define USBC_UPSTA1CLR_ERRORFIC     (_U(0x1) << USBC_UPSTA1CLR_ERRORFIC_Pos)
+#define USBC_UPSTA1CLR_ERRORFIC     (_U_(0x1) << USBC_UPSTA1CLR_ERRORFIC_Pos)
 #define USBC_UPSTA1CLR_RXSTALLDIC_Pos 6            /**< \brief (USBC_UPSTA1CLR) RXSTALLDI Clear */
-#define USBC_UPSTA1CLR_RXSTALLDIC   (_U(0x1) << USBC_UPSTA1CLR_RXSTALLDIC_Pos)
+#define USBC_UPSTA1CLR_RXSTALLDIC   (_U_(0x1) << USBC_UPSTA1CLR_RXSTALLDIC_Pos)
 #define USBC_UPSTA1CLR_RAMACERIC_Pos 10           /**< \brief (USBC_UPSTA1CLR) RAMACERI Clear */
-#define USBC_UPSTA1CLR_RAMACERIC    (_U(0x1) << USBC_UPSTA1CLR_RAMACERIC_Pos)
-#define USBC_UPSTA1CLR_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA1CLR) MASK Register */
+#define USBC_UPSTA1CLR_RAMACERIC    (_U_(0x1) << USBC_UPSTA1CLR_RAMACERIC_Pos)
+#define USBC_UPSTA1CLR_MASK         _U_(0x0000047F) /**< \brief (USBC_UPSTA1CLR) MASK Register */
 
 /* -------- USBC_UPSTA2CLR : (USBC Offset: 0x568) ( /W 32) Pipe Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5282,25 +5282,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPSTA2CLR_OFFSET       0x568        /**< \brief (USBC_UPSTA2CLR offset) Pipe Status Clear Register */
-#define USBC_UPSTA2CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA2CLR reset_value) Pipe Status Clear Register */
+#define USBC_UPSTA2CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPSTA2CLR reset_value) Pipe Status Clear Register */
 
 #define USBC_UPSTA2CLR_RXINIC_Pos   0            /**< \brief (USBC_UPSTA2CLR) RXINI Clear */
-#define USBC_UPSTA2CLR_RXINIC       (_U(0x1) << USBC_UPSTA2CLR_RXINIC_Pos)
+#define USBC_UPSTA2CLR_RXINIC       (_U_(0x1) << USBC_UPSTA2CLR_RXINIC_Pos)
 #define USBC_UPSTA2CLR_TXOUTIC_Pos  1            /**< \brief (USBC_UPSTA2CLR) TXOUTI Clear */
-#define USBC_UPSTA2CLR_TXOUTIC      (_U(0x1) << USBC_UPSTA2CLR_TXOUTIC_Pos)
+#define USBC_UPSTA2CLR_TXOUTIC      (_U_(0x1) << USBC_UPSTA2CLR_TXOUTIC_Pos)
 #define USBC_UPSTA2CLR_TXSTPIC_Pos  2            /**< \brief (USBC_UPSTA2CLR) TXSTPI Clear */
-#define USBC_UPSTA2CLR_TXSTPIC      (_U(0x1) << USBC_UPSTA2CLR_TXSTPIC_Pos)
+#define USBC_UPSTA2CLR_TXSTPIC      (_U_(0x1) << USBC_UPSTA2CLR_TXSTPIC_Pos)
 #define USBC_UPSTA2CLR_PERRIC_Pos   3            /**< \brief (USBC_UPSTA2CLR) PERRI Clear */
-#define USBC_UPSTA2CLR_PERRIC       (_U(0x1) << USBC_UPSTA2CLR_PERRIC_Pos)
+#define USBC_UPSTA2CLR_PERRIC       (_U_(0x1) << USBC_UPSTA2CLR_PERRIC_Pos)
 #define USBC_UPSTA2CLR_NAKEDIC_Pos  4            /**< \brief (USBC_UPSTA2CLR) NAKEDI Clear */
-#define USBC_UPSTA2CLR_NAKEDIC      (_U(0x1) << USBC_UPSTA2CLR_NAKEDIC_Pos)
+#define USBC_UPSTA2CLR_NAKEDIC      (_U_(0x1) << USBC_UPSTA2CLR_NAKEDIC_Pos)
 #define USBC_UPSTA2CLR_ERRORFIC_Pos 5            /**< \brief (USBC_UPSTA2CLR) ERRORFI Clear */
-#define USBC_UPSTA2CLR_ERRORFIC     (_U(0x1) << USBC_UPSTA2CLR_ERRORFIC_Pos)
+#define USBC_UPSTA2CLR_ERRORFIC     (_U_(0x1) << USBC_UPSTA2CLR_ERRORFIC_Pos)
 #define USBC_UPSTA2CLR_RXSTALLDIC_Pos 6            /**< \brief (USBC_UPSTA2CLR) RXSTALLDI Clear */
-#define USBC_UPSTA2CLR_RXSTALLDIC   (_U(0x1) << USBC_UPSTA2CLR_RXSTALLDIC_Pos)
+#define USBC_UPSTA2CLR_RXSTALLDIC   (_U_(0x1) << USBC_UPSTA2CLR_RXSTALLDIC_Pos)
 #define USBC_UPSTA2CLR_RAMACERIC_Pos 10           /**< \brief (USBC_UPSTA2CLR) RAMACERI Clear */
-#define USBC_UPSTA2CLR_RAMACERIC    (_U(0x1) << USBC_UPSTA2CLR_RAMACERIC_Pos)
-#define USBC_UPSTA2CLR_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA2CLR) MASK Register */
+#define USBC_UPSTA2CLR_RAMACERIC    (_U_(0x1) << USBC_UPSTA2CLR_RAMACERIC_Pos)
+#define USBC_UPSTA2CLR_MASK         _U_(0x0000047F) /**< \brief (USBC_UPSTA2CLR) MASK Register */
 
 /* -------- USBC_UPSTA3CLR : (USBC Offset: 0x56C) ( /W 32) Pipe Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5322,25 +5322,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPSTA3CLR_OFFSET       0x56C        /**< \brief (USBC_UPSTA3CLR offset) Pipe Status Clear Register */
-#define USBC_UPSTA3CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA3CLR reset_value) Pipe Status Clear Register */
+#define USBC_UPSTA3CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPSTA3CLR reset_value) Pipe Status Clear Register */
 
 #define USBC_UPSTA3CLR_RXINIC_Pos   0            /**< \brief (USBC_UPSTA3CLR) RXINI Clear */
-#define USBC_UPSTA3CLR_RXINIC       (_U(0x1) << USBC_UPSTA3CLR_RXINIC_Pos)
+#define USBC_UPSTA3CLR_RXINIC       (_U_(0x1) << USBC_UPSTA3CLR_RXINIC_Pos)
 #define USBC_UPSTA3CLR_TXOUTIC_Pos  1            /**< \brief (USBC_UPSTA3CLR) TXOUTI Clear */
-#define USBC_UPSTA3CLR_TXOUTIC      (_U(0x1) << USBC_UPSTA3CLR_TXOUTIC_Pos)
+#define USBC_UPSTA3CLR_TXOUTIC      (_U_(0x1) << USBC_UPSTA3CLR_TXOUTIC_Pos)
 #define USBC_UPSTA3CLR_TXSTPIC_Pos  2            /**< \brief (USBC_UPSTA3CLR) TXSTPI Clear */
-#define USBC_UPSTA3CLR_TXSTPIC      (_U(0x1) << USBC_UPSTA3CLR_TXSTPIC_Pos)
+#define USBC_UPSTA3CLR_TXSTPIC      (_U_(0x1) << USBC_UPSTA3CLR_TXSTPIC_Pos)
 #define USBC_UPSTA3CLR_PERRIC_Pos   3            /**< \brief (USBC_UPSTA3CLR) PERRI Clear */
-#define USBC_UPSTA3CLR_PERRIC       (_U(0x1) << USBC_UPSTA3CLR_PERRIC_Pos)
+#define USBC_UPSTA3CLR_PERRIC       (_U_(0x1) << USBC_UPSTA3CLR_PERRIC_Pos)
 #define USBC_UPSTA3CLR_NAKEDIC_Pos  4            /**< \brief (USBC_UPSTA3CLR) NAKEDI Clear */
-#define USBC_UPSTA3CLR_NAKEDIC      (_U(0x1) << USBC_UPSTA3CLR_NAKEDIC_Pos)
+#define USBC_UPSTA3CLR_NAKEDIC      (_U_(0x1) << USBC_UPSTA3CLR_NAKEDIC_Pos)
 #define USBC_UPSTA3CLR_ERRORFIC_Pos 5            /**< \brief (USBC_UPSTA3CLR) ERRORFI Clear */
-#define USBC_UPSTA3CLR_ERRORFIC     (_U(0x1) << USBC_UPSTA3CLR_ERRORFIC_Pos)
+#define USBC_UPSTA3CLR_ERRORFIC     (_U_(0x1) << USBC_UPSTA3CLR_ERRORFIC_Pos)
 #define USBC_UPSTA3CLR_RXSTALLDIC_Pos 6            /**< \brief (USBC_UPSTA3CLR) RXSTALLDI Clear */
-#define USBC_UPSTA3CLR_RXSTALLDIC   (_U(0x1) << USBC_UPSTA3CLR_RXSTALLDIC_Pos)
+#define USBC_UPSTA3CLR_RXSTALLDIC   (_U_(0x1) << USBC_UPSTA3CLR_RXSTALLDIC_Pos)
 #define USBC_UPSTA3CLR_RAMACERIC_Pos 10           /**< \brief (USBC_UPSTA3CLR) RAMACERI Clear */
-#define USBC_UPSTA3CLR_RAMACERIC    (_U(0x1) << USBC_UPSTA3CLR_RAMACERIC_Pos)
-#define USBC_UPSTA3CLR_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA3CLR) MASK Register */
+#define USBC_UPSTA3CLR_RAMACERIC    (_U_(0x1) << USBC_UPSTA3CLR_RAMACERIC_Pos)
+#define USBC_UPSTA3CLR_MASK         _U_(0x0000047F) /**< \brief (USBC_UPSTA3CLR) MASK Register */
 
 /* -------- USBC_UPSTA4CLR : (USBC Offset: 0x570) ( /W 32) Pipe Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5362,25 +5362,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPSTA4CLR_OFFSET       0x570        /**< \brief (USBC_UPSTA4CLR offset) Pipe Status Clear Register */
-#define USBC_UPSTA4CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA4CLR reset_value) Pipe Status Clear Register */
+#define USBC_UPSTA4CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPSTA4CLR reset_value) Pipe Status Clear Register */
 
 #define USBC_UPSTA4CLR_RXINIC_Pos   0            /**< \brief (USBC_UPSTA4CLR) RXINI Clear */
-#define USBC_UPSTA4CLR_RXINIC       (_U(0x1) << USBC_UPSTA4CLR_RXINIC_Pos)
+#define USBC_UPSTA4CLR_RXINIC       (_U_(0x1) << USBC_UPSTA4CLR_RXINIC_Pos)
 #define USBC_UPSTA4CLR_TXOUTIC_Pos  1            /**< \brief (USBC_UPSTA4CLR) TXOUTI Clear */
-#define USBC_UPSTA4CLR_TXOUTIC      (_U(0x1) << USBC_UPSTA4CLR_TXOUTIC_Pos)
+#define USBC_UPSTA4CLR_TXOUTIC      (_U_(0x1) << USBC_UPSTA4CLR_TXOUTIC_Pos)
 #define USBC_UPSTA4CLR_TXSTPIC_Pos  2            /**< \brief (USBC_UPSTA4CLR) TXSTPI Clear */
-#define USBC_UPSTA4CLR_TXSTPIC      (_U(0x1) << USBC_UPSTA4CLR_TXSTPIC_Pos)
+#define USBC_UPSTA4CLR_TXSTPIC      (_U_(0x1) << USBC_UPSTA4CLR_TXSTPIC_Pos)
 #define USBC_UPSTA4CLR_PERRIC_Pos   3            /**< \brief (USBC_UPSTA4CLR) PERRI Clear */
-#define USBC_UPSTA4CLR_PERRIC       (_U(0x1) << USBC_UPSTA4CLR_PERRIC_Pos)
+#define USBC_UPSTA4CLR_PERRIC       (_U_(0x1) << USBC_UPSTA4CLR_PERRIC_Pos)
 #define USBC_UPSTA4CLR_NAKEDIC_Pos  4            /**< \brief (USBC_UPSTA4CLR) NAKEDI Clear */
-#define USBC_UPSTA4CLR_NAKEDIC      (_U(0x1) << USBC_UPSTA4CLR_NAKEDIC_Pos)
+#define USBC_UPSTA4CLR_NAKEDIC      (_U_(0x1) << USBC_UPSTA4CLR_NAKEDIC_Pos)
 #define USBC_UPSTA4CLR_ERRORFIC_Pos 5            /**< \brief (USBC_UPSTA4CLR) ERRORFI Clear */
-#define USBC_UPSTA4CLR_ERRORFIC     (_U(0x1) << USBC_UPSTA4CLR_ERRORFIC_Pos)
+#define USBC_UPSTA4CLR_ERRORFIC     (_U_(0x1) << USBC_UPSTA4CLR_ERRORFIC_Pos)
 #define USBC_UPSTA4CLR_RXSTALLDIC_Pos 6            /**< \brief (USBC_UPSTA4CLR) RXSTALLDI Clear */
-#define USBC_UPSTA4CLR_RXSTALLDIC   (_U(0x1) << USBC_UPSTA4CLR_RXSTALLDIC_Pos)
+#define USBC_UPSTA4CLR_RXSTALLDIC   (_U_(0x1) << USBC_UPSTA4CLR_RXSTALLDIC_Pos)
 #define USBC_UPSTA4CLR_RAMACERIC_Pos 10           /**< \brief (USBC_UPSTA4CLR) RAMACERI Clear */
-#define USBC_UPSTA4CLR_RAMACERIC    (_U(0x1) << USBC_UPSTA4CLR_RAMACERIC_Pos)
-#define USBC_UPSTA4CLR_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA4CLR) MASK Register */
+#define USBC_UPSTA4CLR_RAMACERIC    (_U_(0x1) << USBC_UPSTA4CLR_RAMACERIC_Pos)
+#define USBC_UPSTA4CLR_MASK         _U_(0x0000047F) /**< \brief (USBC_UPSTA4CLR) MASK Register */
 
 /* -------- USBC_UPSTA5CLR : (USBC Offset: 0x574) ( /W 32) Pipe Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5402,25 +5402,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPSTA5CLR_OFFSET       0x574        /**< \brief (USBC_UPSTA5CLR offset) Pipe Status Clear Register */
-#define USBC_UPSTA5CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA5CLR reset_value) Pipe Status Clear Register */
+#define USBC_UPSTA5CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPSTA5CLR reset_value) Pipe Status Clear Register */
 
 #define USBC_UPSTA5CLR_RXINIC_Pos   0            /**< \brief (USBC_UPSTA5CLR) RXINI Clear */
-#define USBC_UPSTA5CLR_RXINIC       (_U(0x1) << USBC_UPSTA5CLR_RXINIC_Pos)
+#define USBC_UPSTA5CLR_RXINIC       (_U_(0x1) << USBC_UPSTA5CLR_RXINIC_Pos)
 #define USBC_UPSTA5CLR_TXOUTIC_Pos  1            /**< \brief (USBC_UPSTA5CLR) TXOUTI Clear */
-#define USBC_UPSTA5CLR_TXOUTIC      (_U(0x1) << USBC_UPSTA5CLR_TXOUTIC_Pos)
+#define USBC_UPSTA5CLR_TXOUTIC      (_U_(0x1) << USBC_UPSTA5CLR_TXOUTIC_Pos)
 #define USBC_UPSTA5CLR_TXSTPIC_Pos  2            /**< \brief (USBC_UPSTA5CLR) TXSTPI Clear */
-#define USBC_UPSTA5CLR_TXSTPIC      (_U(0x1) << USBC_UPSTA5CLR_TXSTPIC_Pos)
+#define USBC_UPSTA5CLR_TXSTPIC      (_U_(0x1) << USBC_UPSTA5CLR_TXSTPIC_Pos)
 #define USBC_UPSTA5CLR_PERRIC_Pos   3            /**< \brief (USBC_UPSTA5CLR) PERRI Clear */
-#define USBC_UPSTA5CLR_PERRIC       (_U(0x1) << USBC_UPSTA5CLR_PERRIC_Pos)
+#define USBC_UPSTA5CLR_PERRIC       (_U_(0x1) << USBC_UPSTA5CLR_PERRIC_Pos)
 #define USBC_UPSTA5CLR_NAKEDIC_Pos  4            /**< \brief (USBC_UPSTA5CLR) NAKEDI Clear */
-#define USBC_UPSTA5CLR_NAKEDIC      (_U(0x1) << USBC_UPSTA5CLR_NAKEDIC_Pos)
+#define USBC_UPSTA5CLR_NAKEDIC      (_U_(0x1) << USBC_UPSTA5CLR_NAKEDIC_Pos)
 #define USBC_UPSTA5CLR_ERRORFIC_Pos 5            /**< \brief (USBC_UPSTA5CLR) ERRORFI Clear */
-#define USBC_UPSTA5CLR_ERRORFIC     (_U(0x1) << USBC_UPSTA5CLR_ERRORFIC_Pos)
+#define USBC_UPSTA5CLR_ERRORFIC     (_U_(0x1) << USBC_UPSTA5CLR_ERRORFIC_Pos)
 #define USBC_UPSTA5CLR_RXSTALLDIC_Pos 6            /**< \brief (USBC_UPSTA5CLR) RXSTALLDI Clear */
-#define USBC_UPSTA5CLR_RXSTALLDIC   (_U(0x1) << USBC_UPSTA5CLR_RXSTALLDIC_Pos)
+#define USBC_UPSTA5CLR_RXSTALLDIC   (_U_(0x1) << USBC_UPSTA5CLR_RXSTALLDIC_Pos)
 #define USBC_UPSTA5CLR_RAMACERIC_Pos 10           /**< \brief (USBC_UPSTA5CLR) RAMACERI Clear */
-#define USBC_UPSTA5CLR_RAMACERIC    (_U(0x1) << USBC_UPSTA5CLR_RAMACERIC_Pos)
-#define USBC_UPSTA5CLR_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA5CLR) MASK Register */
+#define USBC_UPSTA5CLR_RAMACERIC    (_U_(0x1) << USBC_UPSTA5CLR_RAMACERIC_Pos)
+#define USBC_UPSTA5CLR_MASK         _U_(0x0000047F) /**< \brief (USBC_UPSTA5CLR) MASK Register */
 
 /* -------- USBC_UPSTA6CLR : (USBC Offset: 0x578) ( /W 32) Pipe Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5442,25 +5442,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPSTA6CLR_OFFSET       0x578        /**< \brief (USBC_UPSTA6CLR offset) Pipe Status Clear Register */
-#define USBC_UPSTA6CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA6CLR reset_value) Pipe Status Clear Register */
+#define USBC_UPSTA6CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPSTA6CLR reset_value) Pipe Status Clear Register */
 
 #define USBC_UPSTA6CLR_RXINIC_Pos   0            /**< \brief (USBC_UPSTA6CLR) RXINI Clear */
-#define USBC_UPSTA6CLR_RXINIC       (_U(0x1) << USBC_UPSTA6CLR_RXINIC_Pos)
+#define USBC_UPSTA6CLR_RXINIC       (_U_(0x1) << USBC_UPSTA6CLR_RXINIC_Pos)
 #define USBC_UPSTA6CLR_TXOUTIC_Pos  1            /**< \brief (USBC_UPSTA6CLR) TXOUTI Clear */
-#define USBC_UPSTA6CLR_TXOUTIC      (_U(0x1) << USBC_UPSTA6CLR_TXOUTIC_Pos)
+#define USBC_UPSTA6CLR_TXOUTIC      (_U_(0x1) << USBC_UPSTA6CLR_TXOUTIC_Pos)
 #define USBC_UPSTA6CLR_TXSTPIC_Pos  2            /**< \brief (USBC_UPSTA6CLR) TXSTPI Clear */
-#define USBC_UPSTA6CLR_TXSTPIC      (_U(0x1) << USBC_UPSTA6CLR_TXSTPIC_Pos)
+#define USBC_UPSTA6CLR_TXSTPIC      (_U_(0x1) << USBC_UPSTA6CLR_TXSTPIC_Pos)
 #define USBC_UPSTA6CLR_PERRIC_Pos   3            /**< \brief (USBC_UPSTA6CLR) PERRI Clear */
-#define USBC_UPSTA6CLR_PERRIC       (_U(0x1) << USBC_UPSTA6CLR_PERRIC_Pos)
+#define USBC_UPSTA6CLR_PERRIC       (_U_(0x1) << USBC_UPSTA6CLR_PERRIC_Pos)
 #define USBC_UPSTA6CLR_NAKEDIC_Pos  4            /**< \brief (USBC_UPSTA6CLR) NAKEDI Clear */
-#define USBC_UPSTA6CLR_NAKEDIC      (_U(0x1) << USBC_UPSTA6CLR_NAKEDIC_Pos)
+#define USBC_UPSTA6CLR_NAKEDIC      (_U_(0x1) << USBC_UPSTA6CLR_NAKEDIC_Pos)
 #define USBC_UPSTA6CLR_ERRORFIC_Pos 5            /**< \brief (USBC_UPSTA6CLR) ERRORFI Clear */
-#define USBC_UPSTA6CLR_ERRORFIC     (_U(0x1) << USBC_UPSTA6CLR_ERRORFIC_Pos)
+#define USBC_UPSTA6CLR_ERRORFIC     (_U_(0x1) << USBC_UPSTA6CLR_ERRORFIC_Pos)
 #define USBC_UPSTA6CLR_RXSTALLDIC_Pos 6            /**< \brief (USBC_UPSTA6CLR) RXSTALLDI Clear */
-#define USBC_UPSTA6CLR_RXSTALLDIC   (_U(0x1) << USBC_UPSTA6CLR_RXSTALLDIC_Pos)
+#define USBC_UPSTA6CLR_RXSTALLDIC   (_U_(0x1) << USBC_UPSTA6CLR_RXSTALLDIC_Pos)
 #define USBC_UPSTA6CLR_RAMACERIC_Pos 10           /**< \brief (USBC_UPSTA6CLR) RAMACERI Clear */
-#define USBC_UPSTA6CLR_RAMACERIC    (_U(0x1) << USBC_UPSTA6CLR_RAMACERIC_Pos)
-#define USBC_UPSTA6CLR_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA6CLR) MASK Register */
+#define USBC_UPSTA6CLR_RAMACERIC    (_U_(0x1) << USBC_UPSTA6CLR_RAMACERIC_Pos)
+#define USBC_UPSTA6CLR_MASK         _U_(0x0000047F) /**< \brief (USBC_UPSTA6CLR) MASK Register */
 
 /* -------- USBC_UPSTA7CLR : (USBC Offset: 0x57C) ( /W 32) Pipe Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5482,25 +5482,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPSTA7CLR_OFFSET       0x57C        /**< \brief (USBC_UPSTA7CLR offset) Pipe Status Clear Register */
-#define USBC_UPSTA7CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA7CLR reset_value) Pipe Status Clear Register */
+#define USBC_UPSTA7CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPSTA7CLR reset_value) Pipe Status Clear Register */
 
 #define USBC_UPSTA7CLR_RXINIC_Pos   0            /**< \brief (USBC_UPSTA7CLR) RXINI Clear */
-#define USBC_UPSTA7CLR_RXINIC       (_U(0x1) << USBC_UPSTA7CLR_RXINIC_Pos)
+#define USBC_UPSTA7CLR_RXINIC       (_U_(0x1) << USBC_UPSTA7CLR_RXINIC_Pos)
 #define USBC_UPSTA7CLR_TXOUTIC_Pos  1            /**< \brief (USBC_UPSTA7CLR) TXOUTI Clear */
-#define USBC_UPSTA7CLR_TXOUTIC      (_U(0x1) << USBC_UPSTA7CLR_TXOUTIC_Pos)
+#define USBC_UPSTA7CLR_TXOUTIC      (_U_(0x1) << USBC_UPSTA7CLR_TXOUTIC_Pos)
 #define USBC_UPSTA7CLR_TXSTPIC_Pos  2            /**< \brief (USBC_UPSTA7CLR) TXSTPI Clear */
-#define USBC_UPSTA7CLR_TXSTPIC      (_U(0x1) << USBC_UPSTA7CLR_TXSTPIC_Pos)
+#define USBC_UPSTA7CLR_TXSTPIC      (_U_(0x1) << USBC_UPSTA7CLR_TXSTPIC_Pos)
 #define USBC_UPSTA7CLR_PERRIC_Pos   3            /**< \brief (USBC_UPSTA7CLR) PERRI Clear */
-#define USBC_UPSTA7CLR_PERRIC       (_U(0x1) << USBC_UPSTA7CLR_PERRIC_Pos)
+#define USBC_UPSTA7CLR_PERRIC       (_U_(0x1) << USBC_UPSTA7CLR_PERRIC_Pos)
 #define USBC_UPSTA7CLR_NAKEDIC_Pos  4            /**< \brief (USBC_UPSTA7CLR) NAKEDI Clear */
-#define USBC_UPSTA7CLR_NAKEDIC      (_U(0x1) << USBC_UPSTA7CLR_NAKEDIC_Pos)
+#define USBC_UPSTA7CLR_NAKEDIC      (_U_(0x1) << USBC_UPSTA7CLR_NAKEDIC_Pos)
 #define USBC_UPSTA7CLR_ERRORFIC_Pos 5            /**< \brief (USBC_UPSTA7CLR) ERRORFI Clear */
-#define USBC_UPSTA7CLR_ERRORFIC     (_U(0x1) << USBC_UPSTA7CLR_ERRORFIC_Pos)
+#define USBC_UPSTA7CLR_ERRORFIC     (_U_(0x1) << USBC_UPSTA7CLR_ERRORFIC_Pos)
 #define USBC_UPSTA7CLR_RXSTALLDIC_Pos 6            /**< \brief (USBC_UPSTA7CLR) RXSTALLDI Clear */
-#define USBC_UPSTA7CLR_RXSTALLDIC   (_U(0x1) << USBC_UPSTA7CLR_RXSTALLDIC_Pos)
+#define USBC_UPSTA7CLR_RXSTALLDIC   (_U_(0x1) << USBC_UPSTA7CLR_RXSTALLDIC_Pos)
 #define USBC_UPSTA7CLR_RAMACERIC_Pos 10           /**< \brief (USBC_UPSTA7CLR) RAMACERI Clear */
-#define USBC_UPSTA7CLR_RAMACERIC    (_U(0x1) << USBC_UPSTA7CLR_RAMACERIC_Pos)
-#define USBC_UPSTA7CLR_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA7CLR) MASK Register */
+#define USBC_UPSTA7CLR_RAMACERIC    (_U_(0x1) << USBC_UPSTA7CLR_RAMACERIC_Pos)
+#define USBC_UPSTA7CLR_MASK         _U_(0x0000047F) /**< \brief (USBC_UPSTA7CLR) MASK Register */
 
 /* -------- USBC_UPSTA0SET : (USBC Offset: 0x590) ( /W 32) Pipe Status Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5522,25 +5522,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPSTA0SET_OFFSET       0x590        /**< \brief (USBC_UPSTA0SET offset) Pipe Status Set Register */
-#define USBC_UPSTA0SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA0SET reset_value) Pipe Status Set Register */
+#define USBC_UPSTA0SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPSTA0SET reset_value) Pipe Status Set Register */
 
 #define USBC_UPSTA0SET_RXINIS_Pos   0            /**< \brief (USBC_UPSTA0SET) RXINI Set */
-#define USBC_UPSTA0SET_RXINIS       (_U(0x1) << USBC_UPSTA0SET_RXINIS_Pos)
+#define USBC_UPSTA0SET_RXINIS       (_U_(0x1) << USBC_UPSTA0SET_RXINIS_Pos)
 #define USBC_UPSTA0SET_TXOUTIS_Pos  1            /**< \brief (USBC_UPSTA0SET) TXOUTI Set */
-#define USBC_UPSTA0SET_TXOUTIS      (_U(0x1) << USBC_UPSTA0SET_TXOUTIS_Pos)
+#define USBC_UPSTA0SET_TXOUTIS      (_U_(0x1) << USBC_UPSTA0SET_TXOUTIS_Pos)
 #define USBC_UPSTA0SET_TXSTPIS_Pos  2            /**< \brief (USBC_UPSTA0SET) TXSTPI Set */
-#define USBC_UPSTA0SET_TXSTPIS      (_U(0x1) << USBC_UPSTA0SET_TXSTPIS_Pos)
+#define USBC_UPSTA0SET_TXSTPIS      (_U_(0x1) << USBC_UPSTA0SET_TXSTPIS_Pos)
 #define USBC_UPSTA0SET_PERRIS_Pos   3            /**< \brief (USBC_UPSTA0SET) PERRI Set */
-#define USBC_UPSTA0SET_PERRIS       (_U(0x1) << USBC_UPSTA0SET_PERRIS_Pos)
+#define USBC_UPSTA0SET_PERRIS       (_U_(0x1) << USBC_UPSTA0SET_PERRIS_Pos)
 #define USBC_UPSTA0SET_NAKEDIS_Pos  4            /**< \brief (USBC_UPSTA0SET) NAKEDI Set */
-#define USBC_UPSTA0SET_NAKEDIS      (_U(0x1) << USBC_UPSTA0SET_NAKEDIS_Pos)
+#define USBC_UPSTA0SET_NAKEDIS      (_U_(0x1) << USBC_UPSTA0SET_NAKEDIS_Pos)
 #define USBC_UPSTA0SET_ERRORFIS_Pos 5            /**< \brief (USBC_UPSTA0SET) ERRORFI Set */
-#define USBC_UPSTA0SET_ERRORFIS     (_U(0x1) << USBC_UPSTA0SET_ERRORFIS_Pos)
+#define USBC_UPSTA0SET_ERRORFIS     (_U_(0x1) << USBC_UPSTA0SET_ERRORFIS_Pos)
 #define USBC_UPSTA0SET_RXSTALLDIS_Pos 6            /**< \brief (USBC_UPSTA0SET) RXSTALLDI Set */
-#define USBC_UPSTA0SET_RXSTALLDIS   (_U(0x1) << USBC_UPSTA0SET_RXSTALLDIS_Pos)
+#define USBC_UPSTA0SET_RXSTALLDIS   (_U_(0x1) << USBC_UPSTA0SET_RXSTALLDIS_Pos)
 #define USBC_UPSTA0SET_RAMACERIS_Pos 10           /**< \brief (USBC_UPSTA0SET) RAMACERI Set */
-#define USBC_UPSTA0SET_RAMACERIS    (_U(0x1) << USBC_UPSTA0SET_RAMACERIS_Pos)
-#define USBC_UPSTA0SET_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA0SET) MASK Register */
+#define USBC_UPSTA0SET_RAMACERIS    (_U_(0x1) << USBC_UPSTA0SET_RAMACERIS_Pos)
+#define USBC_UPSTA0SET_MASK         _U_(0x0000047F) /**< \brief (USBC_UPSTA0SET) MASK Register */
 
 /* -------- USBC_UPSTA1SET : (USBC Offset: 0x594) ( /W 32) Pipe Status Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5562,25 +5562,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPSTA1SET_OFFSET       0x594        /**< \brief (USBC_UPSTA1SET offset) Pipe Status Set Register */
-#define USBC_UPSTA1SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA1SET reset_value) Pipe Status Set Register */
+#define USBC_UPSTA1SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPSTA1SET reset_value) Pipe Status Set Register */
 
 #define USBC_UPSTA1SET_RXINIS_Pos   0            /**< \brief (USBC_UPSTA1SET) RXINI Set */
-#define USBC_UPSTA1SET_RXINIS       (_U(0x1) << USBC_UPSTA1SET_RXINIS_Pos)
+#define USBC_UPSTA1SET_RXINIS       (_U_(0x1) << USBC_UPSTA1SET_RXINIS_Pos)
 #define USBC_UPSTA1SET_TXOUTIS_Pos  1            /**< \brief (USBC_UPSTA1SET) TXOUTI Set */
-#define USBC_UPSTA1SET_TXOUTIS      (_U(0x1) << USBC_UPSTA1SET_TXOUTIS_Pos)
+#define USBC_UPSTA1SET_TXOUTIS      (_U_(0x1) << USBC_UPSTA1SET_TXOUTIS_Pos)
 #define USBC_UPSTA1SET_TXSTPIS_Pos  2            /**< \brief (USBC_UPSTA1SET) TXSTPI Set */
-#define USBC_UPSTA1SET_TXSTPIS      (_U(0x1) << USBC_UPSTA1SET_TXSTPIS_Pos)
+#define USBC_UPSTA1SET_TXSTPIS      (_U_(0x1) << USBC_UPSTA1SET_TXSTPIS_Pos)
 #define USBC_UPSTA1SET_PERRIS_Pos   3            /**< \brief (USBC_UPSTA1SET) PERRI Set */
-#define USBC_UPSTA1SET_PERRIS       (_U(0x1) << USBC_UPSTA1SET_PERRIS_Pos)
+#define USBC_UPSTA1SET_PERRIS       (_U_(0x1) << USBC_UPSTA1SET_PERRIS_Pos)
 #define USBC_UPSTA1SET_NAKEDIS_Pos  4            /**< \brief (USBC_UPSTA1SET) NAKEDI Set */
-#define USBC_UPSTA1SET_NAKEDIS      (_U(0x1) << USBC_UPSTA1SET_NAKEDIS_Pos)
+#define USBC_UPSTA1SET_NAKEDIS      (_U_(0x1) << USBC_UPSTA1SET_NAKEDIS_Pos)
 #define USBC_UPSTA1SET_ERRORFIS_Pos 5            /**< \brief (USBC_UPSTA1SET) ERRORFI Set */
-#define USBC_UPSTA1SET_ERRORFIS     (_U(0x1) << USBC_UPSTA1SET_ERRORFIS_Pos)
+#define USBC_UPSTA1SET_ERRORFIS     (_U_(0x1) << USBC_UPSTA1SET_ERRORFIS_Pos)
 #define USBC_UPSTA1SET_RXSTALLDIS_Pos 6            /**< \brief (USBC_UPSTA1SET) RXSTALLDI Set */
-#define USBC_UPSTA1SET_RXSTALLDIS   (_U(0x1) << USBC_UPSTA1SET_RXSTALLDIS_Pos)
+#define USBC_UPSTA1SET_RXSTALLDIS   (_U_(0x1) << USBC_UPSTA1SET_RXSTALLDIS_Pos)
 #define USBC_UPSTA1SET_RAMACERIS_Pos 10           /**< \brief (USBC_UPSTA1SET) RAMACERI Set */
-#define USBC_UPSTA1SET_RAMACERIS    (_U(0x1) << USBC_UPSTA1SET_RAMACERIS_Pos)
-#define USBC_UPSTA1SET_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA1SET) MASK Register */
+#define USBC_UPSTA1SET_RAMACERIS    (_U_(0x1) << USBC_UPSTA1SET_RAMACERIS_Pos)
+#define USBC_UPSTA1SET_MASK         _U_(0x0000047F) /**< \brief (USBC_UPSTA1SET) MASK Register */
 
 /* -------- USBC_UPSTA2SET : (USBC Offset: 0x598) ( /W 32) Pipe Status Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5602,25 +5602,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPSTA2SET_OFFSET       0x598        /**< \brief (USBC_UPSTA2SET offset) Pipe Status Set Register */
-#define USBC_UPSTA2SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA2SET reset_value) Pipe Status Set Register */
+#define USBC_UPSTA2SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPSTA2SET reset_value) Pipe Status Set Register */
 
 #define USBC_UPSTA2SET_RXINIS_Pos   0            /**< \brief (USBC_UPSTA2SET) RXINI Set */
-#define USBC_UPSTA2SET_RXINIS       (_U(0x1) << USBC_UPSTA2SET_RXINIS_Pos)
+#define USBC_UPSTA2SET_RXINIS       (_U_(0x1) << USBC_UPSTA2SET_RXINIS_Pos)
 #define USBC_UPSTA2SET_TXOUTIS_Pos  1            /**< \brief (USBC_UPSTA2SET) TXOUTI Set */
-#define USBC_UPSTA2SET_TXOUTIS      (_U(0x1) << USBC_UPSTA2SET_TXOUTIS_Pos)
+#define USBC_UPSTA2SET_TXOUTIS      (_U_(0x1) << USBC_UPSTA2SET_TXOUTIS_Pos)
 #define USBC_UPSTA2SET_TXSTPIS_Pos  2            /**< \brief (USBC_UPSTA2SET) TXSTPI Set */
-#define USBC_UPSTA2SET_TXSTPIS      (_U(0x1) << USBC_UPSTA2SET_TXSTPIS_Pos)
+#define USBC_UPSTA2SET_TXSTPIS      (_U_(0x1) << USBC_UPSTA2SET_TXSTPIS_Pos)
 #define USBC_UPSTA2SET_PERRIS_Pos   3            /**< \brief (USBC_UPSTA2SET) PERRI Set */
-#define USBC_UPSTA2SET_PERRIS       (_U(0x1) << USBC_UPSTA2SET_PERRIS_Pos)
+#define USBC_UPSTA2SET_PERRIS       (_U_(0x1) << USBC_UPSTA2SET_PERRIS_Pos)
 #define USBC_UPSTA2SET_NAKEDIS_Pos  4            /**< \brief (USBC_UPSTA2SET) NAKEDI Set */
-#define USBC_UPSTA2SET_NAKEDIS      (_U(0x1) << USBC_UPSTA2SET_NAKEDIS_Pos)
+#define USBC_UPSTA2SET_NAKEDIS      (_U_(0x1) << USBC_UPSTA2SET_NAKEDIS_Pos)
 #define USBC_UPSTA2SET_ERRORFIS_Pos 5            /**< \brief (USBC_UPSTA2SET) ERRORFI Set */
-#define USBC_UPSTA2SET_ERRORFIS     (_U(0x1) << USBC_UPSTA2SET_ERRORFIS_Pos)
+#define USBC_UPSTA2SET_ERRORFIS     (_U_(0x1) << USBC_UPSTA2SET_ERRORFIS_Pos)
 #define USBC_UPSTA2SET_RXSTALLDIS_Pos 6            /**< \brief (USBC_UPSTA2SET) RXSTALLDI Set */
-#define USBC_UPSTA2SET_RXSTALLDIS   (_U(0x1) << USBC_UPSTA2SET_RXSTALLDIS_Pos)
+#define USBC_UPSTA2SET_RXSTALLDIS   (_U_(0x1) << USBC_UPSTA2SET_RXSTALLDIS_Pos)
 #define USBC_UPSTA2SET_RAMACERIS_Pos 10           /**< \brief (USBC_UPSTA2SET) RAMACERI Set */
-#define USBC_UPSTA2SET_RAMACERIS    (_U(0x1) << USBC_UPSTA2SET_RAMACERIS_Pos)
-#define USBC_UPSTA2SET_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA2SET) MASK Register */
+#define USBC_UPSTA2SET_RAMACERIS    (_U_(0x1) << USBC_UPSTA2SET_RAMACERIS_Pos)
+#define USBC_UPSTA2SET_MASK         _U_(0x0000047F) /**< \brief (USBC_UPSTA2SET) MASK Register */
 
 /* -------- USBC_UPSTA3SET : (USBC Offset: 0x59C) ( /W 32) Pipe Status Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5642,25 +5642,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPSTA3SET_OFFSET       0x59C        /**< \brief (USBC_UPSTA3SET offset) Pipe Status Set Register */
-#define USBC_UPSTA3SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA3SET reset_value) Pipe Status Set Register */
+#define USBC_UPSTA3SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPSTA3SET reset_value) Pipe Status Set Register */
 
 #define USBC_UPSTA3SET_RXINIS_Pos   0            /**< \brief (USBC_UPSTA3SET) RXINI Set */
-#define USBC_UPSTA3SET_RXINIS       (_U(0x1) << USBC_UPSTA3SET_RXINIS_Pos)
+#define USBC_UPSTA3SET_RXINIS       (_U_(0x1) << USBC_UPSTA3SET_RXINIS_Pos)
 #define USBC_UPSTA3SET_TXOUTIS_Pos  1            /**< \brief (USBC_UPSTA3SET) TXOUTI Set */
-#define USBC_UPSTA3SET_TXOUTIS      (_U(0x1) << USBC_UPSTA3SET_TXOUTIS_Pos)
+#define USBC_UPSTA3SET_TXOUTIS      (_U_(0x1) << USBC_UPSTA3SET_TXOUTIS_Pos)
 #define USBC_UPSTA3SET_TXSTPIS_Pos  2            /**< \brief (USBC_UPSTA3SET) TXSTPI Set */
-#define USBC_UPSTA3SET_TXSTPIS      (_U(0x1) << USBC_UPSTA3SET_TXSTPIS_Pos)
+#define USBC_UPSTA3SET_TXSTPIS      (_U_(0x1) << USBC_UPSTA3SET_TXSTPIS_Pos)
 #define USBC_UPSTA3SET_PERRIS_Pos   3            /**< \brief (USBC_UPSTA3SET) PERRI Set */
-#define USBC_UPSTA3SET_PERRIS       (_U(0x1) << USBC_UPSTA3SET_PERRIS_Pos)
+#define USBC_UPSTA3SET_PERRIS       (_U_(0x1) << USBC_UPSTA3SET_PERRIS_Pos)
 #define USBC_UPSTA3SET_NAKEDIS_Pos  4            /**< \brief (USBC_UPSTA3SET) NAKEDI Set */
-#define USBC_UPSTA3SET_NAKEDIS      (_U(0x1) << USBC_UPSTA3SET_NAKEDIS_Pos)
+#define USBC_UPSTA3SET_NAKEDIS      (_U_(0x1) << USBC_UPSTA3SET_NAKEDIS_Pos)
 #define USBC_UPSTA3SET_ERRORFIS_Pos 5            /**< \brief (USBC_UPSTA3SET) ERRORFI Set */
-#define USBC_UPSTA3SET_ERRORFIS     (_U(0x1) << USBC_UPSTA3SET_ERRORFIS_Pos)
+#define USBC_UPSTA3SET_ERRORFIS     (_U_(0x1) << USBC_UPSTA3SET_ERRORFIS_Pos)
 #define USBC_UPSTA3SET_RXSTALLDIS_Pos 6            /**< \brief (USBC_UPSTA3SET) RXSTALLDI Set */
-#define USBC_UPSTA3SET_RXSTALLDIS   (_U(0x1) << USBC_UPSTA3SET_RXSTALLDIS_Pos)
+#define USBC_UPSTA3SET_RXSTALLDIS   (_U_(0x1) << USBC_UPSTA3SET_RXSTALLDIS_Pos)
 #define USBC_UPSTA3SET_RAMACERIS_Pos 10           /**< \brief (USBC_UPSTA3SET) RAMACERI Set */
-#define USBC_UPSTA3SET_RAMACERIS    (_U(0x1) << USBC_UPSTA3SET_RAMACERIS_Pos)
-#define USBC_UPSTA3SET_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA3SET) MASK Register */
+#define USBC_UPSTA3SET_RAMACERIS    (_U_(0x1) << USBC_UPSTA3SET_RAMACERIS_Pos)
+#define USBC_UPSTA3SET_MASK         _U_(0x0000047F) /**< \brief (USBC_UPSTA3SET) MASK Register */
 
 /* -------- USBC_UPSTA4SET : (USBC Offset: 0x5A0) ( /W 32) Pipe Status Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5682,25 +5682,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPSTA4SET_OFFSET       0x5A0        /**< \brief (USBC_UPSTA4SET offset) Pipe Status Set Register */
-#define USBC_UPSTA4SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA4SET reset_value) Pipe Status Set Register */
+#define USBC_UPSTA4SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPSTA4SET reset_value) Pipe Status Set Register */
 
 #define USBC_UPSTA4SET_RXINIS_Pos   0            /**< \brief (USBC_UPSTA4SET) RXINI Set */
-#define USBC_UPSTA4SET_RXINIS       (_U(0x1) << USBC_UPSTA4SET_RXINIS_Pos)
+#define USBC_UPSTA4SET_RXINIS       (_U_(0x1) << USBC_UPSTA4SET_RXINIS_Pos)
 #define USBC_UPSTA4SET_TXOUTIS_Pos  1            /**< \brief (USBC_UPSTA4SET) TXOUTI Set */
-#define USBC_UPSTA4SET_TXOUTIS      (_U(0x1) << USBC_UPSTA4SET_TXOUTIS_Pos)
+#define USBC_UPSTA4SET_TXOUTIS      (_U_(0x1) << USBC_UPSTA4SET_TXOUTIS_Pos)
 #define USBC_UPSTA4SET_TXSTPIS_Pos  2            /**< \brief (USBC_UPSTA4SET) TXSTPI Set */
-#define USBC_UPSTA4SET_TXSTPIS      (_U(0x1) << USBC_UPSTA4SET_TXSTPIS_Pos)
+#define USBC_UPSTA4SET_TXSTPIS      (_U_(0x1) << USBC_UPSTA4SET_TXSTPIS_Pos)
 #define USBC_UPSTA4SET_PERRIS_Pos   3            /**< \brief (USBC_UPSTA4SET) PERRI Set */
-#define USBC_UPSTA4SET_PERRIS       (_U(0x1) << USBC_UPSTA4SET_PERRIS_Pos)
+#define USBC_UPSTA4SET_PERRIS       (_U_(0x1) << USBC_UPSTA4SET_PERRIS_Pos)
 #define USBC_UPSTA4SET_NAKEDIS_Pos  4            /**< \brief (USBC_UPSTA4SET) NAKEDI Set */
-#define USBC_UPSTA4SET_NAKEDIS      (_U(0x1) << USBC_UPSTA4SET_NAKEDIS_Pos)
+#define USBC_UPSTA4SET_NAKEDIS      (_U_(0x1) << USBC_UPSTA4SET_NAKEDIS_Pos)
 #define USBC_UPSTA4SET_ERRORFIS_Pos 5            /**< \brief (USBC_UPSTA4SET) ERRORFI Set */
-#define USBC_UPSTA4SET_ERRORFIS     (_U(0x1) << USBC_UPSTA4SET_ERRORFIS_Pos)
+#define USBC_UPSTA4SET_ERRORFIS     (_U_(0x1) << USBC_UPSTA4SET_ERRORFIS_Pos)
 #define USBC_UPSTA4SET_RXSTALLDIS_Pos 6            /**< \brief (USBC_UPSTA4SET) RXSTALLDI Set */
-#define USBC_UPSTA4SET_RXSTALLDIS   (_U(0x1) << USBC_UPSTA4SET_RXSTALLDIS_Pos)
+#define USBC_UPSTA4SET_RXSTALLDIS   (_U_(0x1) << USBC_UPSTA4SET_RXSTALLDIS_Pos)
 #define USBC_UPSTA4SET_RAMACERIS_Pos 10           /**< \brief (USBC_UPSTA4SET) RAMACERI Set */
-#define USBC_UPSTA4SET_RAMACERIS    (_U(0x1) << USBC_UPSTA4SET_RAMACERIS_Pos)
-#define USBC_UPSTA4SET_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA4SET) MASK Register */
+#define USBC_UPSTA4SET_RAMACERIS    (_U_(0x1) << USBC_UPSTA4SET_RAMACERIS_Pos)
+#define USBC_UPSTA4SET_MASK         _U_(0x0000047F) /**< \brief (USBC_UPSTA4SET) MASK Register */
 
 /* -------- USBC_UPSTA5SET : (USBC Offset: 0x5A4) ( /W 32) Pipe Status Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5722,25 +5722,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPSTA5SET_OFFSET       0x5A4        /**< \brief (USBC_UPSTA5SET offset) Pipe Status Set Register */
-#define USBC_UPSTA5SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA5SET reset_value) Pipe Status Set Register */
+#define USBC_UPSTA5SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPSTA5SET reset_value) Pipe Status Set Register */
 
 #define USBC_UPSTA5SET_RXINIS_Pos   0            /**< \brief (USBC_UPSTA5SET) RXINI Set */
-#define USBC_UPSTA5SET_RXINIS       (_U(0x1) << USBC_UPSTA5SET_RXINIS_Pos)
+#define USBC_UPSTA5SET_RXINIS       (_U_(0x1) << USBC_UPSTA5SET_RXINIS_Pos)
 #define USBC_UPSTA5SET_TXOUTIS_Pos  1            /**< \brief (USBC_UPSTA5SET) TXOUTI Set */
-#define USBC_UPSTA5SET_TXOUTIS      (_U(0x1) << USBC_UPSTA5SET_TXOUTIS_Pos)
+#define USBC_UPSTA5SET_TXOUTIS      (_U_(0x1) << USBC_UPSTA5SET_TXOUTIS_Pos)
 #define USBC_UPSTA5SET_TXSTPIS_Pos  2            /**< \brief (USBC_UPSTA5SET) TXSTPI Set */
-#define USBC_UPSTA5SET_TXSTPIS      (_U(0x1) << USBC_UPSTA5SET_TXSTPIS_Pos)
+#define USBC_UPSTA5SET_TXSTPIS      (_U_(0x1) << USBC_UPSTA5SET_TXSTPIS_Pos)
 #define USBC_UPSTA5SET_PERRIS_Pos   3            /**< \brief (USBC_UPSTA5SET) PERRI Set */
-#define USBC_UPSTA5SET_PERRIS       (_U(0x1) << USBC_UPSTA5SET_PERRIS_Pos)
+#define USBC_UPSTA5SET_PERRIS       (_U_(0x1) << USBC_UPSTA5SET_PERRIS_Pos)
 #define USBC_UPSTA5SET_NAKEDIS_Pos  4            /**< \brief (USBC_UPSTA5SET) NAKEDI Set */
-#define USBC_UPSTA5SET_NAKEDIS      (_U(0x1) << USBC_UPSTA5SET_NAKEDIS_Pos)
+#define USBC_UPSTA5SET_NAKEDIS      (_U_(0x1) << USBC_UPSTA5SET_NAKEDIS_Pos)
 #define USBC_UPSTA5SET_ERRORFIS_Pos 5            /**< \brief (USBC_UPSTA5SET) ERRORFI Set */
-#define USBC_UPSTA5SET_ERRORFIS     (_U(0x1) << USBC_UPSTA5SET_ERRORFIS_Pos)
+#define USBC_UPSTA5SET_ERRORFIS     (_U_(0x1) << USBC_UPSTA5SET_ERRORFIS_Pos)
 #define USBC_UPSTA5SET_RXSTALLDIS_Pos 6            /**< \brief (USBC_UPSTA5SET) RXSTALLDI Set */
-#define USBC_UPSTA5SET_RXSTALLDIS   (_U(0x1) << USBC_UPSTA5SET_RXSTALLDIS_Pos)
+#define USBC_UPSTA5SET_RXSTALLDIS   (_U_(0x1) << USBC_UPSTA5SET_RXSTALLDIS_Pos)
 #define USBC_UPSTA5SET_RAMACERIS_Pos 10           /**< \brief (USBC_UPSTA5SET) RAMACERI Set */
-#define USBC_UPSTA5SET_RAMACERIS    (_U(0x1) << USBC_UPSTA5SET_RAMACERIS_Pos)
-#define USBC_UPSTA5SET_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA5SET) MASK Register */
+#define USBC_UPSTA5SET_RAMACERIS    (_U_(0x1) << USBC_UPSTA5SET_RAMACERIS_Pos)
+#define USBC_UPSTA5SET_MASK         _U_(0x0000047F) /**< \brief (USBC_UPSTA5SET) MASK Register */
 
 /* -------- USBC_UPSTA6SET : (USBC Offset: 0x5A8) ( /W 32) Pipe Status Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5762,25 +5762,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPSTA6SET_OFFSET       0x5A8        /**< \brief (USBC_UPSTA6SET offset) Pipe Status Set Register */
-#define USBC_UPSTA6SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA6SET reset_value) Pipe Status Set Register */
+#define USBC_UPSTA6SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPSTA6SET reset_value) Pipe Status Set Register */
 
 #define USBC_UPSTA6SET_RXINIS_Pos   0            /**< \brief (USBC_UPSTA6SET) RXINI Set */
-#define USBC_UPSTA6SET_RXINIS       (_U(0x1) << USBC_UPSTA6SET_RXINIS_Pos)
+#define USBC_UPSTA6SET_RXINIS       (_U_(0x1) << USBC_UPSTA6SET_RXINIS_Pos)
 #define USBC_UPSTA6SET_TXOUTIS_Pos  1            /**< \brief (USBC_UPSTA6SET) TXOUTI Set */
-#define USBC_UPSTA6SET_TXOUTIS      (_U(0x1) << USBC_UPSTA6SET_TXOUTIS_Pos)
+#define USBC_UPSTA6SET_TXOUTIS      (_U_(0x1) << USBC_UPSTA6SET_TXOUTIS_Pos)
 #define USBC_UPSTA6SET_TXSTPIS_Pos  2            /**< \brief (USBC_UPSTA6SET) TXSTPI Set */
-#define USBC_UPSTA6SET_TXSTPIS      (_U(0x1) << USBC_UPSTA6SET_TXSTPIS_Pos)
+#define USBC_UPSTA6SET_TXSTPIS      (_U_(0x1) << USBC_UPSTA6SET_TXSTPIS_Pos)
 #define USBC_UPSTA6SET_PERRIS_Pos   3            /**< \brief (USBC_UPSTA6SET) PERRI Set */
-#define USBC_UPSTA6SET_PERRIS       (_U(0x1) << USBC_UPSTA6SET_PERRIS_Pos)
+#define USBC_UPSTA6SET_PERRIS       (_U_(0x1) << USBC_UPSTA6SET_PERRIS_Pos)
 #define USBC_UPSTA6SET_NAKEDIS_Pos  4            /**< \brief (USBC_UPSTA6SET) NAKEDI Set */
-#define USBC_UPSTA6SET_NAKEDIS      (_U(0x1) << USBC_UPSTA6SET_NAKEDIS_Pos)
+#define USBC_UPSTA6SET_NAKEDIS      (_U_(0x1) << USBC_UPSTA6SET_NAKEDIS_Pos)
 #define USBC_UPSTA6SET_ERRORFIS_Pos 5            /**< \brief (USBC_UPSTA6SET) ERRORFI Set */
-#define USBC_UPSTA6SET_ERRORFIS     (_U(0x1) << USBC_UPSTA6SET_ERRORFIS_Pos)
+#define USBC_UPSTA6SET_ERRORFIS     (_U_(0x1) << USBC_UPSTA6SET_ERRORFIS_Pos)
 #define USBC_UPSTA6SET_RXSTALLDIS_Pos 6            /**< \brief (USBC_UPSTA6SET) RXSTALLDI Set */
-#define USBC_UPSTA6SET_RXSTALLDIS   (_U(0x1) << USBC_UPSTA6SET_RXSTALLDIS_Pos)
+#define USBC_UPSTA6SET_RXSTALLDIS   (_U_(0x1) << USBC_UPSTA6SET_RXSTALLDIS_Pos)
 #define USBC_UPSTA6SET_RAMACERIS_Pos 10           /**< \brief (USBC_UPSTA6SET) RAMACERI Set */
-#define USBC_UPSTA6SET_RAMACERIS    (_U(0x1) << USBC_UPSTA6SET_RAMACERIS_Pos)
-#define USBC_UPSTA6SET_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA6SET) MASK Register */
+#define USBC_UPSTA6SET_RAMACERIS    (_U_(0x1) << USBC_UPSTA6SET_RAMACERIS_Pos)
+#define USBC_UPSTA6SET_MASK         _U_(0x0000047F) /**< \brief (USBC_UPSTA6SET) MASK Register */
 
 /* -------- USBC_UPSTA7SET : (USBC Offset: 0x5AC) ( /W 32) Pipe Status Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5802,25 +5802,25 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPSTA7SET_OFFSET       0x5AC        /**< \brief (USBC_UPSTA7SET offset) Pipe Status Set Register */
-#define USBC_UPSTA7SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA7SET reset_value) Pipe Status Set Register */
+#define USBC_UPSTA7SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPSTA7SET reset_value) Pipe Status Set Register */
 
 #define USBC_UPSTA7SET_RXINIS_Pos   0            /**< \brief (USBC_UPSTA7SET) RXINI Set */
-#define USBC_UPSTA7SET_RXINIS       (_U(0x1) << USBC_UPSTA7SET_RXINIS_Pos)
+#define USBC_UPSTA7SET_RXINIS       (_U_(0x1) << USBC_UPSTA7SET_RXINIS_Pos)
 #define USBC_UPSTA7SET_TXOUTIS_Pos  1            /**< \brief (USBC_UPSTA7SET) TXOUTI Set */
-#define USBC_UPSTA7SET_TXOUTIS      (_U(0x1) << USBC_UPSTA7SET_TXOUTIS_Pos)
+#define USBC_UPSTA7SET_TXOUTIS      (_U_(0x1) << USBC_UPSTA7SET_TXOUTIS_Pos)
 #define USBC_UPSTA7SET_TXSTPIS_Pos  2            /**< \brief (USBC_UPSTA7SET) TXSTPI Set */
-#define USBC_UPSTA7SET_TXSTPIS      (_U(0x1) << USBC_UPSTA7SET_TXSTPIS_Pos)
+#define USBC_UPSTA7SET_TXSTPIS      (_U_(0x1) << USBC_UPSTA7SET_TXSTPIS_Pos)
 #define USBC_UPSTA7SET_PERRIS_Pos   3            /**< \brief (USBC_UPSTA7SET) PERRI Set */
-#define USBC_UPSTA7SET_PERRIS       (_U(0x1) << USBC_UPSTA7SET_PERRIS_Pos)
+#define USBC_UPSTA7SET_PERRIS       (_U_(0x1) << USBC_UPSTA7SET_PERRIS_Pos)
 #define USBC_UPSTA7SET_NAKEDIS_Pos  4            /**< \brief (USBC_UPSTA7SET) NAKEDI Set */
-#define USBC_UPSTA7SET_NAKEDIS      (_U(0x1) << USBC_UPSTA7SET_NAKEDIS_Pos)
+#define USBC_UPSTA7SET_NAKEDIS      (_U_(0x1) << USBC_UPSTA7SET_NAKEDIS_Pos)
 #define USBC_UPSTA7SET_ERRORFIS_Pos 5            /**< \brief (USBC_UPSTA7SET) ERRORFI Set */
-#define USBC_UPSTA7SET_ERRORFIS     (_U(0x1) << USBC_UPSTA7SET_ERRORFIS_Pos)
+#define USBC_UPSTA7SET_ERRORFIS     (_U_(0x1) << USBC_UPSTA7SET_ERRORFIS_Pos)
 #define USBC_UPSTA7SET_RXSTALLDIS_Pos 6            /**< \brief (USBC_UPSTA7SET) RXSTALLDI Set */
-#define USBC_UPSTA7SET_RXSTALLDIS   (_U(0x1) << USBC_UPSTA7SET_RXSTALLDIS_Pos)
+#define USBC_UPSTA7SET_RXSTALLDIS   (_U_(0x1) << USBC_UPSTA7SET_RXSTALLDIS_Pos)
 #define USBC_UPSTA7SET_RAMACERIS_Pos 10           /**< \brief (USBC_UPSTA7SET) RAMACERI Set */
-#define USBC_UPSTA7SET_RAMACERIS    (_U(0x1) << USBC_UPSTA7SET_RAMACERIS_Pos)
-#define USBC_UPSTA7SET_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA7SET) MASK Register */
+#define USBC_UPSTA7SET_RAMACERIS    (_U_(0x1) << USBC_UPSTA7SET_RAMACERIS_Pos)
+#define USBC_UPSTA7SET_MASK         _U_(0x0000047F) /**< \brief (USBC_UPSTA7SET) MASK Register */
 
 /* -------- USBC_UPCON0 : (USBC Offset: 0x5C0) (R/  32) Pipe Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5850,35 +5850,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCON0_OFFSET          0x5C0        /**< \brief (USBC_UPCON0 offset) Pipe Control Register */
-#define USBC_UPCON0_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCON0 reset_value) Pipe Control Register */
+#define USBC_UPCON0_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UPCON0 reset_value) Pipe Control Register */
 
 #define USBC_UPCON0_RXINE_Pos       0            /**< \brief (USBC_UPCON0) RXIN Interrupt Enable */
-#define USBC_UPCON0_RXINE           (_U(0x1) << USBC_UPCON0_RXINE_Pos)
+#define USBC_UPCON0_RXINE           (_U_(0x1) << USBC_UPCON0_RXINE_Pos)
 #define USBC_UPCON0_TXOUTE_Pos      1            /**< \brief (USBC_UPCON0) TXOUT Interrupt Enable */
-#define USBC_UPCON0_TXOUTE          (_U(0x1) << USBC_UPCON0_TXOUTE_Pos)
+#define USBC_UPCON0_TXOUTE          (_U_(0x1) << USBC_UPCON0_TXOUTE_Pos)
 #define USBC_UPCON0_TXSTPE_Pos      2            /**< \brief (USBC_UPCON0) TXSTP Interrupt Enable */
-#define USBC_UPCON0_TXSTPE          (_U(0x1) << USBC_UPCON0_TXSTPE_Pos)
+#define USBC_UPCON0_TXSTPE          (_U_(0x1) << USBC_UPCON0_TXSTPE_Pos)
 #define USBC_UPCON0_PERRE_Pos       3            /**< \brief (USBC_UPCON0) PERR Interrupt Enable */
-#define USBC_UPCON0_PERRE           (_U(0x1) << USBC_UPCON0_PERRE_Pos)
+#define USBC_UPCON0_PERRE           (_U_(0x1) << USBC_UPCON0_PERRE_Pos)
 #define USBC_UPCON0_NAKEDE_Pos      4            /**< \brief (USBC_UPCON0) NAKED Interrupt Enable */
-#define USBC_UPCON0_NAKEDE          (_U(0x1) << USBC_UPCON0_NAKEDE_Pos)
+#define USBC_UPCON0_NAKEDE          (_U_(0x1) << USBC_UPCON0_NAKEDE_Pos)
 #define USBC_UPCON0_ERRORFIE_Pos    5            /**< \brief (USBC_UPCON0) ERRORFI Interrupt Enable */
-#define USBC_UPCON0_ERRORFIE        (_U(0x1) << USBC_UPCON0_ERRORFIE_Pos)
+#define USBC_UPCON0_ERRORFIE        (_U_(0x1) << USBC_UPCON0_ERRORFIE_Pos)
 #define USBC_UPCON0_RXSTALLDE_Pos   6            /**< \brief (USBC_UPCON0) RXTALLD Interrupt Enable */
-#define USBC_UPCON0_RXSTALLDE       (_U(0x1) << USBC_UPCON0_RXSTALLDE_Pos)
+#define USBC_UPCON0_RXSTALLDE       (_U_(0x1) << USBC_UPCON0_RXSTALLDE_Pos)
 #define USBC_UPCON0_RAMACERE_Pos    10           /**< \brief (USBC_UPCON0) RAMACER Interrupt Enable */
-#define USBC_UPCON0_RAMACERE        (_U(0x1) << USBC_UPCON0_RAMACERE_Pos)
+#define USBC_UPCON0_RAMACERE        (_U_(0x1) << USBC_UPCON0_RAMACERE_Pos)
 #define USBC_UPCON0_NBUSYBKE_Pos    12           /**< \brief (USBC_UPCON0) NBUSYBKInterrupt Enable */
-#define USBC_UPCON0_NBUSYBKE        (_U(0x1) << USBC_UPCON0_NBUSYBKE_Pos)
+#define USBC_UPCON0_NBUSYBKE        (_U_(0x1) << USBC_UPCON0_NBUSYBKE_Pos)
 #define USBC_UPCON0_FIFOCON_Pos     14           /**< \brief (USBC_UPCON0) FIFO Control */
-#define USBC_UPCON0_FIFOCON         (_U(0x1) << USBC_UPCON0_FIFOCON_Pos)
+#define USBC_UPCON0_FIFOCON         (_U_(0x1) << USBC_UPCON0_FIFOCON_Pos)
 #define USBC_UPCON0_PFREEZE_Pos     17           /**< \brief (USBC_UPCON0) Pipe Freeze */
-#define USBC_UPCON0_PFREEZE         (_U(0x1) << USBC_UPCON0_PFREEZE_Pos)
+#define USBC_UPCON0_PFREEZE         (_U_(0x1) << USBC_UPCON0_PFREEZE_Pos)
 #define USBC_UPCON0_INITDTGL_Pos    18           /**< \brief (USBC_UPCON0) Data Toggle Initialization */
-#define USBC_UPCON0_INITDTGL        (_U(0x1) << USBC_UPCON0_INITDTGL_Pos)
+#define USBC_UPCON0_INITDTGL        (_U_(0x1) << USBC_UPCON0_INITDTGL_Pos)
 #define USBC_UPCON0_INITBK_Pos      19           /**< \brief (USBC_UPCON0) Bank Initialization */
-#define USBC_UPCON0_INITBK          (_U(0x1) << USBC_UPCON0_INITBK_Pos)
-#define USBC_UPCON0_MASK            _U(0x000E547F) /**< \brief (USBC_UPCON0) MASK Register */
+#define USBC_UPCON0_INITBK          (_U_(0x1) << USBC_UPCON0_INITBK_Pos)
+#define USBC_UPCON0_MASK            _U_(0x000E547F) /**< \brief (USBC_UPCON0) MASK Register */
 
 /* -------- USBC_UPCON1 : (USBC Offset: 0x5C4) (R/  32) Pipe Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5908,35 +5908,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCON1_OFFSET          0x5C4        /**< \brief (USBC_UPCON1 offset) Pipe Control Register */
-#define USBC_UPCON1_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCON1 reset_value) Pipe Control Register */
+#define USBC_UPCON1_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UPCON1 reset_value) Pipe Control Register */
 
 #define USBC_UPCON1_RXINE_Pos       0            /**< \brief (USBC_UPCON1) RXIN Interrupt Enable */
-#define USBC_UPCON1_RXINE           (_U(0x1) << USBC_UPCON1_RXINE_Pos)
+#define USBC_UPCON1_RXINE           (_U_(0x1) << USBC_UPCON1_RXINE_Pos)
 #define USBC_UPCON1_TXOUTE_Pos      1            /**< \brief (USBC_UPCON1) TXOUT Interrupt Enable */
-#define USBC_UPCON1_TXOUTE          (_U(0x1) << USBC_UPCON1_TXOUTE_Pos)
+#define USBC_UPCON1_TXOUTE          (_U_(0x1) << USBC_UPCON1_TXOUTE_Pos)
 #define USBC_UPCON1_TXSTPE_Pos      2            /**< \brief (USBC_UPCON1) TXSTP Interrupt Enable */
-#define USBC_UPCON1_TXSTPE          (_U(0x1) << USBC_UPCON1_TXSTPE_Pos)
+#define USBC_UPCON1_TXSTPE          (_U_(0x1) << USBC_UPCON1_TXSTPE_Pos)
 #define USBC_UPCON1_PERRE_Pos       3            /**< \brief (USBC_UPCON1) PERR Interrupt Enable */
-#define USBC_UPCON1_PERRE           (_U(0x1) << USBC_UPCON1_PERRE_Pos)
+#define USBC_UPCON1_PERRE           (_U_(0x1) << USBC_UPCON1_PERRE_Pos)
 #define USBC_UPCON1_NAKEDE_Pos      4            /**< \brief (USBC_UPCON1) NAKED Interrupt Enable */
-#define USBC_UPCON1_NAKEDE          (_U(0x1) << USBC_UPCON1_NAKEDE_Pos)
+#define USBC_UPCON1_NAKEDE          (_U_(0x1) << USBC_UPCON1_NAKEDE_Pos)
 #define USBC_UPCON1_ERRORFIE_Pos    5            /**< \brief (USBC_UPCON1) ERRORFI Interrupt Enable */
-#define USBC_UPCON1_ERRORFIE        (_U(0x1) << USBC_UPCON1_ERRORFIE_Pos)
+#define USBC_UPCON1_ERRORFIE        (_U_(0x1) << USBC_UPCON1_ERRORFIE_Pos)
 #define USBC_UPCON1_RXSTALLDE_Pos   6            /**< \brief (USBC_UPCON1) RXTALLD Interrupt Enable */
-#define USBC_UPCON1_RXSTALLDE       (_U(0x1) << USBC_UPCON1_RXSTALLDE_Pos)
+#define USBC_UPCON1_RXSTALLDE       (_U_(0x1) << USBC_UPCON1_RXSTALLDE_Pos)
 #define USBC_UPCON1_RAMACERE_Pos    10           /**< \brief (USBC_UPCON1) RAMACER Interrupt Enable */
-#define USBC_UPCON1_RAMACERE        (_U(0x1) << USBC_UPCON1_RAMACERE_Pos)
+#define USBC_UPCON1_RAMACERE        (_U_(0x1) << USBC_UPCON1_RAMACERE_Pos)
 #define USBC_UPCON1_NBUSYBKE_Pos    12           /**< \brief (USBC_UPCON1) NBUSYBKInterrupt Enable */
-#define USBC_UPCON1_NBUSYBKE        (_U(0x1) << USBC_UPCON1_NBUSYBKE_Pos)
+#define USBC_UPCON1_NBUSYBKE        (_U_(0x1) << USBC_UPCON1_NBUSYBKE_Pos)
 #define USBC_UPCON1_FIFOCON_Pos     14           /**< \brief (USBC_UPCON1) FIFO Control */
-#define USBC_UPCON1_FIFOCON         (_U(0x1) << USBC_UPCON1_FIFOCON_Pos)
+#define USBC_UPCON1_FIFOCON         (_U_(0x1) << USBC_UPCON1_FIFOCON_Pos)
 #define USBC_UPCON1_PFREEZE_Pos     17           /**< \brief (USBC_UPCON1) Pipe Freeze */
-#define USBC_UPCON1_PFREEZE         (_U(0x1) << USBC_UPCON1_PFREEZE_Pos)
+#define USBC_UPCON1_PFREEZE         (_U_(0x1) << USBC_UPCON1_PFREEZE_Pos)
 #define USBC_UPCON1_INITDTGL_Pos    18           /**< \brief (USBC_UPCON1) Data Toggle Initialization */
-#define USBC_UPCON1_INITDTGL        (_U(0x1) << USBC_UPCON1_INITDTGL_Pos)
+#define USBC_UPCON1_INITDTGL        (_U_(0x1) << USBC_UPCON1_INITDTGL_Pos)
 #define USBC_UPCON1_INITBK_Pos      19           /**< \brief (USBC_UPCON1) Bank Initialization */
-#define USBC_UPCON1_INITBK          (_U(0x1) << USBC_UPCON1_INITBK_Pos)
-#define USBC_UPCON1_MASK            _U(0x000E547F) /**< \brief (USBC_UPCON1) MASK Register */
+#define USBC_UPCON1_INITBK          (_U_(0x1) << USBC_UPCON1_INITBK_Pos)
+#define USBC_UPCON1_MASK            _U_(0x000E547F) /**< \brief (USBC_UPCON1) MASK Register */
 
 /* -------- USBC_UPCON2 : (USBC Offset: 0x5C8) (R/  32) Pipe Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -5966,35 +5966,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCON2_OFFSET          0x5C8        /**< \brief (USBC_UPCON2 offset) Pipe Control Register */
-#define USBC_UPCON2_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCON2 reset_value) Pipe Control Register */
+#define USBC_UPCON2_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UPCON2 reset_value) Pipe Control Register */
 
 #define USBC_UPCON2_RXINE_Pos       0            /**< \brief (USBC_UPCON2) RXIN Interrupt Enable */
-#define USBC_UPCON2_RXINE           (_U(0x1) << USBC_UPCON2_RXINE_Pos)
+#define USBC_UPCON2_RXINE           (_U_(0x1) << USBC_UPCON2_RXINE_Pos)
 #define USBC_UPCON2_TXOUTE_Pos      1            /**< \brief (USBC_UPCON2) TXOUT Interrupt Enable */
-#define USBC_UPCON2_TXOUTE          (_U(0x1) << USBC_UPCON2_TXOUTE_Pos)
+#define USBC_UPCON2_TXOUTE          (_U_(0x1) << USBC_UPCON2_TXOUTE_Pos)
 #define USBC_UPCON2_TXSTPE_Pos      2            /**< \brief (USBC_UPCON2) TXSTP Interrupt Enable */
-#define USBC_UPCON2_TXSTPE          (_U(0x1) << USBC_UPCON2_TXSTPE_Pos)
+#define USBC_UPCON2_TXSTPE          (_U_(0x1) << USBC_UPCON2_TXSTPE_Pos)
 #define USBC_UPCON2_PERRE_Pos       3            /**< \brief (USBC_UPCON2) PERR Interrupt Enable */
-#define USBC_UPCON2_PERRE           (_U(0x1) << USBC_UPCON2_PERRE_Pos)
+#define USBC_UPCON2_PERRE           (_U_(0x1) << USBC_UPCON2_PERRE_Pos)
 #define USBC_UPCON2_NAKEDE_Pos      4            /**< \brief (USBC_UPCON2) NAKED Interrupt Enable */
-#define USBC_UPCON2_NAKEDE          (_U(0x1) << USBC_UPCON2_NAKEDE_Pos)
+#define USBC_UPCON2_NAKEDE          (_U_(0x1) << USBC_UPCON2_NAKEDE_Pos)
 #define USBC_UPCON2_ERRORFIE_Pos    5            /**< \brief (USBC_UPCON2) ERRORFI Interrupt Enable */
-#define USBC_UPCON2_ERRORFIE        (_U(0x1) << USBC_UPCON2_ERRORFIE_Pos)
+#define USBC_UPCON2_ERRORFIE        (_U_(0x1) << USBC_UPCON2_ERRORFIE_Pos)
 #define USBC_UPCON2_RXSTALLDE_Pos   6            /**< \brief (USBC_UPCON2) RXTALLD Interrupt Enable */
-#define USBC_UPCON2_RXSTALLDE       (_U(0x1) << USBC_UPCON2_RXSTALLDE_Pos)
+#define USBC_UPCON2_RXSTALLDE       (_U_(0x1) << USBC_UPCON2_RXSTALLDE_Pos)
 #define USBC_UPCON2_RAMACERE_Pos    10           /**< \brief (USBC_UPCON2) RAMACER Interrupt Enable */
-#define USBC_UPCON2_RAMACERE        (_U(0x1) << USBC_UPCON2_RAMACERE_Pos)
+#define USBC_UPCON2_RAMACERE        (_U_(0x1) << USBC_UPCON2_RAMACERE_Pos)
 #define USBC_UPCON2_NBUSYBKE_Pos    12           /**< \brief (USBC_UPCON2) NBUSYBKInterrupt Enable */
-#define USBC_UPCON2_NBUSYBKE        (_U(0x1) << USBC_UPCON2_NBUSYBKE_Pos)
+#define USBC_UPCON2_NBUSYBKE        (_U_(0x1) << USBC_UPCON2_NBUSYBKE_Pos)
 #define USBC_UPCON2_FIFOCON_Pos     14           /**< \brief (USBC_UPCON2) FIFO Control */
-#define USBC_UPCON2_FIFOCON         (_U(0x1) << USBC_UPCON2_FIFOCON_Pos)
+#define USBC_UPCON2_FIFOCON         (_U_(0x1) << USBC_UPCON2_FIFOCON_Pos)
 #define USBC_UPCON2_PFREEZE_Pos     17           /**< \brief (USBC_UPCON2) Pipe Freeze */
-#define USBC_UPCON2_PFREEZE         (_U(0x1) << USBC_UPCON2_PFREEZE_Pos)
+#define USBC_UPCON2_PFREEZE         (_U_(0x1) << USBC_UPCON2_PFREEZE_Pos)
 #define USBC_UPCON2_INITDTGL_Pos    18           /**< \brief (USBC_UPCON2) Data Toggle Initialization */
-#define USBC_UPCON2_INITDTGL        (_U(0x1) << USBC_UPCON2_INITDTGL_Pos)
+#define USBC_UPCON2_INITDTGL        (_U_(0x1) << USBC_UPCON2_INITDTGL_Pos)
 #define USBC_UPCON2_INITBK_Pos      19           /**< \brief (USBC_UPCON2) Bank Initialization */
-#define USBC_UPCON2_INITBK          (_U(0x1) << USBC_UPCON2_INITBK_Pos)
-#define USBC_UPCON2_MASK            _U(0x000E547F) /**< \brief (USBC_UPCON2) MASK Register */
+#define USBC_UPCON2_INITBK          (_U_(0x1) << USBC_UPCON2_INITBK_Pos)
+#define USBC_UPCON2_MASK            _U_(0x000E547F) /**< \brief (USBC_UPCON2) MASK Register */
 
 /* -------- USBC_UPCON3 : (USBC Offset: 0x5CC) (R/  32) Pipe Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -6024,35 +6024,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCON3_OFFSET          0x5CC        /**< \brief (USBC_UPCON3 offset) Pipe Control Register */
-#define USBC_UPCON3_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCON3 reset_value) Pipe Control Register */
+#define USBC_UPCON3_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UPCON3 reset_value) Pipe Control Register */
 
 #define USBC_UPCON3_RXINE_Pos       0            /**< \brief (USBC_UPCON3) RXIN Interrupt Enable */
-#define USBC_UPCON3_RXINE           (_U(0x1) << USBC_UPCON3_RXINE_Pos)
+#define USBC_UPCON3_RXINE           (_U_(0x1) << USBC_UPCON3_RXINE_Pos)
 #define USBC_UPCON3_TXOUTE_Pos      1            /**< \brief (USBC_UPCON3) TXOUT Interrupt Enable */
-#define USBC_UPCON3_TXOUTE          (_U(0x1) << USBC_UPCON3_TXOUTE_Pos)
+#define USBC_UPCON3_TXOUTE          (_U_(0x1) << USBC_UPCON3_TXOUTE_Pos)
 #define USBC_UPCON3_TXSTPE_Pos      2            /**< \brief (USBC_UPCON3) TXSTP Interrupt Enable */
-#define USBC_UPCON3_TXSTPE          (_U(0x1) << USBC_UPCON3_TXSTPE_Pos)
+#define USBC_UPCON3_TXSTPE          (_U_(0x1) << USBC_UPCON3_TXSTPE_Pos)
 #define USBC_UPCON3_PERRE_Pos       3            /**< \brief (USBC_UPCON3) PERR Interrupt Enable */
-#define USBC_UPCON3_PERRE           (_U(0x1) << USBC_UPCON3_PERRE_Pos)
+#define USBC_UPCON3_PERRE           (_U_(0x1) << USBC_UPCON3_PERRE_Pos)
 #define USBC_UPCON3_NAKEDE_Pos      4            /**< \brief (USBC_UPCON3) NAKED Interrupt Enable */
-#define USBC_UPCON3_NAKEDE          (_U(0x1) << USBC_UPCON3_NAKEDE_Pos)
+#define USBC_UPCON3_NAKEDE          (_U_(0x1) << USBC_UPCON3_NAKEDE_Pos)
 #define USBC_UPCON3_ERRORFIE_Pos    5            /**< \brief (USBC_UPCON3) ERRORFI Interrupt Enable */
-#define USBC_UPCON3_ERRORFIE        (_U(0x1) << USBC_UPCON3_ERRORFIE_Pos)
+#define USBC_UPCON3_ERRORFIE        (_U_(0x1) << USBC_UPCON3_ERRORFIE_Pos)
 #define USBC_UPCON3_RXSTALLDE_Pos   6            /**< \brief (USBC_UPCON3) RXTALLD Interrupt Enable */
-#define USBC_UPCON3_RXSTALLDE       (_U(0x1) << USBC_UPCON3_RXSTALLDE_Pos)
+#define USBC_UPCON3_RXSTALLDE       (_U_(0x1) << USBC_UPCON3_RXSTALLDE_Pos)
 #define USBC_UPCON3_RAMACERE_Pos    10           /**< \brief (USBC_UPCON3) RAMACER Interrupt Enable */
-#define USBC_UPCON3_RAMACERE        (_U(0x1) << USBC_UPCON3_RAMACERE_Pos)
+#define USBC_UPCON3_RAMACERE        (_U_(0x1) << USBC_UPCON3_RAMACERE_Pos)
 #define USBC_UPCON3_NBUSYBKE_Pos    12           /**< \brief (USBC_UPCON3) NBUSYBKInterrupt Enable */
-#define USBC_UPCON3_NBUSYBKE        (_U(0x1) << USBC_UPCON3_NBUSYBKE_Pos)
+#define USBC_UPCON3_NBUSYBKE        (_U_(0x1) << USBC_UPCON3_NBUSYBKE_Pos)
 #define USBC_UPCON3_FIFOCON_Pos     14           /**< \brief (USBC_UPCON3) FIFO Control */
-#define USBC_UPCON3_FIFOCON         (_U(0x1) << USBC_UPCON3_FIFOCON_Pos)
+#define USBC_UPCON3_FIFOCON         (_U_(0x1) << USBC_UPCON3_FIFOCON_Pos)
 #define USBC_UPCON3_PFREEZE_Pos     17           /**< \brief (USBC_UPCON3) Pipe Freeze */
-#define USBC_UPCON3_PFREEZE         (_U(0x1) << USBC_UPCON3_PFREEZE_Pos)
+#define USBC_UPCON3_PFREEZE         (_U_(0x1) << USBC_UPCON3_PFREEZE_Pos)
 #define USBC_UPCON3_INITDTGL_Pos    18           /**< \brief (USBC_UPCON3) Data Toggle Initialization */
-#define USBC_UPCON3_INITDTGL        (_U(0x1) << USBC_UPCON3_INITDTGL_Pos)
+#define USBC_UPCON3_INITDTGL        (_U_(0x1) << USBC_UPCON3_INITDTGL_Pos)
 #define USBC_UPCON3_INITBK_Pos      19           /**< \brief (USBC_UPCON3) Bank Initialization */
-#define USBC_UPCON3_INITBK          (_U(0x1) << USBC_UPCON3_INITBK_Pos)
-#define USBC_UPCON3_MASK            _U(0x000E547F) /**< \brief (USBC_UPCON3) MASK Register */
+#define USBC_UPCON3_INITBK          (_U_(0x1) << USBC_UPCON3_INITBK_Pos)
+#define USBC_UPCON3_MASK            _U_(0x000E547F) /**< \brief (USBC_UPCON3) MASK Register */
 
 /* -------- USBC_UPCON4 : (USBC Offset: 0x5D0) (R/  32) Pipe Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -6082,35 +6082,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCON4_OFFSET          0x5D0        /**< \brief (USBC_UPCON4 offset) Pipe Control Register */
-#define USBC_UPCON4_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCON4 reset_value) Pipe Control Register */
+#define USBC_UPCON4_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UPCON4 reset_value) Pipe Control Register */
 
 #define USBC_UPCON4_RXINE_Pos       0            /**< \brief (USBC_UPCON4) RXIN Interrupt Enable */
-#define USBC_UPCON4_RXINE           (_U(0x1) << USBC_UPCON4_RXINE_Pos)
+#define USBC_UPCON4_RXINE           (_U_(0x1) << USBC_UPCON4_RXINE_Pos)
 #define USBC_UPCON4_TXOUTE_Pos      1            /**< \brief (USBC_UPCON4) TXOUT Interrupt Enable */
-#define USBC_UPCON4_TXOUTE          (_U(0x1) << USBC_UPCON4_TXOUTE_Pos)
+#define USBC_UPCON4_TXOUTE          (_U_(0x1) << USBC_UPCON4_TXOUTE_Pos)
 #define USBC_UPCON4_TXSTPE_Pos      2            /**< \brief (USBC_UPCON4) TXSTP Interrupt Enable */
-#define USBC_UPCON4_TXSTPE          (_U(0x1) << USBC_UPCON4_TXSTPE_Pos)
+#define USBC_UPCON4_TXSTPE          (_U_(0x1) << USBC_UPCON4_TXSTPE_Pos)
 #define USBC_UPCON4_PERRE_Pos       3            /**< \brief (USBC_UPCON4) PERR Interrupt Enable */
-#define USBC_UPCON4_PERRE           (_U(0x1) << USBC_UPCON4_PERRE_Pos)
+#define USBC_UPCON4_PERRE           (_U_(0x1) << USBC_UPCON4_PERRE_Pos)
 #define USBC_UPCON4_NAKEDE_Pos      4            /**< \brief (USBC_UPCON4) NAKED Interrupt Enable */
-#define USBC_UPCON4_NAKEDE          (_U(0x1) << USBC_UPCON4_NAKEDE_Pos)
+#define USBC_UPCON4_NAKEDE          (_U_(0x1) << USBC_UPCON4_NAKEDE_Pos)
 #define USBC_UPCON4_ERRORFIE_Pos    5            /**< \brief (USBC_UPCON4) ERRORFI Interrupt Enable */
-#define USBC_UPCON4_ERRORFIE        (_U(0x1) << USBC_UPCON4_ERRORFIE_Pos)
+#define USBC_UPCON4_ERRORFIE        (_U_(0x1) << USBC_UPCON4_ERRORFIE_Pos)
 #define USBC_UPCON4_RXSTALLDE_Pos   6            /**< \brief (USBC_UPCON4) RXTALLD Interrupt Enable */
-#define USBC_UPCON4_RXSTALLDE       (_U(0x1) << USBC_UPCON4_RXSTALLDE_Pos)
+#define USBC_UPCON4_RXSTALLDE       (_U_(0x1) << USBC_UPCON4_RXSTALLDE_Pos)
 #define USBC_UPCON4_RAMACERE_Pos    10           /**< \brief (USBC_UPCON4) RAMACER Interrupt Enable */
-#define USBC_UPCON4_RAMACERE        (_U(0x1) << USBC_UPCON4_RAMACERE_Pos)
+#define USBC_UPCON4_RAMACERE        (_U_(0x1) << USBC_UPCON4_RAMACERE_Pos)
 #define USBC_UPCON4_NBUSYBKE_Pos    12           /**< \brief (USBC_UPCON4) NBUSYBKInterrupt Enable */
-#define USBC_UPCON4_NBUSYBKE        (_U(0x1) << USBC_UPCON4_NBUSYBKE_Pos)
+#define USBC_UPCON4_NBUSYBKE        (_U_(0x1) << USBC_UPCON4_NBUSYBKE_Pos)
 #define USBC_UPCON4_FIFOCON_Pos     14           /**< \brief (USBC_UPCON4) FIFO Control */
-#define USBC_UPCON4_FIFOCON         (_U(0x1) << USBC_UPCON4_FIFOCON_Pos)
+#define USBC_UPCON4_FIFOCON         (_U_(0x1) << USBC_UPCON4_FIFOCON_Pos)
 #define USBC_UPCON4_PFREEZE_Pos     17           /**< \brief (USBC_UPCON4) Pipe Freeze */
-#define USBC_UPCON4_PFREEZE         (_U(0x1) << USBC_UPCON4_PFREEZE_Pos)
+#define USBC_UPCON4_PFREEZE         (_U_(0x1) << USBC_UPCON4_PFREEZE_Pos)
 #define USBC_UPCON4_INITDTGL_Pos    18           /**< \brief (USBC_UPCON4) Data Toggle Initialization */
-#define USBC_UPCON4_INITDTGL        (_U(0x1) << USBC_UPCON4_INITDTGL_Pos)
+#define USBC_UPCON4_INITDTGL        (_U_(0x1) << USBC_UPCON4_INITDTGL_Pos)
 #define USBC_UPCON4_INITBK_Pos      19           /**< \brief (USBC_UPCON4) Bank Initialization */
-#define USBC_UPCON4_INITBK          (_U(0x1) << USBC_UPCON4_INITBK_Pos)
-#define USBC_UPCON4_MASK            _U(0x000E547F) /**< \brief (USBC_UPCON4) MASK Register */
+#define USBC_UPCON4_INITBK          (_U_(0x1) << USBC_UPCON4_INITBK_Pos)
+#define USBC_UPCON4_MASK            _U_(0x000E547F) /**< \brief (USBC_UPCON4) MASK Register */
 
 /* -------- USBC_UPCON5 : (USBC Offset: 0x5D4) (R/  32) Pipe Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -6140,35 +6140,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCON5_OFFSET          0x5D4        /**< \brief (USBC_UPCON5 offset) Pipe Control Register */
-#define USBC_UPCON5_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCON5 reset_value) Pipe Control Register */
+#define USBC_UPCON5_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UPCON5 reset_value) Pipe Control Register */
 
 #define USBC_UPCON5_RXINE_Pos       0            /**< \brief (USBC_UPCON5) RXIN Interrupt Enable */
-#define USBC_UPCON5_RXINE           (_U(0x1) << USBC_UPCON5_RXINE_Pos)
+#define USBC_UPCON5_RXINE           (_U_(0x1) << USBC_UPCON5_RXINE_Pos)
 #define USBC_UPCON5_TXOUTE_Pos      1            /**< \brief (USBC_UPCON5) TXOUT Interrupt Enable */
-#define USBC_UPCON5_TXOUTE          (_U(0x1) << USBC_UPCON5_TXOUTE_Pos)
+#define USBC_UPCON5_TXOUTE          (_U_(0x1) << USBC_UPCON5_TXOUTE_Pos)
 #define USBC_UPCON5_TXSTPE_Pos      2            /**< \brief (USBC_UPCON5) TXSTP Interrupt Enable */
-#define USBC_UPCON5_TXSTPE          (_U(0x1) << USBC_UPCON5_TXSTPE_Pos)
+#define USBC_UPCON5_TXSTPE          (_U_(0x1) << USBC_UPCON5_TXSTPE_Pos)
 #define USBC_UPCON5_PERRE_Pos       3            /**< \brief (USBC_UPCON5) PERR Interrupt Enable */
-#define USBC_UPCON5_PERRE           (_U(0x1) << USBC_UPCON5_PERRE_Pos)
+#define USBC_UPCON5_PERRE           (_U_(0x1) << USBC_UPCON5_PERRE_Pos)
 #define USBC_UPCON5_NAKEDE_Pos      4            /**< \brief (USBC_UPCON5) NAKED Interrupt Enable */
-#define USBC_UPCON5_NAKEDE          (_U(0x1) << USBC_UPCON5_NAKEDE_Pos)
+#define USBC_UPCON5_NAKEDE          (_U_(0x1) << USBC_UPCON5_NAKEDE_Pos)
 #define USBC_UPCON5_ERRORFIE_Pos    5            /**< \brief (USBC_UPCON5) ERRORFI Interrupt Enable */
-#define USBC_UPCON5_ERRORFIE        (_U(0x1) << USBC_UPCON5_ERRORFIE_Pos)
+#define USBC_UPCON5_ERRORFIE        (_U_(0x1) << USBC_UPCON5_ERRORFIE_Pos)
 #define USBC_UPCON5_RXSTALLDE_Pos   6            /**< \brief (USBC_UPCON5) RXTALLD Interrupt Enable */
-#define USBC_UPCON5_RXSTALLDE       (_U(0x1) << USBC_UPCON5_RXSTALLDE_Pos)
+#define USBC_UPCON5_RXSTALLDE       (_U_(0x1) << USBC_UPCON5_RXSTALLDE_Pos)
 #define USBC_UPCON5_RAMACERE_Pos    10           /**< \brief (USBC_UPCON5) RAMACER Interrupt Enable */
-#define USBC_UPCON5_RAMACERE        (_U(0x1) << USBC_UPCON5_RAMACERE_Pos)
+#define USBC_UPCON5_RAMACERE        (_U_(0x1) << USBC_UPCON5_RAMACERE_Pos)
 #define USBC_UPCON5_NBUSYBKE_Pos    12           /**< \brief (USBC_UPCON5) NBUSYBKInterrupt Enable */
-#define USBC_UPCON5_NBUSYBKE        (_U(0x1) << USBC_UPCON5_NBUSYBKE_Pos)
+#define USBC_UPCON5_NBUSYBKE        (_U_(0x1) << USBC_UPCON5_NBUSYBKE_Pos)
 #define USBC_UPCON5_FIFOCON_Pos     14           /**< \brief (USBC_UPCON5) FIFO Control */
-#define USBC_UPCON5_FIFOCON         (_U(0x1) << USBC_UPCON5_FIFOCON_Pos)
+#define USBC_UPCON5_FIFOCON         (_U_(0x1) << USBC_UPCON5_FIFOCON_Pos)
 #define USBC_UPCON5_PFREEZE_Pos     17           /**< \brief (USBC_UPCON5) Pipe Freeze */
-#define USBC_UPCON5_PFREEZE         (_U(0x1) << USBC_UPCON5_PFREEZE_Pos)
+#define USBC_UPCON5_PFREEZE         (_U_(0x1) << USBC_UPCON5_PFREEZE_Pos)
 #define USBC_UPCON5_INITDTGL_Pos    18           /**< \brief (USBC_UPCON5) Data Toggle Initialization */
-#define USBC_UPCON5_INITDTGL        (_U(0x1) << USBC_UPCON5_INITDTGL_Pos)
+#define USBC_UPCON5_INITDTGL        (_U_(0x1) << USBC_UPCON5_INITDTGL_Pos)
 #define USBC_UPCON5_INITBK_Pos      19           /**< \brief (USBC_UPCON5) Bank Initialization */
-#define USBC_UPCON5_INITBK          (_U(0x1) << USBC_UPCON5_INITBK_Pos)
-#define USBC_UPCON5_MASK            _U(0x000E547F) /**< \brief (USBC_UPCON5) MASK Register */
+#define USBC_UPCON5_INITBK          (_U_(0x1) << USBC_UPCON5_INITBK_Pos)
+#define USBC_UPCON5_MASK            _U_(0x000E547F) /**< \brief (USBC_UPCON5) MASK Register */
 
 /* -------- USBC_UPCON6 : (USBC Offset: 0x5D8) (R/  32) Pipe Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -6198,35 +6198,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCON6_OFFSET          0x5D8        /**< \brief (USBC_UPCON6 offset) Pipe Control Register */
-#define USBC_UPCON6_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCON6 reset_value) Pipe Control Register */
+#define USBC_UPCON6_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UPCON6 reset_value) Pipe Control Register */
 
 #define USBC_UPCON6_RXINE_Pos       0            /**< \brief (USBC_UPCON6) RXIN Interrupt Enable */
-#define USBC_UPCON6_RXINE           (_U(0x1) << USBC_UPCON6_RXINE_Pos)
+#define USBC_UPCON6_RXINE           (_U_(0x1) << USBC_UPCON6_RXINE_Pos)
 #define USBC_UPCON6_TXOUTE_Pos      1            /**< \brief (USBC_UPCON6) TXOUT Interrupt Enable */
-#define USBC_UPCON6_TXOUTE          (_U(0x1) << USBC_UPCON6_TXOUTE_Pos)
+#define USBC_UPCON6_TXOUTE          (_U_(0x1) << USBC_UPCON6_TXOUTE_Pos)
 #define USBC_UPCON6_TXSTPE_Pos      2            /**< \brief (USBC_UPCON6) TXSTP Interrupt Enable */
-#define USBC_UPCON6_TXSTPE          (_U(0x1) << USBC_UPCON6_TXSTPE_Pos)
+#define USBC_UPCON6_TXSTPE          (_U_(0x1) << USBC_UPCON6_TXSTPE_Pos)
 #define USBC_UPCON6_PERRE_Pos       3            /**< \brief (USBC_UPCON6) PERR Interrupt Enable */
-#define USBC_UPCON6_PERRE           (_U(0x1) << USBC_UPCON6_PERRE_Pos)
+#define USBC_UPCON6_PERRE           (_U_(0x1) << USBC_UPCON6_PERRE_Pos)
 #define USBC_UPCON6_NAKEDE_Pos      4            /**< \brief (USBC_UPCON6) NAKED Interrupt Enable */
-#define USBC_UPCON6_NAKEDE          (_U(0x1) << USBC_UPCON6_NAKEDE_Pos)
+#define USBC_UPCON6_NAKEDE          (_U_(0x1) << USBC_UPCON6_NAKEDE_Pos)
 #define USBC_UPCON6_ERRORFIE_Pos    5            /**< \brief (USBC_UPCON6) ERRORFI Interrupt Enable */
-#define USBC_UPCON6_ERRORFIE        (_U(0x1) << USBC_UPCON6_ERRORFIE_Pos)
+#define USBC_UPCON6_ERRORFIE        (_U_(0x1) << USBC_UPCON6_ERRORFIE_Pos)
 #define USBC_UPCON6_RXSTALLDE_Pos   6            /**< \brief (USBC_UPCON6) RXTALLD Interrupt Enable */
-#define USBC_UPCON6_RXSTALLDE       (_U(0x1) << USBC_UPCON6_RXSTALLDE_Pos)
+#define USBC_UPCON6_RXSTALLDE       (_U_(0x1) << USBC_UPCON6_RXSTALLDE_Pos)
 #define USBC_UPCON6_RAMACERE_Pos    10           /**< \brief (USBC_UPCON6) RAMACER Interrupt Enable */
-#define USBC_UPCON6_RAMACERE        (_U(0x1) << USBC_UPCON6_RAMACERE_Pos)
+#define USBC_UPCON6_RAMACERE        (_U_(0x1) << USBC_UPCON6_RAMACERE_Pos)
 #define USBC_UPCON6_NBUSYBKE_Pos    12           /**< \brief (USBC_UPCON6) NBUSYBKInterrupt Enable */
-#define USBC_UPCON6_NBUSYBKE        (_U(0x1) << USBC_UPCON6_NBUSYBKE_Pos)
+#define USBC_UPCON6_NBUSYBKE        (_U_(0x1) << USBC_UPCON6_NBUSYBKE_Pos)
 #define USBC_UPCON6_FIFOCON_Pos     14           /**< \brief (USBC_UPCON6) FIFO Control */
-#define USBC_UPCON6_FIFOCON         (_U(0x1) << USBC_UPCON6_FIFOCON_Pos)
+#define USBC_UPCON6_FIFOCON         (_U_(0x1) << USBC_UPCON6_FIFOCON_Pos)
 #define USBC_UPCON6_PFREEZE_Pos     17           /**< \brief (USBC_UPCON6) Pipe Freeze */
-#define USBC_UPCON6_PFREEZE         (_U(0x1) << USBC_UPCON6_PFREEZE_Pos)
+#define USBC_UPCON6_PFREEZE         (_U_(0x1) << USBC_UPCON6_PFREEZE_Pos)
 #define USBC_UPCON6_INITDTGL_Pos    18           /**< \brief (USBC_UPCON6) Data Toggle Initialization */
-#define USBC_UPCON6_INITDTGL        (_U(0x1) << USBC_UPCON6_INITDTGL_Pos)
+#define USBC_UPCON6_INITDTGL        (_U_(0x1) << USBC_UPCON6_INITDTGL_Pos)
 #define USBC_UPCON6_INITBK_Pos      19           /**< \brief (USBC_UPCON6) Bank Initialization */
-#define USBC_UPCON6_INITBK          (_U(0x1) << USBC_UPCON6_INITBK_Pos)
-#define USBC_UPCON6_MASK            _U(0x000E547F) /**< \brief (USBC_UPCON6) MASK Register */
+#define USBC_UPCON6_INITBK          (_U_(0x1) << USBC_UPCON6_INITBK_Pos)
+#define USBC_UPCON6_MASK            _U_(0x000E547F) /**< \brief (USBC_UPCON6) MASK Register */
 
 /* -------- USBC_UPCON7 : (USBC Offset: 0x5DC) (R/  32) Pipe Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -6256,35 +6256,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCON7_OFFSET          0x5DC        /**< \brief (USBC_UPCON7 offset) Pipe Control Register */
-#define USBC_UPCON7_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCON7 reset_value) Pipe Control Register */
+#define USBC_UPCON7_RESETVALUE      _U_(0x00000000); /**< \brief (USBC_UPCON7 reset_value) Pipe Control Register */
 
 #define USBC_UPCON7_RXINE_Pos       0            /**< \brief (USBC_UPCON7) RXIN Interrupt Enable */
-#define USBC_UPCON7_RXINE           (_U(0x1) << USBC_UPCON7_RXINE_Pos)
+#define USBC_UPCON7_RXINE           (_U_(0x1) << USBC_UPCON7_RXINE_Pos)
 #define USBC_UPCON7_TXOUTE_Pos      1            /**< \brief (USBC_UPCON7) TXOUT Interrupt Enable */
-#define USBC_UPCON7_TXOUTE          (_U(0x1) << USBC_UPCON7_TXOUTE_Pos)
+#define USBC_UPCON7_TXOUTE          (_U_(0x1) << USBC_UPCON7_TXOUTE_Pos)
 #define USBC_UPCON7_TXSTPE_Pos      2            /**< \brief (USBC_UPCON7) TXSTP Interrupt Enable */
-#define USBC_UPCON7_TXSTPE          (_U(0x1) << USBC_UPCON7_TXSTPE_Pos)
+#define USBC_UPCON7_TXSTPE          (_U_(0x1) << USBC_UPCON7_TXSTPE_Pos)
 #define USBC_UPCON7_PERRE_Pos       3            /**< \brief (USBC_UPCON7) PERR Interrupt Enable */
-#define USBC_UPCON7_PERRE           (_U(0x1) << USBC_UPCON7_PERRE_Pos)
+#define USBC_UPCON7_PERRE           (_U_(0x1) << USBC_UPCON7_PERRE_Pos)
 #define USBC_UPCON7_NAKEDE_Pos      4            /**< \brief (USBC_UPCON7) NAKED Interrupt Enable */
-#define USBC_UPCON7_NAKEDE          (_U(0x1) << USBC_UPCON7_NAKEDE_Pos)
+#define USBC_UPCON7_NAKEDE          (_U_(0x1) << USBC_UPCON7_NAKEDE_Pos)
 #define USBC_UPCON7_ERRORFIE_Pos    5            /**< \brief (USBC_UPCON7) ERRORFI Interrupt Enable */
-#define USBC_UPCON7_ERRORFIE        (_U(0x1) << USBC_UPCON7_ERRORFIE_Pos)
+#define USBC_UPCON7_ERRORFIE        (_U_(0x1) << USBC_UPCON7_ERRORFIE_Pos)
 #define USBC_UPCON7_RXSTALLDE_Pos   6            /**< \brief (USBC_UPCON7) RXTALLD Interrupt Enable */
-#define USBC_UPCON7_RXSTALLDE       (_U(0x1) << USBC_UPCON7_RXSTALLDE_Pos)
+#define USBC_UPCON7_RXSTALLDE       (_U_(0x1) << USBC_UPCON7_RXSTALLDE_Pos)
 #define USBC_UPCON7_RAMACERE_Pos    10           /**< \brief (USBC_UPCON7) RAMACER Interrupt Enable */
-#define USBC_UPCON7_RAMACERE        (_U(0x1) << USBC_UPCON7_RAMACERE_Pos)
+#define USBC_UPCON7_RAMACERE        (_U_(0x1) << USBC_UPCON7_RAMACERE_Pos)
 #define USBC_UPCON7_NBUSYBKE_Pos    12           /**< \brief (USBC_UPCON7) NBUSYBKInterrupt Enable */
-#define USBC_UPCON7_NBUSYBKE        (_U(0x1) << USBC_UPCON7_NBUSYBKE_Pos)
+#define USBC_UPCON7_NBUSYBKE        (_U_(0x1) << USBC_UPCON7_NBUSYBKE_Pos)
 #define USBC_UPCON7_FIFOCON_Pos     14           /**< \brief (USBC_UPCON7) FIFO Control */
-#define USBC_UPCON7_FIFOCON         (_U(0x1) << USBC_UPCON7_FIFOCON_Pos)
+#define USBC_UPCON7_FIFOCON         (_U_(0x1) << USBC_UPCON7_FIFOCON_Pos)
 #define USBC_UPCON7_PFREEZE_Pos     17           /**< \brief (USBC_UPCON7) Pipe Freeze */
-#define USBC_UPCON7_PFREEZE         (_U(0x1) << USBC_UPCON7_PFREEZE_Pos)
+#define USBC_UPCON7_PFREEZE         (_U_(0x1) << USBC_UPCON7_PFREEZE_Pos)
 #define USBC_UPCON7_INITDTGL_Pos    18           /**< \brief (USBC_UPCON7) Data Toggle Initialization */
-#define USBC_UPCON7_INITDTGL        (_U(0x1) << USBC_UPCON7_INITDTGL_Pos)
+#define USBC_UPCON7_INITDTGL        (_U_(0x1) << USBC_UPCON7_INITDTGL_Pos)
 #define USBC_UPCON7_INITBK_Pos      19           /**< \brief (USBC_UPCON7) Bank Initialization */
-#define USBC_UPCON7_INITBK          (_U(0x1) << USBC_UPCON7_INITBK_Pos)
-#define USBC_UPCON7_MASK            _U(0x000E547F) /**< \brief (USBC_UPCON7) MASK Register */
+#define USBC_UPCON7_INITBK          (_U_(0x1) << USBC_UPCON7_INITBK_Pos)
+#define USBC_UPCON7_MASK            _U_(0x000E547F) /**< \brief (USBC_UPCON7) MASK Register */
 
 /* -------- USBC_UPCON0SET : (USBC Offset: 0x5F0) ( /W 32) Pipe Control Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -6314,35 +6314,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCON0SET_OFFSET       0x5F0        /**< \brief (USBC_UPCON0SET offset) Pipe Control Set Register */
-#define USBC_UPCON0SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON0SET reset_value) Pipe Control Set Register */
+#define USBC_UPCON0SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPCON0SET reset_value) Pipe Control Set Register */
 
 #define USBC_UPCON0SET_RXINES_Pos   0            /**< \brief (USBC_UPCON0SET) RXINE Set */
-#define USBC_UPCON0SET_RXINES       (_U(0x1) << USBC_UPCON0SET_RXINES_Pos)
+#define USBC_UPCON0SET_RXINES       (_U_(0x1) << USBC_UPCON0SET_RXINES_Pos)
 #define USBC_UPCON0SET_TXOUTES_Pos  1            /**< \brief (USBC_UPCON0SET) TXOUTE Set */
-#define USBC_UPCON0SET_TXOUTES      (_U(0x1) << USBC_UPCON0SET_TXOUTES_Pos)
+#define USBC_UPCON0SET_TXOUTES      (_U_(0x1) << USBC_UPCON0SET_TXOUTES_Pos)
 #define USBC_UPCON0SET_TXSTPES_Pos  2            /**< \brief (USBC_UPCON0SET) TXSTPE Set */
-#define USBC_UPCON0SET_TXSTPES      (_U(0x1) << USBC_UPCON0SET_TXSTPES_Pos)
+#define USBC_UPCON0SET_TXSTPES      (_U_(0x1) << USBC_UPCON0SET_TXSTPES_Pos)
 #define USBC_UPCON0SET_PERRES_Pos   3            /**< \brief (USBC_UPCON0SET) PERRE Set */
-#define USBC_UPCON0SET_PERRES       (_U(0x1) << USBC_UPCON0SET_PERRES_Pos)
+#define USBC_UPCON0SET_PERRES       (_U_(0x1) << USBC_UPCON0SET_PERRES_Pos)
 #define USBC_UPCON0SET_NAKEDES_Pos  4            /**< \brief (USBC_UPCON0SET) NAKEDE Set */
-#define USBC_UPCON0SET_NAKEDES      (_U(0x1) << USBC_UPCON0SET_NAKEDES_Pos)
+#define USBC_UPCON0SET_NAKEDES      (_U_(0x1) << USBC_UPCON0SET_NAKEDES_Pos)
 #define USBC_UPCON0SET_ERRORFIES_Pos 5            /**< \brief (USBC_UPCON0SET) ERRORFIE Set */
-#define USBC_UPCON0SET_ERRORFIES    (_U(0x1) << USBC_UPCON0SET_ERRORFIES_Pos)
+#define USBC_UPCON0SET_ERRORFIES    (_U_(0x1) << USBC_UPCON0SET_ERRORFIES_Pos)
 #define USBC_UPCON0SET_RXSTALLDES_Pos 6            /**< \brief (USBC_UPCON0SET) RXSTALLDE Set */
-#define USBC_UPCON0SET_RXSTALLDES   (_U(0x1) << USBC_UPCON0SET_RXSTALLDES_Pos)
+#define USBC_UPCON0SET_RXSTALLDES   (_U_(0x1) << USBC_UPCON0SET_RXSTALLDES_Pos)
 #define USBC_UPCON0SET_RAMACERES_Pos 10           /**< \brief (USBC_UPCON0SET) RAMACERE Set */
-#define USBC_UPCON0SET_RAMACERES    (_U(0x1) << USBC_UPCON0SET_RAMACERES_Pos)
+#define USBC_UPCON0SET_RAMACERES    (_U_(0x1) << USBC_UPCON0SET_RAMACERES_Pos)
 #define USBC_UPCON0SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UPCON0SET) NBUSYBKE Set */
-#define USBC_UPCON0SET_NBUSYBKES    (_U(0x1) << USBC_UPCON0SET_NBUSYBKES_Pos)
+#define USBC_UPCON0SET_NBUSYBKES    (_U_(0x1) << USBC_UPCON0SET_NBUSYBKES_Pos)
 #define USBC_UPCON0SET_FIFOCONS_Pos 14           /**< \brief (USBC_UPCON0SET) FIFOCON Set */
-#define USBC_UPCON0SET_FIFOCONS     (_U(0x1) << USBC_UPCON0SET_FIFOCONS_Pos)
+#define USBC_UPCON0SET_FIFOCONS     (_U_(0x1) << USBC_UPCON0SET_FIFOCONS_Pos)
 #define USBC_UPCON0SET_PFREEZES_Pos 17           /**< \brief (USBC_UPCON0SET) PFREEZE Set */
-#define USBC_UPCON0SET_PFREEZES     (_U(0x1) << USBC_UPCON0SET_PFREEZES_Pos)
+#define USBC_UPCON0SET_PFREEZES     (_U_(0x1) << USBC_UPCON0SET_PFREEZES_Pos)
 #define USBC_UPCON0SET_INITDTGLS_Pos 18           /**< \brief (USBC_UPCON0SET) INITDTGL Set */
-#define USBC_UPCON0SET_INITDTGLS    (_U(0x1) << USBC_UPCON0SET_INITDTGLS_Pos)
+#define USBC_UPCON0SET_INITDTGLS    (_U_(0x1) << USBC_UPCON0SET_INITDTGLS_Pos)
 #define USBC_UPCON0SET_INITBKS_Pos  19           /**< \brief (USBC_UPCON0SET) INITBK Set */
-#define USBC_UPCON0SET_INITBKS      (_U(0x1) << USBC_UPCON0SET_INITBKS_Pos)
-#define USBC_UPCON0SET_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON0SET) MASK Register */
+#define USBC_UPCON0SET_INITBKS      (_U_(0x1) << USBC_UPCON0SET_INITBKS_Pos)
+#define USBC_UPCON0SET_MASK         _U_(0x000E547F) /**< \brief (USBC_UPCON0SET) MASK Register */
 
 /* -------- USBC_UPCON1SET : (USBC Offset: 0x5F4) ( /W 32) Pipe Control Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -6372,35 +6372,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCON1SET_OFFSET       0x5F4        /**< \brief (USBC_UPCON1SET offset) Pipe Control Set Register */
-#define USBC_UPCON1SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON1SET reset_value) Pipe Control Set Register */
+#define USBC_UPCON1SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPCON1SET reset_value) Pipe Control Set Register */
 
 #define USBC_UPCON1SET_RXINES_Pos   0            /**< \brief (USBC_UPCON1SET) RXINE Set */
-#define USBC_UPCON1SET_RXINES       (_U(0x1) << USBC_UPCON1SET_RXINES_Pos)
+#define USBC_UPCON1SET_RXINES       (_U_(0x1) << USBC_UPCON1SET_RXINES_Pos)
 #define USBC_UPCON1SET_TXOUTES_Pos  1            /**< \brief (USBC_UPCON1SET) TXOUTE Set */
-#define USBC_UPCON1SET_TXOUTES      (_U(0x1) << USBC_UPCON1SET_TXOUTES_Pos)
+#define USBC_UPCON1SET_TXOUTES      (_U_(0x1) << USBC_UPCON1SET_TXOUTES_Pos)
 #define USBC_UPCON1SET_TXSTPES_Pos  2            /**< \brief (USBC_UPCON1SET) TXSTPE Set */
-#define USBC_UPCON1SET_TXSTPES      (_U(0x1) << USBC_UPCON1SET_TXSTPES_Pos)
+#define USBC_UPCON1SET_TXSTPES      (_U_(0x1) << USBC_UPCON1SET_TXSTPES_Pos)
 #define USBC_UPCON1SET_PERRES_Pos   3            /**< \brief (USBC_UPCON1SET) PERRE Set */
-#define USBC_UPCON1SET_PERRES       (_U(0x1) << USBC_UPCON1SET_PERRES_Pos)
+#define USBC_UPCON1SET_PERRES       (_U_(0x1) << USBC_UPCON1SET_PERRES_Pos)
 #define USBC_UPCON1SET_NAKEDES_Pos  4            /**< \brief (USBC_UPCON1SET) NAKEDE Set */
-#define USBC_UPCON1SET_NAKEDES      (_U(0x1) << USBC_UPCON1SET_NAKEDES_Pos)
+#define USBC_UPCON1SET_NAKEDES      (_U_(0x1) << USBC_UPCON1SET_NAKEDES_Pos)
 #define USBC_UPCON1SET_ERRORFIES_Pos 5            /**< \brief (USBC_UPCON1SET) ERRORFIE Set */
-#define USBC_UPCON1SET_ERRORFIES    (_U(0x1) << USBC_UPCON1SET_ERRORFIES_Pos)
+#define USBC_UPCON1SET_ERRORFIES    (_U_(0x1) << USBC_UPCON1SET_ERRORFIES_Pos)
 #define USBC_UPCON1SET_RXSTALLDES_Pos 6            /**< \brief (USBC_UPCON1SET) RXSTALLDE Set */
-#define USBC_UPCON1SET_RXSTALLDES   (_U(0x1) << USBC_UPCON1SET_RXSTALLDES_Pos)
+#define USBC_UPCON1SET_RXSTALLDES   (_U_(0x1) << USBC_UPCON1SET_RXSTALLDES_Pos)
 #define USBC_UPCON1SET_RAMACERES_Pos 10           /**< \brief (USBC_UPCON1SET) RAMACERE Set */
-#define USBC_UPCON1SET_RAMACERES    (_U(0x1) << USBC_UPCON1SET_RAMACERES_Pos)
+#define USBC_UPCON1SET_RAMACERES    (_U_(0x1) << USBC_UPCON1SET_RAMACERES_Pos)
 #define USBC_UPCON1SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UPCON1SET) NBUSYBKE Set */
-#define USBC_UPCON1SET_NBUSYBKES    (_U(0x1) << USBC_UPCON1SET_NBUSYBKES_Pos)
+#define USBC_UPCON1SET_NBUSYBKES    (_U_(0x1) << USBC_UPCON1SET_NBUSYBKES_Pos)
 #define USBC_UPCON1SET_FIFOCONS_Pos 14           /**< \brief (USBC_UPCON1SET) FIFOCON Set */
-#define USBC_UPCON1SET_FIFOCONS     (_U(0x1) << USBC_UPCON1SET_FIFOCONS_Pos)
+#define USBC_UPCON1SET_FIFOCONS     (_U_(0x1) << USBC_UPCON1SET_FIFOCONS_Pos)
 #define USBC_UPCON1SET_PFREEZES_Pos 17           /**< \brief (USBC_UPCON1SET) PFREEZE Set */
-#define USBC_UPCON1SET_PFREEZES     (_U(0x1) << USBC_UPCON1SET_PFREEZES_Pos)
+#define USBC_UPCON1SET_PFREEZES     (_U_(0x1) << USBC_UPCON1SET_PFREEZES_Pos)
 #define USBC_UPCON1SET_INITDTGLS_Pos 18           /**< \brief (USBC_UPCON1SET) INITDTGL Set */
-#define USBC_UPCON1SET_INITDTGLS    (_U(0x1) << USBC_UPCON1SET_INITDTGLS_Pos)
+#define USBC_UPCON1SET_INITDTGLS    (_U_(0x1) << USBC_UPCON1SET_INITDTGLS_Pos)
 #define USBC_UPCON1SET_INITBKS_Pos  19           /**< \brief (USBC_UPCON1SET) INITBK Set */
-#define USBC_UPCON1SET_INITBKS      (_U(0x1) << USBC_UPCON1SET_INITBKS_Pos)
-#define USBC_UPCON1SET_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON1SET) MASK Register */
+#define USBC_UPCON1SET_INITBKS      (_U_(0x1) << USBC_UPCON1SET_INITBKS_Pos)
+#define USBC_UPCON1SET_MASK         _U_(0x000E547F) /**< \brief (USBC_UPCON1SET) MASK Register */
 
 /* -------- USBC_UPCON2SET : (USBC Offset: 0x5F8) ( /W 32) Pipe Control Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -6430,35 +6430,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCON2SET_OFFSET       0x5F8        /**< \brief (USBC_UPCON2SET offset) Pipe Control Set Register */
-#define USBC_UPCON2SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON2SET reset_value) Pipe Control Set Register */
+#define USBC_UPCON2SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPCON2SET reset_value) Pipe Control Set Register */
 
 #define USBC_UPCON2SET_RXINES_Pos   0            /**< \brief (USBC_UPCON2SET) RXINE Set */
-#define USBC_UPCON2SET_RXINES       (_U(0x1) << USBC_UPCON2SET_RXINES_Pos)
+#define USBC_UPCON2SET_RXINES       (_U_(0x1) << USBC_UPCON2SET_RXINES_Pos)
 #define USBC_UPCON2SET_TXOUTES_Pos  1            /**< \brief (USBC_UPCON2SET) TXOUTE Set */
-#define USBC_UPCON2SET_TXOUTES      (_U(0x1) << USBC_UPCON2SET_TXOUTES_Pos)
+#define USBC_UPCON2SET_TXOUTES      (_U_(0x1) << USBC_UPCON2SET_TXOUTES_Pos)
 #define USBC_UPCON2SET_TXSTPES_Pos  2            /**< \brief (USBC_UPCON2SET) TXSTPE Set */
-#define USBC_UPCON2SET_TXSTPES      (_U(0x1) << USBC_UPCON2SET_TXSTPES_Pos)
+#define USBC_UPCON2SET_TXSTPES      (_U_(0x1) << USBC_UPCON2SET_TXSTPES_Pos)
 #define USBC_UPCON2SET_PERRES_Pos   3            /**< \brief (USBC_UPCON2SET) PERRE Set */
-#define USBC_UPCON2SET_PERRES       (_U(0x1) << USBC_UPCON2SET_PERRES_Pos)
+#define USBC_UPCON2SET_PERRES       (_U_(0x1) << USBC_UPCON2SET_PERRES_Pos)
 #define USBC_UPCON2SET_NAKEDES_Pos  4            /**< \brief (USBC_UPCON2SET) NAKEDE Set */
-#define USBC_UPCON2SET_NAKEDES      (_U(0x1) << USBC_UPCON2SET_NAKEDES_Pos)
+#define USBC_UPCON2SET_NAKEDES      (_U_(0x1) << USBC_UPCON2SET_NAKEDES_Pos)
 #define USBC_UPCON2SET_ERRORFIES_Pos 5            /**< \brief (USBC_UPCON2SET) ERRORFIE Set */
-#define USBC_UPCON2SET_ERRORFIES    (_U(0x1) << USBC_UPCON2SET_ERRORFIES_Pos)
+#define USBC_UPCON2SET_ERRORFIES    (_U_(0x1) << USBC_UPCON2SET_ERRORFIES_Pos)
 #define USBC_UPCON2SET_RXSTALLDES_Pos 6            /**< \brief (USBC_UPCON2SET) RXSTALLDE Set */
-#define USBC_UPCON2SET_RXSTALLDES   (_U(0x1) << USBC_UPCON2SET_RXSTALLDES_Pos)
+#define USBC_UPCON2SET_RXSTALLDES   (_U_(0x1) << USBC_UPCON2SET_RXSTALLDES_Pos)
 #define USBC_UPCON2SET_RAMACERES_Pos 10           /**< \brief (USBC_UPCON2SET) RAMACERE Set */
-#define USBC_UPCON2SET_RAMACERES    (_U(0x1) << USBC_UPCON2SET_RAMACERES_Pos)
+#define USBC_UPCON2SET_RAMACERES    (_U_(0x1) << USBC_UPCON2SET_RAMACERES_Pos)
 #define USBC_UPCON2SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UPCON2SET) NBUSYBKE Set */
-#define USBC_UPCON2SET_NBUSYBKES    (_U(0x1) << USBC_UPCON2SET_NBUSYBKES_Pos)
+#define USBC_UPCON2SET_NBUSYBKES    (_U_(0x1) << USBC_UPCON2SET_NBUSYBKES_Pos)
 #define USBC_UPCON2SET_FIFOCONS_Pos 14           /**< \brief (USBC_UPCON2SET) FIFOCON Set */
-#define USBC_UPCON2SET_FIFOCONS     (_U(0x1) << USBC_UPCON2SET_FIFOCONS_Pos)
+#define USBC_UPCON2SET_FIFOCONS     (_U_(0x1) << USBC_UPCON2SET_FIFOCONS_Pos)
 #define USBC_UPCON2SET_PFREEZES_Pos 17           /**< \brief (USBC_UPCON2SET) PFREEZE Set */
-#define USBC_UPCON2SET_PFREEZES     (_U(0x1) << USBC_UPCON2SET_PFREEZES_Pos)
+#define USBC_UPCON2SET_PFREEZES     (_U_(0x1) << USBC_UPCON2SET_PFREEZES_Pos)
 #define USBC_UPCON2SET_INITDTGLS_Pos 18           /**< \brief (USBC_UPCON2SET) INITDTGL Set */
-#define USBC_UPCON2SET_INITDTGLS    (_U(0x1) << USBC_UPCON2SET_INITDTGLS_Pos)
+#define USBC_UPCON2SET_INITDTGLS    (_U_(0x1) << USBC_UPCON2SET_INITDTGLS_Pos)
 #define USBC_UPCON2SET_INITBKS_Pos  19           /**< \brief (USBC_UPCON2SET) INITBK Set */
-#define USBC_UPCON2SET_INITBKS      (_U(0x1) << USBC_UPCON2SET_INITBKS_Pos)
-#define USBC_UPCON2SET_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON2SET) MASK Register */
+#define USBC_UPCON2SET_INITBKS      (_U_(0x1) << USBC_UPCON2SET_INITBKS_Pos)
+#define USBC_UPCON2SET_MASK         _U_(0x000E547F) /**< \brief (USBC_UPCON2SET) MASK Register */
 
 /* -------- USBC_UPCON3SET : (USBC Offset: 0x5FC) ( /W 32) Pipe Control Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -6488,35 +6488,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCON3SET_OFFSET       0x5FC        /**< \brief (USBC_UPCON3SET offset) Pipe Control Set Register */
-#define USBC_UPCON3SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON3SET reset_value) Pipe Control Set Register */
+#define USBC_UPCON3SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPCON3SET reset_value) Pipe Control Set Register */
 
 #define USBC_UPCON3SET_RXINES_Pos   0            /**< \brief (USBC_UPCON3SET) RXINE Set */
-#define USBC_UPCON3SET_RXINES       (_U(0x1) << USBC_UPCON3SET_RXINES_Pos)
+#define USBC_UPCON3SET_RXINES       (_U_(0x1) << USBC_UPCON3SET_RXINES_Pos)
 #define USBC_UPCON3SET_TXOUTES_Pos  1            /**< \brief (USBC_UPCON3SET) TXOUTE Set */
-#define USBC_UPCON3SET_TXOUTES      (_U(0x1) << USBC_UPCON3SET_TXOUTES_Pos)
+#define USBC_UPCON3SET_TXOUTES      (_U_(0x1) << USBC_UPCON3SET_TXOUTES_Pos)
 #define USBC_UPCON3SET_TXSTPES_Pos  2            /**< \brief (USBC_UPCON3SET) TXSTPE Set */
-#define USBC_UPCON3SET_TXSTPES      (_U(0x1) << USBC_UPCON3SET_TXSTPES_Pos)
+#define USBC_UPCON3SET_TXSTPES      (_U_(0x1) << USBC_UPCON3SET_TXSTPES_Pos)
 #define USBC_UPCON3SET_PERRES_Pos   3            /**< \brief (USBC_UPCON3SET) PERRE Set */
-#define USBC_UPCON3SET_PERRES       (_U(0x1) << USBC_UPCON3SET_PERRES_Pos)
+#define USBC_UPCON3SET_PERRES       (_U_(0x1) << USBC_UPCON3SET_PERRES_Pos)
 #define USBC_UPCON3SET_NAKEDES_Pos  4            /**< \brief (USBC_UPCON3SET) NAKEDE Set */
-#define USBC_UPCON3SET_NAKEDES      (_U(0x1) << USBC_UPCON3SET_NAKEDES_Pos)
+#define USBC_UPCON3SET_NAKEDES      (_U_(0x1) << USBC_UPCON3SET_NAKEDES_Pos)
 #define USBC_UPCON3SET_ERRORFIES_Pos 5            /**< \brief (USBC_UPCON3SET) ERRORFIE Set */
-#define USBC_UPCON3SET_ERRORFIES    (_U(0x1) << USBC_UPCON3SET_ERRORFIES_Pos)
+#define USBC_UPCON3SET_ERRORFIES    (_U_(0x1) << USBC_UPCON3SET_ERRORFIES_Pos)
 #define USBC_UPCON3SET_RXSTALLDES_Pos 6            /**< \brief (USBC_UPCON3SET) RXSTALLDE Set */
-#define USBC_UPCON3SET_RXSTALLDES   (_U(0x1) << USBC_UPCON3SET_RXSTALLDES_Pos)
+#define USBC_UPCON3SET_RXSTALLDES   (_U_(0x1) << USBC_UPCON3SET_RXSTALLDES_Pos)
 #define USBC_UPCON3SET_RAMACERES_Pos 10           /**< \brief (USBC_UPCON3SET) RAMACERE Set */
-#define USBC_UPCON3SET_RAMACERES    (_U(0x1) << USBC_UPCON3SET_RAMACERES_Pos)
+#define USBC_UPCON3SET_RAMACERES    (_U_(0x1) << USBC_UPCON3SET_RAMACERES_Pos)
 #define USBC_UPCON3SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UPCON3SET) NBUSYBKE Set */
-#define USBC_UPCON3SET_NBUSYBKES    (_U(0x1) << USBC_UPCON3SET_NBUSYBKES_Pos)
+#define USBC_UPCON3SET_NBUSYBKES    (_U_(0x1) << USBC_UPCON3SET_NBUSYBKES_Pos)
 #define USBC_UPCON3SET_FIFOCONS_Pos 14           /**< \brief (USBC_UPCON3SET) FIFOCON Set */
-#define USBC_UPCON3SET_FIFOCONS     (_U(0x1) << USBC_UPCON3SET_FIFOCONS_Pos)
+#define USBC_UPCON3SET_FIFOCONS     (_U_(0x1) << USBC_UPCON3SET_FIFOCONS_Pos)
 #define USBC_UPCON3SET_PFREEZES_Pos 17           /**< \brief (USBC_UPCON3SET) PFREEZE Set */
-#define USBC_UPCON3SET_PFREEZES     (_U(0x1) << USBC_UPCON3SET_PFREEZES_Pos)
+#define USBC_UPCON3SET_PFREEZES     (_U_(0x1) << USBC_UPCON3SET_PFREEZES_Pos)
 #define USBC_UPCON3SET_INITDTGLS_Pos 18           /**< \brief (USBC_UPCON3SET) INITDTGL Set */
-#define USBC_UPCON3SET_INITDTGLS    (_U(0x1) << USBC_UPCON3SET_INITDTGLS_Pos)
+#define USBC_UPCON3SET_INITDTGLS    (_U_(0x1) << USBC_UPCON3SET_INITDTGLS_Pos)
 #define USBC_UPCON3SET_INITBKS_Pos  19           /**< \brief (USBC_UPCON3SET) INITBK Set */
-#define USBC_UPCON3SET_INITBKS      (_U(0x1) << USBC_UPCON3SET_INITBKS_Pos)
-#define USBC_UPCON3SET_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON3SET) MASK Register */
+#define USBC_UPCON3SET_INITBKS      (_U_(0x1) << USBC_UPCON3SET_INITBKS_Pos)
+#define USBC_UPCON3SET_MASK         _U_(0x000E547F) /**< \brief (USBC_UPCON3SET) MASK Register */
 
 /* -------- USBC_UPCON4SET : (USBC Offset: 0x600) ( /W 32) Pipe Control Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -6546,35 +6546,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCON4SET_OFFSET       0x600        /**< \brief (USBC_UPCON4SET offset) Pipe Control Set Register */
-#define USBC_UPCON4SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON4SET reset_value) Pipe Control Set Register */
+#define USBC_UPCON4SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPCON4SET reset_value) Pipe Control Set Register */
 
 #define USBC_UPCON4SET_RXINES_Pos   0            /**< \brief (USBC_UPCON4SET) RXINE Set */
-#define USBC_UPCON4SET_RXINES       (_U(0x1) << USBC_UPCON4SET_RXINES_Pos)
+#define USBC_UPCON4SET_RXINES       (_U_(0x1) << USBC_UPCON4SET_RXINES_Pos)
 #define USBC_UPCON4SET_TXOUTES_Pos  1            /**< \brief (USBC_UPCON4SET) TXOUTE Set */
-#define USBC_UPCON4SET_TXOUTES      (_U(0x1) << USBC_UPCON4SET_TXOUTES_Pos)
+#define USBC_UPCON4SET_TXOUTES      (_U_(0x1) << USBC_UPCON4SET_TXOUTES_Pos)
 #define USBC_UPCON4SET_TXSTPES_Pos  2            /**< \brief (USBC_UPCON4SET) TXSTPE Set */
-#define USBC_UPCON4SET_TXSTPES      (_U(0x1) << USBC_UPCON4SET_TXSTPES_Pos)
+#define USBC_UPCON4SET_TXSTPES      (_U_(0x1) << USBC_UPCON4SET_TXSTPES_Pos)
 #define USBC_UPCON4SET_PERRES_Pos   3            /**< \brief (USBC_UPCON4SET) PERRE Set */
-#define USBC_UPCON4SET_PERRES       (_U(0x1) << USBC_UPCON4SET_PERRES_Pos)
+#define USBC_UPCON4SET_PERRES       (_U_(0x1) << USBC_UPCON4SET_PERRES_Pos)
 #define USBC_UPCON4SET_NAKEDES_Pos  4            /**< \brief (USBC_UPCON4SET) NAKEDE Set */
-#define USBC_UPCON4SET_NAKEDES      (_U(0x1) << USBC_UPCON4SET_NAKEDES_Pos)
+#define USBC_UPCON4SET_NAKEDES      (_U_(0x1) << USBC_UPCON4SET_NAKEDES_Pos)
 #define USBC_UPCON4SET_ERRORFIES_Pos 5            /**< \brief (USBC_UPCON4SET) ERRORFIE Set */
-#define USBC_UPCON4SET_ERRORFIES    (_U(0x1) << USBC_UPCON4SET_ERRORFIES_Pos)
+#define USBC_UPCON4SET_ERRORFIES    (_U_(0x1) << USBC_UPCON4SET_ERRORFIES_Pos)
 #define USBC_UPCON4SET_RXSTALLDES_Pos 6            /**< \brief (USBC_UPCON4SET) RXSTALLDE Set */
-#define USBC_UPCON4SET_RXSTALLDES   (_U(0x1) << USBC_UPCON4SET_RXSTALLDES_Pos)
+#define USBC_UPCON4SET_RXSTALLDES   (_U_(0x1) << USBC_UPCON4SET_RXSTALLDES_Pos)
 #define USBC_UPCON4SET_RAMACERES_Pos 10           /**< \brief (USBC_UPCON4SET) RAMACERE Set */
-#define USBC_UPCON4SET_RAMACERES    (_U(0x1) << USBC_UPCON4SET_RAMACERES_Pos)
+#define USBC_UPCON4SET_RAMACERES    (_U_(0x1) << USBC_UPCON4SET_RAMACERES_Pos)
 #define USBC_UPCON4SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UPCON4SET) NBUSYBKE Set */
-#define USBC_UPCON4SET_NBUSYBKES    (_U(0x1) << USBC_UPCON4SET_NBUSYBKES_Pos)
+#define USBC_UPCON4SET_NBUSYBKES    (_U_(0x1) << USBC_UPCON4SET_NBUSYBKES_Pos)
 #define USBC_UPCON4SET_FIFOCONS_Pos 14           /**< \brief (USBC_UPCON4SET) FIFOCON Set */
-#define USBC_UPCON4SET_FIFOCONS     (_U(0x1) << USBC_UPCON4SET_FIFOCONS_Pos)
+#define USBC_UPCON4SET_FIFOCONS     (_U_(0x1) << USBC_UPCON4SET_FIFOCONS_Pos)
 #define USBC_UPCON4SET_PFREEZES_Pos 17           /**< \brief (USBC_UPCON4SET) PFREEZE Set */
-#define USBC_UPCON4SET_PFREEZES     (_U(0x1) << USBC_UPCON4SET_PFREEZES_Pos)
+#define USBC_UPCON4SET_PFREEZES     (_U_(0x1) << USBC_UPCON4SET_PFREEZES_Pos)
 #define USBC_UPCON4SET_INITDTGLS_Pos 18           /**< \brief (USBC_UPCON4SET) INITDTGL Set */
-#define USBC_UPCON4SET_INITDTGLS    (_U(0x1) << USBC_UPCON4SET_INITDTGLS_Pos)
+#define USBC_UPCON4SET_INITDTGLS    (_U_(0x1) << USBC_UPCON4SET_INITDTGLS_Pos)
 #define USBC_UPCON4SET_INITBKS_Pos  19           /**< \brief (USBC_UPCON4SET) INITBK Set */
-#define USBC_UPCON4SET_INITBKS      (_U(0x1) << USBC_UPCON4SET_INITBKS_Pos)
-#define USBC_UPCON4SET_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON4SET) MASK Register */
+#define USBC_UPCON4SET_INITBKS      (_U_(0x1) << USBC_UPCON4SET_INITBKS_Pos)
+#define USBC_UPCON4SET_MASK         _U_(0x000E547F) /**< \brief (USBC_UPCON4SET) MASK Register */
 
 /* -------- USBC_UPCON5SET : (USBC Offset: 0x604) ( /W 32) Pipe Control Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -6604,35 +6604,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCON5SET_OFFSET       0x604        /**< \brief (USBC_UPCON5SET offset) Pipe Control Set Register */
-#define USBC_UPCON5SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON5SET reset_value) Pipe Control Set Register */
+#define USBC_UPCON5SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPCON5SET reset_value) Pipe Control Set Register */
 
 #define USBC_UPCON5SET_RXINES_Pos   0            /**< \brief (USBC_UPCON5SET) RXINE Set */
-#define USBC_UPCON5SET_RXINES       (_U(0x1) << USBC_UPCON5SET_RXINES_Pos)
+#define USBC_UPCON5SET_RXINES       (_U_(0x1) << USBC_UPCON5SET_RXINES_Pos)
 #define USBC_UPCON5SET_TXOUTES_Pos  1            /**< \brief (USBC_UPCON5SET) TXOUTE Set */
-#define USBC_UPCON5SET_TXOUTES      (_U(0x1) << USBC_UPCON5SET_TXOUTES_Pos)
+#define USBC_UPCON5SET_TXOUTES      (_U_(0x1) << USBC_UPCON5SET_TXOUTES_Pos)
 #define USBC_UPCON5SET_TXSTPES_Pos  2            /**< \brief (USBC_UPCON5SET) TXSTPE Set */
-#define USBC_UPCON5SET_TXSTPES      (_U(0x1) << USBC_UPCON5SET_TXSTPES_Pos)
+#define USBC_UPCON5SET_TXSTPES      (_U_(0x1) << USBC_UPCON5SET_TXSTPES_Pos)
 #define USBC_UPCON5SET_PERRES_Pos   3            /**< \brief (USBC_UPCON5SET) PERRE Set */
-#define USBC_UPCON5SET_PERRES       (_U(0x1) << USBC_UPCON5SET_PERRES_Pos)
+#define USBC_UPCON5SET_PERRES       (_U_(0x1) << USBC_UPCON5SET_PERRES_Pos)
 #define USBC_UPCON5SET_NAKEDES_Pos  4            /**< \brief (USBC_UPCON5SET) NAKEDE Set */
-#define USBC_UPCON5SET_NAKEDES      (_U(0x1) << USBC_UPCON5SET_NAKEDES_Pos)
+#define USBC_UPCON5SET_NAKEDES      (_U_(0x1) << USBC_UPCON5SET_NAKEDES_Pos)
 #define USBC_UPCON5SET_ERRORFIES_Pos 5            /**< \brief (USBC_UPCON5SET) ERRORFIE Set */
-#define USBC_UPCON5SET_ERRORFIES    (_U(0x1) << USBC_UPCON5SET_ERRORFIES_Pos)
+#define USBC_UPCON5SET_ERRORFIES    (_U_(0x1) << USBC_UPCON5SET_ERRORFIES_Pos)
 #define USBC_UPCON5SET_RXSTALLDES_Pos 6            /**< \brief (USBC_UPCON5SET) RXSTALLDE Set */
-#define USBC_UPCON5SET_RXSTALLDES   (_U(0x1) << USBC_UPCON5SET_RXSTALLDES_Pos)
+#define USBC_UPCON5SET_RXSTALLDES   (_U_(0x1) << USBC_UPCON5SET_RXSTALLDES_Pos)
 #define USBC_UPCON5SET_RAMACERES_Pos 10           /**< \brief (USBC_UPCON5SET) RAMACERE Set */
-#define USBC_UPCON5SET_RAMACERES    (_U(0x1) << USBC_UPCON5SET_RAMACERES_Pos)
+#define USBC_UPCON5SET_RAMACERES    (_U_(0x1) << USBC_UPCON5SET_RAMACERES_Pos)
 #define USBC_UPCON5SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UPCON5SET) NBUSYBKE Set */
-#define USBC_UPCON5SET_NBUSYBKES    (_U(0x1) << USBC_UPCON5SET_NBUSYBKES_Pos)
+#define USBC_UPCON5SET_NBUSYBKES    (_U_(0x1) << USBC_UPCON5SET_NBUSYBKES_Pos)
 #define USBC_UPCON5SET_FIFOCONS_Pos 14           /**< \brief (USBC_UPCON5SET) FIFOCON Set */
-#define USBC_UPCON5SET_FIFOCONS     (_U(0x1) << USBC_UPCON5SET_FIFOCONS_Pos)
+#define USBC_UPCON5SET_FIFOCONS     (_U_(0x1) << USBC_UPCON5SET_FIFOCONS_Pos)
 #define USBC_UPCON5SET_PFREEZES_Pos 17           /**< \brief (USBC_UPCON5SET) PFREEZE Set */
-#define USBC_UPCON5SET_PFREEZES     (_U(0x1) << USBC_UPCON5SET_PFREEZES_Pos)
+#define USBC_UPCON5SET_PFREEZES     (_U_(0x1) << USBC_UPCON5SET_PFREEZES_Pos)
 #define USBC_UPCON5SET_INITDTGLS_Pos 18           /**< \brief (USBC_UPCON5SET) INITDTGL Set */
-#define USBC_UPCON5SET_INITDTGLS    (_U(0x1) << USBC_UPCON5SET_INITDTGLS_Pos)
+#define USBC_UPCON5SET_INITDTGLS    (_U_(0x1) << USBC_UPCON5SET_INITDTGLS_Pos)
 #define USBC_UPCON5SET_INITBKS_Pos  19           /**< \brief (USBC_UPCON5SET) INITBK Set */
-#define USBC_UPCON5SET_INITBKS      (_U(0x1) << USBC_UPCON5SET_INITBKS_Pos)
-#define USBC_UPCON5SET_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON5SET) MASK Register */
+#define USBC_UPCON5SET_INITBKS      (_U_(0x1) << USBC_UPCON5SET_INITBKS_Pos)
+#define USBC_UPCON5SET_MASK         _U_(0x000E547F) /**< \brief (USBC_UPCON5SET) MASK Register */
 
 /* -------- USBC_UPCON6SET : (USBC Offset: 0x608) ( /W 32) Pipe Control Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -6662,35 +6662,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCON6SET_OFFSET       0x608        /**< \brief (USBC_UPCON6SET offset) Pipe Control Set Register */
-#define USBC_UPCON6SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON6SET reset_value) Pipe Control Set Register */
+#define USBC_UPCON6SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPCON6SET reset_value) Pipe Control Set Register */
 
 #define USBC_UPCON6SET_RXINES_Pos   0            /**< \brief (USBC_UPCON6SET) RXINE Set */
-#define USBC_UPCON6SET_RXINES       (_U(0x1) << USBC_UPCON6SET_RXINES_Pos)
+#define USBC_UPCON6SET_RXINES       (_U_(0x1) << USBC_UPCON6SET_RXINES_Pos)
 #define USBC_UPCON6SET_TXOUTES_Pos  1            /**< \brief (USBC_UPCON6SET) TXOUTE Set */
-#define USBC_UPCON6SET_TXOUTES      (_U(0x1) << USBC_UPCON6SET_TXOUTES_Pos)
+#define USBC_UPCON6SET_TXOUTES      (_U_(0x1) << USBC_UPCON6SET_TXOUTES_Pos)
 #define USBC_UPCON6SET_TXSTPES_Pos  2            /**< \brief (USBC_UPCON6SET) TXSTPE Set */
-#define USBC_UPCON6SET_TXSTPES      (_U(0x1) << USBC_UPCON6SET_TXSTPES_Pos)
+#define USBC_UPCON6SET_TXSTPES      (_U_(0x1) << USBC_UPCON6SET_TXSTPES_Pos)
 #define USBC_UPCON6SET_PERRES_Pos   3            /**< \brief (USBC_UPCON6SET) PERRE Set */
-#define USBC_UPCON6SET_PERRES       (_U(0x1) << USBC_UPCON6SET_PERRES_Pos)
+#define USBC_UPCON6SET_PERRES       (_U_(0x1) << USBC_UPCON6SET_PERRES_Pos)
 #define USBC_UPCON6SET_NAKEDES_Pos  4            /**< \brief (USBC_UPCON6SET) NAKEDE Set */
-#define USBC_UPCON6SET_NAKEDES      (_U(0x1) << USBC_UPCON6SET_NAKEDES_Pos)
+#define USBC_UPCON6SET_NAKEDES      (_U_(0x1) << USBC_UPCON6SET_NAKEDES_Pos)
 #define USBC_UPCON6SET_ERRORFIES_Pos 5            /**< \brief (USBC_UPCON6SET) ERRORFIE Set */
-#define USBC_UPCON6SET_ERRORFIES    (_U(0x1) << USBC_UPCON6SET_ERRORFIES_Pos)
+#define USBC_UPCON6SET_ERRORFIES    (_U_(0x1) << USBC_UPCON6SET_ERRORFIES_Pos)
 #define USBC_UPCON6SET_RXSTALLDES_Pos 6            /**< \brief (USBC_UPCON6SET) RXSTALLDE Set */
-#define USBC_UPCON6SET_RXSTALLDES   (_U(0x1) << USBC_UPCON6SET_RXSTALLDES_Pos)
+#define USBC_UPCON6SET_RXSTALLDES   (_U_(0x1) << USBC_UPCON6SET_RXSTALLDES_Pos)
 #define USBC_UPCON6SET_RAMACERES_Pos 10           /**< \brief (USBC_UPCON6SET) RAMACERE Set */
-#define USBC_UPCON6SET_RAMACERES    (_U(0x1) << USBC_UPCON6SET_RAMACERES_Pos)
+#define USBC_UPCON6SET_RAMACERES    (_U_(0x1) << USBC_UPCON6SET_RAMACERES_Pos)
 #define USBC_UPCON6SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UPCON6SET) NBUSYBKE Set */
-#define USBC_UPCON6SET_NBUSYBKES    (_U(0x1) << USBC_UPCON6SET_NBUSYBKES_Pos)
+#define USBC_UPCON6SET_NBUSYBKES    (_U_(0x1) << USBC_UPCON6SET_NBUSYBKES_Pos)
 #define USBC_UPCON6SET_FIFOCONS_Pos 14           /**< \brief (USBC_UPCON6SET) FIFOCON Set */
-#define USBC_UPCON6SET_FIFOCONS     (_U(0x1) << USBC_UPCON6SET_FIFOCONS_Pos)
+#define USBC_UPCON6SET_FIFOCONS     (_U_(0x1) << USBC_UPCON6SET_FIFOCONS_Pos)
 #define USBC_UPCON6SET_PFREEZES_Pos 17           /**< \brief (USBC_UPCON6SET) PFREEZE Set */
-#define USBC_UPCON6SET_PFREEZES     (_U(0x1) << USBC_UPCON6SET_PFREEZES_Pos)
+#define USBC_UPCON6SET_PFREEZES     (_U_(0x1) << USBC_UPCON6SET_PFREEZES_Pos)
 #define USBC_UPCON6SET_INITDTGLS_Pos 18           /**< \brief (USBC_UPCON6SET) INITDTGL Set */
-#define USBC_UPCON6SET_INITDTGLS    (_U(0x1) << USBC_UPCON6SET_INITDTGLS_Pos)
+#define USBC_UPCON6SET_INITDTGLS    (_U_(0x1) << USBC_UPCON6SET_INITDTGLS_Pos)
 #define USBC_UPCON6SET_INITBKS_Pos  19           /**< \brief (USBC_UPCON6SET) INITBK Set */
-#define USBC_UPCON6SET_INITBKS      (_U(0x1) << USBC_UPCON6SET_INITBKS_Pos)
-#define USBC_UPCON6SET_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON6SET) MASK Register */
+#define USBC_UPCON6SET_INITBKS      (_U_(0x1) << USBC_UPCON6SET_INITBKS_Pos)
+#define USBC_UPCON6SET_MASK         _U_(0x000E547F) /**< \brief (USBC_UPCON6SET) MASK Register */
 
 /* -------- USBC_UPCON7SET : (USBC Offset: 0x60C) ( /W 32) Pipe Control Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -6720,35 +6720,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCON7SET_OFFSET       0x60C        /**< \brief (USBC_UPCON7SET offset) Pipe Control Set Register */
-#define USBC_UPCON7SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON7SET reset_value) Pipe Control Set Register */
+#define USBC_UPCON7SET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPCON7SET reset_value) Pipe Control Set Register */
 
 #define USBC_UPCON7SET_RXINES_Pos   0            /**< \brief (USBC_UPCON7SET) RXINE Set */
-#define USBC_UPCON7SET_RXINES       (_U(0x1) << USBC_UPCON7SET_RXINES_Pos)
+#define USBC_UPCON7SET_RXINES       (_U_(0x1) << USBC_UPCON7SET_RXINES_Pos)
 #define USBC_UPCON7SET_TXOUTES_Pos  1            /**< \brief (USBC_UPCON7SET) TXOUTE Set */
-#define USBC_UPCON7SET_TXOUTES      (_U(0x1) << USBC_UPCON7SET_TXOUTES_Pos)
+#define USBC_UPCON7SET_TXOUTES      (_U_(0x1) << USBC_UPCON7SET_TXOUTES_Pos)
 #define USBC_UPCON7SET_TXSTPES_Pos  2            /**< \brief (USBC_UPCON7SET) TXSTPE Set */
-#define USBC_UPCON7SET_TXSTPES      (_U(0x1) << USBC_UPCON7SET_TXSTPES_Pos)
+#define USBC_UPCON7SET_TXSTPES      (_U_(0x1) << USBC_UPCON7SET_TXSTPES_Pos)
 #define USBC_UPCON7SET_PERRES_Pos   3            /**< \brief (USBC_UPCON7SET) PERRE Set */
-#define USBC_UPCON7SET_PERRES       (_U(0x1) << USBC_UPCON7SET_PERRES_Pos)
+#define USBC_UPCON7SET_PERRES       (_U_(0x1) << USBC_UPCON7SET_PERRES_Pos)
 #define USBC_UPCON7SET_NAKEDES_Pos  4            /**< \brief (USBC_UPCON7SET) NAKEDE Set */
-#define USBC_UPCON7SET_NAKEDES      (_U(0x1) << USBC_UPCON7SET_NAKEDES_Pos)
+#define USBC_UPCON7SET_NAKEDES      (_U_(0x1) << USBC_UPCON7SET_NAKEDES_Pos)
 #define USBC_UPCON7SET_ERRORFIES_Pos 5            /**< \brief (USBC_UPCON7SET) ERRORFIE Set */
-#define USBC_UPCON7SET_ERRORFIES    (_U(0x1) << USBC_UPCON7SET_ERRORFIES_Pos)
+#define USBC_UPCON7SET_ERRORFIES    (_U_(0x1) << USBC_UPCON7SET_ERRORFIES_Pos)
 #define USBC_UPCON7SET_RXSTALLDES_Pos 6            /**< \brief (USBC_UPCON7SET) RXSTALLDE Set */
-#define USBC_UPCON7SET_RXSTALLDES   (_U(0x1) << USBC_UPCON7SET_RXSTALLDES_Pos)
+#define USBC_UPCON7SET_RXSTALLDES   (_U_(0x1) << USBC_UPCON7SET_RXSTALLDES_Pos)
 #define USBC_UPCON7SET_RAMACERES_Pos 10           /**< \brief (USBC_UPCON7SET) RAMACERE Set */
-#define USBC_UPCON7SET_RAMACERES    (_U(0x1) << USBC_UPCON7SET_RAMACERES_Pos)
+#define USBC_UPCON7SET_RAMACERES    (_U_(0x1) << USBC_UPCON7SET_RAMACERES_Pos)
 #define USBC_UPCON7SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UPCON7SET) NBUSYBKE Set */
-#define USBC_UPCON7SET_NBUSYBKES    (_U(0x1) << USBC_UPCON7SET_NBUSYBKES_Pos)
+#define USBC_UPCON7SET_NBUSYBKES    (_U_(0x1) << USBC_UPCON7SET_NBUSYBKES_Pos)
 #define USBC_UPCON7SET_FIFOCONS_Pos 14           /**< \brief (USBC_UPCON7SET) FIFOCON Set */
-#define USBC_UPCON7SET_FIFOCONS     (_U(0x1) << USBC_UPCON7SET_FIFOCONS_Pos)
+#define USBC_UPCON7SET_FIFOCONS     (_U_(0x1) << USBC_UPCON7SET_FIFOCONS_Pos)
 #define USBC_UPCON7SET_PFREEZES_Pos 17           /**< \brief (USBC_UPCON7SET) PFREEZE Set */
-#define USBC_UPCON7SET_PFREEZES     (_U(0x1) << USBC_UPCON7SET_PFREEZES_Pos)
+#define USBC_UPCON7SET_PFREEZES     (_U_(0x1) << USBC_UPCON7SET_PFREEZES_Pos)
 #define USBC_UPCON7SET_INITDTGLS_Pos 18           /**< \brief (USBC_UPCON7SET) INITDTGL Set */
-#define USBC_UPCON7SET_INITDTGLS    (_U(0x1) << USBC_UPCON7SET_INITDTGLS_Pos)
+#define USBC_UPCON7SET_INITDTGLS    (_U_(0x1) << USBC_UPCON7SET_INITDTGLS_Pos)
 #define USBC_UPCON7SET_INITBKS_Pos  19           /**< \brief (USBC_UPCON7SET) INITBK Set */
-#define USBC_UPCON7SET_INITBKS      (_U(0x1) << USBC_UPCON7SET_INITBKS_Pos)
-#define USBC_UPCON7SET_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON7SET) MASK Register */
+#define USBC_UPCON7SET_INITBKS      (_U_(0x1) << USBC_UPCON7SET_INITBKS_Pos)
+#define USBC_UPCON7SET_MASK         _U_(0x000E547F) /**< \brief (USBC_UPCON7SET) MASK Register */
 
 /* -------- USBC_UPCON0CLR : (USBC Offset: 0x620) ( /W 32) Pipe Control Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -6778,35 +6778,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCON0CLR_OFFSET       0x620        /**< \brief (USBC_UPCON0CLR offset) Pipe Control Clear Register */
-#define USBC_UPCON0CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON0CLR reset_value) Pipe Control Clear Register */
+#define USBC_UPCON0CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPCON0CLR reset_value) Pipe Control Clear Register */
 
 #define USBC_UPCON0CLR_RXINEC_Pos   0            /**< \brief (USBC_UPCON0CLR) RXINE Clear */
-#define USBC_UPCON0CLR_RXINEC       (_U(0x1) << USBC_UPCON0CLR_RXINEC_Pos)
+#define USBC_UPCON0CLR_RXINEC       (_U_(0x1) << USBC_UPCON0CLR_RXINEC_Pos)
 #define USBC_UPCON0CLR_TXOUTEC_Pos  1            /**< \brief (USBC_UPCON0CLR) TXOUTE Clear */
-#define USBC_UPCON0CLR_TXOUTEC      (_U(0x1) << USBC_UPCON0CLR_TXOUTEC_Pos)
+#define USBC_UPCON0CLR_TXOUTEC      (_U_(0x1) << USBC_UPCON0CLR_TXOUTEC_Pos)
 #define USBC_UPCON0CLR_TXSTPEC_Pos  2            /**< \brief (USBC_UPCON0CLR) TXSTPE Clear */
-#define USBC_UPCON0CLR_TXSTPEC      (_U(0x1) << USBC_UPCON0CLR_TXSTPEC_Pos)
+#define USBC_UPCON0CLR_TXSTPEC      (_U_(0x1) << USBC_UPCON0CLR_TXSTPEC_Pos)
 #define USBC_UPCON0CLR_PERREC_Pos   3            /**< \brief (USBC_UPCON0CLR) PERRE Clear */
-#define USBC_UPCON0CLR_PERREC       (_U(0x1) << USBC_UPCON0CLR_PERREC_Pos)
+#define USBC_UPCON0CLR_PERREC       (_U_(0x1) << USBC_UPCON0CLR_PERREC_Pos)
 #define USBC_UPCON0CLR_NAKEDEC_Pos  4            /**< \brief (USBC_UPCON0CLR) NAKEDE Clear */
-#define USBC_UPCON0CLR_NAKEDEC      (_U(0x1) << USBC_UPCON0CLR_NAKEDEC_Pos)
+#define USBC_UPCON0CLR_NAKEDEC      (_U_(0x1) << USBC_UPCON0CLR_NAKEDEC_Pos)
 #define USBC_UPCON0CLR_ERRORFIEC_Pos 5            /**< \brief (USBC_UPCON0CLR) ERRORFIE Clear */
-#define USBC_UPCON0CLR_ERRORFIEC    (_U(0x1) << USBC_UPCON0CLR_ERRORFIEC_Pos)
+#define USBC_UPCON0CLR_ERRORFIEC    (_U_(0x1) << USBC_UPCON0CLR_ERRORFIEC_Pos)
 #define USBC_UPCON0CLR_RXSTALLDEC_Pos 6            /**< \brief (USBC_UPCON0CLR) RXTALLDE Clear */
-#define USBC_UPCON0CLR_RXSTALLDEC   (_U(0x1) << USBC_UPCON0CLR_RXSTALLDEC_Pos)
+#define USBC_UPCON0CLR_RXSTALLDEC   (_U_(0x1) << USBC_UPCON0CLR_RXSTALLDEC_Pos)
 #define USBC_UPCON0CLR_RAMACEREC_Pos 10           /**< \brief (USBC_UPCON0CLR) RAMACERE Clear */
-#define USBC_UPCON0CLR_RAMACEREC    (_U(0x1) << USBC_UPCON0CLR_RAMACEREC_Pos)
+#define USBC_UPCON0CLR_RAMACEREC    (_U_(0x1) << USBC_UPCON0CLR_RAMACEREC_Pos)
 #define USBC_UPCON0CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UPCON0CLR) NBUSYBKE Clear */
-#define USBC_UPCON0CLR_NBUSYBKEC    (_U(0x1) << USBC_UPCON0CLR_NBUSYBKEC_Pos)
+#define USBC_UPCON0CLR_NBUSYBKEC    (_U_(0x1) << USBC_UPCON0CLR_NBUSYBKEC_Pos)
 #define USBC_UPCON0CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UPCON0CLR) FIFOCON Clear */
-#define USBC_UPCON0CLR_FIFOCONC     (_U(0x1) << USBC_UPCON0CLR_FIFOCONC_Pos)
+#define USBC_UPCON0CLR_FIFOCONC     (_U_(0x1) << USBC_UPCON0CLR_FIFOCONC_Pos)
 #define USBC_UPCON0CLR_PFREEZEC_Pos 17           /**< \brief (USBC_UPCON0CLR) PFREEZE Clear */
-#define USBC_UPCON0CLR_PFREEZEC     (_U(0x1) << USBC_UPCON0CLR_PFREEZEC_Pos)
+#define USBC_UPCON0CLR_PFREEZEC     (_U_(0x1) << USBC_UPCON0CLR_PFREEZEC_Pos)
 #define USBC_UPCON0CLR_INITDTGLC_Pos 18           /**< \brief (USBC_UPCON0CLR) INITDTGL Clear */
-#define USBC_UPCON0CLR_INITDTGLC    (_U(0x1) << USBC_UPCON0CLR_INITDTGLC_Pos)
+#define USBC_UPCON0CLR_INITDTGLC    (_U_(0x1) << USBC_UPCON0CLR_INITDTGLC_Pos)
 #define USBC_UPCON0CLR_INITBKC_Pos  19           /**< \brief (USBC_UPCON0CLR) INITBK Clear */
-#define USBC_UPCON0CLR_INITBKC      (_U(0x1) << USBC_UPCON0CLR_INITBKC_Pos)
-#define USBC_UPCON0CLR_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON0CLR) MASK Register */
+#define USBC_UPCON0CLR_INITBKC      (_U_(0x1) << USBC_UPCON0CLR_INITBKC_Pos)
+#define USBC_UPCON0CLR_MASK         _U_(0x000E547F) /**< \brief (USBC_UPCON0CLR) MASK Register */
 
 /* -------- USBC_UPCON1CLR : (USBC Offset: 0x624) ( /W 32) Pipe Control Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -6836,35 +6836,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCON1CLR_OFFSET       0x624        /**< \brief (USBC_UPCON1CLR offset) Pipe Control Clear Register */
-#define USBC_UPCON1CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON1CLR reset_value) Pipe Control Clear Register */
+#define USBC_UPCON1CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPCON1CLR reset_value) Pipe Control Clear Register */
 
 #define USBC_UPCON1CLR_RXINEC_Pos   0            /**< \brief (USBC_UPCON1CLR) RXINE Clear */
-#define USBC_UPCON1CLR_RXINEC       (_U(0x1) << USBC_UPCON1CLR_RXINEC_Pos)
+#define USBC_UPCON1CLR_RXINEC       (_U_(0x1) << USBC_UPCON1CLR_RXINEC_Pos)
 #define USBC_UPCON1CLR_TXOUTEC_Pos  1            /**< \brief (USBC_UPCON1CLR) TXOUTE Clear */
-#define USBC_UPCON1CLR_TXOUTEC      (_U(0x1) << USBC_UPCON1CLR_TXOUTEC_Pos)
+#define USBC_UPCON1CLR_TXOUTEC      (_U_(0x1) << USBC_UPCON1CLR_TXOUTEC_Pos)
 #define USBC_UPCON1CLR_TXSTPEC_Pos  2            /**< \brief (USBC_UPCON1CLR) TXSTPE Clear */
-#define USBC_UPCON1CLR_TXSTPEC      (_U(0x1) << USBC_UPCON1CLR_TXSTPEC_Pos)
+#define USBC_UPCON1CLR_TXSTPEC      (_U_(0x1) << USBC_UPCON1CLR_TXSTPEC_Pos)
 #define USBC_UPCON1CLR_PERREC_Pos   3            /**< \brief (USBC_UPCON1CLR) PERRE Clear */
-#define USBC_UPCON1CLR_PERREC       (_U(0x1) << USBC_UPCON1CLR_PERREC_Pos)
+#define USBC_UPCON1CLR_PERREC       (_U_(0x1) << USBC_UPCON1CLR_PERREC_Pos)
 #define USBC_UPCON1CLR_NAKEDEC_Pos  4            /**< \brief (USBC_UPCON1CLR) NAKEDE Clear */
-#define USBC_UPCON1CLR_NAKEDEC      (_U(0x1) << USBC_UPCON1CLR_NAKEDEC_Pos)
+#define USBC_UPCON1CLR_NAKEDEC      (_U_(0x1) << USBC_UPCON1CLR_NAKEDEC_Pos)
 #define USBC_UPCON1CLR_ERRORFIEC_Pos 5            /**< \brief (USBC_UPCON1CLR) ERRORFIE Clear */
-#define USBC_UPCON1CLR_ERRORFIEC    (_U(0x1) << USBC_UPCON1CLR_ERRORFIEC_Pos)
+#define USBC_UPCON1CLR_ERRORFIEC    (_U_(0x1) << USBC_UPCON1CLR_ERRORFIEC_Pos)
 #define USBC_UPCON1CLR_RXSTALLDEC_Pos 6            /**< \brief (USBC_UPCON1CLR) RXTALLDE Clear */
-#define USBC_UPCON1CLR_RXSTALLDEC   (_U(0x1) << USBC_UPCON1CLR_RXSTALLDEC_Pos)
+#define USBC_UPCON1CLR_RXSTALLDEC   (_U_(0x1) << USBC_UPCON1CLR_RXSTALLDEC_Pos)
 #define USBC_UPCON1CLR_RAMACEREC_Pos 10           /**< \brief (USBC_UPCON1CLR) RAMACERE Clear */
-#define USBC_UPCON1CLR_RAMACEREC    (_U(0x1) << USBC_UPCON1CLR_RAMACEREC_Pos)
+#define USBC_UPCON1CLR_RAMACEREC    (_U_(0x1) << USBC_UPCON1CLR_RAMACEREC_Pos)
 #define USBC_UPCON1CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UPCON1CLR) NBUSYBKE Clear */
-#define USBC_UPCON1CLR_NBUSYBKEC    (_U(0x1) << USBC_UPCON1CLR_NBUSYBKEC_Pos)
+#define USBC_UPCON1CLR_NBUSYBKEC    (_U_(0x1) << USBC_UPCON1CLR_NBUSYBKEC_Pos)
 #define USBC_UPCON1CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UPCON1CLR) FIFOCON Clear */
-#define USBC_UPCON1CLR_FIFOCONC     (_U(0x1) << USBC_UPCON1CLR_FIFOCONC_Pos)
+#define USBC_UPCON1CLR_FIFOCONC     (_U_(0x1) << USBC_UPCON1CLR_FIFOCONC_Pos)
 #define USBC_UPCON1CLR_PFREEZEC_Pos 17           /**< \brief (USBC_UPCON1CLR) PFREEZE Clear */
-#define USBC_UPCON1CLR_PFREEZEC     (_U(0x1) << USBC_UPCON1CLR_PFREEZEC_Pos)
+#define USBC_UPCON1CLR_PFREEZEC     (_U_(0x1) << USBC_UPCON1CLR_PFREEZEC_Pos)
 #define USBC_UPCON1CLR_INITDTGLC_Pos 18           /**< \brief (USBC_UPCON1CLR) INITDTGL Clear */
-#define USBC_UPCON1CLR_INITDTGLC    (_U(0x1) << USBC_UPCON1CLR_INITDTGLC_Pos)
+#define USBC_UPCON1CLR_INITDTGLC    (_U_(0x1) << USBC_UPCON1CLR_INITDTGLC_Pos)
 #define USBC_UPCON1CLR_INITBKC_Pos  19           /**< \brief (USBC_UPCON1CLR) INITBK Clear */
-#define USBC_UPCON1CLR_INITBKC      (_U(0x1) << USBC_UPCON1CLR_INITBKC_Pos)
-#define USBC_UPCON1CLR_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON1CLR) MASK Register */
+#define USBC_UPCON1CLR_INITBKC      (_U_(0x1) << USBC_UPCON1CLR_INITBKC_Pos)
+#define USBC_UPCON1CLR_MASK         _U_(0x000E547F) /**< \brief (USBC_UPCON1CLR) MASK Register */
 
 /* -------- USBC_UPCON2CLR : (USBC Offset: 0x628) ( /W 32) Pipe Control Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -6894,35 +6894,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCON2CLR_OFFSET       0x628        /**< \brief (USBC_UPCON2CLR offset) Pipe Control Clear Register */
-#define USBC_UPCON2CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON2CLR reset_value) Pipe Control Clear Register */
+#define USBC_UPCON2CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPCON2CLR reset_value) Pipe Control Clear Register */
 
 #define USBC_UPCON2CLR_RXINEC_Pos   0            /**< \brief (USBC_UPCON2CLR) RXINE Clear */
-#define USBC_UPCON2CLR_RXINEC       (_U(0x1) << USBC_UPCON2CLR_RXINEC_Pos)
+#define USBC_UPCON2CLR_RXINEC       (_U_(0x1) << USBC_UPCON2CLR_RXINEC_Pos)
 #define USBC_UPCON2CLR_TXOUTEC_Pos  1            /**< \brief (USBC_UPCON2CLR) TXOUTE Clear */
-#define USBC_UPCON2CLR_TXOUTEC      (_U(0x1) << USBC_UPCON2CLR_TXOUTEC_Pos)
+#define USBC_UPCON2CLR_TXOUTEC      (_U_(0x1) << USBC_UPCON2CLR_TXOUTEC_Pos)
 #define USBC_UPCON2CLR_TXSTPEC_Pos  2            /**< \brief (USBC_UPCON2CLR) TXSTPE Clear */
-#define USBC_UPCON2CLR_TXSTPEC      (_U(0x1) << USBC_UPCON2CLR_TXSTPEC_Pos)
+#define USBC_UPCON2CLR_TXSTPEC      (_U_(0x1) << USBC_UPCON2CLR_TXSTPEC_Pos)
 #define USBC_UPCON2CLR_PERREC_Pos   3            /**< \brief (USBC_UPCON2CLR) PERRE Clear */
-#define USBC_UPCON2CLR_PERREC       (_U(0x1) << USBC_UPCON2CLR_PERREC_Pos)
+#define USBC_UPCON2CLR_PERREC       (_U_(0x1) << USBC_UPCON2CLR_PERREC_Pos)
 #define USBC_UPCON2CLR_NAKEDEC_Pos  4            /**< \brief (USBC_UPCON2CLR) NAKEDE Clear */
-#define USBC_UPCON2CLR_NAKEDEC      (_U(0x1) << USBC_UPCON2CLR_NAKEDEC_Pos)
+#define USBC_UPCON2CLR_NAKEDEC      (_U_(0x1) << USBC_UPCON2CLR_NAKEDEC_Pos)
 #define USBC_UPCON2CLR_ERRORFIEC_Pos 5            /**< \brief (USBC_UPCON2CLR) ERRORFIE Clear */
-#define USBC_UPCON2CLR_ERRORFIEC    (_U(0x1) << USBC_UPCON2CLR_ERRORFIEC_Pos)
+#define USBC_UPCON2CLR_ERRORFIEC    (_U_(0x1) << USBC_UPCON2CLR_ERRORFIEC_Pos)
 #define USBC_UPCON2CLR_RXSTALLDEC_Pos 6            /**< \brief (USBC_UPCON2CLR) RXTALLDE Clear */
-#define USBC_UPCON2CLR_RXSTALLDEC   (_U(0x1) << USBC_UPCON2CLR_RXSTALLDEC_Pos)
+#define USBC_UPCON2CLR_RXSTALLDEC   (_U_(0x1) << USBC_UPCON2CLR_RXSTALLDEC_Pos)
 #define USBC_UPCON2CLR_RAMACEREC_Pos 10           /**< \brief (USBC_UPCON2CLR) RAMACERE Clear */
-#define USBC_UPCON2CLR_RAMACEREC    (_U(0x1) << USBC_UPCON2CLR_RAMACEREC_Pos)
+#define USBC_UPCON2CLR_RAMACEREC    (_U_(0x1) << USBC_UPCON2CLR_RAMACEREC_Pos)
 #define USBC_UPCON2CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UPCON2CLR) NBUSYBKE Clear */
-#define USBC_UPCON2CLR_NBUSYBKEC    (_U(0x1) << USBC_UPCON2CLR_NBUSYBKEC_Pos)
+#define USBC_UPCON2CLR_NBUSYBKEC    (_U_(0x1) << USBC_UPCON2CLR_NBUSYBKEC_Pos)
 #define USBC_UPCON2CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UPCON2CLR) FIFOCON Clear */
-#define USBC_UPCON2CLR_FIFOCONC     (_U(0x1) << USBC_UPCON2CLR_FIFOCONC_Pos)
+#define USBC_UPCON2CLR_FIFOCONC     (_U_(0x1) << USBC_UPCON2CLR_FIFOCONC_Pos)
 #define USBC_UPCON2CLR_PFREEZEC_Pos 17           /**< \brief (USBC_UPCON2CLR) PFREEZE Clear */
-#define USBC_UPCON2CLR_PFREEZEC     (_U(0x1) << USBC_UPCON2CLR_PFREEZEC_Pos)
+#define USBC_UPCON2CLR_PFREEZEC     (_U_(0x1) << USBC_UPCON2CLR_PFREEZEC_Pos)
 #define USBC_UPCON2CLR_INITDTGLC_Pos 18           /**< \brief (USBC_UPCON2CLR) INITDTGL Clear */
-#define USBC_UPCON2CLR_INITDTGLC    (_U(0x1) << USBC_UPCON2CLR_INITDTGLC_Pos)
+#define USBC_UPCON2CLR_INITDTGLC    (_U_(0x1) << USBC_UPCON2CLR_INITDTGLC_Pos)
 #define USBC_UPCON2CLR_INITBKC_Pos  19           /**< \brief (USBC_UPCON2CLR) INITBK Clear */
-#define USBC_UPCON2CLR_INITBKC      (_U(0x1) << USBC_UPCON2CLR_INITBKC_Pos)
-#define USBC_UPCON2CLR_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON2CLR) MASK Register */
+#define USBC_UPCON2CLR_INITBKC      (_U_(0x1) << USBC_UPCON2CLR_INITBKC_Pos)
+#define USBC_UPCON2CLR_MASK         _U_(0x000E547F) /**< \brief (USBC_UPCON2CLR) MASK Register */
 
 /* -------- USBC_UPCON3CLR : (USBC Offset: 0x62C) ( /W 32) Pipe Control Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -6952,35 +6952,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCON3CLR_OFFSET       0x62C        /**< \brief (USBC_UPCON3CLR offset) Pipe Control Clear Register */
-#define USBC_UPCON3CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON3CLR reset_value) Pipe Control Clear Register */
+#define USBC_UPCON3CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPCON3CLR reset_value) Pipe Control Clear Register */
 
 #define USBC_UPCON3CLR_RXINEC_Pos   0            /**< \brief (USBC_UPCON3CLR) RXINE Clear */
-#define USBC_UPCON3CLR_RXINEC       (_U(0x1) << USBC_UPCON3CLR_RXINEC_Pos)
+#define USBC_UPCON3CLR_RXINEC       (_U_(0x1) << USBC_UPCON3CLR_RXINEC_Pos)
 #define USBC_UPCON3CLR_TXOUTEC_Pos  1            /**< \brief (USBC_UPCON3CLR) TXOUTE Clear */
-#define USBC_UPCON3CLR_TXOUTEC      (_U(0x1) << USBC_UPCON3CLR_TXOUTEC_Pos)
+#define USBC_UPCON3CLR_TXOUTEC      (_U_(0x1) << USBC_UPCON3CLR_TXOUTEC_Pos)
 #define USBC_UPCON3CLR_TXSTPEC_Pos  2            /**< \brief (USBC_UPCON3CLR) TXSTPE Clear */
-#define USBC_UPCON3CLR_TXSTPEC      (_U(0x1) << USBC_UPCON3CLR_TXSTPEC_Pos)
+#define USBC_UPCON3CLR_TXSTPEC      (_U_(0x1) << USBC_UPCON3CLR_TXSTPEC_Pos)
 #define USBC_UPCON3CLR_PERREC_Pos   3            /**< \brief (USBC_UPCON3CLR) PERRE Clear */
-#define USBC_UPCON3CLR_PERREC       (_U(0x1) << USBC_UPCON3CLR_PERREC_Pos)
+#define USBC_UPCON3CLR_PERREC       (_U_(0x1) << USBC_UPCON3CLR_PERREC_Pos)
 #define USBC_UPCON3CLR_NAKEDEC_Pos  4            /**< \brief (USBC_UPCON3CLR) NAKEDE Clear */
-#define USBC_UPCON3CLR_NAKEDEC      (_U(0x1) << USBC_UPCON3CLR_NAKEDEC_Pos)
+#define USBC_UPCON3CLR_NAKEDEC      (_U_(0x1) << USBC_UPCON3CLR_NAKEDEC_Pos)
 #define USBC_UPCON3CLR_ERRORFIEC_Pos 5            /**< \brief (USBC_UPCON3CLR) ERRORFIE Clear */
-#define USBC_UPCON3CLR_ERRORFIEC    (_U(0x1) << USBC_UPCON3CLR_ERRORFIEC_Pos)
+#define USBC_UPCON3CLR_ERRORFIEC    (_U_(0x1) << USBC_UPCON3CLR_ERRORFIEC_Pos)
 #define USBC_UPCON3CLR_RXSTALLDEC_Pos 6            /**< \brief (USBC_UPCON3CLR) RXTALLDE Clear */
-#define USBC_UPCON3CLR_RXSTALLDEC   (_U(0x1) << USBC_UPCON3CLR_RXSTALLDEC_Pos)
+#define USBC_UPCON3CLR_RXSTALLDEC   (_U_(0x1) << USBC_UPCON3CLR_RXSTALLDEC_Pos)
 #define USBC_UPCON3CLR_RAMACEREC_Pos 10           /**< \brief (USBC_UPCON3CLR) RAMACERE Clear */
-#define USBC_UPCON3CLR_RAMACEREC    (_U(0x1) << USBC_UPCON3CLR_RAMACEREC_Pos)
+#define USBC_UPCON3CLR_RAMACEREC    (_U_(0x1) << USBC_UPCON3CLR_RAMACEREC_Pos)
 #define USBC_UPCON3CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UPCON3CLR) NBUSYBKE Clear */
-#define USBC_UPCON3CLR_NBUSYBKEC    (_U(0x1) << USBC_UPCON3CLR_NBUSYBKEC_Pos)
+#define USBC_UPCON3CLR_NBUSYBKEC    (_U_(0x1) << USBC_UPCON3CLR_NBUSYBKEC_Pos)
 #define USBC_UPCON3CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UPCON3CLR) FIFOCON Clear */
-#define USBC_UPCON3CLR_FIFOCONC     (_U(0x1) << USBC_UPCON3CLR_FIFOCONC_Pos)
+#define USBC_UPCON3CLR_FIFOCONC     (_U_(0x1) << USBC_UPCON3CLR_FIFOCONC_Pos)
 #define USBC_UPCON3CLR_PFREEZEC_Pos 17           /**< \brief (USBC_UPCON3CLR) PFREEZE Clear */
-#define USBC_UPCON3CLR_PFREEZEC     (_U(0x1) << USBC_UPCON3CLR_PFREEZEC_Pos)
+#define USBC_UPCON3CLR_PFREEZEC     (_U_(0x1) << USBC_UPCON3CLR_PFREEZEC_Pos)
 #define USBC_UPCON3CLR_INITDTGLC_Pos 18           /**< \brief (USBC_UPCON3CLR) INITDTGL Clear */
-#define USBC_UPCON3CLR_INITDTGLC    (_U(0x1) << USBC_UPCON3CLR_INITDTGLC_Pos)
+#define USBC_UPCON3CLR_INITDTGLC    (_U_(0x1) << USBC_UPCON3CLR_INITDTGLC_Pos)
 #define USBC_UPCON3CLR_INITBKC_Pos  19           /**< \brief (USBC_UPCON3CLR) INITBK Clear */
-#define USBC_UPCON3CLR_INITBKC      (_U(0x1) << USBC_UPCON3CLR_INITBKC_Pos)
-#define USBC_UPCON3CLR_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON3CLR) MASK Register */
+#define USBC_UPCON3CLR_INITBKC      (_U_(0x1) << USBC_UPCON3CLR_INITBKC_Pos)
+#define USBC_UPCON3CLR_MASK         _U_(0x000E547F) /**< \brief (USBC_UPCON3CLR) MASK Register */
 
 /* -------- USBC_UPCON4CLR : (USBC Offset: 0x630) ( /W 32) Pipe Control Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7010,35 +7010,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCON4CLR_OFFSET       0x630        /**< \brief (USBC_UPCON4CLR offset) Pipe Control Clear Register */
-#define USBC_UPCON4CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON4CLR reset_value) Pipe Control Clear Register */
+#define USBC_UPCON4CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPCON4CLR reset_value) Pipe Control Clear Register */
 
 #define USBC_UPCON4CLR_RXINEC_Pos   0            /**< \brief (USBC_UPCON4CLR) RXINE Clear */
-#define USBC_UPCON4CLR_RXINEC       (_U(0x1) << USBC_UPCON4CLR_RXINEC_Pos)
+#define USBC_UPCON4CLR_RXINEC       (_U_(0x1) << USBC_UPCON4CLR_RXINEC_Pos)
 #define USBC_UPCON4CLR_TXOUTEC_Pos  1            /**< \brief (USBC_UPCON4CLR) TXOUTE Clear */
-#define USBC_UPCON4CLR_TXOUTEC      (_U(0x1) << USBC_UPCON4CLR_TXOUTEC_Pos)
+#define USBC_UPCON4CLR_TXOUTEC      (_U_(0x1) << USBC_UPCON4CLR_TXOUTEC_Pos)
 #define USBC_UPCON4CLR_TXSTPEC_Pos  2            /**< \brief (USBC_UPCON4CLR) TXSTPE Clear */
-#define USBC_UPCON4CLR_TXSTPEC      (_U(0x1) << USBC_UPCON4CLR_TXSTPEC_Pos)
+#define USBC_UPCON4CLR_TXSTPEC      (_U_(0x1) << USBC_UPCON4CLR_TXSTPEC_Pos)
 #define USBC_UPCON4CLR_PERREC_Pos   3            /**< \brief (USBC_UPCON4CLR) PERRE Clear */
-#define USBC_UPCON4CLR_PERREC       (_U(0x1) << USBC_UPCON4CLR_PERREC_Pos)
+#define USBC_UPCON4CLR_PERREC       (_U_(0x1) << USBC_UPCON4CLR_PERREC_Pos)
 #define USBC_UPCON4CLR_NAKEDEC_Pos  4            /**< \brief (USBC_UPCON4CLR) NAKEDE Clear */
-#define USBC_UPCON4CLR_NAKEDEC      (_U(0x1) << USBC_UPCON4CLR_NAKEDEC_Pos)
+#define USBC_UPCON4CLR_NAKEDEC      (_U_(0x1) << USBC_UPCON4CLR_NAKEDEC_Pos)
 #define USBC_UPCON4CLR_ERRORFIEC_Pos 5            /**< \brief (USBC_UPCON4CLR) ERRORFIE Clear */
-#define USBC_UPCON4CLR_ERRORFIEC    (_U(0x1) << USBC_UPCON4CLR_ERRORFIEC_Pos)
+#define USBC_UPCON4CLR_ERRORFIEC    (_U_(0x1) << USBC_UPCON4CLR_ERRORFIEC_Pos)
 #define USBC_UPCON4CLR_RXSTALLDEC_Pos 6            /**< \brief (USBC_UPCON4CLR) RXTALLDE Clear */
-#define USBC_UPCON4CLR_RXSTALLDEC   (_U(0x1) << USBC_UPCON4CLR_RXSTALLDEC_Pos)
+#define USBC_UPCON4CLR_RXSTALLDEC   (_U_(0x1) << USBC_UPCON4CLR_RXSTALLDEC_Pos)
 #define USBC_UPCON4CLR_RAMACEREC_Pos 10           /**< \brief (USBC_UPCON4CLR) RAMACERE Clear */
-#define USBC_UPCON4CLR_RAMACEREC    (_U(0x1) << USBC_UPCON4CLR_RAMACEREC_Pos)
+#define USBC_UPCON4CLR_RAMACEREC    (_U_(0x1) << USBC_UPCON4CLR_RAMACEREC_Pos)
 #define USBC_UPCON4CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UPCON4CLR) NBUSYBKE Clear */
-#define USBC_UPCON4CLR_NBUSYBKEC    (_U(0x1) << USBC_UPCON4CLR_NBUSYBKEC_Pos)
+#define USBC_UPCON4CLR_NBUSYBKEC    (_U_(0x1) << USBC_UPCON4CLR_NBUSYBKEC_Pos)
 #define USBC_UPCON4CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UPCON4CLR) FIFOCON Clear */
-#define USBC_UPCON4CLR_FIFOCONC     (_U(0x1) << USBC_UPCON4CLR_FIFOCONC_Pos)
+#define USBC_UPCON4CLR_FIFOCONC     (_U_(0x1) << USBC_UPCON4CLR_FIFOCONC_Pos)
 #define USBC_UPCON4CLR_PFREEZEC_Pos 17           /**< \brief (USBC_UPCON4CLR) PFREEZE Clear */
-#define USBC_UPCON4CLR_PFREEZEC     (_U(0x1) << USBC_UPCON4CLR_PFREEZEC_Pos)
+#define USBC_UPCON4CLR_PFREEZEC     (_U_(0x1) << USBC_UPCON4CLR_PFREEZEC_Pos)
 #define USBC_UPCON4CLR_INITDTGLC_Pos 18           /**< \brief (USBC_UPCON4CLR) INITDTGL Clear */
-#define USBC_UPCON4CLR_INITDTGLC    (_U(0x1) << USBC_UPCON4CLR_INITDTGLC_Pos)
+#define USBC_UPCON4CLR_INITDTGLC    (_U_(0x1) << USBC_UPCON4CLR_INITDTGLC_Pos)
 #define USBC_UPCON4CLR_INITBKC_Pos  19           /**< \brief (USBC_UPCON4CLR) INITBK Clear */
-#define USBC_UPCON4CLR_INITBKC      (_U(0x1) << USBC_UPCON4CLR_INITBKC_Pos)
-#define USBC_UPCON4CLR_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON4CLR) MASK Register */
+#define USBC_UPCON4CLR_INITBKC      (_U_(0x1) << USBC_UPCON4CLR_INITBKC_Pos)
+#define USBC_UPCON4CLR_MASK         _U_(0x000E547F) /**< \brief (USBC_UPCON4CLR) MASK Register */
 
 /* -------- USBC_UPCON5CLR : (USBC Offset: 0x634) ( /W 32) Pipe Control Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7068,35 +7068,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCON5CLR_OFFSET       0x634        /**< \brief (USBC_UPCON5CLR offset) Pipe Control Clear Register */
-#define USBC_UPCON5CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON5CLR reset_value) Pipe Control Clear Register */
+#define USBC_UPCON5CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPCON5CLR reset_value) Pipe Control Clear Register */
 
 #define USBC_UPCON5CLR_RXINEC_Pos   0            /**< \brief (USBC_UPCON5CLR) RXINE Clear */
-#define USBC_UPCON5CLR_RXINEC       (_U(0x1) << USBC_UPCON5CLR_RXINEC_Pos)
+#define USBC_UPCON5CLR_RXINEC       (_U_(0x1) << USBC_UPCON5CLR_RXINEC_Pos)
 #define USBC_UPCON5CLR_TXOUTEC_Pos  1            /**< \brief (USBC_UPCON5CLR) TXOUTE Clear */
-#define USBC_UPCON5CLR_TXOUTEC      (_U(0x1) << USBC_UPCON5CLR_TXOUTEC_Pos)
+#define USBC_UPCON5CLR_TXOUTEC      (_U_(0x1) << USBC_UPCON5CLR_TXOUTEC_Pos)
 #define USBC_UPCON5CLR_TXSTPEC_Pos  2            /**< \brief (USBC_UPCON5CLR) TXSTPE Clear */
-#define USBC_UPCON5CLR_TXSTPEC      (_U(0x1) << USBC_UPCON5CLR_TXSTPEC_Pos)
+#define USBC_UPCON5CLR_TXSTPEC      (_U_(0x1) << USBC_UPCON5CLR_TXSTPEC_Pos)
 #define USBC_UPCON5CLR_PERREC_Pos   3            /**< \brief (USBC_UPCON5CLR) PERRE Clear */
-#define USBC_UPCON5CLR_PERREC       (_U(0x1) << USBC_UPCON5CLR_PERREC_Pos)
+#define USBC_UPCON5CLR_PERREC       (_U_(0x1) << USBC_UPCON5CLR_PERREC_Pos)
 #define USBC_UPCON5CLR_NAKEDEC_Pos  4            /**< \brief (USBC_UPCON5CLR) NAKEDE Clear */
-#define USBC_UPCON5CLR_NAKEDEC      (_U(0x1) << USBC_UPCON5CLR_NAKEDEC_Pos)
+#define USBC_UPCON5CLR_NAKEDEC      (_U_(0x1) << USBC_UPCON5CLR_NAKEDEC_Pos)
 #define USBC_UPCON5CLR_ERRORFIEC_Pos 5            /**< \brief (USBC_UPCON5CLR) ERRORFIE Clear */
-#define USBC_UPCON5CLR_ERRORFIEC    (_U(0x1) << USBC_UPCON5CLR_ERRORFIEC_Pos)
+#define USBC_UPCON5CLR_ERRORFIEC    (_U_(0x1) << USBC_UPCON5CLR_ERRORFIEC_Pos)
 #define USBC_UPCON5CLR_RXSTALLDEC_Pos 6            /**< \brief (USBC_UPCON5CLR) RXTALLDE Clear */
-#define USBC_UPCON5CLR_RXSTALLDEC   (_U(0x1) << USBC_UPCON5CLR_RXSTALLDEC_Pos)
+#define USBC_UPCON5CLR_RXSTALLDEC   (_U_(0x1) << USBC_UPCON5CLR_RXSTALLDEC_Pos)
 #define USBC_UPCON5CLR_RAMACEREC_Pos 10           /**< \brief (USBC_UPCON5CLR) RAMACERE Clear */
-#define USBC_UPCON5CLR_RAMACEREC    (_U(0x1) << USBC_UPCON5CLR_RAMACEREC_Pos)
+#define USBC_UPCON5CLR_RAMACEREC    (_U_(0x1) << USBC_UPCON5CLR_RAMACEREC_Pos)
 #define USBC_UPCON5CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UPCON5CLR) NBUSYBKE Clear */
-#define USBC_UPCON5CLR_NBUSYBKEC    (_U(0x1) << USBC_UPCON5CLR_NBUSYBKEC_Pos)
+#define USBC_UPCON5CLR_NBUSYBKEC    (_U_(0x1) << USBC_UPCON5CLR_NBUSYBKEC_Pos)
 #define USBC_UPCON5CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UPCON5CLR) FIFOCON Clear */
-#define USBC_UPCON5CLR_FIFOCONC     (_U(0x1) << USBC_UPCON5CLR_FIFOCONC_Pos)
+#define USBC_UPCON5CLR_FIFOCONC     (_U_(0x1) << USBC_UPCON5CLR_FIFOCONC_Pos)
 #define USBC_UPCON5CLR_PFREEZEC_Pos 17           /**< \brief (USBC_UPCON5CLR) PFREEZE Clear */
-#define USBC_UPCON5CLR_PFREEZEC     (_U(0x1) << USBC_UPCON5CLR_PFREEZEC_Pos)
+#define USBC_UPCON5CLR_PFREEZEC     (_U_(0x1) << USBC_UPCON5CLR_PFREEZEC_Pos)
 #define USBC_UPCON5CLR_INITDTGLC_Pos 18           /**< \brief (USBC_UPCON5CLR) INITDTGL Clear */
-#define USBC_UPCON5CLR_INITDTGLC    (_U(0x1) << USBC_UPCON5CLR_INITDTGLC_Pos)
+#define USBC_UPCON5CLR_INITDTGLC    (_U_(0x1) << USBC_UPCON5CLR_INITDTGLC_Pos)
 #define USBC_UPCON5CLR_INITBKC_Pos  19           /**< \brief (USBC_UPCON5CLR) INITBK Clear */
-#define USBC_UPCON5CLR_INITBKC      (_U(0x1) << USBC_UPCON5CLR_INITBKC_Pos)
-#define USBC_UPCON5CLR_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON5CLR) MASK Register */
+#define USBC_UPCON5CLR_INITBKC      (_U_(0x1) << USBC_UPCON5CLR_INITBKC_Pos)
+#define USBC_UPCON5CLR_MASK         _U_(0x000E547F) /**< \brief (USBC_UPCON5CLR) MASK Register */
 
 /* -------- USBC_UPCON6CLR : (USBC Offset: 0x638) ( /W 32) Pipe Control Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7126,35 +7126,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCON6CLR_OFFSET       0x638        /**< \brief (USBC_UPCON6CLR offset) Pipe Control Clear Register */
-#define USBC_UPCON6CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON6CLR reset_value) Pipe Control Clear Register */
+#define USBC_UPCON6CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPCON6CLR reset_value) Pipe Control Clear Register */
 
 #define USBC_UPCON6CLR_RXINEC_Pos   0            /**< \brief (USBC_UPCON6CLR) RXINE Clear */
-#define USBC_UPCON6CLR_RXINEC       (_U(0x1) << USBC_UPCON6CLR_RXINEC_Pos)
+#define USBC_UPCON6CLR_RXINEC       (_U_(0x1) << USBC_UPCON6CLR_RXINEC_Pos)
 #define USBC_UPCON6CLR_TXOUTEC_Pos  1            /**< \brief (USBC_UPCON6CLR) TXOUTE Clear */
-#define USBC_UPCON6CLR_TXOUTEC      (_U(0x1) << USBC_UPCON6CLR_TXOUTEC_Pos)
+#define USBC_UPCON6CLR_TXOUTEC      (_U_(0x1) << USBC_UPCON6CLR_TXOUTEC_Pos)
 #define USBC_UPCON6CLR_TXSTPEC_Pos  2            /**< \brief (USBC_UPCON6CLR) TXSTPE Clear */
-#define USBC_UPCON6CLR_TXSTPEC      (_U(0x1) << USBC_UPCON6CLR_TXSTPEC_Pos)
+#define USBC_UPCON6CLR_TXSTPEC      (_U_(0x1) << USBC_UPCON6CLR_TXSTPEC_Pos)
 #define USBC_UPCON6CLR_PERREC_Pos   3            /**< \brief (USBC_UPCON6CLR) PERRE Clear */
-#define USBC_UPCON6CLR_PERREC       (_U(0x1) << USBC_UPCON6CLR_PERREC_Pos)
+#define USBC_UPCON6CLR_PERREC       (_U_(0x1) << USBC_UPCON6CLR_PERREC_Pos)
 #define USBC_UPCON6CLR_NAKEDEC_Pos  4            /**< \brief (USBC_UPCON6CLR) NAKEDE Clear */
-#define USBC_UPCON6CLR_NAKEDEC      (_U(0x1) << USBC_UPCON6CLR_NAKEDEC_Pos)
+#define USBC_UPCON6CLR_NAKEDEC      (_U_(0x1) << USBC_UPCON6CLR_NAKEDEC_Pos)
 #define USBC_UPCON6CLR_ERRORFIEC_Pos 5            /**< \brief (USBC_UPCON6CLR) ERRORFIE Clear */
-#define USBC_UPCON6CLR_ERRORFIEC    (_U(0x1) << USBC_UPCON6CLR_ERRORFIEC_Pos)
+#define USBC_UPCON6CLR_ERRORFIEC    (_U_(0x1) << USBC_UPCON6CLR_ERRORFIEC_Pos)
 #define USBC_UPCON6CLR_RXSTALLDEC_Pos 6            /**< \brief (USBC_UPCON6CLR) RXTALLDE Clear */
-#define USBC_UPCON6CLR_RXSTALLDEC   (_U(0x1) << USBC_UPCON6CLR_RXSTALLDEC_Pos)
+#define USBC_UPCON6CLR_RXSTALLDEC   (_U_(0x1) << USBC_UPCON6CLR_RXSTALLDEC_Pos)
 #define USBC_UPCON6CLR_RAMACEREC_Pos 10           /**< \brief (USBC_UPCON6CLR) RAMACERE Clear */
-#define USBC_UPCON6CLR_RAMACEREC    (_U(0x1) << USBC_UPCON6CLR_RAMACEREC_Pos)
+#define USBC_UPCON6CLR_RAMACEREC    (_U_(0x1) << USBC_UPCON6CLR_RAMACEREC_Pos)
 #define USBC_UPCON6CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UPCON6CLR) NBUSYBKE Clear */
-#define USBC_UPCON6CLR_NBUSYBKEC    (_U(0x1) << USBC_UPCON6CLR_NBUSYBKEC_Pos)
+#define USBC_UPCON6CLR_NBUSYBKEC    (_U_(0x1) << USBC_UPCON6CLR_NBUSYBKEC_Pos)
 #define USBC_UPCON6CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UPCON6CLR) FIFOCON Clear */
-#define USBC_UPCON6CLR_FIFOCONC     (_U(0x1) << USBC_UPCON6CLR_FIFOCONC_Pos)
+#define USBC_UPCON6CLR_FIFOCONC     (_U_(0x1) << USBC_UPCON6CLR_FIFOCONC_Pos)
 #define USBC_UPCON6CLR_PFREEZEC_Pos 17           /**< \brief (USBC_UPCON6CLR) PFREEZE Clear */
-#define USBC_UPCON6CLR_PFREEZEC     (_U(0x1) << USBC_UPCON6CLR_PFREEZEC_Pos)
+#define USBC_UPCON6CLR_PFREEZEC     (_U_(0x1) << USBC_UPCON6CLR_PFREEZEC_Pos)
 #define USBC_UPCON6CLR_INITDTGLC_Pos 18           /**< \brief (USBC_UPCON6CLR) INITDTGL Clear */
-#define USBC_UPCON6CLR_INITDTGLC    (_U(0x1) << USBC_UPCON6CLR_INITDTGLC_Pos)
+#define USBC_UPCON6CLR_INITDTGLC    (_U_(0x1) << USBC_UPCON6CLR_INITDTGLC_Pos)
 #define USBC_UPCON6CLR_INITBKC_Pos  19           /**< \brief (USBC_UPCON6CLR) INITBK Clear */
-#define USBC_UPCON6CLR_INITBKC      (_U(0x1) << USBC_UPCON6CLR_INITBKC_Pos)
-#define USBC_UPCON6CLR_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON6CLR) MASK Register */
+#define USBC_UPCON6CLR_INITBKC      (_U_(0x1) << USBC_UPCON6CLR_INITBKC_Pos)
+#define USBC_UPCON6CLR_MASK         _U_(0x000E547F) /**< \brief (USBC_UPCON6CLR) MASK Register */
 
 /* -------- USBC_UPCON7CLR : (USBC Offset: 0x63C) ( /W 32) Pipe Control Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7184,35 +7184,35 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPCON7CLR_OFFSET       0x63C        /**< \brief (USBC_UPCON7CLR offset) Pipe Control Clear Register */
-#define USBC_UPCON7CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON7CLR reset_value) Pipe Control Clear Register */
+#define USBC_UPCON7CLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_UPCON7CLR reset_value) Pipe Control Clear Register */
 
 #define USBC_UPCON7CLR_RXINEC_Pos   0            /**< \brief (USBC_UPCON7CLR) RXINE Clear */
-#define USBC_UPCON7CLR_RXINEC       (_U(0x1) << USBC_UPCON7CLR_RXINEC_Pos)
+#define USBC_UPCON7CLR_RXINEC       (_U_(0x1) << USBC_UPCON7CLR_RXINEC_Pos)
 #define USBC_UPCON7CLR_TXOUTEC_Pos  1            /**< \brief (USBC_UPCON7CLR) TXOUTE Clear */
-#define USBC_UPCON7CLR_TXOUTEC      (_U(0x1) << USBC_UPCON7CLR_TXOUTEC_Pos)
+#define USBC_UPCON7CLR_TXOUTEC      (_U_(0x1) << USBC_UPCON7CLR_TXOUTEC_Pos)
 #define USBC_UPCON7CLR_TXSTPEC_Pos  2            /**< \brief (USBC_UPCON7CLR) TXSTPE Clear */
-#define USBC_UPCON7CLR_TXSTPEC      (_U(0x1) << USBC_UPCON7CLR_TXSTPEC_Pos)
+#define USBC_UPCON7CLR_TXSTPEC      (_U_(0x1) << USBC_UPCON7CLR_TXSTPEC_Pos)
 #define USBC_UPCON7CLR_PERREC_Pos   3            /**< \brief (USBC_UPCON7CLR) PERRE Clear */
-#define USBC_UPCON7CLR_PERREC       (_U(0x1) << USBC_UPCON7CLR_PERREC_Pos)
+#define USBC_UPCON7CLR_PERREC       (_U_(0x1) << USBC_UPCON7CLR_PERREC_Pos)
 #define USBC_UPCON7CLR_NAKEDEC_Pos  4            /**< \brief (USBC_UPCON7CLR) NAKEDE Clear */
-#define USBC_UPCON7CLR_NAKEDEC      (_U(0x1) << USBC_UPCON7CLR_NAKEDEC_Pos)
+#define USBC_UPCON7CLR_NAKEDEC      (_U_(0x1) << USBC_UPCON7CLR_NAKEDEC_Pos)
 #define USBC_UPCON7CLR_ERRORFIEC_Pos 5            /**< \brief (USBC_UPCON7CLR) ERRORFIE Clear */
-#define USBC_UPCON7CLR_ERRORFIEC    (_U(0x1) << USBC_UPCON7CLR_ERRORFIEC_Pos)
+#define USBC_UPCON7CLR_ERRORFIEC    (_U_(0x1) << USBC_UPCON7CLR_ERRORFIEC_Pos)
 #define USBC_UPCON7CLR_RXSTALLDEC_Pos 6            /**< \brief (USBC_UPCON7CLR) RXTALLDE Clear */
-#define USBC_UPCON7CLR_RXSTALLDEC   (_U(0x1) << USBC_UPCON7CLR_RXSTALLDEC_Pos)
+#define USBC_UPCON7CLR_RXSTALLDEC   (_U_(0x1) << USBC_UPCON7CLR_RXSTALLDEC_Pos)
 #define USBC_UPCON7CLR_RAMACEREC_Pos 10           /**< \brief (USBC_UPCON7CLR) RAMACERE Clear */
-#define USBC_UPCON7CLR_RAMACEREC    (_U(0x1) << USBC_UPCON7CLR_RAMACEREC_Pos)
+#define USBC_UPCON7CLR_RAMACEREC    (_U_(0x1) << USBC_UPCON7CLR_RAMACEREC_Pos)
 #define USBC_UPCON7CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UPCON7CLR) NBUSYBKE Clear */
-#define USBC_UPCON7CLR_NBUSYBKEC    (_U(0x1) << USBC_UPCON7CLR_NBUSYBKEC_Pos)
+#define USBC_UPCON7CLR_NBUSYBKEC    (_U_(0x1) << USBC_UPCON7CLR_NBUSYBKEC_Pos)
 #define USBC_UPCON7CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UPCON7CLR) FIFOCON Clear */
-#define USBC_UPCON7CLR_FIFOCONC     (_U(0x1) << USBC_UPCON7CLR_FIFOCONC_Pos)
+#define USBC_UPCON7CLR_FIFOCONC     (_U_(0x1) << USBC_UPCON7CLR_FIFOCONC_Pos)
 #define USBC_UPCON7CLR_PFREEZEC_Pos 17           /**< \brief (USBC_UPCON7CLR) PFREEZE Clear */
-#define USBC_UPCON7CLR_PFREEZEC     (_U(0x1) << USBC_UPCON7CLR_PFREEZEC_Pos)
+#define USBC_UPCON7CLR_PFREEZEC     (_U_(0x1) << USBC_UPCON7CLR_PFREEZEC_Pos)
 #define USBC_UPCON7CLR_INITDTGLC_Pos 18           /**< \brief (USBC_UPCON7CLR) INITDTGL Clear */
-#define USBC_UPCON7CLR_INITDTGLC    (_U(0x1) << USBC_UPCON7CLR_INITDTGLC_Pos)
+#define USBC_UPCON7CLR_INITDTGLC    (_U_(0x1) << USBC_UPCON7CLR_INITDTGLC_Pos)
 #define USBC_UPCON7CLR_INITBKC_Pos  19           /**< \brief (USBC_UPCON7CLR) INITBK Clear */
-#define USBC_UPCON7CLR_INITBKC      (_U(0x1) << USBC_UPCON7CLR_INITBKC_Pos)
-#define USBC_UPCON7CLR_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON7CLR) MASK Register */
+#define USBC_UPCON7CLR_INITBKC      (_U_(0x1) << USBC_UPCON7CLR_INITBKC_Pos)
+#define USBC_UPCON7CLR_MASK         _U_(0x000E547F) /**< \brief (USBC_UPCON7CLR) MASK Register */
 
 /* -------- USBC_UPINRQ0 : (USBC Offset: 0x650) (R/W 32) Pipe In Request -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7227,14 +7227,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPINRQ0_OFFSET         0x650        /**< \brief (USBC_UPINRQ0 offset) Pipe In Request */
-#define USBC_UPINRQ0_RESETVALUE     _U(0x00000001); /**< \brief (USBC_UPINRQ0 reset_value) Pipe In Request */
+#define USBC_UPINRQ0_RESETVALUE     _U_(0x00000001); /**< \brief (USBC_UPINRQ0 reset_value) Pipe In Request */
 
 #define USBC_UPINRQ0_INRQ_Pos       0            /**< \brief (USBC_UPINRQ0) IN Request Number before Freeze */
-#define USBC_UPINRQ0_INRQ_Msk       (_U(0xFF) << USBC_UPINRQ0_INRQ_Pos)
+#define USBC_UPINRQ0_INRQ_Msk       (_U_(0xFF) << USBC_UPINRQ0_INRQ_Pos)
 #define USBC_UPINRQ0_INRQ(value)    (USBC_UPINRQ0_INRQ_Msk & ((value) << USBC_UPINRQ0_INRQ_Pos))
 #define USBC_UPINRQ0_INMODE_Pos     8            /**< \brief (USBC_UPINRQ0) IN Request Mode */
-#define USBC_UPINRQ0_INMODE         (_U(0x1) << USBC_UPINRQ0_INMODE_Pos)
-#define USBC_UPINRQ0_MASK           _U(0x000001FF) /**< \brief (USBC_UPINRQ0) MASK Register */
+#define USBC_UPINRQ0_INMODE         (_U_(0x1) << USBC_UPINRQ0_INMODE_Pos)
+#define USBC_UPINRQ0_MASK           _U_(0x000001FF) /**< \brief (USBC_UPINRQ0) MASK Register */
 
 /* -------- USBC_UPINRQ1 : (USBC Offset: 0x654) (R/W 32) Pipe In Request -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7249,14 +7249,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPINRQ1_OFFSET         0x654        /**< \brief (USBC_UPINRQ1 offset) Pipe In Request */
-#define USBC_UPINRQ1_RESETVALUE     _U(0x00000001); /**< \brief (USBC_UPINRQ1 reset_value) Pipe In Request */
+#define USBC_UPINRQ1_RESETVALUE     _U_(0x00000001); /**< \brief (USBC_UPINRQ1 reset_value) Pipe In Request */
 
 #define USBC_UPINRQ1_INRQ_Pos       0            /**< \brief (USBC_UPINRQ1) IN Request Number before Freeze */
-#define USBC_UPINRQ1_INRQ_Msk       (_U(0xFF) << USBC_UPINRQ1_INRQ_Pos)
+#define USBC_UPINRQ1_INRQ_Msk       (_U_(0xFF) << USBC_UPINRQ1_INRQ_Pos)
 #define USBC_UPINRQ1_INRQ(value)    (USBC_UPINRQ1_INRQ_Msk & ((value) << USBC_UPINRQ1_INRQ_Pos))
 #define USBC_UPINRQ1_INMODE_Pos     8            /**< \brief (USBC_UPINRQ1) IN Request Mode */
-#define USBC_UPINRQ1_INMODE         (_U(0x1) << USBC_UPINRQ1_INMODE_Pos)
-#define USBC_UPINRQ1_MASK           _U(0x000001FF) /**< \brief (USBC_UPINRQ1) MASK Register */
+#define USBC_UPINRQ1_INMODE         (_U_(0x1) << USBC_UPINRQ1_INMODE_Pos)
+#define USBC_UPINRQ1_MASK           _U_(0x000001FF) /**< \brief (USBC_UPINRQ1) MASK Register */
 
 /* -------- USBC_UPINRQ2 : (USBC Offset: 0x658) (R/W 32) Pipe In Request -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7271,14 +7271,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPINRQ2_OFFSET         0x658        /**< \brief (USBC_UPINRQ2 offset) Pipe In Request */
-#define USBC_UPINRQ2_RESETVALUE     _U(0x00000001); /**< \brief (USBC_UPINRQ2 reset_value) Pipe In Request */
+#define USBC_UPINRQ2_RESETVALUE     _U_(0x00000001); /**< \brief (USBC_UPINRQ2 reset_value) Pipe In Request */
 
 #define USBC_UPINRQ2_INRQ_Pos       0            /**< \brief (USBC_UPINRQ2) IN Request Number before Freeze */
-#define USBC_UPINRQ2_INRQ_Msk       (_U(0xFF) << USBC_UPINRQ2_INRQ_Pos)
+#define USBC_UPINRQ2_INRQ_Msk       (_U_(0xFF) << USBC_UPINRQ2_INRQ_Pos)
 #define USBC_UPINRQ2_INRQ(value)    (USBC_UPINRQ2_INRQ_Msk & ((value) << USBC_UPINRQ2_INRQ_Pos))
 #define USBC_UPINRQ2_INMODE_Pos     8            /**< \brief (USBC_UPINRQ2) IN Request Mode */
-#define USBC_UPINRQ2_INMODE         (_U(0x1) << USBC_UPINRQ2_INMODE_Pos)
-#define USBC_UPINRQ2_MASK           _U(0x000001FF) /**< \brief (USBC_UPINRQ2) MASK Register */
+#define USBC_UPINRQ2_INMODE         (_U_(0x1) << USBC_UPINRQ2_INMODE_Pos)
+#define USBC_UPINRQ2_MASK           _U_(0x000001FF) /**< \brief (USBC_UPINRQ2) MASK Register */
 
 /* -------- USBC_UPINRQ3 : (USBC Offset: 0x65C) (R/W 32) Pipe In Request -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7293,14 +7293,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPINRQ3_OFFSET         0x65C        /**< \brief (USBC_UPINRQ3 offset) Pipe In Request */
-#define USBC_UPINRQ3_RESETVALUE     _U(0x00000001); /**< \brief (USBC_UPINRQ3 reset_value) Pipe In Request */
+#define USBC_UPINRQ3_RESETVALUE     _U_(0x00000001); /**< \brief (USBC_UPINRQ3 reset_value) Pipe In Request */
 
 #define USBC_UPINRQ3_INRQ_Pos       0            /**< \brief (USBC_UPINRQ3) IN Request Number before Freeze */
-#define USBC_UPINRQ3_INRQ_Msk       (_U(0xFF) << USBC_UPINRQ3_INRQ_Pos)
+#define USBC_UPINRQ3_INRQ_Msk       (_U_(0xFF) << USBC_UPINRQ3_INRQ_Pos)
 #define USBC_UPINRQ3_INRQ(value)    (USBC_UPINRQ3_INRQ_Msk & ((value) << USBC_UPINRQ3_INRQ_Pos))
 #define USBC_UPINRQ3_INMODE_Pos     8            /**< \brief (USBC_UPINRQ3) IN Request Mode */
-#define USBC_UPINRQ3_INMODE         (_U(0x1) << USBC_UPINRQ3_INMODE_Pos)
-#define USBC_UPINRQ3_MASK           _U(0x000001FF) /**< \brief (USBC_UPINRQ3) MASK Register */
+#define USBC_UPINRQ3_INMODE         (_U_(0x1) << USBC_UPINRQ3_INMODE_Pos)
+#define USBC_UPINRQ3_MASK           _U_(0x000001FF) /**< \brief (USBC_UPINRQ3) MASK Register */
 
 /* -------- USBC_UPINRQ4 : (USBC Offset: 0x660) (R/W 32) Pipe In Request -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7315,14 +7315,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPINRQ4_OFFSET         0x660        /**< \brief (USBC_UPINRQ4 offset) Pipe In Request */
-#define USBC_UPINRQ4_RESETVALUE     _U(0x00000001); /**< \brief (USBC_UPINRQ4 reset_value) Pipe In Request */
+#define USBC_UPINRQ4_RESETVALUE     _U_(0x00000001); /**< \brief (USBC_UPINRQ4 reset_value) Pipe In Request */
 
 #define USBC_UPINRQ4_INRQ_Pos       0            /**< \brief (USBC_UPINRQ4) IN Request Number before Freeze */
-#define USBC_UPINRQ4_INRQ_Msk       (_U(0xFF) << USBC_UPINRQ4_INRQ_Pos)
+#define USBC_UPINRQ4_INRQ_Msk       (_U_(0xFF) << USBC_UPINRQ4_INRQ_Pos)
 #define USBC_UPINRQ4_INRQ(value)    (USBC_UPINRQ4_INRQ_Msk & ((value) << USBC_UPINRQ4_INRQ_Pos))
 #define USBC_UPINRQ4_INMODE_Pos     8            /**< \brief (USBC_UPINRQ4) IN Request Mode */
-#define USBC_UPINRQ4_INMODE         (_U(0x1) << USBC_UPINRQ4_INMODE_Pos)
-#define USBC_UPINRQ4_MASK           _U(0x000001FF) /**< \brief (USBC_UPINRQ4) MASK Register */
+#define USBC_UPINRQ4_INMODE         (_U_(0x1) << USBC_UPINRQ4_INMODE_Pos)
+#define USBC_UPINRQ4_MASK           _U_(0x000001FF) /**< \brief (USBC_UPINRQ4) MASK Register */
 
 /* -------- USBC_UPINRQ5 : (USBC Offset: 0x664) (R/W 32) Pipe In Request -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7337,14 +7337,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPINRQ5_OFFSET         0x664        /**< \brief (USBC_UPINRQ5 offset) Pipe In Request */
-#define USBC_UPINRQ5_RESETVALUE     _U(0x00000001); /**< \brief (USBC_UPINRQ5 reset_value) Pipe In Request */
+#define USBC_UPINRQ5_RESETVALUE     _U_(0x00000001); /**< \brief (USBC_UPINRQ5 reset_value) Pipe In Request */
 
 #define USBC_UPINRQ5_INRQ_Pos       0            /**< \brief (USBC_UPINRQ5) IN Request Number before Freeze */
-#define USBC_UPINRQ5_INRQ_Msk       (_U(0xFF) << USBC_UPINRQ5_INRQ_Pos)
+#define USBC_UPINRQ5_INRQ_Msk       (_U_(0xFF) << USBC_UPINRQ5_INRQ_Pos)
 #define USBC_UPINRQ5_INRQ(value)    (USBC_UPINRQ5_INRQ_Msk & ((value) << USBC_UPINRQ5_INRQ_Pos))
 #define USBC_UPINRQ5_INMODE_Pos     8            /**< \brief (USBC_UPINRQ5) IN Request Mode */
-#define USBC_UPINRQ5_INMODE         (_U(0x1) << USBC_UPINRQ5_INMODE_Pos)
-#define USBC_UPINRQ5_MASK           _U(0x000001FF) /**< \brief (USBC_UPINRQ5) MASK Register */
+#define USBC_UPINRQ5_INMODE         (_U_(0x1) << USBC_UPINRQ5_INMODE_Pos)
+#define USBC_UPINRQ5_MASK           _U_(0x000001FF) /**< \brief (USBC_UPINRQ5) MASK Register */
 
 /* -------- USBC_UPINRQ6 : (USBC Offset: 0x668) (R/W 32) Pipe In Request -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7359,14 +7359,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPINRQ6_OFFSET         0x668        /**< \brief (USBC_UPINRQ6 offset) Pipe In Request */
-#define USBC_UPINRQ6_RESETVALUE     _U(0x00000001); /**< \brief (USBC_UPINRQ6 reset_value) Pipe In Request */
+#define USBC_UPINRQ6_RESETVALUE     _U_(0x00000001); /**< \brief (USBC_UPINRQ6 reset_value) Pipe In Request */
 
 #define USBC_UPINRQ6_INRQ_Pos       0            /**< \brief (USBC_UPINRQ6) IN Request Number before Freeze */
-#define USBC_UPINRQ6_INRQ_Msk       (_U(0xFF) << USBC_UPINRQ6_INRQ_Pos)
+#define USBC_UPINRQ6_INRQ_Msk       (_U_(0xFF) << USBC_UPINRQ6_INRQ_Pos)
 #define USBC_UPINRQ6_INRQ(value)    (USBC_UPINRQ6_INRQ_Msk & ((value) << USBC_UPINRQ6_INRQ_Pos))
 #define USBC_UPINRQ6_INMODE_Pos     8            /**< \brief (USBC_UPINRQ6) IN Request Mode */
-#define USBC_UPINRQ6_INMODE         (_U(0x1) << USBC_UPINRQ6_INMODE_Pos)
-#define USBC_UPINRQ6_MASK           _U(0x000001FF) /**< \brief (USBC_UPINRQ6) MASK Register */
+#define USBC_UPINRQ6_INMODE         (_U_(0x1) << USBC_UPINRQ6_INMODE_Pos)
+#define USBC_UPINRQ6_MASK           _U_(0x000001FF) /**< \brief (USBC_UPINRQ6) MASK Register */
 
 /* -------- USBC_UPINRQ7 : (USBC Offset: 0x66C) (R/W 32) Pipe In Request -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7381,14 +7381,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UPINRQ7_OFFSET         0x66C        /**< \brief (USBC_UPINRQ7 offset) Pipe In Request */
-#define USBC_UPINRQ7_RESETVALUE     _U(0x00000001); /**< \brief (USBC_UPINRQ7 reset_value) Pipe In Request */
+#define USBC_UPINRQ7_RESETVALUE     _U_(0x00000001); /**< \brief (USBC_UPINRQ7 reset_value) Pipe In Request */
 
 #define USBC_UPINRQ7_INRQ_Pos       0            /**< \brief (USBC_UPINRQ7) IN Request Number before Freeze */
-#define USBC_UPINRQ7_INRQ_Msk       (_U(0xFF) << USBC_UPINRQ7_INRQ_Pos)
+#define USBC_UPINRQ7_INRQ_Msk       (_U_(0xFF) << USBC_UPINRQ7_INRQ_Pos)
 #define USBC_UPINRQ7_INRQ(value)    (USBC_UPINRQ7_INRQ_Msk & ((value) << USBC_UPINRQ7_INRQ_Pos))
 #define USBC_UPINRQ7_INMODE_Pos     8            /**< \brief (USBC_UPINRQ7) IN Request Mode */
-#define USBC_UPINRQ7_INMODE         (_U(0x1) << USBC_UPINRQ7_INMODE_Pos)
-#define USBC_UPINRQ7_MASK           _U(0x000001FF) /**< \brief (USBC_UPINRQ7) MASK Register */
+#define USBC_UPINRQ7_INMODE         (_U_(0x1) << USBC_UPINRQ7_INMODE_Pos)
+#define USBC_UPINRQ7_MASK           _U_(0x000001FF) /**< \brief (USBC_UPINRQ7) MASK Register */
 
 /* -------- USBC_USBCON : (USBC Offset: 0x800) (R/W 32) General Control Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7406,15 +7406,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_USBCON_OFFSET          0x800        /**< \brief (USBC_USBCON offset) General Control Register */
-#define USBC_USBCON_RESETVALUE      _U(0x01004000); /**< \brief (USBC_USBCON reset_value) General Control Register */
+#define USBC_USBCON_RESETVALUE      _U_(0x01004000); /**< \brief (USBC_USBCON reset_value) General Control Register */
 
 #define USBC_USBCON_FRZCLK_Pos      14           /**< \brief (USBC_USBCON) Freeze USB Clock */
-#define USBC_USBCON_FRZCLK          (_U(0x1) << USBC_USBCON_FRZCLK_Pos)
+#define USBC_USBCON_FRZCLK          (_U_(0x1) << USBC_USBCON_FRZCLK_Pos)
 #define USBC_USBCON_USBE_Pos        15           /**< \brief (USBC_USBCON) USBC Enable */
-#define USBC_USBCON_USBE            (_U(0x1) << USBC_USBCON_USBE_Pos)
+#define USBC_USBCON_USBE            (_U_(0x1) << USBC_USBCON_USBE_Pos)
 #define USBC_USBCON_UIMOD_Pos       24           /**< \brief (USBC_USBCON) USBC Mode */
-#define USBC_USBCON_UIMOD           (_U(0x1) << USBC_USBCON_UIMOD_Pos)
-#define USBC_USBCON_MASK            _U(0x0100C000) /**< \brief (USBC_USBCON) MASK Register */
+#define USBC_USBCON_UIMOD           (_U_(0x1) << USBC_USBCON_UIMOD_Pos)
+#define USBC_USBCON_MASK            _U_(0x0100C000) /**< \brief (USBC_USBCON) MASK Register */
 
 /* -------- USBC_USBSTA : (USBC Offset: 0x804) (R/  32) General Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7434,24 +7434,24 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_USBSTA_OFFSET          0x804        /**< \brief (USBC_USBSTA offset) General Status Register */
-#define USBC_USBSTA_RESETVALUE      _U(0x00010000); /**< \brief (USBC_USBSTA reset_value) General Status Register */
+#define USBC_USBSTA_RESETVALUE      _U_(0x00010000); /**< \brief (USBC_USBSTA reset_value) General Status Register */
 
 #define USBC_USBSTA_VBUSRQ_Pos      9            /**< \brief (USBC_USBSTA) VBus Request */
-#define USBC_USBSTA_VBUSRQ          (_U(0x1) << USBC_USBSTA_VBUSRQ_Pos)
+#define USBC_USBSTA_VBUSRQ          (_U_(0x1) << USBC_USBSTA_VBUSRQ_Pos)
 #define USBC_USBSTA_SPEED_Pos       12           /**< \brief (USBC_USBSTA) Speed Status */
-#define USBC_USBSTA_SPEED_Msk       (_U(0x3) << USBC_USBSTA_SPEED_Pos)
+#define USBC_USBSTA_SPEED_Msk       (_U_(0x3) << USBC_USBSTA_SPEED_Pos)
 #define USBC_USBSTA_SPEED(value)    (USBC_USBSTA_SPEED_Msk & ((value) << USBC_USBSTA_SPEED_Pos))
-#define   USBC_USBSTA_SPEED_FULL_Val      _U(0x0)   /**< \brief (USBC_USBSTA)  */
-#define   USBC_USBSTA_SPEED_HIGH_Val      _U(0x1)   /**< \brief (USBC_USBSTA)  */
-#define   USBC_USBSTA_SPEED_LOW_Val       _U(0x2)   /**< \brief (USBC_USBSTA)  */
+#define   USBC_USBSTA_SPEED_FULL_Val      _U_(0x0)   /**< \brief (USBC_USBSTA)  */
+#define   USBC_USBSTA_SPEED_HIGH_Val      _U_(0x1)   /**< \brief (USBC_USBSTA)  */
+#define   USBC_USBSTA_SPEED_LOW_Val       _U_(0x2)   /**< \brief (USBC_USBSTA)  */
 #define USBC_USBSTA_SPEED_FULL      (USBC_USBSTA_SPEED_FULL_Val    << USBC_USBSTA_SPEED_Pos)
 #define USBC_USBSTA_SPEED_HIGH      (USBC_USBSTA_SPEED_HIGH_Val    << USBC_USBSTA_SPEED_Pos)
 #define USBC_USBSTA_SPEED_LOW       (USBC_USBSTA_SPEED_LOW_Val     << USBC_USBSTA_SPEED_Pos)
 #define USBC_USBSTA_CLKUSABLE_Pos   14           /**< \brief (USBC_USBSTA) USB Clock Usable */
-#define USBC_USBSTA_CLKUSABLE       (_U(0x1) << USBC_USBSTA_CLKUSABLE_Pos)
+#define USBC_USBSTA_CLKUSABLE       (_U_(0x1) << USBC_USBSTA_CLKUSABLE_Pos)
 #define USBC_USBSTA_SUSPEND_Pos     16           /**< \brief (USBC_USBSTA) Suspend module state */
-#define USBC_USBSTA_SUSPEND         (_U(0x1) << USBC_USBSTA_SUSPEND_Pos)
-#define USBC_USBSTA_MASK            _U(0x00017200) /**< \brief (USBC_USBSTA) MASK Register */
+#define USBC_USBSTA_SUSPEND         (_U_(0x1) << USBC_USBSTA_SUSPEND_Pos)
+#define USBC_USBSTA_MASK            _U_(0x00017200) /**< \brief (USBC_USBSTA) MASK Register */
 
 /* -------- USBC_USBSTACLR : (USBC Offset: 0x808) ( /W 32) General Status Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7467,13 +7467,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_USBSTACLR_OFFSET       0x808        /**< \brief (USBC_USBSTACLR offset) General Status Clear Register */
-#define USBC_USBSTACLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_USBSTACLR reset_value) General Status Clear Register */
+#define USBC_USBSTACLR_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_USBSTACLR reset_value) General Status Clear Register */
 
 #define USBC_USBSTACLR_RAMACERIC_Pos 8            /**< \brief (USBC_USBSTACLR) RAMACERI Clear */
-#define USBC_USBSTACLR_RAMACERIC    (_U(0x1) << USBC_USBSTACLR_RAMACERIC_Pos)
+#define USBC_USBSTACLR_RAMACERIC    (_U_(0x1) << USBC_USBSTACLR_RAMACERIC_Pos)
 #define USBC_USBSTACLR_VBUSRQC_Pos  9            /**< \brief (USBC_USBSTACLR) VBUSRQ Clear */
-#define USBC_USBSTACLR_VBUSRQC      (_U(0x1) << USBC_USBSTACLR_VBUSRQC_Pos)
-#define USBC_USBSTACLR_MASK         _U(0x00000300) /**< \brief (USBC_USBSTACLR) MASK Register */
+#define USBC_USBSTACLR_VBUSRQC      (_U_(0x1) << USBC_USBSTACLR_VBUSRQC_Pos)
+#define USBC_USBSTACLR_MASK         _U_(0x00000300) /**< \brief (USBC_USBSTACLR) MASK Register */
 
 /* -------- USBC_USBSTASET : (USBC Offset: 0x80C) ( /W 32) General Status Set Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7489,13 +7489,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_USBSTASET_OFFSET       0x80C        /**< \brief (USBC_USBSTASET offset) General Status Set Register */
-#define USBC_USBSTASET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_USBSTASET reset_value) General Status Set Register */
+#define USBC_USBSTASET_RESETVALUE   _U_(0x00000000); /**< \brief (USBC_USBSTASET reset_value) General Status Set Register */
 
 #define USBC_USBSTASET_RAMACERIS_Pos 8            /**< \brief (USBC_USBSTASET) RAMACERI Set */
-#define USBC_USBSTASET_RAMACERIS    (_U(0x1) << USBC_USBSTASET_RAMACERIS_Pos)
+#define USBC_USBSTASET_RAMACERIS    (_U_(0x1) << USBC_USBSTASET_RAMACERIS_Pos)
 #define USBC_USBSTASET_VBUSRQS_Pos  9            /**< \brief (USBC_USBSTASET) VBUSRQ Set */
-#define USBC_USBSTASET_VBUSRQS      (_U(0x1) << USBC_USBSTASET_VBUSRQS_Pos)
-#define USBC_USBSTASET_MASK         _U(0x00000300) /**< \brief (USBC_USBSTASET) MASK Register */
+#define USBC_USBSTASET_VBUSRQS      (_U_(0x1) << USBC_USBSTASET_VBUSRQS_Pos)
+#define USBC_USBSTASET_MASK         _U_(0x00000300) /**< \brief (USBC_USBSTASET) MASK Register */
 
 /* -------- USBC_UVERS : (USBC Offset: 0x818) (R/  32) IP Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7511,15 +7511,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UVERS_OFFSET           0x818        /**< \brief (USBC_UVERS offset) IP Version Register */
-#define USBC_UVERS_RESETVALUE       _U(0x00000310); /**< \brief (USBC_UVERS reset_value) IP Version Register */
+#define USBC_UVERS_RESETVALUE       _U_(0x00000310); /**< \brief (USBC_UVERS reset_value) IP Version Register */
 
 #define USBC_UVERS_VERSION_Pos      0            /**< \brief (USBC_UVERS) Version Number */
-#define USBC_UVERS_VERSION_Msk      (_U(0xFFF) << USBC_UVERS_VERSION_Pos)
+#define USBC_UVERS_VERSION_Msk      (_U_(0xFFF) << USBC_UVERS_VERSION_Pos)
 #define USBC_UVERS_VERSION(value)   (USBC_UVERS_VERSION_Msk & ((value) << USBC_UVERS_VERSION_Pos))
 #define USBC_UVERS_VARIANT_Pos      16           /**< \brief (USBC_UVERS) Variant Number */
-#define USBC_UVERS_VARIANT_Msk      (_U(0x7) << USBC_UVERS_VARIANT_Pos)
+#define USBC_UVERS_VARIANT_Msk      (_U_(0x7) << USBC_UVERS_VARIANT_Pos)
 #define USBC_UVERS_VARIANT(value)   (USBC_UVERS_VARIANT_Msk & ((value) << USBC_UVERS_VARIANT_Pos))
-#define USBC_UVERS_MASK             _U(0x00070FFF) /**< \brief (USBC_UVERS) MASK Register */
+#define USBC_UVERS_MASK             _U_(0x00070FFF) /**< \brief (USBC_UVERS) MASK Register */
 
 /* -------- USBC_UFEATURES : (USBC Offset: 0x81C) (R/  32) IP Features Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7535,14 +7535,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UFEATURES_OFFSET       0x81C        /**< \brief (USBC_UFEATURES offset) IP Features Register */
-#define USBC_UFEATURES_RESETVALUE   _U(0x00000007); /**< \brief (USBC_UFEATURES reset_value) IP Features Register */
+#define USBC_UFEATURES_RESETVALUE   _U_(0x00000007); /**< \brief (USBC_UFEATURES reset_value) IP Features Register */
 
 #define USBC_UFEATURES_EPTNBRMAX_Pos 0            /**< \brief (USBC_UFEATURES) Maximum Number of Pipes/Endpints */
-#define USBC_UFEATURES_EPTNBRMAX_Msk (_U(0xF) << USBC_UFEATURES_EPTNBRMAX_Pos)
+#define USBC_UFEATURES_EPTNBRMAX_Msk (_U_(0xF) << USBC_UFEATURES_EPTNBRMAX_Pos)
 #define USBC_UFEATURES_EPTNBRMAX(value) (USBC_UFEATURES_EPTNBRMAX_Msk & ((value) << USBC_UFEATURES_EPTNBRMAX_Pos))
 #define USBC_UFEATURES_UTMIMODE_Pos 8            /**< \brief (USBC_UFEATURES) UTMI Mode */
-#define USBC_UFEATURES_UTMIMODE     (_U(0x1) << USBC_UFEATURES_UTMIMODE_Pos)
-#define USBC_UFEATURES_MASK         _U(0x0000010F) /**< \brief (USBC_UFEATURES) MASK Register */
+#define USBC_UFEATURES_UTMIMODE     (_U_(0x1) << USBC_UFEATURES_UTMIMODE_Pos)
+#define USBC_UFEATURES_MASK         _U_(0x0000010F) /**< \brief (USBC_UFEATURES) MASK Register */
 
 /* -------- USBC_UADDRSIZE : (USBC Offset: 0x820) (R/  32) IP PB address size Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7555,12 +7555,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UADDRSIZE_OFFSET       0x820        /**< \brief (USBC_UADDRSIZE offset) IP PB address size Register */
-#define USBC_UADDRSIZE_RESETVALUE   _U(0x00001000); /**< \brief (USBC_UADDRSIZE reset_value) IP PB address size Register */
+#define USBC_UADDRSIZE_RESETVALUE   _U_(0x00001000); /**< \brief (USBC_UADDRSIZE reset_value) IP PB address size Register */
 
 #define USBC_UADDRSIZE_UADDRSIZE_Pos 0            /**< \brief (USBC_UADDRSIZE) IP PB Address Size */
-#define USBC_UADDRSIZE_UADDRSIZE_Msk (_U(0xFFFFFFFF) << USBC_UADDRSIZE_UADDRSIZE_Pos)
+#define USBC_UADDRSIZE_UADDRSIZE_Msk (_U_(0xFFFFFFFF) << USBC_UADDRSIZE_UADDRSIZE_Pos)
 #define USBC_UADDRSIZE_UADDRSIZE(value) (USBC_UADDRSIZE_UADDRSIZE_Msk & ((value) << USBC_UADDRSIZE_UADDRSIZE_Pos))
-#define USBC_UADDRSIZE_MASK         _U(0xFFFFFFFF) /**< \brief (USBC_UADDRSIZE) MASK Register */
+#define USBC_UADDRSIZE_MASK         _U_(0xFFFFFFFF) /**< \brief (USBC_UADDRSIZE) MASK Register */
 
 /* -------- USBC_UNAME1 : (USBC Offset: 0x824) (R/  32) IP Name Part One: HUSB -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7573,12 +7573,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UNAME1_OFFSET          0x824        /**< \brief (USBC_UNAME1 offset) IP Name Part One: HUSB */
-#define USBC_UNAME1_RESETVALUE      _U(0x48555342); /**< \brief (USBC_UNAME1 reset_value) IP Name Part One: HUSB */
+#define USBC_UNAME1_RESETVALUE      _U_(0x48555342); /**< \brief (USBC_UNAME1 reset_value) IP Name Part One: HUSB */
 
 #define USBC_UNAME1_UNAME1_Pos      0            /**< \brief (USBC_UNAME1) IP Name Part One */
-#define USBC_UNAME1_UNAME1_Msk      (_U(0xFFFFFFFF) << USBC_UNAME1_UNAME1_Pos)
+#define USBC_UNAME1_UNAME1_Msk      (_U_(0xFFFFFFFF) << USBC_UNAME1_UNAME1_Pos)
 #define USBC_UNAME1_UNAME1(value)   (USBC_UNAME1_UNAME1_Msk & ((value) << USBC_UNAME1_UNAME1_Pos))
-#define USBC_UNAME1_MASK            _U(0xFFFFFFFF) /**< \brief (USBC_UNAME1) MASK Register */
+#define USBC_UNAME1_MASK            _U_(0xFFFFFFFF) /**< \brief (USBC_UNAME1) MASK Register */
 
 /* -------- USBC_UNAME2 : (USBC Offset: 0x828) (R/  32) IP Name Part Two: HOST -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7591,12 +7591,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UNAME2_OFFSET          0x828        /**< \brief (USBC_UNAME2 offset) IP Name Part Two: HOST */
-#define USBC_UNAME2_RESETVALUE      _U(0x484F5354); /**< \brief (USBC_UNAME2 reset_value) IP Name Part Two: HOST */
+#define USBC_UNAME2_RESETVALUE      _U_(0x484F5354); /**< \brief (USBC_UNAME2 reset_value) IP Name Part Two: HOST */
 
 #define USBC_UNAME2_UNAME2_Pos      0            /**< \brief (USBC_UNAME2) IP Name Part Two */
-#define USBC_UNAME2_UNAME2_Msk      (_U(0xFFFFFFFF) << USBC_UNAME2_UNAME2_Pos)
+#define USBC_UNAME2_UNAME2_Msk      (_U_(0xFFFFFFFF) << USBC_UNAME2_UNAME2_Pos)
 #define USBC_UNAME2_UNAME2(value)   (USBC_UNAME2_UNAME2_Msk & ((value) << USBC_UNAME2_UNAME2_Pos))
-#define USBC_UNAME2_MASK            _U(0xFFFFFFFF) /**< \brief (USBC_UNAME2) MASK Register */
+#define USBC_UNAME2_MASK            _U_(0xFFFFFFFF) /**< \brief (USBC_UNAME2) MASK Register */
 
 /* -------- USBC_USBFSM : (USBC Offset: 0x82C) (R/  32) USB internal finite state machine -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7610,27 +7610,27 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_USBFSM_OFFSET          0x82C        /**< \brief (USBC_USBFSM offset) USB internal finite state machine */
-#define USBC_USBFSM_RESETVALUE      _U(0x00000009); /**< \brief (USBC_USBFSM reset_value) USB internal finite state machine */
+#define USBC_USBFSM_RESETVALUE      _U_(0x00000009); /**< \brief (USBC_USBFSM reset_value) USB internal finite state machine */
 
 #define USBC_USBFSM_DRDSTATE_Pos    0            /**< \brief (USBC_USBFSM) DualRoleDevice state */
-#define USBC_USBFSM_DRDSTATE_Msk    (_U(0xF) << USBC_USBFSM_DRDSTATE_Pos)
+#define USBC_USBFSM_DRDSTATE_Msk    (_U_(0xF) << USBC_USBFSM_DRDSTATE_Pos)
 #define USBC_USBFSM_DRDSTATE(value) (USBC_USBFSM_DRDSTATE_Msk & ((value) << USBC_USBFSM_DRDSTATE_Pos))
-#define   USBC_USBFSM_DRDSTATE_A_IDLE_Val _U(0x0)   /**< \brief (USBC_USBFSM)  */
-#define   USBC_USBFSM_DRDSTATE_A_WAIT_VRISE_Val _U(0x1)   /**< \brief (USBC_USBFSM)  */
-#define   USBC_USBFSM_DRDSTATE_A_WAIT_BCON_Val _U(0x2)   /**< \brief (USBC_USBFSM)  */
-#define   USBC_USBFSM_DRDSTATE_A_HOST_Val _U(0x3)   /**< \brief (USBC_USBFSM)  */
-#define   USBC_USBFSM_DRDSTATE_A_SUSPEND_Val _U(0x4)   /**< \brief (USBC_USBFSM)  */
-#define   USBC_USBFSM_DRDSTATE_A_PERIPHERAL_Val _U(0x5)   /**< \brief (USBC_USBFSM)  */
-#define   USBC_USBFSM_DRDSTATE_A_WAIT_VFALL_Val _U(0x6)   /**< \brief (USBC_USBFSM)  */
-#define   USBC_USBFSM_DRDSTATE_A_VBUS_ERR_Val _U(0x7)   /**< \brief (USBC_USBFSM)  */
-#define   USBC_USBFSM_DRDSTATE_A_WAIT_DISCHARGE_Val _U(0x8)   /**< \brief (USBC_USBFSM)  */
-#define   USBC_USBFSM_DRDSTATE_B_IDLE_Val _U(0x9)   /**< \brief (USBC_USBFSM)  */
-#define   USBC_USBFSM_DRDSTATE_B_PERIPHERAL_Val _U(0xA)   /**< \brief (USBC_USBFSM)  */
-#define   USBC_USBFSM_DRDSTATE_B_WAIT_BEGIN_HNP_Val _U(0xB)   /**< \brief (USBC_USBFSM)  */
-#define   USBC_USBFSM_DRDSTATE_B_WAIT_DISCHARGE_Val _U(0xC)   /**< \brief (USBC_USBFSM)  */
-#define   USBC_USBFSM_DRDSTATE_B_WAIT_ACON_Val _U(0xD)   /**< \brief (USBC_USBFSM)  */
-#define   USBC_USBFSM_DRDSTATE_B_HOST_Val _U(0xE)   /**< \brief (USBC_USBFSM)  */
-#define   USBC_USBFSM_DRDSTATE_B_SRP_INIT_Val _U(0xF)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_A_IDLE_Val _U_(0x0)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_A_WAIT_VRISE_Val _U_(0x1)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_A_WAIT_BCON_Val _U_(0x2)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_A_HOST_Val _U_(0x3)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_A_SUSPEND_Val _U_(0x4)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_A_PERIPHERAL_Val _U_(0x5)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_A_WAIT_VFALL_Val _U_(0x6)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_A_VBUS_ERR_Val _U_(0x7)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_A_WAIT_DISCHARGE_Val _U_(0x8)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_B_IDLE_Val _U_(0x9)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_B_PERIPHERAL_Val _U_(0xA)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_B_WAIT_BEGIN_HNP_Val _U_(0xB)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_B_WAIT_DISCHARGE_Val _U_(0xC)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_B_WAIT_ACON_Val _U_(0xD)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_B_HOST_Val _U_(0xE)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_B_SRP_INIT_Val _U_(0xF)   /**< \brief (USBC_USBFSM)  */
 #define USBC_USBFSM_DRDSTATE_A_IDLE (USBC_USBFSM_DRDSTATE_A_IDLE_Val << USBC_USBFSM_DRDSTATE_Pos)
 #define USBC_USBFSM_DRDSTATE_A_WAIT_VRISE (USBC_USBFSM_DRDSTATE_A_WAIT_VRISE_Val << USBC_USBFSM_DRDSTATE_Pos)
 #define USBC_USBFSM_DRDSTATE_A_WAIT_BCON (USBC_USBFSM_DRDSTATE_A_WAIT_BCON_Val << USBC_USBFSM_DRDSTATE_Pos)
@@ -7647,7 +7647,7 @@ typedef union {
 #define USBC_USBFSM_DRDSTATE_B_WAIT_ACON (USBC_USBFSM_DRDSTATE_B_WAIT_ACON_Val << USBC_USBFSM_DRDSTATE_Pos)
 #define USBC_USBFSM_DRDSTATE_B_HOST (USBC_USBFSM_DRDSTATE_B_HOST_Val << USBC_USBFSM_DRDSTATE_Pos)
 #define USBC_USBFSM_DRDSTATE_B_SRP_INIT (USBC_USBFSM_DRDSTATE_B_SRP_INIT_Val << USBC_USBFSM_DRDSTATE_Pos)
-#define USBC_USBFSM_MASK            _U(0x0000000F) /**< \brief (USBC_USBFSM) MASK Register */
+#define USBC_USBFSM_MASK            _U_(0x0000000F) /**< \brief (USBC_USBFSM) MASK Register */
 
 /* -------- USBC_UDESC : (USBC Offset: 0x830) (R/W 32) Endpoint descriptor table -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -7660,12 +7660,12 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBC_UDESC_OFFSET           0x830        /**< \brief (USBC_UDESC offset) Endpoint descriptor table */
-#define USBC_UDESC_RESETVALUE       _U(0x00000000); /**< \brief (USBC_UDESC reset_value) Endpoint descriptor table */
+#define USBC_UDESC_RESETVALUE       _U_(0x00000000); /**< \brief (USBC_UDESC reset_value) Endpoint descriptor table */
 
 #define USBC_UDESC_UDESCA_Pos       0            /**< \brief (USBC_UDESC) USB Descriptor Address */
-#define USBC_UDESC_UDESCA_Msk       (_U(0xFFFFFFFF) << USBC_UDESC_UDESCA_Pos)
+#define USBC_UDESC_UDESCA_Msk       (_U_(0xFFFFFFFF) << USBC_UDESC_UDESCA_Pos)
 #define USBC_UDESC_UDESCA(value)    (USBC_UDESC_UDESCA_Msk & ((value) << USBC_UDESC_UDESCA_Pos))
-#define USBC_UDESC_MASK             _U(0xFFFFFFFF) /**< \brief (USBC_UDESC) MASK Register */
+#define USBC_UDESC_MASK             _U_(0xFFFFFFFF) /**< \brief (USBC_UDESC) MASK Register */
 
 /** \brief USBC hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/usbc.h
+++ b/asf/sam/include/sam4l/component/usbc.h
@@ -1,0 +1,8018 @@
+/**
+ * \file
+ *
+ * \brief Component description for USBC
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_USBC_COMPONENT_
+#define _SAM4L_USBC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR USBC */
+/* ========================================================================== */
+/** \addtogroup SAM4L_USBC USB 2.0 Interface */
+/*@{*/
+
+#define USBC_I7553
+#define REV_USBC                    0x310
+
+/* -------- USBC_UDCON : (USBC Offset: 0x000) (R/W 32) Device General Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t UADD:7;           /*!< bit:  0.. 6  USB Address                        */
+    uint32_t ADDEN:1;          /*!< bit:      7  Address Enable                     */
+    uint32_t DETACH:1;         /*!< bit:      8  Detach                             */
+    uint32_t RMWKUP:1;         /*!< bit:      9  Remote Wake-Up                     */
+    uint32_t SPDCONF:2;        /*!< bit: 10..11  Speed configuration                */
+    uint32_t LS:1;             /*!< bit:     12  Low Speed Mode Force               */
+    uint32_t TSTJ:1;           /*!< bit:     13  Test mode J                        */
+    uint32_t TSTK:1;           /*!< bit:     14  Test mode K                        */
+    uint32_t TSTPCKT:1;        /*!< bit:     15  Test Packet mode                   */
+    uint32_t OPMODE2:1;        /*!< bit:     16  Specific Operational mode          */
+    uint32_t GNAK:1;           /*!< bit:     17  Global NAK                         */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UDCON_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UDCON_OFFSET           0x000        /**< \brief (USBC_UDCON offset) Device General Control Register */
+#define USBC_UDCON_RESETVALUE       _U(0x00000100); /**< \brief (USBC_UDCON reset_value) Device General Control Register */
+
+#define USBC_UDCON_UADD_Pos         0            /**< \brief (USBC_UDCON) USB Address */
+#define USBC_UDCON_UADD_Msk         (_U(0x7F) << USBC_UDCON_UADD_Pos)
+#define USBC_UDCON_UADD(value)      (USBC_UDCON_UADD_Msk & ((value) << USBC_UDCON_UADD_Pos))
+#define USBC_UDCON_ADDEN_Pos        7            /**< \brief (USBC_UDCON) Address Enable */
+#define USBC_UDCON_ADDEN            (_U(0x1) << USBC_UDCON_ADDEN_Pos)
+#define USBC_UDCON_DETACH_Pos       8            /**< \brief (USBC_UDCON) Detach */
+#define USBC_UDCON_DETACH           (_U(0x1) << USBC_UDCON_DETACH_Pos)
+#define USBC_UDCON_RMWKUP_Pos       9            /**< \brief (USBC_UDCON) Remote Wake-Up */
+#define USBC_UDCON_RMWKUP           (_U(0x1) << USBC_UDCON_RMWKUP_Pos)
+#define USBC_UDCON_SPDCONF_Pos      10           /**< \brief (USBC_UDCON) Speed configuration */
+#define USBC_UDCON_SPDCONF_Msk      (_U(0x3) << USBC_UDCON_SPDCONF_Pos)
+#define USBC_UDCON_SPDCONF(value)   (USBC_UDCON_SPDCONF_Msk & ((value) << USBC_UDCON_SPDCONF_Pos))
+#define USBC_UDCON_LS_Pos           12           /**< \brief (USBC_UDCON) Low Speed Mode Force */
+#define USBC_UDCON_LS               (_U(0x1) << USBC_UDCON_LS_Pos)
+#define USBC_UDCON_TSTJ_Pos         13           /**< \brief (USBC_UDCON) Test mode J */
+#define USBC_UDCON_TSTJ             (_U(0x1) << USBC_UDCON_TSTJ_Pos)
+#define USBC_UDCON_TSTK_Pos         14           /**< \brief (USBC_UDCON) Test mode K */
+#define USBC_UDCON_TSTK             (_U(0x1) << USBC_UDCON_TSTK_Pos)
+#define USBC_UDCON_TSTPCKT_Pos      15           /**< \brief (USBC_UDCON) Test Packet mode */
+#define USBC_UDCON_TSTPCKT          (_U(0x1) << USBC_UDCON_TSTPCKT_Pos)
+#define USBC_UDCON_OPMODE2_Pos      16           /**< \brief (USBC_UDCON) Specific Operational mode */
+#define USBC_UDCON_OPMODE2          (_U(0x1) << USBC_UDCON_OPMODE2_Pos)
+#define USBC_UDCON_GNAK_Pos         17           /**< \brief (USBC_UDCON) Global NAK */
+#define USBC_UDCON_GNAK             (_U(0x1) << USBC_UDCON_GNAK_Pos)
+#define USBC_UDCON_MASK             _U(0x0003FFFF) /**< \brief (USBC_UDCON) MASK Register */
+
+/* -------- USBC_UDINT : (USBC Offset: 0x004) (R/  32) Device Global Interupt Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SUSP:1;           /*!< bit:      0  Suspend Interrupt                  */
+    uint32_t MSOF:1;           /*!< bit:      1  Micro Start of Frame Interrupt     */
+    uint32_t SOF:1;            /*!< bit:      2  Start of Frame Interrupt           */
+    uint32_t EORST:1;          /*!< bit:      3  End of Reset Interrupt             */
+    uint32_t WAKEUP:1;         /*!< bit:      4  Wake-Up Interrupt                  */
+    uint32_t EORSM:1;          /*!< bit:      5  End Of Resume Interrupt            */
+    uint32_t UPRSM:1;          /*!< bit:      6  Upstream Resume Interrupt          */
+    uint32_t :5;               /*!< bit:  7..11  Reserved                           */
+    uint32_t EP0INT:1;         /*!< bit:     12  Endpoint 0 Interrupt               */
+    uint32_t EP1INT:1;         /*!< bit:     13  Endpoint 1 Interrupt               */
+    uint32_t EP2INT:1;         /*!< bit:     14  Endpoint 2 Interrupt               */
+    uint32_t EP3INT:1;         /*!< bit:     15  Endpoint 3 Interrupt               */
+    uint32_t EP4INT:1;         /*!< bit:     16  Endpoint 4 Interrupt               */
+    uint32_t EP5INT:1;         /*!< bit:     17  Endpoint 5 Interrupt               */
+    uint32_t EP6INT:1;         /*!< bit:     18  Endpoint 6 Interrupt               */
+    uint32_t EP7INT:1;         /*!< bit:     19  Endpoint 7 Interrupt               */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UDINT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UDINT_OFFSET           0x004        /**< \brief (USBC_UDINT offset) Device Global Interupt Register */
+#define USBC_UDINT_RESETVALUE       _U(0x00000000); /**< \brief (USBC_UDINT reset_value) Device Global Interupt Register */
+
+#define USBC_UDINT_SUSP_Pos         0            /**< \brief (USBC_UDINT) Suspend Interrupt */
+#define USBC_UDINT_SUSP             (_U(0x1) << USBC_UDINT_SUSP_Pos)
+#define USBC_UDINT_MSOF_Pos         1            /**< \brief (USBC_UDINT) Micro Start of Frame Interrupt */
+#define USBC_UDINT_MSOF             (_U(0x1) << USBC_UDINT_MSOF_Pos)
+#define USBC_UDINT_SOF_Pos          2            /**< \brief (USBC_UDINT) Start of Frame Interrupt */
+#define USBC_UDINT_SOF              (_U(0x1) << USBC_UDINT_SOF_Pos)
+#define USBC_UDINT_EORST_Pos        3            /**< \brief (USBC_UDINT) End of Reset Interrupt */
+#define USBC_UDINT_EORST            (_U(0x1) << USBC_UDINT_EORST_Pos)
+#define USBC_UDINT_WAKEUP_Pos       4            /**< \brief (USBC_UDINT) Wake-Up Interrupt */
+#define USBC_UDINT_WAKEUP           (_U(0x1) << USBC_UDINT_WAKEUP_Pos)
+#define USBC_UDINT_EORSM_Pos        5            /**< \brief (USBC_UDINT) End Of Resume Interrupt */
+#define USBC_UDINT_EORSM            (_U(0x1) << USBC_UDINT_EORSM_Pos)
+#define USBC_UDINT_UPRSM_Pos        6            /**< \brief (USBC_UDINT) Upstream Resume Interrupt */
+#define USBC_UDINT_UPRSM            (_U(0x1) << USBC_UDINT_UPRSM_Pos)
+#define USBC_UDINT_EP0INT_Pos       12           /**< \brief (USBC_UDINT) Endpoint 0 Interrupt */
+#define USBC_UDINT_EP0INT           (_U(0x1) << USBC_UDINT_EP0INT_Pos)
+#define USBC_UDINT_EP1INT_Pos       13           /**< \brief (USBC_UDINT) Endpoint 1 Interrupt */
+#define USBC_UDINT_EP1INT           (_U(0x1) << USBC_UDINT_EP1INT_Pos)
+#define USBC_UDINT_EP2INT_Pos       14           /**< \brief (USBC_UDINT) Endpoint 2 Interrupt */
+#define USBC_UDINT_EP2INT           (_U(0x1) << USBC_UDINT_EP2INT_Pos)
+#define USBC_UDINT_EP3INT_Pos       15           /**< \brief (USBC_UDINT) Endpoint 3 Interrupt */
+#define USBC_UDINT_EP3INT           (_U(0x1) << USBC_UDINT_EP3INT_Pos)
+#define USBC_UDINT_EP4INT_Pos       16           /**< \brief (USBC_UDINT) Endpoint 4 Interrupt */
+#define USBC_UDINT_EP4INT           (_U(0x1) << USBC_UDINT_EP4INT_Pos)
+#define USBC_UDINT_EP5INT_Pos       17           /**< \brief (USBC_UDINT) Endpoint 5 Interrupt */
+#define USBC_UDINT_EP5INT           (_U(0x1) << USBC_UDINT_EP5INT_Pos)
+#define USBC_UDINT_EP6INT_Pos       18           /**< \brief (USBC_UDINT) Endpoint 6 Interrupt */
+#define USBC_UDINT_EP6INT           (_U(0x1) << USBC_UDINT_EP6INT_Pos)
+#define USBC_UDINT_EP7INT_Pos       19           /**< \brief (USBC_UDINT) Endpoint 7 Interrupt */
+#define USBC_UDINT_EP7INT           (_U(0x1) << USBC_UDINT_EP7INT_Pos)
+#define USBC_UDINT_MASK             _U(0x000FF07F) /**< \brief (USBC_UDINT) MASK Register */
+
+/* -------- USBC_UDINTCLR : (USBC Offset: 0x008) ( /W 32) Device Global Interrupt Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SUSPC:1;          /*!< bit:      0  SUSP Interrupt Clear               */
+    uint32_t MSOFC:1;          /*!< bit:      1  MSOF Interrupt Clear               */
+    uint32_t SOFC:1;           /*!< bit:      2  SOF Interrupt Clear                */
+    uint32_t EORSTC:1;         /*!< bit:      3  EORST Interrupt Clear              */
+    uint32_t WAKEUPC:1;        /*!< bit:      4  WAKEUP Interrupt Clear             */
+    uint32_t EORSMC:1;         /*!< bit:      5  EORSM Interrupt Clear              */
+    uint32_t UPRSMC:1;         /*!< bit:      6  UPRSM Interrupt Clear              */
+    uint32_t :25;              /*!< bit:  7..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UDINTCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UDINTCLR_OFFSET        0x008        /**< \brief (USBC_UDINTCLR offset) Device Global Interrupt Clear Register */
+#define USBC_UDINTCLR_RESETVALUE    _U(0x00000000); /**< \brief (USBC_UDINTCLR reset_value) Device Global Interrupt Clear Register */
+
+#define USBC_UDINTCLR_SUSPC_Pos     0            /**< \brief (USBC_UDINTCLR) SUSP Interrupt Clear */
+#define USBC_UDINTCLR_SUSPC         (_U(0x1) << USBC_UDINTCLR_SUSPC_Pos)
+#define USBC_UDINTCLR_MSOFC_Pos     1            /**< \brief (USBC_UDINTCLR) MSOF Interrupt Clear */
+#define USBC_UDINTCLR_MSOFC         (_U(0x1) << USBC_UDINTCLR_MSOFC_Pos)
+#define USBC_UDINTCLR_SOFC_Pos      2            /**< \brief (USBC_UDINTCLR) SOF Interrupt Clear */
+#define USBC_UDINTCLR_SOFC          (_U(0x1) << USBC_UDINTCLR_SOFC_Pos)
+#define USBC_UDINTCLR_EORSTC_Pos    3            /**< \brief (USBC_UDINTCLR) EORST Interrupt Clear */
+#define USBC_UDINTCLR_EORSTC        (_U(0x1) << USBC_UDINTCLR_EORSTC_Pos)
+#define USBC_UDINTCLR_WAKEUPC_Pos   4            /**< \brief (USBC_UDINTCLR) WAKEUP Interrupt Clear */
+#define USBC_UDINTCLR_WAKEUPC       (_U(0x1) << USBC_UDINTCLR_WAKEUPC_Pos)
+#define USBC_UDINTCLR_EORSMC_Pos    5            /**< \brief (USBC_UDINTCLR) EORSM Interrupt Clear */
+#define USBC_UDINTCLR_EORSMC        (_U(0x1) << USBC_UDINTCLR_EORSMC_Pos)
+#define USBC_UDINTCLR_UPRSMC_Pos    6            /**< \brief (USBC_UDINTCLR) UPRSM Interrupt Clear */
+#define USBC_UDINTCLR_UPRSMC        (_U(0x1) << USBC_UDINTCLR_UPRSMC_Pos)
+#define USBC_UDINTCLR_MASK          _U(0x0000007F) /**< \brief (USBC_UDINTCLR) MASK Register */
+
+/* -------- USBC_UDINTSET : (USBC Offset: 0x00C) ( /W 32) Device Global Interrupt Set Regsiter -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SUSPS:1;          /*!< bit:      0  SUSP Interrupt Set                 */
+    uint32_t MSOFS:1;          /*!< bit:      1  MSOF Interrupt Set                 */
+    uint32_t SOFS:1;           /*!< bit:      2  SOF Interrupt Set                  */
+    uint32_t EORSTS:1;         /*!< bit:      3  EORST Interrupt Set                */
+    uint32_t WAKEUPS:1;        /*!< bit:      4  WAKEUP Interrupt Set               */
+    uint32_t EORSMS:1;         /*!< bit:      5  EORSM Interrupt Set                */
+    uint32_t UPRSMS:1;         /*!< bit:      6  UPRSM Interrupt Set                */
+    uint32_t :25;              /*!< bit:  7..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UDINTSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UDINTSET_OFFSET        0x00C        /**< \brief (USBC_UDINTSET offset) Device Global Interrupt Set Regsiter */
+#define USBC_UDINTSET_RESETVALUE    _U(0x00000000); /**< \brief (USBC_UDINTSET reset_value) Device Global Interrupt Set Regsiter */
+
+#define USBC_UDINTSET_SUSPS_Pos     0            /**< \brief (USBC_UDINTSET) SUSP Interrupt Set */
+#define USBC_UDINTSET_SUSPS         (_U(0x1) << USBC_UDINTSET_SUSPS_Pos)
+#define USBC_UDINTSET_MSOFS_Pos     1            /**< \brief (USBC_UDINTSET) MSOF Interrupt Set */
+#define USBC_UDINTSET_MSOFS         (_U(0x1) << USBC_UDINTSET_MSOFS_Pos)
+#define USBC_UDINTSET_SOFS_Pos      2            /**< \brief (USBC_UDINTSET) SOF Interrupt Set */
+#define USBC_UDINTSET_SOFS          (_U(0x1) << USBC_UDINTSET_SOFS_Pos)
+#define USBC_UDINTSET_EORSTS_Pos    3            /**< \brief (USBC_UDINTSET) EORST Interrupt Set */
+#define USBC_UDINTSET_EORSTS        (_U(0x1) << USBC_UDINTSET_EORSTS_Pos)
+#define USBC_UDINTSET_WAKEUPS_Pos   4            /**< \brief (USBC_UDINTSET) WAKEUP Interrupt Set */
+#define USBC_UDINTSET_WAKEUPS       (_U(0x1) << USBC_UDINTSET_WAKEUPS_Pos)
+#define USBC_UDINTSET_EORSMS_Pos    5            /**< \brief (USBC_UDINTSET) EORSM Interrupt Set */
+#define USBC_UDINTSET_EORSMS        (_U(0x1) << USBC_UDINTSET_EORSMS_Pos)
+#define USBC_UDINTSET_UPRSMS_Pos    6            /**< \brief (USBC_UDINTSET) UPRSM Interrupt Set */
+#define USBC_UDINTSET_UPRSMS        (_U(0x1) << USBC_UDINTSET_UPRSMS_Pos)
+#define USBC_UDINTSET_MASK          _U(0x0000007F) /**< \brief (USBC_UDINTSET) MASK Register */
+
+/* -------- USBC_UDINTE : (USBC Offset: 0x010) (R/  32) Device Global Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SUSPE:1;          /*!< bit:      0  SUSP Interrupt Enable              */
+    uint32_t MSOFE:1;          /*!< bit:      1  MSOF Interrupt Enable              */
+    uint32_t SOFE:1;           /*!< bit:      2  SOF Interrupt Enable               */
+    uint32_t EORSTE:1;         /*!< bit:      3  EORST Interrupt Enable             */
+    uint32_t WAKEUPE:1;        /*!< bit:      4  WAKEUP Interrupt Enable            */
+    uint32_t EORSME:1;         /*!< bit:      5  EORSM Interrupt Enable             */
+    uint32_t UPRSME:1;         /*!< bit:      6  UPRSM Interrupt Enable             */
+    uint32_t :5;               /*!< bit:  7..11  Reserved                           */
+    uint32_t EP0INTE:1;        /*!< bit:     12  EP0INT Interrupt Enable            */
+    uint32_t EP1INTE:1;        /*!< bit:     13  EP1INT Interrupt Enable            */
+    uint32_t EP2INTE:1;        /*!< bit:     14  EP2INT Interrupt Enable            */
+    uint32_t EP3INTE:1;        /*!< bit:     15  EP3INT Interrupt Enable            */
+    uint32_t EP4INTE:1;        /*!< bit:     16  EP4INT Interrupt Enable            */
+    uint32_t EP5INTE:1;        /*!< bit:     17  EP5INT Interrupt Enable            */
+    uint32_t EP6INTE:1;        /*!< bit:     18  EP6INT Interrupt Enable            */
+    uint32_t EP7INTE:1;        /*!< bit:     19  EP7INT Interrupt Enable            */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UDINTE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UDINTE_OFFSET          0x010        /**< \brief (USBC_UDINTE offset) Device Global Interrupt Enable Register */
+#define USBC_UDINTE_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UDINTE reset_value) Device Global Interrupt Enable Register */
+
+#define USBC_UDINTE_SUSPE_Pos       0            /**< \brief (USBC_UDINTE) SUSP Interrupt Enable */
+#define USBC_UDINTE_SUSPE           (_U(0x1) << USBC_UDINTE_SUSPE_Pos)
+#define USBC_UDINTE_MSOFE_Pos       1            /**< \brief (USBC_UDINTE) MSOF Interrupt Enable */
+#define USBC_UDINTE_MSOFE           (_U(0x1) << USBC_UDINTE_MSOFE_Pos)
+#define USBC_UDINTE_SOFE_Pos        2            /**< \brief (USBC_UDINTE) SOF Interrupt Enable */
+#define USBC_UDINTE_SOFE            (_U(0x1) << USBC_UDINTE_SOFE_Pos)
+#define USBC_UDINTE_EORSTE_Pos      3            /**< \brief (USBC_UDINTE) EORST Interrupt Enable */
+#define USBC_UDINTE_EORSTE          (_U(0x1) << USBC_UDINTE_EORSTE_Pos)
+#define USBC_UDINTE_WAKEUPE_Pos     4            /**< \brief (USBC_UDINTE) WAKEUP Interrupt Enable */
+#define USBC_UDINTE_WAKEUPE         (_U(0x1) << USBC_UDINTE_WAKEUPE_Pos)
+#define USBC_UDINTE_EORSME_Pos      5            /**< \brief (USBC_UDINTE) EORSM Interrupt Enable */
+#define USBC_UDINTE_EORSME          (_U(0x1) << USBC_UDINTE_EORSME_Pos)
+#define USBC_UDINTE_UPRSME_Pos      6            /**< \brief (USBC_UDINTE) UPRSM Interrupt Enable */
+#define USBC_UDINTE_UPRSME          (_U(0x1) << USBC_UDINTE_UPRSME_Pos)
+#define USBC_UDINTE_EP0INTE_Pos     12           /**< \brief (USBC_UDINTE) EP0INT Interrupt Enable */
+#define USBC_UDINTE_EP0INTE         (_U(0x1) << USBC_UDINTE_EP0INTE_Pos)
+#define USBC_UDINTE_EP1INTE_Pos     13           /**< \brief (USBC_UDINTE) EP1INT Interrupt Enable */
+#define USBC_UDINTE_EP1INTE         (_U(0x1) << USBC_UDINTE_EP1INTE_Pos)
+#define USBC_UDINTE_EP2INTE_Pos     14           /**< \brief (USBC_UDINTE) EP2INT Interrupt Enable */
+#define USBC_UDINTE_EP2INTE         (_U(0x1) << USBC_UDINTE_EP2INTE_Pos)
+#define USBC_UDINTE_EP3INTE_Pos     15           /**< \brief (USBC_UDINTE) EP3INT Interrupt Enable */
+#define USBC_UDINTE_EP3INTE         (_U(0x1) << USBC_UDINTE_EP3INTE_Pos)
+#define USBC_UDINTE_EP4INTE_Pos     16           /**< \brief (USBC_UDINTE) EP4INT Interrupt Enable */
+#define USBC_UDINTE_EP4INTE         (_U(0x1) << USBC_UDINTE_EP4INTE_Pos)
+#define USBC_UDINTE_EP5INTE_Pos     17           /**< \brief (USBC_UDINTE) EP5INT Interrupt Enable */
+#define USBC_UDINTE_EP5INTE         (_U(0x1) << USBC_UDINTE_EP5INTE_Pos)
+#define USBC_UDINTE_EP6INTE_Pos     18           /**< \brief (USBC_UDINTE) EP6INT Interrupt Enable */
+#define USBC_UDINTE_EP6INTE         (_U(0x1) << USBC_UDINTE_EP6INTE_Pos)
+#define USBC_UDINTE_EP7INTE_Pos     19           /**< \brief (USBC_UDINTE) EP7INT Interrupt Enable */
+#define USBC_UDINTE_EP7INTE         (_U(0x1) << USBC_UDINTE_EP7INTE_Pos)
+#define USBC_UDINTE_MASK            _U(0x000FF07F) /**< \brief (USBC_UDINTE) MASK Register */
+
+/* -------- USBC_UDINTECLR : (USBC Offset: 0x014) ( /W 32) Device Global Interrupt Enable Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SUSPEC:1;         /*!< bit:      0  SUSP Interrupt Enable Clear        */
+    uint32_t MSOFEC:1;         /*!< bit:      1  MSOF Interrupt Enable Clear        */
+    uint32_t SOFEC:1;          /*!< bit:      2  SOF Interrupt Enable Clear         */
+    uint32_t EORSTEC:1;        /*!< bit:      3  EORST Interrupt Enable Clear       */
+    uint32_t WAKEUPEC:1;       /*!< bit:      4  WAKEUP Interrupt Enable Clear      */
+    uint32_t EORSMEC:1;        /*!< bit:      5  EORSM Interrupt Enable Clear       */
+    uint32_t UPRSMEC:1;        /*!< bit:      6  UPRSM Interrupt Enable Clear       */
+    uint32_t :5;               /*!< bit:  7..11  Reserved                           */
+    uint32_t EP0INTEC:1;       /*!< bit:     12  EP0INT Interrupt Enable Clear      */
+    uint32_t EP1INTEC:1;       /*!< bit:     13  EP1INT Interrupt Enable Clear      */
+    uint32_t EP2INTEC:1;       /*!< bit:     14  EP2INT Interrupt Enable Clear      */
+    uint32_t EP3INTEC:1;       /*!< bit:     15  EP3INT Interrupt Enable Clear      */
+    uint32_t EP4INTEC:1;       /*!< bit:     16  EP4INT Interrupt Enable Clear      */
+    uint32_t EP5INTEC:1;       /*!< bit:     17  EP5INT Interrupt Enable Clear      */
+    uint32_t EP6INTEC:1;       /*!< bit:     18  EP6INT Interrupt Enable Clear      */
+    uint32_t EP7INTEC:1;       /*!< bit:     19  EP7INT Interrupt Enable Clear      */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UDINTECLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UDINTECLR_OFFSET       0x014        /**< \brief (USBC_UDINTECLR offset) Device Global Interrupt Enable Clear Register */
+#define USBC_UDINTECLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UDINTECLR reset_value) Device Global Interrupt Enable Clear Register */
+
+#define USBC_UDINTECLR_SUSPEC_Pos   0            /**< \brief (USBC_UDINTECLR) SUSP Interrupt Enable Clear */
+#define USBC_UDINTECLR_SUSPEC       (_U(0x1) << USBC_UDINTECLR_SUSPEC_Pos)
+#define USBC_UDINTECLR_MSOFEC_Pos   1            /**< \brief (USBC_UDINTECLR) MSOF Interrupt Enable Clear */
+#define USBC_UDINTECLR_MSOFEC       (_U(0x1) << USBC_UDINTECLR_MSOFEC_Pos)
+#define USBC_UDINTECLR_SOFEC_Pos    2            /**< \brief (USBC_UDINTECLR) SOF Interrupt Enable Clear */
+#define USBC_UDINTECLR_SOFEC        (_U(0x1) << USBC_UDINTECLR_SOFEC_Pos)
+#define USBC_UDINTECLR_EORSTEC_Pos  3            /**< \brief (USBC_UDINTECLR) EORST Interrupt Enable Clear */
+#define USBC_UDINTECLR_EORSTEC      (_U(0x1) << USBC_UDINTECLR_EORSTEC_Pos)
+#define USBC_UDINTECLR_WAKEUPEC_Pos 4            /**< \brief (USBC_UDINTECLR) WAKEUP Interrupt Enable Clear */
+#define USBC_UDINTECLR_WAKEUPEC     (_U(0x1) << USBC_UDINTECLR_WAKEUPEC_Pos)
+#define USBC_UDINTECLR_EORSMEC_Pos  5            /**< \brief (USBC_UDINTECLR) EORSM Interrupt Enable Clear */
+#define USBC_UDINTECLR_EORSMEC      (_U(0x1) << USBC_UDINTECLR_EORSMEC_Pos)
+#define USBC_UDINTECLR_UPRSMEC_Pos  6            /**< \brief (USBC_UDINTECLR) UPRSM Interrupt Enable Clear */
+#define USBC_UDINTECLR_UPRSMEC      (_U(0x1) << USBC_UDINTECLR_UPRSMEC_Pos)
+#define USBC_UDINTECLR_EP0INTEC_Pos 12           /**< \brief (USBC_UDINTECLR) EP0INT Interrupt Enable Clear */
+#define USBC_UDINTECLR_EP0INTEC     (_U(0x1) << USBC_UDINTECLR_EP0INTEC_Pos)
+#define USBC_UDINTECLR_EP1INTEC_Pos 13           /**< \brief (USBC_UDINTECLR) EP1INT Interrupt Enable Clear */
+#define USBC_UDINTECLR_EP1INTEC     (_U(0x1) << USBC_UDINTECLR_EP1INTEC_Pos)
+#define USBC_UDINTECLR_EP2INTEC_Pos 14           /**< \brief (USBC_UDINTECLR) EP2INT Interrupt Enable Clear */
+#define USBC_UDINTECLR_EP2INTEC     (_U(0x1) << USBC_UDINTECLR_EP2INTEC_Pos)
+#define USBC_UDINTECLR_EP3INTEC_Pos 15           /**< \brief (USBC_UDINTECLR) EP3INT Interrupt Enable Clear */
+#define USBC_UDINTECLR_EP3INTEC     (_U(0x1) << USBC_UDINTECLR_EP3INTEC_Pos)
+#define USBC_UDINTECLR_EP4INTEC_Pos 16           /**< \brief (USBC_UDINTECLR) EP4INT Interrupt Enable Clear */
+#define USBC_UDINTECLR_EP4INTEC     (_U(0x1) << USBC_UDINTECLR_EP4INTEC_Pos)
+#define USBC_UDINTECLR_EP5INTEC_Pos 17           /**< \brief (USBC_UDINTECLR) EP5INT Interrupt Enable Clear */
+#define USBC_UDINTECLR_EP5INTEC     (_U(0x1) << USBC_UDINTECLR_EP5INTEC_Pos)
+#define USBC_UDINTECLR_EP6INTEC_Pos 18           /**< \brief (USBC_UDINTECLR) EP6INT Interrupt Enable Clear */
+#define USBC_UDINTECLR_EP6INTEC     (_U(0x1) << USBC_UDINTECLR_EP6INTEC_Pos)
+#define USBC_UDINTECLR_EP7INTEC_Pos 19           /**< \brief (USBC_UDINTECLR) EP7INT Interrupt Enable Clear */
+#define USBC_UDINTECLR_EP7INTEC     (_U(0x1) << USBC_UDINTECLR_EP7INTEC_Pos)
+#define USBC_UDINTECLR_MASK         _U(0x000FF07F) /**< \brief (USBC_UDINTECLR) MASK Register */
+
+/* -------- USBC_UDINTESET : (USBC Offset: 0x018) ( /W 32) Device Global Interrupt Enable Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SUSPES:1;         /*!< bit:      0  SUSP Interrupt Enable Set          */
+    uint32_t MSOFES:1;         /*!< bit:      1  MSOF Interrupt Enable Set          */
+    uint32_t SOFES:1;          /*!< bit:      2  SOF Interrupt Enable Set           */
+    uint32_t EORSTES:1;        /*!< bit:      3  EORST Interrupt Enable Set         */
+    uint32_t WAKEUPES:1;       /*!< bit:      4  WAKEUP Interrupt Enable Set        */
+    uint32_t EORSMES:1;        /*!< bit:      5  EORSM Interrupt Enable Set         */
+    uint32_t UPRSMES:1;        /*!< bit:      6  UPRSM Interrupt Enable Set         */
+    uint32_t :5;               /*!< bit:  7..11  Reserved                           */
+    uint32_t EP0INTES:1;       /*!< bit:     12  EP0INT Interrupt Enable Set        */
+    uint32_t EP1INTES:1;       /*!< bit:     13  EP1INT Interrupt Enable Set        */
+    uint32_t EP2INTES:1;       /*!< bit:     14  EP2INT Interrupt Enable Set        */
+    uint32_t EP3INTES:1;       /*!< bit:     15  EP3INT Interrupt Enable Set        */
+    uint32_t EP4INTES:1;       /*!< bit:     16  EP4INT Interrupt Enable Set        */
+    uint32_t EP5INTES:1;       /*!< bit:     17  EP5INT Interrupt Enable Set        */
+    uint32_t EP6INTES:1;       /*!< bit:     18  EP6INT Interrupt Enable Set        */
+    uint32_t EP7INTES:1;       /*!< bit:     19  EP7INT Interrupt Enable Set        */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UDINTESET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UDINTESET_OFFSET       0x018        /**< \brief (USBC_UDINTESET offset) Device Global Interrupt Enable Set Register */
+#define USBC_UDINTESET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UDINTESET reset_value) Device Global Interrupt Enable Set Register */
+
+#define USBC_UDINTESET_SUSPES_Pos   0            /**< \brief (USBC_UDINTESET) SUSP Interrupt Enable Set */
+#define USBC_UDINTESET_SUSPES       (_U(0x1) << USBC_UDINTESET_SUSPES_Pos)
+#define USBC_UDINTESET_MSOFES_Pos   1            /**< \brief (USBC_UDINTESET) MSOF Interrupt Enable Set */
+#define USBC_UDINTESET_MSOFES       (_U(0x1) << USBC_UDINTESET_MSOFES_Pos)
+#define USBC_UDINTESET_SOFES_Pos    2            /**< \brief (USBC_UDINTESET) SOF Interrupt Enable Set */
+#define USBC_UDINTESET_SOFES        (_U(0x1) << USBC_UDINTESET_SOFES_Pos)
+#define USBC_UDINTESET_EORSTES_Pos  3            /**< \brief (USBC_UDINTESET) EORST Interrupt Enable Set */
+#define USBC_UDINTESET_EORSTES      (_U(0x1) << USBC_UDINTESET_EORSTES_Pos)
+#define USBC_UDINTESET_WAKEUPES_Pos 4            /**< \brief (USBC_UDINTESET) WAKEUP Interrupt Enable Set */
+#define USBC_UDINTESET_WAKEUPES     (_U(0x1) << USBC_UDINTESET_WAKEUPES_Pos)
+#define USBC_UDINTESET_EORSMES_Pos  5            /**< \brief (USBC_UDINTESET) EORSM Interrupt Enable Set */
+#define USBC_UDINTESET_EORSMES      (_U(0x1) << USBC_UDINTESET_EORSMES_Pos)
+#define USBC_UDINTESET_UPRSMES_Pos  6            /**< \brief (USBC_UDINTESET) UPRSM Interrupt Enable Set */
+#define USBC_UDINTESET_UPRSMES      (_U(0x1) << USBC_UDINTESET_UPRSMES_Pos)
+#define USBC_UDINTESET_EP0INTES_Pos 12           /**< \brief (USBC_UDINTESET) EP0INT Interrupt Enable Set */
+#define USBC_UDINTESET_EP0INTES     (_U(0x1) << USBC_UDINTESET_EP0INTES_Pos)
+#define USBC_UDINTESET_EP1INTES_Pos 13           /**< \brief (USBC_UDINTESET) EP1INT Interrupt Enable Set */
+#define USBC_UDINTESET_EP1INTES     (_U(0x1) << USBC_UDINTESET_EP1INTES_Pos)
+#define USBC_UDINTESET_EP2INTES_Pos 14           /**< \brief (USBC_UDINTESET) EP2INT Interrupt Enable Set */
+#define USBC_UDINTESET_EP2INTES     (_U(0x1) << USBC_UDINTESET_EP2INTES_Pos)
+#define USBC_UDINTESET_EP3INTES_Pos 15           /**< \brief (USBC_UDINTESET) EP3INT Interrupt Enable Set */
+#define USBC_UDINTESET_EP3INTES     (_U(0x1) << USBC_UDINTESET_EP3INTES_Pos)
+#define USBC_UDINTESET_EP4INTES_Pos 16           /**< \brief (USBC_UDINTESET) EP4INT Interrupt Enable Set */
+#define USBC_UDINTESET_EP4INTES     (_U(0x1) << USBC_UDINTESET_EP4INTES_Pos)
+#define USBC_UDINTESET_EP5INTES_Pos 17           /**< \brief (USBC_UDINTESET) EP5INT Interrupt Enable Set */
+#define USBC_UDINTESET_EP5INTES     (_U(0x1) << USBC_UDINTESET_EP5INTES_Pos)
+#define USBC_UDINTESET_EP6INTES_Pos 18           /**< \brief (USBC_UDINTESET) EP6INT Interrupt Enable Set */
+#define USBC_UDINTESET_EP6INTES     (_U(0x1) << USBC_UDINTESET_EP6INTES_Pos)
+#define USBC_UDINTESET_EP7INTES_Pos 19           /**< \brief (USBC_UDINTESET) EP7INT Interrupt Enable Set */
+#define USBC_UDINTESET_EP7INTES     (_U(0x1) << USBC_UDINTESET_EP7INTES_Pos)
+#define USBC_UDINTESET_MASK         _U(0x000FF07F) /**< \brief (USBC_UDINTESET) MASK Register */
+
+/* -------- USBC_UERST : (USBC Offset: 0x01C) (R/W 32) Endpoint Enable/Reset Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EPEN0:1;          /*!< bit:      0  Endpoint0 Enable                   */
+    uint32_t EPEN1:1;          /*!< bit:      1  Endpoint1 Enable                   */
+    uint32_t EPEN2:1;          /*!< bit:      2  Endpoint2 Enable                   */
+    uint32_t EPEN3:1;          /*!< bit:      3  Endpoint3 Enable                   */
+    uint32_t EPEN4:1;          /*!< bit:      4  Endpoint4 Enable                   */
+    uint32_t EPEN5:1;          /*!< bit:      5  Endpoint5 Enable                   */
+    uint32_t EPEN6:1;          /*!< bit:      6  Endpoint6 Enable                   */
+    uint32_t EPEN7:1;          /*!< bit:      7  Endpoint7 Enable                   */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UERST_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UERST_OFFSET           0x01C        /**< \brief (USBC_UERST offset) Endpoint Enable/Reset Register */
+#define USBC_UERST_RESETVALUE       _U(0x00000000); /**< \brief (USBC_UERST reset_value) Endpoint Enable/Reset Register */
+
+#define USBC_UERST_EPEN0_Pos        0            /**< \brief (USBC_UERST) Endpoint0 Enable */
+#define USBC_UERST_EPEN0            (_U(0x1) << USBC_UERST_EPEN0_Pos)
+#define USBC_UERST_EPEN1_Pos        1            /**< \brief (USBC_UERST) Endpoint1 Enable */
+#define USBC_UERST_EPEN1            (_U(0x1) << USBC_UERST_EPEN1_Pos)
+#define USBC_UERST_EPEN2_Pos        2            /**< \brief (USBC_UERST) Endpoint2 Enable */
+#define USBC_UERST_EPEN2            (_U(0x1) << USBC_UERST_EPEN2_Pos)
+#define USBC_UERST_EPEN3_Pos        3            /**< \brief (USBC_UERST) Endpoint3 Enable */
+#define USBC_UERST_EPEN3            (_U(0x1) << USBC_UERST_EPEN3_Pos)
+#define USBC_UERST_EPEN4_Pos        4            /**< \brief (USBC_UERST) Endpoint4 Enable */
+#define USBC_UERST_EPEN4            (_U(0x1) << USBC_UERST_EPEN4_Pos)
+#define USBC_UERST_EPEN5_Pos        5            /**< \brief (USBC_UERST) Endpoint5 Enable */
+#define USBC_UERST_EPEN5            (_U(0x1) << USBC_UERST_EPEN5_Pos)
+#define USBC_UERST_EPEN6_Pos        6            /**< \brief (USBC_UERST) Endpoint6 Enable */
+#define USBC_UERST_EPEN6            (_U(0x1) << USBC_UERST_EPEN6_Pos)
+#define USBC_UERST_EPEN7_Pos        7            /**< \brief (USBC_UERST) Endpoint7 Enable */
+#define USBC_UERST_EPEN7            (_U(0x1) << USBC_UERST_EPEN7_Pos)
+#define USBC_UERST_MASK             _U(0x000000FF) /**< \brief (USBC_UERST) MASK Register */
+
+/* -------- USBC_UDFNUM : (USBC Offset: 0x020) (R/  32) Device Frame Number Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t MFNUM:3;          /*!< bit:  0.. 2  Micro Frame Number                 */
+    uint32_t FNUM:11;          /*!< bit:  3..13  Frame Number                       */
+    uint32_t :1;               /*!< bit:     14  Reserved                           */
+    uint32_t FNCERR:1;         /*!< bit:     15  Frame Number CRC Error             */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UDFNUM_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UDFNUM_OFFSET          0x020        /**< \brief (USBC_UDFNUM offset) Device Frame Number Register */
+#define USBC_UDFNUM_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UDFNUM reset_value) Device Frame Number Register */
+
+#define USBC_UDFNUM_MFNUM_Pos       0            /**< \brief (USBC_UDFNUM) Micro Frame Number */
+#define USBC_UDFNUM_MFNUM_Msk       (_U(0x7) << USBC_UDFNUM_MFNUM_Pos)
+#define USBC_UDFNUM_MFNUM(value)    (USBC_UDFNUM_MFNUM_Msk & ((value) << USBC_UDFNUM_MFNUM_Pos))
+#define USBC_UDFNUM_FNUM_Pos        3            /**< \brief (USBC_UDFNUM) Frame Number */
+#define USBC_UDFNUM_FNUM_Msk        (_U(0x7FF) << USBC_UDFNUM_FNUM_Pos)
+#define USBC_UDFNUM_FNUM(value)     (USBC_UDFNUM_FNUM_Msk & ((value) << USBC_UDFNUM_FNUM_Pos))
+#define USBC_UDFNUM_FNCERR_Pos      15           /**< \brief (USBC_UDFNUM) Frame Number CRC Error */
+#define USBC_UDFNUM_FNCERR          (_U(0x1) << USBC_UDFNUM_FNCERR_Pos)
+#define USBC_UDFNUM_MASK            _U(0x0000BFFF) /**< \brief (USBC_UDFNUM) MASK Register */
+
+/* -------- USBC_UECFG0 : (USBC Offset: 0x100) (R/W 32) Endpoint Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t EPBK:1;           /*!< bit:      2  Endpoint Bank                      */
+    uint32_t :1;               /*!< bit:      3  Reserved                           */
+    uint32_t EPSIZE:3;         /*!< bit:  4.. 6  Endpoint Size                      */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t EPDIR:1;          /*!< bit:      8  Endpoint Direction                 */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t EPTYPE:2;         /*!< bit: 11..12  Endpoint Type                      */
+    uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t REPNB:4;          /*!< bit: 16..19  Redirected Endpoint Number         */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECFG0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECFG0_OFFSET          0x100        /**< \brief (USBC_UECFG0 offset) Endpoint Configuration Register */
+#define USBC_UECFG0_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECFG0 reset_value) Endpoint Configuration Register */
+
+#define USBC_UECFG0_EPBK_Pos        2            /**< \brief (USBC_UECFG0) Endpoint Bank */
+#define USBC_UECFG0_EPBK            (_U(0x1) << USBC_UECFG0_EPBK_Pos)
+#define   USBC_UECFG0_EPBK_SINGLE_Val     _U(0x0)   /**< \brief (USBC_UECFG0)  */
+#define   USBC_UECFG0_EPBK_DOUBLE_Val     _U(0x1)   /**< \brief (USBC_UECFG0)  */
+#define USBC_UECFG0_EPBK_SINGLE     (USBC_UECFG0_EPBK_SINGLE_Val   << USBC_UECFG0_EPBK_Pos)
+#define USBC_UECFG0_EPBK_DOUBLE     (USBC_UECFG0_EPBK_DOUBLE_Val   << USBC_UECFG0_EPBK_Pos)
+#define USBC_UECFG0_EPSIZE_Pos      4            /**< \brief (USBC_UECFG0) Endpoint Size */
+#define USBC_UECFG0_EPSIZE_Msk      (_U(0x7) << USBC_UECFG0_EPSIZE_Pos)
+#define USBC_UECFG0_EPSIZE(value)   (USBC_UECFG0_EPSIZE_Msk & ((value) << USBC_UECFG0_EPSIZE_Pos))
+#define   USBC_UECFG0_EPSIZE_8_Val        _U(0x0)   /**< \brief (USBC_UECFG0)  */
+#define   USBC_UECFG0_EPSIZE_16_Val       _U(0x1)   /**< \brief (USBC_UECFG0)  */
+#define   USBC_UECFG0_EPSIZE_32_Val       _U(0x2)   /**< \brief (USBC_UECFG0)  */
+#define   USBC_UECFG0_EPSIZE_64_Val       _U(0x3)   /**< \brief (USBC_UECFG0)  */
+#define   USBC_UECFG0_EPSIZE_128_Val      _U(0x4)   /**< \brief (USBC_UECFG0)  */
+#define   USBC_UECFG0_EPSIZE_256_Val      _U(0x5)   /**< \brief (USBC_UECFG0)  */
+#define   USBC_UECFG0_EPSIZE_512_Val      _U(0x6)   /**< \brief (USBC_UECFG0)  */
+#define   USBC_UECFG0_EPSIZE_1024_Val     _U(0x7)   /**< \brief (USBC_UECFG0)  */
+#define USBC_UECFG0_EPSIZE_8        (USBC_UECFG0_EPSIZE_8_Val      << USBC_UECFG0_EPSIZE_Pos)
+#define USBC_UECFG0_EPSIZE_16       (USBC_UECFG0_EPSIZE_16_Val     << USBC_UECFG0_EPSIZE_Pos)
+#define USBC_UECFG0_EPSIZE_32       (USBC_UECFG0_EPSIZE_32_Val     << USBC_UECFG0_EPSIZE_Pos)
+#define USBC_UECFG0_EPSIZE_64       (USBC_UECFG0_EPSIZE_64_Val     << USBC_UECFG0_EPSIZE_Pos)
+#define USBC_UECFG0_EPSIZE_128      (USBC_UECFG0_EPSIZE_128_Val    << USBC_UECFG0_EPSIZE_Pos)
+#define USBC_UECFG0_EPSIZE_256      (USBC_UECFG0_EPSIZE_256_Val    << USBC_UECFG0_EPSIZE_Pos)
+#define USBC_UECFG0_EPSIZE_512      (USBC_UECFG0_EPSIZE_512_Val    << USBC_UECFG0_EPSIZE_Pos)
+#define USBC_UECFG0_EPSIZE_1024     (USBC_UECFG0_EPSIZE_1024_Val   << USBC_UECFG0_EPSIZE_Pos)
+#define USBC_UECFG0_EPDIR_Pos       8            /**< \brief (USBC_UECFG0) Endpoint Direction */
+#define USBC_UECFG0_EPDIR           (_U(0x1) << USBC_UECFG0_EPDIR_Pos)
+#define   USBC_UECFG0_EPDIR_OUT_Val       _U(0x0)   /**< \brief (USBC_UECFG0)  */
+#define   USBC_UECFG0_EPDIR_IN_Val        _U(0x1)   /**< \brief (USBC_UECFG0)  */
+#define USBC_UECFG0_EPDIR_OUT       (USBC_UECFG0_EPDIR_OUT_Val     << USBC_UECFG0_EPDIR_Pos)
+#define USBC_UECFG0_EPDIR_IN        (USBC_UECFG0_EPDIR_IN_Val      << USBC_UECFG0_EPDIR_Pos)
+#define USBC_UECFG0_EPTYPE_Pos      11           /**< \brief (USBC_UECFG0) Endpoint Type */
+#define USBC_UECFG0_EPTYPE_Msk      (_U(0x3) << USBC_UECFG0_EPTYPE_Pos)
+#define USBC_UECFG0_EPTYPE(value)   (USBC_UECFG0_EPTYPE_Msk & ((value) << USBC_UECFG0_EPTYPE_Pos))
+#define   USBC_UECFG0_EPTYPE_CONTROL_Val  _U(0x0)   /**< \brief (USBC_UECFG0)  */
+#define   USBC_UECFG0_EPTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UECFG0)  */
+#define   USBC_UECFG0_EPTYPE_BULK_Val     _U(0x2)   /**< \brief (USBC_UECFG0)  */
+#define   USBC_UECFG0_EPTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UECFG0)  */
+#define USBC_UECFG0_EPTYPE_CONTROL  (USBC_UECFG0_EPTYPE_CONTROL_Val << USBC_UECFG0_EPTYPE_Pos)
+#define USBC_UECFG0_EPTYPE_ISOCHRONOUS (USBC_UECFG0_EPTYPE_ISOCHRONOUS_Val << USBC_UECFG0_EPTYPE_Pos)
+#define USBC_UECFG0_EPTYPE_BULK     (USBC_UECFG0_EPTYPE_BULK_Val   << USBC_UECFG0_EPTYPE_Pos)
+#define USBC_UECFG0_EPTYPE_INTERRUPT (USBC_UECFG0_EPTYPE_INTERRUPT_Val << USBC_UECFG0_EPTYPE_Pos)
+#define USBC_UECFG0_REPNB_Pos       16           /**< \brief (USBC_UECFG0) Redirected Endpoint Number */
+#define USBC_UECFG0_REPNB_Msk       (_U(0xF) << USBC_UECFG0_REPNB_Pos)
+#define USBC_UECFG0_REPNB(value)    (USBC_UECFG0_REPNB_Msk & ((value) << USBC_UECFG0_REPNB_Pos))
+#define USBC_UECFG0_MASK            _U(0x000F1974) /**< \brief (USBC_UECFG0) MASK Register */
+
+/* -------- USBC_UECFG1 : (USBC Offset: 0x104) (R/W 32) Endpoint Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t EPBK:1;           /*!< bit:      2  Endpoint Bank                      */
+    uint32_t :1;               /*!< bit:      3  Reserved                           */
+    uint32_t EPSIZE:3;         /*!< bit:  4.. 6  Endpoint Size                      */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t EPDIR:1;          /*!< bit:      8  Endpoint Direction                 */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t EPTYPE:2;         /*!< bit: 11..12  Endpoint Type                      */
+    uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t REPNB:4;          /*!< bit: 16..19  Redirected Endpoint Number         */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECFG1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECFG1_OFFSET          0x104        /**< \brief (USBC_UECFG1 offset) Endpoint Configuration Register */
+#define USBC_UECFG1_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECFG1 reset_value) Endpoint Configuration Register */
+
+#define USBC_UECFG1_EPBK_Pos        2            /**< \brief (USBC_UECFG1) Endpoint Bank */
+#define USBC_UECFG1_EPBK            (_U(0x1) << USBC_UECFG1_EPBK_Pos)
+#define   USBC_UECFG1_EPBK_SINGLE_Val     _U(0x0)   /**< \brief (USBC_UECFG1)  */
+#define   USBC_UECFG1_EPBK_DOUBLE_Val     _U(0x1)   /**< \brief (USBC_UECFG1)  */
+#define USBC_UECFG1_EPBK_SINGLE     (USBC_UECFG1_EPBK_SINGLE_Val   << USBC_UECFG1_EPBK_Pos)
+#define USBC_UECFG1_EPBK_DOUBLE     (USBC_UECFG1_EPBK_DOUBLE_Val   << USBC_UECFG1_EPBK_Pos)
+#define USBC_UECFG1_EPSIZE_Pos      4            /**< \brief (USBC_UECFG1) Endpoint Size */
+#define USBC_UECFG1_EPSIZE_Msk      (_U(0x7) << USBC_UECFG1_EPSIZE_Pos)
+#define USBC_UECFG1_EPSIZE(value)   (USBC_UECFG1_EPSIZE_Msk & ((value) << USBC_UECFG1_EPSIZE_Pos))
+#define   USBC_UECFG1_EPSIZE_8_Val        _U(0x0)   /**< \brief (USBC_UECFG1)  */
+#define   USBC_UECFG1_EPSIZE_16_Val       _U(0x1)   /**< \brief (USBC_UECFG1)  */
+#define   USBC_UECFG1_EPSIZE_32_Val       _U(0x2)   /**< \brief (USBC_UECFG1)  */
+#define   USBC_UECFG1_EPSIZE_64_Val       _U(0x3)   /**< \brief (USBC_UECFG1)  */
+#define   USBC_UECFG1_EPSIZE_128_Val      _U(0x4)   /**< \brief (USBC_UECFG1)  */
+#define   USBC_UECFG1_EPSIZE_256_Val      _U(0x5)   /**< \brief (USBC_UECFG1)  */
+#define   USBC_UECFG1_EPSIZE_512_Val      _U(0x6)   /**< \brief (USBC_UECFG1)  */
+#define   USBC_UECFG1_EPSIZE_1024_Val     _U(0x7)   /**< \brief (USBC_UECFG1)  */
+#define USBC_UECFG1_EPSIZE_8        (USBC_UECFG1_EPSIZE_8_Val      << USBC_UECFG1_EPSIZE_Pos)
+#define USBC_UECFG1_EPSIZE_16       (USBC_UECFG1_EPSIZE_16_Val     << USBC_UECFG1_EPSIZE_Pos)
+#define USBC_UECFG1_EPSIZE_32       (USBC_UECFG1_EPSIZE_32_Val     << USBC_UECFG1_EPSIZE_Pos)
+#define USBC_UECFG1_EPSIZE_64       (USBC_UECFG1_EPSIZE_64_Val     << USBC_UECFG1_EPSIZE_Pos)
+#define USBC_UECFG1_EPSIZE_128      (USBC_UECFG1_EPSIZE_128_Val    << USBC_UECFG1_EPSIZE_Pos)
+#define USBC_UECFG1_EPSIZE_256      (USBC_UECFG1_EPSIZE_256_Val    << USBC_UECFG1_EPSIZE_Pos)
+#define USBC_UECFG1_EPSIZE_512      (USBC_UECFG1_EPSIZE_512_Val    << USBC_UECFG1_EPSIZE_Pos)
+#define USBC_UECFG1_EPSIZE_1024     (USBC_UECFG1_EPSIZE_1024_Val   << USBC_UECFG1_EPSIZE_Pos)
+#define USBC_UECFG1_EPDIR_Pos       8            /**< \brief (USBC_UECFG1) Endpoint Direction */
+#define USBC_UECFG1_EPDIR           (_U(0x1) << USBC_UECFG1_EPDIR_Pos)
+#define   USBC_UECFG1_EPDIR_OUT_Val       _U(0x0)   /**< \brief (USBC_UECFG1)  */
+#define   USBC_UECFG1_EPDIR_IN_Val        _U(0x1)   /**< \brief (USBC_UECFG1)  */
+#define USBC_UECFG1_EPDIR_OUT       (USBC_UECFG1_EPDIR_OUT_Val     << USBC_UECFG1_EPDIR_Pos)
+#define USBC_UECFG1_EPDIR_IN        (USBC_UECFG1_EPDIR_IN_Val      << USBC_UECFG1_EPDIR_Pos)
+#define USBC_UECFG1_EPTYPE_Pos      11           /**< \brief (USBC_UECFG1) Endpoint Type */
+#define USBC_UECFG1_EPTYPE_Msk      (_U(0x3) << USBC_UECFG1_EPTYPE_Pos)
+#define USBC_UECFG1_EPTYPE(value)   (USBC_UECFG1_EPTYPE_Msk & ((value) << USBC_UECFG1_EPTYPE_Pos))
+#define   USBC_UECFG1_EPTYPE_CONTROL_Val  _U(0x0)   /**< \brief (USBC_UECFG1)  */
+#define   USBC_UECFG1_EPTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UECFG1)  */
+#define   USBC_UECFG1_EPTYPE_BULK_Val     _U(0x2)   /**< \brief (USBC_UECFG1)  */
+#define   USBC_UECFG1_EPTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UECFG1)  */
+#define USBC_UECFG1_EPTYPE_CONTROL  (USBC_UECFG1_EPTYPE_CONTROL_Val << USBC_UECFG1_EPTYPE_Pos)
+#define USBC_UECFG1_EPTYPE_ISOCHRONOUS (USBC_UECFG1_EPTYPE_ISOCHRONOUS_Val << USBC_UECFG1_EPTYPE_Pos)
+#define USBC_UECFG1_EPTYPE_BULK     (USBC_UECFG1_EPTYPE_BULK_Val   << USBC_UECFG1_EPTYPE_Pos)
+#define USBC_UECFG1_EPTYPE_INTERRUPT (USBC_UECFG1_EPTYPE_INTERRUPT_Val << USBC_UECFG1_EPTYPE_Pos)
+#define USBC_UECFG1_REPNB_Pos       16           /**< \brief (USBC_UECFG1) Redirected Endpoint Number */
+#define USBC_UECFG1_REPNB_Msk       (_U(0xF) << USBC_UECFG1_REPNB_Pos)
+#define USBC_UECFG1_REPNB(value)    (USBC_UECFG1_REPNB_Msk & ((value) << USBC_UECFG1_REPNB_Pos))
+#define USBC_UECFG1_MASK            _U(0x000F1974) /**< \brief (USBC_UECFG1) MASK Register */
+
+/* -------- USBC_UECFG2 : (USBC Offset: 0x108) (R/W 32) Endpoint Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t EPBK:1;           /*!< bit:      2  Endpoint Bank                      */
+    uint32_t :1;               /*!< bit:      3  Reserved                           */
+    uint32_t EPSIZE:3;         /*!< bit:  4.. 6  Endpoint Size                      */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t EPDIR:1;          /*!< bit:      8  Endpoint Direction                 */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t EPTYPE:2;         /*!< bit: 11..12  Endpoint Type                      */
+    uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t REPNB:4;          /*!< bit: 16..19  Redirected Endpoint Number         */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECFG2_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECFG2_OFFSET          0x108        /**< \brief (USBC_UECFG2 offset) Endpoint Configuration Register */
+#define USBC_UECFG2_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECFG2 reset_value) Endpoint Configuration Register */
+
+#define USBC_UECFG2_EPBK_Pos        2            /**< \brief (USBC_UECFG2) Endpoint Bank */
+#define USBC_UECFG2_EPBK            (_U(0x1) << USBC_UECFG2_EPBK_Pos)
+#define   USBC_UECFG2_EPBK_SINGLE_Val     _U(0x0)   /**< \brief (USBC_UECFG2)  */
+#define   USBC_UECFG2_EPBK_DOUBLE_Val     _U(0x1)   /**< \brief (USBC_UECFG2)  */
+#define USBC_UECFG2_EPBK_SINGLE     (USBC_UECFG2_EPBK_SINGLE_Val   << USBC_UECFG2_EPBK_Pos)
+#define USBC_UECFG2_EPBK_DOUBLE     (USBC_UECFG2_EPBK_DOUBLE_Val   << USBC_UECFG2_EPBK_Pos)
+#define USBC_UECFG2_EPSIZE_Pos      4            /**< \brief (USBC_UECFG2) Endpoint Size */
+#define USBC_UECFG2_EPSIZE_Msk      (_U(0x7) << USBC_UECFG2_EPSIZE_Pos)
+#define USBC_UECFG2_EPSIZE(value)   (USBC_UECFG2_EPSIZE_Msk & ((value) << USBC_UECFG2_EPSIZE_Pos))
+#define   USBC_UECFG2_EPSIZE_8_Val        _U(0x0)   /**< \brief (USBC_UECFG2)  */
+#define   USBC_UECFG2_EPSIZE_16_Val       _U(0x1)   /**< \brief (USBC_UECFG2)  */
+#define   USBC_UECFG2_EPSIZE_32_Val       _U(0x2)   /**< \brief (USBC_UECFG2)  */
+#define   USBC_UECFG2_EPSIZE_64_Val       _U(0x3)   /**< \brief (USBC_UECFG2)  */
+#define   USBC_UECFG2_EPSIZE_128_Val      _U(0x4)   /**< \brief (USBC_UECFG2)  */
+#define   USBC_UECFG2_EPSIZE_256_Val      _U(0x5)   /**< \brief (USBC_UECFG2)  */
+#define   USBC_UECFG2_EPSIZE_512_Val      _U(0x6)   /**< \brief (USBC_UECFG2)  */
+#define   USBC_UECFG2_EPSIZE_1024_Val     _U(0x7)   /**< \brief (USBC_UECFG2)  */
+#define USBC_UECFG2_EPSIZE_8        (USBC_UECFG2_EPSIZE_8_Val      << USBC_UECFG2_EPSIZE_Pos)
+#define USBC_UECFG2_EPSIZE_16       (USBC_UECFG2_EPSIZE_16_Val     << USBC_UECFG2_EPSIZE_Pos)
+#define USBC_UECFG2_EPSIZE_32       (USBC_UECFG2_EPSIZE_32_Val     << USBC_UECFG2_EPSIZE_Pos)
+#define USBC_UECFG2_EPSIZE_64       (USBC_UECFG2_EPSIZE_64_Val     << USBC_UECFG2_EPSIZE_Pos)
+#define USBC_UECFG2_EPSIZE_128      (USBC_UECFG2_EPSIZE_128_Val    << USBC_UECFG2_EPSIZE_Pos)
+#define USBC_UECFG2_EPSIZE_256      (USBC_UECFG2_EPSIZE_256_Val    << USBC_UECFG2_EPSIZE_Pos)
+#define USBC_UECFG2_EPSIZE_512      (USBC_UECFG2_EPSIZE_512_Val    << USBC_UECFG2_EPSIZE_Pos)
+#define USBC_UECFG2_EPSIZE_1024     (USBC_UECFG2_EPSIZE_1024_Val   << USBC_UECFG2_EPSIZE_Pos)
+#define USBC_UECFG2_EPDIR_Pos       8            /**< \brief (USBC_UECFG2) Endpoint Direction */
+#define USBC_UECFG2_EPDIR           (_U(0x1) << USBC_UECFG2_EPDIR_Pos)
+#define   USBC_UECFG2_EPDIR_OUT_Val       _U(0x0)   /**< \brief (USBC_UECFG2)  */
+#define   USBC_UECFG2_EPDIR_IN_Val        _U(0x1)   /**< \brief (USBC_UECFG2)  */
+#define USBC_UECFG2_EPDIR_OUT       (USBC_UECFG2_EPDIR_OUT_Val     << USBC_UECFG2_EPDIR_Pos)
+#define USBC_UECFG2_EPDIR_IN        (USBC_UECFG2_EPDIR_IN_Val      << USBC_UECFG2_EPDIR_Pos)
+#define USBC_UECFG2_EPTYPE_Pos      11           /**< \brief (USBC_UECFG2) Endpoint Type */
+#define USBC_UECFG2_EPTYPE_Msk      (_U(0x3) << USBC_UECFG2_EPTYPE_Pos)
+#define USBC_UECFG2_EPTYPE(value)   (USBC_UECFG2_EPTYPE_Msk & ((value) << USBC_UECFG2_EPTYPE_Pos))
+#define   USBC_UECFG2_EPTYPE_CONTROL_Val  _U(0x0)   /**< \brief (USBC_UECFG2)  */
+#define   USBC_UECFG2_EPTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UECFG2)  */
+#define   USBC_UECFG2_EPTYPE_BULK_Val     _U(0x2)   /**< \brief (USBC_UECFG2)  */
+#define   USBC_UECFG2_EPTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UECFG2)  */
+#define USBC_UECFG2_EPTYPE_CONTROL  (USBC_UECFG2_EPTYPE_CONTROL_Val << USBC_UECFG2_EPTYPE_Pos)
+#define USBC_UECFG2_EPTYPE_ISOCHRONOUS (USBC_UECFG2_EPTYPE_ISOCHRONOUS_Val << USBC_UECFG2_EPTYPE_Pos)
+#define USBC_UECFG2_EPTYPE_BULK     (USBC_UECFG2_EPTYPE_BULK_Val   << USBC_UECFG2_EPTYPE_Pos)
+#define USBC_UECFG2_EPTYPE_INTERRUPT (USBC_UECFG2_EPTYPE_INTERRUPT_Val << USBC_UECFG2_EPTYPE_Pos)
+#define USBC_UECFG2_REPNB_Pos       16           /**< \brief (USBC_UECFG2) Redirected Endpoint Number */
+#define USBC_UECFG2_REPNB_Msk       (_U(0xF) << USBC_UECFG2_REPNB_Pos)
+#define USBC_UECFG2_REPNB(value)    (USBC_UECFG2_REPNB_Msk & ((value) << USBC_UECFG2_REPNB_Pos))
+#define USBC_UECFG2_MASK            _U(0x000F1974) /**< \brief (USBC_UECFG2) MASK Register */
+
+/* -------- USBC_UECFG3 : (USBC Offset: 0x10C) (R/W 32) Endpoint Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t EPBK:1;           /*!< bit:      2  Endpoint Bank                      */
+    uint32_t :1;               /*!< bit:      3  Reserved                           */
+    uint32_t EPSIZE:3;         /*!< bit:  4.. 6  Endpoint Size                      */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t EPDIR:1;          /*!< bit:      8  Endpoint Direction                 */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t EPTYPE:2;         /*!< bit: 11..12  Endpoint Type                      */
+    uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t REPNB:4;          /*!< bit: 16..19  Redirected Endpoint Number         */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECFG3_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECFG3_OFFSET          0x10C        /**< \brief (USBC_UECFG3 offset) Endpoint Configuration Register */
+#define USBC_UECFG3_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECFG3 reset_value) Endpoint Configuration Register */
+
+#define USBC_UECFG3_EPBK_Pos        2            /**< \brief (USBC_UECFG3) Endpoint Bank */
+#define USBC_UECFG3_EPBK            (_U(0x1) << USBC_UECFG3_EPBK_Pos)
+#define   USBC_UECFG3_EPBK_SINGLE_Val     _U(0x0)   /**< \brief (USBC_UECFG3)  */
+#define   USBC_UECFG3_EPBK_DOUBLE_Val     _U(0x1)   /**< \brief (USBC_UECFG3)  */
+#define USBC_UECFG3_EPBK_SINGLE     (USBC_UECFG3_EPBK_SINGLE_Val   << USBC_UECFG3_EPBK_Pos)
+#define USBC_UECFG3_EPBK_DOUBLE     (USBC_UECFG3_EPBK_DOUBLE_Val   << USBC_UECFG3_EPBK_Pos)
+#define USBC_UECFG3_EPSIZE_Pos      4            /**< \brief (USBC_UECFG3) Endpoint Size */
+#define USBC_UECFG3_EPSIZE_Msk      (_U(0x7) << USBC_UECFG3_EPSIZE_Pos)
+#define USBC_UECFG3_EPSIZE(value)   (USBC_UECFG3_EPSIZE_Msk & ((value) << USBC_UECFG3_EPSIZE_Pos))
+#define   USBC_UECFG3_EPSIZE_8_Val        _U(0x0)   /**< \brief (USBC_UECFG3)  */
+#define   USBC_UECFG3_EPSIZE_16_Val       _U(0x1)   /**< \brief (USBC_UECFG3)  */
+#define   USBC_UECFG3_EPSIZE_32_Val       _U(0x2)   /**< \brief (USBC_UECFG3)  */
+#define   USBC_UECFG3_EPSIZE_64_Val       _U(0x3)   /**< \brief (USBC_UECFG3)  */
+#define   USBC_UECFG3_EPSIZE_128_Val      _U(0x4)   /**< \brief (USBC_UECFG3)  */
+#define   USBC_UECFG3_EPSIZE_256_Val      _U(0x5)   /**< \brief (USBC_UECFG3)  */
+#define   USBC_UECFG3_EPSIZE_512_Val      _U(0x6)   /**< \brief (USBC_UECFG3)  */
+#define   USBC_UECFG3_EPSIZE_1024_Val     _U(0x7)   /**< \brief (USBC_UECFG3)  */
+#define USBC_UECFG3_EPSIZE_8        (USBC_UECFG3_EPSIZE_8_Val      << USBC_UECFG3_EPSIZE_Pos)
+#define USBC_UECFG3_EPSIZE_16       (USBC_UECFG3_EPSIZE_16_Val     << USBC_UECFG3_EPSIZE_Pos)
+#define USBC_UECFG3_EPSIZE_32       (USBC_UECFG3_EPSIZE_32_Val     << USBC_UECFG3_EPSIZE_Pos)
+#define USBC_UECFG3_EPSIZE_64       (USBC_UECFG3_EPSIZE_64_Val     << USBC_UECFG3_EPSIZE_Pos)
+#define USBC_UECFG3_EPSIZE_128      (USBC_UECFG3_EPSIZE_128_Val    << USBC_UECFG3_EPSIZE_Pos)
+#define USBC_UECFG3_EPSIZE_256      (USBC_UECFG3_EPSIZE_256_Val    << USBC_UECFG3_EPSIZE_Pos)
+#define USBC_UECFG3_EPSIZE_512      (USBC_UECFG3_EPSIZE_512_Val    << USBC_UECFG3_EPSIZE_Pos)
+#define USBC_UECFG3_EPSIZE_1024     (USBC_UECFG3_EPSIZE_1024_Val   << USBC_UECFG3_EPSIZE_Pos)
+#define USBC_UECFG3_EPDIR_Pos       8            /**< \brief (USBC_UECFG3) Endpoint Direction */
+#define USBC_UECFG3_EPDIR           (_U(0x1) << USBC_UECFG3_EPDIR_Pos)
+#define   USBC_UECFG3_EPDIR_OUT_Val       _U(0x0)   /**< \brief (USBC_UECFG3)  */
+#define   USBC_UECFG3_EPDIR_IN_Val        _U(0x1)   /**< \brief (USBC_UECFG3)  */
+#define USBC_UECFG3_EPDIR_OUT       (USBC_UECFG3_EPDIR_OUT_Val     << USBC_UECFG3_EPDIR_Pos)
+#define USBC_UECFG3_EPDIR_IN        (USBC_UECFG3_EPDIR_IN_Val      << USBC_UECFG3_EPDIR_Pos)
+#define USBC_UECFG3_EPTYPE_Pos      11           /**< \brief (USBC_UECFG3) Endpoint Type */
+#define USBC_UECFG3_EPTYPE_Msk      (_U(0x3) << USBC_UECFG3_EPTYPE_Pos)
+#define USBC_UECFG3_EPTYPE(value)   (USBC_UECFG3_EPTYPE_Msk & ((value) << USBC_UECFG3_EPTYPE_Pos))
+#define   USBC_UECFG3_EPTYPE_CONTROL_Val  _U(0x0)   /**< \brief (USBC_UECFG3)  */
+#define   USBC_UECFG3_EPTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UECFG3)  */
+#define   USBC_UECFG3_EPTYPE_BULK_Val     _U(0x2)   /**< \brief (USBC_UECFG3)  */
+#define   USBC_UECFG3_EPTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UECFG3)  */
+#define USBC_UECFG3_EPTYPE_CONTROL  (USBC_UECFG3_EPTYPE_CONTROL_Val << USBC_UECFG3_EPTYPE_Pos)
+#define USBC_UECFG3_EPTYPE_ISOCHRONOUS (USBC_UECFG3_EPTYPE_ISOCHRONOUS_Val << USBC_UECFG3_EPTYPE_Pos)
+#define USBC_UECFG3_EPTYPE_BULK     (USBC_UECFG3_EPTYPE_BULK_Val   << USBC_UECFG3_EPTYPE_Pos)
+#define USBC_UECFG3_EPTYPE_INTERRUPT (USBC_UECFG3_EPTYPE_INTERRUPT_Val << USBC_UECFG3_EPTYPE_Pos)
+#define USBC_UECFG3_REPNB_Pos       16           /**< \brief (USBC_UECFG3) Redirected Endpoint Number */
+#define USBC_UECFG3_REPNB_Msk       (_U(0xF) << USBC_UECFG3_REPNB_Pos)
+#define USBC_UECFG3_REPNB(value)    (USBC_UECFG3_REPNB_Msk & ((value) << USBC_UECFG3_REPNB_Pos))
+#define USBC_UECFG3_MASK            _U(0x000F1974) /**< \brief (USBC_UECFG3) MASK Register */
+
+/* -------- USBC_UECFG4 : (USBC Offset: 0x110) (R/W 32) Endpoint Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t EPBK:1;           /*!< bit:      2  Endpoint Bank                      */
+    uint32_t :1;               /*!< bit:      3  Reserved                           */
+    uint32_t EPSIZE:3;         /*!< bit:  4.. 6  Endpoint Size                      */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t EPDIR:1;          /*!< bit:      8  Endpoint Direction                 */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t EPTYPE:2;         /*!< bit: 11..12  Endpoint Type                      */
+    uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t REPNB:4;          /*!< bit: 16..19  Redirected Endpoint Number         */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECFG4_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECFG4_OFFSET          0x110        /**< \brief (USBC_UECFG4 offset) Endpoint Configuration Register */
+#define USBC_UECFG4_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECFG4 reset_value) Endpoint Configuration Register */
+
+#define USBC_UECFG4_EPBK_Pos        2            /**< \brief (USBC_UECFG4) Endpoint Bank */
+#define USBC_UECFG4_EPBK            (_U(0x1) << USBC_UECFG4_EPBK_Pos)
+#define   USBC_UECFG4_EPBK_SINGLE_Val     _U(0x0)   /**< \brief (USBC_UECFG4)  */
+#define   USBC_UECFG4_EPBK_DOUBLE_Val     _U(0x1)   /**< \brief (USBC_UECFG4)  */
+#define USBC_UECFG4_EPBK_SINGLE     (USBC_UECFG4_EPBK_SINGLE_Val   << USBC_UECFG4_EPBK_Pos)
+#define USBC_UECFG4_EPBK_DOUBLE     (USBC_UECFG4_EPBK_DOUBLE_Val   << USBC_UECFG4_EPBK_Pos)
+#define USBC_UECFG4_EPSIZE_Pos      4            /**< \brief (USBC_UECFG4) Endpoint Size */
+#define USBC_UECFG4_EPSIZE_Msk      (_U(0x7) << USBC_UECFG4_EPSIZE_Pos)
+#define USBC_UECFG4_EPSIZE(value)   (USBC_UECFG4_EPSIZE_Msk & ((value) << USBC_UECFG4_EPSIZE_Pos))
+#define   USBC_UECFG4_EPSIZE_8_Val        _U(0x0)   /**< \brief (USBC_UECFG4)  */
+#define   USBC_UECFG4_EPSIZE_16_Val       _U(0x1)   /**< \brief (USBC_UECFG4)  */
+#define   USBC_UECFG4_EPSIZE_32_Val       _U(0x2)   /**< \brief (USBC_UECFG4)  */
+#define   USBC_UECFG4_EPSIZE_64_Val       _U(0x3)   /**< \brief (USBC_UECFG4)  */
+#define   USBC_UECFG4_EPSIZE_128_Val      _U(0x4)   /**< \brief (USBC_UECFG4)  */
+#define   USBC_UECFG4_EPSIZE_256_Val      _U(0x5)   /**< \brief (USBC_UECFG4)  */
+#define   USBC_UECFG4_EPSIZE_512_Val      _U(0x6)   /**< \brief (USBC_UECFG4)  */
+#define   USBC_UECFG4_EPSIZE_1024_Val     _U(0x7)   /**< \brief (USBC_UECFG4)  */
+#define USBC_UECFG4_EPSIZE_8        (USBC_UECFG4_EPSIZE_8_Val      << USBC_UECFG4_EPSIZE_Pos)
+#define USBC_UECFG4_EPSIZE_16       (USBC_UECFG4_EPSIZE_16_Val     << USBC_UECFG4_EPSIZE_Pos)
+#define USBC_UECFG4_EPSIZE_32       (USBC_UECFG4_EPSIZE_32_Val     << USBC_UECFG4_EPSIZE_Pos)
+#define USBC_UECFG4_EPSIZE_64       (USBC_UECFG4_EPSIZE_64_Val     << USBC_UECFG4_EPSIZE_Pos)
+#define USBC_UECFG4_EPSIZE_128      (USBC_UECFG4_EPSIZE_128_Val    << USBC_UECFG4_EPSIZE_Pos)
+#define USBC_UECFG4_EPSIZE_256      (USBC_UECFG4_EPSIZE_256_Val    << USBC_UECFG4_EPSIZE_Pos)
+#define USBC_UECFG4_EPSIZE_512      (USBC_UECFG4_EPSIZE_512_Val    << USBC_UECFG4_EPSIZE_Pos)
+#define USBC_UECFG4_EPSIZE_1024     (USBC_UECFG4_EPSIZE_1024_Val   << USBC_UECFG4_EPSIZE_Pos)
+#define USBC_UECFG4_EPDIR_Pos       8            /**< \brief (USBC_UECFG4) Endpoint Direction */
+#define USBC_UECFG4_EPDIR           (_U(0x1) << USBC_UECFG4_EPDIR_Pos)
+#define   USBC_UECFG4_EPDIR_OUT_Val       _U(0x0)   /**< \brief (USBC_UECFG4)  */
+#define   USBC_UECFG4_EPDIR_IN_Val        _U(0x1)   /**< \brief (USBC_UECFG4)  */
+#define USBC_UECFG4_EPDIR_OUT       (USBC_UECFG4_EPDIR_OUT_Val     << USBC_UECFG4_EPDIR_Pos)
+#define USBC_UECFG4_EPDIR_IN        (USBC_UECFG4_EPDIR_IN_Val      << USBC_UECFG4_EPDIR_Pos)
+#define USBC_UECFG4_EPTYPE_Pos      11           /**< \brief (USBC_UECFG4) Endpoint Type */
+#define USBC_UECFG4_EPTYPE_Msk      (_U(0x3) << USBC_UECFG4_EPTYPE_Pos)
+#define USBC_UECFG4_EPTYPE(value)   (USBC_UECFG4_EPTYPE_Msk & ((value) << USBC_UECFG4_EPTYPE_Pos))
+#define   USBC_UECFG4_EPTYPE_CONTROL_Val  _U(0x0)   /**< \brief (USBC_UECFG4)  */
+#define   USBC_UECFG4_EPTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UECFG4)  */
+#define   USBC_UECFG4_EPTYPE_BULK_Val     _U(0x2)   /**< \brief (USBC_UECFG4)  */
+#define   USBC_UECFG4_EPTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UECFG4)  */
+#define USBC_UECFG4_EPTYPE_CONTROL  (USBC_UECFG4_EPTYPE_CONTROL_Val << USBC_UECFG4_EPTYPE_Pos)
+#define USBC_UECFG4_EPTYPE_ISOCHRONOUS (USBC_UECFG4_EPTYPE_ISOCHRONOUS_Val << USBC_UECFG4_EPTYPE_Pos)
+#define USBC_UECFG4_EPTYPE_BULK     (USBC_UECFG4_EPTYPE_BULK_Val   << USBC_UECFG4_EPTYPE_Pos)
+#define USBC_UECFG4_EPTYPE_INTERRUPT (USBC_UECFG4_EPTYPE_INTERRUPT_Val << USBC_UECFG4_EPTYPE_Pos)
+#define USBC_UECFG4_REPNB_Pos       16           /**< \brief (USBC_UECFG4) Redirected Endpoint Number */
+#define USBC_UECFG4_REPNB_Msk       (_U(0xF) << USBC_UECFG4_REPNB_Pos)
+#define USBC_UECFG4_REPNB(value)    (USBC_UECFG4_REPNB_Msk & ((value) << USBC_UECFG4_REPNB_Pos))
+#define USBC_UECFG4_MASK            _U(0x000F1974) /**< \brief (USBC_UECFG4) MASK Register */
+
+/* -------- USBC_UECFG5 : (USBC Offset: 0x114) (R/W 32) Endpoint Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t EPBK:1;           /*!< bit:      2  Endpoint Bank                      */
+    uint32_t :1;               /*!< bit:      3  Reserved                           */
+    uint32_t EPSIZE:3;         /*!< bit:  4.. 6  Endpoint Size                      */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t EPDIR:1;          /*!< bit:      8  Endpoint Direction                 */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t EPTYPE:2;         /*!< bit: 11..12  Endpoint Type                      */
+    uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t REPNB:4;          /*!< bit: 16..19  Redirected Endpoint Number         */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECFG5_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECFG5_OFFSET          0x114        /**< \brief (USBC_UECFG5 offset) Endpoint Configuration Register */
+#define USBC_UECFG5_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECFG5 reset_value) Endpoint Configuration Register */
+
+#define USBC_UECFG5_EPBK_Pos        2            /**< \brief (USBC_UECFG5) Endpoint Bank */
+#define USBC_UECFG5_EPBK            (_U(0x1) << USBC_UECFG5_EPBK_Pos)
+#define   USBC_UECFG5_EPBK_SINGLE_Val     _U(0x0)   /**< \brief (USBC_UECFG5)  */
+#define   USBC_UECFG5_EPBK_DOUBLE_Val     _U(0x1)   /**< \brief (USBC_UECFG5)  */
+#define USBC_UECFG5_EPBK_SINGLE     (USBC_UECFG5_EPBK_SINGLE_Val   << USBC_UECFG5_EPBK_Pos)
+#define USBC_UECFG5_EPBK_DOUBLE     (USBC_UECFG5_EPBK_DOUBLE_Val   << USBC_UECFG5_EPBK_Pos)
+#define USBC_UECFG5_EPSIZE_Pos      4            /**< \brief (USBC_UECFG5) Endpoint Size */
+#define USBC_UECFG5_EPSIZE_Msk      (_U(0x7) << USBC_UECFG5_EPSIZE_Pos)
+#define USBC_UECFG5_EPSIZE(value)   (USBC_UECFG5_EPSIZE_Msk & ((value) << USBC_UECFG5_EPSIZE_Pos))
+#define   USBC_UECFG5_EPSIZE_8_Val        _U(0x0)   /**< \brief (USBC_UECFG5)  */
+#define   USBC_UECFG5_EPSIZE_16_Val       _U(0x1)   /**< \brief (USBC_UECFG5)  */
+#define   USBC_UECFG5_EPSIZE_32_Val       _U(0x2)   /**< \brief (USBC_UECFG5)  */
+#define   USBC_UECFG5_EPSIZE_64_Val       _U(0x3)   /**< \brief (USBC_UECFG5)  */
+#define   USBC_UECFG5_EPSIZE_128_Val      _U(0x4)   /**< \brief (USBC_UECFG5)  */
+#define   USBC_UECFG5_EPSIZE_256_Val      _U(0x5)   /**< \brief (USBC_UECFG5)  */
+#define   USBC_UECFG5_EPSIZE_512_Val      _U(0x6)   /**< \brief (USBC_UECFG5)  */
+#define   USBC_UECFG5_EPSIZE_1024_Val     _U(0x7)   /**< \brief (USBC_UECFG5)  */
+#define USBC_UECFG5_EPSIZE_8        (USBC_UECFG5_EPSIZE_8_Val      << USBC_UECFG5_EPSIZE_Pos)
+#define USBC_UECFG5_EPSIZE_16       (USBC_UECFG5_EPSIZE_16_Val     << USBC_UECFG5_EPSIZE_Pos)
+#define USBC_UECFG5_EPSIZE_32       (USBC_UECFG5_EPSIZE_32_Val     << USBC_UECFG5_EPSIZE_Pos)
+#define USBC_UECFG5_EPSIZE_64       (USBC_UECFG5_EPSIZE_64_Val     << USBC_UECFG5_EPSIZE_Pos)
+#define USBC_UECFG5_EPSIZE_128      (USBC_UECFG5_EPSIZE_128_Val    << USBC_UECFG5_EPSIZE_Pos)
+#define USBC_UECFG5_EPSIZE_256      (USBC_UECFG5_EPSIZE_256_Val    << USBC_UECFG5_EPSIZE_Pos)
+#define USBC_UECFG5_EPSIZE_512      (USBC_UECFG5_EPSIZE_512_Val    << USBC_UECFG5_EPSIZE_Pos)
+#define USBC_UECFG5_EPSIZE_1024     (USBC_UECFG5_EPSIZE_1024_Val   << USBC_UECFG5_EPSIZE_Pos)
+#define USBC_UECFG5_EPDIR_Pos       8            /**< \brief (USBC_UECFG5) Endpoint Direction */
+#define USBC_UECFG5_EPDIR           (_U(0x1) << USBC_UECFG5_EPDIR_Pos)
+#define   USBC_UECFG5_EPDIR_OUT_Val       _U(0x0)   /**< \brief (USBC_UECFG5)  */
+#define   USBC_UECFG5_EPDIR_IN_Val        _U(0x1)   /**< \brief (USBC_UECFG5)  */
+#define USBC_UECFG5_EPDIR_OUT       (USBC_UECFG5_EPDIR_OUT_Val     << USBC_UECFG5_EPDIR_Pos)
+#define USBC_UECFG5_EPDIR_IN        (USBC_UECFG5_EPDIR_IN_Val      << USBC_UECFG5_EPDIR_Pos)
+#define USBC_UECFG5_EPTYPE_Pos      11           /**< \brief (USBC_UECFG5) Endpoint Type */
+#define USBC_UECFG5_EPTYPE_Msk      (_U(0x3) << USBC_UECFG5_EPTYPE_Pos)
+#define USBC_UECFG5_EPTYPE(value)   (USBC_UECFG5_EPTYPE_Msk & ((value) << USBC_UECFG5_EPTYPE_Pos))
+#define   USBC_UECFG5_EPTYPE_CONTROL_Val  _U(0x0)   /**< \brief (USBC_UECFG5)  */
+#define   USBC_UECFG5_EPTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UECFG5)  */
+#define   USBC_UECFG5_EPTYPE_BULK_Val     _U(0x2)   /**< \brief (USBC_UECFG5)  */
+#define   USBC_UECFG5_EPTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UECFG5)  */
+#define USBC_UECFG5_EPTYPE_CONTROL  (USBC_UECFG5_EPTYPE_CONTROL_Val << USBC_UECFG5_EPTYPE_Pos)
+#define USBC_UECFG5_EPTYPE_ISOCHRONOUS (USBC_UECFG5_EPTYPE_ISOCHRONOUS_Val << USBC_UECFG5_EPTYPE_Pos)
+#define USBC_UECFG5_EPTYPE_BULK     (USBC_UECFG5_EPTYPE_BULK_Val   << USBC_UECFG5_EPTYPE_Pos)
+#define USBC_UECFG5_EPTYPE_INTERRUPT (USBC_UECFG5_EPTYPE_INTERRUPT_Val << USBC_UECFG5_EPTYPE_Pos)
+#define USBC_UECFG5_REPNB_Pos       16           /**< \brief (USBC_UECFG5) Redirected Endpoint Number */
+#define USBC_UECFG5_REPNB_Msk       (_U(0xF) << USBC_UECFG5_REPNB_Pos)
+#define USBC_UECFG5_REPNB(value)    (USBC_UECFG5_REPNB_Msk & ((value) << USBC_UECFG5_REPNB_Pos))
+#define USBC_UECFG5_MASK            _U(0x000F1974) /**< \brief (USBC_UECFG5) MASK Register */
+
+/* -------- USBC_UECFG6 : (USBC Offset: 0x118) (R/W 32) Endpoint Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t EPBK:1;           /*!< bit:      2  Endpoint Bank                      */
+    uint32_t :1;               /*!< bit:      3  Reserved                           */
+    uint32_t EPSIZE:3;         /*!< bit:  4.. 6  Endpoint Size                      */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t EPDIR:1;          /*!< bit:      8  Endpoint Direction                 */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t EPTYPE:2;         /*!< bit: 11..12  Endpoint Type                      */
+    uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t REPNB:4;          /*!< bit: 16..19  Redirected Endpoint Number         */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECFG6_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECFG6_OFFSET          0x118        /**< \brief (USBC_UECFG6 offset) Endpoint Configuration Register */
+#define USBC_UECFG6_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECFG6 reset_value) Endpoint Configuration Register */
+
+#define USBC_UECFG6_EPBK_Pos        2            /**< \brief (USBC_UECFG6) Endpoint Bank */
+#define USBC_UECFG6_EPBK            (_U(0x1) << USBC_UECFG6_EPBK_Pos)
+#define   USBC_UECFG6_EPBK_SINGLE_Val     _U(0x0)   /**< \brief (USBC_UECFG6)  */
+#define   USBC_UECFG6_EPBK_DOUBLE_Val     _U(0x1)   /**< \brief (USBC_UECFG6)  */
+#define USBC_UECFG6_EPBK_SINGLE     (USBC_UECFG6_EPBK_SINGLE_Val   << USBC_UECFG6_EPBK_Pos)
+#define USBC_UECFG6_EPBK_DOUBLE     (USBC_UECFG6_EPBK_DOUBLE_Val   << USBC_UECFG6_EPBK_Pos)
+#define USBC_UECFG6_EPSIZE_Pos      4            /**< \brief (USBC_UECFG6) Endpoint Size */
+#define USBC_UECFG6_EPSIZE_Msk      (_U(0x7) << USBC_UECFG6_EPSIZE_Pos)
+#define USBC_UECFG6_EPSIZE(value)   (USBC_UECFG6_EPSIZE_Msk & ((value) << USBC_UECFG6_EPSIZE_Pos))
+#define   USBC_UECFG6_EPSIZE_8_Val        _U(0x0)   /**< \brief (USBC_UECFG6)  */
+#define   USBC_UECFG6_EPSIZE_16_Val       _U(0x1)   /**< \brief (USBC_UECFG6)  */
+#define   USBC_UECFG6_EPSIZE_32_Val       _U(0x2)   /**< \brief (USBC_UECFG6)  */
+#define   USBC_UECFG6_EPSIZE_64_Val       _U(0x3)   /**< \brief (USBC_UECFG6)  */
+#define   USBC_UECFG6_EPSIZE_128_Val      _U(0x4)   /**< \brief (USBC_UECFG6)  */
+#define   USBC_UECFG6_EPSIZE_256_Val      _U(0x5)   /**< \brief (USBC_UECFG6)  */
+#define   USBC_UECFG6_EPSIZE_512_Val      _U(0x6)   /**< \brief (USBC_UECFG6)  */
+#define   USBC_UECFG6_EPSIZE_1024_Val     _U(0x7)   /**< \brief (USBC_UECFG6)  */
+#define USBC_UECFG6_EPSIZE_8        (USBC_UECFG6_EPSIZE_8_Val      << USBC_UECFG6_EPSIZE_Pos)
+#define USBC_UECFG6_EPSIZE_16       (USBC_UECFG6_EPSIZE_16_Val     << USBC_UECFG6_EPSIZE_Pos)
+#define USBC_UECFG6_EPSIZE_32       (USBC_UECFG6_EPSIZE_32_Val     << USBC_UECFG6_EPSIZE_Pos)
+#define USBC_UECFG6_EPSIZE_64       (USBC_UECFG6_EPSIZE_64_Val     << USBC_UECFG6_EPSIZE_Pos)
+#define USBC_UECFG6_EPSIZE_128      (USBC_UECFG6_EPSIZE_128_Val    << USBC_UECFG6_EPSIZE_Pos)
+#define USBC_UECFG6_EPSIZE_256      (USBC_UECFG6_EPSIZE_256_Val    << USBC_UECFG6_EPSIZE_Pos)
+#define USBC_UECFG6_EPSIZE_512      (USBC_UECFG6_EPSIZE_512_Val    << USBC_UECFG6_EPSIZE_Pos)
+#define USBC_UECFG6_EPSIZE_1024     (USBC_UECFG6_EPSIZE_1024_Val   << USBC_UECFG6_EPSIZE_Pos)
+#define USBC_UECFG6_EPDIR_Pos       8            /**< \brief (USBC_UECFG6) Endpoint Direction */
+#define USBC_UECFG6_EPDIR           (_U(0x1) << USBC_UECFG6_EPDIR_Pos)
+#define   USBC_UECFG6_EPDIR_OUT_Val       _U(0x0)   /**< \brief (USBC_UECFG6)  */
+#define   USBC_UECFG6_EPDIR_IN_Val        _U(0x1)   /**< \brief (USBC_UECFG6)  */
+#define USBC_UECFG6_EPDIR_OUT       (USBC_UECFG6_EPDIR_OUT_Val     << USBC_UECFG6_EPDIR_Pos)
+#define USBC_UECFG6_EPDIR_IN        (USBC_UECFG6_EPDIR_IN_Val      << USBC_UECFG6_EPDIR_Pos)
+#define USBC_UECFG6_EPTYPE_Pos      11           /**< \brief (USBC_UECFG6) Endpoint Type */
+#define USBC_UECFG6_EPTYPE_Msk      (_U(0x3) << USBC_UECFG6_EPTYPE_Pos)
+#define USBC_UECFG6_EPTYPE(value)   (USBC_UECFG6_EPTYPE_Msk & ((value) << USBC_UECFG6_EPTYPE_Pos))
+#define   USBC_UECFG6_EPTYPE_CONTROL_Val  _U(0x0)   /**< \brief (USBC_UECFG6)  */
+#define   USBC_UECFG6_EPTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UECFG6)  */
+#define   USBC_UECFG6_EPTYPE_BULK_Val     _U(0x2)   /**< \brief (USBC_UECFG6)  */
+#define   USBC_UECFG6_EPTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UECFG6)  */
+#define USBC_UECFG6_EPTYPE_CONTROL  (USBC_UECFG6_EPTYPE_CONTROL_Val << USBC_UECFG6_EPTYPE_Pos)
+#define USBC_UECFG6_EPTYPE_ISOCHRONOUS (USBC_UECFG6_EPTYPE_ISOCHRONOUS_Val << USBC_UECFG6_EPTYPE_Pos)
+#define USBC_UECFG6_EPTYPE_BULK     (USBC_UECFG6_EPTYPE_BULK_Val   << USBC_UECFG6_EPTYPE_Pos)
+#define USBC_UECFG6_EPTYPE_INTERRUPT (USBC_UECFG6_EPTYPE_INTERRUPT_Val << USBC_UECFG6_EPTYPE_Pos)
+#define USBC_UECFG6_REPNB_Pos       16           /**< \brief (USBC_UECFG6) Redirected Endpoint Number */
+#define USBC_UECFG6_REPNB_Msk       (_U(0xF) << USBC_UECFG6_REPNB_Pos)
+#define USBC_UECFG6_REPNB(value)    (USBC_UECFG6_REPNB_Msk & ((value) << USBC_UECFG6_REPNB_Pos))
+#define USBC_UECFG6_MASK            _U(0x000F1974) /**< \brief (USBC_UECFG6) MASK Register */
+
+/* -------- USBC_UECFG7 : (USBC Offset: 0x11C) (R/W 32) Endpoint Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t EPBK:1;           /*!< bit:      2  Endpoint Bank                      */
+    uint32_t :1;               /*!< bit:      3  Reserved                           */
+    uint32_t EPSIZE:3;         /*!< bit:  4.. 6  Endpoint Size                      */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t EPDIR:1;          /*!< bit:      8  Endpoint Direction                 */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t EPTYPE:2;         /*!< bit: 11..12  Endpoint Type                      */
+    uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t REPNB:4;          /*!< bit: 16..19  Redirected Endpoint Number         */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECFG7_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECFG7_OFFSET          0x11C        /**< \brief (USBC_UECFG7 offset) Endpoint Configuration Register */
+#define USBC_UECFG7_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECFG7 reset_value) Endpoint Configuration Register */
+
+#define USBC_UECFG7_EPBK_Pos        2            /**< \brief (USBC_UECFG7) Endpoint Bank */
+#define USBC_UECFG7_EPBK            (_U(0x1) << USBC_UECFG7_EPBK_Pos)
+#define   USBC_UECFG7_EPBK_SINGLE_Val     _U(0x0)   /**< \brief (USBC_UECFG7)  */
+#define   USBC_UECFG7_EPBK_DOUBLE_Val     _U(0x1)   /**< \brief (USBC_UECFG7)  */
+#define USBC_UECFG7_EPBK_SINGLE     (USBC_UECFG7_EPBK_SINGLE_Val   << USBC_UECFG7_EPBK_Pos)
+#define USBC_UECFG7_EPBK_DOUBLE     (USBC_UECFG7_EPBK_DOUBLE_Val   << USBC_UECFG7_EPBK_Pos)
+#define USBC_UECFG7_EPSIZE_Pos      4            /**< \brief (USBC_UECFG7) Endpoint Size */
+#define USBC_UECFG7_EPSIZE_Msk      (_U(0x7) << USBC_UECFG7_EPSIZE_Pos)
+#define USBC_UECFG7_EPSIZE(value)   (USBC_UECFG7_EPSIZE_Msk & ((value) << USBC_UECFG7_EPSIZE_Pos))
+#define   USBC_UECFG7_EPSIZE_8_Val        _U(0x0)   /**< \brief (USBC_UECFG7)  */
+#define   USBC_UECFG7_EPSIZE_16_Val       _U(0x1)   /**< \brief (USBC_UECFG7)  */
+#define   USBC_UECFG7_EPSIZE_32_Val       _U(0x2)   /**< \brief (USBC_UECFG7)  */
+#define   USBC_UECFG7_EPSIZE_64_Val       _U(0x3)   /**< \brief (USBC_UECFG7)  */
+#define   USBC_UECFG7_EPSIZE_128_Val      _U(0x4)   /**< \brief (USBC_UECFG7)  */
+#define   USBC_UECFG7_EPSIZE_256_Val      _U(0x5)   /**< \brief (USBC_UECFG7)  */
+#define   USBC_UECFG7_EPSIZE_512_Val      _U(0x6)   /**< \brief (USBC_UECFG7)  */
+#define   USBC_UECFG7_EPSIZE_1024_Val     _U(0x7)   /**< \brief (USBC_UECFG7)  */
+#define USBC_UECFG7_EPSIZE_8        (USBC_UECFG7_EPSIZE_8_Val      << USBC_UECFG7_EPSIZE_Pos)
+#define USBC_UECFG7_EPSIZE_16       (USBC_UECFG7_EPSIZE_16_Val     << USBC_UECFG7_EPSIZE_Pos)
+#define USBC_UECFG7_EPSIZE_32       (USBC_UECFG7_EPSIZE_32_Val     << USBC_UECFG7_EPSIZE_Pos)
+#define USBC_UECFG7_EPSIZE_64       (USBC_UECFG7_EPSIZE_64_Val     << USBC_UECFG7_EPSIZE_Pos)
+#define USBC_UECFG7_EPSIZE_128      (USBC_UECFG7_EPSIZE_128_Val    << USBC_UECFG7_EPSIZE_Pos)
+#define USBC_UECFG7_EPSIZE_256      (USBC_UECFG7_EPSIZE_256_Val    << USBC_UECFG7_EPSIZE_Pos)
+#define USBC_UECFG7_EPSIZE_512      (USBC_UECFG7_EPSIZE_512_Val    << USBC_UECFG7_EPSIZE_Pos)
+#define USBC_UECFG7_EPSIZE_1024     (USBC_UECFG7_EPSIZE_1024_Val   << USBC_UECFG7_EPSIZE_Pos)
+#define USBC_UECFG7_EPDIR_Pos       8            /**< \brief (USBC_UECFG7) Endpoint Direction */
+#define USBC_UECFG7_EPDIR           (_U(0x1) << USBC_UECFG7_EPDIR_Pos)
+#define   USBC_UECFG7_EPDIR_OUT_Val       _U(0x0)   /**< \brief (USBC_UECFG7)  */
+#define   USBC_UECFG7_EPDIR_IN_Val        _U(0x1)   /**< \brief (USBC_UECFG7)  */
+#define USBC_UECFG7_EPDIR_OUT       (USBC_UECFG7_EPDIR_OUT_Val     << USBC_UECFG7_EPDIR_Pos)
+#define USBC_UECFG7_EPDIR_IN        (USBC_UECFG7_EPDIR_IN_Val      << USBC_UECFG7_EPDIR_Pos)
+#define USBC_UECFG7_EPTYPE_Pos      11           /**< \brief (USBC_UECFG7) Endpoint Type */
+#define USBC_UECFG7_EPTYPE_Msk      (_U(0x3) << USBC_UECFG7_EPTYPE_Pos)
+#define USBC_UECFG7_EPTYPE(value)   (USBC_UECFG7_EPTYPE_Msk & ((value) << USBC_UECFG7_EPTYPE_Pos))
+#define   USBC_UECFG7_EPTYPE_CONTROL_Val  _U(0x0)   /**< \brief (USBC_UECFG7)  */
+#define   USBC_UECFG7_EPTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UECFG7)  */
+#define   USBC_UECFG7_EPTYPE_BULK_Val     _U(0x2)   /**< \brief (USBC_UECFG7)  */
+#define   USBC_UECFG7_EPTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UECFG7)  */
+#define USBC_UECFG7_EPTYPE_CONTROL  (USBC_UECFG7_EPTYPE_CONTROL_Val << USBC_UECFG7_EPTYPE_Pos)
+#define USBC_UECFG7_EPTYPE_ISOCHRONOUS (USBC_UECFG7_EPTYPE_ISOCHRONOUS_Val << USBC_UECFG7_EPTYPE_Pos)
+#define USBC_UECFG7_EPTYPE_BULK     (USBC_UECFG7_EPTYPE_BULK_Val   << USBC_UECFG7_EPTYPE_Pos)
+#define USBC_UECFG7_EPTYPE_INTERRUPT (USBC_UECFG7_EPTYPE_INTERRUPT_Val << USBC_UECFG7_EPTYPE_Pos)
+#define USBC_UECFG7_REPNB_Pos       16           /**< \brief (USBC_UECFG7) Redirected Endpoint Number */
+#define USBC_UECFG7_REPNB_Msk       (_U(0xF) << USBC_UECFG7_REPNB_Pos)
+#define USBC_UECFG7_REPNB(value)    (USBC_UECFG7_REPNB_Msk & ((value) << USBC_UECFG7_REPNB_Pos))
+#define USBC_UECFG7_MASK            _U(0x000F1974) /**< \brief (USBC_UECFG7) MASK Register */
+
+/* -------- USBC_UESTA0 : (USBC Offset: 0x130) (R/  32) Endpoint Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINI:1;          /*!< bit:      0  Transmitted IN Data Interrupt      */
+    uint32_t RXOUTI:1;         /*!< bit:      1  Received OUT Data Interrupt        */
+    uint32_t RXSTPI:1;         /*!< bit:      2  Received SETUP Interrupt           */
+    uint32_t NAKOUTI:1;        /*!< bit:      3  NAKed OUT Interrupt                */
+    uint32_t NAKINI:1;         /*!< bit:      4  NAKed IN Interrupt                 */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDI:1;       /*!< bit:      6  STALLed Interrupt                  */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t DTSEQ:2;          /*!< bit:  8.. 9  Data Toggle Sequence               */
+    uint32_t :1;               /*!< bit:     10  Reserved                           */
+    uint32_t RAMACERI:1;       /*!< bit:     11  Ram Access Error Interrupt         */
+    uint32_t NBUSYBK:2;        /*!< bit: 12..13  Number Of Busy Banks               */
+    uint32_t CURRBK:2;         /*!< bit: 14..15  Current Bank                       */
+    uint32_t :1;               /*!< bit:     16  Reserved                           */
+    uint32_t CTRLDIR:1;        /*!< bit:     17  Control Direction                  */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UESTA0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UESTA0_OFFSET          0x130        /**< \brief (USBC_UESTA0 offset) Endpoint Status Register */
+#define USBC_UESTA0_RESETVALUE      _U(0x00000100); /**< \brief (USBC_UESTA0 reset_value) Endpoint Status Register */
+
+#define USBC_UESTA0_TXINI_Pos       0            /**< \brief (USBC_UESTA0) Transmitted IN Data Interrupt */
+#define USBC_UESTA0_TXINI           (_U(0x1) << USBC_UESTA0_TXINI_Pos)
+#define USBC_UESTA0_RXOUTI_Pos      1            /**< \brief (USBC_UESTA0) Received OUT Data Interrupt */
+#define USBC_UESTA0_RXOUTI          (_U(0x1) << USBC_UESTA0_RXOUTI_Pos)
+#define USBC_UESTA0_RXSTPI_Pos      2            /**< \brief (USBC_UESTA0) Received SETUP Interrupt */
+#define USBC_UESTA0_RXSTPI          (_U(0x1) << USBC_UESTA0_RXSTPI_Pos)
+#define USBC_UESTA0_NAKOUTI_Pos     3            /**< \brief (USBC_UESTA0) NAKed OUT Interrupt */
+#define USBC_UESTA0_NAKOUTI         (_U(0x1) << USBC_UESTA0_NAKOUTI_Pos)
+#define USBC_UESTA0_NAKINI_Pos      4            /**< \brief (USBC_UESTA0) NAKed IN Interrupt */
+#define USBC_UESTA0_NAKINI          (_U(0x1) << USBC_UESTA0_NAKINI_Pos)
+#define USBC_UESTA0_STALLEDI_Pos    6            /**< \brief (USBC_UESTA0) STALLed Interrupt */
+#define USBC_UESTA0_STALLEDI        (_U(0x1) << USBC_UESTA0_STALLEDI_Pos)
+#define USBC_UESTA0_DTSEQ_Pos       8            /**< \brief (USBC_UESTA0) Data Toggle Sequence */
+#define USBC_UESTA0_DTSEQ_Msk       (_U(0x3) << USBC_UESTA0_DTSEQ_Pos)
+#define USBC_UESTA0_DTSEQ(value)    (USBC_UESTA0_DTSEQ_Msk & ((value) << USBC_UESTA0_DTSEQ_Pos))
+#define USBC_UESTA0_RAMACERI_Pos    11           /**< \brief (USBC_UESTA0) Ram Access Error Interrupt */
+#define USBC_UESTA0_RAMACERI        (_U(0x1) << USBC_UESTA0_RAMACERI_Pos)
+#define USBC_UESTA0_NBUSYBK_Pos     12           /**< \brief (USBC_UESTA0) Number Of Busy Banks */
+#define USBC_UESTA0_NBUSYBK_Msk     (_U(0x3) << USBC_UESTA0_NBUSYBK_Pos)
+#define USBC_UESTA0_NBUSYBK(value)  (USBC_UESTA0_NBUSYBK_Msk & ((value) << USBC_UESTA0_NBUSYBK_Pos))
+#define USBC_UESTA0_CURRBK_Pos      14           /**< \brief (USBC_UESTA0) Current Bank */
+#define USBC_UESTA0_CURRBK_Msk      (_U(0x3) << USBC_UESTA0_CURRBK_Pos)
+#define USBC_UESTA0_CURRBK(value)   (USBC_UESTA0_CURRBK_Msk & ((value) << USBC_UESTA0_CURRBK_Pos))
+#define USBC_UESTA0_CTRLDIR_Pos     17           /**< \brief (USBC_UESTA0) Control Direction */
+#define USBC_UESTA0_CTRLDIR         (_U(0x1) << USBC_UESTA0_CTRLDIR_Pos)
+#define   USBC_UESTA0_CTRLDIR_OUT_Val     _U(0x0)   /**< \brief (USBC_UESTA0)  */
+#define   USBC_UESTA0_CTRLDIR_IN_Val      _U(0x1)   /**< \brief (USBC_UESTA0)  */
+#define USBC_UESTA0_CTRLDIR_OUT     (USBC_UESTA0_CTRLDIR_OUT_Val   << USBC_UESTA0_CTRLDIR_Pos)
+#define USBC_UESTA0_CTRLDIR_IN      (USBC_UESTA0_CTRLDIR_IN_Val    << USBC_UESTA0_CTRLDIR_Pos)
+#define USBC_UESTA0_MASK            _U(0x0002FB5F) /**< \brief (USBC_UESTA0) MASK Register */
+
+/* -------- USBC_UESTA1 : (USBC Offset: 0x134) (R/  32) Endpoint Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINI:1;          /*!< bit:      0  Transmitted IN Data Interrupt      */
+    uint32_t RXOUTI:1;         /*!< bit:      1  Received OUT Data Interrupt        */
+    uint32_t RXSTPI:1;         /*!< bit:      2  Received SETUP Interrupt           */
+    uint32_t NAKOUTI:1;        /*!< bit:      3  NAKed OUT Interrupt                */
+    uint32_t NAKINI:1;         /*!< bit:      4  NAKed IN Interrupt                 */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDI:1;       /*!< bit:      6  STALLed Interrupt                  */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t DTSEQ:2;          /*!< bit:  8.. 9  Data Toggle Sequence               */
+    uint32_t :1;               /*!< bit:     10  Reserved                           */
+    uint32_t RAMACERI:1;       /*!< bit:     11  Ram Access Error Interrupt         */
+    uint32_t NBUSYBK:2;        /*!< bit: 12..13  Number Of Busy Banks               */
+    uint32_t CURRBK:2;         /*!< bit: 14..15  Current Bank                       */
+    uint32_t :1;               /*!< bit:     16  Reserved                           */
+    uint32_t CTRLDIR:1;        /*!< bit:     17  Control Direction                  */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UESTA1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UESTA1_OFFSET          0x134        /**< \brief (USBC_UESTA1 offset) Endpoint Status Register */
+#define USBC_UESTA1_RESETVALUE      _U(0x00000100); /**< \brief (USBC_UESTA1 reset_value) Endpoint Status Register */
+
+#define USBC_UESTA1_TXINI_Pos       0            /**< \brief (USBC_UESTA1) Transmitted IN Data Interrupt */
+#define USBC_UESTA1_TXINI           (_U(0x1) << USBC_UESTA1_TXINI_Pos)
+#define USBC_UESTA1_RXOUTI_Pos      1            /**< \brief (USBC_UESTA1) Received OUT Data Interrupt */
+#define USBC_UESTA1_RXOUTI          (_U(0x1) << USBC_UESTA1_RXOUTI_Pos)
+#define USBC_UESTA1_RXSTPI_Pos      2            /**< \brief (USBC_UESTA1) Received SETUP Interrupt */
+#define USBC_UESTA1_RXSTPI          (_U(0x1) << USBC_UESTA1_RXSTPI_Pos)
+#define USBC_UESTA1_NAKOUTI_Pos     3            /**< \brief (USBC_UESTA1) NAKed OUT Interrupt */
+#define USBC_UESTA1_NAKOUTI         (_U(0x1) << USBC_UESTA1_NAKOUTI_Pos)
+#define USBC_UESTA1_NAKINI_Pos      4            /**< \brief (USBC_UESTA1) NAKed IN Interrupt */
+#define USBC_UESTA1_NAKINI          (_U(0x1) << USBC_UESTA1_NAKINI_Pos)
+#define USBC_UESTA1_STALLEDI_Pos    6            /**< \brief (USBC_UESTA1) STALLed Interrupt */
+#define USBC_UESTA1_STALLEDI        (_U(0x1) << USBC_UESTA1_STALLEDI_Pos)
+#define USBC_UESTA1_DTSEQ_Pos       8            /**< \brief (USBC_UESTA1) Data Toggle Sequence */
+#define USBC_UESTA1_DTSEQ_Msk       (_U(0x3) << USBC_UESTA1_DTSEQ_Pos)
+#define USBC_UESTA1_DTSEQ(value)    (USBC_UESTA1_DTSEQ_Msk & ((value) << USBC_UESTA1_DTSEQ_Pos))
+#define USBC_UESTA1_RAMACERI_Pos    11           /**< \brief (USBC_UESTA1) Ram Access Error Interrupt */
+#define USBC_UESTA1_RAMACERI        (_U(0x1) << USBC_UESTA1_RAMACERI_Pos)
+#define USBC_UESTA1_NBUSYBK_Pos     12           /**< \brief (USBC_UESTA1) Number Of Busy Banks */
+#define USBC_UESTA1_NBUSYBK_Msk     (_U(0x3) << USBC_UESTA1_NBUSYBK_Pos)
+#define USBC_UESTA1_NBUSYBK(value)  (USBC_UESTA1_NBUSYBK_Msk & ((value) << USBC_UESTA1_NBUSYBK_Pos))
+#define USBC_UESTA1_CURRBK_Pos      14           /**< \brief (USBC_UESTA1) Current Bank */
+#define USBC_UESTA1_CURRBK_Msk      (_U(0x3) << USBC_UESTA1_CURRBK_Pos)
+#define USBC_UESTA1_CURRBK(value)   (USBC_UESTA1_CURRBK_Msk & ((value) << USBC_UESTA1_CURRBK_Pos))
+#define USBC_UESTA1_CTRLDIR_Pos     17           /**< \brief (USBC_UESTA1) Control Direction */
+#define USBC_UESTA1_CTRLDIR         (_U(0x1) << USBC_UESTA1_CTRLDIR_Pos)
+#define   USBC_UESTA1_CTRLDIR_OUT_Val     _U(0x0)   /**< \brief (USBC_UESTA1)  */
+#define   USBC_UESTA1_CTRLDIR_IN_Val      _U(0x1)   /**< \brief (USBC_UESTA1)  */
+#define USBC_UESTA1_CTRLDIR_OUT     (USBC_UESTA1_CTRLDIR_OUT_Val   << USBC_UESTA1_CTRLDIR_Pos)
+#define USBC_UESTA1_CTRLDIR_IN      (USBC_UESTA1_CTRLDIR_IN_Val    << USBC_UESTA1_CTRLDIR_Pos)
+#define USBC_UESTA1_MASK            _U(0x0002FB5F) /**< \brief (USBC_UESTA1) MASK Register */
+
+/* -------- USBC_UESTA2 : (USBC Offset: 0x138) (R/  32) Endpoint Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINI:1;          /*!< bit:      0  Transmitted IN Data Interrupt      */
+    uint32_t RXOUTI:1;         /*!< bit:      1  Received OUT Data Interrupt        */
+    uint32_t RXSTPI:1;         /*!< bit:      2  Received SETUP Interrupt           */
+    uint32_t NAKOUTI:1;        /*!< bit:      3  NAKed OUT Interrupt                */
+    uint32_t NAKINI:1;         /*!< bit:      4  NAKed IN Interrupt                 */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDI:1;       /*!< bit:      6  STALLed Interrupt                  */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t DTSEQ:2;          /*!< bit:  8.. 9  Data Toggle Sequence               */
+    uint32_t :1;               /*!< bit:     10  Reserved                           */
+    uint32_t RAMACERI:1;       /*!< bit:     11  Ram Access Error Interrupt         */
+    uint32_t NBUSYBK:2;        /*!< bit: 12..13  Number Of Busy Banks               */
+    uint32_t CURRBK:2;         /*!< bit: 14..15  Current Bank                       */
+    uint32_t :1;               /*!< bit:     16  Reserved                           */
+    uint32_t CTRLDIR:1;        /*!< bit:     17  Control Direction                  */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UESTA2_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UESTA2_OFFSET          0x138        /**< \brief (USBC_UESTA2 offset) Endpoint Status Register */
+#define USBC_UESTA2_RESETVALUE      _U(0x00000100); /**< \brief (USBC_UESTA2 reset_value) Endpoint Status Register */
+
+#define USBC_UESTA2_TXINI_Pos       0            /**< \brief (USBC_UESTA2) Transmitted IN Data Interrupt */
+#define USBC_UESTA2_TXINI           (_U(0x1) << USBC_UESTA2_TXINI_Pos)
+#define USBC_UESTA2_RXOUTI_Pos      1            /**< \brief (USBC_UESTA2) Received OUT Data Interrupt */
+#define USBC_UESTA2_RXOUTI          (_U(0x1) << USBC_UESTA2_RXOUTI_Pos)
+#define USBC_UESTA2_RXSTPI_Pos      2            /**< \brief (USBC_UESTA2) Received SETUP Interrupt */
+#define USBC_UESTA2_RXSTPI          (_U(0x1) << USBC_UESTA2_RXSTPI_Pos)
+#define USBC_UESTA2_NAKOUTI_Pos     3            /**< \brief (USBC_UESTA2) NAKed OUT Interrupt */
+#define USBC_UESTA2_NAKOUTI         (_U(0x1) << USBC_UESTA2_NAKOUTI_Pos)
+#define USBC_UESTA2_NAKINI_Pos      4            /**< \brief (USBC_UESTA2) NAKed IN Interrupt */
+#define USBC_UESTA2_NAKINI          (_U(0x1) << USBC_UESTA2_NAKINI_Pos)
+#define USBC_UESTA2_STALLEDI_Pos    6            /**< \brief (USBC_UESTA2) STALLed Interrupt */
+#define USBC_UESTA2_STALLEDI        (_U(0x1) << USBC_UESTA2_STALLEDI_Pos)
+#define USBC_UESTA2_DTSEQ_Pos       8            /**< \brief (USBC_UESTA2) Data Toggle Sequence */
+#define USBC_UESTA2_DTSEQ_Msk       (_U(0x3) << USBC_UESTA2_DTSEQ_Pos)
+#define USBC_UESTA2_DTSEQ(value)    (USBC_UESTA2_DTSEQ_Msk & ((value) << USBC_UESTA2_DTSEQ_Pos))
+#define USBC_UESTA2_RAMACERI_Pos    11           /**< \brief (USBC_UESTA2) Ram Access Error Interrupt */
+#define USBC_UESTA2_RAMACERI        (_U(0x1) << USBC_UESTA2_RAMACERI_Pos)
+#define USBC_UESTA2_NBUSYBK_Pos     12           /**< \brief (USBC_UESTA2) Number Of Busy Banks */
+#define USBC_UESTA2_NBUSYBK_Msk     (_U(0x3) << USBC_UESTA2_NBUSYBK_Pos)
+#define USBC_UESTA2_NBUSYBK(value)  (USBC_UESTA2_NBUSYBK_Msk & ((value) << USBC_UESTA2_NBUSYBK_Pos))
+#define USBC_UESTA2_CURRBK_Pos      14           /**< \brief (USBC_UESTA2) Current Bank */
+#define USBC_UESTA2_CURRBK_Msk      (_U(0x3) << USBC_UESTA2_CURRBK_Pos)
+#define USBC_UESTA2_CURRBK(value)   (USBC_UESTA2_CURRBK_Msk & ((value) << USBC_UESTA2_CURRBK_Pos))
+#define USBC_UESTA2_CTRLDIR_Pos     17           /**< \brief (USBC_UESTA2) Control Direction */
+#define USBC_UESTA2_CTRLDIR         (_U(0x1) << USBC_UESTA2_CTRLDIR_Pos)
+#define   USBC_UESTA2_CTRLDIR_OUT_Val     _U(0x0)   /**< \brief (USBC_UESTA2)  */
+#define   USBC_UESTA2_CTRLDIR_IN_Val      _U(0x1)   /**< \brief (USBC_UESTA2)  */
+#define USBC_UESTA2_CTRLDIR_OUT     (USBC_UESTA2_CTRLDIR_OUT_Val   << USBC_UESTA2_CTRLDIR_Pos)
+#define USBC_UESTA2_CTRLDIR_IN      (USBC_UESTA2_CTRLDIR_IN_Val    << USBC_UESTA2_CTRLDIR_Pos)
+#define USBC_UESTA2_MASK            _U(0x0002FB5F) /**< \brief (USBC_UESTA2) MASK Register */
+
+/* -------- USBC_UESTA3 : (USBC Offset: 0x13C) (R/  32) Endpoint Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINI:1;          /*!< bit:      0  Transmitted IN Data Interrupt      */
+    uint32_t RXOUTI:1;         /*!< bit:      1  Received OUT Data Interrupt        */
+    uint32_t RXSTPI:1;         /*!< bit:      2  Received SETUP Interrupt           */
+    uint32_t NAKOUTI:1;        /*!< bit:      3  NAKed OUT Interrupt                */
+    uint32_t NAKINI:1;         /*!< bit:      4  NAKed IN Interrupt                 */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDI:1;       /*!< bit:      6  STALLed Interrupt                  */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t DTSEQ:2;          /*!< bit:  8.. 9  Data Toggle Sequence               */
+    uint32_t :1;               /*!< bit:     10  Reserved                           */
+    uint32_t RAMACERI:1;       /*!< bit:     11  Ram Access Error Interrupt         */
+    uint32_t NBUSYBK:2;        /*!< bit: 12..13  Number Of Busy Banks               */
+    uint32_t CURRBK:2;         /*!< bit: 14..15  Current Bank                       */
+    uint32_t :1;               /*!< bit:     16  Reserved                           */
+    uint32_t CTRLDIR:1;        /*!< bit:     17  Control Direction                  */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UESTA3_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UESTA3_OFFSET          0x13C        /**< \brief (USBC_UESTA3 offset) Endpoint Status Register */
+#define USBC_UESTA3_RESETVALUE      _U(0x00000100); /**< \brief (USBC_UESTA3 reset_value) Endpoint Status Register */
+
+#define USBC_UESTA3_TXINI_Pos       0            /**< \brief (USBC_UESTA3) Transmitted IN Data Interrupt */
+#define USBC_UESTA3_TXINI           (_U(0x1) << USBC_UESTA3_TXINI_Pos)
+#define USBC_UESTA3_RXOUTI_Pos      1            /**< \brief (USBC_UESTA3) Received OUT Data Interrupt */
+#define USBC_UESTA3_RXOUTI          (_U(0x1) << USBC_UESTA3_RXOUTI_Pos)
+#define USBC_UESTA3_RXSTPI_Pos      2            /**< \brief (USBC_UESTA3) Received SETUP Interrupt */
+#define USBC_UESTA3_RXSTPI          (_U(0x1) << USBC_UESTA3_RXSTPI_Pos)
+#define USBC_UESTA3_NAKOUTI_Pos     3            /**< \brief (USBC_UESTA3) NAKed OUT Interrupt */
+#define USBC_UESTA3_NAKOUTI         (_U(0x1) << USBC_UESTA3_NAKOUTI_Pos)
+#define USBC_UESTA3_NAKINI_Pos      4            /**< \brief (USBC_UESTA3) NAKed IN Interrupt */
+#define USBC_UESTA3_NAKINI          (_U(0x1) << USBC_UESTA3_NAKINI_Pos)
+#define USBC_UESTA3_STALLEDI_Pos    6            /**< \brief (USBC_UESTA3) STALLed Interrupt */
+#define USBC_UESTA3_STALLEDI        (_U(0x1) << USBC_UESTA3_STALLEDI_Pos)
+#define USBC_UESTA3_DTSEQ_Pos       8            /**< \brief (USBC_UESTA3) Data Toggle Sequence */
+#define USBC_UESTA3_DTSEQ_Msk       (_U(0x3) << USBC_UESTA3_DTSEQ_Pos)
+#define USBC_UESTA3_DTSEQ(value)    (USBC_UESTA3_DTSEQ_Msk & ((value) << USBC_UESTA3_DTSEQ_Pos))
+#define USBC_UESTA3_RAMACERI_Pos    11           /**< \brief (USBC_UESTA3) Ram Access Error Interrupt */
+#define USBC_UESTA3_RAMACERI        (_U(0x1) << USBC_UESTA3_RAMACERI_Pos)
+#define USBC_UESTA3_NBUSYBK_Pos     12           /**< \brief (USBC_UESTA3) Number Of Busy Banks */
+#define USBC_UESTA3_NBUSYBK_Msk     (_U(0x3) << USBC_UESTA3_NBUSYBK_Pos)
+#define USBC_UESTA3_NBUSYBK(value)  (USBC_UESTA3_NBUSYBK_Msk & ((value) << USBC_UESTA3_NBUSYBK_Pos))
+#define USBC_UESTA3_CURRBK_Pos      14           /**< \brief (USBC_UESTA3) Current Bank */
+#define USBC_UESTA3_CURRBK_Msk      (_U(0x3) << USBC_UESTA3_CURRBK_Pos)
+#define USBC_UESTA3_CURRBK(value)   (USBC_UESTA3_CURRBK_Msk & ((value) << USBC_UESTA3_CURRBK_Pos))
+#define USBC_UESTA3_CTRLDIR_Pos     17           /**< \brief (USBC_UESTA3) Control Direction */
+#define USBC_UESTA3_CTRLDIR         (_U(0x1) << USBC_UESTA3_CTRLDIR_Pos)
+#define   USBC_UESTA3_CTRLDIR_OUT_Val     _U(0x0)   /**< \brief (USBC_UESTA3)  */
+#define   USBC_UESTA3_CTRLDIR_IN_Val      _U(0x1)   /**< \brief (USBC_UESTA3)  */
+#define USBC_UESTA3_CTRLDIR_OUT     (USBC_UESTA3_CTRLDIR_OUT_Val   << USBC_UESTA3_CTRLDIR_Pos)
+#define USBC_UESTA3_CTRLDIR_IN      (USBC_UESTA3_CTRLDIR_IN_Val    << USBC_UESTA3_CTRLDIR_Pos)
+#define USBC_UESTA3_MASK            _U(0x0002FB5F) /**< \brief (USBC_UESTA3) MASK Register */
+
+/* -------- USBC_UESTA4 : (USBC Offset: 0x140) (R/  32) Endpoint Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINI:1;          /*!< bit:      0  Transmitted IN Data Interrupt      */
+    uint32_t RXOUTI:1;         /*!< bit:      1  Received OUT Data Interrupt        */
+    uint32_t RXSTPI:1;         /*!< bit:      2  Received SETUP Interrupt           */
+    uint32_t NAKOUTI:1;        /*!< bit:      3  NAKed OUT Interrupt                */
+    uint32_t NAKINI:1;         /*!< bit:      4  NAKed IN Interrupt                 */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDI:1;       /*!< bit:      6  STALLed Interrupt                  */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t DTSEQ:2;          /*!< bit:  8.. 9  Data Toggle Sequence               */
+    uint32_t :1;               /*!< bit:     10  Reserved                           */
+    uint32_t RAMACERI:1;       /*!< bit:     11  Ram Access Error Interrupt         */
+    uint32_t NBUSYBK:2;        /*!< bit: 12..13  Number Of Busy Banks               */
+    uint32_t CURRBK:2;         /*!< bit: 14..15  Current Bank                       */
+    uint32_t :1;               /*!< bit:     16  Reserved                           */
+    uint32_t CTRLDIR:1;        /*!< bit:     17  Control Direction                  */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UESTA4_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UESTA4_OFFSET          0x140        /**< \brief (USBC_UESTA4 offset) Endpoint Status Register */
+#define USBC_UESTA4_RESETVALUE      _U(0x00000100); /**< \brief (USBC_UESTA4 reset_value) Endpoint Status Register */
+
+#define USBC_UESTA4_TXINI_Pos       0            /**< \brief (USBC_UESTA4) Transmitted IN Data Interrupt */
+#define USBC_UESTA4_TXINI           (_U(0x1) << USBC_UESTA4_TXINI_Pos)
+#define USBC_UESTA4_RXOUTI_Pos      1            /**< \brief (USBC_UESTA4) Received OUT Data Interrupt */
+#define USBC_UESTA4_RXOUTI          (_U(0x1) << USBC_UESTA4_RXOUTI_Pos)
+#define USBC_UESTA4_RXSTPI_Pos      2            /**< \brief (USBC_UESTA4) Received SETUP Interrupt */
+#define USBC_UESTA4_RXSTPI          (_U(0x1) << USBC_UESTA4_RXSTPI_Pos)
+#define USBC_UESTA4_NAKOUTI_Pos     3            /**< \brief (USBC_UESTA4) NAKed OUT Interrupt */
+#define USBC_UESTA4_NAKOUTI         (_U(0x1) << USBC_UESTA4_NAKOUTI_Pos)
+#define USBC_UESTA4_NAKINI_Pos      4            /**< \brief (USBC_UESTA4) NAKed IN Interrupt */
+#define USBC_UESTA4_NAKINI          (_U(0x1) << USBC_UESTA4_NAKINI_Pos)
+#define USBC_UESTA4_STALLEDI_Pos    6            /**< \brief (USBC_UESTA4) STALLed Interrupt */
+#define USBC_UESTA4_STALLEDI        (_U(0x1) << USBC_UESTA4_STALLEDI_Pos)
+#define USBC_UESTA4_DTSEQ_Pos       8            /**< \brief (USBC_UESTA4) Data Toggle Sequence */
+#define USBC_UESTA4_DTSEQ_Msk       (_U(0x3) << USBC_UESTA4_DTSEQ_Pos)
+#define USBC_UESTA4_DTSEQ(value)    (USBC_UESTA4_DTSEQ_Msk & ((value) << USBC_UESTA4_DTSEQ_Pos))
+#define USBC_UESTA4_RAMACERI_Pos    11           /**< \brief (USBC_UESTA4) Ram Access Error Interrupt */
+#define USBC_UESTA4_RAMACERI        (_U(0x1) << USBC_UESTA4_RAMACERI_Pos)
+#define USBC_UESTA4_NBUSYBK_Pos     12           /**< \brief (USBC_UESTA4) Number Of Busy Banks */
+#define USBC_UESTA4_NBUSYBK_Msk     (_U(0x3) << USBC_UESTA4_NBUSYBK_Pos)
+#define USBC_UESTA4_NBUSYBK(value)  (USBC_UESTA4_NBUSYBK_Msk & ((value) << USBC_UESTA4_NBUSYBK_Pos))
+#define USBC_UESTA4_CURRBK_Pos      14           /**< \brief (USBC_UESTA4) Current Bank */
+#define USBC_UESTA4_CURRBK_Msk      (_U(0x3) << USBC_UESTA4_CURRBK_Pos)
+#define USBC_UESTA4_CURRBK(value)   (USBC_UESTA4_CURRBK_Msk & ((value) << USBC_UESTA4_CURRBK_Pos))
+#define USBC_UESTA4_CTRLDIR_Pos     17           /**< \brief (USBC_UESTA4) Control Direction */
+#define USBC_UESTA4_CTRLDIR         (_U(0x1) << USBC_UESTA4_CTRLDIR_Pos)
+#define   USBC_UESTA4_CTRLDIR_OUT_Val     _U(0x0)   /**< \brief (USBC_UESTA4)  */
+#define   USBC_UESTA4_CTRLDIR_IN_Val      _U(0x1)   /**< \brief (USBC_UESTA4)  */
+#define USBC_UESTA4_CTRLDIR_OUT     (USBC_UESTA4_CTRLDIR_OUT_Val   << USBC_UESTA4_CTRLDIR_Pos)
+#define USBC_UESTA4_CTRLDIR_IN      (USBC_UESTA4_CTRLDIR_IN_Val    << USBC_UESTA4_CTRLDIR_Pos)
+#define USBC_UESTA4_MASK            _U(0x0002FB5F) /**< \brief (USBC_UESTA4) MASK Register */
+
+/* -------- USBC_UESTA5 : (USBC Offset: 0x144) (R/  32) Endpoint Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINI:1;          /*!< bit:      0  Transmitted IN Data Interrupt      */
+    uint32_t RXOUTI:1;         /*!< bit:      1  Received OUT Data Interrupt        */
+    uint32_t RXSTPI:1;         /*!< bit:      2  Received SETUP Interrupt           */
+    uint32_t NAKOUTI:1;        /*!< bit:      3  NAKed OUT Interrupt                */
+    uint32_t NAKINI:1;         /*!< bit:      4  NAKed IN Interrupt                 */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDI:1;       /*!< bit:      6  STALLed Interrupt                  */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t DTSEQ:2;          /*!< bit:  8.. 9  Data Toggle Sequence               */
+    uint32_t :1;               /*!< bit:     10  Reserved                           */
+    uint32_t RAMACERI:1;       /*!< bit:     11  Ram Access Error Interrupt         */
+    uint32_t NBUSYBK:2;        /*!< bit: 12..13  Number Of Busy Banks               */
+    uint32_t CURRBK:2;         /*!< bit: 14..15  Current Bank                       */
+    uint32_t :1;               /*!< bit:     16  Reserved                           */
+    uint32_t CTRLDIR:1;        /*!< bit:     17  Control Direction                  */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UESTA5_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UESTA5_OFFSET          0x144        /**< \brief (USBC_UESTA5 offset) Endpoint Status Register */
+#define USBC_UESTA5_RESETVALUE      _U(0x00000100); /**< \brief (USBC_UESTA5 reset_value) Endpoint Status Register */
+
+#define USBC_UESTA5_TXINI_Pos       0            /**< \brief (USBC_UESTA5) Transmitted IN Data Interrupt */
+#define USBC_UESTA5_TXINI           (_U(0x1) << USBC_UESTA5_TXINI_Pos)
+#define USBC_UESTA5_RXOUTI_Pos      1            /**< \brief (USBC_UESTA5) Received OUT Data Interrupt */
+#define USBC_UESTA5_RXOUTI          (_U(0x1) << USBC_UESTA5_RXOUTI_Pos)
+#define USBC_UESTA5_RXSTPI_Pos      2            /**< \brief (USBC_UESTA5) Received SETUP Interrupt */
+#define USBC_UESTA5_RXSTPI          (_U(0x1) << USBC_UESTA5_RXSTPI_Pos)
+#define USBC_UESTA5_NAKOUTI_Pos     3            /**< \brief (USBC_UESTA5) NAKed OUT Interrupt */
+#define USBC_UESTA5_NAKOUTI         (_U(0x1) << USBC_UESTA5_NAKOUTI_Pos)
+#define USBC_UESTA5_NAKINI_Pos      4            /**< \brief (USBC_UESTA5) NAKed IN Interrupt */
+#define USBC_UESTA5_NAKINI          (_U(0x1) << USBC_UESTA5_NAKINI_Pos)
+#define USBC_UESTA5_STALLEDI_Pos    6            /**< \brief (USBC_UESTA5) STALLed Interrupt */
+#define USBC_UESTA5_STALLEDI        (_U(0x1) << USBC_UESTA5_STALLEDI_Pos)
+#define USBC_UESTA5_DTSEQ_Pos       8            /**< \brief (USBC_UESTA5) Data Toggle Sequence */
+#define USBC_UESTA5_DTSEQ_Msk       (_U(0x3) << USBC_UESTA5_DTSEQ_Pos)
+#define USBC_UESTA5_DTSEQ(value)    (USBC_UESTA5_DTSEQ_Msk & ((value) << USBC_UESTA5_DTSEQ_Pos))
+#define USBC_UESTA5_RAMACERI_Pos    11           /**< \brief (USBC_UESTA5) Ram Access Error Interrupt */
+#define USBC_UESTA5_RAMACERI        (_U(0x1) << USBC_UESTA5_RAMACERI_Pos)
+#define USBC_UESTA5_NBUSYBK_Pos     12           /**< \brief (USBC_UESTA5) Number Of Busy Banks */
+#define USBC_UESTA5_NBUSYBK_Msk     (_U(0x3) << USBC_UESTA5_NBUSYBK_Pos)
+#define USBC_UESTA5_NBUSYBK(value)  (USBC_UESTA5_NBUSYBK_Msk & ((value) << USBC_UESTA5_NBUSYBK_Pos))
+#define USBC_UESTA5_CURRBK_Pos      14           /**< \brief (USBC_UESTA5) Current Bank */
+#define USBC_UESTA5_CURRBK_Msk      (_U(0x3) << USBC_UESTA5_CURRBK_Pos)
+#define USBC_UESTA5_CURRBK(value)   (USBC_UESTA5_CURRBK_Msk & ((value) << USBC_UESTA5_CURRBK_Pos))
+#define USBC_UESTA5_CTRLDIR_Pos     17           /**< \brief (USBC_UESTA5) Control Direction */
+#define USBC_UESTA5_CTRLDIR         (_U(0x1) << USBC_UESTA5_CTRLDIR_Pos)
+#define   USBC_UESTA5_CTRLDIR_OUT_Val     _U(0x0)   /**< \brief (USBC_UESTA5)  */
+#define   USBC_UESTA5_CTRLDIR_IN_Val      _U(0x1)   /**< \brief (USBC_UESTA5)  */
+#define USBC_UESTA5_CTRLDIR_OUT     (USBC_UESTA5_CTRLDIR_OUT_Val   << USBC_UESTA5_CTRLDIR_Pos)
+#define USBC_UESTA5_CTRLDIR_IN      (USBC_UESTA5_CTRLDIR_IN_Val    << USBC_UESTA5_CTRLDIR_Pos)
+#define USBC_UESTA5_MASK            _U(0x0002FB5F) /**< \brief (USBC_UESTA5) MASK Register */
+
+/* -------- USBC_UESTA6 : (USBC Offset: 0x148) (R/  32) Endpoint Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINI:1;          /*!< bit:      0  Transmitted IN Data Interrupt      */
+    uint32_t RXOUTI:1;         /*!< bit:      1  Received OUT Data Interrupt        */
+    uint32_t RXSTPI:1;         /*!< bit:      2  Received SETUP Interrupt           */
+    uint32_t NAKOUTI:1;        /*!< bit:      3  NAKed OUT Interrupt                */
+    uint32_t NAKINI:1;         /*!< bit:      4  NAKed IN Interrupt                 */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDI:1;       /*!< bit:      6  STALLed Interrupt                  */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t DTSEQ:2;          /*!< bit:  8.. 9  Data Toggle Sequence               */
+    uint32_t :1;               /*!< bit:     10  Reserved                           */
+    uint32_t RAMACERI:1;       /*!< bit:     11  Ram Access Error Interrupt         */
+    uint32_t NBUSYBK:2;        /*!< bit: 12..13  Number Of Busy Banks               */
+    uint32_t CURRBK:2;         /*!< bit: 14..15  Current Bank                       */
+    uint32_t :1;               /*!< bit:     16  Reserved                           */
+    uint32_t CTRLDIR:1;        /*!< bit:     17  Control Direction                  */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UESTA6_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UESTA6_OFFSET          0x148        /**< \brief (USBC_UESTA6 offset) Endpoint Status Register */
+#define USBC_UESTA6_RESETVALUE      _U(0x00000100); /**< \brief (USBC_UESTA6 reset_value) Endpoint Status Register */
+
+#define USBC_UESTA6_TXINI_Pos       0            /**< \brief (USBC_UESTA6) Transmitted IN Data Interrupt */
+#define USBC_UESTA6_TXINI           (_U(0x1) << USBC_UESTA6_TXINI_Pos)
+#define USBC_UESTA6_RXOUTI_Pos      1            /**< \brief (USBC_UESTA6) Received OUT Data Interrupt */
+#define USBC_UESTA6_RXOUTI          (_U(0x1) << USBC_UESTA6_RXOUTI_Pos)
+#define USBC_UESTA6_RXSTPI_Pos      2            /**< \brief (USBC_UESTA6) Received SETUP Interrupt */
+#define USBC_UESTA6_RXSTPI          (_U(0x1) << USBC_UESTA6_RXSTPI_Pos)
+#define USBC_UESTA6_NAKOUTI_Pos     3            /**< \brief (USBC_UESTA6) NAKed OUT Interrupt */
+#define USBC_UESTA6_NAKOUTI         (_U(0x1) << USBC_UESTA6_NAKOUTI_Pos)
+#define USBC_UESTA6_NAKINI_Pos      4            /**< \brief (USBC_UESTA6) NAKed IN Interrupt */
+#define USBC_UESTA6_NAKINI          (_U(0x1) << USBC_UESTA6_NAKINI_Pos)
+#define USBC_UESTA6_STALLEDI_Pos    6            /**< \brief (USBC_UESTA6) STALLed Interrupt */
+#define USBC_UESTA6_STALLEDI        (_U(0x1) << USBC_UESTA6_STALLEDI_Pos)
+#define USBC_UESTA6_DTSEQ_Pos       8            /**< \brief (USBC_UESTA6) Data Toggle Sequence */
+#define USBC_UESTA6_DTSEQ_Msk       (_U(0x3) << USBC_UESTA6_DTSEQ_Pos)
+#define USBC_UESTA6_DTSEQ(value)    (USBC_UESTA6_DTSEQ_Msk & ((value) << USBC_UESTA6_DTSEQ_Pos))
+#define USBC_UESTA6_RAMACERI_Pos    11           /**< \brief (USBC_UESTA6) Ram Access Error Interrupt */
+#define USBC_UESTA6_RAMACERI        (_U(0x1) << USBC_UESTA6_RAMACERI_Pos)
+#define USBC_UESTA6_NBUSYBK_Pos     12           /**< \brief (USBC_UESTA6) Number Of Busy Banks */
+#define USBC_UESTA6_NBUSYBK_Msk     (_U(0x3) << USBC_UESTA6_NBUSYBK_Pos)
+#define USBC_UESTA6_NBUSYBK(value)  (USBC_UESTA6_NBUSYBK_Msk & ((value) << USBC_UESTA6_NBUSYBK_Pos))
+#define USBC_UESTA6_CURRBK_Pos      14           /**< \brief (USBC_UESTA6) Current Bank */
+#define USBC_UESTA6_CURRBK_Msk      (_U(0x3) << USBC_UESTA6_CURRBK_Pos)
+#define USBC_UESTA6_CURRBK(value)   (USBC_UESTA6_CURRBK_Msk & ((value) << USBC_UESTA6_CURRBK_Pos))
+#define USBC_UESTA6_CTRLDIR_Pos     17           /**< \brief (USBC_UESTA6) Control Direction */
+#define USBC_UESTA6_CTRLDIR         (_U(0x1) << USBC_UESTA6_CTRLDIR_Pos)
+#define   USBC_UESTA6_CTRLDIR_OUT_Val     _U(0x0)   /**< \brief (USBC_UESTA6)  */
+#define   USBC_UESTA6_CTRLDIR_IN_Val      _U(0x1)   /**< \brief (USBC_UESTA6)  */
+#define USBC_UESTA6_CTRLDIR_OUT     (USBC_UESTA6_CTRLDIR_OUT_Val   << USBC_UESTA6_CTRLDIR_Pos)
+#define USBC_UESTA6_CTRLDIR_IN      (USBC_UESTA6_CTRLDIR_IN_Val    << USBC_UESTA6_CTRLDIR_Pos)
+#define USBC_UESTA6_MASK            _U(0x0002FB5F) /**< \brief (USBC_UESTA6) MASK Register */
+
+/* -------- USBC_UESTA7 : (USBC Offset: 0x14C) (R/  32) Endpoint Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINI:1;          /*!< bit:      0  Transmitted IN Data Interrupt      */
+    uint32_t RXOUTI:1;         /*!< bit:      1  Received OUT Data Interrupt        */
+    uint32_t RXSTPI:1;         /*!< bit:      2  Received SETUP Interrupt           */
+    uint32_t NAKOUTI:1;        /*!< bit:      3  NAKed OUT Interrupt                */
+    uint32_t NAKINI:1;         /*!< bit:      4  NAKed IN Interrupt                 */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDI:1;       /*!< bit:      6  STALLed Interrupt                  */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t DTSEQ:2;          /*!< bit:  8.. 9  Data Toggle Sequence               */
+    uint32_t :1;               /*!< bit:     10  Reserved                           */
+    uint32_t RAMACERI:1;       /*!< bit:     11  Ram Access Error Interrupt         */
+    uint32_t NBUSYBK:2;        /*!< bit: 12..13  Number Of Busy Banks               */
+    uint32_t CURRBK:2;         /*!< bit: 14..15  Current Bank                       */
+    uint32_t :1;               /*!< bit:     16  Reserved                           */
+    uint32_t CTRLDIR:1;        /*!< bit:     17  Control Direction                  */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UESTA7_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UESTA7_OFFSET          0x14C        /**< \brief (USBC_UESTA7 offset) Endpoint Status Register */
+#define USBC_UESTA7_RESETVALUE      _U(0x00000100); /**< \brief (USBC_UESTA7 reset_value) Endpoint Status Register */
+
+#define USBC_UESTA7_TXINI_Pos       0            /**< \brief (USBC_UESTA7) Transmitted IN Data Interrupt */
+#define USBC_UESTA7_TXINI           (_U(0x1) << USBC_UESTA7_TXINI_Pos)
+#define USBC_UESTA7_RXOUTI_Pos      1            /**< \brief (USBC_UESTA7) Received OUT Data Interrupt */
+#define USBC_UESTA7_RXOUTI          (_U(0x1) << USBC_UESTA7_RXOUTI_Pos)
+#define USBC_UESTA7_RXSTPI_Pos      2            /**< \brief (USBC_UESTA7) Received SETUP Interrupt */
+#define USBC_UESTA7_RXSTPI          (_U(0x1) << USBC_UESTA7_RXSTPI_Pos)
+#define USBC_UESTA7_NAKOUTI_Pos     3            /**< \brief (USBC_UESTA7) NAKed OUT Interrupt */
+#define USBC_UESTA7_NAKOUTI         (_U(0x1) << USBC_UESTA7_NAKOUTI_Pos)
+#define USBC_UESTA7_NAKINI_Pos      4            /**< \brief (USBC_UESTA7) NAKed IN Interrupt */
+#define USBC_UESTA7_NAKINI          (_U(0x1) << USBC_UESTA7_NAKINI_Pos)
+#define USBC_UESTA7_STALLEDI_Pos    6            /**< \brief (USBC_UESTA7) STALLed Interrupt */
+#define USBC_UESTA7_STALLEDI        (_U(0x1) << USBC_UESTA7_STALLEDI_Pos)
+#define USBC_UESTA7_DTSEQ_Pos       8            /**< \brief (USBC_UESTA7) Data Toggle Sequence */
+#define USBC_UESTA7_DTSEQ_Msk       (_U(0x3) << USBC_UESTA7_DTSEQ_Pos)
+#define USBC_UESTA7_DTSEQ(value)    (USBC_UESTA7_DTSEQ_Msk & ((value) << USBC_UESTA7_DTSEQ_Pos))
+#define USBC_UESTA7_RAMACERI_Pos    11           /**< \brief (USBC_UESTA7) Ram Access Error Interrupt */
+#define USBC_UESTA7_RAMACERI        (_U(0x1) << USBC_UESTA7_RAMACERI_Pos)
+#define USBC_UESTA7_NBUSYBK_Pos     12           /**< \brief (USBC_UESTA7) Number Of Busy Banks */
+#define USBC_UESTA7_NBUSYBK_Msk     (_U(0x3) << USBC_UESTA7_NBUSYBK_Pos)
+#define USBC_UESTA7_NBUSYBK(value)  (USBC_UESTA7_NBUSYBK_Msk & ((value) << USBC_UESTA7_NBUSYBK_Pos))
+#define USBC_UESTA7_CURRBK_Pos      14           /**< \brief (USBC_UESTA7) Current Bank */
+#define USBC_UESTA7_CURRBK_Msk      (_U(0x3) << USBC_UESTA7_CURRBK_Pos)
+#define USBC_UESTA7_CURRBK(value)   (USBC_UESTA7_CURRBK_Msk & ((value) << USBC_UESTA7_CURRBK_Pos))
+#define USBC_UESTA7_CTRLDIR_Pos     17           /**< \brief (USBC_UESTA7) Control Direction */
+#define USBC_UESTA7_CTRLDIR         (_U(0x1) << USBC_UESTA7_CTRLDIR_Pos)
+#define   USBC_UESTA7_CTRLDIR_OUT_Val     _U(0x0)   /**< \brief (USBC_UESTA7)  */
+#define   USBC_UESTA7_CTRLDIR_IN_Val      _U(0x1)   /**< \brief (USBC_UESTA7)  */
+#define USBC_UESTA7_CTRLDIR_OUT     (USBC_UESTA7_CTRLDIR_OUT_Val   << USBC_UESTA7_CTRLDIR_Pos)
+#define USBC_UESTA7_CTRLDIR_IN      (USBC_UESTA7_CTRLDIR_IN_Val    << USBC_UESTA7_CTRLDIR_Pos)
+#define USBC_UESTA7_MASK            _U(0x0002FB5F) /**< \brief (USBC_UESTA7) MASK Register */
+
+/* -------- USBC_UESTA0CLR : (USBC Offset: 0x160) ( /W 32) Endpoint Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINIC:1;         /*!< bit:      0  TXINI Clear                        */
+    uint32_t RXOUTIC:1;        /*!< bit:      1  RXOUTI Clear                       */
+    uint32_t RXSTPIC:1;        /*!< bit:      2  RXSTPI Clear                       */
+    uint32_t NAKOUTIC:1;       /*!< bit:      3  NAKOUTI Clear                      */
+    uint32_t NAKINIC:1;        /*!< bit:      4  NAKINI Clear                       */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDIC:1;      /*!< bit:      6  STALLEDI Clear                     */
+    uint32_t :4;               /*!< bit:  7..10  Reserved                           */
+    uint32_t RAMACERIC:1;      /*!< bit:     11  RAMACERI Clear                     */
+    uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UESTA0CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UESTA0CLR_OFFSET       0x160        /**< \brief (USBC_UESTA0CLR offset) Endpoint Status Clear Register */
+#define USBC_UESTA0CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA0CLR reset_value) Endpoint Status Clear Register */
+
+#define USBC_UESTA0CLR_TXINIC_Pos   0            /**< \brief (USBC_UESTA0CLR) TXINI Clear */
+#define USBC_UESTA0CLR_TXINIC       (_U(0x1) << USBC_UESTA0CLR_TXINIC_Pos)
+#define USBC_UESTA0CLR_RXOUTIC_Pos  1            /**< \brief (USBC_UESTA0CLR) RXOUTI Clear */
+#define USBC_UESTA0CLR_RXOUTIC      (_U(0x1) << USBC_UESTA0CLR_RXOUTIC_Pos)
+#define USBC_UESTA0CLR_RXSTPIC_Pos  2            /**< \brief (USBC_UESTA0CLR) RXSTPI Clear */
+#define USBC_UESTA0CLR_RXSTPIC      (_U(0x1) << USBC_UESTA0CLR_RXSTPIC_Pos)
+#define USBC_UESTA0CLR_NAKOUTIC_Pos 3            /**< \brief (USBC_UESTA0CLR) NAKOUTI Clear */
+#define USBC_UESTA0CLR_NAKOUTIC     (_U(0x1) << USBC_UESTA0CLR_NAKOUTIC_Pos)
+#define USBC_UESTA0CLR_NAKINIC_Pos  4            /**< \brief (USBC_UESTA0CLR) NAKINI Clear */
+#define USBC_UESTA0CLR_NAKINIC      (_U(0x1) << USBC_UESTA0CLR_NAKINIC_Pos)
+#define USBC_UESTA0CLR_STALLEDIC_Pos 6            /**< \brief (USBC_UESTA0CLR) STALLEDI Clear */
+#define USBC_UESTA0CLR_STALLEDIC    (_U(0x1) << USBC_UESTA0CLR_STALLEDIC_Pos)
+#define USBC_UESTA0CLR_RAMACERIC_Pos 11           /**< \brief (USBC_UESTA0CLR) RAMACERI Clear */
+#define USBC_UESTA0CLR_RAMACERIC    (_U(0x1) << USBC_UESTA0CLR_RAMACERIC_Pos)
+#define USBC_UESTA0CLR_MASK         _U(0x0000085F) /**< \brief (USBC_UESTA0CLR) MASK Register */
+
+/* -------- USBC_UESTA1CLR : (USBC Offset: 0x164) ( /W 32) Endpoint Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINIC:1;         /*!< bit:      0  TXINI Clear                        */
+    uint32_t RXOUTIC:1;        /*!< bit:      1  RXOUTI Clear                       */
+    uint32_t RXSTPIC:1;        /*!< bit:      2  RXSTPI Clear                       */
+    uint32_t NAKOUTIC:1;       /*!< bit:      3  NAKOUTI Clear                      */
+    uint32_t NAKINIC:1;        /*!< bit:      4  NAKINI Clear                       */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDIC:1;      /*!< bit:      6  STALLEDI Clear                     */
+    uint32_t :4;               /*!< bit:  7..10  Reserved                           */
+    uint32_t RAMACERIC:1;      /*!< bit:     11  RAMACERI Clear                     */
+    uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UESTA1CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UESTA1CLR_OFFSET       0x164        /**< \brief (USBC_UESTA1CLR offset) Endpoint Status Clear Register */
+#define USBC_UESTA1CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA1CLR reset_value) Endpoint Status Clear Register */
+
+#define USBC_UESTA1CLR_TXINIC_Pos   0            /**< \brief (USBC_UESTA1CLR) TXINI Clear */
+#define USBC_UESTA1CLR_TXINIC       (_U(0x1) << USBC_UESTA1CLR_TXINIC_Pos)
+#define USBC_UESTA1CLR_RXOUTIC_Pos  1            /**< \brief (USBC_UESTA1CLR) RXOUTI Clear */
+#define USBC_UESTA1CLR_RXOUTIC      (_U(0x1) << USBC_UESTA1CLR_RXOUTIC_Pos)
+#define USBC_UESTA1CLR_RXSTPIC_Pos  2            /**< \brief (USBC_UESTA1CLR) RXSTPI Clear */
+#define USBC_UESTA1CLR_RXSTPIC      (_U(0x1) << USBC_UESTA1CLR_RXSTPIC_Pos)
+#define USBC_UESTA1CLR_NAKOUTIC_Pos 3            /**< \brief (USBC_UESTA1CLR) NAKOUTI Clear */
+#define USBC_UESTA1CLR_NAKOUTIC     (_U(0x1) << USBC_UESTA1CLR_NAKOUTIC_Pos)
+#define USBC_UESTA1CLR_NAKINIC_Pos  4            /**< \brief (USBC_UESTA1CLR) NAKINI Clear */
+#define USBC_UESTA1CLR_NAKINIC      (_U(0x1) << USBC_UESTA1CLR_NAKINIC_Pos)
+#define USBC_UESTA1CLR_STALLEDIC_Pos 6            /**< \brief (USBC_UESTA1CLR) STALLEDI Clear */
+#define USBC_UESTA1CLR_STALLEDIC    (_U(0x1) << USBC_UESTA1CLR_STALLEDIC_Pos)
+#define USBC_UESTA1CLR_RAMACERIC_Pos 11           /**< \brief (USBC_UESTA1CLR) RAMACERI Clear */
+#define USBC_UESTA1CLR_RAMACERIC    (_U(0x1) << USBC_UESTA1CLR_RAMACERIC_Pos)
+#define USBC_UESTA1CLR_MASK         _U(0x0000085F) /**< \brief (USBC_UESTA1CLR) MASK Register */
+
+/* -------- USBC_UESTA2CLR : (USBC Offset: 0x168) ( /W 32) Endpoint Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINIC:1;         /*!< bit:      0  TXINI Clear                        */
+    uint32_t RXOUTIC:1;        /*!< bit:      1  RXOUTI Clear                       */
+    uint32_t RXSTPIC:1;        /*!< bit:      2  RXSTPI Clear                       */
+    uint32_t NAKOUTIC:1;       /*!< bit:      3  NAKOUTI Clear                      */
+    uint32_t NAKINIC:1;        /*!< bit:      4  NAKINI Clear                       */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDIC:1;      /*!< bit:      6  STALLEDI Clear                     */
+    uint32_t :4;               /*!< bit:  7..10  Reserved                           */
+    uint32_t RAMACERIC:1;      /*!< bit:     11  RAMACERI Clear                     */
+    uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UESTA2CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UESTA2CLR_OFFSET       0x168        /**< \brief (USBC_UESTA2CLR offset) Endpoint Status Clear Register */
+#define USBC_UESTA2CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA2CLR reset_value) Endpoint Status Clear Register */
+
+#define USBC_UESTA2CLR_TXINIC_Pos   0            /**< \brief (USBC_UESTA2CLR) TXINI Clear */
+#define USBC_UESTA2CLR_TXINIC       (_U(0x1) << USBC_UESTA2CLR_TXINIC_Pos)
+#define USBC_UESTA2CLR_RXOUTIC_Pos  1            /**< \brief (USBC_UESTA2CLR) RXOUTI Clear */
+#define USBC_UESTA2CLR_RXOUTIC      (_U(0x1) << USBC_UESTA2CLR_RXOUTIC_Pos)
+#define USBC_UESTA2CLR_RXSTPIC_Pos  2            /**< \brief (USBC_UESTA2CLR) RXSTPI Clear */
+#define USBC_UESTA2CLR_RXSTPIC      (_U(0x1) << USBC_UESTA2CLR_RXSTPIC_Pos)
+#define USBC_UESTA2CLR_NAKOUTIC_Pos 3            /**< \brief (USBC_UESTA2CLR) NAKOUTI Clear */
+#define USBC_UESTA2CLR_NAKOUTIC     (_U(0x1) << USBC_UESTA2CLR_NAKOUTIC_Pos)
+#define USBC_UESTA2CLR_NAKINIC_Pos  4            /**< \brief (USBC_UESTA2CLR) NAKINI Clear */
+#define USBC_UESTA2CLR_NAKINIC      (_U(0x1) << USBC_UESTA2CLR_NAKINIC_Pos)
+#define USBC_UESTA2CLR_STALLEDIC_Pos 6            /**< \brief (USBC_UESTA2CLR) STALLEDI Clear */
+#define USBC_UESTA2CLR_STALLEDIC    (_U(0x1) << USBC_UESTA2CLR_STALLEDIC_Pos)
+#define USBC_UESTA2CLR_RAMACERIC_Pos 11           /**< \brief (USBC_UESTA2CLR) RAMACERI Clear */
+#define USBC_UESTA2CLR_RAMACERIC    (_U(0x1) << USBC_UESTA2CLR_RAMACERIC_Pos)
+#define USBC_UESTA2CLR_MASK         _U(0x0000085F) /**< \brief (USBC_UESTA2CLR) MASK Register */
+
+/* -------- USBC_UESTA3CLR : (USBC Offset: 0x16C) ( /W 32) Endpoint Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINIC:1;         /*!< bit:      0  TXINI Clear                        */
+    uint32_t RXOUTIC:1;        /*!< bit:      1  RXOUTI Clear                       */
+    uint32_t RXSTPIC:1;        /*!< bit:      2  RXSTPI Clear                       */
+    uint32_t NAKOUTIC:1;       /*!< bit:      3  NAKOUTI Clear                      */
+    uint32_t NAKINIC:1;        /*!< bit:      4  NAKINI Clear                       */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDIC:1;      /*!< bit:      6  STALLEDI Clear                     */
+    uint32_t :4;               /*!< bit:  7..10  Reserved                           */
+    uint32_t RAMACERIC:1;      /*!< bit:     11  RAMACERI Clear                     */
+    uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UESTA3CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UESTA3CLR_OFFSET       0x16C        /**< \brief (USBC_UESTA3CLR offset) Endpoint Status Clear Register */
+#define USBC_UESTA3CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA3CLR reset_value) Endpoint Status Clear Register */
+
+#define USBC_UESTA3CLR_TXINIC_Pos   0            /**< \brief (USBC_UESTA3CLR) TXINI Clear */
+#define USBC_UESTA3CLR_TXINIC       (_U(0x1) << USBC_UESTA3CLR_TXINIC_Pos)
+#define USBC_UESTA3CLR_RXOUTIC_Pos  1            /**< \brief (USBC_UESTA3CLR) RXOUTI Clear */
+#define USBC_UESTA3CLR_RXOUTIC      (_U(0x1) << USBC_UESTA3CLR_RXOUTIC_Pos)
+#define USBC_UESTA3CLR_RXSTPIC_Pos  2            /**< \brief (USBC_UESTA3CLR) RXSTPI Clear */
+#define USBC_UESTA3CLR_RXSTPIC      (_U(0x1) << USBC_UESTA3CLR_RXSTPIC_Pos)
+#define USBC_UESTA3CLR_NAKOUTIC_Pos 3            /**< \brief (USBC_UESTA3CLR) NAKOUTI Clear */
+#define USBC_UESTA3CLR_NAKOUTIC     (_U(0x1) << USBC_UESTA3CLR_NAKOUTIC_Pos)
+#define USBC_UESTA3CLR_NAKINIC_Pos  4            /**< \brief (USBC_UESTA3CLR) NAKINI Clear */
+#define USBC_UESTA3CLR_NAKINIC      (_U(0x1) << USBC_UESTA3CLR_NAKINIC_Pos)
+#define USBC_UESTA3CLR_STALLEDIC_Pos 6            /**< \brief (USBC_UESTA3CLR) STALLEDI Clear */
+#define USBC_UESTA3CLR_STALLEDIC    (_U(0x1) << USBC_UESTA3CLR_STALLEDIC_Pos)
+#define USBC_UESTA3CLR_RAMACERIC_Pos 11           /**< \brief (USBC_UESTA3CLR) RAMACERI Clear */
+#define USBC_UESTA3CLR_RAMACERIC    (_U(0x1) << USBC_UESTA3CLR_RAMACERIC_Pos)
+#define USBC_UESTA3CLR_MASK         _U(0x0000085F) /**< \brief (USBC_UESTA3CLR) MASK Register */
+
+/* -------- USBC_UESTA4CLR : (USBC Offset: 0x170) ( /W 32) Endpoint Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINIC:1;         /*!< bit:      0  TXINI Clear                        */
+    uint32_t RXOUTIC:1;        /*!< bit:      1  RXOUTI Clear                       */
+    uint32_t RXSTPIC:1;        /*!< bit:      2  RXSTPI Clear                       */
+    uint32_t NAKOUTIC:1;       /*!< bit:      3  NAKOUTI Clear                      */
+    uint32_t NAKINIC:1;        /*!< bit:      4  NAKINI Clear                       */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDIC:1;      /*!< bit:      6  STALLEDI Clear                     */
+    uint32_t :4;               /*!< bit:  7..10  Reserved                           */
+    uint32_t RAMACERIC:1;      /*!< bit:     11  RAMACERI Clear                     */
+    uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UESTA4CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UESTA4CLR_OFFSET       0x170        /**< \brief (USBC_UESTA4CLR offset) Endpoint Status Clear Register */
+#define USBC_UESTA4CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA4CLR reset_value) Endpoint Status Clear Register */
+
+#define USBC_UESTA4CLR_TXINIC_Pos   0            /**< \brief (USBC_UESTA4CLR) TXINI Clear */
+#define USBC_UESTA4CLR_TXINIC       (_U(0x1) << USBC_UESTA4CLR_TXINIC_Pos)
+#define USBC_UESTA4CLR_RXOUTIC_Pos  1            /**< \brief (USBC_UESTA4CLR) RXOUTI Clear */
+#define USBC_UESTA4CLR_RXOUTIC      (_U(0x1) << USBC_UESTA4CLR_RXOUTIC_Pos)
+#define USBC_UESTA4CLR_RXSTPIC_Pos  2            /**< \brief (USBC_UESTA4CLR) RXSTPI Clear */
+#define USBC_UESTA4CLR_RXSTPIC      (_U(0x1) << USBC_UESTA4CLR_RXSTPIC_Pos)
+#define USBC_UESTA4CLR_NAKOUTIC_Pos 3            /**< \brief (USBC_UESTA4CLR) NAKOUTI Clear */
+#define USBC_UESTA4CLR_NAKOUTIC     (_U(0x1) << USBC_UESTA4CLR_NAKOUTIC_Pos)
+#define USBC_UESTA4CLR_NAKINIC_Pos  4            /**< \brief (USBC_UESTA4CLR) NAKINI Clear */
+#define USBC_UESTA4CLR_NAKINIC      (_U(0x1) << USBC_UESTA4CLR_NAKINIC_Pos)
+#define USBC_UESTA4CLR_STALLEDIC_Pos 6            /**< \brief (USBC_UESTA4CLR) STALLEDI Clear */
+#define USBC_UESTA4CLR_STALLEDIC    (_U(0x1) << USBC_UESTA4CLR_STALLEDIC_Pos)
+#define USBC_UESTA4CLR_RAMACERIC_Pos 11           /**< \brief (USBC_UESTA4CLR) RAMACERI Clear */
+#define USBC_UESTA4CLR_RAMACERIC    (_U(0x1) << USBC_UESTA4CLR_RAMACERIC_Pos)
+#define USBC_UESTA4CLR_MASK         _U(0x0000085F) /**< \brief (USBC_UESTA4CLR) MASK Register */
+
+/* -------- USBC_UESTA5CLR : (USBC Offset: 0x174) ( /W 32) Endpoint Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINIC:1;         /*!< bit:      0  TXINI Clear                        */
+    uint32_t RXOUTIC:1;        /*!< bit:      1  RXOUTI Clear                       */
+    uint32_t RXSTPIC:1;        /*!< bit:      2  RXSTPI Clear                       */
+    uint32_t NAKOUTIC:1;       /*!< bit:      3  NAKOUTI Clear                      */
+    uint32_t NAKINIC:1;        /*!< bit:      4  NAKINI Clear                       */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDIC:1;      /*!< bit:      6  STALLEDI Clear                     */
+    uint32_t :4;               /*!< bit:  7..10  Reserved                           */
+    uint32_t RAMACERIC:1;      /*!< bit:     11  RAMACERI Clear                     */
+    uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UESTA5CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UESTA5CLR_OFFSET       0x174        /**< \brief (USBC_UESTA5CLR offset) Endpoint Status Clear Register */
+#define USBC_UESTA5CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA5CLR reset_value) Endpoint Status Clear Register */
+
+#define USBC_UESTA5CLR_TXINIC_Pos   0            /**< \brief (USBC_UESTA5CLR) TXINI Clear */
+#define USBC_UESTA5CLR_TXINIC       (_U(0x1) << USBC_UESTA5CLR_TXINIC_Pos)
+#define USBC_UESTA5CLR_RXOUTIC_Pos  1            /**< \brief (USBC_UESTA5CLR) RXOUTI Clear */
+#define USBC_UESTA5CLR_RXOUTIC      (_U(0x1) << USBC_UESTA5CLR_RXOUTIC_Pos)
+#define USBC_UESTA5CLR_RXSTPIC_Pos  2            /**< \brief (USBC_UESTA5CLR) RXSTPI Clear */
+#define USBC_UESTA5CLR_RXSTPIC      (_U(0x1) << USBC_UESTA5CLR_RXSTPIC_Pos)
+#define USBC_UESTA5CLR_NAKOUTIC_Pos 3            /**< \brief (USBC_UESTA5CLR) NAKOUTI Clear */
+#define USBC_UESTA5CLR_NAKOUTIC     (_U(0x1) << USBC_UESTA5CLR_NAKOUTIC_Pos)
+#define USBC_UESTA5CLR_NAKINIC_Pos  4            /**< \brief (USBC_UESTA5CLR) NAKINI Clear */
+#define USBC_UESTA5CLR_NAKINIC      (_U(0x1) << USBC_UESTA5CLR_NAKINIC_Pos)
+#define USBC_UESTA5CLR_STALLEDIC_Pos 6            /**< \brief (USBC_UESTA5CLR) STALLEDI Clear */
+#define USBC_UESTA5CLR_STALLEDIC    (_U(0x1) << USBC_UESTA5CLR_STALLEDIC_Pos)
+#define USBC_UESTA5CLR_RAMACERIC_Pos 11           /**< \brief (USBC_UESTA5CLR) RAMACERI Clear */
+#define USBC_UESTA5CLR_RAMACERIC    (_U(0x1) << USBC_UESTA5CLR_RAMACERIC_Pos)
+#define USBC_UESTA5CLR_MASK         _U(0x0000085F) /**< \brief (USBC_UESTA5CLR) MASK Register */
+
+/* -------- USBC_UESTA6CLR : (USBC Offset: 0x178) ( /W 32) Endpoint Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINIC:1;         /*!< bit:      0  TXINI Clear                        */
+    uint32_t RXOUTIC:1;        /*!< bit:      1  RXOUTI Clear                       */
+    uint32_t RXSTPIC:1;        /*!< bit:      2  RXSTPI Clear                       */
+    uint32_t NAKOUTIC:1;       /*!< bit:      3  NAKOUTI Clear                      */
+    uint32_t NAKINIC:1;        /*!< bit:      4  NAKINI Clear                       */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDIC:1;      /*!< bit:      6  STALLEDI Clear                     */
+    uint32_t :4;               /*!< bit:  7..10  Reserved                           */
+    uint32_t RAMACERIC:1;      /*!< bit:     11  RAMACERI Clear                     */
+    uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UESTA6CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UESTA6CLR_OFFSET       0x178        /**< \brief (USBC_UESTA6CLR offset) Endpoint Status Clear Register */
+#define USBC_UESTA6CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA6CLR reset_value) Endpoint Status Clear Register */
+
+#define USBC_UESTA6CLR_TXINIC_Pos   0            /**< \brief (USBC_UESTA6CLR) TXINI Clear */
+#define USBC_UESTA6CLR_TXINIC       (_U(0x1) << USBC_UESTA6CLR_TXINIC_Pos)
+#define USBC_UESTA6CLR_RXOUTIC_Pos  1            /**< \brief (USBC_UESTA6CLR) RXOUTI Clear */
+#define USBC_UESTA6CLR_RXOUTIC      (_U(0x1) << USBC_UESTA6CLR_RXOUTIC_Pos)
+#define USBC_UESTA6CLR_RXSTPIC_Pos  2            /**< \brief (USBC_UESTA6CLR) RXSTPI Clear */
+#define USBC_UESTA6CLR_RXSTPIC      (_U(0x1) << USBC_UESTA6CLR_RXSTPIC_Pos)
+#define USBC_UESTA6CLR_NAKOUTIC_Pos 3            /**< \brief (USBC_UESTA6CLR) NAKOUTI Clear */
+#define USBC_UESTA6CLR_NAKOUTIC     (_U(0x1) << USBC_UESTA6CLR_NAKOUTIC_Pos)
+#define USBC_UESTA6CLR_NAKINIC_Pos  4            /**< \brief (USBC_UESTA6CLR) NAKINI Clear */
+#define USBC_UESTA6CLR_NAKINIC      (_U(0x1) << USBC_UESTA6CLR_NAKINIC_Pos)
+#define USBC_UESTA6CLR_STALLEDIC_Pos 6            /**< \brief (USBC_UESTA6CLR) STALLEDI Clear */
+#define USBC_UESTA6CLR_STALLEDIC    (_U(0x1) << USBC_UESTA6CLR_STALLEDIC_Pos)
+#define USBC_UESTA6CLR_RAMACERIC_Pos 11           /**< \brief (USBC_UESTA6CLR) RAMACERI Clear */
+#define USBC_UESTA6CLR_RAMACERIC    (_U(0x1) << USBC_UESTA6CLR_RAMACERIC_Pos)
+#define USBC_UESTA6CLR_MASK         _U(0x0000085F) /**< \brief (USBC_UESTA6CLR) MASK Register */
+
+/* -------- USBC_UESTA7CLR : (USBC Offset: 0x17C) ( /W 32) Endpoint Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINIC:1;         /*!< bit:      0  TXINI Clear                        */
+    uint32_t RXOUTIC:1;        /*!< bit:      1  RXOUTI Clear                       */
+    uint32_t RXSTPIC:1;        /*!< bit:      2  RXSTPI Clear                       */
+    uint32_t NAKOUTIC:1;       /*!< bit:      3  NAKOUTI Clear                      */
+    uint32_t NAKINIC:1;        /*!< bit:      4  NAKINI Clear                       */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDIC:1;      /*!< bit:      6  STALLEDI Clear                     */
+    uint32_t :4;               /*!< bit:  7..10  Reserved                           */
+    uint32_t RAMACERIC:1;      /*!< bit:     11  RAMACERI Clear                     */
+    uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UESTA7CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UESTA7CLR_OFFSET       0x17C        /**< \brief (USBC_UESTA7CLR offset) Endpoint Status Clear Register */
+#define USBC_UESTA7CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA7CLR reset_value) Endpoint Status Clear Register */
+
+#define USBC_UESTA7CLR_TXINIC_Pos   0            /**< \brief (USBC_UESTA7CLR) TXINI Clear */
+#define USBC_UESTA7CLR_TXINIC       (_U(0x1) << USBC_UESTA7CLR_TXINIC_Pos)
+#define USBC_UESTA7CLR_RXOUTIC_Pos  1            /**< \brief (USBC_UESTA7CLR) RXOUTI Clear */
+#define USBC_UESTA7CLR_RXOUTIC      (_U(0x1) << USBC_UESTA7CLR_RXOUTIC_Pos)
+#define USBC_UESTA7CLR_RXSTPIC_Pos  2            /**< \brief (USBC_UESTA7CLR) RXSTPI Clear */
+#define USBC_UESTA7CLR_RXSTPIC      (_U(0x1) << USBC_UESTA7CLR_RXSTPIC_Pos)
+#define USBC_UESTA7CLR_NAKOUTIC_Pos 3            /**< \brief (USBC_UESTA7CLR) NAKOUTI Clear */
+#define USBC_UESTA7CLR_NAKOUTIC     (_U(0x1) << USBC_UESTA7CLR_NAKOUTIC_Pos)
+#define USBC_UESTA7CLR_NAKINIC_Pos  4            /**< \brief (USBC_UESTA7CLR) NAKINI Clear */
+#define USBC_UESTA7CLR_NAKINIC      (_U(0x1) << USBC_UESTA7CLR_NAKINIC_Pos)
+#define USBC_UESTA7CLR_STALLEDIC_Pos 6            /**< \brief (USBC_UESTA7CLR) STALLEDI Clear */
+#define USBC_UESTA7CLR_STALLEDIC    (_U(0x1) << USBC_UESTA7CLR_STALLEDIC_Pos)
+#define USBC_UESTA7CLR_RAMACERIC_Pos 11           /**< \brief (USBC_UESTA7CLR) RAMACERI Clear */
+#define USBC_UESTA7CLR_RAMACERIC    (_U(0x1) << USBC_UESTA7CLR_RAMACERIC_Pos)
+#define USBC_UESTA7CLR_MASK         _U(0x0000085F) /**< \brief (USBC_UESTA7CLR) MASK Register */
+
+/* -------- USBC_UESTA0SET : (USBC Offset: 0x190) ( /W 32) Endpoint Status Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINIS:1;         /*!< bit:      0  TXINI Set                          */
+    uint32_t RXOUTIS:1;        /*!< bit:      1  RXOUTI Set                         */
+    uint32_t RXSTPIS:1;        /*!< bit:      2  RXSTPI Set                         */
+    uint32_t NAKOUTIS:1;       /*!< bit:      3  NAKOUTI Set                        */
+    uint32_t NAKINIS:1;        /*!< bit:      4  NAKINI Set                         */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDIS:1;      /*!< bit:      6  STALLEDI Set                       */
+    uint32_t :4;               /*!< bit:  7..10  Reserved                           */
+    uint32_t RAMACERIS:1;      /*!< bit:     11  RAMACERI Set                       */
+    uint32_t NBUSYBKS:1;       /*!< bit:     12  NBUSYBK Set                        */
+    uint32_t :19;              /*!< bit: 13..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UESTA0SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UESTA0SET_OFFSET       0x190        /**< \brief (USBC_UESTA0SET offset) Endpoint Status Set Register */
+#define USBC_UESTA0SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA0SET reset_value) Endpoint Status Set Register */
+
+#define USBC_UESTA0SET_TXINIS_Pos   0            /**< \brief (USBC_UESTA0SET) TXINI Set */
+#define USBC_UESTA0SET_TXINIS       (_U(0x1) << USBC_UESTA0SET_TXINIS_Pos)
+#define USBC_UESTA0SET_RXOUTIS_Pos  1            /**< \brief (USBC_UESTA0SET) RXOUTI Set */
+#define USBC_UESTA0SET_RXOUTIS      (_U(0x1) << USBC_UESTA0SET_RXOUTIS_Pos)
+#define USBC_UESTA0SET_RXSTPIS_Pos  2            /**< \brief (USBC_UESTA0SET) RXSTPI Set */
+#define USBC_UESTA0SET_RXSTPIS      (_U(0x1) << USBC_UESTA0SET_RXSTPIS_Pos)
+#define USBC_UESTA0SET_NAKOUTIS_Pos 3            /**< \brief (USBC_UESTA0SET) NAKOUTI Set */
+#define USBC_UESTA0SET_NAKOUTIS     (_U(0x1) << USBC_UESTA0SET_NAKOUTIS_Pos)
+#define USBC_UESTA0SET_NAKINIS_Pos  4            /**< \brief (USBC_UESTA0SET) NAKINI Set */
+#define USBC_UESTA0SET_NAKINIS      (_U(0x1) << USBC_UESTA0SET_NAKINIS_Pos)
+#define USBC_UESTA0SET_STALLEDIS_Pos 6            /**< \brief (USBC_UESTA0SET) STALLEDI Set */
+#define USBC_UESTA0SET_STALLEDIS    (_U(0x1) << USBC_UESTA0SET_STALLEDIS_Pos)
+#define USBC_UESTA0SET_RAMACERIS_Pos 11           /**< \brief (USBC_UESTA0SET) RAMACERI Set */
+#define USBC_UESTA0SET_RAMACERIS    (_U(0x1) << USBC_UESTA0SET_RAMACERIS_Pos)
+#define USBC_UESTA0SET_NBUSYBKS_Pos 12           /**< \brief (USBC_UESTA0SET) NBUSYBK Set */
+#define USBC_UESTA0SET_NBUSYBKS     (_U(0x1) << USBC_UESTA0SET_NBUSYBKS_Pos)
+#define USBC_UESTA0SET_MASK         _U(0x0000185F) /**< \brief (USBC_UESTA0SET) MASK Register */
+
+/* -------- USBC_UESTA1SET : (USBC Offset: 0x194) ( /W 32) Endpoint Status Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINIS:1;         /*!< bit:      0  TXINI Set                          */
+    uint32_t RXOUTIS:1;        /*!< bit:      1  RXOUTI Set                         */
+    uint32_t RXSTPIS:1;        /*!< bit:      2  RXSTPI Set                         */
+    uint32_t NAKOUTIS:1;       /*!< bit:      3  NAKOUTI Set                        */
+    uint32_t NAKINIS:1;        /*!< bit:      4  NAKINI Set                         */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDIS:1;      /*!< bit:      6  STALLEDI Set                       */
+    uint32_t :4;               /*!< bit:  7..10  Reserved                           */
+    uint32_t RAMACERIS:1;      /*!< bit:     11  RAMACERI Set                       */
+    uint32_t NBUSYBKS:1;       /*!< bit:     12  NBUSYBK Set                        */
+    uint32_t :19;              /*!< bit: 13..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UESTA1SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UESTA1SET_OFFSET       0x194        /**< \brief (USBC_UESTA1SET offset) Endpoint Status Set Register */
+#define USBC_UESTA1SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA1SET reset_value) Endpoint Status Set Register */
+
+#define USBC_UESTA1SET_TXINIS_Pos   0            /**< \brief (USBC_UESTA1SET) TXINI Set */
+#define USBC_UESTA1SET_TXINIS       (_U(0x1) << USBC_UESTA1SET_TXINIS_Pos)
+#define USBC_UESTA1SET_RXOUTIS_Pos  1            /**< \brief (USBC_UESTA1SET) RXOUTI Set */
+#define USBC_UESTA1SET_RXOUTIS      (_U(0x1) << USBC_UESTA1SET_RXOUTIS_Pos)
+#define USBC_UESTA1SET_RXSTPIS_Pos  2            /**< \brief (USBC_UESTA1SET) RXSTPI Set */
+#define USBC_UESTA1SET_RXSTPIS      (_U(0x1) << USBC_UESTA1SET_RXSTPIS_Pos)
+#define USBC_UESTA1SET_NAKOUTIS_Pos 3            /**< \brief (USBC_UESTA1SET) NAKOUTI Set */
+#define USBC_UESTA1SET_NAKOUTIS     (_U(0x1) << USBC_UESTA1SET_NAKOUTIS_Pos)
+#define USBC_UESTA1SET_NAKINIS_Pos  4            /**< \brief (USBC_UESTA1SET) NAKINI Set */
+#define USBC_UESTA1SET_NAKINIS      (_U(0x1) << USBC_UESTA1SET_NAKINIS_Pos)
+#define USBC_UESTA1SET_STALLEDIS_Pos 6            /**< \brief (USBC_UESTA1SET) STALLEDI Set */
+#define USBC_UESTA1SET_STALLEDIS    (_U(0x1) << USBC_UESTA1SET_STALLEDIS_Pos)
+#define USBC_UESTA1SET_RAMACERIS_Pos 11           /**< \brief (USBC_UESTA1SET) RAMACERI Set */
+#define USBC_UESTA1SET_RAMACERIS    (_U(0x1) << USBC_UESTA1SET_RAMACERIS_Pos)
+#define USBC_UESTA1SET_NBUSYBKS_Pos 12           /**< \brief (USBC_UESTA1SET) NBUSYBK Set */
+#define USBC_UESTA1SET_NBUSYBKS     (_U(0x1) << USBC_UESTA1SET_NBUSYBKS_Pos)
+#define USBC_UESTA1SET_MASK         _U(0x0000185F) /**< \brief (USBC_UESTA1SET) MASK Register */
+
+/* -------- USBC_UESTA2SET : (USBC Offset: 0x198) ( /W 32) Endpoint Status Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINIS:1;         /*!< bit:      0  TXINI Set                          */
+    uint32_t RXOUTIS:1;        /*!< bit:      1  RXOUTI Set                         */
+    uint32_t RXSTPIS:1;        /*!< bit:      2  RXSTPI Set                         */
+    uint32_t NAKOUTIS:1;       /*!< bit:      3  NAKOUTI Set                        */
+    uint32_t NAKINIS:1;        /*!< bit:      4  NAKINI Set                         */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDIS:1;      /*!< bit:      6  STALLEDI Set                       */
+    uint32_t :4;               /*!< bit:  7..10  Reserved                           */
+    uint32_t RAMACERIS:1;      /*!< bit:     11  RAMACERI Set                       */
+    uint32_t NBUSYBKS:1;       /*!< bit:     12  NBUSYBK Set                        */
+    uint32_t :19;              /*!< bit: 13..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UESTA2SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UESTA2SET_OFFSET       0x198        /**< \brief (USBC_UESTA2SET offset) Endpoint Status Set Register */
+#define USBC_UESTA2SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA2SET reset_value) Endpoint Status Set Register */
+
+#define USBC_UESTA2SET_TXINIS_Pos   0            /**< \brief (USBC_UESTA2SET) TXINI Set */
+#define USBC_UESTA2SET_TXINIS       (_U(0x1) << USBC_UESTA2SET_TXINIS_Pos)
+#define USBC_UESTA2SET_RXOUTIS_Pos  1            /**< \brief (USBC_UESTA2SET) RXOUTI Set */
+#define USBC_UESTA2SET_RXOUTIS      (_U(0x1) << USBC_UESTA2SET_RXOUTIS_Pos)
+#define USBC_UESTA2SET_RXSTPIS_Pos  2            /**< \brief (USBC_UESTA2SET) RXSTPI Set */
+#define USBC_UESTA2SET_RXSTPIS      (_U(0x1) << USBC_UESTA2SET_RXSTPIS_Pos)
+#define USBC_UESTA2SET_NAKOUTIS_Pos 3            /**< \brief (USBC_UESTA2SET) NAKOUTI Set */
+#define USBC_UESTA2SET_NAKOUTIS     (_U(0x1) << USBC_UESTA2SET_NAKOUTIS_Pos)
+#define USBC_UESTA2SET_NAKINIS_Pos  4            /**< \brief (USBC_UESTA2SET) NAKINI Set */
+#define USBC_UESTA2SET_NAKINIS      (_U(0x1) << USBC_UESTA2SET_NAKINIS_Pos)
+#define USBC_UESTA2SET_STALLEDIS_Pos 6            /**< \brief (USBC_UESTA2SET) STALLEDI Set */
+#define USBC_UESTA2SET_STALLEDIS    (_U(0x1) << USBC_UESTA2SET_STALLEDIS_Pos)
+#define USBC_UESTA2SET_RAMACERIS_Pos 11           /**< \brief (USBC_UESTA2SET) RAMACERI Set */
+#define USBC_UESTA2SET_RAMACERIS    (_U(0x1) << USBC_UESTA2SET_RAMACERIS_Pos)
+#define USBC_UESTA2SET_NBUSYBKS_Pos 12           /**< \brief (USBC_UESTA2SET) NBUSYBK Set */
+#define USBC_UESTA2SET_NBUSYBKS     (_U(0x1) << USBC_UESTA2SET_NBUSYBKS_Pos)
+#define USBC_UESTA2SET_MASK         _U(0x0000185F) /**< \brief (USBC_UESTA2SET) MASK Register */
+
+/* -------- USBC_UESTA3SET : (USBC Offset: 0x19C) ( /W 32) Endpoint Status Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINIS:1;         /*!< bit:      0  TXINI Set                          */
+    uint32_t RXOUTIS:1;        /*!< bit:      1  RXOUTI Set                         */
+    uint32_t RXSTPIS:1;        /*!< bit:      2  RXSTPI Set                         */
+    uint32_t NAKOUTIS:1;       /*!< bit:      3  NAKOUTI Set                        */
+    uint32_t NAKINIS:1;        /*!< bit:      4  NAKINI Set                         */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDIS:1;      /*!< bit:      6  STALLEDI Set                       */
+    uint32_t :4;               /*!< bit:  7..10  Reserved                           */
+    uint32_t RAMACERIS:1;      /*!< bit:     11  RAMACERI Set                       */
+    uint32_t NBUSYBKS:1;       /*!< bit:     12  NBUSYBK Set                        */
+    uint32_t :19;              /*!< bit: 13..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UESTA3SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UESTA3SET_OFFSET       0x19C        /**< \brief (USBC_UESTA3SET offset) Endpoint Status Set Register */
+#define USBC_UESTA3SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA3SET reset_value) Endpoint Status Set Register */
+
+#define USBC_UESTA3SET_TXINIS_Pos   0            /**< \brief (USBC_UESTA3SET) TXINI Set */
+#define USBC_UESTA3SET_TXINIS       (_U(0x1) << USBC_UESTA3SET_TXINIS_Pos)
+#define USBC_UESTA3SET_RXOUTIS_Pos  1            /**< \brief (USBC_UESTA3SET) RXOUTI Set */
+#define USBC_UESTA3SET_RXOUTIS      (_U(0x1) << USBC_UESTA3SET_RXOUTIS_Pos)
+#define USBC_UESTA3SET_RXSTPIS_Pos  2            /**< \brief (USBC_UESTA3SET) RXSTPI Set */
+#define USBC_UESTA3SET_RXSTPIS      (_U(0x1) << USBC_UESTA3SET_RXSTPIS_Pos)
+#define USBC_UESTA3SET_NAKOUTIS_Pos 3            /**< \brief (USBC_UESTA3SET) NAKOUTI Set */
+#define USBC_UESTA3SET_NAKOUTIS     (_U(0x1) << USBC_UESTA3SET_NAKOUTIS_Pos)
+#define USBC_UESTA3SET_NAKINIS_Pos  4            /**< \brief (USBC_UESTA3SET) NAKINI Set */
+#define USBC_UESTA3SET_NAKINIS      (_U(0x1) << USBC_UESTA3SET_NAKINIS_Pos)
+#define USBC_UESTA3SET_STALLEDIS_Pos 6            /**< \brief (USBC_UESTA3SET) STALLEDI Set */
+#define USBC_UESTA3SET_STALLEDIS    (_U(0x1) << USBC_UESTA3SET_STALLEDIS_Pos)
+#define USBC_UESTA3SET_RAMACERIS_Pos 11           /**< \brief (USBC_UESTA3SET) RAMACERI Set */
+#define USBC_UESTA3SET_RAMACERIS    (_U(0x1) << USBC_UESTA3SET_RAMACERIS_Pos)
+#define USBC_UESTA3SET_NBUSYBKS_Pos 12           /**< \brief (USBC_UESTA3SET) NBUSYBK Set */
+#define USBC_UESTA3SET_NBUSYBKS     (_U(0x1) << USBC_UESTA3SET_NBUSYBKS_Pos)
+#define USBC_UESTA3SET_MASK         _U(0x0000185F) /**< \brief (USBC_UESTA3SET) MASK Register */
+
+/* -------- USBC_UESTA4SET : (USBC Offset: 0x1A0) ( /W 32) Endpoint Status Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINIS:1;         /*!< bit:      0  TXINI Set                          */
+    uint32_t RXOUTIS:1;        /*!< bit:      1  RXOUTI Set                         */
+    uint32_t RXSTPIS:1;        /*!< bit:      2  RXSTPI Set                         */
+    uint32_t NAKOUTIS:1;       /*!< bit:      3  NAKOUTI Set                        */
+    uint32_t NAKINIS:1;        /*!< bit:      4  NAKINI Set                         */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDIS:1;      /*!< bit:      6  STALLEDI Set                       */
+    uint32_t :4;               /*!< bit:  7..10  Reserved                           */
+    uint32_t RAMACERIS:1;      /*!< bit:     11  RAMACERI Set                       */
+    uint32_t NBUSYBKS:1;       /*!< bit:     12  NBUSYBK Set                        */
+    uint32_t :19;              /*!< bit: 13..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UESTA4SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UESTA4SET_OFFSET       0x1A0        /**< \brief (USBC_UESTA4SET offset) Endpoint Status Set Register */
+#define USBC_UESTA4SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA4SET reset_value) Endpoint Status Set Register */
+
+#define USBC_UESTA4SET_TXINIS_Pos   0            /**< \brief (USBC_UESTA4SET) TXINI Set */
+#define USBC_UESTA4SET_TXINIS       (_U(0x1) << USBC_UESTA4SET_TXINIS_Pos)
+#define USBC_UESTA4SET_RXOUTIS_Pos  1            /**< \brief (USBC_UESTA4SET) RXOUTI Set */
+#define USBC_UESTA4SET_RXOUTIS      (_U(0x1) << USBC_UESTA4SET_RXOUTIS_Pos)
+#define USBC_UESTA4SET_RXSTPIS_Pos  2            /**< \brief (USBC_UESTA4SET) RXSTPI Set */
+#define USBC_UESTA4SET_RXSTPIS      (_U(0x1) << USBC_UESTA4SET_RXSTPIS_Pos)
+#define USBC_UESTA4SET_NAKOUTIS_Pos 3            /**< \brief (USBC_UESTA4SET) NAKOUTI Set */
+#define USBC_UESTA4SET_NAKOUTIS     (_U(0x1) << USBC_UESTA4SET_NAKOUTIS_Pos)
+#define USBC_UESTA4SET_NAKINIS_Pos  4            /**< \brief (USBC_UESTA4SET) NAKINI Set */
+#define USBC_UESTA4SET_NAKINIS      (_U(0x1) << USBC_UESTA4SET_NAKINIS_Pos)
+#define USBC_UESTA4SET_STALLEDIS_Pos 6            /**< \brief (USBC_UESTA4SET) STALLEDI Set */
+#define USBC_UESTA4SET_STALLEDIS    (_U(0x1) << USBC_UESTA4SET_STALLEDIS_Pos)
+#define USBC_UESTA4SET_RAMACERIS_Pos 11           /**< \brief (USBC_UESTA4SET) RAMACERI Set */
+#define USBC_UESTA4SET_RAMACERIS    (_U(0x1) << USBC_UESTA4SET_RAMACERIS_Pos)
+#define USBC_UESTA4SET_NBUSYBKS_Pos 12           /**< \brief (USBC_UESTA4SET) NBUSYBK Set */
+#define USBC_UESTA4SET_NBUSYBKS     (_U(0x1) << USBC_UESTA4SET_NBUSYBKS_Pos)
+#define USBC_UESTA4SET_MASK         _U(0x0000185F) /**< \brief (USBC_UESTA4SET) MASK Register */
+
+/* -------- USBC_UESTA5SET : (USBC Offset: 0x1A4) ( /W 32) Endpoint Status Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINIS:1;         /*!< bit:      0  TXINI Set                          */
+    uint32_t RXOUTIS:1;        /*!< bit:      1  RXOUTI Set                         */
+    uint32_t RXSTPIS:1;        /*!< bit:      2  RXSTPI Set                         */
+    uint32_t NAKOUTIS:1;       /*!< bit:      3  NAKOUTI Set                        */
+    uint32_t NAKINIS:1;        /*!< bit:      4  NAKINI Set                         */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDIS:1;      /*!< bit:      6  STALLEDI Set                       */
+    uint32_t :4;               /*!< bit:  7..10  Reserved                           */
+    uint32_t RAMACERIS:1;      /*!< bit:     11  RAMACERI Set                       */
+    uint32_t NBUSYBKS:1;       /*!< bit:     12  NBUSYBK Set                        */
+    uint32_t :19;              /*!< bit: 13..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UESTA5SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UESTA5SET_OFFSET       0x1A4        /**< \brief (USBC_UESTA5SET offset) Endpoint Status Set Register */
+#define USBC_UESTA5SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA5SET reset_value) Endpoint Status Set Register */
+
+#define USBC_UESTA5SET_TXINIS_Pos   0            /**< \brief (USBC_UESTA5SET) TXINI Set */
+#define USBC_UESTA5SET_TXINIS       (_U(0x1) << USBC_UESTA5SET_TXINIS_Pos)
+#define USBC_UESTA5SET_RXOUTIS_Pos  1            /**< \brief (USBC_UESTA5SET) RXOUTI Set */
+#define USBC_UESTA5SET_RXOUTIS      (_U(0x1) << USBC_UESTA5SET_RXOUTIS_Pos)
+#define USBC_UESTA5SET_RXSTPIS_Pos  2            /**< \brief (USBC_UESTA5SET) RXSTPI Set */
+#define USBC_UESTA5SET_RXSTPIS      (_U(0x1) << USBC_UESTA5SET_RXSTPIS_Pos)
+#define USBC_UESTA5SET_NAKOUTIS_Pos 3            /**< \brief (USBC_UESTA5SET) NAKOUTI Set */
+#define USBC_UESTA5SET_NAKOUTIS     (_U(0x1) << USBC_UESTA5SET_NAKOUTIS_Pos)
+#define USBC_UESTA5SET_NAKINIS_Pos  4            /**< \brief (USBC_UESTA5SET) NAKINI Set */
+#define USBC_UESTA5SET_NAKINIS      (_U(0x1) << USBC_UESTA5SET_NAKINIS_Pos)
+#define USBC_UESTA5SET_STALLEDIS_Pos 6            /**< \brief (USBC_UESTA5SET) STALLEDI Set */
+#define USBC_UESTA5SET_STALLEDIS    (_U(0x1) << USBC_UESTA5SET_STALLEDIS_Pos)
+#define USBC_UESTA5SET_RAMACERIS_Pos 11           /**< \brief (USBC_UESTA5SET) RAMACERI Set */
+#define USBC_UESTA5SET_RAMACERIS    (_U(0x1) << USBC_UESTA5SET_RAMACERIS_Pos)
+#define USBC_UESTA5SET_NBUSYBKS_Pos 12           /**< \brief (USBC_UESTA5SET) NBUSYBK Set */
+#define USBC_UESTA5SET_NBUSYBKS     (_U(0x1) << USBC_UESTA5SET_NBUSYBKS_Pos)
+#define USBC_UESTA5SET_MASK         _U(0x0000185F) /**< \brief (USBC_UESTA5SET) MASK Register */
+
+/* -------- USBC_UESTA6SET : (USBC Offset: 0x1A8) ( /W 32) Endpoint Status Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINIS:1;         /*!< bit:      0  TXINI Set                          */
+    uint32_t RXOUTIS:1;        /*!< bit:      1  RXOUTI Set                         */
+    uint32_t RXSTPIS:1;        /*!< bit:      2  RXSTPI Set                         */
+    uint32_t NAKOUTIS:1;       /*!< bit:      3  NAKOUTI Set                        */
+    uint32_t NAKINIS:1;        /*!< bit:      4  NAKINI Set                         */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDIS:1;      /*!< bit:      6  STALLEDI Set                       */
+    uint32_t :4;               /*!< bit:  7..10  Reserved                           */
+    uint32_t RAMACERIS:1;      /*!< bit:     11  RAMACERI Set                       */
+    uint32_t NBUSYBKS:1;       /*!< bit:     12  NBUSYBK Set                        */
+    uint32_t :19;              /*!< bit: 13..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UESTA6SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UESTA6SET_OFFSET       0x1A8        /**< \brief (USBC_UESTA6SET offset) Endpoint Status Set Register */
+#define USBC_UESTA6SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA6SET reset_value) Endpoint Status Set Register */
+
+#define USBC_UESTA6SET_TXINIS_Pos   0            /**< \brief (USBC_UESTA6SET) TXINI Set */
+#define USBC_UESTA6SET_TXINIS       (_U(0x1) << USBC_UESTA6SET_TXINIS_Pos)
+#define USBC_UESTA6SET_RXOUTIS_Pos  1            /**< \brief (USBC_UESTA6SET) RXOUTI Set */
+#define USBC_UESTA6SET_RXOUTIS      (_U(0x1) << USBC_UESTA6SET_RXOUTIS_Pos)
+#define USBC_UESTA6SET_RXSTPIS_Pos  2            /**< \brief (USBC_UESTA6SET) RXSTPI Set */
+#define USBC_UESTA6SET_RXSTPIS      (_U(0x1) << USBC_UESTA6SET_RXSTPIS_Pos)
+#define USBC_UESTA6SET_NAKOUTIS_Pos 3            /**< \brief (USBC_UESTA6SET) NAKOUTI Set */
+#define USBC_UESTA6SET_NAKOUTIS     (_U(0x1) << USBC_UESTA6SET_NAKOUTIS_Pos)
+#define USBC_UESTA6SET_NAKINIS_Pos  4            /**< \brief (USBC_UESTA6SET) NAKINI Set */
+#define USBC_UESTA6SET_NAKINIS      (_U(0x1) << USBC_UESTA6SET_NAKINIS_Pos)
+#define USBC_UESTA6SET_STALLEDIS_Pos 6            /**< \brief (USBC_UESTA6SET) STALLEDI Set */
+#define USBC_UESTA6SET_STALLEDIS    (_U(0x1) << USBC_UESTA6SET_STALLEDIS_Pos)
+#define USBC_UESTA6SET_RAMACERIS_Pos 11           /**< \brief (USBC_UESTA6SET) RAMACERI Set */
+#define USBC_UESTA6SET_RAMACERIS    (_U(0x1) << USBC_UESTA6SET_RAMACERIS_Pos)
+#define USBC_UESTA6SET_NBUSYBKS_Pos 12           /**< \brief (USBC_UESTA6SET) NBUSYBK Set */
+#define USBC_UESTA6SET_NBUSYBKS     (_U(0x1) << USBC_UESTA6SET_NBUSYBKS_Pos)
+#define USBC_UESTA6SET_MASK         _U(0x0000185F) /**< \brief (USBC_UESTA6SET) MASK Register */
+
+/* -------- USBC_UESTA7SET : (USBC Offset: 0x1AC) ( /W 32) Endpoint Status Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINIS:1;         /*!< bit:      0  TXINI Set                          */
+    uint32_t RXOUTIS:1;        /*!< bit:      1  RXOUTI Set                         */
+    uint32_t RXSTPIS:1;        /*!< bit:      2  RXSTPI Set                         */
+    uint32_t NAKOUTIS:1;       /*!< bit:      3  NAKOUTI Set                        */
+    uint32_t NAKINIS:1;        /*!< bit:      4  NAKINI Set                         */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDIS:1;      /*!< bit:      6  STALLEDI Set                       */
+    uint32_t :4;               /*!< bit:  7..10  Reserved                           */
+    uint32_t RAMACERIS:1;      /*!< bit:     11  RAMACERI Set                       */
+    uint32_t NBUSYBKS:1;       /*!< bit:     12  NBUSYBK Set                        */
+    uint32_t :19;              /*!< bit: 13..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UESTA7SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UESTA7SET_OFFSET       0x1AC        /**< \brief (USBC_UESTA7SET offset) Endpoint Status Set Register */
+#define USBC_UESTA7SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UESTA7SET reset_value) Endpoint Status Set Register */
+
+#define USBC_UESTA7SET_TXINIS_Pos   0            /**< \brief (USBC_UESTA7SET) TXINI Set */
+#define USBC_UESTA7SET_TXINIS       (_U(0x1) << USBC_UESTA7SET_TXINIS_Pos)
+#define USBC_UESTA7SET_RXOUTIS_Pos  1            /**< \brief (USBC_UESTA7SET) RXOUTI Set */
+#define USBC_UESTA7SET_RXOUTIS      (_U(0x1) << USBC_UESTA7SET_RXOUTIS_Pos)
+#define USBC_UESTA7SET_RXSTPIS_Pos  2            /**< \brief (USBC_UESTA7SET) RXSTPI Set */
+#define USBC_UESTA7SET_RXSTPIS      (_U(0x1) << USBC_UESTA7SET_RXSTPIS_Pos)
+#define USBC_UESTA7SET_NAKOUTIS_Pos 3            /**< \brief (USBC_UESTA7SET) NAKOUTI Set */
+#define USBC_UESTA7SET_NAKOUTIS     (_U(0x1) << USBC_UESTA7SET_NAKOUTIS_Pos)
+#define USBC_UESTA7SET_NAKINIS_Pos  4            /**< \brief (USBC_UESTA7SET) NAKINI Set */
+#define USBC_UESTA7SET_NAKINIS      (_U(0x1) << USBC_UESTA7SET_NAKINIS_Pos)
+#define USBC_UESTA7SET_STALLEDIS_Pos 6            /**< \brief (USBC_UESTA7SET) STALLEDI Set */
+#define USBC_UESTA7SET_STALLEDIS    (_U(0x1) << USBC_UESTA7SET_STALLEDIS_Pos)
+#define USBC_UESTA7SET_RAMACERIS_Pos 11           /**< \brief (USBC_UESTA7SET) RAMACERI Set */
+#define USBC_UESTA7SET_RAMACERIS    (_U(0x1) << USBC_UESTA7SET_RAMACERIS_Pos)
+#define USBC_UESTA7SET_NBUSYBKS_Pos 12           /**< \brief (USBC_UESTA7SET) NBUSYBK Set */
+#define USBC_UESTA7SET_NBUSYBKS     (_U(0x1) << USBC_UESTA7SET_NBUSYBKS_Pos)
+#define USBC_UESTA7SET_MASK         _U(0x0000185F) /**< \brief (USBC_UESTA7SET) MASK Register */
+
+/* -------- USBC_UECON0 : (USBC Offset: 0x1C0) (R/  32) Endpoint Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINE:1;          /*!< bit:      0  TXIN Interrupt Enable              */
+    uint32_t RXOUTE:1;         /*!< bit:      1  RXOUT Interrupt Enable             */
+    uint32_t RXSTPE:1;         /*!< bit:      2  RXSTP Interrupt Enable             */
+    uint32_t NAKOUTE:1;        /*!< bit:      3  NAKOUT Interrupt Enable            */
+    uint32_t NAKINE:1;         /*!< bit:      4  NAKIN Interrupt Enable             */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDE:1;       /*!< bit:      6  STALLED Interrupt Enable           */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t NREPLY:1;         /*!< bit:      8  No Reply                           */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t RAMACERE:1;       /*!< bit:     11  RAMACER Interrupt Enable           */
+    uint32_t NBUSYBKE:1;       /*!< bit:     12  Number of Busy Banks Interrupt Enable */
+    uint32_t KILLBK:1;         /*!< bit:     13  Kill IN Bank                       */
+    uint32_t FIFOCON:1;        /*!< bit:     14  FIFO Control                       */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t NYETDIS:1;        /*!< bit:     17  NYET token disable                 */
+    uint32_t RSTDT:1;          /*!< bit:     18  Reset Data Toggle                  */
+    uint32_t STALLRQ:1;        /*!< bit:     19  STALL Request                      */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t BUSY0:1;          /*!< bit:     24  Busy Bank1 Enable                  */
+    uint32_t BUSY1:1;          /*!< bit:     25  Busy Bank0 Enable                  */
+    uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECON0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECON0_OFFSET          0x1C0        /**< \brief (USBC_UECON0 offset) Endpoint Control Register */
+#define USBC_UECON0_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECON0 reset_value) Endpoint Control Register */
+
+#define USBC_UECON0_TXINE_Pos       0            /**< \brief (USBC_UECON0) TXIN Interrupt Enable */
+#define USBC_UECON0_TXINE           (_U(0x1) << USBC_UECON0_TXINE_Pos)
+#define USBC_UECON0_RXOUTE_Pos      1            /**< \brief (USBC_UECON0) RXOUT Interrupt Enable */
+#define USBC_UECON0_RXOUTE          (_U(0x1) << USBC_UECON0_RXOUTE_Pos)
+#define USBC_UECON0_RXSTPE_Pos      2            /**< \brief (USBC_UECON0) RXSTP Interrupt Enable */
+#define USBC_UECON0_RXSTPE          (_U(0x1) << USBC_UECON0_RXSTPE_Pos)
+#define USBC_UECON0_NAKOUTE_Pos     3            /**< \brief (USBC_UECON0) NAKOUT Interrupt Enable */
+#define USBC_UECON0_NAKOUTE         (_U(0x1) << USBC_UECON0_NAKOUTE_Pos)
+#define USBC_UECON0_NAKINE_Pos      4            /**< \brief (USBC_UECON0) NAKIN Interrupt Enable */
+#define USBC_UECON0_NAKINE          (_U(0x1) << USBC_UECON0_NAKINE_Pos)
+#define USBC_UECON0_STALLEDE_Pos    6            /**< \brief (USBC_UECON0) STALLED Interrupt Enable */
+#define USBC_UECON0_STALLEDE        (_U(0x1) << USBC_UECON0_STALLEDE_Pos)
+#define USBC_UECON0_NREPLY_Pos      8            /**< \brief (USBC_UECON0) No Reply */
+#define USBC_UECON0_NREPLY          (_U(0x1) << USBC_UECON0_NREPLY_Pos)
+#define USBC_UECON0_RAMACERE_Pos    11           /**< \brief (USBC_UECON0) RAMACER Interrupt Enable */
+#define USBC_UECON0_RAMACERE        (_U(0x1) << USBC_UECON0_RAMACERE_Pos)
+#define USBC_UECON0_NBUSYBKE_Pos    12           /**< \brief (USBC_UECON0) Number of Busy Banks Interrupt Enable */
+#define USBC_UECON0_NBUSYBKE        (_U(0x1) << USBC_UECON0_NBUSYBKE_Pos)
+#define USBC_UECON0_KILLBK_Pos      13           /**< \brief (USBC_UECON0) Kill IN Bank */
+#define USBC_UECON0_KILLBK          (_U(0x1) << USBC_UECON0_KILLBK_Pos)
+#define USBC_UECON0_FIFOCON_Pos     14           /**< \brief (USBC_UECON0) FIFO Control */
+#define USBC_UECON0_FIFOCON         (_U(0x1) << USBC_UECON0_FIFOCON_Pos)
+#define USBC_UECON0_NYETDIS_Pos     17           /**< \brief (USBC_UECON0) NYET token disable */
+#define USBC_UECON0_NYETDIS         (_U(0x1) << USBC_UECON0_NYETDIS_Pos)
+#define USBC_UECON0_RSTDT_Pos       18           /**< \brief (USBC_UECON0) Reset Data Toggle */
+#define USBC_UECON0_RSTDT           (_U(0x1) << USBC_UECON0_RSTDT_Pos)
+#define USBC_UECON0_STALLRQ_Pos     19           /**< \brief (USBC_UECON0) STALL Request */
+#define USBC_UECON0_STALLRQ         (_U(0x1) << USBC_UECON0_STALLRQ_Pos)
+#define USBC_UECON0_BUSY0_Pos       24           /**< \brief (USBC_UECON0) Busy Bank1 Enable */
+#define USBC_UECON0_BUSY0           (_U(0x1) << USBC_UECON0_BUSY0_Pos)
+#define USBC_UECON0_BUSY1_Pos       25           /**< \brief (USBC_UECON0) Busy Bank0 Enable */
+#define USBC_UECON0_BUSY1           (_U(0x1) << USBC_UECON0_BUSY1_Pos)
+#define USBC_UECON0_MASK            _U(0x030E795F) /**< \brief (USBC_UECON0) MASK Register */
+
+/* -------- USBC_UECON1 : (USBC Offset: 0x1C4) (R/  32) Endpoint Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINE:1;          /*!< bit:      0  TXIN Interrupt Enable              */
+    uint32_t RXOUTE:1;         /*!< bit:      1  RXOUT Interrupt Enable             */
+    uint32_t RXSTPE:1;         /*!< bit:      2  RXSTP Interrupt Enable             */
+    uint32_t NAKOUTE:1;        /*!< bit:      3  NAKOUT Interrupt Enable            */
+    uint32_t NAKINE:1;         /*!< bit:      4  NAKIN Interrupt Enable             */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDE:1;       /*!< bit:      6  STALLED Interrupt Enable           */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t NREPLY:1;         /*!< bit:      8  No Reply                           */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t RAMACERE:1;       /*!< bit:     11  RAMACER Interrupt Enable           */
+    uint32_t NBUSYBKE:1;       /*!< bit:     12  Number of Busy Banks Interrupt Enable */
+    uint32_t KILLBK:1;         /*!< bit:     13  Kill IN Bank                       */
+    uint32_t FIFOCON:1;        /*!< bit:     14  FIFO Control                       */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t NYETDIS:1;        /*!< bit:     17  NYET Token Enable                  */
+    uint32_t RSTDT:1;          /*!< bit:     18  Reset Data Toggle                  */
+    uint32_t STALLRQ:1;        /*!< bit:     19  STALL Request                      */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t BUSY0:1;          /*!< bit:     24  Busy Bank1 Enable                  */
+    uint32_t BUSY1:1;          /*!< bit:     25  Busy Bank0 Enable                  */
+    uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECON1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECON1_OFFSET          0x1C4        /**< \brief (USBC_UECON1 offset) Endpoint Control Register */
+#define USBC_UECON1_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECON1 reset_value) Endpoint Control Register */
+
+#define USBC_UECON1_TXINE_Pos       0            /**< \brief (USBC_UECON1) TXIN Interrupt Enable */
+#define USBC_UECON1_TXINE           (_U(0x1) << USBC_UECON1_TXINE_Pos)
+#define USBC_UECON1_RXOUTE_Pos      1            /**< \brief (USBC_UECON1) RXOUT Interrupt Enable */
+#define USBC_UECON1_RXOUTE          (_U(0x1) << USBC_UECON1_RXOUTE_Pos)
+#define USBC_UECON1_RXSTPE_Pos      2            /**< \brief (USBC_UECON1) RXSTP Interrupt Enable */
+#define USBC_UECON1_RXSTPE          (_U(0x1) << USBC_UECON1_RXSTPE_Pos)
+#define USBC_UECON1_NAKOUTE_Pos     3            /**< \brief (USBC_UECON1) NAKOUT Interrupt Enable */
+#define USBC_UECON1_NAKOUTE         (_U(0x1) << USBC_UECON1_NAKOUTE_Pos)
+#define USBC_UECON1_NAKINE_Pos      4            /**< \brief (USBC_UECON1) NAKIN Interrupt Enable */
+#define USBC_UECON1_NAKINE          (_U(0x1) << USBC_UECON1_NAKINE_Pos)
+#define USBC_UECON1_STALLEDE_Pos    6            /**< \brief (USBC_UECON1) STALLED Interrupt Enable */
+#define USBC_UECON1_STALLEDE        (_U(0x1) << USBC_UECON1_STALLEDE_Pos)
+#define USBC_UECON1_NREPLY_Pos      8            /**< \brief (USBC_UECON1) No Reply */
+#define USBC_UECON1_NREPLY          (_U(0x1) << USBC_UECON1_NREPLY_Pos)
+#define USBC_UECON1_RAMACERE_Pos    11           /**< \brief (USBC_UECON1) RAMACER Interrupt Enable */
+#define USBC_UECON1_RAMACERE        (_U(0x1) << USBC_UECON1_RAMACERE_Pos)
+#define USBC_UECON1_NBUSYBKE_Pos    12           /**< \brief (USBC_UECON1) Number of Busy Banks Interrupt Enable */
+#define USBC_UECON1_NBUSYBKE        (_U(0x1) << USBC_UECON1_NBUSYBKE_Pos)
+#define USBC_UECON1_KILLBK_Pos      13           /**< \brief (USBC_UECON1) Kill IN Bank */
+#define USBC_UECON1_KILLBK          (_U(0x1) << USBC_UECON1_KILLBK_Pos)
+#define USBC_UECON1_FIFOCON_Pos     14           /**< \brief (USBC_UECON1) FIFO Control */
+#define USBC_UECON1_FIFOCON         (_U(0x1) << USBC_UECON1_FIFOCON_Pos)
+#define USBC_UECON1_NYETDIS_Pos     17           /**< \brief (USBC_UECON1) NYET Token Enable */
+#define USBC_UECON1_NYETDIS         (_U(0x1) << USBC_UECON1_NYETDIS_Pos)
+#define USBC_UECON1_RSTDT_Pos       18           /**< \brief (USBC_UECON1) Reset Data Toggle */
+#define USBC_UECON1_RSTDT           (_U(0x1) << USBC_UECON1_RSTDT_Pos)
+#define USBC_UECON1_STALLRQ_Pos     19           /**< \brief (USBC_UECON1) STALL Request */
+#define USBC_UECON1_STALLRQ         (_U(0x1) << USBC_UECON1_STALLRQ_Pos)
+#define USBC_UECON1_BUSY0_Pos       24           /**< \brief (USBC_UECON1) Busy Bank1 Enable */
+#define USBC_UECON1_BUSY0           (_U(0x1) << USBC_UECON1_BUSY0_Pos)
+#define USBC_UECON1_BUSY1_Pos       25           /**< \brief (USBC_UECON1) Busy Bank0 Enable */
+#define USBC_UECON1_BUSY1           (_U(0x1) << USBC_UECON1_BUSY1_Pos)
+#define USBC_UECON1_MASK            _U(0x030E795F) /**< \brief (USBC_UECON1) MASK Register */
+
+/* -------- USBC_UECON2 : (USBC Offset: 0x1C8) (R/  32) Endpoint Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINE:1;          /*!< bit:      0  TXIN Interrupt Enable              */
+    uint32_t RXOUTE:1;         /*!< bit:      1  RXOUT Interrupt Enable             */
+    uint32_t RXSTPE:1;         /*!< bit:      2  RXSTP Interrupt Enable             */
+    uint32_t NAKOUTE:1;        /*!< bit:      3  NAKOUT Interrupt Enable            */
+    uint32_t NAKINE:1;         /*!< bit:      4  NAKIN Interrupt Enable             */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDE:1;       /*!< bit:      6  STALLED Interrupt Enable           */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t NREPLY:1;         /*!< bit:      8  No Reply                           */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t RAMACERE:1;       /*!< bit:     11  RAMACER Interrupt Enable           */
+    uint32_t NBUSYBKE:1;       /*!< bit:     12  Number of Busy Banks Interrupt Enable */
+    uint32_t KILLBK:1;         /*!< bit:     13  Kill IN Bank                       */
+    uint32_t FIFOCON:1;        /*!< bit:     14  FIFO Control                       */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t NYETDIS:1;        /*!< bit:     17  NYET Token Enable                  */
+    uint32_t RSTDT:1;          /*!< bit:     18  Reset Data Toggle                  */
+    uint32_t STALLRQ:1;        /*!< bit:     19  STALL Request                      */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t BUSY0:1;          /*!< bit:     24  Busy Bank1 Enable                  */
+    uint32_t BUSY1:1;          /*!< bit:     25  Busy Bank0 Enable                  */
+    uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECON2_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECON2_OFFSET          0x1C8        /**< \brief (USBC_UECON2 offset) Endpoint Control Register */
+#define USBC_UECON2_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECON2 reset_value) Endpoint Control Register */
+
+#define USBC_UECON2_TXINE_Pos       0            /**< \brief (USBC_UECON2) TXIN Interrupt Enable */
+#define USBC_UECON2_TXINE           (_U(0x1) << USBC_UECON2_TXINE_Pos)
+#define USBC_UECON2_RXOUTE_Pos      1            /**< \brief (USBC_UECON2) RXOUT Interrupt Enable */
+#define USBC_UECON2_RXOUTE          (_U(0x1) << USBC_UECON2_RXOUTE_Pos)
+#define USBC_UECON2_RXSTPE_Pos      2            /**< \brief (USBC_UECON2) RXSTP Interrupt Enable */
+#define USBC_UECON2_RXSTPE          (_U(0x1) << USBC_UECON2_RXSTPE_Pos)
+#define USBC_UECON2_NAKOUTE_Pos     3            /**< \brief (USBC_UECON2) NAKOUT Interrupt Enable */
+#define USBC_UECON2_NAKOUTE         (_U(0x1) << USBC_UECON2_NAKOUTE_Pos)
+#define USBC_UECON2_NAKINE_Pos      4            /**< \brief (USBC_UECON2) NAKIN Interrupt Enable */
+#define USBC_UECON2_NAKINE          (_U(0x1) << USBC_UECON2_NAKINE_Pos)
+#define USBC_UECON2_STALLEDE_Pos    6            /**< \brief (USBC_UECON2) STALLED Interrupt Enable */
+#define USBC_UECON2_STALLEDE        (_U(0x1) << USBC_UECON2_STALLEDE_Pos)
+#define USBC_UECON2_NREPLY_Pos      8            /**< \brief (USBC_UECON2) No Reply */
+#define USBC_UECON2_NREPLY          (_U(0x1) << USBC_UECON2_NREPLY_Pos)
+#define USBC_UECON2_RAMACERE_Pos    11           /**< \brief (USBC_UECON2) RAMACER Interrupt Enable */
+#define USBC_UECON2_RAMACERE        (_U(0x1) << USBC_UECON2_RAMACERE_Pos)
+#define USBC_UECON2_NBUSYBKE_Pos    12           /**< \brief (USBC_UECON2) Number of Busy Banks Interrupt Enable */
+#define USBC_UECON2_NBUSYBKE        (_U(0x1) << USBC_UECON2_NBUSYBKE_Pos)
+#define USBC_UECON2_KILLBK_Pos      13           /**< \brief (USBC_UECON2) Kill IN Bank */
+#define USBC_UECON2_KILLBK          (_U(0x1) << USBC_UECON2_KILLBK_Pos)
+#define USBC_UECON2_FIFOCON_Pos     14           /**< \brief (USBC_UECON2) FIFO Control */
+#define USBC_UECON2_FIFOCON         (_U(0x1) << USBC_UECON2_FIFOCON_Pos)
+#define USBC_UECON2_NYETDIS_Pos     17           /**< \brief (USBC_UECON2) NYET Token Enable */
+#define USBC_UECON2_NYETDIS         (_U(0x1) << USBC_UECON2_NYETDIS_Pos)
+#define USBC_UECON2_RSTDT_Pos       18           /**< \brief (USBC_UECON2) Reset Data Toggle */
+#define USBC_UECON2_RSTDT           (_U(0x1) << USBC_UECON2_RSTDT_Pos)
+#define USBC_UECON2_STALLRQ_Pos     19           /**< \brief (USBC_UECON2) STALL Request */
+#define USBC_UECON2_STALLRQ         (_U(0x1) << USBC_UECON2_STALLRQ_Pos)
+#define USBC_UECON2_BUSY0_Pos       24           /**< \brief (USBC_UECON2) Busy Bank1 Enable */
+#define USBC_UECON2_BUSY0           (_U(0x1) << USBC_UECON2_BUSY0_Pos)
+#define USBC_UECON2_BUSY1_Pos       25           /**< \brief (USBC_UECON2) Busy Bank0 Enable */
+#define USBC_UECON2_BUSY1           (_U(0x1) << USBC_UECON2_BUSY1_Pos)
+#define USBC_UECON2_MASK            _U(0x030E795F) /**< \brief (USBC_UECON2) MASK Register */
+
+/* -------- USBC_UECON3 : (USBC Offset: 0x1CC) (R/  32) Endpoint Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINE:1;          /*!< bit:      0  TXIN Interrupt Enable              */
+    uint32_t RXOUTE:1;         /*!< bit:      1  RXOUT Interrupt Enable             */
+    uint32_t RXSTPE:1;         /*!< bit:      2  RXSTP Interrupt Enable             */
+    uint32_t NAKOUTE:1;        /*!< bit:      3  NAKOUT Interrupt Enable            */
+    uint32_t NAKINE:1;         /*!< bit:      4  NAKIN Interrupt Enable             */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDE:1;       /*!< bit:      6  STALLED Interrupt Enable           */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t NREPLY:1;         /*!< bit:      8  No Reply                           */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t RAMACERE:1;       /*!< bit:     11  RAMACER Interrupt Enable           */
+    uint32_t NBUSYBKE:1;       /*!< bit:     12  Number of Busy Banks Interrupt Enable */
+    uint32_t KILLBK:1;         /*!< bit:     13  Kill IN Bank                       */
+    uint32_t FIFOCON:1;        /*!< bit:     14  FIFO Control                       */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t NYETDIS:1;        /*!< bit:     17  NYET Token Enable                  */
+    uint32_t RSTDT:1;          /*!< bit:     18  Reset Data Toggle                  */
+    uint32_t STALLRQ:1;        /*!< bit:     19  STALL Request                      */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t BUSY0:1;          /*!< bit:     24  Busy Bank1 Enable                  */
+    uint32_t BUSY1:1;          /*!< bit:     25  Busy Bank0 Enable                  */
+    uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECON3_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECON3_OFFSET          0x1CC        /**< \brief (USBC_UECON3 offset) Endpoint Control Register */
+#define USBC_UECON3_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECON3 reset_value) Endpoint Control Register */
+
+#define USBC_UECON3_TXINE_Pos       0            /**< \brief (USBC_UECON3) TXIN Interrupt Enable */
+#define USBC_UECON3_TXINE           (_U(0x1) << USBC_UECON3_TXINE_Pos)
+#define USBC_UECON3_RXOUTE_Pos      1            /**< \brief (USBC_UECON3) RXOUT Interrupt Enable */
+#define USBC_UECON3_RXOUTE          (_U(0x1) << USBC_UECON3_RXOUTE_Pos)
+#define USBC_UECON3_RXSTPE_Pos      2            /**< \brief (USBC_UECON3) RXSTP Interrupt Enable */
+#define USBC_UECON3_RXSTPE          (_U(0x1) << USBC_UECON3_RXSTPE_Pos)
+#define USBC_UECON3_NAKOUTE_Pos     3            /**< \brief (USBC_UECON3) NAKOUT Interrupt Enable */
+#define USBC_UECON3_NAKOUTE         (_U(0x1) << USBC_UECON3_NAKOUTE_Pos)
+#define USBC_UECON3_NAKINE_Pos      4            /**< \brief (USBC_UECON3) NAKIN Interrupt Enable */
+#define USBC_UECON3_NAKINE          (_U(0x1) << USBC_UECON3_NAKINE_Pos)
+#define USBC_UECON3_STALLEDE_Pos    6            /**< \brief (USBC_UECON3) STALLED Interrupt Enable */
+#define USBC_UECON3_STALLEDE        (_U(0x1) << USBC_UECON3_STALLEDE_Pos)
+#define USBC_UECON3_NREPLY_Pos      8            /**< \brief (USBC_UECON3) No Reply */
+#define USBC_UECON3_NREPLY          (_U(0x1) << USBC_UECON3_NREPLY_Pos)
+#define USBC_UECON3_RAMACERE_Pos    11           /**< \brief (USBC_UECON3) RAMACER Interrupt Enable */
+#define USBC_UECON3_RAMACERE        (_U(0x1) << USBC_UECON3_RAMACERE_Pos)
+#define USBC_UECON3_NBUSYBKE_Pos    12           /**< \brief (USBC_UECON3) Number of Busy Banks Interrupt Enable */
+#define USBC_UECON3_NBUSYBKE        (_U(0x1) << USBC_UECON3_NBUSYBKE_Pos)
+#define USBC_UECON3_KILLBK_Pos      13           /**< \brief (USBC_UECON3) Kill IN Bank */
+#define USBC_UECON3_KILLBK          (_U(0x1) << USBC_UECON3_KILLBK_Pos)
+#define USBC_UECON3_FIFOCON_Pos     14           /**< \brief (USBC_UECON3) FIFO Control */
+#define USBC_UECON3_FIFOCON         (_U(0x1) << USBC_UECON3_FIFOCON_Pos)
+#define USBC_UECON3_NYETDIS_Pos     17           /**< \brief (USBC_UECON3) NYET Token Enable */
+#define USBC_UECON3_NYETDIS         (_U(0x1) << USBC_UECON3_NYETDIS_Pos)
+#define USBC_UECON3_RSTDT_Pos       18           /**< \brief (USBC_UECON3) Reset Data Toggle */
+#define USBC_UECON3_RSTDT           (_U(0x1) << USBC_UECON3_RSTDT_Pos)
+#define USBC_UECON3_STALLRQ_Pos     19           /**< \brief (USBC_UECON3) STALL Request */
+#define USBC_UECON3_STALLRQ         (_U(0x1) << USBC_UECON3_STALLRQ_Pos)
+#define USBC_UECON3_BUSY0_Pos       24           /**< \brief (USBC_UECON3) Busy Bank1 Enable */
+#define USBC_UECON3_BUSY0           (_U(0x1) << USBC_UECON3_BUSY0_Pos)
+#define USBC_UECON3_BUSY1_Pos       25           /**< \brief (USBC_UECON3) Busy Bank0 Enable */
+#define USBC_UECON3_BUSY1           (_U(0x1) << USBC_UECON3_BUSY1_Pos)
+#define USBC_UECON3_MASK            _U(0x030E795F) /**< \brief (USBC_UECON3) MASK Register */
+
+/* -------- USBC_UECON4 : (USBC Offset: 0x1D0) (R/  32) Endpoint Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINE:1;          /*!< bit:      0  TXIN Interrupt Enable              */
+    uint32_t RXOUTE:1;         /*!< bit:      1  RXOUT Interrupt Enable             */
+    uint32_t RXSTPE:1;         /*!< bit:      2  RXSTP Interrupt Enable             */
+    uint32_t NAKOUTE:1;        /*!< bit:      3  NAKOUT Interrupt Enable            */
+    uint32_t NAKINE:1;         /*!< bit:      4  NAKIN Interrupt Enable             */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDE:1;       /*!< bit:      6  STALLED Interrupt Enable           */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t NREPLY:1;         /*!< bit:      8  No Reply                           */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t RAMACERE:1;       /*!< bit:     11  RAMACER Interrupt Enable           */
+    uint32_t NBUSYBKE:1;       /*!< bit:     12  Number of Busy Banks Interrupt Enable */
+    uint32_t KILLBK:1;         /*!< bit:     13  Kill IN Bank                       */
+    uint32_t FIFOCON:1;        /*!< bit:     14  FIFO Control                       */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t NYETDIS:1;        /*!< bit:     17  NYET Token Enable                  */
+    uint32_t RSTDT:1;          /*!< bit:     18  Reset Data Toggle                  */
+    uint32_t STALLRQ:1;        /*!< bit:     19  STALL Request                      */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t BUSY0:1;          /*!< bit:     24  Busy Bank1 Enable                  */
+    uint32_t BUSY1:1;          /*!< bit:     25  Busy Bank0 Enable                  */
+    uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECON4_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECON4_OFFSET          0x1D0        /**< \brief (USBC_UECON4 offset) Endpoint Control Register */
+#define USBC_UECON4_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECON4 reset_value) Endpoint Control Register */
+
+#define USBC_UECON4_TXINE_Pos       0            /**< \brief (USBC_UECON4) TXIN Interrupt Enable */
+#define USBC_UECON4_TXINE           (_U(0x1) << USBC_UECON4_TXINE_Pos)
+#define USBC_UECON4_RXOUTE_Pos      1            /**< \brief (USBC_UECON4) RXOUT Interrupt Enable */
+#define USBC_UECON4_RXOUTE          (_U(0x1) << USBC_UECON4_RXOUTE_Pos)
+#define USBC_UECON4_RXSTPE_Pos      2            /**< \brief (USBC_UECON4) RXSTP Interrupt Enable */
+#define USBC_UECON4_RXSTPE          (_U(0x1) << USBC_UECON4_RXSTPE_Pos)
+#define USBC_UECON4_NAKOUTE_Pos     3            /**< \brief (USBC_UECON4) NAKOUT Interrupt Enable */
+#define USBC_UECON4_NAKOUTE         (_U(0x1) << USBC_UECON4_NAKOUTE_Pos)
+#define USBC_UECON4_NAKINE_Pos      4            /**< \brief (USBC_UECON4) NAKIN Interrupt Enable */
+#define USBC_UECON4_NAKINE          (_U(0x1) << USBC_UECON4_NAKINE_Pos)
+#define USBC_UECON4_STALLEDE_Pos    6            /**< \brief (USBC_UECON4) STALLED Interrupt Enable */
+#define USBC_UECON4_STALLEDE        (_U(0x1) << USBC_UECON4_STALLEDE_Pos)
+#define USBC_UECON4_NREPLY_Pos      8            /**< \brief (USBC_UECON4) No Reply */
+#define USBC_UECON4_NREPLY          (_U(0x1) << USBC_UECON4_NREPLY_Pos)
+#define USBC_UECON4_RAMACERE_Pos    11           /**< \brief (USBC_UECON4) RAMACER Interrupt Enable */
+#define USBC_UECON4_RAMACERE        (_U(0x1) << USBC_UECON4_RAMACERE_Pos)
+#define USBC_UECON4_NBUSYBKE_Pos    12           /**< \brief (USBC_UECON4) Number of Busy Banks Interrupt Enable */
+#define USBC_UECON4_NBUSYBKE        (_U(0x1) << USBC_UECON4_NBUSYBKE_Pos)
+#define USBC_UECON4_KILLBK_Pos      13           /**< \brief (USBC_UECON4) Kill IN Bank */
+#define USBC_UECON4_KILLBK          (_U(0x1) << USBC_UECON4_KILLBK_Pos)
+#define USBC_UECON4_FIFOCON_Pos     14           /**< \brief (USBC_UECON4) FIFO Control */
+#define USBC_UECON4_FIFOCON         (_U(0x1) << USBC_UECON4_FIFOCON_Pos)
+#define USBC_UECON4_NYETDIS_Pos     17           /**< \brief (USBC_UECON4) NYET Token Enable */
+#define USBC_UECON4_NYETDIS         (_U(0x1) << USBC_UECON4_NYETDIS_Pos)
+#define USBC_UECON4_RSTDT_Pos       18           /**< \brief (USBC_UECON4) Reset Data Toggle */
+#define USBC_UECON4_RSTDT           (_U(0x1) << USBC_UECON4_RSTDT_Pos)
+#define USBC_UECON4_STALLRQ_Pos     19           /**< \brief (USBC_UECON4) STALL Request */
+#define USBC_UECON4_STALLRQ         (_U(0x1) << USBC_UECON4_STALLRQ_Pos)
+#define USBC_UECON4_BUSY0_Pos       24           /**< \brief (USBC_UECON4) Busy Bank1 Enable */
+#define USBC_UECON4_BUSY0           (_U(0x1) << USBC_UECON4_BUSY0_Pos)
+#define USBC_UECON4_BUSY1_Pos       25           /**< \brief (USBC_UECON4) Busy Bank0 Enable */
+#define USBC_UECON4_BUSY1           (_U(0x1) << USBC_UECON4_BUSY1_Pos)
+#define USBC_UECON4_MASK            _U(0x030E795F) /**< \brief (USBC_UECON4) MASK Register */
+
+/* -------- USBC_UECON5 : (USBC Offset: 0x1D4) (R/  32) Endpoint Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINE:1;          /*!< bit:      0  TXIN Interrupt Enable              */
+    uint32_t RXOUTE:1;         /*!< bit:      1  RXOUT Interrupt Enable             */
+    uint32_t RXSTPE:1;         /*!< bit:      2  RXSTP Interrupt Enable             */
+    uint32_t NAKOUTE:1;        /*!< bit:      3  NAKOUT Interrupt Enable            */
+    uint32_t NAKINE:1;         /*!< bit:      4  NAKIN Interrupt Enable             */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDE:1;       /*!< bit:      6  STALLED Interrupt Enable           */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t NREPLY:1;         /*!< bit:      8  No Reply                           */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t RAMACERE:1;       /*!< bit:     11  RAMACER Interrupt Enable           */
+    uint32_t NBUSYBKE:1;       /*!< bit:     12  Number of Busy Banks Interrupt Enable */
+    uint32_t KILLBK:1;         /*!< bit:     13  Kill IN Bank                       */
+    uint32_t FIFOCON:1;        /*!< bit:     14  FIFO Control                       */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t NYETDIS:1;        /*!< bit:     17  NYET Token Enable                  */
+    uint32_t RSTDT:1;          /*!< bit:     18  Reset Data Toggle                  */
+    uint32_t STALLRQ:1;        /*!< bit:     19  STALL Request                      */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t BUSY0:1;          /*!< bit:     24  Busy Bank1 Enable                  */
+    uint32_t BUSY1:1;          /*!< bit:     25  Busy Bank0 Enable                  */
+    uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECON5_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECON5_OFFSET          0x1D4        /**< \brief (USBC_UECON5 offset) Endpoint Control Register */
+#define USBC_UECON5_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECON5 reset_value) Endpoint Control Register */
+
+#define USBC_UECON5_TXINE_Pos       0            /**< \brief (USBC_UECON5) TXIN Interrupt Enable */
+#define USBC_UECON5_TXINE           (_U(0x1) << USBC_UECON5_TXINE_Pos)
+#define USBC_UECON5_RXOUTE_Pos      1            /**< \brief (USBC_UECON5) RXOUT Interrupt Enable */
+#define USBC_UECON5_RXOUTE          (_U(0x1) << USBC_UECON5_RXOUTE_Pos)
+#define USBC_UECON5_RXSTPE_Pos      2            /**< \brief (USBC_UECON5) RXSTP Interrupt Enable */
+#define USBC_UECON5_RXSTPE          (_U(0x1) << USBC_UECON5_RXSTPE_Pos)
+#define USBC_UECON5_NAKOUTE_Pos     3            /**< \brief (USBC_UECON5) NAKOUT Interrupt Enable */
+#define USBC_UECON5_NAKOUTE         (_U(0x1) << USBC_UECON5_NAKOUTE_Pos)
+#define USBC_UECON5_NAKINE_Pos      4            /**< \brief (USBC_UECON5) NAKIN Interrupt Enable */
+#define USBC_UECON5_NAKINE          (_U(0x1) << USBC_UECON5_NAKINE_Pos)
+#define USBC_UECON5_STALLEDE_Pos    6            /**< \brief (USBC_UECON5) STALLED Interrupt Enable */
+#define USBC_UECON5_STALLEDE        (_U(0x1) << USBC_UECON5_STALLEDE_Pos)
+#define USBC_UECON5_NREPLY_Pos      8            /**< \brief (USBC_UECON5) No Reply */
+#define USBC_UECON5_NREPLY          (_U(0x1) << USBC_UECON5_NREPLY_Pos)
+#define USBC_UECON5_RAMACERE_Pos    11           /**< \brief (USBC_UECON5) RAMACER Interrupt Enable */
+#define USBC_UECON5_RAMACERE        (_U(0x1) << USBC_UECON5_RAMACERE_Pos)
+#define USBC_UECON5_NBUSYBKE_Pos    12           /**< \brief (USBC_UECON5) Number of Busy Banks Interrupt Enable */
+#define USBC_UECON5_NBUSYBKE        (_U(0x1) << USBC_UECON5_NBUSYBKE_Pos)
+#define USBC_UECON5_KILLBK_Pos      13           /**< \brief (USBC_UECON5) Kill IN Bank */
+#define USBC_UECON5_KILLBK          (_U(0x1) << USBC_UECON5_KILLBK_Pos)
+#define USBC_UECON5_FIFOCON_Pos     14           /**< \brief (USBC_UECON5) FIFO Control */
+#define USBC_UECON5_FIFOCON         (_U(0x1) << USBC_UECON5_FIFOCON_Pos)
+#define USBC_UECON5_NYETDIS_Pos     17           /**< \brief (USBC_UECON5) NYET Token Enable */
+#define USBC_UECON5_NYETDIS         (_U(0x1) << USBC_UECON5_NYETDIS_Pos)
+#define USBC_UECON5_RSTDT_Pos       18           /**< \brief (USBC_UECON5) Reset Data Toggle */
+#define USBC_UECON5_RSTDT           (_U(0x1) << USBC_UECON5_RSTDT_Pos)
+#define USBC_UECON5_STALLRQ_Pos     19           /**< \brief (USBC_UECON5) STALL Request */
+#define USBC_UECON5_STALLRQ         (_U(0x1) << USBC_UECON5_STALLRQ_Pos)
+#define USBC_UECON5_BUSY0_Pos       24           /**< \brief (USBC_UECON5) Busy Bank1 Enable */
+#define USBC_UECON5_BUSY0           (_U(0x1) << USBC_UECON5_BUSY0_Pos)
+#define USBC_UECON5_BUSY1_Pos       25           /**< \brief (USBC_UECON5) Busy Bank0 Enable */
+#define USBC_UECON5_BUSY1           (_U(0x1) << USBC_UECON5_BUSY1_Pos)
+#define USBC_UECON5_MASK            _U(0x030E795F) /**< \brief (USBC_UECON5) MASK Register */
+
+/* -------- USBC_UECON6 : (USBC Offset: 0x1D8) (R/  32) Endpoint Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINE:1;          /*!< bit:      0  TXIN Interrupt Enable              */
+    uint32_t RXOUTE:1;         /*!< bit:      1  RXOUT Interrupt Enable             */
+    uint32_t RXSTPE:1;         /*!< bit:      2  RXSTP Interrupt Enable             */
+    uint32_t NAKOUTE:1;        /*!< bit:      3  NAKOUT Interrupt Enable            */
+    uint32_t NAKINE:1;         /*!< bit:      4  NAKIN Interrupt Enable             */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDE:1;       /*!< bit:      6  STALLED Interrupt Enable           */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t NREPLY:1;         /*!< bit:      8  No Reply                           */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t RAMACERE:1;       /*!< bit:     11  RAMACER Interrupt Enable           */
+    uint32_t NBUSYBKE:1;       /*!< bit:     12  Number of Busy Banks Interrupt Enable */
+    uint32_t KILLBK:1;         /*!< bit:     13  Kill IN Bank                       */
+    uint32_t FIFOCON:1;        /*!< bit:     14  FIFO Control                       */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t NYETDIS:1;        /*!< bit:     17  NYET Token Enable                  */
+    uint32_t RSTDT:1;          /*!< bit:     18  Reset Data Toggle                  */
+    uint32_t STALLRQ:1;        /*!< bit:     19  STALL Request                      */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t BUSY0:1;          /*!< bit:     24  Busy Bank1 Enable                  */
+    uint32_t BUSY1:1;          /*!< bit:     25  Busy Bank0 Enable                  */
+    uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECON6_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECON6_OFFSET          0x1D8        /**< \brief (USBC_UECON6 offset) Endpoint Control Register */
+#define USBC_UECON6_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECON6 reset_value) Endpoint Control Register */
+
+#define USBC_UECON6_TXINE_Pos       0            /**< \brief (USBC_UECON6) TXIN Interrupt Enable */
+#define USBC_UECON6_TXINE           (_U(0x1) << USBC_UECON6_TXINE_Pos)
+#define USBC_UECON6_RXOUTE_Pos      1            /**< \brief (USBC_UECON6) RXOUT Interrupt Enable */
+#define USBC_UECON6_RXOUTE          (_U(0x1) << USBC_UECON6_RXOUTE_Pos)
+#define USBC_UECON6_RXSTPE_Pos      2            /**< \brief (USBC_UECON6) RXSTP Interrupt Enable */
+#define USBC_UECON6_RXSTPE          (_U(0x1) << USBC_UECON6_RXSTPE_Pos)
+#define USBC_UECON6_NAKOUTE_Pos     3            /**< \brief (USBC_UECON6) NAKOUT Interrupt Enable */
+#define USBC_UECON6_NAKOUTE         (_U(0x1) << USBC_UECON6_NAKOUTE_Pos)
+#define USBC_UECON6_NAKINE_Pos      4            /**< \brief (USBC_UECON6) NAKIN Interrupt Enable */
+#define USBC_UECON6_NAKINE          (_U(0x1) << USBC_UECON6_NAKINE_Pos)
+#define USBC_UECON6_STALLEDE_Pos    6            /**< \brief (USBC_UECON6) STALLED Interrupt Enable */
+#define USBC_UECON6_STALLEDE        (_U(0x1) << USBC_UECON6_STALLEDE_Pos)
+#define USBC_UECON6_NREPLY_Pos      8            /**< \brief (USBC_UECON6) No Reply */
+#define USBC_UECON6_NREPLY          (_U(0x1) << USBC_UECON6_NREPLY_Pos)
+#define USBC_UECON6_RAMACERE_Pos    11           /**< \brief (USBC_UECON6) RAMACER Interrupt Enable */
+#define USBC_UECON6_RAMACERE        (_U(0x1) << USBC_UECON6_RAMACERE_Pos)
+#define USBC_UECON6_NBUSYBKE_Pos    12           /**< \brief (USBC_UECON6) Number of Busy Banks Interrupt Enable */
+#define USBC_UECON6_NBUSYBKE        (_U(0x1) << USBC_UECON6_NBUSYBKE_Pos)
+#define USBC_UECON6_KILLBK_Pos      13           /**< \brief (USBC_UECON6) Kill IN Bank */
+#define USBC_UECON6_KILLBK          (_U(0x1) << USBC_UECON6_KILLBK_Pos)
+#define USBC_UECON6_FIFOCON_Pos     14           /**< \brief (USBC_UECON6) FIFO Control */
+#define USBC_UECON6_FIFOCON         (_U(0x1) << USBC_UECON6_FIFOCON_Pos)
+#define USBC_UECON6_NYETDIS_Pos     17           /**< \brief (USBC_UECON6) NYET Token Enable */
+#define USBC_UECON6_NYETDIS         (_U(0x1) << USBC_UECON6_NYETDIS_Pos)
+#define USBC_UECON6_RSTDT_Pos       18           /**< \brief (USBC_UECON6) Reset Data Toggle */
+#define USBC_UECON6_RSTDT           (_U(0x1) << USBC_UECON6_RSTDT_Pos)
+#define USBC_UECON6_STALLRQ_Pos     19           /**< \brief (USBC_UECON6) STALL Request */
+#define USBC_UECON6_STALLRQ         (_U(0x1) << USBC_UECON6_STALLRQ_Pos)
+#define USBC_UECON6_BUSY0_Pos       24           /**< \brief (USBC_UECON6) Busy Bank1 Enable */
+#define USBC_UECON6_BUSY0           (_U(0x1) << USBC_UECON6_BUSY0_Pos)
+#define USBC_UECON6_BUSY1_Pos       25           /**< \brief (USBC_UECON6) Busy Bank0 Enable */
+#define USBC_UECON6_BUSY1           (_U(0x1) << USBC_UECON6_BUSY1_Pos)
+#define USBC_UECON6_MASK            _U(0x030E795F) /**< \brief (USBC_UECON6) MASK Register */
+
+/* -------- USBC_UECON7 : (USBC Offset: 0x1DC) (R/  32) Endpoint Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINE:1;          /*!< bit:      0  TXIN Interrupt Enable              */
+    uint32_t RXOUTE:1;         /*!< bit:      1  RXOUT Interrupt Enable             */
+    uint32_t RXSTPE:1;         /*!< bit:      2  RXSTP Interrupt Enable             */
+    uint32_t NAKOUTE:1;        /*!< bit:      3  NAKOUT Interrupt Enable            */
+    uint32_t NAKINE:1;         /*!< bit:      4  NAKIN Interrupt Enable             */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDE:1;       /*!< bit:      6  STALLED Interrupt Enable           */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t NREPLY:1;         /*!< bit:      8  No Reply                           */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t RAMACERE:1;       /*!< bit:     11  RAMACER Interrupt Enable           */
+    uint32_t NBUSYBKE:1;       /*!< bit:     12  Number of Busy Banks Interrupt Enable */
+    uint32_t KILLBK:1;         /*!< bit:     13  Kill IN Bank                       */
+    uint32_t FIFOCON:1;        /*!< bit:     14  FIFO Control                       */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t NYETDIS:1;        /*!< bit:     17  NYET Token Enable                  */
+    uint32_t RSTDT:1;          /*!< bit:     18  Reset Data Toggle                  */
+    uint32_t STALLRQ:1;        /*!< bit:     19  STALL Request                      */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t BUSY0:1;          /*!< bit:     24  Busy Bank1 Enable                  */
+    uint32_t BUSY1:1;          /*!< bit:     25  Busy Bank0 Enable                  */
+    uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECON7_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECON7_OFFSET          0x1DC        /**< \brief (USBC_UECON7 offset) Endpoint Control Register */
+#define USBC_UECON7_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UECON7 reset_value) Endpoint Control Register */
+
+#define USBC_UECON7_TXINE_Pos       0            /**< \brief (USBC_UECON7) TXIN Interrupt Enable */
+#define USBC_UECON7_TXINE           (_U(0x1) << USBC_UECON7_TXINE_Pos)
+#define USBC_UECON7_RXOUTE_Pos      1            /**< \brief (USBC_UECON7) RXOUT Interrupt Enable */
+#define USBC_UECON7_RXOUTE          (_U(0x1) << USBC_UECON7_RXOUTE_Pos)
+#define USBC_UECON7_RXSTPE_Pos      2            /**< \brief (USBC_UECON7) RXSTP Interrupt Enable */
+#define USBC_UECON7_RXSTPE          (_U(0x1) << USBC_UECON7_RXSTPE_Pos)
+#define USBC_UECON7_NAKOUTE_Pos     3            /**< \brief (USBC_UECON7) NAKOUT Interrupt Enable */
+#define USBC_UECON7_NAKOUTE         (_U(0x1) << USBC_UECON7_NAKOUTE_Pos)
+#define USBC_UECON7_NAKINE_Pos      4            /**< \brief (USBC_UECON7) NAKIN Interrupt Enable */
+#define USBC_UECON7_NAKINE          (_U(0x1) << USBC_UECON7_NAKINE_Pos)
+#define USBC_UECON7_STALLEDE_Pos    6            /**< \brief (USBC_UECON7) STALLED Interrupt Enable */
+#define USBC_UECON7_STALLEDE        (_U(0x1) << USBC_UECON7_STALLEDE_Pos)
+#define USBC_UECON7_NREPLY_Pos      8            /**< \brief (USBC_UECON7) No Reply */
+#define USBC_UECON7_NREPLY          (_U(0x1) << USBC_UECON7_NREPLY_Pos)
+#define USBC_UECON7_RAMACERE_Pos    11           /**< \brief (USBC_UECON7) RAMACER Interrupt Enable */
+#define USBC_UECON7_RAMACERE        (_U(0x1) << USBC_UECON7_RAMACERE_Pos)
+#define USBC_UECON7_NBUSYBKE_Pos    12           /**< \brief (USBC_UECON7) Number of Busy Banks Interrupt Enable */
+#define USBC_UECON7_NBUSYBKE        (_U(0x1) << USBC_UECON7_NBUSYBKE_Pos)
+#define USBC_UECON7_KILLBK_Pos      13           /**< \brief (USBC_UECON7) Kill IN Bank */
+#define USBC_UECON7_KILLBK          (_U(0x1) << USBC_UECON7_KILLBK_Pos)
+#define USBC_UECON7_FIFOCON_Pos     14           /**< \brief (USBC_UECON7) FIFO Control */
+#define USBC_UECON7_FIFOCON         (_U(0x1) << USBC_UECON7_FIFOCON_Pos)
+#define USBC_UECON7_NYETDIS_Pos     17           /**< \brief (USBC_UECON7) NYET Token Enable */
+#define USBC_UECON7_NYETDIS         (_U(0x1) << USBC_UECON7_NYETDIS_Pos)
+#define USBC_UECON7_RSTDT_Pos       18           /**< \brief (USBC_UECON7) Reset Data Toggle */
+#define USBC_UECON7_RSTDT           (_U(0x1) << USBC_UECON7_RSTDT_Pos)
+#define USBC_UECON7_STALLRQ_Pos     19           /**< \brief (USBC_UECON7) STALL Request */
+#define USBC_UECON7_STALLRQ         (_U(0x1) << USBC_UECON7_STALLRQ_Pos)
+#define USBC_UECON7_BUSY0_Pos       24           /**< \brief (USBC_UECON7) Busy Bank1 Enable */
+#define USBC_UECON7_BUSY0           (_U(0x1) << USBC_UECON7_BUSY0_Pos)
+#define USBC_UECON7_BUSY1_Pos       25           /**< \brief (USBC_UECON7) Busy Bank0 Enable */
+#define USBC_UECON7_BUSY1           (_U(0x1) << USBC_UECON7_BUSY1_Pos)
+#define USBC_UECON7_MASK            _U(0x030E795F) /**< \brief (USBC_UECON7) MASK Register */
+
+/* -------- USBC_UECON0SET : (USBC Offset: 0x1F0) ( /W 32) Endpoint Control Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINES:1;         /*!< bit:      0  TXINE Set                          */
+    uint32_t RXOUTES:1;        /*!< bit:      1  RXOUTE Set                         */
+    uint32_t RXSTPES:1;        /*!< bit:      2  RXSTPE Set                         */
+    uint32_t NAKOUTES:1;       /*!< bit:      3  NAKOUTE Set                        */
+    uint32_t NAKINES:1;        /*!< bit:      4  NAKINE Set                         */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDES:1;      /*!< bit:      6  STALLEDE Set                       */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t NREPLYS:1;        /*!< bit:      8  NREPLY Set                         */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t RAMACERES:1;      /*!< bit:     11  RAMACERE Set                       */
+    uint32_t NBUSYBKES:1;      /*!< bit:     12  NBUSYBKE Set                       */
+    uint32_t KILLBKS:1;        /*!< bit:     13  KILLBK Set                         */
+    uint32_t :3;               /*!< bit: 14..16  Reserved                           */
+    uint32_t NYETDISS:1;       /*!< bit:     17  NYETDIS Set                        */
+    uint32_t RSTDTS:1;         /*!< bit:     18  RSTDT Set                          */
+    uint32_t STALLRQS:1;       /*!< bit:     19  STALLRQ Set                        */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t BUSY0S:1;         /*!< bit:     24  BUSY0 Set                          */
+    uint32_t BUSY1S:1;         /*!< bit:     25  BUSY1 Set                          */
+    uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECON0SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECON0SET_OFFSET       0x1F0        /**< \brief (USBC_UECON0SET offset) Endpoint Control Set Register */
+#define USBC_UECON0SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON0SET reset_value) Endpoint Control Set Register */
+
+#define USBC_UECON0SET_TXINES_Pos   0            /**< \brief (USBC_UECON0SET) TXINE Set */
+#define USBC_UECON0SET_TXINES       (_U(0x1) << USBC_UECON0SET_TXINES_Pos)
+#define USBC_UECON0SET_RXOUTES_Pos  1            /**< \brief (USBC_UECON0SET) RXOUTE Set */
+#define USBC_UECON0SET_RXOUTES      (_U(0x1) << USBC_UECON0SET_RXOUTES_Pos)
+#define USBC_UECON0SET_RXSTPES_Pos  2            /**< \brief (USBC_UECON0SET) RXSTPE Set */
+#define USBC_UECON0SET_RXSTPES      (_U(0x1) << USBC_UECON0SET_RXSTPES_Pos)
+#define USBC_UECON0SET_NAKOUTES_Pos 3            /**< \brief (USBC_UECON0SET) NAKOUTE Set */
+#define USBC_UECON0SET_NAKOUTES     (_U(0x1) << USBC_UECON0SET_NAKOUTES_Pos)
+#define USBC_UECON0SET_NAKINES_Pos  4            /**< \brief (USBC_UECON0SET) NAKINE Set */
+#define USBC_UECON0SET_NAKINES      (_U(0x1) << USBC_UECON0SET_NAKINES_Pos)
+#define USBC_UECON0SET_STALLEDES_Pos 6            /**< \brief (USBC_UECON0SET) STALLEDE Set */
+#define USBC_UECON0SET_STALLEDES    (_U(0x1) << USBC_UECON0SET_STALLEDES_Pos)
+#define USBC_UECON0SET_NREPLYS_Pos  8            /**< \brief (USBC_UECON0SET) NREPLY Set */
+#define USBC_UECON0SET_NREPLYS      (_U(0x1) << USBC_UECON0SET_NREPLYS_Pos)
+#define USBC_UECON0SET_RAMACERES_Pos 11           /**< \brief (USBC_UECON0SET) RAMACERE Set */
+#define USBC_UECON0SET_RAMACERES    (_U(0x1) << USBC_UECON0SET_RAMACERES_Pos)
+#define USBC_UECON0SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UECON0SET) NBUSYBKE Set */
+#define USBC_UECON0SET_NBUSYBKES    (_U(0x1) << USBC_UECON0SET_NBUSYBKES_Pos)
+#define USBC_UECON0SET_KILLBKS_Pos  13           /**< \brief (USBC_UECON0SET) KILLBK Set */
+#define USBC_UECON0SET_KILLBKS      (_U(0x1) << USBC_UECON0SET_KILLBKS_Pos)
+#define USBC_UECON0SET_NYETDISS_Pos 17           /**< \brief (USBC_UECON0SET) NYETDIS Set */
+#define USBC_UECON0SET_NYETDISS     (_U(0x1) << USBC_UECON0SET_NYETDISS_Pos)
+#define USBC_UECON0SET_RSTDTS_Pos   18           /**< \brief (USBC_UECON0SET) RSTDT Set */
+#define USBC_UECON0SET_RSTDTS       (_U(0x1) << USBC_UECON0SET_RSTDTS_Pos)
+#define USBC_UECON0SET_STALLRQS_Pos 19           /**< \brief (USBC_UECON0SET) STALLRQ Set */
+#define USBC_UECON0SET_STALLRQS     (_U(0x1) << USBC_UECON0SET_STALLRQS_Pos)
+#define USBC_UECON0SET_BUSY0S_Pos   24           /**< \brief (USBC_UECON0SET) BUSY0 Set */
+#define USBC_UECON0SET_BUSY0S       (_U(0x1) << USBC_UECON0SET_BUSY0S_Pos)
+#define USBC_UECON0SET_BUSY1S_Pos   25           /**< \brief (USBC_UECON0SET) BUSY1 Set */
+#define USBC_UECON0SET_BUSY1S       (_U(0x1) << USBC_UECON0SET_BUSY1S_Pos)
+#define USBC_UECON0SET_MASK         _U(0x030E395F) /**< \brief (USBC_UECON0SET) MASK Register */
+
+/* -------- USBC_UECON1SET : (USBC Offset: 0x1F4) ( /W 32) Endpoint Control Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINES:1;         /*!< bit:      0  TXINE Set                          */
+    uint32_t RXOUTES:1;        /*!< bit:      1  RXOUTE Set                         */
+    uint32_t RXSTPES:1;        /*!< bit:      2  RXSTPE Set                         */
+    uint32_t NAKOUTES:1;       /*!< bit:      3  NAKOUTE Set                        */
+    uint32_t NAKINES:1;        /*!< bit:      4  NAKINE Set                         */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDES:1;      /*!< bit:      6  STALLEDE Set                       */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t NREPLYS:1;        /*!< bit:      8  NREPLY Set                         */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t RAMACERES:1;      /*!< bit:     11  RAMACERE Set                       */
+    uint32_t NBUSYBKES:1;      /*!< bit:     12  NBUSYBKE Set                       */
+    uint32_t KILLBKS:1;        /*!< bit:     13  KILLBK Set                         */
+    uint32_t :3;               /*!< bit: 14..16  Reserved                           */
+    uint32_t NYETDISS:1;       /*!< bit:     17  NYETDIS Set                        */
+    uint32_t RSTDTS:1;         /*!< bit:     18  RSTDT Set                          */
+    uint32_t STALLRQS:1;       /*!< bit:     19  STALLRQ Set                        */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t BUSY0S:1;         /*!< bit:     24  BUSY0 Set                          */
+    uint32_t BUSY1S:1;         /*!< bit:     25  BUSY1 Set                          */
+    uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECON1SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECON1SET_OFFSET       0x1F4        /**< \brief (USBC_UECON1SET offset) Endpoint Control Set Register */
+#define USBC_UECON1SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON1SET reset_value) Endpoint Control Set Register */
+
+#define USBC_UECON1SET_TXINES_Pos   0            /**< \brief (USBC_UECON1SET) TXINE Set */
+#define USBC_UECON1SET_TXINES       (_U(0x1) << USBC_UECON1SET_TXINES_Pos)
+#define USBC_UECON1SET_RXOUTES_Pos  1            /**< \brief (USBC_UECON1SET) RXOUTE Set */
+#define USBC_UECON1SET_RXOUTES      (_U(0x1) << USBC_UECON1SET_RXOUTES_Pos)
+#define USBC_UECON1SET_RXSTPES_Pos  2            /**< \brief (USBC_UECON1SET) RXSTPE Set */
+#define USBC_UECON1SET_RXSTPES      (_U(0x1) << USBC_UECON1SET_RXSTPES_Pos)
+#define USBC_UECON1SET_NAKOUTES_Pos 3            /**< \brief (USBC_UECON1SET) NAKOUTE Set */
+#define USBC_UECON1SET_NAKOUTES     (_U(0x1) << USBC_UECON1SET_NAKOUTES_Pos)
+#define USBC_UECON1SET_NAKINES_Pos  4            /**< \brief (USBC_UECON1SET) NAKINE Set */
+#define USBC_UECON1SET_NAKINES      (_U(0x1) << USBC_UECON1SET_NAKINES_Pos)
+#define USBC_UECON1SET_STALLEDES_Pos 6            /**< \brief (USBC_UECON1SET) STALLEDE Set */
+#define USBC_UECON1SET_STALLEDES    (_U(0x1) << USBC_UECON1SET_STALLEDES_Pos)
+#define USBC_UECON1SET_NREPLYS_Pos  8            /**< \brief (USBC_UECON1SET) NREPLY Set */
+#define USBC_UECON1SET_NREPLYS      (_U(0x1) << USBC_UECON1SET_NREPLYS_Pos)
+#define USBC_UECON1SET_RAMACERES_Pos 11           /**< \brief (USBC_UECON1SET) RAMACERE Set */
+#define USBC_UECON1SET_RAMACERES    (_U(0x1) << USBC_UECON1SET_RAMACERES_Pos)
+#define USBC_UECON1SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UECON1SET) NBUSYBKE Set */
+#define USBC_UECON1SET_NBUSYBKES    (_U(0x1) << USBC_UECON1SET_NBUSYBKES_Pos)
+#define USBC_UECON1SET_KILLBKS_Pos  13           /**< \brief (USBC_UECON1SET) KILLBK Set */
+#define USBC_UECON1SET_KILLBKS      (_U(0x1) << USBC_UECON1SET_KILLBKS_Pos)
+#define USBC_UECON1SET_NYETDISS_Pos 17           /**< \brief (USBC_UECON1SET) NYETDIS Set */
+#define USBC_UECON1SET_NYETDISS     (_U(0x1) << USBC_UECON1SET_NYETDISS_Pos)
+#define USBC_UECON1SET_RSTDTS_Pos   18           /**< \brief (USBC_UECON1SET) RSTDT Set */
+#define USBC_UECON1SET_RSTDTS       (_U(0x1) << USBC_UECON1SET_RSTDTS_Pos)
+#define USBC_UECON1SET_STALLRQS_Pos 19           /**< \brief (USBC_UECON1SET) STALLRQ Set */
+#define USBC_UECON1SET_STALLRQS     (_U(0x1) << USBC_UECON1SET_STALLRQS_Pos)
+#define USBC_UECON1SET_BUSY0S_Pos   24           /**< \brief (USBC_UECON1SET) BUSY0 Set */
+#define USBC_UECON1SET_BUSY0S       (_U(0x1) << USBC_UECON1SET_BUSY0S_Pos)
+#define USBC_UECON1SET_BUSY1S_Pos   25           /**< \brief (USBC_UECON1SET) BUSY1 Set */
+#define USBC_UECON1SET_BUSY1S       (_U(0x1) << USBC_UECON1SET_BUSY1S_Pos)
+#define USBC_UECON1SET_MASK         _U(0x030E395F) /**< \brief (USBC_UECON1SET) MASK Register */
+
+/* -------- USBC_UECON2SET : (USBC Offset: 0x1F8) ( /W 32) Endpoint Control Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINES:1;         /*!< bit:      0  TXINE Set                          */
+    uint32_t RXOUTES:1;        /*!< bit:      1  RXOUTE Set                         */
+    uint32_t RXSTPES:1;        /*!< bit:      2  RXSTPE Set                         */
+    uint32_t NAKOUTES:1;       /*!< bit:      3  NAKOUTE Set                        */
+    uint32_t NAKINES:1;        /*!< bit:      4  NAKINE Set                         */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDES:1;      /*!< bit:      6  STALLEDE Set                       */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t NREPLYS:1;        /*!< bit:      8  NREPLY Set                         */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t RAMACERES:1;      /*!< bit:     11  RAMACERE Set                       */
+    uint32_t NBUSYBKES:1;      /*!< bit:     12  NBUSYBKE Set                       */
+    uint32_t KILLBKS:1;        /*!< bit:     13  KILLBK Set                         */
+    uint32_t :3;               /*!< bit: 14..16  Reserved                           */
+    uint32_t NYETDISS:1;       /*!< bit:     17  NYETDIS Set                        */
+    uint32_t RSTDTS:1;         /*!< bit:     18  RSTDT Set                          */
+    uint32_t STALLRQS:1;       /*!< bit:     19  STALLRQ Set                        */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t BUSY0S:1;         /*!< bit:     24  BUSY0 Set                          */
+    uint32_t BUSY1S:1;         /*!< bit:     25  BUSY1 Set                          */
+    uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECON2SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECON2SET_OFFSET       0x1F8        /**< \brief (USBC_UECON2SET offset) Endpoint Control Set Register */
+#define USBC_UECON2SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON2SET reset_value) Endpoint Control Set Register */
+
+#define USBC_UECON2SET_TXINES_Pos   0            /**< \brief (USBC_UECON2SET) TXINE Set */
+#define USBC_UECON2SET_TXINES       (_U(0x1) << USBC_UECON2SET_TXINES_Pos)
+#define USBC_UECON2SET_RXOUTES_Pos  1            /**< \brief (USBC_UECON2SET) RXOUTE Set */
+#define USBC_UECON2SET_RXOUTES      (_U(0x1) << USBC_UECON2SET_RXOUTES_Pos)
+#define USBC_UECON2SET_RXSTPES_Pos  2            /**< \brief (USBC_UECON2SET) RXSTPE Set */
+#define USBC_UECON2SET_RXSTPES      (_U(0x1) << USBC_UECON2SET_RXSTPES_Pos)
+#define USBC_UECON2SET_NAKOUTES_Pos 3            /**< \brief (USBC_UECON2SET) NAKOUTE Set */
+#define USBC_UECON2SET_NAKOUTES     (_U(0x1) << USBC_UECON2SET_NAKOUTES_Pos)
+#define USBC_UECON2SET_NAKINES_Pos  4            /**< \brief (USBC_UECON2SET) NAKINE Set */
+#define USBC_UECON2SET_NAKINES      (_U(0x1) << USBC_UECON2SET_NAKINES_Pos)
+#define USBC_UECON2SET_STALLEDES_Pos 6            /**< \brief (USBC_UECON2SET) STALLEDE Set */
+#define USBC_UECON2SET_STALLEDES    (_U(0x1) << USBC_UECON2SET_STALLEDES_Pos)
+#define USBC_UECON2SET_NREPLYS_Pos  8            /**< \brief (USBC_UECON2SET) NREPLY Set */
+#define USBC_UECON2SET_NREPLYS      (_U(0x1) << USBC_UECON2SET_NREPLYS_Pos)
+#define USBC_UECON2SET_RAMACERES_Pos 11           /**< \brief (USBC_UECON2SET) RAMACERE Set */
+#define USBC_UECON2SET_RAMACERES    (_U(0x1) << USBC_UECON2SET_RAMACERES_Pos)
+#define USBC_UECON2SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UECON2SET) NBUSYBKE Set */
+#define USBC_UECON2SET_NBUSYBKES    (_U(0x1) << USBC_UECON2SET_NBUSYBKES_Pos)
+#define USBC_UECON2SET_KILLBKS_Pos  13           /**< \brief (USBC_UECON2SET) KILLBK Set */
+#define USBC_UECON2SET_KILLBKS      (_U(0x1) << USBC_UECON2SET_KILLBKS_Pos)
+#define USBC_UECON2SET_NYETDISS_Pos 17           /**< \brief (USBC_UECON2SET) NYETDIS Set */
+#define USBC_UECON2SET_NYETDISS     (_U(0x1) << USBC_UECON2SET_NYETDISS_Pos)
+#define USBC_UECON2SET_RSTDTS_Pos   18           /**< \brief (USBC_UECON2SET) RSTDT Set */
+#define USBC_UECON2SET_RSTDTS       (_U(0x1) << USBC_UECON2SET_RSTDTS_Pos)
+#define USBC_UECON2SET_STALLRQS_Pos 19           /**< \brief (USBC_UECON2SET) STALLRQ Set */
+#define USBC_UECON2SET_STALLRQS     (_U(0x1) << USBC_UECON2SET_STALLRQS_Pos)
+#define USBC_UECON2SET_BUSY0S_Pos   24           /**< \brief (USBC_UECON2SET) BUSY0 Set */
+#define USBC_UECON2SET_BUSY0S       (_U(0x1) << USBC_UECON2SET_BUSY0S_Pos)
+#define USBC_UECON2SET_BUSY1S_Pos   25           /**< \brief (USBC_UECON2SET) BUSY1 Set */
+#define USBC_UECON2SET_BUSY1S       (_U(0x1) << USBC_UECON2SET_BUSY1S_Pos)
+#define USBC_UECON2SET_MASK         _U(0x030E395F) /**< \brief (USBC_UECON2SET) MASK Register */
+
+/* -------- USBC_UECON3SET : (USBC Offset: 0x1FC) ( /W 32) Endpoint Control Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINES:1;         /*!< bit:      0  TXINE Set                          */
+    uint32_t RXOUTES:1;        /*!< bit:      1  RXOUTE Set                         */
+    uint32_t RXSTPES:1;        /*!< bit:      2  RXSTPE Set                         */
+    uint32_t NAKOUTES:1;       /*!< bit:      3  NAKOUTE Set                        */
+    uint32_t NAKINES:1;        /*!< bit:      4  NAKINE Set                         */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDES:1;      /*!< bit:      6  STALLEDE Set                       */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t NREPLYS:1;        /*!< bit:      8  NREPLY Set                         */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t RAMACERES:1;      /*!< bit:     11  RAMACERE Set                       */
+    uint32_t NBUSYBKES:1;      /*!< bit:     12  NBUSYBKE Set                       */
+    uint32_t KILLBKS:1;        /*!< bit:     13  KILLBK Set                         */
+    uint32_t :3;               /*!< bit: 14..16  Reserved                           */
+    uint32_t NYETDISS:1;       /*!< bit:     17  NYETDIS Set                        */
+    uint32_t RSTDTS:1;         /*!< bit:     18  RSTDT Set                          */
+    uint32_t STALLRQS:1;       /*!< bit:     19  STALLRQ Set                        */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t BUSY0S:1;         /*!< bit:     24  BUSY0 Set                          */
+    uint32_t BUSY1S:1;         /*!< bit:     25  BUSY1 Set                          */
+    uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECON3SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECON3SET_OFFSET       0x1FC        /**< \brief (USBC_UECON3SET offset) Endpoint Control Set Register */
+#define USBC_UECON3SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON3SET reset_value) Endpoint Control Set Register */
+
+#define USBC_UECON3SET_TXINES_Pos   0            /**< \brief (USBC_UECON3SET) TXINE Set */
+#define USBC_UECON3SET_TXINES       (_U(0x1) << USBC_UECON3SET_TXINES_Pos)
+#define USBC_UECON3SET_RXOUTES_Pos  1            /**< \brief (USBC_UECON3SET) RXOUTE Set */
+#define USBC_UECON3SET_RXOUTES      (_U(0x1) << USBC_UECON3SET_RXOUTES_Pos)
+#define USBC_UECON3SET_RXSTPES_Pos  2            /**< \brief (USBC_UECON3SET) RXSTPE Set */
+#define USBC_UECON3SET_RXSTPES      (_U(0x1) << USBC_UECON3SET_RXSTPES_Pos)
+#define USBC_UECON3SET_NAKOUTES_Pos 3            /**< \brief (USBC_UECON3SET) NAKOUTE Set */
+#define USBC_UECON3SET_NAKOUTES     (_U(0x1) << USBC_UECON3SET_NAKOUTES_Pos)
+#define USBC_UECON3SET_NAKINES_Pos  4            /**< \brief (USBC_UECON3SET) NAKINE Set */
+#define USBC_UECON3SET_NAKINES      (_U(0x1) << USBC_UECON3SET_NAKINES_Pos)
+#define USBC_UECON3SET_STALLEDES_Pos 6            /**< \brief (USBC_UECON3SET) STALLEDE Set */
+#define USBC_UECON3SET_STALLEDES    (_U(0x1) << USBC_UECON3SET_STALLEDES_Pos)
+#define USBC_UECON3SET_NREPLYS_Pos  8            /**< \brief (USBC_UECON3SET) NREPLY Set */
+#define USBC_UECON3SET_NREPLYS      (_U(0x1) << USBC_UECON3SET_NREPLYS_Pos)
+#define USBC_UECON3SET_RAMACERES_Pos 11           /**< \brief (USBC_UECON3SET) RAMACERE Set */
+#define USBC_UECON3SET_RAMACERES    (_U(0x1) << USBC_UECON3SET_RAMACERES_Pos)
+#define USBC_UECON3SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UECON3SET) NBUSYBKE Set */
+#define USBC_UECON3SET_NBUSYBKES    (_U(0x1) << USBC_UECON3SET_NBUSYBKES_Pos)
+#define USBC_UECON3SET_KILLBKS_Pos  13           /**< \brief (USBC_UECON3SET) KILLBK Set */
+#define USBC_UECON3SET_KILLBKS      (_U(0x1) << USBC_UECON3SET_KILLBKS_Pos)
+#define USBC_UECON3SET_NYETDISS_Pos 17           /**< \brief (USBC_UECON3SET) NYETDIS Set */
+#define USBC_UECON3SET_NYETDISS     (_U(0x1) << USBC_UECON3SET_NYETDISS_Pos)
+#define USBC_UECON3SET_RSTDTS_Pos   18           /**< \brief (USBC_UECON3SET) RSTDT Set */
+#define USBC_UECON3SET_RSTDTS       (_U(0x1) << USBC_UECON3SET_RSTDTS_Pos)
+#define USBC_UECON3SET_STALLRQS_Pos 19           /**< \brief (USBC_UECON3SET) STALLRQ Set */
+#define USBC_UECON3SET_STALLRQS     (_U(0x1) << USBC_UECON3SET_STALLRQS_Pos)
+#define USBC_UECON3SET_BUSY0S_Pos   24           /**< \brief (USBC_UECON3SET) BUSY0 Set */
+#define USBC_UECON3SET_BUSY0S       (_U(0x1) << USBC_UECON3SET_BUSY0S_Pos)
+#define USBC_UECON3SET_BUSY1S_Pos   25           /**< \brief (USBC_UECON3SET) BUSY1 Set */
+#define USBC_UECON3SET_BUSY1S       (_U(0x1) << USBC_UECON3SET_BUSY1S_Pos)
+#define USBC_UECON3SET_MASK         _U(0x030E395F) /**< \brief (USBC_UECON3SET) MASK Register */
+
+/* -------- USBC_UECON4SET : (USBC Offset: 0x200) ( /W 32) Endpoint Control Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINES:1;         /*!< bit:      0  TXINE Set                          */
+    uint32_t RXOUTES:1;        /*!< bit:      1  RXOUTE Set                         */
+    uint32_t RXSTPES:1;        /*!< bit:      2  RXSTPE Set                         */
+    uint32_t NAKOUTES:1;       /*!< bit:      3  NAKOUTE Set                        */
+    uint32_t NAKINES:1;        /*!< bit:      4  NAKINE Set                         */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDES:1;      /*!< bit:      6  STALLEDE Set                       */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t NREPLYS:1;        /*!< bit:      8  NREPLY Set                         */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t RAMACERES:1;      /*!< bit:     11  RAMACERE Set                       */
+    uint32_t NBUSYBKES:1;      /*!< bit:     12  NBUSYBKE Set                       */
+    uint32_t KILLBKS:1;        /*!< bit:     13  KILLBK Set                         */
+    uint32_t :3;               /*!< bit: 14..16  Reserved                           */
+    uint32_t NYETDISS:1;       /*!< bit:     17  NYETDIS Set                        */
+    uint32_t RSTDTS:1;         /*!< bit:     18  RSTDT Set                          */
+    uint32_t STALLRQS:1;       /*!< bit:     19  STALLRQ Set                        */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t BUSY0S:1;         /*!< bit:     24  BUSY0 Set                          */
+    uint32_t BUSY1S:1;         /*!< bit:     25  BUSY1 Set                          */
+    uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECON4SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECON4SET_OFFSET       0x200        /**< \brief (USBC_UECON4SET offset) Endpoint Control Set Register */
+#define USBC_UECON4SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON4SET reset_value) Endpoint Control Set Register */
+
+#define USBC_UECON4SET_TXINES_Pos   0            /**< \brief (USBC_UECON4SET) TXINE Set */
+#define USBC_UECON4SET_TXINES       (_U(0x1) << USBC_UECON4SET_TXINES_Pos)
+#define USBC_UECON4SET_RXOUTES_Pos  1            /**< \brief (USBC_UECON4SET) RXOUTE Set */
+#define USBC_UECON4SET_RXOUTES      (_U(0x1) << USBC_UECON4SET_RXOUTES_Pos)
+#define USBC_UECON4SET_RXSTPES_Pos  2            /**< \brief (USBC_UECON4SET) RXSTPE Set */
+#define USBC_UECON4SET_RXSTPES      (_U(0x1) << USBC_UECON4SET_RXSTPES_Pos)
+#define USBC_UECON4SET_NAKOUTES_Pos 3            /**< \brief (USBC_UECON4SET) NAKOUTE Set */
+#define USBC_UECON4SET_NAKOUTES     (_U(0x1) << USBC_UECON4SET_NAKOUTES_Pos)
+#define USBC_UECON4SET_NAKINES_Pos  4            /**< \brief (USBC_UECON4SET) NAKINE Set */
+#define USBC_UECON4SET_NAKINES      (_U(0x1) << USBC_UECON4SET_NAKINES_Pos)
+#define USBC_UECON4SET_STALLEDES_Pos 6            /**< \brief (USBC_UECON4SET) STALLEDE Set */
+#define USBC_UECON4SET_STALLEDES    (_U(0x1) << USBC_UECON4SET_STALLEDES_Pos)
+#define USBC_UECON4SET_NREPLYS_Pos  8            /**< \brief (USBC_UECON4SET) NREPLY Set */
+#define USBC_UECON4SET_NREPLYS      (_U(0x1) << USBC_UECON4SET_NREPLYS_Pos)
+#define USBC_UECON4SET_RAMACERES_Pos 11           /**< \brief (USBC_UECON4SET) RAMACERE Set */
+#define USBC_UECON4SET_RAMACERES    (_U(0x1) << USBC_UECON4SET_RAMACERES_Pos)
+#define USBC_UECON4SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UECON4SET) NBUSYBKE Set */
+#define USBC_UECON4SET_NBUSYBKES    (_U(0x1) << USBC_UECON4SET_NBUSYBKES_Pos)
+#define USBC_UECON4SET_KILLBKS_Pos  13           /**< \brief (USBC_UECON4SET) KILLBK Set */
+#define USBC_UECON4SET_KILLBKS      (_U(0x1) << USBC_UECON4SET_KILLBKS_Pos)
+#define USBC_UECON4SET_NYETDISS_Pos 17           /**< \brief (USBC_UECON4SET) NYETDIS Set */
+#define USBC_UECON4SET_NYETDISS     (_U(0x1) << USBC_UECON4SET_NYETDISS_Pos)
+#define USBC_UECON4SET_RSTDTS_Pos   18           /**< \brief (USBC_UECON4SET) RSTDT Set */
+#define USBC_UECON4SET_RSTDTS       (_U(0x1) << USBC_UECON4SET_RSTDTS_Pos)
+#define USBC_UECON4SET_STALLRQS_Pos 19           /**< \brief (USBC_UECON4SET) STALLRQ Set */
+#define USBC_UECON4SET_STALLRQS     (_U(0x1) << USBC_UECON4SET_STALLRQS_Pos)
+#define USBC_UECON4SET_BUSY0S_Pos   24           /**< \brief (USBC_UECON4SET) BUSY0 Set */
+#define USBC_UECON4SET_BUSY0S       (_U(0x1) << USBC_UECON4SET_BUSY0S_Pos)
+#define USBC_UECON4SET_BUSY1S_Pos   25           /**< \brief (USBC_UECON4SET) BUSY1 Set */
+#define USBC_UECON4SET_BUSY1S       (_U(0x1) << USBC_UECON4SET_BUSY1S_Pos)
+#define USBC_UECON4SET_MASK         _U(0x030E395F) /**< \brief (USBC_UECON4SET) MASK Register */
+
+/* -------- USBC_UECON5SET : (USBC Offset: 0x204) ( /W 32) Endpoint Control Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINES:1;         /*!< bit:      0  TXINE Set                          */
+    uint32_t RXOUTES:1;        /*!< bit:      1  RXOUTE Set                         */
+    uint32_t RXSTPES:1;        /*!< bit:      2  RXSTPE Set                         */
+    uint32_t NAKOUTES:1;       /*!< bit:      3  NAKOUTE Set                        */
+    uint32_t NAKINES:1;        /*!< bit:      4  NAKINE Set                         */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDES:1;      /*!< bit:      6  STALLEDE Set                       */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t NREPLYS:1;        /*!< bit:      8  NREPLY Set                         */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t RAMACERES:1;      /*!< bit:     11  RAMACERE Set                       */
+    uint32_t NBUSYBKES:1;      /*!< bit:     12  NBUSYBKE Set                       */
+    uint32_t KILLBKS:1;        /*!< bit:     13  KILLBK Set                         */
+    uint32_t :3;               /*!< bit: 14..16  Reserved                           */
+    uint32_t NYETDISS:1;       /*!< bit:     17  NYETDIS Set                        */
+    uint32_t RSTDTS:1;         /*!< bit:     18  RSTDT Set                          */
+    uint32_t STALLRQS:1;       /*!< bit:     19  STALLRQ Set                        */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t BUSY0S:1;         /*!< bit:     24  BUSY0 Set                          */
+    uint32_t BUSY1S:1;         /*!< bit:     25  BUSY1 Set                          */
+    uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECON5SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECON5SET_OFFSET       0x204        /**< \brief (USBC_UECON5SET offset) Endpoint Control Set Register */
+#define USBC_UECON5SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON5SET reset_value) Endpoint Control Set Register */
+
+#define USBC_UECON5SET_TXINES_Pos   0            /**< \brief (USBC_UECON5SET) TXINE Set */
+#define USBC_UECON5SET_TXINES       (_U(0x1) << USBC_UECON5SET_TXINES_Pos)
+#define USBC_UECON5SET_RXOUTES_Pos  1            /**< \brief (USBC_UECON5SET) RXOUTE Set */
+#define USBC_UECON5SET_RXOUTES      (_U(0x1) << USBC_UECON5SET_RXOUTES_Pos)
+#define USBC_UECON5SET_RXSTPES_Pos  2            /**< \brief (USBC_UECON5SET) RXSTPE Set */
+#define USBC_UECON5SET_RXSTPES      (_U(0x1) << USBC_UECON5SET_RXSTPES_Pos)
+#define USBC_UECON5SET_NAKOUTES_Pos 3            /**< \brief (USBC_UECON5SET) NAKOUTE Set */
+#define USBC_UECON5SET_NAKOUTES     (_U(0x1) << USBC_UECON5SET_NAKOUTES_Pos)
+#define USBC_UECON5SET_NAKINES_Pos  4            /**< \brief (USBC_UECON5SET) NAKINE Set */
+#define USBC_UECON5SET_NAKINES      (_U(0x1) << USBC_UECON5SET_NAKINES_Pos)
+#define USBC_UECON5SET_STALLEDES_Pos 6            /**< \brief (USBC_UECON5SET) STALLEDE Set */
+#define USBC_UECON5SET_STALLEDES    (_U(0x1) << USBC_UECON5SET_STALLEDES_Pos)
+#define USBC_UECON5SET_NREPLYS_Pos  8            /**< \brief (USBC_UECON5SET) NREPLY Set */
+#define USBC_UECON5SET_NREPLYS      (_U(0x1) << USBC_UECON5SET_NREPLYS_Pos)
+#define USBC_UECON5SET_RAMACERES_Pos 11           /**< \brief (USBC_UECON5SET) RAMACERE Set */
+#define USBC_UECON5SET_RAMACERES    (_U(0x1) << USBC_UECON5SET_RAMACERES_Pos)
+#define USBC_UECON5SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UECON5SET) NBUSYBKE Set */
+#define USBC_UECON5SET_NBUSYBKES    (_U(0x1) << USBC_UECON5SET_NBUSYBKES_Pos)
+#define USBC_UECON5SET_KILLBKS_Pos  13           /**< \brief (USBC_UECON5SET) KILLBK Set */
+#define USBC_UECON5SET_KILLBKS      (_U(0x1) << USBC_UECON5SET_KILLBKS_Pos)
+#define USBC_UECON5SET_NYETDISS_Pos 17           /**< \brief (USBC_UECON5SET) NYETDIS Set */
+#define USBC_UECON5SET_NYETDISS     (_U(0x1) << USBC_UECON5SET_NYETDISS_Pos)
+#define USBC_UECON5SET_RSTDTS_Pos   18           /**< \brief (USBC_UECON5SET) RSTDT Set */
+#define USBC_UECON5SET_RSTDTS       (_U(0x1) << USBC_UECON5SET_RSTDTS_Pos)
+#define USBC_UECON5SET_STALLRQS_Pos 19           /**< \brief (USBC_UECON5SET) STALLRQ Set */
+#define USBC_UECON5SET_STALLRQS     (_U(0x1) << USBC_UECON5SET_STALLRQS_Pos)
+#define USBC_UECON5SET_BUSY0S_Pos   24           /**< \brief (USBC_UECON5SET) BUSY0 Set */
+#define USBC_UECON5SET_BUSY0S       (_U(0x1) << USBC_UECON5SET_BUSY0S_Pos)
+#define USBC_UECON5SET_BUSY1S_Pos   25           /**< \brief (USBC_UECON5SET) BUSY1 Set */
+#define USBC_UECON5SET_BUSY1S       (_U(0x1) << USBC_UECON5SET_BUSY1S_Pos)
+#define USBC_UECON5SET_MASK         _U(0x030E395F) /**< \brief (USBC_UECON5SET) MASK Register */
+
+/* -------- USBC_UECON6SET : (USBC Offset: 0x208) ( /W 32) Endpoint Control Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINES:1;         /*!< bit:      0  TXINE Set                          */
+    uint32_t RXOUTES:1;        /*!< bit:      1  RXOUTE Set                         */
+    uint32_t RXSTPES:1;        /*!< bit:      2  RXSTPE Set                         */
+    uint32_t NAKOUTES:1;       /*!< bit:      3  NAKOUTE Set                        */
+    uint32_t NAKINES:1;        /*!< bit:      4  NAKINE Set                         */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDES:1;      /*!< bit:      6  STALLEDE Set                       */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t NREPLYS:1;        /*!< bit:      8  NREPLY Set                         */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t RAMACERES:1;      /*!< bit:     11  RAMACERE Set                       */
+    uint32_t NBUSYBKES:1;      /*!< bit:     12  NBUSYBKE Set                       */
+    uint32_t KILLBKS:1;        /*!< bit:     13  KILLBK Set                         */
+    uint32_t :3;               /*!< bit: 14..16  Reserved                           */
+    uint32_t NYETDISS:1;       /*!< bit:     17  NYETDIS Set                        */
+    uint32_t RSTDTS:1;         /*!< bit:     18  RSTDT Set                          */
+    uint32_t STALLRQS:1;       /*!< bit:     19  STALLRQ Set                        */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t BUSY0S:1;         /*!< bit:     24  BUSY0 Set                          */
+    uint32_t BUSY1S:1;         /*!< bit:     25  BUSY1 Set                          */
+    uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECON6SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECON6SET_OFFSET       0x208        /**< \brief (USBC_UECON6SET offset) Endpoint Control Set Register */
+#define USBC_UECON6SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON6SET reset_value) Endpoint Control Set Register */
+
+#define USBC_UECON6SET_TXINES_Pos   0            /**< \brief (USBC_UECON6SET) TXINE Set */
+#define USBC_UECON6SET_TXINES       (_U(0x1) << USBC_UECON6SET_TXINES_Pos)
+#define USBC_UECON6SET_RXOUTES_Pos  1            /**< \brief (USBC_UECON6SET) RXOUTE Set */
+#define USBC_UECON6SET_RXOUTES      (_U(0x1) << USBC_UECON6SET_RXOUTES_Pos)
+#define USBC_UECON6SET_RXSTPES_Pos  2            /**< \brief (USBC_UECON6SET) RXSTPE Set */
+#define USBC_UECON6SET_RXSTPES      (_U(0x1) << USBC_UECON6SET_RXSTPES_Pos)
+#define USBC_UECON6SET_NAKOUTES_Pos 3            /**< \brief (USBC_UECON6SET) NAKOUTE Set */
+#define USBC_UECON6SET_NAKOUTES     (_U(0x1) << USBC_UECON6SET_NAKOUTES_Pos)
+#define USBC_UECON6SET_NAKINES_Pos  4            /**< \brief (USBC_UECON6SET) NAKINE Set */
+#define USBC_UECON6SET_NAKINES      (_U(0x1) << USBC_UECON6SET_NAKINES_Pos)
+#define USBC_UECON6SET_STALLEDES_Pos 6            /**< \brief (USBC_UECON6SET) STALLEDE Set */
+#define USBC_UECON6SET_STALLEDES    (_U(0x1) << USBC_UECON6SET_STALLEDES_Pos)
+#define USBC_UECON6SET_NREPLYS_Pos  8            /**< \brief (USBC_UECON6SET) NREPLY Set */
+#define USBC_UECON6SET_NREPLYS      (_U(0x1) << USBC_UECON6SET_NREPLYS_Pos)
+#define USBC_UECON6SET_RAMACERES_Pos 11           /**< \brief (USBC_UECON6SET) RAMACERE Set */
+#define USBC_UECON6SET_RAMACERES    (_U(0x1) << USBC_UECON6SET_RAMACERES_Pos)
+#define USBC_UECON6SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UECON6SET) NBUSYBKE Set */
+#define USBC_UECON6SET_NBUSYBKES    (_U(0x1) << USBC_UECON6SET_NBUSYBKES_Pos)
+#define USBC_UECON6SET_KILLBKS_Pos  13           /**< \brief (USBC_UECON6SET) KILLBK Set */
+#define USBC_UECON6SET_KILLBKS      (_U(0x1) << USBC_UECON6SET_KILLBKS_Pos)
+#define USBC_UECON6SET_NYETDISS_Pos 17           /**< \brief (USBC_UECON6SET) NYETDIS Set */
+#define USBC_UECON6SET_NYETDISS     (_U(0x1) << USBC_UECON6SET_NYETDISS_Pos)
+#define USBC_UECON6SET_RSTDTS_Pos   18           /**< \brief (USBC_UECON6SET) RSTDT Set */
+#define USBC_UECON6SET_RSTDTS       (_U(0x1) << USBC_UECON6SET_RSTDTS_Pos)
+#define USBC_UECON6SET_STALLRQS_Pos 19           /**< \brief (USBC_UECON6SET) STALLRQ Set */
+#define USBC_UECON6SET_STALLRQS     (_U(0x1) << USBC_UECON6SET_STALLRQS_Pos)
+#define USBC_UECON6SET_BUSY0S_Pos   24           /**< \brief (USBC_UECON6SET) BUSY0 Set */
+#define USBC_UECON6SET_BUSY0S       (_U(0x1) << USBC_UECON6SET_BUSY0S_Pos)
+#define USBC_UECON6SET_BUSY1S_Pos   25           /**< \brief (USBC_UECON6SET) BUSY1 Set */
+#define USBC_UECON6SET_BUSY1S       (_U(0x1) << USBC_UECON6SET_BUSY1S_Pos)
+#define USBC_UECON6SET_MASK         _U(0x030E395F) /**< \brief (USBC_UECON6SET) MASK Register */
+
+/* -------- USBC_UECON7SET : (USBC Offset: 0x20C) ( /W 32) Endpoint Control Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINES:1;         /*!< bit:      0  TXINE Set                          */
+    uint32_t RXOUTES:1;        /*!< bit:      1  RXOUTE Set                         */
+    uint32_t RXSTPES:1;        /*!< bit:      2  RXSTPE Set                         */
+    uint32_t NAKOUTES:1;       /*!< bit:      3  NAKOUTE Set                        */
+    uint32_t NAKINES:1;        /*!< bit:      4  NAKINE Set                         */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDES:1;      /*!< bit:      6  STALLEDE Set                       */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t NREPLYS:1;        /*!< bit:      8  NREPLY Set                         */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t RAMACERES:1;      /*!< bit:     11  RAMACERE Set                       */
+    uint32_t NBUSYBKES:1;      /*!< bit:     12  NBUSYBKE Set                       */
+    uint32_t KILLBKS:1;        /*!< bit:     13  KILLBK Set                         */
+    uint32_t :3;               /*!< bit: 14..16  Reserved                           */
+    uint32_t NYETDISS:1;       /*!< bit:     17  NYETDIS Set                        */
+    uint32_t RSTDTS:1;         /*!< bit:     18  RSTDT Set                          */
+    uint32_t STALLRQS:1;       /*!< bit:     19  STALLRQ Set                        */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t BUSY0S:1;         /*!< bit:     24  BUSY0 Set                          */
+    uint32_t BUSY1S:1;         /*!< bit:     25  BUSY1 Set                          */
+    uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECON7SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECON7SET_OFFSET       0x20C        /**< \brief (USBC_UECON7SET offset) Endpoint Control Set Register */
+#define USBC_UECON7SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON7SET reset_value) Endpoint Control Set Register */
+
+#define USBC_UECON7SET_TXINES_Pos   0            /**< \brief (USBC_UECON7SET) TXINE Set */
+#define USBC_UECON7SET_TXINES       (_U(0x1) << USBC_UECON7SET_TXINES_Pos)
+#define USBC_UECON7SET_RXOUTES_Pos  1            /**< \brief (USBC_UECON7SET) RXOUTE Set */
+#define USBC_UECON7SET_RXOUTES      (_U(0x1) << USBC_UECON7SET_RXOUTES_Pos)
+#define USBC_UECON7SET_RXSTPES_Pos  2            /**< \brief (USBC_UECON7SET) RXSTPE Set */
+#define USBC_UECON7SET_RXSTPES      (_U(0x1) << USBC_UECON7SET_RXSTPES_Pos)
+#define USBC_UECON7SET_NAKOUTES_Pos 3            /**< \brief (USBC_UECON7SET) NAKOUTE Set */
+#define USBC_UECON7SET_NAKOUTES     (_U(0x1) << USBC_UECON7SET_NAKOUTES_Pos)
+#define USBC_UECON7SET_NAKINES_Pos  4            /**< \brief (USBC_UECON7SET) NAKINE Set */
+#define USBC_UECON7SET_NAKINES      (_U(0x1) << USBC_UECON7SET_NAKINES_Pos)
+#define USBC_UECON7SET_STALLEDES_Pos 6            /**< \brief (USBC_UECON7SET) STALLEDE Set */
+#define USBC_UECON7SET_STALLEDES    (_U(0x1) << USBC_UECON7SET_STALLEDES_Pos)
+#define USBC_UECON7SET_NREPLYS_Pos  8            /**< \brief (USBC_UECON7SET) NREPLY Set */
+#define USBC_UECON7SET_NREPLYS      (_U(0x1) << USBC_UECON7SET_NREPLYS_Pos)
+#define USBC_UECON7SET_RAMACERES_Pos 11           /**< \brief (USBC_UECON7SET) RAMACERE Set */
+#define USBC_UECON7SET_RAMACERES    (_U(0x1) << USBC_UECON7SET_RAMACERES_Pos)
+#define USBC_UECON7SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UECON7SET) NBUSYBKE Set */
+#define USBC_UECON7SET_NBUSYBKES    (_U(0x1) << USBC_UECON7SET_NBUSYBKES_Pos)
+#define USBC_UECON7SET_KILLBKS_Pos  13           /**< \brief (USBC_UECON7SET) KILLBK Set */
+#define USBC_UECON7SET_KILLBKS      (_U(0x1) << USBC_UECON7SET_KILLBKS_Pos)
+#define USBC_UECON7SET_NYETDISS_Pos 17           /**< \brief (USBC_UECON7SET) NYETDIS Set */
+#define USBC_UECON7SET_NYETDISS     (_U(0x1) << USBC_UECON7SET_NYETDISS_Pos)
+#define USBC_UECON7SET_RSTDTS_Pos   18           /**< \brief (USBC_UECON7SET) RSTDT Set */
+#define USBC_UECON7SET_RSTDTS       (_U(0x1) << USBC_UECON7SET_RSTDTS_Pos)
+#define USBC_UECON7SET_STALLRQS_Pos 19           /**< \brief (USBC_UECON7SET) STALLRQ Set */
+#define USBC_UECON7SET_STALLRQS     (_U(0x1) << USBC_UECON7SET_STALLRQS_Pos)
+#define USBC_UECON7SET_BUSY0S_Pos   24           /**< \brief (USBC_UECON7SET) BUSY0 Set */
+#define USBC_UECON7SET_BUSY0S       (_U(0x1) << USBC_UECON7SET_BUSY0S_Pos)
+#define USBC_UECON7SET_BUSY1S_Pos   25           /**< \brief (USBC_UECON7SET) BUSY1 Set */
+#define USBC_UECON7SET_BUSY1S       (_U(0x1) << USBC_UECON7SET_BUSY1S_Pos)
+#define USBC_UECON7SET_MASK         _U(0x030E395F) /**< \brief (USBC_UECON7SET) MASK Register */
+
+/* -------- USBC_UECON0CLR : (USBC Offset: 0x220) ( /W 32) Endpoint Control Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINEC:1;         /*!< bit:      0  TXINE Clear                        */
+    uint32_t RXOUTEC:1;        /*!< bit:      1  RXOUTE Clear                       */
+    uint32_t RXSTPEC:1;        /*!< bit:      2  RXSTPE Clear                       */
+    uint32_t NAKOUTEC:1;       /*!< bit:      3  NAKOUTE Clear                      */
+    uint32_t NAKINEC:1;        /*!< bit:      4  NAKINE Clear                       */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDEC:1;      /*!< bit:      6  STALLEDE Clear                     */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t NREPLYC:1;        /*!< bit:      8  NREPLY Clear                       */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t RAMACEREC:1;      /*!< bit:     11  RAMACERE Clear                     */
+    uint32_t NBUSYBKEC:1;      /*!< bit:     12  NBUSYBKE Clear                     */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCONC:1;       /*!< bit:     14  FIFOCON Clear                      */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t NYETDISC:1;       /*!< bit:     17  NYETDIS Clear                      */
+    uint32_t :1;               /*!< bit:     18  Reserved                           */
+    uint32_t STALLRQC:1;       /*!< bit:     19  STALLRQ Clear                      */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t BUSY0C:1;         /*!< bit:     24  BUSY0 Clear                        */
+    uint32_t BUSY1C:1;         /*!< bit:     25  BUSY1 Clear                        */
+    uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECON0CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECON0CLR_OFFSET       0x220        /**< \brief (USBC_UECON0CLR offset) Endpoint Control Clear Register */
+#define USBC_UECON0CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON0CLR reset_value) Endpoint Control Clear Register */
+
+#define USBC_UECON0CLR_TXINEC_Pos   0            /**< \brief (USBC_UECON0CLR) TXINE Clear */
+#define USBC_UECON0CLR_TXINEC       (_U(0x1) << USBC_UECON0CLR_TXINEC_Pos)
+#define USBC_UECON0CLR_RXOUTEC_Pos  1            /**< \brief (USBC_UECON0CLR) RXOUTE Clear */
+#define USBC_UECON0CLR_RXOUTEC      (_U(0x1) << USBC_UECON0CLR_RXOUTEC_Pos)
+#define USBC_UECON0CLR_RXSTPEC_Pos  2            /**< \brief (USBC_UECON0CLR) RXSTPE Clear */
+#define USBC_UECON0CLR_RXSTPEC      (_U(0x1) << USBC_UECON0CLR_RXSTPEC_Pos)
+#define USBC_UECON0CLR_NAKOUTEC_Pos 3            /**< \brief (USBC_UECON0CLR) NAKOUTE Clear */
+#define USBC_UECON0CLR_NAKOUTEC     (_U(0x1) << USBC_UECON0CLR_NAKOUTEC_Pos)
+#define USBC_UECON0CLR_NAKINEC_Pos  4            /**< \brief (USBC_UECON0CLR) NAKINE Clear */
+#define USBC_UECON0CLR_NAKINEC      (_U(0x1) << USBC_UECON0CLR_NAKINEC_Pos)
+#define USBC_UECON0CLR_STALLEDEC_Pos 6            /**< \brief (USBC_UECON0CLR) STALLEDE Clear */
+#define USBC_UECON0CLR_STALLEDEC    (_U(0x1) << USBC_UECON0CLR_STALLEDEC_Pos)
+#define USBC_UECON0CLR_NREPLYC_Pos  8            /**< \brief (USBC_UECON0CLR) NREPLY Clear */
+#define USBC_UECON0CLR_NREPLYC      (_U(0x1) << USBC_UECON0CLR_NREPLYC_Pos)
+#define USBC_UECON0CLR_RAMACEREC_Pos 11           /**< \brief (USBC_UECON0CLR) RAMACERE Clear */
+#define USBC_UECON0CLR_RAMACEREC    (_U(0x1) << USBC_UECON0CLR_RAMACEREC_Pos)
+#define USBC_UECON0CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UECON0CLR) NBUSYBKE Clear */
+#define USBC_UECON0CLR_NBUSYBKEC    (_U(0x1) << USBC_UECON0CLR_NBUSYBKEC_Pos)
+#define USBC_UECON0CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UECON0CLR) FIFOCON Clear */
+#define USBC_UECON0CLR_FIFOCONC     (_U(0x1) << USBC_UECON0CLR_FIFOCONC_Pos)
+#define USBC_UECON0CLR_NYETDISC_Pos 17           /**< \brief (USBC_UECON0CLR) NYETDIS Clear */
+#define USBC_UECON0CLR_NYETDISC     (_U(0x1) << USBC_UECON0CLR_NYETDISC_Pos)
+#define USBC_UECON0CLR_STALLRQC_Pos 19           /**< \brief (USBC_UECON0CLR) STALLRQ Clear */
+#define USBC_UECON0CLR_STALLRQC     (_U(0x1) << USBC_UECON0CLR_STALLRQC_Pos)
+#define USBC_UECON0CLR_BUSY0C_Pos   24           /**< \brief (USBC_UECON0CLR) BUSY0 Clear */
+#define USBC_UECON0CLR_BUSY0C       (_U(0x1) << USBC_UECON0CLR_BUSY0C_Pos)
+#define USBC_UECON0CLR_BUSY1C_Pos   25           /**< \brief (USBC_UECON0CLR) BUSY1 Clear */
+#define USBC_UECON0CLR_BUSY1C       (_U(0x1) << USBC_UECON0CLR_BUSY1C_Pos)
+#define USBC_UECON0CLR_MASK         _U(0x030A595F) /**< \brief (USBC_UECON0CLR) MASK Register */
+
+/* -------- USBC_UECON1CLR : (USBC Offset: 0x224) ( /W 32) TXINE Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINEC:1;         /*!< bit:      0  TXINE Clear                        */
+    uint32_t RXOUTEC:1;        /*!< bit:      1  RXOUTE Clear                       */
+    uint32_t RXSTPEC:1;        /*!< bit:      2  RXOUTE Clear                       */
+    uint32_t NAKOUTEC:1;       /*!< bit:      3  NAKOUTE Clear                      */
+    uint32_t NAKINEC:1;        /*!< bit:      4  NAKINE Clear                       */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDEC:1;      /*!< bit:      6  RXSTPE Clear                       */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t NREPLYC:1;        /*!< bit:      8  NREPLY Clear                       */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t RAMACEREC:1;      /*!< bit:     11  RAMACERE Clear                     */
+    uint32_t NBUSYBKEC:1;      /*!< bit:     12  NBUSYBKE Clear                     */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCONC:1;       /*!< bit:     14  FIFOCON Clear                      */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t NYETDISC:1;       /*!< bit:     17  NYETDIS Clear                      */
+    uint32_t :1;               /*!< bit:     18  Reserved                           */
+    uint32_t STALLRQC:1;       /*!< bit:     19  STALLEDE Clear                     */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t BUSY0C:1;         /*!< bit:     24  BUSY0 Clear                        */
+    uint32_t BUSY1C:1;         /*!< bit:     25  BUSY1 Clear                        */
+    uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECON1CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECON1CLR_OFFSET       0x224        /**< \brief (USBC_UECON1CLR offset) TXINE Clear */
+#define USBC_UECON1CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON1CLR reset_value) TXINE Clear */
+
+#define USBC_UECON1CLR_TXINEC_Pos   0            /**< \brief (USBC_UECON1CLR) TXINE Clear */
+#define USBC_UECON1CLR_TXINEC       (_U(0x1) << USBC_UECON1CLR_TXINEC_Pos)
+#define USBC_UECON1CLR_RXOUTEC_Pos  1            /**< \brief (USBC_UECON1CLR) RXOUTE Clear */
+#define USBC_UECON1CLR_RXOUTEC      (_U(0x1) << USBC_UECON1CLR_RXOUTEC_Pos)
+#define USBC_UECON1CLR_RXSTPEC_Pos  2            /**< \brief (USBC_UECON1CLR) RXOUTE Clear */
+#define USBC_UECON1CLR_RXSTPEC      (_U(0x1) << USBC_UECON1CLR_RXSTPEC_Pos)
+#define USBC_UECON1CLR_NAKOUTEC_Pos 3            /**< \brief (USBC_UECON1CLR) NAKOUTE Clear */
+#define USBC_UECON1CLR_NAKOUTEC     (_U(0x1) << USBC_UECON1CLR_NAKOUTEC_Pos)
+#define USBC_UECON1CLR_NAKINEC_Pos  4            /**< \brief (USBC_UECON1CLR) NAKINE Clear */
+#define USBC_UECON1CLR_NAKINEC      (_U(0x1) << USBC_UECON1CLR_NAKINEC_Pos)
+#define USBC_UECON1CLR_STALLEDEC_Pos 6            /**< \brief (USBC_UECON1CLR) RXSTPE Clear */
+#define USBC_UECON1CLR_STALLEDEC    (_U(0x1) << USBC_UECON1CLR_STALLEDEC_Pos)
+#define USBC_UECON1CLR_NREPLYC_Pos  8            /**< \brief (USBC_UECON1CLR) NREPLY Clear */
+#define USBC_UECON1CLR_NREPLYC      (_U(0x1) << USBC_UECON1CLR_NREPLYC_Pos)
+#define USBC_UECON1CLR_RAMACEREC_Pos 11           /**< \brief (USBC_UECON1CLR) RAMACERE Clear */
+#define USBC_UECON1CLR_RAMACEREC    (_U(0x1) << USBC_UECON1CLR_RAMACEREC_Pos)
+#define USBC_UECON1CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UECON1CLR) NBUSYBKE Clear */
+#define USBC_UECON1CLR_NBUSYBKEC    (_U(0x1) << USBC_UECON1CLR_NBUSYBKEC_Pos)
+#define USBC_UECON1CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UECON1CLR) FIFOCON Clear */
+#define USBC_UECON1CLR_FIFOCONC     (_U(0x1) << USBC_UECON1CLR_FIFOCONC_Pos)
+#define USBC_UECON1CLR_NYETDISC_Pos 17           /**< \brief (USBC_UECON1CLR) NYETDIS Clear */
+#define USBC_UECON1CLR_NYETDISC     (_U(0x1) << USBC_UECON1CLR_NYETDISC_Pos)
+#define USBC_UECON1CLR_STALLRQC_Pos 19           /**< \brief (USBC_UECON1CLR) STALLEDE Clear */
+#define USBC_UECON1CLR_STALLRQC     (_U(0x1) << USBC_UECON1CLR_STALLRQC_Pos)
+#define USBC_UECON1CLR_BUSY0C_Pos   24           /**< \brief (USBC_UECON1CLR) BUSY0 Clear */
+#define USBC_UECON1CLR_BUSY0C       (_U(0x1) << USBC_UECON1CLR_BUSY0C_Pos)
+#define USBC_UECON1CLR_BUSY1C_Pos   25           /**< \brief (USBC_UECON1CLR) BUSY1 Clear */
+#define USBC_UECON1CLR_BUSY1C       (_U(0x1) << USBC_UECON1CLR_BUSY1C_Pos)
+#define USBC_UECON1CLR_MASK         _U(0x030A595F) /**< \brief (USBC_UECON1CLR) MASK Register */
+
+/* -------- USBC_UECON2CLR : (USBC Offset: 0x228) ( /W 32) TXINE Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINEC:1;         /*!< bit:      0  TXINE Clear                        */
+    uint32_t RXOUTEC:1;        /*!< bit:      1  RXOUTE Clear                       */
+    uint32_t RXSTPEC:1;        /*!< bit:      2  RXOUTE Clear                       */
+    uint32_t NAKOUTEC:1;       /*!< bit:      3  NAKOUTE Clear                      */
+    uint32_t NAKINEC:1;        /*!< bit:      4  NAKINE Clear                       */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDEC:1;      /*!< bit:      6  RXSTPE Clear                       */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t NREPLYC:1;        /*!< bit:      8  NREPLY Clear                       */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t RAMACEREC:1;      /*!< bit:     11  RAMACERE Clear                     */
+    uint32_t NBUSYBKEC:1;      /*!< bit:     12  NBUSYBKE Clear                     */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCONC:1;       /*!< bit:     14  FIFOCON Clear                      */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t NYETDISC:1;       /*!< bit:     17  NYETDIS Clear                      */
+    uint32_t :1;               /*!< bit:     18  Reserved                           */
+    uint32_t STALLRQC:1;       /*!< bit:     19  STALLEDE Clear                     */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t BUSY0C:1;         /*!< bit:     24  BUSY0 Clear                        */
+    uint32_t BUSY1C:1;         /*!< bit:     25  BUSY1 Clear                        */
+    uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECON2CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECON2CLR_OFFSET       0x228        /**< \brief (USBC_UECON2CLR offset) TXINE Clear */
+#define USBC_UECON2CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON2CLR reset_value) TXINE Clear */
+
+#define USBC_UECON2CLR_TXINEC_Pos   0            /**< \brief (USBC_UECON2CLR) TXINE Clear */
+#define USBC_UECON2CLR_TXINEC       (_U(0x1) << USBC_UECON2CLR_TXINEC_Pos)
+#define USBC_UECON2CLR_RXOUTEC_Pos  1            /**< \brief (USBC_UECON2CLR) RXOUTE Clear */
+#define USBC_UECON2CLR_RXOUTEC      (_U(0x1) << USBC_UECON2CLR_RXOUTEC_Pos)
+#define USBC_UECON2CLR_RXSTPEC_Pos  2            /**< \brief (USBC_UECON2CLR) RXOUTE Clear */
+#define USBC_UECON2CLR_RXSTPEC      (_U(0x1) << USBC_UECON2CLR_RXSTPEC_Pos)
+#define USBC_UECON2CLR_NAKOUTEC_Pos 3            /**< \brief (USBC_UECON2CLR) NAKOUTE Clear */
+#define USBC_UECON2CLR_NAKOUTEC     (_U(0x1) << USBC_UECON2CLR_NAKOUTEC_Pos)
+#define USBC_UECON2CLR_NAKINEC_Pos  4            /**< \brief (USBC_UECON2CLR) NAKINE Clear */
+#define USBC_UECON2CLR_NAKINEC      (_U(0x1) << USBC_UECON2CLR_NAKINEC_Pos)
+#define USBC_UECON2CLR_STALLEDEC_Pos 6            /**< \brief (USBC_UECON2CLR) RXSTPE Clear */
+#define USBC_UECON2CLR_STALLEDEC    (_U(0x1) << USBC_UECON2CLR_STALLEDEC_Pos)
+#define USBC_UECON2CLR_NREPLYC_Pos  8            /**< \brief (USBC_UECON2CLR) NREPLY Clear */
+#define USBC_UECON2CLR_NREPLYC      (_U(0x1) << USBC_UECON2CLR_NREPLYC_Pos)
+#define USBC_UECON2CLR_RAMACEREC_Pos 11           /**< \brief (USBC_UECON2CLR) RAMACERE Clear */
+#define USBC_UECON2CLR_RAMACEREC    (_U(0x1) << USBC_UECON2CLR_RAMACEREC_Pos)
+#define USBC_UECON2CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UECON2CLR) NBUSYBKE Clear */
+#define USBC_UECON2CLR_NBUSYBKEC    (_U(0x1) << USBC_UECON2CLR_NBUSYBKEC_Pos)
+#define USBC_UECON2CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UECON2CLR) FIFOCON Clear */
+#define USBC_UECON2CLR_FIFOCONC     (_U(0x1) << USBC_UECON2CLR_FIFOCONC_Pos)
+#define USBC_UECON2CLR_NYETDISC_Pos 17           /**< \brief (USBC_UECON2CLR) NYETDIS Clear */
+#define USBC_UECON2CLR_NYETDISC     (_U(0x1) << USBC_UECON2CLR_NYETDISC_Pos)
+#define USBC_UECON2CLR_STALLRQC_Pos 19           /**< \brief (USBC_UECON2CLR) STALLEDE Clear */
+#define USBC_UECON2CLR_STALLRQC     (_U(0x1) << USBC_UECON2CLR_STALLRQC_Pos)
+#define USBC_UECON2CLR_BUSY0C_Pos   24           /**< \brief (USBC_UECON2CLR) BUSY0 Clear */
+#define USBC_UECON2CLR_BUSY0C       (_U(0x1) << USBC_UECON2CLR_BUSY0C_Pos)
+#define USBC_UECON2CLR_BUSY1C_Pos   25           /**< \brief (USBC_UECON2CLR) BUSY1 Clear */
+#define USBC_UECON2CLR_BUSY1C       (_U(0x1) << USBC_UECON2CLR_BUSY1C_Pos)
+#define USBC_UECON2CLR_MASK         _U(0x030A595F) /**< \brief (USBC_UECON2CLR) MASK Register */
+
+/* -------- USBC_UECON3CLR : (USBC Offset: 0x22C) ( /W 32) TXINE Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINEC:1;         /*!< bit:      0  TXINE Clear                        */
+    uint32_t RXOUTEC:1;        /*!< bit:      1  RXOUTE Clear                       */
+    uint32_t RXSTPEC:1;        /*!< bit:      2  RXOUTE Clear                       */
+    uint32_t NAKOUTEC:1;       /*!< bit:      3  NAKOUTE Clear                      */
+    uint32_t NAKINEC:1;        /*!< bit:      4  NAKINE Clear                       */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDEC:1;      /*!< bit:      6  RXSTPE Clear                       */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t NREPLYC:1;        /*!< bit:      8  NREPLY Clear                       */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t RAMACEREC:1;      /*!< bit:     11  RAMACERE Clear                     */
+    uint32_t NBUSYBKEC:1;      /*!< bit:     12  NBUSYBKE Clear                     */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCONC:1;       /*!< bit:     14  FIFOCON Clear                      */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t NYETDISC:1;       /*!< bit:     17  NYETDIS Clear                      */
+    uint32_t :1;               /*!< bit:     18  Reserved                           */
+    uint32_t STALLRQC:1;       /*!< bit:     19  STALLEDE Clear                     */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t BUSY0C:1;         /*!< bit:     24  BUSY0 Clear                        */
+    uint32_t BUSY1C:1;         /*!< bit:     25  BUSY1 Clear                        */
+    uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECON3CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECON3CLR_OFFSET       0x22C        /**< \brief (USBC_UECON3CLR offset) TXINE Clear */
+#define USBC_UECON3CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON3CLR reset_value) TXINE Clear */
+
+#define USBC_UECON3CLR_TXINEC_Pos   0            /**< \brief (USBC_UECON3CLR) TXINE Clear */
+#define USBC_UECON3CLR_TXINEC       (_U(0x1) << USBC_UECON3CLR_TXINEC_Pos)
+#define USBC_UECON3CLR_RXOUTEC_Pos  1            /**< \brief (USBC_UECON3CLR) RXOUTE Clear */
+#define USBC_UECON3CLR_RXOUTEC      (_U(0x1) << USBC_UECON3CLR_RXOUTEC_Pos)
+#define USBC_UECON3CLR_RXSTPEC_Pos  2            /**< \brief (USBC_UECON3CLR) RXOUTE Clear */
+#define USBC_UECON3CLR_RXSTPEC      (_U(0x1) << USBC_UECON3CLR_RXSTPEC_Pos)
+#define USBC_UECON3CLR_NAKOUTEC_Pos 3            /**< \brief (USBC_UECON3CLR) NAKOUTE Clear */
+#define USBC_UECON3CLR_NAKOUTEC     (_U(0x1) << USBC_UECON3CLR_NAKOUTEC_Pos)
+#define USBC_UECON3CLR_NAKINEC_Pos  4            /**< \brief (USBC_UECON3CLR) NAKINE Clear */
+#define USBC_UECON3CLR_NAKINEC      (_U(0x1) << USBC_UECON3CLR_NAKINEC_Pos)
+#define USBC_UECON3CLR_STALLEDEC_Pos 6            /**< \brief (USBC_UECON3CLR) RXSTPE Clear */
+#define USBC_UECON3CLR_STALLEDEC    (_U(0x1) << USBC_UECON3CLR_STALLEDEC_Pos)
+#define USBC_UECON3CLR_NREPLYC_Pos  8            /**< \brief (USBC_UECON3CLR) NREPLY Clear */
+#define USBC_UECON3CLR_NREPLYC      (_U(0x1) << USBC_UECON3CLR_NREPLYC_Pos)
+#define USBC_UECON3CLR_RAMACEREC_Pos 11           /**< \brief (USBC_UECON3CLR) RAMACERE Clear */
+#define USBC_UECON3CLR_RAMACEREC    (_U(0x1) << USBC_UECON3CLR_RAMACEREC_Pos)
+#define USBC_UECON3CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UECON3CLR) NBUSYBKE Clear */
+#define USBC_UECON3CLR_NBUSYBKEC    (_U(0x1) << USBC_UECON3CLR_NBUSYBKEC_Pos)
+#define USBC_UECON3CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UECON3CLR) FIFOCON Clear */
+#define USBC_UECON3CLR_FIFOCONC     (_U(0x1) << USBC_UECON3CLR_FIFOCONC_Pos)
+#define USBC_UECON3CLR_NYETDISC_Pos 17           /**< \brief (USBC_UECON3CLR) NYETDIS Clear */
+#define USBC_UECON3CLR_NYETDISC     (_U(0x1) << USBC_UECON3CLR_NYETDISC_Pos)
+#define USBC_UECON3CLR_STALLRQC_Pos 19           /**< \brief (USBC_UECON3CLR) STALLEDE Clear */
+#define USBC_UECON3CLR_STALLRQC     (_U(0x1) << USBC_UECON3CLR_STALLRQC_Pos)
+#define USBC_UECON3CLR_BUSY0C_Pos   24           /**< \brief (USBC_UECON3CLR) BUSY0 Clear */
+#define USBC_UECON3CLR_BUSY0C       (_U(0x1) << USBC_UECON3CLR_BUSY0C_Pos)
+#define USBC_UECON3CLR_BUSY1C_Pos   25           /**< \brief (USBC_UECON3CLR) BUSY1 Clear */
+#define USBC_UECON3CLR_BUSY1C       (_U(0x1) << USBC_UECON3CLR_BUSY1C_Pos)
+#define USBC_UECON3CLR_MASK         _U(0x030A595F) /**< \brief (USBC_UECON3CLR) MASK Register */
+
+/* -------- USBC_UECON4CLR : (USBC Offset: 0x230) ( /W 32) TXINE Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINEC:1;         /*!< bit:      0  TXINE Clear                        */
+    uint32_t RXOUTEC:1;        /*!< bit:      1  RXOUTE Clear                       */
+    uint32_t RXSTPEC:1;        /*!< bit:      2  RXOUTE Clear                       */
+    uint32_t NAKOUTEC:1;       /*!< bit:      3  NAKOUTE Clear                      */
+    uint32_t NAKINEC:1;        /*!< bit:      4  NAKINE Clear                       */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDEC:1;      /*!< bit:      6  RXSTPE Clear                       */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t NREPLYC:1;        /*!< bit:      8  NREPLY Clear                       */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t RAMACEREC:1;      /*!< bit:     11  RAMACERE Clear                     */
+    uint32_t NBUSYBKEC:1;      /*!< bit:     12  NBUSYBKE Clear                     */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCONC:1;       /*!< bit:     14  FIFOCON Clear                      */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t NYETDISC:1;       /*!< bit:     17  NYETDIS Clear                      */
+    uint32_t :1;               /*!< bit:     18  Reserved                           */
+    uint32_t STALLRQC:1;       /*!< bit:     19  STALLEDE Clear                     */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t BUSY0C:1;         /*!< bit:     24  BUSY0 Clear                        */
+    uint32_t BUSY1C:1;         /*!< bit:     25  BUSY1 Clear                        */
+    uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECON4CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECON4CLR_OFFSET       0x230        /**< \brief (USBC_UECON4CLR offset) TXINE Clear */
+#define USBC_UECON4CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON4CLR reset_value) TXINE Clear */
+
+#define USBC_UECON4CLR_TXINEC_Pos   0            /**< \brief (USBC_UECON4CLR) TXINE Clear */
+#define USBC_UECON4CLR_TXINEC       (_U(0x1) << USBC_UECON4CLR_TXINEC_Pos)
+#define USBC_UECON4CLR_RXOUTEC_Pos  1            /**< \brief (USBC_UECON4CLR) RXOUTE Clear */
+#define USBC_UECON4CLR_RXOUTEC      (_U(0x1) << USBC_UECON4CLR_RXOUTEC_Pos)
+#define USBC_UECON4CLR_RXSTPEC_Pos  2            /**< \brief (USBC_UECON4CLR) RXOUTE Clear */
+#define USBC_UECON4CLR_RXSTPEC      (_U(0x1) << USBC_UECON4CLR_RXSTPEC_Pos)
+#define USBC_UECON4CLR_NAKOUTEC_Pos 3            /**< \brief (USBC_UECON4CLR) NAKOUTE Clear */
+#define USBC_UECON4CLR_NAKOUTEC     (_U(0x1) << USBC_UECON4CLR_NAKOUTEC_Pos)
+#define USBC_UECON4CLR_NAKINEC_Pos  4            /**< \brief (USBC_UECON4CLR) NAKINE Clear */
+#define USBC_UECON4CLR_NAKINEC      (_U(0x1) << USBC_UECON4CLR_NAKINEC_Pos)
+#define USBC_UECON4CLR_STALLEDEC_Pos 6            /**< \brief (USBC_UECON4CLR) RXSTPE Clear */
+#define USBC_UECON4CLR_STALLEDEC    (_U(0x1) << USBC_UECON4CLR_STALLEDEC_Pos)
+#define USBC_UECON4CLR_NREPLYC_Pos  8            /**< \brief (USBC_UECON4CLR) NREPLY Clear */
+#define USBC_UECON4CLR_NREPLYC      (_U(0x1) << USBC_UECON4CLR_NREPLYC_Pos)
+#define USBC_UECON4CLR_RAMACEREC_Pos 11           /**< \brief (USBC_UECON4CLR) RAMACERE Clear */
+#define USBC_UECON4CLR_RAMACEREC    (_U(0x1) << USBC_UECON4CLR_RAMACEREC_Pos)
+#define USBC_UECON4CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UECON4CLR) NBUSYBKE Clear */
+#define USBC_UECON4CLR_NBUSYBKEC    (_U(0x1) << USBC_UECON4CLR_NBUSYBKEC_Pos)
+#define USBC_UECON4CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UECON4CLR) FIFOCON Clear */
+#define USBC_UECON4CLR_FIFOCONC     (_U(0x1) << USBC_UECON4CLR_FIFOCONC_Pos)
+#define USBC_UECON4CLR_NYETDISC_Pos 17           /**< \brief (USBC_UECON4CLR) NYETDIS Clear */
+#define USBC_UECON4CLR_NYETDISC     (_U(0x1) << USBC_UECON4CLR_NYETDISC_Pos)
+#define USBC_UECON4CLR_STALLRQC_Pos 19           /**< \brief (USBC_UECON4CLR) STALLEDE Clear */
+#define USBC_UECON4CLR_STALLRQC     (_U(0x1) << USBC_UECON4CLR_STALLRQC_Pos)
+#define USBC_UECON4CLR_BUSY0C_Pos   24           /**< \brief (USBC_UECON4CLR) BUSY0 Clear */
+#define USBC_UECON4CLR_BUSY0C       (_U(0x1) << USBC_UECON4CLR_BUSY0C_Pos)
+#define USBC_UECON4CLR_BUSY1C_Pos   25           /**< \brief (USBC_UECON4CLR) BUSY1 Clear */
+#define USBC_UECON4CLR_BUSY1C       (_U(0x1) << USBC_UECON4CLR_BUSY1C_Pos)
+#define USBC_UECON4CLR_MASK         _U(0x030A595F) /**< \brief (USBC_UECON4CLR) MASK Register */
+
+/* -------- USBC_UECON5CLR : (USBC Offset: 0x234) ( /W 32) TXINE Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINEC:1;         /*!< bit:      0  TXINE Clear                        */
+    uint32_t RXOUTEC:1;        /*!< bit:      1  RXOUTE Clear                       */
+    uint32_t RXSTPEC:1;        /*!< bit:      2  RXOUTE Clear                       */
+    uint32_t NAKOUTEC:1;       /*!< bit:      3  NAKOUTE Clear                      */
+    uint32_t NAKINEC:1;        /*!< bit:      4  NAKINE Clear                       */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDEC:1;      /*!< bit:      6  RXSTPE Clear                       */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t NREPLYC:1;        /*!< bit:      8  NREPLY Clear                       */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t RAMACEREC:1;      /*!< bit:     11  RAMACERE Clear                     */
+    uint32_t NBUSYBKEC:1;      /*!< bit:     12  NBUSYBKE Clear                     */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCONC:1;       /*!< bit:     14  FIFOCON Clear                      */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t NYETDISC:1;       /*!< bit:     17  NYETDIS Clear                      */
+    uint32_t :1;               /*!< bit:     18  Reserved                           */
+    uint32_t STALLRQC:1;       /*!< bit:     19  STALLEDE Clear                     */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t BUSY0C:1;         /*!< bit:     24  BUSY0 Clear                        */
+    uint32_t BUSY1C:1;         /*!< bit:     25  BUSY1 Clear                        */
+    uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECON5CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECON5CLR_OFFSET       0x234        /**< \brief (USBC_UECON5CLR offset) TXINE Clear */
+#define USBC_UECON5CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON5CLR reset_value) TXINE Clear */
+
+#define USBC_UECON5CLR_TXINEC_Pos   0            /**< \brief (USBC_UECON5CLR) TXINE Clear */
+#define USBC_UECON5CLR_TXINEC       (_U(0x1) << USBC_UECON5CLR_TXINEC_Pos)
+#define USBC_UECON5CLR_RXOUTEC_Pos  1            /**< \brief (USBC_UECON5CLR) RXOUTE Clear */
+#define USBC_UECON5CLR_RXOUTEC      (_U(0x1) << USBC_UECON5CLR_RXOUTEC_Pos)
+#define USBC_UECON5CLR_RXSTPEC_Pos  2            /**< \brief (USBC_UECON5CLR) RXOUTE Clear */
+#define USBC_UECON5CLR_RXSTPEC      (_U(0x1) << USBC_UECON5CLR_RXSTPEC_Pos)
+#define USBC_UECON5CLR_NAKOUTEC_Pos 3            /**< \brief (USBC_UECON5CLR) NAKOUTE Clear */
+#define USBC_UECON5CLR_NAKOUTEC     (_U(0x1) << USBC_UECON5CLR_NAKOUTEC_Pos)
+#define USBC_UECON5CLR_NAKINEC_Pos  4            /**< \brief (USBC_UECON5CLR) NAKINE Clear */
+#define USBC_UECON5CLR_NAKINEC      (_U(0x1) << USBC_UECON5CLR_NAKINEC_Pos)
+#define USBC_UECON5CLR_STALLEDEC_Pos 6            /**< \brief (USBC_UECON5CLR) RXSTPE Clear */
+#define USBC_UECON5CLR_STALLEDEC    (_U(0x1) << USBC_UECON5CLR_STALLEDEC_Pos)
+#define USBC_UECON5CLR_NREPLYC_Pos  8            /**< \brief (USBC_UECON5CLR) NREPLY Clear */
+#define USBC_UECON5CLR_NREPLYC      (_U(0x1) << USBC_UECON5CLR_NREPLYC_Pos)
+#define USBC_UECON5CLR_RAMACEREC_Pos 11           /**< \brief (USBC_UECON5CLR) RAMACERE Clear */
+#define USBC_UECON5CLR_RAMACEREC    (_U(0x1) << USBC_UECON5CLR_RAMACEREC_Pos)
+#define USBC_UECON5CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UECON5CLR) NBUSYBKE Clear */
+#define USBC_UECON5CLR_NBUSYBKEC    (_U(0x1) << USBC_UECON5CLR_NBUSYBKEC_Pos)
+#define USBC_UECON5CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UECON5CLR) FIFOCON Clear */
+#define USBC_UECON5CLR_FIFOCONC     (_U(0x1) << USBC_UECON5CLR_FIFOCONC_Pos)
+#define USBC_UECON5CLR_NYETDISC_Pos 17           /**< \brief (USBC_UECON5CLR) NYETDIS Clear */
+#define USBC_UECON5CLR_NYETDISC     (_U(0x1) << USBC_UECON5CLR_NYETDISC_Pos)
+#define USBC_UECON5CLR_STALLRQC_Pos 19           /**< \brief (USBC_UECON5CLR) STALLEDE Clear */
+#define USBC_UECON5CLR_STALLRQC     (_U(0x1) << USBC_UECON5CLR_STALLRQC_Pos)
+#define USBC_UECON5CLR_BUSY0C_Pos   24           /**< \brief (USBC_UECON5CLR) BUSY0 Clear */
+#define USBC_UECON5CLR_BUSY0C       (_U(0x1) << USBC_UECON5CLR_BUSY0C_Pos)
+#define USBC_UECON5CLR_BUSY1C_Pos   25           /**< \brief (USBC_UECON5CLR) BUSY1 Clear */
+#define USBC_UECON5CLR_BUSY1C       (_U(0x1) << USBC_UECON5CLR_BUSY1C_Pos)
+#define USBC_UECON5CLR_MASK         _U(0x030A595F) /**< \brief (USBC_UECON5CLR) MASK Register */
+
+/* -------- USBC_UECON6CLR : (USBC Offset: 0x238) ( /W 32) TXINE Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINEC:1;         /*!< bit:      0  TXINE Clear                        */
+    uint32_t RXOUTEC:1;        /*!< bit:      1  RXOUTE Clear                       */
+    uint32_t RXSTPEC:1;        /*!< bit:      2  RXOUTE Clear                       */
+    uint32_t NAKOUTEC:1;       /*!< bit:      3  NAKOUTE Clear                      */
+    uint32_t NAKINEC:1;        /*!< bit:      4  NAKINE Clear                       */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDEC:1;      /*!< bit:      6  RXSTPE Clear                       */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t NREPLYC:1;        /*!< bit:      8  NREPLY Clear                       */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t RAMACEREC:1;      /*!< bit:     11  RAMACERE Clear                     */
+    uint32_t NBUSYBKEC:1;      /*!< bit:     12  NBUSYBKE Clear                     */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCONC:1;       /*!< bit:     14  FIFOCON Clear                      */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t NYETDISC:1;       /*!< bit:     17  NYETDIS Clear                      */
+    uint32_t :1;               /*!< bit:     18  Reserved                           */
+    uint32_t STALLRQC:1;       /*!< bit:     19  STALLEDE Clear                     */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t BUSY0C:1;         /*!< bit:     24  BUSY0 Clear                        */
+    uint32_t BUSY1C:1;         /*!< bit:     25  BUSY1 Clear                        */
+    uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECON6CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECON6CLR_OFFSET       0x238        /**< \brief (USBC_UECON6CLR offset) TXINE Clear */
+#define USBC_UECON6CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON6CLR reset_value) TXINE Clear */
+
+#define USBC_UECON6CLR_TXINEC_Pos   0            /**< \brief (USBC_UECON6CLR) TXINE Clear */
+#define USBC_UECON6CLR_TXINEC       (_U(0x1) << USBC_UECON6CLR_TXINEC_Pos)
+#define USBC_UECON6CLR_RXOUTEC_Pos  1            /**< \brief (USBC_UECON6CLR) RXOUTE Clear */
+#define USBC_UECON6CLR_RXOUTEC      (_U(0x1) << USBC_UECON6CLR_RXOUTEC_Pos)
+#define USBC_UECON6CLR_RXSTPEC_Pos  2            /**< \brief (USBC_UECON6CLR) RXOUTE Clear */
+#define USBC_UECON6CLR_RXSTPEC      (_U(0x1) << USBC_UECON6CLR_RXSTPEC_Pos)
+#define USBC_UECON6CLR_NAKOUTEC_Pos 3            /**< \brief (USBC_UECON6CLR) NAKOUTE Clear */
+#define USBC_UECON6CLR_NAKOUTEC     (_U(0x1) << USBC_UECON6CLR_NAKOUTEC_Pos)
+#define USBC_UECON6CLR_NAKINEC_Pos  4            /**< \brief (USBC_UECON6CLR) NAKINE Clear */
+#define USBC_UECON6CLR_NAKINEC      (_U(0x1) << USBC_UECON6CLR_NAKINEC_Pos)
+#define USBC_UECON6CLR_STALLEDEC_Pos 6            /**< \brief (USBC_UECON6CLR) RXSTPE Clear */
+#define USBC_UECON6CLR_STALLEDEC    (_U(0x1) << USBC_UECON6CLR_STALLEDEC_Pos)
+#define USBC_UECON6CLR_NREPLYC_Pos  8            /**< \brief (USBC_UECON6CLR) NREPLY Clear */
+#define USBC_UECON6CLR_NREPLYC      (_U(0x1) << USBC_UECON6CLR_NREPLYC_Pos)
+#define USBC_UECON6CLR_RAMACEREC_Pos 11           /**< \brief (USBC_UECON6CLR) RAMACERE Clear */
+#define USBC_UECON6CLR_RAMACEREC    (_U(0x1) << USBC_UECON6CLR_RAMACEREC_Pos)
+#define USBC_UECON6CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UECON6CLR) NBUSYBKE Clear */
+#define USBC_UECON6CLR_NBUSYBKEC    (_U(0x1) << USBC_UECON6CLR_NBUSYBKEC_Pos)
+#define USBC_UECON6CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UECON6CLR) FIFOCON Clear */
+#define USBC_UECON6CLR_FIFOCONC     (_U(0x1) << USBC_UECON6CLR_FIFOCONC_Pos)
+#define USBC_UECON6CLR_NYETDISC_Pos 17           /**< \brief (USBC_UECON6CLR) NYETDIS Clear */
+#define USBC_UECON6CLR_NYETDISC     (_U(0x1) << USBC_UECON6CLR_NYETDISC_Pos)
+#define USBC_UECON6CLR_STALLRQC_Pos 19           /**< \brief (USBC_UECON6CLR) STALLEDE Clear */
+#define USBC_UECON6CLR_STALLRQC     (_U(0x1) << USBC_UECON6CLR_STALLRQC_Pos)
+#define USBC_UECON6CLR_BUSY0C_Pos   24           /**< \brief (USBC_UECON6CLR) BUSY0 Clear */
+#define USBC_UECON6CLR_BUSY0C       (_U(0x1) << USBC_UECON6CLR_BUSY0C_Pos)
+#define USBC_UECON6CLR_BUSY1C_Pos   25           /**< \brief (USBC_UECON6CLR) BUSY1 Clear */
+#define USBC_UECON6CLR_BUSY1C       (_U(0x1) << USBC_UECON6CLR_BUSY1C_Pos)
+#define USBC_UECON6CLR_MASK         _U(0x030A595F) /**< \brief (USBC_UECON6CLR) MASK Register */
+
+/* -------- USBC_UECON7CLR : (USBC Offset: 0x23C) ( /W 32) TXINE Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t TXINEC:1;         /*!< bit:      0  TXINE Clear                        */
+    uint32_t RXOUTEC:1;        /*!< bit:      1  RXOUTE Clear                       */
+    uint32_t RXSTPEC:1;        /*!< bit:      2  RXOUTE Clear                       */
+    uint32_t NAKOUTEC:1;       /*!< bit:      3  NAKOUTE Clear                      */
+    uint32_t NAKINEC:1;        /*!< bit:      4  NAKINE Clear                       */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t STALLEDEC:1;      /*!< bit:      6  RXSTPE Clear                       */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t NREPLYC:1;        /*!< bit:      8  NREPLY Clear                       */
+    uint32_t :2;               /*!< bit:  9..10  Reserved                           */
+    uint32_t RAMACEREC:1;      /*!< bit:     11  RAMACERE Clear                     */
+    uint32_t NBUSYBKEC:1;      /*!< bit:     12  NBUSYBKE Clear                     */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCONC:1;       /*!< bit:     14  FIFOCON Clear                      */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t NYETDISC:1;       /*!< bit:     17  NYETDIS Clear                      */
+    uint32_t :1;               /*!< bit:     18  Reserved                           */
+    uint32_t STALLRQC:1;       /*!< bit:     19  STALLEDE Clear                     */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t BUSY0C:1;         /*!< bit:     24  BUSY0 Clear                        */
+    uint32_t BUSY1C:1;         /*!< bit:     25  BUSY1 Clear                        */
+    uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UECON7CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UECON7CLR_OFFSET       0x23C        /**< \brief (USBC_UECON7CLR offset) TXINE Clear */
+#define USBC_UECON7CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UECON7CLR reset_value) TXINE Clear */
+
+#define USBC_UECON7CLR_TXINEC_Pos   0            /**< \brief (USBC_UECON7CLR) TXINE Clear */
+#define USBC_UECON7CLR_TXINEC       (_U(0x1) << USBC_UECON7CLR_TXINEC_Pos)
+#define USBC_UECON7CLR_RXOUTEC_Pos  1            /**< \brief (USBC_UECON7CLR) RXOUTE Clear */
+#define USBC_UECON7CLR_RXOUTEC      (_U(0x1) << USBC_UECON7CLR_RXOUTEC_Pos)
+#define USBC_UECON7CLR_RXSTPEC_Pos  2            /**< \brief (USBC_UECON7CLR) RXOUTE Clear */
+#define USBC_UECON7CLR_RXSTPEC      (_U(0x1) << USBC_UECON7CLR_RXSTPEC_Pos)
+#define USBC_UECON7CLR_NAKOUTEC_Pos 3            /**< \brief (USBC_UECON7CLR) NAKOUTE Clear */
+#define USBC_UECON7CLR_NAKOUTEC     (_U(0x1) << USBC_UECON7CLR_NAKOUTEC_Pos)
+#define USBC_UECON7CLR_NAKINEC_Pos  4            /**< \brief (USBC_UECON7CLR) NAKINE Clear */
+#define USBC_UECON7CLR_NAKINEC      (_U(0x1) << USBC_UECON7CLR_NAKINEC_Pos)
+#define USBC_UECON7CLR_STALLEDEC_Pos 6            /**< \brief (USBC_UECON7CLR) RXSTPE Clear */
+#define USBC_UECON7CLR_STALLEDEC    (_U(0x1) << USBC_UECON7CLR_STALLEDEC_Pos)
+#define USBC_UECON7CLR_NREPLYC_Pos  8            /**< \brief (USBC_UECON7CLR) NREPLY Clear */
+#define USBC_UECON7CLR_NREPLYC      (_U(0x1) << USBC_UECON7CLR_NREPLYC_Pos)
+#define USBC_UECON7CLR_RAMACEREC_Pos 11           /**< \brief (USBC_UECON7CLR) RAMACERE Clear */
+#define USBC_UECON7CLR_RAMACEREC    (_U(0x1) << USBC_UECON7CLR_RAMACEREC_Pos)
+#define USBC_UECON7CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UECON7CLR) NBUSYBKE Clear */
+#define USBC_UECON7CLR_NBUSYBKEC    (_U(0x1) << USBC_UECON7CLR_NBUSYBKEC_Pos)
+#define USBC_UECON7CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UECON7CLR) FIFOCON Clear */
+#define USBC_UECON7CLR_FIFOCONC     (_U(0x1) << USBC_UECON7CLR_FIFOCONC_Pos)
+#define USBC_UECON7CLR_NYETDISC_Pos 17           /**< \brief (USBC_UECON7CLR) NYETDIS Clear */
+#define USBC_UECON7CLR_NYETDISC     (_U(0x1) << USBC_UECON7CLR_NYETDISC_Pos)
+#define USBC_UECON7CLR_STALLRQC_Pos 19           /**< \brief (USBC_UECON7CLR) STALLEDE Clear */
+#define USBC_UECON7CLR_STALLRQC     (_U(0x1) << USBC_UECON7CLR_STALLRQC_Pos)
+#define USBC_UECON7CLR_BUSY0C_Pos   24           /**< \brief (USBC_UECON7CLR) BUSY0 Clear */
+#define USBC_UECON7CLR_BUSY0C       (_U(0x1) << USBC_UECON7CLR_BUSY0C_Pos)
+#define USBC_UECON7CLR_BUSY1C_Pos   25           /**< \brief (USBC_UECON7CLR) BUSY1 Clear */
+#define USBC_UECON7CLR_BUSY1C       (_U(0x1) << USBC_UECON7CLR_BUSY1C_Pos)
+#define USBC_UECON7CLR_MASK         _U(0x030A595F) /**< \brief (USBC_UECON7CLR) MASK Register */
+
+/* -------- USBC_UHCON : (USBC Offset: 0x400) (R/W 32) Host General Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :8;               /*!< bit:  0.. 7  Reserved                           */
+    uint32_t SOFE:1;           /*!< bit:      8  SOF Enable                         */
+    uint32_t RESET:1;          /*!< bit:      9  Send USB Reset                     */
+    uint32_t RESUME:1;         /*!< bit:     10  Send USB Resume                    */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t SPDCONF:2;        /*!< bit: 12..13  Speed Configuration                */
+    uint32_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint32_t TSTJ:1;           /*!< bit:     16  Test J                             */
+    uint32_t TSTK:1;           /*!< bit:     17  Test K                             */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UHCON_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UHCON_OFFSET           0x400        /**< \brief (USBC_UHCON offset) Host General Control Register */
+#define USBC_UHCON_RESETVALUE       _U(0x00000000); /**< \brief (USBC_UHCON reset_value) Host General Control Register */
+
+#define USBC_UHCON_SOFE_Pos         8            /**< \brief (USBC_UHCON) SOF Enable */
+#define USBC_UHCON_SOFE             (_U(0x1) << USBC_UHCON_SOFE_Pos)
+#define USBC_UHCON_RESET_Pos        9            /**< \brief (USBC_UHCON) Send USB Reset */
+#define USBC_UHCON_RESET            (_U(0x1) << USBC_UHCON_RESET_Pos)
+#define USBC_UHCON_RESUME_Pos       10           /**< \brief (USBC_UHCON) Send USB Resume */
+#define USBC_UHCON_RESUME           (_U(0x1) << USBC_UHCON_RESUME_Pos)
+#define USBC_UHCON_SPDCONF_Pos      12           /**< \brief (USBC_UHCON) Speed Configuration */
+#define USBC_UHCON_SPDCONF_Msk      (_U(0x3) << USBC_UHCON_SPDCONF_Pos)
+#define USBC_UHCON_SPDCONF(value)   (USBC_UHCON_SPDCONF_Msk & ((value) << USBC_UHCON_SPDCONF_Pos))
+#define USBC_UHCON_TSTJ_Pos         16           /**< \brief (USBC_UHCON) Test J */
+#define USBC_UHCON_TSTJ             (_U(0x1) << USBC_UHCON_TSTJ_Pos)
+#define USBC_UHCON_TSTK_Pos         17           /**< \brief (USBC_UHCON) Test K */
+#define USBC_UHCON_TSTK             (_U(0x1) << USBC_UHCON_TSTK_Pos)
+#define USBC_UHCON_MASK             _U(0x00033700) /**< \brief (USBC_UHCON) MASK Register */
+
+/* -------- USBC_UHINT : (USBC Offset: 0x404) (R/  32) Host Global Interrupt Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DCONNI:1;         /*!< bit:      0  Device Connection Interrupt        */
+    uint32_t DDISCI:1;         /*!< bit:      1  Device Disconnection Interrupt     */
+    uint32_t RSTI:1;           /*!< bit:      2  USB Reset Sent Interrupt           */
+    uint32_t RSMEDI:1;         /*!< bit:      3  Downstream Resume Sent Interrupt   */
+    uint32_t RXRSMI:1;         /*!< bit:      4  Upstream Resume Received Interrupt */
+    uint32_t HSOFI:1;          /*!< bit:      5  Host SOF Interrupt                 */
+    uint32_t HWUPI:1;          /*!< bit:      6  Host Wake-Up Interrupt             */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t P0INT:1;          /*!< bit:      8  Pipe 0 Interrupt                   */
+    uint32_t P1INT:1;          /*!< bit:      9  Pipe 1 Interrupt                   */
+    uint32_t P2INT:1;          /*!< bit:     10  Pipe 2 Interrupt                   */
+    uint32_t P3INT:1;          /*!< bit:     11  Pipe 3 Interrupt                   */
+    uint32_t P4INT:1;          /*!< bit:     12  Pipe 4 Interrupt                   */
+    uint32_t P5INT:1;          /*!< bit:     13  Pipe 5 Interrupt                   */
+    uint32_t P6INT:1;          /*!< bit:     14  Pipe 6 Interrupt                   */
+    uint32_t :17;              /*!< bit: 15..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UHINT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UHINT_OFFSET           0x404        /**< \brief (USBC_UHINT offset) Host Global Interrupt Register */
+#define USBC_UHINT_RESETVALUE       _U(0x00000000); /**< \brief (USBC_UHINT reset_value) Host Global Interrupt Register */
+
+#define USBC_UHINT_DCONNI_Pos       0            /**< \brief (USBC_UHINT) Device Connection Interrupt */
+#define USBC_UHINT_DCONNI           (_U(0x1) << USBC_UHINT_DCONNI_Pos)
+#define USBC_UHINT_DDISCI_Pos       1            /**< \brief (USBC_UHINT) Device Disconnection Interrupt */
+#define USBC_UHINT_DDISCI           (_U(0x1) << USBC_UHINT_DDISCI_Pos)
+#define USBC_UHINT_RSTI_Pos         2            /**< \brief (USBC_UHINT) USB Reset Sent Interrupt */
+#define USBC_UHINT_RSTI             (_U(0x1) << USBC_UHINT_RSTI_Pos)
+#define USBC_UHINT_RSMEDI_Pos       3            /**< \brief (USBC_UHINT) Downstream Resume Sent Interrupt */
+#define USBC_UHINT_RSMEDI           (_U(0x1) << USBC_UHINT_RSMEDI_Pos)
+#define USBC_UHINT_RXRSMI_Pos       4            /**< \brief (USBC_UHINT) Upstream Resume Received Interrupt */
+#define USBC_UHINT_RXRSMI           (_U(0x1) << USBC_UHINT_RXRSMI_Pos)
+#define USBC_UHINT_HSOFI_Pos        5            /**< \brief (USBC_UHINT) Host SOF Interrupt */
+#define USBC_UHINT_HSOFI            (_U(0x1) << USBC_UHINT_HSOFI_Pos)
+#define USBC_UHINT_HWUPI_Pos        6            /**< \brief (USBC_UHINT) Host Wake-Up Interrupt */
+#define USBC_UHINT_HWUPI            (_U(0x1) << USBC_UHINT_HWUPI_Pos)
+#define USBC_UHINT_P0INT_Pos        8            /**< \brief (USBC_UHINT) Pipe 0 Interrupt */
+#define USBC_UHINT_P0INT            (_U(0x1) << USBC_UHINT_P0INT_Pos)
+#define USBC_UHINT_P1INT_Pos        9            /**< \brief (USBC_UHINT) Pipe 1 Interrupt */
+#define USBC_UHINT_P1INT            (_U(0x1) << USBC_UHINT_P1INT_Pos)
+#define USBC_UHINT_P2INT_Pos        10           /**< \brief (USBC_UHINT) Pipe 2 Interrupt */
+#define USBC_UHINT_P2INT            (_U(0x1) << USBC_UHINT_P2INT_Pos)
+#define USBC_UHINT_P3INT_Pos        11           /**< \brief (USBC_UHINT) Pipe 3 Interrupt */
+#define USBC_UHINT_P3INT            (_U(0x1) << USBC_UHINT_P3INT_Pos)
+#define USBC_UHINT_P4INT_Pos        12           /**< \brief (USBC_UHINT) Pipe 4 Interrupt */
+#define USBC_UHINT_P4INT            (_U(0x1) << USBC_UHINT_P4INT_Pos)
+#define USBC_UHINT_P5INT_Pos        13           /**< \brief (USBC_UHINT) Pipe 5 Interrupt */
+#define USBC_UHINT_P5INT            (_U(0x1) << USBC_UHINT_P5INT_Pos)
+#define USBC_UHINT_P6INT_Pos        14           /**< \brief (USBC_UHINT) Pipe 6 Interrupt */
+#define USBC_UHINT_P6INT            (_U(0x1) << USBC_UHINT_P6INT_Pos)
+#define USBC_UHINT_MASK             _U(0x00007F7F) /**< \brief (USBC_UHINT) MASK Register */
+
+/* -------- USBC_UHINTCLR : (USBC Offset: 0x408) ( /W 32) Host Global Interrrupt Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DCONNIC:1;        /*!< bit:      0  DCONNI Clear                       */
+    uint32_t DDISCIC:1;        /*!< bit:      1  DDISCI Clear                       */
+    uint32_t RSTIC:1;          /*!< bit:      2  RSTI Clear                         */
+    uint32_t RSMEDIC:1;        /*!< bit:      3  RSMEDI Clear                       */
+    uint32_t RXRSMIC:1;        /*!< bit:      4  RXRSMI Clear                       */
+    uint32_t HSOFIC:1;         /*!< bit:      5  HSOFI Clear                        */
+    uint32_t HWUPIC:1;         /*!< bit:      6  HWUPI Clear                        */
+    uint32_t :25;              /*!< bit:  7..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UHINTCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UHINTCLR_OFFSET        0x408        /**< \brief (USBC_UHINTCLR offset) Host Global Interrrupt Clear Register */
+#define USBC_UHINTCLR_RESETVALUE    _U(0x00000000); /**< \brief (USBC_UHINTCLR reset_value) Host Global Interrrupt Clear Register */
+
+#define USBC_UHINTCLR_DCONNIC_Pos   0            /**< \brief (USBC_UHINTCLR) DCONNI Clear */
+#define USBC_UHINTCLR_DCONNIC       (_U(0x1) << USBC_UHINTCLR_DCONNIC_Pos)
+#define USBC_UHINTCLR_DDISCIC_Pos   1            /**< \brief (USBC_UHINTCLR) DDISCI Clear */
+#define USBC_UHINTCLR_DDISCIC       (_U(0x1) << USBC_UHINTCLR_DDISCIC_Pos)
+#define USBC_UHINTCLR_RSTIC_Pos     2            /**< \brief (USBC_UHINTCLR) RSTI Clear */
+#define USBC_UHINTCLR_RSTIC         (_U(0x1) << USBC_UHINTCLR_RSTIC_Pos)
+#define USBC_UHINTCLR_RSMEDIC_Pos   3            /**< \brief (USBC_UHINTCLR) RSMEDI Clear */
+#define USBC_UHINTCLR_RSMEDIC       (_U(0x1) << USBC_UHINTCLR_RSMEDIC_Pos)
+#define USBC_UHINTCLR_RXRSMIC_Pos   4            /**< \brief (USBC_UHINTCLR) RXRSMI Clear */
+#define USBC_UHINTCLR_RXRSMIC       (_U(0x1) << USBC_UHINTCLR_RXRSMIC_Pos)
+#define USBC_UHINTCLR_HSOFIC_Pos    5            /**< \brief (USBC_UHINTCLR) HSOFI Clear */
+#define USBC_UHINTCLR_HSOFIC        (_U(0x1) << USBC_UHINTCLR_HSOFIC_Pos)
+#define USBC_UHINTCLR_HWUPIC_Pos    6            /**< \brief (USBC_UHINTCLR) HWUPI Clear */
+#define USBC_UHINTCLR_HWUPIC        (_U(0x1) << USBC_UHINTCLR_HWUPIC_Pos)
+#define USBC_UHINTCLR_MASK          _U(0x0000007F) /**< \brief (USBC_UHINTCLR) MASK Register */
+
+/* -------- USBC_UHINTSET : (USBC Offset: 0x40C) ( /W 32) Host Global Interrupt Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DCONNIS:1;        /*!< bit:      0  DCONNI Set                         */
+    uint32_t DDISCIS:1;        /*!< bit:      1  DDISCI Set                         */
+    uint32_t RSTIS:1;          /*!< bit:      2  RSTI Set                           */
+    uint32_t RSMEDIS:1;        /*!< bit:      3  RSMEDI Set                         */
+    uint32_t RXRSMIS:1;        /*!< bit:      4  RXRSMI Set                         */
+    uint32_t HSOFIS:1;         /*!< bit:      5  HSOFI Set                          */
+    uint32_t HWUPIS:1;         /*!< bit:      6  HWUPI Set                          */
+    uint32_t :25;              /*!< bit:  7..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UHINTSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UHINTSET_OFFSET        0x40C        /**< \brief (USBC_UHINTSET offset) Host Global Interrupt Set Register */
+#define USBC_UHINTSET_RESETVALUE    _U(0x00000000); /**< \brief (USBC_UHINTSET reset_value) Host Global Interrupt Set Register */
+
+#define USBC_UHINTSET_DCONNIS_Pos   0            /**< \brief (USBC_UHINTSET) DCONNI Set */
+#define USBC_UHINTSET_DCONNIS       (_U(0x1) << USBC_UHINTSET_DCONNIS_Pos)
+#define USBC_UHINTSET_DDISCIS_Pos   1            /**< \brief (USBC_UHINTSET) DDISCI Set */
+#define USBC_UHINTSET_DDISCIS       (_U(0x1) << USBC_UHINTSET_DDISCIS_Pos)
+#define USBC_UHINTSET_RSTIS_Pos     2            /**< \brief (USBC_UHINTSET) RSTI Set */
+#define USBC_UHINTSET_RSTIS         (_U(0x1) << USBC_UHINTSET_RSTIS_Pos)
+#define USBC_UHINTSET_RSMEDIS_Pos   3            /**< \brief (USBC_UHINTSET) RSMEDI Set */
+#define USBC_UHINTSET_RSMEDIS       (_U(0x1) << USBC_UHINTSET_RSMEDIS_Pos)
+#define USBC_UHINTSET_RXRSMIS_Pos   4            /**< \brief (USBC_UHINTSET) RXRSMI Set */
+#define USBC_UHINTSET_RXRSMIS       (_U(0x1) << USBC_UHINTSET_RXRSMIS_Pos)
+#define USBC_UHINTSET_HSOFIS_Pos    5            /**< \brief (USBC_UHINTSET) HSOFI Set */
+#define USBC_UHINTSET_HSOFIS        (_U(0x1) << USBC_UHINTSET_HSOFIS_Pos)
+#define USBC_UHINTSET_HWUPIS_Pos    6            /**< \brief (USBC_UHINTSET) HWUPI Set */
+#define USBC_UHINTSET_HWUPIS        (_U(0x1) << USBC_UHINTSET_HWUPIS_Pos)
+#define USBC_UHINTSET_MASK          _U(0x0000007F) /**< \brief (USBC_UHINTSET) MASK Register */
+
+/* -------- USBC_UHINTE : (USBC Offset: 0x410) (R/  32) Host Global Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DCONNIE:1;        /*!< bit:      0  DCONNI Enable                      */
+    uint32_t DDISCIE:1;        /*!< bit:      1  DDISCI Enable                      */
+    uint32_t RSTIE:1;          /*!< bit:      2  RSTI Enable                        */
+    uint32_t RSMEDIE:1;        /*!< bit:      3  RSMEDI Enable                      */
+    uint32_t RXRSMIE:1;        /*!< bit:      4  RXRSMI Enable                      */
+    uint32_t HSOFIE:1;         /*!< bit:      5  HSOFI Enable                       */
+    uint32_t HWUPIE:1;         /*!< bit:      6  HWUPI Enable                       */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t P0INTE:1;         /*!< bit:      8  P0INT Enable                       */
+    uint32_t P1INTE:1;         /*!< bit:      9  P1INT Enable                       */
+    uint32_t P2INTE:1;         /*!< bit:     10  P2INT Enable                       */
+    uint32_t P3INTE:1;         /*!< bit:     11  P3INT Enable                       */
+    uint32_t P4INTE:1;         /*!< bit:     12  P4INT Enable                       */
+    uint32_t P5INTE:1;         /*!< bit:     13  P5INT Enable                       */
+    uint32_t P6INTE:1;         /*!< bit:     14  P6INT Enable                       */
+    uint32_t P7INTE:1;         /*!< bit:     15  P7INT Enable                       */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UHINTE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UHINTE_OFFSET          0x410        /**< \brief (USBC_UHINTE offset) Host Global Interrupt Enable Register */
+#define USBC_UHINTE_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UHINTE reset_value) Host Global Interrupt Enable Register */
+
+#define USBC_UHINTE_DCONNIE_Pos     0            /**< \brief (USBC_UHINTE) DCONNI Enable */
+#define USBC_UHINTE_DCONNIE         (_U(0x1) << USBC_UHINTE_DCONNIE_Pos)
+#define USBC_UHINTE_DDISCIE_Pos     1            /**< \brief (USBC_UHINTE) DDISCI Enable */
+#define USBC_UHINTE_DDISCIE         (_U(0x1) << USBC_UHINTE_DDISCIE_Pos)
+#define USBC_UHINTE_RSTIE_Pos       2            /**< \brief (USBC_UHINTE) RSTI Enable */
+#define USBC_UHINTE_RSTIE           (_U(0x1) << USBC_UHINTE_RSTIE_Pos)
+#define USBC_UHINTE_RSMEDIE_Pos     3            /**< \brief (USBC_UHINTE) RSMEDI Enable */
+#define USBC_UHINTE_RSMEDIE         (_U(0x1) << USBC_UHINTE_RSMEDIE_Pos)
+#define USBC_UHINTE_RXRSMIE_Pos     4            /**< \brief (USBC_UHINTE) RXRSMI Enable */
+#define USBC_UHINTE_RXRSMIE         (_U(0x1) << USBC_UHINTE_RXRSMIE_Pos)
+#define USBC_UHINTE_HSOFIE_Pos      5            /**< \brief (USBC_UHINTE) HSOFI Enable */
+#define USBC_UHINTE_HSOFIE          (_U(0x1) << USBC_UHINTE_HSOFIE_Pos)
+#define USBC_UHINTE_HWUPIE_Pos      6            /**< \brief (USBC_UHINTE) HWUPI Enable */
+#define USBC_UHINTE_HWUPIE          (_U(0x1) << USBC_UHINTE_HWUPIE_Pos)
+#define USBC_UHINTE_P0INTE_Pos      8            /**< \brief (USBC_UHINTE) P0INT Enable */
+#define USBC_UHINTE_P0INTE          (_U(0x1) << USBC_UHINTE_P0INTE_Pos)
+#define USBC_UHINTE_P1INTE_Pos      9            /**< \brief (USBC_UHINTE) P1INT Enable */
+#define USBC_UHINTE_P1INTE          (_U(0x1) << USBC_UHINTE_P1INTE_Pos)
+#define USBC_UHINTE_P2INTE_Pos      10           /**< \brief (USBC_UHINTE) P2INT Enable */
+#define USBC_UHINTE_P2INTE          (_U(0x1) << USBC_UHINTE_P2INTE_Pos)
+#define USBC_UHINTE_P3INTE_Pos      11           /**< \brief (USBC_UHINTE) P3INT Enable */
+#define USBC_UHINTE_P3INTE          (_U(0x1) << USBC_UHINTE_P3INTE_Pos)
+#define USBC_UHINTE_P4INTE_Pos      12           /**< \brief (USBC_UHINTE) P4INT Enable */
+#define USBC_UHINTE_P4INTE          (_U(0x1) << USBC_UHINTE_P4INTE_Pos)
+#define USBC_UHINTE_P5INTE_Pos      13           /**< \brief (USBC_UHINTE) P5INT Enable */
+#define USBC_UHINTE_P5INTE          (_U(0x1) << USBC_UHINTE_P5INTE_Pos)
+#define USBC_UHINTE_P6INTE_Pos      14           /**< \brief (USBC_UHINTE) P6INT Enable */
+#define USBC_UHINTE_P6INTE          (_U(0x1) << USBC_UHINTE_P6INTE_Pos)
+#define USBC_UHINTE_P7INTE_Pos      15           /**< \brief (USBC_UHINTE) P7INT Enable */
+#define USBC_UHINTE_P7INTE          (_U(0x1) << USBC_UHINTE_P7INTE_Pos)
+#define USBC_UHINTE_MASK            _U(0x0000FF7F) /**< \brief (USBC_UHINTE) MASK Register */
+
+/* -------- USBC_UHINTECLR : (USBC Offset: 0x414) ( /W 32) Host Global Interrupt Enable Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DCONNIEC:1;       /*!< bit:      0  DCONNIE Clear                      */
+    uint32_t DDISCIEC:1;       /*!< bit:      1  DDISCIE Clear                      */
+    uint32_t RSTIEC:1;         /*!< bit:      2  RSTIE Clear                        */
+    uint32_t RSMEDIEC:1;       /*!< bit:      3  RSMEDIE Clear                      */
+    uint32_t RXRSMIEC:1;       /*!< bit:      4  RXRSMIE Clear                      */
+    uint32_t HSOFIEC:1;        /*!< bit:      5  HSOFIE Clear                       */
+    uint32_t HWUPIEC:1;        /*!< bit:      6  HWUPIE Clear                       */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t P0INTEC:1;        /*!< bit:      8  P0INTE Clear                       */
+    uint32_t P1INTEC:1;        /*!< bit:      9  P1INTE Clear                       */
+    uint32_t P2INTEC:1;        /*!< bit:     10  P2INTE Clear                       */
+    uint32_t P3INTEC:1;        /*!< bit:     11  P3INTE Clear                       */
+    uint32_t P4INTEC:1;        /*!< bit:     12  P4INTE Clear                       */
+    uint32_t P5INTEC:1;        /*!< bit:     13  P5INTE Clear                       */
+    uint32_t P6INTEC:1;        /*!< bit:     14  P6INTE Clear                       */
+    uint32_t P7INTEC:1;        /*!< bit:     15  P7INTE Clear                       */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UHINTECLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UHINTECLR_OFFSET       0x414        /**< \brief (USBC_UHINTECLR offset) Host Global Interrupt Enable Clear Register */
+#define USBC_UHINTECLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UHINTECLR reset_value) Host Global Interrupt Enable Clear Register */
+
+#define USBC_UHINTECLR_DCONNIEC_Pos 0            /**< \brief (USBC_UHINTECLR) DCONNIE Clear */
+#define USBC_UHINTECLR_DCONNIEC     (_U(0x1) << USBC_UHINTECLR_DCONNIEC_Pos)
+#define USBC_UHINTECLR_DDISCIEC_Pos 1            /**< \brief (USBC_UHINTECLR) DDISCIE Clear */
+#define USBC_UHINTECLR_DDISCIEC     (_U(0x1) << USBC_UHINTECLR_DDISCIEC_Pos)
+#define USBC_UHINTECLR_RSTIEC_Pos   2            /**< \brief (USBC_UHINTECLR) RSTIE Clear */
+#define USBC_UHINTECLR_RSTIEC       (_U(0x1) << USBC_UHINTECLR_RSTIEC_Pos)
+#define USBC_UHINTECLR_RSMEDIEC_Pos 3            /**< \brief (USBC_UHINTECLR) RSMEDIE Clear */
+#define USBC_UHINTECLR_RSMEDIEC     (_U(0x1) << USBC_UHINTECLR_RSMEDIEC_Pos)
+#define USBC_UHINTECLR_RXRSMIEC_Pos 4            /**< \brief (USBC_UHINTECLR) RXRSMIE Clear */
+#define USBC_UHINTECLR_RXRSMIEC     (_U(0x1) << USBC_UHINTECLR_RXRSMIEC_Pos)
+#define USBC_UHINTECLR_HSOFIEC_Pos  5            /**< \brief (USBC_UHINTECLR) HSOFIE Clear */
+#define USBC_UHINTECLR_HSOFIEC      (_U(0x1) << USBC_UHINTECLR_HSOFIEC_Pos)
+#define USBC_UHINTECLR_HWUPIEC_Pos  6            /**< \brief (USBC_UHINTECLR) HWUPIE Clear */
+#define USBC_UHINTECLR_HWUPIEC      (_U(0x1) << USBC_UHINTECLR_HWUPIEC_Pos)
+#define USBC_UHINTECLR_P0INTEC_Pos  8            /**< \brief (USBC_UHINTECLR) P0INTE Clear */
+#define USBC_UHINTECLR_P0INTEC      (_U(0x1) << USBC_UHINTECLR_P0INTEC_Pos)
+#define USBC_UHINTECLR_P1INTEC_Pos  9            /**< \brief (USBC_UHINTECLR) P1INTE Clear */
+#define USBC_UHINTECLR_P1INTEC      (_U(0x1) << USBC_UHINTECLR_P1INTEC_Pos)
+#define USBC_UHINTECLR_P2INTEC_Pos  10           /**< \brief (USBC_UHINTECLR) P2INTE Clear */
+#define USBC_UHINTECLR_P2INTEC      (_U(0x1) << USBC_UHINTECLR_P2INTEC_Pos)
+#define USBC_UHINTECLR_P3INTEC_Pos  11           /**< \brief (USBC_UHINTECLR) P3INTE Clear */
+#define USBC_UHINTECLR_P3INTEC      (_U(0x1) << USBC_UHINTECLR_P3INTEC_Pos)
+#define USBC_UHINTECLR_P4INTEC_Pos  12           /**< \brief (USBC_UHINTECLR) P4INTE Clear */
+#define USBC_UHINTECLR_P4INTEC      (_U(0x1) << USBC_UHINTECLR_P4INTEC_Pos)
+#define USBC_UHINTECLR_P5INTEC_Pos  13           /**< \brief (USBC_UHINTECLR) P5INTE Clear */
+#define USBC_UHINTECLR_P5INTEC      (_U(0x1) << USBC_UHINTECLR_P5INTEC_Pos)
+#define USBC_UHINTECLR_P6INTEC_Pos  14           /**< \brief (USBC_UHINTECLR) P6INTE Clear */
+#define USBC_UHINTECLR_P6INTEC      (_U(0x1) << USBC_UHINTECLR_P6INTEC_Pos)
+#define USBC_UHINTECLR_P7INTEC_Pos  15           /**< \brief (USBC_UHINTECLR) P7INTE Clear */
+#define USBC_UHINTECLR_P7INTEC      (_U(0x1) << USBC_UHINTECLR_P7INTEC_Pos)
+#define USBC_UHINTECLR_MASK         _U(0x0000FF7F) /**< \brief (USBC_UHINTECLR) MASK Register */
+
+/* -------- USBC_UHINTESET : (USBC Offset: 0x418) ( /W 32) Host Global Interrupt Enable Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DCONNIES:1;       /*!< bit:      0  DCONNIE Set                        */
+    uint32_t DDISCIES:1;       /*!< bit:      1  DDISCIE Set                        */
+    uint32_t RSTIES:1;         /*!< bit:      2  RSTIE Set                          */
+    uint32_t RSMEDIES:1;       /*!< bit:      3  RSMEDIE Set                        */
+    uint32_t RXRSMIES:1;       /*!< bit:      4  RXRSMIE Set                        */
+    uint32_t HSOFIES:1;        /*!< bit:      5  HSOFIE Set                         */
+    uint32_t HWUPIES:1;        /*!< bit:      6  HWUPIE Set                         */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t P0INTES:1;        /*!< bit:      8  P0INTE Set                         */
+    uint32_t P1INTES:1;        /*!< bit:      9  P1INTE Set                         */
+    uint32_t P2INTES:1;        /*!< bit:     10  P2INTE Set                         */
+    uint32_t P3INTES:1;        /*!< bit:     11  P3INTE Set                         */
+    uint32_t P4INTES:1;        /*!< bit:     12  P4INTE Set                         */
+    uint32_t P5INTES:1;        /*!< bit:     13  P5INTE Set                         */
+    uint32_t P6INTES:1;        /*!< bit:     14  P6INTE Set                         */
+    uint32_t P7INTES:1;        /*!< bit:     15  P7INTE Set                         */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UHINTESET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UHINTESET_OFFSET       0x418        /**< \brief (USBC_UHINTESET offset) Host Global Interrupt Enable Set Register */
+#define USBC_UHINTESET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UHINTESET reset_value) Host Global Interrupt Enable Set Register */
+
+#define USBC_UHINTESET_DCONNIES_Pos 0            /**< \brief (USBC_UHINTESET) DCONNIE Set */
+#define USBC_UHINTESET_DCONNIES     (_U(0x1) << USBC_UHINTESET_DCONNIES_Pos)
+#define USBC_UHINTESET_DDISCIES_Pos 1            /**< \brief (USBC_UHINTESET) DDISCIE Set */
+#define USBC_UHINTESET_DDISCIES     (_U(0x1) << USBC_UHINTESET_DDISCIES_Pos)
+#define USBC_UHINTESET_RSTIES_Pos   2            /**< \brief (USBC_UHINTESET) RSTIE Set */
+#define USBC_UHINTESET_RSTIES       (_U(0x1) << USBC_UHINTESET_RSTIES_Pos)
+#define USBC_UHINTESET_RSMEDIES_Pos 3            /**< \brief (USBC_UHINTESET) RSMEDIE Set */
+#define USBC_UHINTESET_RSMEDIES     (_U(0x1) << USBC_UHINTESET_RSMEDIES_Pos)
+#define USBC_UHINTESET_RXRSMIES_Pos 4            /**< \brief (USBC_UHINTESET) RXRSMIE Set */
+#define USBC_UHINTESET_RXRSMIES     (_U(0x1) << USBC_UHINTESET_RXRSMIES_Pos)
+#define USBC_UHINTESET_HSOFIES_Pos  5            /**< \brief (USBC_UHINTESET) HSOFIE Set */
+#define USBC_UHINTESET_HSOFIES      (_U(0x1) << USBC_UHINTESET_HSOFIES_Pos)
+#define USBC_UHINTESET_HWUPIES_Pos  6            /**< \brief (USBC_UHINTESET) HWUPIE Set */
+#define USBC_UHINTESET_HWUPIES      (_U(0x1) << USBC_UHINTESET_HWUPIES_Pos)
+#define USBC_UHINTESET_P0INTES_Pos  8            /**< \brief (USBC_UHINTESET) P0INTE Set */
+#define USBC_UHINTESET_P0INTES      (_U(0x1) << USBC_UHINTESET_P0INTES_Pos)
+#define USBC_UHINTESET_P1INTES_Pos  9            /**< \brief (USBC_UHINTESET) P1INTE Set */
+#define USBC_UHINTESET_P1INTES      (_U(0x1) << USBC_UHINTESET_P1INTES_Pos)
+#define USBC_UHINTESET_P2INTES_Pos  10           /**< \brief (USBC_UHINTESET) P2INTE Set */
+#define USBC_UHINTESET_P2INTES      (_U(0x1) << USBC_UHINTESET_P2INTES_Pos)
+#define USBC_UHINTESET_P3INTES_Pos  11           /**< \brief (USBC_UHINTESET) P3INTE Set */
+#define USBC_UHINTESET_P3INTES      (_U(0x1) << USBC_UHINTESET_P3INTES_Pos)
+#define USBC_UHINTESET_P4INTES_Pos  12           /**< \brief (USBC_UHINTESET) P4INTE Set */
+#define USBC_UHINTESET_P4INTES      (_U(0x1) << USBC_UHINTESET_P4INTES_Pos)
+#define USBC_UHINTESET_P5INTES_Pos  13           /**< \brief (USBC_UHINTESET) P5INTE Set */
+#define USBC_UHINTESET_P5INTES      (_U(0x1) << USBC_UHINTESET_P5INTES_Pos)
+#define USBC_UHINTESET_P6INTES_Pos  14           /**< \brief (USBC_UHINTESET) P6INTE Set */
+#define USBC_UHINTESET_P6INTES      (_U(0x1) << USBC_UHINTESET_P6INTES_Pos)
+#define USBC_UHINTESET_P7INTES_Pos  15           /**< \brief (USBC_UHINTESET) P7INTE Set */
+#define USBC_UHINTESET_P7INTES      (_U(0x1) << USBC_UHINTESET_P7INTES_Pos)
+#define USBC_UHINTESET_MASK         _U(0x0000FF7F) /**< \brief (USBC_UHINTESET) MASK Register */
+
+/* -------- USBC_UPRST : (USBC Offset: 0x41C) (R/W 32) Pipe Reset Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PEN0:1;           /*!< bit:      0  Pipe0 Enable                       */
+    uint32_t PEN1:1;           /*!< bit:      1  Pipe1 Enable                       */
+    uint32_t PEN2:1;           /*!< bit:      2  Pipe2 Enable                       */
+    uint32_t PEN3:1;           /*!< bit:      3  Pipe3 Enable                       */
+    uint32_t PEN4:1;           /*!< bit:      4  Pipe4 Enable                       */
+    uint32_t PEN5:1;           /*!< bit:      5  Pipe5 Enable                       */
+    uint32_t PEN6:1;           /*!< bit:      6  Pipe6 Enable                       */
+    uint32_t PEN7:1;           /*!< bit:      7  Pipe7 Enable                       */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPRST_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPRST_OFFSET           0x41C        /**< \brief (USBC_UPRST offset) Pipe Reset Register */
+#define USBC_UPRST_RESETVALUE       _U(0x00000000); /**< \brief (USBC_UPRST reset_value) Pipe Reset Register */
+
+#define USBC_UPRST_PEN0_Pos         0            /**< \brief (USBC_UPRST) Pipe0 Enable */
+#define USBC_UPRST_PEN0             (_U(0x1) << USBC_UPRST_PEN0_Pos)
+#define USBC_UPRST_PEN1_Pos         1            /**< \brief (USBC_UPRST) Pipe1 Enable */
+#define USBC_UPRST_PEN1             (_U(0x1) << USBC_UPRST_PEN1_Pos)
+#define USBC_UPRST_PEN2_Pos         2            /**< \brief (USBC_UPRST) Pipe2 Enable */
+#define USBC_UPRST_PEN2             (_U(0x1) << USBC_UPRST_PEN2_Pos)
+#define USBC_UPRST_PEN3_Pos         3            /**< \brief (USBC_UPRST) Pipe3 Enable */
+#define USBC_UPRST_PEN3             (_U(0x1) << USBC_UPRST_PEN3_Pos)
+#define USBC_UPRST_PEN4_Pos         4            /**< \brief (USBC_UPRST) Pipe4 Enable */
+#define USBC_UPRST_PEN4             (_U(0x1) << USBC_UPRST_PEN4_Pos)
+#define USBC_UPRST_PEN5_Pos         5            /**< \brief (USBC_UPRST) Pipe5 Enable */
+#define USBC_UPRST_PEN5             (_U(0x1) << USBC_UPRST_PEN5_Pos)
+#define USBC_UPRST_PEN6_Pos         6            /**< \brief (USBC_UPRST) Pipe6 Enable */
+#define USBC_UPRST_PEN6             (_U(0x1) << USBC_UPRST_PEN6_Pos)
+#define USBC_UPRST_PEN7_Pos         7            /**< \brief (USBC_UPRST) Pipe7 Enable */
+#define USBC_UPRST_PEN7             (_U(0x1) << USBC_UPRST_PEN7_Pos)
+#define USBC_UPRST_MASK             _U(0x000000FF) /**< \brief (USBC_UPRST) MASK Register */
+
+/* -------- USBC_UHFNUM : (USBC Offset: 0x420) (R/W 32) Host Frame Number Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t MFNUM:3;          /*!< bit:  0.. 2  Micro Frame Number                 */
+    uint32_t FNUM:11;          /*!< bit:  3..13  Frame Number                       */
+    uint32_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint32_t FLENHIGH:8;       /*!< bit: 16..23  Frame Length                       */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UHFNUM_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UHFNUM_OFFSET          0x420        /**< \brief (USBC_UHFNUM offset) Host Frame Number Register */
+#define USBC_UHFNUM_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UHFNUM reset_value) Host Frame Number Register */
+
+#define USBC_UHFNUM_MFNUM_Pos       0            /**< \brief (USBC_UHFNUM) Micro Frame Number */
+#define USBC_UHFNUM_MFNUM_Msk       (_U(0x7) << USBC_UHFNUM_MFNUM_Pos)
+#define USBC_UHFNUM_MFNUM(value)    (USBC_UHFNUM_MFNUM_Msk & ((value) << USBC_UHFNUM_MFNUM_Pos))
+#define USBC_UHFNUM_FNUM_Pos        3            /**< \brief (USBC_UHFNUM) Frame Number */
+#define USBC_UHFNUM_FNUM_Msk        (_U(0x7FF) << USBC_UHFNUM_FNUM_Pos)
+#define USBC_UHFNUM_FNUM(value)     (USBC_UHFNUM_FNUM_Msk & ((value) << USBC_UHFNUM_FNUM_Pos))
+#define USBC_UHFNUM_FLENHIGH_Pos    16           /**< \brief (USBC_UHFNUM) Frame Length */
+#define USBC_UHFNUM_FLENHIGH_Msk    (_U(0xFF) << USBC_UHFNUM_FLENHIGH_Pos)
+#define USBC_UHFNUM_FLENHIGH(value) (USBC_UHFNUM_FLENHIGH_Msk & ((value) << USBC_UHFNUM_FLENHIGH_Pos))
+#define USBC_UHFNUM_MASK            _U(0x00FF3FFF) /**< \brief (USBC_UHFNUM) MASK Register */
+
+/* -------- USBC_UHSOFC : (USBC Offset: 0x424) (R/W 32) Host Start of Frame Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t FLENC:14;         /*!< bit:  0..13  Frame Length Control               */
+    uint32_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint32_t FLENCE:1;         /*!< bit:     16  Frame Length Control Enable        */
+    uint32_t :15;              /*!< bit: 17..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UHSOFC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UHSOFC_OFFSET          0x424        /**< \brief (USBC_UHSOFC offset) Host Start of Frame Control Register */
+#define USBC_UHSOFC_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UHSOFC reset_value) Host Start of Frame Control Register */
+
+#define USBC_UHSOFC_FLENC_Pos       0            /**< \brief (USBC_UHSOFC) Frame Length Control */
+#define USBC_UHSOFC_FLENC_Msk       (_U(0x3FFF) << USBC_UHSOFC_FLENC_Pos)
+#define USBC_UHSOFC_FLENC(value)    (USBC_UHSOFC_FLENC_Msk & ((value) << USBC_UHSOFC_FLENC_Pos))
+#define USBC_UHSOFC_FLENCE_Pos      16           /**< \brief (USBC_UHSOFC) Frame Length Control Enable */
+#define USBC_UHSOFC_FLENCE          (_U(0x1) << USBC_UHSOFC_FLENCE_Pos)
+#define USBC_UHSOFC_MASK            _U(0x00013FFF) /**< \brief (USBC_UHSOFC) MASK Register */
+
+/* -------- USBC_UPCFG0 : (USBC Offset: 0x500) (R/W 32) Pipe Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t PBK:1;            /*!< bit:      2  Pipe Banks                         */
+    uint32_t :1;               /*!< bit:      3  Reserved                           */
+    uint32_t PSIZE:3;          /*!< bit:  4.. 6  Pipe Size                          */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t PTOKEN:2;         /*!< bit:  8.. 9  Pipe Token                         */
+    uint32_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint32_t PTYPE:2;          /*!< bit: 12..13  Pipe Type                          */
+    uint32_t :6;               /*!< bit: 14..19  Reserved                           */
+    uint32_t PINGEN:1;         /*!< bit:     20  Ping Enable                        */
+    uint32_t :3;               /*!< bit: 21..23  Reserved                           */
+    uint32_t BINTERVAL:8;      /*!< bit: 24..31  binterval parameter                */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCFG0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCFG0_OFFSET          0x500        /**< \brief (USBC_UPCFG0 offset) Pipe Configuration Register */
+#define USBC_UPCFG0_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCFG0 reset_value) Pipe Configuration Register */
+
+#define USBC_UPCFG0_PBK_Pos         2            /**< \brief (USBC_UPCFG0) Pipe Banks */
+#define USBC_UPCFG0_PBK             (_U(0x1) << USBC_UPCFG0_PBK_Pos)
+#define   USBC_UPCFG0_PBK_SINGLE_Val      _U(0x0)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PBK_DOUBLE_Val      _U(0x1)   /**< \brief (USBC_UPCFG0)  */
+#define USBC_UPCFG0_PBK_SINGLE      (USBC_UPCFG0_PBK_SINGLE_Val    << USBC_UPCFG0_PBK_Pos)
+#define USBC_UPCFG0_PBK_DOUBLE      (USBC_UPCFG0_PBK_DOUBLE_Val    << USBC_UPCFG0_PBK_Pos)
+#define USBC_UPCFG0_PSIZE_Pos       4            /**< \brief (USBC_UPCFG0) Pipe Size */
+#define USBC_UPCFG0_PSIZE_Msk       (_U(0x7) << USBC_UPCFG0_PSIZE_Pos)
+#define USBC_UPCFG0_PSIZE(value)    (USBC_UPCFG0_PSIZE_Msk & ((value) << USBC_UPCFG0_PSIZE_Pos))
+#define   USBC_UPCFG0_PSIZE_8_Val         _U(0x0)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PSIZE_16_Val        _U(0x1)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PSIZE_32_Val        _U(0x2)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PSIZE_64_Val        _U(0x3)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PSIZE_128_Val       _U(0x4)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PSIZE_256_Val       _U(0x5)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PSIZE_512_Val       _U(0x6)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PSIZE_1024_Val      _U(0x7)   /**< \brief (USBC_UPCFG0)  */
+#define USBC_UPCFG0_PSIZE_8         (USBC_UPCFG0_PSIZE_8_Val       << USBC_UPCFG0_PSIZE_Pos)
+#define USBC_UPCFG0_PSIZE_16        (USBC_UPCFG0_PSIZE_16_Val      << USBC_UPCFG0_PSIZE_Pos)
+#define USBC_UPCFG0_PSIZE_32        (USBC_UPCFG0_PSIZE_32_Val      << USBC_UPCFG0_PSIZE_Pos)
+#define USBC_UPCFG0_PSIZE_64        (USBC_UPCFG0_PSIZE_64_Val      << USBC_UPCFG0_PSIZE_Pos)
+#define USBC_UPCFG0_PSIZE_128       (USBC_UPCFG0_PSIZE_128_Val     << USBC_UPCFG0_PSIZE_Pos)
+#define USBC_UPCFG0_PSIZE_256       (USBC_UPCFG0_PSIZE_256_Val     << USBC_UPCFG0_PSIZE_Pos)
+#define USBC_UPCFG0_PSIZE_512       (USBC_UPCFG0_PSIZE_512_Val     << USBC_UPCFG0_PSIZE_Pos)
+#define USBC_UPCFG0_PSIZE_1024      (USBC_UPCFG0_PSIZE_1024_Val    << USBC_UPCFG0_PSIZE_Pos)
+#define USBC_UPCFG0_PTOKEN_Pos      8            /**< \brief (USBC_UPCFG0) Pipe Token */
+#define USBC_UPCFG0_PTOKEN_Msk      (_U(0x3) << USBC_UPCFG0_PTOKEN_Pos)
+#define USBC_UPCFG0_PTOKEN(value)   (USBC_UPCFG0_PTOKEN_Msk & ((value) << USBC_UPCFG0_PTOKEN_Pos))
+#define   USBC_UPCFG0_PTOKEN_SETUP_Val    _U(0x0)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PTOKEN_IN_Val       _U(0x1)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PTOKEN_OUT_Val      _U(0x2)   /**< \brief (USBC_UPCFG0)  */
+#define USBC_UPCFG0_PTOKEN_SETUP    (USBC_UPCFG0_PTOKEN_SETUP_Val  << USBC_UPCFG0_PTOKEN_Pos)
+#define USBC_UPCFG0_PTOKEN_IN       (USBC_UPCFG0_PTOKEN_IN_Val     << USBC_UPCFG0_PTOKEN_Pos)
+#define USBC_UPCFG0_PTOKEN_OUT      (USBC_UPCFG0_PTOKEN_OUT_Val    << USBC_UPCFG0_PTOKEN_Pos)
+#define USBC_UPCFG0_PTYPE_Pos       12           /**< \brief (USBC_UPCFG0) Pipe Type */
+#define USBC_UPCFG0_PTYPE_Msk       (_U(0x3) << USBC_UPCFG0_PTYPE_Pos)
+#define USBC_UPCFG0_PTYPE(value)    (USBC_UPCFG0_PTYPE_Msk & ((value) << USBC_UPCFG0_PTYPE_Pos))
+#define   USBC_UPCFG0_PTYPE_CONTROL_Val   _U(0x0)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PTYPE_BULK_Val      _U(0x2)   /**< \brief (USBC_UPCFG0)  */
+#define   USBC_UPCFG0_PTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UPCFG0)  */
+#define USBC_UPCFG0_PTYPE_CONTROL   (USBC_UPCFG0_PTYPE_CONTROL_Val << USBC_UPCFG0_PTYPE_Pos)
+#define USBC_UPCFG0_PTYPE_ISOCHRONOUS (USBC_UPCFG0_PTYPE_ISOCHRONOUS_Val << USBC_UPCFG0_PTYPE_Pos)
+#define USBC_UPCFG0_PTYPE_BULK      (USBC_UPCFG0_PTYPE_BULK_Val    << USBC_UPCFG0_PTYPE_Pos)
+#define USBC_UPCFG0_PTYPE_INTERRUPT (USBC_UPCFG0_PTYPE_INTERRUPT_Val << USBC_UPCFG0_PTYPE_Pos)
+#define USBC_UPCFG0_PINGEN_Pos      20           /**< \brief (USBC_UPCFG0) Ping Enable */
+#define USBC_UPCFG0_PINGEN          (_U(0x1) << USBC_UPCFG0_PINGEN_Pos)
+#define USBC_UPCFG0_BINTERVAL_Pos   24           /**< \brief (USBC_UPCFG0) binterval parameter */
+#define USBC_UPCFG0_BINTERVAL_Msk   (_U(0xFF) << USBC_UPCFG0_BINTERVAL_Pos)
+#define USBC_UPCFG0_BINTERVAL(value) (USBC_UPCFG0_BINTERVAL_Msk & ((value) << USBC_UPCFG0_BINTERVAL_Pos))
+#define USBC_UPCFG0_MASK            _U(0xFF103374) /**< \brief (USBC_UPCFG0) MASK Register */
+
+/* -------- USBC_UPCFG1 : (USBC Offset: 0x504) (R/W 32) Pipe Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t PBK:1;            /*!< bit:      2  Pipe Banks                         */
+    uint32_t :1;               /*!< bit:      3  Reserved                           */
+    uint32_t PSIZE:3;          /*!< bit:  4.. 6  Pipe Size                          */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t PTOKEN:2;         /*!< bit:  8.. 9  Pipe Token                         */
+    uint32_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint32_t PTYPE:2;          /*!< bit: 12..13  Pipe Type                          */
+    uint32_t :6;               /*!< bit: 14..19  Reserved                           */
+    uint32_t PINGEN:1;         /*!< bit:     20  Ping Enable                        */
+    uint32_t :3;               /*!< bit: 21..23  Reserved                           */
+    uint32_t BINTERVAL:8;      /*!< bit: 24..31  binterval parameter                */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCFG1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCFG1_OFFSET          0x504        /**< \brief (USBC_UPCFG1 offset) Pipe Configuration Register */
+#define USBC_UPCFG1_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCFG1 reset_value) Pipe Configuration Register */
+
+#define USBC_UPCFG1_PBK_Pos         2            /**< \brief (USBC_UPCFG1) Pipe Banks */
+#define USBC_UPCFG1_PBK             (_U(0x1) << USBC_UPCFG1_PBK_Pos)
+#define   USBC_UPCFG1_PBK_SINGLE_Val      _U(0x0)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PBK_DOUBLE_Val      _U(0x1)   /**< \brief (USBC_UPCFG1)  */
+#define USBC_UPCFG1_PBK_SINGLE      (USBC_UPCFG1_PBK_SINGLE_Val    << USBC_UPCFG1_PBK_Pos)
+#define USBC_UPCFG1_PBK_DOUBLE      (USBC_UPCFG1_PBK_DOUBLE_Val    << USBC_UPCFG1_PBK_Pos)
+#define USBC_UPCFG1_PSIZE_Pos       4            /**< \brief (USBC_UPCFG1) Pipe Size */
+#define USBC_UPCFG1_PSIZE_Msk       (_U(0x7) << USBC_UPCFG1_PSIZE_Pos)
+#define USBC_UPCFG1_PSIZE(value)    (USBC_UPCFG1_PSIZE_Msk & ((value) << USBC_UPCFG1_PSIZE_Pos))
+#define   USBC_UPCFG1_PSIZE_8_Val         _U(0x0)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PSIZE_16_Val        _U(0x1)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PSIZE_32_Val        _U(0x2)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PSIZE_64_Val        _U(0x3)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PSIZE_128_Val       _U(0x4)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PSIZE_256_Val       _U(0x5)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PSIZE_512_Val       _U(0x6)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PSIZE_1024_Val      _U(0x7)   /**< \brief (USBC_UPCFG1)  */
+#define USBC_UPCFG1_PSIZE_8         (USBC_UPCFG1_PSIZE_8_Val       << USBC_UPCFG1_PSIZE_Pos)
+#define USBC_UPCFG1_PSIZE_16        (USBC_UPCFG1_PSIZE_16_Val      << USBC_UPCFG1_PSIZE_Pos)
+#define USBC_UPCFG1_PSIZE_32        (USBC_UPCFG1_PSIZE_32_Val      << USBC_UPCFG1_PSIZE_Pos)
+#define USBC_UPCFG1_PSIZE_64        (USBC_UPCFG1_PSIZE_64_Val      << USBC_UPCFG1_PSIZE_Pos)
+#define USBC_UPCFG1_PSIZE_128       (USBC_UPCFG1_PSIZE_128_Val     << USBC_UPCFG1_PSIZE_Pos)
+#define USBC_UPCFG1_PSIZE_256       (USBC_UPCFG1_PSIZE_256_Val     << USBC_UPCFG1_PSIZE_Pos)
+#define USBC_UPCFG1_PSIZE_512       (USBC_UPCFG1_PSIZE_512_Val     << USBC_UPCFG1_PSIZE_Pos)
+#define USBC_UPCFG1_PSIZE_1024      (USBC_UPCFG1_PSIZE_1024_Val    << USBC_UPCFG1_PSIZE_Pos)
+#define USBC_UPCFG1_PTOKEN_Pos      8            /**< \brief (USBC_UPCFG1) Pipe Token */
+#define USBC_UPCFG1_PTOKEN_Msk      (_U(0x3) << USBC_UPCFG1_PTOKEN_Pos)
+#define USBC_UPCFG1_PTOKEN(value)   (USBC_UPCFG1_PTOKEN_Msk & ((value) << USBC_UPCFG1_PTOKEN_Pos))
+#define   USBC_UPCFG1_PTOKEN_SETUP_Val    _U(0x0)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PTOKEN_IN_Val       _U(0x1)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PTOKEN_OUT_Val      _U(0x2)   /**< \brief (USBC_UPCFG1)  */
+#define USBC_UPCFG1_PTOKEN_SETUP    (USBC_UPCFG1_PTOKEN_SETUP_Val  << USBC_UPCFG1_PTOKEN_Pos)
+#define USBC_UPCFG1_PTOKEN_IN       (USBC_UPCFG1_PTOKEN_IN_Val     << USBC_UPCFG1_PTOKEN_Pos)
+#define USBC_UPCFG1_PTOKEN_OUT      (USBC_UPCFG1_PTOKEN_OUT_Val    << USBC_UPCFG1_PTOKEN_Pos)
+#define USBC_UPCFG1_PTYPE_Pos       12           /**< \brief (USBC_UPCFG1) Pipe Type */
+#define USBC_UPCFG1_PTYPE_Msk       (_U(0x3) << USBC_UPCFG1_PTYPE_Pos)
+#define USBC_UPCFG1_PTYPE(value)    (USBC_UPCFG1_PTYPE_Msk & ((value) << USBC_UPCFG1_PTYPE_Pos))
+#define   USBC_UPCFG1_PTYPE_CONTROL_Val   _U(0x0)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PTYPE_BULK_Val      _U(0x2)   /**< \brief (USBC_UPCFG1)  */
+#define   USBC_UPCFG1_PTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UPCFG1)  */
+#define USBC_UPCFG1_PTYPE_CONTROL   (USBC_UPCFG1_PTYPE_CONTROL_Val << USBC_UPCFG1_PTYPE_Pos)
+#define USBC_UPCFG1_PTYPE_ISOCHRONOUS (USBC_UPCFG1_PTYPE_ISOCHRONOUS_Val << USBC_UPCFG1_PTYPE_Pos)
+#define USBC_UPCFG1_PTYPE_BULK      (USBC_UPCFG1_PTYPE_BULK_Val    << USBC_UPCFG1_PTYPE_Pos)
+#define USBC_UPCFG1_PTYPE_INTERRUPT (USBC_UPCFG1_PTYPE_INTERRUPT_Val << USBC_UPCFG1_PTYPE_Pos)
+#define USBC_UPCFG1_PINGEN_Pos      20           /**< \brief (USBC_UPCFG1) Ping Enable */
+#define USBC_UPCFG1_PINGEN          (_U(0x1) << USBC_UPCFG1_PINGEN_Pos)
+#define USBC_UPCFG1_BINTERVAL_Pos   24           /**< \brief (USBC_UPCFG1) binterval parameter */
+#define USBC_UPCFG1_BINTERVAL_Msk   (_U(0xFF) << USBC_UPCFG1_BINTERVAL_Pos)
+#define USBC_UPCFG1_BINTERVAL(value) (USBC_UPCFG1_BINTERVAL_Msk & ((value) << USBC_UPCFG1_BINTERVAL_Pos))
+#define USBC_UPCFG1_MASK            _U(0xFF103374) /**< \brief (USBC_UPCFG1) MASK Register */
+
+/* -------- USBC_UPCFG2 : (USBC Offset: 0x508) (R/W 32) Pipe Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t PBK:1;            /*!< bit:      2  Pipe Banks                         */
+    uint32_t :1;               /*!< bit:      3  Reserved                           */
+    uint32_t PSIZE:3;          /*!< bit:  4.. 6  Pipe Size                          */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t PTOKEN:2;         /*!< bit:  8.. 9  Pipe Token                         */
+    uint32_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint32_t PTYPE:2;          /*!< bit: 12..13  Pipe Type                          */
+    uint32_t :6;               /*!< bit: 14..19  Reserved                           */
+    uint32_t PINGEN:1;         /*!< bit:     20  Ping Enable                        */
+    uint32_t :3;               /*!< bit: 21..23  Reserved                           */
+    uint32_t BINTERVAL:8;      /*!< bit: 24..31  binterval parameter                */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCFG2_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCFG2_OFFSET          0x508        /**< \brief (USBC_UPCFG2 offset) Pipe Configuration Register */
+#define USBC_UPCFG2_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCFG2 reset_value) Pipe Configuration Register */
+
+#define USBC_UPCFG2_PBK_Pos         2            /**< \brief (USBC_UPCFG2) Pipe Banks */
+#define USBC_UPCFG2_PBK             (_U(0x1) << USBC_UPCFG2_PBK_Pos)
+#define   USBC_UPCFG2_PBK_SINGLE_Val      _U(0x0)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PBK_DOUBLE_Val      _U(0x1)   /**< \brief (USBC_UPCFG2)  */
+#define USBC_UPCFG2_PBK_SINGLE      (USBC_UPCFG2_PBK_SINGLE_Val    << USBC_UPCFG2_PBK_Pos)
+#define USBC_UPCFG2_PBK_DOUBLE      (USBC_UPCFG2_PBK_DOUBLE_Val    << USBC_UPCFG2_PBK_Pos)
+#define USBC_UPCFG2_PSIZE_Pos       4            /**< \brief (USBC_UPCFG2) Pipe Size */
+#define USBC_UPCFG2_PSIZE_Msk       (_U(0x7) << USBC_UPCFG2_PSIZE_Pos)
+#define USBC_UPCFG2_PSIZE(value)    (USBC_UPCFG2_PSIZE_Msk & ((value) << USBC_UPCFG2_PSIZE_Pos))
+#define   USBC_UPCFG2_PSIZE_8_Val         _U(0x0)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PSIZE_16_Val        _U(0x1)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PSIZE_32_Val        _U(0x2)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PSIZE_64_Val        _U(0x3)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PSIZE_128_Val       _U(0x4)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PSIZE_256_Val       _U(0x5)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PSIZE_512_Val       _U(0x6)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PSIZE_1024_Val      _U(0x7)   /**< \brief (USBC_UPCFG2)  */
+#define USBC_UPCFG2_PSIZE_8         (USBC_UPCFG2_PSIZE_8_Val       << USBC_UPCFG2_PSIZE_Pos)
+#define USBC_UPCFG2_PSIZE_16        (USBC_UPCFG2_PSIZE_16_Val      << USBC_UPCFG2_PSIZE_Pos)
+#define USBC_UPCFG2_PSIZE_32        (USBC_UPCFG2_PSIZE_32_Val      << USBC_UPCFG2_PSIZE_Pos)
+#define USBC_UPCFG2_PSIZE_64        (USBC_UPCFG2_PSIZE_64_Val      << USBC_UPCFG2_PSIZE_Pos)
+#define USBC_UPCFG2_PSIZE_128       (USBC_UPCFG2_PSIZE_128_Val     << USBC_UPCFG2_PSIZE_Pos)
+#define USBC_UPCFG2_PSIZE_256       (USBC_UPCFG2_PSIZE_256_Val     << USBC_UPCFG2_PSIZE_Pos)
+#define USBC_UPCFG2_PSIZE_512       (USBC_UPCFG2_PSIZE_512_Val     << USBC_UPCFG2_PSIZE_Pos)
+#define USBC_UPCFG2_PSIZE_1024      (USBC_UPCFG2_PSIZE_1024_Val    << USBC_UPCFG2_PSIZE_Pos)
+#define USBC_UPCFG2_PTOKEN_Pos      8            /**< \brief (USBC_UPCFG2) Pipe Token */
+#define USBC_UPCFG2_PTOKEN_Msk      (_U(0x3) << USBC_UPCFG2_PTOKEN_Pos)
+#define USBC_UPCFG2_PTOKEN(value)   (USBC_UPCFG2_PTOKEN_Msk & ((value) << USBC_UPCFG2_PTOKEN_Pos))
+#define   USBC_UPCFG2_PTOKEN_SETUP_Val    _U(0x0)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PTOKEN_IN_Val       _U(0x1)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PTOKEN_OUT_Val      _U(0x2)   /**< \brief (USBC_UPCFG2)  */
+#define USBC_UPCFG2_PTOKEN_SETUP    (USBC_UPCFG2_PTOKEN_SETUP_Val  << USBC_UPCFG2_PTOKEN_Pos)
+#define USBC_UPCFG2_PTOKEN_IN       (USBC_UPCFG2_PTOKEN_IN_Val     << USBC_UPCFG2_PTOKEN_Pos)
+#define USBC_UPCFG2_PTOKEN_OUT      (USBC_UPCFG2_PTOKEN_OUT_Val    << USBC_UPCFG2_PTOKEN_Pos)
+#define USBC_UPCFG2_PTYPE_Pos       12           /**< \brief (USBC_UPCFG2) Pipe Type */
+#define USBC_UPCFG2_PTYPE_Msk       (_U(0x3) << USBC_UPCFG2_PTYPE_Pos)
+#define USBC_UPCFG2_PTYPE(value)    (USBC_UPCFG2_PTYPE_Msk & ((value) << USBC_UPCFG2_PTYPE_Pos))
+#define   USBC_UPCFG2_PTYPE_CONTROL_Val   _U(0x0)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PTYPE_BULK_Val      _U(0x2)   /**< \brief (USBC_UPCFG2)  */
+#define   USBC_UPCFG2_PTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UPCFG2)  */
+#define USBC_UPCFG2_PTYPE_CONTROL   (USBC_UPCFG2_PTYPE_CONTROL_Val << USBC_UPCFG2_PTYPE_Pos)
+#define USBC_UPCFG2_PTYPE_ISOCHRONOUS (USBC_UPCFG2_PTYPE_ISOCHRONOUS_Val << USBC_UPCFG2_PTYPE_Pos)
+#define USBC_UPCFG2_PTYPE_BULK      (USBC_UPCFG2_PTYPE_BULK_Val    << USBC_UPCFG2_PTYPE_Pos)
+#define USBC_UPCFG2_PTYPE_INTERRUPT (USBC_UPCFG2_PTYPE_INTERRUPT_Val << USBC_UPCFG2_PTYPE_Pos)
+#define USBC_UPCFG2_PINGEN_Pos      20           /**< \brief (USBC_UPCFG2) Ping Enable */
+#define USBC_UPCFG2_PINGEN          (_U(0x1) << USBC_UPCFG2_PINGEN_Pos)
+#define USBC_UPCFG2_BINTERVAL_Pos   24           /**< \brief (USBC_UPCFG2) binterval parameter */
+#define USBC_UPCFG2_BINTERVAL_Msk   (_U(0xFF) << USBC_UPCFG2_BINTERVAL_Pos)
+#define USBC_UPCFG2_BINTERVAL(value) (USBC_UPCFG2_BINTERVAL_Msk & ((value) << USBC_UPCFG2_BINTERVAL_Pos))
+#define USBC_UPCFG2_MASK            _U(0xFF103374) /**< \brief (USBC_UPCFG2) MASK Register */
+
+/* -------- USBC_UPCFG3 : (USBC Offset: 0x50C) (R/W 32) Pipe Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t PBK:1;            /*!< bit:      2  Pipe Banks                         */
+    uint32_t :1;               /*!< bit:      3  Reserved                           */
+    uint32_t PSIZE:3;          /*!< bit:  4.. 6  Pipe Size                          */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t PTOKEN:2;         /*!< bit:  8.. 9  Pipe Token                         */
+    uint32_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint32_t PTYPE:2;          /*!< bit: 12..13  Pipe Type                          */
+    uint32_t :6;               /*!< bit: 14..19  Reserved                           */
+    uint32_t PINGEN:1;         /*!< bit:     20  Ping Enable                        */
+    uint32_t :3;               /*!< bit: 21..23  Reserved                           */
+    uint32_t BINTERVAL:8;      /*!< bit: 24..31  binterval parameter                */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCFG3_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCFG3_OFFSET          0x50C        /**< \brief (USBC_UPCFG3 offset) Pipe Configuration Register */
+#define USBC_UPCFG3_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCFG3 reset_value) Pipe Configuration Register */
+
+#define USBC_UPCFG3_PBK_Pos         2            /**< \brief (USBC_UPCFG3) Pipe Banks */
+#define USBC_UPCFG3_PBK             (_U(0x1) << USBC_UPCFG3_PBK_Pos)
+#define   USBC_UPCFG3_PBK_SINGLE_Val      _U(0x0)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PBK_DOUBLE_Val      _U(0x1)   /**< \brief (USBC_UPCFG3)  */
+#define USBC_UPCFG3_PBK_SINGLE      (USBC_UPCFG3_PBK_SINGLE_Val    << USBC_UPCFG3_PBK_Pos)
+#define USBC_UPCFG3_PBK_DOUBLE      (USBC_UPCFG3_PBK_DOUBLE_Val    << USBC_UPCFG3_PBK_Pos)
+#define USBC_UPCFG3_PSIZE_Pos       4            /**< \brief (USBC_UPCFG3) Pipe Size */
+#define USBC_UPCFG3_PSIZE_Msk       (_U(0x7) << USBC_UPCFG3_PSIZE_Pos)
+#define USBC_UPCFG3_PSIZE(value)    (USBC_UPCFG3_PSIZE_Msk & ((value) << USBC_UPCFG3_PSIZE_Pos))
+#define   USBC_UPCFG3_PSIZE_8_Val         _U(0x0)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PSIZE_16_Val        _U(0x1)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PSIZE_32_Val        _U(0x2)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PSIZE_64_Val        _U(0x3)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PSIZE_128_Val       _U(0x4)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PSIZE_256_Val       _U(0x5)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PSIZE_512_Val       _U(0x6)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PSIZE_1024_Val      _U(0x7)   /**< \brief (USBC_UPCFG3)  */
+#define USBC_UPCFG3_PSIZE_8         (USBC_UPCFG3_PSIZE_8_Val       << USBC_UPCFG3_PSIZE_Pos)
+#define USBC_UPCFG3_PSIZE_16        (USBC_UPCFG3_PSIZE_16_Val      << USBC_UPCFG3_PSIZE_Pos)
+#define USBC_UPCFG3_PSIZE_32        (USBC_UPCFG3_PSIZE_32_Val      << USBC_UPCFG3_PSIZE_Pos)
+#define USBC_UPCFG3_PSIZE_64        (USBC_UPCFG3_PSIZE_64_Val      << USBC_UPCFG3_PSIZE_Pos)
+#define USBC_UPCFG3_PSIZE_128       (USBC_UPCFG3_PSIZE_128_Val     << USBC_UPCFG3_PSIZE_Pos)
+#define USBC_UPCFG3_PSIZE_256       (USBC_UPCFG3_PSIZE_256_Val     << USBC_UPCFG3_PSIZE_Pos)
+#define USBC_UPCFG3_PSIZE_512       (USBC_UPCFG3_PSIZE_512_Val     << USBC_UPCFG3_PSIZE_Pos)
+#define USBC_UPCFG3_PSIZE_1024      (USBC_UPCFG3_PSIZE_1024_Val    << USBC_UPCFG3_PSIZE_Pos)
+#define USBC_UPCFG3_PTOKEN_Pos      8            /**< \brief (USBC_UPCFG3) Pipe Token */
+#define USBC_UPCFG3_PTOKEN_Msk      (_U(0x3) << USBC_UPCFG3_PTOKEN_Pos)
+#define USBC_UPCFG3_PTOKEN(value)   (USBC_UPCFG3_PTOKEN_Msk & ((value) << USBC_UPCFG3_PTOKEN_Pos))
+#define   USBC_UPCFG3_PTOKEN_SETUP_Val    _U(0x0)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PTOKEN_IN_Val       _U(0x1)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PTOKEN_OUT_Val      _U(0x2)   /**< \brief (USBC_UPCFG3)  */
+#define USBC_UPCFG3_PTOKEN_SETUP    (USBC_UPCFG3_PTOKEN_SETUP_Val  << USBC_UPCFG3_PTOKEN_Pos)
+#define USBC_UPCFG3_PTOKEN_IN       (USBC_UPCFG3_PTOKEN_IN_Val     << USBC_UPCFG3_PTOKEN_Pos)
+#define USBC_UPCFG3_PTOKEN_OUT      (USBC_UPCFG3_PTOKEN_OUT_Val    << USBC_UPCFG3_PTOKEN_Pos)
+#define USBC_UPCFG3_PTYPE_Pos       12           /**< \brief (USBC_UPCFG3) Pipe Type */
+#define USBC_UPCFG3_PTYPE_Msk       (_U(0x3) << USBC_UPCFG3_PTYPE_Pos)
+#define USBC_UPCFG3_PTYPE(value)    (USBC_UPCFG3_PTYPE_Msk & ((value) << USBC_UPCFG3_PTYPE_Pos))
+#define   USBC_UPCFG3_PTYPE_CONTROL_Val   _U(0x0)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PTYPE_BULK_Val      _U(0x2)   /**< \brief (USBC_UPCFG3)  */
+#define   USBC_UPCFG3_PTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UPCFG3)  */
+#define USBC_UPCFG3_PTYPE_CONTROL   (USBC_UPCFG3_PTYPE_CONTROL_Val << USBC_UPCFG3_PTYPE_Pos)
+#define USBC_UPCFG3_PTYPE_ISOCHRONOUS (USBC_UPCFG3_PTYPE_ISOCHRONOUS_Val << USBC_UPCFG3_PTYPE_Pos)
+#define USBC_UPCFG3_PTYPE_BULK      (USBC_UPCFG3_PTYPE_BULK_Val    << USBC_UPCFG3_PTYPE_Pos)
+#define USBC_UPCFG3_PTYPE_INTERRUPT (USBC_UPCFG3_PTYPE_INTERRUPT_Val << USBC_UPCFG3_PTYPE_Pos)
+#define USBC_UPCFG3_PINGEN_Pos      20           /**< \brief (USBC_UPCFG3) Ping Enable */
+#define USBC_UPCFG3_PINGEN          (_U(0x1) << USBC_UPCFG3_PINGEN_Pos)
+#define USBC_UPCFG3_BINTERVAL_Pos   24           /**< \brief (USBC_UPCFG3) binterval parameter */
+#define USBC_UPCFG3_BINTERVAL_Msk   (_U(0xFF) << USBC_UPCFG3_BINTERVAL_Pos)
+#define USBC_UPCFG3_BINTERVAL(value) (USBC_UPCFG3_BINTERVAL_Msk & ((value) << USBC_UPCFG3_BINTERVAL_Pos))
+#define USBC_UPCFG3_MASK            _U(0xFF103374) /**< \brief (USBC_UPCFG3) MASK Register */
+
+/* -------- USBC_UPCFG4 : (USBC Offset: 0x510) (R/W 32) Pipe Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t PBK:1;            /*!< bit:      2  Pipe Banks                         */
+    uint32_t :1;               /*!< bit:      3  Reserved                           */
+    uint32_t PSIZE:3;          /*!< bit:  4.. 6  Pipe Size                          */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t PTOKEN:2;         /*!< bit:  8.. 9  Pipe Token                         */
+    uint32_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint32_t PTYPE:2;          /*!< bit: 12..13  Pipe Type                          */
+    uint32_t :6;               /*!< bit: 14..19  Reserved                           */
+    uint32_t PINGEN:1;         /*!< bit:     20  Ping Enable                        */
+    uint32_t :3;               /*!< bit: 21..23  Reserved                           */
+    uint32_t BINTERVAL:8;      /*!< bit: 24..31  binterval parameter                */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCFG4_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCFG4_OFFSET          0x510        /**< \brief (USBC_UPCFG4 offset) Pipe Configuration Register */
+#define USBC_UPCFG4_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCFG4 reset_value) Pipe Configuration Register */
+
+#define USBC_UPCFG4_PBK_Pos         2            /**< \brief (USBC_UPCFG4) Pipe Banks */
+#define USBC_UPCFG4_PBK             (_U(0x1) << USBC_UPCFG4_PBK_Pos)
+#define   USBC_UPCFG4_PBK_SINGLE_Val      _U(0x0)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PBK_DOUBLE_Val      _U(0x1)   /**< \brief (USBC_UPCFG4)  */
+#define USBC_UPCFG4_PBK_SINGLE      (USBC_UPCFG4_PBK_SINGLE_Val    << USBC_UPCFG4_PBK_Pos)
+#define USBC_UPCFG4_PBK_DOUBLE      (USBC_UPCFG4_PBK_DOUBLE_Val    << USBC_UPCFG4_PBK_Pos)
+#define USBC_UPCFG4_PSIZE_Pos       4            /**< \brief (USBC_UPCFG4) Pipe Size */
+#define USBC_UPCFG4_PSIZE_Msk       (_U(0x7) << USBC_UPCFG4_PSIZE_Pos)
+#define USBC_UPCFG4_PSIZE(value)    (USBC_UPCFG4_PSIZE_Msk & ((value) << USBC_UPCFG4_PSIZE_Pos))
+#define   USBC_UPCFG4_PSIZE_8_Val         _U(0x0)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PSIZE_16_Val        _U(0x1)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PSIZE_32_Val        _U(0x2)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PSIZE_64_Val        _U(0x3)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PSIZE_128_Val       _U(0x4)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PSIZE_256_Val       _U(0x5)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PSIZE_512_Val       _U(0x6)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PSIZE_1024_Val      _U(0x7)   /**< \brief (USBC_UPCFG4)  */
+#define USBC_UPCFG4_PSIZE_8         (USBC_UPCFG4_PSIZE_8_Val       << USBC_UPCFG4_PSIZE_Pos)
+#define USBC_UPCFG4_PSIZE_16        (USBC_UPCFG4_PSIZE_16_Val      << USBC_UPCFG4_PSIZE_Pos)
+#define USBC_UPCFG4_PSIZE_32        (USBC_UPCFG4_PSIZE_32_Val      << USBC_UPCFG4_PSIZE_Pos)
+#define USBC_UPCFG4_PSIZE_64        (USBC_UPCFG4_PSIZE_64_Val      << USBC_UPCFG4_PSIZE_Pos)
+#define USBC_UPCFG4_PSIZE_128       (USBC_UPCFG4_PSIZE_128_Val     << USBC_UPCFG4_PSIZE_Pos)
+#define USBC_UPCFG4_PSIZE_256       (USBC_UPCFG4_PSIZE_256_Val     << USBC_UPCFG4_PSIZE_Pos)
+#define USBC_UPCFG4_PSIZE_512       (USBC_UPCFG4_PSIZE_512_Val     << USBC_UPCFG4_PSIZE_Pos)
+#define USBC_UPCFG4_PSIZE_1024      (USBC_UPCFG4_PSIZE_1024_Val    << USBC_UPCFG4_PSIZE_Pos)
+#define USBC_UPCFG4_PTOKEN_Pos      8            /**< \brief (USBC_UPCFG4) Pipe Token */
+#define USBC_UPCFG4_PTOKEN_Msk      (_U(0x3) << USBC_UPCFG4_PTOKEN_Pos)
+#define USBC_UPCFG4_PTOKEN(value)   (USBC_UPCFG4_PTOKEN_Msk & ((value) << USBC_UPCFG4_PTOKEN_Pos))
+#define   USBC_UPCFG4_PTOKEN_SETUP_Val    _U(0x0)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PTOKEN_IN_Val       _U(0x1)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PTOKEN_OUT_Val      _U(0x2)   /**< \brief (USBC_UPCFG4)  */
+#define USBC_UPCFG4_PTOKEN_SETUP    (USBC_UPCFG4_PTOKEN_SETUP_Val  << USBC_UPCFG4_PTOKEN_Pos)
+#define USBC_UPCFG4_PTOKEN_IN       (USBC_UPCFG4_PTOKEN_IN_Val     << USBC_UPCFG4_PTOKEN_Pos)
+#define USBC_UPCFG4_PTOKEN_OUT      (USBC_UPCFG4_PTOKEN_OUT_Val    << USBC_UPCFG4_PTOKEN_Pos)
+#define USBC_UPCFG4_PTYPE_Pos       12           /**< \brief (USBC_UPCFG4) Pipe Type */
+#define USBC_UPCFG4_PTYPE_Msk       (_U(0x3) << USBC_UPCFG4_PTYPE_Pos)
+#define USBC_UPCFG4_PTYPE(value)    (USBC_UPCFG4_PTYPE_Msk & ((value) << USBC_UPCFG4_PTYPE_Pos))
+#define   USBC_UPCFG4_PTYPE_CONTROL_Val   _U(0x0)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PTYPE_BULK_Val      _U(0x2)   /**< \brief (USBC_UPCFG4)  */
+#define   USBC_UPCFG4_PTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UPCFG4)  */
+#define USBC_UPCFG4_PTYPE_CONTROL   (USBC_UPCFG4_PTYPE_CONTROL_Val << USBC_UPCFG4_PTYPE_Pos)
+#define USBC_UPCFG4_PTYPE_ISOCHRONOUS (USBC_UPCFG4_PTYPE_ISOCHRONOUS_Val << USBC_UPCFG4_PTYPE_Pos)
+#define USBC_UPCFG4_PTYPE_BULK      (USBC_UPCFG4_PTYPE_BULK_Val    << USBC_UPCFG4_PTYPE_Pos)
+#define USBC_UPCFG4_PTYPE_INTERRUPT (USBC_UPCFG4_PTYPE_INTERRUPT_Val << USBC_UPCFG4_PTYPE_Pos)
+#define USBC_UPCFG4_PINGEN_Pos      20           /**< \brief (USBC_UPCFG4) Ping Enable */
+#define USBC_UPCFG4_PINGEN          (_U(0x1) << USBC_UPCFG4_PINGEN_Pos)
+#define USBC_UPCFG4_BINTERVAL_Pos   24           /**< \brief (USBC_UPCFG4) binterval parameter */
+#define USBC_UPCFG4_BINTERVAL_Msk   (_U(0xFF) << USBC_UPCFG4_BINTERVAL_Pos)
+#define USBC_UPCFG4_BINTERVAL(value) (USBC_UPCFG4_BINTERVAL_Msk & ((value) << USBC_UPCFG4_BINTERVAL_Pos))
+#define USBC_UPCFG4_MASK            _U(0xFF103374) /**< \brief (USBC_UPCFG4) MASK Register */
+
+/* -------- USBC_UPCFG5 : (USBC Offset: 0x514) (R/W 32) Pipe Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t PBK:1;            /*!< bit:      2  Pipe Banks                         */
+    uint32_t :1;               /*!< bit:      3  Reserved                           */
+    uint32_t PSIZE:3;          /*!< bit:  4.. 6  Pipe Size                          */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t PTOKEN:2;         /*!< bit:  8.. 9  Pipe Token                         */
+    uint32_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint32_t PTYPE:2;          /*!< bit: 12..13  Pipe Type                          */
+    uint32_t :6;               /*!< bit: 14..19  Reserved                           */
+    uint32_t PINGEN:1;         /*!< bit:     20  Ping Enable                        */
+    uint32_t :3;               /*!< bit: 21..23  Reserved                           */
+    uint32_t BINTERVAL:8;      /*!< bit: 24..31  binterval parameter                */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCFG5_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCFG5_OFFSET          0x514        /**< \brief (USBC_UPCFG5 offset) Pipe Configuration Register */
+#define USBC_UPCFG5_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCFG5 reset_value) Pipe Configuration Register */
+
+#define USBC_UPCFG5_PBK_Pos         2            /**< \brief (USBC_UPCFG5) Pipe Banks */
+#define USBC_UPCFG5_PBK             (_U(0x1) << USBC_UPCFG5_PBK_Pos)
+#define   USBC_UPCFG5_PBK_SINGLE_Val      _U(0x0)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PBK_DOUBLE_Val      _U(0x1)   /**< \brief (USBC_UPCFG5)  */
+#define USBC_UPCFG5_PBK_SINGLE      (USBC_UPCFG5_PBK_SINGLE_Val    << USBC_UPCFG5_PBK_Pos)
+#define USBC_UPCFG5_PBK_DOUBLE      (USBC_UPCFG5_PBK_DOUBLE_Val    << USBC_UPCFG5_PBK_Pos)
+#define USBC_UPCFG5_PSIZE_Pos       4            /**< \brief (USBC_UPCFG5) Pipe Size */
+#define USBC_UPCFG5_PSIZE_Msk       (_U(0x7) << USBC_UPCFG5_PSIZE_Pos)
+#define USBC_UPCFG5_PSIZE(value)    (USBC_UPCFG5_PSIZE_Msk & ((value) << USBC_UPCFG5_PSIZE_Pos))
+#define   USBC_UPCFG5_PSIZE_8_Val         _U(0x0)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PSIZE_16_Val        _U(0x1)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PSIZE_32_Val        _U(0x2)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PSIZE_64_Val        _U(0x3)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PSIZE_128_Val       _U(0x4)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PSIZE_256_Val       _U(0x5)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PSIZE_512_Val       _U(0x6)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PSIZE_1024_Val      _U(0x7)   /**< \brief (USBC_UPCFG5)  */
+#define USBC_UPCFG5_PSIZE_8         (USBC_UPCFG5_PSIZE_8_Val       << USBC_UPCFG5_PSIZE_Pos)
+#define USBC_UPCFG5_PSIZE_16        (USBC_UPCFG5_PSIZE_16_Val      << USBC_UPCFG5_PSIZE_Pos)
+#define USBC_UPCFG5_PSIZE_32        (USBC_UPCFG5_PSIZE_32_Val      << USBC_UPCFG5_PSIZE_Pos)
+#define USBC_UPCFG5_PSIZE_64        (USBC_UPCFG5_PSIZE_64_Val      << USBC_UPCFG5_PSIZE_Pos)
+#define USBC_UPCFG5_PSIZE_128       (USBC_UPCFG5_PSIZE_128_Val     << USBC_UPCFG5_PSIZE_Pos)
+#define USBC_UPCFG5_PSIZE_256       (USBC_UPCFG5_PSIZE_256_Val     << USBC_UPCFG5_PSIZE_Pos)
+#define USBC_UPCFG5_PSIZE_512       (USBC_UPCFG5_PSIZE_512_Val     << USBC_UPCFG5_PSIZE_Pos)
+#define USBC_UPCFG5_PSIZE_1024      (USBC_UPCFG5_PSIZE_1024_Val    << USBC_UPCFG5_PSIZE_Pos)
+#define USBC_UPCFG5_PTOKEN_Pos      8            /**< \brief (USBC_UPCFG5) Pipe Token */
+#define USBC_UPCFG5_PTOKEN_Msk      (_U(0x3) << USBC_UPCFG5_PTOKEN_Pos)
+#define USBC_UPCFG5_PTOKEN(value)   (USBC_UPCFG5_PTOKEN_Msk & ((value) << USBC_UPCFG5_PTOKEN_Pos))
+#define   USBC_UPCFG5_PTOKEN_SETUP_Val    _U(0x0)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PTOKEN_IN_Val       _U(0x1)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PTOKEN_OUT_Val      _U(0x2)   /**< \brief (USBC_UPCFG5)  */
+#define USBC_UPCFG5_PTOKEN_SETUP    (USBC_UPCFG5_PTOKEN_SETUP_Val  << USBC_UPCFG5_PTOKEN_Pos)
+#define USBC_UPCFG5_PTOKEN_IN       (USBC_UPCFG5_PTOKEN_IN_Val     << USBC_UPCFG5_PTOKEN_Pos)
+#define USBC_UPCFG5_PTOKEN_OUT      (USBC_UPCFG5_PTOKEN_OUT_Val    << USBC_UPCFG5_PTOKEN_Pos)
+#define USBC_UPCFG5_PTYPE_Pos       12           /**< \brief (USBC_UPCFG5) Pipe Type */
+#define USBC_UPCFG5_PTYPE_Msk       (_U(0x3) << USBC_UPCFG5_PTYPE_Pos)
+#define USBC_UPCFG5_PTYPE(value)    (USBC_UPCFG5_PTYPE_Msk & ((value) << USBC_UPCFG5_PTYPE_Pos))
+#define   USBC_UPCFG5_PTYPE_CONTROL_Val   _U(0x0)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PTYPE_BULK_Val      _U(0x2)   /**< \brief (USBC_UPCFG5)  */
+#define   USBC_UPCFG5_PTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UPCFG5)  */
+#define USBC_UPCFG5_PTYPE_CONTROL   (USBC_UPCFG5_PTYPE_CONTROL_Val << USBC_UPCFG5_PTYPE_Pos)
+#define USBC_UPCFG5_PTYPE_ISOCHRONOUS (USBC_UPCFG5_PTYPE_ISOCHRONOUS_Val << USBC_UPCFG5_PTYPE_Pos)
+#define USBC_UPCFG5_PTYPE_BULK      (USBC_UPCFG5_PTYPE_BULK_Val    << USBC_UPCFG5_PTYPE_Pos)
+#define USBC_UPCFG5_PTYPE_INTERRUPT (USBC_UPCFG5_PTYPE_INTERRUPT_Val << USBC_UPCFG5_PTYPE_Pos)
+#define USBC_UPCFG5_PINGEN_Pos      20           /**< \brief (USBC_UPCFG5) Ping Enable */
+#define USBC_UPCFG5_PINGEN          (_U(0x1) << USBC_UPCFG5_PINGEN_Pos)
+#define USBC_UPCFG5_BINTERVAL_Pos   24           /**< \brief (USBC_UPCFG5) binterval parameter */
+#define USBC_UPCFG5_BINTERVAL_Msk   (_U(0xFF) << USBC_UPCFG5_BINTERVAL_Pos)
+#define USBC_UPCFG5_BINTERVAL(value) (USBC_UPCFG5_BINTERVAL_Msk & ((value) << USBC_UPCFG5_BINTERVAL_Pos))
+#define USBC_UPCFG5_MASK            _U(0xFF103374) /**< \brief (USBC_UPCFG5) MASK Register */
+
+/* -------- USBC_UPCFG6 : (USBC Offset: 0x518) (R/W 32) Pipe Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t PBK:1;            /*!< bit:      2  Pipe Banks                         */
+    uint32_t :1;               /*!< bit:      3  Reserved                           */
+    uint32_t PSIZE:3;          /*!< bit:  4.. 6  Pipe Size                          */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t PTOKEN:2;         /*!< bit:  8.. 9  Pipe Token                         */
+    uint32_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint32_t PTYPE:2;          /*!< bit: 12..13  Pipe Type                          */
+    uint32_t :6;               /*!< bit: 14..19  Reserved                           */
+    uint32_t PINGEN:1;         /*!< bit:     20  Ping Enable                        */
+    uint32_t :3;               /*!< bit: 21..23  Reserved                           */
+    uint32_t BINTERVAL:8;      /*!< bit: 24..31  binterval parameter                */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCFG6_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCFG6_OFFSET          0x518        /**< \brief (USBC_UPCFG6 offset) Pipe Configuration Register */
+#define USBC_UPCFG6_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCFG6 reset_value) Pipe Configuration Register */
+
+#define USBC_UPCFG6_PBK_Pos         2            /**< \brief (USBC_UPCFG6) Pipe Banks */
+#define USBC_UPCFG6_PBK             (_U(0x1) << USBC_UPCFG6_PBK_Pos)
+#define   USBC_UPCFG6_PBK_SINGLE_Val      _U(0x0)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PBK_DOUBLE_Val      _U(0x1)   /**< \brief (USBC_UPCFG6)  */
+#define USBC_UPCFG6_PBK_SINGLE      (USBC_UPCFG6_PBK_SINGLE_Val    << USBC_UPCFG6_PBK_Pos)
+#define USBC_UPCFG6_PBK_DOUBLE      (USBC_UPCFG6_PBK_DOUBLE_Val    << USBC_UPCFG6_PBK_Pos)
+#define USBC_UPCFG6_PSIZE_Pos       4            /**< \brief (USBC_UPCFG6) Pipe Size */
+#define USBC_UPCFG6_PSIZE_Msk       (_U(0x7) << USBC_UPCFG6_PSIZE_Pos)
+#define USBC_UPCFG6_PSIZE(value)    (USBC_UPCFG6_PSIZE_Msk & ((value) << USBC_UPCFG6_PSIZE_Pos))
+#define   USBC_UPCFG6_PSIZE_8_Val         _U(0x0)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PSIZE_16_Val        _U(0x1)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PSIZE_32_Val        _U(0x2)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PSIZE_64_Val        _U(0x3)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PSIZE_128_Val       _U(0x4)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PSIZE_256_Val       _U(0x5)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PSIZE_512_Val       _U(0x6)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PSIZE_1024_Val      _U(0x7)   /**< \brief (USBC_UPCFG6)  */
+#define USBC_UPCFG6_PSIZE_8         (USBC_UPCFG6_PSIZE_8_Val       << USBC_UPCFG6_PSIZE_Pos)
+#define USBC_UPCFG6_PSIZE_16        (USBC_UPCFG6_PSIZE_16_Val      << USBC_UPCFG6_PSIZE_Pos)
+#define USBC_UPCFG6_PSIZE_32        (USBC_UPCFG6_PSIZE_32_Val      << USBC_UPCFG6_PSIZE_Pos)
+#define USBC_UPCFG6_PSIZE_64        (USBC_UPCFG6_PSIZE_64_Val      << USBC_UPCFG6_PSIZE_Pos)
+#define USBC_UPCFG6_PSIZE_128       (USBC_UPCFG6_PSIZE_128_Val     << USBC_UPCFG6_PSIZE_Pos)
+#define USBC_UPCFG6_PSIZE_256       (USBC_UPCFG6_PSIZE_256_Val     << USBC_UPCFG6_PSIZE_Pos)
+#define USBC_UPCFG6_PSIZE_512       (USBC_UPCFG6_PSIZE_512_Val     << USBC_UPCFG6_PSIZE_Pos)
+#define USBC_UPCFG6_PSIZE_1024      (USBC_UPCFG6_PSIZE_1024_Val    << USBC_UPCFG6_PSIZE_Pos)
+#define USBC_UPCFG6_PTOKEN_Pos      8            /**< \brief (USBC_UPCFG6) Pipe Token */
+#define USBC_UPCFG6_PTOKEN_Msk      (_U(0x3) << USBC_UPCFG6_PTOKEN_Pos)
+#define USBC_UPCFG6_PTOKEN(value)   (USBC_UPCFG6_PTOKEN_Msk & ((value) << USBC_UPCFG6_PTOKEN_Pos))
+#define   USBC_UPCFG6_PTOKEN_SETUP_Val    _U(0x0)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PTOKEN_IN_Val       _U(0x1)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PTOKEN_OUT_Val      _U(0x2)   /**< \brief (USBC_UPCFG6)  */
+#define USBC_UPCFG6_PTOKEN_SETUP    (USBC_UPCFG6_PTOKEN_SETUP_Val  << USBC_UPCFG6_PTOKEN_Pos)
+#define USBC_UPCFG6_PTOKEN_IN       (USBC_UPCFG6_PTOKEN_IN_Val     << USBC_UPCFG6_PTOKEN_Pos)
+#define USBC_UPCFG6_PTOKEN_OUT      (USBC_UPCFG6_PTOKEN_OUT_Val    << USBC_UPCFG6_PTOKEN_Pos)
+#define USBC_UPCFG6_PTYPE_Pos       12           /**< \brief (USBC_UPCFG6) Pipe Type */
+#define USBC_UPCFG6_PTYPE_Msk       (_U(0x3) << USBC_UPCFG6_PTYPE_Pos)
+#define USBC_UPCFG6_PTYPE(value)    (USBC_UPCFG6_PTYPE_Msk & ((value) << USBC_UPCFG6_PTYPE_Pos))
+#define   USBC_UPCFG6_PTYPE_CONTROL_Val   _U(0x0)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PTYPE_BULK_Val      _U(0x2)   /**< \brief (USBC_UPCFG6)  */
+#define   USBC_UPCFG6_PTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UPCFG6)  */
+#define USBC_UPCFG6_PTYPE_CONTROL   (USBC_UPCFG6_PTYPE_CONTROL_Val << USBC_UPCFG6_PTYPE_Pos)
+#define USBC_UPCFG6_PTYPE_ISOCHRONOUS (USBC_UPCFG6_PTYPE_ISOCHRONOUS_Val << USBC_UPCFG6_PTYPE_Pos)
+#define USBC_UPCFG6_PTYPE_BULK      (USBC_UPCFG6_PTYPE_BULK_Val    << USBC_UPCFG6_PTYPE_Pos)
+#define USBC_UPCFG6_PTYPE_INTERRUPT (USBC_UPCFG6_PTYPE_INTERRUPT_Val << USBC_UPCFG6_PTYPE_Pos)
+#define USBC_UPCFG6_PINGEN_Pos      20           /**< \brief (USBC_UPCFG6) Ping Enable */
+#define USBC_UPCFG6_PINGEN          (_U(0x1) << USBC_UPCFG6_PINGEN_Pos)
+#define USBC_UPCFG6_BINTERVAL_Pos   24           /**< \brief (USBC_UPCFG6) binterval parameter */
+#define USBC_UPCFG6_BINTERVAL_Msk   (_U(0xFF) << USBC_UPCFG6_BINTERVAL_Pos)
+#define USBC_UPCFG6_BINTERVAL(value) (USBC_UPCFG6_BINTERVAL_Msk & ((value) << USBC_UPCFG6_BINTERVAL_Pos))
+#define USBC_UPCFG6_MASK            _U(0xFF103374) /**< \brief (USBC_UPCFG6) MASK Register */
+
+/* -------- USBC_UPCFG7 : (USBC Offset: 0x51C) (R/W 32) Pipe Configuration Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t PBK:1;            /*!< bit:      2  Pipe Banks                         */
+    uint32_t :1;               /*!< bit:      3  Reserved                           */
+    uint32_t PSIZE:3;          /*!< bit:  4.. 6  Pipe Size                          */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t PTOKEN:2;         /*!< bit:  8.. 9  Pipe Token                         */
+    uint32_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint32_t PTYPE:2;          /*!< bit: 12..13  Pipe Type                          */
+    uint32_t :6;               /*!< bit: 14..19  Reserved                           */
+    uint32_t PINGEN:1;         /*!< bit:     20  Ping Enable                        */
+    uint32_t :3;               /*!< bit: 21..23  Reserved                           */
+    uint32_t BINTERVAL:8;      /*!< bit: 24..31  binterval parameter                */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCFG7_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCFG7_OFFSET          0x51C        /**< \brief (USBC_UPCFG7 offset) Pipe Configuration Register */
+#define USBC_UPCFG7_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCFG7 reset_value) Pipe Configuration Register */
+
+#define USBC_UPCFG7_PBK_Pos         2            /**< \brief (USBC_UPCFG7) Pipe Banks */
+#define USBC_UPCFG7_PBK             (_U(0x1) << USBC_UPCFG7_PBK_Pos)
+#define   USBC_UPCFG7_PBK_SINGLE_Val      _U(0x0)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PBK_DOUBLE_Val      _U(0x1)   /**< \brief (USBC_UPCFG7)  */
+#define USBC_UPCFG7_PBK_SINGLE      (USBC_UPCFG7_PBK_SINGLE_Val    << USBC_UPCFG7_PBK_Pos)
+#define USBC_UPCFG7_PBK_DOUBLE      (USBC_UPCFG7_PBK_DOUBLE_Val    << USBC_UPCFG7_PBK_Pos)
+#define USBC_UPCFG7_PSIZE_Pos       4            /**< \brief (USBC_UPCFG7) Pipe Size */
+#define USBC_UPCFG7_PSIZE_Msk       (_U(0x7) << USBC_UPCFG7_PSIZE_Pos)
+#define USBC_UPCFG7_PSIZE(value)    (USBC_UPCFG7_PSIZE_Msk & ((value) << USBC_UPCFG7_PSIZE_Pos))
+#define   USBC_UPCFG7_PSIZE_8_Val         _U(0x0)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PSIZE_16_Val        _U(0x1)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PSIZE_32_Val        _U(0x2)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PSIZE_64_Val        _U(0x3)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PSIZE_128_Val       _U(0x4)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PSIZE_256_Val       _U(0x5)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PSIZE_512_Val       _U(0x6)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PSIZE_1024_Val      _U(0x7)   /**< \brief (USBC_UPCFG7)  */
+#define USBC_UPCFG7_PSIZE_8         (USBC_UPCFG7_PSIZE_8_Val       << USBC_UPCFG7_PSIZE_Pos)
+#define USBC_UPCFG7_PSIZE_16        (USBC_UPCFG7_PSIZE_16_Val      << USBC_UPCFG7_PSIZE_Pos)
+#define USBC_UPCFG7_PSIZE_32        (USBC_UPCFG7_PSIZE_32_Val      << USBC_UPCFG7_PSIZE_Pos)
+#define USBC_UPCFG7_PSIZE_64        (USBC_UPCFG7_PSIZE_64_Val      << USBC_UPCFG7_PSIZE_Pos)
+#define USBC_UPCFG7_PSIZE_128       (USBC_UPCFG7_PSIZE_128_Val     << USBC_UPCFG7_PSIZE_Pos)
+#define USBC_UPCFG7_PSIZE_256       (USBC_UPCFG7_PSIZE_256_Val     << USBC_UPCFG7_PSIZE_Pos)
+#define USBC_UPCFG7_PSIZE_512       (USBC_UPCFG7_PSIZE_512_Val     << USBC_UPCFG7_PSIZE_Pos)
+#define USBC_UPCFG7_PSIZE_1024      (USBC_UPCFG7_PSIZE_1024_Val    << USBC_UPCFG7_PSIZE_Pos)
+#define USBC_UPCFG7_PTOKEN_Pos      8            /**< \brief (USBC_UPCFG7) Pipe Token */
+#define USBC_UPCFG7_PTOKEN_Msk      (_U(0x3) << USBC_UPCFG7_PTOKEN_Pos)
+#define USBC_UPCFG7_PTOKEN(value)   (USBC_UPCFG7_PTOKEN_Msk & ((value) << USBC_UPCFG7_PTOKEN_Pos))
+#define   USBC_UPCFG7_PTOKEN_SETUP_Val    _U(0x0)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PTOKEN_IN_Val       _U(0x1)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PTOKEN_OUT_Val      _U(0x2)   /**< \brief (USBC_UPCFG7)  */
+#define USBC_UPCFG7_PTOKEN_SETUP    (USBC_UPCFG7_PTOKEN_SETUP_Val  << USBC_UPCFG7_PTOKEN_Pos)
+#define USBC_UPCFG7_PTOKEN_IN       (USBC_UPCFG7_PTOKEN_IN_Val     << USBC_UPCFG7_PTOKEN_Pos)
+#define USBC_UPCFG7_PTOKEN_OUT      (USBC_UPCFG7_PTOKEN_OUT_Val    << USBC_UPCFG7_PTOKEN_Pos)
+#define USBC_UPCFG7_PTYPE_Pos       12           /**< \brief (USBC_UPCFG7) Pipe Type */
+#define USBC_UPCFG7_PTYPE_Msk       (_U(0x3) << USBC_UPCFG7_PTYPE_Pos)
+#define USBC_UPCFG7_PTYPE(value)    (USBC_UPCFG7_PTYPE_Msk & ((value) << USBC_UPCFG7_PTYPE_Pos))
+#define   USBC_UPCFG7_PTYPE_CONTROL_Val   _U(0x0)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PTYPE_ISOCHRONOUS_Val _U(0x1)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PTYPE_BULK_Val      _U(0x2)   /**< \brief (USBC_UPCFG7)  */
+#define   USBC_UPCFG7_PTYPE_INTERRUPT_Val _U(0x3)   /**< \brief (USBC_UPCFG7)  */
+#define USBC_UPCFG7_PTYPE_CONTROL   (USBC_UPCFG7_PTYPE_CONTROL_Val << USBC_UPCFG7_PTYPE_Pos)
+#define USBC_UPCFG7_PTYPE_ISOCHRONOUS (USBC_UPCFG7_PTYPE_ISOCHRONOUS_Val << USBC_UPCFG7_PTYPE_Pos)
+#define USBC_UPCFG7_PTYPE_BULK      (USBC_UPCFG7_PTYPE_BULK_Val    << USBC_UPCFG7_PTYPE_Pos)
+#define USBC_UPCFG7_PTYPE_INTERRUPT (USBC_UPCFG7_PTYPE_INTERRUPT_Val << USBC_UPCFG7_PTYPE_Pos)
+#define USBC_UPCFG7_PINGEN_Pos      20           /**< \brief (USBC_UPCFG7) Ping Enable */
+#define USBC_UPCFG7_PINGEN          (_U(0x1) << USBC_UPCFG7_PINGEN_Pos)
+#define USBC_UPCFG7_BINTERVAL_Pos   24           /**< \brief (USBC_UPCFG7) binterval parameter */
+#define USBC_UPCFG7_BINTERVAL_Msk   (_U(0xFF) << USBC_UPCFG7_BINTERVAL_Pos)
+#define USBC_UPCFG7_BINTERVAL(value) (USBC_UPCFG7_BINTERVAL_Msk & ((value) << USBC_UPCFG7_BINTERVAL_Pos))
+#define USBC_UPCFG7_MASK            _U(0xFF103374) /**< \brief (USBC_UPCFG7) MASK Register */
+
+/* -------- USBC_UPSTA0 : (USBC Offset: 0x530) (R/  32) Pipe Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINI:1;          /*!< bit:      0  Received IN Data Interrupt         */
+    uint32_t TXOUTI:1;         /*!< bit:      1  Transmitted OUT Data Interrupt     */
+    uint32_t TXSTPI:1;         /*!< bit:      2  Transmitted SETUP Interrupt        */
+    uint32_t PERRI:1;          /*!< bit:      3  Pipe Error Interrupt               */
+    uint32_t NAKEDI:1;         /*!< bit:      4  NAKed Interrupt                    */
+    uint32_t ERRORFI:1;        /*!< bit:      5  Errorflow Interrupt                */
+    uint32_t RXSTALLDI:1;      /*!< bit:      6  Received STALLed Interrupt         */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t DTSEQ:2;          /*!< bit:  8.. 9  Data Toggle Sequence               */
+    uint32_t RAMACERI:1;       /*!< bit:     10  Ram Access Error Interrupt         */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBK:2;        /*!< bit: 12..13  Number of Busy Bank                */
+    uint32_t CURRBK:2;         /*!< bit: 14..15  Current Bank                       */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPSTA0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPSTA0_OFFSET          0x530        /**< \brief (USBC_UPSTA0 offset) Pipe Status Register */
+#define USBC_UPSTA0_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPSTA0 reset_value) Pipe Status Register */
+
+#define USBC_UPSTA0_RXINI_Pos       0            /**< \brief (USBC_UPSTA0) Received IN Data Interrupt */
+#define USBC_UPSTA0_RXINI           (_U(0x1) << USBC_UPSTA0_RXINI_Pos)
+#define USBC_UPSTA0_TXOUTI_Pos      1            /**< \brief (USBC_UPSTA0) Transmitted OUT Data Interrupt */
+#define USBC_UPSTA0_TXOUTI          (_U(0x1) << USBC_UPSTA0_TXOUTI_Pos)
+#define USBC_UPSTA0_TXSTPI_Pos      2            /**< \brief (USBC_UPSTA0) Transmitted SETUP Interrupt */
+#define USBC_UPSTA0_TXSTPI          (_U(0x1) << USBC_UPSTA0_TXSTPI_Pos)
+#define USBC_UPSTA0_PERRI_Pos       3            /**< \brief (USBC_UPSTA0) Pipe Error Interrupt */
+#define USBC_UPSTA0_PERRI           (_U(0x1) << USBC_UPSTA0_PERRI_Pos)
+#define USBC_UPSTA0_NAKEDI_Pos      4            /**< \brief (USBC_UPSTA0) NAKed Interrupt */
+#define USBC_UPSTA0_NAKEDI          (_U(0x1) << USBC_UPSTA0_NAKEDI_Pos)
+#define USBC_UPSTA0_ERRORFI_Pos     5            /**< \brief (USBC_UPSTA0) Errorflow Interrupt */
+#define USBC_UPSTA0_ERRORFI         (_U(0x1) << USBC_UPSTA0_ERRORFI_Pos)
+#define USBC_UPSTA0_RXSTALLDI_Pos   6            /**< \brief (USBC_UPSTA0) Received STALLed Interrupt */
+#define USBC_UPSTA0_RXSTALLDI       (_U(0x1) << USBC_UPSTA0_RXSTALLDI_Pos)
+#define USBC_UPSTA0_DTSEQ_Pos       8            /**< \brief (USBC_UPSTA0) Data Toggle Sequence */
+#define USBC_UPSTA0_DTSEQ_Msk       (_U(0x3) << USBC_UPSTA0_DTSEQ_Pos)
+#define USBC_UPSTA0_DTSEQ(value)    (USBC_UPSTA0_DTSEQ_Msk & ((value) << USBC_UPSTA0_DTSEQ_Pos))
+#define USBC_UPSTA0_RAMACERI_Pos    10           /**< \brief (USBC_UPSTA0) Ram Access Error Interrupt */
+#define USBC_UPSTA0_RAMACERI        (_U(0x1) << USBC_UPSTA0_RAMACERI_Pos)
+#define USBC_UPSTA0_NBUSYBK_Pos     12           /**< \brief (USBC_UPSTA0) Number of Busy Bank */
+#define USBC_UPSTA0_NBUSYBK_Msk     (_U(0x3) << USBC_UPSTA0_NBUSYBK_Pos)
+#define USBC_UPSTA0_NBUSYBK(value)  (USBC_UPSTA0_NBUSYBK_Msk & ((value) << USBC_UPSTA0_NBUSYBK_Pos))
+#define USBC_UPSTA0_CURRBK_Pos      14           /**< \brief (USBC_UPSTA0) Current Bank */
+#define USBC_UPSTA0_CURRBK_Msk      (_U(0x3) << USBC_UPSTA0_CURRBK_Pos)
+#define USBC_UPSTA0_CURRBK(value)   (USBC_UPSTA0_CURRBK_Msk & ((value) << USBC_UPSTA0_CURRBK_Pos))
+#define USBC_UPSTA0_MASK            _U(0x0000F77F) /**< \brief (USBC_UPSTA0) MASK Register */
+
+/* -------- USBC_UPSTA1 : (USBC Offset: 0x534) (R/  32) Pipe Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINI:1;          /*!< bit:      0  Received IN Data Interrupt         */
+    uint32_t TXOUTI:1;         /*!< bit:      1  Transmitted OUT Data Interrupt     */
+    uint32_t TXSTPI:1;         /*!< bit:      2  Transmitted SETUP Interrupt        */
+    uint32_t PERRI:1;          /*!< bit:      3  Pipe Error Interrupt               */
+    uint32_t NAKEDI:1;         /*!< bit:      4  NAKed Interrupt                    */
+    uint32_t ERRORFI:1;        /*!< bit:      5  Errorflow Interrupt                */
+    uint32_t RXSTALLDI:1;      /*!< bit:      6  Received STALLed Interrupt         */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t DTSEQ:2;          /*!< bit:  8.. 9  Data Toggle Sequence               */
+    uint32_t RAMACERI:1;       /*!< bit:     10  Ram Access Error Interrupt         */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBK:2;        /*!< bit: 12..13  Number of Busy Bank                */
+    uint32_t CURRBK:2;         /*!< bit: 14..15  Current Bank                       */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPSTA1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPSTA1_OFFSET          0x534        /**< \brief (USBC_UPSTA1 offset) Pipe Status Register */
+#define USBC_UPSTA1_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPSTA1 reset_value) Pipe Status Register */
+
+#define USBC_UPSTA1_RXINI_Pos       0            /**< \brief (USBC_UPSTA1) Received IN Data Interrupt */
+#define USBC_UPSTA1_RXINI           (_U(0x1) << USBC_UPSTA1_RXINI_Pos)
+#define USBC_UPSTA1_TXOUTI_Pos      1            /**< \brief (USBC_UPSTA1) Transmitted OUT Data Interrupt */
+#define USBC_UPSTA1_TXOUTI          (_U(0x1) << USBC_UPSTA1_TXOUTI_Pos)
+#define USBC_UPSTA1_TXSTPI_Pos      2            /**< \brief (USBC_UPSTA1) Transmitted SETUP Interrupt */
+#define USBC_UPSTA1_TXSTPI          (_U(0x1) << USBC_UPSTA1_TXSTPI_Pos)
+#define USBC_UPSTA1_PERRI_Pos       3            /**< \brief (USBC_UPSTA1) Pipe Error Interrupt */
+#define USBC_UPSTA1_PERRI           (_U(0x1) << USBC_UPSTA1_PERRI_Pos)
+#define USBC_UPSTA1_NAKEDI_Pos      4            /**< \brief (USBC_UPSTA1) NAKed Interrupt */
+#define USBC_UPSTA1_NAKEDI          (_U(0x1) << USBC_UPSTA1_NAKEDI_Pos)
+#define USBC_UPSTA1_ERRORFI_Pos     5            /**< \brief (USBC_UPSTA1) Errorflow Interrupt */
+#define USBC_UPSTA1_ERRORFI         (_U(0x1) << USBC_UPSTA1_ERRORFI_Pos)
+#define USBC_UPSTA1_RXSTALLDI_Pos   6            /**< \brief (USBC_UPSTA1) Received STALLed Interrupt */
+#define USBC_UPSTA1_RXSTALLDI       (_U(0x1) << USBC_UPSTA1_RXSTALLDI_Pos)
+#define USBC_UPSTA1_DTSEQ_Pos       8            /**< \brief (USBC_UPSTA1) Data Toggle Sequence */
+#define USBC_UPSTA1_DTSEQ_Msk       (_U(0x3) << USBC_UPSTA1_DTSEQ_Pos)
+#define USBC_UPSTA1_DTSEQ(value)    (USBC_UPSTA1_DTSEQ_Msk & ((value) << USBC_UPSTA1_DTSEQ_Pos))
+#define USBC_UPSTA1_RAMACERI_Pos    10           /**< \brief (USBC_UPSTA1) Ram Access Error Interrupt */
+#define USBC_UPSTA1_RAMACERI        (_U(0x1) << USBC_UPSTA1_RAMACERI_Pos)
+#define USBC_UPSTA1_NBUSYBK_Pos     12           /**< \brief (USBC_UPSTA1) Number of Busy Bank */
+#define USBC_UPSTA1_NBUSYBK_Msk     (_U(0x3) << USBC_UPSTA1_NBUSYBK_Pos)
+#define USBC_UPSTA1_NBUSYBK(value)  (USBC_UPSTA1_NBUSYBK_Msk & ((value) << USBC_UPSTA1_NBUSYBK_Pos))
+#define USBC_UPSTA1_CURRBK_Pos      14           /**< \brief (USBC_UPSTA1) Current Bank */
+#define USBC_UPSTA1_CURRBK_Msk      (_U(0x3) << USBC_UPSTA1_CURRBK_Pos)
+#define USBC_UPSTA1_CURRBK(value)   (USBC_UPSTA1_CURRBK_Msk & ((value) << USBC_UPSTA1_CURRBK_Pos))
+#define USBC_UPSTA1_MASK            _U(0x0000F77F) /**< \brief (USBC_UPSTA1) MASK Register */
+
+/* -------- USBC_UPSTA2 : (USBC Offset: 0x538) (R/  32) Pipe Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINI:1;          /*!< bit:      0  Received IN Data Interrupt         */
+    uint32_t TXOUTI:1;         /*!< bit:      1  Transmitted OUT Data Interrupt     */
+    uint32_t TXSTPI:1;         /*!< bit:      2  Transmitted SETUP Interrupt        */
+    uint32_t PERRI:1;          /*!< bit:      3  Pipe Error Interrupt               */
+    uint32_t NAKEDI:1;         /*!< bit:      4  NAKed Interrupt                    */
+    uint32_t ERRORFI:1;        /*!< bit:      5  Errorflow Interrupt                */
+    uint32_t RXSTALLDI:1;      /*!< bit:      6  Received STALLed Interrupt         */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t DTSEQ:2;          /*!< bit:  8.. 9  Data Toggle Sequence               */
+    uint32_t RAMACERI:1;       /*!< bit:     10  Ram Access Error Interrupt         */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBK:2;        /*!< bit: 12..13  Number of Busy Bank                */
+    uint32_t CURRBK:2;         /*!< bit: 14..15  Current Bank                       */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPSTA2_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPSTA2_OFFSET          0x538        /**< \brief (USBC_UPSTA2 offset) Pipe Status Register */
+#define USBC_UPSTA2_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPSTA2 reset_value) Pipe Status Register */
+
+#define USBC_UPSTA2_RXINI_Pos       0            /**< \brief (USBC_UPSTA2) Received IN Data Interrupt */
+#define USBC_UPSTA2_RXINI           (_U(0x1) << USBC_UPSTA2_RXINI_Pos)
+#define USBC_UPSTA2_TXOUTI_Pos      1            /**< \brief (USBC_UPSTA2) Transmitted OUT Data Interrupt */
+#define USBC_UPSTA2_TXOUTI          (_U(0x1) << USBC_UPSTA2_TXOUTI_Pos)
+#define USBC_UPSTA2_TXSTPI_Pos      2            /**< \brief (USBC_UPSTA2) Transmitted SETUP Interrupt */
+#define USBC_UPSTA2_TXSTPI          (_U(0x1) << USBC_UPSTA2_TXSTPI_Pos)
+#define USBC_UPSTA2_PERRI_Pos       3            /**< \brief (USBC_UPSTA2) Pipe Error Interrupt */
+#define USBC_UPSTA2_PERRI           (_U(0x1) << USBC_UPSTA2_PERRI_Pos)
+#define USBC_UPSTA2_NAKEDI_Pos      4            /**< \brief (USBC_UPSTA2) NAKed Interrupt */
+#define USBC_UPSTA2_NAKEDI          (_U(0x1) << USBC_UPSTA2_NAKEDI_Pos)
+#define USBC_UPSTA2_ERRORFI_Pos     5            /**< \brief (USBC_UPSTA2) Errorflow Interrupt */
+#define USBC_UPSTA2_ERRORFI         (_U(0x1) << USBC_UPSTA2_ERRORFI_Pos)
+#define USBC_UPSTA2_RXSTALLDI_Pos   6            /**< \brief (USBC_UPSTA2) Received STALLed Interrupt */
+#define USBC_UPSTA2_RXSTALLDI       (_U(0x1) << USBC_UPSTA2_RXSTALLDI_Pos)
+#define USBC_UPSTA2_DTSEQ_Pos       8            /**< \brief (USBC_UPSTA2) Data Toggle Sequence */
+#define USBC_UPSTA2_DTSEQ_Msk       (_U(0x3) << USBC_UPSTA2_DTSEQ_Pos)
+#define USBC_UPSTA2_DTSEQ(value)    (USBC_UPSTA2_DTSEQ_Msk & ((value) << USBC_UPSTA2_DTSEQ_Pos))
+#define USBC_UPSTA2_RAMACERI_Pos    10           /**< \brief (USBC_UPSTA2) Ram Access Error Interrupt */
+#define USBC_UPSTA2_RAMACERI        (_U(0x1) << USBC_UPSTA2_RAMACERI_Pos)
+#define USBC_UPSTA2_NBUSYBK_Pos     12           /**< \brief (USBC_UPSTA2) Number of Busy Bank */
+#define USBC_UPSTA2_NBUSYBK_Msk     (_U(0x3) << USBC_UPSTA2_NBUSYBK_Pos)
+#define USBC_UPSTA2_NBUSYBK(value)  (USBC_UPSTA2_NBUSYBK_Msk & ((value) << USBC_UPSTA2_NBUSYBK_Pos))
+#define USBC_UPSTA2_CURRBK_Pos      14           /**< \brief (USBC_UPSTA2) Current Bank */
+#define USBC_UPSTA2_CURRBK_Msk      (_U(0x3) << USBC_UPSTA2_CURRBK_Pos)
+#define USBC_UPSTA2_CURRBK(value)   (USBC_UPSTA2_CURRBK_Msk & ((value) << USBC_UPSTA2_CURRBK_Pos))
+#define USBC_UPSTA2_MASK            _U(0x0000F77F) /**< \brief (USBC_UPSTA2) MASK Register */
+
+/* -------- USBC_UPSTA3 : (USBC Offset: 0x53C) (R/  32) Pipe Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINI:1;          /*!< bit:      0  Received IN Data Interrupt         */
+    uint32_t TXOUTI:1;         /*!< bit:      1  Transmitted OUT Data Interrupt     */
+    uint32_t TXSTPI:1;         /*!< bit:      2  Transmitted SETUP Interrupt        */
+    uint32_t PERRI:1;          /*!< bit:      3  Pipe Error Interrupt               */
+    uint32_t NAKEDI:1;         /*!< bit:      4  NAKed Interrupt                    */
+    uint32_t ERRORFI:1;        /*!< bit:      5  Errorflow Interrupt                */
+    uint32_t RXSTALLDI:1;      /*!< bit:      6  Received STALLed Interrupt         */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t DTSEQ:2;          /*!< bit:  8.. 9  Data Toggle Sequence               */
+    uint32_t RAMACERI:1;       /*!< bit:     10  Ram Access Error Interrupt         */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBK:2;        /*!< bit: 12..13  Number of Busy Bank                */
+    uint32_t CURRBK:2;         /*!< bit: 14..15  Current Bank                       */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPSTA3_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPSTA3_OFFSET          0x53C        /**< \brief (USBC_UPSTA3 offset) Pipe Status Register */
+#define USBC_UPSTA3_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPSTA3 reset_value) Pipe Status Register */
+
+#define USBC_UPSTA3_RXINI_Pos       0            /**< \brief (USBC_UPSTA3) Received IN Data Interrupt */
+#define USBC_UPSTA3_RXINI           (_U(0x1) << USBC_UPSTA3_RXINI_Pos)
+#define USBC_UPSTA3_TXOUTI_Pos      1            /**< \brief (USBC_UPSTA3) Transmitted OUT Data Interrupt */
+#define USBC_UPSTA3_TXOUTI          (_U(0x1) << USBC_UPSTA3_TXOUTI_Pos)
+#define USBC_UPSTA3_TXSTPI_Pos      2            /**< \brief (USBC_UPSTA3) Transmitted SETUP Interrupt */
+#define USBC_UPSTA3_TXSTPI          (_U(0x1) << USBC_UPSTA3_TXSTPI_Pos)
+#define USBC_UPSTA3_PERRI_Pos       3            /**< \brief (USBC_UPSTA3) Pipe Error Interrupt */
+#define USBC_UPSTA3_PERRI           (_U(0x1) << USBC_UPSTA3_PERRI_Pos)
+#define USBC_UPSTA3_NAKEDI_Pos      4            /**< \brief (USBC_UPSTA3) NAKed Interrupt */
+#define USBC_UPSTA3_NAKEDI          (_U(0x1) << USBC_UPSTA3_NAKEDI_Pos)
+#define USBC_UPSTA3_ERRORFI_Pos     5            /**< \brief (USBC_UPSTA3) Errorflow Interrupt */
+#define USBC_UPSTA3_ERRORFI         (_U(0x1) << USBC_UPSTA3_ERRORFI_Pos)
+#define USBC_UPSTA3_RXSTALLDI_Pos   6            /**< \brief (USBC_UPSTA3) Received STALLed Interrupt */
+#define USBC_UPSTA3_RXSTALLDI       (_U(0x1) << USBC_UPSTA3_RXSTALLDI_Pos)
+#define USBC_UPSTA3_DTSEQ_Pos       8            /**< \brief (USBC_UPSTA3) Data Toggle Sequence */
+#define USBC_UPSTA3_DTSEQ_Msk       (_U(0x3) << USBC_UPSTA3_DTSEQ_Pos)
+#define USBC_UPSTA3_DTSEQ(value)    (USBC_UPSTA3_DTSEQ_Msk & ((value) << USBC_UPSTA3_DTSEQ_Pos))
+#define USBC_UPSTA3_RAMACERI_Pos    10           /**< \brief (USBC_UPSTA3) Ram Access Error Interrupt */
+#define USBC_UPSTA3_RAMACERI        (_U(0x1) << USBC_UPSTA3_RAMACERI_Pos)
+#define USBC_UPSTA3_NBUSYBK_Pos     12           /**< \brief (USBC_UPSTA3) Number of Busy Bank */
+#define USBC_UPSTA3_NBUSYBK_Msk     (_U(0x3) << USBC_UPSTA3_NBUSYBK_Pos)
+#define USBC_UPSTA3_NBUSYBK(value)  (USBC_UPSTA3_NBUSYBK_Msk & ((value) << USBC_UPSTA3_NBUSYBK_Pos))
+#define USBC_UPSTA3_CURRBK_Pos      14           /**< \brief (USBC_UPSTA3) Current Bank */
+#define USBC_UPSTA3_CURRBK_Msk      (_U(0x3) << USBC_UPSTA3_CURRBK_Pos)
+#define USBC_UPSTA3_CURRBK(value)   (USBC_UPSTA3_CURRBK_Msk & ((value) << USBC_UPSTA3_CURRBK_Pos))
+#define USBC_UPSTA3_MASK            _U(0x0000F77F) /**< \brief (USBC_UPSTA3) MASK Register */
+
+/* -------- USBC_UPSTA4 : (USBC Offset: 0x540) (R/  32) Pipe Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINI:1;          /*!< bit:      0  Received IN Data Interrupt         */
+    uint32_t TXOUTI:1;         /*!< bit:      1  Transmitted OUT Data Interrupt     */
+    uint32_t TXSTPI:1;         /*!< bit:      2  Transmitted SETUP Interrupt        */
+    uint32_t PERRI:1;          /*!< bit:      3  Pipe Error Interrupt               */
+    uint32_t NAKEDI:1;         /*!< bit:      4  NAKed Interrupt                    */
+    uint32_t ERRORFI:1;        /*!< bit:      5  Errorflow Interrupt                */
+    uint32_t RXSTALLDI:1;      /*!< bit:      6  Received STALLed Interrupt         */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t DTSEQ:2;          /*!< bit:  8.. 9  Data Toggle Sequence               */
+    uint32_t RAMACERI:1;       /*!< bit:     10  Ram Access Error Interrupt         */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBK:2;        /*!< bit: 12..13  Number of Busy Bank                */
+    uint32_t CURRBK:2;         /*!< bit: 14..15  Current Bank                       */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPSTA4_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPSTA4_OFFSET          0x540        /**< \brief (USBC_UPSTA4 offset) Pipe Status Register */
+#define USBC_UPSTA4_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPSTA4 reset_value) Pipe Status Register */
+
+#define USBC_UPSTA4_RXINI_Pos       0            /**< \brief (USBC_UPSTA4) Received IN Data Interrupt */
+#define USBC_UPSTA4_RXINI           (_U(0x1) << USBC_UPSTA4_RXINI_Pos)
+#define USBC_UPSTA4_TXOUTI_Pos      1            /**< \brief (USBC_UPSTA4) Transmitted OUT Data Interrupt */
+#define USBC_UPSTA4_TXOUTI          (_U(0x1) << USBC_UPSTA4_TXOUTI_Pos)
+#define USBC_UPSTA4_TXSTPI_Pos      2            /**< \brief (USBC_UPSTA4) Transmitted SETUP Interrupt */
+#define USBC_UPSTA4_TXSTPI          (_U(0x1) << USBC_UPSTA4_TXSTPI_Pos)
+#define USBC_UPSTA4_PERRI_Pos       3            /**< \brief (USBC_UPSTA4) Pipe Error Interrupt */
+#define USBC_UPSTA4_PERRI           (_U(0x1) << USBC_UPSTA4_PERRI_Pos)
+#define USBC_UPSTA4_NAKEDI_Pos      4            /**< \brief (USBC_UPSTA4) NAKed Interrupt */
+#define USBC_UPSTA4_NAKEDI          (_U(0x1) << USBC_UPSTA4_NAKEDI_Pos)
+#define USBC_UPSTA4_ERRORFI_Pos     5            /**< \brief (USBC_UPSTA4) Errorflow Interrupt */
+#define USBC_UPSTA4_ERRORFI         (_U(0x1) << USBC_UPSTA4_ERRORFI_Pos)
+#define USBC_UPSTA4_RXSTALLDI_Pos   6            /**< \brief (USBC_UPSTA4) Received STALLed Interrupt */
+#define USBC_UPSTA4_RXSTALLDI       (_U(0x1) << USBC_UPSTA4_RXSTALLDI_Pos)
+#define USBC_UPSTA4_DTSEQ_Pos       8            /**< \brief (USBC_UPSTA4) Data Toggle Sequence */
+#define USBC_UPSTA4_DTSEQ_Msk       (_U(0x3) << USBC_UPSTA4_DTSEQ_Pos)
+#define USBC_UPSTA4_DTSEQ(value)    (USBC_UPSTA4_DTSEQ_Msk & ((value) << USBC_UPSTA4_DTSEQ_Pos))
+#define USBC_UPSTA4_RAMACERI_Pos    10           /**< \brief (USBC_UPSTA4) Ram Access Error Interrupt */
+#define USBC_UPSTA4_RAMACERI        (_U(0x1) << USBC_UPSTA4_RAMACERI_Pos)
+#define USBC_UPSTA4_NBUSYBK_Pos     12           /**< \brief (USBC_UPSTA4) Number of Busy Bank */
+#define USBC_UPSTA4_NBUSYBK_Msk     (_U(0x3) << USBC_UPSTA4_NBUSYBK_Pos)
+#define USBC_UPSTA4_NBUSYBK(value)  (USBC_UPSTA4_NBUSYBK_Msk & ((value) << USBC_UPSTA4_NBUSYBK_Pos))
+#define USBC_UPSTA4_CURRBK_Pos      14           /**< \brief (USBC_UPSTA4) Current Bank */
+#define USBC_UPSTA4_CURRBK_Msk      (_U(0x3) << USBC_UPSTA4_CURRBK_Pos)
+#define USBC_UPSTA4_CURRBK(value)   (USBC_UPSTA4_CURRBK_Msk & ((value) << USBC_UPSTA4_CURRBK_Pos))
+#define USBC_UPSTA4_MASK            _U(0x0000F77F) /**< \brief (USBC_UPSTA4) MASK Register */
+
+/* -------- USBC_UPSTA5 : (USBC Offset: 0x544) (R/  32) Pipe Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINI:1;          /*!< bit:      0  Received IN Data Interrupt         */
+    uint32_t TXOUTI:1;         /*!< bit:      1  Transmitted OUT Data Interrupt     */
+    uint32_t TXSTPI:1;         /*!< bit:      2  Transmitted SETUP Interrupt        */
+    uint32_t PERRI:1;          /*!< bit:      3  Pipe Error Interrupt               */
+    uint32_t NAKEDI:1;         /*!< bit:      4  NAKed Interrupt                    */
+    uint32_t ERRORFI:1;        /*!< bit:      5  Errorflow Interrupt                */
+    uint32_t RXSTALLDI:1;      /*!< bit:      6  Received STALLed Interrupt         */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t DTSEQ:2;          /*!< bit:  8.. 9  Data Toggle Sequence               */
+    uint32_t RAMACERI:1;       /*!< bit:     10  Ram Access Error Interrupt         */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBK:2;        /*!< bit: 12..13  Number of Busy Bank                */
+    uint32_t CURRBK:2;         /*!< bit: 14..15  Current Bank                       */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPSTA5_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPSTA5_OFFSET          0x544        /**< \brief (USBC_UPSTA5 offset) Pipe Status Register */
+#define USBC_UPSTA5_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPSTA5 reset_value) Pipe Status Register */
+
+#define USBC_UPSTA5_RXINI_Pos       0            /**< \brief (USBC_UPSTA5) Received IN Data Interrupt */
+#define USBC_UPSTA5_RXINI           (_U(0x1) << USBC_UPSTA5_RXINI_Pos)
+#define USBC_UPSTA5_TXOUTI_Pos      1            /**< \brief (USBC_UPSTA5) Transmitted OUT Data Interrupt */
+#define USBC_UPSTA5_TXOUTI          (_U(0x1) << USBC_UPSTA5_TXOUTI_Pos)
+#define USBC_UPSTA5_TXSTPI_Pos      2            /**< \brief (USBC_UPSTA5) Transmitted SETUP Interrupt */
+#define USBC_UPSTA5_TXSTPI          (_U(0x1) << USBC_UPSTA5_TXSTPI_Pos)
+#define USBC_UPSTA5_PERRI_Pos       3            /**< \brief (USBC_UPSTA5) Pipe Error Interrupt */
+#define USBC_UPSTA5_PERRI           (_U(0x1) << USBC_UPSTA5_PERRI_Pos)
+#define USBC_UPSTA5_NAKEDI_Pos      4            /**< \brief (USBC_UPSTA5) NAKed Interrupt */
+#define USBC_UPSTA5_NAKEDI          (_U(0x1) << USBC_UPSTA5_NAKEDI_Pos)
+#define USBC_UPSTA5_ERRORFI_Pos     5            /**< \brief (USBC_UPSTA5) Errorflow Interrupt */
+#define USBC_UPSTA5_ERRORFI         (_U(0x1) << USBC_UPSTA5_ERRORFI_Pos)
+#define USBC_UPSTA5_RXSTALLDI_Pos   6            /**< \brief (USBC_UPSTA5) Received STALLed Interrupt */
+#define USBC_UPSTA5_RXSTALLDI       (_U(0x1) << USBC_UPSTA5_RXSTALLDI_Pos)
+#define USBC_UPSTA5_DTSEQ_Pos       8            /**< \brief (USBC_UPSTA5) Data Toggle Sequence */
+#define USBC_UPSTA5_DTSEQ_Msk       (_U(0x3) << USBC_UPSTA5_DTSEQ_Pos)
+#define USBC_UPSTA5_DTSEQ(value)    (USBC_UPSTA5_DTSEQ_Msk & ((value) << USBC_UPSTA5_DTSEQ_Pos))
+#define USBC_UPSTA5_RAMACERI_Pos    10           /**< \brief (USBC_UPSTA5) Ram Access Error Interrupt */
+#define USBC_UPSTA5_RAMACERI        (_U(0x1) << USBC_UPSTA5_RAMACERI_Pos)
+#define USBC_UPSTA5_NBUSYBK_Pos     12           /**< \brief (USBC_UPSTA5) Number of Busy Bank */
+#define USBC_UPSTA5_NBUSYBK_Msk     (_U(0x3) << USBC_UPSTA5_NBUSYBK_Pos)
+#define USBC_UPSTA5_NBUSYBK(value)  (USBC_UPSTA5_NBUSYBK_Msk & ((value) << USBC_UPSTA5_NBUSYBK_Pos))
+#define USBC_UPSTA5_CURRBK_Pos      14           /**< \brief (USBC_UPSTA5) Current Bank */
+#define USBC_UPSTA5_CURRBK_Msk      (_U(0x3) << USBC_UPSTA5_CURRBK_Pos)
+#define USBC_UPSTA5_CURRBK(value)   (USBC_UPSTA5_CURRBK_Msk & ((value) << USBC_UPSTA5_CURRBK_Pos))
+#define USBC_UPSTA5_MASK            _U(0x0000F77F) /**< \brief (USBC_UPSTA5) MASK Register */
+
+/* -------- USBC_UPSTA6 : (USBC Offset: 0x548) (R/  32) Pipe Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINI:1;          /*!< bit:      0  Received IN Data Interrupt         */
+    uint32_t TXOUTI:1;         /*!< bit:      1  Transmitted OUT Data Interrupt     */
+    uint32_t TXSTPI:1;         /*!< bit:      2  Transmitted SETUP Interrupt        */
+    uint32_t PERRI:1;          /*!< bit:      3  Pipe Error Interrupt               */
+    uint32_t NAKEDI:1;         /*!< bit:      4  NAKed Interrupt                    */
+    uint32_t ERRORFI:1;        /*!< bit:      5  Errorflow Interrupt                */
+    uint32_t RXSTALLDI:1;      /*!< bit:      6  Received STALLed Interrupt         */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t DTSEQ:2;          /*!< bit:  8.. 9  Data Toggle Sequence               */
+    uint32_t RAMACERI:1;       /*!< bit:     10  Ram Access Error Interrupt         */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBK:2;        /*!< bit: 12..13  Number of Busy Bank                */
+    uint32_t CURRBK:2;         /*!< bit: 14..15  Current Bank                       */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPSTA6_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPSTA6_OFFSET          0x548        /**< \brief (USBC_UPSTA6 offset) Pipe Status Register */
+#define USBC_UPSTA6_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPSTA6 reset_value) Pipe Status Register */
+
+#define USBC_UPSTA6_RXINI_Pos       0            /**< \brief (USBC_UPSTA6) Received IN Data Interrupt */
+#define USBC_UPSTA6_RXINI           (_U(0x1) << USBC_UPSTA6_RXINI_Pos)
+#define USBC_UPSTA6_TXOUTI_Pos      1            /**< \brief (USBC_UPSTA6) Transmitted OUT Data Interrupt */
+#define USBC_UPSTA6_TXOUTI          (_U(0x1) << USBC_UPSTA6_TXOUTI_Pos)
+#define USBC_UPSTA6_TXSTPI_Pos      2            /**< \brief (USBC_UPSTA6) Transmitted SETUP Interrupt */
+#define USBC_UPSTA6_TXSTPI          (_U(0x1) << USBC_UPSTA6_TXSTPI_Pos)
+#define USBC_UPSTA6_PERRI_Pos       3            /**< \brief (USBC_UPSTA6) Pipe Error Interrupt */
+#define USBC_UPSTA6_PERRI           (_U(0x1) << USBC_UPSTA6_PERRI_Pos)
+#define USBC_UPSTA6_NAKEDI_Pos      4            /**< \brief (USBC_UPSTA6) NAKed Interrupt */
+#define USBC_UPSTA6_NAKEDI          (_U(0x1) << USBC_UPSTA6_NAKEDI_Pos)
+#define USBC_UPSTA6_ERRORFI_Pos     5            /**< \brief (USBC_UPSTA6) Errorflow Interrupt */
+#define USBC_UPSTA6_ERRORFI         (_U(0x1) << USBC_UPSTA6_ERRORFI_Pos)
+#define USBC_UPSTA6_RXSTALLDI_Pos   6            /**< \brief (USBC_UPSTA6) Received STALLed Interrupt */
+#define USBC_UPSTA6_RXSTALLDI       (_U(0x1) << USBC_UPSTA6_RXSTALLDI_Pos)
+#define USBC_UPSTA6_DTSEQ_Pos       8            /**< \brief (USBC_UPSTA6) Data Toggle Sequence */
+#define USBC_UPSTA6_DTSEQ_Msk       (_U(0x3) << USBC_UPSTA6_DTSEQ_Pos)
+#define USBC_UPSTA6_DTSEQ(value)    (USBC_UPSTA6_DTSEQ_Msk & ((value) << USBC_UPSTA6_DTSEQ_Pos))
+#define USBC_UPSTA6_RAMACERI_Pos    10           /**< \brief (USBC_UPSTA6) Ram Access Error Interrupt */
+#define USBC_UPSTA6_RAMACERI        (_U(0x1) << USBC_UPSTA6_RAMACERI_Pos)
+#define USBC_UPSTA6_NBUSYBK_Pos     12           /**< \brief (USBC_UPSTA6) Number of Busy Bank */
+#define USBC_UPSTA6_NBUSYBK_Msk     (_U(0x3) << USBC_UPSTA6_NBUSYBK_Pos)
+#define USBC_UPSTA6_NBUSYBK(value)  (USBC_UPSTA6_NBUSYBK_Msk & ((value) << USBC_UPSTA6_NBUSYBK_Pos))
+#define USBC_UPSTA6_CURRBK_Pos      14           /**< \brief (USBC_UPSTA6) Current Bank */
+#define USBC_UPSTA6_CURRBK_Msk      (_U(0x3) << USBC_UPSTA6_CURRBK_Pos)
+#define USBC_UPSTA6_CURRBK(value)   (USBC_UPSTA6_CURRBK_Msk & ((value) << USBC_UPSTA6_CURRBK_Pos))
+#define USBC_UPSTA6_MASK            _U(0x0000F77F) /**< \brief (USBC_UPSTA6) MASK Register */
+
+/* -------- USBC_UPSTA7 : (USBC Offset: 0x54C) (R/  32) Pipe Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINI:1;          /*!< bit:      0  Received IN Data Interrupt         */
+    uint32_t TXOUTI:1;         /*!< bit:      1  Transmitted OUT Data Interrupt     */
+    uint32_t TXSTPI:1;         /*!< bit:      2  Transmitted SETUP Interrupt        */
+    uint32_t PERRI:1;          /*!< bit:      3  Pipe Error Interrupt               */
+    uint32_t NAKEDI:1;         /*!< bit:      4  NAKed Interrupt                    */
+    uint32_t ERRORFI:1;        /*!< bit:      5  Errorflow Interrupt                */
+    uint32_t RXSTALLDI:1;      /*!< bit:      6  Received STALLed Interrupt         */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t DTSEQ:2;          /*!< bit:  8.. 9  Data Toggle Sequence               */
+    uint32_t RAMACERI:1;       /*!< bit:     10  Ram Access Error Interrupt         */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBK:2;        /*!< bit: 12..13  Number of Busy Bank                */
+    uint32_t CURRBK:2;         /*!< bit: 14..15  Current Bank                       */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPSTA7_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPSTA7_OFFSET          0x54C        /**< \brief (USBC_UPSTA7 offset) Pipe Status Register */
+#define USBC_UPSTA7_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPSTA7 reset_value) Pipe Status Register */
+
+#define USBC_UPSTA7_RXINI_Pos       0            /**< \brief (USBC_UPSTA7) Received IN Data Interrupt */
+#define USBC_UPSTA7_RXINI           (_U(0x1) << USBC_UPSTA7_RXINI_Pos)
+#define USBC_UPSTA7_TXOUTI_Pos      1            /**< \brief (USBC_UPSTA7) Transmitted OUT Data Interrupt */
+#define USBC_UPSTA7_TXOUTI          (_U(0x1) << USBC_UPSTA7_TXOUTI_Pos)
+#define USBC_UPSTA7_TXSTPI_Pos      2            /**< \brief (USBC_UPSTA7) Transmitted SETUP Interrupt */
+#define USBC_UPSTA7_TXSTPI          (_U(0x1) << USBC_UPSTA7_TXSTPI_Pos)
+#define USBC_UPSTA7_PERRI_Pos       3            /**< \brief (USBC_UPSTA7) Pipe Error Interrupt */
+#define USBC_UPSTA7_PERRI           (_U(0x1) << USBC_UPSTA7_PERRI_Pos)
+#define USBC_UPSTA7_NAKEDI_Pos      4            /**< \brief (USBC_UPSTA7) NAKed Interrupt */
+#define USBC_UPSTA7_NAKEDI          (_U(0x1) << USBC_UPSTA7_NAKEDI_Pos)
+#define USBC_UPSTA7_ERRORFI_Pos     5            /**< \brief (USBC_UPSTA7) Errorflow Interrupt */
+#define USBC_UPSTA7_ERRORFI         (_U(0x1) << USBC_UPSTA7_ERRORFI_Pos)
+#define USBC_UPSTA7_RXSTALLDI_Pos   6            /**< \brief (USBC_UPSTA7) Received STALLed Interrupt */
+#define USBC_UPSTA7_RXSTALLDI       (_U(0x1) << USBC_UPSTA7_RXSTALLDI_Pos)
+#define USBC_UPSTA7_DTSEQ_Pos       8            /**< \brief (USBC_UPSTA7) Data Toggle Sequence */
+#define USBC_UPSTA7_DTSEQ_Msk       (_U(0x3) << USBC_UPSTA7_DTSEQ_Pos)
+#define USBC_UPSTA7_DTSEQ(value)    (USBC_UPSTA7_DTSEQ_Msk & ((value) << USBC_UPSTA7_DTSEQ_Pos))
+#define USBC_UPSTA7_RAMACERI_Pos    10           /**< \brief (USBC_UPSTA7) Ram Access Error Interrupt */
+#define USBC_UPSTA7_RAMACERI        (_U(0x1) << USBC_UPSTA7_RAMACERI_Pos)
+#define USBC_UPSTA7_NBUSYBK_Pos     12           /**< \brief (USBC_UPSTA7) Number of Busy Bank */
+#define USBC_UPSTA7_NBUSYBK_Msk     (_U(0x3) << USBC_UPSTA7_NBUSYBK_Pos)
+#define USBC_UPSTA7_NBUSYBK(value)  (USBC_UPSTA7_NBUSYBK_Msk & ((value) << USBC_UPSTA7_NBUSYBK_Pos))
+#define USBC_UPSTA7_CURRBK_Pos      14           /**< \brief (USBC_UPSTA7) Current Bank */
+#define USBC_UPSTA7_CURRBK_Msk      (_U(0x3) << USBC_UPSTA7_CURRBK_Pos)
+#define USBC_UPSTA7_CURRBK(value)   (USBC_UPSTA7_CURRBK_Msk & ((value) << USBC_UPSTA7_CURRBK_Pos))
+#define USBC_UPSTA7_MASK            _U(0x0000F77F) /**< \brief (USBC_UPSTA7) MASK Register */
+
+/* -------- USBC_UPSTA0CLR : (USBC Offset: 0x560) ( /W 32) Pipe Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINIC:1;         /*!< bit:      0  RXINI Clear                        */
+    uint32_t TXOUTIC:1;        /*!< bit:      1  TXOUTI Clear                       */
+    uint32_t TXSTPIC:1;        /*!< bit:      2  TXSTPI Clear                       */
+    uint32_t PERRIC:1;         /*!< bit:      3  PERRI Clear                        */
+    uint32_t NAKEDIC:1;        /*!< bit:      4  NAKEDI Clear                       */
+    uint32_t ERRORFIC:1;       /*!< bit:      5  ERRORFI Clear                      */
+    uint32_t RXSTALLDIC:1;     /*!< bit:      6  RXSTALLDI Clear                    */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERIC:1;      /*!< bit:     10  RAMACERI Clear                     */
+    uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPSTA0CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPSTA0CLR_OFFSET       0x560        /**< \brief (USBC_UPSTA0CLR offset) Pipe Status Clear Register */
+#define USBC_UPSTA0CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA0CLR reset_value) Pipe Status Clear Register */
+
+#define USBC_UPSTA0CLR_RXINIC_Pos   0            /**< \brief (USBC_UPSTA0CLR) RXINI Clear */
+#define USBC_UPSTA0CLR_RXINIC       (_U(0x1) << USBC_UPSTA0CLR_RXINIC_Pos)
+#define USBC_UPSTA0CLR_TXOUTIC_Pos  1            /**< \brief (USBC_UPSTA0CLR) TXOUTI Clear */
+#define USBC_UPSTA0CLR_TXOUTIC      (_U(0x1) << USBC_UPSTA0CLR_TXOUTIC_Pos)
+#define USBC_UPSTA0CLR_TXSTPIC_Pos  2            /**< \brief (USBC_UPSTA0CLR) TXSTPI Clear */
+#define USBC_UPSTA0CLR_TXSTPIC      (_U(0x1) << USBC_UPSTA0CLR_TXSTPIC_Pos)
+#define USBC_UPSTA0CLR_PERRIC_Pos   3            /**< \brief (USBC_UPSTA0CLR) PERRI Clear */
+#define USBC_UPSTA0CLR_PERRIC       (_U(0x1) << USBC_UPSTA0CLR_PERRIC_Pos)
+#define USBC_UPSTA0CLR_NAKEDIC_Pos  4            /**< \brief (USBC_UPSTA0CLR) NAKEDI Clear */
+#define USBC_UPSTA0CLR_NAKEDIC      (_U(0x1) << USBC_UPSTA0CLR_NAKEDIC_Pos)
+#define USBC_UPSTA0CLR_ERRORFIC_Pos 5            /**< \brief (USBC_UPSTA0CLR) ERRORFI Clear */
+#define USBC_UPSTA0CLR_ERRORFIC     (_U(0x1) << USBC_UPSTA0CLR_ERRORFIC_Pos)
+#define USBC_UPSTA0CLR_RXSTALLDIC_Pos 6            /**< \brief (USBC_UPSTA0CLR) RXSTALLDI Clear */
+#define USBC_UPSTA0CLR_RXSTALLDIC   (_U(0x1) << USBC_UPSTA0CLR_RXSTALLDIC_Pos)
+#define USBC_UPSTA0CLR_RAMACERIC_Pos 10           /**< \brief (USBC_UPSTA0CLR) RAMACERI Clear */
+#define USBC_UPSTA0CLR_RAMACERIC    (_U(0x1) << USBC_UPSTA0CLR_RAMACERIC_Pos)
+#define USBC_UPSTA0CLR_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA0CLR) MASK Register */
+
+/* -------- USBC_UPSTA1CLR : (USBC Offset: 0x564) ( /W 32) Pipe Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINIC:1;         /*!< bit:      0  RXINI Clear                        */
+    uint32_t TXOUTIC:1;        /*!< bit:      1  TXOUTI Clear                       */
+    uint32_t TXSTPIC:1;        /*!< bit:      2  TXSTPI Clear                       */
+    uint32_t PERRIC:1;         /*!< bit:      3  PERRI Clear                        */
+    uint32_t NAKEDIC:1;        /*!< bit:      4  NAKEDI Clear                       */
+    uint32_t ERRORFIC:1;       /*!< bit:      5  ERRORFI Clear                      */
+    uint32_t RXSTALLDIC:1;     /*!< bit:      6  RXSTALLDI Clear                    */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERIC:1;      /*!< bit:     10  RAMACERI Clear                     */
+    uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPSTA1CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPSTA1CLR_OFFSET       0x564        /**< \brief (USBC_UPSTA1CLR offset) Pipe Status Clear Register */
+#define USBC_UPSTA1CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA1CLR reset_value) Pipe Status Clear Register */
+
+#define USBC_UPSTA1CLR_RXINIC_Pos   0            /**< \brief (USBC_UPSTA1CLR) RXINI Clear */
+#define USBC_UPSTA1CLR_RXINIC       (_U(0x1) << USBC_UPSTA1CLR_RXINIC_Pos)
+#define USBC_UPSTA1CLR_TXOUTIC_Pos  1            /**< \brief (USBC_UPSTA1CLR) TXOUTI Clear */
+#define USBC_UPSTA1CLR_TXOUTIC      (_U(0x1) << USBC_UPSTA1CLR_TXOUTIC_Pos)
+#define USBC_UPSTA1CLR_TXSTPIC_Pos  2            /**< \brief (USBC_UPSTA1CLR) TXSTPI Clear */
+#define USBC_UPSTA1CLR_TXSTPIC      (_U(0x1) << USBC_UPSTA1CLR_TXSTPIC_Pos)
+#define USBC_UPSTA1CLR_PERRIC_Pos   3            /**< \brief (USBC_UPSTA1CLR) PERRI Clear */
+#define USBC_UPSTA1CLR_PERRIC       (_U(0x1) << USBC_UPSTA1CLR_PERRIC_Pos)
+#define USBC_UPSTA1CLR_NAKEDIC_Pos  4            /**< \brief (USBC_UPSTA1CLR) NAKEDI Clear */
+#define USBC_UPSTA1CLR_NAKEDIC      (_U(0x1) << USBC_UPSTA1CLR_NAKEDIC_Pos)
+#define USBC_UPSTA1CLR_ERRORFIC_Pos 5            /**< \brief (USBC_UPSTA1CLR) ERRORFI Clear */
+#define USBC_UPSTA1CLR_ERRORFIC     (_U(0x1) << USBC_UPSTA1CLR_ERRORFIC_Pos)
+#define USBC_UPSTA1CLR_RXSTALLDIC_Pos 6            /**< \brief (USBC_UPSTA1CLR) RXSTALLDI Clear */
+#define USBC_UPSTA1CLR_RXSTALLDIC   (_U(0x1) << USBC_UPSTA1CLR_RXSTALLDIC_Pos)
+#define USBC_UPSTA1CLR_RAMACERIC_Pos 10           /**< \brief (USBC_UPSTA1CLR) RAMACERI Clear */
+#define USBC_UPSTA1CLR_RAMACERIC    (_U(0x1) << USBC_UPSTA1CLR_RAMACERIC_Pos)
+#define USBC_UPSTA1CLR_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA1CLR) MASK Register */
+
+/* -------- USBC_UPSTA2CLR : (USBC Offset: 0x568) ( /W 32) Pipe Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINIC:1;         /*!< bit:      0  RXINI Clear                        */
+    uint32_t TXOUTIC:1;        /*!< bit:      1  TXOUTI Clear                       */
+    uint32_t TXSTPIC:1;        /*!< bit:      2  TXSTPI Clear                       */
+    uint32_t PERRIC:1;         /*!< bit:      3  PERRI Clear                        */
+    uint32_t NAKEDIC:1;        /*!< bit:      4  NAKEDI Clear                       */
+    uint32_t ERRORFIC:1;       /*!< bit:      5  ERRORFI Clear                      */
+    uint32_t RXSTALLDIC:1;     /*!< bit:      6  RXSTALLDI Clear                    */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERIC:1;      /*!< bit:     10  RAMACERI Clear                     */
+    uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPSTA2CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPSTA2CLR_OFFSET       0x568        /**< \brief (USBC_UPSTA2CLR offset) Pipe Status Clear Register */
+#define USBC_UPSTA2CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA2CLR reset_value) Pipe Status Clear Register */
+
+#define USBC_UPSTA2CLR_RXINIC_Pos   0            /**< \brief (USBC_UPSTA2CLR) RXINI Clear */
+#define USBC_UPSTA2CLR_RXINIC       (_U(0x1) << USBC_UPSTA2CLR_RXINIC_Pos)
+#define USBC_UPSTA2CLR_TXOUTIC_Pos  1            /**< \brief (USBC_UPSTA2CLR) TXOUTI Clear */
+#define USBC_UPSTA2CLR_TXOUTIC      (_U(0x1) << USBC_UPSTA2CLR_TXOUTIC_Pos)
+#define USBC_UPSTA2CLR_TXSTPIC_Pos  2            /**< \brief (USBC_UPSTA2CLR) TXSTPI Clear */
+#define USBC_UPSTA2CLR_TXSTPIC      (_U(0x1) << USBC_UPSTA2CLR_TXSTPIC_Pos)
+#define USBC_UPSTA2CLR_PERRIC_Pos   3            /**< \brief (USBC_UPSTA2CLR) PERRI Clear */
+#define USBC_UPSTA2CLR_PERRIC       (_U(0x1) << USBC_UPSTA2CLR_PERRIC_Pos)
+#define USBC_UPSTA2CLR_NAKEDIC_Pos  4            /**< \brief (USBC_UPSTA2CLR) NAKEDI Clear */
+#define USBC_UPSTA2CLR_NAKEDIC      (_U(0x1) << USBC_UPSTA2CLR_NAKEDIC_Pos)
+#define USBC_UPSTA2CLR_ERRORFIC_Pos 5            /**< \brief (USBC_UPSTA2CLR) ERRORFI Clear */
+#define USBC_UPSTA2CLR_ERRORFIC     (_U(0x1) << USBC_UPSTA2CLR_ERRORFIC_Pos)
+#define USBC_UPSTA2CLR_RXSTALLDIC_Pos 6            /**< \brief (USBC_UPSTA2CLR) RXSTALLDI Clear */
+#define USBC_UPSTA2CLR_RXSTALLDIC   (_U(0x1) << USBC_UPSTA2CLR_RXSTALLDIC_Pos)
+#define USBC_UPSTA2CLR_RAMACERIC_Pos 10           /**< \brief (USBC_UPSTA2CLR) RAMACERI Clear */
+#define USBC_UPSTA2CLR_RAMACERIC    (_U(0x1) << USBC_UPSTA2CLR_RAMACERIC_Pos)
+#define USBC_UPSTA2CLR_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA2CLR) MASK Register */
+
+/* -------- USBC_UPSTA3CLR : (USBC Offset: 0x56C) ( /W 32) Pipe Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINIC:1;         /*!< bit:      0  RXINI Clear                        */
+    uint32_t TXOUTIC:1;        /*!< bit:      1  TXOUTI Clear                       */
+    uint32_t TXSTPIC:1;        /*!< bit:      2  TXSTPI Clear                       */
+    uint32_t PERRIC:1;         /*!< bit:      3  PERRI Clear                        */
+    uint32_t NAKEDIC:1;        /*!< bit:      4  NAKEDI Clear                       */
+    uint32_t ERRORFIC:1;       /*!< bit:      5  ERRORFI Clear                      */
+    uint32_t RXSTALLDIC:1;     /*!< bit:      6  RXSTALLDI Clear                    */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERIC:1;      /*!< bit:     10  RAMACERI Clear                     */
+    uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPSTA3CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPSTA3CLR_OFFSET       0x56C        /**< \brief (USBC_UPSTA3CLR offset) Pipe Status Clear Register */
+#define USBC_UPSTA3CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA3CLR reset_value) Pipe Status Clear Register */
+
+#define USBC_UPSTA3CLR_RXINIC_Pos   0            /**< \brief (USBC_UPSTA3CLR) RXINI Clear */
+#define USBC_UPSTA3CLR_RXINIC       (_U(0x1) << USBC_UPSTA3CLR_RXINIC_Pos)
+#define USBC_UPSTA3CLR_TXOUTIC_Pos  1            /**< \brief (USBC_UPSTA3CLR) TXOUTI Clear */
+#define USBC_UPSTA3CLR_TXOUTIC      (_U(0x1) << USBC_UPSTA3CLR_TXOUTIC_Pos)
+#define USBC_UPSTA3CLR_TXSTPIC_Pos  2            /**< \brief (USBC_UPSTA3CLR) TXSTPI Clear */
+#define USBC_UPSTA3CLR_TXSTPIC      (_U(0x1) << USBC_UPSTA3CLR_TXSTPIC_Pos)
+#define USBC_UPSTA3CLR_PERRIC_Pos   3            /**< \brief (USBC_UPSTA3CLR) PERRI Clear */
+#define USBC_UPSTA3CLR_PERRIC       (_U(0x1) << USBC_UPSTA3CLR_PERRIC_Pos)
+#define USBC_UPSTA3CLR_NAKEDIC_Pos  4            /**< \brief (USBC_UPSTA3CLR) NAKEDI Clear */
+#define USBC_UPSTA3CLR_NAKEDIC      (_U(0x1) << USBC_UPSTA3CLR_NAKEDIC_Pos)
+#define USBC_UPSTA3CLR_ERRORFIC_Pos 5            /**< \brief (USBC_UPSTA3CLR) ERRORFI Clear */
+#define USBC_UPSTA3CLR_ERRORFIC     (_U(0x1) << USBC_UPSTA3CLR_ERRORFIC_Pos)
+#define USBC_UPSTA3CLR_RXSTALLDIC_Pos 6            /**< \brief (USBC_UPSTA3CLR) RXSTALLDI Clear */
+#define USBC_UPSTA3CLR_RXSTALLDIC   (_U(0x1) << USBC_UPSTA3CLR_RXSTALLDIC_Pos)
+#define USBC_UPSTA3CLR_RAMACERIC_Pos 10           /**< \brief (USBC_UPSTA3CLR) RAMACERI Clear */
+#define USBC_UPSTA3CLR_RAMACERIC    (_U(0x1) << USBC_UPSTA3CLR_RAMACERIC_Pos)
+#define USBC_UPSTA3CLR_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA3CLR) MASK Register */
+
+/* -------- USBC_UPSTA4CLR : (USBC Offset: 0x570) ( /W 32) Pipe Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINIC:1;         /*!< bit:      0  RXINI Clear                        */
+    uint32_t TXOUTIC:1;        /*!< bit:      1  TXOUTI Clear                       */
+    uint32_t TXSTPIC:1;        /*!< bit:      2  TXSTPI Clear                       */
+    uint32_t PERRIC:1;         /*!< bit:      3  PERRI Clear                        */
+    uint32_t NAKEDIC:1;        /*!< bit:      4  NAKEDI Clear                       */
+    uint32_t ERRORFIC:1;       /*!< bit:      5  ERRORFI Clear                      */
+    uint32_t RXSTALLDIC:1;     /*!< bit:      6  RXSTALLDI Clear                    */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERIC:1;      /*!< bit:     10  RAMACERI Clear                     */
+    uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPSTA4CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPSTA4CLR_OFFSET       0x570        /**< \brief (USBC_UPSTA4CLR offset) Pipe Status Clear Register */
+#define USBC_UPSTA4CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA4CLR reset_value) Pipe Status Clear Register */
+
+#define USBC_UPSTA4CLR_RXINIC_Pos   0            /**< \brief (USBC_UPSTA4CLR) RXINI Clear */
+#define USBC_UPSTA4CLR_RXINIC       (_U(0x1) << USBC_UPSTA4CLR_RXINIC_Pos)
+#define USBC_UPSTA4CLR_TXOUTIC_Pos  1            /**< \brief (USBC_UPSTA4CLR) TXOUTI Clear */
+#define USBC_UPSTA4CLR_TXOUTIC      (_U(0x1) << USBC_UPSTA4CLR_TXOUTIC_Pos)
+#define USBC_UPSTA4CLR_TXSTPIC_Pos  2            /**< \brief (USBC_UPSTA4CLR) TXSTPI Clear */
+#define USBC_UPSTA4CLR_TXSTPIC      (_U(0x1) << USBC_UPSTA4CLR_TXSTPIC_Pos)
+#define USBC_UPSTA4CLR_PERRIC_Pos   3            /**< \brief (USBC_UPSTA4CLR) PERRI Clear */
+#define USBC_UPSTA4CLR_PERRIC       (_U(0x1) << USBC_UPSTA4CLR_PERRIC_Pos)
+#define USBC_UPSTA4CLR_NAKEDIC_Pos  4            /**< \brief (USBC_UPSTA4CLR) NAKEDI Clear */
+#define USBC_UPSTA4CLR_NAKEDIC      (_U(0x1) << USBC_UPSTA4CLR_NAKEDIC_Pos)
+#define USBC_UPSTA4CLR_ERRORFIC_Pos 5            /**< \brief (USBC_UPSTA4CLR) ERRORFI Clear */
+#define USBC_UPSTA4CLR_ERRORFIC     (_U(0x1) << USBC_UPSTA4CLR_ERRORFIC_Pos)
+#define USBC_UPSTA4CLR_RXSTALLDIC_Pos 6            /**< \brief (USBC_UPSTA4CLR) RXSTALLDI Clear */
+#define USBC_UPSTA4CLR_RXSTALLDIC   (_U(0x1) << USBC_UPSTA4CLR_RXSTALLDIC_Pos)
+#define USBC_UPSTA4CLR_RAMACERIC_Pos 10           /**< \brief (USBC_UPSTA4CLR) RAMACERI Clear */
+#define USBC_UPSTA4CLR_RAMACERIC    (_U(0x1) << USBC_UPSTA4CLR_RAMACERIC_Pos)
+#define USBC_UPSTA4CLR_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA4CLR) MASK Register */
+
+/* -------- USBC_UPSTA5CLR : (USBC Offset: 0x574) ( /W 32) Pipe Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINIC:1;         /*!< bit:      0  RXINI Clear                        */
+    uint32_t TXOUTIC:1;        /*!< bit:      1  TXOUTI Clear                       */
+    uint32_t TXSTPIC:1;        /*!< bit:      2  TXSTPI Clear                       */
+    uint32_t PERRIC:1;         /*!< bit:      3  PERRI Clear                        */
+    uint32_t NAKEDIC:1;        /*!< bit:      4  NAKEDI Clear                       */
+    uint32_t ERRORFIC:1;       /*!< bit:      5  ERRORFI Clear                      */
+    uint32_t RXSTALLDIC:1;     /*!< bit:      6  RXSTALLDI Clear                    */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERIC:1;      /*!< bit:     10  RAMACERI Clear                     */
+    uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPSTA5CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPSTA5CLR_OFFSET       0x574        /**< \brief (USBC_UPSTA5CLR offset) Pipe Status Clear Register */
+#define USBC_UPSTA5CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA5CLR reset_value) Pipe Status Clear Register */
+
+#define USBC_UPSTA5CLR_RXINIC_Pos   0            /**< \brief (USBC_UPSTA5CLR) RXINI Clear */
+#define USBC_UPSTA5CLR_RXINIC       (_U(0x1) << USBC_UPSTA5CLR_RXINIC_Pos)
+#define USBC_UPSTA5CLR_TXOUTIC_Pos  1            /**< \brief (USBC_UPSTA5CLR) TXOUTI Clear */
+#define USBC_UPSTA5CLR_TXOUTIC      (_U(0x1) << USBC_UPSTA5CLR_TXOUTIC_Pos)
+#define USBC_UPSTA5CLR_TXSTPIC_Pos  2            /**< \brief (USBC_UPSTA5CLR) TXSTPI Clear */
+#define USBC_UPSTA5CLR_TXSTPIC      (_U(0x1) << USBC_UPSTA5CLR_TXSTPIC_Pos)
+#define USBC_UPSTA5CLR_PERRIC_Pos   3            /**< \brief (USBC_UPSTA5CLR) PERRI Clear */
+#define USBC_UPSTA5CLR_PERRIC       (_U(0x1) << USBC_UPSTA5CLR_PERRIC_Pos)
+#define USBC_UPSTA5CLR_NAKEDIC_Pos  4            /**< \brief (USBC_UPSTA5CLR) NAKEDI Clear */
+#define USBC_UPSTA5CLR_NAKEDIC      (_U(0x1) << USBC_UPSTA5CLR_NAKEDIC_Pos)
+#define USBC_UPSTA5CLR_ERRORFIC_Pos 5            /**< \brief (USBC_UPSTA5CLR) ERRORFI Clear */
+#define USBC_UPSTA5CLR_ERRORFIC     (_U(0x1) << USBC_UPSTA5CLR_ERRORFIC_Pos)
+#define USBC_UPSTA5CLR_RXSTALLDIC_Pos 6            /**< \brief (USBC_UPSTA5CLR) RXSTALLDI Clear */
+#define USBC_UPSTA5CLR_RXSTALLDIC   (_U(0x1) << USBC_UPSTA5CLR_RXSTALLDIC_Pos)
+#define USBC_UPSTA5CLR_RAMACERIC_Pos 10           /**< \brief (USBC_UPSTA5CLR) RAMACERI Clear */
+#define USBC_UPSTA5CLR_RAMACERIC    (_U(0x1) << USBC_UPSTA5CLR_RAMACERIC_Pos)
+#define USBC_UPSTA5CLR_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA5CLR) MASK Register */
+
+/* -------- USBC_UPSTA6CLR : (USBC Offset: 0x578) ( /W 32) Pipe Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINIC:1;         /*!< bit:      0  RXINI Clear                        */
+    uint32_t TXOUTIC:1;        /*!< bit:      1  TXOUTI Clear                       */
+    uint32_t TXSTPIC:1;        /*!< bit:      2  TXSTPI Clear                       */
+    uint32_t PERRIC:1;         /*!< bit:      3  PERRI Clear                        */
+    uint32_t NAKEDIC:1;        /*!< bit:      4  NAKEDI Clear                       */
+    uint32_t ERRORFIC:1;       /*!< bit:      5  ERRORFI Clear                      */
+    uint32_t RXSTALLDIC:1;     /*!< bit:      6  RXSTALLDI Clear                    */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERIC:1;      /*!< bit:     10  RAMACERI Clear                     */
+    uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPSTA6CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPSTA6CLR_OFFSET       0x578        /**< \brief (USBC_UPSTA6CLR offset) Pipe Status Clear Register */
+#define USBC_UPSTA6CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA6CLR reset_value) Pipe Status Clear Register */
+
+#define USBC_UPSTA6CLR_RXINIC_Pos   0            /**< \brief (USBC_UPSTA6CLR) RXINI Clear */
+#define USBC_UPSTA6CLR_RXINIC       (_U(0x1) << USBC_UPSTA6CLR_RXINIC_Pos)
+#define USBC_UPSTA6CLR_TXOUTIC_Pos  1            /**< \brief (USBC_UPSTA6CLR) TXOUTI Clear */
+#define USBC_UPSTA6CLR_TXOUTIC      (_U(0x1) << USBC_UPSTA6CLR_TXOUTIC_Pos)
+#define USBC_UPSTA6CLR_TXSTPIC_Pos  2            /**< \brief (USBC_UPSTA6CLR) TXSTPI Clear */
+#define USBC_UPSTA6CLR_TXSTPIC      (_U(0x1) << USBC_UPSTA6CLR_TXSTPIC_Pos)
+#define USBC_UPSTA6CLR_PERRIC_Pos   3            /**< \brief (USBC_UPSTA6CLR) PERRI Clear */
+#define USBC_UPSTA6CLR_PERRIC       (_U(0x1) << USBC_UPSTA6CLR_PERRIC_Pos)
+#define USBC_UPSTA6CLR_NAKEDIC_Pos  4            /**< \brief (USBC_UPSTA6CLR) NAKEDI Clear */
+#define USBC_UPSTA6CLR_NAKEDIC      (_U(0x1) << USBC_UPSTA6CLR_NAKEDIC_Pos)
+#define USBC_UPSTA6CLR_ERRORFIC_Pos 5            /**< \brief (USBC_UPSTA6CLR) ERRORFI Clear */
+#define USBC_UPSTA6CLR_ERRORFIC     (_U(0x1) << USBC_UPSTA6CLR_ERRORFIC_Pos)
+#define USBC_UPSTA6CLR_RXSTALLDIC_Pos 6            /**< \brief (USBC_UPSTA6CLR) RXSTALLDI Clear */
+#define USBC_UPSTA6CLR_RXSTALLDIC   (_U(0x1) << USBC_UPSTA6CLR_RXSTALLDIC_Pos)
+#define USBC_UPSTA6CLR_RAMACERIC_Pos 10           /**< \brief (USBC_UPSTA6CLR) RAMACERI Clear */
+#define USBC_UPSTA6CLR_RAMACERIC    (_U(0x1) << USBC_UPSTA6CLR_RAMACERIC_Pos)
+#define USBC_UPSTA6CLR_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA6CLR) MASK Register */
+
+/* -------- USBC_UPSTA7CLR : (USBC Offset: 0x57C) ( /W 32) Pipe Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINIC:1;         /*!< bit:      0  RXINI Clear                        */
+    uint32_t TXOUTIC:1;        /*!< bit:      1  TXOUTI Clear                       */
+    uint32_t TXSTPIC:1;        /*!< bit:      2  TXSTPI Clear                       */
+    uint32_t PERRIC:1;         /*!< bit:      3  PERRI Clear                        */
+    uint32_t NAKEDIC:1;        /*!< bit:      4  NAKEDI Clear                       */
+    uint32_t ERRORFIC:1;       /*!< bit:      5  ERRORFI Clear                      */
+    uint32_t RXSTALLDIC:1;     /*!< bit:      6  RXSTALLDI Clear                    */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERIC:1;      /*!< bit:     10  RAMACERI Clear                     */
+    uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPSTA7CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPSTA7CLR_OFFSET       0x57C        /**< \brief (USBC_UPSTA7CLR offset) Pipe Status Clear Register */
+#define USBC_UPSTA7CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA7CLR reset_value) Pipe Status Clear Register */
+
+#define USBC_UPSTA7CLR_RXINIC_Pos   0            /**< \brief (USBC_UPSTA7CLR) RXINI Clear */
+#define USBC_UPSTA7CLR_RXINIC       (_U(0x1) << USBC_UPSTA7CLR_RXINIC_Pos)
+#define USBC_UPSTA7CLR_TXOUTIC_Pos  1            /**< \brief (USBC_UPSTA7CLR) TXOUTI Clear */
+#define USBC_UPSTA7CLR_TXOUTIC      (_U(0x1) << USBC_UPSTA7CLR_TXOUTIC_Pos)
+#define USBC_UPSTA7CLR_TXSTPIC_Pos  2            /**< \brief (USBC_UPSTA7CLR) TXSTPI Clear */
+#define USBC_UPSTA7CLR_TXSTPIC      (_U(0x1) << USBC_UPSTA7CLR_TXSTPIC_Pos)
+#define USBC_UPSTA7CLR_PERRIC_Pos   3            /**< \brief (USBC_UPSTA7CLR) PERRI Clear */
+#define USBC_UPSTA7CLR_PERRIC       (_U(0x1) << USBC_UPSTA7CLR_PERRIC_Pos)
+#define USBC_UPSTA7CLR_NAKEDIC_Pos  4            /**< \brief (USBC_UPSTA7CLR) NAKEDI Clear */
+#define USBC_UPSTA7CLR_NAKEDIC      (_U(0x1) << USBC_UPSTA7CLR_NAKEDIC_Pos)
+#define USBC_UPSTA7CLR_ERRORFIC_Pos 5            /**< \brief (USBC_UPSTA7CLR) ERRORFI Clear */
+#define USBC_UPSTA7CLR_ERRORFIC     (_U(0x1) << USBC_UPSTA7CLR_ERRORFIC_Pos)
+#define USBC_UPSTA7CLR_RXSTALLDIC_Pos 6            /**< \brief (USBC_UPSTA7CLR) RXSTALLDI Clear */
+#define USBC_UPSTA7CLR_RXSTALLDIC   (_U(0x1) << USBC_UPSTA7CLR_RXSTALLDIC_Pos)
+#define USBC_UPSTA7CLR_RAMACERIC_Pos 10           /**< \brief (USBC_UPSTA7CLR) RAMACERI Clear */
+#define USBC_UPSTA7CLR_RAMACERIC    (_U(0x1) << USBC_UPSTA7CLR_RAMACERIC_Pos)
+#define USBC_UPSTA7CLR_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA7CLR) MASK Register */
+
+/* -------- USBC_UPSTA0SET : (USBC Offset: 0x590) ( /W 32) Pipe Status Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINIS:1;         /*!< bit:      0  RXINI Set                          */
+    uint32_t TXOUTIS:1;        /*!< bit:      1  TXOUTI Set                         */
+    uint32_t TXSTPIS:1;        /*!< bit:      2  TXSTPI Set                         */
+    uint32_t PERRIS:1;         /*!< bit:      3  PERRI Set                          */
+    uint32_t NAKEDIS:1;        /*!< bit:      4  NAKEDI Set                         */
+    uint32_t ERRORFIS:1;       /*!< bit:      5  ERRORFI Set                        */
+    uint32_t RXSTALLDIS:1;     /*!< bit:      6  RXSTALLDI Set                      */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERIS:1;      /*!< bit:     10  RAMACERI Set                       */
+    uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPSTA0SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPSTA0SET_OFFSET       0x590        /**< \brief (USBC_UPSTA0SET offset) Pipe Status Set Register */
+#define USBC_UPSTA0SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA0SET reset_value) Pipe Status Set Register */
+
+#define USBC_UPSTA0SET_RXINIS_Pos   0            /**< \brief (USBC_UPSTA0SET) RXINI Set */
+#define USBC_UPSTA0SET_RXINIS       (_U(0x1) << USBC_UPSTA0SET_RXINIS_Pos)
+#define USBC_UPSTA0SET_TXOUTIS_Pos  1            /**< \brief (USBC_UPSTA0SET) TXOUTI Set */
+#define USBC_UPSTA0SET_TXOUTIS      (_U(0x1) << USBC_UPSTA0SET_TXOUTIS_Pos)
+#define USBC_UPSTA0SET_TXSTPIS_Pos  2            /**< \brief (USBC_UPSTA0SET) TXSTPI Set */
+#define USBC_UPSTA0SET_TXSTPIS      (_U(0x1) << USBC_UPSTA0SET_TXSTPIS_Pos)
+#define USBC_UPSTA0SET_PERRIS_Pos   3            /**< \brief (USBC_UPSTA0SET) PERRI Set */
+#define USBC_UPSTA0SET_PERRIS       (_U(0x1) << USBC_UPSTA0SET_PERRIS_Pos)
+#define USBC_UPSTA0SET_NAKEDIS_Pos  4            /**< \brief (USBC_UPSTA0SET) NAKEDI Set */
+#define USBC_UPSTA0SET_NAKEDIS      (_U(0x1) << USBC_UPSTA0SET_NAKEDIS_Pos)
+#define USBC_UPSTA0SET_ERRORFIS_Pos 5            /**< \brief (USBC_UPSTA0SET) ERRORFI Set */
+#define USBC_UPSTA0SET_ERRORFIS     (_U(0x1) << USBC_UPSTA0SET_ERRORFIS_Pos)
+#define USBC_UPSTA0SET_RXSTALLDIS_Pos 6            /**< \brief (USBC_UPSTA0SET) RXSTALLDI Set */
+#define USBC_UPSTA0SET_RXSTALLDIS   (_U(0x1) << USBC_UPSTA0SET_RXSTALLDIS_Pos)
+#define USBC_UPSTA0SET_RAMACERIS_Pos 10           /**< \brief (USBC_UPSTA0SET) RAMACERI Set */
+#define USBC_UPSTA0SET_RAMACERIS    (_U(0x1) << USBC_UPSTA0SET_RAMACERIS_Pos)
+#define USBC_UPSTA0SET_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA0SET) MASK Register */
+
+/* -------- USBC_UPSTA1SET : (USBC Offset: 0x594) ( /W 32) Pipe Status Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINIS:1;         /*!< bit:      0  RXINI Set                          */
+    uint32_t TXOUTIS:1;        /*!< bit:      1  TXOUTI Set                         */
+    uint32_t TXSTPIS:1;        /*!< bit:      2  TXSTPI Set                         */
+    uint32_t PERRIS:1;         /*!< bit:      3  PERRI Set                          */
+    uint32_t NAKEDIS:1;        /*!< bit:      4  NAKEDI Set                         */
+    uint32_t ERRORFIS:1;       /*!< bit:      5  ERRORFI Set                        */
+    uint32_t RXSTALLDIS:1;     /*!< bit:      6  RXSTALLDI Set                      */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERIS:1;      /*!< bit:     10  RAMACERI Set                       */
+    uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPSTA1SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPSTA1SET_OFFSET       0x594        /**< \brief (USBC_UPSTA1SET offset) Pipe Status Set Register */
+#define USBC_UPSTA1SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA1SET reset_value) Pipe Status Set Register */
+
+#define USBC_UPSTA1SET_RXINIS_Pos   0            /**< \brief (USBC_UPSTA1SET) RXINI Set */
+#define USBC_UPSTA1SET_RXINIS       (_U(0x1) << USBC_UPSTA1SET_RXINIS_Pos)
+#define USBC_UPSTA1SET_TXOUTIS_Pos  1            /**< \brief (USBC_UPSTA1SET) TXOUTI Set */
+#define USBC_UPSTA1SET_TXOUTIS      (_U(0x1) << USBC_UPSTA1SET_TXOUTIS_Pos)
+#define USBC_UPSTA1SET_TXSTPIS_Pos  2            /**< \brief (USBC_UPSTA1SET) TXSTPI Set */
+#define USBC_UPSTA1SET_TXSTPIS      (_U(0x1) << USBC_UPSTA1SET_TXSTPIS_Pos)
+#define USBC_UPSTA1SET_PERRIS_Pos   3            /**< \brief (USBC_UPSTA1SET) PERRI Set */
+#define USBC_UPSTA1SET_PERRIS       (_U(0x1) << USBC_UPSTA1SET_PERRIS_Pos)
+#define USBC_UPSTA1SET_NAKEDIS_Pos  4            /**< \brief (USBC_UPSTA1SET) NAKEDI Set */
+#define USBC_UPSTA1SET_NAKEDIS      (_U(0x1) << USBC_UPSTA1SET_NAKEDIS_Pos)
+#define USBC_UPSTA1SET_ERRORFIS_Pos 5            /**< \brief (USBC_UPSTA1SET) ERRORFI Set */
+#define USBC_UPSTA1SET_ERRORFIS     (_U(0x1) << USBC_UPSTA1SET_ERRORFIS_Pos)
+#define USBC_UPSTA1SET_RXSTALLDIS_Pos 6            /**< \brief (USBC_UPSTA1SET) RXSTALLDI Set */
+#define USBC_UPSTA1SET_RXSTALLDIS   (_U(0x1) << USBC_UPSTA1SET_RXSTALLDIS_Pos)
+#define USBC_UPSTA1SET_RAMACERIS_Pos 10           /**< \brief (USBC_UPSTA1SET) RAMACERI Set */
+#define USBC_UPSTA1SET_RAMACERIS    (_U(0x1) << USBC_UPSTA1SET_RAMACERIS_Pos)
+#define USBC_UPSTA1SET_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA1SET) MASK Register */
+
+/* -------- USBC_UPSTA2SET : (USBC Offset: 0x598) ( /W 32) Pipe Status Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINIS:1;         /*!< bit:      0  RXINI Set                          */
+    uint32_t TXOUTIS:1;        /*!< bit:      1  TXOUTI Set                         */
+    uint32_t TXSTPIS:1;        /*!< bit:      2  TXSTPI Set                         */
+    uint32_t PERRIS:1;         /*!< bit:      3  PERRI Set                          */
+    uint32_t NAKEDIS:1;        /*!< bit:      4  NAKEDI Set                         */
+    uint32_t ERRORFIS:1;       /*!< bit:      5  ERRORFI Set                        */
+    uint32_t RXSTALLDIS:1;     /*!< bit:      6  RXSTALLDI Set                      */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERIS:1;      /*!< bit:     10  RAMACERI Set                       */
+    uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPSTA2SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPSTA2SET_OFFSET       0x598        /**< \brief (USBC_UPSTA2SET offset) Pipe Status Set Register */
+#define USBC_UPSTA2SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA2SET reset_value) Pipe Status Set Register */
+
+#define USBC_UPSTA2SET_RXINIS_Pos   0            /**< \brief (USBC_UPSTA2SET) RXINI Set */
+#define USBC_UPSTA2SET_RXINIS       (_U(0x1) << USBC_UPSTA2SET_RXINIS_Pos)
+#define USBC_UPSTA2SET_TXOUTIS_Pos  1            /**< \brief (USBC_UPSTA2SET) TXOUTI Set */
+#define USBC_UPSTA2SET_TXOUTIS      (_U(0x1) << USBC_UPSTA2SET_TXOUTIS_Pos)
+#define USBC_UPSTA2SET_TXSTPIS_Pos  2            /**< \brief (USBC_UPSTA2SET) TXSTPI Set */
+#define USBC_UPSTA2SET_TXSTPIS      (_U(0x1) << USBC_UPSTA2SET_TXSTPIS_Pos)
+#define USBC_UPSTA2SET_PERRIS_Pos   3            /**< \brief (USBC_UPSTA2SET) PERRI Set */
+#define USBC_UPSTA2SET_PERRIS       (_U(0x1) << USBC_UPSTA2SET_PERRIS_Pos)
+#define USBC_UPSTA2SET_NAKEDIS_Pos  4            /**< \brief (USBC_UPSTA2SET) NAKEDI Set */
+#define USBC_UPSTA2SET_NAKEDIS      (_U(0x1) << USBC_UPSTA2SET_NAKEDIS_Pos)
+#define USBC_UPSTA2SET_ERRORFIS_Pos 5            /**< \brief (USBC_UPSTA2SET) ERRORFI Set */
+#define USBC_UPSTA2SET_ERRORFIS     (_U(0x1) << USBC_UPSTA2SET_ERRORFIS_Pos)
+#define USBC_UPSTA2SET_RXSTALLDIS_Pos 6            /**< \brief (USBC_UPSTA2SET) RXSTALLDI Set */
+#define USBC_UPSTA2SET_RXSTALLDIS   (_U(0x1) << USBC_UPSTA2SET_RXSTALLDIS_Pos)
+#define USBC_UPSTA2SET_RAMACERIS_Pos 10           /**< \brief (USBC_UPSTA2SET) RAMACERI Set */
+#define USBC_UPSTA2SET_RAMACERIS    (_U(0x1) << USBC_UPSTA2SET_RAMACERIS_Pos)
+#define USBC_UPSTA2SET_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA2SET) MASK Register */
+
+/* -------- USBC_UPSTA3SET : (USBC Offset: 0x59C) ( /W 32) Pipe Status Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINIS:1;         /*!< bit:      0  RXINI Set                          */
+    uint32_t TXOUTIS:1;        /*!< bit:      1  TXOUTI Set                         */
+    uint32_t TXSTPIS:1;        /*!< bit:      2  TXSTPI Set                         */
+    uint32_t PERRIS:1;         /*!< bit:      3  PERRI Set                          */
+    uint32_t NAKEDIS:1;        /*!< bit:      4  NAKEDI Set                         */
+    uint32_t ERRORFIS:1;       /*!< bit:      5  ERRORFI Set                        */
+    uint32_t RXSTALLDIS:1;     /*!< bit:      6  RXSTALLDI Set                      */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERIS:1;      /*!< bit:     10  RAMACERI Set                       */
+    uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPSTA3SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPSTA3SET_OFFSET       0x59C        /**< \brief (USBC_UPSTA3SET offset) Pipe Status Set Register */
+#define USBC_UPSTA3SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA3SET reset_value) Pipe Status Set Register */
+
+#define USBC_UPSTA3SET_RXINIS_Pos   0            /**< \brief (USBC_UPSTA3SET) RXINI Set */
+#define USBC_UPSTA3SET_RXINIS       (_U(0x1) << USBC_UPSTA3SET_RXINIS_Pos)
+#define USBC_UPSTA3SET_TXOUTIS_Pos  1            /**< \brief (USBC_UPSTA3SET) TXOUTI Set */
+#define USBC_UPSTA3SET_TXOUTIS      (_U(0x1) << USBC_UPSTA3SET_TXOUTIS_Pos)
+#define USBC_UPSTA3SET_TXSTPIS_Pos  2            /**< \brief (USBC_UPSTA3SET) TXSTPI Set */
+#define USBC_UPSTA3SET_TXSTPIS      (_U(0x1) << USBC_UPSTA3SET_TXSTPIS_Pos)
+#define USBC_UPSTA3SET_PERRIS_Pos   3            /**< \brief (USBC_UPSTA3SET) PERRI Set */
+#define USBC_UPSTA3SET_PERRIS       (_U(0x1) << USBC_UPSTA3SET_PERRIS_Pos)
+#define USBC_UPSTA3SET_NAKEDIS_Pos  4            /**< \brief (USBC_UPSTA3SET) NAKEDI Set */
+#define USBC_UPSTA3SET_NAKEDIS      (_U(0x1) << USBC_UPSTA3SET_NAKEDIS_Pos)
+#define USBC_UPSTA3SET_ERRORFIS_Pos 5            /**< \brief (USBC_UPSTA3SET) ERRORFI Set */
+#define USBC_UPSTA3SET_ERRORFIS     (_U(0x1) << USBC_UPSTA3SET_ERRORFIS_Pos)
+#define USBC_UPSTA3SET_RXSTALLDIS_Pos 6            /**< \brief (USBC_UPSTA3SET) RXSTALLDI Set */
+#define USBC_UPSTA3SET_RXSTALLDIS   (_U(0x1) << USBC_UPSTA3SET_RXSTALLDIS_Pos)
+#define USBC_UPSTA3SET_RAMACERIS_Pos 10           /**< \brief (USBC_UPSTA3SET) RAMACERI Set */
+#define USBC_UPSTA3SET_RAMACERIS    (_U(0x1) << USBC_UPSTA3SET_RAMACERIS_Pos)
+#define USBC_UPSTA3SET_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA3SET) MASK Register */
+
+/* -------- USBC_UPSTA4SET : (USBC Offset: 0x5A0) ( /W 32) Pipe Status Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINIS:1;         /*!< bit:      0  RXINI Set                          */
+    uint32_t TXOUTIS:1;        /*!< bit:      1  TXOUTI Set                         */
+    uint32_t TXSTPIS:1;        /*!< bit:      2  TXSTPI Set                         */
+    uint32_t PERRIS:1;         /*!< bit:      3  PERRI Set                          */
+    uint32_t NAKEDIS:1;        /*!< bit:      4  NAKEDI Set                         */
+    uint32_t ERRORFIS:1;       /*!< bit:      5  ERRORFI Set                        */
+    uint32_t RXSTALLDIS:1;     /*!< bit:      6  RXSTALLDI Set                      */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERIS:1;      /*!< bit:     10  RAMACERI Set                       */
+    uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPSTA4SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPSTA4SET_OFFSET       0x5A0        /**< \brief (USBC_UPSTA4SET offset) Pipe Status Set Register */
+#define USBC_UPSTA4SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA4SET reset_value) Pipe Status Set Register */
+
+#define USBC_UPSTA4SET_RXINIS_Pos   0            /**< \brief (USBC_UPSTA4SET) RXINI Set */
+#define USBC_UPSTA4SET_RXINIS       (_U(0x1) << USBC_UPSTA4SET_RXINIS_Pos)
+#define USBC_UPSTA4SET_TXOUTIS_Pos  1            /**< \brief (USBC_UPSTA4SET) TXOUTI Set */
+#define USBC_UPSTA4SET_TXOUTIS      (_U(0x1) << USBC_UPSTA4SET_TXOUTIS_Pos)
+#define USBC_UPSTA4SET_TXSTPIS_Pos  2            /**< \brief (USBC_UPSTA4SET) TXSTPI Set */
+#define USBC_UPSTA4SET_TXSTPIS      (_U(0x1) << USBC_UPSTA4SET_TXSTPIS_Pos)
+#define USBC_UPSTA4SET_PERRIS_Pos   3            /**< \brief (USBC_UPSTA4SET) PERRI Set */
+#define USBC_UPSTA4SET_PERRIS       (_U(0x1) << USBC_UPSTA4SET_PERRIS_Pos)
+#define USBC_UPSTA4SET_NAKEDIS_Pos  4            /**< \brief (USBC_UPSTA4SET) NAKEDI Set */
+#define USBC_UPSTA4SET_NAKEDIS      (_U(0x1) << USBC_UPSTA4SET_NAKEDIS_Pos)
+#define USBC_UPSTA4SET_ERRORFIS_Pos 5            /**< \brief (USBC_UPSTA4SET) ERRORFI Set */
+#define USBC_UPSTA4SET_ERRORFIS     (_U(0x1) << USBC_UPSTA4SET_ERRORFIS_Pos)
+#define USBC_UPSTA4SET_RXSTALLDIS_Pos 6            /**< \brief (USBC_UPSTA4SET) RXSTALLDI Set */
+#define USBC_UPSTA4SET_RXSTALLDIS   (_U(0x1) << USBC_UPSTA4SET_RXSTALLDIS_Pos)
+#define USBC_UPSTA4SET_RAMACERIS_Pos 10           /**< \brief (USBC_UPSTA4SET) RAMACERI Set */
+#define USBC_UPSTA4SET_RAMACERIS    (_U(0x1) << USBC_UPSTA4SET_RAMACERIS_Pos)
+#define USBC_UPSTA4SET_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA4SET) MASK Register */
+
+/* -------- USBC_UPSTA5SET : (USBC Offset: 0x5A4) ( /W 32) Pipe Status Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINIS:1;         /*!< bit:      0  RXINI Set                          */
+    uint32_t TXOUTIS:1;        /*!< bit:      1  TXOUTI Set                         */
+    uint32_t TXSTPIS:1;        /*!< bit:      2  TXSTPI Set                         */
+    uint32_t PERRIS:1;         /*!< bit:      3  PERRI Set                          */
+    uint32_t NAKEDIS:1;        /*!< bit:      4  NAKEDI Set                         */
+    uint32_t ERRORFIS:1;       /*!< bit:      5  ERRORFI Set                        */
+    uint32_t RXSTALLDIS:1;     /*!< bit:      6  RXSTALLDI Set                      */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERIS:1;      /*!< bit:     10  RAMACERI Set                       */
+    uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPSTA5SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPSTA5SET_OFFSET       0x5A4        /**< \brief (USBC_UPSTA5SET offset) Pipe Status Set Register */
+#define USBC_UPSTA5SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA5SET reset_value) Pipe Status Set Register */
+
+#define USBC_UPSTA5SET_RXINIS_Pos   0            /**< \brief (USBC_UPSTA5SET) RXINI Set */
+#define USBC_UPSTA5SET_RXINIS       (_U(0x1) << USBC_UPSTA5SET_RXINIS_Pos)
+#define USBC_UPSTA5SET_TXOUTIS_Pos  1            /**< \brief (USBC_UPSTA5SET) TXOUTI Set */
+#define USBC_UPSTA5SET_TXOUTIS      (_U(0x1) << USBC_UPSTA5SET_TXOUTIS_Pos)
+#define USBC_UPSTA5SET_TXSTPIS_Pos  2            /**< \brief (USBC_UPSTA5SET) TXSTPI Set */
+#define USBC_UPSTA5SET_TXSTPIS      (_U(0x1) << USBC_UPSTA5SET_TXSTPIS_Pos)
+#define USBC_UPSTA5SET_PERRIS_Pos   3            /**< \brief (USBC_UPSTA5SET) PERRI Set */
+#define USBC_UPSTA5SET_PERRIS       (_U(0x1) << USBC_UPSTA5SET_PERRIS_Pos)
+#define USBC_UPSTA5SET_NAKEDIS_Pos  4            /**< \brief (USBC_UPSTA5SET) NAKEDI Set */
+#define USBC_UPSTA5SET_NAKEDIS      (_U(0x1) << USBC_UPSTA5SET_NAKEDIS_Pos)
+#define USBC_UPSTA5SET_ERRORFIS_Pos 5            /**< \brief (USBC_UPSTA5SET) ERRORFI Set */
+#define USBC_UPSTA5SET_ERRORFIS     (_U(0x1) << USBC_UPSTA5SET_ERRORFIS_Pos)
+#define USBC_UPSTA5SET_RXSTALLDIS_Pos 6            /**< \brief (USBC_UPSTA5SET) RXSTALLDI Set */
+#define USBC_UPSTA5SET_RXSTALLDIS   (_U(0x1) << USBC_UPSTA5SET_RXSTALLDIS_Pos)
+#define USBC_UPSTA5SET_RAMACERIS_Pos 10           /**< \brief (USBC_UPSTA5SET) RAMACERI Set */
+#define USBC_UPSTA5SET_RAMACERIS    (_U(0x1) << USBC_UPSTA5SET_RAMACERIS_Pos)
+#define USBC_UPSTA5SET_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA5SET) MASK Register */
+
+/* -------- USBC_UPSTA6SET : (USBC Offset: 0x5A8) ( /W 32) Pipe Status Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINIS:1;         /*!< bit:      0  RXINI Set                          */
+    uint32_t TXOUTIS:1;        /*!< bit:      1  TXOUTI Set                         */
+    uint32_t TXSTPIS:1;        /*!< bit:      2  TXSTPI Set                         */
+    uint32_t PERRIS:1;         /*!< bit:      3  PERRI Set                          */
+    uint32_t NAKEDIS:1;        /*!< bit:      4  NAKEDI Set                         */
+    uint32_t ERRORFIS:1;       /*!< bit:      5  ERRORFI Set                        */
+    uint32_t RXSTALLDIS:1;     /*!< bit:      6  RXSTALLDI Set                      */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERIS:1;      /*!< bit:     10  RAMACERI Set                       */
+    uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPSTA6SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPSTA6SET_OFFSET       0x5A8        /**< \brief (USBC_UPSTA6SET offset) Pipe Status Set Register */
+#define USBC_UPSTA6SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA6SET reset_value) Pipe Status Set Register */
+
+#define USBC_UPSTA6SET_RXINIS_Pos   0            /**< \brief (USBC_UPSTA6SET) RXINI Set */
+#define USBC_UPSTA6SET_RXINIS       (_U(0x1) << USBC_UPSTA6SET_RXINIS_Pos)
+#define USBC_UPSTA6SET_TXOUTIS_Pos  1            /**< \brief (USBC_UPSTA6SET) TXOUTI Set */
+#define USBC_UPSTA6SET_TXOUTIS      (_U(0x1) << USBC_UPSTA6SET_TXOUTIS_Pos)
+#define USBC_UPSTA6SET_TXSTPIS_Pos  2            /**< \brief (USBC_UPSTA6SET) TXSTPI Set */
+#define USBC_UPSTA6SET_TXSTPIS      (_U(0x1) << USBC_UPSTA6SET_TXSTPIS_Pos)
+#define USBC_UPSTA6SET_PERRIS_Pos   3            /**< \brief (USBC_UPSTA6SET) PERRI Set */
+#define USBC_UPSTA6SET_PERRIS       (_U(0x1) << USBC_UPSTA6SET_PERRIS_Pos)
+#define USBC_UPSTA6SET_NAKEDIS_Pos  4            /**< \brief (USBC_UPSTA6SET) NAKEDI Set */
+#define USBC_UPSTA6SET_NAKEDIS      (_U(0x1) << USBC_UPSTA6SET_NAKEDIS_Pos)
+#define USBC_UPSTA6SET_ERRORFIS_Pos 5            /**< \brief (USBC_UPSTA6SET) ERRORFI Set */
+#define USBC_UPSTA6SET_ERRORFIS     (_U(0x1) << USBC_UPSTA6SET_ERRORFIS_Pos)
+#define USBC_UPSTA6SET_RXSTALLDIS_Pos 6            /**< \brief (USBC_UPSTA6SET) RXSTALLDI Set */
+#define USBC_UPSTA6SET_RXSTALLDIS   (_U(0x1) << USBC_UPSTA6SET_RXSTALLDIS_Pos)
+#define USBC_UPSTA6SET_RAMACERIS_Pos 10           /**< \brief (USBC_UPSTA6SET) RAMACERI Set */
+#define USBC_UPSTA6SET_RAMACERIS    (_U(0x1) << USBC_UPSTA6SET_RAMACERIS_Pos)
+#define USBC_UPSTA6SET_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA6SET) MASK Register */
+
+/* -------- USBC_UPSTA7SET : (USBC Offset: 0x5AC) ( /W 32) Pipe Status Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINIS:1;         /*!< bit:      0  RXINI Set                          */
+    uint32_t TXOUTIS:1;        /*!< bit:      1  TXOUTI Set                         */
+    uint32_t TXSTPIS:1;        /*!< bit:      2  TXSTPI Set                         */
+    uint32_t PERRIS:1;         /*!< bit:      3  PERRI Set                          */
+    uint32_t NAKEDIS:1;        /*!< bit:      4  NAKEDI Set                         */
+    uint32_t ERRORFIS:1;       /*!< bit:      5  ERRORFI Set                        */
+    uint32_t RXSTALLDIS:1;     /*!< bit:      6  RXSTALLDI Set                      */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERIS:1;      /*!< bit:     10  RAMACERI Set                       */
+    uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPSTA7SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPSTA7SET_OFFSET       0x5AC        /**< \brief (USBC_UPSTA7SET offset) Pipe Status Set Register */
+#define USBC_UPSTA7SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPSTA7SET reset_value) Pipe Status Set Register */
+
+#define USBC_UPSTA7SET_RXINIS_Pos   0            /**< \brief (USBC_UPSTA7SET) RXINI Set */
+#define USBC_UPSTA7SET_RXINIS       (_U(0x1) << USBC_UPSTA7SET_RXINIS_Pos)
+#define USBC_UPSTA7SET_TXOUTIS_Pos  1            /**< \brief (USBC_UPSTA7SET) TXOUTI Set */
+#define USBC_UPSTA7SET_TXOUTIS      (_U(0x1) << USBC_UPSTA7SET_TXOUTIS_Pos)
+#define USBC_UPSTA7SET_TXSTPIS_Pos  2            /**< \brief (USBC_UPSTA7SET) TXSTPI Set */
+#define USBC_UPSTA7SET_TXSTPIS      (_U(0x1) << USBC_UPSTA7SET_TXSTPIS_Pos)
+#define USBC_UPSTA7SET_PERRIS_Pos   3            /**< \brief (USBC_UPSTA7SET) PERRI Set */
+#define USBC_UPSTA7SET_PERRIS       (_U(0x1) << USBC_UPSTA7SET_PERRIS_Pos)
+#define USBC_UPSTA7SET_NAKEDIS_Pos  4            /**< \brief (USBC_UPSTA7SET) NAKEDI Set */
+#define USBC_UPSTA7SET_NAKEDIS      (_U(0x1) << USBC_UPSTA7SET_NAKEDIS_Pos)
+#define USBC_UPSTA7SET_ERRORFIS_Pos 5            /**< \brief (USBC_UPSTA7SET) ERRORFI Set */
+#define USBC_UPSTA7SET_ERRORFIS     (_U(0x1) << USBC_UPSTA7SET_ERRORFIS_Pos)
+#define USBC_UPSTA7SET_RXSTALLDIS_Pos 6            /**< \brief (USBC_UPSTA7SET) RXSTALLDI Set */
+#define USBC_UPSTA7SET_RXSTALLDIS   (_U(0x1) << USBC_UPSTA7SET_RXSTALLDIS_Pos)
+#define USBC_UPSTA7SET_RAMACERIS_Pos 10           /**< \brief (USBC_UPSTA7SET) RAMACERI Set */
+#define USBC_UPSTA7SET_RAMACERIS    (_U(0x1) << USBC_UPSTA7SET_RAMACERIS_Pos)
+#define USBC_UPSTA7SET_MASK         _U(0x0000047F) /**< \brief (USBC_UPSTA7SET) MASK Register */
+
+/* -------- USBC_UPCON0 : (USBC Offset: 0x5C0) (R/  32) Pipe Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINE:1;          /*!< bit:      0  RXIN Interrupt Enable              */
+    uint32_t TXOUTE:1;         /*!< bit:      1  TXOUT Interrupt Enable             */
+    uint32_t TXSTPE:1;         /*!< bit:      2  TXSTP Interrupt Enable             */
+    uint32_t PERRE:1;          /*!< bit:      3  PERR Interrupt Enable              */
+    uint32_t NAKEDE:1;         /*!< bit:      4  NAKED Interrupt Enable             */
+    uint32_t ERRORFIE:1;       /*!< bit:      5  ERRORFI Interrupt Enable           */
+    uint32_t RXSTALLDE:1;      /*!< bit:      6  RXTALLD Interrupt Enable           */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERE:1;       /*!< bit:     10  RAMACER Interrupt Enable           */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBKE:1;       /*!< bit:     12  NBUSYBKInterrupt Enable            */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCON:1;        /*!< bit:     14  FIFO Control                       */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t PFREEZE:1;        /*!< bit:     17  Pipe Freeze                        */
+    uint32_t INITDTGL:1;       /*!< bit:     18  Data Toggle Initialization         */
+    uint32_t INITBK:1;         /*!< bit:     19  Bank Initialization                */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCON0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCON0_OFFSET          0x5C0        /**< \brief (USBC_UPCON0 offset) Pipe Control Register */
+#define USBC_UPCON0_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCON0 reset_value) Pipe Control Register */
+
+#define USBC_UPCON0_RXINE_Pos       0            /**< \brief (USBC_UPCON0) RXIN Interrupt Enable */
+#define USBC_UPCON0_RXINE           (_U(0x1) << USBC_UPCON0_RXINE_Pos)
+#define USBC_UPCON0_TXOUTE_Pos      1            /**< \brief (USBC_UPCON0) TXOUT Interrupt Enable */
+#define USBC_UPCON0_TXOUTE          (_U(0x1) << USBC_UPCON0_TXOUTE_Pos)
+#define USBC_UPCON0_TXSTPE_Pos      2            /**< \brief (USBC_UPCON0) TXSTP Interrupt Enable */
+#define USBC_UPCON0_TXSTPE          (_U(0x1) << USBC_UPCON0_TXSTPE_Pos)
+#define USBC_UPCON0_PERRE_Pos       3            /**< \brief (USBC_UPCON0) PERR Interrupt Enable */
+#define USBC_UPCON0_PERRE           (_U(0x1) << USBC_UPCON0_PERRE_Pos)
+#define USBC_UPCON0_NAKEDE_Pos      4            /**< \brief (USBC_UPCON0) NAKED Interrupt Enable */
+#define USBC_UPCON0_NAKEDE          (_U(0x1) << USBC_UPCON0_NAKEDE_Pos)
+#define USBC_UPCON0_ERRORFIE_Pos    5            /**< \brief (USBC_UPCON0) ERRORFI Interrupt Enable */
+#define USBC_UPCON0_ERRORFIE        (_U(0x1) << USBC_UPCON0_ERRORFIE_Pos)
+#define USBC_UPCON0_RXSTALLDE_Pos   6            /**< \brief (USBC_UPCON0) RXTALLD Interrupt Enable */
+#define USBC_UPCON0_RXSTALLDE       (_U(0x1) << USBC_UPCON0_RXSTALLDE_Pos)
+#define USBC_UPCON0_RAMACERE_Pos    10           /**< \brief (USBC_UPCON0) RAMACER Interrupt Enable */
+#define USBC_UPCON0_RAMACERE        (_U(0x1) << USBC_UPCON0_RAMACERE_Pos)
+#define USBC_UPCON0_NBUSYBKE_Pos    12           /**< \brief (USBC_UPCON0) NBUSYBKInterrupt Enable */
+#define USBC_UPCON0_NBUSYBKE        (_U(0x1) << USBC_UPCON0_NBUSYBKE_Pos)
+#define USBC_UPCON0_FIFOCON_Pos     14           /**< \brief (USBC_UPCON0) FIFO Control */
+#define USBC_UPCON0_FIFOCON         (_U(0x1) << USBC_UPCON0_FIFOCON_Pos)
+#define USBC_UPCON0_PFREEZE_Pos     17           /**< \brief (USBC_UPCON0) Pipe Freeze */
+#define USBC_UPCON0_PFREEZE         (_U(0x1) << USBC_UPCON0_PFREEZE_Pos)
+#define USBC_UPCON0_INITDTGL_Pos    18           /**< \brief (USBC_UPCON0) Data Toggle Initialization */
+#define USBC_UPCON0_INITDTGL        (_U(0x1) << USBC_UPCON0_INITDTGL_Pos)
+#define USBC_UPCON0_INITBK_Pos      19           /**< \brief (USBC_UPCON0) Bank Initialization */
+#define USBC_UPCON0_INITBK          (_U(0x1) << USBC_UPCON0_INITBK_Pos)
+#define USBC_UPCON0_MASK            _U(0x000E547F) /**< \brief (USBC_UPCON0) MASK Register */
+
+/* -------- USBC_UPCON1 : (USBC Offset: 0x5C4) (R/  32) Pipe Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINE:1;          /*!< bit:      0  RXIN Interrupt Enable              */
+    uint32_t TXOUTE:1;         /*!< bit:      1  TXOUT Interrupt Enable             */
+    uint32_t TXSTPE:1;         /*!< bit:      2  TXSTP Interrupt Enable             */
+    uint32_t PERRE:1;          /*!< bit:      3  PERR Interrupt Enable              */
+    uint32_t NAKEDE:1;         /*!< bit:      4  NAKED Interrupt Enable             */
+    uint32_t ERRORFIE:1;       /*!< bit:      5  ERRORFI Interrupt Enable           */
+    uint32_t RXSTALLDE:1;      /*!< bit:      6  RXTALLD Interrupt Enable           */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERE:1;       /*!< bit:     10  RAMACER Interrupt Enable           */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBKE:1;       /*!< bit:     12  NBUSYBKInterrupt Enable            */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCON:1;        /*!< bit:     14  FIFO Control                       */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t PFREEZE:1;        /*!< bit:     17  Pipe Freeze                        */
+    uint32_t INITDTGL:1;       /*!< bit:     18  Data Toggle Initialization         */
+    uint32_t INITBK:1;         /*!< bit:     19  Bank Initialization                */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCON1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCON1_OFFSET          0x5C4        /**< \brief (USBC_UPCON1 offset) Pipe Control Register */
+#define USBC_UPCON1_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCON1 reset_value) Pipe Control Register */
+
+#define USBC_UPCON1_RXINE_Pos       0            /**< \brief (USBC_UPCON1) RXIN Interrupt Enable */
+#define USBC_UPCON1_RXINE           (_U(0x1) << USBC_UPCON1_RXINE_Pos)
+#define USBC_UPCON1_TXOUTE_Pos      1            /**< \brief (USBC_UPCON1) TXOUT Interrupt Enable */
+#define USBC_UPCON1_TXOUTE          (_U(0x1) << USBC_UPCON1_TXOUTE_Pos)
+#define USBC_UPCON1_TXSTPE_Pos      2            /**< \brief (USBC_UPCON1) TXSTP Interrupt Enable */
+#define USBC_UPCON1_TXSTPE          (_U(0x1) << USBC_UPCON1_TXSTPE_Pos)
+#define USBC_UPCON1_PERRE_Pos       3            /**< \brief (USBC_UPCON1) PERR Interrupt Enable */
+#define USBC_UPCON1_PERRE           (_U(0x1) << USBC_UPCON1_PERRE_Pos)
+#define USBC_UPCON1_NAKEDE_Pos      4            /**< \brief (USBC_UPCON1) NAKED Interrupt Enable */
+#define USBC_UPCON1_NAKEDE          (_U(0x1) << USBC_UPCON1_NAKEDE_Pos)
+#define USBC_UPCON1_ERRORFIE_Pos    5            /**< \brief (USBC_UPCON1) ERRORFI Interrupt Enable */
+#define USBC_UPCON1_ERRORFIE        (_U(0x1) << USBC_UPCON1_ERRORFIE_Pos)
+#define USBC_UPCON1_RXSTALLDE_Pos   6            /**< \brief (USBC_UPCON1) RXTALLD Interrupt Enable */
+#define USBC_UPCON1_RXSTALLDE       (_U(0x1) << USBC_UPCON1_RXSTALLDE_Pos)
+#define USBC_UPCON1_RAMACERE_Pos    10           /**< \brief (USBC_UPCON1) RAMACER Interrupt Enable */
+#define USBC_UPCON1_RAMACERE        (_U(0x1) << USBC_UPCON1_RAMACERE_Pos)
+#define USBC_UPCON1_NBUSYBKE_Pos    12           /**< \brief (USBC_UPCON1) NBUSYBKInterrupt Enable */
+#define USBC_UPCON1_NBUSYBKE        (_U(0x1) << USBC_UPCON1_NBUSYBKE_Pos)
+#define USBC_UPCON1_FIFOCON_Pos     14           /**< \brief (USBC_UPCON1) FIFO Control */
+#define USBC_UPCON1_FIFOCON         (_U(0x1) << USBC_UPCON1_FIFOCON_Pos)
+#define USBC_UPCON1_PFREEZE_Pos     17           /**< \brief (USBC_UPCON1) Pipe Freeze */
+#define USBC_UPCON1_PFREEZE         (_U(0x1) << USBC_UPCON1_PFREEZE_Pos)
+#define USBC_UPCON1_INITDTGL_Pos    18           /**< \brief (USBC_UPCON1) Data Toggle Initialization */
+#define USBC_UPCON1_INITDTGL        (_U(0x1) << USBC_UPCON1_INITDTGL_Pos)
+#define USBC_UPCON1_INITBK_Pos      19           /**< \brief (USBC_UPCON1) Bank Initialization */
+#define USBC_UPCON1_INITBK          (_U(0x1) << USBC_UPCON1_INITBK_Pos)
+#define USBC_UPCON1_MASK            _U(0x000E547F) /**< \brief (USBC_UPCON1) MASK Register */
+
+/* -------- USBC_UPCON2 : (USBC Offset: 0x5C8) (R/  32) Pipe Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINE:1;          /*!< bit:      0  RXIN Interrupt Enable              */
+    uint32_t TXOUTE:1;         /*!< bit:      1  TXOUT Interrupt Enable             */
+    uint32_t TXSTPE:1;         /*!< bit:      2  TXSTP Interrupt Enable             */
+    uint32_t PERRE:1;          /*!< bit:      3  PERR Interrupt Enable              */
+    uint32_t NAKEDE:1;         /*!< bit:      4  NAKED Interrupt Enable             */
+    uint32_t ERRORFIE:1;       /*!< bit:      5  ERRORFI Interrupt Enable           */
+    uint32_t RXSTALLDE:1;      /*!< bit:      6  RXTALLD Interrupt Enable           */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERE:1;       /*!< bit:     10  RAMACER Interrupt Enable           */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBKE:1;       /*!< bit:     12  NBUSYBKInterrupt Enable            */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCON:1;        /*!< bit:     14  FIFO Control                       */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t PFREEZE:1;        /*!< bit:     17  Pipe Freeze                        */
+    uint32_t INITDTGL:1;       /*!< bit:     18  Data Toggle Initialization         */
+    uint32_t INITBK:1;         /*!< bit:     19  Bank Initialization                */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCON2_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCON2_OFFSET          0x5C8        /**< \brief (USBC_UPCON2 offset) Pipe Control Register */
+#define USBC_UPCON2_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCON2 reset_value) Pipe Control Register */
+
+#define USBC_UPCON2_RXINE_Pos       0            /**< \brief (USBC_UPCON2) RXIN Interrupt Enable */
+#define USBC_UPCON2_RXINE           (_U(0x1) << USBC_UPCON2_RXINE_Pos)
+#define USBC_UPCON2_TXOUTE_Pos      1            /**< \brief (USBC_UPCON2) TXOUT Interrupt Enable */
+#define USBC_UPCON2_TXOUTE          (_U(0x1) << USBC_UPCON2_TXOUTE_Pos)
+#define USBC_UPCON2_TXSTPE_Pos      2            /**< \brief (USBC_UPCON2) TXSTP Interrupt Enable */
+#define USBC_UPCON2_TXSTPE          (_U(0x1) << USBC_UPCON2_TXSTPE_Pos)
+#define USBC_UPCON2_PERRE_Pos       3            /**< \brief (USBC_UPCON2) PERR Interrupt Enable */
+#define USBC_UPCON2_PERRE           (_U(0x1) << USBC_UPCON2_PERRE_Pos)
+#define USBC_UPCON2_NAKEDE_Pos      4            /**< \brief (USBC_UPCON2) NAKED Interrupt Enable */
+#define USBC_UPCON2_NAKEDE          (_U(0x1) << USBC_UPCON2_NAKEDE_Pos)
+#define USBC_UPCON2_ERRORFIE_Pos    5            /**< \brief (USBC_UPCON2) ERRORFI Interrupt Enable */
+#define USBC_UPCON2_ERRORFIE        (_U(0x1) << USBC_UPCON2_ERRORFIE_Pos)
+#define USBC_UPCON2_RXSTALLDE_Pos   6            /**< \brief (USBC_UPCON2) RXTALLD Interrupt Enable */
+#define USBC_UPCON2_RXSTALLDE       (_U(0x1) << USBC_UPCON2_RXSTALLDE_Pos)
+#define USBC_UPCON2_RAMACERE_Pos    10           /**< \brief (USBC_UPCON2) RAMACER Interrupt Enable */
+#define USBC_UPCON2_RAMACERE        (_U(0x1) << USBC_UPCON2_RAMACERE_Pos)
+#define USBC_UPCON2_NBUSYBKE_Pos    12           /**< \brief (USBC_UPCON2) NBUSYBKInterrupt Enable */
+#define USBC_UPCON2_NBUSYBKE        (_U(0x1) << USBC_UPCON2_NBUSYBKE_Pos)
+#define USBC_UPCON2_FIFOCON_Pos     14           /**< \brief (USBC_UPCON2) FIFO Control */
+#define USBC_UPCON2_FIFOCON         (_U(0x1) << USBC_UPCON2_FIFOCON_Pos)
+#define USBC_UPCON2_PFREEZE_Pos     17           /**< \brief (USBC_UPCON2) Pipe Freeze */
+#define USBC_UPCON2_PFREEZE         (_U(0x1) << USBC_UPCON2_PFREEZE_Pos)
+#define USBC_UPCON2_INITDTGL_Pos    18           /**< \brief (USBC_UPCON2) Data Toggle Initialization */
+#define USBC_UPCON2_INITDTGL        (_U(0x1) << USBC_UPCON2_INITDTGL_Pos)
+#define USBC_UPCON2_INITBK_Pos      19           /**< \brief (USBC_UPCON2) Bank Initialization */
+#define USBC_UPCON2_INITBK          (_U(0x1) << USBC_UPCON2_INITBK_Pos)
+#define USBC_UPCON2_MASK            _U(0x000E547F) /**< \brief (USBC_UPCON2) MASK Register */
+
+/* -------- USBC_UPCON3 : (USBC Offset: 0x5CC) (R/  32) Pipe Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINE:1;          /*!< bit:      0  RXIN Interrupt Enable              */
+    uint32_t TXOUTE:1;         /*!< bit:      1  TXOUT Interrupt Enable             */
+    uint32_t TXSTPE:1;         /*!< bit:      2  TXSTP Interrupt Enable             */
+    uint32_t PERRE:1;          /*!< bit:      3  PERR Interrupt Enable              */
+    uint32_t NAKEDE:1;         /*!< bit:      4  NAKED Interrupt Enable             */
+    uint32_t ERRORFIE:1;       /*!< bit:      5  ERRORFI Interrupt Enable           */
+    uint32_t RXSTALLDE:1;      /*!< bit:      6  RXTALLD Interrupt Enable           */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERE:1;       /*!< bit:     10  RAMACER Interrupt Enable           */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBKE:1;       /*!< bit:     12  NBUSYBKInterrupt Enable            */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCON:1;        /*!< bit:     14  FIFO Control                       */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t PFREEZE:1;        /*!< bit:     17  Pipe Freeze                        */
+    uint32_t INITDTGL:1;       /*!< bit:     18  Data Toggle Initialization         */
+    uint32_t INITBK:1;         /*!< bit:     19  Bank Initialization                */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCON3_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCON3_OFFSET          0x5CC        /**< \brief (USBC_UPCON3 offset) Pipe Control Register */
+#define USBC_UPCON3_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCON3 reset_value) Pipe Control Register */
+
+#define USBC_UPCON3_RXINE_Pos       0            /**< \brief (USBC_UPCON3) RXIN Interrupt Enable */
+#define USBC_UPCON3_RXINE           (_U(0x1) << USBC_UPCON3_RXINE_Pos)
+#define USBC_UPCON3_TXOUTE_Pos      1            /**< \brief (USBC_UPCON3) TXOUT Interrupt Enable */
+#define USBC_UPCON3_TXOUTE          (_U(0x1) << USBC_UPCON3_TXOUTE_Pos)
+#define USBC_UPCON3_TXSTPE_Pos      2            /**< \brief (USBC_UPCON3) TXSTP Interrupt Enable */
+#define USBC_UPCON3_TXSTPE          (_U(0x1) << USBC_UPCON3_TXSTPE_Pos)
+#define USBC_UPCON3_PERRE_Pos       3            /**< \brief (USBC_UPCON3) PERR Interrupt Enable */
+#define USBC_UPCON3_PERRE           (_U(0x1) << USBC_UPCON3_PERRE_Pos)
+#define USBC_UPCON3_NAKEDE_Pos      4            /**< \brief (USBC_UPCON3) NAKED Interrupt Enable */
+#define USBC_UPCON3_NAKEDE          (_U(0x1) << USBC_UPCON3_NAKEDE_Pos)
+#define USBC_UPCON3_ERRORFIE_Pos    5            /**< \brief (USBC_UPCON3) ERRORFI Interrupt Enable */
+#define USBC_UPCON3_ERRORFIE        (_U(0x1) << USBC_UPCON3_ERRORFIE_Pos)
+#define USBC_UPCON3_RXSTALLDE_Pos   6            /**< \brief (USBC_UPCON3) RXTALLD Interrupt Enable */
+#define USBC_UPCON3_RXSTALLDE       (_U(0x1) << USBC_UPCON3_RXSTALLDE_Pos)
+#define USBC_UPCON3_RAMACERE_Pos    10           /**< \brief (USBC_UPCON3) RAMACER Interrupt Enable */
+#define USBC_UPCON3_RAMACERE        (_U(0x1) << USBC_UPCON3_RAMACERE_Pos)
+#define USBC_UPCON3_NBUSYBKE_Pos    12           /**< \brief (USBC_UPCON3) NBUSYBKInterrupt Enable */
+#define USBC_UPCON3_NBUSYBKE        (_U(0x1) << USBC_UPCON3_NBUSYBKE_Pos)
+#define USBC_UPCON3_FIFOCON_Pos     14           /**< \brief (USBC_UPCON3) FIFO Control */
+#define USBC_UPCON3_FIFOCON         (_U(0x1) << USBC_UPCON3_FIFOCON_Pos)
+#define USBC_UPCON3_PFREEZE_Pos     17           /**< \brief (USBC_UPCON3) Pipe Freeze */
+#define USBC_UPCON3_PFREEZE         (_U(0x1) << USBC_UPCON3_PFREEZE_Pos)
+#define USBC_UPCON3_INITDTGL_Pos    18           /**< \brief (USBC_UPCON3) Data Toggle Initialization */
+#define USBC_UPCON3_INITDTGL        (_U(0x1) << USBC_UPCON3_INITDTGL_Pos)
+#define USBC_UPCON3_INITBK_Pos      19           /**< \brief (USBC_UPCON3) Bank Initialization */
+#define USBC_UPCON3_INITBK          (_U(0x1) << USBC_UPCON3_INITBK_Pos)
+#define USBC_UPCON3_MASK            _U(0x000E547F) /**< \brief (USBC_UPCON3) MASK Register */
+
+/* -------- USBC_UPCON4 : (USBC Offset: 0x5D0) (R/  32) Pipe Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINE:1;          /*!< bit:      0  RXIN Interrupt Enable              */
+    uint32_t TXOUTE:1;         /*!< bit:      1  TXOUT Interrupt Enable             */
+    uint32_t TXSTPE:1;         /*!< bit:      2  TXSTP Interrupt Enable             */
+    uint32_t PERRE:1;          /*!< bit:      3  PERR Interrupt Enable              */
+    uint32_t NAKEDE:1;         /*!< bit:      4  NAKED Interrupt Enable             */
+    uint32_t ERRORFIE:1;       /*!< bit:      5  ERRORFI Interrupt Enable           */
+    uint32_t RXSTALLDE:1;      /*!< bit:      6  RXTALLD Interrupt Enable           */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERE:1;       /*!< bit:     10  RAMACER Interrupt Enable           */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBKE:1;       /*!< bit:     12  NBUSYBKInterrupt Enable            */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCON:1;        /*!< bit:     14  FIFO Control                       */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t PFREEZE:1;        /*!< bit:     17  Pipe Freeze                        */
+    uint32_t INITDTGL:1;       /*!< bit:     18  Data Toggle Initialization         */
+    uint32_t INITBK:1;         /*!< bit:     19  Bank Initialization                */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCON4_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCON4_OFFSET          0x5D0        /**< \brief (USBC_UPCON4 offset) Pipe Control Register */
+#define USBC_UPCON4_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCON4 reset_value) Pipe Control Register */
+
+#define USBC_UPCON4_RXINE_Pos       0            /**< \brief (USBC_UPCON4) RXIN Interrupt Enable */
+#define USBC_UPCON4_RXINE           (_U(0x1) << USBC_UPCON4_RXINE_Pos)
+#define USBC_UPCON4_TXOUTE_Pos      1            /**< \brief (USBC_UPCON4) TXOUT Interrupt Enable */
+#define USBC_UPCON4_TXOUTE          (_U(0x1) << USBC_UPCON4_TXOUTE_Pos)
+#define USBC_UPCON4_TXSTPE_Pos      2            /**< \brief (USBC_UPCON4) TXSTP Interrupt Enable */
+#define USBC_UPCON4_TXSTPE          (_U(0x1) << USBC_UPCON4_TXSTPE_Pos)
+#define USBC_UPCON4_PERRE_Pos       3            /**< \brief (USBC_UPCON4) PERR Interrupt Enable */
+#define USBC_UPCON4_PERRE           (_U(0x1) << USBC_UPCON4_PERRE_Pos)
+#define USBC_UPCON4_NAKEDE_Pos      4            /**< \brief (USBC_UPCON4) NAKED Interrupt Enable */
+#define USBC_UPCON4_NAKEDE          (_U(0x1) << USBC_UPCON4_NAKEDE_Pos)
+#define USBC_UPCON4_ERRORFIE_Pos    5            /**< \brief (USBC_UPCON4) ERRORFI Interrupt Enable */
+#define USBC_UPCON4_ERRORFIE        (_U(0x1) << USBC_UPCON4_ERRORFIE_Pos)
+#define USBC_UPCON4_RXSTALLDE_Pos   6            /**< \brief (USBC_UPCON4) RXTALLD Interrupt Enable */
+#define USBC_UPCON4_RXSTALLDE       (_U(0x1) << USBC_UPCON4_RXSTALLDE_Pos)
+#define USBC_UPCON4_RAMACERE_Pos    10           /**< \brief (USBC_UPCON4) RAMACER Interrupt Enable */
+#define USBC_UPCON4_RAMACERE        (_U(0x1) << USBC_UPCON4_RAMACERE_Pos)
+#define USBC_UPCON4_NBUSYBKE_Pos    12           /**< \brief (USBC_UPCON4) NBUSYBKInterrupt Enable */
+#define USBC_UPCON4_NBUSYBKE        (_U(0x1) << USBC_UPCON4_NBUSYBKE_Pos)
+#define USBC_UPCON4_FIFOCON_Pos     14           /**< \brief (USBC_UPCON4) FIFO Control */
+#define USBC_UPCON4_FIFOCON         (_U(0x1) << USBC_UPCON4_FIFOCON_Pos)
+#define USBC_UPCON4_PFREEZE_Pos     17           /**< \brief (USBC_UPCON4) Pipe Freeze */
+#define USBC_UPCON4_PFREEZE         (_U(0x1) << USBC_UPCON4_PFREEZE_Pos)
+#define USBC_UPCON4_INITDTGL_Pos    18           /**< \brief (USBC_UPCON4) Data Toggle Initialization */
+#define USBC_UPCON4_INITDTGL        (_U(0x1) << USBC_UPCON4_INITDTGL_Pos)
+#define USBC_UPCON4_INITBK_Pos      19           /**< \brief (USBC_UPCON4) Bank Initialization */
+#define USBC_UPCON4_INITBK          (_U(0x1) << USBC_UPCON4_INITBK_Pos)
+#define USBC_UPCON4_MASK            _U(0x000E547F) /**< \brief (USBC_UPCON4) MASK Register */
+
+/* -------- USBC_UPCON5 : (USBC Offset: 0x5D4) (R/  32) Pipe Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINE:1;          /*!< bit:      0  RXIN Interrupt Enable              */
+    uint32_t TXOUTE:1;         /*!< bit:      1  TXOUT Interrupt Enable             */
+    uint32_t TXSTPE:1;         /*!< bit:      2  TXSTP Interrupt Enable             */
+    uint32_t PERRE:1;          /*!< bit:      3  PERR Interrupt Enable              */
+    uint32_t NAKEDE:1;         /*!< bit:      4  NAKED Interrupt Enable             */
+    uint32_t ERRORFIE:1;       /*!< bit:      5  ERRORFI Interrupt Enable           */
+    uint32_t RXSTALLDE:1;      /*!< bit:      6  RXTALLD Interrupt Enable           */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERE:1;       /*!< bit:     10  RAMACER Interrupt Enable           */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBKE:1;       /*!< bit:     12  NBUSYBKInterrupt Enable            */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCON:1;        /*!< bit:     14  FIFO Control                       */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t PFREEZE:1;        /*!< bit:     17  Pipe Freeze                        */
+    uint32_t INITDTGL:1;       /*!< bit:     18  Data Toggle Initialization         */
+    uint32_t INITBK:1;         /*!< bit:     19  Bank Initialization                */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCON5_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCON5_OFFSET          0x5D4        /**< \brief (USBC_UPCON5 offset) Pipe Control Register */
+#define USBC_UPCON5_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCON5 reset_value) Pipe Control Register */
+
+#define USBC_UPCON5_RXINE_Pos       0            /**< \brief (USBC_UPCON5) RXIN Interrupt Enable */
+#define USBC_UPCON5_RXINE           (_U(0x1) << USBC_UPCON5_RXINE_Pos)
+#define USBC_UPCON5_TXOUTE_Pos      1            /**< \brief (USBC_UPCON5) TXOUT Interrupt Enable */
+#define USBC_UPCON5_TXOUTE          (_U(0x1) << USBC_UPCON5_TXOUTE_Pos)
+#define USBC_UPCON5_TXSTPE_Pos      2            /**< \brief (USBC_UPCON5) TXSTP Interrupt Enable */
+#define USBC_UPCON5_TXSTPE          (_U(0x1) << USBC_UPCON5_TXSTPE_Pos)
+#define USBC_UPCON5_PERRE_Pos       3            /**< \brief (USBC_UPCON5) PERR Interrupt Enable */
+#define USBC_UPCON5_PERRE           (_U(0x1) << USBC_UPCON5_PERRE_Pos)
+#define USBC_UPCON5_NAKEDE_Pos      4            /**< \brief (USBC_UPCON5) NAKED Interrupt Enable */
+#define USBC_UPCON5_NAKEDE          (_U(0x1) << USBC_UPCON5_NAKEDE_Pos)
+#define USBC_UPCON5_ERRORFIE_Pos    5            /**< \brief (USBC_UPCON5) ERRORFI Interrupt Enable */
+#define USBC_UPCON5_ERRORFIE        (_U(0x1) << USBC_UPCON5_ERRORFIE_Pos)
+#define USBC_UPCON5_RXSTALLDE_Pos   6            /**< \brief (USBC_UPCON5) RXTALLD Interrupt Enable */
+#define USBC_UPCON5_RXSTALLDE       (_U(0x1) << USBC_UPCON5_RXSTALLDE_Pos)
+#define USBC_UPCON5_RAMACERE_Pos    10           /**< \brief (USBC_UPCON5) RAMACER Interrupt Enable */
+#define USBC_UPCON5_RAMACERE        (_U(0x1) << USBC_UPCON5_RAMACERE_Pos)
+#define USBC_UPCON5_NBUSYBKE_Pos    12           /**< \brief (USBC_UPCON5) NBUSYBKInterrupt Enable */
+#define USBC_UPCON5_NBUSYBKE        (_U(0x1) << USBC_UPCON5_NBUSYBKE_Pos)
+#define USBC_UPCON5_FIFOCON_Pos     14           /**< \brief (USBC_UPCON5) FIFO Control */
+#define USBC_UPCON5_FIFOCON         (_U(0x1) << USBC_UPCON5_FIFOCON_Pos)
+#define USBC_UPCON5_PFREEZE_Pos     17           /**< \brief (USBC_UPCON5) Pipe Freeze */
+#define USBC_UPCON5_PFREEZE         (_U(0x1) << USBC_UPCON5_PFREEZE_Pos)
+#define USBC_UPCON5_INITDTGL_Pos    18           /**< \brief (USBC_UPCON5) Data Toggle Initialization */
+#define USBC_UPCON5_INITDTGL        (_U(0x1) << USBC_UPCON5_INITDTGL_Pos)
+#define USBC_UPCON5_INITBK_Pos      19           /**< \brief (USBC_UPCON5) Bank Initialization */
+#define USBC_UPCON5_INITBK          (_U(0x1) << USBC_UPCON5_INITBK_Pos)
+#define USBC_UPCON5_MASK            _U(0x000E547F) /**< \brief (USBC_UPCON5) MASK Register */
+
+/* -------- USBC_UPCON6 : (USBC Offset: 0x5D8) (R/  32) Pipe Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINE:1;          /*!< bit:      0  RXIN Interrupt Enable              */
+    uint32_t TXOUTE:1;         /*!< bit:      1  TXOUT Interrupt Enable             */
+    uint32_t TXSTPE:1;         /*!< bit:      2  TXSTP Interrupt Enable             */
+    uint32_t PERRE:1;          /*!< bit:      3  PERR Interrupt Enable              */
+    uint32_t NAKEDE:1;         /*!< bit:      4  NAKED Interrupt Enable             */
+    uint32_t ERRORFIE:1;       /*!< bit:      5  ERRORFI Interrupt Enable           */
+    uint32_t RXSTALLDE:1;      /*!< bit:      6  RXTALLD Interrupt Enable           */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERE:1;       /*!< bit:     10  RAMACER Interrupt Enable           */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBKE:1;       /*!< bit:     12  NBUSYBKInterrupt Enable            */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCON:1;        /*!< bit:     14  FIFO Control                       */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t PFREEZE:1;        /*!< bit:     17  Pipe Freeze                        */
+    uint32_t INITDTGL:1;       /*!< bit:     18  Data Toggle Initialization         */
+    uint32_t INITBK:1;         /*!< bit:     19  Bank Initialization                */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCON6_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCON6_OFFSET          0x5D8        /**< \brief (USBC_UPCON6 offset) Pipe Control Register */
+#define USBC_UPCON6_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCON6 reset_value) Pipe Control Register */
+
+#define USBC_UPCON6_RXINE_Pos       0            /**< \brief (USBC_UPCON6) RXIN Interrupt Enable */
+#define USBC_UPCON6_RXINE           (_U(0x1) << USBC_UPCON6_RXINE_Pos)
+#define USBC_UPCON6_TXOUTE_Pos      1            /**< \brief (USBC_UPCON6) TXOUT Interrupt Enable */
+#define USBC_UPCON6_TXOUTE          (_U(0x1) << USBC_UPCON6_TXOUTE_Pos)
+#define USBC_UPCON6_TXSTPE_Pos      2            /**< \brief (USBC_UPCON6) TXSTP Interrupt Enable */
+#define USBC_UPCON6_TXSTPE          (_U(0x1) << USBC_UPCON6_TXSTPE_Pos)
+#define USBC_UPCON6_PERRE_Pos       3            /**< \brief (USBC_UPCON6) PERR Interrupt Enable */
+#define USBC_UPCON6_PERRE           (_U(0x1) << USBC_UPCON6_PERRE_Pos)
+#define USBC_UPCON6_NAKEDE_Pos      4            /**< \brief (USBC_UPCON6) NAKED Interrupt Enable */
+#define USBC_UPCON6_NAKEDE          (_U(0x1) << USBC_UPCON6_NAKEDE_Pos)
+#define USBC_UPCON6_ERRORFIE_Pos    5            /**< \brief (USBC_UPCON6) ERRORFI Interrupt Enable */
+#define USBC_UPCON6_ERRORFIE        (_U(0x1) << USBC_UPCON6_ERRORFIE_Pos)
+#define USBC_UPCON6_RXSTALLDE_Pos   6            /**< \brief (USBC_UPCON6) RXTALLD Interrupt Enable */
+#define USBC_UPCON6_RXSTALLDE       (_U(0x1) << USBC_UPCON6_RXSTALLDE_Pos)
+#define USBC_UPCON6_RAMACERE_Pos    10           /**< \brief (USBC_UPCON6) RAMACER Interrupt Enable */
+#define USBC_UPCON6_RAMACERE        (_U(0x1) << USBC_UPCON6_RAMACERE_Pos)
+#define USBC_UPCON6_NBUSYBKE_Pos    12           /**< \brief (USBC_UPCON6) NBUSYBKInterrupt Enable */
+#define USBC_UPCON6_NBUSYBKE        (_U(0x1) << USBC_UPCON6_NBUSYBKE_Pos)
+#define USBC_UPCON6_FIFOCON_Pos     14           /**< \brief (USBC_UPCON6) FIFO Control */
+#define USBC_UPCON6_FIFOCON         (_U(0x1) << USBC_UPCON6_FIFOCON_Pos)
+#define USBC_UPCON6_PFREEZE_Pos     17           /**< \brief (USBC_UPCON6) Pipe Freeze */
+#define USBC_UPCON6_PFREEZE         (_U(0x1) << USBC_UPCON6_PFREEZE_Pos)
+#define USBC_UPCON6_INITDTGL_Pos    18           /**< \brief (USBC_UPCON6) Data Toggle Initialization */
+#define USBC_UPCON6_INITDTGL        (_U(0x1) << USBC_UPCON6_INITDTGL_Pos)
+#define USBC_UPCON6_INITBK_Pos      19           /**< \brief (USBC_UPCON6) Bank Initialization */
+#define USBC_UPCON6_INITBK          (_U(0x1) << USBC_UPCON6_INITBK_Pos)
+#define USBC_UPCON6_MASK            _U(0x000E547F) /**< \brief (USBC_UPCON6) MASK Register */
+
+/* -------- USBC_UPCON7 : (USBC Offset: 0x5DC) (R/  32) Pipe Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINE:1;          /*!< bit:      0  RXIN Interrupt Enable              */
+    uint32_t TXOUTE:1;         /*!< bit:      1  TXOUT Interrupt Enable             */
+    uint32_t TXSTPE:1;         /*!< bit:      2  TXSTP Interrupt Enable             */
+    uint32_t PERRE:1;          /*!< bit:      3  PERR Interrupt Enable              */
+    uint32_t NAKEDE:1;         /*!< bit:      4  NAKED Interrupt Enable             */
+    uint32_t ERRORFIE:1;       /*!< bit:      5  ERRORFI Interrupt Enable           */
+    uint32_t RXSTALLDE:1;      /*!< bit:      6  RXTALLD Interrupt Enable           */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERE:1;       /*!< bit:     10  RAMACER Interrupt Enable           */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBKE:1;       /*!< bit:     12  NBUSYBKInterrupt Enable            */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCON:1;        /*!< bit:     14  FIFO Control                       */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t PFREEZE:1;        /*!< bit:     17  Pipe Freeze                        */
+    uint32_t INITDTGL:1;       /*!< bit:     18  Data Toggle Initialization         */
+    uint32_t INITBK:1;         /*!< bit:     19  Bank Initialization                */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCON7_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCON7_OFFSET          0x5DC        /**< \brief (USBC_UPCON7 offset) Pipe Control Register */
+#define USBC_UPCON7_RESETVALUE      _U(0x00000000); /**< \brief (USBC_UPCON7 reset_value) Pipe Control Register */
+
+#define USBC_UPCON7_RXINE_Pos       0            /**< \brief (USBC_UPCON7) RXIN Interrupt Enable */
+#define USBC_UPCON7_RXINE           (_U(0x1) << USBC_UPCON7_RXINE_Pos)
+#define USBC_UPCON7_TXOUTE_Pos      1            /**< \brief (USBC_UPCON7) TXOUT Interrupt Enable */
+#define USBC_UPCON7_TXOUTE          (_U(0x1) << USBC_UPCON7_TXOUTE_Pos)
+#define USBC_UPCON7_TXSTPE_Pos      2            /**< \brief (USBC_UPCON7) TXSTP Interrupt Enable */
+#define USBC_UPCON7_TXSTPE          (_U(0x1) << USBC_UPCON7_TXSTPE_Pos)
+#define USBC_UPCON7_PERRE_Pos       3            /**< \brief (USBC_UPCON7) PERR Interrupt Enable */
+#define USBC_UPCON7_PERRE           (_U(0x1) << USBC_UPCON7_PERRE_Pos)
+#define USBC_UPCON7_NAKEDE_Pos      4            /**< \brief (USBC_UPCON7) NAKED Interrupt Enable */
+#define USBC_UPCON7_NAKEDE          (_U(0x1) << USBC_UPCON7_NAKEDE_Pos)
+#define USBC_UPCON7_ERRORFIE_Pos    5            /**< \brief (USBC_UPCON7) ERRORFI Interrupt Enable */
+#define USBC_UPCON7_ERRORFIE        (_U(0x1) << USBC_UPCON7_ERRORFIE_Pos)
+#define USBC_UPCON7_RXSTALLDE_Pos   6            /**< \brief (USBC_UPCON7) RXTALLD Interrupt Enable */
+#define USBC_UPCON7_RXSTALLDE       (_U(0x1) << USBC_UPCON7_RXSTALLDE_Pos)
+#define USBC_UPCON7_RAMACERE_Pos    10           /**< \brief (USBC_UPCON7) RAMACER Interrupt Enable */
+#define USBC_UPCON7_RAMACERE        (_U(0x1) << USBC_UPCON7_RAMACERE_Pos)
+#define USBC_UPCON7_NBUSYBKE_Pos    12           /**< \brief (USBC_UPCON7) NBUSYBKInterrupt Enable */
+#define USBC_UPCON7_NBUSYBKE        (_U(0x1) << USBC_UPCON7_NBUSYBKE_Pos)
+#define USBC_UPCON7_FIFOCON_Pos     14           /**< \brief (USBC_UPCON7) FIFO Control */
+#define USBC_UPCON7_FIFOCON         (_U(0x1) << USBC_UPCON7_FIFOCON_Pos)
+#define USBC_UPCON7_PFREEZE_Pos     17           /**< \brief (USBC_UPCON7) Pipe Freeze */
+#define USBC_UPCON7_PFREEZE         (_U(0x1) << USBC_UPCON7_PFREEZE_Pos)
+#define USBC_UPCON7_INITDTGL_Pos    18           /**< \brief (USBC_UPCON7) Data Toggle Initialization */
+#define USBC_UPCON7_INITDTGL        (_U(0x1) << USBC_UPCON7_INITDTGL_Pos)
+#define USBC_UPCON7_INITBK_Pos      19           /**< \brief (USBC_UPCON7) Bank Initialization */
+#define USBC_UPCON7_INITBK          (_U(0x1) << USBC_UPCON7_INITBK_Pos)
+#define USBC_UPCON7_MASK            _U(0x000E547F) /**< \brief (USBC_UPCON7) MASK Register */
+
+/* -------- USBC_UPCON0SET : (USBC Offset: 0x5F0) ( /W 32) Pipe Control Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINES:1;         /*!< bit:      0  RXINE Set                          */
+    uint32_t TXOUTES:1;        /*!< bit:      1  TXOUTE Set                         */
+    uint32_t TXSTPES:1;        /*!< bit:      2  TXSTPE Set                         */
+    uint32_t PERRES:1;         /*!< bit:      3  PERRE Set                          */
+    uint32_t NAKEDES:1;        /*!< bit:      4  NAKEDE Set                         */
+    uint32_t ERRORFIES:1;      /*!< bit:      5  ERRORFIE Set                       */
+    uint32_t RXSTALLDES:1;     /*!< bit:      6  RXSTALLDE Set                      */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERES:1;      /*!< bit:     10  RAMACERE Set                       */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBKES:1;      /*!< bit:     12  NBUSYBKE Set                       */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCONS:1;       /*!< bit:     14  FIFOCON Set                        */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t PFREEZES:1;       /*!< bit:     17  PFREEZE Set                        */
+    uint32_t INITDTGLS:1;      /*!< bit:     18  INITDTGL Set                       */
+    uint32_t INITBKS:1;        /*!< bit:     19  INITBK Set                         */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCON0SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCON0SET_OFFSET       0x5F0        /**< \brief (USBC_UPCON0SET offset) Pipe Control Set Register */
+#define USBC_UPCON0SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON0SET reset_value) Pipe Control Set Register */
+
+#define USBC_UPCON0SET_RXINES_Pos   0            /**< \brief (USBC_UPCON0SET) RXINE Set */
+#define USBC_UPCON0SET_RXINES       (_U(0x1) << USBC_UPCON0SET_RXINES_Pos)
+#define USBC_UPCON0SET_TXOUTES_Pos  1            /**< \brief (USBC_UPCON0SET) TXOUTE Set */
+#define USBC_UPCON0SET_TXOUTES      (_U(0x1) << USBC_UPCON0SET_TXOUTES_Pos)
+#define USBC_UPCON0SET_TXSTPES_Pos  2            /**< \brief (USBC_UPCON0SET) TXSTPE Set */
+#define USBC_UPCON0SET_TXSTPES      (_U(0x1) << USBC_UPCON0SET_TXSTPES_Pos)
+#define USBC_UPCON0SET_PERRES_Pos   3            /**< \brief (USBC_UPCON0SET) PERRE Set */
+#define USBC_UPCON0SET_PERRES       (_U(0x1) << USBC_UPCON0SET_PERRES_Pos)
+#define USBC_UPCON0SET_NAKEDES_Pos  4            /**< \brief (USBC_UPCON0SET) NAKEDE Set */
+#define USBC_UPCON0SET_NAKEDES      (_U(0x1) << USBC_UPCON0SET_NAKEDES_Pos)
+#define USBC_UPCON0SET_ERRORFIES_Pos 5            /**< \brief (USBC_UPCON0SET) ERRORFIE Set */
+#define USBC_UPCON0SET_ERRORFIES    (_U(0x1) << USBC_UPCON0SET_ERRORFIES_Pos)
+#define USBC_UPCON0SET_RXSTALLDES_Pos 6            /**< \brief (USBC_UPCON0SET) RXSTALLDE Set */
+#define USBC_UPCON0SET_RXSTALLDES   (_U(0x1) << USBC_UPCON0SET_RXSTALLDES_Pos)
+#define USBC_UPCON0SET_RAMACERES_Pos 10           /**< \brief (USBC_UPCON0SET) RAMACERE Set */
+#define USBC_UPCON0SET_RAMACERES    (_U(0x1) << USBC_UPCON0SET_RAMACERES_Pos)
+#define USBC_UPCON0SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UPCON0SET) NBUSYBKE Set */
+#define USBC_UPCON0SET_NBUSYBKES    (_U(0x1) << USBC_UPCON0SET_NBUSYBKES_Pos)
+#define USBC_UPCON0SET_FIFOCONS_Pos 14           /**< \brief (USBC_UPCON0SET) FIFOCON Set */
+#define USBC_UPCON0SET_FIFOCONS     (_U(0x1) << USBC_UPCON0SET_FIFOCONS_Pos)
+#define USBC_UPCON0SET_PFREEZES_Pos 17           /**< \brief (USBC_UPCON0SET) PFREEZE Set */
+#define USBC_UPCON0SET_PFREEZES     (_U(0x1) << USBC_UPCON0SET_PFREEZES_Pos)
+#define USBC_UPCON0SET_INITDTGLS_Pos 18           /**< \brief (USBC_UPCON0SET) INITDTGL Set */
+#define USBC_UPCON0SET_INITDTGLS    (_U(0x1) << USBC_UPCON0SET_INITDTGLS_Pos)
+#define USBC_UPCON0SET_INITBKS_Pos  19           /**< \brief (USBC_UPCON0SET) INITBK Set */
+#define USBC_UPCON0SET_INITBKS      (_U(0x1) << USBC_UPCON0SET_INITBKS_Pos)
+#define USBC_UPCON0SET_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON0SET) MASK Register */
+
+/* -------- USBC_UPCON1SET : (USBC Offset: 0x5F4) ( /W 32) Pipe Control Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINES:1;         /*!< bit:      0  RXINE Set                          */
+    uint32_t TXOUTES:1;        /*!< bit:      1  TXOUTE Set                         */
+    uint32_t TXSTPES:1;        /*!< bit:      2  TXSTPE Set                         */
+    uint32_t PERRES:1;         /*!< bit:      3  PERRE Set                          */
+    uint32_t NAKEDES:1;        /*!< bit:      4  NAKEDE Set                         */
+    uint32_t ERRORFIES:1;      /*!< bit:      5  ERRORFIE Set                       */
+    uint32_t RXSTALLDES:1;     /*!< bit:      6  RXSTALLDE Set                      */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERES:1;      /*!< bit:     10  RAMACERE Set                       */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBKES:1;      /*!< bit:     12  NBUSYBKE Set                       */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCONS:1;       /*!< bit:     14  FIFOCON Set                        */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t PFREEZES:1;       /*!< bit:     17  PFREEZE Set                        */
+    uint32_t INITDTGLS:1;      /*!< bit:     18  INITDTGL Set                       */
+    uint32_t INITBKS:1;        /*!< bit:     19  INITBK Set                         */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCON1SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCON1SET_OFFSET       0x5F4        /**< \brief (USBC_UPCON1SET offset) Pipe Control Set Register */
+#define USBC_UPCON1SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON1SET reset_value) Pipe Control Set Register */
+
+#define USBC_UPCON1SET_RXINES_Pos   0            /**< \brief (USBC_UPCON1SET) RXINE Set */
+#define USBC_UPCON1SET_RXINES       (_U(0x1) << USBC_UPCON1SET_RXINES_Pos)
+#define USBC_UPCON1SET_TXOUTES_Pos  1            /**< \brief (USBC_UPCON1SET) TXOUTE Set */
+#define USBC_UPCON1SET_TXOUTES      (_U(0x1) << USBC_UPCON1SET_TXOUTES_Pos)
+#define USBC_UPCON1SET_TXSTPES_Pos  2            /**< \brief (USBC_UPCON1SET) TXSTPE Set */
+#define USBC_UPCON1SET_TXSTPES      (_U(0x1) << USBC_UPCON1SET_TXSTPES_Pos)
+#define USBC_UPCON1SET_PERRES_Pos   3            /**< \brief (USBC_UPCON1SET) PERRE Set */
+#define USBC_UPCON1SET_PERRES       (_U(0x1) << USBC_UPCON1SET_PERRES_Pos)
+#define USBC_UPCON1SET_NAKEDES_Pos  4            /**< \brief (USBC_UPCON1SET) NAKEDE Set */
+#define USBC_UPCON1SET_NAKEDES      (_U(0x1) << USBC_UPCON1SET_NAKEDES_Pos)
+#define USBC_UPCON1SET_ERRORFIES_Pos 5            /**< \brief (USBC_UPCON1SET) ERRORFIE Set */
+#define USBC_UPCON1SET_ERRORFIES    (_U(0x1) << USBC_UPCON1SET_ERRORFIES_Pos)
+#define USBC_UPCON1SET_RXSTALLDES_Pos 6            /**< \brief (USBC_UPCON1SET) RXSTALLDE Set */
+#define USBC_UPCON1SET_RXSTALLDES   (_U(0x1) << USBC_UPCON1SET_RXSTALLDES_Pos)
+#define USBC_UPCON1SET_RAMACERES_Pos 10           /**< \brief (USBC_UPCON1SET) RAMACERE Set */
+#define USBC_UPCON1SET_RAMACERES    (_U(0x1) << USBC_UPCON1SET_RAMACERES_Pos)
+#define USBC_UPCON1SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UPCON1SET) NBUSYBKE Set */
+#define USBC_UPCON1SET_NBUSYBKES    (_U(0x1) << USBC_UPCON1SET_NBUSYBKES_Pos)
+#define USBC_UPCON1SET_FIFOCONS_Pos 14           /**< \brief (USBC_UPCON1SET) FIFOCON Set */
+#define USBC_UPCON1SET_FIFOCONS     (_U(0x1) << USBC_UPCON1SET_FIFOCONS_Pos)
+#define USBC_UPCON1SET_PFREEZES_Pos 17           /**< \brief (USBC_UPCON1SET) PFREEZE Set */
+#define USBC_UPCON1SET_PFREEZES     (_U(0x1) << USBC_UPCON1SET_PFREEZES_Pos)
+#define USBC_UPCON1SET_INITDTGLS_Pos 18           /**< \brief (USBC_UPCON1SET) INITDTGL Set */
+#define USBC_UPCON1SET_INITDTGLS    (_U(0x1) << USBC_UPCON1SET_INITDTGLS_Pos)
+#define USBC_UPCON1SET_INITBKS_Pos  19           /**< \brief (USBC_UPCON1SET) INITBK Set */
+#define USBC_UPCON1SET_INITBKS      (_U(0x1) << USBC_UPCON1SET_INITBKS_Pos)
+#define USBC_UPCON1SET_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON1SET) MASK Register */
+
+/* -------- USBC_UPCON2SET : (USBC Offset: 0x5F8) ( /W 32) Pipe Control Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINES:1;         /*!< bit:      0  RXINE Set                          */
+    uint32_t TXOUTES:1;        /*!< bit:      1  TXOUTE Set                         */
+    uint32_t TXSTPES:1;        /*!< bit:      2  TXSTPE Set                         */
+    uint32_t PERRES:1;         /*!< bit:      3  PERRE Set                          */
+    uint32_t NAKEDES:1;        /*!< bit:      4  NAKEDE Set                         */
+    uint32_t ERRORFIES:1;      /*!< bit:      5  ERRORFIE Set                       */
+    uint32_t RXSTALLDES:1;     /*!< bit:      6  RXSTALLDE Set                      */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERES:1;      /*!< bit:     10  RAMACERE Set                       */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBKES:1;      /*!< bit:     12  NBUSYBKE Set                       */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCONS:1;       /*!< bit:     14  FIFOCON Set                        */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t PFREEZES:1;       /*!< bit:     17  PFREEZE Set                        */
+    uint32_t INITDTGLS:1;      /*!< bit:     18  INITDTGL Set                       */
+    uint32_t INITBKS:1;        /*!< bit:     19  INITBK Set                         */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCON2SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCON2SET_OFFSET       0x5F8        /**< \brief (USBC_UPCON2SET offset) Pipe Control Set Register */
+#define USBC_UPCON2SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON2SET reset_value) Pipe Control Set Register */
+
+#define USBC_UPCON2SET_RXINES_Pos   0            /**< \brief (USBC_UPCON2SET) RXINE Set */
+#define USBC_UPCON2SET_RXINES       (_U(0x1) << USBC_UPCON2SET_RXINES_Pos)
+#define USBC_UPCON2SET_TXOUTES_Pos  1            /**< \brief (USBC_UPCON2SET) TXOUTE Set */
+#define USBC_UPCON2SET_TXOUTES      (_U(0x1) << USBC_UPCON2SET_TXOUTES_Pos)
+#define USBC_UPCON2SET_TXSTPES_Pos  2            /**< \brief (USBC_UPCON2SET) TXSTPE Set */
+#define USBC_UPCON2SET_TXSTPES      (_U(0x1) << USBC_UPCON2SET_TXSTPES_Pos)
+#define USBC_UPCON2SET_PERRES_Pos   3            /**< \brief (USBC_UPCON2SET) PERRE Set */
+#define USBC_UPCON2SET_PERRES       (_U(0x1) << USBC_UPCON2SET_PERRES_Pos)
+#define USBC_UPCON2SET_NAKEDES_Pos  4            /**< \brief (USBC_UPCON2SET) NAKEDE Set */
+#define USBC_UPCON2SET_NAKEDES      (_U(0x1) << USBC_UPCON2SET_NAKEDES_Pos)
+#define USBC_UPCON2SET_ERRORFIES_Pos 5            /**< \brief (USBC_UPCON2SET) ERRORFIE Set */
+#define USBC_UPCON2SET_ERRORFIES    (_U(0x1) << USBC_UPCON2SET_ERRORFIES_Pos)
+#define USBC_UPCON2SET_RXSTALLDES_Pos 6            /**< \brief (USBC_UPCON2SET) RXSTALLDE Set */
+#define USBC_UPCON2SET_RXSTALLDES   (_U(0x1) << USBC_UPCON2SET_RXSTALLDES_Pos)
+#define USBC_UPCON2SET_RAMACERES_Pos 10           /**< \brief (USBC_UPCON2SET) RAMACERE Set */
+#define USBC_UPCON2SET_RAMACERES    (_U(0x1) << USBC_UPCON2SET_RAMACERES_Pos)
+#define USBC_UPCON2SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UPCON2SET) NBUSYBKE Set */
+#define USBC_UPCON2SET_NBUSYBKES    (_U(0x1) << USBC_UPCON2SET_NBUSYBKES_Pos)
+#define USBC_UPCON2SET_FIFOCONS_Pos 14           /**< \brief (USBC_UPCON2SET) FIFOCON Set */
+#define USBC_UPCON2SET_FIFOCONS     (_U(0x1) << USBC_UPCON2SET_FIFOCONS_Pos)
+#define USBC_UPCON2SET_PFREEZES_Pos 17           /**< \brief (USBC_UPCON2SET) PFREEZE Set */
+#define USBC_UPCON2SET_PFREEZES     (_U(0x1) << USBC_UPCON2SET_PFREEZES_Pos)
+#define USBC_UPCON2SET_INITDTGLS_Pos 18           /**< \brief (USBC_UPCON2SET) INITDTGL Set */
+#define USBC_UPCON2SET_INITDTGLS    (_U(0x1) << USBC_UPCON2SET_INITDTGLS_Pos)
+#define USBC_UPCON2SET_INITBKS_Pos  19           /**< \brief (USBC_UPCON2SET) INITBK Set */
+#define USBC_UPCON2SET_INITBKS      (_U(0x1) << USBC_UPCON2SET_INITBKS_Pos)
+#define USBC_UPCON2SET_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON2SET) MASK Register */
+
+/* -------- USBC_UPCON3SET : (USBC Offset: 0x5FC) ( /W 32) Pipe Control Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINES:1;         /*!< bit:      0  RXINE Set                          */
+    uint32_t TXOUTES:1;        /*!< bit:      1  TXOUTE Set                         */
+    uint32_t TXSTPES:1;        /*!< bit:      2  TXSTPE Set                         */
+    uint32_t PERRES:1;         /*!< bit:      3  PERRE Set                          */
+    uint32_t NAKEDES:1;        /*!< bit:      4  NAKEDE Set                         */
+    uint32_t ERRORFIES:1;      /*!< bit:      5  ERRORFIE Set                       */
+    uint32_t RXSTALLDES:1;     /*!< bit:      6  RXSTALLDE Set                      */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERES:1;      /*!< bit:     10  RAMACERE Set                       */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBKES:1;      /*!< bit:     12  NBUSYBKE Set                       */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCONS:1;       /*!< bit:     14  FIFOCON Set                        */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t PFREEZES:1;       /*!< bit:     17  PFREEZE Set                        */
+    uint32_t INITDTGLS:1;      /*!< bit:     18  INITDTGL Set                       */
+    uint32_t INITBKS:1;        /*!< bit:     19  INITBK Set                         */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCON3SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCON3SET_OFFSET       0x5FC        /**< \brief (USBC_UPCON3SET offset) Pipe Control Set Register */
+#define USBC_UPCON3SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON3SET reset_value) Pipe Control Set Register */
+
+#define USBC_UPCON3SET_RXINES_Pos   0            /**< \brief (USBC_UPCON3SET) RXINE Set */
+#define USBC_UPCON3SET_RXINES       (_U(0x1) << USBC_UPCON3SET_RXINES_Pos)
+#define USBC_UPCON3SET_TXOUTES_Pos  1            /**< \brief (USBC_UPCON3SET) TXOUTE Set */
+#define USBC_UPCON3SET_TXOUTES      (_U(0x1) << USBC_UPCON3SET_TXOUTES_Pos)
+#define USBC_UPCON3SET_TXSTPES_Pos  2            /**< \brief (USBC_UPCON3SET) TXSTPE Set */
+#define USBC_UPCON3SET_TXSTPES      (_U(0x1) << USBC_UPCON3SET_TXSTPES_Pos)
+#define USBC_UPCON3SET_PERRES_Pos   3            /**< \brief (USBC_UPCON3SET) PERRE Set */
+#define USBC_UPCON3SET_PERRES       (_U(0x1) << USBC_UPCON3SET_PERRES_Pos)
+#define USBC_UPCON3SET_NAKEDES_Pos  4            /**< \brief (USBC_UPCON3SET) NAKEDE Set */
+#define USBC_UPCON3SET_NAKEDES      (_U(0x1) << USBC_UPCON3SET_NAKEDES_Pos)
+#define USBC_UPCON3SET_ERRORFIES_Pos 5            /**< \brief (USBC_UPCON3SET) ERRORFIE Set */
+#define USBC_UPCON3SET_ERRORFIES    (_U(0x1) << USBC_UPCON3SET_ERRORFIES_Pos)
+#define USBC_UPCON3SET_RXSTALLDES_Pos 6            /**< \brief (USBC_UPCON3SET) RXSTALLDE Set */
+#define USBC_UPCON3SET_RXSTALLDES   (_U(0x1) << USBC_UPCON3SET_RXSTALLDES_Pos)
+#define USBC_UPCON3SET_RAMACERES_Pos 10           /**< \brief (USBC_UPCON3SET) RAMACERE Set */
+#define USBC_UPCON3SET_RAMACERES    (_U(0x1) << USBC_UPCON3SET_RAMACERES_Pos)
+#define USBC_UPCON3SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UPCON3SET) NBUSYBKE Set */
+#define USBC_UPCON3SET_NBUSYBKES    (_U(0x1) << USBC_UPCON3SET_NBUSYBKES_Pos)
+#define USBC_UPCON3SET_FIFOCONS_Pos 14           /**< \brief (USBC_UPCON3SET) FIFOCON Set */
+#define USBC_UPCON3SET_FIFOCONS     (_U(0x1) << USBC_UPCON3SET_FIFOCONS_Pos)
+#define USBC_UPCON3SET_PFREEZES_Pos 17           /**< \brief (USBC_UPCON3SET) PFREEZE Set */
+#define USBC_UPCON3SET_PFREEZES     (_U(0x1) << USBC_UPCON3SET_PFREEZES_Pos)
+#define USBC_UPCON3SET_INITDTGLS_Pos 18           /**< \brief (USBC_UPCON3SET) INITDTGL Set */
+#define USBC_UPCON3SET_INITDTGLS    (_U(0x1) << USBC_UPCON3SET_INITDTGLS_Pos)
+#define USBC_UPCON3SET_INITBKS_Pos  19           /**< \brief (USBC_UPCON3SET) INITBK Set */
+#define USBC_UPCON3SET_INITBKS      (_U(0x1) << USBC_UPCON3SET_INITBKS_Pos)
+#define USBC_UPCON3SET_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON3SET) MASK Register */
+
+/* -------- USBC_UPCON4SET : (USBC Offset: 0x600) ( /W 32) Pipe Control Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINES:1;         /*!< bit:      0  RXINE Set                          */
+    uint32_t TXOUTES:1;        /*!< bit:      1  TXOUTE Set                         */
+    uint32_t TXSTPES:1;        /*!< bit:      2  TXSTPE Set                         */
+    uint32_t PERRES:1;         /*!< bit:      3  PERRE Set                          */
+    uint32_t NAKEDES:1;        /*!< bit:      4  NAKEDE Set                         */
+    uint32_t ERRORFIES:1;      /*!< bit:      5  ERRORFIE Set                       */
+    uint32_t RXSTALLDES:1;     /*!< bit:      6  RXSTALLDE Set                      */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERES:1;      /*!< bit:     10  RAMACERE Set                       */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBKES:1;      /*!< bit:     12  NBUSYBKE Set                       */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCONS:1;       /*!< bit:     14  FIFOCON Set                        */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t PFREEZES:1;       /*!< bit:     17  PFREEZE Set                        */
+    uint32_t INITDTGLS:1;      /*!< bit:     18  INITDTGL Set                       */
+    uint32_t INITBKS:1;        /*!< bit:     19  INITBK Set                         */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCON4SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCON4SET_OFFSET       0x600        /**< \brief (USBC_UPCON4SET offset) Pipe Control Set Register */
+#define USBC_UPCON4SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON4SET reset_value) Pipe Control Set Register */
+
+#define USBC_UPCON4SET_RXINES_Pos   0            /**< \brief (USBC_UPCON4SET) RXINE Set */
+#define USBC_UPCON4SET_RXINES       (_U(0x1) << USBC_UPCON4SET_RXINES_Pos)
+#define USBC_UPCON4SET_TXOUTES_Pos  1            /**< \brief (USBC_UPCON4SET) TXOUTE Set */
+#define USBC_UPCON4SET_TXOUTES      (_U(0x1) << USBC_UPCON4SET_TXOUTES_Pos)
+#define USBC_UPCON4SET_TXSTPES_Pos  2            /**< \brief (USBC_UPCON4SET) TXSTPE Set */
+#define USBC_UPCON4SET_TXSTPES      (_U(0x1) << USBC_UPCON4SET_TXSTPES_Pos)
+#define USBC_UPCON4SET_PERRES_Pos   3            /**< \brief (USBC_UPCON4SET) PERRE Set */
+#define USBC_UPCON4SET_PERRES       (_U(0x1) << USBC_UPCON4SET_PERRES_Pos)
+#define USBC_UPCON4SET_NAKEDES_Pos  4            /**< \brief (USBC_UPCON4SET) NAKEDE Set */
+#define USBC_UPCON4SET_NAKEDES      (_U(0x1) << USBC_UPCON4SET_NAKEDES_Pos)
+#define USBC_UPCON4SET_ERRORFIES_Pos 5            /**< \brief (USBC_UPCON4SET) ERRORFIE Set */
+#define USBC_UPCON4SET_ERRORFIES    (_U(0x1) << USBC_UPCON4SET_ERRORFIES_Pos)
+#define USBC_UPCON4SET_RXSTALLDES_Pos 6            /**< \brief (USBC_UPCON4SET) RXSTALLDE Set */
+#define USBC_UPCON4SET_RXSTALLDES   (_U(0x1) << USBC_UPCON4SET_RXSTALLDES_Pos)
+#define USBC_UPCON4SET_RAMACERES_Pos 10           /**< \brief (USBC_UPCON4SET) RAMACERE Set */
+#define USBC_UPCON4SET_RAMACERES    (_U(0x1) << USBC_UPCON4SET_RAMACERES_Pos)
+#define USBC_UPCON4SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UPCON4SET) NBUSYBKE Set */
+#define USBC_UPCON4SET_NBUSYBKES    (_U(0x1) << USBC_UPCON4SET_NBUSYBKES_Pos)
+#define USBC_UPCON4SET_FIFOCONS_Pos 14           /**< \brief (USBC_UPCON4SET) FIFOCON Set */
+#define USBC_UPCON4SET_FIFOCONS     (_U(0x1) << USBC_UPCON4SET_FIFOCONS_Pos)
+#define USBC_UPCON4SET_PFREEZES_Pos 17           /**< \brief (USBC_UPCON4SET) PFREEZE Set */
+#define USBC_UPCON4SET_PFREEZES     (_U(0x1) << USBC_UPCON4SET_PFREEZES_Pos)
+#define USBC_UPCON4SET_INITDTGLS_Pos 18           /**< \brief (USBC_UPCON4SET) INITDTGL Set */
+#define USBC_UPCON4SET_INITDTGLS    (_U(0x1) << USBC_UPCON4SET_INITDTGLS_Pos)
+#define USBC_UPCON4SET_INITBKS_Pos  19           /**< \brief (USBC_UPCON4SET) INITBK Set */
+#define USBC_UPCON4SET_INITBKS      (_U(0x1) << USBC_UPCON4SET_INITBKS_Pos)
+#define USBC_UPCON4SET_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON4SET) MASK Register */
+
+/* -------- USBC_UPCON5SET : (USBC Offset: 0x604) ( /W 32) Pipe Control Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINES:1;         /*!< bit:      0  RXINE Set                          */
+    uint32_t TXOUTES:1;        /*!< bit:      1  TXOUTE Set                         */
+    uint32_t TXSTPES:1;        /*!< bit:      2  TXSTPE Set                         */
+    uint32_t PERRES:1;         /*!< bit:      3  PERRE Set                          */
+    uint32_t NAKEDES:1;        /*!< bit:      4  NAKEDE Set                         */
+    uint32_t ERRORFIES:1;      /*!< bit:      5  ERRORFIE Set                       */
+    uint32_t RXSTALLDES:1;     /*!< bit:      6  RXSTALLDE Set                      */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERES:1;      /*!< bit:     10  RAMACERE Set                       */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBKES:1;      /*!< bit:     12  NBUSYBKE Set                       */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCONS:1;       /*!< bit:     14  FIFOCON Set                        */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t PFREEZES:1;       /*!< bit:     17  PFREEZE Set                        */
+    uint32_t INITDTGLS:1;      /*!< bit:     18  INITDTGL Set                       */
+    uint32_t INITBKS:1;        /*!< bit:     19  INITBK Set                         */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCON5SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCON5SET_OFFSET       0x604        /**< \brief (USBC_UPCON5SET offset) Pipe Control Set Register */
+#define USBC_UPCON5SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON5SET reset_value) Pipe Control Set Register */
+
+#define USBC_UPCON5SET_RXINES_Pos   0            /**< \brief (USBC_UPCON5SET) RXINE Set */
+#define USBC_UPCON5SET_RXINES       (_U(0x1) << USBC_UPCON5SET_RXINES_Pos)
+#define USBC_UPCON5SET_TXOUTES_Pos  1            /**< \brief (USBC_UPCON5SET) TXOUTE Set */
+#define USBC_UPCON5SET_TXOUTES      (_U(0x1) << USBC_UPCON5SET_TXOUTES_Pos)
+#define USBC_UPCON5SET_TXSTPES_Pos  2            /**< \brief (USBC_UPCON5SET) TXSTPE Set */
+#define USBC_UPCON5SET_TXSTPES      (_U(0x1) << USBC_UPCON5SET_TXSTPES_Pos)
+#define USBC_UPCON5SET_PERRES_Pos   3            /**< \brief (USBC_UPCON5SET) PERRE Set */
+#define USBC_UPCON5SET_PERRES       (_U(0x1) << USBC_UPCON5SET_PERRES_Pos)
+#define USBC_UPCON5SET_NAKEDES_Pos  4            /**< \brief (USBC_UPCON5SET) NAKEDE Set */
+#define USBC_UPCON5SET_NAKEDES      (_U(0x1) << USBC_UPCON5SET_NAKEDES_Pos)
+#define USBC_UPCON5SET_ERRORFIES_Pos 5            /**< \brief (USBC_UPCON5SET) ERRORFIE Set */
+#define USBC_UPCON5SET_ERRORFIES    (_U(0x1) << USBC_UPCON5SET_ERRORFIES_Pos)
+#define USBC_UPCON5SET_RXSTALLDES_Pos 6            /**< \brief (USBC_UPCON5SET) RXSTALLDE Set */
+#define USBC_UPCON5SET_RXSTALLDES   (_U(0x1) << USBC_UPCON5SET_RXSTALLDES_Pos)
+#define USBC_UPCON5SET_RAMACERES_Pos 10           /**< \brief (USBC_UPCON5SET) RAMACERE Set */
+#define USBC_UPCON5SET_RAMACERES    (_U(0x1) << USBC_UPCON5SET_RAMACERES_Pos)
+#define USBC_UPCON5SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UPCON5SET) NBUSYBKE Set */
+#define USBC_UPCON5SET_NBUSYBKES    (_U(0x1) << USBC_UPCON5SET_NBUSYBKES_Pos)
+#define USBC_UPCON5SET_FIFOCONS_Pos 14           /**< \brief (USBC_UPCON5SET) FIFOCON Set */
+#define USBC_UPCON5SET_FIFOCONS     (_U(0x1) << USBC_UPCON5SET_FIFOCONS_Pos)
+#define USBC_UPCON5SET_PFREEZES_Pos 17           /**< \brief (USBC_UPCON5SET) PFREEZE Set */
+#define USBC_UPCON5SET_PFREEZES     (_U(0x1) << USBC_UPCON5SET_PFREEZES_Pos)
+#define USBC_UPCON5SET_INITDTGLS_Pos 18           /**< \brief (USBC_UPCON5SET) INITDTGL Set */
+#define USBC_UPCON5SET_INITDTGLS    (_U(0x1) << USBC_UPCON5SET_INITDTGLS_Pos)
+#define USBC_UPCON5SET_INITBKS_Pos  19           /**< \brief (USBC_UPCON5SET) INITBK Set */
+#define USBC_UPCON5SET_INITBKS      (_U(0x1) << USBC_UPCON5SET_INITBKS_Pos)
+#define USBC_UPCON5SET_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON5SET) MASK Register */
+
+/* -------- USBC_UPCON6SET : (USBC Offset: 0x608) ( /W 32) Pipe Control Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINES:1;         /*!< bit:      0  RXINE Set                          */
+    uint32_t TXOUTES:1;        /*!< bit:      1  TXOUTE Set                         */
+    uint32_t TXSTPES:1;        /*!< bit:      2  TXSTPE Set                         */
+    uint32_t PERRES:1;         /*!< bit:      3  PERRE Set                          */
+    uint32_t NAKEDES:1;        /*!< bit:      4  NAKEDE Set                         */
+    uint32_t ERRORFIES:1;      /*!< bit:      5  ERRORFIE Set                       */
+    uint32_t RXSTALLDES:1;     /*!< bit:      6  RXSTALLDE Set                      */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERES:1;      /*!< bit:     10  RAMACERE Set                       */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBKES:1;      /*!< bit:     12  NBUSYBKE Set                       */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCONS:1;       /*!< bit:     14  FIFOCON Set                        */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t PFREEZES:1;       /*!< bit:     17  PFREEZE Set                        */
+    uint32_t INITDTGLS:1;      /*!< bit:     18  INITDTGL Set                       */
+    uint32_t INITBKS:1;        /*!< bit:     19  INITBK Set                         */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCON6SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCON6SET_OFFSET       0x608        /**< \brief (USBC_UPCON6SET offset) Pipe Control Set Register */
+#define USBC_UPCON6SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON6SET reset_value) Pipe Control Set Register */
+
+#define USBC_UPCON6SET_RXINES_Pos   0            /**< \brief (USBC_UPCON6SET) RXINE Set */
+#define USBC_UPCON6SET_RXINES       (_U(0x1) << USBC_UPCON6SET_RXINES_Pos)
+#define USBC_UPCON6SET_TXOUTES_Pos  1            /**< \brief (USBC_UPCON6SET) TXOUTE Set */
+#define USBC_UPCON6SET_TXOUTES      (_U(0x1) << USBC_UPCON6SET_TXOUTES_Pos)
+#define USBC_UPCON6SET_TXSTPES_Pos  2            /**< \brief (USBC_UPCON6SET) TXSTPE Set */
+#define USBC_UPCON6SET_TXSTPES      (_U(0x1) << USBC_UPCON6SET_TXSTPES_Pos)
+#define USBC_UPCON6SET_PERRES_Pos   3            /**< \brief (USBC_UPCON6SET) PERRE Set */
+#define USBC_UPCON6SET_PERRES       (_U(0x1) << USBC_UPCON6SET_PERRES_Pos)
+#define USBC_UPCON6SET_NAKEDES_Pos  4            /**< \brief (USBC_UPCON6SET) NAKEDE Set */
+#define USBC_UPCON6SET_NAKEDES      (_U(0x1) << USBC_UPCON6SET_NAKEDES_Pos)
+#define USBC_UPCON6SET_ERRORFIES_Pos 5            /**< \brief (USBC_UPCON6SET) ERRORFIE Set */
+#define USBC_UPCON6SET_ERRORFIES    (_U(0x1) << USBC_UPCON6SET_ERRORFIES_Pos)
+#define USBC_UPCON6SET_RXSTALLDES_Pos 6            /**< \brief (USBC_UPCON6SET) RXSTALLDE Set */
+#define USBC_UPCON6SET_RXSTALLDES   (_U(0x1) << USBC_UPCON6SET_RXSTALLDES_Pos)
+#define USBC_UPCON6SET_RAMACERES_Pos 10           /**< \brief (USBC_UPCON6SET) RAMACERE Set */
+#define USBC_UPCON6SET_RAMACERES    (_U(0x1) << USBC_UPCON6SET_RAMACERES_Pos)
+#define USBC_UPCON6SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UPCON6SET) NBUSYBKE Set */
+#define USBC_UPCON6SET_NBUSYBKES    (_U(0x1) << USBC_UPCON6SET_NBUSYBKES_Pos)
+#define USBC_UPCON6SET_FIFOCONS_Pos 14           /**< \brief (USBC_UPCON6SET) FIFOCON Set */
+#define USBC_UPCON6SET_FIFOCONS     (_U(0x1) << USBC_UPCON6SET_FIFOCONS_Pos)
+#define USBC_UPCON6SET_PFREEZES_Pos 17           /**< \brief (USBC_UPCON6SET) PFREEZE Set */
+#define USBC_UPCON6SET_PFREEZES     (_U(0x1) << USBC_UPCON6SET_PFREEZES_Pos)
+#define USBC_UPCON6SET_INITDTGLS_Pos 18           /**< \brief (USBC_UPCON6SET) INITDTGL Set */
+#define USBC_UPCON6SET_INITDTGLS    (_U(0x1) << USBC_UPCON6SET_INITDTGLS_Pos)
+#define USBC_UPCON6SET_INITBKS_Pos  19           /**< \brief (USBC_UPCON6SET) INITBK Set */
+#define USBC_UPCON6SET_INITBKS      (_U(0x1) << USBC_UPCON6SET_INITBKS_Pos)
+#define USBC_UPCON6SET_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON6SET) MASK Register */
+
+/* -------- USBC_UPCON7SET : (USBC Offset: 0x60C) ( /W 32) Pipe Control Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINES:1;         /*!< bit:      0  RXINE Set                          */
+    uint32_t TXOUTES:1;        /*!< bit:      1  TXOUTE Set                         */
+    uint32_t TXSTPES:1;        /*!< bit:      2  TXSTPE Set                         */
+    uint32_t PERRES:1;         /*!< bit:      3  PERRE Set                          */
+    uint32_t NAKEDES:1;        /*!< bit:      4  NAKEDE Set                         */
+    uint32_t ERRORFIES:1;      /*!< bit:      5  ERRORFIE Set                       */
+    uint32_t RXSTALLDES:1;     /*!< bit:      6  RXSTALLDE Set                      */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACERES:1;      /*!< bit:     10  RAMACERE Set                       */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBKES:1;      /*!< bit:     12  NBUSYBKE Set                       */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCONS:1;       /*!< bit:     14  FIFOCON Set                        */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t PFREEZES:1;       /*!< bit:     17  PFREEZE Set                        */
+    uint32_t INITDTGLS:1;      /*!< bit:     18  INITDTGL Set                       */
+    uint32_t INITBKS:1;        /*!< bit:     19  INITBK Set                         */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCON7SET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCON7SET_OFFSET       0x60C        /**< \brief (USBC_UPCON7SET offset) Pipe Control Set Register */
+#define USBC_UPCON7SET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON7SET reset_value) Pipe Control Set Register */
+
+#define USBC_UPCON7SET_RXINES_Pos   0            /**< \brief (USBC_UPCON7SET) RXINE Set */
+#define USBC_UPCON7SET_RXINES       (_U(0x1) << USBC_UPCON7SET_RXINES_Pos)
+#define USBC_UPCON7SET_TXOUTES_Pos  1            /**< \brief (USBC_UPCON7SET) TXOUTE Set */
+#define USBC_UPCON7SET_TXOUTES      (_U(0x1) << USBC_UPCON7SET_TXOUTES_Pos)
+#define USBC_UPCON7SET_TXSTPES_Pos  2            /**< \brief (USBC_UPCON7SET) TXSTPE Set */
+#define USBC_UPCON7SET_TXSTPES      (_U(0x1) << USBC_UPCON7SET_TXSTPES_Pos)
+#define USBC_UPCON7SET_PERRES_Pos   3            /**< \brief (USBC_UPCON7SET) PERRE Set */
+#define USBC_UPCON7SET_PERRES       (_U(0x1) << USBC_UPCON7SET_PERRES_Pos)
+#define USBC_UPCON7SET_NAKEDES_Pos  4            /**< \brief (USBC_UPCON7SET) NAKEDE Set */
+#define USBC_UPCON7SET_NAKEDES      (_U(0x1) << USBC_UPCON7SET_NAKEDES_Pos)
+#define USBC_UPCON7SET_ERRORFIES_Pos 5            /**< \brief (USBC_UPCON7SET) ERRORFIE Set */
+#define USBC_UPCON7SET_ERRORFIES    (_U(0x1) << USBC_UPCON7SET_ERRORFIES_Pos)
+#define USBC_UPCON7SET_RXSTALLDES_Pos 6            /**< \brief (USBC_UPCON7SET) RXSTALLDE Set */
+#define USBC_UPCON7SET_RXSTALLDES   (_U(0x1) << USBC_UPCON7SET_RXSTALLDES_Pos)
+#define USBC_UPCON7SET_RAMACERES_Pos 10           /**< \brief (USBC_UPCON7SET) RAMACERE Set */
+#define USBC_UPCON7SET_RAMACERES    (_U(0x1) << USBC_UPCON7SET_RAMACERES_Pos)
+#define USBC_UPCON7SET_NBUSYBKES_Pos 12           /**< \brief (USBC_UPCON7SET) NBUSYBKE Set */
+#define USBC_UPCON7SET_NBUSYBKES    (_U(0x1) << USBC_UPCON7SET_NBUSYBKES_Pos)
+#define USBC_UPCON7SET_FIFOCONS_Pos 14           /**< \brief (USBC_UPCON7SET) FIFOCON Set */
+#define USBC_UPCON7SET_FIFOCONS     (_U(0x1) << USBC_UPCON7SET_FIFOCONS_Pos)
+#define USBC_UPCON7SET_PFREEZES_Pos 17           /**< \brief (USBC_UPCON7SET) PFREEZE Set */
+#define USBC_UPCON7SET_PFREEZES     (_U(0x1) << USBC_UPCON7SET_PFREEZES_Pos)
+#define USBC_UPCON7SET_INITDTGLS_Pos 18           /**< \brief (USBC_UPCON7SET) INITDTGL Set */
+#define USBC_UPCON7SET_INITDTGLS    (_U(0x1) << USBC_UPCON7SET_INITDTGLS_Pos)
+#define USBC_UPCON7SET_INITBKS_Pos  19           /**< \brief (USBC_UPCON7SET) INITBK Set */
+#define USBC_UPCON7SET_INITBKS      (_U(0x1) << USBC_UPCON7SET_INITBKS_Pos)
+#define USBC_UPCON7SET_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON7SET) MASK Register */
+
+/* -------- USBC_UPCON0CLR : (USBC Offset: 0x620) ( /W 32) Pipe Control Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINEC:1;         /*!< bit:      0  RXINE Clear                        */
+    uint32_t TXOUTEC:1;        /*!< bit:      1  TXOUTE Clear                       */
+    uint32_t TXSTPEC:1;        /*!< bit:      2  TXSTPE Clear                       */
+    uint32_t PERREC:1;         /*!< bit:      3  PERRE Clear                        */
+    uint32_t NAKEDEC:1;        /*!< bit:      4  NAKEDE Clear                       */
+    uint32_t ERRORFIEC:1;      /*!< bit:      5  ERRORFIE Clear                     */
+    uint32_t RXSTALLDEC:1;     /*!< bit:      6  RXTALLDE Clear                     */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACEREC:1;      /*!< bit:     10  RAMACERE Clear                     */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBKEC:1;      /*!< bit:     12  NBUSYBKE Clear                     */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCONC:1;       /*!< bit:     14  FIFOCON Clear                      */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t PFREEZEC:1;       /*!< bit:     17  PFREEZE Clear                      */
+    uint32_t INITDTGLC:1;      /*!< bit:     18  INITDTGL Clear                     */
+    uint32_t INITBKC:1;        /*!< bit:     19  INITBK Clear                       */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCON0CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCON0CLR_OFFSET       0x620        /**< \brief (USBC_UPCON0CLR offset) Pipe Control Clear Register */
+#define USBC_UPCON0CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON0CLR reset_value) Pipe Control Clear Register */
+
+#define USBC_UPCON0CLR_RXINEC_Pos   0            /**< \brief (USBC_UPCON0CLR) RXINE Clear */
+#define USBC_UPCON0CLR_RXINEC       (_U(0x1) << USBC_UPCON0CLR_RXINEC_Pos)
+#define USBC_UPCON0CLR_TXOUTEC_Pos  1            /**< \brief (USBC_UPCON0CLR) TXOUTE Clear */
+#define USBC_UPCON0CLR_TXOUTEC      (_U(0x1) << USBC_UPCON0CLR_TXOUTEC_Pos)
+#define USBC_UPCON0CLR_TXSTPEC_Pos  2            /**< \brief (USBC_UPCON0CLR) TXSTPE Clear */
+#define USBC_UPCON0CLR_TXSTPEC      (_U(0x1) << USBC_UPCON0CLR_TXSTPEC_Pos)
+#define USBC_UPCON0CLR_PERREC_Pos   3            /**< \brief (USBC_UPCON0CLR) PERRE Clear */
+#define USBC_UPCON0CLR_PERREC       (_U(0x1) << USBC_UPCON0CLR_PERREC_Pos)
+#define USBC_UPCON0CLR_NAKEDEC_Pos  4            /**< \brief (USBC_UPCON0CLR) NAKEDE Clear */
+#define USBC_UPCON0CLR_NAKEDEC      (_U(0x1) << USBC_UPCON0CLR_NAKEDEC_Pos)
+#define USBC_UPCON0CLR_ERRORFIEC_Pos 5            /**< \brief (USBC_UPCON0CLR) ERRORFIE Clear */
+#define USBC_UPCON0CLR_ERRORFIEC    (_U(0x1) << USBC_UPCON0CLR_ERRORFIEC_Pos)
+#define USBC_UPCON0CLR_RXSTALLDEC_Pos 6            /**< \brief (USBC_UPCON0CLR) RXTALLDE Clear */
+#define USBC_UPCON0CLR_RXSTALLDEC   (_U(0x1) << USBC_UPCON0CLR_RXSTALLDEC_Pos)
+#define USBC_UPCON0CLR_RAMACEREC_Pos 10           /**< \brief (USBC_UPCON0CLR) RAMACERE Clear */
+#define USBC_UPCON0CLR_RAMACEREC    (_U(0x1) << USBC_UPCON0CLR_RAMACEREC_Pos)
+#define USBC_UPCON0CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UPCON0CLR) NBUSYBKE Clear */
+#define USBC_UPCON0CLR_NBUSYBKEC    (_U(0x1) << USBC_UPCON0CLR_NBUSYBKEC_Pos)
+#define USBC_UPCON0CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UPCON0CLR) FIFOCON Clear */
+#define USBC_UPCON0CLR_FIFOCONC     (_U(0x1) << USBC_UPCON0CLR_FIFOCONC_Pos)
+#define USBC_UPCON0CLR_PFREEZEC_Pos 17           /**< \brief (USBC_UPCON0CLR) PFREEZE Clear */
+#define USBC_UPCON0CLR_PFREEZEC     (_U(0x1) << USBC_UPCON0CLR_PFREEZEC_Pos)
+#define USBC_UPCON0CLR_INITDTGLC_Pos 18           /**< \brief (USBC_UPCON0CLR) INITDTGL Clear */
+#define USBC_UPCON0CLR_INITDTGLC    (_U(0x1) << USBC_UPCON0CLR_INITDTGLC_Pos)
+#define USBC_UPCON0CLR_INITBKC_Pos  19           /**< \brief (USBC_UPCON0CLR) INITBK Clear */
+#define USBC_UPCON0CLR_INITBKC      (_U(0x1) << USBC_UPCON0CLR_INITBKC_Pos)
+#define USBC_UPCON0CLR_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON0CLR) MASK Register */
+
+/* -------- USBC_UPCON1CLR : (USBC Offset: 0x624) ( /W 32) Pipe Control Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINEC:1;         /*!< bit:      0  RXINE Clear                        */
+    uint32_t TXOUTEC:1;        /*!< bit:      1  TXOUTE Clear                       */
+    uint32_t TXSTPEC:1;        /*!< bit:      2  TXSTPE Clear                       */
+    uint32_t PERREC:1;         /*!< bit:      3  PERRE Clear                        */
+    uint32_t NAKEDEC:1;        /*!< bit:      4  NAKEDE Clear                       */
+    uint32_t ERRORFIEC:1;      /*!< bit:      5  ERRORFIE Clear                     */
+    uint32_t RXSTALLDEC:1;     /*!< bit:      6  RXTALLDE Clear                     */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACEREC:1;      /*!< bit:     10  RAMACERE Clear                     */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBKEC:1;      /*!< bit:     12  NBUSYBKE Clear                     */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCONC:1;       /*!< bit:     14  FIFOCON Clear                      */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t PFREEZEC:1;       /*!< bit:     17  PFREEZE Clear                      */
+    uint32_t INITDTGLC:1;      /*!< bit:     18  INITDTGL Clear                     */
+    uint32_t INITBKC:1;        /*!< bit:     19  INITBK Clear                       */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCON1CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCON1CLR_OFFSET       0x624        /**< \brief (USBC_UPCON1CLR offset) Pipe Control Clear Register */
+#define USBC_UPCON1CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON1CLR reset_value) Pipe Control Clear Register */
+
+#define USBC_UPCON1CLR_RXINEC_Pos   0            /**< \brief (USBC_UPCON1CLR) RXINE Clear */
+#define USBC_UPCON1CLR_RXINEC       (_U(0x1) << USBC_UPCON1CLR_RXINEC_Pos)
+#define USBC_UPCON1CLR_TXOUTEC_Pos  1            /**< \brief (USBC_UPCON1CLR) TXOUTE Clear */
+#define USBC_UPCON1CLR_TXOUTEC      (_U(0x1) << USBC_UPCON1CLR_TXOUTEC_Pos)
+#define USBC_UPCON1CLR_TXSTPEC_Pos  2            /**< \brief (USBC_UPCON1CLR) TXSTPE Clear */
+#define USBC_UPCON1CLR_TXSTPEC      (_U(0x1) << USBC_UPCON1CLR_TXSTPEC_Pos)
+#define USBC_UPCON1CLR_PERREC_Pos   3            /**< \brief (USBC_UPCON1CLR) PERRE Clear */
+#define USBC_UPCON1CLR_PERREC       (_U(0x1) << USBC_UPCON1CLR_PERREC_Pos)
+#define USBC_UPCON1CLR_NAKEDEC_Pos  4            /**< \brief (USBC_UPCON1CLR) NAKEDE Clear */
+#define USBC_UPCON1CLR_NAKEDEC      (_U(0x1) << USBC_UPCON1CLR_NAKEDEC_Pos)
+#define USBC_UPCON1CLR_ERRORFIEC_Pos 5            /**< \brief (USBC_UPCON1CLR) ERRORFIE Clear */
+#define USBC_UPCON1CLR_ERRORFIEC    (_U(0x1) << USBC_UPCON1CLR_ERRORFIEC_Pos)
+#define USBC_UPCON1CLR_RXSTALLDEC_Pos 6            /**< \brief (USBC_UPCON1CLR) RXTALLDE Clear */
+#define USBC_UPCON1CLR_RXSTALLDEC   (_U(0x1) << USBC_UPCON1CLR_RXSTALLDEC_Pos)
+#define USBC_UPCON1CLR_RAMACEREC_Pos 10           /**< \brief (USBC_UPCON1CLR) RAMACERE Clear */
+#define USBC_UPCON1CLR_RAMACEREC    (_U(0x1) << USBC_UPCON1CLR_RAMACEREC_Pos)
+#define USBC_UPCON1CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UPCON1CLR) NBUSYBKE Clear */
+#define USBC_UPCON1CLR_NBUSYBKEC    (_U(0x1) << USBC_UPCON1CLR_NBUSYBKEC_Pos)
+#define USBC_UPCON1CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UPCON1CLR) FIFOCON Clear */
+#define USBC_UPCON1CLR_FIFOCONC     (_U(0x1) << USBC_UPCON1CLR_FIFOCONC_Pos)
+#define USBC_UPCON1CLR_PFREEZEC_Pos 17           /**< \brief (USBC_UPCON1CLR) PFREEZE Clear */
+#define USBC_UPCON1CLR_PFREEZEC     (_U(0x1) << USBC_UPCON1CLR_PFREEZEC_Pos)
+#define USBC_UPCON1CLR_INITDTGLC_Pos 18           /**< \brief (USBC_UPCON1CLR) INITDTGL Clear */
+#define USBC_UPCON1CLR_INITDTGLC    (_U(0x1) << USBC_UPCON1CLR_INITDTGLC_Pos)
+#define USBC_UPCON1CLR_INITBKC_Pos  19           /**< \brief (USBC_UPCON1CLR) INITBK Clear */
+#define USBC_UPCON1CLR_INITBKC      (_U(0x1) << USBC_UPCON1CLR_INITBKC_Pos)
+#define USBC_UPCON1CLR_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON1CLR) MASK Register */
+
+/* -------- USBC_UPCON2CLR : (USBC Offset: 0x628) ( /W 32) Pipe Control Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINEC:1;         /*!< bit:      0  RXINE Clear                        */
+    uint32_t TXOUTEC:1;        /*!< bit:      1  TXOUTE Clear                       */
+    uint32_t TXSTPEC:1;        /*!< bit:      2  TXSTPE Clear                       */
+    uint32_t PERREC:1;         /*!< bit:      3  PERRE Clear                        */
+    uint32_t NAKEDEC:1;        /*!< bit:      4  NAKEDE Clear                       */
+    uint32_t ERRORFIEC:1;      /*!< bit:      5  ERRORFIE Clear                     */
+    uint32_t RXSTALLDEC:1;     /*!< bit:      6  RXTALLDE Clear                     */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACEREC:1;      /*!< bit:     10  RAMACERE Clear                     */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBKEC:1;      /*!< bit:     12  NBUSYBKE Clear                     */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCONC:1;       /*!< bit:     14  FIFOCON Clear                      */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t PFREEZEC:1;       /*!< bit:     17  PFREEZE Clear                      */
+    uint32_t INITDTGLC:1;      /*!< bit:     18  INITDTGL Clear                     */
+    uint32_t INITBKC:1;        /*!< bit:     19  INITBK Clear                       */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCON2CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCON2CLR_OFFSET       0x628        /**< \brief (USBC_UPCON2CLR offset) Pipe Control Clear Register */
+#define USBC_UPCON2CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON2CLR reset_value) Pipe Control Clear Register */
+
+#define USBC_UPCON2CLR_RXINEC_Pos   0            /**< \brief (USBC_UPCON2CLR) RXINE Clear */
+#define USBC_UPCON2CLR_RXINEC       (_U(0x1) << USBC_UPCON2CLR_RXINEC_Pos)
+#define USBC_UPCON2CLR_TXOUTEC_Pos  1            /**< \brief (USBC_UPCON2CLR) TXOUTE Clear */
+#define USBC_UPCON2CLR_TXOUTEC      (_U(0x1) << USBC_UPCON2CLR_TXOUTEC_Pos)
+#define USBC_UPCON2CLR_TXSTPEC_Pos  2            /**< \brief (USBC_UPCON2CLR) TXSTPE Clear */
+#define USBC_UPCON2CLR_TXSTPEC      (_U(0x1) << USBC_UPCON2CLR_TXSTPEC_Pos)
+#define USBC_UPCON2CLR_PERREC_Pos   3            /**< \brief (USBC_UPCON2CLR) PERRE Clear */
+#define USBC_UPCON2CLR_PERREC       (_U(0x1) << USBC_UPCON2CLR_PERREC_Pos)
+#define USBC_UPCON2CLR_NAKEDEC_Pos  4            /**< \brief (USBC_UPCON2CLR) NAKEDE Clear */
+#define USBC_UPCON2CLR_NAKEDEC      (_U(0x1) << USBC_UPCON2CLR_NAKEDEC_Pos)
+#define USBC_UPCON2CLR_ERRORFIEC_Pos 5            /**< \brief (USBC_UPCON2CLR) ERRORFIE Clear */
+#define USBC_UPCON2CLR_ERRORFIEC    (_U(0x1) << USBC_UPCON2CLR_ERRORFIEC_Pos)
+#define USBC_UPCON2CLR_RXSTALLDEC_Pos 6            /**< \brief (USBC_UPCON2CLR) RXTALLDE Clear */
+#define USBC_UPCON2CLR_RXSTALLDEC   (_U(0x1) << USBC_UPCON2CLR_RXSTALLDEC_Pos)
+#define USBC_UPCON2CLR_RAMACEREC_Pos 10           /**< \brief (USBC_UPCON2CLR) RAMACERE Clear */
+#define USBC_UPCON2CLR_RAMACEREC    (_U(0x1) << USBC_UPCON2CLR_RAMACEREC_Pos)
+#define USBC_UPCON2CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UPCON2CLR) NBUSYBKE Clear */
+#define USBC_UPCON2CLR_NBUSYBKEC    (_U(0x1) << USBC_UPCON2CLR_NBUSYBKEC_Pos)
+#define USBC_UPCON2CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UPCON2CLR) FIFOCON Clear */
+#define USBC_UPCON2CLR_FIFOCONC     (_U(0x1) << USBC_UPCON2CLR_FIFOCONC_Pos)
+#define USBC_UPCON2CLR_PFREEZEC_Pos 17           /**< \brief (USBC_UPCON2CLR) PFREEZE Clear */
+#define USBC_UPCON2CLR_PFREEZEC     (_U(0x1) << USBC_UPCON2CLR_PFREEZEC_Pos)
+#define USBC_UPCON2CLR_INITDTGLC_Pos 18           /**< \brief (USBC_UPCON2CLR) INITDTGL Clear */
+#define USBC_UPCON2CLR_INITDTGLC    (_U(0x1) << USBC_UPCON2CLR_INITDTGLC_Pos)
+#define USBC_UPCON2CLR_INITBKC_Pos  19           /**< \brief (USBC_UPCON2CLR) INITBK Clear */
+#define USBC_UPCON2CLR_INITBKC      (_U(0x1) << USBC_UPCON2CLR_INITBKC_Pos)
+#define USBC_UPCON2CLR_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON2CLR) MASK Register */
+
+/* -------- USBC_UPCON3CLR : (USBC Offset: 0x62C) ( /W 32) Pipe Control Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINEC:1;         /*!< bit:      0  RXINE Clear                        */
+    uint32_t TXOUTEC:1;        /*!< bit:      1  TXOUTE Clear                       */
+    uint32_t TXSTPEC:1;        /*!< bit:      2  TXSTPE Clear                       */
+    uint32_t PERREC:1;         /*!< bit:      3  PERRE Clear                        */
+    uint32_t NAKEDEC:1;        /*!< bit:      4  NAKEDE Clear                       */
+    uint32_t ERRORFIEC:1;      /*!< bit:      5  ERRORFIE Clear                     */
+    uint32_t RXSTALLDEC:1;     /*!< bit:      6  RXTALLDE Clear                     */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACEREC:1;      /*!< bit:     10  RAMACERE Clear                     */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBKEC:1;      /*!< bit:     12  NBUSYBKE Clear                     */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCONC:1;       /*!< bit:     14  FIFOCON Clear                      */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t PFREEZEC:1;       /*!< bit:     17  PFREEZE Clear                      */
+    uint32_t INITDTGLC:1;      /*!< bit:     18  INITDTGL Clear                     */
+    uint32_t INITBKC:1;        /*!< bit:     19  INITBK Clear                       */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCON3CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCON3CLR_OFFSET       0x62C        /**< \brief (USBC_UPCON3CLR offset) Pipe Control Clear Register */
+#define USBC_UPCON3CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON3CLR reset_value) Pipe Control Clear Register */
+
+#define USBC_UPCON3CLR_RXINEC_Pos   0            /**< \brief (USBC_UPCON3CLR) RXINE Clear */
+#define USBC_UPCON3CLR_RXINEC       (_U(0x1) << USBC_UPCON3CLR_RXINEC_Pos)
+#define USBC_UPCON3CLR_TXOUTEC_Pos  1            /**< \brief (USBC_UPCON3CLR) TXOUTE Clear */
+#define USBC_UPCON3CLR_TXOUTEC      (_U(0x1) << USBC_UPCON3CLR_TXOUTEC_Pos)
+#define USBC_UPCON3CLR_TXSTPEC_Pos  2            /**< \brief (USBC_UPCON3CLR) TXSTPE Clear */
+#define USBC_UPCON3CLR_TXSTPEC      (_U(0x1) << USBC_UPCON3CLR_TXSTPEC_Pos)
+#define USBC_UPCON3CLR_PERREC_Pos   3            /**< \brief (USBC_UPCON3CLR) PERRE Clear */
+#define USBC_UPCON3CLR_PERREC       (_U(0x1) << USBC_UPCON3CLR_PERREC_Pos)
+#define USBC_UPCON3CLR_NAKEDEC_Pos  4            /**< \brief (USBC_UPCON3CLR) NAKEDE Clear */
+#define USBC_UPCON3CLR_NAKEDEC      (_U(0x1) << USBC_UPCON3CLR_NAKEDEC_Pos)
+#define USBC_UPCON3CLR_ERRORFIEC_Pos 5            /**< \brief (USBC_UPCON3CLR) ERRORFIE Clear */
+#define USBC_UPCON3CLR_ERRORFIEC    (_U(0x1) << USBC_UPCON3CLR_ERRORFIEC_Pos)
+#define USBC_UPCON3CLR_RXSTALLDEC_Pos 6            /**< \brief (USBC_UPCON3CLR) RXTALLDE Clear */
+#define USBC_UPCON3CLR_RXSTALLDEC   (_U(0x1) << USBC_UPCON3CLR_RXSTALLDEC_Pos)
+#define USBC_UPCON3CLR_RAMACEREC_Pos 10           /**< \brief (USBC_UPCON3CLR) RAMACERE Clear */
+#define USBC_UPCON3CLR_RAMACEREC    (_U(0x1) << USBC_UPCON3CLR_RAMACEREC_Pos)
+#define USBC_UPCON3CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UPCON3CLR) NBUSYBKE Clear */
+#define USBC_UPCON3CLR_NBUSYBKEC    (_U(0x1) << USBC_UPCON3CLR_NBUSYBKEC_Pos)
+#define USBC_UPCON3CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UPCON3CLR) FIFOCON Clear */
+#define USBC_UPCON3CLR_FIFOCONC     (_U(0x1) << USBC_UPCON3CLR_FIFOCONC_Pos)
+#define USBC_UPCON3CLR_PFREEZEC_Pos 17           /**< \brief (USBC_UPCON3CLR) PFREEZE Clear */
+#define USBC_UPCON3CLR_PFREEZEC     (_U(0x1) << USBC_UPCON3CLR_PFREEZEC_Pos)
+#define USBC_UPCON3CLR_INITDTGLC_Pos 18           /**< \brief (USBC_UPCON3CLR) INITDTGL Clear */
+#define USBC_UPCON3CLR_INITDTGLC    (_U(0x1) << USBC_UPCON3CLR_INITDTGLC_Pos)
+#define USBC_UPCON3CLR_INITBKC_Pos  19           /**< \brief (USBC_UPCON3CLR) INITBK Clear */
+#define USBC_UPCON3CLR_INITBKC      (_U(0x1) << USBC_UPCON3CLR_INITBKC_Pos)
+#define USBC_UPCON3CLR_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON3CLR) MASK Register */
+
+/* -------- USBC_UPCON4CLR : (USBC Offset: 0x630) ( /W 32) Pipe Control Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINEC:1;         /*!< bit:      0  RXINE Clear                        */
+    uint32_t TXOUTEC:1;        /*!< bit:      1  TXOUTE Clear                       */
+    uint32_t TXSTPEC:1;        /*!< bit:      2  TXSTPE Clear                       */
+    uint32_t PERREC:1;         /*!< bit:      3  PERRE Clear                        */
+    uint32_t NAKEDEC:1;        /*!< bit:      4  NAKEDE Clear                       */
+    uint32_t ERRORFIEC:1;      /*!< bit:      5  ERRORFIE Clear                     */
+    uint32_t RXSTALLDEC:1;     /*!< bit:      6  RXTALLDE Clear                     */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACEREC:1;      /*!< bit:     10  RAMACERE Clear                     */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBKEC:1;      /*!< bit:     12  NBUSYBKE Clear                     */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCONC:1;       /*!< bit:     14  FIFOCON Clear                      */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t PFREEZEC:1;       /*!< bit:     17  PFREEZE Clear                      */
+    uint32_t INITDTGLC:1;      /*!< bit:     18  INITDTGL Clear                     */
+    uint32_t INITBKC:1;        /*!< bit:     19  INITBK Clear                       */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCON4CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCON4CLR_OFFSET       0x630        /**< \brief (USBC_UPCON4CLR offset) Pipe Control Clear Register */
+#define USBC_UPCON4CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON4CLR reset_value) Pipe Control Clear Register */
+
+#define USBC_UPCON4CLR_RXINEC_Pos   0            /**< \brief (USBC_UPCON4CLR) RXINE Clear */
+#define USBC_UPCON4CLR_RXINEC       (_U(0x1) << USBC_UPCON4CLR_RXINEC_Pos)
+#define USBC_UPCON4CLR_TXOUTEC_Pos  1            /**< \brief (USBC_UPCON4CLR) TXOUTE Clear */
+#define USBC_UPCON4CLR_TXOUTEC      (_U(0x1) << USBC_UPCON4CLR_TXOUTEC_Pos)
+#define USBC_UPCON4CLR_TXSTPEC_Pos  2            /**< \brief (USBC_UPCON4CLR) TXSTPE Clear */
+#define USBC_UPCON4CLR_TXSTPEC      (_U(0x1) << USBC_UPCON4CLR_TXSTPEC_Pos)
+#define USBC_UPCON4CLR_PERREC_Pos   3            /**< \brief (USBC_UPCON4CLR) PERRE Clear */
+#define USBC_UPCON4CLR_PERREC       (_U(0x1) << USBC_UPCON4CLR_PERREC_Pos)
+#define USBC_UPCON4CLR_NAKEDEC_Pos  4            /**< \brief (USBC_UPCON4CLR) NAKEDE Clear */
+#define USBC_UPCON4CLR_NAKEDEC      (_U(0x1) << USBC_UPCON4CLR_NAKEDEC_Pos)
+#define USBC_UPCON4CLR_ERRORFIEC_Pos 5            /**< \brief (USBC_UPCON4CLR) ERRORFIE Clear */
+#define USBC_UPCON4CLR_ERRORFIEC    (_U(0x1) << USBC_UPCON4CLR_ERRORFIEC_Pos)
+#define USBC_UPCON4CLR_RXSTALLDEC_Pos 6            /**< \brief (USBC_UPCON4CLR) RXTALLDE Clear */
+#define USBC_UPCON4CLR_RXSTALLDEC   (_U(0x1) << USBC_UPCON4CLR_RXSTALLDEC_Pos)
+#define USBC_UPCON4CLR_RAMACEREC_Pos 10           /**< \brief (USBC_UPCON4CLR) RAMACERE Clear */
+#define USBC_UPCON4CLR_RAMACEREC    (_U(0x1) << USBC_UPCON4CLR_RAMACEREC_Pos)
+#define USBC_UPCON4CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UPCON4CLR) NBUSYBKE Clear */
+#define USBC_UPCON4CLR_NBUSYBKEC    (_U(0x1) << USBC_UPCON4CLR_NBUSYBKEC_Pos)
+#define USBC_UPCON4CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UPCON4CLR) FIFOCON Clear */
+#define USBC_UPCON4CLR_FIFOCONC     (_U(0x1) << USBC_UPCON4CLR_FIFOCONC_Pos)
+#define USBC_UPCON4CLR_PFREEZEC_Pos 17           /**< \brief (USBC_UPCON4CLR) PFREEZE Clear */
+#define USBC_UPCON4CLR_PFREEZEC     (_U(0x1) << USBC_UPCON4CLR_PFREEZEC_Pos)
+#define USBC_UPCON4CLR_INITDTGLC_Pos 18           /**< \brief (USBC_UPCON4CLR) INITDTGL Clear */
+#define USBC_UPCON4CLR_INITDTGLC    (_U(0x1) << USBC_UPCON4CLR_INITDTGLC_Pos)
+#define USBC_UPCON4CLR_INITBKC_Pos  19           /**< \brief (USBC_UPCON4CLR) INITBK Clear */
+#define USBC_UPCON4CLR_INITBKC      (_U(0x1) << USBC_UPCON4CLR_INITBKC_Pos)
+#define USBC_UPCON4CLR_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON4CLR) MASK Register */
+
+/* -------- USBC_UPCON5CLR : (USBC Offset: 0x634) ( /W 32) Pipe Control Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINEC:1;         /*!< bit:      0  RXINE Clear                        */
+    uint32_t TXOUTEC:1;        /*!< bit:      1  TXOUTE Clear                       */
+    uint32_t TXSTPEC:1;        /*!< bit:      2  TXSTPE Clear                       */
+    uint32_t PERREC:1;         /*!< bit:      3  PERRE Clear                        */
+    uint32_t NAKEDEC:1;        /*!< bit:      4  NAKEDE Clear                       */
+    uint32_t ERRORFIEC:1;      /*!< bit:      5  ERRORFIE Clear                     */
+    uint32_t RXSTALLDEC:1;     /*!< bit:      6  RXTALLDE Clear                     */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACEREC:1;      /*!< bit:     10  RAMACERE Clear                     */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBKEC:1;      /*!< bit:     12  NBUSYBKE Clear                     */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCONC:1;       /*!< bit:     14  FIFOCON Clear                      */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t PFREEZEC:1;       /*!< bit:     17  PFREEZE Clear                      */
+    uint32_t INITDTGLC:1;      /*!< bit:     18  INITDTGL Clear                     */
+    uint32_t INITBKC:1;        /*!< bit:     19  INITBK Clear                       */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCON5CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCON5CLR_OFFSET       0x634        /**< \brief (USBC_UPCON5CLR offset) Pipe Control Clear Register */
+#define USBC_UPCON5CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON5CLR reset_value) Pipe Control Clear Register */
+
+#define USBC_UPCON5CLR_RXINEC_Pos   0            /**< \brief (USBC_UPCON5CLR) RXINE Clear */
+#define USBC_UPCON5CLR_RXINEC       (_U(0x1) << USBC_UPCON5CLR_RXINEC_Pos)
+#define USBC_UPCON5CLR_TXOUTEC_Pos  1            /**< \brief (USBC_UPCON5CLR) TXOUTE Clear */
+#define USBC_UPCON5CLR_TXOUTEC      (_U(0x1) << USBC_UPCON5CLR_TXOUTEC_Pos)
+#define USBC_UPCON5CLR_TXSTPEC_Pos  2            /**< \brief (USBC_UPCON5CLR) TXSTPE Clear */
+#define USBC_UPCON5CLR_TXSTPEC      (_U(0x1) << USBC_UPCON5CLR_TXSTPEC_Pos)
+#define USBC_UPCON5CLR_PERREC_Pos   3            /**< \brief (USBC_UPCON5CLR) PERRE Clear */
+#define USBC_UPCON5CLR_PERREC       (_U(0x1) << USBC_UPCON5CLR_PERREC_Pos)
+#define USBC_UPCON5CLR_NAKEDEC_Pos  4            /**< \brief (USBC_UPCON5CLR) NAKEDE Clear */
+#define USBC_UPCON5CLR_NAKEDEC      (_U(0x1) << USBC_UPCON5CLR_NAKEDEC_Pos)
+#define USBC_UPCON5CLR_ERRORFIEC_Pos 5            /**< \brief (USBC_UPCON5CLR) ERRORFIE Clear */
+#define USBC_UPCON5CLR_ERRORFIEC    (_U(0x1) << USBC_UPCON5CLR_ERRORFIEC_Pos)
+#define USBC_UPCON5CLR_RXSTALLDEC_Pos 6            /**< \brief (USBC_UPCON5CLR) RXTALLDE Clear */
+#define USBC_UPCON5CLR_RXSTALLDEC   (_U(0x1) << USBC_UPCON5CLR_RXSTALLDEC_Pos)
+#define USBC_UPCON5CLR_RAMACEREC_Pos 10           /**< \brief (USBC_UPCON5CLR) RAMACERE Clear */
+#define USBC_UPCON5CLR_RAMACEREC    (_U(0x1) << USBC_UPCON5CLR_RAMACEREC_Pos)
+#define USBC_UPCON5CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UPCON5CLR) NBUSYBKE Clear */
+#define USBC_UPCON5CLR_NBUSYBKEC    (_U(0x1) << USBC_UPCON5CLR_NBUSYBKEC_Pos)
+#define USBC_UPCON5CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UPCON5CLR) FIFOCON Clear */
+#define USBC_UPCON5CLR_FIFOCONC     (_U(0x1) << USBC_UPCON5CLR_FIFOCONC_Pos)
+#define USBC_UPCON5CLR_PFREEZEC_Pos 17           /**< \brief (USBC_UPCON5CLR) PFREEZE Clear */
+#define USBC_UPCON5CLR_PFREEZEC     (_U(0x1) << USBC_UPCON5CLR_PFREEZEC_Pos)
+#define USBC_UPCON5CLR_INITDTGLC_Pos 18           /**< \brief (USBC_UPCON5CLR) INITDTGL Clear */
+#define USBC_UPCON5CLR_INITDTGLC    (_U(0x1) << USBC_UPCON5CLR_INITDTGLC_Pos)
+#define USBC_UPCON5CLR_INITBKC_Pos  19           /**< \brief (USBC_UPCON5CLR) INITBK Clear */
+#define USBC_UPCON5CLR_INITBKC      (_U(0x1) << USBC_UPCON5CLR_INITBKC_Pos)
+#define USBC_UPCON5CLR_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON5CLR) MASK Register */
+
+/* -------- USBC_UPCON6CLR : (USBC Offset: 0x638) ( /W 32) Pipe Control Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINEC:1;         /*!< bit:      0  RXINE Clear                        */
+    uint32_t TXOUTEC:1;        /*!< bit:      1  TXOUTE Clear                       */
+    uint32_t TXSTPEC:1;        /*!< bit:      2  TXSTPE Clear                       */
+    uint32_t PERREC:1;         /*!< bit:      3  PERRE Clear                        */
+    uint32_t NAKEDEC:1;        /*!< bit:      4  NAKEDE Clear                       */
+    uint32_t ERRORFIEC:1;      /*!< bit:      5  ERRORFIE Clear                     */
+    uint32_t RXSTALLDEC:1;     /*!< bit:      6  RXTALLDE Clear                     */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACEREC:1;      /*!< bit:     10  RAMACERE Clear                     */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBKEC:1;      /*!< bit:     12  NBUSYBKE Clear                     */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCONC:1;       /*!< bit:     14  FIFOCON Clear                      */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t PFREEZEC:1;       /*!< bit:     17  PFREEZE Clear                      */
+    uint32_t INITDTGLC:1;      /*!< bit:     18  INITDTGL Clear                     */
+    uint32_t INITBKC:1;        /*!< bit:     19  INITBK Clear                       */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCON6CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCON6CLR_OFFSET       0x638        /**< \brief (USBC_UPCON6CLR offset) Pipe Control Clear Register */
+#define USBC_UPCON6CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON6CLR reset_value) Pipe Control Clear Register */
+
+#define USBC_UPCON6CLR_RXINEC_Pos   0            /**< \brief (USBC_UPCON6CLR) RXINE Clear */
+#define USBC_UPCON6CLR_RXINEC       (_U(0x1) << USBC_UPCON6CLR_RXINEC_Pos)
+#define USBC_UPCON6CLR_TXOUTEC_Pos  1            /**< \brief (USBC_UPCON6CLR) TXOUTE Clear */
+#define USBC_UPCON6CLR_TXOUTEC      (_U(0x1) << USBC_UPCON6CLR_TXOUTEC_Pos)
+#define USBC_UPCON6CLR_TXSTPEC_Pos  2            /**< \brief (USBC_UPCON6CLR) TXSTPE Clear */
+#define USBC_UPCON6CLR_TXSTPEC      (_U(0x1) << USBC_UPCON6CLR_TXSTPEC_Pos)
+#define USBC_UPCON6CLR_PERREC_Pos   3            /**< \brief (USBC_UPCON6CLR) PERRE Clear */
+#define USBC_UPCON6CLR_PERREC       (_U(0x1) << USBC_UPCON6CLR_PERREC_Pos)
+#define USBC_UPCON6CLR_NAKEDEC_Pos  4            /**< \brief (USBC_UPCON6CLR) NAKEDE Clear */
+#define USBC_UPCON6CLR_NAKEDEC      (_U(0x1) << USBC_UPCON6CLR_NAKEDEC_Pos)
+#define USBC_UPCON6CLR_ERRORFIEC_Pos 5            /**< \brief (USBC_UPCON6CLR) ERRORFIE Clear */
+#define USBC_UPCON6CLR_ERRORFIEC    (_U(0x1) << USBC_UPCON6CLR_ERRORFIEC_Pos)
+#define USBC_UPCON6CLR_RXSTALLDEC_Pos 6            /**< \brief (USBC_UPCON6CLR) RXTALLDE Clear */
+#define USBC_UPCON6CLR_RXSTALLDEC   (_U(0x1) << USBC_UPCON6CLR_RXSTALLDEC_Pos)
+#define USBC_UPCON6CLR_RAMACEREC_Pos 10           /**< \brief (USBC_UPCON6CLR) RAMACERE Clear */
+#define USBC_UPCON6CLR_RAMACEREC    (_U(0x1) << USBC_UPCON6CLR_RAMACEREC_Pos)
+#define USBC_UPCON6CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UPCON6CLR) NBUSYBKE Clear */
+#define USBC_UPCON6CLR_NBUSYBKEC    (_U(0x1) << USBC_UPCON6CLR_NBUSYBKEC_Pos)
+#define USBC_UPCON6CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UPCON6CLR) FIFOCON Clear */
+#define USBC_UPCON6CLR_FIFOCONC     (_U(0x1) << USBC_UPCON6CLR_FIFOCONC_Pos)
+#define USBC_UPCON6CLR_PFREEZEC_Pos 17           /**< \brief (USBC_UPCON6CLR) PFREEZE Clear */
+#define USBC_UPCON6CLR_PFREEZEC     (_U(0x1) << USBC_UPCON6CLR_PFREEZEC_Pos)
+#define USBC_UPCON6CLR_INITDTGLC_Pos 18           /**< \brief (USBC_UPCON6CLR) INITDTGL Clear */
+#define USBC_UPCON6CLR_INITDTGLC    (_U(0x1) << USBC_UPCON6CLR_INITDTGLC_Pos)
+#define USBC_UPCON6CLR_INITBKC_Pos  19           /**< \brief (USBC_UPCON6CLR) INITBK Clear */
+#define USBC_UPCON6CLR_INITBKC      (_U(0x1) << USBC_UPCON6CLR_INITBKC_Pos)
+#define USBC_UPCON6CLR_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON6CLR) MASK Register */
+
+/* -------- USBC_UPCON7CLR : (USBC Offset: 0x63C) ( /W 32) Pipe Control Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t RXINEC:1;         /*!< bit:      0  RXINE Clear                        */
+    uint32_t TXOUTEC:1;        /*!< bit:      1  TXOUTE Clear                       */
+    uint32_t TXSTPEC:1;        /*!< bit:      2  TXSTPE Clear                       */
+    uint32_t PERREC:1;         /*!< bit:      3  PERRE Clear                        */
+    uint32_t NAKEDEC:1;        /*!< bit:      4  NAKEDE Clear                       */
+    uint32_t ERRORFIEC:1;      /*!< bit:      5  ERRORFIE Clear                     */
+    uint32_t RXSTALLDEC:1;     /*!< bit:      6  RXTALLDE Clear                     */
+    uint32_t :3;               /*!< bit:  7.. 9  Reserved                           */
+    uint32_t RAMACEREC:1;      /*!< bit:     10  RAMACERE Clear                     */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t NBUSYBKEC:1;      /*!< bit:     12  NBUSYBKE Clear                     */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t FIFOCONC:1;       /*!< bit:     14  FIFOCON Clear                      */
+    uint32_t :2;               /*!< bit: 15..16  Reserved                           */
+    uint32_t PFREEZEC:1;       /*!< bit:     17  PFREEZE Clear                      */
+    uint32_t INITDTGLC:1;      /*!< bit:     18  INITDTGL Clear                     */
+    uint32_t INITBKC:1;        /*!< bit:     19  INITBK Clear                       */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPCON7CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPCON7CLR_OFFSET       0x63C        /**< \brief (USBC_UPCON7CLR offset) Pipe Control Clear Register */
+#define USBC_UPCON7CLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_UPCON7CLR reset_value) Pipe Control Clear Register */
+
+#define USBC_UPCON7CLR_RXINEC_Pos   0            /**< \brief (USBC_UPCON7CLR) RXINE Clear */
+#define USBC_UPCON7CLR_RXINEC       (_U(0x1) << USBC_UPCON7CLR_RXINEC_Pos)
+#define USBC_UPCON7CLR_TXOUTEC_Pos  1            /**< \brief (USBC_UPCON7CLR) TXOUTE Clear */
+#define USBC_UPCON7CLR_TXOUTEC      (_U(0x1) << USBC_UPCON7CLR_TXOUTEC_Pos)
+#define USBC_UPCON7CLR_TXSTPEC_Pos  2            /**< \brief (USBC_UPCON7CLR) TXSTPE Clear */
+#define USBC_UPCON7CLR_TXSTPEC      (_U(0x1) << USBC_UPCON7CLR_TXSTPEC_Pos)
+#define USBC_UPCON7CLR_PERREC_Pos   3            /**< \brief (USBC_UPCON7CLR) PERRE Clear */
+#define USBC_UPCON7CLR_PERREC       (_U(0x1) << USBC_UPCON7CLR_PERREC_Pos)
+#define USBC_UPCON7CLR_NAKEDEC_Pos  4            /**< \brief (USBC_UPCON7CLR) NAKEDE Clear */
+#define USBC_UPCON7CLR_NAKEDEC      (_U(0x1) << USBC_UPCON7CLR_NAKEDEC_Pos)
+#define USBC_UPCON7CLR_ERRORFIEC_Pos 5            /**< \brief (USBC_UPCON7CLR) ERRORFIE Clear */
+#define USBC_UPCON7CLR_ERRORFIEC    (_U(0x1) << USBC_UPCON7CLR_ERRORFIEC_Pos)
+#define USBC_UPCON7CLR_RXSTALLDEC_Pos 6            /**< \brief (USBC_UPCON7CLR) RXTALLDE Clear */
+#define USBC_UPCON7CLR_RXSTALLDEC   (_U(0x1) << USBC_UPCON7CLR_RXSTALLDEC_Pos)
+#define USBC_UPCON7CLR_RAMACEREC_Pos 10           /**< \brief (USBC_UPCON7CLR) RAMACERE Clear */
+#define USBC_UPCON7CLR_RAMACEREC    (_U(0x1) << USBC_UPCON7CLR_RAMACEREC_Pos)
+#define USBC_UPCON7CLR_NBUSYBKEC_Pos 12           /**< \brief (USBC_UPCON7CLR) NBUSYBKE Clear */
+#define USBC_UPCON7CLR_NBUSYBKEC    (_U(0x1) << USBC_UPCON7CLR_NBUSYBKEC_Pos)
+#define USBC_UPCON7CLR_FIFOCONC_Pos 14           /**< \brief (USBC_UPCON7CLR) FIFOCON Clear */
+#define USBC_UPCON7CLR_FIFOCONC     (_U(0x1) << USBC_UPCON7CLR_FIFOCONC_Pos)
+#define USBC_UPCON7CLR_PFREEZEC_Pos 17           /**< \brief (USBC_UPCON7CLR) PFREEZE Clear */
+#define USBC_UPCON7CLR_PFREEZEC     (_U(0x1) << USBC_UPCON7CLR_PFREEZEC_Pos)
+#define USBC_UPCON7CLR_INITDTGLC_Pos 18           /**< \brief (USBC_UPCON7CLR) INITDTGL Clear */
+#define USBC_UPCON7CLR_INITDTGLC    (_U(0x1) << USBC_UPCON7CLR_INITDTGLC_Pos)
+#define USBC_UPCON7CLR_INITBKC_Pos  19           /**< \brief (USBC_UPCON7CLR) INITBK Clear */
+#define USBC_UPCON7CLR_INITBKC      (_U(0x1) << USBC_UPCON7CLR_INITBKC_Pos)
+#define USBC_UPCON7CLR_MASK         _U(0x000E547F) /**< \brief (USBC_UPCON7CLR) MASK Register */
+
+/* -------- USBC_UPINRQ0 : (USBC Offset: 0x650) (R/W 32) Pipe In Request -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t INRQ:8;           /*!< bit:  0.. 7  IN Request Number before Freeze    */
+    uint32_t INMODE:1;         /*!< bit:      8  IN Request Mode                    */
+    uint32_t :23;              /*!< bit:  9..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPINRQ0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPINRQ0_OFFSET         0x650        /**< \brief (USBC_UPINRQ0 offset) Pipe In Request */
+#define USBC_UPINRQ0_RESETVALUE     _U(0x00000001); /**< \brief (USBC_UPINRQ0 reset_value) Pipe In Request */
+
+#define USBC_UPINRQ0_INRQ_Pos       0            /**< \brief (USBC_UPINRQ0) IN Request Number before Freeze */
+#define USBC_UPINRQ0_INRQ_Msk       (_U(0xFF) << USBC_UPINRQ0_INRQ_Pos)
+#define USBC_UPINRQ0_INRQ(value)    (USBC_UPINRQ0_INRQ_Msk & ((value) << USBC_UPINRQ0_INRQ_Pos))
+#define USBC_UPINRQ0_INMODE_Pos     8            /**< \brief (USBC_UPINRQ0) IN Request Mode */
+#define USBC_UPINRQ0_INMODE         (_U(0x1) << USBC_UPINRQ0_INMODE_Pos)
+#define USBC_UPINRQ0_MASK           _U(0x000001FF) /**< \brief (USBC_UPINRQ0) MASK Register */
+
+/* -------- USBC_UPINRQ1 : (USBC Offset: 0x654) (R/W 32) Pipe In Request -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t INRQ:8;           /*!< bit:  0.. 7  IN Request Number before Freeze    */
+    uint32_t INMODE:1;         /*!< bit:      8  IN Request Mode                    */
+    uint32_t :23;              /*!< bit:  9..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPINRQ1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPINRQ1_OFFSET         0x654        /**< \brief (USBC_UPINRQ1 offset) Pipe In Request */
+#define USBC_UPINRQ1_RESETVALUE     _U(0x00000001); /**< \brief (USBC_UPINRQ1 reset_value) Pipe In Request */
+
+#define USBC_UPINRQ1_INRQ_Pos       0            /**< \brief (USBC_UPINRQ1) IN Request Number before Freeze */
+#define USBC_UPINRQ1_INRQ_Msk       (_U(0xFF) << USBC_UPINRQ1_INRQ_Pos)
+#define USBC_UPINRQ1_INRQ(value)    (USBC_UPINRQ1_INRQ_Msk & ((value) << USBC_UPINRQ1_INRQ_Pos))
+#define USBC_UPINRQ1_INMODE_Pos     8            /**< \brief (USBC_UPINRQ1) IN Request Mode */
+#define USBC_UPINRQ1_INMODE         (_U(0x1) << USBC_UPINRQ1_INMODE_Pos)
+#define USBC_UPINRQ1_MASK           _U(0x000001FF) /**< \brief (USBC_UPINRQ1) MASK Register */
+
+/* -------- USBC_UPINRQ2 : (USBC Offset: 0x658) (R/W 32) Pipe In Request -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t INRQ:8;           /*!< bit:  0.. 7  IN Request Number before Freeze    */
+    uint32_t INMODE:1;         /*!< bit:      8  IN Request Mode                    */
+    uint32_t :23;              /*!< bit:  9..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPINRQ2_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPINRQ2_OFFSET         0x658        /**< \brief (USBC_UPINRQ2 offset) Pipe In Request */
+#define USBC_UPINRQ2_RESETVALUE     _U(0x00000001); /**< \brief (USBC_UPINRQ2 reset_value) Pipe In Request */
+
+#define USBC_UPINRQ2_INRQ_Pos       0            /**< \brief (USBC_UPINRQ2) IN Request Number before Freeze */
+#define USBC_UPINRQ2_INRQ_Msk       (_U(0xFF) << USBC_UPINRQ2_INRQ_Pos)
+#define USBC_UPINRQ2_INRQ(value)    (USBC_UPINRQ2_INRQ_Msk & ((value) << USBC_UPINRQ2_INRQ_Pos))
+#define USBC_UPINRQ2_INMODE_Pos     8            /**< \brief (USBC_UPINRQ2) IN Request Mode */
+#define USBC_UPINRQ2_INMODE         (_U(0x1) << USBC_UPINRQ2_INMODE_Pos)
+#define USBC_UPINRQ2_MASK           _U(0x000001FF) /**< \brief (USBC_UPINRQ2) MASK Register */
+
+/* -------- USBC_UPINRQ3 : (USBC Offset: 0x65C) (R/W 32) Pipe In Request -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t INRQ:8;           /*!< bit:  0.. 7  IN Request Number before Freeze    */
+    uint32_t INMODE:1;         /*!< bit:      8  IN Request Mode                    */
+    uint32_t :23;              /*!< bit:  9..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPINRQ3_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPINRQ3_OFFSET         0x65C        /**< \brief (USBC_UPINRQ3 offset) Pipe In Request */
+#define USBC_UPINRQ3_RESETVALUE     _U(0x00000001); /**< \brief (USBC_UPINRQ3 reset_value) Pipe In Request */
+
+#define USBC_UPINRQ3_INRQ_Pos       0            /**< \brief (USBC_UPINRQ3) IN Request Number before Freeze */
+#define USBC_UPINRQ3_INRQ_Msk       (_U(0xFF) << USBC_UPINRQ3_INRQ_Pos)
+#define USBC_UPINRQ3_INRQ(value)    (USBC_UPINRQ3_INRQ_Msk & ((value) << USBC_UPINRQ3_INRQ_Pos))
+#define USBC_UPINRQ3_INMODE_Pos     8            /**< \brief (USBC_UPINRQ3) IN Request Mode */
+#define USBC_UPINRQ3_INMODE         (_U(0x1) << USBC_UPINRQ3_INMODE_Pos)
+#define USBC_UPINRQ3_MASK           _U(0x000001FF) /**< \brief (USBC_UPINRQ3) MASK Register */
+
+/* -------- USBC_UPINRQ4 : (USBC Offset: 0x660) (R/W 32) Pipe In Request -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t INRQ:8;           /*!< bit:  0.. 7  IN Request Number before Freeze    */
+    uint32_t INMODE:1;         /*!< bit:      8  IN Request Mode                    */
+    uint32_t :23;              /*!< bit:  9..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPINRQ4_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPINRQ4_OFFSET         0x660        /**< \brief (USBC_UPINRQ4 offset) Pipe In Request */
+#define USBC_UPINRQ4_RESETVALUE     _U(0x00000001); /**< \brief (USBC_UPINRQ4 reset_value) Pipe In Request */
+
+#define USBC_UPINRQ4_INRQ_Pos       0            /**< \brief (USBC_UPINRQ4) IN Request Number before Freeze */
+#define USBC_UPINRQ4_INRQ_Msk       (_U(0xFF) << USBC_UPINRQ4_INRQ_Pos)
+#define USBC_UPINRQ4_INRQ(value)    (USBC_UPINRQ4_INRQ_Msk & ((value) << USBC_UPINRQ4_INRQ_Pos))
+#define USBC_UPINRQ4_INMODE_Pos     8            /**< \brief (USBC_UPINRQ4) IN Request Mode */
+#define USBC_UPINRQ4_INMODE         (_U(0x1) << USBC_UPINRQ4_INMODE_Pos)
+#define USBC_UPINRQ4_MASK           _U(0x000001FF) /**< \brief (USBC_UPINRQ4) MASK Register */
+
+/* -------- USBC_UPINRQ5 : (USBC Offset: 0x664) (R/W 32) Pipe In Request -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t INRQ:8;           /*!< bit:  0.. 7  IN Request Number before Freeze    */
+    uint32_t INMODE:1;         /*!< bit:      8  IN Request Mode                    */
+    uint32_t :23;              /*!< bit:  9..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPINRQ5_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPINRQ5_OFFSET         0x664        /**< \brief (USBC_UPINRQ5 offset) Pipe In Request */
+#define USBC_UPINRQ5_RESETVALUE     _U(0x00000001); /**< \brief (USBC_UPINRQ5 reset_value) Pipe In Request */
+
+#define USBC_UPINRQ5_INRQ_Pos       0            /**< \brief (USBC_UPINRQ5) IN Request Number before Freeze */
+#define USBC_UPINRQ5_INRQ_Msk       (_U(0xFF) << USBC_UPINRQ5_INRQ_Pos)
+#define USBC_UPINRQ5_INRQ(value)    (USBC_UPINRQ5_INRQ_Msk & ((value) << USBC_UPINRQ5_INRQ_Pos))
+#define USBC_UPINRQ5_INMODE_Pos     8            /**< \brief (USBC_UPINRQ5) IN Request Mode */
+#define USBC_UPINRQ5_INMODE         (_U(0x1) << USBC_UPINRQ5_INMODE_Pos)
+#define USBC_UPINRQ5_MASK           _U(0x000001FF) /**< \brief (USBC_UPINRQ5) MASK Register */
+
+/* -------- USBC_UPINRQ6 : (USBC Offset: 0x668) (R/W 32) Pipe In Request -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t INRQ:8;           /*!< bit:  0.. 7  IN Request Number before Freeze    */
+    uint32_t INMODE:1;         /*!< bit:      8  IN Request Mode                    */
+    uint32_t :23;              /*!< bit:  9..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPINRQ6_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPINRQ6_OFFSET         0x668        /**< \brief (USBC_UPINRQ6 offset) Pipe In Request */
+#define USBC_UPINRQ6_RESETVALUE     _U(0x00000001); /**< \brief (USBC_UPINRQ6 reset_value) Pipe In Request */
+
+#define USBC_UPINRQ6_INRQ_Pos       0            /**< \brief (USBC_UPINRQ6) IN Request Number before Freeze */
+#define USBC_UPINRQ6_INRQ_Msk       (_U(0xFF) << USBC_UPINRQ6_INRQ_Pos)
+#define USBC_UPINRQ6_INRQ(value)    (USBC_UPINRQ6_INRQ_Msk & ((value) << USBC_UPINRQ6_INRQ_Pos))
+#define USBC_UPINRQ6_INMODE_Pos     8            /**< \brief (USBC_UPINRQ6) IN Request Mode */
+#define USBC_UPINRQ6_INMODE         (_U(0x1) << USBC_UPINRQ6_INMODE_Pos)
+#define USBC_UPINRQ6_MASK           _U(0x000001FF) /**< \brief (USBC_UPINRQ6) MASK Register */
+
+/* -------- USBC_UPINRQ7 : (USBC Offset: 0x66C) (R/W 32) Pipe In Request -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t INRQ:8;           /*!< bit:  0.. 7  IN Request Number before Freeze    */
+    uint32_t INMODE:1;         /*!< bit:      8  IN Request Mode                    */
+    uint32_t :23;              /*!< bit:  9..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UPINRQ7_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UPINRQ7_OFFSET         0x66C        /**< \brief (USBC_UPINRQ7 offset) Pipe In Request */
+#define USBC_UPINRQ7_RESETVALUE     _U(0x00000001); /**< \brief (USBC_UPINRQ7 reset_value) Pipe In Request */
+
+#define USBC_UPINRQ7_INRQ_Pos       0            /**< \brief (USBC_UPINRQ7) IN Request Number before Freeze */
+#define USBC_UPINRQ7_INRQ_Msk       (_U(0xFF) << USBC_UPINRQ7_INRQ_Pos)
+#define USBC_UPINRQ7_INRQ(value)    (USBC_UPINRQ7_INRQ_Msk & ((value) << USBC_UPINRQ7_INRQ_Pos))
+#define USBC_UPINRQ7_INMODE_Pos     8            /**< \brief (USBC_UPINRQ7) IN Request Mode */
+#define USBC_UPINRQ7_INMODE         (_U(0x1) << USBC_UPINRQ7_INMODE_Pos)
+#define USBC_UPINRQ7_MASK           _U(0x000001FF) /**< \brief (USBC_UPINRQ7) MASK Register */
+
+/* -------- USBC_USBCON : (USBC Offset: 0x800) (R/W 32) General Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :14;              /*!< bit:  0..13  Reserved                           */
+    uint32_t FRZCLK:1;         /*!< bit:     14  Freeze USB Clock                   */
+    uint32_t USBE:1;           /*!< bit:     15  USBC Enable                        */
+    uint32_t :8;               /*!< bit: 16..23  Reserved                           */
+    uint32_t UIMOD:1;          /*!< bit:     24  USBC Mode                          */
+    uint32_t :7;               /*!< bit: 25..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_USBCON_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_USBCON_OFFSET          0x800        /**< \brief (USBC_USBCON offset) General Control Register */
+#define USBC_USBCON_RESETVALUE      _U(0x01004000); /**< \brief (USBC_USBCON reset_value) General Control Register */
+
+#define USBC_USBCON_FRZCLK_Pos      14           /**< \brief (USBC_USBCON) Freeze USB Clock */
+#define USBC_USBCON_FRZCLK          (_U(0x1) << USBC_USBCON_FRZCLK_Pos)
+#define USBC_USBCON_USBE_Pos        15           /**< \brief (USBC_USBCON) USBC Enable */
+#define USBC_USBCON_USBE            (_U(0x1) << USBC_USBCON_USBE_Pos)
+#define USBC_USBCON_UIMOD_Pos       24           /**< \brief (USBC_USBCON) USBC Mode */
+#define USBC_USBCON_UIMOD           (_U(0x1) << USBC_USBCON_UIMOD_Pos)
+#define USBC_USBCON_MASK            _U(0x0100C000) /**< \brief (USBC_USBCON) MASK Register */
+
+/* -------- USBC_USBSTA : (USBC Offset: 0x804) (R/  32) General Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :9;               /*!< bit:  0.. 8  Reserved                           */
+    uint32_t VBUSRQ:1;         /*!< bit:      9  VBus Request                       */
+    uint32_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint32_t SPEED:2;          /*!< bit: 12..13  Speed Status                       */
+    uint32_t CLKUSABLE:1;      /*!< bit:     14  USB Clock Usable                   */
+    uint32_t :1;               /*!< bit:     15  Reserved                           */
+    uint32_t SUSPEND:1;        /*!< bit:     16  Suspend module state               */
+    uint32_t :15;              /*!< bit: 17..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_USBSTA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_USBSTA_OFFSET          0x804        /**< \brief (USBC_USBSTA offset) General Status Register */
+#define USBC_USBSTA_RESETVALUE      _U(0x00010000); /**< \brief (USBC_USBSTA reset_value) General Status Register */
+
+#define USBC_USBSTA_VBUSRQ_Pos      9            /**< \brief (USBC_USBSTA) VBus Request */
+#define USBC_USBSTA_VBUSRQ          (_U(0x1) << USBC_USBSTA_VBUSRQ_Pos)
+#define USBC_USBSTA_SPEED_Pos       12           /**< \brief (USBC_USBSTA) Speed Status */
+#define USBC_USBSTA_SPEED_Msk       (_U(0x3) << USBC_USBSTA_SPEED_Pos)
+#define USBC_USBSTA_SPEED(value)    (USBC_USBSTA_SPEED_Msk & ((value) << USBC_USBSTA_SPEED_Pos))
+#define   USBC_USBSTA_SPEED_FULL_Val      _U(0x0)   /**< \brief (USBC_USBSTA)  */
+#define   USBC_USBSTA_SPEED_HIGH_Val      _U(0x1)   /**< \brief (USBC_USBSTA)  */
+#define   USBC_USBSTA_SPEED_LOW_Val       _U(0x2)   /**< \brief (USBC_USBSTA)  */
+#define USBC_USBSTA_SPEED_FULL      (USBC_USBSTA_SPEED_FULL_Val    << USBC_USBSTA_SPEED_Pos)
+#define USBC_USBSTA_SPEED_HIGH      (USBC_USBSTA_SPEED_HIGH_Val    << USBC_USBSTA_SPEED_Pos)
+#define USBC_USBSTA_SPEED_LOW       (USBC_USBSTA_SPEED_LOW_Val     << USBC_USBSTA_SPEED_Pos)
+#define USBC_USBSTA_CLKUSABLE_Pos   14           /**< \brief (USBC_USBSTA) USB Clock Usable */
+#define USBC_USBSTA_CLKUSABLE       (_U(0x1) << USBC_USBSTA_CLKUSABLE_Pos)
+#define USBC_USBSTA_SUSPEND_Pos     16           /**< \brief (USBC_USBSTA) Suspend module state */
+#define USBC_USBSTA_SUSPEND         (_U(0x1) << USBC_USBSTA_SUSPEND_Pos)
+#define USBC_USBSTA_MASK            _U(0x00017200) /**< \brief (USBC_USBSTA) MASK Register */
+
+/* -------- USBC_USBSTACLR : (USBC Offset: 0x808) ( /W 32) General Status Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :8;               /*!< bit:  0.. 7  Reserved                           */
+    uint32_t RAMACERIC:1;      /*!< bit:      8  RAMACERI Clear                     */
+    uint32_t VBUSRQC:1;        /*!< bit:      9  VBUSRQ Clear                       */
+    uint32_t :22;              /*!< bit: 10..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_USBSTACLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_USBSTACLR_OFFSET       0x808        /**< \brief (USBC_USBSTACLR offset) General Status Clear Register */
+#define USBC_USBSTACLR_RESETVALUE   _U(0x00000000); /**< \brief (USBC_USBSTACLR reset_value) General Status Clear Register */
+
+#define USBC_USBSTACLR_RAMACERIC_Pos 8            /**< \brief (USBC_USBSTACLR) RAMACERI Clear */
+#define USBC_USBSTACLR_RAMACERIC    (_U(0x1) << USBC_USBSTACLR_RAMACERIC_Pos)
+#define USBC_USBSTACLR_VBUSRQC_Pos  9            /**< \brief (USBC_USBSTACLR) VBUSRQ Clear */
+#define USBC_USBSTACLR_VBUSRQC      (_U(0x1) << USBC_USBSTACLR_VBUSRQC_Pos)
+#define USBC_USBSTACLR_MASK         _U(0x00000300) /**< \brief (USBC_USBSTACLR) MASK Register */
+
+/* -------- USBC_USBSTASET : (USBC Offset: 0x80C) ( /W 32) General Status Set Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :8;               /*!< bit:  0.. 7  Reserved                           */
+    uint32_t RAMACERIS:1;      /*!< bit:      8  RAMACERI Set                       */
+    uint32_t VBUSRQS:1;        /*!< bit:      9  VBUSRQ Set                         */
+    uint32_t :22;              /*!< bit: 10..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_USBSTASET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_USBSTASET_OFFSET       0x80C        /**< \brief (USBC_USBSTASET offset) General Status Set Register */
+#define USBC_USBSTASET_RESETVALUE   _U(0x00000000); /**< \brief (USBC_USBSTASET reset_value) General Status Set Register */
+
+#define USBC_USBSTASET_RAMACERIS_Pos 8            /**< \brief (USBC_USBSTASET) RAMACERI Set */
+#define USBC_USBSTASET_RAMACERIS    (_U(0x1) << USBC_USBSTASET_RAMACERIS_Pos)
+#define USBC_USBSTASET_VBUSRQS_Pos  9            /**< \brief (USBC_USBSTASET) VBUSRQ Set */
+#define USBC_USBSTASET_VBUSRQS      (_U(0x1) << USBC_USBSTASET_VBUSRQS_Pos)
+#define USBC_USBSTASET_MASK         _U(0x00000300) /**< \brief (USBC_USBSTASET) MASK Register */
+
+/* -------- USBC_UVERS : (USBC Offset: 0x818) (R/  32) IP Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version Number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:3;        /*!< bit: 16..18  Variant Number                     */
+    uint32_t :13;              /*!< bit: 19..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UVERS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UVERS_OFFSET           0x818        /**< \brief (USBC_UVERS offset) IP Version Register */
+#define USBC_UVERS_RESETVALUE       _U(0x00000310); /**< \brief (USBC_UVERS reset_value) IP Version Register */
+
+#define USBC_UVERS_VERSION_Pos      0            /**< \brief (USBC_UVERS) Version Number */
+#define USBC_UVERS_VERSION_Msk      (_U(0xFFF) << USBC_UVERS_VERSION_Pos)
+#define USBC_UVERS_VERSION(value)   (USBC_UVERS_VERSION_Msk & ((value) << USBC_UVERS_VERSION_Pos))
+#define USBC_UVERS_VARIANT_Pos      16           /**< \brief (USBC_UVERS) Variant Number */
+#define USBC_UVERS_VARIANT_Msk      (_U(0x7) << USBC_UVERS_VARIANT_Pos)
+#define USBC_UVERS_VARIANT(value)   (USBC_UVERS_VARIANT_Msk & ((value) << USBC_UVERS_VARIANT_Pos))
+#define USBC_UVERS_MASK             _U(0x00070FFF) /**< \brief (USBC_UVERS) MASK Register */
+
+/* -------- USBC_UFEATURES : (USBC Offset: 0x81C) (R/  32) IP Features Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EPTNBRMAX:4;      /*!< bit:  0.. 3  Maximum Number of Pipes/Endpints   */
+    uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint32_t UTMIMODE:1;       /*!< bit:      8  UTMI Mode                          */
+    uint32_t :23;              /*!< bit:  9..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UFEATURES_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UFEATURES_OFFSET       0x81C        /**< \brief (USBC_UFEATURES offset) IP Features Register */
+#define USBC_UFEATURES_RESETVALUE   _U(0x00000007); /**< \brief (USBC_UFEATURES reset_value) IP Features Register */
+
+#define USBC_UFEATURES_EPTNBRMAX_Pos 0            /**< \brief (USBC_UFEATURES) Maximum Number of Pipes/Endpints */
+#define USBC_UFEATURES_EPTNBRMAX_Msk (_U(0xF) << USBC_UFEATURES_EPTNBRMAX_Pos)
+#define USBC_UFEATURES_EPTNBRMAX(value) (USBC_UFEATURES_EPTNBRMAX_Msk & ((value) << USBC_UFEATURES_EPTNBRMAX_Pos))
+#define USBC_UFEATURES_UTMIMODE_Pos 8            /**< \brief (USBC_UFEATURES) UTMI Mode */
+#define USBC_UFEATURES_UTMIMODE     (_U(0x1) << USBC_UFEATURES_UTMIMODE_Pos)
+#define USBC_UFEATURES_MASK         _U(0x0000010F) /**< \brief (USBC_UFEATURES) MASK Register */
+
+/* -------- USBC_UADDRSIZE : (USBC Offset: 0x820) (R/  32) IP PB address size Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t UADDRSIZE:32;     /*!< bit:  0..31  IP PB Address Size                 */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UADDRSIZE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UADDRSIZE_OFFSET       0x820        /**< \brief (USBC_UADDRSIZE offset) IP PB address size Register */
+#define USBC_UADDRSIZE_RESETVALUE   _U(0x00001000); /**< \brief (USBC_UADDRSIZE reset_value) IP PB address size Register */
+
+#define USBC_UADDRSIZE_UADDRSIZE_Pos 0            /**< \brief (USBC_UADDRSIZE) IP PB Address Size */
+#define USBC_UADDRSIZE_UADDRSIZE_Msk (_U(0xFFFFFFFF) << USBC_UADDRSIZE_UADDRSIZE_Pos)
+#define USBC_UADDRSIZE_UADDRSIZE(value) (USBC_UADDRSIZE_UADDRSIZE_Msk & ((value) << USBC_UADDRSIZE_UADDRSIZE_Pos))
+#define USBC_UADDRSIZE_MASK         _U(0xFFFFFFFF) /**< \brief (USBC_UADDRSIZE) MASK Register */
+
+/* -------- USBC_UNAME1 : (USBC Offset: 0x824) (R/  32) IP Name Part One: HUSB -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t UNAME1:32;        /*!< bit:  0..31  IP Name Part One                   */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UNAME1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UNAME1_OFFSET          0x824        /**< \brief (USBC_UNAME1 offset) IP Name Part One: HUSB */
+#define USBC_UNAME1_RESETVALUE      _U(0x48555342); /**< \brief (USBC_UNAME1 reset_value) IP Name Part One: HUSB */
+
+#define USBC_UNAME1_UNAME1_Pos      0            /**< \brief (USBC_UNAME1) IP Name Part One */
+#define USBC_UNAME1_UNAME1_Msk      (_U(0xFFFFFFFF) << USBC_UNAME1_UNAME1_Pos)
+#define USBC_UNAME1_UNAME1(value)   (USBC_UNAME1_UNAME1_Msk & ((value) << USBC_UNAME1_UNAME1_Pos))
+#define USBC_UNAME1_MASK            _U(0xFFFFFFFF) /**< \brief (USBC_UNAME1) MASK Register */
+
+/* -------- USBC_UNAME2 : (USBC Offset: 0x828) (R/  32) IP Name Part Two: HOST -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t UNAME2:32;        /*!< bit:  0..31  IP Name Part Two                   */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UNAME2_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UNAME2_OFFSET          0x828        /**< \brief (USBC_UNAME2 offset) IP Name Part Two: HOST */
+#define USBC_UNAME2_RESETVALUE      _U(0x484F5354); /**< \brief (USBC_UNAME2 reset_value) IP Name Part Two: HOST */
+
+#define USBC_UNAME2_UNAME2_Pos      0            /**< \brief (USBC_UNAME2) IP Name Part Two */
+#define USBC_UNAME2_UNAME2_Msk      (_U(0xFFFFFFFF) << USBC_UNAME2_UNAME2_Pos)
+#define USBC_UNAME2_UNAME2(value)   (USBC_UNAME2_UNAME2_Msk & ((value) << USBC_UNAME2_UNAME2_Pos))
+#define USBC_UNAME2_MASK            _U(0xFFFFFFFF) /**< \brief (USBC_UNAME2) MASK Register */
+
+/* -------- USBC_USBFSM : (USBC Offset: 0x82C) (R/  32) USB internal finite state machine -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DRDSTATE:4;       /*!< bit:  0.. 3  DualRoleDevice state               */
+    uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_USBFSM_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_USBFSM_OFFSET          0x82C        /**< \brief (USBC_USBFSM offset) USB internal finite state machine */
+#define USBC_USBFSM_RESETVALUE      _U(0x00000009); /**< \brief (USBC_USBFSM reset_value) USB internal finite state machine */
+
+#define USBC_USBFSM_DRDSTATE_Pos    0            /**< \brief (USBC_USBFSM) DualRoleDevice state */
+#define USBC_USBFSM_DRDSTATE_Msk    (_U(0xF) << USBC_USBFSM_DRDSTATE_Pos)
+#define USBC_USBFSM_DRDSTATE(value) (USBC_USBFSM_DRDSTATE_Msk & ((value) << USBC_USBFSM_DRDSTATE_Pos))
+#define   USBC_USBFSM_DRDSTATE_A_IDLE_Val _U(0x0)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_A_WAIT_VRISE_Val _U(0x1)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_A_WAIT_BCON_Val _U(0x2)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_A_HOST_Val _U(0x3)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_A_SUSPEND_Val _U(0x4)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_A_PERIPHERAL_Val _U(0x5)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_A_WAIT_VFALL_Val _U(0x6)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_A_VBUS_ERR_Val _U(0x7)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_A_WAIT_DISCHARGE_Val _U(0x8)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_B_IDLE_Val _U(0x9)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_B_PERIPHERAL_Val _U(0xA)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_B_WAIT_BEGIN_HNP_Val _U(0xB)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_B_WAIT_DISCHARGE_Val _U(0xC)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_B_WAIT_ACON_Val _U(0xD)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_B_HOST_Val _U(0xE)   /**< \brief (USBC_USBFSM)  */
+#define   USBC_USBFSM_DRDSTATE_B_SRP_INIT_Val _U(0xF)   /**< \brief (USBC_USBFSM)  */
+#define USBC_USBFSM_DRDSTATE_A_IDLE (USBC_USBFSM_DRDSTATE_A_IDLE_Val << USBC_USBFSM_DRDSTATE_Pos)
+#define USBC_USBFSM_DRDSTATE_A_WAIT_VRISE (USBC_USBFSM_DRDSTATE_A_WAIT_VRISE_Val << USBC_USBFSM_DRDSTATE_Pos)
+#define USBC_USBFSM_DRDSTATE_A_WAIT_BCON (USBC_USBFSM_DRDSTATE_A_WAIT_BCON_Val << USBC_USBFSM_DRDSTATE_Pos)
+#define USBC_USBFSM_DRDSTATE_A_HOST (USBC_USBFSM_DRDSTATE_A_HOST_Val << USBC_USBFSM_DRDSTATE_Pos)
+#define USBC_USBFSM_DRDSTATE_A_SUSPEND (USBC_USBFSM_DRDSTATE_A_SUSPEND_Val << USBC_USBFSM_DRDSTATE_Pos)
+#define USBC_USBFSM_DRDSTATE_A_PERIPHERAL (USBC_USBFSM_DRDSTATE_A_PERIPHERAL_Val << USBC_USBFSM_DRDSTATE_Pos)
+#define USBC_USBFSM_DRDSTATE_A_WAIT_VFALL (USBC_USBFSM_DRDSTATE_A_WAIT_VFALL_Val << USBC_USBFSM_DRDSTATE_Pos)
+#define USBC_USBFSM_DRDSTATE_A_VBUS_ERR (USBC_USBFSM_DRDSTATE_A_VBUS_ERR_Val << USBC_USBFSM_DRDSTATE_Pos)
+#define USBC_USBFSM_DRDSTATE_A_WAIT_DISCHARGE (USBC_USBFSM_DRDSTATE_A_WAIT_DISCHARGE_Val << USBC_USBFSM_DRDSTATE_Pos)
+#define USBC_USBFSM_DRDSTATE_B_IDLE (USBC_USBFSM_DRDSTATE_B_IDLE_Val << USBC_USBFSM_DRDSTATE_Pos)
+#define USBC_USBFSM_DRDSTATE_B_PERIPHERAL (USBC_USBFSM_DRDSTATE_B_PERIPHERAL_Val << USBC_USBFSM_DRDSTATE_Pos)
+#define USBC_USBFSM_DRDSTATE_B_WAIT_BEGIN_HNP (USBC_USBFSM_DRDSTATE_B_WAIT_BEGIN_HNP_Val << USBC_USBFSM_DRDSTATE_Pos)
+#define USBC_USBFSM_DRDSTATE_B_WAIT_DISCHARGE (USBC_USBFSM_DRDSTATE_B_WAIT_DISCHARGE_Val << USBC_USBFSM_DRDSTATE_Pos)
+#define USBC_USBFSM_DRDSTATE_B_WAIT_ACON (USBC_USBFSM_DRDSTATE_B_WAIT_ACON_Val << USBC_USBFSM_DRDSTATE_Pos)
+#define USBC_USBFSM_DRDSTATE_B_HOST (USBC_USBFSM_DRDSTATE_B_HOST_Val << USBC_USBFSM_DRDSTATE_Pos)
+#define USBC_USBFSM_DRDSTATE_B_SRP_INIT (USBC_USBFSM_DRDSTATE_B_SRP_INIT_Val << USBC_USBFSM_DRDSTATE_Pos)
+#define USBC_USBFSM_MASK            _U(0x0000000F) /**< \brief (USBC_USBFSM) MASK Register */
+
+/* -------- USBC_UDESC : (USBC Offset: 0x830) (R/W 32) Endpoint descriptor table -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t UDESCA:32;        /*!< bit:  0..31  USB Descriptor Address             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} USBC_UDESC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define USBC_UDESC_OFFSET           0x830        /**< \brief (USBC_UDESC offset) Endpoint descriptor table */
+#define USBC_UDESC_RESETVALUE       _U(0x00000000); /**< \brief (USBC_UDESC reset_value) Endpoint descriptor table */
+
+#define USBC_UDESC_UDESCA_Pos       0            /**< \brief (USBC_UDESC) USB Descriptor Address */
+#define USBC_UDESC_UDESCA_Msk       (_U(0xFFFFFFFF) << USBC_UDESC_UDESCA_Pos)
+#define USBC_UDESC_UDESCA(value)    (USBC_UDESC_UDESCA_Msk & ((value) << USBC_UDESC_UDESCA_Pos))
+#define USBC_UDESC_MASK             _U(0xFFFFFFFF) /**< \brief (USBC_UDESC) MASK Register */
+
+/** \brief USBC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __IO USBC_UDCON_Type           UDCON;       /**< \brief Offset: 0x000 (R/W 32) Device General Control Register */
+  __I  USBC_UDINT_Type           UDINT;       /**< \brief Offset: 0x004 (R/  32) Device Global Interupt Register */
+  __O  USBC_UDINTCLR_Type        UDINTCLR;    /**< \brief Offset: 0x008 ( /W 32) Device Global Interrupt Clear Register */
+  __O  USBC_UDINTSET_Type        UDINTSET;    /**< \brief Offset: 0x00C ( /W 32) Device Global Interrupt Set Regsiter */
+  __I  USBC_UDINTE_Type          UDINTE;      /**< \brief Offset: 0x010 (R/  32) Device Global Interrupt Enable Register */
+  __O  USBC_UDINTECLR_Type       UDINTECLR;   /**< \brief Offset: 0x014 ( /W 32) Device Global Interrupt Enable Clear Register */
+  __O  USBC_UDINTESET_Type       UDINTESET;   /**< \brief Offset: 0x018 ( /W 32) Device Global Interrupt Enable Set Register */
+  __IO USBC_UERST_Type           UERST;       /**< \brief Offset: 0x01C (R/W 32) Endpoint Enable/Reset Register */
+  __I  USBC_UDFNUM_Type          UDFNUM;      /**< \brief Offset: 0x020 (R/  32) Device Frame Number Register */
+       RoReg8                    Reserved1[0xDC];
+  __IO USBC_UECFG0_Type          UECFG0;      /**< \brief Offset: 0x100 (R/W 32) Endpoint Configuration Register */
+  __IO USBC_UECFG1_Type          UECFG1;      /**< \brief Offset: 0x104 (R/W 32) Endpoint Configuration Register */
+  __IO USBC_UECFG2_Type          UECFG2;      /**< \brief Offset: 0x108 (R/W 32) Endpoint Configuration Register */
+  __IO USBC_UECFG3_Type          UECFG3;      /**< \brief Offset: 0x10C (R/W 32) Endpoint Configuration Register */
+  __IO USBC_UECFG4_Type          UECFG4;      /**< \brief Offset: 0x110 (R/W 32) Endpoint Configuration Register */
+  __IO USBC_UECFG5_Type          UECFG5;      /**< \brief Offset: 0x114 (R/W 32) Endpoint Configuration Register */
+  __IO USBC_UECFG6_Type          UECFG6;      /**< \brief Offset: 0x118 (R/W 32) Endpoint Configuration Register */
+  __IO USBC_UECFG7_Type          UECFG7;      /**< \brief Offset: 0x11C (R/W 32) Endpoint Configuration Register */
+       RoReg8                    Reserved2[0x10];
+  __I  USBC_UESTA0_Type          UESTA0;      /**< \brief Offset: 0x130 (R/  32) Endpoint Status Register */
+  __I  USBC_UESTA1_Type          UESTA1;      /**< \brief Offset: 0x134 (R/  32) Endpoint Status Register */
+  __I  USBC_UESTA2_Type          UESTA2;      /**< \brief Offset: 0x138 (R/  32) Endpoint Status Register */
+  __I  USBC_UESTA3_Type          UESTA3;      /**< \brief Offset: 0x13C (R/  32) Endpoint Status Register */
+  __I  USBC_UESTA4_Type          UESTA4;      /**< \brief Offset: 0x140 (R/  32) Endpoint Status Register */
+  __I  USBC_UESTA5_Type          UESTA5;      /**< \brief Offset: 0x144 (R/  32) Endpoint Status Register */
+  __I  USBC_UESTA6_Type          UESTA6;      /**< \brief Offset: 0x148 (R/  32) Endpoint Status Register */
+  __I  USBC_UESTA7_Type          UESTA7;      /**< \brief Offset: 0x14C (R/  32) Endpoint Status Register */
+       RoReg8                    Reserved3[0x10];
+  __O  USBC_UESTA0CLR_Type       UESTA0CLR;   /**< \brief Offset: 0x160 ( /W 32) Endpoint Status Clear Register */
+  __O  USBC_UESTA1CLR_Type       UESTA1CLR;   /**< \brief Offset: 0x164 ( /W 32) Endpoint Status Clear Register */
+  __O  USBC_UESTA2CLR_Type       UESTA2CLR;   /**< \brief Offset: 0x168 ( /W 32) Endpoint Status Clear Register */
+  __O  USBC_UESTA3CLR_Type       UESTA3CLR;   /**< \brief Offset: 0x16C ( /W 32) Endpoint Status Clear Register */
+  __O  USBC_UESTA4CLR_Type       UESTA4CLR;   /**< \brief Offset: 0x170 ( /W 32) Endpoint Status Clear Register */
+  __O  USBC_UESTA5CLR_Type       UESTA5CLR;   /**< \brief Offset: 0x174 ( /W 32) Endpoint Status Clear Register */
+  __O  USBC_UESTA6CLR_Type       UESTA6CLR;   /**< \brief Offset: 0x178 ( /W 32) Endpoint Status Clear Register */
+  __O  USBC_UESTA7CLR_Type       UESTA7CLR;   /**< \brief Offset: 0x17C ( /W 32) Endpoint Status Clear Register */
+       RoReg8                    Reserved4[0x10];
+  __O  USBC_UESTA0SET_Type       UESTA0SET;   /**< \brief Offset: 0x190 ( /W 32) Endpoint Status Set Register */
+  __O  USBC_UESTA1SET_Type       UESTA1SET;   /**< \brief Offset: 0x194 ( /W 32) Endpoint Status Set Register */
+  __O  USBC_UESTA2SET_Type       UESTA2SET;   /**< \brief Offset: 0x198 ( /W 32) Endpoint Status Set Register */
+  __O  USBC_UESTA3SET_Type       UESTA3SET;   /**< \brief Offset: 0x19C ( /W 32) Endpoint Status Set Register */
+  __O  USBC_UESTA4SET_Type       UESTA4SET;   /**< \brief Offset: 0x1A0 ( /W 32) Endpoint Status Set Register */
+  __O  USBC_UESTA5SET_Type       UESTA5SET;   /**< \brief Offset: 0x1A4 ( /W 32) Endpoint Status Set Register */
+  __O  USBC_UESTA6SET_Type       UESTA6SET;   /**< \brief Offset: 0x1A8 ( /W 32) Endpoint Status Set Register */
+  __O  USBC_UESTA7SET_Type       UESTA7SET;   /**< \brief Offset: 0x1AC ( /W 32) Endpoint Status Set Register */
+       RoReg8                    Reserved5[0x10];
+  __I  USBC_UECON0_Type          UECON0;      /**< \brief Offset: 0x1C0 (R/  32) Endpoint Control Register */
+  __I  USBC_UECON1_Type          UECON1;      /**< \brief Offset: 0x1C4 (R/  32) Endpoint Control Register */
+  __I  USBC_UECON2_Type          UECON2;      /**< \brief Offset: 0x1C8 (R/  32) Endpoint Control Register */
+  __I  USBC_UECON3_Type          UECON3;      /**< \brief Offset: 0x1CC (R/  32) Endpoint Control Register */
+  __I  USBC_UECON4_Type          UECON4;      /**< \brief Offset: 0x1D0 (R/  32) Endpoint Control Register */
+  __I  USBC_UECON5_Type          UECON5;      /**< \brief Offset: 0x1D4 (R/  32) Endpoint Control Register */
+  __I  USBC_UECON6_Type          UECON6;      /**< \brief Offset: 0x1D8 (R/  32) Endpoint Control Register */
+  __I  USBC_UECON7_Type          UECON7;      /**< \brief Offset: 0x1DC (R/  32) Endpoint Control Register */
+       RoReg8                    Reserved6[0x10];
+  __O  USBC_UECON0SET_Type       UECON0SET;   /**< \brief Offset: 0x1F0 ( /W 32) Endpoint Control Set Register */
+  __O  USBC_UECON1SET_Type       UECON1SET;   /**< \brief Offset: 0x1F4 ( /W 32) Endpoint Control Set Register */
+  __O  USBC_UECON2SET_Type       UECON2SET;   /**< \brief Offset: 0x1F8 ( /W 32) Endpoint Control Set Register */
+  __O  USBC_UECON3SET_Type       UECON3SET;   /**< \brief Offset: 0x1FC ( /W 32) Endpoint Control Set Register */
+  __O  USBC_UECON4SET_Type       UECON4SET;   /**< \brief Offset: 0x200 ( /W 32) Endpoint Control Set Register */
+  __O  USBC_UECON5SET_Type       UECON5SET;   /**< \brief Offset: 0x204 ( /W 32) Endpoint Control Set Register */
+  __O  USBC_UECON6SET_Type       UECON6SET;   /**< \brief Offset: 0x208 ( /W 32) Endpoint Control Set Register */
+  __O  USBC_UECON7SET_Type       UECON7SET;   /**< \brief Offset: 0x20C ( /W 32) Endpoint Control Set Register */
+       RoReg8                    Reserved7[0x10];
+  __O  USBC_UECON0CLR_Type       UECON0CLR;   /**< \brief Offset: 0x220 ( /W 32) Endpoint Control Clear Register */
+  __O  USBC_UECON1CLR_Type       UECON1CLR;   /**< \brief Offset: 0x224 ( /W 32) TXINE Clear */
+  __O  USBC_UECON2CLR_Type       UECON2CLR;   /**< \brief Offset: 0x228 ( /W 32) TXINE Clear */
+  __O  USBC_UECON3CLR_Type       UECON3CLR;   /**< \brief Offset: 0x22C ( /W 32) TXINE Clear */
+  __O  USBC_UECON4CLR_Type       UECON4CLR;   /**< \brief Offset: 0x230 ( /W 32) TXINE Clear */
+  __O  USBC_UECON5CLR_Type       UECON5CLR;   /**< \brief Offset: 0x234 ( /W 32) TXINE Clear */
+  __O  USBC_UECON6CLR_Type       UECON6CLR;   /**< \brief Offset: 0x238 ( /W 32) TXINE Clear */
+  __O  USBC_UECON7CLR_Type       UECON7CLR;   /**< \brief Offset: 0x23C ( /W 32) TXINE Clear */
+       RoReg8                    Reserved8[0x1C0];
+  __IO USBC_UHCON_Type           UHCON;       /**< \brief Offset: 0x400 (R/W 32) Host General Control Register */
+  __I  USBC_UHINT_Type           UHINT;       /**< \brief Offset: 0x404 (R/  32) Host Global Interrupt Register */
+  __O  USBC_UHINTCLR_Type        UHINTCLR;    /**< \brief Offset: 0x408 ( /W 32) Host Global Interrrupt Clear Register */
+  __O  USBC_UHINTSET_Type        UHINTSET;    /**< \brief Offset: 0x40C ( /W 32) Host Global Interrupt Set Register */
+  __I  USBC_UHINTE_Type          UHINTE;      /**< \brief Offset: 0x410 (R/  32) Host Global Interrupt Enable Register */
+  __O  USBC_UHINTECLR_Type       UHINTECLR;   /**< \brief Offset: 0x414 ( /W 32) Host Global Interrupt Enable Clear Register */
+  __O  USBC_UHINTESET_Type       UHINTESET;   /**< \brief Offset: 0x418 ( /W 32) Host Global Interrupt Enable Set Register */
+  __IO USBC_UPRST_Type           UPRST;       /**< \brief Offset: 0x41C (R/W 32) Pipe Reset Register */
+  __IO USBC_UHFNUM_Type          UHFNUM;      /**< \brief Offset: 0x420 (R/W 32) Host Frame Number Register */
+  __IO USBC_UHSOFC_Type          UHSOFC;      /**< \brief Offset: 0x424 (R/W 32) Host Start of Frame Control Register */
+       RoReg8                    Reserved9[0xD8];
+  __IO USBC_UPCFG0_Type          UPCFG0;      /**< \brief Offset: 0x500 (R/W 32) Pipe Configuration Register */
+  __IO USBC_UPCFG1_Type          UPCFG1;      /**< \brief Offset: 0x504 (R/W 32) Pipe Configuration Register */
+  __IO USBC_UPCFG2_Type          UPCFG2;      /**< \brief Offset: 0x508 (R/W 32) Pipe Configuration Register */
+  __IO USBC_UPCFG3_Type          UPCFG3;      /**< \brief Offset: 0x50C (R/W 32) Pipe Configuration Register */
+  __IO USBC_UPCFG4_Type          UPCFG4;      /**< \brief Offset: 0x510 (R/W 32) Pipe Configuration Register */
+  __IO USBC_UPCFG5_Type          UPCFG5;      /**< \brief Offset: 0x514 (R/W 32) Pipe Configuration Register */
+  __IO USBC_UPCFG6_Type          UPCFG6;      /**< \brief Offset: 0x518 (R/W 32) Pipe Configuration Register */
+  __IO USBC_UPCFG7_Type          UPCFG7;      /**< \brief Offset: 0x51C (R/W 32) Pipe Configuration Register */
+       RoReg8                    Reserved10[0x10];
+  __I  USBC_UPSTA0_Type          UPSTA0;      /**< \brief Offset: 0x530 (R/  32) Pipe Status Register */
+  __I  USBC_UPSTA1_Type          UPSTA1;      /**< \brief Offset: 0x534 (R/  32) Pipe Status Register */
+  __I  USBC_UPSTA2_Type          UPSTA2;      /**< \brief Offset: 0x538 (R/  32) Pipe Status Register */
+  __I  USBC_UPSTA3_Type          UPSTA3;      /**< \brief Offset: 0x53C (R/  32) Pipe Status Register */
+  __I  USBC_UPSTA4_Type          UPSTA4;      /**< \brief Offset: 0x540 (R/  32) Pipe Status Register */
+  __I  USBC_UPSTA5_Type          UPSTA5;      /**< \brief Offset: 0x544 (R/  32) Pipe Status Register */
+  __I  USBC_UPSTA6_Type          UPSTA6;      /**< \brief Offset: 0x548 (R/  32) Pipe Status Register */
+  __I  USBC_UPSTA7_Type          UPSTA7;      /**< \brief Offset: 0x54C (R/  32) Pipe Status Register */
+       RoReg8                    Reserved11[0x10];
+  __O  USBC_UPSTA0CLR_Type       UPSTA0CLR;   /**< \brief Offset: 0x560 ( /W 32) Pipe Status Clear Register */
+  __O  USBC_UPSTA1CLR_Type       UPSTA1CLR;   /**< \brief Offset: 0x564 ( /W 32) Pipe Status Clear Register */
+  __O  USBC_UPSTA2CLR_Type       UPSTA2CLR;   /**< \brief Offset: 0x568 ( /W 32) Pipe Status Clear Register */
+  __O  USBC_UPSTA3CLR_Type       UPSTA3CLR;   /**< \brief Offset: 0x56C ( /W 32) Pipe Status Clear Register */
+  __O  USBC_UPSTA4CLR_Type       UPSTA4CLR;   /**< \brief Offset: 0x570 ( /W 32) Pipe Status Clear Register */
+  __O  USBC_UPSTA5CLR_Type       UPSTA5CLR;   /**< \brief Offset: 0x574 ( /W 32) Pipe Status Clear Register */
+  __O  USBC_UPSTA6CLR_Type       UPSTA6CLR;   /**< \brief Offset: 0x578 ( /W 32) Pipe Status Clear Register */
+  __O  USBC_UPSTA7CLR_Type       UPSTA7CLR;   /**< \brief Offset: 0x57C ( /W 32) Pipe Status Clear Register */
+       RoReg8                    Reserved12[0x10];
+  __O  USBC_UPSTA0SET_Type       UPSTA0SET;   /**< \brief Offset: 0x590 ( /W 32) Pipe Status Set Register */
+  __O  USBC_UPSTA1SET_Type       UPSTA1SET;   /**< \brief Offset: 0x594 ( /W 32) Pipe Status Set Register */
+  __O  USBC_UPSTA2SET_Type       UPSTA2SET;   /**< \brief Offset: 0x598 ( /W 32) Pipe Status Set Register */
+  __O  USBC_UPSTA3SET_Type       UPSTA3SET;   /**< \brief Offset: 0x59C ( /W 32) Pipe Status Set Register */
+  __O  USBC_UPSTA4SET_Type       UPSTA4SET;   /**< \brief Offset: 0x5A0 ( /W 32) Pipe Status Set Register */
+  __O  USBC_UPSTA5SET_Type       UPSTA5SET;   /**< \brief Offset: 0x5A4 ( /W 32) Pipe Status Set Register */
+  __O  USBC_UPSTA6SET_Type       UPSTA6SET;   /**< \brief Offset: 0x5A8 ( /W 32) Pipe Status Set Register */
+  __O  USBC_UPSTA7SET_Type       UPSTA7SET;   /**< \brief Offset: 0x5AC ( /W 32) Pipe Status Set Register */
+       RoReg8                    Reserved13[0x10];
+  __I  USBC_UPCON0_Type          UPCON0;      /**< \brief Offset: 0x5C0 (R/  32) Pipe Control Register */
+  __I  USBC_UPCON1_Type          UPCON1;      /**< \brief Offset: 0x5C4 (R/  32) Pipe Control Register */
+  __I  USBC_UPCON2_Type          UPCON2;      /**< \brief Offset: 0x5C8 (R/  32) Pipe Control Register */
+  __I  USBC_UPCON3_Type          UPCON3;      /**< \brief Offset: 0x5CC (R/  32) Pipe Control Register */
+  __I  USBC_UPCON4_Type          UPCON4;      /**< \brief Offset: 0x5D0 (R/  32) Pipe Control Register */
+  __I  USBC_UPCON5_Type          UPCON5;      /**< \brief Offset: 0x5D4 (R/  32) Pipe Control Register */
+  __I  USBC_UPCON6_Type          UPCON6;      /**< \brief Offset: 0x5D8 (R/  32) Pipe Control Register */
+  __I  USBC_UPCON7_Type          UPCON7;      /**< \brief Offset: 0x5DC (R/  32) Pipe Control Register */
+       RoReg8                    Reserved14[0x10];
+  __O  USBC_UPCON0SET_Type       UPCON0SET;   /**< \brief Offset: 0x5F0 ( /W 32) Pipe Control Set Register */
+  __O  USBC_UPCON1SET_Type       UPCON1SET;   /**< \brief Offset: 0x5F4 ( /W 32) Pipe Control Set Register */
+  __O  USBC_UPCON2SET_Type       UPCON2SET;   /**< \brief Offset: 0x5F8 ( /W 32) Pipe Control Set Register */
+  __O  USBC_UPCON3SET_Type       UPCON3SET;   /**< \brief Offset: 0x5FC ( /W 32) Pipe Control Set Register */
+  __O  USBC_UPCON4SET_Type       UPCON4SET;   /**< \brief Offset: 0x600 ( /W 32) Pipe Control Set Register */
+  __O  USBC_UPCON5SET_Type       UPCON5SET;   /**< \brief Offset: 0x604 ( /W 32) Pipe Control Set Register */
+  __O  USBC_UPCON6SET_Type       UPCON6SET;   /**< \brief Offset: 0x608 ( /W 32) Pipe Control Set Register */
+  __O  USBC_UPCON7SET_Type       UPCON7SET;   /**< \brief Offset: 0x60C ( /W 32) Pipe Control Set Register */
+       RoReg8                    Reserved15[0x10];
+  __O  USBC_UPCON0CLR_Type       UPCON0CLR;   /**< \brief Offset: 0x620 ( /W 32) Pipe Control Clear Register */
+  __O  USBC_UPCON1CLR_Type       UPCON1CLR;   /**< \brief Offset: 0x624 ( /W 32) Pipe Control Clear Register */
+  __O  USBC_UPCON2CLR_Type       UPCON2CLR;   /**< \brief Offset: 0x628 ( /W 32) Pipe Control Clear Register */
+  __O  USBC_UPCON3CLR_Type       UPCON3CLR;   /**< \brief Offset: 0x62C ( /W 32) Pipe Control Clear Register */
+  __O  USBC_UPCON4CLR_Type       UPCON4CLR;   /**< \brief Offset: 0x630 ( /W 32) Pipe Control Clear Register */
+  __O  USBC_UPCON5CLR_Type       UPCON5CLR;   /**< \brief Offset: 0x634 ( /W 32) Pipe Control Clear Register */
+  __O  USBC_UPCON6CLR_Type       UPCON6CLR;   /**< \brief Offset: 0x638 ( /W 32) Pipe Control Clear Register */
+  __O  USBC_UPCON7CLR_Type       UPCON7CLR;   /**< \brief Offset: 0x63C ( /W 32) Pipe Control Clear Register */
+       RoReg8                    Reserved16[0x10];
+  __IO USBC_UPINRQ0_Type         UPINRQ0;     /**< \brief Offset: 0x650 (R/W 32) Pipe In Request */
+  __IO USBC_UPINRQ1_Type         UPINRQ1;     /**< \brief Offset: 0x654 (R/W 32) Pipe In Request */
+  __IO USBC_UPINRQ2_Type         UPINRQ2;     /**< \brief Offset: 0x658 (R/W 32) Pipe In Request */
+  __IO USBC_UPINRQ3_Type         UPINRQ3;     /**< \brief Offset: 0x65C (R/W 32) Pipe In Request */
+  __IO USBC_UPINRQ4_Type         UPINRQ4;     /**< \brief Offset: 0x660 (R/W 32) Pipe In Request */
+  __IO USBC_UPINRQ5_Type         UPINRQ5;     /**< \brief Offset: 0x664 (R/W 32) Pipe In Request */
+  __IO USBC_UPINRQ6_Type         UPINRQ6;     /**< \brief Offset: 0x668 (R/W 32) Pipe In Request */
+  __IO USBC_UPINRQ7_Type         UPINRQ7;     /**< \brief Offset: 0x66C (R/W 32) Pipe In Request */
+       RoReg8                    Reserved17[0x190];
+  __IO USBC_USBCON_Type          USBCON;      /**< \brief Offset: 0x800 (R/W 32) General Control Register */
+  __I  USBC_USBSTA_Type          USBSTA;      /**< \brief Offset: 0x804 (R/  32) General Status Register */
+  __O  USBC_USBSTACLR_Type       USBSTACLR;   /**< \brief Offset: 0x808 ( /W 32) General Status Clear Register */
+  __O  USBC_USBSTASET_Type       USBSTASET;   /**< \brief Offset: 0x80C ( /W 32) General Status Set Register */
+       RoReg8                    Reserved18[0x8];
+  __I  USBC_UVERS_Type           UVERS;       /**< \brief Offset: 0x818 (R/  32) IP Version Register */
+  __I  USBC_UFEATURES_Type       UFEATURES;   /**< \brief Offset: 0x81C (R/  32) IP Features Register */
+  __I  USBC_UADDRSIZE_Type       UADDRSIZE;   /**< \brief Offset: 0x820 (R/  32) IP PB address size Register */
+  __I  USBC_UNAME1_Type          UNAME1;      /**< \brief Offset: 0x824 (R/  32) IP Name Part One: HUSB */
+  __I  USBC_UNAME2_Type          UNAME2;      /**< \brief Offset: 0x828 (R/  32) IP Name Part Two: HOST */
+  __I  USBC_USBFSM_Type          USBFSM;      /**< \brief Offset: 0x82C (R/  32) USB internal finite state machine */
+  __IO USBC_UDESC_Type           UDESC;       /**< \brief Offset: 0x830 (R/W 32) Endpoint descriptor table */
+ } bf;
+ struct {
+  RwReg   USBC_UDCON;         /**< \brief (USBC Offset: 0x000) Device General Control Register */
+  RoReg   USBC_UDINT;         /**< \brief (USBC Offset: 0x004) Device Global Interupt Register */
+  WoReg   USBC_UDINTCLR;      /**< \brief (USBC Offset: 0x008) Device Global Interrupt Clear Register */
+  WoReg   USBC_UDINTSET;      /**< \brief (USBC Offset: 0x00C) Device Global Interrupt Set Regsiter */
+  RoReg   USBC_UDINTE;        /**< \brief (USBC Offset: 0x010) Device Global Interrupt Enable Register */
+  WoReg   USBC_UDINTECLR;     /**< \brief (USBC Offset: 0x014) Device Global Interrupt Enable Clear Register */
+  WoReg   USBC_UDINTESET;     /**< \brief (USBC Offset: 0x018) Device Global Interrupt Enable Set Register */
+  RwReg   USBC_UERST;         /**< \brief (USBC Offset: 0x01C) Endpoint Enable/Reset Register */
+  RoReg   USBC_UDFNUM;        /**< \brief (USBC Offset: 0x020) Device Frame Number Register */
+  RoReg8  Reserved19[0xDC];
+  RwReg   USBC_UECFG0;        /**< \brief (USBC Offset: 0x100) Endpoint Configuration Register */
+  RwReg   USBC_UECFG1;        /**< \brief (USBC Offset: 0x104) Endpoint Configuration Register */
+  RwReg   USBC_UECFG2;        /**< \brief (USBC Offset: 0x108) Endpoint Configuration Register */
+  RwReg   USBC_UECFG3;        /**< \brief (USBC Offset: 0x10C) Endpoint Configuration Register */
+  RwReg   USBC_UECFG4;        /**< \brief (USBC Offset: 0x110) Endpoint Configuration Register */
+  RwReg   USBC_UECFG5;        /**< \brief (USBC Offset: 0x114) Endpoint Configuration Register */
+  RwReg   USBC_UECFG6;        /**< \brief (USBC Offset: 0x118) Endpoint Configuration Register */
+  RwReg   USBC_UECFG7;        /**< \brief (USBC Offset: 0x11C) Endpoint Configuration Register */
+  RoReg8  Reserved20[0x10];
+  RoReg   USBC_UESTA0;        /**< \brief (USBC Offset: 0x130) Endpoint Status Register */
+  RoReg   USBC_UESTA1;        /**< \brief (USBC Offset: 0x134) Endpoint Status Register */
+  RoReg   USBC_UESTA2;        /**< \brief (USBC Offset: 0x138) Endpoint Status Register */
+  RoReg   USBC_UESTA3;        /**< \brief (USBC Offset: 0x13C) Endpoint Status Register */
+  RoReg   USBC_UESTA4;        /**< \brief (USBC Offset: 0x140) Endpoint Status Register */
+  RoReg   USBC_UESTA5;        /**< \brief (USBC Offset: 0x144) Endpoint Status Register */
+  RoReg   USBC_UESTA6;        /**< \brief (USBC Offset: 0x148) Endpoint Status Register */
+  RoReg   USBC_UESTA7;        /**< \brief (USBC Offset: 0x14C) Endpoint Status Register */
+  RoReg8  Reserved21[0x10];
+  WoReg   USBC_UESTA0CLR;     /**< \brief (USBC Offset: 0x160) Endpoint Status Clear Register */
+  WoReg   USBC_UESTA1CLR;     /**< \brief (USBC Offset: 0x164) Endpoint Status Clear Register */
+  WoReg   USBC_UESTA2CLR;     /**< \brief (USBC Offset: 0x168) Endpoint Status Clear Register */
+  WoReg   USBC_UESTA3CLR;     /**< \brief (USBC Offset: 0x16C) Endpoint Status Clear Register */
+  WoReg   USBC_UESTA4CLR;     /**< \brief (USBC Offset: 0x170) Endpoint Status Clear Register */
+  WoReg   USBC_UESTA5CLR;     /**< \brief (USBC Offset: 0x174) Endpoint Status Clear Register */
+  WoReg   USBC_UESTA6CLR;     /**< \brief (USBC Offset: 0x178) Endpoint Status Clear Register */
+  WoReg   USBC_UESTA7CLR;     /**< \brief (USBC Offset: 0x17C) Endpoint Status Clear Register */
+  RoReg8  Reserved22[0x10];
+  WoReg   USBC_UESTA0SET;     /**< \brief (USBC Offset: 0x190) Endpoint Status Set Register */
+  WoReg   USBC_UESTA1SET;     /**< \brief (USBC Offset: 0x194) Endpoint Status Set Register */
+  WoReg   USBC_UESTA2SET;     /**< \brief (USBC Offset: 0x198) Endpoint Status Set Register */
+  WoReg   USBC_UESTA3SET;     /**< \brief (USBC Offset: 0x19C) Endpoint Status Set Register */
+  WoReg   USBC_UESTA4SET;     /**< \brief (USBC Offset: 0x1A0) Endpoint Status Set Register */
+  WoReg   USBC_UESTA5SET;     /**< \brief (USBC Offset: 0x1A4) Endpoint Status Set Register */
+  WoReg   USBC_UESTA6SET;     /**< \brief (USBC Offset: 0x1A8) Endpoint Status Set Register */
+  WoReg   USBC_UESTA7SET;     /**< \brief (USBC Offset: 0x1AC) Endpoint Status Set Register */
+  RoReg8  Reserved23[0x10];
+  RoReg   USBC_UECON0;        /**< \brief (USBC Offset: 0x1C0) Endpoint Control Register */
+  RoReg   USBC_UECON1;        /**< \brief (USBC Offset: 0x1C4) Endpoint Control Register */
+  RoReg   USBC_UECON2;        /**< \brief (USBC Offset: 0x1C8) Endpoint Control Register */
+  RoReg   USBC_UECON3;        /**< \brief (USBC Offset: 0x1CC) Endpoint Control Register */
+  RoReg   USBC_UECON4;        /**< \brief (USBC Offset: 0x1D0) Endpoint Control Register */
+  RoReg   USBC_UECON5;        /**< \brief (USBC Offset: 0x1D4) Endpoint Control Register */
+  RoReg   USBC_UECON6;        /**< \brief (USBC Offset: 0x1D8) Endpoint Control Register */
+  RoReg   USBC_UECON7;        /**< \brief (USBC Offset: 0x1DC) Endpoint Control Register */
+  RoReg8  Reserved24[0x10];
+  WoReg   USBC_UECON0SET;     /**< \brief (USBC Offset: 0x1F0) Endpoint Control Set Register */
+  WoReg   USBC_UECON1SET;     /**< \brief (USBC Offset: 0x1F4) Endpoint Control Set Register */
+  WoReg   USBC_UECON2SET;     /**< \brief (USBC Offset: 0x1F8) Endpoint Control Set Register */
+  WoReg   USBC_UECON3SET;     /**< \brief (USBC Offset: 0x1FC) Endpoint Control Set Register */
+  WoReg   USBC_UECON4SET;     /**< \brief (USBC Offset: 0x200) Endpoint Control Set Register */
+  WoReg   USBC_UECON5SET;     /**< \brief (USBC Offset: 0x204) Endpoint Control Set Register */
+  WoReg   USBC_UECON6SET;     /**< \brief (USBC Offset: 0x208) Endpoint Control Set Register */
+  WoReg   USBC_UECON7SET;     /**< \brief (USBC Offset: 0x20C) Endpoint Control Set Register */
+  RoReg8  Reserved25[0x10];
+  WoReg   USBC_UECON0CLR;     /**< \brief (USBC Offset: 0x220) Endpoint Control Clear Register */
+  WoReg   USBC_UECON1CLR;     /**< \brief (USBC Offset: 0x224) TXINE Clear */
+  WoReg   USBC_UECON2CLR;     /**< \brief (USBC Offset: 0x228) TXINE Clear */
+  WoReg   USBC_UECON3CLR;     /**< \brief (USBC Offset: 0x22C) TXINE Clear */
+  WoReg   USBC_UECON4CLR;     /**< \brief (USBC Offset: 0x230) TXINE Clear */
+  WoReg   USBC_UECON5CLR;     /**< \brief (USBC Offset: 0x234) TXINE Clear */
+  WoReg   USBC_UECON6CLR;     /**< \brief (USBC Offset: 0x238) TXINE Clear */
+  WoReg   USBC_UECON7CLR;     /**< \brief (USBC Offset: 0x23C) TXINE Clear */
+  RoReg8  Reserved26[0x1C0];
+  RwReg   USBC_UHCON;         /**< \brief (USBC Offset: 0x400) Host General Control Register */
+  RoReg   USBC_UHINT;         /**< \brief (USBC Offset: 0x404) Host Global Interrupt Register */
+  WoReg   USBC_UHINTCLR;      /**< \brief (USBC Offset: 0x408) Host Global Interrrupt Clear Register */
+  WoReg   USBC_UHINTSET;      /**< \brief (USBC Offset: 0x40C) Host Global Interrupt Set Register */
+  RoReg   USBC_UHINTE;        /**< \brief (USBC Offset: 0x410) Host Global Interrupt Enable Register */
+  WoReg   USBC_UHINTECLR;     /**< \brief (USBC Offset: 0x414) Host Global Interrupt Enable Clear Register */
+  WoReg   USBC_UHINTESET;     /**< \brief (USBC Offset: 0x418) Host Global Interrupt Enable Set Register */
+  RwReg   USBC_UPRST;         /**< \brief (USBC Offset: 0x41C) Pipe Reset Register */
+  RwReg   USBC_UHFNUM;        /**< \brief (USBC Offset: 0x420) Host Frame Number Register */
+  RwReg   USBC_UHSOFC;        /**< \brief (USBC Offset: 0x424) Host Start of Frame Control Register */
+  RoReg8  Reserved27[0xD8];
+  RwReg   USBC_UPCFG0;        /**< \brief (USBC Offset: 0x500) Pipe Configuration Register */
+  RwReg   USBC_UPCFG1;        /**< \brief (USBC Offset: 0x504) Pipe Configuration Register */
+  RwReg   USBC_UPCFG2;        /**< \brief (USBC Offset: 0x508) Pipe Configuration Register */
+  RwReg   USBC_UPCFG3;        /**< \brief (USBC Offset: 0x50C) Pipe Configuration Register */
+  RwReg   USBC_UPCFG4;        /**< \brief (USBC Offset: 0x510) Pipe Configuration Register */
+  RwReg   USBC_UPCFG5;        /**< \brief (USBC Offset: 0x514) Pipe Configuration Register */
+  RwReg   USBC_UPCFG6;        /**< \brief (USBC Offset: 0x518) Pipe Configuration Register */
+  RwReg   USBC_UPCFG7;        /**< \brief (USBC Offset: 0x51C) Pipe Configuration Register */
+  RoReg8  Reserved28[0x10];
+  RoReg   USBC_UPSTA0;        /**< \brief (USBC Offset: 0x530) Pipe Status Register */
+  RoReg   USBC_UPSTA1;        /**< \brief (USBC Offset: 0x534) Pipe Status Register */
+  RoReg   USBC_UPSTA2;        /**< \brief (USBC Offset: 0x538) Pipe Status Register */
+  RoReg   USBC_UPSTA3;        /**< \brief (USBC Offset: 0x53C) Pipe Status Register */
+  RoReg   USBC_UPSTA4;        /**< \brief (USBC Offset: 0x540) Pipe Status Register */
+  RoReg   USBC_UPSTA5;        /**< \brief (USBC Offset: 0x544) Pipe Status Register */
+  RoReg   USBC_UPSTA6;        /**< \brief (USBC Offset: 0x548) Pipe Status Register */
+  RoReg   USBC_UPSTA7;        /**< \brief (USBC Offset: 0x54C) Pipe Status Register */
+  RoReg8  Reserved29[0x10];
+  WoReg   USBC_UPSTA0CLR;     /**< \brief (USBC Offset: 0x560) Pipe Status Clear Register */
+  WoReg   USBC_UPSTA1CLR;     /**< \brief (USBC Offset: 0x564) Pipe Status Clear Register */
+  WoReg   USBC_UPSTA2CLR;     /**< \brief (USBC Offset: 0x568) Pipe Status Clear Register */
+  WoReg   USBC_UPSTA3CLR;     /**< \brief (USBC Offset: 0x56C) Pipe Status Clear Register */
+  WoReg   USBC_UPSTA4CLR;     /**< \brief (USBC Offset: 0x570) Pipe Status Clear Register */
+  WoReg   USBC_UPSTA5CLR;     /**< \brief (USBC Offset: 0x574) Pipe Status Clear Register */
+  WoReg   USBC_UPSTA6CLR;     /**< \brief (USBC Offset: 0x578) Pipe Status Clear Register */
+  WoReg   USBC_UPSTA7CLR;     /**< \brief (USBC Offset: 0x57C) Pipe Status Clear Register */
+  RoReg8  Reserved30[0x10];
+  WoReg   USBC_UPSTA0SET;     /**< \brief (USBC Offset: 0x590) Pipe Status Set Register */
+  WoReg   USBC_UPSTA1SET;     /**< \brief (USBC Offset: 0x594) Pipe Status Set Register */
+  WoReg   USBC_UPSTA2SET;     /**< \brief (USBC Offset: 0x598) Pipe Status Set Register */
+  WoReg   USBC_UPSTA3SET;     /**< \brief (USBC Offset: 0x59C) Pipe Status Set Register */
+  WoReg   USBC_UPSTA4SET;     /**< \brief (USBC Offset: 0x5A0) Pipe Status Set Register */
+  WoReg   USBC_UPSTA5SET;     /**< \brief (USBC Offset: 0x5A4) Pipe Status Set Register */
+  WoReg   USBC_UPSTA6SET;     /**< \brief (USBC Offset: 0x5A8) Pipe Status Set Register */
+  WoReg   USBC_UPSTA7SET;     /**< \brief (USBC Offset: 0x5AC) Pipe Status Set Register */
+  RoReg8  Reserved31[0x10];
+  RoReg   USBC_UPCON0;        /**< \brief (USBC Offset: 0x5C0) Pipe Control Register */
+  RoReg   USBC_UPCON1;        /**< \brief (USBC Offset: 0x5C4) Pipe Control Register */
+  RoReg   USBC_UPCON2;        /**< \brief (USBC Offset: 0x5C8) Pipe Control Register */
+  RoReg   USBC_UPCON3;        /**< \brief (USBC Offset: 0x5CC) Pipe Control Register */
+  RoReg   USBC_UPCON4;        /**< \brief (USBC Offset: 0x5D0) Pipe Control Register */
+  RoReg   USBC_UPCON5;        /**< \brief (USBC Offset: 0x5D4) Pipe Control Register */
+  RoReg   USBC_UPCON6;        /**< \brief (USBC Offset: 0x5D8) Pipe Control Register */
+  RoReg   USBC_UPCON7;        /**< \brief (USBC Offset: 0x5DC) Pipe Control Register */
+  RoReg8  Reserved32[0x10];
+  WoReg   USBC_UPCON0SET;     /**< \brief (USBC Offset: 0x5F0) Pipe Control Set Register */
+  WoReg   USBC_UPCON1SET;     /**< \brief (USBC Offset: 0x5F4) Pipe Control Set Register */
+  WoReg   USBC_UPCON2SET;     /**< \brief (USBC Offset: 0x5F8) Pipe Control Set Register */
+  WoReg   USBC_UPCON3SET;     /**< \brief (USBC Offset: 0x5FC) Pipe Control Set Register */
+  WoReg   USBC_UPCON4SET;     /**< \brief (USBC Offset: 0x600) Pipe Control Set Register */
+  WoReg   USBC_UPCON5SET;     /**< \brief (USBC Offset: 0x604) Pipe Control Set Register */
+  WoReg   USBC_UPCON6SET;     /**< \brief (USBC Offset: 0x608) Pipe Control Set Register */
+  WoReg   USBC_UPCON7SET;     /**< \brief (USBC Offset: 0x60C) Pipe Control Set Register */
+  RoReg8  Reserved33[0x10];
+  WoReg   USBC_UPCON0CLR;     /**< \brief (USBC Offset: 0x620) Pipe Control Clear Register */
+  WoReg   USBC_UPCON1CLR;     /**< \brief (USBC Offset: 0x624) Pipe Control Clear Register */
+  WoReg   USBC_UPCON2CLR;     /**< \brief (USBC Offset: 0x628) Pipe Control Clear Register */
+  WoReg   USBC_UPCON3CLR;     /**< \brief (USBC Offset: 0x62C) Pipe Control Clear Register */
+  WoReg   USBC_UPCON4CLR;     /**< \brief (USBC Offset: 0x630) Pipe Control Clear Register */
+  WoReg   USBC_UPCON5CLR;     /**< \brief (USBC Offset: 0x634) Pipe Control Clear Register */
+  WoReg   USBC_UPCON6CLR;     /**< \brief (USBC Offset: 0x638) Pipe Control Clear Register */
+  WoReg   USBC_UPCON7CLR;     /**< \brief (USBC Offset: 0x63C) Pipe Control Clear Register */
+  RoReg8  Reserved34[0x10];
+  RwReg   USBC_UPINRQ0;       /**< \brief (USBC Offset: 0x650) Pipe In Request */
+  RwReg   USBC_UPINRQ1;       /**< \brief (USBC Offset: 0x654) Pipe In Request */
+  RwReg   USBC_UPINRQ2;       /**< \brief (USBC Offset: 0x658) Pipe In Request */
+  RwReg   USBC_UPINRQ3;       /**< \brief (USBC Offset: 0x65C) Pipe In Request */
+  RwReg   USBC_UPINRQ4;       /**< \brief (USBC Offset: 0x660) Pipe In Request */
+  RwReg   USBC_UPINRQ5;       /**< \brief (USBC Offset: 0x664) Pipe In Request */
+  RwReg   USBC_UPINRQ6;       /**< \brief (USBC Offset: 0x668) Pipe In Request */
+  RwReg   USBC_UPINRQ7;       /**< \brief (USBC Offset: 0x66C) Pipe In Request */
+  RoReg8  Reserved35[0x190];
+  RwReg   USBC_USBCON;        /**< \brief (USBC Offset: 0x800) General Control Register */
+  RoReg   USBC_USBSTA;        /**< \brief (USBC Offset: 0x804) General Status Register */
+  WoReg   USBC_USBSTACLR;     /**< \brief (USBC Offset: 0x808) General Status Clear Register */
+  WoReg   USBC_USBSTASET;     /**< \brief (USBC Offset: 0x80C) General Status Set Register */
+  RoReg8  Reserved36[0x8];
+  RoReg   USBC_UVERS;         /**< \brief (USBC Offset: 0x818) IP Version Register */
+  RoReg   USBC_UFEATURES;     /**< \brief (USBC Offset: 0x81C) IP Features Register */
+  RoReg   USBC_UADDRSIZE;     /**< \brief (USBC Offset: 0x820) IP PB address size Register */
+  RoReg   USBC_UNAME1;        /**< \brief (USBC Offset: 0x824) IP Name Part One: HUSB */
+  RoReg   USBC_UNAME2;        /**< \brief (USBC Offset: 0x828) IP Name Part Two: HOST */
+  RoReg   USBC_USBFSM;        /**< \brief (USBC Offset: 0x82C) USB internal finite state machine */
+  RwReg   USBC_UDESC;         /**< \brief (USBC Offset: 0x830) Endpoint descriptor table */
+ } reg;
+} Usbc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_USBC_COMPONENT_ */

--- a/asf/sam/include/sam4l/component/wdt.h
+++ b/asf/sam/include/sam4l/component/wdt.h
@@ -263,31 +263,17 @@ typedef union {
 
 /** \brief WDT hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union {
- struct {
-  __IO WDT_CTRL_Type             CTRL;        /**< \brief Offset: 0x000 (R/W 32) Control Register */
-  __O  WDT_CLR_Type              CLR;         /**< \brief Offset: 0x004 ( /W 32) Clear Register */
-  __I  WDT_SR_Type               SR;          /**< \brief Offset: 0x008 (R/  32) Status Register */
-  __O  WDT_IER_Type              IER;         /**< \brief Offset: 0x00C ( /W 32) Interrupt Enable Register */
-  __O  WDT_IDR_Type              IDR;         /**< \brief Offset: 0x010 ( /W 32) Interrupt Disable Register */
-  __I  WDT_IMR_Type              IMR;         /**< \brief Offset: 0x014 (R/  32) Interrupt Mask Register */
-  __I  WDT_ISR_Type              ISR;         /**< \brief Offset: 0x018 (R/  32) Interrupt Status Register */
-  __O  WDT_ICR_Type              ICR;         /**< \brief Offset: 0x01C ( /W 32) Interrupt Clear Register */
-       RoReg8                    Reserved1[0x3DC];
-  __I  WDT_VERSION_Type          VERSION;     /**< \brief Offset: 0x3FC (R/  32) Version Register */
- } bf;
- struct {
-  RwReg   WDT_CTRL;           /**< \brief (WDT Offset: 0x000) Control Register */
-  WoReg   WDT_CLR;            /**< \brief (WDT Offset: 0x004) Clear Register */
-  RoReg   WDT_SR;             /**< \brief (WDT Offset: 0x008) Status Register */
-  WoReg   WDT_IER;            /**< \brief (WDT Offset: 0x00C) Interrupt Enable Register */
-  WoReg   WDT_IDR;            /**< \brief (WDT Offset: 0x010) Interrupt Disable Register */
-  RoReg   WDT_IMR;            /**< \brief (WDT Offset: 0x014) Interrupt Mask Register */
-  RoReg   WDT_ISR;            /**< \brief (WDT Offset: 0x018) Interrupt Status Register */
-  WoReg   WDT_ICR;            /**< \brief (WDT Offset: 0x01C) Interrupt Clear Register */
-  RoReg8  Reserved2[0x3DC];
-  RoReg   WDT_VERSION;        /**< \brief (WDT Offset: 0x3FC) Version Register */
- } reg;
+typedef struct {
+  __IO uint32_t CTRL;        /**< \brief Offset: 0x000 (R/W 32) Control Register */
+  __O  uint32_t CLR;         /**< \brief Offset: 0x004 ( /W 32) Clear Register */
+  __I  uint32_t SR;          /**< \brief Offset: 0x008 (R/  32) Status Register */
+  __O  uint32_t IER;         /**< \brief Offset: 0x00C ( /W 32) Interrupt Enable Register */
+  __O  uint32_t IDR;         /**< \brief Offset: 0x010 ( /W 32) Interrupt Disable Register */
+  __I  uint32_t IMR;         /**< \brief Offset: 0x014 (R/  32) Interrupt Mask Register */
+  __I  uint32_t ISR;         /**< \brief Offset: 0x018 (R/  32) Interrupt Status Register */
+  __O  uint32_t ICR;         /**< \brief Offset: 0x01C ( /W 32) Interrupt Clear Register */
+       RoReg8   Reserved1[0x3DC];
+  __I  uint32_t VERSION;     /**< \brief Offset: 0x3FC (R/  32) Version Register */
 } Wdt;
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 

--- a/asf/sam/include/sam4l/component/wdt.h
+++ b/asf/sam/include/sam4l/component/wdt.h
@@ -64,40 +64,40 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define WDT_CTRL_OFFSET             0x000        /**< \brief (WDT_CTRL offset) Control Register */
-#define WDT_CTRL_RESETVALUE         _U(0x00010080); /**< \brief (WDT_CTRL reset_value) Control Register */
+#define WDT_CTRL_RESETVALUE         _U_(0x00010080); /**< \brief (WDT_CTRL reset_value) Control Register */
 
 #define WDT_CTRL_EN_Pos             0            /**< \brief (WDT_CTRL) WDT Enable */
-#define WDT_CTRL_EN                 (_U(0x1) << WDT_CTRL_EN_Pos)
-#define   WDT_CTRL_EN_0_Val               _U(0x0)   /**< \brief (WDT_CTRL) WDT is disabled. */
-#define   WDT_CTRL_EN_1_Val               _U(0x1)   /**< \brief (WDT_CTRL) WDT is enabled */
+#define WDT_CTRL_EN                 (_U_(0x1) << WDT_CTRL_EN_Pos)
+#define   WDT_CTRL_EN_0_Val               _U_(0x0)   /**< \brief (WDT_CTRL) WDT is disabled. */
+#define   WDT_CTRL_EN_1_Val               _U_(0x1)   /**< \brief (WDT_CTRL) WDT is enabled */
 #define WDT_CTRL_EN_0               (WDT_CTRL_EN_0_Val             << WDT_CTRL_EN_Pos)
 #define WDT_CTRL_EN_1               (WDT_CTRL_EN_1_Val             << WDT_CTRL_EN_Pos)
 #define WDT_CTRL_DAR_Pos            1            /**< \brief (WDT_CTRL) WDT Disable After Reset */
-#define WDT_CTRL_DAR                (_U(0x1) << WDT_CTRL_DAR_Pos)
+#define WDT_CTRL_DAR                (_U_(0x1) << WDT_CTRL_DAR_Pos)
 #define WDT_CTRL_MODE_Pos           2            /**< \brief (WDT_CTRL) WDT Mode */
-#define WDT_CTRL_MODE               (_U(0x1) << WDT_CTRL_MODE_Pos)
+#define WDT_CTRL_MODE               (_U_(0x1) << WDT_CTRL_MODE_Pos)
 #define WDT_CTRL_SFV_Pos            3            /**< \brief (WDT_CTRL) WDT Store Final Value */
-#define WDT_CTRL_SFV                (_U(0x1) << WDT_CTRL_SFV_Pos)
+#define WDT_CTRL_SFV                (_U_(0x1) << WDT_CTRL_SFV_Pos)
 #define WDT_CTRL_IM_Pos             4            /**< \brief (WDT_CTRL) WDT Interruput Mode */
-#define WDT_CTRL_IM                 (_U(0x1) << WDT_CTRL_IM_Pos)
+#define WDT_CTRL_IM                 (_U_(0x1) << WDT_CTRL_IM_Pos)
 #define WDT_CTRL_FCD_Pos            7            /**< \brief (WDT_CTRL) WDT Fuse Calibration Done */
-#define WDT_CTRL_FCD                (_U(0x1) << WDT_CTRL_FCD_Pos)
+#define WDT_CTRL_FCD                (_U_(0x1) << WDT_CTRL_FCD_Pos)
 #define WDT_CTRL_PSEL_Pos           8            /**< \brief (WDT_CTRL) Timeout Prescale Select */
-#define WDT_CTRL_PSEL_Msk           (_U(0x1F) << WDT_CTRL_PSEL_Pos)
+#define WDT_CTRL_PSEL_Msk           (_U_(0x1F) << WDT_CTRL_PSEL_Pos)
 #define WDT_CTRL_PSEL(value)        (WDT_CTRL_PSEL_Msk & ((value) << WDT_CTRL_PSEL_Pos))
 #define WDT_CTRL_CSSEL1_Pos         14           /**< \brief (WDT_CTRL) Clock Source Selection1 */
-#define WDT_CTRL_CSSEL1             (_U(0x1) << WDT_CTRL_CSSEL1_Pos)
+#define WDT_CTRL_CSSEL1             (_U_(0x1) << WDT_CTRL_CSSEL1_Pos)
 #define WDT_CTRL_CEN_Pos            16           /**< \brief (WDT_CTRL) Clock Enable */
-#define WDT_CTRL_CEN                (_U(0x1) << WDT_CTRL_CEN_Pos)
+#define WDT_CTRL_CEN                (_U_(0x1) << WDT_CTRL_CEN_Pos)
 #define WDT_CTRL_CSSEL_Pos          17           /**< \brief (WDT_CTRL) Clock Source Selection0 */
-#define WDT_CTRL_CSSEL              (_U(0x1) << WDT_CTRL_CSSEL_Pos)
+#define WDT_CTRL_CSSEL              (_U_(0x1) << WDT_CTRL_CSSEL_Pos)
 #define WDT_CTRL_TBAN_Pos           18           /**< \brief (WDT_CTRL) TBAN Prescale Select */
-#define WDT_CTRL_TBAN_Msk           (_U(0x1F) << WDT_CTRL_TBAN_Pos)
+#define WDT_CTRL_TBAN_Msk           (_U_(0x1F) << WDT_CTRL_TBAN_Pos)
 #define WDT_CTRL_TBAN(value)        (WDT_CTRL_TBAN_Msk & ((value) << WDT_CTRL_TBAN_Pos))
 #define WDT_CTRL_KEY_Pos            24           /**< \brief (WDT_CTRL) Key */
-#define WDT_CTRL_KEY_Msk            (_U(0xFF) << WDT_CTRL_KEY_Pos)
+#define WDT_CTRL_KEY_Msk            (_U_(0xFF) << WDT_CTRL_KEY_Pos)
 #define WDT_CTRL_KEY(value)         (WDT_CTRL_KEY_Msk & ((value) << WDT_CTRL_KEY_Pos))
-#define WDT_CTRL_MASK               _U(0xFF7F5F9F) /**< \brief (WDT_CTRL) MASK Register */
+#define WDT_CTRL_MASK               _U_(0xFF7F5F9F) /**< \brief (WDT_CTRL) MASK Register */
 
 /* -------- WDT_CLR : (WDT Offset: 0x004) ( /W 32) Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -112,14 +112,14 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define WDT_CLR_OFFSET              0x004        /**< \brief (WDT_CLR offset) Clear Register */
-#define WDT_CLR_RESETVALUE          _U(0x00000000); /**< \brief (WDT_CLR reset_value) Clear Register */
+#define WDT_CLR_RESETVALUE          _U_(0x00000000); /**< \brief (WDT_CLR reset_value) Clear Register */
 
 #define WDT_CLR_WDTCLR_Pos          0            /**< \brief (WDT_CLR) Clear WDT counter */
-#define WDT_CLR_WDTCLR              (_U(0x1) << WDT_CLR_WDTCLR_Pos)
+#define WDT_CLR_WDTCLR              (_U_(0x1) << WDT_CLR_WDTCLR_Pos)
 #define WDT_CLR_KEY_Pos             24           /**< \brief (WDT_CLR) Key */
-#define WDT_CLR_KEY_Msk             (_U(0xFF) << WDT_CLR_KEY_Pos)
+#define WDT_CLR_KEY_Msk             (_U_(0xFF) << WDT_CLR_KEY_Pos)
 #define WDT_CLR_KEY(value)          (WDT_CLR_KEY_Msk & ((value) << WDT_CLR_KEY_Pos))
-#define WDT_CLR_MASK                _U(0xFF000001) /**< \brief (WDT_CLR) MASK Register */
+#define WDT_CLR_MASK                _U_(0xFF000001) /**< \brief (WDT_CLR) MASK Register */
 
 /* -------- WDT_SR : (WDT Offset: 0x008) (R/  32) Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -134,13 +134,13 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define WDT_SR_OFFSET               0x008        /**< \brief (WDT_SR offset) Status Register */
-#define WDT_SR_RESETVALUE           _U(0x00000003); /**< \brief (WDT_SR reset_value) Status Register */
+#define WDT_SR_RESETVALUE           _U_(0x00000003); /**< \brief (WDT_SR reset_value) Status Register */
 
 #define WDT_SR_WINDOW_Pos           0            /**< \brief (WDT_SR) WDT in window */
-#define WDT_SR_WINDOW               (_U(0x1) << WDT_SR_WINDOW_Pos)
+#define WDT_SR_WINDOW               (_U_(0x1) << WDT_SR_WINDOW_Pos)
 #define WDT_SR_CLEARED_Pos          1            /**< \brief (WDT_SR) WDT cleared */
-#define WDT_SR_CLEARED              (_U(0x1) << WDT_SR_CLEARED_Pos)
-#define WDT_SR_MASK                 _U(0x00000003) /**< \brief (WDT_SR) MASK Register */
+#define WDT_SR_CLEARED              (_U_(0x1) << WDT_SR_CLEARED_Pos)
+#define WDT_SR_MASK                 _U_(0x00000003) /**< \brief (WDT_SR) MASK Register */
 
 /* -------- WDT_IER : (WDT Offset: 0x00C) ( /W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -155,11 +155,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define WDT_IER_OFFSET              0x00C        /**< \brief (WDT_IER offset) Interrupt Enable Register */
-#define WDT_IER_RESETVALUE          _U(0x00000000); /**< \brief (WDT_IER reset_value) Interrupt Enable Register */
+#define WDT_IER_RESETVALUE          _U_(0x00000000); /**< \brief (WDT_IER reset_value) Interrupt Enable Register */
 
 #define WDT_IER_WINT_Pos            2            /**< \brief (WDT_IER) Watchdog Interrupt */
-#define WDT_IER_WINT                (_U(0x1) << WDT_IER_WINT_Pos)
-#define WDT_IER_MASK                _U(0x00000004) /**< \brief (WDT_IER) MASK Register */
+#define WDT_IER_WINT                (_U_(0x1) << WDT_IER_WINT_Pos)
+#define WDT_IER_MASK                _U_(0x00000004) /**< \brief (WDT_IER) MASK Register */
 
 /* -------- WDT_IDR : (WDT Offset: 0x010) ( /W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -174,11 +174,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define WDT_IDR_OFFSET              0x010        /**< \brief (WDT_IDR offset) Interrupt Disable Register */
-#define WDT_IDR_RESETVALUE          _U(0x00000000); /**< \brief (WDT_IDR reset_value) Interrupt Disable Register */
+#define WDT_IDR_RESETVALUE          _U_(0x00000000); /**< \brief (WDT_IDR reset_value) Interrupt Disable Register */
 
 #define WDT_IDR_WINT_Pos            2            /**< \brief (WDT_IDR) Watchdog Interrupt */
-#define WDT_IDR_WINT                (_U(0x1) << WDT_IDR_WINT_Pos)
-#define WDT_IDR_MASK                _U(0x00000004) /**< \brief (WDT_IDR) MASK Register */
+#define WDT_IDR_WINT                (_U_(0x1) << WDT_IDR_WINT_Pos)
+#define WDT_IDR_MASK                _U_(0x00000004) /**< \brief (WDT_IDR) MASK Register */
 
 /* -------- WDT_IMR : (WDT Offset: 0x014) (R/  32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -193,11 +193,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define WDT_IMR_OFFSET              0x014        /**< \brief (WDT_IMR offset) Interrupt Mask Register */
-#define WDT_IMR_RESETVALUE          _U(0x00000000); /**< \brief (WDT_IMR reset_value) Interrupt Mask Register */
+#define WDT_IMR_RESETVALUE          _U_(0x00000000); /**< \brief (WDT_IMR reset_value) Interrupt Mask Register */
 
 #define WDT_IMR_WINT_Pos            2            /**< \brief (WDT_IMR) Watchdog Interrupt */
-#define WDT_IMR_WINT                (_U(0x1) << WDT_IMR_WINT_Pos)
-#define WDT_IMR_MASK                _U(0x00000004) /**< \brief (WDT_IMR) MASK Register */
+#define WDT_IMR_WINT                (_U_(0x1) << WDT_IMR_WINT_Pos)
+#define WDT_IMR_MASK                _U_(0x00000004) /**< \brief (WDT_IMR) MASK Register */
 
 /* -------- WDT_ISR : (WDT Offset: 0x018) (R/  32) Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -212,11 +212,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define WDT_ISR_OFFSET              0x018        /**< \brief (WDT_ISR offset) Interrupt Status Register */
-#define WDT_ISR_RESETVALUE          _U(0x00000000); /**< \brief (WDT_ISR reset_value) Interrupt Status Register */
+#define WDT_ISR_RESETVALUE          _U_(0x00000000); /**< \brief (WDT_ISR reset_value) Interrupt Status Register */
 
 #define WDT_ISR_WINT_Pos            2            /**< \brief (WDT_ISR) Watchdog Interrupt */
-#define WDT_ISR_WINT                (_U(0x1) << WDT_ISR_WINT_Pos)
-#define WDT_ISR_MASK                _U(0x00000004) /**< \brief (WDT_ISR) MASK Register */
+#define WDT_ISR_WINT                (_U_(0x1) << WDT_ISR_WINT_Pos)
+#define WDT_ISR_MASK                _U_(0x00000004) /**< \brief (WDT_ISR) MASK Register */
 
 /* -------- WDT_ICR : (WDT Offset: 0x01C) ( /W 32) Interrupt Clear Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -231,11 +231,11 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define WDT_ICR_OFFSET              0x01C        /**< \brief (WDT_ICR offset) Interrupt Clear Register */
-#define WDT_ICR_RESETVALUE          _U(0x00000000); /**< \brief (WDT_ICR reset_value) Interrupt Clear Register */
+#define WDT_ICR_RESETVALUE          _U_(0x00000000); /**< \brief (WDT_ICR reset_value) Interrupt Clear Register */
 
 #define WDT_ICR_WINT_Pos            2            /**< \brief (WDT_ICR) Watchdog Interrupt */
-#define WDT_ICR_WINT                (_U(0x1) << WDT_ICR_WINT_Pos)
-#define WDT_ICR_MASK                _U(0x00000004) /**< \brief (WDT_ICR) MASK Register */
+#define WDT_ICR_WINT                (_U_(0x1) << WDT_ICR_WINT_Pos)
+#define WDT_ICR_MASK                _U_(0x00000004) /**< \brief (WDT_ICR) MASK Register */
 
 /* -------- WDT_VERSION : (WDT Offset: 0x3FC) (R/  32) Version Register -------- */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
@@ -251,15 +251,15 @@ typedef union {
 #endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define WDT_VERSION_OFFSET          0x3FC        /**< \brief (WDT_VERSION offset) Version Register */
-#define WDT_VERSION_RESETVALUE      _U(0x00000501); /**< \brief (WDT_VERSION reset_value) Version Register */
+#define WDT_VERSION_RESETVALUE      _U_(0x00000501); /**< \brief (WDT_VERSION reset_value) Version Register */
 
 #define WDT_VERSION_VERSION_Pos     0            /**< \brief (WDT_VERSION) Version number */
-#define WDT_VERSION_VERSION_Msk     (_U(0xFFF) << WDT_VERSION_VERSION_Pos)
+#define WDT_VERSION_VERSION_Msk     (_U_(0xFFF) << WDT_VERSION_VERSION_Pos)
 #define WDT_VERSION_VERSION(value)  (WDT_VERSION_VERSION_Msk & ((value) << WDT_VERSION_VERSION_Pos))
 #define WDT_VERSION_VARIANT_Pos     16           /**< \brief (WDT_VERSION) Variant number */
-#define WDT_VERSION_VARIANT_Msk     (_U(0xF) << WDT_VERSION_VARIANT_Pos)
+#define WDT_VERSION_VARIANT_Msk     (_U_(0xF) << WDT_VERSION_VARIANT_Pos)
 #define WDT_VERSION_VARIANT(value)  (WDT_VERSION_VARIANT_Msk & ((value) << WDT_VERSION_VARIANT_Pos))
-#define WDT_VERSION_MASK            _U(0x000F0FFF) /**< \brief (WDT_VERSION) MASK Register */
+#define WDT_VERSION_MASK            _U_(0x000F0FFF) /**< \brief (WDT_VERSION) MASK Register */
 
 /** \brief WDT hardware registers */
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))

--- a/asf/sam/include/sam4l/component/wdt.h
+++ b/asf/sam/include/sam4l/component/wdt.h
@@ -1,0 +1,296 @@
+/**
+ * \file
+ *
+ * \brief Component description for WDT
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_WDT_COMPONENT_
+#define _SAM4L_WDT_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR WDT */
+/* ========================================================================== */
+/** \addtogroup SAM4L_WDT Watchdog Timer */
+/*@{*/
+
+#define WDT_I7528
+#define REV_WDT                     0x501
+
+/* -------- WDT_CTRL : (WDT Offset: 0x000) (R/W 32) Control Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EN:1;             /*!< bit:      0  WDT Enable                         */
+    uint32_t DAR:1;            /*!< bit:      1  WDT Disable After Reset            */
+    uint32_t MODE:1;           /*!< bit:      2  WDT Mode                           */
+    uint32_t SFV:1;            /*!< bit:      3  WDT Store Final Value              */
+    uint32_t IM:1;             /*!< bit:      4  WDT Interruput Mode                */
+    uint32_t :2;               /*!< bit:  5.. 6  Reserved                           */
+    uint32_t FCD:1;            /*!< bit:      7  WDT Fuse Calibration Done          */
+    uint32_t PSEL:5;           /*!< bit:  8..12  Timeout Prescale Select            */
+    uint32_t :1;               /*!< bit:     13  Reserved                           */
+    uint32_t CSSEL1:1;         /*!< bit:     14  Clock Source Selection1            */
+    uint32_t :1;               /*!< bit:     15  Reserved                           */
+    uint32_t CEN:1;            /*!< bit:     16  Clock Enable                       */
+    uint32_t CSSEL:1;          /*!< bit:     17  Clock Source Selection0            */
+    uint32_t TBAN:5;           /*!< bit: 18..22  TBAN Prescale Select               */
+    uint32_t :1;               /*!< bit:     23  Reserved                           */
+    uint32_t KEY:8;            /*!< bit: 24..31  Key                                */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} WDT_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_CTRL_OFFSET             0x000        /**< \brief (WDT_CTRL offset) Control Register */
+#define WDT_CTRL_RESETVALUE         _U(0x00010080); /**< \brief (WDT_CTRL reset_value) Control Register */
+
+#define WDT_CTRL_EN_Pos             0            /**< \brief (WDT_CTRL) WDT Enable */
+#define WDT_CTRL_EN                 (_U(0x1) << WDT_CTRL_EN_Pos)
+#define   WDT_CTRL_EN_0_Val               _U(0x0)   /**< \brief (WDT_CTRL) WDT is disabled. */
+#define   WDT_CTRL_EN_1_Val               _U(0x1)   /**< \brief (WDT_CTRL) WDT is enabled */
+#define WDT_CTRL_EN_0               (WDT_CTRL_EN_0_Val             << WDT_CTRL_EN_Pos)
+#define WDT_CTRL_EN_1               (WDT_CTRL_EN_1_Val             << WDT_CTRL_EN_Pos)
+#define WDT_CTRL_DAR_Pos            1            /**< \brief (WDT_CTRL) WDT Disable After Reset */
+#define WDT_CTRL_DAR                (_U(0x1) << WDT_CTRL_DAR_Pos)
+#define WDT_CTRL_MODE_Pos           2            /**< \brief (WDT_CTRL) WDT Mode */
+#define WDT_CTRL_MODE               (_U(0x1) << WDT_CTRL_MODE_Pos)
+#define WDT_CTRL_SFV_Pos            3            /**< \brief (WDT_CTRL) WDT Store Final Value */
+#define WDT_CTRL_SFV                (_U(0x1) << WDT_CTRL_SFV_Pos)
+#define WDT_CTRL_IM_Pos             4            /**< \brief (WDT_CTRL) WDT Interruput Mode */
+#define WDT_CTRL_IM                 (_U(0x1) << WDT_CTRL_IM_Pos)
+#define WDT_CTRL_FCD_Pos            7            /**< \brief (WDT_CTRL) WDT Fuse Calibration Done */
+#define WDT_CTRL_FCD                (_U(0x1) << WDT_CTRL_FCD_Pos)
+#define WDT_CTRL_PSEL_Pos           8            /**< \brief (WDT_CTRL) Timeout Prescale Select */
+#define WDT_CTRL_PSEL_Msk           (_U(0x1F) << WDT_CTRL_PSEL_Pos)
+#define WDT_CTRL_PSEL(value)        (WDT_CTRL_PSEL_Msk & ((value) << WDT_CTRL_PSEL_Pos))
+#define WDT_CTRL_CSSEL1_Pos         14           /**< \brief (WDT_CTRL) Clock Source Selection1 */
+#define WDT_CTRL_CSSEL1             (_U(0x1) << WDT_CTRL_CSSEL1_Pos)
+#define WDT_CTRL_CEN_Pos            16           /**< \brief (WDT_CTRL) Clock Enable */
+#define WDT_CTRL_CEN                (_U(0x1) << WDT_CTRL_CEN_Pos)
+#define WDT_CTRL_CSSEL_Pos          17           /**< \brief (WDT_CTRL) Clock Source Selection0 */
+#define WDT_CTRL_CSSEL              (_U(0x1) << WDT_CTRL_CSSEL_Pos)
+#define WDT_CTRL_TBAN_Pos           18           /**< \brief (WDT_CTRL) TBAN Prescale Select */
+#define WDT_CTRL_TBAN_Msk           (_U(0x1F) << WDT_CTRL_TBAN_Pos)
+#define WDT_CTRL_TBAN(value)        (WDT_CTRL_TBAN_Msk & ((value) << WDT_CTRL_TBAN_Pos))
+#define WDT_CTRL_KEY_Pos            24           /**< \brief (WDT_CTRL) Key */
+#define WDT_CTRL_KEY_Msk            (_U(0xFF) << WDT_CTRL_KEY_Pos)
+#define WDT_CTRL_KEY(value)         (WDT_CTRL_KEY_Msk & ((value) << WDT_CTRL_KEY_Pos))
+#define WDT_CTRL_MASK               _U(0xFF7F5F9F) /**< \brief (WDT_CTRL) MASK Register */
+
+/* -------- WDT_CLR : (WDT Offset: 0x004) ( /W 32) Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t WDTCLR:1;         /*!< bit:      0  Clear WDT counter                  */
+    uint32_t :23;              /*!< bit:  1..23  Reserved                           */
+    uint32_t KEY:8;            /*!< bit: 24..31  Key                                */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} WDT_CLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_CLR_OFFSET              0x004        /**< \brief (WDT_CLR offset) Clear Register */
+#define WDT_CLR_RESETVALUE          _U(0x00000000); /**< \brief (WDT_CLR reset_value) Clear Register */
+
+#define WDT_CLR_WDTCLR_Pos          0            /**< \brief (WDT_CLR) Clear WDT counter */
+#define WDT_CLR_WDTCLR              (_U(0x1) << WDT_CLR_WDTCLR_Pos)
+#define WDT_CLR_KEY_Pos             24           /**< \brief (WDT_CLR) Key */
+#define WDT_CLR_KEY_Msk             (_U(0xFF) << WDT_CLR_KEY_Pos)
+#define WDT_CLR_KEY(value)          (WDT_CLR_KEY_Msk & ((value) << WDT_CLR_KEY_Pos))
+#define WDT_CLR_MASK                _U(0xFF000001) /**< \brief (WDT_CLR) MASK Register */
+
+/* -------- WDT_SR : (WDT Offset: 0x008) (R/  32) Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t WINDOW:1;         /*!< bit:      0  WDT in window                      */
+    uint32_t CLEARED:1;        /*!< bit:      1  WDT cleared                        */
+    uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} WDT_SR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_SR_OFFSET               0x008        /**< \brief (WDT_SR offset) Status Register */
+#define WDT_SR_RESETVALUE           _U(0x00000003); /**< \brief (WDT_SR reset_value) Status Register */
+
+#define WDT_SR_WINDOW_Pos           0            /**< \brief (WDT_SR) WDT in window */
+#define WDT_SR_WINDOW               (_U(0x1) << WDT_SR_WINDOW_Pos)
+#define WDT_SR_CLEARED_Pos          1            /**< \brief (WDT_SR) WDT cleared */
+#define WDT_SR_CLEARED              (_U(0x1) << WDT_SR_CLEARED_Pos)
+#define WDT_SR_MASK                 _U(0x00000003) /**< \brief (WDT_SR) MASK Register */
+
+/* -------- WDT_IER : (WDT Offset: 0x00C) ( /W 32) Interrupt Enable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t WINT:1;           /*!< bit:      2  Watchdog Interrupt                 */
+    uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} WDT_IER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_IER_OFFSET              0x00C        /**< \brief (WDT_IER offset) Interrupt Enable Register */
+#define WDT_IER_RESETVALUE          _U(0x00000000); /**< \brief (WDT_IER reset_value) Interrupt Enable Register */
+
+#define WDT_IER_WINT_Pos            2            /**< \brief (WDT_IER) Watchdog Interrupt */
+#define WDT_IER_WINT                (_U(0x1) << WDT_IER_WINT_Pos)
+#define WDT_IER_MASK                _U(0x00000004) /**< \brief (WDT_IER) MASK Register */
+
+/* -------- WDT_IDR : (WDT Offset: 0x010) ( /W 32) Interrupt Disable Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t WINT:1;           /*!< bit:      2  Watchdog Interrupt                 */
+    uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} WDT_IDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_IDR_OFFSET              0x010        /**< \brief (WDT_IDR offset) Interrupt Disable Register */
+#define WDT_IDR_RESETVALUE          _U(0x00000000); /**< \brief (WDT_IDR reset_value) Interrupt Disable Register */
+
+#define WDT_IDR_WINT_Pos            2            /**< \brief (WDT_IDR) Watchdog Interrupt */
+#define WDT_IDR_WINT                (_U(0x1) << WDT_IDR_WINT_Pos)
+#define WDT_IDR_MASK                _U(0x00000004) /**< \brief (WDT_IDR) MASK Register */
+
+/* -------- WDT_IMR : (WDT Offset: 0x014) (R/  32) Interrupt Mask Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t WINT:1;           /*!< bit:      2  Watchdog Interrupt                 */
+    uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} WDT_IMR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_IMR_OFFSET              0x014        /**< \brief (WDT_IMR offset) Interrupt Mask Register */
+#define WDT_IMR_RESETVALUE          _U(0x00000000); /**< \brief (WDT_IMR reset_value) Interrupt Mask Register */
+
+#define WDT_IMR_WINT_Pos            2            /**< \brief (WDT_IMR) Watchdog Interrupt */
+#define WDT_IMR_WINT                (_U(0x1) << WDT_IMR_WINT_Pos)
+#define WDT_IMR_MASK                _U(0x00000004) /**< \brief (WDT_IMR) MASK Register */
+
+/* -------- WDT_ISR : (WDT Offset: 0x018) (R/  32) Interrupt Status Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t WINT:1;           /*!< bit:      2  Watchdog Interrupt                 */
+    uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} WDT_ISR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_ISR_OFFSET              0x018        /**< \brief (WDT_ISR offset) Interrupt Status Register */
+#define WDT_ISR_RESETVALUE          _U(0x00000000); /**< \brief (WDT_ISR reset_value) Interrupt Status Register */
+
+#define WDT_ISR_WINT_Pos            2            /**< \brief (WDT_ISR) Watchdog Interrupt */
+#define WDT_ISR_WINT                (_U(0x1) << WDT_ISR_WINT_Pos)
+#define WDT_ISR_MASK                _U(0x00000004) /**< \brief (WDT_ISR) MASK Register */
+
+/* -------- WDT_ICR : (WDT Offset: 0x01C) ( /W 32) Interrupt Clear Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t WINT:1;           /*!< bit:      2  Watchdog Interrupt                 */
+    uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} WDT_ICR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_ICR_OFFSET              0x01C        /**< \brief (WDT_ICR offset) Interrupt Clear Register */
+#define WDT_ICR_RESETVALUE          _U(0x00000000); /**< \brief (WDT_ICR reset_value) Interrupt Clear Register */
+
+#define WDT_ICR_WINT_Pos            2            /**< \brief (WDT_ICR) Watchdog Interrupt */
+#define WDT_ICR_WINT                (_U(0x1) << WDT_ICR_WINT_Pos)
+#define WDT_ICR_MASK                _U(0x00000004) /**< \brief (WDT_ICR) MASK Register */
+
+/* -------- WDT_VERSION : (WDT Offset: 0x3FC) (R/  32) Version Register -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t VERSION:12;       /*!< bit:  0..11  Version number                     */
+    uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    uint32_t VARIANT:4;        /*!< bit: 16..19  Variant number                     */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} WDT_VERSION_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_VERSION_OFFSET          0x3FC        /**< \brief (WDT_VERSION offset) Version Register */
+#define WDT_VERSION_RESETVALUE      _U(0x00000501); /**< \brief (WDT_VERSION reset_value) Version Register */
+
+#define WDT_VERSION_VERSION_Pos     0            /**< \brief (WDT_VERSION) Version number */
+#define WDT_VERSION_VERSION_Msk     (_U(0xFFF) << WDT_VERSION_VERSION_Pos)
+#define WDT_VERSION_VERSION(value)  (WDT_VERSION_VERSION_Msk & ((value) << WDT_VERSION_VERSION_Pos))
+#define WDT_VERSION_VARIANT_Pos     16           /**< \brief (WDT_VERSION) Variant number */
+#define WDT_VERSION_VARIANT_Msk     (_U(0xF) << WDT_VERSION_VARIANT_Pos)
+#define WDT_VERSION_VARIANT(value)  (WDT_VERSION_VARIANT_Msk & ((value) << WDT_VERSION_VARIANT_Pos))
+#define WDT_VERSION_MASK            _U(0x000F0FFF) /**< \brief (WDT_VERSION) MASK Register */
+
+/** \brief WDT hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+ struct {
+  __IO WDT_CTRL_Type             CTRL;        /**< \brief Offset: 0x000 (R/W 32) Control Register */
+  __O  WDT_CLR_Type              CLR;         /**< \brief Offset: 0x004 ( /W 32) Clear Register */
+  __I  WDT_SR_Type               SR;          /**< \brief Offset: 0x008 (R/  32) Status Register */
+  __O  WDT_IER_Type              IER;         /**< \brief Offset: 0x00C ( /W 32) Interrupt Enable Register */
+  __O  WDT_IDR_Type              IDR;         /**< \brief Offset: 0x010 ( /W 32) Interrupt Disable Register */
+  __I  WDT_IMR_Type              IMR;         /**< \brief Offset: 0x014 (R/  32) Interrupt Mask Register */
+  __I  WDT_ISR_Type              ISR;         /**< \brief Offset: 0x018 (R/  32) Interrupt Status Register */
+  __O  WDT_ICR_Type              ICR;         /**< \brief Offset: 0x01C ( /W 32) Interrupt Clear Register */
+       RoReg8                    Reserved1[0x3DC];
+  __I  WDT_VERSION_Type          VERSION;     /**< \brief Offset: 0x3FC (R/  32) Version Register */
+ } bf;
+ struct {
+  RwReg   WDT_CTRL;           /**< \brief (WDT Offset: 0x000) Control Register */
+  WoReg   WDT_CLR;            /**< \brief (WDT Offset: 0x004) Clear Register */
+  RoReg   WDT_SR;             /**< \brief (WDT Offset: 0x008) Status Register */
+  WoReg   WDT_IER;            /**< \brief (WDT Offset: 0x00C) Interrupt Enable Register */
+  WoReg   WDT_IDR;            /**< \brief (WDT Offset: 0x010) Interrupt Disable Register */
+  RoReg   WDT_IMR;            /**< \brief (WDT Offset: 0x014) Interrupt Mask Register */
+  RoReg   WDT_ISR;            /**< \brief (WDT Offset: 0x018) Interrupt Status Register */
+  WoReg   WDT_ICR;            /**< \brief (WDT Offset: 0x01C) Interrupt Clear Register */
+  RoReg8  Reserved2[0x3DC];
+  RoReg   WDT_VERSION;        /**< \brief (WDT Offset: 0x3FC) Version Register */
+ } reg;
+} Wdt;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAM4L_WDT_COMPONENT_ */

--- a/asf/sam/include/sam4l/instance/abdacb.h
+++ b/asf/sam/include/sam4l/instance/abdacb.h
@@ -1,0 +1,66 @@
+/**
+ * \file
+ *
+ * \brief Instance description for ABDACB
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_ABDACB_INSTANCE_
+#define _SAM4L_ABDACB_INSTANCE_
+
+/* ========== Register definition for ABDACB peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_ABDACB_CR              (0x40064000) /**< \brief (ABDACB) Control Register */
+#define REG_ABDACB_SDR0            (0x40064004) /**< \brief (ABDACB) Sample Data Register 0 */
+#define REG_ABDACB_SDR1            (0x40064008) /**< \brief (ABDACB) Sample Data Register 1 */
+#define REG_ABDACB_VCR0            (0x4006400C) /**< \brief (ABDACB) Volume Control Register 0 */
+#define REG_ABDACB_VCR1            (0x40064010) /**< \brief (ABDACB) Volume Control Register 1 */
+#define REG_ABDACB_IER             (0x40064014) /**< \brief (ABDACB) Interrupt Enable Register */
+#define REG_ABDACB_IDR             (0x40064018) /**< \brief (ABDACB) Interupt Disable Register */
+#define REG_ABDACB_IMR             (0x4006401C) /**< \brief (ABDACB) Interrupt Mask Register */
+#define REG_ABDACB_SR              (0x40064020) /**< \brief (ABDACB) Status Register */
+#define REG_ABDACB_SCR             (0x40064024) /**< \brief (ABDACB) Status Clear Register */
+#define REG_ABDACB_PARAMETER       (0x40064028) /**< \brief (ABDACB) Parameter Register */
+#define REG_ABDACB_VERSION         (0x4006402C) /**< \brief (ABDACB) Version Register */
+#else
+#define REG_ABDACB_CR              (*(RwReg  *)0x40064000UL) /**< \brief (ABDACB) Control Register */
+#define REG_ABDACB_SDR0            (*(RwReg  *)0x40064004UL) /**< \brief (ABDACB) Sample Data Register 0 */
+#define REG_ABDACB_SDR1            (*(RwReg  *)0x40064008UL) /**< \brief (ABDACB) Sample Data Register 1 */
+#define REG_ABDACB_VCR0            (*(RwReg  *)0x4006400CUL) /**< \brief (ABDACB) Volume Control Register 0 */
+#define REG_ABDACB_VCR1            (*(RwReg  *)0x40064010UL) /**< \brief (ABDACB) Volume Control Register 1 */
+#define REG_ABDACB_IER             (*(WoReg  *)0x40064014UL) /**< \brief (ABDACB) Interrupt Enable Register */
+#define REG_ABDACB_IDR             (*(WoReg  *)0x40064018UL) /**< \brief (ABDACB) Interupt Disable Register */
+#define REG_ABDACB_IMR             (*(RoReg  *)0x4006401CUL) /**< \brief (ABDACB) Interrupt Mask Register */
+#define REG_ABDACB_SR              (*(RoReg  *)0x40064020UL) /**< \brief (ABDACB) Status Register */
+#define REG_ABDACB_SCR             (*(WoReg  *)0x40064024UL) /**< \brief (ABDACB) Status Clear Register */
+#define REG_ABDACB_PARAMETER       (*(RoReg  *)0x40064028UL) /**< \brief (ABDACB) Parameter Register */
+#define REG_ABDACB_VERSION         (*(RoReg  *)0x4006402CUL) /**< \brief (ABDACB) Version Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for ABDACB peripheral ========== */
+#define ABDACB_GCLK_NUM             6       
+#define ABDACB_PDCA_ID_TX_CH0       31      
+#define ABDACB_PDCA_ID_TX_CH1       32      
+
+#endif /* _SAM4L_ABDACB_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/acifc.h
+++ b/asf/sam/include/sam4l/instance/acifc.h
@@ -1,0 +1,82 @@
+/**
+ * \file
+ *
+ * \brief Instance description for ACIFC
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_ACIFC_INSTANCE_
+#define _SAM4L_ACIFC_INSTANCE_
+
+/* ========== Register definition for ACIFC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_ACIFC_CTRL             (0x40040000) /**< \brief (ACIFC) Control Register */
+#define REG_ACIFC_SR               (0x40040004) /**< \brief (ACIFC) Status Register */
+#define REG_ACIFC_IER              (0x40040010) /**< \brief (ACIFC) Interrupt Enable Register */
+#define REG_ACIFC_IDR              (0x40040014) /**< \brief (ACIFC) Interrupt Disable Register */
+#define REG_ACIFC_IMR              (0x40040018) /**< \brief (ACIFC) Interrupt Mask Register */
+#define REG_ACIFC_ISR              (0x4004001C) /**< \brief (ACIFC) Interrupt Status Register */
+#define REG_ACIFC_ICR              (0x40040020) /**< \brief (ACIFC) Interrupt Status Clear Register */
+#define REG_ACIFC_TR               (0x40040024) /**< \brief (ACIFC) Test Register */
+#define REG_ACIFC_PARAMETER        (0x40040030) /**< \brief (ACIFC) Parameter Register */
+#define REG_ACIFC_VERSION          (0x40040034) /**< \brief (ACIFC) Version Register */
+#define REG_ACIFC_CONFW0           (0x40040080) /**< \brief (ACIFC) Window configuration Register 0 */
+#define REG_ACIFC_CONFW1           (0x40040084) /**< \brief (ACIFC) Window configuration Register 1 */
+#define REG_ACIFC_CONFW2           (0x40040088) /**< \brief (ACIFC) Window configuration Register 2 */
+#define REG_ACIFC_CONFW3           (0x4004008C) /**< \brief (ACIFC) Window configuration Register 3 */
+#define REG_ACIFC_CONF0            (0x400400D0) /**< \brief (ACIFC) AC Configuration Register 0 */
+#define REG_ACIFC_CONF1            (0x400400D4) /**< \brief (ACIFC) AC Configuration Register 1 */
+#define REG_ACIFC_CONF2            (0x400400D8) /**< \brief (ACIFC) AC Configuration Register 2 */
+#define REG_ACIFC_CONF3            (0x400400DC) /**< \brief (ACIFC) AC Configuration Register 3 */
+#define REG_ACIFC_CONF4            (0x400400E0) /**< \brief (ACIFC) AC Configuration Register 4 */
+#define REG_ACIFC_CONF5            (0x400400E4) /**< \brief (ACIFC) AC Configuration Register 5 */
+#define REG_ACIFC_CONF6            (0x400400E8) /**< \brief (ACIFC) AC Configuration Register 6 */
+#define REG_ACIFC_CONF7            (0x400400EC) /**< \brief (ACIFC) AC Configuration Register 7 */
+#else
+#define REG_ACIFC_CTRL             (*(RwReg  *)0x40040000UL) /**< \brief (ACIFC) Control Register */
+#define REG_ACIFC_SR               (*(RoReg  *)0x40040004UL) /**< \brief (ACIFC) Status Register */
+#define REG_ACIFC_IER              (*(WoReg  *)0x40040010UL) /**< \brief (ACIFC) Interrupt Enable Register */
+#define REG_ACIFC_IDR              (*(WoReg  *)0x40040014UL) /**< \brief (ACIFC) Interrupt Disable Register */
+#define REG_ACIFC_IMR              (*(RoReg  *)0x40040018UL) /**< \brief (ACIFC) Interrupt Mask Register */
+#define REG_ACIFC_ISR              (*(RoReg  *)0x4004001CUL) /**< \brief (ACIFC) Interrupt Status Register */
+#define REG_ACIFC_ICR              (*(WoReg  *)0x40040020UL) /**< \brief (ACIFC) Interrupt Status Clear Register */
+#define REG_ACIFC_TR               (*(RwReg  *)0x40040024UL) /**< \brief (ACIFC) Test Register */
+#define REG_ACIFC_PARAMETER        (*(RoReg  *)0x40040030UL) /**< \brief (ACIFC) Parameter Register */
+#define REG_ACIFC_VERSION          (*(RoReg  *)0x40040034UL) /**< \brief (ACIFC) Version Register */
+#define REG_ACIFC_CONFW0           (*(RwReg  *)0x40040080UL) /**< \brief (ACIFC) Window configuration Register 0 */
+#define REG_ACIFC_CONFW1           (*(RwReg  *)0x40040084UL) /**< \brief (ACIFC) Window configuration Register 1 */
+#define REG_ACIFC_CONFW2           (*(RwReg  *)0x40040088UL) /**< \brief (ACIFC) Window configuration Register 2 */
+#define REG_ACIFC_CONFW3           (*(RwReg  *)0x4004008CUL) /**< \brief (ACIFC) Window configuration Register 3 */
+#define REG_ACIFC_CONF0            (*(RwReg  *)0x400400D0UL) /**< \brief (ACIFC) AC Configuration Register 0 */
+#define REG_ACIFC_CONF1            (*(RwReg  *)0x400400D4UL) /**< \brief (ACIFC) AC Configuration Register 1 */
+#define REG_ACIFC_CONF2            (*(RwReg  *)0x400400D8UL) /**< \brief (ACIFC) AC Configuration Register 2 */
+#define REG_ACIFC_CONF3            (*(RwReg  *)0x400400DCUL) /**< \brief (ACIFC) AC Configuration Register 3 */
+#define REG_ACIFC_CONF4            (*(RwReg  *)0x400400E0UL) /**< \brief (ACIFC) AC Configuration Register 4 */
+#define REG_ACIFC_CONF5            (*(RwReg  *)0x400400E4UL) /**< \brief (ACIFC) AC Configuration Register 5 */
+#define REG_ACIFC_CONF6            (*(RwReg  *)0x400400E8UL) /**< \brief (ACIFC) AC Configuration Register 6 */
+#define REG_ACIFC_CONF7            (*(RwReg  *)0x400400ECUL) /**< \brief (ACIFC) AC Configuration Register 7 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+#endif /* _SAM4L_ACIFC_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/adcife.h
+++ b/asf/sam/include/sam4l/instance/adcife.h
@@ -1,0 +1,83 @@
+/**
+ * \file
+ *
+ * \brief Instance description for ADCIFE
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_ADCIFE_INSTANCE_
+#define _SAM4L_ADCIFE_INSTANCE_
+
+/* ========== Register definition for ADCIFE peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_ADCIFE_CR              (0x40038000) /**< \brief (ADCIFE) Control Register */
+#define REG_ADCIFE_CFG             (0x40038004) /**< \brief (ADCIFE) Configuration Register */
+#define REG_ADCIFE_SR              (0x40038008) /**< \brief (ADCIFE) Status Register */
+#define REG_ADCIFE_SCR             (0x4003800C) /**< \brief (ADCIFE) Status Clear Register */
+#define REG_ADCIFE_RTS             (0x40038010) /**< \brief (ADCIFE) Resistive Touch Screen Register */
+#define REG_ADCIFE_SEQCFG          (0x40038014) /**< \brief (ADCIFE) Sequencer Configuration Register */
+#define REG_ADCIFE_CDMA            (0x40038018) /**< \brief (ADCIFE) Configuration Direct Memory Access Register */
+#define REG_ADCIFE_TIM             (0x4003801C) /**< \brief (ADCIFE) Timing Configuration Register */
+#define REG_ADCIFE_ITIMER          (0x40038020) /**< \brief (ADCIFE) Internal Timer Register */
+#define REG_ADCIFE_WCFG            (0x40038024) /**< \brief (ADCIFE) Window Monitor Configuration Register */
+#define REG_ADCIFE_WTH             (0x40038028) /**< \brief (ADCIFE) Window Monitor Threshold Configuration Register */
+#define REG_ADCIFE_LCV             (0x4003802C) /**< \brief (ADCIFE) Sequencer Last Converted Value Register */
+#define REG_ADCIFE_IER             (0x40038030) /**< \brief (ADCIFE) Interrupt Enable Register */
+#define REG_ADCIFE_IDR             (0x40038034) /**< \brief (ADCIFE) Interrupt Disable Register */
+#define REG_ADCIFE_IMR             (0x40038038) /**< \brief (ADCIFE) Interrupt Mask Register */
+#define REG_ADCIFE_CALIB           (0x4003803C) /**< \brief (ADCIFE) Calibration Register */
+#define REG_ADCIFE_VERSION         (0x40038040) /**< \brief (ADCIFE) Version Register */
+#define REG_ADCIFE_PARAMETER       (0x40038044) /**< \brief (ADCIFE) Parameter Register */
+#else
+#define REG_ADCIFE_CR              (*(WoReg  *)0x40038000UL) /**< \brief (ADCIFE) Control Register */
+#define REG_ADCIFE_CFG             (*(RwReg  *)0x40038004UL) /**< \brief (ADCIFE) Configuration Register */
+#define REG_ADCIFE_SR              (*(RoReg  *)0x40038008UL) /**< \brief (ADCIFE) Status Register */
+#define REG_ADCIFE_SCR             (*(WoReg  *)0x4003800CUL) /**< \brief (ADCIFE) Status Clear Register */
+#define REG_ADCIFE_RTS             (*(RwReg  *)0x40038010UL) /**< \brief (ADCIFE) Resistive Touch Screen Register */
+#define REG_ADCIFE_SEQCFG          (*(RwReg  *)0x40038014UL) /**< \brief (ADCIFE) Sequencer Configuration Register */
+#define REG_ADCIFE_CDMA            (*(WoReg  *)0x40038018UL) /**< \brief (ADCIFE) Configuration Direct Memory Access Register */
+#define REG_ADCIFE_TIM             (*(RwReg  *)0x4003801CUL) /**< \brief (ADCIFE) Timing Configuration Register */
+#define REG_ADCIFE_ITIMER          (*(RwReg  *)0x40038020UL) /**< \brief (ADCIFE) Internal Timer Register */
+#define REG_ADCIFE_WCFG            (*(RwReg  *)0x40038024UL) /**< \brief (ADCIFE) Window Monitor Configuration Register */
+#define REG_ADCIFE_WTH             (*(RwReg  *)0x40038028UL) /**< \brief (ADCIFE) Window Monitor Threshold Configuration Register */
+#define REG_ADCIFE_LCV             (*(RoReg  *)0x4003802CUL) /**< \brief (ADCIFE) Sequencer Last Converted Value Register */
+#define REG_ADCIFE_IER             (*(WoReg  *)0x40038030UL) /**< \brief (ADCIFE) Interrupt Enable Register */
+#define REG_ADCIFE_IDR             (*(WoReg  *)0x40038034UL) /**< \brief (ADCIFE) Interrupt Disable Register */
+#define REG_ADCIFE_IMR             (*(RoReg  *)0x40038038UL) /**< \brief (ADCIFE) Interrupt Mask Register */
+#define REG_ADCIFE_CALIB           (*(RwReg  *)0x4003803CUL) /**< \brief (ADCIFE) Calibration Register */
+#define REG_ADCIFE_VERSION         (*(RoReg  *)0x40038040UL) /**< \brief (ADCIFE) Version Register */
+#define REG_ADCIFE_PARAMETER       (*(RoReg  *)0x40038044UL) /**< \brief (ADCIFE) Parameter Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for ADCIFE peripheral ========== */
+#define ADCIFE_CHANNELS             16      
+#define ADCIFE_CHANNEL_MSB          15      
+#define ADCIFE_EXT_TRIGGERS_MSB     0       
+#define ADCIFE_GCLK_NUM             10      
+#define ADCIFE_PDCA_ID_RX           11      
+#define ADCIFE_PDCA_ID_TX           29      
+#define ADCIFE_REG_RX               LCV     
+#define ADCIFE_REG_TX               CDMA    
+
+#endif /* _SAM4L_ADCIFE_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/aesa.h
+++ b/asf/sam/include/sam4l/instance/aesa.h
@@ -1,0 +1,92 @@
+/**
+ * \file
+ *
+ * \brief Instance description for AESA
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_AESA_INSTANCE_
+#define _SAM4L_AESA_INSTANCE_
+
+/* ========== Register definition for AESA peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_AESA_CTRL              (0x400B0000) /**< \brief (AESA) Control Register */
+#define REG_AESA_MODE              (0x400B0004) /**< \brief (AESA) Mode Register */
+#define REG_AESA_DATABUFPTR        (0x400B0008) /**< \brief (AESA) Data Buffer Pointer Register */
+#define REG_AESA_SR                (0x400B000C) /**< \brief (AESA) Status Register */
+#define REG_AESA_IER               (0x400B0010) /**< \brief (AESA) Interrupt Enable Register */
+#define REG_AESA_IDR               (0x400B0014) /**< \brief (AESA) Interrupt Disable Register */
+#define REG_AESA_IMR               (0x400B0018) /**< \brief (AESA) Interrupt Mask Register */
+#define REG_AESA_KEY0              (0x400B0020) /**< \brief (AESA) Key Register 0 */
+#define REG_AESA_KEY1              (0x400B0024) /**< \brief (AESA) Key Register 1 */
+#define REG_AESA_KEY2              (0x400B0028) /**< \brief (AESA) Key Register 2 */
+#define REG_AESA_KEY3              (0x400B002C) /**< \brief (AESA) Key Register 3 */
+#define REG_AESA_KEY4              (0x400B0030) /**< \brief (AESA) Key Register 4 */
+#define REG_AESA_KEY5              (0x400B0034) /**< \brief (AESA) Key Register 5 */
+#define REG_AESA_KEY6              (0x400B0038) /**< \brief (AESA) Key Register 6 */
+#define REG_AESA_KEY7              (0x400B003C) /**< \brief (AESA) Key Register 7 */
+#define REG_AESA_INITVECT0         (0x400B0040) /**< \brief (AESA) Initialization Vector Register 0 */
+#define REG_AESA_INITVECT1         (0x400B0044) /**< \brief (AESA) Initialization Vector Register 1 */
+#define REG_AESA_INITVECT2         (0x400B0048) /**< \brief (AESA) Initialization Vector Register 2 */
+#define REG_AESA_INITVECT3         (0x400B004C) /**< \brief (AESA) Initialization Vector Register 3 */
+#define REG_AESA_IDATA             (0x400B0050) /**< \brief (AESA) Input Data Register */
+#define REG_AESA_ODATA             (0x400B0060) /**< \brief (AESA) Output Data Register */
+#define REG_AESA_DRNGSEED          (0x400B0070) /**< \brief (AESA) DRNG Seed Register */
+#define REG_AESA_PARAMETER         (0x400B00F8) /**< \brief (AESA) Parameter Register */
+#define REG_AESA_VERSION           (0x400B00FC) /**< \brief (AESA) Version Register */
+#else
+#define REG_AESA_CTRL              (*(RwReg  *)0x400B0000UL) /**< \brief (AESA) Control Register */
+#define REG_AESA_MODE              (*(RwReg  *)0x400B0004UL) /**< \brief (AESA) Mode Register */
+#define REG_AESA_DATABUFPTR        (*(RwReg  *)0x400B0008UL) /**< \brief (AESA) Data Buffer Pointer Register */
+#define REG_AESA_SR                (*(RoReg  *)0x400B000CUL) /**< \brief (AESA) Status Register */
+#define REG_AESA_IER               (*(WoReg  *)0x400B0010UL) /**< \brief (AESA) Interrupt Enable Register */
+#define REG_AESA_IDR               (*(WoReg  *)0x400B0014UL) /**< \brief (AESA) Interrupt Disable Register */
+#define REG_AESA_IMR               (*(RoReg  *)0x400B0018UL) /**< \brief (AESA) Interrupt Mask Register */
+#define REG_AESA_KEY0              (*(WoReg  *)0x400B0020UL) /**< \brief (AESA) Key Register 0 */
+#define REG_AESA_KEY1              (*(WoReg  *)0x400B0024UL) /**< \brief (AESA) Key Register 1 */
+#define REG_AESA_KEY2              (*(WoReg  *)0x400B0028UL) /**< \brief (AESA) Key Register 2 */
+#define REG_AESA_KEY3              (*(WoReg  *)0x400B002CUL) /**< \brief (AESA) Key Register 3 */
+#define REG_AESA_KEY4              (*(WoReg  *)0x400B0030UL) /**< \brief (AESA) Key Register 4 */
+#define REG_AESA_KEY5              (*(WoReg  *)0x400B0034UL) /**< \brief (AESA) Key Register 5 */
+#define REG_AESA_KEY6              (*(WoReg  *)0x400B0038UL) /**< \brief (AESA) Key Register 6 */
+#define REG_AESA_KEY7              (*(WoReg  *)0x400B003CUL) /**< \brief (AESA) Key Register 7 */
+#define REG_AESA_INITVECT0         (*(WoReg  *)0x400B0040UL) /**< \brief (AESA) Initialization Vector Register 0 */
+#define REG_AESA_INITVECT1         (*(WoReg  *)0x400B0044UL) /**< \brief (AESA) Initialization Vector Register 1 */
+#define REG_AESA_INITVECT2         (*(WoReg  *)0x400B0048UL) /**< \brief (AESA) Initialization Vector Register 2 */
+#define REG_AESA_INITVECT3         (*(WoReg  *)0x400B004CUL) /**< \brief (AESA) Initialization Vector Register 3 */
+#define REG_AESA_IDATA             (*(WoReg  *)0x400B0050UL) /**< \brief (AESA) Input Data Register */
+#define REG_AESA_ODATA             (*(RoReg  *)0x400B0060UL) /**< \brief (AESA) Output Data Register */
+#define REG_AESA_DRNGSEED          (*(WoReg  *)0x400B0070UL) /**< \brief (AESA) DRNG Seed Register */
+#define REG_AESA_PARAMETER         (*(RoReg  *)0x400B00F8UL) /**< \brief (AESA) Parameter Register */
+#define REG_AESA_VERSION           (*(RoReg  *)0x400B00FCUL) /**< \brief (AESA) Version Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for AESA peripheral ========== */
+#define AESA_DMAC_ID_RX                     
+#define AESA_DMAC_ID_TX                     
+#define AESA_GCLK_NUM               4       
+#define AESA_PDCA_ID_RX             17      
+#define AESA_PDCA_ID_TX             36      
+
+#endif /* _SAM4L_AESA_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/ast.h
+++ b/asf/sam/include/sam4l/instance/ast.h
@@ -1,0 +1,85 @@
+/**
+ * \file
+ *
+ * \brief Instance description for AST
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_AST_INSTANCE_
+#define _SAM4L_AST_INSTANCE_
+
+/* ========== Register definition for AST peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_AST_CR                 (0x400F0800) /**< \brief (AST) Control Register */
+#define REG_AST_CV                 (0x400F0804) /**< \brief (AST) Counter Value */
+#define REG_AST_SR                 (0x400F0808) /**< \brief (AST) Status Register */
+#define REG_AST_SCR                (0x400F080C) /**< \brief (AST) Status Clear Register */
+#define REG_AST_IER                (0x400F0810) /**< \brief (AST) Interrupt Enable Register */
+#define REG_AST_IDR                (0x400F0814) /**< \brief (AST) Interrupt Disable Register */
+#define REG_AST_IMR                (0x400F0818) /**< \brief (AST) Interrupt Mask Register */
+#define REG_AST_WER                (0x400F081C) /**< \brief (AST) Wake Enable Register */
+#define REG_AST_AR0                (0x400F0820) /**< \brief (AST) Alarm Register 0 */
+#define REG_AST_AR1                (0x400F0824) /**< \brief (AST) Alarm Register 1 */
+#define REG_AST_PIR0               (0x400F0830) /**< \brief (AST) Periodic Interval Register 0 */
+#define REG_AST_PIR1               (0x400F0834) /**< \brief (AST) Periodic Interval Register 1 */
+#define REG_AST_CLOCK              (0x400F0840) /**< \brief (AST) Clock Control Register */
+#define REG_AST_DTR                (0x400F0844) /**< \brief (AST) Digital Tuner Register */
+#define REG_AST_EVE                (0x400F0848) /**< \brief (AST) Event Enable Register */
+#define REG_AST_EVD                (0x400F084C) /**< \brief (AST) Event Disable Register */
+#define REG_AST_EVM                (0x400F0850) /**< \brief (AST) Event Mask Register */
+#define REG_AST_CALV               (0x400F0854) /**< \brief (AST) Calendar Value */
+#define REG_AST_PARAMETER          (0x400F08F0) /**< \brief (AST) Parameter Register */
+#define REG_AST_VERSION            (0x400F08FC) /**< \brief (AST) Version Register */
+#else
+#define REG_AST_CR                 (*(RwReg  *)0x400F0800UL) /**< \brief (AST) Control Register */
+#define REG_AST_CV                 (*(RwReg  *)0x400F0804UL) /**< \brief (AST) Counter Value */
+#define REG_AST_SR                 (*(RoReg  *)0x400F0808UL) /**< \brief (AST) Status Register */
+#define REG_AST_SCR                (*(WoReg  *)0x400F080CUL) /**< \brief (AST) Status Clear Register */
+#define REG_AST_IER                (*(WoReg  *)0x400F0810UL) /**< \brief (AST) Interrupt Enable Register */
+#define REG_AST_IDR                (*(WoReg  *)0x400F0814UL) /**< \brief (AST) Interrupt Disable Register */
+#define REG_AST_IMR                (*(RoReg  *)0x400F0818UL) /**< \brief (AST) Interrupt Mask Register */
+#define REG_AST_WER                (*(RwReg  *)0x400F081CUL) /**< \brief (AST) Wake Enable Register */
+#define REG_AST_AR0                (*(RwReg  *)0x400F0820UL) /**< \brief (AST) Alarm Register 0 */
+#define REG_AST_AR1                (*(RwReg  *)0x400F0824UL) /**< \brief (AST) Alarm Register 1 */
+#define REG_AST_PIR0               (*(RwReg  *)0x400F0830UL) /**< \brief (AST) Periodic Interval Register 0 */
+#define REG_AST_PIR1               (*(RwReg  *)0x400F0834UL) /**< \brief (AST) Periodic Interval Register 1 */
+#define REG_AST_CLOCK              (*(RwReg  *)0x400F0840UL) /**< \brief (AST) Clock Control Register */
+#define REG_AST_DTR                (*(RwReg  *)0x400F0844UL) /**< \brief (AST) Digital Tuner Register */
+#define REG_AST_EVE                (*(WoReg  *)0x400F0848UL) /**< \brief (AST) Event Enable Register */
+#define REG_AST_EVD                (*(WoReg  *)0x400F084CUL) /**< \brief (AST) Event Disable Register */
+#define REG_AST_EVM                (*(RoReg  *)0x400F0850UL) /**< \brief (AST) Event Mask Register */
+#define REG_AST_CALV               (*(RwReg  *)0x400F0854UL) /**< \brief (AST) Calendar Value */
+#define REG_AST_PARAMETER          (*(RoReg  *)0x400F08F0UL) /**< \brief (AST) Parameter Register */
+#define REG_AST_VERSION            (*(RoReg  *)0x400F08FCUL) /**< \brief (AST) Version Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for AST peripheral ========== */
+#define AST_CLK1K                   4       
+#define AST_CLK32                   1       
+#define AST_GCLK_NUM                2       
+#define AST_GENCLK                  3       
+#define AST_PB                      2       
+#define AST_RCOSC                   0       
+
+#endif /* _SAM4L_AST_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/bpm.h
+++ b/asf/sam/include/sam4l/instance/bpm.h
@@ -1,0 +1,79 @@
+/**
+ * \file
+ *
+ * \brief Instance description for BPM
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_BPM_INSTANCE_
+#define _SAM4L_BPM_INSTANCE_
+
+/* ========== Register definition for BPM peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_BPM_IER                (0x400F0000) /**< \brief (BPM) Interrupt Enable Register */
+#define REG_BPM_IDR                (0x400F0004) /**< \brief (BPM) Interrupt Disable Register */
+#define REG_BPM_IMR                (0x400F0008) /**< \brief (BPM) Interrupt Mask Register */
+#define REG_BPM_ISR                (0x400F000C) /**< \brief (BPM) Interrupt Status Register */
+#define REG_BPM_ICR                (0x400F0010) /**< \brief (BPM) Interrupt Clear Register */
+#define REG_BPM_SR                 (0x400F0014) /**< \brief (BPM) Status Register */
+#define REG_BPM_UNLOCK             (0x400F0018) /**< \brief (BPM) Unlock Register */
+#define REG_BPM_PMCON              (0x400F001C) /**< \brief (BPM) Power Mode Control Register */
+#define REG_BPM_BKUPWCAUSE         (0x400F0028) /**< \brief (BPM) Backup Wake up Cause Register */
+#define REG_BPM_BKUPWEN            (0x400F002C) /**< \brief (BPM) Backup Wake up Enable Register */
+#define REG_BPM_BKUPPMUX           (0x400F0030) /**< \brief (BPM) Backup Pin Muxing Register */
+#define REG_BPM_IORET              (0x400F0034) /**< \brief (BPM) Input Output Retention Register */
+#define REG_BPM_BPR                (0x400F0040) /**< \brief (BPM) Bypass Register */
+#define REG_BPM_FWRUNPS            (0x400F0044) /**< \brief (BPM) Factory Word Run PS Register */
+#define REG_BPM_FWPSAVEPS          (0x400F0048) /**< \brief (BPM) Factory Word Power Save PS Register */
+#define REG_BPM_VERSION            (0x400F00FC) /**< \brief (BPM) Version Register */
+#else
+#define REG_BPM_IER                (*(WoReg  *)0x400F0000UL) /**< \brief (BPM) Interrupt Enable Register */
+#define REG_BPM_IDR                (*(WoReg  *)0x400F0004UL) /**< \brief (BPM) Interrupt Disable Register */
+#define REG_BPM_IMR                (*(RoReg  *)0x400F0008UL) /**< \brief (BPM) Interrupt Mask Register */
+#define REG_BPM_ISR                (*(RoReg  *)0x400F000CUL) /**< \brief (BPM) Interrupt Status Register */
+#define REG_BPM_ICR                (*(WoReg  *)0x400F0010UL) /**< \brief (BPM) Interrupt Clear Register */
+#define REG_BPM_SR                 (*(RoReg  *)0x400F0014UL) /**< \brief (BPM) Status Register */
+#define REG_BPM_UNLOCK             (*(WoReg  *)0x400F0018UL) /**< \brief (BPM) Unlock Register */
+#define REG_BPM_PMCON              (*(RwReg  *)0x400F001CUL) /**< \brief (BPM) Power Mode Control Register */
+#define REG_BPM_BKUPWCAUSE         (*(RoReg  *)0x400F0028UL) /**< \brief (BPM) Backup Wake up Cause Register */
+#define REG_BPM_BKUPWEN            (*(RwReg  *)0x400F002CUL) /**< \brief (BPM) Backup Wake up Enable Register */
+#define REG_BPM_BKUPPMUX           (*(RwReg  *)0x400F0030UL) /**< \brief (BPM) Backup Pin Muxing Register */
+#define REG_BPM_IORET              (*(RwReg  *)0x400F0034UL) /**< \brief (BPM) Input Output Retention Register */
+#define REG_BPM_BPR                (*(RwReg  *)0x400F0040UL) /**< \brief (BPM) Bypass Register */
+#define REG_BPM_FWRUNPS            (*(RoReg  *)0x400F0044UL) /**< \brief (BPM) Factory Word Run PS Register */
+#define REG_BPM_FWPSAVEPS          (*(RoReg  *)0x400F0048UL) /**< \brief (BPM) Factory Word Power Save PS Register */
+#define REG_BPM_VERSION            (*(RoReg  *)0x400F00FCUL) /**< \brief (BPM) Version Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for BPM peripheral ========== */
+#define BPM_BKUPPMUX_MSB            9       
+#define BPM_BKUPWEN_AST             1       
+#define BPM_BKUPWEN_BOD18           4       
+#define BPM_BKUPWEN_BOD33           3       
+#define BPM_BKUPWEN_EIC             0       
+#define BPM_BKUPWEN_MSB             5       
+#define BPM_BKUPWEN_PICOUART        5       
+#define BPM_BKUPWEN_WDT             2       
+
+#endif /* _SAM4L_BPM_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/bscif.h
+++ b/asf/sam/include/sam4l/instance/bscif.h
@@ -1,0 +1,117 @@
+/**
+ * \file
+ *
+ * \brief Instance description for BSCIF
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_BSCIF_INSTANCE_
+#define _SAM4L_BSCIF_INSTANCE_
+
+/* ========== Register definition for BSCIF peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_BSCIF_IER              (0x400F0400) /**< \brief (BSCIF) Interrupt Enable Register */
+#define REG_BSCIF_IDR              (0x400F0404) /**< \brief (BSCIF) Interrupt Disable Register */
+#define REG_BSCIF_IMR              (0x400F0408) /**< \brief (BSCIF) Interrupt Mask Register */
+#define REG_BSCIF_ISR              (0x400F040C) /**< \brief (BSCIF) Interrupt Status Register */
+#define REG_BSCIF_ICR              (0x400F0410) /**< \brief (BSCIF) Interrupt Clear Register */
+#define REG_BSCIF_PCLKSR           (0x400F0414) /**< \brief (BSCIF) Power and Clocks Status Register */
+#define REG_BSCIF_UNLOCK           (0x400F0418) /**< \brief (BSCIF) Unlock Register */
+#define REG_BSCIF_CSCR             (0x400F041C) /**< \brief (BSCIF) Chip Specific Configuration Register */
+#define REG_BSCIF_OSCCTRL32        (0x400F0420) /**< \brief (BSCIF) Oscillator 32 Control Register */
+#define REG_BSCIF_RC32KCR          (0x400F0424) /**< \brief (BSCIF) 32 kHz RC Oscillator Control Register */
+#define REG_BSCIF_RC32KTUNE        (0x400F0428) /**< \brief (BSCIF) 32kHz RC Oscillator Tuning Register */
+#define REG_BSCIF_BOD33CTRL        (0x400F042C) /**< \brief (BSCIF) BOD33 Control Register */
+#define REG_BSCIF_BOD33LEVEL       (0x400F0430) /**< \brief (BSCIF) BOD33 Level Register */
+#define REG_BSCIF_BOD33SAMPLING    (0x400F0434) /**< \brief (BSCIF) BOD33 Sampling Control Register */
+#define REG_BSCIF_BOD18CTRL        (0x400F0438) /**< \brief (BSCIF) BOD18 Control Register */
+#define REG_BSCIF_BOD18LEVEL       (0x400F043C) /**< \brief (BSCIF) BOD18 Level Register */
+#define REG_BSCIF_VREGCR           (0x400F0444) /**< \brief (BSCIF) Voltage Regulator Configuration Register */
+#define REG_BSCIF_VREGNCSR         (0x400F044C) /**< \brief (BSCIF) Normal Mode Control and Status Register */
+#define REG_BSCIF_VREGLPCSR        (0x400F0450) /**< \brief (BSCIF) LP Mode Control and Status Register */
+#define REG_BSCIF_RC1MCR           (0x400F0458) /**< \brief (BSCIF) 1MHz RC Clock Configuration Register */
+#define REG_BSCIF_BGCR             (0x400F045C) /**< \brief (BSCIF) Bandgap Calibration Register */
+#define REG_BSCIF_BGCTRL           (0x400F0460) /**< \brief (BSCIF) Bandgap Control Register */
+#define REG_BSCIF_BGSR             (0x400F0464) /**< \brief (BSCIF) Bandgap Status Register */
+#define REG_BSCIF_BR0              (0x400F0478) /**< \brief (BSCIF) Backup Register 0 */
+#define REG_BSCIF_BR1              (0x400F047C) /**< \brief (BSCIF) Backup Register 1 */
+#define REG_BSCIF_BR2              (0x400F0480) /**< \brief (BSCIF) Backup Register 2 */
+#define REG_BSCIF_BR3              (0x400F0484) /**< \brief (BSCIF) Backup Register 3 */
+#define REG_BSCIF_BRIFBVERSION     (0x400F07E4) /**< \brief (BSCIF) Backup Register Interface Version Register */
+#define REG_BSCIF_BGREFIFBVERSION  (0x400F07E8) /**< \brief (BSCIF) BGREFIFB Version Register */
+#define REG_BSCIF_VREGIFGVERSION   (0x400F07EC) /**< \brief (BSCIF) VREGIFA Version Register */
+#define REG_BSCIF_BODIFCVERSION    (0x400F07F0) /**< \brief (BSCIF) BODIFC Version Register */
+#define REG_BSCIF_RC32KIFBVERSION  (0x400F07F4) /**< \brief (BSCIF) 32 kHz RC Oscillator Version Register */
+#define REG_BSCIF_OSC32IFAVERSION  (0x400F07F8) /**< \brief (BSCIF) 32 KHz Oscillator Version Register */
+#define REG_BSCIF_VERSION          (0x400F07FC) /**< \brief (BSCIF) BSCIF Version Register */
+#else
+#define REG_BSCIF_IER              (*(WoReg  *)0x400F0400UL) /**< \brief (BSCIF) Interrupt Enable Register */
+#define REG_BSCIF_IDR              (*(WoReg  *)0x400F0404UL) /**< \brief (BSCIF) Interrupt Disable Register */
+#define REG_BSCIF_IMR              (*(RoReg  *)0x400F0408UL) /**< \brief (BSCIF) Interrupt Mask Register */
+#define REG_BSCIF_ISR              (*(RoReg  *)0x400F040CUL) /**< \brief (BSCIF) Interrupt Status Register */
+#define REG_BSCIF_ICR              (*(WoReg  *)0x400F0410UL) /**< \brief (BSCIF) Interrupt Clear Register */
+#define REG_BSCIF_PCLKSR           (*(RoReg  *)0x400F0414UL) /**< \brief (BSCIF) Power and Clocks Status Register */
+#define REG_BSCIF_UNLOCK           (*(WoReg  *)0x400F0418UL) /**< \brief (BSCIF) Unlock Register */
+#define REG_BSCIF_CSCR             (*(RwReg  *)0x400F041CUL) /**< \brief (BSCIF) Chip Specific Configuration Register */
+#define REG_BSCIF_OSCCTRL32        (*(RwReg  *)0x400F0420UL) /**< \brief (BSCIF) Oscillator 32 Control Register */
+#define REG_BSCIF_RC32KCR          (*(RwReg  *)0x400F0424UL) /**< \brief (BSCIF) 32 kHz RC Oscillator Control Register */
+#define REG_BSCIF_RC32KTUNE        (*(RwReg  *)0x400F0428UL) /**< \brief (BSCIF) 32kHz RC Oscillator Tuning Register */
+#define REG_BSCIF_BOD33CTRL        (*(RwReg  *)0x400F042CUL) /**< \brief (BSCIF) BOD33 Control Register */
+#define REG_BSCIF_BOD33LEVEL       (*(RwReg  *)0x400F0430UL) /**< \brief (BSCIF) BOD33 Level Register */
+#define REG_BSCIF_BOD33SAMPLING    (*(RwReg  *)0x400F0434UL) /**< \brief (BSCIF) BOD33 Sampling Control Register */
+#define REG_BSCIF_BOD18CTRL        (*(RwReg  *)0x400F0438UL) /**< \brief (BSCIF) BOD18 Control Register */
+#define REG_BSCIF_BOD18LEVEL       (*(RwReg  *)0x400F043CUL) /**< \brief (BSCIF) BOD18 Level Register */
+#define REG_BSCIF_VREGCR           (*(RwReg  *)0x400F0444UL) /**< \brief (BSCIF) Voltage Regulator Configuration Register */
+#define REG_BSCIF_VREGNCSR         (*(RwReg  *)0x400F044CUL) /**< \brief (BSCIF) Normal Mode Control and Status Register */
+#define REG_BSCIF_VREGLPCSR        (*(RwReg  *)0x400F0450UL) /**< \brief (BSCIF) LP Mode Control and Status Register */
+#define REG_BSCIF_RC1MCR           (*(RwReg  *)0x400F0458UL) /**< \brief (BSCIF) 1MHz RC Clock Configuration Register */
+#define REG_BSCIF_BGCR             (*(RwReg  *)0x400F045CUL) /**< \brief (BSCIF) Bandgap Calibration Register */
+#define REG_BSCIF_BGCTRL           (*(RwReg  *)0x400F0460UL) /**< \brief (BSCIF) Bandgap Control Register */
+#define REG_BSCIF_BGSR             (*(RoReg  *)0x400F0464UL) /**< \brief (BSCIF) Bandgap Status Register */
+#define REG_BSCIF_BR0              (*(RwReg  *)0x400F0478UL) /**< \brief (BSCIF) Backup Register 0 */
+#define REG_BSCIF_BR1              (*(RwReg  *)0x400F047CUL) /**< \brief (BSCIF) Backup Register 1 */
+#define REG_BSCIF_BR2              (*(RwReg  *)0x400F0480UL) /**< \brief (BSCIF) Backup Register 2 */
+#define REG_BSCIF_BR3              (*(RwReg  *)0x400F0484UL) /**< \brief (BSCIF) Backup Register 3 */
+#define REG_BSCIF_BRIFBVERSION     (*(RoReg  *)0x400F07E4UL) /**< \brief (BSCIF) Backup Register Interface Version Register */
+#define REG_BSCIF_BGREFIFBVERSION  (*(RoReg  *)0x400F07E8UL) /**< \brief (BSCIF) BGREFIFB Version Register */
+#define REG_BSCIF_VREGIFGVERSION   (*(RoReg  *)0x400F07ECUL) /**< \brief (BSCIF) VREGIFA Version Register */
+#define REG_BSCIF_BODIFCVERSION    (*(RoReg  *)0x400F07F0UL) /**< \brief (BSCIF) BODIFC Version Register */
+#define REG_BSCIF_RC32KIFBVERSION  (*(RoReg  *)0x400F07F4UL) /**< \brief (BSCIF) 32 kHz RC Oscillator Version Register */
+#define REG_BSCIF_OSC32IFAVERSION  (*(RoReg  *)0x400F07F8UL) /**< \brief (BSCIF) 32 KHz Oscillator Version Register */
+#define REG_BSCIF_VERSION          (*(RoReg  *)0x400F07FCUL) /**< \brief (BSCIF) BSCIF Version Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for BSCIF peripheral ========== */
+#define BSCIF_BGBUF_NUM             6       
+#define BSCIF_BOD18_IMPLEMENTED     0       
+#define BSCIF_BOD33_IMPLEMENTED     0       
+#define BSCIF_BOD50_IMPLEMENTED     0       
+#define BSCIF_BR_NUM                4       
+#define BSCIF_BOD_OFF               0       
+#define BSCIF_BOD_ON                1       
+#define BSCIF_BOD_ON_NORESET        2       
+#define BSCIF_GC_DIV_CLOCK          1       
+#define BSCIF_GC_NO_DIV_CLOCK       0       
+
+#endif /* _SAM4L_BSCIF_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/catb.h
+++ b/asf/sam/include/sam4l/instance/catb.h
@@ -1,0 +1,84 @@
+/**
+ * \file
+ *
+ * \brief Instance description for CATB
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_CATB_INSTANCE_
+#define _SAM4L_CATB_INSTANCE_
+
+/* ========== Register definition for CATB peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_CATB_CR                (0x40070000) /**< \brief (CATB) Control Register */
+#define REG_CATB_CNTCR             (0x40070004) /**< \brief (CATB) Counter Control Register */
+#define REG_CATB_IDLE              (0x40070008) /**< \brief (CATB) Sensor Idle Level */
+#define REG_CATB_LEVEL             (0x4007000C) /**< \brief (CATB) Sensor Relative Level */
+#define REG_CATB_RAW               (0x40070010) /**< \brief (CATB) Sensor Raw Value */
+#define REG_CATB_TIMING            (0x40070014) /**< \brief (CATB) Filter Timing Register */
+#define REG_CATB_THRESH            (0x40070018) /**< \brief (CATB) Threshold Register */
+#define REG_CATB_PINSEL            (0x4007001C) /**< \brief (CATB) Pin Selection Register */
+#define REG_CATB_DMA               (0x40070020) /**< \brief (CATB) Direct Memory Access Register */
+#define REG_CATB_ISR               (0x40070024) /**< \brief (CATB) Interrupt Status Register */
+#define REG_CATB_IER               (0x40070028) /**< \brief (CATB) Interrupt Enable Register */
+#define REG_CATB_IDR               (0x4007002C) /**< \brief (CATB) Interrupt Disable Register */
+#define REG_CATB_IMR               (0x40070030) /**< \brief (CATB) Interrupt Mask Register */
+#define REG_CATB_SCR               (0x40070034) /**< \brief (CATB) Status Clear Register */
+#define REG_CATB_INTCH0            (0x40070040) /**< \brief (CATB) In-Touch Status Register 0 */
+#define REG_CATB_INTCHCLR0         (0x40070050) /**< \brief (CATB) In-Touch Status Clear Register 0 */
+#define REG_CATB_OUTTCH0           (0x40070060) /**< \brief (CATB) Out-of-Touch Status Register 0 */
+#define REG_CATB_OUTTCHCLR0        (0x40070070) /**< \brief (CATB) Out-of-Touch Status Clear Register 0 */
+#define REG_CATB_PARAMETER         (0x400700F8) /**< \brief (CATB) Parameter Register */
+#define REG_CATB_VERSION           (0x400700FC) /**< \brief (CATB) Version Register */
+#else
+#define REG_CATB_CR                (*(RwReg  *)0x40070000UL) /**< \brief (CATB) Control Register */
+#define REG_CATB_CNTCR             (*(RwReg  *)0x40070004UL) /**< \brief (CATB) Counter Control Register */
+#define REG_CATB_IDLE              (*(RwReg  *)0x40070008UL) /**< \brief (CATB) Sensor Idle Level */
+#define REG_CATB_LEVEL             (*(RoReg  *)0x4007000CUL) /**< \brief (CATB) Sensor Relative Level */
+#define REG_CATB_RAW               (*(RoReg  *)0x40070010UL) /**< \brief (CATB) Sensor Raw Value */
+#define REG_CATB_TIMING            (*(RwReg  *)0x40070014UL) /**< \brief (CATB) Filter Timing Register */
+#define REG_CATB_THRESH            (*(RwReg  *)0x40070018UL) /**< \brief (CATB) Threshold Register */
+#define REG_CATB_PINSEL            (*(RwReg  *)0x4007001CUL) /**< \brief (CATB) Pin Selection Register */
+#define REG_CATB_DMA               (*(RwReg  *)0x40070020UL) /**< \brief (CATB) Direct Memory Access Register */
+#define REG_CATB_ISR               (*(RoReg  *)0x40070024UL) /**< \brief (CATB) Interrupt Status Register */
+#define REG_CATB_IER               (*(WoReg  *)0x40070028UL) /**< \brief (CATB) Interrupt Enable Register */
+#define REG_CATB_IDR               (*(WoReg  *)0x4007002CUL) /**< \brief (CATB) Interrupt Disable Register */
+#define REG_CATB_IMR               (*(RoReg  *)0x40070030UL) /**< \brief (CATB) Interrupt Mask Register */
+#define REG_CATB_SCR               (*(WoReg  *)0x40070034UL) /**< \brief (CATB) Status Clear Register */
+#define REG_CATB_INTCH0            (*(RoReg  *)0x40070040UL) /**< \brief (CATB) In-Touch Status Register 0 */
+#define REG_CATB_INTCHCLR0         (*(WoReg  *)0x40070050UL) /**< \brief (CATB) In-Touch Status Clear Register 0 */
+#define REG_CATB_OUTTCH0           (*(RoReg  *)0x40070060UL) /**< \brief (CATB) Out-of-Touch Status Register 0 */
+#define REG_CATB_OUTTCHCLR0        (*(WoReg  *)0x40070070UL) /**< \brief (CATB) Out-of-Touch Status Clear Register 0 */
+#define REG_CATB_PARAMETER         (*(RoReg  *)0x400700F8UL) /**< \brief (CATB) Parameter Register */
+#define REG_CATB_VERSION           (*(RoReg  *)0x400700FCUL) /**< \brief (CATB) Version Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for CATB peripheral ========== */
+#define CATB_GCLK_NUM               3       
+#define CATB_PDCA_ID_RX             12      
+#define CATB_PDCA_ID_TX             30      
+#define CATB_SENSORS_MSB            31      
+#define CATB_STATUS_REG_NUMBER      1       
+
+#endif /* _SAM4L_CATB_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/chipid.h
+++ b/asf/sam/include/sam4l/instance/chipid.h
@@ -1,0 +1,42 @@
+/**
+ * \file
+ *
+ * \brief Instance description for CHIPID
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_CHIPID_INSTANCE_
+#define _SAM4L_CHIPID_INSTANCE_
+
+/* ========== Register definition for CHIPID peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_CHIPID_CIDR            (0x400E0740) /**< \brief (CHIPID) Chip ID Register */
+#define REG_CHIPID_EXID            (0x400E0744) /**< \brief (CHIPID) Chip ID Extension Register */
+#else
+#define REG_CHIPID_CIDR            (*(RoReg  *)0x400E0740UL) /**< \brief (CHIPID) Chip ID Register */
+#define REG_CHIPID_EXID            (*(RoReg  *)0x400E0744UL) /**< \brief (CHIPID) Chip ID Extension Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+#endif /* _SAM4L_CHIPID_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/crccu.h
+++ b/asf/sam/include/sam4l/instance/crccu.h
@@ -1,0 +1,70 @@
+/**
+ * \file
+ *
+ * \brief Instance description for CRCCU
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_CRCCU_INSTANCE_
+#define _SAM4L_CRCCU_INSTANCE_
+
+/* ========== Register definition for CRCCU peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_CRCCU_DSCR             (0x400A4000) /**< \brief (CRCCU) Descriptor Base Register */
+#define REG_CRCCU_DMAEN            (0x400A4008) /**< \brief (CRCCU) DMA Enable Register */
+#define REG_CRCCU_DMADIS           (0x400A400C) /**< \brief (CRCCU) DMA Disable Register */
+#define REG_CRCCU_DMASR            (0x400A4010) /**< \brief (CRCCU) DMA Status Register */
+#define REG_CRCCU_DMAIER           (0x400A4014) /**< \brief (CRCCU) DMA Interrupt Enable Register */
+#define REG_CRCCU_DMAIDR           (0x400A4018) /**< \brief (CRCCU) DMA Interrupt Disable Register */
+#define REG_CRCCU_DMAIMR           (0x400A401C) /**< \brief (CRCCU) DMA Interrupt Mask Register */
+#define REG_CRCCU_DMAISR           (0x400A4020) /**< \brief (CRCCU) DMA Interrupt Status Register */
+#define REG_CRCCU_CR               (0x400A4034) /**< \brief (CRCCU) Control Register */
+#define REG_CRCCU_MR               (0x400A4038) /**< \brief (CRCCU) Mode Register */
+#define REG_CRCCU_SR               (0x400A403C) /**< \brief (CRCCU) Status Register */
+#define REG_CRCCU_IER              (0x400A4040) /**< \brief (CRCCU) Interrupt Enable Register */
+#define REG_CRCCU_IDR              (0x400A4044) /**< \brief (CRCCU) Interrupt Disable Register */
+#define REG_CRCCU_IMR              (0x400A4048) /**< \brief (CRCCU) Interrupt Mask Register */
+#define REG_CRCCU_ISR              (0x400A404C) /**< \brief (CRCCU) Interrupt Status Register */
+#define REG_CRCCU_VERSION          (0x400A40FC) /**< \brief (CRCCU) Version Register */
+#else
+#define REG_CRCCU_DSCR             (*(RwReg  *)0x400A4000UL) /**< \brief (CRCCU) Descriptor Base Register */
+#define REG_CRCCU_DMAEN            (*(WoReg  *)0x400A4008UL) /**< \brief (CRCCU) DMA Enable Register */
+#define REG_CRCCU_DMADIS           (*(WoReg  *)0x400A400CUL) /**< \brief (CRCCU) DMA Disable Register */
+#define REG_CRCCU_DMASR            (*(RoReg  *)0x400A4010UL) /**< \brief (CRCCU) DMA Status Register */
+#define REG_CRCCU_DMAIER           (*(WoReg  *)0x400A4014UL) /**< \brief (CRCCU) DMA Interrupt Enable Register */
+#define REG_CRCCU_DMAIDR           (*(WoReg  *)0x400A4018UL) /**< \brief (CRCCU) DMA Interrupt Disable Register */
+#define REG_CRCCU_DMAIMR           (*(RoReg  *)0x400A401CUL) /**< \brief (CRCCU) DMA Interrupt Mask Register */
+#define REG_CRCCU_DMAISR           (*(RoReg  *)0x400A4020UL) /**< \brief (CRCCU) DMA Interrupt Status Register */
+#define REG_CRCCU_CR               (*(WoReg  *)0x400A4034UL) /**< \brief (CRCCU) Control Register */
+#define REG_CRCCU_MR               (*(RwReg  *)0x400A4038UL) /**< \brief (CRCCU) Mode Register */
+#define REG_CRCCU_SR               (*(RoReg  *)0x400A403CUL) /**< \brief (CRCCU) Status Register */
+#define REG_CRCCU_IER              (*(WoReg  *)0x400A4040UL) /**< \brief (CRCCU) Interrupt Enable Register */
+#define REG_CRCCU_IDR              (*(WoReg  *)0x400A4044UL) /**< \brief (CRCCU) Interrupt Disable Register */
+#define REG_CRCCU_IMR              (*(RoReg  *)0x400A4048UL) /**< \brief (CRCCU) Interrupt Mask Register */
+#define REG_CRCCU_ISR              (*(RoReg  *)0x400A404CUL) /**< \brief (CRCCU) Interrupt Status Register */
+#define REG_CRCCU_VERSION          (*(RoReg  *)0x400A40FCUL) /**< \brief (CRCCU) Version Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+#endif /* _SAM4L_CRCCU_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/dacc.h
+++ b/asf/sam/include/sam4l/instance/dacc.h
@@ -1,0 +1,62 @@
+/**
+ * \file
+ *
+ * \brief Instance description for DACC
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_DACC_INSTANCE_
+#define _SAM4L_DACC_INSTANCE_
+
+/* ========== Register definition for DACC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_DACC_CR                (0x4003C000) /**< \brief (DACC) Control Register */
+#define REG_DACC_MR                (0x4003C004) /**< \brief (DACC) Mode Register */
+#define REG_DACC_CDR               (0x4003C008) /**< \brief (DACC) Conversion Data Register */
+#define REG_DACC_IER               (0x4003C00C) /**< \brief (DACC) Interrupt Enable Register */
+#define REG_DACC_IDR               (0x4003C010) /**< \brief (DACC) Interrupt Disable Register */
+#define REG_DACC_IMR               (0x4003C014) /**< \brief (DACC) Interrupt Mask Register */
+#define REG_DACC_ISR               (0x4003C018) /**< \brief (DACC) Interrupt Status Register */
+#define REG_DACC_WPMR              (0x4003C0E4) /**< \brief (DACC) Write Protect Mode Register */
+#define REG_DACC_WPSR              (0x4003C0E8) /**< \brief (DACC) Write Protect Status Register */
+#define REG_DACC_VERSION           (0x4003C0FC) /**< \brief (DACC) Version Register */
+#else
+#define REG_DACC_CR                (*(WoReg  *)0x4003C000UL) /**< \brief (DACC) Control Register */
+#define REG_DACC_MR                (*(RwReg  *)0x4003C004UL) /**< \brief (DACC) Mode Register */
+#define REG_DACC_CDR               (*(WoReg  *)0x4003C008UL) /**< \brief (DACC) Conversion Data Register */
+#define REG_DACC_IER               (*(WoReg  *)0x4003C00CUL) /**< \brief (DACC) Interrupt Enable Register */
+#define REG_DACC_IDR               (*(WoReg  *)0x4003C010UL) /**< \brief (DACC) Interrupt Disable Register */
+#define REG_DACC_IMR               (*(RoReg  *)0x4003C014UL) /**< \brief (DACC) Interrupt Mask Register */
+#define REG_DACC_ISR               (*(RoReg  *)0x4003C018UL) /**< \brief (DACC) Interrupt Status Register */
+#define REG_DACC_WPMR              (*(RwReg  *)0x4003C0E4UL) /**< \brief (DACC) Write Protect Mode Register */
+#define REG_DACC_WPSR              (*(RoReg  *)0x4003C0E8UL) /**< \brief (DACC) Write Protect Status Register */
+#define REG_DACC_VERSION           (*(RoReg  *)0x4003C0FCUL) /**< \brief (DACC) Version Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for DACC peripheral ========== */
+#define DACC_DACC_EXT_TRIG_MSB      0       
+#define DACC_DAC_RES_MSB            9       
+#define DACC_PDCA_ID_TX             35      
+
+#endif /* _SAM4L_DACC_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/eic.h
+++ b/asf/sam/include/sam4l/instance/eic.h
@@ -1,0 +1,78 @@
+/**
+ * \file
+ *
+ * \brief Instance description for EIC
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_EIC_INSTANCE_
+#define _SAM4L_EIC_INSTANCE_
+
+/* ========== Register definition for EIC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_EIC_IER                (0x400F1000) /**< \brief (EIC) Interrupt Enable Register */
+#define REG_EIC_IDR                (0x400F1004) /**< \brief (EIC) Interrupt Disable Register */
+#define REG_EIC_IMR                (0x400F1008) /**< \brief (EIC) Interrupt Mask Register */
+#define REG_EIC_ISR                (0x400F100C) /**< \brief (EIC) Interrupt Status Register */
+#define REG_EIC_ICR                (0x400F1010) /**< \brief (EIC) Interrupt Clear Register */
+#define REG_EIC_MODE               (0x400F1014) /**< \brief (EIC) Mode Register */
+#define REG_EIC_EDGE               (0x400F1018) /**< \brief (EIC) Edge Register */
+#define REG_EIC_LEVEL              (0x400F101C) /**< \brief (EIC) Level Register */
+#define REG_EIC_FILTER             (0x400F1020) /**< \brief (EIC) Filter Register */
+#define REG_EIC_ASYNC              (0x400F1028) /**< \brief (EIC) Asynchronous Register */
+#define REG_EIC_EN                 (0x400F1030) /**< \brief (EIC) Enable Register */
+#define REG_EIC_DIS                (0x400F1034) /**< \brief (EIC) Disable Register */
+#define REG_EIC_CTRL               (0x400F1038) /**< \brief (EIC) Control Register */
+#define REG_EIC_VERSION            (0x400F13FC) /**< \brief (EIC) Version Register */
+#else
+#define REG_EIC_IER                (*(WoReg  *)0x400F1000UL) /**< \brief (EIC) Interrupt Enable Register */
+#define REG_EIC_IDR                (*(WoReg  *)0x400F1004UL) /**< \brief (EIC) Interrupt Disable Register */
+#define REG_EIC_IMR                (*(RoReg  *)0x400F1008UL) /**< \brief (EIC) Interrupt Mask Register */
+#define REG_EIC_ISR                (*(RoReg  *)0x400F100CUL) /**< \brief (EIC) Interrupt Status Register */
+#define REG_EIC_ICR                (*(WoReg  *)0x400F1010UL) /**< \brief (EIC) Interrupt Clear Register */
+#define REG_EIC_MODE               (*(RwReg  *)0x400F1014UL) /**< \brief (EIC) Mode Register */
+#define REG_EIC_EDGE               (*(RwReg  *)0x400F1018UL) /**< \brief (EIC) Edge Register */
+#define REG_EIC_LEVEL              (*(RwReg  *)0x400F101CUL) /**< \brief (EIC) Level Register */
+#define REG_EIC_FILTER             (*(RwReg  *)0x400F1020UL) /**< \brief (EIC) Filter Register */
+#define REG_EIC_ASYNC              (*(RwReg  *)0x400F1028UL) /**< \brief (EIC) Asynchronous Register */
+#define REG_EIC_EN                 (*(WoReg  *)0x400F1030UL) /**< \brief (EIC) Enable Register */
+#define REG_EIC_DIS                (*(WoReg  *)0x400F1034UL) /**< \brief (EIC) Disable Register */
+#define REG_EIC_CTRL               (*(RoReg  *)0x400F1038UL) /**< \brief (EIC) Control Register */
+#define REG_EIC_VERSION            (*(RoReg  *)0x400F13FCUL) /**< \brief (EIC) Version Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for EIC peripheral ========== */
+#define EIC_STD_NUM                 8       
+#define EIC_EIC_EDGE_IRQ            0       
+#define EIC_EIC_FALLING_EDGE        0       
+#define EIC_EIC_FILTER_OFF          0       
+#define EIC_EIC_FILTER_ON           1       
+#define EIC_EIC_HIGH_LEVEL          1       
+#define EIC_EIC_LEVEL_IRQ           1       
+#define EIC_EIC_LOW_LEVEL           0       
+#define EIC_EIC_RISING_EDGE         1       
+#define EIC_EIC_SYNC                0       
+#define EIC_EIC_USE_ASYNC           1       
+
+#endif /* _SAM4L_EIC_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/freqm.h
+++ b/asf/sam/include/sam4l/instance/freqm.h
@@ -1,0 +1,91 @@
+/**
+ * \file
+ *
+ * \brief Instance description for FREQM
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_FREQM_INSTANCE_
+#define _SAM4L_FREQM_INSTANCE_
+
+/* ========== Register definition for FREQM peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_FREQM_CTRL             (0x400E0C00) /**< \brief (FREQM) Control register */
+#define REG_FREQM_MODE             (0x400E0C04) /**< \brief (FREQM) Mode  register */
+#define REG_FREQM_STATUS           (0x400E0C08) /**< \brief (FREQM) Status  register */
+#define REG_FREQM_VALUE            (0x400E0C0C) /**< \brief (FREQM) Value register */
+#define REG_FREQM_IER              (0x400E0C10) /**< \brief (FREQM) Interrupt Enable Register */
+#define REG_FREQM_IDR              (0x400E0C14) /**< \brief (FREQM) Interrupt Diable Register */
+#define REG_FREQM_IMR              (0x400E0C18) /**< \brief (FREQM) Interrupt Mask Register */
+#define REG_FREQM_ISR              (0x400E0C1C) /**< \brief (FREQM) Interrupt Status Register */
+#define REG_FREQM_ICR              (0x400E0C20) /**< \brief (FREQM) Interrupt Clear Register */
+#define REG_FREQM_VERSION          (0x400E0FFC) /**< \brief (FREQM) Version Register */
+#else
+#define REG_FREQM_CTRL             (*(WoReg  *)0x400E0C00UL) /**< \brief (FREQM) Control register */
+#define REG_FREQM_MODE             (*(RwReg  *)0x400E0C04UL) /**< \brief (FREQM) Mode  register */
+#define REG_FREQM_STATUS           (*(RoReg  *)0x400E0C08UL) /**< \brief (FREQM) Status  register */
+#define REG_FREQM_VALUE            (*(RoReg  *)0x400E0C0CUL) /**< \brief (FREQM) Value register */
+#define REG_FREQM_IER              (*(WoReg  *)0x400E0C10UL) /**< \brief (FREQM) Interrupt Enable Register */
+#define REG_FREQM_IDR              (*(WoReg  *)0x400E0C14UL) /**< \brief (FREQM) Interrupt Diable Register */
+#define REG_FREQM_IMR              (*(RoReg  *)0x400E0C18UL) /**< \brief (FREQM) Interrupt Mask Register */
+#define REG_FREQM_ISR              (*(RoReg  *)0x400E0C1CUL) /**< \brief (FREQM) Interrupt Status Register */
+#define REG_FREQM_ICR              (*(WoReg  *)0x400E0C20UL) /**< \brief (FREQM) Interrupt Clear Register */
+#define REG_FREQM_VERSION          (*(RoReg  *)0x400E0FFCUL) /**< \brief (FREQM) Version Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for FREQM peripheral ========== */
+#define FREQM_CPU                   0       
+#define FREQM_CRIPOSC               10      
+#define FREQM_DFLL0                 9       
+#define FREQM_FLO_JITTER            27      
+#define FREQM_GENCLK0               11      
+#define FREQM_GENCLK1               12      
+#define FREQM_GENCLK2               13      
+#define FREQM_GENCLK3               14      
+#define FREQM_GENCLK4               15      
+#define FREQM_GENCLK5               16      
+#define FREQM_GENCLK6               17      
+#define FREQM_GENCLK7               18      
+#define FREQM_GENCLK8               19      
+#define FREQM_GENCLK9               20      
+#define FREQM_GENCLK10              21      
+#define FREQM_HSB                   1       
+#define FREQM_NUM_CLK               28      
+#define FREQM_NUM_REF_CLK           4       
+#define FREQM_OSC0                  6       
+#define FREQM_OSC32                 7       
+#define FREQM_PBA                   2       
+#define FREQM_PBB                   3       
+#define FREQM_PBC                   4       
+#define FREQM_PLL0                  26      
+#define FREQM_RCFAST                24      
+#define FREQM_RCOSC                 8       
+#define FREQM_RC1M                  25      
+#define FREQM_RC32K                 7       
+#define FREQM_RC80M                 23      
+#define FREQM_REFSEL_BITS           2       
+#define FREQM_REF_OSC32             1       
+#define FREQM_REF_RCOSC             0       
+
+#endif /* _SAM4L_FREQM_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/gloc.h
+++ b/asf/sam/include/sam4l/instance/gloc.h
@@ -1,0 +1,53 @@
+/**
+ * \file
+ *
+ * \brief Instance description for GLOC
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_GLOC_INSTANCE_
+#define _SAM4L_GLOC_INSTANCE_
+
+/* ========== Register definition for GLOC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_GLOC_CR0               (0x40060000) /**< \brief (GLOC) Control Register 0 */
+#define REG_GLOC_TRUTH0            (0x40060004) /**< \brief (GLOC) Truth Register 0 */
+#define REG_GLOC_CR1               (0x40060008) /**< \brief (GLOC) Control Register 1 */
+#define REG_GLOC_TRUTH1            (0x4006000C) /**< \brief (GLOC) Truth Register 1 */
+#define REG_GLOC_PARAMETER         (0x40060038) /**< \brief (GLOC) Parameter Register */
+#define REG_GLOC_VERSION           (0x4006003C) /**< \brief (GLOC) Version Register */
+#else
+#define REG_GLOC_CR0               (*(RwReg  *)0x40060000UL) /**< \brief (GLOC) Control Register 0 */
+#define REG_GLOC_TRUTH0            (*(RwReg  *)0x40060004UL) /**< \brief (GLOC) Truth Register 0 */
+#define REG_GLOC_CR1               (*(RwReg  *)0x40060008UL) /**< \brief (GLOC) Control Register 1 */
+#define REG_GLOC_TRUTH1            (*(RwReg  *)0x4006000CUL) /**< \brief (GLOC) Truth Register 1 */
+#define REG_GLOC_PARAMETER         (*(RoReg  *)0x40060038UL) /**< \brief (GLOC) Parameter Register */
+#define REG_GLOC_VERSION           (*(RoReg  *)0x4006003CUL) /**< \brief (GLOC) Version Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for GLOC peripheral ========== */
+#define GLOC_GCLK_NUM               5       
+#define GLOC_LUTS                   2       
+
+#endif /* _SAM4L_GLOC_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/gpio.h
+++ b/asf/sam/include/sam4l/instance/gpio.h
@@ -1,0 +1,586 @@
+/**
+ * \file
+ *
+ * \brief Instance description for GPIO
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_GPIO_INSTANCE_
+#define _SAM4L_GPIO_INSTANCE_
+
+/* ========== Register definition for GPIO peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_GPIO_GPER0             (0x400E1000) /**< \brief (GPIO) GPIO Enable Register 0 */
+#define REG_GPIO_GPERS0            (0x400E1004) /**< \brief (GPIO) GPIO Enable Register - Set 0 */
+#define REG_GPIO_GPERC0            (0x400E1008) /**< \brief (GPIO) GPIO Enable Register - Clear 0 */
+#define REG_GPIO_GPERT0            (0x400E100C) /**< \brief (GPIO) GPIO Enable Register - Toggle 0 */
+#define REG_GPIO_PMR00             (0x400E1010) /**< \brief (GPIO) Peripheral Mux Register 0 0 */
+#define REG_GPIO_PMR0S0            (0x400E1014) /**< \brief (GPIO) Peripheral Mux Register 0 - Set 0 */
+#define REG_GPIO_PMR0C0            (0x400E1018) /**< \brief (GPIO) Peripheral Mux Register 0 - Clear 0 */
+#define REG_GPIO_PMR0T0            (0x400E101C) /**< \brief (GPIO) Peripheral Mux Register 0 - Toggle 0 */
+#define REG_GPIO_PMR10             (0x400E1020) /**< \brief (GPIO) Peripheral Mux Register 1 0 */
+#define REG_GPIO_PMR1S0            (0x400E1024) /**< \brief (GPIO) Peripheral Mux Register 1 - Set 0 */
+#define REG_GPIO_PMR1C0            (0x400E1028) /**< \brief (GPIO) Peripheral Mux Register 1 - Clear 0 */
+#define REG_GPIO_PMR1T0            (0x400E102C) /**< \brief (GPIO) Peripheral Mux Register 1 - Toggle 0 */
+#define REG_GPIO_PMR20             (0x400E1030) /**< \brief (GPIO) Peripheral Mux Register 2 0 */
+#define REG_GPIO_PMR2S0            (0x400E1034) /**< \brief (GPIO) Peripheral Mux Register 2 - Set 0 */
+#define REG_GPIO_PMR2C0            (0x400E1038) /**< \brief (GPIO) Peripheral Mux Register 2 - Clear 0 */
+#define REG_GPIO_PMR2T0            (0x400E103C) /**< \brief (GPIO) Peripheral Mux Register 2 - Toggle 0 */
+#define REG_GPIO_ODER0             (0x400E1040) /**< \brief (GPIO) Output Driver Enable Register 0 */
+#define REG_GPIO_ODERS0            (0x400E1044) /**< \brief (GPIO) Output Driver Enable Register - Set 0 */
+#define REG_GPIO_ODERC0            (0x400E1048) /**< \brief (GPIO) Output Driver Enable Register - Clear 0 */
+#define REG_GPIO_ODERT0            (0x400E104C) /**< \brief (GPIO) Output Driver Enable Register - Toggle 0 */
+#define REG_GPIO_OVR0              (0x400E1050) /**< \brief (GPIO) Output Value Register 0 */
+#define REG_GPIO_OVRS0             (0x400E1054) /**< \brief (GPIO) Output Value Register - Set 0 */
+#define REG_GPIO_OVRC0             (0x400E1058) /**< \brief (GPIO) Output Value Register - Clear 0 */
+#define REG_GPIO_OVRT0             (0x400E105C) /**< \brief (GPIO) Output Value Register - Toggle 0 */
+#define REG_GPIO_PVR0              (0x400E1060) /**< \brief (GPIO) Pin Value Register 0 */
+#define REG_GPIO_PUER0             (0x400E1070) /**< \brief (GPIO) Pull-up Enable Register 0 */
+#define REG_GPIO_PUERS0            (0x400E1074) /**< \brief (GPIO) Pull-up Enable Register - Set 0 */
+#define REG_GPIO_PUERC0            (0x400E1078) /**< \brief (GPIO) Pull-up Enable Register - Clear 0 */
+#define REG_GPIO_PUERT0            (0x400E107C) /**< \brief (GPIO) Pull-up Enable Register - Toggle 0 */
+#define REG_GPIO_PDER0             (0x400E1080) /**< \brief (GPIO) Pull-down Enable Register 0 */
+#define REG_GPIO_PDERS0            (0x400E1084) /**< \brief (GPIO) Pull-down Enable Register - Set 0 */
+#define REG_GPIO_PDERC0            (0x400E1088) /**< \brief (GPIO) Pull-down Enable Register - Clear 0 */
+#define REG_GPIO_PDERT0            (0x400E108C) /**< \brief (GPIO) Pull-down Enable Register - Toggle 0 */
+#define REG_GPIO_IER0              (0x400E1090) /**< \brief (GPIO) Interrupt Enable Register 0 */
+#define REG_GPIO_IERS0             (0x400E1094) /**< \brief (GPIO) Interrupt Enable Register - Set 0 */
+#define REG_GPIO_IERC0             (0x400E1098) /**< \brief (GPIO) Interrupt Enable Register - Clear 0 */
+#define REG_GPIO_IERT0             (0x400E109C) /**< \brief (GPIO) Interrupt Enable Register - Toggle 0 */
+#define REG_GPIO_IMR00             (0x400E10A0) /**< \brief (GPIO) Interrupt Mode Register 0 0 */
+#define REG_GPIO_IMR0S0            (0x400E10A4) /**< \brief (GPIO) Interrupt Mode Register 0 - Set 0 */
+#define REG_GPIO_IMR0C0            (0x400E10A8) /**< \brief (GPIO) Interrupt Mode Register 0 - Clear 0 */
+#define REG_GPIO_IMR0T0            (0x400E10AC) /**< \brief (GPIO) Interrupt Mode Register 0 - Toggle 0 */
+#define REG_GPIO_IMR10             (0x400E10B0) /**< \brief (GPIO) Interrupt Mode Register 1 0 */
+#define REG_GPIO_IMR1S0            (0x400E10B4) /**< \brief (GPIO) Interrupt Mode Register 1 - Set 0 */
+#define REG_GPIO_IMR1C0            (0x400E10B8) /**< \brief (GPIO) Interrupt Mode Register 1 - Clear 0 */
+#define REG_GPIO_IMR1T0            (0x400E10BC) /**< \brief (GPIO) Interrupt Mode Register 1 - Toggle 0 */
+#define REG_GPIO_GFER0             (0x400E10C0) /**< \brief (GPIO) Glitch Filter Enable Register 0 */
+#define REG_GPIO_GFERS0            (0x400E10C4) /**< \brief (GPIO) Glitch Filter Enable Register - Set 0 */
+#define REG_GPIO_GFERC0            (0x400E10C8) /**< \brief (GPIO) Glitch Filter Enable Register - Clear 0 */
+#define REG_GPIO_GFERT0            (0x400E10CC) /**< \brief (GPIO) Glitch Filter Enable Register - Toggle 0 */
+#define REG_GPIO_IFR0              (0x400E10D0) /**< \brief (GPIO) Interrupt Flag Register 0 */
+#define REG_GPIO_IFRC0             (0x400E10D8) /**< \brief (GPIO) Interrupt Flag Register - Clear 0 */
+#define REG_GPIO_ODMER0            (0x400E10E0) /**< \brief (GPIO) Open Drain Mode Register 0 */
+#define REG_GPIO_ODMERS0           (0x400E10E4) /**< \brief (GPIO) Open Drain Mode Register - Set 0 */
+#define REG_GPIO_ODMERC0           (0x400E10E8) /**< \brief (GPIO) Open Drain Mode Register - Clear 0 */
+#define REG_GPIO_ODMERT0           (0x400E10EC) /**< \brief (GPIO) Open Drain Mode Register - Toggle 0 */
+#define REG_GPIO_ODCR00            (0x400E1100) /**< \brief (GPIO) Output Driving Capability Register 0 0 */
+#define REG_GPIO_ODCR0S0           (0x400E1104) /**< \brief (GPIO) Output Driving Capability Register 0 - Set 0 */
+#define REG_GPIO_ODCR0C0           (0x400E1108) /**< \brief (GPIO) Output Driving Capability Register 0 - Clear 0 */
+#define REG_GPIO_ODCR0T0           (0x400E110C) /**< \brief (GPIO) Output Driving Capability Register 0 - Toggle 0 */
+#define REG_GPIO_ODCR10            (0x400E1110) /**< \brief (GPIO) Output Driving Capability Register 1 0 */
+#define REG_GPIO_ODCR1S0           (0x400E1114) /**< \brief (GPIO) Output Driving Capability Register 1 - Set 0 */
+#define REG_GPIO_ODCR1C0           (0x400E1118) /**< \brief (GPIO) Output Driving Capability Register 1 - Clear 0 */
+#define REG_GPIO_ODCR1T0           (0x400E111C) /**< \brief (GPIO) Output Driving Capability Register 1 - Toggle 0 */
+#define REG_GPIO_OSRR00            (0x400E1130) /**< \brief (GPIO) Output Slew Rate Register 0 0 */
+#define REG_GPIO_OSRR0S0           (0x400E1134) /**< \brief (GPIO) Output Slew Rate Register 0 - Set 0 */
+#define REG_GPIO_OSRR0C0           (0x400E1138) /**< \brief (GPIO) Output Slew Rate Register 0 - Clear 0 */
+#define REG_GPIO_OSRR0T0           (0x400E113C) /**< \brief (GPIO) Output Slew Rate Register 0 - Toggle 0 */
+#define REG_GPIO_STER0             (0x400E1160) /**< \brief (GPIO) Schmitt Trigger Enable Register 0 */
+#define REG_GPIO_STERS0            (0x400E1164) /**< \brief (GPIO) Schmitt Trigger Enable Register - Set 0 */
+#define REG_GPIO_STERC0            (0x400E1168) /**< \brief (GPIO) Schmitt Trigger Enable Register - Clear 0 */
+#define REG_GPIO_STERT0            (0x400E116C) /**< \brief (GPIO) Schmitt Trigger Enable Register - Toggle 0 */
+#define REG_GPIO_EVER0             (0x400E1180) /**< \brief (GPIO) Event Enable Register 0 */
+#define REG_GPIO_EVERS0            (0x400E1184) /**< \brief (GPIO) Event Enable Register - Set 0 */
+#define REG_GPIO_EVERC0            (0x400E1188) /**< \brief (GPIO) Event Enable Register - Clear 0 */
+#define REG_GPIO_EVERT0            (0x400E118C) /**< \brief (GPIO) Event Enable Register - Toggle 0 */
+#define REG_GPIO_LOCK0             (0x400E11A0) /**< \brief (GPIO) Lock Register 0 */
+#define REG_GPIO_LOCKS0            (0x400E11A4) /**< \brief (GPIO) Lock Register - Set 0 */
+#define REG_GPIO_LOCKC0            (0x400E11A8) /**< \brief (GPIO) Lock Register - Clear 0 */
+#define REG_GPIO_LOCKT0            (0x400E11AC) /**< \brief (GPIO) Lock Register - Toggle 0 */
+#define REG_GPIO_UNLOCK0           (0x400E11E0) /**< \brief (GPIO) Unlock Register 0 */
+#define REG_GPIO_ASR0              (0x400E11E4) /**< \brief (GPIO) Access Status Register 0 */
+#define REG_GPIO_PARAMETER0        (0x400E11F8) /**< \brief (GPIO) Parameter Register 0 */
+#define REG_GPIO_VERSION0          (0x400E11FC) /**< \brief (GPIO) Version Register 0 */
+#define REG_GPIO_GPER1             (0x400E1200) /**< \brief (GPIO) GPIO Enable Register 1 */
+#define REG_GPIO_GPERS1            (0x400E1204) /**< \brief (GPIO) GPIO Enable Register - Set 1 */
+#define REG_GPIO_GPERC1            (0x400E1208) /**< \brief (GPIO) GPIO Enable Register - Clear 1 */
+#define REG_GPIO_GPERT1            (0x400E120C) /**< \brief (GPIO) GPIO Enable Register - Toggle 1 */
+#define REG_GPIO_PMR01             (0x400E1210) /**< \brief (GPIO) Peripheral Mux Register 0 1 */
+#define REG_GPIO_PMR0S1            (0x400E1214) /**< \brief (GPIO) Peripheral Mux Register 0 - Set 1 */
+#define REG_GPIO_PMR0C1            (0x400E1218) /**< \brief (GPIO) Peripheral Mux Register 0 - Clear 1 */
+#define REG_GPIO_PMR0T1            (0x400E121C) /**< \brief (GPIO) Peripheral Mux Register 0 - Toggle 1 */
+#define REG_GPIO_PMR11             (0x400E1220) /**< \brief (GPIO) Peripheral Mux Register 1 1 */
+#define REG_GPIO_PMR1S1            (0x400E1224) /**< \brief (GPIO) Peripheral Mux Register 1 - Set 1 */
+#define REG_GPIO_PMR1C1            (0x400E1228) /**< \brief (GPIO) Peripheral Mux Register 1 - Clear 1 */
+#define REG_GPIO_PMR1T1            (0x400E122C) /**< \brief (GPIO) Peripheral Mux Register 1 - Toggle 1 */
+#define REG_GPIO_PMR21             (0x400E1230) /**< \brief (GPIO) Peripheral Mux Register 2 1 */
+#define REG_GPIO_PMR2S1            (0x400E1234) /**< \brief (GPIO) Peripheral Mux Register 2 - Set 1 */
+#define REG_GPIO_PMR2C1            (0x400E1238) /**< \brief (GPIO) Peripheral Mux Register 2 - Clear 1 */
+#define REG_GPIO_PMR2T1            (0x400E123C) /**< \brief (GPIO) Peripheral Mux Register 2 - Toggle 1 */
+#define REG_GPIO_ODER1             (0x400E1240) /**< \brief (GPIO) Output Driver Enable Register 1 */
+#define REG_GPIO_ODERS1            (0x400E1244) /**< \brief (GPIO) Output Driver Enable Register - Set 1 */
+#define REG_GPIO_ODERC1            (0x400E1248) /**< \brief (GPIO) Output Driver Enable Register - Clear 1 */
+#define REG_GPIO_ODERT1            (0x400E124C) /**< \brief (GPIO) Output Driver Enable Register - Toggle 1 */
+#define REG_GPIO_OVR1              (0x400E1250) /**< \brief (GPIO) Output Value Register 1 */
+#define REG_GPIO_OVRS1             (0x400E1254) /**< \brief (GPIO) Output Value Register - Set 1 */
+#define REG_GPIO_OVRC1             (0x400E1258) /**< \brief (GPIO) Output Value Register - Clear 1 */
+#define REG_GPIO_OVRT1             (0x400E125C) /**< \brief (GPIO) Output Value Register - Toggle 1 */
+#define REG_GPIO_PVR1              (0x400E1260) /**< \brief (GPIO) Pin Value Register 1 */
+#define REG_GPIO_PUER1             (0x400E1270) /**< \brief (GPIO) Pull-up Enable Register 1 */
+#define REG_GPIO_PUERS1            (0x400E1274) /**< \brief (GPIO) Pull-up Enable Register - Set 1 */
+#define REG_GPIO_PUERC1            (0x400E1278) /**< \brief (GPIO) Pull-up Enable Register - Clear 1 */
+#define REG_GPIO_PUERT1            (0x400E127C) /**< \brief (GPIO) Pull-up Enable Register - Toggle 1 */
+#define REG_GPIO_PDER1             (0x400E1280) /**< \brief (GPIO) Pull-down Enable Register 1 */
+#define REG_GPIO_PDERS1            (0x400E1284) /**< \brief (GPIO) Pull-down Enable Register - Set 1 */
+#define REG_GPIO_PDERC1            (0x400E1288) /**< \brief (GPIO) Pull-down Enable Register - Clear 1 */
+#define REG_GPIO_PDERT1            (0x400E128C) /**< \brief (GPIO) Pull-down Enable Register - Toggle 1 */
+#define REG_GPIO_IER1              (0x400E1290) /**< \brief (GPIO) Interrupt Enable Register 1 */
+#define REG_GPIO_IERS1             (0x400E1294) /**< \brief (GPIO) Interrupt Enable Register - Set 1 */
+#define REG_GPIO_IERC1             (0x400E1298) /**< \brief (GPIO) Interrupt Enable Register - Clear 1 */
+#define REG_GPIO_IERT1             (0x400E129C) /**< \brief (GPIO) Interrupt Enable Register - Toggle 1 */
+#define REG_GPIO_IMR01             (0x400E12A0) /**< \brief (GPIO) Interrupt Mode Register 0 1 */
+#define REG_GPIO_IMR0S1            (0x400E12A4) /**< \brief (GPIO) Interrupt Mode Register 0 - Set 1 */
+#define REG_GPIO_IMR0C1            (0x400E12A8) /**< \brief (GPIO) Interrupt Mode Register 0 - Clear 1 */
+#define REG_GPIO_IMR0T1            (0x400E12AC) /**< \brief (GPIO) Interrupt Mode Register 0 - Toggle 1 */
+#define REG_GPIO_IMR11             (0x400E12B0) /**< \brief (GPIO) Interrupt Mode Register 1 1 */
+#define REG_GPIO_IMR1S1            (0x400E12B4) /**< \brief (GPIO) Interrupt Mode Register 1 - Set 1 */
+#define REG_GPIO_IMR1C1            (0x400E12B8) /**< \brief (GPIO) Interrupt Mode Register 1 - Clear 1 */
+#define REG_GPIO_IMR1T1            (0x400E12BC) /**< \brief (GPIO) Interrupt Mode Register 1 - Toggle 1 */
+#define REG_GPIO_GFER1             (0x400E12C0) /**< \brief (GPIO) Glitch Filter Enable Register 1 */
+#define REG_GPIO_GFERS1            (0x400E12C4) /**< \brief (GPIO) Glitch Filter Enable Register - Set 1 */
+#define REG_GPIO_GFERC1            (0x400E12C8) /**< \brief (GPIO) Glitch Filter Enable Register - Clear 1 */
+#define REG_GPIO_GFERT1            (0x400E12CC) /**< \brief (GPIO) Glitch Filter Enable Register - Toggle 1 */
+#define REG_GPIO_IFR1              (0x400E12D0) /**< \brief (GPIO) Interrupt Flag Register 1 */
+#define REG_GPIO_IFRC1             (0x400E12D8) /**< \brief (GPIO) Interrupt Flag Register - Clear 1 */
+#define REG_GPIO_ODMER1            (0x400E12E0) /**< \brief (GPIO) Open Drain Mode Register 1 */
+#define REG_GPIO_ODMERS1           (0x400E12E4) /**< \brief (GPIO) Open Drain Mode Register - Set 1 */
+#define REG_GPIO_ODMERC1           (0x400E12E8) /**< \brief (GPIO) Open Drain Mode Register - Clear 1 */
+#define REG_GPIO_ODMERT1           (0x400E12EC) /**< \brief (GPIO) Open Drain Mode Register - Toggle 1 */
+#define REG_GPIO_ODCR01            (0x400E1300) /**< \brief (GPIO) Output Driving Capability Register 0 1 */
+#define REG_GPIO_ODCR0S1           (0x400E1304) /**< \brief (GPIO) Output Driving Capability Register 0 - Set 1 */
+#define REG_GPIO_ODCR0C1           (0x400E1308) /**< \brief (GPIO) Output Driving Capability Register 0 - Clear 1 */
+#define REG_GPIO_ODCR0T1           (0x400E130C) /**< \brief (GPIO) Output Driving Capability Register 0 - Toggle 1 */
+#define REG_GPIO_ODCR11            (0x400E1310) /**< \brief (GPIO) Output Driving Capability Register 1 1 */
+#define REG_GPIO_ODCR1S1           (0x400E1314) /**< \brief (GPIO) Output Driving Capability Register 1 - Set 1 */
+#define REG_GPIO_ODCR1C1           (0x400E1318) /**< \brief (GPIO) Output Driving Capability Register 1 - Clear 1 */
+#define REG_GPIO_ODCR1T1           (0x400E131C) /**< \brief (GPIO) Output Driving Capability Register 1 - Toggle 1 */
+#define REG_GPIO_OSRR01            (0x400E1330) /**< \brief (GPIO) Output Slew Rate Register 0 1 */
+#define REG_GPIO_OSRR0S1           (0x400E1334) /**< \brief (GPIO) Output Slew Rate Register 0 - Set 1 */
+#define REG_GPIO_OSRR0C1           (0x400E1338) /**< \brief (GPIO) Output Slew Rate Register 0 - Clear 1 */
+#define REG_GPIO_OSRR0T1           (0x400E133C) /**< \brief (GPIO) Output Slew Rate Register 0 - Toggle 1 */
+#define REG_GPIO_STER1             (0x400E1360) /**< \brief (GPIO) Schmitt Trigger Enable Register 1 */
+#define REG_GPIO_STERS1            (0x400E1364) /**< \brief (GPIO) Schmitt Trigger Enable Register - Set 1 */
+#define REG_GPIO_STERC1            (0x400E1368) /**< \brief (GPIO) Schmitt Trigger Enable Register - Clear 1 */
+#define REG_GPIO_STERT1            (0x400E136C) /**< \brief (GPIO) Schmitt Trigger Enable Register - Toggle 1 */
+#define REG_GPIO_EVER1             (0x400E1380) /**< \brief (GPIO) Event Enable Register 1 */
+#define REG_GPIO_EVERS1            (0x400E1384) /**< \brief (GPIO) Event Enable Register - Set 1 */
+#define REG_GPIO_EVERC1            (0x400E1388) /**< \brief (GPIO) Event Enable Register - Clear 1 */
+#define REG_GPIO_EVERT1            (0x400E138C) /**< \brief (GPIO) Event Enable Register - Toggle 1 */
+#define REG_GPIO_LOCK1             (0x400E13A0) /**< \brief (GPIO) Lock Register 1 */
+#define REG_GPIO_LOCKS1            (0x400E13A4) /**< \brief (GPIO) Lock Register - Set 1 */
+#define REG_GPIO_LOCKC1            (0x400E13A8) /**< \brief (GPIO) Lock Register - Clear 1 */
+#define REG_GPIO_LOCKT1            (0x400E13AC) /**< \brief (GPIO) Lock Register - Toggle 1 */
+#define REG_GPIO_UNLOCK1           (0x400E13E0) /**< \brief (GPIO) Unlock Register 1 */
+#define REG_GPIO_ASR1              (0x400E13E4) /**< \brief (GPIO) Access Status Register 1 */
+#define REG_GPIO_PARAMETER1        (0x400E13F8) /**< \brief (GPIO) Parameter Register 1 */
+#define REG_GPIO_VERSION1          (0x400E13FC) /**< \brief (GPIO) Version Register 1 */
+#define REG_GPIO_GPER2             (0x400E1400) /**< \brief (GPIO) GPIO Enable Register 2 */
+#define REG_GPIO_GPERS2            (0x400E1404) /**< \brief (GPIO) GPIO Enable Register - Set 2 */
+#define REG_GPIO_GPERC2            (0x400E1408) /**< \brief (GPIO) GPIO Enable Register - Clear 2 */
+#define REG_GPIO_GPERT2            (0x400E140C) /**< \brief (GPIO) GPIO Enable Register - Toggle 2 */
+#define REG_GPIO_PMR02             (0x400E1410) /**< \brief (GPIO) Peripheral Mux Register 0 2 */
+#define REG_GPIO_PMR0S2            (0x400E1414) /**< \brief (GPIO) Peripheral Mux Register 0 - Set 2 */
+#define REG_GPIO_PMR0C2            (0x400E1418) /**< \brief (GPIO) Peripheral Mux Register 0 - Clear 2 */
+#define REG_GPIO_PMR0T2            (0x400E141C) /**< \brief (GPIO) Peripheral Mux Register 0 - Toggle 2 */
+#define REG_GPIO_PMR12             (0x400E1420) /**< \brief (GPIO) Peripheral Mux Register 1 2 */
+#define REG_GPIO_PMR1S2            (0x400E1424) /**< \brief (GPIO) Peripheral Mux Register 1 - Set 2 */
+#define REG_GPIO_PMR1C2            (0x400E1428) /**< \brief (GPIO) Peripheral Mux Register 1 - Clear 2 */
+#define REG_GPIO_PMR1T2            (0x400E142C) /**< \brief (GPIO) Peripheral Mux Register 1 - Toggle 2 */
+#define REG_GPIO_PMR22             (0x400E1430) /**< \brief (GPIO) Peripheral Mux Register 2 2 */
+#define REG_GPIO_PMR2S2            (0x400E1434) /**< \brief (GPIO) Peripheral Mux Register 2 - Set 2 */
+#define REG_GPIO_PMR2C2            (0x400E1438) /**< \brief (GPIO) Peripheral Mux Register 2 - Clear 2 */
+#define REG_GPIO_PMR2T2            (0x400E143C) /**< \brief (GPIO) Peripheral Mux Register 2 - Toggle 2 */
+#define REG_GPIO_ODER2             (0x400E1440) /**< \brief (GPIO) Output Driver Enable Register 2 */
+#define REG_GPIO_ODERS2            (0x400E1444) /**< \brief (GPIO) Output Driver Enable Register - Set 2 */
+#define REG_GPIO_ODERC2            (0x400E1448) /**< \brief (GPIO) Output Driver Enable Register - Clear 2 */
+#define REG_GPIO_ODERT2            (0x400E144C) /**< \brief (GPIO) Output Driver Enable Register - Toggle 2 */
+#define REG_GPIO_OVR2              (0x400E1450) /**< \brief (GPIO) Output Value Register 2 */
+#define REG_GPIO_OVRS2             (0x400E1454) /**< \brief (GPIO) Output Value Register - Set 2 */
+#define REG_GPIO_OVRC2             (0x400E1458) /**< \brief (GPIO) Output Value Register - Clear 2 */
+#define REG_GPIO_OVRT2             (0x400E145C) /**< \brief (GPIO) Output Value Register - Toggle 2 */
+#define REG_GPIO_PVR2              (0x400E1460) /**< \brief (GPIO) Pin Value Register 2 */
+#define REG_GPIO_PUER2             (0x400E1470) /**< \brief (GPIO) Pull-up Enable Register 2 */
+#define REG_GPIO_PUERS2            (0x400E1474) /**< \brief (GPIO) Pull-up Enable Register - Set 2 */
+#define REG_GPIO_PUERC2            (0x400E1478) /**< \brief (GPIO) Pull-up Enable Register - Clear 2 */
+#define REG_GPIO_PUERT2            (0x400E147C) /**< \brief (GPIO) Pull-up Enable Register - Toggle 2 */
+#define REG_GPIO_PDER2             (0x400E1480) /**< \brief (GPIO) Pull-down Enable Register 2 */
+#define REG_GPIO_PDERS2            (0x400E1484) /**< \brief (GPIO) Pull-down Enable Register - Set 2 */
+#define REG_GPIO_PDERC2            (0x400E1488) /**< \brief (GPIO) Pull-down Enable Register - Clear 2 */
+#define REG_GPIO_PDERT2            (0x400E148C) /**< \brief (GPIO) Pull-down Enable Register - Toggle 2 */
+#define REG_GPIO_IER2              (0x400E1490) /**< \brief (GPIO) Interrupt Enable Register 2 */
+#define REG_GPIO_IERS2             (0x400E1494) /**< \brief (GPIO) Interrupt Enable Register - Set 2 */
+#define REG_GPIO_IERC2             (0x400E1498) /**< \brief (GPIO) Interrupt Enable Register - Clear 2 */
+#define REG_GPIO_IERT2             (0x400E149C) /**< \brief (GPIO) Interrupt Enable Register - Toggle 2 */
+#define REG_GPIO_IMR02             (0x400E14A0) /**< \brief (GPIO) Interrupt Mode Register 0 2 */
+#define REG_GPIO_IMR0S2            (0x400E14A4) /**< \brief (GPIO) Interrupt Mode Register 0 - Set 2 */
+#define REG_GPIO_IMR0C2            (0x400E14A8) /**< \brief (GPIO) Interrupt Mode Register 0 - Clear 2 */
+#define REG_GPIO_IMR0T2            (0x400E14AC) /**< \brief (GPIO) Interrupt Mode Register 0 - Toggle 2 */
+#define REG_GPIO_IMR12             (0x400E14B0) /**< \brief (GPIO) Interrupt Mode Register 1 2 */
+#define REG_GPIO_IMR1S2            (0x400E14B4) /**< \brief (GPIO) Interrupt Mode Register 1 - Set 2 */
+#define REG_GPIO_IMR1C2            (0x400E14B8) /**< \brief (GPIO) Interrupt Mode Register 1 - Clear 2 */
+#define REG_GPIO_IMR1T2            (0x400E14BC) /**< \brief (GPIO) Interrupt Mode Register 1 - Toggle 2 */
+#define REG_GPIO_GFER2             (0x400E14C0) /**< \brief (GPIO) Glitch Filter Enable Register 2 */
+#define REG_GPIO_GFERS2            (0x400E14C4) /**< \brief (GPIO) Glitch Filter Enable Register - Set 2 */
+#define REG_GPIO_GFERC2            (0x400E14C8) /**< \brief (GPIO) Glitch Filter Enable Register - Clear 2 */
+#define REG_GPIO_GFERT2            (0x400E14CC) /**< \brief (GPIO) Glitch Filter Enable Register - Toggle 2 */
+#define REG_GPIO_IFR2              (0x400E14D0) /**< \brief (GPIO) Interrupt Flag Register 2 */
+#define REG_GPIO_IFRC2             (0x400E14D8) /**< \brief (GPIO) Interrupt Flag Register - Clear 2 */
+#define REG_GPIO_ODMER2            (0x400E14E0) /**< \brief (GPIO) Open Drain Mode Register 2 */
+#define REG_GPIO_ODMERS2           (0x400E14E4) /**< \brief (GPIO) Open Drain Mode Register - Set 2 */
+#define REG_GPIO_ODMERC2           (0x400E14E8) /**< \brief (GPIO) Open Drain Mode Register - Clear 2 */
+#define REG_GPIO_ODMERT2           (0x400E14EC) /**< \brief (GPIO) Open Drain Mode Register - Toggle 2 */
+#define REG_GPIO_ODCR02            (0x400E1500) /**< \brief (GPIO) Output Driving Capability Register 0 2 */
+#define REG_GPIO_ODCR0S2           (0x400E1504) /**< \brief (GPIO) Output Driving Capability Register 0 - Set 2 */
+#define REG_GPIO_ODCR0C2           (0x400E1508) /**< \brief (GPIO) Output Driving Capability Register 0 - Clear 2 */
+#define REG_GPIO_ODCR0T2           (0x400E150C) /**< \brief (GPIO) Output Driving Capability Register 0 - Toggle 2 */
+#define REG_GPIO_ODCR12            (0x400E1510) /**< \brief (GPIO) Output Driving Capability Register 1 2 */
+#define REG_GPIO_ODCR1S2           (0x400E1514) /**< \brief (GPIO) Output Driving Capability Register 1 - Set 2 */
+#define REG_GPIO_ODCR1C2           (0x400E1518) /**< \brief (GPIO) Output Driving Capability Register 1 - Clear 2 */
+#define REG_GPIO_ODCR1T2           (0x400E151C) /**< \brief (GPIO) Output Driving Capability Register 1 - Toggle 2 */
+#define REG_GPIO_OSRR02            (0x400E1530) /**< \brief (GPIO) Output Slew Rate Register 0 2 */
+#define REG_GPIO_OSRR0S2           (0x400E1534) /**< \brief (GPIO) Output Slew Rate Register 0 - Set 2 */
+#define REG_GPIO_OSRR0C2           (0x400E1538) /**< \brief (GPIO) Output Slew Rate Register 0 - Clear 2 */
+#define REG_GPIO_OSRR0T2           (0x400E153C) /**< \brief (GPIO) Output Slew Rate Register 0 - Toggle 2 */
+#define REG_GPIO_STER2             (0x400E1560) /**< \brief (GPIO) Schmitt Trigger Enable Register 2 */
+#define REG_GPIO_STERS2            (0x400E1564) /**< \brief (GPIO) Schmitt Trigger Enable Register - Set 2 */
+#define REG_GPIO_STERC2            (0x400E1568) /**< \brief (GPIO) Schmitt Trigger Enable Register - Clear 2 */
+#define REG_GPIO_STERT2            (0x400E156C) /**< \brief (GPIO) Schmitt Trigger Enable Register - Toggle 2 */
+#define REG_GPIO_EVER2             (0x400E1580) /**< \brief (GPIO) Event Enable Register 2 */
+#define REG_GPIO_EVERS2            (0x400E1584) /**< \brief (GPIO) Event Enable Register - Set 2 */
+#define REG_GPIO_EVERC2            (0x400E1588) /**< \brief (GPIO) Event Enable Register - Clear 2 */
+#define REG_GPIO_EVERT2            (0x400E158C) /**< \brief (GPIO) Event Enable Register - Toggle 2 */
+#define REG_GPIO_LOCK2             (0x400E15A0) /**< \brief (GPIO) Lock Register 2 */
+#define REG_GPIO_LOCKS2            (0x400E15A4) /**< \brief (GPIO) Lock Register - Set 2 */
+#define REG_GPIO_LOCKC2            (0x400E15A8) /**< \brief (GPIO) Lock Register - Clear 2 */
+#define REG_GPIO_LOCKT2            (0x400E15AC) /**< \brief (GPIO) Lock Register - Toggle 2 */
+#define REG_GPIO_UNLOCK2           (0x400E15E0) /**< \brief (GPIO) Unlock Register 2 */
+#define REG_GPIO_ASR2              (0x400E15E4) /**< \brief (GPIO) Access Status Register 2 */
+#define REG_GPIO_PARAMETER2        (0x400E15F8) /**< \brief (GPIO) Parameter Register 2 */
+#define REG_GPIO_VERSION2          (0x400E15FC) /**< \brief (GPIO) Version Register 2 */
+#else
+#define REG_GPIO_GPER0             (*(RwReg  *)0x400E1000UL) /**< \brief (GPIO) GPIO Enable Register 0 */
+#define REG_GPIO_GPERS0            (*(WoReg  *)0x400E1004UL) /**< \brief (GPIO) GPIO Enable Register - Set 0 */
+#define REG_GPIO_GPERC0            (*(WoReg  *)0x400E1008UL) /**< \brief (GPIO) GPIO Enable Register - Clear 0 */
+#define REG_GPIO_GPERT0            (*(WoReg  *)0x400E100CUL) /**< \brief (GPIO) GPIO Enable Register - Toggle 0 */
+#define REG_GPIO_PMR00             (*(RwReg  *)0x400E1010UL) /**< \brief (GPIO) Peripheral Mux Register 0 0 */
+#define REG_GPIO_PMR0S0            (*(WoReg  *)0x400E1014UL) /**< \brief (GPIO) Peripheral Mux Register 0 - Set 0 */
+#define REG_GPIO_PMR0C0            (*(WoReg  *)0x400E1018UL) /**< \brief (GPIO) Peripheral Mux Register 0 - Clear 0 */
+#define REG_GPIO_PMR0T0            (*(WoReg  *)0x400E101CUL) /**< \brief (GPIO) Peripheral Mux Register 0 - Toggle 0 */
+#define REG_GPIO_PMR10             (*(RwReg  *)0x400E1020UL) /**< \brief (GPIO) Peripheral Mux Register 1 0 */
+#define REG_GPIO_PMR1S0            (*(WoReg  *)0x400E1024UL) /**< \brief (GPIO) Peripheral Mux Register 1 - Set 0 */
+#define REG_GPIO_PMR1C0            (*(WoReg  *)0x400E1028UL) /**< \brief (GPIO) Peripheral Mux Register 1 - Clear 0 */
+#define REG_GPIO_PMR1T0            (*(WoReg  *)0x400E102CUL) /**< \brief (GPIO) Peripheral Mux Register 1 - Toggle 0 */
+#define REG_GPIO_PMR20             (*(RwReg  *)0x400E1030UL) /**< \brief (GPIO) Peripheral Mux Register 2 0 */
+#define REG_GPIO_PMR2S0            (*(WoReg  *)0x400E1034UL) /**< \brief (GPIO) Peripheral Mux Register 2 - Set 0 */
+#define REG_GPIO_PMR2C0            (*(WoReg  *)0x400E1038UL) /**< \brief (GPIO) Peripheral Mux Register 2 - Clear 0 */
+#define REG_GPIO_PMR2T0            (*(WoReg  *)0x400E103CUL) /**< \brief (GPIO) Peripheral Mux Register 2 - Toggle 0 */
+#define REG_GPIO_ODER0             (*(RwReg  *)0x400E1040UL) /**< \brief (GPIO) Output Driver Enable Register 0 */
+#define REG_GPIO_ODERS0            (*(WoReg  *)0x400E1044UL) /**< \brief (GPIO) Output Driver Enable Register - Set 0 */
+#define REG_GPIO_ODERC0            (*(WoReg  *)0x400E1048UL) /**< \brief (GPIO) Output Driver Enable Register - Clear 0 */
+#define REG_GPIO_ODERT0            (*(WoReg  *)0x400E104CUL) /**< \brief (GPIO) Output Driver Enable Register - Toggle 0 */
+#define REG_GPIO_OVR0              (*(RwReg  *)0x400E1050UL) /**< \brief (GPIO) Output Value Register 0 */
+#define REG_GPIO_OVRS0             (*(WoReg  *)0x400E1054UL) /**< \brief (GPIO) Output Value Register - Set 0 */
+#define REG_GPIO_OVRC0             (*(WoReg  *)0x400E1058UL) /**< \brief (GPIO) Output Value Register - Clear 0 */
+#define REG_GPIO_OVRT0             (*(WoReg  *)0x400E105CUL) /**< \brief (GPIO) Output Value Register - Toggle 0 */
+#define REG_GPIO_PVR0              (*(RoReg  *)0x400E1060UL) /**< \brief (GPIO) Pin Value Register 0 */
+#define REG_GPIO_PUER0             (*(RwReg  *)0x400E1070UL) /**< \brief (GPIO) Pull-up Enable Register 0 */
+#define REG_GPIO_PUERS0            (*(WoReg  *)0x400E1074UL) /**< \brief (GPIO) Pull-up Enable Register - Set 0 */
+#define REG_GPIO_PUERC0            (*(WoReg  *)0x400E1078UL) /**< \brief (GPIO) Pull-up Enable Register - Clear 0 */
+#define REG_GPIO_PUERT0            (*(WoReg  *)0x400E107CUL) /**< \brief (GPIO) Pull-up Enable Register - Toggle 0 */
+#define REG_GPIO_PDER0             (*(RwReg  *)0x400E1080UL) /**< \brief (GPIO) Pull-down Enable Register 0 */
+#define REG_GPIO_PDERS0            (*(WoReg  *)0x400E1084UL) /**< \brief (GPIO) Pull-down Enable Register - Set 0 */
+#define REG_GPIO_PDERC0            (*(WoReg  *)0x400E1088UL) /**< \brief (GPIO) Pull-down Enable Register - Clear 0 */
+#define REG_GPIO_PDERT0            (*(WoReg  *)0x400E108CUL) /**< \brief (GPIO) Pull-down Enable Register - Toggle 0 */
+#define REG_GPIO_IER0              (*(RwReg  *)0x400E1090UL) /**< \brief (GPIO) Interrupt Enable Register 0 */
+#define REG_GPIO_IERS0             (*(WoReg  *)0x400E1094UL) /**< \brief (GPIO) Interrupt Enable Register - Set 0 */
+#define REG_GPIO_IERC0             (*(WoReg  *)0x400E1098UL) /**< \brief (GPIO) Interrupt Enable Register - Clear 0 */
+#define REG_GPIO_IERT0             (*(WoReg  *)0x400E109CUL) /**< \brief (GPIO) Interrupt Enable Register - Toggle 0 */
+#define REG_GPIO_IMR00             (*(RwReg  *)0x400E10A0UL) /**< \brief (GPIO) Interrupt Mode Register 0 0 */
+#define REG_GPIO_IMR0S0            (*(WoReg  *)0x400E10A4UL) /**< \brief (GPIO) Interrupt Mode Register 0 - Set 0 */
+#define REG_GPIO_IMR0C0            (*(WoReg  *)0x400E10A8UL) /**< \brief (GPIO) Interrupt Mode Register 0 - Clear 0 */
+#define REG_GPIO_IMR0T0            (*(WoReg  *)0x400E10ACUL) /**< \brief (GPIO) Interrupt Mode Register 0 - Toggle 0 */
+#define REG_GPIO_IMR10             (*(RwReg  *)0x400E10B0UL) /**< \brief (GPIO) Interrupt Mode Register 1 0 */
+#define REG_GPIO_IMR1S0            (*(WoReg  *)0x400E10B4UL) /**< \brief (GPIO) Interrupt Mode Register 1 - Set 0 */
+#define REG_GPIO_IMR1C0            (*(WoReg  *)0x400E10B8UL) /**< \brief (GPIO) Interrupt Mode Register 1 - Clear 0 */
+#define REG_GPIO_IMR1T0            (*(WoReg  *)0x400E10BCUL) /**< \brief (GPIO) Interrupt Mode Register 1 - Toggle 0 */
+#define REG_GPIO_GFER0             (*(RwReg  *)0x400E10C0UL) /**< \brief (GPIO) Glitch Filter Enable Register 0 */
+#define REG_GPIO_GFERS0            (*(WoReg  *)0x400E10C4UL) /**< \brief (GPIO) Glitch Filter Enable Register - Set 0 */
+#define REG_GPIO_GFERC0            (*(WoReg  *)0x400E10C8UL) /**< \brief (GPIO) Glitch Filter Enable Register - Clear 0 */
+#define REG_GPIO_GFERT0            (*(WoReg  *)0x400E10CCUL) /**< \brief (GPIO) Glitch Filter Enable Register - Toggle 0 */
+#define REG_GPIO_IFR0              (*(RoReg  *)0x400E10D0UL) /**< \brief (GPIO) Interrupt Flag Register 0 */
+#define REG_GPIO_IFRC0             (*(WoReg  *)0x400E10D8UL) /**< \brief (GPIO) Interrupt Flag Register - Clear 0 */
+#define REG_GPIO_ODMER0            (*(RwReg  *)0x400E10E0UL) /**< \brief (GPIO) Open Drain Mode Register 0 */
+#define REG_GPIO_ODMERS0           (*(WoReg  *)0x400E10E4UL) /**< \brief (GPIO) Open Drain Mode Register - Set 0 */
+#define REG_GPIO_ODMERC0           (*(WoReg  *)0x400E10E8UL) /**< \brief (GPIO) Open Drain Mode Register - Clear 0 */
+#define REG_GPIO_ODMERT0           (*(WoReg  *)0x400E10ECUL) /**< \brief (GPIO) Open Drain Mode Register - Toggle 0 */
+#define REG_GPIO_ODCR00            (*(RwReg  *)0x400E1100UL) /**< \brief (GPIO) Output Driving Capability Register 0 0 */
+#define REG_GPIO_ODCR0S0           (*(RwReg  *)0x400E1104UL) /**< \brief (GPIO) Output Driving Capability Register 0 - Set 0 */
+#define REG_GPIO_ODCR0C0           (*(RwReg  *)0x400E1108UL) /**< \brief (GPIO) Output Driving Capability Register 0 - Clear 0 */
+#define REG_GPIO_ODCR0T0           (*(RwReg  *)0x400E110CUL) /**< \brief (GPIO) Output Driving Capability Register 0 - Toggle 0 */
+#define REG_GPIO_ODCR10            (*(RwReg  *)0x400E1110UL) /**< \brief (GPIO) Output Driving Capability Register 1 0 */
+#define REG_GPIO_ODCR1S0           (*(RwReg  *)0x400E1114UL) /**< \brief (GPIO) Output Driving Capability Register 1 - Set 0 */
+#define REG_GPIO_ODCR1C0           (*(RwReg  *)0x400E1118UL) /**< \brief (GPIO) Output Driving Capability Register 1 - Clear 0 */
+#define REG_GPIO_ODCR1T0           (*(RwReg  *)0x400E111CUL) /**< \brief (GPIO) Output Driving Capability Register 1 - Toggle 0 */
+#define REG_GPIO_OSRR00            (*(RwReg  *)0x400E1130UL) /**< \brief (GPIO) Output Slew Rate Register 0 0 */
+#define REG_GPIO_OSRR0S0           (*(RwReg  *)0x400E1134UL) /**< \brief (GPIO) Output Slew Rate Register 0 - Set 0 */
+#define REG_GPIO_OSRR0C0           (*(RwReg  *)0x400E1138UL) /**< \brief (GPIO) Output Slew Rate Register 0 - Clear 0 */
+#define REG_GPIO_OSRR0T0           (*(RwReg  *)0x400E113CUL) /**< \brief (GPIO) Output Slew Rate Register 0 - Toggle 0 */
+#define REG_GPIO_STER0             (*(RwReg  *)0x400E1160UL) /**< \brief (GPIO) Schmitt Trigger Enable Register 0 */
+#define REG_GPIO_STERS0            (*(RwReg  *)0x400E1164UL) /**< \brief (GPIO) Schmitt Trigger Enable Register - Set 0 */
+#define REG_GPIO_STERC0            (*(RwReg  *)0x400E1168UL) /**< \brief (GPIO) Schmitt Trigger Enable Register - Clear 0 */
+#define REG_GPIO_STERT0            (*(RwReg  *)0x400E116CUL) /**< \brief (GPIO) Schmitt Trigger Enable Register - Toggle 0 */
+#define REG_GPIO_EVER0             (*(RwReg  *)0x400E1180UL) /**< \brief (GPIO) Event Enable Register 0 */
+#define REG_GPIO_EVERS0            (*(WoReg  *)0x400E1184UL) /**< \brief (GPIO) Event Enable Register - Set 0 */
+#define REG_GPIO_EVERC0            (*(WoReg  *)0x400E1188UL) /**< \brief (GPIO) Event Enable Register - Clear 0 */
+#define REG_GPIO_EVERT0            (*(WoReg  *)0x400E118CUL) /**< \brief (GPIO) Event Enable Register - Toggle 0 */
+#define REG_GPIO_LOCK0             (*(RwReg  *)0x400E11A0UL) /**< \brief (GPIO) Lock Register 0 */
+#define REG_GPIO_LOCKS0            (*(WoReg  *)0x400E11A4UL) /**< \brief (GPIO) Lock Register - Set 0 */
+#define REG_GPIO_LOCKC0            (*(WoReg  *)0x400E11A8UL) /**< \brief (GPIO) Lock Register - Clear 0 */
+#define REG_GPIO_LOCKT0            (*(WoReg  *)0x400E11ACUL) /**< \brief (GPIO) Lock Register - Toggle 0 */
+#define REG_GPIO_UNLOCK0           (*(WoReg  *)0x400E11E0UL) /**< \brief (GPIO) Unlock Register 0 */
+#define REG_GPIO_ASR0              (*(RwReg  *)0x400E11E4UL) /**< \brief (GPIO) Access Status Register 0 */
+#define REG_GPIO_PARAMETER0        (*(RoReg  *)0x400E11F8UL) /**< \brief (GPIO) Parameter Register 0 */
+#define REG_GPIO_VERSION0          (*(RoReg  *)0x400E11FCUL) /**< \brief (GPIO) Version Register 0 */
+#define REG_GPIO_GPER1             (*(RwReg  *)0x400E1200UL) /**< \brief (GPIO) GPIO Enable Register 1 */
+#define REG_GPIO_GPERS1            (*(WoReg  *)0x400E1204UL) /**< \brief (GPIO) GPIO Enable Register - Set 1 */
+#define REG_GPIO_GPERC1            (*(WoReg  *)0x400E1208UL) /**< \brief (GPIO) GPIO Enable Register - Clear 1 */
+#define REG_GPIO_GPERT1            (*(WoReg  *)0x400E120CUL) /**< \brief (GPIO) GPIO Enable Register - Toggle 1 */
+#define REG_GPIO_PMR01             (*(RwReg  *)0x400E1210UL) /**< \brief (GPIO) Peripheral Mux Register 0 1 */
+#define REG_GPIO_PMR0S1            (*(WoReg  *)0x400E1214UL) /**< \brief (GPIO) Peripheral Mux Register 0 - Set 1 */
+#define REG_GPIO_PMR0C1            (*(WoReg  *)0x400E1218UL) /**< \brief (GPIO) Peripheral Mux Register 0 - Clear 1 */
+#define REG_GPIO_PMR0T1            (*(WoReg  *)0x400E121CUL) /**< \brief (GPIO) Peripheral Mux Register 0 - Toggle 1 */
+#define REG_GPIO_PMR11             (*(RwReg  *)0x400E1220UL) /**< \brief (GPIO) Peripheral Mux Register 1 1 */
+#define REG_GPIO_PMR1S1            (*(WoReg  *)0x400E1224UL) /**< \brief (GPIO) Peripheral Mux Register 1 - Set 1 */
+#define REG_GPIO_PMR1C1            (*(WoReg  *)0x400E1228UL) /**< \brief (GPIO) Peripheral Mux Register 1 - Clear 1 */
+#define REG_GPIO_PMR1T1            (*(WoReg  *)0x400E122CUL) /**< \brief (GPIO) Peripheral Mux Register 1 - Toggle 1 */
+#define REG_GPIO_PMR21             (*(RwReg  *)0x400E1230UL) /**< \brief (GPIO) Peripheral Mux Register 2 1 */
+#define REG_GPIO_PMR2S1            (*(WoReg  *)0x400E1234UL) /**< \brief (GPIO) Peripheral Mux Register 2 - Set 1 */
+#define REG_GPIO_PMR2C1            (*(WoReg  *)0x400E1238UL) /**< \brief (GPIO) Peripheral Mux Register 2 - Clear 1 */
+#define REG_GPIO_PMR2T1            (*(WoReg  *)0x400E123CUL) /**< \brief (GPIO) Peripheral Mux Register 2 - Toggle 1 */
+#define REG_GPIO_ODER1             (*(RwReg  *)0x400E1240UL) /**< \brief (GPIO) Output Driver Enable Register 1 */
+#define REG_GPIO_ODERS1            (*(WoReg  *)0x400E1244UL) /**< \brief (GPIO) Output Driver Enable Register - Set 1 */
+#define REG_GPIO_ODERC1            (*(WoReg  *)0x400E1248UL) /**< \brief (GPIO) Output Driver Enable Register - Clear 1 */
+#define REG_GPIO_ODERT1            (*(WoReg  *)0x400E124CUL) /**< \brief (GPIO) Output Driver Enable Register - Toggle 1 */
+#define REG_GPIO_OVR1              (*(RwReg  *)0x400E1250UL) /**< \brief (GPIO) Output Value Register 1 */
+#define REG_GPIO_OVRS1             (*(WoReg  *)0x400E1254UL) /**< \brief (GPIO) Output Value Register - Set 1 */
+#define REG_GPIO_OVRC1             (*(WoReg  *)0x400E1258UL) /**< \brief (GPIO) Output Value Register - Clear 1 */
+#define REG_GPIO_OVRT1             (*(WoReg  *)0x400E125CUL) /**< \brief (GPIO) Output Value Register - Toggle 1 */
+#define REG_GPIO_PVR1              (*(RoReg  *)0x400E1260UL) /**< \brief (GPIO) Pin Value Register 1 */
+#define REG_GPIO_PUER1             (*(RwReg  *)0x400E1270UL) /**< \brief (GPIO) Pull-up Enable Register 1 */
+#define REG_GPIO_PUERS1            (*(WoReg  *)0x400E1274UL) /**< \brief (GPIO) Pull-up Enable Register - Set 1 */
+#define REG_GPIO_PUERC1            (*(WoReg  *)0x400E1278UL) /**< \brief (GPIO) Pull-up Enable Register - Clear 1 */
+#define REG_GPIO_PUERT1            (*(WoReg  *)0x400E127CUL) /**< \brief (GPIO) Pull-up Enable Register - Toggle 1 */
+#define REG_GPIO_PDER1             (*(RwReg  *)0x400E1280UL) /**< \brief (GPIO) Pull-down Enable Register 1 */
+#define REG_GPIO_PDERS1            (*(WoReg  *)0x400E1284UL) /**< \brief (GPIO) Pull-down Enable Register - Set 1 */
+#define REG_GPIO_PDERC1            (*(WoReg  *)0x400E1288UL) /**< \brief (GPIO) Pull-down Enable Register - Clear 1 */
+#define REG_GPIO_PDERT1            (*(WoReg  *)0x400E128CUL) /**< \brief (GPIO) Pull-down Enable Register - Toggle 1 */
+#define REG_GPIO_IER1              (*(RwReg  *)0x400E1290UL) /**< \brief (GPIO) Interrupt Enable Register 1 */
+#define REG_GPIO_IERS1             (*(WoReg  *)0x400E1294UL) /**< \brief (GPIO) Interrupt Enable Register - Set 1 */
+#define REG_GPIO_IERC1             (*(WoReg  *)0x400E1298UL) /**< \brief (GPIO) Interrupt Enable Register - Clear 1 */
+#define REG_GPIO_IERT1             (*(WoReg  *)0x400E129CUL) /**< \brief (GPIO) Interrupt Enable Register - Toggle 1 */
+#define REG_GPIO_IMR01             (*(RwReg  *)0x400E12A0UL) /**< \brief (GPIO) Interrupt Mode Register 0 1 */
+#define REG_GPIO_IMR0S1            (*(WoReg  *)0x400E12A4UL) /**< \brief (GPIO) Interrupt Mode Register 0 - Set 1 */
+#define REG_GPIO_IMR0C1            (*(WoReg  *)0x400E12A8UL) /**< \brief (GPIO) Interrupt Mode Register 0 - Clear 1 */
+#define REG_GPIO_IMR0T1            (*(WoReg  *)0x400E12ACUL) /**< \brief (GPIO) Interrupt Mode Register 0 - Toggle 1 */
+#define REG_GPIO_IMR11             (*(RwReg  *)0x400E12B0UL) /**< \brief (GPIO) Interrupt Mode Register 1 1 */
+#define REG_GPIO_IMR1S1            (*(WoReg  *)0x400E12B4UL) /**< \brief (GPIO) Interrupt Mode Register 1 - Set 1 */
+#define REG_GPIO_IMR1C1            (*(WoReg  *)0x400E12B8UL) /**< \brief (GPIO) Interrupt Mode Register 1 - Clear 1 */
+#define REG_GPIO_IMR1T1            (*(WoReg  *)0x400E12BCUL) /**< \brief (GPIO) Interrupt Mode Register 1 - Toggle 1 */
+#define REG_GPIO_GFER1             (*(RwReg  *)0x400E12C0UL) /**< \brief (GPIO) Glitch Filter Enable Register 1 */
+#define REG_GPIO_GFERS1            (*(WoReg  *)0x400E12C4UL) /**< \brief (GPIO) Glitch Filter Enable Register - Set 1 */
+#define REG_GPIO_GFERC1            (*(WoReg  *)0x400E12C8UL) /**< \brief (GPIO) Glitch Filter Enable Register - Clear 1 */
+#define REG_GPIO_GFERT1            (*(WoReg  *)0x400E12CCUL) /**< \brief (GPIO) Glitch Filter Enable Register - Toggle 1 */
+#define REG_GPIO_IFR1              (*(RoReg  *)0x400E12D0UL) /**< \brief (GPIO) Interrupt Flag Register 1 */
+#define REG_GPIO_IFRC1             (*(WoReg  *)0x400E12D8UL) /**< \brief (GPIO) Interrupt Flag Register - Clear 1 */
+#define REG_GPIO_ODMER1            (*(RwReg  *)0x400E12E0UL) /**< \brief (GPIO) Open Drain Mode Register 1 */
+#define REG_GPIO_ODMERS1           (*(WoReg  *)0x400E12E4UL) /**< \brief (GPIO) Open Drain Mode Register - Set 1 */
+#define REG_GPIO_ODMERC1           (*(WoReg  *)0x400E12E8UL) /**< \brief (GPIO) Open Drain Mode Register - Clear 1 */
+#define REG_GPIO_ODMERT1           (*(WoReg  *)0x400E12ECUL) /**< \brief (GPIO) Open Drain Mode Register - Toggle 1 */
+#define REG_GPIO_ODCR01            (*(RwReg  *)0x400E1300UL) /**< \brief (GPIO) Output Driving Capability Register 0 1 */
+#define REG_GPIO_ODCR0S1           (*(RwReg  *)0x400E1304UL) /**< \brief (GPIO) Output Driving Capability Register 0 - Set 1 */
+#define REG_GPIO_ODCR0C1           (*(RwReg  *)0x400E1308UL) /**< \brief (GPIO) Output Driving Capability Register 0 - Clear 1 */
+#define REG_GPIO_ODCR0T1           (*(RwReg  *)0x400E130CUL) /**< \brief (GPIO) Output Driving Capability Register 0 - Toggle 1 */
+#define REG_GPIO_ODCR11            (*(RwReg  *)0x400E1310UL) /**< \brief (GPIO) Output Driving Capability Register 1 1 */
+#define REG_GPIO_ODCR1S1           (*(RwReg  *)0x400E1314UL) /**< \brief (GPIO) Output Driving Capability Register 1 - Set 1 */
+#define REG_GPIO_ODCR1C1           (*(RwReg  *)0x400E1318UL) /**< \brief (GPIO) Output Driving Capability Register 1 - Clear 1 */
+#define REG_GPIO_ODCR1T1           (*(RwReg  *)0x400E131CUL) /**< \brief (GPIO) Output Driving Capability Register 1 - Toggle 1 */
+#define REG_GPIO_OSRR01            (*(RwReg  *)0x400E1330UL) /**< \brief (GPIO) Output Slew Rate Register 0 1 */
+#define REG_GPIO_OSRR0S1           (*(RwReg  *)0x400E1334UL) /**< \brief (GPIO) Output Slew Rate Register 0 - Set 1 */
+#define REG_GPIO_OSRR0C1           (*(RwReg  *)0x400E1338UL) /**< \brief (GPIO) Output Slew Rate Register 0 - Clear 1 */
+#define REG_GPIO_OSRR0T1           (*(RwReg  *)0x400E133CUL) /**< \brief (GPIO) Output Slew Rate Register 0 - Toggle 1 */
+#define REG_GPIO_STER1             (*(RwReg  *)0x400E1360UL) /**< \brief (GPIO) Schmitt Trigger Enable Register 1 */
+#define REG_GPIO_STERS1            (*(RwReg  *)0x400E1364UL) /**< \brief (GPIO) Schmitt Trigger Enable Register - Set 1 */
+#define REG_GPIO_STERC1            (*(RwReg  *)0x400E1368UL) /**< \brief (GPIO) Schmitt Trigger Enable Register - Clear 1 */
+#define REG_GPIO_STERT1            (*(RwReg  *)0x400E136CUL) /**< \brief (GPIO) Schmitt Trigger Enable Register - Toggle 1 */
+#define REG_GPIO_EVER1             (*(RwReg  *)0x400E1380UL) /**< \brief (GPIO) Event Enable Register 1 */
+#define REG_GPIO_EVERS1            (*(WoReg  *)0x400E1384UL) /**< \brief (GPIO) Event Enable Register - Set 1 */
+#define REG_GPIO_EVERC1            (*(WoReg  *)0x400E1388UL) /**< \brief (GPIO) Event Enable Register - Clear 1 */
+#define REG_GPIO_EVERT1            (*(WoReg  *)0x400E138CUL) /**< \brief (GPIO) Event Enable Register - Toggle 1 */
+#define REG_GPIO_LOCK1             (*(RwReg  *)0x400E13A0UL) /**< \brief (GPIO) Lock Register 1 */
+#define REG_GPIO_LOCKS1            (*(WoReg  *)0x400E13A4UL) /**< \brief (GPIO) Lock Register - Set 1 */
+#define REG_GPIO_LOCKC1            (*(WoReg  *)0x400E13A8UL) /**< \brief (GPIO) Lock Register - Clear 1 */
+#define REG_GPIO_LOCKT1            (*(WoReg  *)0x400E13ACUL) /**< \brief (GPIO) Lock Register - Toggle 1 */
+#define REG_GPIO_UNLOCK1           (*(WoReg  *)0x400E13E0UL) /**< \brief (GPIO) Unlock Register 1 */
+#define REG_GPIO_ASR1              (*(RwReg  *)0x400E13E4UL) /**< \brief (GPIO) Access Status Register 1 */
+#define REG_GPIO_PARAMETER1        (*(RoReg  *)0x400E13F8UL) /**< \brief (GPIO) Parameter Register 1 */
+#define REG_GPIO_VERSION1          (*(RoReg  *)0x400E13FCUL) /**< \brief (GPIO) Version Register 1 */
+#define REG_GPIO_GPER2             (*(RwReg  *)0x400E1400UL) /**< \brief (GPIO) GPIO Enable Register 2 */
+#define REG_GPIO_GPERS2            (*(WoReg  *)0x400E1404UL) /**< \brief (GPIO) GPIO Enable Register - Set 2 */
+#define REG_GPIO_GPERC2            (*(WoReg  *)0x400E1408UL) /**< \brief (GPIO) GPIO Enable Register - Clear 2 */
+#define REG_GPIO_GPERT2            (*(WoReg  *)0x400E140CUL) /**< \brief (GPIO) GPIO Enable Register - Toggle 2 */
+#define REG_GPIO_PMR02             (*(RwReg  *)0x400E1410UL) /**< \brief (GPIO) Peripheral Mux Register 0 2 */
+#define REG_GPIO_PMR0S2            (*(WoReg  *)0x400E1414UL) /**< \brief (GPIO) Peripheral Mux Register 0 - Set 2 */
+#define REG_GPIO_PMR0C2            (*(WoReg  *)0x400E1418UL) /**< \brief (GPIO) Peripheral Mux Register 0 - Clear 2 */
+#define REG_GPIO_PMR0T2            (*(WoReg  *)0x400E141CUL) /**< \brief (GPIO) Peripheral Mux Register 0 - Toggle 2 */
+#define REG_GPIO_PMR12             (*(RwReg  *)0x400E1420UL) /**< \brief (GPIO) Peripheral Mux Register 1 2 */
+#define REG_GPIO_PMR1S2            (*(WoReg  *)0x400E1424UL) /**< \brief (GPIO) Peripheral Mux Register 1 - Set 2 */
+#define REG_GPIO_PMR1C2            (*(WoReg  *)0x400E1428UL) /**< \brief (GPIO) Peripheral Mux Register 1 - Clear 2 */
+#define REG_GPIO_PMR1T2            (*(WoReg  *)0x400E142CUL) /**< \brief (GPIO) Peripheral Mux Register 1 - Toggle 2 */
+#define REG_GPIO_PMR22             (*(RwReg  *)0x400E1430UL) /**< \brief (GPIO) Peripheral Mux Register 2 2 */
+#define REG_GPIO_PMR2S2            (*(WoReg  *)0x400E1434UL) /**< \brief (GPIO) Peripheral Mux Register 2 - Set 2 */
+#define REG_GPIO_PMR2C2            (*(WoReg  *)0x400E1438UL) /**< \brief (GPIO) Peripheral Mux Register 2 - Clear 2 */
+#define REG_GPIO_PMR2T2            (*(WoReg  *)0x400E143CUL) /**< \brief (GPIO) Peripheral Mux Register 2 - Toggle 2 */
+#define REG_GPIO_ODER2             (*(RwReg  *)0x400E1440UL) /**< \brief (GPIO) Output Driver Enable Register 2 */
+#define REG_GPIO_ODERS2            (*(WoReg  *)0x400E1444UL) /**< \brief (GPIO) Output Driver Enable Register - Set 2 */
+#define REG_GPIO_ODERC2            (*(WoReg  *)0x400E1448UL) /**< \brief (GPIO) Output Driver Enable Register - Clear 2 */
+#define REG_GPIO_ODERT2            (*(WoReg  *)0x400E144CUL) /**< \brief (GPIO) Output Driver Enable Register - Toggle 2 */
+#define REG_GPIO_OVR2              (*(RwReg  *)0x400E1450UL) /**< \brief (GPIO) Output Value Register 2 */
+#define REG_GPIO_OVRS2             (*(WoReg  *)0x400E1454UL) /**< \brief (GPIO) Output Value Register - Set 2 */
+#define REG_GPIO_OVRC2             (*(WoReg  *)0x400E1458UL) /**< \brief (GPIO) Output Value Register - Clear 2 */
+#define REG_GPIO_OVRT2             (*(WoReg  *)0x400E145CUL) /**< \brief (GPIO) Output Value Register - Toggle 2 */
+#define REG_GPIO_PVR2              (*(RoReg  *)0x400E1460UL) /**< \brief (GPIO) Pin Value Register 2 */
+#define REG_GPIO_PUER2             (*(RwReg  *)0x400E1470UL) /**< \brief (GPIO) Pull-up Enable Register 2 */
+#define REG_GPIO_PUERS2            (*(WoReg  *)0x400E1474UL) /**< \brief (GPIO) Pull-up Enable Register - Set 2 */
+#define REG_GPIO_PUERC2            (*(WoReg  *)0x400E1478UL) /**< \brief (GPIO) Pull-up Enable Register - Clear 2 */
+#define REG_GPIO_PUERT2            (*(WoReg  *)0x400E147CUL) /**< \brief (GPIO) Pull-up Enable Register - Toggle 2 */
+#define REG_GPIO_PDER2             (*(RwReg  *)0x400E1480UL) /**< \brief (GPIO) Pull-down Enable Register 2 */
+#define REG_GPIO_PDERS2            (*(WoReg  *)0x400E1484UL) /**< \brief (GPIO) Pull-down Enable Register - Set 2 */
+#define REG_GPIO_PDERC2            (*(WoReg  *)0x400E1488UL) /**< \brief (GPIO) Pull-down Enable Register - Clear 2 */
+#define REG_GPIO_PDERT2            (*(WoReg  *)0x400E148CUL) /**< \brief (GPIO) Pull-down Enable Register - Toggle 2 */
+#define REG_GPIO_IER2              (*(RwReg  *)0x400E1490UL) /**< \brief (GPIO) Interrupt Enable Register 2 */
+#define REG_GPIO_IERS2             (*(WoReg  *)0x400E1494UL) /**< \brief (GPIO) Interrupt Enable Register - Set 2 */
+#define REG_GPIO_IERC2             (*(WoReg  *)0x400E1498UL) /**< \brief (GPIO) Interrupt Enable Register - Clear 2 */
+#define REG_GPIO_IERT2             (*(WoReg  *)0x400E149CUL) /**< \brief (GPIO) Interrupt Enable Register - Toggle 2 */
+#define REG_GPIO_IMR02             (*(RwReg  *)0x400E14A0UL) /**< \brief (GPIO) Interrupt Mode Register 0 2 */
+#define REG_GPIO_IMR0S2            (*(WoReg  *)0x400E14A4UL) /**< \brief (GPIO) Interrupt Mode Register 0 - Set 2 */
+#define REG_GPIO_IMR0C2            (*(WoReg  *)0x400E14A8UL) /**< \brief (GPIO) Interrupt Mode Register 0 - Clear 2 */
+#define REG_GPIO_IMR0T2            (*(WoReg  *)0x400E14ACUL) /**< \brief (GPIO) Interrupt Mode Register 0 - Toggle 2 */
+#define REG_GPIO_IMR12             (*(RwReg  *)0x400E14B0UL) /**< \brief (GPIO) Interrupt Mode Register 1 2 */
+#define REG_GPIO_IMR1S2            (*(WoReg  *)0x400E14B4UL) /**< \brief (GPIO) Interrupt Mode Register 1 - Set 2 */
+#define REG_GPIO_IMR1C2            (*(WoReg  *)0x400E14B8UL) /**< \brief (GPIO) Interrupt Mode Register 1 - Clear 2 */
+#define REG_GPIO_IMR1T2            (*(WoReg  *)0x400E14BCUL) /**< \brief (GPIO) Interrupt Mode Register 1 - Toggle 2 */
+#define REG_GPIO_GFER2             (*(RwReg  *)0x400E14C0UL) /**< \brief (GPIO) Glitch Filter Enable Register 2 */
+#define REG_GPIO_GFERS2            (*(WoReg  *)0x400E14C4UL) /**< \brief (GPIO) Glitch Filter Enable Register - Set 2 */
+#define REG_GPIO_GFERC2            (*(WoReg  *)0x400E14C8UL) /**< \brief (GPIO) Glitch Filter Enable Register - Clear 2 */
+#define REG_GPIO_GFERT2            (*(WoReg  *)0x400E14CCUL) /**< \brief (GPIO) Glitch Filter Enable Register - Toggle 2 */
+#define REG_GPIO_IFR2              (*(RoReg  *)0x400E14D0UL) /**< \brief (GPIO) Interrupt Flag Register 2 */
+#define REG_GPIO_IFRC2             (*(WoReg  *)0x400E14D8UL) /**< \brief (GPIO) Interrupt Flag Register - Clear 2 */
+#define REG_GPIO_ODMER2            (*(RwReg  *)0x400E14E0UL) /**< \brief (GPIO) Open Drain Mode Register 2 */
+#define REG_GPIO_ODMERS2           (*(WoReg  *)0x400E14E4UL) /**< \brief (GPIO) Open Drain Mode Register - Set 2 */
+#define REG_GPIO_ODMERC2           (*(WoReg  *)0x400E14E8UL) /**< \brief (GPIO) Open Drain Mode Register - Clear 2 */
+#define REG_GPIO_ODMERT2           (*(WoReg  *)0x400E14ECUL) /**< \brief (GPIO) Open Drain Mode Register - Toggle 2 */
+#define REG_GPIO_ODCR02            (*(RwReg  *)0x400E1500UL) /**< \brief (GPIO) Output Driving Capability Register 0 2 */
+#define REG_GPIO_ODCR0S2           (*(RwReg  *)0x400E1504UL) /**< \brief (GPIO) Output Driving Capability Register 0 - Set 2 */
+#define REG_GPIO_ODCR0C2           (*(RwReg  *)0x400E1508UL) /**< \brief (GPIO) Output Driving Capability Register 0 - Clear 2 */
+#define REG_GPIO_ODCR0T2           (*(RwReg  *)0x400E150CUL) /**< \brief (GPIO) Output Driving Capability Register 0 - Toggle 2 */
+#define REG_GPIO_ODCR12            (*(RwReg  *)0x400E1510UL) /**< \brief (GPIO) Output Driving Capability Register 1 2 */
+#define REG_GPIO_ODCR1S2           (*(RwReg  *)0x400E1514UL) /**< \brief (GPIO) Output Driving Capability Register 1 - Set 2 */
+#define REG_GPIO_ODCR1C2           (*(RwReg  *)0x400E1518UL) /**< \brief (GPIO) Output Driving Capability Register 1 - Clear 2 */
+#define REG_GPIO_ODCR1T2           (*(RwReg  *)0x400E151CUL) /**< \brief (GPIO) Output Driving Capability Register 1 - Toggle 2 */
+#define REG_GPIO_OSRR02            (*(RwReg  *)0x400E1530UL) /**< \brief (GPIO) Output Slew Rate Register 0 2 */
+#define REG_GPIO_OSRR0S2           (*(RwReg  *)0x400E1534UL) /**< \brief (GPIO) Output Slew Rate Register 0 - Set 2 */
+#define REG_GPIO_OSRR0C2           (*(RwReg  *)0x400E1538UL) /**< \brief (GPIO) Output Slew Rate Register 0 - Clear 2 */
+#define REG_GPIO_OSRR0T2           (*(RwReg  *)0x400E153CUL) /**< \brief (GPIO) Output Slew Rate Register 0 - Toggle 2 */
+#define REG_GPIO_STER2             (*(RwReg  *)0x400E1560UL) /**< \brief (GPIO) Schmitt Trigger Enable Register 2 */
+#define REG_GPIO_STERS2            (*(RwReg  *)0x400E1564UL) /**< \brief (GPIO) Schmitt Trigger Enable Register - Set 2 */
+#define REG_GPIO_STERC2            (*(RwReg  *)0x400E1568UL) /**< \brief (GPIO) Schmitt Trigger Enable Register - Clear 2 */
+#define REG_GPIO_STERT2            (*(RwReg  *)0x400E156CUL) /**< \brief (GPIO) Schmitt Trigger Enable Register - Toggle 2 */
+#define REG_GPIO_EVER2             (*(RwReg  *)0x400E1580UL) /**< \brief (GPIO) Event Enable Register 2 */
+#define REG_GPIO_EVERS2            (*(WoReg  *)0x400E1584UL) /**< \brief (GPIO) Event Enable Register - Set 2 */
+#define REG_GPIO_EVERC2            (*(WoReg  *)0x400E1588UL) /**< \brief (GPIO) Event Enable Register - Clear 2 */
+#define REG_GPIO_EVERT2            (*(WoReg  *)0x400E158CUL) /**< \brief (GPIO) Event Enable Register - Toggle 2 */
+#define REG_GPIO_LOCK2             (*(RwReg  *)0x400E15A0UL) /**< \brief (GPIO) Lock Register 2 */
+#define REG_GPIO_LOCKS2            (*(WoReg  *)0x400E15A4UL) /**< \brief (GPIO) Lock Register - Set 2 */
+#define REG_GPIO_LOCKC2            (*(WoReg  *)0x400E15A8UL) /**< \brief (GPIO) Lock Register - Clear 2 */
+#define REG_GPIO_LOCKT2            (*(WoReg  *)0x400E15ACUL) /**< \brief (GPIO) Lock Register - Toggle 2 */
+#define REG_GPIO_UNLOCK2           (*(WoReg  *)0x400E15E0UL) /**< \brief (GPIO) Unlock Register 2 */
+#define REG_GPIO_ASR2              (*(RwReg  *)0x400E15E4UL) /**< \brief (GPIO) Access Status Register 2 */
+#define REG_GPIO_PARAMETER2        (*(RoReg  *)0x400E15F8UL) /**< \brief (GPIO) Parameter Register 2 */
+#define REG_GPIO_VERSION2          (*(RoReg  *)0x400E15FCUL) /**< \brief (GPIO) Version Register 2 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for GPIO peripheral ========== */
+#define GPIO_GFER_DEFAULT_VAL       { 0x00000000, 0x00000000, 0x00000000 }
+#define GPIO_GFER_IMPLEMENTED       { 0x00000000, 0x00000000, 0x00000000 }
+#define GPIO_GFILTER_IMPLEMENTED    { 0x00000000, 0x00000000, 0x00000000 }
+#define GPIO_GPER_DEFAULT_VAL       { 0xFFFFFFFF, 0x0000FFFF, 0xFFFFFFFF }
+#define GPIO_GPER_IMPLEMENTED       { 0xFFFFFFFC, 0x0000FFFF, 0xFFFFFFFF }
+#define GPIO_GPIO_IRQ_MSB           11      
+#define GPIO_GPIO_MAX_IRQ_MSB       11      
+#define GPIO_GPIO_PADDR_BITS        11      
+#define GPIO_GPIO_PINS_MSB          95      
+#define GPIO_IER_DEFAULT_VAL        { 0x00000000, 0x00000000, 0x00000000 }
+#define GPIO_IER_IMPLEMENTED        { 0xFFFFFFFF, 0x0000FFFF, 0xFFFFFFFF }
+#define GPIO_IFE_IMPLEMENTED        { 0xFFFFFFFF, 0x0000FFFF, 0xFFFFFFFF }
+#define GPIO_IFR_IMPLEMENTED        { 0xFFFFFFFF, 0x0000FFFF, 0xFFFFFFFF }
+#define GPIO_IMR0_DEFAULT_VAL       { 0x00000000, 0x00000000, 0x00000000 }
+#define GPIO_IMR0_IMPLEMENTED       { 0xFFFFFFFF, 0x0000FFFF, 0xFFFFFFFF }
+#define GPIO_IMR1_DEFAULT_VAL       { 0x00000000, 0x00000000, 0x00000000 }
+#define GPIO_IMR1_IMPLEMENTED       { 0xFFFFFFFF, 0x0000FFFF, 0xFFFFFFFF }
+#define GPIO_INPUT_SYNC_IMPLEMENTED { 0xFFFFFFFF, 0x0000FFFF, 0xFFFFFFFF }
+#define GPIO_IRQS_PER_GROUP         8       
+#define GPIO_LOCK_DEFAULT_VAL       { 0x00000000, 0x00000000, 0x00000000 }
+#define GPIO_LOCK_IMPLEMENTED       { 0x00000000, 0x00000000, 0x00000000 }
+#define GPIO_NUMBER_OF_PINS         96      
+#define GPIO_ODCR0_DEFAULT_VAL      { 0x00000000, 0x00000000, 0x00000000 }
+#define GPIO_ODCR0_IMPLEMENTED      { 0xFFFFFFFF, 0x0000FFFF, 0xFFFFFFFF }
+#define GPIO_ODCR1_DEFAULT_VAL      { 0x00000000, 0x00000000, 0x00000000 }
+#define GPIO_ODCR1_IMPLEMENTED      { 0x00000000, 0x00000000, 0x00000000 }
+#define GPIO_ODER_DEFAULT_VAL       { 0x00000000, 0x00000000, 0x00000000 }
+#define GPIO_ODER_IMPLEMENTED       { 0xFFFFFFFF, 0x0000FFFF, 0xFFFFFFFF }
+#define GPIO_ODMER_DEFAULT_VAL      { 0x00000000, 0x00000000, 0x00000000 }
+#define GPIO_ODMER_IMPLEMENTED      { 0x00000000, 0x00000000, 0x00000000 }
+#define GPIO_OSRR0_DEFAULT_VAL      { 0xFFFFFFFF, 0x0000FFFF, 0xFFFFFFFF }
+#define GPIO_OSRR0_IMPLEMENTED      { 0xFFFFFFFF, 0x0000FFFF, 0xFFFFFFFF }
+#define GPIO_OVR_DEFAULT_VAL        { 0x00000000, 0x00000000, 0x00000000 }
+#define GPIO_OVR_IMPLEMENTED        { 0xFFFFFFFF, 0x0000FFFF, 0xFFFFFFFF }
+#define GPIO_PADDR_MSB              10      
+#define GPIO_PDATA_MSB              31      
+#define GPIO_PDER_DEFAULT_VAL       { 0x00000000, 0x00000000, 0x00000000 }
+#define GPIO_PDER_IMPLEMENTED       { 0xFFFFFFFF, 0x0000FFFF, 0xFFFFFFFF }
+#define GPIO_PMR0_DEFAULT_VAL       { 0x00000008, 0x00000000, 0x00000000 }
+#define GPIO_PMR0_IMPLEMENTED       { 0xFFFFFFF4, 0x0000FFFF, 0xFFFFFFFF }
+#define GPIO_PMR1_DEFAULT_VAL       { 0x00000000, 0x00000000, 0x00000000 }
+#define GPIO_PMR1_IMPLEMENTED       { 0xFFFFFFF4, 0x0000FFFF, 0xFFFFFFFF }
+#define GPIO_PMR2_DEFAULT_VAL       { 0x00000000, 0x00000000, 0x00000000 }
+#define GPIO_PMR2_IMPLEMENTED       { 0xFFFFFFF4, 0x0000FFFF, 0xFFFFFFFF }
+#define GPIO_PORT_LENGTH            3       
+#define GPIO_PUER_DEFAULT_VAL       { 0x00000000, 0x00000000, 0x00000000 }
+#define GPIO_PUER_IMPLEMENTED       { 0xFFFFFFFF, 0x0000FFFF, 0xFFFFFFFF }
+#define GPIO_STER_DEFAULT_VAL       { 0x00000004, 0x00000000, 0x00000000 }
+#define GPIO_STER_IMPLEMENTED       { 0xFFFFFFFF, 0x0000FFFF, 0xFFFFFFFF }
+
+#endif /* _SAM4L_GPIO_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/hcache.h
+++ b/asf/sam/include/sam4l/instance/hcache.h
@@ -1,0 +1,56 @@
+/**
+ * \file
+ *
+ * \brief Instance description for HCACHE
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_HCACHE_INSTANCE_
+#define _SAM4L_HCACHE_INSTANCE_
+
+/* ========== Register definition for HCACHE peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_HCACHE_CTRL            (0x400A0408) /**< \brief (HCACHE) Control Register */
+#define REG_HCACHE_SR              (0x400A040C) /**< \brief (HCACHE) Status Register */
+#define REG_HCACHE_MAINT0          (0x400A0420) /**< \brief (HCACHE) Maintenance Register 0 */
+#define REG_HCACHE_MAINT1          (0x400A0424) /**< \brief (HCACHE) Maintenance Register 1 */
+#define REG_HCACHE_MCFG            (0x400A0428) /**< \brief (HCACHE) Monitor Configuration Register */
+#define REG_HCACHE_MEN             (0x400A042C) /**< \brief (HCACHE) Monitor Enable Register */
+#define REG_HCACHE_MCTRL           (0x400A0430) /**< \brief (HCACHE) Monitor Control Register */
+#define REG_HCACHE_MSR             (0x400A0434) /**< \brief (HCACHE) Monitor Status Register */
+#define REG_HCACHE_VERSION         (0x400A04FC) /**< \brief (HCACHE) Version Register */
+#else
+#define REG_HCACHE_CTRL            (*(WoReg  *)0x400A0408UL) /**< \brief (HCACHE) Control Register */
+#define REG_HCACHE_SR              (*(RwReg  *)0x400A040CUL) /**< \brief (HCACHE) Status Register */
+#define REG_HCACHE_MAINT0          (*(WoReg  *)0x400A0420UL) /**< \brief (HCACHE) Maintenance Register 0 */
+#define REG_HCACHE_MAINT1          (*(WoReg  *)0x400A0424UL) /**< \brief (HCACHE) Maintenance Register 1 */
+#define REG_HCACHE_MCFG            (*(RwReg  *)0x400A0428UL) /**< \brief (HCACHE) Monitor Configuration Register */
+#define REG_HCACHE_MEN             (*(RwReg  *)0x400A042CUL) /**< \brief (HCACHE) Monitor Enable Register */
+#define REG_HCACHE_MCTRL           (*(WoReg  *)0x400A0430UL) /**< \brief (HCACHE) Monitor Control Register */
+#define REG_HCACHE_MSR             (*(RoReg  *)0x400A0434UL) /**< \brief (HCACHE) Monitor Status Register */
+#define REG_HCACHE_VERSION         (*(RoReg  *)0x400A04FCUL) /**< \brief (HCACHE) Version Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+#endif /* _SAM4L_HCACHE_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/hflashc.h
+++ b/asf/sam/include/sam4l/instance/hflashc.h
@@ -1,0 +1,52 @@
+/**
+ * \file
+ *
+ * \brief Instance description for HFLASHC
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_HFLASHC_INSTANCE_
+#define _SAM4L_HFLASHC_INSTANCE_
+
+/* ========== Register definition for HFLASHC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_HFLASHC_FCR            (0x400A0000) /**< \brief (HFLASHC) Flash Controller Control Register */
+#define REG_HFLASHC_FCMD           (0x400A0004) /**< \brief (HFLASHC) Flash Controller Command Register */
+#define REG_HFLASHC_FSR            (0x400A0008) /**< \brief (HFLASHC) Flash Controller Status Register */
+#define REG_HFLASHC_FPR            (0x400A000C) /**< \brief (HFLASHC) Flash Controller Parameter Register */
+#define REG_HFLASHC_VERSION        (0x400A0010) /**< \brief (HFLASHC) Flash Controller Version Register */
+#define REG_HFLASHC_FGPFRHI        (0x400A0014) /**< \brief (HFLASHC) Flash Controller General Purpose Fuse Register High */
+#define REG_HFLASHC_FGPFRLO        (0x400A0018) /**< \brief (HFLASHC) Flash Controller General Purpose Fuse Register Low */
+#else
+#define REG_HFLASHC_FCR            (*(RwReg  *)0x400A0000UL) /**< \brief (HFLASHC) Flash Controller Control Register */
+#define REG_HFLASHC_FCMD           (*(RwReg  *)0x400A0004UL) /**< \brief (HFLASHC) Flash Controller Command Register */
+#define REG_HFLASHC_FSR            (*(RwReg  *)0x400A0008UL) /**< \brief (HFLASHC) Flash Controller Status Register */
+#define REG_HFLASHC_FPR            (*(RoReg  *)0x400A000CUL) /**< \brief (HFLASHC) Flash Controller Parameter Register */
+#define REG_HFLASHC_VERSION        (*(RoReg  *)0x400A0010UL) /**< \brief (HFLASHC) Flash Controller Version Register */
+#define REG_HFLASHC_FGPFRHI        (*(RwReg  *)0x400A0014UL) /**< \brief (HFLASHC) Flash Controller General Purpose Fuse Register High */
+#define REG_HFLASHC_FGPFRLO        (*(RwReg  *)0x400A0018UL) /**< \brief (HFLASHC) Flash Controller General Purpose Fuse Register Low */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+#endif /* _SAM4L_HFLASHC_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/hmatrix.h
+++ b/asf/sam/include/sam4l/instance/hmatrix.h
@@ -1,0 +1,218 @@
+/**
+ * \file
+ *
+ * \brief Instance description for HMATRIX
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_HMATRIX_INSTANCE_
+#define _SAM4L_HMATRIX_INSTANCE_
+
+/* ========== Register definition for HMATRIX peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_HMATRIX_MCFG0          (0x400A1000) /**< \brief (HMATRIX) Master Configuration Register 0 */
+#define REG_HMATRIX_MCFG1          (0x400A1004) /**< \brief (HMATRIX) Master Configuration Register 1 */
+#define REG_HMATRIX_MCFG2          (0x400A1008) /**< \brief (HMATRIX) Master Configuration Register 2 */
+#define REG_HMATRIX_MCFG3          (0x400A100C) /**< \brief (HMATRIX) Master Configuration Register 3 */
+#define REG_HMATRIX_MCFG4          (0x400A1010) /**< \brief (HMATRIX) Master Configuration Register 4 */
+#define REG_HMATRIX_MCFG5          (0x400A1014) /**< \brief (HMATRIX) Master Configuration Register 5 */
+#define REG_HMATRIX_MCFG6          (0x400A1018) /**< \brief (HMATRIX) Master Configuration Register 6 */
+#define REG_HMATRIX_MCFG7          (0x400A101C) /**< \brief (HMATRIX) Master Configuration Register 7 */
+#define REG_HMATRIX_MCFG8          (0x400A1020) /**< \brief (HMATRIX) Master Configuration Register 8 */
+#define REG_HMATRIX_MCFG9          (0x400A1024) /**< \brief (HMATRIX) Master Configuration Register 9 */
+#define REG_HMATRIX_MCFG10         (0x400A1028) /**< \brief (HMATRIX) Master Configuration Register 10 */
+#define REG_HMATRIX_MCFG11         (0x400A102C) /**< \brief (HMATRIX) Master Configuration Register 11 */
+#define REG_HMATRIX_MCFG12         (0x400A1030) /**< \brief (HMATRIX) Master Configuration Register 12 */
+#define REG_HMATRIX_MCFG13         (0x400A1034) /**< \brief (HMATRIX) Master Configuration Register 13 */
+#define REG_HMATRIX_MCFG14         (0x400A1038) /**< \brief (HMATRIX) Master Configuration Register 14 */
+#define REG_HMATRIX_MCFG15         (0x400A103C) /**< \brief (HMATRIX) Master Configuration Register 15 */
+#define REG_HMATRIX_SCFG0          (0x400A1040) /**< \brief (HMATRIX) Slave Configuration Register 0 */
+#define REG_HMATRIX_SCFG1          (0x400A1044) /**< \brief (HMATRIX) Slave Configuration Register 1 */
+#define REG_HMATRIX_SCFG2          (0x400A1048) /**< \brief (HMATRIX) Slave Configuration Register 2 */
+#define REG_HMATRIX_SCFG3          (0x400A104C) /**< \brief (HMATRIX) Slave Configuration Register 3 */
+#define REG_HMATRIX_SCFG4          (0x400A1050) /**< \brief (HMATRIX) Slave Configuration Register 4 */
+#define REG_HMATRIX_SCFG5          (0x400A1054) /**< \brief (HMATRIX) Slave Configuration Register 5 */
+#define REG_HMATRIX_SCFG6          (0x400A1058) /**< \brief (HMATRIX) Slave Configuration Register 6 */
+#define REG_HMATRIX_SCFG7          (0x400A105C) /**< \brief (HMATRIX) Slave Configuration Register 7 */
+#define REG_HMATRIX_SCFG8          (0x400A1060) /**< \brief (HMATRIX) Slave Configuration Register 8 */
+#define REG_HMATRIX_SCFG9          (0x400A1064) /**< \brief (HMATRIX) Slave Configuration Register 9 */
+#define REG_HMATRIX_SCFG10         (0x400A1068) /**< \brief (HMATRIX) Slave Configuration Register 10 */
+#define REG_HMATRIX_SCFG11         (0x400A106C) /**< \brief (HMATRIX) Slave Configuration Register 11 */
+#define REG_HMATRIX_SCFG12         (0x400A1070) /**< \brief (HMATRIX) Slave Configuration Register 12 */
+#define REG_HMATRIX_SCFG13         (0x400A1074) /**< \brief (HMATRIX) Slave Configuration Register 13 */
+#define REG_HMATRIX_SCFG14         (0x400A1078) /**< \brief (HMATRIX) Slave Configuration Register 14 */
+#define REG_HMATRIX_SCFG15         (0x400A107C) /**< \brief (HMATRIX) Slave Configuration Register 15 */
+#define REG_HMATRIX_PRAS0          (0x400A1080) /**< \brief (HMATRIX) Priority Register A for Slave 0 */
+#define REG_HMATRIX_PRBS0          (0x400A1084) /**< \brief (HMATRIX) Priority Register B for Slave 0 */
+#define REG_HMATRIX_PRAS1          (0x400A1088) /**< \brief (HMATRIX) Priority Register A for Slave 1 */
+#define REG_HMATRIX_PRBS1          (0x400A108C) /**< \brief (HMATRIX) Priority Register B for Slave 1 */
+#define REG_HMATRIX_PRAS2          (0x400A1090) /**< \brief (HMATRIX) Priority Register A for Slave 2 */
+#define REG_HMATRIX_PRBS2          (0x400A1094) /**< \brief (HMATRIX) Priority Register B for Slave 2 */
+#define REG_HMATRIX_PRAS3          (0x400A1098) /**< \brief (HMATRIX) Priority Register A for Slave 3 */
+#define REG_HMATRIX_PRBS3          (0x400A109C) /**< \brief (HMATRIX) Priority Register B for Slave 3 */
+#define REG_HMATRIX_PRAS4          (0x400A10A0) /**< \brief (HMATRIX) Priority Register A for Slave 4 */
+#define REG_HMATRIX_PRBS4          (0x400A10A4) /**< \brief (HMATRIX) Priority Register B for Slave 4 */
+#define REG_HMATRIX_PRAS5          (0x400A10A8) /**< \brief (HMATRIX) Priority Register A for Slave 5 */
+#define REG_HMATRIX_PRBS5          (0x400A10AC) /**< \brief (HMATRIX) Priority Register B for Slave 5 */
+#define REG_HMATRIX_PRAS6          (0x400A10B0) /**< \brief (HMATRIX) Priority Register A for Slave 6 */
+#define REG_HMATRIX_PRBS6          (0x400A10B4) /**< \brief (HMATRIX) Priority Register B for Slave 6 */
+#define REG_HMATRIX_PRAS7          (0x400A10B8) /**< \brief (HMATRIX) Priority Register A for Slave 7 */
+#define REG_HMATRIX_PRBS7          (0x400A10BC) /**< \brief (HMATRIX) Priority Register B for Slave 7 */
+#define REG_HMATRIX_PRAS8          (0x400A10C0) /**< \brief (HMATRIX) Priority Register A for Slave 8 */
+#define REG_HMATRIX_PRBS8          (0x400A10C4) /**< \brief (HMATRIX) Priority Register B for Slave 8 */
+#define REG_HMATRIX_PRAS9          (0x400A10C8) /**< \brief (HMATRIX) Priority Register A for Slave 9 */
+#define REG_HMATRIX_PRBS9          (0x400A10CC) /**< \brief (HMATRIX) Priority Register B for Slave 9 */
+#define REG_HMATRIX_PRAS10         (0x400A10D0) /**< \brief (HMATRIX) Priority Register A for Slave 10 */
+#define REG_HMATRIX_PRBS10         (0x400A10D4) /**< \brief (HMATRIX) Priority Register B for Slave 10 */
+#define REG_HMATRIX_PRAS11         (0x400A10D8) /**< \brief (HMATRIX) Priority Register A for Slave 11 */
+#define REG_HMATRIX_PRBS11         (0x400A10DC) /**< \brief (HMATRIX) Priority Register B for Slave 11 */
+#define REG_HMATRIX_PRAS12         (0x400A10E0) /**< \brief (HMATRIX) Priority Register A for Slave 12 */
+#define REG_HMATRIX_PRBS12         (0x400A10E4) /**< \brief (HMATRIX) Priority Register B for Slave 12 */
+#define REG_HMATRIX_PRAS13         (0x400A10E8) /**< \brief (HMATRIX) Priority Register A for Slave 13 */
+#define REG_HMATRIX_PRBS13         (0x400A10EC) /**< \brief (HMATRIX) Priority Register B for Slave 13 */
+#define REG_HMATRIX_PRAS14         (0x400A10F0) /**< \brief (HMATRIX) Priority Register A for Slave 14 */
+#define REG_HMATRIX_PRBS14         (0x400A10F4) /**< \brief (HMATRIX) Priority Register B for Slave 14 */
+#define REG_HMATRIX_PRAS15         (0x400A10F8) /**< \brief (HMATRIX) Priority Register A for Slave 15 */
+#define REG_HMATRIX_PRBS15         (0x400A10FC) /**< \brief (HMATRIX) Priority Register B for Slave 15 */
+#define REG_HMATRIX_MRCR           (0x400A1100) /**< \brief (HMATRIX) Master Remap Control Register */
+#define REG_HMATRIX_SFR0           (0x400A1110) /**< \brief (HMATRIX) Special Function Register 0 */
+#define REG_HMATRIX_SFR1           (0x400A1114) /**< \brief (HMATRIX) Special Function Register 1 */
+#define REG_HMATRIX_SFR2           (0x400A1118) /**< \brief (HMATRIX) Special Function Register 2 */
+#define REG_HMATRIX_SFR3           (0x400A111C) /**< \brief (HMATRIX) Special Function Register 3 */
+#define REG_HMATRIX_SFR4           (0x400A1120) /**< \brief (HMATRIX) Special Function Register 4 */
+#define REG_HMATRIX_SFR5           (0x400A1124) /**< \brief (HMATRIX) Special Function Register 5 */
+#define REG_HMATRIX_SFR6           (0x400A1128) /**< \brief (HMATRIX) Special Function Register 6 */
+#define REG_HMATRIX_SFR7           (0x400A112C) /**< \brief (HMATRIX) Special Function Register 7 */
+#define REG_HMATRIX_SFR8           (0x400A1130) /**< \brief (HMATRIX) Special Function Register 8 */
+#define REG_HMATRIX_SFR9           (0x400A1134) /**< \brief (HMATRIX) Special Function Register 9 */
+#define REG_HMATRIX_SFR10          (0x400A1138) /**< \brief (HMATRIX) Special Function Register 10 */
+#define REG_HMATRIX_SFR11          (0x400A113C) /**< \brief (HMATRIX) Special Function Register 11 */
+#define REG_HMATRIX_SFR12          (0x400A1140) /**< \brief (HMATRIX) Special Function Register 12 */
+#define REG_HMATRIX_SFR13          (0x400A1144) /**< \brief (HMATRIX) Special Function Register 13 */
+#define REG_HMATRIX_SFR14          (0x400A1148) /**< \brief (HMATRIX) Special Function Register 14 */
+#define REG_HMATRIX_SFR15          (0x400A114C) /**< \brief (HMATRIX) Special Function Register 15 */
+#else
+#define REG_HMATRIX_MCFG0          (*(RwReg  *)0x400A1000UL) /**< \brief (HMATRIX) Master Configuration Register 0 */
+#define REG_HMATRIX_MCFG1          (*(RwReg  *)0x400A1004UL) /**< \brief (HMATRIX) Master Configuration Register 1 */
+#define REG_HMATRIX_MCFG2          (*(RwReg  *)0x400A1008UL) /**< \brief (HMATRIX) Master Configuration Register 2 */
+#define REG_HMATRIX_MCFG3          (*(RwReg  *)0x400A100CUL) /**< \brief (HMATRIX) Master Configuration Register 3 */
+#define REG_HMATRIX_MCFG4          (*(RwReg  *)0x400A1010UL) /**< \brief (HMATRIX) Master Configuration Register 4 */
+#define REG_HMATRIX_MCFG5          (*(RwReg  *)0x400A1014UL) /**< \brief (HMATRIX) Master Configuration Register 5 */
+#define REG_HMATRIX_MCFG6          (*(RwReg  *)0x400A1018UL) /**< \brief (HMATRIX) Master Configuration Register 6 */
+#define REG_HMATRIX_MCFG7          (*(RwReg  *)0x400A101CUL) /**< \brief (HMATRIX) Master Configuration Register 7 */
+#define REG_HMATRIX_MCFG8          (*(RwReg  *)0x400A1020UL) /**< \brief (HMATRIX) Master Configuration Register 8 */
+#define REG_HMATRIX_MCFG9          (*(RwReg  *)0x400A1024UL) /**< \brief (HMATRIX) Master Configuration Register 9 */
+#define REG_HMATRIX_MCFG10         (*(RwReg  *)0x400A1028UL) /**< \brief (HMATRIX) Master Configuration Register 10 */
+#define REG_HMATRIX_MCFG11         (*(RwReg  *)0x400A102CUL) /**< \brief (HMATRIX) Master Configuration Register 11 */
+#define REG_HMATRIX_MCFG12         (*(RwReg  *)0x400A1030UL) /**< \brief (HMATRIX) Master Configuration Register 12 */
+#define REG_HMATRIX_MCFG13         (*(RwReg  *)0x400A1034UL) /**< \brief (HMATRIX) Master Configuration Register 13 */
+#define REG_HMATRIX_MCFG14         (*(RwReg  *)0x400A1038UL) /**< \brief (HMATRIX) Master Configuration Register 14 */
+#define REG_HMATRIX_MCFG15         (*(RwReg  *)0x400A103CUL) /**< \brief (HMATRIX) Master Configuration Register 15 */
+#define REG_HMATRIX_SCFG0          (*(RwReg  *)0x400A1040UL) /**< \brief (HMATRIX) Slave Configuration Register 0 */
+#define REG_HMATRIX_SCFG1          (*(RwReg  *)0x400A1044UL) /**< \brief (HMATRIX) Slave Configuration Register 1 */
+#define REG_HMATRIX_SCFG2          (*(RwReg  *)0x400A1048UL) /**< \brief (HMATRIX) Slave Configuration Register 2 */
+#define REG_HMATRIX_SCFG3          (*(RwReg  *)0x400A104CUL) /**< \brief (HMATRIX) Slave Configuration Register 3 */
+#define REG_HMATRIX_SCFG4          (*(RwReg  *)0x400A1050UL) /**< \brief (HMATRIX) Slave Configuration Register 4 */
+#define REG_HMATRIX_SCFG5          (*(RwReg  *)0x400A1054UL) /**< \brief (HMATRIX) Slave Configuration Register 5 */
+#define REG_HMATRIX_SCFG6          (*(RwReg  *)0x400A1058UL) /**< \brief (HMATRIX) Slave Configuration Register 6 */
+#define REG_HMATRIX_SCFG7          (*(RwReg  *)0x400A105CUL) /**< \brief (HMATRIX) Slave Configuration Register 7 */
+#define REG_HMATRIX_SCFG8          (*(RwReg  *)0x400A1060UL) /**< \brief (HMATRIX) Slave Configuration Register 8 */
+#define REG_HMATRIX_SCFG9          (*(RwReg  *)0x400A1064UL) /**< \brief (HMATRIX) Slave Configuration Register 9 */
+#define REG_HMATRIX_SCFG10         (*(RwReg  *)0x400A1068UL) /**< \brief (HMATRIX) Slave Configuration Register 10 */
+#define REG_HMATRIX_SCFG11         (*(RwReg  *)0x400A106CUL) /**< \brief (HMATRIX) Slave Configuration Register 11 */
+#define REG_HMATRIX_SCFG12         (*(RwReg  *)0x400A1070UL) /**< \brief (HMATRIX) Slave Configuration Register 12 */
+#define REG_HMATRIX_SCFG13         (*(RwReg  *)0x400A1074UL) /**< \brief (HMATRIX) Slave Configuration Register 13 */
+#define REG_HMATRIX_SCFG14         (*(RwReg  *)0x400A1078UL) /**< \brief (HMATRIX) Slave Configuration Register 14 */
+#define REG_HMATRIX_SCFG15         (*(RwReg  *)0x400A107CUL) /**< \brief (HMATRIX) Slave Configuration Register 15 */
+#define REG_HMATRIX_PRAS0          (*(RwReg  *)0x400A1080UL) /**< \brief (HMATRIX) Priority Register A for Slave 0 */
+#define REG_HMATRIX_PRBS0          (*(RwReg  *)0x400A1084UL) /**< \brief (HMATRIX) Priority Register B for Slave 0 */
+#define REG_HMATRIX_PRAS1          (*(RwReg  *)0x400A1088UL) /**< \brief (HMATRIX) Priority Register A for Slave 1 */
+#define REG_HMATRIX_PRBS1          (*(RwReg  *)0x400A108CUL) /**< \brief (HMATRIX) Priority Register B for Slave 1 */
+#define REG_HMATRIX_PRAS2          (*(RwReg  *)0x400A1090UL) /**< \brief (HMATRIX) Priority Register A for Slave 2 */
+#define REG_HMATRIX_PRBS2          (*(RwReg  *)0x400A1094UL) /**< \brief (HMATRIX) Priority Register B for Slave 2 */
+#define REG_HMATRIX_PRAS3          (*(RwReg  *)0x400A1098UL) /**< \brief (HMATRIX) Priority Register A for Slave 3 */
+#define REG_HMATRIX_PRBS3          (*(RwReg  *)0x400A109CUL) /**< \brief (HMATRIX) Priority Register B for Slave 3 */
+#define REG_HMATRIX_PRAS4          (*(RwReg  *)0x400A10A0UL) /**< \brief (HMATRIX) Priority Register A for Slave 4 */
+#define REG_HMATRIX_PRBS4          (*(RwReg  *)0x400A10A4UL) /**< \brief (HMATRIX) Priority Register B for Slave 4 */
+#define REG_HMATRIX_PRAS5          (*(RwReg  *)0x400A10A8UL) /**< \brief (HMATRIX) Priority Register A for Slave 5 */
+#define REG_HMATRIX_PRBS5          (*(RwReg  *)0x400A10ACUL) /**< \brief (HMATRIX) Priority Register B for Slave 5 */
+#define REG_HMATRIX_PRAS6          (*(RwReg  *)0x400A10B0UL) /**< \brief (HMATRIX) Priority Register A for Slave 6 */
+#define REG_HMATRIX_PRBS6          (*(RwReg  *)0x400A10B4UL) /**< \brief (HMATRIX) Priority Register B for Slave 6 */
+#define REG_HMATRIX_PRAS7          (*(RwReg  *)0x400A10B8UL) /**< \brief (HMATRIX) Priority Register A for Slave 7 */
+#define REG_HMATRIX_PRBS7          (*(RwReg  *)0x400A10BCUL) /**< \brief (HMATRIX) Priority Register B for Slave 7 */
+#define REG_HMATRIX_PRAS8          (*(RwReg  *)0x400A10C0UL) /**< \brief (HMATRIX) Priority Register A for Slave 8 */
+#define REG_HMATRIX_PRBS8          (*(RwReg  *)0x400A10C4UL) /**< \brief (HMATRIX) Priority Register B for Slave 8 */
+#define REG_HMATRIX_PRAS9          (*(RwReg  *)0x400A10C8UL) /**< \brief (HMATRIX) Priority Register A for Slave 9 */
+#define REG_HMATRIX_PRBS9          (*(RwReg  *)0x400A10CCUL) /**< \brief (HMATRIX) Priority Register B for Slave 9 */
+#define REG_HMATRIX_PRAS10         (*(RwReg  *)0x400A10D0UL) /**< \brief (HMATRIX) Priority Register A for Slave 10 */
+#define REG_HMATRIX_PRBS10         (*(RwReg  *)0x400A10D4UL) /**< \brief (HMATRIX) Priority Register B for Slave 10 */
+#define REG_HMATRIX_PRAS11         (*(RwReg  *)0x400A10D8UL) /**< \brief (HMATRIX) Priority Register A for Slave 11 */
+#define REG_HMATRIX_PRBS11         (*(RwReg  *)0x400A10DCUL) /**< \brief (HMATRIX) Priority Register B for Slave 11 */
+#define REG_HMATRIX_PRAS12         (*(RwReg  *)0x400A10E0UL) /**< \brief (HMATRIX) Priority Register A for Slave 12 */
+#define REG_HMATRIX_PRBS12         (*(RwReg  *)0x400A10E4UL) /**< \brief (HMATRIX) Priority Register B for Slave 12 */
+#define REG_HMATRIX_PRAS13         (*(RwReg  *)0x400A10E8UL) /**< \brief (HMATRIX) Priority Register A for Slave 13 */
+#define REG_HMATRIX_PRBS13         (*(RwReg  *)0x400A10ECUL) /**< \brief (HMATRIX) Priority Register B for Slave 13 */
+#define REG_HMATRIX_PRAS14         (*(RwReg  *)0x400A10F0UL) /**< \brief (HMATRIX) Priority Register A for Slave 14 */
+#define REG_HMATRIX_PRBS14         (*(RwReg  *)0x400A10F4UL) /**< \brief (HMATRIX) Priority Register B for Slave 14 */
+#define REG_HMATRIX_PRAS15         (*(RwReg  *)0x400A10F8UL) /**< \brief (HMATRIX) Priority Register A for Slave 15 */
+#define REG_HMATRIX_PRBS15         (*(RwReg  *)0x400A10FCUL) /**< \brief (HMATRIX) Priority Register B for Slave 15 */
+#define REG_HMATRIX_MRCR           (*(RwReg  *)0x400A1100UL) /**< \brief (HMATRIX) Master Remap Control Register */
+#define REG_HMATRIX_SFR0           (*(RwReg  *)0x400A1110UL) /**< \brief (HMATRIX) Special Function Register 0 */
+#define REG_HMATRIX_SFR1           (*(RwReg  *)0x400A1114UL) /**< \brief (HMATRIX) Special Function Register 1 */
+#define REG_HMATRIX_SFR2           (*(RwReg  *)0x400A1118UL) /**< \brief (HMATRIX) Special Function Register 2 */
+#define REG_HMATRIX_SFR3           (*(RwReg  *)0x400A111CUL) /**< \brief (HMATRIX) Special Function Register 3 */
+#define REG_HMATRIX_SFR4           (*(RwReg  *)0x400A1120UL) /**< \brief (HMATRIX) Special Function Register 4 */
+#define REG_HMATRIX_SFR5           (*(RwReg  *)0x400A1124UL) /**< \brief (HMATRIX) Special Function Register 5 */
+#define REG_HMATRIX_SFR6           (*(RwReg  *)0x400A1128UL) /**< \brief (HMATRIX) Special Function Register 6 */
+#define REG_HMATRIX_SFR7           (*(RwReg  *)0x400A112CUL) /**< \brief (HMATRIX) Special Function Register 7 */
+#define REG_HMATRIX_SFR8           (*(RwReg  *)0x400A1130UL) /**< \brief (HMATRIX) Special Function Register 8 */
+#define REG_HMATRIX_SFR9           (*(RwReg  *)0x400A1134UL) /**< \brief (HMATRIX) Special Function Register 9 */
+#define REG_HMATRIX_SFR10          (*(RwReg  *)0x400A1138UL) /**< \brief (HMATRIX) Special Function Register 10 */
+#define REG_HMATRIX_SFR11          (*(RwReg  *)0x400A113CUL) /**< \brief (HMATRIX) Special Function Register 11 */
+#define REG_HMATRIX_SFR12          (*(RwReg  *)0x400A1140UL) /**< \brief (HMATRIX) Special Function Register 12 */
+#define REG_HMATRIX_SFR13          (*(RwReg  *)0x400A1144UL) /**< \brief (HMATRIX) Special Function Register 13 */
+#define REG_HMATRIX_SFR14          (*(RwReg  *)0x400A1148UL) /**< \brief (HMATRIX) Special Function Register 14 */
+#define REG_HMATRIX_SFR15          (*(RwReg  *)0x400A114CUL) /**< \brief (HMATRIX) Special Function Register 15 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for HMATRIX ========== */
+#define HMATRIX_SLAVE_FLASH         0
+#define HMATRIX_SLAVE_HTOP0         1
+#define HMATRIX_SLAVE_HTOP1         2
+#define HMATRIX_SLAVE_HTOP2         3
+#define HMATRIX_SLAVE_HTOP3         4
+#define HMATRIX_SLAVE_HRAMC0        5
+#define HMATRIX_SLAVE_HRAMC1        6
+#define HMATRIX_SLAVE_AESA          7
+#define HMATRIX_SLAVE_NUM           8
+
+#define HMATRIX_MASTER_CPU_IDCODE   0
+#define HMATRIX_MASTER_CPU_SYS      1
+#define HMATRIX_MASTER_SMAP         2
+#define HMATRIX_MASTER_PDCA         3
+#define HMATRIX_MASTER_USBC_MASTER  4
+#define HMATRIX_MASTER_CRCCU        5
+#define HMATRIX_MASTER_NUM          6
+
+#endif /* _SAM4L_HMATRIX_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/iisc.h
+++ b/asf/sam/include/sam4l/instance/iisc.h
@@ -1,0 +1,68 @@
+/**
+ * \file
+ *
+ * \brief Instance description for IISC
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_IISC_INSTANCE_
+#define _SAM4L_IISC_INSTANCE_
+
+/* ========== Register definition for IISC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_IISC_CR                (0x40004000) /**< \brief (IISC) Control Register */
+#define REG_IISC_MR                (0x40004004) /**< \brief (IISC) Mode Register */
+#define REG_IISC_SR                (0x40004008) /**< \brief (IISC) Status Register */
+#define REG_IISC_SCR               (0x4000400C) /**< \brief (IISC) Status Clear Register */
+#define REG_IISC_SSR               (0x40004010) /**< \brief (IISC) Status Set Register */
+#define REG_IISC_IER               (0x40004014) /**< \brief (IISC) Interrupt Enable Register */
+#define REG_IISC_IDR               (0x40004018) /**< \brief (IISC) Interrupt Disable Register */
+#define REG_IISC_IMR               (0x4000401C) /**< \brief (IISC) Interrupt Mask Register */
+#define REG_IISC_RHR               (0x40004020) /**< \brief (IISC) Receive Holding Register */
+#define REG_IISC_THR               (0x40004024) /**< \brief (IISC) Transmit Holding Register */
+#define REG_IISC_VERSION           (0x40004028) /**< \brief (IISC) Version Register */
+#define REG_IISC_PARAMETER         (0x4000402C) /**< \brief (IISC) Parameter Register */
+#else
+#define REG_IISC_CR                (*(WoReg  *)0x40004000UL) /**< \brief (IISC) Control Register */
+#define REG_IISC_MR                (*(RwReg  *)0x40004004UL) /**< \brief (IISC) Mode Register */
+#define REG_IISC_SR                (*(RoReg  *)0x40004008UL) /**< \brief (IISC) Status Register */
+#define REG_IISC_SCR               (*(WoReg  *)0x4000400CUL) /**< \brief (IISC) Status Clear Register */
+#define REG_IISC_SSR               (*(WoReg  *)0x40004010UL) /**< \brief (IISC) Status Set Register */
+#define REG_IISC_IER               (*(WoReg  *)0x40004014UL) /**< \brief (IISC) Interrupt Enable Register */
+#define REG_IISC_IDR               (*(WoReg  *)0x40004018UL) /**< \brief (IISC) Interrupt Disable Register */
+#define REG_IISC_IMR               (*(RoReg  *)0x4000401CUL) /**< \brief (IISC) Interrupt Mask Register */
+#define REG_IISC_RHR               (*(RoReg  *)0x40004020UL) /**< \brief (IISC) Receive Holding Register */
+#define REG_IISC_THR               (*(WoReg  *)0x40004024UL) /**< \brief (IISC) Transmit Holding Register */
+#define REG_IISC_VERSION           (*(RoReg  *)0x40004028UL) /**< \brief (IISC) Version Register */
+#define REG_IISC_PARAMETER         (*(RoReg  *)0x4000402CUL) /**< \brief (IISC) Parameter Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for IISC peripheral ========== */
+#define IISC_GCLK_NUM               6       
+#define IISC_PDCA_ID_RX             14      
+#define IISC_PDCA_ID_RX_1           15      
+#define IISC_PDCA_ID_TX             33      
+#define IISC_PDCA_ID_TX_1           34      
+
+#endif /* _SAM4L_IISC_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/lcdca.h
+++ b/asf/sam/include/sam4l/instance/lcdca.h
@@ -1,0 +1,93 @@
+/**
+ * \file
+ *
+ * \brief Instance description for LCDCA
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_LCDCA_INSTANCE_
+#define _SAM4L_LCDCA_INSTANCE_
+
+/* ========== Register definition for LCDCA peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_LCDCA_CR               (0x40080000) /**< \brief (LCDCA) Control Register */
+#define REG_LCDCA_CFG              (0x40080004) /**< \brief (LCDCA) Configuration Register */
+#define REG_LCDCA_TIM              (0x40080008) /**< \brief (LCDCA) Timing Register */
+#define REG_LCDCA_SR               (0x4008000C) /**< \brief (LCDCA) Status Register */
+#define REG_LCDCA_SCR              (0x40080010) /**< \brief (LCDCA) Status Clear Register */
+#define REG_LCDCA_DRL0             (0x40080014) /**< \brief (LCDCA) Data Register Low 0 */
+#define REG_LCDCA_DRH0             (0x40080018) /**< \brief (LCDCA) Data Register High 0 */
+#define REG_LCDCA_DRL1             (0x4008001C) /**< \brief (LCDCA) Data Register Low 1 */
+#define REG_LCDCA_DRH1             (0x40080020) /**< \brief (LCDCA) Data Register High 1 */
+#define REG_LCDCA_DRL2             (0x40080024) /**< \brief (LCDCA) Data Register Low 2 */
+#define REG_LCDCA_DRH2             (0x40080028) /**< \brief (LCDCA) Data Register High 2 */
+#define REG_LCDCA_DRL3             (0x4008002C) /**< \brief (LCDCA) Data Register Low 3 */
+#define REG_LCDCA_DRH3             (0x40080030) /**< \brief (LCDCA) Data Register High 3 */
+#define REG_LCDCA_IADR             (0x40080034) /**< \brief (LCDCA) Indirect Access Data Register */
+#define REG_LCDCA_BCFG             (0x40080038) /**< \brief (LCDCA) Blink Configuration Register */
+#define REG_LCDCA_CSRCFG           (0x4008003C) /**< \brief (LCDCA) Circular Shift Register Configuration */
+#define REG_LCDCA_CMCFG            (0x40080040) /**< \brief (LCDCA) Character Mapping Configuration Register */
+#define REG_LCDCA_CMDR             (0x40080044) /**< \brief (LCDCA) Character Mapping Data Register */
+#define REG_LCDCA_ACMCFG           (0x40080048) /**< \brief (LCDCA) Automated Character Mapping Configuration Register */
+#define REG_LCDCA_ACMDR            (0x4008004C) /**< \brief (LCDCA) Automated Character Mapping Data Register */
+#define REG_LCDCA_ABMCFG           (0x40080050) /**< \brief (LCDCA) Automated Bit Mapping Configuration Register */
+#define REG_LCDCA_ABMDR            (0x40080054) /**< \brief (LCDCA) Automated Bit Mapping Data Register */
+#define REG_LCDCA_IER              (0x40080058) /**< \brief (LCDCA) Interrupt Enable Register */
+#define REG_LCDCA_IDR              (0x4008005C) /**< \brief (LCDCA) Interrupt Disable Register */
+#define REG_LCDCA_IMR              (0x40080060) /**< \brief (LCDCA) Interrupt Mask Register */
+#define REG_LCDCA_VERSION          (0x40080064) /**< \brief (LCDCA) Version Register */
+#else
+#define REG_LCDCA_CR               (*(WoReg  *)0x40080000UL) /**< \brief (LCDCA) Control Register */
+#define REG_LCDCA_CFG              (*(RwReg  *)0x40080004UL) /**< \brief (LCDCA) Configuration Register */
+#define REG_LCDCA_TIM              (*(RwReg  *)0x40080008UL) /**< \brief (LCDCA) Timing Register */
+#define REG_LCDCA_SR               (*(RoReg  *)0x4008000CUL) /**< \brief (LCDCA) Status Register */
+#define REG_LCDCA_SCR              (*(WoReg  *)0x40080010UL) /**< \brief (LCDCA) Status Clear Register */
+#define REG_LCDCA_DRL0             (*(RwReg  *)0x40080014UL) /**< \brief (LCDCA) Data Register Low 0 */
+#define REG_LCDCA_DRH0             (*(RwReg  *)0x40080018UL) /**< \brief (LCDCA) Data Register High 0 */
+#define REG_LCDCA_DRL1             (*(RwReg  *)0x4008001CUL) /**< \brief (LCDCA) Data Register Low 1 */
+#define REG_LCDCA_DRH1             (*(RwReg  *)0x40080020UL) /**< \brief (LCDCA) Data Register High 1 */
+#define REG_LCDCA_DRL2             (*(RwReg  *)0x40080024UL) /**< \brief (LCDCA) Data Register Low 2 */
+#define REG_LCDCA_DRH2             (*(RwReg  *)0x40080028UL) /**< \brief (LCDCA) Data Register High 2 */
+#define REG_LCDCA_DRL3             (*(RwReg  *)0x4008002CUL) /**< \brief (LCDCA) Data Register Low 3 */
+#define REG_LCDCA_DRH3             (*(RwReg  *)0x40080030UL) /**< \brief (LCDCA) Data Register High 3 */
+#define REG_LCDCA_IADR             (*(WoReg  *)0x40080034UL) /**< \brief (LCDCA) Indirect Access Data Register */
+#define REG_LCDCA_BCFG             (*(RwReg  *)0x40080038UL) /**< \brief (LCDCA) Blink Configuration Register */
+#define REG_LCDCA_CSRCFG           (*(RwReg  *)0x4008003CUL) /**< \brief (LCDCA) Circular Shift Register Configuration */
+#define REG_LCDCA_CMCFG            (*(RwReg  *)0x40080040UL) /**< \brief (LCDCA) Character Mapping Configuration Register */
+#define REG_LCDCA_CMDR             (*(WoReg  *)0x40080044UL) /**< \brief (LCDCA) Character Mapping Data Register */
+#define REG_LCDCA_ACMCFG           (*(RwReg  *)0x40080048UL) /**< \brief (LCDCA) Automated Character Mapping Configuration Register */
+#define REG_LCDCA_ACMDR            (*(WoReg  *)0x4008004CUL) /**< \brief (LCDCA) Automated Character Mapping Data Register */
+#define REG_LCDCA_ABMCFG           (*(RwReg  *)0x40080050UL) /**< \brief (LCDCA) Automated Bit Mapping Configuration Register */
+#define REG_LCDCA_ABMDR            (*(WoReg  *)0x40080054UL) /**< \brief (LCDCA) Automated Bit Mapping Data Register */
+#define REG_LCDCA_IER              (*(WoReg  *)0x40080058UL) /**< \brief (LCDCA) Interrupt Enable Register */
+#define REG_LCDCA_IDR              (*(WoReg  *)0x4008005CUL) /**< \brief (LCDCA) Interrupt Disable Register */
+#define REG_LCDCA_IMR              (*(RoReg  *)0x40080060UL) /**< \brief (LCDCA) Interrupt Mask Register */
+#define REG_LCDCA_VERSION          (*(RoReg  *)0x40080064UL) /**< \brief (LCDCA) Version Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for LCDCA peripheral ========== */
+#define LCDCA_PDCA_ID_TX_ABM        38      
+#define LCDCA_PDCA_ID_TX_ACM        37      
+
+#endif /* _SAM4L_LCDCA_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/parc.h
+++ b/asf/sam/include/sam4l/instance/parc.h
@@ -1,0 +1,58 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PARC
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_PARC_INSTANCE_
+#define _SAM4L_PARC_INSTANCE_
+
+/* ========== Register definition for PARC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_PARC_CFG               (0x4006C000) /**< \brief (PARC) Configuration Register */
+#define REG_PARC_CR                (0x4006C004) /**< \brief (PARC) Control Register */
+#define REG_PARC_IER               (0x4006C008) /**< \brief (PARC) Interrupt Enable Register */
+#define REG_PARC_IDR               (0x4006C00C) /**< \brief (PARC) Interrupt Disable Register */
+#define REG_PARC_IMR               (0x4006C010) /**< \brief (PARC) Interrupt Mask Register */
+#define REG_PARC_SR                (0x4006C014) /**< \brief (PARC) Status Register */
+#define REG_PARC_ICR               (0x4006C018) /**< \brief (PARC) Interrupt Status Clear Register */
+#define REG_PARC_RHR               (0x4006C01C) /**< \brief (PARC) Receive Holding Register */
+#define REG_PARC_VERSION           (0x4006C020) /**< \brief (PARC) Version Register */
+#else
+#define REG_PARC_CFG               (*(RwReg  *)0x4006C000UL) /**< \brief (PARC) Configuration Register */
+#define REG_PARC_CR                (*(RwReg  *)0x4006C004UL) /**< \brief (PARC) Control Register */
+#define REG_PARC_IER               (*(WoReg  *)0x4006C008UL) /**< \brief (PARC) Interrupt Enable Register */
+#define REG_PARC_IDR               (*(WoReg  *)0x4006C00CUL) /**< \brief (PARC) Interrupt Disable Register */
+#define REG_PARC_IMR               (*(RoReg  *)0x4006C010UL) /**< \brief (PARC) Interrupt Mask Register */
+#define REG_PARC_SR                (*(RoReg  *)0x4006C014UL) /**< \brief (PARC) Status Register */
+#define REG_PARC_ICR               (*(WoReg  *)0x4006C018UL) /**< \brief (PARC) Interrupt Status Clear Register */
+#define REG_PARC_RHR               (*(RoReg  *)0x4006C01CUL) /**< \brief (PARC) Receive Holding Register */
+#define REG_PARC_VERSION           (*(RoReg  *)0x4006C020UL) /**< \brief (PARC) Version Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for PARC peripheral ========== */
+#define PARC_PDCA_ID_RX             16      
+
+#endif /* _SAM4L_PARC_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/pdca.h
+++ b/asf/sam/include/sam4l/instance/pdca.h
@@ -1,0 +1,455 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PDCA
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_PDCA_INSTANCE_
+#define _SAM4L_PDCA_INSTANCE_
+
+/* ========== Register definition for PDCA peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_PDCA_MAR0              (0x400A2000) /**< \brief (PDCA) Memory Address Register 0 */
+#define REG_PDCA_PSR0              (0x400A2004) /**< \brief (PDCA) Peripheral Select Register 0 */
+#define REG_PDCA_TCR0              (0x400A2008) /**< \brief (PDCA) Transfer Counter Register 0 */
+#define REG_PDCA_MARR0             (0x400A200C) /**< \brief (PDCA) Memory Address Reload Register 0 */
+#define REG_PDCA_TCRR0             (0x400A2010) /**< \brief (PDCA) Transfer Counter Reload Register 0 */
+#define REG_PDCA_CR0               (0x400A2014) /**< \brief (PDCA) Control Register 0 */
+#define REG_PDCA_MR0               (0x400A2018) /**< \brief (PDCA) Mode Register 0 */
+#define REG_PDCA_SR0               (0x400A201C) /**< \brief (PDCA) Status Register 0 */
+#define REG_PDCA_IER0              (0x400A2020) /**< \brief (PDCA) Interrupt Enable Register 0 */
+#define REG_PDCA_IDR0              (0x400A2024) /**< \brief (PDCA) Interrupt Disable Register 0 */
+#define REG_PDCA_IMR0              (0x400A2028) /**< \brief (PDCA) Interrupt Mask Register 0 */
+#define REG_PDCA_ISR0              (0x400A202C) /**< \brief (PDCA) Interrupt Status Register 0 */
+#define REG_PDCA_MAR1              (0x400A2040) /**< \brief (PDCA) Memory Address Register 1 */
+#define REG_PDCA_PSR1              (0x400A2044) /**< \brief (PDCA) Peripheral Select Register 1 */
+#define REG_PDCA_TCR1              (0x400A2048) /**< \brief (PDCA) Transfer Counter Register 1 */
+#define REG_PDCA_MARR1             (0x400A204C) /**< \brief (PDCA) Memory Address Reload Register 1 */
+#define REG_PDCA_TCRR1             (0x400A2050) /**< \brief (PDCA) Transfer Counter Reload Register 1 */
+#define REG_PDCA_CR1               (0x400A2054) /**< \brief (PDCA) Control Register 1 */
+#define REG_PDCA_MR1               (0x400A2058) /**< \brief (PDCA) Mode Register 1 */
+#define REG_PDCA_SR1               (0x400A205C) /**< \brief (PDCA) Status Register 1 */
+#define REG_PDCA_IER1              (0x400A2060) /**< \brief (PDCA) Interrupt Enable Register 1 */
+#define REG_PDCA_IDR1              (0x400A2064) /**< \brief (PDCA) Interrupt Disable Register 1 */
+#define REG_PDCA_IMR1              (0x400A2068) /**< \brief (PDCA) Interrupt Mask Register 1 */
+#define REG_PDCA_ISR1              (0x400A206C) /**< \brief (PDCA) Interrupt Status Register 1 */
+#define REG_PDCA_MAR2              (0x400A2080) /**< \brief (PDCA) Memory Address Register 2 */
+#define REG_PDCA_PSR2              (0x400A2084) /**< \brief (PDCA) Peripheral Select Register 2 */
+#define REG_PDCA_TCR2              (0x400A2088) /**< \brief (PDCA) Transfer Counter Register 2 */
+#define REG_PDCA_MARR2             (0x400A208C) /**< \brief (PDCA) Memory Address Reload Register 2 */
+#define REG_PDCA_TCRR2             (0x400A2090) /**< \brief (PDCA) Transfer Counter Reload Register 2 */
+#define REG_PDCA_CR2               (0x400A2094) /**< \brief (PDCA) Control Register 2 */
+#define REG_PDCA_MR2               (0x400A2098) /**< \brief (PDCA) Mode Register 2 */
+#define REG_PDCA_SR2               (0x400A209C) /**< \brief (PDCA) Status Register 2 */
+#define REG_PDCA_IER2              (0x400A20A0) /**< \brief (PDCA) Interrupt Enable Register 2 */
+#define REG_PDCA_IDR2              (0x400A20A4) /**< \brief (PDCA) Interrupt Disable Register 2 */
+#define REG_PDCA_IMR2              (0x400A20A8) /**< \brief (PDCA) Interrupt Mask Register 2 */
+#define REG_PDCA_ISR2              (0x400A20AC) /**< \brief (PDCA) Interrupt Status Register 2 */
+#define REG_PDCA_MAR3              (0x400A20C0) /**< \brief (PDCA) Memory Address Register 3 */
+#define REG_PDCA_PSR3              (0x400A20C4) /**< \brief (PDCA) Peripheral Select Register 3 */
+#define REG_PDCA_TCR3              (0x400A20C8) /**< \brief (PDCA) Transfer Counter Register 3 */
+#define REG_PDCA_MARR3             (0x400A20CC) /**< \brief (PDCA) Memory Address Reload Register 3 */
+#define REG_PDCA_TCRR3             (0x400A20D0) /**< \brief (PDCA) Transfer Counter Reload Register 3 */
+#define REG_PDCA_CR3               (0x400A20D4) /**< \brief (PDCA) Control Register 3 */
+#define REG_PDCA_MR3               (0x400A20D8) /**< \brief (PDCA) Mode Register 3 */
+#define REG_PDCA_SR3               (0x400A20DC) /**< \brief (PDCA) Status Register 3 */
+#define REG_PDCA_IER3              (0x400A20E0) /**< \brief (PDCA) Interrupt Enable Register 3 */
+#define REG_PDCA_IDR3              (0x400A20E4) /**< \brief (PDCA) Interrupt Disable Register 3 */
+#define REG_PDCA_IMR3              (0x400A20E8) /**< \brief (PDCA) Interrupt Mask Register 3 */
+#define REG_PDCA_ISR3              (0x400A20EC) /**< \brief (PDCA) Interrupt Status Register 3 */
+#define REG_PDCA_MAR4              (0x400A2100) /**< \brief (PDCA) Memory Address Register 4 */
+#define REG_PDCA_PSR4              (0x400A2104) /**< \brief (PDCA) Peripheral Select Register 4 */
+#define REG_PDCA_TCR4              (0x400A2108) /**< \brief (PDCA) Transfer Counter Register 4 */
+#define REG_PDCA_MARR4             (0x400A210C) /**< \brief (PDCA) Memory Address Reload Register 4 */
+#define REG_PDCA_TCRR4             (0x400A2110) /**< \brief (PDCA) Transfer Counter Reload Register 4 */
+#define REG_PDCA_CR4               (0x400A2114) /**< \brief (PDCA) Control Register 4 */
+#define REG_PDCA_MR4               (0x400A2118) /**< \brief (PDCA) Mode Register 4 */
+#define REG_PDCA_SR4               (0x400A211C) /**< \brief (PDCA) Status Register 4 */
+#define REG_PDCA_IER4              (0x400A2120) /**< \brief (PDCA) Interrupt Enable Register 4 */
+#define REG_PDCA_IDR4              (0x400A2124) /**< \brief (PDCA) Interrupt Disable Register 4 */
+#define REG_PDCA_IMR4              (0x400A2128) /**< \brief (PDCA) Interrupt Mask Register 4 */
+#define REG_PDCA_ISR4              (0x400A212C) /**< \brief (PDCA) Interrupt Status Register 4 */
+#define REG_PDCA_MAR5              (0x400A2140) /**< \brief (PDCA) Memory Address Register 5 */
+#define REG_PDCA_PSR5              (0x400A2144) /**< \brief (PDCA) Peripheral Select Register 5 */
+#define REG_PDCA_TCR5              (0x400A2148) /**< \brief (PDCA) Transfer Counter Register 5 */
+#define REG_PDCA_MARR5             (0x400A214C) /**< \brief (PDCA) Memory Address Reload Register 5 */
+#define REG_PDCA_TCRR5             (0x400A2150) /**< \brief (PDCA) Transfer Counter Reload Register 5 */
+#define REG_PDCA_CR5               (0x400A2154) /**< \brief (PDCA) Control Register 5 */
+#define REG_PDCA_MR5               (0x400A2158) /**< \brief (PDCA) Mode Register 5 */
+#define REG_PDCA_SR5               (0x400A215C) /**< \brief (PDCA) Status Register 5 */
+#define REG_PDCA_IER5              (0x400A2160) /**< \brief (PDCA) Interrupt Enable Register 5 */
+#define REG_PDCA_IDR5              (0x400A2164) /**< \brief (PDCA) Interrupt Disable Register 5 */
+#define REG_PDCA_IMR5              (0x400A2168) /**< \brief (PDCA) Interrupt Mask Register 5 */
+#define REG_PDCA_ISR5              (0x400A216C) /**< \brief (PDCA) Interrupt Status Register 5 */
+#define REG_PDCA_MAR6              (0x400A2180) /**< \brief (PDCA) Memory Address Register 6 */
+#define REG_PDCA_PSR6              (0x400A2184) /**< \brief (PDCA) Peripheral Select Register 6 */
+#define REG_PDCA_TCR6              (0x400A2188) /**< \brief (PDCA) Transfer Counter Register 6 */
+#define REG_PDCA_MARR6             (0x400A218C) /**< \brief (PDCA) Memory Address Reload Register 6 */
+#define REG_PDCA_TCRR6             (0x400A2190) /**< \brief (PDCA) Transfer Counter Reload Register 6 */
+#define REG_PDCA_CR6               (0x400A2194) /**< \brief (PDCA) Control Register 6 */
+#define REG_PDCA_MR6               (0x400A2198) /**< \brief (PDCA) Mode Register 6 */
+#define REG_PDCA_SR6               (0x400A219C) /**< \brief (PDCA) Status Register 6 */
+#define REG_PDCA_IER6              (0x400A21A0) /**< \brief (PDCA) Interrupt Enable Register 6 */
+#define REG_PDCA_IDR6              (0x400A21A4) /**< \brief (PDCA) Interrupt Disable Register 6 */
+#define REG_PDCA_IMR6              (0x400A21A8) /**< \brief (PDCA) Interrupt Mask Register 6 */
+#define REG_PDCA_ISR6              (0x400A21AC) /**< \brief (PDCA) Interrupt Status Register 6 */
+#define REG_PDCA_MAR7              (0x400A21C0) /**< \brief (PDCA) Memory Address Register 7 */
+#define REG_PDCA_PSR7              (0x400A21C4) /**< \brief (PDCA) Peripheral Select Register 7 */
+#define REG_PDCA_TCR7              (0x400A21C8) /**< \brief (PDCA) Transfer Counter Register 7 */
+#define REG_PDCA_MARR7             (0x400A21CC) /**< \brief (PDCA) Memory Address Reload Register 7 */
+#define REG_PDCA_TCRR7             (0x400A21D0) /**< \brief (PDCA) Transfer Counter Reload Register 7 */
+#define REG_PDCA_CR7               (0x400A21D4) /**< \brief (PDCA) Control Register 7 */
+#define REG_PDCA_MR7               (0x400A21D8) /**< \brief (PDCA) Mode Register 7 */
+#define REG_PDCA_SR7               (0x400A21DC) /**< \brief (PDCA) Status Register 7 */
+#define REG_PDCA_IER7              (0x400A21E0) /**< \brief (PDCA) Interrupt Enable Register 7 */
+#define REG_PDCA_IDR7              (0x400A21E4) /**< \brief (PDCA) Interrupt Disable Register 7 */
+#define REG_PDCA_IMR7              (0x400A21E8) /**< \brief (PDCA) Interrupt Mask Register 7 */
+#define REG_PDCA_ISR7              (0x400A21EC) /**< \brief (PDCA) Interrupt Status Register 7 */
+#define REG_PDCA_MAR8              (0x400A2200) /**< \brief (PDCA) Memory Address Register 8 */
+#define REG_PDCA_PSR8              (0x400A2204) /**< \brief (PDCA) Peripheral Select Register 8 */
+#define REG_PDCA_TCR8              (0x400A2208) /**< \brief (PDCA) Transfer Counter Register 8 */
+#define REG_PDCA_MARR8             (0x400A220C) /**< \brief (PDCA) Memory Address Reload Register 8 */
+#define REG_PDCA_TCRR8             (0x400A2210) /**< \brief (PDCA) Transfer Counter Reload Register 8 */
+#define REG_PDCA_CR8               (0x400A2214) /**< \brief (PDCA) Control Register 8 */
+#define REG_PDCA_MR8               (0x400A2218) /**< \brief (PDCA) Mode Register 8 */
+#define REG_PDCA_SR8               (0x400A221C) /**< \brief (PDCA) Status Register 8 */
+#define REG_PDCA_IER8              (0x400A2220) /**< \brief (PDCA) Interrupt Enable Register 8 */
+#define REG_PDCA_IDR8              (0x400A2224) /**< \brief (PDCA) Interrupt Disable Register 8 */
+#define REG_PDCA_IMR8              (0x400A2228) /**< \brief (PDCA) Interrupt Mask Register 8 */
+#define REG_PDCA_ISR8              (0x400A222C) /**< \brief (PDCA) Interrupt Status Register 8 */
+#define REG_PDCA_MAR9              (0x400A2240) /**< \brief (PDCA) Memory Address Register 9 */
+#define REG_PDCA_PSR9              (0x400A2244) /**< \brief (PDCA) Peripheral Select Register 9 */
+#define REG_PDCA_TCR9              (0x400A2248) /**< \brief (PDCA) Transfer Counter Register 9 */
+#define REG_PDCA_MARR9             (0x400A224C) /**< \brief (PDCA) Memory Address Reload Register 9 */
+#define REG_PDCA_TCRR9             (0x400A2250) /**< \brief (PDCA) Transfer Counter Reload Register 9 */
+#define REG_PDCA_CR9               (0x400A2254) /**< \brief (PDCA) Control Register 9 */
+#define REG_PDCA_MR9               (0x400A2258) /**< \brief (PDCA) Mode Register 9 */
+#define REG_PDCA_SR9               (0x400A225C) /**< \brief (PDCA) Status Register 9 */
+#define REG_PDCA_IER9              (0x400A2260) /**< \brief (PDCA) Interrupt Enable Register 9 */
+#define REG_PDCA_IDR9              (0x400A2264) /**< \brief (PDCA) Interrupt Disable Register 9 */
+#define REG_PDCA_IMR9              (0x400A2268) /**< \brief (PDCA) Interrupt Mask Register 9 */
+#define REG_PDCA_ISR9              (0x400A226C) /**< \brief (PDCA) Interrupt Status Register 9 */
+#define REG_PDCA_MAR10             (0x400A2280) /**< \brief (PDCA) Memory Address Register 10 */
+#define REG_PDCA_PSR10             (0x400A2284) /**< \brief (PDCA) Peripheral Select Register 10 */
+#define REG_PDCA_TCR10             (0x400A2288) /**< \brief (PDCA) Transfer Counter Register 10 */
+#define REG_PDCA_MARR10            (0x400A228C) /**< \brief (PDCA) Memory Address Reload Register 10 */
+#define REG_PDCA_TCRR10            (0x400A2290) /**< \brief (PDCA) Transfer Counter Reload Register 10 */
+#define REG_PDCA_CR10              (0x400A2294) /**< \brief (PDCA) Control Register 10 */
+#define REG_PDCA_MR10              (0x400A2298) /**< \brief (PDCA) Mode Register 10 */
+#define REG_PDCA_SR10              (0x400A229C) /**< \brief (PDCA) Status Register 10 */
+#define REG_PDCA_IER10             (0x400A22A0) /**< \brief (PDCA) Interrupt Enable Register 10 */
+#define REG_PDCA_IDR10             (0x400A22A4) /**< \brief (PDCA) Interrupt Disable Register 10 */
+#define REG_PDCA_IMR10             (0x400A22A8) /**< \brief (PDCA) Interrupt Mask Register 10 */
+#define REG_PDCA_ISR10             (0x400A22AC) /**< \brief (PDCA) Interrupt Status Register 10 */
+#define REG_PDCA_MAR11             (0x400A22C0) /**< \brief (PDCA) Memory Address Register 11 */
+#define REG_PDCA_PSR11             (0x400A22C4) /**< \brief (PDCA) Peripheral Select Register 11 */
+#define REG_PDCA_TCR11             (0x400A22C8) /**< \brief (PDCA) Transfer Counter Register 11 */
+#define REG_PDCA_MARR11            (0x400A22CC) /**< \brief (PDCA) Memory Address Reload Register 11 */
+#define REG_PDCA_TCRR11            (0x400A22D0) /**< \brief (PDCA) Transfer Counter Reload Register 11 */
+#define REG_PDCA_CR11              (0x400A22D4) /**< \brief (PDCA) Control Register 11 */
+#define REG_PDCA_MR11              (0x400A22D8) /**< \brief (PDCA) Mode Register 11 */
+#define REG_PDCA_SR11              (0x400A22DC) /**< \brief (PDCA) Status Register 11 */
+#define REG_PDCA_IER11             (0x400A22E0) /**< \brief (PDCA) Interrupt Enable Register 11 */
+#define REG_PDCA_IDR11             (0x400A22E4) /**< \brief (PDCA) Interrupt Disable Register 11 */
+#define REG_PDCA_IMR11             (0x400A22E8) /**< \brief (PDCA) Interrupt Mask Register 11 */
+#define REG_PDCA_ISR11             (0x400A22EC) /**< \brief (PDCA) Interrupt Status Register 11 */
+#define REG_PDCA_MAR12             (0x400A2300) /**< \brief (PDCA) Memory Address Register 12 */
+#define REG_PDCA_PSR12             (0x400A2304) /**< \brief (PDCA) Peripheral Select Register 12 */
+#define REG_PDCA_TCR12             (0x400A2308) /**< \brief (PDCA) Transfer Counter Register 12 */
+#define REG_PDCA_MARR12            (0x400A230C) /**< \brief (PDCA) Memory Address Reload Register 12 */
+#define REG_PDCA_TCRR12            (0x400A2310) /**< \brief (PDCA) Transfer Counter Reload Register 12 */
+#define REG_PDCA_CR12              (0x400A2314) /**< \brief (PDCA) Control Register 12 */
+#define REG_PDCA_MR12              (0x400A2318) /**< \brief (PDCA) Mode Register 12 */
+#define REG_PDCA_SR12              (0x400A231C) /**< \brief (PDCA) Status Register 12 */
+#define REG_PDCA_IER12             (0x400A2320) /**< \brief (PDCA) Interrupt Enable Register 12 */
+#define REG_PDCA_IDR12             (0x400A2324) /**< \brief (PDCA) Interrupt Disable Register 12 */
+#define REG_PDCA_IMR12             (0x400A2328) /**< \brief (PDCA) Interrupt Mask Register 12 */
+#define REG_PDCA_ISR12             (0x400A232C) /**< \brief (PDCA) Interrupt Status Register 12 */
+#define REG_PDCA_MAR13             (0x400A2340) /**< \brief (PDCA) Memory Address Register 13 */
+#define REG_PDCA_PSR13             (0x400A2344) /**< \brief (PDCA) Peripheral Select Register 13 */
+#define REG_PDCA_TCR13             (0x400A2348) /**< \brief (PDCA) Transfer Counter Register 13 */
+#define REG_PDCA_MARR13            (0x400A234C) /**< \brief (PDCA) Memory Address Reload Register 13 */
+#define REG_PDCA_TCRR13            (0x400A2350) /**< \brief (PDCA) Transfer Counter Reload Register 13 */
+#define REG_PDCA_CR13              (0x400A2354) /**< \brief (PDCA) Control Register 13 */
+#define REG_PDCA_MR13              (0x400A2358) /**< \brief (PDCA) Mode Register 13 */
+#define REG_PDCA_SR13              (0x400A235C) /**< \brief (PDCA) Status Register 13 */
+#define REG_PDCA_IER13             (0x400A2360) /**< \brief (PDCA) Interrupt Enable Register 13 */
+#define REG_PDCA_IDR13             (0x400A2364) /**< \brief (PDCA) Interrupt Disable Register 13 */
+#define REG_PDCA_IMR13             (0x400A2368) /**< \brief (PDCA) Interrupt Mask Register 13 */
+#define REG_PDCA_ISR13             (0x400A236C) /**< \brief (PDCA) Interrupt Status Register 13 */
+#define REG_PDCA_MAR14             (0x400A2380) /**< \brief (PDCA) Memory Address Register 14 */
+#define REG_PDCA_PSR14             (0x400A2384) /**< \brief (PDCA) Peripheral Select Register 14 */
+#define REG_PDCA_TCR14             (0x400A2388) /**< \brief (PDCA) Transfer Counter Register 14 */
+#define REG_PDCA_MARR14            (0x400A238C) /**< \brief (PDCA) Memory Address Reload Register 14 */
+#define REG_PDCA_TCRR14            (0x400A2390) /**< \brief (PDCA) Transfer Counter Reload Register 14 */
+#define REG_PDCA_CR14              (0x400A2394) /**< \brief (PDCA) Control Register 14 */
+#define REG_PDCA_MR14              (0x400A2398) /**< \brief (PDCA) Mode Register 14 */
+#define REG_PDCA_SR14              (0x400A239C) /**< \brief (PDCA) Status Register 14 */
+#define REG_PDCA_IER14             (0x400A23A0) /**< \brief (PDCA) Interrupt Enable Register 14 */
+#define REG_PDCA_IDR14             (0x400A23A4) /**< \brief (PDCA) Interrupt Disable Register 14 */
+#define REG_PDCA_IMR14             (0x400A23A8) /**< \brief (PDCA) Interrupt Mask Register 14 */
+#define REG_PDCA_ISR14             (0x400A23AC) /**< \brief (PDCA) Interrupt Status Register 14 */
+#define REG_PDCA_MAR15             (0x400A23C0) /**< \brief (PDCA) Memory Address Register 15 */
+#define REG_PDCA_PSR15             (0x400A23C4) /**< \brief (PDCA) Peripheral Select Register 15 */
+#define REG_PDCA_TCR15             (0x400A23C8) /**< \brief (PDCA) Transfer Counter Register 15 */
+#define REG_PDCA_MARR15            (0x400A23CC) /**< \brief (PDCA) Memory Address Reload Register 15 */
+#define REG_PDCA_TCRR15            (0x400A23D0) /**< \brief (PDCA) Transfer Counter Reload Register 15 */
+#define REG_PDCA_CR15              (0x400A23D4) /**< \brief (PDCA) Control Register 15 */
+#define REG_PDCA_MR15              (0x400A23D8) /**< \brief (PDCA) Mode Register 15 */
+#define REG_PDCA_SR15              (0x400A23DC) /**< \brief (PDCA) Status Register 15 */
+#define REG_PDCA_IER15             (0x400A23E0) /**< \brief (PDCA) Interrupt Enable Register 15 */
+#define REG_PDCA_IDR15             (0x400A23E4) /**< \brief (PDCA) Interrupt Disable Register 15 */
+#define REG_PDCA_IMR15             (0x400A23E8) /**< \brief (PDCA) Interrupt Mask Register 15 */
+#define REG_PDCA_ISR15             (0x400A23EC) /**< \brief (PDCA) Interrupt Status Register 15 */
+#define REG_PDCA_PCONTROL          (0x400A2800) /**< \brief (PDCA) Performance Control Register */
+#define REG_PDCA_PRDATA0           (0x400A2804) /**< \brief (PDCA) Channel 0 Read Data Cycles */
+#define REG_PDCA_PRSTALL0          (0x400A2808) /**< \brief (PDCA) Channel 0 Read Stall Cycles */
+#define REG_PDCA_PRLAT0            (0x400A280C) /**< \brief (PDCA) Channel 0 Read Max Latency */
+#define REG_PDCA_PWDATA0           (0x400A2810) /**< \brief (PDCA) Channel 0 Write Data Cycles */
+#define REG_PDCA_PWSTALL0          (0x400A2814) /**< \brief (PDCA) Channel 0 Write Stall Cycles */
+#define REG_PDCA_PWLAT0            (0x400A2818) /**< \brief (PDCA) Channel0 Write Max Latency */
+#define REG_PDCA_PRDATA1           (0x400A281C) /**< \brief (PDCA) Channel 1 Read Data Cycles */
+#define REG_PDCA_PRSTALL1          (0x400A2820) /**< \brief (PDCA) Channel Read Stall Cycles */
+#define REG_PDCA_PRLAT1            (0x400A2824) /**< \brief (PDCA) Channel 1 Read Max Latency */
+#define REG_PDCA_PWDATA1           (0x400A2828) /**< \brief (PDCA) Channel 1 Write Data Cycles */
+#define REG_PDCA_PWSTALL1          (0x400A282C) /**< \brief (PDCA) Channel 1 Write stall Cycles */
+#define REG_PDCA_PWLAT1            (0x400A2830) /**< \brief (PDCA) Channel 1 Read Max Latency */
+#define REG_PDCA_VERSION           (0x400A2834) /**< \brief (PDCA) Version Register */
+#else
+#define REG_PDCA_MAR0              (*(RwReg  *)0x400A2000UL) /**< \brief (PDCA) Memory Address Register 0 */
+#define REG_PDCA_PSR0              (*(RwReg  *)0x400A2004UL) /**< \brief (PDCA) Peripheral Select Register 0 */
+#define REG_PDCA_TCR0              (*(RwReg  *)0x400A2008UL) /**< \brief (PDCA) Transfer Counter Register 0 */
+#define REG_PDCA_MARR0             (*(RwReg  *)0x400A200CUL) /**< \brief (PDCA) Memory Address Reload Register 0 */
+#define REG_PDCA_TCRR0             (*(RwReg  *)0x400A2010UL) /**< \brief (PDCA) Transfer Counter Reload Register 0 */
+#define REG_PDCA_CR0               (*(WoReg  *)0x400A2014UL) /**< \brief (PDCA) Control Register 0 */
+#define REG_PDCA_MR0               (*(RwReg  *)0x400A2018UL) /**< \brief (PDCA) Mode Register 0 */
+#define REG_PDCA_SR0               (*(RoReg  *)0x400A201CUL) /**< \brief (PDCA) Status Register 0 */
+#define REG_PDCA_IER0              (*(WoReg  *)0x400A2020UL) /**< \brief (PDCA) Interrupt Enable Register 0 */
+#define REG_PDCA_IDR0              (*(WoReg  *)0x400A2024UL) /**< \brief (PDCA) Interrupt Disable Register 0 */
+#define REG_PDCA_IMR0              (*(RoReg  *)0x400A2028UL) /**< \brief (PDCA) Interrupt Mask Register 0 */
+#define REG_PDCA_ISR0              (*(RoReg  *)0x400A202CUL) /**< \brief (PDCA) Interrupt Status Register 0 */
+#define REG_PDCA_MAR1              (*(RwReg  *)0x400A2040UL) /**< \brief (PDCA) Memory Address Register 1 */
+#define REG_PDCA_PSR1              (*(RwReg  *)0x400A2044UL) /**< \brief (PDCA) Peripheral Select Register 1 */
+#define REG_PDCA_TCR1              (*(RwReg  *)0x400A2048UL) /**< \brief (PDCA) Transfer Counter Register 1 */
+#define REG_PDCA_MARR1             (*(RwReg  *)0x400A204CUL) /**< \brief (PDCA) Memory Address Reload Register 1 */
+#define REG_PDCA_TCRR1             (*(RwReg  *)0x400A2050UL) /**< \brief (PDCA) Transfer Counter Reload Register 1 */
+#define REG_PDCA_CR1               (*(WoReg  *)0x400A2054UL) /**< \brief (PDCA) Control Register 1 */
+#define REG_PDCA_MR1               (*(RwReg  *)0x400A2058UL) /**< \brief (PDCA) Mode Register 1 */
+#define REG_PDCA_SR1               (*(RoReg  *)0x400A205CUL) /**< \brief (PDCA) Status Register 1 */
+#define REG_PDCA_IER1              (*(WoReg  *)0x400A2060UL) /**< \brief (PDCA) Interrupt Enable Register 1 */
+#define REG_PDCA_IDR1              (*(WoReg  *)0x400A2064UL) /**< \brief (PDCA) Interrupt Disable Register 1 */
+#define REG_PDCA_IMR1              (*(RoReg  *)0x400A2068UL) /**< \brief (PDCA) Interrupt Mask Register 1 */
+#define REG_PDCA_ISR1              (*(RoReg  *)0x400A206CUL) /**< \brief (PDCA) Interrupt Status Register 1 */
+#define REG_PDCA_MAR2              (*(RwReg  *)0x400A2080UL) /**< \brief (PDCA) Memory Address Register 2 */
+#define REG_PDCA_PSR2              (*(RwReg  *)0x400A2084UL) /**< \brief (PDCA) Peripheral Select Register 2 */
+#define REG_PDCA_TCR2              (*(RwReg  *)0x400A2088UL) /**< \brief (PDCA) Transfer Counter Register 2 */
+#define REG_PDCA_MARR2             (*(RwReg  *)0x400A208CUL) /**< \brief (PDCA) Memory Address Reload Register 2 */
+#define REG_PDCA_TCRR2             (*(RwReg  *)0x400A2090UL) /**< \brief (PDCA) Transfer Counter Reload Register 2 */
+#define REG_PDCA_CR2               (*(WoReg  *)0x400A2094UL) /**< \brief (PDCA) Control Register 2 */
+#define REG_PDCA_MR2               (*(RwReg  *)0x400A2098UL) /**< \brief (PDCA) Mode Register 2 */
+#define REG_PDCA_SR2               (*(RoReg  *)0x400A209CUL) /**< \brief (PDCA) Status Register 2 */
+#define REG_PDCA_IER2              (*(WoReg  *)0x400A20A0UL) /**< \brief (PDCA) Interrupt Enable Register 2 */
+#define REG_PDCA_IDR2              (*(WoReg  *)0x400A20A4UL) /**< \brief (PDCA) Interrupt Disable Register 2 */
+#define REG_PDCA_IMR2              (*(RoReg  *)0x400A20A8UL) /**< \brief (PDCA) Interrupt Mask Register 2 */
+#define REG_PDCA_ISR2              (*(RoReg  *)0x400A20ACUL) /**< \brief (PDCA) Interrupt Status Register 2 */
+#define REG_PDCA_MAR3              (*(RwReg  *)0x400A20C0UL) /**< \brief (PDCA) Memory Address Register 3 */
+#define REG_PDCA_PSR3              (*(RwReg  *)0x400A20C4UL) /**< \brief (PDCA) Peripheral Select Register 3 */
+#define REG_PDCA_TCR3              (*(RwReg  *)0x400A20C8UL) /**< \brief (PDCA) Transfer Counter Register 3 */
+#define REG_PDCA_MARR3             (*(RwReg  *)0x400A20CCUL) /**< \brief (PDCA) Memory Address Reload Register 3 */
+#define REG_PDCA_TCRR3             (*(RwReg  *)0x400A20D0UL) /**< \brief (PDCA) Transfer Counter Reload Register 3 */
+#define REG_PDCA_CR3               (*(WoReg  *)0x400A20D4UL) /**< \brief (PDCA) Control Register 3 */
+#define REG_PDCA_MR3               (*(RwReg  *)0x400A20D8UL) /**< \brief (PDCA) Mode Register 3 */
+#define REG_PDCA_SR3               (*(RoReg  *)0x400A20DCUL) /**< \brief (PDCA) Status Register 3 */
+#define REG_PDCA_IER3              (*(WoReg  *)0x400A20E0UL) /**< \brief (PDCA) Interrupt Enable Register 3 */
+#define REG_PDCA_IDR3              (*(WoReg  *)0x400A20E4UL) /**< \brief (PDCA) Interrupt Disable Register 3 */
+#define REG_PDCA_IMR3              (*(RoReg  *)0x400A20E8UL) /**< \brief (PDCA) Interrupt Mask Register 3 */
+#define REG_PDCA_ISR3              (*(RoReg  *)0x400A20ECUL) /**< \brief (PDCA) Interrupt Status Register 3 */
+#define REG_PDCA_MAR4              (*(RwReg  *)0x400A2100UL) /**< \brief (PDCA) Memory Address Register 4 */
+#define REG_PDCA_PSR4              (*(RwReg  *)0x400A2104UL) /**< \brief (PDCA) Peripheral Select Register 4 */
+#define REG_PDCA_TCR4              (*(RwReg  *)0x400A2108UL) /**< \brief (PDCA) Transfer Counter Register 4 */
+#define REG_PDCA_MARR4             (*(RwReg  *)0x400A210CUL) /**< \brief (PDCA) Memory Address Reload Register 4 */
+#define REG_PDCA_TCRR4             (*(RwReg  *)0x400A2110UL) /**< \brief (PDCA) Transfer Counter Reload Register 4 */
+#define REG_PDCA_CR4               (*(WoReg  *)0x400A2114UL) /**< \brief (PDCA) Control Register 4 */
+#define REG_PDCA_MR4               (*(RwReg  *)0x400A2118UL) /**< \brief (PDCA) Mode Register 4 */
+#define REG_PDCA_SR4               (*(RoReg  *)0x400A211CUL) /**< \brief (PDCA) Status Register 4 */
+#define REG_PDCA_IER4              (*(WoReg  *)0x400A2120UL) /**< \brief (PDCA) Interrupt Enable Register 4 */
+#define REG_PDCA_IDR4              (*(WoReg  *)0x400A2124UL) /**< \brief (PDCA) Interrupt Disable Register 4 */
+#define REG_PDCA_IMR4              (*(RoReg  *)0x400A2128UL) /**< \brief (PDCA) Interrupt Mask Register 4 */
+#define REG_PDCA_ISR4              (*(RoReg  *)0x400A212CUL) /**< \brief (PDCA) Interrupt Status Register 4 */
+#define REG_PDCA_MAR5              (*(RwReg  *)0x400A2140UL) /**< \brief (PDCA) Memory Address Register 5 */
+#define REG_PDCA_PSR5              (*(RwReg  *)0x400A2144UL) /**< \brief (PDCA) Peripheral Select Register 5 */
+#define REG_PDCA_TCR5              (*(RwReg  *)0x400A2148UL) /**< \brief (PDCA) Transfer Counter Register 5 */
+#define REG_PDCA_MARR5             (*(RwReg  *)0x400A214CUL) /**< \brief (PDCA) Memory Address Reload Register 5 */
+#define REG_PDCA_TCRR5             (*(RwReg  *)0x400A2150UL) /**< \brief (PDCA) Transfer Counter Reload Register 5 */
+#define REG_PDCA_CR5               (*(WoReg  *)0x400A2154UL) /**< \brief (PDCA) Control Register 5 */
+#define REG_PDCA_MR5               (*(RwReg  *)0x400A2158UL) /**< \brief (PDCA) Mode Register 5 */
+#define REG_PDCA_SR5               (*(RoReg  *)0x400A215CUL) /**< \brief (PDCA) Status Register 5 */
+#define REG_PDCA_IER5              (*(WoReg  *)0x400A2160UL) /**< \brief (PDCA) Interrupt Enable Register 5 */
+#define REG_PDCA_IDR5              (*(WoReg  *)0x400A2164UL) /**< \brief (PDCA) Interrupt Disable Register 5 */
+#define REG_PDCA_IMR5              (*(RoReg  *)0x400A2168UL) /**< \brief (PDCA) Interrupt Mask Register 5 */
+#define REG_PDCA_ISR5              (*(RoReg  *)0x400A216CUL) /**< \brief (PDCA) Interrupt Status Register 5 */
+#define REG_PDCA_MAR6              (*(RwReg  *)0x400A2180UL) /**< \brief (PDCA) Memory Address Register 6 */
+#define REG_PDCA_PSR6              (*(RwReg  *)0x400A2184UL) /**< \brief (PDCA) Peripheral Select Register 6 */
+#define REG_PDCA_TCR6              (*(RwReg  *)0x400A2188UL) /**< \brief (PDCA) Transfer Counter Register 6 */
+#define REG_PDCA_MARR6             (*(RwReg  *)0x400A218CUL) /**< \brief (PDCA) Memory Address Reload Register 6 */
+#define REG_PDCA_TCRR6             (*(RwReg  *)0x400A2190UL) /**< \brief (PDCA) Transfer Counter Reload Register 6 */
+#define REG_PDCA_CR6               (*(WoReg  *)0x400A2194UL) /**< \brief (PDCA) Control Register 6 */
+#define REG_PDCA_MR6               (*(RwReg  *)0x400A2198UL) /**< \brief (PDCA) Mode Register 6 */
+#define REG_PDCA_SR6               (*(RoReg  *)0x400A219CUL) /**< \brief (PDCA) Status Register 6 */
+#define REG_PDCA_IER6              (*(WoReg  *)0x400A21A0UL) /**< \brief (PDCA) Interrupt Enable Register 6 */
+#define REG_PDCA_IDR6              (*(WoReg  *)0x400A21A4UL) /**< \brief (PDCA) Interrupt Disable Register 6 */
+#define REG_PDCA_IMR6              (*(RoReg  *)0x400A21A8UL) /**< \brief (PDCA) Interrupt Mask Register 6 */
+#define REG_PDCA_ISR6              (*(RoReg  *)0x400A21ACUL) /**< \brief (PDCA) Interrupt Status Register 6 */
+#define REG_PDCA_MAR7              (*(RwReg  *)0x400A21C0UL) /**< \brief (PDCA) Memory Address Register 7 */
+#define REG_PDCA_PSR7              (*(RwReg  *)0x400A21C4UL) /**< \brief (PDCA) Peripheral Select Register 7 */
+#define REG_PDCA_TCR7              (*(RwReg  *)0x400A21C8UL) /**< \brief (PDCA) Transfer Counter Register 7 */
+#define REG_PDCA_MARR7             (*(RwReg  *)0x400A21CCUL) /**< \brief (PDCA) Memory Address Reload Register 7 */
+#define REG_PDCA_TCRR7             (*(RwReg  *)0x400A21D0UL) /**< \brief (PDCA) Transfer Counter Reload Register 7 */
+#define REG_PDCA_CR7               (*(WoReg  *)0x400A21D4UL) /**< \brief (PDCA) Control Register 7 */
+#define REG_PDCA_MR7               (*(RwReg  *)0x400A21D8UL) /**< \brief (PDCA) Mode Register 7 */
+#define REG_PDCA_SR7               (*(RoReg  *)0x400A21DCUL) /**< \brief (PDCA) Status Register 7 */
+#define REG_PDCA_IER7              (*(WoReg  *)0x400A21E0UL) /**< \brief (PDCA) Interrupt Enable Register 7 */
+#define REG_PDCA_IDR7              (*(WoReg  *)0x400A21E4UL) /**< \brief (PDCA) Interrupt Disable Register 7 */
+#define REG_PDCA_IMR7              (*(RoReg  *)0x400A21E8UL) /**< \brief (PDCA) Interrupt Mask Register 7 */
+#define REG_PDCA_ISR7              (*(RoReg  *)0x400A21ECUL) /**< \brief (PDCA) Interrupt Status Register 7 */
+#define REG_PDCA_MAR8              (*(RwReg  *)0x400A2200UL) /**< \brief (PDCA) Memory Address Register 8 */
+#define REG_PDCA_PSR8              (*(RwReg  *)0x400A2204UL) /**< \brief (PDCA) Peripheral Select Register 8 */
+#define REG_PDCA_TCR8              (*(RwReg  *)0x400A2208UL) /**< \brief (PDCA) Transfer Counter Register 8 */
+#define REG_PDCA_MARR8             (*(RwReg  *)0x400A220CUL) /**< \brief (PDCA) Memory Address Reload Register 8 */
+#define REG_PDCA_TCRR8             (*(RwReg  *)0x400A2210UL) /**< \brief (PDCA) Transfer Counter Reload Register 8 */
+#define REG_PDCA_CR8               (*(WoReg  *)0x400A2214UL) /**< \brief (PDCA) Control Register 8 */
+#define REG_PDCA_MR8               (*(RwReg  *)0x400A2218UL) /**< \brief (PDCA) Mode Register 8 */
+#define REG_PDCA_SR8               (*(RoReg  *)0x400A221CUL) /**< \brief (PDCA) Status Register 8 */
+#define REG_PDCA_IER8              (*(WoReg  *)0x400A2220UL) /**< \brief (PDCA) Interrupt Enable Register 8 */
+#define REG_PDCA_IDR8              (*(WoReg  *)0x400A2224UL) /**< \brief (PDCA) Interrupt Disable Register 8 */
+#define REG_PDCA_IMR8              (*(RoReg  *)0x400A2228UL) /**< \brief (PDCA) Interrupt Mask Register 8 */
+#define REG_PDCA_ISR8              (*(RoReg  *)0x400A222CUL) /**< \brief (PDCA) Interrupt Status Register 8 */
+#define REG_PDCA_MAR9              (*(RwReg  *)0x400A2240UL) /**< \brief (PDCA) Memory Address Register 9 */
+#define REG_PDCA_PSR9              (*(RwReg  *)0x400A2244UL) /**< \brief (PDCA) Peripheral Select Register 9 */
+#define REG_PDCA_TCR9              (*(RwReg  *)0x400A2248UL) /**< \brief (PDCA) Transfer Counter Register 9 */
+#define REG_PDCA_MARR9             (*(RwReg  *)0x400A224CUL) /**< \brief (PDCA) Memory Address Reload Register 9 */
+#define REG_PDCA_TCRR9             (*(RwReg  *)0x400A2250UL) /**< \brief (PDCA) Transfer Counter Reload Register 9 */
+#define REG_PDCA_CR9               (*(WoReg  *)0x400A2254UL) /**< \brief (PDCA) Control Register 9 */
+#define REG_PDCA_MR9               (*(RwReg  *)0x400A2258UL) /**< \brief (PDCA) Mode Register 9 */
+#define REG_PDCA_SR9               (*(RoReg  *)0x400A225CUL) /**< \brief (PDCA) Status Register 9 */
+#define REG_PDCA_IER9              (*(WoReg  *)0x400A2260UL) /**< \brief (PDCA) Interrupt Enable Register 9 */
+#define REG_PDCA_IDR9              (*(WoReg  *)0x400A2264UL) /**< \brief (PDCA) Interrupt Disable Register 9 */
+#define REG_PDCA_IMR9              (*(RoReg  *)0x400A2268UL) /**< \brief (PDCA) Interrupt Mask Register 9 */
+#define REG_PDCA_ISR9              (*(RoReg  *)0x400A226CUL) /**< \brief (PDCA) Interrupt Status Register 9 */
+#define REG_PDCA_MAR10             (*(RwReg  *)0x400A2280UL) /**< \brief (PDCA) Memory Address Register 10 */
+#define REG_PDCA_PSR10             (*(RwReg  *)0x400A2284UL) /**< \brief (PDCA) Peripheral Select Register 10 */
+#define REG_PDCA_TCR10             (*(RwReg  *)0x400A2288UL) /**< \brief (PDCA) Transfer Counter Register 10 */
+#define REG_PDCA_MARR10            (*(RwReg  *)0x400A228CUL) /**< \brief (PDCA) Memory Address Reload Register 10 */
+#define REG_PDCA_TCRR10            (*(RwReg  *)0x400A2290UL) /**< \brief (PDCA) Transfer Counter Reload Register 10 */
+#define REG_PDCA_CR10              (*(WoReg  *)0x400A2294UL) /**< \brief (PDCA) Control Register 10 */
+#define REG_PDCA_MR10              (*(RwReg  *)0x400A2298UL) /**< \brief (PDCA) Mode Register 10 */
+#define REG_PDCA_SR10              (*(RoReg  *)0x400A229CUL) /**< \brief (PDCA) Status Register 10 */
+#define REG_PDCA_IER10             (*(WoReg  *)0x400A22A0UL) /**< \brief (PDCA) Interrupt Enable Register 10 */
+#define REG_PDCA_IDR10             (*(WoReg  *)0x400A22A4UL) /**< \brief (PDCA) Interrupt Disable Register 10 */
+#define REG_PDCA_IMR10             (*(RoReg  *)0x400A22A8UL) /**< \brief (PDCA) Interrupt Mask Register 10 */
+#define REG_PDCA_ISR10             (*(RoReg  *)0x400A22ACUL) /**< \brief (PDCA) Interrupt Status Register 10 */
+#define REG_PDCA_MAR11             (*(RwReg  *)0x400A22C0UL) /**< \brief (PDCA) Memory Address Register 11 */
+#define REG_PDCA_PSR11             (*(RwReg  *)0x400A22C4UL) /**< \brief (PDCA) Peripheral Select Register 11 */
+#define REG_PDCA_TCR11             (*(RwReg  *)0x400A22C8UL) /**< \brief (PDCA) Transfer Counter Register 11 */
+#define REG_PDCA_MARR11            (*(RwReg  *)0x400A22CCUL) /**< \brief (PDCA) Memory Address Reload Register 11 */
+#define REG_PDCA_TCRR11            (*(RwReg  *)0x400A22D0UL) /**< \brief (PDCA) Transfer Counter Reload Register 11 */
+#define REG_PDCA_CR11              (*(WoReg  *)0x400A22D4UL) /**< \brief (PDCA) Control Register 11 */
+#define REG_PDCA_MR11              (*(RwReg  *)0x400A22D8UL) /**< \brief (PDCA) Mode Register 11 */
+#define REG_PDCA_SR11              (*(RoReg  *)0x400A22DCUL) /**< \brief (PDCA) Status Register 11 */
+#define REG_PDCA_IER11             (*(WoReg  *)0x400A22E0UL) /**< \brief (PDCA) Interrupt Enable Register 11 */
+#define REG_PDCA_IDR11             (*(WoReg  *)0x400A22E4UL) /**< \brief (PDCA) Interrupt Disable Register 11 */
+#define REG_PDCA_IMR11             (*(RoReg  *)0x400A22E8UL) /**< \brief (PDCA) Interrupt Mask Register 11 */
+#define REG_PDCA_ISR11             (*(RoReg  *)0x400A22ECUL) /**< \brief (PDCA) Interrupt Status Register 11 */
+#define REG_PDCA_MAR12             (*(RwReg  *)0x400A2300UL) /**< \brief (PDCA) Memory Address Register 12 */
+#define REG_PDCA_PSR12             (*(RwReg  *)0x400A2304UL) /**< \brief (PDCA) Peripheral Select Register 12 */
+#define REG_PDCA_TCR12             (*(RwReg  *)0x400A2308UL) /**< \brief (PDCA) Transfer Counter Register 12 */
+#define REG_PDCA_MARR12            (*(RwReg  *)0x400A230CUL) /**< \brief (PDCA) Memory Address Reload Register 12 */
+#define REG_PDCA_TCRR12            (*(RwReg  *)0x400A2310UL) /**< \brief (PDCA) Transfer Counter Reload Register 12 */
+#define REG_PDCA_CR12              (*(WoReg  *)0x400A2314UL) /**< \brief (PDCA) Control Register 12 */
+#define REG_PDCA_MR12              (*(RwReg  *)0x400A2318UL) /**< \brief (PDCA) Mode Register 12 */
+#define REG_PDCA_SR12              (*(RoReg  *)0x400A231CUL) /**< \brief (PDCA) Status Register 12 */
+#define REG_PDCA_IER12             (*(WoReg  *)0x400A2320UL) /**< \brief (PDCA) Interrupt Enable Register 12 */
+#define REG_PDCA_IDR12             (*(WoReg  *)0x400A2324UL) /**< \brief (PDCA) Interrupt Disable Register 12 */
+#define REG_PDCA_IMR12             (*(RoReg  *)0x400A2328UL) /**< \brief (PDCA) Interrupt Mask Register 12 */
+#define REG_PDCA_ISR12             (*(RoReg  *)0x400A232CUL) /**< \brief (PDCA) Interrupt Status Register 12 */
+#define REG_PDCA_MAR13             (*(RwReg  *)0x400A2340UL) /**< \brief (PDCA) Memory Address Register 13 */
+#define REG_PDCA_PSR13             (*(RwReg  *)0x400A2344UL) /**< \brief (PDCA) Peripheral Select Register 13 */
+#define REG_PDCA_TCR13             (*(RwReg  *)0x400A2348UL) /**< \brief (PDCA) Transfer Counter Register 13 */
+#define REG_PDCA_MARR13            (*(RwReg  *)0x400A234CUL) /**< \brief (PDCA) Memory Address Reload Register 13 */
+#define REG_PDCA_TCRR13            (*(RwReg  *)0x400A2350UL) /**< \brief (PDCA) Transfer Counter Reload Register 13 */
+#define REG_PDCA_CR13              (*(WoReg  *)0x400A2354UL) /**< \brief (PDCA) Control Register 13 */
+#define REG_PDCA_MR13              (*(RwReg  *)0x400A2358UL) /**< \brief (PDCA) Mode Register 13 */
+#define REG_PDCA_SR13              (*(RoReg  *)0x400A235CUL) /**< \brief (PDCA) Status Register 13 */
+#define REG_PDCA_IER13             (*(WoReg  *)0x400A2360UL) /**< \brief (PDCA) Interrupt Enable Register 13 */
+#define REG_PDCA_IDR13             (*(WoReg  *)0x400A2364UL) /**< \brief (PDCA) Interrupt Disable Register 13 */
+#define REG_PDCA_IMR13             (*(RoReg  *)0x400A2368UL) /**< \brief (PDCA) Interrupt Mask Register 13 */
+#define REG_PDCA_ISR13             (*(RoReg  *)0x400A236CUL) /**< \brief (PDCA) Interrupt Status Register 13 */
+#define REG_PDCA_MAR14             (*(RwReg  *)0x400A2380UL) /**< \brief (PDCA) Memory Address Register 14 */
+#define REG_PDCA_PSR14             (*(RwReg  *)0x400A2384UL) /**< \brief (PDCA) Peripheral Select Register 14 */
+#define REG_PDCA_TCR14             (*(RwReg  *)0x400A2388UL) /**< \brief (PDCA) Transfer Counter Register 14 */
+#define REG_PDCA_MARR14            (*(RwReg  *)0x400A238CUL) /**< \brief (PDCA) Memory Address Reload Register 14 */
+#define REG_PDCA_TCRR14            (*(RwReg  *)0x400A2390UL) /**< \brief (PDCA) Transfer Counter Reload Register 14 */
+#define REG_PDCA_CR14              (*(WoReg  *)0x400A2394UL) /**< \brief (PDCA) Control Register 14 */
+#define REG_PDCA_MR14              (*(RwReg  *)0x400A2398UL) /**< \brief (PDCA) Mode Register 14 */
+#define REG_PDCA_SR14              (*(RoReg  *)0x400A239CUL) /**< \brief (PDCA) Status Register 14 */
+#define REG_PDCA_IER14             (*(WoReg  *)0x400A23A0UL) /**< \brief (PDCA) Interrupt Enable Register 14 */
+#define REG_PDCA_IDR14             (*(WoReg  *)0x400A23A4UL) /**< \brief (PDCA) Interrupt Disable Register 14 */
+#define REG_PDCA_IMR14             (*(RoReg  *)0x400A23A8UL) /**< \brief (PDCA) Interrupt Mask Register 14 */
+#define REG_PDCA_ISR14             (*(RoReg  *)0x400A23ACUL) /**< \brief (PDCA) Interrupt Status Register 14 */
+#define REG_PDCA_MAR15             (*(RwReg  *)0x400A23C0UL) /**< \brief (PDCA) Memory Address Register 15 */
+#define REG_PDCA_PSR15             (*(RwReg  *)0x400A23C4UL) /**< \brief (PDCA) Peripheral Select Register 15 */
+#define REG_PDCA_TCR15             (*(RwReg  *)0x400A23C8UL) /**< \brief (PDCA) Transfer Counter Register 15 */
+#define REG_PDCA_MARR15            (*(RwReg  *)0x400A23CCUL) /**< \brief (PDCA) Memory Address Reload Register 15 */
+#define REG_PDCA_TCRR15            (*(RwReg  *)0x400A23D0UL) /**< \brief (PDCA) Transfer Counter Reload Register 15 */
+#define REG_PDCA_CR15              (*(WoReg  *)0x400A23D4UL) /**< \brief (PDCA) Control Register 15 */
+#define REG_PDCA_MR15              (*(RwReg  *)0x400A23D8UL) /**< \brief (PDCA) Mode Register 15 */
+#define REG_PDCA_SR15              (*(RoReg  *)0x400A23DCUL) /**< \brief (PDCA) Status Register 15 */
+#define REG_PDCA_IER15             (*(WoReg  *)0x400A23E0UL) /**< \brief (PDCA) Interrupt Enable Register 15 */
+#define REG_PDCA_IDR15             (*(WoReg  *)0x400A23E4UL) /**< \brief (PDCA) Interrupt Disable Register 15 */
+#define REG_PDCA_IMR15             (*(RoReg  *)0x400A23E8UL) /**< \brief (PDCA) Interrupt Mask Register 15 */
+#define REG_PDCA_ISR15             (*(RoReg  *)0x400A23ECUL) /**< \brief (PDCA) Interrupt Status Register 15 */
+#define REG_PDCA_PCONTROL          (*(RwReg  *)0x400A2800UL) /**< \brief (PDCA) Performance Control Register */
+#define REG_PDCA_PRDATA0           (*(RoReg  *)0x400A2804UL) /**< \brief (PDCA) Channel 0 Read Data Cycles */
+#define REG_PDCA_PRSTALL0          (*(RoReg  *)0x400A2808UL) /**< \brief (PDCA) Channel 0 Read Stall Cycles */
+#define REG_PDCA_PRLAT0            (*(RoReg  *)0x400A280CUL) /**< \brief (PDCA) Channel 0 Read Max Latency */
+#define REG_PDCA_PWDATA0           (*(RoReg  *)0x400A2810UL) /**< \brief (PDCA) Channel 0 Write Data Cycles */
+#define REG_PDCA_PWSTALL0          (*(RoReg  *)0x400A2814UL) /**< \brief (PDCA) Channel 0 Write Stall Cycles */
+#define REG_PDCA_PWLAT0            (*(RoReg  *)0x400A2818UL) /**< \brief (PDCA) Channel0 Write Max Latency */
+#define REG_PDCA_PRDATA1           (*(RoReg  *)0x400A281CUL) /**< \brief (PDCA) Channel 1 Read Data Cycles */
+#define REG_PDCA_PRSTALL1          (*(RoReg  *)0x400A2820UL) /**< \brief (PDCA) Channel Read Stall Cycles */
+#define REG_PDCA_PRLAT1            (*(RoReg  *)0x400A2824UL) /**< \brief (PDCA) Channel 1 Read Max Latency */
+#define REG_PDCA_PWDATA1           (*(RoReg  *)0x400A2828UL) /**< \brief (PDCA) Channel 1 Write Data Cycles */
+#define REG_PDCA_PWSTALL1          (*(RoReg  *)0x400A282CUL) /**< \brief (PDCA) Channel 1 Write stall Cycles */
+#define REG_PDCA_PWLAT1            (*(RoReg  *)0x400A2830UL) /**< \brief (PDCA) Channel 1 Read Max Latency */
+#define REG_PDCA_VERSION           (*(RoReg  *)0x400A2834UL) /**< \brief (PDCA) Version Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for PDCA peripheral ========== */
+#define PDCA_CHANNEL_LENGTH         16      
+#define PDCA_CLK_AHB_ID             0       
+#define PDCA_MON_CH0_IMPL           0       
+#define PDCA_MON_CH1_IMPL           0       
+
+#endif /* _SAM4L_PDCA_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/pevc.h
+++ b/asf/sam/include/sam4l/instance/pevc.h
@@ -1,0 +1,242 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PEVC
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_PEVC_INSTANCE_
+#define _SAM4L_PEVC_INSTANCE_
+
+/* ========== Register definition for PEVC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_PEVC_CHSR              (0x400A6000) /**< \brief (PEVC) Channel Status Register */
+#define REG_PEVC_CHER              (0x400A6004) /**< \brief (PEVC) Channel Enable Register */
+#define REG_PEVC_CHDR              (0x400A6008) /**< \brief (PEVC) Channel Disable Register */
+#define REG_PEVC_SEV               (0x400A6010) /**< \brief (PEVC) Software Event */
+#define REG_PEVC_BUSY              (0x400A6014) /**< \brief (PEVC) Channel / User Busy */
+#define REG_PEVC_TRIER             (0x400A6020) /**< \brief (PEVC) Trigger Interrupt Mask Enable Register */
+#define REG_PEVC_TRIDR             (0x400A6024) /**< \brief (PEVC) Trigger Interrupt Mask Disable Register */
+#define REG_PEVC_TRIMR             (0x400A6028) /**< \brief (PEVC) Trigger Interrupt Mask Register */
+#define REG_PEVC_TRSR              (0x400A6030) /**< \brief (PEVC) Trigger Status Register */
+#define REG_PEVC_TRSCR             (0x400A6034) /**< \brief (PEVC) Trigger Status Clear Register */
+#define REG_PEVC_OVIER             (0x400A6040) /**< \brief (PEVC) Overrun Interrupt Mask Enable Register */
+#define REG_PEVC_OVIDR             (0x400A6044) /**< \brief (PEVC) Overrun Interrupt Mask Disable Register */
+#define REG_PEVC_OVIMR             (0x400A6048) /**< \brief (PEVC) Overrun Interrupt Mask Register */
+#define REG_PEVC_OVSR              (0x400A6050) /**< \brief (PEVC) Overrun Status Register */
+#define REG_PEVC_OVSCR             (0x400A6054) /**< \brief (PEVC) Overrun Status Clear Register */
+#define REG_PEVC_CHMX0             (0x400A6100) /**< \brief (PEVC) Channel Multiplexer 0 */
+#define REG_PEVC_CHMX1             (0x400A6104) /**< \brief (PEVC) Channel Multiplexer 1 */
+#define REG_PEVC_CHMX2             (0x400A6108) /**< \brief (PEVC) Channel Multiplexer 2 */
+#define REG_PEVC_CHMX3             (0x400A610C) /**< \brief (PEVC) Channel Multiplexer 3 */
+#define REG_PEVC_CHMX4             (0x400A6110) /**< \brief (PEVC) Channel Multiplexer 4 */
+#define REG_PEVC_CHMX5             (0x400A6114) /**< \brief (PEVC) Channel Multiplexer 5 */
+#define REG_PEVC_CHMX6             (0x400A6118) /**< \brief (PEVC) Channel Multiplexer 6 */
+#define REG_PEVC_CHMX7             (0x400A611C) /**< \brief (PEVC) Channel Multiplexer 7 */
+#define REG_PEVC_CHMX8             (0x400A6120) /**< \brief (PEVC) Channel Multiplexer 8 */
+#define REG_PEVC_CHMX9             (0x400A6124) /**< \brief (PEVC) Channel Multiplexer 9 */
+#define REG_PEVC_CHMX10            (0x400A6128) /**< \brief (PEVC) Channel Multiplexer 10 */
+#define REG_PEVC_CHMX11            (0x400A612C) /**< \brief (PEVC) Channel Multiplexer 11 */
+#define REG_PEVC_CHMX12            (0x400A6130) /**< \brief (PEVC) Channel Multiplexer 12 */
+#define REG_PEVC_CHMX13            (0x400A6134) /**< \brief (PEVC) Channel Multiplexer 13 */
+#define REG_PEVC_CHMX14            (0x400A6138) /**< \brief (PEVC) Channel Multiplexer 14 */
+#define REG_PEVC_CHMX15            (0x400A613C) /**< \brief (PEVC) Channel Multiplexer 15 */
+#define REG_PEVC_CHMX16            (0x400A6140) /**< \brief (PEVC) Channel Multiplexer 16 */
+#define REG_PEVC_CHMX17            (0x400A6144) /**< \brief (PEVC) Channel Multiplexer 17 */
+#define REG_PEVC_CHMX18            (0x400A6148) /**< \brief (PEVC) Channel Multiplexer 18 */
+#define REG_PEVC_EVS0              (0x400A6200) /**< \brief (PEVC) Event Shaper 0 */
+#define REG_PEVC_EVS1              (0x400A6204) /**< \brief (PEVC) Event Shaper 1 */
+#define REG_PEVC_EVS2              (0x400A6208) /**< \brief (PEVC) Event Shaper 2 */
+#define REG_PEVC_EVS3              (0x400A620C) /**< \brief (PEVC) Event Shaper 3 */
+#define REG_PEVC_EVS4              (0x400A6210) /**< \brief (PEVC) Event Shaper 4 */
+#define REG_PEVC_EVS5              (0x400A6214) /**< \brief (PEVC) Event Shaper 5 */
+#define REG_PEVC_EVS6              (0x400A6218) /**< \brief (PEVC) Event Shaper 6 */
+#define REG_PEVC_EVS7              (0x400A621C) /**< \brief (PEVC) Event Shaper 7 */
+#define REG_PEVC_EVS8              (0x400A6220) /**< \brief (PEVC) Event Shaper 8 */
+#define REG_PEVC_EVS9              (0x400A6224) /**< \brief (PEVC) Event Shaper 9 */
+#define REG_PEVC_EVS10             (0x400A6228) /**< \brief (PEVC) Event Shaper 10 */
+#define REG_PEVC_EVS11             (0x400A622C) /**< \brief (PEVC) Event Shaper 11 */
+#define REG_PEVC_EVS12             (0x400A6230) /**< \brief (PEVC) Event Shaper 12 */
+#define REG_PEVC_EVS13             (0x400A6234) /**< \brief (PEVC) Event Shaper 13 */
+#define REG_PEVC_EVS14             (0x400A6238) /**< \brief (PEVC) Event Shaper 14 */
+#define REG_PEVC_EVS15             (0x400A623C) /**< \brief (PEVC) Event Shaper 15 */
+#define REG_PEVC_EVS16             (0x400A6240) /**< \brief (PEVC) Event Shaper 16 */
+#define REG_PEVC_EVS17             (0x400A6244) /**< \brief (PEVC) Event Shaper 17 */
+#define REG_PEVC_EVS18             (0x400A6248) /**< \brief (PEVC) Event Shaper 18 */
+#define REG_PEVC_EVS19             (0x400A624C) /**< \brief (PEVC) Event Shaper 19 */
+#define REG_PEVC_EVS20             (0x400A6250) /**< \brief (PEVC) Event Shaper 20 */
+#define REG_PEVC_EVS21             (0x400A6254) /**< \brief (PEVC) Event Shaper 21 */
+#define REG_PEVC_EVS22             (0x400A6258) /**< \brief (PEVC) Event Shaper 22 */
+#define REG_PEVC_EVS23             (0x400A625C) /**< \brief (PEVC) Event Shaper 23 */
+#define REG_PEVC_EVS24             (0x400A6260) /**< \brief (PEVC) Event Shaper 24 */
+#define REG_PEVC_EVS25             (0x400A6264) /**< \brief (PEVC) Event Shaper 25 */
+#define REG_PEVC_EVS26             (0x400A6268) /**< \brief (PEVC) Event Shaper 26 */
+#define REG_PEVC_EVS27             (0x400A626C) /**< \brief (PEVC) Event Shaper 27 */
+#define REG_PEVC_EVS28             (0x400A6270) /**< \brief (PEVC) Event Shaper 28 */
+#define REG_PEVC_EVS29             (0x400A6274) /**< \brief (PEVC) Event Shaper 29 */
+#define REG_PEVC_EVS30             (0x400A6278) /**< \brief (PEVC) Event Shaper 30 */
+#define REG_PEVC_IGFDR             (0x400A6300) /**< \brief (PEVC) Input Glitch Filter Divider Register */
+#define REG_PEVC_PARAMETER         (0x400A63F8) /**< \brief (PEVC) Parameter */
+#define REG_PEVC_VERSION           (0x400A63FC) /**< \brief (PEVC) Version */
+#else
+#define REG_PEVC_CHSR              (*(RoReg  *)0x400A6000UL) /**< \brief (PEVC) Channel Status Register */
+#define REG_PEVC_CHER              (*(WoReg  *)0x400A6004UL) /**< \brief (PEVC) Channel Enable Register */
+#define REG_PEVC_CHDR              (*(WoReg  *)0x400A6008UL) /**< \brief (PEVC) Channel Disable Register */
+#define REG_PEVC_SEV               (*(WoReg  *)0x400A6010UL) /**< \brief (PEVC) Software Event */
+#define REG_PEVC_BUSY              (*(RoReg  *)0x400A6014UL) /**< \brief (PEVC) Channel / User Busy */
+#define REG_PEVC_TRIER             (*(WoReg  *)0x400A6020UL) /**< \brief (PEVC) Trigger Interrupt Mask Enable Register */
+#define REG_PEVC_TRIDR             (*(WoReg  *)0x400A6024UL) /**< \brief (PEVC) Trigger Interrupt Mask Disable Register */
+#define REG_PEVC_TRIMR             (*(RoReg  *)0x400A6028UL) /**< \brief (PEVC) Trigger Interrupt Mask Register */
+#define REG_PEVC_TRSR              (*(RoReg  *)0x400A6030UL) /**< \brief (PEVC) Trigger Status Register */
+#define REG_PEVC_TRSCR             (*(WoReg  *)0x400A6034UL) /**< \brief (PEVC) Trigger Status Clear Register */
+#define REG_PEVC_OVIER             (*(WoReg  *)0x400A6040UL) /**< \brief (PEVC) Overrun Interrupt Mask Enable Register */
+#define REG_PEVC_OVIDR             (*(WoReg  *)0x400A6044UL) /**< \brief (PEVC) Overrun Interrupt Mask Disable Register */
+#define REG_PEVC_OVIMR             (*(RoReg  *)0x400A6048UL) /**< \brief (PEVC) Overrun Interrupt Mask Register */
+#define REG_PEVC_OVSR              (*(RoReg  *)0x400A6050UL) /**< \brief (PEVC) Overrun Status Register */
+#define REG_PEVC_OVSCR             (*(WoReg  *)0x400A6054UL) /**< \brief (PEVC) Overrun Status Clear Register */
+#define REG_PEVC_CHMX0             (*(RwReg  *)0x400A6100UL) /**< \brief (PEVC) Channel Multiplexer 0 */
+#define REG_PEVC_CHMX1             (*(RwReg  *)0x400A6104UL) /**< \brief (PEVC) Channel Multiplexer 1 */
+#define REG_PEVC_CHMX2             (*(RwReg  *)0x400A6108UL) /**< \brief (PEVC) Channel Multiplexer 2 */
+#define REG_PEVC_CHMX3             (*(RwReg  *)0x400A610CUL) /**< \brief (PEVC) Channel Multiplexer 3 */
+#define REG_PEVC_CHMX4             (*(RwReg  *)0x400A6110UL) /**< \brief (PEVC) Channel Multiplexer 4 */
+#define REG_PEVC_CHMX5             (*(RwReg  *)0x400A6114UL) /**< \brief (PEVC) Channel Multiplexer 5 */
+#define REG_PEVC_CHMX6             (*(RwReg  *)0x400A6118UL) /**< \brief (PEVC) Channel Multiplexer 6 */
+#define REG_PEVC_CHMX7             (*(RwReg  *)0x400A611CUL) /**< \brief (PEVC) Channel Multiplexer 7 */
+#define REG_PEVC_CHMX8             (*(RwReg  *)0x400A6120UL) /**< \brief (PEVC) Channel Multiplexer 8 */
+#define REG_PEVC_CHMX9             (*(RwReg  *)0x400A6124UL) /**< \brief (PEVC) Channel Multiplexer 9 */
+#define REG_PEVC_CHMX10            (*(RwReg  *)0x400A6128UL) /**< \brief (PEVC) Channel Multiplexer 10 */
+#define REG_PEVC_CHMX11            (*(RwReg  *)0x400A612CUL) /**< \brief (PEVC) Channel Multiplexer 11 */
+#define REG_PEVC_CHMX12            (*(RwReg  *)0x400A6130UL) /**< \brief (PEVC) Channel Multiplexer 12 */
+#define REG_PEVC_CHMX13            (*(RwReg  *)0x400A6134UL) /**< \brief (PEVC) Channel Multiplexer 13 */
+#define REG_PEVC_CHMX14            (*(RwReg  *)0x400A6138UL) /**< \brief (PEVC) Channel Multiplexer 14 */
+#define REG_PEVC_CHMX15            (*(RwReg  *)0x400A613CUL) /**< \brief (PEVC) Channel Multiplexer 15 */
+#define REG_PEVC_CHMX16            (*(RwReg  *)0x400A6140UL) /**< \brief (PEVC) Channel Multiplexer 16 */
+#define REG_PEVC_CHMX17            (*(RwReg  *)0x400A6144UL) /**< \brief (PEVC) Channel Multiplexer 17 */
+#define REG_PEVC_CHMX18            (*(RwReg  *)0x400A6148UL) /**< \brief (PEVC) Channel Multiplexer 18 */
+#define REG_PEVC_EVS0              (*(RwReg  *)0x400A6200UL) /**< \brief (PEVC) Event Shaper 0 */
+#define REG_PEVC_EVS1              (*(RwReg  *)0x400A6204UL) /**< \brief (PEVC) Event Shaper 1 */
+#define REG_PEVC_EVS2              (*(RwReg  *)0x400A6208UL) /**< \brief (PEVC) Event Shaper 2 */
+#define REG_PEVC_EVS3              (*(RwReg  *)0x400A620CUL) /**< \brief (PEVC) Event Shaper 3 */
+#define REG_PEVC_EVS4              (*(RwReg  *)0x400A6210UL) /**< \brief (PEVC) Event Shaper 4 */
+#define REG_PEVC_EVS5              (*(RwReg  *)0x400A6214UL) /**< \brief (PEVC) Event Shaper 5 */
+#define REG_PEVC_EVS6              (*(RwReg  *)0x400A6218UL) /**< \brief (PEVC) Event Shaper 6 */
+#define REG_PEVC_EVS7              (*(RwReg  *)0x400A621CUL) /**< \brief (PEVC) Event Shaper 7 */
+#define REG_PEVC_EVS8              (*(RwReg  *)0x400A6220UL) /**< \brief (PEVC) Event Shaper 8 */
+#define REG_PEVC_EVS9              (*(RwReg  *)0x400A6224UL) /**< \brief (PEVC) Event Shaper 9 */
+#define REG_PEVC_EVS10             (*(RwReg  *)0x400A6228UL) /**< \brief (PEVC) Event Shaper 10 */
+#define REG_PEVC_EVS11             (*(RwReg  *)0x400A622CUL) /**< \brief (PEVC) Event Shaper 11 */
+#define REG_PEVC_EVS12             (*(RwReg  *)0x400A6230UL) /**< \brief (PEVC) Event Shaper 12 */
+#define REG_PEVC_EVS13             (*(RwReg  *)0x400A6234UL) /**< \brief (PEVC) Event Shaper 13 */
+#define REG_PEVC_EVS14             (*(RwReg  *)0x400A6238UL) /**< \brief (PEVC) Event Shaper 14 */
+#define REG_PEVC_EVS15             (*(RwReg  *)0x400A623CUL) /**< \brief (PEVC) Event Shaper 15 */
+#define REG_PEVC_EVS16             (*(RwReg  *)0x400A6240UL) /**< \brief (PEVC) Event Shaper 16 */
+#define REG_PEVC_EVS17             (*(RwReg  *)0x400A6244UL) /**< \brief (PEVC) Event Shaper 17 */
+#define REG_PEVC_EVS18             (*(RwReg  *)0x400A6248UL) /**< \brief (PEVC) Event Shaper 18 */
+#define REG_PEVC_EVS19             (*(RwReg  *)0x400A624CUL) /**< \brief (PEVC) Event Shaper 19 */
+#define REG_PEVC_EVS20             (*(RwReg  *)0x400A6250UL) /**< \brief (PEVC) Event Shaper 20 */
+#define REG_PEVC_EVS21             (*(RwReg  *)0x400A6254UL) /**< \brief (PEVC) Event Shaper 21 */
+#define REG_PEVC_EVS22             (*(RwReg  *)0x400A6258UL) /**< \brief (PEVC) Event Shaper 22 */
+#define REG_PEVC_EVS23             (*(RwReg  *)0x400A625CUL) /**< \brief (PEVC) Event Shaper 23 */
+#define REG_PEVC_EVS24             (*(RwReg  *)0x400A6260UL) /**< \brief (PEVC) Event Shaper 24 */
+#define REG_PEVC_EVS25             (*(RwReg  *)0x400A6264UL) /**< \brief (PEVC) Event Shaper 25 */
+#define REG_PEVC_EVS26             (*(RwReg  *)0x400A6268UL) /**< \brief (PEVC) Event Shaper 26 */
+#define REG_PEVC_EVS27             (*(RwReg  *)0x400A626CUL) /**< \brief (PEVC) Event Shaper 27 */
+#define REG_PEVC_EVS28             (*(RwReg  *)0x400A6270UL) /**< \brief (PEVC) Event Shaper 28 */
+#define REG_PEVC_EVS29             (*(RwReg  *)0x400A6274UL) /**< \brief (PEVC) Event Shaper 29 */
+#define REG_PEVC_EVS30             (*(RwReg  *)0x400A6278UL) /**< \brief (PEVC) Event Shaper 30 */
+#define REG_PEVC_IGFDR             (*(RwReg  *)0x400A6300UL) /**< \brief (PEVC) Input Glitch Filter Divider Register */
+#define REG_PEVC_PARAMETER         (*(RoReg  *)0x400A63F8UL) /**< \brief (PEVC) Parameter */
+#define REG_PEVC_VERSION           (*(RoReg  *)0x400A63FCUL) /**< \brief (PEVC) Version */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for PEVC peripheral ========== */
+#define PEVC_EVIN_BITS              31      
+#define PEVC_GCLK_NUM_0             8
+#define PEVC_GCLK_NUM_1             9
+#define PEVC_GCLK_NUM_LSB           8
+#define PEVC_GCLK_NUM_MSB           9
+#define PEVC_GCLK_NUM_SIZE          2
+#define PEVC_PADS_BITS              4       
+#define PEVC_TRIGOUT_BITS           19      
+
+// GENERATORS
+#define PEVC_ID_GEN_PAD_0          0 /* EVS IGF */
+#define PEVC_ID_GEN_PAD_1          1 /* EVS IGF */
+#define PEVC_ID_GEN_PAD_2          2 /* EVS IGF */
+#define PEVC_ID_GEN_PAD_3          3 /* EVS IGF */
+#define PEVC_ID_GEN_GCLK_0         4 /* EVS */
+#define PEVC_ID_GEN_GCLK_1         5 /* EVS */
+#define PEVC_ID_GEN_AST_0          6 /* EVS */
+#define PEVC_ID_GEN_AST_1          7 /* EVS */
+#define PEVC_ID_GEN_AST_2          8 /* EVS */
+#define PEVC_ID_GEN_AST_3          9 /* EVS */
+#define PEVC_ID_GEN_AST_4          10 /* EVS */
+#define PEVC_ID_GEN_ACIFC_CHANNEL_POSITIVE_0 11
+#define PEVC_ID_GEN_ACIFC_CHANNEL_POSITIVE_1 12
+#define PEVC_ID_GEN_ACIFC_CHANNEL_POSITIVE_2 13
+#define PEVC_ID_GEN_ACIFC_CHANNEL_POSITIVE_3 14
+#define PEVC_ID_GEN_ACIFC_CHANNEL_NEGATIVE_0 15
+#define PEVC_ID_GEN_ACIFC_CHANNEL_NEGATIVE_1 16
+#define PEVC_ID_GEN_ACIFC_CHANNEL_NEGATIVE_2 17
+#define PEVC_ID_GEN_ACIFC_CHANNEL_NEGATIVE_3 18
+#define PEVC_ID_GEN_ACIFC_WINDOW_0 19
+#define PEVC_ID_GEN_ACIFC_WINDOW_1 20
+#define PEVC_ID_GEN_TC0_A0         21 /* EVS */
+#define PEVC_ID_GEN_TC0_A1         22 /* EVS */
+#define PEVC_ID_GEN_TC0_A2         23 /* EVS */
+#define PEVC_ID_GEN_TC0_B0         24 /* EVS */
+#define PEVC_ID_GEN_TC0_B1         25 /* EVS */
+#define PEVC_ID_GEN_TC0_B2         26 /* EVS */
+#define PEVC_ID_GEN_ADCIFE_WM      27
+#define PEVC_ID_GEN_ADCIFE_EOC     28
+#define PEVC_ID_GEN_VREGIFG_SSWRDY 29
+#define PEVC_ID_GEN_PICOUART       30 /* EVS */
+
+#define PEVC_CHMX0_EVMX_SIZE_IMPL 5
+#define PEVC_CHMX0_EVMX_MASK_IMPL 0x0000001F
+
+#define PEVC_EVS_IMPL 0b1000111111000000000011111111111
+#define PEVC_IGF_IMPL 0b0000000000000000000000000001111
+
+// USERS / CHANNELS
+#define PEVC_ID_USER_PDCA_0        0
+#define PEVC_ID_USER_PDCA_1        1
+#define PEVC_ID_USER_PDCA_2        2
+#define PEVC_ID_USER_PDCA_3        3
+#define PEVC_ID_USER_ADCIFE_SOC    4
+#define PEVC_ID_USER_DACC_CONV     5
+#define PEVC_ID_USER_CATB          6
+#define PEVC_ID_USER_TC1_A0        8
+#define PEVC_ID_USER_TC1_A1        9
+#define PEVC_ID_USER_TC1_A2        10
+#define PEVC_ID_USER_TC1_B0        11
+#define PEVC_ID_USER_TC1_B1        12
+#define PEVC_ID_USER_TC1_B2        13
+#define PEVC_ID_USER_ACIFC         14
+#define PEVC_ID_USER_PARC_START    15
+#define PEVC_ID_USER_PARC_STOP     16
+#define PEVC_ID_USER_VREGIFG_SSWREQ 17
+#define PEVC_ID_USER_VREGIFG_SSWDIS 18
+
+#endif /* _SAM4L_PEVC_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/picouart.h
+++ b/asf/sam/include/sam4l/instance/picouart.h
@@ -1,0 +1,48 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PICOUART
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_PICOUART_INSTANCE_
+#define _SAM4L_PICOUART_INSTANCE_
+
+/* ========== Register definition for PICOUART peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_PICOUART_CR            (0x400F1400) /**< \brief (PICOUART) Control Register */
+#define REG_PICOUART_CFG           (0x400F1404) /**< \brief (PICOUART) Configuration Register */
+#define REG_PICOUART_SR            (0x400F1408) /**< \brief (PICOUART) Status Register */
+#define REG_PICOUART_RHR           (0x400F140C) /**< \brief (PICOUART) Receive Holding Register */
+#define REG_PICOUART_VERSION       (0x400F1420) /**< \brief (PICOUART) Version Register */
+#else
+#define REG_PICOUART_CR            (*(WoReg  *)0x400F1400UL) /**< \brief (PICOUART) Control Register */
+#define REG_PICOUART_CFG           (*(RwReg  *)0x400F1404UL) /**< \brief (PICOUART) Configuration Register */
+#define REG_PICOUART_SR            (*(RoReg  *)0x400F1408UL) /**< \brief (PICOUART) Status Register */
+#define REG_PICOUART_RHR           (*(RoReg  *)0x400F140CUL) /**< \brief (PICOUART) Receive Holding Register */
+#define REG_PICOUART_VERSION       (*(RoReg  *)0x400F1420UL) /**< \brief (PICOUART) Version Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+#endif /* _SAM4L_PICOUART_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/pm.h
+++ b/asf/sam/include/sam4l/instance/pm.h
@@ -1,0 +1,121 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PM
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_PM_INSTANCE_
+#define _SAM4L_PM_INSTANCE_
+
+/* ========== Register definition for PM peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_PM_MCCTRL              (0x400E0000) /**< \brief (PM) Main Clock Control */
+#define REG_PM_CPUSEL              (0x400E0004) /**< \brief (PM) CPU Clock Select */
+#define REG_PM_PBASEL              (0x400E000C) /**< \brief (PM) PBA Clock Select */
+#define REG_PM_PBBSEL              (0x400E0010) /**< \brief (PM) PBB Clock Select */
+#define REG_PM_PBCSEL              (0x400E0014) /**< \brief (PM) PBC Clock Select */
+#define REG_PM_PBDSEL              (0x400E0018) /**< \brief (PM) PBD Clock Select */
+#define REG_PM_CPUMASK             (0x400E0020) /**< \brief (PM) CPU Mask */
+#define REG_PM_HSBMASK             (0x400E0024) /**< \brief (PM) HSB Mask */
+#define REG_PM_PBAMASK             (0x400E0028) /**< \brief (PM) PBA Mask */
+#define REG_PM_PBBMASK             (0x400E002C) /**< \brief (PM) PBB Mask */
+#define REG_PM_PBCMASK             (0x400E0030) /**< \brief (PM) PBC Mask */
+#define REG_PM_PBDMASK             (0x400E0034) /**< \brief (PM) PBD Mask */
+#define REG_PM_PBADIVMASK          (0x400E0040) /**< \brief (PM) PBA Divided Clock Mask */
+#define REG_PM_CFDCTRL             (0x400E0054) /**< \brief (PM) Clock Failure Detector Control */
+#define REG_PM_UNLOCK              (0x400E0058) /**< \brief (PM) Unlock Register */
+#define REG_PM_IER                 (0x400E00C0) /**< \brief (PM) Interrupt Enable Register */
+#define REG_PM_IDR                 (0x400E00C4) /**< \brief (PM) Interrupt Disable Register */
+#define REG_PM_IMR                 (0x400E00C8) /**< \brief (PM) Interrupt Mask Register */
+#define REG_PM_ISR                 (0x400E00CC) /**< \brief (PM) Interrupt Status Register */
+#define REG_PM_ICR                 (0x400E00D0) /**< \brief (PM) Interrupt Clear Register */
+#define REG_PM_SR                  (0x400E00D4) /**< \brief (PM) Status Register */
+#define REG_PM_PPCR                (0x400E0160) /**< \brief (PM) Peripheral Power Control Register */
+#define REG_PM_RCAUSE              (0x400E0180) /**< \brief (PM) Reset Cause Register */
+#define REG_PM_WCAUSE              (0x400E0184) /**< \brief (PM) Wake Cause Register */
+#define REG_PM_AWEN                (0x400E0188) /**< \brief (PM) Asynchronous Wake Enable */
+#define REG_PM_OBS                 (0x400E0190) /**< \brief (PM) Obsvervability */
+#define REG_PM_FASTSLEEP           (0x400E0194) /**< \brief (PM) Fast Sleep Register */
+#define REG_PM_CONFIG              (0x400E03F8) /**< \brief (PM) Configuration Register */
+#define REG_PM_VERSION             (0x400E03FC) /**< \brief (PM) Version Register */
+#else
+#define REG_PM_MCCTRL              (*(RwReg  *)0x400E0000UL) /**< \brief (PM) Main Clock Control */
+#define REG_PM_CPUSEL              (*(RwReg  *)0x400E0004UL) /**< \brief (PM) CPU Clock Select */
+#define REG_PM_PBASEL              (*(RwReg  *)0x400E000CUL) /**< \brief (PM) PBA Clock Select */
+#define REG_PM_PBBSEL              (*(RwReg  *)0x400E0010UL) /**< \brief (PM) PBB Clock Select */
+#define REG_PM_PBCSEL              (*(RwReg  *)0x400E0014UL) /**< \brief (PM) PBC Clock Select */
+#define REG_PM_PBDSEL              (*(RwReg  *)0x400E0018UL) /**< \brief (PM) PBD Clock Select */
+#define REG_PM_CPUMASK             (*(RwReg  *)0x400E0020UL) /**< \brief (PM) CPU Mask */
+#define REG_PM_HSBMASK             (*(RwReg  *)0x400E0024UL) /**< \brief (PM) HSB Mask */
+#define REG_PM_PBAMASK             (*(RwReg  *)0x400E0028UL) /**< \brief (PM) PBA Mask */
+#define REG_PM_PBBMASK             (*(RwReg  *)0x400E002CUL) /**< \brief (PM) PBB Mask */
+#define REG_PM_PBCMASK             (*(RwReg  *)0x400E0030UL) /**< \brief (PM) PBC Mask */
+#define REG_PM_PBDMASK             (*(RwReg  *)0x400E0034UL) /**< \brief (PM) PBD Mask */
+#define REG_PM_PBADIVMASK          (*(RwReg  *)0x400E0040UL) /**< \brief (PM) PBA Divided Clock Mask */
+#define REG_PM_CFDCTRL             (*(RwReg  *)0x400E0054UL) /**< \brief (PM) Clock Failure Detector Control */
+#define REG_PM_UNLOCK              (*(WoReg  *)0x400E0058UL) /**< \brief (PM) Unlock Register */
+#define REG_PM_IER                 (*(WoReg  *)0x400E00C0UL) /**< \brief (PM) Interrupt Enable Register */
+#define REG_PM_IDR                 (*(WoReg  *)0x400E00C4UL) /**< \brief (PM) Interrupt Disable Register */
+#define REG_PM_IMR                 (*(RoReg  *)0x400E00C8UL) /**< \brief (PM) Interrupt Mask Register */
+#define REG_PM_ISR                 (*(RoReg  *)0x400E00CCUL) /**< \brief (PM) Interrupt Status Register */
+#define REG_PM_ICR                 (*(WoReg  *)0x400E00D0UL) /**< \brief (PM) Interrupt Clear Register */
+#define REG_PM_SR                  (*(RoReg  *)0x400E00D4UL) /**< \brief (PM) Status Register */
+#define REG_PM_PPCR                (*(RwReg  *)0x400E0160UL) /**< \brief (PM) Peripheral Power Control Register */
+#define REG_PM_RCAUSE              (*(RoReg  *)0x400E0180UL) /**< \brief (PM) Reset Cause Register */
+#define REG_PM_WCAUSE              (*(RoReg  *)0x400E0184UL) /**< \brief (PM) Wake Cause Register */
+#define REG_PM_AWEN                (*(RwReg  *)0x400E0188UL) /**< \brief (PM) Asynchronous Wake Enable */
+#define REG_PM_OBS                 (*(RwReg  *)0x400E0190UL) /**< \brief (PM) Obsvervability */
+#define REG_PM_FASTSLEEP           (*(RwReg  *)0x400E0194UL) /**< \brief (PM) Fast Sleep Register */
+#define REG_PM_CONFIG              (*(RoReg  *)0x400E03F8UL) /**< \brief (PM) Configuration Register */
+#define REG_PM_VERSION             (*(RoReg  *)0x400E03FCUL) /**< \brief (PM) Version Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for PM peripheral ========== */
+#define PM_AWEN_LCDCA               7       
+#define PM_AWEN_PICOUART            6       
+#define PM_AWEN_TWIS0               0       
+#define PM_AWEN_TWIS1               1       
+#define PM_AWEN_USBC                2       
+#define PM_MCCTRL_MCSEL_DFLL0       3       
+#define PM_MCCTRL_MCSEL_FLO         7       
+#define PM_MCCTRL_MCSEL_OSC0        1       
+#define PM_MCCTRL_MCSEL_PLL0        2       
+#define PM_MCCTRL_MCSEL_RCFAST      5       
+#define PM_MCCTRL_MCSEL_RC1M        6       
+#define PM_MCCTRL_MCSEL_RC80M       4       
+#define PM_MCCTRL_MCSEL_SLOW        0       
+#define PM_PM_CLK_APB_NUM           4       
+#define PM_PPCR_FLASH_WAIT_BGREF_MASK 512     
+#define PM_PPCR_FLASH_WAIT_BOD18_MASK 1024    
+#define PM_SYSTEM_CLOCK             115000   // System clock frequency at reset
+#define PM_PM_SMODE_DEEPSTOP        4       
+#define PM_PM_SMODE_FROZEN          1       
+#define PM_PM_SMODE_IDLE            0       
+#define PM_PM_SMODE_SHUTDOWN        6       
+#define PM_PM_SMODE_STANDBY         2       
+#define PM_PM_SMODE_STATIC          5       
+#define PM_PM_SMODE_STOP            3       
+
+#endif /* _SAM4L_PM_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/scif.h
+++ b/asf/sam/include/sam4l/instance/scif.h
@@ -1,0 +1,191 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SCIF
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_SCIF_INSTANCE_
+#define _SAM4L_SCIF_INSTANCE_
+
+/* ========== Register definition for SCIF peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_SCIF_IER               (0x400E0800) /**< \brief (SCIF) Interrupt Enable Register */
+#define REG_SCIF_IDR               (0x400E0804) /**< \brief (SCIF) Interrupt Disable Register */
+#define REG_SCIF_IMR               (0x400E0808) /**< \brief (SCIF) Interrupt Mask Register */
+#define REG_SCIF_ISR               (0x400E080C) /**< \brief (SCIF) Interrupt Status Register */
+#define REG_SCIF_ICR               (0x400E0810) /**< \brief (SCIF) Interrupt Clear Register */
+#define REG_SCIF_PCLKSR            (0x400E0814) /**< \brief (SCIF) Power and Clocks Status Register */
+#define REG_SCIF_UNLOCK            (0x400E0818) /**< \brief (SCIF) Unlock Register */
+#define REG_SCIF_CSCR              (0x400E081C) /**< \brief (SCIF) Chip Specific Configuration Register */
+#define REG_SCIF_OSCCTRL0          (0x400E0820) /**< \brief (SCIF) Oscillator Control Register */
+#define REG_SCIF_PLL               (0x400E0824) /**< \brief (SCIF) PLL0 Control Register */
+#define REG_SCIF_DFLL0CONF         (0x400E0828) /**< \brief (SCIF) DFLL0 Config Register */
+#define REG_SCIF_DFLL0VAL          (0x400E082C) /**< \brief (SCIF) DFLL Value Register */
+#define REG_SCIF_DFLL0MUL          (0x400E0830) /**< \brief (SCIF) DFLL0 Multiplier Register */
+#define REG_SCIF_DFLL0STEP         (0x400E0834) /**< \brief (SCIF) DFLL0 Step Register */
+#define REG_SCIF_DFLL0SSG          (0x400E0838) /**< \brief (SCIF) DFLL0 Spread Spectrum Generator Control Register */
+#define REG_SCIF_DFLL0RATIO        (0x400E083C) /**< \brief (SCIF) DFLL0 Ratio Registe */
+#define REG_SCIF_DFLL0SYNC         (0x400E0840) /**< \brief (SCIF) DFLL0 Synchronization Register */
+#define REG_SCIF_RCCR              (0x400E0844) /**< \brief (SCIF) System RC Oscillator Calibration Register */
+#define REG_SCIF_RCFASTCFG         (0x400E0848) /**< \brief (SCIF) 4/8/12 MHz RC Oscillator Configuration Register */
+#define REG_SCIF_RCFASTSR          (0x400E084C) /**< \brief (SCIF) 4/8/12 MHz RC Oscillator Status Register */
+#define REG_SCIF_RC80MCR           (0x400E0850) /**< \brief (SCIF) 80 MHz RC Oscillator Register */
+#define REG_SCIF_HRPCR             (0x400E0864) /**< \brief (SCIF) High Resolution Prescaler Control Register */
+#define REG_SCIF_FPCR              (0x400E0868) /**< \brief (SCIF) Fractional Prescaler Control Register */
+#define REG_SCIF_FPMUL             (0x400E086C) /**< \brief (SCIF) Fractional Prescaler Multiplier Register */
+#define REG_SCIF_FPDIV             (0x400E0870) /**< \brief (SCIF) Fractional Prescaler DIVIDER Register */
+#define REG_SCIF_GCCTRL0           (0x400E0874) /**< \brief (SCIF) Generic Clock Control 0 */
+#define REG_SCIF_GCCTRL1           (0x400E0878) /**< \brief (SCIF) Generic Clock Control 1 */
+#define REG_SCIF_GCCTRL2           (0x400E087C) /**< \brief (SCIF) Generic Clock Control 2 */
+#define REG_SCIF_GCCTRL3           (0x400E0880) /**< \brief (SCIF) Generic Clock Control 3 */
+#define REG_SCIF_GCCTRL4           (0x400E0884) /**< \brief (SCIF) Generic Clock Control 4 */
+#define REG_SCIF_GCCTRL5           (0x400E0888) /**< \brief (SCIF) Generic Clock Control 5 */
+#define REG_SCIF_GCCTRL6           (0x400E088C) /**< \brief (SCIF) Generic Clock Control 6 */
+#define REG_SCIF_GCCTRL7           (0x400E0890) /**< \brief (SCIF) Generic Clock Control 7 */
+#define REG_SCIF_GCCTRL8           (0x400E0894) /**< \brief (SCIF) Generic Clock Control 8 */
+#define REG_SCIF_GCCTRL9           (0x400E0898) /**< \brief (SCIF) Generic Clock Control 9 */
+#define REG_SCIF_GCCTRL10          (0x400E089C) /**< \brief (SCIF) Generic Clock Control 10 */
+#define REG_SCIF_GCCTRL11          (0x400E08A0) /**< \brief (SCIF) Generic Clock Control 11 */
+#define REG_SCIF_RCFASTVERSION     (0x400E0BD8) /**< \brief (SCIF) 4/8/12 MHz RC Oscillator Version Register */
+#define REG_SCIF_GCLKPRESCVERSION  (0x400E0BDC) /**< \brief (SCIF) Generic Clock Prescaler Version Register */
+#define REG_SCIF_PLLIFAVERSION     (0x400E0BE0) /**< \brief (SCIF) PLL Version Register */
+#define REG_SCIF_OSCIFAVERSION     (0x400E0BE4) /**< \brief (SCIF) Oscillator 0 Version Register */
+#define REG_SCIF_DFLLIFBVERSION    (0x400E0BE8) /**< \brief (SCIF) DFLL Version Register */
+#define REG_SCIF_RCOSCIFAVERSION   (0x400E0BEC) /**< \brief (SCIF) System RC Oscillator Version Register */
+#define REG_SCIF_FLOVERSION        (0x400E0BF0) /**< \brief (SCIF) Frequency Locked Oscillator Version Register */
+#define REG_SCIF_RC80MVERSION      (0x400E0BF4) /**< \brief (SCIF) 80MHz RC Oscillator Version Register */
+#define REG_SCIF_GCLKIFVERSION     (0x400E0BF8) /**< \brief (SCIF) Generic Clock Version Register */
+#define REG_SCIF_VERSION           (0x400E0BFC) /**< \brief (SCIF) SCIF Version Register */
+#else
+#define REG_SCIF_IER               (*(WoReg  *)0x400E0800UL) /**< \brief (SCIF) Interrupt Enable Register */
+#define REG_SCIF_IDR               (*(WoReg  *)0x400E0804UL) /**< \brief (SCIF) Interrupt Disable Register */
+#define REG_SCIF_IMR               (*(RoReg  *)0x400E0808UL) /**< \brief (SCIF) Interrupt Mask Register */
+#define REG_SCIF_ISR               (*(RoReg  *)0x400E080CUL) /**< \brief (SCIF) Interrupt Status Register */
+#define REG_SCIF_ICR               (*(WoReg  *)0x400E0810UL) /**< \brief (SCIF) Interrupt Clear Register */
+#define REG_SCIF_PCLKSR            (*(RoReg  *)0x400E0814UL) /**< \brief (SCIF) Power and Clocks Status Register */
+#define REG_SCIF_UNLOCK            (*(WoReg  *)0x400E0818UL) /**< \brief (SCIF) Unlock Register */
+#define REG_SCIF_CSCR              (*(RwReg  *)0x400E081CUL) /**< \brief (SCIF) Chip Specific Configuration Register */
+#define REG_SCIF_OSCCTRL0          (*(RwReg  *)0x400E0820UL) /**< \brief (SCIF) Oscillator Control Register */
+#define REG_SCIF_PLL               (*(RwReg  *)0x400E0824UL) /**< \brief (SCIF) PLL0 Control Register */
+#define REG_SCIF_DFLL0CONF         (*(RwReg  *)0x400E0828UL) /**< \brief (SCIF) DFLL0 Config Register */
+#define REG_SCIF_DFLL0VAL          (*(RwReg  *)0x400E082CUL) /**< \brief (SCIF) DFLL Value Register */
+#define REG_SCIF_DFLL0MUL          (*(RwReg  *)0x400E0830UL) /**< \brief (SCIF) DFLL0 Multiplier Register */
+#define REG_SCIF_DFLL0STEP         (*(RwReg  *)0x400E0834UL) /**< \brief (SCIF) DFLL0 Step Register */
+#define REG_SCIF_DFLL0SSG          (*(RwReg  *)0x400E0838UL) /**< \brief (SCIF) DFLL0 Spread Spectrum Generator Control Register */
+#define REG_SCIF_DFLL0RATIO        (*(RoReg  *)0x400E083CUL) /**< \brief (SCIF) DFLL0 Ratio Registe */
+#define REG_SCIF_DFLL0SYNC         (*(WoReg  *)0x400E0840UL) /**< \brief (SCIF) DFLL0 Synchronization Register */
+#define REG_SCIF_RCCR              (*(RwReg  *)0x400E0844UL) /**< \brief (SCIF) System RC Oscillator Calibration Register */
+#define REG_SCIF_RCFASTCFG         (*(RwReg  *)0x400E0848UL) /**< \brief (SCIF) 4/8/12 MHz RC Oscillator Configuration Register */
+#define REG_SCIF_RCFASTSR          (*(RwReg  *)0x400E084CUL) /**< \brief (SCIF) 4/8/12 MHz RC Oscillator Status Register */
+#define REG_SCIF_RC80MCR           (*(RwReg  *)0x400E0850UL) /**< \brief (SCIF) 80 MHz RC Oscillator Register */
+#define REG_SCIF_HRPCR             (*(RwReg  *)0x400E0864UL) /**< \brief (SCIF) High Resolution Prescaler Control Register */
+#define REG_SCIF_FPCR              (*(RwReg  *)0x400E0868UL) /**< \brief (SCIF) Fractional Prescaler Control Register */
+#define REG_SCIF_FPMUL             (*(RwReg  *)0x400E086CUL) /**< \brief (SCIF) Fractional Prescaler Multiplier Register */
+#define REG_SCIF_FPDIV             (*(RwReg  *)0x400E0870UL) /**< \brief (SCIF) Fractional Prescaler DIVIDER Register */
+#define REG_SCIF_GCCTRL0           (*(RwReg  *)0x400E0874UL) /**< \brief (SCIF) Generic Clock Control 0 */
+#define REG_SCIF_GCCTRL1           (*(RwReg  *)0x400E0878UL) /**< \brief (SCIF) Generic Clock Control 1 */
+#define REG_SCIF_GCCTRL2           (*(RwReg  *)0x400E087CUL) /**< \brief (SCIF) Generic Clock Control 2 */
+#define REG_SCIF_GCCTRL3           (*(RwReg  *)0x400E0880UL) /**< \brief (SCIF) Generic Clock Control 3 */
+#define REG_SCIF_GCCTRL4           (*(RwReg  *)0x400E0884UL) /**< \brief (SCIF) Generic Clock Control 4 */
+#define REG_SCIF_GCCTRL5           (*(RwReg  *)0x400E0888UL) /**< \brief (SCIF) Generic Clock Control 5 */
+#define REG_SCIF_GCCTRL6           (*(RwReg  *)0x400E088CUL) /**< \brief (SCIF) Generic Clock Control 6 */
+#define REG_SCIF_GCCTRL7           (*(RwReg  *)0x400E0890UL) /**< \brief (SCIF) Generic Clock Control 7 */
+#define REG_SCIF_GCCTRL8           (*(RwReg  *)0x400E0894UL) /**< \brief (SCIF) Generic Clock Control 8 */
+#define REG_SCIF_GCCTRL9           (*(RwReg  *)0x400E0898UL) /**< \brief (SCIF) Generic Clock Control 9 */
+#define REG_SCIF_GCCTRL10          (*(RwReg  *)0x400E089CUL) /**< \brief (SCIF) Generic Clock Control 10 */
+#define REG_SCIF_GCCTRL11          (*(RwReg  *)0x400E08A0UL) /**< \brief (SCIF) Generic Clock Control 11 */
+#define REG_SCIF_RCFASTVERSION     (*(RoReg  *)0x400E0BD8UL) /**< \brief (SCIF) 4/8/12 MHz RC Oscillator Version Register */
+#define REG_SCIF_GCLKPRESCVERSION  (*(RoReg  *)0x400E0BDCUL) /**< \brief (SCIF) Generic Clock Prescaler Version Register */
+#define REG_SCIF_PLLIFAVERSION     (*(RoReg  *)0x400E0BE0UL) /**< \brief (SCIF) PLL Version Register */
+#define REG_SCIF_OSCIFAVERSION     (*(RoReg  *)0x400E0BE4UL) /**< \brief (SCIF) Oscillator 0 Version Register */
+#define REG_SCIF_DFLLIFBVERSION    (*(RoReg  *)0x400E0BE8UL) /**< \brief (SCIF) DFLL Version Register */
+#define REG_SCIF_RCOSCIFAVERSION   (*(RoReg  *)0x400E0BECUL) /**< \brief (SCIF) System RC Oscillator Version Register */
+#define REG_SCIF_FLOVERSION        (*(RoReg  *)0x400E0BF0UL) /**< \brief (SCIF) Frequency Locked Oscillator Version Register */
+#define REG_SCIF_RC80MVERSION      (*(RoReg  *)0x400E0BF4UL) /**< \brief (SCIF) 80MHz RC Oscillator Version Register */
+#define REG_SCIF_GCLKIFVERSION     (*(RoReg  *)0x400E0BF8UL) /**< \brief (SCIF) Generic Clock Version Register */
+#define REG_SCIF_VERSION           (*(RoReg  *)0x400E0BFCUL) /**< \brief (SCIF) SCIF Version Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for SCIF peripheral ========== */
+#define SCIF_BOD33_IMPLEMENTED      0       
+#define SCIF_BOD50_IMPLEMENTED      0       
+#define SCIF_BR_NUM                 0       
+#define SCIF_DFLL_CALIB_MSB         3       
+#define SCIF_DFLL_COARSE_MSB        4       
+#define SCIF_DFLL_FINE_MSB          7       
+#define SCIF_DFLL_RANGE_MSB         1       
+#define SCIF_GCLK_EXTCLK_MSB        3       
+#define SCIF_GCLK_IN_MSB            1       
+#define SCIF_GCLK_IN_NUM            2       
+#define SCIF_GCLK_MSB               10      
+#define SCIF_GCLK_NUM               12      
+#define SCIF_GCLK_NUM_DFLL_REF      0       
+#define SCIF_GCLK_NUM_DFLL_SSG      1       
+#define SCIF_GCLK_NUM_EXTCLK_0      0
+#define SCIF_GCLK_NUM_EXTCLK_1      1
+#define SCIF_GCLK_NUM_EXTCLK_2      2
+#define SCIF_GCLK_NUM_EXTCLK_3      3
+#define SCIF_GCLK_NUM_EXTCLK_LSB    0
+#define SCIF_GCLK_NUM_EXTCLK_MSB    3
+#define SCIF_GCLK_NUM_EXTCLK_SIZE   4
+#define SCIF_GCLK_NUM_FLO           4       
+#define SCIF_GCLK_NUM_MASTER        11      
+#define SCIF_GCLK_NUM_PLL           9       
+#define SCIF_GCLK_NUM_RC32KIFB_REF  5       
+#define SCIF_GC_USES_CLK_CPU        7       
+#define SCIF_GC_USES_CLK_HSB        8       
+#define SCIF_GC_USES_CLK_PBA        9       
+#define SCIF_GC_USES_CLK_PBB        10      
+#define SCIF_GC_USES_CLK_PBC        11      
+#define SCIF_GC_USES_CLK_PBD        12      
+#define SCIF_GC_USES_CLK_SLOW       0       
+#define SCIF_GC_USES_CLK_1K         15      
+#define SCIF_GC_USES_CLK_32         1       
+#define SCIF_GC_USES_DFLL0          2       
+#define SCIF_GC_USES_FLO            14      
+#define SCIF_GC_USES_GCLKPRESC_FP   18      
+#define SCIF_GC_USES_GCLKPRESC_HRP  17      
+#define SCIF_GC_USES_GCLK_IN0       19      
+#define SCIF_GC_USES_GCLK_IN1       20      
+#define SCIF_GC_USES_MASTER         21      
+#define SCIF_GC_USES_OSC0           3       
+#define SCIF_GC_USES_PLL0           16      
+#define SCIF_GC_USES_RCFAST         5       
+#define SCIF_GC_USES_RC1M           6       
+#define SCIF_GC_USES_RC32K          13      
+#define SCIF_GC_USES_RC80M          4       
+#define SCIF_OSC_NUM                1       
+#define SCIF_PLL_NUM                1       
+#define SCIF_RCFAST_CALIBRATION_MSB 6       
+#define SCIF_RCFAST_FRANGE_MSB      1       
+#define SCIF_RCOSC_FREQUENCY        115200  
+#define SCIF_RC80M_CALIBRATION_MSB  1       
+#define SCIF_BOD_OFF                0       
+#define SCIF_BOD_ON                 1       
+#define SCIF_BOD_ON_NORESET         2       
+#define SCIF_GC_DIV_CLOCK           1       
+#define SCIF_GC_NO_DIV_CLOCK        0       
+
+#endif /* _SAM4L_SCIF_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/smap.h
+++ b/asf/sam/include/sam4l/instance/smap.h
@@ -1,0 +1,58 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SMAP
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_SMAP_INSTANCE_
+#define _SAM4L_SMAP_INSTANCE_
+
+/* ========== Register definition for SMAP peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_SMAP_CR                (0x400A3000) /**< \brief (SMAP) Control Register */
+#define REG_SMAP_SR                (0x400A3004) /**< \brief (SMAP) Status Register */
+#define REG_SMAP_SCR               (0x400A3008) /**< \brief (SMAP) Status Clear Register */
+#define REG_SMAP_ADDR              (0x400A300C) /**< \brief (SMAP) Address Register */
+#define REG_SMAP_LENGTH            (0x400A3010) /**< \brief (SMAP) Length Register */
+#define REG_SMAP_DATA              (0x400A3014) /**< \brief (SMAP) Data Register */
+#define REG_SMAP_VERSION           (0x400A3028) /**< \brief (SMAP) VERSION register */
+#define REG_SMAP_CIDR              (0x400A30F0) /**< \brief (SMAP) Chip ID Register */
+#define REG_SMAP_EXID              (0x400A30F4) /**< \brief (SMAP) Chip ID Extension Register */
+#define REG_SMAP_IDR               (0x400A30FC) /**< \brief (SMAP) AP Identification register */
+#else
+#define REG_SMAP_CR                (*(WoReg  *)0x400A3000UL) /**< \brief (SMAP) Control Register */
+#define REG_SMAP_SR                (*(RoReg  *)0x400A3004UL) /**< \brief (SMAP) Status Register */
+#define REG_SMAP_SCR               (*(WoReg  *)0x400A3008UL) /**< \brief (SMAP) Status Clear Register */
+#define REG_SMAP_ADDR              (*(RwReg  *)0x400A300CUL) /**< \brief (SMAP) Address Register */
+#define REG_SMAP_LENGTH            (*(RwReg  *)0x400A3010UL) /**< \brief (SMAP) Length Register */
+#define REG_SMAP_DATA              (*(RwReg  *)0x400A3014UL) /**< \brief (SMAP) Data Register */
+#define REG_SMAP_VERSION           (*(RoReg  *)0x400A3028UL) /**< \brief (SMAP) VERSION register */
+#define REG_SMAP_CIDR              (*(RoReg  *)0x400A30F0UL) /**< \brief (SMAP) Chip ID Register */
+#define REG_SMAP_EXID              (*(RoReg  *)0x400A30F4UL) /**< \brief (SMAP) Chip ID Extension Register */
+#define REG_SMAP_IDR               (*(RoReg  *)0x400A30FCUL) /**< \brief (SMAP) AP Identification register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+#endif /* _SAM4L_SMAP_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/spi.h
+++ b/asf/sam/include/sam4l/instance/spi.h
@@ -1,0 +1,74 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SPI
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_SPI_INSTANCE_
+#define _SAM4L_SPI_INSTANCE_
+
+/* ========== Register definition for SPI peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_SPI_CR                 (0x40008000) /**< \brief (SPI) Control Register */
+#define REG_SPI_MR                 (0x40008004) /**< \brief (SPI) Mode Register */
+#define REG_SPI_RDR                (0x40008008) /**< \brief (SPI) Receive Data Register */
+#define REG_SPI_TDR                (0x4000800C) /**< \brief (SPI) Transmit Data Register */
+#define REG_SPI_SR                 (0x40008010) /**< \brief (SPI) Status Register */
+#define REG_SPI_IER                (0x40008014) /**< \brief (SPI) Interrupt Enable Register */
+#define REG_SPI_IDR                (0x40008018) /**< \brief (SPI) Interrupt Disable Register */
+#define REG_SPI_IMR                (0x4000801C) /**< \brief (SPI) Interrupt Mask Register */
+#define REG_SPI_CSR0               (0x40008030) /**< \brief (SPI) Chip Select Register 0 */
+#define REG_SPI_CSR1               (0x40008034) /**< \brief (SPI) Chip Select Register 1 */
+#define REG_SPI_CSR2               (0x40008038) /**< \brief (SPI) Chip Select Register 2 */
+#define REG_SPI_CSR3               (0x4000803C) /**< \brief (SPI) Chip Select Register 3 */
+#define REG_SPI_WPCR               (0x400080E4) /**< \brief (SPI) Write Protection control Register */
+#define REG_SPI_WPSR               (0x400080E8) /**< \brief (SPI) Write Protection status Register */
+#define REG_SPI_FEATURES           (0x400080F8) /**< \brief (SPI) Features Register */
+#define REG_SPI_VERSION            (0x400080FC) /**< \brief (SPI) Version Register */
+#else
+#define REG_SPI_CR                 (*(WoReg  *)0x40008000UL) /**< \brief (SPI) Control Register */
+#define REG_SPI_MR                 (*(RwReg  *)0x40008004UL) /**< \brief (SPI) Mode Register */
+#define REG_SPI_RDR                (*(RoReg  *)0x40008008UL) /**< \brief (SPI) Receive Data Register */
+#define REG_SPI_TDR                (*(WoReg  *)0x4000800CUL) /**< \brief (SPI) Transmit Data Register */
+#define REG_SPI_SR                 (*(RoReg  *)0x40008010UL) /**< \brief (SPI) Status Register */
+#define REG_SPI_IER                (*(WoReg  *)0x40008014UL) /**< \brief (SPI) Interrupt Enable Register */
+#define REG_SPI_IDR                (*(WoReg  *)0x40008018UL) /**< \brief (SPI) Interrupt Disable Register */
+#define REG_SPI_IMR                (*(RoReg  *)0x4000801CUL) /**< \brief (SPI) Interrupt Mask Register */
+#define REG_SPI_CSR0               (*(RwReg  *)0x40008030UL) /**< \brief (SPI) Chip Select Register 0 */
+#define REG_SPI_CSR1               (*(RwReg  *)0x40008034UL) /**< \brief (SPI) Chip Select Register 1 */
+#define REG_SPI_CSR2               (*(RwReg  *)0x40008038UL) /**< \brief (SPI) Chip Select Register 2 */
+#define REG_SPI_CSR3               (*(RwReg  *)0x4000803CUL) /**< \brief (SPI) Chip Select Register 3 */
+#define REG_SPI_WPCR               (*(RwReg  *)0x400080E4UL) /**< \brief (SPI) Write Protection control Register */
+#define REG_SPI_WPSR               (*(RoReg  *)0x400080E8UL) /**< \brief (SPI) Write Protection status Register */
+#define REG_SPI_FEATURES           (*(RoReg  *)0x400080F8UL) /**< \brief (SPI) Features Register */
+#define REG_SPI_VERSION            (*(RoReg  *)0x400080FCUL) /**< \brief (SPI) Version Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for SPI peripheral ========== */
+#define SPI_CS_MSB                  3       
+#define SPI_PDCA_ID_RX              4       
+#define SPI_PDCA_ID_TX              22      
+
+#endif /* _SAM4L_SPI_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/tc0.h
+++ b/asf/sam/include/sam4l/instance/tc0.h
@@ -1,0 +1,121 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC0
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_TC0_INSTANCE_
+#define _SAM4L_TC0_INSTANCE_
+
+/* ========== Register definition for TC0 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC0_CCR0               (0x40010000) /**< \brief (TC0) Channel Control Register Channel 0 */
+#define REG_TC0_CMR0               (0x40010004) /**< \brief (TC0) Channel Mode Register Channel 0 */
+#define REG_TC0_SMMR0              (0x40010008) /**< \brief (TC0) Stepper Motor Mode Register 0 */
+#define REG_TC0_CV0                (0x40010010) /**< \brief (TC0) Counter Value Channel 0 */
+#define REG_TC0_RA0                (0x40010014) /**< \brief (TC0) Register A Channel 0 */
+#define REG_TC0_RB0                (0x40010018) /**< \brief (TC0) Register B Channel 0 */
+#define REG_TC0_RC0                (0x4001001C) /**< \brief (TC0) Register C Channel 0 */
+#define REG_TC0_SR0                (0x40010020) /**< \brief (TC0) Status Register Channel 0 */
+#define REG_TC0_IER0               (0x40010024) /**< \brief (TC0) Interrupt Enable Register Channel 0 */
+#define REG_TC0_IDR0               (0x40010028) /**< \brief (TC0) Interrupt Disable Register Channel 0 */
+#define REG_TC0_IMR0               (0x4001002C) /**< \brief (TC0) Interrupt Mask Register Channel 0 */
+#define REG_TC0_CCR1               (0x40010040) /**< \brief (TC0) Channel Control Register Channel 1 */
+#define REG_TC0_CMR1               (0x40010044) /**< \brief (TC0) Channel Mode Register Channel 1 */
+#define REG_TC0_SMMR1              (0x40010048) /**< \brief (TC0) Stepper Motor Mode Register 1 */
+#define REG_TC0_CV1                (0x40010050) /**< \brief (TC0) Counter Value Channel 1 */
+#define REG_TC0_RA1                (0x40010054) /**< \brief (TC0) Register A Channel 1 */
+#define REG_TC0_RB1                (0x40010058) /**< \brief (TC0) Register B Channel 1 */
+#define REG_TC0_RC1                (0x4001005C) /**< \brief (TC0) Register C Channel 1 */
+#define REG_TC0_SR1                (0x40010060) /**< \brief (TC0) Status Register Channel 1 */
+#define REG_TC0_IER1               (0x40010064) /**< \brief (TC0) Interrupt Enable Register Channel 1 */
+#define REG_TC0_IDR1               (0x40010068) /**< \brief (TC0) Interrupt Disable Register Channel 1 */
+#define REG_TC0_IMR1               (0x4001006C) /**< \brief (TC0) Interrupt Mask Register Channel 1 */
+#define REG_TC0_CCR2               (0x40010080) /**< \brief (TC0) Channel Control Register Channel 2 */
+#define REG_TC0_CMR2               (0x40010084) /**< \brief (TC0) Channel Mode Register Channel 2 */
+#define REG_TC0_SMMR2              (0x40010088) /**< \brief (TC0) Stepper Motor Mode Register 2 */
+#define REG_TC0_CV2                (0x40010090) /**< \brief (TC0) Counter Value Channel 2 */
+#define REG_TC0_RA2                (0x40010094) /**< \brief (TC0) Register A Channel 2 */
+#define REG_TC0_RB2                (0x40010098) /**< \brief (TC0) Register B Channel 2 */
+#define REG_TC0_RC2                (0x4001009C) /**< \brief (TC0) Register C Channel 2 */
+#define REG_TC0_SR2                (0x400100A0) /**< \brief (TC0) Status Register Channel 2 */
+#define REG_TC0_IER2               (0x400100A4) /**< \brief (TC0) Interrupt Enable Register Channel 2 */
+#define REG_TC0_IDR2               (0x400100A8) /**< \brief (TC0) Interrupt Disable Register Channel 2 */
+#define REG_TC0_IMR2               (0x400100AC) /**< \brief (TC0) Interrupt Mask Register Channel 2 */
+#define REG_TC0_BCR                (0x400100C0) /**< \brief (TC0) TC Block Control Register */
+#define REG_TC0_BMR                (0x400100C4) /**< \brief (TC0) TC Block Mode Register */
+#define REG_TC0_WPMR               (0x400100E4) /**< \brief (TC0) Write Protect Mode Register */
+#define REG_TC0_FEATURES           (0x400100F8) /**< \brief (TC0) Features Register */
+#define REG_TC0_VERSION            (0x400100FC) /**< \brief (TC0) Version Register */
+#else
+#define REG_TC0_CCR0               (*(WoReg  *)0x40010000UL) /**< \brief (TC0) Channel Control Register Channel 0 */
+#define REG_TC0_CMR0               (*(RwReg  *)0x40010004UL) /**< \brief (TC0) Channel Mode Register Channel 0 */
+#define REG_TC0_SMMR0              (*(RwReg  *)0x40010008UL) /**< \brief (TC0) Stepper Motor Mode Register 0 */
+#define REG_TC0_CV0                (*(RoReg  *)0x40010010UL) /**< \brief (TC0) Counter Value Channel 0 */
+#define REG_TC0_RA0                (*(RwReg  *)0x40010014UL) /**< \brief (TC0) Register A Channel 0 */
+#define REG_TC0_RB0                (*(RwReg  *)0x40010018UL) /**< \brief (TC0) Register B Channel 0 */
+#define REG_TC0_RC0                (*(RwReg  *)0x4001001CUL) /**< \brief (TC0) Register C Channel 0 */
+#define REG_TC0_SR0                (*(RoReg  *)0x40010020UL) /**< \brief (TC0) Status Register Channel 0 */
+#define REG_TC0_IER0               (*(WoReg  *)0x40010024UL) /**< \brief (TC0) Interrupt Enable Register Channel 0 */
+#define REG_TC0_IDR0               (*(WoReg  *)0x40010028UL) /**< \brief (TC0) Interrupt Disable Register Channel 0 */
+#define REG_TC0_IMR0               (*(RoReg  *)0x4001002CUL) /**< \brief (TC0) Interrupt Mask Register Channel 0 */
+#define REG_TC0_CCR1               (*(WoReg  *)0x40010040UL) /**< \brief (TC0) Channel Control Register Channel 1 */
+#define REG_TC0_CMR1               (*(RwReg  *)0x40010044UL) /**< \brief (TC0) Channel Mode Register Channel 1 */
+#define REG_TC0_SMMR1              (*(RwReg  *)0x40010048UL) /**< \brief (TC0) Stepper Motor Mode Register 1 */
+#define REG_TC0_CV1                (*(RoReg  *)0x40010050UL) /**< \brief (TC0) Counter Value Channel 1 */
+#define REG_TC0_RA1                (*(RwReg  *)0x40010054UL) /**< \brief (TC0) Register A Channel 1 */
+#define REG_TC0_RB1                (*(RwReg  *)0x40010058UL) /**< \brief (TC0) Register B Channel 1 */
+#define REG_TC0_RC1                (*(RwReg  *)0x4001005CUL) /**< \brief (TC0) Register C Channel 1 */
+#define REG_TC0_SR1                (*(RoReg  *)0x40010060UL) /**< \brief (TC0) Status Register Channel 1 */
+#define REG_TC0_IER1               (*(WoReg  *)0x40010064UL) /**< \brief (TC0) Interrupt Enable Register Channel 1 */
+#define REG_TC0_IDR1               (*(WoReg  *)0x40010068UL) /**< \brief (TC0) Interrupt Disable Register Channel 1 */
+#define REG_TC0_IMR1               (*(RoReg  *)0x4001006CUL) /**< \brief (TC0) Interrupt Mask Register Channel 1 */
+#define REG_TC0_CCR2               (*(WoReg  *)0x40010080UL) /**< \brief (TC0) Channel Control Register Channel 2 */
+#define REG_TC0_CMR2               (*(RwReg  *)0x40010084UL) /**< \brief (TC0) Channel Mode Register Channel 2 */
+#define REG_TC0_SMMR2              (*(RwReg  *)0x40010088UL) /**< \brief (TC0) Stepper Motor Mode Register 2 */
+#define REG_TC0_CV2                (*(RoReg  *)0x40010090UL) /**< \brief (TC0) Counter Value Channel 2 */
+#define REG_TC0_RA2                (*(RwReg  *)0x40010094UL) /**< \brief (TC0) Register A Channel 2 */
+#define REG_TC0_RB2                (*(RwReg  *)0x40010098UL) /**< \brief (TC0) Register B Channel 2 */
+#define REG_TC0_RC2                (*(RwReg  *)0x4001009CUL) /**< \brief (TC0) Register C Channel 2 */
+#define REG_TC0_SR2                (*(RoReg  *)0x400100A0UL) /**< \brief (TC0) Status Register Channel 2 */
+#define REG_TC0_IER2               (*(WoReg  *)0x400100A4UL) /**< \brief (TC0) Interrupt Enable Register Channel 2 */
+#define REG_TC0_IDR2               (*(WoReg  *)0x400100A8UL) /**< \brief (TC0) Interrupt Disable Register Channel 2 */
+#define REG_TC0_IMR2               (*(RoReg  *)0x400100ACUL) /**< \brief (TC0) Interrupt Mask Register Channel 2 */
+#define REG_TC0_BCR                (*(WoReg  *)0x400100C0UL) /**< \brief (TC0) TC Block Control Register */
+#define REG_TC0_BMR                (*(RwReg  *)0x400100C4UL) /**< \brief (TC0) TC Block Mode Register */
+#define REG_TC0_WPMR               (*(RwReg  *)0x400100E4UL) /**< \brief (TC0) Write Protect Mode Register */
+#define REG_TC0_FEATURES           (*(RoReg  *)0x400100F8UL) /**< \brief (TC0) Features Register */
+#define REG_TC0_VERSION            (*(RoReg  *)0x400100FCUL) /**< \brief (TC0) Version Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TC0 peripheral ========== */
+#define TC0_CLK_DIV1                gen_clk_tc0
+#define TC0_CLK_DIV2                2       
+#define TC0_CLK_DIV3                8       
+#define TC0_CLK_DIV4                32      
+#define TC0_CLK_DIV5                128     
+#define TC0_GCLK_NUM                5       
+
+#endif /* _SAM4L_TC0_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/tc1.h
+++ b/asf/sam/include/sam4l/instance/tc1.h
@@ -1,0 +1,121 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC1
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_TC1_INSTANCE_
+#define _SAM4L_TC1_INSTANCE_
+
+/* ========== Register definition for TC1 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC1_CCR0               (0x40014000) /**< \brief (TC1) Channel Control Register Channel 0 */
+#define REG_TC1_CMR0               (0x40014004) /**< \brief (TC1) Channel Mode Register Channel 0 */
+#define REG_TC1_SMMR0              (0x40014008) /**< \brief (TC1) Stepper Motor Mode Register 0 */
+#define REG_TC1_CV0                (0x40014010) /**< \brief (TC1) Counter Value Channel 0 */
+#define REG_TC1_RA0                (0x40014014) /**< \brief (TC1) Register A Channel 0 */
+#define REG_TC1_RB0                (0x40014018) /**< \brief (TC1) Register B Channel 0 */
+#define REG_TC1_RC0                (0x4001401C) /**< \brief (TC1) Register C Channel 0 */
+#define REG_TC1_SR0                (0x40014020) /**< \brief (TC1) Status Register Channel 0 */
+#define REG_TC1_IER0               (0x40014024) /**< \brief (TC1) Interrupt Enable Register Channel 0 */
+#define REG_TC1_IDR0               (0x40014028) /**< \brief (TC1) Interrupt Disable Register Channel 0 */
+#define REG_TC1_IMR0               (0x4001402C) /**< \brief (TC1) Interrupt Mask Register Channel 0 */
+#define REG_TC1_CCR1               (0x40014040) /**< \brief (TC1) Channel Control Register Channel 1 */
+#define REG_TC1_CMR1               (0x40014044) /**< \brief (TC1) Channel Mode Register Channel 1 */
+#define REG_TC1_SMMR1              (0x40014048) /**< \brief (TC1) Stepper Motor Mode Register 1 */
+#define REG_TC1_CV1                (0x40014050) /**< \brief (TC1) Counter Value Channel 1 */
+#define REG_TC1_RA1                (0x40014054) /**< \brief (TC1) Register A Channel 1 */
+#define REG_TC1_RB1                (0x40014058) /**< \brief (TC1) Register B Channel 1 */
+#define REG_TC1_RC1                (0x4001405C) /**< \brief (TC1) Register C Channel 1 */
+#define REG_TC1_SR1                (0x40014060) /**< \brief (TC1) Status Register Channel 1 */
+#define REG_TC1_IER1               (0x40014064) /**< \brief (TC1) Interrupt Enable Register Channel 1 */
+#define REG_TC1_IDR1               (0x40014068) /**< \brief (TC1) Interrupt Disable Register Channel 1 */
+#define REG_TC1_IMR1               (0x4001406C) /**< \brief (TC1) Interrupt Mask Register Channel 1 */
+#define REG_TC1_CCR2               (0x40014080) /**< \brief (TC1) Channel Control Register Channel 2 */
+#define REG_TC1_CMR2               (0x40014084) /**< \brief (TC1) Channel Mode Register Channel 2 */
+#define REG_TC1_SMMR2              (0x40014088) /**< \brief (TC1) Stepper Motor Mode Register 2 */
+#define REG_TC1_CV2                (0x40014090) /**< \brief (TC1) Counter Value Channel 2 */
+#define REG_TC1_RA2                (0x40014094) /**< \brief (TC1) Register A Channel 2 */
+#define REG_TC1_RB2                (0x40014098) /**< \brief (TC1) Register B Channel 2 */
+#define REG_TC1_RC2                (0x4001409C) /**< \brief (TC1) Register C Channel 2 */
+#define REG_TC1_SR2                (0x400140A0) /**< \brief (TC1) Status Register Channel 2 */
+#define REG_TC1_IER2               (0x400140A4) /**< \brief (TC1) Interrupt Enable Register Channel 2 */
+#define REG_TC1_IDR2               (0x400140A8) /**< \brief (TC1) Interrupt Disable Register Channel 2 */
+#define REG_TC1_IMR2               (0x400140AC) /**< \brief (TC1) Interrupt Mask Register Channel 2 */
+#define REG_TC1_BCR                (0x400140C0) /**< \brief (TC1) TC Block Control Register */
+#define REG_TC1_BMR                (0x400140C4) /**< \brief (TC1) TC Block Mode Register */
+#define REG_TC1_WPMR               (0x400140E4) /**< \brief (TC1) Write Protect Mode Register */
+#define REG_TC1_FEATURES           (0x400140F8) /**< \brief (TC1) Features Register */
+#define REG_TC1_VERSION            (0x400140FC) /**< \brief (TC1) Version Register */
+#else
+#define REG_TC1_CCR0               (*(WoReg  *)0x40014000UL) /**< \brief (TC1) Channel Control Register Channel 0 */
+#define REG_TC1_CMR0               (*(RwReg  *)0x40014004UL) /**< \brief (TC1) Channel Mode Register Channel 0 */
+#define REG_TC1_SMMR0              (*(RwReg  *)0x40014008UL) /**< \brief (TC1) Stepper Motor Mode Register 0 */
+#define REG_TC1_CV0                (*(RoReg  *)0x40014010UL) /**< \brief (TC1) Counter Value Channel 0 */
+#define REG_TC1_RA0                (*(RwReg  *)0x40014014UL) /**< \brief (TC1) Register A Channel 0 */
+#define REG_TC1_RB0                (*(RwReg  *)0x40014018UL) /**< \brief (TC1) Register B Channel 0 */
+#define REG_TC1_RC0                (*(RwReg  *)0x4001401CUL) /**< \brief (TC1) Register C Channel 0 */
+#define REG_TC1_SR0                (*(RoReg  *)0x40014020UL) /**< \brief (TC1) Status Register Channel 0 */
+#define REG_TC1_IER0               (*(WoReg  *)0x40014024UL) /**< \brief (TC1) Interrupt Enable Register Channel 0 */
+#define REG_TC1_IDR0               (*(WoReg  *)0x40014028UL) /**< \brief (TC1) Interrupt Disable Register Channel 0 */
+#define REG_TC1_IMR0               (*(RoReg  *)0x4001402CUL) /**< \brief (TC1) Interrupt Mask Register Channel 0 */
+#define REG_TC1_CCR1               (*(WoReg  *)0x40014040UL) /**< \brief (TC1) Channel Control Register Channel 1 */
+#define REG_TC1_CMR1               (*(RwReg  *)0x40014044UL) /**< \brief (TC1) Channel Mode Register Channel 1 */
+#define REG_TC1_SMMR1              (*(RwReg  *)0x40014048UL) /**< \brief (TC1) Stepper Motor Mode Register 1 */
+#define REG_TC1_CV1                (*(RoReg  *)0x40014050UL) /**< \brief (TC1) Counter Value Channel 1 */
+#define REG_TC1_RA1                (*(RwReg  *)0x40014054UL) /**< \brief (TC1) Register A Channel 1 */
+#define REG_TC1_RB1                (*(RwReg  *)0x40014058UL) /**< \brief (TC1) Register B Channel 1 */
+#define REG_TC1_RC1                (*(RwReg  *)0x4001405CUL) /**< \brief (TC1) Register C Channel 1 */
+#define REG_TC1_SR1                (*(RoReg  *)0x40014060UL) /**< \brief (TC1) Status Register Channel 1 */
+#define REG_TC1_IER1               (*(WoReg  *)0x40014064UL) /**< \brief (TC1) Interrupt Enable Register Channel 1 */
+#define REG_TC1_IDR1               (*(WoReg  *)0x40014068UL) /**< \brief (TC1) Interrupt Disable Register Channel 1 */
+#define REG_TC1_IMR1               (*(RoReg  *)0x4001406CUL) /**< \brief (TC1) Interrupt Mask Register Channel 1 */
+#define REG_TC1_CCR2               (*(WoReg  *)0x40014080UL) /**< \brief (TC1) Channel Control Register Channel 2 */
+#define REG_TC1_CMR2               (*(RwReg  *)0x40014084UL) /**< \brief (TC1) Channel Mode Register Channel 2 */
+#define REG_TC1_SMMR2              (*(RwReg  *)0x40014088UL) /**< \brief (TC1) Stepper Motor Mode Register 2 */
+#define REG_TC1_CV2                (*(RoReg  *)0x40014090UL) /**< \brief (TC1) Counter Value Channel 2 */
+#define REG_TC1_RA2                (*(RwReg  *)0x40014094UL) /**< \brief (TC1) Register A Channel 2 */
+#define REG_TC1_RB2                (*(RwReg  *)0x40014098UL) /**< \brief (TC1) Register B Channel 2 */
+#define REG_TC1_RC2                (*(RwReg  *)0x4001409CUL) /**< \brief (TC1) Register C Channel 2 */
+#define REG_TC1_SR2                (*(RoReg  *)0x400140A0UL) /**< \brief (TC1) Status Register Channel 2 */
+#define REG_TC1_IER2               (*(WoReg  *)0x400140A4UL) /**< \brief (TC1) Interrupt Enable Register Channel 2 */
+#define REG_TC1_IDR2               (*(WoReg  *)0x400140A8UL) /**< \brief (TC1) Interrupt Disable Register Channel 2 */
+#define REG_TC1_IMR2               (*(RoReg  *)0x400140ACUL) /**< \brief (TC1) Interrupt Mask Register Channel 2 */
+#define REG_TC1_BCR                (*(WoReg  *)0x400140C0UL) /**< \brief (TC1) TC Block Control Register */
+#define REG_TC1_BMR                (*(RwReg  *)0x400140C4UL) /**< \brief (TC1) TC Block Mode Register */
+#define REG_TC1_WPMR               (*(RwReg  *)0x400140E4UL) /**< \brief (TC1) Write Protect Mode Register */
+#define REG_TC1_FEATURES           (*(RoReg  *)0x400140F8UL) /**< \brief (TC1) Features Register */
+#define REG_TC1_VERSION            (*(RoReg  *)0x400140FCUL) /**< \brief (TC1) Version Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TC1 peripheral ========== */
+#define TC1_CLK_DIV1                gen_clk_tc1
+#define TC1_CLK_DIV2                2       
+#define TC1_CLK_DIV3                8       
+#define TC1_CLK_DIV4                32      
+#define TC1_CLK_DIV5                128     
+#define TC1_GCLK_NUM                8       
+
+#endif /* _SAM4L_TC1_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/trng.h
+++ b/asf/sam/include/sam4l/instance/trng.h
@@ -1,0 +1,52 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TRNG
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_TRNG_INSTANCE_
+#define _SAM4L_TRNG_INSTANCE_
+
+/* ========== Register definition for TRNG peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TRNG_CR                (0x40068000) /**< \brief (TRNG) Control Register */
+#define REG_TRNG_IER               (0x40068010) /**< \brief (TRNG) Interrupt Enable Register */
+#define REG_TRNG_IDR               (0x40068014) /**< \brief (TRNG) Interrupt Disable Register */
+#define REG_TRNG_IMR               (0x40068018) /**< \brief (TRNG) Interrupt Mask Register */
+#define REG_TRNG_ISR               (0x4006801C) /**< \brief (TRNG) Interrupt Status Register */
+#define REG_TRNG_ODATA             (0x40068050) /**< \brief (TRNG) Output Data Register */
+#define REG_TRNG_VERSION           (0x400680FC) /**< \brief (TRNG) Version Register */
+#else
+#define REG_TRNG_CR                (*(WoReg  *)0x40068000UL) /**< \brief (TRNG) Control Register */
+#define REG_TRNG_IER               (*(WoReg  *)0x40068010UL) /**< \brief (TRNG) Interrupt Enable Register */
+#define REG_TRNG_IDR               (*(WoReg  *)0x40068014UL) /**< \brief (TRNG) Interrupt Disable Register */
+#define REG_TRNG_IMR               (*(RoReg  *)0x40068018UL) /**< \brief (TRNG) Interrupt Mask Register */
+#define REG_TRNG_ISR               (*(RoReg  *)0x4006801CUL) /**< \brief (TRNG) Interrupt Status Register */
+#define REG_TRNG_ODATA             (*(RoReg  *)0x40068050UL) /**< \brief (TRNG) Output Data Register */
+#define REG_TRNG_VERSION           (*(RoReg  *)0x400680FCUL) /**< \brief (TRNG) Version Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+
+#endif /* _SAM4L_TRNG_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/twim0.h
+++ b/asf/sam/include/sam4l/instance/twim0.h
@@ -1,0 +1,75 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TWIM0
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_TWIM0_INSTANCE_
+#define _SAM4L_TWIM0_INSTANCE_
+
+/* ========== Register definition for TWIM0 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TWIM0_CR               (0x40018000) /**< \brief (TWIM0) Control Register */
+#define REG_TWIM0_CWGR             (0x40018004) /**< \brief (TWIM0) Clock Waveform Generator Register */
+#define REG_TWIM0_SMBTR            (0x40018008) /**< \brief (TWIM0) SMBus Timing Register */
+#define REG_TWIM0_CMDR             (0x4001800C) /**< \brief (TWIM0) Command Register */
+#define REG_TWIM0_NCMDR            (0x40018010) /**< \brief (TWIM0) Next Command Register */
+#define REG_TWIM0_RHR              (0x40018014) /**< \brief (TWIM0) Receive Holding Register */
+#define REG_TWIM0_THR              (0x40018018) /**< \brief (TWIM0) Transmit Holding Register */
+#define REG_TWIM0_SR               (0x4001801C) /**< \brief (TWIM0) Status Register */
+#define REG_TWIM0_IER              (0x40018020) /**< \brief (TWIM0) Interrupt Enable Register */
+#define REG_TWIM0_IDR              (0x40018024) /**< \brief (TWIM0) Interrupt Disable Register */
+#define REG_TWIM0_IMR              (0x40018028) /**< \brief (TWIM0) Interrupt Mask Register */
+#define REG_TWIM0_SCR              (0x4001802C) /**< \brief (TWIM0) Status Clear Register */
+#define REG_TWIM0_PR               (0x40018030) /**< \brief (TWIM0) Parameter Register */
+#define REG_TWIM0_VR               (0x40018034) /**< \brief (TWIM0) Version Register */
+#define REG_TWIM0_HSCWGR           (0x40018038) /**< \brief (TWIM0) HS-mode Clock Waveform Generator */
+#define REG_TWIM0_SRR              (0x4001803C) /**< \brief (TWIM0) Slew Rate Register */
+#define REG_TWIM0_HSSRR            (0x40018040) /**< \brief (TWIM0) HS-mode Slew Rate Register */
+#else
+#define REG_TWIM0_CR               (*(WoReg  *)0x40018000UL) /**< \brief (TWIM0) Control Register */
+#define REG_TWIM0_CWGR             (*(RwReg  *)0x40018004UL) /**< \brief (TWIM0) Clock Waveform Generator Register */
+#define REG_TWIM0_SMBTR            (*(RwReg  *)0x40018008UL) /**< \brief (TWIM0) SMBus Timing Register */
+#define REG_TWIM0_CMDR             (*(RwReg  *)0x4001800CUL) /**< \brief (TWIM0) Command Register */
+#define REG_TWIM0_NCMDR            (*(RwReg  *)0x40018010UL) /**< \brief (TWIM0) Next Command Register */
+#define REG_TWIM0_RHR              (*(RoReg  *)0x40018014UL) /**< \brief (TWIM0) Receive Holding Register */
+#define REG_TWIM0_THR              (*(WoReg  *)0x40018018UL) /**< \brief (TWIM0) Transmit Holding Register */
+#define REG_TWIM0_SR               (*(RoReg  *)0x4001801CUL) /**< \brief (TWIM0) Status Register */
+#define REG_TWIM0_IER              (*(WoReg  *)0x40018020UL) /**< \brief (TWIM0) Interrupt Enable Register */
+#define REG_TWIM0_IDR              (*(WoReg  *)0x40018024UL) /**< \brief (TWIM0) Interrupt Disable Register */
+#define REG_TWIM0_IMR              (*(RoReg  *)0x40018028UL) /**< \brief (TWIM0) Interrupt Mask Register */
+#define REG_TWIM0_SCR              (*(WoReg  *)0x4001802CUL) /**< \brief (TWIM0) Status Clear Register */
+#define REG_TWIM0_PR               (*(RoReg  *)0x40018030UL) /**< \brief (TWIM0) Parameter Register */
+#define REG_TWIM0_VR               (*(RoReg  *)0x40018034UL) /**< \brief (TWIM0) Version Register */
+#define REG_TWIM0_HSCWGR           (*(RwReg  *)0x40018038UL) /**< \brief (TWIM0) HS-mode Clock Waveform Generator */
+#define REG_TWIM0_SRR              (*(RwReg  *)0x4001803CUL) /**< \brief (TWIM0) Slew Rate Register */
+#define REG_TWIM0_HSSRR            (*(RwReg  *)0x40018040UL) /**< \brief (TWIM0) HS-mode Slew Rate Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TWIM0 peripheral ========== */
+#define TWIM0_PDCA_ID_RX            5       
+#define TWIM0_PDCA_ID_TX            23      
+
+#endif /* _SAM4L_TWIM0_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/twim1.h
+++ b/asf/sam/include/sam4l/instance/twim1.h
@@ -1,0 +1,75 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TWIM1
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_TWIM1_INSTANCE_
+#define _SAM4L_TWIM1_INSTANCE_
+
+/* ========== Register definition for TWIM1 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TWIM1_CR               (0x4001C000) /**< \brief (TWIM1) Control Register */
+#define REG_TWIM1_CWGR             (0x4001C004) /**< \brief (TWIM1) Clock Waveform Generator Register */
+#define REG_TWIM1_SMBTR            (0x4001C008) /**< \brief (TWIM1) SMBus Timing Register */
+#define REG_TWIM1_CMDR             (0x4001C00C) /**< \brief (TWIM1) Command Register */
+#define REG_TWIM1_NCMDR            (0x4001C010) /**< \brief (TWIM1) Next Command Register */
+#define REG_TWIM1_RHR              (0x4001C014) /**< \brief (TWIM1) Receive Holding Register */
+#define REG_TWIM1_THR              (0x4001C018) /**< \brief (TWIM1) Transmit Holding Register */
+#define REG_TWIM1_SR               (0x4001C01C) /**< \brief (TWIM1) Status Register */
+#define REG_TWIM1_IER              (0x4001C020) /**< \brief (TWIM1) Interrupt Enable Register */
+#define REG_TWIM1_IDR              (0x4001C024) /**< \brief (TWIM1) Interrupt Disable Register */
+#define REG_TWIM1_IMR              (0x4001C028) /**< \brief (TWIM1) Interrupt Mask Register */
+#define REG_TWIM1_SCR              (0x4001C02C) /**< \brief (TWIM1) Status Clear Register */
+#define REG_TWIM1_PR               (0x4001C030) /**< \brief (TWIM1) Parameter Register */
+#define REG_TWIM1_VR               (0x4001C034) /**< \brief (TWIM1) Version Register */
+#define REG_TWIM1_HSCWGR           (0x4001C038) /**< \brief (TWIM1) HS-mode Clock Waveform Generator */
+#define REG_TWIM1_SRR              (0x4001C03C) /**< \brief (TWIM1) Slew Rate Register */
+#define REG_TWIM1_HSSRR            (0x4001C040) /**< \brief (TWIM1) HS-mode Slew Rate Register */
+#else
+#define REG_TWIM1_CR               (*(WoReg  *)0x4001C000UL) /**< \brief (TWIM1) Control Register */
+#define REG_TWIM1_CWGR             (*(RwReg  *)0x4001C004UL) /**< \brief (TWIM1) Clock Waveform Generator Register */
+#define REG_TWIM1_SMBTR            (*(RwReg  *)0x4001C008UL) /**< \brief (TWIM1) SMBus Timing Register */
+#define REG_TWIM1_CMDR             (*(RwReg  *)0x4001C00CUL) /**< \brief (TWIM1) Command Register */
+#define REG_TWIM1_NCMDR            (*(RwReg  *)0x4001C010UL) /**< \brief (TWIM1) Next Command Register */
+#define REG_TWIM1_RHR              (*(RoReg  *)0x4001C014UL) /**< \brief (TWIM1) Receive Holding Register */
+#define REG_TWIM1_THR              (*(WoReg  *)0x4001C018UL) /**< \brief (TWIM1) Transmit Holding Register */
+#define REG_TWIM1_SR               (*(RoReg  *)0x4001C01CUL) /**< \brief (TWIM1) Status Register */
+#define REG_TWIM1_IER              (*(WoReg  *)0x4001C020UL) /**< \brief (TWIM1) Interrupt Enable Register */
+#define REG_TWIM1_IDR              (*(WoReg  *)0x4001C024UL) /**< \brief (TWIM1) Interrupt Disable Register */
+#define REG_TWIM1_IMR              (*(RoReg  *)0x4001C028UL) /**< \brief (TWIM1) Interrupt Mask Register */
+#define REG_TWIM1_SCR              (*(WoReg  *)0x4001C02CUL) /**< \brief (TWIM1) Status Clear Register */
+#define REG_TWIM1_PR               (*(RoReg  *)0x4001C030UL) /**< \brief (TWIM1) Parameter Register */
+#define REG_TWIM1_VR               (*(RoReg  *)0x4001C034UL) /**< \brief (TWIM1) Version Register */
+#define REG_TWIM1_HSCWGR           (*(RwReg  *)0x4001C038UL) /**< \brief (TWIM1) HS-mode Clock Waveform Generator */
+#define REG_TWIM1_SRR              (*(RwReg  *)0x4001C03CUL) /**< \brief (TWIM1) Slew Rate Register */
+#define REG_TWIM1_HSSRR            (*(RwReg  *)0x4001C040UL) /**< \brief (TWIM1) HS-mode Slew Rate Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TWIM1 peripheral ========== */
+#define TWIM1_PDCA_ID_RX            6       
+#define TWIM1_PDCA_ID_TX            24      
+
+#endif /* _SAM4L_TWIM1_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/twim2.h
+++ b/asf/sam/include/sam4l/instance/twim2.h
@@ -1,0 +1,75 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TWIM2
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_TWIM2_INSTANCE_
+#define _SAM4L_TWIM2_INSTANCE_
+
+/* ========== Register definition for TWIM2 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TWIM2_CR               (0x40078000) /**< \brief (TWIM2) Control Register */
+#define REG_TWIM2_CWGR             (0x40078004) /**< \brief (TWIM2) Clock Waveform Generator Register */
+#define REG_TWIM2_SMBTR            (0x40078008) /**< \brief (TWIM2) SMBus Timing Register */
+#define REG_TWIM2_CMDR             (0x4007800C) /**< \brief (TWIM2) Command Register */
+#define REG_TWIM2_NCMDR            (0x40078010) /**< \brief (TWIM2) Next Command Register */
+#define REG_TWIM2_RHR              (0x40078014) /**< \brief (TWIM2) Receive Holding Register */
+#define REG_TWIM2_THR              (0x40078018) /**< \brief (TWIM2) Transmit Holding Register */
+#define REG_TWIM2_SR               (0x4007801C) /**< \brief (TWIM2) Status Register */
+#define REG_TWIM2_IER              (0x40078020) /**< \brief (TWIM2) Interrupt Enable Register */
+#define REG_TWIM2_IDR              (0x40078024) /**< \brief (TWIM2) Interrupt Disable Register */
+#define REG_TWIM2_IMR              (0x40078028) /**< \brief (TWIM2) Interrupt Mask Register */
+#define REG_TWIM2_SCR              (0x4007802C) /**< \brief (TWIM2) Status Clear Register */
+#define REG_TWIM2_PR               (0x40078030) /**< \brief (TWIM2) Parameter Register */
+#define REG_TWIM2_VR               (0x40078034) /**< \brief (TWIM2) Version Register */
+#define REG_TWIM2_HSCWGR           (0x40078038) /**< \brief (TWIM2) HS-mode Clock Waveform Generator */
+#define REG_TWIM2_SRR              (0x4007803C) /**< \brief (TWIM2) Slew Rate Register */
+#define REG_TWIM2_HSSRR            (0x40078040) /**< \brief (TWIM2) HS-mode Slew Rate Register */
+#else
+#define REG_TWIM2_CR               (*(WoReg  *)0x40078000UL) /**< \brief (TWIM2) Control Register */
+#define REG_TWIM2_CWGR             (*(RwReg  *)0x40078004UL) /**< \brief (TWIM2) Clock Waveform Generator Register */
+#define REG_TWIM2_SMBTR            (*(RwReg  *)0x40078008UL) /**< \brief (TWIM2) SMBus Timing Register */
+#define REG_TWIM2_CMDR             (*(RwReg  *)0x4007800CUL) /**< \brief (TWIM2) Command Register */
+#define REG_TWIM2_NCMDR            (*(RwReg  *)0x40078010UL) /**< \brief (TWIM2) Next Command Register */
+#define REG_TWIM2_RHR              (*(RoReg  *)0x40078014UL) /**< \brief (TWIM2) Receive Holding Register */
+#define REG_TWIM2_THR              (*(WoReg  *)0x40078018UL) /**< \brief (TWIM2) Transmit Holding Register */
+#define REG_TWIM2_SR               (*(RoReg  *)0x4007801CUL) /**< \brief (TWIM2) Status Register */
+#define REG_TWIM2_IER              (*(WoReg  *)0x40078020UL) /**< \brief (TWIM2) Interrupt Enable Register */
+#define REG_TWIM2_IDR              (*(WoReg  *)0x40078024UL) /**< \brief (TWIM2) Interrupt Disable Register */
+#define REG_TWIM2_IMR              (*(RoReg  *)0x40078028UL) /**< \brief (TWIM2) Interrupt Mask Register */
+#define REG_TWIM2_SCR              (*(WoReg  *)0x4007802CUL) /**< \brief (TWIM2) Status Clear Register */
+#define REG_TWIM2_PR               (*(RoReg  *)0x40078030UL) /**< \brief (TWIM2) Parameter Register */
+#define REG_TWIM2_VR               (*(RoReg  *)0x40078034UL) /**< \brief (TWIM2) Version Register */
+#define REG_TWIM2_HSCWGR           (*(RwReg  *)0x40078038UL) /**< \brief (TWIM2) HS-mode Clock Waveform Generator */
+#define REG_TWIM2_SRR              (*(RwReg  *)0x4007803CUL) /**< \brief (TWIM2) Slew Rate Register */
+#define REG_TWIM2_HSSRR            (*(RwReg  *)0x40078040UL) /**< \brief (TWIM2) HS-mode Slew Rate Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TWIM2 peripheral ========== */
+#define TWIM2_PDCA_ID_RX            7       
+#define TWIM2_PDCA_ID_TX            25      
+
+#endif /* _SAM4L_TWIM2_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/twim3.h
+++ b/asf/sam/include/sam4l/instance/twim3.h
@@ -1,0 +1,75 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TWIM3
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_TWIM3_INSTANCE_
+#define _SAM4L_TWIM3_INSTANCE_
+
+/* ========== Register definition for TWIM3 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TWIM3_CR               (0x4007C000) /**< \brief (TWIM3) Control Register */
+#define REG_TWIM3_CWGR             (0x4007C004) /**< \brief (TWIM3) Clock Waveform Generator Register */
+#define REG_TWIM3_SMBTR            (0x4007C008) /**< \brief (TWIM3) SMBus Timing Register */
+#define REG_TWIM3_CMDR             (0x4007C00C) /**< \brief (TWIM3) Command Register */
+#define REG_TWIM3_NCMDR            (0x4007C010) /**< \brief (TWIM3) Next Command Register */
+#define REG_TWIM3_RHR              (0x4007C014) /**< \brief (TWIM3) Receive Holding Register */
+#define REG_TWIM3_THR              (0x4007C018) /**< \brief (TWIM3) Transmit Holding Register */
+#define REG_TWIM3_SR               (0x4007C01C) /**< \brief (TWIM3) Status Register */
+#define REG_TWIM3_IER              (0x4007C020) /**< \brief (TWIM3) Interrupt Enable Register */
+#define REG_TWIM3_IDR              (0x4007C024) /**< \brief (TWIM3) Interrupt Disable Register */
+#define REG_TWIM3_IMR              (0x4007C028) /**< \brief (TWIM3) Interrupt Mask Register */
+#define REG_TWIM3_SCR              (0x4007C02C) /**< \brief (TWIM3) Status Clear Register */
+#define REG_TWIM3_PR               (0x4007C030) /**< \brief (TWIM3) Parameter Register */
+#define REG_TWIM3_VR               (0x4007C034) /**< \brief (TWIM3) Version Register */
+#define REG_TWIM3_HSCWGR           (0x4007C038) /**< \brief (TWIM3) HS-mode Clock Waveform Generator */
+#define REG_TWIM3_SRR              (0x4007C03C) /**< \brief (TWIM3) Slew Rate Register */
+#define REG_TWIM3_HSSRR            (0x4007C040) /**< \brief (TWIM3) HS-mode Slew Rate Register */
+#else
+#define REG_TWIM3_CR               (*(WoReg  *)0x4007C000UL) /**< \brief (TWIM3) Control Register */
+#define REG_TWIM3_CWGR             (*(RwReg  *)0x4007C004UL) /**< \brief (TWIM3) Clock Waveform Generator Register */
+#define REG_TWIM3_SMBTR            (*(RwReg  *)0x4007C008UL) /**< \brief (TWIM3) SMBus Timing Register */
+#define REG_TWIM3_CMDR             (*(RwReg  *)0x4007C00CUL) /**< \brief (TWIM3) Command Register */
+#define REG_TWIM3_NCMDR            (*(RwReg  *)0x4007C010UL) /**< \brief (TWIM3) Next Command Register */
+#define REG_TWIM3_RHR              (*(RoReg  *)0x4007C014UL) /**< \brief (TWIM3) Receive Holding Register */
+#define REG_TWIM3_THR              (*(WoReg  *)0x4007C018UL) /**< \brief (TWIM3) Transmit Holding Register */
+#define REG_TWIM3_SR               (*(RoReg  *)0x4007C01CUL) /**< \brief (TWIM3) Status Register */
+#define REG_TWIM3_IER              (*(WoReg  *)0x4007C020UL) /**< \brief (TWIM3) Interrupt Enable Register */
+#define REG_TWIM3_IDR              (*(WoReg  *)0x4007C024UL) /**< \brief (TWIM3) Interrupt Disable Register */
+#define REG_TWIM3_IMR              (*(RoReg  *)0x4007C028UL) /**< \brief (TWIM3) Interrupt Mask Register */
+#define REG_TWIM3_SCR              (*(WoReg  *)0x4007C02CUL) /**< \brief (TWIM3) Status Clear Register */
+#define REG_TWIM3_PR               (*(RoReg  *)0x4007C030UL) /**< \brief (TWIM3) Parameter Register */
+#define REG_TWIM3_VR               (*(RoReg  *)0x4007C034UL) /**< \brief (TWIM3) Version Register */
+#define REG_TWIM3_HSCWGR           (*(RwReg  *)0x4007C038UL) /**< \brief (TWIM3) HS-mode Clock Waveform Generator */
+#define REG_TWIM3_SRR              (*(RwReg  *)0x4007C03CUL) /**< \brief (TWIM3) Slew Rate Register */
+#define REG_TWIM3_HSSRR            (*(RwReg  *)0x4007C040UL) /**< \brief (TWIM3) HS-mode Slew Rate Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TWIM3 peripheral ========== */
+#define TWIM3_PDCA_ID_RX            8       
+#define TWIM3_PDCA_ID_TX            26      
+
+#endif /* _SAM4L_TWIM3_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/twis0.h
+++ b/asf/sam/include/sam4l/instance/twis0.h
@@ -1,0 +1,73 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TWIS0
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_TWIS0_INSTANCE_
+#define _SAM4L_TWIS0_INSTANCE_
+
+/* ========== Register definition for TWIS0 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TWIS0_CR               (0x40018400) /**< \brief (TWIS0) Control Register */
+#define REG_TWIS0_NBYTES           (0x40018404) /**< \brief (TWIS0) NBYTES Register */
+#define REG_TWIS0_TR               (0x40018408) /**< \brief (TWIS0) Timing Register */
+#define REG_TWIS0_RHR              (0x4001840C) /**< \brief (TWIS0) Receive Holding Register */
+#define REG_TWIS0_THR              (0x40018410) /**< \brief (TWIS0) Transmit Holding Register */
+#define REG_TWIS0_PECR             (0x40018414) /**< \brief (TWIS0) Packet Error Check Register */
+#define REG_TWIS0_SR               (0x40018418) /**< \brief (TWIS0) Status Register */
+#define REG_TWIS0_IER              (0x4001841C) /**< \brief (TWIS0) Interrupt Enable Register */
+#define REG_TWIS0_IDR              (0x40018420) /**< \brief (TWIS0) Interrupt Disable Register */
+#define REG_TWIS0_IMR              (0x40018424) /**< \brief (TWIS0) Interrupt Mask Register */
+#define REG_TWIS0_SCR              (0x40018428) /**< \brief (TWIS0) Status Clear Register */
+#define REG_TWIS0_PR               (0x4001842C) /**< \brief (TWIS0) Parameter Register */
+#define REG_TWIS0_VR               (0x40018430) /**< \brief (TWIS0) Version Register */
+#define REG_TWIS0_HSTR             (0x40018434) /**< \brief (TWIS0) HS-mode Timing Register */
+#define REG_TWIS0_SRR              (0x40018438) /**< \brief (TWIS0) Slew Rate Register */
+#define REG_TWIS0_HSSRR            (0x4001843C) /**< \brief (TWIS0) HS-mode Slew Rate Register */
+#else
+#define REG_TWIS0_CR               (*(RwReg  *)0x40018400UL) /**< \brief (TWIS0) Control Register */
+#define REG_TWIS0_NBYTES           (*(RwReg  *)0x40018404UL) /**< \brief (TWIS0) NBYTES Register */
+#define REG_TWIS0_TR               (*(RwReg  *)0x40018408UL) /**< \brief (TWIS0) Timing Register */
+#define REG_TWIS0_RHR              (*(RoReg  *)0x4001840CUL) /**< \brief (TWIS0) Receive Holding Register */
+#define REG_TWIS0_THR              (*(WoReg  *)0x40018410UL) /**< \brief (TWIS0) Transmit Holding Register */
+#define REG_TWIS0_PECR             (*(RoReg  *)0x40018414UL) /**< \brief (TWIS0) Packet Error Check Register */
+#define REG_TWIS0_SR               (*(RoReg  *)0x40018418UL) /**< \brief (TWIS0) Status Register */
+#define REG_TWIS0_IER              (*(WoReg  *)0x4001841CUL) /**< \brief (TWIS0) Interrupt Enable Register */
+#define REG_TWIS0_IDR              (*(WoReg  *)0x40018420UL) /**< \brief (TWIS0) Interrupt Disable Register */
+#define REG_TWIS0_IMR              (*(RoReg  *)0x40018424UL) /**< \brief (TWIS0) Interrupt Mask Register */
+#define REG_TWIS0_SCR              (*(WoReg  *)0x40018428UL) /**< \brief (TWIS0) Status Clear Register */
+#define REG_TWIS0_PR               (*(RoReg  *)0x4001842CUL) /**< \brief (TWIS0) Parameter Register */
+#define REG_TWIS0_VR               (*(RoReg  *)0x40018430UL) /**< \brief (TWIS0) Version Register */
+#define REG_TWIS0_HSTR             (*(RwReg  *)0x40018434UL) /**< \brief (TWIS0) HS-mode Timing Register */
+#define REG_TWIS0_SRR              (*(RwReg  *)0x40018438UL) /**< \brief (TWIS0) Slew Rate Register */
+#define REG_TWIS0_HSSRR            (*(RwReg  *)0x4001843CUL) /**< \brief (TWIS0) HS-mode Slew Rate Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TWIS0 peripheral ========== */
+#define TWIS0_PDCA_ID_RX            9       
+#define TWIS0_PDCA_ID_TX            27      
+
+#endif /* _SAM4L_TWIS0_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/twis1.h
+++ b/asf/sam/include/sam4l/instance/twis1.h
@@ -1,0 +1,73 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TWIS1
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_TWIS1_INSTANCE_
+#define _SAM4L_TWIS1_INSTANCE_
+
+/* ========== Register definition for TWIS1 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TWIS1_CR               (0x4001C400) /**< \brief (TWIS1) Control Register */
+#define REG_TWIS1_NBYTES           (0x4001C404) /**< \brief (TWIS1) NBYTES Register */
+#define REG_TWIS1_TR               (0x4001C408) /**< \brief (TWIS1) Timing Register */
+#define REG_TWIS1_RHR              (0x4001C40C) /**< \brief (TWIS1) Receive Holding Register */
+#define REG_TWIS1_THR              (0x4001C410) /**< \brief (TWIS1) Transmit Holding Register */
+#define REG_TWIS1_PECR             (0x4001C414) /**< \brief (TWIS1) Packet Error Check Register */
+#define REG_TWIS1_SR               (0x4001C418) /**< \brief (TWIS1) Status Register */
+#define REG_TWIS1_IER              (0x4001C41C) /**< \brief (TWIS1) Interrupt Enable Register */
+#define REG_TWIS1_IDR              (0x4001C420) /**< \brief (TWIS1) Interrupt Disable Register */
+#define REG_TWIS1_IMR              (0x4001C424) /**< \brief (TWIS1) Interrupt Mask Register */
+#define REG_TWIS1_SCR              (0x4001C428) /**< \brief (TWIS1) Status Clear Register */
+#define REG_TWIS1_PR               (0x4001C42C) /**< \brief (TWIS1) Parameter Register */
+#define REG_TWIS1_VR               (0x4001C430) /**< \brief (TWIS1) Version Register */
+#define REG_TWIS1_HSTR             (0x4001C434) /**< \brief (TWIS1) HS-mode Timing Register */
+#define REG_TWIS1_SRR              (0x4001C438) /**< \brief (TWIS1) Slew Rate Register */
+#define REG_TWIS1_HSSRR            (0x4001C43C) /**< \brief (TWIS1) HS-mode Slew Rate Register */
+#else
+#define REG_TWIS1_CR               (*(RwReg  *)0x4001C400UL) /**< \brief (TWIS1) Control Register */
+#define REG_TWIS1_NBYTES           (*(RwReg  *)0x4001C404UL) /**< \brief (TWIS1) NBYTES Register */
+#define REG_TWIS1_TR               (*(RwReg  *)0x4001C408UL) /**< \brief (TWIS1) Timing Register */
+#define REG_TWIS1_RHR              (*(RoReg  *)0x4001C40CUL) /**< \brief (TWIS1) Receive Holding Register */
+#define REG_TWIS1_THR              (*(WoReg  *)0x4001C410UL) /**< \brief (TWIS1) Transmit Holding Register */
+#define REG_TWIS1_PECR             (*(RoReg  *)0x4001C414UL) /**< \brief (TWIS1) Packet Error Check Register */
+#define REG_TWIS1_SR               (*(RoReg  *)0x4001C418UL) /**< \brief (TWIS1) Status Register */
+#define REG_TWIS1_IER              (*(WoReg  *)0x4001C41CUL) /**< \brief (TWIS1) Interrupt Enable Register */
+#define REG_TWIS1_IDR              (*(WoReg  *)0x4001C420UL) /**< \brief (TWIS1) Interrupt Disable Register */
+#define REG_TWIS1_IMR              (*(RoReg  *)0x4001C424UL) /**< \brief (TWIS1) Interrupt Mask Register */
+#define REG_TWIS1_SCR              (*(WoReg  *)0x4001C428UL) /**< \brief (TWIS1) Status Clear Register */
+#define REG_TWIS1_PR               (*(RoReg  *)0x4001C42CUL) /**< \brief (TWIS1) Parameter Register */
+#define REG_TWIS1_VR               (*(RoReg  *)0x4001C430UL) /**< \brief (TWIS1) Version Register */
+#define REG_TWIS1_HSTR             (*(RwReg  *)0x4001C434UL) /**< \brief (TWIS1) HS-mode Timing Register */
+#define REG_TWIS1_SRR              (*(RwReg  *)0x4001C438UL) /**< \brief (TWIS1) Slew Rate Register */
+#define REG_TWIS1_HSSRR            (*(RwReg  *)0x4001C43CUL) /**< \brief (TWIS1) HS-mode Slew Rate Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TWIS1 peripheral ========== */
+#define TWIS1_PDCA_ID_RX            10      
+#define TWIS1_PDCA_ID_TX            28      
+
+#endif /* _SAM4L_TWIS1_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/usart0.h
+++ b/asf/sam/include/sam4l/instance/usart0.h
@@ -1,0 +1,84 @@
+/**
+ * \file
+ *
+ * \brief Instance description for USART0
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_USART0_INSTANCE_
+#define _SAM4L_USART0_INSTANCE_
+
+/* ========== Register definition for USART0 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_USART0_CR              (0x40024000) /**< \brief (USART0) Control Register */
+#define REG_USART0_MR              (0x40024004) /**< \brief (USART0) Mode Register */
+#define REG_USART0_IER             (0x40024008) /**< \brief (USART0) Interrupt Enable Register */
+#define REG_USART0_IDR             (0x4002400C) /**< \brief (USART0) Interrupt Disable Register */
+#define REG_USART0_IMR             (0x40024010) /**< \brief (USART0) Interrupt Mask Register */
+#define REG_USART0_CSR             (0x40024014) /**< \brief (USART0) Channel Status Register */
+#define REG_USART0_RHR             (0x40024018) /**< \brief (USART0) Receiver Holding Register */
+#define REG_USART0_THR             (0x4002401C) /**< \brief (USART0) Transmitter Holding Register */
+#define REG_USART0_BRGR            (0x40024020) /**< \brief (USART0) Baud Rate Generator Register */
+#define REG_USART0_RTOR            (0x40024024) /**< \brief (USART0) Receiver Time-out Register */
+#define REG_USART0_TTGR            (0x40024028) /**< \brief (USART0) Transmitter Timeguard Register */
+#define REG_USART0_FIDI            (0x40024040) /**< \brief (USART0) FI DI Ratio Register */
+#define REG_USART0_NER             (0x40024044) /**< \brief (USART0) Number of Errors Register */
+#define REG_USART0_IFR             (0x4002404C) /**< \brief (USART0) IrDA Filter Register */
+#define REG_USART0_MAN             (0x40024050) /**< \brief (USART0) Manchester Configuration Register */
+#define REG_USART0_LINMR           (0x40024054) /**< \brief (USART0) LIN Mode Register */
+#define REG_USART0_LINIR           (0x40024058) /**< \brief (USART0) LIN Identifier Register */
+#define REG_USART0_LINBRR          (0x4002405C) /**< \brief (USART0) LIN Baud Rate Register */
+#define REG_USART0_WPMR            (0x400240E4) /**< \brief (USART0) Write Protect Mode Register */
+#define REG_USART0_WPSR            (0x400240E8) /**< \brief (USART0) Write Protect Status Register */
+#define REG_USART0_VERSION         (0x400240FC) /**< \brief (USART0) Version Register */
+#else
+#define REG_USART0_CR              (*(WoReg  *)0x40024000UL) /**< \brief (USART0) Control Register */
+#define REG_USART0_MR              (*(RwReg  *)0x40024004UL) /**< \brief (USART0) Mode Register */
+#define REG_USART0_IER             (*(WoReg  *)0x40024008UL) /**< \brief (USART0) Interrupt Enable Register */
+#define REG_USART0_IDR             (*(WoReg  *)0x4002400CUL) /**< \brief (USART0) Interrupt Disable Register */
+#define REG_USART0_IMR             (*(RoReg  *)0x40024010UL) /**< \brief (USART0) Interrupt Mask Register */
+#define REG_USART0_CSR             (*(RoReg  *)0x40024014UL) /**< \brief (USART0) Channel Status Register */
+#define REG_USART0_RHR             (*(RoReg  *)0x40024018UL) /**< \brief (USART0) Receiver Holding Register */
+#define REG_USART0_THR             (*(WoReg  *)0x4002401CUL) /**< \brief (USART0) Transmitter Holding Register */
+#define REG_USART0_BRGR            (*(RwReg  *)0x40024020UL) /**< \brief (USART0) Baud Rate Generator Register */
+#define REG_USART0_RTOR            (*(RwReg  *)0x40024024UL) /**< \brief (USART0) Receiver Time-out Register */
+#define REG_USART0_TTGR            (*(RwReg  *)0x40024028UL) /**< \brief (USART0) Transmitter Timeguard Register */
+#define REG_USART0_FIDI            (*(RwReg  *)0x40024040UL) /**< \brief (USART0) FI DI Ratio Register */
+#define REG_USART0_NER             (*(RoReg  *)0x40024044UL) /**< \brief (USART0) Number of Errors Register */
+#define REG_USART0_IFR             (*(RwReg  *)0x4002404CUL) /**< \brief (USART0) IrDA Filter Register */
+#define REG_USART0_MAN             (*(RwReg  *)0x40024050UL) /**< \brief (USART0) Manchester Configuration Register */
+#define REG_USART0_LINMR           (*(RwReg  *)0x40024054UL) /**< \brief (USART0) LIN Mode Register */
+#define REG_USART0_LINIR           (*(RwReg  *)0x40024058UL) /**< \brief (USART0) LIN Identifier Register */
+#define REG_USART0_LINBRR          (*(RoReg  *)0x4002405CUL) /**< \brief (USART0) LIN Baud Rate Register */
+#define REG_USART0_WPMR            (*(RwReg  *)0x400240E4UL) /**< \brief (USART0) Write Protect Mode Register */
+#define REG_USART0_WPSR            (*(RoReg  *)0x400240E8UL) /**< \brief (USART0) Write Protect Status Register */
+#define REG_USART0_VERSION         (*(RoReg  *)0x400240FCUL) /**< \brief (USART0) Version Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for USART0 peripheral ========== */
+#define USART0_CLK_DIV              8       
+#define USART0_PDCA_ID_RX           0       
+#define USART0_PDCA_ID_TX           18      
+
+#endif /* _SAM4L_USART0_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/usart1.h
+++ b/asf/sam/include/sam4l/instance/usart1.h
@@ -1,0 +1,84 @@
+/**
+ * \file
+ *
+ * \brief Instance description for USART1
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_USART1_INSTANCE_
+#define _SAM4L_USART1_INSTANCE_
+
+/* ========== Register definition for USART1 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_USART1_CR              (0x40028000) /**< \brief (USART1) Control Register */
+#define REG_USART1_MR              (0x40028004) /**< \brief (USART1) Mode Register */
+#define REG_USART1_IER             (0x40028008) /**< \brief (USART1) Interrupt Enable Register */
+#define REG_USART1_IDR             (0x4002800C) /**< \brief (USART1) Interrupt Disable Register */
+#define REG_USART1_IMR             (0x40028010) /**< \brief (USART1) Interrupt Mask Register */
+#define REG_USART1_CSR             (0x40028014) /**< \brief (USART1) Channel Status Register */
+#define REG_USART1_RHR             (0x40028018) /**< \brief (USART1) Receiver Holding Register */
+#define REG_USART1_THR             (0x4002801C) /**< \brief (USART1) Transmitter Holding Register */
+#define REG_USART1_BRGR            (0x40028020) /**< \brief (USART1) Baud Rate Generator Register */
+#define REG_USART1_RTOR            (0x40028024) /**< \brief (USART1) Receiver Time-out Register */
+#define REG_USART1_TTGR            (0x40028028) /**< \brief (USART1) Transmitter Timeguard Register */
+#define REG_USART1_FIDI            (0x40028040) /**< \brief (USART1) FI DI Ratio Register */
+#define REG_USART1_NER             (0x40028044) /**< \brief (USART1) Number of Errors Register */
+#define REG_USART1_IFR             (0x4002804C) /**< \brief (USART1) IrDA Filter Register */
+#define REG_USART1_MAN             (0x40028050) /**< \brief (USART1) Manchester Configuration Register */
+#define REG_USART1_LINMR           (0x40028054) /**< \brief (USART1) LIN Mode Register */
+#define REG_USART1_LINIR           (0x40028058) /**< \brief (USART1) LIN Identifier Register */
+#define REG_USART1_LINBRR          (0x4002805C) /**< \brief (USART1) LIN Baud Rate Register */
+#define REG_USART1_WPMR            (0x400280E4) /**< \brief (USART1) Write Protect Mode Register */
+#define REG_USART1_WPSR            (0x400280E8) /**< \brief (USART1) Write Protect Status Register */
+#define REG_USART1_VERSION         (0x400280FC) /**< \brief (USART1) Version Register */
+#else
+#define REG_USART1_CR              (*(WoReg  *)0x40028000UL) /**< \brief (USART1) Control Register */
+#define REG_USART1_MR              (*(RwReg  *)0x40028004UL) /**< \brief (USART1) Mode Register */
+#define REG_USART1_IER             (*(WoReg  *)0x40028008UL) /**< \brief (USART1) Interrupt Enable Register */
+#define REG_USART1_IDR             (*(WoReg  *)0x4002800CUL) /**< \brief (USART1) Interrupt Disable Register */
+#define REG_USART1_IMR             (*(RoReg  *)0x40028010UL) /**< \brief (USART1) Interrupt Mask Register */
+#define REG_USART1_CSR             (*(RoReg  *)0x40028014UL) /**< \brief (USART1) Channel Status Register */
+#define REG_USART1_RHR             (*(RoReg  *)0x40028018UL) /**< \brief (USART1) Receiver Holding Register */
+#define REG_USART1_THR             (*(WoReg  *)0x4002801CUL) /**< \brief (USART1) Transmitter Holding Register */
+#define REG_USART1_BRGR            (*(RwReg  *)0x40028020UL) /**< \brief (USART1) Baud Rate Generator Register */
+#define REG_USART1_RTOR            (*(RwReg  *)0x40028024UL) /**< \brief (USART1) Receiver Time-out Register */
+#define REG_USART1_TTGR            (*(RwReg  *)0x40028028UL) /**< \brief (USART1) Transmitter Timeguard Register */
+#define REG_USART1_FIDI            (*(RwReg  *)0x40028040UL) /**< \brief (USART1) FI DI Ratio Register */
+#define REG_USART1_NER             (*(RoReg  *)0x40028044UL) /**< \brief (USART1) Number of Errors Register */
+#define REG_USART1_IFR             (*(RwReg  *)0x4002804CUL) /**< \brief (USART1) IrDA Filter Register */
+#define REG_USART1_MAN             (*(RwReg  *)0x40028050UL) /**< \brief (USART1) Manchester Configuration Register */
+#define REG_USART1_LINMR           (*(RwReg  *)0x40028054UL) /**< \brief (USART1) LIN Mode Register */
+#define REG_USART1_LINIR           (*(RwReg  *)0x40028058UL) /**< \brief (USART1) LIN Identifier Register */
+#define REG_USART1_LINBRR          (*(RoReg  *)0x4002805CUL) /**< \brief (USART1) LIN Baud Rate Register */
+#define REG_USART1_WPMR            (*(RwReg  *)0x400280E4UL) /**< \brief (USART1) Write Protect Mode Register */
+#define REG_USART1_WPSR            (*(RoReg  *)0x400280E8UL) /**< \brief (USART1) Write Protect Status Register */
+#define REG_USART1_VERSION         (*(RoReg  *)0x400280FCUL) /**< \brief (USART1) Version Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for USART1 peripheral ========== */
+#define USART1_CLK_DIV              8       
+#define USART1_PDCA_ID_RX           1       
+#define USART1_PDCA_ID_TX           19      
+
+#endif /* _SAM4L_USART1_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/usart2.h
+++ b/asf/sam/include/sam4l/instance/usart2.h
@@ -1,0 +1,84 @@
+/**
+ * \file
+ *
+ * \brief Instance description for USART2
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_USART2_INSTANCE_
+#define _SAM4L_USART2_INSTANCE_
+
+/* ========== Register definition for USART2 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_USART2_CR              (0x4002C000) /**< \brief (USART2) Control Register */
+#define REG_USART2_MR              (0x4002C004) /**< \brief (USART2) Mode Register */
+#define REG_USART2_IER             (0x4002C008) /**< \brief (USART2) Interrupt Enable Register */
+#define REG_USART2_IDR             (0x4002C00C) /**< \brief (USART2) Interrupt Disable Register */
+#define REG_USART2_IMR             (0x4002C010) /**< \brief (USART2) Interrupt Mask Register */
+#define REG_USART2_CSR             (0x4002C014) /**< \brief (USART2) Channel Status Register */
+#define REG_USART2_RHR             (0x4002C018) /**< \brief (USART2) Receiver Holding Register */
+#define REG_USART2_THR             (0x4002C01C) /**< \brief (USART2) Transmitter Holding Register */
+#define REG_USART2_BRGR            (0x4002C020) /**< \brief (USART2) Baud Rate Generator Register */
+#define REG_USART2_RTOR            (0x4002C024) /**< \brief (USART2) Receiver Time-out Register */
+#define REG_USART2_TTGR            (0x4002C028) /**< \brief (USART2) Transmitter Timeguard Register */
+#define REG_USART2_FIDI            (0x4002C040) /**< \brief (USART2) FI DI Ratio Register */
+#define REG_USART2_NER             (0x4002C044) /**< \brief (USART2) Number of Errors Register */
+#define REG_USART2_IFR             (0x4002C04C) /**< \brief (USART2) IrDA Filter Register */
+#define REG_USART2_MAN             (0x4002C050) /**< \brief (USART2) Manchester Configuration Register */
+#define REG_USART2_LINMR           (0x4002C054) /**< \brief (USART2) LIN Mode Register */
+#define REG_USART2_LINIR           (0x4002C058) /**< \brief (USART2) LIN Identifier Register */
+#define REG_USART2_LINBRR          (0x4002C05C) /**< \brief (USART2) LIN Baud Rate Register */
+#define REG_USART2_WPMR            (0x4002C0E4) /**< \brief (USART2) Write Protect Mode Register */
+#define REG_USART2_WPSR            (0x4002C0E8) /**< \brief (USART2) Write Protect Status Register */
+#define REG_USART2_VERSION         (0x4002C0FC) /**< \brief (USART2) Version Register */
+#else
+#define REG_USART2_CR              (*(WoReg  *)0x4002C000UL) /**< \brief (USART2) Control Register */
+#define REG_USART2_MR              (*(RwReg  *)0x4002C004UL) /**< \brief (USART2) Mode Register */
+#define REG_USART2_IER             (*(WoReg  *)0x4002C008UL) /**< \brief (USART2) Interrupt Enable Register */
+#define REG_USART2_IDR             (*(WoReg  *)0x4002C00CUL) /**< \brief (USART2) Interrupt Disable Register */
+#define REG_USART2_IMR             (*(RoReg  *)0x4002C010UL) /**< \brief (USART2) Interrupt Mask Register */
+#define REG_USART2_CSR             (*(RoReg  *)0x4002C014UL) /**< \brief (USART2) Channel Status Register */
+#define REG_USART2_RHR             (*(RoReg  *)0x4002C018UL) /**< \brief (USART2) Receiver Holding Register */
+#define REG_USART2_THR             (*(WoReg  *)0x4002C01CUL) /**< \brief (USART2) Transmitter Holding Register */
+#define REG_USART2_BRGR            (*(RwReg  *)0x4002C020UL) /**< \brief (USART2) Baud Rate Generator Register */
+#define REG_USART2_RTOR            (*(RwReg  *)0x4002C024UL) /**< \brief (USART2) Receiver Time-out Register */
+#define REG_USART2_TTGR            (*(RwReg  *)0x4002C028UL) /**< \brief (USART2) Transmitter Timeguard Register */
+#define REG_USART2_FIDI            (*(RwReg  *)0x4002C040UL) /**< \brief (USART2) FI DI Ratio Register */
+#define REG_USART2_NER             (*(RoReg  *)0x4002C044UL) /**< \brief (USART2) Number of Errors Register */
+#define REG_USART2_IFR             (*(RwReg  *)0x4002C04CUL) /**< \brief (USART2) IrDA Filter Register */
+#define REG_USART2_MAN             (*(RwReg  *)0x4002C050UL) /**< \brief (USART2) Manchester Configuration Register */
+#define REG_USART2_LINMR           (*(RwReg  *)0x4002C054UL) /**< \brief (USART2) LIN Mode Register */
+#define REG_USART2_LINIR           (*(RwReg  *)0x4002C058UL) /**< \brief (USART2) LIN Identifier Register */
+#define REG_USART2_LINBRR          (*(RoReg  *)0x4002C05CUL) /**< \brief (USART2) LIN Baud Rate Register */
+#define REG_USART2_WPMR            (*(RwReg  *)0x4002C0E4UL) /**< \brief (USART2) Write Protect Mode Register */
+#define REG_USART2_WPSR            (*(RoReg  *)0x4002C0E8UL) /**< \brief (USART2) Write Protect Status Register */
+#define REG_USART2_VERSION         (*(RoReg  *)0x4002C0FCUL) /**< \brief (USART2) Version Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for USART2 peripheral ========== */
+#define USART2_CLK_DIV              8       
+#define USART2_PDCA_ID_RX           2       
+#define USART2_PDCA_ID_TX           20      
+
+#endif /* _SAM4L_USART2_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/usart3.h
+++ b/asf/sam/include/sam4l/instance/usart3.h
@@ -1,0 +1,84 @@
+/**
+ * \file
+ *
+ * \brief Instance description for USART3
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_USART3_INSTANCE_
+#define _SAM4L_USART3_INSTANCE_
+
+/* ========== Register definition for USART3 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_USART3_CR              (0x40030000) /**< \brief (USART3) Control Register */
+#define REG_USART3_MR              (0x40030004) /**< \brief (USART3) Mode Register */
+#define REG_USART3_IER             (0x40030008) /**< \brief (USART3) Interrupt Enable Register */
+#define REG_USART3_IDR             (0x4003000C) /**< \brief (USART3) Interrupt Disable Register */
+#define REG_USART3_IMR             (0x40030010) /**< \brief (USART3) Interrupt Mask Register */
+#define REG_USART3_CSR             (0x40030014) /**< \brief (USART3) Channel Status Register */
+#define REG_USART3_RHR             (0x40030018) /**< \brief (USART3) Receiver Holding Register */
+#define REG_USART3_THR             (0x4003001C) /**< \brief (USART3) Transmitter Holding Register */
+#define REG_USART3_BRGR            (0x40030020) /**< \brief (USART3) Baud Rate Generator Register */
+#define REG_USART3_RTOR            (0x40030024) /**< \brief (USART3) Receiver Time-out Register */
+#define REG_USART3_TTGR            (0x40030028) /**< \brief (USART3) Transmitter Timeguard Register */
+#define REG_USART3_FIDI            (0x40030040) /**< \brief (USART3) FI DI Ratio Register */
+#define REG_USART3_NER             (0x40030044) /**< \brief (USART3) Number of Errors Register */
+#define REG_USART3_IFR             (0x4003004C) /**< \brief (USART3) IrDA Filter Register */
+#define REG_USART3_MAN             (0x40030050) /**< \brief (USART3) Manchester Configuration Register */
+#define REG_USART3_LINMR           (0x40030054) /**< \brief (USART3) LIN Mode Register */
+#define REG_USART3_LINIR           (0x40030058) /**< \brief (USART3) LIN Identifier Register */
+#define REG_USART3_LINBRR          (0x4003005C) /**< \brief (USART3) LIN Baud Rate Register */
+#define REG_USART3_WPMR            (0x400300E4) /**< \brief (USART3) Write Protect Mode Register */
+#define REG_USART3_WPSR            (0x400300E8) /**< \brief (USART3) Write Protect Status Register */
+#define REG_USART3_VERSION         (0x400300FC) /**< \brief (USART3) Version Register */
+#else
+#define REG_USART3_CR              (*(WoReg  *)0x40030000UL) /**< \brief (USART3) Control Register */
+#define REG_USART3_MR              (*(RwReg  *)0x40030004UL) /**< \brief (USART3) Mode Register */
+#define REG_USART3_IER             (*(WoReg  *)0x40030008UL) /**< \brief (USART3) Interrupt Enable Register */
+#define REG_USART3_IDR             (*(WoReg  *)0x4003000CUL) /**< \brief (USART3) Interrupt Disable Register */
+#define REG_USART3_IMR             (*(RoReg  *)0x40030010UL) /**< \brief (USART3) Interrupt Mask Register */
+#define REG_USART3_CSR             (*(RoReg  *)0x40030014UL) /**< \brief (USART3) Channel Status Register */
+#define REG_USART3_RHR             (*(RoReg  *)0x40030018UL) /**< \brief (USART3) Receiver Holding Register */
+#define REG_USART3_THR             (*(WoReg  *)0x4003001CUL) /**< \brief (USART3) Transmitter Holding Register */
+#define REG_USART3_BRGR            (*(RwReg  *)0x40030020UL) /**< \brief (USART3) Baud Rate Generator Register */
+#define REG_USART3_RTOR            (*(RwReg  *)0x40030024UL) /**< \brief (USART3) Receiver Time-out Register */
+#define REG_USART3_TTGR            (*(RwReg  *)0x40030028UL) /**< \brief (USART3) Transmitter Timeguard Register */
+#define REG_USART3_FIDI            (*(RwReg  *)0x40030040UL) /**< \brief (USART3) FI DI Ratio Register */
+#define REG_USART3_NER             (*(RoReg  *)0x40030044UL) /**< \brief (USART3) Number of Errors Register */
+#define REG_USART3_IFR             (*(RwReg  *)0x4003004CUL) /**< \brief (USART3) IrDA Filter Register */
+#define REG_USART3_MAN             (*(RwReg  *)0x40030050UL) /**< \brief (USART3) Manchester Configuration Register */
+#define REG_USART3_LINMR           (*(RwReg  *)0x40030054UL) /**< \brief (USART3) LIN Mode Register */
+#define REG_USART3_LINIR           (*(RwReg  *)0x40030058UL) /**< \brief (USART3) LIN Identifier Register */
+#define REG_USART3_LINBRR          (*(RoReg  *)0x4003005CUL) /**< \brief (USART3) LIN Baud Rate Register */
+#define REG_USART3_WPMR            (*(RwReg  *)0x400300E4UL) /**< \brief (USART3) Write Protect Mode Register */
+#define REG_USART3_WPSR            (*(RoReg  *)0x400300E8UL) /**< \brief (USART3) Write Protect Status Register */
+#define REG_USART3_VERSION         (*(RoReg  *)0x400300FCUL) /**< \brief (USART3) Version Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for USART3 peripheral ========== */
+#define USART3_CLK_DIV              8       
+#define USART3_PDCA_ID_RX           3       
+#define USART3_PDCA_ID_TX           21      
+
+#endif /* _SAM4L_USART3_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/usbc.h
+++ b/asf/sam/include/sam4l/instance/usbc.h
@@ -1,0 +1,344 @@
+/**
+ * \file
+ *
+ * \brief Instance description for USBC
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_USBC_INSTANCE_
+#define _SAM4L_USBC_INSTANCE_
+
+/* ========== Register definition for USBC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_USBC_UDCON             (0x400A5000) /**< \brief (USBC) Device General Control Register */
+#define REG_USBC_UDINT             (0x400A5004) /**< \brief (USBC) Device Global Interupt Register */
+#define REG_USBC_UDINTCLR          (0x400A5008) /**< \brief (USBC) Device Global Interrupt Clear Register */
+#define REG_USBC_UDINTSET          (0x400A500C) /**< \brief (USBC) Device Global Interrupt Set Regsiter */
+#define REG_USBC_UDINTE            (0x400A5010) /**< \brief (USBC) Device Global Interrupt Enable Register */
+#define REG_USBC_UDINTECLR         (0x400A5014) /**< \brief (USBC) Device Global Interrupt Enable Clear Register */
+#define REG_USBC_UDINTESET         (0x400A5018) /**< \brief (USBC) Device Global Interrupt Enable Set Register */
+#define REG_USBC_UERST             (0x400A501C) /**< \brief (USBC) Endpoint Enable/Reset Register */
+#define REG_USBC_UDFNUM            (0x400A5020) /**< \brief (USBC) Device Frame Number Register */
+#define REG_USBC_UECFG0            (0x400A5100) /**< \brief (USBC) Endpoint Configuration Register */
+#define REG_USBC_UECFG1            (0x400A5104) /**< \brief (USBC) Endpoint Configuration Register */
+#define REG_USBC_UECFG2            (0x400A5108) /**< \brief (USBC) Endpoint Configuration Register */
+#define REG_USBC_UECFG3            (0x400A510C) /**< \brief (USBC) Endpoint Configuration Register */
+#define REG_USBC_UECFG4            (0x400A5110) /**< \brief (USBC) Endpoint Configuration Register */
+#define REG_USBC_UECFG5            (0x400A5114) /**< \brief (USBC) Endpoint Configuration Register */
+#define REG_USBC_UECFG6            (0x400A5118) /**< \brief (USBC) Endpoint Configuration Register */
+#define REG_USBC_UECFG7            (0x400A511C) /**< \brief (USBC) Endpoint Configuration Register */
+#define REG_USBC_UESTA0            (0x400A5130) /**< \brief (USBC) Endpoint Status Register */
+#define REG_USBC_UESTA1            (0x400A5134) /**< \brief (USBC) Endpoint Status Register */
+#define REG_USBC_UESTA2            (0x400A5138) /**< \brief (USBC) Endpoint Status Register */
+#define REG_USBC_UESTA3            (0x400A513C) /**< \brief (USBC) Endpoint Status Register */
+#define REG_USBC_UESTA4            (0x400A5140) /**< \brief (USBC) Endpoint Status Register */
+#define REG_USBC_UESTA5            (0x400A5144) /**< \brief (USBC) Endpoint Status Register */
+#define REG_USBC_UESTA6            (0x400A5148) /**< \brief (USBC) Endpoint Status Register */
+#define REG_USBC_UESTA7            (0x400A514C) /**< \brief (USBC) Endpoint Status Register */
+#define REG_USBC_UESTA0CLR         (0x400A5160) /**< \brief (USBC) Endpoint Status Clear Register */
+#define REG_USBC_UESTA1CLR         (0x400A5164) /**< \brief (USBC) Endpoint Status Clear Register */
+#define REG_USBC_UESTA2CLR         (0x400A5168) /**< \brief (USBC) Endpoint Status Clear Register */
+#define REG_USBC_UESTA3CLR         (0x400A516C) /**< \brief (USBC) Endpoint Status Clear Register */
+#define REG_USBC_UESTA4CLR         (0x400A5170) /**< \brief (USBC) Endpoint Status Clear Register */
+#define REG_USBC_UESTA5CLR         (0x400A5174) /**< \brief (USBC) Endpoint Status Clear Register */
+#define REG_USBC_UESTA6CLR         (0x400A5178) /**< \brief (USBC) Endpoint Status Clear Register */
+#define REG_USBC_UESTA7CLR         (0x400A517C) /**< \brief (USBC) Endpoint Status Clear Register */
+#define REG_USBC_UESTA0SET         (0x400A5190) /**< \brief (USBC) Endpoint Status Set Register */
+#define REG_USBC_UESTA1SET         (0x400A5194) /**< \brief (USBC) Endpoint Status Set Register */
+#define REG_USBC_UESTA2SET         (0x400A5198) /**< \brief (USBC) Endpoint Status Set Register */
+#define REG_USBC_UESTA3SET         (0x400A519C) /**< \brief (USBC) Endpoint Status Set Register */
+#define REG_USBC_UESTA4SET         (0x400A51A0) /**< \brief (USBC) Endpoint Status Set Register */
+#define REG_USBC_UESTA5SET         (0x400A51A4) /**< \brief (USBC) Endpoint Status Set Register */
+#define REG_USBC_UESTA6SET         (0x400A51A8) /**< \brief (USBC) Endpoint Status Set Register */
+#define REG_USBC_UESTA7SET         (0x400A51AC) /**< \brief (USBC) Endpoint Status Set Register */
+#define REG_USBC_UECON0            (0x400A51C0) /**< \brief (USBC) Endpoint Control Register */
+#define REG_USBC_UECON1            (0x400A51C4) /**< \brief (USBC) Endpoint Control Register */
+#define REG_USBC_UECON2            (0x400A51C8) /**< \brief (USBC) Endpoint Control Register */
+#define REG_USBC_UECON3            (0x400A51CC) /**< \brief (USBC) Endpoint Control Register */
+#define REG_USBC_UECON4            (0x400A51D0) /**< \brief (USBC) Endpoint Control Register */
+#define REG_USBC_UECON5            (0x400A51D4) /**< \brief (USBC) Endpoint Control Register */
+#define REG_USBC_UECON6            (0x400A51D8) /**< \brief (USBC) Endpoint Control Register */
+#define REG_USBC_UECON7            (0x400A51DC) /**< \brief (USBC) Endpoint Control Register */
+#define REG_USBC_UECON0SET         (0x400A51F0) /**< \brief (USBC) Endpoint Control Set Register */
+#define REG_USBC_UECON1SET         (0x400A51F4) /**< \brief (USBC) Endpoint Control Set Register */
+#define REG_USBC_UECON2SET         (0x400A51F8) /**< \brief (USBC) Endpoint Control Set Register */
+#define REG_USBC_UECON3SET         (0x400A51FC) /**< \brief (USBC) Endpoint Control Set Register */
+#define REG_USBC_UECON4SET         (0x400A5200) /**< \brief (USBC) Endpoint Control Set Register */
+#define REG_USBC_UECON5SET         (0x400A5204) /**< \brief (USBC) Endpoint Control Set Register */
+#define REG_USBC_UECON6SET         (0x400A5208) /**< \brief (USBC) Endpoint Control Set Register */
+#define REG_USBC_UECON7SET         (0x400A520C) /**< \brief (USBC) Endpoint Control Set Register */
+#define REG_USBC_UECON0CLR         (0x400A5220) /**< \brief (USBC) Endpoint Control Clear Register */
+#define REG_USBC_UECON1CLR         (0x400A5224) /**< \brief (USBC) TXINE Clear */
+#define REG_USBC_UECON2CLR         (0x400A5228) /**< \brief (USBC) TXINE Clear */
+#define REG_USBC_UECON3CLR         (0x400A522C) /**< \brief (USBC) TXINE Clear */
+#define REG_USBC_UECON4CLR         (0x400A5230) /**< \brief (USBC) TXINE Clear */
+#define REG_USBC_UECON5CLR         (0x400A5234) /**< \brief (USBC) TXINE Clear */
+#define REG_USBC_UECON6CLR         (0x400A5238) /**< \brief (USBC) TXINE Clear */
+#define REG_USBC_UECON7CLR         (0x400A523C) /**< \brief (USBC) TXINE Clear */
+#define REG_USBC_UHCON             (0x400A5400) /**< \brief (USBC) Host General Control Register */
+#define REG_USBC_UHINT             (0x400A5404) /**< \brief (USBC) Host Global Interrupt Register */
+#define REG_USBC_UHINTCLR          (0x400A5408) /**< \brief (USBC) Host Global Interrrupt Clear Register */
+#define REG_USBC_UHINTSET          (0x400A540C) /**< \brief (USBC) Host Global Interrupt Set Register */
+#define REG_USBC_UHINTE            (0x400A5410) /**< \brief (USBC) Host Global Interrupt Enable Register */
+#define REG_USBC_UHINTECLR         (0x400A5414) /**< \brief (USBC) Host Global Interrupt Enable Clear Register */
+#define REG_USBC_UHINTESET         (0x400A5418) /**< \brief (USBC) Host Global Interrupt Enable Set Register */
+#define REG_USBC_UPRST             (0x400A541C) /**< \brief (USBC) Pipe Reset Register */
+#define REG_USBC_UHFNUM            (0x400A5420) /**< \brief (USBC) Host Frame Number Register */
+#define REG_USBC_UHSOFC            (0x400A5424) /**< \brief (USBC) Host Start of Frame Control Register */
+#define REG_USBC_UPCFG0            (0x400A5500) /**< \brief (USBC) Pipe Configuration Register */
+#define REG_USBC_UPCFG1            (0x400A5504) /**< \brief (USBC) Pipe Configuration Register */
+#define REG_USBC_UPCFG2            (0x400A5508) /**< \brief (USBC) Pipe Configuration Register */
+#define REG_USBC_UPCFG3            (0x400A550C) /**< \brief (USBC) Pipe Configuration Register */
+#define REG_USBC_UPCFG4            (0x400A5510) /**< \brief (USBC) Pipe Configuration Register */
+#define REG_USBC_UPCFG5            (0x400A5514) /**< \brief (USBC) Pipe Configuration Register */
+#define REG_USBC_UPCFG6            (0x400A5518) /**< \brief (USBC) Pipe Configuration Register */
+#define REG_USBC_UPCFG7            (0x400A551C) /**< \brief (USBC) Pipe Configuration Register */
+#define REG_USBC_UPSTA0            (0x400A5530) /**< \brief (USBC) Pipe Status Register */
+#define REG_USBC_UPSTA1            (0x400A5534) /**< \brief (USBC) Pipe Status Register */
+#define REG_USBC_UPSTA2            (0x400A5538) /**< \brief (USBC) Pipe Status Register */
+#define REG_USBC_UPSTA3            (0x400A553C) /**< \brief (USBC) Pipe Status Register */
+#define REG_USBC_UPSTA4            (0x400A5540) /**< \brief (USBC) Pipe Status Register */
+#define REG_USBC_UPSTA5            (0x400A5544) /**< \brief (USBC) Pipe Status Register */
+#define REG_USBC_UPSTA6            (0x400A5548) /**< \brief (USBC) Pipe Status Register */
+#define REG_USBC_UPSTA7            (0x400A554C) /**< \brief (USBC) Pipe Status Register */
+#define REG_USBC_UPSTA0CLR         (0x400A5560) /**< \brief (USBC) Pipe Status Clear Register */
+#define REG_USBC_UPSTA1CLR         (0x400A5564) /**< \brief (USBC) Pipe Status Clear Register */
+#define REG_USBC_UPSTA2CLR         (0x400A5568) /**< \brief (USBC) Pipe Status Clear Register */
+#define REG_USBC_UPSTA3CLR         (0x400A556C) /**< \brief (USBC) Pipe Status Clear Register */
+#define REG_USBC_UPSTA4CLR         (0x400A5570) /**< \brief (USBC) Pipe Status Clear Register */
+#define REG_USBC_UPSTA5CLR         (0x400A5574) /**< \brief (USBC) Pipe Status Clear Register */
+#define REG_USBC_UPSTA6CLR         (0x400A5578) /**< \brief (USBC) Pipe Status Clear Register */
+#define REG_USBC_UPSTA7CLR         (0x400A557C) /**< \brief (USBC) Pipe Status Clear Register */
+#define REG_USBC_UPSTA0SET         (0x400A5590) /**< \brief (USBC) Pipe Status Set Register */
+#define REG_USBC_UPSTA1SET         (0x400A5594) /**< \brief (USBC) Pipe Status Set Register */
+#define REG_USBC_UPSTA2SET         (0x400A5598) /**< \brief (USBC) Pipe Status Set Register */
+#define REG_USBC_UPSTA3SET         (0x400A559C) /**< \brief (USBC) Pipe Status Set Register */
+#define REG_USBC_UPSTA4SET         (0x400A55A0) /**< \brief (USBC) Pipe Status Set Register */
+#define REG_USBC_UPSTA5SET         (0x400A55A4) /**< \brief (USBC) Pipe Status Set Register */
+#define REG_USBC_UPSTA6SET         (0x400A55A8) /**< \brief (USBC) Pipe Status Set Register */
+#define REG_USBC_UPSTA7SET         (0x400A55AC) /**< \brief (USBC) Pipe Status Set Register */
+#define REG_USBC_UPCON0            (0x400A55C0) /**< \brief (USBC) Pipe Control Register */
+#define REG_USBC_UPCON1            (0x400A55C4) /**< \brief (USBC) Pipe Control Register */
+#define REG_USBC_UPCON2            (0x400A55C8) /**< \brief (USBC) Pipe Control Register */
+#define REG_USBC_UPCON3            (0x400A55CC) /**< \brief (USBC) Pipe Control Register */
+#define REG_USBC_UPCON4            (0x400A55D0) /**< \brief (USBC) Pipe Control Register */
+#define REG_USBC_UPCON5            (0x400A55D4) /**< \brief (USBC) Pipe Control Register */
+#define REG_USBC_UPCON6            (0x400A55D8) /**< \brief (USBC) Pipe Control Register */
+#define REG_USBC_UPCON7            (0x400A55DC) /**< \brief (USBC) Pipe Control Register */
+#define REG_USBC_UPCON0SET         (0x400A55F0) /**< \brief (USBC) Pipe Control Set Register */
+#define REG_USBC_UPCON1SET         (0x400A55F4) /**< \brief (USBC) Pipe Control Set Register */
+#define REG_USBC_UPCON2SET         (0x400A55F8) /**< \brief (USBC) Pipe Control Set Register */
+#define REG_USBC_UPCON3SET         (0x400A55FC) /**< \brief (USBC) Pipe Control Set Register */
+#define REG_USBC_UPCON4SET         (0x400A5600) /**< \brief (USBC) Pipe Control Set Register */
+#define REG_USBC_UPCON5SET         (0x400A5604) /**< \brief (USBC) Pipe Control Set Register */
+#define REG_USBC_UPCON6SET         (0x400A5608) /**< \brief (USBC) Pipe Control Set Register */
+#define REG_USBC_UPCON7SET         (0x400A560C) /**< \brief (USBC) Pipe Control Set Register */
+#define REG_USBC_UPCON0CLR         (0x400A5620) /**< \brief (USBC) Pipe Control Clear Register */
+#define REG_USBC_UPCON1CLR         (0x400A5624) /**< \brief (USBC) Pipe Control Clear Register */
+#define REG_USBC_UPCON2CLR         (0x400A5628) /**< \brief (USBC) Pipe Control Clear Register */
+#define REG_USBC_UPCON3CLR         (0x400A562C) /**< \brief (USBC) Pipe Control Clear Register */
+#define REG_USBC_UPCON4CLR         (0x400A5630) /**< \brief (USBC) Pipe Control Clear Register */
+#define REG_USBC_UPCON5CLR         (0x400A5634) /**< \brief (USBC) Pipe Control Clear Register */
+#define REG_USBC_UPCON6CLR         (0x400A5638) /**< \brief (USBC) Pipe Control Clear Register */
+#define REG_USBC_UPCON7CLR         (0x400A563C) /**< \brief (USBC) Pipe Control Clear Register */
+#define REG_USBC_UPINRQ0           (0x400A5650) /**< \brief (USBC) Pipe In Request */
+#define REG_USBC_UPINRQ1           (0x400A5654) /**< \brief (USBC) Pipe In Request */
+#define REG_USBC_UPINRQ2           (0x400A5658) /**< \brief (USBC) Pipe In Request */
+#define REG_USBC_UPINRQ3           (0x400A565C) /**< \brief (USBC) Pipe In Request */
+#define REG_USBC_UPINRQ4           (0x400A5660) /**< \brief (USBC) Pipe In Request */
+#define REG_USBC_UPINRQ5           (0x400A5664) /**< \brief (USBC) Pipe In Request */
+#define REG_USBC_UPINRQ6           (0x400A5668) /**< \brief (USBC) Pipe In Request */
+#define REG_USBC_UPINRQ7           (0x400A566C) /**< \brief (USBC) Pipe In Request */
+#define REG_USBC_USBCON            (0x400A5800) /**< \brief (USBC) General Control Register */
+#define REG_USBC_USBSTA            (0x400A5804) /**< \brief (USBC) General Status Register */
+#define REG_USBC_USBSTACLR         (0x400A5808) /**< \brief (USBC) General Status Clear Register */
+#define REG_USBC_USBSTASET         (0x400A580C) /**< \brief (USBC) General Status Set Register */
+#define REG_USBC_UVERS             (0x400A5818) /**< \brief (USBC) IP Version Register */
+#define REG_USBC_UFEATURES         (0x400A581C) /**< \brief (USBC) IP Features Register */
+#define REG_USBC_UADDRSIZE         (0x400A5820) /**< \brief (USBC) IP PB address size Register */
+#define REG_USBC_UNAME1            (0x400A5824) /**< \brief (USBC) IP Name Part One: HUSB */
+#define REG_USBC_UNAME2            (0x400A5828) /**< \brief (USBC) IP Name Part Two: HOST */
+#define REG_USBC_USBFSM            (0x400A582C) /**< \brief (USBC) USB internal finite state machine */
+#define REG_USBC_UDESC             (0x400A5830) /**< \brief (USBC) Endpoint descriptor table */
+#else
+#define REG_USBC_UDCON             (*(RwReg  *)0x400A5000UL) /**< \brief (USBC) Device General Control Register */
+#define REG_USBC_UDINT             (*(RoReg  *)0x400A5004UL) /**< \brief (USBC) Device Global Interupt Register */
+#define REG_USBC_UDINTCLR          (*(WoReg  *)0x400A5008UL) /**< \brief (USBC) Device Global Interrupt Clear Register */
+#define REG_USBC_UDINTSET          (*(WoReg  *)0x400A500CUL) /**< \brief (USBC) Device Global Interrupt Set Regsiter */
+#define REG_USBC_UDINTE            (*(RoReg  *)0x400A5010UL) /**< \brief (USBC) Device Global Interrupt Enable Register */
+#define REG_USBC_UDINTECLR         (*(WoReg  *)0x400A5014UL) /**< \brief (USBC) Device Global Interrupt Enable Clear Register */
+#define REG_USBC_UDINTESET         (*(WoReg  *)0x400A5018UL) /**< \brief (USBC) Device Global Interrupt Enable Set Register */
+#define REG_USBC_UERST             (*(RwReg  *)0x400A501CUL) /**< \brief (USBC) Endpoint Enable/Reset Register */
+#define REG_USBC_UDFNUM            (*(RoReg  *)0x400A5020UL) /**< \brief (USBC) Device Frame Number Register */
+#define REG_USBC_UECFG0            (*(RwReg  *)0x400A5100UL) /**< \brief (USBC) Endpoint Configuration Register */
+#define REG_USBC_UECFG1            (*(RwReg  *)0x400A5104UL) /**< \brief (USBC) Endpoint Configuration Register */
+#define REG_USBC_UECFG2            (*(RwReg  *)0x400A5108UL) /**< \brief (USBC) Endpoint Configuration Register */
+#define REG_USBC_UECFG3            (*(RwReg  *)0x400A510CUL) /**< \brief (USBC) Endpoint Configuration Register */
+#define REG_USBC_UECFG4            (*(RwReg  *)0x400A5110UL) /**< \brief (USBC) Endpoint Configuration Register */
+#define REG_USBC_UECFG5            (*(RwReg  *)0x400A5114UL) /**< \brief (USBC) Endpoint Configuration Register */
+#define REG_USBC_UECFG6            (*(RwReg  *)0x400A5118UL) /**< \brief (USBC) Endpoint Configuration Register */
+#define REG_USBC_UECFG7            (*(RwReg  *)0x400A511CUL) /**< \brief (USBC) Endpoint Configuration Register */
+#define REG_USBC_UESTA0            (*(RoReg  *)0x400A5130UL) /**< \brief (USBC) Endpoint Status Register */
+#define REG_USBC_UESTA1            (*(RoReg  *)0x400A5134UL) /**< \brief (USBC) Endpoint Status Register */
+#define REG_USBC_UESTA2            (*(RoReg  *)0x400A5138UL) /**< \brief (USBC) Endpoint Status Register */
+#define REG_USBC_UESTA3            (*(RoReg  *)0x400A513CUL) /**< \brief (USBC) Endpoint Status Register */
+#define REG_USBC_UESTA4            (*(RoReg  *)0x400A5140UL) /**< \brief (USBC) Endpoint Status Register */
+#define REG_USBC_UESTA5            (*(RoReg  *)0x400A5144UL) /**< \brief (USBC) Endpoint Status Register */
+#define REG_USBC_UESTA6            (*(RoReg  *)0x400A5148UL) /**< \brief (USBC) Endpoint Status Register */
+#define REG_USBC_UESTA7            (*(RoReg  *)0x400A514CUL) /**< \brief (USBC) Endpoint Status Register */
+#define REG_USBC_UESTA0CLR         (*(WoReg  *)0x400A5160UL) /**< \brief (USBC) Endpoint Status Clear Register */
+#define REG_USBC_UESTA1CLR         (*(WoReg  *)0x400A5164UL) /**< \brief (USBC) Endpoint Status Clear Register */
+#define REG_USBC_UESTA2CLR         (*(WoReg  *)0x400A5168UL) /**< \brief (USBC) Endpoint Status Clear Register */
+#define REG_USBC_UESTA3CLR         (*(WoReg  *)0x400A516CUL) /**< \brief (USBC) Endpoint Status Clear Register */
+#define REG_USBC_UESTA4CLR         (*(WoReg  *)0x400A5170UL) /**< \brief (USBC) Endpoint Status Clear Register */
+#define REG_USBC_UESTA5CLR         (*(WoReg  *)0x400A5174UL) /**< \brief (USBC) Endpoint Status Clear Register */
+#define REG_USBC_UESTA6CLR         (*(WoReg  *)0x400A5178UL) /**< \brief (USBC) Endpoint Status Clear Register */
+#define REG_USBC_UESTA7CLR         (*(WoReg  *)0x400A517CUL) /**< \brief (USBC) Endpoint Status Clear Register */
+#define REG_USBC_UESTA0SET         (*(WoReg  *)0x400A5190UL) /**< \brief (USBC) Endpoint Status Set Register */
+#define REG_USBC_UESTA1SET         (*(WoReg  *)0x400A5194UL) /**< \brief (USBC) Endpoint Status Set Register */
+#define REG_USBC_UESTA2SET         (*(WoReg  *)0x400A5198UL) /**< \brief (USBC) Endpoint Status Set Register */
+#define REG_USBC_UESTA3SET         (*(WoReg  *)0x400A519CUL) /**< \brief (USBC) Endpoint Status Set Register */
+#define REG_USBC_UESTA4SET         (*(WoReg  *)0x400A51A0UL) /**< \brief (USBC) Endpoint Status Set Register */
+#define REG_USBC_UESTA5SET         (*(WoReg  *)0x400A51A4UL) /**< \brief (USBC) Endpoint Status Set Register */
+#define REG_USBC_UESTA6SET         (*(WoReg  *)0x400A51A8UL) /**< \brief (USBC) Endpoint Status Set Register */
+#define REG_USBC_UESTA7SET         (*(WoReg  *)0x400A51ACUL) /**< \brief (USBC) Endpoint Status Set Register */
+#define REG_USBC_UECON0            (*(RoReg  *)0x400A51C0UL) /**< \brief (USBC) Endpoint Control Register */
+#define REG_USBC_UECON1            (*(RoReg  *)0x400A51C4UL) /**< \brief (USBC) Endpoint Control Register */
+#define REG_USBC_UECON2            (*(RoReg  *)0x400A51C8UL) /**< \brief (USBC) Endpoint Control Register */
+#define REG_USBC_UECON3            (*(RoReg  *)0x400A51CCUL) /**< \brief (USBC) Endpoint Control Register */
+#define REG_USBC_UECON4            (*(RoReg  *)0x400A51D0UL) /**< \brief (USBC) Endpoint Control Register */
+#define REG_USBC_UECON5            (*(RoReg  *)0x400A51D4UL) /**< \brief (USBC) Endpoint Control Register */
+#define REG_USBC_UECON6            (*(RoReg  *)0x400A51D8UL) /**< \brief (USBC) Endpoint Control Register */
+#define REG_USBC_UECON7            (*(RoReg  *)0x400A51DCUL) /**< \brief (USBC) Endpoint Control Register */
+#define REG_USBC_UECON0SET         (*(WoReg  *)0x400A51F0UL) /**< \brief (USBC) Endpoint Control Set Register */
+#define REG_USBC_UECON1SET         (*(WoReg  *)0x400A51F4UL) /**< \brief (USBC) Endpoint Control Set Register */
+#define REG_USBC_UECON2SET         (*(WoReg  *)0x400A51F8UL) /**< \brief (USBC) Endpoint Control Set Register */
+#define REG_USBC_UECON3SET         (*(WoReg  *)0x400A51FCUL) /**< \brief (USBC) Endpoint Control Set Register */
+#define REG_USBC_UECON4SET         (*(WoReg  *)0x400A5200UL) /**< \brief (USBC) Endpoint Control Set Register */
+#define REG_USBC_UECON5SET         (*(WoReg  *)0x400A5204UL) /**< \brief (USBC) Endpoint Control Set Register */
+#define REG_USBC_UECON6SET         (*(WoReg  *)0x400A5208UL) /**< \brief (USBC) Endpoint Control Set Register */
+#define REG_USBC_UECON7SET         (*(WoReg  *)0x400A520CUL) /**< \brief (USBC) Endpoint Control Set Register */
+#define REG_USBC_UECON0CLR         (*(WoReg  *)0x400A5220UL) /**< \brief (USBC) Endpoint Control Clear Register */
+#define REG_USBC_UECON1CLR         (*(WoReg  *)0x400A5224UL) /**< \brief (USBC) TXINE Clear */
+#define REG_USBC_UECON2CLR         (*(WoReg  *)0x400A5228UL) /**< \brief (USBC) TXINE Clear */
+#define REG_USBC_UECON3CLR         (*(WoReg  *)0x400A522CUL) /**< \brief (USBC) TXINE Clear */
+#define REG_USBC_UECON4CLR         (*(WoReg  *)0x400A5230UL) /**< \brief (USBC) TXINE Clear */
+#define REG_USBC_UECON5CLR         (*(WoReg  *)0x400A5234UL) /**< \brief (USBC) TXINE Clear */
+#define REG_USBC_UECON6CLR         (*(WoReg  *)0x400A5238UL) /**< \brief (USBC) TXINE Clear */
+#define REG_USBC_UECON7CLR         (*(WoReg  *)0x400A523CUL) /**< \brief (USBC) TXINE Clear */
+#define REG_USBC_UHCON             (*(RwReg  *)0x400A5400UL) /**< \brief (USBC) Host General Control Register */
+#define REG_USBC_UHINT             (*(RoReg  *)0x400A5404UL) /**< \brief (USBC) Host Global Interrupt Register */
+#define REG_USBC_UHINTCLR          (*(WoReg  *)0x400A5408UL) /**< \brief (USBC) Host Global Interrrupt Clear Register */
+#define REG_USBC_UHINTSET          (*(WoReg  *)0x400A540CUL) /**< \brief (USBC) Host Global Interrupt Set Register */
+#define REG_USBC_UHINTE            (*(RoReg  *)0x400A5410UL) /**< \brief (USBC) Host Global Interrupt Enable Register */
+#define REG_USBC_UHINTECLR         (*(WoReg  *)0x400A5414UL) /**< \brief (USBC) Host Global Interrupt Enable Clear Register */
+#define REG_USBC_UHINTESET         (*(WoReg  *)0x400A5418UL) /**< \brief (USBC) Host Global Interrupt Enable Set Register */
+#define REG_USBC_UPRST             (*(RwReg  *)0x400A541CUL) /**< \brief (USBC) Pipe Reset Register */
+#define REG_USBC_UHFNUM            (*(RwReg  *)0x400A5420UL) /**< \brief (USBC) Host Frame Number Register */
+#define REG_USBC_UHSOFC            (*(RwReg  *)0x400A5424UL) /**< \brief (USBC) Host Start of Frame Control Register */
+#define REG_USBC_UPCFG0            (*(RwReg  *)0x400A5500UL) /**< \brief (USBC) Pipe Configuration Register */
+#define REG_USBC_UPCFG1            (*(RwReg  *)0x400A5504UL) /**< \brief (USBC) Pipe Configuration Register */
+#define REG_USBC_UPCFG2            (*(RwReg  *)0x400A5508UL) /**< \brief (USBC) Pipe Configuration Register */
+#define REG_USBC_UPCFG3            (*(RwReg  *)0x400A550CUL) /**< \brief (USBC) Pipe Configuration Register */
+#define REG_USBC_UPCFG4            (*(RwReg  *)0x400A5510UL) /**< \brief (USBC) Pipe Configuration Register */
+#define REG_USBC_UPCFG5            (*(RwReg  *)0x400A5514UL) /**< \brief (USBC) Pipe Configuration Register */
+#define REG_USBC_UPCFG6            (*(RwReg  *)0x400A5518UL) /**< \brief (USBC) Pipe Configuration Register */
+#define REG_USBC_UPCFG7            (*(RwReg  *)0x400A551CUL) /**< \brief (USBC) Pipe Configuration Register */
+#define REG_USBC_UPSTA0            (*(RoReg  *)0x400A5530UL) /**< \brief (USBC) Pipe Status Register */
+#define REG_USBC_UPSTA1            (*(RoReg  *)0x400A5534UL) /**< \brief (USBC) Pipe Status Register */
+#define REG_USBC_UPSTA2            (*(RoReg  *)0x400A5538UL) /**< \brief (USBC) Pipe Status Register */
+#define REG_USBC_UPSTA3            (*(RoReg  *)0x400A553CUL) /**< \brief (USBC) Pipe Status Register */
+#define REG_USBC_UPSTA4            (*(RoReg  *)0x400A5540UL) /**< \brief (USBC) Pipe Status Register */
+#define REG_USBC_UPSTA5            (*(RoReg  *)0x400A5544UL) /**< \brief (USBC) Pipe Status Register */
+#define REG_USBC_UPSTA6            (*(RoReg  *)0x400A5548UL) /**< \brief (USBC) Pipe Status Register */
+#define REG_USBC_UPSTA7            (*(RoReg  *)0x400A554CUL) /**< \brief (USBC) Pipe Status Register */
+#define REG_USBC_UPSTA0CLR         (*(WoReg  *)0x400A5560UL) /**< \brief (USBC) Pipe Status Clear Register */
+#define REG_USBC_UPSTA1CLR         (*(WoReg  *)0x400A5564UL) /**< \brief (USBC) Pipe Status Clear Register */
+#define REG_USBC_UPSTA2CLR         (*(WoReg  *)0x400A5568UL) /**< \brief (USBC) Pipe Status Clear Register */
+#define REG_USBC_UPSTA3CLR         (*(WoReg  *)0x400A556CUL) /**< \brief (USBC) Pipe Status Clear Register */
+#define REG_USBC_UPSTA4CLR         (*(WoReg  *)0x400A5570UL) /**< \brief (USBC) Pipe Status Clear Register */
+#define REG_USBC_UPSTA5CLR         (*(WoReg  *)0x400A5574UL) /**< \brief (USBC) Pipe Status Clear Register */
+#define REG_USBC_UPSTA6CLR         (*(WoReg  *)0x400A5578UL) /**< \brief (USBC) Pipe Status Clear Register */
+#define REG_USBC_UPSTA7CLR         (*(WoReg  *)0x400A557CUL) /**< \brief (USBC) Pipe Status Clear Register */
+#define REG_USBC_UPSTA0SET         (*(WoReg  *)0x400A5590UL) /**< \brief (USBC) Pipe Status Set Register */
+#define REG_USBC_UPSTA1SET         (*(WoReg  *)0x400A5594UL) /**< \brief (USBC) Pipe Status Set Register */
+#define REG_USBC_UPSTA2SET         (*(WoReg  *)0x400A5598UL) /**< \brief (USBC) Pipe Status Set Register */
+#define REG_USBC_UPSTA3SET         (*(WoReg  *)0x400A559CUL) /**< \brief (USBC) Pipe Status Set Register */
+#define REG_USBC_UPSTA4SET         (*(WoReg  *)0x400A55A0UL) /**< \brief (USBC) Pipe Status Set Register */
+#define REG_USBC_UPSTA5SET         (*(WoReg  *)0x400A55A4UL) /**< \brief (USBC) Pipe Status Set Register */
+#define REG_USBC_UPSTA6SET         (*(WoReg  *)0x400A55A8UL) /**< \brief (USBC) Pipe Status Set Register */
+#define REG_USBC_UPSTA7SET         (*(WoReg  *)0x400A55ACUL) /**< \brief (USBC) Pipe Status Set Register */
+#define REG_USBC_UPCON0            (*(RoReg  *)0x400A55C0UL) /**< \brief (USBC) Pipe Control Register */
+#define REG_USBC_UPCON1            (*(RoReg  *)0x400A55C4UL) /**< \brief (USBC) Pipe Control Register */
+#define REG_USBC_UPCON2            (*(RoReg  *)0x400A55C8UL) /**< \brief (USBC) Pipe Control Register */
+#define REG_USBC_UPCON3            (*(RoReg  *)0x400A55CCUL) /**< \brief (USBC) Pipe Control Register */
+#define REG_USBC_UPCON4            (*(RoReg  *)0x400A55D0UL) /**< \brief (USBC) Pipe Control Register */
+#define REG_USBC_UPCON5            (*(RoReg  *)0x400A55D4UL) /**< \brief (USBC) Pipe Control Register */
+#define REG_USBC_UPCON6            (*(RoReg  *)0x400A55D8UL) /**< \brief (USBC) Pipe Control Register */
+#define REG_USBC_UPCON7            (*(RoReg  *)0x400A55DCUL) /**< \brief (USBC) Pipe Control Register */
+#define REG_USBC_UPCON0SET         (*(WoReg  *)0x400A55F0UL) /**< \brief (USBC) Pipe Control Set Register */
+#define REG_USBC_UPCON1SET         (*(WoReg  *)0x400A55F4UL) /**< \brief (USBC) Pipe Control Set Register */
+#define REG_USBC_UPCON2SET         (*(WoReg  *)0x400A55F8UL) /**< \brief (USBC) Pipe Control Set Register */
+#define REG_USBC_UPCON3SET         (*(WoReg  *)0x400A55FCUL) /**< \brief (USBC) Pipe Control Set Register */
+#define REG_USBC_UPCON4SET         (*(WoReg  *)0x400A5600UL) /**< \brief (USBC) Pipe Control Set Register */
+#define REG_USBC_UPCON5SET         (*(WoReg  *)0x400A5604UL) /**< \brief (USBC) Pipe Control Set Register */
+#define REG_USBC_UPCON6SET         (*(WoReg  *)0x400A5608UL) /**< \brief (USBC) Pipe Control Set Register */
+#define REG_USBC_UPCON7SET         (*(WoReg  *)0x400A560CUL) /**< \brief (USBC) Pipe Control Set Register */
+#define REG_USBC_UPCON0CLR         (*(WoReg  *)0x400A5620UL) /**< \brief (USBC) Pipe Control Clear Register */
+#define REG_USBC_UPCON1CLR         (*(WoReg  *)0x400A5624UL) /**< \brief (USBC) Pipe Control Clear Register */
+#define REG_USBC_UPCON2CLR         (*(WoReg  *)0x400A5628UL) /**< \brief (USBC) Pipe Control Clear Register */
+#define REG_USBC_UPCON3CLR         (*(WoReg  *)0x400A562CUL) /**< \brief (USBC) Pipe Control Clear Register */
+#define REG_USBC_UPCON4CLR         (*(WoReg  *)0x400A5630UL) /**< \brief (USBC) Pipe Control Clear Register */
+#define REG_USBC_UPCON5CLR         (*(WoReg  *)0x400A5634UL) /**< \brief (USBC) Pipe Control Clear Register */
+#define REG_USBC_UPCON6CLR         (*(WoReg  *)0x400A5638UL) /**< \brief (USBC) Pipe Control Clear Register */
+#define REG_USBC_UPCON7CLR         (*(WoReg  *)0x400A563CUL) /**< \brief (USBC) Pipe Control Clear Register */
+#define REG_USBC_UPINRQ0           (*(RwReg  *)0x400A5650UL) /**< \brief (USBC) Pipe In Request */
+#define REG_USBC_UPINRQ1           (*(RwReg  *)0x400A5654UL) /**< \brief (USBC) Pipe In Request */
+#define REG_USBC_UPINRQ2           (*(RwReg  *)0x400A5658UL) /**< \brief (USBC) Pipe In Request */
+#define REG_USBC_UPINRQ3           (*(RwReg  *)0x400A565CUL) /**< \brief (USBC) Pipe In Request */
+#define REG_USBC_UPINRQ4           (*(RwReg  *)0x400A5660UL) /**< \brief (USBC) Pipe In Request */
+#define REG_USBC_UPINRQ5           (*(RwReg  *)0x400A5664UL) /**< \brief (USBC) Pipe In Request */
+#define REG_USBC_UPINRQ6           (*(RwReg  *)0x400A5668UL) /**< \brief (USBC) Pipe In Request */
+#define REG_USBC_UPINRQ7           (*(RwReg  *)0x400A566CUL) /**< \brief (USBC) Pipe In Request */
+#define REG_USBC_USBCON            (*(RwReg  *)0x400A5800UL) /**< \brief (USBC) General Control Register */
+#define REG_USBC_USBSTA            (*(RoReg  *)0x400A5804UL) /**< \brief (USBC) General Status Register */
+#define REG_USBC_USBSTACLR         (*(WoReg  *)0x400A5808UL) /**< \brief (USBC) General Status Clear Register */
+#define REG_USBC_USBSTASET         (*(WoReg  *)0x400A580CUL) /**< \brief (USBC) General Status Set Register */
+#define REG_USBC_UVERS             (*(RoReg  *)0x400A5818UL) /**< \brief (USBC) IP Version Register */
+#define REG_USBC_UFEATURES         (*(RoReg  *)0x400A581CUL) /**< \brief (USBC) IP Features Register */
+#define REG_USBC_UADDRSIZE         (*(RoReg  *)0x400A5820UL) /**< \brief (USBC) IP PB address size Register */
+#define REG_USBC_UNAME1            (*(RoReg  *)0x400A5824UL) /**< \brief (USBC) IP Name Part One: HUSB */
+#define REG_USBC_UNAME2            (*(RoReg  *)0x400A5828UL) /**< \brief (USBC) IP Name Part Two: HOST */
+#define REG_USBC_USBFSM            (*(RoReg  *)0x400A582CUL) /**< \brief (USBC) USB internal finite state machine */
+#define REG_USBC_UDESC             (*(RwReg  *)0x400A5830UL) /**< \brief (USBC) Endpoint descriptor table */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for USBC peripheral ========== */
+#define USBC_EPT_NBR                7       
+#define USBC_GCLK_NUM               7       
+#define USBC_HOST_IMPLEMENTED       1       
+#define USBC_OTG_IMPLEMENTED                
+#define USBC_USB_UTMI_IMPLEMENTED           
+
+#endif /* _SAM4L_USBC_INSTANCE_ */

--- a/asf/sam/include/sam4l/instance/wdt.h
+++ b/asf/sam/include/sam4l/instance/wdt.h
@@ -1,0 +1,58 @@
+/**
+ * \file
+ *
+ * \brief Instance description for WDT
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4L_WDT_INSTANCE_
+#define _SAM4L_WDT_INSTANCE_
+
+/* ========== Register definition for WDT peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_WDT_CTRL               (0x400F0C00) /**< \brief (WDT) Control Register */
+#define REG_WDT_CLR                (0x400F0C04) /**< \brief (WDT) Clear Register */
+#define REG_WDT_SR                 (0x400F0C08) /**< \brief (WDT) Status Register */
+#define REG_WDT_IER                (0x400F0C0C) /**< \brief (WDT) Interrupt Enable Register */
+#define REG_WDT_IDR                (0x400F0C10) /**< \brief (WDT) Interrupt Disable Register */
+#define REG_WDT_IMR                (0x400F0C14) /**< \brief (WDT) Interrupt Mask Register */
+#define REG_WDT_ISR                (0x400F0C18) /**< \brief (WDT) Interrupt Status Register */
+#define REG_WDT_ICR                (0x400F0C1C) /**< \brief (WDT) Interrupt Clear Register */
+#define REG_WDT_VERSION            (0x400F0FFC) /**< \brief (WDT) Version Register */
+#else
+#define REG_WDT_CTRL               (*(RwReg  *)0x400F0C00UL) /**< \brief (WDT) Control Register */
+#define REG_WDT_CLR                (*(WoReg  *)0x400F0C04UL) /**< \brief (WDT) Clear Register */
+#define REG_WDT_SR                 (*(RoReg  *)0x400F0C08UL) /**< \brief (WDT) Status Register */
+#define REG_WDT_IER                (*(WoReg  *)0x400F0C0CUL) /**< \brief (WDT) Interrupt Enable Register */
+#define REG_WDT_IDR                (*(WoReg  *)0x400F0C10UL) /**< \brief (WDT) Interrupt Disable Register */
+#define REG_WDT_IMR                (*(RoReg  *)0x400F0C14UL) /**< \brief (WDT) Interrupt Mask Register */
+#define REG_WDT_ISR                (*(RoReg  *)0x400F0C18UL) /**< \brief (WDT) Interrupt Status Register */
+#define REG_WDT_ICR                (*(WoReg  *)0x400F0C1CUL) /**< \brief (WDT) Interrupt Clear Register */
+#define REG_WDT_VERSION            (*(RoReg  *)0x400F0FFCUL) /**< \brief (WDT) Version Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for WDT peripheral ========== */
+#define WDT_WDT_KEY_CONST           85      
+
+#endif /* _SAM4L_WDT_INSTANCE_ */

--- a/asf/sam/include/sam4l/pio/sam4lc2a.h
+++ b/asf/sam/include/sam4l/pio/sam4lc2a.h
@@ -30,645 +30,645 @@
 #define _SAM4LC2A_PIO_
 
 #define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
-#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define GPIO_PA00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PA00 */
 #define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
-#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define GPIO_PA01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PA01 */
 #define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
-#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define GPIO_PA02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PA02 */
 #define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
-#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define GPIO_PA03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PA03 */
 #define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
-#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define GPIO_PA04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PA04 */
 #define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
-#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define GPIO_PA05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PA05 */
 #define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
-#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define GPIO_PA06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PA06 */
 #define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
-#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define GPIO_PA07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PA07 */
 #define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
-#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define GPIO_PA08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PA08 */
 #define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
-#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define GPIO_PA09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PA09 */
 #define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
-#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define GPIO_PA10                _UL_(1 << 10) /**< \brief GPIO Mask  for PA10 */
 #define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
-#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define GPIO_PA11                _UL_(1 << 11) /**< \brief GPIO Mask  for PA11 */
 #define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
-#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define GPIO_PA12                _UL_(1 << 12) /**< \brief GPIO Mask  for PA12 */
 #define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
-#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define GPIO_PA13                _UL_(1 << 13) /**< \brief GPIO Mask  for PA13 */
 #define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
-#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define GPIO_PA14                _UL_(1 << 14) /**< \brief GPIO Mask  for PA14 */
 #define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
-#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define GPIO_PA15                _UL_(1 << 15) /**< \brief GPIO Mask  for PA15 */
 #define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
-#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define GPIO_PA16                _UL_(1 << 16) /**< \brief GPIO Mask  for PA16 */
 #define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
-#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define GPIO_PA17                _UL_(1 << 17) /**< \brief GPIO Mask  for PA17 */
 #define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
-#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define GPIO_PA18                _UL_(1 << 18) /**< \brief GPIO Mask  for PA18 */
 #define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
-#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define GPIO_PA19                _UL_(1 << 19) /**< \brief GPIO Mask  for PA19 */
 #define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
-#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define GPIO_PA20                _UL_(1 << 20) /**< \brief GPIO Mask  for PA20 */
 #define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
-#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define GPIO_PA21                _UL_(1 << 21) /**< \brief GPIO Mask  for PA21 */
 #define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
-#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define GPIO_PA22                _UL_(1 << 22) /**< \brief GPIO Mask  for PA22 */
 #define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
-#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define GPIO_PA23                _UL_(1 << 23) /**< \brief GPIO Mask  for PA23 */
 #define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
-#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define GPIO_PA24                _UL_(1 << 24) /**< \brief GPIO Mask  for PA24 */
 #define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
-#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define GPIO_PA25                _UL_(1 << 25) /**< \brief GPIO Mask  for PA25 */
 #define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
-#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define GPIO_PA26                _UL_(1 << 26) /**< \brief GPIO Mask  for PA26 */
 /* ========== GPIO definition for TWIMS0 peripheral ========== */
-#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
-#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PIN_PA24B_TWIMS0_TWCK          _L_(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L_(1)
 #define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
-#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
-#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
-#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL_(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L_(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L_(1)
 #define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
-#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+#define GPIO_PA23B_TWIMS0_TWD    _UL_(1 << 23)
 /* ========== GPIO definition for TWIMS2 peripheral ========== */
-#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
-#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PIN_PA22E_TWIMS2_TWCK          _L_(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L_(4)
 #define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
-#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
-#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
-#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL_(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L_(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L_(4)
 #define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
-#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+#define GPIO_PA21E_TWIMS2_TWD    _UL_(1 << 21)
 /* ========== GPIO definition for SPI peripheral ========== */
-#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
-#define MUX_PA03B_SPI_MISO              _L(1)
+#define PIN_PA03B_SPI_MISO              _L_(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L_(1)
 #define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
-#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
-#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
-#define MUX_PA21A_SPI_MISO              _L(0)
+#define GPIO_PA03B_SPI_MISO      _UL_(1 <<  3)
+#define PIN_PA21A_SPI_MISO             _L_(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L_(0)
 #define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
-#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
-#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
-#define MUX_PA22A_SPI_MOSI              _L(0)
+#define GPIO_PA21A_SPI_MISO      _UL_(1 << 21)
+#define PIN_PA22A_SPI_MOSI             _L_(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L_(0)
 #define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
-#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
-#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
-#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define GPIO_PA22A_SPI_MOSI      _UL_(1 << 22)
+#define PIN_PA02B_SPI_NPCS0             _L_(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L_(1)
 #define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
-#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
-#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
-#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define GPIO_PA02B_SPI_NPCS0     _UL_(1 <<  2)
+#define PIN_PA24A_SPI_NPCS0            _L_(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L_(0)
 #define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
-#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
-#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
-#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define GPIO_PA24A_SPI_NPCS0     _UL_(1 << 24)
+#define PIN_PA13C_SPI_NPCS1            _L_(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L_(2)
 #define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
-#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
-#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define GPIO_PA13C_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PA14C_SPI_NPCS2            _L_(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L_(2)
 #define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
-#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
-#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
-#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define GPIO_PA14C_SPI_NPCS2     _UL_(1 << 14)
+#define PIN_PA15C_SPI_NPCS3            _L_(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L_(2)
 #define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
-#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
-#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
-#define MUX_PA23A_SPI_SCK               _L(0)
+#define GPIO_PA15C_SPI_NPCS3     _UL_(1 << 15)
+#define PIN_PA23A_SPI_SCK              _L_(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L_(0)
 #define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
-#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
+#define GPIO_PA23A_SPI_SCK       _UL_(1 << 23)
 /* ========== GPIO definition for TC0 peripheral ========== */
-#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
-#define MUX_PA08B_TC0_A0                _L(1)
+#define PIN_PA08B_TC0_A0                _L_(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L_(1)
 #define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
-#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
-#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
-#define MUX_PA10B_TC0_A1                _L(1)
+#define GPIO_PA08B_TC0_A0        _UL_(1 <<  8)
+#define PIN_PA10B_TC0_A1               _L_(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L_(1)
 #define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
-#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
-#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
-#define MUX_PA12B_TC0_A2                _L(1)
+#define GPIO_PA10B_TC0_A1        _UL_(1 << 10)
+#define PIN_PA12B_TC0_A2               _L_(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L_(1)
 #define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
-#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
-#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
-#define MUX_PA09B_TC0_B0                _L(1)
+#define GPIO_PA12B_TC0_A2        _UL_(1 << 12)
+#define PIN_PA09B_TC0_B0                _L_(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L_(1)
 #define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
-#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
-#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
-#define MUX_PA11B_TC0_B1                _L(1)
+#define GPIO_PA09B_TC0_B0        _UL_(1 <<  9)
+#define PIN_PA11B_TC0_B1               _L_(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L_(1)
 #define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
-#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
-#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
-#define MUX_PA13B_TC0_B2                _L(1)
+#define GPIO_PA11B_TC0_B1        _UL_(1 << 11)
+#define PIN_PA13B_TC0_B2               _L_(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L_(1)
 #define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
-#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
-#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
-#define MUX_PA14B_TC0_CLK0              _L(1)
+#define GPIO_PA13B_TC0_B2        _UL_(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L_(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L_(1)
 #define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
-#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
-#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
-#define MUX_PA15B_TC0_CLK1              _L(1)
+#define GPIO_PA14B_TC0_CLK0      _UL_(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L_(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L_(1)
 #define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
-#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
-#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
-#define MUX_PA16B_TC0_CLK2              _L(1)
+#define GPIO_PA15B_TC0_CLK1      _UL_(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L_(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L_(1)
 #define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
-#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+#define GPIO_PA16B_TC0_CLK2      _UL_(1 << 16)
 /* ========== GPIO definition for USART0 peripheral ========== */
-#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
-#define MUX_PA04B_USART0_CLK            _L(1)
+#define PIN_PA04B_USART0_CLK            _L_(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L_(1)
 #define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
-#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
-#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
-#define MUX_PA10A_USART0_CLK            _L(0)
+#define GPIO_PA04B_USART0_CLK    _UL_(1 <<  4)
+#define PIN_PA10A_USART0_CLK           _L_(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L_(0)
 #define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
-#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
-#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
-#define MUX_PA09A_USART0_CTS            _L(0)
+#define GPIO_PA10A_USART0_CLK    _UL_(1 << 10)
+#define PIN_PA09A_USART0_CTS            _L_(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L_(0)
 #define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
-#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
-#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
-#define MUX_PA06B_USART0_RTS            _L(1)
+#define GPIO_PA09A_USART0_CTS    _UL_(1 <<  9)
+#define PIN_PA06B_USART0_RTS            _L_(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L_(1)
 #define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
-#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
-#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
-#define MUX_PA08A_USART0_RTS            _L(0)
+#define GPIO_PA06B_USART0_RTS    _UL_(1 <<  6)
+#define PIN_PA08A_USART0_RTS            _L_(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L_(0)
 #define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
-#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
-#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
-#define MUX_PA05B_USART0_RXD            _L(1)
+#define GPIO_PA08A_USART0_RTS    _UL_(1 <<  8)
+#define PIN_PA05B_USART0_RXD            _L_(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L_(1)
 #define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
-#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
-#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
-#define MUX_PA11A_USART0_RXD            _L(0)
+#define GPIO_PA05B_USART0_RXD    _UL_(1 <<  5)
+#define PIN_PA11A_USART0_RXD           _L_(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L_(0)
 #define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
-#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
-#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
-#define MUX_PA07B_USART0_TXD            _L(1)
+#define GPIO_PA11A_USART0_RXD    _UL_(1 << 11)
+#define PIN_PA07B_USART0_TXD            _L_(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L_(1)
 #define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
-#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
-#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
-#define MUX_PA12A_USART0_TXD            _L(0)
+#define GPIO_PA07B_USART0_TXD    _UL_(1 <<  7)
+#define PIN_PA12A_USART0_TXD           _L_(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L_(0)
 #define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
-#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
+#define GPIO_PA12A_USART0_TXD    _UL_(1 << 12)
 /* ========== GPIO definition for USART1 peripheral ========== */
-#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
-#define MUX_PA14A_USART1_CLK            _L(0)
+#define PIN_PA14A_USART1_CLK           _L_(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L_(0)
 #define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
-#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
-#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
-#define MUX_PA21B_USART1_CTS            _L(1)
+#define GPIO_PA14A_USART1_CLK    _UL_(1 << 14)
+#define PIN_PA21B_USART1_CTS           _L_(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L_(1)
 #define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
-#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
-#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
-#define MUX_PA13A_USART1_RTS            _L(0)
+#define GPIO_PA21B_USART1_CTS    _UL_(1 << 21)
+#define PIN_PA13A_USART1_RTS           _L_(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L_(0)
 #define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
-#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
-#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
-#define MUX_PA15A_USART1_RXD            _L(0)
+#define GPIO_PA13A_USART1_RTS    _UL_(1 << 13)
+#define PIN_PA15A_USART1_RXD           _L_(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L_(0)
 #define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
-#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
-#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
-#define MUX_PA16A_USART1_TXD            _L(0)
+#define GPIO_PA15A_USART1_RXD    _UL_(1 << 15)
+#define PIN_PA16A_USART1_TXD           _L_(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L_(0)
 #define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
-#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+#define GPIO_PA16A_USART1_TXD    _UL_(1 << 16)
 /* ========== GPIO definition for USART2 peripheral ========== */
-#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
-#define MUX_PA18A_USART2_CLK            _L(0)
+#define PIN_PA18A_USART2_CLK           _L_(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L_(0)
 #define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
-#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
-#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
-#define MUX_PA22B_USART2_CTS            _L(1)
+#define GPIO_PA18A_USART2_CLK    _UL_(1 << 18)
+#define PIN_PA22B_USART2_CTS           _L_(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L_(1)
 #define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
-#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
-#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
-#define MUX_PA17A_USART2_RTS            _L(0)
+#define GPIO_PA22B_USART2_CTS    _UL_(1 << 22)
+#define PIN_PA17A_USART2_RTS           _L_(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L_(0)
 #define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
-#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
-#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
-#define MUX_PA25B_USART2_RXD            _L(1)
+#define GPIO_PA17A_USART2_RTS    _UL_(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L_(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L_(1)
 #define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
-#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
-#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
-#define MUX_PA19A_USART2_RXD            _L(0)
+#define GPIO_PA25B_USART2_RXD    _UL_(1 << 25)
+#define PIN_PA19A_USART2_RXD           _L_(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L_(0)
 #define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
-#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
-#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
-#define MUX_PA26B_USART2_TXD            _L(1)
+#define GPIO_PA19A_USART2_RXD    _UL_(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L_(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L_(1)
 #define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
-#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
-#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
-#define MUX_PA20A_USART2_TXD            _L(0)
+#define GPIO_PA26B_USART2_TXD    _UL_(1 << 26)
+#define PIN_PA20A_USART2_TXD           _L_(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L_(0)
 #define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
-#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+#define GPIO_PA20A_USART2_TXD    _UL_(1 << 20)
 /* ========== GPIO definition for ADCIFE peripheral ========== */
-#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
-#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PIN_PA04A_ADCIFE_AD0            _L_(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L_(0)
 #define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
-#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
-#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
-#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL_(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L_(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L_(0)
 #define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
-#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
-#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
-#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define GPIO_PA05A_ADCIFE_AD1    _UL_(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L_(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L_(0)
 #define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
-#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
-#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
-#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define GPIO_PA07A_ADCIFE_AD2    _UL_(1 <<  7)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L_(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L_(4)
 #define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
-#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL_(1 <<  5)
 /* ========== GPIO definition for DACC peripheral ========== */
-#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
-#define MUX_PA06A_DACC_VOUT             _L(0)
+#define PIN_PA06A_DACC_VOUT             _L_(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L_(0)
 #define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
-#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+#define GPIO_PA06A_DACC_VOUT     _UL_(1 <<  6)
 /* ========== GPIO definition for ACIFC peripheral ========== */
-#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
-#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PIN_PA06E_ACIFC_ACAN0           _L_(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L_(4)
 #define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
-#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
-#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
-#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL_(1 <<  6)
+#define PIN_PA07E_ACIFC_ACAP0           _L_(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L_(4)
 #define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
-#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL_(1 <<  7)
 /* ========== GPIO definition for GLOC peripheral ========== */
-#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
-#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PIN_PA06D_GLOC_IN0              _L_(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L_(3)
 #define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
-#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
-#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
-#define MUX_PA20D_GLOC_IN0              _L(3)
+#define GPIO_PA06D_GLOC_IN0      _UL_(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L_(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L_(3)
 #define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
-#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
-#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
-#define MUX_PA04D_GLOC_IN1              _L(3)
+#define GPIO_PA20D_GLOC_IN0      _UL_(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L_(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L_(3)
 #define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
-#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
-#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
-#define MUX_PA21D_GLOC_IN1              _L(3)
+#define GPIO_PA04D_GLOC_IN1      _UL_(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L_(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L_(3)
 #define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
-#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
-#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
-#define MUX_PA05D_GLOC_IN2              _L(3)
+#define GPIO_PA21D_GLOC_IN1      _UL_(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L_(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L_(3)
 #define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
-#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
-#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
-#define MUX_PA22D_GLOC_IN2              _L(3)
+#define GPIO_PA05D_GLOC_IN2      _UL_(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L_(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L_(3)
 #define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
-#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
-#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
-#define MUX_PA07D_GLOC_IN3              _L(3)
+#define GPIO_PA22D_GLOC_IN2      _UL_(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L_(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L_(3)
 #define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
-#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
-#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
-#define MUX_PA23D_GLOC_IN3              _L(3)
+#define GPIO_PA07D_GLOC_IN3      _UL_(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L_(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L_(3)
 #define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
-#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
-#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
-#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define GPIO_PA23D_GLOC_IN3      _UL_(1 << 23)
+#define PIN_PA08D_GLOC_OUT0             _L_(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
-#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
-#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
-#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define GPIO_PA08D_GLOC_OUT0     _UL_(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L_(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
-#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
+#define GPIO_PA24D_GLOC_OUT0     _UL_(1 << 24)
 /* ========== GPIO definition for ABDACB peripheral ========== */
-#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
-#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define PIN_PA17B_ABDACB_DAC0          _L_(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L_(1)
 #define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
-#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
-#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
-#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define GPIO_PA17B_ABDACB_DAC0   _UL_(1 << 17)
+#define PIN_PA19B_ABDACB_DAC1          _L_(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L_(1)
 #define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
-#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
-#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
-#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define GPIO_PA19B_ABDACB_DAC1   _UL_(1 << 19)
+#define PIN_PA18B_ABDACB_DACN0         _L_(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L_(1)
 #define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
-#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
-#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
-#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define GPIO_PA18B_ABDACB_DACN0  _UL_(1 << 18)
+#define PIN_PA20B_ABDACB_DACN1         _L_(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L_(1)
 #define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
-#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+#define GPIO_PA20B_ABDACB_DACN1  _UL_(1 << 20)
 /* ========== GPIO definition for PARC peripheral ========== */
-#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
-#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PIN_PA17D_PARC_PCCK            _L_(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L_(3)
 #define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
-#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
-#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
-#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define GPIO_PA17D_PARC_PCCK     _UL_(1 << 17)
+#define PIN_PA09D_PARC_PCDATA0          _L_(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L_(3)
 #define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
-#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
-#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
-#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define GPIO_PA09D_PARC_PCDATA0  _UL_(1 <<  9)
+#define PIN_PA10D_PARC_PCDATA1         _L_(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L_(3)
 #define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
-#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
-#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
-#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define GPIO_PA10D_PARC_PCDATA1  _UL_(1 << 10)
+#define PIN_PA11D_PARC_PCDATA2         _L_(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L_(3)
 #define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
-#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
-#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
-#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define GPIO_PA11D_PARC_PCDATA2  _UL_(1 << 11)
+#define PIN_PA12D_PARC_PCDATA3         _L_(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L_(3)
 #define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
-#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
-#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
-#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL_(1 << 12)
+#define PIN_PA13D_PARC_PCDATA4         _L_(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L_(3)
 #define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
-#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
-#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
-#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define GPIO_PA13D_PARC_PCDATA4  _UL_(1 << 13)
+#define PIN_PA14D_PARC_PCDATA5         _L_(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L_(3)
 #define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
-#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
-#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
-#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define GPIO_PA14D_PARC_PCDATA5  _UL_(1 << 14)
+#define PIN_PA15D_PARC_PCDATA6         _L_(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L_(3)
 #define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
-#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
-#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
-#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define GPIO_PA15D_PARC_PCDATA6  _UL_(1 << 15)
+#define PIN_PA16D_PARC_PCDATA7         _L_(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L_(3)
 #define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
-#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
-#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
-#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define GPIO_PA16D_PARC_PCDATA7  _UL_(1 << 16)
+#define PIN_PA18D_PARC_PCEN1           _L_(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L_(3)
 #define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
-#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
-#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
-#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define GPIO_PA18D_PARC_PCEN1    _UL_(1 << 18)
+#define PIN_PA19D_PARC_PCEN2           _L_(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L_(3)
 #define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
-#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+#define GPIO_PA19D_PARC_PCEN2    _UL_(1 << 19)
 /* ========== GPIO definition for CATB peripheral ========== */
-#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
-#define MUX_PA02G_CATB_DIS              _L(6)
+#define PIN_PA02G_CATB_DIS              _L_(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L_(6)
 #define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
-#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
-#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
-#define MUX_PA12G_CATB_DIS              _L(6)
+#define GPIO_PA02G_CATB_DIS      _UL_(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L_(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L_(6)
 #define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
-#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
-#define MUX_PA23G_CATB_DIS              _L(6)
+#define GPIO_PA12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L_(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L_(6)
 #define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
-#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
-#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
-#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define GPIO_PA23G_CATB_DIS      _UL_(1 << 23)
+#define PIN_PA04G_CATB_SENSE0           _L_(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L_(6)
 #define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
-#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
-#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
-#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define GPIO_PA04G_CATB_SENSE0   _UL_(1 <<  4)
+#define PIN_PA05G_CATB_SENSE1           _L_(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L_(6)
 #define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
-#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
-#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
-#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define GPIO_PA05G_CATB_SENSE1   _UL_(1 <<  5)
+#define PIN_PA06G_CATB_SENSE2           _L_(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L_(6)
 #define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
-#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
-#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
-#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define GPIO_PA06G_CATB_SENSE2   _UL_(1 <<  6)
+#define PIN_PA07G_CATB_SENSE3           _L_(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L_(6)
 #define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
-#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
-#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
-#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define GPIO_PA07G_CATB_SENSE3   _UL_(1 <<  7)
+#define PIN_PA08G_CATB_SENSE4           _L_(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L_(6)
 #define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
-#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
-#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
-#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define GPIO_PA08G_CATB_SENSE4   _UL_(1 <<  8)
+#define PIN_PA09G_CATB_SENSE5           _L_(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L_(6)
 #define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
-#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
-#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
-#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define GPIO_PA09G_CATB_SENSE5   _UL_(1 <<  9)
+#define PIN_PA10G_CATB_SENSE6          _L_(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L_(6)
 #define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
-#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
-#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
-#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define GPIO_PA10G_CATB_SENSE6   _UL_(1 << 10)
+#define PIN_PA11G_CATB_SENSE7          _L_(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L_(6)
 #define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
-#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
-#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
-#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define GPIO_PA11G_CATB_SENSE7   _UL_(1 << 11)
+#define PIN_PA13G_CATB_SENSE8          _L_(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L_(6)
 #define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
-#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
-#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
-#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define GPIO_PA13G_CATB_SENSE8   _UL_(1 << 13)
+#define PIN_PA14G_CATB_SENSE9          _L_(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L_(6)
 #define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
-#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
-#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
-#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define GPIO_PA14G_CATB_SENSE9   _UL_(1 << 14)
+#define PIN_PA15G_CATB_SENSE10         _L_(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L_(6)
 #define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
-#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
-#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
-#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define GPIO_PA15G_CATB_SENSE10  _UL_(1 << 15)
+#define PIN_PA16G_CATB_SENSE11         _L_(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L_(6)
 #define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
-#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
-#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
-#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define GPIO_PA16G_CATB_SENSE11  _UL_(1 << 16)
+#define PIN_PA17G_CATB_SENSE12         _L_(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L_(6)
 #define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
-#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
-#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
-#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define GPIO_PA17G_CATB_SENSE12  _UL_(1 << 17)
+#define PIN_PA18G_CATB_SENSE13         _L_(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L_(6)
 #define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
-#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
-#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
-#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define GPIO_PA18G_CATB_SENSE13  _UL_(1 << 18)
+#define PIN_PA19G_CATB_SENSE14         _L_(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L_(6)
 #define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
-#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
-#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
-#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define GPIO_PA19G_CATB_SENSE14  _UL_(1 << 19)
+#define PIN_PA20G_CATB_SENSE15         _L_(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L_(6)
 #define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
-#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
-#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
-#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define GPIO_PA20G_CATB_SENSE15  _UL_(1 << 20)
+#define PIN_PA21G_CATB_SENSE16         _L_(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L_(6)
 #define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
-#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
-#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
-#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define GPIO_PA21G_CATB_SENSE16  _UL_(1 << 21)
+#define PIN_PA22G_CATB_SENSE17         _L_(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L_(6)
 #define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
-#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
-#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
-#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define GPIO_PA22G_CATB_SENSE17  _UL_(1 << 22)
+#define PIN_PA24G_CATB_SENSE18         _L_(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L_(6)
 #define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
-#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
-#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
-#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define GPIO_PA24G_CATB_SENSE18  _UL_(1 << 24)
+#define PIN_PA25G_CATB_SENSE19         _L_(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L_(6)
 #define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
-#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
-#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
-#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define GPIO_PA25G_CATB_SENSE19  _UL_(1 << 25)
+#define PIN_PA26G_CATB_SENSE20         _L_(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L_(6)
 #define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
-#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
+#define GPIO_PA26G_CATB_SENSE20  _UL_(1 << 26)
 /* ========== GPIO definition for LCDCA peripheral ========== */
-#define PIN_PA12F_LCDCA_COM0           _L(12) /**< \brief LCDCA signal: COM0 on PA12 mux F */
-#define MUX_PA12F_LCDCA_COM0            _L(5)
+#define PIN_PA12F_LCDCA_COM0           _L_(12) /**< \brief LCDCA signal: COM0 on PA12 mux F */
+#define MUX_PA12F_LCDCA_COM0            _L_(5)
 #define PINMUX_PA12F_LCDCA_COM0    ((PIN_PA12F_LCDCA_COM0 << 16) | MUX_PA12F_LCDCA_COM0)
-#define GPIO_PA12F_LCDCA_COM0    _UL(1 << 12)
-#define PIN_PA11F_LCDCA_COM1           _L(11) /**< \brief LCDCA signal: COM1 on PA11 mux F */
-#define MUX_PA11F_LCDCA_COM1            _L(5)
+#define GPIO_PA12F_LCDCA_COM0    _UL_(1 << 12)
+#define PIN_PA11F_LCDCA_COM1           _L_(11) /**< \brief LCDCA signal: COM1 on PA11 mux F */
+#define MUX_PA11F_LCDCA_COM1            _L_(5)
 #define PINMUX_PA11F_LCDCA_COM1    ((PIN_PA11F_LCDCA_COM1 << 16) | MUX_PA11F_LCDCA_COM1)
-#define GPIO_PA11F_LCDCA_COM1    _UL(1 << 11)
-#define PIN_PA10F_LCDCA_COM2           _L(10) /**< \brief LCDCA signal: COM2 on PA10 mux F */
-#define MUX_PA10F_LCDCA_COM2            _L(5)
+#define GPIO_PA11F_LCDCA_COM1    _UL_(1 << 11)
+#define PIN_PA10F_LCDCA_COM2           _L_(10) /**< \brief LCDCA signal: COM2 on PA10 mux F */
+#define MUX_PA10F_LCDCA_COM2            _L_(5)
 #define PINMUX_PA10F_LCDCA_COM2    ((PIN_PA10F_LCDCA_COM2 << 16) | MUX_PA10F_LCDCA_COM2)
-#define GPIO_PA10F_LCDCA_COM2    _UL(1 << 10)
-#define PIN_PA09F_LCDCA_COM3            _L(9) /**< \brief LCDCA signal: COM3 on PA09 mux F */
-#define MUX_PA09F_LCDCA_COM3            _L(5)
+#define GPIO_PA10F_LCDCA_COM2    _UL_(1 << 10)
+#define PIN_PA09F_LCDCA_COM3            _L_(9) /**< \brief LCDCA signal: COM3 on PA09 mux F */
+#define MUX_PA09F_LCDCA_COM3            _L_(5)
 #define PINMUX_PA09F_LCDCA_COM3    ((PIN_PA09F_LCDCA_COM3 << 16) | MUX_PA09F_LCDCA_COM3)
-#define GPIO_PA09F_LCDCA_COM3    _UL(1 <<  9)
-#define PIN_PA13F_LCDCA_SEG5           _L(13) /**< \brief LCDCA signal: SEG5 on PA13 mux F */
-#define MUX_PA13F_LCDCA_SEG5            _L(5)
+#define GPIO_PA09F_LCDCA_COM3    _UL_(1 <<  9)
+#define PIN_PA13F_LCDCA_SEG5           _L_(13) /**< \brief LCDCA signal: SEG5 on PA13 mux F */
+#define MUX_PA13F_LCDCA_SEG5            _L_(5)
 #define PINMUX_PA13F_LCDCA_SEG5    ((PIN_PA13F_LCDCA_SEG5 << 16) | MUX_PA13F_LCDCA_SEG5)
-#define GPIO_PA13F_LCDCA_SEG5    _UL(1 << 13)
-#define PIN_PA14F_LCDCA_SEG6           _L(14) /**< \brief LCDCA signal: SEG6 on PA14 mux F */
-#define MUX_PA14F_LCDCA_SEG6            _L(5)
+#define GPIO_PA13F_LCDCA_SEG5    _UL_(1 << 13)
+#define PIN_PA14F_LCDCA_SEG6           _L_(14) /**< \brief LCDCA signal: SEG6 on PA14 mux F */
+#define MUX_PA14F_LCDCA_SEG6            _L_(5)
 #define PINMUX_PA14F_LCDCA_SEG6    ((PIN_PA14F_LCDCA_SEG6 << 16) | MUX_PA14F_LCDCA_SEG6)
-#define GPIO_PA14F_LCDCA_SEG6    _UL(1 << 14)
-#define PIN_PA15F_LCDCA_SEG7           _L(15) /**< \brief LCDCA signal: SEG7 on PA15 mux F */
-#define MUX_PA15F_LCDCA_SEG7            _L(5)
+#define GPIO_PA14F_LCDCA_SEG6    _UL_(1 << 14)
+#define PIN_PA15F_LCDCA_SEG7           _L_(15) /**< \brief LCDCA signal: SEG7 on PA15 mux F */
+#define MUX_PA15F_LCDCA_SEG7            _L_(5)
 #define PINMUX_PA15F_LCDCA_SEG7    ((PIN_PA15F_LCDCA_SEG7 << 16) | MUX_PA15F_LCDCA_SEG7)
-#define GPIO_PA15F_LCDCA_SEG7    _UL(1 << 15)
-#define PIN_PA16F_LCDCA_SEG8           _L(16) /**< \brief LCDCA signal: SEG8 on PA16 mux F */
-#define MUX_PA16F_LCDCA_SEG8            _L(5)
+#define GPIO_PA15F_LCDCA_SEG7    _UL_(1 << 15)
+#define PIN_PA16F_LCDCA_SEG8           _L_(16) /**< \brief LCDCA signal: SEG8 on PA16 mux F */
+#define MUX_PA16F_LCDCA_SEG8            _L_(5)
 #define PINMUX_PA16F_LCDCA_SEG8    ((PIN_PA16F_LCDCA_SEG8 << 16) | MUX_PA16F_LCDCA_SEG8)
-#define GPIO_PA16F_LCDCA_SEG8    _UL(1 << 16)
-#define PIN_PA17F_LCDCA_SEG9           _L(17) /**< \brief LCDCA signal: SEG9 on PA17 mux F */
-#define MUX_PA17F_LCDCA_SEG9            _L(5)
+#define GPIO_PA16F_LCDCA_SEG8    _UL_(1 << 16)
+#define PIN_PA17F_LCDCA_SEG9           _L_(17) /**< \brief LCDCA signal: SEG9 on PA17 mux F */
+#define MUX_PA17F_LCDCA_SEG9            _L_(5)
 #define PINMUX_PA17F_LCDCA_SEG9    ((PIN_PA17F_LCDCA_SEG9 << 16) | MUX_PA17F_LCDCA_SEG9)
-#define GPIO_PA17F_LCDCA_SEG9    _UL(1 << 17)
-#define PIN_PA18F_LCDCA_SEG18          _L(18) /**< \brief LCDCA signal: SEG18 on PA18 mux F */
-#define MUX_PA18F_LCDCA_SEG18           _L(5)
+#define GPIO_PA17F_LCDCA_SEG9    _UL_(1 << 17)
+#define PIN_PA18F_LCDCA_SEG18          _L_(18) /**< \brief LCDCA signal: SEG18 on PA18 mux F */
+#define MUX_PA18F_LCDCA_SEG18           _L_(5)
 #define PINMUX_PA18F_LCDCA_SEG18   ((PIN_PA18F_LCDCA_SEG18 << 16) | MUX_PA18F_LCDCA_SEG18)
-#define GPIO_PA18F_LCDCA_SEG18   _UL(1 << 18)
-#define PIN_PA19F_LCDCA_SEG19          _L(19) /**< \brief LCDCA signal: SEG19 on PA19 mux F */
-#define MUX_PA19F_LCDCA_SEG19           _L(5)
+#define GPIO_PA18F_LCDCA_SEG18   _UL_(1 << 18)
+#define PIN_PA19F_LCDCA_SEG19          _L_(19) /**< \brief LCDCA signal: SEG19 on PA19 mux F */
+#define MUX_PA19F_LCDCA_SEG19           _L_(5)
 #define PINMUX_PA19F_LCDCA_SEG19   ((PIN_PA19F_LCDCA_SEG19 << 16) | MUX_PA19F_LCDCA_SEG19)
-#define GPIO_PA19F_LCDCA_SEG19   _UL(1 << 19)
-#define PIN_PA20F_LCDCA_SEG20          _L(20) /**< \brief LCDCA signal: SEG20 on PA20 mux F */
-#define MUX_PA20F_LCDCA_SEG20           _L(5)
+#define GPIO_PA19F_LCDCA_SEG19   _UL_(1 << 19)
+#define PIN_PA20F_LCDCA_SEG20          _L_(20) /**< \brief LCDCA signal: SEG20 on PA20 mux F */
+#define MUX_PA20F_LCDCA_SEG20           _L_(5)
 #define PINMUX_PA20F_LCDCA_SEG20   ((PIN_PA20F_LCDCA_SEG20 << 16) | MUX_PA20F_LCDCA_SEG20)
-#define GPIO_PA20F_LCDCA_SEG20   _UL(1 << 20)
-#define PIN_PA08F_LCDCA_SEG23           _L(8) /**< \brief LCDCA signal: SEG23 on PA08 mux F */
-#define MUX_PA08F_LCDCA_SEG23           _L(5)
+#define GPIO_PA20F_LCDCA_SEG20   _UL_(1 << 20)
+#define PIN_PA08F_LCDCA_SEG23           _L_(8) /**< \brief LCDCA signal: SEG23 on PA08 mux F */
+#define MUX_PA08F_LCDCA_SEG23           _L_(5)
 #define PINMUX_PA08F_LCDCA_SEG23   ((PIN_PA08F_LCDCA_SEG23 << 16) | MUX_PA08F_LCDCA_SEG23)
-#define GPIO_PA08F_LCDCA_SEG23   _UL(1 <<  8)
-#define PIN_PA21F_LCDCA_SEG34          _L(21) /**< \brief LCDCA signal: SEG34 on PA21 mux F */
-#define MUX_PA21F_LCDCA_SEG34           _L(5)
+#define GPIO_PA08F_LCDCA_SEG23   _UL_(1 <<  8)
+#define PIN_PA21F_LCDCA_SEG34          _L_(21) /**< \brief LCDCA signal: SEG34 on PA21 mux F */
+#define MUX_PA21F_LCDCA_SEG34           _L_(5)
 #define PINMUX_PA21F_LCDCA_SEG34   ((PIN_PA21F_LCDCA_SEG34 << 16) | MUX_PA21F_LCDCA_SEG34)
-#define GPIO_PA21F_LCDCA_SEG34   _UL(1 << 21)
-#define PIN_PA22F_LCDCA_SEG35          _L(22) /**< \brief LCDCA signal: SEG35 on PA22 mux F */
-#define MUX_PA22F_LCDCA_SEG35           _L(5)
+#define GPIO_PA21F_LCDCA_SEG34   _UL_(1 << 21)
+#define PIN_PA22F_LCDCA_SEG35          _L_(22) /**< \brief LCDCA signal: SEG35 on PA22 mux F */
+#define MUX_PA22F_LCDCA_SEG35           _L_(5)
 #define PINMUX_PA22F_LCDCA_SEG35   ((PIN_PA22F_LCDCA_SEG35 << 16) | MUX_PA22F_LCDCA_SEG35)
-#define GPIO_PA22F_LCDCA_SEG35   _UL(1 << 22)
-#define PIN_PA23F_LCDCA_SEG38          _L(23) /**< \brief LCDCA signal: SEG38 on PA23 mux F */
-#define MUX_PA23F_LCDCA_SEG38           _L(5)
+#define GPIO_PA22F_LCDCA_SEG35   _UL_(1 << 22)
+#define PIN_PA23F_LCDCA_SEG38          _L_(23) /**< \brief LCDCA signal: SEG38 on PA23 mux F */
+#define MUX_PA23F_LCDCA_SEG38           _L_(5)
 #define PINMUX_PA23F_LCDCA_SEG38   ((PIN_PA23F_LCDCA_SEG38 << 16) | MUX_PA23F_LCDCA_SEG38)
-#define GPIO_PA23F_LCDCA_SEG38   _UL(1 << 23)
-#define PIN_PA24F_LCDCA_SEG39          _L(24) /**< \brief LCDCA signal: SEG39 on PA24 mux F */
-#define MUX_PA24F_LCDCA_SEG39           _L(5)
+#define GPIO_PA23F_LCDCA_SEG38   _UL_(1 << 23)
+#define PIN_PA24F_LCDCA_SEG39          _L_(24) /**< \brief LCDCA signal: SEG39 on PA24 mux F */
+#define MUX_PA24F_LCDCA_SEG39           _L_(5)
 #define PINMUX_PA24F_LCDCA_SEG39   ((PIN_PA24F_LCDCA_SEG39 << 16) | MUX_PA24F_LCDCA_SEG39)
-#define GPIO_PA24F_LCDCA_SEG39   _UL(1 << 24)
+#define GPIO_PA24F_LCDCA_SEG39   _UL_(1 << 24)
 /* ========== GPIO definition for USBC peripheral ========== */
-#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
-#define MUX_PA25A_USBC_DM               _L(0)
+#define PIN_PA25A_USBC_DM              _L_(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L_(0)
 #define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
-#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
-#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
-#define MUX_PA26A_USBC_DP               _L(0)
+#define GPIO_PA25A_USBC_DM       _UL_(1 << 25)
+#define PIN_PA26A_USBC_DP              _L_(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L_(0)
 #define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
-#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+#define GPIO_PA26A_USBC_DP       _UL_(1 << 26)
 /* ========== GPIO definition for PEVC peripheral ========== */
-#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
-#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PIN_PA08C_PEVC_PAD_EVT0         _L_(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
-#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
-#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
-#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL_(1 <<  8)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L_(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
-#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
-#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
-#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL_(1 <<  9)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L_(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
-#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
-#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
-#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL_(1 << 10)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L_(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L_(2)
 #define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
-#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL_(1 << 11)
 /* ========== GPIO definition for SCIF peripheral ========== */
-#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
-#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PIN_PA19E_SCIF_GCLK0           _L_(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
-#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
-#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
-#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define GPIO_PA19E_SCIF_GCLK0    _UL_(1 << 19)
+#define PIN_PA02A_SCIF_GCLK0            _L_(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L_(0)
 #define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
-#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
-#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
-#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define GPIO_PA02A_SCIF_GCLK0    _UL_(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L_(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
-#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
-#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
-#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PA20E_SCIF_GCLK1    _UL_(1 << 20)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L_(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
-#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
-#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
-#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL_(1 << 23)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L_(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
-#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL_(1 << 24)
 /* ========== GPIO definition for EIC peripheral ========== */
-#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
-#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define PIN_PA06C_EIC_EXTINT1           _L_(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
-#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
-#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
-#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
-#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define GPIO_PA06C_EIC_EXTINT1   _UL_(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L_(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
-#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
-#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
-#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
-#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define GPIO_PA16C_EIC_EXTINT1   _UL_(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L_(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
-#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
-#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
-#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
-#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL_(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L_(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
-#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
-#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
-#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
-#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL_(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L_(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
-#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
-#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
-#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
-#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define GPIO_PA05C_EIC_EXTINT3   _UL_(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L_(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
-#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
-#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
-#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
-#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define GPIO_PA18C_EIC_EXTINT3   _UL_(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L_(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
-#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
-#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
-#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
-#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define GPIO_PA07C_EIC_EXTINT4   _UL_(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L_(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
-#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
-#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
-#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
-#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define GPIO_PA19C_EIC_EXTINT4   _UL_(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L_(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L_(2)
 #define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
-#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
-#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
-#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
-#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define GPIO_PA20C_EIC_EXTINT5   _UL_(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L_(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L_(2)
 #define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
-#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
-#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
-#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
-#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define GPIO_PA21C_EIC_EXTINT6   _UL_(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L_(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L_(2)
 #define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
-#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
-#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
-#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
-#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define GPIO_PA22C_EIC_EXTINT7   _UL_(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L_(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L_(2)
 #define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
-#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
-#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define GPIO_PA23C_EIC_EXTINT8   _UL_(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
 
 #endif /* _SAM4LC2A_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4lc2a.h
+++ b/asf/sam/include/sam4l/pio/sam4lc2a.h
@@ -1,0 +1,674 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAM4LC2A
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LC2A_PIO_
+#define _SAM4LC2A_PIO_
+
+#define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
+#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
+#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
+#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
+#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
+#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
+#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
+#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
+#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
+#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
+#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
+#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
+#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
+#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
+#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
+#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
+#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
+#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
+#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
+#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
+#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
+#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
+#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
+#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
+#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
+#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
+#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
+#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+/* ========== GPIO definition for TWIMS0 peripheral ========== */
+#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
+#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+/* ========== GPIO definition for TWIMS2 peripheral ========== */
+#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
+#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+/* ========== GPIO definition for SPI peripheral ========== */
+#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L(1)
+#define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
+#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
+#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L(0)
+#define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
+#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
+#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L(0)
+#define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
+#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
+#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
+#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
+#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
+#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
+#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
+#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
+#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
+#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
+#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
+#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L(0)
+#define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
+#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
+/* ========== GPIO definition for TC0 peripheral ========== */
+#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L(1)
+#define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
+#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
+#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L(1)
+#define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
+#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
+#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L(1)
+#define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
+#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
+#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L(1)
+#define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
+#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
+#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L(1)
+#define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
+#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
+#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L(1)
+#define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
+#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L(1)
+#define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
+#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L(1)
+#define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
+#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L(1)
+#define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
+#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+/* ========== GPIO definition for USART0 peripheral ========== */
+#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L(1)
+#define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
+#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
+#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L(0)
+#define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
+#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
+#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L(0)
+#define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
+#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
+#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L(1)
+#define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
+#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
+#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L(0)
+#define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
+#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
+#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L(1)
+#define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
+#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
+#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L(0)
+#define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
+#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
+#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L(1)
+#define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
+#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
+#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L(0)
+#define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
+#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
+/* ========== GPIO definition for USART1 peripheral ========== */
+#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L(0)
+#define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
+#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
+#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L(1)
+#define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
+#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
+#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L(0)
+#define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
+#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
+#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L(0)
+#define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
+#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
+#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L(0)
+#define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
+#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+/* ========== GPIO definition for USART2 peripheral ========== */
+#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L(0)
+#define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
+#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
+#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L(1)
+#define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
+#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
+#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L(0)
+#define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
+#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L(1)
+#define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
+#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
+#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L(0)
+#define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
+#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L(1)
+#define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
+#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
+#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L(0)
+#define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
+#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+/* ========== GPIO definition for ADCIFE peripheral ========== */
+#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
+#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
+#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+/* ========== GPIO definition for DACC peripheral ========== */
+#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L(0)
+#define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
+#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+/* ========== GPIO definition for ACIFC peripheral ========== */
+#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
+#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
+/* ========== GPIO definition for GLOC peripheral ========== */
+#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
+#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L(3)
+#define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
+#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L(3)
+#define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
+#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L(3)
+#define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
+#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L(3)
+#define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
+#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L(3)
+#define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
+#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L(3)
+#define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
+#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L(3)
+#define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
+#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
+#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
+#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
+#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
+/* ========== GPIO definition for ABDACB peripheral ========== */
+#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
+#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
+#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
+#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
+#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
+#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
+#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
+#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+/* ========== GPIO definition for PARC peripheral ========== */
+#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
+#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
+#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
+#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
+#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
+#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
+#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
+#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
+#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
+#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
+#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
+#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
+#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
+#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
+#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
+#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
+#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
+#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
+#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
+#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
+#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+/* ========== GPIO definition for CATB peripheral ========== */
+#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L(6)
+#define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
+#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L(6)
+#define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
+#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L(6)
+#define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
+#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
+#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
+#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
+#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
+#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
+#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
+#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
+#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
+#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
+#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
+#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
+#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
+#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
+#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
+#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
+#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
+#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
+#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
+#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
+#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
+#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
+#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
+#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
+#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
+#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
+#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
+#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
+#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
+#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
+#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
+#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
+#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
+#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
+#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
+#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
+#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
+#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
+#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
+#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
+#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
+#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
+#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
+#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
+/* ========== GPIO definition for LCDCA peripheral ========== */
+#define PIN_PA12F_LCDCA_COM0           _L(12) /**< \brief LCDCA signal: COM0 on PA12 mux F */
+#define MUX_PA12F_LCDCA_COM0            _L(5)
+#define PINMUX_PA12F_LCDCA_COM0    ((PIN_PA12F_LCDCA_COM0 << 16) | MUX_PA12F_LCDCA_COM0)
+#define GPIO_PA12F_LCDCA_COM0    _UL(1 << 12)
+#define PIN_PA11F_LCDCA_COM1           _L(11) /**< \brief LCDCA signal: COM1 on PA11 mux F */
+#define MUX_PA11F_LCDCA_COM1            _L(5)
+#define PINMUX_PA11F_LCDCA_COM1    ((PIN_PA11F_LCDCA_COM1 << 16) | MUX_PA11F_LCDCA_COM1)
+#define GPIO_PA11F_LCDCA_COM1    _UL(1 << 11)
+#define PIN_PA10F_LCDCA_COM2           _L(10) /**< \brief LCDCA signal: COM2 on PA10 mux F */
+#define MUX_PA10F_LCDCA_COM2            _L(5)
+#define PINMUX_PA10F_LCDCA_COM2    ((PIN_PA10F_LCDCA_COM2 << 16) | MUX_PA10F_LCDCA_COM2)
+#define GPIO_PA10F_LCDCA_COM2    _UL(1 << 10)
+#define PIN_PA09F_LCDCA_COM3            _L(9) /**< \brief LCDCA signal: COM3 on PA09 mux F */
+#define MUX_PA09F_LCDCA_COM3            _L(5)
+#define PINMUX_PA09F_LCDCA_COM3    ((PIN_PA09F_LCDCA_COM3 << 16) | MUX_PA09F_LCDCA_COM3)
+#define GPIO_PA09F_LCDCA_COM3    _UL(1 <<  9)
+#define PIN_PA13F_LCDCA_SEG5           _L(13) /**< \brief LCDCA signal: SEG5 on PA13 mux F */
+#define MUX_PA13F_LCDCA_SEG5            _L(5)
+#define PINMUX_PA13F_LCDCA_SEG5    ((PIN_PA13F_LCDCA_SEG5 << 16) | MUX_PA13F_LCDCA_SEG5)
+#define GPIO_PA13F_LCDCA_SEG5    _UL(1 << 13)
+#define PIN_PA14F_LCDCA_SEG6           _L(14) /**< \brief LCDCA signal: SEG6 on PA14 mux F */
+#define MUX_PA14F_LCDCA_SEG6            _L(5)
+#define PINMUX_PA14F_LCDCA_SEG6    ((PIN_PA14F_LCDCA_SEG6 << 16) | MUX_PA14F_LCDCA_SEG6)
+#define GPIO_PA14F_LCDCA_SEG6    _UL(1 << 14)
+#define PIN_PA15F_LCDCA_SEG7           _L(15) /**< \brief LCDCA signal: SEG7 on PA15 mux F */
+#define MUX_PA15F_LCDCA_SEG7            _L(5)
+#define PINMUX_PA15F_LCDCA_SEG7    ((PIN_PA15F_LCDCA_SEG7 << 16) | MUX_PA15F_LCDCA_SEG7)
+#define GPIO_PA15F_LCDCA_SEG7    _UL(1 << 15)
+#define PIN_PA16F_LCDCA_SEG8           _L(16) /**< \brief LCDCA signal: SEG8 on PA16 mux F */
+#define MUX_PA16F_LCDCA_SEG8            _L(5)
+#define PINMUX_PA16F_LCDCA_SEG8    ((PIN_PA16F_LCDCA_SEG8 << 16) | MUX_PA16F_LCDCA_SEG8)
+#define GPIO_PA16F_LCDCA_SEG8    _UL(1 << 16)
+#define PIN_PA17F_LCDCA_SEG9           _L(17) /**< \brief LCDCA signal: SEG9 on PA17 mux F */
+#define MUX_PA17F_LCDCA_SEG9            _L(5)
+#define PINMUX_PA17F_LCDCA_SEG9    ((PIN_PA17F_LCDCA_SEG9 << 16) | MUX_PA17F_LCDCA_SEG9)
+#define GPIO_PA17F_LCDCA_SEG9    _UL(1 << 17)
+#define PIN_PA18F_LCDCA_SEG18          _L(18) /**< \brief LCDCA signal: SEG18 on PA18 mux F */
+#define MUX_PA18F_LCDCA_SEG18           _L(5)
+#define PINMUX_PA18F_LCDCA_SEG18   ((PIN_PA18F_LCDCA_SEG18 << 16) | MUX_PA18F_LCDCA_SEG18)
+#define GPIO_PA18F_LCDCA_SEG18   _UL(1 << 18)
+#define PIN_PA19F_LCDCA_SEG19          _L(19) /**< \brief LCDCA signal: SEG19 on PA19 mux F */
+#define MUX_PA19F_LCDCA_SEG19           _L(5)
+#define PINMUX_PA19F_LCDCA_SEG19   ((PIN_PA19F_LCDCA_SEG19 << 16) | MUX_PA19F_LCDCA_SEG19)
+#define GPIO_PA19F_LCDCA_SEG19   _UL(1 << 19)
+#define PIN_PA20F_LCDCA_SEG20          _L(20) /**< \brief LCDCA signal: SEG20 on PA20 mux F */
+#define MUX_PA20F_LCDCA_SEG20           _L(5)
+#define PINMUX_PA20F_LCDCA_SEG20   ((PIN_PA20F_LCDCA_SEG20 << 16) | MUX_PA20F_LCDCA_SEG20)
+#define GPIO_PA20F_LCDCA_SEG20   _UL(1 << 20)
+#define PIN_PA08F_LCDCA_SEG23           _L(8) /**< \brief LCDCA signal: SEG23 on PA08 mux F */
+#define MUX_PA08F_LCDCA_SEG23           _L(5)
+#define PINMUX_PA08F_LCDCA_SEG23   ((PIN_PA08F_LCDCA_SEG23 << 16) | MUX_PA08F_LCDCA_SEG23)
+#define GPIO_PA08F_LCDCA_SEG23   _UL(1 <<  8)
+#define PIN_PA21F_LCDCA_SEG34          _L(21) /**< \brief LCDCA signal: SEG34 on PA21 mux F */
+#define MUX_PA21F_LCDCA_SEG34           _L(5)
+#define PINMUX_PA21F_LCDCA_SEG34   ((PIN_PA21F_LCDCA_SEG34 << 16) | MUX_PA21F_LCDCA_SEG34)
+#define GPIO_PA21F_LCDCA_SEG34   _UL(1 << 21)
+#define PIN_PA22F_LCDCA_SEG35          _L(22) /**< \brief LCDCA signal: SEG35 on PA22 mux F */
+#define MUX_PA22F_LCDCA_SEG35           _L(5)
+#define PINMUX_PA22F_LCDCA_SEG35   ((PIN_PA22F_LCDCA_SEG35 << 16) | MUX_PA22F_LCDCA_SEG35)
+#define GPIO_PA22F_LCDCA_SEG35   _UL(1 << 22)
+#define PIN_PA23F_LCDCA_SEG38          _L(23) /**< \brief LCDCA signal: SEG38 on PA23 mux F */
+#define MUX_PA23F_LCDCA_SEG38           _L(5)
+#define PINMUX_PA23F_LCDCA_SEG38   ((PIN_PA23F_LCDCA_SEG38 << 16) | MUX_PA23F_LCDCA_SEG38)
+#define GPIO_PA23F_LCDCA_SEG38   _UL(1 << 23)
+#define PIN_PA24F_LCDCA_SEG39          _L(24) /**< \brief LCDCA signal: SEG39 on PA24 mux F */
+#define MUX_PA24F_LCDCA_SEG39           _L(5)
+#define PINMUX_PA24F_LCDCA_SEG39   ((PIN_PA24F_LCDCA_SEG39 << 16) | MUX_PA24F_LCDCA_SEG39)
+#define GPIO_PA24F_LCDCA_SEG39   _UL(1 << 24)
+/* ========== GPIO definition for USBC peripheral ========== */
+#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L(0)
+#define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
+#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
+#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L(0)
+#define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
+#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+/* ========== GPIO definition for PEVC peripheral ========== */
+#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
+/* ========== GPIO definition for SCIF peripheral ========== */
+#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
+#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
+#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
+#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
+#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
+/* ========== GPIO definition for EIC peripheral ========== */
+#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
+#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
+#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
+#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
+#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
+#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
+#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
+#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
+#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
+#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
+#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+
+#endif /* _SAM4LC2A_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4lc2b.h
+++ b/asf/sam/include/sam4l/pio/sam4lc2b.h
@@ -30,1050 +30,1050 @@
 #define _SAM4LC2B_PIO_
 
 #define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
-#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define GPIO_PA00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PA00 */
 #define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
-#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define GPIO_PA01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PA01 */
 #define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
-#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define GPIO_PA02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PA02 */
 #define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
-#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define GPIO_PA03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PA03 */
 #define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
-#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define GPIO_PA04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PA04 */
 #define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
-#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define GPIO_PA05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PA05 */
 #define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
-#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define GPIO_PA06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PA06 */
 #define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
-#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define GPIO_PA07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PA07 */
 #define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
-#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define GPIO_PA08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PA08 */
 #define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
-#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define GPIO_PA09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PA09 */
 #define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
-#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define GPIO_PA10                _UL_(1 << 10) /**< \brief GPIO Mask  for PA10 */
 #define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
-#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define GPIO_PA11                _UL_(1 << 11) /**< \brief GPIO Mask  for PA11 */
 #define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
-#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define GPIO_PA12                _UL_(1 << 12) /**< \brief GPIO Mask  for PA12 */
 #define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
-#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define GPIO_PA13                _UL_(1 << 13) /**< \brief GPIO Mask  for PA13 */
 #define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
-#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define GPIO_PA14                _UL_(1 << 14) /**< \brief GPIO Mask  for PA14 */
 #define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
-#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define GPIO_PA15                _UL_(1 << 15) /**< \brief GPIO Mask  for PA15 */
 #define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
-#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define GPIO_PA16                _UL_(1 << 16) /**< \brief GPIO Mask  for PA16 */
 #define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
-#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define GPIO_PA17                _UL_(1 << 17) /**< \brief GPIO Mask  for PA17 */
 #define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
-#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define GPIO_PA18                _UL_(1 << 18) /**< \brief GPIO Mask  for PA18 */
 #define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
-#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define GPIO_PA19                _UL_(1 << 19) /**< \brief GPIO Mask  for PA19 */
 #define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
-#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define GPIO_PA20                _UL_(1 << 20) /**< \brief GPIO Mask  for PA20 */
 #define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
-#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define GPIO_PA21                _UL_(1 << 21) /**< \brief GPIO Mask  for PA21 */
 #define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
-#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define GPIO_PA22                _UL_(1 << 22) /**< \brief GPIO Mask  for PA22 */
 #define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
-#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define GPIO_PA23                _UL_(1 << 23) /**< \brief GPIO Mask  for PA23 */
 #define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
-#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define GPIO_PA24                _UL_(1 << 24) /**< \brief GPIO Mask  for PA24 */
 #define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
-#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define GPIO_PA25                _UL_(1 << 25) /**< \brief GPIO Mask  for PA25 */
 #define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
-#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define GPIO_PA26                _UL_(1 << 26) /**< \brief GPIO Mask  for PA26 */
 #define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
-#define GPIO_PB00                _UL(1 <<  0) /**< \brief GPIO Mask  for PB00 */
+#define GPIO_PB00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PB00 */
 #define PIN_PB01                          33  /**< \brief Pin Number for PB01 */
-#define GPIO_PB01                _UL(1 <<  1) /**< \brief GPIO Mask  for PB01 */
+#define GPIO_PB01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PB01 */
 #define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
-#define GPIO_PB02                _UL(1 <<  2) /**< \brief GPIO Mask  for PB02 */
+#define GPIO_PB02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PB02 */
 #define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
-#define GPIO_PB03                _UL(1 <<  3) /**< \brief GPIO Mask  for PB03 */
+#define GPIO_PB03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PB03 */
 #define PIN_PB04                          36  /**< \brief Pin Number for PB04 */
-#define GPIO_PB04                _UL(1 <<  4) /**< \brief GPIO Mask  for PB04 */
+#define GPIO_PB04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PB04 */
 #define PIN_PB05                          37  /**< \brief Pin Number for PB05 */
-#define GPIO_PB05                _UL(1 <<  5) /**< \brief GPIO Mask  for PB05 */
+#define GPIO_PB05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PB05 */
 #define PIN_PB06                          38  /**< \brief Pin Number for PB06 */
-#define GPIO_PB06                _UL(1 <<  6) /**< \brief GPIO Mask  for PB06 */
+#define GPIO_PB06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PB06 */
 #define PIN_PB07                          39  /**< \brief Pin Number for PB07 */
-#define GPIO_PB07                _UL(1 <<  7) /**< \brief GPIO Mask  for PB07 */
+#define GPIO_PB07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PB07 */
 #define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
-#define GPIO_PB08                _UL(1 <<  8) /**< \brief GPIO Mask  for PB08 */
+#define GPIO_PB08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PB08 */
 #define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
-#define GPIO_PB09                _UL(1 <<  9) /**< \brief GPIO Mask  for PB09 */
+#define GPIO_PB09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PB09 */
 #define PIN_PB10                          42  /**< \brief Pin Number for PB10 */
-#define GPIO_PB10                _UL(1 << 10) /**< \brief GPIO Mask  for PB10 */
+#define GPIO_PB10                _UL_(1 << 10) /**< \brief GPIO Mask  for PB10 */
 #define PIN_PB11                          43  /**< \brief Pin Number for PB11 */
-#define GPIO_PB11                _UL(1 << 11) /**< \brief GPIO Mask  for PB11 */
+#define GPIO_PB11                _UL_(1 << 11) /**< \brief GPIO Mask  for PB11 */
 #define PIN_PB12                          44  /**< \brief Pin Number for PB12 */
-#define GPIO_PB12                _UL(1 << 12) /**< \brief GPIO Mask  for PB12 */
+#define GPIO_PB12                _UL_(1 << 12) /**< \brief GPIO Mask  for PB12 */
 #define PIN_PB13                          45  /**< \brief Pin Number for PB13 */
-#define GPIO_PB13                _UL(1 << 13) /**< \brief GPIO Mask  for PB13 */
+#define GPIO_PB13                _UL_(1 << 13) /**< \brief GPIO Mask  for PB13 */
 #define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
-#define GPIO_PB14                _UL(1 << 14) /**< \brief GPIO Mask  for PB14 */
+#define GPIO_PB14                _UL_(1 << 14) /**< \brief GPIO Mask  for PB14 */
 #define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
-#define GPIO_PB15                _UL(1 << 15) /**< \brief GPIO Mask  for PB15 */
+#define GPIO_PB15                _UL_(1 << 15) /**< \brief GPIO Mask  for PB15 */
 /* ========== GPIO definition for TWIMS0 peripheral ========== */
-#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
-#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PIN_PA24B_TWIMS0_TWCK          _L_(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L_(1)
 #define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
-#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
-#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
-#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL_(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L_(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L_(1)
 #define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
-#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+#define GPIO_PA23B_TWIMS0_TWD    _UL_(1 << 23)
 /* ========== GPIO definition for TWIMS1 peripheral ========== */
-#define PIN_PB01A_TWIMS1_TWCK          _L(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
-#define MUX_PB01A_TWIMS1_TWCK           _L(0)
+#define PIN_PB01A_TWIMS1_TWCK          _L_(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
+#define MUX_PB01A_TWIMS1_TWCK           _L_(0)
 #define PINMUX_PB01A_TWIMS1_TWCK   ((PIN_PB01A_TWIMS1_TWCK << 16) | MUX_PB01A_TWIMS1_TWCK)
-#define GPIO_PB01A_TWIMS1_TWCK   _UL(1 <<  1)
-#define PIN_PB00A_TWIMS1_TWD           _L(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
-#define MUX_PB00A_TWIMS1_TWD            _L(0)
+#define GPIO_PB01A_TWIMS1_TWCK   _UL_(1 <<  1)
+#define PIN_PB00A_TWIMS1_TWD           _L_(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
+#define MUX_PB00A_TWIMS1_TWD            _L_(0)
 #define PINMUX_PB00A_TWIMS1_TWD    ((PIN_PB00A_TWIMS1_TWD << 16) | MUX_PB00A_TWIMS1_TWD)
-#define GPIO_PB00A_TWIMS1_TWD    _UL(1 <<  0)
+#define GPIO_PB00A_TWIMS1_TWD    _UL_(1 <<  0)
 /* ========== GPIO definition for TWIMS2 peripheral ========== */
-#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
-#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PIN_PA22E_TWIMS2_TWCK          _L_(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L_(4)
 #define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
-#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
-#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
-#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL_(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L_(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L_(4)
 #define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
-#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+#define GPIO_PA21E_TWIMS2_TWD    _UL_(1 << 21)
 /* ========== GPIO definition for TWIMS3 peripheral ========== */
-#define PIN_PB15C_TWIMS3_TWCK          _L(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
-#define MUX_PB15C_TWIMS3_TWCK           _L(2)
+#define PIN_PB15C_TWIMS3_TWCK          _L_(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
+#define MUX_PB15C_TWIMS3_TWCK           _L_(2)
 #define PINMUX_PB15C_TWIMS3_TWCK   ((PIN_PB15C_TWIMS3_TWCK << 16) | MUX_PB15C_TWIMS3_TWCK)
-#define GPIO_PB15C_TWIMS3_TWCK   _UL(1 << 15)
-#define PIN_PB14C_TWIMS3_TWD           _L(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
-#define MUX_PB14C_TWIMS3_TWD            _L(2)
+#define GPIO_PB15C_TWIMS3_TWCK   _UL_(1 << 15)
+#define PIN_PB14C_TWIMS3_TWD           _L_(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
+#define MUX_PB14C_TWIMS3_TWD            _L_(2)
 #define PINMUX_PB14C_TWIMS3_TWD    ((PIN_PB14C_TWIMS3_TWD << 16) | MUX_PB14C_TWIMS3_TWD)
-#define GPIO_PB14C_TWIMS3_TWD    _UL(1 << 14)
+#define GPIO_PB14C_TWIMS3_TWD    _UL_(1 << 14)
 /* ========== GPIO definition for IISC peripheral ========== */
-#define PIN_PB05D_IISC_IMCK            _L(37) /**< \brief IISC signal: IMCK on PB05 mux D */
-#define MUX_PB05D_IISC_IMCK             _L(3)
+#define PIN_PB05D_IISC_IMCK            _L_(37) /**< \brief IISC signal: IMCK on PB05 mux D */
+#define MUX_PB05D_IISC_IMCK             _L_(3)
 #define PINMUX_PB05D_IISC_IMCK     ((PIN_PB05D_IISC_IMCK << 16) | MUX_PB05D_IISC_IMCK)
-#define GPIO_PB05D_IISC_IMCK     _UL(1 <<  5)
-#define PIN_PB02D_IISC_ISCK            _L(34) /**< \brief IISC signal: ISCK on PB02 mux D */
-#define MUX_PB02D_IISC_ISCK             _L(3)
+#define GPIO_PB05D_IISC_IMCK     _UL_(1 <<  5)
+#define PIN_PB02D_IISC_ISCK            _L_(34) /**< \brief IISC signal: ISCK on PB02 mux D */
+#define MUX_PB02D_IISC_ISCK             _L_(3)
 #define PINMUX_PB02D_IISC_ISCK     ((PIN_PB02D_IISC_ISCK << 16) | MUX_PB02D_IISC_ISCK)
-#define GPIO_PB02D_IISC_ISCK     _UL(1 <<  2)
-#define PIN_PB03D_IISC_ISDI            _L(35) /**< \brief IISC signal: ISDI on PB03 mux D */
-#define MUX_PB03D_IISC_ISDI             _L(3)
+#define GPIO_PB02D_IISC_ISCK     _UL_(1 <<  2)
+#define PIN_PB03D_IISC_ISDI            _L_(35) /**< \brief IISC signal: ISDI on PB03 mux D */
+#define MUX_PB03D_IISC_ISDI             _L_(3)
 #define PINMUX_PB03D_IISC_ISDI     ((PIN_PB03D_IISC_ISDI << 16) | MUX_PB03D_IISC_ISDI)
-#define GPIO_PB03D_IISC_ISDI     _UL(1 <<  3)
-#define PIN_PB04D_IISC_ISDO            _L(36) /**< \brief IISC signal: ISDO on PB04 mux D */
-#define MUX_PB04D_IISC_ISDO             _L(3)
+#define GPIO_PB03D_IISC_ISDI     _UL_(1 <<  3)
+#define PIN_PB04D_IISC_ISDO            _L_(36) /**< \brief IISC signal: ISDO on PB04 mux D */
+#define MUX_PB04D_IISC_ISDO             _L_(3)
 #define PINMUX_PB04D_IISC_ISDO     ((PIN_PB04D_IISC_ISDO << 16) | MUX_PB04D_IISC_ISDO)
-#define GPIO_PB04D_IISC_ISDO     _UL(1 <<  4)
-#define PIN_PB06D_IISC_IWS             _L(38) /**< \brief IISC signal: IWS on PB06 mux D */
-#define MUX_PB06D_IISC_IWS              _L(3)
+#define GPIO_PB04D_IISC_ISDO     _UL_(1 <<  4)
+#define PIN_PB06D_IISC_IWS             _L_(38) /**< \brief IISC signal: IWS on PB06 mux D */
+#define MUX_PB06D_IISC_IWS              _L_(3)
 #define PINMUX_PB06D_IISC_IWS      ((PIN_PB06D_IISC_IWS << 16) | MUX_PB06D_IISC_IWS)
-#define GPIO_PB06D_IISC_IWS      _UL(1 <<  6)
+#define GPIO_PB06D_IISC_IWS      _UL_(1 <<  6)
 /* ========== GPIO definition for SPI peripheral ========== */
-#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
-#define MUX_PA03B_SPI_MISO              _L(1)
+#define PIN_PA03B_SPI_MISO              _L_(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L_(1)
 #define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
-#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
-#define PIN_PB14B_SPI_MISO             _L(46) /**< \brief SPI signal: MISO on PB14 mux B */
-#define MUX_PB14B_SPI_MISO              _L(1)
+#define GPIO_PA03B_SPI_MISO      _UL_(1 <<  3)
+#define PIN_PB14B_SPI_MISO             _L_(46) /**< \brief SPI signal: MISO on PB14 mux B */
+#define MUX_PB14B_SPI_MISO              _L_(1)
 #define PINMUX_PB14B_SPI_MISO      ((PIN_PB14B_SPI_MISO << 16) | MUX_PB14B_SPI_MISO)
-#define GPIO_PB14B_SPI_MISO      _UL(1 << 14)
-#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
-#define MUX_PA21A_SPI_MISO              _L(0)
+#define GPIO_PB14B_SPI_MISO      _UL_(1 << 14)
+#define PIN_PA21A_SPI_MISO             _L_(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L_(0)
 #define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
-#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
-#define PIN_PB15B_SPI_MOSI             _L(47) /**< \brief SPI signal: MOSI on PB15 mux B */
-#define MUX_PB15B_SPI_MOSI              _L(1)
+#define GPIO_PA21A_SPI_MISO      _UL_(1 << 21)
+#define PIN_PB15B_SPI_MOSI             _L_(47) /**< \brief SPI signal: MOSI on PB15 mux B */
+#define MUX_PB15B_SPI_MOSI              _L_(1)
 #define PINMUX_PB15B_SPI_MOSI      ((PIN_PB15B_SPI_MOSI << 16) | MUX_PB15B_SPI_MOSI)
-#define GPIO_PB15B_SPI_MOSI      _UL(1 << 15)
-#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
-#define MUX_PA22A_SPI_MOSI              _L(0)
+#define GPIO_PB15B_SPI_MOSI      _UL_(1 << 15)
+#define PIN_PA22A_SPI_MOSI             _L_(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L_(0)
 #define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
-#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
-#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
-#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define GPIO_PA22A_SPI_MOSI      _UL_(1 << 22)
+#define PIN_PA02B_SPI_NPCS0             _L_(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L_(1)
 #define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
-#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
-#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
-#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define GPIO_PA02B_SPI_NPCS0     _UL_(1 <<  2)
+#define PIN_PA24A_SPI_NPCS0            _L_(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L_(0)
 #define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
-#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
-#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
-#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define GPIO_PA24A_SPI_NPCS0     _UL_(1 << 24)
+#define PIN_PA13C_SPI_NPCS1            _L_(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L_(2)
 #define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
-#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PB13B_SPI_NPCS1            _L(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
-#define MUX_PB13B_SPI_NPCS1             _L(1)
+#define GPIO_PA13C_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PB13B_SPI_NPCS1            _L_(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
+#define MUX_PB13B_SPI_NPCS1             _L_(1)
 #define PINMUX_PB13B_SPI_NPCS1     ((PIN_PB13B_SPI_NPCS1 << 16) | MUX_PB13B_SPI_NPCS1)
-#define GPIO_PB13B_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
-#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define GPIO_PB13B_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PA14C_SPI_NPCS2            _L_(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L_(2)
 #define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
-#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
-#define PIN_PB11B_SPI_NPCS2            _L(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
-#define MUX_PB11B_SPI_NPCS2             _L(1)
+#define GPIO_PA14C_SPI_NPCS2     _UL_(1 << 14)
+#define PIN_PB11B_SPI_NPCS2            _L_(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
+#define MUX_PB11B_SPI_NPCS2             _L_(1)
 #define PINMUX_PB11B_SPI_NPCS2     ((PIN_PB11B_SPI_NPCS2 << 16) | MUX_PB11B_SPI_NPCS2)
-#define GPIO_PB11B_SPI_NPCS2     _UL(1 << 11)
-#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
-#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define GPIO_PB11B_SPI_NPCS2     _UL_(1 << 11)
+#define PIN_PA15C_SPI_NPCS3            _L_(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L_(2)
 #define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
-#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
-#define PIN_PB12B_SPI_NPCS3            _L(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
-#define MUX_PB12B_SPI_NPCS3             _L(1)
+#define GPIO_PA15C_SPI_NPCS3     _UL_(1 << 15)
+#define PIN_PB12B_SPI_NPCS3            _L_(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
+#define MUX_PB12B_SPI_NPCS3             _L_(1)
 #define PINMUX_PB12B_SPI_NPCS3     ((PIN_PB12B_SPI_NPCS3 << 16) | MUX_PB12B_SPI_NPCS3)
-#define GPIO_PB12B_SPI_NPCS3     _UL(1 << 12)
-#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
-#define MUX_PA23A_SPI_SCK               _L(0)
+#define GPIO_PB12B_SPI_NPCS3     _UL_(1 << 12)
+#define PIN_PA23A_SPI_SCK              _L_(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L_(0)
 #define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
-#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
+#define GPIO_PA23A_SPI_SCK       _UL_(1 << 23)
 /* ========== GPIO definition for TC0 peripheral ========== */
-#define PIN_PB07D_TC0_A0               _L(39) /**< \brief TC0 signal: A0 on PB07 mux D */
-#define MUX_PB07D_TC0_A0                _L(3)
+#define PIN_PB07D_TC0_A0               _L_(39) /**< \brief TC0 signal: A0 on PB07 mux D */
+#define MUX_PB07D_TC0_A0                _L_(3)
 #define PINMUX_PB07D_TC0_A0        ((PIN_PB07D_TC0_A0 << 16) | MUX_PB07D_TC0_A0)
-#define GPIO_PB07D_TC0_A0        _UL(1 <<  7)
-#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
-#define MUX_PA08B_TC0_A0                _L(1)
+#define GPIO_PB07D_TC0_A0        _UL_(1 <<  7)
+#define PIN_PA08B_TC0_A0                _L_(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L_(1)
 #define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
-#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
-#define PIN_PB09D_TC0_A1               _L(41) /**< \brief TC0 signal: A1 on PB09 mux D */
-#define MUX_PB09D_TC0_A1                _L(3)
+#define GPIO_PA08B_TC0_A0        _UL_(1 <<  8)
+#define PIN_PB09D_TC0_A1               _L_(41) /**< \brief TC0 signal: A1 on PB09 mux D */
+#define MUX_PB09D_TC0_A1                _L_(3)
 #define PINMUX_PB09D_TC0_A1        ((PIN_PB09D_TC0_A1 << 16) | MUX_PB09D_TC0_A1)
-#define GPIO_PB09D_TC0_A1        _UL(1 <<  9)
-#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
-#define MUX_PA10B_TC0_A1                _L(1)
+#define GPIO_PB09D_TC0_A1        _UL_(1 <<  9)
+#define PIN_PA10B_TC0_A1               _L_(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L_(1)
 #define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
-#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
-#define PIN_PB11D_TC0_A2               _L(43) /**< \brief TC0 signal: A2 on PB11 mux D */
-#define MUX_PB11D_TC0_A2                _L(3)
+#define GPIO_PA10B_TC0_A1        _UL_(1 << 10)
+#define PIN_PB11D_TC0_A2               _L_(43) /**< \brief TC0 signal: A2 on PB11 mux D */
+#define MUX_PB11D_TC0_A2                _L_(3)
 #define PINMUX_PB11D_TC0_A2        ((PIN_PB11D_TC0_A2 << 16) | MUX_PB11D_TC0_A2)
-#define GPIO_PB11D_TC0_A2        _UL(1 << 11)
-#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
-#define MUX_PA12B_TC0_A2                _L(1)
+#define GPIO_PB11D_TC0_A2        _UL_(1 << 11)
+#define PIN_PA12B_TC0_A2               _L_(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L_(1)
 #define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
-#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
-#define PIN_PB08D_TC0_B0               _L(40) /**< \brief TC0 signal: B0 on PB08 mux D */
-#define MUX_PB08D_TC0_B0                _L(3)
+#define GPIO_PA12B_TC0_A2        _UL_(1 << 12)
+#define PIN_PB08D_TC0_B0               _L_(40) /**< \brief TC0 signal: B0 on PB08 mux D */
+#define MUX_PB08D_TC0_B0                _L_(3)
 #define PINMUX_PB08D_TC0_B0        ((PIN_PB08D_TC0_B0 << 16) | MUX_PB08D_TC0_B0)
-#define GPIO_PB08D_TC0_B0        _UL(1 <<  8)
-#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
-#define MUX_PA09B_TC0_B0                _L(1)
+#define GPIO_PB08D_TC0_B0        _UL_(1 <<  8)
+#define PIN_PA09B_TC0_B0                _L_(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L_(1)
 #define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
-#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
-#define PIN_PB10D_TC0_B1               _L(42) /**< \brief TC0 signal: B1 on PB10 mux D */
-#define MUX_PB10D_TC0_B1                _L(3)
+#define GPIO_PA09B_TC0_B0        _UL_(1 <<  9)
+#define PIN_PB10D_TC0_B1               _L_(42) /**< \brief TC0 signal: B1 on PB10 mux D */
+#define MUX_PB10D_TC0_B1                _L_(3)
 #define PINMUX_PB10D_TC0_B1        ((PIN_PB10D_TC0_B1 << 16) | MUX_PB10D_TC0_B1)
-#define GPIO_PB10D_TC0_B1        _UL(1 << 10)
-#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
-#define MUX_PA11B_TC0_B1                _L(1)
+#define GPIO_PB10D_TC0_B1        _UL_(1 << 10)
+#define PIN_PA11B_TC0_B1               _L_(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L_(1)
 #define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
-#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
-#define PIN_PB12D_TC0_B2               _L(44) /**< \brief TC0 signal: B2 on PB12 mux D */
-#define MUX_PB12D_TC0_B2                _L(3)
+#define GPIO_PA11B_TC0_B1        _UL_(1 << 11)
+#define PIN_PB12D_TC0_B2               _L_(44) /**< \brief TC0 signal: B2 on PB12 mux D */
+#define MUX_PB12D_TC0_B2                _L_(3)
 #define PINMUX_PB12D_TC0_B2        ((PIN_PB12D_TC0_B2 << 16) | MUX_PB12D_TC0_B2)
-#define GPIO_PB12D_TC0_B2        _UL(1 << 12)
-#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
-#define MUX_PA13B_TC0_B2                _L(1)
+#define GPIO_PB12D_TC0_B2        _UL_(1 << 12)
+#define PIN_PA13B_TC0_B2               _L_(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L_(1)
 #define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
-#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
-#define PIN_PB13D_TC0_CLK0             _L(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
-#define MUX_PB13D_TC0_CLK0              _L(3)
+#define GPIO_PA13B_TC0_B2        _UL_(1 << 13)
+#define PIN_PB13D_TC0_CLK0             _L_(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
+#define MUX_PB13D_TC0_CLK0              _L_(3)
 #define PINMUX_PB13D_TC0_CLK0      ((PIN_PB13D_TC0_CLK0 << 16) | MUX_PB13D_TC0_CLK0)
-#define GPIO_PB13D_TC0_CLK0      _UL(1 << 13)
-#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
-#define MUX_PA14B_TC0_CLK0              _L(1)
+#define GPIO_PB13D_TC0_CLK0      _UL_(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L_(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L_(1)
 #define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
-#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
-#define PIN_PB14D_TC0_CLK1             _L(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
-#define MUX_PB14D_TC0_CLK1              _L(3)
+#define GPIO_PA14B_TC0_CLK0      _UL_(1 << 14)
+#define PIN_PB14D_TC0_CLK1             _L_(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
+#define MUX_PB14D_TC0_CLK1              _L_(3)
 #define PINMUX_PB14D_TC0_CLK1      ((PIN_PB14D_TC0_CLK1 << 16) | MUX_PB14D_TC0_CLK1)
-#define GPIO_PB14D_TC0_CLK1      _UL(1 << 14)
-#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
-#define MUX_PA15B_TC0_CLK1              _L(1)
+#define GPIO_PB14D_TC0_CLK1      _UL_(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L_(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L_(1)
 #define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
-#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
-#define PIN_PB15D_TC0_CLK2             _L(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
-#define MUX_PB15D_TC0_CLK2              _L(3)
+#define GPIO_PA15B_TC0_CLK1      _UL_(1 << 15)
+#define PIN_PB15D_TC0_CLK2             _L_(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
+#define MUX_PB15D_TC0_CLK2              _L_(3)
 #define PINMUX_PB15D_TC0_CLK2      ((PIN_PB15D_TC0_CLK2 << 16) | MUX_PB15D_TC0_CLK2)
-#define GPIO_PB15D_TC0_CLK2      _UL(1 << 15)
-#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
-#define MUX_PA16B_TC0_CLK2              _L(1)
+#define GPIO_PB15D_TC0_CLK2      _UL_(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L_(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L_(1)
 #define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
-#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+#define GPIO_PA16B_TC0_CLK2      _UL_(1 << 16)
 /* ========== GPIO definition for USART0 peripheral ========== */
-#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
-#define MUX_PA04B_USART0_CLK            _L(1)
+#define PIN_PA04B_USART0_CLK            _L_(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L_(1)
 #define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
-#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
-#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
-#define MUX_PA10A_USART0_CLK            _L(0)
+#define GPIO_PA04B_USART0_CLK    _UL_(1 <<  4)
+#define PIN_PA10A_USART0_CLK           _L_(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L_(0)
 #define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
-#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
-#define PIN_PB13A_USART0_CLK           _L(45) /**< \brief USART0 signal: CLK on PB13 mux A */
-#define MUX_PB13A_USART0_CLK            _L(0)
+#define GPIO_PA10A_USART0_CLK    _UL_(1 << 10)
+#define PIN_PB13A_USART0_CLK           _L_(45) /**< \brief USART0 signal: CLK on PB13 mux A */
+#define MUX_PB13A_USART0_CLK            _L_(0)
 #define PINMUX_PB13A_USART0_CLK    ((PIN_PB13A_USART0_CLK << 16) | MUX_PB13A_USART0_CLK)
-#define GPIO_PB13A_USART0_CLK    _UL(1 << 13)
-#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
-#define MUX_PA09A_USART0_CTS            _L(0)
+#define GPIO_PB13A_USART0_CLK    _UL_(1 << 13)
+#define PIN_PA09A_USART0_CTS            _L_(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L_(0)
 #define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
-#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
-#define PIN_PB11A_USART0_CTS           _L(43) /**< \brief USART0 signal: CTS on PB11 mux A */
-#define MUX_PB11A_USART0_CTS            _L(0)
+#define GPIO_PA09A_USART0_CTS    _UL_(1 <<  9)
+#define PIN_PB11A_USART0_CTS           _L_(43) /**< \brief USART0 signal: CTS on PB11 mux A */
+#define MUX_PB11A_USART0_CTS            _L_(0)
 #define PINMUX_PB11A_USART0_CTS    ((PIN_PB11A_USART0_CTS << 16) | MUX_PB11A_USART0_CTS)
-#define GPIO_PB11A_USART0_CTS    _UL(1 << 11)
-#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
-#define MUX_PA06B_USART0_RTS            _L(1)
+#define GPIO_PB11A_USART0_CTS    _UL_(1 << 11)
+#define PIN_PA06B_USART0_RTS            _L_(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L_(1)
 #define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
-#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
-#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
-#define MUX_PA08A_USART0_RTS            _L(0)
+#define GPIO_PA06B_USART0_RTS    _UL_(1 <<  6)
+#define PIN_PA08A_USART0_RTS            _L_(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L_(0)
 #define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
-#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
-#define PIN_PB12A_USART0_RTS           _L(44) /**< \brief USART0 signal: RTS on PB12 mux A */
-#define MUX_PB12A_USART0_RTS            _L(0)
+#define GPIO_PA08A_USART0_RTS    _UL_(1 <<  8)
+#define PIN_PB12A_USART0_RTS           _L_(44) /**< \brief USART0 signal: RTS on PB12 mux A */
+#define MUX_PB12A_USART0_RTS            _L_(0)
 #define PINMUX_PB12A_USART0_RTS    ((PIN_PB12A_USART0_RTS << 16) | MUX_PB12A_USART0_RTS)
-#define GPIO_PB12A_USART0_RTS    _UL(1 << 12)
-#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
-#define MUX_PA05B_USART0_RXD            _L(1)
+#define GPIO_PB12A_USART0_RTS    _UL_(1 << 12)
+#define PIN_PA05B_USART0_RXD            _L_(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L_(1)
 #define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
-#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
-#define PIN_PB00B_USART0_RXD           _L(32) /**< \brief USART0 signal: RXD on PB00 mux B */
-#define MUX_PB00B_USART0_RXD            _L(1)
+#define GPIO_PA05B_USART0_RXD    _UL_(1 <<  5)
+#define PIN_PB00B_USART0_RXD           _L_(32) /**< \brief USART0 signal: RXD on PB00 mux B */
+#define MUX_PB00B_USART0_RXD            _L_(1)
 #define PINMUX_PB00B_USART0_RXD    ((PIN_PB00B_USART0_RXD << 16) | MUX_PB00B_USART0_RXD)
-#define GPIO_PB00B_USART0_RXD    _UL(1 <<  0)
-#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
-#define MUX_PA11A_USART0_RXD            _L(0)
+#define GPIO_PB00B_USART0_RXD    _UL_(1 <<  0)
+#define PIN_PA11A_USART0_RXD           _L_(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L_(0)
 #define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
-#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
-#define PIN_PB14A_USART0_RXD           _L(46) /**< \brief USART0 signal: RXD on PB14 mux A */
-#define MUX_PB14A_USART0_RXD            _L(0)
+#define GPIO_PA11A_USART0_RXD    _UL_(1 << 11)
+#define PIN_PB14A_USART0_RXD           _L_(46) /**< \brief USART0 signal: RXD on PB14 mux A */
+#define MUX_PB14A_USART0_RXD            _L_(0)
 #define PINMUX_PB14A_USART0_RXD    ((PIN_PB14A_USART0_RXD << 16) | MUX_PB14A_USART0_RXD)
-#define GPIO_PB14A_USART0_RXD    _UL(1 << 14)
-#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
-#define MUX_PA07B_USART0_TXD            _L(1)
+#define GPIO_PB14A_USART0_RXD    _UL_(1 << 14)
+#define PIN_PA07B_USART0_TXD            _L_(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L_(1)
 #define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
-#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
-#define PIN_PB01B_USART0_TXD           _L(33) /**< \brief USART0 signal: TXD on PB01 mux B */
-#define MUX_PB01B_USART0_TXD            _L(1)
+#define GPIO_PA07B_USART0_TXD    _UL_(1 <<  7)
+#define PIN_PB01B_USART0_TXD           _L_(33) /**< \brief USART0 signal: TXD on PB01 mux B */
+#define MUX_PB01B_USART0_TXD            _L_(1)
 #define PINMUX_PB01B_USART0_TXD    ((PIN_PB01B_USART0_TXD << 16) | MUX_PB01B_USART0_TXD)
-#define GPIO_PB01B_USART0_TXD    _UL(1 <<  1)
-#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
-#define MUX_PA12A_USART0_TXD            _L(0)
+#define GPIO_PB01B_USART0_TXD    _UL_(1 <<  1)
+#define PIN_PA12A_USART0_TXD           _L_(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L_(0)
 #define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
-#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
-#define PIN_PB15A_USART0_TXD           _L(47) /**< \brief USART0 signal: TXD on PB15 mux A */
-#define MUX_PB15A_USART0_TXD            _L(0)
+#define GPIO_PA12A_USART0_TXD    _UL_(1 << 12)
+#define PIN_PB15A_USART0_TXD           _L_(47) /**< \brief USART0 signal: TXD on PB15 mux A */
+#define MUX_PB15A_USART0_TXD            _L_(0)
 #define PINMUX_PB15A_USART0_TXD    ((PIN_PB15A_USART0_TXD << 16) | MUX_PB15A_USART0_TXD)
-#define GPIO_PB15A_USART0_TXD    _UL(1 << 15)
+#define GPIO_PB15A_USART0_TXD    _UL_(1 << 15)
 /* ========== GPIO definition for USART1 peripheral ========== */
-#define PIN_PB03B_USART1_CLK           _L(35) /**< \brief USART1 signal: CLK on PB03 mux B */
-#define MUX_PB03B_USART1_CLK            _L(1)
+#define PIN_PB03B_USART1_CLK           _L_(35) /**< \brief USART1 signal: CLK on PB03 mux B */
+#define MUX_PB03B_USART1_CLK            _L_(1)
 #define PINMUX_PB03B_USART1_CLK    ((PIN_PB03B_USART1_CLK << 16) | MUX_PB03B_USART1_CLK)
-#define GPIO_PB03B_USART1_CLK    _UL(1 <<  3)
-#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
-#define MUX_PA14A_USART1_CLK            _L(0)
+#define GPIO_PB03B_USART1_CLK    _UL_(1 <<  3)
+#define PIN_PA14A_USART1_CLK           _L_(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L_(0)
 #define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
-#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
-#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
-#define MUX_PA21B_USART1_CTS            _L(1)
+#define GPIO_PA14A_USART1_CLK    _UL_(1 << 14)
+#define PIN_PA21B_USART1_CTS           _L_(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L_(1)
 #define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
-#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
-#define PIN_PB02B_USART1_RTS           _L(34) /**< \brief USART1 signal: RTS on PB02 mux B */
-#define MUX_PB02B_USART1_RTS            _L(1)
+#define GPIO_PA21B_USART1_CTS    _UL_(1 << 21)
+#define PIN_PB02B_USART1_RTS           _L_(34) /**< \brief USART1 signal: RTS on PB02 mux B */
+#define MUX_PB02B_USART1_RTS            _L_(1)
 #define PINMUX_PB02B_USART1_RTS    ((PIN_PB02B_USART1_RTS << 16) | MUX_PB02B_USART1_RTS)
-#define GPIO_PB02B_USART1_RTS    _UL(1 <<  2)
-#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
-#define MUX_PA13A_USART1_RTS            _L(0)
+#define GPIO_PB02B_USART1_RTS    _UL_(1 <<  2)
+#define PIN_PA13A_USART1_RTS           _L_(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L_(0)
 #define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
-#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
-#define PIN_PB04B_USART1_RXD           _L(36) /**< \brief USART1 signal: RXD on PB04 mux B */
-#define MUX_PB04B_USART1_RXD            _L(1)
+#define GPIO_PA13A_USART1_RTS    _UL_(1 << 13)
+#define PIN_PB04B_USART1_RXD           _L_(36) /**< \brief USART1 signal: RXD on PB04 mux B */
+#define MUX_PB04B_USART1_RXD            _L_(1)
 #define PINMUX_PB04B_USART1_RXD    ((PIN_PB04B_USART1_RXD << 16) | MUX_PB04B_USART1_RXD)
-#define GPIO_PB04B_USART1_RXD    _UL(1 <<  4)
-#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
-#define MUX_PA15A_USART1_RXD            _L(0)
+#define GPIO_PB04B_USART1_RXD    _UL_(1 <<  4)
+#define PIN_PA15A_USART1_RXD           _L_(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L_(0)
 #define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
-#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
-#define PIN_PB05B_USART1_TXD           _L(37) /**< \brief USART1 signal: TXD on PB05 mux B */
-#define MUX_PB05B_USART1_TXD            _L(1)
+#define GPIO_PA15A_USART1_RXD    _UL_(1 << 15)
+#define PIN_PB05B_USART1_TXD           _L_(37) /**< \brief USART1 signal: TXD on PB05 mux B */
+#define MUX_PB05B_USART1_TXD            _L_(1)
 #define PINMUX_PB05B_USART1_TXD    ((PIN_PB05B_USART1_TXD << 16) | MUX_PB05B_USART1_TXD)
-#define GPIO_PB05B_USART1_TXD    _UL(1 <<  5)
-#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
-#define MUX_PA16A_USART1_TXD            _L(0)
+#define GPIO_PB05B_USART1_TXD    _UL_(1 <<  5)
+#define PIN_PA16A_USART1_TXD           _L_(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L_(0)
 #define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
-#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+#define GPIO_PA16A_USART1_TXD    _UL_(1 << 16)
 /* ========== GPIO definition for USART2 peripheral ========== */
-#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
-#define MUX_PA18A_USART2_CLK            _L(0)
+#define PIN_PA18A_USART2_CLK           _L_(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L_(0)
 #define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
-#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
-#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
-#define MUX_PA22B_USART2_CTS            _L(1)
+#define GPIO_PA18A_USART2_CLK    _UL_(1 << 18)
+#define PIN_PA22B_USART2_CTS           _L_(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L_(1)
 #define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
-#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
-#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
-#define MUX_PA17A_USART2_RTS            _L(0)
+#define GPIO_PA22B_USART2_CTS    _UL_(1 << 22)
+#define PIN_PA17A_USART2_RTS           _L_(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L_(0)
 #define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
-#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
-#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
-#define MUX_PA25B_USART2_RXD            _L(1)
+#define GPIO_PA17A_USART2_RTS    _UL_(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L_(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L_(1)
 #define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
-#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
-#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
-#define MUX_PA19A_USART2_RXD            _L(0)
+#define GPIO_PA25B_USART2_RXD    _UL_(1 << 25)
+#define PIN_PA19A_USART2_RXD           _L_(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L_(0)
 #define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
-#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
-#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
-#define MUX_PA26B_USART2_TXD            _L(1)
+#define GPIO_PA19A_USART2_RXD    _UL_(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L_(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L_(1)
 #define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
-#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
-#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
-#define MUX_PA20A_USART2_TXD            _L(0)
+#define GPIO_PA26B_USART2_TXD    _UL_(1 << 26)
+#define PIN_PA20A_USART2_TXD           _L_(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L_(0)
 #define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
-#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+#define GPIO_PA20A_USART2_TXD    _UL_(1 << 20)
 /* ========== GPIO definition for USART3 peripheral ========== */
-#define PIN_PB08A_USART3_CLK           _L(40) /**< \brief USART3 signal: CLK on PB08 mux A */
-#define MUX_PB08A_USART3_CLK            _L(0)
+#define PIN_PB08A_USART3_CLK           _L_(40) /**< \brief USART3 signal: CLK on PB08 mux A */
+#define MUX_PB08A_USART3_CLK            _L_(0)
 #define PINMUX_PB08A_USART3_CLK    ((PIN_PB08A_USART3_CLK << 16) | MUX_PB08A_USART3_CLK)
-#define GPIO_PB08A_USART3_CLK    _UL(1 <<  8)
-#define PIN_PB07A_USART3_CTS           _L(39) /**< \brief USART3 signal: CTS on PB07 mux A */
-#define MUX_PB07A_USART3_CTS            _L(0)
+#define GPIO_PB08A_USART3_CLK    _UL_(1 <<  8)
+#define PIN_PB07A_USART3_CTS           _L_(39) /**< \brief USART3 signal: CTS on PB07 mux A */
+#define MUX_PB07A_USART3_CTS            _L_(0)
 #define PINMUX_PB07A_USART3_CTS    ((PIN_PB07A_USART3_CTS << 16) | MUX_PB07A_USART3_CTS)
-#define GPIO_PB07A_USART3_CTS    _UL(1 <<  7)
-#define PIN_PB06A_USART3_RTS           _L(38) /**< \brief USART3 signal: RTS on PB06 mux A */
-#define MUX_PB06A_USART3_RTS            _L(0)
+#define GPIO_PB07A_USART3_CTS    _UL_(1 <<  7)
+#define PIN_PB06A_USART3_RTS           _L_(38) /**< \brief USART3 signal: RTS on PB06 mux A */
+#define MUX_PB06A_USART3_RTS            _L_(0)
 #define PINMUX_PB06A_USART3_RTS    ((PIN_PB06A_USART3_RTS << 16) | MUX_PB06A_USART3_RTS)
-#define GPIO_PB06A_USART3_RTS    _UL(1 <<  6)
-#define PIN_PB09A_USART3_RXD           _L(41) /**< \brief USART3 signal: RXD on PB09 mux A */
-#define MUX_PB09A_USART3_RXD            _L(0)
+#define GPIO_PB06A_USART3_RTS    _UL_(1 <<  6)
+#define PIN_PB09A_USART3_RXD           _L_(41) /**< \brief USART3 signal: RXD on PB09 mux A */
+#define MUX_PB09A_USART3_RXD            _L_(0)
 #define PINMUX_PB09A_USART3_RXD    ((PIN_PB09A_USART3_RXD << 16) | MUX_PB09A_USART3_RXD)
-#define GPIO_PB09A_USART3_RXD    _UL(1 <<  9)
-#define PIN_PB10A_USART3_TXD           _L(42) /**< \brief USART3 signal: TXD on PB10 mux A */
-#define MUX_PB10A_USART3_TXD            _L(0)
+#define GPIO_PB09A_USART3_RXD    _UL_(1 <<  9)
+#define PIN_PB10A_USART3_TXD           _L_(42) /**< \brief USART3 signal: TXD on PB10 mux A */
+#define MUX_PB10A_USART3_TXD            _L_(0)
 #define PINMUX_PB10A_USART3_TXD    ((PIN_PB10A_USART3_TXD << 16) | MUX_PB10A_USART3_TXD)
-#define GPIO_PB10A_USART3_TXD    _UL(1 << 10)
+#define GPIO_PB10A_USART3_TXD    _UL_(1 << 10)
 /* ========== GPIO definition for ADCIFE peripheral ========== */
-#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
-#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PIN_PA04A_ADCIFE_AD0            _L_(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L_(0)
 #define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
-#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
-#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
-#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL_(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L_(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L_(0)
 #define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
-#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
-#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
-#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define GPIO_PA05A_ADCIFE_AD1    _UL_(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L_(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L_(0)
 #define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
-#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
-#define PIN_PB02A_ADCIFE_AD3           _L(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
-#define MUX_PB02A_ADCIFE_AD3            _L(0)
+#define GPIO_PA07A_ADCIFE_AD2    _UL_(1 <<  7)
+#define PIN_PB02A_ADCIFE_AD3           _L_(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
+#define MUX_PB02A_ADCIFE_AD3            _L_(0)
 #define PINMUX_PB02A_ADCIFE_AD3    ((PIN_PB02A_ADCIFE_AD3 << 16) | MUX_PB02A_ADCIFE_AD3)
-#define GPIO_PB02A_ADCIFE_AD3    _UL(1 <<  2)
-#define PIN_PB03A_ADCIFE_AD4           _L(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
-#define MUX_PB03A_ADCIFE_AD4            _L(0)
+#define GPIO_PB02A_ADCIFE_AD3    _UL_(1 <<  2)
+#define PIN_PB03A_ADCIFE_AD4           _L_(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
+#define MUX_PB03A_ADCIFE_AD4            _L_(0)
 #define PINMUX_PB03A_ADCIFE_AD4    ((PIN_PB03A_ADCIFE_AD4 << 16) | MUX_PB03A_ADCIFE_AD4)
-#define GPIO_PB03A_ADCIFE_AD4    _UL(1 <<  3)
-#define PIN_PB04A_ADCIFE_AD5           _L(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
-#define MUX_PB04A_ADCIFE_AD5            _L(0)
+#define GPIO_PB03A_ADCIFE_AD4    _UL_(1 <<  3)
+#define PIN_PB04A_ADCIFE_AD5           _L_(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
+#define MUX_PB04A_ADCIFE_AD5            _L_(0)
 #define PINMUX_PB04A_ADCIFE_AD5    ((PIN_PB04A_ADCIFE_AD5 << 16) | MUX_PB04A_ADCIFE_AD5)
-#define GPIO_PB04A_ADCIFE_AD5    _UL(1 <<  4)
-#define PIN_PB05A_ADCIFE_AD6           _L(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
-#define MUX_PB05A_ADCIFE_AD6            _L(0)
+#define GPIO_PB04A_ADCIFE_AD5    _UL_(1 <<  4)
+#define PIN_PB05A_ADCIFE_AD6           _L_(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
+#define MUX_PB05A_ADCIFE_AD6            _L_(0)
 #define PINMUX_PB05A_ADCIFE_AD6    ((PIN_PB05A_ADCIFE_AD6 << 16) | MUX_PB05A_ADCIFE_AD6)
-#define GPIO_PB05A_ADCIFE_AD6    _UL(1 <<  5)
-#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
-#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define GPIO_PB05A_ADCIFE_AD6    _UL_(1 <<  5)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L_(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L_(4)
 #define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
-#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL_(1 <<  5)
 /* ========== GPIO definition for DACC peripheral ========== */
-#define PIN_PB04E_DACC_EXT_TRIG0       _L(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
-#define MUX_PB04E_DACC_EXT_TRIG0        _L(4)
+#define PIN_PB04E_DACC_EXT_TRIG0       _L_(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
+#define MUX_PB04E_DACC_EXT_TRIG0        _L_(4)
 #define PINMUX_PB04E_DACC_EXT_TRIG0  ((PIN_PB04E_DACC_EXT_TRIG0 << 16) | MUX_PB04E_DACC_EXT_TRIG0)
-#define GPIO_PB04E_DACC_EXT_TRIG0  _UL(1 <<  4)
-#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
-#define MUX_PA06A_DACC_VOUT             _L(0)
+#define GPIO_PB04E_DACC_EXT_TRIG0  _UL_(1 <<  4)
+#define PIN_PA06A_DACC_VOUT             _L_(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L_(0)
 #define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
-#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+#define GPIO_PA06A_DACC_VOUT     _UL_(1 <<  6)
 /* ========== GPIO definition for ACIFC peripheral ========== */
-#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
-#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PIN_PA06E_ACIFC_ACAN0           _L_(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L_(4)
 #define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
-#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
-#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
-#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL_(1 <<  6)
+#define PIN_PA07E_ACIFC_ACAP0           _L_(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L_(4)
 #define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
-#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
-#define PIN_PB02E_ACIFC_ACBN0          _L(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
-#define MUX_PB02E_ACIFC_ACBN0           _L(4)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL_(1 <<  7)
+#define PIN_PB02E_ACIFC_ACBN0          _L_(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
+#define MUX_PB02E_ACIFC_ACBN0           _L_(4)
 #define PINMUX_PB02E_ACIFC_ACBN0   ((PIN_PB02E_ACIFC_ACBN0 << 16) | MUX_PB02E_ACIFC_ACBN0)
-#define GPIO_PB02E_ACIFC_ACBN0   _UL(1 <<  2)
-#define PIN_PB03E_ACIFC_ACBP0          _L(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
-#define MUX_PB03E_ACIFC_ACBP0           _L(4)
+#define GPIO_PB02E_ACIFC_ACBN0   _UL_(1 <<  2)
+#define PIN_PB03E_ACIFC_ACBP0          _L_(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
+#define MUX_PB03E_ACIFC_ACBP0           _L_(4)
 #define PINMUX_PB03E_ACIFC_ACBP0   ((PIN_PB03E_ACIFC_ACBP0 << 16) | MUX_PB03E_ACIFC_ACBP0)
-#define GPIO_PB03E_ACIFC_ACBP0   _UL(1 <<  3)
+#define GPIO_PB03E_ACIFC_ACBP0   _UL_(1 <<  3)
 /* ========== GPIO definition for GLOC peripheral ========== */
-#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
-#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PIN_PA06D_GLOC_IN0              _L_(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L_(3)
 #define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
-#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
-#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
-#define MUX_PA20D_GLOC_IN0              _L(3)
+#define GPIO_PA06D_GLOC_IN0      _UL_(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L_(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L_(3)
 #define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
-#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
-#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
-#define MUX_PA04D_GLOC_IN1              _L(3)
+#define GPIO_PA20D_GLOC_IN0      _UL_(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L_(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L_(3)
 #define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
-#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
-#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
-#define MUX_PA21D_GLOC_IN1              _L(3)
+#define GPIO_PA04D_GLOC_IN1      _UL_(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L_(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L_(3)
 #define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
-#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
-#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
-#define MUX_PA05D_GLOC_IN2              _L(3)
+#define GPIO_PA21D_GLOC_IN1      _UL_(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L_(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L_(3)
 #define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
-#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
-#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
-#define MUX_PA22D_GLOC_IN2              _L(3)
+#define GPIO_PA05D_GLOC_IN2      _UL_(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L_(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L_(3)
 #define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
-#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
-#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
-#define MUX_PA07D_GLOC_IN3              _L(3)
+#define GPIO_PA22D_GLOC_IN2      _UL_(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L_(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L_(3)
 #define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
-#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
-#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
-#define MUX_PA23D_GLOC_IN3              _L(3)
+#define GPIO_PA07D_GLOC_IN3      _UL_(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L_(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L_(3)
 #define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
-#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
-#define PIN_PB06C_GLOC_IN4             _L(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
-#define MUX_PB06C_GLOC_IN4              _L(2)
+#define GPIO_PA23D_GLOC_IN3      _UL_(1 << 23)
+#define PIN_PB06C_GLOC_IN4             _L_(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
+#define MUX_PB06C_GLOC_IN4              _L_(2)
 #define PINMUX_PB06C_GLOC_IN4      ((PIN_PB06C_GLOC_IN4 << 16) | MUX_PB06C_GLOC_IN4)
-#define GPIO_PB06C_GLOC_IN4      _UL(1 <<  6)
-#define PIN_PB07C_GLOC_IN5             _L(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
-#define MUX_PB07C_GLOC_IN5              _L(2)
+#define GPIO_PB06C_GLOC_IN4      _UL_(1 <<  6)
+#define PIN_PB07C_GLOC_IN5             _L_(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
+#define MUX_PB07C_GLOC_IN5              _L_(2)
 #define PINMUX_PB07C_GLOC_IN5      ((PIN_PB07C_GLOC_IN5 << 16) | MUX_PB07C_GLOC_IN5)
-#define GPIO_PB07C_GLOC_IN5      _UL(1 <<  7)
-#define PIN_PB08C_GLOC_IN6             _L(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
-#define MUX_PB08C_GLOC_IN6              _L(2)
+#define GPIO_PB07C_GLOC_IN5      _UL_(1 <<  7)
+#define PIN_PB08C_GLOC_IN6             _L_(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
+#define MUX_PB08C_GLOC_IN6              _L_(2)
 #define PINMUX_PB08C_GLOC_IN6      ((PIN_PB08C_GLOC_IN6 << 16) | MUX_PB08C_GLOC_IN6)
-#define GPIO_PB08C_GLOC_IN6      _UL(1 <<  8)
-#define PIN_PB09C_GLOC_IN7             _L(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
-#define MUX_PB09C_GLOC_IN7              _L(2)
+#define GPIO_PB08C_GLOC_IN6      _UL_(1 <<  8)
+#define PIN_PB09C_GLOC_IN7             _L_(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
+#define MUX_PB09C_GLOC_IN7              _L_(2)
 #define PINMUX_PB09C_GLOC_IN7      ((PIN_PB09C_GLOC_IN7 << 16) | MUX_PB09C_GLOC_IN7)
-#define GPIO_PB09C_GLOC_IN7      _UL(1 <<  9)
-#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
-#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define GPIO_PB09C_GLOC_IN7      _UL_(1 <<  9)
+#define PIN_PA08D_GLOC_OUT0             _L_(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
-#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
-#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
-#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define GPIO_PA08D_GLOC_OUT0     _UL_(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L_(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
-#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
-#define PIN_PB10C_GLOC_OUT1            _L(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
-#define MUX_PB10C_GLOC_OUT1             _L(2)
+#define GPIO_PA24D_GLOC_OUT0     _UL_(1 << 24)
+#define PIN_PB10C_GLOC_OUT1            _L_(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
+#define MUX_PB10C_GLOC_OUT1             _L_(2)
 #define PINMUX_PB10C_GLOC_OUT1     ((PIN_PB10C_GLOC_OUT1 << 16) | MUX_PB10C_GLOC_OUT1)
-#define GPIO_PB10C_GLOC_OUT1     _UL(1 << 10)
+#define GPIO_PB10C_GLOC_OUT1     _UL_(1 << 10)
 /* ========== GPIO definition for ABDACB peripheral ========== */
-#define PIN_PB02C_ABDACB_DAC0          _L(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
-#define MUX_PB02C_ABDACB_DAC0           _L(2)
+#define PIN_PB02C_ABDACB_DAC0          _L_(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
+#define MUX_PB02C_ABDACB_DAC0           _L_(2)
 #define PINMUX_PB02C_ABDACB_DAC0   ((PIN_PB02C_ABDACB_DAC0 << 16) | MUX_PB02C_ABDACB_DAC0)
-#define GPIO_PB02C_ABDACB_DAC0   _UL(1 <<  2)
-#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
-#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define GPIO_PB02C_ABDACB_DAC0   _UL_(1 <<  2)
+#define PIN_PA17B_ABDACB_DAC0          _L_(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L_(1)
 #define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
-#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
-#define PIN_PB04C_ABDACB_DAC1          _L(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
-#define MUX_PB04C_ABDACB_DAC1           _L(2)
+#define GPIO_PA17B_ABDACB_DAC0   _UL_(1 << 17)
+#define PIN_PB04C_ABDACB_DAC1          _L_(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
+#define MUX_PB04C_ABDACB_DAC1           _L_(2)
 #define PINMUX_PB04C_ABDACB_DAC1   ((PIN_PB04C_ABDACB_DAC1 << 16) | MUX_PB04C_ABDACB_DAC1)
-#define GPIO_PB04C_ABDACB_DAC1   _UL(1 <<  4)
-#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
-#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define GPIO_PB04C_ABDACB_DAC1   _UL_(1 <<  4)
+#define PIN_PA19B_ABDACB_DAC1          _L_(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L_(1)
 #define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
-#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
-#define PIN_PB03C_ABDACB_DACN0         _L(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
-#define MUX_PB03C_ABDACB_DACN0          _L(2)
+#define GPIO_PA19B_ABDACB_DAC1   _UL_(1 << 19)
+#define PIN_PB03C_ABDACB_DACN0         _L_(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
+#define MUX_PB03C_ABDACB_DACN0          _L_(2)
 #define PINMUX_PB03C_ABDACB_DACN0  ((PIN_PB03C_ABDACB_DACN0 << 16) | MUX_PB03C_ABDACB_DACN0)
-#define GPIO_PB03C_ABDACB_DACN0  _UL(1 <<  3)
-#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
-#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define GPIO_PB03C_ABDACB_DACN0  _UL_(1 <<  3)
+#define PIN_PA18B_ABDACB_DACN0         _L_(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L_(1)
 #define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
-#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
-#define PIN_PB05C_ABDACB_DACN1         _L(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
-#define MUX_PB05C_ABDACB_DACN1          _L(2)
+#define GPIO_PA18B_ABDACB_DACN0  _UL_(1 << 18)
+#define PIN_PB05C_ABDACB_DACN1         _L_(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
+#define MUX_PB05C_ABDACB_DACN1          _L_(2)
 #define PINMUX_PB05C_ABDACB_DACN1  ((PIN_PB05C_ABDACB_DACN1 << 16) | MUX_PB05C_ABDACB_DACN1)
-#define GPIO_PB05C_ABDACB_DACN1  _UL(1 <<  5)
-#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
-#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define GPIO_PB05C_ABDACB_DACN1  _UL_(1 <<  5)
+#define PIN_PA20B_ABDACB_DACN1         _L_(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L_(1)
 #define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
-#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+#define GPIO_PA20B_ABDACB_DACN1  _UL_(1 << 20)
 /* ========== GPIO definition for PARC peripheral ========== */
-#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
-#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PIN_PA17D_PARC_PCCK            _L_(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L_(3)
 #define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
-#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
-#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
-#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define GPIO_PA17D_PARC_PCCK     _UL_(1 << 17)
+#define PIN_PA09D_PARC_PCDATA0          _L_(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L_(3)
 #define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
-#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
-#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
-#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define GPIO_PA09D_PARC_PCDATA0  _UL_(1 <<  9)
+#define PIN_PA10D_PARC_PCDATA1         _L_(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L_(3)
 #define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
-#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
-#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
-#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define GPIO_PA10D_PARC_PCDATA1  _UL_(1 << 10)
+#define PIN_PA11D_PARC_PCDATA2         _L_(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L_(3)
 #define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
-#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
-#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
-#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define GPIO_PA11D_PARC_PCDATA2  _UL_(1 << 11)
+#define PIN_PA12D_PARC_PCDATA3         _L_(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L_(3)
 #define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
-#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
-#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
-#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL_(1 << 12)
+#define PIN_PA13D_PARC_PCDATA4         _L_(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L_(3)
 #define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
-#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
-#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
-#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define GPIO_PA13D_PARC_PCDATA4  _UL_(1 << 13)
+#define PIN_PA14D_PARC_PCDATA5         _L_(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L_(3)
 #define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
-#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
-#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
-#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define GPIO_PA14D_PARC_PCDATA5  _UL_(1 << 14)
+#define PIN_PA15D_PARC_PCDATA6         _L_(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L_(3)
 #define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
-#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
-#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
-#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define GPIO_PA15D_PARC_PCDATA6  _UL_(1 << 15)
+#define PIN_PA16D_PARC_PCDATA7         _L_(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L_(3)
 #define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
-#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
-#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
-#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define GPIO_PA16D_PARC_PCDATA7  _UL_(1 << 16)
+#define PIN_PA18D_PARC_PCEN1           _L_(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L_(3)
 #define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
-#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
-#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
-#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define GPIO_PA18D_PARC_PCEN1    _UL_(1 << 18)
+#define PIN_PA19D_PARC_PCEN2           _L_(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L_(3)
 #define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
-#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+#define GPIO_PA19D_PARC_PCEN2    _UL_(1 << 19)
 /* ========== GPIO definition for CATB peripheral ========== */
-#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
-#define MUX_PA02G_CATB_DIS              _L(6)
+#define PIN_PA02G_CATB_DIS              _L_(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L_(6)
 #define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
-#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
-#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
-#define MUX_PA12G_CATB_DIS              _L(6)
+#define GPIO_PA02G_CATB_DIS      _UL_(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L_(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L_(6)
 #define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
-#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
-#define MUX_PA23G_CATB_DIS              _L(6)
+#define GPIO_PA12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L_(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L_(6)
 #define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
-#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
-#define PIN_PB03G_CATB_DIS             _L(35) /**< \brief CATB signal: DIS on PB03 mux G */
-#define MUX_PB03G_CATB_DIS              _L(6)
+#define GPIO_PA23G_CATB_DIS      _UL_(1 << 23)
+#define PIN_PB03G_CATB_DIS             _L_(35) /**< \brief CATB signal: DIS on PB03 mux G */
+#define MUX_PB03G_CATB_DIS              _L_(6)
 #define PINMUX_PB03G_CATB_DIS      ((PIN_PB03G_CATB_DIS << 16) | MUX_PB03G_CATB_DIS)
-#define GPIO_PB03G_CATB_DIS      _UL(1 <<  3)
-#define PIN_PB12G_CATB_DIS             _L(44) /**< \brief CATB signal: DIS on PB12 mux G */
-#define MUX_PB12G_CATB_DIS              _L(6)
+#define GPIO_PB03G_CATB_DIS      _UL_(1 <<  3)
+#define PIN_PB12G_CATB_DIS             _L_(44) /**< \brief CATB signal: DIS on PB12 mux G */
+#define MUX_PB12G_CATB_DIS              _L_(6)
 #define PINMUX_PB12G_CATB_DIS      ((PIN_PB12G_CATB_DIS << 16) | MUX_PB12G_CATB_DIS)
-#define GPIO_PB12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
-#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define GPIO_PB12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PA04G_CATB_SENSE0           _L_(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L_(6)
 #define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
-#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
-#define PIN_PB13G_CATB_SENSE0          _L(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
-#define MUX_PB13G_CATB_SENSE0           _L(6)
+#define GPIO_PA04G_CATB_SENSE0   _UL_(1 <<  4)
+#define PIN_PB13G_CATB_SENSE0          _L_(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
+#define MUX_PB13G_CATB_SENSE0           _L_(6)
 #define PINMUX_PB13G_CATB_SENSE0   ((PIN_PB13G_CATB_SENSE0 << 16) | MUX_PB13G_CATB_SENSE0)
-#define GPIO_PB13G_CATB_SENSE0   _UL(1 << 13)
-#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
-#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define GPIO_PB13G_CATB_SENSE0   _UL_(1 << 13)
+#define PIN_PA05G_CATB_SENSE1           _L_(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L_(6)
 #define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
-#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
-#define PIN_PB14G_CATB_SENSE1          _L(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
-#define MUX_PB14G_CATB_SENSE1           _L(6)
+#define GPIO_PA05G_CATB_SENSE1   _UL_(1 <<  5)
+#define PIN_PB14G_CATB_SENSE1          _L_(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
+#define MUX_PB14G_CATB_SENSE1           _L_(6)
 #define PINMUX_PB14G_CATB_SENSE1   ((PIN_PB14G_CATB_SENSE1 << 16) | MUX_PB14G_CATB_SENSE1)
-#define GPIO_PB14G_CATB_SENSE1   _UL(1 << 14)
-#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
-#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define GPIO_PB14G_CATB_SENSE1   _UL_(1 << 14)
+#define PIN_PA06G_CATB_SENSE2           _L_(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L_(6)
 #define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
-#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
-#define PIN_PB15G_CATB_SENSE2          _L(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
-#define MUX_PB15G_CATB_SENSE2           _L(6)
+#define GPIO_PA06G_CATB_SENSE2   _UL_(1 <<  6)
+#define PIN_PB15G_CATB_SENSE2          _L_(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
+#define MUX_PB15G_CATB_SENSE2           _L_(6)
 #define PINMUX_PB15G_CATB_SENSE2   ((PIN_PB15G_CATB_SENSE2 << 16) | MUX_PB15G_CATB_SENSE2)
-#define GPIO_PB15G_CATB_SENSE2   _UL(1 << 15)
-#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
-#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define GPIO_PB15G_CATB_SENSE2   _UL_(1 << 15)
+#define PIN_PA07G_CATB_SENSE3           _L_(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L_(6)
 #define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
-#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
-#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
-#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define GPIO_PA07G_CATB_SENSE3   _UL_(1 <<  7)
+#define PIN_PA08G_CATB_SENSE4           _L_(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L_(6)
 #define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
-#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
-#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
-#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define GPIO_PA08G_CATB_SENSE4   _UL_(1 <<  8)
+#define PIN_PA09G_CATB_SENSE5           _L_(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L_(6)
 #define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
-#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
-#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
-#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define GPIO_PA09G_CATB_SENSE5   _UL_(1 <<  9)
+#define PIN_PA10G_CATB_SENSE6          _L_(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L_(6)
 #define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
-#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
-#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
-#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define GPIO_PA10G_CATB_SENSE6   _UL_(1 << 10)
+#define PIN_PA11G_CATB_SENSE7          _L_(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L_(6)
 #define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
-#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
-#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
-#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define GPIO_PA11G_CATB_SENSE7   _UL_(1 << 11)
+#define PIN_PA13G_CATB_SENSE8          _L_(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L_(6)
 #define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
-#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
-#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
-#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define GPIO_PA13G_CATB_SENSE8   _UL_(1 << 13)
+#define PIN_PA14G_CATB_SENSE9          _L_(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L_(6)
 #define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
-#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
-#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
-#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define GPIO_PA14G_CATB_SENSE9   _UL_(1 << 14)
+#define PIN_PA15G_CATB_SENSE10         _L_(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L_(6)
 #define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
-#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
-#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
-#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define GPIO_PA15G_CATB_SENSE10  _UL_(1 << 15)
+#define PIN_PA16G_CATB_SENSE11         _L_(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L_(6)
 #define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
-#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
-#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
-#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define GPIO_PA16G_CATB_SENSE11  _UL_(1 << 16)
+#define PIN_PA17G_CATB_SENSE12         _L_(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L_(6)
 #define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
-#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
-#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
-#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define GPIO_PA17G_CATB_SENSE12  _UL_(1 << 17)
+#define PIN_PA18G_CATB_SENSE13         _L_(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L_(6)
 #define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
-#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
-#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
-#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define GPIO_PA18G_CATB_SENSE13  _UL_(1 << 18)
+#define PIN_PA19G_CATB_SENSE14         _L_(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L_(6)
 #define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
-#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
-#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
-#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define GPIO_PA19G_CATB_SENSE14  _UL_(1 << 19)
+#define PIN_PA20G_CATB_SENSE15         _L_(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L_(6)
 #define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
-#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
-#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
-#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define GPIO_PA20G_CATB_SENSE15  _UL_(1 << 20)
+#define PIN_PA21G_CATB_SENSE16         _L_(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L_(6)
 #define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
-#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
-#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
-#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define GPIO_PA21G_CATB_SENSE16  _UL_(1 << 21)
+#define PIN_PA22G_CATB_SENSE17         _L_(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L_(6)
 #define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
-#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
-#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
-#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define GPIO_PA22G_CATB_SENSE17  _UL_(1 << 22)
+#define PIN_PA24G_CATB_SENSE18         _L_(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L_(6)
 #define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
-#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
-#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
-#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define GPIO_PA24G_CATB_SENSE18  _UL_(1 << 24)
+#define PIN_PA25G_CATB_SENSE19         _L_(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L_(6)
 #define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
-#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
-#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
-#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define GPIO_PA25G_CATB_SENSE19  _UL_(1 << 25)
+#define PIN_PA26G_CATB_SENSE20         _L_(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L_(6)
 #define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
-#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
-#define PIN_PB00G_CATB_SENSE21         _L(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
-#define MUX_PB00G_CATB_SENSE21          _L(6)
+#define GPIO_PA26G_CATB_SENSE20  _UL_(1 << 26)
+#define PIN_PB00G_CATB_SENSE21         _L_(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
+#define MUX_PB00G_CATB_SENSE21          _L_(6)
 #define PINMUX_PB00G_CATB_SENSE21  ((PIN_PB00G_CATB_SENSE21 << 16) | MUX_PB00G_CATB_SENSE21)
-#define GPIO_PB00G_CATB_SENSE21  _UL(1 <<  0)
-#define PIN_PB01G_CATB_SENSE22         _L(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
-#define MUX_PB01G_CATB_SENSE22          _L(6)
+#define GPIO_PB00G_CATB_SENSE21  _UL_(1 <<  0)
+#define PIN_PB01G_CATB_SENSE22         _L_(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
+#define MUX_PB01G_CATB_SENSE22          _L_(6)
 #define PINMUX_PB01G_CATB_SENSE22  ((PIN_PB01G_CATB_SENSE22 << 16) | MUX_PB01G_CATB_SENSE22)
-#define GPIO_PB01G_CATB_SENSE22  _UL(1 <<  1)
-#define PIN_PB02G_CATB_SENSE23         _L(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
-#define MUX_PB02G_CATB_SENSE23          _L(6)
+#define GPIO_PB01G_CATB_SENSE22  _UL_(1 <<  1)
+#define PIN_PB02G_CATB_SENSE23         _L_(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
+#define MUX_PB02G_CATB_SENSE23          _L_(6)
 #define PINMUX_PB02G_CATB_SENSE23  ((PIN_PB02G_CATB_SENSE23 << 16) | MUX_PB02G_CATB_SENSE23)
-#define GPIO_PB02G_CATB_SENSE23  _UL(1 <<  2)
-#define PIN_PB04G_CATB_SENSE24         _L(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
-#define MUX_PB04G_CATB_SENSE24          _L(6)
+#define GPIO_PB02G_CATB_SENSE23  _UL_(1 <<  2)
+#define PIN_PB04G_CATB_SENSE24         _L_(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
+#define MUX_PB04G_CATB_SENSE24          _L_(6)
 #define PINMUX_PB04G_CATB_SENSE24  ((PIN_PB04G_CATB_SENSE24 << 16) | MUX_PB04G_CATB_SENSE24)
-#define GPIO_PB04G_CATB_SENSE24  _UL(1 <<  4)
-#define PIN_PB05G_CATB_SENSE25         _L(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
-#define MUX_PB05G_CATB_SENSE25          _L(6)
+#define GPIO_PB04G_CATB_SENSE24  _UL_(1 <<  4)
+#define PIN_PB05G_CATB_SENSE25         _L_(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
+#define MUX_PB05G_CATB_SENSE25          _L_(6)
 #define PINMUX_PB05G_CATB_SENSE25  ((PIN_PB05G_CATB_SENSE25 << 16) | MUX_PB05G_CATB_SENSE25)
-#define GPIO_PB05G_CATB_SENSE25  _UL(1 <<  5)
-#define PIN_PB06G_CATB_SENSE26         _L(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
-#define MUX_PB06G_CATB_SENSE26          _L(6)
+#define GPIO_PB05G_CATB_SENSE25  _UL_(1 <<  5)
+#define PIN_PB06G_CATB_SENSE26         _L_(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
+#define MUX_PB06G_CATB_SENSE26          _L_(6)
 #define PINMUX_PB06G_CATB_SENSE26  ((PIN_PB06G_CATB_SENSE26 << 16) | MUX_PB06G_CATB_SENSE26)
-#define GPIO_PB06G_CATB_SENSE26  _UL(1 <<  6)
-#define PIN_PB07G_CATB_SENSE27         _L(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
-#define MUX_PB07G_CATB_SENSE27          _L(6)
+#define GPIO_PB06G_CATB_SENSE26  _UL_(1 <<  6)
+#define PIN_PB07G_CATB_SENSE27         _L_(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
+#define MUX_PB07G_CATB_SENSE27          _L_(6)
 #define PINMUX_PB07G_CATB_SENSE27  ((PIN_PB07G_CATB_SENSE27 << 16) | MUX_PB07G_CATB_SENSE27)
-#define GPIO_PB07G_CATB_SENSE27  _UL(1 <<  7)
-#define PIN_PB08G_CATB_SENSE28         _L(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
-#define MUX_PB08G_CATB_SENSE28          _L(6)
+#define GPIO_PB07G_CATB_SENSE27  _UL_(1 <<  7)
+#define PIN_PB08G_CATB_SENSE28         _L_(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
+#define MUX_PB08G_CATB_SENSE28          _L_(6)
 #define PINMUX_PB08G_CATB_SENSE28  ((PIN_PB08G_CATB_SENSE28 << 16) | MUX_PB08G_CATB_SENSE28)
-#define GPIO_PB08G_CATB_SENSE28  _UL(1 <<  8)
-#define PIN_PB09G_CATB_SENSE29         _L(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
-#define MUX_PB09G_CATB_SENSE29          _L(6)
+#define GPIO_PB08G_CATB_SENSE28  _UL_(1 <<  8)
+#define PIN_PB09G_CATB_SENSE29         _L_(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
+#define MUX_PB09G_CATB_SENSE29          _L_(6)
 #define PINMUX_PB09G_CATB_SENSE29  ((PIN_PB09G_CATB_SENSE29 << 16) | MUX_PB09G_CATB_SENSE29)
-#define GPIO_PB09G_CATB_SENSE29  _UL(1 <<  9)
-#define PIN_PB10G_CATB_SENSE30         _L(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
-#define MUX_PB10G_CATB_SENSE30          _L(6)
+#define GPIO_PB09G_CATB_SENSE29  _UL_(1 <<  9)
+#define PIN_PB10G_CATB_SENSE30         _L_(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
+#define MUX_PB10G_CATB_SENSE30          _L_(6)
 #define PINMUX_PB10G_CATB_SENSE30  ((PIN_PB10G_CATB_SENSE30 << 16) | MUX_PB10G_CATB_SENSE30)
-#define GPIO_PB10G_CATB_SENSE30  _UL(1 << 10)
-#define PIN_PB11G_CATB_SENSE31         _L(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
-#define MUX_PB11G_CATB_SENSE31          _L(6)
+#define GPIO_PB10G_CATB_SENSE30  _UL_(1 << 10)
+#define PIN_PB11G_CATB_SENSE31         _L_(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
+#define MUX_PB11G_CATB_SENSE31          _L_(6)
 #define PINMUX_PB11G_CATB_SENSE31  ((PIN_PB11G_CATB_SENSE31 << 16) | MUX_PB11G_CATB_SENSE31)
-#define GPIO_PB11G_CATB_SENSE31  _UL(1 << 11)
+#define GPIO_PB11G_CATB_SENSE31  _UL_(1 << 11)
 /* ========== GPIO definition for LCDCA peripheral ========== */
-#define PIN_PA12F_LCDCA_COM0           _L(12) /**< \brief LCDCA signal: COM0 on PA12 mux F */
-#define MUX_PA12F_LCDCA_COM0            _L(5)
+#define PIN_PA12F_LCDCA_COM0           _L_(12) /**< \brief LCDCA signal: COM0 on PA12 mux F */
+#define MUX_PA12F_LCDCA_COM0            _L_(5)
 #define PINMUX_PA12F_LCDCA_COM0    ((PIN_PA12F_LCDCA_COM0 << 16) | MUX_PA12F_LCDCA_COM0)
-#define GPIO_PA12F_LCDCA_COM0    _UL(1 << 12)
-#define PIN_PA11F_LCDCA_COM1           _L(11) /**< \brief LCDCA signal: COM1 on PA11 mux F */
-#define MUX_PA11F_LCDCA_COM1            _L(5)
+#define GPIO_PA12F_LCDCA_COM0    _UL_(1 << 12)
+#define PIN_PA11F_LCDCA_COM1           _L_(11) /**< \brief LCDCA signal: COM1 on PA11 mux F */
+#define MUX_PA11F_LCDCA_COM1            _L_(5)
 #define PINMUX_PA11F_LCDCA_COM1    ((PIN_PA11F_LCDCA_COM1 << 16) | MUX_PA11F_LCDCA_COM1)
-#define GPIO_PA11F_LCDCA_COM1    _UL(1 << 11)
-#define PIN_PA10F_LCDCA_COM2           _L(10) /**< \brief LCDCA signal: COM2 on PA10 mux F */
-#define MUX_PA10F_LCDCA_COM2            _L(5)
+#define GPIO_PA11F_LCDCA_COM1    _UL_(1 << 11)
+#define PIN_PA10F_LCDCA_COM2           _L_(10) /**< \brief LCDCA signal: COM2 on PA10 mux F */
+#define MUX_PA10F_LCDCA_COM2            _L_(5)
 #define PINMUX_PA10F_LCDCA_COM2    ((PIN_PA10F_LCDCA_COM2 << 16) | MUX_PA10F_LCDCA_COM2)
-#define GPIO_PA10F_LCDCA_COM2    _UL(1 << 10)
-#define PIN_PA09F_LCDCA_COM3            _L(9) /**< \brief LCDCA signal: COM3 on PA09 mux F */
-#define MUX_PA09F_LCDCA_COM3            _L(5)
+#define GPIO_PA10F_LCDCA_COM2    _UL_(1 << 10)
+#define PIN_PA09F_LCDCA_COM3            _L_(9) /**< \brief LCDCA signal: COM3 on PA09 mux F */
+#define MUX_PA09F_LCDCA_COM3            _L_(5)
 #define PINMUX_PA09F_LCDCA_COM3    ((PIN_PA09F_LCDCA_COM3 << 16) | MUX_PA09F_LCDCA_COM3)
-#define GPIO_PA09F_LCDCA_COM3    _UL(1 <<  9)
-#define PIN_PA13F_LCDCA_SEG5           _L(13) /**< \brief LCDCA signal: SEG5 on PA13 mux F */
-#define MUX_PA13F_LCDCA_SEG5            _L(5)
+#define GPIO_PA09F_LCDCA_COM3    _UL_(1 <<  9)
+#define PIN_PA13F_LCDCA_SEG5           _L_(13) /**< \brief LCDCA signal: SEG5 on PA13 mux F */
+#define MUX_PA13F_LCDCA_SEG5            _L_(5)
 #define PINMUX_PA13F_LCDCA_SEG5    ((PIN_PA13F_LCDCA_SEG5 << 16) | MUX_PA13F_LCDCA_SEG5)
-#define GPIO_PA13F_LCDCA_SEG5    _UL(1 << 13)
-#define PIN_PA14F_LCDCA_SEG6           _L(14) /**< \brief LCDCA signal: SEG6 on PA14 mux F */
-#define MUX_PA14F_LCDCA_SEG6            _L(5)
+#define GPIO_PA13F_LCDCA_SEG5    _UL_(1 << 13)
+#define PIN_PA14F_LCDCA_SEG6           _L_(14) /**< \brief LCDCA signal: SEG6 on PA14 mux F */
+#define MUX_PA14F_LCDCA_SEG6            _L_(5)
 #define PINMUX_PA14F_LCDCA_SEG6    ((PIN_PA14F_LCDCA_SEG6 << 16) | MUX_PA14F_LCDCA_SEG6)
-#define GPIO_PA14F_LCDCA_SEG6    _UL(1 << 14)
-#define PIN_PA15F_LCDCA_SEG7           _L(15) /**< \brief LCDCA signal: SEG7 on PA15 mux F */
-#define MUX_PA15F_LCDCA_SEG7            _L(5)
+#define GPIO_PA14F_LCDCA_SEG6    _UL_(1 << 14)
+#define PIN_PA15F_LCDCA_SEG7           _L_(15) /**< \brief LCDCA signal: SEG7 on PA15 mux F */
+#define MUX_PA15F_LCDCA_SEG7            _L_(5)
 #define PINMUX_PA15F_LCDCA_SEG7    ((PIN_PA15F_LCDCA_SEG7 << 16) | MUX_PA15F_LCDCA_SEG7)
-#define GPIO_PA15F_LCDCA_SEG7    _UL(1 << 15)
-#define PIN_PA16F_LCDCA_SEG8           _L(16) /**< \brief LCDCA signal: SEG8 on PA16 mux F */
-#define MUX_PA16F_LCDCA_SEG8            _L(5)
+#define GPIO_PA15F_LCDCA_SEG7    _UL_(1 << 15)
+#define PIN_PA16F_LCDCA_SEG8           _L_(16) /**< \brief LCDCA signal: SEG8 on PA16 mux F */
+#define MUX_PA16F_LCDCA_SEG8            _L_(5)
 #define PINMUX_PA16F_LCDCA_SEG8    ((PIN_PA16F_LCDCA_SEG8 << 16) | MUX_PA16F_LCDCA_SEG8)
-#define GPIO_PA16F_LCDCA_SEG8    _UL(1 << 16)
-#define PIN_PA17F_LCDCA_SEG9           _L(17) /**< \brief LCDCA signal: SEG9 on PA17 mux F */
-#define MUX_PA17F_LCDCA_SEG9            _L(5)
+#define GPIO_PA16F_LCDCA_SEG8    _UL_(1 << 16)
+#define PIN_PA17F_LCDCA_SEG9           _L_(17) /**< \brief LCDCA signal: SEG9 on PA17 mux F */
+#define MUX_PA17F_LCDCA_SEG9            _L_(5)
 #define PINMUX_PA17F_LCDCA_SEG9    ((PIN_PA17F_LCDCA_SEG9 << 16) | MUX_PA17F_LCDCA_SEG9)
-#define GPIO_PA17F_LCDCA_SEG9    _UL(1 << 17)
-#define PIN_PB08F_LCDCA_SEG14          _L(40) /**< \brief LCDCA signal: SEG14 on PB08 mux F */
-#define MUX_PB08F_LCDCA_SEG14           _L(5)
+#define GPIO_PA17F_LCDCA_SEG9    _UL_(1 << 17)
+#define PIN_PB08F_LCDCA_SEG14          _L_(40) /**< \brief LCDCA signal: SEG14 on PB08 mux F */
+#define MUX_PB08F_LCDCA_SEG14           _L_(5)
 #define PINMUX_PB08F_LCDCA_SEG14   ((PIN_PB08F_LCDCA_SEG14 << 16) | MUX_PB08F_LCDCA_SEG14)
-#define GPIO_PB08F_LCDCA_SEG14   _UL(1 <<  8)
-#define PIN_PB09F_LCDCA_SEG15          _L(41) /**< \brief LCDCA signal: SEG15 on PB09 mux F */
-#define MUX_PB09F_LCDCA_SEG15           _L(5)
+#define GPIO_PB08F_LCDCA_SEG14   _UL_(1 <<  8)
+#define PIN_PB09F_LCDCA_SEG15          _L_(41) /**< \brief LCDCA signal: SEG15 on PB09 mux F */
+#define MUX_PB09F_LCDCA_SEG15           _L_(5)
 #define PINMUX_PB09F_LCDCA_SEG15   ((PIN_PB09F_LCDCA_SEG15 << 16) | MUX_PB09F_LCDCA_SEG15)
-#define GPIO_PB09F_LCDCA_SEG15   _UL(1 <<  9)
-#define PIN_PB10F_LCDCA_SEG16          _L(42) /**< \brief LCDCA signal: SEG16 on PB10 mux F */
-#define MUX_PB10F_LCDCA_SEG16           _L(5)
+#define GPIO_PB09F_LCDCA_SEG15   _UL_(1 <<  9)
+#define PIN_PB10F_LCDCA_SEG16          _L_(42) /**< \brief LCDCA signal: SEG16 on PB10 mux F */
+#define MUX_PB10F_LCDCA_SEG16           _L_(5)
 #define PINMUX_PB10F_LCDCA_SEG16   ((PIN_PB10F_LCDCA_SEG16 << 16) | MUX_PB10F_LCDCA_SEG16)
-#define GPIO_PB10F_LCDCA_SEG16   _UL(1 << 10)
-#define PIN_PB11F_LCDCA_SEG17          _L(43) /**< \brief LCDCA signal: SEG17 on PB11 mux F */
-#define MUX_PB11F_LCDCA_SEG17           _L(5)
+#define GPIO_PB10F_LCDCA_SEG16   _UL_(1 << 10)
+#define PIN_PB11F_LCDCA_SEG17          _L_(43) /**< \brief LCDCA signal: SEG17 on PB11 mux F */
+#define MUX_PB11F_LCDCA_SEG17           _L_(5)
 #define PINMUX_PB11F_LCDCA_SEG17   ((PIN_PB11F_LCDCA_SEG17 << 16) | MUX_PB11F_LCDCA_SEG17)
-#define GPIO_PB11F_LCDCA_SEG17   _UL(1 << 11)
-#define PIN_PA18F_LCDCA_SEG18          _L(18) /**< \brief LCDCA signal: SEG18 on PA18 mux F */
-#define MUX_PA18F_LCDCA_SEG18           _L(5)
+#define GPIO_PB11F_LCDCA_SEG17   _UL_(1 << 11)
+#define PIN_PA18F_LCDCA_SEG18          _L_(18) /**< \brief LCDCA signal: SEG18 on PA18 mux F */
+#define MUX_PA18F_LCDCA_SEG18           _L_(5)
 #define PINMUX_PA18F_LCDCA_SEG18   ((PIN_PA18F_LCDCA_SEG18 << 16) | MUX_PA18F_LCDCA_SEG18)
-#define GPIO_PA18F_LCDCA_SEG18   _UL(1 << 18)
-#define PIN_PA19F_LCDCA_SEG19          _L(19) /**< \brief LCDCA signal: SEG19 on PA19 mux F */
-#define MUX_PA19F_LCDCA_SEG19           _L(5)
+#define GPIO_PA18F_LCDCA_SEG18   _UL_(1 << 18)
+#define PIN_PA19F_LCDCA_SEG19          _L_(19) /**< \brief LCDCA signal: SEG19 on PA19 mux F */
+#define MUX_PA19F_LCDCA_SEG19           _L_(5)
 #define PINMUX_PA19F_LCDCA_SEG19   ((PIN_PA19F_LCDCA_SEG19 << 16) | MUX_PA19F_LCDCA_SEG19)
-#define GPIO_PA19F_LCDCA_SEG19   _UL(1 << 19)
-#define PIN_PA20F_LCDCA_SEG20          _L(20) /**< \brief LCDCA signal: SEG20 on PA20 mux F */
-#define MUX_PA20F_LCDCA_SEG20           _L(5)
+#define GPIO_PA19F_LCDCA_SEG19   _UL_(1 << 19)
+#define PIN_PA20F_LCDCA_SEG20          _L_(20) /**< \brief LCDCA signal: SEG20 on PA20 mux F */
+#define MUX_PA20F_LCDCA_SEG20           _L_(5)
 #define PINMUX_PA20F_LCDCA_SEG20   ((PIN_PA20F_LCDCA_SEG20 << 16) | MUX_PA20F_LCDCA_SEG20)
-#define GPIO_PA20F_LCDCA_SEG20   _UL(1 << 20)
-#define PIN_PB07F_LCDCA_SEG21          _L(39) /**< \brief LCDCA signal: SEG21 on PB07 mux F */
-#define MUX_PB07F_LCDCA_SEG21           _L(5)
+#define GPIO_PA20F_LCDCA_SEG20   _UL_(1 << 20)
+#define PIN_PB07F_LCDCA_SEG21          _L_(39) /**< \brief LCDCA signal: SEG21 on PB07 mux F */
+#define MUX_PB07F_LCDCA_SEG21           _L_(5)
 #define PINMUX_PB07F_LCDCA_SEG21   ((PIN_PB07F_LCDCA_SEG21 << 16) | MUX_PB07F_LCDCA_SEG21)
-#define GPIO_PB07F_LCDCA_SEG21   _UL(1 <<  7)
-#define PIN_PB06F_LCDCA_SEG22          _L(38) /**< \brief LCDCA signal: SEG22 on PB06 mux F */
-#define MUX_PB06F_LCDCA_SEG22           _L(5)
+#define GPIO_PB07F_LCDCA_SEG21   _UL_(1 <<  7)
+#define PIN_PB06F_LCDCA_SEG22          _L_(38) /**< \brief LCDCA signal: SEG22 on PB06 mux F */
+#define MUX_PB06F_LCDCA_SEG22           _L_(5)
 #define PINMUX_PB06F_LCDCA_SEG22   ((PIN_PB06F_LCDCA_SEG22 << 16) | MUX_PB06F_LCDCA_SEG22)
-#define GPIO_PB06F_LCDCA_SEG22   _UL(1 <<  6)
-#define PIN_PA08F_LCDCA_SEG23           _L(8) /**< \brief LCDCA signal: SEG23 on PA08 mux F */
-#define MUX_PA08F_LCDCA_SEG23           _L(5)
+#define GPIO_PB06F_LCDCA_SEG22   _UL_(1 <<  6)
+#define PIN_PA08F_LCDCA_SEG23           _L_(8) /**< \brief LCDCA signal: SEG23 on PA08 mux F */
+#define MUX_PA08F_LCDCA_SEG23           _L_(5)
 #define PINMUX_PA08F_LCDCA_SEG23   ((PIN_PA08F_LCDCA_SEG23 << 16) | MUX_PA08F_LCDCA_SEG23)
-#define GPIO_PA08F_LCDCA_SEG23   _UL(1 <<  8)
-#define PIN_PB12F_LCDCA_SEG32          _L(44) /**< \brief LCDCA signal: SEG32 on PB12 mux F */
-#define MUX_PB12F_LCDCA_SEG32           _L(5)
+#define GPIO_PA08F_LCDCA_SEG23   _UL_(1 <<  8)
+#define PIN_PB12F_LCDCA_SEG32          _L_(44) /**< \brief LCDCA signal: SEG32 on PB12 mux F */
+#define MUX_PB12F_LCDCA_SEG32           _L_(5)
 #define PINMUX_PB12F_LCDCA_SEG32   ((PIN_PB12F_LCDCA_SEG32 << 16) | MUX_PB12F_LCDCA_SEG32)
-#define GPIO_PB12F_LCDCA_SEG32   _UL(1 << 12)
-#define PIN_PB13F_LCDCA_SEG33          _L(45) /**< \brief LCDCA signal: SEG33 on PB13 mux F */
-#define MUX_PB13F_LCDCA_SEG33           _L(5)
+#define GPIO_PB12F_LCDCA_SEG32   _UL_(1 << 12)
+#define PIN_PB13F_LCDCA_SEG33          _L_(45) /**< \brief LCDCA signal: SEG33 on PB13 mux F */
+#define MUX_PB13F_LCDCA_SEG33           _L_(5)
 #define PINMUX_PB13F_LCDCA_SEG33   ((PIN_PB13F_LCDCA_SEG33 << 16) | MUX_PB13F_LCDCA_SEG33)
-#define GPIO_PB13F_LCDCA_SEG33   _UL(1 << 13)
-#define PIN_PA21F_LCDCA_SEG34          _L(21) /**< \brief LCDCA signal: SEG34 on PA21 mux F */
-#define MUX_PA21F_LCDCA_SEG34           _L(5)
+#define GPIO_PB13F_LCDCA_SEG33   _UL_(1 << 13)
+#define PIN_PA21F_LCDCA_SEG34          _L_(21) /**< \brief LCDCA signal: SEG34 on PA21 mux F */
+#define MUX_PA21F_LCDCA_SEG34           _L_(5)
 #define PINMUX_PA21F_LCDCA_SEG34   ((PIN_PA21F_LCDCA_SEG34 << 16) | MUX_PA21F_LCDCA_SEG34)
-#define GPIO_PA21F_LCDCA_SEG34   _UL(1 << 21)
-#define PIN_PA22F_LCDCA_SEG35          _L(22) /**< \brief LCDCA signal: SEG35 on PA22 mux F */
-#define MUX_PA22F_LCDCA_SEG35           _L(5)
+#define GPIO_PA21F_LCDCA_SEG34   _UL_(1 << 21)
+#define PIN_PA22F_LCDCA_SEG35          _L_(22) /**< \brief LCDCA signal: SEG35 on PA22 mux F */
+#define MUX_PA22F_LCDCA_SEG35           _L_(5)
 #define PINMUX_PA22F_LCDCA_SEG35   ((PIN_PA22F_LCDCA_SEG35 << 16) | MUX_PA22F_LCDCA_SEG35)
-#define GPIO_PA22F_LCDCA_SEG35   _UL(1 << 22)
-#define PIN_PB14F_LCDCA_SEG36          _L(46) /**< \brief LCDCA signal: SEG36 on PB14 mux F */
-#define MUX_PB14F_LCDCA_SEG36           _L(5)
+#define GPIO_PA22F_LCDCA_SEG35   _UL_(1 << 22)
+#define PIN_PB14F_LCDCA_SEG36          _L_(46) /**< \brief LCDCA signal: SEG36 on PB14 mux F */
+#define MUX_PB14F_LCDCA_SEG36           _L_(5)
 #define PINMUX_PB14F_LCDCA_SEG36   ((PIN_PB14F_LCDCA_SEG36 << 16) | MUX_PB14F_LCDCA_SEG36)
-#define GPIO_PB14F_LCDCA_SEG36   _UL(1 << 14)
-#define PIN_PB15F_LCDCA_SEG37          _L(47) /**< \brief LCDCA signal: SEG37 on PB15 mux F */
-#define MUX_PB15F_LCDCA_SEG37           _L(5)
+#define GPIO_PB14F_LCDCA_SEG36   _UL_(1 << 14)
+#define PIN_PB15F_LCDCA_SEG37          _L_(47) /**< \brief LCDCA signal: SEG37 on PB15 mux F */
+#define MUX_PB15F_LCDCA_SEG37           _L_(5)
 #define PINMUX_PB15F_LCDCA_SEG37   ((PIN_PB15F_LCDCA_SEG37 << 16) | MUX_PB15F_LCDCA_SEG37)
-#define GPIO_PB15F_LCDCA_SEG37   _UL(1 << 15)
-#define PIN_PA23F_LCDCA_SEG38          _L(23) /**< \brief LCDCA signal: SEG38 on PA23 mux F */
-#define MUX_PA23F_LCDCA_SEG38           _L(5)
+#define GPIO_PB15F_LCDCA_SEG37   _UL_(1 << 15)
+#define PIN_PA23F_LCDCA_SEG38          _L_(23) /**< \brief LCDCA signal: SEG38 on PA23 mux F */
+#define MUX_PA23F_LCDCA_SEG38           _L_(5)
 #define PINMUX_PA23F_LCDCA_SEG38   ((PIN_PA23F_LCDCA_SEG38 << 16) | MUX_PA23F_LCDCA_SEG38)
-#define GPIO_PA23F_LCDCA_SEG38   _UL(1 << 23)
-#define PIN_PA24F_LCDCA_SEG39          _L(24) /**< \brief LCDCA signal: SEG39 on PA24 mux F */
-#define MUX_PA24F_LCDCA_SEG39           _L(5)
+#define GPIO_PA23F_LCDCA_SEG38   _UL_(1 << 23)
+#define PIN_PA24F_LCDCA_SEG39          _L_(24) /**< \brief LCDCA signal: SEG39 on PA24 mux F */
+#define MUX_PA24F_LCDCA_SEG39           _L_(5)
 #define PINMUX_PA24F_LCDCA_SEG39   ((PIN_PA24F_LCDCA_SEG39 << 16) | MUX_PA24F_LCDCA_SEG39)
-#define GPIO_PA24F_LCDCA_SEG39   _UL(1 << 24)
+#define GPIO_PA24F_LCDCA_SEG39   _UL_(1 << 24)
 /* ========== GPIO definition for USBC peripheral ========== */
-#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
-#define MUX_PA25A_USBC_DM               _L(0)
+#define PIN_PA25A_USBC_DM              _L_(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L_(0)
 #define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
-#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
-#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
-#define MUX_PA26A_USBC_DP               _L(0)
+#define GPIO_PA25A_USBC_DM       _UL_(1 << 25)
+#define PIN_PA26A_USBC_DP              _L_(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L_(0)
 #define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
-#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+#define GPIO_PA26A_USBC_DP       _UL_(1 << 26)
 /* ========== GPIO definition for PEVC peripheral ========== */
-#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
-#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PIN_PA08C_PEVC_PAD_EVT0         _L_(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
-#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
-#define PIN_PB12C_PEVC_PAD_EVT0        _L(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
-#define MUX_PB12C_PEVC_PAD_EVT0         _L(2)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL_(1 <<  8)
+#define PIN_PB12C_PEVC_PAD_EVT0        _L_(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
+#define MUX_PB12C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PB12C_PEVC_PAD_EVT0  ((PIN_PB12C_PEVC_PAD_EVT0 << 16) | MUX_PB12C_PEVC_PAD_EVT0)
-#define GPIO_PB12C_PEVC_PAD_EVT0  _UL(1 << 12)
-#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
-#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PB12C_PEVC_PAD_EVT0  _UL_(1 << 12)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L_(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
-#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
-#define PIN_PB13C_PEVC_PAD_EVT1        _L(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
-#define MUX_PB13C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL_(1 <<  9)
+#define PIN_PB13C_PEVC_PAD_EVT1        _L_(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
+#define MUX_PB13C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PB13C_PEVC_PAD_EVT1  ((PIN_PB13C_PEVC_PAD_EVT1 << 16) | MUX_PB13C_PEVC_PAD_EVT1)
-#define GPIO_PB13C_PEVC_PAD_EVT1  _UL(1 << 13)
-#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
-#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PB13C_PEVC_PAD_EVT1  _UL_(1 << 13)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L_(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
-#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
-#define PIN_PB09B_PEVC_PAD_EVT2        _L(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
-#define MUX_PB09B_PEVC_PAD_EVT2         _L(1)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL_(1 << 10)
+#define PIN_PB09B_PEVC_PAD_EVT2        _L_(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
+#define MUX_PB09B_PEVC_PAD_EVT2         _L_(1)
 #define PINMUX_PB09B_PEVC_PAD_EVT2  ((PIN_PB09B_PEVC_PAD_EVT2 << 16) | MUX_PB09B_PEVC_PAD_EVT2)
-#define GPIO_PB09B_PEVC_PAD_EVT2  _UL(1 <<  9)
-#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
-#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define GPIO_PB09B_PEVC_PAD_EVT2  _UL_(1 <<  9)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L_(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L_(2)
 #define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
-#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
-#define PIN_PB10B_PEVC_PAD_EVT3        _L(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
-#define MUX_PB10B_PEVC_PAD_EVT3         _L(1)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL_(1 << 11)
+#define PIN_PB10B_PEVC_PAD_EVT3        _L_(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
+#define MUX_PB10B_PEVC_PAD_EVT3         _L_(1)
 #define PINMUX_PB10B_PEVC_PAD_EVT3  ((PIN_PB10B_PEVC_PAD_EVT3 << 16) | MUX_PB10B_PEVC_PAD_EVT3)
-#define GPIO_PB10B_PEVC_PAD_EVT3  _UL(1 << 10)
+#define GPIO_PB10B_PEVC_PAD_EVT3  _UL_(1 << 10)
 /* ========== GPIO definition for SCIF peripheral ========== */
-#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
-#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PIN_PA19E_SCIF_GCLK0           _L_(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
-#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
-#define PIN_PB10E_SCIF_GCLK0           _L(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
-#define MUX_PB10E_SCIF_GCLK0            _L(4)
+#define GPIO_PA19E_SCIF_GCLK0    _UL_(1 << 19)
+#define PIN_PB10E_SCIF_GCLK0           _L_(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
+#define MUX_PB10E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PB10E_SCIF_GCLK0    ((PIN_PB10E_SCIF_GCLK0 << 16) | MUX_PB10E_SCIF_GCLK0)
-#define GPIO_PB10E_SCIF_GCLK0    _UL(1 << 10)
-#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
-#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define GPIO_PB10E_SCIF_GCLK0    _UL_(1 << 10)
+#define PIN_PA02A_SCIF_GCLK0            _L_(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L_(0)
 #define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
-#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
-#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
-#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define GPIO_PA02A_SCIF_GCLK0    _UL_(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L_(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
-#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
-#define PIN_PB11E_SCIF_GCLK1           _L(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
-#define MUX_PB11E_SCIF_GCLK1            _L(4)
+#define GPIO_PA20E_SCIF_GCLK1    _UL_(1 << 20)
+#define PIN_PB11E_SCIF_GCLK1           _L_(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
+#define MUX_PB11E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PB11E_SCIF_GCLK1    ((PIN_PB11E_SCIF_GCLK1 << 16) | MUX_PB11E_SCIF_GCLK1)
-#define GPIO_PB11E_SCIF_GCLK1    _UL(1 << 11)
-#define PIN_PB12E_SCIF_GCLK2           _L(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
-#define MUX_PB12E_SCIF_GCLK2            _L(4)
+#define GPIO_PB11E_SCIF_GCLK1    _UL_(1 << 11)
+#define PIN_PB12E_SCIF_GCLK2           _L_(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
+#define MUX_PB12E_SCIF_GCLK2            _L_(4)
 #define PINMUX_PB12E_SCIF_GCLK2    ((PIN_PB12E_SCIF_GCLK2 << 16) | MUX_PB12E_SCIF_GCLK2)
-#define GPIO_PB12E_SCIF_GCLK2    _UL(1 << 12)
-#define PIN_PB13E_SCIF_GCLK3           _L(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
-#define MUX_PB13E_SCIF_GCLK3            _L(4)
+#define GPIO_PB12E_SCIF_GCLK2    _UL_(1 << 12)
+#define PIN_PB13E_SCIF_GCLK3           _L_(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
+#define MUX_PB13E_SCIF_GCLK3            _L_(4)
 #define PINMUX_PB13E_SCIF_GCLK3    ((PIN_PB13E_SCIF_GCLK3 << 16) | MUX_PB13E_SCIF_GCLK3)
-#define GPIO_PB13E_SCIF_GCLK3    _UL(1 << 13)
-#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
-#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PB13E_SCIF_GCLK3    _UL_(1 << 13)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L_(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
-#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
-#define PIN_PB14E_SCIF_GCLK_IN0        _L(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
-#define MUX_PB14E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL_(1 << 23)
+#define PIN_PB14E_SCIF_GCLK_IN0        _L_(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
+#define MUX_PB14E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PB14E_SCIF_GCLK_IN0  ((PIN_PB14E_SCIF_GCLK_IN0 << 16) | MUX_PB14E_SCIF_GCLK_IN0)
-#define GPIO_PB14E_SCIF_GCLK_IN0  _UL(1 << 14)
-#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
-#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PB14E_SCIF_GCLK_IN0  _UL_(1 << 14)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L_(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
-#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
-#define PIN_PB15E_SCIF_GCLK_IN1        _L(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
-#define MUX_PB15E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL_(1 << 24)
+#define PIN_PB15E_SCIF_GCLK_IN1        _L_(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
+#define MUX_PB15E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PB15E_SCIF_GCLK_IN1  ((PIN_PB15E_SCIF_GCLK_IN1 << 16) | MUX_PB15E_SCIF_GCLK_IN1)
-#define GPIO_PB15E_SCIF_GCLK_IN1  _UL(1 << 15)
+#define GPIO_PB15E_SCIF_GCLK_IN1  _UL_(1 << 15)
 /* ========== GPIO definition for EIC peripheral ========== */
-#define PIN_PB01C_EIC_EXTINT0          _L(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
-#define MUX_PB01C_EIC_EXTINT0           _L(2)
+#define PIN_PB01C_EIC_EXTINT0          _L_(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
+#define MUX_PB01C_EIC_EXTINT0           _L_(2)
 #define PINMUX_PB01C_EIC_EXTINT0   ((PIN_PB01C_EIC_EXTINT0 << 16) | MUX_PB01C_EIC_EXTINT0)
-#define GPIO_PB01C_EIC_EXTINT0   _UL(1 <<  1)
-#define PIN_PB01C_EIC_EXTINT_NUM        _L(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
-#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
-#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define GPIO_PB01C_EIC_EXTINT0   _UL_(1 <<  1)
+#define PIN_PB01C_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PA06C_EIC_EXTINT1           _L_(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
-#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
-#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
-#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
-#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define GPIO_PA06C_EIC_EXTINT1   _UL_(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L_(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
-#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
-#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
-#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
-#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define GPIO_PA16C_EIC_EXTINT1   _UL_(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L_(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
-#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
-#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
-#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
-#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL_(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L_(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
-#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
-#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
-#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
-#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL_(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L_(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
-#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
-#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
-#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
-#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define GPIO_PA05C_EIC_EXTINT3   _UL_(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L_(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
-#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
-#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
-#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
-#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define GPIO_PA18C_EIC_EXTINT3   _UL_(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L_(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
-#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
-#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
-#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
-#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define GPIO_PA07C_EIC_EXTINT4   _UL_(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L_(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
-#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
-#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
-#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
-#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define GPIO_PA19C_EIC_EXTINT4   _UL_(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L_(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L_(2)
 #define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
-#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
-#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
-#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
-#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define GPIO_PA20C_EIC_EXTINT5   _UL_(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L_(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L_(2)
 #define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
-#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
-#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
-#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
-#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define GPIO_PA21C_EIC_EXTINT6   _UL_(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L_(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L_(2)
 #define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
-#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
-#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
-#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
-#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define GPIO_PA22C_EIC_EXTINT7   _UL_(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L_(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L_(2)
 #define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
-#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
-#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define GPIO_PA23C_EIC_EXTINT8   _UL_(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
 
 #endif /* _SAM4LC2B_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4lc2b.h
+++ b/asf/sam/include/sam4l/pio/sam4lc2b.h
@@ -1,0 +1,1079 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAM4LC2B
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LC2B_PIO_
+#define _SAM4LC2B_PIO_
+
+#define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
+#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
+#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
+#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
+#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
+#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
+#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
+#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
+#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
+#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
+#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
+#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
+#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
+#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
+#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
+#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
+#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
+#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
+#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
+#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
+#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
+#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
+#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
+#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
+#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
+#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
+#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
+#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
+#define GPIO_PB00                _UL(1 <<  0) /**< \brief GPIO Mask  for PB00 */
+#define PIN_PB01                          33  /**< \brief Pin Number for PB01 */
+#define GPIO_PB01                _UL(1 <<  1) /**< \brief GPIO Mask  for PB01 */
+#define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
+#define GPIO_PB02                _UL(1 <<  2) /**< \brief GPIO Mask  for PB02 */
+#define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
+#define GPIO_PB03                _UL(1 <<  3) /**< \brief GPIO Mask  for PB03 */
+#define PIN_PB04                          36  /**< \brief Pin Number for PB04 */
+#define GPIO_PB04                _UL(1 <<  4) /**< \brief GPIO Mask  for PB04 */
+#define PIN_PB05                          37  /**< \brief Pin Number for PB05 */
+#define GPIO_PB05                _UL(1 <<  5) /**< \brief GPIO Mask  for PB05 */
+#define PIN_PB06                          38  /**< \brief Pin Number for PB06 */
+#define GPIO_PB06                _UL(1 <<  6) /**< \brief GPIO Mask  for PB06 */
+#define PIN_PB07                          39  /**< \brief Pin Number for PB07 */
+#define GPIO_PB07                _UL(1 <<  7) /**< \brief GPIO Mask  for PB07 */
+#define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
+#define GPIO_PB08                _UL(1 <<  8) /**< \brief GPIO Mask  for PB08 */
+#define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
+#define GPIO_PB09                _UL(1 <<  9) /**< \brief GPIO Mask  for PB09 */
+#define PIN_PB10                          42  /**< \brief Pin Number for PB10 */
+#define GPIO_PB10                _UL(1 << 10) /**< \brief GPIO Mask  for PB10 */
+#define PIN_PB11                          43  /**< \brief Pin Number for PB11 */
+#define GPIO_PB11                _UL(1 << 11) /**< \brief GPIO Mask  for PB11 */
+#define PIN_PB12                          44  /**< \brief Pin Number for PB12 */
+#define GPIO_PB12                _UL(1 << 12) /**< \brief GPIO Mask  for PB12 */
+#define PIN_PB13                          45  /**< \brief Pin Number for PB13 */
+#define GPIO_PB13                _UL(1 << 13) /**< \brief GPIO Mask  for PB13 */
+#define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
+#define GPIO_PB14                _UL(1 << 14) /**< \brief GPIO Mask  for PB14 */
+#define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
+#define GPIO_PB15                _UL(1 << 15) /**< \brief GPIO Mask  for PB15 */
+/* ========== GPIO definition for TWIMS0 peripheral ========== */
+#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
+#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+/* ========== GPIO definition for TWIMS1 peripheral ========== */
+#define PIN_PB01A_TWIMS1_TWCK          _L(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
+#define MUX_PB01A_TWIMS1_TWCK           _L(0)
+#define PINMUX_PB01A_TWIMS1_TWCK   ((PIN_PB01A_TWIMS1_TWCK << 16) | MUX_PB01A_TWIMS1_TWCK)
+#define GPIO_PB01A_TWIMS1_TWCK   _UL(1 <<  1)
+#define PIN_PB00A_TWIMS1_TWD           _L(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
+#define MUX_PB00A_TWIMS1_TWD            _L(0)
+#define PINMUX_PB00A_TWIMS1_TWD    ((PIN_PB00A_TWIMS1_TWD << 16) | MUX_PB00A_TWIMS1_TWD)
+#define GPIO_PB00A_TWIMS1_TWD    _UL(1 <<  0)
+/* ========== GPIO definition for TWIMS2 peripheral ========== */
+#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
+#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+/* ========== GPIO definition for TWIMS3 peripheral ========== */
+#define PIN_PB15C_TWIMS3_TWCK          _L(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
+#define MUX_PB15C_TWIMS3_TWCK           _L(2)
+#define PINMUX_PB15C_TWIMS3_TWCK   ((PIN_PB15C_TWIMS3_TWCK << 16) | MUX_PB15C_TWIMS3_TWCK)
+#define GPIO_PB15C_TWIMS3_TWCK   _UL(1 << 15)
+#define PIN_PB14C_TWIMS3_TWD           _L(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
+#define MUX_PB14C_TWIMS3_TWD            _L(2)
+#define PINMUX_PB14C_TWIMS3_TWD    ((PIN_PB14C_TWIMS3_TWD << 16) | MUX_PB14C_TWIMS3_TWD)
+#define GPIO_PB14C_TWIMS3_TWD    _UL(1 << 14)
+/* ========== GPIO definition for IISC peripheral ========== */
+#define PIN_PB05D_IISC_IMCK            _L(37) /**< \brief IISC signal: IMCK on PB05 mux D */
+#define MUX_PB05D_IISC_IMCK             _L(3)
+#define PINMUX_PB05D_IISC_IMCK     ((PIN_PB05D_IISC_IMCK << 16) | MUX_PB05D_IISC_IMCK)
+#define GPIO_PB05D_IISC_IMCK     _UL(1 <<  5)
+#define PIN_PB02D_IISC_ISCK            _L(34) /**< \brief IISC signal: ISCK on PB02 mux D */
+#define MUX_PB02D_IISC_ISCK             _L(3)
+#define PINMUX_PB02D_IISC_ISCK     ((PIN_PB02D_IISC_ISCK << 16) | MUX_PB02D_IISC_ISCK)
+#define GPIO_PB02D_IISC_ISCK     _UL(1 <<  2)
+#define PIN_PB03D_IISC_ISDI            _L(35) /**< \brief IISC signal: ISDI on PB03 mux D */
+#define MUX_PB03D_IISC_ISDI             _L(3)
+#define PINMUX_PB03D_IISC_ISDI     ((PIN_PB03D_IISC_ISDI << 16) | MUX_PB03D_IISC_ISDI)
+#define GPIO_PB03D_IISC_ISDI     _UL(1 <<  3)
+#define PIN_PB04D_IISC_ISDO            _L(36) /**< \brief IISC signal: ISDO on PB04 mux D */
+#define MUX_PB04D_IISC_ISDO             _L(3)
+#define PINMUX_PB04D_IISC_ISDO     ((PIN_PB04D_IISC_ISDO << 16) | MUX_PB04D_IISC_ISDO)
+#define GPIO_PB04D_IISC_ISDO     _UL(1 <<  4)
+#define PIN_PB06D_IISC_IWS             _L(38) /**< \brief IISC signal: IWS on PB06 mux D */
+#define MUX_PB06D_IISC_IWS              _L(3)
+#define PINMUX_PB06D_IISC_IWS      ((PIN_PB06D_IISC_IWS << 16) | MUX_PB06D_IISC_IWS)
+#define GPIO_PB06D_IISC_IWS      _UL(1 <<  6)
+/* ========== GPIO definition for SPI peripheral ========== */
+#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L(1)
+#define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
+#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
+#define PIN_PB14B_SPI_MISO             _L(46) /**< \brief SPI signal: MISO on PB14 mux B */
+#define MUX_PB14B_SPI_MISO              _L(1)
+#define PINMUX_PB14B_SPI_MISO      ((PIN_PB14B_SPI_MISO << 16) | MUX_PB14B_SPI_MISO)
+#define GPIO_PB14B_SPI_MISO      _UL(1 << 14)
+#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L(0)
+#define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
+#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
+#define PIN_PB15B_SPI_MOSI             _L(47) /**< \brief SPI signal: MOSI on PB15 mux B */
+#define MUX_PB15B_SPI_MOSI              _L(1)
+#define PINMUX_PB15B_SPI_MOSI      ((PIN_PB15B_SPI_MOSI << 16) | MUX_PB15B_SPI_MOSI)
+#define GPIO_PB15B_SPI_MOSI      _UL(1 << 15)
+#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L(0)
+#define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
+#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
+#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
+#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
+#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
+#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
+#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
+#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PB13B_SPI_NPCS1            _L(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
+#define MUX_PB13B_SPI_NPCS1             _L(1)
+#define PINMUX_PB13B_SPI_NPCS1     ((PIN_PB13B_SPI_NPCS1 << 16) | MUX_PB13B_SPI_NPCS1)
+#define GPIO_PB13B_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
+#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
+#define PIN_PB11B_SPI_NPCS2            _L(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
+#define MUX_PB11B_SPI_NPCS2             _L(1)
+#define PINMUX_PB11B_SPI_NPCS2     ((PIN_PB11B_SPI_NPCS2 << 16) | MUX_PB11B_SPI_NPCS2)
+#define GPIO_PB11B_SPI_NPCS2     _UL(1 << 11)
+#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
+#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
+#define PIN_PB12B_SPI_NPCS3            _L(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
+#define MUX_PB12B_SPI_NPCS3             _L(1)
+#define PINMUX_PB12B_SPI_NPCS3     ((PIN_PB12B_SPI_NPCS3 << 16) | MUX_PB12B_SPI_NPCS3)
+#define GPIO_PB12B_SPI_NPCS3     _UL(1 << 12)
+#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L(0)
+#define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
+#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
+/* ========== GPIO definition for TC0 peripheral ========== */
+#define PIN_PB07D_TC0_A0               _L(39) /**< \brief TC0 signal: A0 on PB07 mux D */
+#define MUX_PB07D_TC0_A0                _L(3)
+#define PINMUX_PB07D_TC0_A0        ((PIN_PB07D_TC0_A0 << 16) | MUX_PB07D_TC0_A0)
+#define GPIO_PB07D_TC0_A0        _UL(1 <<  7)
+#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L(1)
+#define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
+#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
+#define PIN_PB09D_TC0_A1               _L(41) /**< \brief TC0 signal: A1 on PB09 mux D */
+#define MUX_PB09D_TC0_A1                _L(3)
+#define PINMUX_PB09D_TC0_A1        ((PIN_PB09D_TC0_A1 << 16) | MUX_PB09D_TC0_A1)
+#define GPIO_PB09D_TC0_A1        _UL(1 <<  9)
+#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L(1)
+#define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
+#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
+#define PIN_PB11D_TC0_A2               _L(43) /**< \brief TC0 signal: A2 on PB11 mux D */
+#define MUX_PB11D_TC0_A2                _L(3)
+#define PINMUX_PB11D_TC0_A2        ((PIN_PB11D_TC0_A2 << 16) | MUX_PB11D_TC0_A2)
+#define GPIO_PB11D_TC0_A2        _UL(1 << 11)
+#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L(1)
+#define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
+#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
+#define PIN_PB08D_TC0_B0               _L(40) /**< \brief TC0 signal: B0 on PB08 mux D */
+#define MUX_PB08D_TC0_B0                _L(3)
+#define PINMUX_PB08D_TC0_B0        ((PIN_PB08D_TC0_B0 << 16) | MUX_PB08D_TC0_B0)
+#define GPIO_PB08D_TC0_B0        _UL(1 <<  8)
+#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L(1)
+#define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
+#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
+#define PIN_PB10D_TC0_B1               _L(42) /**< \brief TC0 signal: B1 on PB10 mux D */
+#define MUX_PB10D_TC0_B1                _L(3)
+#define PINMUX_PB10D_TC0_B1        ((PIN_PB10D_TC0_B1 << 16) | MUX_PB10D_TC0_B1)
+#define GPIO_PB10D_TC0_B1        _UL(1 << 10)
+#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L(1)
+#define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
+#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
+#define PIN_PB12D_TC0_B2               _L(44) /**< \brief TC0 signal: B2 on PB12 mux D */
+#define MUX_PB12D_TC0_B2                _L(3)
+#define PINMUX_PB12D_TC0_B2        ((PIN_PB12D_TC0_B2 << 16) | MUX_PB12D_TC0_B2)
+#define GPIO_PB12D_TC0_B2        _UL(1 << 12)
+#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L(1)
+#define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
+#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
+#define PIN_PB13D_TC0_CLK0             _L(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
+#define MUX_PB13D_TC0_CLK0              _L(3)
+#define PINMUX_PB13D_TC0_CLK0      ((PIN_PB13D_TC0_CLK0 << 16) | MUX_PB13D_TC0_CLK0)
+#define GPIO_PB13D_TC0_CLK0      _UL(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L(1)
+#define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
+#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
+#define PIN_PB14D_TC0_CLK1             _L(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
+#define MUX_PB14D_TC0_CLK1              _L(3)
+#define PINMUX_PB14D_TC0_CLK1      ((PIN_PB14D_TC0_CLK1 << 16) | MUX_PB14D_TC0_CLK1)
+#define GPIO_PB14D_TC0_CLK1      _UL(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L(1)
+#define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
+#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
+#define PIN_PB15D_TC0_CLK2             _L(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
+#define MUX_PB15D_TC0_CLK2              _L(3)
+#define PINMUX_PB15D_TC0_CLK2      ((PIN_PB15D_TC0_CLK2 << 16) | MUX_PB15D_TC0_CLK2)
+#define GPIO_PB15D_TC0_CLK2      _UL(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L(1)
+#define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
+#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+/* ========== GPIO definition for USART0 peripheral ========== */
+#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L(1)
+#define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
+#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
+#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L(0)
+#define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
+#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
+#define PIN_PB13A_USART0_CLK           _L(45) /**< \brief USART0 signal: CLK on PB13 mux A */
+#define MUX_PB13A_USART0_CLK            _L(0)
+#define PINMUX_PB13A_USART0_CLK    ((PIN_PB13A_USART0_CLK << 16) | MUX_PB13A_USART0_CLK)
+#define GPIO_PB13A_USART0_CLK    _UL(1 << 13)
+#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L(0)
+#define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
+#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
+#define PIN_PB11A_USART0_CTS           _L(43) /**< \brief USART0 signal: CTS on PB11 mux A */
+#define MUX_PB11A_USART0_CTS            _L(0)
+#define PINMUX_PB11A_USART0_CTS    ((PIN_PB11A_USART0_CTS << 16) | MUX_PB11A_USART0_CTS)
+#define GPIO_PB11A_USART0_CTS    _UL(1 << 11)
+#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L(1)
+#define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
+#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
+#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L(0)
+#define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
+#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
+#define PIN_PB12A_USART0_RTS           _L(44) /**< \brief USART0 signal: RTS on PB12 mux A */
+#define MUX_PB12A_USART0_RTS            _L(0)
+#define PINMUX_PB12A_USART0_RTS    ((PIN_PB12A_USART0_RTS << 16) | MUX_PB12A_USART0_RTS)
+#define GPIO_PB12A_USART0_RTS    _UL(1 << 12)
+#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L(1)
+#define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
+#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
+#define PIN_PB00B_USART0_RXD           _L(32) /**< \brief USART0 signal: RXD on PB00 mux B */
+#define MUX_PB00B_USART0_RXD            _L(1)
+#define PINMUX_PB00B_USART0_RXD    ((PIN_PB00B_USART0_RXD << 16) | MUX_PB00B_USART0_RXD)
+#define GPIO_PB00B_USART0_RXD    _UL(1 <<  0)
+#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L(0)
+#define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
+#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
+#define PIN_PB14A_USART0_RXD           _L(46) /**< \brief USART0 signal: RXD on PB14 mux A */
+#define MUX_PB14A_USART0_RXD            _L(0)
+#define PINMUX_PB14A_USART0_RXD    ((PIN_PB14A_USART0_RXD << 16) | MUX_PB14A_USART0_RXD)
+#define GPIO_PB14A_USART0_RXD    _UL(1 << 14)
+#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L(1)
+#define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
+#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
+#define PIN_PB01B_USART0_TXD           _L(33) /**< \brief USART0 signal: TXD on PB01 mux B */
+#define MUX_PB01B_USART0_TXD            _L(1)
+#define PINMUX_PB01B_USART0_TXD    ((PIN_PB01B_USART0_TXD << 16) | MUX_PB01B_USART0_TXD)
+#define GPIO_PB01B_USART0_TXD    _UL(1 <<  1)
+#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L(0)
+#define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
+#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
+#define PIN_PB15A_USART0_TXD           _L(47) /**< \brief USART0 signal: TXD on PB15 mux A */
+#define MUX_PB15A_USART0_TXD            _L(0)
+#define PINMUX_PB15A_USART0_TXD    ((PIN_PB15A_USART0_TXD << 16) | MUX_PB15A_USART0_TXD)
+#define GPIO_PB15A_USART0_TXD    _UL(1 << 15)
+/* ========== GPIO definition for USART1 peripheral ========== */
+#define PIN_PB03B_USART1_CLK           _L(35) /**< \brief USART1 signal: CLK on PB03 mux B */
+#define MUX_PB03B_USART1_CLK            _L(1)
+#define PINMUX_PB03B_USART1_CLK    ((PIN_PB03B_USART1_CLK << 16) | MUX_PB03B_USART1_CLK)
+#define GPIO_PB03B_USART1_CLK    _UL(1 <<  3)
+#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L(0)
+#define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
+#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
+#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L(1)
+#define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
+#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
+#define PIN_PB02B_USART1_RTS           _L(34) /**< \brief USART1 signal: RTS on PB02 mux B */
+#define MUX_PB02B_USART1_RTS            _L(1)
+#define PINMUX_PB02B_USART1_RTS    ((PIN_PB02B_USART1_RTS << 16) | MUX_PB02B_USART1_RTS)
+#define GPIO_PB02B_USART1_RTS    _UL(1 <<  2)
+#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L(0)
+#define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
+#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
+#define PIN_PB04B_USART1_RXD           _L(36) /**< \brief USART1 signal: RXD on PB04 mux B */
+#define MUX_PB04B_USART1_RXD            _L(1)
+#define PINMUX_PB04B_USART1_RXD    ((PIN_PB04B_USART1_RXD << 16) | MUX_PB04B_USART1_RXD)
+#define GPIO_PB04B_USART1_RXD    _UL(1 <<  4)
+#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L(0)
+#define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
+#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
+#define PIN_PB05B_USART1_TXD           _L(37) /**< \brief USART1 signal: TXD on PB05 mux B */
+#define MUX_PB05B_USART1_TXD            _L(1)
+#define PINMUX_PB05B_USART1_TXD    ((PIN_PB05B_USART1_TXD << 16) | MUX_PB05B_USART1_TXD)
+#define GPIO_PB05B_USART1_TXD    _UL(1 <<  5)
+#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L(0)
+#define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
+#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+/* ========== GPIO definition for USART2 peripheral ========== */
+#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L(0)
+#define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
+#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
+#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L(1)
+#define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
+#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
+#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L(0)
+#define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
+#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L(1)
+#define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
+#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
+#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L(0)
+#define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
+#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L(1)
+#define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
+#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
+#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L(0)
+#define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
+#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+/* ========== GPIO definition for USART3 peripheral ========== */
+#define PIN_PB08A_USART3_CLK           _L(40) /**< \brief USART3 signal: CLK on PB08 mux A */
+#define MUX_PB08A_USART3_CLK            _L(0)
+#define PINMUX_PB08A_USART3_CLK    ((PIN_PB08A_USART3_CLK << 16) | MUX_PB08A_USART3_CLK)
+#define GPIO_PB08A_USART3_CLK    _UL(1 <<  8)
+#define PIN_PB07A_USART3_CTS           _L(39) /**< \brief USART3 signal: CTS on PB07 mux A */
+#define MUX_PB07A_USART3_CTS            _L(0)
+#define PINMUX_PB07A_USART3_CTS    ((PIN_PB07A_USART3_CTS << 16) | MUX_PB07A_USART3_CTS)
+#define GPIO_PB07A_USART3_CTS    _UL(1 <<  7)
+#define PIN_PB06A_USART3_RTS           _L(38) /**< \brief USART3 signal: RTS on PB06 mux A */
+#define MUX_PB06A_USART3_RTS            _L(0)
+#define PINMUX_PB06A_USART3_RTS    ((PIN_PB06A_USART3_RTS << 16) | MUX_PB06A_USART3_RTS)
+#define GPIO_PB06A_USART3_RTS    _UL(1 <<  6)
+#define PIN_PB09A_USART3_RXD           _L(41) /**< \brief USART3 signal: RXD on PB09 mux A */
+#define MUX_PB09A_USART3_RXD            _L(0)
+#define PINMUX_PB09A_USART3_RXD    ((PIN_PB09A_USART3_RXD << 16) | MUX_PB09A_USART3_RXD)
+#define GPIO_PB09A_USART3_RXD    _UL(1 <<  9)
+#define PIN_PB10A_USART3_TXD           _L(42) /**< \brief USART3 signal: TXD on PB10 mux A */
+#define MUX_PB10A_USART3_TXD            _L(0)
+#define PINMUX_PB10A_USART3_TXD    ((PIN_PB10A_USART3_TXD << 16) | MUX_PB10A_USART3_TXD)
+#define GPIO_PB10A_USART3_TXD    _UL(1 << 10)
+/* ========== GPIO definition for ADCIFE peripheral ========== */
+#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
+#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
+#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
+#define PIN_PB02A_ADCIFE_AD3           _L(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
+#define MUX_PB02A_ADCIFE_AD3            _L(0)
+#define PINMUX_PB02A_ADCIFE_AD3    ((PIN_PB02A_ADCIFE_AD3 << 16) | MUX_PB02A_ADCIFE_AD3)
+#define GPIO_PB02A_ADCIFE_AD3    _UL(1 <<  2)
+#define PIN_PB03A_ADCIFE_AD4           _L(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
+#define MUX_PB03A_ADCIFE_AD4            _L(0)
+#define PINMUX_PB03A_ADCIFE_AD4    ((PIN_PB03A_ADCIFE_AD4 << 16) | MUX_PB03A_ADCIFE_AD4)
+#define GPIO_PB03A_ADCIFE_AD4    _UL(1 <<  3)
+#define PIN_PB04A_ADCIFE_AD5           _L(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
+#define MUX_PB04A_ADCIFE_AD5            _L(0)
+#define PINMUX_PB04A_ADCIFE_AD5    ((PIN_PB04A_ADCIFE_AD5 << 16) | MUX_PB04A_ADCIFE_AD5)
+#define GPIO_PB04A_ADCIFE_AD5    _UL(1 <<  4)
+#define PIN_PB05A_ADCIFE_AD6           _L(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
+#define MUX_PB05A_ADCIFE_AD6            _L(0)
+#define PINMUX_PB05A_ADCIFE_AD6    ((PIN_PB05A_ADCIFE_AD6 << 16) | MUX_PB05A_ADCIFE_AD6)
+#define GPIO_PB05A_ADCIFE_AD6    _UL(1 <<  5)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+/* ========== GPIO definition for DACC peripheral ========== */
+#define PIN_PB04E_DACC_EXT_TRIG0       _L(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
+#define MUX_PB04E_DACC_EXT_TRIG0        _L(4)
+#define PINMUX_PB04E_DACC_EXT_TRIG0  ((PIN_PB04E_DACC_EXT_TRIG0 << 16) | MUX_PB04E_DACC_EXT_TRIG0)
+#define GPIO_PB04E_DACC_EXT_TRIG0  _UL(1 <<  4)
+#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L(0)
+#define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
+#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+/* ========== GPIO definition for ACIFC peripheral ========== */
+#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
+#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
+#define PIN_PB02E_ACIFC_ACBN0          _L(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
+#define MUX_PB02E_ACIFC_ACBN0           _L(4)
+#define PINMUX_PB02E_ACIFC_ACBN0   ((PIN_PB02E_ACIFC_ACBN0 << 16) | MUX_PB02E_ACIFC_ACBN0)
+#define GPIO_PB02E_ACIFC_ACBN0   _UL(1 <<  2)
+#define PIN_PB03E_ACIFC_ACBP0          _L(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
+#define MUX_PB03E_ACIFC_ACBP0           _L(4)
+#define PINMUX_PB03E_ACIFC_ACBP0   ((PIN_PB03E_ACIFC_ACBP0 << 16) | MUX_PB03E_ACIFC_ACBP0)
+#define GPIO_PB03E_ACIFC_ACBP0   _UL(1 <<  3)
+/* ========== GPIO definition for GLOC peripheral ========== */
+#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
+#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L(3)
+#define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
+#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L(3)
+#define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
+#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L(3)
+#define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
+#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L(3)
+#define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
+#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L(3)
+#define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
+#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L(3)
+#define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
+#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L(3)
+#define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
+#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
+#define PIN_PB06C_GLOC_IN4             _L(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
+#define MUX_PB06C_GLOC_IN4              _L(2)
+#define PINMUX_PB06C_GLOC_IN4      ((PIN_PB06C_GLOC_IN4 << 16) | MUX_PB06C_GLOC_IN4)
+#define GPIO_PB06C_GLOC_IN4      _UL(1 <<  6)
+#define PIN_PB07C_GLOC_IN5             _L(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
+#define MUX_PB07C_GLOC_IN5              _L(2)
+#define PINMUX_PB07C_GLOC_IN5      ((PIN_PB07C_GLOC_IN5 << 16) | MUX_PB07C_GLOC_IN5)
+#define GPIO_PB07C_GLOC_IN5      _UL(1 <<  7)
+#define PIN_PB08C_GLOC_IN6             _L(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
+#define MUX_PB08C_GLOC_IN6              _L(2)
+#define PINMUX_PB08C_GLOC_IN6      ((PIN_PB08C_GLOC_IN6 << 16) | MUX_PB08C_GLOC_IN6)
+#define GPIO_PB08C_GLOC_IN6      _UL(1 <<  8)
+#define PIN_PB09C_GLOC_IN7             _L(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
+#define MUX_PB09C_GLOC_IN7              _L(2)
+#define PINMUX_PB09C_GLOC_IN7      ((PIN_PB09C_GLOC_IN7 << 16) | MUX_PB09C_GLOC_IN7)
+#define GPIO_PB09C_GLOC_IN7      _UL(1 <<  9)
+#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
+#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
+#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
+#define PIN_PB10C_GLOC_OUT1            _L(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
+#define MUX_PB10C_GLOC_OUT1             _L(2)
+#define PINMUX_PB10C_GLOC_OUT1     ((PIN_PB10C_GLOC_OUT1 << 16) | MUX_PB10C_GLOC_OUT1)
+#define GPIO_PB10C_GLOC_OUT1     _UL(1 << 10)
+/* ========== GPIO definition for ABDACB peripheral ========== */
+#define PIN_PB02C_ABDACB_DAC0          _L(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
+#define MUX_PB02C_ABDACB_DAC0           _L(2)
+#define PINMUX_PB02C_ABDACB_DAC0   ((PIN_PB02C_ABDACB_DAC0 << 16) | MUX_PB02C_ABDACB_DAC0)
+#define GPIO_PB02C_ABDACB_DAC0   _UL(1 <<  2)
+#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
+#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
+#define PIN_PB04C_ABDACB_DAC1          _L(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
+#define MUX_PB04C_ABDACB_DAC1           _L(2)
+#define PINMUX_PB04C_ABDACB_DAC1   ((PIN_PB04C_ABDACB_DAC1 << 16) | MUX_PB04C_ABDACB_DAC1)
+#define GPIO_PB04C_ABDACB_DAC1   _UL(1 <<  4)
+#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
+#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
+#define PIN_PB03C_ABDACB_DACN0         _L(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
+#define MUX_PB03C_ABDACB_DACN0          _L(2)
+#define PINMUX_PB03C_ABDACB_DACN0  ((PIN_PB03C_ABDACB_DACN0 << 16) | MUX_PB03C_ABDACB_DACN0)
+#define GPIO_PB03C_ABDACB_DACN0  _UL(1 <<  3)
+#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
+#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
+#define PIN_PB05C_ABDACB_DACN1         _L(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
+#define MUX_PB05C_ABDACB_DACN1          _L(2)
+#define PINMUX_PB05C_ABDACB_DACN1  ((PIN_PB05C_ABDACB_DACN1 << 16) | MUX_PB05C_ABDACB_DACN1)
+#define GPIO_PB05C_ABDACB_DACN1  _UL(1 <<  5)
+#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
+#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+/* ========== GPIO definition for PARC peripheral ========== */
+#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
+#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
+#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
+#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
+#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
+#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
+#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
+#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
+#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
+#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
+#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
+#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
+#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
+#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
+#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
+#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
+#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
+#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
+#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
+#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
+#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+/* ========== GPIO definition for CATB peripheral ========== */
+#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L(6)
+#define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
+#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L(6)
+#define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
+#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L(6)
+#define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
+#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
+#define PIN_PB03G_CATB_DIS             _L(35) /**< \brief CATB signal: DIS on PB03 mux G */
+#define MUX_PB03G_CATB_DIS              _L(6)
+#define PINMUX_PB03G_CATB_DIS      ((PIN_PB03G_CATB_DIS << 16) | MUX_PB03G_CATB_DIS)
+#define GPIO_PB03G_CATB_DIS      _UL(1 <<  3)
+#define PIN_PB12G_CATB_DIS             _L(44) /**< \brief CATB signal: DIS on PB12 mux G */
+#define MUX_PB12G_CATB_DIS              _L(6)
+#define PINMUX_PB12G_CATB_DIS      ((PIN_PB12G_CATB_DIS << 16) | MUX_PB12G_CATB_DIS)
+#define GPIO_PB12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
+#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
+#define PIN_PB13G_CATB_SENSE0          _L(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
+#define MUX_PB13G_CATB_SENSE0           _L(6)
+#define PINMUX_PB13G_CATB_SENSE0   ((PIN_PB13G_CATB_SENSE0 << 16) | MUX_PB13G_CATB_SENSE0)
+#define GPIO_PB13G_CATB_SENSE0   _UL(1 << 13)
+#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
+#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
+#define PIN_PB14G_CATB_SENSE1          _L(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
+#define MUX_PB14G_CATB_SENSE1           _L(6)
+#define PINMUX_PB14G_CATB_SENSE1   ((PIN_PB14G_CATB_SENSE1 << 16) | MUX_PB14G_CATB_SENSE1)
+#define GPIO_PB14G_CATB_SENSE1   _UL(1 << 14)
+#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
+#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
+#define PIN_PB15G_CATB_SENSE2          _L(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
+#define MUX_PB15G_CATB_SENSE2           _L(6)
+#define PINMUX_PB15G_CATB_SENSE2   ((PIN_PB15G_CATB_SENSE2 << 16) | MUX_PB15G_CATB_SENSE2)
+#define GPIO_PB15G_CATB_SENSE2   _UL(1 << 15)
+#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
+#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
+#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
+#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
+#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
+#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
+#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
+#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
+#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
+#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
+#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
+#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
+#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
+#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
+#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
+#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
+#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
+#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
+#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
+#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
+#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
+#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
+#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
+#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
+#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
+#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
+#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
+#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
+#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
+#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
+#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
+#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
+#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
+#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
+#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
+#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
+#define PIN_PB00G_CATB_SENSE21         _L(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
+#define MUX_PB00G_CATB_SENSE21          _L(6)
+#define PINMUX_PB00G_CATB_SENSE21  ((PIN_PB00G_CATB_SENSE21 << 16) | MUX_PB00G_CATB_SENSE21)
+#define GPIO_PB00G_CATB_SENSE21  _UL(1 <<  0)
+#define PIN_PB01G_CATB_SENSE22         _L(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
+#define MUX_PB01G_CATB_SENSE22          _L(6)
+#define PINMUX_PB01G_CATB_SENSE22  ((PIN_PB01G_CATB_SENSE22 << 16) | MUX_PB01G_CATB_SENSE22)
+#define GPIO_PB01G_CATB_SENSE22  _UL(1 <<  1)
+#define PIN_PB02G_CATB_SENSE23         _L(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
+#define MUX_PB02G_CATB_SENSE23          _L(6)
+#define PINMUX_PB02G_CATB_SENSE23  ((PIN_PB02G_CATB_SENSE23 << 16) | MUX_PB02G_CATB_SENSE23)
+#define GPIO_PB02G_CATB_SENSE23  _UL(1 <<  2)
+#define PIN_PB04G_CATB_SENSE24         _L(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
+#define MUX_PB04G_CATB_SENSE24          _L(6)
+#define PINMUX_PB04G_CATB_SENSE24  ((PIN_PB04G_CATB_SENSE24 << 16) | MUX_PB04G_CATB_SENSE24)
+#define GPIO_PB04G_CATB_SENSE24  _UL(1 <<  4)
+#define PIN_PB05G_CATB_SENSE25         _L(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
+#define MUX_PB05G_CATB_SENSE25          _L(6)
+#define PINMUX_PB05G_CATB_SENSE25  ((PIN_PB05G_CATB_SENSE25 << 16) | MUX_PB05G_CATB_SENSE25)
+#define GPIO_PB05G_CATB_SENSE25  _UL(1 <<  5)
+#define PIN_PB06G_CATB_SENSE26         _L(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
+#define MUX_PB06G_CATB_SENSE26          _L(6)
+#define PINMUX_PB06G_CATB_SENSE26  ((PIN_PB06G_CATB_SENSE26 << 16) | MUX_PB06G_CATB_SENSE26)
+#define GPIO_PB06G_CATB_SENSE26  _UL(1 <<  6)
+#define PIN_PB07G_CATB_SENSE27         _L(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
+#define MUX_PB07G_CATB_SENSE27          _L(6)
+#define PINMUX_PB07G_CATB_SENSE27  ((PIN_PB07G_CATB_SENSE27 << 16) | MUX_PB07G_CATB_SENSE27)
+#define GPIO_PB07G_CATB_SENSE27  _UL(1 <<  7)
+#define PIN_PB08G_CATB_SENSE28         _L(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
+#define MUX_PB08G_CATB_SENSE28          _L(6)
+#define PINMUX_PB08G_CATB_SENSE28  ((PIN_PB08G_CATB_SENSE28 << 16) | MUX_PB08G_CATB_SENSE28)
+#define GPIO_PB08G_CATB_SENSE28  _UL(1 <<  8)
+#define PIN_PB09G_CATB_SENSE29         _L(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
+#define MUX_PB09G_CATB_SENSE29          _L(6)
+#define PINMUX_PB09G_CATB_SENSE29  ((PIN_PB09G_CATB_SENSE29 << 16) | MUX_PB09G_CATB_SENSE29)
+#define GPIO_PB09G_CATB_SENSE29  _UL(1 <<  9)
+#define PIN_PB10G_CATB_SENSE30         _L(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
+#define MUX_PB10G_CATB_SENSE30          _L(6)
+#define PINMUX_PB10G_CATB_SENSE30  ((PIN_PB10G_CATB_SENSE30 << 16) | MUX_PB10G_CATB_SENSE30)
+#define GPIO_PB10G_CATB_SENSE30  _UL(1 << 10)
+#define PIN_PB11G_CATB_SENSE31         _L(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
+#define MUX_PB11G_CATB_SENSE31          _L(6)
+#define PINMUX_PB11G_CATB_SENSE31  ((PIN_PB11G_CATB_SENSE31 << 16) | MUX_PB11G_CATB_SENSE31)
+#define GPIO_PB11G_CATB_SENSE31  _UL(1 << 11)
+/* ========== GPIO definition for LCDCA peripheral ========== */
+#define PIN_PA12F_LCDCA_COM0           _L(12) /**< \brief LCDCA signal: COM0 on PA12 mux F */
+#define MUX_PA12F_LCDCA_COM0            _L(5)
+#define PINMUX_PA12F_LCDCA_COM0    ((PIN_PA12F_LCDCA_COM0 << 16) | MUX_PA12F_LCDCA_COM0)
+#define GPIO_PA12F_LCDCA_COM0    _UL(1 << 12)
+#define PIN_PA11F_LCDCA_COM1           _L(11) /**< \brief LCDCA signal: COM1 on PA11 mux F */
+#define MUX_PA11F_LCDCA_COM1            _L(5)
+#define PINMUX_PA11F_LCDCA_COM1    ((PIN_PA11F_LCDCA_COM1 << 16) | MUX_PA11F_LCDCA_COM1)
+#define GPIO_PA11F_LCDCA_COM1    _UL(1 << 11)
+#define PIN_PA10F_LCDCA_COM2           _L(10) /**< \brief LCDCA signal: COM2 on PA10 mux F */
+#define MUX_PA10F_LCDCA_COM2            _L(5)
+#define PINMUX_PA10F_LCDCA_COM2    ((PIN_PA10F_LCDCA_COM2 << 16) | MUX_PA10F_LCDCA_COM2)
+#define GPIO_PA10F_LCDCA_COM2    _UL(1 << 10)
+#define PIN_PA09F_LCDCA_COM3            _L(9) /**< \brief LCDCA signal: COM3 on PA09 mux F */
+#define MUX_PA09F_LCDCA_COM3            _L(5)
+#define PINMUX_PA09F_LCDCA_COM3    ((PIN_PA09F_LCDCA_COM3 << 16) | MUX_PA09F_LCDCA_COM3)
+#define GPIO_PA09F_LCDCA_COM3    _UL(1 <<  9)
+#define PIN_PA13F_LCDCA_SEG5           _L(13) /**< \brief LCDCA signal: SEG5 on PA13 mux F */
+#define MUX_PA13F_LCDCA_SEG5            _L(5)
+#define PINMUX_PA13F_LCDCA_SEG5    ((PIN_PA13F_LCDCA_SEG5 << 16) | MUX_PA13F_LCDCA_SEG5)
+#define GPIO_PA13F_LCDCA_SEG5    _UL(1 << 13)
+#define PIN_PA14F_LCDCA_SEG6           _L(14) /**< \brief LCDCA signal: SEG6 on PA14 mux F */
+#define MUX_PA14F_LCDCA_SEG6            _L(5)
+#define PINMUX_PA14F_LCDCA_SEG6    ((PIN_PA14F_LCDCA_SEG6 << 16) | MUX_PA14F_LCDCA_SEG6)
+#define GPIO_PA14F_LCDCA_SEG6    _UL(1 << 14)
+#define PIN_PA15F_LCDCA_SEG7           _L(15) /**< \brief LCDCA signal: SEG7 on PA15 mux F */
+#define MUX_PA15F_LCDCA_SEG7            _L(5)
+#define PINMUX_PA15F_LCDCA_SEG7    ((PIN_PA15F_LCDCA_SEG7 << 16) | MUX_PA15F_LCDCA_SEG7)
+#define GPIO_PA15F_LCDCA_SEG7    _UL(1 << 15)
+#define PIN_PA16F_LCDCA_SEG8           _L(16) /**< \brief LCDCA signal: SEG8 on PA16 mux F */
+#define MUX_PA16F_LCDCA_SEG8            _L(5)
+#define PINMUX_PA16F_LCDCA_SEG8    ((PIN_PA16F_LCDCA_SEG8 << 16) | MUX_PA16F_LCDCA_SEG8)
+#define GPIO_PA16F_LCDCA_SEG8    _UL(1 << 16)
+#define PIN_PA17F_LCDCA_SEG9           _L(17) /**< \brief LCDCA signal: SEG9 on PA17 mux F */
+#define MUX_PA17F_LCDCA_SEG9            _L(5)
+#define PINMUX_PA17F_LCDCA_SEG9    ((PIN_PA17F_LCDCA_SEG9 << 16) | MUX_PA17F_LCDCA_SEG9)
+#define GPIO_PA17F_LCDCA_SEG9    _UL(1 << 17)
+#define PIN_PB08F_LCDCA_SEG14          _L(40) /**< \brief LCDCA signal: SEG14 on PB08 mux F */
+#define MUX_PB08F_LCDCA_SEG14           _L(5)
+#define PINMUX_PB08F_LCDCA_SEG14   ((PIN_PB08F_LCDCA_SEG14 << 16) | MUX_PB08F_LCDCA_SEG14)
+#define GPIO_PB08F_LCDCA_SEG14   _UL(1 <<  8)
+#define PIN_PB09F_LCDCA_SEG15          _L(41) /**< \brief LCDCA signal: SEG15 on PB09 mux F */
+#define MUX_PB09F_LCDCA_SEG15           _L(5)
+#define PINMUX_PB09F_LCDCA_SEG15   ((PIN_PB09F_LCDCA_SEG15 << 16) | MUX_PB09F_LCDCA_SEG15)
+#define GPIO_PB09F_LCDCA_SEG15   _UL(1 <<  9)
+#define PIN_PB10F_LCDCA_SEG16          _L(42) /**< \brief LCDCA signal: SEG16 on PB10 mux F */
+#define MUX_PB10F_LCDCA_SEG16           _L(5)
+#define PINMUX_PB10F_LCDCA_SEG16   ((PIN_PB10F_LCDCA_SEG16 << 16) | MUX_PB10F_LCDCA_SEG16)
+#define GPIO_PB10F_LCDCA_SEG16   _UL(1 << 10)
+#define PIN_PB11F_LCDCA_SEG17          _L(43) /**< \brief LCDCA signal: SEG17 on PB11 mux F */
+#define MUX_PB11F_LCDCA_SEG17           _L(5)
+#define PINMUX_PB11F_LCDCA_SEG17   ((PIN_PB11F_LCDCA_SEG17 << 16) | MUX_PB11F_LCDCA_SEG17)
+#define GPIO_PB11F_LCDCA_SEG17   _UL(1 << 11)
+#define PIN_PA18F_LCDCA_SEG18          _L(18) /**< \brief LCDCA signal: SEG18 on PA18 mux F */
+#define MUX_PA18F_LCDCA_SEG18           _L(5)
+#define PINMUX_PA18F_LCDCA_SEG18   ((PIN_PA18F_LCDCA_SEG18 << 16) | MUX_PA18F_LCDCA_SEG18)
+#define GPIO_PA18F_LCDCA_SEG18   _UL(1 << 18)
+#define PIN_PA19F_LCDCA_SEG19          _L(19) /**< \brief LCDCA signal: SEG19 on PA19 mux F */
+#define MUX_PA19F_LCDCA_SEG19           _L(5)
+#define PINMUX_PA19F_LCDCA_SEG19   ((PIN_PA19F_LCDCA_SEG19 << 16) | MUX_PA19F_LCDCA_SEG19)
+#define GPIO_PA19F_LCDCA_SEG19   _UL(1 << 19)
+#define PIN_PA20F_LCDCA_SEG20          _L(20) /**< \brief LCDCA signal: SEG20 on PA20 mux F */
+#define MUX_PA20F_LCDCA_SEG20           _L(5)
+#define PINMUX_PA20F_LCDCA_SEG20   ((PIN_PA20F_LCDCA_SEG20 << 16) | MUX_PA20F_LCDCA_SEG20)
+#define GPIO_PA20F_LCDCA_SEG20   _UL(1 << 20)
+#define PIN_PB07F_LCDCA_SEG21          _L(39) /**< \brief LCDCA signal: SEG21 on PB07 mux F */
+#define MUX_PB07F_LCDCA_SEG21           _L(5)
+#define PINMUX_PB07F_LCDCA_SEG21   ((PIN_PB07F_LCDCA_SEG21 << 16) | MUX_PB07F_LCDCA_SEG21)
+#define GPIO_PB07F_LCDCA_SEG21   _UL(1 <<  7)
+#define PIN_PB06F_LCDCA_SEG22          _L(38) /**< \brief LCDCA signal: SEG22 on PB06 mux F */
+#define MUX_PB06F_LCDCA_SEG22           _L(5)
+#define PINMUX_PB06F_LCDCA_SEG22   ((PIN_PB06F_LCDCA_SEG22 << 16) | MUX_PB06F_LCDCA_SEG22)
+#define GPIO_PB06F_LCDCA_SEG22   _UL(1 <<  6)
+#define PIN_PA08F_LCDCA_SEG23           _L(8) /**< \brief LCDCA signal: SEG23 on PA08 mux F */
+#define MUX_PA08F_LCDCA_SEG23           _L(5)
+#define PINMUX_PA08F_LCDCA_SEG23   ((PIN_PA08F_LCDCA_SEG23 << 16) | MUX_PA08F_LCDCA_SEG23)
+#define GPIO_PA08F_LCDCA_SEG23   _UL(1 <<  8)
+#define PIN_PB12F_LCDCA_SEG32          _L(44) /**< \brief LCDCA signal: SEG32 on PB12 mux F */
+#define MUX_PB12F_LCDCA_SEG32           _L(5)
+#define PINMUX_PB12F_LCDCA_SEG32   ((PIN_PB12F_LCDCA_SEG32 << 16) | MUX_PB12F_LCDCA_SEG32)
+#define GPIO_PB12F_LCDCA_SEG32   _UL(1 << 12)
+#define PIN_PB13F_LCDCA_SEG33          _L(45) /**< \brief LCDCA signal: SEG33 on PB13 mux F */
+#define MUX_PB13F_LCDCA_SEG33           _L(5)
+#define PINMUX_PB13F_LCDCA_SEG33   ((PIN_PB13F_LCDCA_SEG33 << 16) | MUX_PB13F_LCDCA_SEG33)
+#define GPIO_PB13F_LCDCA_SEG33   _UL(1 << 13)
+#define PIN_PA21F_LCDCA_SEG34          _L(21) /**< \brief LCDCA signal: SEG34 on PA21 mux F */
+#define MUX_PA21F_LCDCA_SEG34           _L(5)
+#define PINMUX_PA21F_LCDCA_SEG34   ((PIN_PA21F_LCDCA_SEG34 << 16) | MUX_PA21F_LCDCA_SEG34)
+#define GPIO_PA21F_LCDCA_SEG34   _UL(1 << 21)
+#define PIN_PA22F_LCDCA_SEG35          _L(22) /**< \brief LCDCA signal: SEG35 on PA22 mux F */
+#define MUX_PA22F_LCDCA_SEG35           _L(5)
+#define PINMUX_PA22F_LCDCA_SEG35   ((PIN_PA22F_LCDCA_SEG35 << 16) | MUX_PA22F_LCDCA_SEG35)
+#define GPIO_PA22F_LCDCA_SEG35   _UL(1 << 22)
+#define PIN_PB14F_LCDCA_SEG36          _L(46) /**< \brief LCDCA signal: SEG36 on PB14 mux F */
+#define MUX_PB14F_LCDCA_SEG36           _L(5)
+#define PINMUX_PB14F_LCDCA_SEG36   ((PIN_PB14F_LCDCA_SEG36 << 16) | MUX_PB14F_LCDCA_SEG36)
+#define GPIO_PB14F_LCDCA_SEG36   _UL(1 << 14)
+#define PIN_PB15F_LCDCA_SEG37          _L(47) /**< \brief LCDCA signal: SEG37 on PB15 mux F */
+#define MUX_PB15F_LCDCA_SEG37           _L(5)
+#define PINMUX_PB15F_LCDCA_SEG37   ((PIN_PB15F_LCDCA_SEG37 << 16) | MUX_PB15F_LCDCA_SEG37)
+#define GPIO_PB15F_LCDCA_SEG37   _UL(1 << 15)
+#define PIN_PA23F_LCDCA_SEG38          _L(23) /**< \brief LCDCA signal: SEG38 on PA23 mux F */
+#define MUX_PA23F_LCDCA_SEG38           _L(5)
+#define PINMUX_PA23F_LCDCA_SEG38   ((PIN_PA23F_LCDCA_SEG38 << 16) | MUX_PA23F_LCDCA_SEG38)
+#define GPIO_PA23F_LCDCA_SEG38   _UL(1 << 23)
+#define PIN_PA24F_LCDCA_SEG39          _L(24) /**< \brief LCDCA signal: SEG39 on PA24 mux F */
+#define MUX_PA24F_LCDCA_SEG39           _L(5)
+#define PINMUX_PA24F_LCDCA_SEG39   ((PIN_PA24F_LCDCA_SEG39 << 16) | MUX_PA24F_LCDCA_SEG39)
+#define GPIO_PA24F_LCDCA_SEG39   _UL(1 << 24)
+/* ========== GPIO definition for USBC peripheral ========== */
+#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L(0)
+#define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
+#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
+#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L(0)
+#define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
+#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+/* ========== GPIO definition for PEVC peripheral ========== */
+#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
+#define PIN_PB12C_PEVC_PAD_EVT0        _L(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
+#define MUX_PB12C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PB12C_PEVC_PAD_EVT0  ((PIN_PB12C_PEVC_PAD_EVT0 << 16) | MUX_PB12C_PEVC_PAD_EVT0)
+#define GPIO_PB12C_PEVC_PAD_EVT0  _UL(1 << 12)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
+#define PIN_PB13C_PEVC_PAD_EVT1        _L(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
+#define MUX_PB13C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PB13C_PEVC_PAD_EVT1  ((PIN_PB13C_PEVC_PAD_EVT1 << 16) | MUX_PB13C_PEVC_PAD_EVT1)
+#define GPIO_PB13C_PEVC_PAD_EVT1  _UL(1 << 13)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
+#define PIN_PB09B_PEVC_PAD_EVT2        _L(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
+#define MUX_PB09B_PEVC_PAD_EVT2         _L(1)
+#define PINMUX_PB09B_PEVC_PAD_EVT2  ((PIN_PB09B_PEVC_PAD_EVT2 << 16) | MUX_PB09B_PEVC_PAD_EVT2)
+#define GPIO_PB09B_PEVC_PAD_EVT2  _UL(1 <<  9)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
+#define PIN_PB10B_PEVC_PAD_EVT3        _L(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
+#define MUX_PB10B_PEVC_PAD_EVT3         _L(1)
+#define PINMUX_PB10B_PEVC_PAD_EVT3  ((PIN_PB10B_PEVC_PAD_EVT3 << 16) | MUX_PB10B_PEVC_PAD_EVT3)
+#define GPIO_PB10B_PEVC_PAD_EVT3  _UL(1 << 10)
+/* ========== GPIO definition for SCIF peripheral ========== */
+#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
+#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
+#define PIN_PB10E_SCIF_GCLK0           _L(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
+#define MUX_PB10E_SCIF_GCLK0            _L(4)
+#define PINMUX_PB10E_SCIF_GCLK0    ((PIN_PB10E_SCIF_GCLK0 << 16) | MUX_PB10E_SCIF_GCLK0)
+#define GPIO_PB10E_SCIF_GCLK0    _UL(1 << 10)
+#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
+#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
+#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
+#define PIN_PB11E_SCIF_GCLK1           _L(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
+#define MUX_PB11E_SCIF_GCLK1            _L(4)
+#define PINMUX_PB11E_SCIF_GCLK1    ((PIN_PB11E_SCIF_GCLK1 << 16) | MUX_PB11E_SCIF_GCLK1)
+#define GPIO_PB11E_SCIF_GCLK1    _UL(1 << 11)
+#define PIN_PB12E_SCIF_GCLK2           _L(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
+#define MUX_PB12E_SCIF_GCLK2            _L(4)
+#define PINMUX_PB12E_SCIF_GCLK2    ((PIN_PB12E_SCIF_GCLK2 << 16) | MUX_PB12E_SCIF_GCLK2)
+#define GPIO_PB12E_SCIF_GCLK2    _UL(1 << 12)
+#define PIN_PB13E_SCIF_GCLK3           _L(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
+#define MUX_PB13E_SCIF_GCLK3            _L(4)
+#define PINMUX_PB13E_SCIF_GCLK3    ((PIN_PB13E_SCIF_GCLK3 << 16) | MUX_PB13E_SCIF_GCLK3)
+#define GPIO_PB13E_SCIF_GCLK3    _UL(1 << 13)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
+#define PIN_PB14E_SCIF_GCLK_IN0        _L(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
+#define MUX_PB14E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PB14E_SCIF_GCLK_IN0  ((PIN_PB14E_SCIF_GCLK_IN0 << 16) | MUX_PB14E_SCIF_GCLK_IN0)
+#define GPIO_PB14E_SCIF_GCLK_IN0  _UL(1 << 14)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
+#define PIN_PB15E_SCIF_GCLK_IN1        _L(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
+#define MUX_PB15E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PB15E_SCIF_GCLK_IN1  ((PIN_PB15E_SCIF_GCLK_IN1 << 16) | MUX_PB15E_SCIF_GCLK_IN1)
+#define GPIO_PB15E_SCIF_GCLK_IN1  _UL(1 << 15)
+/* ========== GPIO definition for EIC peripheral ========== */
+#define PIN_PB01C_EIC_EXTINT0          _L(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
+#define MUX_PB01C_EIC_EXTINT0           _L(2)
+#define PINMUX_PB01C_EIC_EXTINT0   ((PIN_PB01C_EIC_EXTINT0 << 16) | MUX_PB01C_EIC_EXTINT0)
+#define GPIO_PB01C_EIC_EXTINT0   _UL(1 <<  1)
+#define PIN_PB01C_EIC_EXTINT_NUM        _L(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
+#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
+#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
+#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
+#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
+#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
+#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
+#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
+#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
+#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
+#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+
+#endif /* _SAM4LC2B_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4lc2c.h
+++ b/asf/sam/include/sam4l/pio/sam4lc2c.h
@@ -30,1775 +30,1775 @@
 #define _SAM4LC2C_PIO_
 
 #define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
-#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define GPIO_PA00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PA00 */
 #define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
-#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define GPIO_PA01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PA01 */
 #define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
-#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define GPIO_PA02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PA02 */
 #define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
-#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define GPIO_PA03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PA03 */
 #define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
-#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define GPIO_PA04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PA04 */
 #define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
-#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define GPIO_PA05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PA05 */
 #define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
-#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define GPIO_PA06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PA06 */
 #define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
-#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define GPIO_PA07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PA07 */
 #define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
-#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define GPIO_PA08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PA08 */
 #define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
-#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define GPIO_PA09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PA09 */
 #define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
-#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define GPIO_PA10                _UL_(1 << 10) /**< \brief GPIO Mask  for PA10 */
 #define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
-#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define GPIO_PA11                _UL_(1 << 11) /**< \brief GPIO Mask  for PA11 */
 #define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
-#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define GPIO_PA12                _UL_(1 << 12) /**< \brief GPIO Mask  for PA12 */
 #define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
-#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define GPIO_PA13                _UL_(1 << 13) /**< \brief GPIO Mask  for PA13 */
 #define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
-#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define GPIO_PA14                _UL_(1 << 14) /**< \brief GPIO Mask  for PA14 */
 #define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
-#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define GPIO_PA15                _UL_(1 << 15) /**< \brief GPIO Mask  for PA15 */
 #define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
-#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define GPIO_PA16                _UL_(1 << 16) /**< \brief GPIO Mask  for PA16 */
 #define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
-#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define GPIO_PA17                _UL_(1 << 17) /**< \brief GPIO Mask  for PA17 */
 #define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
-#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define GPIO_PA18                _UL_(1 << 18) /**< \brief GPIO Mask  for PA18 */
 #define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
-#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define GPIO_PA19                _UL_(1 << 19) /**< \brief GPIO Mask  for PA19 */
 #define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
-#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define GPIO_PA20                _UL_(1 << 20) /**< \brief GPIO Mask  for PA20 */
 #define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
-#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define GPIO_PA21                _UL_(1 << 21) /**< \brief GPIO Mask  for PA21 */
 #define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
-#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define GPIO_PA22                _UL_(1 << 22) /**< \brief GPIO Mask  for PA22 */
 #define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
-#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define GPIO_PA23                _UL_(1 << 23) /**< \brief GPIO Mask  for PA23 */
 #define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
-#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define GPIO_PA24                _UL_(1 << 24) /**< \brief GPIO Mask  for PA24 */
 #define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
-#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define GPIO_PA25                _UL_(1 << 25) /**< \brief GPIO Mask  for PA25 */
 #define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
-#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define GPIO_PA26                _UL_(1 << 26) /**< \brief GPIO Mask  for PA26 */
 #define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
-#define GPIO_PB00                _UL(1 <<  0) /**< \brief GPIO Mask  for PB00 */
+#define GPIO_PB00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PB00 */
 #define PIN_PB01                          33  /**< \brief Pin Number for PB01 */
-#define GPIO_PB01                _UL(1 <<  1) /**< \brief GPIO Mask  for PB01 */
+#define GPIO_PB01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PB01 */
 #define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
-#define GPIO_PB02                _UL(1 <<  2) /**< \brief GPIO Mask  for PB02 */
+#define GPIO_PB02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PB02 */
 #define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
-#define GPIO_PB03                _UL(1 <<  3) /**< \brief GPIO Mask  for PB03 */
+#define GPIO_PB03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PB03 */
 #define PIN_PB04                          36  /**< \brief Pin Number for PB04 */
-#define GPIO_PB04                _UL(1 <<  4) /**< \brief GPIO Mask  for PB04 */
+#define GPIO_PB04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PB04 */
 #define PIN_PB05                          37  /**< \brief Pin Number for PB05 */
-#define GPIO_PB05                _UL(1 <<  5) /**< \brief GPIO Mask  for PB05 */
+#define GPIO_PB05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PB05 */
 #define PIN_PB06                          38  /**< \brief Pin Number for PB06 */
-#define GPIO_PB06                _UL(1 <<  6) /**< \brief GPIO Mask  for PB06 */
+#define GPIO_PB06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PB06 */
 #define PIN_PB07                          39  /**< \brief Pin Number for PB07 */
-#define GPIO_PB07                _UL(1 <<  7) /**< \brief GPIO Mask  for PB07 */
+#define GPIO_PB07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PB07 */
 #define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
-#define GPIO_PB08                _UL(1 <<  8) /**< \brief GPIO Mask  for PB08 */
+#define GPIO_PB08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PB08 */
 #define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
-#define GPIO_PB09                _UL(1 <<  9) /**< \brief GPIO Mask  for PB09 */
+#define GPIO_PB09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PB09 */
 #define PIN_PB10                          42  /**< \brief Pin Number for PB10 */
-#define GPIO_PB10                _UL(1 << 10) /**< \brief GPIO Mask  for PB10 */
+#define GPIO_PB10                _UL_(1 << 10) /**< \brief GPIO Mask  for PB10 */
 #define PIN_PB11                          43  /**< \brief Pin Number for PB11 */
-#define GPIO_PB11                _UL(1 << 11) /**< \brief GPIO Mask  for PB11 */
+#define GPIO_PB11                _UL_(1 << 11) /**< \brief GPIO Mask  for PB11 */
 #define PIN_PB12                          44  /**< \brief Pin Number for PB12 */
-#define GPIO_PB12                _UL(1 << 12) /**< \brief GPIO Mask  for PB12 */
+#define GPIO_PB12                _UL_(1 << 12) /**< \brief GPIO Mask  for PB12 */
 #define PIN_PB13                          45  /**< \brief Pin Number for PB13 */
-#define GPIO_PB13                _UL(1 << 13) /**< \brief GPIO Mask  for PB13 */
+#define GPIO_PB13                _UL_(1 << 13) /**< \brief GPIO Mask  for PB13 */
 #define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
-#define GPIO_PB14                _UL(1 << 14) /**< \brief GPIO Mask  for PB14 */
+#define GPIO_PB14                _UL_(1 << 14) /**< \brief GPIO Mask  for PB14 */
 #define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
-#define GPIO_PB15                _UL(1 << 15) /**< \brief GPIO Mask  for PB15 */
+#define GPIO_PB15                _UL_(1 << 15) /**< \brief GPIO Mask  for PB15 */
 #define PIN_PC00                          64  /**< \brief Pin Number for PC00 */
-#define GPIO_PC00                _UL(1 <<  0) /**< \brief GPIO Mask  for PC00 */
+#define GPIO_PC00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PC00 */
 #define PIN_PC01                          65  /**< \brief Pin Number for PC01 */
-#define GPIO_PC01                _UL(1 <<  1) /**< \brief GPIO Mask  for PC01 */
+#define GPIO_PC01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PC01 */
 #define PIN_PC02                          66  /**< \brief Pin Number for PC02 */
-#define GPIO_PC02                _UL(1 <<  2) /**< \brief GPIO Mask  for PC02 */
+#define GPIO_PC02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PC02 */
 #define PIN_PC03                          67  /**< \brief Pin Number for PC03 */
-#define GPIO_PC03                _UL(1 <<  3) /**< \brief GPIO Mask  for PC03 */
+#define GPIO_PC03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PC03 */
 #define PIN_PC04                          68  /**< \brief Pin Number for PC04 */
-#define GPIO_PC04                _UL(1 <<  4) /**< \brief GPIO Mask  for PC04 */
+#define GPIO_PC04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PC04 */
 #define PIN_PC05                          69  /**< \brief Pin Number for PC05 */
-#define GPIO_PC05                _UL(1 <<  5) /**< \brief GPIO Mask  for PC05 */
+#define GPIO_PC05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PC05 */
 #define PIN_PC06                          70  /**< \brief Pin Number for PC06 */
-#define GPIO_PC06                _UL(1 <<  6) /**< \brief GPIO Mask  for PC06 */
+#define GPIO_PC06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PC06 */
 #define PIN_PC07                          71  /**< \brief Pin Number for PC07 */
-#define GPIO_PC07                _UL(1 <<  7) /**< \brief GPIO Mask  for PC07 */
+#define GPIO_PC07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PC07 */
 #define PIN_PC08                          72  /**< \brief Pin Number for PC08 */
-#define GPIO_PC08                _UL(1 <<  8) /**< \brief GPIO Mask  for PC08 */
+#define GPIO_PC08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PC08 */
 #define PIN_PC09                          73  /**< \brief Pin Number for PC09 */
-#define GPIO_PC09                _UL(1 <<  9) /**< \brief GPIO Mask  for PC09 */
+#define GPIO_PC09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PC09 */
 #define PIN_PC10                          74  /**< \brief Pin Number for PC10 */
-#define GPIO_PC10                _UL(1 << 10) /**< \brief GPIO Mask  for PC10 */
+#define GPIO_PC10                _UL_(1 << 10) /**< \brief GPIO Mask  for PC10 */
 #define PIN_PC11                          75  /**< \brief Pin Number for PC11 */
-#define GPIO_PC11                _UL(1 << 11) /**< \brief GPIO Mask  for PC11 */
+#define GPIO_PC11                _UL_(1 << 11) /**< \brief GPIO Mask  for PC11 */
 #define PIN_PC12                          76  /**< \brief Pin Number for PC12 */
-#define GPIO_PC12                _UL(1 << 12) /**< \brief GPIO Mask  for PC12 */
+#define GPIO_PC12                _UL_(1 << 12) /**< \brief GPIO Mask  for PC12 */
 #define PIN_PC13                          77  /**< \brief Pin Number for PC13 */
-#define GPIO_PC13                _UL(1 << 13) /**< \brief GPIO Mask  for PC13 */
+#define GPIO_PC13                _UL_(1 << 13) /**< \brief GPIO Mask  for PC13 */
 #define PIN_PC14                          78  /**< \brief Pin Number for PC14 */
-#define GPIO_PC14                _UL(1 << 14) /**< \brief GPIO Mask  for PC14 */
+#define GPIO_PC14                _UL_(1 << 14) /**< \brief GPIO Mask  for PC14 */
 #define PIN_PC15                          79  /**< \brief Pin Number for PC15 */
-#define GPIO_PC15                _UL(1 << 15) /**< \brief GPIO Mask  for PC15 */
+#define GPIO_PC15                _UL_(1 << 15) /**< \brief GPIO Mask  for PC15 */
 #define PIN_PC16                          80  /**< \brief Pin Number for PC16 */
-#define GPIO_PC16                _UL(1 << 16) /**< \brief GPIO Mask  for PC16 */
+#define GPIO_PC16                _UL_(1 << 16) /**< \brief GPIO Mask  for PC16 */
 #define PIN_PC17                          81  /**< \brief Pin Number for PC17 */
-#define GPIO_PC17                _UL(1 << 17) /**< \brief GPIO Mask  for PC17 */
+#define GPIO_PC17                _UL_(1 << 17) /**< \brief GPIO Mask  for PC17 */
 #define PIN_PC18                          82  /**< \brief Pin Number for PC18 */
-#define GPIO_PC18                _UL(1 << 18) /**< \brief GPIO Mask  for PC18 */
+#define GPIO_PC18                _UL_(1 << 18) /**< \brief GPIO Mask  for PC18 */
 #define PIN_PC19                          83  /**< \brief Pin Number for PC19 */
-#define GPIO_PC19                _UL(1 << 19) /**< \brief GPIO Mask  for PC19 */
+#define GPIO_PC19                _UL_(1 << 19) /**< \brief GPIO Mask  for PC19 */
 #define PIN_PC20                          84  /**< \brief Pin Number for PC20 */
-#define GPIO_PC20                _UL(1 << 20) /**< \brief GPIO Mask  for PC20 */
+#define GPIO_PC20                _UL_(1 << 20) /**< \brief GPIO Mask  for PC20 */
 #define PIN_PC21                          85  /**< \brief Pin Number for PC21 */
-#define GPIO_PC21                _UL(1 << 21) /**< \brief GPIO Mask  for PC21 */
+#define GPIO_PC21                _UL_(1 << 21) /**< \brief GPIO Mask  for PC21 */
 #define PIN_PC22                          86  /**< \brief Pin Number for PC22 */
-#define GPIO_PC22                _UL(1 << 22) /**< \brief GPIO Mask  for PC22 */
+#define GPIO_PC22                _UL_(1 << 22) /**< \brief GPIO Mask  for PC22 */
 #define PIN_PC23                          87  /**< \brief Pin Number for PC23 */
-#define GPIO_PC23                _UL(1 << 23) /**< \brief GPIO Mask  for PC23 */
+#define GPIO_PC23                _UL_(1 << 23) /**< \brief GPIO Mask  for PC23 */
 #define PIN_PC24                          88  /**< \brief Pin Number for PC24 */
-#define GPIO_PC24                _UL(1 << 24) /**< \brief GPIO Mask  for PC24 */
+#define GPIO_PC24                _UL_(1 << 24) /**< \brief GPIO Mask  for PC24 */
 #define PIN_PC25                          89  /**< \brief Pin Number for PC25 */
-#define GPIO_PC25                _UL(1 << 25) /**< \brief GPIO Mask  for PC25 */
+#define GPIO_PC25                _UL_(1 << 25) /**< \brief GPIO Mask  for PC25 */
 #define PIN_PC26                          90  /**< \brief Pin Number for PC26 */
-#define GPIO_PC26                _UL(1 << 26) /**< \brief GPIO Mask  for PC26 */
+#define GPIO_PC26                _UL_(1 << 26) /**< \brief GPIO Mask  for PC26 */
 #define PIN_PC27                          91  /**< \brief Pin Number for PC27 */
-#define GPIO_PC27                _UL(1 << 27) /**< \brief GPIO Mask  for PC27 */
+#define GPIO_PC27                _UL_(1 << 27) /**< \brief GPIO Mask  for PC27 */
 #define PIN_PC28                          92  /**< \brief Pin Number for PC28 */
-#define GPIO_PC28                _UL(1 << 28) /**< \brief GPIO Mask  for PC28 */
+#define GPIO_PC28                _UL_(1 << 28) /**< \brief GPIO Mask  for PC28 */
 #define PIN_PC29                          93  /**< \brief Pin Number for PC29 */
-#define GPIO_PC29                _UL(1 << 29) /**< \brief GPIO Mask  for PC29 */
+#define GPIO_PC29                _UL_(1 << 29) /**< \brief GPIO Mask  for PC29 */
 #define PIN_PC30                          94  /**< \brief Pin Number for PC30 */
-#define GPIO_PC30                _UL(1 << 30) /**< \brief GPIO Mask  for PC30 */
+#define GPIO_PC30                _UL_(1 << 30) /**< \brief GPIO Mask  for PC30 */
 #define PIN_PC31                          95  /**< \brief Pin Number for PC31 */
-#define GPIO_PC31                _UL(1 << 31) /**< \brief GPIO Mask  for PC31 */
+#define GPIO_PC31                _UL_(1 << 31) /**< \brief GPIO Mask  for PC31 */
 /* ========== GPIO definition for TWIMS0 peripheral ========== */
-#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
-#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PIN_PA24B_TWIMS0_TWCK          _L_(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L_(1)
 #define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
-#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
-#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
-#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL_(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L_(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L_(1)
 #define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
-#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+#define GPIO_PA23B_TWIMS0_TWD    _UL_(1 << 23)
 /* ========== GPIO definition for TWIMS1 peripheral ========== */
-#define PIN_PB01A_TWIMS1_TWCK          _L(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
-#define MUX_PB01A_TWIMS1_TWCK           _L(0)
+#define PIN_PB01A_TWIMS1_TWCK          _L_(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
+#define MUX_PB01A_TWIMS1_TWCK           _L_(0)
 #define PINMUX_PB01A_TWIMS1_TWCK   ((PIN_PB01A_TWIMS1_TWCK << 16) | MUX_PB01A_TWIMS1_TWCK)
-#define GPIO_PB01A_TWIMS1_TWCK   _UL(1 <<  1)
-#define PIN_PB00A_TWIMS1_TWD           _L(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
-#define MUX_PB00A_TWIMS1_TWD            _L(0)
+#define GPIO_PB01A_TWIMS1_TWCK   _UL_(1 <<  1)
+#define PIN_PB00A_TWIMS1_TWD           _L_(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
+#define MUX_PB00A_TWIMS1_TWD            _L_(0)
 #define PINMUX_PB00A_TWIMS1_TWD    ((PIN_PB00A_TWIMS1_TWD << 16) | MUX_PB00A_TWIMS1_TWD)
-#define GPIO_PB00A_TWIMS1_TWD    _UL(1 <<  0)
+#define GPIO_PB00A_TWIMS1_TWD    _UL_(1 <<  0)
 /* ========== GPIO definition for TWIMS2 peripheral ========== */
-#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
-#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PIN_PA22E_TWIMS2_TWCK          _L_(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L_(4)
 #define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
-#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
-#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
-#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL_(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L_(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L_(4)
 #define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
-#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+#define GPIO_PA21E_TWIMS2_TWD    _UL_(1 << 21)
 /* ========== GPIO definition for TWIMS3 peripheral ========== */
-#define PIN_PB15C_TWIMS3_TWCK          _L(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
-#define MUX_PB15C_TWIMS3_TWCK           _L(2)
+#define PIN_PB15C_TWIMS3_TWCK          _L_(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
+#define MUX_PB15C_TWIMS3_TWCK           _L_(2)
 #define PINMUX_PB15C_TWIMS3_TWCK   ((PIN_PB15C_TWIMS3_TWCK << 16) | MUX_PB15C_TWIMS3_TWCK)
-#define GPIO_PB15C_TWIMS3_TWCK   _UL(1 << 15)
-#define PIN_PB14C_TWIMS3_TWD           _L(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
-#define MUX_PB14C_TWIMS3_TWD            _L(2)
+#define GPIO_PB15C_TWIMS3_TWCK   _UL_(1 << 15)
+#define PIN_PB14C_TWIMS3_TWD           _L_(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
+#define MUX_PB14C_TWIMS3_TWD            _L_(2)
 #define PINMUX_PB14C_TWIMS3_TWD    ((PIN_PB14C_TWIMS3_TWD << 16) | MUX_PB14C_TWIMS3_TWD)
-#define GPIO_PB14C_TWIMS3_TWD    _UL(1 << 14)
+#define GPIO_PB14C_TWIMS3_TWD    _UL_(1 << 14)
 /* ========== GPIO definition for IISC peripheral ========== */
-#define PIN_PB05D_IISC_IMCK            _L(37) /**< \brief IISC signal: IMCK on PB05 mux D */
-#define MUX_PB05D_IISC_IMCK             _L(3)
+#define PIN_PB05D_IISC_IMCK            _L_(37) /**< \brief IISC signal: IMCK on PB05 mux D */
+#define MUX_PB05D_IISC_IMCK             _L_(3)
 #define PINMUX_PB05D_IISC_IMCK     ((PIN_PB05D_IISC_IMCK << 16) | MUX_PB05D_IISC_IMCK)
-#define GPIO_PB05D_IISC_IMCK     _UL(1 <<  5)
-#define PIN_PC14D_IISC_IMCK            _L(78) /**< \brief IISC signal: IMCK on PC14 mux D */
-#define MUX_PC14D_IISC_IMCK             _L(3)
+#define GPIO_PB05D_IISC_IMCK     _UL_(1 <<  5)
+#define PIN_PC14D_IISC_IMCK            _L_(78) /**< \brief IISC signal: IMCK on PC14 mux D */
+#define MUX_PC14D_IISC_IMCK             _L_(3)
 #define PINMUX_PC14D_IISC_IMCK     ((PIN_PC14D_IISC_IMCK << 16) | MUX_PC14D_IISC_IMCK)
-#define GPIO_PC14D_IISC_IMCK     _UL(1 << 14)
-#define PIN_PB02D_IISC_ISCK            _L(34) /**< \brief IISC signal: ISCK on PB02 mux D */
-#define MUX_PB02D_IISC_ISCK             _L(3)
+#define GPIO_PC14D_IISC_IMCK     _UL_(1 << 14)
+#define PIN_PB02D_IISC_ISCK            _L_(34) /**< \brief IISC signal: ISCK on PB02 mux D */
+#define MUX_PB02D_IISC_ISCK             _L_(3)
 #define PINMUX_PB02D_IISC_ISCK     ((PIN_PB02D_IISC_ISCK << 16) | MUX_PB02D_IISC_ISCK)
-#define GPIO_PB02D_IISC_ISCK     _UL(1 <<  2)
-#define PIN_PC09D_IISC_ISCK            _L(73) /**< \brief IISC signal: ISCK on PC09 mux D */
-#define MUX_PC09D_IISC_ISCK             _L(3)
+#define GPIO_PB02D_IISC_ISCK     _UL_(1 <<  2)
+#define PIN_PC09D_IISC_ISCK            _L_(73) /**< \brief IISC signal: ISCK on PC09 mux D */
+#define MUX_PC09D_IISC_ISCK             _L_(3)
 #define PINMUX_PC09D_IISC_ISCK     ((PIN_PC09D_IISC_ISCK << 16) | MUX_PC09D_IISC_ISCK)
-#define GPIO_PC09D_IISC_ISCK     _UL(1 <<  9)
-#define PIN_PB03D_IISC_ISDI            _L(35) /**< \brief IISC signal: ISDI on PB03 mux D */
-#define MUX_PB03D_IISC_ISDI             _L(3)
+#define GPIO_PC09D_IISC_ISCK     _UL_(1 <<  9)
+#define PIN_PB03D_IISC_ISDI            _L_(35) /**< \brief IISC signal: ISDI on PB03 mux D */
+#define MUX_PB03D_IISC_ISDI             _L_(3)
 #define PINMUX_PB03D_IISC_ISDI     ((PIN_PB03D_IISC_ISDI << 16) | MUX_PB03D_IISC_ISDI)
-#define GPIO_PB03D_IISC_ISDI     _UL(1 <<  3)
-#define PIN_PC10D_IISC_ISDI            _L(74) /**< \brief IISC signal: ISDI on PC10 mux D */
-#define MUX_PC10D_IISC_ISDI             _L(3)
+#define GPIO_PB03D_IISC_ISDI     _UL_(1 <<  3)
+#define PIN_PC10D_IISC_ISDI            _L_(74) /**< \brief IISC signal: ISDI on PC10 mux D */
+#define MUX_PC10D_IISC_ISDI             _L_(3)
 #define PINMUX_PC10D_IISC_ISDI     ((PIN_PC10D_IISC_ISDI << 16) | MUX_PC10D_IISC_ISDI)
-#define GPIO_PC10D_IISC_ISDI     _UL(1 << 10)
-#define PIN_PB04D_IISC_ISDO            _L(36) /**< \brief IISC signal: ISDO on PB04 mux D */
-#define MUX_PB04D_IISC_ISDO             _L(3)
+#define GPIO_PC10D_IISC_ISDI     _UL_(1 << 10)
+#define PIN_PB04D_IISC_ISDO            _L_(36) /**< \brief IISC signal: ISDO on PB04 mux D */
+#define MUX_PB04D_IISC_ISDO             _L_(3)
 #define PINMUX_PB04D_IISC_ISDO     ((PIN_PB04D_IISC_ISDO << 16) | MUX_PB04D_IISC_ISDO)
-#define GPIO_PB04D_IISC_ISDO     _UL(1 <<  4)
-#define PIN_PC13D_IISC_ISDO            _L(77) /**< \brief IISC signal: ISDO on PC13 mux D */
-#define MUX_PC13D_IISC_ISDO             _L(3)
+#define GPIO_PB04D_IISC_ISDO     _UL_(1 <<  4)
+#define PIN_PC13D_IISC_ISDO            _L_(77) /**< \brief IISC signal: ISDO on PC13 mux D */
+#define MUX_PC13D_IISC_ISDO             _L_(3)
 #define PINMUX_PC13D_IISC_ISDO     ((PIN_PC13D_IISC_ISDO << 16) | MUX_PC13D_IISC_ISDO)
-#define GPIO_PC13D_IISC_ISDO     _UL(1 << 13)
-#define PIN_PB06D_IISC_IWS             _L(38) /**< \brief IISC signal: IWS on PB06 mux D */
-#define MUX_PB06D_IISC_IWS              _L(3)
+#define GPIO_PC13D_IISC_ISDO     _UL_(1 << 13)
+#define PIN_PB06D_IISC_IWS             _L_(38) /**< \brief IISC signal: IWS on PB06 mux D */
+#define MUX_PB06D_IISC_IWS              _L_(3)
 #define PINMUX_PB06D_IISC_IWS      ((PIN_PB06D_IISC_IWS << 16) | MUX_PB06D_IISC_IWS)
-#define GPIO_PB06D_IISC_IWS      _UL(1 <<  6)
-#define PIN_PC12D_IISC_IWS             _L(76) /**< \brief IISC signal: IWS on PC12 mux D */
-#define MUX_PC12D_IISC_IWS              _L(3)
+#define GPIO_PB06D_IISC_IWS      _UL_(1 <<  6)
+#define PIN_PC12D_IISC_IWS             _L_(76) /**< \brief IISC signal: IWS on PC12 mux D */
+#define MUX_PC12D_IISC_IWS              _L_(3)
 #define PINMUX_PC12D_IISC_IWS      ((PIN_PC12D_IISC_IWS << 16) | MUX_PC12D_IISC_IWS)
-#define GPIO_PC12D_IISC_IWS      _UL(1 << 12)
+#define GPIO_PC12D_IISC_IWS      _UL_(1 << 12)
 /* ========== GPIO definition for SPI peripheral ========== */
-#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
-#define MUX_PA03B_SPI_MISO              _L(1)
+#define PIN_PA03B_SPI_MISO              _L_(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L_(1)
 #define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
-#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
-#define PIN_PB14B_SPI_MISO             _L(46) /**< \brief SPI signal: MISO on PB14 mux B */
-#define MUX_PB14B_SPI_MISO              _L(1)
+#define GPIO_PA03B_SPI_MISO      _UL_(1 <<  3)
+#define PIN_PB14B_SPI_MISO             _L_(46) /**< \brief SPI signal: MISO on PB14 mux B */
+#define MUX_PB14B_SPI_MISO              _L_(1)
 #define PINMUX_PB14B_SPI_MISO      ((PIN_PB14B_SPI_MISO << 16) | MUX_PB14B_SPI_MISO)
-#define GPIO_PB14B_SPI_MISO      _UL(1 << 14)
-#define PIN_PC28B_SPI_MISO             _L(92) /**< \brief SPI signal: MISO on PC28 mux B */
-#define MUX_PC28B_SPI_MISO              _L(1)
+#define GPIO_PB14B_SPI_MISO      _UL_(1 << 14)
+#define PIN_PC28B_SPI_MISO             _L_(92) /**< \brief SPI signal: MISO on PC28 mux B */
+#define MUX_PC28B_SPI_MISO              _L_(1)
 #define PINMUX_PC28B_SPI_MISO      ((PIN_PC28B_SPI_MISO << 16) | MUX_PC28B_SPI_MISO)
-#define GPIO_PC28B_SPI_MISO      _UL(1 << 28)
-#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
-#define MUX_PA21A_SPI_MISO              _L(0)
+#define GPIO_PC28B_SPI_MISO      _UL_(1 << 28)
+#define PIN_PA21A_SPI_MISO             _L_(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L_(0)
 #define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
-#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
-#define PIN_PC04A_SPI_MISO             _L(68) /**< \brief SPI signal: MISO on PC04 mux A */
-#define MUX_PC04A_SPI_MISO              _L(0)
+#define GPIO_PA21A_SPI_MISO      _UL_(1 << 21)
+#define PIN_PC04A_SPI_MISO             _L_(68) /**< \brief SPI signal: MISO on PC04 mux A */
+#define MUX_PC04A_SPI_MISO              _L_(0)
 #define PINMUX_PC04A_SPI_MISO      ((PIN_PC04A_SPI_MISO << 16) | MUX_PC04A_SPI_MISO)
-#define GPIO_PC04A_SPI_MISO      _UL(1 <<  4)
-#define PIN_PB15B_SPI_MOSI             _L(47) /**< \brief SPI signal: MOSI on PB15 mux B */
-#define MUX_PB15B_SPI_MOSI              _L(1)
+#define GPIO_PC04A_SPI_MISO      _UL_(1 <<  4)
+#define PIN_PB15B_SPI_MOSI             _L_(47) /**< \brief SPI signal: MOSI on PB15 mux B */
+#define MUX_PB15B_SPI_MOSI              _L_(1)
 #define PINMUX_PB15B_SPI_MOSI      ((PIN_PB15B_SPI_MOSI << 16) | MUX_PB15B_SPI_MOSI)
-#define GPIO_PB15B_SPI_MOSI      _UL(1 << 15)
-#define PIN_PC29B_SPI_MOSI             _L(93) /**< \brief SPI signal: MOSI on PC29 mux B */
-#define MUX_PC29B_SPI_MOSI              _L(1)
+#define GPIO_PB15B_SPI_MOSI      _UL_(1 << 15)
+#define PIN_PC29B_SPI_MOSI             _L_(93) /**< \brief SPI signal: MOSI on PC29 mux B */
+#define MUX_PC29B_SPI_MOSI              _L_(1)
 #define PINMUX_PC29B_SPI_MOSI      ((PIN_PC29B_SPI_MOSI << 16) | MUX_PC29B_SPI_MOSI)
-#define GPIO_PC29B_SPI_MOSI      _UL(1 << 29)
-#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
-#define MUX_PA22A_SPI_MOSI              _L(0)
+#define GPIO_PC29B_SPI_MOSI      _UL_(1 << 29)
+#define PIN_PA22A_SPI_MOSI             _L_(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L_(0)
 #define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
-#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
-#define PIN_PC05A_SPI_MOSI             _L(69) /**< \brief SPI signal: MOSI on PC05 mux A */
-#define MUX_PC05A_SPI_MOSI              _L(0)
+#define GPIO_PA22A_SPI_MOSI      _UL_(1 << 22)
+#define PIN_PC05A_SPI_MOSI             _L_(69) /**< \brief SPI signal: MOSI on PC05 mux A */
+#define MUX_PC05A_SPI_MOSI              _L_(0)
 #define PINMUX_PC05A_SPI_MOSI      ((PIN_PC05A_SPI_MOSI << 16) | MUX_PC05A_SPI_MOSI)
-#define GPIO_PC05A_SPI_MOSI      _UL(1 <<  5)
-#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
-#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define GPIO_PC05A_SPI_MOSI      _UL_(1 <<  5)
+#define PIN_PA02B_SPI_NPCS0             _L_(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L_(1)
 #define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
-#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
-#define PIN_PC31B_SPI_NPCS0            _L(95) /**< \brief SPI signal: NPCS0 on PC31 mux B */
-#define MUX_PC31B_SPI_NPCS0             _L(1)
+#define GPIO_PA02B_SPI_NPCS0     _UL_(1 <<  2)
+#define PIN_PC31B_SPI_NPCS0            _L_(95) /**< \brief SPI signal: NPCS0 on PC31 mux B */
+#define MUX_PC31B_SPI_NPCS0             _L_(1)
 #define PINMUX_PC31B_SPI_NPCS0     ((PIN_PC31B_SPI_NPCS0 << 16) | MUX_PC31B_SPI_NPCS0)
-#define GPIO_PC31B_SPI_NPCS0     _UL(1 << 31)
-#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
-#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define GPIO_PC31B_SPI_NPCS0     _UL_(1 << 31)
+#define PIN_PA24A_SPI_NPCS0            _L_(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L_(0)
 #define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
-#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
-#define PIN_PC03A_SPI_NPCS0            _L(67) /**< \brief SPI signal: NPCS0 on PC03 mux A */
-#define MUX_PC03A_SPI_NPCS0             _L(0)
+#define GPIO_PA24A_SPI_NPCS0     _UL_(1 << 24)
+#define PIN_PC03A_SPI_NPCS0            _L_(67) /**< \brief SPI signal: NPCS0 on PC03 mux A */
+#define MUX_PC03A_SPI_NPCS0             _L_(0)
 #define PINMUX_PC03A_SPI_NPCS0     ((PIN_PC03A_SPI_NPCS0 << 16) | MUX_PC03A_SPI_NPCS0)
-#define GPIO_PC03A_SPI_NPCS0     _UL(1 <<  3)
-#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
-#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define GPIO_PC03A_SPI_NPCS0     _UL_(1 <<  3)
+#define PIN_PA13C_SPI_NPCS1            _L_(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L_(2)
 #define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
-#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PB13B_SPI_NPCS1            _L(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
-#define MUX_PB13B_SPI_NPCS1             _L(1)
+#define GPIO_PA13C_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PB13B_SPI_NPCS1            _L_(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
+#define MUX_PB13B_SPI_NPCS1             _L_(1)
 #define PINMUX_PB13B_SPI_NPCS1     ((PIN_PB13B_SPI_NPCS1 << 16) | MUX_PB13B_SPI_NPCS1)
-#define GPIO_PB13B_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PC02A_SPI_NPCS1            _L(66) /**< \brief SPI signal: NPCS1 on PC02 mux A */
-#define MUX_PC02A_SPI_NPCS1             _L(0)
+#define GPIO_PB13B_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PC02A_SPI_NPCS1            _L_(66) /**< \brief SPI signal: NPCS1 on PC02 mux A */
+#define MUX_PC02A_SPI_NPCS1             _L_(0)
 #define PINMUX_PC02A_SPI_NPCS1     ((PIN_PC02A_SPI_NPCS1 << 16) | MUX_PC02A_SPI_NPCS1)
-#define GPIO_PC02A_SPI_NPCS1     _UL(1 <<  2)
-#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
-#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define GPIO_PC02A_SPI_NPCS1     _UL_(1 <<  2)
+#define PIN_PA14C_SPI_NPCS2            _L_(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L_(2)
 #define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
-#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
-#define PIN_PB11B_SPI_NPCS2            _L(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
-#define MUX_PB11B_SPI_NPCS2             _L(1)
+#define GPIO_PA14C_SPI_NPCS2     _UL_(1 << 14)
+#define PIN_PB11B_SPI_NPCS2            _L_(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
+#define MUX_PB11B_SPI_NPCS2             _L_(1)
 #define PINMUX_PB11B_SPI_NPCS2     ((PIN_PB11B_SPI_NPCS2 << 16) | MUX_PB11B_SPI_NPCS2)
-#define GPIO_PB11B_SPI_NPCS2     _UL(1 << 11)
-#define PIN_PC00A_SPI_NPCS2            _L(64) /**< \brief SPI signal: NPCS2 on PC00 mux A */
-#define MUX_PC00A_SPI_NPCS2             _L(0)
+#define GPIO_PB11B_SPI_NPCS2     _UL_(1 << 11)
+#define PIN_PC00A_SPI_NPCS2            _L_(64) /**< \brief SPI signal: NPCS2 on PC00 mux A */
+#define MUX_PC00A_SPI_NPCS2             _L_(0)
 #define PINMUX_PC00A_SPI_NPCS2     ((PIN_PC00A_SPI_NPCS2 << 16) | MUX_PC00A_SPI_NPCS2)
-#define GPIO_PC00A_SPI_NPCS2     _UL(1 <<  0)
-#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
-#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define GPIO_PC00A_SPI_NPCS2     _UL_(1 <<  0)
+#define PIN_PA15C_SPI_NPCS3            _L_(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L_(2)
 #define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
-#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
-#define PIN_PB12B_SPI_NPCS3            _L(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
-#define MUX_PB12B_SPI_NPCS3             _L(1)
+#define GPIO_PA15C_SPI_NPCS3     _UL_(1 << 15)
+#define PIN_PB12B_SPI_NPCS3            _L_(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
+#define MUX_PB12B_SPI_NPCS3             _L_(1)
 #define PINMUX_PB12B_SPI_NPCS3     ((PIN_PB12B_SPI_NPCS3 << 16) | MUX_PB12B_SPI_NPCS3)
-#define GPIO_PB12B_SPI_NPCS3     _UL(1 << 12)
-#define PIN_PC01A_SPI_NPCS3            _L(65) /**< \brief SPI signal: NPCS3 on PC01 mux A */
-#define MUX_PC01A_SPI_NPCS3             _L(0)
+#define GPIO_PB12B_SPI_NPCS3     _UL_(1 << 12)
+#define PIN_PC01A_SPI_NPCS3            _L_(65) /**< \brief SPI signal: NPCS3 on PC01 mux A */
+#define MUX_PC01A_SPI_NPCS3             _L_(0)
 #define PINMUX_PC01A_SPI_NPCS3     ((PIN_PC01A_SPI_NPCS3 << 16) | MUX_PC01A_SPI_NPCS3)
-#define GPIO_PC01A_SPI_NPCS3     _UL(1 <<  1)
-#define PIN_PC30B_SPI_SCK              _L(94) /**< \brief SPI signal: SCK on PC30 mux B */
-#define MUX_PC30B_SPI_SCK               _L(1)
+#define GPIO_PC01A_SPI_NPCS3     _UL_(1 <<  1)
+#define PIN_PC30B_SPI_SCK              _L_(94) /**< \brief SPI signal: SCK on PC30 mux B */
+#define MUX_PC30B_SPI_SCK               _L_(1)
 #define PINMUX_PC30B_SPI_SCK       ((PIN_PC30B_SPI_SCK << 16) | MUX_PC30B_SPI_SCK)
-#define GPIO_PC30B_SPI_SCK       _UL(1 << 30)
-#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
-#define MUX_PA23A_SPI_SCK               _L(0)
+#define GPIO_PC30B_SPI_SCK       _UL_(1 << 30)
+#define PIN_PA23A_SPI_SCK              _L_(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L_(0)
 #define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
-#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
-#define PIN_PC06A_SPI_SCK              _L(70) /**< \brief SPI signal: SCK on PC06 mux A */
-#define MUX_PC06A_SPI_SCK               _L(0)
+#define GPIO_PA23A_SPI_SCK       _UL_(1 << 23)
+#define PIN_PC06A_SPI_SCK              _L_(70) /**< \brief SPI signal: SCK on PC06 mux A */
+#define MUX_PC06A_SPI_SCK               _L_(0)
 #define PINMUX_PC06A_SPI_SCK       ((PIN_PC06A_SPI_SCK << 16) | MUX_PC06A_SPI_SCK)
-#define GPIO_PC06A_SPI_SCK       _UL(1 <<  6)
+#define GPIO_PC06A_SPI_SCK       _UL_(1 <<  6)
 /* ========== GPIO definition for TC0 peripheral ========== */
-#define PIN_PB07D_TC0_A0               _L(39) /**< \brief TC0 signal: A0 on PB07 mux D */
-#define MUX_PB07D_TC0_A0                _L(3)
+#define PIN_PB07D_TC0_A0               _L_(39) /**< \brief TC0 signal: A0 on PB07 mux D */
+#define MUX_PB07D_TC0_A0                _L_(3)
 #define PINMUX_PB07D_TC0_A0        ((PIN_PB07D_TC0_A0 << 16) | MUX_PB07D_TC0_A0)
-#define GPIO_PB07D_TC0_A0        _UL(1 <<  7)
-#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
-#define MUX_PA08B_TC0_A0                _L(1)
+#define GPIO_PB07D_TC0_A0        _UL_(1 <<  7)
+#define PIN_PA08B_TC0_A0                _L_(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L_(1)
 #define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
-#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
-#define PIN_PB09D_TC0_A1               _L(41) /**< \brief TC0 signal: A1 on PB09 mux D */
-#define MUX_PB09D_TC0_A1                _L(3)
+#define GPIO_PA08B_TC0_A0        _UL_(1 <<  8)
+#define PIN_PB09D_TC0_A1               _L_(41) /**< \brief TC0 signal: A1 on PB09 mux D */
+#define MUX_PB09D_TC0_A1                _L_(3)
 #define PINMUX_PB09D_TC0_A1        ((PIN_PB09D_TC0_A1 << 16) | MUX_PB09D_TC0_A1)
-#define GPIO_PB09D_TC0_A1        _UL(1 <<  9)
-#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
-#define MUX_PA10B_TC0_A1                _L(1)
+#define GPIO_PB09D_TC0_A1        _UL_(1 <<  9)
+#define PIN_PA10B_TC0_A1               _L_(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L_(1)
 #define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
-#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
-#define PIN_PB11D_TC0_A2               _L(43) /**< \brief TC0 signal: A2 on PB11 mux D */
-#define MUX_PB11D_TC0_A2                _L(3)
+#define GPIO_PA10B_TC0_A1        _UL_(1 << 10)
+#define PIN_PB11D_TC0_A2               _L_(43) /**< \brief TC0 signal: A2 on PB11 mux D */
+#define MUX_PB11D_TC0_A2                _L_(3)
 #define PINMUX_PB11D_TC0_A2        ((PIN_PB11D_TC0_A2 << 16) | MUX_PB11D_TC0_A2)
-#define GPIO_PB11D_TC0_A2        _UL(1 << 11)
-#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
-#define MUX_PA12B_TC0_A2                _L(1)
+#define GPIO_PB11D_TC0_A2        _UL_(1 << 11)
+#define PIN_PA12B_TC0_A2               _L_(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L_(1)
 #define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
-#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
-#define PIN_PB08D_TC0_B0               _L(40) /**< \brief TC0 signal: B0 on PB08 mux D */
-#define MUX_PB08D_TC0_B0                _L(3)
+#define GPIO_PA12B_TC0_A2        _UL_(1 << 12)
+#define PIN_PB08D_TC0_B0               _L_(40) /**< \brief TC0 signal: B0 on PB08 mux D */
+#define MUX_PB08D_TC0_B0                _L_(3)
 #define PINMUX_PB08D_TC0_B0        ((PIN_PB08D_TC0_B0 << 16) | MUX_PB08D_TC0_B0)
-#define GPIO_PB08D_TC0_B0        _UL(1 <<  8)
-#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
-#define MUX_PA09B_TC0_B0                _L(1)
+#define GPIO_PB08D_TC0_B0        _UL_(1 <<  8)
+#define PIN_PA09B_TC0_B0                _L_(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L_(1)
 #define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
-#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
-#define PIN_PB10D_TC0_B1               _L(42) /**< \brief TC0 signal: B1 on PB10 mux D */
-#define MUX_PB10D_TC0_B1                _L(3)
+#define GPIO_PA09B_TC0_B0        _UL_(1 <<  9)
+#define PIN_PB10D_TC0_B1               _L_(42) /**< \brief TC0 signal: B1 on PB10 mux D */
+#define MUX_PB10D_TC0_B1                _L_(3)
 #define PINMUX_PB10D_TC0_B1        ((PIN_PB10D_TC0_B1 << 16) | MUX_PB10D_TC0_B1)
-#define GPIO_PB10D_TC0_B1        _UL(1 << 10)
-#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
-#define MUX_PA11B_TC0_B1                _L(1)
+#define GPIO_PB10D_TC0_B1        _UL_(1 << 10)
+#define PIN_PA11B_TC0_B1               _L_(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L_(1)
 #define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
-#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
-#define PIN_PB12D_TC0_B2               _L(44) /**< \brief TC0 signal: B2 on PB12 mux D */
-#define MUX_PB12D_TC0_B2                _L(3)
+#define GPIO_PA11B_TC0_B1        _UL_(1 << 11)
+#define PIN_PB12D_TC0_B2               _L_(44) /**< \brief TC0 signal: B2 on PB12 mux D */
+#define MUX_PB12D_TC0_B2                _L_(3)
 #define PINMUX_PB12D_TC0_B2        ((PIN_PB12D_TC0_B2 << 16) | MUX_PB12D_TC0_B2)
-#define GPIO_PB12D_TC0_B2        _UL(1 << 12)
-#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
-#define MUX_PA13B_TC0_B2                _L(1)
+#define GPIO_PB12D_TC0_B2        _UL_(1 << 12)
+#define PIN_PA13B_TC0_B2               _L_(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L_(1)
 #define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
-#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
-#define PIN_PB13D_TC0_CLK0             _L(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
-#define MUX_PB13D_TC0_CLK0              _L(3)
+#define GPIO_PA13B_TC0_B2        _UL_(1 << 13)
+#define PIN_PB13D_TC0_CLK0             _L_(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
+#define MUX_PB13D_TC0_CLK0              _L_(3)
 #define PINMUX_PB13D_TC0_CLK0      ((PIN_PB13D_TC0_CLK0 << 16) | MUX_PB13D_TC0_CLK0)
-#define GPIO_PB13D_TC0_CLK0      _UL(1 << 13)
-#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
-#define MUX_PA14B_TC0_CLK0              _L(1)
+#define GPIO_PB13D_TC0_CLK0      _UL_(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L_(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L_(1)
 #define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
-#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
-#define PIN_PB14D_TC0_CLK1             _L(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
-#define MUX_PB14D_TC0_CLK1              _L(3)
+#define GPIO_PA14B_TC0_CLK0      _UL_(1 << 14)
+#define PIN_PB14D_TC0_CLK1             _L_(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
+#define MUX_PB14D_TC0_CLK1              _L_(3)
 #define PINMUX_PB14D_TC0_CLK1      ((PIN_PB14D_TC0_CLK1 << 16) | MUX_PB14D_TC0_CLK1)
-#define GPIO_PB14D_TC0_CLK1      _UL(1 << 14)
-#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
-#define MUX_PA15B_TC0_CLK1              _L(1)
+#define GPIO_PB14D_TC0_CLK1      _UL_(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L_(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L_(1)
 #define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
-#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
-#define PIN_PB15D_TC0_CLK2             _L(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
-#define MUX_PB15D_TC0_CLK2              _L(3)
+#define GPIO_PA15B_TC0_CLK1      _UL_(1 << 15)
+#define PIN_PB15D_TC0_CLK2             _L_(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
+#define MUX_PB15D_TC0_CLK2              _L_(3)
 #define PINMUX_PB15D_TC0_CLK2      ((PIN_PB15D_TC0_CLK2 << 16) | MUX_PB15D_TC0_CLK2)
-#define GPIO_PB15D_TC0_CLK2      _UL(1 << 15)
-#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
-#define MUX_PA16B_TC0_CLK2              _L(1)
+#define GPIO_PB15D_TC0_CLK2      _UL_(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L_(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L_(1)
 #define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
-#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+#define GPIO_PA16B_TC0_CLK2      _UL_(1 << 16)
 /* ========== GPIO definition for TC1 peripheral ========== */
-#define PIN_PC00D_TC1_A0               _L(64) /**< \brief TC1 signal: A0 on PC00 mux D */
-#define MUX_PC00D_TC1_A0                _L(3)
+#define PIN_PC00D_TC1_A0               _L_(64) /**< \brief TC1 signal: A0 on PC00 mux D */
+#define MUX_PC00D_TC1_A0                _L_(3)
 #define PINMUX_PC00D_TC1_A0        ((PIN_PC00D_TC1_A0 << 16) | MUX_PC00D_TC1_A0)
-#define GPIO_PC00D_TC1_A0        _UL(1 <<  0)
-#define PIN_PC15A_TC1_A0               _L(79) /**< \brief TC1 signal: A0 on PC15 mux A */
-#define MUX_PC15A_TC1_A0                _L(0)
+#define GPIO_PC00D_TC1_A0        _UL_(1 <<  0)
+#define PIN_PC15A_TC1_A0               _L_(79) /**< \brief TC1 signal: A0 on PC15 mux A */
+#define MUX_PC15A_TC1_A0                _L_(0)
 #define PINMUX_PC15A_TC1_A0        ((PIN_PC15A_TC1_A0 << 16) | MUX_PC15A_TC1_A0)
-#define GPIO_PC15A_TC1_A0        _UL(1 << 15)
-#define PIN_PC02D_TC1_A1               _L(66) /**< \brief TC1 signal: A1 on PC02 mux D */
-#define MUX_PC02D_TC1_A1                _L(3)
+#define GPIO_PC15A_TC1_A0        _UL_(1 << 15)
+#define PIN_PC02D_TC1_A1               _L_(66) /**< \brief TC1 signal: A1 on PC02 mux D */
+#define MUX_PC02D_TC1_A1                _L_(3)
 #define PINMUX_PC02D_TC1_A1        ((PIN_PC02D_TC1_A1 << 16) | MUX_PC02D_TC1_A1)
-#define GPIO_PC02D_TC1_A1        _UL(1 <<  2)
-#define PIN_PC17A_TC1_A1               _L(81) /**< \brief TC1 signal: A1 on PC17 mux A */
-#define MUX_PC17A_TC1_A1                _L(0)
+#define GPIO_PC02D_TC1_A1        _UL_(1 <<  2)
+#define PIN_PC17A_TC1_A1               _L_(81) /**< \brief TC1 signal: A1 on PC17 mux A */
+#define MUX_PC17A_TC1_A1                _L_(0)
 #define PINMUX_PC17A_TC1_A1        ((PIN_PC17A_TC1_A1 << 16) | MUX_PC17A_TC1_A1)
-#define GPIO_PC17A_TC1_A1        _UL(1 << 17)
-#define PIN_PC04D_TC1_A2               _L(68) /**< \brief TC1 signal: A2 on PC04 mux D */
-#define MUX_PC04D_TC1_A2                _L(3)
+#define GPIO_PC17A_TC1_A1        _UL_(1 << 17)
+#define PIN_PC04D_TC1_A2               _L_(68) /**< \brief TC1 signal: A2 on PC04 mux D */
+#define MUX_PC04D_TC1_A2                _L_(3)
 #define PINMUX_PC04D_TC1_A2        ((PIN_PC04D_TC1_A2 << 16) | MUX_PC04D_TC1_A2)
-#define GPIO_PC04D_TC1_A2        _UL(1 <<  4)
-#define PIN_PC19A_TC1_A2               _L(83) /**< \brief TC1 signal: A2 on PC19 mux A */
-#define MUX_PC19A_TC1_A2                _L(0)
+#define GPIO_PC04D_TC1_A2        _UL_(1 <<  4)
+#define PIN_PC19A_TC1_A2               _L_(83) /**< \brief TC1 signal: A2 on PC19 mux A */
+#define MUX_PC19A_TC1_A2                _L_(0)
 #define PINMUX_PC19A_TC1_A2        ((PIN_PC19A_TC1_A2 << 16) | MUX_PC19A_TC1_A2)
-#define GPIO_PC19A_TC1_A2        _UL(1 << 19)
-#define PIN_PC01D_TC1_B0               _L(65) /**< \brief TC1 signal: B0 on PC01 mux D */
-#define MUX_PC01D_TC1_B0                _L(3)
+#define GPIO_PC19A_TC1_A2        _UL_(1 << 19)
+#define PIN_PC01D_TC1_B0               _L_(65) /**< \brief TC1 signal: B0 on PC01 mux D */
+#define MUX_PC01D_TC1_B0                _L_(3)
 #define PINMUX_PC01D_TC1_B0        ((PIN_PC01D_TC1_B0 << 16) | MUX_PC01D_TC1_B0)
-#define GPIO_PC01D_TC1_B0        _UL(1 <<  1)
-#define PIN_PC16A_TC1_B0               _L(80) /**< \brief TC1 signal: B0 on PC16 mux A */
-#define MUX_PC16A_TC1_B0                _L(0)
+#define GPIO_PC01D_TC1_B0        _UL_(1 <<  1)
+#define PIN_PC16A_TC1_B0               _L_(80) /**< \brief TC1 signal: B0 on PC16 mux A */
+#define MUX_PC16A_TC1_B0                _L_(0)
 #define PINMUX_PC16A_TC1_B0        ((PIN_PC16A_TC1_B0 << 16) | MUX_PC16A_TC1_B0)
-#define GPIO_PC16A_TC1_B0        _UL(1 << 16)
-#define PIN_PC03D_TC1_B1               _L(67) /**< \brief TC1 signal: B1 on PC03 mux D */
-#define MUX_PC03D_TC1_B1                _L(3)
+#define GPIO_PC16A_TC1_B0        _UL_(1 << 16)
+#define PIN_PC03D_TC1_B1               _L_(67) /**< \brief TC1 signal: B1 on PC03 mux D */
+#define MUX_PC03D_TC1_B1                _L_(3)
 #define PINMUX_PC03D_TC1_B1        ((PIN_PC03D_TC1_B1 << 16) | MUX_PC03D_TC1_B1)
-#define GPIO_PC03D_TC1_B1        _UL(1 <<  3)
-#define PIN_PC18A_TC1_B1               _L(82) /**< \brief TC1 signal: B1 on PC18 mux A */
-#define MUX_PC18A_TC1_B1                _L(0)
+#define GPIO_PC03D_TC1_B1        _UL_(1 <<  3)
+#define PIN_PC18A_TC1_B1               _L_(82) /**< \brief TC1 signal: B1 on PC18 mux A */
+#define MUX_PC18A_TC1_B1                _L_(0)
 #define PINMUX_PC18A_TC1_B1        ((PIN_PC18A_TC1_B1 << 16) | MUX_PC18A_TC1_B1)
-#define GPIO_PC18A_TC1_B1        _UL(1 << 18)
-#define PIN_PC05D_TC1_B2               _L(69) /**< \brief TC1 signal: B2 on PC05 mux D */
-#define MUX_PC05D_TC1_B2                _L(3)
+#define GPIO_PC18A_TC1_B1        _UL_(1 << 18)
+#define PIN_PC05D_TC1_B2               _L_(69) /**< \brief TC1 signal: B2 on PC05 mux D */
+#define MUX_PC05D_TC1_B2                _L_(3)
 #define PINMUX_PC05D_TC1_B2        ((PIN_PC05D_TC1_B2 << 16) | MUX_PC05D_TC1_B2)
-#define GPIO_PC05D_TC1_B2        _UL(1 <<  5)
-#define PIN_PC20A_TC1_B2               _L(84) /**< \brief TC1 signal: B2 on PC20 mux A */
-#define MUX_PC20A_TC1_B2                _L(0)
+#define GPIO_PC05D_TC1_B2        _UL_(1 <<  5)
+#define PIN_PC20A_TC1_B2               _L_(84) /**< \brief TC1 signal: B2 on PC20 mux A */
+#define MUX_PC20A_TC1_B2                _L_(0)
 #define PINMUX_PC20A_TC1_B2        ((PIN_PC20A_TC1_B2 << 16) | MUX_PC20A_TC1_B2)
-#define GPIO_PC20A_TC1_B2        _UL(1 << 20)
-#define PIN_PC06D_TC1_CLK0             _L(70) /**< \brief TC1 signal: CLK0 on PC06 mux D */
-#define MUX_PC06D_TC1_CLK0              _L(3)
+#define GPIO_PC20A_TC1_B2        _UL_(1 << 20)
+#define PIN_PC06D_TC1_CLK0             _L_(70) /**< \brief TC1 signal: CLK0 on PC06 mux D */
+#define MUX_PC06D_TC1_CLK0              _L_(3)
 #define PINMUX_PC06D_TC1_CLK0      ((PIN_PC06D_TC1_CLK0 << 16) | MUX_PC06D_TC1_CLK0)
-#define GPIO_PC06D_TC1_CLK0      _UL(1 <<  6)
-#define PIN_PC21A_TC1_CLK0             _L(85) /**< \brief TC1 signal: CLK0 on PC21 mux A */
-#define MUX_PC21A_TC1_CLK0              _L(0)
+#define GPIO_PC06D_TC1_CLK0      _UL_(1 <<  6)
+#define PIN_PC21A_TC1_CLK0             _L_(85) /**< \brief TC1 signal: CLK0 on PC21 mux A */
+#define MUX_PC21A_TC1_CLK0              _L_(0)
 #define PINMUX_PC21A_TC1_CLK0      ((PIN_PC21A_TC1_CLK0 << 16) | MUX_PC21A_TC1_CLK0)
-#define GPIO_PC21A_TC1_CLK0      _UL(1 << 21)
-#define PIN_PC07D_TC1_CLK1             _L(71) /**< \brief TC1 signal: CLK1 on PC07 mux D */
-#define MUX_PC07D_TC1_CLK1              _L(3)
+#define GPIO_PC21A_TC1_CLK0      _UL_(1 << 21)
+#define PIN_PC07D_TC1_CLK1             _L_(71) /**< \brief TC1 signal: CLK1 on PC07 mux D */
+#define MUX_PC07D_TC1_CLK1              _L_(3)
 #define PINMUX_PC07D_TC1_CLK1      ((PIN_PC07D_TC1_CLK1 << 16) | MUX_PC07D_TC1_CLK1)
-#define GPIO_PC07D_TC1_CLK1      _UL(1 <<  7)
-#define PIN_PC22A_TC1_CLK1             _L(86) /**< \brief TC1 signal: CLK1 on PC22 mux A */
-#define MUX_PC22A_TC1_CLK1              _L(0)
+#define GPIO_PC07D_TC1_CLK1      _UL_(1 <<  7)
+#define PIN_PC22A_TC1_CLK1             _L_(86) /**< \brief TC1 signal: CLK1 on PC22 mux A */
+#define MUX_PC22A_TC1_CLK1              _L_(0)
 #define PINMUX_PC22A_TC1_CLK1      ((PIN_PC22A_TC1_CLK1 << 16) | MUX_PC22A_TC1_CLK1)
-#define GPIO_PC22A_TC1_CLK1      _UL(1 << 22)
-#define PIN_PC08D_TC1_CLK2             _L(72) /**< \brief TC1 signal: CLK2 on PC08 mux D */
-#define MUX_PC08D_TC1_CLK2              _L(3)
+#define GPIO_PC22A_TC1_CLK1      _UL_(1 << 22)
+#define PIN_PC08D_TC1_CLK2             _L_(72) /**< \brief TC1 signal: CLK2 on PC08 mux D */
+#define MUX_PC08D_TC1_CLK2              _L_(3)
 #define PINMUX_PC08D_TC1_CLK2      ((PIN_PC08D_TC1_CLK2 << 16) | MUX_PC08D_TC1_CLK2)
-#define GPIO_PC08D_TC1_CLK2      _UL(1 <<  8)
-#define PIN_PC23A_TC1_CLK2             _L(87) /**< \brief TC1 signal: CLK2 on PC23 mux A */
-#define MUX_PC23A_TC1_CLK2              _L(0)
+#define GPIO_PC08D_TC1_CLK2      _UL_(1 <<  8)
+#define PIN_PC23A_TC1_CLK2             _L_(87) /**< \brief TC1 signal: CLK2 on PC23 mux A */
+#define MUX_PC23A_TC1_CLK2              _L_(0)
 #define PINMUX_PC23A_TC1_CLK2      ((PIN_PC23A_TC1_CLK2 << 16) | MUX_PC23A_TC1_CLK2)
-#define GPIO_PC23A_TC1_CLK2      _UL(1 << 23)
+#define GPIO_PC23A_TC1_CLK2      _UL_(1 << 23)
 /* ========== GPIO definition for USART0 peripheral ========== */
-#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
-#define MUX_PA04B_USART0_CLK            _L(1)
+#define PIN_PA04B_USART0_CLK            _L_(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L_(1)
 #define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
-#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
-#define PIN_PC00B_USART0_CLK           _L(64) /**< \brief USART0 signal: CLK on PC00 mux B */
-#define MUX_PC00B_USART0_CLK            _L(1)
+#define GPIO_PA04B_USART0_CLK    _UL_(1 <<  4)
+#define PIN_PC00B_USART0_CLK           _L_(64) /**< \brief USART0 signal: CLK on PC00 mux B */
+#define MUX_PC00B_USART0_CLK            _L_(1)
 #define PINMUX_PC00B_USART0_CLK    ((PIN_PC00B_USART0_CLK << 16) | MUX_PC00B_USART0_CLK)
-#define GPIO_PC00B_USART0_CLK    _UL(1 <<  0)
-#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
-#define MUX_PA10A_USART0_CLK            _L(0)
+#define GPIO_PC00B_USART0_CLK    _UL_(1 <<  0)
+#define PIN_PA10A_USART0_CLK           _L_(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L_(0)
 #define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
-#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
-#define PIN_PB13A_USART0_CLK           _L(45) /**< \brief USART0 signal: CLK on PB13 mux A */
-#define MUX_PB13A_USART0_CLK            _L(0)
+#define GPIO_PA10A_USART0_CLK    _UL_(1 << 10)
+#define PIN_PB13A_USART0_CLK           _L_(45) /**< \brief USART0 signal: CLK on PB13 mux A */
+#define MUX_PB13A_USART0_CLK            _L_(0)
 #define PINMUX_PB13A_USART0_CLK    ((PIN_PB13A_USART0_CLK << 16) | MUX_PB13A_USART0_CLK)
-#define GPIO_PB13A_USART0_CLK    _UL(1 << 13)
-#define PIN_PC02B_USART0_CTS           _L(66) /**< \brief USART0 signal: CTS on PC02 mux B */
-#define MUX_PC02B_USART0_CTS            _L(1)
+#define GPIO_PB13A_USART0_CLK    _UL_(1 << 13)
+#define PIN_PC02B_USART0_CTS           _L_(66) /**< \brief USART0 signal: CTS on PC02 mux B */
+#define MUX_PC02B_USART0_CTS            _L_(1)
 #define PINMUX_PC02B_USART0_CTS    ((PIN_PC02B_USART0_CTS << 16) | MUX_PC02B_USART0_CTS)
-#define GPIO_PC02B_USART0_CTS    _UL(1 <<  2)
-#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
-#define MUX_PA09A_USART0_CTS            _L(0)
+#define GPIO_PC02B_USART0_CTS    _UL_(1 <<  2)
+#define PIN_PA09A_USART0_CTS            _L_(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L_(0)
 #define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
-#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
-#define PIN_PB11A_USART0_CTS           _L(43) /**< \brief USART0 signal: CTS on PB11 mux A */
-#define MUX_PB11A_USART0_CTS            _L(0)
+#define GPIO_PA09A_USART0_CTS    _UL_(1 <<  9)
+#define PIN_PB11A_USART0_CTS           _L_(43) /**< \brief USART0 signal: CTS on PB11 mux A */
+#define MUX_PB11A_USART0_CTS            _L_(0)
 #define PINMUX_PB11A_USART0_CTS    ((PIN_PB11A_USART0_CTS << 16) | MUX_PB11A_USART0_CTS)
-#define GPIO_PB11A_USART0_CTS    _UL(1 << 11)
-#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
-#define MUX_PA06B_USART0_RTS            _L(1)
+#define GPIO_PB11A_USART0_CTS    _UL_(1 << 11)
+#define PIN_PA06B_USART0_RTS            _L_(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L_(1)
 #define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
-#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
-#define PIN_PC01B_USART0_RTS           _L(65) /**< \brief USART0 signal: RTS on PC01 mux B */
-#define MUX_PC01B_USART0_RTS            _L(1)
+#define GPIO_PA06B_USART0_RTS    _UL_(1 <<  6)
+#define PIN_PC01B_USART0_RTS           _L_(65) /**< \brief USART0 signal: RTS on PC01 mux B */
+#define MUX_PC01B_USART0_RTS            _L_(1)
 #define PINMUX_PC01B_USART0_RTS    ((PIN_PC01B_USART0_RTS << 16) | MUX_PC01B_USART0_RTS)
-#define GPIO_PC01B_USART0_RTS    _UL(1 <<  1)
-#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
-#define MUX_PA08A_USART0_RTS            _L(0)
+#define GPIO_PC01B_USART0_RTS    _UL_(1 <<  1)
+#define PIN_PA08A_USART0_RTS            _L_(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L_(0)
 #define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
-#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
-#define PIN_PB12A_USART0_RTS           _L(44) /**< \brief USART0 signal: RTS on PB12 mux A */
-#define MUX_PB12A_USART0_RTS            _L(0)
+#define GPIO_PA08A_USART0_RTS    _UL_(1 <<  8)
+#define PIN_PB12A_USART0_RTS           _L_(44) /**< \brief USART0 signal: RTS on PB12 mux A */
+#define MUX_PB12A_USART0_RTS            _L_(0)
 #define PINMUX_PB12A_USART0_RTS    ((PIN_PB12A_USART0_RTS << 16) | MUX_PB12A_USART0_RTS)
-#define GPIO_PB12A_USART0_RTS    _UL(1 << 12)
-#define PIN_PC02C_USART0_RXD           _L(66) /**< \brief USART0 signal: RXD on PC02 mux C */
-#define MUX_PC02C_USART0_RXD            _L(2)
+#define GPIO_PB12A_USART0_RTS    _UL_(1 << 12)
+#define PIN_PC02C_USART0_RXD           _L_(66) /**< \brief USART0 signal: RXD on PC02 mux C */
+#define MUX_PC02C_USART0_RXD            _L_(2)
 #define PINMUX_PC02C_USART0_RXD    ((PIN_PC02C_USART0_RXD << 16) | MUX_PC02C_USART0_RXD)
-#define GPIO_PC02C_USART0_RXD    _UL(1 <<  2)
-#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
-#define MUX_PA05B_USART0_RXD            _L(1)
+#define GPIO_PC02C_USART0_RXD    _UL_(1 <<  2)
+#define PIN_PA05B_USART0_RXD            _L_(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L_(1)
 #define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
-#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
-#define PIN_PB00B_USART0_RXD           _L(32) /**< \brief USART0 signal: RXD on PB00 mux B */
-#define MUX_PB00B_USART0_RXD            _L(1)
+#define GPIO_PA05B_USART0_RXD    _UL_(1 <<  5)
+#define PIN_PB00B_USART0_RXD           _L_(32) /**< \brief USART0 signal: RXD on PB00 mux B */
+#define MUX_PB00B_USART0_RXD            _L_(1)
 #define PINMUX_PB00B_USART0_RXD    ((PIN_PB00B_USART0_RXD << 16) | MUX_PB00B_USART0_RXD)
-#define GPIO_PB00B_USART0_RXD    _UL(1 <<  0)
-#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
-#define MUX_PA11A_USART0_RXD            _L(0)
+#define GPIO_PB00B_USART0_RXD    _UL_(1 <<  0)
+#define PIN_PA11A_USART0_RXD           _L_(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L_(0)
 #define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
-#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
-#define PIN_PB14A_USART0_RXD           _L(46) /**< \brief USART0 signal: RXD on PB14 mux A */
-#define MUX_PB14A_USART0_RXD            _L(0)
+#define GPIO_PA11A_USART0_RXD    _UL_(1 << 11)
+#define PIN_PB14A_USART0_RXD           _L_(46) /**< \brief USART0 signal: RXD on PB14 mux A */
+#define MUX_PB14A_USART0_RXD            _L_(0)
 #define PINMUX_PB14A_USART0_RXD    ((PIN_PB14A_USART0_RXD << 16) | MUX_PB14A_USART0_RXD)
-#define GPIO_PB14A_USART0_RXD    _UL(1 << 14)
-#define PIN_PC03C_USART0_TXD           _L(67) /**< \brief USART0 signal: TXD on PC03 mux C */
-#define MUX_PC03C_USART0_TXD            _L(2)
+#define GPIO_PB14A_USART0_RXD    _UL_(1 << 14)
+#define PIN_PC03C_USART0_TXD           _L_(67) /**< \brief USART0 signal: TXD on PC03 mux C */
+#define MUX_PC03C_USART0_TXD            _L_(2)
 #define PINMUX_PC03C_USART0_TXD    ((PIN_PC03C_USART0_TXD << 16) | MUX_PC03C_USART0_TXD)
-#define GPIO_PC03C_USART0_TXD    _UL(1 <<  3)
-#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
-#define MUX_PA07B_USART0_TXD            _L(1)
+#define GPIO_PC03C_USART0_TXD    _UL_(1 <<  3)
+#define PIN_PA07B_USART0_TXD            _L_(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L_(1)
 #define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
-#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
-#define PIN_PB01B_USART0_TXD           _L(33) /**< \brief USART0 signal: TXD on PB01 mux B */
-#define MUX_PB01B_USART0_TXD            _L(1)
+#define GPIO_PA07B_USART0_TXD    _UL_(1 <<  7)
+#define PIN_PB01B_USART0_TXD           _L_(33) /**< \brief USART0 signal: TXD on PB01 mux B */
+#define MUX_PB01B_USART0_TXD            _L_(1)
 #define PINMUX_PB01B_USART0_TXD    ((PIN_PB01B_USART0_TXD << 16) | MUX_PB01B_USART0_TXD)
-#define GPIO_PB01B_USART0_TXD    _UL(1 <<  1)
-#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
-#define MUX_PA12A_USART0_TXD            _L(0)
+#define GPIO_PB01B_USART0_TXD    _UL_(1 <<  1)
+#define PIN_PA12A_USART0_TXD           _L_(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L_(0)
 #define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
-#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
-#define PIN_PB15A_USART0_TXD           _L(47) /**< \brief USART0 signal: TXD on PB15 mux A */
-#define MUX_PB15A_USART0_TXD            _L(0)
+#define GPIO_PA12A_USART0_TXD    _UL_(1 << 12)
+#define PIN_PB15A_USART0_TXD           _L_(47) /**< \brief USART0 signal: TXD on PB15 mux A */
+#define MUX_PB15A_USART0_TXD            _L_(0)
 #define PINMUX_PB15A_USART0_TXD    ((PIN_PB15A_USART0_TXD << 16) | MUX_PB15A_USART0_TXD)
-#define GPIO_PB15A_USART0_TXD    _UL(1 << 15)
+#define GPIO_PB15A_USART0_TXD    _UL_(1 << 15)
 /* ========== GPIO definition for USART1 peripheral ========== */
-#define PIN_PB03B_USART1_CLK           _L(35) /**< \brief USART1 signal: CLK on PB03 mux B */
-#define MUX_PB03B_USART1_CLK            _L(1)
+#define PIN_PB03B_USART1_CLK           _L_(35) /**< \brief USART1 signal: CLK on PB03 mux B */
+#define MUX_PB03B_USART1_CLK            _L_(1)
 #define PINMUX_PB03B_USART1_CLK    ((PIN_PB03B_USART1_CLK << 16) | MUX_PB03B_USART1_CLK)
-#define GPIO_PB03B_USART1_CLK    _UL(1 <<  3)
-#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
-#define MUX_PA14A_USART1_CLK            _L(0)
+#define GPIO_PB03B_USART1_CLK    _UL_(1 <<  3)
+#define PIN_PA14A_USART1_CLK           _L_(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L_(0)
 #define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
-#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
-#define PIN_PC25A_USART1_CLK           _L(89) /**< \brief USART1 signal: CLK on PC25 mux A */
-#define MUX_PC25A_USART1_CLK            _L(0)
+#define GPIO_PA14A_USART1_CLK    _UL_(1 << 14)
+#define PIN_PC25A_USART1_CLK           _L_(89) /**< \brief USART1 signal: CLK on PC25 mux A */
+#define MUX_PC25A_USART1_CLK            _L_(0)
 #define PINMUX_PC25A_USART1_CLK    ((PIN_PC25A_USART1_CLK << 16) | MUX_PC25A_USART1_CLK)
-#define GPIO_PC25A_USART1_CLK    _UL(1 << 25)
-#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
-#define MUX_PA21B_USART1_CTS            _L(1)
+#define GPIO_PC25A_USART1_CLK    _UL_(1 << 25)
+#define PIN_PA21B_USART1_CTS           _L_(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L_(1)
 #define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
-#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
-#define PIN_PB02B_USART1_RTS           _L(34) /**< \brief USART1 signal: RTS on PB02 mux B */
-#define MUX_PB02B_USART1_RTS            _L(1)
+#define GPIO_PA21B_USART1_CTS    _UL_(1 << 21)
+#define PIN_PB02B_USART1_RTS           _L_(34) /**< \brief USART1 signal: RTS on PB02 mux B */
+#define MUX_PB02B_USART1_RTS            _L_(1)
 #define PINMUX_PB02B_USART1_RTS    ((PIN_PB02B_USART1_RTS << 16) | MUX_PB02B_USART1_RTS)
-#define GPIO_PB02B_USART1_RTS    _UL(1 <<  2)
-#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
-#define MUX_PA13A_USART1_RTS            _L(0)
+#define GPIO_PB02B_USART1_RTS    _UL_(1 <<  2)
+#define PIN_PA13A_USART1_RTS           _L_(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L_(0)
 #define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
-#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
-#define PIN_PC24A_USART1_RTS           _L(88) /**< \brief USART1 signal: RTS on PC24 mux A */
-#define MUX_PC24A_USART1_RTS            _L(0)
+#define GPIO_PA13A_USART1_RTS    _UL_(1 << 13)
+#define PIN_PC24A_USART1_RTS           _L_(88) /**< \brief USART1 signal: RTS on PC24 mux A */
+#define MUX_PC24A_USART1_RTS            _L_(0)
 #define PINMUX_PC24A_USART1_RTS    ((PIN_PC24A_USART1_RTS << 16) | MUX_PC24A_USART1_RTS)
-#define GPIO_PC24A_USART1_RTS    _UL(1 << 24)
-#define PIN_PB04B_USART1_RXD           _L(36) /**< \brief USART1 signal: RXD on PB04 mux B */
-#define MUX_PB04B_USART1_RXD            _L(1)
+#define GPIO_PC24A_USART1_RTS    _UL_(1 << 24)
+#define PIN_PB04B_USART1_RXD           _L_(36) /**< \brief USART1 signal: RXD on PB04 mux B */
+#define MUX_PB04B_USART1_RXD            _L_(1)
 #define PINMUX_PB04B_USART1_RXD    ((PIN_PB04B_USART1_RXD << 16) | MUX_PB04B_USART1_RXD)
-#define GPIO_PB04B_USART1_RXD    _UL(1 <<  4)
-#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
-#define MUX_PA15A_USART1_RXD            _L(0)
+#define GPIO_PB04B_USART1_RXD    _UL_(1 <<  4)
+#define PIN_PA15A_USART1_RXD           _L_(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L_(0)
 #define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
-#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
-#define PIN_PC26A_USART1_RXD           _L(90) /**< \brief USART1 signal: RXD on PC26 mux A */
-#define MUX_PC26A_USART1_RXD            _L(0)
+#define GPIO_PA15A_USART1_RXD    _UL_(1 << 15)
+#define PIN_PC26A_USART1_RXD           _L_(90) /**< \brief USART1 signal: RXD on PC26 mux A */
+#define MUX_PC26A_USART1_RXD            _L_(0)
 #define PINMUX_PC26A_USART1_RXD    ((PIN_PC26A_USART1_RXD << 16) | MUX_PC26A_USART1_RXD)
-#define GPIO_PC26A_USART1_RXD    _UL(1 << 26)
-#define PIN_PB05B_USART1_TXD           _L(37) /**< \brief USART1 signal: TXD on PB05 mux B */
-#define MUX_PB05B_USART1_TXD            _L(1)
+#define GPIO_PC26A_USART1_RXD    _UL_(1 << 26)
+#define PIN_PB05B_USART1_TXD           _L_(37) /**< \brief USART1 signal: TXD on PB05 mux B */
+#define MUX_PB05B_USART1_TXD            _L_(1)
 #define PINMUX_PB05B_USART1_TXD    ((PIN_PB05B_USART1_TXD << 16) | MUX_PB05B_USART1_TXD)
-#define GPIO_PB05B_USART1_TXD    _UL(1 <<  5)
-#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
-#define MUX_PA16A_USART1_TXD            _L(0)
+#define GPIO_PB05B_USART1_TXD    _UL_(1 <<  5)
+#define PIN_PA16A_USART1_TXD           _L_(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L_(0)
 #define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
-#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
-#define PIN_PC27A_USART1_TXD           _L(91) /**< \brief USART1 signal: TXD on PC27 mux A */
-#define MUX_PC27A_USART1_TXD            _L(0)
+#define GPIO_PA16A_USART1_TXD    _UL_(1 << 16)
+#define PIN_PC27A_USART1_TXD           _L_(91) /**< \brief USART1 signal: TXD on PC27 mux A */
+#define MUX_PC27A_USART1_TXD            _L_(0)
 #define PINMUX_PC27A_USART1_TXD    ((PIN_PC27A_USART1_TXD << 16) | MUX_PC27A_USART1_TXD)
-#define GPIO_PC27A_USART1_TXD    _UL(1 << 27)
+#define GPIO_PC27A_USART1_TXD    _UL_(1 << 27)
 /* ========== GPIO definition for USART2 peripheral ========== */
-#define PIN_PC08B_USART2_CLK           _L(72) /**< \brief USART2 signal: CLK on PC08 mux B */
-#define MUX_PC08B_USART2_CLK            _L(1)
+#define PIN_PC08B_USART2_CLK           _L_(72) /**< \brief USART2 signal: CLK on PC08 mux B */
+#define MUX_PC08B_USART2_CLK            _L_(1)
 #define PINMUX_PC08B_USART2_CLK    ((PIN_PC08B_USART2_CLK << 16) | MUX_PC08B_USART2_CLK)
-#define GPIO_PC08B_USART2_CLK    _UL(1 <<  8)
-#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
-#define MUX_PA18A_USART2_CLK            _L(0)
+#define GPIO_PC08B_USART2_CLK    _UL_(1 <<  8)
+#define PIN_PA18A_USART2_CLK           _L_(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L_(0)
 #define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
-#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
-#define PIN_PC08E_USART2_CTS           _L(72) /**< \brief USART2 signal: CTS on PC08 mux E */
-#define MUX_PC08E_USART2_CTS            _L(4)
+#define GPIO_PA18A_USART2_CLK    _UL_(1 << 18)
+#define PIN_PC08E_USART2_CTS           _L_(72) /**< \brief USART2 signal: CTS on PC08 mux E */
+#define MUX_PC08E_USART2_CTS            _L_(4)
 #define PINMUX_PC08E_USART2_CTS    ((PIN_PC08E_USART2_CTS << 16) | MUX_PC08E_USART2_CTS)
-#define GPIO_PC08E_USART2_CTS    _UL(1 <<  8)
-#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
-#define MUX_PA22B_USART2_CTS            _L(1)
+#define GPIO_PC08E_USART2_CTS    _UL_(1 <<  8)
+#define PIN_PA22B_USART2_CTS           _L_(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L_(1)
 #define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
-#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
-#define PIN_PC07B_USART2_RTS           _L(71) /**< \brief USART2 signal: RTS on PC07 mux B */
-#define MUX_PC07B_USART2_RTS            _L(1)
+#define GPIO_PA22B_USART2_CTS    _UL_(1 << 22)
+#define PIN_PC07B_USART2_RTS           _L_(71) /**< \brief USART2 signal: RTS on PC07 mux B */
+#define MUX_PC07B_USART2_RTS            _L_(1)
 #define PINMUX_PC07B_USART2_RTS    ((PIN_PC07B_USART2_RTS << 16) | MUX_PC07B_USART2_RTS)
-#define GPIO_PC07B_USART2_RTS    _UL(1 <<  7)
-#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
-#define MUX_PA17A_USART2_RTS            _L(0)
+#define GPIO_PC07B_USART2_RTS    _UL_(1 <<  7)
+#define PIN_PA17A_USART2_RTS           _L_(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L_(0)
 #define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
-#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
-#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
-#define MUX_PA25B_USART2_RXD            _L(1)
+#define GPIO_PA17A_USART2_RTS    _UL_(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L_(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L_(1)
 #define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
-#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
-#define PIN_PC11B_USART2_RXD           _L(75) /**< \brief USART2 signal: RXD on PC11 mux B */
-#define MUX_PC11B_USART2_RXD            _L(1)
+#define GPIO_PA25B_USART2_RXD    _UL_(1 << 25)
+#define PIN_PC11B_USART2_RXD           _L_(75) /**< \brief USART2 signal: RXD on PC11 mux B */
+#define MUX_PC11B_USART2_RXD            _L_(1)
 #define PINMUX_PC11B_USART2_RXD    ((PIN_PC11B_USART2_RXD << 16) | MUX_PC11B_USART2_RXD)
-#define GPIO_PC11B_USART2_RXD    _UL(1 << 11)
-#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
-#define MUX_PA19A_USART2_RXD            _L(0)
+#define GPIO_PC11B_USART2_RXD    _UL_(1 << 11)
+#define PIN_PA19A_USART2_RXD           _L_(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L_(0)
 #define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
-#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
-#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
-#define MUX_PA26B_USART2_TXD            _L(1)
+#define GPIO_PA19A_USART2_RXD    _UL_(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L_(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L_(1)
 #define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
-#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
-#define PIN_PC12B_USART2_TXD           _L(76) /**< \brief USART2 signal: TXD on PC12 mux B */
-#define MUX_PC12B_USART2_TXD            _L(1)
+#define GPIO_PA26B_USART2_TXD    _UL_(1 << 26)
+#define PIN_PC12B_USART2_TXD           _L_(76) /**< \brief USART2 signal: TXD on PC12 mux B */
+#define MUX_PC12B_USART2_TXD            _L_(1)
 #define PINMUX_PC12B_USART2_TXD    ((PIN_PC12B_USART2_TXD << 16) | MUX_PC12B_USART2_TXD)
-#define GPIO_PC12B_USART2_TXD    _UL(1 << 12)
-#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
-#define MUX_PA20A_USART2_TXD            _L(0)
+#define GPIO_PC12B_USART2_TXD    _UL_(1 << 12)
+#define PIN_PA20A_USART2_TXD           _L_(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L_(0)
 #define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
-#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+#define GPIO_PA20A_USART2_TXD    _UL_(1 << 20)
 /* ========== GPIO definition for USART3 peripheral ========== */
-#define PIN_PC14B_USART3_CLK           _L(78) /**< \brief USART3 signal: CLK on PC14 mux B */
-#define MUX_PC14B_USART3_CLK            _L(1)
+#define PIN_PC14B_USART3_CLK           _L_(78) /**< \brief USART3 signal: CLK on PC14 mux B */
+#define MUX_PC14B_USART3_CLK            _L_(1)
 #define PINMUX_PC14B_USART3_CLK    ((PIN_PC14B_USART3_CLK << 16) | MUX_PC14B_USART3_CLK)
-#define GPIO_PC14B_USART3_CLK    _UL(1 << 14)
-#define PIN_PB08A_USART3_CLK           _L(40) /**< \brief USART3 signal: CLK on PB08 mux A */
-#define MUX_PB08A_USART3_CLK            _L(0)
+#define GPIO_PC14B_USART3_CLK    _UL_(1 << 14)
+#define PIN_PB08A_USART3_CLK           _L_(40) /**< \brief USART3 signal: CLK on PB08 mux A */
+#define MUX_PB08A_USART3_CLK            _L_(0)
 #define PINMUX_PB08A_USART3_CLK    ((PIN_PB08A_USART3_CLK << 16) | MUX_PB08A_USART3_CLK)
-#define GPIO_PB08A_USART3_CLK    _UL(1 <<  8)
-#define PIN_PC31A_USART3_CLK           _L(95) /**< \brief USART3 signal: CLK on PC31 mux A */
-#define MUX_PC31A_USART3_CLK            _L(0)
+#define GPIO_PB08A_USART3_CLK    _UL_(1 <<  8)
+#define PIN_PC31A_USART3_CLK           _L_(95) /**< \brief USART3 signal: CLK on PC31 mux A */
+#define MUX_PC31A_USART3_CLK            _L_(0)
 #define PINMUX_PC31A_USART3_CLK    ((PIN_PC31A_USART3_CLK << 16) | MUX_PC31A_USART3_CLK)
-#define GPIO_PC31A_USART3_CLK    _UL(1 << 31)
-#define PIN_PB07A_USART3_CTS           _L(39) /**< \brief USART3 signal: CTS on PB07 mux A */
-#define MUX_PB07A_USART3_CTS            _L(0)
+#define GPIO_PC31A_USART3_CLK    _UL_(1 << 31)
+#define PIN_PB07A_USART3_CTS           _L_(39) /**< \brief USART3 signal: CTS on PB07 mux A */
+#define MUX_PB07A_USART3_CTS            _L_(0)
 #define PINMUX_PB07A_USART3_CTS    ((PIN_PB07A_USART3_CTS << 16) | MUX_PB07A_USART3_CTS)
-#define GPIO_PB07A_USART3_CTS    _UL(1 <<  7)
-#define PIN_PC13B_USART3_RTS           _L(77) /**< \brief USART3 signal: RTS on PC13 mux B */
-#define MUX_PC13B_USART3_RTS            _L(1)
+#define GPIO_PB07A_USART3_CTS    _UL_(1 <<  7)
+#define PIN_PC13B_USART3_RTS           _L_(77) /**< \brief USART3 signal: RTS on PC13 mux B */
+#define MUX_PC13B_USART3_RTS            _L_(1)
 #define PINMUX_PC13B_USART3_RTS    ((PIN_PC13B_USART3_RTS << 16) | MUX_PC13B_USART3_RTS)
-#define GPIO_PC13B_USART3_RTS    _UL(1 << 13)
-#define PIN_PB06A_USART3_RTS           _L(38) /**< \brief USART3 signal: RTS on PB06 mux A */
-#define MUX_PB06A_USART3_RTS            _L(0)
+#define GPIO_PC13B_USART3_RTS    _UL_(1 << 13)
+#define PIN_PB06A_USART3_RTS           _L_(38) /**< \brief USART3 signal: RTS on PB06 mux A */
+#define MUX_PB06A_USART3_RTS            _L_(0)
 #define PINMUX_PB06A_USART3_RTS    ((PIN_PB06A_USART3_RTS << 16) | MUX_PB06A_USART3_RTS)
-#define GPIO_PB06A_USART3_RTS    _UL(1 <<  6)
-#define PIN_PC30A_USART3_RTS           _L(94) /**< \brief USART3 signal: RTS on PC30 mux A */
-#define MUX_PC30A_USART3_RTS            _L(0)
+#define GPIO_PB06A_USART3_RTS    _UL_(1 <<  6)
+#define PIN_PC30A_USART3_RTS           _L_(94) /**< \brief USART3 signal: RTS on PC30 mux A */
+#define MUX_PC30A_USART3_RTS            _L_(0)
 #define PINMUX_PC30A_USART3_RTS    ((PIN_PC30A_USART3_RTS << 16) | MUX_PC30A_USART3_RTS)
-#define GPIO_PC30A_USART3_RTS    _UL(1 << 30)
-#define PIN_PC09B_USART3_RXD           _L(73) /**< \brief USART3 signal: RXD on PC09 mux B */
-#define MUX_PC09B_USART3_RXD            _L(1)
+#define GPIO_PC30A_USART3_RTS    _UL_(1 << 30)
+#define PIN_PC09B_USART3_RXD           _L_(73) /**< \brief USART3 signal: RXD on PC09 mux B */
+#define MUX_PC09B_USART3_RXD            _L_(1)
 #define PINMUX_PC09B_USART3_RXD    ((PIN_PC09B_USART3_RXD << 16) | MUX_PC09B_USART3_RXD)
-#define GPIO_PC09B_USART3_RXD    _UL(1 <<  9)
-#define PIN_PB09A_USART3_RXD           _L(41) /**< \brief USART3 signal: RXD on PB09 mux A */
-#define MUX_PB09A_USART3_RXD            _L(0)
+#define GPIO_PC09B_USART3_RXD    _UL_(1 <<  9)
+#define PIN_PB09A_USART3_RXD           _L_(41) /**< \brief USART3 signal: RXD on PB09 mux A */
+#define MUX_PB09A_USART3_RXD            _L_(0)
 #define PINMUX_PB09A_USART3_RXD    ((PIN_PB09A_USART3_RXD << 16) | MUX_PB09A_USART3_RXD)
-#define GPIO_PB09A_USART3_RXD    _UL(1 <<  9)
-#define PIN_PC28A_USART3_RXD           _L(92) /**< \brief USART3 signal: RXD on PC28 mux A */
-#define MUX_PC28A_USART3_RXD            _L(0)
+#define GPIO_PB09A_USART3_RXD    _UL_(1 <<  9)
+#define PIN_PC28A_USART3_RXD           _L_(92) /**< \brief USART3 signal: RXD on PC28 mux A */
+#define MUX_PC28A_USART3_RXD            _L_(0)
 #define PINMUX_PC28A_USART3_RXD    ((PIN_PC28A_USART3_RXD << 16) | MUX_PC28A_USART3_RXD)
-#define GPIO_PC28A_USART3_RXD    _UL(1 << 28)
-#define PIN_PC10B_USART3_TXD           _L(74) /**< \brief USART3 signal: TXD on PC10 mux B */
-#define MUX_PC10B_USART3_TXD            _L(1)
+#define GPIO_PC28A_USART3_RXD    _UL_(1 << 28)
+#define PIN_PC10B_USART3_TXD           _L_(74) /**< \brief USART3 signal: TXD on PC10 mux B */
+#define MUX_PC10B_USART3_TXD            _L_(1)
 #define PINMUX_PC10B_USART3_TXD    ((PIN_PC10B_USART3_TXD << 16) | MUX_PC10B_USART3_TXD)
-#define GPIO_PC10B_USART3_TXD    _UL(1 << 10)
-#define PIN_PB10A_USART3_TXD           _L(42) /**< \brief USART3 signal: TXD on PB10 mux A */
-#define MUX_PB10A_USART3_TXD            _L(0)
+#define GPIO_PC10B_USART3_TXD    _UL_(1 << 10)
+#define PIN_PB10A_USART3_TXD           _L_(42) /**< \brief USART3 signal: TXD on PB10 mux A */
+#define MUX_PB10A_USART3_TXD            _L_(0)
 #define PINMUX_PB10A_USART3_TXD    ((PIN_PB10A_USART3_TXD << 16) | MUX_PB10A_USART3_TXD)
-#define GPIO_PB10A_USART3_TXD    _UL(1 << 10)
-#define PIN_PC29A_USART3_TXD           _L(93) /**< \brief USART3 signal: TXD on PC29 mux A */
-#define MUX_PC29A_USART3_TXD            _L(0)
+#define GPIO_PB10A_USART3_TXD    _UL_(1 << 10)
+#define PIN_PC29A_USART3_TXD           _L_(93) /**< \brief USART3 signal: TXD on PC29 mux A */
+#define MUX_PC29A_USART3_TXD            _L_(0)
 #define PINMUX_PC29A_USART3_TXD    ((PIN_PC29A_USART3_TXD << 16) | MUX_PC29A_USART3_TXD)
-#define GPIO_PC29A_USART3_TXD    _UL(1 << 29)
+#define GPIO_PC29A_USART3_TXD    _UL_(1 << 29)
 /* ========== GPIO definition for ADCIFE peripheral ========== */
-#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
-#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PIN_PA04A_ADCIFE_AD0            _L_(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L_(0)
 #define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
-#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
-#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
-#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL_(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L_(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L_(0)
 #define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
-#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
-#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
-#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define GPIO_PA05A_ADCIFE_AD1    _UL_(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L_(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L_(0)
 #define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
-#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
-#define PIN_PB02A_ADCIFE_AD3           _L(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
-#define MUX_PB02A_ADCIFE_AD3            _L(0)
+#define GPIO_PA07A_ADCIFE_AD2    _UL_(1 <<  7)
+#define PIN_PB02A_ADCIFE_AD3           _L_(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
+#define MUX_PB02A_ADCIFE_AD3            _L_(0)
 #define PINMUX_PB02A_ADCIFE_AD3    ((PIN_PB02A_ADCIFE_AD3 << 16) | MUX_PB02A_ADCIFE_AD3)
-#define GPIO_PB02A_ADCIFE_AD3    _UL(1 <<  2)
-#define PIN_PB03A_ADCIFE_AD4           _L(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
-#define MUX_PB03A_ADCIFE_AD4            _L(0)
+#define GPIO_PB02A_ADCIFE_AD3    _UL_(1 <<  2)
+#define PIN_PB03A_ADCIFE_AD4           _L_(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
+#define MUX_PB03A_ADCIFE_AD4            _L_(0)
 #define PINMUX_PB03A_ADCIFE_AD4    ((PIN_PB03A_ADCIFE_AD4 << 16) | MUX_PB03A_ADCIFE_AD4)
-#define GPIO_PB03A_ADCIFE_AD4    _UL(1 <<  3)
-#define PIN_PB04A_ADCIFE_AD5           _L(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
-#define MUX_PB04A_ADCIFE_AD5            _L(0)
+#define GPIO_PB03A_ADCIFE_AD4    _UL_(1 <<  3)
+#define PIN_PB04A_ADCIFE_AD5           _L_(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
+#define MUX_PB04A_ADCIFE_AD5            _L_(0)
 #define PINMUX_PB04A_ADCIFE_AD5    ((PIN_PB04A_ADCIFE_AD5 << 16) | MUX_PB04A_ADCIFE_AD5)
-#define GPIO_PB04A_ADCIFE_AD5    _UL(1 <<  4)
-#define PIN_PB05A_ADCIFE_AD6           _L(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
-#define MUX_PB05A_ADCIFE_AD6            _L(0)
+#define GPIO_PB04A_ADCIFE_AD5    _UL_(1 <<  4)
+#define PIN_PB05A_ADCIFE_AD6           _L_(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
+#define MUX_PB05A_ADCIFE_AD6            _L_(0)
 #define PINMUX_PB05A_ADCIFE_AD6    ((PIN_PB05A_ADCIFE_AD6 << 16) | MUX_PB05A_ADCIFE_AD6)
-#define GPIO_PB05A_ADCIFE_AD6    _UL(1 <<  5)
-#define PIN_PC07A_ADCIFE_AD7           _L(71) /**< \brief ADCIFE signal: AD7 on PC07 mux A */
-#define MUX_PC07A_ADCIFE_AD7            _L(0)
+#define GPIO_PB05A_ADCIFE_AD6    _UL_(1 <<  5)
+#define PIN_PC07A_ADCIFE_AD7           _L_(71) /**< \brief ADCIFE signal: AD7 on PC07 mux A */
+#define MUX_PC07A_ADCIFE_AD7            _L_(0)
 #define PINMUX_PC07A_ADCIFE_AD7    ((PIN_PC07A_ADCIFE_AD7 << 16) | MUX_PC07A_ADCIFE_AD7)
-#define GPIO_PC07A_ADCIFE_AD7    _UL(1 <<  7)
-#define PIN_PC08A_ADCIFE_AD8           _L(72) /**< \brief ADCIFE signal: AD8 on PC08 mux A */
-#define MUX_PC08A_ADCIFE_AD8            _L(0)
+#define GPIO_PC07A_ADCIFE_AD7    _UL_(1 <<  7)
+#define PIN_PC08A_ADCIFE_AD8           _L_(72) /**< \brief ADCIFE signal: AD8 on PC08 mux A */
+#define MUX_PC08A_ADCIFE_AD8            _L_(0)
 #define PINMUX_PC08A_ADCIFE_AD8    ((PIN_PC08A_ADCIFE_AD8 << 16) | MUX_PC08A_ADCIFE_AD8)
-#define GPIO_PC08A_ADCIFE_AD8    _UL(1 <<  8)
-#define PIN_PC09A_ADCIFE_AD9           _L(73) /**< \brief ADCIFE signal: AD9 on PC09 mux A */
-#define MUX_PC09A_ADCIFE_AD9            _L(0)
+#define GPIO_PC08A_ADCIFE_AD8    _UL_(1 <<  8)
+#define PIN_PC09A_ADCIFE_AD9           _L_(73) /**< \brief ADCIFE signal: AD9 on PC09 mux A */
+#define MUX_PC09A_ADCIFE_AD9            _L_(0)
 #define PINMUX_PC09A_ADCIFE_AD9    ((PIN_PC09A_ADCIFE_AD9 << 16) | MUX_PC09A_ADCIFE_AD9)
-#define GPIO_PC09A_ADCIFE_AD9    _UL(1 <<  9)
-#define PIN_PC10A_ADCIFE_AD10          _L(74) /**< \brief ADCIFE signal: AD10 on PC10 mux A */
-#define MUX_PC10A_ADCIFE_AD10           _L(0)
+#define GPIO_PC09A_ADCIFE_AD9    _UL_(1 <<  9)
+#define PIN_PC10A_ADCIFE_AD10          _L_(74) /**< \brief ADCIFE signal: AD10 on PC10 mux A */
+#define MUX_PC10A_ADCIFE_AD10           _L_(0)
 #define PINMUX_PC10A_ADCIFE_AD10   ((PIN_PC10A_ADCIFE_AD10 << 16) | MUX_PC10A_ADCIFE_AD10)
-#define GPIO_PC10A_ADCIFE_AD10   _UL(1 << 10)
-#define PIN_PC11A_ADCIFE_AD11          _L(75) /**< \brief ADCIFE signal: AD11 on PC11 mux A */
-#define MUX_PC11A_ADCIFE_AD11           _L(0)
+#define GPIO_PC10A_ADCIFE_AD10   _UL_(1 << 10)
+#define PIN_PC11A_ADCIFE_AD11          _L_(75) /**< \brief ADCIFE signal: AD11 on PC11 mux A */
+#define MUX_PC11A_ADCIFE_AD11           _L_(0)
 #define PINMUX_PC11A_ADCIFE_AD11   ((PIN_PC11A_ADCIFE_AD11 << 16) | MUX_PC11A_ADCIFE_AD11)
-#define GPIO_PC11A_ADCIFE_AD11   _UL(1 << 11)
-#define PIN_PC12A_ADCIFE_AD12          _L(76) /**< \brief ADCIFE signal: AD12 on PC12 mux A */
-#define MUX_PC12A_ADCIFE_AD12           _L(0)
+#define GPIO_PC11A_ADCIFE_AD11   _UL_(1 << 11)
+#define PIN_PC12A_ADCIFE_AD12          _L_(76) /**< \brief ADCIFE signal: AD12 on PC12 mux A */
+#define MUX_PC12A_ADCIFE_AD12           _L_(0)
 #define PINMUX_PC12A_ADCIFE_AD12   ((PIN_PC12A_ADCIFE_AD12 << 16) | MUX_PC12A_ADCIFE_AD12)
-#define GPIO_PC12A_ADCIFE_AD12   _UL(1 << 12)
-#define PIN_PC13A_ADCIFE_AD13          _L(77) /**< \brief ADCIFE signal: AD13 on PC13 mux A */
-#define MUX_PC13A_ADCIFE_AD13           _L(0)
+#define GPIO_PC12A_ADCIFE_AD12   _UL_(1 << 12)
+#define PIN_PC13A_ADCIFE_AD13          _L_(77) /**< \brief ADCIFE signal: AD13 on PC13 mux A */
+#define MUX_PC13A_ADCIFE_AD13           _L_(0)
 #define PINMUX_PC13A_ADCIFE_AD13   ((PIN_PC13A_ADCIFE_AD13 << 16) | MUX_PC13A_ADCIFE_AD13)
-#define GPIO_PC13A_ADCIFE_AD13   _UL(1 << 13)
-#define PIN_PC14A_ADCIFE_AD14          _L(78) /**< \brief ADCIFE signal: AD14 on PC14 mux A */
-#define MUX_PC14A_ADCIFE_AD14           _L(0)
+#define GPIO_PC13A_ADCIFE_AD13   _UL_(1 << 13)
+#define PIN_PC14A_ADCIFE_AD14          _L_(78) /**< \brief ADCIFE signal: AD14 on PC14 mux A */
+#define MUX_PC14A_ADCIFE_AD14           _L_(0)
 #define PINMUX_PC14A_ADCIFE_AD14   ((PIN_PC14A_ADCIFE_AD14 << 16) | MUX_PC14A_ADCIFE_AD14)
-#define GPIO_PC14A_ADCIFE_AD14   _UL(1 << 14)
-#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
-#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define GPIO_PC14A_ADCIFE_AD14   _UL_(1 << 14)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L_(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L_(4)
 #define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
-#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL_(1 <<  5)
 /* ========== GPIO definition for DACC peripheral ========== */
-#define PIN_PB04E_DACC_EXT_TRIG0       _L(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
-#define MUX_PB04E_DACC_EXT_TRIG0        _L(4)
+#define PIN_PB04E_DACC_EXT_TRIG0       _L_(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
+#define MUX_PB04E_DACC_EXT_TRIG0        _L_(4)
 #define PINMUX_PB04E_DACC_EXT_TRIG0  ((PIN_PB04E_DACC_EXT_TRIG0 << 16) | MUX_PB04E_DACC_EXT_TRIG0)
-#define GPIO_PB04E_DACC_EXT_TRIG0  _UL(1 <<  4)
-#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
-#define MUX_PA06A_DACC_VOUT             _L(0)
+#define GPIO_PB04E_DACC_EXT_TRIG0  _UL_(1 <<  4)
+#define PIN_PA06A_DACC_VOUT             _L_(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L_(0)
 #define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
-#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+#define GPIO_PA06A_DACC_VOUT     _UL_(1 <<  6)
 /* ========== GPIO definition for ACIFC peripheral ========== */
-#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
-#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PIN_PA06E_ACIFC_ACAN0           _L_(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L_(4)
 #define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
-#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
-#define PIN_PC09E_ACIFC_ACAN1          _L(73) /**< \brief ACIFC signal: ACAN1 on PC09 mux E */
-#define MUX_PC09E_ACIFC_ACAN1           _L(4)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL_(1 <<  6)
+#define PIN_PC09E_ACIFC_ACAN1          _L_(73) /**< \brief ACIFC signal: ACAN1 on PC09 mux E */
+#define MUX_PC09E_ACIFC_ACAN1           _L_(4)
 #define PINMUX_PC09E_ACIFC_ACAN1   ((PIN_PC09E_ACIFC_ACAN1 << 16) | MUX_PC09E_ACIFC_ACAN1)
-#define GPIO_PC09E_ACIFC_ACAN1   _UL(1 <<  9)
-#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
-#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define GPIO_PC09E_ACIFC_ACAN1   _UL_(1 <<  9)
+#define PIN_PA07E_ACIFC_ACAP0           _L_(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L_(4)
 #define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
-#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
-#define PIN_PC10E_ACIFC_ACAP1          _L(74) /**< \brief ACIFC signal: ACAP1 on PC10 mux E */
-#define MUX_PC10E_ACIFC_ACAP1           _L(4)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL_(1 <<  7)
+#define PIN_PC10E_ACIFC_ACAP1          _L_(74) /**< \brief ACIFC signal: ACAP1 on PC10 mux E */
+#define MUX_PC10E_ACIFC_ACAP1           _L_(4)
 #define PINMUX_PC10E_ACIFC_ACAP1   ((PIN_PC10E_ACIFC_ACAP1 << 16) | MUX_PC10E_ACIFC_ACAP1)
-#define GPIO_PC10E_ACIFC_ACAP1   _UL(1 << 10)
-#define PIN_PB02E_ACIFC_ACBN0          _L(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
-#define MUX_PB02E_ACIFC_ACBN0           _L(4)
+#define GPIO_PC10E_ACIFC_ACAP1   _UL_(1 << 10)
+#define PIN_PB02E_ACIFC_ACBN0          _L_(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
+#define MUX_PB02E_ACIFC_ACBN0           _L_(4)
 #define PINMUX_PB02E_ACIFC_ACBN0   ((PIN_PB02E_ACIFC_ACBN0 << 16) | MUX_PB02E_ACIFC_ACBN0)
-#define GPIO_PB02E_ACIFC_ACBN0   _UL(1 <<  2)
-#define PIN_PC13E_ACIFC_ACBN1          _L(77) /**< \brief ACIFC signal: ACBN1 on PC13 mux E */
-#define MUX_PC13E_ACIFC_ACBN1           _L(4)
+#define GPIO_PB02E_ACIFC_ACBN0   _UL_(1 <<  2)
+#define PIN_PC13E_ACIFC_ACBN1          _L_(77) /**< \brief ACIFC signal: ACBN1 on PC13 mux E */
+#define MUX_PC13E_ACIFC_ACBN1           _L_(4)
 #define PINMUX_PC13E_ACIFC_ACBN1   ((PIN_PC13E_ACIFC_ACBN1 << 16) | MUX_PC13E_ACIFC_ACBN1)
-#define GPIO_PC13E_ACIFC_ACBN1   _UL(1 << 13)
-#define PIN_PB03E_ACIFC_ACBP0          _L(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
-#define MUX_PB03E_ACIFC_ACBP0           _L(4)
+#define GPIO_PC13E_ACIFC_ACBN1   _UL_(1 << 13)
+#define PIN_PB03E_ACIFC_ACBP0          _L_(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
+#define MUX_PB03E_ACIFC_ACBP0           _L_(4)
 #define PINMUX_PB03E_ACIFC_ACBP0   ((PIN_PB03E_ACIFC_ACBP0 << 16) | MUX_PB03E_ACIFC_ACBP0)
-#define GPIO_PB03E_ACIFC_ACBP0   _UL(1 <<  3)
-#define PIN_PC14E_ACIFC_ACBP1          _L(78) /**< \brief ACIFC signal: ACBP1 on PC14 mux E */
-#define MUX_PC14E_ACIFC_ACBP1           _L(4)
+#define GPIO_PB03E_ACIFC_ACBP0   _UL_(1 <<  3)
+#define PIN_PC14E_ACIFC_ACBP1          _L_(78) /**< \brief ACIFC signal: ACBP1 on PC14 mux E */
+#define MUX_PC14E_ACIFC_ACBP1           _L_(4)
 #define PINMUX_PC14E_ACIFC_ACBP1   ((PIN_PC14E_ACIFC_ACBP1 << 16) | MUX_PC14E_ACIFC_ACBP1)
-#define GPIO_PC14E_ACIFC_ACBP1   _UL(1 << 14)
+#define GPIO_PC14E_ACIFC_ACBP1   _UL_(1 << 14)
 /* ========== GPIO definition for GLOC peripheral ========== */
-#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
-#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PIN_PA06D_GLOC_IN0              _L_(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L_(3)
 #define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
-#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
-#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
-#define MUX_PA20D_GLOC_IN0              _L(3)
+#define GPIO_PA06D_GLOC_IN0      _UL_(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L_(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L_(3)
 #define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
-#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
-#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
-#define MUX_PA04D_GLOC_IN1              _L(3)
+#define GPIO_PA20D_GLOC_IN0      _UL_(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L_(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L_(3)
 #define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
-#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
-#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
-#define MUX_PA21D_GLOC_IN1              _L(3)
+#define GPIO_PA04D_GLOC_IN1      _UL_(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L_(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L_(3)
 #define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
-#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
-#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
-#define MUX_PA05D_GLOC_IN2              _L(3)
+#define GPIO_PA21D_GLOC_IN1      _UL_(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L_(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L_(3)
 #define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
-#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
-#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
-#define MUX_PA22D_GLOC_IN2              _L(3)
+#define GPIO_PA05D_GLOC_IN2      _UL_(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L_(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L_(3)
 #define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
-#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
-#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
-#define MUX_PA07D_GLOC_IN3              _L(3)
+#define GPIO_PA22D_GLOC_IN2      _UL_(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L_(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L_(3)
 #define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
-#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
-#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
-#define MUX_PA23D_GLOC_IN3              _L(3)
+#define GPIO_PA07D_GLOC_IN3      _UL_(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L_(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L_(3)
 #define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
-#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
-#define PIN_PC15D_GLOC_IN4             _L(79) /**< \brief GLOC signal: IN4 on PC15 mux D */
-#define MUX_PC15D_GLOC_IN4              _L(3)
+#define GPIO_PA23D_GLOC_IN3      _UL_(1 << 23)
+#define PIN_PC15D_GLOC_IN4             _L_(79) /**< \brief GLOC signal: IN4 on PC15 mux D */
+#define MUX_PC15D_GLOC_IN4              _L_(3)
 #define PINMUX_PC15D_GLOC_IN4      ((PIN_PC15D_GLOC_IN4 << 16) | MUX_PC15D_GLOC_IN4)
-#define GPIO_PC15D_GLOC_IN4      _UL(1 << 15)
-#define PIN_PB06C_GLOC_IN4             _L(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
-#define MUX_PB06C_GLOC_IN4              _L(2)
+#define GPIO_PC15D_GLOC_IN4      _UL_(1 << 15)
+#define PIN_PB06C_GLOC_IN4             _L_(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
+#define MUX_PB06C_GLOC_IN4              _L_(2)
 #define PINMUX_PB06C_GLOC_IN4      ((PIN_PB06C_GLOC_IN4 << 16) | MUX_PB06C_GLOC_IN4)
-#define GPIO_PB06C_GLOC_IN4      _UL(1 <<  6)
-#define PIN_PC28C_GLOC_IN4             _L(92) /**< \brief GLOC signal: IN4 on PC28 mux C */
-#define MUX_PC28C_GLOC_IN4              _L(2)
+#define GPIO_PB06C_GLOC_IN4      _UL_(1 <<  6)
+#define PIN_PC28C_GLOC_IN4             _L_(92) /**< \brief GLOC signal: IN4 on PC28 mux C */
+#define MUX_PC28C_GLOC_IN4              _L_(2)
 #define PINMUX_PC28C_GLOC_IN4      ((PIN_PC28C_GLOC_IN4 << 16) | MUX_PC28C_GLOC_IN4)
-#define GPIO_PC28C_GLOC_IN4      _UL(1 << 28)
-#define PIN_PC16D_GLOC_IN5             _L(80) /**< \brief GLOC signal: IN5 on PC16 mux D */
-#define MUX_PC16D_GLOC_IN5              _L(3)
+#define GPIO_PC28C_GLOC_IN4      _UL_(1 << 28)
+#define PIN_PC16D_GLOC_IN5             _L_(80) /**< \brief GLOC signal: IN5 on PC16 mux D */
+#define MUX_PC16D_GLOC_IN5              _L_(3)
 #define PINMUX_PC16D_GLOC_IN5      ((PIN_PC16D_GLOC_IN5 << 16) | MUX_PC16D_GLOC_IN5)
-#define GPIO_PC16D_GLOC_IN5      _UL(1 << 16)
-#define PIN_PB07C_GLOC_IN5             _L(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
-#define MUX_PB07C_GLOC_IN5              _L(2)
+#define GPIO_PC16D_GLOC_IN5      _UL_(1 << 16)
+#define PIN_PB07C_GLOC_IN5             _L_(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
+#define MUX_PB07C_GLOC_IN5              _L_(2)
 #define PINMUX_PB07C_GLOC_IN5      ((PIN_PB07C_GLOC_IN5 << 16) | MUX_PB07C_GLOC_IN5)
-#define GPIO_PB07C_GLOC_IN5      _UL(1 <<  7)
-#define PIN_PC29C_GLOC_IN5             _L(93) /**< \brief GLOC signal: IN5 on PC29 mux C */
-#define MUX_PC29C_GLOC_IN5              _L(2)
+#define GPIO_PB07C_GLOC_IN5      _UL_(1 <<  7)
+#define PIN_PC29C_GLOC_IN5             _L_(93) /**< \brief GLOC signal: IN5 on PC29 mux C */
+#define MUX_PC29C_GLOC_IN5              _L_(2)
 #define PINMUX_PC29C_GLOC_IN5      ((PIN_PC29C_GLOC_IN5 << 16) | MUX_PC29C_GLOC_IN5)
-#define GPIO_PC29C_GLOC_IN5      _UL(1 << 29)
-#define PIN_PC17D_GLOC_IN6             _L(81) /**< \brief GLOC signal: IN6 on PC17 mux D */
-#define MUX_PC17D_GLOC_IN6              _L(3)
+#define GPIO_PC29C_GLOC_IN5      _UL_(1 << 29)
+#define PIN_PC17D_GLOC_IN6             _L_(81) /**< \brief GLOC signal: IN6 on PC17 mux D */
+#define MUX_PC17D_GLOC_IN6              _L_(3)
 #define PINMUX_PC17D_GLOC_IN6      ((PIN_PC17D_GLOC_IN6 << 16) | MUX_PC17D_GLOC_IN6)
-#define GPIO_PC17D_GLOC_IN6      _UL(1 << 17)
-#define PIN_PB08C_GLOC_IN6             _L(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
-#define MUX_PB08C_GLOC_IN6              _L(2)
+#define GPIO_PC17D_GLOC_IN6      _UL_(1 << 17)
+#define PIN_PB08C_GLOC_IN6             _L_(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
+#define MUX_PB08C_GLOC_IN6              _L_(2)
 #define PINMUX_PB08C_GLOC_IN6      ((PIN_PB08C_GLOC_IN6 << 16) | MUX_PB08C_GLOC_IN6)
-#define GPIO_PB08C_GLOC_IN6      _UL(1 <<  8)
-#define PIN_PC30C_GLOC_IN6             _L(94) /**< \brief GLOC signal: IN6 on PC30 mux C */
-#define MUX_PC30C_GLOC_IN6              _L(2)
+#define GPIO_PB08C_GLOC_IN6      _UL_(1 <<  8)
+#define PIN_PC30C_GLOC_IN6             _L_(94) /**< \brief GLOC signal: IN6 on PC30 mux C */
+#define MUX_PC30C_GLOC_IN6              _L_(2)
 #define PINMUX_PC30C_GLOC_IN6      ((PIN_PC30C_GLOC_IN6 << 16) | MUX_PC30C_GLOC_IN6)
-#define GPIO_PC30C_GLOC_IN6      _UL(1 << 30)
-#define PIN_PC18D_GLOC_IN7             _L(82) /**< \brief GLOC signal: IN7 on PC18 mux D */
-#define MUX_PC18D_GLOC_IN7              _L(3)
+#define GPIO_PC30C_GLOC_IN6      _UL_(1 << 30)
+#define PIN_PC18D_GLOC_IN7             _L_(82) /**< \brief GLOC signal: IN7 on PC18 mux D */
+#define MUX_PC18D_GLOC_IN7              _L_(3)
 #define PINMUX_PC18D_GLOC_IN7      ((PIN_PC18D_GLOC_IN7 << 16) | MUX_PC18D_GLOC_IN7)
-#define GPIO_PC18D_GLOC_IN7      _UL(1 << 18)
-#define PIN_PB09C_GLOC_IN7             _L(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
-#define MUX_PB09C_GLOC_IN7              _L(2)
+#define GPIO_PC18D_GLOC_IN7      _UL_(1 << 18)
+#define PIN_PB09C_GLOC_IN7             _L_(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
+#define MUX_PB09C_GLOC_IN7              _L_(2)
 #define PINMUX_PB09C_GLOC_IN7      ((PIN_PB09C_GLOC_IN7 << 16) | MUX_PB09C_GLOC_IN7)
-#define GPIO_PB09C_GLOC_IN7      _UL(1 <<  9)
-#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
-#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define GPIO_PB09C_GLOC_IN7      _UL_(1 <<  9)
+#define PIN_PA08D_GLOC_OUT0             _L_(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
-#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
-#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
-#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define GPIO_PA08D_GLOC_OUT0     _UL_(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L_(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
-#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
-#define PIN_PC19D_GLOC_OUT1            _L(83) /**< \brief GLOC signal: OUT1 on PC19 mux D */
-#define MUX_PC19D_GLOC_OUT1             _L(3)
+#define GPIO_PA24D_GLOC_OUT0     _UL_(1 << 24)
+#define PIN_PC19D_GLOC_OUT1            _L_(83) /**< \brief GLOC signal: OUT1 on PC19 mux D */
+#define MUX_PC19D_GLOC_OUT1             _L_(3)
 #define PINMUX_PC19D_GLOC_OUT1     ((PIN_PC19D_GLOC_OUT1 << 16) | MUX_PC19D_GLOC_OUT1)
-#define GPIO_PC19D_GLOC_OUT1     _UL(1 << 19)
-#define PIN_PB10C_GLOC_OUT1            _L(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
-#define MUX_PB10C_GLOC_OUT1             _L(2)
+#define GPIO_PC19D_GLOC_OUT1     _UL_(1 << 19)
+#define PIN_PB10C_GLOC_OUT1            _L_(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
+#define MUX_PB10C_GLOC_OUT1             _L_(2)
 #define PINMUX_PB10C_GLOC_OUT1     ((PIN_PB10C_GLOC_OUT1 << 16) | MUX_PB10C_GLOC_OUT1)
-#define GPIO_PB10C_GLOC_OUT1     _UL(1 << 10)
-#define PIN_PC31C_GLOC_OUT1            _L(95) /**< \brief GLOC signal: OUT1 on PC31 mux C */
-#define MUX_PC31C_GLOC_OUT1             _L(2)
+#define GPIO_PB10C_GLOC_OUT1     _UL_(1 << 10)
+#define PIN_PC31C_GLOC_OUT1            _L_(95) /**< \brief GLOC signal: OUT1 on PC31 mux C */
+#define MUX_PC31C_GLOC_OUT1             _L_(2)
 #define PINMUX_PC31C_GLOC_OUT1     ((PIN_PC31C_GLOC_OUT1 << 16) | MUX_PC31C_GLOC_OUT1)
-#define GPIO_PC31C_GLOC_OUT1     _UL(1 << 31)
+#define GPIO_PC31C_GLOC_OUT1     _UL_(1 << 31)
 /* ========== GPIO definition for ABDACB peripheral ========== */
-#define PIN_PC12C_ABDACB_CLK           _L(76) /**< \brief ABDACB signal: CLK on PC12 mux C */
-#define MUX_PC12C_ABDACB_CLK            _L(2)
+#define PIN_PC12C_ABDACB_CLK           _L_(76) /**< \brief ABDACB signal: CLK on PC12 mux C */
+#define MUX_PC12C_ABDACB_CLK            _L_(2)
 #define PINMUX_PC12C_ABDACB_CLK    ((PIN_PC12C_ABDACB_CLK << 16) | MUX_PC12C_ABDACB_CLK)
-#define GPIO_PC12C_ABDACB_CLK    _UL(1 << 12)
-#define PIN_PB02C_ABDACB_DAC0          _L(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
-#define MUX_PB02C_ABDACB_DAC0           _L(2)
+#define GPIO_PC12C_ABDACB_CLK    _UL_(1 << 12)
+#define PIN_PB02C_ABDACB_DAC0          _L_(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
+#define MUX_PB02C_ABDACB_DAC0           _L_(2)
 #define PINMUX_PB02C_ABDACB_DAC0   ((PIN_PB02C_ABDACB_DAC0 << 16) | MUX_PB02C_ABDACB_DAC0)
-#define GPIO_PB02C_ABDACB_DAC0   _UL(1 <<  2)
-#define PIN_PC09C_ABDACB_DAC0          _L(73) /**< \brief ABDACB signal: DAC0 on PC09 mux C */
-#define MUX_PC09C_ABDACB_DAC0           _L(2)
+#define GPIO_PB02C_ABDACB_DAC0   _UL_(1 <<  2)
+#define PIN_PC09C_ABDACB_DAC0          _L_(73) /**< \brief ABDACB signal: DAC0 on PC09 mux C */
+#define MUX_PC09C_ABDACB_DAC0           _L_(2)
 #define PINMUX_PC09C_ABDACB_DAC0   ((PIN_PC09C_ABDACB_DAC0 << 16) | MUX_PC09C_ABDACB_DAC0)
-#define GPIO_PC09C_ABDACB_DAC0   _UL(1 <<  9)
-#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
-#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define GPIO_PC09C_ABDACB_DAC0   _UL_(1 <<  9)
+#define PIN_PA17B_ABDACB_DAC0          _L_(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L_(1)
 #define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
-#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
-#define PIN_PB04C_ABDACB_DAC1          _L(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
-#define MUX_PB04C_ABDACB_DAC1           _L(2)
+#define GPIO_PA17B_ABDACB_DAC0   _UL_(1 << 17)
+#define PIN_PB04C_ABDACB_DAC1          _L_(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
+#define MUX_PB04C_ABDACB_DAC1           _L_(2)
 #define PINMUX_PB04C_ABDACB_DAC1   ((PIN_PB04C_ABDACB_DAC1 << 16) | MUX_PB04C_ABDACB_DAC1)
-#define GPIO_PB04C_ABDACB_DAC1   _UL(1 <<  4)
-#define PIN_PC13C_ABDACB_DAC1          _L(77) /**< \brief ABDACB signal: DAC1 on PC13 mux C */
-#define MUX_PC13C_ABDACB_DAC1           _L(2)
+#define GPIO_PB04C_ABDACB_DAC1   _UL_(1 <<  4)
+#define PIN_PC13C_ABDACB_DAC1          _L_(77) /**< \brief ABDACB signal: DAC1 on PC13 mux C */
+#define MUX_PC13C_ABDACB_DAC1           _L_(2)
 #define PINMUX_PC13C_ABDACB_DAC1   ((PIN_PC13C_ABDACB_DAC1 << 16) | MUX_PC13C_ABDACB_DAC1)
-#define GPIO_PC13C_ABDACB_DAC1   _UL(1 << 13)
-#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
-#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define GPIO_PC13C_ABDACB_DAC1   _UL_(1 << 13)
+#define PIN_PA19B_ABDACB_DAC1          _L_(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L_(1)
 #define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
-#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
-#define PIN_PB03C_ABDACB_DACN0         _L(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
-#define MUX_PB03C_ABDACB_DACN0          _L(2)
+#define GPIO_PA19B_ABDACB_DAC1   _UL_(1 << 19)
+#define PIN_PB03C_ABDACB_DACN0         _L_(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
+#define MUX_PB03C_ABDACB_DACN0          _L_(2)
 #define PINMUX_PB03C_ABDACB_DACN0  ((PIN_PB03C_ABDACB_DACN0 << 16) | MUX_PB03C_ABDACB_DACN0)
-#define GPIO_PB03C_ABDACB_DACN0  _UL(1 <<  3)
-#define PIN_PC10C_ABDACB_DACN0         _L(74) /**< \brief ABDACB signal: DACN0 on PC10 mux C */
-#define MUX_PC10C_ABDACB_DACN0          _L(2)
+#define GPIO_PB03C_ABDACB_DACN0  _UL_(1 <<  3)
+#define PIN_PC10C_ABDACB_DACN0         _L_(74) /**< \brief ABDACB signal: DACN0 on PC10 mux C */
+#define MUX_PC10C_ABDACB_DACN0          _L_(2)
 #define PINMUX_PC10C_ABDACB_DACN0  ((PIN_PC10C_ABDACB_DACN0 << 16) | MUX_PC10C_ABDACB_DACN0)
-#define GPIO_PC10C_ABDACB_DACN0  _UL(1 << 10)
-#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
-#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define GPIO_PC10C_ABDACB_DACN0  _UL_(1 << 10)
+#define PIN_PA18B_ABDACB_DACN0         _L_(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L_(1)
 #define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
-#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
-#define PIN_PB05C_ABDACB_DACN1         _L(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
-#define MUX_PB05C_ABDACB_DACN1          _L(2)
+#define GPIO_PA18B_ABDACB_DACN0  _UL_(1 << 18)
+#define PIN_PB05C_ABDACB_DACN1         _L_(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
+#define MUX_PB05C_ABDACB_DACN1          _L_(2)
 #define PINMUX_PB05C_ABDACB_DACN1  ((PIN_PB05C_ABDACB_DACN1 << 16) | MUX_PB05C_ABDACB_DACN1)
-#define GPIO_PB05C_ABDACB_DACN1  _UL(1 <<  5)
-#define PIN_PC14C_ABDACB_DACN1         _L(78) /**< \brief ABDACB signal: DACN1 on PC14 mux C */
-#define MUX_PC14C_ABDACB_DACN1          _L(2)
+#define GPIO_PB05C_ABDACB_DACN1  _UL_(1 <<  5)
+#define PIN_PC14C_ABDACB_DACN1         _L_(78) /**< \brief ABDACB signal: DACN1 on PC14 mux C */
+#define MUX_PC14C_ABDACB_DACN1          _L_(2)
 #define PINMUX_PC14C_ABDACB_DACN1  ((PIN_PC14C_ABDACB_DACN1 << 16) | MUX_PC14C_ABDACB_DACN1)
-#define GPIO_PC14C_ABDACB_DACN1  _UL(1 << 14)
-#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
-#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define GPIO_PC14C_ABDACB_DACN1  _UL_(1 << 14)
+#define PIN_PA20B_ABDACB_DACN1         _L_(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L_(1)
 #define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
-#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+#define GPIO_PA20B_ABDACB_DACN1  _UL_(1 << 20)
 /* ========== GPIO definition for PARC peripheral ========== */
-#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
-#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PIN_PA17D_PARC_PCCK            _L_(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L_(3)
 #define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
-#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
-#define PIN_PC21D_PARC_PCCK            _L(85) /**< \brief PARC signal: PCCK on PC21 mux D */
-#define MUX_PC21D_PARC_PCCK             _L(3)
+#define GPIO_PA17D_PARC_PCCK     _UL_(1 << 17)
+#define PIN_PC21D_PARC_PCCK            _L_(85) /**< \brief PARC signal: PCCK on PC21 mux D */
+#define MUX_PC21D_PARC_PCCK             _L_(3)
 #define PINMUX_PC21D_PARC_PCCK     ((PIN_PC21D_PARC_PCCK << 16) | MUX_PC21D_PARC_PCCK)
-#define GPIO_PC21D_PARC_PCCK     _UL(1 << 21)
-#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
-#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define GPIO_PC21D_PARC_PCCK     _UL_(1 << 21)
+#define PIN_PA09D_PARC_PCDATA0          _L_(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L_(3)
 #define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
-#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
-#define PIN_PC24D_PARC_PCDATA0         _L(88) /**< \brief PARC signal: PCDATA0 on PC24 mux D */
-#define MUX_PC24D_PARC_PCDATA0          _L(3)
+#define GPIO_PA09D_PARC_PCDATA0  _UL_(1 <<  9)
+#define PIN_PC24D_PARC_PCDATA0         _L_(88) /**< \brief PARC signal: PCDATA0 on PC24 mux D */
+#define MUX_PC24D_PARC_PCDATA0          _L_(3)
 #define PINMUX_PC24D_PARC_PCDATA0  ((PIN_PC24D_PARC_PCDATA0 << 16) | MUX_PC24D_PARC_PCDATA0)
-#define GPIO_PC24D_PARC_PCDATA0  _UL(1 << 24)
-#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
-#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define GPIO_PC24D_PARC_PCDATA0  _UL_(1 << 24)
+#define PIN_PA10D_PARC_PCDATA1         _L_(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L_(3)
 #define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
-#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
-#define PIN_PC25D_PARC_PCDATA1         _L(89) /**< \brief PARC signal: PCDATA1 on PC25 mux D */
-#define MUX_PC25D_PARC_PCDATA1          _L(3)
+#define GPIO_PA10D_PARC_PCDATA1  _UL_(1 << 10)
+#define PIN_PC25D_PARC_PCDATA1         _L_(89) /**< \brief PARC signal: PCDATA1 on PC25 mux D */
+#define MUX_PC25D_PARC_PCDATA1          _L_(3)
 #define PINMUX_PC25D_PARC_PCDATA1  ((PIN_PC25D_PARC_PCDATA1 << 16) | MUX_PC25D_PARC_PCDATA1)
-#define GPIO_PC25D_PARC_PCDATA1  _UL(1 << 25)
-#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
-#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define GPIO_PC25D_PARC_PCDATA1  _UL_(1 << 25)
+#define PIN_PA11D_PARC_PCDATA2         _L_(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L_(3)
 #define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
-#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
-#define PIN_PC26D_PARC_PCDATA2         _L(90) /**< \brief PARC signal: PCDATA2 on PC26 mux D */
-#define MUX_PC26D_PARC_PCDATA2          _L(3)
+#define GPIO_PA11D_PARC_PCDATA2  _UL_(1 << 11)
+#define PIN_PC26D_PARC_PCDATA2         _L_(90) /**< \brief PARC signal: PCDATA2 on PC26 mux D */
+#define MUX_PC26D_PARC_PCDATA2          _L_(3)
 #define PINMUX_PC26D_PARC_PCDATA2  ((PIN_PC26D_PARC_PCDATA2 << 16) | MUX_PC26D_PARC_PCDATA2)
-#define GPIO_PC26D_PARC_PCDATA2  _UL(1 << 26)
-#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
-#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define GPIO_PC26D_PARC_PCDATA2  _UL_(1 << 26)
+#define PIN_PA12D_PARC_PCDATA3         _L_(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L_(3)
 #define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
-#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
-#define PIN_PC27D_PARC_PCDATA3         _L(91) /**< \brief PARC signal: PCDATA3 on PC27 mux D */
-#define MUX_PC27D_PARC_PCDATA3          _L(3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL_(1 << 12)
+#define PIN_PC27D_PARC_PCDATA3         _L_(91) /**< \brief PARC signal: PCDATA3 on PC27 mux D */
+#define MUX_PC27D_PARC_PCDATA3          _L_(3)
 #define PINMUX_PC27D_PARC_PCDATA3  ((PIN_PC27D_PARC_PCDATA3 << 16) | MUX_PC27D_PARC_PCDATA3)
-#define GPIO_PC27D_PARC_PCDATA3  _UL(1 << 27)
-#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
-#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define GPIO_PC27D_PARC_PCDATA3  _UL_(1 << 27)
+#define PIN_PA13D_PARC_PCDATA4         _L_(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L_(3)
 #define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
-#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
-#define PIN_PC28D_PARC_PCDATA4         _L(92) /**< \brief PARC signal: PCDATA4 on PC28 mux D */
-#define MUX_PC28D_PARC_PCDATA4          _L(3)
+#define GPIO_PA13D_PARC_PCDATA4  _UL_(1 << 13)
+#define PIN_PC28D_PARC_PCDATA4         _L_(92) /**< \brief PARC signal: PCDATA4 on PC28 mux D */
+#define MUX_PC28D_PARC_PCDATA4          _L_(3)
 #define PINMUX_PC28D_PARC_PCDATA4  ((PIN_PC28D_PARC_PCDATA4 << 16) | MUX_PC28D_PARC_PCDATA4)
-#define GPIO_PC28D_PARC_PCDATA4  _UL(1 << 28)
-#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
-#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define GPIO_PC28D_PARC_PCDATA4  _UL_(1 << 28)
+#define PIN_PA14D_PARC_PCDATA5         _L_(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L_(3)
 #define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
-#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
-#define PIN_PC29D_PARC_PCDATA5         _L(93) /**< \brief PARC signal: PCDATA5 on PC29 mux D */
-#define MUX_PC29D_PARC_PCDATA5          _L(3)
+#define GPIO_PA14D_PARC_PCDATA5  _UL_(1 << 14)
+#define PIN_PC29D_PARC_PCDATA5         _L_(93) /**< \brief PARC signal: PCDATA5 on PC29 mux D */
+#define MUX_PC29D_PARC_PCDATA5          _L_(3)
 #define PINMUX_PC29D_PARC_PCDATA5  ((PIN_PC29D_PARC_PCDATA5 << 16) | MUX_PC29D_PARC_PCDATA5)
-#define GPIO_PC29D_PARC_PCDATA5  _UL(1 << 29)
-#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
-#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define GPIO_PC29D_PARC_PCDATA5  _UL_(1 << 29)
+#define PIN_PA15D_PARC_PCDATA6         _L_(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L_(3)
 #define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
-#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
-#define PIN_PC30D_PARC_PCDATA6         _L(94) /**< \brief PARC signal: PCDATA6 on PC30 mux D */
-#define MUX_PC30D_PARC_PCDATA6          _L(3)
+#define GPIO_PA15D_PARC_PCDATA6  _UL_(1 << 15)
+#define PIN_PC30D_PARC_PCDATA6         _L_(94) /**< \brief PARC signal: PCDATA6 on PC30 mux D */
+#define MUX_PC30D_PARC_PCDATA6          _L_(3)
 #define PINMUX_PC30D_PARC_PCDATA6  ((PIN_PC30D_PARC_PCDATA6 << 16) | MUX_PC30D_PARC_PCDATA6)
-#define GPIO_PC30D_PARC_PCDATA6  _UL(1 << 30)
-#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
-#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define GPIO_PC30D_PARC_PCDATA6  _UL_(1 << 30)
+#define PIN_PA16D_PARC_PCDATA7         _L_(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L_(3)
 #define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
-#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
-#define PIN_PC31D_PARC_PCDATA7         _L(95) /**< \brief PARC signal: PCDATA7 on PC31 mux D */
-#define MUX_PC31D_PARC_PCDATA7          _L(3)
+#define GPIO_PA16D_PARC_PCDATA7  _UL_(1 << 16)
+#define PIN_PC31D_PARC_PCDATA7         _L_(95) /**< \brief PARC signal: PCDATA7 on PC31 mux D */
+#define MUX_PC31D_PARC_PCDATA7          _L_(3)
 #define PINMUX_PC31D_PARC_PCDATA7  ((PIN_PC31D_PARC_PCDATA7 << 16) | MUX_PC31D_PARC_PCDATA7)
-#define GPIO_PC31D_PARC_PCDATA7  _UL(1 << 31)
-#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
-#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define GPIO_PC31D_PARC_PCDATA7  _UL_(1 << 31)
+#define PIN_PA18D_PARC_PCEN1           _L_(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L_(3)
 #define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
-#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
-#define PIN_PC22D_PARC_PCEN1           _L(86) /**< \brief PARC signal: PCEN1 on PC22 mux D */
-#define MUX_PC22D_PARC_PCEN1            _L(3)
+#define GPIO_PA18D_PARC_PCEN1    _UL_(1 << 18)
+#define PIN_PC22D_PARC_PCEN1           _L_(86) /**< \brief PARC signal: PCEN1 on PC22 mux D */
+#define MUX_PC22D_PARC_PCEN1            _L_(3)
 #define PINMUX_PC22D_PARC_PCEN1    ((PIN_PC22D_PARC_PCEN1 << 16) | MUX_PC22D_PARC_PCEN1)
-#define GPIO_PC22D_PARC_PCEN1    _UL(1 << 22)
-#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
-#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define GPIO_PC22D_PARC_PCEN1    _UL_(1 << 22)
+#define PIN_PA19D_PARC_PCEN2           _L_(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L_(3)
 #define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
-#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
-#define PIN_PC23D_PARC_PCEN2           _L(87) /**< \brief PARC signal: PCEN2 on PC23 mux D */
-#define MUX_PC23D_PARC_PCEN2            _L(3)
+#define GPIO_PA19D_PARC_PCEN2    _UL_(1 << 19)
+#define PIN_PC23D_PARC_PCEN2           _L_(87) /**< \brief PARC signal: PCEN2 on PC23 mux D */
+#define MUX_PC23D_PARC_PCEN2            _L_(3)
 #define PINMUX_PC23D_PARC_PCEN2    ((PIN_PC23D_PARC_PCEN2 << 16) | MUX_PC23D_PARC_PCEN2)
-#define GPIO_PC23D_PARC_PCEN2    _UL(1 << 23)
+#define GPIO_PC23D_PARC_PCEN2    _UL_(1 << 23)
 /* ========== GPIO definition for CATB peripheral ========== */
-#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
-#define MUX_PA02G_CATB_DIS              _L(6)
+#define PIN_PA02G_CATB_DIS              _L_(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L_(6)
 #define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
-#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
-#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
-#define MUX_PA12G_CATB_DIS              _L(6)
+#define GPIO_PA02G_CATB_DIS      _UL_(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L_(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L_(6)
 #define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
-#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
-#define MUX_PA23G_CATB_DIS              _L(6)
+#define GPIO_PA12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L_(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L_(6)
 #define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
-#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
-#define PIN_PB03G_CATB_DIS             _L(35) /**< \brief CATB signal: DIS on PB03 mux G */
-#define MUX_PB03G_CATB_DIS              _L(6)
+#define GPIO_PA23G_CATB_DIS      _UL_(1 << 23)
+#define PIN_PB03G_CATB_DIS             _L_(35) /**< \brief CATB signal: DIS on PB03 mux G */
+#define MUX_PB03G_CATB_DIS              _L_(6)
 #define PINMUX_PB03G_CATB_DIS      ((PIN_PB03G_CATB_DIS << 16) | MUX_PB03G_CATB_DIS)
-#define GPIO_PB03G_CATB_DIS      _UL(1 <<  3)
-#define PIN_PB12G_CATB_DIS             _L(44) /**< \brief CATB signal: DIS on PB12 mux G */
-#define MUX_PB12G_CATB_DIS              _L(6)
+#define GPIO_PB03G_CATB_DIS      _UL_(1 <<  3)
+#define PIN_PB12G_CATB_DIS             _L_(44) /**< \brief CATB signal: DIS on PB12 mux G */
+#define MUX_PB12G_CATB_DIS              _L_(6)
 #define PINMUX_PB12G_CATB_DIS      ((PIN_PB12G_CATB_DIS << 16) | MUX_PB12G_CATB_DIS)
-#define GPIO_PB12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PC05G_CATB_DIS             _L(69) /**< \brief CATB signal: DIS on PC05 mux G */
-#define MUX_PC05G_CATB_DIS              _L(6)
+#define GPIO_PB12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PC05G_CATB_DIS             _L_(69) /**< \brief CATB signal: DIS on PC05 mux G */
+#define MUX_PC05G_CATB_DIS              _L_(6)
 #define PINMUX_PC05G_CATB_DIS      ((PIN_PC05G_CATB_DIS << 16) | MUX_PC05G_CATB_DIS)
-#define GPIO_PC05G_CATB_DIS      _UL(1 <<  5)
-#define PIN_PC14G_CATB_DIS             _L(78) /**< \brief CATB signal: DIS on PC14 mux G */
-#define MUX_PC14G_CATB_DIS              _L(6)
+#define GPIO_PC05G_CATB_DIS      _UL_(1 <<  5)
+#define PIN_PC14G_CATB_DIS             _L_(78) /**< \brief CATB signal: DIS on PC14 mux G */
+#define MUX_PC14G_CATB_DIS              _L_(6)
 #define PINMUX_PC14G_CATB_DIS      ((PIN_PC14G_CATB_DIS << 16) | MUX_PC14G_CATB_DIS)
-#define GPIO_PC14G_CATB_DIS      _UL(1 << 14)
-#define PIN_PC23G_CATB_DIS             _L(87) /**< \brief CATB signal: DIS on PC23 mux G */
-#define MUX_PC23G_CATB_DIS              _L(6)
+#define GPIO_PC14G_CATB_DIS      _UL_(1 << 14)
+#define PIN_PC23G_CATB_DIS             _L_(87) /**< \brief CATB signal: DIS on PC23 mux G */
+#define MUX_PC23G_CATB_DIS              _L_(6)
 #define PINMUX_PC23G_CATB_DIS      ((PIN_PC23G_CATB_DIS << 16) | MUX_PC23G_CATB_DIS)
-#define GPIO_PC23G_CATB_DIS      _UL(1 << 23)
-#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
-#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define GPIO_PC23G_CATB_DIS      _UL_(1 << 23)
+#define PIN_PA04G_CATB_SENSE0           _L_(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L_(6)
 #define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
-#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
-#define PIN_PB13G_CATB_SENSE0          _L(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
-#define MUX_PB13G_CATB_SENSE0           _L(6)
+#define GPIO_PA04G_CATB_SENSE0   _UL_(1 <<  4)
+#define PIN_PB13G_CATB_SENSE0          _L_(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
+#define MUX_PB13G_CATB_SENSE0           _L_(6)
 #define PINMUX_PB13G_CATB_SENSE0   ((PIN_PB13G_CATB_SENSE0 << 16) | MUX_PB13G_CATB_SENSE0)
-#define GPIO_PB13G_CATB_SENSE0   _UL(1 << 13)
-#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
-#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define GPIO_PB13G_CATB_SENSE0   _UL_(1 << 13)
+#define PIN_PA05G_CATB_SENSE1           _L_(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L_(6)
 #define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
-#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
-#define PIN_PB14G_CATB_SENSE1          _L(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
-#define MUX_PB14G_CATB_SENSE1           _L(6)
+#define GPIO_PA05G_CATB_SENSE1   _UL_(1 <<  5)
+#define PIN_PB14G_CATB_SENSE1          _L_(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
+#define MUX_PB14G_CATB_SENSE1           _L_(6)
 #define PINMUX_PB14G_CATB_SENSE1   ((PIN_PB14G_CATB_SENSE1 << 16) | MUX_PB14G_CATB_SENSE1)
-#define GPIO_PB14G_CATB_SENSE1   _UL(1 << 14)
-#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
-#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define GPIO_PB14G_CATB_SENSE1   _UL_(1 << 14)
+#define PIN_PA06G_CATB_SENSE2           _L_(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L_(6)
 #define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
-#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
-#define PIN_PB15G_CATB_SENSE2          _L(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
-#define MUX_PB15G_CATB_SENSE2           _L(6)
+#define GPIO_PA06G_CATB_SENSE2   _UL_(1 <<  6)
+#define PIN_PB15G_CATB_SENSE2          _L_(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
+#define MUX_PB15G_CATB_SENSE2           _L_(6)
 #define PINMUX_PB15G_CATB_SENSE2   ((PIN_PB15G_CATB_SENSE2 << 16) | MUX_PB15G_CATB_SENSE2)
-#define GPIO_PB15G_CATB_SENSE2   _UL(1 << 15)
-#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
-#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define GPIO_PB15G_CATB_SENSE2   _UL_(1 << 15)
+#define PIN_PA07G_CATB_SENSE3           _L_(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L_(6)
 #define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
-#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
-#define PIN_PC00G_CATB_SENSE3          _L(64) /**< \brief CATB signal: SENSE3 on PC00 mux G */
-#define MUX_PC00G_CATB_SENSE3           _L(6)
+#define GPIO_PA07G_CATB_SENSE3   _UL_(1 <<  7)
+#define PIN_PC00G_CATB_SENSE3          _L_(64) /**< \brief CATB signal: SENSE3 on PC00 mux G */
+#define MUX_PC00G_CATB_SENSE3           _L_(6)
 #define PINMUX_PC00G_CATB_SENSE3   ((PIN_PC00G_CATB_SENSE3 << 16) | MUX_PC00G_CATB_SENSE3)
-#define GPIO_PC00G_CATB_SENSE3   _UL(1 <<  0)
-#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
-#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define GPIO_PC00G_CATB_SENSE3   _UL_(1 <<  0)
+#define PIN_PA08G_CATB_SENSE4           _L_(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L_(6)
 #define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
-#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
-#define PIN_PC01G_CATB_SENSE4          _L(65) /**< \brief CATB signal: SENSE4 on PC01 mux G */
-#define MUX_PC01G_CATB_SENSE4           _L(6)
+#define GPIO_PA08G_CATB_SENSE4   _UL_(1 <<  8)
+#define PIN_PC01G_CATB_SENSE4          _L_(65) /**< \brief CATB signal: SENSE4 on PC01 mux G */
+#define MUX_PC01G_CATB_SENSE4           _L_(6)
 #define PINMUX_PC01G_CATB_SENSE4   ((PIN_PC01G_CATB_SENSE4 << 16) | MUX_PC01G_CATB_SENSE4)
-#define GPIO_PC01G_CATB_SENSE4   _UL(1 <<  1)
-#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
-#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define GPIO_PC01G_CATB_SENSE4   _UL_(1 <<  1)
+#define PIN_PA09G_CATB_SENSE5           _L_(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L_(6)
 #define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
-#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
-#define PIN_PC02G_CATB_SENSE5          _L(66) /**< \brief CATB signal: SENSE5 on PC02 mux G */
-#define MUX_PC02G_CATB_SENSE5           _L(6)
+#define GPIO_PA09G_CATB_SENSE5   _UL_(1 <<  9)
+#define PIN_PC02G_CATB_SENSE5          _L_(66) /**< \brief CATB signal: SENSE5 on PC02 mux G */
+#define MUX_PC02G_CATB_SENSE5           _L_(6)
 #define PINMUX_PC02G_CATB_SENSE5   ((PIN_PC02G_CATB_SENSE5 << 16) | MUX_PC02G_CATB_SENSE5)
-#define GPIO_PC02G_CATB_SENSE5   _UL(1 <<  2)
-#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
-#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define GPIO_PC02G_CATB_SENSE5   _UL_(1 <<  2)
+#define PIN_PA10G_CATB_SENSE6          _L_(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L_(6)
 #define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
-#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
-#define PIN_PC03G_CATB_SENSE6          _L(67) /**< \brief CATB signal: SENSE6 on PC03 mux G */
-#define MUX_PC03G_CATB_SENSE6           _L(6)
+#define GPIO_PA10G_CATB_SENSE6   _UL_(1 << 10)
+#define PIN_PC03G_CATB_SENSE6          _L_(67) /**< \brief CATB signal: SENSE6 on PC03 mux G */
+#define MUX_PC03G_CATB_SENSE6           _L_(6)
 #define PINMUX_PC03G_CATB_SENSE6   ((PIN_PC03G_CATB_SENSE6 << 16) | MUX_PC03G_CATB_SENSE6)
-#define GPIO_PC03G_CATB_SENSE6   _UL(1 <<  3)
-#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
-#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define GPIO_PC03G_CATB_SENSE6   _UL_(1 <<  3)
+#define PIN_PA11G_CATB_SENSE7          _L_(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L_(6)
 #define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
-#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
-#define PIN_PC04G_CATB_SENSE7          _L(68) /**< \brief CATB signal: SENSE7 on PC04 mux G */
-#define MUX_PC04G_CATB_SENSE7           _L(6)
+#define GPIO_PA11G_CATB_SENSE7   _UL_(1 << 11)
+#define PIN_PC04G_CATB_SENSE7          _L_(68) /**< \brief CATB signal: SENSE7 on PC04 mux G */
+#define MUX_PC04G_CATB_SENSE7           _L_(6)
 #define PINMUX_PC04G_CATB_SENSE7   ((PIN_PC04G_CATB_SENSE7 << 16) | MUX_PC04G_CATB_SENSE7)
-#define GPIO_PC04G_CATB_SENSE7   _UL(1 <<  4)
-#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
-#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define GPIO_PC04G_CATB_SENSE7   _UL_(1 <<  4)
+#define PIN_PA13G_CATB_SENSE8          _L_(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L_(6)
 #define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
-#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
-#define PIN_PC06G_CATB_SENSE8          _L(70) /**< \brief CATB signal: SENSE8 on PC06 mux G */
-#define MUX_PC06G_CATB_SENSE8           _L(6)
+#define GPIO_PA13G_CATB_SENSE8   _UL_(1 << 13)
+#define PIN_PC06G_CATB_SENSE8          _L_(70) /**< \brief CATB signal: SENSE8 on PC06 mux G */
+#define MUX_PC06G_CATB_SENSE8           _L_(6)
 #define PINMUX_PC06G_CATB_SENSE8   ((PIN_PC06G_CATB_SENSE8 << 16) | MUX_PC06G_CATB_SENSE8)
-#define GPIO_PC06G_CATB_SENSE8   _UL(1 <<  6)
-#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
-#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define GPIO_PC06G_CATB_SENSE8   _UL_(1 <<  6)
+#define PIN_PA14G_CATB_SENSE9          _L_(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L_(6)
 #define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
-#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
-#define PIN_PC07G_CATB_SENSE9          _L(71) /**< \brief CATB signal: SENSE9 on PC07 mux G */
-#define MUX_PC07G_CATB_SENSE9           _L(6)
+#define GPIO_PA14G_CATB_SENSE9   _UL_(1 << 14)
+#define PIN_PC07G_CATB_SENSE9          _L_(71) /**< \brief CATB signal: SENSE9 on PC07 mux G */
+#define MUX_PC07G_CATB_SENSE9           _L_(6)
 #define PINMUX_PC07G_CATB_SENSE9   ((PIN_PC07G_CATB_SENSE9 << 16) | MUX_PC07G_CATB_SENSE9)
-#define GPIO_PC07G_CATB_SENSE9   _UL(1 <<  7)
-#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
-#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define GPIO_PC07G_CATB_SENSE9   _UL_(1 <<  7)
+#define PIN_PA15G_CATB_SENSE10         _L_(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L_(6)
 #define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
-#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
-#define PIN_PC08G_CATB_SENSE10         _L(72) /**< \brief CATB signal: SENSE10 on PC08 mux G */
-#define MUX_PC08G_CATB_SENSE10          _L(6)
+#define GPIO_PA15G_CATB_SENSE10  _UL_(1 << 15)
+#define PIN_PC08G_CATB_SENSE10         _L_(72) /**< \brief CATB signal: SENSE10 on PC08 mux G */
+#define MUX_PC08G_CATB_SENSE10          _L_(6)
 #define PINMUX_PC08G_CATB_SENSE10  ((PIN_PC08G_CATB_SENSE10 << 16) | MUX_PC08G_CATB_SENSE10)
-#define GPIO_PC08G_CATB_SENSE10  _UL(1 <<  8)
-#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
-#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define GPIO_PC08G_CATB_SENSE10  _UL_(1 <<  8)
+#define PIN_PA16G_CATB_SENSE11         _L_(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L_(6)
 #define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
-#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
-#define PIN_PC09G_CATB_SENSE11         _L(73) /**< \brief CATB signal: SENSE11 on PC09 mux G */
-#define MUX_PC09G_CATB_SENSE11          _L(6)
+#define GPIO_PA16G_CATB_SENSE11  _UL_(1 << 16)
+#define PIN_PC09G_CATB_SENSE11         _L_(73) /**< \brief CATB signal: SENSE11 on PC09 mux G */
+#define MUX_PC09G_CATB_SENSE11          _L_(6)
 #define PINMUX_PC09G_CATB_SENSE11  ((PIN_PC09G_CATB_SENSE11 << 16) | MUX_PC09G_CATB_SENSE11)
-#define GPIO_PC09G_CATB_SENSE11  _UL(1 <<  9)
-#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
-#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define GPIO_PC09G_CATB_SENSE11  _UL_(1 <<  9)
+#define PIN_PA17G_CATB_SENSE12         _L_(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L_(6)
 #define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
-#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
-#define PIN_PC10G_CATB_SENSE12         _L(74) /**< \brief CATB signal: SENSE12 on PC10 mux G */
-#define MUX_PC10G_CATB_SENSE12          _L(6)
+#define GPIO_PA17G_CATB_SENSE12  _UL_(1 << 17)
+#define PIN_PC10G_CATB_SENSE12         _L_(74) /**< \brief CATB signal: SENSE12 on PC10 mux G */
+#define MUX_PC10G_CATB_SENSE12          _L_(6)
 #define PINMUX_PC10G_CATB_SENSE12  ((PIN_PC10G_CATB_SENSE12 << 16) | MUX_PC10G_CATB_SENSE12)
-#define GPIO_PC10G_CATB_SENSE12  _UL(1 << 10)
-#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
-#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define GPIO_PC10G_CATB_SENSE12  _UL_(1 << 10)
+#define PIN_PA18G_CATB_SENSE13         _L_(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L_(6)
 #define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
-#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
-#define PIN_PC11G_CATB_SENSE13         _L(75) /**< \brief CATB signal: SENSE13 on PC11 mux G */
-#define MUX_PC11G_CATB_SENSE13          _L(6)
+#define GPIO_PA18G_CATB_SENSE13  _UL_(1 << 18)
+#define PIN_PC11G_CATB_SENSE13         _L_(75) /**< \brief CATB signal: SENSE13 on PC11 mux G */
+#define MUX_PC11G_CATB_SENSE13          _L_(6)
 #define PINMUX_PC11G_CATB_SENSE13  ((PIN_PC11G_CATB_SENSE13 << 16) | MUX_PC11G_CATB_SENSE13)
-#define GPIO_PC11G_CATB_SENSE13  _UL(1 << 11)
-#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
-#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define GPIO_PC11G_CATB_SENSE13  _UL_(1 << 11)
+#define PIN_PA19G_CATB_SENSE14         _L_(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L_(6)
 #define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
-#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
-#define PIN_PC12G_CATB_SENSE14         _L(76) /**< \brief CATB signal: SENSE14 on PC12 mux G */
-#define MUX_PC12G_CATB_SENSE14          _L(6)
+#define GPIO_PA19G_CATB_SENSE14  _UL_(1 << 19)
+#define PIN_PC12G_CATB_SENSE14         _L_(76) /**< \brief CATB signal: SENSE14 on PC12 mux G */
+#define MUX_PC12G_CATB_SENSE14          _L_(6)
 #define PINMUX_PC12G_CATB_SENSE14  ((PIN_PC12G_CATB_SENSE14 << 16) | MUX_PC12G_CATB_SENSE14)
-#define GPIO_PC12G_CATB_SENSE14  _UL(1 << 12)
-#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
-#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define GPIO_PC12G_CATB_SENSE14  _UL_(1 << 12)
+#define PIN_PA20G_CATB_SENSE15         _L_(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L_(6)
 #define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
-#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
-#define PIN_PC13G_CATB_SENSE15         _L(77) /**< \brief CATB signal: SENSE15 on PC13 mux G */
-#define MUX_PC13G_CATB_SENSE15          _L(6)
+#define GPIO_PA20G_CATB_SENSE15  _UL_(1 << 20)
+#define PIN_PC13G_CATB_SENSE15         _L_(77) /**< \brief CATB signal: SENSE15 on PC13 mux G */
+#define MUX_PC13G_CATB_SENSE15          _L_(6)
 #define PINMUX_PC13G_CATB_SENSE15  ((PIN_PC13G_CATB_SENSE15 << 16) | MUX_PC13G_CATB_SENSE15)
-#define GPIO_PC13G_CATB_SENSE15  _UL(1 << 13)
-#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
-#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define GPIO_PC13G_CATB_SENSE15  _UL_(1 << 13)
+#define PIN_PA21G_CATB_SENSE16         _L_(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L_(6)
 #define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
-#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
-#define PIN_PC15G_CATB_SENSE16         _L(79) /**< \brief CATB signal: SENSE16 on PC15 mux G */
-#define MUX_PC15G_CATB_SENSE16          _L(6)
+#define GPIO_PA21G_CATB_SENSE16  _UL_(1 << 21)
+#define PIN_PC15G_CATB_SENSE16         _L_(79) /**< \brief CATB signal: SENSE16 on PC15 mux G */
+#define MUX_PC15G_CATB_SENSE16          _L_(6)
 #define PINMUX_PC15G_CATB_SENSE16  ((PIN_PC15G_CATB_SENSE16 << 16) | MUX_PC15G_CATB_SENSE16)
-#define GPIO_PC15G_CATB_SENSE16  _UL(1 << 15)
-#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
-#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define GPIO_PC15G_CATB_SENSE16  _UL_(1 << 15)
+#define PIN_PA22G_CATB_SENSE17         _L_(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L_(6)
 #define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
-#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
-#define PIN_PC16G_CATB_SENSE17         _L(80) /**< \brief CATB signal: SENSE17 on PC16 mux G */
-#define MUX_PC16G_CATB_SENSE17          _L(6)
+#define GPIO_PA22G_CATB_SENSE17  _UL_(1 << 22)
+#define PIN_PC16G_CATB_SENSE17         _L_(80) /**< \brief CATB signal: SENSE17 on PC16 mux G */
+#define MUX_PC16G_CATB_SENSE17          _L_(6)
 #define PINMUX_PC16G_CATB_SENSE17  ((PIN_PC16G_CATB_SENSE17 << 16) | MUX_PC16G_CATB_SENSE17)
-#define GPIO_PC16G_CATB_SENSE17  _UL(1 << 16)
-#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
-#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define GPIO_PC16G_CATB_SENSE17  _UL_(1 << 16)
+#define PIN_PA24G_CATB_SENSE18         _L_(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L_(6)
 #define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
-#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
-#define PIN_PC17G_CATB_SENSE18         _L(81) /**< \brief CATB signal: SENSE18 on PC17 mux G */
-#define MUX_PC17G_CATB_SENSE18          _L(6)
+#define GPIO_PA24G_CATB_SENSE18  _UL_(1 << 24)
+#define PIN_PC17G_CATB_SENSE18         _L_(81) /**< \brief CATB signal: SENSE18 on PC17 mux G */
+#define MUX_PC17G_CATB_SENSE18          _L_(6)
 #define PINMUX_PC17G_CATB_SENSE18  ((PIN_PC17G_CATB_SENSE18 << 16) | MUX_PC17G_CATB_SENSE18)
-#define GPIO_PC17G_CATB_SENSE18  _UL(1 << 17)
-#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
-#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define GPIO_PC17G_CATB_SENSE18  _UL_(1 << 17)
+#define PIN_PA25G_CATB_SENSE19         _L_(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L_(6)
 #define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
-#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
-#define PIN_PC18G_CATB_SENSE19         _L(82) /**< \brief CATB signal: SENSE19 on PC18 mux G */
-#define MUX_PC18G_CATB_SENSE19          _L(6)
+#define GPIO_PA25G_CATB_SENSE19  _UL_(1 << 25)
+#define PIN_PC18G_CATB_SENSE19         _L_(82) /**< \brief CATB signal: SENSE19 on PC18 mux G */
+#define MUX_PC18G_CATB_SENSE19          _L_(6)
 #define PINMUX_PC18G_CATB_SENSE19  ((PIN_PC18G_CATB_SENSE19 << 16) | MUX_PC18G_CATB_SENSE19)
-#define GPIO_PC18G_CATB_SENSE19  _UL(1 << 18)
-#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
-#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define GPIO_PC18G_CATB_SENSE19  _UL_(1 << 18)
+#define PIN_PA26G_CATB_SENSE20         _L_(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L_(6)
 #define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
-#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
-#define PIN_PC19G_CATB_SENSE20         _L(83) /**< \brief CATB signal: SENSE20 on PC19 mux G */
-#define MUX_PC19G_CATB_SENSE20          _L(6)
+#define GPIO_PA26G_CATB_SENSE20  _UL_(1 << 26)
+#define PIN_PC19G_CATB_SENSE20         _L_(83) /**< \brief CATB signal: SENSE20 on PC19 mux G */
+#define MUX_PC19G_CATB_SENSE20          _L_(6)
 #define PINMUX_PC19G_CATB_SENSE20  ((PIN_PC19G_CATB_SENSE20 << 16) | MUX_PC19G_CATB_SENSE20)
-#define GPIO_PC19G_CATB_SENSE20  _UL(1 << 19)
-#define PIN_PB00G_CATB_SENSE21         _L(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
-#define MUX_PB00G_CATB_SENSE21          _L(6)
+#define GPIO_PC19G_CATB_SENSE20  _UL_(1 << 19)
+#define PIN_PB00G_CATB_SENSE21         _L_(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
+#define MUX_PB00G_CATB_SENSE21          _L_(6)
 #define PINMUX_PB00G_CATB_SENSE21  ((PIN_PB00G_CATB_SENSE21 << 16) | MUX_PB00G_CATB_SENSE21)
-#define GPIO_PB00G_CATB_SENSE21  _UL(1 <<  0)
-#define PIN_PC20G_CATB_SENSE21         _L(84) /**< \brief CATB signal: SENSE21 on PC20 mux G */
-#define MUX_PC20G_CATB_SENSE21          _L(6)
+#define GPIO_PB00G_CATB_SENSE21  _UL_(1 <<  0)
+#define PIN_PC20G_CATB_SENSE21         _L_(84) /**< \brief CATB signal: SENSE21 on PC20 mux G */
+#define MUX_PC20G_CATB_SENSE21          _L_(6)
 #define PINMUX_PC20G_CATB_SENSE21  ((PIN_PC20G_CATB_SENSE21 << 16) | MUX_PC20G_CATB_SENSE21)
-#define GPIO_PC20G_CATB_SENSE21  _UL(1 << 20)
-#define PIN_PB01G_CATB_SENSE22         _L(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
-#define MUX_PB01G_CATB_SENSE22          _L(6)
+#define GPIO_PC20G_CATB_SENSE21  _UL_(1 << 20)
+#define PIN_PB01G_CATB_SENSE22         _L_(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
+#define MUX_PB01G_CATB_SENSE22          _L_(6)
 #define PINMUX_PB01G_CATB_SENSE22  ((PIN_PB01G_CATB_SENSE22 << 16) | MUX_PB01G_CATB_SENSE22)
-#define GPIO_PB01G_CATB_SENSE22  _UL(1 <<  1)
-#define PIN_PC21G_CATB_SENSE22         _L(85) /**< \brief CATB signal: SENSE22 on PC21 mux G */
-#define MUX_PC21G_CATB_SENSE22          _L(6)
+#define GPIO_PB01G_CATB_SENSE22  _UL_(1 <<  1)
+#define PIN_PC21G_CATB_SENSE22         _L_(85) /**< \brief CATB signal: SENSE22 on PC21 mux G */
+#define MUX_PC21G_CATB_SENSE22          _L_(6)
 #define PINMUX_PC21G_CATB_SENSE22  ((PIN_PC21G_CATB_SENSE22 << 16) | MUX_PC21G_CATB_SENSE22)
-#define GPIO_PC21G_CATB_SENSE22  _UL(1 << 21)
-#define PIN_PB02G_CATB_SENSE23         _L(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
-#define MUX_PB02G_CATB_SENSE23          _L(6)
+#define GPIO_PC21G_CATB_SENSE22  _UL_(1 << 21)
+#define PIN_PB02G_CATB_SENSE23         _L_(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
+#define MUX_PB02G_CATB_SENSE23          _L_(6)
 #define PINMUX_PB02G_CATB_SENSE23  ((PIN_PB02G_CATB_SENSE23 << 16) | MUX_PB02G_CATB_SENSE23)
-#define GPIO_PB02G_CATB_SENSE23  _UL(1 <<  2)
-#define PIN_PC22G_CATB_SENSE23         _L(86) /**< \brief CATB signal: SENSE23 on PC22 mux G */
-#define MUX_PC22G_CATB_SENSE23          _L(6)
+#define GPIO_PB02G_CATB_SENSE23  _UL_(1 <<  2)
+#define PIN_PC22G_CATB_SENSE23         _L_(86) /**< \brief CATB signal: SENSE23 on PC22 mux G */
+#define MUX_PC22G_CATB_SENSE23          _L_(6)
 #define PINMUX_PC22G_CATB_SENSE23  ((PIN_PC22G_CATB_SENSE23 << 16) | MUX_PC22G_CATB_SENSE23)
-#define GPIO_PC22G_CATB_SENSE23  _UL(1 << 22)
-#define PIN_PB04G_CATB_SENSE24         _L(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
-#define MUX_PB04G_CATB_SENSE24          _L(6)
+#define GPIO_PC22G_CATB_SENSE23  _UL_(1 << 22)
+#define PIN_PB04G_CATB_SENSE24         _L_(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
+#define MUX_PB04G_CATB_SENSE24          _L_(6)
 #define PINMUX_PB04G_CATB_SENSE24  ((PIN_PB04G_CATB_SENSE24 << 16) | MUX_PB04G_CATB_SENSE24)
-#define GPIO_PB04G_CATB_SENSE24  _UL(1 <<  4)
-#define PIN_PC24G_CATB_SENSE24         _L(88) /**< \brief CATB signal: SENSE24 on PC24 mux G */
-#define MUX_PC24G_CATB_SENSE24          _L(6)
+#define GPIO_PB04G_CATB_SENSE24  _UL_(1 <<  4)
+#define PIN_PC24G_CATB_SENSE24         _L_(88) /**< \brief CATB signal: SENSE24 on PC24 mux G */
+#define MUX_PC24G_CATB_SENSE24          _L_(6)
 #define PINMUX_PC24G_CATB_SENSE24  ((PIN_PC24G_CATB_SENSE24 << 16) | MUX_PC24G_CATB_SENSE24)
-#define GPIO_PC24G_CATB_SENSE24  _UL(1 << 24)
-#define PIN_PB05G_CATB_SENSE25         _L(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
-#define MUX_PB05G_CATB_SENSE25          _L(6)
+#define GPIO_PC24G_CATB_SENSE24  _UL_(1 << 24)
+#define PIN_PB05G_CATB_SENSE25         _L_(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
+#define MUX_PB05G_CATB_SENSE25          _L_(6)
 #define PINMUX_PB05G_CATB_SENSE25  ((PIN_PB05G_CATB_SENSE25 << 16) | MUX_PB05G_CATB_SENSE25)
-#define GPIO_PB05G_CATB_SENSE25  _UL(1 <<  5)
-#define PIN_PC25G_CATB_SENSE25         _L(89) /**< \brief CATB signal: SENSE25 on PC25 mux G */
-#define MUX_PC25G_CATB_SENSE25          _L(6)
+#define GPIO_PB05G_CATB_SENSE25  _UL_(1 <<  5)
+#define PIN_PC25G_CATB_SENSE25         _L_(89) /**< \brief CATB signal: SENSE25 on PC25 mux G */
+#define MUX_PC25G_CATB_SENSE25          _L_(6)
 #define PINMUX_PC25G_CATB_SENSE25  ((PIN_PC25G_CATB_SENSE25 << 16) | MUX_PC25G_CATB_SENSE25)
-#define GPIO_PC25G_CATB_SENSE25  _UL(1 << 25)
-#define PIN_PB06G_CATB_SENSE26         _L(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
-#define MUX_PB06G_CATB_SENSE26          _L(6)
+#define GPIO_PC25G_CATB_SENSE25  _UL_(1 << 25)
+#define PIN_PB06G_CATB_SENSE26         _L_(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
+#define MUX_PB06G_CATB_SENSE26          _L_(6)
 #define PINMUX_PB06G_CATB_SENSE26  ((PIN_PB06G_CATB_SENSE26 << 16) | MUX_PB06G_CATB_SENSE26)
-#define GPIO_PB06G_CATB_SENSE26  _UL(1 <<  6)
-#define PIN_PC26G_CATB_SENSE26         _L(90) /**< \brief CATB signal: SENSE26 on PC26 mux G */
-#define MUX_PC26G_CATB_SENSE26          _L(6)
+#define GPIO_PB06G_CATB_SENSE26  _UL_(1 <<  6)
+#define PIN_PC26G_CATB_SENSE26         _L_(90) /**< \brief CATB signal: SENSE26 on PC26 mux G */
+#define MUX_PC26G_CATB_SENSE26          _L_(6)
 #define PINMUX_PC26G_CATB_SENSE26  ((PIN_PC26G_CATB_SENSE26 << 16) | MUX_PC26G_CATB_SENSE26)
-#define GPIO_PC26G_CATB_SENSE26  _UL(1 << 26)
-#define PIN_PB07G_CATB_SENSE27         _L(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
-#define MUX_PB07G_CATB_SENSE27          _L(6)
+#define GPIO_PC26G_CATB_SENSE26  _UL_(1 << 26)
+#define PIN_PB07G_CATB_SENSE27         _L_(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
+#define MUX_PB07G_CATB_SENSE27          _L_(6)
 #define PINMUX_PB07G_CATB_SENSE27  ((PIN_PB07G_CATB_SENSE27 << 16) | MUX_PB07G_CATB_SENSE27)
-#define GPIO_PB07G_CATB_SENSE27  _UL(1 <<  7)
-#define PIN_PC27G_CATB_SENSE27         _L(91) /**< \brief CATB signal: SENSE27 on PC27 mux G */
-#define MUX_PC27G_CATB_SENSE27          _L(6)
+#define GPIO_PB07G_CATB_SENSE27  _UL_(1 <<  7)
+#define PIN_PC27G_CATB_SENSE27         _L_(91) /**< \brief CATB signal: SENSE27 on PC27 mux G */
+#define MUX_PC27G_CATB_SENSE27          _L_(6)
 #define PINMUX_PC27G_CATB_SENSE27  ((PIN_PC27G_CATB_SENSE27 << 16) | MUX_PC27G_CATB_SENSE27)
-#define GPIO_PC27G_CATB_SENSE27  _UL(1 << 27)
-#define PIN_PB08G_CATB_SENSE28         _L(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
-#define MUX_PB08G_CATB_SENSE28          _L(6)
+#define GPIO_PC27G_CATB_SENSE27  _UL_(1 << 27)
+#define PIN_PB08G_CATB_SENSE28         _L_(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
+#define MUX_PB08G_CATB_SENSE28          _L_(6)
 #define PINMUX_PB08G_CATB_SENSE28  ((PIN_PB08G_CATB_SENSE28 << 16) | MUX_PB08G_CATB_SENSE28)
-#define GPIO_PB08G_CATB_SENSE28  _UL(1 <<  8)
-#define PIN_PC28G_CATB_SENSE28         _L(92) /**< \brief CATB signal: SENSE28 on PC28 mux G */
-#define MUX_PC28G_CATB_SENSE28          _L(6)
+#define GPIO_PB08G_CATB_SENSE28  _UL_(1 <<  8)
+#define PIN_PC28G_CATB_SENSE28         _L_(92) /**< \brief CATB signal: SENSE28 on PC28 mux G */
+#define MUX_PC28G_CATB_SENSE28          _L_(6)
 #define PINMUX_PC28G_CATB_SENSE28  ((PIN_PC28G_CATB_SENSE28 << 16) | MUX_PC28G_CATB_SENSE28)
-#define GPIO_PC28G_CATB_SENSE28  _UL(1 << 28)
-#define PIN_PB09G_CATB_SENSE29         _L(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
-#define MUX_PB09G_CATB_SENSE29          _L(6)
+#define GPIO_PC28G_CATB_SENSE28  _UL_(1 << 28)
+#define PIN_PB09G_CATB_SENSE29         _L_(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
+#define MUX_PB09G_CATB_SENSE29          _L_(6)
 #define PINMUX_PB09G_CATB_SENSE29  ((PIN_PB09G_CATB_SENSE29 << 16) | MUX_PB09G_CATB_SENSE29)
-#define GPIO_PB09G_CATB_SENSE29  _UL(1 <<  9)
-#define PIN_PC29G_CATB_SENSE29         _L(93) /**< \brief CATB signal: SENSE29 on PC29 mux G */
-#define MUX_PC29G_CATB_SENSE29          _L(6)
+#define GPIO_PB09G_CATB_SENSE29  _UL_(1 <<  9)
+#define PIN_PC29G_CATB_SENSE29         _L_(93) /**< \brief CATB signal: SENSE29 on PC29 mux G */
+#define MUX_PC29G_CATB_SENSE29          _L_(6)
 #define PINMUX_PC29G_CATB_SENSE29  ((PIN_PC29G_CATB_SENSE29 << 16) | MUX_PC29G_CATB_SENSE29)
-#define GPIO_PC29G_CATB_SENSE29  _UL(1 << 29)
-#define PIN_PB10G_CATB_SENSE30         _L(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
-#define MUX_PB10G_CATB_SENSE30          _L(6)
+#define GPIO_PC29G_CATB_SENSE29  _UL_(1 << 29)
+#define PIN_PB10G_CATB_SENSE30         _L_(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
+#define MUX_PB10G_CATB_SENSE30          _L_(6)
 #define PINMUX_PB10G_CATB_SENSE30  ((PIN_PB10G_CATB_SENSE30 << 16) | MUX_PB10G_CATB_SENSE30)
-#define GPIO_PB10G_CATB_SENSE30  _UL(1 << 10)
-#define PIN_PC30G_CATB_SENSE30         _L(94) /**< \brief CATB signal: SENSE30 on PC30 mux G */
-#define MUX_PC30G_CATB_SENSE30          _L(6)
+#define GPIO_PB10G_CATB_SENSE30  _UL_(1 << 10)
+#define PIN_PC30G_CATB_SENSE30         _L_(94) /**< \brief CATB signal: SENSE30 on PC30 mux G */
+#define MUX_PC30G_CATB_SENSE30          _L_(6)
 #define PINMUX_PC30G_CATB_SENSE30  ((PIN_PC30G_CATB_SENSE30 << 16) | MUX_PC30G_CATB_SENSE30)
-#define GPIO_PC30G_CATB_SENSE30  _UL(1 << 30)
-#define PIN_PB11G_CATB_SENSE31         _L(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
-#define MUX_PB11G_CATB_SENSE31          _L(6)
+#define GPIO_PC30G_CATB_SENSE30  _UL_(1 << 30)
+#define PIN_PB11G_CATB_SENSE31         _L_(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
+#define MUX_PB11G_CATB_SENSE31          _L_(6)
 #define PINMUX_PB11G_CATB_SENSE31  ((PIN_PB11G_CATB_SENSE31 << 16) | MUX_PB11G_CATB_SENSE31)
-#define GPIO_PB11G_CATB_SENSE31  _UL(1 << 11)
-#define PIN_PC31G_CATB_SENSE31         _L(95) /**< \brief CATB signal: SENSE31 on PC31 mux G */
-#define MUX_PC31G_CATB_SENSE31          _L(6)
+#define GPIO_PB11G_CATB_SENSE31  _UL_(1 << 11)
+#define PIN_PC31G_CATB_SENSE31         _L_(95) /**< \brief CATB signal: SENSE31 on PC31 mux G */
+#define MUX_PC31G_CATB_SENSE31          _L_(6)
 #define PINMUX_PC31G_CATB_SENSE31  ((PIN_PC31G_CATB_SENSE31 << 16) | MUX_PC31G_CATB_SENSE31)
-#define GPIO_PC31G_CATB_SENSE31  _UL(1 << 31)
+#define GPIO_PC31G_CATB_SENSE31  _UL_(1 << 31)
 /* ========== GPIO definition for LCDCA peripheral ========== */
-#define PIN_PA12F_LCDCA_COM0           _L(12) /**< \brief LCDCA signal: COM0 on PA12 mux F */
-#define MUX_PA12F_LCDCA_COM0            _L(5)
+#define PIN_PA12F_LCDCA_COM0           _L_(12) /**< \brief LCDCA signal: COM0 on PA12 mux F */
+#define MUX_PA12F_LCDCA_COM0            _L_(5)
 #define PINMUX_PA12F_LCDCA_COM0    ((PIN_PA12F_LCDCA_COM0 << 16) | MUX_PA12F_LCDCA_COM0)
-#define GPIO_PA12F_LCDCA_COM0    _UL(1 << 12)
-#define PIN_PA11F_LCDCA_COM1           _L(11) /**< \brief LCDCA signal: COM1 on PA11 mux F */
-#define MUX_PA11F_LCDCA_COM1            _L(5)
+#define GPIO_PA12F_LCDCA_COM0    _UL_(1 << 12)
+#define PIN_PA11F_LCDCA_COM1           _L_(11) /**< \brief LCDCA signal: COM1 on PA11 mux F */
+#define MUX_PA11F_LCDCA_COM1            _L_(5)
 #define PINMUX_PA11F_LCDCA_COM1    ((PIN_PA11F_LCDCA_COM1 << 16) | MUX_PA11F_LCDCA_COM1)
-#define GPIO_PA11F_LCDCA_COM1    _UL(1 << 11)
-#define PIN_PA10F_LCDCA_COM2           _L(10) /**< \brief LCDCA signal: COM2 on PA10 mux F */
-#define MUX_PA10F_LCDCA_COM2            _L(5)
+#define GPIO_PA11F_LCDCA_COM1    _UL_(1 << 11)
+#define PIN_PA10F_LCDCA_COM2           _L_(10) /**< \brief LCDCA signal: COM2 on PA10 mux F */
+#define MUX_PA10F_LCDCA_COM2            _L_(5)
 #define PINMUX_PA10F_LCDCA_COM2    ((PIN_PA10F_LCDCA_COM2 << 16) | MUX_PA10F_LCDCA_COM2)
-#define GPIO_PA10F_LCDCA_COM2    _UL(1 << 10)
-#define PIN_PA09F_LCDCA_COM3            _L(9) /**< \brief LCDCA signal: COM3 on PA09 mux F */
-#define MUX_PA09F_LCDCA_COM3            _L(5)
+#define GPIO_PA10F_LCDCA_COM2    _UL_(1 << 10)
+#define PIN_PA09F_LCDCA_COM3            _L_(9) /**< \brief LCDCA signal: COM3 on PA09 mux F */
+#define MUX_PA09F_LCDCA_COM3            _L_(5)
 #define PINMUX_PA09F_LCDCA_COM3    ((PIN_PA09F_LCDCA_COM3 << 16) | MUX_PA09F_LCDCA_COM3)
-#define GPIO_PA09F_LCDCA_COM3    _UL(1 <<  9)
-#define PIN_PC15F_LCDCA_SEG0           _L(79) /**< \brief LCDCA signal: SEG0 on PC15 mux F */
-#define MUX_PC15F_LCDCA_SEG0            _L(5)
+#define GPIO_PA09F_LCDCA_COM3    _UL_(1 <<  9)
+#define PIN_PC15F_LCDCA_SEG0           _L_(79) /**< \brief LCDCA signal: SEG0 on PC15 mux F */
+#define MUX_PC15F_LCDCA_SEG0            _L_(5)
 #define PINMUX_PC15F_LCDCA_SEG0    ((PIN_PC15F_LCDCA_SEG0 << 16) | MUX_PC15F_LCDCA_SEG0)
-#define GPIO_PC15F_LCDCA_SEG0    _UL(1 << 15)
-#define PIN_PC16F_LCDCA_SEG1           _L(80) /**< \brief LCDCA signal: SEG1 on PC16 mux F */
-#define MUX_PC16F_LCDCA_SEG1            _L(5)
+#define GPIO_PC15F_LCDCA_SEG0    _UL_(1 << 15)
+#define PIN_PC16F_LCDCA_SEG1           _L_(80) /**< \brief LCDCA signal: SEG1 on PC16 mux F */
+#define MUX_PC16F_LCDCA_SEG1            _L_(5)
 #define PINMUX_PC16F_LCDCA_SEG1    ((PIN_PC16F_LCDCA_SEG1 << 16) | MUX_PC16F_LCDCA_SEG1)
-#define GPIO_PC16F_LCDCA_SEG1    _UL(1 << 16)
-#define PIN_PC17F_LCDCA_SEG2           _L(81) /**< \brief LCDCA signal: SEG2 on PC17 mux F */
-#define MUX_PC17F_LCDCA_SEG2            _L(5)
+#define GPIO_PC16F_LCDCA_SEG1    _UL_(1 << 16)
+#define PIN_PC17F_LCDCA_SEG2           _L_(81) /**< \brief LCDCA signal: SEG2 on PC17 mux F */
+#define MUX_PC17F_LCDCA_SEG2            _L_(5)
 #define PINMUX_PC17F_LCDCA_SEG2    ((PIN_PC17F_LCDCA_SEG2 << 16) | MUX_PC17F_LCDCA_SEG2)
-#define GPIO_PC17F_LCDCA_SEG2    _UL(1 << 17)
-#define PIN_PC18F_LCDCA_SEG3           _L(82) /**< \brief LCDCA signal: SEG3 on PC18 mux F */
-#define MUX_PC18F_LCDCA_SEG3            _L(5)
+#define GPIO_PC17F_LCDCA_SEG2    _UL_(1 << 17)
+#define PIN_PC18F_LCDCA_SEG3           _L_(82) /**< \brief LCDCA signal: SEG3 on PC18 mux F */
+#define MUX_PC18F_LCDCA_SEG3            _L_(5)
 #define PINMUX_PC18F_LCDCA_SEG3    ((PIN_PC18F_LCDCA_SEG3 << 16) | MUX_PC18F_LCDCA_SEG3)
-#define GPIO_PC18F_LCDCA_SEG3    _UL(1 << 18)
-#define PIN_PC19F_LCDCA_SEG4           _L(83) /**< \brief LCDCA signal: SEG4 on PC19 mux F */
-#define MUX_PC19F_LCDCA_SEG4            _L(5)
+#define GPIO_PC18F_LCDCA_SEG3    _UL_(1 << 18)
+#define PIN_PC19F_LCDCA_SEG4           _L_(83) /**< \brief LCDCA signal: SEG4 on PC19 mux F */
+#define MUX_PC19F_LCDCA_SEG4            _L_(5)
 #define PINMUX_PC19F_LCDCA_SEG4    ((PIN_PC19F_LCDCA_SEG4 << 16) | MUX_PC19F_LCDCA_SEG4)
-#define GPIO_PC19F_LCDCA_SEG4    _UL(1 << 19)
-#define PIN_PA13F_LCDCA_SEG5           _L(13) /**< \brief LCDCA signal: SEG5 on PA13 mux F */
-#define MUX_PA13F_LCDCA_SEG5            _L(5)
+#define GPIO_PC19F_LCDCA_SEG4    _UL_(1 << 19)
+#define PIN_PA13F_LCDCA_SEG5           _L_(13) /**< \brief LCDCA signal: SEG5 on PA13 mux F */
+#define MUX_PA13F_LCDCA_SEG5            _L_(5)
 #define PINMUX_PA13F_LCDCA_SEG5    ((PIN_PA13F_LCDCA_SEG5 << 16) | MUX_PA13F_LCDCA_SEG5)
-#define GPIO_PA13F_LCDCA_SEG5    _UL(1 << 13)
-#define PIN_PA14F_LCDCA_SEG6           _L(14) /**< \brief LCDCA signal: SEG6 on PA14 mux F */
-#define MUX_PA14F_LCDCA_SEG6            _L(5)
+#define GPIO_PA13F_LCDCA_SEG5    _UL_(1 << 13)
+#define PIN_PA14F_LCDCA_SEG6           _L_(14) /**< \brief LCDCA signal: SEG6 on PA14 mux F */
+#define MUX_PA14F_LCDCA_SEG6            _L_(5)
 #define PINMUX_PA14F_LCDCA_SEG6    ((PIN_PA14F_LCDCA_SEG6 << 16) | MUX_PA14F_LCDCA_SEG6)
-#define GPIO_PA14F_LCDCA_SEG6    _UL(1 << 14)
-#define PIN_PA15F_LCDCA_SEG7           _L(15) /**< \brief LCDCA signal: SEG7 on PA15 mux F */
-#define MUX_PA15F_LCDCA_SEG7            _L(5)
+#define GPIO_PA14F_LCDCA_SEG6    _UL_(1 << 14)
+#define PIN_PA15F_LCDCA_SEG7           _L_(15) /**< \brief LCDCA signal: SEG7 on PA15 mux F */
+#define MUX_PA15F_LCDCA_SEG7            _L_(5)
 #define PINMUX_PA15F_LCDCA_SEG7    ((PIN_PA15F_LCDCA_SEG7 << 16) | MUX_PA15F_LCDCA_SEG7)
-#define GPIO_PA15F_LCDCA_SEG7    _UL(1 << 15)
-#define PIN_PA16F_LCDCA_SEG8           _L(16) /**< \brief LCDCA signal: SEG8 on PA16 mux F */
-#define MUX_PA16F_LCDCA_SEG8            _L(5)
+#define GPIO_PA15F_LCDCA_SEG7    _UL_(1 << 15)
+#define PIN_PA16F_LCDCA_SEG8           _L_(16) /**< \brief LCDCA signal: SEG8 on PA16 mux F */
+#define MUX_PA16F_LCDCA_SEG8            _L_(5)
 #define PINMUX_PA16F_LCDCA_SEG8    ((PIN_PA16F_LCDCA_SEG8 << 16) | MUX_PA16F_LCDCA_SEG8)
-#define GPIO_PA16F_LCDCA_SEG8    _UL(1 << 16)
-#define PIN_PA17F_LCDCA_SEG9           _L(17) /**< \brief LCDCA signal: SEG9 on PA17 mux F */
-#define MUX_PA17F_LCDCA_SEG9            _L(5)
+#define GPIO_PA16F_LCDCA_SEG8    _UL_(1 << 16)
+#define PIN_PA17F_LCDCA_SEG9           _L_(17) /**< \brief LCDCA signal: SEG9 on PA17 mux F */
+#define MUX_PA17F_LCDCA_SEG9            _L_(5)
 #define PINMUX_PA17F_LCDCA_SEG9    ((PIN_PA17F_LCDCA_SEG9 << 16) | MUX_PA17F_LCDCA_SEG9)
-#define GPIO_PA17F_LCDCA_SEG9    _UL(1 << 17)
-#define PIN_PC20F_LCDCA_SEG10          _L(84) /**< \brief LCDCA signal: SEG10 on PC20 mux F */
-#define MUX_PC20F_LCDCA_SEG10           _L(5)
+#define GPIO_PA17F_LCDCA_SEG9    _UL_(1 << 17)
+#define PIN_PC20F_LCDCA_SEG10          _L_(84) /**< \brief LCDCA signal: SEG10 on PC20 mux F */
+#define MUX_PC20F_LCDCA_SEG10           _L_(5)
 #define PINMUX_PC20F_LCDCA_SEG10   ((PIN_PC20F_LCDCA_SEG10 << 16) | MUX_PC20F_LCDCA_SEG10)
-#define GPIO_PC20F_LCDCA_SEG10   _UL(1 << 20)
-#define PIN_PC21F_LCDCA_SEG11          _L(85) /**< \brief LCDCA signal: SEG11 on PC21 mux F */
-#define MUX_PC21F_LCDCA_SEG11           _L(5)
+#define GPIO_PC20F_LCDCA_SEG10   _UL_(1 << 20)
+#define PIN_PC21F_LCDCA_SEG11          _L_(85) /**< \brief LCDCA signal: SEG11 on PC21 mux F */
+#define MUX_PC21F_LCDCA_SEG11           _L_(5)
 #define PINMUX_PC21F_LCDCA_SEG11   ((PIN_PC21F_LCDCA_SEG11 << 16) | MUX_PC21F_LCDCA_SEG11)
-#define GPIO_PC21F_LCDCA_SEG11   _UL(1 << 21)
-#define PIN_PC22F_LCDCA_SEG12          _L(86) /**< \brief LCDCA signal: SEG12 on PC22 mux F */
-#define MUX_PC22F_LCDCA_SEG12           _L(5)
+#define GPIO_PC21F_LCDCA_SEG11   _UL_(1 << 21)
+#define PIN_PC22F_LCDCA_SEG12          _L_(86) /**< \brief LCDCA signal: SEG12 on PC22 mux F */
+#define MUX_PC22F_LCDCA_SEG12           _L_(5)
 #define PINMUX_PC22F_LCDCA_SEG12   ((PIN_PC22F_LCDCA_SEG12 << 16) | MUX_PC22F_LCDCA_SEG12)
-#define GPIO_PC22F_LCDCA_SEG12   _UL(1 << 22)
-#define PIN_PC23F_LCDCA_SEG13          _L(87) /**< \brief LCDCA signal: SEG13 on PC23 mux F */
-#define MUX_PC23F_LCDCA_SEG13           _L(5)
+#define GPIO_PC22F_LCDCA_SEG12   _UL_(1 << 22)
+#define PIN_PC23F_LCDCA_SEG13          _L_(87) /**< \brief LCDCA signal: SEG13 on PC23 mux F */
+#define MUX_PC23F_LCDCA_SEG13           _L_(5)
 #define PINMUX_PC23F_LCDCA_SEG13   ((PIN_PC23F_LCDCA_SEG13 << 16) | MUX_PC23F_LCDCA_SEG13)
-#define GPIO_PC23F_LCDCA_SEG13   _UL(1 << 23)
-#define PIN_PB08F_LCDCA_SEG14          _L(40) /**< \brief LCDCA signal: SEG14 on PB08 mux F */
-#define MUX_PB08F_LCDCA_SEG14           _L(5)
+#define GPIO_PC23F_LCDCA_SEG13   _UL_(1 << 23)
+#define PIN_PB08F_LCDCA_SEG14          _L_(40) /**< \brief LCDCA signal: SEG14 on PB08 mux F */
+#define MUX_PB08F_LCDCA_SEG14           _L_(5)
 #define PINMUX_PB08F_LCDCA_SEG14   ((PIN_PB08F_LCDCA_SEG14 << 16) | MUX_PB08F_LCDCA_SEG14)
-#define GPIO_PB08F_LCDCA_SEG14   _UL(1 <<  8)
-#define PIN_PB09F_LCDCA_SEG15          _L(41) /**< \brief LCDCA signal: SEG15 on PB09 mux F */
-#define MUX_PB09F_LCDCA_SEG15           _L(5)
+#define GPIO_PB08F_LCDCA_SEG14   _UL_(1 <<  8)
+#define PIN_PB09F_LCDCA_SEG15          _L_(41) /**< \brief LCDCA signal: SEG15 on PB09 mux F */
+#define MUX_PB09F_LCDCA_SEG15           _L_(5)
 #define PINMUX_PB09F_LCDCA_SEG15   ((PIN_PB09F_LCDCA_SEG15 << 16) | MUX_PB09F_LCDCA_SEG15)
-#define GPIO_PB09F_LCDCA_SEG15   _UL(1 <<  9)
-#define PIN_PB10F_LCDCA_SEG16          _L(42) /**< \brief LCDCA signal: SEG16 on PB10 mux F */
-#define MUX_PB10F_LCDCA_SEG16           _L(5)
+#define GPIO_PB09F_LCDCA_SEG15   _UL_(1 <<  9)
+#define PIN_PB10F_LCDCA_SEG16          _L_(42) /**< \brief LCDCA signal: SEG16 on PB10 mux F */
+#define MUX_PB10F_LCDCA_SEG16           _L_(5)
 #define PINMUX_PB10F_LCDCA_SEG16   ((PIN_PB10F_LCDCA_SEG16 << 16) | MUX_PB10F_LCDCA_SEG16)
-#define GPIO_PB10F_LCDCA_SEG16   _UL(1 << 10)
-#define PIN_PB11F_LCDCA_SEG17          _L(43) /**< \brief LCDCA signal: SEG17 on PB11 mux F */
-#define MUX_PB11F_LCDCA_SEG17           _L(5)
+#define GPIO_PB10F_LCDCA_SEG16   _UL_(1 << 10)
+#define PIN_PB11F_LCDCA_SEG17          _L_(43) /**< \brief LCDCA signal: SEG17 on PB11 mux F */
+#define MUX_PB11F_LCDCA_SEG17           _L_(5)
 #define PINMUX_PB11F_LCDCA_SEG17   ((PIN_PB11F_LCDCA_SEG17 << 16) | MUX_PB11F_LCDCA_SEG17)
-#define GPIO_PB11F_LCDCA_SEG17   _UL(1 << 11)
-#define PIN_PA18F_LCDCA_SEG18          _L(18) /**< \brief LCDCA signal: SEG18 on PA18 mux F */
-#define MUX_PA18F_LCDCA_SEG18           _L(5)
+#define GPIO_PB11F_LCDCA_SEG17   _UL_(1 << 11)
+#define PIN_PA18F_LCDCA_SEG18          _L_(18) /**< \brief LCDCA signal: SEG18 on PA18 mux F */
+#define MUX_PA18F_LCDCA_SEG18           _L_(5)
 #define PINMUX_PA18F_LCDCA_SEG18   ((PIN_PA18F_LCDCA_SEG18 << 16) | MUX_PA18F_LCDCA_SEG18)
-#define GPIO_PA18F_LCDCA_SEG18   _UL(1 << 18)
-#define PIN_PA19F_LCDCA_SEG19          _L(19) /**< \brief LCDCA signal: SEG19 on PA19 mux F */
-#define MUX_PA19F_LCDCA_SEG19           _L(5)
+#define GPIO_PA18F_LCDCA_SEG18   _UL_(1 << 18)
+#define PIN_PA19F_LCDCA_SEG19          _L_(19) /**< \brief LCDCA signal: SEG19 on PA19 mux F */
+#define MUX_PA19F_LCDCA_SEG19           _L_(5)
 #define PINMUX_PA19F_LCDCA_SEG19   ((PIN_PA19F_LCDCA_SEG19 << 16) | MUX_PA19F_LCDCA_SEG19)
-#define GPIO_PA19F_LCDCA_SEG19   _UL(1 << 19)
-#define PIN_PA20F_LCDCA_SEG20          _L(20) /**< \brief LCDCA signal: SEG20 on PA20 mux F */
-#define MUX_PA20F_LCDCA_SEG20           _L(5)
+#define GPIO_PA19F_LCDCA_SEG19   _UL_(1 << 19)
+#define PIN_PA20F_LCDCA_SEG20          _L_(20) /**< \brief LCDCA signal: SEG20 on PA20 mux F */
+#define MUX_PA20F_LCDCA_SEG20           _L_(5)
 #define PINMUX_PA20F_LCDCA_SEG20   ((PIN_PA20F_LCDCA_SEG20 << 16) | MUX_PA20F_LCDCA_SEG20)
-#define GPIO_PA20F_LCDCA_SEG20   _UL(1 << 20)
-#define PIN_PB07F_LCDCA_SEG21          _L(39) /**< \brief LCDCA signal: SEG21 on PB07 mux F */
-#define MUX_PB07F_LCDCA_SEG21           _L(5)
+#define GPIO_PA20F_LCDCA_SEG20   _UL_(1 << 20)
+#define PIN_PB07F_LCDCA_SEG21          _L_(39) /**< \brief LCDCA signal: SEG21 on PB07 mux F */
+#define MUX_PB07F_LCDCA_SEG21           _L_(5)
 #define PINMUX_PB07F_LCDCA_SEG21   ((PIN_PB07F_LCDCA_SEG21 << 16) | MUX_PB07F_LCDCA_SEG21)
-#define GPIO_PB07F_LCDCA_SEG21   _UL(1 <<  7)
-#define PIN_PB06F_LCDCA_SEG22          _L(38) /**< \brief LCDCA signal: SEG22 on PB06 mux F */
-#define MUX_PB06F_LCDCA_SEG22           _L(5)
+#define GPIO_PB07F_LCDCA_SEG21   _UL_(1 <<  7)
+#define PIN_PB06F_LCDCA_SEG22          _L_(38) /**< \brief LCDCA signal: SEG22 on PB06 mux F */
+#define MUX_PB06F_LCDCA_SEG22           _L_(5)
 #define PINMUX_PB06F_LCDCA_SEG22   ((PIN_PB06F_LCDCA_SEG22 << 16) | MUX_PB06F_LCDCA_SEG22)
-#define GPIO_PB06F_LCDCA_SEG22   _UL(1 <<  6)
-#define PIN_PA08F_LCDCA_SEG23           _L(8) /**< \brief LCDCA signal: SEG23 on PA08 mux F */
-#define MUX_PA08F_LCDCA_SEG23           _L(5)
+#define GPIO_PB06F_LCDCA_SEG22   _UL_(1 <<  6)
+#define PIN_PA08F_LCDCA_SEG23           _L_(8) /**< \brief LCDCA signal: SEG23 on PA08 mux F */
+#define MUX_PA08F_LCDCA_SEG23           _L_(5)
 #define PINMUX_PA08F_LCDCA_SEG23   ((PIN_PA08F_LCDCA_SEG23 << 16) | MUX_PA08F_LCDCA_SEG23)
-#define GPIO_PA08F_LCDCA_SEG23   _UL(1 <<  8)
-#define PIN_PC24F_LCDCA_SEG24          _L(88) /**< \brief LCDCA signal: SEG24 on PC24 mux F */
-#define MUX_PC24F_LCDCA_SEG24           _L(5)
+#define GPIO_PA08F_LCDCA_SEG23   _UL_(1 <<  8)
+#define PIN_PC24F_LCDCA_SEG24          _L_(88) /**< \brief LCDCA signal: SEG24 on PC24 mux F */
+#define MUX_PC24F_LCDCA_SEG24           _L_(5)
 #define PINMUX_PC24F_LCDCA_SEG24   ((PIN_PC24F_LCDCA_SEG24 << 16) | MUX_PC24F_LCDCA_SEG24)
-#define GPIO_PC24F_LCDCA_SEG24   _UL(1 << 24)
-#define PIN_PC25F_LCDCA_SEG25          _L(89) /**< \brief LCDCA signal: SEG25 on PC25 mux F */
-#define MUX_PC25F_LCDCA_SEG25           _L(5)
+#define GPIO_PC24F_LCDCA_SEG24   _UL_(1 << 24)
+#define PIN_PC25F_LCDCA_SEG25          _L_(89) /**< \brief LCDCA signal: SEG25 on PC25 mux F */
+#define MUX_PC25F_LCDCA_SEG25           _L_(5)
 #define PINMUX_PC25F_LCDCA_SEG25   ((PIN_PC25F_LCDCA_SEG25 << 16) | MUX_PC25F_LCDCA_SEG25)
-#define GPIO_PC25F_LCDCA_SEG25   _UL(1 << 25)
-#define PIN_PC26F_LCDCA_SEG26          _L(90) /**< \brief LCDCA signal: SEG26 on PC26 mux F */
-#define MUX_PC26F_LCDCA_SEG26           _L(5)
+#define GPIO_PC25F_LCDCA_SEG25   _UL_(1 << 25)
+#define PIN_PC26F_LCDCA_SEG26          _L_(90) /**< \brief LCDCA signal: SEG26 on PC26 mux F */
+#define MUX_PC26F_LCDCA_SEG26           _L_(5)
 #define PINMUX_PC26F_LCDCA_SEG26   ((PIN_PC26F_LCDCA_SEG26 << 16) | MUX_PC26F_LCDCA_SEG26)
-#define GPIO_PC26F_LCDCA_SEG26   _UL(1 << 26)
-#define PIN_PC27F_LCDCA_SEG27          _L(91) /**< \brief LCDCA signal: SEG27 on PC27 mux F */
-#define MUX_PC27F_LCDCA_SEG27           _L(5)
+#define GPIO_PC26F_LCDCA_SEG26   _UL_(1 << 26)
+#define PIN_PC27F_LCDCA_SEG27          _L_(91) /**< \brief LCDCA signal: SEG27 on PC27 mux F */
+#define MUX_PC27F_LCDCA_SEG27           _L_(5)
 #define PINMUX_PC27F_LCDCA_SEG27   ((PIN_PC27F_LCDCA_SEG27 << 16) | MUX_PC27F_LCDCA_SEG27)
-#define GPIO_PC27F_LCDCA_SEG27   _UL(1 << 27)
-#define PIN_PC28F_LCDCA_SEG28          _L(92) /**< \brief LCDCA signal: SEG28 on PC28 mux F */
-#define MUX_PC28F_LCDCA_SEG28           _L(5)
+#define GPIO_PC27F_LCDCA_SEG27   _UL_(1 << 27)
+#define PIN_PC28F_LCDCA_SEG28          _L_(92) /**< \brief LCDCA signal: SEG28 on PC28 mux F */
+#define MUX_PC28F_LCDCA_SEG28           _L_(5)
 #define PINMUX_PC28F_LCDCA_SEG28   ((PIN_PC28F_LCDCA_SEG28 << 16) | MUX_PC28F_LCDCA_SEG28)
-#define GPIO_PC28F_LCDCA_SEG28   _UL(1 << 28)
-#define PIN_PC29F_LCDCA_SEG29          _L(93) /**< \brief LCDCA signal: SEG29 on PC29 mux F */
-#define MUX_PC29F_LCDCA_SEG29           _L(5)
+#define GPIO_PC28F_LCDCA_SEG28   _UL_(1 << 28)
+#define PIN_PC29F_LCDCA_SEG29          _L_(93) /**< \brief LCDCA signal: SEG29 on PC29 mux F */
+#define MUX_PC29F_LCDCA_SEG29           _L_(5)
 #define PINMUX_PC29F_LCDCA_SEG29   ((PIN_PC29F_LCDCA_SEG29 << 16) | MUX_PC29F_LCDCA_SEG29)
-#define GPIO_PC29F_LCDCA_SEG29   _UL(1 << 29)
-#define PIN_PC30F_LCDCA_SEG30          _L(94) /**< \brief LCDCA signal: SEG30 on PC30 mux F */
-#define MUX_PC30F_LCDCA_SEG30           _L(5)
+#define GPIO_PC29F_LCDCA_SEG29   _UL_(1 << 29)
+#define PIN_PC30F_LCDCA_SEG30          _L_(94) /**< \brief LCDCA signal: SEG30 on PC30 mux F */
+#define MUX_PC30F_LCDCA_SEG30           _L_(5)
 #define PINMUX_PC30F_LCDCA_SEG30   ((PIN_PC30F_LCDCA_SEG30 << 16) | MUX_PC30F_LCDCA_SEG30)
-#define GPIO_PC30F_LCDCA_SEG30   _UL(1 << 30)
-#define PIN_PC31F_LCDCA_SEG31          _L(95) /**< \brief LCDCA signal: SEG31 on PC31 mux F */
-#define MUX_PC31F_LCDCA_SEG31           _L(5)
+#define GPIO_PC30F_LCDCA_SEG30   _UL_(1 << 30)
+#define PIN_PC31F_LCDCA_SEG31          _L_(95) /**< \brief LCDCA signal: SEG31 on PC31 mux F */
+#define MUX_PC31F_LCDCA_SEG31           _L_(5)
 #define PINMUX_PC31F_LCDCA_SEG31   ((PIN_PC31F_LCDCA_SEG31 << 16) | MUX_PC31F_LCDCA_SEG31)
-#define GPIO_PC31F_LCDCA_SEG31   _UL(1 << 31)
-#define PIN_PB12F_LCDCA_SEG32          _L(44) /**< \brief LCDCA signal: SEG32 on PB12 mux F */
-#define MUX_PB12F_LCDCA_SEG32           _L(5)
+#define GPIO_PC31F_LCDCA_SEG31   _UL_(1 << 31)
+#define PIN_PB12F_LCDCA_SEG32          _L_(44) /**< \brief LCDCA signal: SEG32 on PB12 mux F */
+#define MUX_PB12F_LCDCA_SEG32           _L_(5)
 #define PINMUX_PB12F_LCDCA_SEG32   ((PIN_PB12F_LCDCA_SEG32 << 16) | MUX_PB12F_LCDCA_SEG32)
-#define GPIO_PB12F_LCDCA_SEG32   _UL(1 << 12)
-#define PIN_PB13F_LCDCA_SEG33          _L(45) /**< \brief LCDCA signal: SEG33 on PB13 mux F */
-#define MUX_PB13F_LCDCA_SEG33           _L(5)
+#define GPIO_PB12F_LCDCA_SEG32   _UL_(1 << 12)
+#define PIN_PB13F_LCDCA_SEG33          _L_(45) /**< \brief LCDCA signal: SEG33 on PB13 mux F */
+#define MUX_PB13F_LCDCA_SEG33           _L_(5)
 #define PINMUX_PB13F_LCDCA_SEG33   ((PIN_PB13F_LCDCA_SEG33 << 16) | MUX_PB13F_LCDCA_SEG33)
-#define GPIO_PB13F_LCDCA_SEG33   _UL(1 << 13)
-#define PIN_PA21F_LCDCA_SEG34          _L(21) /**< \brief LCDCA signal: SEG34 on PA21 mux F */
-#define MUX_PA21F_LCDCA_SEG34           _L(5)
+#define GPIO_PB13F_LCDCA_SEG33   _UL_(1 << 13)
+#define PIN_PA21F_LCDCA_SEG34          _L_(21) /**< \brief LCDCA signal: SEG34 on PA21 mux F */
+#define MUX_PA21F_LCDCA_SEG34           _L_(5)
 #define PINMUX_PA21F_LCDCA_SEG34   ((PIN_PA21F_LCDCA_SEG34 << 16) | MUX_PA21F_LCDCA_SEG34)
-#define GPIO_PA21F_LCDCA_SEG34   _UL(1 << 21)
-#define PIN_PA22F_LCDCA_SEG35          _L(22) /**< \brief LCDCA signal: SEG35 on PA22 mux F */
-#define MUX_PA22F_LCDCA_SEG35           _L(5)
+#define GPIO_PA21F_LCDCA_SEG34   _UL_(1 << 21)
+#define PIN_PA22F_LCDCA_SEG35          _L_(22) /**< \brief LCDCA signal: SEG35 on PA22 mux F */
+#define MUX_PA22F_LCDCA_SEG35           _L_(5)
 #define PINMUX_PA22F_LCDCA_SEG35   ((PIN_PA22F_LCDCA_SEG35 << 16) | MUX_PA22F_LCDCA_SEG35)
-#define GPIO_PA22F_LCDCA_SEG35   _UL(1 << 22)
-#define PIN_PB14F_LCDCA_SEG36          _L(46) /**< \brief LCDCA signal: SEG36 on PB14 mux F */
-#define MUX_PB14F_LCDCA_SEG36           _L(5)
+#define GPIO_PA22F_LCDCA_SEG35   _UL_(1 << 22)
+#define PIN_PB14F_LCDCA_SEG36          _L_(46) /**< \brief LCDCA signal: SEG36 on PB14 mux F */
+#define MUX_PB14F_LCDCA_SEG36           _L_(5)
 #define PINMUX_PB14F_LCDCA_SEG36   ((PIN_PB14F_LCDCA_SEG36 << 16) | MUX_PB14F_LCDCA_SEG36)
-#define GPIO_PB14F_LCDCA_SEG36   _UL(1 << 14)
-#define PIN_PB15F_LCDCA_SEG37          _L(47) /**< \brief LCDCA signal: SEG37 on PB15 mux F */
-#define MUX_PB15F_LCDCA_SEG37           _L(5)
+#define GPIO_PB14F_LCDCA_SEG36   _UL_(1 << 14)
+#define PIN_PB15F_LCDCA_SEG37          _L_(47) /**< \brief LCDCA signal: SEG37 on PB15 mux F */
+#define MUX_PB15F_LCDCA_SEG37           _L_(5)
 #define PINMUX_PB15F_LCDCA_SEG37   ((PIN_PB15F_LCDCA_SEG37 << 16) | MUX_PB15F_LCDCA_SEG37)
-#define GPIO_PB15F_LCDCA_SEG37   _UL(1 << 15)
-#define PIN_PA23F_LCDCA_SEG38          _L(23) /**< \brief LCDCA signal: SEG38 on PA23 mux F */
-#define MUX_PA23F_LCDCA_SEG38           _L(5)
+#define GPIO_PB15F_LCDCA_SEG37   _UL_(1 << 15)
+#define PIN_PA23F_LCDCA_SEG38          _L_(23) /**< \brief LCDCA signal: SEG38 on PA23 mux F */
+#define MUX_PA23F_LCDCA_SEG38           _L_(5)
 #define PINMUX_PA23F_LCDCA_SEG38   ((PIN_PA23F_LCDCA_SEG38 << 16) | MUX_PA23F_LCDCA_SEG38)
-#define GPIO_PA23F_LCDCA_SEG38   _UL(1 << 23)
-#define PIN_PA24F_LCDCA_SEG39          _L(24) /**< \brief LCDCA signal: SEG39 on PA24 mux F */
-#define MUX_PA24F_LCDCA_SEG39           _L(5)
+#define GPIO_PA23F_LCDCA_SEG38   _UL_(1 << 23)
+#define PIN_PA24F_LCDCA_SEG39          _L_(24) /**< \brief LCDCA signal: SEG39 on PA24 mux F */
+#define MUX_PA24F_LCDCA_SEG39           _L_(5)
 #define PINMUX_PA24F_LCDCA_SEG39   ((PIN_PA24F_LCDCA_SEG39 << 16) | MUX_PA24F_LCDCA_SEG39)
-#define GPIO_PA24F_LCDCA_SEG39   _UL(1 << 24)
+#define GPIO_PA24F_LCDCA_SEG39   _UL_(1 << 24)
 /* ========== GPIO definition for USBC peripheral ========== */
-#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
-#define MUX_PA25A_USBC_DM               _L(0)
+#define PIN_PA25A_USBC_DM              _L_(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L_(0)
 #define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
-#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
-#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
-#define MUX_PA26A_USBC_DP               _L(0)
+#define GPIO_PA25A_USBC_DM       _UL_(1 << 25)
+#define PIN_PA26A_USBC_DP              _L_(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L_(0)
 #define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
-#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+#define GPIO_PA26A_USBC_DP       _UL_(1 << 26)
 /* ========== GPIO definition for PEVC peripheral ========== */
-#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
-#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PIN_PA08C_PEVC_PAD_EVT0         _L_(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
-#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
-#define PIN_PB12C_PEVC_PAD_EVT0        _L(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
-#define MUX_PB12C_PEVC_PAD_EVT0         _L(2)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL_(1 <<  8)
+#define PIN_PB12C_PEVC_PAD_EVT0        _L_(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
+#define MUX_PB12C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PB12C_PEVC_PAD_EVT0  ((PIN_PB12C_PEVC_PAD_EVT0 << 16) | MUX_PB12C_PEVC_PAD_EVT0)
-#define GPIO_PB12C_PEVC_PAD_EVT0  _UL(1 << 12)
-#define PIN_PC07C_PEVC_PAD_EVT0        _L(71) /**< \brief PEVC signal: PAD_EVT0 on PC07 mux C */
-#define MUX_PC07C_PEVC_PAD_EVT0         _L(2)
+#define GPIO_PB12C_PEVC_PAD_EVT0  _UL_(1 << 12)
+#define PIN_PC07C_PEVC_PAD_EVT0        _L_(71) /**< \brief PEVC signal: PAD_EVT0 on PC07 mux C */
+#define MUX_PC07C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PC07C_PEVC_PAD_EVT0  ((PIN_PC07C_PEVC_PAD_EVT0 << 16) | MUX_PC07C_PEVC_PAD_EVT0)
-#define GPIO_PC07C_PEVC_PAD_EVT0  _UL(1 <<  7)
-#define PIN_PC24C_PEVC_PAD_EVT0        _L(88) /**< \brief PEVC signal: PAD_EVT0 on PC24 mux C */
-#define MUX_PC24C_PEVC_PAD_EVT0         _L(2)
+#define GPIO_PC07C_PEVC_PAD_EVT0  _UL_(1 <<  7)
+#define PIN_PC24C_PEVC_PAD_EVT0        _L_(88) /**< \brief PEVC signal: PAD_EVT0 on PC24 mux C */
+#define MUX_PC24C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PC24C_PEVC_PAD_EVT0  ((PIN_PC24C_PEVC_PAD_EVT0 << 16) | MUX_PC24C_PEVC_PAD_EVT0)
-#define GPIO_PC24C_PEVC_PAD_EVT0  _UL(1 << 24)
-#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
-#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PC24C_PEVC_PAD_EVT0  _UL_(1 << 24)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L_(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
-#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
-#define PIN_PB13C_PEVC_PAD_EVT1        _L(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
-#define MUX_PB13C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL_(1 <<  9)
+#define PIN_PB13C_PEVC_PAD_EVT1        _L_(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
+#define MUX_PB13C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PB13C_PEVC_PAD_EVT1  ((PIN_PB13C_PEVC_PAD_EVT1 << 16) | MUX_PB13C_PEVC_PAD_EVT1)
-#define GPIO_PB13C_PEVC_PAD_EVT1  _UL(1 << 13)
-#define PIN_PC08C_PEVC_PAD_EVT1        _L(72) /**< \brief PEVC signal: PAD_EVT1 on PC08 mux C */
-#define MUX_PC08C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PB13C_PEVC_PAD_EVT1  _UL_(1 << 13)
+#define PIN_PC08C_PEVC_PAD_EVT1        _L_(72) /**< \brief PEVC signal: PAD_EVT1 on PC08 mux C */
+#define MUX_PC08C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PC08C_PEVC_PAD_EVT1  ((PIN_PC08C_PEVC_PAD_EVT1 << 16) | MUX_PC08C_PEVC_PAD_EVT1)
-#define GPIO_PC08C_PEVC_PAD_EVT1  _UL(1 <<  8)
-#define PIN_PC25C_PEVC_PAD_EVT1        _L(89) /**< \brief PEVC signal: PAD_EVT1 on PC25 mux C */
-#define MUX_PC25C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PC08C_PEVC_PAD_EVT1  _UL_(1 <<  8)
+#define PIN_PC25C_PEVC_PAD_EVT1        _L_(89) /**< \brief PEVC signal: PAD_EVT1 on PC25 mux C */
+#define MUX_PC25C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PC25C_PEVC_PAD_EVT1  ((PIN_PC25C_PEVC_PAD_EVT1 << 16) | MUX_PC25C_PEVC_PAD_EVT1)
-#define GPIO_PC25C_PEVC_PAD_EVT1  _UL(1 << 25)
-#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
-#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PC25C_PEVC_PAD_EVT1  _UL_(1 << 25)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L_(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
-#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
-#define PIN_PC11C_PEVC_PAD_EVT2        _L(75) /**< \brief PEVC signal: PAD_EVT2 on PC11 mux C */
-#define MUX_PC11C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL_(1 << 10)
+#define PIN_PC11C_PEVC_PAD_EVT2        _L_(75) /**< \brief PEVC signal: PAD_EVT2 on PC11 mux C */
+#define MUX_PC11C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PC11C_PEVC_PAD_EVT2  ((PIN_PC11C_PEVC_PAD_EVT2 << 16) | MUX_PC11C_PEVC_PAD_EVT2)
-#define GPIO_PC11C_PEVC_PAD_EVT2  _UL(1 << 11)
-#define PIN_PC26C_PEVC_PAD_EVT2        _L(90) /**< \brief PEVC signal: PAD_EVT2 on PC26 mux C */
-#define MUX_PC26C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PC11C_PEVC_PAD_EVT2  _UL_(1 << 11)
+#define PIN_PC26C_PEVC_PAD_EVT2        _L_(90) /**< \brief PEVC signal: PAD_EVT2 on PC26 mux C */
+#define MUX_PC26C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PC26C_PEVC_PAD_EVT2  ((PIN_PC26C_PEVC_PAD_EVT2 << 16) | MUX_PC26C_PEVC_PAD_EVT2)
-#define GPIO_PC26C_PEVC_PAD_EVT2  _UL(1 << 26)
-#define PIN_PB09B_PEVC_PAD_EVT2        _L(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
-#define MUX_PB09B_PEVC_PAD_EVT2         _L(1)
+#define GPIO_PC26C_PEVC_PAD_EVT2  _UL_(1 << 26)
+#define PIN_PB09B_PEVC_PAD_EVT2        _L_(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
+#define MUX_PB09B_PEVC_PAD_EVT2         _L_(1)
 #define PINMUX_PB09B_PEVC_PAD_EVT2  ((PIN_PB09B_PEVC_PAD_EVT2 << 16) | MUX_PB09B_PEVC_PAD_EVT2)
-#define GPIO_PB09B_PEVC_PAD_EVT2  _UL(1 <<  9)
-#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
-#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define GPIO_PB09B_PEVC_PAD_EVT2  _UL_(1 <<  9)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L_(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L_(2)
 #define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
-#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
-#define PIN_PC27C_PEVC_PAD_EVT3        _L(91) /**< \brief PEVC signal: PAD_EVT3 on PC27 mux C */
-#define MUX_PC27C_PEVC_PAD_EVT3         _L(2)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL_(1 << 11)
+#define PIN_PC27C_PEVC_PAD_EVT3        _L_(91) /**< \brief PEVC signal: PAD_EVT3 on PC27 mux C */
+#define MUX_PC27C_PEVC_PAD_EVT3         _L_(2)
 #define PINMUX_PC27C_PEVC_PAD_EVT3  ((PIN_PC27C_PEVC_PAD_EVT3 << 16) | MUX_PC27C_PEVC_PAD_EVT3)
-#define GPIO_PC27C_PEVC_PAD_EVT3  _UL(1 << 27)
-#define PIN_PB10B_PEVC_PAD_EVT3        _L(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
-#define MUX_PB10B_PEVC_PAD_EVT3         _L(1)
+#define GPIO_PC27C_PEVC_PAD_EVT3  _UL_(1 << 27)
+#define PIN_PB10B_PEVC_PAD_EVT3        _L_(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
+#define MUX_PB10B_PEVC_PAD_EVT3         _L_(1)
 #define PINMUX_PB10B_PEVC_PAD_EVT3  ((PIN_PB10B_PEVC_PAD_EVT3 << 16) | MUX_PB10B_PEVC_PAD_EVT3)
-#define GPIO_PB10B_PEVC_PAD_EVT3  _UL(1 << 10)
+#define GPIO_PB10B_PEVC_PAD_EVT3  _UL_(1 << 10)
 /* ========== GPIO definition for SCIF peripheral ========== */
-#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
-#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PIN_PA19E_SCIF_GCLK0           _L_(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
-#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
-#define PIN_PB10E_SCIF_GCLK0           _L(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
-#define MUX_PB10E_SCIF_GCLK0            _L(4)
+#define GPIO_PA19E_SCIF_GCLK0    _UL_(1 << 19)
+#define PIN_PB10E_SCIF_GCLK0           _L_(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
+#define MUX_PB10E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PB10E_SCIF_GCLK0    ((PIN_PB10E_SCIF_GCLK0 << 16) | MUX_PB10E_SCIF_GCLK0)
-#define GPIO_PB10E_SCIF_GCLK0    _UL(1 << 10)
-#define PIN_PC26E_SCIF_GCLK0           _L(90) /**< \brief SCIF signal: GCLK0 on PC26 mux E */
-#define MUX_PC26E_SCIF_GCLK0            _L(4)
+#define GPIO_PB10E_SCIF_GCLK0    _UL_(1 << 10)
+#define PIN_PC26E_SCIF_GCLK0           _L_(90) /**< \brief SCIF signal: GCLK0 on PC26 mux E */
+#define MUX_PC26E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PC26E_SCIF_GCLK0    ((PIN_PC26E_SCIF_GCLK0 << 16) | MUX_PC26E_SCIF_GCLK0)
-#define GPIO_PC26E_SCIF_GCLK0    _UL(1 << 26)
-#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
-#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define GPIO_PC26E_SCIF_GCLK0    _UL_(1 << 26)
+#define PIN_PA02A_SCIF_GCLK0            _L_(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L_(0)
 #define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
-#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
-#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
-#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define GPIO_PA02A_SCIF_GCLK0    _UL_(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L_(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
-#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
-#define PIN_PB11E_SCIF_GCLK1           _L(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
-#define MUX_PB11E_SCIF_GCLK1            _L(4)
+#define GPIO_PA20E_SCIF_GCLK1    _UL_(1 << 20)
+#define PIN_PB11E_SCIF_GCLK1           _L_(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
+#define MUX_PB11E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PB11E_SCIF_GCLK1    ((PIN_PB11E_SCIF_GCLK1 << 16) | MUX_PB11E_SCIF_GCLK1)
-#define GPIO_PB11E_SCIF_GCLK1    _UL(1 << 11)
-#define PIN_PC27E_SCIF_GCLK1           _L(91) /**< \brief SCIF signal: GCLK1 on PC27 mux E */
-#define MUX_PC27E_SCIF_GCLK1            _L(4)
+#define GPIO_PB11E_SCIF_GCLK1    _UL_(1 << 11)
+#define PIN_PC27E_SCIF_GCLK1           _L_(91) /**< \brief SCIF signal: GCLK1 on PC27 mux E */
+#define MUX_PC27E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PC27E_SCIF_GCLK1    ((PIN_PC27E_SCIF_GCLK1 << 16) | MUX_PC27E_SCIF_GCLK1)
-#define GPIO_PC27E_SCIF_GCLK1    _UL(1 << 27)
-#define PIN_PB12E_SCIF_GCLK2           _L(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
-#define MUX_PB12E_SCIF_GCLK2            _L(4)
+#define GPIO_PC27E_SCIF_GCLK1    _UL_(1 << 27)
+#define PIN_PB12E_SCIF_GCLK2           _L_(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
+#define MUX_PB12E_SCIF_GCLK2            _L_(4)
 #define PINMUX_PB12E_SCIF_GCLK2    ((PIN_PB12E_SCIF_GCLK2 << 16) | MUX_PB12E_SCIF_GCLK2)
-#define GPIO_PB12E_SCIF_GCLK2    _UL(1 << 12)
-#define PIN_PC28E_SCIF_GCLK2           _L(92) /**< \brief SCIF signal: GCLK2 on PC28 mux E */
-#define MUX_PC28E_SCIF_GCLK2            _L(4)
+#define GPIO_PB12E_SCIF_GCLK2    _UL_(1 << 12)
+#define PIN_PC28E_SCIF_GCLK2           _L_(92) /**< \brief SCIF signal: GCLK2 on PC28 mux E */
+#define MUX_PC28E_SCIF_GCLK2            _L_(4)
 #define PINMUX_PC28E_SCIF_GCLK2    ((PIN_PC28E_SCIF_GCLK2 << 16) | MUX_PC28E_SCIF_GCLK2)
-#define GPIO_PC28E_SCIF_GCLK2    _UL(1 << 28)
-#define PIN_PB13E_SCIF_GCLK3           _L(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
-#define MUX_PB13E_SCIF_GCLK3            _L(4)
+#define GPIO_PC28E_SCIF_GCLK2    _UL_(1 << 28)
+#define PIN_PB13E_SCIF_GCLK3           _L_(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
+#define MUX_PB13E_SCIF_GCLK3            _L_(4)
 #define PINMUX_PB13E_SCIF_GCLK3    ((PIN_PB13E_SCIF_GCLK3 << 16) | MUX_PB13E_SCIF_GCLK3)
-#define GPIO_PB13E_SCIF_GCLK3    _UL(1 << 13)
-#define PIN_PC29E_SCIF_GCLK3           _L(93) /**< \brief SCIF signal: GCLK3 on PC29 mux E */
-#define MUX_PC29E_SCIF_GCLK3            _L(4)
+#define GPIO_PB13E_SCIF_GCLK3    _UL_(1 << 13)
+#define PIN_PC29E_SCIF_GCLK3           _L_(93) /**< \brief SCIF signal: GCLK3 on PC29 mux E */
+#define MUX_PC29E_SCIF_GCLK3            _L_(4)
 #define PINMUX_PC29E_SCIF_GCLK3    ((PIN_PC29E_SCIF_GCLK3 << 16) | MUX_PC29E_SCIF_GCLK3)
-#define GPIO_PC29E_SCIF_GCLK3    _UL(1 << 29)
-#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
-#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PC29E_SCIF_GCLK3    _UL_(1 << 29)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L_(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
-#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
-#define PIN_PB14E_SCIF_GCLK_IN0        _L(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
-#define MUX_PB14E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL_(1 << 23)
+#define PIN_PB14E_SCIF_GCLK_IN0        _L_(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
+#define MUX_PB14E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PB14E_SCIF_GCLK_IN0  ((PIN_PB14E_SCIF_GCLK_IN0 << 16) | MUX_PB14E_SCIF_GCLK_IN0)
-#define GPIO_PB14E_SCIF_GCLK_IN0  _UL(1 << 14)
-#define PIN_PC30E_SCIF_GCLK_IN0        _L(94) /**< \brief SCIF signal: GCLK_IN0 on PC30 mux E */
-#define MUX_PC30E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PB14E_SCIF_GCLK_IN0  _UL_(1 << 14)
+#define PIN_PC30E_SCIF_GCLK_IN0        _L_(94) /**< \brief SCIF signal: GCLK_IN0 on PC30 mux E */
+#define MUX_PC30E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PC30E_SCIF_GCLK_IN0  ((PIN_PC30E_SCIF_GCLK_IN0 << 16) | MUX_PC30E_SCIF_GCLK_IN0)
-#define GPIO_PC30E_SCIF_GCLK_IN0  _UL(1 << 30)
-#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
-#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PC30E_SCIF_GCLK_IN0  _UL_(1 << 30)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L_(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
-#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
-#define PIN_PB15E_SCIF_GCLK_IN1        _L(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
-#define MUX_PB15E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL_(1 << 24)
+#define PIN_PB15E_SCIF_GCLK_IN1        _L_(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
+#define MUX_PB15E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PB15E_SCIF_GCLK_IN1  ((PIN_PB15E_SCIF_GCLK_IN1 << 16) | MUX_PB15E_SCIF_GCLK_IN1)
-#define GPIO_PB15E_SCIF_GCLK_IN1  _UL(1 << 15)
-#define PIN_PC31E_SCIF_GCLK_IN1        _L(95) /**< \brief SCIF signal: GCLK_IN1 on PC31 mux E */
-#define MUX_PC31E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PB15E_SCIF_GCLK_IN1  _UL_(1 << 15)
+#define PIN_PC31E_SCIF_GCLK_IN1        _L_(95) /**< \brief SCIF signal: GCLK_IN1 on PC31 mux E */
+#define MUX_PC31E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PC31E_SCIF_GCLK_IN1  ((PIN_PC31E_SCIF_GCLK_IN1 << 16) | MUX_PC31E_SCIF_GCLK_IN1)
-#define GPIO_PC31E_SCIF_GCLK_IN1  _UL(1 << 31)
+#define GPIO_PC31E_SCIF_GCLK_IN1  _UL_(1 << 31)
 /* ========== GPIO definition for EIC peripheral ========== */
-#define PIN_PB01C_EIC_EXTINT0          _L(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
-#define MUX_PB01C_EIC_EXTINT0           _L(2)
+#define PIN_PB01C_EIC_EXTINT0          _L_(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
+#define MUX_PB01C_EIC_EXTINT0           _L_(2)
 #define PINMUX_PB01C_EIC_EXTINT0   ((PIN_PB01C_EIC_EXTINT0 << 16) | MUX_PB01C_EIC_EXTINT0)
-#define GPIO_PB01C_EIC_EXTINT0   _UL(1 <<  1)
-#define PIN_PB01C_EIC_EXTINT_NUM        _L(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
-#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
-#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define GPIO_PB01C_EIC_EXTINT0   _UL_(1 <<  1)
+#define PIN_PB01C_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PA06C_EIC_EXTINT1           _L_(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
-#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
-#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
-#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
-#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define GPIO_PA06C_EIC_EXTINT1   _UL_(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L_(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
-#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
-#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
-#define PIN_PC24B_EIC_EXTINT1          _L(88) /**< \brief EIC signal: EXTINT1 on PC24 mux B */
-#define MUX_PC24B_EIC_EXTINT1           _L(1)
+#define GPIO_PA16C_EIC_EXTINT1   _UL_(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PC24B_EIC_EXTINT1          _L_(88) /**< \brief EIC signal: EXTINT1 on PC24 mux B */
+#define MUX_PC24B_EIC_EXTINT1           _L_(1)
 #define PINMUX_PC24B_EIC_EXTINT1   ((PIN_PC24B_EIC_EXTINT1 << 16) | MUX_PC24B_EIC_EXTINT1)
-#define GPIO_PC24B_EIC_EXTINT1   _UL(1 << 24)
-#define PIN_PC24B_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PC24 External Interrupt Line */
-#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
-#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define GPIO_PC24B_EIC_EXTINT1   _UL_(1 << 24)
+#define PIN_PC24B_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PC24 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L_(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
-#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
-#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
-#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
-#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL_(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L_(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
-#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
-#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
-#define PIN_PC25B_EIC_EXTINT2          _L(89) /**< \brief EIC signal: EXTINT2 on PC25 mux B */
-#define MUX_PC25B_EIC_EXTINT2           _L(1)
+#define GPIO_PA17C_EIC_EXTINT2   _UL_(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PC25B_EIC_EXTINT2          _L_(89) /**< \brief EIC signal: EXTINT2 on PC25 mux B */
+#define MUX_PC25B_EIC_EXTINT2           _L_(1)
 #define PINMUX_PC25B_EIC_EXTINT2   ((PIN_PC25B_EIC_EXTINT2 << 16) | MUX_PC25B_EIC_EXTINT2)
-#define GPIO_PC25B_EIC_EXTINT2   _UL(1 << 25)
-#define PIN_PC25B_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PC25 External Interrupt Line */
-#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
-#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define GPIO_PC25B_EIC_EXTINT2   _UL_(1 << 25)
+#define PIN_PC25B_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PC25 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L_(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
-#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
-#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
-#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
-#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define GPIO_PA05C_EIC_EXTINT3   _UL_(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L_(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
-#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
-#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
-#define PIN_PC26B_EIC_EXTINT3          _L(90) /**< \brief EIC signal: EXTINT3 on PC26 mux B */
-#define MUX_PC26B_EIC_EXTINT3           _L(1)
+#define GPIO_PA18C_EIC_EXTINT3   _UL_(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PC26B_EIC_EXTINT3          _L_(90) /**< \brief EIC signal: EXTINT3 on PC26 mux B */
+#define MUX_PC26B_EIC_EXTINT3           _L_(1)
 #define PINMUX_PC26B_EIC_EXTINT3   ((PIN_PC26B_EIC_EXTINT3 << 16) | MUX_PC26B_EIC_EXTINT3)
-#define GPIO_PC26B_EIC_EXTINT3   _UL(1 << 26)
-#define PIN_PC26B_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PC26 External Interrupt Line */
-#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
-#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define GPIO_PC26B_EIC_EXTINT3   _UL_(1 << 26)
+#define PIN_PC26B_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PC26 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L_(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
-#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
-#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
-#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
-#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define GPIO_PA07C_EIC_EXTINT4   _UL_(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L_(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
-#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
-#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
-#define PIN_PC27B_EIC_EXTINT4          _L(91) /**< \brief EIC signal: EXTINT4 on PC27 mux B */
-#define MUX_PC27B_EIC_EXTINT4           _L(1)
+#define GPIO_PA19C_EIC_EXTINT4   _UL_(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PC27B_EIC_EXTINT4          _L_(91) /**< \brief EIC signal: EXTINT4 on PC27 mux B */
+#define MUX_PC27B_EIC_EXTINT4           _L_(1)
 #define PINMUX_PC27B_EIC_EXTINT4   ((PIN_PC27B_EIC_EXTINT4 << 16) | MUX_PC27B_EIC_EXTINT4)
-#define GPIO_PC27B_EIC_EXTINT4   _UL(1 << 27)
-#define PIN_PC27B_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PC27 External Interrupt Line */
-#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
-#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define GPIO_PC27B_EIC_EXTINT4   _UL_(1 << 27)
+#define PIN_PC27B_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PC27 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L_(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L_(2)
 #define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
-#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
-#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
-#define PIN_PC03B_EIC_EXTINT5          _L(67) /**< \brief EIC signal: EXTINT5 on PC03 mux B */
-#define MUX_PC03B_EIC_EXTINT5           _L(1)
+#define GPIO_PA20C_EIC_EXTINT5   _UL_(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PC03B_EIC_EXTINT5          _L_(67) /**< \brief EIC signal: EXTINT5 on PC03 mux B */
+#define MUX_PC03B_EIC_EXTINT5           _L_(1)
 #define PINMUX_PC03B_EIC_EXTINT5   ((PIN_PC03B_EIC_EXTINT5 << 16) | MUX_PC03B_EIC_EXTINT5)
-#define GPIO_PC03B_EIC_EXTINT5   _UL(1 <<  3)
-#define PIN_PC03B_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PC03 External Interrupt Line */
-#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
-#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define GPIO_PC03B_EIC_EXTINT5   _UL_(1 <<  3)
+#define PIN_PC03B_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PC03 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L_(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L_(2)
 #define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
-#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
-#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
-#define PIN_PC04B_EIC_EXTINT6          _L(68) /**< \brief EIC signal: EXTINT6 on PC04 mux B */
-#define MUX_PC04B_EIC_EXTINT6           _L(1)
+#define GPIO_PA21C_EIC_EXTINT6   _UL_(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PC04B_EIC_EXTINT6          _L_(68) /**< \brief EIC signal: EXTINT6 on PC04 mux B */
+#define MUX_PC04B_EIC_EXTINT6           _L_(1)
 #define PINMUX_PC04B_EIC_EXTINT6   ((PIN_PC04B_EIC_EXTINT6 << 16) | MUX_PC04B_EIC_EXTINT6)
-#define GPIO_PC04B_EIC_EXTINT6   _UL(1 <<  4)
-#define PIN_PC04B_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PC04 External Interrupt Line */
-#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
-#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define GPIO_PC04B_EIC_EXTINT6   _UL_(1 <<  4)
+#define PIN_PC04B_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PC04 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L_(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L_(2)
 #define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
-#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
-#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
-#define PIN_PC05B_EIC_EXTINT7          _L(69) /**< \brief EIC signal: EXTINT7 on PC05 mux B */
-#define MUX_PC05B_EIC_EXTINT7           _L(1)
+#define GPIO_PA22C_EIC_EXTINT7   _UL_(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PC05B_EIC_EXTINT7          _L_(69) /**< \brief EIC signal: EXTINT7 on PC05 mux B */
+#define MUX_PC05B_EIC_EXTINT7           _L_(1)
 #define PINMUX_PC05B_EIC_EXTINT7   ((PIN_PC05B_EIC_EXTINT7 << 16) | MUX_PC05B_EIC_EXTINT7)
-#define GPIO_PC05B_EIC_EXTINT7   _UL(1 <<  5)
-#define PIN_PC05B_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PC05 External Interrupt Line */
-#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
-#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define GPIO_PC05B_EIC_EXTINT7   _UL_(1 <<  5)
+#define PIN_PC05B_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PC05 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L_(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L_(2)
 #define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
-#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
-#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
-#define PIN_PC06B_EIC_EXTINT8          _L(70) /**< \brief EIC signal: EXTINT8 on PC06 mux B */
-#define MUX_PC06B_EIC_EXTINT8           _L(1)
+#define GPIO_PA23C_EIC_EXTINT8   _UL_(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PC06B_EIC_EXTINT8          _L_(70) /**< \brief EIC signal: EXTINT8 on PC06 mux B */
+#define MUX_PC06B_EIC_EXTINT8           _L_(1)
 #define PINMUX_PC06B_EIC_EXTINT8   ((PIN_PC06B_EIC_EXTINT8 << 16) | MUX_PC06B_EIC_EXTINT8)
-#define GPIO_PC06B_EIC_EXTINT8   _UL(1 <<  6)
-#define PIN_PC06B_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PC06 External Interrupt Line */
+#define GPIO_PC06B_EIC_EXTINT8   _UL_(1 <<  6)
+#define PIN_PC06B_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PC06 External Interrupt Line */
 
 #endif /* _SAM4LC2C_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4lc2c.h
+++ b/asf/sam/include/sam4l/pio/sam4lc2c.h
@@ -1,0 +1,1804 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAM4LC2C
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LC2C_PIO_
+#define _SAM4LC2C_PIO_
+
+#define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
+#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
+#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
+#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
+#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
+#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
+#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
+#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
+#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
+#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
+#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
+#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
+#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
+#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
+#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
+#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
+#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
+#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
+#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
+#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
+#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
+#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
+#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
+#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
+#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
+#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
+#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
+#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
+#define GPIO_PB00                _UL(1 <<  0) /**< \brief GPIO Mask  for PB00 */
+#define PIN_PB01                          33  /**< \brief Pin Number for PB01 */
+#define GPIO_PB01                _UL(1 <<  1) /**< \brief GPIO Mask  for PB01 */
+#define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
+#define GPIO_PB02                _UL(1 <<  2) /**< \brief GPIO Mask  for PB02 */
+#define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
+#define GPIO_PB03                _UL(1 <<  3) /**< \brief GPIO Mask  for PB03 */
+#define PIN_PB04                          36  /**< \brief Pin Number for PB04 */
+#define GPIO_PB04                _UL(1 <<  4) /**< \brief GPIO Mask  for PB04 */
+#define PIN_PB05                          37  /**< \brief Pin Number for PB05 */
+#define GPIO_PB05                _UL(1 <<  5) /**< \brief GPIO Mask  for PB05 */
+#define PIN_PB06                          38  /**< \brief Pin Number for PB06 */
+#define GPIO_PB06                _UL(1 <<  6) /**< \brief GPIO Mask  for PB06 */
+#define PIN_PB07                          39  /**< \brief Pin Number for PB07 */
+#define GPIO_PB07                _UL(1 <<  7) /**< \brief GPIO Mask  for PB07 */
+#define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
+#define GPIO_PB08                _UL(1 <<  8) /**< \brief GPIO Mask  for PB08 */
+#define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
+#define GPIO_PB09                _UL(1 <<  9) /**< \brief GPIO Mask  for PB09 */
+#define PIN_PB10                          42  /**< \brief Pin Number for PB10 */
+#define GPIO_PB10                _UL(1 << 10) /**< \brief GPIO Mask  for PB10 */
+#define PIN_PB11                          43  /**< \brief Pin Number for PB11 */
+#define GPIO_PB11                _UL(1 << 11) /**< \brief GPIO Mask  for PB11 */
+#define PIN_PB12                          44  /**< \brief Pin Number for PB12 */
+#define GPIO_PB12                _UL(1 << 12) /**< \brief GPIO Mask  for PB12 */
+#define PIN_PB13                          45  /**< \brief Pin Number for PB13 */
+#define GPIO_PB13                _UL(1 << 13) /**< \brief GPIO Mask  for PB13 */
+#define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
+#define GPIO_PB14                _UL(1 << 14) /**< \brief GPIO Mask  for PB14 */
+#define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
+#define GPIO_PB15                _UL(1 << 15) /**< \brief GPIO Mask  for PB15 */
+#define PIN_PC00                          64  /**< \brief Pin Number for PC00 */
+#define GPIO_PC00                _UL(1 <<  0) /**< \brief GPIO Mask  for PC00 */
+#define PIN_PC01                          65  /**< \brief Pin Number for PC01 */
+#define GPIO_PC01                _UL(1 <<  1) /**< \brief GPIO Mask  for PC01 */
+#define PIN_PC02                          66  /**< \brief Pin Number for PC02 */
+#define GPIO_PC02                _UL(1 <<  2) /**< \brief GPIO Mask  for PC02 */
+#define PIN_PC03                          67  /**< \brief Pin Number for PC03 */
+#define GPIO_PC03                _UL(1 <<  3) /**< \brief GPIO Mask  for PC03 */
+#define PIN_PC04                          68  /**< \brief Pin Number for PC04 */
+#define GPIO_PC04                _UL(1 <<  4) /**< \brief GPIO Mask  for PC04 */
+#define PIN_PC05                          69  /**< \brief Pin Number for PC05 */
+#define GPIO_PC05                _UL(1 <<  5) /**< \brief GPIO Mask  for PC05 */
+#define PIN_PC06                          70  /**< \brief Pin Number for PC06 */
+#define GPIO_PC06                _UL(1 <<  6) /**< \brief GPIO Mask  for PC06 */
+#define PIN_PC07                          71  /**< \brief Pin Number for PC07 */
+#define GPIO_PC07                _UL(1 <<  7) /**< \brief GPIO Mask  for PC07 */
+#define PIN_PC08                          72  /**< \brief Pin Number for PC08 */
+#define GPIO_PC08                _UL(1 <<  8) /**< \brief GPIO Mask  for PC08 */
+#define PIN_PC09                          73  /**< \brief Pin Number for PC09 */
+#define GPIO_PC09                _UL(1 <<  9) /**< \brief GPIO Mask  for PC09 */
+#define PIN_PC10                          74  /**< \brief Pin Number for PC10 */
+#define GPIO_PC10                _UL(1 << 10) /**< \brief GPIO Mask  for PC10 */
+#define PIN_PC11                          75  /**< \brief Pin Number for PC11 */
+#define GPIO_PC11                _UL(1 << 11) /**< \brief GPIO Mask  for PC11 */
+#define PIN_PC12                          76  /**< \brief Pin Number for PC12 */
+#define GPIO_PC12                _UL(1 << 12) /**< \brief GPIO Mask  for PC12 */
+#define PIN_PC13                          77  /**< \brief Pin Number for PC13 */
+#define GPIO_PC13                _UL(1 << 13) /**< \brief GPIO Mask  for PC13 */
+#define PIN_PC14                          78  /**< \brief Pin Number for PC14 */
+#define GPIO_PC14                _UL(1 << 14) /**< \brief GPIO Mask  for PC14 */
+#define PIN_PC15                          79  /**< \brief Pin Number for PC15 */
+#define GPIO_PC15                _UL(1 << 15) /**< \brief GPIO Mask  for PC15 */
+#define PIN_PC16                          80  /**< \brief Pin Number for PC16 */
+#define GPIO_PC16                _UL(1 << 16) /**< \brief GPIO Mask  for PC16 */
+#define PIN_PC17                          81  /**< \brief Pin Number for PC17 */
+#define GPIO_PC17                _UL(1 << 17) /**< \brief GPIO Mask  for PC17 */
+#define PIN_PC18                          82  /**< \brief Pin Number for PC18 */
+#define GPIO_PC18                _UL(1 << 18) /**< \brief GPIO Mask  for PC18 */
+#define PIN_PC19                          83  /**< \brief Pin Number for PC19 */
+#define GPIO_PC19                _UL(1 << 19) /**< \brief GPIO Mask  for PC19 */
+#define PIN_PC20                          84  /**< \brief Pin Number for PC20 */
+#define GPIO_PC20                _UL(1 << 20) /**< \brief GPIO Mask  for PC20 */
+#define PIN_PC21                          85  /**< \brief Pin Number for PC21 */
+#define GPIO_PC21                _UL(1 << 21) /**< \brief GPIO Mask  for PC21 */
+#define PIN_PC22                          86  /**< \brief Pin Number for PC22 */
+#define GPIO_PC22                _UL(1 << 22) /**< \brief GPIO Mask  for PC22 */
+#define PIN_PC23                          87  /**< \brief Pin Number for PC23 */
+#define GPIO_PC23                _UL(1 << 23) /**< \brief GPIO Mask  for PC23 */
+#define PIN_PC24                          88  /**< \brief Pin Number for PC24 */
+#define GPIO_PC24                _UL(1 << 24) /**< \brief GPIO Mask  for PC24 */
+#define PIN_PC25                          89  /**< \brief Pin Number for PC25 */
+#define GPIO_PC25                _UL(1 << 25) /**< \brief GPIO Mask  for PC25 */
+#define PIN_PC26                          90  /**< \brief Pin Number for PC26 */
+#define GPIO_PC26                _UL(1 << 26) /**< \brief GPIO Mask  for PC26 */
+#define PIN_PC27                          91  /**< \brief Pin Number for PC27 */
+#define GPIO_PC27                _UL(1 << 27) /**< \brief GPIO Mask  for PC27 */
+#define PIN_PC28                          92  /**< \brief Pin Number for PC28 */
+#define GPIO_PC28                _UL(1 << 28) /**< \brief GPIO Mask  for PC28 */
+#define PIN_PC29                          93  /**< \brief Pin Number for PC29 */
+#define GPIO_PC29                _UL(1 << 29) /**< \brief GPIO Mask  for PC29 */
+#define PIN_PC30                          94  /**< \brief Pin Number for PC30 */
+#define GPIO_PC30                _UL(1 << 30) /**< \brief GPIO Mask  for PC30 */
+#define PIN_PC31                          95  /**< \brief Pin Number for PC31 */
+#define GPIO_PC31                _UL(1 << 31) /**< \brief GPIO Mask  for PC31 */
+/* ========== GPIO definition for TWIMS0 peripheral ========== */
+#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
+#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+/* ========== GPIO definition for TWIMS1 peripheral ========== */
+#define PIN_PB01A_TWIMS1_TWCK          _L(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
+#define MUX_PB01A_TWIMS1_TWCK           _L(0)
+#define PINMUX_PB01A_TWIMS1_TWCK   ((PIN_PB01A_TWIMS1_TWCK << 16) | MUX_PB01A_TWIMS1_TWCK)
+#define GPIO_PB01A_TWIMS1_TWCK   _UL(1 <<  1)
+#define PIN_PB00A_TWIMS1_TWD           _L(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
+#define MUX_PB00A_TWIMS1_TWD            _L(0)
+#define PINMUX_PB00A_TWIMS1_TWD    ((PIN_PB00A_TWIMS1_TWD << 16) | MUX_PB00A_TWIMS1_TWD)
+#define GPIO_PB00A_TWIMS1_TWD    _UL(1 <<  0)
+/* ========== GPIO definition for TWIMS2 peripheral ========== */
+#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
+#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+/* ========== GPIO definition for TWIMS3 peripheral ========== */
+#define PIN_PB15C_TWIMS3_TWCK          _L(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
+#define MUX_PB15C_TWIMS3_TWCK           _L(2)
+#define PINMUX_PB15C_TWIMS3_TWCK   ((PIN_PB15C_TWIMS3_TWCK << 16) | MUX_PB15C_TWIMS3_TWCK)
+#define GPIO_PB15C_TWIMS3_TWCK   _UL(1 << 15)
+#define PIN_PB14C_TWIMS3_TWD           _L(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
+#define MUX_PB14C_TWIMS3_TWD            _L(2)
+#define PINMUX_PB14C_TWIMS3_TWD    ((PIN_PB14C_TWIMS3_TWD << 16) | MUX_PB14C_TWIMS3_TWD)
+#define GPIO_PB14C_TWIMS3_TWD    _UL(1 << 14)
+/* ========== GPIO definition for IISC peripheral ========== */
+#define PIN_PB05D_IISC_IMCK            _L(37) /**< \brief IISC signal: IMCK on PB05 mux D */
+#define MUX_PB05D_IISC_IMCK             _L(3)
+#define PINMUX_PB05D_IISC_IMCK     ((PIN_PB05D_IISC_IMCK << 16) | MUX_PB05D_IISC_IMCK)
+#define GPIO_PB05D_IISC_IMCK     _UL(1 <<  5)
+#define PIN_PC14D_IISC_IMCK            _L(78) /**< \brief IISC signal: IMCK on PC14 mux D */
+#define MUX_PC14D_IISC_IMCK             _L(3)
+#define PINMUX_PC14D_IISC_IMCK     ((PIN_PC14D_IISC_IMCK << 16) | MUX_PC14D_IISC_IMCK)
+#define GPIO_PC14D_IISC_IMCK     _UL(1 << 14)
+#define PIN_PB02D_IISC_ISCK            _L(34) /**< \brief IISC signal: ISCK on PB02 mux D */
+#define MUX_PB02D_IISC_ISCK             _L(3)
+#define PINMUX_PB02D_IISC_ISCK     ((PIN_PB02D_IISC_ISCK << 16) | MUX_PB02D_IISC_ISCK)
+#define GPIO_PB02D_IISC_ISCK     _UL(1 <<  2)
+#define PIN_PC09D_IISC_ISCK            _L(73) /**< \brief IISC signal: ISCK on PC09 mux D */
+#define MUX_PC09D_IISC_ISCK             _L(3)
+#define PINMUX_PC09D_IISC_ISCK     ((PIN_PC09D_IISC_ISCK << 16) | MUX_PC09D_IISC_ISCK)
+#define GPIO_PC09D_IISC_ISCK     _UL(1 <<  9)
+#define PIN_PB03D_IISC_ISDI            _L(35) /**< \brief IISC signal: ISDI on PB03 mux D */
+#define MUX_PB03D_IISC_ISDI             _L(3)
+#define PINMUX_PB03D_IISC_ISDI     ((PIN_PB03D_IISC_ISDI << 16) | MUX_PB03D_IISC_ISDI)
+#define GPIO_PB03D_IISC_ISDI     _UL(1 <<  3)
+#define PIN_PC10D_IISC_ISDI            _L(74) /**< \brief IISC signal: ISDI on PC10 mux D */
+#define MUX_PC10D_IISC_ISDI             _L(3)
+#define PINMUX_PC10D_IISC_ISDI     ((PIN_PC10D_IISC_ISDI << 16) | MUX_PC10D_IISC_ISDI)
+#define GPIO_PC10D_IISC_ISDI     _UL(1 << 10)
+#define PIN_PB04D_IISC_ISDO            _L(36) /**< \brief IISC signal: ISDO on PB04 mux D */
+#define MUX_PB04D_IISC_ISDO             _L(3)
+#define PINMUX_PB04D_IISC_ISDO     ((PIN_PB04D_IISC_ISDO << 16) | MUX_PB04D_IISC_ISDO)
+#define GPIO_PB04D_IISC_ISDO     _UL(1 <<  4)
+#define PIN_PC13D_IISC_ISDO            _L(77) /**< \brief IISC signal: ISDO on PC13 mux D */
+#define MUX_PC13D_IISC_ISDO             _L(3)
+#define PINMUX_PC13D_IISC_ISDO     ((PIN_PC13D_IISC_ISDO << 16) | MUX_PC13D_IISC_ISDO)
+#define GPIO_PC13D_IISC_ISDO     _UL(1 << 13)
+#define PIN_PB06D_IISC_IWS             _L(38) /**< \brief IISC signal: IWS on PB06 mux D */
+#define MUX_PB06D_IISC_IWS              _L(3)
+#define PINMUX_PB06D_IISC_IWS      ((PIN_PB06D_IISC_IWS << 16) | MUX_PB06D_IISC_IWS)
+#define GPIO_PB06D_IISC_IWS      _UL(1 <<  6)
+#define PIN_PC12D_IISC_IWS             _L(76) /**< \brief IISC signal: IWS on PC12 mux D */
+#define MUX_PC12D_IISC_IWS              _L(3)
+#define PINMUX_PC12D_IISC_IWS      ((PIN_PC12D_IISC_IWS << 16) | MUX_PC12D_IISC_IWS)
+#define GPIO_PC12D_IISC_IWS      _UL(1 << 12)
+/* ========== GPIO definition for SPI peripheral ========== */
+#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L(1)
+#define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
+#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
+#define PIN_PB14B_SPI_MISO             _L(46) /**< \brief SPI signal: MISO on PB14 mux B */
+#define MUX_PB14B_SPI_MISO              _L(1)
+#define PINMUX_PB14B_SPI_MISO      ((PIN_PB14B_SPI_MISO << 16) | MUX_PB14B_SPI_MISO)
+#define GPIO_PB14B_SPI_MISO      _UL(1 << 14)
+#define PIN_PC28B_SPI_MISO             _L(92) /**< \brief SPI signal: MISO on PC28 mux B */
+#define MUX_PC28B_SPI_MISO              _L(1)
+#define PINMUX_PC28B_SPI_MISO      ((PIN_PC28B_SPI_MISO << 16) | MUX_PC28B_SPI_MISO)
+#define GPIO_PC28B_SPI_MISO      _UL(1 << 28)
+#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L(0)
+#define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
+#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
+#define PIN_PC04A_SPI_MISO             _L(68) /**< \brief SPI signal: MISO on PC04 mux A */
+#define MUX_PC04A_SPI_MISO              _L(0)
+#define PINMUX_PC04A_SPI_MISO      ((PIN_PC04A_SPI_MISO << 16) | MUX_PC04A_SPI_MISO)
+#define GPIO_PC04A_SPI_MISO      _UL(1 <<  4)
+#define PIN_PB15B_SPI_MOSI             _L(47) /**< \brief SPI signal: MOSI on PB15 mux B */
+#define MUX_PB15B_SPI_MOSI              _L(1)
+#define PINMUX_PB15B_SPI_MOSI      ((PIN_PB15B_SPI_MOSI << 16) | MUX_PB15B_SPI_MOSI)
+#define GPIO_PB15B_SPI_MOSI      _UL(1 << 15)
+#define PIN_PC29B_SPI_MOSI             _L(93) /**< \brief SPI signal: MOSI on PC29 mux B */
+#define MUX_PC29B_SPI_MOSI              _L(1)
+#define PINMUX_PC29B_SPI_MOSI      ((PIN_PC29B_SPI_MOSI << 16) | MUX_PC29B_SPI_MOSI)
+#define GPIO_PC29B_SPI_MOSI      _UL(1 << 29)
+#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L(0)
+#define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
+#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
+#define PIN_PC05A_SPI_MOSI             _L(69) /**< \brief SPI signal: MOSI on PC05 mux A */
+#define MUX_PC05A_SPI_MOSI              _L(0)
+#define PINMUX_PC05A_SPI_MOSI      ((PIN_PC05A_SPI_MOSI << 16) | MUX_PC05A_SPI_MOSI)
+#define GPIO_PC05A_SPI_MOSI      _UL(1 <<  5)
+#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
+#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
+#define PIN_PC31B_SPI_NPCS0            _L(95) /**< \brief SPI signal: NPCS0 on PC31 mux B */
+#define MUX_PC31B_SPI_NPCS0             _L(1)
+#define PINMUX_PC31B_SPI_NPCS0     ((PIN_PC31B_SPI_NPCS0 << 16) | MUX_PC31B_SPI_NPCS0)
+#define GPIO_PC31B_SPI_NPCS0     _UL(1 << 31)
+#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
+#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
+#define PIN_PC03A_SPI_NPCS0            _L(67) /**< \brief SPI signal: NPCS0 on PC03 mux A */
+#define MUX_PC03A_SPI_NPCS0             _L(0)
+#define PINMUX_PC03A_SPI_NPCS0     ((PIN_PC03A_SPI_NPCS0 << 16) | MUX_PC03A_SPI_NPCS0)
+#define GPIO_PC03A_SPI_NPCS0     _UL(1 <<  3)
+#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
+#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PB13B_SPI_NPCS1            _L(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
+#define MUX_PB13B_SPI_NPCS1             _L(1)
+#define PINMUX_PB13B_SPI_NPCS1     ((PIN_PB13B_SPI_NPCS1 << 16) | MUX_PB13B_SPI_NPCS1)
+#define GPIO_PB13B_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PC02A_SPI_NPCS1            _L(66) /**< \brief SPI signal: NPCS1 on PC02 mux A */
+#define MUX_PC02A_SPI_NPCS1             _L(0)
+#define PINMUX_PC02A_SPI_NPCS1     ((PIN_PC02A_SPI_NPCS1 << 16) | MUX_PC02A_SPI_NPCS1)
+#define GPIO_PC02A_SPI_NPCS1     _UL(1 <<  2)
+#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
+#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
+#define PIN_PB11B_SPI_NPCS2            _L(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
+#define MUX_PB11B_SPI_NPCS2             _L(1)
+#define PINMUX_PB11B_SPI_NPCS2     ((PIN_PB11B_SPI_NPCS2 << 16) | MUX_PB11B_SPI_NPCS2)
+#define GPIO_PB11B_SPI_NPCS2     _UL(1 << 11)
+#define PIN_PC00A_SPI_NPCS2            _L(64) /**< \brief SPI signal: NPCS2 on PC00 mux A */
+#define MUX_PC00A_SPI_NPCS2             _L(0)
+#define PINMUX_PC00A_SPI_NPCS2     ((PIN_PC00A_SPI_NPCS2 << 16) | MUX_PC00A_SPI_NPCS2)
+#define GPIO_PC00A_SPI_NPCS2     _UL(1 <<  0)
+#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
+#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
+#define PIN_PB12B_SPI_NPCS3            _L(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
+#define MUX_PB12B_SPI_NPCS3             _L(1)
+#define PINMUX_PB12B_SPI_NPCS3     ((PIN_PB12B_SPI_NPCS3 << 16) | MUX_PB12B_SPI_NPCS3)
+#define GPIO_PB12B_SPI_NPCS3     _UL(1 << 12)
+#define PIN_PC01A_SPI_NPCS3            _L(65) /**< \brief SPI signal: NPCS3 on PC01 mux A */
+#define MUX_PC01A_SPI_NPCS3             _L(0)
+#define PINMUX_PC01A_SPI_NPCS3     ((PIN_PC01A_SPI_NPCS3 << 16) | MUX_PC01A_SPI_NPCS3)
+#define GPIO_PC01A_SPI_NPCS3     _UL(1 <<  1)
+#define PIN_PC30B_SPI_SCK              _L(94) /**< \brief SPI signal: SCK on PC30 mux B */
+#define MUX_PC30B_SPI_SCK               _L(1)
+#define PINMUX_PC30B_SPI_SCK       ((PIN_PC30B_SPI_SCK << 16) | MUX_PC30B_SPI_SCK)
+#define GPIO_PC30B_SPI_SCK       _UL(1 << 30)
+#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L(0)
+#define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
+#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
+#define PIN_PC06A_SPI_SCK              _L(70) /**< \brief SPI signal: SCK on PC06 mux A */
+#define MUX_PC06A_SPI_SCK               _L(0)
+#define PINMUX_PC06A_SPI_SCK       ((PIN_PC06A_SPI_SCK << 16) | MUX_PC06A_SPI_SCK)
+#define GPIO_PC06A_SPI_SCK       _UL(1 <<  6)
+/* ========== GPIO definition for TC0 peripheral ========== */
+#define PIN_PB07D_TC0_A0               _L(39) /**< \brief TC0 signal: A0 on PB07 mux D */
+#define MUX_PB07D_TC0_A0                _L(3)
+#define PINMUX_PB07D_TC0_A0        ((PIN_PB07D_TC0_A0 << 16) | MUX_PB07D_TC0_A0)
+#define GPIO_PB07D_TC0_A0        _UL(1 <<  7)
+#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L(1)
+#define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
+#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
+#define PIN_PB09D_TC0_A1               _L(41) /**< \brief TC0 signal: A1 on PB09 mux D */
+#define MUX_PB09D_TC0_A1                _L(3)
+#define PINMUX_PB09D_TC0_A1        ((PIN_PB09D_TC0_A1 << 16) | MUX_PB09D_TC0_A1)
+#define GPIO_PB09D_TC0_A1        _UL(1 <<  9)
+#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L(1)
+#define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
+#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
+#define PIN_PB11D_TC0_A2               _L(43) /**< \brief TC0 signal: A2 on PB11 mux D */
+#define MUX_PB11D_TC0_A2                _L(3)
+#define PINMUX_PB11D_TC0_A2        ((PIN_PB11D_TC0_A2 << 16) | MUX_PB11D_TC0_A2)
+#define GPIO_PB11D_TC0_A2        _UL(1 << 11)
+#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L(1)
+#define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
+#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
+#define PIN_PB08D_TC0_B0               _L(40) /**< \brief TC0 signal: B0 on PB08 mux D */
+#define MUX_PB08D_TC0_B0                _L(3)
+#define PINMUX_PB08D_TC0_B0        ((PIN_PB08D_TC0_B0 << 16) | MUX_PB08D_TC0_B0)
+#define GPIO_PB08D_TC0_B0        _UL(1 <<  8)
+#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L(1)
+#define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
+#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
+#define PIN_PB10D_TC0_B1               _L(42) /**< \brief TC0 signal: B1 on PB10 mux D */
+#define MUX_PB10D_TC0_B1                _L(3)
+#define PINMUX_PB10D_TC0_B1        ((PIN_PB10D_TC0_B1 << 16) | MUX_PB10D_TC0_B1)
+#define GPIO_PB10D_TC0_B1        _UL(1 << 10)
+#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L(1)
+#define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
+#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
+#define PIN_PB12D_TC0_B2               _L(44) /**< \brief TC0 signal: B2 on PB12 mux D */
+#define MUX_PB12D_TC0_B2                _L(3)
+#define PINMUX_PB12D_TC0_B2        ((PIN_PB12D_TC0_B2 << 16) | MUX_PB12D_TC0_B2)
+#define GPIO_PB12D_TC0_B2        _UL(1 << 12)
+#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L(1)
+#define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
+#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
+#define PIN_PB13D_TC0_CLK0             _L(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
+#define MUX_PB13D_TC0_CLK0              _L(3)
+#define PINMUX_PB13D_TC0_CLK0      ((PIN_PB13D_TC0_CLK0 << 16) | MUX_PB13D_TC0_CLK0)
+#define GPIO_PB13D_TC0_CLK0      _UL(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L(1)
+#define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
+#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
+#define PIN_PB14D_TC0_CLK1             _L(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
+#define MUX_PB14D_TC0_CLK1              _L(3)
+#define PINMUX_PB14D_TC0_CLK1      ((PIN_PB14D_TC0_CLK1 << 16) | MUX_PB14D_TC0_CLK1)
+#define GPIO_PB14D_TC0_CLK1      _UL(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L(1)
+#define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
+#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
+#define PIN_PB15D_TC0_CLK2             _L(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
+#define MUX_PB15D_TC0_CLK2              _L(3)
+#define PINMUX_PB15D_TC0_CLK2      ((PIN_PB15D_TC0_CLK2 << 16) | MUX_PB15D_TC0_CLK2)
+#define GPIO_PB15D_TC0_CLK2      _UL(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L(1)
+#define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
+#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+/* ========== GPIO definition for TC1 peripheral ========== */
+#define PIN_PC00D_TC1_A0               _L(64) /**< \brief TC1 signal: A0 on PC00 mux D */
+#define MUX_PC00D_TC1_A0                _L(3)
+#define PINMUX_PC00D_TC1_A0        ((PIN_PC00D_TC1_A0 << 16) | MUX_PC00D_TC1_A0)
+#define GPIO_PC00D_TC1_A0        _UL(1 <<  0)
+#define PIN_PC15A_TC1_A0               _L(79) /**< \brief TC1 signal: A0 on PC15 mux A */
+#define MUX_PC15A_TC1_A0                _L(0)
+#define PINMUX_PC15A_TC1_A0        ((PIN_PC15A_TC1_A0 << 16) | MUX_PC15A_TC1_A0)
+#define GPIO_PC15A_TC1_A0        _UL(1 << 15)
+#define PIN_PC02D_TC1_A1               _L(66) /**< \brief TC1 signal: A1 on PC02 mux D */
+#define MUX_PC02D_TC1_A1                _L(3)
+#define PINMUX_PC02D_TC1_A1        ((PIN_PC02D_TC1_A1 << 16) | MUX_PC02D_TC1_A1)
+#define GPIO_PC02D_TC1_A1        _UL(1 <<  2)
+#define PIN_PC17A_TC1_A1               _L(81) /**< \brief TC1 signal: A1 on PC17 mux A */
+#define MUX_PC17A_TC1_A1                _L(0)
+#define PINMUX_PC17A_TC1_A1        ((PIN_PC17A_TC1_A1 << 16) | MUX_PC17A_TC1_A1)
+#define GPIO_PC17A_TC1_A1        _UL(1 << 17)
+#define PIN_PC04D_TC1_A2               _L(68) /**< \brief TC1 signal: A2 on PC04 mux D */
+#define MUX_PC04D_TC1_A2                _L(3)
+#define PINMUX_PC04D_TC1_A2        ((PIN_PC04D_TC1_A2 << 16) | MUX_PC04D_TC1_A2)
+#define GPIO_PC04D_TC1_A2        _UL(1 <<  4)
+#define PIN_PC19A_TC1_A2               _L(83) /**< \brief TC1 signal: A2 on PC19 mux A */
+#define MUX_PC19A_TC1_A2                _L(0)
+#define PINMUX_PC19A_TC1_A2        ((PIN_PC19A_TC1_A2 << 16) | MUX_PC19A_TC1_A2)
+#define GPIO_PC19A_TC1_A2        _UL(1 << 19)
+#define PIN_PC01D_TC1_B0               _L(65) /**< \brief TC1 signal: B0 on PC01 mux D */
+#define MUX_PC01D_TC1_B0                _L(3)
+#define PINMUX_PC01D_TC1_B0        ((PIN_PC01D_TC1_B0 << 16) | MUX_PC01D_TC1_B0)
+#define GPIO_PC01D_TC1_B0        _UL(1 <<  1)
+#define PIN_PC16A_TC1_B0               _L(80) /**< \brief TC1 signal: B0 on PC16 mux A */
+#define MUX_PC16A_TC1_B0                _L(0)
+#define PINMUX_PC16A_TC1_B0        ((PIN_PC16A_TC1_B0 << 16) | MUX_PC16A_TC1_B0)
+#define GPIO_PC16A_TC1_B0        _UL(1 << 16)
+#define PIN_PC03D_TC1_B1               _L(67) /**< \brief TC1 signal: B1 on PC03 mux D */
+#define MUX_PC03D_TC1_B1                _L(3)
+#define PINMUX_PC03D_TC1_B1        ((PIN_PC03D_TC1_B1 << 16) | MUX_PC03D_TC1_B1)
+#define GPIO_PC03D_TC1_B1        _UL(1 <<  3)
+#define PIN_PC18A_TC1_B1               _L(82) /**< \brief TC1 signal: B1 on PC18 mux A */
+#define MUX_PC18A_TC1_B1                _L(0)
+#define PINMUX_PC18A_TC1_B1        ((PIN_PC18A_TC1_B1 << 16) | MUX_PC18A_TC1_B1)
+#define GPIO_PC18A_TC1_B1        _UL(1 << 18)
+#define PIN_PC05D_TC1_B2               _L(69) /**< \brief TC1 signal: B2 on PC05 mux D */
+#define MUX_PC05D_TC1_B2                _L(3)
+#define PINMUX_PC05D_TC1_B2        ((PIN_PC05D_TC1_B2 << 16) | MUX_PC05D_TC1_B2)
+#define GPIO_PC05D_TC1_B2        _UL(1 <<  5)
+#define PIN_PC20A_TC1_B2               _L(84) /**< \brief TC1 signal: B2 on PC20 mux A */
+#define MUX_PC20A_TC1_B2                _L(0)
+#define PINMUX_PC20A_TC1_B2        ((PIN_PC20A_TC1_B2 << 16) | MUX_PC20A_TC1_B2)
+#define GPIO_PC20A_TC1_B2        _UL(1 << 20)
+#define PIN_PC06D_TC1_CLK0             _L(70) /**< \brief TC1 signal: CLK0 on PC06 mux D */
+#define MUX_PC06D_TC1_CLK0              _L(3)
+#define PINMUX_PC06D_TC1_CLK0      ((PIN_PC06D_TC1_CLK0 << 16) | MUX_PC06D_TC1_CLK0)
+#define GPIO_PC06D_TC1_CLK0      _UL(1 <<  6)
+#define PIN_PC21A_TC1_CLK0             _L(85) /**< \brief TC1 signal: CLK0 on PC21 mux A */
+#define MUX_PC21A_TC1_CLK0              _L(0)
+#define PINMUX_PC21A_TC1_CLK0      ((PIN_PC21A_TC1_CLK0 << 16) | MUX_PC21A_TC1_CLK0)
+#define GPIO_PC21A_TC1_CLK0      _UL(1 << 21)
+#define PIN_PC07D_TC1_CLK1             _L(71) /**< \brief TC1 signal: CLK1 on PC07 mux D */
+#define MUX_PC07D_TC1_CLK1              _L(3)
+#define PINMUX_PC07D_TC1_CLK1      ((PIN_PC07D_TC1_CLK1 << 16) | MUX_PC07D_TC1_CLK1)
+#define GPIO_PC07D_TC1_CLK1      _UL(1 <<  7)
+#define PIN_PC22A_TC1_CLK1             _L(86) /**< \brief TC1 signal: CLK1 on PC22 mux A */
+#define MUX_PC22A_TC1_CLK1              _L(0)
+#define PINMUX_PC22A_TC1_CLK1      ((PIN_PC22A_TC1_CLK1 << 16) | MUX_PC22A_TC1_CLK1)
+#define GPIO_PC22A_TC1_CLK1      _UL(1 << 22)
+#define PIN_PC08D_TC1_CLK2             _L(72) /**< \brief TC1 signal: CLK2 on PC08 mux D */
+#define MUX_PC08D_TC1_CLK2              _L(3)
+#define PINMUX_PC08D_TC1_CLK2      ((PIN_PC08D_TC1_CLK2 << 16) | MUX_PC08D_TC1_CLK2)
+#define GPIO_PC08D_TC1_CLK2      _UL(1 <<  8)
+#define PIN_PC23A_TC1_CLK2             _L(87) /**< \brief TC1 signal: CLK2 on PC23 mux A */
+#define MUX_PC23A_TC1_CLK2              _L(0)
+#define PINMUX_PC23A_TC1_CLK2      ((PIN_PC23A_TC1_CLK2 << 16) | MUX_PC23A_TC1_CLK2)
+#define GPIO_PC23A_TC1_CLK2      _UL(1 << 23)
+/* ========== GPIO definition for USART0 peripheral ========== */
+#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L(1)
+#define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
+#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
+#define PIN_PC00B_USART0_CLK           _L(64) /**< \brief USART0 signal: CLK on PC00 mux B */
+#define MUX_PC00B_USART0_CLK            _L(1)
+#define PINMUX_PC00B_USART0_CLK    ((PIN_PC00B_USART0_CLK << 16) | MUX_PC00B_USART0_CLK)
+#define GPIO_PC00B_USART0_CLK    _UL(1 <<  0)
+#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L(0)
+#define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
+#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
+#define PIN_PB13A_USART0_CLK           _L(45) /**< \brief USART0 signal: CLK on PB13 mux A */
+#define MUX_PB13A_USART0_CLK            _L(0)
+#define PINMUX_PB13A_USART0_CLK    ((PIN_PB13A_USART0_CLK << 16) | MUX_PB13A_USART0_CLK)
+#define GPIO_PB13A_USART0_CLK    _UL(1 << 13)
+#define PIN_PC02B_USART0_CTS           _L(66) /**< \brief USART0 signal: CTS on PC02 mux B */
+#define MUX_PC02B_USART0_CTS            _L(1)
+#define PINMUX_PC02B_USART0_CTS    ((PIN_PC02B_USART0_CTS << 16) | MUX_PC02B_USART0_CTS)
+#define GPIO_PC02B_USART0_CTS    _UL(1 <<  2)
+#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L(0)
+#define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
+#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
+#define PIN_PB11A_USART0_CTS           _L(43) /**< \brief USART0 signal: CTS on PB11 mux A */
+#define MUX_PB11A_USART0_CTS            _L(0)
+#define PINMUX_PB11A_USART0_CTS    ((PIN_PB11A_USART0_CTS << 16) | MUX_PB11A_USART0_CTS)
+#define GPIO_PB11A_USART0_CTS    _UL(1 << 11)
+#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L(1)
+#define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
+#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
+#define PIN_PC01B_USART0_RTS           _L(65) /**< \brief USART0 signal: RTS on PC01 mux B */
+#define MUX_PC01B_USART0_RTS            _L(1)
+#define PINMUX_PC01B_USART0_RTS    ((PIN_PC01B_USART0_RTS << 16) | MUX_PC01B_USART0_RTS)
+#define GPIO_PC01B_USART0_RTS    _UL(1 <<  1)
+#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L(0)
+#define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
+#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
+#define PIN_PB12A_USART0_RTS           _L(44) /**< \brief USART0 signal: RTS on PB12 mux A */
+#define MUX_PB12A_USART0_RTS            _L(0)
+#define PINMUX_PB12A_USART0_RTS    ((PIN_PB12A_USART0_RTS << 16) | MUX_PB12A_USART0_RTS)
+#define GPIO_PB12A_USART0_RTS    _UL(1 << 12)
+#define PIN_PC02C_USART0_RXD           _L(66) /**< \brief USART0 signal: RXD on PC02 mux C */
+#define MUX_PC02C_USART0_RXD            _L(2)
+#define PINMUX_PC02C_USART0_RXD    ((PIN_PC02C_USART0_RXD << 16) | MUX_PC02C_USART0_RXD)
+#define GPIO_PC02C_USART0_RXD    _UL(1 <<  2)
+#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L(1)
+#define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
+#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
+#define PIN_PB00B_USART0_RXD           _L(32) /**< \brief USART0 signal: RXD on PB00 mux B */
+#define MUX_PB00B_USART0_RXD            _L(1)
+#define PINMUX_PB00B_USART0_RXD    ((PIN_PB00B_USART0_RXD << 16) | MUX_PB00B_USART0_RXD)
+#define GPIO_PB00B_USART0_RXD    _UL(1 <<  0)
+#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L(0)
+#define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
+#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
+#define PIN_PB14A_USART0_RXD           _L(46) /**< \brief USART0 signal: RXD on PB14 mux A */
+#define MUX_PB14A_USART0_RXD            _L(0)
+#define PINMUX_PB14A_USART0_RXD    ((PIN_PB14A_USART0_RXD << 16) | MUX_PB14A_USART0_RXD)
+#define GPIO_PB14A_USART0_RXD    _UL(1 << 14)
+#define PIN_PC03C_USART0_TXD           _L(67) /**< \brief USART0 signal: TXD on PC03 mux C */
+#define MUX_PC03C_USART0_TXD            _L(2)
+#define PINMUX_PC03C_USART0_TXD    ((PIN_PC03C_USART0_TXD << 16) | MUX_PC03C_USART0_TXD)
+#define GPIO_PC03C_USART0_TXD    _UL(1 <<  3)
+#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L(1)
+#define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
+#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
+#define PIN_PB01B_USART0_TXD           _L(33) /**< \brief USART0 signal: TXD on PB01 mux B */
+#define MUX_PB01B_USART0_TXD            _L(1)
+#define PINMUX_PB01B_USART0_TXD    ((PIN_PB01B_USART0_TXD << 16) | MUX_PB01B_USART0_TXD)
+#define GPIO_PB01B_USART0_TXD    _UL(1 <<  1)
+#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L(0)
+#define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
+#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
+#define PIN_PB15A_USART0_TXD           _L(47) /**< \brief USART0 signal: TXD on PB15 mux A */
+#define MUX_PB15A_USART0_TXD            _L(0)
+#define PINMUX_PB15A_USART0_TXD    ((PIN_PB15A_USART0_TXD << 16) | MUX_PB15A_USART0_TXD)
+#define GPIO_PB15A_USART0_TXD    _UL(1 << 15)
+/* ========== GPIO definition for USART1 peripheral ========== */
+#define PIN_PB03B_USART1_CLK           _L(35) /**< \brief USART1 signal: CLK on PB03 mux B */
+#define MUX_PB03B_USART1_CLK            _L(1)
+#define PINMUX_PB03B_USART1_CLK    ((PIN_PB03B_USART1_CLK << 16) | MUX_PB03B_USART1_CLK)
+#define GPIO_PB03B_USART1_CLK    _UL(1 <<  3)
+#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L(0)
+#define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
+#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
+#define PIN_PC25A_USART1_CLK           _L(89) /**< \brief USART1 signal: CLK on PC25 mux A */
+#define MUX_PC25A_USART1_CLK            _L(0)
+#define PINMUX_PC25A_USART1_CLK    ((PIN_PC25A_USART1_CLK << 16) | MUX_PC25A_USART1_CLK)
+#define GPIO_PC25A_USART1_CLK    _UL(1 << 25)
+#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L(1)
+#define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
+#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
+#define PIN_PB02B_USART1_RTS           _L(34) /**< \brief USART1 signal: RTS on PB02 mux B */
+#define MUX_PB02B_USART1_RTS            _L(1)
+#define PINMUX_PB02B_USART1_RTS    ((PIN_PB02B_USART1_RTS << 16) | MUX_PB02B_USART1_RTS)
+#define GPIO_PB02B_USART1_RTS    _UL(1 <<  2)
+#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L(0)
+#define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
+#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
+#define PIN_PC24A_USART1_RTS           _L(88) /**< \brief USART1 signal: RTS on PC24 mux A */
+#define MUX_PC24A_USART1_RTS            _L(0)
+#define PINMUX_PC24A_USART1_RTS    ((PIN_PC24A_USART1_RTS << 16) | MUX_PC24A_USART1_RTS)
+#define GPIO_PC24A_USART1_RTS    _UL(1 << 24)
+#define PIN_PB04B_USART1_RXD           _L(36) /**< \brief USART1 signal: RXD on PB04 mux B */
+#define MUX_PB04B_USART1_RXD            _L(1)
+#define PINMUX_PB04B_USART1_RXD    ((PIN_PB04B_USART1_RXD << 16) | MUX_PB04B_USART1_RXD)
+#define GPIO_PB04B_USART1_RXD    _UL(1 <<  4)
+#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L(0)
+#define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
+#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
+#define PIN_PC26A_USART1_RXD           _L(90) /**< \brief USART1 signal: RXD on PC26 mux A */
+#define MUX_PC26A_USART1_RXD            _L(0)
+#define PINMUX_PC26A_USART1_RXD    ((PIN_PC26A_USART1_RXD << 16) | MUX_PC26A_USART1_RXD)
+#define GPIO_PC26A_USART1_RXD    _UL(1 << 26)
+#define PIN_PB05B_USART1_TXD           _L(37) /**< \brief USART1 signal: TXD on PB05 mux B */
+#define MUX_PB05B_USART1_TXD            _L(1)
+#define PINMUX_PB05B_USART1_TXD    ((PIN_PB05B_USART1_TXD << 16) | MUX_PB05B_USART1_TXD)
+#define GPIO_PB05B_USART1_TXD    _UL(1 <<  5)
+#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L(0)
+#define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
+#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+#define PIN_PC27A_USART1_TXD           _L(91) /**< \brief USART1 signal: TXD on PC27 mux A */
+#define MUX_PC27A_USART1_TXD            _L(0)
+#define PINMUX_PC27A_USART1_TXD    ((PIN_PC27A_USART1_TXD << 16) | MUX_PC27A_USART1_TXD)
+#define GPIO_PC27A_USART1_TXD    _UL(1 << 27)
+/* ========== GPIO definition for USART2 peripheral ========== */
+#define PIN_PC08B_USART2_CLK           _L(72) /**< \brief USART2 signal: CLK on PC08 mux B */
+#define MUX_PC08B_USART2_CLK            _L(1)
+#define PINMUX_PC08B_USART2_CLK    ((PIN_PC08B_USART2_CLK << 16) | MUX_PC08B_USART2_CLK)
+#define GPIO_PC08B_USART2_CLK    _UL(1 <<  8)
+#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L(0)
+#define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
+#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
+#define PIN_PC08E_USART2_CTS           _L(72) /**< \brief USART2 signal: CTS on PC08 mux E */
+#define MUX_PC08E_USART2_CTS            _L(4)
+#define PINMUX_PC08E_USART2_CTS    ((PIN_PC08E_USART2_CTS << 16) | MUX_PC08E_USART2_CTS)
+#define GPIO_PC08E_USART2_CTS    _UL(1 <<  8)
+#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L(1)
+#define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
+#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
+#define PIN_PC07B_USART2_RTS           _L(71) /**< \brief USART2 signal: RTS on PC07 mux B */
+#define MUX_PC07B_USART2_RTS            _L(1)
+#define PINMUX_PC07B_USART2_RTS    ((PIN_PC07B_USART2_RTS << 16) | MUX_PC07B_USART2_RTS)
+#define GPIO_PC07B_USART2_RTS    _UL(1 <<  7)
+#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L(0)
+#define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
+#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L(1)
+#define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
+#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
+#define PIN_PC11B_USART2_RXD           _L(75) /**< \brief USART2 signal: RXD on PC11 mux B */
+#define MUX_PC11B_USART2_RXD            _L(1)
+#define PINMUX_PC11B_USART2_RXD    ((PIN_PC11B_USART2_RXD << 16) | MUX_PC11B_USART2_RXD)
+#define GPIO_PC11B_USART2_RXD    _UL(1 << 11)
+#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L(0)
+#define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
+#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L(1)
+#define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
+#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
+#define PIN_PC12B_USART2_TXD           _L(76) /**< \brief USART2 signal: TXD on PC12 mux B */
+#define MUX_PC12B_USART2_TXD            _L(1)
+#define PINMUX_PC12B_USART2_TXD    ((PIN_PC12B_USART2_TXD << 16) | MUX_PC12B_USART2_TXD)
+#define GPIO_PC12B_USART2_TXD    _UL(1 << 12)
+#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L(0)
+#define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
+#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+/* ========== GPIO definition for USART3 peripheral ========== */
+#define PIN_PC14B_USART3_CLK           _L(78) /**< \brief USART3 signal: CLK on PC14 mux B */
+#define MUX_PC14B_USART3_CLK            _L(1)
+#define PINMUX_PC14B_USART3_CLK    ((PIN_PC14B_USART3_CLK << 16) | MUX_PC14B_USART3_CLK)
+#define GPIO_PC14B_USART3_CLK    _UL(1 << 14)
+#define PIN_PB08A_USART3_CLK           _L(40) /**< \brief USART3 signal: CLK on PB08 mux A */
+#define MUX_PB08A_USART3_CLK            _L(0)
+#define PINMUX_PB08A_USART3_CLK    ((PIN_PB08A_USART3_CLK << 16) | MUX_PB08A_USART3_CLK)
+#define GPIO_PB08A_USART3_CLK    _UL(1 <<  8)
+#define PIN_PC31A_USART3_CLK           _L(95) /**< \brief USART3 signal: CLK on PC31 mux A */
+#define MUX_PC31A_USART3_CLK            _L(0)
+#define PINMUX_PC31A_USART3_CLK    ((PIN_PC31A_USART3_CLK << 16) | MUX_PC31A_USART3_CLK)
+#define GPIO_PC31A_USART3_CLK    _UL(1 << 31)
+#define PIN_PB07A_USART3_CTS           _L(39) /**< \brief USART3 signal: CTS on PB07 mux A */
+#define MUX_PB07A_USART3_CTS            _L(0)
+#define PINMUX_PB07A_USART3_CTS    ((PIN_PB07A_USART3_CTS << 16) | MUX_PB07A_USART3_CTS)
+#define GPIO_PB07A_USART3_CTS    _UL(1 <<  7)
+#define PIN_PC13B_USART3_RTS           _L(77) /**< \brief USART3 signal: RTS on PC13 mux B */
+#define MUX_PC13B_USART3_RTS            _L(1)
+#define PINMUX_PC13B_USART3_RTS    ((PIN_PC13B_USART3_RTS << 16) | MUX_PC13B_USART3_RTS)
+#define GPIO_PC13B_USART3_RTS    _UL(1 << 13)
+#define PIN_PB06A_USART3_RTS           _L(38) /**< \brief USART3 signal: RTS on PB06 mux A */
+#define MUX_PB06A_USART3_RTS            _L(0)
+#define PINMUX_PB06A_USART3_RTS    ((PIN_PB06A_USART3_RTS << 16) | MUX_PB06A_USART3_RTS)
+#define GPIO_PB06A_USART3_RTS    _UL(1 <<  6)
+#define PIN_PC30A_USART3_RTS           _L(94) /**< \brief USART3 signal: RTS on PC30 mux A */
+#define MUX_PC30A_USART3_RTS            _L(0)
+#define PINMUX_PC30A_USART3_RTS    ((PIN_PC30A_USART3_RTS << 16) | MUX_PC30A_USART3_RTS)
+#define GPIO_PC30A_USART3_RTS    _UL(1 << 30)
+#define PIN_PC09B_USART3_RXD           _L(73) /**< \brief USART3 signal: RXD on PC09 mux B */
+#define MUX_PC09B_USART3_RXD            _L(1)
+#define PINMUX_PC09B_USART3_RXD    ((PIN_PC09B_USART3_RXD << 16) | MUX_PC09B_USART3_RXD)
+#define GPIO_PC09B_USART3_RXD    _UL(1 <<  9)
+#define PIN_PB09A_USART3_RXD           _L(41) /**< \brief USART3 signal: RXD on PB09 mux A */
+#define MUX_PB09A_USART3_RXD            _L(0)
+#define PINMUX_PB09A_USART3_RXD    ((PIN_PB09A_USART3_RXD << 16) | MUX_PB09A_USART3_RXD)
+#define GPIO_PB09A_USART3_RXD    _UL(1 <<  9)
+#define PIN_PC28A_USART3_RXD           _L(92) /**< \brief USART3 signal: RXD on PC28 mux A */
+#define MUX_PC28A_USART3_RXD            _L(0)
+#define PINMUX_PC28A_USART3_RXD    ((PIN_PC28A_USART3_RXD << 16) | MUX_PC28A_USART3_RXD)
+#define GPIO_PC28A_USART3_RXD    _UL(1 << 28)
+#define PIN_PC10B_USART3_TXD           _L(74) /**< \brief USART3 signal: TXD on PC10 mux B */
+#define MUX_PC10B_USART3_TXD            _L(1)
+#define PINMUX_PC10B_USART3_TXD    ((PIN_PC10B_USART3_TXD << 16) | MUX_PC10B_USART3_TXD)
+#define GPIO_PC10B_USART3_TXD    _UL(1 << 10)
+#define PIN_PB10A_USART3_TXD           _L(42) /**< \brief USART3 signal: TXD on PB10 mux A */
+#define MUX_PB10A_USART3_TXD            _L(0)
+#define PINMUX_PB10A_USART3_TXD    ((PIN_PB10A_USART3_TXD << 16) | MUX_PB10A_USART3_TXD)
+#define GPIO_PB10A_USART3_TXD    _UL(1 << 10)
+#define PIN_PC29A_USART3_TXD           _L(93) /**< \brief USART3 signal: TXD on PC29 mux A */
+#define MUX_PC29A_USART3_TXD            _L(0)
+#define PINMUX_PC29A_USART3_TXD    ((PIN_PC29A_USART3_TXD << 16) | MUX_PC29A_USART3_TXD)
+#define GPIO_PC29A_USART3_TXD    _UL(1 << 29)
+/* ========== GPIO definition for ADCIFE peripheral ========== */
+#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
+#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
+#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
+#define PIN_PB02A_ADCIFE_AD3           _L(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
+#define MUX_PB02A_ADCIFE_AD3            _L(0)
+#define PINMUX_PB02A_ADCIFE_AD3    ((PIN_PB02A_ADCIFE_AD3 << 16) | MUX_PB02A_ADCIFE_AD3)
+#define GPIO_PB02A_ADCIFE_AD3    _UL(1 <<  2)
+#define PIN_PB03A_ADCIFE_AD4           _L(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
+#define MUX_PB03A_ADCIFE_AD4            _L(0)
+#define PINMUX_PB03A_ADCIFE_AD4    ((PIN_PB03A_ADCIFE_AD4 << 16) | MUX_PB03A_ADCIFE_AD4)
+#define GPIO_PB03A_ADCIFE_AD4    _UL(1 <<  3)
+#define PIN_PB04A_ADCIFE_AD5           _L(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
+#define MUX_PB04A_ADCIFE_AD5            _L(0)
+#define PINMUX_PB04A_ADCIFE_AD5    ((PIN_PB04A_ADCIFE_AD5 << 16) | MUX_PB04A_ADCIFE_AD5)
+#define GPIO_PB04A_ADCIFE_AD5    _UL(1 <<  4)
+#define PIN_PB05A_ADCIFE_AD6           _L(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
+#define MUX_PB05A_ADCIFE_AD6            _L(0)
+#define PINMUX_PB05A_ADCIFE_AD6    ((PIN_PB05A_ADCIFE_AD6 << 16) | MUX_PB05A_ADCIFE_AD6)
+#define GPIO_PB05A_ADCIFE_AD6    _UL(1 <<  5)
+#define PIN_PC07A_ADCIFE_AD7           _L(71) /**< \brief ADCIFE signal: AD7 on PC07 mux A */
+#define MUX_PC07A_ADCIFE_AD7            _L(0)
+#define PINMUX_PC07A_ADCIFE_AD7    ((PIN_PC07A_ADCIFE_AD7 << 16) | MUX_PC07A_ADCIFE_AD7)
+#define GPIO_PC07A_ADCIFE_AD7    _UL(1 <<  7)
+#define PIN_PC08A_ADCIFE_AD8           _L(72) /**< \brief ADCIFE signal: AD8 on PC08 mux A */
+#define MUX_PC08A_ADCIFE_AD8            _L(0)
+#define PINMUX_PC08A_ADCIFE_AD8    ((PIN_PC08A_ADCIFE_AD8 << 16) | MUX_PC08A_ADCIFE_AD8)
+#define GPIO_PC08A_ADCIFE_AD8    _UL(1 <<  8)
+#define PIN_PC09A_ADCIFE_AD9           _L(73) /**< \brief ADCIFE signal: AD9 on PC09 mux A */
+#define MUX_PC09A_ADCIFE_AD9            _L(0)
+#define PINMUX_PC09A_ADCIFE_AD9    ((PIN_PC09A_ADCIFE_AD9 << 16) | MUX_PC09A_ADCIFE_AD9)
+#define GPIO_PC09A_ADCIFE_AD9    _UL(1 <<  9)
+#define PIN_PC10A_ADCIFE_AD10          _L(74) /**< \brief ADCIFE signal: AD10 on PC10 mux A */
+#define MUX_PC10A_ADCIFE_AD10           _L(0)
+#define PINMUX_PC10A_ADCIFE_AD10   ((PIN_PC10A_ADCIFE_AD10 << 16) | MUX_PC10A_ADCIFE_AD10)
+#define GPIO_PC10A_ADCIFE_AD10   _UL(1 << 10)
+#define PIN_PC11A_ADCIFE_AD11          _L(75) /**< \brief ADCIFE signal: AD11 on PC11 mux A */
+#define MUX_PC11A_ADCIFE_AD11           _L(0)
+#define PINMUX_PC11A_ADCIFE_AD11   ((PIN_PC11A_ADCIFE_AD11 << 16) | MUX_PC11A_ADCIFE_AD11)
+#define GPIO_PC11A_ADCIFE_AD11   _UL(1 << 11)
+#define PIN_PC12A_ADCIFE_AD12          _L(76) /**< \brief ADCIFE signal: AD12 on PC12 mux A */
+#define MUX_PC12A_ADCIFE_AD12           _L(0)
+#define PINMUX_PC12A_ADCIFE_AD12   ((PIN_PC12A_ADCIFE_AD12 << 16) | MUX_PC12A_ADCIFE_AD12)
+#define GPIO_PC12A_ADCIFE_AD12   _UL(1 << 12)
+#define PIN_PC13A_ADCIFE_AD13          _L(77) /**< \brief ADCIFE signal: AD13 on PC13 mux A */
+#define MUX_PC13A_ADCIFE_AD13           _L(0)
+#define PINMUX_PC13A_ADCIFE_AD13   ((PIN_PC13A_ADCIFE_AD13 << 16) | MUX_PC13A_ADCIFE_AD13)
+#define GPIO_PC13A_ADCIFE_AD13   _UL(1 << 13)
+#define PIN_PC14A_ADCIFE_AD14          _L(78) /**< \brief ADCIFE signal: AD14 on PC14 mux A */
+#define MUX_PC14A_ADCIFE_AD14           _L(0)
+#define PINMUX_PC14A_ADCIFE_AD14   ((PIN_PC14A_ADCIFE_AD14 << 16) | MUX_PC14A_ADCIFE_AD14)
+#define GPIO_PC14A_ADCIFE_AD14   _UL(1 << 14)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+/* ========== GPIO definition for DACC peripheral ========== */
+#define PIN_PB04E_DACC_EXT_TRIG0       _L(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
+#define MUX_PB04E_DACC_EXT_TRIG0        _L(4)
+#define PINMUX_PB04E_DACC_EXT_TRIG0  ((PIN_PB04E_DACC_EXT_TRIG0 << 16) | MUX_PB04E_DACC_EXT_TRIG0)
+#define GPIO_PB04E_DACC_EXT_TRIG0  _UL(1 <<  4)
+#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L(0)
+#define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
+#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+/* ========== GPIO definition for ACIFC peripheral ========== */
+#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
+#define PIN_PC09E_ACIFC_ACAN1          _L(73) /**< \brief ACIFC signal: ACAN1 on PC09 mux E */
+#define MUX_PC09E_ACIFC_ACAN1           _L(4)
+#define PINMUX_PC09E_ACIFC_ACAN1   ((PIN_PC09E_ACIFC_ACAN1 << 16) | MUX_PC09E_ACIFC_ACAN1)
+#define GPIO_PC09E_ACIFC_ACAN1   _UL(1 <<  9)
+#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
+#define PIN_PC10E_ACIFC_ACAP1          _L(74) /**< \brief ACIFC signal: ACAP1 on PC10 mux E */
+#define MUX_PC10E_ACIFC_ACAP1           _L(4)
+#define PINMUX_PC10E_ACIFC_ACAP1   ((PIN_PC10E_ACIFC_ACAP1 << 16) | MUX_PC10E_ACIFC_ACAP1)
+#define GPIO_PC10E_ACIFC_ACAP1   _UL(1 << 10)
+#define PIN_PB02E_ACIFC_ACBN0          _L(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
+#define MUX_PB02E_ACIFC_ACBN0           _L(4)
+#define PINMUX_PB02E_ACIFC_ACBN0   ((PIN_PB02E_ACIFC_ACBN0 << 16) | MUX_PB02E_ACIFC_ACBN0)
+#define GPIO_PB02E_ACIFC_ACBN0   _UL(1 <<  2)
+#define PIN_PC13E_ACIFC_ACBN1          _L(77) /**< \brief ACIFC signal: ACBN1 on PC13 mux E */
+#define MUX_PC13E_ACIFC_ACBN1           _L(4)
+#define PINMUX_PC13E_ACIFC_ACBN1   ((PIN_PC13E_ACIFC_ACBN1 << 16) | MUX_PC13E_ACIFC_ACBN1)
+#define GPIO_PC13E_ACIFC_ACBN1   _UL(1 << 13)
+#define PIN_PB03E_ACIFC_ACBP0          _L(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
+#define MUX_PB03E_ACIFC_ACBP0           _L(4)
+#define PINMUX_PB03E_ACIFC_ACBP0   ((PIN_PB03E_ACIFC_ACBP0 << 16) | MUX_PB03E_ACIFC_ACBP0)
+#define GPIO_PB03E_ACIFC_ACBP0   _UL(1 <<  3)
+#define PIN_PC14E_ACIFC_ACBP1          _L(78) /**< \brief ACIFC signal: ACBP1 on PC14 mux E */
+#define MUX_PC14E_ACIFC_ACBP1           _L(4)
+#define PINMUX_PC14E_ACIFC_ACBP1   ((PIN_PC14E_ACIFC_ACBP1 << 16) | MUX_PC14E_ACIFC_ACBP1)
+#define GPIO_PC14E_ACIFC_ACBP1   _UL(1 << 14)
+/* ========== GPIO definition for GLOC peripheral ========== */
+#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
+#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L(3)
+#define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
+#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L(3)
+#define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
+#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L(3)
+#define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
+#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L(3)
+#define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
+#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L(3)
+#define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
+#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L(3)
+#define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
+#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L(3)
+#define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
+#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
+#define PIN_PC15D_GLOC_IN4             _L(79) /**< \brief GLOC signal: IN4 on PC15 mux D */
+#define MUX_PC15D_GLOC_IN4              _L(3)
+#define PINMUX_PC15D_GLOC_IN4      ((PIN_PC15D_GLOC_IN4 << 16) | MUX_PC15D_GLOC_IN4)
+#define GPIO_PC15D_GLOC_IN4      _UL(1 << 15)
+#define PIN_PB06C_GLOC_IN4             _L(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
+#define MUX_PB06C_GLOC_IN4              _L(2)
+#define PINMUX_PB06C_GLOC_IN4      ((PIN_PB06C_GLOC_IN4 << 16) | MUX_PB06C_GLOC_IN4)
+#define GPIO_PB06C_GLOC_IN4      _UL(1 <<  6)
+#define PIN_PC28C_GLOC_IN4             _L(92) /**< \brief GLOC signal: IN4 on PC28 mux C */
+#define MUX_PC28C_GLOC_IN4              _L(2)
+#define PINMUX_PC28C_GLOC_IN4      ((PIN_PC28C_GLOC_IN4 << 16) | MUX_PC28C_GLOC_IN4)
+#define GPIO_PC28C_GLOC_IN4      _UL(1 << 28)
+#define PIN_PC16D_GLOC_IN5             _L(80) /**< \brief GLOC signal: IN5 on PC16 mux D */
+#define MUX_PC16D_GLOC_IN5              _L(3)
+#define PINMUX_PC16D_GLOC_IN5      ((PIN_PC16D_GLOC_IN5 << 16) | MUX_PC16D_GLOC_IN5)
+#define GPIO_PC16D_GLOC_IN5      _UL(1 << 16)
+#define PIN_PB07C_GLOC_IN5             _L(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
+#define MUX_PB07C_GLOC_IN5              _L(2)
+#define PINMUX_PB07C_GLOC_IN5      ((PIN_PB07C_GLOC_IN5 << 16) | MUX_PB07C_GLOC_IN5)
+#define GPIO_PB07C_GLOC_IN5      _UL(1 <<  7)
+#define PIN_PC29C_GLOC_IN5             _L(93) /**< \brief GLOC signal: IN5 on PC29 mux C */
+#define MUX_PC29C_GLOC_IN5              _L(2)
+#define PINMUX_PC29C_GLOC_IN5      ((PIN_PC29C_GLOC_IN5 << 16) | MUX_PC29C_GLOC_IN5)
+#define GPIO_PC29C_GLOC_IN5      _UL(1 << 29)
+#define PIN_PC17D_GLOC_IN6             _L(81) /**< \brief GLOC signal: IN6 on PC17 mux D */
+#define MUX_PC17D_GLOC_IN6              _L(3)
+#define PINMUX_PC17D_GLOC_IN6      ((PIN_PC17D_GLOC_IN6 << 16) | MUX_PC17D_GLOC_IN6)
+#define GPIO_PC17D_GLOC_IN6      _UL(1 << 17)
+#define PIN_PB08C_GLOC_IN6             _L(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
+#define MUX_PB08C_GLOC_IN6              _L(2)
+#define PINMUX_PB08C_GLOC_IN6      ((PIN_PB08C_GLOC_IN6 << 16) | MUX_PB08C_GLOC_IN6)
+#define GPIO_PB08C_GLOC_IN6      _UL(1 <<  8)
+#define PIN_PC30C_GLOC_IN6             _L(94) /**< \brief GLOC signal: IN6 on PC30 mux C */
+#define MUX_PC30C_GLOC_IN6              _L(2)
+#define PINMUX_PC30C_GLOC_IN6      ((PIN_PC30C_GLOC_IN6 << 16) | MUX_PC30C_GLOC_IN6)
+#define GPIO_PC30C_GLOC_IN6      _UL(1 << 30)
+#define PIN_PC18D_GLOC_IN7             _L(82) /**< \brief GLOC signal: IN7 on PC18 mux D */
+#define MUX_PC18D_GLOC_IN7              _L(3)
+#define PINMUX_PC18D_GLOC_IN7      ((PIN_PC18D_GLOC_IN7 << 16) | MUX_PC18D_GLOC_IN7)
+#define GPIO_PC18D_GLOC_IN7      _UL(1 << 18)
+#define PIN_PB09C_GLOC_IN7             _L(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
+#define MUX_PB09C_GLOC_IN7              _L(2)
+#define PINMUX_PB09C_GLOC_IN7      ((PIN_PB09C_GLOC_IN7 << 16) | MUX_PB09C_GLOC_IN7)
+#define GPIO_PB09C_GLOC_IN7      _UL(1 <<  9)
+#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
+#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
+#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
+#define PIN_PC19D_GLOC_OUT1            _L(83) /**< \brief GLOC signal: OUT1 on PC19 mux D */
+#define MUX_PC19D_GLOC_OUT1             _L(3)
+#define PINMUX_PC19D_GLOC_OUT1     ((PIN_PC19D_GLOC_OUT1 << 16) | MUX_PC19D_GLOC_OUT1)
+#define GPIO_PC19D_GLOC_OUT1     _UL(1 << 19)
+#define PIN_PB10C_GLOC_OUT1            _L(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
+#define MUX_PB10C_GLOC_OUT1             _L(2)
+#define PINMUX_PB10C_GLOC_OUT1     ((PIN_PB10C_GLOC_OUT1 << 16) | MUX_PB10C_GLOC_OUT1)
+#define GPIO_PB10C_GLOC_OUT1     _UL(1 << 10)
+#define PIN_PC31C_GLOC_OUT1            _L(95) /**< \brief GLOC signal: OUT1 on PC31 mux C */
+#define MUX_PC31C_GLOC_OUT1             _L(2)
+#define PINMUX_PC31C_GLOC_OUT1     ((PIN_PC31C_GLOC_OUT1 << 16) | MUX_PC31C_GLOC_OUT1)
+#define GPIO_PC31C_GLOC_OUT1     _UL(1 << 31)
+/* ========== GPIO definition for ABDACB peripheral ========== */
+#define PIN_PC12C_ABDACB_CLK           _L(76) /**< \brief ABDACB signal: CLK on PC12 mux C */
+#define MUX_PC12C_ABDACB_CLK            _L(2)
+#define PINMUX_PC12C_ABDACB_CLK    ((PIN_PC12C_ABDACB_CLK << 16) | MUX_PC12C_ABDACB_CLK)
+#define GPIO_PC12C_ABDACB_CLK    _UL(1 << 12)
+#define PIN_PB02C_ABDACB_DAC0          _L(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
+#define MUX_PB02C_ABDACB_DAC0           _L(2)
+#define PINMUX_PB02C_ABDACB_DAC0   ((PIN_PB02C_ABDACB_DAC0 << 16) | MUX_PB02C_ABDACB_DAC0)
+#define GPIO_PB02C_ABDACB_DAC0   _UL(1 <<  2)
+#define PIN_PC09C_ABDACB_DAC0          _L(73) /**< \brief ABDACB signal: DAC0 on PC09 mux C */
+#define MUX_PC09C_ABDACB_DAC0           _L(2)
+#define PINMUX_PC09C_ABDACB_DAC0   ((PIN_PC09C_ABDACB_DAC0 << 16) | MUX_PC09C_ABDACB_DAC0)
+#define GPIO_PC09C_ABDACB_DAC0   _UL(1 <<  9)
+#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
+#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
+#define PIN_PB04C_ABDACB_DAC1          _L(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
+#define MUX_PB04C_ABDACB_DAC1           _L(2)
+#define PINMUX_PB04C_ABDACB_DAC1   ((PIN_PB04C_ABDACB_DAC1 << 16) | MUX_PB04C_ABDACB_DAC1)
+#define GPIO_PB04C_ABDACB_DAC1   _UL(1 <<  4)
+#define PIN_PC13C_ABDACB_DAC1          _L(77) /**< \brief ABDACB signal: DAC1 on PC13 mux C */
+#define MUX_PC13C_ABDACB_DAC1           _L(2)
+#define PINMUX_PC13C_ABDACB_DAC1   ((PIN_PC13C_ABDACB_DAC1 << 16) | MUX_PC13C_ABDACB_DAC1)
+#define GPIO_PC13C_ABDACB_DAC1   _UL(1 << 13)
+#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
+#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
+#define PIN_PB03C_ABDACB_DACN0         _L(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
+#define MUX_PB03C_ABDACB_DACN0          _L(2)
+#define PINMUX_PB03C_ABDACB_DACN0  ((PIN_PB03C_ABDACB_DACN0 << 16) | MUX_PB03C_ABDACB_DACN0)
+#define GPIO_PB03C_ABDACB_DACN0  _UL(1 <<  3)
+#define PIN_PC10C_ABDACB_DACN0         _L(74) /**< \brief ABDACB signal: DACN0 on PC10 mux C */
+#define MUX_PC10C_ABDACB_DACN0          _L(2)
+#define PINMUX_PC10C_ABDACB_DACN0  ((PIN_PC10C_ABDACB_DACN0 << 16) | MUX_PC10C_ABDACB_DACN0)
+#define GPIO_PC10C_ABDACB_DACN0  _UL(1 << 10)
+#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
+#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
+#define PIN_PB05C_ABDACB_DACN1         _L(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
+#define MUX_PB05C_ABDACB_DACN1          _L(2)
+#define PINMUX_PB05C_ABDACB_DACN1  ((PIN_PB05C_ABDACB_DACN1 << 16) | MUX_PB05C_ABDACB_DACN1)
+#define GPIO_PB05C_ABDACB_DACN1  _UL(1 <<  5)
+#define PIN_PC14C_ABDACB_DACN1         _L(78) /**< \brief ABDACB signal: DACN1 on PC14 mux C */
+#define MUX_PC14C_ABDACB_DACN1          _L(2)
+#define PINMUX_PC14C_ABDACB_DACN1  ((PIN_PC14C_ABDACB_DACN1 << 16) | MUX_PC14C_ABDACB_DACN1)
+#define GPIO_PC14C_ABDACB_DACN1  _UL(1 << 14)
+#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
+#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+/* ========== GPIO definition for PARC peripheral ========== */
+#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
+#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
+#define PIN_PC21D_PARC_PCCK            _L(85) /**< \brief PARC signal: PCCK on PC21 mux D */
+#define MUX_PC21D_PARC_PCCK             _L(3)
+#define PINMUX_PC21D_PARC_PCCK     ((PIN_PC21D_PARC_PCCK << 16) | MUX_PC21D_PARC_PCCK)
+#define GPIO_PC21D_PARC_PCCK     _UL(1 << 21)
+#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
+#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
+#define PIN_PC24D_PARC_PCDATA0         _L(88) /**< \brief PARC signal: PCDATA0 on PC24 mux D */
+#define MUX_PC24D_PARC_PCDATA0          _L(3)
+#define PINMUX_PC24D_PARC_PCDATA0  ((PIN_PC24D_PARC_PCDATA0 << 16) | MUX_PC24D_PARC_PCDATA0)
+#define GPIO_PC24D_PARC_PCDATA0  _UL(1 << 24)
+#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
+#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
+#define PIN_PC25D_PARC_PCDATA1         _L(89) /**< \brief PARC signal: PCDATA1 on PC25 mux D */
+#define MUX_PC25D_PARC_PCDATA1          _L(3)
+#define PINMUX_PC25D_PARC_PCDATA1  ((PIN_PC25D_PARC_PCDATA1 << 16) | MUX_PC25D_PARC_PCDATA1)
+#define GPIO_PC25D_PARC_PCDATA1  _UL(1 << 25)
+#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
+#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
+#define PIN_PC26D_PARC_PCDATA2         _L(90) /**< \brief PARC signal: PCDATA2 on PC26 mux D */
+#define MUX_PC26D_PARC_PCDATA2          _L(3)
+#define PINMUX_PC26D_PARC_PCDATA2  ((PIN_PC26D_PARC_PCDATA2 << 16) | MUX_PC26D_PARC_PCDATA2)
+#define GPIO_PC26D_PARC_PCDATA2  _UL(1 << 26)
+#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
+#define PIN_PC27D_PARC_PCDATA3         _L(91) /**< \brief PARC signal: PCDATA3 on PC27 mux D */
+#define MUX_PC27D_PARC_PCDATA3          _L(3)
+#define PINMUX_PC27D_PARC_PCDATA3  ((PIN_PC27D_PARC_PCDATA3 << 16) | MUX_PC27D_PARC_PCDATA3)
+#define GPIO_PC27D_PARC_PCDATA3  _UL(1 << 27)
+#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
+#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
+#define PIN_PC28D_PARC_PCDATA4         _L(92) /**< \brief PARC signal: PCDATA4 on PC28 mux D */
+#define MUX_PC28D_PARC_PCDATA4          _L(3)
+#define PINMUX_PC28D_PARC_PCDATA4  ((PIN_PC28D_PARC_PCDATA4 << 16) | MUX_PC28D_PARC_PCDATA4)
+#define GPIO_PC28D_PARC_PCDATA4  _UL(1 << 28)
+#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
+#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
+#define PIN_PC29D_PARC_PCDATA5         _L(93) /**< \brief PARC signal: PCDATA5 on PC29 mux D */
+#define MUX_PC29D_PARC_PCDATA5          _L(3)
+#define PINMUX_PC29D_PARC_PCDATA5  ((PIN_PC29D_PARC_PCDATA5 << 16) | MUX_PC29D_PARC_PCDATA5)
+#define GPIO_PC29D_PARC_PCDATA5  _UL(1 << 29)
+#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
+#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
+#define PIN_PC30D_PARC_PCDATA6         _L(94) /**< \brief PARC signal: PCDATA6 on PC30 mux D */
+#define MUX_PC30D_PARC_PCDATA6          _L(3)
+#define PINMUX_PC30D_PARC_PCDATA6  ((PIN_PC30D_PARC_PCDATA6 << 16) | MUX_PC30D_PARC_PCDATA6)
+#define GPIO_PC30D_PARC_PCDATA6  _UL(1 << 30)
+#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
+#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
+#define PIN_PC31D_PARC_PCDATA7         _L(95) /**< \brief PARC signal: PCDATA7 on PC31 mux D */
+#define MUX_PC31D_PARC_PCDATA7          _L(3)
+#define PINMUX_PC31D_PARC_PCDATA7  ((PIN_PC31D_PARC_PCDATA7 << 16) | MUX_PC31D_PARC_PCDATA7)
+#define GPIO_PC31D_PARC_PCDATA7  _UL(1 << 31)
+#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
+#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
+#define PIN_PC22D_PARC_PCEN1           _L(86) /**< \brief PARC signal: PCEN1 on PC22 mux D */
+#define MUX_PC22D_PARC_PCEN1            _L(3)
+#define PINMUX_PC22D_PARC_PCEN1    ((PIN_PC22D_PARC_PCEN1 << 16) | MUX_PC22D_PARC_PCEN1)
+#define GPIO_PC22D_PARC_PCEN1    _UL(1 << 22)
+#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
+#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+#define PIN_PC23D_PARC_PCEN2           _L(87) /**< \brief PARC signal: PCEN2 on PC23 mux D */
+#define MUX_PC23D_PARC_PCEN2            _L(3)
+#define PINMUX_PC23D_PARC_PCEN2    ((PIN_PC23D_PARC_PCEN2 << 16) | MUX_PC23D_PARC_PCEN2)
+#define GPIO_PC23D_PARC_PCEN2    _UL(1 << 23)
+/* ========== GPIO definition for CATB peripheral ========== */
+#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L(6)
+#define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
+#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L(6)
+#define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
+#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L(6)
+#define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
+#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
+#define PIN_PB03G_CATB_DIS             _L(35) /**< \brief CATB signal: DIS on PB03 mux G */
+#define MUX_PB03G_CATB_DIS              _L(6)
+#define PINMUX_PB03G_CATB_DIS      ((PIN_PB03G_CATB_DIS << 16) | MUX_PB03G_CATB_DIS)
+#define GPIO_PB03G_CATB_DIS      _UL(1 <<  3)
+#define PIN_PB12G_CATB_DIS             _L(44) /**< \brief CATB signal: DIS on PB12 mux G */
+#define MUX_PB12G_CATB_DIS              _L(6)
+#define PINMUX_PB12G_CATB_DIS      ((PIN_PB12G_CATB_DIS << 16) | MUX_PB12G_CATB_DIS)
+#define GPIO_PB12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PC05G_CATB_DIS             _L(69) /**< \brief CATB signal: DIS on PC05 mux G */
+#define MUX_PC05G_CATB_DIS              _L(6)
+#define PINMUX_PC05G_CATB_DIS      ((PIN_PC05G_CATB_DIS << 16) | MUX_PC05G_CATB_DIS)
+#define GPIO_PC05G_CATB_DIS      _UL(1 <<  5)
+#define PIN_PC14G_CATB_DIS             _L(78) /**< \brief CATB signal: DIS on PC14 mux G */
+#define MUX_PC14G_CATB_DIS              _L(6)
+#define PINMUX_PC14G_CATB_DIS      ((PIN_PC14G_CATB_DIS << 16) | MUX_PC14G_CATB_DIS)
+#define GPIO_PC14G_CATB_DIS      _UL(1 << 14)
+#define PIN_PC23G_CATB_DIS             _L(87) /**< \brief CATB signal: DIS on PC23 mux G */
+#define MUX_PC23G_CATB_DIS              _L(6)
+#define PINMUX_PC23G_CATB_DIS      ((PIN_PC23G_CATB_DIS << 16) | MUX_PC23G_CATB_DIS)
+#define GPIO_PC23G_CATB_DIS      _UL(1 << 23)
+#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
+#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
+#define PIN_PB13G_CATB_SENSE0          _L(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
+#define MUX_PB13G_CATB_SENSE0           _L(6)
+#define PINMUX_PB13G_CATB_SENSE0   ((PIN_PB13G_CATB_SENSE0 << 16) | MUX_PB13G_CATB_SENSE0)
+#define GPIO_PB13G_CATB_SENSE0   _UL(1 << 13)
+#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
+#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
+#define PIN_PB14G_CATB_SENSE1          _L(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
+#define MUX_PB14G_CATB_SENSE1           _L(6)
+#define PINMUX_PB14G_CATB_SENSE1   ((PIN_PB14G_CATB_SENSE1 << 16) | MUX_PB14G_CATB_SENSE1)
+#define GPIO_PB14G_CATB_SENSE1   _UL(1 << 14)
+#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
+#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
+#define PIN_PB15G_CATB_SENSE2          _L(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
+#define MUX_PB15G_CATB_SENSE2           _L(6)
+#define PINMUX_PB15G_CATB_SENSE2   ((PIN_PB15G_CATB_SENSE2 << 16) | MUX_PB15G_CATB_SENSE2)
+#define GPIO_PB15G_CATB_SENSE2   _UL(1 << 15)
+#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
+#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
+#define PIN_PC00G_CATB_SENSE3          _L(64) /**< \brief CATB signal: SENSE3 on PC00 mux G */
+#define MUX_PC00G_CATB_SENSE3           _L(6)
+#define PINMUX_PC00G_CATB_SENSE3   ((PIN_PC00G_CATB_SENSE3 << 16) | MUX_PC00G_CATB_SENSE3)
+#define GPIO_PC00G_CATB_SENSE3   _UL(1 <<  0)
+#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
+#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
+#define PIN_PC01G_CATB_SENSE4          _L(65) /**< \brief CATB signal: SENSE4 on PC01 mux G */
+#define MUX_PC01G_CATB_SENSE4           _L(6)
+#define PINMUX_PC01G_CATB_SENSE4   ((PIN_PC01G_CATB_SENSE4 << 16) | MUX_PC01G_CATB_SENSE4)
+#define GPIO_PC01G_CATB_SENSE4   _UL(1 <<  1)
+#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
+#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
+#define PIN_PC02G_CATB_SENSE5          _L(66) /**< \brief CATB signal: SENSE5 on PC02 mux G */
+#define MUX_PC02G_CATB_SENSE5           _L(6)
+#define PINMUX_PC02G_CATB_SENSE5   ((PIN_PC02G_CATB_SENSE5 << 16) | MUX_PC02G_CATB_SENSE5)
+#define GPIO_PC02G_CATB_SENSE5   _UL(1 <<  2)
+#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
+#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
+#define PIN_PC03G_CATB_SENSE6          _L(67) /**< \brief CATB signal: SENSE6 on PC03 mux G */
+#define MUX_PC03G_CATB_SENSE6           _L(6)
+#define PINMUX_PC03G_CATB_SENSE6   ((PIN_PC03G_CATB_SENSE6 << 16) | MUX_PC03G_CATB_SENSE6)
+#define GPIO_PC03G_CATB_SENSE6   _UL(1 <<  3)
+#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
+#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
+#define PIN_PC04G_CATB_SENSE7          _L(68) /**< \brief CATB signal: SENSE7 on PC04 mux G */
+#define MUX_PC04G_CATB_SENSE7           _L(6)
+#define PINMUX_PC04G_CATB_SENSE7   ((PIN_PC04G_CATB_SENSE7 << 16) | MUX_PC04G_CATB_SENSE7)
+#define GPIO_PC04G_CATB_SENSE7   _UL(1 <<  4)
+#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
+#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
+#define PIN_PC06G_CATB_SENSE8          _L(70) /**< \brief CATB signal: SENSE8 on PC06 mux G */
+#define MUX_PC06G_CATB_SENSE8           _L(6)
+#define PINMUX_PC06G_CATB_SENSE8   ((PIN_PC06G_CATB_SENSE8 << 16) | MUX_PC06G_CATB_SENSE8)
+#define GPIO_PC06G_CATB_SENSE8   _UL(1 <<  6)
+#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
+#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
+#define PIN_PC07G_CATB_SENSE9          _L(71) /**< \brief CATB signal: SENSE9 on PC07 mux G */
+#define MUX_PC07G_CATB_SENSE9           _L(6)
+#define PINMUX_PC07G_CATB_SENSE9   ((PIN_PC07G_CATB_SENSE9 << 16) | MUX_PC07G_CATB_SENSE9)
+#define GPIO_PC07G_CATB_SENSE9   _UL(1 <<  7)
+#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
+#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
+#define PIN_PC08G_CATB_SENSE10         _L(72) /**< \brief CATB signal: SENSE10 on PC08 mux G */
+#define MUX_PC08G_CATB_SENSE10          _L(6)
+#define PINMUX_PC08G_CATB_SENSE10  ((PIN_PC08G_CATB_SENSE10 << 16) | MUX_PC08G_CATB_SENSE10)
+#define GPIO_PC08G_CATB_SENSE10  _UL(1 <<  8)
+#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
+#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
+#define PIN_PC09G_CATB_SENSE11         _L(73) /**< \brief CATB signal: SENSE11 on PC09 mux G */
+#define MUX_PC09G_CATB_SENSE11          _L(6)
+#define PINMUX_PC09G_CATB_SENSE11  ((PIN_PC09G_CATB_SENSE11 << 16) | MUX_PC09G_CATB_SENSE11)
+#define GPIO_PC09G_CATB_SENSE11  _UL(1 <<  9)
+#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
+#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
+#define PIN_PC10G_CATB_SENSE12         _L(74) /**< \brief CATB signal: SENSE12 on PC10 mux G */
+#define MUX_PC10G_CATB_SENSE12          _L(6)
+#define PINMUX_PC10G_CATB_SENSE12  ((PIN_PC10G_CATB_SENSE12 << 16) | MUX_PC10G_CATB_SENSE12)
+#define GPIO_PC10G_CATB_SENSE12  _UL(1 << 10)
+#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
+#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
+#define PIN_PC11G_CATB_SENSE13         _L(75) /**< \brief CATB signal: SENSE13 on PC11 mux G */
+#define MUX_PC11G_CATB_SENSE13          _L(6)
+#define PINMUX_PC11G_CATB_SENSE13  ((PIN_PC11G_CATB_SENSE13 << 16) | MUX_PC11G_CATB_SENSE13)
+#define GPIO_PC11G_CATB_SENSE13  _UL(1 << 11)
+#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
+#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
+#define PIN_PC12G_CATB_SENSE14         _L(76) /**< \brief CATB signal: SENSE14 on PC12 mux G */
+#define MUX_PC12G_CATB_SENSE14          _L(6)
+#define PINMUX_PC12G_CATB_SENSE14  ((PIN_PC12G_CATB_SENSE14 << 16) | MUX_PC12G_CATB_SENSE14)
+#define GPIO_PC12G_CATB_SENSE14  _UL(1 << 12)
+#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
+#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
+#define PIN_PC13G_CATB_SENSE15         _L(77) /**< \brief CATB signal: SENSE15 on PC13 mux G */
+#define MUX_PC13G_CATB_SENSE15          _L(6)
+#define PINMUX_PC13G_CATB_SENSE15  ((PIN_PC13G_CATB_SENSE15 << 16) | MUX_PC13G_CATB_SENSE15)
+#define GPIO_PC13G_CATB_SENSE15  _UL(1 << 13)
+#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
+#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
+#define PIN_PC15G_CATB_SENSE16         _L(79) /**< \brief CATB signal: SENSE16 on PC15 mux G */
+#define MUX_PC15G_CATB_SENSE16          _L(6)
+#define PINMUX_PC15G_CATB_SENSE16  ((PIN_PC15G_CATB_SENSE16 << 16) | MUX_PC15G_CATB_SENSE16)
+#define GPIO_PC15G_CATB_SENSE16  _UL(1 << 15)
+#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
+#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
+#define PIN_PC16G_CATB_SENSE17         _L(80) /**< \brief CATB signal: SENSE17 on PC16 mux G */
+#define MUX_PC16G_CATB_SENSE17          _L(6)
+#define PINMUX_PC16G_CATB_SENSE17  ((PIN_PC16G_CATB_SENSE17 << 16) | MUX_PC16G_CATB_SENSE17)
+#define GPIO_PC16G_CATB_SENSE17  _UL(1 << 16)
+#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
+#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
+#define PIN_PC17G_CATB_SENSE18         _L(81) /**< \brief CATB signal: SENSE18 on PC17 mux G */
+#define MUX_PC17G_CATB_SENSE18          _L(6)
+#define PINMUX_PC17G_CATB_SENSE18  ((PIN_PC17G_CATB_SENSE18 << 16) | MUX_PC17G_CATB_SENSE18)
+#define GPIO_PC17G_CATB_SENSE18  _UL(1 << 17)
+#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
+#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
+#define PIN_PC18G_CATB_SENSE19         _L(82) /**< \brief CATB signal: SENSE19 on PC18 mux G */
+#define MUX_PC18G_CATB_SENSE19          _L(6)
+#define PINMUX_PC18G_CATB_SENSE19  ((PIN_PC18G_CATB_SENSE19 << 16) | MUX_PC18G_CATB_SENSE19)
+#define GPIO_PC18G_CATB_SENSE19  _UL(1 << 18)
+#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
+#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
+#define PIN_PC19G_CATB_SENSE20         _L(83) /**< \brief CATB signal: SENSE20 on PC19 mux G */
+#define MUX_PC19G_CATB_SENSE20          _L(6)
+#define PINMUX_PC19G_CATB_SENSE20  ((PIN_PC19G_CATB_SENSE20 << 16) | MUX_PC19G_CATB_SENSE20)
+#define GPIO_PC19G_CATB_SENSE20  _UL(1 << 19)
+#define PIN_PB00G_CATB_SENSE21         _L(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
+#define MUX_PB00G_CATB_SENSE21          _L(6)
+#define PINMUX_PB00G_CATB_SENSE21  ((PIN_PB00G_CATB_SENSE21 << 16) | MUX_PB00G_CATB_SENSE21)
+#define GPIO_PB00G_CATB_SENSE21  _UL(1 <<  0)
+#define PIN_PC20G_CATB_SENSE21         _L(84) /**< \brief CATB signal: SENSE21 on PC20 mux G */
+#define MUX_PC20G_CATB_SENSE21          _L(6)
+#define PINMUX_PC20G_CATB_SENSE21  ((PIN_PC20G_CATB_SENSE21 << 16) | MUX_PC20G_CATB_SENSE21)
+#define GPIO_PC20G_CATB_SENSE21  _UL(1 << 20)
+#define PIN_PB01G_CATB_SENSE22         _L(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
+#define MUX_PB01G_CATB_SENSE22          _L(6)
+#define PINMUX_PB01G_CATB_SENSE22  ((PIN_PB01G_CATB_SENSE22 << 16) | MUX_PB01G_CATB_SENSE22)
+#define GPIO_PB01G_CATB_SENSE22  _UL(1 <<  1)
+#define PIN_PC21G_CATB_SENSE22         _L(85) /**< \brief CATB signal: SENSE22 on PC21 mux G */
+#define MUX_PC21G_CATB_SENSE22          _L(6)
+#define PINMUX_PC21G_CATB_SENSE22  ((PIN_PC21G_CATB_SENSE22 << 16) | MUX_PC21G_CATB_SENSE22)
+#define GPIO_PC21G_CATB_SENSE22  _UL(1 << 21)
+#define PIN_PB02G_CATB_SENSE23         _L(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
+#define MUX_PB02G_CATB_SENSE23          _L(6)
+#define PINMUX_PB02G_CATB_SENSE23  ((PIN_PB02G_CATB_SENSE23 << 16) | MUX_PB02G_CATB_SENSE23)
+#define GPIO_PB02G_CATB_SENSE23  _UL(1 <<  2)
+#define PIN_PC22G_CATB_SENSE23         _L(86) /**< \brief CATB signal: SENSE23 on PC22 mux G */
+#define MUX_PC22G_CATB_SENSE23          _L(6)
+#define PINMUX_PC22G_CATB_SENSE23  ((PIN_PC22G_CATB_SENSE23 << 16) | MUX_PC22G_CATB_SENSE23)
+#define GPIO_PC22G_CATB_SENSE23  _UL(1 << 22)
+#define PIN_PB04G_CATB_SENSE24         _L(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
+#define MUX_PB04G_CATB_SENSE24          _L(6)
+#define PINMUX_PB04G_CATB_SENSE24  ((PIN_PB04G_CATB_SENSE24 << 16) | MUX_PB04G_CATB_SENSE24)
+#define GPIO_PB04G_CATB_SENSE24  _UL(1 <<  4)
+#define PIN_PC24G_CATB_SENSE24         _L(88) /**< \brief CATB signal: SENSE24 on PC24 mux G */
+#define MUX_PC24G_CATB_SENSE24          _L(6)
+#define PINMUX_PC24G_CATB_SENSE24  ((PIN_PC24G_CATB_SENSE24 << 16) | MUX_PC24G_CATB_SENSE24)
+#define GPIO_PC24G_CATB_SENSE24  _UL(1 << 24)
+#define PIN_PB05G_CATB_SENSE25         _L(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
+#define MUX_PB05G_CATB_SENSE25          _L(6)
+#define PINMUX_PB05G_CATB_SENSE25  ((PIN_PB05G_CATB_SENSE25 << 16) | MUX_PB05G_CATB_SENSE25)
+#define GPIO_PB05G_CATB_SENSE25  _UL(1 <<  5)
+#define PIN_PC25G_CATB_SENSE25         _L(89) /**< \brief CATB signal: SENSE25 on PC25 mux G */
+#define MUX_PC25G_CATB_SENSE25          _L(6)
+#define PINMUX_PC25G_CATB_SENSE25  ((PIN_PC25G_CATB_SENSE25 << 16) | MUX_PC25G_CATB_SENSE25)
+#define GPIO_PC25G_CATB_SENSE25  _UL(1 << 25)
+#define PIN_PB06G_CATB_SENSE26         _L(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
+#define MUX_PB06G_CATB_SENSE26          _L(6)
+#define PINMUX_PB06G_CATB_SENSE26  ((PIN_PB06G_CATB_SENSE26 << 16) | MUX_PB06G_CATB_SENSE26)
+#define GPIO_PB06G_CATB_SENSE26  _UL(1 <<  6)
+#define PIN_PC26G_CATB_SENSE26         _L(90) /**< \brief CATB signal: SENSE26 on PC26 mux G */
+#define MUX_PC26G_CATB_SENSE26          _L(6)
+#define PINMUX_PC26G_CATB_SENSE26  ((PIN_PC26G_CATB_SENSE26 << 16) | MUX_PC26G_CATB_SENSE26)
+#define GPIO_PC26G_CATB_SENSE26  _UL(1 << 26)
+#define PIN_PB07G_CATB_SENSE27         _L(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
+#define MUX_PB07G_CATB_SENSE27          _L(6)
+#define PINMUX_PB07G_CATB_SENSE27  ((PIN_PB07G_CATB_SENSE27 << 16) | MUX_PB07G_CATB_SENSE27)
+#define GPIO_PB07G_CATB_SENSE27  _UL(1 <<  7)
+#define PIN_PC27G_CATB_SENSE27         _L(91) /**< \brief CATB signal: SENSE27 on PC27 mux G */
+#define MUX_PC27G_CATB_SENSE27          _L(6)
+#define PINMUX_PC27G_CATB_SENSE27  ((PIN_PC27G_CATB_SENSE27 << 16) | MUX_PC27G_CATB_SENSE27)
+#define GPIO_PC27G_CATB_SENSE27  _UL(1 << 27)
+#define PIN_PB08G_CATB_SENSE28         _L(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
+#define MUX_PB08G_CATB_SENSE28          _L(6)
+#define PINMUX_PB08G_CATB_SENSE28  ((PIN_PB08G_CATB_SENSE28 << 16) | MUX_PB08G_CATB_SENSE28)
+#define GPIO_PB08G_CATB_SENSE28  _UL(1 <<  8)
+#define PIN_PC28G_CATB_SENSE28         _L(92) /**< \brief CATB signal: SENSE28 on PC28 mux G */
+#define MUX_PC28G_CATB_SENSE28          _L(6)
+#define PINMUX_PC28G_CATB_SENSE28  ((PIN_PC28G_CATB_SENSE28 << 16) | MUX_PC28G_CATB_SENSE28)
+#define GPIO_PC28G_CATB_SENSE28  _UL(1 << 28)
+#define PIN_PB09G_CATB_SENSE29         _L(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
+#define MUX_PB09G_CATB_SENSE29          _L(6)
+#define PINMUX_PB09G_CATB_SENSE29  ((PIN_PB09G_CATB_SENSE29 << 16) | MUX_PB09G_CATB_SENSE29)
+#define GPIO_PB09G_CATB_SENSE29  _UL(1 <<  9)
+#define PIN_PC29G_CATB_SENSE29         _L(93) /**< \brief CATB signal: SENSE29 on PC29 mux G */
+#define MUX_PC29G_CATB_SENSE29          _L(6)
+#define PINMUX_PC29G_CATB_SENSE29  ((PIN_PC29G_CATB_SENSE29 << 16) | MUX_PC29G_CATB_SENSE29)
+#define GPIO_PC29G_CATB_SENSE29  _UL(1 << 29)
+#define PIN_PB10G_CATB_SENSE30         _L(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
+#define MUX_PB10G_CATB_SENSE30          _L(6)
+#define PINMUX_PB10G_CATB_SENSE30  ((PIN_PB10G_CATB_SENSE30 << 16) | MUX_PB10G_CATB_SENSE30)
+#define GPIO_PB10G_CATB_SENSE30  _UL(1 << 10)
+#define PIN_PC30G_CATB_SENSE30         _L(94) /**< \brief CATB signal: SENSE30 on PC30 mux G */
+#define MUX_PC30G_CATB_SENSE30          _L(6)
+#define PINMUX_PC30G_CATB_SENSE30  ((PIN_PC30G_CATB_SENSE30 << 16) | MUX_PC30G_CATB_SENSE30)
+#define GPIO_PC30G_CATB_SENSE30  _UL(1 << 30)
+#define PIN_PB11G_CATB_SENSE31         _L(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
+#define MUX_PB11G_CATB_SENSE31          _L(6)
+#define PINMUX_PB11G_CATB_SENSE31  ((PIN_PB11G_CATB_SENSE31 << 16) | MUX_PB11G_CATB_SENSE31)
+#define GPIO_PB11G_CATB_SENSE31  _UL(1 << 11)
+#define PIN_PC31G_CATB_SENSE31         _L(95) /**< \brief CATB signal: SENSE31 on PC31 mux G */
+#define MUX_PC31G_CATB_SENSE31          _L(6)
+#define PINMUX_PC31G_CATB_SENSE31  ((PIN_PC31G_CATB_SENSE31 << 16) | MUX_PC31G_CATB_SENSE31)
+#define GPIO_PC31G_CATB_SENSE31  _UL(1 << 31)
+/* ========== GPIO definition for LCDCA peripheral ========== */
+#define PIN_PA12F_LCDCA_COM0           _L(12) /**< \brief LCDCA signal: COM0 on PA12 mux F */
+#define MUX_PA12F_LCDCA_COM0            _L(5)
+#define PINMUX_PA12F_LCDCA_COM0    ((PIN_PA12F_LCDCA_COM0 << 16) | MUX_PA12F_LCDCA_COM0)
+#define GPIO_PA12F_LCDCA_COM0    _UL(1 << 12)
+#define PIN_PA11F_LCDCA_COM1           _L(11) /**< \brief LCDCA signal: COM1 on PA11 mux F */
+#define MUX_PA11F_LCDCA_COM1            _L(5)
+#define PINMUX_PA11F_LCDCA_COM1    ((PIN_PA11F_LCDCA_COM1 << 16) | MUX_PA11F_LCDCA_COM1)
+#define GPIO_PA11F_LCDCA_COM1    _UL(1 << 11)
+#define PIN_PA10F_LCDCA_COM2           _L(10) /**< \brief LCDCA signal: COM2 on PA10 mux F */
+#define MUX_PA10F_LCDCA_COM2            _L(5)
+#define PINMUX_PA10F_LCDCA_COM2    ((PIN_PA10F_LCDCA_COM2 << 16) | MUX_PA10F_LCDCA_COM2)
+#define GPIO_PA10F_LCDCA_COM2    _UL(1 << 10)
+#define PIN_PA09F_LCDCA_COM3            _L(9) /**< \brief LCDCA signal: COM3 on PA09 mux F */
+#define MUX_PA09F_LCDCA_COM3            _L(5)
+#define PINMUX_PA09F_LCDCA_COM3    ((PIN_PA09F_LCDCA_COM3 << 16) | MUX_PA09F_LCDCA_COM3)
+#define GPIO_PA09F_LCDCA_COM3    _UL(1 <<  9)
+#define PIN_PC15F_LCDCA_SEG0           _L(79) /**< \brief LCDCA signal: SEG0 on PC15 mux F */
+#define MUX_PC15F_LCDCA_SEG0            _L(5)
+#define PINMUX_PC15F_LCDCA_SEG0    ((PIN_PC15F_LCDCA_SEG0 << 16) | MUX_PC15F_LCDCA_SEG0)
+#define GPIO_PC15F_LCDCA_SEG0    _UL(1 << 15)
+#define PIN_PC16F_LCDCA_SEG1           _L(80) /**< \brief LCDCA signal: SEG1 on PC16 mux F */
+#define MUX_PC16F_LCDCA_SEG1            _L(5)
+#define PINMUX_PC16F_LCDCA_SEG1    ((PIN_PC16F_LCDCA_SEG1 << 16) | MUX_PC16F_LCDCA_SEG1)
+#define GPIO_PC16F_LCDCA_SEG1    _UL(1 << 16)
+#define PIN_PC17F_LCDCA_SEG2           _L(81) /**< \brief LCDCA signal: SEG2 on PC17 mux F */
+#define MUX_PC17F_LCDCA_SEG2            _L(5)
+#define PINMUX_PC17F_LCDCA_SEG2    ((PIN_PC17F_LCDCA_SEG2 << 16) | MUX_PC17F_LCDCA_SEG2)
+#define GPIO_PC17F_LCDCA_SEG2    _UL(1 << 17)
+#define PIN_PC18F_LCDCA_SEG3           _L(82) /**< \brief LCDCA signal: SEG3 on PC18 mux F */
+#define MUX_PC18F_LCDCA_SEG3            _L(5)
+#define PINMUX_PC18F_LCDCA_SEG3    ((PIN_PC18F_LCDCA_SEG3 << 16) | MUX_PC18F_LCDCA_SEG3)
+#define GPIO_PC18F_LCDCA_SEG3    _UL(1 << 18)
+#define PIN_PC19F_LCDCA_SEG4           _L(83) /**< \brief LCDCA signal: SEG4 on PC19 mux F */
+#define MUX_PC19F_LCDCA_SEG4            _L(5)
+#define PINMUX_PC19F_LCDCA_SEG4    ((PIN_PC19F_LCDCA_SEG4 << 16) | MUX_PC19F_LCDCA_SEG4)
+#define GPIO_PC19F_LCDCA_SEG4    _UL(1 << 19)
+#define PIN_PA13F_LCDCA_SEG5           _L(13) /**< \brief LCDCA signal: SEG5 on PA13 mux F */
+#define MUX_PA13F_LCDCA_SEG5            _L(5)
+#define PINMUX_PA13F_LCDCA_SEG5    ((PIN_PA13F_LCDCA_SEG5 << 16) | MUX_PA13F_LCDCA_SEG5)
+#define GPIO_PA13F_LCDCA_SEG5    _UL(1 << 13)
+#define PIN_PA14F_LCDCA_SEG6           _L(14) /**< \brief LCDCA signal: SEG6 on PA14 mux F */
+#define MUX_PA14F_LCDCA_SEG6            _L(5)
+#define PINMUX_PA14F_LCDCA_SEG6    ((PIN_PA14F_LCDCA_SEG6 << 16) | MUX_PA14F_LCDCA_SEG6)
+#define GPIO_PA14F_LCDCA_SEG6    _UL(1 << 14)
+#define PIN_PA15F_LCDCA_SEG7           _L(15) /**< \brief LCDCA signal: SEG7 on PA15 mux F */
+#define MUX_PA15F_LCDCA_SEG7            _L(5)
+#define PINMUX_PA15F_LCDCA_SEG7    ((PIN_PA15F_LCDCA_SEG7 << 16) | MUX_PA15F_LCDCA_SEG7)
+#define GPIO_PA15F_LCDCA_SEG7    _UL(1 << 15)
+#define PIN_PA16F_LCDCA_SEG8           _L(16) /**< \brief LCDCA signal: SEG8 on PA16 mux F */
+#define MUX_PA16F_LCDCA_SEG8            _L(5)
+#define PINMUX_PA16F_LCDCA_SEG8    ((PIN_PA16F_LCDCA_SEG8 << 16) | MUX_PA16F_LCDCA_SEG8)
+#define GPIO_PA16F_LCDCA_SEG8    _UL(1 << 16)
+#define PIN_PA17F_LCDCA_SEG9           _L(17) /**< \brief LCDCA signal: SEG9 on PA17 mux F */
+#define MUX_PA17F_LCDCA_SEG9            _L(5)
+#define PINMUX_PA17F_LCDCA_SEG9    ((PIN_PA17F_LCDCA_SEG9 << 16) | MUX_PA17F_LCDCA_SEG9)
+#define GPIO_PA17F_LCDCA_SEG9    _UL(1 << 17)
+#define PIN_PC20F_LCDCA_SEG10          _L(84) /**< \brief LCDCA signal: SEG10 on PC20 mux F */
+#define MUX_PC20F_LCDCA_SEG10           _L(5)
+#define PINMUX_PC20F_LCDCA_SEG10   ((PIN_PC20F_LCDCA_SEG10 << 16) | MUX_PC20F_LCDCA_SEG10)
+#define GPIO_PC20F_LCDCA_SEG10   _UL(1 << 20)
+#define PIN_PC21F_LCDCA_SEG11          _L(85) /**< \brief LCDCA signal: SEG11 on PC21 mux F */
+#define MUX_PC21F_LCDCA_SEG11           _L(5)
+#define PINMUX_PC21F_LCDCA_SEG11   ((PIN_PC21F_LCDCA_SEG11 << 16) | MUX_PC21F_LCDCA_SEG11)
+#define GPIO_PC21F_LCDCA_SEG11   _UL(1 << 21)
+#define PIN_PC22F_LCDCA_SEG12          _L(86) /**< \brief LCDCA signal: SEG12 on PC22 mux F */
+#define MUX_PC22F_LCDCA_SEG12           _L(5)
+#define PINMUX_PC22F_LCDCA_SEG12   ((PIN_PC22F_LCDCA_SEG12 << 16) | MUX_PC22F_LCDCA_SEG12)
+#define GPIO_PC22F_LCDCA_SEG12   _UL(1 << 22)
+#define PIN_PC23F_LCDCA_SEG13          _L(87) /**< \brief LCDCA signal: SEG13 on PC23 mux F */
+#define MUX_PC23F_LCDCA_SEG13           _L(5)
+#define PINMUX_PC23F_LCDCA_SEG13   ((PIN_PC23F_LCDCA_SEG13 << 16) | MUX_PC23F_LCDCA_SEG13)
+#define GPIO_PC23F_LCDCA_SEG13   _UL(1 << 23)
+#define PIN_PB08F_LCDCA_SEG14          _L(40) /**< \brief LCDCA signal: SEG14 on PB08 mux F */
+#define MUX_PB08F_LCDCA_SEG14           _L(5)
+#define PINMUX_PB08F_LCDCA_SEG14   ((PIN_PB08F_LCDCA_SEG14 << 16) | MUX_PB08F_LCDCA_SEG14)
+#define GPIO_PB08F_LCDCA_SEG14   _UL(1 <<  8)
+#define PIN_PB09F_LCDCA_SEG15          _L(41) /**< \brief LCDCA signal: SEG15 on PB09 mux F */
+#define MUX_PB09F_LCDCA_SEG15           _L(5)
+#define PINMUX_PB09F_LCDCA_SEG15   ((PIN_PB09F_LCDCA_SEG15 << 16) | MUX_PB09F_LCDCA_SEG15)
+#define GPIO_PB09F_LCDCA_SEG15   _UL(1 <<  9)
+#define PIN_PB10F_LCDCA_SEG16          _L(42) /**< \brief LCDCA signal: SEG16 on PB10 mux F */
+#define MUX_PB10F_LCDCA_SEG16           _L(5)
+#define PINMUX_PB10F_LCDCA_SEG16   ((PIN_PB10F_LCDCA_SEG16 << 16) | MUX_PB10F_LCDCA_SEG16)
+#define GPIO_PB10F_LCDCA_SEG16   _UL(1 << 10)
+#define PIN_PB11F_LCDCA_SEG17          _L(43) /**< \brief LCDCA signal: SEG17 on PB11 mux F */
+#define MUX_PB11F_LCDCA_SEG17           _L(5)
+#define PINMUX_PB11F_LCDCA_SEG17   ((PIN_PB11F_LCDCA_SEG17 << 16) | MUX_PB11F_LCDCA_SEG17)
+#define GPIO_PB11F_LCDCA_SEG17   _UL(1 << 11)
+#define PIN_PA18F_LCDCA_SEG18          _L(18) /**< \brief LCDCA signal: SEG18 on PA18 mux F */
+#define MUX_PA18F_LCDCA_SEG18           _L(5)
+#define PINMUX_PA18F_LCDCA_SEG18   ((PIN_PA18F_LCDCA_SEG18 << 16) | MUX_PA18F_LCDCA_SEG18)
+#define GPIO_PA18F_LCDCA_SEG18   _UL(1 << 18)
+#define PIN_PA19F_LCDCA_SEG19          _L(19) /**< \brief LCDCA signal: SEG19 on PA19 mux F */
+#define MUX_PA19F_LCDCA_SEG19           _L(5)
+#define PINMUX_PA19F_LCDCA_SEG19   ((PIN_PA19F_LCDCA_SEG19 << 16) | MUX_PA19F_LCDCA_SEG19)
+#define GPIO_PA19F_LCDCA_SEG19   _UL(1 << 19)
+#define PIN_PA20F_LCDCA_SEG20          _L(20) /**< \brief LCDCA signal: SEG20 on PA20 mux F */
+#define MUX_PA20F_LCDCA_SEG20           _L(5)
+#define PINMUX_PA20F_LCDCA_SEG20   ((PIN_PA20F_LCDCA_SEG20 << 16) | MUX_PA20F_LCDCA_SEG20)
+#define GPIO_PA20F_LCDCA_SEG20   _UL(1 << 20)
+#define PIN_PB07F_LCDCA_SEG21          _L(39) /**< \brief LCDCA signal: SEG21 on PB07 mux F */
+#define MUX_PB07F_LCDCA_SEG21           _L(5)
+#define PINMUX_PB07F_LCDCA_SEG21   ((PIN_PB07F_LCDCA_SEG21 << 16) | MUX_PB07F_LCDCA_SEG21)
+#define GPIO_PB07F_LCDCA_SEG21   _UL(1 <<  7)
+#define PIN_PB06F_LCDCA_SEG22          _L(38) /**< \brief LCDCA signal: SEG22 on PB06 mux F */
+#define MUX_PB06F_LCDCA_SEG22           _L(5)
+#define PINMUX_PB06F_LCDCA_SEG22   ((PIN_PB06F_LCDCA_SEG22 << 16) | MUX_PB06F_LCDCA_SEG22)
+#define GPIO_PB06F_LCDCA_SEG22   _UL(1 <<  6)
+#define PIN_PA08F_LCDCA_SEG23           _L(8) /**< \brief LCDCA signal: SEG23 on PA08 mux F */
+#define MUX_PA08F_LCDCA_SEG23           _L(5)
+#define PINMUX_PA08F_LCDCA_SEG23   ((PIN_PA08F_LCDCA_SEG23 << 16) | MUX_PA08F_LCDCA_SEG23)
+#define GPIO_PA08F_LCDCA_SEG23   _UL(1 <<  8)
+#define PIN_PC24F_LCDCA_SEG24          _L(88) /**< \brief LCDCA signal: SEG24 on PC24 mux F */
+#define MUX_PC24F_LCDCA_SEG24           _L(5)
+#define PINMUX_PC24F_LCDCA_SEG24   ((PIN_PC24F_LCDCA_SEG24 << 16) | MUX_PC24F_LCDCA_SEG24)
+#define GPIO_PC24F_LCDCA_SEG24   _UL(1 << 24)
+#define PIN_PC25F_LCDCA_SEG25          _L(89) /**< \brief LCDCA signal: SEG25 on PC25 mux F */
+#define MUX_PC25F_LCDCA_SEG25           _L(5)
+#define PINMUX_PC25F_LCDCA_SEG25   ((PIN_PC25F_LCDCA_SEG25 << 16) | MUX_PC25F_LCDCA_SEG25)
+#define GPIO_PC25F_LCDCA_SEG25   _UL(1 << 25)
+#define PIN_PC26F_LCDCA_SEG26          _L(90) /**< \brief LCDCA signal: SEG26 on PC26 mux F */
+#define MUX_PC26F_LCDCA_SEG26           _L(5)
+#define PINMUX_PC26F_LCDCA_SEG26   ((PIN_PC26F_LCDCA_SEG26 << 16) | MUX_PC26F_LCDCA_SEG26)
+#define GPIO_PC26F_LCDCA_SEG26   _UL(1 << 26)
+#define PIN_PC27F_LCDCA_SEG27          _L(91) /**< \brief LCDCA signal: SEG27 on PC27 mux F */
+#define MUX_PC27F_LCDCA_SEG27           _L(5)
+#define PINMUX_PC27F_LCDCA_SEG27   ((PIN_PC27F_LCDCA_SEG27 << 16) | MUX_PC27F_LCDCA_SEG27)
+#define GPIO_PC27F_LCDCA_SEG27   _UL(1 << 27)
+#define PIN_PC28F_LCDCA_SEG28          _L(92) /**< \brief LCDCA signal: SEG28 on PC28 mux F */
+#define MUX_PC28F_LCDCA_SEG28           _L(5)
+#define PINMUX_PC28F_LCDCA_SEG28   ((PIN_PC28F_LCDCA_SEG28 << 16) | MUX_PC28F_LCDCA_SEG28)
+#define GPIO_PC28F_LCDCA_SEG28   _UL(1 << 28)
+#define PIN_PC29F_LCDCA_SEG29          _L(93) /**< \brief LCDCA signal: SEG29 on PC29 mux F */
+#define MUX_PC29F_LCDCA_SEG29           _L(5)
+#define PINMUX_PC29F_LCDCA_SEG29   ((PIN_PC29F_LCDCA_SEG29 << 16) | MUX_PC29F_LCDCA_SEG29)
+#define GPIO_PC29F_LCDCA_SEG29   _UL(1 << 29)
+#define PIN_PC30F_LCDCA_SEG30          _L(94) /**< \brief LCDCA signal: SEG30 on PC30 mux F */
+#define MUX_PC30F_LCDCA_SEG30           _L(5)
+#define PINMUX_PC30F_LCDCA_SEG30   ((PIN_PC30F_LCDCA_SEG30 << 16) | MUX_PC30F_LCDCA_SEG30)
+#define GPIO_PC30F_LCDCA_SEG30   _UL(1 << 30)
+#define PIN_PC31F_LCDCA_SEG31          _L(95) /**< \brief LCDCA signal: SEG31 on PC31 mux F */
+#define MUX_PC31F_LCDCA_SEG31           _L(5)
+#define PINMUX_PC31F_LCDCA_SEG31   ((PIN_PC31F_LCDCA_SEG31 << 16) | MUX_PC31F_LCDCA_SEG31)
+#define GPIO_PC31F_LCDCA_SEG31   _UL(1 << 31)
+#define PIN_PB12F_LCDCA_SEG32          _L(44) /**< \brief LCDCA signal: SEG32 on PB12 mux F */
+#define MUX_PB12F_LCDCA_SEG32           _L(5)
+#define PINMUX_PB12F_LCDCA_SEG32   ((PIN_PB12F_LCDCA_SEG32 << 16) | MUX_PB12F_LCDCA_SEG32)
+#define GPIO_PB12F_LCDCA_SEG32   _UL(1 << 12)
+#define PIN_PB13F_LCDCA_SEG33          _L(45) /**< \brief LCDCA signal: SEG33 on PB13 mux F */
+#define MUX_PB13F_LCDCA_SEG33           _L(5)
+#define PINMUX_PB13F_LCDCA_SEG33   ((PIN_PB13F_LCDCA_SEG33 << 16) | MUX_PB13F_LCDCA_SEG33)
+#define GPIO_PB13F_LCDCA_SEG33   _UL(1 << 13)
+#define PIN_PA21F_LCDCA_SEG34          _L(21) /**< \brief LCDCA signal: SEG34 on PA21 mux F */
+#define MUX_PA21F_LCDCA_SEG34           _L(5)
+#define PINMUX_PA21F_LCDCA_SEG34   ((PIN_PA21F_LCDCA_SEG34 << 16) | MUX_PA21F_LCDCA_SEG34)
+#define GPIO_PA21F_LCDCA_SEG34   _UL(1 << 21)
+#define PIN_PA22F_LCDCA_SEG35          _L(22) /**< \brief LCDCA signal: SEG35 on PA22 mux F */
+#define MUX_PA22F_LCDCA_SEG35           _L(5)
+#define PINMUX_PA22F_LCDCA_SEG35   ((PIN_PA22F_LCDCA_SEG35 << 16) | MUX_PA22F_LCDCA_SEG35)
+#define GPIO_PA22F_LCDCA_SEG35   _UL(1 << 22)
+#define PIN_PB14F_LCDCA_SEG36          _L(46) /**< \brief LCDCA signal: SEG36 on PB14 mux F */
+#define MUX_PB14F_LCDCA_SEG36           _L(5)
+#define PINMUX_PB14F_LCDCA_SEG36   ((PIN_PB14F_LCDCA_SEG36 << 16) | MUX_PB14F_LCDCA_SEG36)
+#define GPIO_PB14F_LCDCA_SEG36   _UL(1 << 14)
+#define PIN_PB15F_LCDCA_SEG37          _L(47) /**< \brief LCDCA signal: SEG37 on PB15 mux F */
+#define MUX_PB15F_LCDCA_SEG37           _L(5)
+#define PINMUX_PB15F_LCDCA_SEG37   ((PIN_PB15F_LCDCA_SEG37 << 16) | MUX_PB15F_LCDCA_SEG37)
+#define GPIO_PB15F_LCDCA_SEG37   _UL(1 << 15)
+#define PIN_PA23F_LCDCA_SEG38          _L(23) /**< \brief LCDCA signal: SEG38 on PA23 mux F */
+#define MUX_PA23F_LCDCA_SEG38           _L(5)
+#define PINMUX_PA23F_LCDCA_SEG38   ((PIN_PA23F_LCDCA_SEG38 << 16) | MUX_PA23F_LCDCA_SEG38)
+#define GPIO_PA23F_LCDCA_SEG38   _UL(1 << 23)
+#define PIN_PA24F_LCDCA_SEG39          _L(24) /**< \brief LCDCA signal: SEG39 on PA24 mux F */
+#define MUX_PA24F_LCDCA_SEG39           _L(5)
+#define PINMUX_PA24F_LCDCA_SEG39   ((PIN_PA24F_LCDCA_SEG39 << 16) | MUX_PA24F_LCDCA_SEG39)
+#define GPIO_PA24F_LCDCA_SEG39   _UL(1 << 24)
+/* ========== GPIO definition for USBC peripheral ========== */
+#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L(0)
+#define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
+#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
+#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L(0)
+#define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
+#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+/* ========== GPIO definition for PEVC peripheral ========== */
+#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
+#define PIN_PB12C_PEVC_PAD_EVT0        _L(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
+#define MUX_PB12C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PB12C_PEVC_PAD_EVT0  ((PIN_PB12C_PEVC_PAD_EVT0 << 16) | MUX_PB12C_PEVC_PAD_EVT0)
+#define GPIO_PB12C_PEVC_PAD_EVT0  _UL(1 << 12)
+#define PIN_PC07C_PEVC_PAD_EVT0        _L(71) /**< \brief PEVC signal: PAD_EVT0 on PC07 mux C */
+#define MUX_PC07C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PC07C_PEVC_PAD_EVT0  ((PIN_PC07C_PEVC_PAD_EVT0 << 16) | MUX_PC07C_PEVC_PAD_EVT0)
+#define GPIO_PC07C_PEVC_PAD_EVT0  _UL(1 <<  7)
+#define PIN_PC24C_PEVC_PAD_EVT0        _L(88) /**< \brief PEVC signal: PAD_EVT0 on PC24 mux C */
+#define MUX_PC24C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PC24C_PEVC_PAD_EVT0  ((PIN_PC24C_PEVC_PAD_EVT0 << 16) | MUX_PC24C_PEVC_PAD_EVT0)
+#define GPIO_PC24C_PEVC_PAD_EVT0  _UL(1 << 24)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
+#define PIN_PB13C_PEVC_PAD_EVT1        _L(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
+#define MUX_PB13C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PB13C_PEVC_PAD_EVT1  ((PIN_PB13C_PEVC_PAD_EVT1 << 16) | MUX_PB13C_PEVC_PAD_EVT1)
+#define GPIO_PB13C_PEVC_PAD_EVT1  _UL(1 << 13)
+#define PIN_PC08C_PEVC_PAD_EVT1        _L(72) /**< \brief PEVC signal: PAD_EVT1 on PC08 mux C */
+#define MUX_PC08C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PC08C_PEVC_PAD_EVT1  ((PIN_PC08C_PEVC_PAD_EVT1 << 16) | MUX_PC08C_PEVC_PAD_EVT1)
+#define GPIO_PC08C_PEVC_PAD_EVT1  _UL(1 <<  8)
+#define PIN_PC25C_PEVC_PAD_EVT1        _L(89) /**< \brief PEVC signal: PAD_EVT1 on PC25 mux C */
+#define MUX_PC25C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PC25C_PEVC_PAD_EVT1  ((PIN_PC25C_PEVC_PAD_EVT1 << 16) | MUX_PC25C_PEVC_PAD_EVT1)
+#define GPIO_PC25C_PEVC_PAD_EVT1  _UL(1 << 25)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
+#define PIN_PC11C_PEVC_PAD_EVT2        _L(75) /**< \brief PEVC signal: PAD_EVT2 on PC11 mux C */
+#define MUX_PC11C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PC11C_PEVC_PAD_EVT2  ((PIN_PC11C_PEVC_PAD_EVT2 << 16) | MUX_PC11C_PEVC_PAD_EVT2)
+#define GPIO_PC11C_PEVC_PAD_EVT2  _UL(1 << 11)
+#define PIN_PC26C_PEVC_PAD_EVT2        _L(90) /**< \brief PEVC signal: PAD_EVT2 on PC26 mux C */
+#define MUX_PC26C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PC26C_PEVC_PAD_EVT2  ((PIN_PC26C_PEVC_PAD_EVT2 << 16) | MUX_PC26C_PEVC_PAD_EVT2)
+#define GPIO_PC26C_PEVC_PAD_EVT2  _UL(1 << 26)
+#define PIN_PB09B_PEVC_PAD_EVT2        _L(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
+#define MUX_PB09B_PEVC_PAD_EVT2         _L(1)
+#define PINMUX_PB09B_PEVC_PAD_EVT2  ((PIN_PB09B_PEVC_PAD_EVT2 << 16) | MUX_PB09B_PEVC_PAD_EVT2)
+#define GPIO_PB09B_PEVC_PAD_EVT2  _UL(1 <<  9)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
+#define PIN_PC27C_PEVC_PAD_EVT3        _L(91) /**< \brief PEVC signal: PAD_EVT3 on PC27 mux C */
+#define MUX_PC27C_PEVC_PAD_EVT3         _L(2)
+#define PINMUX_PC27C_PEVC_PAD_EVT3  ((PIN_PC27C_PEVC_PAD_EVT3 << 16) | MUX_PC27C_PEVC_PAD_EVT3)
+#define GPIO_PC27C_PEVC_PAD_EVT3  _UL(1 << 27)
+#define PIN_PB10B_PEVC_PAD_EVT3        _L(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
+#define MUX_PB10B_PEVC_PAD_EVT3         _L(1)
+#define PINMUX_PB10B_PEVC_PAD_EVT3  ((PIN_PB10B_PEVC_PAD_EVT3 << 16) | MUX_PB10B_PEVC_PAD_EVT3)
+#define GPIO_PB10B_PEVC_PAD_EVT3  _UL(1 << 10)
+/* ========== GPIO definition for SCIF peripheral ========== */
+#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
+#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
+#define PIN_PB10E_SCIF_GCLK0           _L(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
+#define MUX_PB10E_SCIF_GCLK0            _L(4)
+#define PINMUX_PB10E_SCIF_GCLK0    ((PIN_PB10E_SCIF_GCLK0 << 16) | MUX_PB10E_SCIF_GCLK0)
+#define GPIO_PB10E_SCIF_GCLK0    _UL(1 << 10)
+#define PIN_PC26E_SCIF_GCLK0           _L(90) /**< \brief SCIF signal: GCLK0 on PC26 mux E */
+#define MUX_PC26E_SCIF_GCLK0            _L(4)
+#define PINMUX_PC26E_SCIF_GCLK0    ((PIN_PC26E_SCIF_GCLK0 << 16) | MUX_PC26E_SCIF_GCLK0)
+#define GPIO_PC26E_SCIF_GCLK0    _UL(1 << 26)
+#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
+#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
+#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
+#define PIN_PB11E_SCIF_GCLK1           _L(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
+#define MUX_PB11E_SCIF_GCLK1            _L(4)
+#define PINMUX_PB11E_SCIF_GCLK1    ((PIN_PB11E_SCIF_GCLK1 << 16) | MUX_PB11E_SCIF_GCLK1)
+#define GPIO_PB11E_SCIF_GCLK1    _UL(1 << 11)
+#define PIN_PC27E_SCIF_GCLK1           _L(91) /**< \brief SCIF signal: GCLK1 on PC27 mux E */
+#define MUX_PC27E_SCIF_GCLK1            _L(4)
+#define PINMUX_PC27E_SCIF_GCLK1    ((PIN_PC27E_SCIF_GCLK1 << 16) | MUX_PC27E_SCIF_GCLK1)
+#define GPIO_PC27E_SCIF_GCLK1    _UL(1 << 27)
+#define PIN_PB12E_SCIF_GCLK2           _L(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
+#define MUX_PB12E_SCIF_GCLK2            _L(4)
+#define PINMUX_PB12E_SCIF_GCLK2    ((PIN_PB12E_SCIF_GCLK2 << 16) | MUX_PB12E_SCIF_GCLK2)
+#define GPIO_PB12E_SCIF_GCLK2    _UL(1 << 12)
+#define PIN_PC28E_SCIF_GCLK2           _L(92) /**< \brief SCIF signal: GCLK2 on PC28 mux E */
+#define MUX_PC28E_SCIF_GCLK2            _L(4)
+#define PINMUX_PC28E_SCIF_GCLK2    ((PIN_PC28E_SCIF_GCLK2 << 16) | MUX_PC28E_SCIF_GCLK2)
+#define GPIO_PC28E_SCIF_GCLK2    _UL(1 << 28)
+#define PIN_PB13E_SCIF_GCLK3           _L(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
+#define MUX_PB13E_SCIF_GCLK3            _L(4)
+#define PINMUX_PB13E_SCIF_GCLK3    ((PIN_PB13E_SCIF_GCLK3 << 16) | MUX_PB13E_SCIF_GCLK3)
+#define GPIO_PB13E_SCIF_GCLK3    _UL(1 << 13)
+#define PIN_PC29E_SCIF_GCLK3           _L(93) /**< \brief SCIF signal: GCLK3 on PC29 mux E */
+#define MUX_PC29E_SCIF_GCLK3            _L(4)
+#define PINMUX_PC29E_SCIF_GCLK3    ((PIN_PC29E_SCIF_GCLK3 << 16) | MUX_PC29E_SCIF_GCLK3)
+#define GPIO_PC29E_SCIF_GCLK3    _UL(1 << 29)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
+#define PIN_PB14E_SCIF_GCLK_IN0        _L(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
+#define MUX_PB14E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PB14E_SCIF_GCLK_IN0  ((PIN_PB14E_SCIF_GCLK_IN0 << 16) | MUX_PB14E_SCIF_GCLK_IN0)
+#define GPIO_PB14E_SCIF_GCLK_IN0  _UL(1 << 14)
+#define PIN_PC30E_SCIF_GCLK_IN0        _L(94) /**< \brief SCIF signal: GCLK_IN0 on PC30 mux E */
+#define MUX_PC30E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PC30E_SCIF_GCLK_IN0  ((PIN_PC30E_SCIF_GCLK_IN0 << 16) | MUX_PC30E_SCIF_GCLK_IN0)
+#define GPIO_PC30E_SCIF_GCLK_IN0  _UL(1 << 30)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
+#define PIN_PB15E_SCIF_GCLK_IN1        _L(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
+#define MUX_PB15E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PB15E_SCIF_GCLK_IN1  ((PIN_PB15E_SCIF_GCLK_IN1 << 16) | MUX_PB15E_SCIF_GCLK_IN1)
+#define GPIO_PB15E_SCIF_GCLK_IN1  _UL(1 << 15)
+#define PIN_PC31E_SCIF_GCLK_IN1        _L(95) /**< \brief SCIF signal: GCLK_IN1 on PC31 mux E */
+#define MUX_PC31E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PC31E_SCIF_GCLK_IN1  ((PIN_PC31E_SCIF_GCLK_IN1 << 16) | MUX_PC31E_SCIF_GCLK_IN1)
+#define GPIO_PC31E_SCIF_GCLK_IN1  _UL(1 << 31)
+/* ========== GPIO definition for EIC peripheral ========== */
+#define PIN_PB01C_EIC_EXTINT0          _L(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
+#define MUX_PB01C_EIC_EXTINT0           _L(2)
+#define PINMUX_PB01C_EIC_EXTINT0   ((PIN_PB01C_EIC_EXTINT0 << 16) | MUX_PB01C_EIC_EXTINT0)
+#define GPIO_PB01C_EIC_EXTINT0   _UL(1 <<  1)
+#define PIN_PB01C_EIC_EXTINT_NUM        _L(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
+#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
+#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PC24B_EIC_EXTINT1          _L(88) /**< \brief EIC signal: EXTINT1 on PC24 mux B */
+#define MUX_PC24B_EIC_EXTINT1           _L(1)
+#define PINMUX_PC24B_EIC_EXTINT1   ((PIN_PC24B_EIC_EXTINT1 << 16) | MUX_PC24B_EIC_EXTINT1)
+#define GPIO_PC24B_EIC_EXTINT1   _UL(1 << 24)
+#define PIN_PC24B_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PC24 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PC25B_EIC_EXTINT2          _L(89) /**< \brief EIC signal: EXTINT2 on PC25 mux B */
+#define MUX_PC25B_EIC_EXTINT2           _L(1)
+#define PINMUX_PC25B_EIC_EXTINT2   ((PIN_PC25B_EIC_EXTINT2 << 16) | MUX_PC25B_EIC_EXTINT2)
+#define GPIO_PC25B_EIC_EXTINT2   _UL(1 << 25)
+#define PIN_PC25B_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PC25 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
+#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
+#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PC26B_EIC_EXTINT3          _L(90) /**< \brief EIC signal: EXTINT3 on PC26 mux B */
+#define MUX_PC26B_EIC_EXTINT3           _L(1)
+#define PINMUX_PC26B_EIC_EXTINT3   ((PIN_PC26B_EIC_EXTINT3 << 16) | MUX_PC26B_EIC_EXTINT3)
+#define GPIO_PC26B_EIC_EXTINT3   _UL(1 << 26)
+#define PIN_PC26B_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PC26 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
+#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
+#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PC27B_EIC_EXTINT4          _L(91) /**< \brief EIC signal: EXTINT4 on PC27 mux B */
+#define MUX_PC27B_EIC_EXTINT4           _L(1)
+#define PINMUX_PC27B_EIC_EXTINT4   ((PIN_PC27B_EIC_EXTINT4 << 16) | MUX_PC27B_EIC_EXTINT4)
+#define GPIO_PC27B_EIC_EXTINT4   _UL(1 << 27)
+#define PIN_PC27B_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PC27 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
+#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PC03B_EIC_EXTINT5          _L(67) /**< \brief EIC signal: EXTINT5 on PC03 mux B */
+#define MUX_PC03B_EIC_EXTINT5           _L(1)
+#define PINMUX_PC03B_EIC_EXTINT5   ((PIN_PC03B_EIC_EXTINT5 << 16) | MUX_PC03B_EIC_EXTINT5)
+#define GPIO_PC03B_EIC_EXTINT5   _UL(1 <<  3)
+#define PIN_PC03B_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PC03 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
+#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PC04B_EIC_EXTINT6          _L(68) /**< \brief EIC signal: EXTINT6 on PC04 mux B */
+#define MUX_PC04B_EIC_EXTINT6           _L(1)
+#define PINMUX_PC04B_EIC_EXTINT6   ((PIN_PC04B_EIC_EXTINT6 << 16) | MUX_PC04B_EIC_EXTINT6)
+#define GPIO_PC04B_EIC_EXTINT6   _UL(1 <<  4)
+#define PIN_PC04B_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PC04 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
+#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PC05B_EIC_EXTINT7          _L(69) /**< \brief EIC signal: EXTINT7 on PC05 mux B */
+#define MUX_PC05B_EIC_EXTINT7           _L(1)
+#define PINMUX_PC05B_EIC_EXTINT7   ((PIN_PC05B_EIC_EXTINT7 << 16) | MUX_PC05B_EIC_EXTINT7)
+#define GPIO_PC05B_EIC_EXTINT7   _UL(1 <<  5)
+#define PIN_PC05B_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PC05 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
+#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PC06B_EIC_EXTINT8          _L(70) /**< \brief EIC signal: EXTINT8 on PC06 mux B */
+#define MUX_PC06B_EIC_EXTINT8           _L(1)
+#define PINMUX_PC06B_EIC_EXTINT8   ((PIN_PC06B_EIC_EXTINT8 << 16) | MUX_PC06B_EIC_EXTINT8)
+#define GPIO_PC06B_EIC_EXTINT8   _UL(1 <<  6)
+#define PIN_PC06B_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PC06 External Interrupt Line */
+
+#endif /* _SAM4LC2C_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4lc4a.h
+++ b/asf/sam/include/sam4l/pio/sam4lc4a.h
@@ -30,645 +30,645 @@
 #define _SAM4LC4A_PIO_
 
 #define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
-#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define GPIO_PA00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PA00 */
 #define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
-#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define GPIO_PA01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PA01 */
 #define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
-#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define GPIO_PA02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PA02 */
 #define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
-#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define GPIO_PA03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PA03 */
 #define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
-#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define GPIO_PA04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PA04 */
 #define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
-#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define GPIO_PA05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PA05 */
 #define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
-#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define GPIO_PA06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PA06 */
 #define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
-#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define GPIO_PA07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PA07 */
 #define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
-#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define GPIO_PA08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PA08 */
 #define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
-#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define GPIO_PA09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PA09 */
 #define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
-#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define GPIO_PA10                _UL_(1 << 10) /**< \brief GPIO Mask  for PA10 */
 #define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
-#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define GPIO_PA11                _UL_(1 << 11) /**< \brief GPIO Mask  for PA11 */
 #define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
-#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define GPIO_PA12                _UL_(1 << 12) /**< \brief GPIO Mask  for PA12 */
 #define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
-#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define GPIO_PA13                _UL_(1 << 13) /**< \brief GPIO Mask  for PA13 */
 #define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
-#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define GPIO_PA14                _UL_(1 << 14) /**< \brief GPIO Mask  for PA14 */
 #define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
-#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define GPIO_PA15                _UL_(1 << 15) /**< \brief GPIO Mask  for PA15 */
 #define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
-#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define GPIO_PA16                _UL_(1 << 16) /**< \brief GPIO Mask  for PA16 */
 #define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
-#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define GPIO_PA17                _UL_(1 << 17) /**< \brief GPIO Mask  for PA17 */
 #define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
-#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define GPIO_PA18                _UL_(1 << 18) /**< \brief GPIO Mask  for PA18 */
 #define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
-#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define GPIO_PA19                _UL_(1 << 19) /**< \brief GPIO Mask  for PA19 */
 #define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
-#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define GPIO_PA20                _UL_(1 << 20) /**< \brief GPIO Mask  for PA20 */
 #define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
-#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define GPIO_PA21                _UL_(1 << 21) /**< \brief GPIO Mask  for PA21 */
 #define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
-#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define GPIO_PA22                _UL_(1 << 22) /**< \brief GPIO Mask  for PA22 */
 #define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
-#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define GPIO_PA23                _UL_(1 << 23) /**< \brief GPIO Mask  for PA23 */
 #define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
-#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define GPIO_PA24                _UL_(1 << 24) /**< \brief GPIO Mask  for PA24 */
 #define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
-#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define GPIO_PA25                _UL_(1 << 25) /**< \brief GPIO Mask  for PA25 */
 #define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
-#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define GPIO_PA26                _UL_(1 << 26) /**< \brief GPIO Mask  for PA26 */
 /* ========== GPIO definition for TWIMS0 peripheral ========== */
-#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
-#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PIN_PA24B_TWIMS0_TWCK          _L_(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L_(1)
 #define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
-#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
-#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
-#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL_(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L_(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L_(1)
 #define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
-#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+#define GPIO_PA23B_TWIMS0_TWD    _UL_(1 << 23)
 /* ========== GPIO definition for TWIMS2 peripheral ========== */
-#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
-#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PIN_PA22E_TWIMS2_TWCK          _L_(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L_(4)
 #define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
-#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
-#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
-#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL_(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L_(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L_(4)
 #define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
-#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+#define GPIO_PA21E_TWIMS2_TWD    _UL_(1 << 21)
 /* ========== GPIO definition for SPI peripheral ========== */
-#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
-#define MUX_PA03B_SPI_MISO              _L(1)
+#define PIN_PA03B_SPI_MISO              _L_(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L_(1)
 #define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
-#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
-#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
-#define MUX_PA21A_SPI_MISO              _L(0)
+#define GPIO_PA03B_SPI_MISO      _UL_(1 <<  3)
+#define PIN_PA21A_SPI_MISO             _L_(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L_(0)
 #define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
-#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
-#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
-#define MUX_PA22A_SPI_MOSI              _L(0)
+#define GPIO_PA21A_SPI_MISO      _UL_(1 << 21)
+#define PIN_PA22A_SPI_MOSI             _L_(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L_(0)
 #define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
-#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
-#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
-#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define GPIO_PA22A_SPI_MOSI      _UL_(1 << 22)
+#define PIN_PA02B_SPI_NPCS0             _L_(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L_(1)
 #define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
-#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
-#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
-#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define GPIO_PA02B_SPI_NPCS0     _UL_(1 <<  2)
+#define PIN_PA24A_SPI_NPCS0            _L_(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L_(0)
 #define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
-#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
-#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
-#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define GPIO_PA24A_SPI_NPCS0     _UL_(1 << 24)
+#define PIN_PA13C_SPI_NPCS1            _L_(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L_(2)
 #define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
-#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
-#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define GPIO_PA13C_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PA14C_SPI_NPCS2            _L_(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L_(2)
 #define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
-#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
-#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
-#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define GPIO_PA14C_SPI_NPCS2     _UL_(1 << 14)
+#define PIN_PA15C_SPI_NPCS3            _L_(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L_(2)
 #define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
-#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
-#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
-#define MUX_PA23A_SPI_SCK               _L(0)
+#define GPIO_PA15C_SPI_NPCS3     _UL_(1 << 15)
+#define PIN_PA23A_SPI_SCK              _L_(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L_(0)
 #define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
-#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
+#define GPIO_PA23A_SPI_SCK       _UL_(1 << 23)
 /* ========== GPIO definition for TC0 peripheral ========== */
-#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
-#define MUX_PA08B_TC0_A0                _L(1)
+#define PIN_PA08B_TC0_A0                _L_(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L_(1)
 #define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
-#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
-#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
-#define MUX_PA10B_TC0_A1                _L(1)
+#define GPIO_PA08B_TC0_A0        _UL_(1 <<  8)
+#define PIN_PA10B_TC0_A1               _L_(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L_(1)
 #define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
-#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
-#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
-#define MUX_PA12B_TC0_A2                _L(1)
+#define GPIO_PA10B_TC0_A1        _UL_(1 << 10)
+#define PIN_PA12B_TC0_A2               _L_(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L_(1)
 #define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
-#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
-#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
-#define MUX_PA09B_TC0_B0                _L(1)
+#define GPIO_PA12B_TC0_A2        _UL_(1 << 12)
+#define PIN_PA09B_TC0_B0                _L_(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L_(1)
 #define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
-#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
-#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
-#define MUX_PA11B_TC0_B1                _L(1)
+#define GPIO_PA09B_TC0_B0        _UL_(1 <<  9)
+#define PIN_PA11B_TC0_B1               _L_(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L_(1)
 #define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
-#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
-#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
-#define MUX_PA13B_TC0_B2                _L(1)
+#define GPIO_PA11B_TC0_B1        _UL_(1 << 11)
+#define PIN_PA13B_TC0_B2               _L_(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L_(1)
 #define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
-#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
-#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
-#define MUX_PA14B_TC0_CLK0              _L(1)
+#define GPIO_PA13B_TC0_B2        _UL_(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L_(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L_(1)
 #define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
-#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
-#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
-#define MUX_PA15B_TC0_CLK1              _L(1)
+#define GPIO_PA14B_TC0_CLK0      _UL_(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L_(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L_(1)
 #define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
-#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
-#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
-#define MUX_PA16B_TC0_CLK2              _L(1)
+#define GPIO_PA15B_TC0_CLK1      _UL_(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L_(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L_(1)
 #define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
-#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+#define GPIO_PA16B_TC0_CLK2      _UL_(1 << 16)
 /* ========== GPIO definition for USART0 peripheral ========== */
-#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
-#define MUX_PA04B_USART0_CLK            _L(1)
+#define PIN_PA04B_USART0_CLK            _L_(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L_(1)
 #define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
-#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
-#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
-#define MUX_PA10A_USART0_CLK            _L(0)
+#define GPIO_PA04B_USART0_CLK    _UL_(1 <<  4)
+#define PIN_PA10A_USART0_CLK           _L_(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L_(0)
 #define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
-#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
-#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
-#define MUX_PA09A_USART0_CTS            _L(0)
+#define GPIO_PA10A_USART0_CLK    _UL_(1 << 10)
+#define PIN_PA09A_USART0_CTS            _L_(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L_(0)
 #define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
-#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
-#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
-#define MUX_PA06B_USART0_RTS            _L(1)
+#define GPIO_PA09A_USART0_CTS    _UL_(1 <<  9)
+#define PIN_PA06B_USART0_RTS            _L_(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L_(1)
 #define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
-#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
-#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
-#define MUX_PA08A_USART0_RTS            _L(0)
+#define GPIO_PA06B_USART0_RTS    _UL_(1 <<  6)
+#define PIN_PA08A_USART0_RTS            _L_(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L_(0)
 #define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
-#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
-#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
-#define MUX_PA05B_USART0_RXD            _L(1)
+#define GPIO_PA08A_USART0_RTS    _UL_(1 <<  8)
+#define PIN_PA05B_USART0_RXD            _L_(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L_(1)
 #define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
-#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
-#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
-#define MUX_PA11A_USART0_RXD            _L(0)
+#define GPIO_PA05B_USART0_RXD    _UL_(1 <<  5)
+#define PIN_PA11A_USART0_RXD           _L_(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L_(0)
 #define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
-#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
-#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
-#define MUX_PA07B_USART0_TXD            _L(1)
+#define GPIO_PA11A_USART0_RXD    _UL_(1 << 11)
+#define PIN_PA07B_USART0_TXD            _L_(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L_(1)
 #define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
-#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
-#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
-#define MUX_PA12A_USART0_TXD            _L(0)
+#define GPIO_PA07B_USART0_TXD    _UL_(1 <<  7)
+#define PIN_PA12A_USART0_TXD           _L_(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L_(0)
 #define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
-#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
+#define GPIO_PA12A_USART0_TXD    _UL_(1 << 12)
 /* ========== GPIO definition for USART1 peripheral ========== */
-#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
-#define MUX_PA14A_USART1_CLK            _L(0)
+#define PIN_PA14A_USART1_CLK           _L_(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L_(0)
 #define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
-#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
-#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
-#define MUX_PA21B_USART1_CTS            _L(1)
+#define GPIO_PA14A_USART1_CLK    _UL_(1 << 14)
+#define PIN_PA21B_USART1_CTS           _L_(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L_(1)
 #define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
-#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
-#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
-#define MUX_PA13A_USART1_RTS            _L(0)
+#define GPIO_PA21B_USART1_CTS    _UL_(1 << 21)
+#define PIN_PA13A_USART1_RTS           _L_(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L_(0)
 #define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
-#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
-#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
-#define MUX_PA15A_USART1_RXD            _L(0)
+#define GPIO_PA13A_USART1_RTS    _UL_(1 << 13)
+#define PIN_PA15A_USART1_RXD           _L_(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L_(0)
 #define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
-#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
-#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
-#define MUX_PA16A_USART1_TXD            _L(0)
+#define GPIO_PA15A_USART1_RXD    _UL_(1 << 15)
+#define PIN_PA16A_USART1_TXD           _L_(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L_(0)
 #define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
-#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+#define GPIO_PA16A_USART1_TXD    _UL_(1 << 16)
 /* ========== GPIO definition for USART2 peripheral ========== */
-#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
-#define MUX_PA18A_USART2_CLK            _L(0)
+#define PIN_PA18A_USART2_CLK           _L_(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L_(0)
 #define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
-#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
-#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
-#define MUX_PA22B_USART2_CTS            _L(1)
+#define GPIO_PA18A_USART2_CLK    _UL_(1 << 18)
+#define PIN_PA22B_USART2_CTS           _L_(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L_(1)
 #define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
-#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
-#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
-#define MUX_PA17A_USART2_RTS            _L(0)
+#define GPIO_PA22B_USART2_CTS    _UL_(1 << 22)
+#define PIN_PA17A_USART2_RTS           _L_(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L_(0)
 #define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
-#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
-#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
-#define MUX_PA25B_USART2_RXD            _L(1)
+#define GPIO_PA17A_USART2_RTS    _UL_(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L_(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L_(1)
 #define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
-#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
-#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
-#define MUX_PA19A_USART2_RXD            _L(0)
+#define GPIO_PA25B_USART2_RXD    _UL_(1 << 25)
+#define PIN_PA19A_USART2_RXD           _L_(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L_(0)
 #define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
-#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
-#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
-#define MUX_PA26B_USART2_TXD            _L(1)
+#define GPIO_PA19A_USART2_RXD    _UL_(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L_(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L_(1)
 #define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
-#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
-#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
-#define MUX_PA20A_USART2_TXD            _L(0)
+#define GPIO_PA26B_USART2_TXD    _UL_(1 << 26)
+#define PIN_PA20A_USART2_TXD           _L_(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L_(0)
 #define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
-#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+#define GPIO_PA20A_USART2_TXD    _UL_(1 << 20)
 /* ========== GPIO definition for ADCIFE peripheral ========== */
-#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
-#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PIN_PA04A_ADCIFE_AD0            _L_(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L_(0)
 #define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
-#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
-#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
-#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL_(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L_(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L_(0)
 #define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
-#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
-#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
-#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define GPIO_PA05A_ADCIFE_AD1    _UL_(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L_(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L_(0)
 #define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
-#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
-#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
-#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define GPIO_PA07A_ADCIFE_AD2    _UL_(1 <<  7)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L_(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L_(4)
 #define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
-#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL_(1 <<  5)
 /* ========== GPIO definition for DACC peripheral ========== */
-#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
-#define MUX_PA06A_DACC_VOUT             _L(0)
+#define PIN_PA06A_DACC_VOUT             _L_(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L_(0)
 #define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
-#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+#define GPIO_PA06A_DACC_VOUT     _UL_(1 <<  6)
 /* ========== GPIO definition for ACIFC peripheral ========== */
-#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
-#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PIN_PA06E_ACIFC_ACAN0           _L_(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L_(4)
 #define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
-#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
-#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
-#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL_(1 <<  6)
+#define PIN_PA07E_ACIFC_ACAP0           _L_(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L_(4)
 #define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
-#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL_(1 <<  7)
 /* ========== GPIO definition for GLOC peripheral ========== */
-#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
-#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PIN_PA06D_GLOC_IN0              _L_(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L_(3)
 #define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
-#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
-#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
-#define MUX_PA20D_GLOC_IN0              _L(3)
+#define GPIO_PA06D_GLOC_IN0      _UL_(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L_(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L_(3)
 #define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
-#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
-#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
-#define MUX_PA04D_GLOC_IN1              _L(3)
+#define GPIO_PA20D_GLOC_IN0      _UL_(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L_(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L_(3)
 #define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
-#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
-#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
-#define MUX_PA21D_GLOC_IN1              _L(3)
+#define GPIO_PA04D_GLOC_IN1      _UL_(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L_(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L_(3)
 #define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
-#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
-#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
-#define MUX_PA05D_GLOC_IN2              _L(3)
+#define GPIO_PA21D_GLOC_IN1      _UL_(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L_(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L_(3)
 #define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
-#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
-#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
-#define MUX_PA22D_GLOC_IN2              _L(3)
+#define GPIO_PA05D_GLOC_IN2      _UL_(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L_(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L_(3)
 #define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
-#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
-#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
-#define MUX_PA07D_GLOC_IN3              _L(3)
+#define GPIO_PA22D_GLOC_IN2      _UL_(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L_(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L_(3)
 #define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
-#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
-#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
-#define MUX_PA23D_GLOC_IN3              _L(3)
+#define GPIO_PA07D_GLOC_IN3      _UL_(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L_(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L_(3)
 #define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
-#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
-#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
-#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define GPIO_PA23D_GLOC_IN3      _UL_(1 << 23)
+#define PIN_PA08D_GLOC_OUT0             _L_(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
-#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
-#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
-#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define GPIO_PA08D_GLOC_OUT0     _UL_(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L_(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
-#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
+#define GPIO_PA24D_GLOC_OUT0     _UL_(1 << 24)
 /* ========== GPIO definition for ABDACB peripheral ========== */
-#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
-#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define PIN_PA17B_ABDACB_DAC0          _L_(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L_(1)
 #define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
-#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
-#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
-#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define GPIO_PA17B_ABDACB_DAC0   _UL_(1 << 17)
+#define PIN_PA19B_ABDACB_DAC1          _L_(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L_(1)
 #define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
-#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
-#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
-#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define GPIO_PA19B_ABDACB_DAC1   _UL_(1 << 19)
+#define PIN_PA18B_ABDACB_DACN0         _L_(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L_(1)
 #define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
-#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
-#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
-#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define GPIO_PA18B_ABDACB_DACN0  _UL_(1 << 18)
+#define PIN_PA20B_ABDACB_DACN1         _L_(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L_(1)
 #define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
-#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+#define GPIO_PA20B_ABDACB_DACN1  _UL_(1 << 20)
 /* ========== GPIO definition for PARC peripheral ========== */
-#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
-#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PIN_PA17D_PARC_PCCK            _L_(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L_(3)
 #define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
-#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
-#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
-#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define GPIO_PA17D_PARC_PCCK     _UL_(1 << 17)
+#define PIN_PA09D_PARC_PCDATA0          _L_(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L_(3)
 #define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
-#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
-#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
-#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define GPIO_PA09D_PARC_PCDATA0  _UL_(1 <<  9)
+#define PIN_PA10D_PARC_PCDATA1         _L_(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L_(3)
 #define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
-#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
-#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
-#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define GPIO_PA10D_PARC_PCDATA1  _UL_(1 << 10)
+#define PIN_PA11D_PARC_PCDATA2         _L_(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L_(3)
 #define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
-#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
-#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
-#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define GPIO_PA11D_PARC_PCDATA2  _UL_(1 << 11)
+#define PIN_PA12D_PARC_PCDATA3         _L_(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L_(3)
 #define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
-#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
-#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
-#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL_(1 << 12)
+#define PIN_PA13D_PARC_PCDATA4         _L_(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L_(3)
 #define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
-#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
-#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
-#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define GPIO_PA13D_PARC_PCDATA4  _UL_(1 << 13)
+#define PIN_PA14D_PARC_PCDATA5         _L_(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L_(3)
 #define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
-#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
-#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
-#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define GPIO_PA14D_PARC_PCDATA5  _UL_(1 << 14)
+#define PIN_PA15D_PARC_PCDATA6         _L_(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L_(3)
 #define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
-#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
-#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
-#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define GPIO_PA15D_PARC_PCDATA6  _UL_(1 << 15)
+#define PIN_PA16D_PARC_PCDATA7         _L_(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L_(3)
 #define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
-#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
-#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
-#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define GPIO_PA16D_PARC_PCDATA7  _UL_(1 << 16)
+#define PIN_PA18D_PARC_PCEN1           _L_(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L_(3)
 #define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
-#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
-#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
-#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define GPIO_PA18D_PARC_PCEN1    _UL_(1 << 18)
+#define PIN_PA19D_PARC_PCEN2           _L_(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L_(3)
 #define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
-#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+#define GPIO_PA19D_PARC_PCEN2    _UL_(1 << 19)
 /* ========== GPIO definition for CATB peripheral ========== */
-#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
-#define MUX_PA02G_CATB_DIS              _L(6)
+#define PIN_PA02G_CATB_DIS              _L_(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L_(6)
 #define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
-#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
-#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
-#define MUX_PA12G_CATB_DIS              _L(6)
+#define GPIO_PA02G_CATB_DIS      _UL_(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L_(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L_(6)
 #define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
-#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
-#define MUX_PA23G_CATB_DIS              _L(6)
+#define GPIO_PA12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L_(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L_(6)
 #define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
-#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
-#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
-#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define GPIO_PA23G_CATB_DIS      _UL_(1 << 23)
+#define PIN_PA04G_CATB_SENSE0           _L_(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L_(6)
 #define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
-#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
-#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
-#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define GPIO_PA04G_CATB_SENSE0   _UL_(1 <<  4)
+#define PIN_PA05G_CATB_SENSE1           _L_(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L_(6)
 #define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
-#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
-#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
-#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define GPIO_PA05G_CATB_SENSE1   _UL_(1 <<  5)
+#define PIN_PA06G_CATB_SENSE2           _L_(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L_(6)
 #define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
-#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
-#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
-#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define GPIO_PA06G_CATB_SENSE2   _UL_(1 <<  6)
+#define PIN_PA07G_CATB_SENSE3           _L_(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L_(6)
 #define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
-#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
-#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
-#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define GPIO_PA07G_CATB_SENSE3   _UL_(1 <<  7)
+#define PIN_PA08G_CATB_SENSE4           _L_(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L_(6)
 #define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
-#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
-#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
-#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define GPIO_PA08G_CATB_SENSE4   _UL_(1 <<  8)
+#define PIN_PA09G_CATB_SENSE5           _L_(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L_(6)
 #define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
-#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
-#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
-#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define GPIO_PA09G_CATB_SENSE5   _UL_(1 <<  9)
+#define PIN_PA10G_CATB_SENSE6          _L_(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L_(6)
 #define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
-#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
-#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
-#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define GPIO_PA10G_CATB_SENSE6   _UL_(1 << 10)
+#define PIN_PA11G_CATB_SENSE7          _L_(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L_(6)
 #define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
-#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
-#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
-#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define GPIO_PA11G_CATB_SENSE7   _UL_(1 << 11)
+#define PIN_PA13G_CATB_SENSE8          _L_(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L_(6)
 #define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
-#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
-#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
-#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define GPIO_PA13G_CATB_SENSE8   _UL_(1 << 13)
+#define PIN_PA14G_CATB_SENSE9          _L_(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L_(6)
 #define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
-#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
-#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
-#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define GPIO_PA14G_CATB_SENSE9   _UL_(1 << 14)
+#define PIN_PA15G_CATB_SENSE10         _L_(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L_(6)
 #define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
-#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
-#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
-#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define GPIO_PA15G_CATB_SENSE10  _UL_(1 << 15)
+#define PIN_PA16G_CATB_SENSE11         _L_(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L_(6)
 #define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
-#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
-#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
-#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define GPIO_PA16G_CATB_SENSE11  _UL_(1 << 16)
+#define PIN_PA17G_CATB_SENSE12         _L_(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L_(6)
 #define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
-#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
-#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
-#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define GPIO_PA17G_CATB_SENSE12  _UL_(1 << 17)
+#define PIN_PA18G_CATB_SENSE13         _L_(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L_(6)
 #define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
-#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
-#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
-#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define GPIO_PA18G_CATB_SENSE13  _UL_(1 << 18)
+#define PIN_PA19G_CATB_SENSE14         _L_(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L_(6)
 #define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
-#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
-#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
-#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define GPIO_PA19G_CATB_SENSE14  _UL_(1 << 19)
+#define PIN_PA20G_CATB_SENSE15         _L_(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L_(6)
 #define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
-#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
-#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
-#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define GPIO_PA20G_CATB_SENSE15  _UL_(1 << 20)
+#define PIN_PA21G_CATB_SENSE16         _L_(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L_(6)
 #define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
-#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
-#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
-#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define GPIO_PA21G_CATB_SENSE16  _UL_(1 << 21)
+#define PIN_PA22G_CATB_SENSE17         _L_(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L_(6)
 #define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
-#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
-#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
-#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define GPIO_PA22G_CATB_SENSE17  _UL_(1 << 22)
+#define PIN_PA24G_CATB_SENSE18         _L_(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L_(6)
 #define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
-#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
-#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
-#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define GPIO_PA24G_CATB_SENSE18  _UL_(1 << 24)
+#define PIN_PA25G_CATB_SENSE19         _L_(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L_(6)
 #define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
-#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
-#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
-#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define GPIO_PA25G_CATB_SENSE19  _UL_(1 << 25)
+#define PIN_PA26G_CATB_SENSE20         _L_(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L_(6)
 #define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
-#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
+#define GPIO_PA26G_CATB_SENSE20  _UL_(1 << 26)
 /* ========== GPIO definition for LCDCA peripheral ========== */
-#define PIN_PA12F_LCDCA_COM0           _L(12) /**< \brief LCDCA signal: COM0 on PA12 mux F */
-#define MUX_PA12F_LCDCA_COM0            _L(5)
+#define PIN_PA12F_LCDCA_COM0           _L_(12) /**< \brief LCDCA signal: COM0 on PA12 mux F */
+#define MUX_PA12F_LCDCA_COM0            _L_(5)
 #define PINMUX_PA12F_LCDCA_COM0    ((PIN_PA12F_LCDCA_COM0 << 16) | MUX_PA12F_LCDCA_COM0)
-#define GPIO_PA12F_LCDCA_COM0    _UL(1 << 12)
-#define PIN_PA11F_LCDCA_COM1           _L(11) /**< \brief LCDCA signal: COM1 on PA11 mux F */
-#define MUX_PA11F_LCDCA_COM1            _L(5)
+#define GPIO_PA12F_LCDCA_COM0    _UL_(1 << 12)
+#define PIN_PA11F_LCDCA_COM1           _L_(11) /**< \brief LCDCA signal: COM1 on PA11 mux F */
+#define MUX_PA11F_LCDCA_COM1            _L_(5)
 #define PINMUX_PA11F_LCDCA_COM1    ((PIN_PA11F_LCDCA_COM1 << 16) | MUX_PA11F_LCDCA_COM1)
-#define GPIO_PA11F_LCDCA_COM1    _UL(1 << 11)
-#define PIN_PA10F_LCDCA_COM2           _L(10) /**< \brief LCDCA signal: COM2 on PA10 mux F */
-#define MUX_PA10F_LCDCA_COM2            _L(5)
+#define GPIO_PA11F_LCDCA_COM1    _UL_(1 << 11)
+#define PIN_PA10F_LCDCA_COM2           _L_(10) /**< \brief LCDCA signal: COM2 on PA10 mux F */
+#define MUX_PA10F_LCDCA_COM2            _L_(5)
 #define PINMUX_PA10F_LCDCA_COM2    ((PIN_PA10F_LCDCA_COM2 << 16) | MUX_PA10F_LCDCA_COM2)
-#define GPIO_PA10F_LCDCA_COM2    _UL(1 << 10)
-#define PIN_PA09F_LCDCA_COM3            _L(9) /**< \brief LCDCA signal: COM3 on PA09 mux F */
-#define MUX_PA09F_LCDCA_COM3            _L(5)
+#define GPIO_PA10F_LCDCA_COM2    _UL_(1 << 10)
+#define PIN_PA09F_LCDCA_COM3            _L_(9) /**< \brief LCDCA signal: COM3 on PA09 mux F */
+#define MUX_PA09F_LCDCA_COM3            _L_(5)
 #define PINMUX_PA09F_LCDCA_COM3    ((PIN_PA09F_LCDCA_COM3 << 16) | MUX_PA09F_LCDCA_COM3)
-#define GPIO_PA09F_LCDCA_COM3    _UL(1 <<  9)
-#define PIN_PA13F_LCDCA_SEG5           _L(13) /**< \brief LCDCA signal: SEG5 on PA13 mux F */
-#define MUX_PA13F_LCDCA_SEG5            _L(5)
+#define GPIO_PA09F_LCDCA_COM3    _UL_(1 <<  9)
+#define PIN_PA13F_LCDCA_SEG5           _L_(13) /**< \brief LCDCA signal: SEG5 on PA13 mux F */
+#define MUX_PA13F_LCDCA_SEG5            _L_(5)
 #define PINMUX_PA13F_LCDCA_SEG5    ((PIN_PA13F_LCDCA_SEG5 << 16) | MUX_PA13F_LCDCA_SEG5)
-#define GPIO_PA13F_LCDCA_SEG5    _UL(1 << 13)
-#define PIN_PA14F_LCDCA_SEG6           _L(14) /**< \brief LCDCA signal: SEG6 on PA14 mux F */
-#define MUX_PA14F_LCDCA_SEG6            _L(5)
+#define GPIO_PA13F_LCDCA_SEG5    _UL_(1 << 13)
+#define PIN_PA14F_LCDCA_SEG6           _L_(14) /**< \brief LCDCA signal: SEG6 on PA14 mux F */
+#define MUX_PA14F_LCDCA_SEG6            _L_(5)
 #define PINMUX_PA14F_LCDCA_SEG6    ((PIN_PA14F_LCDCA_SEG6 << 16) | MUX_PA14F_LCDCA_SEG6)
-#define GPIO_PA14F_LCDCA_SEG6    _UL(1 << 14)
-#define PIN_PA15F_LCDCA_SEG7           _L(15) /**< \brief LCDCA signal: SEG7 on PA15 mux F */
-#define MUX_PA15F_LCDCA_SEG7            _L(5)
+#define GPIO_PA14F_LCDCA_SEG6    _UL_(1 << 14)
+#define PIN_PA15F_LCDCA_SEG7           _L_(15) /**< \brief LCDCA signal: SEG7 on PA15 mux F */
+#define MUX_PA15F_LCDCA_SEG7            _L_(5)
 #define PINMUX_PA15F_LCDCA_SEG7    ((PIN_PA15F_LCDCA_SEG7 << 16) | MUX_PA15F_LCDCA_SEG7)
-#define GPIO_PA15F_LCDCA_SEG7    _UL(1 << 15)
-#define PIN_PA16F_LCDCA_SEG8           _L(16) /**< \brief LCDCA signal: SEG8 on PA16 mux F */
-#define MUX_PA16F_LCDCA_SEG8            _L(5)
+#define GPIO_PA15F_LCDCA_SEG7    _UL_(1 << 15)
+#define PIN_PA16F_LCDCA_SEG8           _L_(16) /**< \brief LCDCA signal: SEG8 on PA16 mux F */
+#define MUX_PA16F_LCDCA_SEG8            _L_(5)
 #define PINMUX_PA16F_LCDCA_SEG8    ((PIN_PA16F_LCDCA_SEG8 << 16) | MUX_PA16F_LCDCA_SEG8)
-#define GPIO_PA16F_LCDCA_SEG8    _UL(1 << 16)
-#define PIN_PA17F_LCDCA_SEG9           _L(17) /**< \brief LCDCA signal: SEG9 on PA17 mux F */
-#define MUX_PA17F_LCDCA_SEG9            _L(5)
+#define GPIO_PA16F_LCDCA_SEG8    _UL_(1 << 16)
+#define PIN_PA17F_LCDCA_SEG9           _L_(17) /**< \brief LCDCA signal: SEG9 on PA17 mux F */
+#define MUX_PA17F_LCDCA_SEG9            _L_(5)
 #define PINMUX_PA17F_LCDCA_SEG9    ((PIN_PA17F_LCDCA_SEG9 << 16) | MUX_PA17F_LCDCA_SEG9)
-#define GPIO_PA17F_LCDCA_SEG9    _UL(1 << 17)
-#define PIN_PA18F_LCDCA_SEG18          _L(18) /**< \brief LCDCA signal: SEG18 on PA18 mux F */
-#define MUX_PA18F_LCDCA_SEG18           _L(5)
+#define GPIO_PA17F_LCDCA_SEG9    _UL_(1 << 17)
+#define PIN_PA18F_LCDCA_SEG18          _L_(18) /**< \brief LCDCA signal: SEG18 on PA18 mux F */
+#define MUX_PA18F_LCDCA_SEG18           _L_(5)
 #define PINMUX_PA18F_LCDCA_SEG18   ((PIN_PA18F_LCDCA_SEG18 << 16) | MUX_PA18F_LCDCA_SEG18)
-#define GPIO_PA18F_LCDCA_SEG18   _UL(1 << 18)
-#define PIN_PA19F_LCDCA_SEG19          _L(19) /**< \brief LCDCA signal: SEG19 on PA19 mux F */
-#define MUX_PA19F_LCDCA_SEG19           _L(5)
+#define GPIO_PA18F_LCDCA_SEG18   _UL_(1 << 18)
+#define PIN_PA19F_LCDCA_SEG19          _L_(19) /**< \brief LCDCA signal: SEG19 on PA19 mux F */
+#define MUX_PA19F_LCDCA_SEG19           _L_(5)
 #define PINMUX_PA19F_LCDCA_SEG19   ((PIN_PA19F_LCDCA_SEG19 << 16) | MUX_PA19F_LCDCA_SEG19)
-#define GPIO_PA19F_LCDCA_SEG19   _UL(1 << 19)
-#define PIN_PA20F_LCDCA_SEG20          _L(20) /**< \brief LCDCA signal: SEG20 on PA20 mux F */
-#define MUX_PA20F_LCDCA_SEG20           _L(5)
+#define GPIO_PA19F_LCDCA_SEG19   _UL_(1 << 19)
+#define PIN_PA20F_LCDCA_SEG20          _L_(20) /**< \brief LCDCA signal: SEG20 on PA20 mux F */
+#define MUX_PA20F_LCDCA_SEG20           _L_(5)
 #define PINMUX_PA20F_LCDCA_SEG20   ((PIN_PA20F_LCDCA_SEG20 << 16) | MUX_PA20F_LCDCA_SEG20)
-#define GPIO_PA20F_LCDCA_SEG20   _UL(1 << 20)
-#define PIN_PA08F_LCDCA_SEG23           _L(8) /**< \brief LCDCA signal: SEG23 on PA08 mux F */
-#define MUX_PA08F_LCDCA_SEG23           _L(5)
+#define GPIO_PA20F_LCDCA_SEG20   _UL_(1 << 20)
+#define PIN_PA08F_LCDCA_SEG23           _L_(8) /**< \brief LCDCA signal: SEG23 on PA08 mux F */
+#define MUX_PA08F_LCDCA_SEG23           _L_(5)
 #define PINMUX_PA08F_LCDCA_SEG23   ((PIN_PA08F_LCDCA_SEG23 << 16) | MUX_PA08F_LCDCA_SEG23)
-#define GPIO_PA08F_LCDCA_SEG23   _UL(1 <<  8)
-#define PIN_PA21F_LCDCA_SEG34          _L(21) /**< \brief LCDCA signal: SEG34 on PA21 mux F */
-#define MUX_PA21F_LCDCA_SEG34           _L(5)
+#define GPIO_PA08F_LCDCA_SEG23   _UL_(1 <<  8)
+#define PIN_PA21F_LCDCA_SEG34          _L_(21) /**< \brief LCDCA signal: SEG34 on PA21 mux F */
+#define MUX_PA21F_LCDCA_SEG34           _L_(5)
 #define PINMUX_PA21F_LCDCA_SEG34   ((PIN_PA21F_LCDCA_SEG34 << 16) | MUX_PA21F_LCDCA_SEG34)
-#define GPIO_PA21F_LCDCA_SEG34   _UL(1 << 21)
-#define PIN_PA22F_LCDCA_SEG35          _L(22) /**< \brief LCDCA signal: SEG35 on PA22 mux F */
-#define MUX_PA22F_LCDCA_SEG35           _L(5)
+#define GPIO_PA21F_LCDCA_SEG34   _UL_(1 << 21)
+#define PIN_PA22F_LCDCA_SEG35          _L_(22) /**< \brief LCDCA signal: SEG35 on PA22 mux F */
+#define MUX_PA22F_LCDCA_SEG35           _L_(5)
 #define PINMUX_PA22F_LCDCA_SEG35   ((PIN_PA22F_LCDCA_SEG35 << 16) | MUX_PA22F_LCDCA_SEG35)
-#define GPIO_PA22F_LCDCA_SEG35   _UL(1 << 22)
-#define PIN_PA23F_LCDCA_SEG38          _L(23) /**< \brief LCDCA signal: SEG38 on PA23 mux F */
-#define MUX_PA23F_LCDCA_SEG38           _L(5)
+#define GPIO_PA22F_LCDCA_SEG35   _UL_(1 << 22)
+#define PIN_PA23F_LCDCA_SEG38          _L_(23) /**< \brief LCDCA signal: SEG38 on PA23 mux F */
+#define MUX_PA23F_LCDCA_SEG38           _L_(5)
 #define PINMUX_PA23F_LCDCA_SEG38   ((PIN_PA23F_LCDCA_SEG38 << 16) | MUX_PA23F_LCDCA_SEG38)
-#define GPIO_PA23F_LCDCA_SEG38   _UL(1 << 23)
-#define PIN_PA24F_LCDCA_SEG39          _L(24) /**< \brief LCDCA signal: SEG39 on PA24 mux F */
-#define MUX_PA24F_LCDCA_SEG39           _L(5)
+#define GPIO_PA23F_LCDCA_SEG38   _UL_(1 << 23)
+#define PIN_PA24F_LCDCA_SEG39          _L_(24) /**< \brief LCDCA signal: SEG39 on PA24 mux F */
+#define MUX_PA24F_LCDCA_SEG39           _L_(5)
 #define PINMUX_PA24F_LCDCA_SEG39   ((PIN_PA24F_LCDCA_SEG39 << 16) | MUX_PA24F_LCDCA_SEG39)
-#define GPIO_PA24F_LCDCA_SEG39   _UL(1 << 24)
+#define GPIO_PA24F_LCDCA_SEG39   _UL_(1 << 24)
 /* ========== GPIO definition for USBC peripheral ========== */
-#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
-#define MUX_PA25A_USBC_DM               _L(0)
+#define PIN_PA25A_USBC_DM              _L_(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L_(0)
 #define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
-#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
-#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
-#define MUX_PA26A_USBC_DP               _L(0)
+#define GPIO_PA25A_USBC_DM       _UL_(1 << 25)
+#define PIN_PA26A_USBC_DP              _L_(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L_(0)
 #define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
-#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+#define GPIO_PA26A_USBC_DP       _UL_(1 << 26)
 /* ========== GPIO definition for PEVC peripheral ========== */
-#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
-#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PIN_PA08C_PEVC_PAD_EVT0         _L_(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
-#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
-#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
-#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL_(1 <<  8)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L_(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
-#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
-#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
-#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL_(1 <<  9)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L_(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
-#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
-#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
-#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL_(1 << 10)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L_(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L_(2)
 #define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
-#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL_(1 << 11)
 /* ========== GPIO definition for SCIF peripheral ========== */
-#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
-#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PIN_PA19E_SCIF_GCLK0           _L_(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
-#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
-#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
-#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define GPIO_PA19E_SCIF_GCLK0    _UL_(1 << 19)
+#define PIN_PA02A_SCIF_GCLK0            _L_(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L_(0)
 #define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
-#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
-#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
-#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define GPIO_PA02A_SCIF_GCLK0    _UL_(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L_(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
-#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
-#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
-#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PA20E_SCIF_GCLK1    _UL_(1 << 20)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L_(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
-#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
-#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
-#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL_(1 << 23)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L_(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
-#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL_(1 << 24)
 /* ========== GPIO definition for EIC peripheral ========== */
-#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
-#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define PIN_PA06C_EIC_EXTINT1           _L_(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
-#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
-#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
-#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
-#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define GPIO_PA06C_EIC_EXTINT1   _UL_(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L_(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
-#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
-#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
-#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
-#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define GPIO_PA16C_EIC_EXTINT1   _UL_(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L_(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
-#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
-#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
-#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
-#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL_(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L_(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
-#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
-#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
-#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
-#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL_(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L_(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
-#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
-#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
-#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
-#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define GPIO_PA05C_EIC_EXTINT3   _UL_(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L_(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
-#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
-#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
-#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
-#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define GPIO_PA18C_EIC_EXTINT3   _UL_(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L_(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
-#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
-#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
-#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
-#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define GPIO_PA07C_EIC_EXTINT4   _UL_(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L_(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
-#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
-#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
-#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
-#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define GPIO_PA19C_EIC_EXTINT4   _UL_(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L_(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L_(2)
 #define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
-#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
-#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
-#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
-#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define GPIO_PA20C_EIC_EXTINT5   _UL_(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L_(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L_(2)
 #define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
-#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
-#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
-#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
-#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define GPIO_PA21C_EIC_EXTINT6   _UL_(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L_(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L_(2)
 #define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
-#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
-#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
-#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
-#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define GPIO_PA22C_EIC_EXTINT7   _UL_(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L_(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L_(2)
 #define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
-#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
-#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define GPIO_PA23C_EIC_EXTINT8   _UL_(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
 
 #endif /* _SAM4LC4A_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4lc4a.h
+++ b/asf/sam/include/sam4l/pio/sam4lc4a.h
@@ -1,0 +1,674 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAM4LC4A
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LC4A_PIO_
+#define _SAM4LC4A_PIO_
+
+#define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
+#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
+#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
+#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
+#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
+#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
+#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
+#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
+#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
+#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
+#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
+#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
+#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
+#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
+#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
+#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
+#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
+#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
+#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
+#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
+#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
+#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
+#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
+#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
+#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
+#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
+#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
+#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+/* ========== GPIO definition for TWIMS0 peripheral ========== */
+#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
+#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+/* ========== GPIO definition for TWIMS2 peripheral ========== */
+#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
+#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+/* ========== GPIO definition for SPI peripheral ========== */
+#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L(1)
+#define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
+#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
+#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L(0)
+#define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
+#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
+#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L(0)
+#define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
+#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
+#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
+#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
+#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
+#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
+#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
+#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
+#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
+#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
+#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
+#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L(0)
+#define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
+#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
+/* ========== GPIO definition for TC0 peripheral ========== */
+#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L(1)
+#define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
+#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
+#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L(1)
+#define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
+#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
+#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L(1)
+#define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
+#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
+#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L(1)
+#define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
+#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
+#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L(1)
+#define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
+#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
+#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L(1)
+#define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
+#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L(1)
+#define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
+#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L(1)
+#define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
+#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L(1)
+#define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
+#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+/* ========== GPIO definition for USART0 peripheral ========== */
+#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L(1)
+#define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
+#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
+#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L(0)
+#define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
+#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
+#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L(0)
+#define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
+#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
+#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L(1)
+#define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
+#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
+#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L(0)
+#define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
+#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
+#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L(1)
+#define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
+#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
+#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L(0)
+#define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
+#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
+#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L(1)
+#define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
+#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
+#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L(0)
+#define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
+#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
+/* ========== GPIO definition for USART1 peripheral ========== */
+#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L(0)
+#define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
+#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
+#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L(1)
+#define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
+#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
+#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L(0)
+#define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
+#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
+#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L(0)
+#define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
+#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
+#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L(0)
+#define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
+#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+/* ========== GPIO definition for USART2 peripheral ========== */
+#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L(0)
+#define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
+#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
+#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L(1)
+#define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
+#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
+#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L(0)
+#define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
+#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L(1)
+#define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
+#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
+#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L(0)
+#define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
+#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L(1)
+#define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
+#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
+#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L(0)
+#define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
+#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+/* ========== GPIO definition for ADCIFE peripheral ========== */
+#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
+#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
+#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+/* ========== GPIO definition for DACC peripheral ========== */
+#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L(0)
+#define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
+#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+/* ========== GPIO definition for ACIFC peripheral ========== */
+#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
+#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
+/* ========== GPIO definition for GLOC peripheral ========== */
+#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
+#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L(3)
+#define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
+#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L(3)
+#define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
+#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L(3)
+#define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
+#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L(3)
+#define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
+#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L(3)
+#define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
+#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L(3)
+#define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
+#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L(3)
+#define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
+#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
+#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
+#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
+#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
+/* ========== GPIO definition for ABDACB peripheral ========== */
+#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
+#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
+#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
+#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
+#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
+#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
+#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
+#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+/* ========== GPIO definition for PARC peripheral ========== */
+#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
+#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
+#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
+#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
+#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
+#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
+#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
+#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
+#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
+#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
+#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
+#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
+#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
+#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
+#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
+#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
+#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
+#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
+#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
+#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
+#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+/* ========== GPIO definition for CATB peripheral ========== */
+#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L(6)
+#define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
+#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L(6)
+#define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
+#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L(6)
+#define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
+#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
+#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
+#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
+#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
+#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
+#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
+#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
+#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
+#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
+#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
+#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
+#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
+#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
+#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
+#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
+#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
+#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
+#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
+#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
+#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
+#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
+#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
+#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
+#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
+#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
+#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
+#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
+#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
+#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
+#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
+#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
+#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
+#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
+#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
+#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
+#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
+#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
+#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
+#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
+#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
+#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
+#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
+#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
+/* ========== GPIO definition for LCDCA peripheral ========== */
+#define PIN_PA12F_LCDCA_COM0           _L(12) /**< \brief LCDCA signal: COM0 on PA12 mux F */
+#define MUX_PA12F_LCDCA_COM0            _L(5)
+#define PINMUX_PA12F_LCDCA_COM0    ((PIN_PA12F_LCDCA_COM0 << 16) | MUX_PA12F_LCDCA_COM0)
+#define GPIO_PA12F_LCDCA_COM0    _UL(1 << 12)
+#define PIN_PA11F_LCDCA_COM1           _L(11) /**< \brief LCDCA signal: COM1 on PA11 mux F */
+#define MUX_PA11F_LCDCA_COM1            _L(5)
+#define PINMUX_PA11F_LCDCA_COM1    ((PIN_PA11F_LCDCA_COM1 << 16) | MUX_PA11F_LCDCA_COM1)
+#define GPIO_PA11F_LCDCA_COM1    _UL(1 << 11)
+#define PIN_PA10F_LCDCA_COM2           _L(10) /**< \brief LCDCA signal: COM2 on PA10 mux F */
+#define MUX_PA10F_LCDCA_COM2            _L(5)
+#define PINMUX_PA10F_LCDCA_COM2    ((PIN_PA10F_LCDCA_COM2 << 16) | MUX_PA10F_LCDCA_COM2)
+#define GPIO_PA10F_LCDCA_COM2    _UL(1 << 10)
+#define PIN_PA09F_LCDCA_COM3            _L(9) /**< \brief LCDCA signal: COM3 on PA09 mux F */
+#define MUX_PA09F_LCDCA_COM3            _L(5)
+#define PINMUX_PA09F_LCDCA_COM3    ((PIN_PA09F_LCDCA_COM3 << 16) | MUX_PA09F_LCDCA_COM3)
+#define GPIO_PA09F_LCDCA_COM3    _UL(1 <<  9)
+#define PIN_PA13F_LCDCA_SEG5           _L(13) /**< \brief LCDCA signal: SEG5 on PA13 mux F */
+#define MUX_PA13F_LCDCA_SEG5            _L(5)
+#define PINMUX_PA13F_LCDCA_SEG5    ((PIN_PA13F_LCDCA_SEG5 << 16) | MUX_PA13F_LCDCA_SEG5)
+#define GPIO_PA13F_LCDCA_SEG5    _UL(1 << 13)
+#define PIN_PA14F_LCDCA_SEG6           _L(14) /**< \brief LCDCA signal: SEG6 on PA14 mux F */
+#define MUX_PA14F_LCDCA_SEG6            _L(5)
+#define PINMUX_PA14F_LCDCA_SEG6    ((PIN_PA14F_LCDCA_SEG6 << 16) | MUX_PA14F_LCDCA_SEG6)
+#define GPIO_PA14F_LCDCA_SEG6    _UL(1 << 14)
+#define PIN_PA15F_LCDCA_SEG7           _L(15) /**< \brief LCDCA signal: SEG7 on PA15 mux F */
+#define MUX_PA15F_LCDCA_SEG7            _L(5)
+#define PINMUX_PA15F_LCDCA_SEG7    ((PIN_PA15F_LCDCA_SEG7 << 16) | MUX_PA15F_LCDCA_SEG7)
+#define GPIO_PA15F_LCDCA_SEG7    _UL(1 << 15)
+#define PIN_PA16F_LCDCA_SEG8           _L(16) /**< \brief LCDCA signal: SEG8 on PA16 mux F */
+#define MUX_PA16F_LCDCA_SEG8            _L(5)
+#define PINMUX_PA16F_LCDCA_SEG8    ((PIN_PA16F_LCDCA_SEG8 << 16) | MUX_PA16F_LCDCA_SEG8)
+#define GPIO_PA16F_LCDCA_SEG8    _UL(1 << 16)
+#define PIN_PA17F_LCDCA_SEG9           _L(17) /**< \brief LCDCA signal: SEG9 on PA17 mux F */
+#define MUX_PA17F_LCDCA_SEG9            _L(5)
+#define PINMUX_PA17F_LCDCA_SEG9    ((PIN_PA17F_LCDCA_SEG9 << 16) | MUX_PA17F_LCDCA_SEG9)
+#define GPIO_PA17F_LCDCA_SEG9    _UL(1 << 17)
+#define PIN_PA18F_LCDCA_SEG18          _L(18) /**< \brief LCDCA signal: SEG18 on PA18 mux F */
+#define MUX_PA18F_LCDCA_SEG18           _L(5)
+#define PINMUX_PA18F_LCDCA_SEG18   ((PIN_PA18F_LCDCA_SEG18 << 16) | MUX_PA18F_LCDCA_SEG18)
+#define GPIO_PA18F_LCDCA_SEG18   _UL(1 << 18)
+#define PIN_PA19F_LCDCA_SEG19          _L(19) /**< \brief LCDCA signal: SEG19 on PA19 mux F */
+#define MUX_PA19F_LCDCA_SEG19           _L(5)
+#define PINMUX_PA19F_LCDCA_SEG19   ((PIN_PA19F_LCDCA_SEG19 << 16) | MUX_PA19F_LCDCA_SEG19)
+#define GPIO_PA19F_LCDCA_SEG19   _UL(1 << 19)
+#define PIN_PA20F_LCDCA_SEG20          _L(20) /**< \brief LCDCA signal: SEG20 on PA20 mux F */
+#define MUX_PA20F_LCDCA_SEG20           _L(5)
+#define PINMUX_PA20F_LCDCA_SEG20   ((PIN_PA20F_LCDCA_SEG20 << 16) | MUX_PA20F_LCDCA_SEG20)
+#define GPIO_PA20F_LCDCA_SEG20   _UL(1 << 20)
+#define PIN_PA08F_LCDCA_SEG23           _L(8) /**< \brief LCDCA signal: SEG23 on PA08 mux F */
+#define MUX_PA08F_LCDCA_SEG23           _L(5)
+#define PINMUX_PA08F_LCDCA_SEG23   ((PIN_PA08F_LCDCA_SEG23 << 16) | MUX_PA08F_LCDCA_SEG23)
+#define GPIO_PA08F_LCDCA_SEG23   _UL(1 <<  8)
+#define PIN_PA21F_LCDCA_SEG34          _L(21) /**< \brief LCDCA signal: SEG34 on PA21 mux F */
+#define MUX_PA21F_LCDCA_SEG34           _L(5)
+#define PINMUX_PA21F_LCDCA_SEG34   ((PIN_PA21F_LCDCA_SEG34 << 16) | MUX_PA21F_LCDCA_SEG34)
+#define GPIO_PA21F_LCDCA_SEG34   _UL(1 << 21)
+#define PIN_PA22F_LCDCA_SEG35          _L(22) /**< \brief LCDCA signal: SEG35 on PA22 mux F */
+#define MUX_PA22F_LCDCA_SEG35           _L(5)
+#define PINMUX_PA22F_LCDCA_SEG35   ((PIN_PA22F_LCDCA_SEG35 << 16) | MUX_PA22F_LCDCA_SEG35)
+#define GPIO_PA22F_LCDCA_SEG35   _UL(1 << 22)
+#define PIN_PA23F_LCDCA_SEG38          _L(23) /**< \brief LCDCA signal: SEG38 on PA23 mux F */
+#define MUX_PA23F_LCDCA_SEG38           _L(5)
+#define PINMUX_PA23F_LCDCA_SEG38   ((PIN_PA23F_LCDCA_SEG38 << 16) | MUX_PA23F_LCDCA_SEG38)
+#define GPIO_PA23F_LCDCA_SEG38   _UL(1 << 23)
+#define PIN_PA24F_LCDCA_SEG39          _L(24) /**< \brief LCDCA signal: SEG39 on PA24 mux F */
+#define MUX_PA24F_LCDCA_SEG39           _L(5)
+#define PINMUX_PA24F_LCDCA_SEG39   ((PIN_PA24F_LCDCA_SEG39 << 16) | MUX_PA24F_LCDCA_SEG39)
+#define GPIO_PA24F_LCDCA_SEG39   _UL(1 << 24)
+/* ========== GPIO definition for USBC peripheral ========== */
+#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L(0)
+#define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
+#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
+#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L(0)
+#define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
+#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+/* ========== GPIO definition for PEVC peripheral ========== */
+#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
+/* ========== GPIO definition for SCIF peripheral ========== */
+#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
+#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
+#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
+#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
+#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
+/* ========== GPIO definition for EIC peripheral ========== */
+#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
+#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
+#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
+#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
+#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
+#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
+#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
+#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
+#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
+#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
+#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+
+#endif /* _SAM4LC4A_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4lc4b.h
+++ b/asf/sam/include/sam4l/pio/sam4lc4b.h
@@ -30,1050 +30,1050 @@
 #define _SAM4LC4B_PIO_
 
 #define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
-#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define GPIO_PA00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PA00 */
 #define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
-#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define GPIO_PA01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PA01 */
 #define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
-#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define GPIO_PA02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PA02 */
 #define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
-#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define GPIO_PA03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PA03 */
 #define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
-#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define GPIO_PA04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PA04 */
 #define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
-#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define GPIO_PA05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PA05 */
 #define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
-#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define GPIO_PA06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PA06 */
 #define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
-#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define GPIO_PA07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PA07 */
 #define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
-#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define GPIO_PA08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PA08 */
 #define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
-#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define GPIO_PA09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PA09 */
 #define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
-#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define GPIO_PA10                _UL_(1 << 10) /**< \brief GPIO Mask  for PA10 */
 #define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
-#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define GPIO_PA11                _UL_(1 << 11) /**< \brief GPIO Mask  for PA11 */
 #define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
-#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define GPIO_PA12                _UL_(1 << 12) /**< \brief GPIO Mask  for PA12 */
 #define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
-#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define GPIO_PA13                _UL_(1 << 13) /**< \brief GPIO Mask  for PA13 */
 #define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
-#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define GPIO_PA14                _UL_(1 << 14) /**< \brief GPIO Mask  for PA14 */
 #define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
-#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define GPIO_PA15                _UL_(1 << 15) /**< \brief GPIO Mask  for PA15 */
 #define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
-#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define GPIO_PA16                _UL_(1 << 16) /**< \brief GPIO Mask  for PA16 */
 #define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
-#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define GPIO_PA17                _UL_(1 << 17) /**< \brief GPIO Mask  for PA17 */
 #define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
-#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define GPIO_PA18                _UL_(1 << 18) /**< \brief GPIO Mask  for PA18 */
 #define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
-#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define GPIO_PA19                _UL_(1 << 19) /**< \brief GPIO Mask  for PA19 */
 #define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
-#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define GPIO_PA20                _UL_(1 << 20) /**< \brief GPIO Mask  for PA20 */
 #define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
-#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define GPIO_PA21                _UL_(1 << 21) /**< \brief GPIO Mask  for PA21 */
 #define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
-#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define GPIO_PA22                _UL_(1 << 22) /**< \brief GPIO Mask  for PA22 */
 #define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
-#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define GPIO_PA23                _UL_(1 << 23) /**< \brief GPIO Mask  for PA23 */
 #define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
-#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define GPIO_PA24                _UL_(1 << 24) /**< \brief GPIO Mask  for PA24 */
 #define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
-#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define GPIO_PA25                _UL_(1 << 25) /**< \brief GPIO Mask  for PA25 */
 #define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
-#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define GPIO_PA26                _UL_(1 << 26) /**< \brief GPIO Mask  for PA26 */
 #define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
-#define GPIO_PB00                _UL(1 <<  0) /**< \brief GPIO Mask  for PB00 */
+#define GPIO_PB00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PB00 */
 #define PIN_PB01                          33  /**< \brief Pin Number for PB01 */
-#define GPIO_PB01                _UL(1 <<  1) /**< \brief GPIO Mask  for PB01 */
+#define GPIO_PB01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PB01 */
 #define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
-#define GPIO_PB02                _UL(1 <<  2) /**< \brief GPIO Mask  for PB02 */
+#define GPIO_PB02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PB02 */
 #define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
-#define GPIO_PB03                _UL(1 <<  3) /**< \brief GPIO Mask  for PB03 */
+#define GPIO_PB03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PB03 */
 #define PIN_PB04                          36  /**< \brief Pin Number for PB04 */
-#define GPIO_PB04                _UL(1 <<  4) /**< \brief GPIO Mask  for PB04 */
+#define GPIO_PB04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PB04 */
 #define PIN_PB05                          37  /**< \brief Pin Number for PB05 */
-#define GPIO_PB05                _UL(1 <<  5) /**< \brief GPIO Mask  for PB05 */
+#define GPIO_PB05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PB05 */
 #define PIN_PB06                          38  /**< \brief Pin Number for PB06 */
-#define GPIO_PB06                _UL(1 <<  6) /**< \brief GPIO Mask  for PB06 */
+#define GPIO_PB06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PB06 */
 #define PIN_PB07                          39  /**< \brief Pin Number for PB07 */
-#define GPIO_PB07                _UL(1 <<  7) /**< \brief GPIO Mask  for PB07 */
+#define GPIO_PB07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PB07 */
 #define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
-#define GPIO_PB08                _UL(1 <<  8) /**< \brief GPIO Mask  for PB08 */
+#define GPIO_PB08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PB08 */
 #define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
-#define GPIO_PB09                _UL(1 <<  9) /**< \brief GPIO Mask  for PB09 */
+#define GPIO_PB09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PB09 */
 #define PIN_PB10                          42  /**< \brief Pin Number for PB10 */
-#define GPIO_PB10                _UL(1 << 10) /**< \brief GPIO Mask  for PB10 */
+#define GPIO_PB10                _UL_(1 << 10) /**< \brief GPIO Mask  for PB10 */
 #define PIN_PB11                          43  /**< \brief Pin Number for PB11 */
-#define GPIO_PB11                _UL(1 << 11) /**< \brief GPIO Mask  for PB11 */
+#define GPIO_PB11                _UL_(1 << 11) /**< \brief GPIO Mask  for PB11 */
 #define PIN_PB12                          44  /**< \brief Pin Number for PB12 */
-#define GPIO_PB12                _UL(1 << 12) /**< \brief GPIO Mask  for PB12 */
+#define GPIO_PB12                _UL_(1 << 12) /**< \brief GPIO Mask  for PB12 */
 #define PIN_PB13                          45  /**< \brief Pin Number for PB13 */
-#define GPIO_PB13                _UL(1 << 13) /**< \brief GPIO Mask  for PB13 */
+#define GPIO_PB13                _UL_(1 << 13) /**< \brief GPIO Mask  for PB13 */
 #define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
-#define GPIO_PB14                _UL(1 << 14) /**< \brief GPIO Mask  for PB14 */
+#define GPIO_PB14                _UL_(1 << 14) /**< \brief GPIO Mask  for PB14 */
 #define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
-#define GPIO_PB15                _UL(1 << 15) /**< \brief GPIO Mask  for PB15 */
+#define GPIO_PB15                _UL_(1 << 15) /**< \brief GPIO Mask  for PB15 */
 /* ========== GPIO definition for TWIMS0 peripheral ========== */
-#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
-#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PIN_PA24B_TWIMS0_TWCK          _L_(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L_(1)
 #define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
-#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
-#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
-#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL_(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L_(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L_(1)
 #define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
-#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+#define GPIO_PA23B_TWIMS0_TWD    _UL_(1 << 23)
 /* ========== GPIO definition for TWIMS1 peripheral ========== */
-#define PIN_PB01A_TWIMS1_TWCK          _L(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
-#define MUX_PB01A_TWIMS1_TWCK           _L(0)
+#define PIN_PB01A_TWIMS1_TWCK          _L_(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
+#define MUX_PB01A_TWIMS1_TWCK           _L_(0)
 #define PINMUX_PB01A_TWIMS1_TWCK   ((PIN_PB01A_TWIMS1_TWCK << 16) | MUX_PB01A_TWIMS1_TWCK)
-#define GPIO_PB01A_TWIMS1_TWCK   _UL(1 <<  1)
-#define PIN_PB00A_TWIMS1_TWD           _L(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
-#define MUX_PB00A_TWIMS1_TWD            _L(0)
+#define GPIO_PB01A_TWIMS1_TWCK   _UL_(1 <<  1)
+#define PIN_PB00A_TWIMS1_TWD           _L_(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
+#define MUX_PB00A_TWIMS1_TWD            _L_(0)
 #define PINMUX_PB00A_TWIMS1_TWD    ((PIN_PB00A_TWIMS1_TWD << 16) | MUX_PB00A_TWIMS1_TWD)
-#define GPIO_PB00A_TWIMS1_TWD    _UL(1 <<  0)
+#define GPIO_PB00A_TWIMS1_TWD    _UL_(1 <<  0)
 /* ========== GPIO definition for TWIMS2 peripheral ========== */
-#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
-#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PIN_PA22E_TWIMS2_TWCK          _L_(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L_(4)
 #define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
-#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
-#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
-#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL_(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L_(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L_(4)
 #define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
-#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+#define GPIO_PA21E_TWIMS2_TWD    _UL_(1 << 21)
 /* ========== GPIO definition for TWIMS3 peripheral ========== */
-#define PIN_PB15C_TWIMS3_TWCK          _L(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
-#define MUX_PB15C_TWIMS3_TWCK           _L(2)
+#define PIN_PB15C_TWIMS3_TWCK          _L_(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
+#define MUX_PB15C_TWIMS3_TWCK           _L_(2)
 #define PINMUX_PB15C_TWIMS3_TWCK   ((PIN_PB15C_TWIMS3_TWCK << 16) | MUX_PB15C_TWIMS3_TWCK)
-#define GPIO_PB15C_TWIMS3_TWCK   _UL(1 << 15)
-#define PIN_PB14C_TWIMS3_TWD           _L(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
-#define MUX_PB14C_TWIMS3_TWD            _L(2)
+#define GPIO_PB15C_TWIMS3_TWCK   _UL_(1 << 15)
+#define PIN_PB14C_TWIMS3_TWD           _L_(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
+#define MUX_PB14C_TWIMS3_TWD            _L_(2)
 #define PINMUX_PB14C_TWIMS3_TWD    ((PIN_PB14C_TWIMS3_TWD << 16) | MUX_PB14C_TWIMS3_TWD)
-#define GPIO_PB14C_TWIMS3_TWD    _UL(1 << 14)
+#define GPIO_PB14C_TWIMS3_TWD    _UL_(1 << 14)
 /* ========== GPIO definition for IISC peripheral ========== */
-#define PIN_PB05D_IISC_IMCK            _L(37) /**< \brief IISC signal: IMCK on PB05 mux D */
-#define MUX_PB05D_IISC_IMCK             _L(3)
+#define PIN_PB05D_IISC_IMCK            _L_(37) /**< \brief IISC signal: IMCK on PB05 mux D */
+#define MUX_PB05D_IISC_IMCK             _L_(3)
 #define PINMUX_PB05D_IISC_IMCK     ((PIN_PB05D_IISC_IMCK << 16) | MUX_PB05D_IISC_IMCK)
-#define GPIO_PB05D_IISC_IMCK     _UL(1 <<  5)
-#define PIN_PB02D_IISC_ISCK            _L(34) /**< \brief IISC signal: ISCK on PB02 mux D */
-#define MUX_PB02D_IISC_ISCK             _L(3)
+#define GPIO_PB05D_IISC_IMCK     _UL_(1 <<  5)
+#define PIN_PB02D_IISC_ISCK            _L_(34) /**< \brief IISC signal: ISCK on PB02 mux D */
+#define MUX_PB02D_IISC_ISCK             _L_(3)
 #define PINMUX_PB02D_IISC_ISCK     ((PIN_PB02D_IISC_ISCK << 16) | MUX_PB02D_IISC_ISCK)
-#define GPIO_PB02D_IISC_ISCK     _UL(1 <<  2)
-#define PIN_PB03D_IISC_ISDI            _L(35) /**< \brief IISC signal: ISDI on PB03 mux D */
-#define MUX_PB03D_IISC_ISDI             _L(3)
+#define GPIO_PB02D_IISC_ISCK     _UL_(1 <<  2)
+#define PIN_PB03D_IISC_ISDI            _L_(35) /**< \brief IISC signal: ISDI on PB03 mux D */
+#define MUX_PB03D_IISC_ISDI             _L_(3)
 #define PINMUX_PB03D_IISC_ISDI     ((PIN_PB03D_IISC_ISDI << 16) | MUX_PB03D_IISC_ISDI)
-#define GPIO_PB03D_IISC_ISDI     _UL(1 <<  3)
-#define PIN_PB04D_IISC_ISDO            _L(36) /**< \brief IISC signal: ISDO on PB04 mux D */
-#define MUX_PB04D_IISC_ISDO             _L(3)
+#define GPIO_PB03D_IISC_ISDI     _UL_(1 <<  3)
+#define PIN_PB04D_IISC_ISDO            _L_(36) /**< \brief IISC signal: ISDO on PB04 mux D */
+#define MUX_PB04D_IISC_ISDO             _L_(3)
 #define PINMUX_PB04D_IISC_ISDO     ((PIN_PB04D_IISC_ISDO << 16) | MUX_PB04D_IISC_ISDO)
-#define GPIO_PB04D_IISC_ISDO     _UL(1 <<  4)
-#define PIN_PB06D_IISC_IWS             _L(38) /**< \brief IISC signal: IWS on PB06 mux D */
-#define MUX_PB06D_IISC_IWS              _L(3)
+#define GPIO_PB04D_IISC_ISDO     _UL_(1 <<  4)
+#define PIN_PB06D_IISC_IWS             _L_(38) /**< \brief IISC signal: IWS on PB06 mux D */
+#define MUX_PB06D_IISC_IWS              _L_(3)
 #define PINMUX_PB06D_IISC_IWS      ((PIN_PB06D_IISC_IWS << 16) | MUX_PB06D_IISC_IWS)
-#define GPIO_PB06D_IISC_IWS      _UL(1 <<  6)
+#define GPIO_PB06D_IISC_IWS      _UL_(1 <<  6)
 /* ========== GPIO definition for SPI peripheral ========== */
-#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
-#define MUX_PA03B_SPI_MISO              _L(1)
+#define PIN_PA03B_SPI_MISO              _L_(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L_(1)
 #define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
-#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
-#define PIN_PB14B_SPI_MISO             _L(46) /**< \brief SPI signal: MISO on PB14 mux B */
-#define MUX_PB14B_SPI_MISO              _L(1)
+#define GPIO_PA03B_SPI_MISO      _UL_(1 <<  3)
+#define PIN_PB14B_SPI_MISO             _L_(46) /**< \brief SPI signal: MISO on PB14 mux B */
+#define MUX_PB14B_SPI_MISO              _L_(1)
 #define PINMUX_PB14B_SPI_MISO      ((PIN_PB14B_SPI_MISO << 16) | MUX_PB14B_SPI_MISO)
-#define GPIO_PB14B_SPI_MISO      _UL(1 << 14)
-#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
-#define MUX_PA21A_SPI_MISO              _L(0)
+#define GPIO_PB14B_SPI_MISO      _UL_(1 << 14)
+#define PIN_PA21A_SPI_MISO             _L_(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L_(0)
 #define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
-#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
-#define PIN_PB15B_SPI_MOSI             _L(47) /**< \brief SPI signal: MOSI on PB15 mux B */
-#define MUX_PB15B_SPI_MOSI              _L(1)
+#define GPIO_PA21A_SPI_MISO      _UL_(1 << 21)
+#define PIN_PB15B_SPI_MOSI             _L_(47) /**< \brief SPI signal: MOSI on PB15 mux B */
+#define MUX_PB15B_SPI_MOSI              _L_(1)
 #define PINMUX_PB15B_SPI_MOSI      ((PIN_PB15B_SPI_MOSI << 16) | MUX_PB15B_SPI_MOSI)
-#define GPIO_PB15B_SPI_MOSI      _UL(1 << 15)
-#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
-#define MUX_PA22A_SPI_MOSI              _L(0)
+#define GPIO_PB15B_SPI_MOSI      _UL_(1 << 15)
+#define PIN_PA22A_SPI_MOSI             _L_(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L_(0)
 #define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
-#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
-#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
-#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define GPIO_PA22A_SPI_MOSI      _UL_(1 << 22)
+#define PIN_PA02B_SPI_NPCS0             _L_(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L_(1)
 #define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
-#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
-#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
-#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define GPIO_PA02B_SPI_NPCS0     _UL_(1 <<  2)
+#define PIN_PA24A_SPI_NPCS0            _L_(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L_(0)
 #define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
-#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
-#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
-#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define GPIO_PA24A_SPI_NPCS0     _UL_(1 << 24)
+#define PIN_PA13C_SPI_NPCS1            _L_(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L_(2)
 #define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
-#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PB13B_SPI_NPCS1            _L(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
-#define MUX_PB13B_SPI_NPCS1             _L(1)
+#define GPIO_PA13C_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PB13B_SPI_NPCS1            _L_(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
+#define MUX_PB13B_SPI_NPCS1             _L_(1)
 #define PINMUX_PB13B_SPI_NPCS1     ((PIN_PB13B_SPI_NPCS1 << 16) | MUX_PB13B_SPI_NPCS1)
-#define GPIO_PB13B_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
-#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define GPIO_PB13B_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PA14C_SPI_NPCS2            _L_(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L_(2)
 #define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
-#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
-#define PIN_PB11B_SPI_NPCS2            _L(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
-#define MUX_PB11B_SPI_NPCS2             _L(1)
+#define GPIO_PA14C_SPI_NPCS2     _UL_(1 << 14)
+#define PIN_PB11B_SPI_NPCS2            _L_(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
+#define MUX_PB11B_SPI_NPCS2             _L_(1)
 #define PINMUX_PB11B_SPI_NPCS2     ((PIN_PB11B_SPI_NPCS2 << 16) | MUX_PB11B_SPI_NPCS2)
-#define GPIO_PB11B_SPI_NPCS2     _UL(1 << 11)
-#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
-#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define GPIO_PB11B_SPI_NPCS2     _UL_(1 << 11)
+#define PIN_PA15C_SPI_NPCS3            _L_(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L_(2)
 #define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
-#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
-#define PIN_PB12B_SPI_NPCS3            _L(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
-#define MUX_PB12B_SPI_NPCS3             _L(1)
+#define GPIO_PA15C_SPI_NPCS3     _UL_(1 << 15)
+#define PIN_PB12B_SPI_NPCS3            _L_(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
+#define MUX_PB12B_SPI_NPCS3             _L_(1)
 #define PINMUX_PB12B_SPI_NPCS3     ((PIN_PB12B_SPI_NPCS3 << 16) | MUX_PB12B_SPI_NPCS3)
-#define GPIO_PB12B_SPI_NPCS3     _UL(1 << 12)
-#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
-#define MUX_PA23A_SPI_SCK               _L(0)
+#define GPIO_PB12B_SPI_NPCS3     _UL_(1 << 12)
+#define PIN_PA23A_SPI_SCK              _L_(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L_(0)
 #define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
-#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
+#define GPIO_PA23A_SPI_SCK       _UL_(1 << 23)
 /* ========== GPIO definition for TC0 peripheral ========== */
-#define PIN_PB07D_TC0_A0               _L(39) /**< \brief TC0 signal: A0 on PB07 mux D */
-#define MUX_PB07D_TC0_A0                _L(3)
+#define PIN_PB07D_TC0_A0               _L_(39) /**< \brief TC0 signal: A0 on PB07 mux D */
+#define MUX_PB07D_TC0_A0                _L_(3)
 #define PINMUX_PB07D_TC0_A0        ((PIN_PB07D_TC0_A0 << 16) | MUX_PB07D_TC0_A0)
-#define GPIO_PB07D_TC0_A0        _UL(1 <<  7)
-#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
-#define MUX_PA08B_TC0_A0                _L(1)
+#define GPIO_PB07D_TC0_A0        _UL_(1 <<  7)
+#define PIN_PA08B_TC0_A0                _L_(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L_(1)
 #define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
-#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
-#define PIN_PB09D_TC0_A1               _L(41) /**< \brief TC0 signal: A1 on PB09 mux D */
-#define MUX_PB09D_TC0_A1                _L(3)
+#define GPIO_PA08B_TC0_A0        _UL_(1 <<  8)
+#define PIN_PB09D_TC0_A1               _L_(41) /**< \brief TC0 signal: A1 on PB09 mux D */
+#define MUX_PB09D_TC0_A1                _L_(3)
 #define PINMUX_PB09D_TC0_A1        ((PIN_PB09D_TC0_A1 << 16) | MUX_PB09D_TC0_A1)
-#define GPIO_PB09D_TC0_A1        _UL(1 <<  9)
-#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
-#define MUX_PA10B_TC0_A1                _L(1)
+#define GPIO_PB09D_TC0_A1        _UL_(1 <<  9)
+#define PIN_PA10B_TC0_A1               _L_(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L_(1)
 #define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
-#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
-#define PIN_PB11D_TC0_A2               _L(43) /**< \brief TC0 signal: A2 on PB11 mux D */
-#define MUX_PB11D_TC0_A2                _L(3)
+#define GPIO_PA10B_TC0_A1        _UL_(1 << 10)
+#define PIN_PB11D_TC0_A2               _L_(43) /**< \brief TC0 signal: A2 on PB11 mux D */
+#define MUX_PB11D_TC0_A2                _L_(3)
 #define PINMUX_PB11D_TC0_A2        ((PIN_PB11D_TC0_A2 << 16) | MUX_PB11D_TC0_A2)
-#define GPIO_PB11D_TC0_A2        _UL(1 << 11)
-#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
-#define MUX_PA12B_TC0_A2                _L(1)
+#define GPIO_PB11D_TC0_A2        _UL_(1 << 11)
+#define PIN_PA12B_TC0_A2               _L_(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L_(1)
 #define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
-#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
-#define PIN_PB08D_TC0_B0               _L(40) /**< \brief TC0 signal: B0 on PB08 mux D */
-#define MUX_PB08D_TC0_B0                _L(3)
+#define GPIO_PA12B_TC0_A2        _UL_(1 << 12)
+#define PIN_PB08D_TC0_B0               _L_(40) /**< \brief TC0 signal: B0 on PB08 mux D */
+#define MUX_PB08D_TC0_B0                _L_(3)
 #define PINMUX_PB08D_TC0_B0        ((PIN_PB08D_TC0_B0 << 16) | MUX_PB08D_TC0_B0)
-#define GPIO_PB08D_TC0_B0        _UL(1 <<  8)
-#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
-#define MUX_PA09B_TC0_B0                _L(1)
+#define GPIO_PB08D_TC0_B0        _UL_(1 <<  8)
+#define PIN_PA09B_TC0_B0                _L_(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L_(1)
 #define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
-#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
-#define PIN_PB10D_TC0_B1               _L(42) /**< \brief TC0 signal: B1 on PB10 mux D */
-#define MUX_PB10D_TC0_B1                _L(3)
+#define GPIO_PA09B_TC0_B0        _UL_(1 <<  9)
+#define PIN_PB10D_TC0_B1               _L_(42) /**< \brief TC0 signal: B1 on PB10 mux D */
+#define MUX_PB10D_TC0_B1                _L_(3)
 #define PINMUX_PB10D_TC0_B1        ((PIN_PB10D_TC0_B1 << 16) | MUX_PB10D_TC0_B1)
-#define GPIO_PB10D_TC0_B1        _UL(1 << 10)
-#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
-#define MUX_PA11B_TC0_B1                _L(1)
+#define GPIO_PB10D_TC0_B1        _UL_(1 << 10)
+#define PIN_PA11B_TC0_B1               _L_(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L_(1)
 #define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
-#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
-#define PIN_PB12D_TC0_B2               _L(44) /**< \brief TC0 signal: B2 on PB12 mux D */
-#define MUX_PB12D_TC0_B2                _L(3)
+#define GPIO_PA11B_TC0_B1        _UL_(1 << 11)
+#define PIN_PB12D_TC0_B2               _L_(44) /**< \brief TC0 signal: B2 on PB12 mux D */
+#define MUX_PB12D_TC0_B2                _L_(3)
 #define PINMUX_PB12D_TC0_B2        ((PIN_PB12D_TC0_B2 << 16) | MUX_PB12D_TC0_B2)
-#define GPIO_PB12D_TC0_B2        _UL(1 << 12)
-#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
-#define MUX_PA13B_TC0_B2                _L(1)
+#define GPIO_PB12D_TC0_B2        _UL_(1 << 12)
+#define PIN_PA13B_TC0_B2               _L_(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L_(1)
 #define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
-#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
-#define PIN_PB13D_TC0_CLK0             _L(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
-#define MUX_PB13D_TC0_CLK0              _L(3)
+#define GPIO_PA13B_TC0_B2        _UL_(1 << 13)
+#define PIN_PB13D_TC0_CLK0             _L_(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
+#define MUX_PB13D_TC0_CLK0              _L_(3)
 #define PINMUX_PB13D_TC0_CLK0      ((PIN_PB13D_TC0_CLK0 << 16) | MUX_PB13D_TC0_CLK0)
-#define GPIO_PB13D_TC0_CLK0      _UL(1 << 13)
-#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
-#define MUX_PA14B_TC0_CLK0              _L(1)
+#define GPIO_PB13D_TC0_CLK0      _UL_(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L_(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L_(1)
 #define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
-#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
-#define PIN_PB14D_TC0_CLK1             _L(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
-#define MUX_PB14D_TC0_CLK1              _L(3)
+#define GPIO_PA14B_TC0_CLK0      _UL_(1 << 14)
+#define PIN_PB14D_TC0_CLK1             _L_(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
+#define MUX_PB14D_TC0_CLK1              _L_(3)
 #define PINMUX_PB14D_TC0_CLK1      ((PIN_PB14D_TC0_CLK1 << 16) | MUX_PB14D_TC0_CLK1)
-#define GPIO_PB14D_TC0_CLK1      _UL(1 << 14)
-#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
-#define MUX_PA15B_TC0_CLK1              _L(1)
+#define GPIO_PB14D_TC0_CLK1      _UL_(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L_(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L_(1)
 #define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
-#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
-#define PIN_PB15D_TC0_CLK2             _L(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
-#define MUX_PB15D_TC0_CLK2              _L(3)
+#define GPIO_PA15B_TC0_CLK1      _UL_(1 << 15)
+#define PIN_PB15D_TC0_CLK2             _L_(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
+#define MUX_PB15D_TC0_CLK2              _L_(3)
 #define PINMUX_PB15D_TC0_CLK2      ((PIN_PB15D_TC0_CLK2 << 16) | MUX_PB15D_TC0_CLK2)
-#define GPIO_PB15D_TC0_CLK2      _UL(1 << 15)
-#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
-#define MUX_PA16B_TC0_CLK2              _L(1)
+#define GPIO_PB15D_TC0_CLK2      _UL_(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L_(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L_(1)
 #define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
-#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+#define GPIO_PA16B_TC0_CLK2      _UL_(1 << 16)
 /* ========== GPIO definition for USART0 peripheral ========== */
-#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
-#define MUX_PA04B_USART0_CLK            _L(1)
+#define PIN_PA04B_USART0_CLK            _L_(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L_(1)
 #define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
-#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
-#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
-#define MUX_PA10A_USART0_CLK            _L(0)
+#define GPIO_PA04B_USART0_CLK    _UL_(1 <<  4)
+#define PIN_PA10A_USART0_CLK           _L_(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L_(0)
 #define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
-#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
-#define PIN_PB13A_USART0_CLK           _L(45) /**< \brief USART0 signal: CLK on PB13 mux A */
-#define MUX_PB13A_USART0_CLK            _L(0)
+#define GPIO_PA10A_USART0_CLK    _UL_(1 << 10)
+#define PIN_PB13A_USART0_CLK           _L_(45) /**< \brief USART0 signal: CLK on PB13 mux A */
+#define MUX_PB13A_USART0_CLK            _L_(0)
 #define PINMUX_PB13A_USART0_CLK    ((PIN_PB13A_USART0_CLK << 16) | MUX_PB13A_USART0_CLK)
-#define GPIO_PB13A_USART0_CLK    _UL(1 << 13)
-#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
-#define MUX_PA09A_USART0_CTS            _L(0)
+#define GPIO_PB13A_USART0_CLK    _UL_(1 << 13)
+#define PIN_PA09A_USART0_CTS            _L_(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L_(0)
 #define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
-#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
-#define PIN_PB11A_USART0_CTS           _L(43) /**< \brief USART0 signal: CTS on PB11 mux A */
-#define MUX_PB11A_USART0_CTS            _L(0)
+#define GPIO_PA09A_USART0_CTS    _UL_(1 <<  9)
+#define PIN_PB11A_USART0_CTS           _L_(43) /**< \brief USART0 signal: CTS on PB11 mux A */
+#define MUX_PB11A_USART0_CTS            _L_(0)
 #define PINMUX_PB11A_USART0_CTS    ((PIN_PB11A_USART0_CTS << 16) | MUX_PB11A_USART0_CTS)
-#define GPIO_PB11A_USART0_CTS    _UL(1 << 11)
-#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
-#define MUX_PA06B_USART0_RTS            _L(1)
+#define GPIO_PB11A_USART0_CTS    _UL_(1 << 11)
+#define PIN_PA06B_USART0_RTS            _L_(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L_(1)
 #define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
-#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
-#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
-#define MUX_PA08A_USART0_RTS            _L(0)
+#define GPIO_PA06B_USART0_RTS    _UL_(1 <<  6)
+#define PIN_PA08A_USART0_RTS            _L_(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L_(0)
 #define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
-#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
-#define PIN_PB12A_USART0_RTS           _L(44) /**< \brief USART0 signal: RTS on PB12 mux A */
-#define MUX_PB12A_USART0_RTS            _L(0)
+#define GPIO_PA08A_USART0_RTS    _UL_(1 <<  8)
+#define PIN_PB12A_USART0_RTS           _L_(44) /**< \brief USART0 signal: RTS on PB12 mux A */
+#define MUX_PB12A_USART0_RTS            _L_(0)
 #define PINMUX_PB12A_USART0_RTS    ((PIN_PB12A_USART0_RTS << 16) | MUX_PB12A_USART0_RTS)
-#define GPIO_PB12A_USART0_RTS    _UL(1 << 12)
-#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
-#define MUX_PA05B_USART0_RXD            _L(1)
+#define GPIO_PB12A_USART0_RTS    _UL_(1 << 12)
+#define PIN_PA05B_USART0_RXD            _L_(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L_(1)
 #define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
-#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
-#define PIN_PB00B_USART0_RXD           _L(32) /**< \brief USART0 signal: RXD on PB00 mux B */
-#define MUX_PB00B_USART0_RXD            _L(1)
+#define GPIO_PA05B_USART0_RXD    _UL_(1 <<  5)
+#define PIN_PB00B_USART0_RXD           _L_(32) /**< \brief USART0 signal: RXD on PB00 mux B */
+#define MUX_PB00B_USART0_RXD            _L_(1)
 #define PINMUX_PB00B_USART0_RXD    ((PIN_PB00B_USART0_RXD << 16) | MUX_PB00B_USART0_RXD)
-#define GPIO_PB00B_USART0_RXD    _UL(1 <<  0)
-#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
-#define MUX_PA11A_USART0_RXD            _L(0)
+#define GPIO_PB00B_USART0_RXD    _UL_(1 <<  0)
+#define PIN_PA11A_USART0_RXD           _L_(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L_(0)
 #define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
-#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
-#define PIN_PB14A_USART0_RXD           _L(46) /**< \brief USART0 signal: RXD on PB14 mux A */
-#define MUX_PB14A_USART0_RXD            _L(0)
+#define GPIO_PA11A_USART0_RXD    _UL_(1 << 11)
+#define PIN_PB14A_USART0_RXD           _L_(46) /**< \brief USART0 signal: RXD on PB14 mux A */
+#define MUX_PB14A_USART0_RXD            _L_(0)
 #define PINMUX_PB14A_USART0_RXD    ((PIN_PB14A_USART0_RXD << 16) | MUX_PB14A_USART0_RXD)
-#define GPIO_PB14A_USART0_RXD    _UL(1 << 14)
-#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
-#define MUX_PA07B_USART0_TXD            _L(1)
+#define GPIO_PB14A_USART0_RXD    _UL_(1 << 14)
+#define PIN_PA07B_USART0_TXD            _L_(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L_(1)
 #define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
-#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
-#define PIN_PB01B_USART0_TXD           _L(33) /**< \brief USART0 signal: TXD on PB01 mux B */
-#define MUX_PB01B_USART0_TXD            _L(1)
+#define GPIO_PA07B_USART0_TXD    _UL_(1 <<  7)
+#define PIN_PB01B_USART0_TXD           _L_(33) /**< \brief USART0 signal: TXD on PB01 mux B */
+#define MUX_PB01B_USART0_TXD            _L_(1)
 #define PINMUX_PB01B_USART0_TXD    ((PIN_PB01B_USART0_TXD << 16) | MUX_PB01B_USART0_TXD)
-#define GPIO_PB01B_USART0_TXD    _UL(1 <<  1)
-#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
-#define MUX_PA12A_USART0_TXD            _L(0)
+#define GPIO_PB01B_USART0_TXD    _UL_(1 <<  1)
+#define PIN_PA12A_USART0_TXD           _L_(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L_(0)
 #define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
-#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
-#define PIN_PB15A_USART0_TXD           _L(47) /**< \brief USART0 signal: TXD on PB15 mux A */
-#define MUX_PB15A_USART0_TXD            _L(0)
+#define GPIO_PA12A_USART0_TXD    _UL_(1 << 12)
+#define PIN_PB15A_USART0_TXD           _L_(47) /**< \brief USART0 signal: TXD on PB15 mux A */
+#define MUX_PB15A_USART0_TXD            _L_(0)
 #define PINMUX_PB15A_USART0_TXD    ((PIN_PB15A_USART0_TXD << 16) | MUX_PB15A_USART0_TXD)
-#define GPIO_PB15A_USART0_TXD    _UL(1 << 15)
+#define GPIO_PB15A_USART0_TXD    _UL_(1 << 15)
 /* ========== GPIO definition for USART1 peripheral ========== */
-#define PIN_PB03B_USART1_CLK           _L(35) /**< \brief USART1 signal: CLK on PB03 mux B */
-#define MUX_PB03B_USART1_CLK            _L(1)
+#define PIN_PB03B_USART1_CLK           _L_(35) /**< \brief USART1 signal: CLK on PB03 mux B */
+#define MUX_PB03B_USART1_CLK            _L_(1)
 #define PINMUX_PB03B_USART1_CLK    ((PIN_PB03B_USART1_CLK << 16) | MUX_PB03B_USART1_CLK)
-#define GPIO_PB03B_USART1_CLK    _UL(1 <<  3)
-#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
-#define MUX_PA14A_USART1_CLK            _L(0)
+#define GPIO_PB03B_USART1_CLK    _UL_(1 <<  3)
+#define PIN_PA14A_USART1_CLK           _L_(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L_(0)
 #define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
-#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
-#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
-#define MUX_PA21B_USART1_CTS            _L(1)
+#define GPIO_PA14A_USART1_CLK    _UL_(1 << 14)
+#define PIN_PA21B_USART1_CTS           _L_(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L_(1)
 #define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
-#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
-#define PIN_PB02B_USART1_RTS           _L(34) /**< \brief USART1 signal: RTS on PB02 mux B */
-#define MUX_PB02B_USART1_RTS            _L(1)
+#define GPIO_PA21B_USART1_CTS    _UL_(1 << 21)
+#define PIN_PB02B_USART1_RTS           _L_(34) /**< \brief USART1 signal: RTS on PB02 mux B */
+#define MUX_PB02B_USART1_RTS            _L_(1)
 #define PINMUX_PB02B_USART1_RTS    ((PIN_PB02B_USART1_RTS << 16) | MUX_PB02B_USART1_RTS)
-#define GPIO_PB02B_USART1_RTS    _UL(1 <<  2)
-#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
-#define MUX_PA13A_USART1_RTS            _L(0)
+#define GPIO_PB02B_USART1_RTS    _UL_(1 <<  2)
+#define PIN_PA13A_USART1_RTS           _L_(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L_(0)
 #define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
-#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
-#define PIN_PB04B_USART1_RXD           _L(36) /**< \brief USART1 signal: RXD on PB04 mux B */
-#define MUX_PB04B_USART1_RXD            _L(1)
+#define GPIO_PA13A_USART1_RTS    _UL_(1 << 13)
+#define PIN_PB04B_USART1_RXD           _L_(36) /**< \brief USART1 signal: RXD on PB04 mux B */
+#define MUX_PB04B_USART1_RXD            _L_(1)
 #define PINMUX_PB04B_USART1_RXD    ((PIN_PB04B_USART1_RXD << 16) | MUX_PB04B_USART1_RXD)
-#define GPIO_PB04B_USART1_RXD    _UL(1 <<  4)
-#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
-#define MUX_PA15A_USART1_RXD            _L(0)
+#define GPIO_PB04B_USART1_RXD    _UL_(1 <<  4)
+#define PIN_PA15A_USART1_RXD           _L_(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L_(0)
 #define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
-#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
-#define PIN_PB05B_USART1_TXD           _L(37) /**< \brief USART1 signal: TXD on PB05 mux B */
-#define MUX_PB05B_USART1_TXD            _L(1)
+#define GPIO_PA15A_USART1_RXD    _UL_(1 << 15)
+#define PIN_PB05B_USART1_TXD           _L_(37) /**< \brief USART1 signal: TXD on PB05 mux B */
+#define MUX_PB05B_USART1_TXD            _L_(1)
 #define PINMUX_PB05B_USART1_TXD    ((PIN_PB05B_USART1_TXD << 16) | MUX_PB05B_USART1_TXD)
-#define GPIO_PB05B_USART1_TXD    _UL(1 <<  5)
-#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
-#define MUX_PA16A_USART1_TXD            _L(0)
+#define GPIO_PB05B_USART1_TXD    _UL_(1 <<  5)
+#define PIN_PA16A_USART1_TXD           _L_(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L_(0)
 #define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
-#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+#define GPIO_PA16A_USART1_TXD    _UL_(1 << 16)
 /* ========== GPIO definition for USART2 peripheral ========== */
-#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
-#define MUX_PA18A_USART2_CLK            _L(0)
+#define PIN_PA18A_USART2_CLK           _L_(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L_(0)
 #define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
-#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
-#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
-#define MUX_PA22B_USART2_CTS            _L(1)
+#define GPIO_PA18A_USART2_CLK    _UL_(1 << 18)
+#define PIN_PA22B_USART2_CTS           _L_(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L_(1)
 #define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
-#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
-#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
-#define MUX_PA17A_USART2_RTS            _L(0)
+#define GPIO_PA22B_USART2_CTS    _UL_(1 << 22)
+#define PIN_PA17A_USART2_RTS           _L_(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L_(0)
 #define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
-#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
-#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
-#define MUX_PA25B_USART2_RXD            _L(1)
+#define GPIO_PA17A_USART2_RTS    _UL_(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L_(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L_(1)
 #define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
-#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
-#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
-#define MUX_PA19A_USART2_RXD            _L(0)
+#define GPIO_PA25B_USART2_RXD    _UL_(1 << 25)
+#define PIN_PA19A_USART2_RXD           _L_(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L_(0)
 #define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
-#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
-#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
-#define MUX_PA26B_USART2_TXD            _L(1)
+#define GPIO_PA19A_USART2_RXD    _UL_(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L_(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L_(1)
 #define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
-#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
-#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
-#define MUX_PA20A_USART2_TXD            _L(0)
+#define GPIO_PA26B_USART2_TXD    _UL_(1 << 26)
+#define PIN_PA20A_USART2_TXD           _L_(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L_(0)
 #define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
-#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+#define GPIO_PA20A_USART2_TXD    _UL_(1 << 20)
 /* ========== GPIO definition for USART3 peripheral ========== */
-#define PIN_PB08A_USART3_CLK           _L(40) /**< \brief USART3 signal: CLK on PB08 mux A */
-#define MUX_PB08A_USART3_CLK            _L(0)
+#define PIN_PB08A_USART3_CLK           _L_(40) /**< \brief USART3 signal: CLK on PB08 mux A */
+#define MUX_PB08A_USART3_CLK            _L_(0)
 #define PINMUX_PB08A_USART3_CLK    ((PIN_PB08A_USART3_CLK << 16) | MUX_PB08A_USART3_CLK)
-#define GPIO_PB08A_USART3_CLK    _UL(1 <<  8)
-#define PIN_PB07A_USART3_CTS           _L(39) /**< \brief USART3 signal: CTS on PB07 mux A */
-#define MUX_PB07A_USART3_CTS            _L(0)
+#define GPIO_PB08A_USART3_CLK    _UL_(1 <<  8)
+#define PIN_PB07A_USART3_CTS           _L_(39) /**< \brief USART3 signal: CTS on PB07 mux A */
+#define MUX_PB07A_USART3_CTS            _L_(0)
 #define PINMUX_PB07A_USART3_CTS    ((PIN_PB07A_USART3_CTS << 16) | MUX_PB07A_USART3_CTS)
-#define GPIO_PB07A_USART3_CTS    _UL(1 <<  7)
-#define PIN_PB06A_USART3_RTS           _L(38) /**< \brief USART3 signal: RTS on PB06 mux A */
-#define MUX_PB06A_USART3_RTS            _L(0)
+#define GPIO_PB07A_USART3_CTS    _UL_(1 <<  7)
+#define PIN_PB06A_USART3_RTS           _L_(38) /**< \brief USART3 signal: RTS on PB06 mux A */
+#define MUX_PB06A_USART3_RTS            _L_(0)
 #define PINMUX_PB06A_USART3_RTS    ((PIN_PB06A_USART3_RTS << 16) | MUX_PB06A_USART3_RTS)
-#define GPIO_PB06A_USART3_RTS    _UL(1 <<  6)
-#define PIN_PB09A_USART3_RXD           _L(41) /**< \brief USART3 signal: RXD on PB09 mux A */
-#define MUX_PB09A_USART3_RXD            _L(0)
+#define GPIO_PB06A_USART3_RTS    _UL_(1 <<  6)
+#define PIN_PB09A_USART3_RXD           _L_(41) /**< \brief USART3 signal: RXD on PB09 mux A */
+#define MUX_PB09A_USART3_RXD            _L_(0)
 #define PINMUX_PB09A_USART3_RXD    ((PIN_PB09A_USART3_RXD << 16) | MUX_PB09A_USART3_RXD)
-#define GPIO_PB09A_USART3_RXD    _UL(1 <<  9)
-#define PIN_PB10A_USART3_TXD           _L(42) /**< \brief USART3 signal: TXD on PB10 mux A */
-#define MUX_PB10A_USART3_TXD            _L(0)
+#define GPIO_PB09A_USART3_RXD    _UL_(1 <<  9)
+#define PIN_PB10A_USART3_TXD           _L_(42) /**< \brief USART3 signal: TXD on PB10 mux A */
+#define MUX_PB10A_USART3_TXD            _L_(0)
 #define PINMUX_PB10A_USART3_TXD    ((PIN_PB10A_USART3_TXD << 16) | MUX_PB10A_USART3_TXD)
-#define GPIO_PB10A_USART3_TXD    _UL(1 << 10)
+#define GPIO_PB10A_USART3_TXD    _UL_(1 << 10)
 /* ========== GPIO definition for ADCIFE peripheral ========== */
-#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
-#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PIN_PA04A_ADCIFE_AD0            _L_(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L_(0)
 #define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
-#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
-#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
-#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL_(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L_(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L_(0)
 #define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
-#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
-#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
-#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define GPIO_PA05A_ADCIFE_AD1    _UL_(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L_(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L_(0)
 #define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
-#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
-#define PIN_PB02A_ADCIFE_AD3           _L(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
-#define MUX_PB02A_ADCIFE_AD3            _L(0)
+#define GPIO_PA07A_ADCIFE_AD2    _UL_(1 <<  7)
+#define PIN_PB02A_ADCIFE_AD3           _L_(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
+#define MUX_PB02A_ADCIFE_AD3            _L_(0)
 #define PINMUX_PB02A_ADCIFE_AD3    ((PIN_PB02A_ADCIFE_AD3 << 16) | MUX_PB02A_ADCIFE_AD3)
-#define GPIO_PB02A_ADCIFE_AD3    _UL(1 <<  2)
-#define PIN_PB03A_ADCIFE_AD4           _L(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
-#define MUX_PB03A_ADCIFE_AD4            _L(0)
+#define GPIO_PB02A_ADCIFE_AD3    _UL_(1 <<  2)
+#define PIN_PB03A_ADCIFE_AD4           _L_(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
+#define MUX_PB03A_ADCIFE_AD4            _L_(0)
 #define PINMUX_PB03A_ADCIFE_AD4    ((PIN_PB03A_ADCIFE_AD4 << 16) | MUX_PB03A_ADCIFE_AD4)
-#define GPIO_PB03A_ADCIFE_AD4    _UL(1 <<  3)
-#define PIN_PB04A_ADCIFE_AD5           _L(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
-#define MUX_PB04A_ADCIFE_AD5            _L(0)
+#define GPIO_PB03A_ADCIFE_AD4    _UL_(1 <<  3)
+#define PIN_PB04A_ADCIFE_AD5           _L_(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
+#define MUX_PB04A_ADCIFE_AD5            _L_(0)
 #define PINMUX_PB04A_ADCIFE_AD5    ((PIN_PB04A_ADCIFE_AD5 << 16) | MUX_PB04A_ADCIFE_AD5)
-#define GPIO_PB04A_ADCIFE_AD5    _UL(1 <<  4)
-#define PIN_PB05A_ADCIFE_AD6           _L(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
-#define MUX_PB05A_ADCIFE_AD6            _L(0)
+#define GPIO_PB04A_ADCIFE_AD5    _UL_(1 <<  4)
+#define PIN_PB05A_ADCIFE_AD6           _L_(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
+#define MUX_PB05A_ADCIFE_AD6            _L_(0)
 #define PINMUX_PB05A_ADCIFE_AD6    ((PIN_PB05A_ADCIFE_AD6 << 16) | MUX_PB05A_ADCIFE_AD6)
-#define GPIO_PB05A_ADCIFE_AD6    _UL(1 <<  5)
-#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
-#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define GPIO_PB05A_ADCIFE_AD6    _UL_(1 <<  5)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L_(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L_(4)
 #define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
-#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL_(1 <<  5)
 /* ========== GPIO definition for DACC peripheral ========== */
-#define PIN_PB04E_DACC_EXT_TRIG0       _L(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
-#define MUX_PB04E_DACC_EXT_TRIG0        _L(4)
+#define PIN_PB04E_DACC_EXT_TRIG0       _L_(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
+#define MUX_PB04E_DACC_EXT_TRIG0        _L_(4)
 #define PINMUX_PB04E_DACC_EXT_TRIG0  ((PIN_PB04E_DACC_EXT_TRIG0 << 16) | MUX_PB04E_DACC_EXT_TRIG0)
-#define GPIO_PB04E_DACC_EXT_TRIG0  _UL(1 <<  4)
-#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
-#define MUX_PA06A_DACC_VOUT             _L(0)
+#define GPIO_PB04E_DACC_EXT_TRIG0  _UL_(1 <<  4)
+#define PIN_PA06A_DACC_VOUT             _L_(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L_(0)
 #define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
-#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+#define GPIO_PA06A_DACC_VOUT     _UL_(1 <<  6)
 /* ========== GPIO definition for ACIFC peripheral ========== */
-#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
-#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PIN_PA06E_ACIFC_ACAN0           _L_(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L_(4)
 #define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
-#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
-#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
-#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL_(1 <<  6)
+#define PIN_PA07E_ACIFC_ACAP0           _L_(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L_(4)
 #define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
-#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
-#define PIN_PB02E_ACIFC_ACBN0          _L(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
-#define MUX_PB02E_ACIFC_ACBN0           _L(4)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL_(1 <<  7)
+#define PIN_PB02E_ACIFC_ACBN0          _L_(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
+#define MUX_PB02E_ACIFC_ACBN0           _L_(4)
 #define PINMUX_PB02E_ACIFC_ACBN0   ((PIN_PB02E_ACIFC_ACBN0 << 16) | MUX_PB02E_ACIFC_ACBN0)
-#define GPIO_PB02E_ACIFC_ACBN0   _UL(1 <<  2)
-#define PIN_PB03E_ACIFC_ACBP0          _L(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
-#define MUX_PB03E_ACIFC_ACBP0           _L(4)
+#define GPIO_PB02E_ACIFC_ACBN0   _UL_(1 <<  2)
+#define PIN_PB03E_ACIFC_ACBP0          _L_(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
+#define MUX_PB03E_ACIFC_ACBP0           _L_(4)
 #define PINMUX_PB03E_ACIFC_ACBP0   ((PIN_PB03E_ACIFC_ACBP0 << 16) | MUX_PB03E_ACIFC_ACBP0)
-#define GPIO_PB03E_ACIFC_ACBP0   _UL(1 <<  3)
+#define GPIO_PB03E_ACIFC_ACBP0   _UL_(1 <<  3)
 /* ========== GPIO definition for GLOC peripheral ========== */
-#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
-#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PIN_PA06D_GLOC_IN0              _L_(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L_(3)
 #define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
-#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
-#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
-#define MUX_PA20D_GLOC_IN0              _L(3)
+#define GPIO_PA06D_GLOC_IN0      _UL_(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L_(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L_(3)
 #define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
-#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
-#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
-#define MUX_PA04D_GLOC_IN1              _L(3)
+#define GPIO_PA20D_GLOC_IN0      _UL_(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L_(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L_(3)
 #define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
-#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
-#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
-#define MUX_PA21D_GLOC_IN1              _L(3)
+#define GPIO_PA04D_GLOC_IN1      _UL_(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L_(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L_(3)
 #define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
-#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
-#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
-#define MUX_PA05D_GLOC_IN2              _L(3)
+#define GPIO_PA21D_GLOC_IN1      _UL_(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L_(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L_(3)
 #define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
-#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
-#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
-#define MUX_PA22D_GLOC_IN2              _L(3)
+#define GPIO_PA05D_GLOC_IN2      _UL_(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L_(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L_(3)
 #define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
-#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
-#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
-#define MUX_PA07D_GLOC_IN3              _L(3)
+#define GPIO_PA22D_GLOC_IN2      _UL_(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L_(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L_(3)
 #define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
-#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
-#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
-#define MUX_PA23D_GLOC_IN3              _L(3)
+#define GPIO_PA07D_GLOC_IN3      _UL_(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L_(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L_(3)
 #define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
-#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
-#define PIN_PB06C_GLOC_IN4             _L(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
-#define MUX_PB06C_GLOC_IN4              _L(2)
+#define GPIO_PA23D_GLOC_IN3      _UL_(1 << 23)
+#define PIN_PB06C_GLOC_IN4             _L_(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
+#define MUX_PB06C_GLOC_IN4              _L_(2)
 #define PINMUX_PB06C_GLOC_IN4      ((PIN_PB06C_GLOC_IN4 << 16) | MUX_PB06C_GLOC_IN4)
-#define GPIO_PB06C_GLOC_IN4      _UL(1 <<  6)
-#define PIN_PB07C_GLOC_IN5             _L(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
-#define MUX_PB07C_GLOC_IN5              _L(2)
+#define GPIO_PB06C_GLOC_IN4      _UL_(1 <<  6)
+#define PIN_PB07C_GLOC_IN5             _L_(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
+#define MUX_PB07C_GLOC_IN5              _L_(2)
 #define PINMUX_PB07C_GLOC_IN5      ((PIN_PB07C_GLOC_IN5 << 16) | MUX_PB07C_GLOC_IN5)
-#define GPIO_PB07C_GLOC_IN5      _UL(1 <<  7)
-#define PIN_PB08C_GLOC_IN6             _L(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
-#define MUX_PB08C_GLOC_IN6              _L(2)
+#define GPIO_PB07C_GLOC_IN5      _UL_(1 <<  7)
+#define PIN_PB08C_GLOC_IN6             _L_(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
+#define MUX_PB08C_GLOC_IN6              _L_(2)
 #define PINMUX_PB08C_GLOC_IN6      ((PIN_PB08C_GLOC_IN6 << 16) | MUX_PB08C_GLOC_IN6)
-#define GPIO_PB08C_GLOC_IN6      _UL(1 <<  8)
-#define PIN_PB09C_GLOC_IN7             _L(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
-#define MUX_PB09C_GLOC_IN7              _L(2)
+#define GPIO_PB08C_GLOC_IN6      _UL_(1 <<  8)
+#define PIN_PB09C_GLOC_IN7             _L_(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
+#define MUX_PB09C_GLOC_IN7              _L_(2)
 #define PINMUX_PB09C_GLOC_IN7      ((PIN_PB09C_GLOC_IN7 << 16) | MUX_PB09C_GLOC_IN7)
-#define GPIO_PB09C_GLOC_IN7      _UL(1 <<  9)
-#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
-#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define GPIO_PB09C_GLOC_IN7      _UL_(1 <<  9)
+#define PIN_PA08D_GLOC_OUT0             _L_(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
-#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
-#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
-#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define GPIO_PA08D_GLOC_OUT0     _UL_(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L_(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
-#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
-#define PIN_PB10C_GLOC_OUT1            _L(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
-#define MUX_PB10C_GLOC_OUT1             _L(2)
+#define GPIO_PA24D_GLOC_OUT0     _UL_(1 << 24)
+#define PIN_PB10C_GLOC_OUT1            _L_(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
+#define MUX_PB10C_GLOC_OUT1             _L_(2)
 #define PINMUX_PB10C_GLOC_OUT1     ((PIN_PB10C_GLOC_OUT1 << 16) | MUX_PB10C_GLOC_OUT1)
-#define GPIO_PB10C_GLOC_OUT1     _UL(1 << 10)
+#define GPIO_PB10C_GLOC_OUT1     _UL_(1 << 10)
 /* ========== GPIO definition for ABDACB peripheral ========== */
-#define PIN_PB02C_ABDACB_DAC0          _L(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
-#define MUX_PB02C_ABDACB_DAC0           _L(2)
+#define PIN_PB02C_ABDACB_DAC0          _L_(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
+#define MUX_PB02C_ABDACB_DAC0           _L_(2)
 #define PINMUX_PB02C_ABDACB_DAC0   ((PIN_PB02C_ABDACB_DAC0 << 16) | MUX_PB02C_ABDACB_DAC0)
-#define GPIO_PB02C_ABDACB_DAC0   _UL(1 <<  2)
-#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
-#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define GPIO_PB02C_ABDACB_DAC0   _UL_(1 <<  2)
+#define PIN_PA17B_ABDACB_DAC0          _L_(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L_(1)
 #define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
-#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
-#define PIN_PB04C_ABDACB_DAC1          _L(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
-#define MUX_PB04C_ABDACB_DAC1           _L(2)
+#define GPIO_PA17B_ABDACB_DAC0   _UL_(1 << 17)
+#define PIN_PB04C_ABDACB_DAC1          _L_(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
+#define MUX_PB04C_ABDACB_DAC1           _L_(2)
 #define PINMUX_PB04C_ABDACB_DAC1   ((PIN_PB04C_ABDACB_DAC1 << 16) | MUX_PB04C_ABDACB_DAC1)
-#define GPIO_PB04C_ABDACB_DAC1   _UL(1 <<  4)
-#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
-#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define GPIO_PB04C_ABDACB_DAC1   _UL_(1 <<  4)
+#define PIN_PA19B_ABDACB_DAC1          _L_(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L_(1)
 #define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
-#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
-#define PIN_PB03C_ABDACB_DACN0         _L(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
-#define MUX_PB03C_ABDACB_DACN0          _L(2)
+#define GPIO_PA19B_ABDACB_DAC1   _UL_(1 << 19)
+#define PIN_PB03C_ABDACB_DACN0         _L_(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
+#define MUX_PB03C_ABDACB_DACN0          _L_(2)
 #define PINMUX_PB03C_ABDACB_DACN0  ((PIN_PB03C_ABDACB_DACN0 << 16) | MUX_PB03C_ABDACB_DACN0)
-#define GPIO_PB03C_ABDACB_DACN0  _UL(1 <<  3)
-#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
-#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define GPIO_PB03C_ABDACB_DACN0  _UL_(1 <<  3)
+#define PIN_PA18B_ABDACB_DACN0         _L_(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L_(1)
 #define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
-#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
-#define PIN_PB05C_ABDACB_DACN1         _L(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
-#define MUX_PB05C_ABDACB_DACN1          _L(2)
+#define GPIO_PA18B_ABDACB_DACN0  _UL_(1 << 18)
+#define PIN_PB05C_ABDACB_DACN1         _L_(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
+#define MUX_PB05C_ABDACB_DACN1          _L_(2)
 #define PINMUX_PB05C_ABDACB_DACN1  ((PIN_PB05C_ABDACB_DACN1 << 16) | MUX_PB05C_ABDACB_DACN1)
-#define GPIO_PB05C_ABDACB_DACN1  _UL(1 <<  5)
-#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
-#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define GPIO_PB05C_ABDACB_DACN1  _UL_(1 <<  5)
+#define PIN_PA20B_ABDACB_DACN1         _L_(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L_(1)
 #define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
-#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+#define GPIO_PA20B_ABDACB_DACN1  _UL_(1 << 20)
 /* ========== GPIO definition for PARC peripheral ========== */
-#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
-#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PIN_PA17D_PARC_PCCK            _L_(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L_(3)
 #define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
-#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
-#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
-#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define GPIO_PA17D_PARC_PCCK     _UL_(1 << 17)
+#define PIN_PA09D_PARC_PCDATA0          _L_(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L_(3)
 #define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
-#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
-#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
-#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define GPIO_PA09D_PARC_PCDATA0  _UL_(1 <<  9)
+#define PIN_PA10D_PARC_PCDATA1         _L_(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L_(3)
 #define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
-#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
-#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
-#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define GPIO_PA10D_PARC_PCDATA1  _UL_(1 << 10)
+#define PIN_PA11D_PARC_PCDATA2         _L_(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L_(3)
 #define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
-#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
-#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
-#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define GPIO_PA11D_PARC_PCDATA2  _UL_(1 << 11)
+#define PIN_PA12D_PARC_PCDATA3         _L_(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L_(3)
 #define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
-#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
-#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
-#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL_(1 << 12)
+#define PIN_PA13D_PARC_PCDATA4         _L_(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L_(3)
 #define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
-#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
-#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
-#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define GPIO_PA13D_PARC_PCDATA4  _UL_(1 << 13)
+#define PIN_PA14D_PARC_PCDATA5         _L_(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L_(3)
 #define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
-#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
-#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
-#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define GPIO_PA14D_PARC_PCDATA5  _UL_(1 << 14)
+#define PIN_PA15D_PARC_PCDATA6         _L_(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L_(3)
 #define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
-#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
-#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
-#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define GPIO_PA15D_PARC_PCDATA6  _UL_(1 << 15)
+#define PIN_PA16D_PARC_PCDATA7         _L_(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L_(3)
 #define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
-#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
-#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
-#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define GPIO_PA16D_PARC_PCDATA7  _UL_(1 << 16)
+#define PIN_PA18D_PARC_PCEN1           _L_(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L_(3)
 #define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
-#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
-#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
-#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define GPIO_PA18D_PARC_PCEN1    _UL_(1 << 18)
+#define PIN_PA19D_PARC_PCEN2           _L_(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L_(3)
 #define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
-#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+#define GPIO_PA19D_PARC_PCEN2    _UL_(1 << 19)
 /* ========== GPIO definition for CATB peripheral ========== */
-#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
-#define MUX_PA02G_CATB_DIS              _L(6)
+#define PIN_PA02G_CATB_DIS              _L_(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L_(6)
 #define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
-#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
-#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
-#define MUX_PA12G_CATB_DIS              _L(6)
+#define GPIO_PA02G_CATB_DIS      _UL_(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L_(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L_(6)
 #define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
-#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
-#define MUX_PA23G_CATB_DIS              _L(6)
+#define GPIO_PA12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L_(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L_(6)
 #define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
-#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
-#define PIN_PB03G_CATB_DIS             _L(35) /**< \brief CATB signal: DIS on PB03 mux G */
-#define MUX_PB03G_CATB_DIS              _L(6)
+#define GPIO_PA23G_CATB_DIS      _UL_(1 << 23)
+#define PIN_PB03G_CATB_DIS             _L_(35) /**< \brief CATB signal: DIS on PB03 mux G */
+#define MUX_PB03G_CATB_DIS              _L_(6)
 #define PINMUX_PB03G_CATB_DIS      ((PIN_PB03G_CATB_DIS << 16) | MUX_PB03G_CATB_DIS)
-#define GPIO_PB03G_CATB_DIS      _UL(1 <<  3)
-#define PIN_PB12G_CATB_DIS             _L(44) /**< \brief CATB signal: DIS on PB12 mux G */
-#define MUX_PB12G_CATB_DIS              _L(6)
+#define GPIO_PB03G_CATB_DIS      _UL_(1 <<  3)
+#define PIN_PB12G_CATB_DIS             _L_(44) /**< \brief CATB signal: DIS on PB12 mux G */
+#define MUX_PB12G_CATB_DIS              _L_(6)
 #define PINMUX_PB12G_CATB_DIS      ((PIN_PB12G_CATB_DIS << 16) | MUX_PB12G_CATB_DIS)
-#define GPIO_PB12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
-#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define GPIO_PB12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PA04G_CATB_SENSE0           _L_(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L_(6)
 #define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
-#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
-#define PIN_PB13G_CATB_SENSE0          _L(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
-#define MUX_PB13G_CATB_SENSE0           _L(6)
+#define GPIO_PA04G_CATB_SENSE0   _UL_(1 <<  4)
+#define PIN_PB13G_CATB_SENSE0          _L_(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
+#define MUX_PB13G_CATB_SENSE0           _L_(6)
 #define PINMUX_PB13G_CATB_SENSE0   ((PIN_PB13G_CATB_SENSE0 << 16) | MUX_PB13G_CATB_SENSE0)
-#define GPIO_PB13G_CATB_SENSE0   _UL(1 << 13)
-#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
-#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define GPIO_PB13G_CATB_SENSE0   _UL_(1 << 13)
+#define PIN_PA05G_CATB_SENSE1           _L_(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L_(6)
 #define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
-#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
-#define PIN_PB14G_CATB_SENSE1          _L(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
-#define MUX_PB14G_CATB_SENSE1           _L(6)
+#define GPIO_PA05G_CATB_SENSE1   _UL_(1 <<  5)
+#define PIN_PB14G_CATB_SENSE1          _L_(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
+#define MUX_PB14G_CATB_SENSE1           _L_(6)
 #define PINMUX_PB14G_CATB_SENSE1   ((PIN_PB14G_CATB_SENSE1 << 16) | MUX_PB14G_CATB_SENSE1)
-#define GPIO_PB14G_CATB_SENSE1   _UL(1 << 14)
-#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
-#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define GPIO_PB14G_CATB_SENSE1   _UL_(1 << 14)
+#define PIN_PA06G_CATB_SENSE2           _L_(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L_(6)
 #define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
-#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
-#define PIN_PB15G_CATB_SENSE2          _L(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
-#define MUX_PB15G_CATB_SENSE2           _L(6)
+#define GPIO_PA06G_CATB_SENSE2   _UL_(1 <<  6)
+#define PIN_PB15G_CATB_SENSE2          _L_(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
+#define MUX_PB15G_CATB_SENSE2           _L_(6)
 #define PINMUX_PB15G_CATB_SENSE2   ((PIN_PB15G_CATB_SENSE2 << 16) | MUX_PB15G_CATB_SENSE2)
-#define GPIO_PB15G_CATB_SENSE2   _UL(1 << 15)
-#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
-#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define GPIO_PB15G_CATB_SENSE2   _UL_(1 << 15)
+#define PIN_PA07G_CATB_SENSE3           _L_(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L_(6)
 #define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
-#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
-#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
-#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define GPIO_PA07G_CATB_SENSE3   _UL_(1 <<  7)
+#define PIN_PA08G_CATB_SENSE4           _L_(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L_(6)
 #define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
-#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
-#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
-#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define GPIO_PA08G_CATB_SENSE4   _UL_(1 <<  8)
+#define PIN_PA09G_CATB_SENSE5           _L_(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L_(6)
 #define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
-#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
-#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
-#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define GPIO_PA09G_CATB_SENSE5   _UL_(1 <<  9)
+#define PIN_PA10G_CATB_SENSE6          _L_(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L_(6)
 #define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
-#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
-#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
-#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define GPIO_PA10G_CATB_SENSE6   _UL_(1 << 10)
+#define PIN_PA11G_CATB_SENSE7          _L_(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L_(6)
 #define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
-#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
-#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
-#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define GPIO_PA11G_CATB_SENSE7   _UL_(1 << 11)
+#define PIN_PA13G_CATB_SENSE8          _L_(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L_(6)
 #define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
-#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
-#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
-#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define GPIO_PA13G_CATB_SENSE8   _UL_(1 << 13)
+#define PIN_PA14G_CATB_SENSE9          _L_(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L_(6)
 #define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
-#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
-#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
-#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define GPIO_PA14G_CATB_SENSE9   _UL_(1 << 14)
+#define PIN_PA15G_CATB_SENSE10         _L_(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L_(6)
 #define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
-#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
-#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
-#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define GPIO_PA15G_CATB_SENSE10  _UL_(1 << 15)
+#define PIN_PA16G_CATB_SENSE11         _L_(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L_(6)
 #define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
-#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
-#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
-#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define GPIO_PA16G_CATB_SENSE11  _UL_(1 << 16)
+#define PIN_PA17G_CATB_SENSE12         _L_(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L_(6)
 #define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
-#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
-#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
-#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define GPIO_PA17G_CATB_SENSE12  _UL_(1 << 17)
+#define PIN_PA18G_CATB_SENSE13         _L_(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L_(6)
 #define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
-#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
-#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
-#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define GPIO_PA18G_CATB_SENSE13  _UL_(1 << 18)
+#define PIN_PA19G_CATB_SENSE14         _L_(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L_(6)
 #define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
-#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
-#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
-#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define GPIO_PA19G_CATB_SENSE14  _UL_(1 << 19)
+#define PIN_PA20G_CATB_SENSE15         _L_(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L_(6)
 #define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
-#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
-#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
-#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define GPIO_PA20G_CATB_SENSE15  _UL_(1 << 20)
+#define PIN_PA21G_CATB_SENSE16         _L_(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L_(6)
 #define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
-#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
-#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
-#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define GPIO_PA21G_CATB_SENSE16  _UL_(1 << 21)
+#define PIN_PA22G_CATB_SENSE17         _L_(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L_(6)
 #define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
-#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
-#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
-#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define GPIO_PA22G_CATB_SENSE17  _UL_(1 << 22)
+#define PIN_PA24G_CATB_SENSE18         _L_(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L_(6)
 #define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
-#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
-#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
-#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define GPIO_PA24G_CATB_SENSE18  _UL_(1 << 24)
+#define PIN_PA25G_CATB_SENSE19         _L_(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L_(6)
 #define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
-#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
-#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
-#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define GPIO_PA25G_CATB_SENSE19  _UL_(1 << 25)
+#define PIN_PA26G_CATB_SENSE20         _L_(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L_(6)
 #define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
-#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
-#define PIN_PB00G_CATB_SENSE21         _L(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
-#define MUX_PB00G_CATB_SENSE21          _L(6)
+#define GPIO_PA26G_CATB_SENSE20  _UL_(1 << 26)
+#define PIN_PB00G_CATB_SENSE21         _L_(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
+#define MUX_PB00G_CATB_SENSE21          _L_(6)
 #define PINMUX_PB00G_CATB_SENSE21  ((PIN_PB00G_CATB_SENSE21 << 16) | MUX_PB00G_CATB_SENSE21)
-#define GPIO_PB00G_CATB_SENSE21  _UL(1 <<  0)
-#define PIN_PB01G_CATB_SENSE22         _L(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
-#define MUX_PB01G_CATB_SENSE22          _L(6)
+#define GPIO_PB00G_CATB_SENSE21  _UL_(1 <<  0)
+#define PIN_PB01G_CATB_SENSE22         _L_(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
+#define MUX_PB01G_CATB_SENSE22          _L_(6)
 #define PINMUX_PB01G_CATB_SENSE22  ((PIN_PB01G_CATB_SENSE22 << 16) | MUX_PB01G_CATB_SENSE22)
-#define GPIO_PB01G_CATB_SENSE22  _UL(1 <<  1)
-#define PIN_PB02G_CATB_SENSE23         _L(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
-#define MUX_PB02G_CATB_SENSE23          _L(6)
+#define GPIO_PB01G_CATB_SENSE22  _UL_(1 <<  1)
+#define PIN_PB02G_CATB_SENSE23         _L_(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
+#define MUX_PB02G_CATB_SENSE23          _L_(6)
 #define PINMUX_PB02G_CATB_SENSE23  ((PIN_PB02G_CATB_SENSE23 << 16) | MUX_PB02G_CATB_SENSE23)
-#define GPIO_PB02G_CATB_SENSE23  _UL(1 <<  2)
-#define PIN_PB04G_CATB_SENSE24         _L(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
-#define MUX_PB04G_CATB_SENSE24          _L(6)
+#define GPIO_PB02G_CATB_SENSE23  _UL_(1 <<  2)
+#define PIN_PB04G_CATB_SENSE24         _L_(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
+#define MUX_PB04G_CATB_SENSE24          _L_(6)
 #define PINMUX_PB04G_CATB_SENSE24  ((PIN_PB04G_CATB_SENSE24 << 16) | MUX_PB04G_CATB_SENSE24)
-#define GPIO_PB04G_CATB_SENSE24  _UL(1 <<  4)
-#define PIN_PB05G_CATB_SENSE25         _L(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
-#define MUX_PB05G_CATB_SENSE25          _L(6)
+#define GPIO_PB04G_CATB_SENSE24  _UL_(1 <<  4)
+#define PIN_PB05G_CATB_SENSE25         _L_(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
+#define MUX_PB05G_CATB_SENSE25          _L_(6)
 #define PINMUX_PB05G_CATB_SENSE25  ((PIN_PB05G_CATB_SENSE25 << 16) | MUX_PB05G_CATB_SENSE25)
-#define GPIO_PB05G_CATB_SENSE25  _UL(1 <<  5)
-#define PIN_PB06G_CATB_SENSE26         _L(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
-#define MUX_PB06G_CATB_SENSE26          _L(6)
+#define GPIO_PB05G_CATB_SENSE25  _UL_(1 <<  5)
+#define PIN_PB06G_CATB_SENSE26         _L_(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
+#define MUX_PB06G_CATB_SENSE26          _L_(6)
 #define PINMUX_PB06G_CATB_SENSE26  ((PIN_PB06G_CATB_SENSE26 << 16) | MUX_PB06G_CATB_SENSE26)
-#define GPIO_PB06G_CATB_SENSE26  _UL(1 <<  6)
-#define PIN_PB07G_CATB_SENSE27         _L(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
-#define MUX_PB07G_CATB_SENSE27          _L(6)
+#define GPIO_PB06G_CATB_SENSE26  _UL_(1 <<  6)
+#define PIN_PB07G_CATB_SENSE27         _L_(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
+#define MUX_PB07G_CATB_SENSE27          _L_(6)
 #define PINMUX_PB07G_CATB_SENSE27  ((PIN_PB07G_CATB_SENSE27 << 16) | MUX_PB07G_CATB_SENSE27)
-#define GPIO_PB07G_CATB_SENSE27  _UL(1 <<  7)
-#define PIN_PB08G_CATB_SENSE28         _L(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
-#define MUX_PB08G_CATB_SENSE28          _L(6)
+#define GPIO_PB07G_CATB_SENSE27  _UL_(1 <<  7)
+#define PIN_PB08G_CATB_SENSE28         _L_(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
+#define MUX_PB08G_CATB_SENSE28          _L_(6)
 #define PINMUX_PB08G_CATB_SENSE28  ((PIN_PB08G_CATB_SENSE28 << 16) | MUX_PB08G_CATB_SENSE28)
-#define GPIO_PB08G_CATB_SENSE28  _UL(1 <<  8)
-#define PIN_PB09G_CATB_SENSE29         _L(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
-#define MUX_PB09G_CATB_SENSE29          _L(6)
+#define GPIO_PB08G_CATB_SENSE28  _UL_(1 <<  8)
+#define PIN_PB09G_CATB_SENSE29         _L_(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
+#define MUX_PB09G_CATB_SENSE29          _L_(6)
 #define PINMUX_PB09G_CATB_SENSE29  ((PIN_PB09G_CATB_SENSE29 << 16) | MUX_PB09G_CATB_SENSE29)
-#define GPIO_PB09G_CATB_SENSE29  _UL(1 <<  9)
-#define PIN_PB10G_CATB_SENSE30         _L(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
-#define MUX_PB10G_CATB_SENSE30          _L(6)
+#define GPIO_PB09G_CATB_SENSE29  _UL_(1 <<  9)
+#define PIN_PB10G_CATB_SENSE30         _L_(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
+#define MUX_PB10G_CATB_SENSE30          _L_(6)
 #define PINMUX_PB10G_CATB_SENSE30  ((PIN_PB10G_CATB_SENSE30 << 16) | MUX_PB10G_CATB_SENSE30)
-#define GPIO_PB10G_CATB_SENSE30  _UL(1 << 10)
-#define PIN_PB11G_CATB_SENSE31         _L(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
-#define MUX_PB11G_CATB_SENSE31          _L(6)
+#define GPIO_PB10G_CATB_SENSE30  _UL_(1 << 10)
+#define PIN_PB11G_CATB_SENSE31         _L_(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
+#define MUX_PB11G_CATB_SENSE31          _L_(6)
 #define PINMUX_PB11G_CATB_SENSE31  ((PIN_PB11G_CATB_SENSE31 << 16) | MUX_PB11G_CATB_SENSE31)
-#define GPIO_PB11G_CATB_SENSE31  _UL(1 << 11)
+#define GPIO_PB11G_CATB_SENSE31  _UL_(1 << 11)
 /* ========== GPIO definition for LCDCA peripheral ========== */
-#define PIN_PA12F_LCDCA_COM0           _L(12) /**< \brief LCDCA signal: COM0 on PA12 mux F */
-#define MUX_PA12F_LCDCA_COM0            _L(5)
+#define PIN_PA12F_LCDCA_COM0           _L_(12) /**< \brief LCDCA signal: COM0 on PA12 mux F */
+#define MUX_PA12F_LCDCA_COM0            _L_(5)
 #define PINMUX_PA12F_LCDCA_COM0    ((PIN_PA12F_LCDCA_COM0 << 16) | MUX_PA12F_LCDCA_COM0)
-#define GPIO_PA12F_LCDCA_COM0    _UL(1 << 12)
-#define PIN_PA11F_LCDCA_COM1           _L(11) /**< \brief LCDCA signal: COM1 on PA11 mux F */
-#define MUX_PA11F_LCDCA_COM1            _L(5)
+#define GPIO_PA12F_LCDCA_COM0    _UL_(1 << 12)
+#define PIN_PA11F_LCDCA_COM1           _L_(11) /**< \brief LCDCA signal: COM1 on PA11 mux F */
+#define MUX_PA11F_LCDCA_COM1            _L_(5)
 #define PINMUX_PA11F_LCDCA_COM1    ((PIN_PA11F_LCDCA_COM1 << 16) | MUX_PA11F_LCDCA_COM1)
-#define GPIO_PA11F_LCDCA_COM1    _UL(1 << 11)
-#define PIN_PA10F_LCDCA_COM2           _L(10) /**< \brief LCDCA signal: COM2 on PA10 mux F */
-#define MUX_PA10F_LCDCA_COM2            _L(5)
+#define GPIO_PA11F_LCDCA_COM1    _UL_(1 << 11)
+#define PIN_PA10F_LCDCA_COM2           _L_(10) /**< \brief LCDCA signal: COM2 on PA10 mux F */
+#define MUX_PA10F_LCDCA_COM2            _L_(5)
 #define PINMUX_PA10F_LCDCA_COM2    ((PIN_PA10F_LCDCA_COM2 << 16) | MUX_PA10F_LCDCA_COM2)
-#define GPIO_PA10F_LCDCA_COM2    _UL(1 << 10)
-#define PIN_PA09F_LCDCA_COM3            _L(9) /**< \brief LCDCA signal: COM3 on PA09 mux F */
-#define MUX_PA09F_LCDCA_COM3            _L(5)
+#define GPIO_PA10F_LCDCA_COM2    _UL_(1 << 10)
+#define PIN_PA09F_LCDCA_COM3            _L_(9) /**< \brief LCDCA signal: COM3 on PA09 mux F */
+#define MUX_PA09F_LCDCA_COM3            _L_(5)
 #define PINMUX_PA09F_LCDCA_COM3    ((PIN_PA09F_LCDCA_COM3 << 16) | MUX_PA09F_LCDCA_COM3)
-#define GPIO_PA09F_LCDCA_COM3    _UL(1 <<  9)
-#define PIN_PA13F_LCDCA_SEG5           _L(13) /**< \brief LCDCA signal: SEG5 on PA13 mux F */
-#define MUX_PA13F_LCDCA_SEG5            _L(5)
+#define GPIO_PA09F_LCDCA_COM3    _UL_(1 <<  9)
+#define PIN_PA13F_LCDCA_SEG5           _L_(13) /**< \brief LCDCA signal: SEG5 on PA13 mux F */
+#define MUX_PA13F_LCDCA_SEG5            _L_(5)
 #define PINMUX_PA13F_LCDCA_SEG5    ((PIN_PA13F_LCDCA_SEG5 << 16) | MUX_PA13F_LCDCA_SEG5)
-#define GPIO_PA13F_LCDCA_SEG5    _UL(1 << 13)
-#define PIN_PA14F_LCDCA_SEG6           _L(14) /**< \brief LCDCA signal: SEG6 on PA14 mux F */
-#define MUX_PA14F_LCDCA_SEG6            _L(5)
+#define GPIO_PA13F_LCDCA_SEG5    _UL_(1 << 13)
+#define PIN_PA14F_LCDCA_SEG6           _L_(14) /**< \brief LCDCA signal: SEG6 on PA14 mux F */
+#define MUX_PA14F_LCDCA_SEG6            _L_(5)
 #define PINMUX_PA14F_LCDCA_SEG6    ((PIN_PA14F_LCDCA_SEG6 << 16) | MUX_PA14F_LCDCA_SEG6)
-#define GPIO_PA14F_LCDCA_SEG6    _UL(1 << 14)
-#define PIN_PA15F_LCDCA_SEG7           _L(15) /**< \brief LCDCA signal: SEG7 on PA15 mux F */
-#define MUX_PA15F_LCDCA_SEG7            _L(5)
+#define GPIO_PA14F_LCDCA_SEG6    _UL_(1 << 14)
+#define PIN_PA15F_LCDCA_SEG7           _L_(15) /**< \brief LCDCA signal: SEG7 on PA15 mux F */
+#define MUX_PA15F_LCDCA_SEG7            _L_(5)
 #define PINMUX_PA15F_LCDCA_SEG7    ((PIN_PA15F_LCDCA_SEG7 << 16) | MUX_PA15F_LCDCA_SEG7)
-#define GPIO_PA15F_LCDCA_SEG7    _UL(1 << 15)
-#define PIN_PA16F_LCDCA_SEG8           _L(16) /**< \brief LCDCA signal: SEG8 on PA16 mux F */
-#define MUX_PA16F_LCDCA_SEG8            _L(5)
+#define GPIO_PA15F_LCDCA_SEG7    _UL_(1 << 15)
+#define PIN_PA16F_LCDCA_SEG8           _L_(16) /**< \brief LCDCA signal: SEG8 on PA16 mux F */
+#define MUX_PA16F_LCDCA_SEG8            _L_(5)
 #define PINMUX_PA16F_LCDCA_SEG8    ((PIN_PA16F_LCDCA_SEG8 << 16) | MUX_PA16F_LCDCA_SEG8)
-#define GPIO_PA16F_LCDCA_SEG8    _UL(1 << 16)
-#define PIN_PA17F_LCDCA_SEG9           _L(17) /**< \brief LCDCA signal: SEG9 on PA17 mux F */
-#define MUX_PA17F_LCDCA_SEG9            _L(5)
+#define GPIO_PA16F_LCDCA_SEG8    _UL_(1 << 16)
+#define PIN_PA17F_LCDCA_SEG9           _L_(17) /**< \brief LCDCA signal: SEG9 on PA17 mux F */
+#define MUX_PA17F_LCDCA_SEG9            _L_(5)
 #define PINMUX_PA17F_LCDCA_SEG9    ((PIN_PA17F_LCDCA_SEG9 << 16) | MUX_PA17F_LCDCA_SEG9)
-#define GPIO_PA17F_LCDCA_SEG9    _UL(1 << 17)
-#define PIN_PB08F_LCDCA_SEG14          _L(40) /**< \brief LCDCA signal: SEG14 on PB08 mux F */
-#define MUX_PB08F_LCDCA_SEG14           _L(5)
+#define GPIO_PA17F_LCDCA_SEG9    _UL_(1 << 17)
+#define PIN_PB08F_LCDCA_SEG14          _L_(40) /**< \brief LCDCA signal: SEG14 on PB08 mux F */
+#define MUX_PB08F_LCDCA_SEG14           _L_(5)
 #define PINMUX_PB08F_LCDCA_SEG14   ((PIN_PB08F_LCDCA_SEG14 << 16) | MUX_PB08F_LCDCA_SEG14)
-#define GPIO_PB08F_LCDCA_SEG14   _UL(1 <<  8)
-#define PIN_PB09F_LCDCA_SEG15          _L(41) /**< \brief LCDCA signal: SEG15 on PB09 mux F */
-#define MUX_PB09F_LCDCA_SEG15           _L(5)
+#define GPIO_PB08F_LCDCA_SEG14   _UL_(1 <<  8)
+#define PIN_PB09F_LCDCA_SEG15          _L_(41) /**< \brief LCDCA signal: SEG15 on PB09 mux F */
+#define MUX_PB09F_LCDCA_SEG15           _L_(5)
 #define PINMUX_PB09F_LCDCA_SEG15   ((PIN_PB09F_LCDCA_SEG15 << 16) | MUX_PB09F_LCDCA_SEG15)
-#define GPIO_PB09F_LCDCA_SEG15   _UL(1 <<  9)
-#define PIN_PB10F_LCDCA_SEG16          _L(42) /**< \brief LCDCA signal: SEG16 on PB10 mux F */
-#define MUX_PB10F_LCDCA_SEG16           _L(5)
+#define GPIO_PB09F_LCDCA_SEG15   _UL_(1 <<  9)
+#define PIN_PB10F_LCDCA_SEG16          _L_(42) /**< \brief LCDCA signal: SEG16 on PB10 mux F */
+#define MUX_PB10F_LCDCA_SEG16           _L_(5)
 #define PINMUX_PB10F_LCDCA_SEG16   ((PIN_PB10F_LCDCA_SEG16 << 16) | MUX_PB10F_LCDCA_SEG16)
-#define GPIO_PB10F_LCDCA_SEG16   _UL(1 << 10)
-#define PIN_PB11F_LCDCA_SEG17          _L(43) /**< \brief LCDCA signal: SEG17 on PB11 mux F */
-#define MUX_PB11F_LCDCA_SEG17           _L(5)
+#define GPIO_PB10F_LCDCA_SEG16   _UL_(1 << 10)
+#define PIN_PB11F_LCDCA_SEG17          _L_(43) /**< \brief LCDCA signal: SEG17 on PB11 mux F */
+#define MUX_PB11F_LCDCA_SEG17           _L_(5)
 #define PINMUX_PB11F_LCDCA_SEG17   ((PIN_PB11F_LCDCA_SEG17 << 16) | MUX_PB11F_LCDCA_SEG17)
-#define GPIO_PB11F_LCDCA_SEG17   _UL(1 << 11)
-#define PIN_PA18F_LCDCA_SEG18          _L(18) /**< \brief LCDCA signal: SEG18 on PA18 mux F */
-#define MUX_PA18F_LCDCA_SEG18           _L(5)
+#define GPIO_PB11F_LCDCA_SEG17   _UL_(1 << 11)
+#define PIN_PA18F_LCDCA_SEG18          _L_(18) /**< \brief LCDCA signal: SEG18 on PA18 mux F */
+#define MUX_PA18F_LCDCA_SEG18           _L_(5)
 #define PINMUX_PA18F_LCDCA_SEG18   ((PIN_PA18F_LCDCA_SEG18 << 16) | MUX_PA18F_LCDCA_SEG18)
-#define GPIO_PA18F_LCDCA_SEG18   _UL(1 << 18)
-#define PIN_PA19F_LCDCA_SEG19          _L(19) /**< \brief LCDCA signal: SEG19 on PA19 mux F */
-#define MUX_PA19F_LCDCA_SEG19           _L(5)
+#define GPIO_PA18F_LCDCA_SEG18   _UL_(1 << 18)
+#define PIN_PA19F_LCDCA_SEG19          _L_(19) /**< \brief LCDCA signal: SEG19 on PA19 mux F */
+#define MUX_PA19F_LCDCA_SEG19           _L_(5)
 #define PINMUX_PA19F_LCDCA_SEG19   ((PIN_PA19F_LCDCA_SEG19 << 16) | MUX_PA19F_LCDCA_SEG19)
-#define GPIO_PA19F_LCDCA_SEG19   _UL(1 << 19)
-#define PIN_PA20F_LCDCA_SEG20          _L(20) /**< \brief LCDCA signal: SEG20 on PA20 mux F */
-#define MUX_PA20F_LCDCA_SEG20           _L(5)
+#define GPIO_PA19F_LCDCA_SEG19   _UL_(1 << 19)
+#define PIN_PA20F_LCDCA_SEG20          _L_(20) /**< \brief LCDCA signal: SEG20 on PA20 mux F */
+#define MUX_PA20F_LCDCA_SEG20           _L_(5)
 #define PINMUX_PA20F_LCDCA_SEG20   ((PIN_PA20F_LCDCA_SEG20 << 16) | MUX_PA20F_LCDCA_SEG20)
-#define GPIO_PA20F_LCDCA_SEG20   _UL(1 << 20)
-#define PIN_PB07F_LCDCA_SEG21          _L(39) /**< \brief LCDCA signal: SEG21 on PB07 mux F */
-#define MUX_PB07F_LCDCA_SEG21           _L(5)
+#define GPIO_PA20F_LCDCA_SEG20   _UL_(1 << 20)
+#define PIN_PB07F_LCDCA_SEG21          _L_(39) /**< \brief LCDCA signal: SEG21 on PB07 mux F */
+#define MUX_PB07F_LCDCA_SEG21           _L_(5)
 #define PINMUX_PB07F_LCDCA_SEG21   ((PIN_PB07F_LCDCA_SEG21 << 16) | MUX_PB07F_LCDCA_SEG21)
-#define GPIO_PB07F_LCDCA_SEG21   _UL(1 <<  7)
-#define PIN_PB06F_LCDCA_SEG22          _L(38) /**< \brief LCDCA signal: SEG22 on PB06 mux F */
-#define MUX_PB06F_LCDCA_SEG22           _L(5)
+#define GPIO_PB07F_LCDCA_SEG21   _UL_(1 <<  7)
+#define PIN_PB06F_LCDCA_SEG22          _L_(38) /**< \brief LCDCA signal: SEG22 on PB06 mux F */
+#define MUX_PB06F_LCDCA_SEG22           _L_(5)
 #define PINMUX_PB06F_LCDCA_SEG22   ((PIN_PB06F_LCDCA_SEG22 << 16) | MUX_PB06F_LCDCA_SEG22)
-#define GPIO_PB06F_LCDCA_SEG22   _UL(1 <<  6)
-#define PIN_PA08F_LCDCA_SEG23           _L(8) /**< \brief LCDCA signal: SEG23 on PA08 mux F */
-#define MUX_PA08F_LCDCA_SEG23           _L(5)
+#define GPIO_PB06F_LCDCA_SEG22   _UL_(1 <<  6)
+#define PIN_PA08F_LCDCA_SEG23           _L_(8) /**< \brief LCDCA signal: SEG23 on PA08 mux F */
+#define MUX_PA08F_LCDCA_SEG23           _L_(5)
 #define PINMUX_PA08F_LCDCA_SEG23   ((PIN_PA08F_LCDCA_SEG23 << 16) | MUX_PA08F_LCDCA_SEG23)
-#define GPIO_PA08F_LCDCA_SEG23   _UL(1 <<  8)
-#define PIN_PB12F_LCDCA_SEG32          _L(44) /**< \brief LCDCA signal: SEG32 on PB12 mux F */
-#define MUX_PB12F_LCDCA_SEG32           _L(5)
+#define GPIO_PA08F_LCDCA_SEG23   _UL_(1 <<  8)
+#define PIN_PB12F_LCDCA_SEG32          _L_(44) /**< \brief LCDCA signal: SEG32 on PB12 mux F */
+#define MUX_PB12F_LCDCA_SEG32           _L_(5)
 #define PINMUX_PB12F_LCDCA_SEG32   ((PIN_PB12F_LCDCA_SEG32 << 16) | MUX_PB12F_LCDCA_SEG32)
-#define GPIO_PB12F_LCDCA_SEG32   _UL(1 << 12)
-#define PIN_PB13F_LCDCA_SEG33          _L(45) /**< \brief LCDCA signal: SEG33 on PB13 mux F */
-#define MUX_PB13F_LCDCA_SEG33           _L(5)
+#define GPIO_PB12F_LCDCA_SEG32   _UL_(1 << 12)
+#define PIN_PB13F_LCDCA_SEG33          _L_(45) /**< \brief LCDCA signal: SEG33 on PB13 mux F */
+#define MUX_PB13F_LCDCA_SEG33           _L_(5)
 #define PINMUX_PB13F_LCDCA_SEG33   ((PIN_PB13F_LCDCA_SEG33 << 16) | MUX_PB13F_LCDCA_SEG33)
-#define GPIO_PB13F_LCDCA_SEG33   _UL(1 << 13)
-#define PIN_PA21F_LCDCA_SEG34          _L(21) /**< \brief LCDCA signal: SEG34 on PA21 mux F */
-#define MUX_PA21F_LCDCA_SEG34           _L(5)
+#define GPIO_PB13F_LCDCA_SEG33   _UL_(1 << 13)
+#define PIN_PA21F_LCDCA_SEG34          _L_(21) /**< \brief LCDCA signal: SEG34 on PA21 mux F */
+#define MUX_PA21F_LCDCA_SEG34           _L_(5)
 #define PINMUX_PA21F_LCDCA_SEG34   ((PIN_PA21F_LCDCA_SEG34 << 16) | MUX_PA21F_LCDCA_SEG34)
-#define GPIO_PA21F_LCDCA_SEG34   _UL(1 << 21)
-#define PIN_PA22F_LCDCA_SEG35          _L(22) /**< \brief LCDCA signal: SEG35 on PA22 mux F */
-#define MUX_PA22F_LCDCA_SEG35           _L(5)
+#define GPIO_PA21F_LCDCA_SEG34   _UL_(1 << 21)
+#define PIN_PA22F_LCDCA_SEG35          _L_(22) /**< \brief LCDCA signal: SEG35 on PA22 mux F */
+#define MUX_PA22F_LCDCA_SEG35           _L_(5)
 #define PINMUX_PA22F_LCDCA_SEG35   ((PIN_PA22F_LCDCA_SEG35 << 16) | MUX_PA22F_LCDCA_SEG35)
-#define GPIO_PA22F_LCDCA_SEG35   _UL(1 << 22)
-#define PIN_PB14F_LCDCA_SEG36          _L(46) /**< \brief LCDCA signal: SEG36 on PB14 mux F */
-#define MUX_PB14F_LCDCA_SEG36           _L(5)
+#define GPIO_PA22F_LCDCA_SEG35   _UL_(1 << 22)
+#define PIN_PB14F_LCDCA_SEG36          _L_(46) /**< \brief LCDCA signal: SEG36 on PB14 mux F */
+#define MUX_PB14F_LCDCA_SEG36           _L_(5)
 #define PINMUX_PB14F_LCDCA_SEG36   ((PIN_PB14F_LCDCA_SEG36 << 16) | MUX_PB14F_LCDCA_SEG36)
-#define GPIO_PB14F_LCDCA_SEG36   _UL(1 << 14)
-#define PIN_PB15F_LCDCA_SEG37          _L(47) /**< \brief LCDCA signal: SEG37 on PB15 mux F */
-#define MUX_PB15F_LCDCA_SEG37           _L(5)
+#define GPIO_PB14F_LCDCA_SEG36   _UL_(1 << 14)
+#define PIN_PB15F_LCDCA_SEG37          _L_(47) /**< \brief LCDCA signal: SEG37 on PB15 mux F */
+#define MUX_PB15F_LCDCA_SEG37           _L_(5)
 #define PINMUX_PB15F_LCDCA_SEG37   ((PIN_PB15F_LCDCA_SEG37 << 16) | MUX_PB15F_LCDCA_SEG37)
-#define GPIO_PB15F_LCDCA_SEG37   _UL(1 << 15)
-#define PIN_PA23F_LCDCA_SEG38          _L(23) /**< \brief LCDCA signal: SEG38 on PA23 mux F */
-#define MUX_PA23F_LCDCA_SEG38           _L(5)
+#define GPIO_PB15F_LCDCA_SEG37   _UL_(1 << 15)
+#define PIN_PA23F_LCDCA_SEG38          _L_(23) /**< \brief LCDCA signal: SEG38 on PA23 mux F */
+#define MUX_PA23F_LCDCA_SEG38           _L_(5)
 #define PINMUX_PA23F_LCDCA_SEG38   ((PIN_PA23F_LCDCA_SEG38 << 16) | MUX_PA23F_LCDCA_SEG38)
-#define GPIO_PA23F_LCDCA_SEG38   _UL(1 << 23)
-#define PIN_PA24F_LCDCA_SEG39          _L(24) /**< \brief LCDCA signal: SEG39 on PA24 mux F */
-#define MUX_PA24F_LCDCA_SEG39           _L(5)
+#define GPIO_PA23F_LCDCA_SEG38   _UL_(1 << 23)
+#define PIN_PA24F_LCDCA_SEG39          _L_(24) /**< \brief LCDCA signal: SEG39 on PA24 mux F */
+#define MUX_PA24F_LCDCA_SEG39           _L_(5)
 #define PINMUX_PA24F_LCDCA_SEG39   ((PIN_PA24F_LCDCA_SEG39 << 16) | MUX_PA24F_LCDCA_SEG39)
-#define GPIO_PA24F_LCDCA_SEG39   _UL(1 << 24)
+#define GPIO_PA24F_LCDCA_SEG39   _UL_(1 << 24)
 /* ========== GPIO definition for USBC peripheral ========== */
-#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
-#define MUX_PA25A_USBC_DM               _L(0)
+#define PIN_PA25A_USBC_DM              _L_(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L_(0)
 #define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
-#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
-#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
-#define MUX_PA26A_USBC_DP               _L(0)
+#define GPIO_PA25A_USBC_DM       _UL_(1 << 25)
+#define PIN_PA26A_USBC_DP              _L_(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L_(0)
 #define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
-#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+#define GPIO_PA26A_USBC_DP       _UL_(1 << 26)
 /* ========== GPIO definition for PEVC peripheral ========== */
-#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
-#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PIN_PA08C_PEVC_PAD_EVT0         _L_(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
-#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
-#define PIN_PB12C_PEVC_PAD_EVT0        _L(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
-#define MUX_PB12C_PEVC_PAD_EVT0         _L(2)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL_(1 <<  8)
+#define PIN_PB12C_PEVC_PAD_EVT0        _L_(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
+#define MUX_PB12C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PB12C_PEVC_PAD_EVT0  ((PIN_PB12C_PEVC_PAD_EVT0 << 16) | MUX_PB12C_PEVC_PAD_EVT0)
-#define GPIO_PB12C_PEVC_PAD_EVT0  _UL(1 << 12)
-#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
-#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PB12C_PEVC_PAD_EVT0  _UL_(1 << 12)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L_(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
-#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
-#define PIN_PB13C_PEVC_PAD_EVT1        _L(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
-#define MUX_PB13C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL_(1 <<  9)
+#define PIN_PB13C_PEVC_PAD_EVT1        _L_(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
+#define MUX_PB13C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PB13C_PEVC_PAD_EVT1  ((PIN_PB13C_PEVC_PAD_EVT1 << 16) | MUX_PB13C_PEVC_PAD_EVT1)
-#define GPIO_PB13C_PEVC_PAD_EVT1  _UL(1 << 13)
-#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
-#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PB13C_PEVC_PAD_EVT1  _UL_(1 << 13)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L_(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
-#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
-#define PIN_PB09B_PEVC_PAD_EVT2        _L(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
-#define MUX_PB09B_PEVC_PAD_EVT2         _L(1)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL_(1 << 10)
+#define PIN_PB09B_PEVC_PAD_EVT2        _L_(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
+#define MUX_PB09B_PEVC_PAD_EVT2         _L_(1)
 #define PINMUX_PB09B_PEVC_PAD_EVT2  ((PIN_PB09B_PEVC_PAD_EVT2 << 16) | MUX_PB09B_PEVC_PAD_EVT2)
-#define GPIO_PB09B_PEVC_PAD_EVT2  _UL(1 <<  9)
-#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
-#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define GPIO_PB09B_PEVC_PAD_EVT2  _UL_(1 <<  9)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L_(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L_(2)
 #define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
-#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
-#define PIN_PB10B_PEVC_PAD_EVT3        _L(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
-#define MUX_PB10B_PEVC_PAD_EVT3         _L(1)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL_(1 << 11)
+#define PIN_PB10B_PEVC_PAD_EVT3        _L_(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
+#define MUX_PB10B_PEVC_PAD_EVT3         _L_(1)
 #define PINMUX_PB10B_PEVC_PAD_EVT3  ((PIN_PB10B_PEVC_PAD_EVT3 << 16) | MUX_PB10B_PEVC_PAD_EVT3)
-#define GPIO_PB10B_PEVC_PAD_EVT3  _UL(1 << 10)
+#define GPIO_PB10B_PEVC_PAD_EVT3  _UL_(1 << 10)
 /* ========== GPIO definition for SCIF peripheral ========== */
-#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
-#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PIN_PA19E_SCIF_GCLK0           _L_(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
-#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
-#define PIN_PB10E_SCIF_GCLK0           _L(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
-#define MUX_PB10E_SCIF_GCLK0            _L(4)
+#define GPIO_PA19E_SCIF_GCLK0    _UL_(1 << 19)
+#define PIN_PB10E_SCIF_GCLK0           _L_(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
+#define MUX_PB10E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PB10E_SCIF_GCLK0    ((PIN_PB10E_SCIF_GCLK0 << 16) | MUX_PB10E_SCIF_GCLK0)
-#define GPIO_PB10E_SCIF_GCLK0    _UL(1 << 10)
-#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
-#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define GPIO_PB10E_SCIF_GCLK0    _UL_(1 << 10)
+#define PIN_PA02A_SCIF_GCLK0            _L_(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L_(0)
 #define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
-#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
-#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
-#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define GPIO_PA02A_SCIF_GCLK0    _UL_(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L_(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
-#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
-#define PIN_PB11E_SCIF_GCLK1           _L(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
-#define MUX_PB11E_SCIF_GCLK1            _L(4)
+#define GPIO_PA20E_SCIF_GCLK1    _UL_(1 << 20)
+#define PIN_PB11E_SCIF_GCLK1           _L_(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
+#define MUX_PB11E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PB11E_SCIF_GCLK1    ((PIN_PB11E_SCIF_GCLK1 << 16) | MUX_PB11E_SCIF_GCLK1)
-#define GPIO_PB11E_SCIF_GCLK1    _UL(1 << 11)
-#define PIN_PB12E_SCIF_GCLK2           _L(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
-#define MUX_PB12E_SCIF_GCLK2            _L(4)
+#define GPIO_PB11E_SCIF_GCLK1    _UL_(1 << 11)
+#define PIN_PB12E_SCIF_GCLK2           _L_(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
+#define MUX_PB12E_SCIF_GCLK2            _L_(4)
 #define PINMUX_PB12E_SCIF_GCLK2    ((PIN_PB12E_SCIF_GCLK2 << 16) | MUX_PB12E_SCIF_GCLK2)
-#define GPIO_PB12E_SCIF_GCLK2    _UL(1 << 12)
-#define PIN_PB13E_SCIF_GCLK3           _L(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
-#define MUX_PB13E_SCIF_GCLK3            _L(4)
+#define GPIO_PB12E_SCIF_GCLK2    _UL_(1 << 12)
+#define PIN_PB13E_SCIF_GCLK3           _L_(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
+#define MUX_PB13E_SCIF_GCLK3            _L_(4)
 #define PINMUX_PB13E_SCIF_GCLK3    ((PIN_PB13E_SCIF_GCLK3 << 16) | MUX_PB13E_SCIF_GCLK3)
-#define GPIO_PB13E_SCIF_GCLK3    _UL(1 << 13)
-#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
-#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PB13E_SCIF_GCLK3    _UL_(1 << 13)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L_(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
-#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
-#define PIN_PB14E_SCIF_GCLK_IN0        _L(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
-#define MUX_PB14E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL_(1 << 23)
+#define PIN_PB14E_SCIF_GCLK_IN0        _L_(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
+#define MUX_PB14E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PB14E_SCIF_GCLK_IN0  ((PIN_PB14E_SCIF_GCLK_IN0 << 16) | MUX_PB14E_SCIF_GCLK_IN0)
-#define GPIO_PB14E_SCIF_GCLK_IN0  _UL(1 << 14)
-#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
-#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PB14E_SCIF_GCLK_IN0  _UL_(1 << 14)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L_(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
-#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
-#define PIN_PB15E_SCIF_GCLK_IN1        _L(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
-#define MUX_PB15E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL_(1 << 24)
+#define PIN_PB15E_SCIF_GCLK_IN1        _L_(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
+#define MUX_PB15E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PB15E_SCIF_GCLK_IN1  ((PIN_PB15E_SCIF_GCLK_IN1 << 16) | MUX_PB15E_SCIF_GCLK_IN1)
-#define GPIO_PB15E_SCIF_GCLK_IN1  _UL(1 << 15)
+#define GPIO_PB15E_SCIF_GCLK_IN1  _UL_(1 << 15)
 /* ========== GPIO definition for EIC peripheral ========== */
-#define PIN_PB01C_EIC_EXTINT0          _L(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
-#define MUX_PB01C_EIC_EXTINT0           _L(2)
+#define PIN_PB01C_EIC_EXTINT0          _L_(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
+#define MUX_PB01C_EIC_EXTINT0           _L_(2)
 #define PINMUX_PB01C_EIC_EXTINT0   ((PIN_PB01C_EIC_EXTINT0 << 16) | MUX_PB01C_EIC_EXTINT0)
-#define GPIO_PB01C_EIC_EXTINT0   _UL(1 <<  1)
-#define PIN_PB01C_EIC_EXTINT_NUM        _L(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
-#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
-#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define GPIO_PB01C_EIC_EXTINT0   _UL_(1 <<  1)
+#define PIN_PB01C_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PA06C_EIC_EXTINT1           _L_(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
-#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
-#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
-#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
-#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define GPIO_PA06C_EIC_EXTINT1   _UL_(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L_(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
-#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
-#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
-#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
-#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define GPIO_PA16C_EIC_EXTINT1   _UL_(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L_(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
-#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
-#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
-#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
-#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL_(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L_(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
-#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
-#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
-#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
-#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL_(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L_(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
-#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
-#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
-#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
-#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define GPIO_PA05C_EIC_EXTINT3   _UL_(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L_(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
-#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
-#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
-#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
-#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define GPIO_PA18C_EIC_EXTINT3   _UL_(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L_(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
-#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
-#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
-#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
-#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define GPIO_PA07C_EIC_EXTINT4   _UL_(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L_(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
-#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
-#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
-#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
-#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define GPIO_PA19C_EIC_EXTINT4   _UL_(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L_(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L_(2)
 #define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
-#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
-#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
-#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
-#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define GPIO_PA20C_EIC_EXTINT5   _UL_(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L_(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L_(2)
 #define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
-#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
-#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
-#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
-#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define GPIO_PA21C_EIC_EXTINT6   _UL_(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L_(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L_(2)
 #define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
-#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
-#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
-#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
-#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define GPIO_PA22C_EIC_EXTINT7   _UL_(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L_(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L_(2)
 #define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
-#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
-#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define GPIO_PA23C_EIC_EXTINT8   _UL_(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
 
 #endif /* _SAM4LC4B_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4lc4b.h
+++ b/asf/sam/include/sam4l/pio/sam4lc4b.h
@@ -1,0 +1,1079 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAM4LC4B
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LC4B_PIO_
+#define _SAM4LC4B_PIO_
+
+#define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
+#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
+#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
+#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
+#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
+#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
+#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
+#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
+#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
+#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
+#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
+#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
+#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
+#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
+#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
+#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
+#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
+#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
+#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
+#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
+#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
+#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
+#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
+#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
+#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
+#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
+#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
+#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
+#define GPIO_PB00                _UL(1 <<  0) /**< \brief GPIO Mask  for PB00 */
+#define PIN_PB01                          33  /**< \brief Pin Number for PB01 */
+#define GPIO_PB01                _UL(1 <<  1) /**< \brief GPIO Mask  for PB01 */
+#define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
+#define GPIO_PB02                _UL(1 <<  2) /**< \brief GPIO Mask  for PB02 */
+#define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
+#define GPIO_PB03                _UL(1 <<  3) /**< \brief GPIO Mask  for PB03 */
+#define PIN_PB04                          36  /**< \brief Pin Number for PB04 */
+#define GPIO_PB04                _UL(1 <<  4) /**< \brief GPIO Mask  for PB04 */
+#define PIN_PB05                          37  /**< \brief Pin Number for PB05 */
+#define GPIO_PB05                _UL(1 <<  5) /**< \brief GPIO Mask  for PB05 */
+#define PIN_PB06                          38  /**< \brief Pin Number for PB06 */
+#define GPIO_PB06                _UL(1 <<  6) /**< \brief GPIO Mask  for PB06 */
+#define PIN_PB07                          39  /**< \brief Pin Number for PB07 */
+#define GPIO_PB07                _UL(1 <<  7) /**< \brief GPIO Mask  for PB07 */
+#define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
+#define GPIO_PB08                _UL(1 <<  8) /**< \brief GPIO Mask  for PB08 */
+#define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
+#define GPIO_PB09                _UL(1 <<  9) /**< \brief GPIO Mask  for PB09 */
+#define PIN_PB10                          42  /**< \brief Pin Number for PB10 */
+#define GPIO_PB10                _UL(1 << 10) /**< \brief GPIO Mask  for PB10 */
+#define PIN_PB11                          43  /**< \brief Pin Number for PB11 */
+#define GPIO_PB11                _UL(1 << 11) /**< \brief GPIO Mask  for PB11 */
+#define PIN_PB12                          44  /**< \brief Pin Number for PB12 */
+#define GPIO_PB12                _UL(1 << 12) /**< \brief GPIO Mask  for PB12 */
+#define PIN_PB13                          45  /**< \brief Pin Number for PB13 */
+#define GPIO_PB13                _UL(1 << 13) /**< \brief GPIO Mask  for PB13 */
+#define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
+#define GPIO_PB14                _UL(1 << 14) /**< \brief GPIO Mask  for PB14 */
+#define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
+#define GPIO_PB15                _UL(1 << 15) /**< \brief GPIO Mask  for PB15 */
+/* ========== GPIO definition for TWIMS0 peripheral ========== */
+#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
+#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+/* ========== GPIO definition for TWIMS1 peripheral ========== */
+#define PIN_PB01A_TWIMS1_TWCK          _L(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
+#define MUX_PB01A_TWIMS1_TWCK           _L(0)
+#define PINMUX_PB01A_TWIMS1_TWCK   ((PIN_PB01A_TWIMS1_TWCK << 16) | MUX_PB01A_TWIMS1_TWCK)
+#define GPIO_PB01A_TWIMS1_TWCK   _UL(1 <<  1)
+#define PIN_PB00A_TWIMS1_TWD           _L(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
+#define MUX_PB00A_TWIMS1_TWD            _L(0)
+#define PINMUX_PB00A_TWIMS1_TWD    ((PIN_PB00A_TWIMS1_TWD << 16) | MUX_PB00A_TWIMS1_TWD)
+#define GPIO_PB00A_TWIMS1_TWD    _UL(1 <<  0)
+/* ========== GPIO definition for TWIMS2 peripheral ========== */
+#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
+#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+/* ========== GPIO definition for TWIMS3 peripheral ========== */
+#define PIN_PB15C_TWIMS3_TWCK          _L(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
+#define MUX_PB15C_TWIMS3_TWCK           _L(2)
+#define PINMUX_PB15C_TWIMS3_TWCK   ((PIN_PB15C_TWIMS3_TWCK << 16) | MUX_PB15C_TWIMS3_TWCK)
+#define GPIO_PB15C_TWIMS3_TWCK   _UL(1 << 15)
+#define PIN_PB14C_TWIMS3_TWD           _L(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
+#define MUX_PB14C_TWIMS3_TWD            _L(2)
+#define PINMUX_PB14C_TWIMS3_TWD    ((PIN_PB14C_TWIMS3_TWD << 16) | MUX_PB14C_TWIMS3_TWD)
+#define GPIO_PB14C_TWIMS3_TWD    _UL(1 << 14)
+/* ========== GPIO definition for IISC peripheral ========== */
+#define PIN_PB05D_IISC_IMCK            _L(37) /**< \brief IISC signal: IMCK on PB05 mux D */
+#define MUX_PB05D_IISC_IMCK             _L(3)
+#define PINMUX_PB05D_IISC_IMCK     ((PIN_PB05D_IISC_IMCK << 16) | MUX_PB05D_IISC_IMCK)
+#define GPIO_PB05D_IISC_IMCK     _UL(1 <<  5)
+#define PIN_PB02D_IISC_ISCK            _L(34) /**< \brief IISC signal: ISCK on PB02 mux D */
+#define MUX_PB02D_IISC_ISCK             _L(3)
+#define PINMUX_PB02D_IISC_ISCK     ((PIN_PB02D_IISC_ISCK << 16) | MUX_PB02D_IISC_ISCK)
+#define GPIO_PB02D_IISC_ISCK     _UL(1 <<  2)
+#define PIN_PB03D_IISC_ISDI            _L(35) /**< \brief IISC signal: ISDI on PB03 mux D */
+#define MUX_PB03D_IISC_ISDI             _L(3)
+#define PINMUX_PB03D_IISC_ISDI     ((PIN_PB03D_IISC_ISDI << 16) | MUX_PB03D_IISC_ISDI)
+#define GPIO_PB03D_IISC_ISDI     _UL(1 <<  3)
+#define PIN_PB04D_IISC_ISDO            _L(36) /**< \brief IISC signal: ISDO on PB04 mux D */
+#define MUX_PB04D_IISC_ISDO             _L(3)
+#define PINMUX_PB04D_IISC_ISDO     ((PIN_PB04D_IISC_ISDO << 16) | MUX_PB04D_IISC_ISDO)
+#define GPIO_PB04D_IISC_ISDO     _UL(1 <<  4)
+#define PIN_PB06D_IISC_IWS             _L(38) /**< \brief IISC signal: IWS on PB06 mux D */
+#define MUX_PB06D_IISC_IWS              _L(3)
+#define PINMUX_PB06D_IISC_IWS      ((PIN_PB06D_IISC_IWS << 16) | MUX_PB06D_IISC_IWS)
+#define GPIO_PB06D_IISC_IWS      _UL(1 <<  6)
+/* ========== GPIO definition for SPI peripheral ========== */
+#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L(1)
+#define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
+#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
+#define PIN_PB14B_SPI_MISO             _L(46) /**< \brief SPI signal: MISO on PB14 mux B */
+#define MUX_PB14B_SPI_MISO              _L(1)
+#define PINMUX_PB14B_SPI_MISO      ((PIN_PB14B_SPI_MISO << 16) | MUX_PB14B_SPI_MISO)
+#define GPIO_PB14B_SPI_MISO      _UL(1 << 14)
+#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L(0)
+#define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
+#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
+#define PIN_PB15B_SPI_MOSI             _L(47) /**< \brief SPI signal: MOSI on PB15 mux B */
+#define MUX_PB15B_SPI_MOSI              _L(1)
+#define PINMUX_PB15B_SPI_MOSI      ((PIN_PB15B_SPI_MOSI << 16) | MUX_PB15B_SPI_MOSI)
+#define GPIO_PB15B_SPI_MOSI      _UL(1 << 15)
+#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L(0)
+#define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
+#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
+#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
+#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
+#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
+#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
+#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
+#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PB13B_SPI_NPCS1            _L(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
+#define MUX_PB13B_SPI_NPCS1             _L(1)
+#define PINMUX_PB13B_SPI_NPCS1     ((PIN_PB13B_SPI_NPCS1 << 16) | MUX_PB13B_SPI_NPCS1)
+#define GPIO_PB13B_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
+#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
+#define PIN_PB11B_SPI_NPCS2            _L(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
+#define MUX_PB11B_SPI_NPCS2             _L(1)
+#define PINMUX_PB11B_SPI_NPCS2     ((PIN_PB11B_SPI_NPCS2 << 16) | MUX_PB11B_SPI_NPCS2)
+#define GPIO_PB11B_SPI_NPCS2     _UL(1 << 11)
+#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
+#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
+#define PIN_PB12B_SPI_NPCS3            _L(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
+#define MUX_PB12B_SPI_NPCS3             _L(1)
+#define PINMUX_PB12B_SPI_NPCS3     ((PIN_PB12B_SPI_NPCS3 << 16) | MUX_PB12B_SPI_NPCS3)
+#define GPIO_PB12B_SPI_NPCS3     _UL(1 << 12)
+#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L(0)
+#define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
+#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
+/* ========== GPIO definition for TC0 peripheral ========== */
+#define PIN_PB07D_TC0_A0               _L(39) /**< \brief TC0 signal: A0 on PB07 mux D */
+#define MUX_PB07D_TC0_A0                _L(3)
+#define PINMUX_PB07D_TC0_A0        ((PIN_PB07D_TC0_A0 << 16) | MUX_PB07D_TC0_A0)
+#define GPIO_PB07D_TC0_A0        _UL(1 <<  7)
+#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L(1)
+#define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
+#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
+#define PIN_PB09D_TC0_A1               _L(41) /**< \brief TC0 signal: A1 on PB09 mux D */
+#define MUX_PB09D_TC0_A1                _L(3)
+#define PINMUX_PB09D_TC0_A1        ((PIN_PB09D_TC0_A1 << 16) | MUX_PB09D_TC0_A1)
+#define GPIO_PB09D_TC0_A1        _UL(1 <<  9)
+#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L(1)
+#define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
+#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
+#define PIN_PB11D_TC0_A2               _L(43) /**< \brief TC0 signal: A2 on PB11 mux D */
+#define MUX_PB11D_TC0_A2                _L(3)
+#define PINMUX_PB11D_TC0_A2        ((PIN_PB11D_TC0_A2 << 16) | MUX_PB11D_TC0_A2)
+#define GPIO_PB11D_TC0_A2        _UL(1 << 11)
+#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L(1)
+#define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
+#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
+#define PIN_PB08D_TC0_B0               _L(40) /**< \brief TC0 signal: B0 on PB08 mux D */
+#define MUX_PB08D_TC0_B0                _L(3)
+#define PINMUX_PB08D_TC0_B0        ((PIN_PB08D_TC0_B0 << 16) | MUX_PB08D_TC0_B0)
+#define GPIO_PB08D_TC0_B0        _UL(1 <<  8)
+#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L(1)
+#define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
+#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
+#define PIN_PB10D_TC0_B1               _L(42) /**< \brief TC0 signal: B1 on PB10 mux D */
+#define MUX_PB10D_TC0_B1                _L(3)
+#define PINMUX_PB10D_TC0_B1        ((PIN_PB10D_TC0_B1 << 16) | MUX_PB10D_TC0_B1)
+#define GPIO_PB10D_TC0_B1        _UL(1 << 10)
+#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L(1)
+#define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
+#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
+#define PIN_PB12D_TC0_B2               _L(44) /**< \brief TC0 signal: B2 on PB12 mux D */
+#define MUX_PB12D_TC0_B2                _L(3)
+#define PINMUX_PB12D_TC0_B2        ((PIN_PB12D_TC0_B2 << 16) | MUX_PB12D_TC0_B2)
+#define GPIO_PB12D_TC0_B2        _UL(1 << 12)
+#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L(1)
+#define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
+#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
+#define PIN_PB13D_TC0_CLK0             _L(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
+#define MUX_PB13D_TC0_CLK0              _L(3)
+#define PINMUX_PB13D_TC0_CLK0      ((PIN_PB13D_TC0_CLK0 << 16) | MUX_PB13D_TC0_CLK0)
+#define GPIO_PB13D_TC0_CLK0      _UL(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L(1)
+#define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
+#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
+#define PIN_PB14D_TC0_CLK1             _L(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
+#define MUX_PB14D_TC0_CLK1              _L(3)
+#define PINMUX_PB14D_TC0_CLK1      ((PIN_PB14D_TC0_CLK1 << 16) | MUX_PB14D_TC0_CLK1)
+#define GPIO_PB14D_TC0_CLK1      _UL(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L(1)
+#define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
+#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
+#define PIN_PB15D_TC0_CLK2             _L(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
+#define MUX_PB15D_TC0_CLK2              _L(3)
+#define PINMUX_PB15D_TC0_CLK2      ((PIN_PB15D_TC0_CLK2 << 16) | MUX_PB15D_TC0_CLK2)
+#define GPIO_PB15D_TC0_CLK2      _UL(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L(1)
+#define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
+#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+/* ========== GPIO definition for USART0 peripheral ========== */
+#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L(1)
+#define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
+#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
+#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L(0)
+#define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
+#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
+#define PIN_PB13A_USART0_CLK           _L(45) /**< \brief USART0 signal: CLK on PB13 mux A */
+#define MUX_PB13A_USART0_CLK            _L(0)
+#define PINMUX_PB13A_USART0_CLK    ((PIN_PB13A_USART0_CLK << 16) | MUX_PB13A_USART0_CLK)
+#define GPIO_PB13A_USART0_CLK    _UL(1 << 13)
+#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L(0)
+#define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
+#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
+#define PIN_PB11A_USART0_CTS           _L(43) /**< \brief USART0 signal: CTS on PB11 mux A */
+#define MUX_PB11A_USART0_CTS            _L(0)
+#define PINMUX_PB11A_USART0_CTS    ((PIN_PB11A_USART0_CTS << 16) | MUX_PB11A_USART0_CTS)
+#define GPIO_PB11A_USART0_CTS    _UL(1 << 11)
+#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L(1)
+#define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
+#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
+#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L(0)
+#define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
+#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
+#define PIN_PB12A_USART0_RTS           _L(44) /**< \brief USART0 signal: RTS on PB12 mux A */
+#define MUX_PB12A_USART0_RTS            _L(0)
+#define PINMUX_PB12A_USART0_RTS    ((PIN_PB12A_USART0_RTS << 16) | MUX_PB12A_USART0_RTS)
+#define GPIO_PB12A_USART0_RTS    _UL(1 << 12)
+#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L(1)
+#define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
+#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
+#define PIN_PB00B_USART0_RXD           _L(32) /**< \brief USART0 signal: RXD on PB00 mux B */
+#define MUX_PB00B_USART0_RXD            _L(1)
+#define PINMUX_PB00B_USART0_RXD    ((PIN_PB00B_USART0_RXD << 16) | MUX_PB00B_USART0_RXD)
+#define GPIO_PB00B_USART0_RXD    _UL(1 <<  0)
+#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L(0)
+#define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
+#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
+#define PIN_PB14A_USART0_RXD           _L(46) /**< \brief USART0 signal: RXD on PB14 mux A */
+#define MUX_PB14A_USART0_RXD            _L(0)
+#define PINMUX_PB14A_USART0_RXD    ((PIN_PB14A_USART0_RXD << 16) | MUX_PB14A_USART0_RXD)
+#define GPIO_PB14A_USART0_RXD    _UL(1 << 14)
+#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L(1)
+#define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
+#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
+#define PIN_PB01B_USART0_TXD           _L(33) /**< \brief USART0 signal: TXD on PB01 mux B */
+#define MUX_PB01B_USART0_TXD            _L(1)
+#define PINMUX_PB01B_USART0_TXD    ((PIN_PB01B_USART0_TXD << 16) | MUX_PB01B_USART0_TXD)
+#define GPIO_PB01B_USART0_TXD    _UL(1 <<  1)
+#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L(0)
+#define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
+#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
+#define PIN_PB15A_USART0_TXD           _L(47) /**< \brief USART0 signal: TXD on PB15 mux A */
+#define MUX_PB15A_USART0_TXD            _L(0)
+#define PINMUX_PB15A_USART0_TXD    ((PIN_PB15A_USART0_TXD << 16) | MUX_PB15A_USART0_TXD)
+#define GPIO_PB15A_USART0_TXD    _UL(1 << 15)
+/* ========== GPIO definition for USART1 peripheral ========== */
+#define PIN_PB03B_USART1_CLK           _L(35) /**< \brief USART1 signal: CLK on PB03 mux B */
+#define MUX_PB03B_USART1_CLK            _L(1)
+#define PINMUX_PB03B_USART1_CLK    ((PIN_PB03B_USART1_CLK << 16) | MUX_PB03B_USART1_CLK)
+#define GPIO_PB03B_USART1_CLK    _UL(1 <<  3)
+#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L(0)
+#define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
+#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
+#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L(1)
+#define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
+#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
+#define PIN_PB02B_USART1_RTS           _L(34) /**< \brief USART1 signal: RTS on PB02 mux B */
+#define MUX_PB02B_USART1_RTS            _L(1)
+#define PINMUX_PB02B_USART1_RTS    ((PIN_PB02B_USART1_RTS << 16) | MUX_PB02B_USART1_RTS)
+#define GPIO_PB02B_USART1_RTS    _UL(1 <<  2)
+#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L(0)
+#define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
+#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
+#define PIN_PB04B_USART1_RXD           _L(36) /**< \brief USART1 signal: RXD on PB04 mux B */
+#define MUX_PB04B_USART1_RXD            _L(1)
+#define PINMUX_PB04B_USART1_RXD    ((PIN_PB04B_USART1_RXD << 16) | MUX_PB04B_USART1_RXD)
+#define GPIO_PB04B_USART1_RXD    _UL(1 <<  4)
+#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L(0)
+#define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
+#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
+#define PIN_PB05B_USART1_TXD           _L(37) /**< \brief USART1 signal: TXD on PB05 mux B */
+#define MUX_PB05B_USART1_TXD            _L(1)
+#define PINMUX_PB05B_USART1_TXD    ((PIN_PB05B_USART1_TXD << 16) | MUX_PB05B_USART1_TXD)
+#define GPIO_PB05B_USART1_TXD    _UL(1 <<  5)
+#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L(0)
+#define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
+#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+/* ========== GPIO definition for USART2 peripheral ========== */
+#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L(0)
+#define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
+#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
+#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L(1)
+#define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
+#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
+#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L(0)
+#define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
+#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L(1)
+#define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
+#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
+#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L(0)
+#define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
+#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L(1)
+#define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
+#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
+#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L(0)
+#define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
+#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+/* ========== GPIO definition for USART3 peripheral ========== */
+#define PIN_PB08A_USART3_CLK           _L(40) /**< \brief USART3 signal: CLK on PB08 mux A */
+#define MUX_PB08A_USART3_CLK            _L(0)
+#define PINMUX_PB08A_USART3_CLK    ((PIN_PB08A_USART3_CLK << 16) | MUX_PB08A_USART3_CLK)
+#define GPIO_PB08A_USART3_CLK    _UL(1 <<  8)
+#define PIN_PB07A_USART3_CTS           _L(39) /**< \brief USART3 signal: CTS on PB07 mux A */
+#define MUX_PB07A_USART3_CTS            _L(0)
+#define PINMUX_PB07A_USART3_CTS    ((PIN_PB07A_USART3_CTS << 16) | MUX_PB07A_USART3_CTS)
+#define GPIO_PB07A_USART3_CTS    _UL(1 <<  7)
+#define PIN_PB06A_USART3_RTS           _L(38) /**< \brief USART3 signal: RTS on PB06 mux A */
+#define MUX_PB06A_USART3_RTS            _L(0)
+#define PINMUX_PB06A_USART3_RTS    ((PIN_PB06A_USART3_RTS << 16) | MUX_PB06A_USART3_RTS)
+#define GPIO_PB06A_USART3_RTS    _UL(1 <<  6)
+#define PIN_PB09A_USART3_RXD           _L(41) /**< \brief USART3 signal: RXD on PB09 mux A */
+#define MUX_PB09A_USART3_RXD            _L(0)
+#define PINMUX_PB09A_USART3_RXD    ((PIN_PB09A_USART3_RXD << 16) | MUX_PB09A_USART3_RXD)
+#define GPIO_PB09A_USART3_RXD    _UL(1 <<  9)
+#define PIN_PB10A_USART3_TXD           _L(42) /**< \brief USART3 signal: TXD on PB10 mux A */
+#define MUX_PB10A_USART3_TXD            _L(0)
+#define PINMUX_PB10A_USART3_TXD    ((PIN_PB10A_USART3_TXD << 16) | MUX_PB10A_USART3_TXD)
+#define GPIO_PB10A_USART3_TXD    _UL(1 << 10)
+/* ========== GPIO definition for ADCIFE peripheral ========== */
+#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
+#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
+#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
+#define PIN_PB02A_ADCIFE_AD3           _L(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
+#define MUX_PB02A_ADCIFE_AD3            _L(0)
+#define PINMUX_PB02A_ADCIFE_AD3    ((PIN_PB02A_ADCIFE_AD3 << 16) | MUX_PB02A_ADCIFE_AD3)
+#define GPIO_PB02A_ADCIFE_AD3    _UL(1 <<  2)
+#define PIN_PB03A_ADCIFE_AD4           _L(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
+#define MUX_PB03A_ADCIFE_AD4            _L(0)
+#define PINMUX_PB03A_ADCIFE_AD4    ((PIN_PB03A_ADCIFE_AD4 << 16) | MUX_PB03A_ADCIFE_AD4)
+#define GPIO_PB03A_ADCIFE_AD4    _UL(1 <<  3)
+#define PIN_PB04A_ADCIFE_AD5           _L(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
+#define MUX_PB04A_ADCIFE_AD5            _L(0)
+#define PINMUX_PB04A_ADCIFE_AD5    ((PIN_PB04A_ADCIFE_AD5 << 16) | MUX_PB04A_ADCIFE_AD5)
+#define GPIO_PB04A_ADCIFE_AD5    _UL(1 <<  4)
+#define PIN_PB05A_ADCIFE_AD6           _L(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
+#define MUX_PB05A_ADCIFE_AD6            _L(0)
+#define PINMUX_PB05A_ADCIFE_AD6    ((PIN_PB05A_ADCIFE_AD6 << 16) | MUX_PB05A_ADCIFE_AD6)
+#define GPIO_PB05A_ADCIFE_AD6    _UL(1 <<  5)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+/* ========== GPIO definition for DACC peripheral ========== */
+#define PIN_PB04E_DACC_EXT_TRIG0       _L(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
+#define MUX_PB04E_DACC_EXT_TRIG0        _L(4)
+#define PINMUX_PB04E_DACC_EXT_TRIG0  ((PIN_PB04E_DACC_EXT_TRIG0 << 16) | MUX_PB04E_DACC_EXT_TRIG0)
+#define GPIO_PB04E_DACC_EXT_TRIG0  _UL(1 <<  4)
+#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L(0)
+#define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
+#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+/* ========== GPIO definition for ACIFC peripheral ========== */
+#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
+#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
+#define PIN_PB02E_ACIFC_ACBN0          _L(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
+#define MUX_PB02E_ACIFC_ACBN0           _L(4)
+#define PINMUX_PB02E_ACIFC_ACBN0   ((PIN_PB02E_ACIFC_ACBN0 << 16) | MUX_PB02E_ACIFC_ACBN0)
+#define GPIO_PB02E_ACIFC_ACBN0   _UL(1 <<  2)
+#define PIN_PB03E_ACIFC_ACBP0          _L(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
+#define MUX_PB03E_ACIFC_ACBP0           _L(4)
+#define PINMUX_PB03E_ACIFC_ACBP0   ((PIN_PB03E_ACIFC_ACBP0 << 16) | MUX_PB03E_ACIFC_ACBP0)
+#define GPIO_PB03E_ACIFC_ACBP0   _UL(1 <<  3)
+/* ========== GPIO definition for GLOC peripheral ========== */
+#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
+#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L(3)
+#define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
+#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L(3)
+#define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
+#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L(3)
+#define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
+#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L(3)
+#define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
+#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L(3)
+#define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
+#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L(3)
+#define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
+#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L(3)
+#define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
+#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
+#define PIN_PB06C_GLOC_IN4             _L(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
+#define MUX_PB06C_GLOC_IN4              _L(2)
+#define PINMUX_PB06C_GLOC_IN4      ((PIN_PB06C_GLOC_IN4 << 16) | MUX_PB06C_GLOC_IN4)
+#define GPIO_PB06C_GLOC_IN4      _UL(1 <<  6)
+#define PIN_PB07C_GLOC_IN5             _L(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
+#define MUX_PB07C_GLOC_IN5              _L(2)
+#define PINMUX_PB07C_GLOC_IN5      ((PIN_PB07C_GLOC_IN5 << 16) | MUX_PB07C_GLOC_IN5)
+#define GPIO_PB07C_GLOC_IN5      _UL(1 <<  7)
+#define PIN_PB08C_GLOC_IN6             _L(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
+#define MUX_PB08C_GLOC_IN6              _L(2)
+#define PINMUX_PB08C_GLOC_IN6      ((PIN_PB08C_GLOC_IN6 << 16) | MUX_PB08C_GLOC_IN6)
+#define GPIO_PB08C_GLOC_IN6      _UL(1 <<  8)
+#define PIN_PB09C_GLOC_IN7             _L(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
+#define MUX_PB09C_GLOC_IN7              _L(2)
+#define PINMUX_PB09C_GLOC_IN7      ((PIN_PB09C_GLOC_IN7 << 16) | MUX_PB09C_GLOC_IN7)
+#define GPIO_PB09C_GLOC_IN7      _UL(1 <<  9)
+#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
+#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
+#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
+#define PIN_PB10C_GLOC_OUT1            _L(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
+#define MUX_PB10C_GLOC_OUT1             _L(2)
+#define PINMUX_PB10C_GLOC_OUT1     ((PIN_PB10C_GLOC_OUT1 << 16) | MUX_PB10C_GLOC_OUT1)
+#define GPIO_PB10C_GLOC_OUT1     _UL(1 << 10)
+/* ========== GPIO definition for ABDACB peripheral ========== */
+#define PIN_PB02C_ABDACB_DAC0          _L(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
+#define MUX_PB02C_ABDACB_DAC0           _L(2)
+#define PINMUX_PB02C_ABDACB_DAC0   ((PIN_PB02C_ABDACB_DAC0 << 16) | MUX_PB02C_ABDACB_DAC0)
+#define GPIO_PB02C_ABDACB_DAC0   _UL(1 <<  2)
+#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
+#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
+#define PIN_PB04C_ABDACB_DAC1          _L(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
+#define MUX_PB04C_ABDACB_DAC1           _L(2)
+#define PINMUX_PB04C_ABDACB_DAC1   ((PIN_PB04C_ABDACB_DAC1 << 16) | MUX_PB04C_ABDACB_DAC1)
+#define GPIO_PB04C_ABDACB_DAC1   _UL(1 <<  4)
+#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
+#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
+#define PIN_PB03C_ABDACB_DACN0         _L(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
+#define MUX_PB03C_ABDACB_DACN0          _L(2)
+#define PINMUX_PB03C_ABDACB_DACN0  ((PIN_PB03C_ABDACB_DACN0 << 16) | MUX_PB03C_ABDACB_DACN0)
+#define GPIO_PB03C_ABDACB_DACN0  _UL(1 <<  3)
+#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
+#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
+#define PIN_PB05C_ABDACB_DACN1         _L(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
+#define MUX_PB05C_ABDACB_DACN1          _L(2)
+#define PINMUX_PB05C_ABDACB_DACN1  ((PIN_PB05C_ABDACB_DACN1 << 16) | MUX_PB05C_ABDACB_DACN1)
+#define GPIO_PB05C_ABDACB_DACN1  _UL(1 <<  5)
+#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
+#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+/* ========== GPIO definition for PARC peripheral ========== */
+#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
+#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
+#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
+#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
+#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
+#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
+#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
+#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
+#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
+#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
+#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
+#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
+#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
+#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
+#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
+#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
+#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
+#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
+#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
+#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
+#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+/* ========== GPIO definition for CATB peripheral ========== */
+#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L(6)
+#define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
+#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L(6)
+#define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
+#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L(6)
+#define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
+#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
+#define PIN_PB03G_CATB_DIS             _L(35) /**< \brief CATB signal: DIS on PB03 mux G */
+#define MUX_PB03G_CATB_DIS              _L(6)
+#define PINMUX_PB03G_CATB_DIS      ((PIN_PB03G_CATB_DIS << 16) | MUX_PB03G_CATB_DIS)
+#define GPIO_PB03G_CATB_DIS      _UL(1 <<  3)
+#define PIN_PB12G_CATB_DIS             _L(44) /**< \brief CATB signal: DIS on PB12 mux G */
+#define MUX_PB12G_CATB_DIS              _L(6)
+#define PINMUX_PB12G_CATB_DIS      ((PIN_PB12G_CATB_DIS << 16) | MUX_PB12G_CATB_DIS)
+#define GPIO_PB12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
+#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
+#define PIN_PB13G_CATB_SENSE0          _L(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
+#define MUX_PB13G_CATB_SENSE0           _L(6)
+#define PINMUX_PB13G_CATB_SENSE0   ((PIN_PB13G_CATB_SENSE0 << 16) | MUX_PB13G_CATB_SENSE0)
+#define GPIO_PB13G_CATB_SENSE0   _UL(1 << 13)
+#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
+#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
+#define PIN_PB14G_CATB_SENSE1          _L(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
+#define MUX_PB14G_CATB_SENSE1           _L(6)
+#define PINMUX_PB14G_CATB_SENSE1   ((PIN_PB14G_CATB_SENSE1 << 16) | MUX_PB14G_CATB_SENSE1)
+#define GPIO_PB14G_CATB_SENSE1   _UL(1 << 14)
+#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
+#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
+#define PIN_PB15G_CATB_SENSE2          _L(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
+#define MUX_PB15G_CATB_SENSE2           _L(6)
+#define PINMUX_PB15G_CATB_SENSE2   ((PIN_PB15G_CATB_SENSE2 << 16) | MUX_PB15G_CATB_SENSE2)
+#define GPIO_PB15G_CATB_SENSE2   _UL(1 << 15)
+#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
+#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
+#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
+#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
+#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
+#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
+#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
+#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
+#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
+#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
+#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
+#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
+#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
+#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
+#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
+#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
+#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
+#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
+#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
+#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
+#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
+#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
+#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
+#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
+#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
+#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
+#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
+#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
+#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
+#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
+#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
+#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
+#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
+#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
+#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
+#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
+#define PIN_PB00G_CATB_SENSE21         _L(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
+#define MUX_PB00G_CATB_SENSE21          _L(6)
+#define PINMUX_PB00G_CATB_SENSE21  ((PIN_PB00G_CATB_SENSE21 << 16) | MUX_PB00G_CATB_SENSE21)
+#define GPIO_PB00G_CATB_SENSE21  _UL(1 <<  0)
+#define PIN_PB01G_CATB_SENSE22         _L(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
+#define MUX_PB01G_CATB_SENSE22          _L(6)
+#define PINMUX_PB01G_CATB_SENSE22  ((PIN_PB01G_CATB_SENSE22 << 16) | MUX_PB01G_CATB_SENSE22)
+#define GPIO_PB01G_CATB_SENSE22  _UL(1 <<  1)
+#define PIN_PB02G_CATB_SENSE23         _L(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
+#define MUX_PB02G_CATB_SENSE23          _L(6)
+#define PINMUX_PB02G_CATB_SENSE23  ((PIN_PB02G_CATB_SENSE23 << 16) | MUX_PB02G_CATB_SENSE23)
+#define GPIO_PB02G_CATB_SENSE23  _UL(1 <<  2)
+#define PIN_PB04G_CATB_SENSE24         _L(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
+#define MUX_PB04G_CATB_SENSE24          _L(6)
+#define PINMUX_PB04G_CATB_SENSE24  ((PIN_PB04G_CATB_SENSE24 << 16) | MUX_PB04G_CATB_SENSE24)
+#define GPIO_PB04G_CATB_SENSE24  _UL(1 <<  4)
+#define PIN_PB05G_CATB_SENSE25         _L(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
+#define MUX_PB05G_CATB_SENSE25          _L(6)
+#define PINMUX_PB05G_CATB_SENSE25  ((PIN_PB05G_CATB_SENSE25 << 16) | MUX_PB05G_CATB_SENSE25)
+#define GPIO_PB05G_CATB_SENSE25  _UL(1 <<  5)
+#define PIN_PB06G_CATB_SENSE26         _L(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
+#define MUX_PB06G_CATB_SENSE26          _L(6)
+#define PINMUX_PB06G_CATB_SENSE26  ((PIN_PB06G_CATB_SENSE26 << 16) | MUX_PB06G_CATB_SENSE26)
+#define GPIO_PB06G_CATB_SENSE26  _UL(1 <<  6)
+#define PIN_PB07G_CATB_SENSE27         _L(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
+#define MUX_PB07G_CATB_SENSE27          _L(6)
+#define PINMUX_PB07G_CATB_SENSE27  ((PIN_PB07G_CATB_SENSE27 << 16) | MUX_PB07G_CATB_SENSE27)
+#define GPIO_PB07G_CATB_SENSE27  _UL(1 <<  7)
+#define PIN_PB08G_CATB_SENSE28         _L(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
+#define MUX_PB08G_CATB_SENSE28          _L(6)
+#define PINMUX_PB08G_CATB_SENSE28  ((PIN_PB08G_CATB_SENSE28 << 16) | MUX_PB08G_CATB_SENSE28)
+#define GPIO_PB08G_CATB_SENSE28  _UL(1 <<  8)
+#define PIN_PB09G_CATB_SENSE29         _L(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
+#define MUX_PB09G_CATB_SENSE29          _L(6)
+#define PINMUX_PB09G_CATB_SENSE29  ((PIN_PB09G_CATB_SENSE29 << 16) | MUX_PB09G_CATB_SENSE29)
+#define GPIO_PB09G_CATB_SENSE29  _UL(1 <<  9)
+#define PIN_PB10G_CATB_SENSE30         _L(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
+#define MUX_PB10G_CATB_SENSE30          _L(6)
+#define PINMUX_PB10G_CATB_SENSE30  ((PIN_PB10G_CATB_SENSE30 << 16) | MUX_PB10G_CATB_SENSE30)
+#define GPIO_PB10G_CATB_SENSE30  _UL(1 << 10)
+#define PIN_PB11G_CATB_SENSE31         _L(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
+#define MUX_PB11G_CATB_SENSE31          _L(6)
+#define PINMUX_PB11G_CATB_SENSE31  ((PIN_PB11G_CATB_SENSE31 << 16) | MUX_PB11G_CATB_SENSE31)
+#define GPIO_PB11G_CATB_SENSE31  _UL(1 << 11)
+/* ========== GPIO definition for LCDCA peripheral ========== */
+#define PIN_PA12F_LCDCA_COM0           _L(12) /**< \brief LCDCA signal: COM0 on PA12 mux F */
+#define MUX_PA12F_LCDCA_COM0            _L(5)
+#define PINMUX_PA12F_LCDCA_COM0    ((PIN_PA12F_LCDCA_COM0 << 16) | MUX_PA12F_LCDCA_COM0)
+#define GPIO_PA12F_LCDCA_COM0    _UL(1 << 12)
+#define PIN_PA11F_LCDCA_COM1           _L(11) /**< \brief LCDCA signal: COM1 on PA11 mux F */
+#define MUX_PA11F_LCDCA_COM1            _L(5)
+#define PINMUX_PA11F_LCDCA_COM1    ((PIN_PA11F_LCDCA_COM1 << 16) | MUX_PA11F_LCDCA_COM1)
+#define GPIO_PA11F_LCDCA_COM1    _UL(1 << 11)
+#define PIN_PA10F_LCDCA_COM2           _L(10) /**< \brief LCDCA signal: COM2 on PA10 mux F */
+#define MUX_PA10F_LCDCA_COM2            _L(5)
+#define PINMUX_PA10F_LCDCA_COM2    ((PIN_PA10F_LCDCA_COM2 << 16) | MUX_PA10F_LCDCA_COM2)
+#define GPIO_PA10F_LCDCA_COM2    _UL(1 << 10)
+#define PIN_PA09F_LCDCA_COM3            _L(9) /**< \brief LCDCA signal: COM3 on PA09 mux F */
+#define MUX_PA09F_LCDCA_COM3            _L(5)
+#define PINMUX_PA09F_LCDCA_COM3    ((PIN_PA09F_LCDCA_COM3 << 16) | MUX_PA09F_LCDCA_COM3)
+#define GPIO_PA09F_LCDCA_COM3    _UL(1 <<  9)
+#define PIN_PA13F_LCDCA_SEG5           _L(13) /**< \brief LCDCA signal: SEG5 on PA13 mux F */
+#define MUX_PA13F_LCDCA_SEG5            _L(5)
+#define PINMUX_PA13F_LCDCA_SEG5    ((PIN_PA13F_LCDCA_SEG5 << 16) | MUX_PA13F_LCDCA_SEG5)
+#define GPIO_PA13F_LCDCA_SEG5    _UL(1 << 13)
+#define PIN_PA14F_LCDCA_SEG6           _L(14) /**< \brief LCDCA signal: SEG6 on PA14 mux F */
+#define MUX_PA14F_LCDCA_SEG6            _L(5)
+#define PINMUX_PA14F_LCDCA_SEG6    ((PIN_PA14F_LCDCA_SEG6 << 16) | MUX_PA14F_LCDCA_SEG6)
+#define GPIO_PA14F_LCDCA_SEG6    _UL(1 << 14)
+#define PIN_PA15F_LCDCA_SEG7           _L(15) /**< \brief LCDCA signal: SEG7 on PA15 mux F */
+#define MUX_PA15F_LCDCA_SEG7            _L(5)
+#define PINMUX_PA15F_LCDCA_SEG7    ((PIN_PA15F_LCDCA_SEG7 << 16) | MUX_PA15F_LCDCA_SEG7)
+#define GPIO_PA15F_LCDCA_SEG7    _UL(1 << 15)
+#define PIN_PA16F_LCDCA_SEG8           _L(16) /**< \brief LCDCA signal: SEG8 on PA16 mux F */
+#define MUX_PA16F_LCDCA_SEG8            _L(5)
+#define PINMUX_PA16F_LCDCA_SEG8    ((PIN_PA16F_LCDCA_SEG8 << 16) | MUX_PA16F_LCDCA_SEG8)
+#define GPIO_PA16F_LCDCA_SEG8    _UL(1 << 16)
+#define PIN_PA17F_LCDCA_SEG9           _L(17) /**< \brief LCDCA signal: SEG9 on PA17 mux F */
+#define MUX_PA17F_LCDCA_SEG9            _L(5)
+#define PINMUX_PA17F_LCDCA_SEG9    ((PIN_PA17F_LCDCA_SEG9 << 16) | MUX_PA17F_LCDCA_SEG9)
+#define GPIO_PA17F_LCDCA_SEG9    _UL(1 << 17)
+#define PIN_PB08F_LCDCA_SEG14          _L(40) /**< \brief LCDCA signal: SEG14 on PB08 mux F */
+#define MUX_PB08F_LCDCA_SEG14           _L(5)
+#define PINMUX_PB08F_LCDCA_SEG14   ((PIN_PB08F_LCDCA_SEG14 << 16) | MUX_PB08F_LCDCA_SEG14)
+#define GPIO_PB08F_LCDCA_SEG14   _UL(1 <<  8)
+#define PIN_PB09F_LCDCA_SEG15          _L(41) /**< \brief LCDCA signal: SEG15 on PB09 mux F */
+#define MUX_PB09F_LCDCA_SEG15           _L(5)
+#define PINMUX_PB09F_LCDCA_SEG15   ((PIN_PB09F_LCDCA_SEG15 << 16) | MUX_PB09F_LCDCA_SEG15)
+#define GPIO_PB09F_LCDCA_SEG15   _UL(1 <<  9)
+#define PIN_PB10F_LCDCA_SEG16          _L(42) /**< \brief LCDCA signal: SEG16 on PB10 mux F */
+#define MUX_PB10F_LCDCA_SEG16           _L(5)
+#define PINMUX_PB10F_LCDCA_SEG16   ((PIN_PB10F_LCDCA_SEG16 << 16) | MUX_PB10F_LCDCA_SEG16)
+#define GPIO_PB10F_LCDCA_SEG16   _UL(1 << 10)
+#define PIN_PB11F_LCDCA_SEG17          _L(43) /**< \brief LCDCA signal: SEG17 on PB11 mux F */
+#define MUX_PB11F_LCDCA_SEG17           _L(5)
+#define PINMUX_PB11F_LCDCA_SEG17   ((PIN_PB11F_LCDCA_SEG17 << 16) | MUX_PB11F_LCDCA_SEG17)
+#define GPIO_PB11F_LCDCA_SEG17   _UL(1 << 11)
+#define PIN_PA18F_LCDCA_SEG18          _L(18) /**< \brief LCDCA signal: SEG18 on PA18 mux F */
+#define MUX_PA18F_LCDCA_SEG18           _L(5)
+#define PINMUX_PA18F_LCDCA_SEG18   ((PIN_PA18F_LCDCA_SEG18 << 16) | MUX_PA18F_LCDCA_SEG18)
+#define GPIO_PA18F_LCDCA_SEG18   _UL(1 << 18)
+#define PIN_PA19F_LCDCA_SEG19          _L(19) /**< \brief LCDCA signal: SEG19 on PA19 mux F */
+#define MUX_PA19F_LCDCA_SEG19           _L(5)
+#define PINMUX_PA19F_LCDCA_SEG19   ((PIN_PA19F_LCDCA_SEG19 << 16) | MUX_PA19F_LCDCA_SEG19)
+#define GPIO_PA19F_LCDCA_SEG19   _UL(1 << 19)
+#define PIN_PA20F_LCDCA_SEG20          _L(20) /**< \brief LCDCA signal: SEG20 on PA20 mux F */
+#define MUX_PA20F_LCDCA_SEG20           _L(5)
+#define PINMUX_PA20F_LCDCA_SEG20   ((PIN_PA20F_LCDCA_SEG20 << 16) | MUX_PA20F_LCDCA_SEG20)
+#define GPIO_PA20F_LCDCA_SEG20   _UL(1 << 20)
+#define PIN_PB07F_LCDCA_SEG21          _L(39) /**< \brief LCDCA signal: SEG21 on PB07 mux F */
+#define MUX_PB07F_LCDCA_SEG21           _L(5)
+#define PINMUX_PB07F_LCDCA_SEG21   ((PIN_PB07F_LCDCA_SEG21 << 16) | MUX_PB07F_LCDCA_SEG21)
+#define GPIO_PB07F_LCDCA_SEG21   _UL(1 <<  7)
+#define PIN_PB06F_LCDCA_SEG22          _L(38) /**< \brief LCDCA signal: SEG22 on PB06 mux F */
+#define MUX_PB06F_LCDCA_SEG22           _L(5)
+#define PINMUX_PB06F_LCDCA_SEG22   ((PIN_PB06F_LCDCA_SEG22 << 16) | MUX_PB06F_LCDCA_SEG22)
+#define GPIO_PB06F_LCDCA_SEG22   _UL(1 <<  6)
+#define PIN_PA08F_LCDCA_SEG23           _L(8) /**< \brief LCDCA signal: SEG23 on PA08 mux F */
+#define MUX_PA08F_LCDCA_SEG23           _L(5)
+#define PINMUX_PA08F_LCDCA_SEG23   ((PIN_PA08F_LCDCA_SEG23 << 16) | MUX_PA08F_LCDCA_SEG23)
+#define GPIO_PA08F_LCDCA_SEG23   _UL(1 <<  8)
+#define PIN_PB12F_LCDCA_SEG32          _L(44) /**< \brief LCDCA signal: SEG32 on PB12 mux F */
+#define MUX_PB12F_LCDCA_SEG32           _L(5)
+#define PINMUX_PB12F_LCDCA_SEG32   ((PIN_PB12F_LCDCA_SEG32 << 16) | MUX_PB12F_LCDCA_SEG32)
+#define GPIO_PB12F_LCDCA_SEG32   _UL(1 << 12)
+#define PIN_PB13F_LCDCA_SEG33          _L(45) /**< \brief LCDCA signal: SEG33 on PB13 mux F */
+#define MUX_PB13F_LCDCA_SEG33           _L(5)
+#define PINMUX_PB13F_LCDCA_SEG33   ((PIN_PB13F_LCDCA_SEG33 << 16) | MUX_PB13F_LCDCA_SEG33)
+#define GPIO_PB13F_LCDCA_SEG33   _UL(1 << 13)
+#define PIN_PA21F_LCDCA_SEG34          _L(21) /**< \brief LCDCA signal: SEG34 on PA21 mux F */
+#define MUX_PA21F_LCDCA_SEG34           _L(5)
+#define PINMUX_PA21F_LCDCA_SEG34   ((PIN_PA21F_LCDCA_SEG34 << 16) | MUX_PA21F_LCDCA_SEG34)
+#define GPIO_PA21F_LCDCA_SEG34   _UL(1 << 21)
+#define PIN_PA22F_LCDCA_SEG35          _L(22) /**< \brief LCDCA signal: SEG35 on PA22 mux F */
+#define MUX_PA22F_LCDCA_SEG35           _L(5)
+#define PINMUX_PA22F_LCDCA_SEG35   ((PIN_PA22F_LCDCA_SEG35 << 16) | MUX_PA22F_LCDCA_SEG35)
+#define GPIO_PA22F_LCDCA_SEG35   _UL(1 << 22)
+#define PIN_PB14F_LCDCA_SEG36          _L(46) /**< \brief LCDCA signal: SEG36 on PB14 mux F */
+#define MUX_PB14F_LCDCA_SEG36           _L(5)
+#define PINMUX_PB14F_LCDCA_SEG36   ((PIN_PB14F_LCDCA_SEG36 << 16) | MUX_PB14F_LCDCA_SEG36)
+#define GPIO_PB14F_LCDCA_SEG36   _UL(1 << 14)
+#define PIN_PB15F_LCDCA_SEG37          _L(47) /**< \brief LCDCA signal: SEG37 on PB15 mux F */
+#define MUX_PB15F_LCDCA_SEG37           _L(5)
+#define PINMUX_PB15F_LCDCA_SEG37   ((PIN_PB15F_LCDCA_SEG37 << 16) | MUX_PB15F_LCDCA_SEG37)
+#define GPIO_PB15F_LCDCA_SEG37   _UL(1 << 15)
+#define PIN_PA23F_LCDCA_SEG38          _L(23) /**< \brief LCDCA signal: SEG38 on PA23 mux F */
+#define MUX_PA23F_LCDCA_SEG38           _L(5)
+#define PINMUX_PA23F_LCDCA_SEG38   ((PIN_PA23F_LCDCA_SEG38 << 16) | MUX_PA23F_LCDCA_SEG38)
+#define GPIO_PA23F_LCDCA_SEG38   _UL(1 << 23)
+#define PIN_PA24F_LCDCA_SEG39          _L(24) /**< \brief LCDCA signal: SEG39 on PA24 mux F */
+#define MUX_PA24F_LCDCA_SEG39           _L(5)
+#define PINMUX_PA24F_LCDCA_SEG39   ((PIN_PA24F_LCDCA_SEG39 << 16) | MUX_PA24F_LCDCA_SEG39)
+#define GPIO_PA24F_LCDCA_SEG39   _UL(1 << 24)
+/* ========== GPIO definition for USBC peripheral ========== */
+#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L(0)
+#define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
+#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
+#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L(0)
+#define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
+#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+/* ========== GPIO definition for PEVC peripheral ========== */
+#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
+#define PIN_PB12C_PEVC_PAD_EVT0        _L(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
+#define MUX_PB12C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PB12C_PEVC_PAD_EVT0  ((PIN_PB12C_PEVC_PAD_EVT0 << 16) | MUX_PB12C_PEVC_PAD_EVT0)
+#define GPIO_PB12C_PEVC_PAD_EVT0  _UL(1 << 12)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
+#define PIN_PB13C_PEVC_PAD_EVT1        _L(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
+#define MUX_PB13C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PB13C_PEVC_PAD_EVT1  ((PIN_PB13C_PEVC_PAD_EVT1 << 16) | MUX_PB13C_PEVC_PAD_EVT1)
+#define GPIO_PB13C_PEVC_PAD_EVT1  _UL(1 << 13)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
+#define PIN_PB09B_PEVC_PAD_EVT2        _L(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
+#define MUX_PB09B_PEVC_PAD_EVT2         _L(1)
+#define PINMUX_PB09B_PEVC_PAD_EVT2  ((PIN_PB09B_PEVC_PAD_EVT2 << 16) | MUX_PB09B_PEVC_PAD_EVT2)
+#define GPIO_PB09B_PEVC_PAD_EVT2  _UL(1 <<  9)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
+#define PIN_PB10B_PEVC_PAD_EVT3        _L(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
+#define MUX_PB10B_PEVC_PAD_EVT3         _L(1)
+#define PINMUX_PB10B_PEVC_PAD_EVT3  ((PIN_PB10B_PEVC_PAD_EVT3 << 16) | MUX_PB10B_PEVC_PAD_EVT3)
+#define GPIO_PB10B_PEVC_PAD_EVT3  _UL(1 << 10)
+/* ========== GPIO definition for SCIF peripheral ========== */
+#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
+#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
+#define PIN_PB10E_SCIF_GCLK0           _L(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
+#define MUX_PB10E_SCIF_GCLK0            _L(4)
+#define PINMUX_PB10E_SCIF_GCLK0    ((PIN_PB10E_SCIF_GCLK0 << 16) | MUX_PB10E_SCIF_GCLK0)
+#define GPIO_PB10E_SCIF_GCLK0    _UL(1 << 10)
+#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
+#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
+#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
+#define PIN_PB11E_SCIF_GCLK1           _L(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
+#define MUX_PB11E_SCIF_GCLK1            _L(4)
+#define PINMUX_PB11E_SCIF_GCLK1    ((PIN_PB11E_SCIF_GCLK1 << 16) | MUX_PB11E_SCIF_GCLK1)
+#define GPIO_PB11E_SCIF_GCLK1    _UL(1 << 11)
+#define PIN_PB12E_SCIF_GCLK2           _L(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
+#define MUX_PB12E_SCIF_GCLK2            _L(4)
+#define PINMUX_PB12E_SCIF_GCLK2    ((PIN_PB12E_SCIF_GCLK2 << 16) | MUX_PB12E_SCIF_GCLK2)
+#define GPIO_PB12E_SCIF_GCLK2    _UL(1 << 12)
+#define PIN_PB13E_SCIF_GCLK3           _L(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
+#define MUX_PB13E_SCIF_GCLK3            _L(4)
+#define PINMUX_PB13E_SCIF_GCLK3    ((PIN_PB13E_SCIF_GCLK3 << 16) | MUX_PB13E_SCIF_GCLK3)
+#define GPIO_PB13E_SCIF_GCLK3    _UL(1 << 13)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
+#define PIN_PB14E_SCIF_GCLK_IN0        _L(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
+#define MUX_PB14E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PB14E_SCIF_GCLK_IN0  ((PIN_PB14E_SCIF_GCLK_IN0 << 16) | MUX_PB14E_SCIF_GCLK_IN0)
+#define GPIO_PB14E_SCIF_GCLK_IN0  _UL(1 << 14)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
+#define PIN_PB15E_SCIF_GCLK_IN1        _L(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
+#define MUX_PB15E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PB15E_SCIF_GCLK_IN1  ((PIN_PB15E_SCIF_GCLK_IN1 << 16) | MUX_PB15E_SCIF_GCLK_IN1)
+#define GPIO_PB15E_SCIF_GCLK_IN1  _UL(1 << 15)
+/* ========== GPIO definition for EIC peripheral ========== */
+#define PIN_PB01C_EIC_EXTINT0          _L(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
+#define MUX_PB01C_EIC_EXTINT0           _L(2)
+#define PINMUX_PB01C_EIC_EXTINT0   ((PIN_PB01C_EIC_EXTINT0 << 16) | MUX_PB01C_EIC_EXTINT0)
+#define GPIO_PB01C_EIC_EXTINT0   _UL(1 <<  1)
+#define PIN_PB01C_EIC_EXTINT_NUM        _L(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
+#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
+#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
+#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
+#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
+#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
+#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
+#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
+#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
+#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
+#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+
+#endif /* _SAM4LC4B_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4lc4c.h
+++ b/asf/sam/include/sam4l/pio/sam4lc4c.h
@@ -1,0 +1,1804 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAM4LC4C
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LC4C_PIO_
+#define _SAM4LC4C_PIO_
+
+#define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
+#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
+#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
+#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
+#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
+#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
+#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
+#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
+#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
+#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
+#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
+#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
+#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
+#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
+#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
+#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
+#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
+#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
+#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
+#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
+#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
+#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
+#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
+#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
+#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
+#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
+#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
+#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
+#define GPIO_PB00                _UL(1 <<  0) /**< \brief GPIO Mask  for PB00 */
+#define PIN_PB01                          33  /**< \brief Pin Number for PB01 */
+#define GPIO_PB01                _UL(1 <<  1) /**< \brief GPIO Mask  for PB01 */
+#define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
+#define GPIO_PB02                _UL(1 <<  2) /**< \brief GPIO Mask  for PB02 */
+#define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
+#define GPIO_PB03                _UL(1 <<  3) /**< \brief GPIO Mask  for PB03 */
+#define PIN_PB04                          36  /**< \brief Pin Number for PB04 */
+#define GPIO_PB04                _UL(1 <<  4) /**< \brief GPIO Mask  for PB04 */
+#define PIN_PB05                          37  /**< \brief Pin Number for PB05 */
+#define GPIO_PB05                _UL(1 <<  5) /**< \brief GPIO Mask  for PB05 */
+#define PIN_PB06                          38  /**< \brief Pin Number for PB06 */
+#define GPIO_PB06                _UL(1 <<  6) /**< \brief GPIO Mask  for PB06 */
+#define PIN_PB07                          39  /**< \brief Pin Number for PB07 */
+#define GPIO_PB07                _UL(1 <<  7) /**< \brief GPIO Mask  for PB07 */
+#define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
+#define GPIO_PB08                _UL(1 <<  8) /**< \brief GPIO Mask  for PB08 */
+#define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
+#define GPIO_PB09                _UL(1 <<  9) /**< \brief GPIO Mask  for PB09 */
+#define PIN_PB10                          42  /**< \brief Pin Number for PB10 */
+#define GPIO_PB10                _UL(1 << 10) /**< \brief GPIO Mask  for PB10 */
+#define PIN_PB11                          43  /**< \brief Pin Number for PB11 */
+#define GPIO_PB11                _UL(1 << 11) /**< \brief GPIO Mask  for PB11 */
+#define PIN_PB12                          44  /**< \brief Pin Number for PB12 */
+#define GPIO_PB12                _UL(1 << 12) /**< \brief GPIO Mask  for PB12 */
+#define PIN_PB13                          45  /**< \brief Pin Number for PB13 */
+#define GPIO_PB13                _UL(1 << 13) /**< \brief GPIO Mask  for PB13 */
+#define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
+#define GPIO_PB14                _UL(1 << 14) /**< \brief GPIO Mask  for PB14 */
+#define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
+#define GPIO_PB15                _UL(1 << 15) /**< \brief GPIO Mask  for PB15 */
+#define PIN_PC00                          64  /**< \brief Pin Number for PC00 */
+#define GPIO_PC00                _UL(1 <<  0) /**< \brief GPIO Mask  for PC00 */
+#define PIN_PC01                          65  /**< \brief Pin Number for PC01 */
+#define GPIO_PC01                _UL(1 <<  1) /**< \brief GPIO Mask  for PC01 */
+#define PIN_PC02                          66  /**< \brief Pin Number for PC02 */
+#define GPIO_PC02                _UL(1 <<  2) /**< \brief GPIO Mask  for PC02 */
+#define PIN_PC03                          67  /**< \brief Pin Number for PC03 */
+#define GPIO_PC03                _UL(1 <<  3) /**< \brief GPIO Mask  for PC03 */
+#define PIN_PC04                          68  /**< \brief Pin Number for PC04 */
+#define GPIO_PC04                _UL(1 <<  4) /**< \brief GPIO Mask  for PC04 */
+#define PIN_PC05                          69  /**< \brief Pin Number for PC05 */
+#define GPIO_PC05                _UL(1 <<  5) /**< \brief GPIO Mask  for PC05 */
+#define PIN_PC06                          70  /**< \brief Pin Number for PC06 */
+#define GPIO_PC06                _UL(1 <<  6) /**< \brief GPIO Mask  for PC06 */
+#define PIN_PC07                          71  /**< \brief Pin Number for PC07 */
+#define GPIO_PC07                _UL(1 <<  7) /**< \brief GPIO Mask  for PC07 */
+#define PIN_PC08                          72  /**< \brief Pin Number for PC08 */
+#define GPIO_PC08                _UL(1 <<  8) /**< \brief GPIO Mask  for PC08 */
+#define PIN_PC09                          73  /**< \brief Pin Number for PC09 */
+#define GPIO_PC09                _UL(1 <<  9) /**< \brief GPIO Mask  for PC09 */
+#define PIN_PC10                          74  /**< \brief Pin Number for PC10 */
+#define GPIO_PC10                _UL(1 << 10) /**< \brief GPIO Mask  for PC10 */
+#define PIN_PC11                          75  /**< \brief Pin Number for PC11 */
+#define GPIO_PC11                _UL(1 << 11) /**< \brief GPIO Mask  for PC11 */
+#define PIN_PC12                          76  /**< \brief Pin Number for PC12 */
+#define GPIO_PC12                _UL(1 << 12) /**< \brief GPIO Mask  for PC12 */
+#define PIN_PC13                          77  /**< \brief Pin Number for PC13 */
+#define GPIO_PC13                _UL(1 << 13) /**< \brief GPIO Mask  for PC13 */
+#define PIN_PC14                          78  /**< \brief Pin Number for PC14 */
+#define GPIO_PC14                _UL(1 << 14) /**< \brief GPIO Mask  for PC14 */
+#define PIN_PC15                          79  /**< \brief Pin Number for PC15 */
+#define GPIO_PC15                _UL(1 << 15) /**< \brief GPIO Mask  for PC15 */
+#define PIN_PC16                          80  /**< \brief Pin Number for PC16 */
+#define GPIO_PC16                _UL(1 << 16) /**< \brief GPIO Mask  for PC16 */
+#define PIN_PC17                          81  /**< \brief Pin Number for PC17 */
+#define GPIO_PC17                _UL(1 << 17) /**< \brief GPIO Mask  for PC17 */
+#define PIN_PC18                          82  /**< \brief Pin Number for PC18 */
+#define GPIO_PC18                _UL(1 << 18) /**< \brief GPIO Mask  for PC18 */
+#define PIN_PC19                          83  /**< \brief Pin Number for PC19 */
+#define GPIO_PC19                _UL(1 << 19) /**< \brief GPIO Mask  for PC19 */
+#define PIN_PC20                          84  /**< \brief Pin Number for PC20 */
+#define GPIO_PC20                _UL(1 << 20) /**< \brief GPIO Mask  for PC20 */
+#define PIN_PC21                          85  /**< \brief Pin Number for PC21 */
+#define GPIO_PC21                _UL(1 << 21) /**< \brief GPIO Mask  for PC21 */
+#define PIN_PC22                          86  /**< \brief Pin Number for PC22 */
+#define GPIO_PC22                _UL(1 << 22) /**< \brief GPIO Mask  for PC22 */
+#define PIN_PC23                          87  /**< \brief Pin Number for PC23 */
+#define GPIO_PC23                _UL(1 << 23) /**< \brief GPIO Mask  for PC23 */
+#define PIN_PC24                          88  /**< \brief Pin Number for PC24 */
+#define GPIO_PC24                _UL(1 << 24) /**< \brief GPIO Mask  for PC24 */
+#define PIN_PC25                          89  /**< \brief Pin Number for PC25 */
+#define GPIO_PC25                _UL(1 << 25) /**< \brief GPIO Mask  for PC25 */
+#define PIN_PC26                          90  /**< \brief Pin Number for PC26 */
+#define GPIO_PC26                _UL(1 << 26) /**< \brief GPIO Mask  for PC26 */
+#define PIN_PC27                          91  /**< \brief Pin Number for PC27 */
+#define GPIO_PC27                _UL(1 << 27) /**< \brief GPIO Mask  for PC27 */
+#define PIN_PC28                          92  /**< \brief Pin Number for PC28 */
+#define GPIO_PC28                _UL(1 << 28) /**< \brief GPIO Mask  for PC28 */
+#define PIN_PC29                          93  /**< \brief Pin Number for PC29 */
+#define GPIO_PC29                _UL(1 << 29) /**< \brief GPIO Mask  for PC29 */
+#define PIN_PC30                          94  /**< \brief Pin Number for PC30 */
+#define GPIO_PC30                _UL(1 << 30) /**< \brief GPIO Mask  for PC30 */
+#define PIN_PC31                          95  /**< \brief Pin Number for PC31 */
+#define GPIO_PC31                _UL(1 << 31) /**< \brief GPIO Mask  for PC31 */
+/* ========== GPIO definition for TWIMS0 peripheral ========== */
+#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
+#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+/* ========== GPIO definition for TWIMS1 peripheral ========== */
+#define PIN_PB01A_TWIMS1_TWCK          _L(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
+#define MUX_PB01A_TWIMS1_TWCK           _L(0)
+#define PINMUX_PB01A_TWIMS1_TWCK   ((PIN_PB01A_TWIMS1_TWCK << 16) | MUX_PB01A_TWIMS1_TWCK)
+#define GPIO_PB01A_TWIMS1_TWCK   _UL(1 <<  1)
+#define PIN_PB00A_TWIMS1_TWD           _L(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
+#define MUX_PB00A_TWIMS1_TWD            _L(0)
+#define PINMUX_PB00A_TWIMS1_TWD    ((PIN_PB00A_TWIMS1_TWD << 16) | MUX_PB00A_TWIMS1_TWD)
+#define GPIO_PB00A_TWIMS1_TWD    _UL(1 <<  0)
+/* ========== GPIO definition for TWIMS2 peripheral ========== */
+#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
+#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+/* ========== GPIO definition for TWIMS3 peripheral ========== */
+#define PIN_PB15C_TWIMS3_TWCK          _L(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
+#define MUX_PB15C_TWIMS3_TWCK           _L(2)
+#define PINMUX_PB15C_TWIMS3_TWCK   ((PIN_PB15C_TWIMS3_TWCK << 16) | MUX_PB15C_TWIMS3_TWCK)
+#define GPIO_PB15C_TWIMS3_TWCK   _UL(1 << 15)
+#define PIN_PB14C_TWIMS3_TWD           _L(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
+#define MUX_PB14C_TWIMS3_TWD            _L(2)
+#define PINMUX_PB14C_TWIMS3_TWD    ((PIN_PB14C_TWIMS3_TWD << 16) | MUX_PB14C_TWIMS3_TWD)
+#define GPIO_PB14C_TWIMS3_TWD    _UL(1 << 14)
+/* ========== GPIO definition for IISC peripheral ========== */
+#define PIN_PB05D_IISC_IMCK            _L(37) /**< \brief IISC signal: IMCK on PB05 mux D */
+#define MUX_PB05D_IISC_IMCK             _L(3)
+#define PINMUX_PB05D_IISC_IMCK     ((PIN_PB05D_IISC_IMCK << 16) | MUX_PB05D_IISC_IMCK)
+#define GPIO_PB05D_IISC_IMCK     _UL(1 <<  5)
+#define PIN_PC14D_IISC_IMCK            _L(78) /**< \brief IISC signal: IMCK on PC14 mux D */
+#define MUX_PC14D_IISC_IMCK             _L(3)
+#define PINMUX_PC14D_IISC_IMCK     ((PIN_PC14D_IISC_IMCK << 16) | MUX_PC14D_IISC_IMCK)
+#define GPIO_PC14D_IISC_IMCK     _UL(1 << 14)
+#define PIN_PB02D_IISC_ISCK            _L(34) /**< \brief IISC signal: ISCK on PB02 mux D */
+#define MUX_PB02D_IISC_ISCK             _L(3)
+#define PINMUX_PB02D_IISC_ISCK     ((PIN_PB02D_IISC_ISCK << 16) | MUX_PB02D_IISC_ISCK)
+#define GPIO_PB02D_IISC_ISCK     _UL(1 <<  2)
+#define PIN_PC09D_IISC_ISCK            _L(73) /**< \brief IISC signal: ISCK on PC09 mux D */
+#define MUX_PC09D_IISC_ISCK             _L(3)
+#define PINMUX_PC09D_IISC_ISCK     ((PIN_PC09D_IISC_ISCK << 16) | MUX_PC09D_IISC_ISCK)
+#define GPIO_PC09D_IISC_ISCK     _UL(1 <<  9)
+#define PIN_PB03D_IISC_ISDI            _L(35) /**< \brief IISC signal: ISDI on PB03 mux D */
+#define MUX_PB03D_IISC_ISDI             _L(3)
+#define PINMUX_PB03D_IISC_ISDI     ((PIN_PB03D_IISC_ISDI << 16) | MUX_PB03D_IISC_ISDI)
+#define GPIO_PB03D_IISC_ISDI     _UL(1 <<  3)
+#define PIN_PC10D_IISC_ISDI            _L(74) /**< \brief IISC signal: ISDI on PC10 mux D */
+#define MUX_PC10D_IISC_ISDI             _L(3)
+#define PINMUX_PC10D_IISC_ISDI     ((PIN_PC10D_IISC_ISDI << 16) | MUX_PC10D_IISC_ISDI)
+#define GPIO_PC10D_IISC_ISDI     _UL(1 << 10)
+#define PIN_PB04D_IISC_ISDO            _L(36) /**< \brief IISC signal: ISDO on PB04 mux D */
+#define MUX_PB04D_IISC_ISDO             _L(3)
+#define PINMUX_PB04D_IISC_ISDO     ((PIN_PB04D_IISC_ISDO << 16) | MUX_PB04D_IISC_ISDO)
+#define GPIO_PB04D_IISC_ISDO     _UL(1 <<  4)
+#define PIN_PC13D_IISC_ISDO            _L(77) /**< \brief IISC signal: ISDO on PC13 mux D */
+#define MUX_PC13D_IISC_ISDO             _L(3)
+#define PINMUX_PC13D_IISC_ISDO     ((PIN_PC13D_IISC_ISDO << 16) | MUX_PC13D_IISC_ISDO)
+#define GPIO_PC13D_IISC_ISDO     _UL(1 << 13)
+#define PIN_PB06D_IISC_IWS             _L(38) /**< \brief IISC signal: IWS on PB06 mux D */
+#define MUX_PB06D_IISC_IWS              _L(3)
+#define PINMUX_PB06D_IISC_IWS      ((PIN_PB06D_IISC_IWS << 16) | MUX_PB06D_IISC_IWS)
+#define GPIO_PB06D_IISC_IWS      _UL(1 <<  6)
+#define PIN_PC12D_IISC_IWS             _L(76) /**< \brief IISC signal: IWS on PC12 mux D */
+#define MUX_PC12D_IISC_IWS              _L(3)
+#define PINMUX_PC12D_IISC_IWS      ((PIN_PC12D_IISC_IWS << 16) | MUX_PC12D_IISC_IWS)
+#define GPIO_PC12D_IISC_IWS      _UL(1 << 12)
+/* ========== GPIO definition for SPI peripheral ========== */
+#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L(1)
+#define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
+#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
+#define PIN_PB14B_SPI_MISO             _L(46) /**< \brief SPI signal: MISO on PB14 mux B */
+#define MUX_PB14B_SPI_MISO              _L(1)
+#define PINMUX_PB14B_SPI_MISO      ((PIN_PB14B_SPI_MISO << 16) | MUX_PB14B_SPI_MISO)
+#define GPIO_PB14B_SPI_MISO      _UL(1 << 14)
+#define PIN_PC28B_SPI_MISO             _L(92) /**< \brief SPI signal: MISO on PC28 mux B */
+#define MUX_PC28B_SPI_MISO              _L(1)
+#define PINMUX_PC28B_SPI_MISO      ((PIN_PC28B_SPI_MISO << 16) | MUX_PC28B_SPI_MISO)
+#define GPIO_PC28B_SPI_MISO      _UL(1 << 28)
+#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L(0)
+#define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
+#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
+#define PIN_PC04A_SPI_MISO             _L(68) /**< \brief SPI signal: MISO on PC04 mux A */
+#define MUX_PC04A_SPI_MISO              _L(0)
+#define PINMUX_PC04A_SPI_MISO      ((PIN_PC04A_SPI_MISO << 16) | MUX_PC04A_SPI_MISO)
+#define GPIO_PC04A_SPI_MISO      _UL(1 <<  4)
+#define PIN_PB15B_SPI_MOSI             _L(47) /**< \brief SPI signal: MOSI on PB15 mux B */
+#define MUX_PB15B_SPI_MOSI              _L(1)
+#define PINMUX_PB15B_SPI_MOSI      ((PIN_PB15B_SPI_MOSI << 16) | MUX_PB15B_SPI_MOSI)
+#define GPIO_PB15B_SPI_MOSI      _UL(1 << 15)
+#define PIN_PC29B_SPI_MOSI             _L(93) /**< \brief SPI signal: MOSI on PC29 mux B */
+#define MUX_PC29B_SPI_MOSI              _L(1)
+#define PINMUX_PC29B_SPI_MOSI      ((PIN_PC29B_SPI_MOSI << 16) | MUX_PC29B_SPI_MOSI)
+#define GPIO_PC29B_SPI_MOSI      _UL(1 << 29)
+#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L(0)
+#define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
+#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
+#define PIN_PC05A_SPI_MOSI             _L(69) /**< \brief SPI signal: MOSI on PC05 mux A */
+#define MUX_PC05A_SPI_MOSI              _L(0)
+#define PINMUX_PC05A_SPI_MOSI      ((PIN_PC05A_SPI_MOSI << 16) | MUX_PC05A_SPI_MOSI)
+#define GPIO_PC05A_SPI_MOSI      _UL(1 <<  5)
+#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
+#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
+#define PIN_PC31B_SPI_NPCS0            _L(95) /**< \brief SPI signal: NPCS0 on PC31 mux B */
+#define MUX_PC31B_SPI_NPCS0             _L(1)
+#define PINMUX_PC31B_SPI_NPCS0     ((PIN_PC31B_SPI_NPCS0 << 16) | MUX_PC31B_SPI_NPCS0)
+#define GPIO_PC31B_SPI_NPCS0     _UL(1 << 31)
+#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
+#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
+#define PIN_PC03A_SPI_NPCS0            _L(67) /**< \brief SPI signal: NPCS0 on PC03 mux A */
+#define MUX_PC03A_SPI_NPCS0             _L(0)
+#define PINMUX_PC03A_SPI_NPCS0     ((PIN_PC03A_SPI_NPCS0 << 16) | MUX_PC03A_SPI_NPCS0)
+#define GPIO_PC03A_SPI_NPCS0     _UL(1 <<  3)
+#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
+#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PB13B_SPI_NPCS1            _L(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
+#define MUX_PB13B_SPI_NPCS1             _L(1)
+#define PINMUX_PB13B_SPI_NPCS1     ((PIN_PB13B_SPI_NPCS1 << 16) | MUX_PB13B_SPI_NPCS1)
+#define GPIO_PB13B_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PC02A_SPI_NPCS1            _L(66) /**< \brief SPI signal: NPCS1 on PC02 mux A */
+#define MUX_PC02A_SPI_NPCS1             _L(0)
+#define PINMUX_PC02A_SPI_NPCS1     ((PIN_PC02A_SPI_NPCS1 << 16) | MUX_PC02A_SPI_NPCS1)
+#define GPIO_PC02A_SPI_NPCS1     _UL(1 <<  2)
+#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
+#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
+#define PIN_PB11B_SPI_NPCS2            _L(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
+#define MUX_PB11B_SPI_NPCS2             _L(1)
+#define PINMUX_PB11B_SPI_NPCS2     ((PIN_PB11B_SPI_NPCS2 << 16) | MUX_PB11B_SPI_NPCS2)
+#define GPIO_PB11B_SPI_NPCS2     _UL(1 << 11)
+#define PIN_PC00A_SPI_NPCS2            _L(64) /**< \brief SPI signal: NPCS2 on PC00 mux A */
+#define MUX_PC00A_SPI_NPCS2             _L(0)
+#define PINMUX_PC00A_SPI_NPCS2     ((PIN_PC00A_SPI_NPCS2 << 16) | MUX_PC00A_SPI_NPCS2)
+#define GPIO_PC00A_SPI_NPCS2     _UL(1 <<  0)
+#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
+#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
+#define PIN_PB12B_SPI_NPCS3            _L(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
+#define MUX_PB12B_SPI_NPCS3             _L(1)
+#define PINMUX_PB12B_SPI_NPCS3     ((PIN_PB12B_SPI_NPCS3 << 16) | MUX_PB12B_SPI_NPCS3)
+#define GPIO_PB12B_SPI_NPCS3     _UL(1 << 12)
+#define PIN_PC01A_SPI_NPCS3            _L(65) /**< \brief SPI signal: NPCS3 on PC01 mux A */
+#define MUX_PC01A_SPI_NPCS3             _L(0)
+#define PINMUX_PC01A_SPI_NPCS3     ((PIN_PC01A_SPI_NPCS3 << 16) | MUX_PC01A_SPI_NPCS3)
+#define GPIO_PC01A_SPI_NPCS3     _UL(1 <<  1)
+#define PIN_PC30B_SPI_SCK              _L(94) /**< \brief SPI signal: SCK on PC30 mux B */
+#define MUX_PC30B_SPI_SCK               _L(1)
+#define PINMUX_PC30B_SPI_SCK       ((PIN_PC30B_SPI_SCK << 16) | MUX_PC30B_SPI_SCK)
+#define GPIO_PC30B_SPI_SCK       _UL(1 << 30)
+#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L(0)
+#define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
+#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
+#define PIN_PC06A_SPI_SCK              _L(70) /**< \brief SPI signal: SCK on PC06 mux A */
+#define MUX_PC06A_SPI_SCK               _L(0)
+#define PINMUX_PC06A_SPI_SCK       ((PIN_PC06A_SPI_SCK << 16) | MUX_PC06A_SPI_SCK)
+#define GPIO_PC06A_SPI_SCK       _UL(1 <<  6)
+/* ========== GPIO definition for TC0 peripheral ========== */
+#define PIN_PB07D_TC0_A0               _L(39) /**< \brief TC0 signal: A0 on PB07 mux D */
+#define MUX_PB07D_TC0_A0                _L(3)
+#define PINMUX_PB07D_TC0_A0        ((PIN_PB07D_TC0_A0 << 16) | MUX_PB07D_TC0_A0)
+#define GPIO_PB07D_TC0_A0        _UL(1 <<  7)
+#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L(1)
+#define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
+#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
+#define PIN_PB09D_TC0_A1               _L(41) /**< \brief TC0 signal: A1 on PB09 mux D */
+#define MUX_PB09D_TC0_A1                _L(3)
+#define PINMUX_PB09D_TC0_A1        ((PIN_PB09D_TC0_A1 << 16) | MUX_PB09D_TC0_A1)
+#define GPIO_PB09D_TC0_A1        _UL(1 <<  9)
+#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L(1)
+#define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
+#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
+#define PIN_PB11D_TC0_A2               _L(43) /**< \brief TC0 signal: A2 on PB11 mux D */
+#define MUX_PB11D_TC0_A2                _L(3)
+#define PINMUX_PB11D_TC0_A2        ((PIN_PB11D_TC0_A2 << 16) | MUX_PB11D_TC0_A2)
+#define GPIO_PB11D_TC0_A2        _UL(1 << 11)
+#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L(1)
+#define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
+#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
+#define PIN_PB08D_TC0_B0               _L(40) /**< \brief TC0 signal: B0 on PB08 mux D */
+#define MUX_PB08D_TC0_B0                _L(3)
+#define PINMUX_PB08D_TC0_B0        ((PIN_PB08D_TC0_B0 << 16) | MUX_PB08D_TC0_B0)
+#define GPIO_PB08D_TC0_B0        _UL(1 <<  8)
+#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L(1)
+#define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
+#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
+#define PIN_PB10D_TC0_B1               _L(42) /**< \brief TC0 signal: B1 on PB10 mux D */
+#define MUX_PB10D_TC0_B1                _L(3)
+#define PINMUX_PB10D_TC0_B1        ((PIN_PB10D_TC0_B1 << 16) | MUX_PB10D_TC0_B1)
+#define GPIO_PB10D_TC0_B1        _UL(1 << 10)
+#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L(1)
+#define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
+#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
+#define PIN_PB12D_TC0_B2               _L(44) /**< \brief TC0 signal: B2 on PB12 mux D */
+#define MUX_PB12D_TC0_B2                _L(3)
+#define PINMUX_PB12D_TC0_B2        ((PIN_PB12D_TC0_B2 << 16) | MUX_PB12D_TC0_B2)
+#define GPIO_PB12D_TC0_B2        _UL(1 << 12)
+#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L(1)
+#define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
+#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
+#define PIN_PB13D_TC0_CLK0             _L(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
+#define MUX_PB13D_TC0_CLK0              _L(3)
+#define PINMUX_PB13D_TC0_CLK0      ((PIN_PB13D_TC0_CLK0 << 16) | MUX_PB13D_TC0_CLK0)
+#define GPIO_PB13D_TC0_CLK0      _UL(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L(1)
+#define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
+#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
+#define PIN_PB14D_TC0_CLK1             _L(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
+#define MUX_PB14D_TC0_CLK1              _L(3)
+#define PINMUX_PB14D_TC0_CLK1      ((PIN_PB14D_TC0_CLK1 << 16) | MUX_PB14D_TC0_CLK1)
+#define GPIO_PB14D_TC0_CLK1      _UL(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L(1)
+#define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
+#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
+#define PIN_PB15D_TC0_CLK2             _L(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
+#define MUX_PB15D_TC0_CLK2              _L(3)
+#define PINMUX_PB15D_TC0_CLK2      ((PIN_PB15D_TC0_CLK2 << 16) | MUX_PB15D_TC0_CLK2)
+#define GPIO_PB15D_TC0_CLK2      _UL(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L(1)
+#define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
+#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+/* ========== GPIO definition for TC1 peripheral ========== */
+#define PIN_PC00D_TC1_A0               _L(64) /**< \brief TC1 signal: A0 on PC00 mux D */
+#define MUX_PC00D_TC1_A0                _L(3)
+#define PINMUX_PC00D_TC1_A0        ((PIN_PC00D_TC1_A0 << 16) | MUX_PC00D_TC1_A0)
+#define GPIO_PC00D_TC1_A0        _UL(1 <<  0)
+#define PIN_PC15A_TC1_A0               _L(79) /**< \brief TC1 signal: A0 on PC15 mux A */
+#define MUX_PC15A_TC1_A0                _L(0)
+#define PINMUX_PC15A_TC1_A0        ((PIN_PC15A_TC1_A0 << 16) | MUX_PC15A_TC1_A0)
+#define GPIO_PC15A_TC1_A0        _UL(1 << 15)
+#define PIN_PC02D_TC1_A1               _L(66) /**< \brief TC1 signal: A1 on PC02 mux D */
+#define MUX_PC02D_TC1_A1                _L(3)
+#define PINMUX_PC02D_TC1_A1        ((PIN_PC02D_TC1_A1 << 16) | MUX_PC02D_TC1_A1)
+#define GPIO_PC02D_TC1_A1        _UL(1 <<  2)
+#define PIN_PC17A_TC1_A1               _L(81) /**< \brief TC1 signal: A1 on PC17 mux A */
+#define MUX_PC17A_TC1_A1                _L(0)
+#define PINMUX_PC17A_TC1_A1        ((PIN_PC17A_TC1_A1 << 16) | MUX_PC17A_TC1_A1)
+#define GPIO_PC17A_TC1_A1        _UL(1 << 17)
+#define PIN_PC04D_TC1_A2               _L(68) /**< \brief TC1 signal: A2 on PC04 mux D */
+#define MUX_PC04D_TC1_A2                _L(3)
+#define PINMUX_PC04D_TC1_A2        ((PIN_PC04D_TC1_A2 << 16) | MUX_PC04D_TC1_A2)
+#define GPIO_PC04D_TC1_A2        _UL(1 <<  4)
+#define PIN_PC19A_TC1_A2               _L(83) /**< \brief TC1 signal: A2 on PC19 mux A */
+#define MUX_PC19A_TC1_A2                _L(0)
+#define PINMUX_PC19A_TC1_A2        ((PIN_PC19A_TC1_A2 << 16) | MUX_PC19A_TC1_A2)
+#define GPIO_PC19A_TC1_A2        _UL(1 << 19)
+#define PIN_PC01D_TC1_B0               _L(65) /**< \brief TC1 signal: B0 on PC01 mux D */
+#define MUX_PC01D_TC1_B0                _L(3)
+#define PINMUX_PC01D_TC1_B0        ((PIN_PC01D_TC1_B0 << 16) | MUX_PC01D_TC1_B0)
+#define GPIO_PC01D_TC1_B0        _UL(1 <<  1)
+#define PIN_PC16A_TC1_B0               _L(80) /**< \brief TC1 signal: B0 on PC16 mux A */
+#define MUX_PC16A_TC1_B0                _L(0)
+#define PINMUX_PC16A_TC1_B0        ((PIN_PC16A_TC1_B0 << 16) | MUX_PC16A_TC1_B0)
+#define GPIO_PC16A_TC1_B0        _UL(1 << 16)
+#define PIN_PC03D_TC1_B1               _L(67) /**< \brief TC1 signal: B1 on PC03 mux D */
+#define MUX_PC03D_TC1_B1                _L(3)
+#define PINMUX_PC03D_TC1_B1        ((PIN_PC03D_TC1_B1 << 16) | MUX_PC03D_TC1_B1)
+#define GPIO_PC03D_TC1_B1        _UL(1 <<  3)
+#define PIN_PC18A_TC1_B1               _L(82) /**< \brief TC1 signal: B1 on PC18 mux A */
+#define MUX_PC18A_TC1_B1                _L(0)
+#define PINMUX_PC18A_TC1_B1        ((PIN_PC18A_TC1_B1 << 16) | MUX_PC18A_TC1_B1)
+#define GPIO_PC18A_TC1_B1        _UL(1 << 18)
+#define PIN_PC05D_TC1_B2               _L(69) /**< \brief TC1 signal: B2 on PC05 mux D */
+#define MUX_PC05D_TC1_B2                _L(3)
+#define PINMUX_PC05D_TC1_B2        ((PIN_PC05D_TC1_B2 << 16) | MUX_PC05D_TC1_B2)
+#define GPIO_PC05D_TC1_B2        _UL(1 <<  5)
+#define PIN_PC20A_TC1_B2               _L(84) /**< \brief TC1 signal: B2 on PC20 mux A */
+#define MUX_PC20A_TC1_B2                _L(0)
+#define PINMUX_PC20A_TC1_B2        ((PIN_PC20A_TC1_B2 << 16) | MUX_PC20A_TC1_B2)
+#define GPIO_PC20A_TC1_B2        _UL(1 << 20)
+#define PIN_PC06D_TC1_CLK0             _L(70) /**< \brief TC1 signal: CLK0 on PC06 mux D */
+#define MUX_PC06D_TC1_CLK0              _L(3)
+#define PINMUX_PC06D_TC1_CLK0      ((PIN_PC06D_TC1_CLK0 << 16) | MUX_PC06D_TC1_CLK0)
+#define GPIO_PC06D_TC1_CLK0      _UL(1 <<  6)
+#define PIN_PC21A_TC1_CLK0             _L(85) /**< \brief TC1 signal: CLK0 on PC21 mux A */
+#define MUX_PC21A_TC1_CLK0              _L(0)
+#define PINMUX_PC21A_TC1_CLK0      ((PIN_PC21A_TC1_CLK0 << 16) | MUX_PC21A_TC1_CLK0)
+#define GPIO_PC21A_TC1_CLK0      _UL(1 << 21)
+#define PIN_PC07D_TC1_CLK1             _L(71) /**< \brief TC1 signal: CLK1 on PC07 mux D */
+#define MUX_PC07D_TC1_CLK1              _L(3)
+#define PINMUX_PC07D_TC1_CLK1      ((PIN_PC07D_TC1_CLK1 << 16) | MUX_PC07D_TC1_CLK1)
+#define GPIO_PC07D_TC1_CLK1      _UL(1 <<  7)
+#define PIN_PC22A_TC1_CLK1             _L(86) /**< \brief TC1 signal: CLK1 on PC22 mux A */
+#define MUX_PC22A_TC1_CLK1              _L(0)
+#define PINMUX_PC22A_TC1_CLK1      ((PIN_PC22A_TC1_CLK1 << 16) | MUX_PC22A_TC1_CLK1)
+#define GPIO_PC22A_TC1_CLK1      _UL(1 << 22)
+#define PIN_PC08D_TC1_CLK2             _L(72) /**< \brief TC1 signal: CLK2 on PC08 mux D */
+#define MUX_PC08D_TC1_CLK2              _L(3)
+#define PINMUX_PC08D_TC1_CLK2      ((PIN_PC08D_TC1_CLK2 << 16) | MUX_PC08D_TC1_CLK2)
+#define GPIO_PC08D_TC1_CLK2      _UL(1 <<  8)
+#define PIN_PC23A_TC1_CLK2             _L(87) /**< \brief TC1 signal: CLK2 on PC23 mux A */
+#define MUX_PC23A_TC1_CLK2              _L(0)
+#define PINMUX_PC23A_TC1_CLK2      ((PIN_PC23A_TC1_CLK2 << 16) | MUX_PC23A_TC1_CLK2)
+#define GPIO_PC23A_TC1_CLK2      _UL(1 << 23)
+/* ========== GPIO definition for USART0 peripheral ========== */
+#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L(1)
+#define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
+#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
+#define PIN_PC00B_USART0_CLK           _L(64) /**< \brief USART0 signal: CLK on PC00 mux B */
+#define MUX_PC00B_USART0_CLK            _L(1)
+#define PINMUX_PC00B_USART0_CLK    ((PIN_PC00B_USART0_CLK << 16) | MUX_PC00B_USART0_CLK)
+#define GPIO_PC00B_USART0_CLK    _UL(1 <<  0)
+#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L(0)
+#define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
+#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
+#define PIN_PB13A_USART0_CLK           _L(45) /**< \brief USART0 signal: CLK on PB13 mux A */
+#define MUX_PB13A_USART0_CLK            _L(0)
+#define PINMUX_PB13A_USART0_CLK    ((PIN_PB13A_USART0_CLK << 16) | MUX_PB13A_USART0_CLK)
+#define GPIO_PB13A_USART0_CLK    _UL(1 << 13)
+#define PIN_PC02B_USART0_CTS           _L(66) /**< \brief USART0 signal: CTS on PC02 mux B */
+#define MUX_PC02B_USART0_CTS            _L(1)
+#define PINMUX_PC02B_USART0_CTS    ((PIN_PC02B_USART0_CTS << 16) | MUX_PC02B_USART0_CTS)
+#define GPIO_PC02B_USART0_CTS    _UL(1 <<  2)
+#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L(0)
+#define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
+#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
+#define PIN_PB11A_USART0_CTS           _L(43) /**< \brief USART0 signal: CTS on PB11 mux A */
+#define MUX_PB11A_USART0_CTS            _L(0)
+#define PINMUX_PB11A_USART0_CTS    ((PIN_PB11A_USART0_CTS << 16) | MUX_PB11A_USART0_CTS)
+#define GPIO_PB11A_USART0_CTS    _UL(1 << 11)
+#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L(1)
+#define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
+#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
+#define PIN_PC01B_USART0_RTS           _L(65) /**< \brief USART0 signal: RTS on PC01 mux B */
+#define MUX_PC01B_USART0_RTS            _L(1)
+#define PINMUX_PC01B_USART0_RTS    ((PIN_PC01B_USART0_RTS << 16) | MUX_PC01B_USART0_RTS)
+#define GPIO_PC01B_USART0_RTS    _UL(1 <<  1)
+#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L(0)
+#define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
+#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
+#define PIN_PB12A_USART0_RTS           _L(44) /**< \brief USART0 signal: RTS on PB12 mux A */
+#define MUX_PB12A_USART0_RTS            _L(0)
+#define PINMUX_PB12A_USART0_RTS    ((PIN_PB12A_USART0_RTS << 16) | MUX_PB12A_USART0_RTS)
+#define GPIO_PB12A_USART0_RTS    _UL(1 << 12)
+#define PIN_PC02C_USART0_RXD           _L(66) /**< \brief USART0 signal: RXD on PC02 mux C */
+#define MUX_PC02C_USART0_RXD            _L(2)
+#define PINMUX_PC02C_USART0_RXD    ((PIN_PC02C_USART0_RXD << 16) | MUX_PC02C_USART0_RXD)
+#define GPIO_PC02C_USART0_RXD    _UL(1 <<  2)
+#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L(1)
+#define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
+#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
+#define PIN_PB00B_USART0_RXD           _L(32) /**< \brief USART0 signal: RXD on PB00 mux B */
+#define MUX_PB00B_USART0_RXD            _L(1)
+#define PINMUX_PB00B_USART0_RXD    ((PIN_PB00B_USART0_RXD << 16) | MUX_PB00B_USART0_RXD)
+#define GPIO_PB00B_USART0_RXD    _UL(1 <<  0)
+#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L(0)
+#define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
+#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
+#define PIN_PB14A_USART0_RXD           _L(46) /**< \brief USART0 signal: RXD on PB14 mux A */
+#define MUX_PB14A_USART0_RXD            _L(0)
+#define PINMUX_PB14A_USART0_RXD    ((PIN_PB14A_USART0_RXD << 16) | MUX_PB14A_USART0_RXD)
+#define GPIO_PB14A_USART0_RXD    _UL(1 << 14)
+#define PIN_PC03C_USART0_TXD           _L(67) /**< \brief USART0 signal: TXD on PC03 mux C */
+#define MUX_PC03C_USART0_TXD            _L(2)
+#define PINMUX_PC03C_USART0_TXD    ((PIN_PC03C_USART0_TXD << 16) | MUX_PC03C_USART0_TXD)
+#define GPIO_PC03C_USART0_TXD    _UL(1 <<  3)
+#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L(1)
+#define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
+#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
+#define PIN_PB01B_USART0_TXD           _L(33) /**< \brief USART0 signal: TXD on PB01 mux B */
+#define MUX_PB01B_USART0_TXD            _L(1)
+#define PINMUX_PB01B_USART0_TXD    ((PIN_PB01B_USART0_TXD << 16) | MUX_PB01B_USART0_TXD)
+#define GPIO_PB01B_USART0_TXD    _UL(1 <<  1)
+#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L(0)
+#define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
+#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
+#define PIN_PB15A_USART0_TXD           _L(47) /**< \brief USART0 signal: TXD on PB15 mux A */
+#define MUX_PB15A_USART0_TXD            _L(0)
+#define PINMUX_PB15A_USART0_TXD    ((PIN_PB15A_USART0_TXD << 16) | MUX_PB15A_USART0_TXD)
+#define GPIO_PB15A_USART0_TXD    _UL(1 << 15)
+/* ========== GPIO definition for USART1 peripheral ========== */
+#define PIN_PB03B_USART1_CLK           _L(35) /**< \brief USART1 signal: CLK on PB03 mux B */
+#define MUX_PB03B_USART1_CLK            _L(1)
+#define PINMUX_PB03B_USART1_CLK    ((PIN_PB03B_USART1_CLK << 16) | MUX_PB03B_USART1_CLK)
+#define GPIO_PB03B_USART1_CLK    _UL(1 <<  3)
+#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L(0)
+#define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
+#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
+#define PIN_PC25A_USART1_CLK           _L(89) /**< \brief USART1 signal: CLK on PC25 mux A */
+#define MUX_PC25A_USART1_CLK            _L(0)
+#define PINMUX_PC25A_USART1_CLK    ((PIN_PC25A_USART1_CLK << 16) | MUX_PC25A_USART1_CLK)
+#define GPIO_PC25A_USART1_CLK    _UL(1 << 25)
+#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L(1)
+#define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
+#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
+#define PIN_PB02B_USART1_RTS           _L(34) /**< \brief USART1 signal: RTS on PB02 mux B */
+#define MUX_PB02B_USART1_RTS            _L(1)
+#define PINMUX_PB02B_USART1_RTS    ((PIN_PB02B_USART1_RTS << 16) | MUX_PB02B_USART1_RTS)
+#define GPIO_PB02B_USART1_RTS    _UL(1 <<  2)
+#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L(0)
+#define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
+#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
+#define PIN_PC24A_USART1_RTS           _L(88) /**< \brief USART1 signal: RTS on PC24 mux A */
+#define MUX_PC24A_USART1_RTS            _L(0)
+#define PINMUX_PC24A_USART1_RTS    ((PIN_PC24A_USART1_RTS << 16) | MUX_PC24A_USART1_RTS)
+#define GPIO_PC24A_USART1_RTS    _UL(1 << 24)
+#define PIN_PB04B_USART1_RXD           _L(36) /**< \brief USART1 signal: RXD on PB04 mux B */
+#define MUX_PB04B_USART1_RXD            _L(1)
+#define PINMUX_PB04B_USART1_RXD    ((PIN_PB04B_USART1_RXD << 16) | MUX_PB04B_USART1_RXD)
+#define GPIO_PB04B_USART1_RXD    _UL(1 <<  4)
+#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L(0)
+#define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
+#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
+#define PIN_PC26A_USART1_RXD           _L(90) /**< \brief USART1 signal: RXD on PC26 mux A */
+#define MUX_PC26A_USART1_RXD            _L(0)
+#define PINMUX_PC26A_USART1_RXD    ((PIN_PC26A_USART1_RXD << 16) | MUX_PC26A_USART1_RXD)
+#define GPIO_PC26A_USART1_RXD    _UL(1 << 26)
+#define PIN_PB05B_USART1_TXD           _L(37) /**< \brief USART1 signal: TXD on PB05 mux B */
+#define MUX_PB05B_USART1_TXD            _L(1)
+#define PINMUX_PB05B_USART1_TXD    ((PIN_PB05B_USART1_TXD << 16) | MUX_PB05B_USART1_TXD)
+#define GPIO_PB05B_USART1_TXD    _UL(1 <<  5)
+#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L(0)
+#define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
+#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+#define PIN_PC27A_USART1_TXD           _L(91) /**< \brief USART1 signal: TXD on PC27 mux A */
+#define MUX_PC27A_USART1_TXD            _L(0)
+#define PINMUX_PC27A_USART1_TXD    ((PIN_PC27A_USART1_TXD << 16) | MUX_PC27A_USART1_TXD)
+#define GPIO_PC27A_USART1_TXD    _UL(1 << 27)
+/* ========== GPIO definition for USART2 peripheral ========== */
+#define PIN_PC08B_USART2_CLK           _L(72) /**< \brief USART2 signal: CLK on PC08 mux B */
+#define MUX_PC08B_USART2_CLK            _L(1)
+#define PINMUX_PC08B_USART2_CLK    ((PIN_PC08B_USART2_CLK << 16) | MUX_PC08B_USART2_CLK)
+#define GPIO_PC08B_USART2_CLK    _UL(1 <<  8)
+#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L(0)
+#define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
+#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
+#define PIN_PC08E_USART2_CTS           _L(72) /**< \brief USART2 signal: CTS on PC08 mux E */
+#define MUX_PC08E_USART2_CTS            _L(4)
+#define PINMUX_PC08E_USART2_CTS    ((PIN_PC08E_USART2_CTS << 16) | MUX_PC08E_USART2_CTS)
+#define GPIO_PC08E_USART2_CTS    _UL(1 <<  8)
+#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L(1)
+#define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
+#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
+#define PIN_PC07B_USART2_RTS           _L(71) /**< \brief USART2 signal: RTS on PC07 mux B */
+#define MUX_PC07B_USART2_RTS            _L(1)
+#define PINMUX_PC07B_USART2_RTS    ((PIN_PC07B_USART2_RTS << 16) | MUX_PC07B_USART2_RTS)
+#define GPIO_PC07B_USART2_RTS    _UL(1 <<  7)
+#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L(0)
+#define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
+#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L(1)
+#define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
+#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
+#define PIN_PC11B_USART2_RXD           _L(75) /**< \brief USART2 signal: RXD on PC11 mux B */
+#define MUX_PC11B_USART2_RXD            _L(1)
+#define PINMUX_PC11B_USART2_RXD    ((PIN_PC11B_USART2_RXD << 16) | MUX_PC11B_USART2_RXD)
+#define GPIO_PC11B_USART2_RXD    _UL(1 << 11)
+#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L(0)
+#define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
+#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L(1)
+#define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
+#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
+#define PIN_PC12B_USART2_TXD           _L(76) /**< \brief USART2 signal: TXD on PC12 mux B */
+#define MUX_PC12B_USART2_TXD            _L(1)
+#define PINMUX_PC12B_USART2_TXD    ((PIN_PC12B_USART2_TXD << 16) | MUX_PC12B_USART2_TXD)
+#define GPIO_PC12B_USART2_TXD    _UL(1 << 12)
+#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L(0)
+#define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
+#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+/* ========== GPIO definition for USART3 peripheral ========== */
+#define PIN_PC14B_USART3_CLK           _L(78) /**< \brief USART3 signal: CLK on PC14 mux B */
+#define MUX_PC14B_USART3_CLK            _L(1)
+#define PINMUX_PC14B_USART3_CLK    ((PIN_PC14B_USART3_CLK << 16) | MUX_PC14B_USART3_CLK)
+#define GPIO_PC14B_USART3_CLK    _UL(1 << 14)
+#define PIN_PB08A_USART3_CLK           _L(40) /**< \brief USART3 signal: CLK on PB08 mux A */
+#define MUX_PB08A_USART3_CLK            _L(0)
+#define PINMUX_PB08A_USART3_CLK    ((PIN_PB08A_USART3_CLK << 16) | MUX_PB08A_USART3_CLK)
+#define GPIO_PB08A_USART3_CLK    _UL(1 <<  8)
+#define PIN_PC31A_USART3_CLK           _L(95) /**< \brief USART3 signal: CLK on PC31 mux A */
+#define MUX_PC31A_USART3_CLK            _L(0)
+#define PINMUX_PC31A_USART3_CLK    ((PIN_PC31A_USART3_CLK << 16) | MUX_PC31A_USART3_CLK)
+#define GPIO_PC31A_USART3_CLK    _UL(1 << 31)
+#define PIN_PB07A_USART3_CTS           _L(39) /**< \brief USART3 signal: CTS on PB07 mux A */
+#define MUX_PB07A_USART3_CTS            _L(0)
+#define PINMUX_PB07A_USART3_CTS    ((PIN_PB07A_USART3_CTS << 16) | MUX_PB07A_USART3_CTS)
+#define GPIO_PB07A_USART3_CTS    _UL(1 <<  7)
+#define PIN_PC13B_USART3_RTS           _L(77) /**< \brief USART3 signal: RTS on PC13 mux B */
+#define MUX_PC13B_USART3_RTS            _L(1)
+#define PINMUX_PC13B_USART3_RTS    ((PIN_PC13B_USART3_RTS << 16) | MUX_PC13B_USART3_RTS)
+#define GPIO_PC13B_USART3_RTS    _UL(1 << 13)
+#define PIN_PB06A_USART3_RTS           _L(38) /**< \brief USART3 signal: RTS on PB06 mux A */
+#define MUX_PB06A_USART3_RTS            _L(0)
+#define PINMUX_PB06A_USART3_RTS    ((PIN_PB06A_USART3_RTS << 16) | MUX_PB06A_USART3_RTS)
+#define GPIO_PB06A_USART3_RTS    _UL(1 <<  6)
+#define PIN_PC30A_USART3_RTS           _L(94) /**< \brief USART3 signal: RTS on PC30 mux A */
+#define MUX_PC30A_USART3_RTS            _L(0)
+#define PINMUX_PC30A_USART3_RTS    ((PIN_PC30A_USART3_RTS << 16) | MUX_PC30A_USART3_RTS)
+#define GPIO_PC30A_USART3_RTS    _UL(1 << 30)
+#define PIN_PC09B_USART3_RXD           _L(73) /**< \brief USART3 signal: RXD on PC09 mux B */
+#define MUX_PC09B_USART3_RXD            _L(1)
+#define PINMUX_PC09B_USART3_RXD    ((PIN_PC09B_USART3_RXD << 16) | MUX_PC09B_USART3_RXD)
+#define GPIO_PC09B_USART3_RXD    _UL(1 <<  9)
+#define PIN_PB09A_USART3_RXD           _L(41) /**< \brief USART3 signal: RXD on PB09 mux A */
+#define MUX_PB09A_USART3_RXD            _L(0)
+#define PINMUX_PB09A_USART3_RXD    ((PIN_PB09A_USART3_RXD << 16) | MUX_PB09A_USART3_RXD)
+#define GPIO_PB09A_USART3_RXD    _UL(1 <<  9)
+#define PIN_PC28A_USART3_RXD           _L(92) /**< \brief USART3 signal: RXD on PC28 mux A */
+#define MUX_PC28A_USART3_RXD            _L(0)
+#define PINMUX_PC28A_USART3_RXD    ((PIN_PC28A_USART3_RXD << 16) | MUX_PC28A_USART3_RXD)
+#define GPIO_PC28A_USART3_RXD    _UL(1 << 28)
+#define PIN_PC10B_USART3_TXD           _L(74) /**< \brief USART3 signal: TXD on PC10 mux B */
+#define MUX_PC10B_USART3_TXD            _L(1)
+#define PINMUX_PC10B_USART3_TXD    ((PIN_PC10B_USART3_TXD << 16) | MUX_PC10B_USART3_TXD)
+#define GPIO_PC10B_USART3_TXD    _UL(1 << 10)
+#define PIN_PB10A_USART3_TXD           _L(42) /**< \brief USART3 signal: TXD on PB10 mux A */
+#define MUX_PB10A_USART3_TXD            _L(0)
+#define PINMUX_PB10A_USART3_TXD    ((PIN_PB10A_USART3_TXD << 16) | MUX_PB10A_USART3_TXD)
+#define GPIO_PB10A_USART3_TXD    _UL(1 << 10)
+#define PIN_PC29A_USART3_TXD           _L(93) /**< \brief USART3 signal: TXD on PC29 mux A */
+#define MUX_PC29A_USART3_TXD            _L(0)
+#define PINMUX_PC29A_USART3_TXD    ((PIN_PC29A_USART3_TXD << 16) | MUX_PC29A_USART3_TXD)
+#define GPIO_PC29A_USART3_TXD    _UL(1 << 29)
+/* ========== GPIO definition for ADCIFE peripheral ========== */
+#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
+#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
+#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
+#define PIN_PB02A_ADCIFE_AD3           _L(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
+#define MUX_PB02A_ADCIFE_AD3            _L(0)
+#define PINMUX_PB02A_ADCIFE_AD3    ((PIN_PB02A_ADCIFE_AD3 << 16) | MUX_PB02A_ADCIFE_AD3)
+#define GPIO_PB02A_ADCIFE_AD3    _UL(1 <<  2)
+#define PIN_PB03A_ADCIFE_AD4           _L(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
+#define MUX_PB03A_ADCIFE_AD4            _L(0)
+#define PINMUX_PB03A_ADCIFE_AD4    ((PIN_PB03A_ADCIFE_AD4 << 16) | MUX_PB03A_ADCIFE_AD4)
+#define GPIO_PB03A_ADCIFE_AD4    _UL(1 <<  3)
+#define PIN_PB04A_ADCIFE_AD5           _L(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
+#define MUX_PB04A_ADCIFE_AD5            _L(0)
+#define PINMUX_PB04A_ADCIFE_AD5    ((PIN_PB04A_ADCIFE_AD5 << 16) | MUX_PB04A_ADCIFE_AD5)
+#define GPIO_PB04A_ADCIFE_AD5    _UL(1 <<  4)
+#define PIN_PB05A_ADCIFE_AD6           _L(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
+#define MUX_PB05A_ADCIFE_AD6            _L(0)
+#define PINMUX_PB05A_ADCIFE_AD6    ((PIN_PB05A_ADCIFE_AD6 << 16) | MUX_PB05A_ADCIFE_AD6)
+#define GPIO_PB05A_ADCIFE_AD6    _UL(1 <<  5)
+#define PIN_PC07A_ADCIFE_AD7           _L(71) /**< \brief ADCIFE signal: AD7 on PC07 mux A */
+#define MUX_PC07A_ADCIFE_AD7            _L(0)
+#define PINMUX_PC07A_ADCIFE_AD7    ((PIN_PC07A_ADCIFE_AD7 << 16) | MUX_PC07A_ADCIFE_AD7)
+#define GPIO_PC07A_ADCIFE_AD7    _UL(1 <<  7)
+#define PIN_PC08A_ADCIFE_AD8           _L(72) /**< \brief ADCIFE signal: AD8 on PC08 mux A */
+#define MUX_PC08A_ADCIFE_AD8            _L(0)
+#define PINMUX_PC08A_ADCIFE_AD8    ((PIN_PC08A_ADCIFE_AD8 << 16) | MUX_PC08A_ADCIFE_AD8)
+#define GPIO_PC08A_ADCIFE_AD8    _UL(1 <<  8)
+#define PIN_PC09A_ADCIFE_AD9           _L(73) /**< \brief ADCIFE signal: AD9 on PC09 mux A */
+#define MUX_PC09A_ADCIFE_AD9            _L(0)
+#define PINMUX_PC09A_ADCIFE_AD9    ((PIN_PC09A_ADCIFE_AD9 << 16) | MUX_PC09A_ADCIFE_AD9)
+#define GPIO_PC09A_ADCIFE_AD9    _UL(1 <<  9)
+#define PIN_PC10A_ADCIFE_AD10          _L(74) /**< \brief ADCIFE signal: AD10 on PC10 mux A */
+#define MUX_PC10A_ADCIFE_AD10           _L(0)
+#define PINMUX_PC10A_ADCIFE_AD10   ((PIN_PC10A_ADCIFE_AD10 << 16) | MUX_PC10A_ADCIFE_AD10)
+#define GPIO_PC10A_ADCIFE_AD10   _UL(1 << 10)
+#define PIN_PC11A_ADCIFE_AD11          _L(75) /**< \brief ADCIFE signal: AD11 on PC11 mux A */
+#define MUX_PC11A_ADCIFE_AD11           _L(0)
+#define PINMUX_PC11A_ADCIFE_AD11   ((PIN_PC11A_ADCIFE_AD11 << 16) | MUX_PC11A_ADCIFE_AD11)
+#define GPIO_PC11A_ADCIFE_AD11   _UL(1 << 11)
+#define PIN_PC12A_ADCIFE_AD12          _L(76) /**< \brief ADCIFE signal: AD12 on PC12 mux A */
+#define MUX_PC12A_ADCIFE_AD12           _L(0)
+#define PINMUX_PC12A_ADCIFE_AD12   ((PIN_PC12A_ADCIFE_AD12 << 16) | MUX_PC12A_ADCIFE_AD12)
+#define GPIO_PC12A_ADCIFE_AD12   _UL(1 << 12)
+#define PIN_PC13A_ADCIFE_AD13          _L(77) /**< \brief ADCIFE signal: AD13 on PC13 mux A */
+#define MUX_PC13A_ADCIFE_AD13           _L(0)
+#define PINMUX_PC13A_ADCIFE_AD13   ((PIN_PC13A_ADCIFE_AD13 << 16) | MUX_PC13A_ADCIFE_AD13)
+#define GPIO_PC13A_ADCIFE_AD13   _UL(1 << 13)
+#define PIN_PC14A_ADCIFE_AD14          _L(78) /**< \brief ADCIFE signal: AD14 on PC14 mux A */
+#define MUX_PC14A_ADCIFE_AD14           _L(0)
+#define PINMUX_PC14A_ADCIFE_AD14   ((PIN_PC14A_ADCIFE_AD14 << 16) | MUX_PC14A_ADCIFE_AD14)
+#define GPIO_PC14A_ADCIFE_AD14   _UL(1 << 14)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+/* ========== GPIO definition for DACC peripheral ========== */
+#define PIN_PB04E_DACC_EXT_TRIG0       _L(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
+#define MUX_PB04E_DACC_EXT_TRIG0        _L(4)
+#define PINMUX_PB04E_DACC_EXT_TRIG0  ((PIN_PB04E_DACC_EXT_TRIG0 << 16) | MUX_PB04E_DACC_EXT_TRIG0)
+#define GPIO_PB04E_DACC_EXT_TRIG0  _UL(1 <<  4)
+#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L(0)
+#define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
+#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+/* ========== GPIO definition for ACIFC peripheral ========== */
+#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
+#define PIN_PC09E_ACIFC_ACAN1          _L(73) /**< \brief ACIFC signal: ACAN1 on PC09 mux E */
+#define MUX_PC09E_ACIFC_ACAN1           _L(4)
+#define PINMUX_PC09E_ACIFC_ACAN1   ((PIN_PC09E_ACIFC_ACAN1 << 16) | MUX_PC09E_ACIFC_ACAN1)
+#define GPIO_PC09E_ACIFC_ACAN1   _UL(1 <<  9)
+#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
+#define PIN_PC10E_ACIFC_ACAP1          _L(74) /**< \brief ACIFC signal: ACAP1 on PC10 mux E */
+#define MUX_PC10E_ACIFC_ACAP1           _L(4)
+#define PINMUX_PC10E_ACIFC_ACAP1   ((PIN_PC10E_ACIFC_ACAP1 << 16) | MUX_PC10E_ACIFC_ACAP1)
+#define GPIO_PC10E_ACIFC_ACAP1   _UL(1 << 10)
+#define PIN_PB02E_ACIFC_ACBN0          _L(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
+#define MUX_PB02E_ACIFC_ACBN0           _L(4)
+#define PINMUX_PB02E_ACIFC_ACBN0   ((PIN_PB02E_ACIFC_ACBN0 << 16) | MUX_PB02E_ACIFC_ACBN0)
+#define GPIO_PB02E_ACIFC_ACBN0   _UL(1 <<  2)
+#define PIN_PC13E_ACIFC_ACBN1          _L(77) /**< \brief ACIFC signal: ACBN1 on PC13 mux E */
+#define MUX_PC13E_ACIFC_ACBN1           _L(4)
+#define PINMUX_PC13E_ACIFC_ACBN1   ((PIN_PC13E_ACIFC_ACBN1 << 16) | MUX_PC13E_ACIFC_ACBN1)
+#define GPIO_PC13E_ACIFC_ACBN1   _UL(1 << 13)
+#define PIN_PB03E_ACIFC_ACBP0          _L(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
+#define MUX_PB03E_ACIFC_ACBP0           _L(4)
+#define PINMUX_PB03E_ACIFC_ACBP0   ((PIN_PB03E_ACIFC_ACBP0 << 16) | MUX_PB03E_ACIFC_ACBP0)
+#define GPIO_PB03E_ACIFC_ACBP0   _UL(1 <<  3)
+#define PIN_PC14E_ACIFC_ACBP1          _L(78) /**< \brief ACIFC signal: ACBP1 on PC14 mux E */
+#define MUX_PC14E_ACIFC_ACBP1           _L(4)
+#define PINMUX_PC14E_ACIFC_ACBP1   ((PIN_PC14E_ACIFC_ACBP1 << 16) | MUX_PC14E_ACIFC_ACBP1)
+#define GPIO_PC14E_ACIFC_ACBP1   _UL(1 << 14)
+/* ========== GPIO definition for GLOC peripheral ========== */
+#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
+#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L(3)
+#define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
+#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L(3)
+#define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
+#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L(3)
+#define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
+#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L(3)
+#define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
+#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L(3)
+#define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
+#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L(3)
+#define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
+#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L(3)
+#define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
+#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
+#define PIN_PC15D_GLOC_IN4             _L(79) /**< \brief GLOC signal: IN4 on PC15 mux D */
+#define MUX_PC15D_GLOC_IN4              _L(3)
+#define PINMUX_PC15D_GLOC_IN4      ((PIN_PC15D_GLOC_IN4 << 16) | MUX_PC15D_GLOC_IN4)
+#define GPIO_PC15D_GLOC_IN4      _UL(1 << 15)
+#define PIN_PB06C_GLOC_IN4             _L(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
+#define MUX_PB06C_GLOC_IN4              _L(2)
+#define PINMUX_PB06C_GLOC_IN4      ((PIN_PB06C_GLOC_IN4 << 16) | MUX_PB06C_GLOC_IN4)
+#define GPIO_PB06C_GLOC_IN4      _UL(1 <<  6)
+#define PIN_PC28C_GLOC_IN4             _L(92) /**< \brief GLOC signal: IN4 on PC28 mux C */
+#define MUX_PC28C_GLOC_IN4              _L(2)
+#define PINMUX_PC28C_GLOC_IN4      ((PIN_PC28C_GLOC_IN4 << 16) | MUX_PC28C_GLOC_IN4)
+#define GPIO_PC28C_GLOC_IN4      _UL(1 << 28)
+#define PIN_PC16D_GLOC_IN5             _L(80) /**< \brief GLOC signal: IN5 on PC16 mux D */
+#define MUX_PC16D_GLOC_IN5              _L(3)
+#define PINMUX_PC16D_GLOC_IN5      ((PIN_PC16D_GLOC_IN5 << 16) | MUX_PC16D_GLOC_IN5)
+#define GPIO_PC16D_GLOC_IN5      _UL(1 << 16)
+#define PIN_PB07C_GLOC_IN5             _L(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
+#define MUX_PB07C_GLOC_IN5              _L(2)
+#define PINMUX_PB07C_GLOC_IN5      ((PIN_PB07C_GLOC_IN5 << 16) | MUX_PB07C_GLOC_IN5)
+#define GPIO_PB07C_GLOC_IN5      _UL(1 <<  7)
+#define PIN_PC29C_GLOC_IN5             _L(93) /**< \brief GLOC signal: IN5 on PC29 mux C */
+#define MUX_PC29C_GLOC_IN5              _L(2)
+#define PINMUX_PC29C_GLOC_IN5      ((PIN_PC29C_GLOC_IN5 << 16) | MUX_PC29C_GLOC_IN5)
+#define GPIO_PC29C_GLOC_IN5      _UL(1 << 29)
+#define PIN_PC17D_GLOC_IN6             _L(81) /**< \brief GLOC signal: IN6 on PC17 mux D */
+#define MUX_PC17D_GLOC_IN6              _L(3)
+#define PINMUX_PC17D_GLOC_IN6      ((PIN_PC17D_GLOC_IN6 << 16) | MUX_PC17D_GLOC_IN6)
+#define GPIO_PC17D_GLOC_IN6      _UL(1 << 17)
+#define PIN_PB08C_GLOC_IN6             _L(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
+#define MUX_PB08C_GLOC_IN6              _L(2)
+#define PINMUX_PB08C_GLOC_IN6      ((PIN_PB08C_GLOC_IN6 << 16) | MUX_PB08C_GLOC_IN6)
+#define GPIO_PB08C_GLOC_IN6      _UL(1 <<  8)
+#define PIN_PC30C_GLOC_IN6             _L(94) /**< \brief GLOC signal: IN6 on PC30 mux C */
+#define MUX_PC30C_GLOC_IN6              _L(2)
+#define PINMUX_PC30C_GLOC_IN6      ((PIN_PC30C_GLOC_IN6 << 16) | MUX_PC30C_GLOC_IN6)
+#define GPIO_PC30C_GLOC_IN6      _UL(1 << 30)
+#define PIN_PC18D_GLOC_IN7             _L(82) /**< \brief GLOC signal: IN7 on PC18 mux D */
+#define MUX_PC18D_GLOC_IN7              _L(3)
+#define PINMUX_PC18D_GLOC_IN7      ((PIN_PC18D_GLOC_IN7 << 16) | MUX_PC18D_GLOC_IN7)
+#define GPIO_PC18D_GLOC_IN7      _UL(1 << 18)
+#define PIN_PB09C_GLOC_IN7             _L(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
+#define MUX_PB09C_GLOC_IN7              _L(2)
+#define PINMUX_PB09C_GLOC_IN7      ((PIN_PB09C_GLOC_IN7 << 16) | MUX_PB09C_GLOC_IN7)
+#define GPIO_PB09C_GLOC_IN7      _UL(1 <<  9)
+#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
+#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
+#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
+#define PIN_PC19D_GLOC_OUT1            _L(83) /**< \brief GLOC signal: OUT1 on PC19 mux D */
+#define MUX_PC19D_GLOC_OUT1             _L(3)
+#define PINMUX_PC19D_GLOC_OUT1     ((PIN_PC19D_GLOC_OUT1 << 16) | MUX_PC19D_GLOC_OUT1)
+#define GPIO_PC19D_GLOC_OUT1     _UL(1 << 19)
+#define PIN_PB10C_GLOC_OUT1            _L(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
+#define MUX_PB10C_GLOC_OUT1             _L(2)
+#define PINMUX_PB10C_GLOC_OUT1     ((PIN_PB10C_GLOC_OUT1 << 16) | MUX_PB10C_GLOC_OUT1)
+#define GPIO_PB10C_GLOC_OUT1     _UL(1 << 10)
+#define PIN_PC31C_GLOC_OUT1            _L(95) /**< \brief GLOC signal: OUT1 on PC31 mux C */
+#define MUX_PC31C_GLOC_OUT1             _L(2)
+#define PINMUX_PC31C_GLOC_OUT1     ((PIN_PC31C_GLOC_OUT1 << 16) | MUX_PC31C_GLOC_OUT1)
+#define GPIO_PC31C_GLOC_OUT1     _UL(1 << 31)
+/* ========== GPIO definition for ABDACB peripheral ========== */
+#define PIN_PC12C_ABDACB_CLK           _L(76) /**< \brief ABDACB signal: CLK on PC12 mux C */
+#define MUX_PC12C_ABDACB_CLK            _L(2)
+#define PINMUX_PC12C_ABDACB_CLK    ((PIN_PC12C_ABDACB_CLK << 16) | MUX_PC12C_ABDACB_CLK)
+#define GPIO_PC12C_ABDACB_CLK    _UL(1 << 12)
+#define PIN_PB02C_ABDACB_DAC0          _L(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
+#define MUX_PB02C_ABDACB_DAC0           _L(2)
+#define PINMUX_PB02C_ABDACB_DAC0   ((PIN_PB02C_ABDACB_DAC0 << 16) | MUX_PB02C_ABDACB_DAC0)
+#define GPIO_PB02C_ABDACB_DAC0   _UL(1 <<  2)
+#define PIN_PC09C_ABDACB_DAC0          _L(73) /**< \brief ABDACB signal: DAC0 on PC09 mux C */
+#define MUX_PC09C_ABDACB_DAC0           _L(2)
+#define PINMUX_PC09C_ABDACB_DAC0   ((PIN_PC09C_ABDACB_DAC0 << 16) | MUX_PC09C_ABDACB_DAC0)
+#define GPIO_PC09C_ABDACB_DAC0   _UL(1 <<  9)
+#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
+#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
+#define PIN_PB04C_ABDACB_DAC1          _L(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
+#define MUX_PB04C_ABDACB_DAC1           _L(2)
+#define PINMUX_PB04C_ABDACB_DAC1   ((PIN_PB04C_ABDACB_DAC1 << 16) | MUX_PB04C_ABDACB_DAC1)
+#define GPIO_PB04C_ABDACB_DAC1   _UL(1 <<  4)
+#define PIN_PC13C_ABDACB_DAC1          _L(77) /**< \brief ABDACB signal: DAC1 on PC13 mux C */
+#define MUX_PC13C_ABDACB_DAC1           _L(2)
+#define PINMUX_PC13C_ABDACB_DAC1   ((PIN_PC13C_ABDACB_DAC1 << 16) | MUX_PC13C_ABDACB_DAC1)
+#define GPIO_PC13C_ABDACB_DAC1   _UL(1 << 13)
+#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
+#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
+#define PIN_PB03C_ABDACB_DACN0         _L(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
+#define MUX_PB03C_ABDACB_DACN0          _L(2)
+#define PINMUX_PB03C_ABDACB_DACN0  ((PIN_PB03C_ABDACB_DACN0 << 16) | MUX_PB03C_ABDACB_DACN0)
+#define GPIO_PB03C_ABDACB_DACN0  _UL(1 <<  3)
+#define PIN_PC10C_ABDACB_DACN0         _L(74) /**< \brief ABDACB signal: DACN0 on PC10 mux C */
+#define MUX_PC10C_ABDACB_DACN0          _L(2)
+#define PINMUX_PC10C_ABDACB_DACN0  ((PIN_PC10C_ABDACB_DACN0 << 16) | MUX_PC10C_ABDACB_DACN0)
+#define GPIO_PC10C_ABDACB_DACN0  _UL(1 << 10)
+#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
+#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
+#define PIN_PB05C_ABDACB_DACN1         _L(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
+#define MUX_PB05C_ABDACB_DACN1          _L(2)
+#define PINMUX_PB05C_ABDACB_DACN1  ((PIN_PB05C_ABDACB_DACN1 << 16) | MUX_PB05C_ABDACB_DACN1)
+#define GPIO_PB05C_ABDACB_DACN1  _UL(1 <<  5)
+#define PIN_PC14C_ABDACB_DACN1         _L(78) /**< \brief ABDACB signal: DACN1 on PC14 mux C */
+#define MUX_PC14C_ABDACB_DACN1          _L(2)
+#define PINMUX_PC14C_ABDACB_DACN1  ((PIN_PC14C_ABDACB_DACN1 << 16) | MUX_PC14C_ABDACB_DACN1)
+#define GPIO_PC14C_ABDACB_DACN1  _UL(1 << 14)
+#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
+#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+/* ========== GPIO definition for PARC peripheral ========== */
+#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
+#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
+#define PIN_PC21D_PARC_PCCK            _L(85) /**< \brief PARC signal: PCCK on PC21 mux D */
+#define MUX_PC21D_PARC_PCCK             _L(3)
+#define PINMUX_PC21D_PARC_PCCK     ((PIN_PC21D_PARC_PCCK << 16) | MUX_PC21D_PARC_PCCK)
+#define GPIO_PC21D_PARC_PCCK     _UL(1 << 21)
+#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
+#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
+#define PIN_PC24D_PARC_PCDATA0         _L(88) /**< \brief PARC signal: PCDATA0 on PC24 mux D */
+#define MUX_PC24D_PARC_PCDATA0          _L(3)
+#define PINMUX_PC24D_PARC_PCDATA0  ((PIN_PC24D_PARC_PCDATA0 << 16) | MUX_PC24D_PARC_PCDATA0)
+#define GPIO_PC24D_PARC_PCDATA0  _UL(1 << 24)
+#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
+#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
+#define PIN_PC25D_PARC_PCDATA1         _L(89) /**< \brief PARC signal: PCDATA1 on PC25 mux D */
+#define MUX_PC25D_PARC_PCDATA1          _L(3)
+#define PINMUX_PC25D_PARC_PCDATA1  ((PIN_PC25D_PARC_PCDATA1 << 16) | MUX_PC25D_PARC_PCDATA1)
+#define GPIO_PC25D_PARC_PCDATA1  _UL(1 << 25)
+#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
+#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
+#define PIN_PC26D_PARC_PCDATA2         _L(90) /**< \brief PARC signal: PCDATA2 on PC26 mux D */
+#define MUX_PC26D_PARC_PCDATA2          _L(3)
+#define PINMUX_PC26D_PARC_PCDATA2  ((PIN_PC26D_PARC_PCDATA2 << 16) | MUX_PC26D_PARC_PCDATA2)
+#define GPIO_PC26D_PARC_PCDATA2  _UL(1 << 26)
+#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
+#define PIN_PC27D_PARC_PCDATA3         _L(91) /**< \brief PARC signal: PCDATA3 on PC27 mux D */
+#define MUX_PC27D_PARC_PCDATA3          _L(3)
+#define PINMUX_PC27D_PARC_PCDATA3  ((PIN_PC27D_PARC_PCDATA3 << 16) | MUX_PC27D_PARC_PCDATA3)
+#define GPIO_PC27D_PARC_PCDATA3  _UL(1 << 27)
+#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
+#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
+#define PIN_PC28D_PARC_PCDATA4         _L(92) /**< \brief PARC signal: PCDATA4 on PC28 mux D */
+#define MUX_PC28D_PARC_PCDATA4          _L(3)
+#define PINMUX_PC28D_PARC_PCDATA4  ((PIN_PC28D_PARC_PCDATA4 << 16) | MUX_PC28D_PARC_PCDATA4)
+#define GPIO_PC28D_PARC_PCDATA4  _UL(1 << 28)
+#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
+#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
+#define PIN_PC29D_PARC_PCDATA5         _L(93) /**< \brief PARC signal: PCDATA5 on PC29 mux D */
+#define MUX_PC29D_PARC_PCDATA5          _L(3)
+#define PINMUX_PC29D_PARC_PCDATA5  ((PIN_PC29D_PARC_PCDATA5 << 16) | MUX_PC29D_PARC_PCDATA5)
+#define GPIO_PC29D_PARC_PCDATA5  _UL(1 << 29)
+#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
+#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
+#define PIN_PC30D_PARC_PCDATA6         _L(94) /**< \brief PARC signal: PCDATA6 on PC30 mux D */
+#define MUX_PC30D_PARC_PCDATA6          _L(3)
+#define PINMUX_PC30D_PARC_PCDATA6  ((PIN_PC30D_PARC_PCDATA6 << 16) | MUX_PC30D_PARC_PCDATA6)
+#define GPIO_PC30D_PARC_PCDATA6  _UL(1 << 30)
+#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
+#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
+#define PIN_PC31D_PARC_PCDATA7         _L(95) /**< \brief PARC signal: PCDATA7 on PC31 mux D */
+#define MUX_PC31D_PARC_PCDATA7          _L(3)
+#define PINMUX_PC31D_PARC_PCDATA7  ((PIN_PC31D_PARC_PCDATA7 << 16) | MUX_PC31D_PARC_PCDATA7)
+#define GPIO_PC31D_PARC_PCDATA7  _UL(1 << 31)
+#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
+#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
+#define PIN_PC22D_PARC_PCEN1           _L(86) /**< \brief PARC signal: PCEN1 on PC22 mux D */
+#define MUX_PC22D_PARC_PCEN1            _L(3)
+#define PINMUX_PC22D_PARC_PCEN1    ((PIN_PC22D_PARC_PCEN1 << 16) | MUX_PC22D_PARC_PCEN1)
+#define GPIO_PC22D_PARC_PCEN1    _UL(1 << 22)
+#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
+#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+#define PIN_PC23D_PARC_PCEN2           _L(87) /**< \brief PARC signal: PCEN2 on PC23 mux D */
+#define MUX_PC23D_PARC_PCEN2            _L(3)
+#define PINMUX_PC23D_PARC_PCEN2    ((PIN_PC23D_PARC_PCEN2 << 16) | MUX_PC23D_PARC_PCEN2)
+#define GPIO_PC23D_PARC_PCEN2    _UL(1 << 23)
+/* ========== GPIO definition for CATB peripheral ========== */
+#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L(6)
+#define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
+#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L(6)
+#define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
+#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L(6)
+#define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
+#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
+#define PIN_PB03G_CATB_DIS             _L(35) /**< \brief CATB signal: DIS on PB03 mux G */
+#define MUX_PB03G_CATB_DIS              _L(6)
+#define PINMUX_PB03G_CATB_DIS      ((PIN_PB03G_CATB_DIS << 16) | MUX_PB03G_CATB_DIS)
+#define GPIO_PB03G_CATB_DIS      _UL(1 <<  3)
+#define PIN_PB12G_CATB_DIS             _L(44) /**< \brief CATB signal: DIS on PB12 mux G */
+#define MUX_PB12G_CATB_DIS              _L(6)
+#define PINMUX_PB12G_CATB_DIS      ((PIN_PB12G_CATB_DIS << 16) | MUX_PB12G_CATB_DIS)
+#define GPIO_PB12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PC05G_CATB_DIS             _L(69) /**< \brief CATB signal: DIS on PC05 mux G */
+#define MUX_PC05G_CATB_DIS              _L(6)
+#define PINMUX_PC05G_CATB_DIS      ((PIN_PC05G_CATB_DIS << 16) | MUX_PC05G_CATB_DIS)
+#define GPIO_PC05G_CATB_DIS      _UL(1 <<  5)
+#define PIN_PC14G_CATB_DIS             _L(78) /**< \brief CATB signal: DIS on PC14 mux G */
+#define MUX_PC14G_CATB_DIS              _L(6)
+#define PINMUX_PC14G_CATB_DIS      ((PIN_PC14G_CATB_DIS << 16) | MUX_PC14G_CATB_DIS)
+#define GPIO_PC14G_CATB_DIS      _UL(1 << 14)
+#define PIN_PC23G_CATB_DIS             _L(87) /**< \brief CATB signal: DIS on PC23 mux G */
+#define MUX_PC23G_CATB_DIS              _L(6)
+#define PINMUX_PC23G_CATB_DIS      ((PIN_PC23G_CATB_DIS << 16) | MUX_PC23G_CATB_DIS)
+#define GPIO_PC23G_CATB_DIS      _UL(1 << 23)
+#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
+#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
+#define PIN_PB13G_CATB_SENSE0          _L(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
+#define MUX_PB13G_CATB_SENSE0           _L(6)
+#define PINMUX_PB13G_CATB_SENSE0   ((PIN_PB13G_CATB_SENSE0 << 16) | MUX_PB13G_CATB_SENSE0)
+#define GPIO_PB13G_CATB_SENSE0   _UL(1 << 13)
+#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
+#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
+#define PIN_PB14G_CATB_SENSE1          _L(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
+#define MUX_PB14G_CATB_SENSE1           _L(6)
+#define PINMUX_PB14G_CATB_SENSE1   ((PIN_PB14G_CATB_SENSE1 << 16) | MUX_PB14G_CATB_SENSE1)
+#define GPIO_PB14G_CATB_SENSE1   _UL(1 << 14)
+#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
+#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
+#define PIN_PB15G_CATB_SENSE2          _L(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
+#define MUX_PB15G_CATB_SENSE2           _L(6)
+#define PINMUX_PB15G_CATB_SENSE2   ((PIN_PB15G_CATB_SENSE2 << 16) | MUX_PB15G_CATB_SENSE2)
+#define GPIO_PB15G_CATB_SENSE2   _UL(1 << 15)
+#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
+#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
+#define PIN_PC00G_CATB_SENSE3          _L(64) /**< \brief CATB signal: SENSE3 on PC00 mux G */
+#define MUX_PC00G_CATB_SENSE3           _L(6)
+#define PINMUX_PC00G_CATB_SENSE3   ((PIN_PC00G_CATB_SENSE3 << 16) | MUX_PC00G_CATB_SENSE3)
+#define GPIO_PC00G_CATB_SENSE3   _UL(1 <<  0)
+#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
+#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
+#define PIN_PC01G_CATB_SENSE4          _L(65) /**< \brief CATB signal: SENSE4 on PC01 mux G */
+#define MUX_PC01G_CATB_SENSE4           _L(6)
+#define PINMUX_PC01G_CATB_SENSE4   ((PIN_PC01G_CATB_SENSE4 << 16) | MUX_PC01G_CATB_SENSE4)
+#define GPIO_PC01G_CATB_SENSE4   _UL(1 <<  1)
+#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
+#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
+#define PIN_PC02G_CATB_SENSE5          _L(66) /**< \brief CATB signal: SENSE5 on PC02 mux G */
+#define MUX_PC02G_CATB_SENSE5           _L(6)
+#define PINMUX_PC02G_CATB_SENSE5   ((PIN_PC02G_CATB_SENSE5 << 16) | MUX_PC02G_CATB_SENSE5)
+#define GPIO_PC02G_CATB_SENSE5   _UL(1 <<  2)
+#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
+#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
+#define PIN_PC03G_CATB_SENSE6          _L(67) /**< \brief CATB signal: SENSE6 on PC03 mux G */
+#define MUX_PC03G_CATB_SENSE6           _L(6)
+#define PINMUX_PC03G_CATB_SENSE6   ((PIN_PC03G_CATB_SENSE6 << 16) | MUX_PC03G_CATB_SENSE6)
+#define GPIO_PC03G_CATB_SENSE6   _UL(1 <<  3)
+#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
+#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
+#define PIN_PC04G_CATB_SENSE7          _L(68) /**< \brief CATB signal: SENSE7 on PC04 mux G */
+#define MUX_PC04G_CATB_SENSE7           _L(6)
+#define PINMUX_PC04G_CATB_SENSE7   ((PIN_PC04G_CATB_SENSE7 << 16) | MUX_PC04G_CATB_SENSE7)
+#define GPIO_PC04G_CATB_SENSE7   _UL(1 <<  4)
+#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
+#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
+#define PIN_PC06G_CATB_SENSE8          _L(70) /**< \brief CATB signal: SENSE8 on PC06 mux G */
+#define MUX_PC06G_CATB_SENSE8           _L(6)
+#define PINMUX_PC06G_CATB_SENSE8   ((PIN_PC06G_CATB_SENSE8 << 16) | MUX_PC06G_CATB_SENSE8)
+#define GPIO_PC06G_CATB_SENSE8   _UL(1 <<  6)
+#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
+#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
+#define PIN_PC07G_CATB_SENSE9          _L(71) /**< \brief CATB signal: SENSE9 on PC07 mux G */
+#define MUX_PC07G_CATB_SENSE9           _L(6)
+#define PINMUX_PC07G_CATB_SENSE9   ((PIN_PC07G_CATB_SENSE9 << 16) | MUX_PC07G_CATB_SENSE9)
+#define GPIO_PC07G_CATB_SENSE9   _UL(1 <<  7)
+#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
+#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
+#define PIN_PC08G_CATB_SENSE10         _L(72) /**< \brief CATB signal: SENSE10 on PC08 mux G */
+#define MUX_PC08G_CATB_SENSE10          _L(6)
+#define PINMUX_PC08G_CATB_SENSE10  ((PIN_PC08G_CATB_SENSE10 << 16) | MUX_PC08G_CATB_SENSE10)
+#define GPIO_PC08G_CATB_SENSE10  _UL(1 <<  8)
+#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
+#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
+#define PIN_PC09G_CATB_SENSE11         _L(73) /**< \brief CATB signal: SENSE11 on PC09 mux G */
+#define MUX_PC09G_CATB_SENSE11          _L(6)
+#define PINMUX_PC09G_CATB_SENSE11  ((PIN_PC09G_CATB_SENSE11 << 16) | MUX_PC09G_CATB_SENSE11)
+#define GPIO_PC09G_CATB_SENSE11  _UL(1 <<  9)
+#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
+#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
+#define PIN_PC10G_CATB_SENSE12         _L(74) /**< \brief CATB signal: SENSE12 on PC10 mux G */
+#define MUX_PC10G_CATB_SENSE12          _L(6)
+#define PINMUX_PC10G_CATB_SENSE12  ((PIN_PC10G_CATB_SENSE12 << 16) | MUX_PC10G_CATB_SENSE12)
+#define GPIO_PC10G_CATB_SENSE12  _UL(1 << 10)
+#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
+#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
+#define PIN_PC11G_CATB_SENSE13         _L(75) /**< \brief CATB signal: SENSE13 on PC11 mux G */
+#define MUX_PC11G_CATB_SENSE13          _L(6)
+#define PINMUX_PC11G_CATB_SENSE13  ((PIN_PC11G_CATB_SENSE13 << 16) | MUX_PC11G_CATB_SENSE13)
+#define GPIO_PC11G_CATB_SENSE13  _UL(1 << 11)
+#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
+#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
+#define PIN_PC12G_CATB_SENSE14         _L(76) /**< \brief CATB signal: SENSE14 on PC12 mux G */
+#define MUX_PC12G_CATB_SENSE14          _L(6)
+#define PINMUX_PC12G_CATB_SENSE14  ((PIN_PC12G_CATB_SENSE14 << 16) | MUX_PC12G_CATB_SENSE14)
+#define GPIO_PC12G_CATB_SENSE14  _UL(1 << 12)
+#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
+#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
+#define PIN_PC13G_CATB_SENSE15         _L(77) /**< \brief CATB signal: SENSE15 on PC13 mux G */
+#define MUX_PC13G_CATB_SENSE15          _L(6)
+#define PINMUX_PC13G_CATB_SENSE15  ((PIN_PC13G_CATB_SENSE15 << 16) | MUX_PC13G_CATB_SENSE15)
+#define GPIO_PC13G_CATB_SENSE15  _UL(1 << 13)
+#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
+#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
+#define PIN_PC15G_CATB_SENSE16         _L(79) /**< \brief CATB signal: SENSE16 on PC15 mux G */
+#define MUX_PC15G_CATB_SENSE16          _L(6)
+#define PINMUX_PC15G_CATB_SENSE16  ((PIN_PC15G_CATB_SENSE16 << 16) | MUX_PC15G_CATB_SENSE16)
+#define GPIO_PC15G_CATB_SENSE16  _UL(1 << 15)
+#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
+#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
+#define PIN_PC16G_CATB_SENSE17         _L(80) /**< \brief CATB signal: SENSE17 on PC16 mux G */
+#define MUX_PC16G_CATB_SENSE17          _L(6)
+#define PINMUX_PC16G_CATB_SENSE17  ((PIN_PC16G_CATB_SENSE17 << 16) | MUX_PC16G_CATB_SENSE17)
+#define GPIO_PC16G_CATB_SENSE17  _UL(1 << 16)
+#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
+#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
+#define PIN_PC17G_CATB_SENSE18         _L(81) /**< \brief CATB signal: SENSE18 on PC17 mux G */
+#define MUX_PC17G_CATB_SENSE18          _L(6)
+#define PINMUX_PC17G_CATB_SENSE18  ((PIN_PC17G_CATB_SENSE18 << 16) | MUX_PC17G_CATB_SENSE18)
+#define GPIO_PC17G_CATB_SENSE18  _UL(1 << 17)
+#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
+#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
+#define PIN_PC18G_CATB_SENSE19         _L(82) /**< \brief CATB signal: SENSE19 on PC18 mux G */
+#define MUX_PC18G_CATB_SENSE19          _L(6)
+#define PINMUX_PC18G_CATB_SENSE19  ((PIN_PC18G_CATB_SENSE19 << 16) | MUX_PC18G_CATB_SENSE19)
+#define GPIO_PC18G_CATB_SENSE19  _UL(1 << 18)
+#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
+#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
+#define PIN_PC19G_CATB_SENSE20         _L(83) /**< \brief CATB signal: SENSE20 on PC19 mux G */
+#define MUX_PC19G_CATB_SENSE20          _L(6)
+#define PINMUX_PC19G_CATB_SENSE20  ((PIN_PC19G_CATB_SENSE20 << 16) | MUX_PC19G_CATB_SENSE20)
+#define GPIO_PC19G_CATB_SENSE20  _UL(1 << 19)
+#define PIN_PB00G_CATB_SENSE21         _L(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
+#define MUX_PB00G_CATB_SENSE21          _L(6)
+#define PINMUX_PB00G_CATB_SENSE21  ((PIN_PB00G_CATB_SENSE21 << 16) | MUX_PB00G_CATB_SENSE21)
+#define GPIO_PB00G_CATB_SENSE21  _UL(1 <<  0)
+#define PIN_PC20G_CATB_SENSE21         _L(84) /**< \brief CATB signal: SENSE21 on PC20 mux G */
+#define MUX_PC20G_CATB_SENSE21          _L(6)
+#define PINMUX_PC20G_CATB_SENSE21  ((PIN_PC20G_CATB_SENSE21 << 16) | MUX_PC20G_CATB_SENSE21)
+#define GPIO_PC20G_CATB_SENSE21  _UL(1 << 20)
+#define PIN_PB01G_CATB_SENSE22         _L(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
+#define MUX_PB01G_CATB_SENSE22          _L(6)
+#define PINMUX_PB01G_CATB_SENSE22  ((PIN_PB01G_CATB_SENSE22 << 16) | MUX_PB01G_CATB_SENSE22)
+#define GPIO_PB01G_CATB_SENSE22  _UL(1 <<  1)
+#define PIN_PC21G_CATB_SENSE22         _L(85) /**< \brief CATB signal: SENSE22 on PC21 mux G */
+#define MUX_PC21G_CATB_SENSE22          _L(6)
+#define PINMUX_PC21G_CATB_SENSE22  ((PIN_PC21G_CATB_SENSE22 << 16) | MUX_PC21G_CATB_SENSE22)
+#define GPIO_PC21G_CATB_SENSE22  _UL(1 << 21)
+#define PIN_PB02G_CATB_SENSE23         _L(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
+#define MUX_PB02G_CATB_SENSE23          _L(6)
+#define PINMUX_PB02G_CATB_SENSE23  ((PIN_PB02G_CATB_SENSE23 << 16) | MUX_PB02G_CATB_SENSE23)
+#define GPIO_PB02G_CATB_SENSE23  _UL(1 <<  2)
+#define PIN_PC22G_CATB_SENSE23         _L(86) /**< \brief CATB signal: SENSE23 on PC22 mux G */
+#define MUX_PC22G_CATB_SENSE23          _L(6)
+#define PINMUX_PC22G_CATB_SENSE23  ((PIN_PC22G_CATB_SENSE23 << 16) | MUX_PC22G_CATB_SENSE23)
+#define GPIO_PC22G_CATB_SENSE23  _UL(1 << 22)
+#define PIN_PB04G_CATB_SENSE24         _L(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
+#define MUX_PB04G_CATB_SENSE24          _L(6)
+#define PINMUX_PB04G_CATB_SENSE24  ((PIN_PB04G_CATB_SENSE24 << 16) | MUX_PB04G_CATB_SENSE24)
+#define GPIO_PB04G_CATB_SENSE24  _UL(1 <<  4)
+#define PIN_PC24G_CATB_SENSE24         _L(88) /**< \brief CATB signal: SENSE24 on PC24 mux G */
+#define MUX_PC24G_CATB_SENSE24          _L(6)
+#define PINMUX_PC24G_CATB_SENSE24  ((PIN_PC24G_CATB_SENSE24 << 16) | MUX_PC24G_CATB_SENSE24)
+#define GPIO_PC24G_CATB_SENSE24  _UL(1 << 24)
+#define PIN_PB05G_CATB_SENSE25         _L(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
+#define MUX_PB05G_CATB_SENSE25          _L(6)
+#define PINMUX_PB05G_CATB_SENSE25  ((PIN_PB05G_CATB_SENSE25 << 16) | MUX_PB05G_CATB_SENSE25)
+#define GPIO_PB05G_CATB_SENSE25  _UL(1 <<  5)
+#define PIN_PC25G_CATB_SENSE25         _L(89) /**< \brief CATB signal: SENSE25 on PC25 mux G */
+#define MUX_PC25G_CATB_SENSE25          _L(6)
+#define PINMUX_PC25G_CATB_SENSE25  ((PIN_PC25G_CATB_SENSE25 << 16) | MUX_PC25G_CATB_SENSE25)
+#define GPIO_PC25G_CATB_SENSE25  _UL(1 << 25)
+#define PIN_PB06G_CATB_SENSE26         _L(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
+#define MUX_PB06G_CATB_SENSE26          _L(6)
+#define PINMUX_PB06G_CATB_SENSE26  ((PIN_PB06G_CATB_SENSE26 << 16) | MUX_PB06G_CATB_SENSE26)
+#define GPIO_PB06G_CATB_SENSE26  _UL(1 <<  6)
+#define PIN_PC26G_CATB_SENSE26         _L(90) /**< \brief CATB signal: SENSE26 on PC26 mux G */
+#define MUX_PC26G_CATB_SENSE26          _L(6)
+#define PINMUX_PC26G_CATB_SENSE26  ((PIN_PC26G_CATB_SENSE26 << 16) | MUX_PC26G_CATB_SENSE26)
+#define GPIO_PC26G_CATB_SENSE26  _UL(1 << 26)
+#define PIN_PB07G_CATB_SENSE27         _L(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
+#define MUX_PB07G_CATB_SENSE27          _L(6)
+#define PINMUX_PB07G_CATB_SENSE27  ((PIN_PB07G_CATB_SENSE27 << 16) | MUX_PB07G_CATB_SENSE27)
+#define GPIO_PB07G_CATB_SENSE27  _UL(1 <<  7)
+#define PIN_PC27G_CATB_SENSE27         _L(91) /**< \brief CATB signal: SENSE27 on PC27 mux G */
+#define MUX_PC27G_CATB_SENSE27          _L(6)
+#define PINMUX_PC27G_CATB_SENSE27  ((PIN_PC27G_CATB_SENSE27 << 16) | MUX_PC27G_CATB_SENSE27)
+#define GPIO_PC27G_CATB_SENSE27  _UL(1 << 27)
+#define PIN_PB08G_CATB_SENSE28         _L(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
+#define MUX_PB08G_CATB_SENSE28          _L(6)
+#define PINMUX_PB08G_CATB_SENSE28  ((PIN_PB08G_CATB_SENSE28 << 16) | MUX_PB08G_CATB_SENSE28)
+#define GPIO_PB08G_CATB_SENSE28  _UL(1 <<  8)
+#define PIN_PC28G_CATB_SENSE28         _L(92) /**< \brief CATB signal: SENSE28 on PC28 mux G */
+#define MUX_PC28G_CATB_SENSE28          _L(6)
+#define PINMUX_PC28G_CATB_SENSE28  ((PIN_PC28G_CATB_SENSE28 << 16) | MUX_PC28G_CATB_SENSE28)
+#define GPIO_PC28G_CATB_SENSE28  _UL(1 << 28)
+#define PIN_PB09G_CATB_SENSE29         _L(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
+#define MUX_PB09G_CATB_SENSE29          _L(6)
+#define PINMUX_PB09G_CATB_SENSE29  ((PIN_PB09G_CATB_SENSE29 << 16) | MUX_PB09G_CATB_SENSE29)
+#define GPIO_PB09G_CATB_SENSE29  _UL(1 <<  9)
+#define PIN_PC29G_CATB_SENSE29         _L(93) /**< \brief CATB signal: SENSE29 on PC29 mux G */
+#define MUX_PC29G_CATB_SENSE29          _L(6)
+#define PINMUX_PC29G_CATB_SENSE29  ((PIN_PC29G_CATB_SENSE29 << 16) | MUX_PC29G_CATB_SENSE29)
+#define GPIO_PC29G_CATB_SENSE29  _UL(1 << 29)
+#define PIN_PB10G_CATB_SENSE30         _L(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
+#define MUX_PB10G_CATB_SENSE30          _L(6)
+#define PINMUX_PB10G_CATB_SENSE30  ((PIN_PB10G_CATB_SENSE30 << 16) | MUX_PB10G_CATB_SENSE30)
+#define GPIO_PB10G_CATB_SENSE30  _UL(1 << 10)
+#define PIN_PC30G_CATB_SENSE30         _L(94) /**< \brief CATB signal: SENSE30 on PC30 mux G */
+#define MUX_PC30G_CATB_SENSE30          _L(6)
+#define PINMUX_PC30G_CATB_SENSE30  ((PIN_PC30G_CATB_SENSE30 << 16) | MUX_PC30G_CATB_SENSE30)
+#define GPIO_PC30G_CATB_SENSE30  _UL(1 << 30)
+#define PIN_PB11G_CATB_SENSE31         _L(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
+#define MUX_PB11G_CATB_SENSE31          _L(6)
+#define PINMUX_PB11G_CATB_SENSE31  ((PIN_PB11G_CATB_SENSE31 << 16) | MUX_PB11G_CATB_SENSE31)
+#define GPIO_PB11G_CATB_SENSE31  _UL(1 << 11)
+#define PIN_PC31G_CATB_SENSE31         _L(95) /**< \brief CATB signal: SENSE31 on PC31 mux G */
+#define MUX_PC31G_CATB_SENSE31          _L(6)
+#define PINMUX_PC31G_CATB_SENSE31  ((PIN_PC31G_CATB_SENSE31 << 16) | MUX_PC31G_CATB_SENSE31)
+#define GPIO_PC31G_CATB_SENSE31  _UL(1 << 31)
+/* ========== GPIO definition for LCDCA peripheral ========== */
+#define PIN_PA12F_LCDCA_COM0           _L(12) /**< \brief LCDCA signal: COM0 on PA12 mux F */
+#define MUX_PA12F_LCDCA_COM0            _L(5)
+#define PINMUX_PA12F_LCDCA_COM0    ((PIN_PA12F_LCDCA_COM0 << 16) | MUX_PA12F_LCDCA_COM0)
+#define GPIO_PA12F_LCDCA_COM0    _UL(1 << 12)
+#define PIN_PA11F_LCDCA_COM1           _L(11) /**< \brief LCDCA signal: COM1 on PA11 mux F */
+#define MUX_PA11F_LCDCA_COM1            _L(5)
+#define PINMUX_PA11F_LCDCA_COM1    ((PIN_PA11F_LCDCA_COM1 << 16) | MUX_PA11F_LCDCA_COM1)
+#define GPIO_PA11F_LCDCA_COM1    _UL(1 << 11)
+#define PIN_PA10F_LCDCA_COM2           _L(10) /**< \brief LCDCA signal: COM2 on PA10 mux F */
+#define MUX_PA10F_LCDCA_COM2            _L(5)
+#define PINMUX_PA10F_LCDCA_COM2    ((PIN_PA10F_LCDCA_COM2 << 16) | MUX_PA10F_LCDCA_COM2)
+#define GPIO_PA10F_LCDCA_COM2    _UL(1 << 10)
+#define PIN_PA09F_LCDCA_COM3            _L(9) /**< \brief LCDCA signal: COM3 on PA09 mux F */
+#define MUX_PA09F_LCDCA_COM3            _L(5)
+#define PINMUX_PA09F_LCDCA_COM3    ((PIN_PA09F_LCDCA_COM3 << 16) | MUX_PA09F_LCDCA_COM3)
+#define GPIO_PA09F_LCDCA_COM3    _UL(1 <<  9)
+#define PIN_PC15F_LCDCA_SEG0           _L(79) /**< \brief LCDCA signal: SEG0 on PC15 mux F */
+#define MUX_PC15F_LCDCA_SEG0            _L(5)
+#define PINMUX_PC15F_LCDCA_SEG0    ((PIN_PC15F_LCDCA_SEG0 << 16) | MUX_PC15F_LCDCA_SEG0)
+#define GPIO_PC15F_LCDCA_SEG0    _UL(1 << 15)
+#define PIN_PC16F_LCDCA_SEG1           _L(80) /**< \brief LCDCA signal: SEG1 on PC16 mux F */
+#define MUX_PC16F_LCDCA_SEG1            _L(5)
+#define PINMUX_PC16F_LCDCA_SEG1    ((PIN_PC16F_LCDCA_SEG1 << 16) | MUX_PC16F_LCDCA_SEG1)
+#define GPIO_PC16F_LCDCA_SEG1    _UL(1 << 16)
+#define PIN_PC17F_LCDCA_SEG2           _L(81) /**< \brief LCDCA signal: SEG2 on PC17 mux F */
+#define MUX_PC17F_LCDCA_SEG2            _L(5)
+#define PINMUX_PC17F_LCDCA_SEG2    ((PIN_PC17F_LCDCA_SEG2 << 16) | MUX_PC17F_LCDCA_SEG2)
+#define GPIO_PC17F_LCDCA_SEG2    _UL(1 << 17)
+#define PIN_PC18F_LCDCA_SEG3           _L(82) /**< \brief LCDCA signal: SEG3 on PC18 mux F */
+#define MUX_PC18F_LCDCA_SEG3            _L(5)
+#define PINMUX_PC18F_LCDCA_SEG3    ((PIN_PC18F_LCDCA_SEG3 << 16) | MUX_PC18F_LCDCA_SEG3)
+#define GPIO_PC18F_LCDCA_SEG3    _UL(1 << 18)
+#define PIN_PC19F_LCDCA_SEG4           _L(83) /**< \brief LCDCA signal: SEG4 on PC19 mux F */
+#define MUX_PC19F_LCDCA_SEG4            _L(5)
+#define PINMUX_PC19F_LCDCA_SEG4    ((PIN_PC19F_LCDCA_SEG4 << 16) | MUX_PC19F_LCDCA_SEG4)
+#define GPIO_PC19F_LCDCA_SEG4    _UL(1 << 19)
+#define PIN_PA13F_LCDCA_SEG5           _L(13) /**< \brief LCDCA signal: SEG5 on PA13 mux F */
+#define MUX_PA13F_LCDCA_SEG5            _L(5)
+#define PINMUX_PA13F_LCDCA_SEG5    ((PIN_PA13F_LCDCA_SEG5 << 16) | MUX_PA13F_LCDCA_SEG5)
+#define GPIO_PA13F_LCDCA_SEG5    _UL(1 << 13)
+#define PIN_PA14F_LCDCA_SEG6           _L(14) /**< \brief LCDCA signal: SEG6 on PA14 mux F */
+#define MUX_PA14F_LCDCA_SEG6            _L(5)
+#define PINMUX_PA14F_LCDCA_SEG6    ((PIN_PA14F_LCDCA_SEG6 << 16) | MUX_PA14F_LCDCA_SEG6)
+#define GPIO_PA14F_LCDCA_SEG6    _UL(1 << 14)
+#define PIN_PA15F_LCDCA_SEG7           _L(15) /**< \brief LCDCA signal: SEG7 on PA15 mux F */
+#define MUX_PA15F_LCDCA_SEG7            _L(5)
+#define PINMUX_PA15F_LCDCA_SEG7    ((PIN_PA15F_LCDCA_SEG7 << 16) | MUX_PA15F_LCDCA_SEG7)
+#define GPIO_PA15F_LCDCA_SEG7    _UL(1 << 15)
+#define PIN_PA16F_LCDCA_SEG8           _L(16) /**< \brief LCDCA signal: SEG8 on PA16 mux F */
+#define MUX_PA16F_LCDCA_SEG8            _L(5)
+#define PINMUX_PA16F_LCDCA_SEG8    ((PIN_PA16F_LCDCA_SEG8 << 16) | MUX_PA16F_LCDCA_SEG8)
+#define GPIO_PA16F_LCDCA_SEG8    _UL(1 << 16)
+#define PIN_PA17F_LCDCA_SEG9           _L(17) /**< \brief LCDCA signal: SEG9 on PA17 mux F */
+#define MUX_PA17F_LCDCA_SEG9            _L(5)
+#define PINMUX_PA17F_LCDCA_SEG9    ((PIN_PA17F_LCDCA_SEG9 << 16) | MUX_PA17F_LCDCA_SEG9)
+#define GPIO_PA17F_LCDCA_SEG9    _UL(1 << 17)
+#define PIN_PC20F_LCDCA_SEG10          _L(84) /**< \brief LCDCA signal: SEG10 on PC20 mux F */
+#define MUX_PC20F_LCDCA_SEG10           _L(5)
+#define PINMUX_PC20F_LCDCA_SEG10   ((PIN_PC20F_LCDCA_SEG10 << 16) | MUX_PC20F_LCDCA_SEG10)
+#define GPIO_PC20F_LCDCA_SEG10   _UL(1 << 20)
+#define PIN_PC21F_LCDCA_SEG11          _L(85) /**< \brief LCDCA signal: SEG11 on PC21 mux F */
+#define MUX_PC21F_LCDCA_SEG11           _L(5)
+#define PINMUX_PC21F_LCDCA_SEG11   ((PIN_PC21F_LCDCA_SEG11 << 16) | MUX_PC21F_LCDCA_SEG11)
+#define GPIO_PC21F_LCDCA_SEG11   _UL(1 << 21)
+#define PIN_PC22F_LCDCA_SEG12          _L(86) /**< \brief LCDCA signal: SEG12 on PC22 mux F */
+#define MUX_PC22F_LCDCA_SEG12           _L(5)
+#define PINMUX_PC22F_LCDCA_SEG12   ((PIN_PC22F_LCDCA_SEG12 << 16) | MUX_PC22F_LCDCA_SEG12)
+#define GPIO_PC22F_LCDCA_SEG12   _UL(1 << 22)
+#define PIN_PC23F_LCDCA_SEG13          _L(87) /**< \brief LCDCA signal: SEG13 on PC23 mux F */
+#define MUX_PC23F_LCDCA_SEG13           _L(5)
+#define PINMUX_PC23F_LCDCA_SEG13   ((PIN_PC23F_LCDCA_SEG13 << 16) | MUX_PC23F_LCDCA_SEG13)
+#define GPIO_PC23F_LCDCA_SEG13   _UL(1 << 23)
+#define PIN_PB08F_LCDCA_SEG14          _L(40) /**< \brief LCDCA signal: SEG14 on PB08 mux F */
+#define MUX_PB08F_LCDCA_SEG14           _L(5)
+#define PINMUX_PB08F_LCDCA_SEG14   ((PIN_PB08F_LCDCA_SEG14 << 16) | MUX_PB08F_LCDCA_SEG14)
+#define GPIO_PB08F_LCDCA_SEG14   _UL(1 <<  8)
+#define PIN_PB09F_LCDCA_SEG15          _L(41) /**< \brief LCDCA signal: SEG15 on PB09 mux F */
+#define MUX_PB09F_LCDCA_SEG15           _L(5)
+#define PINMUX_PB09F_LCDCA_SEG15   ((PIN_PB09F_LCDCA_SEG15 << 16) | MUX_PB09F_LCDCA_SEG15)
+#define GPIO_PB09F_LCDCA_SEG15   _UL(1 <<  9)
+#define PIN_PB10F_LCDCA_SEG16          _L(42) /**< \brief LCDCA signal: SEG16 on PB10 mux F */
+#define MUX_PB10F_LCDCA_SEG16           _L(5)
+#define PINMUX_PB10F_LCDCA_SEG16   ((PIN_PB10F_LCDCA_SEG16 << 16) | MUX_PB10F_LCDCA_SEG16)
+#define GPIO_PB10F_LCDCA_SEG16   _UL(1 << 10)
+#define PIN_PB11F_LCDCA_SEG17          _L(43) /**< \brief LCDCA signal: SEG17 on PB11 mux F */
+#define MUX_PB11F_LCDCA_SEG17           _L(5)
+#define PINMUX_PB11F_LCDCA_SEG17   ((PIN_PB11F_LCDCA_SEG17 << 16) | MUX_PB11F_LCDCA_SEG17)
+#define GPIO_PB11F_LCDCA_SEG17   _UL(1 << 11)
+#define PIN_PA18F_LCDCA_SEG18          _L(18) /**< \brief LCDCA signal: SEG18 on PA18 mux F */
+#define MUX_PA18F_LCDCA_SEG18           _L(5)
+#define PINMUX_PA18F_LCDCA_SEG18   ((PIN_PA18F_LCDCA_SEG18 << 16) | MUX_PA18F_LCDCA_SEG18)
+#define GPIO_PA18F_LCDCA_SEG18   _UL(1 << 18)
+#define PIN_PA19F_LCDCA_SEG19          _L(19) /**< \brief LCDCA signal: SEG19 on PA19 mux F */
+#define MUX_PA19F_LCDCA_SEG19           _L(5)
+#define PINMUX_PA19F_LCDCA_SEG19   ((PIN_PA19F_LCDCA_SEG19 << 16) | MUX_PA19F_LCDCA_SEG19)
+#define GPIO_PA19F_LCDCA_SEG19   _UL(1 << 19)
+#define PIN_PA20F_LCDCA_SEG20          _L(20) /**< \brief LCDCA signal: SEG20 on PA20 mux F */
+#define MUX_PA20F_LCDCA_SEG20           _L(5)
+#define PINMUX_PA20F_LCDCA_SEG20   ((PIN_PA20F_LCDCA_SEG20 << 16) | MUX_PA20F_LCDCA_SEG20)
+#define GPIO_PA20F_LCDCA_SEG20   _UL(1 << 20)
+#define PIN_PB07F_LCDCA_SEG21          _L(39) /**< \brief LCDCA signal: SEG21 on PB07 mux F */
+#define MUX_PB07F_LCDCA_SEG21           _L(5)
+#define PINMUX_PB07F_LCDCA_SEG21   ((PIN_PB07F_LCDCA_SEG21 << 16) | MUX_PB07F_LCDCA_SEG21)
+#define GPIO_PB07F_LCDCA_SEG21   _UL(1 <<  7)
+#define PIN_PB06F_LCDCA_SEG22          _L(38) /**< \brief LCDCA signal: SEG22 on PB06 mux F */
+#define MUX_PB06F_LCDCA_SEG22           _L(5)
+#define PINMUX_PB06F_LCDCA_SEG22   ((PIN_PB06F_LCDCA_SEG22 << 16) | MUX_PB06F_LCDCA_SEG22)
+#define GPIO_PB06F_LCDCA_SEG22   _UL(1 <<  6)
+#define PIN_PA08F_LCDCA_SEG23           _L(8) /**< \brief LCDCA signal: SEG23 on PA08 mux F */
+#define MUX_PA08F_LCDCA_SEG23           _L(5)
+#define PINMUX_PA08F_LCDCA_SEG23   ((PIN_PA08F_LCDCA_SEG23 << 16) | MUX_PA08F_LCDCA_SEG23)
+#define GPIO_PA08F_LCDCA_SEG23   _UL(1 <<  8)
+#define PIN_PC24F_LCDCA_SEG24          _L(88) /**< \brief LCDCA signal: SEG24 on PC24 mux F */
+#define MUX_PC24F_LCDCA_SEG24           _L(5)
+#define PINMUX_PC24F_LCDCA_SEG24   ((PIN_PC24F_LCDCA_SEG24 << 16) | MUX_PC24F_LCDCA_SEG24)
+#define GPIO_PC24F_LCDCA_SEG24   _UL(1 << 24)
+#define PIN_PC25F_LCDCA_SEG25          _L(89) /**< \brief LCDCA signal: SEG25 on PC25 mux F */
+#define MUX_PC25F_LCDCA_SEG25           _L(5)
+#define PINMUX_PC25F_LCDCA_SEG25   ((PIN_PC25F_LCDCA_SEG25 << 16) | MUX_PC25F_LCDCA_SEG25)
+#define GPIO_PC25F_LCDCA_SEG25   _UL(1 << 25)
+#define PIN_PC26F_LCDCA_SEG26          _L(90) /**< \brief LCDCA signal: SEG26 on PC26 mux F */
+#define MUX_PC26F_LCDCA_SEG26           _L(5)
+#define PINMUX_PC26F_LCDCA_SEG26   ((PIN_PC26F_LCDCA_SEG26 << 16) | MUX_PC26F_LCDCA_SEG26)
+#define GPIO_PC26F_LCDCA_SEG26   _UL(1 << 26)
+#define PIN_PC27F_LCDCA_SEG27          _L(91) /**< \brief LCDCA signal: SEG27 on PC27 mux F */
+#define MUX_PC27F_LCDCA_SEG27           _L(5)
+#define PINMUX_PC27F_LCDCA_SEG27   ((PIN_PC27F_LCDCA_SEG27 << 16) | MUX_PC27F_LCDCA_SEG27)
+#define GPIO_PC27F_LCDCA_SEG27   _UL(1 << 27)
+#define PIN_PC28F_LCDCA_SEG28          _L(92) /**< \brief LCDCA signal: SEG28 on PC28 mux F */
+#define MUX_PC28F_LCDCA_SEG28           _L(5)
+#define PINMUX_PC28F_LCDCA_SEG28   ((PIN_PC28F_LCDCA_SEG28 << 16) | MUX_PC28F_LCDCA_SEG28)
+#define GPIO_PC28F_LCDCA_SEG28   _UL(1 << 28)
+#define PIN_PC29F_LCDCA_SEG29          _L(93) /**< \brief LCDCA signal: SEG29 on PC29 mux F */
+#define MUX_PC29F_LCDCA_SEG29           _L(5)
+#define PINMUX_PC29F_LCDCA_SEG29   ((PIN_PC29F_LCDCA_SEG29 << 16) | MUX_PC29F_LCDCA_SEG29)
+#define GPIO_PC29F_LCDCA_SEG29   _UL(1 << 29)
+#define PIN_PC30F_LCDCA_SEG30          _L(94) /**< \brief LCDCA signal: SEG30 on PC30 mux F */
+#define MUX_PC30F_LCDCA_SEG30           _L(5)
+#define PINMUX_PC30F_LCDCA_SEG30   ((PIN_PC30F_LCDCA_SEG30 << 16) | MUX_PC30F_LCDCA_SEG30)
+#define GPIO_PC30F_LCDCA_SEG30   _UL(1 << 30)
+#define PIN_PC31F_LCDCA_SEG31          _L(95) /**< \brief LCDCA signal: SEG31 on PC31 mux F */
+#define MUX_PC31F_LCDCA_SEG31           _L(5)
+#define PINMUX_PC31F_LCDCA_SEG31   ((PIN_PC31F_LCDCA_SEG31 << 16) | MUX_PC31F_LCDCA_SEG31)
+#define GPIO_PC31F_LCDCA_SEG31   _UL(1 << 31)
+#define PIN_PB12F_LCDCA_SEG32          _L(44) /**< \brief LCDCA signal: SEG32 on PB12 mux F */
+#define MUX_PB12F_LCDCA_SEG32           _L(5)
+#define PINMUX_PB12F_LCDCA_SEG32   ((PIN_PB12F_LCDCA_SEG32 << 16) | MUX_PB12F_LCDCA_SEG32)
+#define GPIO_PB12F_LCDCA_SEG32   _UL(1 << 12)
+#define PIN_PB13F_LCDCA_SEG33          _L(45) /**< \brief LCDCA signal: SEG33 on PB13 mux F */
+#define MUX_PB13F_LCDCA_SEG33           _L(5)
+#define PINMUX_PB13F_LCDCA_SEG33   ((PIN_PB13F_LCDCA_SEG33 << 16) | MUX_PB13F_LCDCA_SEG33)
+#define GPIO_PB13F_LCDCA_SEG33   _UL(1 << 13)
+#define PIN_PA21F_LCDCA_SEG34          _L(21) /**< \brief LCDCA signal: SEG34 on PA21 mux F */
+#define MUX_PA21F_LCDCA_SEG34           _L(5)
+#define PINMUX_PA21F_LCDCA_SEG34   ((PIN_PA21F_LCDCA_SEG34 << 16) | MUX_PA21F_LCDCA_SEG34)
+#define GPIO_PA21F_LCDCA_SEG34   _UL(1 << 21)
+#define PIN_PA22F_LCDCA_SEG35          _L(22) /**< \brief LCDCA signal: SEG35 on PA22 mux F */
+#define MUX_PA22F_LCDCA_SEG35           _L(5)
+#define PINMUX_PA22F_LCDCA_SEG35   ((PIN_PA22F_LCDCA_SEG35 << 16) | MUX_PA22F_LCDCA_SEG35)
+#define GPIO_PA22F_LCDCA_SEG35   _UL(1 << 22)
+#define PIN_PB14F_LCDCA_SEG36          _L(46) /**< \brief LCDCA signal: SEG36 on PB14 mux F */
+#define MUX_PB14F_LCDCA_SEG36           _L(5)
+#define PINMUX_PB14F_LCDCA_SEG36   ((PIN_PB14F_LCDCA_SEG36 << 16) | MUX_PB14F_LCDCA_SEG36)
+#define GPIO_PB14F_LCDCA_SEG36   _UL(1 << 14)
+#define PIN_PB15F_LCDCA_SEG37          _L(47) /**< \brief LCDCA signal: SEG37 on PB15 mux F */
+#define MUX_PB15F_LCDCA_SEG37           _L(5)
+#define PINMUX_PB15F_LCDCA_SEG37   ((PIN_PB15F_LCDCA_SEG37 << 16) | MUX_PB15F_LCDCA_SEG37)
+#define GPIO_PB15F_LCDCA_SEG37   _UL(1 << 15)
+#define PIN_PA23F_LCDCA_SEG38          _L(23) /**< \brief LCDCA signal: SEG38 on PA23 mux F */
+#define MUX_PA23F_LCDCA_SEG38           _L(5)
+#define PINMUX_PA23F_LCDCA_SEG38   ((PIN_PA23F_LCDCA_SEG38 << 16) | MUX_PA23F_LCDCA_SEG38)
+#define GPIO_PA23F_LCDCA_SEG38   _UL(1 << 23)
+#define PIN_PA24F_LCDCA_SEG39          _L(24) /**< \brief LCDCA signal: SEG39 on PA24 mux F */
+#define MUX_PA24F_LCDCA_SEG39           _L(5)
+#define PINMUX_PA24F_LCDCA_SEG39   ((PIN_PA24F_LCDCA_SEG39 << 16) | MUX_PA24F_LCDCA_SEG39)
+#define GPIO_PA24F_LCDCA_SEG39   _UL(1 << 24)
+/* ========== GPIO definition for USBC peripheral ========== */
+#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L(0)
+#define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
+#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
+#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L(0)
+#define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
+#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+/* ========== GPIO definition for PEVC peripheral ========== */
+#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
+#define PIN_PB12C_PEVC_PAD_EVT0        _L(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
+#define MUX_PB12C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PB12C_PEVC_PAD_EVT0  ((PIN_PB12C_PEVC_PAD_EVT0 << 16) | MUX_PB12C_PEVC_PAD_EVT0)
+#define GPIO_PB12C_PEVC_PAD_EVT0  _UL(1 << 12)
+#define PIN_PC07C_PEVC_PAD_EVT0        _L(71) /**< \brief PEVC signal: PAD_EVT0 on PC07 mux C */
+#define MUX_PC07C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PC07C_PEVC_PAD_EVT0  ((PIN_PC07C_PEVC_PAD_EVT0 << 16) | MUX_PC07C_PEVC_PAD_EVT0)
+#define GPIO_PC07C_PEVC_PAD_EVT0  _UL(1 <<  7)
+#define PIN_PC24C_PEVC_PAD_EVT0        _L(88) /**< \brief PEVC signal: PAD_EVT0 on PC24 mux C */
+#define MUX_PC24C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PC24C_PEVC_PAD_EVT0  ((PIN_PC24C_PEVC_PAD_EVT0 << 16) | MUX_PC24C_PEVC_PAD_EVT0)
+#define GPIO_PC24C_PEVC_PAD_EVT0  _UL(1 << 24)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
+#define PIN_PB13C_PEVC_PAD_EVT1        _L(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
+#define MUX_PB13C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PB13C_PEVC_PAD_EVT1  ((PIN_PB13C_PEVC_PAD_EVT1 << 16) | MUX_PB13C_PEVC_PAD_EVT1)
+#define GPIO_PB13C_PEVC_PAD_EVT1  _UL(1 << 13)
+#define PIN_PC08C_PEVC_PAD_EVT1        _L(72) /**< \brief PEVC signal: PAD_EVT1 on PC08 mux C */
+#define MUX_PC08C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PC08C_PEVC_PAD_EVT1  ((PIN_PC08C_PEVC_PAD_EVT1 << 16) | MUX_PC08C_PEVC_PAD_EVT1)
+#define GPIO_PC08C_PEVC_PAD_EVT1  _UL(1 <<  8)
+#define PIN_PC25C_PEVC_PAD_EVT1        _L(89) /**< \brief PEVC signal: PAD_EVT1 on PC25 mux C */
+#define MUX_PC25C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PC25C_PEVC_PAD_EVT1  ((PIN_PC25C_PEVC_PAD_EVT1 << 16) | MUX_PC25C_PEVC_PAD_EVT1)
+#define GPIO_PC25C_PEVC_PAD_EVT1  _UL(1 << 25)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
+#define PIN_PC11C_PEVC_PAD_EVT2        _L(75) /**< \brief PEVC signal: PAD_EVT2 on PC11 mux C */
+#define MUX_PC11C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PC11C_PEVC_PAD_EVT2  ((PIN_PC11C_PEVC_PAD_EVT2 << 16) | MUX_PC11C_PEVC_PAD_EVT2)
+#define GPIO_PC11C_PEVC_PAD_EVT2  _UL(1 << 11)
+#define PIN_PC26C_PEVC_PAD_EVT2        _L(90) /**< \brief PEVC signal: PAD_EVT2 on PC26 mux C */
+#define MUX_PC26C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PC26C_PEVC_PAD_EVT2  ((PIN_PC26C_PEVC_PAD_EVT2 << 16) | MUX_PC26C_PEVC_PAD_EVT2)
+#define GPIO_PC26C_PEVC_PAD_EVT2  _UL(1 << 26)
+#define PIN_PB09B_PEVC_PAD_EVT2        _L(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
+#define MUX_PB09B_PEVC_PAD_EVT2         _L(1)
+#define PINMUX_PB09B_PEVC_PAD_EVT2  ((PIN_PB09B_PEVC_PAD_EVT2 << 16) | MUX_PB09B_PEVC_PAD_EVT2)
+#define GPIO_PB09B_PEVC_PAD_EVT2  _UL(1 <<  9)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
+#define PIN_PC27C_PEVC_PAD_EVT3        _L(91) /**< \brief PEVC signal: PAD_EVT3 on PC27 mux C */
+#define MUX_PC27C_PEVC_PAD_EVT3         _L(2)
+#define PINMUX_PC27C_PEVC_PAD_EVT3  ((PIN_PC27C_PEVC_PAD_EVT3 << 16) | MUX_PC27C_PEVC_PAD_EVT3)
+#define GPIO_PC27C_PEVC_PAD_EVT3  _UL(1 << 27)
+#define PIN_PB10B_PEVC_PAD_EVT3        _L(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
+#define MUX_PB10B_PEVC_PAD_EVT3         _L(1)
+#define PINMUX_PB10B_PEVC_PAD_EVT3  ((PIN_PB10B_PEVC_PAD_EVT3 << 16) | MUX_PB10B_PEVC_PAD_EVT3)
+#define GPIO_PB10B_PEVC_PAD_EVT3  _UL(1 << 10)
+/* ========== GPIO definition for SCIF peripheral ========== */
+#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
+#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
+#define PIN_PB10E_SCIF_GCLK0           _L(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
+#define MUX_PB10E_SCIF_GCLK0            _L(4)
+#define PINMUX_PB10E_SCIF_GCLK0    ((PIN_PB10E_SCIF_GCLK0 << 16) | MUX_PB10E_SCIF_GCLK0)
+#define GPIO_PB10E_SCIF_GCLK0    _UL(1 << 10)
+#define PIN_PC26E_SCIF_GCLK0           _L(90) /**< \brief SCIF signal: GCLK0 on PC26 mux E */
+#define MUX_PC26E_SCIF_GCLK0            _L(4)
+#define PINMUX_PC26E_SCIF_GCLK0    ((PIN_PC26E_SCIF_GCLK0 << 16) | MUX_PC26E_SCIF_GCLK0)
+#define GPIO_PC26E_SCIF_GCLK0    _UL(1 << 26)
+#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
+#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
+#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
+#define PIN_PB11E_SCIF_GCLK1           _L(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
+#define MUX_PB11E_SCIF_GCLK1            _L(4)
+#define PINMUX_PB11E_SCIF_GCLK1    ((PIN_PB11E_SCIF_GCLK1 << 16) | MUX_PB11E_SCIF_GCLK1)
+#define GPIO_PB11E_SCIF_GCLK1    _UL(1 << 11)
+#define PIN_PC27E_SCIF_GCLK1           _L(91) /**< \brief SCIF signal: GCLK1 on PC27 mux E */
+#define MUX_PC27E_SCIF_GCLK1            _L(4)
+#define PINMUX_PC27E_SCIF_GCLK1    ((PIN_PC27E_SCIF_GCLK1 << 16) | MUX_PC27E_SCIF_GCLK1)
+#define GPIO_PC27E_SCIF_GCLK1    _UL(1 << 27)
+#define PIN_PB12E_SCIF_GCLK2           _L(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
+#define MUX_PB12E_SCIF_GCLK2            _L(4)
+#define PINMUX_PB12E_SCIF_GCLK2    ((PIN_PB12E_SCIF_GCLK2 << 16) | MUX_PB12E_SCIF_GCLK2)
+#define GPIO_PB12E_SCIF_GCLK2    _UL(1 << 12)
+#define PIN_PC28E_SCIF_GCLK2           _L(92) /**< \brief SCIF signal: GCLK2 on PC28 mux E */
+#define MUX_PC28E_SCIF_GCLK2            _L(4)
+#define PINMUX_PC28E_SCIF_GCLK2    ((PIN_PC28E_SCIF_GCLK2 << 16) | MUX_PC28E_SCIF_GCLK2)
+#define GPIO_PC28E_SCIF_GCLK2    _UL(1 << 28)
+#define PIN_PB13E_SCIF_GCLK3           _L(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
+#define MUX_PB13E_SCIF_GCLK3            _L(4)
+#define PINMUX_PB13E_SCIF_GCLK3    ((PIN_PB13E_SCIF_GCLK3 << 16) | MUX_PB13E_SCIF_GCLK3)
+#define GPIO_PB13E_SCIF_GCLK3    _UL(1 << 13)
+#define PIN_PC29E_SCIF_GCLK3           _L(93) /**< \brief SCIF signal: GCLK3 on PC29 mux E */
+#define MUX_PC29E_SCIF_GCLK3            _L(4)
+#define PINMUX_PC29E_SCIF_GCLK3    ((PIN_PC29E_SCIF_GCLK3 << 16) | MUX_PC29E_SCIF_GCLK3)
+#define GPIO_PC29E_SCIF_GCLK3    _UL(1 << 29)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
+#define PIN_PB14E_SCIF_GCLK_IN0        _L(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
+#define MUX_PB14E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PB14E_SCIF_GCLK_IN0  ((PIN_PB14E_SCIF_GCLK_IN0 << 16) | MUX_PB14E_SCIF_GCLK_IN0)
+#define GPIO_PB14E_SCIF_GCLK_IN0  _UL(1 << 14)
+#define PIN_PC30E_SCIF_GCLK_IN0        _L(94) /**< \brief SCIF signal: GCLK_IN0 on PC30 mux E */
+#define MUX_PC30E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PC30E_SCIF_GCLK_IN0  ((PIN_PC30E_SCIF_GCLK_IN0 << 16) | MUX_PC30E_SCIF_GCLK_IN0)
+#define GPIO_PC30E_SCIF_GCLK_IN0  _UL(1 << 30)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
+#define PIN_PB15E_SCIF_GCLK_IN1        _L(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
+#define MUX_PB15E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PB15E_SCIF_GCLK_IN1  ((PIN_PB15E_SCIF_GCLK_IN1 << 16) | MUX_PB15E_SCIF_GCLK_IN1)
+#define GPIO_PB15E_SCIF_GCLK_IN1  _UL(1 << 15)
+#define PIN_PC31E_SCIF_GCLK_IN1        _L(95) /**< \brief SCIF signal: GCLK_IN1 on PC31 mux E */
+#define MUX_PC31E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PC31E_SCIF_GCLK_IN1  ((PIN_PC31E_SCIF_GCLK_IN1 << 16) | MUX_PC31E_SCIF_GCLK_IN1)
+#define GPIO_PC31E_SCIF_GCLK_IN1  _UL(1 << 31)
+/* ========== GPIO definition for EIC peripheral ========== */
+#define PIN_PB01C_EIC_EXTINT0          _L(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
+#define MUX_PB01C_EIC_EXTINT0           _L(2)
+#define PINMUX_PB01C_EIC_EXTINT0   ((PIN_PB01C_EIC_EXTINT0 << 16) | MUX_PB01C_EIC_EXTINT0)
+#define GPIO_PB01C_EIC_EXTINT0   _UL(1 <<  1)
+#define PIN_PB01C_EIC_EXTINT_NUM        _L(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
+#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
+#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PC24B_EIC_EXTINT1          _L(88) /**< \brief EIC signal: EXTINT1 on PC24 mux B */
+#define MUX_PC24B_EIC_EXTINT1           _L(1)
+#define PINMUX_PC24B_EIC_EXTINT1   ((PIN_PC24B_EIC_EXTINT1 << 16) | MUX_PC24B_EIC_EXTINT1)
+#define GPIO_PC24B_EIC_EXTINT1   _UL(1 << 24)
+#define PIN_PC24B_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PC24 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PC25B_EIC_EXTINT2          _L(89) /**< \brief EIC signal: EXTINT2 on PC25 mux B */
+#define MUX_PC25B_EIC_EXTINT2           _L(1)
+#define PINMUX_PC25B_EIC_EXTINT2   ((PIN_PC25B_EIC_EXTINT2 << 16) | MUX_PC25B_EIC_EXTINT2)
+#define GPIO_PC25B_EIC_EXTINT2   _UL(1 << 25)
+#define PIN_PC25B_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PC25 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
+#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
+#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PC26B_EIC_EXTINT3          _L(90) /**< \brief EIC signal: EXTINT3 on PC26 mux B */
+#define MUX_PC26B_EIC_EXTINT3           _L(1)
+#define PINMUX_PC26B_EIC_EXTINT3   ((PIN_PC26B_EIC_EXTINT3 << 16) | MUX_PC26B_EIC_EXTINT3)
+#define GPIO_PC26B_EIC_EXTINT3   _UL(1 << 26)
+#define PIN_PC26B_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PC26 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
+#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
+#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PC27B_EIC_EXTINT4          _L(91) /**< \brief EIC signal: EXTINT4 on PC27 mux B */
+#define MUX_PC27B_EIC_EXTINT4           _L(1)
+#define PINMUX_PC27B_EIC_EXTINT4   ((PIN_PC27B_EIC_EXTINT4 << 16) | MUX_PC27B_EIC_EXTINT4)
+#define GPIO_PC27B_EIC_EXTINT4   _UL(1 << 27)
+#define PIN_PC27B_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PC27 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
+#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PC03B_EIC_EXTINT5          _L(67) /**< \brief EIC signal: EXTINT5 on PC03 mux B */
+#define MUX_PC03B_EIC_EXTINT5           _L(1)
+#define PINMUX_PC03B_EIC_EXTINT5   ((PIN_PC03B_EIC_EXTINT5 << 16) | MUX_PC03B_EIC_EXTINT5)
+#define GPIO_PC03B_EIC_EXTINT5   _UL(1 <<  3)
+#define PIN_PC03B_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PC03 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
+#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PC04B_EIC_EXTINT6          _L(68) /**< \brief EIC signal: EXTINT6 on PC04 mux B */
+#define MUX_PC04B_EIC_EXTINT6           _L(1)
+#define PINMUX_PC04B_EIC_EXTINT6   ((PIN_PC04B_EIC_EXTINT6 << 16) | MUX_PC04B_EIC_EXTINT6)
+#define GPIO_PC04B_EIC_EXTINT6   _UL(1 <<  4)
+#define PIN_PC04B_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PC04 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
+#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PC05B_EIC_EXTINT7          _L(69) /**< \brief EIC signal: EXTINT7 on PC05 mux B */
+#define MUX_PC05B_EIC_EXTINT7           _L(1)
+#define PINMUX_PC05B_EIC_EXTINT7   ((PIN_PC05B_EIC_EXTINT7 << 16) | MUX_PC05B_EIC_EXTINT7)
+#define GPIO_PC05B_EIC_EXTINT7   _UL(1 <<  5)
+#define PIN_PC05B_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PC05 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
+#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PC06B_EIC_EXTINT8          _L(70) /**< \brief EIC signal: EXTINT8 on PC06 mux B */
+#define MUX_PC06B_EIC_EXTINT8           _L(1)
+#define PINMUX_PC06B_EIC_EXTINT8   ((PIN_PC06B_EIC_EXTINT8 << 16) | MUX_PC06B_EIC_EXTINT8)
+#define GPIO_PC06B_EIC_EXTINT8   _UL(1 <<  6)
+#define PIN_PC06B_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PC06 External Interrupt Line */
+
+#endif /* _SAM4LC4C_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4lc4c.h
+++ b/asf/sam/include/sam4l/pio/sam4lc4c.h
@@ -30,1775 +30,1775 @@
 #define _SAM4LC4C_PIO_
 
 #define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
-#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define GPIO_PA00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PA00 */
 #define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
-#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define GPIO_PA01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PA01 */
 #define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
-#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define GPIO_PA02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PA02 */
 #define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
-#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define GPIO_PA03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PA03 */
 #define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
-#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define GPIO_PA04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PA04 */
 #define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
-#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define GPIO_PA05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PA05 */
 #define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
-#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define GPIO_PA06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PA06 */
 #define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
-#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define GPIO_PA07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PA07 */
 #define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
-#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define GPIO_PA08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PA08 */
 #define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
-#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define GPIO_PA09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PA09 */
 #define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
-#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define GPIO_PA10                _UL_(1 << 10) /**< \brief GPIO Mask  for PA10 */
 #define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
-#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define GPIO_PA11                _UL_(1 << 11) /**< \brief GPIO Mask  for PA11 */
 #define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
-#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define GPIO_PA12                _UL_(1 << 12) /**< \brief GPIO Mask  for PA12 */
 #define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
-#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define GPIO_PA13                _UL_(1 << 13) /**< \brief GPIO Mask  for PA13 */
 #define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
-#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define GPIO_PA14                _UL_(1 << 14) /**< \brief GPIO Mask  for PA14 */
 #define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
-#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define GPIO_PA15                _UL_(1 << 15) /**< \brief GPIO Mask  for PA15 */
 #define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
-#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define GPIO_PA16                _UL_(1 << 16) /**< \brief GPIO Mask  for PA16 */
 #define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
-#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define GPIO_PA17                _UL_(1 << 17) /**< \brief GPIO Mask  for PA17 */
 #define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
-#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define GPIO_PA18                _UL_(1 << 18) /**< \brief GPIO Mask  for PA18 */
 #define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
-#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define GPIO_PA19                _UL_(1 << 19) /**< \brief GPIO Mask  for PA19 */
 #define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
-#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define GPIO_PA20                _UL_(1 << 20) /**< \brief GPIO Mask  for PA20 */
 #define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
-#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define GPIO_PA21                _UL_(1 << 21) /**< \brief GPIO Mask  for PA21 */
 #define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
-#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define GPIO_PA22                _UL_(1 << 22) /**< \brief GPIO Mask  for PA22 */
 #define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
-#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define GPIO_PA23                _UL_(1 << 23) /**< \brief GPIO Mask  for PA23 */
 #define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
-#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define GPIO_PA24                _UL_(1 << 24) /**< \brief GPIO Mask  for PA24 */
 #define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
-#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define GPIO_PA25                _UL_(1 << 25) /**< \brief GPIO Mask  for PA25 */
 #define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
-#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define GPIO_PA26                _UL_(1 << 26) /**< \brief GPIO Mask  for PA26 */
 #define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
-#define GPIO_PB00                _UL(1 <<  0) /**< \brief GPIO Mask  for PB00 */
+#define GPIO_PB00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PB00 */
 #define PIN_PB01                          33  /**< \brief Pin Number for PB01 */
-#define GPIO_PB01                _UL(1 <<  1) /**< \brief GPIO Mask  for PB01 */
+#define GPIO_PB01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PB01 */
 #define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
-#define GPIO_PB02                _UL(1 <<  2) /**< \brief GPIO Mask  for PB02 */
+#define GPIO_PB02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PB02 */
 #define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
-#define GPIO_PB03                _UL(1 <<  3) /**< \brief GPIO Mask  for PB03 */
+#define GPIO_PB03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PB03 */
 #define PIN_PB04                          36  /**< \brief Pin Number for PB04 */
-#define GPIO_PB04                _UL(1 <<  4) /**< \brief GPIO Mask  for PB04 */
+#define GPIO_PB04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PB04 */
 #define PIN_PB05                          37  /**< \brief Pin Number for PB05 */
-#define GPIO_PB05                _UL(1 <<  5) /**< \brief GPIO Mask  for PB05 */
+#define GPIO_PB05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PB05 */
 #define PIN_PB06                          38  /**< \brief Pin Number for PB06 */
-#define GPIO_PB06                _UL(1 <<  6) /**< \brief GPIO Mask  for PB06 */
+#define GPIO_PB06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PB06 */
 #define PIN_PB07                          39  /**< \brief Pin Number for PB07 */
-#define GPIO_PB07                _UL(1 <<  7) /**< \brief GPIO Mask  for PB07 */
+#define GPIO_PB07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PB07 */
 #define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
-#define GPIO_PB08                _UL(1 <<  8) /**< \brief GPIO Mask  for PB08 */
+#define GPIO_PB08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PB08 */
 #define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
-#define GPIO_PB09                _UL(1 <<  9) /**< \brief GPIO Mask  for PB09 */
+#define GPIO_PB09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PB09 */
 #define PIN_PB10                          42  /**< \brief Pin Number for PB10 */
-#define GPIO_PB10                _UL(1 << 10) /**< \brief GPIO Mask  for PB10 */
+#define GPIO_PB10                _UL_(1 << 10) /**< \brief GPIO Mask  for PB10 */
 #define PIN_PB11                          43  /**< \brief Pin Number for PB11 */
-#define GPIO_PB11                _UL(1 << 11) /**< \brief GPIO Mask  for PB11 */
+#define GPIO_PB11                _UL_(1 << 11) /**< \brief GPIO Mask  for PB11 */
 #define PIN_PB12                          44  /**< \brief Pin Number for PB12 */
-#define GPIO_PB12                _UL(1 << 12) /**< \brief GPIO Mask  for PB12 */
+#define GPIO_PB12                _UL_(1 << 12) /**< \brief GPIO Mask  for PB12 */
 #define PIN_PB13                          45  /**< \brief Pin Number for PB13 */
-#define GPIO_PB13                _UL(1 << 13) /**< \brief GPIO Mask  for PB13 */
+#define GPIO_PB13                _UL_(1 << 13) /**< \brief GPIO Mask  for PB13 */
 #define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
-#define GPIO_PB14                _UL(1 << 14) /**< \brief GPIO Mask  for PB14 */
+#define GPIO_PB14                _UL_(1 << 14) /**< \brief GPIO Mask  for PB14 */
 #define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
-#define GPIO_PB15                _UL(1 << 15) /**< \brief GPIO Mask  for PB15 */
+#define GPIO_PB15                _UL_(1 << 15) /**< \brief GPIO Mask  for PB15 */
 #define PIN_PC00                          64  /**< \brief Pin Number for PC00 */
-#define GPIO_PC00                _UL(1 <<  0) /**< \brief GPIO Mask  for PC00 */
+#define GPIO_PC00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PC00 */
 #define PIN_PC01                          65  /**< \brief Pin Number for PC01 */
-#define GPIO_PC01                _UL(1 <<  1) /**< \brief GPIO Mask  for PC01 */
+#define GPIO_PC01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PC01 */
 #define PIN_PC02                          66  /**< \brief Pin Number for PC02 */
-#define GPIO_PC02                _UL(1 <<  2) /**< \brief GPIO Mask  for PC02 */
+#define GPIO_PC02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PC02 */
 #define PIN_PC03                          67  /**< \brief Pin Number for PC03 */
-#define GPIO_PC03                _UL(1 <<  3) /**< \brief GPIO Mask  for PC03 */
+#define GPIO_PC03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PC03 */
 #define PIN_PC04                          68  /**< \brief Pin Number for PC04 */
-#define GPIO_PC04                _UL(1 <<  4) /**< \brief GPIO Mask  for PC04 */
+#define GPIO_PC04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PC04 */
 #define PIN_PC05                          69  /**< \brief Pin Number for PC05 */
-#define GPIO_PC05                _UL(1 <<  5) /**< \brief GPIO Mask  for PC05 */
+#define GPIO_PC05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PC05 */
 #define PIN_PC06                          70  /**< \brief Pin Number for PC06 */
-#define GPIO_PC06                _UL(1 <<  6) /**< \brief GPIO Mask  for PC06 */
+#define GPIO_PC06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PC06 */
 #define PIN_PC07                          71  /**< \brief Pin Number for PC07 */
-#define GPIO_PC07                _UL(1 <<  7) /**< \brief GPIO Mask  for PC07 */
+#define GPIO_PC07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PC07 */
 #define PIN_PC08                          72  /**< \brief Pin Number for PC08 */
-#define GPIO_PC08                _UL(1 <<  8) /**< \brief GPIO Mask  for PC08 */
+#define GPIO_PC08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PC08 */
 #define PIN_PC09                          73  /**< \brief Pin Number for PC09 */
-#define GPIO_PC09                _UL(1 <<  9) /**< \brief GPIO Mask  for PC09 */
+#define GPIO_PC09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PC09 */
 #define PIN_PC10                          74  /**< \brief Pin Number for PC10 */
-#define GPIO_PC10                _UL(1 << 10) /**< \brief GPIO Mask  for PC10 */
+#define GPIO_PC10                _UL_(1 << 10) /**< \brief GPIO Mask  for PC10 */
 #define PIN_PC11                          75  /**< \brief Pin Number for PC11 */
-#define GPIO_PC11                _UL(1 << 11) /**< \brief GPIO Mask  for PC11 */
+#define GPIO_PC11                _UL_(1 << 11) /**< \brief GPIO Mask  for PC11 */
 #define PIN_PC12                          76  /**< \brief Pin Number for PC12 */
-#define GPIO_PC12                _UL(1 << 12) /**< \brief GPIO Mask  for PC12 */
+#define GPIO_PC12                _UL_(1 << 12) /**< \brief GPIO Mask  for PC12 */
 #define PIN_PC13                          77  /**< \brief Pin Number for PC13 */
-#define GPIO_PC13                _UL(1 << 13) /**< \brief GPIO Mask  for PC13 */
+#define GPIO_PC13                _UL_(1 << 13) /**< \brief GPIO Mask  for PC13 */
 #define PIN_PC14                          78  /**< \brief Pin Number for PC14 */
-#define GPIO_PC14                _UL(1 << 14) /**< \brief GPIO Mask  for PC14 */
+#define GPIO_PC14                _UL_(1 << 14) /**< \brief GPIO Mask  for PC14 */
 #define PIN_PC15                          79  /**< \brief Pin Number for PC15 */
-#define GPIO_PC15                _UL(1 << 15) /**< \brief GPIO Mask  for PC15 */
+#define GPIO_PC15                _UL_(1 << 15) /**< \brief GPIO Mask  for PC15 */
 #define PIN_PC16                          80  /**< \brief Pin Number for PC16 */
-#define GPIO_PC16                _UL(1 << 16) /**< \brief GPIO Mask  for PC16 */
+#define GPIO_PC16                _UL_(1 << 16) /**< \brief GPIO Mask  for PC16 */
 #define PIN_PC17                          81  /**< \brief Pin Number for PC17 */
-#define GPIO_PC17                _UL(1 << 17) /**< \brief GPIO Mask  for PC17 */
+#define GPIO_PC17                _UL_(1 << 17) /**< \brief GPIO Mask  for PC17 */
 #define PIN_PC18                          82  /**< \brief Pin Number for PC18 */
-#define GPIO_PC18                _UL(1 << 18) /**< \brief GPIO Mask  for PC18 */
+#define GPIO_PC18                _UL_(1 << 18) /**< \brief GPIO Mask  for PC18 */
 #define PIN_PC19                          83  /**< \brief Pin Number for PC19 */
-#define GPIO_PC19                _UL(1 << 19) /**< \brief GPIO Mask  for PC19 */
+#define GPIO_PC19                _UL_(1 << 19) /**< \brief GPIO Mask  for PC19 */
 #define PIN_PC20                          84  /**< \brief Pin Number for PC20 */
-#define GPIO_PC20                _UL(1 << 20) /**< \brief GPIO Mask  for PC20 */
+#define GPIO_PC20                _UL_(1 << 20) /**< \brief GPIO Mask  for PC20 */
 #define PIN_PC21                          85  /**< \brief Pin Number for PC21 */
-#define GPIO_PC21                _UL(1 << 21) /**< \brief GPIO Mask  for PC21 */
+#define GPIO_PC21                _UL_(1 << 21) /**< \brief GPIO Mask  for PC21 */
 #define PIN_PC22                          86  /**< \brief Pin Number for PC22 */
-#define GPIO_PC22                _UL(1 << 22) /**< \brief GPIO Mask  for PC22 */
+#define GPIO_PC22                _UL_(1 << 22) /**< \brief GPIO Mask  for PC22 */
 #define PIN_PC23                          87  /**< \brief Pin Number for PC23 */
-#define GPIO_PC23                _UL(1 << 23) /**< \brief GPIO Mask  for PC23 */
+#define GPIO_PC23                _UL_(1 << 23) /**< \brief GPIO Mask  for PC23 */
 #define PIN_PC24                          88  /**< \brief Pin Number for PC24 */
-#define GPIO_PC24                _UL(1 << 24) /**< \brief GPIO Mask  for PC24 */
+#define GPIO_PC24                _UL_(1 << 24) /**< \brief GPIO Mask  for PC24 */
 #define PIN_PC25                          89  /**< \brief Pin Number for PC25 */
-#define GPIO_PC25                _UL(1 << 25) /**< \brief GPIO Mask  for PC25 */
+#define GPIO_PC25                _UL_(1 << 25) /**< \brief GPIO Mask  for PC25 */
 #define PIN_PC26                          90  /**< \brief Pin Number for PC26 */
-#define GPIO_PC26                _UL(1 << 26) /**< \brief GPIO Mask  for PC26 */
+#define GPIO_PC26                _UL_(1 << 26) /**< \brief GPIO Mask  for PC26 */
 #define PIN_PC27                          91  /**< \brief Pin Number for PC27 */
-#define GPIO_PC27                _UL(1 << 27) /**< \brief GPIO Mask  for PC27 */
+#define GPIO_PC27                _UL_(1 << 27) /**< \brief GPIO Mask  for PC27 */
 #define PIN_PC28                          92  /**< \brief Pin Number for PC28 */
-#define GPIO_PC28                _UL(1 << 28) /**< \brief GPIO Mask  for PC28 */
+#define GPIO_PC28                _UL_(1 << 28) /**< \brief GPIO Mask  for PC28 */
 #define PIN_PC29                          93  /**< \brief Pin Number for PC29 */
-#define GPIO_PC29                _UL(1 << 29) /**< \brief GPIO Mask  for PC29 */
+#define GPIO_PC29                _UL_(1 << 29) /**< \brief GPIO Mask  for PC29 */
 #define PIN_PC30                          94  /**< \brief Pin Number for PC30 */
-#define GPIO_PC30                _UL(1 << 30) /**< \brief GPIO Mask  for PC30 */
+#define GPIO_PC30                _UL_(1 << 30) /**< \brief GPIO Mask  for PC30 */
 #define PIN_PC31                          95  /**< \brief Pin Number for PC31 */
-#define GPIO_PC31                _UL(1 << 31) /**< \brief GPIO Mask  for PC31 */
+#define GPIO_PC31                _UL_(1 << 31) /**< \brief GPIO Mask  for PC31 */
 /* ========== GPIO definition for TWIMS0 peripheral ========== */
-#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
-#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PIN_PA24B_TWIMS0_TWCK          _L_(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L_(1)
 #define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
-#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
-#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
-#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL_(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L_(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L_(1)
 #define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
-#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+#define GPIO_PA23B_TWIMS0_TWD    _UL_(1 << 23)
 /* ========== GPIO definition for TWIMS1 peripheral ========== */
-#define PIN_PB01A_TWIMS1_TWCK          _L(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
-#define MUX_PB01A_TWIMS1_TWCK           _L(0)
+#define PIN_PB01A_TWIMS1_TWCK          _L_(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
+#define MUX_PB01A_TWIMS1_TWCK           _L_(0)
 #define PINMUX_PB01A_TWIMS1_TWCK   ((PIN_PB01A_TWIMS1_TWCK << 16) | MUX_PB01A_TWIMS1_TWCK)
-#define GPIO_PB01A_TWIMS1_TWCK   _UL(1 <<  1)
-#define PIN_PB00A_TWIMS1_TWD           _L(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
-#define MUX_PB00A_TWIMS1_TWD            _L(0)
+#define GPIO_PB01A_TWIMS1_TWCK   _UL_(1 <<  1)
+#define PIN_PB00A_TWIMS1_TWD           _L_(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
+#define MUX_PB00A_TWIMS1_TWD            _L_(0)
 #define PINMUX_PB00A_TWIMS1_TWD    ((PIN_PB00A_TWIMS1_TWD << 16) | MUX_PB00A_TWIMS1_TWD)
-#define GPIO_PB00A_TWIMS1_TWD    _UL(1 <<  0)
+#define GPIO_PB00A_TWIMS1_TWD    _UL_(1 <<  0)
 /* ========== GPIO definition for TWIMS2 peripheral ========== */
-#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
-#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PIN_PA22E_TWIMS2_TWCK          _L_(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L_(4)
 #define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
-#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
-#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
-#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL_(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L_(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L_(4)
 #define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
-#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+#define GPIO_PA21E_TWIMS2_TWD    _UL_(1 << 21)
 /* ========== GPIO definition for TWIMS3 peripheral ========== */
-#define PIN_PB15C_TWIMS3_TWCK          _L(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
-#define MUX_PB15C_TWIMS3_TWCK           _L(2)
+#define PIN_PB15C_TWIMS3_TWCK          _L_(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
+#define MUX_PB15C_TWIMS3_TWCK           _L_(2)
 #define PINMUX_PB15C_TWIMS3_TWCK   ((PIN_PB15C_TWIMS3_TWCK << 16) | MUX_PB15C_TWIMS3_TWCK)
-#define GPIO_PB15C_TWIMS3_TWCK   _UL(1 << 15)
-#define PIN_PB14C_TWIMS3_TWD           _L(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
-#define MUX_PB14C_TWIMS3_TWD            _L(2)
+#define GPIO_PB15C_TWIMS3_TWCK   _UL_(1 << 15)
+#define PIN_PB14C_TWIMS3_TWD           _L_(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
+#define MUX_PB14C_TWIMS3_TWD            _L_(2)
 #define PINMUX_PB14C_TWIMS3_TWD    ((PIN_PB14C_TWIMS3_TWD << 16) | MUX_PB14C_TWIMS3_TWD)
-#define GPIO_PB14C_TWIMS3_TWD    _UL(1 << 14)
+#define GPIO_PB14C_TWIMS3_TWD    _UL_(1 << 14)
 /* ========== GPIO definition for IISC peripheral ========== */
-#define PIN_PB05D_IISC_IMCK            _L(37) /**< \brief IISC signal: IMCK on PB05 mux D */
-#define MUX_PB05D_IISC_IMCK             _L(3)
+#define PIN_PB05D_IISC_IMCK            _L_(37) /**< \brief IISC signal: IMCK on PB05 mux D */
+#define MUX_PB05D_IISC_IMCK             _L_(3)
 #define PINMUX_PB05D_IISC_IMCK     ((PIN_PB05D_IISC_IMCK << 16) | MUX_PB05D_IISC_IMCK)
-#define GPIO_PB05D_IISC_IMCK     _UL(1 <<  5)
-#define PIN_PC14D_IISC_IMCK            _L(78) /**< \brief IISC signal: IMCK on PC14 mux D */
-#define MUX_PC14D_IISC_IMCK             _L(3)
+#define GPIO_PB05D_IISC_IMCK     _UL_(1 <<  5)
+#define PIN_PC14D_IISC_IMCK            _L_(78) /**< \brief IISC signal: IMCK on PC14 mux D */
+#define MUX_PC14D_IISC_IMCK             _L_(3)
 #define PINMUX_PC14D_IISC_IMCK     ((PIN_PC14D_IISC_IMCK << 16) | MUX_PC14D_IISC_IMCK)
-#define GPIO_PC14D_IISC_IMCK     _UL(1 << 14)
-#define PIN_PB02D_IISC_ISCK            _L(34) /**< \brief IISC signal: ISCK on PB02 mux D */
-#define MUX_PB02D_IISC_ISCK             _L(3)
+#define GPIO_PC14D_IISC_IMCK     _UL_(1 << 14)
+#define PIN_PB02D_IISC_ISCK            _L_(34) /**< \brief IISC signal: ISCK on PB02 mux D */
+#define MUX_PB02D_IISC_ISCK             _L_(3)
 #define PINMUX_PB02D_IISC_ISCK     ((PIN_PB02D_IISC_ISCK << 16) | MUX_PB02D_IISC_ISCK)
-#define GPIO_PB02D_IISC_ISCK     _UL(1 <<  2)
-#define PIN_PC09D_IISC_ISCK            _L(73) /**< \brief IISC signal: ISCK on PC09 mux D */
-#define MUX_PC09D_IISC_ISCK             _L(3)
+#define GPIO_PB02D_IISC_ISCK     _UL_(1 <<  2)
+#define PIN_PC09D_IISC_ISCK            _L_(73) /**< \brief IISC signal: ISCK on PC09 mux D */
+#define MUX_PC09D_IISC_ISCK             _L_(3)
 #define PINMUX_PC09D_IISC_ISCK     ((PIN_PC09D_IISC_ISCK << 16) | MUX_PC09D_IISC_ISCK)
-#define GPIO_PC09D_IISC_ISCK     _UL(1 <<  9)
-#define PIN_PB03D_IISC_ISDI            _L(35) /**< \brief IISC signal: ISDI on PB03 mux D */
-#define MUX_PB03D_IISC_ISDI             _L(3)
+#define GPIO_PC09D_IISC_ISCK     _UL_(1 <<  9)
+#define PIN_PB03D_IISC_ISDI            _L_(35) /**< \brief IISC signal: ISDI on PB03 mux D */
+#define MUX_PB03D_IISC_ISDI             _L_(3)
 #define PINMUX_PB03D_IISC_ISDI     ((PIN_PB03D_IISC_ISDI << 16) | MUX_PB03D_IISC_ISDI)
-#define GPIO_PB03D_IISC_ISDI     _UL(1 <<  3)
-#define PIN_PC10D_IISC_ISDI            _L(74) /**< \brief IISC signal: ISDI on PC10 mux D */
-#define MUX_PC10D_IISC_ISDI             _L(3)
+#define GPIO_PB03D_IISC_ISDI     _UL_(1 <<  3)
+#define PIN_PC10D_IISC_ISDI            _L_(74) /**< \brief IISC signal: ISDI on PC10 mux D */
+#define MUX_PC10D_IISC_ISDI             _L_(3)
 #define PINMUX_PC10D_IISC_ISDI     ((PIN_PC10D_IISC_ISDI << 16) | MUX_PC10D_IISC_ISDI)
-#define GPIO_PC10D_IISC_ISDI     _UL(1 << 10)
-#define PIN_PB04D_IISC_ISDO            _L(36) /**< \brief IISC signal: ISDO on PB04 mux D */
-#define MUX_PB04D_IISC_ISDO             _L(3)
+#define GPIO_PC10D_IISC_ISDI     _UL_(1 << 10)
+#define PIN_PB04D_IISC_ISDO            _L_(36) /**< \brief IISC signal: ISDO on PB04 mux D */
+#define MUX_PB04D_IISC_ISDO             _L_(3)
 #define PINMUX_PB04D_IISC_ISDO     ((PIN_PB04D_IISC_ISDO << 16) | MUX_PB04D_IISC_ISDO)
-#define GPIO_PB04D_IISC_ISDO     _UL(1 <<  4)
-#define PIN_PC13D_IISC_ISDO            _L(77) /**< \brief IISC signal: ISDO on PC13 mux D */
-#define MUX_PC13D_IISC_ISDO             _L(3)
+#define GPIO_PB04D_IISC_ISDO     _UL_(1 <<  4)
+#define PIN_PC13D_IISC_ISDO            _L_(77) /**< \brief IISC signal: ISDO on PC13 mux D */
+#define MUX_PC13D_IISC_ISDO             _L_(3)
 #define PINMUX_PC13D_IISC_ISDO     ((PIN_PC13D_IISC_ISDO << 16) | MUX_PC13D_IISC_ISDO)
-#define GPIO_PC13D_IISC_ISDO     _UL(1 << 13)
-#define PIN_PB06D_IISC_IWS             _L(38) /**< \brief IISC signal: IWS on PB06 mux D */
-#define MUX_PB06D_IISC_IWS              _L(3)
+#define GPIO_PC13D_IISC_ISDO     _UL_(1 << 13)
+#define PIN_PB06D_IISC_IWS             _L_(38) /**< \brief IISC signal: IWS on PB06 mux D */
+#define MUX_PB06D_IISC_IWS              _L_(3)
 #define PINMUX_PB06D_IISC_IWS      ((PIN_PB06D_IISC_IWS << 16) | MUX_PB06D_IISC_IWS)
-#define GPIO_PB06D_IISC_IWS      _UL(1 <<  6)
-#define PIN_PC12D_IISC_IWS             _L(76) /**< \brief IISC signal: IWS on PC12 mux D */
-#define MUX_PC12D_IISC_IWS              _L(3)
+#define GPIO_PB06D_IISC_IWS      _UL_(1 <<  6)
+#define PIN_PC12D_IISC_IWS             _L_(76) /**< \brief IISC signal: IWS on PC12 mux D */
+#define MUX_PC12D_IISC_IWS              _L_(3)
 #define PINMUX_PC12D_IISC_IWS      ((PIN_PC12D_IISC_IWS << 16) | MUX_PC12D_IISC_IWS)
-#define GPIO_PC12D_IISC_IWS      _UL(1 << 12)
+#define GPIO_PC12D_IISC_IWS      _UL_(1 << 12)
 /* ========== GPIO definition for SPI peripheral ========== */
-#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
-#define MUX_PA03B_SPI_MISO              _L(1)
+#define PIN_PA03B_SPI_MISO              _L_(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L_(1)
 #define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
-#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
-#define PIN_PB14B_SPI_MISO             _L(46) /**< \brief SPI signal: MISO on PB14 mux B */
-#define MUX_PB14B_SPI_MISO              _L(1)
+#define GPIO_PA03B_SPI_MISO      _UL_(1 <<  3)
+#define PIN_PB14B_SPI_MISO             _L_(46) /**< \brief SPI signal: MISO on PB14 mux B */
+#define MUX_PB14B_SPI_MISO              _L_(1)
 #define PINMUX_PB14B_SPI_MISO      ((PIN_PB14B_SPI_MISO << 16) | MUX_PB14B_SPI_MISO)
-#define GPIO_PB14B_SPI_MISO      _UL(1 << 14)
-#define PIN_PC28B_SPI_MISO             _L(92) /**< \brief SPI signal: MISO on PC28 mux B */
-#define MUX_PC28B_SPI_MISO              _L(1)
+#define GPIO_PB14B_SPI_MISO      _UL_(1 << 14)
+#define PIN_PC28B_SPI_MISO             _L_(92) /**< \brief SPI signal: MISO on PC28 mux B */
+#define MUX_PC28B_SPI_MISO              _L_(1)
 #define PINMUX_PC28B_SPI_MISO      ((PIN_PC28B_SPI_MISO << 16) | MUX_PC28B_SPI_MISO)
-#define GPIO_PC28B_SPI_MISO      _UL(1 << 28)
-#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
-#define MUX_PA21A_SPI_MISO              _L(0)
+#define GPIO_PC28B_SPI_MISO      _UL_(1 << 28)
+#define PIN_PA21A_SPI_MISO             _L_(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L_(0)
 #define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
-#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
-#define PIN_PC04A_SPI_MISO             _L(68) /**< \brief SPI signal: MISO on PC04 mux A */
-#define MUX_PC04A_SPI_MISO              _L(0)
+#define GPIO_PA21A_SPI_MISO      _UL_(1 << 21)
+#define PIN_PC04A_SPI_MISO             _L_(68) /**< \brief SPI signal: MISO on PC04 mux A */
+#define MUX_PC04A_SPI_MISO              _L_(0)
 #define PINMUX_PC04A_SPI_MISO      ((PIN_PC04A_SPI_MISO << 16) | MUX_PC04A_SPI_MISO)
-#define GPIO_PC04A_SPI_MISO      _UL(1 <<  4)
-#define PIN_PB15B_SPI_MOSI             _L(47) /**< \brief SPI signal: MOSI on PB15 mux B */
-#define MUX_PB15B_SPI_MOSI              _L(1)
+#define GPIO_PC04A_SPI_MISO      _UL_(1 <<  4)
+#define PIN_PB15B_SPI_MOSI             _L_(47) /**< \brief SPI signal: MOSI on PB15 mux B */
+#define MUX_PB15B_SPI_MOSI              _L_(1)
 #define PINMUX_PB15B_SPI_MOSI      ((PIN_PB15B_SPI_MOSI << 16) | MUX_PB15B_SPI_MOSI)
-#define GPIO_PB15B_SPI_MOSI      _UL(1 << 15)
-#define PIN_PC29B_SPI_MOSI             _L(93) /**< \brief SPI signal: MOSI on PC29 mux B */
-#define MUX_PC29B_SPI_MOSI              _L(1)
+#define GPIO_PB15B_SPI_MOSI      _UL_(1 << 15)
+#define PIN_PC29B_SPI_MOSI             _L_(93) /**< \brief SPI signal: MOSI on PC29 mux B */
+#define MUX_PC29B_SPI_MOSI              _L_(1)
 #define PINMUX_PC29B_SPI_MOSI      ((PIN_PC29B_SPI_MOSI << 16) | MUX_PC29B_SPI_MOSI)
-#define GPIO_PC29B_SPI_MOSI      _UL(1 << 29)
-#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
-#define MUX_PA22A_SPI_MOSI              _L(0)
+#define GPIO_PC29B_SPI_MOSI      _UL_(1 << 29)
+#define PIN_PA22A_SPI_MOSI             _L_(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L_(0)
 #define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
-#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
-#define PIN_PC05A_SPI_MOSI             _L(69) /**< \brief SPI signal: MOSI on PC05 mux A */
-#define MUX_PC05A_SPI_MOSI              _L(0)
+#define GPIO_PA22A_SPI_MOSI      _UL_(1 << 22)
+#define PIN_PC05A_SPI_MOSI             _L_(69) /**< \brief SPI signal: MOSI on PC05 mux A */
+#define MUX_PC05A_SPI_MOSI              _L_(0)
 #define PINMUX_PC05A_SPI_MOSI      ((PIN_PC05A_SPI_MOSI << 16) | MUX_PC05A_SPI_MOSI)
-#define GPIO_PC05A_SPI_MOSI      _UL(1 <<  5)
-#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
-#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define GPIO_PC05A_SPI_MOSI      _UL_(1 <<  5)
+#define PIN_PA02B_SPI_NPCS0             _L_(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L_(1)
 #define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
-#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
-#define PIN_PC31B_SPI_NPCS0            _L(95) /**< \brief SPI signal: NPCS0 on PC31 mux B */
-#define MUX_PC31B_SPI_NPCS0             _L(1)
+#define GPIO_PA02B_SPI_NPCS0     _UL_(1 <<  2)
+#define PIN_PC31B_SPI_NPCS0            _L_(95) /**< \brief SPI signal: NPCS0 on PC31 mux B */
+#define MUX_PC31B_SPI_NPCS0             _L_(1)
 #define PINMUX_PC31B_SPI_NPCS0     ((PIN_PC31B_SPI_NPCS0 << 16) | MUX_PC31B_SPI_NPCS0)
-#define GPIO_PC31B_SPI_NPCS0     _UL(1 << 31)
-#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
-#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define GPIO_PC31B_SPI_NPCS0     _UL_(1 << 31)
+#define PIN_PA24A_SPI_NPCS0            _L_(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L_(0)
 #define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
-#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
-#define PIN_PC03A_SPI_NPCS0            _L(67) /**< \brief SPI signal: NPCS0 on PC03 mux A */
-#define MUX_PC03A_SPI_NPCS0             _L(0)
+#define GPIO_PA24A_SPI_NPCS0     _UL_(1 << 24)
+#define PIN_PC03A_SPI_NPCS0            _L_(67) /**< \brief SPI signal: NPCS0 on PC03 mux A */
+#define MUX_PC03A_SPI_NPCS0             _L_(0)
 #define PINMUX_PC03A_SPI_NPCS0     ((PIN_PC03A_SPI_NPCS0 << 16) | MUX_PC03A_SPI_NPCS0)
-#define GPIO_PC03A_SPI_NPCS0     _UL(1 <<  3)
-#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
-#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define GPIO_PC03A_SPI_NPCS0     _UL_(1 <<  3)
+#define PIN_PA13C_SPI_NPCS1            _L_(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L_(2)
 #define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
-#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PB13B_SPI_NPCS1            _L(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
-#define MUX_PB13B_SPI_NPCS1             _L(1)
+#define GPIO_PA13C_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PB13B_SPI_NPCS1            _L_(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
+#define MUX_PB13B_SPI_NPCS1             _L_(1)
 #define PINMUX_PB13B_SPI_NPCS1     ((PIN_PB13B_SPI_NPCS1 << 16) | MUX_PB13B_SPI_NPCS1)
-#define GPIO_PB13B_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PC02A_SPI_NPCS1            _L(66) /**< \brief SPI signal: NPCS1 on PC02 mux A */
-#define MUX_PC02A_SPI_NPCS1             _L(0)
+#define GPIO_PB13B_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PC02A_SPI_NPCS1            _L_(66) /**< \brief SPI signal: NPCS1 on PC02 mux A */
+#define MUX_PC02A_SPI_NPCS1             _L_(0)
 #define PINMUX_PC02A_SPI_NPCS1     ((PIN_PC02A_SPI_NPCS1 << 16) | MUX_PC02A_SPI_NPCS1)
-#define GPIO_PC02A_SPI_NPCS1     _UL(1 <<  2)
-#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
-#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define GPIO_PC02A_SPI_NPCS1     _UL_(1 <<  2)
+#define PIN_PA14C_SPI_NPCS2            _L_(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L_(2)
 #define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
-#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
-#define PIN_PB11B_SPI_NPCS2            _L(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
-#define MUX_PB11B_SPI_NPCS2             _L(1)
+#define GPIO_PA14C_SPI_NPCS2     _UL_(1 << 14)
+#define PIN_PB11B_SPI_NPCS2            _L_(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
+#define MUX_PB11B_SPI_NPCS2             _L_(1)
 #define PINMUX_PB11B_SPI_NPCS2     ((PIN_PB11B_SPI_NPCS2 << 16) | MUX_PB11B_SPI_NPCS2)
-#define GPIO_PB11B_SPI_NPCS2     _UL(1 << 11)
-#define PIN_PC00A_SPI_NPCS2            _L(64) /**< \brief SPI signal: NPCS2 on PC00 mux A */
-#define MUX_PC00A_SPI_NPCS2             _L(0)
+#define GPIO_PB11B_SPI_NPCS2     _UL_(1 << 11)
+#define PIN_PC00A_SPI_NPCS2            _L_(64) /**< \brief SPI signal: NPCS2 on PC00 mux A */
+#define MUX_PC00A_SPI_NPCS2             _L_(0)
 #define PINMUX_PC00A_SPI_NPCS2     ((PIN_PC00A_SPI_NPCS2 << 16) | MUX_PC00A_SPI_NPCS2)
-#define GPIO_PC00A_SPI_NPCS2     _UL(1 <<  0)
-#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
-#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define GPIO_PC00A_SPI_NPCS2     _UL_(1 <<  0)
+#define PIN_PA15C_SPI_NPCS3            _L_(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L_(2)
 #define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
-#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
-#define PIN_PB12B_SPI_NPCS3            _L(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
-#define MUX_PB12B_SPI_NPCS3             _L(1)
+#define GPIO_PA15C_SPI_NPCS3     _UL_(1 << 15)
+#define PIN_PB12B_SPI_NPCS3            _L_(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
+#define MUX_PB12B_SPI_NPCS3             _L_(1)
 #define PINMUX_PB12B_SPI_NPCS3     ((PIN_PB12B_SPI_NPCS3 << 16) | MUX_PB12B_SPI_NPCS3)
-#define GPIO_PB12B_SPI_NPCS3     _UL(1 << 12)
-#define PIN_PC01A_SPI_NPCS3            _L(65) /**< \brief SPI signal: NPCS3 on PC01 mux A */
-#define MUX_PC01A_SPI_NPCS3             _L(0)
+#define GPIO_PB12B_SPI_NPCS3     _UL_(1 << 12)
+#define PIN_PC01A_SPI_NPCS3            _L_(65) /**< \brief SPI signal: NPCS3 on PC01 mux A */
+#define MUX_PC01A_SPI_NPCS3             _L_(0)
 #define PINMUX_PC01A_SPI_NPCS3     ((PIN_PC01A_SPI_NPCS3 << 16) | MUX_PC01A_SPI_NPCS3)
-#define GPIO_PC01A_SPI_NPCS3     _UL(1 <<  1)
-#define PIN_PC30B_SPI_SCK              _L(94) /**< \brief SPI signal: SCK on PC30 mux B */
-#define MUX_PC30B_SPI_SCK               _L(1)
+#define GPIO_PC01A_SPI_NPCS3     _UL_(1 <<  1)
+#define PIN_PC30B_SPI_SCK              _L_(94) /**< \brief SPI signal: SCK on PC30 mux B */
+#define MUX_PC30B_SPI_SCK               _L_(1)
 #define PINMUX_PC30B_SPI_SCK       ((PIN_PC30B_SPI_SCK << 16) | MUX_PC30B_SPI_SCK)
-#define GPIO_PC30B_SPI_SCK       _UL(1 << 30)
-#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
-#define MUX_PA23A_SPI_SCK               _L(0)
+#define GPIO_PC30B_SPI_SCK       _UL_(1 << 30)
+#define PIN_PA23A_SPI_SCK              _L_(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L_(0)
 #define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
-#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
-#define PIN_PC06A_SPI_SCK              _L(70) /**< \brief SPI signal: SCK on PC06 mux A */
-#define MUX_PC06A_SPI_SCK               _L(0)
+#define GPIO_PA23A_SPI_SCK       _UL_(1 << 23)
+#define PIN_PC06A_SPI_SCK              _L_(70) /**< \brief SPI signal: SCK on PC06 mux A */
+#define MUX_PC06A_SPI_SCK               _L_(0)
 #define PINMUX_PC06A_SPI_SCK       ((PIN_PC06A_SPI_SCK << 16) | MUX_PC06A_SPI_SCK)
-#define GPIO_PC06A_SPI_SCK       _UL(1 <<  6)
+#define GPIO_PC06A_SPI_SCK       _UL_(1 <<  6)
 /* ========== GPIO definition for TC0 peripheral ========== */
-#define PIN_PB07D_TC0_A0               _L(39) /**< \brief TC0 signal: A0 on PB07 mux D */
-#define MUX_PB07D_TC0_A0                _L(3)
+#define PIN_PB07D_TC0_A0               _L_(39) /**< \brief TC0 signal: A0 on PB07 mux D */
+#define MUX_PB07D_TC0_A0                _L_(3)
 #define PINMUX_PB07D_TC0_A0        ((PIN_PB07D_TC0_A0 << 16) | MUX_PB07D_TC0_A0)
-#define GPIO_PB07D_TC0_A0        _UL(1 <<  7)
-#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
-#define MUX_PA08B_TC0_A0                _L(1)
+#define GPIO_PB07D_TC0_A0        _UL_(1 <<  7)
+#define PIN_PA08B_TC0_A0                _L_(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L_(1)
 #define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
-#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
-#define PIN_PB09D_TC0_A1               _L(41) /**< \brief TC0 signal: A1 on PB09 mux D */
-#define MUX_PB09D_TC0_A1                _L(3)
+#define GPIO_PA08B_TC0_A0        _UL_(1 <<  8)
+#define PIN_PB09D_TC0_A1               _L_(41) /**< \brief TC0 signal: A1 on PB09 mux D */
+#define MUX_PB09D_TC0_A1                _L_(3)
 #define PINMUX_PB09D_TC0_A1        ((PIN_PB09D_TC0_A1 << 16) | MUX_PB09D_TC0_A1)
-#define GPIO_PB09D_TC0_A1        _UL(1 <<  9)
-#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
-#define MUX_PA10B_TC0_A1                _L(1)
+#define GPIO_PB09D_TC0_A1        _UL_(1 <<  9)
+#define PIN_PA10B_TC0_A1               _L_(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L_(1)
 #define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
-#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
-#define PIN_PB11D_TC0_A2               _L(43) /**< \brief TC0 signal: A2 on PB11 mux D */
-#define MUX_PB11D_TC0_A2                _L(3)
+#define GPIO_PA10B_TC0_A1        _UL_(1 << 10)
+#define PIN_PB11D_TC0_A2               _L_(43) /**< \brief TC0 signal: A2 on PB11 mux D */
+#define MUX_PB11D_TC0_A2                _L_(3)
 #define PINMUX_PB11D_TC0_A2        ((PIN_PB11D_TC0_A2 << 16) | MUX_PB11D_TC0_A2)
-#define GPIO_PB11D_TC0_A2        _UL(1 << 11)
-#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
-#define MUX_PA12B_TC0_A2                _L(1)
+#define GPIO_PB11D_TC0_A2        _UL_(1 << 11)
+#define PIN_PA12B_TC0_A2               _L_(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L_(1)
 #define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
-#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
-#define PIN_PB08D_TC0_B0               _L(40) /**< \brief TC0 signal: B0 on PB08 mux D */
-#define MUX_PB08D_TC0_B0                _L(3)
+#define GPIO_PA12B_TC0_A2        _UL_(1 << 12)
+#define PIN_PB08D_TC0_B0               _L_(40) /**< \brief TC0 signal: B0 on PB08 mux D */
+#define MUX_PB08D_TC0_B0                _L_(3)
 #define PINMUX_PB08D_TC0_B0        ((PIN_PB08D_TC0_B0 << 16) | MUX_PB08D_TC0_B0)
-#define GPIO_PB08D_TC0_B0        _UL(1 <<  8)
-#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
-#define MUX_PA09B_TC0_B0                _L(1)
+#define GPIO_PB08D_TC0_B0        _UL_(1 <<  8)
+#define PIN_PA09B_TC0_B0                _L_(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L_(1)
 #define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
-#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
-#define PIN_PB10D_TC0_B1               _L(42) /**< \brief TC0 signal: B1 on PB10 mux D */
-#define MUX_PB10D_TC0_B1                _L(3)
+#define GPIO_PA09B_TC0_B0        _UL_(1 <<  9)
+#define PIN_PB10D_TC0_B1               _L_(42) /**< \brief TC0 signal: B1 on PB10 mux D */
+#define MUX_PB10D_TC0_B1                _L_(3)
 #define PINMUX_PB10D_TC0_B1        ((PIN_PB10D_TC0_B1 << 16) | MUX_PB10D_TC0_B1)
-#define GPIO_PB10D_TC0_B1        _UL(1 << 10)
-#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
-#define MUX_PA11B_TC0_B1                _L(1)
+#define GPIO_PB10D_TC0_B1        _UL_(1 << 10)
+#define PIN_PA11B_TC0_B1               _L_(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L_(1)
 #define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
-#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
-#define PIN_PB12D_TC0_B2               _L(44) /**< \brief TC0 signal: B2 on PB12 mux D */
-#define MUX_PB12D_TC0_B2                _L(3)
+#define GPIO_PA11B_TC0_B1        _UL_(1 << 11)
+#define PIN_PB12D_TC0_B2               _L_(44) /**< \brief TC0 signal: B2 on PB12 mux D */
+#define MUX_PB12D_TC0_B2                _L_(3)
 #define PINMUX_PB12D_TC0_B2        ((PIN_PB12D_TC0_B2 << 16) | MUX_PB12D_TC0_B2)
-#define GPIO_PB12D_TC0_B2        _UL(1 << 12)
-#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
-#define MUX_PA13B_TC0_B2                _L(1)
+#define GPIO_PB12D_TC0_B2        _UL_(1 << 12)
+#define PIN_PA13B_TC0_B2               _L_(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L_(1)
 #define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
-#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
-#define PIN_PB13D_TC0_CLK0             _L(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
-#define MUX_PB13D_TC0_CLK0              _L(3)
+#define GPIO_PA13B_TC0_B2        _UL_(1 << 13)
+#define PIN_PB13D_TC0_CLK0             _L_(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
+#define MUX_PB13D_TC0_CLK0              _L_(3)
 #define PINMUX_PB13D_TC0_CLK0      ((PIN_PB13D_TC0_CLK0 << 16) | MUX_PB13D_TC0_CLK0)
-#define GPIO_PB13D_TC0_CLK0      _UL(1 << 13)
-#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
-#define MUX_PA14B_TC0_CLK0              _L(1)
+#define GPIO_PB13D_TC0_CLK0      _UL_(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L_(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L_(1)
 #define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
-#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
-#define PIN_PB14D_TC0_CLK1             _L(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
-#define MUX_PB14D_TC0_CLK1              _L(3)
+#define GPIO_PA14B_TC0_CLK0      _UL_(1 << 14)
+#define PIN_PB14D_TC0_CLK1             _L_(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
+#define MUX_PB14D_TC0_CLK1              _L_(3)
 #define PINMUX_PB14D_TC0_CLK1      ((PIN_PB14D_TC0_CLK1 << 16) | MUX_PB14D_TC0_CLK1)
-#define GPIO_PB14D_TC0_CLK1      _UL(1 << 14)
-#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
-#define MUX_PA15B_TC0_CLK1              _L(1)
+#define GPIO_PB14D_TC0_CLK1      _UL_(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L_(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L_(1)
 #define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
-#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
-#define PIN_PB15D_TC0_CLK2             _L(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
-#define MUX_PB15D_TC0_CLK2              _L(3)
+#define GPIO_PA15B_TC0_CLK1      _UL_(1 << 15)
+#define PIN_PB15D_TC0_CLK2             _L_(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
+#define MUX_PB15D_TC0_CLK2              _L_(3)
 #define PINMUX_PB15D_TC0_CLK2      ((PIN_PB15D_TC0_CLK2 << 16) | MUX_PB15D_TC0_CLK2)
-#define GPIO_PB15D_TC0_CLK2      _UL(1 << 15)
-#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
-#define MUX_PA16B_TC0_CLK2              _L(1)
+#define GPIO_PB15D_TC0_CLK2      _UL_(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L_(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L_(1)
 #define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
-#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+#define GPIO_PA16B_TC0_CLK2      _UL_(1 << 16)
 /* ========== GPIO definition for TC1 peripheral ========== */
-#define PIN_PC00D_TC1_A0               _L(64) /**< \brief TC1 signal: A0 on PC00 mux D */
-#define MUX_PC00D_TC1_A0                _L(3)
+#define PIN_PC00D_TC1_A0               _L_(64) /**< \brief TC1 signal: A0 on PC00 mux D */
+#define MUX_PC00D_TC1_A0                _L_(3)
 #define PINMUX_PC00D_TC1_A0        ((PIN_PC00D_TC1_A0 << 16) | MUX_PC00D_TC1_A0)
-#define GPIO_PC00D_TC1_A0        _UL(1 <<  0)
-#define PIN_PC15A_TC1_A0               _L(79) /**< \brief TC1 signal: A0 on PC15 mux A */
-#define MUX_PC15A_TC1_A0                _L(0)
+#define GPIO_PC00D_TC1_A0        _UL_(1 <<  0)
+#define PIN_PC15A_TC1_A0               _L_(79) /**< \brief TC1 signal: A0 on PC15 mux A */
+#define MUX_PC15A_TC1_A0                _L_(0)
 #define PINMUX_PC15A_TC1_A0        ((PIN_PC15A_TC1_A0 << 16) | MUX_PC15A_TC1_A0)
-#define GPIO_PC15A_TC1_A0        _UL(1 << 15)
-#define PIN_PC02D_TC1_A1               _L(66) /**< \brief TC1 signal: A1 on PC02 mux D */
-#define MUX_PC02D_TC1_A1                _L(3)
+#define GPIO_PC15A_TC1_A0        _UL_(1 << 15)
+#define PIN_PC02D_TC1_A1               _L_(66) /**< \brief TC1 signal: A1 on PC02 mux D */
+#define MUX_PC02D_TC1_A1                _L_(3)
 #define PINMUX_PC02D_TC1_A1        ((PIN_PC02D_TC1_A1 << 16) | MUX_PC02D_TC1_A1)
-#define GPIO_PC02D_TC1_A1        _UL(1 <<  2)
-#define PIN_PC17A_TC1_A1               _L(81) /**< \brief TC1 signal: A1 on PC17 mux A */
-#define MUX_PC17A_TC1_A1                _L(0)
+#define GPIO_PC02D_TC1_A1        _UL_(1 <<  2)
+#define PIN_PC17A_TC1_A1               _L_(81) /**< \brief TC1 signal: A1 on PC17 mux A */
+#define MUX_PC17A_TC1_A1                _L_(0)
 #define PINMUX_PC17A_TC1_A1        ((PIN_PC17A_TC1_A1 << 16) | MUX_PC17A_TC1_A1)
-#define GPIO_PC17A_TC1_A1        _UL(1 << 17)
-#define PIN_PC04D_TC1_A2               _L(68) /**< \brief TC1 signal: A2 on PC04 mux D */
-#define MUX_PC04D_TC1_A2                _L(3)
+#define GPIO_PC17A_TC1_A1        _UL_(1 << 17)
+#define PIN_PC04D_TC1_A2               _L_(68) /**< \brief TC1 signal: A2 on PC04 mux D */
+#define MUX_PC04D_TC1_A2                _L_(3)
 #define PINMUX_PC04D_TC1_A2        ((PIN_PC04D_TC1_A2 << 16) | MUX_PC04D_TC1_A2)
-#define GPIO_PC04D_TC1_A2        _UL(1 <<  4)
-#define PIN_PC19A_TC1_A2               _L(83) /**< \brief TC1 signal: A2 on PC19 mux A */
-#define MUX_PC19A_TC1_A2                _L(0)
+#define GPIO_PC04D_TC1_A2        _UL_(1 <<  4)
+#define PIN_PC19A_TC1_A2               _L_(83) /**< \brief TC1 signal: A2 on PC19 mux A */
+#define MUX_PC19A_TC1_A2                _L_(0)
 #define PINMUX_PC19A_TC1_A2        ((PIN_PC19A_TC1_A2 << 16) | MUX_PC19A_TC1_A2)
-#define GPIO_PC19A_TC1_A2        _UL(1 << 19)
-#define PIN_PC01D_TC1_B0               _L(65) /**< \brief TC1 signal: B0 on PC01 mux D */
-#define MUX_PC01D_TC1_B0                _L(3)
+#define GPIO_PC19A_TC1_A2        _UL_(1 << 19)
+#define PIN_PC01D_TC1_B0               _L_(65) /**< \brief TC1 signal: B0 on PC01 mux D */
+#define MUX_PC01D_TC1_B0                _L_(3)
 #define PINMUX_PC01D_TC1_B0        ((PIN_PC01D_TC1_B0 << 16) | MUX_PC01D_TC1_B0)
-#define GPIO_PC01D_TC1_B0        _UL(1 <<  1)
-#define PIN_PC16A_TC1_B0               _L(80) /**< \brief TC1 signal: B0 on PC16 mux A */
-#define MUX_PC16A_TC1_B0                _L(0)
+#define GPIO_PC01D_TC1_B0        _UL_(1 <<  1)
+#define PIN_PC16A_TC1_B0               _L_(80) /**< \brief TC1 signal: B0 on PC16 mux A */
+#define MUX_PC16A_TC1_B0                _L_(0)
 #define PINMUX_PC16A_TC1_B0        ((PIN_PC16A_TC1_B0 << 16) | MUX_PC16A_TC1_B0)
-#define GPIO_PC16A_TC1_B0        _UL(1 << 16)
-#define PIN_PC03D_TC1_B1               _L(67) /**< \brief TC1 signal: B1 on PC03 mux D */
-#define MUX_PC03D_TC1_B1                _L(3)
+#define GPIO_PC16A_TC1_B0        _UL_(1 << 16)
+#define PIN_PC03D_TC1_B1               _L_(67) /**< \brief TC1 signal: B1 on PC03 mux D */
+#define MUX_PC03D_TC1_B1                _L_(3)
 #define PINMUX_PC03D_TC1_B1        ((PIN_PC03D_TC1_B1 << 16) | MUX_PC03D_TC1_B1)
-#define GPIO_PC03D_TC1_B1        _UL(1 <<  3)
-#define PIN_PC18A_TC1_B1               _L(82) /**< \brief TC1 signal: B1 on PC18 mux A */
-#define MUX_PC18A_TC1_B1                _L(0)
+#define GPIO_PC03D_TC1_B1        _UL_(1 <<  3)
+#define PIN_PC18A_TC1_B1               _L_(82) /**< \brief TC1 signal: B1 on PC18 mux A */
+#define MUX_PC18A_TC1_B1                _L_(0)
 #define PINMUX_PC18A_TC1_B1        ((PIN_PC18A_TC1_B1 << 16) | MUX_PC18A_TC1_B1)
-#define GPIO_PC18A_TC1_B1        _UL(1 << 18)
-#define PIN_PC05D_TC1_B2               _L(69) /**< \brief TC1 signal: B2 on PC05 mux D */
-#define MUX_PC05D_TC1_B2                _L(3)
+#define GPIO_PC18A_TC1_B1        _UL_(1 << 18)
+#define PIN_PC05D_TC1_B2               _L_(69) /**< \brief TC1 signal: B2 on PC05 mux D */
+#define MUX_PC05D_TC1_B2                _L_(3)
 #define PINMUX_PC05D_TC1_B2        ((PIN_PC05D_TC1_B2 << 16) | MUX_PC05D_TC1_B2)
-#define GPIO_PC05D_TC1_B2        _UL(1 <<  5)
-#define PIN_PC20A_TC1_B2               _L(84) /**< \brief TC1 signal: B2 on PC20 mux A */
-#define MUX_PC20A_TC1_B2                _L(0)
+#define GPIO_PC05D_TC1_B2        _UL_(1 <<  5)
+#define PIN_PC20A_TC1_B2               _L_(84) /**< \brief TC1 signal: B2 on PC20 mux A */
+#define MUX_PC20A_TC1_B2                _L_(0)
 #define PINMUX_PC20A_TC1_B2        ((PIN_PC20A_TC1_B2 << 16) | MUX_PC20A_TC1_B2)
-#define GPIO_PC20A_TC1_B2        _UL(1 << 20)
-#define PIN_PC06D_TC1_CLK0             _L(70) /**< \brief TC1 signal: CLK0 on PC06 mux D */
-#define MUX_PC06D_TC1_CLK0              _L(3)
+#define GPIO_PC20A_TC1_B2        _UL_(1 << 20)
+#define PIN_PC06D_TC1_CLK0             _L_(70) /**< \brief TC1 signal: CLK0 on PC06 mux D */
+#define MUX_PC06D_TC1_CLK0              _L_(3)
 #define PINMUX_PC06D_TC1_CLK0      ((PIN_PC06D_TC1_CLK0 << 16) | MUX_PC06D_TC1_CLK0)
-#define GPIO_PC06D_TC1_CLK0      _UL(1 <<  6)
-#define PIN_PC21A_TC1_CLK0             _L(85) /**< \brief TC1 signal: CLK0 on PC21 mux A */
-#define MUX_PC21A_TC1_CLK0              _L(0)
+#define GPIO_PC06D_TC1_CLK0      _UL_(1 <<  6)
+#define PIN_PC21A_TC1_CLK0             _L_(85) /**< \brief TC1 signal: CLK0 on PC21 mux A */
+#define MUX_PC21A_TC1_CLK0              _L_(0)
 #define PINMUX_PC21A_TC1_CLK0      ((PIN_PC21A_TC1_CLK0 << 16) | MUX_PC21A_TC1_CLK0)
-#define GPIO_PC21A_TC1_CLK0      _UL(1 << 21)
-#define PIN_PC07D_TC1_CLK1             _L(71) /**< \brief TC1 signal: CLK1 on PC07 mux D */
-#define MUX_PC07D_TC1_CLK1              _L(3)
+#define GPIO_PC21A_TC1_CLK0      _UL_(1 << 21)
+#define PIN_PC07D_TC1_CLK1             _L_(71) /**< \brief TC1 signal: CLK1 on PC07 mux D */
+#define MUX_PC07D_TC1_CLK1              _L_(3)
 #define PINMUX_PC07D_TC1_CLK1      ((PIN_PC07D_TC1_CLK1 << 16) | MUX_PC07D_TC1_CLK1)
-#define GPIO_PC07D_TC1_CLK1      _UL(1 <<  7)
-#define PIN_PC22A_TC1_CLK1             _L(86) /**< \brief TC1 signal: CLK1 on PC22 mux A */
-#define MUX_PC22A_TC1_CLK1              _L(0)
+#define GPIO_PC07D_TC1_CLK1      _UL_(1 <<  7)
+#define PIN_PC22A_TC1_CLK1             _L_(86) /**< \brief TC1 signal: CLK1 on PC22 mux A */
+#define MUX_PC22A_TC1_CLK1              _L_(0)
 #define PINMUX_PC22A_TC1_CLK1      ((PIN_PC22A_TC1_CLK1 << 16) | MUX_PC22A_TC1_CLK1)
-#define GPIO_PC22A_TC1_CLK1      _UL(1 << 22)
-#define PIN_PC08D_TC1_CLK2             _L(72) /**< \brief TC1 signal: CLK2 on PC08 mux D */
-#define MUX_PC08D_TC1_CLK2              _L(3)
+#define GPIO_PC22A_TC1_CLK1      _UL_(1 << 22)
+#define PIN_PC08D_TC1_CLK2             _L_(72) /**< \brief TC1 signal: CLK2 on PC08 mux D */
+#define MUX_PC08D_TC1_CLK2              _L_(3)
 #define PINMUX_PC08D_TC1_CLK2      ((PIN_PC08D_TC1_CLK2 << 16) | MUX_PC08D_TC1_CLK2)
-#define GPIO_PC08D_TC1_CLK2      _UL(1 <<  8)
-#define PIN_PC23A_TC1_CLK2             _L(87) /**< \brief TC1 signal: CLK2 on PC23 mux A */
-#define MUX_PC23A_TC1_CLK2              _L(0)
+#define GPIO_PC08D_TC1_CLK2      _UL_(1 <<  8)
+#define PIN_PC23A_TC1_CLK2             _L_(87) /**< \brief TC1 signal: CLK2 on PC23 mux A */
+#define MUX_PC23A_TC1_CLK2              _L_(0)
 #define PINMUX_PC23A_TC1_CLK2      ((PIN_PC23A_TC1_CLK2 << 16) | MUX_PC23A_TC1_CLK2)
-#define GPIO_PC23A_TC1_CLK2      _UL(1 << 23)
+#define GPIO_PC23A_TC1_CLK2      _UL_(1 << 23)
 /* ========== GPIO definition for USART0 peripheral ========== */
-#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
-#define MUX_PA04B_USART0_CLK            _L(1)
+#define PIN_PA04B_USART0_CLK            _L_(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L_(1)
 #define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
-#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
-#define PIN_PC00B_USART0_CLK           _L(64) /**< \brief USART0 signal: CLK on PC00 mux B */
-#define MUX_PC00B_USART0_CLK            _L(1)
+#define GPIO_PA04B_USART0_CLK    _UL_(1 <<  4)
+#define PIN_PC00B_USART0_CLK           _L_(64) /**< \brief USART0 signal: CLK on PC00 mux B */
+#define MUX_PC00B_USART0_CLK            _L_(1)
 #define PINMUX_PC00B_USART0_CLK    ((PIN_PC00B_USART0_CLK << 16) | MUX_PC00B_USART0_CLK)
-#define GPIO_PC00B_USART0_CLK    _UL(1 <<  0)
-#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
-#define MUX_PA10A_USART0_CLK            _L(0)
+#define GPIO_PC00B_USART0_CLK    _UL_(1 <<  0)
+#define PIN_PA10A_USART0_CLK           _L_(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L_(0)
 #define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
-#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
-#define PIN_PB13A_USART0_CLK           _L(45) /**< \brief USART0 signal: CLK on PB13 mux A */
-#define MUX_PB13A_USART0_CLK            _L(0)
+#define GPIO_PA10A_USART0_CLK    _UL_(1 << 10)
+#define PIN_PB13A_USART0_CLK           _L_(45) /**< \brief USART0 signal: CLK on PB13 mux A */
+#define MUX_PB13A_USART0_CLK            _L_(0)
 #define PINMUX_PB13A_USART0_CLK    ((PIN_PB13A_USART0_CLK << 16) | MUX_PB13A_USART0_CLK)
-#define GPIO_PB13A_USART0_CLK    _UL(1 << 13)
-#define PIN_PC02B_USART0_CTS           _L(66) /**< \brief USART0 signal: CTS on PC02 mux B */
-#define MUX_PC02B_USART0_CTS            _L(1)
+#define GPIO_PB13A_USART0_CLK    _UL_(1 << 13)
+#define PIN_PC02B_USART0_CTS           _L_(66) /**< \brief USART0 signal: CTS on PC02 mux B */
+#define MUX_PC02B_USART0_CTS            _L_(1)
 #define PINMUX_PC02B_USART0_CTS    ((PIN_PC02B_USART0_CTS << 16) | MUX_PC02B_USART0_CTS)
-#define GPIO_PC02B_USART0_CTS    _UL(1 <<  2)
-#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
-#define MUX_PA09A_USART0_CTS            _L(0)
+#define GPIO_PC02B_USART0_CTS    _UL_(1 <<  2)
+#define PIN_PA09A_USART0_CTS            _L_(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L_(0)
 #define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
-#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
-#define PIN_PB11A_USART0_CTS           _L(43) /**< \brief USART0 signal: CTS on PB11 mux A */
-#define MUX_PB11A_USART0_CTS            _L(0)
+#define GPIO_PA09A_USART0_CTS    _UL_(1 <<  9)
+#define PIN_PB11A_USART0_CTS           _L_(43) /**< \brief USART0 signal: CTS on PB11 mux A */
+#define MUX_PB11A_USART0_CTS            _L_(0)
 #define PINMUX_PB11A_USART0_CTS    ((PIN_PB11A_USART0_CTS << 16) | MUX_PB11A_USART0_CTS)
-#define GPIO_PB11A_USART0_CTS    _UL(1 << 11)
-#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
-#define MUX_PA06B_USART0_RTS            _L(1)
+#define GPIO_PB11A_USART0_CTS    _UL_(1 << 11)
+#define PIN_PA06B_USART0_RTS            _L_(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L_(1)
 #define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
-#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
-#define PIN_PC01B_USART0_RTS           _L(65) /**< \brief USART0 signal: RTS on PC01 mux B */
-#define MUX_PC01B_USART0_RTS            _L(1)
+#define GPIO_PA06B_USART0_RTS    _UL_(1 <<  6)
+#define PIN_PC01B_USART0_RTS           _L_(65) /**< \brief USART0 signal: RTS on PC01 mux B */
+#define MUX_PC01B_USART0_RTS            _L_(1)
 #define PINMUX_PC01B_USART0_RTS    ((PIN_PC01B_USART0_RTS << 16) | MUX_PC01B_USART0_RTS)
-#define GPIO_PC01B_USART0_RTS    _UL(1 <<  1)
-#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
-#define MUX_PA08A_USART0_RTS            _L(0)
+#define GPIO_PC01B_USART0_RTS    _UL_(1 <<  1)
+#define PIN_PA08A_USART0_RTS            _L_(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L_(0)
 #define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
-#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
-#define PIN_PB12A_USART0_RTS           _L(44) /**< \brief USART0 signal: RTS on PB12 mux A */
-#define MUX_PB12A_USART0_RTS            _L(0)
+#define GPIO_PA08A_USART0_RTS    _UL_(1 <<  8)
+#define PIN_PB12A_USART0_RTS           _L_(44) /**< \brief USART0 signal: RTS on PB12 mux A */
+#define MUX_PB12A_USART0_RTS            _L_(0)
 #define PINMUX_PB12A_USART0_RTS    ((PIN_PB12A_USART0_RTS << 16) | MUX_PB12A_USART0_RTS)
-#define GPIO_PB12A_USART0_RTS    _UL(1 << 12)
-#define PIN_PC02C_USART0_RXD           _L(66) /**< \brief USART0 signal: RXD on PC02 mux C */
-#define MUX_PC02C_USART0_RXD            _L(2)
+#define GPIO_PB12A_USART0_RTS    _UL_(1 << 12)
+#define PIN_PC02C_USART0_RXD           _L_(66) /**< \brief USART0 signal: RXD on PC02 mux C */
+#define MUX_PC02C_USART0_RXD            _L_(2)
 #define PINMUX_PC02C_USART0_RXD    ((PIN_PC02C_USART0_RXD << 16) | MUX_PC02C_USART0_RXD)
-#define GPIO_PC02C_USART0_RXD    _UL(1 <<  2)
-#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
-#define MUX_PA05B_USART0_RXD            _L(1)
+#define GPIO_PC02C_USART0_RXD    _UL_(1 <<  2)
+#define PIN_PA05B_USART0_RXD            _L_(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L_(1)
 #define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
-#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
-#define PIN_PB00B_USART0_RXD           _L(32) /**< \brief USART0 signal: RXD on PB00 mux B */
-#define MUX_PB00B_USART0_RXD            _L(1)
+#define GPIO_PA05B_USART0_RXD    _UL_(1 <<  5)
+#define PIN_PB00B_USART0_RXD           _L_(32) /**< \brief USART0 signal: RXD on PB00 mux B */
+#define MUX_PB00B_USART0_RXD            _L_(1)
 #define PINMUX_PB00B_USART0_RXD    ((PIN_PB00B_USART0_RXD << 16) | MUX_PB00B_USART0_RXD)
-#define GPIO_PB00B_USART0_RXD    _UL(1 <<  0)
-#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
-#define MUX_PA11A_USART0_RXD            _L(0)
+#define GPIO_PB00B_USART0_RXD    _UL_(1 <<  0)
+#define PIN_PA11A_USART0_RXD           _L_(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L_(0)
 #define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
-#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
-#define PIN_PB14A_USART0_RXD           _L(46) /**< \brief USART0 signal: RXD on PB14 mux A */
-#define MUX_PB14A_USART0_RXD            _L(0)
+#define GPIO_PA11A_USART0_RXD    _UL_(1 << 11)
+#define PIN_PB14A_USART0_RXD           _L_(46) /**< \brief USART0 signal: RXD on PB14 mux A */
+#define MUX_PB14A_USART0_RXD            _L_(0)
 #define PINMUX_PB14A_USART0_RXD    ((PIN_PB14A_USART0_RXD << 16) | MUX_PB14A_USART0_RXD)
-#define GPIO_PB14A_USART0_RXD    _UL(1 << 14)
-#define PIN_PC03C_USART0_TXD           _L(67) /**< \brief USART0 signal: TXD on PC03 mux C */
-#define MUX_PC03C_USART0_TXD            _L(2)
+#define GPIO_PB14A_USART0_RXD    _UL_(1 << 14)
+#define PIN_PC03C_USART0_TXD           _L_(67) /**< \brief USART0 signal: TXD on PC03 mux C */
+#define MUX_PC03C_USART0_TXD            _L_(2)
 #define PINMUX_PC03C_USART0_TXD    ((PIN_PC03C_USART0_TXD << 16) | MUX_PC03C_USART0_TXD)
-#define GPIO_PC03C_USART0_TXD    _UL(1 <<  3)
-#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
-#define MUX_PA07B_USART0_TXD            _L(1)
+#define GPIO_PC03C_USART0_TXD    _UL_(1 <<  3)
+#define PIN_PA07B_USART0_TXD            _L_(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L_(1)
 #define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
-#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
-#define PIN_PB01B_USART0_TXD           _L(33) /**< \brief USART0 signal: TXD on PB01 mux B */
-#define MUX_PB01B_USART0_TXD            _L(1)
+#define GPIO_PA07B_USART0_TXD    _UL_(1 <<  7)
+#define PIN_PB01B_USART0_TXD           _L_(33) /**< \brief USART0 signal: TXD on PB01 mux B */
+#define MUX_PB01B_USART0_TXD            _L_(1)
 #define PINMUX_PB01B_USART0_TXD    ((PIN_PB01B_USART0_TXD << 16) | MUX_PB01B_USART0_TXD)
-#define GPIO_PB01B_USART0_TXD    _UL(1 <<  1)
-#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
-#define MUX_PA12A_USART0_TXD            _L(0)
+#define GPIO_PB01B_USART0_TXD    _UL_(1 <<  1)
+#define PIN_PA12A_USART0_TXD           _L_(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L_(0)
 #define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
-#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
-#define PIN_PB15A_USART0_TXD           _L(47) /**< \brief USART0 signal: TXD on PB15 mux A */
-#define MUX_PB15A_USART0_TXD            _L(0)
+#define GPIO_PA12A_USART0_TXD    _UL_(1 << 12)
+#define PIN_PB15A_USART0_TXD           _L_(47) /**< \brief USART0 signal: TXD on PB15 mux A */
+#define MUX_PB15A_USART0_TXD            _L_(0)
 #define PINMUX_PB15A_USART0_TXD    ((PIN_PB15A_USART0_TXD << 16) | MUX_PB15A_USART0_TXD)
-#define GPIO_PB15A_USART0_TXD    _UL(1 << 15)
+#define GPIO_PB15A_USART0_TXD    _UL_(1 << 15)
 /* ========== GPIO definition for USART1 peripheral ========== */
-#define PIN_PB03B_USART1_CLK           _L(35) /**< \brief USART1 signal: CLK on PB03 mux B */
-#define MUX_PB03B_USART1_CLK            _L(1)
+#define PIN_PB03B_USART1_CLK           _L_(35) /**< \brief USART1 signal: CLK on PB03 mux B */
+#define MUX_PB03B_USART1_CLK            _L_(1)
 #define PINMUX_PB03B_USART1_CLK    ((PIN_PB03B_USART1_CLK << 16) | MUX_PB03B_USART1_CLK)
-#define GPIO_PB03B_USART1_CLK    _UL(1 <<  3)
-#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
-#define MUX_PA14A_USART1_CLK            _L(0)
+#define GPIO_PB03B_USART1_CLK    _UL_(1 <<  3)
+#define PIN_PA14A_USART1_CLK           _L_(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L_(0)
 #define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
-#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
-#define PIN_PC25A_USART1_CLK           _L(89) /**< \brief USART1 signal: CLK on PC25 mux A */
-#define MUX_PC25A_USART1_CLK            _L(0)
+#define GPIO_PA14A_USART1_CLK    _UL_(1 << 14)
+#define PIN_PC25A_USART1_CLK           _L_(89) /**< \brief USART1 signal: CLK on PC25 mux A */
+#define MUX_PC25A_USART1_CLK            _L_(0)
 #define PINMUX_PC25A_USART1_CLK    ((PIN_PC25A_USART1_CLK << 16) | MUX_PC25A_USART1_CLK)
-#define GPIO_PC25A_USART1_CLK    _UL(1 << 25)
-#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
-#define MUX_PA21B_USART1_CTS            _L(1)
+#define GPIO_PC25A_USART1_CLK    _UL_(1 << 25)
+#define PIN_PA21B_USART1_CTS           _L_(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L_(1)
 #define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
-#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
-#define PIN_PB02B_USART1_RTS           _L(34) /**< \brief USART1 signal: RTS on PB02 mux B */
-#define MUX_PB02B_USART1_RTS            _L(1)
+#define GPIO_PA21B_USART1_CTS    _UL_(1 << 21)
+#define PIN_PB02B_USART1_RTS           _L_(34) /**< \brief USART1 signal: RTS on PB02 mux B */
+#define MUX_PB02B_USART1_RTS            _L_(1)
 #define PINMUX_PB02B_USART1_RTS    ((PIN_PB02B_USART1_RTS << 16) | MUX_PB02B_USART1_RTS)
-#define GPIO_PB02B_USART1_RTS    _UL(1 <<  2)
-#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
-#define MUX_PA13A_USART1_RTS            _L(0)
+#define GPIO_PB02B_USART1_RTS    _UL_(1 <<  2)
+#define PIN_PA13A_USART1_RTS           _L_(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L_(0)
 #define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
-#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
-#define PIN_PC24A_USART1_RTS           _L(88) /**< \brief USART1 signal: RTS on PC24 mux A */
-#define MUX_PC24A_USART1_RTS            _L(0)
+#define GPIO_PA13A_USART1_RTS    _UL_(1 << 13)
+#define PIN_PC24A_USART1_RTS           _L_(88) /**< \brief USART1 signal: RTS on PC24 mux A */
+#define MUX_PC24A_USART1_RTS            _L_(0)
 #define PINMUX_PC24A_USART1_RTS    ((PIN_PC24A_USART1_RTS << 16) | MUX_PC24A_USART1_RTS)
-#define GPIO_PC24A_USART1_RTS    _UL(1 << 24)
-#define PIN_PB04B_USART1_RXD           _L(36) /**< \brief USART1 signal: RXD on PB04 mux B */
-#define MUX_PB04B_USART1_RXD            _L(1)
+#define GPIO_PC24A_USART1_RTS    _UL_(1 << 24)
+#define PIN_PB04B_USART1_RXD           _L_(36) /**< \brief USART1 signal: RXD on PB04 mux B */
+#define MUX_PB04B_USART1_RXD            _L_(1)
 #define PINMUX_PB04B_USART1_RXD    ((PIN_PB04B_USART1_RXD << 16) | MUX_PB04B_USART1_RXD)
-#define GPIO_PB04B_USART1_RXD    _UL(1 <<  4)
-#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
-#define MUX_PA15A_USART1_RXD            _L(0)
+#define GPIO_PB04B_USART1_RXD    _UL_(1 <<  4)
+#define PIN_PA15A_USART1_RXD           _L_(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L_(0)
 #define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
-#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
-#define PIN_PC26A_USART1_RXD           _L(90) /**< \brief USART1 signal: RXD on PC26 mux A */
-#define MUX_PC26A_USART1_RXD            _L(0)
+#define GPIO_PA15A_USART1_RXD    _UL_(1 << 15)
+#define PIN_PC26A_USART1_RXD           _L_(90) /**< \brief USART1 signal: RXD on PC26 mux A */
+#define MUX_PC26A_USART1_RXD            _L_(0)
 #define PINMUX_PC26A_USART1_RXD    ((PIN_PC26A_USART1_RXD << 16) | MUX_PC26A_USART1_RXD)
-#define GPIO_PC26A_USART1_RXD    _UL(1 << 26)
-#define PIN_PB05B_USART1_TXD           _L(37) /**< \brief USART1 signal: TXD on PB05 mux B */
-#define MUX_PB05B_USART1_TXD            _L(1)
+#define GPIO_PC26A_USART1_RXD    _UL_(1 << 26)
+#define PIN_PB05B_USART1_TXD           _L_(37) /**< \brief USART1 signal: TXD on PB05 mux B */
+#define MUX_PB05B_USART1_TXD            _L_(1)
 #define PINMUX_PB05B_USART1_TXD    ((PIN_PB05B_USART1_TXD << 16) | MUX_PB05B_USART1_TXD)
-#define GPIO_PB05B_USART1_TXD    _UL(1 <<  5)
-#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
-#define MUX_PA16A_USART1_TXD            _L(0)
+#define GPIO_PB05B_USART1_TXD    _UL_(1 <<  5)
+#define PIN_PA16A_USART1_TXD           _L_(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L_(0)
 #define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
-#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
-#define PIN_PC27A_USART1_TXD           _L(91) /**< \brief USART1 signal: TXD on PC27 mux A */
-#define MUX_PC27A_USART1_TXD            _L(0)
+#define GPIO_PA16A_USART1_TXD    _UL_(1 << 16)
+#define PIN_PC27A_USART1_TXD           _L_(91) /**< \brief USART1 signal: TXD on PC27 mux A */
+#define MUX_PC27A_USART1_TXD            _L_(0)
 #define PINMUX_PC27A_USART1_TXD    ((PIN_PC27A_USART1_TXD << 16) | MUX_PC27A_USART1_TXD)
-#define GPIO_PC27A_USART1_TXD    _UL(1 << 27)
+#define GPIO_PC27A_USART1_TXD    _UL_(1 << 27)
 /* ========== GPIO definition for USART2 peripheral ========== */
-#define PIN_PC08B_USART2_CLK           _L(72) /**< \brief USART2 signal: CLK on PC08 mux B */
-#define MUX_PC08B_USART2_CLK            _L(1)
+#define PIN_PC08B_USART2_CLK           _L_(72) /**< \brief USART2 signal: CLK on PC08 mux B */
+#define MUX_PC08B_USART2_CLK            _L_(1)
 #define PINMUX_PC08B_USART2_CLK    ((PIN_PC08B_USART2_CLK << 16) | MUX_PC08B_USART2_CLK)
-#define GPIO_PC08B_USART2_CLK    _UL(1 <<  8)
-#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
-#define MUX_PA18A_USART2_CLK            _L(0)
+#define GPIO_PC08B_USART2_CLK    _UL_(1 <<  8)
+#define PIN_PA18A_USART2_CLK           _L_(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L_(0)
 #define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
-#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
-#define PIN_PC08E_USART2_CTS           _L(72) /**< \brief USART2 signal: CTS on PC08 mux E */
-#define MUX_PC08E_USART2_CTS            _L(4)
+#define GPIO_PA18A_USART2_CLK    _UL_(1 << 18)
+#define PIN_PC08E_USART2_CTS           _L_(72) /**< \brief USART2 signal: CTS on PC08 mux E */
+#define MUX_PC08E_USART2_CTS            _L_(4)
 #define PINMUX_PC08E_USART2_CTS    ((PIN_PC08E_USART2_CTS << 16) | MUX_PC08E_USART2_CTS)
-#define GPIO_PC08E_USART2_CTS    _UL(1 <<  8)
-#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
-#define MUX_PA22B_USART2_CTS            _L(1)
+#define GPIO_PC08E_USART2_CTS    _UL_(1 <<  8)
+#define PIN_PA22B_USART2_CTS           _L_(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L_(1)
 #define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
-#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
-#define PIN_PC07B_USART2_RTS           _L(71) /**< \brief USART2 signal: RTS on PC07 mux B */
-#define MUX_PC07B_USART2_RTS            _L(1)
+#define GPIO_PA22B_USART2_CTS    _UL_(1 << 22)
+#define PIN_PC07B_USART2_RTS           _L_(71) /**< \brief USART2 signal: RTS on PC07 mux B */
+#define MUX_PC07B_USART2_RTS            _L_(1)
 #define PINMUX_PC07B_USART2_RTS    ((PIN_PC07B_USART2_RTS << 16) | MUX_PC07B_USART2_RTS)
-#define GPIO_PC07B_USART2_RTS    _UL(1 <<  7)
-#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
-#define MUX_PA17A_USART2_RTS            _L(0)
+#define GPIO_PC07B_USART2_RTS    _UL_(1 <<  7)
+#define PIN_PA17A_USART2_RTS           _L_(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L_(0)
 #define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
-#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
-#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
-#define MUX_PA25B_USART2_RXD            _L(1)
+#define GPIO_PA17A_USART2_RTS    _UL_(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L_(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L_(1)
 #define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
-#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
-#define PIN_PC11B_USART2_RXD           _L(75) /**< \brief USART2 signal: RXD on PC11 mux B */
-#define MUX_PC11B_USART2_RXD            _L(1)
+#define GPIO_PA25B_USART2_RXD    _UL_(1 << 25)
+#define PIN_PC11B_USART2_RXD           _L_(75) /**< \brief USART2 signal: RXD on PC11 mux B */
+#define MUX_PC11B_USART2_RXD            _L_(1)
 #define PINMUX_PC11B_USART2_RXD    ((PIN_PC11B_USART2_RXD << 16) | MUX_PC11B_USART2_RXD)
-#define GPIO_PC11B_USART2_RXD    _UL(1 << 11)
-#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
-#define MUX_PA19A_USART2_RXD            _L(0)
+#define GPIO_PC11B_USART2_RXD    _UL_(1 << 11)
+#define PIN_PA19A_USART2_RXD           _L_(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L_(0)
 #define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
-#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
-#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
-#define MUX_PA26B_USART2_TXD            _L(1)
+#define GPIO_PA19A_USART2_RXD    _UL_(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L_(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L_(1)
 #define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
-#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
-#define PIN_PC12B_USART2_TXD           _L(76) /**< \brief USART2 signal: TXD on PC12 mux B */
-#define MUX_PC12B_USART2_TXD            _L(1)
+#define GPIO_PA26B_USART2_TXD    _UL_(1 << 26)
+#define PIN_PC12B_USART2_TXD           _L_(76) /**< \brief USART2 signal: TXD on PC12 mux B */
+#define MUX_PC12B_USART2_TXD            _L_(1)
 #define PINMUX_PC12B_USART2_TXD    ((PIN_PC12B_USART2_TXD << 16) | MUX_PC12B_USART2_TXD)
-#define GPIO_PC12B_USART2_TXD    _UL(1 << 12)
-#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
-#define MUX_PA20A_USART2_TXD            _L(0)
+#define GPIO_PC12B_USART2_TXD    _UL_(1 << 12)
+#define PIN_PA20A_USART2_TXD           _L_(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L_(0)
 #define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
-#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+#define GPIO_PA20A_USART2_TXD    _UL_(1 << 20)
 /* ========== GPIO definition for USART3 peripheral ========== */
-#define PIN_PC14B_USART3_CLK           _L(78) /**< \brief USART3 signal: CLK on PC14 mux B */
-#define MUX_PC14B_USART3_CLK            _L(1)
+#define PIN_PC14B_USART3_CLK           _L_(78) /**< \brief USART3 signal: CLK on PC14 mux B */
+#define MUX_PC14B_USART3_CLK            _L_(1)
 #define PINMUX_PC14B_USART3_CLK    ((PIN_PC14B_USART3_CLK << 16) | MUX_PC14B_USART3_CLK)
-#define GPIO_PC14B_USART3_CLK    _UL(1 << 14)
-#define PIN_PB08A_USART3_CLK           _L(40) /**< \brief USART3 signal: CLK on PB08 mux A */
-#define MUX_PB08A_USART3_CLK            _L(0)
+#define GPIO_PC14B_USART3_CLK    _UL_(1 << 14)
+#define PIN_PB08A_USART3_CLK           _L_(40) /**< \brief USART3 signal: CLK on PB08 mux A */
+#define MUX_PB08A_USART3_CLK            _L_(0)
 #define PINMUX_PB08A_USART3_CLK    ((PIN_PB08A_USART3_CLK << 16) | MUX_PB08A_USART3_CLK)
-#define GPIO_PB08A_USART3_CLK    _UL(1 <<  8)
-#define PIN_PC31A_USART3_CLK           _L(95) /**< \brief USART3 signal: CLK on PC31 mux A */
-#define MUX_PC31A_USART3_CLK            _L(0)
+#define GPIO_PB08A_USART3_CLK    _UL_(1 <<  8)
+#define PIN_PC31A_USART3_CLK           _L_(95) /**< \brief USART3 signal: CLK on PC31 mux A */
+#define MUX_PC31A_USART3_CLK            _L_(0)
 #define PINMUX_PC31A_USART3_CLK    ((PIN_PC31A_USART3_CLK << 16) | MUX_PC31A_USART3_CLK)
-#define GPIO_PC31A_USART3_CLK    _UL(1 << 31)
-#define PIN_PB07A_USART3_CTS           _L(39) /**< \brief USART3 signal: CTS on PB07 mux A */
-#define MUX_PB07A_USART3_CTS            _L(0)
+#define GPIO_PC31A_USART3_CLK    _UL_(1 << 31)
+#define PIN_PB07A_USART3_CTS           _L_(39) /**< \brief USART3 signal: CTS on PB07 mux A */
+#define MUX_PB07A_USART3_CTS            _L_(0)
 #define PINMUX_PB07A_USART3_CTS    ((PIN_PB07A_USART3_CTS << 16) | MUX_PB07A_USART3_CTS)
-#define GPIO_PB07A_USART3_CTS    _UL(1 <<  7)
-#define PIN_PC13B_USART3_RTS           _L(77) /**< \brief USART3 signal: RTS on PC13 mux B */
-#define MUX_PC13B_USART3_RTS            _L(1)
+#define GPIO_PB07A_USART3_CTS    _UL_(1 <<  7)
+#define PIN_PC13B_USART3_RTS           _L_(77) /**< \brief USART3 signal: RTS on PC13 mux B */
+#define MUX_PC13B_USART3_RTS            _L_(1)
 #define PINMUX_PC13B_USART3_RTS    ((PIN_PC13B_USART3_RTS << 16) | MUX_PC13B_USART3_RTS)
-#define GPIO_PC13B_USART3_RTS    _UL(1 << 13)
-#define PIN_PB06A_USART3_RTS           _L(38) /**< \brief USART3 signal: RTS on PB06 mux A */
-#define MUX_PB06A_USART3_RTS            _L(0)
+#define GPIO_PC13B_USART3_RTS    _UL_(1 << 13)
+#define PIN_PB06A_USART3_RTS           _L_(38) /**< \brief USART3 signal: RTS on PB06 mux A */
+#define MUX_PB06A_USART3_RTS            _L_(0)
 #define PINMUX_PB06A_USART3_RTS    ((PIN_PB06A_USART3_RTS << 16) | MUX_PB06A_USART3_RTS)
-#define GPIO_PB06A_USART3_RTS    _UL(1 <<  6)
-#define PIN_PC30A_USART3_RTS           _L(94) /**< \brief USART3 signal: RTS on PC30 mux A */
-#define MUX_PC30A_USART3_RTS            _L(0)
+#define GPIO_PB06A_USART3_RTS    _UL_(1 <<  6)
+#define PIN_PC30A_USART3_RTS           _L_(94) /**< \brief USART3 signal: RTS on PC30 mux A */
+#define MUX_PC30A_USART3_RTS            _L_(0)
 #define PINMUX_PC30A_USART3_RTS    ((PIN_PC30A_USART3_RTS << 16) | MUX_PC30A_USART3_RTS)
-#define GPIO_PC30A_USART3_RTS    _UL(1 << 30)
-#define PIN_PC09B_USART3_RXD           _L(73) /**< \brief USART3 signal: RXD on PC09 mux B */
-#define MUX_PC09B_USART3_RXD            _L(1)
+#define GPIO_PC30A_USART3_RTS    _UL_(1 << 30)
+#define PIN_PC09B_USART3_RXD           _L_(73) /**< \brief USART3 signal: RXD on PC09 mux B */
+#define MUX_PC09B_USART3_RXD            _L_(1)
 #define PINMUX_PC09B_USART3_RXD    ((PIN_PC09B_USART3_RXD << 16) | MUX_PC09B_USART3_RXD)
-#define GPIO_PC09B_USART3_RXD    _UL(1 <<  9)
-#define PIN_PB09A_USART3_RXD           _L(41) /**< \brief USART3 signal: RXD on PB09 mux A */
-#define MUX_PB09A_USART3_RXD            _L(0)
+#define GPIO_PC09B_USART3_RXD    _UL_(1 <<  9)
+#define PIN_PB09A_USART3_RXD           _L_(41) /**< \brief USART3 signal: RXD on PB09 mux A */
+#define MUX_PB09A_USART3_RXD            _L_(0)
 #define PINMUX_PB09A_USART3_RXD    ((PIN_PB09A_USART3_RXD << 16) | MUX_PB09A_USART3_RXD)
-#define GPIO_PB09A_USART3_RXD    _UL(1 <<  9)
-#define PIN_PC28A_USART3_RXD           _L(92) /**< \brief USART3 signal: RXD on PC28 mux A */
-#define MUX_PC28A_USART3_RXD            _L(0)
+#define GPIO_PB09A_USART3_RXD    _UL_(1 <<  9)
+#define PIN_PC28A_USART3_RXD           _L_(92) /**< \brief USART3 signal: RXD on PC28 mux A */
+#define MUX_PC28A_USART3_RXD            _L_(0)
 #define PINMUX_PC28A_USART3_RXD    ((PIN_PC28A_USART3_RXD << 16) | MUX_PC28A_USART3_RXD)
-#define GPIO_PC28A_USART3_RXD    _UL(1 << 28)
-#define PIN_PC10B_USART3_TXD           _L(74) /**< \brief USART3 signal: TXD on PC10 mux B */
-#define MUX_PC10B_USART3_TXD            _L(1)
+#define GPIO_PC28A_USART3_RXD    _UL_(1 << 28)
+#define PIN_PC10B_USART3_TXD           _L_(74) /**< \brief USART3 signal: TXD on PC10 mux B */
+#define MUX_PC10B_USART3_TXD            _L_(1)
 #define PINMUX_PC10B_USART3_TXD    ((PIN_PC10B_USART3_TXD << 16) | MUX_PC10B_USART3_TXD)
-#define GPIO_PC10B_USART3_TXD    _UL(1 << 10)
-#define PIN_PB10A_USART3_TXD           _L(42) /**< \brief USART3 signal: TXD on PB10 mux A */
-#define MUX_PB10A_USART3_TXD            _L(0)
+#define GPIO_PC10B_USART3_TXD    _UL_(1 << 10)
+#define PIN_PB10A_USART3_TXD           _L_(42) /**< \brief USART3 signal: TXD on PB10 mux A */
+#define MUX_PB10A_USART3_TXD            _L_(0)
 #define PINMUX_PB10A_USART3_TXD    ((PIN_PB10A_USART3_TXD << 16) | MUX_PB10A_USART3_TXD)
-#define GPIO_PB10A_USART3_TXD    _UL(1 << 10)
-#define PIN_PC29A_USART3_TXD           _L(93) /**< \brief USART3 signal: TXD on PC29 mux A */
-#define MUX_PC29A_USART3_TXD            _L(0)
+#define GPIO_PB10A_USART3_TXD    _UL_(1 << 10)
+#define PIN_PC29A_USART3_TXD           _L_(93) /**< \brief USART3 signal: TXD on PC29 mux A */
+#define MUX_PC29A_USART3_TXD            _L_(0)
 #define PINMUX_PC29A_USART3_TXD    ((PIN_PC29A_USART3_TXD << 16) | MUX_PC29A_USART3_TXD)
-#define GPIO_PC29A_USART3_TXD    _UL(1 << 29)
+#define GPIO_PC29A_USART3_TXD    _UL_(1 << 29)
 /* ========== GPIO definition for ADCIFE peripheral ========== */
-#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
-#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PIN_PA04A_ADCIFE_AD0            _L_(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L_(0)
 #define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
-#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
-#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
-#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL_(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L_(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L_(0)
 #define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
-#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
-#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
-#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define GPIO_PA05A_ADCIFE_AD1    _UL_(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L_(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L_(0)
 #define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
-#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
-#define PIN_PB02A_ADCIFE_AD3           _L(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
-#define MUX_PB02A_ADCIFE_AD3            _L(0)
+#define GPIO_PA07A_ADCIFE_AD2    _UL_(1 <<  7)
+#define PIN_PB02A_ADCIFE_AD3           _L_(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
+#define MUX_PB02A_ADCIFE_AD3            _L_(0)
 #define PINMUX_PB02A_ADCIFE_AD3    ((PIN_PB02A_ADCIFE_AD3 << 16) | MUX_PB02A_ADCIFE_AD3)
-#define GPIO_PB02A_ADCIFE_AD3    _UL(1 <<  2)
-#define PIN_PB03A_ADCIFE_AD4           _L(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
-#define MUX_PB03A_ADCIFE_AD4            _L(0)
+#define GPIO_PB02A_ADCIFE_AD3    _UL_(1 <<  2)
+#define PIN_PB03A_ADCIFE_AD4           _L_(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
+#define MUX_PB03A_ADCIFE_AD4            _L_(0)
 #define PINMUX_PB03A_ADCIFE_AD4    ((PIN_PB03A_ADCIFE_AD4 << 16) | MUX_PB03A_ADCIFE_AD4)
-#define GPIO_PB03A_ADCIFE_AD4    _UL(1 <<  3)
-#define PIN_PB04A_ADCIFE_AD5           _L(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
-#define MUX_PB04A_ADCIFE_AD5            _L(0)
+#define GPIO_PB03A_ADCIFE_AD4    _UL_(1 <<  3)
+#define PIN_PB04A_ADCIFE_AD5           _L_(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
+#define MUX_PB04A_ADCIFE_AD5            _L_(0)
 #define PINMUX_PB04A_ADCIFE_AD5    ((PIN_PB04A_ADCIFE_AD5 << 16) | MUX_PB04A_ADCIFE_AD5)
-#define GPIO_PB04A_ADCIFE_AD5    _UL(1 <<  4)
-#define PIN_PB05A_ADCIFE_AD6           _L(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
-#define MUX_PB05A_ADCIFE_AD6            _L(0)
+#define GPIO_PB04A_ADCIFE_AD5    _UL_(1 <<  4)
+#define PIN_PB05A_ADCIFE_AD6           _L_(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
+#define MUX_PB05A_ADCIFE_AD6            _L_(0)
 #define PINMUX_PB05A_ADCIFE_AD6    ((PIN_PB05A_ADCIFE_AD6 << 16) | MUX_PB05A_ADCIFE_AD6)
-#define GPIO_PB05A_ADCIFE_AD6    _UL(1 <<  5)
-#define PIN_PC07A_ADCIFE_AD7           _L(71) /**< \brief ADCIFE signal: AD7 on PC07 mux A */
-#define MUX_PC07A_ADCIFE_AD7            _L(0)
+#define GPIO_PB05A_ADCIFE_AD6    _UL_(1 <<  5)
+#define PIN_PC07A_ADCIFE_AD7           _L_(71) /**< \brief ADCIFE signal: AD7 on PC07 mux A */
+#define MUX_PC07A_ADCIFE_AD7            _L_(0)
 #define PINMUX_PC07A_ADCIFE_AD7    ((PIN_PC07A_ADCIFE_AD7 << 16) | MUX_PC07A_ADCIFE_AD7)
-#define GPIO_PC07A_ADCIFE_AD7    _UL(1 <<  7)
-#define PIN_PC08A_ADCIFE_AD8           _L(72) /**< \brief ADCIFE signal: AD8 on PC08 mux A */
-#define MUX_PC08A_ADCIFE_AD8            _L(0)
+#define GPIO_PC07A_ADCIFE_AD7    _UL_(1 <<  7)
+#define PIN_PC08A_ADCIFE_AD8           _L_(72) /**< \brief ADCIFE signal: AD8 on PC08 mux A */
+#define MUX_PC08A_ADCIFE_AD8            _L_(0)
 #define PINMUX_PC08A_ADCIFE_AD8    ((PIN_PC08A_ADCIFE_AD8 << 16) | MUX_PC08A_ADCIFE_AD8)
-#define GPIO_PC08A_ADCIFE_AD8    _UL(1 <<  8)
-#define PIN_PC09A_ADCIFE_AD9           _L(73) /**< \brief ADCIFE signal: AD9 on PC09 mux A */
-#define MUX_PC09A_ADCIFE_AD9            _L(0)
+#define GPIO_PC08A_ADCIFE_AD8    _UL_(1 <<  8)
+#define PIN_PC09A_ADCIFE_AD9           _L_(73) /**< \brief ADCIFE signal: AD9 on PC09 mux A */
+#define MUX_PC09A_ADCIFE_AD9            _L_(0)
 #define PINMUX_PC09A_ADCIFE_AD9    ((PIN_PC09A_ADCIFE_AD9 << 16) | MUX_PC09A_ADCIFE_AD9)
-#define GPIO_PC09A_ADCIFE_AD9    _UL(1 <<  9)
-#define PIN_PC10A_ADCIFE_AD10          _L(74) /**< \brief ADCIFE signal: AD10 on PC10 mux A */
-#define MUX_PC10A_ADCIFE_AD10           _L(0)
+#define GPIO_PC09A_ADCIFE_AD9    _UL_(1 <<  9)
+#define PIN_PC10A_ADCIFE_AD10          _L_(74) /**< \brief ADCIFE signal: AD10 on PC10 mux A */
+#define MUX_PC10A_ADCIFE_AD10           _L_(0)
 #define PINMUX_PC10A_ADCIFE_AD10   ((PIN_PC10A_ADCIFE_AD10 << 16) | MUX_PC10A_ADCIFE_AD10)
-#define GPIO_PC10A_ADCIFE_AD10   _UL(1 << 10)
-#define PIN_PC11A_ADCIFE_AD11          _L(75) /**< \brief ADCIFE signal: AD11 on PC11 mux A */
-#define MUX_PC11A_ADCIFE_AD11           _L(0)
+#define GPIO_PC10A_ADCIFE_AD10   _UL_(1 << 10)
+#define PIN_PC11A_ADCIFE_AD11          _L_(75) /**< \brief ADCIFE signal: AD11 on PC11 mux A */
+#define MUX_PC11A_ADCIFE_AD11           _L_(0)
 #define PINMUX_PC11A_ADCIFE_AD11   ((PIN_PC11A_ADCIFE_AD11 << 16) | MUX_PC11A_ADCIFE_AD11)
-#define GPIO_PC11A_ADCIFE_AD11   _UL(1 << 11)
-#define PIN_PC12A_ADCIFE_AD12          _L(76) /**< \brief ADCIFE signal: AD12 on PC12 mux A */
-#define MUX_PC12A_ADCIFE_AD12           _L(0)
+#define GPIO_PC11A_ADCIFE_AD11   _UL_(1 << 11)
+#define PIN_PC12A_ADCIFE_AD12          _L_(76) /**< \brief ADCIFE signal: AD12 on PC12 mux A */
+#define MUX_PC12A_ADCIFE_AD12           _L_(0)
 #define PINMUX_PC12A_ADCIFE_AD12   ((PIN_PC12A_ADCIFE_AD12 << 16) | MUX_PC12A_ADCIFE_AD12)
-#define GPIO_PC12A_ADCIFE_AD12   _UL(1 << 12)
-#define PIN_PC13A_ADCIFE_AD13          _L(77) /**< \brief ADCIFE signal: AD13 on PC13 mux A */
-#define MUX_PC13A_ADCIFE_AD13           _L(0)
+#define GPIO_PC12A_ADCIFE_AD12   _UL_(1 << 12)
+#define PIN_PC13A_ADCIFE_AD13          _L_(77) /**< \brief ADCIFE signal: AD13 on PC13 mux A */
+#define MUX_PC13A_ADCIFE_AD13           _L_(0)
 #define PINMUX_PC13A_ADCIFE_AD13   ((PIN_PC13A_ADCIFE_AD13 << 16) | MUX_PC13A_ADCIFE_AD13)
-#define GPIO_PC13A_ADCIFE_AD13   _UL(1 << 13)
-#define PIN_PC14A_ADCIFE_AD14          _L(78) /**< \brief ADCIFE signal: AD14 on PC14 mux A */
-#define MUX_PC14A_ADCIFE_AD14           _L(0)
+#define GPIO_PC13A_ADCIFE_AD13   _UL_(1 << 13)
+#define PIN_PC14A_ADCIFE_AD14          _L_(78) /**< \brief ADCIFE signal: AD14 on PC14 mux A */
+#define MUX_PC14A_ADCIFE_AD14           _L_(0)
 #define PINMUX_PC14A_ADCIFE_AD14   ((PIN_PC14A_ADCIFE_AD14 << 16) | MUX_PC14A_ADCIFE_AD14)
-#define GPIO_PC14A_ADCIFE_AD14   _UL(1 << 14)
-#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
-#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define GPIO_PC14A_ADCIFE_AD14   _UL_(1 << 14)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L_(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L_(4)
 #define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
-#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL_(1 <<  5)
 /* ========== GPIO definition for DACC peripheral ========== */
-#define PIN_PB04E_DACC_EXT_TRIG0       _L(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
-#define MUX_PB04E_DACC_EXT_TRIG0        _L(4)
+#define PIN_PB04E_DACC_EXT_TRIG0       _L_(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
+#define MUX_PB04E_DACC_EXT_TRIG0        _L_(4)
 #define PINMUX_PB04E_DACC_EXT_TRIG0  ((PIN_PB04E_DACC_EXT_TRIG0 << 16) | MUX_PB04E_DACC_EXT_TRIG0)
-#define GPIO_PB04E_DACC_EXT_TRIG0  _UL(1 <<  4)
-#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
-#define MUX_PA06A_DACC_VOUT             _L(0)
+#define GPIO_PB04E_DACC_EXT_TRIG0  _UL_(1 <<  4)
+#define PIN_PA06A_DACC_VOUT             _L_(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L_(0)
 #define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
-#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+#define GPIO_PA06A_DACC_VOUT     _UL_(1 <<  6)
 /* ========== GPIO definition for ACIFC peripheral ========== */
-#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
-#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PIN_PA06E_ACIFC_ACAN0           _L_(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L_(4)
 #define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
-#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
-#define PIN_PC09E_ACIFC_ACAN1          _L(73) /**< \brief ACIFC signal: ACAN1 on PC09 mux E */
-#define MUX_PC09E_ACIFC_ACAN1           _L(4)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL_(1 <<  6)
+#define PIN_PC09E_ACIFC_ACAN1          _L_(73) /**< \brief ACIFC signal: ACAN1 on PC09 mux E */
+#define MUX_PC09E_ACIFC_ACAN1           _L_(4)
 #define PINMUX_PC09E_ACIFC_ACAN1   ((PIN_PC09E_ACIFC_ACAN1 << 16) | MUX_PC09E_ACIFC_ACAN1)
-#define GPIO_PC09E_ACIFC_ACAN1   _UL(1 <<  9)
-#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
-#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define GPIO_PC09E_ACIFC_ACAN1   _UL_(1 <<  9)
+#define PIN_PA07E_ACIFC_ACAP0           _L_(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L_(4)
 #define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
-#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
-#define PIN_PC10E_ACIFC_ACAP1          _L(74) /**< \brief ACIFC signal: ACAP1 on PC10 mux E */
-#define MUX_PC10E_ACIFC_ACAP1           _L(4)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL_(1 <<  7)
+#define PIN_PC10E_ACIFC_ACAP1          _L_(74) /**< \brief ACIFC signal: ACAP1 on PC10 mux E */
+#define MUX_PC10E_ACIFC_ACAP1           _L_(4)
 #define PINMUX_PC10E_ACIFC_ACAP1   ((PIN_PC10E_ACIFC_ACAP1 << 16) | MUX_PC10E_ACIFC_ACAP1)
-#define GPIO_PC10E_ACIFC_ACAP1   _UL(1 << 10)
-#define PIN_PB02E_ACIFC_ACBN0          _L(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
-#define MUX_PB02E_ACIFC_ACBN0           _L(4)
+#define GPIO_PC10E_ACIFC_ACAP1   _UL_(1 << 10)
+#define PIN_PB02E_ACIFC_ACBN0          _L_(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
+#define MUX_PB02E_ACIFC_ACBN0           _L_(4)
 #define PINMUX_PB02E_ACIFC_ACBN0   ((PIN_PB02E_ACIFC_ACBN0 << 16) | MUX_PB02E_ACIFC_ACBN0)
-#define GPIO_PB02E_ACIFC_ACBN0   _UL(1 <<  2)
-#define PIN_PC13E_ACIFC_ACBN1          _L(77) /**< \brief ACIFC signal: ACBN1 on PC13 mux E */
-#define MUX_PC13E_ACIFC_ACBN1           _L(4)
+#define GPIO_PB02E_ACIFC_ACBN0   _UL_(1 <<  2)
+#define PIN_PC13E_ACIFC_ACBN1          _L_(77) /**< \brief ACIFC signal: ACBN1 on PC13 mux E */
+#define MUX_PC13E_ACIFC_ACBN1           _L_(4)
 #define PINMUX_PC13E_ACIFC_ACBN1   ((PIN_PC13E_ACIFC_ACBN1 << 16) | MUX_PC13E_ACIFC_ACBN1)
-#define GPIO_PC13E_ACIFC_ACBN1   _UL(1 << 13)
-#define PIN_PB03E_ACIFC_ACBP0          _L(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
-#define MUX_PB03E_ACIFC_ACBP0           _L(4)
+#define GPIO_PC13E_ACIFC_ACBN1   _UL_(1 << 13)
+#define PIN_PB03E_ACIFC_ACBP0          _L_(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
+#define MUX_PB03E_ACIFC_ACBP0           _L_(4)
 #define PINMUX_PB03E_ACIFC_ACBP0   ((PIN_PB03E_ACIFC_ACBP0 << 16) | MUX_PB03E_ACIFC_ACBP0)
-#define GPIO_PB03E_ACIFC_ACBP0   _UL(1 <<  3)
-#define PIN_PC14E_ACIFC_ACBP1          _L(78) /**< \brief ACIFC signal: ACBP1 on PC14 mux E */
-#define MUX_PC14E_ACIFC_ACBP1           _L(4)
+#define GPIO_PB03E_ACIFC_ACBP0   _UL_(1 <<  3)
+#define PIN_PC14E_ACIFC_ACBP1          _L_(78) /**< \brief ACIFC signal: ACBP1 on PC14 mux E */
+#define MUX_PC14E_ACIFC_ACBP1           _L_(4)
 #define PINMUX_PC14E_ACIFC_ACBP1   ((PIN_PC14E_ACIFC_ACBP1 << 16) | MUX_PC14E_ACIFC_ACBP1)
-#define GPIO_PC14E_ACIFC_ACBP1   _UL(1 << 14)
+#define GPIO_PC14E_ACIFC_ACBP1   _UL_(1 << 14)
 /* ========== GPIO definition for GLOC peripheral ========== */
-#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
-#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PIN_PA06D_GLOC_IN0              _L_(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L_(3)
 #define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
-#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
-#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
-#define MUX_PA20D_GLOC_IN0              _L(3)
+#define GPIO_PA06D_GLOC_IN0      _UL_(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L_(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L_(3)
 #define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
-#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
-#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
-#define MUX_PA04D_GLOC_IN1              _L(3)
+#define GPIO_PA20D_GLOC_IN0      _UL_(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L_(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L_(3)
 #define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
-#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
-#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
-#define MUX_PA21D_GLOC_IN1              _L(3)
+#define GPIO_PA04D_GLOC_IN1      _UL_(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L_(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L_(3)
 #define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
-#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
-#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
-#define MUX_PA05D_GLOC_IN2              _L(3)
+#define GPIO_PA21D_GLOC_IN1      _UL_(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L_(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L_(3)
 #define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
-#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
-#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
-#define MUX_PA22D_GLOC_IN2              _L(3)
+#define GPIO_PA05D_GLOC_IN2      _UL_(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L_(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L_(3)
 #define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
-#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
-#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
-#define MUX_PA07D_GLOC_IN3              _L(3)
+#define GPIO_PA22D_GLOC_IN2      _UL_(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L_(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L_(3)
 #define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
-#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
-#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
-#define MUX_PA23D_GLOC_IN3              _L(3)
+#define GPIO_PA07D_GLOC_IN3      _UL_(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L_(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L_(3)
 #define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
-#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
-#define PIN_PC15D_GLOC_IN4             _L(79) /**< \brief GLOC signal: IN4 on PC15 mux D */
-#define MUX_PC15D_GLOC_IN4              _L(3)
+#define GPIO_PA23D_GLOC_IN3      _UL_(1 << 23)
+#define PIN_PC15D_GLOC_IN4             _L_(79) /**< \brief GLOC signal: IN4 on PC15 mux D */
+#define MUX_PC15D_GLOC_IN4              _L_(3)
 #define PINMUX_PC15D_GLOC_IN4      ((PIN_PC15D_GLOC_IN4 << 16) | MUX_PC15D_GLOC_IN4)
-#define GPIO_PC15D_GLOC_IN4      _UL(1 << 15)
-#define PIN_PB06C_GLOC_IN4             _L(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
-#define MUX_PB06C_GLOC_IN4              _L(2)
+#define GPIO_PC15D_GLOC_IN4      _UL_(1 << 15)
+#define PIN_PB06C_GLOC_IN4             _L_(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
+#define MUX_PB06C_GLOC_IN4              _L_(2)
 #define PINMUX_PB06C_GLOC_IN4      ((PIN_PB06C_GLOC_IN4 << 16) | MUX_PB06C_GLOC_IN4)
-#define GPIO_PB06C_GLOC_IN4      _UL(1 <<  6)
-#define PIN_PC28C_GLOC_IN4             _L(92) /**< \brief GLOC signal: IN4 on PC28 mux C */
-#define MUX_PC28C_GLOC_IN4              _L(2)
+#define GPIO_PB06C_GLOC_IN4      _UL_(1 <<  6)
+#define PIN_PC28C_GLOC_IN4             _L_(92) /**< \brief GLOC signal: IN4 on PC28 mux C */
+#define MUX_PC28C_GLOC_IN4              _L_(2)
 #define PINMUX_PC28C_GLOC_IN4      ((PIN_PC28C_GLOC_IN4 << 16) | MUX_PC28C_GLOC_IN4)
-#define GPIO_PC28C_GLOC_IN4      _UL(1 << 28)
-#define PIN_PC16D_GLOC_IN5             _L(80) /**< \brief GLOC signal: IN5 on PC16 mux D */
-#define MUX_PC16D_GLOC_IN5              _L(3)
+#define GPIO_PC28C_GLOC_IN4      _UL_(1 << 28)
+#define PIN_PC16D_GLOC_IN5             _L_(80) /**< \brief GLOC signal: IN5 on PC16 mux D */
+#define MUX_PC16D_GLOC_IN5              _L_(3)
 #define PINMUX_PC16D_GLOC_IN5      ((PIN_PC16D_GLOC_IN5 << 16) | MUX_PC16D_GLOC_IN5)
-#define GPIO_PC16D_GLOC_IN5      _UL(1 << 16)
-#define PIN_PB07C_GLOC_IN5             _L(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
-#define MUX_PB07C_GLOC_IN5              _L(2)
+#define GPIO_PC16D_GLOC_IN5      _UL_(1 << 16)
+#define PIN_PB07C_GLOC_IN5             _L_(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
+#define MUX_PB07C_GLOC_IN5              _L_(2)
 #define PINMUX_PB07C_GLOC_IN5      ((PIN_PB07C_GLOC_IN5 << 16) | MUX_PB07C_GLOC_IN5)
-#define GPIO_PB07C_GLOC_IN5      _UL(1 <<  7)
-#define PIN_PC29C_GLOC_IN5             _L(93) /**< \brief GLOC signal: IN5 on PC29 mux C */
-#define MUX_PC29C_GLOC_IN5              _L(2)
+#define GPIO_PB07C_GLOC_IN5      _UL_(1 <<  7)
+#define PIN_PC29C_GLOC_IN5             _L_(93) /**< \brief GLOC signal: IN5 on PC29 mux C */
+#define MUX_PC29C_GLOC_IN5              _L_(2)
 #define PINMUX_PC29C_GLOC_IN5      ((PIN_PC29C_GLOC_IN5 << 16) | MUX_PC29C_GLOC_IN5)
-#define GPIO_PC29C_GLOC_IN5      _UL(1 << 29)
-#define PIN_PC17D_GLOC_IN6             _L(81) /**< \brief GLOC signal: IN6 on PC17 mux D */
-#define MUX_PC17D_GLOC_IN6              _L(3)
+#define GPIO_PC29C_GLOC_IN5      _UL_(1 << 29)
+#define PIN_PC17D_GLOC_IN6             _L_(81) /**< \brief GLOC signal: IN6 on PC17 mux D */
+#define MUX_PC17D_GLOC_IN6              _L_(3)
 #define PINMUX_PC17D_GLOC_IN6      ((PIN_PC17D_GLOC_IN6 << 16) | MUX_PC17D_GLOC_IN6)
-#define GPIO_PC17D_GLOC_IN6      _UL(1 << 17)
-#define PIN_PB08C_GLOC_IN6             _L(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
-#define MUX_PB08C_GLOC_IN6              _L(2)
+#define GPIO_PC17D_GLOC_IN6      _UL_(1 << 17)
+#define PIN_PB08C_GLOC_IN6             _L_(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
+#define MUX_PB08C_GLOC_IN6              _L_(2)
 #define PINMUX_PB08C_GLOC_IN6      ((PIN_PB08C_GLOC_IN6 << 16) | MUX_PB08C_GLOC_IN6)
-#define GPIO_PB08C_GLOC_IN6      _UL(1 <<  8)
-#define PIN_PC30C_GLOC_IN6             _L(94) /**< \brief GLOC signal: IN6 on PC30 mux C */
-#define MUX_PC30C_GLOC_IN6              _L(2)
+#define GPIO_PB08C_GLOC_IN6      _UL_(1 <<  8)
+#define PIN_PC30C_GLOC_IN6             _L_(94) /**< \brief GLOC signal: IN6 on PC30 mux C */
+#define MUX_PC30C_GLOC_IN6              _L_(2)
 #define PINMUX_PC30C_GLOC_IN6      ((PIN_PC30C_GLOC_IN6 << 16) | MUX_PC30C_GLOC_IN6)
-#define GPIO_PC30C_GLOC_IN6      _UL(1 << 30)
-#define PIN_PC18D_GLOC_IN7             _L(82) /**< \brief GLOC signal: IN7 on PC18 mux D */
-#define MUX_PC18D_GLOC_IN7              _L(3)
+#define GPIO_PC30C_GLOC_IN6      _UL_(1 << 30)
+#define PIN_PC18D_GLOC_IN7             _L_(82) /**< \brief GLOC signal: IN7 on PC18 mux D */
+#define MUX_PC18D_GLOC_IN7              _L_(3)
 #define PINMUX_PC18D_GLOC_IN7      ((PIN_PC18D_GLOC_IN7 << 16) | MUX_PC18D_GLOC_IN7)
-#define GPIO_PC18D_GLOC_IN7      _UL(1 << 18)
-#define PIN_PB09C_GLOC_IN7             _L(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
-#define MUX_PB09C_GLOC_IN7              _L(2)
+#define GPIO_PC18D_GLOC_IN7      _UL_(1 << 18)
+#define PIN_PB09C_GLOC_IN7             _L_(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
+#define MUX_PB09C_GLOC_IN7              _L_(2)
 #define PINMUX_PB09C_GLOC_IN7      ((PIN_PB09C_GLOC_IN7 << 16) | MUX_PB09C_GLOC_IN7)
-#define GPIO_PB09C_GLOC_IN7      _UL(1 <<  9)
-#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
-#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define GPIO_PB09C_GLOC_IN7      _UL_(1 <<  9)
+#define PIN_PA08D_GLOC_OUT0             _L_(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
-#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
-#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
-#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define GPIO_PA08D_GLOC_OUT0     _UL_(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L_(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
-#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
-#define PIN_PC19D_GLOC_OUT1            _L(83) /**< \brief GLOC signal: OUT1 on PC19 mux D */
-#define MUX_PC19D_GLOC_OUT1             _L(3)
+#define GPIO_PA24D_GLOC_OUT0     _UL_(1 << 24)
+#define PIN_PC19D_GLOC_OUT1            _L_(83) /**< \brief GLOC signal: OUT1 on PC19 mux D */
+#define MUX_PC19D_GLOC_OUT1             _L_(3)
 #define PINMUX_PC19D_GLOC_OUT1     ((PIN_PC19D_GLOC_OUT1 << 16) | MUX_PC19D_GLOC_OUT1)
-#define GPIO_PC19D_GLOC_OUT1     _UL(1 << 19)
-#define PIN_PB10C_GLOC_OUT1            _L(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
-#define MUX_PB10C_GLOC_OUT1             _L(2)
+#define GPIO_PC19D_GLOC_OUT1     _UL_(1 << 19)
+#define PIN_PB10C_GLOC_OUT1            _L_(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
+#define MUX_PB10C_GLOC_OUT1             _L_(2)
 #define PINMUX_PB10C_GLOC_OUT1     ((PIN_PB10C_GLOC_OUT1 << 16) | MUX_PB10C_GLOC_OUT1)
-#define GPIO_PB10C_GLOC_OUT1     _UL(1 << 10)
-#define PIN_PC31C_GLOC_OUT1            _L(95) /**< \brief GLOC signal: OUT1 on PC31 mux C */
-#define MUX_PC31C_GLOC_OUT1             _L(2)
+#define GPIO_PB10C_GLOC_OUT1     _UL_(1 << 10)
+#define PIN_PC31C_GLOC_OUT1            _L_(95) /**< \brief GLOC signal: OUT1 on PC31 mux C */
+#define MUX_PC31C_GLOC_OUT1             _L_(2)
 #define PINMUX_PC31C_GLOC_OUT1     ((PIN_PC31C_GLOC_OUT1 << 16) | MUX_PC31C_GLOC_OUT1)
-#define GPIO_PC31C_GLOC_OUT1     _UL(1 << 31)
+#define GPIO_PC31C_GLOC_OUT1     _UL_(1 << 31)
 /* ========== GPIO definition for ABDACB peripheral ========== */
-#define PIN_PC12C_ABDACB_CLK           _L(76) /**< \brief ABDACB signal: CLK on PC12 mux C */
-#define MUX_PC12C_ABDACB_CLK            _L(2)
+#define PIN_PC12C_ABDACB_CLK           _L_(76) /**< \brief ABDACB signal: CLK on PC12 mux C */
+#define MUX_PC12C_ABDACB_CLK            _L_(2)
 #define PINMUX_PC12C_ABDACB_CLK    ((PIN_PC12C_ABDACB_CLK << 16) | MUX_PC12C_ABDACB_CLK)
-#define GPIO_PC12C_ABDACB_CLK    _UL(1 << 12)
-#define PIN_PB02C_ABDACB_DAC0          _L(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
-#define MUX_PB02C_ABDACB_DAC0           _L(2)
+#define GPIO_PC12C_ABDACB_CLK    _UL_(1 << 12)
+#define PIN_PB02C_ABDACB_DAC0          _L_(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
+#define MUX_PB02C_ABDACB_DAC0           _L_(2)
 #define PINMUX_PB02C_ABDACB_DAC0   ((PIN_PB02C_ABDACB_DAC0 << 16) | MUX_PB02C_ABDACB_DAC0)
-#define GPIO_PB02C_ABDACB_DAC0   _UL(1 <<  2)
-#define PIN_PC09C_ABDACB_DAC0          _L(73) /**< \brief ABDACB signal: DAC0 on PC09 mux C */
-#define MUX_PC09C_ABDACB_DAC0           _L(2)
+#define GPIO_PB02C_ABDACB_DAC0   _UL_(1 <<  2)
+#define PIN_PC09C_ABDACB_DAC0          _L_(73) /**< \brief ABDACB signal: DAC0 on PC09 mux C */
+#define MUX_PC09C_ABDACB_DAC0           _L_(2)
 #define PINMUX_PC09C_ABDACB_DAC0   ((PIN_PC09C_ABDACB_DAC0 << 16) | MUX_PC09C_ABDACB_DAC0)
-#define GPIO_PC09C_ABDACB_DAC0   _UL(1 <<  9)
-#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
-#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define GPIO_PC09C_ABDACB_DAC0   _UL_(1 <<  9)
+#define PIN_PA17B_ABDACB_DAC0          _L_(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L_(1)
 #define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
-#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
-#define PIN_PB04C_ABDACB_DAC1          _L(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
-#define MUX_PB04C_ABDACB_DAC1           _L(2)
+#define GPIO_PA17B_ABDACB_DAC0   _UL_(1 << 17)
+#define PIN_PB04C_ABDACB_DAC1          _L_(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
+#define MUX_PB04C_ABDACB_DAC1           _L_(2)
 #define PINMUX_PB04C_ABDACB_DAC1   ((PIN_PB04C_ABDACB_DAC1 << 16) | MUX_PB04C_ABDACB_DAC1)
-#define GPIO_PB04C_ABDACB_DAC1   _UL(1 <<  4)
-#define PIN_PC13C_ABDACB_DAC1          _L(77) /**< \brief ABDACB signal: DAC1 on PC13 mux C */
-#define MUX_PC13C_ABDACB_DAC1           _L(2)
+#define GPIO_PB04C_ABDACB_DAC1   _UL_(1 <<  4)
+#define PIN_PC13C_ABDACB_DAC1          _L_(77) /**< \brief ABDACB signal: DAC1 on PC13 mux C */
+#define MUX_PC13C_ABDACB_DAC1           _L_(2)
 #define PINMUX_PC13C_ABDACB_DAC1   ((PIN_PC13C_ABDACB_DAC1 << 16) | MUX_PC13C_ABDACB_DAC1)
-#define GPIO_PC13C_ABDACB_DAC1   _UL(1 << 13)
-#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
-#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define GPIO_PC13C_ABDACB_DAC1   _UL_(1 << 13)
+#define PIN_PA19B_ABDACB_DAC1          _L_(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L_(1)
 #define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
-#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
-#define PIN_PB03C_ABDACB_DACN0         _L(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
-#define MUX_PB03C_ABDACB_DACN0          _L(2)
+#define GPIO_PA19B_ABDACB_DAC1   _UL_(1 << 19)
+#define PIN_PB03C_ABDACB_DACN0         _L_(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
+#define MUX_PB03C_ABDACB_DACN0          _L_(2)
 #define PINMUX_PB03C_ABDACB_DACN0  ((PIN_PB03C_ABDACB_DACN0 << 16) | MUX_PB03C_ABDACB_DACN0)
-#define GPIO_PB03C_ABDACB_DACN0  _UL(1 <<  3)
-#define PIN_PC10C_ABDACB_DACN0         _L(74) /**< \brief ABDACB signal: DACN0 on PC10 mux C */
-#define MUX_PC10C_ABDACB_DACN0          _L(2)
+#define GPIO_PB03C_ABDACB_DACN0  _UL_(1 <<  3)
+#define PIN_PC10C_ABDACB_DACN0         _L_(74) /**< \brief ABDACB signal: DACN0 on PC10 mux C */
+#define MUX_PC10C_ABDACB_DACN0          _L_(2)
 #define PINMUX_PC10C_ABDACB_DACN0  ((PIN_PC10C_ABDACB_DACN0 << 16) | MUX_PC10C_ABDACB_DACN0)
-#define GPIO_PC10C_ABDACB_DACN0  _UL(1 << 10)
-#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
-#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define GPIO_PC10C_ABDACB_DACN0  _UL_(1 << 10)
+#define PIN_PA18B_ABDACB_DACN0         _L_(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L_(1)
 #define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
-#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
-#define PIN_PB05C_ABDACB_DACN1         _L(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
-#define MUX_PB05C_ABDACB_DACN1          _L(2)
+#define GPIO_PA18B_ABDACB_DACN0  _UL_(1 << 18)
+#define PIN_PB05C_ABDACB_DACN1         _L_(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
+#define MUX_PB05C_ABDACB_DACN1          _L_(2)
 #define PINMUX_PB05C_ABDACB_DACN1  ((PIN_PB05C_ABDACB_DACN1 << 16) | MUX_PB05C_ABDACB_DACN1)
-#define GPIO_PB05C_ABDACB_DACN1  _UL(1 <<  5)
-#define PIN_PC14C_ABDACB_DACN1         _L(78) /**< \brief ABDACB signal: DACN1 on PC14 mux C */
-#define MUX_PC14C_ABDACB_DACN1          _L(2)
+#define GPIO_PB05C_ABDACB_DACN1  _UL_(1 <<  5)
+#define PIN_PC14C_ABDACB_DACN1         _L_(78) /**< \brief ABDACB signal: DACN1 on PC14 mux C */
+#define MUX_PC14C_ABDACB_DACN1          _L_(2)
 #define PINMUX_PC14C_ABDACB_DACN1  ((PIN_PC14C_ABDACB_DACN1 << 16) | MUX_PC14C_ABDACB_DACN1)
-#define GPIO_PC14C_ABDACB_DACN1  _UL(1 << 14)
-#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
-#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define GPIO_PC14C_ABDACB_DACN1  _UL_(1 << 14)
+#define PIN_PA20B_ABDACB_DACN1         _L_(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L_(1)
 #define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
-#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+#define GPIO_PA20B_ABDACB_DACN1  _UL_(1 << 20)
 /* ========== GPIO definition for PARC peripheral ========== */
-#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
-#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PIN_PA17D_PARC_PCCK            _L_(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L_(3)
 #define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
-#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
-#define PIN_PC21D_PARC_PCCK            _L(85) /**< \brief PARC signal: PCCK on PC21 mux D */
-#define MUX_PC21D_PARC_PCCK             _L(3)
+#define GPIO_PA17D_PARC_PCCK     _UL_(1 << 17)
+#define PIN_PC21D_PARC_PCCK            _L_(85) /**< \brief PARC signal: PCCK on PC21 mux D */
+#define MUX_PC21D_PARC_PCCK             _L_(3)
 #define PINMUX_PC21D_PARC_PCCK     ((PIN_PC21D_PARC_PCCK << 16) | MUX_PC21D_PARC_PCCK)
-#define GPIO_PC21D_PARC_PCCK     _UL(1 << 21)
-#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
-#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define GPIO_PC21D_PARC_PCCK     _UL_(1 << 21)
+#define PIN_PA09D_PARC_PCDATA0          _L_(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L_(3)
 #define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
-#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
-#define PIN_PC24D_PARC_PCDATA0         _L(88) /**< \brief PARC signal: PCDATA0 on PC24 mux D */
-#define MUX_PC24D_PARC_PCDATA0          _L(3)
+#define GPIO_PA09D_PARC_PCDATA0  _UL_(1 <<  9)
+#define PIN_PC24D_PARC_PCDATA0         _L_(88) /**< \brief PARC signal: PCDATA0 on PC24 mux D */
+#define MUX_PC24D_PARC_PCDATA0          _L_(3)
 #define PINMUX_PC24D_PARC_PCDATA0  ((PIN_PC24D_PARC_PCDATA0 << 16) | MUX_PC24D_PARC_PCDATA0)
-#define GPIO_PC24D_PARC_PCDATA0  _UL(1 << 24)
-#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
-#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define GPIO_PC24D_PARC_PCDATA0  _UL_(1 << 24)
+#define PIN_PA10D_PARC_PCDATA1         _L_(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L_(3)
 #define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
-#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
-#define PIN_PC25D_PARC_PCDATA1         _L(89) /**< \brief PARC signal: PCDATA1 on PC25 mux D */
-#define MUX_PC25D_PARC_PCDATA1          _L(3)
+#define GPIO_PA10D_PARC_PCDATA1  _UL_(1 << 10)
+#define PIN_PC25D_PARC_PCDATA1         _L_(89) /**< \brief PARC signal: PCDATA1 on PC25 mux D */
+#define MUX_PC25D_PARC_PCDATA1          _L_(3)
 #define PINMUX_PC25D_PARC_PCDATA1  ((PIN_PC25D_PARC_PCDATA1 << 16) | MUX_PC25D_PARC_PCDATA1)
-#define GPIO_PC25D_PARC_PCDATA1  _UL(1 << 25)
-#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
-#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define GPIO_PC25D_PARC_PCDATA1  _UL_(1 << 25)
+#define PIN_PA11D_PARC_PCDATA2         _L_(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L_(3)
 #define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
-#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
-#define PIN_PC26D_PARC_PCDATA2         _L(90) /**< \brief PARC signal: PCDATA2 on PC26 mux D */
-#define MUX_PC26D_PARC_PCDATA2          _L(3)
+#define GPIO_PA11D_PARC_PCDATA2  _UL_(1 << 11)
+#define PIN_PC26D_PARC_PCDATA2         _L_(90) /**< \brief PARC signal: PCDATA2 on PC26 mux D */
+#define MUX_PC26D_PARC_PCDATA2          _L_(3)
 #define PINMUX_PC26D_PARC_PCDATA2  ((PIN_PC26D_PARC_PCDATA2 << 16) | MUX_PC26D_PARC_PCDATA2)
-#define GPIO_PC26D_PARC_PCDATA2  _UL(1 << 26)
-#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
-#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define GPIO_PC26D_PARC_PCDATA2  _UL_(1 << 26)
+#define PIN_PA12D_PARC_PCDATA3         _L_(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L_(3)
 #define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
-#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
-#define PIN_PC27D_PARC_PCDATA3         _L(91) /**< \brief PARC signal: PCDATA3 on PC27 mux D */
-#define MUX_PC27D_PARC_PCDATA3          _L(3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL_(1 << 12)
+#define PIN_PC27D_PARC_PCDATA3         _L_(91) /**< \brief PARC signal: PCDATA3 on PC27 mux D */
+#define MUX_PC27D_PARC_PCDATA3          _L_(3)
 #define PINMUX_PC27D_PARC_PCDATA3  ((PIN_PC27D_PARC_PCDATA3 << 16) | MUX_PC27D_PARC_PCDATA3)
-#define GPIO_PC27D_PARC_PCDATA3  _UL(1 << 27)
-#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
-#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define GPIO_PC27D_PARC_PCDATA3  _UL_(1 << 27)
+#define PIN_PA13D_PARC_PCDATA4         _L_(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L_(3)
 #define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
-#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
-#define PIN_PC28D_PARC_PCDATA4         _L(92) /**< \brief PARC signal: PCDATA4 on PC28 mux D */
-#define MUX_PC28D_PARC_PCDATA4          _L(3)
+#define GPIO_PA13D_PARC_PCDATA4  _UL_(1 << 13)
+#define PIN_PC28D_PARC_PCDATA4         _L_(92) /**< \brief PARC signal: PCDATA4 on PC28 mux D */
+#define MUX_PC28D_PARC_PCDATA4          _L_(3)
 #define PINMUX_PC28D_PARC_PCDATA4  ((PIN_PC28D_PARC_PCDATA4 << 16) | MUX_PC28D_PARC_PCDATA4)
-#define GPIO_PC28D_PARC_PCDATA4  _UL(1 << 28)
-#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
-#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define GPIO_PC28D_PARC_PCDATA4  _UL_(1 << 28)
+#define PIN_PA14D_PARC_PCDATA5         _L_(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L_(3)
 #define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
-#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
-#define PIN_PC29D_PARC_PCDATA5         _L(93) /**< \brief PARC signal: PCDATA5 on PC29 mux D */
-#define MUX_PC29D_PARC_PCDATA5          _L(3)
+#define GPIO_PA14D_PARC_PCDATA5  _UL_(1 << 14)
+#define PIN_PC29D_PARC_PCDATA5         _L_(93) /**< \brief PARC signal: PCDATA5 on PC29 mux D */
+#define MUX_PC29D_PARC_PCDATA5          _L_(3)
 #define PINMUX_PC29D_PARC_PCDATA5  ((PIN_PC29D_PARC_PCDATA5 << 16) | MUX_PC29D_PARC_PCDATA5)
-#define GPIO_PC29D_PARC_PCDATA5  _UL(1 << 29)
-#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
-#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define GPIO_PC29D_PARC_PCDATA5  _UL_(1 << 29)
+#define PIN_PA15D_PARC_PCDATA6         _L_(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L_(3)
 #define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
-#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
-#define PIN_PC30D_PARC_PCDATA6         _L(94) /**< \brief PARC signal: PCDATA6 on PC30 mux D */
-#define MUX_PC30D_PARC_PCDATA6          _L(3)
+#define GPIO_PA15D_PARC_PCDATA6  _UL_(1 << 15)
+#define PIN_PC30D_PARC_PCDATA6         _L_(94) /**< \brief PARC signal: PCDATA6 on PC30 mux D */
+#define MUX_PC30D_PARC_PCDATA6          _L_(3)
 #define PINMUX_PC30D_PARC_PCDATA6  ((PIN_PC30D_PARC_PCDATA6 << 16) | MUX_PC30D_PARC_PCDATA6)
-#define GPIO_PC30D_PARC_PCDATA6  _UL(1 << 30)
-#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
-#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define GPIO_PC30D_PARC_PCDATA6  _UL_(1 << 30)
+#define PIN_PA16D_PARC_PCDATA7         _L_(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L_(3)
 #define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
-#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
-#define PIN_PC31D_PARC_PCDATA7         _L(95) /**< \brief PARC signal: PCDATA7 on PC31 mux D */
-#define MUX_PC31D_PARC_PCDATA7          _L(3)
+#define GPIO_PA16D_PARC_PCDATA7  _UL_(1 << 16)
+#define PIN_PC31D_PARC_PCDATA7         _L_(95) /**< \brief PARC signal: PCDATA7 on PC31 mux D */
+#define MUX_PC31D_PARC_PCDATA7          _L_(3)
 #define PINMUX_PC31D_PARC_PCDATA7  ((PIN_PC31D_PARC_PCDATA7 << 16) | MUX_PC31D_PARC_PCDATA7)
-#define GPIO_PC31D_PARC_PCDATA7  _UL(1 << 31)
-#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
-#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define GPIO_PC31D_PARC_PCDATA7  _UL_(1 << 31)
+#define PIN_PA18D_PARC_PCEN1           _L_(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L_(3)
 #define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
-#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
-#define PIN_PC22D_PARC_PCEN1           _L(86) /**< \brief PARC signal: PCEN1 on PC22 mux D */
-#define MUX_PC22D_PARC_PCEN1            _L(3)
+#define GPIO_PA18D_PARC_PCEN1    _UL_(1 << 18)
+#define PIN_PC22D_PARC_PCEN1           _L_(86) /**< \brief PARC signal: PCEN1 on PC22 mux D */
+#define MUX_PC22D_PARC_PCEN1            _L_(3)
 #define PINMUX_PC22D_PARC_PCEN1    ((PIN_PC22D_PARC_PCEN1 << 16) | MUX_PC22D_PARC_PCEN1)
-#define GPIO_PC22D_PARC_PCEN1    _UL(1 << 22)
-#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
-#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define GPIO_PC22D_PARC_PCEN1    _UL_(1 << 22)
+#define PIN_PA19D_PARC_PCEN2           _L_(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L_(3)
 #define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
-#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
-#define PIN_PC23D_PARC_PCEN2           _L(87) /**< \brief PARC signal: PCEN2 on PC23 mux D */
-#define MUX_PC23D_PARC_PCEN2            _L(3)
+#define GPIO_PA19D_PARC_PCEN2    _UL_(1 << 19)
+#define PIN_PC23D_PARC_PCEN2           _L_(87) /**< \brief PARC signal: PCEN2 on PC23 mux D */
+#define MUX_PC23D_PARC_PCEN2            _L_(3)
 #define PINMUX_PC23D_PARC_PCEN2    ((PIN_PC23D_PARC_PCEN2 << 16) | MUX_PC23D_PARC_PCEN2)
-#define GPIO_PC23D_PARC_PCEN2    _UL(1 << 23)
+#define GPIO_PC23D_PARC_PCEN2    _UL_(1 << 23)
 /* ========== GPIO definition for CATB peripheral ========== */
-#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
-#define MUX_PA02G_CATB_DIS              _L(6)
+#define PIN_PA02G_CATB_DIS              _L_(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L_(6)
 #define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
-#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
-#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
-#define MUX_PA12G_CATB_DIS              _L(6)
+#define GPIO_PA02G_CATB_DIS      _UL_(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L_(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L_(6)
 #define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
-#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
-#define MUX_PA23G_CATB_DIS              _L(6)
+#define GPIO_PA12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L_(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L_(6)
 #define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
-#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
-#define PIN_PB03G_CATB_DIS             _L(35) /**< \brief CATB signal: DIS on PB03 mux G */
-#define MUX_PB03G_CATB_DIS              _L(6)
+#define GPIO_PA23G_CATB_DIS      _UL_(1 << 23)
+#define PIN_PB03G_CATB_DIS             _L_(35) /**< \brief CATB signal: DIS on PB03 mux G */
+#define MUX_PB03G_CATB_DIS              _L_(6)
 #define PINMUX_PB03G_CATB_DIS      ((PIN_PB03G_CATB_DIS << 16) | MUX_PB03G_CATB_DIS)
-#define GPIO_PB03G_CATB_DIS      _UL(1 <<  3)
-#define PIN_PB12G_CATB_DIS             _L(44) /**< \brief CATB signal: DIS on PB12 mux G */
-#define MUX_PB12G_CATB_DIS              _L(6)
+#define GPIO_PB03G_CATB_DIS      _UL_(1 <<  3)
+#define PIN_PB12G_CATB_DIS             _L_(44) /**< \brief CATB signal: DIS on PB12 mux G */
+#define MUX_PB12G_CATB_DIS              _L_(6)
 #define PINMUX_PB12G_CATB_DIS      ((PIN_PB12G_CATB_DIS << 16) | MUX_PB12G_CATB_DIS)
-#define GPIO_PB12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PC05G_CATB_DIS             _L(69) /**< \brief CATB signal: DIS on PC05 mux G */
-#define MUX_PC05G_CATB_DIS              _L(6)
+#define GPIO_PB12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PC05G_CATB_DIS             _L_(69) /**< \brief CATB signal: DIS on PC05 mux G */
+#define MUX_PC05G_CATB_DIS              _L_(6)
 #define PINMUX_PC05G_CATB_DIS      ((PIN_PC05G_CATB_DIS << 16) | MUX_PC05G_CATB_DIS)
-#define GPIO_PC05G_CATB_DIS      _UL(1 <<  5)
-#define PIN_PC14G_CATB_DIS             _L(78) /**< \brief CATB signal: DIS on PC14 mux G */
-#define MUX_PC14G_CATB_DIS              _L(6)
+#define GPIO_PC05G_CATB_DIS      _UL_(1 <<  5)
+#define PIN_PC14G_CATB_DIS             _L_(78) /**< \brief CATB signal: DIS on PC14 mux G */
+#define MUX_PC14G_CATB_DIS              _L_(6)
 #define PINMUX_PC14G_CATB_DIS      ((PIN_PC14G_CATB_DIS << 16) | MUX_PC14G_CATB_DIS)
-#define GPIO_PC14G_CATB_DIS      _UL(1 << 14)
-#define PIN_PC23G_CATB_DIS             _L(87) /**< \brief CATB signal: DIS on PC23 mux G */
-#define MUX_PC23G_CATB_DIS              _L(6)
+#define GPIO_PC14G_CATB_DIS      _UL_(1 << 14)
+#define PIN_PC23G_CATB_DIS             _L_(87) /**< \brief CATB signal: DIS on PC23 mux G */
+#define MUX_PC23G_CATB_DIS              _L_(6)
 #define PINMUX_PC23G_CATB_DIS      ((PIN_PC23G_CATB_DIS << 16) | MUX_PC23G_CATB_DIS)
-#define GPIO_PC23G_CATB_DIS      _UL(1 << 23)
-#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
-#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define GPIO_PC23G_CATB_DIS      _UL_(1 << 23)
+#define PIN_PA04G_CATB_SENSE0           _L_(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L_(6)
 #define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
-#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
-#define PIN_PB13G_CATB_SENSE0          _L(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
-#define MUX_PB13G_CATB_SENSE0           _L(6)
+#define GPIO_PA04G_CATB_SENSE0   _UL_(1 <<  4)
+#define PIN_PB13G_CATB_SENSE0          _L_(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
+#define MUX_PB13G_CATB_SENSE0           _L_(6)
 #define PINMUX_PB13G_CATB_SENSE0   ((PIN_PB13G_CATB_SENSE0 << 16) | MUX_PB13G_CATB_SENSE0)
-#define GPIO_PB13G_CATB_SENSE0   _UL(1 << 13)
-#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
-#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define GPIO_PB13G_CATB_SENSE0   _UL_(1 << 13)
+#define PIN_PA05G_CATB_SENSE1           _L_(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L_(6)
 #define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
-#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
-#define PIN_PB14G_CATB_SENSE1          _L(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
-#define MUX_PB14G_CATB_SENSE1           _L(6)
+#define GPIO_PA05G_CATB_SENSE1   _UL_(1 <<  5)
+#define PIN_PB14G_CATB_SENSE1          _L_(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
+#define MUX_PB14G_CATB_SENSE1           _L_(6)
 #define PINMUX_PB14G_CATB_SENSE1   ((PIN_PB14G_CATB_SENSE1 << 16) | MUX_PB14G_CATB_SENSE1)
-#define GPIO_PB14G_CATB_SENSE1   _UL(1 << 14)
-#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
-#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define GPIO_PB14G_CATB_SENSE1   _UL_(1 << 14)
+#define PIN_PA06G_CATB_SENSE2           _L_(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L_(6)
 #define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
-#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
-#define PIN_PB15G_CATB_SENSE2          _L(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
-#define MUX_PB15G_CATB_SENSE2           _L(6)
+#define GPIO_PA06G_CATB_SENSE2   _UL_(1 <<  6)
+#define PIN_PB15G_CATB_SENSE2          _L_(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
+#define MUX_PB15G_CATB_SENSE2           _L_(6)
 #define PINMUX_PB15G_CATB_SENSE2   ((PIN_PB15G_CATB_SENSE2 << 16) | MUX_PB15G_CATB_SENSE2)
-#define GPIO_PB15G_CATB_SENSE2   _UL(1 << 15)
-#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
-#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define GPIO_PB15G_CATB_SENSE2   _UL_(1 << 15)
+#define PIN_PA07G_CATB_SENSE3           _L_(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L_(6)
 #define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
-#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
-#define PIN_PC00G_CATB_SENSE3          _L(64) /**< \brief CATB signal: SENSE3 on PC00 mux G */
-#define MUX_PC00G_CATB_SENSE3           _L(6)
+#define GPIO_PA07G_CATB_SENSE3   _UL_(1 <<  7)
+#define PIN_PC00G_CATB_SENSE3          _L_(64) /**< \brief CATB signal: SENSE3 on PC00 mux G */
+#define MUX_PC00G_CATB_SENSE3           _L_(6)
 #define PINMUX_PC00G_CATB_SENSE3   ((PIN_PC00G_CATB_SENSE3 << 16) | MUX_PC00G_CATB_SENSE3)
-#define GPIO_PC00G_CATB_SENSE3   _UL(1 <<  0)
-#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
-#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define GPIO_PC00G_CATB_SENSE3   _UL_(1 <<  0)
+#define PIN_PA08G_CATB_SENSE4           _L_(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L_(6)
 #define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
-#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
-#define PIN_PC01G_CATB_SENSE4          _L(65) /**< \brief CATB signal: SENSE4 on PC01 mux G */
-#define MUX_PC01G_CATB_SENSE4           _L(6)
+#define GPIO_PA08G_CATB_SENSE4   _UL_(1 <<  8)
+#define PIN_PC01G_CATB_SENSE4          _L_(65) /**< \brief CATB signal: SENSE4 on PC01 mux G */
+#define MUX_PC01G_CATB_SENSE4           _L_(6)
 #define PINMUX_PC01G_CATB_SENSE4   ((PIN_PC01G_CATB_SENSE4 << 16) | MUX_PC01G_CATB_SENSE4)
-#define GPIO_PC01G_CATB_SENSE4   _UL(1 <<  1)
-#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
-#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define GPIO_PC01G_CATB_SENSE4   _UL_(1 <<  1)
+#define PIN_PA09G_CATB_SENSE5           _L_(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L_(6)
 #define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
-#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
-#define PIN_PC02G_CATB_SENSE5          _L(66) /**< \brief CATB signal: SENSE5 on PC02 mux G */
-#define MUX_PC02G_CATB_SENSE5           _L(6)
+#define GPIO_PA09G_CATB_SENSE5   _UL_(1 <<  9)
+#define PIN_PC02G_CATB_SENSE5          _L_(66) /**< \brief CATB signal: SENSE5 on PC02 mux G */
+#define MUX_PC02G_CATB_SENSE5           _L_(6)
 #define PINMUX_PC02G_CATB_SENSE5   ((PIN_PC02G_CATB_SENSE5 << 16) | MUX_PC02G_CATB_SENSE5)
-#define GPIO_PC02G_CATB_SENSE5   _UL(1 <<  2)
-#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
-#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define GPIO_PC02G_CATB_SENSE5   _UL_(1 <<  2)
+#define PIN_PA10G_CATB_SENSE6          _L_(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L_(6)
 #define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
-#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
-#define PIN_PC03G_CATB_SENSE6          _L(67) /**< \brief CATB signal: SENSE6 on PC03 mux G */
-#define MUX_PC03G_CATB_SENSE6           _L(6)
+#define GPIO_PA10G_CATB_SENSE6   _UL_(1 << 10)
+#define PIN_PC03G_CATB_SENSE6          _L_(67) /**< \brief CATB signal: SENSE6 on PC03 mux G */
+#define MUX_PC03G_CATB_SENSE6           _L_(6)
 #define PINMUX_PC03G_CATB_SENSE6   ((PIN_PC03G_CATB_SENSE6 << 16) | MUX_PC03G_CATB_SENSE6)
-#define GPIO_PC03G_CATB_SENSE6   _UL(1 <<  3)
-#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
-#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define GPIO_PC03G_CATB_SENSE6   _UL_(1 <<  3)
+#define PIN_PA11G_CATB_SENSE7          _L_(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L_(6)
 #define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
-#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
-#define PIN_PC04G_CATB_SENSE7          _L(68) /**< \brief CATB signal: SENSE7 on PC04 mux G */
-#define MUX_PC04G_CATB_SENSE7           _L(6)
+#define GPIO_PA11G_CATB_SENSE7   _UL_(1 << 11)
+#define PIN_PC04G_CATB_SENSE7          _L_(68) /**< \brief CATB signal: SENSE7 on PC04 mux G */
+#define MUX_PC04G_CATB_SENSE7           _L_(6)
 #define PINMUX_PC04G_CATB_SENSE7   ((PIN_PC04G_CATB_SENSE7 << 16) | MUX_PC04G_CATB_SENSE7)
-#define GPIO_PC04G_CATB_SENSE7   _UL(1 <<  4)
-#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
-#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define GPIO_PC04G_CATB_SENSE7   _UL_(1 <<  4)
+#define PIN_PA13G_CATB_SENSE8          _L_(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L_(6)
 #define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
-#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
-#define PIN_PC06G_CATB_SENSE8          _L(70) /**< \brief CATB signal: SENSE8 on PC06 mux G */
-#define MUX_PC06G_CATB_SENSE8           _L(6)
+#define GPIO_PA13G_CATB_SENSE8   _UL_(1 << 13)
+#define PIN_PC06G_CATB_SENSE8          _L_(70) /**< \brief CATB signal: SENSE8 on PC06 mux G */
+#define MUX_PC06G_CATB_SENSE8           _L_(6)
 #define PINMUX_PC06G_CATB_SENSE8   ((PIN_PC06G_CATB_SENSE8 << 16) | MUX_PC06G_CATB_SENSE8)
-#define GPIO_PC06G_CATB_SENSE8   _UL(1 <<  6)
-#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
-#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define GPIO_PC06G_CATB_SENSE8   _UL_(1 <<  6)
+#define PIN_PA14G_CATB_SENSE9          _L_(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L_(6)
 #define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
-#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
-#define PIN_PC07G_CATB_SENSE9          _L(71) /**< \brief CATB signal: SENSE9 on PC07 mux G */
-#define MUX_PC07G_CATB_SENSE9           _L(6)
+#define GPIO_PA14G_CATB_SENSE9   _UL_(1 << 14)
+#define PIN_PC07G_CATB_SENSE9          _L_(71) /**< \brief CATB signal: SENSE9 on PC07 mux G */
+#define MUX_PC07G_CATB_SENSE9           _L_(6)
 #define PINMUX_PC07G_CATB_SENSE9   ((PIN_PC07G_CATB_SENSE9 << 16) | MUX_PC07G_CATB_SENSE9)
-#define GPIO_PC07G_CATB_SENSE9   _UL(1 <<  7)
-#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
-#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define GPIO_PC07G_CATB_SENSE9   _UL_(1 <<  7)
+#define PIN_PA15G_CATB_SENSE10         _L_(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L_(6)
 #define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
-#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
-#define PIN_PC08G_CATB_SENSE10         _L(72) /**< \brief CATB signal: SENSE10 on PC08 mux G */
-#define MUX_PC08G_CATB_SENSE10          _L(6)
+#define GPIO_PA15G_CATB_SENSE10  _UL_(1 << 15)
+#define PIN_PC08G_CATB_SENSE10         _L_(72) /**< \brief CATB signal: SENSE10 on PC08 mux G */
+#define MUX_PC08G_CATB_SENSE10          _L_(6)
 #define PINMUX_PC08G_CATB_SENSE10  ((PIN_PC08G_CATB_SENSE10 << 16) | MUX_PC08G_CATB_SENSE10)
-#define GPIO_PC08G_CATB_SENSE10  _UL(1 <<  8)
-#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
-#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define GPIO_PC08G_CATB_SENSE10  _UL_(1 <<  8)
+#define PIN_PA16G_CATB_SENSE11         _L_(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L_(6)
 #define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
-#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
-#define PIN_PC09G_CATB_SENSE11         _L(73) /**< \brief CATB signal: SENSE11 on PC09 mux G */
-#define MUX_PC09G_CATB_SENSE11          _L(6)
+#define GPIO_PA16G_CATB_SENSE11  _UL_(1 << 16)
+#define PIN_PC09G_CATB_SENSE11         _L_(73) /**< \brief CATB signal: SENSE11 on PC09 mux G */
+#define MUX_PC09G_CATB_SENSE11          _L_(6)
 #define PINMUX_PC09G_CATB_SENSE11  ((PIN_PC09G_CATB_SENSE11 << 16) | MUX_PC09G_CATB_SENSE11)
-#define GPIO_PC09G_CATB_SENSE11  _UL(1 <<  9)
-#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
-#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define GPIO_PC09G_CATB_SENSE11  _UL_(1 <<  9)
+#define PIN_PA17G_CATB_SENSE12         _L_(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L_(6)
 #define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
-#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
-#define PIN_PC10G_CATB_SENSE12         _L(74) /**< \brief CATB signal: SENSE12 on PC10 mux G */
-#define MUX_PC10G_CATB_SENSE12          _L(6)
+#define GPIO_PA17G_CATB_SENSE12  _UL_(1 << 17)
+#define PIN_PC10G_CATB_SENSE12         _L_(74) /**< \brief CATB signal: SENSE12 on PC10 mux G */
+#define MUX_PC10G_CATB_SENSE12          _L_(6)
 #define PINMUX_PC10G_CATB_SENSE12  ((PIN_PC10G_CATB_SENSE12 << 16) | MUX_PC10G_CATB_SENSE12)
-#define GPIO_PC10G_CATB_SENSE12  _UL(1 << 10)
-#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
-#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define GPIO_PC10G_CATB_SENSE12  _UL_(1 << 10)
+#define PIN_PA18G_CATB_SENSE13         _L_(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L_(6)
 #define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
-#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
-#define PIN_PC11G_CATB_SENSE13         _L(75) /**< \brief CATB signal: SENSE13 on PC11 mux G */
-#define MUX_PC11G_CATB_SENSE13          _L(6)
+#define GPIO_PA18G_CATB_SENSE13  _UL_(1 << 18)
+#define PIN_PC11G_CATB_SENSE13         _L_(75) /**< \brief CATB signal: SENSE13 on PC11 mux G */
+#define MUX_PC11G_CATB_SENSE13          _L_(6)
 #define PINMUX_PC11G_CATB_SENSE13  ((PIN_PC11G_CATB_SENSE13 << 16) | MUX_PC11G_CATB_SENSE13)
-#define GPIO_PC11G_CATB_SENSE13  _UL(1 << 11)
-#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
-#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define GPIO_PC11G_CATB_SENSE13  _UL_(1 << 11)
+#define PIN_PA19G_CATB_SENSE14         _L_(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L_(6)
 #define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
-#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
-#define PIN_PC12G_CATB_SENSE14         _L(76) /**< \brief CATB signal: SENSE14 on PC12 mux G */
-#define MUX_PC12G_CATB_SENSE14          _L(6)
+#define GPIO_PA19G_CATB_SENSE14  _UL_(1 << 19)
+#define PIN_PC12G_CATB_SENSE14         _L_(76) /**< \brief CATB signal: SENSE14 on PC12 mux G */
+#define MUX_PC12G_CATB_SENSE14          _L_(6)
 #define PINMUX_PC12G_CATB_SENSE14  ((PIN_PC12G_CATB_SENSE14 << 16) | MUX_PC12G_CATB_SENSE14)
-#define GPIO_PC12G_CATB_SENSE14  _UL(1 << 12)
-#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
-#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define GPIO_PC12G_CATB_SENSE14  _UL_(1 << 12)
+#define PIN_PA20G_CATB_SENSE15         _L_(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L_(6)
 #define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
-#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
-#define PIN_PC13G_CATB_SENSE15         _L(77) /**< \brief CATB signal: SENSE15 on PC13 mux G */
-#define MUX_PC13G_CATB_SENSE15          _L(6)
+#define GPIO_PA20G_CATB_SENSE15  _UL_(1 << 20)
+#define PIN_PC13G_CATB_SENSE15         _L_(77) /**< \brief CATB signal: SENSE15 on PC13 mux G */
+#define MUX_PC13G_CATB_SENSE15          _L_(6)
 #define PINMUX_PC13G_CATB_SENSE15  ((PIN_PC13G_CATB_SENSE15 << 16) | MUX_PC13G_CATB_SENSE15)
-#define GPIO_PC13G_CATB_SENSE15  _UL(1 << 13)
-#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
-#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define GPIO_PC13G_CATB_SENSE15  _UL_(1 << 13)
+#define PIN_PA21G_CATB_SENSE16         _L_(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L_(6)
 #define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
-#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
-#define PIN_PC15G_CATB_SENSE16         _L(79) /**< \brief CATB signal: SENSE16 on PC15 mux G */
-#define MUX_PC15G_CATB_SENSE16          _L(6)
+#define GPIO_PA21G_CATB_SENSE16  _UL_(1 << 21)
+#define PIN_PC15G_CATB_SENSE16         _L_(79) /**< \brief CATB signal: SENSE16 on PC15 mux G */
+#define MUX_PC15G_CATB_SENSE16          _L_(6)
 #define PINMUX_PC15G_CATB_SENSE16  ((PIN_PC15G_CATB_SENSE16 << 16) | MUX_PC15G_CATB_SENSE16)
-#define GPIO_PC15G_CATB_SENSE16  _UL(1 << 15)
-#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
-#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define GPIO_PC15G_CATB_SENSE16  _UL_(1 << 15)
+#define PIN_PA22G_CATB_SENSE17         _L_(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L_(6)
 #define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
-#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
-#define PIN_PC16G_CATB_SENSE17         _L(80) /**< \brief CATB signal: SENSE17 on PC16 mux G */
-#define MUX_PC16G_CATB_SENSE17          _L(6)
+#define GPIO_PA22G_CATB_SENSE17  _UL_(1 << 22)
+#define PIN_PC16G_CATB_SENSE17         _L_(80) /**< \brief CATB signal: SENSE17 on PC16 mux G */
+#define MUX_PC16G_CATB_SENSE17          _L_(6)
 #define PINMUX_PC16G_CATB_SENSE17  ((PIN_PC16G_CATB_SENSE17 << 16) | MUX_PC16G_CATB_SENSE17)
-#define GPIO_PC16G_CATB_SENSE17  _UL(1 << 16)
-#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
-#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define GPIO_PC16G_CATB_SENSE17  _UL_(1 << 16)
+#define PIN_PA24G_CATB_SENSE18         _L_(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L_(6)
 #define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
-#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
-#define PIN_PC17G_CATB_SENSE18         _L(81) /**< \brief CATB signal: SENSE18 on PC17 mux G */
-#define MUX_PC17G_CATB_SENSE18          _L(6)
+#define GPIO_PA24G_CATB_SENSE18  _UL_(1 << 24)
+#define PIN_PC17G_CATB_SENSE18         _L_(81) /**< \brief CATB signal: SENSE18 on PC17 mux G */
+#define MUX_PC17G_CATB_SENSE18          _L_(6)
 #define PINMUX_PC17G_CATB_SENSE18  ((PIN_PC17G_CATB_SENSE18 << 16) | MUX_PC17G_CATB_SENSE18)
-#define GPIO_PC17G_CATB_SENSE18  _UL(1 << 17)
-#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
-#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define GPIO_PC17G_CATB_SENSE18  _UL_(1 << 17)
+#define PIN_PA25G_CATB_SENSE19         _L_(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L_(6)
 #define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
-#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
-#define PIN_PC18G_CATB_SENSE19         _L(82) /**< \brief CATB signal: SENSE19 on PC18 mux G */
-#define MUX_PC18G_CATB_SENSE19          _L(6)
+#define GPIO_PA25G_CATB_SENSE19  _UL_(1 << 25)
+#define PIN_PC18G_CATB_SENSE19         _L_(82) /**< \brief CATB signal: SENSE19 on PC18 mux G */
+#define MUX_PC18G_CATB_SENSE19          _L_(6)
 #define PINMUX_PC18G_CATB_SENSE19  ((PIN_PC18G_CATB_SENSE19 << 16) | MUX_PC18G_CATB_SENSE19)
-#define GPIO_PC18G_CATB_SENSE19  _UL(1 << 18)
-#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
-#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define GPIO_PC18G_CATB_SENSE19  _UL_(1 << 18)
+#define PIN_PA26G_CATB_SENSE20         _L_(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L_(6)
 #define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
-#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
-#define PIN_PC19G_CATB_SENSE20         _L(83) /**< \brief CATB signal: SENSE20 on PC19 mux G */
-#define MUX_PC19G_CATB_SENSE20          _L(6)
+#define GPIO_PA26G_CATB_SENSE20  _UL_(1 << 26)
+#define PIN_PC19G_CATB_SENSE20         _L_(83) /**< \brief CATB signal: SENSE20 on PC19 mux G */
+#define MUX_PC19G_CATB_SENSE20          _L_(6)
 #define PINMUX_PC19G_CATB_SENSE20  ((PIN_PC19G_CATB_SENSE20 << 16) | MUX_PC19G_CATB_SENSE20)
-#define GPIO_PC19G_CATB_SENSE20  _UL(1 << 19)
-#define PIN_PB00G_CATB_SENSE21         _L(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
-#define MUX_PB00G_CATB_SENSE21          _L(6)
+#define GPIO_PC19G_CATB_SENSE20  _UL_(1 << 19)
+#define PIN_PB00G_CATB_SENSE21         _L_(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
+#define MUX_PB00G_CATB_SENSE21          _L_(6)
 #define PINMUX_PB00G_CATB_SENSE21  ((PIN_PB00G_CATB_SENSE21 << 16) | MUX_PB00G_CATB_SENSE21)
-#define GPIO_PB00G_CATB_SENSE21  _UL(1 <<  0)
-#define PIN_PC20G_CATB_SENSE21         _L(84) /**< \brief CATB signal: SENSE21 on PC20 mux G */
-#define MUX_PC20G_CATB_SENSE21          _L(6)
+#define GPIO_PB00G_CATB_SENSE21  _UL_(1 <<  0)
+#define PIN_PC20G_CATB_SENSE21         _L_(84) /**< \brief CATB signal: SENSE21 on PC20 mux G */
+#define MUX_PC20G_CATB_SENSE21          _L_(6)
 #define PINMUX_PC20G_CATB_SENSE21  ((PIN_PC20G_CATB_SENSE21 << 16) | MUX_PC20G_CATB_SENSE21)
-#define GPIO_PC20G_CATB_SENSE21  _UL(1 << 20)
-#define PIN_PB01G_CATB_SENSE22         _L(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
-#define MUX_PB01G_CATB_SENSE22          _L(6)
+#define GPIO_PC20G_CATB_SENSE21  _UL_(1 << 20)
+#define PIN_PB01G_CATB_SENSE22         _L_(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
+#define MUX_PB01G_CATB_SENSE22          _L_(6)
 #define PINMUX_PB01G_CATB_SENSE22  ((PIN_PB01G_CATB_SENSE22 << 16) | MUX_PB01G_CATB_SENSE22)
-#define GPIO_PB01G_CATB_SENSE22  _UL(1 <<  1)
-#define PIN_PC21G_CATB_SENSE22         _L(85) /**< \brief CATB signal: SENSE22 on PC21 mux G */
-#define MUX_PC21G_CATB_SENSE22          _L(6)
+#define GPIO_PB01G_CATB_SENSE22  _UL_(1 <<  1)
+#define PIN_PC21G_CATB_SENSE22         _L_(85) /**< \brief CATB signal: SENSE22 on PC21 mux G */
+#define MUX_PC21G_CATB_SENSE22          _L_(6)
 #define PINMUX_PC21G_CATB_SENSE22  ((PIN_PC21G_CATB_SENSE22 << 16) | MUX_PC21G_CATB_SENSE22)
-#define GPIO_PC21G_CATB_SENSE22  _UL(1 << 21)
-#define PIN_PB02G_CATB_SENSE23         _L(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
-#define MUX_PB02G_CATB_SENSE23          _L(6)
+#define GPIO_PC21G_CATB_SENSE22  _UL_(1 << 21)
+#define PIN_PB02G_CATB_SENSE23         _L_(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
+#define MUX_PB02G_CATB_SENSE23          _L_(6)
 #define PINMUX_PB02G_CATB_SENSE23  ((PIN_PB02G_CATB_SENSE23 << 16) | MUX_PB02G_CATB_SENSE23)
-#define GPIO_PB02G_CATB_SENSE23  _UL(1 <<  2)
-#define PIN_PC22G_CATB_SENSE23         _L(86) /**< \brief CATB signal: SENSE23 on PC22 mux G */
-#define MUX_PC22G_CATB_SENSE23          _L(6)
+#define GPIO_PB02G_CATB_SENSE23  _UL_(1 <<  2)
+#define PIN_PC22G_CATB_SENSE23         _L_(86) /**< \brief CATB signal: SENSE23 on PC22 mux G */
+#define MUX_PC22G_CATB_SENSE23          _L_(6)
 #define PINMUX_PC22G_CATB_SENSE23  ((PIN_PC22G_CATB_SENSE23 << 16) | MUX_PC22G_CATB_SENSE23)
-#define GPIO_PC22G_CATB_SENSE23  _UL(1 << 22)
-#define PIN_PB04G_CATB_SENSE24         _L(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
-#define MUX_PB04G_CATB_SENSE24          _L(6)
+#define GPIO_PC22G_CATB_SENSE23  _UL_(1 << 22)
+#define PIN_PB04G_CATB_SENSE24         _L_(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
+#define MUX_PB04G_CATB_SENSE24          _L_(6)
 #define PINMUX_PB04G_CATB_SENSE24  ((PIN_PB04G_CATB_SENSE24 << 16) | MUX_PB04G_CATB_SENSE24)
-#define GPIO_PB04G_CATB_SENSE24  _UL(1 <<  4)
-#define PIN_PC24G_CATB_SENSE24         _L(88) /**< \brief CATB signal: SENSE24 on PC24 mux G */
-#define MUX_PC24G_CATB_SENSE24          _L(6)
+#define GPIO_PB04G_CATB_SENSE24  _UL_(1 <<  4)
+#define PIN_PC24G_CATB_SENSE24         _L_(88) /**< \brief CATB signal: SENSE24 on PC24 mux G */
+#define MUX_PC24G_CATB_SENSE24          _L_(6)
 #define PINMUX_PC24G_CATB_SENSE24  ((PIN_PC24G_CATB_SENSE24 << 16) | MUX_PC24G_CATB_SENSE24)
-#define GPIO_PC24G_CATB_SENSE24  _UL(1 << 24)
-#define PIN_PB05G_CATB_SENSE25         _L(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
-#define MUX_PB05G_CATB_SENSE25          _L(6)
+#define GPIO_PC24G_CATB_SENSE24  _UL_(1 << 24)
+#define PIN_PB05G_CATB_SENSE25         _L_(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
+#define MUX_PB05G_CATB_SENSE25          _L_(6)
 #define PINMUX_PB05G_CATB_SENSE25  ((PIN_PB05G_CATB_SENSE25 << 16) | MUX_PB05G_CATB_SENSE25)
-#define GPIO_PB05G_CATB_SENSE25  _UL(1 <<  5)
-#define PIN_PC25G_CATB_SENSE25         _L(89) /**< \brief CATB signal: SENSE25 on PC25 mux G */
-#define MUX_PC25G_CATB_SENSE25          _L(6)
+#define GPIO_PB05G_CATB_SENSE25  _UL_(1 <<  5)
+#define PIN_PC25G_CATB_SENSE25         _L_(89) /**< \brief CATB signal: SENSE25 on PC25 mux G */
+#define MUX_PC25G_CATB_SENSE25          _L_(6)
 #define PINMUX_PC25G_CATB_SENSE25  ((PIN_PC25G_CATB_SENSE25 << 16) | MUX_PC25G_CATB_SENSE25)
-#define GPIO_PC25G_CATB_SENSE25  _UL(1 << 25)
-#define PIN_PB06G_CATB_SENSE26         _L(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
-#define MUX_PB06G_CATB_SENSE26          _L(6)
+#define GPIO_PC25G_CATB_SENSE25  _UL_(1 << 25)
+#define PIN_PB06G_CATB_SENSE26         _L_(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
+#define MUX_PB06G_CATB_SENSE26          _L_(6)
 #define PINMUX_PB06G_CATB_SENSE26  ((PIN_PB06G_CATB_SENSE26 << 16) | MUX_PB06G_CATB_SENSE26)
-#define GPIO_PB06G_CATB_SENSE26  _UL(1 <<  6)
-#define PIN_PC26G_CATB_SENSE26         _L(90) /**< \brief CATB signal: SENSE26 on PC26 mux G */
-#define MUX_PC26G_CATB_SENSE26          _L(6)
+#define GPIO_PB06G_CATB_SENSE26  _UL_(1 <<  6)
+#define PIN_PC26G_CATB_SENSE26         _L_(90) /**< \brief CATB signal: SENSE26 on PC26 mux G */
+#define MUX_PC26G_CATB_SENSE26          _L_(6)
 #define PINMUX_PC26G_CATB_SENSE26  ((PIN_PC26G_CATB_SENSE26 << 16) | MUX_PC26G_CATB_SENSE26)
-#define GPIO_PC26G_CATB_SENSE26  _UL(1 << 26)
-#define PIN_PB07G_CATB_SENSE27         _L(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
-#define MUX_PB07G_CATB_SENSE27          _L(6)
+#define GPIO_PC26G_CATB_SENSE26  _UL_(1 << 26)
+#define PIN_PB07G_CATB_SENSE27         _L_(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
+#define MUX_PB07G_CATB_SENSE27          _L_(6)
 #define PINMUX_PB07G_CATB_SENSE27  ((PIN_PB07G_CATB_SENSE27 << 16) | MUX_PB07G_CATB_SENSE27)
-#define GPIO_PB07G_CATB_SENSE27  _UL(1 <<  7)
-#define PIN_PC27G_CATB_SENSE27         _L(91) /**< \brief CATB signal: SENSE27 on PC27 mux G */
-#define MUX_PC27G_CATB_SENSE27          _L(6)
+#define GPIO_PB07G_CATB_SENSE27  _UL_(1 <<  7)
+#define PIN_PC27G_CATB_SENSE27         _L_(91) /**< \brief CATB signal: SENSE27 on PC27 mux G */
+#define MUX_PC27G_CATB_SENSE27          _L_(6)
 #define PINMUX_PC27G_CATB_SENSE27  ((PIN_PC27G_CATB_SENSE27 << 16) | MUX_PC27G_CATB_SENSE27)
-#define GPIO_PC27G_CATB_SENSE27  _UL(1 << 27)
-#define PIN_PB08G_CATB_SENSE28         _L(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
-#define MUX_PB08G_CATB_SENSE28          _L(6)
+#define GPIO_PC27G_CATB_SENSE27  _UL_(1 << 27)
+#define PIN_PB08G_CATB_SENSE28         _L_(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
+#define MUX_PB08G_CATB_SENSE28          _L_(6)
 #define PINMUX_PB08G_CATB_SENSE28  ((PIN_PB08G_CATB_SENSE28 << 16) | MUX_PB08G_CATB_SENSE28)
-#define GPIO_PB08G_CATB_SENSE28  _UL(1 <<  8)
-#define PIN_PC28G_CATB_SENSE28         _L(92) /**< \brief CATB signal: SENSE28 on PC28 mux G */
-#define MUX_PC28G_CATB_SENSE28          _L(6)
+#define GPIO_PB08G_CATB_SENSE28  _UL_(1 <<  8)
+#define PIN_PC28G_CATB_SENSE28         _L_(92) /**< \brief CATB signal: SENSE28 on PC28 mux G */
+#define MUX_PC28G_CATB_SENSE28          _L_(6)
 #define PINMUX_PC28G_CATB_SENSE28  ((PIN_PC28G_CATB_SENSE28 << 16) | MUX_PC28G_CATB_SENSE28)
-#define GPIO_PC28G_CATB_SENSE28  _UL(1 << 28)
-#define PIN_PB09G_CATB_SENSE29         _L(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
-#define MUX_PB09G_CATB_SENSE29          _L(6)
+#define GPIO_PC28G_CATB_SENSE28  _UL_(1 << 28)
+#define PIN_PB09G_CATB_SENSE29         _L_(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
+#define MUX_PB09G_CATB_SENSE29          _L_(6)
 #define PINMUX_PB09G_CATB_SENSE29  ((PIN_PB09G_CATB_SENSE29 << 16) | MUX_PB09G_CATB_SENSE29)
-#define GPIO_PB09G_CATB_SENSE29  _UL(1 <<  9)
-#define PIN_PC29G_CATB_SENSE29         _L(93) /**< \brief CATB signal: SENSE29 on PC29 mux G */
-#define MUX_PC29G_CATB_SENSE29          _L(6)
+#define GPIO_PB09G_CATB_SENSE29  _UL_(1 <<  9)
+#define PIN_PC29G_CATB_SENSE29         _L_(93) /**< \brief CATB signal: SENSE29 on PC29 mux G */
+#define MUX_PC29G_CATB_SENSE29          _L_(6)
 #define PINMUX_PC29G_CATB_SENSE29  ((PIN_PC29G_CATB_SENSE29 << 16) | MUX_PC29G_CATB_SENSE29)
-#define GPIO_PC29G_CATB_SENSE29  _UL(1 << 29)
-#define PIN_PB10G_CATB_SENSE30         _L(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
-#define MUX_PB10G_CATB_SENSE30          _L(6)
+#define GPIO_PC29G_CATB_SENSE29  _UL_(1 << 29)
+#define PIN_PB10G_CATB_SENSE30         _L_(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
+#define MUX_PB10G_CATB_SENSE30          _L_(6)
 #define PINMUX_PB10G_CATB_SENSE30  ((PIN_PB10G_CATB_SENSE30 << 16) | MUX_PB10G_CATB_SENSE30)
-#define GPIO_PB10G_CATB_SENSE30  _UL(1 << 10)
-#define PIN_PC30G_CATB_SENSE30         _L(94) /**< \brief CATB signal: SENSE30 on PC30 mux G */
-#define MUX_PC30G_CATB_SENSE30          _L(6)
+#define GPIO_PB10G_CATB_SENSE30  _UL_(1 << 10)
+#define PIN_PC30G_CATB_SENSE30         _L_(94) /**< \brief CATB signal: SENSE30 on PC30 mux G */
+#define MUX_PC30G_CATB_SENSE30          _L_(6)
 #define PINMUX_PC30G_CATB_SENSE30  ((PIN_PC30G_CATB_SENSE30 << 16) | MUX_PC30G_CATB_SENSE30)
-#define GPIO_PC30G_CATB_SENSE30  _UL(1 << 30)
-#define PIN_PB11G_CATB_SENSE31         _L(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
-#define MUX_PB11G_CATB_SENSE31          _L(6)
+#define GPIO_PC30G_CATB_SENSE30  _UL_(1 << 30)
+#define PIN_PB11G_CATB_SENSE31         _L_(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
+#define MUX_PB11G_CATB_SENSE31          _L_(6)
 #define PINMUX_PB11G_CATB_SENSE31  ((PIN_PB11G_CATB_SENSE31 << 16) | MUX_PB11G_CATB_SENSE31)
-#define GPIO_PB11G_CATB_SENSE31  _UL(1 << 11)
-#define PIN_PC31G_CATB_SENSE31         _L(95) /**< \brief CATB signal: SENSE31 on PC31 mux G */
-#define MUX_PC31G_CATB_SENSE31          _L(6)
+#define GPIO_PB11G_CATB_SENSE31  _UL_(1 << 11)
+#define PIN_PC31G_CATB_SENSE31         _L_(95) /**< \brief CATB signal: SENSE31 on PC31 mux G */
+#define MUX_PC31G_CATB_SENSE31          _L_(6)
 #define PINMUX_PC31G_CATB_SENSE31  ((PIN_PC31G_CATB_SENSE31 << 16) | MUX_PC31G_CATB_SENSE31)
-#define GPIO_PC31G_CATB_SENSE31  _UL(1 << 31)
+#define GPIO_PC31G_CATB_SENSE31  _UL_(1 << 31)
 /* ========== GPIO definition for LCDCA peripheral ========== */
-#define PIN_PA12F_LCDCA_COM0           _L(12) /**< \brief LCDCA signal: COM0 on PA12 mux F */
-#define MUX_PA12F_LCDCA_COM0            _L(5)
+#define PIN_PA12F_LCDCA_COM0           _L_(12) /**< \brief LCDCA signal: COM0 on PA12 mux F */
+#define MUX_PA12F_LCDCA_COM0            _L_(5)
 #define PINMUX_PA12F_LCDCA_COM0    ((PIN_PA12F_LCDCA_COM0 << 16) | MUX_PA12F_LCDCA_COM0)
-#define GPIO_PA12F_LCDCA_COM0    _UL(1 << 12)
-#define PIN_PA11F_LCDCA_COM1           _L(11) /**< \brief LCDCA signal: COM1 on PA11 mux F */
-#define MUX_PA11F_LCDCA_COM1            _L(5)
+#define GPIO_PA12F_LCDCA_COM0    _UL_(1 << 12)
+#define PIN_PA11F_LCDCA_COM1           _L_(11) /**< \brief LCDCA signal: COM1 on PA11 mux F */
+#define MUX_PA11F_LCDCA_COM1            _L_(5)
 #define PINMUX_PA11F_LCDCA_COM1    ((PIN_PA11F_LCDCA_COM1 << 16) | MUX_PA11F_LCDCA_COM1)
-#define GPIO_PA11F_LCDCA_COM1    _UL(1 << 11)
-#define PIN_PA10F_LCDCA_COM2           _L(10) /**< \brief LCDCA signal: COM2 on PA10 mux F */
-#define MUX_PA10F_LCDCA_COM2            _L(5)
+#define GPIO_PA11F_LCDCA_COM1    _UL_(1 << 11)
+#define PIN_PA10F_LCDCA_COM2           _L_(10) /**< \brief LCDCA signal: COM2 on PA10 mux F */
+#define MUX_PA10F_LCDCA_COM2            _L_(5)
 #define PINMUX_PA10F_LCDCA_COM2    ((PIN_PA10F_LCDCA_COM2 << 16) | MUX_PA10F_LCDCA_COM2)
-#define GPIO_PA10F_LCDCA_COM2    _UL(1 << 10)
-#define PIN_PA09F_LCDCA_COM3            _L(9) /**< \brief LCDCA signal: COM3 on PA09 mux F */
-#define MUX_PA09F_LCDCA_COM3            _L(5)
+#define GPIO_PA10F_LCDCA_COM2    _UL_(1 << 10)
+#define PIN_PA09F_LCDCA_COM3            _L_(9) /**< \brief LCDCA signal: COM3 on PA09 mux F */
+#define MUX_PA09F_LCDCA_COM3            _L_(5)
 #define PINMUX_PA09F_LCDCA_COM3    ((PIN_PA09F_LCDCA_COM3 << 16) | MUX_PA09F_LCDCA_COM3)
-#define GPIO_PA09F_LCDCA_COM3    _UL(1 <<  9)
-#define PIN_PC15F_LCDCA_SEG0           _L(79) /**< \brief LCDCA signal: SEG0 on PC15 mux F */
-#define MUX_PC15F_LCDCA_SEG0            _L(5)
+#define GPIO_PA09F_LCDCA_COM3    _UL_(1 <<  9)
+#define PIN_PC15F_LCDCA_SEG0           _L_(79) /**< \brief LCDCA signal: SEG0 on PC15 mux F */
+#define MUX_PC15F_LCDCA_SEG0            _L_(5)
 #define PINMUX_PC15F_LCDCA_SEG0    ((PIN_PC15F_LCDCA_SEG0 << 16) | MUX_PC15F_LCDCA_SEG0)
-#define GPIO_PC15F_LCDCA_SEG0    _UL(1 << 15)
-#define PIN_PC16F_LCDCA_SEG1           _L(80) /**< \brief LCDCA signal: SEG1 on PC16 mux F */
-#define MUX_PC16F_LCDCA_SEG1            _L(5)
+#define GPIO_PC15F_LCDCA_SEG0    _UL_(1 << 15)
+#define PIN_PC16F_LCDCA_SEG1           _L_(80) /**< \brief LCDCA signal: SEG1 on PC16 mux F */
+#define MUX_PC16F_LCDCA_SEG1            _L_(5)
 #define PINMUX_PC16F_LCDCA_SEG1    ((PIN_PC16F_LCDCA_SEG1 << 16) | MUX_PC16F_LCDCA_SEG1)
-#define GPIO_PC16F_LCDCA_SEG1    _UL(1 << 16)
-#define PIN_PC17F_LCDCA_SEG2           _L(81) /**< \brief LCDCA signal: SEG2 on PC17 mux F */
-#define MUX_PC17F_LCDCA_SEG2            _L(5)
+#define GPIO_PC16F_LCDCA_SEG1    _UL_(1 << 16)
+#define PIN_PC17F_LCDCA_SEG2           _L_(81) /**< \brief LCDCA signal: SEG2 on PC17 mux F */
+#define MUX_PC17F_LCDCA_SEG2            _L_(5)
 #define PINMUX_PC17F_LCDCA_SEG2    ((PIN_PC17F_LCDCA_SEG2 << 16) | MUX_PC17F_LCDCA_SEG2)
-#define GPIO_PC17F_LCDCA_SEG2    _UL(1 << 17)
-#define PIN_PC18F_LCDCA_SEG3           _L(82) /**< \brief LCDCA signal: SEG3 on PC18 mux F */
-#define MUX_PC18F_LCDCA_SEG3            _L(5)
+#define GPIO_PC17F_LCDCA_SEG2    _UL_(1 << 17)
+#define PIN_PC18F_LCDCA_SEG3           _L_(82) /**< \brief LCDCA signal: SEG3 on PC18 mux F */
+#define MUX_PC18F_LCDCA_SEG3            _L_(5)
 #define PINMUX_PC18F_LCDCA_SEG3    ((PIN_PC18F_LCDCA_SEG3 << 16) | MUX_PC18F_LCDCA_SEG3)
-#define GPIO_PC18F_LCDCA_SEG3    _UL(1 << 18)
-#define PIN_PC19F_LCDCA_SEG4           _L(83) /**< \brief LCDCA signal: SEG4 on PC19 mux F */
-#define MUX_PC19F_LCDCA_SEG4            _L(5)
+#define GPIO_PC18F_LCDCA_SEG3    _UL_(1 << 18)
+#define PIN_PC19F_LCDCA_SEG4           _L_(83) /**< \brief LCDCA signal: SEG4 on PC19 mux F */
+#define MUX_PC19F_LCDCA_SEG4            _L_(5)
 #define PINMUX_PC19F_LCDCA_SEG4    ((PIN_PC19F_LCDCA_SEG4 << 16) | MUX_PC19F_LCDCA_SEG4)
-#define GPIO_PC19F_LCDCA_SEG4    _UL(1 << 19)
-#define PIN_PA13F_LCDCA_SEG5           _L(13) /**< \brief LCDCA signal: SEG5 on PA13 mux F */
-#define MUX_PA13F_LCDCA_SEG5            _L(5)
+#define GPIO_PC19F_LCDCA_SEG4    _UL_(1 << 19)
+#define PIN_PA13F_LCDCA_SEG5           _L_(13) /**< \brief LCDCA signal: SEG5 on PA13 mux F */
+#define MUX_PA13F_LCDCA_SEG5            _L_(5)
 #define PINMUX_PA13F_LCDCA_SEG5    ((PIN_PA13F_LCDCA_SEG5 << 16) | MUX_PA13F_LCDCA_SEG5)
-#define GPIO_PA13F_LCDCA_SEG5    _UL(1 << 13)
-#define PIN_PA14F_LCDCA_SEG6           _L(14) /**< \brief LCDCA signal: SEG6 on PA14 mux F */
-#define MUX_PA14F_LCDCA_SEG6            _L(5)
+#define GPIO_PA13F_LCDCA_SEG5    _UL_(1 << 13)
+#define PIN_PA14F_LCDCA_SEG6           _L_(14) /**< \brief LCDCA signal: SEG6 on PA14 mux F */
+#define MUX_PA14F_LCDCA_SEG6            _L_(5)
 #define PINMUX_PA14F_LCDCA_SEG6    ((PIN_PA14F_LCDCA_SEG6 << 16) | MUX_PA14F_LCDCA_SEG6)
-#define GPIO_PA14F_LCDCA_SEG6    _UL(1 << 14)
-#define PIN_PA15F_LCDCA_SEG7           _L(15) /**< \brief LCDCA signal: SEG7 on PA15 mux F */
-#define MUX_PA15F_LCDCA_SEG7            _L(5)
+#define GPIO_PA14F_LCDCA_SEG6    _UL_(1 << 14)
+#define PIN_PA15F_LCDCA_SEG7           _L_(15) /**< \brief LCDCA signal: SEG7 on PA15 mux F */
+#define MUX_PA15F_LCDCA_SEG7            _L_(5)
 #define PINMUX_PA15F_LCDCA_SEG7    ((PIN_PA15F_LCDCA_SEG7 << 16) | MUX_PA15F_LCDCA_SEG7)
-#define GPIO_PA15F_LCDCA_SEG7    _UL(1 << 15)
-#define PIN_PA16F_LCDCA_SEG8           _L(16) /**< \brief LCDCA signal: SEG8 on PA16 mux F */
-#define MUX_PA16F_LCDCA_SEG8            _L(5)
+#define GPIO_PA15F_LCDCA_SEG7    _UL_(1 << 15)
+#define PIN_PA16F_LCDCA_SEG8           _L_(16) /**< \brief LCDCA signal: SEG8 on PA16 mux F */
+#define MUX_PA16F_LCDCA_SEG8            _L_(5)
 #define PINMUX_PA16F_LCDCA_SEG8    ((PIN_PA16F_LCDCA_SEG8 << 16) | MUX_PA16F_LCDCA_SEG8)
-#define GPIO_PA16F_LCDCA_SEG8    _UL(1 << 16)
-#define PIN_PA17F_LCDCA_SEG9           _L(17) /**< \brief LCDCA signal: SEG9 on PA17 mux F */
-#define MUX_PA17F_LCDCA_SEG9            _L(5)
+#define GPIO_PA16F_LCDCA_SEG8    _UL_(1 << 16)
+#define PIN_PA17F_LCDCA_SEG9           _L_(17) /**< \brief LCDCA signal: SEG9 on PA17 mux F */
+#define MUX_PA17F_LCDCA_SEG9            _L_(5)
 #define PINMUX_PA17F_LCDCA_SEG9    ((PIN_PA17F_LCDCA_SEG9 << 16) | MUX_PA17F_LCDCA_SEG9)
-#define GPIO_PA17F_LCDCA_SEG9    _UL(1 << 17)
-#define PIN_PC20F_LCDCA_SEG10          _L(84) /**< \brief LCDCA signal: SEG10 on PC20 mux F */
-#define MUX_PC20F_LCDCA_SEG10           _L(5)
+#define GPIO_PA17F_LCDCA_SEG9    _UL_(1 << 17)
+#define PIN_PC20F_LCDCA_SEG10          _L_(84) /**< \brief LCDCA signal: SEG10 on PC20 mux F */
+#define MUX_PC20F_LCDCA_SEG10           _L_(5)
 #define PINMUX_PC20F_LCDCA_SEG10   ((PIN_PC20F_LCDCA_SEG10 << 16) | MUX_PC20F_LCDCA_SEG10)
-#define GPIO_PC20F_LCDCA_SEG10   _UL(1 << 20)
-#define PIN_PC21F_LCDCA_SEG11          _L(85) /**< \brief LCDCA signal: SEG11 on PC21 mux F */
-#define MUX_PC21F_LCDCA_SEG11           _L(5)
+#define GPIO_PC20F_LCDCA_SEG10   _UL_(1 << 20)
+#define PIN_PC21F_LCDCA_SEG11          _L_(85) /**< \brief LCDCA signal: SEG11 on PC21 mux F */
+#define MUX_PC21F_LCDCA_SEG11           _L_(5)
 #define PINMUX_PC21F_LCDCA_SEG11   ((PIN_PC21F_LCDCA_SEG11 << 16) | MUX_PC21F_LCDCA_SEG11)
-#define GPIO_PC21F_LCDCA_SEG11   _UL(1 << 21)
-#define PIN_PC22F_LCDCA_SEG12          _L(86) /**< \brief LCDCA signal: SEG12 on PC22 mux F */
-#define MUX_PC22F_LCDCA_SEG12           _L(5)
+#define GPIO_PC21F_LCDCA_SEG11   _UL_(1 << 21)
+#define PIN_PC22F_LCDCA_SEG12          _L_(86) /**< \brief LCDCA signal: SEG12 on PC22 mux F */
+#define MUX_PC22F_LCDCA_SEG12           _L_(5)
 #define PINMUX_PC22F_LCDCA_SEG12   ((PIN_PC22F_LCDCA_SEG12 << 16) | MUX_PC22F_LCDCA_SEG12)
-#define GPIO_PC22F_LCDCA_SEG12   _UL(1 << 22)
-#define PIN_PC23F_LCDCA_SEG13          _L(87) /**< \brief LCDCA signal: SEG13 on PC23 mux F */
-#define MUX_PC23F_LCDCA_SEG13           _L(5)
+#define GPIO_PC22F_LCDCA_SEG12   _UL_(1 << 22)
+#define PIN_PC23F_LCDCA_SEG13          _L_(87) /**< \brief LCDCA signal: SEG13 on PC23 mux F */
+#define MUX_PC23F_LCDCA_SEG13           _L_(5)
 #define PINMUX_PC23F_LCDCA_SEG13   ((PIN_PC23F_LCDCA_SEG13 << 16) | MUX_PC23F_LCDCA_SEG13)
-#define GPIO_PC23F_LCDCA_SEG13   _UL(1 << 23)
-#define PIN_PB08F_LCDCA_SEG14          _L(40) /**< \brief LCDCA signal: SEG14 on PB08 mux F */
-#define MUX_PB08F_LCDCA_SEG14           _L(5)
+#define GPIO_PC23F_LCDCA_SEG13   _UL_(1 << 23)
+#define PIN_PB08F_LCDCA_SEG14          _L_(40) /**< \brief LCDCA signal: SEG14 on PB08 mux F */
+#define MUX_PB08F_LCDCA_SEG14           _L_(5)
 #define PINMUX_PB08F_LCDCA_SEG14   ((PIN_PB08F_LCDCA_SEG14 << 16) | MUX_PB08F_LCDCA_SEG14)
-#define GPIO_PB08F_LCDCA_SEG14   _UL(1 <<  8)
-#define PIN_PB09F_LCDCA_SEG15          _L(41) /**< \brief LCDCA signal: SEG15 on PB09 mux F */
-#define MUX_PB09F_LCDCA_SEG15           _L(5)
+#define GPIO_PB08F_LCDCA_SEG14   _UL_(1 <<  8)
+#define PIN_PB09F_LCDCA_SEG15          _L_(41) /**< \brief LCDCA signal: SEG15 on PB09 mux F */
+#define MUX_PB09F_LCDCA_SEG15           _L_(5)
 #define PINMUX_PB09F_LCDCA_SEG15   ((PIN_PB09F_LCDCA_SEG15 << 16) | MUX_PB09F_LCDCA_SEG15)
-#define GPIO_PB09F_LCDCA_SEG15   _UL(1 <<  9)
-#define PIN_PB10F_LCDCA_SEG16          _L(42) /**< \brief LCDCA signal: SEG16 on PB10 mux F */
-#define MUX_PB10F_LCDCA_SEG16           _L(5)
+#define GPIO_PB09F_LCDCA_SEG15   _UL_(1 <<  9)
+#define PIN_PB10F_LCDCA_SEG16          _L_(42) /**< \brief LCDCA signal: SEG16 on PB10 mux F */
+#define MUX_PB10F_LCDCA_SEG16           _L_(5)
 #define PINMUX_PB10F_LCDCA_SEG16   ((PIN_PB10F_LCDCA_SEG16 << 16) | MUX_PB10F_LCDCA_SEG16)
-#define GPIO_PB10F_LCDCA_SEG16   _UL(1 << 10)
-#define PIN_PB11F_LCDCA_SEG17          _L(43) /**< \brief LCDCA signal: SEG17 on PB11 mux F */
-#define MUX_PB11F_LCDCA_SEG17           _L(5)
+#define GPIO_PB10F_LCDCA_SEG16   _UL_(1 << 10)
+#define PIN_PB11F_LCDCA_SEG17          _L_(43) /**< \brief LCDCA signal: SEG17 on PB11 mux F */
+#define MUX_PB11F_LCDCA_SEG17           _L_(5)
 #define PINMUX_PB11F_LCDCA_SEG17   ((PIN_PB11F_LCDCA_SEG17 << 16) | MUX_PB11F_LCDCA_SEG17)
-#define GPIO_PB11F_LCDCA_SEG17   _UL(1 << 11)
-#define PIN_PA18F_LCDCA_SEG18          _L(18) /**< \brief LCDCA signal: SEG18 on PA18 mux F */
-#define MUX_PA18F_LCDCA_SEG18           _L(5)
+#define GPIO_PB11F_LCDCA_SEG17   _UL_(1 << 11)
+#define PIN_PA18F_LCDCA_SEG18          _L_(18) /**< \brief LCDCA signal: SEG18 on PA18 mux F */
+#define MUX_PA18F_LCDCA_SEG18           _L_(5)
 #define PINMUX_PA18F_LCDCA_SEG18   ((PIN_PA18F_LCDCA_SEG18 << 16) | MUX_PA18F_LCDCA_SEG18)
-#define GPIO_PA18F_LCDCA_SEG18   _UL(1 << 18)
-#define PIN_PA19F_LCDCA_SEG19          _L(19) /**< \brief LCDCA signal: SEG19 on PA19 mux F */
-#define MUX_PA19F_LCDCA_SEG19           _L(5)
+#define GPIO_PA18F_LCDCA_SEG18   _UL_(1 << 18)
+#define PIN_PA19F_LCDCA_SEG19          _L_(19) /**< \brief LCDCA signal: SEG19 on PA19 mux F */
+#define MUX_PA19F_LCDCA_SEG19           _L_(5)
 #define PINMUX_PA19F_LCDCA_SEG19   ((PIN_PA19F_LCDCA_SEG19 << 16) | MUX_PA19F_LCDCA_SEG19)
-#define GPIO_PA19F_LCDCA_SEG19   _UL(1 << 19)
-#define PIN_PA20F_LCDCA_SEG20          _L(20) /**< \brief LCDCA signal: SEG20 on PA20 mux F */
-#define MUX_PA20F_LCDCA_SEG20           _L(5)
+#define GPIO_PA19F_LCDCA_SEG19   _UL_(1 << 19)
+#define PIN_PA20F_LCDCA_SEG20          _L_(20) /**< \brief LCDCA signal: SEG20 on PA20 mux F */
+#define MUX_PA20F_LCDCA_SEG20           _L_(5)
 #define PINMUX_PA20F_LCDCA_SEG20   ((PIN_PA20F_LCDCA_SEG20 << 16) | MUX_PA20F_LCDCA_SEG20)
-#define GPIO_PA20F_LCDCA_SEG20   _UL(1 << 20)
-#define PIN_PB07F_LCDCA_SEG21          _L(39) /**< \brief LCDCA signal: SEG21 on PB07 mux F */
-#define MUX_PB07F_LCDCA_SEG21           _L(5)
+#define GPIO_PA20F_LCDCA_SEG20   _UL_(1 << 20)
+#define PIN_PB07F_LCDCA_SEG21          _L_(39) /**< \brief LCDCA signal: SEG21 on PB07 mux F */
+#define MUX_PB07F_LCDCA_SEG21           _L_(5)
 #define PINMUX_PB07F_LCDCA_SEG21   ((PIN_PB07F_LCDCA_SEG21 << 16) | MUX_PB07F_LCDCA_SEG21)
-#define GPIO_PB07F_LCDCA_SEG21   _UL(1 <<  7)
-#define PIN_PB06F_LCDCA_SEG22          _L(38) /**< \brief LCDCA signal: SEG22 on PB06 mux F */
-#define MUX_PB06F_LCDCA_SEG22           _L(5)
+#define GPIO_PB07F_LCDCA_SEG21   _UL_(1 <<  7)
+#define PIN_PB06F_LCDCA_SEG22          _L_(38) /**< \brief LCDCA signal: SEG22 on PB06 mux F */
+#define MUX_PB06F_LCDCA_SEG22           _L_(5)
 #define PINMUX_PB06F_LCDCA_SEG22   ((PIN_PB06F_LCDCA_SEG22 << 16) | MUX_PB06F_LCDCA_SEG22)
-#define GPIO_PB06F_LCDCA_SEG22   _UL(1 <<  6)
-#define PIN_PA08F_LCDCA_SEG23           _L(8) /**< \brief LCDCA signal: SEG23 on PA08 mux F */
-#define MUX_PA08F_LCDCA_SEG23           _L(5)
+#define GPIO_PB06F_LCDCA_SEG22   _UL_(1 <<  6)
+#define PIN_PA08F_LCDCA_SEG23           _L_(8) /**< \brief LCDCA signal: SEG23 on PA08 mux F */
+#define MUX_PA08F_LCDCA_SEG23           _L_(5)
 #define PINMUX_PA08F_LCDCA_SEG23   ((PIN_PA08F_LCDCA_SEG23 << 16) | MUX_PA08F_LCDCA_SEG23)
-#define GPIO_PA08F_LCDCA_SEG23   _UL(1 <<  8)
-#define PIN_PC24F_LCDCA_SEG24          _L(88) /**< \brief LCDCA signal: SEG24 on PC24 mux F */
-#define MUX_PC24F_LCDCA_SEG24           _L(5)
+#define GPIO_PA08F_LCDCA_SEG23   _UL_(1 <<  8)
+#define PIN_PC24F_LCDCA_SEG24          _L_(88) /**< \brief LCDCA signal: SEG24 on PC24 mux F */
+#define MUX_PC24F_LCDCA_SEG24           _L_(5)
 #define PINMUX_PC24F_LCDCA_SEG24   ((PIN_PC24F_LCDCA_SEG24 << 16) | MUX_PC24F_LCDCA_SEG24)
-#define GPIO_PC24F_LCDCA_SEG24   _UL(1 << 24)
-#define PIN_PC25F_LCDCA_SEG25          _L(89) /**< \brief LCDCA signal: SEG25 on PC25 mux F */
-#define MUX_PC25F_LCDCA_SEG25           _L(5)
+#define GPIO_PC24F_LCDCA_SEG24   _UL_(1 << 24)
+#define PIN_PC25F_LCDCA_SEG25          _L_(89) /**< \brief LCDCA signal: SEG25 on PC25 mux F */
+#define MUX_PC25F_LCDCA_SEG25           _L_(5)
 #define PINMUX_PC25F_LCDCA_SEG25   ((PIN_PC25F_LCDCA_SEG25 << 16) | MUX_PC25F_LCDCA_SEG25)
-#define GPIO_PC25F_LCDCA_SEG25   _UL(1 << 25)
-#define PIN_PC26F_LCDCA_SEG26          _L(90) /**< \brief LCDCA signal: SEG26 on PC26 mux F */
-#define MUX_PC26F_LCDCA_SEG26           _L(5)
+#define GPIO_PC25F_LCDCA_SEG25   _UL_(1 << 25)
+#define PIN_PC26F_LCDCA_SEG26          _L_(90) /**< \brief LCDCA signal: SEG26 on PC26 mux F */
+#define MUX_PC26F_LCDCA_SEG26           _L_(5)
 #define PINMUX_PC26F_LCDCA_SEG26   ((PIN_PC26F_LCDCA_SEG26 << 16) | MUX_PC26F_LCDCA_SEG26)
-#define GPIO_PC26F_LCDCA_SEG26   _UL(1 << 26)
-#define PIN_PC27F_LCDCA_SEG27          _L(91) /**< \brief LCDCA signal: SEG27 on PC27 mux F */
-#define MUX_PC27F_LCDCA_SEG27           _L(5)
+#define GPIO_PC26F_LCDCA_SEG26   _UL_(1 << 26)
+#define PIN_PC27F_LCDCA_SEG27          _L_(91) /**< \brief LCDCA signal: SEG27 on PC27 mux F */
+#define MUX_PC27F_LCDCA_SEG27           _L_(5)
 #define PINMUX_PC27F_LCDCA_SEG27   ((PIN_PC27F_LCDCA_SEG27 << 16) | MUX_PC27F_LCDCA_SEG27)
-#define GPIO_PC27F_LCDCA_SEG27   _UL(1 << 27)
-#define PIN_PC28F_LCDCA_SEG28          _L(92) /**< \brief LCDCA signal: SEG28 on PC28 mux F */
-#define MUX_PC28F_LCDCA_SEG28           _L(5)
+#define GPIO_PC27F_LCDCA_SEG27   _UL_(1 << 27)
+#define PIN_PC28F_LCDCA_SEG28          _L_(92) /**< \brief LCDCA signal: SEG28 on PC28 mux F */
+#define MUX_PC28F_LCDCA_SEG28           _L_(5)
 #define PINMUX_PC28F_LCDCA_SEG28   ((PIN_PC28F_LCDCA_SEG28 << 16) | MUX_PC28F_LCDCA_SEG28)
-#define GPIO_PC28F_LCDCA_SEG28   _UL(1 << 28)
-#define PIN_PC29F_LCDCA_SEG29          _L(93) /**< \brief LCDCA signal: SEG29 on PC29 mux F */
-#define MUX_PC29F_LCDCA_SEG29           _L(5)
+#define GPIO_PC28F_LCDCA_SEG28   _UL_(1 << 28)
+#define PIN_PC29F_LCDCA_SEG29          _L_(93) /**< \brief LCDCA signal: SEG29 on PC29 mux F */
+#define MUX_PC29F_LCDCA_SEG29           _L_(5)
 #define PINMUX_PC29F_LCDCA_SEG29   ((PIN_PC29F_LCDCA_SEG29 << 16) | MUX_PC29F_LCDCA_SEG29)
-#define GPIO_PC29F_LCDCA_SEG29   _UL(1 << 29)
-#define PIN_PC30F_LCDCA_SEG30          _L(94) /**< \brief LCDCA signal: SEG30 on PC30 mux F */
-#define MUX_PC30F_LCDCA_SEG30           _L(5)
+#define GPIO_PC29F_LCDCA_SEG29   _UL_(1 << 29)
+#define PIN_PC30F_LCDCA_SEG30          _L_(94) /**< \brief LCDCA signal: SEG30 on PC30 mux F */
+#define MUX_PC30F_LCDCA_SEG30           _L_(5)
 #define PINMUX_PC30F_LCDCA_SEG30   ((PIN_PC30F_LCDCA_SEG30 << 16) | MUX_PC30F_LCDCA_SEG30)
-#define GPIO_PC30F_LCDCA_SEG30   _UL(1 << 30)
-#define PIN_PC31F_LCDCA_SEG31          _L(95) /**< \brief LCDCA signal: SEG31 on PC31 mux F */
-#define MUX_PC31F_LCDCA_SEG31           _L(5)
+#define GPIO_PC30F_LCDCA_SEG30   _UL_(1 << 30)
+#define PIN_PC31F_LCDCA_SEG31          _L_(95) /**< \brief LCDCA signal: SEG31 on PC31 mux F */
+#define MUX_PC31F_LCDCA_SEG31           _L_(5)
 #define PINMUX_PC31F_LCDCA_SEG31   ((PIN_PC31F_LCDCA_SEG31 << 16) | MUX_PC31F_LCDCA_SEG31)
-#define GPIO_PC31F_LCDCA_SEG31   _UL(1 << 31)
-#define PIN_PB12F_LCDCA_SEG32          _L(44) /**< \brief LCDCA signal: SEG32 on PB12 mux F */
-#define MUX_PB12F_LCDCA_SEG32           _L(5)
+#define GPIO_PC31F_LCDCA_SEG31   _UL_(1 << 31)
+#define PIN_PB12F_LCDCA_SEG32          _L_(44) /**< \brief LCDCA signal: SEG32 on PB12 mux F */
+#define MUX_PB12F_LCDCA_SEG32           _L_(5)
 #define PINMUX_PB12F_LCDCA_SEG32   ((PIN_PB12F_LCDCA_SEG32 << 16) | MUX_PB12F_LCDCA_SEG32)
-#define GPIO_PB12F_LCDCA_SEG32   _UL(1 << 12)
-#define PIN_PB13F_LCDCA_SEG33          _L(45) /**< \brief LCDCA signal: SEG33 on PB13 mux F */
-#define MUX_PB13F_LCDCA_SEG33           _L(5)
+#define GPIO_PB12F_LCDCA_SEG32   _UL_(1 << 12)
+#define PIN_PB13F_LCDCA_SEG33          _L_(45) /**< \brief LCDCA signal: SEG33 on PB13 mux F */
+#define MUX_PB13F_LCDCA_SEG33           _L_(5)
 #define PINMUX_PB13F_LCDCA_SEG33   ((PIN_PB13F_LCDCA_SEG33 << 16) | MUX_PB13F_LCDCA_SEG33)
-#define GPIO_PB13F_LCDCA_SEG33   _UL(1 << 13)
-#define PIN_PA21F_LCDCA_SEG34          _L(21) /**< \brief LCDCA signal: SEG34 on PA21 mux F */
-#define MUX_PA21F_LCDCA_SEG34           _L(5)
+#define GPIO_PB13F_LCDCA_SEG33   _UL_(1 << 13)
+#define PIN_PA21F_LCDCA_SEG34          _L_(21) /**< \brief LCDCA signal: SEG34 on PA21 mux F */
+#define MUX_PA21F_LCDCA_SEG34           _L_(5)
 #define PINMUX_PA21F_LCDCA_SEG34   ((PIN_PA21F_LCDCA_SEG34 << 16) | MUX_PA21F_LCDCA_SEG34)
-#define GPIO_PA21F_LCDCA_SEG34   _UL(1 << 21)
-#define PIN_PA22F_LCDCA_SEG35          _L(22) /**< \brief LCDCA signal: SEG35 on PA22 mux F */
-#define MUX_PA22F_LCDCA_SEG35           _L(5)
+#define GPIO_PA21F_LCDCA_SEG34   _UL_(1 << 21)
+#define PIN_PA22F_LCDCA_SEG35          _L_(22) /**< \brief LCDCA signal: SEG35 on PA22 mux F */
+#define MUX_PA22F_LCDCA_SEG35           _L_(5)
 #define PINMUX_PA22F_LCDCA_SEG35   ((PIN_PA22F_LCDCA_SEG35 << 16) | MUX_PA22F_LCDCA_SEG35)
-#define GPIO_PA22F_LCDCA_SEG35   _UL(1 << 22)
-#define PIN_PB14F_LCDCA_SEG36          _L(46) /**< \brief LCDCA signal: SEG36 on PB14 mux F */
-#define MUX_PB14F_LCDCA_SEG36           _L(5)
+#define GPIO_PA22F_LCDCA_SEG35   _UL_(1 << 22)
+#define PIN_PB14F_LCDCA_SEG36          _L_(46) /**< \brief LCDCA signal: SEG36 on PB14 mux F */
+#define MUX_PB14F_LCDCA_SEG36           _L_(5)
 #define PINMUX_PB14F_LCDCA_SEG36   ((PIN_PB14F_LCDCA_SEG36 << 16) | MUX_PB14F_LCDCA_SEG36)
-#define GPIO_PB14F_LCDCA_SEG36   _UL(1 << 14)
-#define PIN_PB15F_LCDCA_SEG37          _L(47) /**< \brief LCDCA signal: SEG37 on PB15 mux F */
-#define MUX_PB15F_LCDCA_SEG37           _L(5)
+#define GPIO_PB14F_LCDCA_SEG36   _UL_(1 << 14)
+#define PIN_PB15F_LCDCA_SEG37          _L_(47) /**< \brief LCDCA signal: SEG37 on PB15 mux F */
+#define MUX_PB15F_LCDCA_SEG37           _L_(5)
 #define PINMUX_PB15F_LCDCA_SEG37   ((PIN_PB15F_LCDCA_SEG37 << 16) | MUX_PB15F_LCDCA_SEG37)
-#define GPIO_PB15F_LCDCA_SEG37   _UL(1 << 15)
-#define PIN_PA23F_LCDCA_SEG38          _L(23) /**< \brief LCDCA signal: SEG38 on PA23 mux F */
-#define MUX_PA23F_LCDCA_SEG38           _L(5)
+#define GPIO_PB15F_LCDCA_SEG37   _UL_(1 << 15)
+#define PIN_PA23F_LCDCA_SEG38          _L_(23) /**< \brief LCDCA signal: SEG38 on PA23 mux F */
+#define MUX_PA23F_LCDCA_SEG38           _L_(5)
 #define PINMUX_PA23F_LCDCA_SEG38   ((PIN_PA23F_LCDCA_SEG38 << 16) | MUX_PA23F_LCDCA_SEG38)
-#define GPIO_PA23F_LCDCA_SEG38   _UL(1 << 23)
-#define PIN_PA24F_LCDCA_SEG39          _L(24) /**< \brief LCDCA signal: SEG39 on PA24 mux F */
-#define MUX_PA24F_LCDCA_SEG39           _L(5)
+#define GPIO_PA23F_LCDCA_SEG38   _UL_(1 << 23)
+#define PIN_PA24F_LCDCA_SEG39          _L_(24) /**< \brief LCDCA signal: SEG39 on PA24 mux F */
+#define MUX_PA24F_LCDCA_SEG39           _L_(5)
 #define PINMUX_PA24F_LCDCA_SEG39   ((PIN_PA24F_LCDCA_SEG39 << 16) | MUX_PA24F_LCDCA_SEG39)
-#define GPIO_PA24F_LCDCA_SEG39   _UL(1 << 24)
+#define GPIO_PA24F_LCDCA_SEG39   _UL_(1 << 24)
 /* ========== GPIO definition for USBC peripheral ========== */
-#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
-#define MUX_PA25A_USBC_DM               _L(0)
+#define PIN_PA25A_USBC_DM              _L_(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L_(0)
 #define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
-#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
-#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
-#define MUX_PA26A_USBC_DP               _L(0)
+#define GPIO_PA25A_USBC_DM       _UL_(1 << 25)
+#define PIN_PA26A_USBC_DP              _L_(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L_(0)
 #define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
-#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+#define GPIO_PA26A_USBC_DP       _UL_(1 << 26)
 /* ========== GPIO definition for PEVC peripheral ========== */
-#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
-#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PIN_PA08C_PEVC_PAD_EVT0         _L_(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
-#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
-#define PIN_PB12C_PEVC_PAD_EVT0        _L(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
-#define MUX_PB12C_PEVC_PAD_EVT0         _L(2)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL_(1 <<  8)
+#define PIN_PB12C_PEVC_PAD_EVT0        _L_(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
+#define MUX_PB12C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PB12C_PEVC_PAD_EVT0  ((PIN_PB12C_PEVC_PAD_EVT0 << 16) | MUX_PB12C_PEVC_PAD_EVT0)
-#define GPIO_PB12C_PEVC_PAD_EVT0  _UL(1 << 12)
-#define PIN_PC07C_PEVC_PAD_EVT0        _L(71) /**< \brief PEVC signal: PAD_EVT0 on PC07 mux C */
-#define MUX_PC07C_PEVC_PAD_EVT0         _L(2)
+#define GPIO_PB12C_PEVC_PAD_EVT0  _UL_(1 << 12)
+#define PIN_PC07C_PEVC_PAD_EVT0        _L_(71) /**< \brief PEVC signal: PAD_EVT0 on PC07 mux C */
+#define MUX_PC07C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PC07C_PEVC_PAD_EVT0  ((PIN_PC07C_PEVC_PAD_EVT0 << 16) | MUX_PC07C_PEVC_PAD_EVT0)
-#define GPIO_PC07C_PEVC_PAD_EVT0  _UL(1 <<  7)
-#define PIN_PC24C_PEVC_PAD_EVT0        _L(88) /**< \brief PEVC signal: PAD_EVT0 on PC24 mux C */
-#define MUX_PC24C_PEVC_PAD_EVT0         _L(2)
+#define GPIO_PC07C_PEVC_PAD_EVT0  _UL_(1 <<  7)
+#define PIN_PC24C_PEVC_PAD_EVT0        _L_(88) /**< \brief PEVC signal: PAD_EVT0 on PC24 mux C */
+#define MUX_PC24C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PC24C_PEVC_PAD_EVT0  ((PIN_PC24C_PEVC_PAD_EVT0 << 16) | MUX_PC24C_PEVC_PAD_EVT0)
-#define GPIO_PC24C_PEVC_PAD_EVT0  _UL(1 << 24)
-#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
-#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PC24C_PEVC_PAD_EVT0  _UL_(1 << 24)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L_(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
-#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
-#define PIN_PB13C_PEVC_PAD_EVT1        _L(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
-#define MUX_PB13C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL_(1 <<  9)
+#define PIN_PB13C_PEVC_PAD_EVT1        _L_(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
+#define MUX_PB13C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PB13C_PEVC_PAD_EVT1  ((PIN_PB13C_PEVC_PAD_EVT1 << 16) | MUX_PB13C_PEVC_PAD_EVT1)
-#define GPIO_PB13C_PEVC_PAD_EVT1  _UL(1 << 13)
-#define PIN_PC08C_PEVC_PAD_EVT1        _L(72) /**< \brief PEVC signal: PAD_EVT1 on PC08 mux C */
-#define MUX_PC08C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PB13C_PEVC_PAD_EVT1  _UL_(1 << 13)
+#define PIN_PC08C_PEVC_PAD_EVT1        _L_(72) /**< \brief PEVC signal: PAD_EVT1 on PC08 mux C */
+#define MUX_PC08C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PC08C_PEVC_PAD_EVT1  ((PIN_PC08C_PEVC_PAD_EVT1 << 16) | MUX_PC08C_PEVC_PAD_EVT1)
-#define GPIO_PC08C_PEVC_PAD_EVT1  _UL(1 <<  8)
-#define PIN_PC25C_PEVC_PAD_EVT1        _L(89) /**< \brief PEVC signal: PAD_EVT1 on PC25 mux C */
-#define MUX_PC25C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PC08C_PEVC_PAD_EVT1  _UL_(1 <<  8)
+#define PIN_PC25C_PEVC_PAD_EVT1        _L_(89) /**< \brief PEVC signal: PAD_EVT1 on PC25 mux C */
+#define MUX_PC25C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PC25C_PEVC_PAD_EVT1  ((PIN_PC25C_PEVC_PAD_EVT1 << 16) | MUX_PC25C_PEVC_PAD_EVT1)
-#define GPIO_PC25C_PEVC_PAD_EVT1  _UL(1 << 25)
-#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
-#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PC25C_PEVC_PAD_EVT1  _UL_(1 << 25)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L_(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
-#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
-#define PIN_PC11C_PEVC_PAD_EVT2        _L(75) /**< \brief PEVC signal: PAD_EVT2 on PC11 mux C */
-#define MUX_PC11C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL_(1 << 10)
+#define PIN_PC11C_PEVC_PAD_EVT2        _L_(75) /**< \brief PEVC signal: PAD_EVT2 on PC11 mux C */
+#define MUX_PC11C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PC11C_PEVC_PAD_EVT2  ((PIN_PC11C_PEVC_PAD_EVT2 << 16) | MUX_PC11C_PEVC_PAD_EVT2)
-#define GPIO_PC11C_PEVC_PAD_EVT2  _UL(1 << 11)
-#define PIN_PC26C_PEVC_PAD_EVT2        _L(90) /**< \brief PEVC signal: PAD_EVT2 on PC26 mux C */
-#define MUX_PC26C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PC11C_PEVC_PAD_EVT2  _UL_(1 << 11)
+#define PIN_PC26C_PEVC_PAD_EVT2        _L_(90) /**< \brief PEVC signal: PAD_EVT2 on PC26 mux C */
+#define MUX_PC26C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PC26C_PEVC_PAD_EVT2  ((PIN_PC26C_PEVC_PAD_EVT2 << 16) | MUX_PC26C_PEVC_PAD_EVT2)
-#define GPIO_PC26C_PEVC_PAD_EVT2  _UL(1 << 26)
-#define PIN_PB09B_PEVC_PAD_EVT2        _L(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
-#define MUX_PB09B_PEVC_PAD_EVT2         _L(1)
+#define GPIO_PC26C_PEVC_PAD_EVT2  _UL_(1 << 26)
+#define PIN_PB09B_PEVC_PAD_EVT2        _L_(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
+#define MUX_PB09B_PEVC_PAD_EVT2         _L_(1)
 #define PINMUX_PB09B_PEVC_PAD_EVT2  ((PIN_PB09B_PEVC_PAD_EVT2 << 16) | MUX_PB09B_PEVC_PAD_EVT2)
-#define GPIO_PB09B_PEVC_PAD_EVT2  _UL(1 <<  9)
-#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
-#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define GPIO_PB09B_PEVC_PAD_EVT2  _UL_(1 <<  9)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L_(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L_(2)
 #define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
-#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
-#define PIN_PC27C_PEVC_PAD_EVT3        _L(91) /**< \brief PEVC signal: PAD_EVT3 on PC27 mux C */
-#define MUX_PC27C_PEVC_PAD_EVT3         _L(2)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL_(1 << 11)
+#define PIN_PC27C_PEVC_PAD_EVT3        _L_(91) /**< \brief PEVC signal: PAD_EVT3 on PC27 mux C */
+#define MUX_PC27C_PEVC_PAD_EVT3         _L_(2)
 #define PINMUX_PC27C_PEVC_PAD_EVT3  ((PIN_PC27C_PEVC_PAD_EVT3 << 16) | MUX_PC27C_PEVC_PAD_EVT3)
-#define GPIO_PC27C_PEVC_PAD_EVT3  _UL(1 << 27)
-#define PIN_PB10B_PEVC_PAD_EVT3        _L(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
-#define MUX_PB10B_PEVC_PAD_EVT3         _L(1)
+#define GPIO_PC27C_PEVC_PAD_EVT3  _UL_(1 << 27)
+#define PIN_PB10B_PEVC_PAD_EVT3        _L_(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
+#define MUX_PB10B_PEVC_PAD_EVT3         _L_(1)
 #define PINMUX_PB10B_PEVC_PAD_EVT3  ((PIN_PB10B_PEVC_PAD_EVT3 << 16) | MUX_PB10B_PEVC_PAD_EVT3)
-#define GPIO_PB10B_PEVC_PAD_EVT3  _UL(1 << 10)
+#define GPIO_PB10B_PEVC_PAD_EVT3  _UL_(1 << 10)
 /* ========== GPIO definition for SCIF peripheral ========== */
-#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
-#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PIN_PA19E_SCIF_GCLK0           _L_(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
-#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
-#define PIN_PB10E_SCIF_GCLK0           _L(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
-#define MUX_PB10E_SCIF_GCLK0            _L(4)
+#define GPIO_PA19E_SCIF_GCLK0    _UL_(1 << 19)
+#define PIN_PB10E_SCIF_GCLK0           _L_(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
+#define MUX_PB10E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PB10E_SCIF_GCLK0    ((PIN_PB10E_SCIF_GCLK0 << 16) | MUX_PB10E_SCIF_GCLK0)
-#define GPIO_PB10E_SCIF_GCLK0    _UL(1 << 10)
-#define PIN_PC26E_SCIF_GCLK0           _L(90) /**< \brief SCIF signal: GCLK0 on PC26 mux E */
-#define MUX_PC26E_SCIF_GCLK0            _L(4)
+#define GPIO_PB10E_SCIF_GCLK0    _UL_(1 << 10)
+#define PIN_PC26E_SCIF_GCLK0           _L_(90) /**< \brief SCIF signal: GCLK0 on PC26 mux E */
+#define MUX_PC26E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PC26E_SCIF_GCLK0    ((PIN_PC26E_SCIF_GCLK0 << 16) | MUX_PC26E_SCIF_GCLK0)
-#define GPIO_PC26E_SCIF_GCLK0    _UL(1 << 26)
-#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
-#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define GPIO_PC26E_SCIF_GCLK0    _UL_(1 << 26)
+#define PIN_PA02A_SCIF_GCLK0            _L_(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L_(0)
 #define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
-#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
-#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
-#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define GPIO_PA02A_SCIF_GCLK0    _UL_(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L_(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
-#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
-#define PIN_PB11E_SCIF_GCLK1           _L(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
-#define MUX_PB11E_SCIF_GCLK1            _L(4)
+#define GPIO_PA20E_SCIF_GCLK1    _UL_(1 << 20)
+#define PIN_PB11E_SCIF_GCLK1           _L_(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
+#define MUX_PB11E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PB11E_SCIF_GCLK1    ((PIN_PB11E_SCIF_GCLK1 << 16) | MUX_PB11E_SCIF_GCLK1)
-#define GPIO_PB11E_SCIF_GCLK1    _UL(1 << 11)
-#define PIN_PC27E_SCIF_GCLK1           _L(91) /**< \brief SCIF signal: GCLK1 on PC27 mux E */
-#define MUX_PC27E_SCIF_GCLK1            _L(4)
+#define GPIO_PB11E_SCIF_GCLK1    _UL_(1 << 11)
+#define PIN_PC27E_SCIF_GCLK1           _L_(91) /**< \brief SCIF signal: GCLK1 on PC27 mux E */
+#define MUX_PC27E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PC27E_SCIF_GCLK1    ((PIN_PC27E_SCIF_GCLK1 << 16) | MUX_PC27E_SCIF_GCLK1)
-#define GPIO_PC27E_SCIF_GCLK1    _UL(1 << 27)
-#define PIN_PB12E_SCIF_GCLK2           _L(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
-#define MUX_PB12E_SCIF_GCLK2            _L(4)
+#define GPIO_PC27E_SCIF_GCLK1    _UL_(1 << 27)
+#define PIN_PB12E_SCIF_GCLK2           _L_(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
+#define MUX_PB12E_SCIF_GCLK2            _L_(4)
 #define PINMUX_PB12E_SCIF_GCLK2    ((PIN_PB12E_SCIF_GCLK2 << 16) | MUX_PB12E_SCIF_GCLK2)
-#define GPIO_PB12E_SCIF_GCLK2    _UL(1 << 12)
-#define PIN_PC28E_SCIF_GCLK2           _L(92) /**< \brief SCIF signal: GCLK2 on PC28 mux E */
-#define MUX_PC28E_SCIF_GCLK2            _L(4)
+#define GPIO_PB12E_SCIF_GCLK2    _UL_(1 << 12)
+#define PIN_PC28E_SCIF_GCLK2           _L_(92) /**< \brief SCIF signal: GCLK2 on PC28 mux E */
+#define MUX_PC28E_SCIF_GCLK2            _L_(4)
 #define PINMUX_PC28E_SCIF_GCLK2    ((PIN_PC28E_SCIF_GCLK2 << 16) | MUX_PC28E_SCIF_GCLK2)
-#define GPIO_PC28E_SCIF_GCLK2    _UL(1 << 28)
-#define PIN_PB13E_SCIF_GCLK3           _L(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
-#define MUX_PB13E_SCIF_GCLK3            _L(4)
+#define GPIO_PC28E_SCIF_GCLK2    _UL_(1 << 28)
+#define PIN_PB13E_SCIF_GCLK3           _L_(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
+#define MUX_PB13E_SCIF_GCLK3            _L_(4)
 #define PINMUX_PB13E_SCIF_GCLK3    ((PIN_PB13E_SCIF_GCLK3 << 16) | MUX_PB13E_SCIF_GCLK3)
-#define GPIO_PB13E_SCIF_GCLK3    _UL(1 << 13)
-#define PIN_PC29E_SCIF_GCLK3           _L(93) /**< \brief SCIF signal: GCLK3 on PC29 mux E */
-#define MUX_PC29E_SCIF_GCLK3            _L(4)
+#define GPIO_PB13E_SCIF_GCLK3    _UL_(1 << 13)
+#define PIN_PC29E_SCIF_GCLK3           _L_(93) /**< \brief SCIF signal: GCLK3 on PC29 mux E */
+#define MUX_PC29E_SCIF_GCLK3            _L_(4)
 #define PINMUX_PC29E_SCIF_GCLK3    ((PIN_PC29E_SCIF_GCLK3 << 16) | MUX_PC29E_SCIF_GCLK3)
-#define GPIO_PC29E_SCIF_GCLK3    _UL(1 << 29)
-#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
-#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PC29E_SCIF_GCLK3    _UL_(1 << 29)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L_(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
-#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
-#define PIN_PB14E_SCIF_GCLK_IN0        _L(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
-#define MUX_PB14E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL_(1 << 23)
+#define PIN_PB14E_SCIF_GCLK_IN0        _L_(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
+#define MUX_PB14E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PB14E_SCIF_GCLK_IN0  ((PIN_PB14E_SCIF_GCLK_IN0 << 16) | MUX_PB14E_SCIF_GCLK_IN0)
-#define GPIO_PB14E_SCIF_GCLK_IN0  _UL(1 << 14)
-#define PIN_PC30E_SCIF_GCLK_IN0        _L(94) /**< \brief SCIF signal: GCLK_IN0 on PC30 mux E */
-#define MUX_PC30E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PB14E_SCIF_GCLK_IN0  _UL_(1 << 14)
+#define PIN_PC30E_SCIF_GCLK_IN0        _L_(94) /**< \brief SCIF signal: GCLK_IN0 on PC30 mux E */
+#define MUX_PC30E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PC30E_SCIF_GCLK_IN0  ((PIN_PC30E_SCIF_GCLK_IN0 << 16) | MUX_PC30E_SCIF_GCLK_IN0)
-#define GPIO_PC30E_SCIF_GCLK_IN0  _UL(1 << 30)
-#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
-#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PC30E_SCIF_GCLK_IN0  _UL_(1 << 30)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L_(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
-#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
-#define PIN_PB15E_SCIF_GCLK_IN1        _L(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
-#define MUX_PB15E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL_(1 << 24)
+#define PIN_PB15E_SCIF_GCLK_IN1        _L_(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
+#define MUX_PB15E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PB15E_SCIF_GCLK_IN1  ((PIN_PB15E_SCIF_GCLK_IN1 << 16) | MUX_PB15E_SCIF_GCLK_IN1)
-#define GPIO_PB15E_SCIF_GCLK_IN1  _UL(1 << 15)
-#define PIN_PC31E_SCIF_GCLK_IN1        _L(95) /**< \brief SCIF signal: GCLK_IN1 on PC31 mux E */
-#define MUX_PC31E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PB15E_SCIF_GCLK_IN1  _UL_(1 << 15)
+#define PIN_PC31E_SCIF_GCLK_IN1        _L_(95) /**< \brief SCIF signal: GCLK_IN1 on PC31 mux E */
+#define MUX_PC31E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PC31E_SCIF_GCLK_IN1  ((PIN_PC31E_SCIF_GCLK_IN1 << 16) | MUX_PC31E_SCIF_GCLK_IN1)
-#define GPIO_PC31E_SCIF_GCLK_IN1  _UL(1 << 31)
+#define GPIO_PC31E_SCIF_GCLK_IN1  _UL_(1 << 31)
 /* ========== GPIO definition for EIC peripheral ========== */
-#define PIN_PB01C_EIC_EXTINT0          _L(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
-#define MUX_PB01C_EIC_EXTINT0           _L(2)
+#define PIN_PB01C_EIC_EXTINT0          _L_(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
+#define MUX_PB01C_EIC_EXTINT0           _L_(2)
 #define PINMUX_PB01C_EIC_EXTINT0   ((PIN_PB01C_EIC_EXTINT0 << 16) | MUX_PB01C_EIC_EXTINT0)
-#define GPIO_PB01C_EIC_EXTINT0   _UL(1 <<  1)
-#define PIN_PB01C_EIC_EXTINT_NUM        _L(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
-#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
-#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define GPIO_PB01C_EIC_EXTINT0   _UL_(1 <<  1)
+#define PIN_PB01C_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PA06C_EIC_EXTINT1           _L_(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
-#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
-#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
-#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
-#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define GPIO_PA06C_EIC_EXTINT1   _UL_(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L_(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
-#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
-#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
-#define PIN_PC24B_EIC_EXTINT1          _L(88) /**< \brief EIC signal: EXTINT1 on PC24 mux B */
-#define MUX_PC24B_EIC_EXTINT1           _L(1)
+#define GPIO_PA16C_EIC_EXTINT1   _UL_(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PC24B_EIC_EXTINT1          _L_(88) /**< \brief EIC signal: EXTINT1 on PC24 mux B */
+#define MUX_PC24B_EIC_EXTINT1           _L_(1)
 #define PINMUX_PC24B_EIC_EXTINT1   ((PIN_PC24B_EIC_EXTINT1 << 16) | MUX_PC24B_EIC_EXTINT1)
-#define GPIO_PC24B_EIC_EXTINT1   _UL(1 << 24)
-#define PIN_PC24B_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PC24 External Interrupt Line */
-#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
-#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define GPIO_PC24B_EIC_EXTINT1   _UL_(1 << 24)
+#define PIN_PC24B_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PC24 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L_(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
-#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
-#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
-#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
-#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL_(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L_(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
-#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
-#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
-#define PIN_PC25B_EIC_EXTINT2          _L(89) /**< \brief EIC signal: EXTINT2 on PC25 mux B */
-#define MUX_PC25B_EIC_EXTINT2           _L(1)
+#define GPIO_PA17C_EIC_EXTINT2   _UL_(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PC25B_EIC_EXTINT2          _L_(89) /**< \brief EIC signal: EXTINT2 on PC25 mux B */
+#define MUX_PC25B_EIC_EXTINT2           _L_(1)
 #define PINMUX_PC25B_EIC_EXTINT2   ((PIN_PC25B_EIC_EXTINT2 << 16) | MUX_PC25B_EIC_EXTINT2)
-#define GPIO_PC25B_EIC_EXTINT2   _UL(1 << 25)
-#define PIN_PC25B_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PC25 External Interrupt Line */
-#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
-#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define GPIO_PC25B_EIC_EXTINT2   _UL_(1 << 25)
+#define PIN_PC25B_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PC25 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L_(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
-#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
-#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
-#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
-#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define GPIO_PA05C_EIC_EXTINT3   _UL_(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L_(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
-#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
-#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
-#define PIN_PC26B_EIC_EXTINT3          _L(90) /**< \brief EIC signal: EXTINT3 on PC26 mux B */
-#define MUX_PC26B_EIC_EXTINT3           _L(1)
+#define GPIO_PA18C_EIC_EXTINT3   _UL_(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PC26B_EIC_EXTINT3          _L_(90) /**< \brief EIC signal: EXTINT3 on PC26 mux B */
+#define MUX_PC26B_EIC_EXTINT3           _L_(1)
 #define PINMUX_PC26B_EIC_EXTINT3   ((PIN_PC26B_EIC_EXTINT3 << 16) | MUX_PC26B_EIC_EXTINT3)
-#define GPIO_PC26B_EIC_EXTINT3   _UL(1 << 26)
-#define PIN_PC26B_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PC26 External Interrupt Line */
-#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
-#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define GPIO_PC26B_EIC_EXTINT3   _UL_(1 << 26)
+#define PIN_PC26B_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PC26 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L_(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
-#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
-#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
-#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
-#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define GPIO_PA07C_EIC_EXTINT4   _UL_(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L_(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
-#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
-#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
-#define PIN_PC27B_EIC_EXTINT4          _L(91) /**< \brief EIC signal: EXTINT4 on PC27 mux B */
-#define MUX_PC27B_EIC_EXTINT4           _L(1)
+#define GPIO_PA19C_EIC_EXTINT4   _UL_(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PC27B_EIC_EXTINT4          _L_(91) /**< \brief EIC signal: EXTINT4 on PC27 mux B */
+#define MUX_PC27B_EIC_EXTINT4           _L_(1)
 #define PINMUX_PC27B_EIC_EXTINT4   ((PIN_PC27B_EIC_EXTINT4 << 16) | MUX_PC27B_EIC_EXTINT4)
-#define GPIO_PC27B_EIC_EXTINT4   _UL(1 << 27)
-#define PIN_PC27B_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PC27 External Interrupt Line */
-#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
-#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define GPIO_PC27B_EIC_EXTINT4   _UL_(1 << 27)
+#define PIN_PC27B_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PC27 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L_(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L_(2)
 #define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
-#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
-#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
-#define PIN_PC03B_EIC_EXTINT5          _L(67) /**< \brief EIC signal: EXTINT5 on PC03 mux B */
-#define MUX_PC03B_EIC_EXTINT5           _L(1)
+#define GPIO_PA20C_EIC_EXTINT5   _UL_(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PC03B_EIC_EXTINT5          _L_(67) /**< \brief EIC signal: EXTINT5 on PC03 mux B */
+#define MUX_PC03B_EIC_EXTINT5           _L_(1)
 #define PINMUX_PC03B_EIC_EXTINT5   ((PIN_PC03B_EIC_EXTINT5 << 16) | MUX_PC03B_EIC_EXTINT5)
-#define GPIO_PC03B_EIC_EXTINT5   _UL(1 <<  3)
-#define PIN_PC03B_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PC03 External Interrupt Line */
-#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
-#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define GPIO_PC03B_EIC_EXTINT5   _UL_(1 <<  3)
+#define PIN_PC03B_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PC03 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L_(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L_(2)
 #define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
-#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
-#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
-#define PIN_PC04B_EIC_EXTINT6          _L(68) /**< \brief EIC signal: EXTINT6 on PC04 mux B */
-#define MUX_PC04B_EIC_EXTINT6           _L(1)
+#define GPIO_PA21C_EIC_EXTINT6   _UL_(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PC04B_EIC_EXTINT6          _L_(68) /**< \brief EIC signal: EXTINT6 on PC04 mux B */
+#define MUX_PC04B_EIC_EXTINT6           _L_(1)
 #define PINMUX_PC04B_EIC_EXTINT6   ((PIN_PC04B_EIC_EXTINT6 << 16) | MUX_PC04B_EIC_EXTINT6)
-#define GPIO_PC04B_EIC_EXTINT6   _UL(1 <<  4)
-#define PIN_PC04B_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PC04 External Interrupt Line */
-#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
-#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define GPIO_PC04B_EIC_EXTINT6   _UL_(1 <<  4)
+#define PIN_PC04B_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PC04 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L_(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L_(2)
 #define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
-#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
-#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
-#define PIN_PC05B_EIC_EXTINT7          _L(69) /**< \brief EIC signal: EXTINT7 on PC05 mux B */
-#define MUX_PC05B_EIC_EXTINT7           _L(1)
+#define GPIO_PA22C_EIC_EXTINT7   _UL_(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PC05B_EIC_EXTINT7          _L_(69) /**< \brief EIC signal: EXTINT7 on PC05 mux B */
+#define MUX_PC05B_EIC_EXTINT7           _L_(1)
 #define PINMUX_PC05B_EIC_EXTINT7   ((PIN_PC05B_EIC_EXTINT7 << 16) | MUX_PC05B_EIC_EXTINT7)
-#define GPIO_PC05B_EIC_EXTINT7   _UL(1 <<  5)
-#define PIN_PC05B_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PC05 External Interrupt Line */
-#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
-#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define GPIO_PC05B_EIC_EXTINT7   _UL_(1 <<  5)
+#define PIN_PC05B_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PC05 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L_(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L_(2)
 #define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
-#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
-#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
-#define PIN_PC06B_EIC_EXTINT8          _L(70) /**< \brief EIC signal: EXTINT8 on PC06 mux B */
-#define MUX_PC06B_EIC_EXTINT8           _L(1)
+#define GPIO_PA23C_EIC_EXTINT8   _UL_(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PC06B_EIC_EXTINT8          _L_(70) /**< \brief EIC signal: EXTINT8 on PC06 mux B */
+#define MUX_PC06B_EIC_EXTINT8           _L_(1)
 #define PINMUX_PC06B_EIC_EXTINT8   ((PIN_PC06B_EIC_EXTINT8 << 16) | MUX_PC06B_EIC_EXTINT8)
-#define GPIO_PC06B_EIC_EXTINT8   _UL(1 <<  6)
-#define PIN_PC06B_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PC06 External Interrupt Line */
+#define GPIO_PC06B_EIC_EXTINT8   _UL_(1 <<  6)
+#define PIN_PC06B_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PC06 External Interrupt Line */
 
 #endif /* _SAM4LC4C_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4lc8a.h
+++ b/asf/sam/include/sam4l/pio/sam4lc8a.h
@@ -1,0 +1,674 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAM4LC8A
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LC8A_PIO_
+#define _SAM4LC8A_PIO_
+
+#define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
+#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
+#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
+#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
+#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
+#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
+#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
+#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
+#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
+#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
+#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
+#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
+#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
+#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
+#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
+#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
+#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
+#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
+#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
+#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
+#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
+#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
+#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
+#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
+#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
+#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
+#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
+#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+/* ========== GPIO definition for TWIMS0 peripheral ========== */
+#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
+#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+/* ========== GPIO definition for TWIMS2 peripheral ========== */
+#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
+#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+/* ========== GPIO definition for SPI peripheral ========== */
+#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L(1)
+#define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
+#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
+#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L(0)
+#define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
+#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
+#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L(0)
+#define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
+#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
+#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
+#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
+#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
+#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
+#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
+#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
+#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
+#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
+#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
+#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L(0)
+#define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
+#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
+/* ========== GPIO definition for TC0 peripheral ========== */
+#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L(1)
+#define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
+#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
+#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L(1)
+#define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
+#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
+#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L(1)
+#define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
+#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
+#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L(1)
+#define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
+#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
+#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L(1)
+#define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
+#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
+#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L(1)
+#define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
+#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L(1)
+#define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
+#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L(1)
+#define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
+#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L(1)
+#define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
+#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+/* ========== GPIO definition for USART0 peripheral ========== */
+#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L(1)
+#define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
+#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
+#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L(0)
+#define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
+#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
+#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L(0)
+#define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
+#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
+#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L(1)
+#define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
+#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
+#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L(0)
+#define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
+#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
+#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L(1)
+#define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
+#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
+#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L(0)
+#define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
+#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
+#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L(1)
+#define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
+#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
+#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L(0)
+#define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
+#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
+/* ========== GPIO definition for USART1 peripheral ========== */
+#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L(0)
+#define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
+#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
+#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L(1)
+#define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
+#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
+#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L(0)
+#define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
+#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
+#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L(0)
+#define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
+#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
+#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L(0)
+#define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
+#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+/* ========== GPIO definition for USART2 peripheral ========== */
+#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L(0)
+#define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
+#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
+#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L(1)
+#define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
+#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
+#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L(0)
+#define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
+#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L(1)
+#define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
+#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
+#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L(0)
+#define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
+#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L(1)
+#define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
+#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
+#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L(0)
+#define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
+#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+/* ========== GPIO definition for ADCIFE peripheral ========== */
+#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
+#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
+#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+/* ========== GPIO definition for DACC peripheral ========== */
+#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L(0)
+#define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
+#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+/* ========== GPIO definition for ACIFC peripheral ========== */
+#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
+#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
+/* ========== GPIO definition for GLOC peripheral ========== */
+#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
+#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L(3)
+#define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
+#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L(3)
+#define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
+#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L(3)
+#define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
+#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L(3)
+#define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
+#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L(3)
+#define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
+#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L(3)
+#define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
+#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L(3)
+#define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
+#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
+#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
+#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
+#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
+/* ========== GPIO definition for ABDACB peripheral ========== */
+#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
+#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
+#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
+#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
+#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
+#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
+#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
+#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+/* ========== GPIO definition for PARC peripheral ========== */
+#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
+#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
+#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
+#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
+#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
+#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
+#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
+#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
+#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
+#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
+#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
+#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
+#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
+#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
+#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
+#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
+#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
+#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
+#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
+#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
+#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+/* ========== GPIO definition for CATB peripheral ========== */
+#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L(6)
+#define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
+#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L(6)
+#define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
+#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L(6)
+#define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
+#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
+#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
+#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
+#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
+#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
+#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
+#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
+#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
+#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
+#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
+#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
+#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
+#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
+#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
+#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
+#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
+#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
+#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
+#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
+#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
+#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
+#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
+#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
+#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
+#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
+#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
+#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
+#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
+#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
+#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
+#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
+#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
+#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
+#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
+#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
+#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
+#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
+#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
+#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
+#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
+#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
+#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
+#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
+/* ========== GPIO definition for LCDCA peripheral ========== */
+#define PIN_PA12F_LCDCA_COM0           _L(12) /**< \brief LCDCA signal: COM0 on PA12 mux F */
+#define MUX_PA12F_LCDCA_COM0            _L(5)
+#define PINMUX_PA12F_LCDCA_COM0    ((PIN_PA12F_LCDCA_COM0 << 16) | MUX_PA12F_LCDCA_COM0)
+#define GPIO_PA12F_LCDCA_COM0    _UL(1 << 12)
+#define PIN_PA11F_LCDCA_COM1           _L(11) /**< \brief LCDCA signal: COM1 on PA11 mux F */
+#define MUX_PA11F_LCDCA_COM1            _L(5)
+#define PINMUX_PA11F_LCDCA_COM1    ((PIN_PA11F_LCDCA_COM1 << 16) | MUX_PA11F_LCDCA_COM1)
+#define GPIO_PA11F_LCDCA_COM1    _UL(1 << 11)
+#define PIN_PA10F_LCDCA_COM2           _L(10) /**< \brief LCDCA signal: COM2 on PA10 mux F */
+#define MUX_PA10F_LCDCA_COM2            _L(5)
+#define PINMUX_PA10F_LCDCA_COM2    ((PIN_PA10F_LCDCA_COM2 << 16) | MUX_PA10F_LCDCA_COM2)
+#define GPIO_PA10F_LCDCA_COM2    _UL(1 << 10)
+#define PIN_PA09F_LCDCA_COM3            _L(9) /**< \brief LCDCA signal: COM3 on PA09 mux F */
+#define MUX_PA09F_LCDCA_COM3            _L(5)
+#define PINMUX_PA09F_LCDCA_COM3    ((PIN_PA09F_LCDCA_COM3 << 16) | MUX_PA09F_LCDCA_COM3)
+#define GPIO_PA09F_LCDCA_COM3    _UL(1 <<  9)
+#define PIN_PA13F_LCDCA_SEG5           _L(13) /**< \brief LCDCA signal: SEG5 on PA13 mux F */
+#define MUX_PA13F_LCDCA_SEG5            _L(5)
+#define PINMUX_PA13F_LCDCA_SEG5    ((PIN_PA13F_LCDCA_SEG5 << 16) | MUX_PA13F_LCDCA_SEG5)
+#define GPIO_PA13F_LCDCA_SEG5    _UL(1 << 13)
+#define PIN_PA14F_LCDCA_SEG6           _L(14) /**< \brief LCDCA signal: SEG6 on PA14 mux F */
+#define MUX_PA14F_LCDCA_SEG6            _L(5)
+#define PINMUX_PA14F_LCDCA_SEG6    ((PIN_PA14F_LCDCA_SEG6 << 16) | MUX_PA14F_LCDCA_SEG6)
+#define GPIO_PA14F_LCDCA_SEG6    _UL(1 << 14)
+#define PIN_PA15F_LCDCA_SEG7           _L(15) /**< \brief LCDCA signal: SEG7 on PA15 mux F */
+#define MUX_PA15F_LCDCA_SEG7            _L(5)
+#define PINMUX_PA15F_LCDCA_SEG7    ((PIN_PA15F_LCDCA_SEG7 << 16) | MUX_PA15F_LCDCA_SEG7)
+#define GPIO_PA15F_LCDCA_SEG7    _UL(1 << 15)
+#define PIN_PA16F_LCDCA_SEG8           _L(16) /**< \brief LCDCA signal: SEG8 on PA16 mux F */
+#define MUX_PA16F_LCDCA_SEG8            _L(5)
+#define PINMUX_PA16F_LCDCA_SEG8    ((PIN_PA16F_LCDCA_SEG8 << 16) | MUX_PA16F_LCDCA_SEG8)
+#define GPIO_PA16F_LCDCA_SEG8    _UL(1 << 16)
+#define PIN_PA17F_LCDCA_SEG9           _L(17) /**< \brief LCDCA signal: SEG9 on PA17 mux F */
+#define MUX_PA17F_LCDCA_SEG9            _L(5)
+#define PINMUX_PA17F_LCDCA_SEG9    ((PIN_PA17F_LCDCA_SEG9 << 16) | MUX_PA17F_LCDCA_SEG9)
+#define GPIO_PA17F_LCDCA_SEG9    _UL(1 << 17)
+#define PIN_PA18F_LCDCA_SEG18          _L(18) /**< \brief LCDCA signal: SEG18 on PA18 mux F */
+#define MUX_PA18F_LCDCA_SEG18           _L(5)
+#define PINMUX_PA18F_LCDCA_SEG18   ((PIN_PA18F_LCDCA_SEG18 << 16) | MUX_PA18F_LCDCA_SEG18)
+#define GPIO_PA18F_LCDCA_SEG18   _UL(1 << 18)
+#define PIN_PA19F_LCDCA_SEG19          _L(19) /**< \brief LCDCA signal: SEG19 on PA19 mux F */
+#define MUX_PA19F_LCDCA_SEG19           _L(5)
+#define PINMUX_PA19F_LCDCA_SEG19   ((PIN_PA19F_LCDCA_SEG19 << 16) | MUX_PA19F_LCDCA_SEG19)
+#define GPIO_PA19F_LCDCA_SEG19   _UL(1 << 19)
+#define PIN_PA20F_LCDCA_SEG20          _L(20) /**< \brief LCDCA signal: SEG20 on PA20 mux F */
+#define MUX_PA20F_LCDCA_SEG20           _L(5)
+#define PINMUX_PA20F_LCDCA_SEG20   ((PIN_PA20F_LCDCA_SEG20 << 16) | MUX_PA20F_LCDCA_SEG20)
+#define GPIO_PA20F_LCDCA_SEG20   _UL(1 << 20)
+#define PIN_PA08F_LCDCA_SEG23           _L(8) /**< \brief LCDCA signal: SEG23 on PA08 mux F */
+#define MUX_PA08F_LCDCA_SEG23           _L(5)
+#define PINMUX_PA08F_LCDCA_SEG23   ((PIN_PA08F_LCDCA_SEG23 << 16) | MUX_PA08F_LCDCA_SEG23)
+#define GPIO_PA08F_LCDCA_SEG23   _UL(1 <<  8)
+#define PIN_PA21F_LCDCA_SEG34          _L(21) /**< \brief LCDCA signal: SEG34 on PA21 mux F */
+#define MUX_PA21F_LCDCA_SEG34           _L(5)
+#define PINMUX_PA21F_LCDCA_SEG34   ((PIN_PA21F_LCDCA_SEG34 << 16) | MUX_PA21F_LCDCA_SEG34)
+#define GPIO_PA21F_LCDCA_SEG34   _UL(1 << 21)
+#define PIN_PA22F_LCDCA_SEG35          _L(22) /**< \brief LCDCA signal: SEG35 on PA22 mux F */
+#define MUX_PA22F_LCDCA_SEG35           _L(5)
+#define PINMUX_PA22F_LCDCA_SEG35   ((PIN_PA22F_LCDCA_SEG35 << 16) | MUX_PA22F_LCDCA_SEG35)
+#define GPIO_PA22F_LCDCA_SEG35   _UL(1 << 22)
+#define PIN_PA23F_LCDCA_SEG38          _L(23) /**< \brief LCDCA signal: SEG38 on PA23 mux F */
+#define MUX_PA23F_LCDCA_SEG38           _L(5)
+#define PINMUX_PA23F_LCDCA_SEG38   ((PIN_PA23F_LCDCA_SEG38 << 16) | MUX_PA23F_LCDCA_SEG38)
+#define GPIO_PA23F_LCDCA_SEG38   _UL(1 << 23)
+#define PIN_PA24F_LCDCA_SEG39          _L(24) /**< \brief LCDCA signal: SEG39 on PA24 mux F */
+#define MUX_PA24F_LCDCA_SEG39           _L(5)
+#define PINMUX_PA24F_LCDCA_SEG39   ((PIN_PA24F_LCDCA_SEG39 << 16) | MUX_PA24F_LCDCA_SEG39)
+#define GPIO_PA24F_LCDCA_SEG39   _UL(1 << 24)
+/* ========== GPIO definition for USBC peripheral ========== */
+#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L(0)
+#define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
+#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
+#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L(0)
+#define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
+#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+/* ========== GPIO definition for PEVC peripheral ========== */
+#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
+/* ========== GPIO definition for SCIF peripheral ========== */
+#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
+#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
+#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
+#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
+#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
+/* ========== GPIO definition for EIC peripheral ========== */
+#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
+#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
+#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
+#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
+#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
+#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
+#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
+#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
+#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
+#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
+#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+
+#endif /* _SAM4LC8A_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4lc8a.h
+++ b/asf/sam/include/sam4l/pio/sam4lc8a.h
@@ -30,645 +30,645 @@
 #define _SAM4LC8A_PIO_
 
 #define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
-#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define GPIO_PA00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PA00 */
 #define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
-#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define GPIO_PA01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PA01 */
 #define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
-#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define GPIO_PA02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PA02 */
 #define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
-#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define GPIO_PA03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PA03 */
 #define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
-#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define GPIO_PA04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PA04 */
 #define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
-#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define GPIO_PA05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PA05 */
 #define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
-#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define GPIO_PA06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PA06 */
 #define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
-#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define GPIO_PA07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PA07 */
 #define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
-#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define GPIO_PA08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PA08 */
 #define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
-#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define GPIO_PA09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PA09 */
 #define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
-#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define GPIO_PA10                _UL_(1 << 10) /**< \brief GPIO Mask  for PA10 */
 #define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
-#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define GPIO_PA11                _UL_(1 << 11) /**< \brief GPIO Mask  for PA11 */
 #define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
-#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define GPIO_PA12                _UL_(1 << 12) /**< \brief GPIO Mask  for PA12 */
 #define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
-#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define GPIO_PA13                _UL_(1 << 13) /**< \brief GPIO Mask  for PA13 */
 #define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
-#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define GPIO_PA14                _UL_(1 << 14) /**< \brief GPIO Mask  for PA14 */
 #define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
-#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define GPIO_PA15                _UL_(1 << 15) /**< \brief GPIO Mask  for PA15 */
 #define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
-#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define GPIO_PA16                _UL_(1 << 16) /**< \brief GPIO Mask  for PA16 */
 #define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
-#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define GPIO_PA17                _UL_(1 << 17) /**< \brief GPIO Mask  for PA17 */
 #define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
-#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define GPIO_PA18                _UL_(1 << 18) /**< \brief GPIO Mask  for PA18 */
 #define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
-#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define GPIO_PA19                _UL_(1 << 19) /**< \brief GPIO Mask  for PA19 */
 #define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
-#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define GPIO_PA20                _UL_(1 << 20) /**< \brief GPIO Mask  for PA20 */
 #define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
-#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define GPIO_PA21                _UL_(1 << 21) /**< \brief GPIO Mask  for PA21 */
 #define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
-#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define GPIO_PA22                _UL_(1 << 22) /**< \brief GPIO Mask  for PA22 */
 #define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
-#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define GPIO_PA23                _UL_(1 << 23) /**< \brief GPIO Mask  for PA23 */
 #define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
-#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define GPIO_PA24                _UL_(1 << 24) /**< \brief GPIO Mask  for PA24 */
 #define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
-#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define GPIO_PA25                _UL_(1 << 25) /**< \brief GPIO Mask  for PA25 */
 #define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
-#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define GPIO_PA26                _UL_(1 << 26) /**< \brief GPIO Mask  for PA26 */
 /* ========== GPIO definition for TWIMS0 peripheral ========== */
-#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
-#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PIN_PA24B_TWIMS0_TWCK          _L_(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L_(1)
 #define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
-#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
-#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
-#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL_(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L_(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L_(1)
 #define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
-#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+#define GPIO_PA23B_TWIMS0_TWD    _UL_(1 << 23)
 /* ========== GPIO definition for TWIMS2 peripheral ========== */
-#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
-#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PIN_PA22E_TWIMS2_TWCK          _L_(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L_(4)
 #define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
-#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
-#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
-#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL_(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L_(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L_(4)
 #define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
-#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+#define GPIO_PA21E_TWIMS2_TWD    _UL_(1 << 21)
 /* ========== GPIO definition for SPI peripheral ========== */
-#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
-#define MUX_PA03B_SPI_MISO              _L(1)
+#define PIN_PA03B_SPI_MISO              _L_(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L_(1)
 #define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
-#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
-#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
-#define MUX_PA21A_SPI_MISO              _L(0)
+#define GPIO_PA03B_SPI_MISO      _UL_(1 <<  3)
+#define PIN_PA21A_SPI_MISO             _L_(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L_(0)
 #define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
-#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
-#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
-#define MUX_PA22A_SPI_MOSI              _L(0)
+#define GPIO_PA21A_SPI_MISO      _UL_(1 << 21)
+#define PIN_PA22A_SPI_MOSI             _L_(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L_(0)
 #define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
-#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
-#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
-#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define GPIO_PA22A_SPI_MOSI      _UL_(1 << 22)
+#define PIN_PA02B_SPI_NPCS0             _L_(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L_(1)
 #define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
-#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
-#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
-#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define GPIO_PA02B_SPI_NPCS0     _UL_(1 <<  2)
+#define PIN_PA24A_SPI_NPCS0            _L_(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L_(0)
 #define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
-#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
-#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
-#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define GPIO_PA24A_SPI_NPCS0     _UL_(1 << 24)
+#define PIN_PA13C_SPI_NPCS1            _L_(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L_(2)
 #define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
-#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
-#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define GPIO_PA13C_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PA14C_SPI_NPCS2            _L_(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L_(2)
 #define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
-#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
-#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
-#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define GPIO_PA14C_SPI_NPCS2     _UL_(1 << 14)
+#define PIN_PA15C_SPI_NPCS3            _L_(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L_(2)
 #define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
-#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
-#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
-#define MUX_PA23A_SPI_SCK               _L(0)
+#define GPIO_PA15C_SPI_NPCS3     _UL_(1 << 15)
+#define PIN_PA23A_SPI_SCK              _L_(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L_(0)
 #define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
-#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
+#define GPIO_PA23A_SPI_SCK       _UL_(1 << 23)
 /* ========== GPIO definition for TC0 peripheral ========== */
-#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
-#define MUX_PA08B_TC0_A0                _L(1)
+#define PIN_PA08B_TC0_A0                _L_(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L_(1)
 #define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
-#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
-#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
-#define MUX_PA10B_TC0_A1                _L(1)
+#define GPIO_PA08B_TC0_A0        _UL_(1 <<  8)
+#define PIN_PA10B_TC0_A1               _L_(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L_(1)
 #define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
-#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
-#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
-#define MUX_PA12B_TC0_A2                _L(1)
+#define GPIO_PA10B_TC0_A1        _UL_(1 << 10)
+#define PIN_PA12B_TC0_A2               _L_(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L_(1)
 #define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
-#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
-#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
-#define MUX_PA09B_TC0_B0                _L(1)
+#define GPIO_PA12B_TC0_A2        _UL_(1 << 12)
+#define PIN_PA09B_TC0_B0                _L_(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L_(1)
 #define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
-#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
-#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
-#define MUX_PA11B_TC0_B1                _L(1)
+#define GPIO_PA09B_TC0_B0        _UL_(1 <<  9)
+#define PIN_PA11B_TC0_B1               _L_(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L_(1)
 #define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
-#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
-#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
-#define MUX_PA13B_TC0_B2                _L(1)
+#define GPIO_PA11B_TC0_B1        _UL_(1 << 11)
+#define PIN_PA13B_TC0_B2               _L_(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L_(1)
 #define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
-#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
-#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
-#define MUX_PA14B_TC0_CLK0              _L(1)
+#define GPIO_PA13B_TC0_B2        _UL_(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L_(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L_(1)
 #define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
-#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
-#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
-#define MUX_PA15B_TC0_CLK1              _L(1)
+#define GPIO_PA14B_TC0_CLK0      _UL_(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L_(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L_(1)
 #define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
-#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
-#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
-#define MUX_PA16B_TC0_CLK2              _L(1)
+#define GPIO_PA15B_TC0_CLK1      _UL_(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L_(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L_(1)
 #define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
-#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+#define GPIO_PA16B_TC0_CLK2      _UL_(1 << 16)
 /* ========== GPIO definition for USART0 peripheral ========== */
-#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
-#define MUX_PA04B_USART0_CLK            _L(1)
+#define PIN_PA04B_USART0_CLK            _L_(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L_(1)
 #define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
-#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
-#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
-#define MUX_PA10A_USART0_CLK            _L(0)
+#define GPIO_PA04B_USART0_CLK    _UL_(1 <<  4)
+#define PIN_PA10A_USART0_CLK           _L_(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L_(0)
 #define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
-#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
-#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
-#define MUX_PA09A_USART0_CTS            _L(0)
+#define GPIO_PA10A_USART0_CLK    _UL_(1 << 10)
+#define PIN_PA09A_USART0_CTS            _L_(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L_(0)
 #define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
-#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
-#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
-#define MUX_PA06B_USART0_RTS            _L(1)
+#define GPIO_PA09A_USART0_CTS    _UL_(1 <<  9)
+#define PIN_PA06B_USART0_RTS            _L_(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L_(1)
 #define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
-#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
-#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
-#define MUX_PA08A_USART0_RTS            _L(0)
+#define GPIO_PA06B_USART0_RTS    _UL_(1 <<  6)
+#define PIN_PA08A_USART0_RTS            _L_(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L_(0)
 #define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
-#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
-#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
-#define MUX_PA05B_USART0_RXD            _L(1)
+#define GPIO_PA08A_USART0_RTS    _UL_(1 <<  8)
+#define PIN_PA05B_USART0_RXD            _L_(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L_(1)
 #define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
-#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
-#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
-#define MUX_PA11A_USART0_RXD            _L(0)
+#define GPIO_PA05B_USART0_RXD    _UL_(1 <<  5)
+#define PIN_PA11A_USART0_RXD           _L_(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L_(0)
 #define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
-#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
-#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
-#define MUX_PA07B_USART0_TXD            _L(1)
+#define GPIO_PA11A_USART0_RXD    _UL_(1 << 11)
+#define PIN_PA07B_USART0_TXD            _L_(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L_(1)
 #define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
-#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
-#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
-#define MUX_PA12A_USART0_TXD            _L(0)
+#define GPIO_PA07B_USART0_TXD    _UL_(1 <<  7)
+#define PIN_PA12A_USART0_TXD           _L_(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L_(0)
 #define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
-#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
+#define GPIO_PA12A_USART0_TXD    _UL_(1 << 12)
 /* ========== GPIO definition for USART1 peripheral ========== */
-#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
-#define MUX_PA14A_USART1_CLK            _L(0)
+#define PIN_PA14A_USART1_CLK           _L_(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L_(0)
 #define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
-#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
-#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
-#define MUX_PA21B_USART1_CTS            _L(1)
+#define GPIO_PA14A_USART1_CLK    _UL_(1 << 14)
+#define PIN_PA21B_USART1_CTS           _L_(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L_(1)
 #define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
-#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
-#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
-#define MUX_PA13A_USART1_RTS            _L(0)
+#define GPIO_PA21B_USART1_CTS    _UL_(1 << 21)
+#define PIN_PA13A_USART1_RTS           _L_(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L_(0)
 #define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
-#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
-#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
-#define MUX_PA15A_USART1_RXD            _L(0)
+#define GPIO_PA13A_USART1_RTS    _UL_(1 << 13)
+#define PIN_PA15A_USART1_RXD           _L_(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L_(0)
 #define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
-#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
-#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
-#define MUX_PA16A_USART1_TXD            _L(0)
+#define GPIO_PA15A_USART1_RXD    _UL_(1 << 15)
+#define PIN_PA16A_USART1_TXD           _L_(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L_(0)
 #define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
-#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+#define GPIO_PA16A_USART1_TXD    _UL_(1 << 16)
 /* ========== GPIO definition for USART2 peripheral ========== */
-#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
-#define MUX_PA18A_USART2_CLK            _L(0)
+#define PIN_PA18A_USART2_CLK           _L_(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L_(0)
 #define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
-#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
-#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
-#define MUX_PA22B_USART2_CTS            _L(1)
+#define GPIO_PA18A_USART2_CLK    _UL_(1 << 18)
+#define PIN_PA22B_USART2_CTS           _L_(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L_(1)
 #define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
-#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
-#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
-#define MUX_PA17A_USART2_RTS            _L(0)
+#define GPIO_PA22B_USART2_CTS    _UL_(1 << 22)
+#define PIN_PA17A_USART2_RTS           _L_(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L_(0)
 #define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
-#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
-#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
-#define MUX_PA25B_USART2_RXD            _L(1)
+#define GPIO_PA17A_USART2_RTS    _UL_(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L_(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L_(1)
 #define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
-#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
-#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
-#define MUX_PA19A_USART2_RXD            _L(0)
+#define GPIO_PA25B_USART2_RXD    _UL_(1 << 25)
+#define PIN_PA19A_USART2_RXD           _L_(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L_(0)
 #define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
-#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
-#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
-#define MUX_PA26B_USART2_TXD            _L(1)
+#define GPIO_PA19A_USART2_RXD    _UL_(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L_(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L_(1)
 #define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
-#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
-#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
-#define MUX_PA20A_USART2_TXD            _L(0)
+#define GPIO_PA26B_USART2_TXD    _UL_(1 << 26)
+#define PIN_PA20A_USART2_TXD           _L_(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L_(0)
 #define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
-#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+#define GPIO_PA20A_USART2_TXD    _UL_(1 << 20)
 /* ========== GPIO definition for ADCIFE peripheral ========== */
-#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
-#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PIN_PA04A_ADCIFE_AD0            _L_(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L_(0)
 #define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
-#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
-#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
-#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL_(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L_(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L_(0)
 #define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
-#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
-#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
-#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define GPIO_PA05A_ADCIFE_AD1    _UL_(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L_(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L_(0)
 #define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
-#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
-#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
-#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define GPIO_PA07A_ADCIFE_AD2    _UL_(1 <<  7)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L_(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L_(4)
 #define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
-#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL_(1 <<  5)
 /* ========== GPIO definition for DACC peripheral ========== */
-#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
-#define MUX_PA06A_DACC_VOUT             _L(0)
+#define PIN_PA06A_DACC_VOUT             _L_(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L_(0)
 #define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
-#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+#define GPIO_PA06A_DACC_VOUT     _UL_(1 <<  6)
 /* ========== GPIO definition for ACIFC peripheral ========== */
-#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
-#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PIN_PA06E_ACIFC_ACAN0           _L_(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L_(4)
 #define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
-#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
-#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
-#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL_(1 <<  6)
+#define PIN_PA07E_ACIFC_ACAP0           _L_(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L_(4)
 #define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
-#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL_(1 <<  7)
 /* ========== GPIO definition for GLOC peripheral ========== */
-#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
-#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PIN_PA06D_GLOC_IN0              _L_(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L_(3)
 #define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
-#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
-#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
-#define MUX_PA20D_GLOC_IN0              _L(3)
+#define GPIO_PA06D_GLOC_IN0      _UL_(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L_(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L_(3)
 #define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
-#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
-#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
-#define MUX_PA04D_GLOC_IN1              _L(3)
+#define GPIO_PA20D_GLOC_IN0      _UL_(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L_(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L_(3)
 #define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
-#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
-#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
-#define MUX_PA21D_GLOC_IN1              _L(3)
+#define GPIO_PA04D_GLOC_IN1      _UL_(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L_(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L_(3)
 #define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
-#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
-#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
-#define MUX_PA05D_GLOC_IN2              _L(3)
+#define GPIO_PA21D_GLOC_IN1      _UL_(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L_(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L_(3)
 #define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
-#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
-#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
-#define MUX_PA22D_GLOC_IN2              _L(3)
+#define GPIO_PA05D_GLOC_IN2      _UL_(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L_(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L_(3)
 #define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
-#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
-#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
-#define MUX_PA07D_GLOC_IN3              _L(3)
+#define GPIO_PA22D_GLOC_IN2      _UL_(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L_(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L_(3)
 #define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
-#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
-#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
-#define MUX_PA23D_GLOC_IN3              _L(3)
+#define GPIO_PA07D_GLOC_IN3      _UL_(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L_(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L_(3)
 #define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
-#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
-#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
-#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define GPIO_PA23D_GLOC_IN3      _UL_(1 << 23)
+#define PIN_PA08D_GLOC_OUT0             _L_(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
-#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
-#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
-#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define GPIO_PA08D_GLOC_OUT0     _UL_(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L_(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
-#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
+#define GPIO_PA24D_GLOC_OUT0     _UL_(1 << 24)
 /* ========== GPIO definition for ABDACB peripheral ========== */
-#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
-#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define PIN_PA17B_ABDACB_DAC0          _L_(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L_(1)
 #define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
-#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
-#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
-#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define GPIO_PA17B_ABDACB_DAC0   _UL_(1 << 17)
+#define PIN_PA19B_ABDACB_DAC1          _L_(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L_(1)
 #define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
-#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
-#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
-#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define GPIO_PA19B_ABDACB_DAC1   _UL_(1 << 19)
+#define PIN_PA18B_ABDACB_DACN0         _L_(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L_(1)
 #define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
-#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
-#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
-#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define GPIO_PA18B_ABDACB_DACN0  _UL_(1 << 18)
+#define PIN_PA20B_ABDACB_DACN1         _L_(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L_(1)
 #define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
-#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+#define GPIO_PA20B_ABDACB_DACN1  _UL_(1 << 20)
 /* ========== GPIO definition for PARC peripheral ========== */
-#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
-#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PIN_PA17D_PARC_PCCK            _L_(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L_(3)
 #define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
-#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
-#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
-#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define GPIO_PA17D_PARC_PCCK     _UL_(1 << 17)
+#define PIN_PA09D_PARC_PCDATA0          _L_(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L_(3)
 #define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
-#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
-#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
-#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define GPIO_PA09D_PARC_PCDATA0  _UL_(1 <<  9)
+#define PIN_PA10D_PARC_PCDATA1         _L_(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L_(3)
 #define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
-#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
-#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
-#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define GPIO_PA10D_PARC_PCDATA1  _UL_(1 << 10)
+#define PIN_PA11D_PARC_PCDATA2         _L_(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L_(3)
 #define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
-#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
-#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
-#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define GPIO_PA11D_PARC_PCDATA2  _UL_(1 << 11)
+#define PIN_PA12D_PARC_PCDATA3         _L_(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L_(3)
 #define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
-#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
-#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
-#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL_(1 << 12)
+#define PIN_PA13D_PARC_PCDATA4         _L_(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L_(3)
 #define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
-#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
-#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
-#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define GPIO_PA13D_PARC_PCDATA4  _UL_(1 << 13)
+#define PIN_PA14D_PARC_PCDATA5         _L_(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L_(3)
 #define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
-#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
-#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
-#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define GPIO_PA14D_PARC_PCDATA5  _UL_(1 << 14)
+#define PIN_PA15D_PARC_PCDATA6         _L_(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L_(3)
 #define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
-#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
-#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
-#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define GPIO_PA15D_PARC_PCDATA6  _UL_(1 << 15)
+#define PIN_PA16D_PARC_PCDATA7         _L_(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L_(3)
 #define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
-#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
-#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
-#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define GPIO_PA16D_PARC_PCDATA7  _UL_(1 << 16)
+#define PIN_PA18D_PARC_PCEN1           _L_(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L_(3)
 #define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
-#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
-#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
-#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define GPIO_PA18D_PARC_PCEN1    _UL_(1 << 18)
+#define PIN_PA19D_PARC_PCEN2           _L_(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L_(3)
 #define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
-#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+#define GPIO_PA19D_PARC_PCEN2    _UL_(1 << 19)
 /* ========== GPIO definition for CATB peripheral ========== */
-#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
-#define MUX_PA02G_CATB_DIS              _L(6)
+#define PIN_PA02G_CATB_DIS              _L_(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L_(6)
 #define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
-#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
-#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
-#define MUX_PA12G_CATB_DIS              _L(6)
+#define GPIO_PA02G_CATB_DIS      _UL_(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L_(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L_(6)
 #define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
-#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
-#define MUX_PA23G_CATB_DIS              _L(6)
+#define GPIO_PA12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L_(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L_(6)
 #define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
-#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
-#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
-#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define GPIO_PA23G_CATB_DIS      _UL_(1 << 23)
+#define PIN_PA04G_CATB_SENSE0           _L_(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L_(6)
 #define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
-#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
-#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
-#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define GPIO_PA04G_CATB_SENSE0   _UL_(1 <<  4)
+#define PIN_PA05G_CATB_SENSE1           _L_(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L_(6)
 #define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
-#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
-#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
-#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define GPIO_PA05G_CATB_SENSE1   _UL_(1 <<  5)
+#define PIN_PA06G_CATB_SENSE2           _L_(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L_(6)
 #define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
-#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
-#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
-#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define GPIO_PA06G_CATB_SENSE2   _UL_(1 <<  6)
+#define PIN_PA07G_CATB_SENSE3           _L_(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L_(6)
 #define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
-#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
-#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
-#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define GPIO_PA07G_CATB_SENSE3   _UL_(1 <<  7)
+#define PIN_PA08G_CATB_SENSE4           _L_(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L_(6)
 #define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
-#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
-#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
-#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define GPIO_PA08G_CATB_SENSE4   _UL_(1 <<  8)
+#define PIN_PA09G_CATB_SENSE5           _L_(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L_(6)
 #define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
-#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
-#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
-#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define GPIO_PA09G_CATB_SENSE5   _UL_(1 <<  9)
+#define PIN_PA10G_CATB_SENSE6          _L_(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L_(6)
 #define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
-#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
-#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
-#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define GPIO_PA10G_CATB_SENSE6   _UL_(1 << 10)
+#define PIN_PA11G_CATB_SENSE7          _L_(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L_(6)
 #define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
-#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
-#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
-#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define GPIO_PA11G_CATB_SENSE7   _UL_(1 << 11)
+#define PIN_PA13G_CATB_SENSE8          _L_(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L_(6)
 #define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
-#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
-#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
-#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define GPIO_PA13G_CATB_SENSE8   _UL_(1 << 13)
+#define PIN_PA14G_CATB_SENSE9          _L_(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L_(6)
 #define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
-#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
-#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
-#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define GPIO_PA14G_CATB_SENSE9   _UL_(1 << 14)
+#define PIN_PA15G_CATB_SENSE10         _L_(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L_(6)
 #define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
-#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
-#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
-#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define GPIO_PA15G_CATB_SENSE10  _UL_(1 << 15)
+#define PIN_PA16G_CATB_SENSE11         _L_(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L_(6)
 #define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
-#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
-#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
-#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define GPIO_PA16G_CATB_SENSE11  _UL_(1 << 16)
+#define PIN_PA17G_CATB_SENSE12         _L_(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L_(6)
 #define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
-#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
-#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
-#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define GPIO_PA17G_CATB_SENSE12  _UL_(1 << 17)
+#define PIN_PA18G_CATB_SENSE13         _L_(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L_(6)
 #define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
-#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
-#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
-#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define GPIO_PA18G_CATB_SENSE13  _UL_(1 << 18)
+#define PIN_PA19G_CATB_SENSE14         _L_(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L_(6)
 #define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
-#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
-#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
-#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define GPIO_PA19G_CATB_SENSE14  _UL_(1 << 19)
+#define PIN_PA20G_CATB_SENSE15         _L_(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L_(6)
 #define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
-#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
-#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
-#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define GPIO_PA20G_CATB_SENSE15  _UL_(1 << 20)
+#define PIN_PA21G_CATB_SENSE16         _L_(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L_(6)
 #define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
-#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
-#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
-#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define GPIO_PA21G_CATB_SENSE16  _UL_(1 << 21)
+#define PIN_PA22G_CATB_SENSE17         _L_(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L_(6)
 #define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
-#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
-#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
-#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define GPIO_PA22G_CATB_SENSE17  _UL_(1 << 22)
+#define PIN_PA24G_CATB_SENSE18         _L_(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L_(6)
 #define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
-#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
-#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
-#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define GPIO_PA24G_CATB_SENSE18  _UL_(1 << 24)
+#define PIN_PA25G_CATB_SENSE19         _L_(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L_(6)
 #define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
-#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
-#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
-#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define GPIO_PA25G_CATB_SENSE19  _UL_(1 << 25)
+#define PIN_PA26G_CATB_SENSE20         _L_(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L_(6)
 #define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
-#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
+#define GPIO_PA26G_CATB_SENSE20  _UL_(1 << 26)
 /* ========== GPIO definition for LCDCA peripheral ========== */
-#define PIN_PA12F_LCDCA_COM0           _L(12) /**< \brief LCDCA signal: COM0 on PA12 mux F */
-#define MUX_PA12F_LCDCA_COM0            _L(5)
+#define PIN_PA12F_LCDCA_COM0           _L_(12) /**< \brief LCDCA signal: COM0 on PA12 mux F */
+#define MUX_PA12F_LCDCA_COM0            _L_(5)
 #define PINMUX_PA12F_LCDCA_COM0    ((PIN_PA12F_LCDCA_COM0 << 16) | MUX_PA12F_LCDCA_COM0)
-#define GPIO_PA12F_LCDCA_COM0    _UL(1 << 12)
-#define PIN_PA11F_LCDCA_COM1           _L(11) /**< \brief LCDCA signal: COM1 on PA11 mux F */
-#define MUX_PA11F_LCDCA_COM1            _L(5)
+#define GPIO_PA12F_LCDCA_COM0    _UL_(1 << 12)
+#define PIN_PA11F_LCDCA_COM1           _L_(11) /**< \brief LCDCA signal: COM1 on PA11 mux F */
+#define MUX_PA11F_LCDCA_COM1            _L_(5)
 #define PINMUX_PA11F_LCDCA_COM1    ((PIN_PA11F_LCDCA_COM1 << 16) | MUX_PA11F_LCDCA_COM1)
-#define GPIO_PA11F_LCDCA_COM1    _UL(1 << 11)
-#define PIN_PA10F_LCDCA_COM2           _L(10) /**< \brief LCDCA signal: COM2 on PA10 mux F */
-#define MUX_PA10F_LCDCA_COM2            _L(5)
+#define GPIO_PA11F_LCDCA_COM1    _UL_(1 << 11)
+#define PIN_PA10F_LCDCA_COM2           _L_(10) /**< \brief LCDCA signal: COM2 on PA10 mux F */
+#define MUX_PA10F_LCDCA_COM2            _L_(5)
 #define PINMUX_PA10F_LCDCA_COM2    ((PIN_PA10F_LCDCA_COM2 << 16) | MUX_PA10F_LCDCA_COM2)
-#define GPIO_PA10F_LCDCA_COM2    _UL(1 << 10)
-#define PIN_PA09F_LCDCA_COM3            _L(9) /**< \brief LCDCA signal: COM3 on PA09 mux F */
-#define MUX_PA09F_LCDCA_COM3            _L(5)
+#define GPIO_PA10F_LCDCA_COM2    _UL_(1 << 10)
+#define PIN_PA09F_LCDCA_COM3            _L_(9) /**< \brief LCDCA signal: COM3 on PA09 mux F */
+#define MUX_PA09F_LCDCA_COM3            _L_(5)
 #define PINMUX_PA09F_LCDCA_COM3    ((PIN_PA09F_LCDCA_COM3 << 16) | MUX_PA09F_LCDCA_COM3)
-#define GPIO_PA09F_LCDCA_COM3    _UL(1 <<  9)
-#define PIN_PA13F_LCDCA_SEG5           _L(13) /**< \brief LCDCA signal: SEG5 on PA13 mux F */
-#define MUX_PA13F_LCDCA_SEG5            _L(5)
+#define GPIO_PA09F_LCDCA_COM3    _UL_(1 <<  9)
+#define PIN_PA13F_LCDCA_SEG5           _L_(13) /**< \brief LCDCA signal: SEG5 on PA13 mux F */
+#define MUX_PA13F_LCDCA_SEG5            _L_(5)
 #define PINMUX_PA13F_LCDCA_SEG5    ((PIN_PA13F_LCDCA_SEG5 << 16) | MUX_PA13F_LCDCA_SEG5)
-#define GPIO_PA13F_LCDCA_SEG5    _UL(1 << 13)
-#define PIN_PA14F_LCDCA_SEG6           _L(14) /**< \brief LCDCA signal: SEG6 on PA14 mux F */
-#define MUX_PA14F_LCDCA_SEG6            _L(5)
+#define GPIO_PA13F_LCDCA_SEG5    _UL_(1 << 13)
+#define PIN_PA14F_LCDCA_SEG6           _L_(14) /**< \brief LCDCA signal: SEG6 on PA14 mux F */
+#define MUX_PA14F_LCDCA_SEG6            _L_(5)
 #define PINMUX_PA14F_LCDCA_SEG6    ((PIN_PA14F_LCDCA_SEG6 << 16) | MUX_PA14F_LCDCA_SEG6)
-#define GPIO_PA14F_LCDCA_SEG6    _UL(1 << 14)
-#define PIN_PA15F_LCDCA_SEG7           _L(15) /**< \brief LCDCA signal: SEG7 on PA15 mux F */
-#define MUX_PA15F_LCDCA_SEG7            _L(5)
+#define GPIO_PA14F_LCDCA_SEG6    _UL_(1 << 14)
+#define PIN_PA15F_LCDCA_SEG7           _L_(15) /**< \brief LCDCA signal: SEG7 on PA15 mux F */
+#define MUX_PA15F_LCDCA_SEG7            _L_(5)
 #define PINMUX_PA15F_LCDCA_SEG7    ((PIN_PA15F_LCDCA_SEG7 << 16) | MUX_PA15F_LCDCA_SEG7)
-#define GPIO_PA15F_LCDCA_SEG7    _UL(1 << 15)
-#define PIN_PA16F_LCDCA_SEG8           _L(16) /**< \brief LCDCA signal: SEG8 on PA16 mux F */
-#define MUX_PA16F_LCDCA_SEG8            _L(5)
+#define GPIO_PA15F_LCDCA_SEG7    _UL_(1 << 15)
+#define PIN_PA16F_LCDCA_SEG8           _L_(16) /**< \brief LCDCA signal: SEG8 on PA16 mux F */
+#define MUX_PA16F_LCDCA_SEG8            _L_(5)
 #define PINMUX_PA16F_LCDCA_SEG8    ((PIN_PA16F_LCDCA_SEG8 << 16) | MUX_PA16F_LCDCA_SEG8)
-#define GPIO_PA16F_LCDCA_SEG8    _UL(1 << 16)
-#define PIN_PA17F_LCDCA_SEG9           _L(17) /**< \brief LCDCA signal: SEG9 on PA17 mux F */
-#define MUX_PA17F_LCDCA_SEG9            _L(5)
+#define GPIO_PA16F_LCDCA_SEG8    _UL_(1 << 16)
+#define PIN_PA17F_LCDCA_SEG9           _L_(17) /**< \brief LCDCA signal: SEG9 on PA17 mux F */
+#define MUX_PA17F_LCDCA_SEG9            _L_(5)
 #define PINMUX_PA17F_LCDCA_SEG9    ((PIN_PA17F_LCDCA_SEG9 << 16) | MUX_PA17F_LCDCA_SEG9)
-#define GPIO_PA17F_LCDCA_SEG9    _UL(1 << 17)
-#define PIN_PA18F_LCDCA_SEG18          _L(18) /**< \brief LCDCA signal: SEG18 on PA18 mux F */
-#define MUX_PA18F_LCDCA_SEG18           _L(5)
+#define GPIO_PA17F_LCDCA_SEG9    _UL_(1 << 17)
+#define PIN_PA18F_LCDCA_SEG18          _L_(18) /**< \brief LCDCA signal: SEG18 on PA18 mux F */
+#define MUX_PA18F_LCDCA_SEG18           _L_(5)
 #define PINMUX_PA18F_LCDCA_SEG18   ((PIN_PA18F_LCDCA_SEG18 << 16) | MUX_PA18F_LCDCA_SEG18)
-#define GPIO_PA18F_LCDCA_SEG18   _UL(1 << 18)
-#define PIN_PA19F_LCDCA_SEG19          _L(19) /**< \brief LCDCA signal: SEG19 on PA19 mux F */
-#define MUX_PA19F_LCDCA_SEG19           _L(5)
+#define GPIO_PA18F_LCDCA_SEG18   _UL_(1 << 18)
+#define PIN_PA19F_LCDCA_SEG19          _L_(19) /**< \brief LCDCA signal: SEG19 on PA19 mux F */
+#define MUX_PA19F_LCDCA_SEG19           _L_(5)
 #define PINMUX_PA19F_LCDCA_SEG19   ((PIN_PA19F_LCDCA_SEG19 << 16) | MUX_PA19F_LCDCA_SEG19)
-#define GPIO_PA19F_LCDCA_SEG19   _UL(1 << 19)
-#define PIN_PA20F_LCDCA_SEG20          _L(20) /**< \brief LCDCA signal: SEG20 on PA20 mux F */
-#define MUX_PA20F_LCDCA_SEG20           _L(5)
+#define GPIO_PA19F_LCDCA_SEG19   _UL_(1 << 19)
+#define PIN_PA20F_LCDCA_SEG20          _L_(20) /**< \brief LCDCA signal: SEG20 on PA20 mux F */
+#define MUX_PA20F_LCDCA_SEG20           _L_(5)
 #define PINMUX_PA20F_LCDCA_SEG20   ((PIN_PA20F_LCDCA_SEG20 << 16) | MUX_PA20F_LCDCA_SEG20)
-#define GPIO_PA20F_LCDCA_SEG20   _UL(1 << 20)
-#define PIN_PA08F_LCDCA_SEG23           _L(8) /**< \brief LCDCA signal: SEG23 on PA08 mux F */
-#define MUX_PA08F_LCDCA_SEG23           _L(5)
+#define GPIO_PA20F_LCDCA_SEG20   _UL_(1 << 20)
+#define PIN_PA08F_LCDCA_SEG23           _L_(8) /**< \brief LCDCA signal: SEG23 on PA08 mux F */
+#define MUX_PA08F_LCDCA_SEG23           _L_(5)
 #define PINMUX_PA08F_LCDCA_SEG23   ((PIN_PA08F_LCDCA_SEG23 << 16) | MUX_PA08F_LCDCA_SEG23)
-#define GPIO_PA08F_LCDCA_SEG23   _UL(1 <<  8)
-#define PIN_PA21F_LCDCA_SEG34          _L(21) /**< \brief LCDCA signal: SEG34 on PA21 mux F */
-#define MUX_PA21F_LCDCA_SEG34           _L(5)
+#define GPIO_PA08F_LCDCA_SEG23   _UL_(1 <<  8)
+#define PIN_PA21F_LCDCA_SEG34          _L_(21) /**< \brief LCDCA signal: SEG34 on PA21 mux F */
+#define MUX_PA21F_LCDCA_SEG34           _L_(5)
 #define PINMUX_PA21F_LCDCA_SEG34   ((PIN_PA21F_LCDCA_SEG34 << 16) | MUX_PA21F_LCDCA_SEG34)
-#define GPIO_PA21F_LCDCA_SEG34   _UL(1 << 21)
-#define PIN_PA22F_LCDCA_SEG35          _L(22) /**< \brief LCDCA signal: SEG35 on PA22 mux F */
-#define MUX_PA22F_LCDCA_SEG35           _L(5)
+#define GPIO_PA21F_LCDCA_SEG34   _UL_(1 << 21)
+#define PIN_PA22F_LCDCA_SEG35          _L_(22) /**< \brief LCDCA signal: SEG35 on PA22 mux F */
+#define MUX_PA22F_LCDCA_SEG35           _L_(5)
 #define PINMUX_PA22F_LCDCA_SEG35   ((PIN_PA22F_LCDCA_SEG35 << 16) | MUX_PA22F_LCDCA_SEG35)
-#define GPIO_PA22F_LCDCA_SEG35   _UL(1 << 22)
-#define PIN_PA23F_LCDCA_SEG38          _L(23) /**< \brief LCDCA signal: SEG38 on PA23 mux F */
-#define MUX_PA23F_LCDCA_SEG38           _L(5)
+#define GPIO_PA22F_LCDCA_SEG35   _UL_(1 << 22)
+#define PIN_PA23F_LCDCA_SEG38          _L_(23) /**< \brief LCDCA signal: SEG38 on PA23 mux F */
+#define MUX_PA23F_LCDCA_SEG38           _L_(5)
 #define PINMUX_PA23F_LCDCA_SEG38   ((PIN_PA23F_LCDCA_SEG38 << 16) | MUX_PA23F_LCDCA_SEG38)
-#define GPIO_PA23F_LCDCA_SEG38   _UL(1 << 23)
-#define PIN_PA24F_LCDCA_SEG39          _L(24) /**< \brief LCDCA signal: SEG39 on PA24 mux F */
-#define MUX_PA24F_LCDCA_SEG39           _L(5)
+#define GPIO_PA23F_LCDCA_SEG38   _UL_(1 << 23)
+#define PIN_PA24F_LCDCA_SEG39          _L_(24) /**< \brief LCDCA signal: SEG39 on PA24 mux F */
+#define MUX_PA24F_LCDCA_SEG39           _L_(5)
 #define PINMUX_PA24F_LCDCA_SEG39   ((PIN_PA24F_LCDCA_SEG39 << 16) | MUX_PA24F_LCDCA_SEG39)
-#define GPIO_PA24F_LCDCA_SEG39   _UL(1 << 24)
+#define GPIO_PA24F_LCDCA_SEG39   _UL_(1 << 24)
 /* ========== GPIO definition for USBC peripheral ========== */
-#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
-#define MUX_PA25A_USBC_DM               _L(0)
+#define PIN_PA25A_USBC_DM              _L_(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L_(0)
 #define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
-#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
-#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
-#define MUX_PA26A_USBC_DP               _L(0)
+#define GPIO_PA25A_USBC_DM       _UL_(1 << 25)
+#define PIN_PA26A_USBC_DP              _L_(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L_(0)
 #define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
-#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+#define GPIO_PA26A_USBC_DP       _UL_(1 << 26)
 /* ========== GPIO definition for PEVC peripheral ========== */
-#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
-#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PIN_PA08C_PEVC_PAD_EVT0         _L_(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
-#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
-#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
-#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL_(1 <<  8)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L_(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
-#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
-#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
-#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL_(1 <<  9)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L_(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
-#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
-#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
-#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL_(1 << 10)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L_(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L_(2)
 #define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
-#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL_(1 << 11)
 /* ========== GPIO definition for SCIF peripheral ========== */
-#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
-#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PIN_PA19E_SCIF_GCLK0           _L_(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
-#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
-#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
-#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define GPIO_PA19E_SCIF_GCLK0    _UL_(1 << 19)
+#define PIN_PA02A_SCIF_GCLK0            _L_(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L_(0)
 #define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
-#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
-#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
-#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define GPIO_PA02A_SCIF_GCLK0    _UL_(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L_(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
-#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
-#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
-#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PA20E_SCIF_GCLK1    _UL_(1 << 20)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L_(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
-#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
-#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
-#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL_(1 << 23)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L_(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
-#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL_(1 << 24)
 /* ========== GPIO definition for EIC peripheral ========== */
-#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
-#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define PIN_PA06C_EIC_EXTINT1           _L_(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
-#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
-#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
-#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
-#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define GPIO_PA06C_EIC_EXTINT1   _UL_(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L_(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
-#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
-#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
-#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
-#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define GPIO_PA16C_EIC_EXTINT1   _UL_(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L_(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
-#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
-#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
-#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
-#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL_(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L_(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
-#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
-#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
-#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
-#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL_(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L_(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
-#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
-#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
-#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
-#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define GPIO_PA05C_EIC_EXTINT3   _UL_(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L_(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
-#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
-#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
-#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
-#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define GPIO_PA18C_EIC_EXTINT3   _UL_(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L_(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
-#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
-#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
-#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
-#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define GPIO_PA07C_EIC_EXTINT4   _UL_(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L_(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
-#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
-#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
-#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
-#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define GPIO_PA19C_EIC_EXTINT4   _UL_(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L_(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L_(2)
 #define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
-#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
-#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
-#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
-#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define GPIO_PA20C_EIC_EXTINT5   _UL_(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L_(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L_(2)
 #define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
-#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
-#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
-#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
-#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define GPIO_PA21C_EIC_EXTINT6   _UL_(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L_(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L_(2)
 #define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
-#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
-#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
-#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
-#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define GPIO_PA22C_EIC_EXTINT7   _UL_(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L_(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L_(2)
 #define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
-#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
-#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define GPIO_PA23C_EIC_EXTINT8   _UL_(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
 
 #endif /* _SAM4LC8A_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4lc8b.h
+++ b/asf/sam/include/sam4l/pio/sam4lc8b.h
@@ -1,0 +1,1079 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAM4LC8B
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LC8B_PIO_
+#define _SAM4LC8B_PIO_
+
+#define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
+#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
+#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
+#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
+#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
+#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
+#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
+#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
+#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
+#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
+#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
+#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
+#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
+#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
+#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
+#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
+#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
+#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
+#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
+#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
+#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
+#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
+#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
+#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
+#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
+#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
+#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
+#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
+#define GPIO_PB00                _UL(1 <<  0) /**< \brief GPIO Mask  for PB00 */
+#define PIN_PB01                          33  /**< \brief Pin Number for PB01 */
+#define GPIO_PB01                _UL(1 <<  1) /**< \brief GPIO Mask  for PB01 */
+#define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
+#define GPIO_PB02                _UL(1 <<  2) /**< \brief GPIO Mask  for PB02 */
+#define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
+#define GPIO_PB03                _UL(1 <<  3) /**< \brief GPIO Mask  for PB03 */
+#define PIN_PB04                          36  /**< \brief Pin Number for PB04 */
+#define GPIO_PB04                _UL(1 <<  4) /**< \brief GPIO Mask  for PB04 */
+#define PIN_PB05                          37  /**< \brief Pin Number for PB05 */
+#define GPIO_PB05                _UL(1 <<  5) /**< \brief GPIO Mask  for PB05 */
+#define PIN_PB06                          38  /**< \brief Pin Number for PB06 */
+#define GPIO_PB06                _UL(1 <<  6) /**< \brief GPIO Mask  for PB06 */
+#define PIN_PB07                          39  /**< \brief Pin Number for PB07 */
+#define GPIO_PB07                _UL(1 <<  7) /**< \brief GPIO Mask  for PB07 */
+#define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
+#define GPIO_PB08                _UL(1 <<  8) /**< \brief GPIO Mask  for PB08 */
+#define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
+#define GPIO_PB09                _UL(1 <<  9) /**< \brief GPIO Mask  for PB09 */
+#define PIN_PB10                          42  /**< \brief Pin Number for PB10 */
+#define GPIO_PB10                _UL(1 << 10) /**< \brief GPIO Mask  for PB10 */
+#define PIN_PB11                          43  /**< \brief Pin Number for PB11 */
+#define GPIO_PB11                _UL(1 << 11) /**< \brief GPIO Mask  for PB11 */
+#define PIN_PB12                          44  /**< \brief Pin Number for PB12 */
+#define GPIO_PB12                _UL(1 << 12) /**< \brief GPIO Mask  for PB12 */
+#define PIN_PB13                          45  /**< \brief Pin Number for PB13 */
+#define GPIO_PB13                _UL(1 << 13) /**< \brief GPIO Mask  for PB13 */
+#define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
+#define GPIO_PB14                _UL(1 << 14) /**< \brief GPIO Mask  for PB14 */
+#define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
+#define GPIO_PB15                _UL(1 << 15) /**< \brief GPIO Mask  for PB15 */
+/* ========== GPIO definition for TWIMS0 peripheral ========== */
+#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
+#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+/* ========== GPIO definition for TWIMS1 peripheral ========== */
+#define PIN_PB01A_TWIMS1_TWCK          _L(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
+#define MUX_PB01A_TWIMS1_TWCK           _L(0)
+#define PINMUX_PB01A_TWIMS1_TWCK   ((PIN_PB01A_TWIMS1_TWCK << 16) | MUX_PB01A_TWIMS1_TWCK)
+#define GPIO_PB01A_TWIMS1_TWCK   _UL(1 <<  1)
+#define PIN_PB00A_TWIMS1_TWD           _L(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
+#define MUX_PB00A_TWIMS1_TWD            _L(0)
+#define PINMUX_PB00A_TWIMS1_TWD    ((PIN_PB00A_TWIMS1_TWD << 16) | MUX_PB00A_TWIMS1_TWD)
+#define GPIO_PB00A_TWIMS1_TWD    _UL(1 <<  0)
+/* ========== GPIO definition for TWIMS2 peripheral ========== */
+#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
+#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+/* ========== GPIO definition for TWIMS3 peripheral ========== */
+#define PIN_PB15C_TWIMS3_TWCK          _L(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
+#define MUX_PB15C_TWIMS3_TWCK           _L(2)
+#define PINMUX_PB15C_TWIMS3_TWCK   ((PIN_PB15C_TWIMS3_TWCK << 16) | MUX_PB15C_TWIMS3_TWCK)
+#define GPIO_PB15C_TWIMS3_TWCK   _UL(1 << 15)
+#define PIN_PB14C_TWIMS3_TWD           _L(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
+#define MUX_PB14C_TWIMS3_TWD            _L(2)
+#define PINMUX_PB14C_TWIMS3_TWD    ((PIN_PB14C_TWIMS3_TWD << 16) | MUX_PB14C_TWIMS3_TWD)
+#define GPIO_PB14C_TWIMS3_TWD    _UL(1 << 14)
+/* ========== GPIO definition for IISC peripheral ========== */
+#define PIN_PB05D_IISC_IMCK            _L(37) /**< \brief IISC signal: IMCK on PB05 mux D */
+#define MUX_PB05D_IISC_IMCK             _L(3)
+#define PINMUX_PB05D_IISC_IMCK     ((PIN_PB05D_IISC_IMCK << 16) | MUX_PB05D_IISC_IMCK)
+#define GPIO_PB05D_IISC_IMCK     _UL(1 <<  5)
+#define PIN_PB02D_IISC_ISCK            _L(34) /**< \brief IISC signal: ISCK on PB02 mux D */
+#define MUX_PB02D_IISC_ISCK             _L(3)
+#define PINMUX_PB02D_IISC_ISCK     ((PIN_PB02D_IISC_ISCK << 16) | MUX_PB02D_IISC_ISCK)
+#define GPIO_PB02D_IISC_ISCK     _UL(1 <<  2)
+#define PIN_PB03D_IISC_ISDI            _L(35) /**< \brief IISC signal: ISDI on PB03 mux D */
+#define MUX_PB03D_IISC_ISDI             _L(3)
+#define PINMUX_PB03D_IISC_ISDI     ((PIN_PB03D_IISC_ISDI << 16) | MUX_PB03D_IISC_ISDI)
+#define GPIO_PB03D_IISC_ISDI     _UL(1 <<  3)
+#define PIN_PB04D_IISC_ISDO            _L(36) /**< \brief IISC signal: ISDO on PB04 mux D */
+#define MUX_PB04D_IISC_ISDO             _L(3)
+#define PINMUX_PB04D_IISC_ISDO     ((PIN_PB04D_IISC_ISDO << 16) | MUX_PB04D_IISC_ISDO)
+#define GPIO_PB04D_IISC_ISDO     _UL(1 <<  4)
+#define PIN_PB06D_IISC_IWS             _L(38) /**< \brief IISC signal: IWS on PB06 mux D */
+#define MUX_PB06D_IISC_IWS              _L(3)
+#define PINMUX_PB06D_IISC_IWS      ((PIN_PB06D_IISC_IWS << 16) | MUX_PB06D_IISC_IWS)
+#define GPIO_PB06D_IISC_IWS      _UL(1 <<  6)
+/* ========== GPIO definition for SPI peripheral ========== */
+#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L(1)
+#define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
+#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
+#define PIN_PB14B_SPI_MISO             _L(46) /**< \brief SPI signal: MISO on PB14 mux B */
+#define MUX_PB14B_SPI_MISO              _L(1)
+#define PINMUX_PB14B_SPI_MISO      ((PIN_PB14B_SPI_MISO << 16) | MUX_PB14B_SPI_MISO)
+#define GPIO_PB14B_SPI_MISO      _UL(1 << 14)
+#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L(0)
+#define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
+#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
+#define PIN_PB15B_SPI_MOSI             _L(47) /**< \brief SPI signal: MOSI on PB15 mux B */
+#define MUX_PB15B_SPI_MOSI              _L(1)
+#define PINMUX_PB15B_SPI_MOSI      ((PIN_PB15B_SPI_MOSI << 16) | MUX_PB15B_SPI_MOSI)
+#define GPIO_PB15B_SPI_MOSI      _UL(1 << 15)
+#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L(0)
+#define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
+#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
+#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
+#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
+#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
+#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
+#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
+#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PB13B_SPI_NPCS1            _L(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
+#define MUX_PB13B_SPI_NPCS1             _L(1)
+#define PINMUX_PB13B_SPI_NPCS1     ((PIN_PB13B_SPI_NPCS1 << 16) | MUX_PB13B_SPI_NPCS1)
+#define GPIO_PB13B_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
+#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
+#define PIN_PB11B_SPI_NPCS2            _L(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
+#define MUX_PB11B_SPI_NPCS2             _L(1)
+#define PINMUX_PB11B_SPI_NPCS2     ((PIN_PB11B_SPI_NPCS2 << 16) | MUX_PB11B_SPI_NPCS2)
+#define GPIO_PB11B_SPI_NPCS2     _UL(1 << 11)
+#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
+#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
+#define PIN_PB12B_SPI_NPCS3            _L(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
+#define MUX_PB12B_SPI_NPCS3             _L(1)
+#define PINMUX_PB12B_SPI_NPCS3     ((PIN_PB12B_SPI_NPCS3 << 16) | MUX_PB12B_SPI_NPCS3)
+#define GPIO_PB12B_SPI_NPCS3     _UL(1 << 12)
+#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L(0)
+#define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
+#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
+/* ========== GPIO definition for TC0 peripheral ========== */
+#define PIN_PB07D_TC0_A0               _L(39) /**< \brief TC0 signal: A0 on PB07 mux D */
+#define MUX_PB07D_TC0_A0                _L(3)
+#define PINMUX_PB07D_TC0_A0        ((PIN_PB07D_TC0_A0 << 16) | MUX_PB07D_TC0_A0)
+#define GPIO_PB07D_TC0_A0        _UL(1 <<  7)
+#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L(1)
+#define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
+#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
+#define PIN_PB09D_TC0_A1               _L(41) /**< \brief TC0 signal: A1 on PB09 mux D */
+#define MUX_PB09D_TC0_A1                _L(3)
+#define PINMUX_PB09D_TC0_A1        ((PIN_PB09D_TC0_A1 << 16) | MUX_PB09D_TC0_A1)
+#define GPIO_PB09D_TC0_A1        _UL(1 <<  9)
+#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L(1)
+#define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
+#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
+#define PIN_PB11D_TC0_A2               _L(43) /**< \brief TC0 signal: A2 on PB11 mux D */
+#define MUX_PB11D_TC0_A2                _L(3)
+#define PINMUX_PB11D_TC0_A2        ((PIN_PB11D_TC0_A2 << 16) | MUX_PB11D_TC0_A2)
+#define GPIO_PB11D_TC0_A2        _UL(1 << 11)
+#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L(1)
+#define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
+#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
+#define PIN_PB08D_TC0_B0               _L(40) /**< \brief TC0 signal: B0 on PB08 mux D */
+#define MUX_PB08D_TC0_B0                _L(3)
+#define PINMUX_PB08D_TC0_B0        ((PIN_PB08D_TC0_B0 << 16) | MUX_PB08D_TC0_B0)
+#define GPIO_PB08D_TC0_B0        _UL(1 <<  8)
+#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L(1)
+#define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
+#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
+#define PIN_PB10D_TC0_B1               _L(42) /**< \brief TC0 signal: B1 on PB10 mux D */
+#define MUX_PB10D_TC0_B1                _L(3)
+#define PINMUX_PB10D_TC0_B1        ((PIN_PB10D_TC0_B1 << 16) | MUX_PB10D_TC0_B1)
+#define GPIO_PB10D_TC0_B1        _UL(1 << 10)
+#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L(1)
+#define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
+#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
+#define PIN_PB12D_TC0_B2               _L(44) /**< \brief TC0 signal: B2 on PB12 mux D */
+#define MUX_PB12D_TC0_B2                _L(3)
+#define PINMUX_PB12D_TC0_B2        ((PIN_PB12D_TC0_B2 << 16) | MUX_PB12D_TC0_B2)
+#define GPIO_PB12D_TC0_B2        _UL(1 << 12)
+#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L(1)
+#define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
+#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
+#define PIN_PB13D_TC0_CLK0             _L(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
+#define MUX_PB13D_TC0_CLK0              _L(3)
+#define PINMUX_PB13D_TC0_CLK0      ((PIN_PB13D_TC0_CLK0 << 16) | MUX_PB13D_TC0_CLK0)
+#define GPIO_PB13D_TC0_CLK0      _UL(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L(1)
+#define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
+#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
+#define PIN_PB14D_TC0_CLK1             _L(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
+#define MUX_PB14D_TC0_CLK1              _L(3)
+#define PINMUX_PB14D_TC0_CLK1      ((PIN_PB14D_TC0_CLK1 << 16) | MUX_PB14D_TC0_CLK1)
+#define GPIO_PB14D_TC0_CLK1      _UL(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L(1)
+#define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
+#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
+#define PIN_PB15D_TC0_CLK2             _L(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
+#define MUX_PB15D_TC0_CLK2              _L(3)
+#define PINMUX_PB15D_TC0_CLK2      ((PIN_PB15D_TC0_CLK2 << 16) | MUX_PB15D_TC0_CLK2)
+#define GPIO_PB15D_TC0_CLK2      _UL(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L(1)
+#define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
+#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+/* ========== GPIO definition for USART0 peripheral ========== */
+#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L(1)
+#define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
+#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
+#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L(0)
+#define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
+#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
+#define PIN_PB13A_USART0_CLK           _L(45) /**< \brief USART0 signal: CLK on PB13 mux A */
+#define MUX_PB13A_USART0_CLK            _L(0)
+#define PINMUX_PB13A_USART0_CLK    ((PIN_PB13A_USART0_CLK << 16) | MUX_PB13A_USART0_CLK)
+#define GPIO_PB13A_USART0_CLK    _UL(1 << 13)
+#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L(0)
+#define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
+#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
+#define PIN_PB11A_USART0_CTS           _L(43) /**< \brief USART0 signal: CTS on PB11 mux A */
+#define MUX_PB11A_USART0_CTS            _L(0)
+#define PINMUX_PB11A_USART0_CTS    ((PIN_PB11A_USART0_CTS << 16) | MUX_PB11A_USART0_CTS)
+#define GPIO_PB11A_USART0_CTS    _UL(1 << 11)
+#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L(1)
+#define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
+#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
+#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L(0)
+#define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
+#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
+#define PIN_PB12A_USART0_RTS           _L(44) /**< \brief USART0 signal: RTS on PB12 mux A */
+#define MUX_PB12A_USART0_RTS            _L(0)
+#define PINMUX_PB12A_USART0_RTS    ((PIN_PB12A_USART0_RTS << 16) | MUX_PB12A_USART0_RTS)
+#define GPIO_PB12A_USART0_RTS    _UL(1 << 12)
+#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L(1)
+#define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
+#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
+#define PIN_PB00B_USART0_RXD           _L(32) /**< \brief USART0 signal: RXD on PB00 mux B */
+#define MUX_PB00B_USART0_RXD            _L(1)
+#define PINMUX_PB00B_USART0_RXD    ((PIN_PB00B_USART0_RXD << 16) | MUX_PB00B_USART0_RXD)
+#define GPIO_PB00B_USART0_RXD    _UL(1 <<  0)
+#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L(0)
+#define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
+#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
+#define PIN_PB14A_USART0_RXD           _L(46) /**< \brief USART0 signal: RXD on PB14 mux A */
+#define MUX_PB14A_USART0_RXD            _L(0)
+#define PINMUX_PB14A_USART0_RXD    ((PIN_PB14A_USART0_RXD << 16) | MUX_PB14A_USART0_RXD)
+#define GPIO_PB14A_USART0_RXD    _UL(1 << 14)
+#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L(1)
+#define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
+#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
+#define PIN_PB01B_USART0_TXD           _L(33) /**< \brief USART0 signal: TXD on PB01 mux B */
+#define MUX_PB01B_USART0_TXD            _L(1)
+#define PINMUX_PB01B_USART0_TXD    ((PIN_PB01B_USART0_TXD << 16) | MUX_PB01B_USART0_TXD)
+#define GPIO_PB01B_USART0_TXD    _UL(1 <<  1)
+#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L(0)
+#define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
+#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
+#define PIN_PB15A_USART0_TXD           _L(47) /**< \brief USART0 signal: TXD on PB15 mux A */
+#define MUX_PB15A_USART0_TXD            _L(0)
+#define PINMUX_PB15A_USART0_TXD    ((PIN_PB15A_USART0_TXD << 16) | MUX_PB15A_USART0_TXD)
+#define GPIO_PB15A_USART0_TXD    _UL(1 << 15)
+/* ========== GPIO definition for USART1 peripheral ========== */
+#define PIN_PB03B_USART1_CLK           _L(35) /**< \brief USART1 signal: CLK on PB03 mux B */
+#define MUX_PB03B_USART1_CLK            _L(1)
+#define PINMUX_PB03B_USART1_CLK    ((PIN_PB03B_USART1_CLK << 16) | MUX_PB03B_USART1_CLK)
+#define GPIO_PB03B_USART1_CLK    _UL(1 <<  3)
+#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L(0)
+#define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
+#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
+#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L(1)
+#define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
+#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
+#define PIN_PB02B_USART1_RTS           _L(34) /**< \brief USART1 signal: RTS on PB02 mux B */
+#define MUX_PB02B_USART1_RTS            _L(1)
+#define PINMUX_PB02B_USART1_RTS    ((PIN_PB02B_USART1_RTS << 16) | MUX_PB02B_USART1_RTS)
+#define GPIO_PB02B_USART1_RTS    _UL(1 <<  2)
+#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L(0)
+#define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
+#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
+#define PIN_PB04B_USART1_RXD           _L(36) /**< \brief USART1 signal: RXD on PB04 mux B */
+#define MUX_PB04B_USART1_RXD            _L(1)
+#define PINMUX_PB04B_USART1_RXD    ((PIN_PB04B_USART1_RXD << 16) | MUX_PB04B_USART1_RXD)
+#define GPIO_PB04B_USART1_RXD    _UL(1 <<  4)
+#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L(0)
+#define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
+#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
+#define PIN_PB05B_USART1_TXD           _L(37) /**< \brief USART1 signal: TXD on PB05 mux B */
+#define MUX_PB05B_USART1_TXD            _L(1)
+#define PINMUX_PB05B_USART1_TXD    ((PIN_PB05B_USART1_TXD << 16) | MUX_PB05B_USART1_TXD)
+#define GPIO_PB05B_USART1_TXD    _UL(1 <<  5)
+#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L(0)
+#define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
+#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+/* ========== GPIO definition for USART2 peripheral ========== */
+#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L(0)
+#define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
+#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
+#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L(1)
+#define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
+#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
+#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L(0)
+#define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
+#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L(1)
+#define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
+#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
+#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L(0)
+#define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
+#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L(1)
+#define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
+#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
+#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L(0)
+#define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
+#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+/* ========== GPIO definition for USART3 peripheral ========== */
+#define PIN_PB08A_USART3_CLK           _L(40) /**< \brief USART3 signal: CLK on PB08 mux A */
+#define MUX_PB08A_USART3_CLK            _L(0)
+#define PINMUX_PB08A_USART3_CLK    ((PIN_PB08A_USART3_CLK << 16) | MUX_PB08A_USART3_CLK)
+#define GPIO_PB08A_USART3_CLK    _UL(1 <<  8)
+#define PIN_PB07A_USART3_CTS           _L(39) /**< \brief USART3 signal: CTS on PB07 mux A */
+#define MUX_PB07A_USART3_CTS            _L(0)
+#define PINMUX_PB07A_USART3_CTS    ((PIN_PB07A_USART3_CTS << 16) | MUX_PB07A_USART3_CTS)
+#define GPIO_PB07A_USART3_CTS    _UL(1 <<  7)
+#define PIN_PB06A_USART3_RTS           _L(38) /**< \brief USART3 signal: RTS on PB06 mux A */
+#define MUX_PB06A_USART3_RTS            _L(0)
+#define PINMUX_PB06A_USART3_RTS    ((PIN_PB06A_USART3_RTS << 16) | MUX_PB06A_USART3_RTS)
+#define GPIO_PB06A_USART3_RTS    _UL(1 <<  6)
+#define PIN_PB09A_USART3_RXD           _L(41) /**< \brief USART3 signal: RXD on PB09 mux A */
+#define MUX_PB09A_USART3_RXD            _L(0)
+#define PINMUX_PB09A_USART3_RXD    ((PIN_PB09A_USART3_RXD << 16) | MUX_PB09A_USART3_RXD)
+#define GPIO_PB09A_USART3_RXD    _UL(1 <<  9)
+#define PIN_PB10A_USART3_TXD           _L(42) /**< \brief USART3 signal: TXD on PB10 mux A */
+#define MUX_PB10A_USART3_TXD            _L(0)
+#define PINMUX_PB10A_USART3_TXD    ((PIN_PB10A_USART3_TXD << 16) | MUX_PB10A_USART3_TXD)
+#define GPIO_PB10A_USART3_TXD    _UL(1 << 10)
+/* ========== GPIO definition for ADCIFE peripheral ========== */
+#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
+#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
+#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
+#define PIN_PB02A_ADCIFE_AD3           _L(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
+#define MUX_PB02A_ADCIFE_AD3            _L(0)
+#define PINMUX_PB02A_ADCIFE_AD3    ((PIN_PB02A_ADCIFE_AD3 << 16) | MUX_PB02A_ADCIFE_AD3)
+#define GPIO_PB02A_ADCIFE_AD3    _UL(1 <<  2)
+#define PIN_PB03A_ADCIFE_AD4           _L(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
+#define MUX_PB03A_ADCIFE_AD4            _L(0)
+#define PINMUX_PB03A_ADCIFE_AD4    ((PIN_PB03A_ADCIFE_AD4 << 16) | MUX_PB03A_ADCIFE_AD4)
+#define GPIO_PB03A_ADCIFE_AD4    _UL(1 <<  3)
+#define PIN_PB04A_ADCIFE_AD5           _L(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
+#define MUX_PB04A_ADCIFE_AD5            _L(0)
+#define PINMUX_PB04A_ADCIFE_AD5    ((PIN_PB04A_ADCIFE_AD5 << 16) | MUX_PB04A_ADCIFE_AD5)
+#define GPIO_PB04A_ADCIFE_AD5    _UL(1 <<  4)
+#define PIN_PB05A_ADCIFE_AD6           _L(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
+#define MUX_PB05A_ADCIFE_AD6            _L(0)
+#define PINMUX_PB05A_ADCIFE_AD6    ((PIN_PB05A_ADCIFE_AD6 << 16) | MUX_PB05A_ADCIFE_AD6)
+#define GPIO_PB05A_ADCIFE_AD6    _UL(1 <<  5)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+/* ========== GPIO definition for DACC peripheral ========== */
+#define PIN_PB04E_DACC_EXT_TRIG0       _L(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
+#define MUX_PB04E_DACC_EXT_TRIG0        _L(4)
+#define PINMUX_PB04E_DACC_EXT_TRIG0  ((PIN_PB04E_DACC_EXT_TRIG0 << 16) | MUX_PB04E_DACC_EXT_TRIG0)
+#define GPIO_PB04E_DACC_EXT_TRIG0  _UL(1 <<  4)
+#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L(0)
+#define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
+#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+/* ========== GPIO definition for ACIFC peripheral ========== */
+#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
+#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
+#define PIN_PB02E_ACIFC_ACBN0          _L(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
+#define MUX_PB02E_ACIFC_ACBN0           _L(4)
+#define PINMUX_PB02E_ACIFC_ACBN0   ((PIN_PB02E_ACIFC_ACBN0 << 16) | MUX_PB02E_ACIFC_ACBN0)
+#define GPIO_PB02E_ACIFC_ACBN0   _UL(1 <<  2)
+#define PIN_PB03E_ACIFC_ACBP0          _L(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
+#define MUX_PB03E_ACIFC_ACBP0           _L(4)
+#define PINMUX_PB03E_ACIFC_ACBP0   ((PIN_PB03E_ACIFC_ACBP0 << 16) | MUX_PB03E_ACIFC_ACBP0)
+#define GPIO_PB03E_ACIFC_ACBP0   _UL(1 <<  3)
+/* ========== GPIO definition for GLOC peripheral ========== */
+#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
+#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L(3)
+#define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
+#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L(3)
+#define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
+#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L(3)
+#define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
+#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L(3)
+#define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
+#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L(3)
+#define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
+#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L(3)
+#define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
+#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L(3)
+#define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
+#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
+#define PIN_PB06C_GLOC_IN4             _L(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
+#define MUX_PB06C_GLOC_IN4              _L(2)
+#define PINMUX_PB06C_GLOC_IN4      ((PIN_PB06C_GLOC_IN4 << 16) | MUX_PB06C_GLOC_IN4)
+#define GPIO_PB06C_GLOC_IN4      _UL(1 <<  6)
+#define PIN_PB07C_GLOC_IN5             _L(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
+#define MUX_PB07C_GLOC_IN5              _L(2)
+#define PINMUX_PB07C_GLOC_IN5      ((PIN_PB07C_GLOC_IN5 << 16) | MUX_PB07C_GLOC_IN5)
+#define GPIO_PB07C_GLOC_IN5      _UL(1 <<  7)
+#define PIN_PB08C_GLOC_IN6             _L(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
+#define MUX_PB08C_GLOC_IN6              _L(2)
+#define PINMUX_PB08C_GLOC_IN6      ((PIN_PB08C_GLOC_IN6 << 16) | MUX_PB08C_GLOC_IN6)
+#define GPIO_PB08C_GLOC_IN6      _UL(1 <<  8)
+#define PIN_PB09C_GLOC_IN7             _L(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
+#define MUX_PB09C_GLOC_IN7              _L(2)
+#define PINMUX_PB09C_GLOC_IN7      ((PIN_PB09C_GLOC_IN7 << 16) | MUX_PB09C_GLOC_IN7)
+#define GPIO_PB09C_GLOC_IN7      _UL(1 <<  9)
+#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
+#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
+#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
+#define PIN_PB10C_GLOC_OUT1            _L(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
+#define MUX_PB10C_GLOC_OUT1             _L(2)
+#define PINMUX_PB10C_GLOC_OUT1     ((PIN_PB10C_GLOC_OUT1 << 16) | MUX_PB10C_GLOC_OUT1)
+#define GPIO_PB10C_GLOC_OUT1     _UL(1 << 10)
+/* ========== GPIO definition for ABDACB peripheral ========== */
+#define PIN_PB02C_ABDACB_DAC0          _L(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
+#define MUX_PB02C_ABDACB_DAC0           _L(2)
+#define PINMUX_PB02C_ABDACB_DAC0   ((PIN_PB02C_ABDACB_DAC0 << 16) | MUX_PB02C_ABDACB_DAC0)
+#define GPIO_PB02C_ABDACB_DAC0   _UL(1 <<  2)
+#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
+#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
+#define PIN_PB04C_ABDACB_DAC1          _L(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
+#define MUX_PB04C_ABDACB_DAC1           _L(2)
+#define PINMUX_PB04C_ABDACB_DAC1   ((PIN_PB04C_ABDACB_DAC1 << 16) | MUX_PB04C_ABDACB_DAC1)
+#define GPIO_PB04C_ABDACB_DAC1   _UL(1 <<  4)
+#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
+#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
+#define PIN_PB03C_ABDACB_DACN0         _L(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
+#define MUX_PB03C_ABDACB_DACN0          _L(2)
+#define PINMUX_PB03C_ABDACB_DACN0  ((PIN_PB03C_ABDACB_DACN0 << 16) | MUX_PB03C_ABDACB_DACN0)
+#define GPIO_PB03C_ABDACB_DACN0  _UL(1 <<  3)
+#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
+#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
+#define PIN_PB05C_ABDACB_DACN1         _L(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
+#define MUX_PB05C_ABDACB_DACN1          _L(2)
+#define PINMUX_PB05C_ABDACB_DACN1  ((PIN_PB05C_ABDACB_DACN1 << 16) | MUX_PB05C_ABDACB_DACN1)
+#define GPIO_PB05C_ABDACB_DACN1  _UL(1 <<  5)
+#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
+#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+/* ========== GPIO definition for PARC peripheral ========== */
+#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
+#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
+#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
+#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
+#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
+#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
+#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
+#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
+#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
+#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
+#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
+#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
+#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
+#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
+#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
+#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
+#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
+#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
+#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
+#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
+#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+/* ========== GPIO definition for CATB peripheral ========== */
+#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L(6)
+#define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
+#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L(6)
+#define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
+#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L(6)
+#define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
+#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
+#define PIN_PB03G_CATB_DIS             _L(35) /**< \brief CATB signal: DIS on PB03 mux G */
+#define MUX_PB03G_CATB_DIS              _L(6)
+#define PINMUX_PB03G_CATB_DIS      ((PIN_PB03G_CATB_DIS << 16) | MUX_PB03G_CATB_DIS)
+#define GPIO_PB03G_CATB_DIS      _UL(1 <<  3)
+#define PIN_PB12G_CATB_DIS             _L(44) /**< \brief CATB signal: DIS on PB12 mux G */
+#define MUX_PB12G_CATB_DIS              _L(6)
+#define PINMUX_PB12G_CATB_DIS      ((PIN_PB12G_CATB_DIS << 16) | MUX_PB12G_CATB_DIS)
+#define GPIO_PB12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
+#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
+#define PIN_PB13G_CATB_SENSE0          _L(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
+#define MUX_PB13G_CATB_SENSE0           _L(6)
+#define PINMUX_PB13G_CATB_SENSE0   ((PIN_PB13G_CATB_SENSE0 << 16) | MUX_PB13G_CATB_SENSE0)
+#define GPIO_PB13G_CATB_SENSE0   _UL(1 << 13)
+#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
+#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
+#define PIN_PB14G_CATB_SENSE1          _L(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
+#define MUX_PB14G_CATB_SENSE1           _L(6)
+#define PINMUX_PB14G_CATB_SENSE1   ((PIN_PB14G_CATB_SENSE1 << 16) | MUX_PB14G_CATB_SENSE1)
+#define GPIO_PB14G_CATB_SENSE1   _UL(1 << 14)
+#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
+#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
+#define PIN_PB15G_CATB_SENSE2          _L(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
+#define MUX_PB15G_CATB_SENSE2           _L(6)
+#define PINMUX_PB15G_CATB_SENSE2   ((PIN_PB15G_CATB_SENSE2 << 16) | MUX_PB15G_CATB_SENSE2)
+#define GPIO_PB15G_CATB_SENSE2   _UL(1 << 15)
+#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
+#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
+#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
+#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
+#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
+#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
+#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
+#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
+#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
+#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
+#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
+#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
+#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
+#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
+#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
+#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
+#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
+#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
+#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
+#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
+#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
+#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
+#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
+#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
+#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
+#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
+#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
+#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
+#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
+#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
+#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
+#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
+#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
+#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
+#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
+#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
+#define PIN_PB00G_CATB_SENSE21         _L(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
+#define MUX_PB00G_CATB_SENSE21          _L(6)
+#define PINMUX_PB00G_CATB_SENSE21  ((PIN_PB00G_CATB_SENSE21 << 16) | MUX_PB00G_CATB_SENSE21)
+#define GPIO_PB00G_CATB_SENSE21  _UL(1 <<  0)
+#define PIN_PB01G_CATB_SENSE22         _L(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
+#define MUX_PB01G_CATB_SENSE22          _L(6)
+#define PINMUX_PB01G_CATB_SENSE22  ((PIN_PB01G_CATB_SENSE22 << 16) | MUX_PB01G_CATB_SENSE22)
+#define GPIO_PB01G_CATB_SENSE22  _UL(1 <<  1)
+#define PIN_PB02G_CATB_SENSE23         _L(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
+#define MUX_PB02G_CATB_SENSE23          _L(6)
+#define PINMUX_PB02G_CATB_SENSE23  ((PIN_PB02G_CATB_SENSE23 << 16) | MUX_PB02G_CATB_SENSE23)
+#define GPIO_PB02G_CATB_SENSE23  _UL(1 <<  2)
+#define PIN_PB04G_CATB_SENSE24         _L(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
+#define MUX_PB04G_CATB_SENSE24          _L(6)
+#define PINMUX_PB04G_CATB_SENSE24  ((PIN_PB04G_CATB_SENSE24 << 16) | MUX_PB04G_CATB_SENSE24)
+#define GPIO_PB04G_CATB_SENSE24  _UL(1 <<  4)
+#define PIN_PB05G_CATB_SENSE25         _L(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
+#define MUX_PB05G_CATB_SENSE25          _L(6)
+#define PINMUX_PB05G_CATB_SENSE25  ((PIN_PB05G_CATB_SENSE25 << 16) | MUX_PB05G_CATB_SENSE25)
+#define GPIO_PB05G_CATB_SENSE25  _UL(1 <<  5)
+#define PIN_PB06G_CATB_SENSE26         _L(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
+#define MUX_PB06G_CATB_SENSE26          _L(6)
+#define PINMUX_PB06G_CATB_SENSE26  ((PIN_PB06G_CATB_SENSE26 << 16) | MUX_PB06G_CATB_SENSE26)
+#define GPIO_PB06G_CATB_SENSE26  _UL(1 <<  6)
+#define PIN_PB07G_CATB_SENSE27         _L(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
+#define MUX_PB07G_CATB_SENSE27          _L(6)
+#define PINMUX_PB07G_CATB_SENSE27  ((PIN_PB07G_CATB_SENSE27 << 16) | MUX_PB07G_CATB_SENSE27)
+#define GPIO_PB07G_CATB_SENSE27  _UL(1 <<  7)
+#define PIN_PB08G_CATB_SENSE28         _L(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
+#define MUX_PB08G_CATB_SENSE28          _L(6)
+#define PINMUX_PB08G_CATB_SENSE28  ((PIN_PB08G_CATB_SENSE28 << 16) | MUX_PB08G_CATB_SENSE28)
+#define GPIO_PB08G_CATB_SENSE28  _UL(1 <<  8)
+#define PIN_PB09G_CATB_SENSE29         _L(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
+#define MUX_PB09G_CATB_SENSE29          _L(6)
+#define PINMUX_PB09G_CATB_SENSE29  ((PIN_PB09G_CATB_SENSE29 << 16) | MUX_PB09G_CATB_SENSE29)
+#define GPIO_PB09G_CATB_SENSE29  _UL(1 <<  9)
+#define PIN_PB10G_CATB_SENSE30         _L(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
+#define MUX_PB10G_CATB_SENSE30          _L(6)
+#define PINMUX_PB10G_CATB_SENSE30  ((PIN_PB10G_CATB_SENSE30 << 16) | MUX_PB10G_CATB_SENSE30)
+#define GPIO_PB10G_CATB_SENSE30  _UL(1 << 10)
+#define PIN_PB11G_CATB_SENSE31         _L(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
+#define MUX_PB11G_CATB_SENSE31          _L(6)
+#define PINMUX_PB11G_CATB_SENSE31  ((PIN_PB11G_CATB_SENSE31 << 16) | MUX_PB11G_CATB_SENSE31)
+#define GPIO_PB11G_CATB_SENSE31  _UL(1 << 11)
+/* ========== GPIO definition for LCDCA peripheral ========== */
+#define PIN_PA12F_LCDCA_COM0           _L(12) /**< \brief LCDCA signal: COM0 on PA12 mux F */
+#define MUX_PA12F_LCDCA_COM0            _L(5)
+#define PINMUX_PA12F_LCDCA_COM0    ((PIN_PA12F_LCDCA_COM0 << 16) | MUX_PA12F_LCDCA_COM0)
+#define GPIO_PA12F_LCDCA_COM0    _UL(1 << 12)
+#define PIN_PA11F_LCDCA_COM1           _L(11) /**< \brief LCDCA signal: COM1 on PA11 mux F */
+#define MUX_PA11F_LCDCA_COM1            _L(5)
+#define PINMUX_PA11F_LCDCA_COM1    ((PIN_PA11F_LCDCA_COM1 << 16) | MUX_PA11F_LCDCA_COM1)
+#define GPIO_PA11F_LCDCA_COM1    _UL(1 << 11)
+#define PIN_PA10F_LCDCA_COM2           _L(10) /**< \brief LCDCA signal: COM2 on PA10 mux F */
+#define MUX_PA10F_LCDCA_COM2            _L(5)
+#define PINMUX_PA10F_LCDCA_COM2    ((PIN_PA10F_LCDCA_COM2 << 16) | MUX_PA10F_LCDCA_COM2)
+#define GPIO_PA10F_LCDCA_COM2    _UL(1 << 10)
+#define PIN_PA09F_LCDCA_COM3            _L(9) /**< \brief LCDCA signal: COM3 on PA09 mux F */
+#define MUX_PA09F_LCDCA_COM3            _L(5)
+#define PINMUX_PA09F_LCDCA_COM3    ((PIN_PA09F_LCDCA_COM3 << 16) | MUX_PA09F_LCDCA_COM3)
+#define GPIO_PA09F_LCDCA_COM3    _UL(1 <<  9)
+#define PIN_PA13F_LCDCA_SEG5           _L(13) /**< \brief LCDCA signal: SEG5 on PA13 mux F */
+#define MUX_PA13F_LCDCA_SEG5            _L(5)
+#define PINMUX_PA13F_LCDCA_SEG5    ((PIN_PA13F_LCDCA_SEG5 << 16) | MUX_PA13F_LCDCA_SEG5)
+#define GPIO_PA13F_LCDCA_SEG5    _UL(1 << 13)
+#define PIN_PA14F_LCDCA_SEG6           _L(14) /**< \brief LCDCA signal: SEG6 on PA14 mux F */
+#define MUX_PA14F_LCDCA_SEG6            _L(5)
+#define PINMUX_PA14F_LCDCA_SEG6    ((PIN_PA14F_LCDCA_SEG6 << 16) | MUX_PA14F_LCDCA_SEG6)
+#define GPIO_PA14F_LCDCA_SEG6    _UL(1 << 14)
+#define PIN_PA15F_LCDCA_SEG7           _L(15) /**< \brief LCDCA signal: SEG7 on PA15 mux F */
+#define MUX_PA15F_LCDCA_SEG7            _L(5)
+#define PINMUX_PA15F_LCDCA_SEG7    ((PIN_PA15F_LCDCA_SEG7 << 16) | MUX_PA15F_LCDCA_SEG7)
+#define GPIO_PA15F_LCDCA_SEG7    _UL(1 << 15)
+#define PIN_PA16F_LCDCA_SEG8           _L(16) /**< \brief LCDCA signal: SEG8 on PA16 mux F */
+#define MUX_PA16F_LCDCA_SEG8            _L(5)
+#define PINMUX_PA16F_LCDCA_SEG8    ((PIN_PA16F_LCDCA_SEG8 << 16) | MUX_PA16F_LCDCA_SEG8)
+#define GPIO_PA16F_LCDCA_SEG8    _UL(1 << 16)
+#define PIN_PA17F_LCDCA_SEG9           _L(17) /**< \brief LCDCA signal: SEG9 on PA17 mux F */
+#define MUX_PA17F_LCDCA_SEG9            _L(5)
+#define PINMUX_PA17F_LCDCA_SEG9    ((PIN_PA17F_LCDCA_SEG9 << 16) | MUX_PA17F_LCDCA_SEG9)
+#define GPIO_PA17F_LCDCA_SEG9    _UL(1 << 17)
+#define PIN_PB08F_LCDCA_SEG14          _L(40) /**< \brief LCDCA signal: SEG14 on PB08 mux F */
+#define MUX_PB08F_LCDCA_SEG14           _L(5)
+#define PINMUX_PB08F_LCDCA_SEG14   ((PIN_PB08F_LCDCA_SEG14 << 16) | MUX_PB08F_LCDCA_SEG14)
+#define GPIO_PB08F_LCDCA_SEG14   _UL(1 <<  8)
+#define PIN_PB09F_LCDCA_SEG15          _L(41) /**< \brief LCDCA signal: SEG15 on PB09 mux F */
+#define MUX_PB09F_LCDCA_SEG15           _L(5)
+#define PINMUX_PB09F_LCDCA_SEG15   ((PIN_PB09F_LCDCA_SEG15 << 16) | MUX_PB09F_LCDCA_SEG15)
+#define GPIO_PB09F_LCDCA_SEG15   _UL(1 <<  9)
+#define PIN_PB10F_LCDCA_SEG16          _L(42) /**< \brief LCDCA signal: SEG16 on PB10 mux F */
+#define MUX_PB10F_LCDCA_SEG16           _L(5)
+#define PINMUX_PB10F_LCDCA_SEG16   ((PIN_PB10F_LCDCA_SEG16 << 16) | MUX_PB10F_LCDCA_SEG16)
+#define GPIO_PB10F_LCDCA_SEG16   _UL(1 << 10)
+#define PIN_PB11F_LCDCA_SEG17          _L(43) /**< \brief LCDCA signal: SEG17 on PB11 mux F */
+#define MUX_PB11F_LCDCA_SEG17           _L(5)
+#define PINMUX_PB11F_LCDCA_SEG17   ((PIN_PB11F_LCDCA_SEG17 << 16) | MUX_PB11F_LCDCA_SEG17)
+#define GPIO_PB11F_LCDCA_SEG17   _UL(1 << 11)
+#define PIN_PA18F_LCDCA_SEG18          _L(18) /**< \brief LCDCA signal: SEG18 on PA18 mux F */
+#define MUX_PA18F_LCDCA_SEG18           _L(5)
+#define PINMUX_PA18F_LCDCA_SEG18   ((PIN_PA18F_LCDCA_SEG18 << 16) | MUX_PA18F_LCDCA_SEG18)
+#define GPIO_PA18F_LCDCA_SEG18   _UL(1 << 18)
+#define PIN_PA19F_LCDCA_SEG19          _L(19) /**< \brief LCDCA signal: SEG19 on PA19 mux F */
+#define MUX_PA19F_LCDCA_SEG19           _L(5)
+#define PINMUX_PA19F_LCDCA_SEG19   ((PIN_PA19F_LCDCA_SEG19 << 16) | MUX_PA19F_LCDCA_SEG19)
+#define GPIO_PA19F_LCDCA_SEG19   _UL(1 << 19)
+#define PIN_PA20F_LCDCA_SEG20          _L(20) /**< \brief LCDCA signal: SEG20 on PA20 mux F */
+#define MUX_PA20F_LCDCA_SEG20           _L(5)
+#define PINMUX_PA20F_LCDCA_SEG20   ((PIN_PA20F_LCDCA_SEG20 << 16) | MUX_PA20F_LCDCA_SEG20)
+#define GPIO_PA20F_LCDCA_SEG20   _UL(1 << 20)
+#define PIN_PB07F_LCDCA_SEG21          _L(39) /**< \brief LCDCA signal: SEG21 on PB07 mux F */
+#define MUX_PB07F_LCDCA_SEG21           _L(5)
+#define PINMUX_PB07F_LCDCA_SEG21   ((PIN_PB07F_LCDCA_SEG21 << 16) | MUX_PB07F_LCDCA_SEG21)
+#define GPIO_PB07F_LCDCA_SEG21   _UL(1 <<  7)
+#define PIN_PB06F_LCDCA_SEG22          _L(38) /**< \brief LCDCA signal: SEG22 on PB06 mux F */
+#define MUX_PB06F_LCDCA_SEG22           _L(5)
+#define PINMUX_PB06F_LCDCA_SEG22   ((PIN_PB06F_LCDCA_SEG22 << 16) | MUX_PB06F_LCDCA_SEG22)
+#define GPIO_PB06F_LCDCA_SEG22   _UL(1 <<  6)
+#define PIN_PA08F_LCDCA_SEG23           _L(8) /**< \brief LCDCA signal: SEG23 on PA08 mux F */
+#define MUX_PA08F_LCDCA_SEG23           _L(5)
+#define PINMUX_PA08F_LCDCA_SEG23   ((PIN_PA08F_LCDCA_SEG23 << 16) | MUX_PA08F_LCDCA_SEG23)
+#define GPIO_PA08F_LCDCA_SEG23   _UL(1 <<  8)
+#define PIN_PB12F_LCDCA_SEG32          _L(44) /**< \brief LCDCA signal: SEG32 on PB12 mux F */
+#define MUX_PB12F_LCDCA_SEG32           _L(5)
+#define PINMUX_PB12F_LCDCA_SEG32   ((PIN_PB12F_LCDCA_SEG32 << 16) | MUX_PB12F_LCDCA_SEG32)
+#define GPIO_PB12F_LCDCA_SEG32   _UL(1 << 12)
+#define PIN_PB13F_LCDCA_SEG33          _L(45) /**< \brief LCDCA signal: SEG33 on PB13 mux F */
+#define MUX_PB13F_LCDCA_SEG33           _L(5)
+#define PINMUX_PB13F_LCDCA_SEG33   ((PIN_PB13F_LCDCA_SEG33 << 16) | MUX_PB13F_LCDCA_SEG33)
+#define GPIO_PB13F_LCDCA_SEG33   _UL(1 << 13)
+#define PIN_PA21F_LCDCA_SEG34          _L(21) /**< \brief LCDCA signal: SEG34 on PA21 mux F */
+#define MUX_PA21F_LCDCA_SEG34           _L(5)
+#define PINMUX_PA21F_LCDCA_SEG34   ((PIN_PA21F_LCDCA_SEG34 << 16) | MUX_PA21F_LCDCA_SEG34)
+#define GPIO_PA21F_LCDCA_SEG34   _UL(1 << 21)
+#define PIN_PA22F_LCDCA_SEG35          _L(22) /**< \brief LCDCA signal: SEG35 on PA22 mux F */
+#define MUX_PA22F_LCDCA_SEG35           _L(5)
+#define PINMUX_PA22F_LCDCA_SEG35   ((PIN_PA22F_LCDCA_SEG35 << 16) | MUX_PA22F_LCDCA_SEG35)
+#define GPIO_PA22F_LCDCA_SEG35   _UL(1 << 22)
+#define PIN_PB14F_LCDCA_SEG36          _L(46) /**< \brief LCDCA signal: SEG36 on PB14 mux F */
+#define MUX_PB14F_LCDCA_SEG36           _L(5)
+#define PINMUX_PB14F_LCDCA_SEG36   ((PIN_PB14F_LCDCA_SEG36 << 16) | MUX_PB14F_LCDCA_SEG36)
+#define GPIO_PB14F_LCDCA_SEG36   _UL(1 << 14)
+#define PIN_PB15F_LCDCA_SEG37          _L(47) /**< \brief LCDCA signal: SEG37 on PB15 mux F */
+#define MUX_PB15F_LCDCA_SEG37           _L(5)
+#define PINMUX_PB15F_LCDCA_SEG37   ((PIN_PB15F_LCDCA_SEG37 << 16) | MUX_PB15F_LCDCA_SEG37)
+#define GPIO_PB15F_LCDCA_SEG37   _UL(1 << 15)
+#define PIN_PA23F_LCDCA_SEG38          _L(23) /**< \brief LCDCA signal: SEG38 on PA23 mux F */
+#define MUX_PA23F_LCDCA_SEG38           _L(5)
+#define PINMUX_PA23F_LCDCA_SEG38   ((PIN_PA23F_LCDCA_SEG38 << 16) | MUX_PA23F_LCDCA_SEG38)
+#define GPIO_PA23F_LCDCA_SEG38   _UL(1 << 23)
+#define PIN_PA24F_LCDCA_SEG39          _L(24) /**< \brief LCDCA signal: SEG39 on PA24 mux F */
+#define MUX_PA24F_LCDCA_SEG39           _L(5)
+#define PINMUX_PA24F_LCDCA_SEG39   ((PIN_PA24F_LCDCA_SEG39 << 16) | MUX_PA24F_LCDCA_SEG39)
+#define GPIO_PA24F_LCDCA_SEG39   _UL(1 << 24)
+/* ========== GPIO definition for USBC peripheral ========== */
+#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L(0)
+#define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
+#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
+#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L(0)
+#define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
+#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+/* ========== GPIO definition for PEVC peripheral ========== */
+#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
+#define PIN_PB12C_PEVC_PAD_EVT0        _L(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
+#define MUX_PB12C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PB12C_PEVC_PAD_EVT0  ((PIN_PB12C_PEVC_PAD_EVT0 << 16) | MUX_PB12C_PEVC_PAD_EVT0)
+#define GPIO_PB12C_PEVC_PAD_EVT0  _UL(1 << 12)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
+#define PIN_PB13C_PEVC_PAD_EVT1        _L(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
+#define MUX_PB13C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PB13C_PEVC_PAD_EVT1  ((PIN_PB13C_PEVC_PAD_EVT1 << 16) | MUX_PB13C_PEVC_PAD_EVT1)
+#define GPIO_PB13C_PEVC_PAD_EVT1  _UL(1 << 13)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
+#define PIN_PB09B_PEVC_PAD_EVT2        _L(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
+#define MUX_PB09B_PEVC_PAD_EVT2         _L(1)
+#define PINMUX_PB09B_PEVC_PAD_EVT2  ((PIN_PB09B_PEVC_PAD_EVT2 << 16) | MUX_PB09B_PEVC_PAD_EVT2)
+#define GPIO_PB09B_PEVC_PAD_EVT2  _UL(1 <<  9)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
+#define PIN_PB10B_PEVC_PAD_EVT3        _L(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
+#define MUX_PB10B_PEVC_PAD_EVT3         _L(1)
+#define PINMUX_PB10B_PEVC_PAD_EVT3  ((PIN_PB10B_PEVC_PAD_EVT3 << 16) | MUX_PB10B_PEVC_PAD_EVT3)
+#define GPIO_PB10B_PEVC_PAD_EVT3  _UL(1 << 10)
+/* ========== GPIO definition for SCIF peripheral ========== */
+#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
+#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
+#define PIN_PB10E_SCIF_GCLK0           _L(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
+#define MUX_PB10E_SCIF_GCLK0            _L(4)
+#define PINMUX_PB10E_SCIF_GCLK0    ((PIN_PB10E_SCIF_GCLK0 << 16) | MUX_PB10E_SCIF_GCLK0)
+#define GPIO_PB10E_SCIF_GCLK0    _UL(1 << 10)
+#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
+#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
+#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
+#define PIN_PB11E_SCIF_GCLK1           _L(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
+#define MUX_PB11E_SCIF_GCLK1            _L(4)
+#define PINMUX_PB11E_SCIF_GCLK1    ((PIN_PB11E_SCIF_GCLK1 << 16) | MUX_PB11E_SCIF_GCLK1)
+#define GPIO_PB11E_SCIF_GCLK1    _UL(1 << 11)
+#define PIN_PB12E_SCIF_GCLK2           _L(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
+#define MUX_PB12E_SCIF_GCLK2            _L(4)
+#define PINMUX_PB12E_SCIF_GCLK2    ((PIN_PB12E_SCIF_GCLK2 << 16) | MUX_PB12E_SCIF_GCLK2)
+#define GPIO_PB12E_SCIF_GCLK2    _UL(1 << 12)
+#define PIN_PB13E_SCIF_GCLK3           _L(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
+#define MUX_PB13E_SCIF_GCLK3            _L(4)
+#define PINMUX_PB13E_SCIF_GCLK3    ((PIN_PB13E_SCIF_GCLK3 << 16) | MUX_PB13E_SCIF_GCLK3)
+#define GPIO_PB13E_SCIF_GCLK3    _UL(1 << 13)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
+#define PIN_PB14E_SCIF_GCLK_IN0        _L(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
+#define MUX_PB14E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PB14E_SCIF_GCLK_IN0  ((PIN_PB14E_SCIF_GCLK_IN0 << 16) | MUX_PB14E_SCIF_GCLK_IN0)
+#define GPIO_PB14E_SCIF_GCLK_IN0  _UL(1 << 14)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
+#define PIN_PB15E_SCIF_GCLK_IN1        _L(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
+#define MUX_PB15E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PB15E_SCIF_GCLK_IN1  ((PIN_PB15E_SCIF_GCLK_IN1 << 16) | MUX_PB15E_SCIF_GCLK_IN1)
+#define GPIO_PB15E_SCIF_GCLK_IN1  _UL(1 << 15)
+/* ========== GPIO definition for EIC peripheral ========== */
+#define PIN_PB01C_EIC_EXTINT0          _L(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
+#define MUX_PB01C_EIC_EXTINT0           _L(2)
+#define PINMUX_PB01C_EIC_EXTINT0   ((PIN_PB01C_EIC_EXTINT0 << 16) | MUX_PB01C_EIC_EXTINT0)
+#define GPIO_PB01C_EIC_EXTINT0   _UL(1 <<  1)
+#define PIN_PB01C_EIC_EXTINT_NUM        _L(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
+#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
+#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
+#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
+#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
+#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
+#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
+#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
+#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
+#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
+#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+
+#endif /* _SAM4LC8B_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4lc8b.h
+++ b/asf/sam/include/sam4l/pio/sam4lc8b.h
@@ -30,1050 +30,1050 @@
 #define _SAM4LC8B_PIO_
 
 #define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
-#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define GPIO_PA00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PA00 */
 #define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
-#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define GPIO_PA01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PA01 */
 #define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
-#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define GPIO_PA02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PA02 */
 #define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
-#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define GPIO_PA03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PA03 */
 #define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
-#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define GPIO_PA04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PA04 */
 #define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
-#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define GPIO_PA05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PA05 */
 #define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
-#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define GPIO_PA06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PA06 */
 #define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
-#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define GPIO_PA07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PA07 */
 #define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
-#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define GPIO_PA08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PA08 */
 #define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
-#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define GPIO_PA09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PA09 */
 #define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
-#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define GPIO_PA10                _UL_(1 << 10) /**< \brief GPIO Mask  for PA10 */
 #define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
-#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define GPIO_PA11                _UL_(1 << 11) /**< \brief GPIO Mask  for PA11 */
 #define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
-#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define GPIO_PA12                _UL_(1 << 12) /**< \brief GPIO Mask  for PA12 */
 #define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
-#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define GPIO_PA13                _UL_(1 << 13) /**< \brief GPIO Mask  for PA13 */
 #define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
-#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define GPIO_PA14                _UL_(1 << 14) /**< \brief GPIO Mask  for PA14 */
 #define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
-#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define GPIO_PA15                _UL_(1 << 15) /**< \brief GPIO Mask  for PA15 */
 #define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
-#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define GPIO_PA16                _UL_(1 << 16) /**< \brief GPIO Mask  for PA16 */
 #define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
-#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define GPIO_PA17                _UL_(1 << 17) /**< \brief GPIO Mask  for PA17 */
 #define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
-#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define GPIO_PA18                _UL_(1 << 18) /**< \brief GPIO Mask  for PA18 */
 #define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
-#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define GPIO_PA19                _UL_(1 << 19) /**< \brief GPIO Mask  for PA19 */
 #define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
-#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define GPIO_PA20                _UL_(1 << 20) /**< \brief GPIO Mask  for PA20 */
 #define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
-#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define GPIO_PA21                _UL_(1 << 21) /**< \brief GPIO Mask  for PA21 */
 #define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
-#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define GPIO_PA22                _UL_(1 << 22) /**< \brief GPIO Mask  for PA22 */
 #define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
-#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define GPIO_PA23                _UL_(1 << 23) /**< \brief GPIO Mask  for PA23 */
 #define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
-#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define GPIO_PA24                _UL_(1 << 24) /**< \brief GPIO Mask  for PA24 */
 #define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
-#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define GPIO_PA25                _UL_(1 << 25) /**< \brief GPIO Mask  for PA25 */
 #define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
-#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define GPIO_PA26                _UL_(1 << 26) /**< \brief GPIO Mask  for PA26 */
 #define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
-#define GPIO_PB00                _UL(1 <<  0) /**< \brief GPIO Mask  for PB00 */
+#define GPIO_PB00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PB00 */
 #define PIN_PB01                          33  /**< \brief Pin Number for PB01 */
-#define GPIO_PB01                _UL(1 <<  1) /**< \brief GPIO Mask  for PB01 */
+#define GPIO_PB01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PB01 */
 #define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
-#define GPIO_PB02                _UL(1 <<  2) /**< \brief GPIO Mask  for PB02 */
+#define GPIO_PB02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PB02 */
 #define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
-#define GPIO_PB03                _UL(1 <<  3) /**< \brief GPIO Mask  for PB03 */
+#define GPIO_PB03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PB03 */
 #define PIN_PB04                          36  /**< \brief Pin Number for PB04 */
-#define GPIO_PB04                _UL(1 <<  4) /**< \brief GPIO Mask  for PB04 */
+#define GPIO_PB04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PB04 */
 #define PIN_PB05                          37  /**< \brief Pin Number for PB05 */
-#define GPIO_PB05                _UL(1 <<  5) /**< \brief GPIO Mask  for PB05 */
+#define GPIO_PB05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PB05 */
 #define PIN_PB06                          38  /**< \brief Pin Number for PB06 */
-#define GPIO_PB06                _UL(1 <<  6) /**< \brief GPIO Mask  for PB06 */
+#define GPIO_PB06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PB06 */
 #define PIN_PB07                          39  /**< \brief Pin Number for PB07 */
-#define GPIO_PB07                _UL(1 <<  7) /**< \brief GPIO Mask  for PB07 */
+#define GPIO_PB07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PB07 */
 #define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
-#define GPIO_PB08                _UL(1 <<  8) /**< \brief GPIO Mask  for PB08 */
+#define GPIO_PB08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PB08 */
 #define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
-#define GPIO_PB09                _UL(1 <<  9) /**< \brief GPIO Mask  for PB09 */
+#define GPIO_PB09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PB09 */
 #define PIN_PB10                          42  /**< \brief Pin Number for PB10 */
-#define GPIO_PB10                _UL(1 << 10) /**< \brief GPIO Mask  for PB10 */
+#define GPIO_PB10                _UL_(1 << 10) /**< \brief GPIO Mask  for PB10 */
 #define PIN_PB11                          43  /**< \brief Pin Number for PB11 */
-#define GPIO_PB11                _UL(1 << 11) /**< \brief GPIO Mask  for PB11 */
+#define GPIO_PB11                _UL_(1 << 11) /**< \brief GPIO Mask  for PB11 */
 #define PIN_PB12                          44  /**< \brief Pin Number for PB12 */
-#define GPIO_PB12                _UL(1 << 12) /**< \brief GPIO Mask  for PB12 */
+#define GPIO_PB12                _UL_(1 << 12) /**< \brief GPIO Mask  for PB12 */
 #define PIN_PB13                          45  /**< \brief Pin Number for PB13 */
-#define GPIO_PB13                _UL(1 << 13) /**< \brief GPIO Mask  for PB13 */
+#define GPIO_PB13                _UL_(1 << 13) /**< \brief GPIO Mask  for PB13 */
 #define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
-#define GPIO_PB14                _UL(1 << 14) /**< \brief GPIO Mask  for PB14 */
+#define GPIO_PB14                _UL_(1 << 14) /**< \brief GPIO Mask  for PB14 */
 #define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
-#define GPIO_PB15                _UL(1 << 15) /**< \brief GPIO Mask  for PB15 */
+#define GPIO_PB15                _UL_(1 << 15) /**< \brief GPIO Mask  for PB15 */
 /* ========== GPIO definition for TWIMS0 peripheral ========== */
-#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
-#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PIN_PA24B_TWIMS0_TWCK          _L_(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L_(1)
 #define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
-#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
-#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
-#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL_(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L_(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L_(1)
 #define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
-#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+#define GPIO_PA23B_TWIMS0_TWD    _UL_(1 << 23)
 /* ========== GPIO definition for TWIMS1 peripheral ========== */
-#define PIN_PB01A_TWIMS1_TWCK          _L(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
-#define MUX_PB01A_TWIMS1_TWCK           _L(0)
+#define PIN_PB01A_TWIMS1_TWCK          _L_(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
+#define MUX_PB01A_TWIMS1_TWCK           _L_(0)
 #define PINMUX_PB01A_TWIMS1_TWCK   ((PIN_PB01A_TWIMS1_TWCK << 16) | MUX_PB01A_TWIMS1_TWCK)
-#define GPIO_PB01A_TWIMS1_TWCK   _UL(1 <<  1)
-#define PIN_PB00A_TWIMS1_TWD           _L(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
-#define MUX_PB00A_TWIMS1_TWD            _L(0)
+#define GPIO_PB01A_TWIMS1_TWCK   _UL_(1 <<  1)
+#define PIN_PB00A_TWIMS1_TWD           _L_(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
+#define MUX_PB00A_TWIMS1_TWD            _L_(0)
 #define PINMUX_PB00A_TWIMS1_TWD    ((PIN_PB00A_TWIMS1_TWD << 16) | MUX_PB00A_TWIMS1_TWD)
-#define GPIO_PB00A_TWIMS1_TWD    _UL(1 <<  0)
+#define GPIO_PB00A_TWIMS1_TWD    _UL_(1 <<  0)
 /* ========== GPIO definition for TWIMS2 peripheral ========== */
-#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
-#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PIN_PA22E_TWIMS2_TWCK          _L_(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L_(4)
 #define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
-#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
-#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
-#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL_(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L_(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L_(4)
 #define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
-#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+#define GPIO_PA21E_TWIMS2_TWD    _UL_(1 << 21)
 /* ========== GPIO definition for TWIMS3 peripheral ========== */
-#define PIN_PB15C_TWIMS3_TWCK          _L(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
-#define MUX_PB15C_TWIMS3_TWCK           _L(2)
+#define PIN_PB15C_TWIMS3_TWCK          _L_(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
+#define MUX_PB15C_TWIMS3_TWCK           _L_(2)
 #define PINMUX_PB15C_TWIMS3_TWCK   ((PIN_PB15C_TWIMS3_TWCK << 16) | MUX_PB15C_TWIMS3_TWCK)
-#define GPIO_PB15C_TWIMS3_TWCK   _UL(1 << 15)
-#define PIN_PB14C_TWIMS3_TWD           _L(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
-#define MUX_PB14C_TWIMS3_TWD            _L(2)
+#define GPIO_PB15C_TWIMS3_TWCK   _UL_(1 << 15)
+#define PIN_PB14C_TWIMS3_TWD           _L_(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
+#define MUX_PB14C_TWIMS3_TWD            _L_(2)
 #define PINMUX_PB14C_TWIMS3_TWD    ((PIN_PB14C_TWIMS3_TWD << 16) | MUX_PB14C_TWIMS3_TWD)
-#define GPIO_PB14C_TWIMS3_TWD    _UL(1 << 14)
+#define GPIO_PB14C_TWIMS3_TWD    _UL_(1 << 14)
 /* ========== GPIO definition for IISC peripheral ========== */
-#define PIN_PB05D_IISC_IMCK            _L(37) /**< \brief IISC signal: IMCK on PB05 mux D */
-#define MUX_PB05D_IISC_IMCK             _L(3)
+#define PIN_PB05D_IISC_IMCK            _L_(37) /**< \brief IISC signal: IMCK on PB05 mux D */
+#define MUX_PB05D_IISC_IMCK             _L_(3)
 #define PINMUX_PB05D_IISC_IMCK     ((PIN_PB05D_IISC_IMCK << 16) | MUX_PB05D_IISC_IMCK)
-#define GPIO_PB05D_IISC_IMCK     _UL(1 <<  5)
-#define PIN_PB02D_IISC_ISCK            _L(34) /**< \brief IISC signal: ISCK on PB02 mux D */
-#define MUX_PB02D_IISC_ISCK             _L(3)
+#define GPIO_PB05D_IISC_IMCK     _UL_(1 <<  5)
+#define PIN_PB02D_IISC_ISCK            _L_(34) /**< \brief IISC signal: ISCK on PB02 mux D */
+#define MUX_PB02D_IISC_ISCK             _L_(3)
 #define PINMUX_PB02D_IISC_ISCK     ((PIN_PB02D_IISC_ISCK << 16) | MUX_PB02D_IISC_ISCK)
-#define GPIO_PB02D_IISC_ISCK     _UL(1 <<  2)
-#define PIN_PB03D_IISC_ISDI            _L(35) /**< \brief IISC signal: ISDI on PB03 mux D */
-#define MUX_PB03D_IISC_ISDI             _L(3)
+#define GPIO_PB02D_IISC_ISCK     _UL_(1 <<  2)
+#define PIN_PB03D_IISC_ISDI            _L_(35) /**< \brief IISC signal: ISDI on PB03 mux D */
+#define MUX_PB03D_IISC_ISDI             _L_(3)
 #define PINMUX_PB03D_IISC_ISDI     ((PIN_PB03D_IISC_ISDI << 16) | MUX_PB03D_IISC_ISDI)
-#define GPIO_PB03D_IISC_ISDI     _UL(1 <<  3)
-#define PIN_PB04D_IISC_ISDO            _L(36) /**< \brief IISC signal: ISDO on PB04 mux D */
-#define MUX_PB04D_IISC_ISDO             _L(3)
+#define GPIO_PB03D_IISC_ISDI     _UL_(1 <<  3)
+#define PIN_PB04D_IISC_ISDO            _L_(36) /**< \brief IISC signal: ISDO on PB04 mux D */
+#define MUX_PB04D_IISC_ISDO             _L_(3)
 #define PINMUX_PB04D_IISC_ISDO     ((PIN_PB04D_IISC_ISDO << 16) | MUX_PB04D_IISC_ISDO)
-#define GPIO_PB04D_IISC_ISDO     _UL(1 <<  4)
-#define PIN_PB06D_IISC_IWS             _L(38) /**< \brief IISC signal: IWS on PB06 mux D */
-#define MUX_PB06D_IISC_IWS              _L(3)
+#define GPIO_PB04D_IISC_ISDO     _UL_(1 <<  4)
+#define PIN_PB06D_IISC_IWS             _L_(38) /**< \brief IISC signal: IWS on PB06 mux D */
+#define MUX_PB06D_IISC_IWS              _L_(3)
 #define PINMUX_PB06D_IISC_IWS      ((PIN_PB06D_IISC_IWS << 16) | MUX_PB06D_IISC_IWS)
-#define GPIO_PB06D_IISC_IWS      _UL(1 <<  6)
+#define GPIO_PB06D_IISC_IWS      _UL_(1 <<  6)
 /* ========== GPIO definition for SPI peripheral ========== */
-#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
-#define MUX_PA03B_SPI_MISO              _L(1)
+#define PIN_PA03B_SPI_MISO              _L_(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L_(1)
 #define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
-#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
-#define PIN_PB14B_SPI_MISO             _L(46) /**< \brief SPI signal: MISO on PB14 mux B */
-#define MUX_PB14B_SPI_MISO              _L(1)
+#define GPIO_PA03B_SPI_MISO      _UL_(1 <<  3)
+#define PIN_PB14B_SPI_MISO             _L_(46) /**< \brief SPI signal: MISO on PB14 mux B */
+#define MUX_PB14B_SPI_MISO              _L_(1)
 #define PINMUX_PB14B_SPI_MISO      ((PIN_PB14B_SPI_MISO << 16) | MUX_PB14B_SPI_MISO)
-#define GPIO_PB14B_SPI_MISO      _UL(1 << 14)
-#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
-#define MUX_PA21A_SPI_MISO              _L(0)
+#define GPIO_PB14B_SPI_MISO      _UL_(1 << 14)
+#define PIN_PA21A_SPI_MISO             _L_(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L_(0)
 #define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
-#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
-#define PIN_PB15B_SPI_MOSI             _L(47) /**< \brief SPI signal: MOSI on PB15 mux B */
-#define MUX_PB15B_SPI_MOSI              _L(1)
+#define GPIO_PA21A_SPI_MISO      _UL_(1 << 21)
+#define PIN_PB15B_SPI_MOSI             _L_(47) /**< \brief SPI signal: MOSI on PB15 mux B */
+#define MUX_PB15B_SPI_MOSI              _L_(1)
 #define PINMUX_PB15B_SPI_MOSI      ((PIN_PB15B_SPI_MOSI << 16) | MUX_PB15B_SPI_MOSI)
-#define GPIO_PB15B_SPI_MOSI      _UL(1 << 15)
-#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
-#define MUX_PA22A_SPI_MOSI              _L(0)
+#define GPIO_PB15B_SPI_MOSI      _UL_(1 << 15)
+#define PIN_PA22A_SPI_MOSI             _L_(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L_(0)
 #define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
-#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
-#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
-#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define GPIO_PA22A_SPI_MOSI      _UL_(1 << 22)
+#define PIN_PA02B_SPI_NPCS0             _L_(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L_(1)
 #define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
-#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
-#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
-#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define GPIO_PA02B_SPI_NPCS0     _UL_(1 <<  2)
+#define PIN_PA24A_SPI_NPCS0            _L_(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L_(0)
 #define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
-#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
-#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
-#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define GPIO_PA24A_SPI_NPCS0     _UL_(1 << 24)
+#define PIN_PA13C_SPI_NPCS1            _L_(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L_(2)
 #define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
-#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PB13B_SPI_NPCS1            _L(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
-#define MUX_PB13B_SPI_NPCS1             _L(1)
+#define GPIO_PA13C_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PB13B_SPI_NPCS1            _L_(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
+#define MUX_PB13B_SPI_NPCS1             _L_(1)
 #define PINMUX_PB13B_SPI_NPCS1     ((PIN_PB13B_SPI_NPCS1 << 16) | MUX_PB13B_SPI_NPCS1)
-#define GPIO_PB13B_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
-#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define GPIO_PB13B_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PA14C_SPI_NPCS2            _L_(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L_(2)
 #define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
-#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
-#define PIN_PB11B_SPI_NPCS2            _L(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
-#define MUX_PB11B_SPI_NPCS2             _L(1)
+#define GPIO_PA14C_SPI_NPCS2     _UL_(1 << 14)
+#define PIN_PB11B_SPI_NPCS2            _L_(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
+#define MUX_PB11B_SPI_NPCS2             _L_(1)
 #define PINMUX_PB11B_SPI_NPCS2     ((PIN_PB11B_SPI_NPCS2 << 16) | MUX_PB11B_SPI_NPCS2)
-#define GPIO_PB11B_SPI_NPCS2     _UL(1 << 11)
-#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
-#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define GPIO_PB11B_SPI_NPCS2     _UL_(1 << 11)
+#define PIN_PA15C_SPI_NPCS3            _L_(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L_(2)
 #define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
-#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
-#define PIN_PB12B_SPI_NPCS3            _L(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
-#define MUX_PB12B_SPI_NPCS3             _L(1)
+#define GPIO_PA15C_SPI_NPCS3     _UL_(1 << 15)
+#define PIN_PB12B_SPI_NPCS3            _L_(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
+#define MUX_PB12B_SPI_NPCS3             _L_(1)
 #define PINMUX_PB12B_SPI_NPCS3     ((PIN_PB12B_SPI_NPCS3 << 16) | MUX_PB12B_SPI_NPCS3)
-#define GPIO_PB12B_SPI_NPCS3     _UL(1 << 12)
-#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
-#define MUX_PA23A_SPI_SCK               _L(0)
+#define GPIO_PB12B_SPI_NPCS3     _UL_(1 << 12)
+#define PIN_PA23A_SPI_SCK              _L_(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L_(0)
 #define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
-#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
+#define GPIO_PA23A_SPI_SCK       _UL_(1 << 23)
 /* ========== GPIO definition for TC0 peripheral ========== */
-#define PIN_PB07D_TC0_A0               _L(39) /**< \brief TC0 signal: A0 on PB07 mux D */
-#define MUX_PB07D_TC0_A0                _L(3)
+#define PIN_PB07D_TC0_A0               _L_(39) /**< \brief TC0 signal: A0 on PB07 mux D */
+#define MUX_PB07D_TC0_A0                _L_(3)
 #define PINMUX_PB07D_TC0_A0        ((PIN_PB07D_TC0_A0 << 16) | MUX_PB07D_TC0_A0)
-#define GPIO_PB07D_TC0_A0        _UL(1 <<  7)
-#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
-#define MUX_PA08B_TC0_A0                _L(1)
+#define GPIO_PB07D_TC0_A0        _UL_(1 <<  7)
+#define PIN_PA08B_TC0_A0                _L_(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L_(1)
 #define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
-#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
-#define PIN_PB09D_TC0_A1               _L(41) /**< \brief TC0 signal: A1 on PB09 mux D */
-#define MUX_PB09D_TC0_A1                _L(3)
+#define GPIO_PA08B_TC0_A0        _UL_(1 <<  8)
+#define PIN_PB09D_TC0_A1               _L_(41) /**< \brief TC0 signal: A1 on PB09 mux D */
+#define MUX_PB09D_TC0_A1                _L_(3)
 #define PINMUX_PB09D_TC0_A1        ((PIN_PB09D_TC0_A1 << 16) | MUX_PB09D_TC0_A1)
-#define GPIO_PB09D_TC0_A1        _UL(1 <<  9)
-#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
-#define MUX_PA10B_TC0_A1                _L(1)
+#define GPIO_PB09D_TC0_A1        _UL_(1 <<  9)
+#define PIN_PA10B_TC0_A1               _L_(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L_(1)
 #define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
-#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
-#define PIN_PB11D_TC0_A2               _L(43) /**< \brief TC0 signal: A2 on PB11 mux D */
-#define MUX_PB11D_TC0_A2                _L(3)
+#define GPIO_PA10B_TC0_A1        _UL_(1 << 10)
+#define PIN_PB11D_TC0_A2               _L_(43) /**< \brief TC0 signal: A2 on PB11 mux D */
+#define MUX_PB11D_TC0_A2                _L_(3)
 #define PINMUX_PB11D_TC0_A2        ((PIN_PB11D_TC0_A2 << 16) | MUX_PB11D_TC0_A2)
-#define GPIO_PB11D_TC0_A2        _UL(1 << 11)
-#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
-#define MUX_PA12B_TC0_A2                _L(1)
+#define GPIO_PB11D_TC0_A2        _UL_(1 << 11)
+#define PIN_PA12B_TC0_A2               _L_(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L_(1)
 #define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
-#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
-#define PIN_PB08D_TC0_B0               _L(40) /**< \brief TC0 signal: B0 on PB08 mux D */
-#define MUX_PB08D_TC0_B0                _L(3)
+#define GPIO_PA12B_TC0_A2        _UL_(1 << 12)
+#define PIN_PB08D_TC0_B0               _L_(40) /**< \brief TC0 signal: B0 on PB08 mux D */
+#define MUX_PB08D_TC0_B0                _L_(3)
 #define PINMUX_PB08D_TC0_B0        ((PIN_PB08D_TC0_B0 << 16) | MUX_PB08D_TC0_B0)
-#define GPIO_PB08D_TC0_B0        _UL(1 <<  8)
-#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
-#define MUX_PA09B_TC0_B0                _L(1)
+#define GPIO_PB08D_TC0_B0        _UL_(1 <<  8)
+#define PIN_PA09B_TC0_B0                _L_(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L_(1)
 #define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
-#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
-#define PIN_PB10D_TC0_B1               _L(42) /**< \brief TC0 signal: B1 on PB10 mux D */
-#define MUX_PB10D_TC0_B1                _L(3)
+#define GPIO_PA09B_TC0_B0        _UL_(1 <<  9)
+#define PIN_PB10D_TC0_B1               _L_(42) /**< \brief TC0 signal: B1 on PB10 mux D */
+#define MUX_PB10D_TC0_B1                _L_(3)
 #define PINMUX_PB10D_TC0_B1        ((PIN_PB10D_TC0_B1 << 16) | MUX_PB10D_TC0_B1)
-#define GPIO_PB10D_TC0_B1        _UL(1 << 10)
-#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
-#define MUX_PA11B_TC0_B1                _L(1)
+#define GPIO_PB10D_TC0_B1        _UL_(1 << 10)
+#define PIN_PA11B_TC0_B1               _L_(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L_(1)
 #define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
-#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
-#define PIN_PB12D_TC0_B2               _L(44) /**< \brief TC0 signal: B2 on PB12 mux D */
-#define MUX_PB12D_TC0_B2                _L(3)
+#define GPIO_PA11B_TC0_B1        _UL_(1 << 11)
+#define PIN_PB12D_TC0_B2               _L_(44) /**< \brief TC0 signal: B2 on PB12 mux D */
+#define MUX_PB12D_TC0_B2                _L_(3)
 #define PINMUX_PB12D_TC0_B2        ((PIN_PB12D_TC0_B2 << 16) | MUX_PB12D_TC0_B2)
-#define GPIO_PB12D_TC0_B2        _UL(1 << 12)
-#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
-#define MUX_PA13B_TC0_B2                _L(1)
+#define GPIO_PB12D_TC0_B2        _UL_(1 << 12)
+#define PIN_PA13B_TC0_B2               _L_(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L_(1)
 #define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
-#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
-#define PIN_PB13D_TC0_CLK0             _L(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
-#define MUX_PB13D_TC0_CLK0              _L(3)
+#define GPIO_PA13B_TC0_B2        _UL_(1 << 13)
+#define PIN_PB13D_TC0_CLK0             _L_(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
+#define MUX_PB13D_TC0_CLK0              _L_(3)
 #define PINMUX_PB13D_TC0_CLK0      ((PIN_PB13D_TC0_CLK0 << 16) | MUX_PB13D_TC0_CLK0)
-#define GPIO_PB13D_TC0_CLK0      _UL(1 << 13)
-#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
-#define MUX_PA14B_TC0_CLK0              _L(1)
+#define GPIO_PB13D_TC0_CLK0      _UL_(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L_(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L_(1)
 #define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
-#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
-#define PIN_PB14D_TC0_CLK1             _L(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
-#define MUX_PB14D_TC0_CLK1              _L(3)
+#define GPIO_PA14B_TC0_CLK0      _UL_(1 << 14)
+#define PIN_PB14D_TC0_CLK1             _L_(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
+#define MUX_PB14D_TC0_CLK1              _L_(3)
 #define PINMUX_PB14D_TC0_CLK1      ((PIN_PB14D_TC0_CLK1 << 16) | MUX_PB14D_TC0_CLK1)
-#define GPIO_PB14D_TC0_CLK1      _UL(1 << 14)
-#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
-#define MUX_PA15B_TC0_CLK1              _L(1)
+#define GPIO_PB14D_TC0_CLK1      _UL_(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L_(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L_(1)
 #define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
-#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
-#define PIN_PB15D_TC0_CLK2             _L(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
-#define MUX_PB15D_TC0_CLK2              _L(3)
+#define GPIO_PA15B_TC0_CLK1      _UL_(1 << 15)
+#define PIN_PB15D_TC0_CLK2             _L_(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
+#define MUX_PB15D_TC0_CLK2              _L_(3)
 #define PINMUX_PB15D_TC0_CLK2      ((PIN_PB15D_TC0_CLK2 << 16) | MUX_PB15D_TC0_CLK2)
-#define GPIO_PB15D_TC0_CLK2      _UL(1 << 15)
-#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
-#define MUX_PA16B_TC0_CLK2              _L(1)
+#define GPIO_PB15D_TC0_CLK2      _UL_(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L_(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L_(1)
 #define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
-#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+#define GPIO_PA16B_TC0_CLK2      _UL_(1 << 16)
 /* ========== GPIO definition for USART0 peripheral ========== */
-#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
-#define MUX_PA04B_USART0_CLK            _L(1)
+#define PIN_PA04B_USART0_CLK            _L_(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L_(1)
 #define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
-#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
-#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
-#define MUX_PA10A_USART0_CLK            _L(0)
+#define GPIO_PA04B_USART0_CLK    _UL_(1 <<  4)
+#define PIN_PA10A_USART0_CLK           _L_(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L_(0)
 #define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
-#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
-#define PIN_PB13A_USART0_CLK           _L(45) /**< \brief USART0 signal: CLK on PB13 mux A */
-#define MUX_PB13A_USART0_CLK            _L(0)
+#define GPIO_PA10A_USART0_CLK    _UL_(1 << 10)
+#define PIN_PB13A_USART0_CLK           _L_(45) /**< \brief USART0 signal: CLK on PB13 mux A */
+#define MUX_PB13A_USART0_CLK            _L_(0)
 #define PINMUX_PB13A_USART0_CLK    ((PIN_PB13A_USART0_CLK << 16) | MUX_PB13A_USART0_CLK)
-#define GPIO_PB13A_USART0_CLK    _UL(1 << 13)
-#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
-#define MUX_PA09A_USART0_CTS            _L(0)
+#define GPIO_PB13A_USART0_CLK    _UL_(1 << 13)
+#define PIN_PA09A_USART0_CTS            _L_(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L_(0)
 #define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
-#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
-#define PIN_PB11A_USART0_CTS           _L(43) /**< \brief USART0 signal: CTS on PB11 mux A */
-#define MUX_PB11A_USART0_CTS            _L(0)
+#define GPIO_PA09A_USART0_CTS    _UL_(1 <<  9)
+#define PIN_PB11A_USART0_CTS           _L_(43) /**< \brief USART0 signal: CTS on PB11 mux A */
+#define MUX_PB11A_USART0_CTS            _L_(0)
 #define PINMUX_PB11A_USART0_CTS    ((PIN_PB11A_USART0_CTS << 16) | MUX_PB11A_USART0_CTS)
-#define GPIO_PB11A_USART0_CTS    _UL(1 << 11)
-#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
-#define MUX_PA06B_USART0_RTS            _L(1)
+#define GPIO_PB11A_USART0_CTS    _UL_(1 << 11)
+#define PIN_PA06B_USART0_RTS            _L_(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L_(1)
 #define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
-#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
-#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
-#define MUX_PA08A_USART0_RTS            _L(0)
+#define GPIO_PA06B_USART0_RTS    _UL_(1 <<  6)
+#define PIN_PA08A_USART0_RTS            _L_(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L_(0)
 #define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
-#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
-#define PIN_PB12A_USART0_RTS           _L(44) /**< \brief USART0 signal: RTS on PB12 mux A */
-#define MUX_PB12A_USART0_RTS            _L(0)
+#define GPIO_PA08A_USART0_RTS    _UL_(1 <<  8)
+#define PIN_PB12A_USART0_RTS           _L_(44) /**< \brief USART0 signal: RTS on PB12 mux A */
+#define MUX_PB12A_USART0_RTS            _L_(0)
 #define PINMUX_PB12A_USART0_RTS    ((PIN_PB12A_USART0_RTS << 16) | MUX_PB12A_USART0_RTS)
-#define GPIO_PB12A_USART0_RTS    _UL(1 << 12)
-#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
-#define MUX_PA05B_USART0_RXD            _L(1)
+#define GPIO_PB12A_USART0_RTS    _UL_(1 << 12)
+#define PIN_PA05B_USART0_RXD            _L_(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L_(1)
 #define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
-#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
-#define PIN_PB00B_USART0_RXD           _L(32) /**< \brief USART0 signal: RXD on PB00 mux B */
-#define MUX_PB00B_USART0_RXD            _L(1)
+#define GPIO_PA05B_USART0_RXD    _UL_(1 <<  5)
+#define PIN_PB00B_USART0_RXD           _L_(32) /**< \brief USART0 signal: RXD on PB00 mux B */
+#define MUX_PB00B_USART0_RXD            _L_(1)
 #define PINMUX_PB00B_USART0_RXD    ((PIN_PB00B_USART0_RXD << 16) | MUX_PB00B_USART0_RXD)
-#define GPIO_PB00B_USART0_RXD    _UL(1 <<  0)
-#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
-#define MUX_PA11A_USART0_RXD            _L(0)
+#define GPIO_PB00B_USART0_RXD    _UL_(1 <<  0)
+#define PIN_PA11A_USART0_RXD           _L_(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L_(0)
 #define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
-#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
-#define PIN_PB14A_USART0_RXD           _L(46) /**< \brief USART0 signal: RXD on PB14 mux A */
-#define MUX_PB14A_USART0_RXD            _L(0)
+#define GPIO_PA11A_USART0_RXD    _UL_(1 << 11)
+#define PIN_PB14A_USART0_RXD           _L_(46) /**< \brief USART0 signal: RXD on PB14 mux A */
+#define MUX_PB14A_USART0_RXD            _L_(0)
 #define PINMUX_PB14A_USART0_RXD    ((PIN_PB14A_USART0_RXD << 16) | MUX_PB14A_USART0_RXD)
-#define GPIO_PB14A_USART0_RXD    _UL(1 << 14)
-#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
-#define MUX_PA07B_USART0_TXD            _L(1)
+#define GPIO_PB14A_USART0_RXD    _UL_(1 << 14)
+#define PIN_PA07B_USART0_TXD            _L_(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L_(1)
 #define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
-#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
-#define PIN_PB01B_USART0_TXD           _L(33) /**< \brief USART0 signal: TXD on PB01 mux B */
-#define MUX_PB01B_USART0_TXD            _L(1)
+#define GPIO_PA07B_USART0_TXD    _UL_(1 <<  7)
+#define PIN_PB01B_USART0_TXD           _L_(33) /**< \brief USART0 signal: TXD on PB01 mux B */
+#define MUX_PB01B_USART0_TXD            _L_(1)
 #define PINMUX_PB01B_USART0_TXD    ((PIN_PB01B_USART0_TXD << 16) | MUX_PB01B_USART0_TXD)
-#define GPIO_PB01B_USART0_TXD    _UL(1 <<  1)
-#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
-#define MUX_PA12A_USART0_TXD            _L(0)
+#define GPIO_PB01B_USART0_TXD    _UL_(1 <<  1)
+#define PIN_PA12A_USART0_TXD           _L_(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L_(0)
 #define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
-#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
-#define PIN_PB15A_USART0_TXD           _L(47) /**< \brief USART0 signal: TXD on PB15 mux A */
-#define MUX_PB15A_USART0_TXD            _L(0)
+#define GPIO_PA12A_USART0_TXD    _UL_(1 << 12)
+#define PIN_PB15A_USART0_TXD           _L_(47) /**< \brief USART0 signal: TXD on PB15 mux A */
+#define MUX_PB15A_USART0_TXD            _L_(0)
 #define PINMUX_PB15A_USART0_TXD    ((PIN_PB15A_USART0_TXD << 16) | MUX_PB15A_USART0_TXD)
-#define GPIO_PB15A_USART0_TXD    _UL(1 << 15)
+#define GPIO_PB15A_USART0_TXD    _UL_(1 << 15)
 /* ========== GPIO definition for USART1 peripheral ========== */
-#define PIN_PB03B_USART1_CLK           _L(35) /**< \brief USART1 signal: CLK on PB03 mux B */
-#define MUX_PB03B_USART1_CLK            _L(1)
+#define PIN_PB03B_USART1_CLK           _L_(35) /**< \brief USART1 signal: CLK on PB03 mux B */
+#define MUX_PB03B_USART1_CLK            _L_(1)
 #define PINMUX_PB03B_USART1_CLK    ((PIN_PB03B_USART1_CLK << 16) | MUX_PB03B_USART1_CLK)
-#define GPIO_PB03B_USART1_CLK    _UL(1 <<  3)
-#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
-#define MUX_PA14A_USART1_CLK            _L(0)
+#define GPIO_PB03B_USART1_CLK    _UL_(1 <<  3)
+#define PIN_PA14A_USART1_CLK           _L_(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L_(0)
 #define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
-#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
-#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
-#define MUX_PA21B_USART1_CTS            _L(1)
+#define GPIO_PA14A_USART1_CLK    _UL_(1 << 14)
+#define PIN_PA21B_USART1_CTS           _L_(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L_(1)
 #define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
-#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
-#define PIN_PB02B_USART1_RTS           _L(34) /**< \brief USART1 signal: RTS on PB02 mux B */
-#define MUX_PB02B_USART1_RTS            _L(1)
+#define GPIO_PA21B_USART1_CTS    _UL_(1 << 21)
+#define PIN_PB02B_USART1_RTS           _L_(34) /**< \brief USART1 signal: RTS on PB02 mux B */
+#define MUX_PB02B_USART1_RTS            _L_(1)
 #define PINMUX_PB02B_USART1_RTS    ((PIN_PB02B_USART1_RTS << 16) | MUX_PB02B_USART1_RTS)
-#define GPIO_PB02B_USART1_RTS    _UL(1 <<  2)
-#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
-#define MUX_PA13A_USART1_RTS            _L(0)
+#define GPIO_PB02B_USART1_RTS    _UL_(1 <<  2)
+#define PIN_PA13A_USART1_RTS           _L_(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L_(0)
 #define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
-#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
-#define PIN_PB04B_USART1_RXD           _L(36) /**< \brief USART1 signal: RXD on PB04 mux B */
-#define MUX_PB04B_USART1_RXD            _L(1)
+#define GPIO_PA13A_USART1_RTS    _UL_(1 << 13)
+#define PIN_PB04B_USART1_RXD           _L_(36) /**< \brief USART1 signal: RXD on PB04 mux B */
+#define MUX_PB04B_USART1_RXD            _L_(1)
 #define PINMUX_PB04B_USART1_RXD    ((PIN_PB04B_USART1_RXD << 16) | MUX_PB04B_USART1_RXD)
-#define GPIO_PB04B_USART1_RXD    _UL(1 <<  4)
-#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
-#define MUX_PA15A_USART1_RXD            _L(0)
+#define GPIO_PB04B_USART1_RXD    _UL_(1 <<  4)
+#define PIN_PA15A_USART1_RXD           _L_(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L_(0)
 #define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
-#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
-#define PIN_PB05B_USART1_TXD           _L(37) /**< \brief USART1 signal: TXD on PB05 mux B */
-#define MUX_PB05B_USART1_TXD            _L(1)
+#define GPIO_PA15A_USART1_RXD    _UL_(1 << 15)
+#define PIN_PB05B_USART1_TXD           _L_(37) /**< \brief USART1 signal: TXD on PB05 mux B */
+#define MUX_PB05B_USART1_TXD            _L_(1)
 #define PINMUX_PB05B_USART1_TXD    ((PIN_PB05B_USART1_TXD << 16) | MUX_PB05B_USART1_TXD)
-#define GPIO_PB05B_USART1_TXD    _UL(1 <<  5)
-#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
-#define MUX_PA16A_USART1_TXD            _L(0)
+#define GPIO_PB05B_USART1_TXD    _UL_(1 <<  5)
+#define PIN_PA16A_USART1_TXD           _L_(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L_(0)
 #define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
-#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+#define GPIO_PA16A_USART1_TXD    _UL_(1 << 16)
 /* ========== GPIO definition for USART2 peripheral ========== */
-#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
-#define MUX_PA18A_USART2_CLK            _L(0)
+#define PIN_PA18A_USART2_CLK           _L_(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L_(0)
 #define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
-#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
-#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
-#define MUX_PA22B_USART2_CTS            _L(1)
+#define GPIO_PA18A_USART2_CLK    _UL_(1 << 18)
+#define PIN_PA22B_USART2_CTS           _L_(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L_(1)
 #define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
-#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
-#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
-#define MUX_PA17A_USART2_RTS            _L(0)
+#define GPIO_PA22B_USART2_CTS    _UL_(1 << 22)
+#define PIN_PA17A_USART2_RTS           _L_(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L_(0)
 #define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
-#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
-#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
-#define MUX_PA25B_USART2_RXD            _L(1)
+#define GPIO_PA17A_USART2_RTS    _UL_(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L_(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L_(1)
 #define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
-#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
-#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
-#define MUX_PA19A_USART2_RXD            _L(0)
+#define GPIO_PA25B_USART2_RXD    _UL_(1 << 25)
+#define PIN_PA19A_USART2_RXD           _L_(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L_(0)
 #define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
-#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
-#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
-#define MUX_PA26B_USART2_TXD            _L(1)
+#define GPIO_PA19A_USART2_RXD    _UL_(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L_(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L_(1)
 #define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
-#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
-#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
-#define MUX_PA20A_USART2_TXD            _L(0)
+#define GPIO_PA26B_USART2_TXD    _UL_(1 << 26)
+#define PIN_PA20A_USART2_TXD           _L_(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L_(0)
 #define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
-#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+#define GPIO_PA20A_USART2_TXD    _UL_(1 << 20)
 /* ========== GPIO definition for USART3 peripheral ========== */
-#define PIN_PB08A_USART3_CLK           _L(40) /**< \brief USART3 signal: CLK on PB08 mux A */
-#define MUX_PB08A_USART3_CLK            _L(0)
+#define PIN_PB08A_USART3_CLK           _L_(40) /**< \brief USART3 signal: CLK on PB08 mux A */
+#define MUX_PB08A_USART3_CLK            _L_(0)
 #define PINMUX_PB08A_USART3_CLK    ((PIN_PB08A_USART3_CLK << 16) | MUX_PB08A_USART3_CLK)
-#define GPIO_PB08A_USART3_CLK    _UL(1 <<  8)
-#define PIN_PB07A_USART3_CTS           _L(39) /**< \brief USART3 signal: CTS on PB07 mux A */
-#define MUX_PB07A_USART3_CTS            _L(0)
+#define GPIO_PB08A_USART3_CLK    _UL_(1 <<  8)
+#define PIN_PB07A_USART3_CTS           _L_(39) /**< \brief USART3 signal: CTS on PB07 mux A */
+#define MUX_PB07A_USART3_CTS            _L_(0)
 #define PINMUX_PB07A_USART3_CTS    ((PIN_PB07A_USART3_CTS << 16) | MUX_PB07A_USART3_CTS)
-#define GPIO_PB07A_USART3_CTS    _UL(1 <<  7)
-#define PIN_PB06A_USART3_RTS           _L(38) /**< \brief USART3 signal: RTS on PB06 mux A */
-#define MUX_PB06A_USART3_RTS            _L(0)
+#define GPIO_PB07A_USART3_CTS    _UL_(1 <<  7)
+#define PIN_PB06A_USART3_RTS           _L_(38) /**< \brief USART3 signal: RTS on PB06 mux A */
+#define MUX_PB06A_USART3_RTS            _L_(0)
 #define PINMUX_PB06A_USART3_RTS    ((PIN_PB06A_USART3_RTS << 16) | MUX_PB06A_USART3_RTS)
-#define GPIO_PB06A_USART3_RTS    _UL(1 <<  6)
-#define PIN_PB09A_USART3_RXD           _L(41) /**< \brief USART3 signal: RXD on PB09 mux A */
-#define MUX_PB09A_USART3_RXD            _L(0)
+#define GPIO_PB06A_USART3_RTS    _UL_(1 <<  6)
+#define PIN_PB09A_USART3_RXD           _L_(41) /**< \brief USART3 signal: RXD on PB09 mux A */
+#define MUX_PB09A_USART3_RXD            _L_(0)
 #define PINMUX_PB09A_USART3_RXD    ((PIN_PB09A_USART3_RXD << 16) | MUX_PB09A_USART3_RXD)
-#define GPIO_PB09A_USART3_RXD    _UL(1 <<  9)
-#define PIN_PB10A_USART3_TXD           _L(42) /**< \brief USART3 signal: TXD on PB10 mux A */
-#define MUX_PB10A_USART3_TXD            _L(0)
+#define GPIO_PB09A_USART3_RXD    _UL_(1 <<  9)
+#define PIN_PB10A_USART3_TXD           _L_(42) /**< \brief USART3 signal: TXD on PB10 mux A */
+#define MUX_PB10A_USART3_TXD            _L_(0)
 #define PINMUX_PB10A_USART3_TXD    ((PIN_PB10A_USART3_TXD << 16) | MUX_PB10A_USART3_TXD)
-#define GPIO_PB10A_USART3_TXD    _UL(1 << 10)
+#define GPIO_PB10A_USART3_TXD    _UL_(1 << 10)
 /* ========== GPIO definition for ADCIFE peripheral ========== */
-#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
-#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PIN_PA04A_ADCIFE_AD0            _L_(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L_(0)
 #define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
-#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
-#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
-#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL_(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L_(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L_(0)
 #define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
-#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
-#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
-#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define GPIO_PA05A_ADCIFE_AD1    _UL_(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L_(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L_(0)
 #define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
-#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
-#define PIN_PB02A_ADCIFE_AD3           _L(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
-#define MUX_PB02A_ADCIFE_AD3            _L(0)
+#define GPIO_PA07A_ADCIFE_AD2    _UL_(1 <<  7)
+#define PIN_PB02A_ADCIFE_AD3           _L_(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
+#define MUX_PB02A_ADCIFE_AD3            _L_(0)
 #define PINMUX_PB02A_ADCIFE_AD3    ((PIN_PB02A_ADCIFE_AD3 << 16) | MUX_PB02A_ADCIFE_AD3)
-#define GPIO_PB02A_ADCIFE_AD3    _UL(1 <<  2)
-#define PIN_PB03A_ADCIFE_AD4           _L(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
-#define MUX_PB03A_ADCIFE_AD4            _L(0)
+#define GPIO_PB02A_ADCIFE_AD3    _UL_(1 <<  2)
+#define PIN_PB03A_ADCIFE_AD4           _L_(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
+#define MUX_PB03A_ADCIFE_AD4            _L_(0)
 #define PINMUX_PB03A_ADCIFE_AD4    ((PIN_PB03A_ADCIFE_AD4 << 16) | MUX_PB03A_ADCIFE_AD4)
-#define GPIO_PB03A_ADCIFE_AD4    _UL(1 <<  3)
-#define PIN_PB04A_ADCIFE_AD5           _L(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
-#define MUX_PB04A_ADCIFE_AD5            _L(0)
+#define GPIO_PB03A_ADCIFE_AD4    _UL_(1 <<  3)
+#define PIN_PB04A_ADCIFE_AD5           _L_(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
+#define MUX_PB04A_ADCIFE_AD5            _L_(0)
 #define PINMUX_PB04A_ADCIFE_AD5    ((PIN_PB04A_ADCIFE_AD5 << 16) | MUX_PB04A_ADCIFE_AD5)
-#define GPIO_PB04A_ADCIFE_AD5    _UL(1 <<  4)
-#define PIN_PB05A_ADCIFE_AD6           _L(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
-#define MUX_PB05A_ADCIFE_AD6            _L(0)
+#define GPIO_PB04A_ADCIFE_AD5    _UL_(1 <<  4)
+#define PIN_PB05A_ADCIFE_AD6           _L_(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
+#define MUX_PB05A_ADCIFE_AD6            _L_(0)
 #define PINMUX_PB05A_ADCIFE_AD6    ((PIN_PB05A_ADCIFE_AD6 << 16) | MUX_PB05A_ADCIFE_AD6)
-#define GPIO_PB05A_ADCIFE_AD6    _UL(1 <<  5)
-#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
-#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define GPIO_PB05A_ADCIFE_AD6    _UL_(1 <<  5)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L_(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L_(4)
 #define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
-#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL_(1 <<  5)
 /* ========== GPIO definition for DACC peripheral ========== */
-#define PIN_PB04E_DACC_EXT_TRIG0       _L(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
-#define MUX_PB04E_DACC_EXT_TRIG0        _L(4)
+#define PIN_PB04E_DACC_EXT_TRIG0       _L_(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
+#define MUX_PB04E_DACC_EXT_TRIG0        _L_(4)
 #define PINMUX_PB04E_DACC_EXT_TRIG0  ((PIN_PB04E_DACC_EXT_TRIG0 << 16) | MUX_PB04E_DACC_EXT_TRIG0)
-#define GPIO_PB04E_DACC_EXT_TRIG0  _UL(1 <<  4)
-#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
-#define MUX_PA06A_DACC_VOUT             _L(0)
+#define GPIO_PB04E_DACC_EXT_TRIG0  _UL_(1 <<  4)
+#define PIN_PA06A_DACC_VOUT             _L_(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L_(0)
 #define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
-#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+#define GPIO_PA06A_DACC_VOUT     _UL_(1 <<  6)
 /* ========== GPIO definition for ACIFC peripheral ========== */
-#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
-#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PIN_PA06E_ACIFC_ACAN0           _L_(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L_(4)
 #define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
-#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
-#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
-#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL_(1 <<  6)
+#define PIN_PA07E_ACIFC_ACAP0           _L_(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L_(4)
 #define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
-#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
-#define PIN_PB02E_ACIFC_ACBN0          _L(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
-#define MUX_PB02E_ACIFC_ACBN0           _L(4)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL_(1 <<  7)
+#define PIN_PB02E_ACIFC_ACBN0          _L_(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
+#define MUX_PB02E_ACIFC_ACBN0           _L_(4)
 #define PINMUX_PB02E_ACIFC_ACBN0   ((PIN_PB02E_ACIFC_ACBN0 << 16) | MUX_PB02E_ACIFC_ACBN0)
-#define GPIO_PB02E_ACIFC_ACBN0   _UL(1 <<  2)
-#define PIN_PB03E_ACIFC_ACBP0          _L(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
-#define MUX_PB03E_ACIFC_ACBP0           _L(4)
+#define GPIO_PB02E_ACIFC_ACBN0   _UL_(1 <<  2)
+#define PIN_PB03E_ACIFC_ACBP0          _L_(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
+#define MUX_PB03E_ACIFC_ACBP0           _L_(4)
 #define PINMUX_PB03E_ACIFC_ACBP0   ((PIN_PB03E_ACIFC_ACBP0 << 16) | MUX_PB03E_ACIFC_ACBP0)
-#define GPIO_PB03E_ACIFC_ACBP0   _UL(1 <<  3)
+#define GPIO_PB03E_ACIFC_ACBP0   _UL_(1 <<  3)
 /* ========== GPIO definition for GLOC peripheral ========== */
-#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
-#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PIN_PA06D_GLOC_IN0              _L_(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L_(3)
 #define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
-#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
-#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
-#define MUX_PA20D_GLOC_IN0              _L(3)
+#define GPIO_PA06D_GLOC_IN0      _UL_(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L_(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L_(3)
 #define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
-#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
-#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
-#define MUX_PA04D_GLOC_IN1              _L(3)
+#define GPIO_PA20D_GLOC_IN0      _UL_(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L_(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L_(3)
 #define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
-#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
-#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
-#define MUX_PA21D_GLOC_IN1              _L(3)
+#define GPIO_PA04D_GLOC_IN1      _UL_(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L_(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L_(3)
 #define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
-#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
-#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
-#define MUX_PA05D_GLOC_IN2              _L(3)
+#define GPIO_PA21D_GLOC_IN1      _UL_(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L_(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L_(3)
 #define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
-#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
-#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
-#define MUX_PA22D_GLOC_IN2              _L(3)
+#define GPIO_PA05D_GLOC_IN2      _UL_(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L_(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L_(3)
 #define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
-#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
-#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
-#define MUX_PA07D_GLOC_IN3              _L(3)
+#define GPIO_PA22D_GLOC_IN2      _UL_(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L_(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L_(3)
 #define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
-#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
-#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
-#define MUX_PA23D_GLOC_IN3              _L(3)
+#define GPIO_PA07D_GLOC_IN3      _UL_(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L_(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L_(3)
 #define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
-#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
-#define PIN_PB06C_GLOC_IN4             _L(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
-#define MUX_PB06C_GLOC_IN4              _L(2)
+#define GPIO_PA23D_GLOC_IN3      _UL_(1 << 23)
+#define PIN_PB06C_GLOC_IN4             _L_(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
+#define MUX_PB06C_GLOC_IN4              _L_(2)
 #define PINMUX_PB06C_GLOC_IN4      ((PIN_PB06C_GLOC_IN4 << 16) | MUX_PB06C_GLOC_IN4)
-#define GPIO_PB06C_GLOC_IN4      _UL(1 <<  6)
-#define PIN_PB07C_GLOC_IN5             _L(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
-#define MUX_PB07C_GLOC_IN5              _L(2)
+#define GPIO_PB06C_GLOC_IN4      _UL_(1 <<  6)
+#define PIN_PB07C_GLOC_IN5             _L_(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
+#define MUX_PB07C_GLOC_IN5              _L_(2)
 #define PINMUX_PB07C_GLOC_IN5      ((PIN_PB07C_GLOC_IN5 << 16) | MUX_PB07C_GLOC_IN5)
-#define GPIO_PB07C_GLOC_IN5      _UL(1 <<  7)
-#define PIN_PB08C_GLOC_IN6             _L(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
-#define MUX_PB08C_GLOC_IN6              _L(2)
+#define GPIO_PB07C_GLOC_IN5      _UL_(1 <<  7)
+#define PIN_PB08C_GLOC_IN6             _L_(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
+#define MUX_PB08C_GLOC_IN6              _L_(2)
 #define PINMUX_PB08C_GLOC_IN6      ((PIN_PB08C_GLOC_IN6 << 16) | MUX_PB08C_GLOC_IN6)
-#define GPIO_PB08C_GLOC_IN6      _UL(1 <<  8)
-#define PIN_PB09C_GLOC_IN7             _L(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
-#define MUX_PB09C_GLOC_IN7              _L(2)
+#define GPIO_PB08C_GLOC_IN6      _UL_(1 <<  8)
+#define PIN_PB09C_GLOC_IN7             _L_(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
+#define MUX_PB09C_GLOC_IN7              _L_(2)
 #define PINMUX_PB09C_GLOC_IN7      ((PIN_PB09C_GLOC_IN7 << 16) | MUX_PB09C_GLOC_IN7)
-#define GPIO_PB09C_GLOC_IN7      _UL(1 <<  9)
-#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
-#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define GPIO_PB09C_GLOC_IN7      _UL_(1 <<  9)
+#define PIN_PA08D_GLOC_OUT0             _L_(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
-#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
-#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
-#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define GPIO_PA08D_GLOC_OUT0     _UL_(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L_(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
-#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
-#define PIN_PB10C_GLOC_OUT1            _L(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
-#define MUX_PB10C_GLOC_OUT1             _L(2)
+#define GPIO_PA24D_GLOC_OUT0     _UL_(1 << 24)
+#define PIN_PB10C_GLOC_OUT1            _L_(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
+#define MUX_PB10C_GLOC_OUT1             _L_(2)
 #define PINMUX_PB10C_GLOC_OUT1     ((PIN_PB10C_GLOC_OUT1 << 16) | MUX_PB10C_GLOC_OUT1)
-#define GPIO_PB10C_GLOC_OUT1     _UL(1 << 10)
+#define GPIO_PB10C_GLOC_OUT1     _UL_(1 << 10)
 /* ========== GPIO definition for ABDACB peripheral ========== */
-#define PIN_PB02C_ABDACB_DAC0          _L(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
-#define MUX_PB02C_ABDACB_DAC0           _L(2)
+#define PIN_PB02C_ABDACB_DAC0          _L_(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
+#define MUX_PB02C_ABDACB_DAC0           _L_(2)
 #define PINMUX_PB02C_ABDACB_DAC0   ((PIN_PB02C_ABDACB_DAC0 << 16) | MUX_PB02C_ABDACB_DAC0)
-#define GPIO_PB02C_ABDACB_DAC0   _UL(1 <<  2)
-#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
-#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define GPIO_PB02C_ABDACB_DAC0   _UL_(1 <<  2)
+#define PIN_PA17B_ABDACB_DAC0          _L_(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L_(1)
 #define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
-#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
-#define PIN_PB04C_ABDACB_DAC1          _L(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
-#define MUX_PB04C_ABDACB_DAC1           _L(2)
+#define GPIO_PA17B_ABDACB_DAC0   _UL_(1 << 17)
+#define PIN_PB04C_ABDACB_DAC1          _L_(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
+#define MUX_PB04C_ABDACB_DAC1           _L_(2)
 #define PINMUX_PB04C_ABDACB_DAC1   ((PIN_PB04C_ABDACB_DAC1 << 16) | MUX_PB04C_ABDACB_DAC1)
-#define GPIO_PB04C_ABDACB_DAC1   _UL(1 <<  4)
-#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
-#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define GPIO_PB04C_ABDACB_DAC1   _UL_(1 <<  4)
+#define PIN_PA19B_ABDACB_DAC1          _L_(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L_(1)
 #define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
-#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
-#define PIN_PB03C_ABDACB_DACN0         _L(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
-#define MUX_PB03C_ABDACB_DACN0          _L(2)
+#define GPIO_PA19B_ABDACB_DAC1   _UL_(1 << 19)
+#define PIN_PB03C_ABDACB_DACN0         _L_(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
+#define MUX_PB03C_ABDACB_DACN0          _L_(2)
 #define PINMUX_PB03C_ABDACB_DACN0  ((PIN_PB03C_ABDACB_DACN0 << 16) | MUX_PB03C_ABDACB_DACN0)
-#define GPIO_PB03C_ABDACB_DACN0  _UL(1 <<  3)
-#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
-#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define GPIO_PB03C_ABDACB_DACN0  _UL_(1 <<  3)
+#define PIN_PA18B_ABDACB_DACN0         _L_(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L_(1)
 #define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
-#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
-#define PIN_PB05C_ABDACB_DACN1         _L(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
-#define MUX_PB05C_ABDACB_DACN1          _L(2)
+#define GPIO_PA18B_ABDACB_DACN0  _UL_(1 << 18)
+#define PIN_PB05C_ABDACB_DACN1         _L_(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
+#define MUX_PB05C_ABDACB_DACN1          _L_(2)
 #define PINMUX_PB05C_ABDACB_DACN1  ((PIN_PB05C_ABDACB_DACN1 << 16) | MUX_PB05C_ABDACB_DACN1)
-#define GPIO_PB05C_ABDACB_DACN1  _UL(1 <<  5)
-#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
-#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define GPIO_PB05C_ABDACB_DACN1  _UL_(1 <<  5)
+#define PIN_PA20B_ABDACB_DACN1         _L_(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L_(1)
 #define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
-#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+#define GPIO_PA20B_ABDACB_DACN1  _UL_(1 << 20)
 /* ========== GPIO definition for PARC peripheral ========== */
-#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
-#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PIN_PA17D_PARC_PCCK            _L_(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L_(3)
 #define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
-#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
-#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
-#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define GPIO_PA17D_PARC_PCCK     _UL_(1 << 17)
+#define PIN_PA09D_PARC_PCDATA0          _L_(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L_(3)
 #define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
-#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
-#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
-#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define GPIO_PA09D_PARC_PCDATA0  _UL_(1 <<  9)
+#define PIN_PA10D_PARC_PCDATA1         _L_(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L_(3)
 #define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
-#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
-#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
-#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define GPIO_PA10D_PARC_PCDATA1  _UL_(1 << 10)
+#define PIN_PA11D_PARC_PCDATA2         _L_(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L_(3)
 #define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
-#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
-#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
-#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define GPIO_PA11D_PARC_PCDATA2  _UL_(1 << 11)
+#define PIN_PA12D_PARC_PCDATA3         _L_(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L_(3)
 #define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
-#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
-#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
-#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL_(1 << 12)
+#define PIN_PA13D_PARC_PCDATA4         _L_(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L_(3)
 #define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
-#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
-#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
-#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define GPIO_PA13D_PARC_PCDATA4  _UL_(1 << 13)
+#define PIN_PA14D_PARC_PCDATA5         _L_(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L_(3)
 #define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
-#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
-#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
-#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define GPIO_PA14D_PARC_PCDATA5  _UL_(1 << 14)
+#define PIN_PA15D_PARC_PCDATA6         _L_(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L_(3)
 #define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
-#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
-#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
-#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define GPIO_PA15D_PARC_PCDATA6  _UL_(1 << 15)
+#define PIN_PA16D_PARC_PCDATA7         _L_(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L_(3)
 #define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
-#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
-#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
-#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define GPIO_PA16D_PARC_PCDATA7  _UL_(1 << 16)
+#define PIN_PA18D_PARC_PCEN1           _L_(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L_(3)
 #define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
-#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
-#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
-#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define GPIO_PA18D_PARC_PCEN1    _UL_(1 << 18)
+#define PIN_PA19D_PARC_PCEN2           _L_(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L_(3)
 #define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
-#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+#define GPIO_PA19D_PARC_PCEN2    _UL_(1 << 19)
 /* ========== GPIO definition for CATB peripheral ========== */
-#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
-#define MUX_PA02G_CATB_DIS              _L(6)
+#define PIN_PA02G_CATB_DIS              _L_(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L_(6)
 #define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
-#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
-#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
-#define MUX_PA12G_CATB_DIS              _L(6)
+#define GPIO_PA02G_CATB_DIS      _UL_(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L_(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L_(6)
 #define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
-#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
-#define MUX_PA23G_CATB_DIS              _L(6)
+#define GPIO_PA12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L_(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L_(6)
 #define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
-#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
-#define PIN_PB03G_CATB_DIS             _L(35) /**< \brief CATB signal: DIS on PB03 mux G */
-#define MUX_PB03G_CATB_DIS              _L(6)
+#define GPIO_PA23G_CATB_DIS      _UL_(1 << 23)
+#define PIN_PB03G_CATB_DIS             _L_(35) /**< \brief CATB signal: DIS on PB03 mux G */
+#define MUX_PB03G_CATB_DIS              _L_(6)
 #define PINMUX_PB03G_CATB_DIS      ((PIN_PB03G_CATB_DIS << 16) | MUX_PB03G_CATB_DIS)
-#define GPIO_PB03G_CATB_DIS      _UL(1 <<  3)
-#define PIN_PB12G_CATB_DIS             _L(44) /**< \brief CATB signal: DIS on PB12 mux G */
-#define MUX_PB12G_CATB_DIS              _L(6)
+#define GPIO_PB03G_CATB_DIS      _UL_(1 <<  3)
+#define PIN_PB12G_CATB_DIS             _L_(44) /**< \brief CATB signal: DIS on PB12 mux G */
+#define MUX_PB12G_CATB_DIS              _L_(6)
 #define PINMUX_PB12G_CATB_DIS      ((PIN_PB12G_CATB_DIS << 16) | MUX_PB12G_CATB_DIS)
-#define GPIO_PB12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
-#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define GPIO_PB12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PA04G_CATB_SENSE0           _L_(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L_(6)
 #define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
-#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
-#define PIN_PB13G_CATB_SENSE0          _L(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
-#define MUX_PB13G_CATB_SENSE0           _L(6)
+#define GPIO_PA04G_CATB_SENSE0   _UL_(1 <<  4)
+#define PIN_PB13G_CATB_SENSE0          _L_(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
+#define MUX_PB13G_CATB_SENSE0           _L_(6)
 #define PINMUX_PB13G_CATB_SENSE0   ((PIN_PB13G_CATB_SENSE0 << 16) | MUX_PB13G_CATB_SENSE0)
-#define GPIO_PB13G_CATB_SENSE0   _UL(1 << 13)
-#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
-#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define GPIO_PB13G_CATB_SENSE0   _UL_(1 << 13)
+#define PIN_PA05G_CATB_SENSE1           _L_(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L_(6)
 #define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
-#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
-#define PIN_PB14G_CATB_SENSE1          _L(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
-#define MUX_PB14G_CATB_SENSE1           _L(6)
+#define GPIO_PA05G_CATB_SENSE1   _UL_(1 <<  5)
+#define PIN_PB14G_CATB_SENSE1          _L_(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
+#define MUX_PB14G_CATB_SENSE1           _L_(6)
 #define PINMUX_PB14G_CATB_SENSE1   ((PIN_PB14G_CATB_SENSE1 << 16) | MUX_PB14G_CATB_SENSE1)
-#define GPIO_PB14G_CATB_SENSE1   _UL(1 << 14)
-#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
-#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define GPIO_PB14G_CATB_SENSE1   _UL_(1 << 14)
+#define PIN_PA06G_CATB_SENSE2           _L_(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L_(6)
 #define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
-#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
-#define PIN_PB15G_CATB_SENSE2          _L(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
-#define MUX_PB15G_CATB_SENSE2           _L(6)
+#define GPIO_PA06G_CATB_SENSE2   _UL_(1 <<  6)
+#define PIN_PB15G_CATB_SENSE2          _L_(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
+#define MUX_PB15G_CATB_SENSE2           _L_(6)
 #define PINMUX_PB15G_CATB_SENSE2   ((PIN_PB15G_CATB_SENSE2 << 16) | MUX_PB15G_CATB_SENSE2)
-#define GPIO_PB15G_CATB_SENSE2   _UL(1 << 15)
-#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
-#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define GPIO_PB15G_CATB_SENSE2   _UL_(1 << 15)
+#define PIN_PA07G_CATB_SENSE3           _L_(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L_(6)
 #define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
-#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
-#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
-#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define GPIO_PA07G_CATB_SENSE3   _UL_(1 <<  7)
+#define PIN_PA08G_CATB_SENSE4           _L_(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L_(6)
 #define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
-#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
-#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
-#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define GPIO_PA08G_CATB_SENSE4   _UL_(1 <<  8)
+#define PIN_PA09G_CATB_SENSE5           _L_(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L_(6)
 #define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
-#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
-#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
-#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define GPIO_PA09G_CATB_SENSE5   _UL_(1 <<  9)
+#define PIN_PA10G_CATB_SENSE6          _L_(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L_(6)
 #define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
-#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
-#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
-#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define GPIO_PA10G_CATB_SENSE6   _UL_(1 << 10)
+#define PIN_PA11G_CATB_SENSE7          _L_(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L_(6)
 #define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
-#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
-#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
-#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define GPIO_PA11G_CATB_SENSE7   _UL_(1 << 11)
+#define PIN_PA13G_CATB_SENSE8          _L_(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L_(6)
 #define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
-#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
-#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
-#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define GPIO_PA13G_CATB_SENSE8   _UL_(1 << 13)
+#define PIN_PA14G_CATB_SENSE9          _L_(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L_(6)
 #define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
-#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
-#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
-#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define GPIO_PA14G_CATB_SENSE9   _UL_(1 << 14)
+#define PIN_PA15G_CATB_SENSE10         _L_(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L_(6)
 #define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
-#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
-#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
-#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define GPIO_PA15G_CATB_SENSE10  _UL_(1 << 15)
+#define PIN_PA16G_CATB_SENSE11         _L_(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L_(6)
 #define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
-#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
-#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
-#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define GPIO_PA16G_CATB_SENSE11  _UL_(1 << 16)
+#define PIN_PA17G_CATB_SENSE12         _L_(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L_(6)
 #define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
-#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
-#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
-#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define GPIO_PA17G_CATB_SENSE12  _UL_(1 << 17)
+#define PIN_PA18G_CATB_SENSE13         _L_(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L_(6)
 #define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
-#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
-#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
-#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define GPIO_PA18G_CATB_SENSE13  _UL_(1 << 18)
+#define PIN_PA19G_CATB_SENSE14         _L_(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L_(6)
 #define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
-#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
-#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
-#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define GPIO_PA19G_CATB_SENSE14  _UL_(1 << 19)
+#define PIN_PA20G_CATB_SENSE15         _L_(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L_(6)
 #define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
-#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
-#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
-#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define GPIO_PA20G_CATB_SENSE15  _UL_(1 << 20)
+#define PIN_PA21G_CATB_SENSE16         _L_(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L_(6)
 #define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
-#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
-#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
-#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define GPIO_PA21G_CATB_SENSE16  _UL_(1 << 21)
+#define PIN_PA22G_CATB_SENSE17         _L_(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L_(6)
 #define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
-#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
-#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
-#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define GPIO_PA22G_CATB_SENSE17  _UL_(1 << 22)
+#define PIN_PA24G_CATB_SENSE18         _L_(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L_(6)
 #define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
-#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
-#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
-#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define GPIO_PA24G_CATB_SENSE18  _UL_(1 << 24)
+#define PIN_PA25G_CATB_SENSE19         _L_(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L_(6)
 #define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
-#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
-#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
-#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define GPIO_PA25G_CATB_SENSE19  _UL_(1 << 25)
+#define PIN_PA26G_CATB_SENSE20         _L_(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L_(6)
 #define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
-#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
-#define PIN_PB00G_CATB_SENSE21         _L(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
-#define MUX_PB00G_CATB_SENSE21          _L(6)
+#define GPIO_PA26G_CATB_SENSE20  _UL_(1 << 26)
+#define PIN_PB00G_CATB_SENSE21         _L_(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
+#define MUX_PB00G_CATB_SENSE21          _L_(6)
 #define PINMUX_PB00G_CATB_SENSE21  ((PIN_PB00G_CATB_SENSE21 << 16) | MUX_PB00G_CATB_SENSE21)
-#define GPIO_PB00G_CATB_SENSE21  _UL(1 <<  0)
-#define PIN_PB01G_CATB_SENSE22         _L(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
-#define MUX_PB01G_CATB_SENSE22          _L(6)
+#define GPIO_PB00G_CATB_SENSE21  _UL_(1 <<  0)
+#define PIN_PB01G_CATB_SENSE22         _L_(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
+#define MUX_PB01G_CATB_SENSE22          _L_(6)
 #define PINMUX_PB01G_CATB_SENSE22  ((PIN_PB01G_CATB_SENSE22 << 16) | MUX_PB01G_CATB_SENSE22)
-#define GPIO_PB01G_CATB_SENSE22  _UL(1 <<  1)
-#define PIN_PB02G_CATB_SENSE23         _L(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
-#define MUX_PB02G_CATB_SENSE23          _L(6)
+#define GPIO_PB01G_CATB_SENSE22  _UL_(1 <<  1)
+#define PIN_PB02G_CATB_SENSE23         _L_(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
+#define MUX_PB02G_CATB_SENSE23          _L_(6)
 #define PINMUX_PB02G_CATB_SENSE23  ((PIN_PB02G_CATB_SENSE23 << 16) | MUX_PB02G_CATB_SENSE23)
-#define GPIO_PB02G_CATB_SENSE23  _UL(1 <<  2)
-#define PIN_PB04G_CATB_SENSE24         _L(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
-#define MUX_PB04G_CATB_SENSE24          _L(6)
+#define GPIO_PB02G_CATB_SENSE23  _UL_(1 <<  2)
+#define PIN_PB04G_CATB_SENSE24         _L_(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
+#define MUX_PB04G_CATB_SENSE24          _L_(6)
 #define PINMUX_PB04G_CATB_SENSE24  ((PIN_PB04G_CATB_SENSE24 << 16) | MUX_PB04G_CATB_SENSE24)
-#define GPIO_PB04G_CATB_SENSE24  _UL(1 <<  4)
-#define PIN_PB05G_CATB_SENSE25         _L(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
-#define MUX_PB05G_CATB_SENSE25          _L(6)
+#define GPIO_PB04G_CATB_SENSE24  _UL_(1 <<  4)
+#define PIN_PB05G_CATB_SENSE25         _L_(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
+#define MUX_PB05G_CATB_SENSE25          _L_(6)
 #define PINMUX_PB05G_CATB_SENSE25  ((PIN_PB05G_CATB_SENSE25 << 16) | MUX_PB05G_CATB_SENSE25)
-#define GPIO_PB05G_CATB_SENSE25  _UL(1 <<  5)
-#define PIN_PB06G_CATB_SENSE26         _L(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
-#define MUX_PB06G_CATB_SENSE26          _L(6)
+#define GPIO_PB05G_CATB_SENSE25  _UL_(1 <<  5)
+#define PIN_PB06G_CATB_SENSE26         _L_(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
+#define MUX_PB06G_CATB_SENSE26          _L_(6)
 #define PINMUX_PB06G_CATB_SENSE26  ((PIN_PB06G_CATB_SENSE26 << 16) | MUX_PB06G_CATB_SENSE26)
-#define GPIO_PB06G_CATB_SENSE26  _UL(1 <<  6)
-#define PIN_PB07G_CATB_SENSE27         _L(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
-#define MUX_PB07G_CATB_SENSE27          _L(6)
+#define GPIO_PB06G_CATB_SENSE26  _UL_(1 <<  6)
+#define PIN_PB07G_CATB_SENSE27         _L_(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
+#define MUX_PB07G_CATB_SENSE27          _L_(6)
 #define PINMUX_PB07G_CATB_SENSE27  ((PIN_PB07G_CATB_SENSE27 << 16) | MUX_PB07G_CATB_SENSE27)
-#define GPIO_PB07G_CATB_SENSE27  _UL(1 <<  7)
-#define PIN_PB08G_CATB_SENSE28         _L(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
-#define MUX_PB08G_CATB_SENSE28          _L(6)
+#define GPIO_PB07G_CATB_SENSE27  _UL_(1 <<  7)
+#define PIN_PB08G_CATB_SENSE28         _L_(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
+#define MUX_PB08G_CATB_SENSE28          _L_(6)
 #define PINMUX_PB08G_CATB_SENSE28  ((PIN_PB08G_CATB_SENSE28 << 16) | MUX_PB08G_CATB_SENSE28)
-#define GPIO_PB08G_CATB_SENSE28  _UL(1 <<  8)
-#define PIN_PB09G_CATB_SENSE29         _L(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
-#define MUX_PB09G_CATB_SENSE29          _L(6)
+#define GPIO_PB08G_CATB_SENSE28  _UL_(1 <<  8)
+#define PIN_PB09G_CATB_SENSE29         _L_(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
+#define MUX_PB09G_CATB_SENSE29          _L_(6)
 #define PINMUX_PB09G_CATB_SENSE29  ((PIN_PB09G_CATB_SENSE29 << 16) | MUX_PB09G_CATB_SENSE29)
-#define GPIO_PB09G_CATB_SENSE29  _UL(1 <<  9)
-#define PIN_PB10G_CATB_SENSE30         _L(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
-#define MUX_PB10G_CATB_SENSE30          _L(6)
+#define GPIO_PB09G_CATB_SENSE29  _UL_(1 <<  9)
+#define PIN_PB10G_CATB_SENSE30         _L_(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
+#define MUX_PB10G_CATB_SENSE30          _L_(6)
 #define PINMUX_PB10G_CATB_SENSE30  ((PIN_PB10G_CATB_SENSE30 << 16) | MUX_PB10G_CATB_SENSE30)
-#define GPIO_PB10G_CATB_SENSE30  _UL(1 << 10)
-#define PIN_PB11G_CATB_SENSE31         _L(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
-#define MUX_PB11G_CATB_SENSE31          _L(6)
+#define GPIO_PB10G_CATB_SENSE30  _UL_(1 << 10)
+#define PIN_PB11G_CATB_SENSE31         _L_(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
+#define MUX_PB11G_CATB_SENSE31          _L_(6)
 #define PINMUX_PB11G_CATB_SENSE31  ((PIN_PB11G_CATB_SENSE31 << 16) | MUX_PB11G_CATB_SENSE31)
-#define GPIO_PB11G_CATB_SENSE31  _UL(1 << 11)
+#define GPIO_PB11G_CATB_SENSE31  _UL_(1 << 11)
 /* ========== GPIO definition for LCDCA peripheral ========== */
-#define PIN_PA12F_LCDCA_COM0           _L(12) /**< \brief LCDCA signal: COM0 on PA12 mux F */
-#define MUX_PA12F_LCDCA_COM0            _L(5)
+#define PIN_PA12F_LCDCA_COM0           _L_(12) /**< \brief LCDCA signal: COM0 on PA12 mux F */
+#define MUX_PA12F_LCDCA_COM0            _L_(5)
 #define PINMUX_PA12F_LCDCA_COM0    ((PIN_PA12F_LCDCA_COM0 << 16) | MUX_PA12F_LCDCA_COM0)
-#define GPIO_PA12F_LCDCA_COM0    _UL(1 << 12)
-#define PIN_PA11F_LCDCA_COM1           _L(11) /**< \brief LCDCA signal: COM1 on PA11 mux F */
-#define MUX_PA11F_LCDCA_COM1            _L(5)
+#define GPIO_PA12F_LCDCA_COM0    _UL_(1 << 12)
+#define PIN_PA11F_LCDCA_COM1           _L_(11) /**< \brief LCDCA signal: COM1 on PA11 mux F */
+#define MUX_PA11F_LCDCA_COM1            _L_(5)
 #define PINMUX_PA11F_LCDCA_COM1    ((PIN_PA11F_LCDCA_COM1 << 16) | MUX_PA11F_LCDCA_COM1)
-#define GPIO_PA11F_LCDCA_COM1    _UL(1 << 11)
-#define PIN_PA10F_LCDCA_COM2           _L(10) /**< \brief LCDCA signal: COM2 on PA10 mux F */
-#define MUX_PA10F_LCDCA_COM2            _L(5)
+#define GPIO_PA11F_LCDCA_COM1    _UL_(1 << 11)
+#define PIN_PA10F_LCDCA_COM2           _L_(10) /**< \brief LCDCA signal: COM2 on PA10 mux F */
+#define MUX_PA10F_LCDCA_COM2            _L_(5)
 #define PINMUX_PA10F_LCDCA_COM2    ((PIN_PA10F_LCDCA_COM2 << 16) | MUX_PA10F_LCDCA_COM2)
-#define GPIO_PA10F_LCDCA_COM2    _UL(1 << 10)
-#define PIN_PA09F_LCDCA_COM3            _L(9) /**< \brief LCDCA signal: COM3 on PA09 mux F */
-#define MUX_PA09F_LCDCA_COM3            _L(5)
+#define GPIO_PA10F_LCDCA_COM2    _UL_(1 << 10)
+#define PIN_PA09F_LCDCA_COM3            _L_(9) /**< \brief LCDCA signal: COM3 on PA09 mux F */
+#define MUX_PA09F_LCDCA_COM3            _L_(5)
 #define PINMUX_PA09F_LCDCA_COM3    ((PIN_PA09F_LCDCA_COM3 << 16) | MUX_PA09F_LCDCA_COM3)
-#define GPIO_PA09F_LCDCA_COM3    _UL(1 <<  9)
-#define PIN_PA13F_LCDCA_SEG5           _L(13) /**< \brief LCDCA signal: SEG5 on PA13 mux F */
-#define MUX_PA13F_LCDCA_SEG5            _L(5)
+#define GPIO_PA09F_LCDCA_COM3    _UL_(1 <<  9)
+#define PIN_PA13F_LCDCA_SEG5           _L_(13) /**< \brief LCDCA signal: SEG5 on PA13 mux F */
+#define MUX_PA13F_LCDCA_SEG5            _L_(5)
 #define PINMUX_PA13F_LCDCA_SEG5    ((PIN_PA13F_LCDCA_SEG5 << 16) | MUX_PA13F_LCDCA_SEG5)
-#define GPIO_PA13F_LCDCA_SEG5    _UL(1 << 13)
-#define PIN_PA14F_LCDCA_SEG6           _L(14) /**< \brief LCDCA signal: SEG6 on PA14 mux F */
-#define MUX_PA14F_LCDCA_SEG6            _L(5)
+#define GPIO_PA13F_LCDCA_SEG5    _UL_(1 << 13)
+#define PIN_PA14F_LCDCA_SEG6           _L_(14) /**< \brief LCDCA signal: SEG6 on PA14 mux F */
+#define MUX_PA14F_LCDCA_SEG6            _L_(5)
 #define PINMUX_PA14F_LCDCA_SEG6    ((PIN_PA14F_LCDCA_SEG6 << 16) | MUX_PA14F_LCDCA_SEG6)
-#define GPIO_PA14F_LCDCA_SEG6    _UL(1 << 14)
-#define PIN_PA15F_LCDCA_SEG7           _L(15) /**< \brief LCDCA signal: SEG7 on PA15 mux F */
-#define MUX_PA15F_LCDCA_SEG7            _L(5)
+#define GPIO_PA14F_LCDCA_SEG6    _UL_(1 << 14)
+#define PIN_PA15F_LCDCA_SEG7           _L_(15) /**< \brief LCDCA signal: SEG7 on PA15 mux F */
+#define MUX_PA15F_LCDCA_SEG7            _L_(5)
 #define PINMUX_PA15F_LCDCA_SEG7    ((PIN_PA15F_LCDCA_SEG7 << 16) | MUX_PA15F_LCDCA_SEG7)
-#define GPIO_PA15F_LCDCA_SEG7    _UL(1 << 15)
-#define PIN_PA16F_LCDCA_SEG8           _L(16) /**< \brief LCDCA signal: SEG8 on PA16 mux F */
-#define MUX_PA16F_LCDCA_SEG8            _L(5)
+#define GPIO_PA15F_LCDCA_SEG7    _UL_(1 << 15)
+#define PIN_PA16F_LCDCA_SEG8           _L_(16) /**< \brief LCDCA signal: SEG8 on PA16 mux F */
+#define MUX_PA16F_LCDCA_SEG8            _L_(5)
 #define PINMUX_PA16F_LCDCA_SEG8    ((PIN_PA16F_LCDCA_SEG8 << 16) | MUX_PA16F_LCDCA_SEG8)
-#define GPIO_PA16F_LCDCA_SEG8    _UL(1 << 16)
-#define PIN_PA17F_LCDCA_SEG9           _L(17) /**< \brief LCDCA signal: SEG9 on PA17 mux F */
-#define MUX_PA17F_LCDCA_SEG9            _L(5)
+#define GPIO_PA16F_LCDCA_SEG8    _UL_(1 << 16)
+#define PIN_PA17F_LCDCA_SEG9           _L_(17) /**< \brief LCDCA signal: SEG9 on PA17 mux F */
+#define MUX_PA17F_LCDCA_SEG9            _L_(5)
 #define PINMUX_PA17F_LCDCA_SEG9    ((PIN_PA17F_LCDCA_SEG9 << 16) | MUX_PA17F_LCDCA_SEG9)
-#define GPIO_PA17F_LCDCA_SEG9    _UL(1 << 17)
-#define PIN_PB08F_LCDCA_SEG14          _L(40) /**< \brief LCDCA signal: SEG14 on PB08 mux F */
-#define MUX_PB08F_LCDCA_SEG14           _L(5)
+#define GPIO_PA17F_LCDCA_SEG9    _UL_(1 << 17)
+#define PIN_PB08F_LCDCA_SEG14          _L_(40) /**< \brief LCDCA signal: SEG14 on PB08 mux F */
+#define MUX_PB08F_LCDCA_SEG14           _L_(5)
 #define PINMUX_PB08F_LCDCA_SEG14   ((PIN_PB08F_LCDCA_SEG14 << 16) | MUX_PB08F_LCDCA_SEG14)
-#define GPIO_PB08F_LCDCA_SEG14   _UL(1 <<  8)
-#define PIN_PB09F_LCDCA_SEG15          _L(41) /**< \brief LCDCA signal: SEG15 on PB09 mux F */
-#define MUX_PB09F_LCDCA_SEG15           _L(5)
+#define GPIO_PB08F_LCDCA_SEG14   _UL_(1 <<  8)
+#define PIN_PB09F_LCDCA_SEG15          _L_(41) /**< \brief LCDCA signal: SEG15 on PB09 mux F */
+#define MUX_PB09F_LCDCA_SEG15           _L_(5)
 #define PINMUX_PB09F_LCDCA_SEG15   ((PIN_PB09F_LCDCA_SEG15 << 16) | MUX_PB09F_LCDCA_SEG15)
-#define GPIO_PB09F_LCDCA_SEG15   _UL(1 <<  9)
-#define PIN_PB10F_LCDCA_SEG16          _L(42) /**< \brief LCDCA signal: SEG16 on PB10 mux F */
-#define MUX_PB10F_LCDCA_SEG16           _L(5)
+#define GPIO_PB09F_LCDCA_SEG15   _UL_(1 <<  9)
+#define PIN_PB10F_LCDCA_SEG16          _L_(42) /**< \brief LCDCA signal: SEG16 on PB10 mux F */
+#define MUX_PB10F_LCDCA_SEG16           _L_(5)
 #define PINMUX_PB10F_LCDCA_SEG16   ((PIN_PB10F_LCDCA_SEG16 << 16) | MUX_PB10F_LCDCA_SEG16)
-#define GPIO_PB10F_LCDCA_SEG16   _UL(1 << 10)
-#define PIN_PB11F_LCDCA_SEG17          _L(43) /**< \brief LCDCA signal: SEG17 on PB11 mux F */
-#define MUX_PB11F_LCDCA_SEG17           _L(5)
+#define GPIO_PB10F_LCDCA_SEG16   _UL_(1 << 10)
+#define PIN_PB11F_LCDCA_SEG17          _L_(43) /**< \brief LCDCA signal: SEG17 on PB11 mux F */
+#define MUX_PB11F_LCDCA_SEG17           _L_(5)
 #define PINMUX_PB11F_LCDCA_SEG17   ((PIN_PB11F_LCDCA_SEG17 << 16) | MUX_PB11F_LCDCA_SEG17)
-#define GPIO_PB11F_LCDCA_SEG17   _UL(1 << 11)
-#define PIN_PA18F_LCDCA_SEG18          _L(18) /**< \brief LCDCA signal: SEG18 on PA18 mux F */
-#define MUX_PA18F_LCDCA_SEG18           _L(5)
+#define GPIO_PB11F_LCDCA_SEG17   _UL_(1 << 11)
+#define PIN_PA18F_LCDCA_SEG18          _L_(18) /**< \brief LCDCA signal: SEG18 on PA18 mux F */
+#define MUX_PA18F_LCDCA_SEG18           _L_(5)
 #define PINMUX_PA18F_LCDCA_SEG18   ((PIN_PA18F_LCDCA_SEG18 << 16) | MUX_PA18F_LCDCA_SEG18)
-#define GPIO_PA18F_LCDCA_SEG18   _UL(1 << 18)
-#define PIN_PA19F_LCDCA_SEG19          _L(19) /**< \brief LCDCA signal: SEG19 on PA19 mux F */
-#define MUX_PA19F_LCDCA_SEG19           _L(5)
+#define GPIO_PA18F_LCDCA_SEG18   _UL_(1 << 18)
+#define PIN_PA19F_LCDCA_SEG19          _L_(19) /**< \brief LCDCA signal: SEG19 on PA19 mux F */
+#define MUX_PA19F_LCDCA_SEG19           _L_(5)
 #define PINMUX_PA19F_LCDCA_SEG19   ((PIN_PA19F_LCDCA_SEG19 << 16) | MUX_PA19F_LCDCA_SEG19)
-#define GPIO_PA19F_LCDCA_SEG19   _UL(1 << 19)
-#define PIN_PA20F_LCDCA_SEG20          _L(20) /**< \brief LCDCA signal: SEG20 on PA20 mux F */
-#define MUX_PA20F_LCDCA_SEG20           _L(5)
+#define GPIO_PA19F_LCDCA_SEG19   _UL_(1 << 19)
+#define PIN_PA20F_LCDCA_SEG20          _L_(20) /**< \brief LCDCA signal: SEG20 on PA20 mux F */
+#define MUX_PA20F_LCDCA_SEG20           _L_(5)
 #define PINMUX_PA20F_LCDCA_SEG20   ((PIN_PA20F_LCDCA_SEG20 << 16) | MUX_PA20F_LCDCA_SEG20)
-#define GPIO_PA20F_LCDCA_SEG20   _UL(1 << 20)
-#define PIN_PB07F_LCDCA_SEG21          _L(39) /**< \brief LCDCA signal: SEG21 on PB07 mux F */
-#define MUX_PB07F_LCDCA_SEG21           _L(5)
+#define GPIO_PA20F_LCDCA_SEG20   _UL_(1 << 20)
+#define PIN_PB07F_LCDCA_SEG21          _L_(39) /**< \brief LCDCA signal: SEG21 on PB07 mux F */
+#define MUX_PB07F_LCDCA_SEG21           _L_(5)
 #define PINMUX_PB07F_LCDCA_SEG21   ((PIN_PB07F_LCDCA_SEG21 << 16) | MUX_PB07F_LCDCA_SEG21)
-#define GPIO_PB07F_LCDCA_SEG21   _UL(1 <<  7)
-#define PIN_PB06F_LCDCA_SEG22          _L(38) /**< \brief LCDCA signal: SEG22 on PB06 mux F */
-#define MUX_PB06F_LCDCA_SEG22           _L(5)
+#define GPIO_PB07F_LCDCA_SEG21   _UL_(1 <<  7)
+#define PIN_PB06F_LCDCA_SEG22          _L_(38) /**< \brief LCDCA signal: SEG22 on PB06 mux F */
+#define MUX_PB06F_LCDCA_SEG22           _L_(5)
 #define PINMUX_PB06F_LCDCA_SEG22   ((PIN_PB06F_LCDCA_SEG22 << 16) | MUX_PB06F_LCDCA_SEG22)
-#define GPIO_PB06F_LCDCA_SEG22   _UL(1 <<  6)
-#define PIN_PA08F_LCDCA_SEG23           _L(8) /**< \brief LCDCA signal: SEG23 on PA08 mux F */
-#define MUX_PA08F_LCDCA_SEG23           _L(5)
+#define GPIO_PB06F_LCDCA_SEG22   _UL_(1 <<  6)
+#define PIN_PA08F_LCDCA_SEG23           _L_(8) /**< \brief LCDCA signal: SEG23 on PA08 mux F */
+#define MUX_PA08F_LCDCA_SEG23           _L_(5)
 #define PINMUX_PA08F_LCDCA_SEG23   ((PIN_PA08F_LCDCA_SEG23 << 16) | MUX_PA08F_LCDCA_SEG23)
-#define GPIO_PA08F_LCDCA_SEG23   _UL(1 <<  8)
-#define PIN_PB12F_LCDCA_SEG32          _L(44) /**< \brief LCDCA signal: SEG32 on PB12 mux F */
-#define MUX_PB12F_LCDCA_SEG32           _L(5)
+#define GPIO_PA08F_LCDCA_SEG23   _UL_(1 <<  8)
+#define PIN_PB12F_LCDCA_SEG32          _L_(44) /**< \brief LCDCA signal: SEG32 on PB12 mux F */
+#define MUX_PB12F_LCDCA_SEG32           _L_(5)
 #define PINMUX_PB12F_LCDCA_SEG32   ((PIN_PB12F_LCDCA_SEG32 << 16) | MUX_PB12F_LCDCA_SEG32)
-#define GPIO_PB12F_LCDCA_SEG32   _UL(1 << 12)
-#define PIN_PB13F_LCDCA_SEG33          _L(45) /**< \brief LCDCA signal: SEG33 on PB13 mux F */
-#define MUX_PB13F_LCDCA_SEG33           _L(5)
+#define GPIO_PB12F_LCDCA_SEG32   _UL_(1 << 12)
+#define PIN_PB13F_LCDCA_SEG33          _L_(45) /**< \brief LCDCA signal: SEG33 on PB13 mux F */
+#define MUX_PB13F_LCDCA_SEG33           _L_(5)
 #define PINMUX_PB13F_LCDCA_SEG33   ((PIN_PB13F_LCDCA_SEG33 << 16) | MUX_PB13F_LCDCA_SEG33)
-#define GPIO_PB13F_LCDCA_SEG33   _UL(1 << 13)
-#define PIN_PA21F_LCDCA_SEG34          _L(21) /**< \brief LCDCA signal: SEG34 on PA21 mux F */
-#define MUX_PA21F_LCDCA_SEG34           _L(5)
+#define GPIO_PB13F_LCDCA_SEG33   _UL_(1 << 13)
+#define PIN_PA21F_LCDCA_SEG34          _L_(21) /**< \brief LCDCA signal: SEG34 on PA21 mux F */
+#define MUX_PA21F_LCDCA_SEG34           _L_(5)
 #define PINMUX_PA21F_LCDCA_SEG34   ((PIN_PA21F_LCDCA_SEG34 << 16) | MUX_PA21F_LCDCA_SEG34)
-#define GPIO_PA21F_LCDCA_SEG34   _UL(1 << 21)
-#define PIN_PA22F_LCDCA_SEG35          _L(22) /**< \brief LCDCA signal: SEG35 on PA22 mux F */
-#define MUX_PA22F_LCDCA_SEG35           _L(5)
+#define GPIO_PA21F_LCDCA_SEG34   _UL_(1 << 21)
+#define PIN_PA22F_LCDCA_SEG35          _L_(22) /**< \brief LCDCA signal: SEG35 on PA22 mux F */
+#define MUX_PA22F_LCDCA_SEG35           _L_(5)
 #define PINMUX_PA22F_LCDCA_SEG35   ((PIN_PA22F_LCDCA_SEG35 << 16) | MUX_PA22F_LCDCA_SEG35)
-#define GPIO_PA22F_LCDCA_SEG35   _UL(1 << 22)
-#define PIN_PB14F_LCDCA_SEG36          _L(46) /**< \brief LCDCA signal: SEG36 on PB14 mux F */
-#define MUX_PB14F_LCDCA_SEG36           _L(5)
+#define GPIO_PA22F_LCDCA_SEG35   _UL_(1 << 22)
+#define PIN_PB14F_LCDCA_SEG36          _L_(46) /**< \brief LCDCA signal: SEG36 on PB14 mux F */
+#define MUX_PB14F_LCDCA_SEG36           _L_(5)
 #define PINMUX_PB14F_LCDCA_SEG36   ((PIN_PB14F_LCDCA_SEG36 << 16) | MUX_PB14F_LCDCA_SEG36)
-#define GPIO_PB14F_LCDCA_SEG36   _UL(1 << 14)
-#define PIN_PB15F_LCDCA_SEG37          _L(47) /**< \brief LCDCA signal: SEG37 on PB15 mux F */
-#define MUX_PB15F_LCDCA_SEG37           _L(5)
+#define GPIO_PB14F_LCDCA_SEG36   _UL_(1 << 14)
+#define PIN_PB15F_LCDCA_SEG37          _L_(47) /**< \brief LCDCA signal: SEG37 on PB15 mux F */
+#define MUX_PB15F_LCDCA_SEG37           _L_(5)
 #define PINMUX_PB15F_LCDCA_SEG37   ((PIN_PB15F_LCDCA_SEG37 << 16) | MUX_PB15F_LCDCA_SEG37)
-#define GPIO_PB15F_LCDCA_SEG37   _UL(1 << 15)
-#define PIN_PA23F_LCDCA_SEG38          _L(23) /**< \brief LCDCA signal: SEG38 on PA23 mux F */
-#define MUX_PA23F_LCDCA_SEG38           _L(5)
+#define GPIO_PB15F_LCDCA_SEG37   _UL_(1 << 15)
+#define PIN_PA23F_LCDCA_SEG38          _L_(23) /**< \brief LCDCA signal: SEG38 on PA23 mux F */
+#define MUX_PA23F_LCDCA_SEG38           _L_(5)
 #define PINMUX_PA23F_LCDCA_SEG38   ((PIN_PA23F_LCDCA_SEG38 << 16) | MUX_PA23F_LCDCA_SEG38)
-#define GPIO_PA23F_LCDCA_SEG38   _UL(1 << 23)
-#define PIN_PA24F_LCDCA_SEG39          _L(24) /**< \brief LCDCA signal: SEG39 on PA24 mux F */
-#define MUX_PA24F_LCDCA_SEG39           _L(5)
+#define GPIO_PA23F_LCDCA_SEG38   _UL_(1 << 23)
+#define PIN_PA24F_LCDCA_SEG39          _L_(24) /**< \brief LCDCA signal: SEG39 on PA24 mux F */
+#define MUX_PA24F_LCDCA_SEG39           _L_(5)
 #define PINMUX_PA24F_LCDCA_SEG39   ((PIN_PA24F_LCDCA_SEG39 << 16) | MUX_PA24F_LCDCA_SEG39)
-#define GPIO_PA24F_LCDCA_SEG39   _UL(1 << 24)
+#define GPIO_PA24F_LCDCA_SEG39   _UL_(1 << 24)
 /* ========== GPIO definition for USBC peripheral ========== */
-#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
-#define MUX_PA25A_USBC_DM               _L(0)
+#define PIN_PA25A_USBC_DM              _L_(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L_(0)
 #define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
-#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
-#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
-#define MUX_PA26A_USBC_DP               _L(0)
+#define GPIO_PA25A_USBC_DM       _UL_(1 << 25)
+#define PIN_PA26A_USBC_DP              _L_(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L_(0)
 #define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
-#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+#define GPIO_PA26A_USBC_DP       _UL_(1 << 26)
 /* ========== GPIO definition for PEVC peripheral ========== */
-#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
-#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PIN_PA08C_PEVC_PAD_EVT0         _L_(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
-#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
-#define PIN_PB12C_PEVC_PAD_EVT0        _L(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
-#define MUX_PB12C_PEVC_PAD_EVT0         _L(2)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL_(1 <<  8)
+#define PIN_PB12C_PEVC_PAD_EVT0        _L_(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
+#define MUX_PB12C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PB12C_PEVC_PAD_EVT0  ((PIN_PB12C_PEVC_PAD_EVT0 << 16) | MUX_PB12C_PEVC_PAD_EVT0)
-#define GPIO_PB12C_PEVC_PAD_EVT0  _UL(1 << 12)
-#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
-#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PB12C_PEVC_PAD_EVT0  _UL_(1 << 12)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L_(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
-#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
-#define PIN_PB13C_PEVC_PAD_EVT1        _L(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
-#define MUX_PB13C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL_(1 <<  9)
+#define PIN_PB13C_PEVC_PAD_EVT1        _L_(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
+#define MUX_PB13C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PB13C_PEVC_PAD_EVT1  ((PIN_PB13C_PEVC_PAD_EVT1 << 16) | MUX_PB13C_PEVC_PAD_EVT1)
-#define GPIO_PB13C_PEVC_PAD_EVT1  _UL(1 << 13)
-#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
-#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PB13C_PEVC_PAD_EVT1  _UL_(1 << 13)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L_(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
-#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
-#define PIN_PB09B_PEVC_PAD_EVT2        _L(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
-#define MUX_PB09B_PEVC_PAD_EVT2         _L(1)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL_(1 << 10)
+#define PIN_PB09B_PEVC_PAD_EVT2        _L_(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
+#define MUX_PB09B_PEVC_PAD_EVT2         _L_(1)
 #define PINMUX_PB09B_PEVC_PAD_EVT2  ((PIN_PB09B_PEVC_PAD_EVT2 << 16) | MUX_PB09B_PEVC_PAD_EVT2)
-#define GPIO_PB09B_PEVC_PAD_EVT2  _UL(1 <<  9)
-#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
-#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define GPIO_PB09B_PEVC_PAD_EVT2  _UL_(1 <<  9)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L_(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L_(2)
 #define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
-#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
-#define PIN_PB10B_PEVC_PAD_EVT3        _L(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
-#define MUX_PB10B_PEVC_PAD_EVT3         _L(1)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL_(1 << 11)
+#define PIN_PB10B_PEVC_PAD_EVT3        _L_(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
+#define MUX_PB10B_PEVC_PAD_EVT3         _L_(1)
 #define PINMUX_PB10B_PEVC_PAD_EVT3  ((PIN_PB10B_PEVC_PAD_EVT3 << 16) | MUX_PB10B_PEVC_PAD_EVT3)
-#define GPIO_PB10B_PEVC_PAD_EVT3  _UL(1 << 10)
+#define GPIO_PB10B_PEVC_PAD_EVT3  _UL_(1 << 10)
 /* ========== GPIO definition for SCIF peripheral ========== */
-#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
-#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PIN_PA19E_SCIF_GCLK0           _L_(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
-#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
-#define PIN_PB10E_SCIF_GCLK0           _L(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
-#define MUX_PB10E_SCIF_GCLK0            _L(4)
+#define GPIO_PA19E_SCIF_GCLK0    _UL_(1 << 19)
+#define PIN_PB10E_SCIF_GCLK0           _L_(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
+#define MUX_PB10E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PB10E_SCIF_GCLK0    ((PIN_PB10E_SCIF_GCLK0 << 16) | MUX_PB10E_SCIF_GCLK0)
-#define GPIO_PB10E_SCIF_GCLK0    _UL(1 << 10)
-#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
-#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define GPIO_PB10E_SCIF_GCLK0    _UL_(1 << 10)
+#define PIN_PA02A_SCIF_GCLK0            _L_(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L_(0)
 #define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
-#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
-#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
-#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define GPIO_PA02A_SCIF_GCLK0    _UL_(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L_(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
-#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
-#define PIN_PB11E_SCIF_GCLK1           _L(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
-#define MUX_PB11E_SCIF_GCLK1            _L(4)
+#define GPIO_PA20E_SCIF_GCLK1    _UL_(1 << 20)
+#define PIN_PB11E_SCIF_GCLK1           _L_(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
+#define MUX_PB11E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PB11E_SCIF_GCLK1    ((PIN_PB11E_SCIF_GCLK1 << 16) | MUX_PB11E_SCIF_GCLK1)
-#define GPIO_PB11E_SCIF_GCLK1    _UL(1 << 11)
-#define PIN_PB12E_SCIF_GCLK2           _L(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
-#define MUX_PB12E_SCIF_GCLK2            _L(4)
+#define GPIO_PB11E_SCIF_GCLK1    _UL_(1 << 11)
+#define PIN_PB12E_SCIF_GCLK2           _L_(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
+#define MUX_PB12E_SCIF_GCLK2            _L_(4)
 #define PINMUX_PB12E_SCIF_GCLK2    ((PIN_PB12E_SCIF_GCLK2 << 16) | MUX_PB12E_SCIF_GCLK2)
-#define GPIO_PB12E_SCIF_GCLK2    _UL(1 << 12)
-#define PIN_PB13E_SCIF_GCLK3           _L(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
-#define MUX_PB13E_SCIF_GCLK3            _L(4)
+#define GPIO_PB12E_SCIF_GCLK2    _UL_(1 << 12)
+#define PIN_PB13E_SCIF_GCLK3           _L_(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
+#define MUX_PB13E_SCIF_GCLK3            _L_(4)
 #define PINMUX_PB13E_SCIF_GCLK3    ((PIN_PB13E_SCIF_GCLK3 << 16) | MUX_PB13E_SCIF_GCLK3)
-#define GPIO_PB13E_SCIF_GCLK3    _UL(1 << 13)
-#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
-#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PB13E_SCIF_GCLK3    _UL_(1 << 13)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L_(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
-#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
-#define PIN_PB14E_SCIF_GCLK_IN0        _L(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
-#define MUX_PB14E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL_(1 << 23)
+#define PIN_PB14E_SCIF_GCLK_IN0        _L_(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
+#define MUX_PB14E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PB14E_SCIF_GCLK_IN0  ((PIN_PB14E_SCIF_GCLK_IN0 << 16) | MUX_PB14E_SCIF_GCLK_IN0)
-#define GPIO_PB14E_SCIF_GCLK_IN0  _UL(1 << 14)
-#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
-#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PB14E_SCIF_GCLK_IN0  _UL_(1 << 14)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L_(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
-#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
-#define PIN_PB15E_SCIF_GCLK_IN1        _L(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
-#define MUX_PB15E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL_(1 << 24)
+#define PIN_PB15E_SCIF_GCLK_IN1        _L_(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
+#define MUX_PB15E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PB15E_SCIF_GCLK_IN1  ((PIN_PB15E_SCIF_GCLK_IN1 << 16) | MUX_PB15E_SCIF_GCLK_IN1)
-#define GPIO_PB15E_SCIF_GCLK_IN1  _UL(1 << 15)
+#define GPIO_PB15E_SCIF_GCLK_IN1  _UL_(1 << 15)
 /* ========== GPIO definition for EIC peripheral ========== */
-#define PIN_PB01C_EIC_EXTINT0          _L(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
-#define MUX_PB01C_EIC_EXTINT0           _L(2)
+#define PIN_PB01C_EIC_EXTINT0          _L_(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
+#define MUX_PB01C_EIC_EXTINT0           _L_(2)
 #define PINMUX_PB01C_EIC_EXTINT0   ((PIN_PB01C_EIC_EXTINT0 << 16) | MUX_PB01C_EIC_EXTINT0)
-#define GPIO_PB01C_EIC_EXTINT0   _UL(1 <<  1)
-#define PIN_PB01C_EIC_EXTINT_NUM        _L(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
-#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
-#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define GPIO_PB01C_EIC_EXTINT0   _UL_(1 <<  1)
+#define PIN_PB01C_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PA06C_EIC_EXTINT1           _L_(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
-#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
-#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
-#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
-#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define GPIO_PA06C_EIC_EXTINT1   _UL_(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L_(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
-#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
-#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
-#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
-#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define GPIO_PA16C_EIC_EXTINT1   _UL_(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L_(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
-#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
-#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
-#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
-#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL_(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L_(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
-#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
-#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
-#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
-#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL_(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L_(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
-#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
-#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
-#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
-#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define GPIO_PA05C_EIC_EXTINT3   _UL_(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L_(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
-#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
-#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
-#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
-#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define GPIO_PA18C_EIC_EXTINT3   _UL_(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L_(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
-#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
-#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
-#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
-#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define GPIO_PA07C_EIC_EXTINT4   _UL_(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L_(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
-#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
-#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
-#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
-#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define GPIO_PA19C_EIC_EXTINT4   _UL_(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L_(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L_(2)
 #define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
-#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
-#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
-#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
-#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define GPIO_PA20C_EIC_EXTINT5   _UL_(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L_(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L_(2)
 #define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
-#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
-#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
-#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
-#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define GPIO_PA21C_EIC_EXTINT6   _UL_(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L_(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L_(2)
 #define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
-#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
-#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
-#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
-#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define GPIO_PA22C_EIC_EXTINT7   _UL_(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L_(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L_(2)
 #define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
-#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
-#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define GPIO_PA23C_EIC_EXTINT8   _UL_(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
 
 #endif /* _SAM4LC8B_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4lc8c.h
+++ b/asf/sam/include/sam4l/pio/sam4lc8c.h
@@ -1,0 +1,1804 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAM4LC8C
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LC8C_PIO_
+#define _SAM4LC8C_PIO_
+
+#define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
+#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
+#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
+#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
+#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
+#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
+#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
+#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
+#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
+#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
+#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
+#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
+#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
+#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
+#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
+#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
+#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
+#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
+#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
+#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
+#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
+#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
+#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
+#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
+#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
+#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
+#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
+#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
+#define GPIO_PB00                _UL(1 <<  0) /**< \brief GPIO Mask  for PB00 */
+#define PIN_PB01                          33  /**< \brief Pin Number for PB01 */
+#define GPIO_PB01                _UL(1 <<  1) /**< \brief GPIO Mask  for PB01 */
+#define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
+#define GPIO_PB02                _UL(1 <<  2) /**< \brief GPIO Mask  for PB02 */
+#define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
+#define GPIO_PB03                _UL(1 <<  3) /**< \brief GPIO Mask  for PB03 */
+#define PIN_PB04                          36  /**< \brief Pin Number for PB04 */
+#define GPIO_PB04                _UL(1 <<  4) /**< \brief GPIO Mask  for PB04 */
+#define PIN_PB05                          37  /**< \brief Pin Number for PB05 */
+#define GPIO_PB05                _UL(1 <<  5) /**< \brief GPIO Mask  for PB05 */
+#define PIN_PB06                          38  /**< \brief Pin Number for PB06 */
+#define GPIO_PB06                _UL(1 <<  6) /**< \brief GPIO Mask  for PB06 */
+#define PIN_PB07                          39  /**< \brief Pin Number for PB07 */
+#define GPIO_PB07                _UL(1 <<  7) /**< \brief GPIO Mask  for PB07 */
+#define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
+#define GPIO_PB08                _UL(1 <<  8) /**< \brief GPIO Mask  for PB08 */
+#define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
+#define GPIO_PB09                _UL(1 <<  9) /**< \brief GPIO Mask  for PB09 */
+#define PIN_PB10                          42  /**< \brief Pin Number for PB10 */
+#define GPIO_PB10                _UL(1 << 10) /**< \brief GPIO Mask  for PB10 */
+#define PIN_PB11                          43  /**< \brief Pin Number for PB11 */
+#define GPIO_PB11                _UL(1 << 11) /**< \brief GPIO Mask  for PB11 */
+#define PIN_PB12                          44  /**< \brief Pin Number for PB12 */
+#define GPIO_PB12                _UL(1 << 12) /**< \brief GPIO Mask  for PB12 */
+#define PIN_PB13                          45  /**< \brief Pin Number for PB13 */
+#define GPIO_PB13                _UL(1 << 13) /**< \brief GPIO Mask  for PB13 */
+#define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
+#define GPIO_PB14                _UL(1 << 14) /**< \brief GPIO Mask  for PB14 */
+#define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
+#define GPIO_PB15                _UL(1 << 15) /**< \brief GPIO Mask  for PB15 */
+#define PIN_PC00                          64  /**< \brief Pin Number for PC00 */
+#define GPIO_PC00                _UL(1 <<  0) /**< \brief GPIO Mask  for PC00 */
+#define PIN_PC01                          65  /**< \brief Pin Number for PC01 */
+#define GPIO_PC01                _UL(1 <<  1) /**< \brief GPIO Mask  for PC01 */
+#define PIN_PC02                          66  /**< \brief Pin Number for PC02 */
+#define GPIO_PC02                _UL(1 <<  2) /**< \brief GPIO Mask  for PC02 */
+#define PIN_PC03                          67  /**< \brief Pin Number for PC03 */
+#define GPIO_PC03                _UL(1 <<  3) /**< \brief GPIO Mask  for PC03 */
+#define PIN_PC04                          68  /**< \brief Pin Number for PC04 */
+#define GPIO_PC04                _UL(1 <<  4) /**< \brief GPIO Mask  for PC04 */
+#define PIN_PC05                          69  /**< \brief Pin Number for PC05 */
+#define GPIO_PC05                _UL(1 <<  5) /**< \brief GPIO Mask  for PC05 */
+#define PIN_PC06                          70  /**< \brief Pin Number for PC06 */
+#define GPIO_PC06                _UL(1 <<  6) /**< \brief GPIO Mask  for PC06 */
+#define PIN_PC07                          71  /**< \brief Pin Number for PC07 */
+#define GPIO_PC07                _UL(1 <<  7) /**< \brief GPIO Mask  for PC07 */
+#define PIN_PC08                          72  /**< \brief Pin Number for PC08 */
+#define GPIO_PC08                _UL(1 <<  8) /**< \brief GPIO Mask  for PC08 */
+#define PIN_PC09                          73  /**< \brief Pin Number for PC09 */
+#define GPIO_PC09                _UL(1 <<  9) /**< \brief GPIO Mask  for PC09 */
+#define PIN_PC10                          74  /**< \brief Pin Number for PC10 */
+#define GPIO_PC10                _UL(1 << 10) /**< \brief GPIO Mask  for PC10 */
+#define PIN_PC11                          75  /**< \brief Pin Number for PC11 */
+#define GPIO_PC11                _UL(1 << 11) /**< \brief GPIO Mask  for PC11 */
+#define PIN_PC12                          76  /**< \brief Pin Number for PC12 */
+#define GPIO_PC12                _UL(1 << 12) /**< \brief GPIO Mask  for PC12 */
+#define PIN_PC13                          77  /**< \brief Pin Number for PC13 */
+#define GPIO_PC13                _UL(1 << 13) /**< \brief GPIO Mask  for PC13 */
+#define PIN_PC14                          78  /**< \brief Pin Number for PC14 */
+#define GPIO_PC14                _UL(1 << 14) /**< \brief GPIO Mask  for PC14 */
+#define PIN_PC15                          79  /**< \brief Pin Number for PC15 */
+#define GPIO_PC15                _UL(1 << 15) /**< \brief GPIO Mask  for PC15 */
+#define PIN_PC16                          80  /**< \brief Pin Number for PC16 */
+#define GPIO_PC16                _UL(1 << 16) /**< \brief GPIO Mask  for PC16 */
+#define PIN_PC17                          81  /**< \brief Pin Number for PC17 */
+#define GPIO_PC17                _UL(1 << 17) /**< \brief GPIO Mask  for PC17 */
+#define PIN_PC18                          82  /**< \brief Pin Number for PC18 */
+#define GPIO_PC18                _UL(1 << 18) /**< \brief GPIO Mask  for PC18 */
+#define PIN_PC19                          83  /**< \brief Pin Number for PC19 */
+#define GPIO_PC19                _UL(1 << 19) /**< \brief GPIO Mask  for PC19 */
+#define PIN_PC20                          84  /**< \brief Pin Number for PC20 */
+#define GPIO_PC20                _UL(1 << 20) /**< \brief GPIO Mask  for PC20 */
+#define PIN_PC21                          85  /**< \brief Pin Number for PC21 */
+#define GPIO_PC21                _UL(1 << 21) /**< \brief GPIO Mask  for PC21 */
+#define PIN_PC22                          86  /**< \brief Pin Number for PC22 */
+#define GPIO_PC22                _UL(1 << 22) /**< \brief GPIO Mask  for PC22 */
+#define PIN_PC23                          87  /**< \brief Pin Number for PC23 */
+#define GPIO_PC23                _UL(1 << 23) /**< \brief GPIO Mask  for PC23 */
+#define PIN_PC24                          88  /**< \brief Pin Number for PC24 */
+#define GPIO_PC24                _UL(1 << 24) /**< \brief GPIO Mask  for PC24 */
+#define PIN_PC25                          89  /**< \brief Pin Number for PC25 */
+#define GPIO_PC25                _UL(1 << 25) /**< \brief GPIO Mask  for PC25 */
+#define PIN_PC26                          90  /**< \brief Pin Number for PC26 */
+#define GPIO_PC26                _UL(1 << 26) /**< \brief GPIO Mask  for PC26 */
+#define PIN_PC27                          91  /**< \brief Pin Number for PC27 */
+#define GPIO_PC27                _UL(1 << 27) /**< \brief GPIO Mask  for PC27 */
+#define PIN_PC28                          92  /**< \brief Pin Number for PC28 */
+#define GPIO_PC28                _UL(1 << 28) /**< \brief GPIO Mask  for PC28 */
+#define PIN_PC29                          93  /**< \brief Pin Number for PC29 */
+#define GPIO_PC29                _UL(1 << 29) /**< \brief GPIO Mask  for PC29 */
+#define PIN_PC30                          94  /**< \brief Pin Number for PC30 */
+#define GPIO_PC30                _UL(1 << 30) /**< \brief GPIO Mask  for PC30 */
+#define PIN_PC31                          95  /**< \brief Pin Number for PC31 */
+#define GPIO_PC31                _UL(1 << 31) /**< \brief GPIO Mask  for PC31 */
+/* ========== GPIO definition for TWIMS0 peripheral ========== */
+#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
+#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+/* ========== GPIO definition for TWIMS1 peripheral ========== */
+#define PIN_PB01A_TWIMS1_TWCK          _L(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
+#define MUX_PB01A_TWIMS1_TWCK           _L(0)
+#define PINMUX_PB01A_TWIMS1_TWCK   ((PIN_PB01A_TWIMS1_TWCK << 16) | MUX_PB01A_TWIMS1_TWCK)
+#define GPIO_PB01A_TWIMS1_TWCK   _UL(1 <<  1)
+#define PIN_PB00A_TWIMS1_TWD           _L(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
+#define MUX_PB00A_TWIMS1_TWD            _L(0)
+#define PINMUX_PB00A_TWIMS1_TWD    ((PIN_PB00A_TWIMS1_TWD << 16) | MUX_PB00A_TWIMS1_TWD)
+#define GPIO_PB00A_TWIMS1_TWD    _UL(1 <<  0)
+/* ========== GPIO definition for TWIMS2 peripheral ========== */
+#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
+#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+/* ========== GPIO definition for TWIMS3 peripheral ========== */
+#define PIN_PB15C_TWIMS3_TWCK          _L(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
+#define MUX_PB15C_TWIMS3_TWCK           _L(2)
+#define PINMUX_PB15C_TWIMS3_TWCK   ((PIN_PB15C_TWIMS3_TWCK << 16) | MUX_PB15C_TWIMS3_TWCK)
+#define GPIO_PB15C_TWIMS3_TWCK   _UL(1 << 15)
+#define PIN_PB14C_TWIMS3_TWD           _L(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
+#define MUX_PB14C_TWIMS3_TWD            _L(2)
+#define PINMUX_PB14C_TWIMS3_TWD    ((PIN_PB14C_TWIMS3_TWD << 16) | MUX_PB14C_TWIMS3_TWD)
+#define GPIO_PB14C_TWIMS3_TWD    _UL(1 << 14)
+/* ========== GPIO definition for IISC peripheral ========== */
+#define PIN_PB05D_IISC_IMCK            _L(37) /**< \brief IISC signal: IMCK on PB05 mux D */
+#define MUX_PB05D_IISC_IMCK             _L(3)
+#define PINMUX_PB05D_IISC_IMCK     ((PIN_PB05D_IISC_IMCK << 16) | MUX_PB05D_IISC_IMCK)
+#define GPIO_PB05D_IISC_IMCK     _UL(1 <<  5)
+#define PIN_PC14D_IISC_IMCK            _L(78) /**< \brief IISC signal: IMCK on PC14 mux D */
+#define MUX_PC14D_IISC_IMCK             _L(3)
+#define PINMUX_PC14D_IISC_IMCK     ((PIN_PC14D_IISC_IMCK << 16) | MUX_PC14D_IISC_IMCK)
+#define GPIO_PC14D_IISC_IMCK     _UL(1 << 14)
+#define PIN_PB02D_IISC_ISCK            _L(34) /**< \brief IISC signal: ISCK on PB02 mux D */
+#define MUX_PB02D_IISC_ISCK             _L(3)
+#define PINMUX_PB02D_IISC_ISCK     ((PIN_PB02D_IISC_ISCK << 16) | MUX_PB02D_IISC_ISCK)
+#define GPIO_PB02D_IISC_ISCK     _UL(1 <<  2)
+#define PIN_PC09D_IISC_ISCK            _L(73) /**< \brief IISC signal: ISCK on PC09 mux D */
+#define MUX_PC09D_IISC_ISCK             _L(3)
+#define PINMUX_PC09D_IISC_ISCK     ((PIN_PC09D_IISC_ISCK << 16) | MUX_PC09D_IISC_ISCK)
+#define GPIO_PC09D_IISC_ISCK     _UL(1 <<  9)
+#define PIN_PB03D_IISC_ISDI            _L(35) /**< \brief IISC signal: ISDI on PB03 mux D */
+#define MUX_PB03D_IISC_ISDI             _L(3)
+#define PINMUX_PB03D_IISC_ISDI     ((PIN_PB03D_IISC_ISDI << 16) | MUX_PB03D_IISC_ISDI)
+#define GPIO_PB03D_IISC_ISDI     _UL(1 <<  3)
+#define PIN_PC10D_IISC_ISDI            _L(74) /**< \brief IISC signal: ISDI on PC10 mux D */
+#define MUX_PC10D_IISC_ISDI             _L(3)
+#define PINMUX_PC10D_IISC_ISDI     ((PIN_PC10D_IISC_ISDI << 16) | MUX_PC10D_IISC_ISDI)
+#define GPIO_PC10D_IISC_ISDI     _UL(1 << 10)
+#define PIN_PB04D_IISC_ISDO            _L(36) /**< \brief IISC signal: ISDO on PB04 mux D */
+#define MUX_PB04D_IISC_ISDO             _L(3)
+#define PINMUX_PB04D_IISC_ISDO     ((PIN_PB04D_IISC_ISDO << 16) | MUX_PB04D_IISC_ISDO)
+#define GPIO_PB04D_IISC_ISDO     _UL(1 <<  4)
+#define PIN_PC13D_IISC_ISDO            _L(77) /**< \brief IISC signal: ISDO on PC13 mux D */
+#define MUX_PC13D_IISC_ISDO             _L(3)
+#define PINMUX_PC13D_IISC_ISDO     ((PIN_PC13D_IISC_ISDO << 16) | MUX_PC13D_IISC_ISDO)
+#define GPIO_PC13D_IISC_ISDO     _UL(1 << 13)
+#define PIN_PB06D_IISC_IWS             _L(38) /**< \brief IISC signal: IWS on PB06 mux D */
+#define MUX_PB06D_IISC_IWS              _L(3)
+#define PINMUX_PB06D_IISC_IWS      ((PIN_PB06D_IISC_IWS << 16) | MUX_PB06D_IISC_IWS)
+#define GPIO_PB06D_IISC_IWS      _UL(1 <<  6)
+#define PIN_PC12D_IISC_IWS             _L(76) /**< \brief IISC signal: IWS on PC12 mux D */
+#define MUX_PC12D_IISC_IWS              _L(3)
+#define PINMUX_PC12D_IISC_IWS      ((PIN_PC12D_IISC_IWS << 16) | MUX_PC12D_IISC_IWS)
+#define GPIO_PC12D_IISC_IWS      _UL(1 << 12)
+/* ========== GPIO definition for SPI peripheral ========== */
+#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L(1)
+#define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
+#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
+#define PIN_PB14B_SPI_MISO             _L(46) /**< \brief SPI signal: MISO on PB14 mux B */
+#define MUX_PB14B_SPI_MISO              _L(1)
+#define PINMUX_PB14B_SPI_MISO      ((PIN_PB14B_SPI_MISO << 16) | MUX_PB14B_SPI_MISO)
+#define GPIO_PB14B_SPI_MISO      _UL(1 << 14)
+#define PIN_PC28B_SPI_MISO             _L(92) /**< \brief SPI signal: MISO on PC28 mux B */
+#define MUX_PC28B_SPI_MISO              _L(1)
+#define PINMUX_PC28B_SPI_MISO      ((PIN_PC28B_SPI_MISO << 16) | MUX_PC28B_SPI_MISO)
+#define GPIO_PC28B_SPI_MISO      _UL(1 << 28)
+#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L(0)
+#define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
+#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
+#define PIN_PC04A_SPI_MISO             _L(68) /**< \brief SPI signal: MISO on PC04 mux A */
+#define MUX_PC04A_SPI_MISO              _L(0)
+#define PINMUX_PC04A_SPI_MISO      ((PIN_PC04A_SPI_MISO << 16) | MUX_PC04A_SPI_MISO)
+#define GPIO_PC04A_SPI_MISO      _UL(1 <<  4)
+#define PIN_PB15B_SPI_MOSI             _L(47) /**< \brief SPI signal: MOSI on PB15 mux B */
+#define MUX_PB15B_SPI_MOSI              _L(1)
+#define PINMUX_PB15B_SPI_MOSI      ((PIN_PB15B_SPI_MOSI << 16) | MUX_PB15B_SPI_MOSI)
+#define GPIO_PB15B_SPI_MOSI      _UL(1 << 15)
+#define PIN_PC29B_SPI_MOSI             _L(93) /**< \brief SPI signal: MOSI on PC29 mux B */
+#define MUX_PC29B_SPI_MOSI              _L(1)
+#define PINMUX_PC29B_SPI_MOSI      ((PIN_PC29B_SPI_MOSI << 16) | MUX_PC29B_SPI_MOSI)
+#define GPIO_PC29B_SPI_MOSI      _UL(1 << 29)
+#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L(0)
+#define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
+#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
+#define PIN_PC05A_SPI_MOSI             _L(69) /**< \brief SPI signal: MOSI on PC05 mux A */
+#define MUX_PC05A_SPI_MOSI              _L(0)
+#define PINMUX_PC05A_SPI_MOSI      ((PIN_PC05A_SPI_MOSI << 16) | MUX_PC05A_SPI_MOSI)
+#define GPIO_PC05A_SPI_MOSI      _UL(1 <<  5)
+#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
+#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
+#define PIN_PC31B_SPI_NPCS0            _L(95) /**< \brief SPI signal: NPCS0 on PC31 mux B */
+#define MUX_PC31B_SPI_NPCS0             _L(1)
+#define PINMUX_PC31B_SPI_NPCS0     ((PIN_PC31B_SPI_NPCS0 << 16) | MUX_PC31B_SPI_NPCS0)
+#define GPIO_PC31B_SPI_NPCS0     _UL(1 << 31)
+#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
+#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
+#define PIN_PC03A_SPI_NPCS0            _L(67) /**< \brief SPI signal: NPCS0 on PC03 mux A */
+#define MUX_PC03A_SPI_NPCS0             _L(0)
+#define PINMUX_PC03A_SPI_NPCS0     ((PIN_PC03A_SPI_NPCS0 << 16) | MUX_PC03A_SPI_NPCS0)
+#define GPIO_PC03A_SPI_NPCS0     _UL(1 <<  3)
+#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
+#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PB13B_SPI_NPCS1            _L(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
+#define MUX_PB13B_SPI_NPCS1             _L(1)
+#define PINMUX_PB13B_SPI_NPCS1     ((PIN_PB13B_SPI_NPCS1 << 16) | MUX_PB13B_SPI_NPCS1)
+#define GPIO_PB13B_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PC02A_SPI_NPCS1            _L(66) /**< \brief SPI signal: NPCS1 on PC02 mux A */
+#define MUX_PC02A_SPI_NPCS1             _L(0)
+#define PINMUX_PC02A_SPI_NPCS1     ((PIN_PC02A_SPI_NPCS1 << 16) | MUX_PC02A_SPI_NPCS1)
+#define GPIO_PC02A_SPI_NPCS1     _UL(1 <<  2)
+#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
+#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
+#define PIN_PB11B_SPI_NPCS2            _L(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
+#define MUX_PB11B_SPI_NPCS2             _L(1)
+#define PINMUX_PB11B_SPI_NPCS2     ((PIN_PB11B_SPI_NPCS2 << 16) | MUX_PB11B_SPI_NPCS2)
+#define GPIO_PB11B_SPI_NPCS2     _UL(1 << 11)
+#define PIN_PC00A_SPI_NPCS2            _L(64) /**< \brief SPI signal: NPCS2 on PC00 mux A */
+#define MUX_PC00A_SPI_NPCS2             _L(0)
+#define PINMUX_PC00A_SPI_NPCS2     ((PIN_PC00A_SPI_NPCS2 << 16) | MUX_PC00A_SPI_NPCS2)
+#define GPIO_PC00A_SPI_NPCS2     _UL(1 <<  0)
+#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
+#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
+#define PIN_PB12B_SPI_NPCS3            _L(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
+#define MUX_PB12B_SPI_NPCS3             _L(1)
+#define PINMUX_PB12B_SPI_NPCS3     ((PIN_PB12B_SPI_NPCS3 << 16) | MUX_PB12B_SPI_NPCS3)
+#define GPIO_PB12B_SPI_NPCS3     _UL(1 << 12)
+#define PIN_PC01A_SPI_NPCS3            _L(65) /**< \brief SPI signal: NPCS3 on PC01 mux A */
+#define MUX_PC01A_SPI_NPCS3             _L(0)
+#define PINMUX_PC01A_SPI_NPCS3     ((PIN_PC01A_SPI_NPCS3 << 16) | MUX_PC01A_SPI_NPCS3)
+#define GPIO_PC01A_SPI_NPCS3     _UL(1 <<  1)
+#define PIN_PC30B_SPI_SCK              _L(94) /**< \brief SPI signal: SCK on PC30 mux B */
+#define MUX_PC30B_SPI_SCK               _L(1)
+#define PINMUX_PC30B_SPI_SCK       ((PIN_PC30B_SPI_SCK << 16) | MUX_PC30B_SPI_SCK)
+#define GPIO_PC30B_SPI_SCK       _UL(1 << 30)
+#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L(0)
+#define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
+#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
+#define PIN_PC06A_SPI_SCK              _L(70) /**< \brief SPI signal: SCK on PC06 mux A */
+#define MUX_PC06A_SPI_SCK               _L(0)
+#define PINMUX_PC06A_SPI_SCK       ((PIN_PC06A_SPI_SCK << 16) | MUX_PC06A_SPI_SCK)
+#define GPIO_PC06A_SPI_SCK       _UL(1 <<  6)
+/* ========== GPIO definition for TC0 peripheral ========== */
+#define PIN_PB07D_TC0_A0               _L(39) /**< \brief TC0 signal: A0 on PB07 mux D */
+#define MUX_PB07D_TC0_A0                _L(3)
+#define PINMUX_PB07D_TC0_A0        ((PIN_PB07D_TC0_A0 << 16) | MUX_PB07D_TC0_A0)
+#define GPIO_PB07D_TC0_A0        _UL(1 <<  7)
+#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L(1)
+#define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
+#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
+#define PIN_PB09D_TC0_A1               _L(41) /**< \brief TC0 signal: A1 on PB09 mux D */
+#define MUX_PB09D_TC0_A1                _L(3)
+#define PINMUX_PB09D_TC0_A1        ((PIN_PB09D_TC0_A1 << 16) | MUX_PB09D_TC0_A1)
+#define GPIO_PB09D_TC0_A1        _UL(1 <<  9)
+#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L(1)
+#define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
+#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
+#define PIN_PB11D_TC0_A2               _L(43) /**< \brief TC0 signal: A2 on PB11 mux D */
+#define MUX_PB11D_TC0_A2                _L(3)
+#define PINMUX_PB11D_TC0_A2        ((PIN_PB11D_TC0_A2 << 16) | MUX_PB11D_TC0_A2)
+#define GPIO_PB11D_TC0_A2        _UL(1 << 11)
+#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L(1)
+#define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
+#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
+#define PIN_PB08D_TC0_B0               _L(40) /**< \brief TC0 signal: B0 on PB08 mux D */
+#define MUX_PB08D_TC0_B0                _L(3)
+#define PINMUX_PB08D_TC0_B0        ((PIN_PB08D_TC0_B0 << 16) | MUX_PB08D_TC0_B0)
+#define GPIO_PB08D_TC0_B0        _UL(1 <<  8)
+#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L(1)
+#define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
+#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
+#define PIN_PB10D_TC0_B1               _L(42) /**< \brief TC0 signal: B1 on PB10 mux D */
+#define MUX_PB10D_TC0_B1                _L(3)
+#define PINMUX_PB10D_TC0_B1        ((PIN_PB10D_TC0_B1 << 16) | MUX_PB10D_TC0_B1)
+#define GPIO_PB10D_TC0_B1        _UL(1 << 10)
+#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L(1)
+#define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
+#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
+#define PIN_PB12D_TC0_B2               _L(44) /**< \brief TC0 signal: B2 on PB12 mux D */
+#define MUX_PB12D_TC0_B2                _L(3)
+#define PINMUX_PB12D_TC0_B2        ((PIN_PB12D_TC0_B2 << 16) | MUX_PB12D_TC0_B2)
+#define GPIO_PB12D_TC0_B2        _UL(1 << 12)
+#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L(1)
+#define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
+#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
+#define PIN_PB13D_TC0_CLK0             _L(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
+#define MUX_PB13D_TC0_CLK0              _L(3)
+#define PINMUX_PB13D_TC0_CLK0      ((PIN_PB13D_TC0_CLK0 << 16) | MUX_PB13D_TC0_CLK0)
+#define GPIO_PB13D_TC0_CLK0      _UL(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L(1)
+#define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
+#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
+#define PIN_PB14D_TC0_CLK1             _L(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
+#define MUX_PB14D_TC0_CLK1              _L(3)
+#define PINMUX_PB14D_TC0_CLK1      ((PIN_PB14D_TC0_CLK1 << 16) | MUX_PB14D_TC0_CLK1)
+#define GPIO_PB14D_TC0_CLK1      _UL(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L(1)
+#define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
+#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
+#define PIN_PB15D_TC0_CLK2             _L(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
+#define MUX_PB15D_TC0_CLK2              _L(3)
+#define PINMUX_PB15D_TC0_CLK2      ((PIN_PB15D_TC0_CLK2 << 16) | MUX_PB15D_TC0_CLK2)
+#define GPIO_PB15D_TC0_CLK2      _UL(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L(1)
+#define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
+#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+/* ========== GPIO definition for TC1 peripheral ========== */
+#define PIN_PC00D_TC1_A0               _L(64) /**< \brief TC1 signal: A0 on PC00 mux D */
+#define MUX_PC00D_TC1_A0                _L(3)
+#define PINMUX_PC00D_TC1_A0        ((PIN_PC00D_TC1_A0 << 16) | MUX_PC00D_TC1_A0)
+#define GPIO_PC00D_TC1_A0        _UL(1 <<  0)
+#define PIN_PC15A_TC1_A0               _L(79) /**< \brief TC1 signal: A0 on PC15 mux A */
+#define MUX_PC15A_TC1_A0                _L(0)
+#define PINMUX_PC15A_TC1_A0        ((PIN_PC15A_TC1_A0 << 16) | MUX_PC15A_TC1_A0)
+#define GPIO_PC15A_TC1_A0        _UL(1 << 15)
+#define PIN_PC02D_TC1_A1               _L(66) /**< \brief TC1 signal: A1 on PC02 mux D */
+#define MUX_PC02D_TC1_A1                _L(3)
+#define PINMUX_PC02D_TC1_A1        ((PIN_PC02D_TC1_A1 << 16) | MUX_PC02D_TC1_A1)
+#define GPIO_PC02D_TC1_A1        _UL(1 <<  2)
+#define PIN_PC17A_TC1_A1               _L(81) /**< \brief TC1 signal: A1 on PC17 mux A */
+#define MUX_PC17A_TC1_A1                _L(0)
+#define PINMUX_PC17A_TC1_A1        ((PIN_PC17A_TC1_A1 << 16) | MUX_PC17A_TC1_A1)
+#define GPIO_PC17A_TC1_A1        _UL(1 << 17)
+#define PIN_PC04D_TC1_A2               _L(68) /**< \brief TC1 signal: A2 on PC04 mux D */
+#define MUX_PC04D_TC1_A2                _L(3)
+#define PINMUX_PC04D_TC1_A2        ((PIN_PC04D_TC1_A2 << 16) | MUX_PC04D_TC1_A2)
+#define GPIO_PC04D_TC1_A2        _UL(1 <<  4)
+#define PIN_PC19A_TC1_A2               _L(83) /**< \brief TC1 signal: A2 on PC19 mux A */
+#define MUX_PC19A_TC1_A2                _L(0)
+#define PINMUX_PC19A_TC1_A2        ((PIN_PC19A_TC1_A2 << 16) | MUX_PC19A_TC1_A2)
+#define GPIO_PC19A_TC1_A2        _UL(1 << 19)
+#define PIN_PC01D_TC1_B0               _L(65) /**< \brief TC1 signal: B0 on PC01 mux D */
+#define MUX_PC01D_TC1_B0                _L(3)
+#define PINMUX_PC01D_TC1_B0        ((PIN_PC01D_TC1_B0 << 16) | MUX_PC01D_TC1_B0)
+#define GPIO_PC01D_TC1_B0        _UL(1 <<  1)
+#define PIN_PC16A_TC1_B0               _L(80) /**< \brief TC1 signal: B0 on PC16 mux A */
+#define MUX_PC16A_TC1_B0                _L(0)
+#define PINMUX_PC16A_TC1_B0        ((PIN_PC16A_TC1_B0 << 16) | MUX_PC16A_TC1_B0)
+#define GPIO_PC16A_TC1_B0        _UL(1 << 16)
+#define PIN_PC03D_TC1_B1               _L(67) /**< \brief TC1 signal: B1 on PC03 mux D */
+#define MUX_PC03D_TC1_B1                _L(3)
+#define PINMUX_PC03D_TC1_B1        ((PIN_PC03D_TC1_B1 << 16) | MUX_PC03D_TC1_B1)
+#define GPIO_PC03D_TC1_B1        _UL(1 <<  3)
+#define PIN_PC18A_TC1_B1               _L(82) /**< \brief TC1 signal: B1 on PC18 mux A */
+#define MUX_PC18A_TC1_B1                _L(0)
+#define PINMUX_PC18A_TC1_B1        ((PIN_PC18A_TC1_B1 << 16) | MUX_PC18A_TC1_B1)
+#define GPIO_PC18A_TC1_B1        _UL(1 << 18)
+#define PIN_PC05D_TC1_B2               _L(69) /**< \brief TC1 signal: B2 on PC05 mux D */
+#define MUX_PC05D_TC1_B2                _L(3)
+#define PINMUX_PC05D_TC1_B2        ((PIN_PC05D_TC1_B2 << 16) | MUX_PC05D_TC1_B2)
+#define GPIO_PC05D_TC1_B2        _UL(1 <<  5)
+#define PIN_PC20A_TC1_B2               _L(84) /**< \brief TC1 signal: B2 on PC20 mux A */
+#define MUX_PC20A_TC1_B2                _L(0)
+#define PINMUX_PC20A_TC1_B2        ((PIN_PC20A_TC1_B2 << 16) | MUX_PC20A_TC1_B2)
+#define GPIO_PC20A_TC1_B2        _UL(1 << 20)
+#define PIN_PC06D_TC1_CLK0             _L(70) /**< \brief TC1 signal: CLK0 on PC06 mux D */
+#define MUX_PC06D_TC1_CLK0              _L(3)
+#define PINMUX_PC06D_TC1_CLK0      ((PIN_PC06D_TC1_CLK0 << 16) | MUX_PC06D_TC1_CLK0)
+#define GPIO_PC06D_TC1_CLK0      _UL(1 <<  6)
+#define PIN_PC21A_TC1_CLK0             _L(85) /**< \brief TC1 signal: CLK0 on PC21 mux A */
+#define MUX_PC21A_TC1_CLK0              _L(0)
+#define PINMUX_PC21A_TC1_CLK0      ((PIN_PC21A_TC1_CLK0 << 16) | MUX_PC21A_TC1_CLK0)
+#define GPIO_PC21A_TC1_CLK0      _UL(1 << 21)
+#define PIN_PC07D_TC1_CLK1             _L(71) /**< \brief TC1 signal: CLK1 on PC07 mux D */
+#define MUX_PC07D_TC1_CLK1              _L(3)
+#define PINMUX_PC07D_TC1_CLK1      ((PIN_PC07D_TC1_CLK1 << 16) | MUX_PC07D_TC1_CLK1)
+#define GPIO_PC07D_TC1_CLK1      _UL(1 <<  7)
+#define PIN_PC22A_TC1_CLK1             _L(86) /**< \brief TC1 signal: CLK1 on PC22 mux A */
+#define MUX_PC22A_TC1_CLK1              _L(0)
+#define PINMUX_PC22A_TC1_CLK1      ((PIN_PC22A_TC1_CLK1 << 16) | MUX_PC22A_TC1_CLK1)
+#define GPIO_PC22A_TC1_CLK1      _UL(1 << 22)
+#define PIN_PC08D_TC1_CLK2             _L(72) /**< \brief TC1 signal: CLK2 on PC08 mux D */
+#define MUX_PC08D_TC1_CLK2              _L(3)
+#define PINMUX_PC08D_TC1_CLK2      ((PIN_PC08D_TC1_CLK2 << 16) | MUX_PC08D_TC1_CLK2)
+#define GPIO_PC08D_TC1_CLK2      _UL(1 <<  8)
+#define PIN_PC23A_TC1_CLK2             _L(87) /**< \brief TC1 signal: CLK2 on PC23 mux A */
+#define MUX_PC23A_TC1_CLK2              _L(0)
+#define PINMUX_PC23A_TC1_CLK2      ((PIN_PC23A_TC1_CLK2 << 16) | MUX_PC23A_TC1_CLK2)
+#define GPIO_PC23A_TC1_CLK2      _UL(1 << 23)
+/* ========== GPIO definition for USART0 peripheral ========== */
+#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L(1)
+#define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
+#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
+#define PIN_PC00B_USART0_CLK           _L(64) /**< \brief USART0 signal: CLK on PC00 mux B */
+#define MUX_PC00B_USART0_CLK            _L(1)
+#define PINMUX_PC00B_USART0_CLK    ((PIN_PC00B_USART0_CLK << 16) | MUX_PC00B_USART0_CLK)
+#define GPIO_PC00B_USART0_CLK    _UL(1 <<  0)
+#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L(0)
+#define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
+#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
+#define PIN_PB13A_USART0_CLK           _L(45) /**< \brief USART0 signal: CLK on PB13 mux A */
+#define MUX_PB13A_USART0_CLK            _L(0)
+#define PINMUX_PB13A_USART0_CLK    ((PIN_PB13A_USART0_CLK << 16) | MUX_PB13A_USART0_CLK)
+#define GPIO_PB13A_USART0_CLK    _UL(1 << 13)
+#define PIN_PC02B_USART0_CTS           _L(66) /**< \brief USART0 signal: CTS on PC02 mux B */
+#define MUX_PC02B_USART0_CTS            _L(1)
+#define PINMUX_PC02B_USART0_CTS    ((PIN_PC02B_USART0_CTS << 16) | MUX_PC02B_USART0_CTS)
+#define GPIO_PC02B_USART0_CTS    _UL(1 <<  2)
+#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L(0)
+#define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
+#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
+#define PIN_PB11A_USART0_CTS           _L(43) /**< \brief USART0 signal: CTS on PB11 mux A */
+#define MUX_PB11A_USART0_CTS            _L(0)
+#define PINMUX_PB11A_USART0_CTS    ((PIN_PB11A_USART0_CTS << 16) | MUX_PB11A_USART0_CTS)
+#define GPIO_PB11A_USART0_CTS    _UL(1 << 11)
+#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L(1)
+#define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
+#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
+#define PIN_PC01B_USART0_RTS           _L(65) /**< \brief USART0 signal: RTS on PC01 mux B */
+#define MUX_PC01B_USART0_RTS            _L(1)
+#define PINMUX_PC01B_USART0_RTS    ((PIN_PC01B_USART0_RTS << 16) | MUX_PC01B_USART0_RTS)
+#define GPIO_PC01B_USART0_RTS    _UL(1 <<  1)
+#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L(0)
+#define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
+#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
+#define PIN_PB12A_USART0_RTS           _L(44) /**< \brief USART0 signal: RTS on PB12 mux A */
+#define MUX_PB12A_USART0_RTS            _L(0)
+#define PINMUX_PB12A_USART0_RTS    ((PIN_PB12A_USART0_RTS << 16) | MUX_PB12A_USART0_RTS)
+#define GPIO_PB12A_USART0_RTS    _UL(1 << 12)
+#define PIN_PC02C_USART0_RXD           _L(66) /**< \brief USART0 signal: RXD on PC02 mux C */
+#define MUX_PC02C_USART0_RXD            _L(2)
+#define PINMUX_PC02C_USART0_RXD    ((PIN_PC02C_USART0_RXD << 16) | MUX_PC02C_USART0_RXD)
+#define GPIO_PC02C_USART0_RXD    _UL(1 <<  2)
+#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L(1)
+#define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
+#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
+#define PIN_PB00B_USART0_RXD           _L(32) /**< \brief USART0 signal: RXD on PB00 mux B */
+#define MUX_PB00B_USART0_RXD            _L(1)
+#define PINMUX_PB00B_USART0_RXD    ((PIN_PB00B_USART0_RXD << 16) | MUX_PB00B_USART0_RXD)
+#define GPIO_PB00B_USART0_RXD    _UL(1 <<  0)
+#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L(0)
+#define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
+#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
+#define PIN_PB14A_USART0_RXD           _L(46) /**< \brief USART0 signal: RXD on PB14 mux A */
+#define MUX_PB14A_USART0_RXD            _L(0)
+#define PINMUX_PB14A_USART0_RXD    ((PIN_PB14A_USART0_RXD << 16) | MUX_PB14A_USART0_RXD)
+#define GPIO_PB14A_USART0_RXD    _UL(1 << 14)
+#define PIN_PC03C_USART0_TXD           _L(67) /**< \brief USART0 signal: TXD on PC03 mux C */
+#define MUX_PC03C_USART0_TXD            _L(2)
+#define PINMUX_PC03C_USART0_TXD    ((PIN_PC03C_USART0_TXD << 16) | MUX_PC03C_USART0_TXD)
+#define GPIO_PC03C_USART0_TXD    _UL(1 <<  3)
+#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L(1)
+#define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
+#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
+#define PIN_PB01B_USART0_TXD           _L(33) /**< \brief USART0 signal: TXD on PB01 mux B */
+#define MUX_PB01B_USART0_TXD            _L(1)
+#define PINMUX_PB01B_USART0_TXD    ((PIN_PB01B_USART0_TXD << 16) | MUX_PB01B_USART0_TXD)
+#define GPIO_PB01B_USART0_TXD    _UL(1 <<  1)
+#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L(0)
+#define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
+#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
+#define PIN_PB15A_USART0_TXD           _L(47) /**< \brief USART0 signal: TXD on PB15 mux A */
+#define MUX_PB15A_USART0_TXD            _L(0)
+#define PINMUX_PB15A_USART0_TXD    ((PIN_PB15A_USART0_TXD << 16) | MUX_PB15A_USART0_TXD)
+#define GPIO_PB15A_USART0_TXD    _UL(1 << 15)
+/* ========== GPIO definition for USART1 peripheral ========== */
+#define PIN_PB03B_USART1_CLK           _L(35) /**< \brief USART1 signal: CLK on PB03 mux B */
+#define MUX_PB03B_USART1_CLK            _L(1)
+#define PINMUX_PB03B_USART1_CLK    ((PIN_PB03B_USART1_CLK << 16) | MUX_PB03B_USART1_CLK)
+#define GPIO_PB03B_USART1_CLK    _UL(1 <<  3)
+#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L(0)
+#define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
+#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
+#define PIN_PC25A_USART1_CLK           _L(89) /**< \brief USART1 signal: CLK on PC25 mux A */
+#define MUX_PC25A_USART1_CLK            _L(0)
+#define PINMUX_PC25A_USART1_CLK    ((PIN_PC25A_USART1_CLK << 16) | MUX_PC25A_USART1_CLK)
+#define GPIO_PC25A_USART1_CLK    _UL(1 << 25)
+#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L(1)
+#define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
+#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
+#define PIN_PB02B_USART1_RTS           _L(34) /**< \brief USART1 signal: RTS on PB02 mux B */
+#define MUX_PB02B_USART1_RTS            _L(1)
+#define PINMUX_PB02B_USART1_RTS    ((PIN_PB02B_USART1_RTS << 16) | MUX_PB02B_USART1_RTS)
+#define GPIO_PB02B_USART1_RTS    _UL(1 <<  2)
+#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L(0)
+#define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
+#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
+#define PIN_PC24A_USART1_RTS           _L(88) /**< \brief USART1 signal: RTS on PC24 mux A */
+#define MUX_PC24A_USART1_RTS            _L(0)
+#define PINMUX_PC24A_USART1_RTS    ((PIN_PC24A_USART1_RTS << 16) | MUX_PC24A_USART1_RTS)
+#define GPIO_PC24A_USART1_RTS    _UL(1 << 24)
+#define PIN_PB04B_USART1_RXD           _L(36) /**< \brief USART1 signal: RXD on PB04 mux B */
+#define MUX_PB04B_USART1_RXD            _L(1)
+#define PINMUX_PB04B_USART1_RXD    ((PIN_PB04B_USART1_RXD << 16) | MUX_PB04B_USART1_RXD)
+#define GPIO_PB04B_USART1_RXD    _UL(1 <<  4)
+#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L(0)
+#define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
+#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
+#define PIN_PC26A_USART1_RXD           _L(90) /**< \brief USART1 signal: RXD on PC26 mux A */
+#define MUX_PC26A_USART1_RXD            _L(0)
+#define PINMUX_PC26A_USART1_RXD    ((PIN_PC26A_USART1_RXD << 16) | MUX_PC26A_USART1_RXD)
+#define GPIO_PC26A_USART1_RXD    _UL(1 << 26)
+#define PIN_PB05B_USART1_TXD           _L(37) /**< \brief USART1 signal: TXD on PB05 mux B */
+#define MUX_PB05B_USART1_TXD            _L(1)
+#define PINMUX_PB05B_USART1_TXD    ((PIN_PB05B_USART1_TXD << 16) | MUX_PB05B_USART1_TXD)
+#define GPIO_PB05B_USART1_TXD    _UL(1 <<  5)
+#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L(0)
+#define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
+#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+#define PIN_PC27A_USART1_TXD           _L(91) /**< \brief USART1 signal: TXD on PC27 mux A */
+#define MUX_PC27A_USART1_TXD            _L(0)
+#define PINMUX_PC27A_USART1_TXD    ((PIN_PC27A_USART1_TXD << 16) | MUX_PC27A_USART1_TXD)
+#define GPIO_PC27A_USART1_TXD    _UL(1 << 27)
+/* ========== GPIO definition for USART2 peripheral ========== */
+#define PIN_PC08B_USART2_CLK           _L(72) /**< \brief USART2 signal: CLK on PC08 mux B */
+#define MUX_PC08B_USART2_CLK            _L(1)
+#define PINMUX_PC08B_USART2_CLK    ((PIN_PC08B_USART2_CLK << 16) | MUX_PC08B_USART2_CLK)
+#define GPIO_PC08B_USART2_CLK    _UL(1 <<  8)
+#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L(0)
+#define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
+#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
+#define PIN_PC08E_USART2_CTS           _L(72) /**< \brief USART2 signal: CTS on PC08 mux E */
+#define MUX_PC08E_USART2_CTS            _L(4)
+#define PINMUX_PC08E_USART2_CTS    ((PIN_PC08E_USART2_CTS << 16) | MUX_PC08E_USART2_CTS)
+#define GPIO_PC08E_USART2_CTS    _UL(1 <<  8)
+#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L(1)
+#define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
+#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
+#define PIN_PC07B_USART2_RTS           _L(71) /**< \brief USART2 signal: RTS on PC07 mux B */
+#define MUX_PC07B_USART2_RTS            _L(1)
+#define PINMUX_PC07B_USART2_RTS    ((PIN_PC07B_USART2_RTS << 16) | MUX_PC07B_USART2_RTS)
+#define GPIO_PC07B_USART2_RTS    _UL(1 <<  7)
+#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L(0)
+#define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
+#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L(1)
+#define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
+#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
+#define PIN_PC11B_USART2_RXD           _L(75) /**< \brief USART2 signal: RXD on PC11 mux B */
+#define MUX_PC11B_USART2_RXD            _L(1)
+#define PINMUX_PC11B_USART2_RXD    ((PIN_PC11B_USART2_RXD << 16) | MUX_PC11B_USART2_RXD)
+#define GPIO_PC11B_USART2_RXD    _UL(1 << 11)
+#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L(0)
+#define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
+#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L(1)
+#define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
+#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
+#define PIN_PC12B_USART2_TXD           _L(76) /**< \brief USART2 signal: TXD on PC12 mux B */
+#define MUX_PC12B_USART2_TXD            _L(1)
+#define PINMUX_PC12B_USART2_TXD    ((PIN_PC12B_USART2_TXD << 16) | MUX_PC12B_USART2_TXD)
+#define GPIO_PC12B_USART2_TXD    _UL(1 << 12)
+#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L(0)
+#define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
+#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+/* ========== GPIO definition for USART3 peripheral ========== */
+#define PIN_PC14B_USART3_CLK           _L(78) /**< \brief USART3 signal: CLK on PC14 mux B */
+#define MUX_PC14B_USART3_CLK            _L(1)
+#define PINMUX_PC14B_USART3_CLK    ((PIN_PC14B_USART3_CLK << 16) | MUX_PC14B_USART3_CLK)
+#define GPIO_PC14B_USART3_CLK    _UL(1 << 14)
+#define PIN_PB08A_USART3_CLK           _L(40) /**< \brief USART3 signal: CLK on PB08 mux A */
+#define MUX_PB08A_USART3_CLK            _L(0)
+#define PINMUX_PB08A_USART3_CLK    ((PIN_PB08A_USART3_CLK << 16) | MUX_PB08A_USART3_CLK)
+#define GPIO_PB08A_USART3_CLK    _UL(1 <<  8)
+#define PIN_PC31A_USART3_CLK           _L(95) /**< \brief USART3 signal: CLK on PC31 mux A */
+#define MUX_PC31A_USART3_CLK            _L(0)
+#define PINMUX_PC31A_USART3_CLK    ((PIN_PC31A_USART3_CLK << 16) | MUX_PC31A_USART3_CLK)
+#define GPIO_PC31A_USART3_CLK    _UL(1 << 31)
+#define PIN_PB07A_USART3_CTS           _L(39) /**< \brief USART3 signal: CTS on PB07 mux A */
+#define MUX_PB07A_USART3_CTS            _L(0)
+#define PINMUX_PB07A_USART3_CTS    ((PIN_PB07A_USART3_CTS << 16) | MUX_PB07A_USART3_CTS)
+#define GPIO_PB07A_USART3_CTS    _UL(1 <<  7)
+#define PIN_PC13B_USART3_RTS           _L(77) /**< \brief USART3 signal: RTS on PC13 mux B */
+#define MUX_PC13B_USART3_RTS            _L(1)
+#define PINMUX_PC13B_USART3_RTS    ((PIN_PC13B_USART3_RTS << 16) | MUX_PC13B_USART3_RTS)
+#define GPIO_PC13B_USART3_RTS    _UL(1 << 13)
+#define PIN_PB06A_USART3_RTS           _L(38) /**< \brief USART3 signal: RTS on PB06 mux A */
+#define MUX_PB06A_USART3_RTS            _L(0)
+#define PINMUX_PB06A_USART3_RTS    ((PIN_PB06A_USART3_RTS << 16) | MUX_PB06A_USART3_RTS)
+#define GPIO_PB06A_USART3_RTS    _UL(1 <<  6)
+#define PIN_PC30A_USART3_RTS           _L(94) /**< \brief USART3 signal: RTS on PC30 mux A */
+#define MUX_PC30A_USART3_RTS            _L(0)
+#define PINMUX_PC30A_USART3_RTS    ((PIN_PC30A_USART3_RTS << 16) | MUX_PC30A_USART3_RTS)
+#define GPIO_PC30A_USART3_RTS    _UL(1 << 30)
+#define PIN_PC09B_USART3_RXD           _L(73) /**< \brief USART3 signal: RXD on PC09 mux B */
+#define MUX_PC09B_USART3_RXD            _L(1)
+#define PINMUX_PC09B_USART3_RXD    ((PIN_PC09B_USART3_RXD << 16) | MUX_PC09B_USART3_RXD)
+#define GPIO_PC09B_USART3_RXD    _UL(1 <<  9)
+#define PIN_PB09A_USART3_RXD           _L(41) /**< \brief USART3 signal: RXD on PB09 mux A */
+#define MUX_PB09A_USART3_RXD            _L(0)
+#define PINMUX_PB09A_USART3_RXD    ((PIN_PB09A_USART3_RXD << 16) | MUX_PB09A_USART3_RXD)
+#define GPIO_PB09A_USART3_RXD    _UL(1 <<  9)
+#define PIN_PC28A_USART3_RXD           _L(92) /**< \brief USART3 signal: RXD on PC28 mux A */
+#define MUX_PC28A_USART3_RXD            _L(0)
+#define PINMUX_PC28A_USART3_RXD    ((PIN_PC28A_USART3_RXD << 16) | MUX_PC28A_USART3_RXD)
+#define GPIO_PC28A_USART3_RXD    _UL(1 << 28)
+#define PIN_PC10B_USART3_TXD           _L(74) /**< \brief USART3 signal: TXD on PC10 mux B */
+#define MUX_PC10B_USART3_TXD            _L(1)
+#define PINMUX_PC10B_USART3_TXD    ((PIN_PC10B_USART3_TXD << 16) | MUX_PC10B_USART3_TXD)
+#define GPIO_PC10B_USART3_TXD    _UL(1 << 10)
+#define PIN_PB10A_USART3_TXD           _L(42) /**< \brief USART3 signal: TXD on PB10 mux A */
+#define MUX_PB10A_USART3_TXD            _L(0)
+#define PINMUX_PB10A_USART3_TXD    ((PIN_PB10A_USART3_TXD << 16) | MUX_PB10A_USART3_TXD)
+#define GPIO_PB10A_USART3_TXD    _UL(1 << 10)
+#define PIN_PC29A_USART3_TXD           _L(93) /**< \brief USART3 signal: TXD on PC29 mux A */
+#define MUX_PC29A_USART3_TXD            _L(0)
+#define PINMUX_PC29A_USART3_TXD    ((PIN_PC29A_USART3_TXD << 16) | MUX_PC29A_USART3_TXD)
+#define GPIO_PC29A_USART3_TXD    _UL(1 << 29)
+/* ========== GPIO definition for ADCIFE peripheral ========== */
+#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
+#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
+#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
+#define PIN_PB02A_ADCIFE_AD3           _L(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
+#define MUX_PB02A_ADCIFE_AD3            _L(0)
+#define PINMUX_PB02A_ADCIFE_AD3    ((PIN_PB02A_ADCIFE_AD3 << 16) | MUX_PB02A_ADCIFE_AD3)
+#define GPIO_PB02A_ADCIFE_AD3    _UL(1 <<  2)
+#define PIN_PB03A_ADCIFE_AD4           _L(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
+#define MUX_PB03A_ADCIFE_AD4            _L(0)
+#define PINMUX_PB03A_ADCIFE_AD4    ((PIN_PB03A_ADCIFE_AD4 << 16) | MUX_PB03A_ADCIFE_AD4)
+#define GPIO_PB03A_ADCIFE_AD4    _UL(1 <<  3)
+#define PIN_PB04A_ADCIFE_AD5           _L(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
+#define MUX_PB04A_ADCIFE_AD5            _L(0)
+#define PINMUX_PB04A_ADCIFE_AD5    ((PIN_PB04A_ADCIFE_AD5 << 16) | MUX_PB04A_ADCIFE_AD5)
+#define GPIO_PB04A_ADCIFE_AD5    _UL(1 <<  4)
+#define PIN_PB05A_ADCIFE_AD6           _L(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
+#define MUX_PB05A_ADCIFE_AD6            _L(0)
+#define PINMUX_PB05A_ADCIFE_AD6    ((PIN_PB05A_ADCIFE_AD6 << 16) | MUX_PB05A_ADCIFE_AD6)
+#define GPIO_PB05A_ADCIFE_AD6    _UL(1 <<  5)
+#define PIN_PC07A_ADCIFE_AD7           _L(71) /**< \brief ADCIFE signal: AD7 on PC07 mux A */
+#define MUX_PC07A_ADCIFE_AD7            _L(0)
+#define PINMUX_PC07A_ADCIFE_AD7    ((PIN_PC07A_ADCIFE_AD7 << 16) | MUX_PC07A_ADCIFE_AD7)
+#define GPIO_PC07A_ADCIFE_AD7    _UL(1 <<  7)
+#define PIN_PC08A_ADCIFE_AD8           _L(72) /**< \brief ADCIFE signal: AD8 on PC08 mux A */
+#define MUX_PC08A_ADCIFE_AD8            _L(0)
+#define PINMUX_PC08A_ADCIFE_AD8    ((PIN_PC08A_ADCIFE_AD8 << 16) | MUX_PC08A_ADCIFE_AD8)
+#define GPIO_PC08A_ADCIFE_AD8    _UL(1 <<  8)
+#define PIN_PC09A_ADCIFE_AD9           _L(73) /**< \brief ADCIFE signal: AD9 on PC09 mux A */
+#define MUX_PC09A_ADCIFE_AD9            _L(0)
+#define PINMUX_PC09A_ADCIFE_AD9    ((PIN_PC09A_ADCIFE_AD9 << 16) | MUX_PC09A_ADCIFE_AD9)
+#define GPIO_PC09A_ADCIFE_AD9    _UL(1 <<  9)
+#define PIN_PC10A_ADCIFE_AD10          _L(74) /**< \brief ADCIFE signal: AD10 on PC10 mux A */
+#define MUX_PC10A_ADCIFE_AD10           _L(0)
+#define PINMUX_PC10A_ADCIFE_AD10   ((PIN_PC10A_ADCIFE_AD10 << 16) | MUX_PC10A_ADCIFE_AD10)
+#define GPIO_PC10A_ADCIFE_AD10   _UL(1 << 10)
+#define PIN_PC11A_ADCIFE_AD11          _L(75) /**< \brief ADCIFE signal: AD11 on PC11 mux A */
+#define MUX_PC11A_ADCIFE_AD11           _L(0)
+#define PINMUX_PC11A_ADCIFE_AD11   ((PIN_PC11A_ADCIFE_AD11 << 16) | MUX_PC11A_ADCIFE_AD11)
+#define GPIO_PC11A_ADCIFE_AD11   _UL(1 << 11)
+#define PIN_PC12A_ADCIFE_AD12          _L(76) /**< \brief ADCIFE signal: AD12 on PC12 mux A */
+#define MUX_PC12A_ADCIFE_AD12           _L(0)
+#define PINMUX_PC12A_ADCIFE_AD12   ((PIN_PC12A_ADCIFE_AD12 << 16) | MUX_PC12A_ADCIFE_AD12)
+#define GPIO_PC12A_ADCIFE_AD12   _UL(1 << 12)
+#define PIN_PC13A_ADCIFE_AD13          _L(77) /**< \brief ADCIFE signal: AD13 on PC13 mux A */
+#define MUX_PC13A_ADCIFE_AD13           _L(0)
+#define PINMUX_PC13A_ADCIFE_AD13   ((PIN_PC13A_ADCIFE_AD13 << 16) | MUX_PC13A_ADCIFE_AD13)
+#define GPIO_PC13A_ADCIFE_AD13   _UL(1 << 13)
+#define PIN_PC14A_ADCIFE_AD14          _L(78) /**< \brief ADCIFE signal: AD14 on PC14 mux A */
+#define MUX_PC14A_ADCIFE_AD14           _L(0)
+#define PINMUX_PC14A_ADCIFE_AD14   ((PIN_PC14A_ADCIFE_AD14 << 16) | MUX_PC14A_ADCIFE_AD14)
+#define GPIO_PC14A_ADCIFE_AD14   _UL(1 << 14)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+/* ========== GPIO definition for DACC peripheral ========== */
+#define PIN_PB04E_DACC_EXT_TRIG0       _L(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
+#define MUX_PB04E_DACC_EXT_TRIG0        _L(4)
+#define PINMUX_PB04E_DACC_EXT_TRIG0  ((PIN_PB04E_DACC_EXT_TRIG0 << 16) | MUX_PB04E_DACC_EXT_TRIG0)
+#define GPIO_PB04E_DACC_EXT_TRIG0  _UL(1 <<  4)
+#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L(0)
+#define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
+#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+/* ========== GPIO definition for ACIFC peripheral ========== */
+#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
+#define PIN_PC09E_ACIFC_ACAN1          _L(73) /**< \brief ACIFC signal: ACAN1 on PC09 mux E */
+#define MUX_PC09E_ACIFC_ACAN1           _L(4)
+#define PINMUX_PC09E_ACIFC_ACAN1   ((PIN_PC09E_ACIFC_ACAN1 << 16) | MUX_PC09E_ACIFC_ACAN1)
+#define GPIO_PC09E_ACIFC_ACAN1   _UL(1 <<  9)
+#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
+#define PIN_PC10E_ACIFC_ACAP1          _L(74) /**< \brief ACIFC signal: ACAP1 on PC10 mux E */
+#define MUX_PC10E_ACIFC_ACAP1           _L(4)
+#define PINMUX_PC10E_ACIFC_ACAP1   ((PIN_PC10E_ACIFC_ACAP1 << 16) | MUX_PC10E_ACIFC_ACAP1)
+#define GPIO_PC10E_ACIFC_ACAP1   _UL(1 << 10)
+#define PIN_PB02E_ACIFC_ACBN0          _L(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
+#define MUX_PB02E_ACIFC_ACBN0           _L(4)
+#define PINMUX_PB02E_ACIFC_ACBN0   ((PIN_PB02E_ACIFC_ACBN0 << 16) | MUX_PB02E_ACIFC_ACBN0)
+#define GPIO_PB02E_ACIFC_ACBN0   _UL(1 <<  2)
+#define PIN_PC13E_ACIFC_ACBN1          _L(77) /**< \brief ACIFC signal: ACBN1 on PC13 mux E */
+#define MUX_PC13E_ACIFC_ACBN1           _L(4)
+#define PINMUX_PC13E_ACIFC_ACBN1   ((PIN_PC13E_ACIFC_ACBN1 << 16) | MUX_PC13E_ACIFC_ACBN1)
+#define GPIO_PC13E_ACIFC_ACBN1   _UL(1 << 13)
+#define PIN_PB03E_ACIFC_ACBP0          _L(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
+#define MUX_PB03E_ACIFC_ACBP0           _L(4)
+#define PINMUX_PB03E_ACIFC_ACBP0   ((PIN_PB03E_ACIFC_ACBP0 << 16) | MUX_PB03E_ACIFC_ACBP0)
+#define GPIO_PB03E_ACIFC_ACBP0   _UL(1 <<  3)
+#define PIN_PC14E_ACIFC_ACBP1          _L(78) /**< \brief ACIFC signal: ACBP1 on PC14 mux E */
+#define MUX_PC14E_ACIFC_ACBP1           _L(4)
+#define PINMUX_PC14E_ACIFC_ACBP1   ((PIN_PC14E_ACIFC_ACBP1 << 16) | MUX_PC14E_ACIFC_ACBP1)
+#define GPIO_PC14E_ACIFC_ACBP1   _UL(1 << 14)
+/* ========== GPIO definition for GLOC peripheral ========== */
+#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
+#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L(3)
+#define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
+#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L(3)
+#define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
+#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L(3)
+#define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
+#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L(3)
+#define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
+#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L(3)
+#define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
+#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L(3)
+#define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
+#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L(3)
+#define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
+#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
+#define PIN_PC15D_GLOC_IN4             _L(79) /**< \brief GLOC signal: IN4 on PC15 mux D */
+#define MUX_PC15D_GLOC_IN4              _L(3)
+#define PINMUX_PC15D_GLOC_IN4      ((PIN_PC15D_GLOC_IN4 << 16) | MUX_PC15D_GLOC_IN4)
+#define GPIO_PC15D_GLOC_IN4      _UL(1 << 15)
+#define PIN_PB06C_GLOC_IN4             _L(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
+#define MUX_PB06C_GLOC_IN4              _L(2)
+#define PINMUX_PB06C_GLOC_IN4      ((PIN_PB06C_GLOC_IN4 << 16) | MUX_PB06C_GLOC_IN4)
+#define GPIO_PB06C_GLOC_IN4      _UL(1 <<  6)
+#define PIN_PC28C_GLOC_IN4             _L(92) /**< \brief GLOC signal: IN4 on PC28 mux C */
+#define MUX_PC28C_GLOC_IN4              _L(2)
+#define PINMUX_PC28C_GLOC_IN4      ((PIN_PC28C_GLOC_IN4 << 16) | MUX_PC28C_GLOC_IN4)
+#define GPIO_PC28C_GLOC_IN4      _UL(1 << 28)
+#define PIN_PC16D_GLOC_IN5             _L(80) /**< \brief GLOC signal: IN5 on PC16 mux D */
+#define MUX_PC16D_GLOC_IN5              _L(3)
+#define PINMUX_PC16D_GLOC_IN5      ((PIN_PC16D_GLOC_IN5 << 16) | MUX_PC16D_GLOC_IN5)
+#define GPIO_PC16D_GLOC_IN5      _UL(1 << 16)
+#define PIN_PB07C_GLOC_IN5             _L(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
+#define MUX_PB07C_GLOC_IN5              _L(2)
+#define PINMUX_PB07C_GLOC_IN5      ((PIN_PB07C_GLOC_IN5 << 16) | MUX_PB07C_GLOC_IN5)
+#define GPIO_PB07C_GLOC_IN5      _UL(1 <<  7)
+#define PIN_PC29C_GLOC_IN5             _L(93) /**< \brief GLOC signal: IN5 on PC29 mux C */
+#define MUX_PC29C_GLOC_IN5              _L(2)
+#define PINMUX_PC29C_GLOC_IN5      ((PIN_PC29C_GLOC_IN5 << 16) | MUX_PC29C_GLOC_IN5)
+#define GPIO_PC29C_GLOC_IN5      _UL(1 << 29)
+#define PIN_PC17D_GLOC_IN6             _L(81) /**< \brief GLOC signal: IN6 on PC17 mux D */
+#define MUX_PC17D_GLOC_IN6              _L(3)
+#define PINMUX_PC17D_GLOC_IN6      ((PIN_PC17D_GLOC_IN6 << 16) | MUX_PC17D_GLOC_IN6)
+#define GPIO_PC17D_GLOC_IN6      _UL(1 << 17)
+#define PIN_PB08C_GLOC_IN6             _L(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
+#define MUX_PB08C_GLOC_IN6              _L(2)
+#define PINMUX_PB08C_GLOC_IN6      ((PIN_PB08C_GLOC_IN6 << 16) | MUX_PB08C_GLOC_IN6)
+#define GPIO_PB08C_GLOC_IN6      _UL(1 <<  8)
+#define PIN_PC30C_GLOC_IN6             _L(94) /**< \brief GLOC signal: IN6 on PC30 mux C */
+#define MUX_PC30C_GLOC_IN6              _L(2)
+#define PINMUX_PC30C_GLOC_IN6      ((PIN_PC30C_GLOC_IN6 << 16) | MUX_PC30C_GLOC_IN6)
+#define GPIO_PC30C_GLOC_IN6      _UL(1 << 30)
+#define PIN_PC18D_GLOC_IN7             _L(82) /**< \brief GLOC signal: IN7 on PC18 mux D */
+#define MUX_PC18D_GLOC_IN7              _L(3)
+#define PINMUX_PC18D_GLOC_IN7      ((PIN_PC18D_GLOC_IN7 << 16) | MUX_PC18D_GLOC_IN7)
+#define GPIO_PC18D_GLOC_IN7      _UL(1 << 18)
+#define PIN_PB09C_GLOC_IN7             _L(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
+#define MUX_PB09C_GLOC_IN7              _L(2)
+#define PINMUX_PB09C_GLOC_IN7      ((PIN_PB09C_GLOC_IN7 << 16) | MUX_PB09C_GLOC_IN7)
+#define GPIO_PB09C_GLOC_IN7      _UL(1 <<  9)
+#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
+#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
+#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
+#define PIN_PC19D_GLOC_OUT1            _L(83) /**< \brief GLOC signal: OUT1 on PC19 mux D */
+#define MUX_PC19D_GLOC_OUT1             _L(3)
+#define PINMUX_PC19D_GLOC_OUT1     ((PIN_PC19D_GLOC_OUT1 << 16) | MUX_PC19D_GLOC_OUT1)
+#define GPIO_PC19D_GLOC_OUT1     _UL(1 << 19)
+#define PIN_PB10C_GLOC_OUT1            _L(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
+#define MUX_PB10C_GLOC_OUT1             _L(2)
+#define PINMUX_PB10C_GLOC_OUT1     ((PIN_PB10C_GLOC_OUT1 << 16) | MUX_PB10C_GLOC_OUT1)
+#define GPIO_PB10C_GLOC_OUT1     _UL(1 << 10)
+#define PIN_PC31C_GLOC_OUT1            _L(95) /**< \brief GLOC signal: OUT1 on PC31 mux C */
+#define MUX_PC31C_GLOC_OUT1             _L(2)
+#define PINMUX_PC31C_GLOC_OUT1     ((PIN_PC31C_GLOC_OUT1 << 16) | MUX_PC31C_GLOC_OUT1)
+#define GPIO_PC31C_GLOC_OUT1     _UL(1 << 31)
+/* ========== GPIO definition for ABDACB peripheral ========== */
+#define PIN_PC12C_ABDACB_CLK           _L(76) /**< \brief ABDACB signal: CLK on PC12 mux C */
+#define MUX_PC12C_ABDACB_CLK            _L(2)
+#define PINMUX_PC12C_ABDACB_CLK    ((PIN_PC12C_ABDACB_CLK << 16) | MUX_PC12C_ABDACB_CLK)
+#define GPIO_PC12C_ABDACB_CLK    _UL(1 << 12)
+#define PIN_PB02C_ABDACB_DAC0          _L(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
+#define MUX_PB02C_ABDACB_DAC0           _L(2)
+#define PINMUX_PB02C_ABDACB_DAC0   ((PIN_PB02C_ABDACB_DAC0 << 16) | MUX_PB02C_ABDACB_DAC0)
+#define GPIO_PB02C_ABDACB_DAC0   _UL(1 <<  2)
+#define PIN_PC09C_ABDACB_DAC0          _L(73) /**< \brief ABDACB signal: DAC0 on PC09 mux C */
+#define MUX_PC09C_ABDACB_DAC0           _L(2)
+#define PINMUX_PC09C_ABDACB_DAC0   ((PIN_PC09C_ABDACB_DAC0 << 16) | MUX_PC09C_ABDACB_DAC0)
+#define GPIO_PC09C_ABDACB_DAC0   _UL(1 <<  9)
+#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
+#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
+#define PIN_PB04C_ABDACB_DAC1          _L(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
+#define MUX_PB04C_ABDACB_DAC1           _L(2)
+#define PINMUX_PB04C_ABDACB_DAC1   ((PIN_PB04C_ABDACB_DAC1 << 16) | MUX_PB04C_ABDACB_DAC1)
+#define GPIO_PB04C_ABDACB_DAC1   _UL(1 <<  4)
+#define PIN_PC13C_ABDACB_DAC1          _L(77) /**< \brief ABDACB signal: DAC1 on PC13 mux C */
+#define MUX_PC13C_ABDACB_DAC1           _L(2)
+#define PINMUX_PC13C_ABDACB_DAC1   ((PIN_PC13C_ABDACB_DAC1 << 16) | MUX_PC13C_ABDACB_DAC1)
+#define GPIO_PC13C_ABDACB_DAC1   _UL(1 << 13)
+#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
+#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
+#define PIN_PB03C_ABDACB_DACN0         _L(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
+#define MUX_PB03C_ABDACB_DACN0          _L(2)
+#define PINMUX_PB03C_ABDACB_DACN0  ((PIN_PB03C_ABDACB_DACN0 << 16) | MUX_PB03C_ABDACB_DACN0)
+#define GPIO_PB03C_ABDACB_DACN0  _UL(1 <<  3)
+#define PIN_PC10C_ABDACB_DACN0         _L(74) /**< \brief ABDACB signal: DACN0 on PC10 mux C */
+#define MUX_PC10C_ABDACB_DACN0          _L(2)
+#define PINMUX_PC10C_ABDACB_DACN0  ((PIN_PC10C_ABDACB_DACN0 << 16) | MUX_PC10C_ABDACB_DACN0)
+#define GPIO_PC10C_ABDACB_DACN0  _UL(1 << 10)
+#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
+#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
+#define PIN_PB05C_ABDACB_DACN1         _L(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
+#define MUX_PB05C_ABDACB_DACN1          _L(2)
+#define PINMUX_PB05C_ABDACB_DACN1  ((PIN_PB05C_ABDACB_DACN1 << 16) | MUX_PB05C_ABDACB_DACN1)
+#define GPIO_PB05C_ABDACB_DACN1  _UL(1 <<  5)
+#define PIN_PC14C_ABDACB_DACN1         _L(78) /**< \brief ABDACB signal: DACN1 on PC14 mux C */
+#define MUX_PC14C_ABDACB_DACN1          _L(2)
+#define PINMUX_PC14C_ABDACB_DACN1  ((PIN_PC14C_ABDACB_DACN1 << 16) | MUX_PC14C_ABDACB_DACN1)
+#define GPIO_PC14C_ABDACB_DACN1  _UL(1 << 14)
+#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
+#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+/* ========== GPIO definition for PARC peripheral ========== */
+#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
+#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
+#define PIN_PC21D_PARC_PCCK            _L(85) /**< \brief PARC signal: PCCK on PC21 mux D */
+#define MUX_PC21D_PARC_PCCK             _L(3)
+#define PINMUX_PC21D_PARC_PCCK     ((PIN_PC21D_PARC_PCCK << 16) | MUX_PC21D_PARC_PCCK)
+#define GPIO_PC21D_PARC_PCCK     _UL(1 << 21)
+#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
+#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
+#define PIN_PC24D_PARC_PCDATA0         _L(88) /**< \brief PARC signal: PCDATA0 on PC24 mux D */
+#define MUX_PC24D_PARC_PCDATA0          _L(3)
+#define PINMUX_PC24D_PARC_PCDATA0  ((PIN_PC24D_PARC_PCDATA0 << 16) | MUX_PC24D_PARC_PCDATA0)
+#define GPIO_PC24D_PARC_PCDATA0  _UL(1 << 24)
+#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
+#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
+#define PIN_PC25D_PARC_PCDATA1         _L(89) /**< \brief PARC signal: PCDATA1 on PC25 mux D */
+#define MUX_PC25D_PARC_PCDATA1          _L(3)
+#define PINMUX_PC25D_PARC_PCDATA1  ((PIN_PC25D_PARC_PCDATA1 << 16) | MUX_PC25D_PARC_PCDATA1)
+#define GPIO_PC25D_PARC_PCDATA1  _UL(1 << 25)
+#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
+#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
+#define PIN_PC26D_PARC_PCDATA2         _L(90) /**< \brief PARC signal: PCDATA2 on PC26 mux D */
+#define MUX_PC26D_PARC_PCDATA2          _L(3)
+#define PINMUX_PC26D_PARC_PCDATA2  ((PIN_PC26D_PARC_PCDATA2 << 16) | MUX_PC26D_PARC_PCDATA2)
+#define GPIO_PC26D_PARC_PCDATA2  _UL(1 << 26)
+#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
+#define PIN_PC27D_PARC_PCDATA3         _L(91) /**< \brief PARC signal: PCDATA3 on PC27 mux D */
+#define MUX_PC27D_PARC_PCDATA3          _L(3)
+#define PINMUX_PC27D_PARC_PCDATA3  ((PIN_PC27D_PARC_PCDATA3 << 16) | MUX_PC27D_PARC_PCDATA3)
+#define GPIO_PC27D_PARC_PCDATA3  _UL(1 << 27)
+#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
+#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
+#define PIN_PC28D_PARC_PCDATA4         _L(92) /**< \brief PARC signal: PCDATA4 on PC28 mux D */
+#define MUX_PC28D_PARC_PCDATA4          _L(3)
+#define PINMUX_PC28D_PARC_PCDATA4  ((PIN_PC28D_PARC_PCDATA4 << 16) | MUX_PC28D_PARC_PCDATA4)
+#define GPIO_PC28D_PARC_PCDATA4  _UL(1 << 28)
+#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
+#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
+#define PIN_PC29D_PARC_PCDATA5         _L(93) /**< \brief PARC signal: PCDATA5 on PC29 mux D */
+#define MUX_PC29D_PARC_PCDATA5          _L(3)
+#define PINMUX_PC29D_PARC_PCDATA5  ((PIN_PC29D_PARC_PCDATA5 << 16) | MUX_PC29D_PARC_PCDATA5)
+#define GPIO_PC29D_PARC_PCDATA5  _UL(1 << 29)
+#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
+#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
+#define PIN_PC30D_PARC_PCDATA6         _L(94) /**< \brief PARC signal: PCDATA6 on PC30 mux D */
+#define MUX_PC30D_PARC_PCDATA6          _L(3)
+#define PINMUX_PC30D_PARC_PCDATA6  ((PIN_PC30D_PARC_PCDATA6 << 16) | MUX_PC30D_PARC_PCDATA6)
+#define GPIO_PC30D_PARC_PCDATA6  _UL(1 << 30)
+#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
+#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
+#define PIN_PC31D_PARC_PCDATA7         _L(95) /**< \brief PARC signal: PCDATA7 on PC31 mux D */
+#define MUX_PC31D_PARC_PCDATA7          _L(3)
+#define PINMUX_PC31D_PARC_PCDATA7  ((PIN_PC31D_PARC_PCDATA7 << 16) | MUX_PC31D_PARC_PCDATA7)
+#define GPIO_PC31D_PARC_PCDATA7  _UL(1 << 31)
+#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
+#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
+#define PIN_PC22D_PARC_PCEN1           _L(86) /**< \brief PARC signal: PCEN1 on PC22 mux D */
+#define MUX_PC22D_PARC_PCEN1            _L(3)
+#define PINMUX_PC22D_PARC_PCEN1    ((PIN_PC22D_PARC_PCEN1 << 16) | MUX_PC22D_PARC_PCEN1)
+#define GPIO_PC22D_PARC_PCEN1    _UL(1 << 22)
+#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
+#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+#define PIN_PC23D_PARC_PCEN2           _L(87) /**< \brief PARC signal: PCEN2 on PC23 mux D */
+#define MUX_PC23D_PARC_PCEN2            _L(3)
+#define PINMUX_PC23D_PARC_PCEN2    ((PIN_PC23D_PARC_PCEN2 << 16) | MUX_PC23D_PARC_PCEN2)
+#define GPIO_PC23D_PARC_PCEN2    _UL(1 << 23)
+/* ========== GPIO definition for CATB peripheral ========== */
+#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L(6)
+#define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
+#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L(6)
+#define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
+#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L(6)
+#define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
+#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
+#define PIN_PB03G_CATB_DIS             _L(35) /**< \brief CATB signal: DIS on PB03 mux G */
+#define MUX_PB03G_CATB_DIS              _L(6)
+#define PINMUX_PB03G_CATB_DIS      ((PIN_PB03G_CATB_DIS << 16) | MUX_PB03G_CATB_DIS)
+#define GPIO_PB03G_CATB_DIS      _UL(1 <<  3)
+#define PIN_PB12G_CATB_DIS             _L(44) /**< \brief CATB signal: DIS on PB12 mux G */
+#define MUX_PB12G_CATB_DIS              _L(6)
+#define PINMUX_PB12G_CATB_DIS      ((PIN_PB12G_CATB_DIS << 16) | MUX_PB12G_CATB_DIS)
+#define GPIO_PB12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PC05G_CATB_DIS             _L(69) /**< \brief CATB signal: DIS on PC05 mux G */
+#define MUX_PC05G_CATB_DIS              _L(6)
+#define PINMUX_PC05G_CATB_DIS      ((PIN_PC05G_CATB_DIS << 16) | MUX_PC05G_CATB_DIS)
+#define GPIO_PC05G_CATB_DIS      _UL(1 <<  5)
+#define PIN_PC14G_CATB_DIS             _L(78) /**< \brief CATB signal: DIS on PC14 mux G */
+#define MUX_PC14G_CATB_DIS              _L(6)
+#define PINMUX_PC14G_CATB_DIS      ((PIN_PC14G_CATB_DIS << 16) | MUX_PC14G_CATB_DIS)
+#define GPIO_PC14G_CATB_DIS      _UL(1 << 14)
+#define PIN_PC23G_CATB_DIS             _L(87) /**< \brief CATB signal: DIS on PC23 mux G */
+#define MUX_PC23G_CATB_DIS              _L(6)
+#define PINMUX_PC23G_CATB_DIS      ((PIN_PC23G_CATB_DIS << 16) | MUX_PC23G_CATB_DIS)
+#define GPIO_PC23G_CATB_DIS      _UL(1 << 23)
+#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
+#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
+#define PIN_PB13G_CATB_SENSE0          _L(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
+#define MUX_PB13G_CATB_SENSE0           _L(6)
+#define PINMUX_PB13G_CATB_SENSE0   ((PIN_PB13G_CATB_SENSE0 << 16) | MUX_PB13G_CATB_SENSE0)
+#define GPIO_PB13G_CATB_SENSE0   _UL(1 << 13)
+#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
+#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
+#define PIN_PB14G_CATB_SENSE1          _L(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
+#define MUX_PB14G_CATB_SENSE1           _L(6)
+#define PINMUX_PB14G_CATB_SENSE1   ((PIN_PB14G_CATB_SENSE1 << 16) | MUX_PB14G_CATB_SENSE1)
+#define GPIO_PB14G_CATB_SENSE1   _UL(1 << 14)
+#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
+#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
+#define PIN_PB15G_CATB_SENSE2          _L(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
+#define MUX_PB15G_CATB_SENSE2           _L(6)
+#define PINMUX_PB15G_CATB_SENSE2   ((PIN_PB15G_CATB_SENSE2 << 16) | MUX_PB15G_CATB_SENSE2)
+#define GPIO_PB15G_CATB_SENSE2   _UL(1 << 15)
+#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
+#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
+#define PIN_PC00G_CATB_SENSE3          _L(64) /**< \brief CATB signal: SENSE3 on PC00 mux G */
+#define MUX_PC00G_CATB_SENSE3           _L(6)
+#define PINMUX_PC00G_CATB_SENSE3   ((PIN_PC00G_CATB_SENSE3 << 16) | MUX_PC00G_CATB_SENSE3)
+#define GPIO_PC00G_CATB_SENSE3   _UL(1 <<  0)
+#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
+#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
+#define PIN_PC01G_CATB_SENSE4          _L(65) /**< \brief CATB signal: SENSE4 on PC01 mux G */
+#define MUX_PC01G_CATB_SENSE4           _L(6)
+#define PINMUX_PC01G_CATB_SENSE4   ((PIN_PC01G_CATB_SENSE4 << 16) | MUX_PC01G_CATB_SENSE4)
+#define GPIO_PC01G_CATB_SENSE4   _UL(1 <<  1)
+#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
+#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
+#define PIN_PC02G_CATB_SENSE5          _L(66) /**< \brief CATB signal: SENSE5 on PC02 mux G */
+#define MUX_PC02G_CATB_SENSE5           _L(6)
+#define PINMUX_PC02G_CATB_SENSE5   ((PIN_PC02G_CATB_SENSE5 << 16) | MUX_PC02G_CATB_SENSE5)
+#define GPIO_PC02G_CATB_SENSE5   _UL(1 <<  2)
+#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
+#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
+#define PIN_PC03G_CATB_SENSE6          _L(67) /**< \brief CATB signal: SENSE6 on PC03 mux G */
+#define MUX_PC03G_CATB_SENSE6           _L(6)
+#define PINMUX_PC03G_CATB_SENSE6   ((PIN_PC03G_CATB_SENSE6 << 16) | MUX_PC03G_CATB_SENSE6)
+#define GPIO_PC03G_CATB_SENSE6   _UL(1 <<  3)
+#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
+#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
+#define PIN_PC04G_CATB_SENSE7          _L(68) /**< \brief CATB signal: SENSE7 on PC04 mux G */
+#define MUX_PC04G_CATB_SENSE7           _L(6)
+#define PINMUX_PC04G_CATB_SENSE7   ((PIN_PC04G_CATB_SENSE7 << 16) | MUX_PC04G_CATB_SENSE7)
+#define GPIO_PC04G_CATB_SENSE7   _UL(1 <<  4)
+#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
+#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
+#define PIN_PC06G_CATB_SENSE8          _L(70) /**< \brief CATB signal: SENSE8 on PC06 mux G */
+#define MUX_PC06G_CATB_SENSE8           _L(6)
+#define PINMUX_PC06G_CATB_SENSE8   ((PIN_PC06G_CATB_SENSE8 << 16) | MUX_PC06G_CATB_SENSE8)
+#define GPIO_PC06G_CATB_SENSE8   _UL(1 <<  6)
+#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
+#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
+#define PIN_PC07G_CATB_SENSE9          _L(71) /**< \brief CATB signal: SENSE9 on PC07 mux G */
+#define MUX_PC07G_CATB_SENSE9           _L(6)
+#define PINMUX_PC07G_CATB_SENSE9   ((PIN_PC07G_CATB_SENSE9 << 16) | MUX_PC07G_CATB_SENSE9)
+#define GPIO_PC07G_CATB_SENSE9   _UL(1 <<  7)
+#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
+#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
+#define PIN_PC08G_CATB_SENSE10         _L(72) /**< \brief CATB signal: SENSE10 on PC08 mux G */
+#define MUX_PC08G_CATB_SENSE10          _L(6)
+#define PINMUX_PC08G_CATB_SENSE10  ((PIN_PC08G_CATB_SENSE10 << 16) | MUX_PC08G_CATB_SENSE10)
+#define GPIO_PC08G_CATB_SENSE10  _UL(1 <<  8)
+#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
+#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
+#define PIN_PC09G_CATB_SENSE11         _L(73) /**< \brief CATB signal: SENSE11 on PC09 mux G */
+#define MUX_PC09G_CATB_SENSE11          _L(6)
+#define PINMUX_PC09G_CATB_SENSE11  ((PIN_PC09G_CATB_SENSE11 << 16) | MUX_PC09G_CATB_SENSE11)
+#define GPIO_PC09G_CATB_SENSE11  _UL(1 <<  9)
+#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
+#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
+#define PIN_PC10G_CATB_SENSE12         _L(74) /**< \brief CATB signal: SENSE12 on PC10 mux G */
+#define MUX_PC10G_CATB_SENSE12          _L(6)
+#define PINMUX_PC10G_CATB_SENSE12  ((PIN_PC10G_CATB_SENSE12 << 16) | MUX_PC10G_CATB_SENSE12)
+#define GPIO_PC10G_CATB_SENSE12  _UL(1 << 10)
+#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
+#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
+#define PIN_PC11G_CATB_SENSE13         _L(75) /**< \brief CATB signal: SENSE13 on PC11 mux G */
+#define MUX_PC11G_CATB_SENSE13          _L(6)
+#define PINMUX_PC11G_CATB_SENSE13  ((PIN_PC11G_CATB_SENSE13 << 16) | MUX_PC11G_CATB_SENSE13)
+#define GPIO_PC11G_CATB_SENSE13  _UL(1 << 11)
+#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
+#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
+#define PIN_PC12G_CATB_SENSE14         _L(76) /**< \brief CATB signal: SENSE14 on PC12 mux G */
+#define MUX_PC12G_CATB_SENSE14          _L(6)
+#define PINMUX_PC12G_CATB_SENSE14  ((PIN_PC12G_CATB_SENSE14 << 16) | MUX_PC12G_CATB_SENSE14)
+#define GPIO_PC12G_CATB_SENSE14  _UL(1 << 12)
+#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
+#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
+#define PIN_PC13G_CATB_SENSE15         _L(77) /**< \brief CATB signal: SENSE15 on PC13 mux G */
+#define MUX_PC13G_CATB_SENSE15          _L(6)
+#define PINMUX_PC13G_CATB_SENSE15  ((PIN_PC13G_CATB_SENSE15 << 16) | MUX_PC13G_CATB_SENSE15)
+#define GPIO_PC13G_CATB_SENSE15  _UL(1 << 13)
+#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
+#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
+#define PIN_PC15G_CATB_SENSE16         _L(79) /**< \brief CATB signal: SENSE16 on PC15 mux G */
+#define MUX_PC15G_CATB_SENSE16          _L(6)
+#define PINMUX_PC15G_CATB_SENSE16  ((PIN_PC15G_CATB_SENSE16 << 16) | MUX_PC15G_CATB_SENSE16)
+#define GPIO_PC15G_CATB_SENSE16  _UL(1 << 15)
+#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
+#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
+#define PIN_PC16G_CATB_SENSE17         _L(80) /**< \brief CATB signal: SENSE17 on PC16 mux G */
+#define MUX_PC16G_CATB_SENSE17          _L(6)
+#define PINMUX_PC16G_CATB_SENSE17  ((PIN_PC16G_CATB_SENSE17 << 16) | MUX_PC16G_CATB_SENSE17)
+#define GPIO_PC16G_CATB_SENSE17  _UL(1 << 16)
+#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
+#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
+#define PIN_PC17G_CATB_SENSE18         _L(81) /**< \brief CATB signal: SENSE18 on PC17 mux G */
+#define MUX_PC17G_CATB_SENSE18          _L(6)
+#define PINMUX_PC17G_CATB_SENSE18  ((PIN_PC17G_CATB_SENSE18 << 16) | MUX_PC17G_CATB_SENSE18)
+#define GPIO_PC17G_CATB_SENSE18  _UL(1 << 17)
+#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
+#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
+#define PIN_PC18G_CATB_SENSE19         _L(82) /**< \brief CATB signal: SENSE19 on PC18 mux G */
+#define MUX_PC18G_CATB_SENSE19          _L(6)
+#define PINMUX_PC18G_CATB_SENSE19  ((PIN_PC18G_CATB_SENSE19 << 16) | MUX_PC18G_CATB_SENSE19)
+#define GPIO_PC18G_CATB_SENSE19  _UL(1 << 18)
+#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
+#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
+#define PIN_PC19G_CATB_SENSE20         _L(83) /**< \brief CATB signal: SENSE20 on PC19 mux G */
+#define MUX_PC19G_CATB_SENSE20          _L(6)
+#define PINMUX_PC19G_CATB_SENSE20  ((PIN_PC19G_CATB_SENSE20 << 16) | MUX_PC19G_CATB_SENSE20)
+#define GPIO_PC19G_CATB_SENSE20  _UL(1 << 19)
+#define PIN_PB00G_CATB_SENSE21         _L(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
+#define MUX_PB00G_CATB_SENSE21          _L(6)
+#define PINMUX_PB00G_CATB_SENSE21  ((PIN_PB00G_CATB_SENSE21 << 16) | MUX_PB00G_CATB_SENSE21)
+#define GPIO_PB00G_CATB_SENSE21  _UL(1 <<  0)
+#define PIN_PC20G_CATB_SENSE21         _L(84) /**< \brief CATB signal: SENSE21 on PC20 mux G */
+#define MUX_PC20G_CATB_SENSE21          _L(6)
+#define PINMUX_PC20G_CATB_SENSE21  ((PIN_PC20G_CATB_SENSE21 << 16) | MUX_PC20G_CATB_SENSE21)
+#define GPIO_PC20G_CATB_SENSE21  _UL(1 << 20)
+#define PIN_PB01G_CATB_SENSE22         _L(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
+#define MUX_PB01G_CATB_SENSE22          _L(6)
+#define PINMUX_PB01G_CATB_SENSE22  ((PIN_PB01G_CATB_SENSE22 << 16) | MUX_PB01G_CATB_SENSE22)
+#define GPIO_PB01G_CATB_SENSE22  _UL(1 <<  1)
+#define PIN_PC21G_CATB_SENSE22         _L(85) /**< \brief CATB signal: SENSE22 on PC21 mux G */
+#define MUX_PC21G_CATB_SENSE22          _L(6)
+#define PINMUX_PC21G_CATB_SENSE22  ((PIN_PC21G_CATB_SENSE22 << 16) | MUX_PC21G_CATB_SENSE22)
+#define GPIO_PC21G_CATB_SENSE22  _UL(1 << 21)
+#define PIN_PB02G_CATB_SENSE23         _L(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
+#define MUX_PB02G_CATB_SENSE23          _L(6)
+#define PINMUX_PB02G_CATB_SENSE23  ((PIN_PB02G_CATB_SENSE23 << 16) | MUX_PB02G_CATB_SENSE23)
+#define GPIO_PB02G_CATB_SENSE23  _UL(1 <<  2)
+#define PIN_PC22G_CATB_SENSE23         _L(86) /**< \brief CATB signal: SENSE23 on PC22 mux G */
+#define MUX_PC22G_CATB_SENSE23          _L(6)
+#define PINMUX_PC22G_CATB_SENSE23  ((PIN_PC22G_CATB_SENSE23 << 16) | MUX_PC22G_CATB_SENSE23)
+#define GPIO_PC22G_CATB_SENSE23  _UL(1 << 22)
+#define PIN_PB04G_CATB_SENSE24         _L(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
+#define MUX_PB04G_CATB_SENSE24          _L(6)
+#define PINMUX_PB04G_CATB_SENSE24  ((PIN_PB04G_CATB_SENSE24 << 16) | MUX_PB04G_CATB_SENSE24)
+#define GPIO_PB04G_CATB_SENSE24  _UL(1 <<  4)
+#define PIN_PC24G_CATB_SENSE24         _L(88) /**< \brief CATB signal: SENSE24 on PC24 mux G */
+#define MUX_PC24G_CATB_SENSE24          _L(6)
+#define PINMUX_PC24G_CATB_SENSE24  ((PIN_PC24G_CATB_SENSE24 << 16) | MUX_PC24G_CATB_SENSE24)
+#define GPIO_PC24G_CATB_SENSE24  _UL(1 << 24)
+#define PIN_PB05G_CATB_SENSE25         _L(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
+#define MUX_PB05G_CATB_SENSE25          _L(6)
+#define PINMUX_PB05G_CATB_SENSE25  ((PIN_PB05G_CATB_SENSE25 << 16) | MUX_PB05G_CATB_SENSE25)
+#define GPIO_PB05G_CATB_SENSE25  _UL(1 <<  5)
+#define PIN_PC25G_CATB_SENSE25         _L(89) /**< \brief CATB signal: SENSE25 on PC25 mux G */
+#define MUX_PC25G_CATB_SENSE25          _L(6)
+#define PINMUX_PC25G_CATB_SENSE25  ((PIN_PC25G_CATB_SENSE25 << 16) | MUX_PC25G_CATB_SENSE25)
+#define GPIO_PC25G_CATB_SENSE25  _UL(1 << 25)
+#define PIN_PB06G_CATB_SENSE26         _L(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
+#define MUX_PB06G_CATB_SENSE26          _L(6)
+#define PINMUX_PB06G_CATB_SENSE26  ((PIN_PB06G_CATB_SENSE26 << 16) | MUX_PB06G_CATB_SENSE26)
+#define GPIO_PB06G_CATB_SENSE26  _UL(1 <<  6)
+#define PIN_PC26G_CATB_SENSE26         _L(90) /**< \brief CATB signal: SENSE26 on PC26 mux G */
+#define MUX_PC26G_CATB_SENSE26          _L(6)
+#define PINMUX_PC26G_CATB_SENSE26  ((PIN_PC26G_CATB_SENSE26 << 16) | MUX_PC26G_CATB_SENSE26)
+#define GPIO_PC26G_CATB_SENSE26  _UL(1 << 26)
+#define PIN_PB07G_CATB_SENSE27         _L(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
+#define MUX_PB07G_CATB_SENSE27          _L(6)
+#define PINMUX_PB07G_CATB_SENSE27  ((PIN_PB07G_CATB_SENSE27 << 16) | MUX_PB07G_CATB_SENSE27)
+#define GPIO_PB07G_CATB_SENSE27  _UL(1 <<  7)
+#define PIN_PC27G_CATB_SENSE27         _L(91) /**< \brief CATB signal: SENSE27 on PC27 mux G */
+#define MUX_PC27G_CATB_SENSE27          _L(6)
+#define PINMUX_PC27G_CATB_SENSE27  ((PIN_PC27G_CATB_SENSE27 << 16) | MUX_PC27G_CATB_SENSE27)
+#define GPIO_PC27G_CATB_SENSE27  _UL(1 << 27)
+#define PIN_PB08G_CATB_SENSE28         _L(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
+#define MUX_PB08G_CATB_SENSE28          _L(6)
+#define PINMUX_PB08G_CATB_SENSE28  ((PIN_PB08G_CATB_SENSE28 << 16) | MUX_PB08G_CATB_SENSE28)
+#define GPIO_PB08G_CATB_SENSE28  _UL(1 <<  8)
+#define PIN_PC28G_CATB_SENSE28         _L(92) /**< \brief CATB signal: SENSE28 on PC28 mux G */
+#define MUX_PC28G_CATB_SENSE28          _L(6)
+#define PINMUX_PC28G_CATB_SENSE28  ((PIN_PC28G_CATB_SENSE28 << 16) | MUX_PC28G_CATB_SENSE28)
+#define GPIO_PC28G_CATB_SENSE28  _UL(1 << 28)
+#define PIN_PB09G_CATB_SENSE29         _L(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
+#define MUX_PB09G_CATB_SENSE29          _L(6)
+#define PINMUX_PB09G_CATB_SENSE29  ((PIN_PB09G_CATB_SENSE29 << 16) | MUX_PB09G_CATB_SENSE29)
+#define GPIO_PB09G_CATB_SENSE29  _UL(1 <<  9)
+#define PIN_PC29G_CATB_SENSE29         _L(93) /**< \brief CATB signal: SENSE29 on PC29 mux G */
+#define MUX_PC29G_CATB_SENSE29          _L(6)
+#define PINMUX_PC29G_CATB_SENSE29  ((PIN_PC29G_CATB_SENSE29 << 16) | MUX_PC29G_CATB_SENSE29)
+#define GPIO_PC29G_CATB_SENSE29  _UL(1 << 29)
+#define PIN_PB10G_CATB_SENSE30         _L(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
+#define MUX_PB10G_CATB_SENSE30          _L(6)
+#define PINMUX_PB10G_CATB_SENSE30  ((PIN_PB10G_CATB_SENSE30 << 16) | MUX_PB10G_CATB_SENSE30)
+#define GPIO_PB10G_CATB_SENSE30  _UL(1 << 10)
+#define PIN_PC30G_CATB_SENSE30         _L(94) /**< \brief CATB signal: SENSE30 on PC30 mux G */
+#define MUX_PC30G_CATB_SENSE30          _L(6)
+#define PINMUX_PC30G_CATB_SENSE30  ((PIN_PC30G_CATB_SENSE30 << 16) | MUX_PC30G_CATB_SENSE30)
+#define GPIO_PC30G_CATB_SENSE30  _UL(1 << 30)
+#define PIN_PB11G_CATB_SENSE31         _L(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
+#define MUX_PB11G_CATB_SENSE31          _L(6)
+#define PINMUX_PB11G_CATB_SENSE31  ((PIN_PB11G_CATB_SENSE31 << 16) | MUX_PB11G_CATB_SENSE31)
+#define GPIO_PB11G_CATB_SENSE31  _UL(1 << 11)
+#define PIN_PC31G_CATB_SENSE31         _L(95) /**< \brief CATB signal: SENSE31 on PC31 mux G */
+#define MUX_PC31G_CATB_SENSE31          _L(6)
+#define PINMUX_PC31G_CATB_SENSE31  ((PIN_PC31G_CATB_SENSE31 << 16) | MUX_PC31G_CATB_SENSE31)
+#define GPIO_PC31G_CATB_SENSE31  _UL(1 << 31)
+/* ========== GPIO definition for LCDCA peripheral ========== */
+#define PIN_PA12F_LCDCA_COM0           _L(12) /**< \brief LCDCA signal: COM0 on PA12 mux F */
+#define MUX_PA12F_LCDCA_COM0            _L(5)
+#define PINMUX_PA12F_LCDCA_COM0    ((PIN_PA12F_LCDCA_COM0 << 16) | MUX_PA12F_LCDCA_COM0)
+#define GPIO_PA12F_LCDCA_COM0    _UL(1 << 12)
+#define PIN_PA11F_LCDCA_COM1           _L(11) /**< \brief LCDCA signal: COM1 on PA11 mux F */
+#define MUX_PA11F_LCDCA_COM1            _L(5)
+#define PINMUX_PA11F_LCDCA_COM1    ((PIN_PA11F_LCDCA_COM1 << 16) | MUX_PA11F_LCDCA_COM1)
+#define GPIO_PA11F_LCDCA_COM1    _UL(1 << 11)
+#define PIN_PA10F_LCDCA_COM2           _L(10) /**< \brief LCDCA signal: COM2 on PA10 mux F */
+#define MUX_PA10F_LCDCA_COM2            _L(5)
+#define PINMUX_PA10F_LCDCA_COM2    ((PIN_PA10F_LCDCA_COM2 << 16) | MUX_PA10F_LCDCA_COM2)
+#define GPIO_PA10F_LCDCA_COM2    _UL(1 << 10)
+#define PIN_PA09F_LCDCA_COM3            _L(9) /**< \brief LCDCA signal: COM3 on PA09 mux F */
+#define MUX_PA09F_LCDCA_COM3            _L(5)
+#define PINMUX_PA09F_LCDCA_COM3    ((PIN_PA09F_LCDCA_COM3 << 16) | MUX_PA09F_LCDCA_COM3)
+#define GPIO_PA09F_LCDCA_COM3    _UL(1 <<  9)
+#define PIN_PC15F_LCDCA_SEG0           _L(79) /**< \brief LCDCA signal: SEG0 on PC15 mux F */
+#define MUX_PC15F_LCDCA_SEG0            _L(5)
+#define PINMUX_PC15F_LCDCA_SEG0    ((PIN_PC15F_LCDCA_SEG0 << 16) | MUX_PC15F_LCDCA_SEG0)
+#define GPIO_PC15F_LCDCA_SEG0    _UL(1 << 15)
+#define PIN_PC16F_LCDCA_SEG1           _L(80) /**< \brief LCDCA signal: SEG1 on PC16 mux F */
+#define MUX_PC16F_LCDCA_SEG1            _L(5)
+#define PINMUX_PC16F_LCDCA_SEG1    ((PIN_PC16F_LCDCA_SEG1 << 16) | MUX_PC16F_LCDCA_SEG1)
+#define GPIO_PC16F_LCDCA_SEG1    _UL(1 << 16)
+#define PIN_PC17F_LCDCA_SEG2           _L(81) /**< \brief LCDCA signal: SEG2 on PC17 mux F */
+#define MUX_PC17F_LCDCA_SEG2            _L(5)
+#define PINMUX_PC17F_LCDCA_SEG2    ((PIN_PC17F_LCDCA_SEG2 << 16) | MUX_PC17F_LCDCA_SEG2)
+#define GPIO_PC17F_LCDCA_SEG2    _UL(1 << 17)
+#define PIN_PC18F_LCDCA_SEG3           _L(82) /**< \brief LCDCA signal: SEG3 on PC18 mux F */
+#define MUX_PC18F_LCDCA_SEG3            _L(5)
+#define PINMUX_PC18F_LCDCA_SEG3    ((PIN_PC18F_LCDCA_SEG3 << 16) | MUX_PC18F_LCDCA_SEG3)
+#define GPIO_PC18F_LCDCA_SEG3    _UL(1 << 18)
+#define PIN_PC19F_LCDCA_SEG4           _L(83) /**< \brief LCDCA signal: SEG4 on PC19 mux F */
+#define MUX_PC19F_LCDCA_SEG4            _L(5)
+#define PINMUX_PC19F_LCDCA_SEG4    ((PIN_PC19F_LCDCA_SEG4 << 16) | MUX_PC19F_LCDCA_SEG4)
+#define GPIO_PC19F_LCDCA_SEG4    _UL(1 << 19)
+#define PIN_PA13F_LCDCA_SEG5           _L(13) /**< \brief LCDCA signal: SEG5 on PA13 mux F */
+#define MUX_PA13F_LCDCA_SEG5            _L(5)
+#define PINMUX_PA13F_LCDCA_SEG5    ((PIN_PA13F_LCDCA_SEG5 << 16) | MUX_PA13F_LCDCA_SEG5)
+#define GPIO_PA13F_LCDCA_SEG5    _UL(1 << 13)
+#define PIN_PA14F_LCDCA_SEG6           _L(14) /**< \brief LCDCA signal: SEG6 on PA14 mux F */
+#define MUX_PA14F_LCDCA_SEG6            _L(5)
+#define PINMUX_PA14F_LCDCA_SEG6    ((PIN_PA14F_LCDCA_SEG6 << 16) | MUX_PA14F_LCDCA_SEG6)
+#define GPIO_PA14F_LCDCA_SEG6    _UL(1 << 14)
+#define PIN_PA15F_LCDCA_SEG7           _L(15) /**< \brief LCDCA signal: SEG7 on PA15 mux F */
+#define MUX_PA15F_LCDCA_SEG7            _L(5)
+#define PINMUX_PA15F_LCDCA_SEG7    ((PIN_PA15F_LCDCA_SEG7 << 16) | MUX_PA15F_LCDCA_SEG7)
+#define GPIO_PA15F_LCDCA_SEG7    _UL(1 << 15)
+#define PIN_PA16F_LCDCA_SEG8           _L(16) /**< \brief LCDCA signal: SEG8 on PA16 mux F */
+#define MUX_PA16F_LCDCA_SEG8            _L(5)
+#define PINMUX_PA16F_LCDCA_SEG8    ((PIN_PA16F_LCDCA_SEG8 << 16) | MUX_PA16F_LCDCA_SEG8)
+#define GPIO_PA16F_LCDCA_SEG8    _UL(1 << 16)
+#define PIN_PA17F_LCDCA_SEG9           _L(17) /**< \brief LCDCA signal: SEG9 on PA17 mux F */
+#define MUX_PA17F_LCDCA_SEG9            _L(5)
+#define PINMUX_PA17F_LCDCA_SEG9    ((PIN_PA17F_LCDCA_SEG9 << 16) | MUX_PA17F_LCDCA_SEG9)
+#define GPIO_PA17F_LCDCA_SEG9    _UL(1 << 17)
+#define PIN_PC20F_LCDCA_SEG10          _L(84) /**< \brief LCDCA signal: SEG10 on PC20 mux F */
+#define MUX_PC20F_LCDCA_SEG10           _L(5)
+#define PINMUX_PC20F_LCDCA_SEG10   ((PIN_PC20F_LCDCA_SEG10 << 16) | MUX_PC20F_LCDCA_SEG10)
+#define GPIO_PC20F_LCDCA_SEG10   _UL(1 << 20)
+#define PIN_PC21F_LCDCA_SEG11          _L(85) /**< \brief LCDCA signal: SEG11 on PC21 mux F */
+#define MUX_PC21F_LCDCA_SEG11           _L(5)
+#define PINMUX_PC21F_LCDCA_SEG11   ((PIN_PC21F_LCDCA_SEG11 << 16) | MUX_PC21F_LCDCA_SEG11)
+#define GPIO_PC21F_LCDCA_SEG11   _UL(1 << 21)
+#define PIN_PC22F_LCDCA_SEG12          _L(86) /**< \brief LCDCA signal: SEG12 on PC22 mux F */
+#define MUX_PC22F_LCDCA_SEG12           _L(5)
+#define PINMUX_PC22F_LCDCA_SEG12   ((PIN_PC22F_LCDCA_SEG12 << 16) | MUX_PC22F_LCDCA_SEG12)
+#define GPIO_PC22F_LCDCA_SEG12   _UL(1 << 22)
+#define PIN_PC23F_LCDCA_SEG13          _L(87) /**< \brief LCDCA signal: SEG13 on PC23 mux F */
+#define MUX_PC23F_LCDCA_SEG13           _L(5)
+#define PINMUX_PC23F_LCDCA_SEG13   ((PIN_PC23F_LCDCA_SEG13 << 16) | MUX_PC23F_LCDCA_SEG13)
+#define GPIO_PC23F_LCDCA_SEG13   _UL(1 << 23)
+#define PIN_PB08F_LCDCA_SEG14          _L(40) /**< \brief LCDCA signal: SEG14 on PB08 mux F */
+#define MUX_PB08F_LCDCA_SEG14           _L(5)
+#define PINMUX_PB08F_LCDCA_SEG14   ((PIN_PB08F_LCDCA_SEG14 << 16) | MUX_PB08F_LCDCA_SEG14)
+#define GPIO_PB08F_LCDCA_SEG14   _UL(1 <<  8)
+#define PIN_PB09F_LCDCA_SEG15          _L(41) /**< \brief LCDCA signal: SEG15 on PB09 mux F */
+#define MUX_PB09F_LCDCA_SEG15           _L(5)
+#define PINMUX_PB09F_LCDCA_SEG15   ((PIN_PB09F_LCDCA_SEG15 << 16) | MUX_PB09F_LCDCA_SEG15)
+#define GPIO_PB09F_LCDCA_SEG15   _UL(1 <<  9)
+#define PIN_PB10F_LCDCA_SEG16          _L(42) /**< \brief LCDCA signal: SEG16 on PB10 mux F */
+#define MUX_PB10F_LCDCA_SEG16           _L(5)
+#define PINMUX_PB10F_LCDCA_SEG16   ((PIN_PB10F_LCDCA_SEG16 << 16) | MUX_PB10F_LCDCA_SEG16)
+#define GPIO_PB10F_LCDCA_SEG16   _UL(1 << 10)
+#define PIN_PB11F_LCDCA_SEG17          _L(43) /**< \brief LCDCA signal: SEG17 on PB11 mux F */
+#define MUX_PB11F_LCDCA_SEG17           _L(5)
+#define PINMUX_PB11F_LCDCA_SEG17   ((PIN_PB11F_LCDCA_SEG17 << 16) | MUX_PB11F_LCDCA_SEG17)
+#define GPIO_PB11F_LCDCA_SEG17   _UL(1 << 11)
+#define PIN_PA18F_LCDCA_SEG18          _L(18) /**< \brief LCDCA signal: SEG18 on PA18 mux F */
+#define MUX_PA18F_LCDCA_SEG18           _L(5)
+#define PINMUX_PA18F_LCDCA_SEG18   ((PIN_PA18F_LCDCA_SEG18 << 16) | MUX_PA18F_LCDCA_SEG18)
+#define GPIO_PA18F_LCDCA_SEG18   _UL(1 << 18)
+#define PIN_PA19F_LCDCA_SEG19          _L(19) /**< \brief LCDCA signal: SEG19 on PA19 mux F */
+#define MUX_PA19F_LCDCA_SEG19           _L(5)
+#define PINMUX_PA19F_LCDCA_SEG19   ((PIN_PA19F_LCDCA_SEG19 << 16) | MUX_PA19F_LCDCA_SEG19)
+#define GPIO_PA19F_LCDCA_SEG19   _UL(1 << 19)
+#define PIN_PA20F_LCDCA_SEG20          _L(20) /**< \brief LCDCA signal: SEG20 on PA20 mux F */
+#define MUX_PA20F_LCDCA_SEG20           _L(5)
+#define PINMUX_PA20F_LCDCA_SEG20   ((PIN_PA20F_LCDCA_SEG20 << 16) | MUX_PA20F_LCDCA_SEG20)
+#define GPIO_PA20F_LCDCA_SEG20   _UL(1 << 20)
+#define PIN_PB07F_LCDCA_SEG21          _L(39) /**< \brief LCDCA signal: SEG21 on PB07 mux F */
+#define MUX_PB07F_LCDCA_SEG21           _L(5)
+#define PINMUX_PB07F_LCDCA_SEG21   ((PIN_PB07F_LCDCA_SEG21 << 16) | MUX_PB07F_LCDCA_SEG21)
+#define GPIO_PB07F_LCDCA_SEG21   _UL(1 <<  7)
+#define PIN_PB06F_LCDCA_SEG22          _L(38) /**< \brief LCDCA signal: SEG22 on PB06 mux F */
+#define MUX_PB06F_LCDCA_SEG22           _L(5)
+#define PINMUX_PB06F_LCDCA_SEG22   ((PIN_PB06F_LCDCA_SEG22 << 16) | MUX_PB06F_LCDCA_SEG22)
+#define GPIO_PB06F_LCDCA_SEG22   _UL(1 <<  6)
+#define PIN_PA08F_LCDCA_SEG23           _L(8) /**< \brief LCDCA signal: SEG23 on PA08 mux F */
+#define MUX_PA08F_LCDCA_SEG23           _L(5)
+#define PINMUX_PA08F_LCDCA_SEG23   ((PIN_PA08F_LCDCA_SEG23 << 16) | MUX_PA08F_LCDCA_SEG23)
+#define GPIO_PA08F_LCDCA_SEG23   _UL(1 <<  8)
+#define PIN_PC24F_LCDCA_SEG24          _L(88) /**< \brief LCDCA signal: SEG24 on PC24 mux F */
+#define MUX_PC24F_LCDCA_SEG24           _L(5)
+#define PINMUX_PC24F_LCDCA_SEG24   ((PIN_PC24F_LCDCA_SEG24 << 16) | MUX_PC24F_LCDCA_SEG24)
+#define GPIO_PC24F_LCDCA_SEG24   _UL(1 << 24)
+#define PIN_PC25F_LCDCA_SEG25          _L(89) /**< \brief LCDCA signal: SEG25 on PC25 mux F */
+#define MUX_PC25F_LCDCA_SEG25           _L(5)
+#define PINMUX_PC25F_LCDCA_SEG25   ((PIN_PC25F_LCDCA_SEG25 << 16) | MUX_PC25F_LCDCA_SEG25)
+#define GPIO_PC25F_LCDCA_SEG25   _UL(1 << 25)
+#define PIN_PC26F_LCDCA_SEG26          _L(90) /**< \brief LCDCA signal: SEG26 on PC26 mux F */
+#define MUX_PC26F_LCDCA_SEG26           _L(5)
+#define PINMUX_PC26F_LCDCA_SEG26   ((PIN_PC26F_LCDCA_SEG26 << 16) | MUX_PC26F_LCDCA_SEG26)
+#define GPIO_PC26F_LCDCA_SEG26   _UL(1 << 26)
+#define PIN_PC27F_LCDCA_SEG27          _L(91) /**< \brief LCDCA signal: SEG27 on PC27 mux F */
+#define MUX_PC27F_LCDCA_SEG27           _L(5)
+#define PINMUX_PC27F_LCDCA_SEG27   ((PIN_PC27F_LCDCA_SEG27 << 16) | MUX_PC27F_LCDCA_SEG27)
+#define GPIO_PC27F_LCDCA_SEG27   _UL(1 << 27)
+#define PIN_PC28F_LCDCA_SEG28          _L(92) /**< \brief LCDCA signal: SEG28 on PC28 mux F */
+#define MUX_PC28F_LCDCA_SEG28           _L(5)
+#define PINMUX_PC28F_LCDCA_SEG28   ((PIN_PC28F_LCDCA_SEG28 << 16) | MUX_PC28F_LCDCA_SEG28)
+#define GPIO_PC28F_LCDCA_SEG28   _UL(1 << 28)
+#define PIN_PC29F_LCDCA_SEG29          _L(93) /**< \brief LCDCA signal: SEG29 on PC29 mux F */
+#define MUX_PC29F_LCDCA_SEG29           _L(5)
+#define PINMUX_PC29F_LCDCA_SEG29   ((PIN_PC29F_LCDCA_SEG29 << 16) | MUX_PC29F_LCDCA_SEG29)
+#define GPIO_PC29F_LCDCA_SEG29   _UL(1 << 29)
+#define PIN_PC30F_LCDCA_SEG30          _L(94) /**< \brief LCDCA signal: SEG30 on PC30 mux F */
+#define MUX_PC30F_LCDCA_SEG30           _L(5)
+#define PINMUX_PC30F_LCDCA_SEG30   ((PIN_PC30F_LCDCA_SEG30 << 16) | MUX_PC30F_LCDCA_SEG30)
+#define GPIO_PC30F_LCDCA_SEG30   _UL(1 << 30)
+#define PIN_PC31F_LCDCA_SEG31          _L(95) /**< \brief LCDCA signal: SEG31 on PC31 mux F */
+#define MUX_PC31F_LCDCA_SEG31           _L(5)
+#define PINMUX_PC31F_LCDCA_SEG31   ((PIN_PC31F_LCDCA_SEG31 << 16) | MUX_PC31F_LCDCA_SEG31)
+#define GPIO_PC31F_LCDCA_SEG31   _UL(1 << 31)
+#define PIN_PB12F_LCDCA_SEG32          _L(44) /**< \brief LCDCA signal: SEG32 on PB12 mux F */
+#define MUX_PB12F_LCDCA_SEG32           _L(5)
+#define PINMUX_PB12F_LCDCA_SEG32   ((PIN_PB12F_LCDCA_SEG32 << 16) | MUX_PB12F_LCDCA_SEG32)
+#define GPIO_PB12F_LCDCA_SEG32   _UL(1 << 12)
+#define PIN_PB13F_LCDCA_SEG33          _L(45) /**< \brief LCDCA signal: SEG33 on PB13 mux F */
+#define MUX_PB13F_LCDCA_SEG33           _L(5)
+#define PINMUX_PB13F_LCDCA_SEG33   ((PIN_PB13F_LCDCA_SEG33 << 16) | MUX_PB13F_LCDCA_SEG33)
+#define GPIO_PB13F_LCDCA_SEG33   _UL(1 << 13)
+#define PIN_PA21F_LCDCA_SEG34          _L(21) /**< \brief LCDCA signal: SEG34 on PA21 mux F */
+#define MUX_PA21F_LCDCA_SEG34           _L(5)
+#define PINMUX_PA21F_LCDCA_SEG34   ((PIN_PA21F_LCDCA_SEG34 << 16) | MUX_PA21F_LCDCA_SEG34)
+#define GPIO_PA21F_LCDCA_SEG34   _UL(1 << 21)
+#define PIN_PA22F_LCDCA_SEG35          _L(22) /**< \brief LCDCA signal: SEG35 on PA22 mux F */
+#define MUX_PA22F_LCDCA_SEG35           _L(5)
+#define PINMUX_PA22F_LCDCA_SEG35   ((PIN_PA22F_LCDCA_SEG35 << 16) | MUX_PA22F_LCDCA_SEG35)
+#define GPIO_PA22F_LCDCA_SEG35   _UL(1 << 22)
+#define PIN_PB14F_LCDCA_SEG36          _L(46) /**< \brief LCDCA signal: SEG36 on PB14 mux F */
+#define MUX_PB14F_LCDCA_SEG36           _L(5)
+#define PINMUX_PB14F_LCDCA_SEG36   ((PIN_PB14F_LCDCA_SEG36 << 16) | MUX_PB14F_LCDCA_SEG36)
+#define GPIO_PB14F_LCDCA_SEG36   _UL(1 << 14)
+#define PIN_PB15F_LCDCA_SEG37          _L(47) /**< \brief LCDCA signal: SEG37 on PB15 mux F */
+#define MUX_PB15F_LCDCA_SEG37           _L(5)
+#define PINMUX_PB15F_LCDCA_SEG37   ((PIN_PB15F_LCDCA_SEG37 << 16) | MUX_PB15F_LCDCA_SEG37)
+#define GPIO_PB15F_LCDCA_SEG37   _UL(1 << 15)
+#define PIN_PA23F_LCDCA_SEG38          _L(23) /**< \brief LCDCA signal: SEG38 on PA23 mux F */
+#define MUX_PA23F_LCDCA_SEG38           _L(5)
+#define PINMUX_PA23F_LCDCA_SEG38   ((PIN_PA23F_LCDCA_SEG38 << 16) | MUX_PA23F_LCDCA_SEG38)
+#define GPIO_PA23F_LCDCA_SEG38   _UL(1 << 23)
+#define PIN_PA24F_LCDCA_SEG39          _L(24) /**< \brief LCDCA signal: SEG39 on PA24 mux F */
+#define MUX_PA24F_LCDCA_SEG39           _L(5)
+#define PINMUX_PA24F_LCDCA_SEG39   ((PIN_PA24F_LCDCA_SEG39 << 16) | MUX_PA24F_LCDCA_SEG39)
+#define GPIO_PA24F_LCDCA_SEG39   _UL(1 << 24)
+/* ========== GPIO definition for USBC peripheral ========== */
+#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L(0)
+#define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
+#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
+#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L(0)
+#define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
+#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+/* ========== GPIO definition for PEVC peripheral ========== */
+#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
+#define PIN_PB12C_PEVC_PAD_EVT0        _L(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
+#define MUX_PB12C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PB12C_PEVC_PAD_EVT0  ((PIN_PB12C_PEVC_PAD_EVT0 << 16) | MUX_PB12C_PEVC_PAD_EVT0)
+#define GPIO_PB12C_PEVC_PAD_EVT0  _UL(1 << 12)
+#define PIN_PC07C_PEVC_PAD_EVT0        _L(71) /**< \brief PEVC signal: PAD_EVT0 on PC07 mux C */
+#define MUX_PC07C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PC07C_PEVC_PAD_EVT0  ((PIN_PC07C_PEVC_PAD_EVT0 << 16) | MUX_PC07C_PEVC_PAD_EVT0)
+#define GPIO_PC07C_PEVC_PAD_EVT0  _UL(1 <<  7)
+#define PIN_PC24C_PEVC_PAD_EVT0        _L(88) /**< \brief PEVC signal: PAD_EVT0 on PC24 mux C */
+#define MUX_PC24C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PC24C_PEVC_PAD_EVT0  ((PIN_PC24C_PEVC_PAD_EVT0 << 16) | MUX_PC24C_PEVC_PAD_EVT0)
+#define GPIO_PC24C_PEVC_PAD_EVT0  _UL(1 << 24)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
+#define PIN_PB13C_PEVC_PAD_EVT1        _L(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
+#define MUX_PB13C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PB13C_PEVC_PAD_EVT1  ((PIN_PB13C_PEVC_PAD_EVT1 << 16) | MUX_PB13C_PEVC_PAD_EVT1)
+#define GPIO_PB13C_PEVC_PAD_EVT1  _UL(1 << 13)
+#define PIN_PC08C_PEVC_PAD_EVT1        _L(72) /**< \brief PEVC signal: PAD_EVT1 on PC08 mux C */
+#define MUX_PC08C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PC08C_PEVC_PAD_EVT1  ((PIN_PC08C_PEVC_PAD_EVT1 << 16) | MUX_PC08C_PEVC_PAD_EVT1)
+#define GPIO_PC08C_PEVC_PAD_EVT1  _UL(1 <<  8)
+#define PIN_PC25C_PEVC_PAD_EVT1        _L(89) /**< \brief PEVC signal: PAD_EVT1 on PC25 mux C */
+#define MUX_PC25C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PC25C_PEVC_PAD_EVT1  ((PIN_PC25C_PEVC_PAD_EVT1 << 16) | MUX_PC25C_PEVC_PAD_EVT1)
+#define GPIO_PC25C_PEVC_PAD_EVT1  _UL(1 << 25)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
+#define PIN_PC11C_PEVC_PAD_EVT2        _L(75) /**< \brief PEVC signal: PAD_EVT2 on PC11 mux C */
+#define MUX_PC11C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PC11C_PEVC_PAD_EVT2  ((PIN_PC11C_PEVC_PAD_EVT2 << 16) | MUX_PC11C_PEVC_PAD_EVT2)
+#define GPIO_PC11C_PEVC_PAD_EVT2  _UL(1 << 11)
+#define PIN_PC26C_PEVC_PAD_EVT2        _L(90) /**< \brief PEVC signal: PAD_EVT2 on PC26 mux C */
+#define MUX_PC26C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PC26C_PEVC_PAD_EVT2  ((PIN_PC26C_PEVC_PAD_EVT2 << 16) | MUX_PC26C_PEVC_PAD_EVT2)
+#define GPIO_PC26C_PEVC_PAD_EVT2  _UL(1 << 26)
+#define PIN_PB09B_PEVC_PAD_EVT2        _L(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
+#define MUX_PB09B_PEVC_PAD_EVT2         _L(1)
+#define PINMUX_PB09B_PEVC_PAD_EVT2  ((PIN_PB09B_PEVC_PAD_EVT2 << 16) | MUX_PB09B_PEVC_PAD_EVT2)
+#define GPIO_PB09B_PEVC_PAD_EVT2  _UL(1 <<  9)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
+#define PIN_PC27C_PEVC_PAD_EVT3        _L(91) /**< \brief PEVC signal: PAD_EVT3 on PC27 mux C */
+#define MUX_PC27C_PEVC_PAD_EVT3         _L(2)
+#define PINMUX_PC27C_PEVC_PAD_EVT3  ((PIN_PC27C_PEVC_PAD_EVT3 << 16) | MUX_PC27C_PEVC_PAD_EVT3)
+#define GPIO_PC27C_PEVC_PAD_EVT3  _UL(1 << 27)
+#define PIN_PB10B_PEVC_PAD_EVT3        _L(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
+#define MUX_PB10B_PEVC_PAD_EVT3         _L(1)
+#define PINMUX_PB10B_PEVC_PAD_EVT3  ((PIN_PB10B_PEVC_PAD_EVT3 << 16) | MUX_PB10B_PEVC_PAD_EVT3)
+#define GPIO_PB10B_PEVC_PAD_EVT3  _UL(1 << 10)
+/* ========== GPIO definition for SCIF peripheral ========== */
+#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
+#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
+#define PIN_PB10E_SCIF_GCLK0           _L(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
+#define MUX_PB10E_SCIF_GCLK0            _L(4)
+#define PINMUX_PB10E_SCIF_GCLK0    ((PIN_PB10E_SCIF_GCLK0 << 16) | MUX_PB10E_SCIF_GCLK0)
+#define GPIO_PB10E_SCIF_GCLK0    _UL(1 << 10)
+#define PIN_PC26E_SCIF_GCLK0           _L(90) /**< \brief SCIF signal: GCLK0 on PC26 mux E */
+#define MUX_PC26E_SCIF_GCLK0            _L(4)
+#define PINMUX_PC26E_SCIF_GCLK0    ((PIN_PC26E_SCIF_GCLK0 << 16) | MUX_PC26E_SCIF_GCLK0)
+#define GPIO_PC26E_SCIF_GCLK0    _UL(1 << 26)
+#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
+#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
+#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
+#define PIN_PB11E_SCIF_GCLK1           _L(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
+#define MUX_PB11E_SCIF_GCLK1            _L(4)
+#define PINMUX_PB11E_SCIF_GCLK1    ((PIN_PB11E_SCIF_GCLK1 << 16) | MUX_PB11E_SCIF_GCLK1)
+#define GPIO_PB11E_SCIF_GCLK1    _UL(1 << 11)
+#define PIN_PC27E_SCIF_GCLK1           _L(91) /**< \brief SCIF signal: GCLK1 on PC27 mux E */
+#define MUX_PC27E_SCIF_GCLK1            _L(4)
+#define PINMUX_PC27E_SCIF_GCLK1    ((PIN_PC27E_SCIF_GCLK1 << 16) | MUX_PC27E_SCIF_GCLK1)
+#define GPIO_PC27E_SCIF_GCLK1    _UL(1 << 27)
+#define PIN_PB12E_SCIF_GCLK2           _L(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
+#define MUX_PB12E_SCIF_GCLK2            _L(4)
+#define PINMUX_PB12E_SCIF_GCLK2    ((PIN_PB12E_SCIF_GCLK2 << 16) | MUX_PB12E_SCIF_GCLK2)
+#define GPIO_PB12E_SCIF_GCLK2    _UL(1 << 12)
+#define PIN_PC28E_SCIF_GCLK2           _L(92) /**< \brief SCIF signal: GCLK2 on PC28 mux E */
+#define MUX_PC28E_SCIF_GCLK2            _L(4)
+#define PINMUX_PC28E_SCIF_GCLK2    ((PIN_PC28E_SCIF_GCLK2 << 16) | MUX_PC28E_SCIF_GCLK2)
+#define GPIO_PC28E_SCIF_GCLK2    _UL(1 << 28)
+#define PIN_PB13E_SCIF_GCLK3           _L(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
+#define MUX_PB13E_SCIF_GCLK3            _L(4)
+#define PINMUX_PB13E_SCIF_GCLK3    ((PIN_PB13E_SCIF_GCLK3 << 16) | MUX_PB13E_SCIF_GCLK3)
+#define GPIO_PB13E_SCIF_GCLK3    _UL(1 << 13)
+#define PIN_PC29E_SCIF_GCLK3           _L(93) /**< \brief SCIF signal: GCLK3 on PC29 mux E */
+#define MUX_PC29E_SCIF_GCLK3            _L(4)
+#define PINMUX_PC29E_SCIF_GCLK3    ((PIN_PC29E_SCIF_GCLK3 << 16) | MUX_PC29E_SCIF_GCLK3)
+#define GPIO_PC29E_SCIF_GCLK3    _UL(1 << 29)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
+#define PIN_PB14E_SCIF_GCLK_IN0        _L(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
+#define MUX_PB14E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PB14E_SCIF_GCLK_IN0  ((PIN_PB14E_SCIF_GCLK_IN0 << 16) | MUX_PB14E_SCIF_GCLK_IN0)
+#define GPIO_PB14E_SCIF_GCLK_IN0  _UL(1 << 14)
+#define PIN_PC30E_SCIF_GCLK_IN0        _L(94) /**< \brief SCIF signal: GCLK_IN0 on PC30 mux E */
+#define MUX_PC30E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PC30E_SCIF_GCLK_IN0  ((PIN_PC30E_SCIF_GCLK_IN0 << 16) | MUX_PC30E_SCIF_GCLK_IN0)
+#define GPIO_PC30E_SCIF_GCLK_IN0  _UL(1 << 30)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
+#define PIN_PB15E_SCIF_GCLK_IN1        _L(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
+#define MUX_PB15E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PB15E_SCIF_GCLK_IN1  ((PIN_PB15E_SCIF_GCLK_IN1 << 16) | MUX_PB15E_SCIF_GCLK_IN1)
+#define GPIO_PB15E_SCIF_GCLK_IN1  _UL(1 << 15)
+#define PIN_PC31E_SCIF_GCLK_IN1        _L(95) /**< \brief SCIF signal: GCLK_IN1 on PC31 mux E */
+#define MUX_PC31E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PC31E_SCIF_GCLK_IN1  ((PIN_PC31E_SCIF_GCLK_IN1 << 16) | MUX_PC31E_SCIF_GCLK_IN1)
+#define GPIO_PC31E_SCIF_GCLK_IN1  _UL(1 << 31)
+/* ========== GPIO definition for EIC peripheral ========== */
+#define PIN_PB01C_EIC_EXTINT0          _L(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
+#define MUX_PB01C_EIC_EXTINT0           _L(2)
+#define PINMUX_PB01C_EIC_EXTINT0   ((PIN_PB01C_EIC_EXTINT0 << 16) | MUX_PB01C_EIC_EXTINT0)
+#define GPIO_PB01C_EIC_EXTINT0   _UL(1 <<  1)
+#define PIN_PB01C_EIC_EXTINT_NUM        _L(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
+#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
+#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PC24B_EIC_EXTINT1          _L(88) /**< \brief EIC signal: EXTINT1 on PC24 mux B */
+#define MUX_PC24B_EIC_EXTINT1           _L(1)
+#define PINMUX_PC24B_EIC_EXTINT1   ((PIN_PC24B_EIC_EXTINT1 << 16) | MUX_PC24B_EIC_EXTINT1)
+#define GPIO_PC24B_EIC_EXTINT1   _UL(1 << 24)
+#define PIN_PC24B_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PC24 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PC25B_EIC_EXTINT2          _L(89) /**< \brief EIC signal: EXTINT2 on PC25 mux B */
+#define MUX_PC25B_EIC_EXTINT2           _L(1)
+#define PINMUX_PC25B_EIC_EXTINT2   ((PIN_PC25B_EIC_EXTINT2 << 16) | MUX_PC25B_EIC_EXTINT2)
+#define GPIO_PC25B_EIC_EXTINT2   _UL(1 << 25)
+#define PIN_PC25B_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PC25 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
+#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
+#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PC26B_EIC_EXTINT3          _L(90) /**< \brief EIC signal: EXTINT3 on PC26 mux B */
+#define MUX_PC26B_EIC_EXTINT3           _L(1)
+#define PINMUX_PC26B_EIC_EXTINT3   ((PIN_PC26B_EIC_EXTINT3 << 16) | MUX_PC26B_EIC_EXTINT3)
+#define GPIO_PC26B_EIC_EXTINT3   _UL(1 << 26)
+#define PIN_PC26B_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PC26 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
+#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
+#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PC27B_EIC_EXTINT4          _L(91) /**< \brief EIC signal: EXTINT4 on PC27 mux B */
+#define MUX_PC27B_EIC_EXTINT4           _L(1)
+#define PINMUX_PC27B_EIC_EXTINT4   ((PIN_PC27B_EIC_EXTINT4 << 16) | MUX_PC27B_EIC_EXTINT4)
+#define GPIO_PC27B_EIC_EXTINT4   _UL(1 << 27)
+#define PIN_PC27B_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PC27 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
+#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PC03B_EIC_EXTINT5          _L(67) /**< \brief EIC signal: EXTINT5 on PC03 mux B */
+#define MUX_PC03B_EIC_EXTINT5           _L(1)
+#define PINMUX_PC03B_EIC_EXTINT5   ((PIN_PC03B_EIC_EXTINT5 << 16) | MUX_PC03B_EIC_EXTINT5)
+#define GPIO_PC03B_EIC_EXTINT5   _UL(1 <<  3)
+#define PIN_PC03B_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PC03 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
+#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PC04B_EIC_EXTINT6          _L(68) /**< \brief EIC signal: EXTINT6 on PC04 mux B */
+#define MUX_PC04B_EIC_EXTINT6           _L(1)
+#define PINMUX_PC04B_EIC_EXTINT6   ((PIN_PC04B_EIC_EXTINT6 << 16) | MUX_PC04B_EIC_EXTINT6)
+#define GPIO_PC04B_EIC_EXTINT6   _UL(1 <<  4)
+#define PIN_PC04B_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PC04 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
+#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PC05B_EIC_EXTINT7          _L(69) /**< \brief EIC signal: EXTINT7 on PC05 mux B */
+#define MUX_PC05B_EIC_EXTINT7           _L(1)
+#define PINMUX_PC05B_EIC_EXTINT7   ((PIN_PC05B_EIC_EXTINT7 << 16) | MUX_PC05B_EIC_EXTINT7)
+#define GPIO_PC05B_EIC_EXTINT7   _UL(1 <<  5)
+#define PIN_PC05B_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PC05 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
+#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PC06B_EIC_EXTINT8          _L(70) /**< \brief EIC signal: EXTINT8 on PC06 mux B */
+#define MUX_PC06B_EIC_EXTINT8           _L(1)
+#define PINMUX_PC06B_EIC_EXTINT8   ((PIN_PC06B_EIC_EXTINT8 << 16) | MUX_PC06B_EIC_EXTINT8)
+#define GPIO_PC06B_EIC_EXTINT8   _UL(1 <<  6)
+#define PIN_PC06B_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PC06 External Interrupt Line */
+
+#endif /* _SAM4LC8C_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4lc8c.h
+++ b/asf/sam/include/sam4l/pio/sam4lc8c.h
@@ -30,1775 +30,1775 @@
 #define _SAM4LC8C_PIO_
 
 #define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
-#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define GPIO_PA00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PA00 */
 #define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
-#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define GPIO_PA01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PA01 */
 #define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
-#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define GPIO_PA02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PA02 */
 #define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
-#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define GPIO_PA03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PA03 */
 #define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
-#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define GPIO_PA04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PA04 */
 #define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
-#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define GPIO_PA05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PA05 */
 #define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
-#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define GPIO_PA06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PA06 */
 #define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
-#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define GPIO_PA07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PA07 */
 #define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
-#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define GPIO_PA08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PA08 */
 #define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
-#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define GPIO_PA09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PA09 */
 #define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
-#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define GPIO_PA10                _UL_(1 << 10) /**< \brief GPIO Mask  for PA10 */
 #define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
-#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define GPIO_PA11                _UL_(1 << 11) /**< \brief GPIO Mask  for PA11 */
 #define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
-#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define GPIO_PA12                _UL_(1 << 12) /**< \brief GPIO Mask  for PA12 */
 #define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
-#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define GPIO_PA13                _UL_(1 << 13) /**< \brief GPIO Mask  for PA13 */
 #define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
-#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define GPIO_PA14                _UL_(1 << 14) /**< \brief GPIO Mask  for PA14 */
 #define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
-#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define GPIO_PA15                _UL_(1 << 15) /**< \brief GPIO Mask  for PA15 */
 #define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
-#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define GPIO_PA16                _UL_(1 << 16) /**< \brief GPIO Mask  for PA16 */
 #define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
-#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define GPIO_PA17                _UL_(1 << 17) /**< \brief GPIO Mask  for PA17 */
 #define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
-#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define GPIO_PA18                _UL_(1 << 18) /**< \brief GPIO Mask  for PA18 */
 #define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
-#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define GPIO_PA19                _UL_(1 << 19) /**< \brief GPIO Mask  for PA19 */
 #define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
-#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define GPIO_PA20                _UL_(1 << 20) /**< \brief GPIO Mask  for PA20 */
 #define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
-#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define GPIO_PA21                _UL_(1 << 21) /**< \brief GPIO Mask  for PA21 */
 #define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
-#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define GPIO_PA22                _UL_(1 << 22) /**< \brief GPIO Mask  for PA22 */
 #define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
-#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define GPIO_PA23                _UL_(1 << 23) /**< \brief GPIO Mask  for PA23 */
 #define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
-#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define GPIO_PA24                _UL_(1 << 24) /**< \brief GPIO Mask  for PA24 */
 #define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
-#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define GPIO_PA25                _UL_(1 << 25) /**< \brief GPIO Mask  for PA25 */
 #define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
-#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define GPIO_PA26                _UL_(1 << 26) /**< \brief GPIO Mask  for PA26 */
 #define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
-#define GPIO_PB00                _UL(1 <<  0) /**< \brief GPIO Mask  for PB00 */
+#define GPIO_PB00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PB00 */
 #define PIN_PB01                          33  /**< \brief Pin Number for PB01 */
-#define GPIO_PB01                _UL(1 <<  1) /**< \brief GPIO Mask  for PB01 */
+#define GPIO_PB01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PB01 */
 #define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
-#define GPIO_PB02                _UL(1 <<  2) /**< \brief GPIO Mask  for PB02 */
+#define GPIO_PB02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PB02 */
 #define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
-#define GPIO_PB03                _UL(1 <<  3) /**< \brief GPIO Mask  for PB03 */
+#define GPIO_PB03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PB03 */
 #define PIN_PB04                          36  /**< \brief Pin Number for PB04 */
-#define GPIO_PB04                _UL(1 <<  4) /**< \brief GPIO Mask  for PB04 */
+#define GPIO_PB04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PB04 */
 #define PIN_PB05                          37  /**< \brief Pin Number for PB05 */
-#define GPIO_PB05                _UL(1 <<  5) /**< \brief GPIO Mask  for PB05 */
+#define GPIO_PB05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PB05 */
 #define PIN_PB06                          38  /**< \brief Pin Number for PB06 */
-#define GPIO_PB06                _UL(1 <<  6) /**< \brief GPIO Mask  for PB06 */
+#define GPIO_PB06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PB06 */
 #define PIN_PB07                          39  /**< \brief Pin Number for PB07 */
-#define GPIO_PB07                _UL(1 <<  7) /**< \brief GPIO Mask  for PB07 */
+#define GPIO_PB07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PB07 */
 #define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
-#define GPIO_PB08                _UL(1 <<  8) /**< \brief GPIO Mask  for PB08 */
+#define GPIO_PB08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PB08 */
 #define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
-#define GPIO_PB09                _UL(1 <<  9) /**< \brief GPIO Mask  for PB09 */
+#define GPIO_PB09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PB09 */
 #define PIN_PB10                          42  /**< \brief Pin Number for PB10 */
-#define GPIO_PB10                _UL(1 << 10) /**< \brief GPIO Mask  for PB10 */
+#define GPIO_PB10                _UL_(1 << 10) /**< \brief GPIO Mask  for PB10 */
 #define PIN_PB11                          43  /**< \brief Pin Number for PB11 */
-#define GPIO_PB11                _UL(1 << 11) /**< \brief GPIO Mask  for PB11 */
+#define GPIO_PB11                _UL_(1 << 11) /**< \brief GPIO Mask  for PB11 */
 #define PIN_PB12                          44  /**< \brief Pin Number for PB12 */
-#define GPIO_PB12                _UL(1 << 12) /**< \brief GPIO Mask  for PB12 */
+#define GPIO_PB12                _UL_(1 << 12) /**< \brief GPIO Mask  for PB12 */
 #define PIN_PB13                          45  /**< \brief Pin Number for PB13 */
-#define GPIO_PB13                _UL(1 << 13) /**< \brief GPIO Mask  for PB13 */
+#define GPIO_PB13                _UL_(1 << 13) /**< \brief GPIO Mask  for PB13 */
 #define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
-#define GPIO_PB14                _UL(1 << 14) /**< \brief GPIO Mask  for PB14 */
+#define GPIO_PB14                _UL_(1 << 14) /**< \brief GPIO Mask  for PB14 */
 #define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
-#define GPIO_PB15                _UL(1 << 15) /**< \brief GPIO Mask  for PB15 */
+#define GPIO_PB15                _UL_(1 << 15) /**< \brief GPIO Mask  for PB15 */
 #define PIN_PC00                          64  /**< \brief Pin Number for PC00 */
-#define GPIO_PC00                _UL(1 <<  0) /**< \brief GPIO Mask  for PC00 */
+#define GPIO_PC00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PC00 */
 #define PIN_PC01                          65  /**< \brief Pin Number for PC01 */
-#define GPIO_PC01                _UL(1 <<  1) /**< \brief GPIO Mask  for PC01 */
+#define GPIO_PC01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PC01 */
 #define PIN_PC02                          66  /**< \brief Pin Number for PC02 */
-#define GPIO_PC02                _UL(1 <<  2) /**< \brief GPIO Mask  for PC02 */
+#define GPIO_PC02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PC02 */
 #define PIN_PC03                          67  /**< \brief Pin Number for PC03 */
-#define GPIO_PC03                _UL(1 <<  3) /**< \brief GPIO Mask  for PC03 */
+#define GPIO_PC03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PC03 */
 #define PIN_PC04                          68  /**< \brief Pin Number for PC04 */
-#define GPIO_PC04                _UL(1 <<  4) /**< \brief GPIO Mask  for PC04 */
+#define GPIO_PC04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PC04 */
 #define PIN_PC05                          69  /**< \brief Pin Number for PC05 */
-#define GPIO_PC05                _UL(1 <<  5) /**< \brief GPIO Mask  for PC05 */
+#define GPIO_PC05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PC05 */
 #define PIN_PC06                          70  /**< \brief Pin Number for PC06 */
-#define GPIO_PC06                _UL(1 <<  6) /**< \brief GPIO Mask  for PC06 */
+#define GPIO_PC06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PC06 */
 #define PIN_PC07                          71  /**< \brief Pin Number for PC07 */
-#define GPIO_PC07                _UL(1 <<  7) /**< \brief GPIO Mask  for PC07 */
+#define GPIO_PC07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PC07 */
 #define PIN_PC08                          72  /**< \brief Pin Number for PC08 */
-#define GPIO_PC08                _UL(1 <<  8) /**< \brief GPIO Mask  for PC08 */
+#define GPIO_PC08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PC08 */
 #define PIN_PC09                          73  /**< \brief Pin Number for PC09 */
-#define GPIO_PC09                _UL(1 <<  9) /**< \brief GPIO Mask  for PC09 */
+#define GPIO_PC09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PC09 */
 #define PIN_PC10                          74  /**< \brief Pin Number for PC10 */
-#define GPIO_PC10                _UL(1 << 10) /**< \brief GPIO Mask  for PC10 */
+#define GPIO_PC10                _UL_(1 << 10) /**< \brief GPIO Mask  for PC10 */
 #define PIN_PC11                          75  /**< \brief Pin Number for PC11 */
-#define GPIO_PC11                _UL(1 << 11) /**< \brief GPIO Mask  for PC11 */
+#define GPIO_PC11                _UL_(1 << 11) /**< \brief GPIO Mask  for PC11 */
 #define PIN_PC12                          76  /**< \brief Pin Number for PC12 */
-#define GPIO_PC12                _UL(1 << 12) /**< \brief GPIO Mask  for PC12 */
+#define GPIO_PC12                _UL_(1 << 12) /**< \brief GPIO Mask  for PC12 */
 #define PIN_PC13                          77  /**< \brief Pin Number for PC13 */
-#define GPIO_PC13                _UL(1 << 13) /**< \brief GPIO Mask  for PC13 */
+#define GPIO_PC13                _UL_(1 << 13) /**< \brief GPIO Mask  for PC13 */
 #define PIN_PC14                          78  /**< \brief Pin Number for PC14 */
-#define GPIO_PC14                _UL(1 << 14) /**< \brief GPIO Mask  for PC14 */
+#define GPIO_PC14                _UL_(1 << 14) /**< \brief GPIO Mask  for PC14 */
 #define PIN_PC15                          79  /**< \brief Pin Number for PC15 */
-#define GPIO_PC15                _UL(1 << 15) /**< \brief GPIO Mask  for PC15 */
+#define GPIO_PC15                _UL_(1 << 15) /**< \brief GPIO Mask  for PC15 */
 #define PIN_PC16                          80  /**< \brief Pin Number for PC16 */
-#define GPIO_PC16                _UL(1 << 16) /**< \brief GPIO Mask  for PC16 */
+#define GPIO_PC16                _UL_(1 << 16) /**< \brief GPIO Mask  for PC16 */
 #define PIN_PC17                          81  /**< \brief Pin Number for PC17 */
-#define GPIO_PC17                _UL(1 << 17) /**< \brief GPIO Mask  for PC17 */
+#define GPIO_PC17                _UL_(1 << 17) /**< \brief GPIO Mask  for PC17 */
 #define PIN_PC18                          82  /**< \brief Pin Number for PC18 */
-#define GPIO_PC18                _UL(1 << 18) /**< \brief GPIO Mask  for PC18 */
+#define GPIO_PC18                _UL_(1 << 18) /**< \brief GPIO Mask  for PC18 */
 #define PIN_PC19                          83  /**< \brief Pin Number for PC19 */
-#define GPIO_PC19                _UL(1 << 19) /**< \brief GPIO Mask  for PC19 */
+#define GPIO_PC19                _UL_(1 << 19) /**< \brief GPIO Mask  for PC19 */
 #define PIN_PC20                          84  /**< \brief Pin Number for PC20 */
-#define GPIO_PC20                _UL(1 << 20) /**< \brief GPIO Mask  for PC20 */
+#define GPIO_PC20                _UL_(1 << 20) /**< \brief GPIO Mask  for PC20 */
 #define PIN_PC21                          85  /**< \brief Pin Number for PC21 */
-#define GPIO_PC21                _UL(1 << 21) /**< \brief GPIO Mask  for PC21 */
+#define GPIO_PC21                _UL_(1 << 21) /**< \brief GPIO Mask  for PC21 */
 #define PIN_PC22                          86  /**< \brief Pin Number for PC22 */
-#define GPIO_PC22                _UL(1 << 22) /**< \brief GPIO Mask  for PC22 */
+#define GPIO_PC22                _UL_(1 << 22) /**< \brief GPIO Mask  for PC22 */
 #define PIN_PC23                          87  /**< \brief Pin Number for PC23 */
-#define GPIO_PC23                _UL(1 << 23) /**< \brief GPIO Mask  for PC23 */
+#define GPIO_PC23                _UL_(1 << 23) /**< \brief GPIO Mask  for PC23 */
 #define PIN_PC24                          88  /**< \brief Pin Number for PC24 */
-#define GPIO_PC24                _UL(1 << 24) /**< \brief GPIO Mask  for PC24 */
+#define GPIO_PC24                _UL_(1 << 24) /**< \brief GPIO Mask  for PC24 */
 #define PIN_PC25                          89  /**< \brief Pin Number for PC25 */
-#define GPIO_PC25                _UL(1 << 25) /**< \brief GPIO Mask  for PC25 */
+#define GPIO_PC25                _UL_(1 << 25) /**< \brief GPIO Mask  for PC25 */
 #define PIN_PC26                          90  /**< \brief Pin Number for PC26 */
-#define GPIO_PC26                _UL(1 << 26) /**< \brief GPIO Mask  for PC26 */
+#define GPIO_PC26                _UL_(1 << 26) /**< \brief GPIO Mask  for PC26 */
 #define PIN_PC27                          91  /**< \brief Pin Number for PC27 */
-#define GPIO_PC27                _UL(1 << 27) /**< \brief GPIO Mask  for PC27 */
+#define GPIO_PC27                _UL_(1 << 27) /**< \brief GPIO Mask  for PC27 */
 #define PIN_PC28                          92  /**< \brief Pin Number for PC28 */
-#define GPIO_PC28                _UL(1 << 28) /**< \brief GPIO Mask  for PC28 */
+#define GPIO_PC28                _UL_(1 << 28) /**< \brief GPIO Mask  for PC28 */
 #define PIN_PC29                          93  /**< \brief Pin Number for PC29 */
-#define GPIO_PC29                _UL(1 << 29) /**< \brief GPIO Mask  for PC29 */
+#define GPIO_PC29                _UL_(1 << 29) /**< \brief GPIO Mask  for PC29 */
 #define PIN_PC30                          94  /**< \brief Pin Number for PC30 */
-#define GPIO_PC30                _UL(1 << 30) /**< \brief GPIO Mask  for PC30 */
+#define GPIO_PC30                _UL_(1 << 30) /**< \brief GPIO Mask  for PC30 */
 #define PIN_PC31                          95  /**< \brief Pin Number for PC31 */
-#define GPIO_PC31                _UL(1 << 31) /**< \brief GPIO Mask  for PC31 */
+#define GPIO_PC31                _UL_(1 << 31) /**< \brief GPIO Mask  for PC31 */
 /* ========== GPIO definition for TWIMS0 peripheral ========== */
-#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
-#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PIN_PA24B_TWIMS0_TWCK          _L_(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L_(1)
 #define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
-#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
-#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
-#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL_(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L_(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L_(1)
 #define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
-#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+#define GPIO_PA23B_TWIMS0_TWD    _UL_(1 << 23)
 /* ========== GPIO definition for TWIMS1 peripheral ========== */
-#define PIN_PB01A_TWIMS1_TWCK          _L(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
-#define MUX_PB01A_TWIMS1_TWCK           _L(0)
+#define PIN_PB01A_TWIMS1_TWCK          _L_(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
+#define MUX_PB01A_TWIMS1_TWCK           _L_(0)
 #define PINMUX_PB01A_TWIMS1_TWCK   ((PIN_PB01A_TWIMS1_TWCK << 16) | MUX_PB01A_TWIMS1_TWCK)
-#define GPIO_PB01A_TWIMS1_TWCK   _UL(1 <<  1)
-#define PIN_PB00A_TWIMS1_TWD           _L(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
-#define MUX_PB00A_TWIMS1_TWD            _L(0)
+#define GPIO_PB01A_TWIMS1_TWCK   _UL_(1 <<  1)
+#define PIN_PB00A_TWIMS1_TWD           _L_(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
+#define MUX_PB00A_TWIMS1_TWD            _L_(0)
 #define PINMUX_PB00A_TWIMS1_TWD    ((PIN_PB00A_TWIMS1_TWD << 16) | MUX_PB00A_TWIMS1_TWD)
-#define GPIO_PB00A_TWIMS1_TWD    _UL(1 <<  0)
+#define GPIO_PB00A_TWIMS1_TWD    _UL_(1 <<  0)
 /* ========== GPIO definition for TWIMS2 peripheral ========== */
-#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
-#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PIN_PA22E_TWIMS2_TWCK          _L_(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L_(4)
 #define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
-#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
-#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
-#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL_(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L_(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L_(4)
 #define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
-#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+#define GPIO_PA21E_TWIMS2_TWD    _UL_(1 << 21)
 /* ========== GPIO definition for TWIMS3 peripheral ========== */
-#define PIN_PB15C_TWIMS3_TWCK          _L(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
-#define MUX_PB15C_TWIMS3_TWCK           _L(2)
+#define PIN_PB15C_TWIMS3_TWCK          _L_(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
+#define MUX_PB15C_TWIMS3_TWCK           _L_(2)
 #define PINMUX_PB15C_TWIMS3_TWCK   ((PIN_PB15C_TWIMS3_TWCK << 16) | MUX_PB15C_TWIMS3_TWCK)
-#define GPIO_PB15C_TWIMS3_TWCK   _UL(1 << 15)
-#define PIN_PB14C_TWIMS3_TWD           _L(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
-#define MUX_PB14C_TWIMS3_TWD            _L(2)
+#define GPIO_PB15C_TWIMS3_TWCK   _UL_(1 << 15)
+#define PIN_PB14C_TWIMS3_TWD           _L_(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
+#define MUX_PB14C_TWIMS3_TWD            _L_(2)
 #define PINMUX_PB14C_TWIMS3_TWD    ((PIN_PB14C_TWIMS3_TWD << 16) | MUX_PB14C_TWIMS3_TWD)
-#define GPIO_PB14C_TWIMS3_TWD    _UL(1 << 14)
+#define GPIO_PB14C_TWIMS3_TWD    _UL_(1 << 14)
 /* ========== GPIO definition for IISC peripheral ========== */
-#define PIN_PB05D_IISC_IMCK            _L(37) /**< \brief IISC signal: IMCK on PB05 mux D */
-#define MUX_PB05D_IISC_IMCK             _L(3)
+#define PIN_PB05D_IISC_IMCK            _L_(37) /**< \brief IISC signal: IMCK on PB05 mux D */
+#define MUX_PB05D_IISC_IMCK             _L_(3)
 #define PINMUX_PB05D_IISC_IMCK     ((PIN_PB05D_IISC_IMCK << 16) | MUX_PB05D_IISC_IMCK)
-#define GPIO_PB05D_IISC_IMCK     _UL(1 <<  5)
-#define PIN_PC14D_IISC_IMCK            _L(78) /**< \brief IISC signal: IMCK on PC14 mux D */
-#define MUX_PC14D_IISC_IMCK             _L(3)
+#define GPIO_PB05D_IISC_IMCK     _UL_(1 <<  5)
+#define PIN_PC14D_IISC_IMCK            _L_(78) /**< \brief IISC signal: IMCK on PC14 mux D */
+#define MUX_PC14D_IISC_IMCK             _L_(3)
 #define PINMUX_PC14D_IISC_IMCK     ((PIN_PC14D_IISC_IMCK << 16) | MUX_PC14D_IISC_IMCK)
-#define GPIO_PC14D_IISC_IMCK     _UL(1 << 14)
-#define PIN_PB02D_IISC_ISCK            _L(34) /**< \brief IISC signal: ISCK on PB02 mux D */
-#define MUX_PB02D_IISC_ISCK             _L(3)
+#define GPIO_PC14D_IISC_IMCK     _UL_(1 << 14)
+#define PIN_PB02D_IISC_ISCK            _L_(34) /**< \brief IISC signal: ISCK on PB02 mux D */
+#define MUX_PB02D_IISC_ISCK             _L_(3)
 #define PINMUX_PB02D_IISC_ISCK     ((PIN_PB02D_IISC_ISCK << 16) | MUX_PB02D_IISC_ISCK)
-#define GPIO_PB02D_IISC_ISCK     _UL(1 <<  2)
-#define PIN_PC09D_IISC_ISCK            _L(73) /**< \brief IISC signal: ISCK on PC09 mux D */
-#define MUX_PC09D_IISC_ISCK             _L(3)
+#define GPIO_PB02D_IISC_ISCK     _UL_(1 <<  2)
+#define PIN_PC09D_IISC_ISCK            _L_(73) /**< \brief IISC signal: ISCK on PC09 mux D */
+#define MUX_PC09D_IISC_ISCK             _L_(3)
 #define PINMUX_PC09D_IISC_ISCK     ((PIN_PC09D_IISC_ISCK << 16) | MUX_PC09D_IISC_ISCK)
-#define GPIO_PC09D_IISC_ISCK     _UL(1 <<  9)
-#define PIN_PB03D_IISC_ISDI            _L(35) /**< \brief IISC signal: ISDI on PB03 mux D */
-#define MUX_PB03D_IISC_ISDI             _L(3)
+#define GPIO_PC09D_IISC_ISCK     _UL_(1 <<  9)
+#define PIN_PB03D_IISC_ISDI            _L_(35) /**< \brief IISC signal: ISDI on PB03 mux D */
+#define MUX_PB03D_IISC_ISDI             _L_(3)
 #define PINMUX_PB03D_IISC_ISDI     ((PIN_PB03D_IISC_ISDI << 16) | MUX_PB03D_IISC_ISDI)
-#define GPIO_PB03D_IISC_ISDI     _UL(1 <<  3)
-#define PIN_PC10D_IISC_ISDI            _L(74) /**< \brief IISC signal: ISDI on PC10 mux D */
-#define MUX_PC10D_IISC_ISDI             _L(3)
+#define GPIO_PB03D_IISC_ISDI     _UL_(1 <<  3)
+#define PIN_PC10D_IISC_ISDI            _L_(74) /**< \brief IISC signal: ISDI on PC10 mux D */
+#define MUX_PC10D_IISC_ISDI             _L_(3)
 #define PINMUX_PC10D_IISC_ISDI     ((PIN_PC10D_IISC_ISDI << 16) | MUX_PC10D_IISC_ISDI)
-#define GPIO_PC10D_IISC_ISDI     _UL(1 << 10)
-#define PIN_PB04D_IISC_ISDO            _L(36) /**< \brief IISC signal: ISDO on PB04 mux D */
-#define MUX_PB04D_IISC_ISDO             _L(3)
+#define GPIO_PC10D_IISC_ISDI     _UL_(1 << 10)
+#define PIN_PB04D_IISC_ISDO            _L_(36) /**< \brief IISC signal: ISDO on PB04 mux D */
+#define MUX_PB04D_IISC_ISDO             _L_(3)
 #define PINMUX_PB04D_IISC_ISDO     ((PIN_PB04D_IISC_ISDO << 16) | MUX_PB04D_IISC_ISDO)
-#define GPIO_PB04D_IISC_ISDO     _UL(1 <<  4)
-#define PIN_PC13D_IISC_ISDO            _L(77) /**< \brief IISC signal: ISDO on PC13 mux D */
-#define MUX_PC13D_IISC_ISDO             _L(3)
+#define GPIO_PB04D_IISC_ISDO     _UL_(1 <<  4)
+#define PIN_PC13D_IISC_ISDO            _L_(77) /**< \brief IISC signal: ISDO on PC13 mux D */
+#define MUX_PC13D_IISC_ISDO             _L_(3)
 #define PINMUX_PC13D_IISC_ISDO     ((PIN_PC13D_IISC_ISDO << 16) | MUX_PC13D_IISC_ISDO)
-#define GPIO_PC13D_IISC_ISDO     _UL(1 << 13)
-#define PIN_PB06D_IISC_IWS             _L(38) /**< \brief IISC signal: IWS on PB06 mux D */
-#define MUX_PB06D_IISC_IWS              _L(3)
+#define GPIO_PC13D_IISC_ISDO     _UL_(1 << 13)
+#define PIN_PB06D_IISC_IWS             _L_(38) /**< \brief IISC signal: IWS on PB06 mux D */
+#define MUX_PB06D_IISC_IWS              _L_(3)
 #define PINMUX_PB06D_IISC_IWS      ((PIN_PB06D_IISC_IWS << 16) | MUX_PB06D_IISC_IWS)
-#define GPIO_PB06D_IISC_IWS      _UL(1 <<  6)
-#define PIN_PC12D_IISC_IWS             _L(76) /**< \brief IISC signal: IWS on PC12 mux D */
-#define MUX_PC12D_IISC_IWS              _L(3)
+#define GPIO_PB06D_IISC_IWS      _UL_(1 <<  6)
+#define PIN_PC12D_IISC_IWS             _L_(76) /**< \brief IISC signal: IWS on PC12 mux D */
+#define MUX_PC12D_IISC_IWS              _L_(3)
 #define PINMUX_PC12D_IISC_IWS      ((PIN_PC12D_IISC_IWS << 16) | MUX_PC12D_IISC_IWS)
-#define GPIO_PC12D_IISC_IWS      _UL(1 << 12)
+#define GPIO_PC12D_IISC_IWS      _UL_(1 << 12)
 /* ========== GPIO definition for SPI peripheral ========== */
-#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
-#define MUX_PA03B_SPI_MISO              _L(1)
+#define PIN_PA03B_SPI_MISO              _L_(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L_(1)
 #define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
-#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
-#define PIN_PB14B_SPI_MISO             _L(46) /**< \brief SPI signal: MISO on PB14 mux B */
-#define MUX_PB14B_SPI_MISO              _L(1)
+#define GPIO_PA03B_SPI_MISO      _UL_(1 <<  3)
+#define PIN_PB14B_SPI_MISO             _L_(46) /**< \brief SPI signal: MISO on PB14 mux B */
+#define MUX_PB14B_SPI_MISO              _L_(1)
 #define PINMUX_PB14B_SPI_MISO      ((PIN_PB14B_SPI_MISO << 16) | MUX_PB14B_SPI_MISO)
-#define GPIO_PB14B_SPI_MISO      _UL(1 << 14)
-#define PIN_PC28B_SPI_MISO             _L(92) /**< \brief SPI signal: MISO on PC28 mux B */
-#define MUX_PC28B_SPI_MISO              _L(1)
+#define GPIO_PB14B_SPI_MISO      _UL_(1 << 14)
+#define PIN_PC28B_SPI_MISO             _L_(92) /**< \brief SPI signal: MISO on PC28 mux B */
+#define MUX_PC28B_SPI_MISO              _L_(1)
 #define PINMUX_PC28B_SPI_MISO      ((PIN_PC28B_SPI_MISO << 16) | MUX_PC28B_SPI_MISO)
-#define GPIO_PC28B_SPI_MISO      _UL(1 << 28)
-#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
-#define MUX_PA21A_SPI_MISO              _L(0)
+#define GPIO_PC28B_SPI_MISO      _UL_(1 << 28)
+#define PIN_PA21A_SPI_MISO             _L_(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L_(0)
 #define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
-#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
-#define PIN_PC04A_SPI_MISO             _L(68) /**< \brief SPI signal: MISO on PC04 mux A */
-#define MUX_PC04A_SPI_MISO              _L(0)
+#define GPIO_PA21A_SPI_MISO      _UL_(1 << 21)
+#define PIN_PC04A_SPI_MISO             _L_(68) /**< \brief SPI signal: MISO on PC04 mux A */
+#define MUX_PC04A_SPI_MISO              _L_(0)
 #define PINMUX_PC04A_SPI_MISO      ((PIN_PC04A_SPI_MISO << 16) | MUX_PC04A_SPI_MISO)
-#define GPIO_PC04A_SPI_MISO      _UL(1 <<  4)
-#define PIN_PB15B_SPI_MOSI             _L(47) /**< \brief SPI signal: MOSI on PB15 mux B */
-#define MUX_PB15B_SPI_MOSI              _L(1)
+#define GPIO_PC04A_SPI_MISO      _UL_(1 <<  4)
+#define PIN_PB15B_SPI_MOSI             _L_(47) /**< \brief SPI signal: MOSI on PB15 mux B */
+#define MUX_PB15B_SPI_MOSI              _L_(1)
 #define PINMUX_PB15B_SPI_MOSI      ((PIN_PB15B_SPI_MOSI << 16) | MUX_PB15B_SPI_MOSI)
-#define GPIO_PB15B_SPI_MOSI      _UL(1 << 15)
-#define PIN_PC29B_SPI_MOSI             _L(93) /**< \brief SPI signal: MOSI on PC29 mux B */
-#define MUX_PC29B_SPI_MOSI              _L(1)
+#define GPIO_PB15B_SPI_MOSI      _UL_(1 << 15)
+#define PIN_PC29B_SPI_MOSI             _L_(93) /**< \brief SPI signal: MOSI on PC29 mux B */
+#define MUX_PC29B_SPI_MOSI              _L_(1)
 #define PINMUX_PC29B_SPI_MOSI      ((PIN_PC29B_SPI_MOSI << 16) | MUX_PC29B_SPI_MOSI)
-#define GPIO_PC29B_SPI_MOSI      _UL(1 << 29)
-#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
-#define MUX_PA22A_SPI_MOSI              _L(0)
+#define GPIO_PC29B_SPI_MOSI      _UL_(1 << 29)
+#define PIN_PA22A_SPI_MOSI             _L_(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L_(0)
 #define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
-#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
-#define PIN_PC05A_SPI_MOSI             _L(69) /**< \brief SPI signal: MOSI on PC05 mux A */
-#define MUX_PC05A_SPI_MOSI              _L(0)
+#define GPIO_PA22A_SPI_MOSI      _UL_(1 << 22)
+#define PIN_PC05A_SPI_MOSI             _L_(69) /**< \brief SPI signal: MOSI on PC05 mux A */
+#define MUX_PC05A_SPI_MOSI              _L_(0)
 #define PINMUX_PC05A_SPI_MOSI      ((PIN_PC05A_SPI_MOSI << 16) | MUX_PC05A_SPI_MOSI)
-#define GPIO_PC05A_SPI_MOSI      _UL(1 <<  5)
-#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
-#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define GPIO_PC05A_SPI_MOSI      _UL_(1 <<  5)
+#define PIN_PA02B_SPI_NPCS0             _L_(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L_(1)
 #define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
-#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
-#define PIN_PC31B_SPI_NPCS0            _L(95) /**< \brief SPI signal: NPCS0 on PC31 mux B */
-#define MUX_PC31B_SPI_NPCS0             _L(1)
+#define GPIO_PA02B_SPI_NPCS0     _UL_(1 <<  2)
+#define PIN_PC31B_SPI_NPCS0            _L_(95) /**< \brief SPI signal: NPCS0 on PC31 mux B */
+#define MUX_PC31B_SPI_NPCS0             _L_(1)
 #define PINMUX_PC31B_SPI_NPCS0     ((PIN_PC31B_SPI_NPCS0 << 16) | MUX_PC31B_SPI_NPCS0)
-#define GPIO_PC31B_SPI_NPCS0     _UL(1 << 31)
-#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
-#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define GPIO_PC31B_SPI_NPCS0     _UL_(1 << 31)
+#define PIN_PA24A_SPI_NPCS0            _L_(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L_(0)
 #define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
-#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
-#define PIN_PC03A_SPI_NPCS0            _L(67) /**< \brief SPI signal: NPCS0 on PC03 mux A */
-#define MUX_PC03A_SPI_NPCS0             _L(0)
+#define GPIO_PA24A_SPI_NPCS0     _UL_(1 << 24)
+#define PIN_PC03A_SPI_NPCS0            _L_(67) /**< \brief SPI signal: NPCS0 on PC03 mux A */
+#define MUX_PC03A_SPI_NPCS0             _L_(0)
 #define PINMUX_PC03A_SPI_NPCS0     ((PIN_PC03A_SPI_NPCS0 << 16) | MUX_PC03A_SPI_NPCS0)
-#define GPIO_PC03A_SPI_NPCS0     _UL(1 <<  3)
-#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
-#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define GPIO_PC03A_SPI_NPCS0     _UL_(1 <<  3)
+#define PIN_PA13C_SPI_NPCS1            _L_(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L_(2)
 #define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
-#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PB13B_SPI_NPCS1            _L(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
-#define MUX_PB13B_SPI_NPCS1             _L(1)
+#define GPIO_PA13C_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PB13B_SPI_NPCS1            _L_(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
+#define MUX_PB13B_SPI_NPCS1             _L_(1)
 #define PINMUX_PB13B_SPI_NPCS1     ((PIN_PB13B_SPI_NPCS1 << 16) | MUX_PB13B_SPI_NPCS1)
-#define GPIO_PB13B_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PC02A_SPI_NPCS1            _L(66) /**< \brief SPI signal: NPCS1 on PC02 mux A */
-#define MUX_PC02A_SPI_NPCS1             _L(0)
+#define GPIO_PB13B_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PC02A_SPI_NPCS1            _L_(66) /**< \brief SPI signal: NPCS1 on PC02 mux A */
+#define MUX_PC02A_SPI_NPCS1             _L_(0)
 #define PINMUX_PC02A_SPI_NPCS1     ((PIN_PC02A_SPI_NPCS1 << 16) | MUX_PC02A_SPI_NPCS1)
-#define GPIO_PC02A_SPI_NPCS1     _UL(1 <<  2)
-#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
-#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define GPIO_PC02A_SPI_NPCS1     _UL_(1 <<  2)
+#define PIN_PA14C_SPI_NPCS2            _L_(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L_(2)
 #define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
-#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
-#define PIN_PB11B_SPI_NPCS2            _L(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
-#define MUX_PB11B_SPI_NPCS2             _L(1)
+#define GPIO_PA14C_SPI_NPCS2     _UL_(1 << 14)
+#define PIN_PB11B_SPI_NPCS2            _L_(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
+#define MUX_PB11B_SPI_NPCS2             _L_(1)
 #define PINMUX_PB11B_SPI_NPCS2     ((PIN_PB11B_SPI_NPCS2 << 16) | MUX_PB11B_SPI_NPCS2)
-#define GPIO_PB11B_SPI_NPCS2     _UL(1 << 11)
-#define PIN_PC00A_SPI_NPCS2            _L(64) /**< \brief SPI signal: NPCS2 on PC00 mux A */
-#define MUX_PC00A_SPI_NPCS2             _L(0)
+#define GPIO_PB11B_SPI_NPCS2     _UL_(1 << 11)
+#define PIN_PC00A_SPI_NPCS2            _L_(64) /**< \brief SPI signal: NPCS2 on PC00 mux A */
+#define MUX_PC00A_SPI_NPCS2             _L_(0)
 #define PINMUX_PC00A_SPI_NPCS2     ((PIN_PC00A_SPI_NPCS2 << 16) | MUX_PC00A_SPI_NPCS2)
-#define GPIO_PC00A_SPI_NPCS2     _UL(1 <<  0)
-#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
-#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define GPIO_PC00A_SPI_NPCS2     _UL_(1 <<  0)
+#define PIN_PA15C_SPI_NPCS3            _L_(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L_(2)
 #define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
-#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
-#define PIN_PB12B_SPI_NPCS3            _L(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
-#define MUX_PB12B_SPI_NPCS3             _L(1)
+#define GPIO_PA15C_SPI_NPCS3     _UL_(1 << 15)
+#define PIN_PB12B_SPI_NPCS3            _L_(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
+#define MUX_PB12B_SPI_NPCS3             _L_(1)
 #define PINMUX_PB12B_SPI_NPCS3     ((PIN_PB12B_SPI_NPCS3 << 16) | MUX_PB12B_SPI_NPCS3)
-#define GPIO_PB12B_SPI_NPCS3     _UL(1 << 12)
-#define PIN_PC01A_SPI_NPCS3            _L(65) /**< \brief SPI signal: NPCS3 on PC01 mux A */
-#define MUX_PC01A_SPI_NPCS3             _L(0)
+#define GPIO_PB12B_SPI_NPCS3     _UL_(1 << 12)
+#define PIN_PC01A_SPI_NPCS3            _L_(65) /**< \brief SPI signal: NPCS3 on PC01 mux A */
+#define MUX_PC01A_SPI_NPCS3             _L_(0)
 #define PINMUX_PC01A_SPI_NPCS3     ((PIN_PC01A_SPI_NPCS3 << 16) | MUX_PC01A_SPI_NPCS3)
-#define GPIO_PC01A_SPI_NPCS3     _UL(1 <<  1)
-#define PIN_PC30B_SPI_SCK              _L(94) /**< \brief SPI signal: SCK on PC30 mux B */
-#define MUX_PC30B_SPI_SCK               _L(1)
+#define GPIO_PC01A_SPI_NPCS3     _UL_(1 <<  1)
+#define PIN_PC30B_SPI_SCK              _L_(94) /**< \brief SPI signal: SCK on PC30 mux B */
+#define MUX_PC30B_SPI_SCK               _L_(1)
 #define PINMUX_PC30B_SPI_SCK       ((PIN_PC30B_SPI_SCK << 16) | MUX_PC30B_SPI_SCK)
-#define GPIO_PC30B_SPI_SCK       _UL(1 << 30)
-#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
-#define MUX_PA23A_SPI_SCK               _L(0)
+#define GPIO_PC30B_SPI_SCK       _UL_(1 << 30)
+#define PIN_PA23A_SPI_SCK              _L_(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L_(0)
 #define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
-#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
-#define PIN_PC06A_SPI_SCK              _L(70) /**< \brief SPI signal: SCK on PC06 mux A */
-#define MUX_PC06A_SPI_SCK               _L(0)
+#define GPIO_PA23A_SPI_SCK       _UL_(1 << 23)
+#define PIN_PC06A_SPI_SCK              _L_(70) /**< \brief SPI signal: SCK on PC06 mux A */
+#define MUX_PC06A_SPI_SCK               _L_(0)
 #define PINMUX_PC06A_SPI_SCK       ((PIN_PC06A_SPI_SCK << 16) | MUX_PC06A_SPI_SCK)
-#define GPIO_PC06A_SPI_SCK       _UL(1 <<  6)
+#define GPIO_PC06A_SPI_SCK       _UL_(1 <<  6)
 /* ========== GPIO definition for TC0 peripheral ========== */
-#define PIN_PB07D_TC0_A0               _L(39) /**< \brief TC0 signal: A0 on PB07 mux D */
-#define MUX_PB07D_TC0_A0                _L(3)
+#define PIN_PB07D_TC0_A0               _L_(39) /**< \brief TC0 signal: A0 on PB07 mux D */
+#define MUX_PB07D_TC0_A0                _L_(3)
 #define PINMUX_PB07D_TC0_A0        ((PIN_PB07D_TC0_A0 << 16) | MUX_PB07D_TC0_A0)
-#define GPIO_PB07D_TC0_A0        _UL(1 <<  7)
-#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
-#define MUX_PA08B_TC0_A0                _L(1)
+#define GPIO_PB07D_TC0_A0        _UL_(1 <<  7)
+#define PIN_PA08B_TC0_A0                _L_(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L_(1)
 #define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
-#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
-#define PIN_PB09D_TC0_A1               _L(41) /**< \brief TC0 signal: A1 on PB09 mux D */
-#define MUX_PB09D_TC0_A1                _L(3)
+#define GPIO_PA08B_TC0_A0        _UL_(1 <<  8)
+#define PIN_PB09D_TC0_A1               _L_(41) /**< \brief TC0 signal: A1 on PB09 mux D */
+#define MUX_PB09D_TC0_A1                _L_(3)
 #define PINMUX_PB09D_TC0_A1        ((PIN_PB09D_TC0_A1 << 16) | MUX_PB09D_TC0_A1)
-#define GPIO_PB09D_TC0_A1        _UL(1 <<  9)
-#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
-#define MUX_PA10B_TC0_A1                _L(1)
+#define GPIO_PB09D_TC0_A1        _UL_(1 <<  9)
+#define PIN_PA10B_TC0_A1               _L_(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L_(1)
 #define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
-#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
-#define PIN_PB11D_TC0_A2               _L(43) /**< \brief TC0 signal: A2 on PB11 mux D */
-#define MUX_PB11D_TC0_A2                _L(3)
+#define GPIO_PA10B_TC0_A1        _UL_(1 << 10)
+#define PIN_PB11D_TC0_A2               _L_(43) /**< \brief TC0 signal: A2 on PB11 mux D */
+#define MUX_PB11D_TC0_A2                _L_(3)
 #define PINMUX_PB11D_TC0_A2        ((PIN_PB11D_TC0_A2 << 16) | MUX_PB11D_TC0_A2)
-#define GPIO_PB11D_TC0_A2        _UL(1 << 11)
-#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
-#define MUX_PA12B_TC0_A2                _L(1)
+#define GPIO_PB11D_TC0_A2        _UL_(1 << 11)
+#define PIN_PA12B_TC0_A2               _L_(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L_(1)
 #define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
-#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
-#define PIN_PB08D_TC0_B0               _L(40) /**< \brief TC0 signal: B0 on PB08 mux D */
-#define MUX_PB08D_TC0_B0                _L(3)
+#define GPIO_PA12B_TC0_A2        _UL_(1 << 12)
+#define PIN_PB08D_TC0_B0               _L_(40) /**< \brief TC0 signal: B0 on PB08 mux D */
+#define MUX_PB08D_TC0_B0                _L_(3)
 #define PINMUX_PB08D_TC0_B0        ((PIN_PB08D_TC0_B0 << 16) | MUX_PB08D_TC0_B0)
-#define GPIO_PB08D_TC0_B0        _UL(1 <<  8)
-#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
-#define MUX_PA09B_TC0_B0                _L(1)
+#define GPIO_PB08D_TC0_B0        _UL_(1 <<  8)
+#define PIN_PA09B_TC0_B0                _L_(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L_(1)
 #define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
-#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
-#define PIN_PB10D_TC0_B1               _L(42) /**< \brief TC0 signal: B1 on PB10 mux D */
-#define MUX_PB10D_TC0_B1                _L(3)
+#define GPIO_PA09B_TC0_B0        _UL_(1 <<  9)
+#define PIN_PB10D_TC0_B1               _L_(42) /**< \brief TC0 signal: B1 on PB10 mux D */
+#define MUX_PB10D_TC0_B1                _L_(3)
 #define PINMUX_PB10D_TC0_B1        ((PIN_PB10D_TC0_B1 << 16) | MUX_PB10D_TC0_B1)
-#define GPIO_PB10D_TC0_B1        _UL(1 << 10)
-#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
-#define MUX_PA11B_TC0_B1                _L(1)
+#define GPIO_PB10D_TC0_B1        _UL_(1 << 10)
+#define PIN_PA11B_TC0_B1               _L_(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L_(1)
 #define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
-#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
-#define PIN_PB12D_TC0_B2               _L(44) /**< \brief TC0 signal: B2 on PB12 mux D */
-#define MUX_PB12D_TC0_B2                _L(3)
+#define GPIO_PA11B_TC0_B1        _UL_(1 << 11)
+#define PIN_PB12D_TC0_B2               _L_(44) /**< \brief TC0 signal: B2 on PB12 mux D */
+#define MUX_PB12D_TC0_B2                _L_(3)
 #define PINMUX_PB12D_TC0_B2        ((PIN_PB12D_TC0_B2 << 16) | MUX_PB12D_TC0_B2)
-#define GPIO_PB12D_TC0_B2        _UL(1 << 12)
-#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
-#define MUX_PA13B_TC0_B2                _L(1)
+#define GPIO_PB12D_TC0_B2        _UL_(1 << 12)
+#define PIN_PA13B_TC0_B2               _L_(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L_(1)
 #define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
-#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
-#define PIN_PB13D_TC0_CLK0             _L(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
-#define MUX_PB13D_TC0_CLK0              _L(3)
+#define GPIO_PA13B_TC0_B2        _UL_(1 << 13)
+#define PIN_PB13D_TC0_CLK0             _L_(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
+#define MUX_PB13D_TC0_CLK0              _L_(3)
 #define PINMUX_PB13D_TC0_CLK0      ((PIN_PB13D_TC0_CLK0 << 16) | MUX_PB13D_TC0_CLK0)
-#define GPIO_PB13D_TC0_CLK0      _UL(1 << 13)
-#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
-#define MUX_PA14B_TC0_CLK0              _L(1)
+#define GPIO_PB13D_TC0_CLK0      _UL_(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L_(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L_(1)
 #define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
-#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
-#define PIN_PB14D_TC0_CLK1             _L(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
-#define MUX_PB14D_TC0_CLK1              _L(3)
+#define GPIO_PA14B_TC0_CLK0      _UL_(1 << 14)
+#define PIN_PB14D_TC0_CLK1             _L_(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
+#define MUX_PB14D_TC0_CLK1              _L_(3)
 #define PINMUX_PB14D_TC0_CLK1      ((PIN_PB14D_TC0_CLK1 << 16) | MUX_PB14D_TC0_CLK1)
-#define GPIO_PB14D_TC0_CLK1      _UL(1 << 14)
-#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
-#define MUX_PA15B_TC0_CLK1              _L(1)
+#define GPIO_PB14D_TC0_CLK1      _UL_(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L_(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L_(1)
 #define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
-#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
-#define PIN_PB15D_TC0_CLK2             _L(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
-#define MUX_PB15D_TC0_CLK2              _L(3)
+#define GPIO_PA15B_TC0_CLK1      _UL_(1 << 15)
+#define PIN_PB15D_TC0_CLK2             _L_(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
+#define MUX_PB15D_TC0_CLK2              _L_(3)
 #define PINMUX_PB15D_TC0_CLK2      ((PIN_PB15D_TC0_CLK2 << 16) | MUX_PB15D_TC0_CLK2)
-#define GPIO_PB15D_TC0_CLK2      _UL(1 << 15)
-#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
-#define MUX_PA16B_TC0_CLK2              _L(1)
+#define GPIO_PB15D_TC0_CLK2      _UL_(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L_(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L_(1)
 #define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
-#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+#define GPIO_PA16B_TC0_CLK2      _UL_(1 << 16)
 /* ========== GPIO definition for TC1 peripheral ========== */
-#define PIN_PC00D_TC1_A0               _L(64) /**< \brief TC1 signal: A0 on PC00 mux D */
-#define MUX_PC00D_TC1_A0                _L(3)
+#define PIN_PC00D_TC1_A0               _L_(64) /**< \brief TC1 signal: A0 on PC00 mux D */
+#define MUX_PC00D_TC1_A0                _L_(3)
 #define PINMUX_PC00D_TC1_A0        ((PIN_PC00D_TC1_A0 << 16) | MUX_PC00D_TC1_A0)
-#define GPIO_PC00D_TC1_A0        _UL(1 <<  0)
-#define PIN_PC15A_TC1_A0               _L(79) /**< \brief TC1 signal: A0 on PC15 mux A */
-#define MUX_PC15A_TC1_A0                _L(0)
+#define GPIO_PC00D_TC1_A0        _UL_(1 <<  0)
+#define PIN_PC15A_TC1_A0               _L_(79) /**< \brief TC1 signal: A0 on PC15 mux A */
+#define MUX_PC15A_TC1_A0                _L_(0)
 #define PINMUX_PC15A_TC1_A0        ((PIN_PC15A_TC1_A0 << 16) | MUX_PC15A_TC1_A0)
-#define GPIO_PC15A_TC1_A0        _UL(1 << 15)
-#define PIN_PC02D_TC1_A1               _L(66) /**< \brief TC1 signal: A1 on PC02 mux D */
-#define MUX_PC02D_TC1_A1                _L(3)
+#define GPIO_PC15A_TC1_A0        _UL_(1 << 15)
+#define PIN_PC02D_TC1_A1               _L_(66) /**< \brief TC1 signal: A1 on PC02 mux D */
+#define MUX_PC02D_TC1_A1                _L_(3)
 #define PINMUX_PC02D_TC1_A1        ((PIN_PC02D_TC1_A1 << 16) | MUX_PC02D_TC1_A1)
-#define GPIO_PC02D_TC1_A1        _UL(1 <<  2)
-#define PIN_PC17A_TC1_A1               _L(81) /**< \brief TC1 signal: A1 on PC17 mux A */
-#define MUX_PC17A_TC1_A1                _L(0)
+#define GPIO_PC02D_TC1_A1        _UL_(1 <<  2)
+#define PIN_PC17A_TC1_A1               _L_(81) /**< \brief TC1 signal: A1 on PC17 mux A */
+#define MUX_PC17A_TC1_A1                _L_(0)
 #define PINMUX_PC17A_TC1_A1        ((PIN_PC17A_TC1_A1 << 16) | MUX_PC17A_TC1_A1)
-#define GPIO_PC17A_TC1_A1        _UL(1 << 17)
-#define PIN_PC04D_TC1_A2               _L(68) /**< \brief TC1 signal: A2 on PC04 mux D */
-#define MUX_PC04D_TC1_A2                _L(3)
+#define GPIO_PC17A_TC1_A1        _UL_(1 << 17)
+#define PIN_PC04D_TC1_A2               _L_(68) /**< \brief TC1 signal: A2 on PC04 mux D */
+#define MUX_PC04D_TC1_A2                _L_(3)
 #define PINMUX_PC04D_TC1_A2        ((PIN_PC04D_TC1_A2 << 16) | MUX_PC04D_TC1_A2)
-#define GPIO_PC04D_TC1_A2        _UL(1 <<  4)
-#define PIN_PC19A_TC1_A2               _L(83) /**< \brief TC1 signal: A2 on PC19 mux A */
-#define MUX_PC19A_TC1_A2                _L(0)
+#define GPIO_PC04D_TC1_A2        _UL_(1 <<  4)
+#define PIN_PC19A_TC1_A2               _L_(83) /**< \brief TC1 signal: A2 on PC19 mux A */
+#define MUX_PC19A_TC1_A2                _L_(0)
 #define PINMUX_PC19A_TC1_A2        ((PIN_PC19A_TC1_A2 << 16) | MUX_PC19A_TC1_A2)
-#define GPIO_PC19A_TC1_A2        _UL(1 << 19)
-#define PIN_PC01D_TC1_B0               _L(65) /**< \brief TC1 signal: B0 on PC01 mux D */
-#define MUX_PC01D_TC1_B0                _L(3)
+#define GPIO_PC19A_TC1_A2        _UL_(1 << 19)
+#define PIN_PC01D_TC1_B0               _L_(65) /**< \brief TC1 signal: B0 on PC01 mux D */
+#define MUX_PC01D_TC1_B0                _L_(3)
 #define PINMUX_PC01D_TC1_B0        ((PIN_PC01D_TC1_B0 << 16) | MUX_PC01D_TC1_B0)
-#define GPIO_PC01D_TC1_B0        _UL(1 <<  1)
-#define PIN_PC16A_TC1_B0               _L(80) /**< \brief TC1 signal: B0 on PC16 mux A */
-#define MUX_PC16A_TC1_B0                _L(0)
+#define GPIO_PC01D_TC1_B0        _UL_(1 <<  1)
+#define PIN_PC16A_TC1_B0               _L_(80) /**< \brief TC1 signal: B0 on PC16 mux A */
+#define MUX_PC16A_TC1_B0                _L_(0)
 #define PINMUX_PC16A_TC1_B0        ((PIN_PC16A_TC1_B0 << 16) | MUX_PC16A_TC1_B0)
-#define GPIO_PC16A_TC1_B0        _UL(1 << 16)
-#define PIN_PC03D_TC1_B1               _L(67) /**< \brief TC1 signal: B1 on PC03 mux D */
-#define MUX_PC03D_TC1_B1                _L(3)
+#define GPIO_PC16A_TC1_B0        _UL_(1 << 16)
+#define PIN_PC03D_TC1_B1               _L_(67) /**< \brief TC1 signal: B1 on PC03 mux D */
+#define MUX_PC03D_TC1_B1                _L_(3)
 #define PINMUX_PC03D_TC1_B1        ((PIN_PC03D_TC1_B1 << 16) | MUX_PC03D_TC1_B1)
-#define GPIO_PC03D_TC1_B1        _UL(1 <<  3)
-#define PIN_PC18A_TC1_B1               _L(82) /**< \brief TC1 signal: B1 on PC18 mux A */
-#define MUX_PC18A_TC1_B1                _L(0)
+#define GPIO_PC03D_TC1_B1        _UL_(1 <<  3)
+#define PIN_PC18A_TC1_B1               _L_(82) /**< \brief TC1 signal: B1 on PC18 mux A */
+#define MUX_PC18A_TC1_B1                _L_(0)
 #define PINMUX_PC18A_TC1_B1        ((PIN_PC18A_TC1_B1 << 16) | MUX_PC18A_TC1_B1)
-#define GPIO_PC18A_TC1_B1        _UL(1 << 18)
-#define PIN_PC05D_TC1_B2               _L(69) /**< \brief TC1 signal: B2 on PC05 mux D */
-#define MUX_PC05D_TC1_B2                _L(3)
+#define GPIO_PC18A_TC1_B1        _UL_(1 << 18)
+#define PIN_PC05D_TC1_B2               _L_(69) /**< \brief TC1 signal: B2 on PC05 mux D */
+#define MUX_PC05D_TC1_B2                _L_(3)
 #define PINMUX_PC05D_TC1_B2        ((PIN_PC05D_TC1_B2 << 16) | MUX_PC05D_TC1_B2)
-#define GPIO_PC05D_TC1_B2        _UL(1 <<  5)
-#define PIN_PC20A_TC1_B2               _L(84) /**< \brief TC1 signal: B2 on PC20 mux A */
-#define MUX_PC20A_TC1_B2                _L(0)
+#define GPIO_PC05D_TC1_B2        _UL_(1 <<  5)
+#define PIN_PC20A_TC1_B2               _L_(84) /**< \brief TC1 signal: B2 on PC20 mux A */
+#define MUX_PC20A_TC1_B2                _L_(0)
 #define PINMUX_PC20A_TC1_B2        ((PIN_PC20A_TC1_B2 << 16) | MUX_PC20A_TC1_B2)
-#define GPIO_PC20A_TC1_B2        _UL(1 << 20)
-#define PIN_PC06D_TC1_CLK0             _L(70) /**< \brief TC1 signal: CLK0 on PC06 mux D */
-#define MUX_PC06D_TC1_CLK0              _L(3)
+#define GPIO_PC20A_TC1_B2        _UL_(1 << 20)
+#define PIN_PC06D_TC1_CLK0             _L_(70) /**< \brief TC1 signal: CLK0 on PC06 mux D */
+#define MUX_PC06D_TC1_CLK0              _L_(3)
 #define PINMUX_PC06D_TC1_CLK0      ((PIN_PC06D_TC1_CLK0 << 16) | MUX_PC06D_TC1_CLK0)
-#define GPIO_PC06D_TC1_CLK0      _UL(1 <<  6)
-#define PIN_PC21A_TC1_CLK0             _L(85) /**< \brief TC1 signal: CLK0 on PC21 mux A */
-#define MUX_PC21A_TC1_CLK0              _L(0)
+#define GPIO_PC06D_TC1_CLK0      _UL_(1 <<  6)
+#define PIN_PC21A_TC1_CLK0             _L_(85) /**< \brief TC1 signal: CLK0 on PC21 mux A */
+#define MUX_PC21A_TC1_CLK0              _L_(0)
 #define PINMUX_PC21A_TC1_CLK0      ((PIN_PC21A_TC1_CLK0 << 16) | MUX_PC21A_TC1_CLK0)
-#define GPIO_PC21A_TC1_CLK0      _UL(1 << 21)
-#define PIN_PC07D_TC1_CLK1             _L(71) /**< \brief TC1 signal: CLK1 on PC07 mux D */
-#define MUX_PC07D_TC1_CLK1              _L(3)
+#define GPIO_PC21A_TC1_CLK0      _UL_(1 << 21)
+#define PIN_PC07D_TC1_CLK1             _L_(71) /**< \brief TC1 signal: CLK1 on PC07 mux D */
+#define MUX_PC07D_TC1_CLK1              _L_(3)
 #define PINMUX_PC07D_TC1_CLK1      ((PIN_PC07D_TC1_CLK1 << 16) | MUX_PC07D_TC1_CLK1)
-#define GPIO_PC07D_TC1_CLK1      _UL(1 <<  7)
-#define PIN_PC22A_TC1_CLK1             _L(86) /**< \brief TC1 signal: CLK1 on PC22 mux A */
-#define MUX_PC22A_TC1_CLK1              _L(0)
+#define GPIO_PC07D_TC1_CLK1      _UL_(1 <<  7)
+#define PIN_PC22A_TC1_CLK1             _L_(86) /**< \brief TC1 signal: CLK1 on PC22 mux A */
+#define MUX_PC22A_TC1_CLK1              _L_(0)
 #define PINMUX_PC22A_TC1_CLK1      ((PIN_PC22A_TC1_CLK1 << 16) | MUX_PC22A_TC1_CLK1)
-#define GPIO_PC22A_TC1_CLK1      _UL(1 << 22)
-#define PIN_PC08D_TC1_CLK2             _L(72) /**< \brief TC1 signal: CLK2 on PC08 mux D */
-#define MUX_PC08D_TC1_CLK2              _L(3)
+#define GPIO_PC22A_TC1_CLK1      _UL_(1 << 22)
+#define PIN_PC08D_TC1_CLK2             _L_(72) /**< \brief TC1 signal: CLK2 on PC08 mux D */
+#define MUX_PC08D_TC1_CLK2              _L_(3)
 #define PINMUX_PC08D_TC1_CLK2      ((PIN_PC08D_TC1_CLK2 << 16) | MUX_PC08D_TC1_CLK2)
-#define GPIO_PC08D_TC1_CLK2      _UL(1 <<  8)
-#define PIN_PC23A_TC1_CLK2             _L(87) /**< \brief TC1 signal: CLK2 on PC23 mux A */
-#define MUX_PC23A_TC1_CLK2              _L(0)
+#define GPIO_PC08D_TC1_CLK2      _UL_(1 <<  8)
+#define PIN_PC23A_TC1_CLK2             _L_(87) /**< \brief TC1 signal: CLK2 on PC23 mux A */
+#define MUX_PC23A_TC1_CLK2              _L_(0)
 #define PINMUX_PC23A_TC1_CLK2      ((PIN_PC23A_TC1_CLK2 << 16) | MUX_PC23A_TC1_CLK2)
-#define GPIO_PC23A_TC1_CLK2      _UL(1 << 23)
+#define GPIO_PC23A_TC1_CLK2      _UL_(1 << 23)
 /* ========== GPIO definition for USART0 peripheral ========== */
-#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
-#define MUX_PA04B_USART0_CLK            _L(1)
+#define PIN_PA04B_USART0_CLK            _L_(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L_(1)
 #define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
-#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
-#define PIN_PC00B_USART0_CLK           _L(64) /**< \brief USART0 signal: CLK on PC00 mux B */
-#define MUX_PC00B_USART0_CLK            _L(1)
+#define GPIO_PA04B_USART0_CLK    _UL_(1 <<  4)
+#define PIN_PC00B_USART0_CLK           _L_(64) /**< \brief USART0 signal: CLK on PC00 mux B */
+#define MUX_PC00B_USART0_CLK            _L_(1)
 #define PINMUX_PC00B_USART0_CLK    ((PIN_PC00B_USART0_CLK << 16) | MUX_PC00B_USART0_CLK)
-#define GPIO_PC00B_USART0_CLK    _UL(1 <<  0)
-#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
-#define MUX_PA10A_USART0_CLK            _L(0)
+#define GPIO_PC00B_USART0_CLK    _UL_(1 <<  0)
+#define PIN_PA10A_USART0_CLK           _L_(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L_(0)
 #define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
-#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
-#define PIN_PB13A_USART0_CLK           _L(45) /**< \brief USART0 signal: CLK on PB13 mux A */
-#define MUX_PB13A_USART0_CLK            _L(0)
+#define GPIO_PA10A_USART0_CLK    _UL_(1 << 10)
+#define PIN_PB13A_USART0_CLK           _L_(45) /**< \brief USART0 signal: CLK on PB13 mux A */
+#define MUX_PB13A_USART0_CLK            _L_(0)
 #define PINMUX_PB13A_USART0_CLK    ((PIN_PB13A_USART0_CLK << 16) | MUX_PB13A_USART0_CLK)
-#define GPIO_PB13A_USART0_CLK    _UL(1 << 13)
-#define PIN_PC02B_USART0_CTS           _L(66) /**< \brief USART0 signal: CTS on PC02 mux B */
-#define MUX_PC02B_USART0_CTS            _L(1)
+#define GPIO_PB13A_USART0_CLK    _UL_(1 << 13)
+#define PIN_PC02B_USART0_CTS           _L_(66) /**< \brief USART0 signal: CTS on PC02 mux B */
+#define MUX_PC02B_USART0_CTS            _L_(1)
 #define PINMUX_PC02B_USART0_CTS    ((PIN_PC02B_USART0_CTS << 16) | MUX_PC02B_USART0_CTS)
-#define GPIO_PC02B_USART0_CTS    _UL(1 <<  2)
-#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
-#define MUX_PA09A_USART0_CTS            _L(0)
+#define GPIO_PC02B_USART0_CTS    _UL_(1 <<  2)
+#define PIN_PA09A_USART0_CTS            _L_(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L_(0)
 #define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
-#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
-#define PIN_PB11A_USART0_CTS           _L(43) /**< \brief USART0 signal: CTS on PB11 mux A */
-#define MUX_PB11A_USART0_CTS            _L(0)
+#define GPIO_PA09A_USART0_CTS    _UL_(1 <<  9)
+#define PIN_PB11A_USART0_CTS           _L_(43) /**< \brief USART0 signal: CTS on PB11 mux A */
+#define MUX_PB11A_USART0_CTS            _L_(0)
 #define PINMUX_PB11A_USART0_CTS    ((PIN_PB11A_USART0_CTS << 16) | MUX_PB11A_USART0_CTS)
-#define GPIO_PB11A_USART0_CTS    _UL(1 << 11)
-#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
-#define MUX_PA06B_USART0_RTS            _L(1)
+#define GPIO_PB11A_USART0_CTS    _UL_(1 << 11)
+#define PIN_PA06B_USART0_RTS            _L_(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L_(1)
 #define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
-#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
-#define PIN_PC01B_USART0_RTS           _L(65) /**< \brief USART0 signal: RTS on PC01 mux B */
-#define MUX_PC01B_USART0_RTS            _L(1)
+#define GPIO_PA06B_USART0_RTS    _UL_(1 <<  6)
+#define PIN_PC01B_USART0_RTS           _L_(65) /**< \brief USART0 signal: RTS on PC01 mux B */
+#define MUX_PC01B_USART0_RTS            _L_(1)
 #define PINMUX_PC01B_USART0_RTS    ((PIN_PC01B_USART0_RTS << 16) | MUX_PC01B_USART0_RTS)
-#define GPIO_PC01B_USART0_RTS    _UL(1 <<  1)
-#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
-#define MUX_PA08A_USART0_RTS            _L(0)
+#define GPIO_PC01B_USART0_RTS    _UL_(1 <<  1)
+#define PIN_PA08A_USART0_RTS            _L_(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L_(0)
 #define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
-#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
-#define PIN_PB12A_USART0_RTS           _L(44) /**< \brief USART0 signal: RTS on PB12 mux A */
-#define MUX_PB12A_USART0_RTS            _L(0)
+#define GPIO_PA08A_USART0_RTS    _UL_(1 <<  8)
+#define PIN_PB12A_USART0_RTS           _L_(44) /**< \brief USART0 signal: RTS on PB12 mux A */
+#define MUX_PB12A_USART0_RTS            _L_(0)
 #define PINMUX_PB12A_USART0_RTS    ((PIN_PB12A_USART0_RTS << 16) | MUX_PB12A_USART0_RTS)
-#define GPIO_PB12A_USART0_RTS    _UL(1 << 12)
-#define PIN_PC02C_USART0_RXD           _L(66) /**< \brief USART0 signal: RXD on PC02 mux C */
-#define MUX_PC02C_USART0_RXD            _L(2)
+#define GPIO_PB12A_USART0_RTS    _UL_(1 << 12)
+#define PIN_PC02C_USART0_RXD           _L_(66) /**< \brief USART0 signal: RXD on PC02 mux C */
+#define MUX_PC02C_USART0_RXD            _L_(2)
 #define PINMUX_PC02C_USART0_RXD    ((PIN_PC02C_USART0_RXD << 16) | MUX_PC02C_USART0_RXD)
-#define GPIO_PC02C_USART0_RXD    _UL(1 <<  2)
-#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
-#define MUX_PA05B_USART0_RXD            _L(1)
+#define GPIO_PC02C_USART0_RXD    _UL_(1 <<  2)
+#define PIN_PA05B_USART0_RXD            _L_(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L_(1)
 #define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
-#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
-#define PIN_PB00B_USART0_RXD           _L(32) /**< \brief USART0 signal: RXD on PB00 mux B */
-#define MUX_PB00B_USART0_RXD            _L(1)
+#define GPIO_PA05B_USART0_RXD    _UL_(1 <<  5)
+#define PIN_PB00B_USART0_RXD           _L_(32) /**< \brief USART0 signal: RXD on PB00 mux B */
+#define MUX_PB00B_USART0_RXD            _L_(1)
 #define PINMUX_PB00B_USART0_RXD    ((PIN_PB00B_USART0_RXD << 16) | MUX_PB00B_USART0_RXD)
-#define GPIO_PB00B_USART0_RXD    _UL(1 <<  0)
-#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
-#define MUX_PA11A_USART0_RXD            _L(0)
+#define GPIO_PB00B_USART0_RXD    _UL_(1 <<  0)
+#define PIN_PA11A_USART0_RXD           _L_(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L_(0)
 #define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
-#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
-#define PIN_PB14A_USART0_RXD           _L(46) /**< \brief USART0 signal: RXD on PB14 mux A */
-#define MUX_PB14A_USART0_RXD            _L(0)
+#define GPIO_PA11A_USART0_RXD    _UL_(1 << 11)
+#define PIN_PB14A_USART0_RXD           _L_(46) /**< \brief USART0 signal: RXD on PB14 mux A */
+#define MUX_PB14A_USART0_RXD            _L_(0)
 #define PINMUX_PB14A_USART0_RXD    ((PIN_PB14A_USART0_RXD << 16) | MUX_PB14A_USART0_RXD)
-#define GPIO_PB14A_USART0_RXD    _UL(1 << 14)
-#define PIN_PC03C_USART0_TXD           _L(67) /**< \brief USART0 signal: TXD on PC03 mux C */
-#define MUX_PC03C_USART0_TXD            _L(2)
+#define GPIO_PB14A_USART0_RXD    _UL_(1 << 14)
+#define PIN_PC03C_USART0_TXD           _L_(67) /**< \brief USART0 signal: TXD on PC03 mux C */
+#define MUX_PC03C_USART0_TXD            _L_(2)
 #define PINMUX_PC03C_USART0_TXD    ((PIN_PC03C_USART0_TXD << 16) | MUX_PC03C_USART0_TXD)
-#define GPIO_PC03C_USART0_TXD    _UL(1 <<  3)
-#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
-#define MUX_PA07B_USART0_TXD            _L(1)
+#define GPIO_PC03C_USART0_TXD    _UL_(1 <<  3)
+#define PIN_PA07B_USART0_TXD            _L_(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L_(1)
 #define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
-#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
-#define PIN_PB01B_USART0_TXD           _L(33) /**< \brief USART0 signal: TXD on PB01 mux B */
-#define MUX_PB01B_USART0_TXD            _L(1)
+#define GPIO_PA07B_USART0_TXD    _UL_(1 <<  7)
+#define PIN_PB01B_USART0_TXD           _L_(33) /**< \brief USART0 signal: TXD on PB01 mux B */
+#define MUX_PB01B_USART0_TXD            _L_(1)
 #define PINMUX_PB01B_USART0_TXD    ((PIN_PB01B_USART0_TXD << 16) | MUX_PB01B_USART0_TXD)
-#define GPIO_PB01B_USART0_TXD    _UL(1 <<  1)
-#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
-#define MUX_PA12A_USART0_TXD            _L(0)
+#define GPIO_PB01B_USART0_TXD    _UL_(1 <<  1)
+#define PIN_PA12A_USART0_TXD           _L_(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L_(0)
 #define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
-#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
-#define PIN_PB15A_USART0_TXD           _L(47) /**< \brief USART0 signal: TXD on PB15 mux A */
-#define MUX_PB15A_USART0_TXD            _L(0)
+#define GPIO_PA12A_USART0_TXD    _UL_(1 << 12)
+#define PIN_PB15A_USART0_TXD           _L_(47) /**< \brief USART0 signal: TXD on PB15 mux A */
+#define MUX_PB15A_USART0_TXD            _L_(0)
 #define PINMUX_PB15A_USART0_TXD    ((PIN_PB15A_USART0_TXD << 16) | MUX_PB15A_USART0_TXD)
-#define GPIO_PB15A_USART0_TXD    _UL(1 << 15)
+#define GPIO_PB15A_USART0_TXD    _UL_(1 << 15)
 /* ========== GPIO definition for USART1 peripheral ========== */
-#define PIN_PB03B_USART1_CLK           _L(35) /**< \brief USART1 signal: CLK on PB03 mux B */
-#define MUX_PB03B_USART1_CLK            _L(1)
+#define PIN_PB03B_USART1_CLK           _L_(35) /**< \brief USART1 signal: CLK on PB03 mux B */
+#define MUX_PB03B_USART1_CLK            _L_(1)
 #define PINMUX_PB03B_USART1_CLK    ((PIN_PB03B_USART1_CLK << 16) | MUX_PB03B_USART1_CLK)
-#define GPIO_PB03B_USART1_CLK    _UL(1 <<  3)
-#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
-#define MUX_PA14A_USART1_CLK            _L(0)
+#define GPIO_PB03B_USART1_CLK    _UL_(1 <<  3)
+#define PIN_PA14A_USART1_CLK           _L_(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L_(0)
 #define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
-#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
-#define PIN_PC25A_USART1_CLK           _L(89) /**< \brief USART1 signal: CLK on PC25 mux A */
-#define MUX_PC25A_USART1_CLK            _L(0)
+#define GPIO_PA14A_USART1_CLK    _UL_(1 << 14)
+#define PIN_PC25A_USART1_CLK           _L_(89) /**< \brief USART1 signal: CLK on PC25 mux A */
+#define MUX_PC25A_USART1_CLK            _L_(0)
 #define PINMUX_PC25A_USART1_CLK    ((PIN_PC25A_USART1_CLK << 16) | MUX_PC25A_USART1_CLK)
-#define GPIO_PC25A_USART1_CLK    _UL(1 << 25)
-#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
-#define MUX_PA21B_USART1_CTS            _L(1)
+#define GPIO_PC25A_USART1_CLK    _UL_(1 << 25)
+#define PIN_PA21B_USART1_CTS           _L_(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L_(1)
 #define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
-#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
-#define PIN_PB02B_USART1_RTS           _L(34) /**< \brief USART1 signal: RTS on PB02 mux B */
-#define MUX_PB02B_USART1_RTS            _L(1)
+#define GPIO_PA21B_USART1_CTS    _UL_(1 << 21)
+#define PIN_PB02B_USART1_RTS           _L_(34) /**< \brief USART1 signal: RTS on PB02 mux B */
+#define MUX_PB02B_USART1_RTS            _L_(1)
 #define PINMUX_PB02B_USART1_RTS    ((PIN_PB02B_USART1_RTS << 16) | MUX_PB02B_USART1_RTS)
-#define GPIO_PB02B_USART1_RTS    _UL(1 <<  2)
-#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
-#define MUX_PA13A_USART1_RTS            _L(0)
+#define GPIO_PB02B_USART1_RTS    _UL_(1 <<  2)
+#define PIN_PA13A_USART1_RTS           _L_(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L_(0)
 #define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
-#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
-#define PIN_PC24A_USART1_RTS           _L(88) /**< \brief USART1 signal: RTS on PC24 mux A */
-#define MUX_PC24A_USART1_RTS            _L(0)
+#define GPIO_PA13A_USART1_RTS    _UL_(1 << 13)
+#define PIN_PC24A_USART1_RTS           _L_(88) /**< \brief USART1 signal: RTS on PC24 mux A */
+#define MUX_PC24A_USART1_RTS            _L_(0)
 #define PINMUX_PC24A_USART1_RTS    ((PIN_PC24A_USART1_RTS << 16) | MUX_PC24A_USART1_RTS)
-#define GPIO_PC24A_USART1_RTS    _UL(1 << 24)
-#define PIN_PB04B_USART1_RXD           _L(36) /**< \brief USART1 signal: RXD on PB04 mux B */
-#define MUX_PB04B_USART1_RXD            _L(1)
+#define GPIO_PC24A_USART1_RTS    _UL_(1 << 24)
+#define PIN_PB04B_USART1_RXD           _L_(36) /**< \brief USART1 signal: RXD on PB04 mux B */
+#define MUX_PB04B_USART1_RXD            _L_(1)
 #define PINMUX_PB04B_USART1_RXD    ((PIN_PB04B_USART1_RXD << 16) | MUX_PB04B_USART1_RXD)
-#define GPIO_PB04B_USART1_RXD    _UL(1 <<  4)
-#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
-#define MUX_PA15A_USART1_RXD            _L(0)
+#define GPIO_PB04B_USART1_RXD    _UL_(1 <<  4)
+#define PIN_PA15A_USART1_RXD           _L_(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L_(0)
 #define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
-#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
-#define PIN_PC26A_USART1_RXD           _L(90) /**< \brief USART1 signal: RXD on PC26 mux A */
-#define MUX_PC26A_USART1_RXD            _L(0)
+#define GPIO_PA15A_USART1_RXD    _UL_(1 << 15)
+#define PIN_PC26A_USART1_RXD           _L_(90) /**< \brief USART1 signal: RXD on PC26 mux A */
+#define MUX_PC26A_USART1_RXD            _L_(0)
 #define PINMUX_PC26A_USART1_RXD    ((PIN_PC26A_USART1_RXD << 16) | MUX_PC26A_USART1_RXD)
-#define GPIO_PC26A_USART1_RXD    _UL(1 << 26)
-#define PIN_PB05B_USART1_TXD           _L(37) /**< \brief USART1 signal: TXD on PB05 mux B */
-#define MUX_PB05B_USART1_TXD            _L(1)
+#define GPIO_PC26A_USART1_RXD    _UL_(1 << 26)
+#define PIN_PB05B_USART1_TXD           _L_(37) /**< \brief USART1 signal: TXD on PB05 mux B */
+#define MUX_PB05B_USART1_TXD            _L_(1)
 #define PINMUX_PB05B_USART1_TXD    ((PIN_PB05B_USART1_TXD << 16) | MUX_PB05B_USART1_TXD)
-#define GPIO_PB05B_USART1_TXD    _UL(1 <<  5)
-#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
-#define MUX_PA16A_USART1_TXD            _L(0)
+#define GPIO_PB05B_USART1_TXD    _UL_(1 <<  5)
+#define PIN_PA16A_USART1_TXD           _L_(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L_(0)
 #define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
-#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
-#define PIN_PC27A_USART1_TXD           _L(91) /**< \brief USART1 signal: TXD on PC27 mux A */
-#define MUX_PC27A_USART1_TXD            _L(0)
+#define GPIO_PA16A_USART1_TXD    _UL_(1 << 16)
+#define PIN_PC27A_USART1_TXD           _L_(91) /**< \brief USART1 signal: TXD on PC27 mux A */
+#define MUX_PC27A_USART1_TXD            _L_(0)
 #define PINMUX_PC27A_USART1_TXD    ((PIN_PC27A_USART1_TXD << 16) | MUX_PC27A_USART1_TXD)
-#define GPIO_PC27A_USART1_TXD    _UL(1 << 27)
+#define GPIO_PC27A_USART1_TXD    _UL_(1 << 27)
 /* ========== GPIO definition for USART2 peripheral ========== */
-#define PIN_PC08B_USART2_CLK           _L(72) /**< \brief USART2 signal: CLK on PC08 mux B */
-#define MUX_PC08B_USART2_CLK            _L(1)
+#define PIN_PC08B_USART2_CLK           _L_(72) /**< \brief USART2 signal: CLK on PC08 mux B */
+#define MUX_PC08B_USART2_CLK            _L_(1)
 #define PINMUX_PC08B_USART2_CLK    ((PIN_PC08B_USART2_CLK << 16) | MUX_PC08B_USART2_CLK)
-#define GPIO_PC08B_USART2_CLK    _UL(1 <<  8)
-#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
-#define MUX_PA18A_USART2_CLK            _L(0)
+#define GPIO_PC08B_USART2_CLK    _UL_(1 <<  8)
+#define PIN_PA18A_USART2_CLK           _L_(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L_(0)
 #define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
-#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
-#define PIN_PC08E_USART2_CTS           _L(72) /**< \brief USART2 signal: CTS on PC08 mux E */
-#define MUX_PC08E_USART2_CTS            _L(4)
+#define GPIO_PA18A_USART2_CLK    _UL_(1 << 18)
+#define PIN_PC08E_USART2_CTS           _L_(72) /**< \brief USART2 signal: CTS on PC08 mux E */
+#define MUX_PC08E_USART2_CTS            _L_(4)
 #define PINMUX_PC08E_USART2_CTS    ((PIN_PC08E_USART2_CTS << 16) | MUX_PC08E_USART2_CTS)
-#define GPIO_PC08E_USART2_CTS    _UL(1 <<  8)
-#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
-#define MUX_PA22B_USART2_CTS            _L(1)
+#define GPIO_PC08E_USART2_CTS    _UL_(1 <<  8)
+#define PIN_PA22B_USART2_CTS           _L_(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L_(1)
 #define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
-#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
-#define PIN_PC07B_USART2_RTS           _L(71) /**< \brief USART2 signal: RTS on PC07 mux B */
-#define MUX_PC07B_USART2_RTS            _L(1)
+#define GPIO_PA22B_USART2_CTS    _UL_(1 << 22)
+#define PIN_PC07B_USART2_RTS           _L_(71) /**< \brief USART2 signal: RTS on PC07 mux B */
+#define MUX_PC07B_USART2_RTS            _L_(1)
 #define PINMUX_PC07B_USART2_RTS    ((PIN_PC07B_USART2_RTS << 16) | MUX_PC07B_USART2_RTS)
-#define GPIO_PC07B_USART2_RTS    _UL(1 <<  7)
-#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
-#define MUX_PA17A_USART2_RTS            _L(0)
+#define GPIO_PC07B_USART2_RTS    _UL_(1 <<  7)
+#define PIN_PA17A_USART2_RTS           _L_(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L_(0)
 #define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
-#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
-#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
-#define MUX_PA25B_USART2_RXD            _L(1)
+#define GPIO_PA17A_USART2_RTS    _UL_(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L_(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L_(1)
 #define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
-#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
-#define PIN_PC11B_USART2_RXD           _L(75) /**< \brief USART2 signal: RXD on PC11 mux B */
-#define MUX_PC11B_USART2_RXD            _L(1)
+#define GPIO_PA25B_USART2_RXD    _UL_(1 << 25)
+#define PIN_PC11B_USART2_RXD           _L_(75) /**< \brief USART2 signal: RXD on PC11 mux B */
+#define MUX_PC11B_USART2_RXD            _L_(1)
 #define PINMUX_PC11B_USART2_RXD    ((PIN_PC11B_USART2_RXD << 16) | MUX_PC11B_USART2_RXD)
-#define GPIO_PC11B_USART2_RXD    _UL(1 << 11)
-#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
-#define MUX_PA19A_USART2_RXD            _L(0)
+#define GPIO_PC11B_USART2_RXD    _UL_(1 << 11)
+#define PIN_PA19A_USART2_RXD           _L_(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L_(0)
 #define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
-#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
-#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
-#define MUX_PA26B_USART2_TXD            _L(1)
+#define GPIO_PA19A_USART2_RXD    _UL_(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L_(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L_(1)
 #define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
-#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
-#define PIN_PC12B_USART2_TXD           _L(76) /**< \brief USART2 signal: TXD on PC12 mux B */
-#define MUX_PC12B_USART2_TXD            _L(1)
+#define GPIO_PA26B_USART2_TXD    _UL_(1 << 26)
+#define PIN_PC12B_USART2_TXD           _L_(76) /**< \brief USART2 signal: TXD on PC12 mux B */
+#define MUX_PC12B_USART2_TXD            _L_(1)
 #define PINMUX_PC12B_USART2_TXD    ((PIN_PC12B_USART2_TXD << 16) | MUX_PC12B_USART2_TXD)
-#define GPIO_PC12B_USART2_TXD    _UL(1 << 12)
-#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
-#define MUX_PA20A_USART2_TXD            _L(0)
+#define GPIO_PC12B_USART2_TXD    _UL_(1 << 12)
+#define PIN_PA20A_USART2_TXD           _L_(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L_(0)
 #define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
-#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+#define GPIO_PA20A_USART2_TXD    _UL_(1 << 20)
 /* ========== GPIO definition for USART3 peripheral ========== */
-#define PIN_PC14B_USART3_CLK           _L(78) /**< \brief USART3 signal: CLK on PC14 mux B */
-#define MUX_PC14B_USART3_CLK            _L(1)
+#define PIN_PC14B_USART3_CLK           _L_(78) /**< \brief USART3 signal: CLK on PC14 mux B */
+#define MUX_PC14B_USART3_CLK            _L_(1)
 #define PINMUX_PC14B_USART3_CLK    ((PIN_PC14B_USART3_CLK << 16) | MUX_PC14B_USART3_CLK)
-#define GPIO_PC14B_USART3_CLK    _UL(1 << 14)
-#define PIN_PB08A_USART3_CLK           _L(40) /**< \brief USART3 signal: CLK on PB08 mux A */
-#define MUX_PB08A_USART3_CLK            _L(0)
+#define GPIO_PC14B_USART3_CLK    _UL_(1 << 14)
+#define PIN_PB08A_USART3_CLK           _L_(40) /**< \brief USART3 signal: CLK on PB08 mux A */
+#define MUX_PB08A_USART3_CLK            _L_(0)
 #define PINMUX_PB08A_USART3_CLK    ((PIN_PB08A_USART3_CLK << 16) | MUX_PB08A_USART3_CLK)
-#define GPIO_PB08A_USART3_CLK    _UL(1 <<  8)
-#define PIN_PC31A_USART3_CLK           _L(95) /**< \brief USART3 signal: CLK on PC31 mux A */
-#define MUX_PC31A_USART3_CLK            _L(0)
+#define GPIO_PB08A_USART3_CLK    _UL_(1 <<  8)
+#define PIN_PC31A_USART3_CLK           _L_(95) /**< \brief USART3 signal: CLK on PC31 mux A */
+#define MUX_PC31A_USART3_CLK            _L_(0)
 #define PINMUX_PC31A_USART3_CLK    ((PIN_PC31A_USART3_CLK << 16) | MUX_PC31A_USART3_CLK)
-#define GPIO_PC31A_USART3_CLK    _UL(1 << 31)
-#define PIN_PB07A_USART3_CTS           _L(39) /**< \brief USART3 signal: CTS on PB07 mux A */
-#define MUX_PB07A_USART3_CTS            _L(0)
+#define GPIO_PC31A_USART3_CLK    _UL_(1 << 31)
+#define PIN_PB07A_USART3_CTS           _L_(39) /**< \brief USART3 signal: CTS on PB07 mux A */
+#define MUX_PB07A_USART3_CTS            _L_(0)
 #define PINMUX_PB07A_USART3_CTS    ((PIN_PB07A_USART3_CTS << 16) | MUX_PB07A_USART3_CTS)
-#define GPIO_PB07A_USART3_CTS    _UL(1 <<  7)
-#define PIN_PC13B_USART3_RTS           _L(77) /**< \brief USART3 signal: RTS on PC13 mux B */
-#define MUX_PC13B_USART3_RTS            _L(1)
+#define GPIO_PB07A_USART3_CTS    _UL_(1 <<  7)
+#define PIN_PC13B_USART3_RTS           _L_(77) /**< \brief USART3 signal: RTS on PC13 mux B */
+#define MUX_PC13B_USART3_RTS            _L_(1)
 #define PINMUX_PC13B_USART3_RTS    ((PIN_PC13B_USART3_RTS << 16) | MUX_PC13B_USART3_RTS)
-#define GPIO_PC13B_USART3_RTS    _UL(1 << 13)
-#define PIN_PB06A_USART3_RTS           _L(38) /**< \brief USART3 signal: RTS on PB06 mux A */
-#define MUX_PB06A_USART3_RTS            _L(0)
+#define GPIO_PC13B_USART3_RTS    _UL_(1 << 13)
+#define PIN_PB06A_USART3_RTS           _L_(38) /**< \brief USART3 signal: RTS on PB06 mux A */
+#define MUX_PB06A_USART3_RTS            _L_(0)
 #define PINMUX_PB06A_USART3_RTS    ((PIN_PB06A_USART3_RTS << 16) | MUX_PB06A_USART3_RTS)
-#define GPIO_PB06A_USART3_RTS    _UL(1 <<  6)
-#define PIN_PC30A_USART3_RTS           _L(94) /**< \brief USART3 signal: RTS on PC30 mux A */
-#define MUX_PC30A_USART3_RTS            _L(0)
+#define GPIO_PB06A_USART3_RTS    _UL_(1 <<  6)
+#define PIN_PC30A_USART3_RTS           _L_(94) /**< \brief USART3 signal: RTS on PC30 mux A */
+#define MUX_PC30A_USART3_RTS            _L_(0)
 #define PINMUX_PC30A_USART3_RTS    ((PIN_PC30A_USART3_RTS << 16) | MUX_PC30A_USART3_RTS)
-#define GPIO_PC30A_USART3_RTS    _UL(1 << 30)
-#define PIN_PC09B_USART3_RXD           _L(73) /**< \brief USART3 signal: RXD on PC09 mux B */
-#define MUX_PC09B_USART3_RXD            _L(1)
+#define GPIO_PC30A_USART3_RTS    _UL_(1 << 30)
+#define PIN_PC09B_USART3_RXD           _L_(73) /**< \brief USART3 signal: RXD on PC09 mux B */
+#define MUX_PC09B_USART3_RXD            _L_(1)
 #define PINMUX_PC09B_USART3_RXD    ((PIN_PC09B_USART3_RXD << 16) | MUX_PC09B_USART3_RXD)
-#define GPIO_PC09B_USART3_RXD    _UL(1 <<  9)
-#define PIN_PB09A_USART3_RXD           _L(41) /**< \brief USART3 signal: RXD on PB09 mux A */
-#define MUX_PB09A_USART3_RXD            _L(0)
+#define GPIO_PC09B_USART3_RXD    _UL_(1 <<  9)
+#define PIN_PB09A_USART3_RXD           _L_(41) /**< \brief USART3 signal: RXD on PB09 mux A */
+#define MUX_PB09A_USART3_RXD            _L_(0)
 #define PINMUX_PB09A_USART3_RXD    ((PIN_PB09A_USART3_RXD << 16) | MUX_PB09A_USART3_RXD)
-#define GPIO_PB09A_USART3_RXD    _UL(1 <<  9)
-#define PIN_PC28A_USART3_RXD           _L(92) /**< \brief USART3 signal: RXD on PC28 mux A */
-#define MUX_PC28A_USART3_RXD            _L(0)
+#define GPIO_PB09A_USART3_RXD    _UL_(1 <<  9)
+#define PIN_PC28A_USART3_RXD           _L_(92) /**< \brief USART3 signal: RXD on PC28 mux A */
+#define MUX_PC28A_USART3_RXD            _L_(0)
 #define PINMUX_PC28A_USART3_RXD    ((PIN_PC28A_USART3_RXD << 16) | MUX_PC28A_USART3_RXD)
-#define GPIO_PC28A_USART3_RXD    _UL(1 << 28)
-#define PIN_PC10B_USART3_TXD           _L(74) /**< \brief USART3 signal: TXD on PC10 mux B */
-#define MUX_PC10B_USART3_TXD            _L(1)
+#define GPIO_PC28A_USART3_RXD    _UL_(1 << 28)
+#define PIN_PC10B_USART3_TXD           _L_(74) /**< \brief USART3 signal: TXD on PC10 mux B */
+#define MUX_PC10B_USART3_TXD            _L_(1)
 #define PINMUX_PC10B_USART3_TXD    ((PIN_PC10B_USART3_TXD << 16) | MUX_PC10B_USART3_TXD)
-#define GPIO_PC10B_USART3_TXD    _UL(1 << 10)
-#define PIN_PB10A_USART3_TXD           _L(42) /**< \brief USART3 signal: TXD on PB10 mux A */
-#define MUX_PB10A_USART3_TXD            _L(0)
+#define GPIO_PC10B_USART3_TXD    _UL_(1 << 10)
+#define PIN_PB10A_USART3_TXD           _L_(42) /**< \brief USART3 signal: TXD on PB10 mux A */
+#define MUX_PB10A_USART3_TXD            _L_(0)
 #define PINMUX_PB10A_USART3_TXD    ((PIN_PB10A_USART3_TXD << 16) | MUX_PB10A_USART3_TXD)
-#define GPIO_PB10A_USART3_TXD    _UL(1 << 10)
-#define PIN_PC29A_USART3_TXD           _L(93) /**< \brief USART3 signal: TXD on PC29 mux A */
-#define MUX_PC29A_USART3_TXD            _L(0)
+#define GPIO_PB10A_USART3_TXD    _UL_(1 << 10)
+#define PIN_PC29A_USART3_TXD           _L_(93) /**< \brief USART3 signal: TXD on PC29 mux A */
+#define MUX_PC29A_USART3_TXD            _L_(0)
 #define PINMUX_PC29A_USART3_TXD    ((PIN_PC29A_USART3_TXD << 16) | MUX_PC29A_USART3_TXD)
-#define GPIO_PC29A_USART3_TXD    _UL(1 << 29)
+#define GPIO_PC29A_USART3_TXD    _UL_(1 << 29)
 /* ========== GPIO definition for ADCIFE peripheral ========== */
-#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
-#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PIN_PA04A_ADCIFE_AD0            _L_(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L_(0)
 #define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
-#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
-#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
-#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL_(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L_(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L_(0)
 #define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
-#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
-#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
-#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define GPIO_PA05A_ADCIFE_AD1    _UL_(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L_(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L_(0)
 #define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
-#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
-#define PIN_PB02A_ADCIFE_AD3           _L(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
-#define MUX_PB02A_ADCIFE_AD3            _L(0)
+#define GPIO_PA07A_ADCIFE_AD2    _UL_(1 <<  7)
+#define PIN_PB02A_ADCIFE_AD3           _L_(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
+#define MUX_PB02A_ADCIFE_AD3            _L_(0)
 #define PINMUX_PB02A_ADCIFE_AD3    ((PIN_PB02A_ADCIFE_AD3 << 16) | MUX_PB02A_ADCIFE_AD3)
-#define GPIO_PB02A_ADCIFE_AD3    _UL(1 <<  2)
-#define PIN_PB03A_ADCIFE_AD4           _L(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
-#define MUX_PB03A_ADCIFE_AD4            _L(0)
+#define GPIO_PB02A_ADCIFE_AD3    _UL_(1 <<  2)
+#define PIN_PB03A_ADCIFE_AD4           _L_(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
+#define MUX_PB03A_ADCIFE_AD4            _L_(0)
 #define PINMUX_PB03A_ADCIFE_AD4    ((PIN_PB03A_ADCIFE_AD4 << 16) | MUX_PB03A_ADCIFE_AD4)
-#define GPIO_PB03A_ADCIFE_AD4    _UL(1 <<  3)
-#define PIN_PB04A_ADCIFE_AD5           _L(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
-#define MUX_PB04A_ADCIFE_AD5            _L(0)
+#define GPIO_PB03A_ADCIFE_AD4    _UL_(1 <<  3)
+#define PIN_PB04A_ADCIFE_AD5           _L_(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
+#define MUX_PB04A_ADCIFE_AD5            _L_(0)
 #define PINMUX_PB04A_ADCIFE_AD5    ((PIN_PB04A_ADCIFE_AD5 << 16) | MUX_PB04A_ADCIFE_AD5)
-#define GPIO_PB04A_ADCIFE_AD5    _UL(1 <<  4)
-#define PIN_PB05A_ADCIFE_AD6           _L(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
-#define MUX_PB05A_ADCIFE_AD6            _L(0)
+#define GPIO_PB04A_ADCIFE_AD5    _UL_(1 <<  4)
+#define PIN_PB05A_ADCIFE_AD6           _L_(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
+#define MUX_PB05A_ADCIFE_AD6            _L_(0)
 #define PINMUX_PB05A_ADCIFE_AD6    ((PIN_PB05A_ADCIFE_AD6 << 16) | MUX_PB05A_ADCIFE_AD6)
-#define GPIO_PB05A_ADCIFE_AD6    _UL(1 <<  5)
-#define PIN_PC07A_ADCIFE_AD7           _L(71) /**< \brief ADCIFE signal: AD7 on PC07 mux A */
-#define MUX_PC07A_ADCIFE_AD7            _L(0)
+#define GPIO_PB05A_ADCIFE_AD6    _UL_(1 <<  5)
+#define PIN_PC07A_ADCIFE_AD7           _L_(71) /**< \brief ADCIFE signal: AD7 on PC07 mux A */
+#define MUX_PC07A_ADCIFE_AD7            _L_(0)
 #define PINMUX_PC07A_ADCIFE_AD7    ((PIN_PC07A_ADCIFE_AD7 << 16) | MUX_PC07A_ADCIFE_AD7)
-#define GPIO_PC07A_ADCIFE_AD7    _UL(1 <<  7)
-#define PIN_PC08A_ADCIFE_AD8           _L(72) /**< \brief ADCIFE signal: AD8 on PC08 mux A */
-#define MUX_PC08A_ADCIFE_AD8            _L(0)
+#define GPIO_PC07A_ADCIFE_AD7    _UL_(1 <<  7)
+#define PIN_PC08A_ADCIFE_AD8           _L_(72) /**< \brief ADCIFE signal: AD8 on PC08 mux A */
+#define MUX_PC08A_ADCIFE_AD8            _L_(0)
 #define PINMUX_PC08A_ADCIFE_AD8    ((PIN_PC08A_ADCIFE_AD8 << 16) | MUX_PC08A_ADCIFE_AD8)
-#define GPIO_PC08A_ADCIFE_AD8    _UL(1 <<  8)
-#define PIN_PC09A_ADCIFE_AD9           _L(73) /**< \brief ADCIFE signal: AD9 on PC09 mux A */
-#define MUX_PC09A_ADCIFE_AD9            _L(0)
+#define GPIO_PC08A_ADCIFE_AD8    _UL_(1 <<  8)
+#define PIN_PC09A_ADCIFE_AD9           _L_(73) /**< \brief ADCIFE signal: AD9 on PC09 mux A */
+#define MUX_PC09A_ADCIFE_AD9            _L_(0)
 #define PINMUX_PC09A_ADCIFE_AD9    ((PIN_PC09A_ADCIFE_AD9 << 16) | MUX_PC09A_ADCIFE_AD9)
-#define GPIO_PC09A_ADCIFE_AD9    _UL(1 <<  9)
-#define PIN_PC10A_ADCIFE_AD10          _L(74) /**< \brief ADCIFE signal: AD10 on PC10 mux A */
-#define MUX_PC10A_ADCIFE_AD10           _L(0)
+#define GPIO_PC09A_ADCIFE_AD9    _UL_(1 <<  9)
+#define PIN_PC10A_ADCIFE_AD10          _L_(74) /**< \brief ADCIFE signal: AD10 on PC10 mux A */
+#define MUX_PC10A_ADCIFE_AD10           _L_(0)
 #define PINMUX_PC10A_ADCIFE_AD10   ((PIN_PC10A_ADCIFE_AD10 << 16) | MUX_PC10A_ADCIFE_AD10)
-#define GPIO_PC10A_ADCIFE_AD10   _UL(1 << 10)
-#define PIN_PC11A_ADCIFE_AD11          _L(75) /**< \brief ADCIFE signal: AD11 on PC11 mux A */
-#define MUX_PC11A_ADCIFE_AD11           _L(0)
+#define GPIO_PC10A_ADCIFE_AD10   _UL_(1 << 10)
+#define PIN_PC11A_ADCIFE_AD11          _L_(75) /**< \brief ADCIFE signal: AD11 on PC11 mux A */
+#define MUX_PC11A_ADCIFE_AD11           _L_(0)
 #define PINMUX_PC11A_ADCIFE_AD11   ((PIN_PC11A_ADCIFE_AD11 << 16) | MUX_PC11A_ADCIFE_AD11)
-#define GPIO_PC11A_ADCIFE_AD11   _UL(1 << 11)
-#define PIN_PC12A_ADCIFE_AD12          _L(76) /**< \brief ADCIFE signal: AD12 on PC12 mux A */
-#define MUX_PC12A_ADCIFE_AD12           _L(0)
+#define GPIO_PC11A_ADCIFE_AD11   _UL_(1 << 11)
+#define PIN_PC12A_ADCIFE_AD12          _L_(76) /**< \brief ADCIFE signal: AD12 on PC12 mux A */
+#define MUX_PC12A_ADCIFE_AD12           _L_(0)
 #define PINMUX_PC12A_ADCIFE_AD12   ((PIN_PC12A_ADCIFE_AD12 << 16) | MUX_PC12A_ADCIFE_AD12)
-#define GPIO_PC12A_ADCIFE_AD12   _UL(1 << 12)
-#define PIN_PC13A_ADCIFE_AD13          _L(77) /**< \brief ADCIFE signal: AD13 on PC13 mux A */
-#define MUX_PC13A_ADCIFE_AD13           _L(0)
+#define GPIO_PC12A_ADCIFE_AD12   _UL_(1 << 12)
+#define PIN_PC13A_ADCIFE_AD13          _L_(77) /**< \brief ADCIFE signal: AD13 on PC13 mux A */
+#define MUX_PC13A_ADCIFE_AD13           _L_(0)
 #define PINMUX_PC13A_ADCIFE_AD13   ((PIN_PC13A_ADCIFE_AD13 << 16) | MUX_PC13A_ADCIFE_AD13)
-#define GPIO_PC13A_ADCIFE_AD13   _UL(1 << 13)
-#define PIN_PC14A_ADCIFE_AD14          _L(78) /**< \brief ADCIFE signal: AD14 on PC14 mux A */
-#define MUX_PC14A_ADCIFE_AD14           _L(0)
+#define GPIO_PC13A_ADCIFE_AD13   _UL_(1 << 13)
+#define PIN_PC14A_ADCIFE_AD14          _L_(78) /**< \brief ADCIFE signal: AD14 on PC14 mux A */
+#define MUX_PC14A_ADCIFE_AD14           _L_(0)
 #define PINMUX_PC14A_ADCIFE_AD14   ((PIN_PC14A_ADCIFE_AD14 << 16) | MUX_PC14A_ADCIFE_AD14)
-#define GPIO_PC14A_ADCIFE_AD14   _UL(1 << 14)
-#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
-#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define GPIO_PC14A_ADCIFE_AD14   _UL_(1 << 14)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L_(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L_(4)
 #define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
-#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL_(1 <<  5)
 /* ========== GPIO definition for DACC peripheral ========== */
-#define PIN_PB04E_DACC_EXT_TRIG0       _L(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
-#define MUX_PB04E_DACC_EXT_TRIG0        _L(4)
+#define PIN_PB04E_DACC_EXT_TRIG0       _L_(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
+#define MUX_PB04E_DACC_EXT_TRIG0        _L_(4)
 #define PINMUX_PB04E_DACC_EXT_TRIG0  ((PIN_PB04E_DACC_EXT_TRIG0 << 16) | MUX_PB04E_DACC_EXT_TRIG0)
-#define GPIO_PB04E_DACC_EXT_TRIG0  _UL(1 <<  4)
-#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
-#define MUX_PA06A_DACC_VOUT             _L(0)
+#define GPIO_PB04E_DACC_EXT_TRIG0  _UL_(1 <<  4)
+#define PIN_PA06A_DACC_VOUT             _L_(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L_(0)
 #define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
-#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+#define GPIO_PA06A_DACC_VOUT     _UL_(1 <<  6)
 /* ========== GPIO definition for ACIFC peripheral ========== */
-#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
-#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PIN_PA06E_ACIFC_ACAN0           _L_(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L_(4)
 #define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
-#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
-#define PIN_PC09E_ACIFC_ACAN1          _L(73) /**< \brief ACIFC signal: ACAN1 on PC09 mux E */
-#define MUX_PC09E_ACIFC_ACAN1           _L(4)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL_(1 <<  6)
+#define PIN_PC09E_ACIFC_ACAN1          _L_(73) /**< \brief ACIFC signal: ACAN1 on PC09 mux E */
+#define MUX_PC09E_ACIFC_ACAN1           _L_(4)
 #define PINMUX_PC09E_ACIFC_ACAN1   ((PIN_PC09E_ACIFC_ACAN1 << 16) | MUX_PC09E_ACIFC_ACAN1)
-#define GPIO_PC09E_ACIFC_ACAN1   _UL(1 <<  9)
-#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
-#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define GPIO_PC09E_ACIFC_ACAN1   _UL_(1 <<  9)
+#define PIN_PA07E_ACIFC_ACAP0           _L_(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L_(4)
 #define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
-#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
-#define PIN_PC10E_ACIFC_ACAP1          _L(74) /**< \brief ACIFC signal: ACAP1 on PC10 mux E */
-#define MUX_PC10E_ACIFC_ACAP1           _L(4)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL_(1 <<  7)
+#define PIN_PC10E_ACIFC_ACAP1          _L_(74) /**< \brief ACIFC signal: ACAP1 on PC10 mux E */
+#define MUX_PC10E_ACIFC_ACAP1           _L_(4)
 #define PINMUX_PC10E_ACIFC_ACAP1   ((PIN_PC10E_ACIFC_ACAP1 << 16) | MUX_PC10E_ACIFC_ACAP1)
-#define GPIO_PC10E_ACIFC_ACAP1   _UL(1 << 10)
-#define PIN_PB02E_ACIFC_ACBN0          _L(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
-#define MUX_PB02E_ACIFC_ACBN0           _L(4)
+#define GPIO_PC10E_ACIFC_ACAP1   _UL_(1 << 10)
+#define PIN_PB02E_ACIFC_ACBN0          _L_(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
+#define MUX_PB02E_ACIFC_ACBN0           _L_(4)
 #define PINMUX_PB02E_ACIFC_ACBN0   ((PIN_PB02E_ACIFC_ACBN0 << 16) | MUX_PB02E_ACIFC_ACBN0)
-#define GPIO_PB02E_ACIFC_ACBN0   _UL(1 <<  2)
-#define PIN_PC13E_ACIFC_ACBN1          _L(77) /**< \brief ACIFC signal: ACBN1 on PC13 mux E */
-#define MUX_PC13E_ACIFC_ACBN1           _L(4)
+#define GPIO_PB02E_ACIFC_ACBN0   _UL_(1 <<  2)
+#define PIN_PC13E_ACIFC_ACBN1          _L_(77) /**< \brief ACIFC signal: ACBN1 on PC13 mux E */
+#define MUX_PC13E_ACIFC_ACBN1           _L_(4)
 #define PINMUX_PC13E_ACIFC_ACBN1   ((PIN_PC13E_ACIFC_ACBN1 << 16) | MUX_PC13E_ACIFC_ACBN1)
-#define GPIO_PC13E_ACIFC_ACBN1   _UL(1 << 13)
-#define PIN_PB03E_ACIFC_ACBP0          _L(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
-#define MUX_PB03E_ACIFC_ACBP0           _L(4)
+#define GPIO_PC13E_ACIFC_ACBN1   _UL_(1 << 13)
+#define PIN_PB03E_ACIFC_ACBP0          _L_(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
+#define MUX_PB03E_ACIFC_ACBP0           _L_(4)
 #define PINMUX_PB03E_ACIFC_ACBP0   ((PIN_PB03E_ACIFC_ACBP0 << 16) | MUX_PB03E_ACIFC_ACBP0)
-#define GPIO_PB03E_ACIFC_ACBP0   _UL(1 <<  3)
-#define PIN_PC14E_ACIFC_ACBP1          _L(78) /**< \brief ACIFC signal: ACBP1 on PC14 mux E */
-#define MUX_PC14E_ACIFC_ACBP1           _L(4)
+#define GPIO_PB03E_ACIFC_ACBP0   _UL_(1 <<  3)
+#define PIN_PC14E_ACIFC_ACBP1          _L_(78) /**< \brief ACIFC signal: ACBP1 on PC14 mux E */
+#define MUX_PC14E_ACIFC_ACBP1           _L_(4)
 #define PINMUX_PC14E_ACIFC_ACBP1   ((PIN_PC14E_ACIFC_ACBP1 << 16) | MUX_PC14E_ACIFC_ACBP1)
-#define GPIO_PC14E_ACIFC_ACBP1   _UL(1 << 14)
+#define GPIO_PC14E_ACIFC_ACBP1   _UL_(1 << 14)
 /* ========== GPIO definition for GLOC peripheral ========== */
-#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
-#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PIN_PA06D_GLOC_IN0              _L_(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L_(3)
 #define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
-#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
-#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
-#define MUX_PA20D_GLOC_IN0              _L(3)
+#define GPIO_PA06D_GLOC_IN0      _UL_(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L_(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L_(3)
 #define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
-#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
-#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
-#define MUX_PA04D_GLOC_IN1              _L(3)
+#define GPIO_PA20D_GLOC_IN0      _UL_(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L_(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L_(3)
 #define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
-#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
-#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
-#define MUX_PA21D_GLOC_IN1              _L(3)
+#define GPIO_PA04D_GLOC_IN1      _UL_(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L_(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L_(3)
 #define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
-#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
-#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
-#define MUX_PA05D_GLOC_IN2              _L(3)
+#define GPIO_PA21D_GLOC_IN1      _UL_(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L_(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L_(3)
 #define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
-#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
-#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
-#define MUX_PA22D_GLOC_IN2              _L(3)
+#define GPIO_PA05D_GLOC_IN2      _UL_(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L_(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L_(3)
 #define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
-#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
-#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
-#define MUX_PA07D_GLOC_IN3              _L(3)
+#define GPIO_PA22D_GLOC_IN2      _UL_(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L_(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L_(3)
 #define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
-#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
-#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
-#define MUX_PA23D_GLOC_IN3              _L(3)
+#define GPIO_PA07D_GLOC_IN3      _UL_(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L_(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L_(3)
 #define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
-#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
-#define PIN_PC15D_GLOC_IN4             _L(79) /**< \brief GLOC signal: IN4 on PC15 mux D */
-#define MUX_PC15D_GLOC_IN4              _L(3)
+#define GPIO_PA23D_GLOC_IN3      _UL_(1 << 23)
+#define PIN_PC15D_GLOC_IN4             _L_(79) /**< \brief GLOC signal: IN4 on PC15 mux D */
+#define MUX_PC15D_GLOC_IN4              _L_(3)
 #define PINMUX_PC15D_GLOC_IN4      ((PIN_PC15D_GLOC_IN4 << 16) | MUX_PC15D_GLOC_IN4)
-#define GPIO_PC15D_GLOC_IN4      _UL(1 << 15)
-#define PIN_PB06C_GLOC_IN4             _L(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
-#define MUX_PB06C_GLOC_IN4              _L(2)
+#define GPIO_PC15D_GLOC_IN4      _UL_(1 << 15)
+#define PIN_PB06C_GLOC_IN4             _L_(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
+#define MUX_PB06C_GLOC_IN4              _L_(2)
 #define PINMUX_PB06C_GLOC_IN4      ((PIN_PB06C_GLOC_IN4 << 16) | MUX_PB06C_GLOC_IN4)
-#define GPIO_PB06C_GLOC_IN4      _UL(1 <<  6)
-#define PIN_PC28C_GLOC_IN4             _L(92) /**< \brief GLOC signal: IN4 on PC28 mux C */
-#define MUX_PC28C_GLOC_IN4              _L(2)
+#define GPIO_PB06C_GLOC_IN4      _UL_(1 <<  6)
+#define PIN_PC28C_GLOC_IN4             _L_(92) /**< \brief GLOC signal: IN4 on PC28 mux C */
+#define MUX_PC28C_GLOC_IN4              _L_(2)
 #define PINMUX_PC28C_GLOC_IN4      ((PIN_PC28C_GLOC_IN4 << 16) | MUX_PC28C_GLOC_IN4)
-#define GPIO_PC28C_GLOC_IN4      _UL(1 << 28)
-#define PIN_PC16D_GLOC_IN5             _L(80) /**< \brief GLOC signal: IN5 on PC16 mux D */
-#define MUX_PC16D_GLOC_IN5              _L(3)
+#define GPIO_PC28C_GLOC_IN4      _UL_(1 << 28)
+#define PIN_PC16D_GLOC_IN5             _L_(80) /**< \brief GLOC signal: IN5 on PC16 mux D */
+#define MUX_PC16D_GLOC_IN5              _L_(3)
 #define PINMUX_PC16D_GLOC_IN5      ((PIN_PC16D_GLOC_IN5 << 16) | MUX_PC16D_GLOC_IN5)
-#define GPIO_PC16D_GLOC_IN5      _UL(1 << 16)
-#define PIN_PB07C_GLOC_IN5             _L(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
-#define MUX_PB07C_GLOC_IN5              _L(2)
+#define GPIO_PC16D_GLOC_IN5      _UL_(1 << 16)
+#define PIN_PB07C_GLOC_IN5             _L_(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
+#define MUX_PB07C_GLOC_IN5              _L_(2)
 #define PINMUX_PB07C_GLOC_IN5      ((PIN_PB07C_GLOC_IN5 << 16) | MUX_PB07C_GLOC_IN5)
-#define GPIO_PB07C_GLOC_IN5      _UL(1 <<  7)
-#define PIN_PC29C_GLOC_IN5             _L(93) /**< \brief GLOC signal: IN5 on PC29 mux C */
-#define MUX_PC29C_GLOC_IN5              _L(2)
+#define GPIO_PB07C_GLOC_IN5      _UL_(1 <<  7)
+#define PIN_PC29C_GLOC_IN5             _L_(93) /**< \brief GLOC signal: IN5 on PC29 mux C */
+#define MUX_PC29C_GLOC_IN5              _L_(2)
 #define PINMUX_PC29C_GLOC_IN5      ((PIN_PC29C_GLOC_IN5 << 16) | MUX_PC29C_GLOC_IN5)
-#define GPIO_PC29C_GLOC_IN5      _UL(1 << 29)
-#define PIN_PC17D_GLOC_IN6             _L(81) /**< \brief GLOC signal: IN6 on PC17 mux D */
-#define MUX_PC17D_GLOC_IN6              _L(3)
+#define GPIO_PC29C_GLOC_IN5      _UL_(1 << 29)
+#define PIN_PC17D_GLOC_IN6             _L_(81) /**< \brief GLOC signal: IN6 on PC17 mux D */
+#define MUX_PC17D_GLOC_IN6              _L_(3)
 #define PINMUX_PC17D_GLOC_IN6      ((PIN_PC17D_GLOC_IN6 << 16) | MUX_PC17D_GLOC_IN6)
-#define GPIO_PC17D_GLOC_IN6      _UL(1 << 17)
-#define PIN_PB08C_GLOC_IN6             _L(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
-#define MUX_PB08C_GLOC_IN6              _L(2)
+#define GPIO_PC17D_GLOC_IN6      _UL_(1 << 17)
+#define PIN_PB08C_GLOC_IN6             _L_(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
+#define MUX_PB08C_GLOC_IN6              _L_(2)
 #define PINMUX_PB08C_GLOC_IN6      ((PIN_PB08C_GLOC_IN6 << 16) | MUX_PB08C_GLOC_IN6)
-#define GPIO_PB08C_GLOC_IN6      _UL(1 <<  8)
-#define PIN_PC30C_GLOC_IN6             _L(94) /**< \brief GLOC signal: IN6 on PC30 mux C */
-#define MUX_PC30C_GLOC_IN6              _L(2)
+#define GPIO_PB08C_GLOC_IN6      _UL_(1 <<  8)
+#define PIN_PC30C_GLOC_IN6             _L_(94) /**< \brief GLOC signal: IN6 on PC30 mux C */
+#define MUX_PC30C_GLOC_IN6              _L_(2)
 #define PINMUX_PC30C_GLOC_IN6      ((PIN_PC30C_GLOC_IN6 << 16) | MUX_PC30C_GLOC_IN6)
-#define GPIO_PC30C_GLOC_IN6      _UL(1 << 30)
-#define PIN_PC18D_GLOC_IN7             _L(82) /**< \brief GLOC signal: IN7 on PC18 mux D */
-#define MUX_PC18D_GLOC_IN7              _L(3)
+#define GPIO_PC30C_GLOC_IN6      _UL_(1 << 30)
+#define PIN_PC18D_GLOC_IN7             _L_(82) /**< \brief GLOC signal: IN7 on PC18 mux D */
+#define MUX_PC18D_GLOC_IN7              _L_(3)
 #define PINMUX_PC18D_GLOC_IN7      ((PIN_PC18D_GLOC_IN7 << 16) | MUX_PC18D_GLOC_IN7)
-#define GPIO_PC18D_GLOC_IN7      _UL(1 << 18)
-#define PIN_PB09C_GLOC_IN7             _L(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
-#define MUX_PB09C_GLOC_IN7              _L(2)
+#define GPIO_PC18D_GLOC_IN7      _UL_(1 << 18)
+#define PIN_PB09C_GLOC_IN7             _L_(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
+#define MUX_PB09C_GLOC_IN7              _L_(2)
 #define PINMUX_PB09C_GLOC_IN7      ((PIN_PB09C_GLOC_IN7 << 16) | MUX_PB09C_GLOC_IN7)
-#define GPIO_PB09C_GLOC_IN7      _UL(1 <<  9)
-#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
-#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define GPIO_PB09C_GLOC_IN7      _UL_(1 <<  9)
+#define PIN_PA08D_GLOC_OUT0             _L_(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
-#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
-#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
-#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define GPIO_PA08D_GLOC_OUT0     _UL_(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L_(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
-#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
-#define PIN_PC19D_GLOC_OUT1            _L(83) /**< \brief GLOC signal: OUT1 on PC19 mux D */
-#define MUX_PC19D_GLOC_OUT1             _L(3)
+#define GPIO_PA24D_GLOC_OUT0     _UL_(1 << 24)
+#define PIN_PC19D_GLOC_OUT1            _L_(83) /**< \brief GLOC signal: OUT1 on PC19 mux D */
+#define MUX_PC19D_GLOC_OUT1             _L_(3)
 #define PINMUX_PC19D_GLOC_OUT1     ((PIN_PC19D_GLOC_OUT1 << 16) | MUX_PC19D_GLOC_OUT1)
-#define GPIO_PC19D_GLOC_OUT1     _UL(1 << 19)
-#define PIN_PB10C_GLOC_OUT1            _L(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
-#define MUX_PB10C_GLOC_OUT1             _L(2)
+#define GPIO_PC19D_GLOC_OUT1     _UL_(1 << 19)
+#define PIN_PB10C_GLOC_OUT1            _L_(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
+#define MUX_PB10C_GLOC_OUT1             _L_(2)
 #define PINMUX_PB10C_GLOC_OUT1     ((PIN_PB10C_GLOC_OUT1 << 16) | MUX_PB10C_GLOC_OUT1)
-#define GPIO_PB10C_GLOC_OUT1     _UL(1 << 10)
-#define PIN_PC31C_GLOC_OUT1            _L(95) /**< \brief GLOC signal: OUT1 on PC31 mux C */
-#define MUX_PC31C_GLOC_OUT1             _L(2)
+#define GPIO_PB10C_GLOC_OUT1     _UL_(1 << 10)
+#define PIN_PC31C_GLOC_OUT1            _L_(95) /**< \brief GLOC signal: OUT1 on PC31 mux C */
+#define MUX_PC31C_GLOC_OUT1             _L_(2)
 #define PINMUX_PC31C_GLOC_OUT1     ((PIN_PC31C_GLOC_OUT1 << 16) | MUX_PC31C_GLOC_OUT1)
-#define GPIO_PC31C_GLOC_OUT1     _UL(1 << 31)
+#define GPIO_PC31C_GLOC_OUT1     _UL_(1 << 31)
 /* ========== GPIO definition for ABDACB peripheral ========== */
-#define PIN_PC12C_ABDACB_CLK           _L(76) /**< \brief ABDACB signal: CLK on PC12 mux C */
-#define MUX_PC12C_ABDACB_CLK            _L(2)
+#define PIN_PC12C_ABDACB_CLK           _L_(76) /**< \brief ABDACB signal: CLK on PC12 mux C */
+#define MUX_PC12C_ABDACB_CLK            _L_(2)
 #define PINMUX_PC12C_ABDACB_CLK    ((PIN_PC12C_ABDACB_CLK << 16) | MUX_PC12C_ABDACB_CLK)
-#define GPIO_PC12C_ABDACB_CLK    _UL(1 << 12)
-#define PIN_PB02C_ABDACB_DAC0          _L(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
-#define MUX_PB02C_ABDACB_DAC0           _L(2)
+#define GPIO_PC12C_ABDACB_CLK    _UL_(1 << 12)
+#define PIN_PB02C_ABDACB_DAC0          _L_(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
+#define MUX_PB02C_ABDACB_DAC0           _L_(2)
 #define PINMUX_PB02C_ABDACB_DAC0   ((PIN_PB02C_ABDACB_DAC0 << 16) | MUX_PB02C_ABDACB_DAC0)
-#define GPIO_PB02C_ABDACB_DAC0   _UL(1 <<  2)
-#define PIN_PC09C_ABDACB_DAC0          _L(73) /**< \brief ABDACB signal: DAC0 on PC09 mux C */
-#define MUX_PC09C_ABDACB_DAC0           _L(2)
+#define GPIO_PB02C_ABDACB_DAC0   _UL_(1 <<  2)
+#define PIN_PC09C_ABDACB_DAC0          _L_(73) /**< \brief ABDACB signal: DAC0 on PC09 mux C */
+#define MUX_PC09C_ABDACB_DAC0           _L_(2)
 #define PINMUX_PC09C_ABDACB_DAC0   ((PIN_PC09C_ABDACB_DAC0 << 16) | MUX_PC09C_ABDACB_DAC0)
-#define GPIO_PC09C_ABDACB_DAC0   _UL(1 <<  9)
-#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
-#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define GPIO_PC09C_ABDACB_DAC0   _UL_(1 <<  9)
+#define PIN_PA17B_ABDACB_DAC0          _L_(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L_(1)
 #define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
-#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
-#define PIN_PB04C_ABDACB_DAC1          _L(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
-#define MUX_PB04C_ABDACB_DAC1           _L(2)
+#define GPIO_PA17B_ABDACB_DAC0   _UL_(1 << 17)
+#define PIN_PB04C_ABDACB_DAC1          _L_(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
+#define MUX_PB04C_ABDACB_DAC1           _L_(2)
 #define PINMUX_PB04C_ABDACB_DAC1   ((PIN_PB04C_ABDACB_DAC1 << 16) | MUX_PB04C_ABDACB_DAC1)
-#define GPIO_PB04C_ABDACB_DAC1   _UL(1 <<  4)
-#define PIN_PC13C_ABDACB_DAC1          _L(77) /**< \brief ABDACB signal: DAC1 on PC13 mux C */
-#define MUX_PC13C_ABDACB_DAC1           _L(2)
+#define GPIO_PB04C_ABDACB_DAC1   _UL_(1 <<  4)
+#define PIN_PC13C_ABDACB_DAC1          _L_(77) /**< \brief ABDACB signal: DAC1 on PC13 mux C */
+#define MUX_PC13C_ABDACB_DAC1           _L_(2)
 #define PINMUX_PC13C_ABDACB_DAC1   ((PIN_PC13C_ABDACB_DAC1 << 16) | MUX_PC13C_ABDACB_DAC1)
-#define GPIO_PC13C_ABDACB_DAC1   _UL(1 << 13)
-#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
-#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define GPIO_PC13C_ABDACB_DAC1   _UL_(1 << 13)
+#define PIN_PA19B_ABDACB_DAC1          _L_(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L_(1)
 #define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
-#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
-#define PIN_PB03C_ABDACB_DACN0         _L(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
-#define MUX_PB03C_ABDACB_DACN0          _L(2)
+#define GPIO_PA19B_ABDACB_DAC1   _UL_(1 << 19)
+#define PIN_PB03C_ABDACB_DACN0         _L_(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
+#define MUX_PB03C_ABDACB_DACN0          _L_(2)
 #define PINMUX_PB03C_ABDACB_DACN0  ((PIN_PB03C_ABDACB_DACN0 << 16) | MUX_PB03C_ABDACB_DACN0)
-#define GPIO_PB03C_ABDACB_DACN0  _UL(1 <<  3)
-#define PIN_PC10C_ABDACB_DACN0         _L(74) /**< \brief ABDACB signal: DACN0 on PC10 mux C */
-#define MUX_PC10C_ABDACB_DACN0          _L(2)
+#define GPIO_PB03C_ABDACB_DACN0  _UL_(1 <<  3)
+#define PIN_PC10C_ABDACB_DACN0         _L_(74) /**< \brief ABDACB signal: DACN0 on PC10 mux C */
+#define MUX_PC10C_ABDACB_DACN0          _L_(2)
 #define PINMUX_PC10C_ABDACB_DACN0  ((PIN_PC10C_ABDACB_DACN0 << 16) | MUX_PC10C_ABDACB_DACN0)
-#define GPIO_PC10C_ABDACB_DACN0  _UL(1 << 10)
-#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
-#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define GPIO_PC10C_ABDACB_DACN0  _UL_(1 << 10)
+#define PIN_PA18B_ABDACB_DACN0         _L_(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L_(1)
 #define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
-#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
-#define PIN_PB05C_ABDACB_DACN1         _L(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
-#define MUX_PB05C_ABDACB_DACN1          _L(2)
+#define GPIO_PA18B_ABDACB_DACN0  _UL_(1 << 18)
+#define PIN_PB05C_ABDACB_DACN1         _L_(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
+#define MUX_PB05C_ABDACB_DACN1          _L_(2)
 #define PINMUX_PB05C_ABDACB_DACN1  ((PIN_PB05C_ABDACB_DACN1 << 16) | MUX_PB05C_ABDACB_DACN1)
-#define GPIO_PB05C_ABDACB_DACN1  _UL(1 <<  5)
-#define PIN_PC14C_ABDACB_DACN1         _L(78) /**< \brief ABDACB signal: DACN1 on PC14 mux C */
-#define MUX_PC14C_ABDACB_DACN1          _L(2)
+#define GPIO_PB05C_ABDACB_DACN1  _UL_(1 <<  5)
+#define PIN_PC14C_ABDACB_DACN1         _L_(78) /**< \brief ABDACB signal: DACN1 on PC14 mux C */
+#define MUX_PC14C_ABDACB_DACN1          _L_(2)
 #define PINMUX_PC14C_ABDACB_DACN1  ((PIN_PC14C_ABDACB_DACN1 << 16) | MUX_PC14C_ABDACB_DACN1)
-#define GPIO_PC14C_ABDACB_DACN1  _UL(1 << 14)
-#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
-#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define GPIO_PC14C_ABDACB_DACN1  _UL_(1 << 14)
+#define PIN_PA20B_ABDACB_DACN1         _L_(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L_(1)
 #define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
-#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+#define GPIO_PA20B_ABDACB_DACN1  _UL_(1 << 20)
 /* ========== GPIO definition for PARC peripheral ========== */
-#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
-#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PIN_PA17D_PARC_PCCK            _L_(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L_(3)
 #define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
-#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
-#define PIN_PC21D_PARC_PCCK            _L(85) /**< \brief PARC signal: PCCK on PC21 mux D */
-#define MUX_PC21D_PARC_PCCK             _L(3)
+#define GPIO_PA17D_PARC_PCCK     _UL_(1 << 17)
+#define PIN_PC21D_PARC_PCCK            _L_(85) /**< \brief PARC signal: PCCK on PC21 mux D */
+#define MUX_PC21D_PARC_PCCK             _L_(3)
 #define PINMUX_PC21D_PARC_PCCK     ((PIN_PC21D_PARC_PCCK << 16) | MUX_PC21D_PARC_PCCK)
-#define GPIO_PC21D_PARC_PCCK     _UL(1 << 21)
-#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
-#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define GPIO_PC21D_PARC_PCCK     _UL_(1 << 21)
+#define PIN_PA09D_PARC_PCDATA0          _L_(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L_(3)
 #define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
-#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
-#define PIN_PC24D_PARC_PCDATA0         _L(88) /**< \brief PARC signal: PCDATA0 on PC24 mux D */
-#define MUX_PC24D_PARC_PCDATA0          _L(3)
+#define GPIO_PA09D_PARC_PCDATA0  _UL_(1 <<  9)
+#define PIN_PC24D_PARC_PCDATA0         _L_(88) /**< \brief PARC signal: PCDATA0 on PC24 mux D */
+#define MUX_PC24D_PARC_PCDATA0          _L_(3)
 #define PINMUX_PC24D_PARC_PCDATA0  ((PIN_PC24D_PARC_PCDATA0 << 16) | MUX_PC24D_PARC_PCDATA0)
-#define GPIO_PC24D_PARC_PCDATA0  _UL(1 << 24)
-#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
-#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define GPIO_PC24D_PARC_PCDATA0  _UL_(1 << 24)
+#define PIN_PA10D_PARC_PCDATA1         _L_(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L_(3)
 #define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
-#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
-#define PIN_PC25D_PARC_PCDATA1         _L(89) /**< \brief PARC signal: PCDATA1 on PC25 mux D */
-#define MUX_PC25D_PARC_PCDATA1          _L(3)
+#define GPIO_PA10D_PARC_PCDATA1  _UL_(1 << 10)
+#define PIN_PC25D_PARC_PCDATA1         _L_(89) /**< \brief PARC signal: PCDATA1 on PC25 mux D */
+#define MUX_PC25D_PARC_PCDATA1          _L_(3)
 #define PINMUX_PC25D_PARC_PCDATA1  ((PIN_PC25D_PARC_PCDATA1 << 16) | MUX_PC25D_PARC_PCDATA1)
-#define GPIO_PC25D_PARC_PCDATA1  _UL(1 << 25)
-#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
-#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define GPIO_PC25D_PARC_PCDATA1  _UL_(1 << 25)
+#define PIN_PA11D_PARC_PCDATA2         _L_(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L_(3)
 #define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
-#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
-#define PIN_PC26D_PARC_PCDATA2         _L(90) /**< \brief PARC signal: PCDATA2 on PC26 mux D */
-#define MUX_PC26D_PARC_PCDATA2          _L(3)
+#define GPIO_PA11D_PARC_PCDATA2  _UL_(1 << 11)
+#define PIN_PC26D_PARC_PCDATA2         _L_(90) /**< \brief PARC signal: PCDATA2 on PC26 mux D */
+#define MUX_PC26D_PARC_PCDATA2          _L_(3)
 #define PINMUX_PC26D_PARC_PCDATA2  ((PIN_PC26D_PARC_PCDATA2 << 16) | MUX_PC26D_PARC_PCDATA2)
-#define GPIO_PC26D_PARC_PCDATA2  _UL(1 << 26)
-#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
-#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define GPIO_PC26D_PARC_PCDATA2  _UL_(1 << 26)
+#define PIN_PA12D_PARC_PCDATA3         _L_(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L_(3)
 #define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
-#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
-#define PIN_PC27D_PARC_PCDATA3         _L(91) /**< \brief PARC signal: PCDATA3 on PC27 mux D */
-#define MUX_PC27D_PARC_PCDATA3          _L(3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL_(1 << 12)
+#define PIN_PC27D_PARC_PCDATA3         _L_(91) /**< \brief PARC signal: PCDATA3 on PC27 mux D */
+#define MUX_PC27D_PARC_PCDATA3          _L_(3)
 #define PINMUX_PC27D_PARC_PCDATA3  ((PIN_PC27D_PARC_PCDATA3 << 16) | MUX_PC27D_PARC_PCDATA3)
-#define GPIO_PC27D_PARC_PCDATA3  _UL(1 << 27)
-#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
-#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define GPIO_PC27D_PARC_PCDATA3  _UL_(1 << 27)
+#define PIN_PA13D_PARC_PCDATA4         _L_(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L_(3)
 #define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
-#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
-#define PIN_PC28D_PARC_PCDATA4         _L(92) /**< \brief PARC signal: PCDATA4 on PC28 mux D */
-#define MUX_PC28D_PARC_PCDATA4          _L(3)
+#define GPIO_PA13D_PARC_PCDATA4  _UL_(1 << 13)
+#define PIN_PC28D_PARC_PCDATA4         _L_(92) /**< \brief PARC signal: PCDATA4 on PC28 mux D */
+#define MUX_PC28D_PARC_PCDATA4          _L_(3)
 #define PINMUX_PC28D_PARC_PCDATA4  ((PIN_PC28D_PARC_PCDATA4 << 16) | MUX_PC28D_PARC_PCDATA4)
-#define GPIO_PC28D_PARC_PCDATA4  _UL(1 << 28)
-#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
-#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define GPIO_PC28D_PARC_PCDATA4  _UL_(1 << 28)
+#define PIN_PA14D_PARC_PCDATA5         _L_(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L_(3)
 #define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
-#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
-#define PIN_PC29D_PARC_PCDATA5         _L(93) /**< \brief PARC signal: PCDATA5 on PC29 mux D */
-#define MUX_PC29D_PARC_PCDATA5          _L(3)
+#define GPIO_PA14D_PARC_PCDATA5  _UL_(1 << 14)
+#define PIN_PC29D_PARC_PCDATA5         _L_(93) /**< \brief PARC signal: PCDATA5 on PC29 mux D */
+#define MUX_PC29D_PARC_PCDATA5          _L_(3)
 #define PINMUX_PC29D_PARC_PCDATA5  ((PIN_PC29D_PARC_PCDATA5 << 16) | MUX_PC29D_PARC_PCDATA5)
-#define GPIO_PC29D_PARC_PCDATA5  _UL(1 << 29)
-#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
-#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define GPIO_PC29D_PARC_PCDATA5  _UL_(1 << 29)
+#define PIN_PA15D_PARC_PCDATA6         _L_(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L_(3)
 #define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
-#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
-#define PIN_PC30D_PARC_PCDATA6         _L(94) /**< \brief PARC signal: PCDATA6 on PC30 mux D */
-#define MUX_PC30D_PARC_PCDATA6          _L(3)
+#define GPIO_PA15D_PARC_PCDATA6  _UL_(1 << 15)
+#define PIN_PC30D_PARC_PCDATA6         _L_(94) /**< \brief PARC signal: PCDATA6 on PC30 mux D */
+#define MUX_PC30D_PARC_PCDATA6          _L_(3)
 #define PINMUX_PC30D_PARC_PCDATA6  ((PIN_PC30D_PARC_PCDATA6 << 16) | MUX_PC30D_PARC_PCDATA6)
-#define GPIO_PC30D_PARC_PCDATA6  _UL(1 << 30)
-#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
-#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define GPIO_PC30D_PARC_PCDATA6  _UL_(1 << 30)
+#define PIN_PA16D_PARC_PCDATA7         _L_(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L_(3)
 #define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
-#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
-#define PIN_PC31D_PARC_PCDATA7         _L(95) /**< \brief PARC signal: PCDATA7 on PC31 mux D */
-#define MUX_PC31D_PARC_PCDATA7          _L(3)
+#define GPIO_PA16D_PARC_PCDATA7  _UL_(1 << 16)
+#define PIN_PC31D_PARC_PCDATA7         _L_(95) /**< \brief PARC signal: PCDATA7 on PC31 mux D */
+#define MUX_PC31D_PARC_PCDATA7          _L_(3)
 #define PINMUX_PC31D_PARC_PCDATA7  ((PIN_PC31D_PARC_PCDATA7 << 16) | MUX_PC31D_PARC_PCDATA7)
-#define GPIO_PC31D_PARC_PCDATA7  _UL(1 << 31)
-#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
-#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define GPIO_PC31D_PARC_PCDATA7  _UL_(1 << 31)
+#define PIN_PA18D_PARC_PCEN1           _L_(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L_(3)
 #define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
-#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
-#define PIN_PC22D_PARC_PCEN1           _L(86) /**< \brief PARC signal: PCEN1 on PC22 mux D */
-#define MUX_PC22D_PARC_PCEN1            _L(3)
+#define GPIO_PA18D_PARC_PCEN1    _UL_(1 << 18)
+#define PIN_PC22D_PARC_PCEN1           _L_(86) /**< \brief PARC signal: PCEN1 on PC22 mux D */
+#define MUX_PC22D_PARC_PCEN1            _L_(3)
 #define PINMUX_PC22D_PARC_PCEN1    ((PIN_PC22D_PARC_PCEN1 << 16) | MUX_PC22D_PARC_PCEN1)
-#define GPIO_PC22D_PARC_PCEN1    _UL(1 << 22)
-#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
-#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define GPIO_PC22D_PARC_PCEN1    _UL_(1 << 22)
+#define PIN_PA19D_PARC_PCEN2           _L_(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L_(3)
 #define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
-#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
-#define PIN_PC23D_PARC_PCEN2           _L(87) /**< \brief PARC signal: PCEN2 on PC23 mux D */
-#define MUX_PC23D_PARC_PCEN2            _L(3)
+#define GPIO_PA19D_PARC_PCEN2    _UL_(1 << 19)
+#define PIN_PC23D_PARC_PCEN2           _L_(87) /**< \brief PARC signal: PCEN2 on PC23 mux D */
+#define MUX_PC23D_PARC_PCEN2            _L_(3)
 #define PINMUX_PC23D_PARC_PCEN2    ((PIN_PC23D_PARC_PCEN2 << 16) | MUX_PC23D_PARC_PCEN2)
-#define GPIO_PC23D_PARC_PCEN2    _UL(1 << 23)
+#define GPIO_PC23D_PARC_PCEN2    _UL_(1 << 23)
 /* ========== GPIO definition for CATB peripheral ========== */
-#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
-#define MUX_PA02G_CATB_DIS              _L(6)
+#define PIN_PA02G_CATB_DIS              _L_(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L_(6)
 #define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
-#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
-#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
-#define MUX_PA12G_CATB_DIS              _L(6)
+#define GPIO_PA02G_CATB_DIS      _UL_(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L_(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L_(6)
 #define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
-#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
-#define MUX_PA23G_CATB_DIS              _L(6)
+#define GPIO_PA12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L_(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L_(6)
 #define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
-#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
-#define PIN_PB03G_CATB_DIS             _L(35) /**< \brief CATB signal: DIS on PB03 mux G */
-#define MUX_PB03G_CATB_DIS              _L(6)
+#define GPIO_PA23G_CATB_DIS      _UL_(1 << 23)
+#define PIN_PB03G_CATB_DIS             _L_(35) /**< \brief CATB signal: DIS on PB03 mux G */
+#define MUX_PB03G_CATB_DIS              _L_(6)
 #define PINMUX_PB03G_CATB_DIS      ((PIN_PB03G_CATB_DIS << 16) | MUX_PB03G_CATB_DIS)
-#define GPIO_PB03G_CATB_DIS      _UL(1 <<  3)
-#define PIN_PB12G_CATB_DIS             _L(44) /**< \brief CATB signal: DIS on PB12 mux G */
-#define MUX_PB12G_CATB_DIS              _L(6)
+#define GPIO_PB03G_CATB_DIS      _UL_(1 <<  3)
+#define PIN_PB12G_CATB_DIS             _L_(44) /**< \brief CATB signal: DIS on PB12 mux G */
+#define MUX_PB12G_CATB_DIS              _L_(6)
 #define PINMUX_PB12G_CATB_DIS      ((PIN_PB12G_CATB_DIS << 16) | MUX_PB12G_CATB_DIS)
-#define GPIO_PB12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PC05G_CATB_DIS             _L(69) /**< \brief CATB signal: DIS on PC05 mux G */
-#define MUX_PC05G_CATB_DIS              _L(6)
+#define GPIO_PB12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PC05G_CATB_DIS             _L_(69) /**< \brief CATB signal: DIS on PC05 mux G */
+#define MUX_PC05G_CATB_DIS              _L_(6)
 #define PINMUX_PC05G_CATB_DIS      ((PIN_PC05G_CATB_DIS << 16) | MUX_PC05G_CATB_DIS)
-#define GPIO_PC05G_CATB_DIS      _UL(1 <<  5)
-#define PIN_PC14G_CATB_DIS             _L(78) /**< \brief CATB signal: DIS on PC14 mux G */
-#define MUX_PC14G_CATB_DIS              _L(6)
+#define GPIO_PC05G_CATB_DIS      _UL_(1 <<  5)
+#define PIN_PC14G_CATB_DIS             _L_(78) /**< \brief CATB signal: DIS on PC14 mux G */
+#define MUX_PC14G_CATB_DIS              _L_(6)
 #define PINMUX_PC14G_CATB_DIS      ((PIN_PC14G_CATB_DIS << 16) | MUX_PC14G_CATB_DIS)
-#define GPIO_PC14G_CATB_DIS      _UL(1 << 14)
-#define PIN_PC23G_CATB_DIS             _L(87) /**< \brief CATB signal: DIS on PC23 mux G */
-#define MUX_PC23G_CATB_DIS              _L(6)
+#define GPIO_PC14G_CATB_DIS      _UL_(1 << 14)
+#define PIN_PC23G_CATB_DIS             _L_(87) /**< \brief CATB signal: DIS on PC23 mux G */
+#define MUX_PC23G_CATB_DIS              _L_(6)
 #define PINMUX_PC23G_CATB_DIS      ((PIN_PC23G_CATB_DIS << 16) | MUX_PC23G_CATB_DIS)
-#define GPIO_PC23G_CATB_DIS      _UL(1 << 23)
-#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
-#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define GPIO_PC23G_CATB_DIS      _UL_(1 << 23)
+#define PIN_PA04G_CATB_SENSE0           _L_(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L_(6)
 #define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
-#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
-#define PIN_PB13G_CATB_SENSE0          _L(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
-#define MUX_PB13G_CATB_SENSE0           _L(6)
+#define GPIO_PA04G_CATB_SENSE0   _UL_(1 <<  4)
+#define PIN_PB13G_CATB_SENSE0          _L_(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
+#define MUX_PB13G_CATB_SENSE0           _L_(6)
 #define PINMUX_PB13G_CATB_SENSE0   ((PIN_PB13G_CATB_SENSE0 << 16) | MUX_PB13G_CATB_SENSE0)
-#define GPIO_PB13G_CATB_SENSE0   _UL(1 << 13)
-#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
-#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define GPIO_PB13G_CATB_SENSE0   _UL_(1 << 13)
+#define PIN_PA05G_CATB_SENSE1           _L_(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L_(6)
 #define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
-#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
-#define PIN_PB14G_CATB_SENSE1          _L(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
-#define MUX_PB14G_CATB_SENSE1           _L(6)
+#define GPIO_PA05G_CATB_SENSE1   _UL_(1 <<  5)
+#define PIN_PB14G_CATB_SENSE1          _L_(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
+#define MUX_PB14G_CATB_SENSE1           _L_(6)
 #define PINMUX_PB14G_CATB_SENSE1   ((PIN_PB14G_CATB_SENSE1 << 16) | MUX_PB14G_CATB_SENSE1)
-#define GPIO_PB14G_CATB_SENSE1   _UL(1 << 14)
-#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
-#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define GPIO_PB14G_CATB_SENSE1   _UL_(1 << 14)
+#define PIN_PA06G_CATB_SENSE2           _L_(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L_(6)
 #define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
-#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
-#define PIN_PB15G_CATB_SENSE2          _L(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
-#define MUX_PB15G_CATB_SENSE2           _L(6)
+#define GPIO_PA06G_CATB_SENSE2   _UL_(1 <<  6)
+#define PIN_PB15G_CATB_SENSE2          _L_(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
+#define MUX_PB15G_CATB_SENSE2           _L_(6)
 #define PINMUX_PB15G_CATB_SENSE2   ((PIN_PB15G_CATB_SENSE2 << 16) | MUX_PB15G_CATB_SENSE2)
-#define GPIO_PB15G_CATB_SENSE2   _UL(1 << 15)
-#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
-#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define GPIO_PB15G_CATB_SENSE2   _UL_(1 << 15)
+#define PIN_PA07G_CATB_SENSE3           _L_(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L_(6)
 #define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
-#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
-#define PIN_PC00G_CATB_SENSE3          _L(64) /**< \brief CATB signal: SENSE3 on PC00 mux G */
-#define MUX_PC00G_CATB_SENSE3           _L(6)
+#define GPIO_PA07G_CATB_SENSE3   _UL_(1 <<  7)
+#define PIN_PC00G_CATB_SENSE3          _L_(64) /**< \brief CATB signal: SENSE3 on PC00 mux G */
+#define MUX_PC00G_CATB_SENSE3           _L_(6)
 #define PINMUX_PC00G_CATB_SENSE3   ((PIN_PC00G_CATB_SENSE3 << 16) | MUX_PC00G_CATB_SENSE3)
-#define GPIO_PC00G_CATB_SENSE3   _UL(1 <<  0)
-#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
-#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define GPIO_PC00G_CATB_SENSE3   _UL_(1 <<  0)
+#define PIN_PA08G_CATB_SENSE4           _L_(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L_(6)
 #define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
-#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
-#define PIN_PC01G_CATB_SENSE4          _L(65) /**< \brief CATB signal: SENSE4 on PC01 mux G */
-#define MUX_PC01G_CATB_SENSE4           _L(6)
+#define GPIO_PA08G_CATB_SENSE4   _UL_(1 <<  8)
+#define PIN_PC01G_CATB_SENSE4          _L_(65) /**< \brief CATB signal: SENSE4 on PC01 mux G */
+#define MUX_PC01G_CATB_SENSE4           _L_(6)
 #define PINMUX_PC01G_CATB_SENSE4   ((PIN_PC01G_CATB_SENSE4 << 16) | MUX_PC01G_CATB_SENSE4)
-#define GPIO_PC01G_CATB_SENSE4   _UL(1 <<  1)
-#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
-#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define GPIO_PC01G_CATB_SENSE4   _UL_(1 <<  1)
+#define PIN_PA09G_CATB_SENSE5           _L_(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L_(6)
 #define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
-#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
-#define PIN_PC02G_CATB_SENSE5          _L(66) /**< \brief CATB signal: SENSE5 on PC02 mux G */
-#define MUX_PC02G_CATB_SENSE5           _L(6)
+#define GPIO_PA09G_CATB_SENSE5   _UL_(1 <<  9)
+#define PIN_PC02G_CATB_SENSE5          _L_(66) /**< \brief CATB signal: SENSE5 on PC02 mux G */
+#define MUX_PC02G_CATB_SENSE5           _L_(6)
 #define PINMUX_PC02G_CATB_SENSE5   ((PIN_PC02G_CATB_SENSE5 << 16) | MUX_PC02G_CATB_SENSE5)
-#define GPIO_PC02G_CATB_SENSE5   _UL(1 <<  2)
-#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
-#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define GPIO_PC02G_CATB_SENSE5   _UL_(1 <<  2)
+#define PIN_PA10G_CATB_SENSE6          _L_(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L_(6)
 #define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
-#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
-#define PIN_PC03G_CATB_SENSE6          _L(67) /**< \brief CATB signal: SENSE6 on PC03 mux G */
-#define MUX_PC03G_CATB_SENSE6           _L(6)
+#define GPIO_PA10G_CATB_SENSE6   _UL_(1 << 10)
+#define PIN_PC03G_CATB_SENSE6          _L_(67) /**< \brief CATB signal: SENSE6 on PC03 mux G */
+#define MUX_PC03G_CATB_SENSE6           _L_(6)
 #define PINMUX_PC03G_CATB_SENSE6   ((PIN_PC03G_CATB_SENSE6 << 16) | MUX_PC03G_CATB_SENSE6)
-#define GPIO_PC03G_CATB_SENSE6   _UL(1 <<  3)
-#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
-#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define GPIO_PC03G_CATB_SENSE6   _UL_(1 <<  3)
+#define PIN_PA11G_CATB_SENSE7          _L_(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L_(6)
 #define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
-#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
-#define PIN_PC04G_CATB_SENSE7          _L(68) /**< \brief CATB signal: SENSE7 on PC04 mux G */
-#define MUX_PC04G_CATB_SENSE7           _L(6)
+#define GPIO_PA11G_CATB_SENSE7   _UL_(1 << 11)
+#define PIN_PC04G_CATB_SENSE7          _L_(68) /**< \brief CATB signal: SENSE7 on PC04 mux G */
+#define MUX_PC04G_CATB_SENSE7           _L_(6)
 #define PINMUX_PC04G_CATB_SENSE7   ((PIN_PC04G_CATB_SENSE7 << 16) | MUX_PC04G_CATB_SENSE7)
-#define GPIO_PC04G_CATB_SENSE7   _UL(1 <<  4)
-#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
-#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define GPIO_PC04G_CATB_SENSE7   _UL_(1 <<  4)
+#define PIN_PA13G_CATB_SENSE8          _L_(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L_(6)
 #define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
-#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
-#define PIN_PC06G_CATB_SENSE8          _L(70) /**< \brief CATB signal: SENSE8 on PC06 mux G */
-#define MUX_PC06G_CATB_SENSE8           _L(6)
+#define GPIO_PA13G_CATB_SENSE8   _UL_(1 << 13)
+#define PIN_PC06G_CATB_SENSE8          _L_(70) /**< \brief CATB signal: SENSE8 on PC06 mux G */
+#define MUX_PC06G_CATB_SENSE8           _L_(6)
 #define PINMUX_PC06G_CATB_SENSE8   ((PIN_PC06G_CATB_SENSE8 << 16) | MUX_PC06G_CATB_SENSE8)
-#define GPIO_PC06G_CATB_SENSE8   _UL(1 <<  6)
-#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
-#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define GPIO_PC06G_CATB_SENSE8   _UL_(1 <<  6)
+#define PIN_PA14G_CATB_SENSE9          _L_(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L_(6)
 #define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
-#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
-#define PIN_PC07G_CATB_SENSE9          _L(71) /**< \brief CATB signal: SENSE9 on PC07 mux G */
-#define MUX_PC07G_CATB_SENSE9           _L(6)
+#define GPIO_PA14G_CATB_SENSE9   _UL_(1 << 14)
+#define PIN_PC07G_CATB_SENSE9          _L_(71) /**< \brief CATB signal: SENSE9 on PC07 mux G */
+#define MUX_PC07G_CATB_SENSE9           _L_(6)
 #define PINMUX_PC07G_CATB_SENSE9   ((PIN_PC07G_CATB_SENSE9 << 16) | MUX_PC07G_CATB_SENSE9)
-#define GPIO_PC07G_CATB_SENSE9   _UL(1 <<  7)
-#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
-#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define GPIO_PC07G_CATB_SENSE9   _UL_(1 <<  7)
+#define PIN_PA15G_CATB_SENSE10         _L_(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L_(6)
 #define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
-#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
-#define PIN_PC08G_CATB_SENSE10         _L(72) /**< \brief CATB signal: SENSE10 on PC08 mux G */
-#define MUX_PC08G_CATB_SENSE10          _L(6)
+#define GPIO_PA15G_CATB_SENSE10  _UL_(1 << 15)
+#define PIN_PC08G_CATB_SENSE10         _L_(72) /**< \brief CATB signal: SENSE10 on PC08 mux G */
+#define MUX_PC08G_CATB_SENSE10          _L_(6)
 #define PINMUX_PC08G_CATB_SENSE10  ((PIN_PC08G_CATB_SENSE10 << 16) | MUX_PC08G_CATB_SENSE10)
-#define GPIO_PC08G_CATB_SENSE10  _UL(1 <<  8)
-#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
-#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define GPIO_PC08G_CATB_SENSE10  _UL_(1 <<  8)
+#define PIN_PA16G_CATB_SENSE11         _L_(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L_(6)
 #define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
-#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
-#define PIN_PC09G_CATB_SENSE11         _L(73) /**< \brief CATB signal: SENSE11 on PC09 mux G */
-#define MUX_PC09G_CATB_SENSE11          _L(6)
+#define GPIO_PA16G_CATB_SENSE11  _UL_(1 << 16)
+#define PIN_PC09G_CATB_SENSE11         _L_(73) /**< \brief CATB signal: SENSE11 on PC09 mux G */
+#define MUX_PC09G_CATB_SENSE11          _L_(6)
 #define PINMUX_PC09G_CATB_SENSE11  ((PIN_PC09G_CATB_SENSE11 << 16) | MUX_PC09G_CATB_SENSE11)
-#define GPIO_PC09G_CATB_SENSE11  _UL(1 <<  9)
-#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
-#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define GPIO_PC09G_CATB_SENSE11  _UL_(1 <<  9)
+#define PIN_PA17G_CATB_SENSE12         _L_(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L_(6)
 #define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
-#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
-#define PIN_PC10G_CATB_SENSE12         _L(74) /**< \brief CATB signal: SENSE12 on PC10 mux G */
-#define MUX_PC10G_CATB_SENSE12          _L(6)
+#define GPIO_PA17G_CATB_SENSE12  _UL_(1 << 17)
+#define PIN_PC10G_CATB_SENSE12         _L_(74) /**< \brief CATB signal: SENSE12 on PC10 mux G */
+#define MUX_PC10G_CATB_SENSE12          _L_(6)
 #define PINMUX_PC10G_CATB_SENSE12  ((PIN_PC10G_CATB_SENSE12 << 16) | MUX_PC10G_CATB_SENSE12)
-#define GPIO_PC10G_CATB_SENSE12  _UL(1 << 10)
-#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
-#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define GPIO_PC10G_CATB_SENSE12  _UL_(1 << 10)
+#define PIN_PA18G_CATB_SENSE13         _L_(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L_(6)
 #define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
-#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
-#define PIN_PC11G_CATB_SENSE13         _L(75) /**< \brief CATB signal: SENSE13 on PC11 mux G */
-#define MUX_PC11G_CATB_SENSE13          _L(6)
+#define GPIO_PA18G_CATB_SENSE13  _UL_(1 << 18)
+#define PIN_PC11G_CATB_SENSE13         _L_(75) /**< \brief CATB signal: SENSE13 on PC11 mux G */
+#define MUX_PC11G_CATB_SENSE13          _L_(6)
 #define PINMUX_PC11G_CATB_SENSE13  ((PIN_PC11G_CATB_SENSE13 << 16) | MUX_PC11G_CATB_SENSE13)
-#define GPIO_PC11G_CATB_SENSE13  _UL(1 << 11)
-#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
-#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define GPIO_PC11G_CATB_SENSE13  _UL_(1 << 11)
+#define PIN_PA19G_CATB_SENSE14         _L_(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L_(6)
 #define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
-#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
-#define PIN_PC12G_CATB_SENSE14         _L(76) /**< \brief CATB signal: SENSE14 on PC12 mux G */
-#define MUX_PC12G_CATB_SENSE14          _L(6)
+#define GPIO_PA19G_CATB_SENSE14  _UL_(1 << 19)
+#define PIN_PC12G_CATB_SENSE14         _L_(76) /**< \brief CATB signal: SENSE14 on PC12 mux G */
+#define MUX_PC12G_CATB_SENSE14          _L_(6)
 #define PINMUX_PC12G_CATB_SENSE14  ((PIN_PC12G_CATB_SENSE14 << 16) | MUX_PC12G_CATB_SENSE14)
-#define GPIO_PC12G_CATB_SENSE14  _UL(1 << 12)
-#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
-#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define GPIO_PC12G_CATB_SENSE14  _UL_(1 << 12)
+#define PIN_PA20G_CATB_SENSE15         _L_(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L_(6)
 #define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
-#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
-#define PIN_PC13G_CATB_SENSE15         _L(77) /**< \brief CATB signal: SENSE15 on PC13 mux G */
-#define MUX_PC13G_CATB_SENSE15          _L(6)
+#define GPIO_PA20G_CATB_SENSE15  _UL_(1 << 20)
+#define PIN_PC13G_CATB_SENSE15         _L_(77) /**< \brief CATB signal: SENSE15 on PC13 mux G */
+#define MUX_PC13G_CATB_SENSE15          _L_(6)
 #define PINMUX_PC13G_CATB_SENSE15  ((PIN_PC13G_CATB_SENSE15 << 16) | MUX_PC13G_CATB_SENSE15)
-#define GPIO_PC13G_CATB_SENSE15  _UL(1 << 13)
-#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
-#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define GPIO_PC13G_CATB_SENSE15  _UL_(1 << 13)
+#define PIN_PA21G_CATB_SENSE16         _L_(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L_(6)
 #define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
-#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
-#define PIN_PC15G_CATB_SENSE16         _L(79) /**< \brief CATB signal: SENSE16 on PC15 mux G */
-#define MUX_PC15G_CATB_SENSE16          _L(6)
+#define GPIO_PA21G_CATB_SENSE16  _UL_(1 << 21)
+#define PIN_PC15G_CATB_SENSE16         _L_(79) /**< \brief CATB signal: SENSE16 on PC15 mux G */
+#define MUX_PC15G_CATB_SENSE16          _L_(6)
 #define PINMUX_PC15G_CATB_SENSE16  ((PIN_PC15G_CATB_SENSE16 << 16) | MUX_PC15G_CATB_SENSE16)
-#define GPIO_PC15G_CATB_SENSE16  _UL(1 << 15)
-#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
-#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define GPIO_PC15G_CATB_SENSE16  _UL_(1 << 15)
+#define PIN_PA22G_CATB_SENSE17         _L_(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L_(6)
 #define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
-#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
-#define PIN_PC16G_CATB_SENSE17         _L(80) /**< \brief CATB signal: SENSE17 on PC16 mux G */
-#define MUX_PC16G_CATB_SENSE17          _L(6)
+#define GPIO_PA22G_CATB_SENSE17  _UL_(1 << 22)
+#define PIN_PC16G_CATB_SENSE17         _L_(80) /**< \brief CATB signal: SENSE17 on PC16 mux G */
+#define MUX_PC16G_CATB_SENSE17          _L_(6)
 #define PINMUX_PC16G_CATB_SENSE17  ((PIN_PC16G_CATB_SENSE17 << 16) | MUX_PC16G_CATB_SENSE17)
-#define GPIO_PC16G_CATB_SENSE17  _UL(1 << 16)
-#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
-#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define GPIO_PC16G_CATB_SENSE17  _UL_(1 << 16)
+#define PIN_PA24G_CATB_SENSE18         _L_(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L_(6)
 #define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
-#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
-#define PIN_PC17G_CATB_SENSE18         _L(81) /**< \brief CATB signal: SENSE18 on PC17 mux G */
-#define MUX_PC17G_CATB_SENSE18          _L(6)
+#define GPIO_PA24G_CATB_SENSE18  _UL_(1 << 24)
+#define PIN_PC17G_CATB_SENSE18         _L_(81) /**< \brief CATB signal: SENSE18 on PC17 mux G */
+#define MUX_PC17G_CATB_SENSE18          _L_(6)
 #define PINMUX_PC17G_CATB_SENSE18  ((PIN_PC17G_CATB_SENSE18 << 16) | MUX_PC17G_CATB_SENSE18)
-#define GPIO_PC17G_CATB_SENSE18  _UL(1 << 17)
-#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
-#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define GPIO_PC17G_CATB_SENSE18  _UL_(1 << 17)
+#define PIN_PA25G_CATB_SENSE19         _L_(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L_(6)
 #define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
-#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
-#define PIN_PC18G_CATB_SENSE19         _L(82) /**< \brief CATB signal: SENSE19 on PC18 mux G */
-#define MUX_PC18G_CATB_SENSE19          _L(6)
+#define GPIO_PA25G_CATB_SENSE19  _UL_(1 << 25)
+#define PIN_PC18G_CATB_SENSE19         _L_(82) /**< \brief CATB signal: SENSE19 on PC18 mux G */
+#define MUX_PC18G_CATB_SENSE19          _L_(6)
 #define PINMUX_PC18G_CATB_SENSE19  ((PIN_PC18G_CATB_SENSE19 << 16) | MUX_PC18G_CATB_SENSE19)
-#define GPIO_PC18G_CATB_SENSE19  _UL(1 << 18)
-#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
-#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define GPIO_PC18G_CATB_SENSE19  _UL_(1 << 18)
+#define PIN_PA26G_CATB_SENSE20         _L_(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L_(6)
 #define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
-#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
-#define PIN_PC19G_CATB_SENSE20         _L(83) /**< \brief CATB signal: SENSE20 on PC19 mux G */
-#define MUX_PC19G_CATB_SENSE20          _L(6)
+#define GPIO_PA26G_CATB_SENSE20  _UL_(1 << 26)
+#define PIN_PC19G_CATB_SENSE20         _L_(83) /**< \brief CATB signal: SENSE20 on PC19 mux G */
+#define MUX_PC19G_CATB_SENSE20          _L_(6)
 #define PINMUX_PC19G_CATB_SENSE20  ((PIN_PC19G_CATB_SENSE20 << 16) | MUX_PC19G_CATB_SENSE20)
-#define GPIO_PC19G_CATB_SENSE20  _UL(1 << 19)
-#define PIN_PB00G_CATB_SENSE21         _L(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
-#define MUX_PB00G_CATB_SENSE21          _L(6)
+#define GPIO_PC19G_CATB_SENSE20  _UL_(1 << 19)
+#define PIN_PB00G_CATB_SENSE21         _L_(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
+#define MUX_PB00G_CATB_SENSE21          _L_(6)
 #define PINMUX_PB00G_CATB_SENSE21  ((PIN_PB00G_CATB_SENSE21 << 16) | MUX_PB00G_CATB_SENSE21)
-#define GPIO_PB00G_CATB_SENSE21  _UL(1 <<  0)
-#define PIN_PC20G_CATB_SENSE21         _L(84) /**< \brief CATB signal: SENSE21 on PC20 mux G */
-#define MUX_PC20G_CATB_SENSE21          _L(6)
+#define GPIO_PB00G_CATB_SENSE21  _UL_(1 <<  0)
+#define PIN_PC20G_CATB_SENSE21         _L_(84) /**< \brief CATB signal: SENSE21 on PC20 mux G */
+#define MUX_PC20G_CATB_SENSE21          _L_(6)
 #define PINMUX_PC20G_CATB_SENSE21  ((PIN_PC20G_CATB_SENSE21 << 16) | MUX_PC20G_CATB_SENSE21)
-#define GPIO_PC20G_CATB_SENSE21  _UL(1 << 20)
-#define PIN_PB01G_CATB_SENSE22         _L(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
-#define MUX_PB01G_CATB_SENSE22          _L(6)
+#define GPIO_PC20G_CATB_SENSE21  _UL_(1 << 20)
+#define PIN_PB01G_CATB_SENSE22         _L_(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
+#define MUX_PB01G_CATB_SENSE22          _L_(6)
 #define PINMUX_PB01G_CATB_SENSE22  ((PIN_PB01G_CATB_SENSE22 << 16) | MUX_PB01G_CATB_SENSE22)
-#define GPIO_PB01G_CATB_SENSE22  _UL(1 <<  1)
-#define PIN_PC21G_CATB_SENSE22         _L(85) /**< \brief CATB signal: SENSE22 on PC21 mux G */
-#define MUX_PC21G_CATB_SENSE22          _L(6)
+#define GPIO_PB01G_CATB_SENSE22  _UL_(1 <<  1)
+#define PIN_PC21G_CATB_SENSE22         _L_(85) /**< \brief CATB signal: SENSE22 on PC21 mux G */
+#define MUX_PC21G_CATB_SENSE22          _L_(6)
 #define PINMUX_PC21G_CATB_SENSE22  ((PIN_PC21G_CATB_SENSE22 << 16) | MUX_PC21G_CATB_SENSE22)
-#define GPIO_PC21G_CATB_SENSE22  _UL(1 << 21)
-#define PIN_PB02G_CATB_SENSE23         _L(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
-#define MUX_PB02G_CATB_SENSE23          _L(6)
+#define GPIO_PC21G_CATB_SENSE22  _UL_(1 << 21)
+#define PIN_PB02G_CATB_SENSE23         _L_(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
+#define MUX_PB02G_CATB_SENSE23          _L_(6)
 #define PINMUX_PB02G_CATB_SENSE23  ((PIN_PB02G_CATB_SENSE23 << 16) | MUX_PB02G_CATB_SENSE23)
-#define GPIO_PB02G_CATB_SENSE23  _UL(1 <<  2)
-#define PIN_PC22G_CATB_SENSE23         _L(86) /**< \brief CATB signal: SENSE23 on PC22 mux G */
-#define MUX_PC22G_CATB_SENSE23          _L(6)
+#define GPIO_PB02G_CATB_SENSE23  _UL_(1 <<  2)
+#define PIN_PC22G_CATB_SENSE23         _L_(86) /**< \brief CATB signal: SENSE23 on PC22 mux G */
+#define MUX_PC22G_CATB_SENSE23          _L_(6)
 #define PINMUX_PC22G_CATB_SENSE23  ((PIN_PC22G_CATB_SENSE23 << 16) | MUX_PC22G_CATB_SENSE23)
-#define GPIO_PC22G_CATB_SENSE23  _UL(1 << 22)
-#define PIN_PB04G_CATB_SENSE24         _L(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
-#define MUX_PB04G_CATB_SENSE24          _L(6)
+#define GPIO_PC22G_CATB_SENSE23  _UL_(1 << 22)
+#define PIN_PB04G_CATB_SENSE24         _L_(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
+#define MUX_PB04G_CATB_SENSE24          _L_(6)
 #define PINMUX_PB04G_CATB_SENSE24  ((PIN_PB04G_CATB_SENSE24 << 16) | MUX_PB04G_CATB_SENSE24)
-#define GPIO_PB04G_CATB_SENSE24  _UL(1 <<  4)
-#define PIN_PC24G_CATB_SENSE24         _L(88) /**< \brief CATB signal: SENSE24 on PC24 mux G */
-#define MUX_PC24G_CATB_SENSE24          _L(6)
+#define GPIO_PB04G_CATB_SENSE24  _UL_(1 <<  4)
+#define PIN_PC24G_CATB_SENSE24         _L_(88) /**< \brief CATB signal: SENSE24 on PC24 mux G */
+#define MUX_PC24G_CATB_SENSE24          _L_(6)
 #define PINMUX_PC24G_CATB_SENSE24  ((PIN_PC24G_CATB_SENSE24 << 16) | MUX_PC24G_CATB_SENSE24)
-#define GPIO_PC24G_CATB_SENSE24  _UL(1 << 24)
-#define PIN_PB05G_CATB_SENSE25         _L(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
-#define MUX_PB05G_CATB_SENSE25          _L(6)
+#define GPIO_PC24G_CATB_SENSE24  _UL_(1 << 24)
+#define PIN_PB05G_CATB_SENSE25         _L_(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
+#define MUX_PB05G_CATB_SENSE25          _L_(6)
 #define PINMUX_PB05G_CATB_SENSE25  ((PIN_PB05G_CATB_SENSE25 << 16) | MUX_PB05G_CATB_SENSE25)
-#define GPIO_PB05G_CATB_SENSE25  _UL(1 <<  5)
-#define PIN_PC25G_CATB_SENSE25         _L(89) /**< \brief CATB signal: SENSE25 on PC25 mux G */
-#define MUX_PC25G_CATB_SENSE25          _L(6)
+#define GPIO_PB05G_CATB_SENSE25  _UL_(1 <<  5)
+#define PIN_PC25G_CATB_SENSE25         _L_(89) /**< \brief CATB signal: SENSE25 on PC25 mux G */
+#define MUX_PC25G_CATB_SENSE25          _L_(6)
 #define PINMUX_PC25G_CATB_SENSE25  ((PIN_PC25G_CATB_SENSE25 << 16) | MUX_PC25G_CATB_SENSE25)
-#define GPIO_PC25G_CATB_SENSE25  _UL(1 << 25)
-#define PIN_PB06G_CATB_SENSE26         _L(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
-#define MUX_PB06G_CATB_SENSE26          _L(6)
+#define GPIO_PC25G_CATB_SENSE25  _UL_(1 << 25)
+#define PIN_PB06G_CATB_SENSE26         _L_(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
+#define MUX_PB06G_CATB_SENSE26          _L_(6)
 #define PINMUX_PB06G_CATB_SENSE26  ((PIN_PB06G_CATB_SENSE26 << 16) | MUX_PB06G_CATB_SENSE26)
-#define GPIO_PB06G_CATB_SENSE26  _UL(1 <<  6)
-#define PIN_PC26G_CATB_SENSE26         _L(90) /**< \brief CATB signal: SENSE26 on PC26 mux G */
-#define MUX_PC26G_CATB_SENSE26          _L(6)
+#define GPIO_PB06G_CATB_SENSE26  _UL_(1 <<  6)
+#define PIN_PC26G_CATB_SENSE26         _L_(90) /**< \brief CATB signal: SENSE26 on PC26 mux G */
+#define MUX_PC26G_CATB_SENSE26          _L_(6)
 #define PINMUX_PC26G_CATB_SENSE26  ((PIN_PC26G_CATB_SENSE26 << 16) | MUX_PC26G_CATB_SENSE26)
-#define GPIO_PC26G_CATB_SENSE26  _UL(1 << 26)
-#define PIN_PB07G_CATB_SENSE27         _L(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
-#define MUX_PB07G_CATB_SENSE27          _L(6)
+#define GPIO_PC26G_CATB_SENSE26  _UL_(1 << 26)
+#define PIN_PB07G_CATB_SENSE27         _L_(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
+#define MUX_PB07G_CATB_SENSE27          _L_(6)
 #define PINMUX_PB07G_CATB_SENSE27  ((PIN_PB07G_CATB_SENSE27 << 16) | MUX_PB07G_CATB_SENSE27)
-#define GPIO_PB07G_CATB_SENSE27  _UL(1 <<  7)
-#define PIN_PC27G_CATB_SENSE27         _L(91) /**< \brief CATB signal: SENSE27 on PC27 mux G */
-#define MUX_PC27G_CATB_SENSE27          _L(6)
+#define GPIO_PB07G_CATB_SENSE27  _UL_(1 <<  7)
+#define PIN_PC27G_CATB_SENSE27         _L_(91) /**< \brief CATB signal: SENSE27 on PC27 mux G */
+#define MUX_PC27G_CATB_SENSE27          _L_(6)
 #define PINMUX_PC27G_CATB_SENSE27  ((PIN_PC27G_CATB_SENSE27 << 16) | MUX_PC27G_CATB_SENSE27)
-#define GPIO_PC27G_CATB_SENSE27  _UL(1 << 27)
-#define PIN_PB08G_CATB_SENSE28         _L(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
-#define MUX_PB08G_CATB_SENSE28          _L(6)
+#define GPIO_PC27G_CATB_SENSE27  _UL_(1 << 27)
+#define PIN_PB08G_CATB_SENSE28         _L_(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
+#define MUX_PB08G_CATB_SENSE28          _L_(6)
 #define PINMUX_PB08G_CATB_SENSE28  ((PIN_PB08G_CATB_SENSE28 << 16) | MUX_PB08G_CATB_SENSE28)
-#define GPIO_PB08G_CATB_SENSE28  _UL(1 <<  8)
-#define PIN_PC28G_CATB_SENSE28         _L(92) /**< \brief CATB signal: SENSE28 on PC28 mux G */
-#define MUX_PC28G_CATB_SENSE28          _L(6)
+#define GPIO_PB08G_CATB_SENSE28  _UL_(1 <<  8)
+#define PIN_PC28G_CATB_SENSE28         _L_(92) /**< \brief CATB signal: SENSE28 on PC28 mux G */
+#define MUX_PC28G_CATB_SENSE28          _L_(6)
 #define PINMUX_PC28G_CATB_SENSE28  ((PIN_PC28G_CATB_SENSE28 << 16) | MUX_PC28G_CATB_SENSE28)
-#define GPIO_PC28G_CATB_SENSE28  _UL(1 << 28)
-#define PIN_PB09G_CATB_SENSE29         _L(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
-#define MUX_PB09G_CATB_SENSE29          _L(6)
+#define GPIO_PC28G_CATB_SENSE28  _UL_(1 << 28)
+#define PIN_PB09G_CATB_SENSE29         _L_(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
+#define MUX_PB09G_CATB_SENSE29          _L_(6)
 #define PINMUX_PB09G_CATB_SENSE29  ((PIN_PB09G_CATB_SENSE29 << 16) | MUX_PB09G_CATB_SENSE29)
-#define GPIO_PB09G_CATB_SENSE29  _UL(1 <<  9)
-#define PIN_PC29G_CATB_SENSE29         _L(93) /**< \brief CATB signal: SENSE29 on PC29 mux G */
-#define MUX_PC29G_CATB_SENSE29          _L(6)
+#define GPIO_PB09G_CATB_SENSE29  _UL_(1 <<  9)
+#define PIN_PC29G_CATB_SENSE29         _L_(93) /**< \brief CATB signal: SENSE29 on PC29 mux G */
+#define MUX_PC29G_CATB_SENSE29          _L_(6)
 #define PINMUX_PC29G_CATB_SENSE29  ((PIN_PC29G_CATB_SENSE29 << 16) | MUX_PC29G_CATB_SENSE29)
-#define GPIO_PC29G_CATB_SENSE29  _UL(1 << 29)
-#define PIN_PB10G_CATB_SENSE30         _L(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
-#define MUX_PB10G_CATB_SENSE30          _L(6)
+#define GPIO_PC29G_CATB_SENSE29  _UL_(1 << 29)
+#define PIN_PB10G_CATB_SENSE30         _L_(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
+#define MUX_PB10G_CATB_SENSE30          _L_(6)
 #define PINMUX_PB10G_CATB_SENSE30  ((PIN_PB10G_CATB_SENSE30 << 16) | MUX_PB10G_CATB_SENSE30)
-#define GPIO_PB10G_CATB_SENSE30  _UL(1 << 10)
-#define PIN_PC30G_CATB_SENSE30         _L(94) /**< \brief CATB signal: SENSE30 on PC30 mux G */
-#define MUX_PC30G_CATB_SENSE30          _L(6)
+#define GPIO_PB10G_CATB_SENSE30  _UL_(1 << 10)
+#define PIN_PC30G_CATB_SENSE30         _L_(94) /**< \brief CATB signal: SENSE30 on PC30 mux G */
+#define MUX_PC30G_CATB_SENSE30          _L_(6)
 #define PINMUX_PC30G_CATB_SENSE30  ((PIN_PC30G_CATB_SENSE30 << 16) | MUX_PC30G_CATB_SENSE30)
-#define GPIO_PC30G_CATB_SENSE30  _UL(1 << 30)
-#define PIN_PB11G_CATB_SENSE31         _L(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
-#define MUX_PB11G_CATB_SENSE31          _L(6)
+#define GPIO_PC30G_CATB_SENSE30  _UL_(1 << 30)
+#define PIN_PB11G_CATB_SENSE31         _L_(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
+#define MUX_PB11G_CATB_SENSE31          _L_(6)
 #define PINMUX_PB11G_CATB_SENSE31  ((PIN_PB11G_CATB_SENSE31 << 16) | MUX_PB11G_CATB_SENSE31)
-#define GPIO_PB11G_CATB_SENSE31  _UL(1 << 11)
-#define PIN_PC31G_CATB_SENSE31         _L(95) /**< \brief CATB signal: SENSE31 on PC31 mux G */
-#define MUX_PC31G_CATB_SENSE31          _L(6)
+#define GPIO_PB11G_CATB_SENSE31  _UL_(1 << 11)
+#define PIN_PC31G_CATB_SENSE31         _L_(95) /**< \brief CATB signal: SENSE31 on PC31 mux G */
+#define MUX_PC31G_CATB_SENSE31          _L_(6)
 #define PINMUX_PC31G_CATB_SENSE31  ((PIN_PC31G_CATB_SENSE31 << 16) | MUX_PC31G_CATB_SENSE31)
-#define GPIO_PC31G_CATB_SENSE31  _UL(1 << 31)
+#define GPIO_PC31G_CATB_SENSE31  _UL_(1 << 31)
 /* ========== GPIO definition for LCDCA peripheral ========== */
-#define PIN_PA12F_LCDCA_COM0           _L(12) /**< \brief LCDCA signal: COM0 on PA12 mux F */
-#define MUX_PA12F_LCDCA_COM0            _L(5)
+#define PIN_PA12F_LCDCA_COM0           _L_(12) /**< \brief LCDCA signal: COM0 on PA12 mux F */
+#define MUX_PA12F_LCDCA_COM0            _L_(5)
 #define PINMUX_PA12F_LCDCA_COM0    ((PIN_PA12F_LCDCA_COM0 << 16) | MUX_PA12F_LCDCA_COM0)
-#define GPIO_PA12F_LCDCA_COM0    _UL(1 << 12)
-#define PIN_PA11F_LCDCA_COM1           _L(11) /**< \brief LCDCA signal: COM1 on PA11 mux F */
-#define MUX_PA11F_LCDCA_COM1            _L(5)
+#define GPIO_PA12F_LCDCA_COM0    _UL_(1 << 12)
+#define PIN_PA11F_LCDCA_COM1           _L_(11) /**< \brief LCDCA signal: COM1 on PA11 mux F */
+#define MUX_PA11F_LCDCA_COM1            _L_(5)
 #define PINMUX_PA11F_LCDCA_COM1    ((PIN_PA11F_LCDCA_COM1 << 16) | MUX_PA11F_LCDCA_COM1)
-#define GPIO_PA11F_LCDCA_COM1    _UL(1 << 11)
-#define PIN_PA10F_LCDCA_COM2           _L(10) /**< \brief LCDCA signal: COM2 on PA10 mux F */
-#define MUX_PA10F_LCDCA_COM2            _L(5)
+#define GPIO_PA11F_LCDCA_COM1    _UL_(1 << 11)
+#define PIN_PA10F_LCDCA_COM2           _L_(10) /**< \brief LCDCA signal: COM2 on PA10 mux F */
+#define MUX_PA10F_LCDCA_COM2            _L_(5)
 #define PINMUX_PA10F_LCDCA_COM2    ((PIN_PA10F_LCDCA_COM2 << 16) | MUX_PA10F_LCDCA_COM2)
-#define GPIO_PA10F_LCDCA_COM2    _UL(1 << 10)
-#define PIN_PA09F_LCDCA_COM3            _L(9) /**< \brief LCDCA signal: COM3 on PA09 mux F */
-#define MUX_PA09F_LCDCA_COM3            _L(5)
+#define GPIO_PA10F_LCDCA_COM2    _UL_(1 << 10)
+#define PIN_PA09F_LCDCA_COM3            _L_(9) /**< \brief LCDCA signal: COM3 on PA09 mux F */
+#define MUX_PA09F_LCDCA_COM3            _L_(5)
 #define PINMUX_PA09F_LCDCA_COM3    ((PIN_PA09F_LCDCA_COM3 << 16) | MUX_PA09F_LCDCA_COM3)
-#define GPIO_PA09F_LCDCA_COM3    _UL(1 <<  9)
-#define PIN_PC15F_LCDCA_SEG0           _L(79) /**< \brief LCDCA signal: SEG0 on PC15 mux F */
-#define MUX_PC15F_LCDCA_SEG0            _L(5)
+#define GPIO_PA09F_LCDCA_COM3    _UL_(1 <<  9)
+#define PIN_PC15F_LCDCA_SEG0           _L_(79) /**< \brief LCDCA signal: SEG0 on PC15 mux F */
+#define MUX_PC15F_LCDCA_SEG0            _L_(5)
 #define PINMUX_PC15F_LCDCA_SEG0    ((PIN_PC15F_LCDCA_SEG0 << 16) | MUX_PC15F_LCDCA_SEG0)
-#define GPIO_PC15F_LCDCA_SEG0    _UL(1 << 15)
-#define PIN_PC16F_LCDCA_SEG1           _L(80) /**< \brief LCDCA signal: SEG1 on PC16 mux F */
-#define MUX_PC16F_LCDCA_SEG1            _L(5)
+#define GPIO_PC15F_LCDCA_SEG0    _UL_(1 << 15)
+#define PIN_PC16F_LCDCA_SEG1           _L_(80) /**< \brief LCDCA signal: SEG1 on PC16 mux F */
+#define MUX_PC16F_LCDCA_SEG1            _L_(5)
 #define PINMUX_PC16F_LCDCA_SEG1    ((PIN_PC16F_LCDCA_SEG1 << 16) | MUX_PC16F_LCDCA_SEG1)
-#define GPIO_PC16F_LCDCA_SEG1    _UL(1 << 16)
-#define PIN_PC17F_LCDCA_SEG2           _L(81) /**< \brief LCDCA signal: SEG2 on PC17 mux F */
-#define MUX_PC17F_LCDCA_SEG2            _L(5)
+#define GPIO_PC16F_LCDCA_SEG1    _UL_(1 << 16)
+#define PIN_PC17F_LCDCA_SEG2           _L_(81) /**< \brief LCDCA signal: SEG2 on PC17 mux F */
+#define MUX_PC17F_LCDCA_SEG2            _L_(5)
 #define PINMUX_PC17F_LCDCA_SEG2    ((PIN_PC17F_LCDCA_SEG2 << 16) | MUX_PC17F_LCDCA_SEG2)
-#define GPIO_PC17F_LCDCA_SEG2    _UL(1 << 17)
-#define PIN_PC18F_LCDCA_SEG3           _L(82) /**< \brief LCDCA signal: SEG3 on PC18 mux F */
-#define MUX_PC18F_LCDCA_SEG3            _L(5)
+#define GPIO_PC17F_LCDCA_SEG2    _UL_(1 << 17)
+#define PIN_PC18F_LCDCA_SEG3           _L_(82) /**< \brief LCDCA signal: SEG3 on PC18 mux F */
+#define MUX_PC18F_LCDCA_SEG3            _L_(5)
 #define PINMUX_PC18F_LCDCA_SEG3    ((PIN_PC18F_LCDCA_SEG3 << 16) | MUX_PC18F_LCDCA_SEG3)
-#define GPIO_PC18F_LCDCA_SEG3    _UL(1 << 18)
-#define PIN_PC19F_LCDCA_SEG4           _L(83) /**< \brief LCDCA signal: SEG4 on PC19 mux F */
-#define MUX_PC19F_LCDCA_SEG4            _L(5)
+#define GPIO_PC18F_LCDCA_SEG3    _UL_(1 << 18)
+#define PIN_PC19F_LCDCA_SEG4           _L_(83) /**< \brief LCDCA signal: SEG4 on PC19 mux F */
+#define MUX_PC19F_LCDCA_SEG4            _L_(5)
 #define PINMUX_PC19F_LCDCA_SEG4    ((PIN_PC19F_LCDCA_SEG4 << 16) | MUX_PC19F_LCDCA_SEG4)
-#define GPIO_PC19F_LCDCA_SEG4    _UL(1 << 19)
-#define PIN_PA13F_LCDCA_SEG5           _L(13) /**< \brief LCDCA signal: SEG5 on PA13 mux F */
-#define MUX_PA13F_LCDCA_SEG5            _L(5)
+#define GPIO_PC19F_LCDCA_SEG4    _UL_(1 << 19)
+#define PIN_PA13F_LCDCA_SEG5           _L_(13) /**< \brief LCDCA signal: SEG5 on PA13 mux F */
+#define MUX_PA13F_LCDCA_SEG5            _L_(5)
 #define PINMUX_PA13F_LCDCA_SEG5    ((PIN_PA13F_LCDCA_SEG5 << 16) | MUX_PA13F_LCDCA_SEG5)
-#define GPIO_PA13F_LCDCA_SEG5    _UL(1 << 13)
-#define PIN_PA14F_LCDCA_SEG6           _L(14) /**< \brief LCDCA signal: SEG6 on PA14 mux F */
-#define MUX_PA14F_LCDCA_SEG6            _L(5)
+#define GPIO_PA13F_LCDCA_SEG5    _UL_(1 << 13)
+#define PIN_PA14F_LCDCA_SEG6           _L_(14) /**< \brief LCDCA signal: SEG6 on PA14 mux F */
+#define MUX_PA14F_LCDCA_SEG6            _L_(5)
 #define PINMUX_PA14F_LCDCA_SEG6    ((PIN_PA14F_LCDCA_SEG6 << 16) | MUX_PA14F_LCDCA_SEG6)
-#define GPIO_PA14F_LCDCA_SEG6    _UL(1 << 14)
-#define PIN_PA15F_LCDCA_SEG7           _L(15) /**< \brief LCDCA signal: SEG7 on PA15 mux F */
-#define MUX_PA15F_LCDCA_SEG7            _L(5)
+#define GPIO_PA14F_LCDCA_SEG6    _UL_(1 << 14)
+#define PIN_PA15F_LCDCA_SEG7           _L_(15) /**< \brief LCDCA signal: SEG7 on PA15 mux F */
+#define MUX_PA15F_LCDCA_SEG7            _L_(5)
 #define PINMUX_PA15F_LCDCA_SEG7    ((PIN_PA15F_LCDCA_SEG7 << 16) | MUX_PA15F_LCDCA_SEG7)
-#define GPIO_PA15F_LCDCA_SEG7    _UL(1 << 15)
-#define PIN_PA16F_LCDCA_SEG8           _L(16) /**< \brief LCDCA signal: SEG8 on PA16 mux F */
-#define MUX_PA16F_LCDCA_SEG8            _L(5)
+#define GPIO_PA15F_LCDCA_SEG7    _UL_(1 << 15)
+#define PIN_PA16F_LCDCA_SEG8           _L_(16) /**< \brief LCDCA signal: SEG8 on PA16 mux F */
+#define MUX_PA16F_LCDCA_SEG8            _L_(5)
 #define PINMUX_PA16F_LCDCA_SEG8    ((PIN_PA16F_LCDCA_SEG8 << 16) | MUX_PA16F_LCDCA_SEG8)
-#define GPIO_PA16F_LCDCA_SEG8    _UL(1 << 16)
-#define PIN_PA17F_LCDCA_SEG9           _L(17) /**< \brief LCDCA signal: SEG9 on PA17 mux F */
-#define MUX_PA17F_LCDCA_SEG9            _L(5)
+#define GPIO_PA16F_LCDCA_SEG8    _UL_(1 << 16)
+#define PIN_PA17F_LCDCA_SEG9           _L_(17) /**< \brief LCDCA signal: SEG9 on PA17 mux F */
+#define MUX_PA17F_LCDCA_SEG9            _L_(5)
 #define PINMUX_PA17F_LCDCA_SEG9    ((PIN_PA17F_LCDCA_SEG9 << 16) | MUX_PA17F_LCDCA_SEG9)
-#define GPIO_PA17F_LCDCA_SEG9    _UL(1 << 17)
-#define PIN_PC20F_LCDCA_SEG10          _L(84) /**< \brief LCDCA signal: SEG10 on PC20 mux F */
-#define MUX_PC20F_LCDCA_SEG10           _L(5)
+#define GPIO_PA17F_LCDCA_SEG9    _UL_(1 << 17)
+#define PIN_PC20F_LCDCA_SEG10          _L_(84) /**< \brief LCDCA signal: SEG10 on PC20 mux F */
+#define MUX_PC20F_LCDCA_SEG10           _L_(5)
 #define PINMUX_PC20F_LCDCA_SEG10   ((PIN_PC20F_LCDCA_SEG10 << 16) | MUX_PC20F_LCDCA_SEG10)
-#define GPIO_PC20F_LCDCA_SEG10   _UL(1 << 20)
-#define PIN_PC21F_LCDCA_SEG11          _L(85) /**< \brief LCDCA signal: SEG11 on PC21 mux F */
-#define MUX_PC21F_LCDCA_SEG11           _L(5)
+#define GPIO_PC20F_LCDCA_SEG10   _UL_(1 << 20)
+#define PIN_PC21F_LCDCA_SEG11          _L_(85) /**< \brief LCDCA signal: SEG11 on PC21 mux F */
+#define MUX_PC21F_LCDCA_SEG11           _L_(5)
 #define PINMUX_PC21F_LCDCA_SEG11   ((PIN_PC21F_LCDCA_SEG11 << 16) | MUX_PC21F_LCDCA_SEG11)
-#define GPIO_PC21F_LCDCA_SEG11   _UL(1 << 21)
-#define PIN_PC22F_LCDCA_SEG12          _L(86) /**< \brief LCDCA signal: SEG12 on PC22 mux F */
-#define MUX_PC22F_LCDCA_SEG12           _L(5)
+#define GPIO_PC21F_LCDCA_SEG11   _UL_(1 << 21)
+#define PIN_PC22F_LCDCA_SEG12          _L_(86) /**< \brief LCDCA signal: SEG12 on PC22 mux F */
+#define MUX_PC22F_LCDCA_SEG12           _L_(5)
 #define PINMUX_PC22F_LCDCA_SEG12   ((PIN_PC22F_LCDCA_SEG12 << 16) | MUX_PC22F_LCDCA_SEG12)
-#define GPIO_PC22F_LCDCA_SEG12   _UL(1 << 22)
-#define PIN_PC23F_LCDCA_SEG13          _L(87) /**< \brief LCDCA signal: SEG13 on PC23 mux F */
-#define MUX_PC23F_LCDCA_SEG13           _L(5)
+#define GPIO_PC22F_LCDCA_SEG12   _UL_(1 << 22)
+#define PIN_PC23F_LCDCA_SEG13          _L_(87) /**< \brief LCDCA signal: SEG13 on PC23 mux F */
+#define MUX_PC23F_LCDCA_SEG13           _L_(5)
 #define PINMUX_PC23F_LCDCA_SEG13   ((PIN_PC23F_LCDCA_SEG13 << 16) | MUX_PC23F_LCDCA_SEG13)
-#define GPIO_PC23F_LCDCA_SEG13   _UL(1 << 23)
-#define PIN_PB08F_LCDCA_SEG14          _L(40) /**< \brief LCDCA signal: SEG14 on PB08 mux F */
-#define MUX_PB08F_LCDCA_SEG14           _L(5)
+#define GPIO_PC23F_LCDCA_SEG13   _UL_(1 << 23)
+#define PIN_PB08F_LCDCA_SEG14          _L_(40) /**< \brief LCDCA signal: SEG14 on PB08 mux F */
+#define MUX_PB08F_LCDCA_SEG14           _L_(5)
 #define PINMUX_PB08F_LCDCA_SEG14   ((PIN_PB08F_LCDCA_SEG14 << 16) | MUX_PB08F_LCDCA_SEG14)
-#define GPIO_PB08F_LCDCA_SEG14   _UL(1 <<  8)
-#define PIN_PB09F_LCDCA_SEG15          _L(41) /**< \brief LCDCA signal: SEG15 on PB09 mux F */
-#define MUX_PB09F_LCDCA_SEG15           _L(5)
+#define GPIO_PB08F_LCDCA_SEG14   _UL_(1 <<  8)
+#define PIN_PB09F_LCDCA_SEG15          _L_(41) /**< \brief LCDCA signal: SEG15 on PB09 mux F */
+#define MUX_PB09F_LCDCA_SEG15           _L_(5)
 #define PINMUX_PB09F_LCDCA_SEG15   ((PIN_PB09F_LCDCA_SEG15 << 16) | MUX_PB09F_LCDCA_SEG15)
-#define GPIO_PB09F_LCDCA_SEG15   _UL(1 <<  9)
-#define PIN_PB10F_LCDCA_SEG16          _L(42) /**< \brief LCDCA signal: SEG16 on PB10 mux F */
-#define MUX_PB10F_LCDCA_SEG16           _L(5)
+#define GPIO_PB09F_LCDCA_SEG15   _UL_(1 <<  9)
+#define PIN_PB10F_LCDCA_SEG16          _L_(42) /**< \brief LCDCA signal: SEG16 on PB10 mux F */
+#define MUX_PB10F_LCDCA_SEG16           _L_(5)
 #define PINMUX_PB10F_LCDCA_SEG16   ((PIN_PB10F_LCDCA_SEG16 << 16) | MUX_PB10F_LCDCA_SEG16)
-#define GPIO_PB10F_LCDCA_SEG16   _UL(1 << 10)
-#define PIN_PB11F_LCDCA_SEG17          _L(43) /**< \brief LCDCA signal: SEG17 on PB11 mux F */
-#define MUX_PB11F_LCDCA_SEG17           _L(5)
+#define GPIO_PB10F_LCDCA_SEG16   _UL_(1 << 10)
+#define PIN_PB11F_LCDCA_SEG17          _L_(43) /**< \brief LCDCA signal: SEG17 on PB11 mux F */
+#define MUX_PB11F_LCDCA_SEG17           _L_(5)
 #define PINMUX_PB11F_LCDCA_SEG17   ((PIN_PB11F_LCDCA_SEG17 << 16) | MUX_PB11F_LCDCA_SEG17)
-#define GPIO_PB11F_LCDCA_SEG17   _UL(1 << 11)
-#define PIN_PA18F_LCDCA_SEG18          _L(18) /**< \brief LCDCA signal: SEG18 on PA18 mux F */
-#define MUX_PA18F_LCDCA_SEG18           _L(5)
+#define GPIO_PB11F_LCDCA_SEG17   _UL_(1 << 11)
+#define PIN_PA18F_LCDCA_SEG18          _L_(18) /**< \brief LCDCA signal: SEG18 on PA18 mux F */
+#define MUX_PA18F_LCDCA_SEG18           _L_(5)
 #define PINMUX_PA18F_LCDCA_SEG18   ((PIN_PA18F_LCDCA_SEG18 << 16) | MUX_PA18F_LCDCA_SEG18)
-#define GPIO_PA18F_LCDCA_SEG18   _UL(1 << 18)
-#define PIN_PA19F_LCDCA_SEG19          _L(19) /**< \brief LCDCA signal: SEG19 on PA19 mux F */
-#define MUX_PA19F_LCDCA_SEG19           _L(5)
+#define GPIO_PA18F_LCDCA_SEG18   _UL_(1 << 18)
+#define PIN_PA19F_LCDCA_SEG19          _L_(19) /**< \brief LCDCA signal: SEG19 on PA19 mux F */
+#define MUX_PA19F_LCDCA_SEG19           _L_(5)
 #define PINMUX_PA19F_LCDCA_SEG19   ((PIN_PA19F_LCDCA_SEG19 << 16) | MUX_PA19F_LCDCA_SEG19)
-#define GPIO_PA19F_LCDCA_SEG19   _UL(1 << 19)
-#define PIN_PA20F_LCDCA_SEG20          _L(20) /**< \brief LCDCA signal: SEG20 on PA20 mux F */
-#define MUX_PA20F_LCDCA_SEG20           _L(5)
+#define GPIO_PA19F_LCDCA_SEG19   _UL_(1 << 19)
+#define PIN_PA20F_LCDCA_SEG20          _L_(20) /**< \brief LCDCA signal: SEG20 on PA20 mux F */
+#define MUX_PA20F_LCDCA_SEG20           _L_(5)
 #define PINMUX_PA20F_LCDCA_SEG20   ((PIN_PA20F_LCDCA_SEG20 << 16) | MUX_PA20F_LCDCA_SEG20)
-#define GPIO_PA20F_LCDCA_SEG20   _UL(1 << 20)
-#define PIN_PB07F_LCDCA_SEG21          _L(39) /**< \brief LCDCA signal: SEG21 on PB07 mux F */
-#define MUX_PB07F_LCDCA_SEG21           _L(5)
+#define GPIO_PA20F_LCDCA_SEG20   _UL_(1 << 20)
+#define PIN_PB07F_LCDCA_SEG21          _L_(39) /**< \brief LCDCA signal: SEG21 on PB07 mux F */
+#define MUX_PB07F_LCDCA_SEG21           _L_(5)
 #define PINMUX_PB07F_LCDCA_SEG21   ((PIN_PB07F_LCDCA_SEG21 << 16) | MUX_PB07F_LCDCA_SEG21)
-#define GPIO_PB07F_LCDCA_SEG21   _UL(1 <<  7)
-#define PIN_PB06F_LCDCA_SEG22          _L(38) /**< \brief LCDCA signal: SEG22 on PB06 mux F */
-#define MUX_PB06F_LCDCA_SEG22           _L(5)
+#define GPIO_PB07F_LCDCA_SEG21   _UL_(1 <<  7)
+#define PIN_PB06F_LCDCA_SEG22          _L_(38) /**< \brief LCDCA signal: SEG22 on PB06 mux F */
+#define MUX_PB06F_LCDCA_SEG22           _L_(5)
 #define PINMUX_PB06F_LCDCA_SEG22   ((PIN_PB06F_LCDCA_SEG22 << 16) | MUX_PB06F_LCDCA_SEG22)
-#define GPIO_PB06F_LCDCA_SEG22   _UL(1 <<  6)
-#define PIN_PA08F_LCDCA_SEG23           _L(8) /**< \brief LCDCA signal: SEG23 on PA08 mux F */
-#define MUX_PA08F_LCDCA_SEG23           _L(5)
+#define GPIO_PB06F_LCDCA_SEG22   _UL_(1 <<  6)
+#define PIN_PA08F_LCDCA_SEG23           _L_(8) /**< \brief LCDCA signal: SEG23 on PA08 mux F */
+#define MUX_PA08F_LCDCA_SEG23           _L_(5)
 #define PINMUX_PA08F_LCDCA_SEG23   ((PIN_PA08F_LCDCA_SEG23 << 16) | MUX_PA08F_LCDCA_SEG23)
-#define GPIO_PA08F_LCDCA_SEG23   _UL(1 <<  8)
-#define PIN_PC24F_LCDCA_SEG24          _L(88) /**< \brief LCDCA signal: SEG24 on PC24 mux F */
-#define MUX_PC24F_LCDCA_SEG24           _L(5)
+#define GPIO_PA08F_LCDCA_SEG23   _UL_(1 <<  8)
+#define PIN_PC24F_LCDCA_SEG24          _L_(88) /**< \brief LCDCA signal: SEG24 on PC24 mux F */
+#define MUX_PC24F_LCDCA_SEG24           _L_(5)
 #define PINMUX_PC24F_LCDCA_SEG24   ((PIN_PC24F_LCDCA_SEG24 << 16) | MUX_PC24F_LCDCA_SEG24)
-#define GPIO_PC24F_LCDCA_SEG24   _UL(1 << 24)
-#define PIN_PC25F_LCDCA_SEG25          _L(89) /**< \brief LCDCA signal: SEG25 on PC25 mux F */
-#define MUX_PC25F_LCDCA_SEG25           _L(5)
+#define GPIO_PC24F_LCDCA_SEG24   _UL_(1 << 24)
+#define PIN_PC25F_LCDCA_SEG25          _L_(89) /**< \brief LCDCA signal: SEG25 on PC25 mux F */
+#define MUX_PC25F_LCDCA_SEG25           _L_(5)
 #define PINMUX_PC25F_LCDCA_SEG25   ((PIN_PC25F_LCDCA_SEG25 << 16) | MUX_PC25F_LCDCA_SEG25)
-#define GPIO_PC25F_LCDCA_SEG25   _UL(1 << 25)
-#define PIN_PC26F_LCDCA_SEG26          _L(90) /**< \brief LCDCA signal: SEG26 on PC26 mux F */
-#define MUX_PC26F_LCDCA_SEG26           _L(5)
+#define GPIO_PC25F_LCDCA_SEG25   _UL_(1 << 25)
+#define PIN_PC26F_LCDCA_SEG26          _L_(90) /**< \brief LCDCA signal: SEG26 on PC26 mux F */
+#define MUX_PC26F_LCDCA_SEG26           _L_(5)
 #define PINMUX_PC26F_LCDCA_SEG26   ((PIN_PC26F_LCDCA_SEG26 << 16) | MUX_PC26F_LCDCA_SEG26)
-#define GPIO_PC26F_LCDCA_SEG26   _UL(1 << 26)
-#define PIN_PC27F_LCDCA_SEG27          _L(91) /**< \brief LCDCA signal: SEG27 on PC27 mux F */
-#define MUX_PC27F_LCDCA_SEG27           _L(5)
+#define GPIO_PC26F_LCDCA_SEG26   _UL_(1 << 26)
+#define PIN_PC27F_LCDCA_SEG27          _L_(91) /**< \brief LCDCA signal: SEG27 on PC27 mux F */
+#define MUX_PC27F_LCDCA_SEG27           _L_(5)
 #define PINMUX_PC27F_LCDCA_SEG27   ((PIN_PC27F_LCDCA_SEG27 << 16) | MUX_PC27F_LCDCA_SEG27)
-#define GPIO_PC27F_LCDCA_SEG27   _UL(1 << 27)
-#define PIN_PC28F_LCDCA_SEG28          _L(92) /**< \brief LCDCA signal: SEG28 on PC28 mux F */
-#define MUX_PC28F_LCDCA_SEG28           _L(5)
+#define GPIO_PC27F_LCDCA_SEG27   _UL_(1 << 27)
+#define PIN_PC28F_LCDCA_SEG28          _L_(92) /**< \brief LCDCA signal: SEG28 on PC28 mux F */
+#define MUX_PC28F_LCDCA_SEG28           _L_(5)
 #define PINMUX_PC28F_LCDCA_SEG28   ((PIN_PC28F_LCDCA_SEG28 << 16) | MUX_PC28F_LCDCA_SEG28)
-#define GPIO_PC28F_LCDCA_SEG28   _UL(1 << 28)
-#define PIN_PC29F_LCDCA_SEG29          _L(93) /**< \brief LCDCA signal: SEG29 on PC29 mux F */
-#define MUX_PC29F_LCDCA_SEG29           _L(5)
+#define GPIO_PC28F_LCDCA_SEG28   _UL_(1 << 28)
+#define PIN_PC29F_LCDCA_SEG29          _L_(93) /**< \brief LCDCA signal: SEG29 on PC29 mux F */
+#define MUX_PC29F_LCDCA_SEG29           _L_(5)
 #define PINMUX_PC29F_LCDCA_SEG29   ((PIN_PC29F_LCDCA_SEG29 << 16) | MUX_PC29F_LCDCA_SEG29)
-#define GPIO_PC29F_LCDCA_SEG29   _UL(1 << 29)
-#define PIN_PC30F_LCDCA_SEG30          _L(94) /**< \brief LCDCA signal: SEG30 on PC30 mux F */
-#define MUX_PC30F_LCDCA_SEG30           _L(5)
+#define GPIO_PC29F_LCDCA_SEG29   _UL_(1 << 29)
+#define PIN_PC30F_LCDCA_SEG30          _L_(94) /**< \brief LCDCA signal: SEG30 on PC30 mux F */
+#define MUX_PC30F_LCDCA_SEG30           _L_(5)
 #define PINMUX_PC30F_LCDCA_SEG30   ((PIN_PC30F_LCDCA_SEG30 << 16) | MUX_PC30F_LCDCA_SEG30)
-#define GPIO_PC30F_LCDCA_SEG30   _UL(1 << 30)
-#define PIN_PC31F_LCDCA_SEG31          _L(95) /**< \brief LCDCA signal: SEG31 on PC31 mux F */
-#define MUX_PC31F_LCDCA_SEG31           _L(5)
+#define GPIO_PC30F_LCDCA_SEG30   _UL_(1 << 30)
+#define PIN_PC31F_LCDCA_SEG31          _L_(95) /**< \brief LCDCA signal: SEG31 on PC31 mux F */
+#define MUX_PC31F_LCDCA_SEG31           _L_(5)
 #define PINMUX_PC31F_LCDCA_SEG31   ((PIN_PC31F_LCDCA_SEG31 << 16) | MUX_PC31F_LCDCA_SEG31)
-#define GPIO_PC31F_LCDCA_SEG31   _UL(1 << 31)
-#define PIN_PB12F_LCDCA_SEG32          _L(44) /**< \brief LCDCA signal: SEG32 on PB12 mux F */
-#define MUX_PB12F_LCDCA_SEG32           _L(5)
+#define GPIO_PC31F_LCDCA_SEG31   _UL_(1 << 31)
+#define PIN_PB12F_LCDCA_SEG32          _L_(44) /**< \brief LCDCA signal: SEG32 on PB12 mux F */
+#define MUX_PB12F_LCDCA_SEG32           _L_(5)
 #define PINMUX_PB12F_LCDCA_SEG32   ((PIN_PB12F_LCDCA_SEG32 << 16) | MUX_PB12F_LCDCA_SEG32)
-#define GPIO_PB12F_LCDCA_SEG32   _UL(1 << 12)
-#define PIN_PB13F_LCDCA_SEG33          _L(45) /**< \brief LCDCA signal: SEG33 on PB13 mux F */
-#define MUX_PB13F_LCDCA_SEG33           _L(5)
+#define GPIO_PB12F_LCDCA_SEG32   _UL_(1 << 12)
+#define PIN_PB13F_LCDCA_SEG33          _L_(45) /**< \brief LCDCA signal: SEG33 on PB13 mux F */
+#define MUX_PB13F_LCDCA_SEG33           _L_(5)
 #define PINMUX_PB13F_LCDCA_SEG33   ((PIN_PB13F_LCDCA_SEG33 << 16) | MUX_PB13F_LCDCA_SEG33)
-#define GPIO_PB13F_LCDCA_SEG33   _UL(1 << 13)
-#define PIN_PA21F_LCDCA_SEG34          _L(21) /**< \brief LCDCA signal: SEG34 on PA21 mux F */
-#define MUX_PA21F_LCDCA_SEG34           _L(5)
+#define GPIO_PB13F_LCDCA_SEG33   _UL_(1 << 13)
+#define PIN_PA21F_LCDCA_SEG34          _L_(21) /**< \brief LCDCA signal: SEG34 on PA21 mux F */
+#define MUX_PA21F_LCDCA_SEG34           _L_(5)
 #define PINMUX_PA21F_LCDCA_SEG34   ((PIN_PA21F_LCDCA_SEG34 << 16) | MUX_PA21F_LCDCA_SEG34)
-#define GPIO_PA21F_LCDCA_SEG34   _UL(1 << 21)
-#define PIN_PA22F_LCDCA_SEG35          _L(22) /**< \brief LCDCA signal: SEG35 on PA22 mux F */
-#define MUX_PA22F_LCDCA_SEG35           _L(5)
+#define GPIO_PA21F_LCDCA_SEG34   _UL_(1 << 21)
+#define PIN_PA22F_LCDCA_SEG35          _L_(22) /**< \brief LCDCA signal: SEG35 on PA22 mux F */
+#define MUX_PA22F_LCDCA_SEG35           _L_(5)
 #define PINMUX_PA22F_LCDCA_SEG35   ((PIN_PA22F_LCDCA_SEG35 << 16) | MUX_PA22F_LCDCA_SEG35)
-#define GPIO_PA22F_LCDCA_SEG35   _UL(1 << 22)
-#define PIN_PB14F_LCDCA_SEG36          _L(46) /**< \brief LCDCA signal: SEG36 on PB14 mux F */
-#define MUX_PB14F_LCDCA_SEG36           _L(5)
+#define GPIO_PA22F_LCDCA_SEG35   _UL_(1 << 22)
+#define PIN_PB14F_LCDCA_SEG36          _L_(46) /**< \brief LCDCA signal: SEG36 on PB14 mux F */
+#define MUX_PB14F_LCDCA_SEG36           _L_(5)
 #define PINMUX_PB14F_LCDCA_SEG36   ((PIN_PB14F_LCDCA_SEG36 << 16) | MUX_PB14F_LCDCA_SEG36)
-#define GPIO_PB14F_LCDCA_SEG36   _UL(1 << 14)
-#define PIN_PB15F_LCDCA_SEG37          _L(47) /**< \brief LCDCA signal: SEG37 on PB15 mux F */
-#define MUX_PB15F_LCDCA_SEG37           _L(5)
+#define GPIO_PB14F_LCDCA_SEG36   _UL_(1 << 14)
+#define PIN_PB15F_LCDCA_SEG37          _L_(47) /**< \brief LCDCA signal: SEG37 on PB15 mux F */
+#define MUX_PB15F_LCDCA_SEG37           _L_(5)
 #define PINMUX_PB15F_LCDCA_SEG37   ((PIN_PB15F_LCDCA_SEG37 << 16) | MUX_PB15F_LCDCA_SEG37)
-#define GPIO_PB15F_LCDCA_SEG37   _UL(1 << 15)
-#define PIN_PA23F_LCDCA_SEG38          _L(23) /**< \brief LCDCA signal: SEG38 on PA23 mux F */
-#define MUX_PA23F_LCDCA_SEG38           _L(5)
+#define GPIO_PB15F_LCDCA_SEG37   _UL_(1 << 15)
+#define PIN_PA23F_LCDCA_SEG38          _L_(23) /**< \brief LCDCA signal: SEG38 on PA23 mux F */
+#define MUX_PA23F_LCDCA_SEG38           _L_(5)
 #define PINMUX_PA23F_LCDCA_SEG38   ((PIN_PA23F_LCDCA_SEG38 << 16) | MUX_PA23F_LCDCA_SEG38)
-#define GPIO_PA23F_LCDCA_SEG38   _UL(1 << 23)
-#define PIN_PA24F_LCDCA_SEG39          _L(24) /**< \brief LCDCA signal: SEG39 on PA24 mux F */
-#define MUX_PA24F_LCDCA_SEG39           _L(5)
+#define GPIO_PA23F_LCDCA_SEG38   _UL_(1 << 23)
+#define PIN_PA24F_LCDCA_SEG39          _L_(24) /**< \brief LCDCA signal: SEG39 on PA24 mux F */
+#define MUX_PA24F_LCDCA_SEG39           _L_(5)
 #define PINMUX_PA24F_LCDCA_SEG39   ((PIN_PA24F_LCDCA_SEG39 << 16) | MUX_PA24F_LCDCA_SEG39)
-#define GPIO_PA24F_LCDCA_SEG39   _UL(1 << 24)
+#define GPIO_PA24F_LCDCA_SEG39   _UL_(1 << 24)
 /* ========== GPIO definition for USBC peripheral ========== */
-#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
-#define MUX_PA25A_USBC_DM               _L(0)
+#define PIN_PA25A_USBC_DM              _L_(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L_(0)
 #define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
-#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
-#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
-#define MUX_PA26A_USBC_DP               _L(0)
+#define GPIO_PA25A_USBC_DM       _UL_(1 << 25)
+#define PIN_PA26A_USBC_DP              _L_(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L_(0)
 #define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
-#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+#define GPIO_PA26A_USBC_DP       _UL_(1 << 26)
 /* ========== GPIO definition for PEVC peripheral ========== */
-#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
-#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PIN_PA08C_PEVC_PAD_EVT0         _L_(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
-#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
-#define PIN_PB12C_PEVC_PAD_EVT0        _L(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
-#define MUX_PB12C_PEVC_PAD_EVT0         _L(2)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL_(1 <<  8)
+#define PIN_PB12C_PEVC_PAD_EVT0        _L_(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
+#define MUX_PB12C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PB12C_PEVC_PAD_EVT0  ((PIN_PB12C_PEVC_PAD_EVT0 << 16) | MUX_PB12C_PEVC_PAD_EVT0)
-#define GPIO_PB12C_PEVC_PAD_EVT0  _UL(1 << 12)
-#define PIN_PC07C_PEVC_PAD_EVT0        _L(71) /**< \brief PEVC signal: PAD_EVT0 on PC07 mux C */
-#define MUX_PC07C_PEVC_PAD_EVT0         _L(2)
+#define GPIO_PB12C_PEVC_PAD_EVT0  _UL_(1 << 12)
+#define PIN_PC07C_PEVC_PAD_EVT0        _L_(71) /**< \brief PEVC signal: PAD_EVT0 on PC07 mux C */
+#define MUX_PC07C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PC07C_PEVC_PAD_EVT0  ((PIN_PC07C_PEVC_PAD_EVT0 << 16) | MUX_PC07C_PEVC_PAD_EVT0)
-#define GPIO_PC07C_PEVC_PAD_EVT0  _UL(1 <<  7)
-#define PIN_PC24C_PEVC_PAD_EVT0        _L(88) /**< \brief PEVC signal: PAD_EVT0 on PC24 mux C */
-#define MUX_PC24C_PEVC_PAD_EVT0         _L(2)
+#define GPIO_PC07C_PEVC_PAD_EVT0  _UL_(1 <<  7)
+#define PIN_PC24C_PEVC_PAD_EVT0        _L_(88) /**< \brief PEVC signal: PAD_EVT0 on PC24 mux C */
+#define MUX_PC24C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PC24C_PEVC_PAD_EVT0  ((PIN_PC24C_PEVC_PAD_EVT0 << 16) | MUX_PC24C_PEVC_PAD_EVT0)
-#define GPIO_PC24C_PEVC_PAD_EVT0  _UL(1 << 24)
-#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
-#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PC24C_PEVC_PAD_EVT0  _UL_(1 << 24)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L_(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
-#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
-#define PIN_PB13C_PEVC_PAD_EVT1        _L(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
-#define MUX_PB13C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL_(1 <<  9)
+#define PIN_PB13C_PEVC_PAD_EVT1        _L_(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
+#define MUX_PB13C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PB13C_PEVC_PAD_EVT1  ((PIN_PB13C_PEVC_PAD_EVT1 << 16) | MUX_PB13C_PEVC_PAD_EVT1)
-#define GPIO_PB13C_PEVC_PAD_EVT1  _UL(1 << 13)
-#define PIN_PC08C_PEVC_PAD_EVT1        _L(72) /**< \brief PEVC signal: PAD_EVT1 on PC08 mux C */
-#define MUX_PC08C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PB13C_PEVC_PAD_EVT1  _UL_(1 << 13)
+#define PIN_PC08C_PEVC_PAD_EVT1        _L_(72) /**< \brief PEVC signal: PAD_EVT1 on PC08 mux C */
+#define MUX_PC08C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PC08C_PEVC_PAD_EVT1  ((PIN_PC08C_PEVC_PAD_EVT1 << 16) | MUX_PC08C_PEVC_PAD_EVT1)
-#define GPIO_PC08C_PEVC_PAD_EVT1  _UL(1 <<  8)
-#define PIN_PC25C_PEVC_PAD_EVT1        _L(89) /**< \brief PEVC signal: PAD_EVT1 on PC25 mux C */
-#define MUX_PC25C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PC08C_PEVC_PAD_EVT1  _UL_(1 <<  8)
+#define PIN_PC25C_PEVC_PAD_EVT1        _L_(89) /**< \brief PEVC signal: PAD_EVT1 on PC25 mux C */
+#define MUX_PC25C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PC25C_PEVC_PAD_EVT1  ((PIN_PC25C_PEVC_PAD_EVT1 << 16) | MUX_PC25C_PEVC_PAD_EVT1)
-#define GPIO_PC25C_PEVC_PAD_EVT1  _UL(1 << 25)
-#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
-#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PC25C_PEVC_PAD_EVT1  _UL_(1 << 25)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L_(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
-#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
-#define PIN_PC11C_PEVC_PAD_EVT2        _L(75) /**< \brief PEVC signal: PAD_EVT2 on PC11 mux C */
-#define MUX_PC11C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL_(1 << 10)
+#define PIN_PC11C_PEVC_PAD_EVT2        _L_(75) /**< \brief PEVC signal: PAD_EVT2 on PC11 mux C */
+#define MUX_PC11C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PC11C_PEVC_PAD_EVT2  ((PIN_PC11C_PEVC_PAD_EVT2 << 16) | MUX_PC11C_PEVC_PAD_EVT2)
-#define GPIO_PC11C_PEVC_PAD_EVT2  _UL(1 << 11)
-#define PIN_PC26C_PEVC_PAD_EVT2        _L(90) /**< \brief PEVC signal: PAD_EVT2 on PC26 mux C */
-#define MUX_PC26C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PC11C_PEVC_PAD_EVT2  _UL_(1 << 11)
+#define PIN_PC26C_PEVC_PAD_EVT2        _L_(90) /**< \brief PEVC signal: PAD_EVT2 on PC26 mux C */
+#define MUX_PC26C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PC26C_PEVC_PAD_EVT2  ((PIN_PC26C_PEVC_PAD_EVT2 << 16) | MUX_PC26C_PEVC_PAD_EVT2)
-#define GPIO_PC26C_PEVC_PAD_EVT2  _UL(1 << 26)
-#define PIN_PB09B_PEVC_PAD_EVT2        _L(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
-#define MUX_PB09B_PEVC_PAD_EVT2         _L(1)
+#define GPIO_PC26C_PEVC_PAD_EVT2  _UL_(1 << 26)
+#define PIN_PB09B_PEVC_PAD_EVT2        _L_(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
+#define MUX_PB09B_PEVC_PAD_EVT2         _L_(1)
 #define PINMUX_PB09B_PEVC_PAD_EVT2  ((PIN_PB09B_PEVC_PAD_EVT2 << 16) | MUX_PB09B_PEVC_PAD_EVT2)
-#define GPIO_PB09B_PEVC_PAD_EVT2  _UL(1 <<  9)
-#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
-#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define GPIO_PB09B_PEVC_PAD_EVT2  _UL_(1 <<  9)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L_(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L_(2)
 #define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
-#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
-#define PIN_PC27C_PEVC_PAD_EVT3        _L(91) /**< \brief PEVC signal: PAD_EVT3 on PC27 mux C */
-#define MUX_PC27C_PEVC_PAD_EVT3         _L(2)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL_(1 << 11)
+#define PIN_PC27C_PEVC_PAD_EVT3        _L_(91) /**< \brief PEVC signal: PAD_EVT3 on PC27 mux C */
+#define MUX_PC27C_PEVC_PAD_EVT3         _L_(2)
 #define PINMUX_PC27C_PEVC_PAD_EVT3  ((PIN_PC27C_PEVC_PAD_EVT3 << 16) | MUX_PC27C_PEVC_PAD_EVT3)
-#define GPIO_PC27C_PEVC_PAD_EVT3  _UL(1 << 27)
-#define PIN_PB10B_PEVC_PAD_EVT3        _L(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
-#define MUX_PB10B_PEVC_PAD_EVT3         _L(1)
+#define GPIO_PC27C_PEVC_PAD_EVT3  _UL_(1 << 27)
+#define PIN_PB10B_PEVC_PAD_EVT3        _L_(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
+#define MUX_PB10B_PEVC_PAD_EVT3         _L_(1)
 #define PINMUX_PB10B_PEVC_PAD_EVT3  ((PIN_PB10B_PEVC_PAD_EVT3 << 16) | MUX_PB10B_PEVC_PAD_EVT3)
-#define GPIO_PB10B_PEVC_PAD_EVT3  _UL(1 << 10)
+#define GPIO_PB10B_PEVC_PAD_EVT3  _UL_(1 << 10)
 /* ========== GPIO definition for SCIF peripheral ========== */
-#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
-#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PIN_PA19E_SCIF_GCLK0           _L_(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
-#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
-#define PIN_PB10E_SCIF_GCLK0           _L(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
-#define MUX_PB10E_SCIF_GCLK0            _L(4)
+#define GPIO_PA19E_SCIF_GCLK0    _UL_(1 << 19)
+#define PIN_PB10E_SCIF_GCLK0           _L_(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
+#define MUX_PB10E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PB10E_SCIF_GCLK0    ((PIN_PB10E_SCIF_GCLK0 << 16) | MUX_PB10E_SCIF_GCLK0)
-#define GPIO_PB10E_SCIF_GCLK0    _UL(1 << 10)
-#define PIN_PC26E_SCIF_GCLK0           _L(90) /**< \brief SCIF signal: GCLK0 on PC26 mux E */
-#define MUX_PC26E_SCIF_GCLK0            _L(4)
+#define GPIO_PB10E_SCIF_GCLK0    _UL_(1 << 10)
+#define PIN_PC26E_SCIF_GCLK0           _L_(90) /**< \brief SCIF signal: GCLK0 on PC26 mux E */
+#define MUX_PC26E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PC26E_SCIF_GCLK0    ((PIN_PC26E_SCIF_GCLK0 << 16) | MUX_PC26E_SCIF_GCLK0)
-#define GPIO_PC26E_SCIF_GCLK0    _UL(1 << 26)
-#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
-#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define GPIO_PC26E_SCIF_GCLK0    _UL_(1 << 26)
+#define PIN_PA02A_SCIF_GCLK0            _L_(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L_(0)
 #define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
-#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
-#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
-#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define GPIO_PA02A_SCIF_GCLK0    _UL_(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L_(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
-#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
-#define PIN_PB11E_SCIF_GCLK1           _L(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
-#define MUX_PB11E_SCIF_GCLK1            _L(4)
+#define GPIO_PA20E_SCIF_GCLK1    _UL_(1 << 20)
+#define PIN_PB11E_SCIF_GCLK1           _L_(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
+#define MUX_PB11E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PB11E_SCIF_GCLK1    ((PIN_PB11E_SCIF_GCLK1 << 16) | MUX_PB11E_SCIF_GCLK1)
-#define GPIO_PB11E_SCIF_GCLK1    _UL(1 << 11)
-#define PIN_PC27E_SCIF_GCLK1           _L(91) /**< \brief SCIF signal: GCLK1 on PC27 mux E */
-#define MUX_PC27E_SCIF_GCLK1            _L(4)
+#define GPIO_PB11E_SCIF_GCLK1    _UL_(1 << 11)
+#define PIN_PC27E_SCIF_GCLK1           _L_(91) /**< \brief SCIF signal: GCLK1 on PC27 mux E */
+#define MUX_PC27E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PC27E_SCIF_GCLK1    ((PIN_PC27E_SCIF_GCLK1 << 16) | MUX_PC27E_SCIF_GCLK1)
-#define GPIO_PC27E_SCIF_GCLK1    _UL(1 << 27)
-#define PIN_PB12E_SCIF_GCLK2           _L(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
-#define MUX_PB12E_SCIF_GCLK2            _L(4)
+#define GPIO_PC27E_SCIF_GCLK1    _UL_(1 << 27)
+#define PIN_PB12E_SCIF_GCLK2           _L_(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
+#define MUX_PB12E_SCIF_GCLK2            _L_(4)
 #define PINMUX_PB12E_SCIF_GCLK2    ((PIN_PB12E_SCIF_GCLK2 << 16) | MUX_PB12E_SCIF_GCLK2)
-#define GPIO_PB12E_SCIF_GCLK2    _UL(1 << 12)
-#define PIN_PC28E_SCIF_GCLK2           _L(92) /**< \brief SCIF signal: GCLK2 on PC28 mux E */
-#define MUX_PC28E_SCIF_GCLK2            _L(4)
+#define GPIO_PB12E_SCIF_GCLK2    _UL_(1 << 12)
+#define PIN_PC28E_SCIF_GCLK2           _L_(92) /**< \brief SCIF signal: GCLK2 on PC28 mux E */
+#define MUX_PC28E_SCIF_GCLK2            _L_(4)
 #define PINMUX_PC28E_SCIF_GCLK2    ((PIN_PC28E_SCIF_GCLK2 << 16) | MUX_PC28E_SCIF_GCLK2)
-#define GPIO_PC28E_SCIF_GCLK2    _UL(1 << 28)
-#define PIN_PB13E_SCIF_GCLK3           _L(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
-#define MUX_PB13E_SCIF_GCLK3            _L(4)
+#define GPIO_PC28E_SCIF_GCLK2    _UL_(1 << 28)
+#define PIN_PB13E_SCIF_GCLK3           _L_(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
+#define MUX_PB13E_SCIF_GCLK3            _L_(4)
 #define PINMUX_PB13E_SCIF_GCLK3    ((PIN_PB13E_SCIF_GCLK3 << 16) | MUX_PB13E_SCIF_GCLK3)
-#define GPIO_PB13E_SCIF_GCLK3    _UL(1 << 13)
-#define PIN_PC29E_SCIF_GCLK3           _L(93) /**< \brief SCIF signal: GCLK3 on PC29 mux E */
-#define MUX_PC29E_SCIF_GCLK3            _L(4)
+#define GPIO_PB13E_SCIF_GCLK3    _UL_(1 << 13)
+#define PIN_PC29E_SCIF_GCLK3           _L_(93) /**< \brief SCIF signal: GCLK3 on PC29 mux E */
+#define MUX_PC29E_SCIF_GCLK3            _L_(4)
 #define PINMUX_PC29E_SCIF_GCLK3    ((PIN_PC29E_SCIF_GCLK3 << 16) | MUX_PC29E_SCIF_GCLK3)
-#define GPIO_PC29E_SCIF_GCLK3    _UL(1 << 29)
-#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
-#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PC29E_SCIF_GCLK3    _UL_(1 << 29)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L_(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
-#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
-#define PIN_PB14E_SCIF_GCLK_IN0        _L(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
-#define MUX_PB14E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL_(1 << 23)
+#define PIN_PB14E_SCIF_GCLK_IN0        _L_(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
+#define MUX_PB14E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PB14E_SCIF_GCLK_IN0  ((PIN_PB14E_SCIF_GCLK_IN0 << 16) | MUX_PB14E_SCIF_GCLK_IN0)
-#define GPIO_PB14E_SCIF_GCLK_IN0  _UL(1 << 14)
-#define PIN_PC30E_SCIF_GCLK_IN0        _L(94) /**< \brief SCIF signal: GCLK_IN0 on PC30 mux E */
-#define MUX_PC30E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PB14E_SCIF_GCLK_IN0  _UL_(1 << 14)
+#define PIN_PC30E_SCIF_GCLK_IN0        _L_(94) /**< \brief SCIF signal: GCLK_IN0 on PC30 mux E */
+#define MUX_PC30E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PC30E_SCIF_GCLK_IN0  ((PIN_PC30E_SCIF_GCLK_IN0 << 16) | MUX_PC30E_SCIF_GCLK_IN0)
-#define GPIO_PC30E_SCIF_GCLK_IN0  _UL(1 << 30)
-#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
-#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PC30E_SCIF_GCLK_IN0  _UL_(1 << 30)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L_(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
-#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
-#define PIN_PB15E_SCIF_GCLK_IN1        _L(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
-#define MUX_PB15E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL_(1 << 24)
+#define PIN_PB15E_SCIF_GCLK_IN1        _L_(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
+#define MUX_PB15E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PB15E_SCIF_GCLK_IN1  ((PIN_PB15E_SCIF_GCLK_IN1 << 16) | MUX_PB15E_SCIF_GCLK_IN1)
-#define GPIO_PB15E_SCIF_GCLK_IN1  _UL(1 << 15)
-#define PIN_PC31E_SCIF_GCLK_IN1        _L(95) /**< \brief SCIF signal: GCLK_IN1 on PC31 mux E */
-#define MUX_PC31E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PB15E_SCIF_GCLK_IN1  _UL_(1 << 15)
+#define PIN_PC31E_SCIF_GCLK_IN1        _L_(95) /**< \brief SCIF signal: GCLK_IN1 on PC31 mux E */
+#define MUX_PC31E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PC31E_SCIF_GCLK_IN1  ((PIN_PC31E_SCIF_GCLK_IN1 << 16) | MUX_PC31E_SCIF_GCLK_IN1)
-#define GPIO_PC31E_SCIF_GCLK_IN1  _UL(1 << 31)
+#define GPIO_PC31E_SCIF_GCLK_IN1  _UL_(1 << 31)
 /* ========== GPIO definition for EIC peripheral ========== */
-#define PIN_PB01C_EIC_EXTINT0          _L(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
-#define MUX_PB01C_EIC_EXTINT0           _L(2)
+#define PIN_PB01C_EIC_EXTINT0          _L_(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
+#define MUX_PB01C_EIC_EXTINT0           _L_(2)
 #define PINMUX_PB01C_EIC_EXTINT0   ((PIN_PB01C_EIC_EXTINT0 << 16) | MUX_PB01C_EIC_EXTINT0)
-#define GPIO_PB01C_EIC_EXTINT0   _UL(1 <<  1)
-#define PIN_PB01C_EIC_EXTINT_NUM        _L(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
-#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
-#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define GPIO_PB01C_EIC_EXTINT0   _UL_(1 <<  1)
+#define PIN_PB01C_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PA06C_EIC_EXTINT1           _L_(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
-#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
-#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
-#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
-#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define GPIO_PA06C_EIC_EXTINT1   _UL_(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L_(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
-#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
-#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
-#define PIN_PC24B_EIC_EXTINT1          _L(88) /**< \brief EIC signal: EXTINT1 on PC24 mux B */
-#define MUX_PC24B_EIC_EXTINT1           _L(1)
+#define GPIO_PA16C_EIC_EXTINT1   _UL_(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PC24B_EIC_EXTINT1          _L_(88) /**< \brief EIC signal: EXTINT1 on PC24 mux B */
+#define MUX_PC24B_EIC_EXTINT1           _L_(1)
 #define PINMUX_PC24B_EIC_EXTINT1   ((PIN_PC24B_EIC_EXTINT1 << 16) | MUX_PC24B_EIC_EXTINT1)
-#define GPIO_PC24B_EIC_EXTINT1   _UL(1 << 24)
-#define PIN_PC24B_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PC24 External Interrupt Line */
-#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
-#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define GPIO_PC24B_EIC_EXTINT1   _UL_(1 << 24)
+#define PIN_PC24B_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PC24 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L_(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
-#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
-#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
-#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
-#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL_(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L_(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
-#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
-#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
-#define PIN_PC25B_EIC_EXTINT2          _L(89) /**< \brief EIC signal: EXTINT2 on PC25 mux B */
-#define MUX_PC25B_EIC_EXTINT2           _L(1)
+#define GPIO_PA17C_EIC_EXTINT2   _UL_(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PC25B_EIC_EXTINT2          _L_(89) /**< \brief EIC signal: EXTINT2 on PC25 mux B */
+#define MUX_PC25B_EIC_EXTINT2           _L_(1)
 #define PINMUX_PC25B_EIC_EXTINT2   ((PIN_PC25B_EIC_EXTINT2 << 16) | MUX_PC25B_EIC_EXTINT2)
-#define GPIO_PC25B_EIC_EXTINT2   _UL(1 << 25)
-#define PIN_PC25B_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PC25 External Interrupt Line */
-#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
-#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define GPIO_PC25B_EIC_EXTINT2   _UL_(1 << 25)
+#define PIN_PC25B_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PC25 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L_(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
-#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
-#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
-#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
-#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define GPIO_PA05C_EIC_EXTINT3   _UL_(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L_(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
-#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
-#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
-#define PIN_PC26B_EIC_EXTINT3          _L(90) /**< \brief EIC signal: EXTINT3 on PC26 mux B */
-#define MUX_PC26B_EIC_EXTINT3           _L(1)
+#define GPIO_PA18C_EIC_EXTINT3   _UL_(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PC26B_EIC_EXTINT3          _L_(90) /**< \brief EIC signal: EXTINT3 on PC26 mux B */
+#define MUX_PC26B_EIC_EXTINT3           _L_(1)
 #define PINMUX_PC26B_EIC_EXTINT3   ((PIN_PC26B_EIC_EXTINT3 << 16) | MUX_PC26B_EIC_EXTINT3)
-#define GPIO_PC26B_EIC_EXTINT3   _UL(1 << 26)
-#define PIN_PC26B_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PC26 External Interrupt Line */
-#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
-#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define GPIO_PC26B_EIC_EXTINT3   _UL_(1 << 26)
+#define PIN_PC26B_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PC26 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L_(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
-#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
-#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
-#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
-#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define GPIO_PA07C_EIC_EXTINT4   _UL_(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L_(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
-#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
-#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
-#define PIN_PC27B_EIC_EXTINT4          _L(91) /**< \brief EIC signal: EXTINT4 on PC27 mux B */
-#define MUX_PC27B_EIC_EXTINT4           _L(1)
+#define GPIO_PA19C_EIC_EXTINT4   _UL_(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PC27B_EIC_EXTINT4          _L_(91) /**< \brief EIC signal: EXTINT4 on PC27 mux B */
+#define MUX_PC27B_EIC_EXTINT4           _L_(1)
 #define PINMUX_PC27B_EIC_EXTINT4   ((PIN_PC27B_EIC_EXTINT4 << 16) | MUX_PC27B_EIC_EXTINT4)
-#define GPIO_PC27B_EIC_EXTINT4   _UL(1 << 27)
-#define PIN_PC27B_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PC27 External Interrupt Line */
-#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
-#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define GPIO_PC27B_EIC_EXTINT4   _UL_(1 << 27)
+#define PIN_PC27B_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PC27 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L_(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L_(2)
 #define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
-#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
-#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
-#define PIN_PC03B_EIC_EXTINT5          _L(67) /**< \brief EIC signal: EXTINT5 on PC03 mux B */
-#define MUX_PC03B_EIC_EXTINT5           _L(1)
+#define GPIO_PA20C_EIC_EXTINT5   _UL_(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PC03B_EIC_EXTINT5          _L_(67) /**< \brief EIC signal: EXTINT5 on PC03 mux B */
+#define MUX_PC03B_EIC_EXTINT5           _L_(1)
 #define PINMUX_PC03B_EIC_EXTINT5   ((PIN_PC03B_EIC_EXTINT5 << 16) | MUX_PC03B_EIC_EXTINT5)
-#define GPIO_PC03B_EIC_EXTINT5   _UL(1 <<  3)
-#define PIN_PC03B_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PC03 External Interrupt Line */
-#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
-#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define GPIO_PC03B_EIC_EXTINT5   _UL_(1 <<  3)
+#define PIN_PC03B_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PC03 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L_(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L_(2)
 #define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
-#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
-#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
-#define PIN_PC04B_EIC_EXTINT6          _L(68) /**< \brief EIC signal: EXTINT6 on PC04 mux B */
-#define MUX_PC04B_EIC_EXTINT6           _L(1)
+#define GPIO_PA21C_EIC_EXTINT6   _UL_(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PC04B_EIC_EXTINT6          _L_(68) /**< \brief EIC signal: EXTINT6 on PC04 mux B */
+#define MUX_PC04B_EIC_EXTINT6           _L_(1)
 #define PINMUX_PC04B_EIC_EXTINT6   ((PIN_PC04B_EIC_EXTINT6 << 16) | MUX_PC04B_EIC_EXTINT6)
-#define GPIO_PC04B_EIC_EXTINT6   _UL(1 <<  4)
-#define PIN_PC04B_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PC04 External Interrupt Line */
-#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
-#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define GPIO_PC04B_EIC_EXTINT6   _UL_(1 <<  4)
+#define PIN_PC04B_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PC04 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L_(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L_(2)
 #define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
-#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
-#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
-#define PIN_PC05B_EIC_EXTINT7          _L(69) /**< \brief EIC signal: EXTINT7 on PC05 mux B */
-#define MUX_PC05B_EIC_EXTINT7           _L(1)
+#define GPIO_PA22C_EIC_EXTINT7   _UL_(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PC05B_EIC_EXTINT7          _L_(69) /**< \brief EIC signal: EXTINT7 on PC05 mux B */
+#define MUX_PC05B_EIC_EXTINT7           _L_(1)
 #define PINMUX_PC05B_EIC_EXTINT7   ((PIN_PC05B_EIC_EXTINT7 << 16) | MUX_PC05B_EIC_EXTINT7)
-#define GPIO_PC05B_EIC_EXTINT7   _UL(1 <<  5)
-#define PIN_PC05B_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PC05 External Interrupt Line */
-#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
-#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define GPIO_PC05B_EIC_EXTINT7   _UL_(1 <<  5)
+#define PIN_PC05B_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PC05 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L_(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L_(2)
 #define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
-#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
-#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
-#define PIN_PC06B_EIC_EXTINT8          _L(70) /**< \brief EIC signal: EXTINT8 on PC06 mux B */
-#define MUX_PC06B_EIC_EXTINT8           _L(1)
+#define GPIO_PA23C_EIC_EXTINT8   _UL_(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PC06B_EIC_EXTINT8          _L_(70) /**< \brief EIC signal: EXTINT8 on PC06 mux B */
+#define MUX_PC06B_EIC_EXTINT8           _L_(1)
 #define PINMUX_PC06B_EIC_EXTINT8   ((PIN_PC06B_EIC_EXTINT8 << 16) | MUX_PC06B_EIC_EXTINT8)
-#define GPIO_PC06B_EIC_EXTINT8   _UL(1 <<  6)
-#define PIN_PC06B_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PC06 External Interrupt Line */
+#define GPIO_PC06B_EIC_EXTINT8   _UL_(1 <<  6)
+#define PIN_PC06B_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PC06 External Interrupt Line */
 
 #endif /* _SAM4LC8C_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4ls2a.h
+++ b/asf/sam/include/sam4l/pio/sam4ls2a.h
@@ -30,708 +30,708 @@
 #define _SAM4LS2A_PIO_
 
 #define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
-#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define GPIO_PA00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PA00 */
 #define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
-#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define GPIO_PA01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PA01 */
 #define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
-#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define GPIO_PA02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PA02 */
 #define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
-#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define GPIO_PA03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PA03 */
 #define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
-#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define GPIO_PA04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PA04 */
 #define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
-#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define GPIO_PA05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PA05 */
 #define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
-#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define GPIO_PA06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PA06 */
 #define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
-#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define GPIO_PA07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PA07 */
 #define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
-#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define GPIO_PA08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PA08 */
 #define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
-#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define GPIO_PA09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PA09 */
 #define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
-#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define GPIO_PA10                _UL_(1 << 10) /**< \brief GPIO Mask  for PA10 */
 #define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
-#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define GPIO_PA11                _UL_(1 << 11) /**< \brief GPIO Mask  for PA11 */
 #define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
-#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define GPIO_PA12                _UL_(1 << 12) /**< \brief GPIO Mask  for PA12 */
 #define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
-#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define GPIO_PA13                _UL_(1 << 13) /**< \brief GPIO Mask  for PA13 */
 #define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
-#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define GPIO_PA14                _UL_(1 << 14) /**< \brief GPIO Mask  for PA14 */
 #define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
-#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define GPIO_PA15                _UL_(1 << 15) /**< \brief GPIO Mask  for PA15 */
 #define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
-#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define GPIO_PA16                _UL_(1 << 16) /**< \brief GPIO Mask  for PA16 */
 #define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
-#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define GPIO_PA17                _UL_(1 << 17) /**< \brief GPIO Mask  for PA17 */
 #define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
-#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define GPIO_PA18                _UL_(1 << 18) /**< \brief GPIO Mask  for PA18 */
 #define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
-#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define GPIO_PA19                _UL_(1 << 19) /**< \brief GPIO Mask  for PA19 */
 #define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
-#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define GPIO_PA20                _UL_(1 << 20) /**< \brief GPIO Mask  for PA20 */
 #define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
-#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define GPIO_PA21                _UL_(1 << 21) /**< \brief GPIO Mask  for PA21 */
 #define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
-#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define GPIO_PA22                _UL_(1 << 22) /**< \brief GPIO Mask  for PA22 */
 #define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
-#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define GPIO_PA23                _UL_(1 << 23) /**< \brief GPIO Mask  for PA23 */
 #define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
-#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define GPIO_PA24                _UL_(1 << 24) /**< \brief GPIO Mask  for PA24 */
 #define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
-#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define GPIO_PA25                _UL_(1 << 25) /**< \brief GPIO Mask  for PA25 */
 #define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
-#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define GPIO_PA26                _UL_(1 << 26) /**< \brief GPIO Mask  for PA26 */
 #define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
-#define GPIO_PA27                _UL(1 << 27) /**< \brief GPIO Mask  for PA27 */
+#define GPIO_PA27                _UL_(1 << 27) /**< \brief GPIO Mask  for PA27 */
 #define PIN_PA28                          28  /**< \brief Pin Number for PA28 */
-#define GPIO_PA28                _UL(1 << 28) /**< \brief GPIO Mask  for PA28 */
+#define GPIO_PA28                _UL_(1 << 28) /**< \brief GPIO Mask  for PA28 */
 #define PIN_PA29                          29  /**< \brief Pin Number for PA29 */
-#define GPIO_PA29                _UL(1 << 29) /**< \brief GPIO Mask  for PA29 */
+#define GPIO_PA29                _UL_(1 << 29) /**< \brief GPIO Mask  for PA29 */
 #define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
-#define GPIO_PA30                _UL(1 << 30) /**< \brief GPIO Mask  for PA30 */
+#define GPIO_PA30                _UL_(1 << 30) /**< \brief GPIO Mask  for PA30 */
 #define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
-#define GPIO_PA31                _UL(1 << 31) /**< \brief GPIO Mask  for PA31 */
+#define GPIO_PA31                _UL_(1 << 31) /**< \brief GPIO Mask  for PA31 */
 /* ========== GPIO definition for TWIMS0 peripheral ========== */
-#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
-#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PIN_PA24B_TWIMS0_TWCK          _L_(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L_(1)
 #define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
-#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
-#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
-#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL_(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L_(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L_(1)
 #define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
-#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+#define GPIO_PA23B_TWIMS0_TWD    _UL_(1 << 23)
 /* ========== GPIO definition for TWIMS2 peripheral ========== */
-#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
-#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PIN_PA22E_TWIMS2_TWCK          _L_(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L_(4)
 #define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
-#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
-#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
-#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL_(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L_(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L_(4)
 #define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
-#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+#define GPIO_PA21E_TWIMS2_TWD    _UL_(1 << 21)
 /* ========== GPIO definition for IISC peripheral ========== */
-#define PIN_PA31B_IISC_IMCK            _L(31) /**< \brief IISC signal: IMCK on PA31 mux B */
-#define MUX_PA31B_IISC_IMCK             _L(1)
+#define PIN_PA31B_IISC_IMCK            _L_(31) /**< \brief IISC signal: IMCK on PA31 mux B */
+#define MUX_PA31B_IISC_IMCK             _L_(1)
 #define PINMUX_PA31B_IISC_IMCK     ((PIN_PA31B_IISC_IMCK << 16) | MUX_PA31B_IISC_IMCK)
-#define GPIO_PA31B_IISC_IMCK     _UL(1 << 31)
-#define PIN_PA27B_IISC_ISCK            _L(27) /**< \brief IISC signal: ISCK on PA27 mux B */
-#define MUX_PA27B_IISC_ISCK             _L(1)
+#define GPIO_PA31B_IISC_IMCK     _UL_(1 << 31)
+#define PIN_PA27B_IISC_ISCK            _L_(27) /**< \brief IISC signal: ISCK on PA27 mux B */
+#define MUX_PA27B_IISC_ISCK             _L_(1)
 #define PINMUX_PA27B_IISC_ISCK     ((PIN_PA27B_IISC_ISCK << 16) | MUX_PA27B_IISC_ISCK)
-#define GPIO_PA27B_IISC_ISCK     _UL(1 << 27)
-#define PIN_PA28B_IISC_ISDI            _L(28) /**< \brief IISC signal: ISDI on PA28 mux B */
-#define MUX_PA28B_IISC_ISDI             _L(1)
+#define GPIO_PA27B_IISC_ISCK     _UL_(1 << 27)
+#define PIN_PA28B_IISC_ISDI            _L_(28) /**< \brief IISC signal: ISDI on PA28 mux B */
+#define MUX_PA28B_IISC_ISDI             _L_(1)
 #define PINMUX_PA28B_IISC_ISDI     ((PIN_PA28B_IISC_ISDI << 16) | MUX_PA28B_IISC_ISDI)
-#define GPIO_PA28B_IISC_ISDI     _UL(1 << 28)
-#define PIN_PA30B_IISC_ISDO            _L(30) /**< \brief IISC signal: ISDO on PA30 mux B */
-#define MUX_PA30B_IISC_ISDO             _L(1)
+#define GPIO_PA28B_IISC_ISDI     _UL_(1 << 28)
+#define PIN_PA30B_IISC_ISDO            _L_(30) /**< \brief IISC signal: ISDO on PA30 mux B */
+#define MUX_PA30B_IISC_ISDO             _L_(1)
 #define PINMUX_PA30B_IISC_ISDO     ((PIN_PA30B_IISC_ISDO << 16) | MUX_PA30B_IISC_ISDO)
-#define GPIO_PA30B_IISC_ISDO     _UL(1 << 30)
-#define PIN_PA29B_IISC_IWS             _L(29) /**< \brief IISC signal: IWS on PA29 mux B */
-#define MUX_PA29B_IISC_IWS              _L(1)
+#define GPIO_PA30B_IISC_ISDO     _UL_(1 << 30)
+#define PIN_PA29B_IISC_IWS             _L_(29) /**< \brief IISC signal: IWS on PA29 mux B */
+#define MUX_PA29B_IISC_IWS              _L_(1)
 #define PINMUX_PA29B_IISC_IWS      ((PIN_PA29B_IISC_IWS << 16) | MUX_PA29B_IISC_IWS)
-#define GPIO_PA29B_IISC_IWS      _UL(1 << 29)
+#define GPIO_PA29B_IISC_IWS      _UL_(1 << 29)
 /* ========== GPIO definition for SPI peripheral ========== */
-#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
-#define MUX_PA03B_SPI_MISO              _L(1)
+#define PIN_PA03B_SPI_MISO              _L_(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L_(1)
 #define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
-#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
-#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
-#define MUX_PA21A_SPI_MISO              _L(0)
+#define GPIO_PA03B_SPI_MISO      _UL_(1 <<  3)
+#define PIN_PA21A_SPI_MISO             _L_(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L_(0)
 #define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
-#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
-#define PIN_PA27A_SPI_MISO             _L(27) /**< \brief SPI signal: MISO on PA27 mux A */
-#define MUX_PA27A_SPI_MISO              _L(0)
+#define GPIO_PA21A_SPI_MISO      _UL_(1 << 21)
+#define PIN_PA27A_SPI_MISO             _L_(27) /**< \brief SPI signal: MISO on PA27 mux A */
+#define MUX_PA27A_SPI_MISO              _L_(0)
 #define PINMUX_PA27A_SPI_MISO      ((PIN_PA27A_SPI_MISO << 16) | MUX_PA27A_SPI_MISO)
-#define GPIO_PA27A_SPI_MISO      _UL(1 << 27)
-#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
-#define MUX_PA22A_SPI_MOSI              _L(0)
+#define GPIO_PA27A_SPI_MISO      _UL_(1 << 27)
+#define PIN_PA22A_SPI_MOSI             _L_(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L_(0)
 #define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
-#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
-#define PIN_PA28A_SPI_MOSI             _L(28) /**< \brief SPI signal: MOSI on PA28 mux A */
-#define MUX_PA28A_SPI_MOSI              _L(0)
+#define GPIO_PA22A_SPI_MOSI      _UL_(1 << 22)
+#define PIN_PA28A_SPI_MOSI             _L_(28) /**< \brief SPI signal: MOSI on PA28 mux A */
+#define MUX_PA28A_SPI_MOSI              _L_(0)
 #define PINMUX_PA28A_SPI_MOSI      ((PIN_PA28A_SPI_MOSI << 16) | MUX_PA28A_SPI_MOSI)
-#define GPIO_PA28A_SPI_MOSI      _UL(1 << 28)
-#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
-#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define GPIO_PA28A_SPI_MOSI      _UL_(1 << 28)
+#define PIN_PA02B_SPI_NPCS0             _L_(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L_(1)
 #define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
-#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
-#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
-#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define GPIO_PA02B_SPI_NPCS0     _UL_(1 <<  2)
+#define PIN_PA24A_SPI_NPCS0            _L_(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L_(0)
 #define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
-#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
-#define PIN_PA30A_SPI_NPCS0            _L(30) /**< \brief SPI signal: NPCS0 on PA30 mux A */
-#define MUX_PA30A_SPI_NPCS0             _L(0)
+#define GPIO_PA24A_SPI_NPCS0     _UL_(1 << 24)
+#define PIN_PA30A_SPI_NPCS0            _L_(30) /**< \brief SPI signal: NPCS0 on PA30 mux A */
+#define MUX_PA30A_SPI_NPCS0             _L_(0)
 #define PINMUX_PA30A_SPI_NPCS0     ((PIN_PA30A_SPI_NPCS0 << 16) | MUX_PA30A_SPI_NPCS0)
-#define GPIO_PA30A_SPI_NPCS0     _UL(1 << 30)
-#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
-#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define GPIO_PA30A_SPI_NPCS0     _UL_(1 << 30)
+#define PIN_PA13C_SPI_NPCS1            _L_(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L_(2)
 #define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
-#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PA31A_SPI_NPCS1            _L(31) /**< \brief SPI signal: NPCS1 on PA31 mux A */
-#define MUX_PA31A_SPI_NPCS1             _L(0)
+#define GPIO_PA13C_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PA31A_SPI_NPCS1            _L_(31) /**< \brief SPI signal: NPCS1 on PA31 mux A */
+#define MUX_PA31A_SPI_NPCS1             _L_(0)
 #define PINMUX_PA31A_SPI_NPCS1     ((PIN_PA31A_SPI_NPCS1 << 16) | MUX_PA31A_SPI_NPCS1)
-#define GPIO_PA31A_SPI_NPCS1     _UL(1 << 31)
-#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
-#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define GPIO_PA31A_SPI_NPCS1     _UL_(1 << 31)
+#define PIN_PA14C_SPI_NPCS2            _L_(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L_(2)
 #define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
-#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
-#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
-#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define GPIO_PA14C_SPI_NPCS2     _UL_(1 << 14)
+#define PIN_PA15C_SPI_NPCS3            _L_(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L_(2)
 #define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
-#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
-#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
-#define MUX_PA23A_SPI_SCK               _L(0)
+#define GPIO_PA15C_SPI_NPCS3     _UL_(1 << 15)
+#define PIN_PA23A_SPI_SCK              _L_(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L_(0)
 #define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
-#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
-#define PIN_PA29A_SPI_SCK              _L(29) /**< \brief SPI signal: SCK on PA29 mux A */
-#define MUX_PA29A_SPI_SCK               _L(0)
+#define GPIO_PA23A_SPI_SCK       _UL_(1 << 23)
+#define PIN_PA29A_SPI_SCK              _L_(29) /**< \brief SPI signal: SCK on PA29 mux A */
+#define MUX_PA29A_SPI_SCK               _L_(0)
 #define PINMUX_PA29A_SPI_SCK       ((PIN_PA29A_SPI_SCK << 16) | MUX_PA29A_SPI_SCK)
-#define GPIO_PA29A_SPI_SCK       _UL(1 << 29)
+#define GPIO_PA29A_SPI_SCK       _UL_(1 << 29)
 /* ========== GPIO definition for TC0 peripheral ========== */
-#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
-#define MUX_PA08B_TC0_A0                _L(1)
+#define PIN_PA08B_TC0_A0                _L_(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L_(1)
 #define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
-#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
-#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
-#define MUX_PA10B_TC0_A1                _L(1)
+#define GPIO_PA08B_TC0_A0        _UL_(1 <<  8)
+#define PIN_PA10B_TC0_A1               _L_(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L_(1)
 #define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
-#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
-#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
-#define MUX_PA12B_TC0_A2                _L(1)
+#define GPIO_PA10B_TC0_A1        _UL_(1 << 10)
+#define PIN_PA12B_TC0_A2               _L_(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L_(1)
 #define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
-#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
-#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
-#define MUX_PA09B_TC0_B0                _L(1)
+#define GPIO_PA12B_TC0_A2        _UL_(1 << 12)
+#define PIN_PA09B_TC0_B0                _L_(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L_(1)
 #define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
-#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
-#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
-#define MUX_PA11B_TC0_B1                _L(1)
+#define GPIO_PA09B_TC0_B0        _UL_(1 <<  9)
+#define PIN_PA11B_TC0_B1               _L_(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L_(1)
 #define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
-#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
-#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
-#define MUX_PA13B_TC0_B2                _L(1)
+#define GPIO_PA11B_TC0_B1        _UL_(1 << 11)
+#define PIN_PA13B_TC0_B2               _L_(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L_(1)
 #define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
-#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
-#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
-#define MUX_PA14B_TC0_CLK0              _L(1)
+#define GPIO_PA13B_TC0_B2        _UL_(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L_(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L_(1)
 #define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
-#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
-#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
-#define MUX_PA15B_TC0_CLK1              _L(1)
+#define GPIO_PA14B_TC0_CLK0      _UL_(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L_(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L_(1)
 #define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
-#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
-#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
-#define MUX_PA16B_TC0_CLK2              _L(1)
+#define GPIO_PA15B_TC0_CLK1      _UL_(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L_(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L_(1)
 #define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
-#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+#define GPIO_PA16B_TC0_CLK2      _UL_(1 << 16)
 /* ========== GPIO definition for USART0 peripheral ========== */
-#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
-#define MUX_PA04B_USART0_CLK            _L(1)
+#define PIN_PA04B_USART0_CLK            _L_(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L_(1)
 #define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
-#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
-#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
-#define MUX_PA10A_USART0_CLK            _L(0)
+#define GPIO_PA04B_USART0_CLK    _UL_(1 <<  4)
+#define PIN_PA10A_USART0_CLK           _L_(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L_(0)
 #define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
-#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
-#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
-#define MUX_PA09A_USART0_CTS            _L(0)
+#define GPIO_PA10A_USART0_CLK    _UL_(1 << 10)
+#define PIN_PA09A_USART0_CTS            _L_(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L_(0)
 #define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
-#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
-#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
-#define MUX_PA06B_USART0_RTS            _L(1)
+#define GPIO_PA09A_USART0_CTS    _UL_(1 <<  9)
+#define PIN_PA06B_USART0_RTS            _L_(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L_(1)
 #define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
-#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
-#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
-#define MUX_PA08A_USART0_RTS            _L(0)
+#define GPIO_PA06B_USART0_RTS    _UL_(1 <<  6)
+#define PIN_PA08A_USART0_RTS            _L_(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L_(0)
 #define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
-#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
-#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
-#define MUX_PA05B_USART0_RXD            _L(1)
+#define GPIO_PA08A_USART0_RTS    _UL_(1 <<  8)
+#define PIN_PA05B_USART0_RXD            _L_(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L_(1)
 #define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
-#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
-#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
-#define MUX_PA11A_USART0_RXD            _L(0)
+#define GPIO_PA05B_USART0_RXD    _UL_(1 <<  5)
+#define PIN_PA11A_USART0_RXD           _L_(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L_(0)
 #define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
-#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
-#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
-#define MUX_PA07B_USART0_TXD            _L(1)
+#define GPIO_PA11A_USART0_RXD    _UL_(1 << 11)
+#define PIN_PA07B_USART0_TXD            _L_(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L_(1)
 #define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
-#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
-#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
-#define MUX_PA12A_USART0_TXD            _L(0)
+#define GPIO_PA07B_USART0_TXD    _UL_(1 <<  7)
+#define PIN_PA12A_USART0_TXD           _L_(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L_(0)
 #define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
-#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
+#define GPIO_PA12A_USART0_TXD    _UL_(1 << 12)
 /* ========== GPIO definition for USART1 peripheral ========== */
-#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
-#define MUX_PA14A_USART1_CLK            _L(0)
+#define PIN_PA14A_USART1_CLK           _L_(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L_(0)
 #define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
-#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
-#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
-#define MUX_PA21B_USART1_CTS            _L(1)
+#define GPIO_PA14A_USART1_CLK    _UL_(1 << 14)
+#define PIN_PA21B_USART1_CTS           _L_(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L_(1)
 #define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
-#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
-#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
-#define MUX_PA13A_USART1_RTS            _L(0)
+#define GPIO_PA21B_USART1_CTS    _UL_(1 << 21)
+#define PIN_PA13A_USART1_RTS           _L_(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L_(0)
 #define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
-#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
-#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
-#define MUX_PA15A_USART1_RXD            _L(0)
+#define GPIO_PA13A_USART1_RTS    _UL_(1 << 13)
+#define PIN_PA15A_USART1_RXD           _L_(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L_(0)
 #define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
-#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
-#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
-#define MUX_PA16A_USART1_TXD            _L(0)
+#define GPIO_PA15A_USART1_RXD    _UL_(1 << 15)
+#define PIN_PA16A_USART1_TXD           _L_(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L_(0)
 #define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
-#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+#define GPIO_PA16A_USART1_TXD    _UL_(1 << 16)
 /* ========== GPIO definition for USART2 peripheral ========== */
-#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
-#define MUX_PA18A_USART2_CLK            _L(0)
+#define PIN_PA18A_USART2_CLK           _L_(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L_(0)
 #define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
-#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
-#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
-#define MUX_PA22B_USART2_CTS            _L(1)
+#define GPIO_PA18A_USART2_CLK    _UL_(1 << 18)
+#define PIN_PA22B_USART2_CTS           _L_(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L_(1)
 #define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
-#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
-#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
-#define MUX_PA17A_USART2_RTS            _L(0)
+#define GPIO_PA22B_USART2_CTS    _UL_(1 << 22)
+#define PIN_PA17A_USART2_RTS           _L_(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L_(0)
 #define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
-#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
-#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
-#define MUX_PA25B_USART2_RXD            _L(1)
+#define GPIO_PA17A_USART2_RTS    _UL_(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L_(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L_(1)
 #define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
-#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
-#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
-#define MUX_PA19A_USART2_RXD            _L(0)
+#define GPIO_PA25B_USART2_RXD    _UL_(1 << 25)
+#define PIN_PA19A_USART2_RXD           _L_(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L_(0)
 #define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
-#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
-#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
-#define MUX_PA26B_USART2_TXD            _L(1)
+#define GPIO_PA19A_USART2_RXD    _UL_(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L_(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L_(1)
 #define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
-#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
-#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
-#define MUX_PA20A_USART2_TXD            _L(0)
+#define GPIO_PA26B_USART2_TXD    _UL_(1 << 26)
+#define PIN_PA20A_USART2_TXD           _L_(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L_(0)
 #define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
-#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+#define GPIO_PA20A_USART2_TXD    _UL_(1 << 20)
 /* ========== GPIO definition for USART3 peripheral ========== */
-#define PIN_PA29E_USART3_CLK           _L(29) /**< \brief USART3 signal: CLK on PA29 mux E */
-#define MUX_PA29E_USART3_CLK            _L(4)
+#define PIN_PA29E_USART3_CLK           _L_(29) /**< \brief USART3 signal: CLK on PA29 mux E */
+#define MUX_PA29E_USART3_CLK            _L_(4)
 #define PINMUX_PA29E_USART3_CLK    ((PIN_PA29E_USART3_CLK << 16) | MUX_PA29E_USART3_CLK)
-#define GPIO_PA29E_USART3_CLK    _UL(1 << 29)
-#define PIN_PA28E_USART3_CTS           _L(28) /**< \brief USART3 signal: CTS on PA28 mux E */
-#define MUX_PA28E_USART3_CTS            _L(4)
+#define GPIO_PA29E_USART3_CLK    _UL_(1 << 29)
+#define PIN_PA28E_USART3_CTS           _L_(28) /**< \brief USART3 signal: CTS on PA28 mux E */
+#define MUX_PA28E_USART3_CTS            _L_(4)
 #define PINMUX_PA28E_USART3_CTS    ((PIN_PA28E_USART3_CTS << 16) | MUX_PA28E_USART3_CTS)
-#define GPIO_PA28E_USART3_CTS    _UL(1 << 28)
-#define PIN_PA27E_USART3_RTS           _L(27) /**< \brief USART3 signal: RTS on PA27 mux E */
-#define MUX_PA27E_USART3_RTS            _L(4)
+#define GPIO_PA28E_USART3_CTS    _UL_(1 << 28)
+#define PIN_PA27E_USART3_RTS           _L_(27) /**< \brief USART3 signal: RTS on PA27 mux E */
+#define MUX_PA27E_USART3_RTS            _L_(4)
 #define PINMUX_PA27E_USART3_RTS    ((PIN_PA27E_USART3_RTS << 16) | MUX_PA27E_USART3_RTS)
-#define GPIO_PA27E_USART3_RTS    _UL(1 << 27)
-#define PIN_PA30E_USART3_RXD           _L(30) /**< \brief USART3 signal: RXD on PA30 mux E */
-#define MUX_PA30E_USART3_RXD            _L(4)
+#define GPIO_PA27E_USART3_RTS    _UL_(1 << 27)
+#define PIN_PA30E_USART3_RXD           _L_(30) /**< \brief USART3 signal: RXD on PA30 mux E */
+#define MUX_PA30E_USART3_RXD            _L_(4)
 #define PINMUX_PA30E_USART3_RXD    ((PIN_PA30E_USART3_RXD << 16) | MUX_PA30E_USART3_RXD)
-#define GPIO_PA30E_USART3_RXD    _UL(1 << 30)
-#define PIN_PA31E_USART3_TXD           _L(31) /**< \brief USART3 signal: TXD on PA31 mux E */
-#define MUX_PA31E_USART3_TXD            _L(4)
+#define GPIO_PA30E_USART3_RXD    _UL_(1 << 30)
+#define PIN_PA31E_USART3_TXD           _L_(31) /**< \brief USART3 signal: TXD on PA31 mux E */
+#define MUX_PA31E_USART3_TXD            _L_(4)
 #define PINMUX_PA31E_USART3_TXD    ((PIN_PA31E_USART3_TXD << 16) | MUX_PA31E_USART3_TXD)
-#define GPIO_PA31E_USART3_TXD    _UL(1 << 31)
+#define GPIO_PA31E_USART3_TXD    _UL_(1 << 31)
 /* ========== GPIO definition for ADCIFE peripheral ========== */
-#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
-#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PIN_PA04A_ADCIFE_AD0            _L_(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L_(0)
 #define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
-#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
-#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
-#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL_(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L_(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L_(0)
 #define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
-#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
-#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
-#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define GPIO_PA05A_ADCIFE_AD1    _UL_(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L_(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L_(0)
 #define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
-#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
-#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
-#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define GPIO_PA07A_ADCIFE_AD2    _UL_(1 <<  7)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L_(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L_(4)
 #define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
-#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL_(1 <<  5)
 /* ========== GPIO definition for DACC peripheral ========== */
-#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
-#define MUX_PA06A_DACC_VOUT             _L(0)
+#define PIN_PA06A_DACC_VOUT             _L_(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L_(0)
 #define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
-#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+#define GPIO_PA06A_DACC_VOUT     _UL_(1 <<  6)
 /* ========== GPIO definition for ACIFC peripheral ========== */
-#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
-#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PIN_PA06E_ACIFC_ACAN0           _L_(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L_(4)
 #define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
-#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
-#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
-#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL_(1 <<  6)
+#define PIN_PA07E_ACIFC_ACAP0           _L_(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L_(4)
 #define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
-#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL_(1 <<  7)
 /* ========== GPIO definition for GLOC peripheral ========== */
-#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
-#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PIN_PA06D_GLOC_IN0              _L_(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L_(3)
 #define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
-#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
-#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
-#define MUX_PA20D_GLOC_IN0              _L(3)
+#define GPIO_PA06D_GLOC_IN0      _UL_(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L_(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L_(3)
 #define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
-#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
-#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
-#define MUX_PA04D_GLOC_IN1              _L(3)
+#define GPIO_PA20D_GLOC_IN0      _UL_(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L_(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L_(3)
 #define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
-#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
-#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
-#define MUX_PA21D_GLOC_IN1              _L(3)
+#define GPIO_PA04D_GLOC_IN1      _UL_(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L_(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L_(3)
 #define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
-#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
-#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
-#define MUX_PA05D_GLOC_IN2              _L(3)
+#define GPIO_PA21D_GLOC_IN1      _UL_(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L_(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L_(3)
 #define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
-#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
-#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
-#define MUX_PA22D_GLOC_IN2              _L(3)
+#define GPIO_PA05D_GLOC_IN2      _UL_(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L_(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L_(3)
 #define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
-#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
-#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
-#define MUX_PA07D_GLOC_IN3              _L(3)
+#define GPIO_PA22D_GLOC_IN2      _UL_(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L_(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L_(3)
 #define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
-#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
-#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
-#define MUX_PA23D_GLOC_IN3              _L(3)
+#define GPIO_PA07D_GLOC_IN3      _UL_(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L_(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L_(3)
 #define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
-#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
-#define PIN_PA27D_GLOC_IN4             _L(27) /**< \brief GLOC signal: IN4 on PA27 mux D */
-#define MUX_PA27D_GLOC_IN4              _L(3)
+#define GPIO_PA23D_GLOC_IN3      _UL_(1 << 23)
+#define PIN_PA27D_GLOC_IN4             _L_(27) /**< \brief GLOC signal: IN4 on PA27 mux D */
+#define MUX_PA27D_GLOC_IN4              _L_(3)
 #define PINMUX_PA27D_GLOC_IN4      ((PIN_PA27D_GLOC_IN4 << 16) | MUX_PA27D_GLOC_IN4)
-#define GPIO_PA27D_GLOC_IN4      _UL(1 << 27)
-#define PIN_PA28D_GLOC_IN5             _L(28) /**< \brief GLOC signal: IN5 on PA28 mux D */
-#define MUX_PA28D_GLOC_IN5              _L(3)
+#define GPIO_PA27D_GLOC_IN4      _UL_(1 << 27)
+#define PIN_PA28D_GLOC_IN5             _L_(28) /**< \brief GLOC signal: IN5 on PA28 mux D */
+#define MUX_PA28D_GLOC_IN5              _L_(3)
 #define PINMUX_PA28D_GLOC_IN5      ((PIN_PA28D_GLOC_IN5 << 16) | MUX_PA28D_GLOC_IN5)
-#define GPIO_PA28D_GLOC_IN5      _UL(1 << 28)
-#define PIN_PA29D_GLOC_IN6             _L(29) /**< \brief GLOC signal: IN6 on PA29 mux D */
-#define MUX_PA29D_GLOC_IN6              _L(3)
+#define GPIO_PA28D_GLOC_IN5      _UL_(1 << 28)
+#define PIN_PA29D_GLOC_IN6             _L_(29) /**< \brief GLOC signal: IN6 on PA29 mux D */
+#define MUX_PA29D_GLOC_IN6              _L_(3)
 #define PINMUX_PA29D_GLOC_IN6      ((PIN_PA29D_GLOC_IN6 << 16) | MUX_PA29D_GLOC_IN6)
-#define GPIO_PA29D_GLOC_IN6      _UL(1 << 29)
-#define PIN_PA30D_GLOC_IN7             _L(30) /**< \brief GLOC signal: IN7 on PA30 mux D */
-#define MUX_PA30D_GLOC_IN7              _L(3)
+#define GPIO_PA29D_GLOC_IN6      _UL_(1 << 29)
+#define PIN_PA30D_GLOC_IN7             _L_(30) /**< \brief GLOC signal: IN7 on PA30 mux D */
+#define MUX_PA30D_GLOC_IN7              _L_(3)
 #define PINMUX_PA30D_GLOC_IN7      ((PIN_PA30D_GLOC_IN7 << 16) | MUX_PA30D_GLOC_IN7)
-#define GPIO_PA30D_GLOC_IN7      _UL(1 << 30)
-#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
-#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define GPIO_PA30D_GLOC_IN7      _UL_(1 << 30)
+#define PIN_PA08D_GLOC_OUT0             _L_(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
-#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
-#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
-#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define GPIO_PA08D_GLOC_OUT0     _UL_(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L_(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
-#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
-#define PIN_PA31D_GLOC_OUT1            _L(31) /**< \brief GLOC signal: OUT1 on PA31 mux D */
-#define MUX_PA31D_GLOC_OUT1             _L(3)
+#define GPIO_PA24D_GLOC_OUT0     _UL_(1 << 24)
+#define PIN_PA31D_GLOC_OUT1            _L_(31) /**< \brief GLOC signal: OUT1 on PA31 mux D */
+#define MUX_PA31D_GLOC_OUT1             _L_(3)
 #define PINMUX_PA31D_GLOC_OUT1     ((PIN_PA31D_GLOC_OUT1 << 16) | MUX_PA31D_GLOC_OUT1)
-#define GPIO_PA31D_GLOC_OUT1     _UL(1 << 31)
+#define GPIO_PA31D_GLOC_OUT1     _UL_(1 << 31)
 /* ========== GPIO definition for ABDACB peripheral ========== */
-#define PIN_PA31C_ABDACB_CLK           _L(31) /**< \brief ABDACB signal: CLK on PA31 mux C */
-#define MUX_PA31C_ABDACB_CLK            _L(2)
+#define PIN_PA31C_ABDACB_CLK           _L_(31) /**< \brief ABDACB signal: CLK on PA31 mux C */
+#define MUX_PA31C_ABDACB_CLK            _L_(2)
 #define PINMUX_PA31C_ABDACB_CLK    ((PIN_PA31C_ABDACB_CLK << 16) | MUX_PA31C_ABDACB_CLK)
-#define GPIO_PA31C_ABDACB_CLK    _UL(1 << 31)
-#define PIN_PA27C_ABDACB_DAC0          _L(27) /**< \brief ABDACB signal: DAC0 on PA27 mux C */
-#define MUX_PA27C_ABDACB_DAC0           _L(2)
+#define GPIO_PA31C_ABDACB_CLK    _UL_(1 << 31)
+#define PIN_PA27C_ABDACB_DAC0          _L_(27) /**< \brief ABDACB signal: DAC0 on PA27 mux C */
+#define MUX_PA27C_ABDACB_DAC0           _L_(2)
 #define PINMUX_PA27C_ABDACB_DAC0   ((PIN_PA27C_ABDACB_DAC0 << 16) | MUX_PA27C_ABDACB_DAC0)
-#define GPIO_PA27C_ABDACB_DAC0   _UL(1 << 27)
-#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
-#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define GPIO_PA27C_ABDACB_DAC0   _UL_(1 << 27)
+#define PIN_PA17B_ABDACB_DAC0          _L_(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L_(1)
 #define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
-#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
-#define PIN_PA29C_ABDACB_DAC1          _L(29) /**< \brief ABDACB signal: DAC1 on PA29 mux C */
-#define MUX_PA29C_ABDACB_DAC1           _L(2)
+#define GPIO_PA17B_ABDACB_DAC0   _UL_(1 << 17)
+#define PIN_PA29C_ABDACB_DAC1          _L_(29) /**< \brief ABDACB signal: DAC1 on PA29 mux C */
+#define MUX_PA29C_ABDACB_DAC1           _L_(2)
 #define PINMUX_PA29C_ABDACB_DAC1   ((PIN_PA29C_ABDACB_DAC1 << 16) | MUX_PA29C_ABDACB_DAC1)
-#define GPIO_PA29C_ABDACB_DAC1   _UL(1 << 29)
-#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
-#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define GPIO_PA29C_ABDACB_DAC1   _UL_(1 << 29)
+#define PIN_PA19B_ABDACB_DAC1          _L_(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L_(1)
 #define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
-#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
-#define PIN_PA28C_ABDACB_DACN0         _L(28) /**< \brief ABDACB signal: DACN0 on PA28 mux C */
-#define MUX_PA28C_ABDACB_DACN0          _L(2)
+#define GPIO_PA19B_ABDACB_DAC1   _UL_(1 << 19)
+#define PIN_PA28C_ABDACB_DACN0         _L_(28) /**< \brief ABDACB signal: DACN0 on PA28 mux C */
+#define MUX_PA28C_ABDACB_DACN0          _L_(2)
 #define PINMUX_PA28C_ABDACB_DACN0  ((PIN_PA28C_ABDACB_DACN0 << 16) | MUX_PA28C_ABDACB_DACN0)
-#define GPIO_PA28C_ABDACB_DACN0  _UL(1 << 28)
-#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
-#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define GPIO_PA28C_ABDACB_DACN0  _UL_(1 << 28)
+#define PIN_PA18B_ABDACB_DACN0         _L_(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L_(1)
 #define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
-#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
-#define PIN_PA30C_ABDACB_DACN1         _L(30) /**< \brief ABDACB signal: DACN1 on PA30 mux C */
-#define MUX_PA30C_ABDACB_DACN1          _L(2)
+#define GPIO_PA18B_ABDACB_DACN0  _UL_(1 << 18)
+#define PIN_PA30C_ABDACB_DACN1         _L_(30) /**< \brief ABDACB signal: DACN1 on PA30 mux C */
+#define MUX_PA30C_ABDACB_DACN1          _L_(2)
 #define PINMUX_PA30C_ABDACB_DACN1  ((PIN_PA30C_ABDACB_DACN1 << 16) | MUX_PA30C_ABDACB_DACN1)
-#define GPIO_PA30C_ABDACB_DACN1  _UL(1 << 30)
-#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
-#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define GPIO_PA30C_ABDACB_DACN1  _UL_(1 << 30)
+#define PIN_PA20B_ABDACB_DACN1         _L_(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L_(1)
 #define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
-#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+#define GPIO_PA20B_ABDACB_DACN1  _UL_(1 << 20)
 /* ========== GPIO definition for PARC peripheral ========== */
-#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
-#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PIN_PA17D_PARC_PCCK            _L_(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L_(3)
 #define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
-#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
-#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
-#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define GPIO_PA17D_PARC_PCCK     _UL_(1 << 17)
+#define PIN_PA09D_PARC_PCDATA0          _L_(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L_(3)
 #define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
-#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
-#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
-#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define GPIO_PA09D_PARC_PCDATA0  _UL_(1 <<  9)
+#define PIN_PA10D_PARC_PCDATA1         _L_(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L_(3)
 #define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
-#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
-#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
-#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define GPIO_PA10D_PARC_PCDATA1  _UL_(1 << 10)
+#define PIN_PA11D_PARC_PCDATA2         _L_(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L_(3)
 #define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
-#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
-#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
-#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define GPIO_PA11D_PARC_PCDATA2  _UL_(1 << 11)
+#define PIN_PA12D_PARC_PCDATA3         _L_(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L_(3)
 #define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
-#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
-#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
-#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL_(1 << 12)
+#define PIN_PA13D_PARC_PCDATA4         _L_(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L_(3)
 #define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
-#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
-#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
-#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define GPIO_PA13D_PARC_PCDATA4  _UL_(1 << 13)
+#define PIN_PA14D_PARC_PCDATA5         _L_(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L_(3)
 #define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
-#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
-#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
-#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define GPIO_PA14D_PARC_PCDATA5  _UL_(1 << 14)
+#define PIN_PA15D_PARC_PCDATA6         _L_(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L_(3)
 #define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
-#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
-#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
-#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define GPIO_PA15D_PARC_PCDATA6  _UL_(1 << 15)
+#define PIN_PA16D_PARC_PCDATA7         _L_(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L_(3)
 #define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
-#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
-#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
-#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define GPIO_PA16D_PARC_PCDATA7  _UL_(1 << 16)
+#define PIN_PA18D_PARC_PCEN1           _L_(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L_(3)
 #define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
-#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
-#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
-#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define GPIO_PA18D_PARC_PCEN1    _UL_(1 << 18)
+#define PIN_PA19D_PARC_PCEN2           _L_(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L_(3)
 #define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
-#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+#define GPIO_PA19D_PARC_PCEN2    _UL_(1 << 19)
 /* ========== GPIO definition for CATB peripheral ========== */
-#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
-#define MUX_PA02G_CATB_DIS              _L(6)
+#define PIN_PA02G_CATB_DIS              _L_(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L_(6)
 #define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
-#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
-#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
-#define MUX_PA12G_CATB_DIS              _L(6)
+#define GPIO_PA02G_CATB_DIS      _UL_(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L_(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L_(6)
 #define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
-#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
-#define MUX_PA23G_CATB_DIS              _L(6)
+#define GPIO_PA12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L_(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L_(6)
 #define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
-#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
-#define PIN_PA31G_CATB_DIS             _L(31) /**< \brief CATB signal: DIS on PA31 mux G */
-#define MUX_PA31G_CATB_DIS              _L(6)
+#define GPIO_PA23G_CATB_DIS      _UL_(1 << 23)
+#define PIN_PA31G_CATB_DIS             _L_(31) /**< \brief CATB signal: DIS on PA31 mux G */
+#define MUX_PA31G_CATB_DIS              _L_(6)
 #define PINMUX_PA31G_CATB_DIS      ((PIN_PA31G_CATB_DIS << 16) | MUX_PA31G_CATB_DIS)
-#define GPIO_PA31G_CATB_DIS      _UL(1 << 31)
-#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
-#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define GPIO_PA31G_CATB_DIS      _UL_(1 << 31)
+#define PIN_PA04G_CATB_SENSE0           _L_(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L_(6)
 #define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
-#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
-#define PIN_PA27G_CATB_SENSE0          _L(27) /**< \brief CATB signal: SENSE0 on PA27 mux G */
-#define MUX_PA27G_CATB_SENSE0           _L(6)
+#define GPIO_PA04G_CATB_SENSE0   _UL_(1 <<  4)
+#define PIN_PA27G_CATB_SENSE0          _L_(27) /**< \brief CATB signal: SENSE0 on PA27 mux G */
+#define MUX_PA27G_CATB_SENSE0           _L_(6)
 #define PINMUX_PA27G_CATB_SENSE0   ((PIN_PA27G_CATB_SENSE0 << 16) | MUX_PA27G_CATB_SENSE0)
-#define GPIO_PA27G_CATB_SENSE0   _UL(1 << 27)
-#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
-#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define GPIO_PA27G_CATB_SENSE0   _UL_(1 << 27)
+#define PIN_PA05G_CATB_SENSE1           _L_(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L_(6)
 #define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
-#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
-#define PIN_PA28G_CATB_SENSE1          _L(28) /**< \brief CATB signal: SENSE1 on PA28 mux G */
-#define MUX_PA28G_CATB_SENSE1           _L(6)
+#define GPIO_PA05G_CATB_SENSE1   _UL_(1 <<  5)
+#define PIN_PA28G_CATB_SENSE1          _L_(28) /**< \brief CATB signal: SENSE1 on PA28 mux G */
+#define MUX_PA28G_CATB_SENSE1           _L_(6)
 #define PINMUX_PA28G_CATB_SENSE1   ((PIN_PA28G_CATB_SENSE1 << 16) | MUX_PA28G_CATB_SENSE1)
-#define GPIO_PA28G_CATB_SENSE1   _UL(1 << 28)
-#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
-#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define GPIO_PA28G_CATB_SENSE1   _UL_(1 << 28)
+#define PIN_PA06G_CATB_SENSE2           _L_(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L_(6)
 #define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
-#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
-#define PIN_PA29G_CATB_SENSE2          _L(29) /**< \brief CATB signal: SENSE2 on PA29 mux G */
-#define MUX_PA29G_CATB_SENSE2           _L(6)
+#define GPIO_PA06G_CATB_SENSE2   _UL_(1 <<  6)
+#define PIN_PA29G_CATB_SENSE2          _L_(29) /**< \brief CATB signal: SENSE2 on PA29 mux G */
+#define MUX_PA29G_CATB_SENSE2           _L_(6)
 #define PINMUX_PA29G_CATB_SENSE2   ((PIN_PA29G_CATB_SENSE2 << 16) | MUX_PA29G_CATB_SENSE2)
-#define GPIO_PA29G_CATB_SENSE2   _UL(1 << 29)
-#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
-#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define GPIO_PA29G_CATB_SENSE2   _UL_(1 << 29)
+#define PIN_PA07G_CATB_SENSE3           _L_(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L_(6)
 #define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
-#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
-#define PIN_PA30G_CATB_SENSE3          _L(30) /**< \brief CATB signal: SENSE3 on PA30 mux G */
-#define MUX_PA30G_CATB_SENSE3           _L(6)
+#define GPIO_PA07G_CATB_SENSE3   _UL_(1 <<  7)
+#define PIN_PA30G_CATB_SENSE3          _L_(30) /**< \brief CATB signal: SENSE3 on PA30 mux G */
+#define MUX_PA30G_CATB_SENSE3           _L_(6)
 #define PINMUX_PA30G_CATB_SENSE3   ((PIN_PA30G_CATB_SENSE3 << 16) | MUX_PA30G_CATB_SENSE3)
-#define GPIO_PA30G_CATB_SENSE3   _UL(1 << 30)
-#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
-#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define GPIO_PA30G_CATB_SENSE3   _UL_(1 << 30)
+#define PIN_PA08G_CATB_SENSE4           _L_(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L_(6)
 #define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
-#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
-#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
-#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define GPIO_PA08G_CATB_SENSE4   _UL_(1 <<  8)
+#define PIN_PA09G_CATB_SENSE5           _L_(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L_(6)
 #define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
-#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
-#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
-#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define GPIO_PA09G_CATB_SENSE5   _UL_(1 <<  9)
+#define PIN_PA10G_CATB_SENSE6          _L_(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L_(6)
 #define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
-#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
-#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
-#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define GPIO_PA10G_CATB_SENSE6   _UL_(1 << 10)
+#define PIN_PA11G_CATB_SENSE7          _L_(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L_(6)
 #define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
-#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
-#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
-#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define GPIO_PA11G_CATB_SENSE7   _UL_(1 << 11)
+#define PIN_PA13G_CATB_SENSE8          _L_(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L_(6)
 #define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
-#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
-#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
-#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define GPIO_PA13G_CATB_SENSE8   _UL_(1 << 13)
+#define PIN_PA14G_CATB_SENSE9          _L_(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L_(6)
 #define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
-#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
-#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
-#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define GPIO_PA14G_CATB_SENSE9   _UL_(1 << 14)
+#define PIN_PA15G_CATB_SENSE10         _L_(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L_(6)
 #define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
-#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
-#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
-#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define GPIO_PA15G_CATB_SENSE10  _UL_(1 << 15)
+#define PIN_PA16G_CATB_SENSE11         _L_(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L_(6)
 #define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
-#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
-#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
-#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define GPIO_PA16G_CATB_SENSE11  _UL_(1 << 16)
+#define PIN_PA17G_CATB_SENSE12         _L_(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L_(6)
 #define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
-#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
-#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
-#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define GPIO_PA17G_CATB_SENSE12  _UL_(1 << 17)
+#define PIN_PA18G_CATB_SENSE13         _L_(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L_(6)
 #define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
-#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
-#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
-#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define GPIO_PA18G_CATB_SENSE13  _UL_(1 << 18)
+#define PIN_PA19G_CATB_SENSE14         _L_(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L_(6)
 #define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
-#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
-#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
-#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define GPIO_PA19G_CATB_SENSE14  _UL_(1 << 19)
+#define PIN_PA20G_CATB_SENSE15         _L_(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L_(6)
 #define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
-#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
-#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
-#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define GPIO_PA20G_CATB_SENSE15  _UL_(1 << 20)
+#define PIN_PA21G_CATB_SENSE16         _L_(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L_(6)
 #define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
-#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
-#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
-#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define GPIO_PA21G_CATB_SENSE16  _UL_(1 << 21)
+#define PIN_PA22G_CATB_SENSE17         _L_(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L_(6)
 #define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
-#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
-#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
-#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define GPIO_PA22G_CATB_SENSE17  _UL_(1 << 22)
+#define PIN_PA24G_CATB_SENSE18         _L_(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L_(6)
 #define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
-#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
-#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
-#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define GPIO_PA24G_CATB_SENSE18  _UL_(1 << 24)
+#define PIN_PA25G_CATB_SENSE19         _L_(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L_(6)
 #define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
-#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
-#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
-#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define GPIO_PA25G_CATB_SENSE19  _UL_(1 << 25)
+#define PIN_PA26G_CATB_SENSE20         _L_(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L_(6)
 #define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
-#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
+#define GPIO_PA26G_CATB_SENSE20  _UL_(1 << 26)
 /* ========== GPIO definition for USBC peripheral ========== */
-#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
-#define MUX_PA25A_USBC_DM               _L(0)
+#define PIN_PA25A_USBC_DM              _L_(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L_(0)
 #define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
-#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
-#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
-#define MUX_PA26A_USBC_DP               _L(0)
+#define GPIO_PA25A_USBC_DM       _UL_(1 << 25)
+#define PIN_PA26A_USBC_DP              _L_(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L_(0)
 #define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
-#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+#define GPIO_PA26A_USBC_DP       _UL_(1 << 26)
 /* ========== GPIO definition for PEVC peripheral ========== */
-#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
-#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PIN_PA08C_PEVC_PAD_EVT0         _L_(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
-#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
-#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
-#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL_(1 <<  8)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L_(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
-#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
-#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
-#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL_(1 <<  9)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L_(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
-#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
-#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
-#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL_(1 << 10)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L_(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L_(2)
 #define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
-#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL_(1 << 11)
 /* ========== GPIO definition for SCIF peripheral ========== */
-#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
-#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PIN_PA19E_SCIF_GCLK0           _L_(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
-#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
-#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
-#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define GPIO_PA19E_SCIF_GCLK0    _UL_(1 << 19)
+#define PIN_PA02A_SCIF_GCLK0            _L_(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L_(0)
 #define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
-#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
-#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
-#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define GPIO_PA02A_SCIF_GCLK0    _UL_(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L_(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
-#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
-#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
-#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PA20E_SCIF_GCLK1    _UL_(1 << 20)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L_(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
-#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
-#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
-#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL_(1 << 23)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L_(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
-#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL_(1 << 24)
 /* ========== GPIO definition for EIC peripheral ========== */
-#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
-#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define PIN_PA06C_EIC_EXTINT1           _L_(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
-#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
-#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
-#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
-#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define GPIO_PA06C_EIC_EXTINT1   _UL_(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L_(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
-#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
-#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
-#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
-#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define GPIO_PA16C_EIC_EXTINT1   _UL_(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L_(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
-#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
-#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
-#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
-#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL_(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L_(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
-#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
-#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
-#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
-#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL_(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L_(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
-#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
-#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
-#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
-#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define GPIO_PA05C_EIC_EXTINT3   _UL_(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L_(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
-#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
-#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
-#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
-#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define GPIO_PA18C_EIC_EXTINT3   _UL_(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L_(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
-#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
-#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
-#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
-#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define GPIO_PA07C_EIC_EXTINT4   _UL_(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L_(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
-#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
-#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
-#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
-#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define GPIO_PA19C_EIC_EXTINT4   _UL_(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L_(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L_(2)
 #define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
-#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
-#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
-#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
-#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define GPIO_PA20C_EIC_EXTINT5   _UL_(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L_(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L_(2)
 #define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
-#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
-#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
-#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
-#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define GPIO_PA21C_EIC_EXTINT6   _UL_(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L_(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L_(2)
 #define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
-#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
-#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
-#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
-#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define GPIO_PA22C_EIC_EXTINT7   _UL_(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L_(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L_(2)
 #define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
-#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
-#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define GPIO_PA23C_EIC_EXTINT8   _UL_(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
 
 #endif /* _SAM4LS2A_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4ls2a.h
+++ b/asf/sam/include/sam4l/pio/sam4ls2a.h
@@ -1,0 +1,737 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAM4LS2A
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LS2A_PIO_
+#define _SAM4LS2A_PIO_
+
+#define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
+#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
+#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
+#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
+#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
+#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
+#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
+#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
+#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
+#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
+#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
+#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
+#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
+#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
+#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
+#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
+#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
+#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
+#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
+#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
+#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
+#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
+#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
+#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
+#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
+#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
+#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
+#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
+#define GPIO_PA27                _UL(1 << 27) /**< \brief GPIO Mask  for PA27 */
+#define PIN_PA28                          28  /**< \brief Pin Number for PA28 */
+#define GPIO_PA28                _UL(1 << 28) /**< \brief GPIO Mask  for PA28 */
+#define PIN_PA29                          29  /**< \brief Pin Number for PA29 */
+#define GPIO_PA29                _UL(1 << 29) /**< \brief GPIO Mask  for PA29 */
+#define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
+#define GPIO_PA30                _UL(1 << 30) /**< \brief GPIO Mask  for PA30 */
+#define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
+#define GPIO_PA31                _UL(1 << 31) /**< \brief GPIO Mask  for PA31 */
+/* ========== GPIO definition for TWIMS0 peripheral ========== */
+#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
+#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+/* ========== GPIO definition for TWIMS2 peripheral ========== */
+#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
+#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+/* ========== GPIO definition for IISC peripheral ========== */
+#define PIN_PA31B_IISC_IMCK            _L(31) /**< \brief IISC signal: IMCK on PA31 mux B */
+#define MUX_PA31B_IISC_IMCK             _L(1)
+#define PINMUX_PA31B_IISC_IMCK     ((PIN_PA31B_IISC_IMCK << 16) | MUX_PA31B_IISC_IMCK)
+#define GPIO_PA31B_IISC_IMCK     _UL(1 << 31)
+#define PIN_PA27B_IISC_ISCK            _L(27) /**< \brief IISC signal: ISCK on PA27 mux B */
+#define MUX_PA27B_IISC_ISCK             _L(1)
+#define PINMUX_PA27B_IISC_ISCK     ((PIN_PA27B_IISC_ISCK << 16) | MUX_PA27B_IISC_ISCK)
+#define GPIO_PA27B_IISC_ISCK     _UL(1 << 27)
+#define PIN_PA28B_IISC_ISDI            _L(28) /**< \brief IISC signal: ISDI on PA28 mux B */
+#define MUX_PA28B_IISC_ISDI             _L(1)
+#define PINMUX_PA28B_IISC_ISDI     ((PIN_PA28B_IISC_ISDI << 16) | MUX_PA28B_IISC_ISDI)
+#define GPIO_PA28B_IISC_ISDI     _UL(1 << 28)
+#define PIN_PA30B_IISC_ISDO            _L(30) /**< \brief IISC signal: ISDO on PA30 mux B */
+#define MUX_PA30B_IISC_ISDO             _L(1)
+#define PINMUX_PA30B_IISC_ISDO     ((PIN_PA30B_IISC_ISDO << 16) | MUX_PA30B_IISC_ISDO)
+#define GPIO_PA30B_IISC_ISDO     _UL(1 << 30)
+#define PIN_PA29B_IISC_IWS             _L(29) /**< \brief IISC signal: IWS on PA29 mux B */
+#define MUX_PA29B_IISC_IWS              _L(1)
+#define PINMUX_PA29B_IISC_IWS      ((PIN_PA29B_IISC_IWS << 16) | MUX_PA29B_IISC_IWS)
+#define GPIO_PA29B_IISC_IWS      _UL(1 << 29)
+/* ========== GPIO definition for SPI peripheral ========== */
+#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L(1)
+#define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
+#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
+#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L(0)
+#define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
+#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
+#define PIN_PA27A_SPI_MISO             _L(27) /**< \brief SPI signal: MISO on PA27 mux A */
+#define MUX_PA27A_SPI_MISO              _L(0)
+#define PINMUX_PA27A_SPI_MISO      ((PIN_PA27A_SPI_MISO << 16) | MUX_PA27A_SPI_MISO)
+#define GPIO_PA27A_SPI_MISO      _UL(1 << 27)
+#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L(0)
+#define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
+#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
+#define PIN_PA28A_SPI_MOSI             _L(28) /**< \brief SPI signal: MOSI on PA28 mux A */
+#define MUX_PA28A_SPI_MOSI              _L(0)
+#define PINMUX_PA28A_SPI_MOSI      ((PIN_PA28A_SPI_MOSI << 16) | MUX_PA28A_SPI_MOSI)
+#define GPIO_PA28A_SPI_MOSI      _UL(1 << 28)
+#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
+#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
+#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
+#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
+#define PIN_PA30A_SPI_NPCS0            _L(30) /**< \brief SPI signal: NPCS0 on PA30 mux A */
+#define MUX_PA30A_SPI_NPCS0             _L(0)
+#define PINMUX_PA30A_SPI_NPCS0     ((PIN_PA30A_SPI_NPCS0 << 16) | MUX_PA30A_SPI_NPCS0)
+#define GPIO_PA30A_SPI_NPCS0     _UL(1 << 30)
+#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
+#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PA31A_SPI_NPCS1            _L(31) /**< \brief SPI signal: NPCS1 on PA31 mux A */
+#define MUX_PA31A_SPI_NPCS1             _L(0)
+#define PINMUX_PA31A_SPI_NPCS1     ((PIN_PA31A_SPI_NPCS1 << 16) | MUX_PA31A_SPI_NPCS1)
+#define GPIO_PA31A_SPI_NPCS1     _UL(1 << 31)
+#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
+#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
+#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
+#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
+#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L(0)
+#define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
+#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
+#define PIN_PA29A_SPI_SCK              _L(29) /**< \brief SPI signal: SCK on PA29 mux A */
+#define MUX_PA29A_SPI_SCK               _L(0)
+#define PINMUX_PA29A_SPI_SCK       ((PIN_PA29A_SPI_SCK << 16) | MUX_PA29A_SPI_SCK)
+#define GPIO_PA29A_SPI_SCK       _UL(1 << 29)
+/* ========== GPIO definition for TC0 peripheral ========== */
+#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L(1)
+#define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
+#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
+#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L(1)
+#define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
+#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
+#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L(1)
+#define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
+#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
+#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L(1)
+#define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
+#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
+#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L(1)
+#define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
+#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
+#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L(1)
+#define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
+#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L(1)
+#define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
+#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L(1)
+#define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
+#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L(1)
+#define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
+#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+/* ========== GPIO definition for USART0 peripheral ========== */
+#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L(1)
+#define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
+#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
+#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L(0)
+#define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
+#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
+#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L(0)
+#define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
+#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
+#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L(1)
+#define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
+#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
+#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L(0)
+#define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
+#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
+#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L(1)
+#define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
+#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
+#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L(0)
+#define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
+#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
+#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L(1)
+#define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
+#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
+#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L(0)
+#define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
+#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
+/* ========== GPIO definition for USART1 peripheral ========== */
+#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L(0)
+#define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
+#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
+#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L(1)
+#define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
+#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
+#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L(0)
+#define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
+#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
+#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L(0)
+#define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
+#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
+#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L(0)
+#define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
+#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+/* ========== GPIO definition for USART2 peripheral ========== */
+#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L(0)
+#define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
+#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
+#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L(1)
+#define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
+#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
+#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L(0)
+#define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
+#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L(1)
+#define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
+#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
+#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L(0)
+#define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
+#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L(1)
+#define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
+#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
+#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L(0)
+#define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
+#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+/* ========== GPIO definition for USART3 peripheral ========== */
+#define PIN_PA29E_USART3_CLK           _L(29) /**< \brief USART3 signal: CLK on PA29 mux E */
+#define MUX_PA29E_USART3_CLK            _L(4)
+#define PINMUX_PA29E_USART3_CLK    ((PIN_PA29E_USART3_CLK << 16) | MUX_PA29E_USART3_CLK)
+#define GPIO_PA29E_USART3_CLK    _UL(1 << 29)
+#define PIN_PA28E_USART3_CTS           _L(28) /**< \brief USART3 signal: CTS on PA28 mux E */
+#define MUX_PA28E_USART3_CTS            _L(4)
+#define PINMUX_PA28E_USART3_CTS    ((PIN_PA28E_USART3_CTS << 16) | MUX_PA28E_USART3_CTS)
+#define GPIO_PA28E_USART3_CTS    _UL(1 << 28)
+#define PIN_PA27E_USART3_RTS           _L(27) /**< \brief USART3 signal: RTS on PA27 mux E */
+#define MUX_PA27E_USART3_RTS            _L(4)
+#define PINMUX_PA27E_USART3_RTS    ((PIN_PA27E_USART3_RTS << 16) | MUX_PA27E_USART3_RTS)
+#define GPIO_PA27E_USART3_RTS    _UL(1 << 27)
+#define PIN_PA30E_USART3_RXD           _L(30) /**< \brief USART3 signal: RXD on PA30 mux E */
+#define MUX_PA30E_USART3_RXD            _L(4)
+#define PINMUX_PA30E_USART3_RXD    ((PIN_PA30E_USART3_RXD << 16) | MUX_PA30E_USART3_RXD)
+#define GPIO_PA30E_USART3_RXD    _UL(1 << 30)
+#define PIN_PA31E_USART3_TXD           _L(31) /**< \brief USART3 signal: TXD on PA31 mux E */
+#define MUX_PA31E_USART3_TXD            _L(4)
+#define PINMUX_PA31E_USART3_TXD    ((PIN_PA31E_USART3_TXD << 16) | MUX_PA31E_USART3_TXD)
+#define GPIO_PA31E_USART3_TXD    _UL(1 << 31)
+/* ========== GPIO definition for ADCIFE peripheral ========== */
+#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
+#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
+#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+/* ========== GPIO definition for DACC peripheral ========== */
+#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L(0)
+#define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
+#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+/* ========== GPIO definition for ACIFC peripheral ========== */
+#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
+#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
+/* ========== GPIO definition for GLOC peripheral ========== */
+#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
+#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L(3)
+#define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
+#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L(3)
+#define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
+#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L(3)
+#define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
+#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L(3)
+#define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
+#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L(3)
+#define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
+#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L(3)
+#define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
+#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L(3)
+#define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
+#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
+#define PIN_PA27D_GLOC_IN4             _L(27) /**< \brief GLOC signal: IN4 on PA27 mux D */
+#define MUX_PA27D_GLOC_IN4              _L(3)
+#define PINMUX_PA27D_GLOC_IN4      ((PIN_PA27D_GLOC_IN4 << 16) | MUX_PA27D_GLOC_IN4)
+#define GPIO_PA27D_GLOC_IN4      _UL(1 << 27)
+#define PIN_PA28D_GLOC_IN5             _L(28) /**< \brief GLOC signal: IN5 on PA28 mux D */
+#define MUX_PA28D_GLOC_IN5              _L(3)
+#define PINMUX_PA28D_GLOC_IN5      ((PIN_PA28D_GLOC_IN5 << 16) | MUX_PA28D_GLOC_IN5)
+#define GPIO_PA28D_GLOC_IN5      _UL(1 << 28)
+#define PIN_PA29D_GLOC_IN6             _L(29) /**< \brief GLOC signal: IN6 on PA29 mux D */
+#define MUX_PA29D_GLOC_IN6              _L(3)
+#define PINMUX_PA29D_GLOC_IN6      ((PIN_PA29D_GLOC_IN6 << 16) | MUX_PA29D_GLOC_IN6)
+#define GPIO_PA29D_GLOC_IN6      _UL(1 << 29)
+#define PIN_PA30D_GLOC_IN7             _L(30) /**< \brief GLOC signal: IN7 on PA30 mux D */
+#define MUX_PA30D_GLOC_IN7              _L(3)
+#define PINMUX_PA30D_GLOC_IN7      ((PIN_PA30D_GLOC_IN7 << 16) | MUX_PA30D_GLOC_IN7)
+#define GPIO_PA30D_GLOC_IN7      _UL(1 << 30)
+#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
+#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
+#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
+#define PIN_PA31D_GLOC_OUT1            _L(31) /**< \brief GLOC signal: OUT1 on PA31 mux D */
+#define MUX_PA31D_GLOC_OUT1             _L(3)
+#define PINMUX_PA31D_GLOC_OUT1     ((PIN_PA31D_GLOC_OUT1 << 16) | MUX_PA31D_GLOC_OUT1)
+#define GPIO_PA31D_GLOC_OUT1     _UL(1 << 31)
+/* ========== GPIO definition for ABDACB peripheral ========== */
+#define PIN_PA31C_ABDACB_CLK           _L(31) /**< \brief ABDACB signal: CLK on PA31 mux C */
+#define MUX_PA31C_ABDACB_CLK            _L(2)
+#define PINMUX_PA31C_ABDACB_CLK    ((PIN_PA31C_ABDACB_CLK << 16) | MUX_PA31C_ABDACB_CLK)
+#define GPIO_PA31C_ABDACB_CLK    _UL(1 << 31)
+#define PIN_PA27C_ABDACB_DAC0          _L(27) /**< \brief ABDACB signal: DAC0 on PA27 mux C */
+#define MUX_PA27C_ABDACB_DAC0           _L(2)
+#define PINMUX_PA27C_ABDACB_DAC0   ((PIN_PA27C_ABDACB_DAC0 << 16) | MUX_PA27C_ABDACB_DAC0)
+#define GPIO_PA27C_ABDACB_DAC0   _UL(1 << 27)
+#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
+#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
+#define PIN_PA29C_ABDACB_DAC1          _L(29) /**< \brief ABDACB signal: DAC1 on PA29 mux C */
+#define MUX_PA29C_ABDACB_DAC1           _L(2)
+#define PINMUX_PA29C_ABDACB_DAC1   ((PIN_PA29C_ABDACB_DAC1 << 16) | MUX_PA29C_ABDACB_DAC1)
+#define GPIO_PA29C_ABDACB_DAC1   _UL(1 << 29)
+#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
+#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
+#define PIN_PA28C_ABDACB_DACN0         _L(28) /**< \brief ABDACB signal: DACN0 on PA28 mux C */
+#define MUX_PA28C_ABDACB_DACN0          _L(2)
+#define PINMUX_PA28C_ABDACB_DACN0  ((PIN_PA28C_ABDACB_DACN0 << 16) | MUX_PA28C_ABDACB_DACN0)
+#define GPIO_PA28C_ABDACB_DACN0  _UL(1 << 28)
+#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
+#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
+#define PIN_PA30C_ABDACB_DACN1         _L(30) /**< \brief ABDACB signal: DACN1 on PA30 mux C */
+#define MUX_PA30C_ABDACB_DACN1          _L(2)
+#define PINMUX_PA30C_ABDACB_DACN1  ((PIN_PA30C_ABDACB_DACN1 << 16) | MUX_PA30C_ABDACB_DACN1)
+#define GPIO_PA30C_ABDACB_DACN1  _UL(1 << 30)
+#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
+#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+/* ========== GPIO definition for PARC peripheral ========== */
+#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
+#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
+#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
+#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
+#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
+#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
+#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
+#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
+#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
+#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
+#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
+#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
+#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
+#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
+#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
+#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
+#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
+#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
+#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
+#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
+#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+/* ========== GPIO definition for CATB peripheral ========== */
+#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L(6)
+#define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
+#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L(6)
+#define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
+#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L(6)
+#define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
+#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
+#define PIN_PA31G_CATB_DIS             _L(31) /**< \brief CATB signal: DIS on PA31 mux G */
+#define MUX_PA31G_CATB_DIS              _L(6)
+#define PINMUX_PA31G_CATB_DIS      ((PIN_PA31G_CATB_DIS << 16) | MUX_PA31G_CATB_DIS)
+#define GPIO_PA31G_CATB_DIS      _UL(1 << 31)
+#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
+#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
+#define PIN_PA27G_CATB_SENSE0          _L(27) /**< \brief CATB signal: SENSE0 on PA27 mux G */
+#define MUX_PA27G_CATB_SENSE0           _L(6)
+#define PINMUX_PA27G_CATB_SENSE0   ((PIN_PA27G_CATB_SENSE0 << 16) | MUX_PA27G_CATB_SENSE0)
+#define GPIO_PA27G_CATB_SENSE0   _UL(1 << 27)
+#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
+#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
+#define PIN_PA28G_CATB_SENSE1          _L(28) /**< \brief CATB signal: SENSE1 on PA28 mux G */
+#define MUX_PA28G_CATB_SENSE1           _L(6)
+#define PINMUX_PA28G_CATB_SENSE1   ((PIN_PA28G_CATB_SENSE1 << 16) | MUX_PA28G_CATB_SENSE1)
+#define GPIO_PA28G_CATB_SENSE1   _UL(1 << 28)
+#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
+#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
+#define PIN_PA29G_CATB_SENSE2          _L(29) /**< \brief CATB signal: SENSE2 on PA29 mux G */
+#define MUX_PA29G_CATB_SENSE2           _L(6)
+#define PINMUX_PA29G_CATB_SENSE2   ((PIN_PA29G_CATB_SENSE2 << 16) | MUX_PA29G_CATB_SENSE2)
+#define GPIO_PA29G_CATB_SENSE2   _UL(1 << 29)
+#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
+#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
+#define PIN_PA30G_CATB_SENSE3          _L(30) /**< \brief CATB signal: SENSE3 on PA30 mux G */
+#define MUX_PA30G_CATB_SENSE3           _L(6)
+#define PINMUX_PA30G_CATB_SENSE3   ((PIN_PA30G_CATB_SENSE3 << 16) | MUX_PA30G_CATB_SENSE3)
+#define GPIO_PA30G_CATB_SENSE3   _UL(1 << 30)
+#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
+#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
+#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
+#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
+#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
+#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
+#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
+#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
+#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
+#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
+#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
+#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
+#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
+#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
+#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
+#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
+#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
+#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
+#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
+#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
+#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
+#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
+#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
+#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
+#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
+#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
+#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
+#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
+#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
+#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
+#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
+#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
+#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
+#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
+/* ========== GPIO definition for USBC peripheral ========== */
+#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L(0)
+#define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
+#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
+#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L(0)
+#define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
+#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+/* ========== GPIO definition for PEVC peripheral ========== */
+#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
+/* ========== GPIO definition for SCIF peripheral ========== */
+#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
+#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
+#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
+#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
+#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
+/* ========== GPIO definition for EIC peripheral ========== */
+#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
+#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
+#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
+#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
+#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
+#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
+#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
+#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
+#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
+#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
+#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+
+#endif /* _SAM4LS2A_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4ls2b.h
+++ b/asf/sam/include/sam4l/pio/sam4ls2b.h
@@ -1,0 +1,1100 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAM4LS2B
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LS2B_PIO_
+#define _SAM4LS2B_PIO_
+
+#define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
+#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
+#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
+#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
+#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
+#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
+#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
+#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
+#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
+#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
+#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
+#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
+#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
+#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
+#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
+#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
+#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
+#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
+#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
+#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
+#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
+#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
+#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
+#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
+#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
+#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
+#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
+#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
+#define GPIO_PA27                _UL(1 << 27) /**< \brief GPIO Mask  for PA27 */
+#define PIN_PA28                          28  /**< \brief Pin Number for PA28 */
+#define GPIO_PA28                _UL(1 << 28) /**< \brief GPIO Mask  for PA28 */
+#define PIN_PA29                          29  /**< \brief Pin Number for PA29 */
+#define GPIO_PA29                _UL(1 << 29) /**< \brief GPIO Mask  for PA29 */
+#define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
+#define GPIO_PA30                _UL(1 << 30) /**< \brief GPIO Mask  for PA30 */
+#define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
+#define GPIO_PA31                _UL(1 << 31) /**< \brief GPIO Mask  for PA31 */
+#define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
+#define GPIO_PB00                _UL(1 <<  0) /**< \brief GPIO Mask  for PB00 */
+#define PIN_PB01                          33  /**< \brief Pin Number for PB01 */
+#define GPIO_PB01                _UL(1 <<  1) /**< \brief GPIO Mask  for PB01 */
+#define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
+#define GPIO_PB02                _UL(1 <<  2) /**< \brief GPIO Mask  for PB02 */
+#define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
+#define GPIO_PB03                _UL(1 <<  3) /**< \brief GPIO Mask  for PB03 */
+#define PIN_PB04                          36  /**< \brief Pin Number for PB04 */
+#define GPIO_PB04                _UL(1 <<  4) /**< \brief GPIO Mask  for PB04 */
+#define PIN_PB05                          37  /**< \brief Pin Number for PB05 */
+#define GPIO_PB05                _UL(1 <<  5) /**< \brief GPIO Mask  for PB05 */
+#define PIN_PB06                          38  /**< \brief Pin Number for PB06 */
+#define GPIO_PB06                _UL(1 <<  6) /**< \brief GPIO Mask  for PB06 */
+#define PIN_PB07                          39  /**< \brief Pin Number for PB07 */
+#define GPIO_PB07                _UL(1 <<  7) /**< \brief GPIO Mask  for PB07 */
+#define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
+#define GPIO_PB08                _UL(1 <<  8) /**< \brief GPIO Mask  for PB08 */
+#define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
+#define GPIO_PB09                _UL(1 <<  9) /**< \brief GPIO Mask  for PB09 */
+#define PIN_PB10                          42  /**< \brief Pin Number for PB10 */
+#define GPIO_PB10                _UL(1 << 10) /**< \brief GPIO Mask  for PB10 */
+#define PIN_PB11                          43  /**< \brief Pin Number for PB11 */
+#define GPIO_PB11                _UL(1 << 11) /**< \brief GPIO Mask  for PB11 */
+#define PIN_PB12                          44  /**< \brief Pin Number for PB12 */
+#define GPIO_PB12                _UL(1 << 12) /**< \brief GPIO Mask  for PB12 */
+#define PIN_PB13                          45  /**< \brief Pin Number for PB13 */
+#define GPIO_PB13                _UL(1 << 13) /**< \brief GPIO Mask  for PB13 */
+#define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
+#define GPIO_PB14                _UL(1 << 14) /**< \brief GPIO Mask  for PB14 */
+#define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
+#define GPIO_PB15                _UL(1 << 15) /**< \brief GPIO Mask  for PB15 */
+/* ========== GPIO definition for TWIMS0 peripheral ========== */
+#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
+#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+/* ========== GPIO definition for TWIMS1 peripheral ========== */
+#define PIN_PB01A_TWIMS1_TWCK          _L(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
+#define MUX_PB01A_TWIMS1_TWCK           _L(0)
+#define PINMUX_PB01A_TWIMS1_TWCK   ((PIN_PB01A_TWIMS1_TWCK << 16) | MUX_PB01A_TWIMS1_TWCK)
+#define GPIO_PB01A_TWIMS1_TWCK   _UL(1 <<  1)
+#define PIN_PB00A_TWIMS1_TWD           _L(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
+#define MUX_PB00A_TWIMS1_TWD            _L(0)
+#define PINMUX_PB00A_TWIMS1_TWD    ((PIN_PB00A_TWIMS1_TWD << 16) | MUX_PB00A_TWIMS1_TWD)
+#define GPIO_PB00A_TWIMS1_TWD    _UL(1 <<  0)
+/* ========== GPIO definition for TWIMS2 peripheral ========== */
+#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
+#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+/* ========== GPIO definition for TWIMS3 peripheral ========== */
+#define PIN_PB15C_TWIMS3_TWCK          _L(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
+#define MUX_PB15C_TWIMS3_TWCK           _L(2)
+#define PINMUX_PB15C_TWIMS3_TWCK   ((PIN_PB15C_TWIMS3_TWCK << 16) | MUX_PB15C_TWIMS3_TWCK)
+#define GPIO_PB15C_TWIMS3_TWCK   _UL(1 << 15)
+#define PIN_PB14C_TWIMS3_TWD           _L(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
+#define MUX_PB14C_TWIMS3_TWD            _L(2)
+#define PINMUX_PB14C_TWIMS3_TWD    ((PIN_PB14C_TWIMS3_TWD << 16) | MUX_PB14C_TWIMS3_TWD)
+#define GPIO_PB14C_TWIMS3_TWD    _UL(1 << 14)
+/* ========== GPIO definition for IISC peripheral ========== */
+#define PIN_PB05D_IISC_IMCK            _L(37) /**< \brief IISC signal: IMCK on PB05 mux D */
+#define MUX_PB05D_IISC_IMCK             _L(3)
+#define PINMUX_PB05D_IISC_IMCK     ((PIN_PB05D_IISC_IMCK << 16) | MUX_PB05D_IISC_IMCK)
+#define GPIO_PB05D_IISC_IMCK     _UL(1 <<  5)
+#define PIN_PA31B_IISC_IMCK            _L(31) /**< \brief IISC signal: IMCK on PA31 mux B */
+#define MUX_PA31B_IISC_IMCK             _L(1)
+#define PINMUX_PA31B_IISC_IMCK     ((PIN_PA31B_IISC_IMCK << 16) | MUX_PA31B_IISC_IMCK)
+#define GPIO_PA31B_IISC_IMCK     _UL(1 << 31)
+#define PIN_PB02D_IISC_ISCK            _L(34) /**< \brief IISC signal: ISCK on PB02 mux D */
+#define MUX_PB02D_IISC_ISCK             _L(3)
+#define PINMUX_PB02D_IISC_ISCK     ((PIN_PB02D_IISC_ISCK << 16) | MUX_PB02D_IISC_ISCK)
+#define GPIO_PB02D_IISC_ISCK     _UL(1 <<  2)
+#define PIN_PA27B_IISC_ISCK            _L(27) /**< \brief IISC signal: ISCK on PA27 mux B */
+#define MUX_PA27B_IISC_ISCK             _L(1)
+#define PINMUX_PA27B_IISC_ISCK     ((PIN_PA27B_IISC_ISCK << 16) | MUX_PA27B_IISC_ISCK)
+#define GPIO_PA27B_IISC_ISCK     _UL(1 << 27)
+#define PIN_PB03D_IISC_ISDI            _L(35) /**< \brief IISC signal: ISDI on PB03 mux D */
+#define MUX_PB03D_IISC_ISDI             _L(3)
+#define PINMUX_PB03D_IISC_ISDI     ((PIN_PB03D_IISC_ISDI << 16) | MUX_PB03D_IISC_ISDI)
+#define GPIO_PB03D_IISC_ISDI     _UL(1 <<  3)
+#define PIN_PA28B_IISC_ISDI            _L(28) /**< \brief IISC signal: ISDI on PA28 mux B */
+#define MUX_PA28B_IISC_ISDI             _L(1)
+#define PINMUX_PA28B_IISC_ISDI     ((PIN_PA28B_IISC_ISDI << 16) | MUX_PA28B_IISC_ISDI)
+#define GPIO_PA28B_IISC_ISDI     _UL(1 << 28)
+#define PIN_PB04D_IISC_ISDO            _L(36) /**< \brief IISC signal: ISDO on PB04 mux D */
+#define MUX_PB04D_IISC_ISDO             _L(3)
+#define PINMUX_PB04D_IISC_ISDO     ((PIN_PB04D_IISC_ISDO << 16) | MUX_PB04D_IISC_ISDO)
+#define GPIO_PB04D_IISC_ISDO     _UL(1 <<  4)
+#define PIN_PA30B_IISC_ISDO            _L(30) /**< \brief IISC signal: ISDO on PA30 mux B */
+#define MUX_PA30B_IISC_ISDO             _L(1)
+#define PINMUX_PA30B_IISC_ISDO     ((PIN_PA30B_IISC_ISDO << 16) | MUX_PA30B_IISC_ISDO)
+#define GPIO_PA30B_IISC_ISDO     _UL(1 << 30)
+#define PIN_PB06D_IISC_IWS             _L(38) /**< \brief IISC signal: IWS on PB06 mux D */
+#define MUX_PB06D_IISC_IWS              _L(3)
+#define PINMUX_PB06D_IISC_IWS      ((PIN_PB06D_IISC_IWS << 16) | MUX_PB06D_IISC_IWS)
+#define GPIO_PB06D_IISC_IWS      _UL(1 <<  6)
+#define PIN_PA29B_IISC_IWS             _L(29) /**< \brief IISC signal: IWS on PA29 mux B */
+#define MUX_PA29B_IISC_IWS              _L(1)
+#define PINMUX_PA29B_IISC_IWS      ((PIN_PA29B_IISC_IWS << 16) | MUX_PA29B_IISC_IWS)
+#define GPIO_PA29B_IISC_IWS      _UL(1 << 29)
+/* ========== GPIO definition for SPI peripheral ========== */
+#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L(1)
+#define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
+#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
+#define PIN_PB14B_SPI_MISO             _L(46) /**< \brief SPI signal: MISO on PB14 mux B */
+#define MUX_PB14B_SPI_MISO              _L(1)
+#define PINMUX_PB14B_SPI_MISO      ((PIN_PB14B_SPI_MISO << 16) | MUX_PB14B_SPI_MISO)
+#define GPIO_PB14B_SPI_MISO      _UL(1 << 14)
+#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L(0)
+#define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
+#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
+#define PIN_PA27A_SPI_MISO             _L(27) /**< \brief SPI signal: MISO on PA27 mux A */
+#define MUX_PA27A_SPI_MISO              _L(0)
+#define PINMUX_PA27A_SPI_MISO      ((PIN_PA27A_SPI_MISO << 16) | MUX_PA27A_SPI_MISO)
+#define GPIO_PA27A_SPI_MISO      _UL(1 << 27)
+#define PIN_PB15B_SPI_MOSI             _L(47) /**< \brief SPI signal: MOSI on PB15 mux B */
+#define MUX_PB15B_SPI_MOSI              _L(1)
+#define PINMUX_PB15B_SPI_MOSI      ((PIN_PB15B_SPI_MOSI << 16) | MUX_PB15B_SPI_MOSI)
+#define GPIO_PB15B_SPI_MOSI      _UL(1 << 15)
+#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L(0)
+#define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
+#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
+#define PIN_PA28A_SPI_MOSI             _L(28) /**< \brief SPI signal: MOSI on PA28 mux A */
+#define MUX_PA28A_SPI_MOSI              _L(0)
+#define PINMUX_PA28A_SPI_MOSI      ((PIN_PA28A_SPI_MOSI << 16) | MUX_PA28A_SPI_MOSI)
+#define GPIO_PA28A_SPI_MOSI      _UL(1 << 28)
+#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
+#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
+#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
+#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
+#define PIN_PA30A_SPI_NPCS0            _L(30) /**< \brief SPI signal: NPCS0 on PA30 mux A */
+#define MUX_PA30A_SPI_NPCS0             _L(0)
+#define PINMUX_PA30A_SPI_NPCS0     ((PIN_PA30A_SPI_NPCS0 << 16) | MUX_PA30A_SPI_NPCS0)
+#define GPIO_PA30A_SPI_NPCS0     _UL(1 << 30)
+#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
+#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PB13B_SPI_NPCS1            _L(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
+#define MUX_PB13B_SPI_NPCS1             _L(1)
+#define PINMUX_PB13B_SPI_NPCS1     ((PIN_PB13B_SPI_NPCS1 << 16) | MUX_PB13B_SPI_NPCS1)
+#define GPIO_PB13B_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PA31A_SPI_NPCS1            _L(31) /**< \brief SPI signal: NPCS1 on PA31 mux A */
+#define MUX_PA31A_SPI_NPCS1             _L(0)
+#define PINMUX_PA31A_SPI_NPCS1     ((PIN_PA31A_SPI_NPCS1 << 16) | MUX_PA31A_SPI_NPCS1)
+#define GPIO_PA31A_SPI_NPCS1     _UL(1 << 31)
+#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
+#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
+#define PIN_PB11B_SPI_NPCS2            _L(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
+#define MUX_PB11B_SPI_NPCS2             _L(1)
+#define PINMUX_PB11B_SPI_NPCS2     ((PIN_PB11B_SPI_NPCS2 << 16) | MUX_PB11B_SPI_NPCS2)
+#define GPIO_PB11B_SPI_NPCS2     _UL(1 << 11)
+#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
+#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
+#define PIN_PB12B_SPI_NPCS3            _L(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
+#define MUX_PB12B_SPI_NPCS3             _L(1)
+#define PINMUX_PB12B_SPI_NPCS3     ((PIN_PB12B_SPI_NPCS3 << 16) | MUX_PB12B_SPI_NPCS3)
+#define GPIO_PB12B_SPI_NPCS3     _UL(1 << 12)
+#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L(0)
+#define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
+#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
+#define PIN_PA29A_SPI_SCK              _L(29) /**< \brief SPI signal: SCK on PA29 mux A */
+#define MUX_PA29A_SPI_SCK               _L(0)
+#define PINMUX_PA29A_SPI_SCK       ((PIN_PA29A_SPI_SCK << 16) | MUX_PA29A_SPI_SCK)
+#define GPIO_PA29A_SPI_SCK       _UL(1 << 29)
+/* ========== GPIO definition for TC0 peripheral ========== */
+#define PIN_PB07D_TC0_A0               _L(39) /**< \brief TC0 signal: A0 on PB07 mux D */
+#define MUX_PB07D_TC0_A0                _L(3)
+#define PINMUX_PB07D_TC0_A0        ((PIN_PB07D_TC0_A0 << 16) | MUX_PB07D_TC0_A0)
+#define GPIO_PB07D_TC0_A0        _UL(1 <<  7)
+#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L(1)
+#define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
+#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
+#define PIN_PB09D_TC0_A1               _L(41) /**< \brief TC0 signal: A1 on PB09 mux D */
+#define MUX_PB09D_TC0_A1                _L(3)
+#define PINMUX_PB09D_TC0_A1        ((PIN_PB09D_TC0_A1 << 16) | MUX_PB09D_TC0_A1)
+#define GPIO_PB09D_TC0_A1        _UL(1 <<  9)
+#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L(1)
+#define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
+#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
+#define PIN_PB11D_TC0_A2               _L(43) /**< \brief TC0 signal: A2 on PB11 mux D */
+#define MUX_PB11D_TC0_A2                _L(3)
+#define PINMUX_PB11D_TC0_A2        ((PIN_PB11D_TC0_A2 << 16) | MUX_PB11D_TC0_A2)
+#define GPIO_PB11D_TC0_A2        _UL(1 << 11)
+#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L(1)
+#define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
+#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
+#define PIN_PB08D_TC0_B0               _L(40) /**< \brief TC0 signal: B0 on PB08 mux D */
+#define MUX_PB08D_TC0_B0                _L(3)
+#define PINMUX_PB08D_TC0_B0        ((PIN_PB08D_TC0_B0 << 16) | MUX_PB08D_TC0_B0)
+#define GPIO_PB08D_TC0_B0        _UL(1 <<  8)
+#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L(1)
+#define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
+#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
+#define PIN_PB10D_TC0_B1               _L(42) /**< \brief TC0 signal: B1 on PB10 mux D */
+#define MUX_PB10D_TC0_B1                _L(3)
+#define PINMUX_PB10D_TC0_B1        ((PIN_PB10D_TC0_B1 << 16) | MUX_PB10D_TC0_B1)
+#define GPIO_PB10D_TC0_B1        _UL(1 << 10)
+#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L(1)
+#define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
+#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
+#define PIN_PB12D_TC0_B2               _L(44) /**< \brief TC0 signal: B2 on PB12 mux D */
+#define MUX_PB12D_TC0_B2                _L(3)
+#define PINMUX_PB12D_TC0_B2        ((PIN_PB12D_TC0_B2 << 16) | MUX_PB12D_TC0_B2)
+#define GPIO_PB12D_TC0_B2        _UL(1 << 12)
+#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L(1)
+#define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
+#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
+#define PIN_PB13D_TC0_CLK0             _L(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
+#define MUX_PB13D_TC0_CLK0              _L(3)
+#define PINMUX_PB13D_TC0_CLK0      ((PIN_PB13D_TC0_CLK0 << 16) | MUX_PB13D_TC0_CLK0)
+#define GPIO_PB13D_TC0_CLK0      _UL(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L(1)
+#define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
+#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
+#define PIN_PB14D_TC0_CLK1             _L(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
+#define MUX_PB14D_TC0_CLK1              _L(3)
+#define PINMUX_PB14D_TC0_CLK1      ((PIN_PB14D_TC0_CLK1 << 16) | MUX_PB14D_TC0_CLK1)
+#define GPIO_PB14D_TC0_CLK1      _UL(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L(1)
+#define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
+#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
+#define PIN_PB15D_TC0_CLK2             _L(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
+#define MUX_PB15D_TC0_CLK2              _L(3)
+#define PINMUX_PB15D_TC0_CLK2      ((PIN_PB15D_TC0_CLK2 << 16) | MUX_PB15D_TC0_CLK2)
+#define GPIO_PB15D_TC0_CLK2      _UL(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L(1)
+#define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
+#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+/* ========== GPIO definition for USART0 peripheral ========== */
+#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L(1)
+#define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
+#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
+#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L(0)
+#define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
+#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
+#define PIN_PB13A_USART0_CLK           _L(45) /**< \brief USART0 signal: CLK on PB13 mux A */
+#define MUX_PB13A_USART0_CLK            _L(0)
+#define PINMUX_PB13A_USART0_CLK    ((PIN_PB13A_USART0_CLK << 16) | MUX_PB13A_USART0_CLK)
+#define GPIO_PB13A_USART0_CLK    _UL(1 << 13)
+#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L(0)
+#define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
+#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
+#define PIN_PB11A_USART0_CTS           _L(43) /**< \brief USART0 signal: CTS on PB11 mux A */
+#define MUX_PB11A_USART0_CTS            _L(0)
+#define PINMUX_PB11A_USART0_CTS    ((PIN_PB11A_USART0_CTS << 16) | MUX_PB11A_USART0_CTS)
+#define GPIO_PB11A_USART0_CTS    _UL(1 << 11)
+#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L(1)
+#define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
+#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
+#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L(0)
+#define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
+#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
+#define PIN_PB12A_USART0_RTS           _L(44) /**< \brief USART0 signal: RTS on PB12 mux A */
+#define MUX_PB12A_USART0_RTS            _L(0)
+#define PINMUX_PB12A_USART0_RTS    ((PIN_PB12A_USART0_RTS << 16) | MUX_PB12A_USART0_RTS)
+#define GPIO_PB12A_USART0_RTS    _UL(1 << 12)
+#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L(1)
+#define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
+#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
+#define PIN_PB00B_USART0_RXD           _L(32) /**< \brief USART0 signal: RXD on PB00 mux B */
+#define MUX_PB00B_USART0_RXD            _L(1)
+#define PINMUX_PB00B_USART0_RXD    ((PIN_PB00B_USART0_RXD << 16) | MUX_PB00B_USART0_RXD)
+#define GPIO_PB00B_USART0_RXD    _UL(1 <<  0)
+#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L(0)
+#define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
+#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
+#define PIN_PB14A_USART0_RXD           _L(46) /**< \brief USART0 signal: RXD on PB14 mux A */
+#define MUX_PB14A_USART0_RXD            _L(0)
+#define PINMUX_PB14A_USART0_RXD    ((PIN_PB14A_USART0_RXD << 16) | MUX_PB14A_USART0_RXD)
+#define GPIO_PB14A_USART0_RXD    _UL(1 << 14)
+#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L(1)
+#define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
+#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
+#define PIN_PB01B_USART0_TXD           _L(33) /**< \brief USART0 signal: TXD on PB01 mux B */
+#define MUX_PB01B_USART0_TXD            _L(1)
+#define PINMUX_PB01B_USART0_TXD    ((PIN_PB01B_USART0_TXD << 16) | MUX_PB01B_USART0_TXD)
+#define GPIO_PB01B_USART0_TXD    _UL(1 <<  1)
+#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L(0)
+#define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
+#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
+#define PIN_PB15A_USART0_TXD           _L(47) /**< \brief USART0 signal: TXD on PB15 mux A */
+#define MUX_PB15A_USART0_TXD            _L(0)
+#define PINMUX_PB15A_USART0_TXD    ((PIN_PB15A_USART0_TXD << 16) | MUX_PB15A_USART0_TXD)
+#define GPIO_PB15A_USART0_TXD    _UL(1 << 15)
+/* ========== GPIO definition for USART1 peripheral ========== */
+#define PIN_PB03B_USART1_CLK           _L(35) /**< \brief USART1 signal: CLK on PB03 mux B */
+#define MUX_PB03B_USART1_CLK            _L(1)
+#define PINMUX_PB03B_USART1_CLK    ((PIN_PB03B_USART1_CLK << 16) | MUX_PB03B_USART1_CLK)
+#define GPIO_PB03B_USART1_CLK    _UL(1 <<  3)
+#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L(0)
+#define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
+#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
+#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L(1)
+#define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
+#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
+#define PIN_PB02B_USART1_RTS           _L(34) /**< \brief USART1 signal: RTS on PB02 mux B */
+#define MUX_PB02B_USART1_RTS            _L(1)
+#define PINMUX_PB02B_USART1_RTS    ((PIN_PB02B_USART1_RTS << 16) | MUX_PB02B_USART1_RTS)
+#define GPIO_PB02B_USART1_RTS    _UL(1 <<  2)
+#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L(0)
+#define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
+#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
+#define PIN_PB04B_USART1_RXD           _L(36) /**< \brief USART1 signal: RXD on PB04 mux B */
+#define MUX_PB04B_USART1_RXD            _L(1)
+#define PINMUX_PB04B_USART1_RXD    ((PIN_PB04B_USART1_RXD << 16) | MUX_PB04B_USART1_RXD)
+#define GPIO_PB04B_USART1_RXD    _UL(1 <<  4)
+#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L(0)
+#define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
+#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
+#define PIN_PB05B_USART1_TXD           _L(37) /**< \brief USART1 signal: TXD on PB05 mux B */
+#define MUX_PB05B_USART1_TXD            _L(1)
+#define PINMUX_PB05B_USART1_TXD    ((PIN_PB05B_USART1_TXD << 16) | MUX_PB05B_USART1_TXD)
+#define GPIO_PB05B_USART1_TXD    _UL(1 <<  5)
+#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L(0)
+#define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
+#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+/* ========== GPIO definition for USART2 peripheral ========== */
+#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L(0)
+#define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
+#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
+#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L(1)
+#define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
+#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
+#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L(0)
+#define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
+#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L(1)
+#define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
+#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
+#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L(0)
+#define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
+#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L(1)
+#define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
+#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
+#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L(0)
+#define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
+#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+/* ========== GPIO definition for USART3 peripheral ========== */
+#define PIN_PA29E_USART3_CLK           _L(29) /**< \brief USART3 signal: CLK on PA29 mux E */
+#define MUX_PA29E_USART3_CLK            _L(4)
+#define PINMUX_PA29E_USART3_CLK    ((PIN_PA29E_USART3_CLK << 16) | MUX_PA29E_USART3_CLK)
+#define GPIO_PA29E_USART3_CLK    _UL(1 << 29)
+#define PIN_PB08A_USART3_CLK           _L(40) /**< \brief USART3 signal: CLK on PB08 mux A */
+#define MUX_PB08A_USART3_CLK            _L(0)
+#define PINMUX_PB08A_USART3_CLK    ((PIN_PB08A_USART3_CLK << 16) | MUX_PB08A_USART3_CLK)
+#define GPIO_PB08A_USART3_CLK    _UL(1 <<  8)
+#define PIN_PA28E_USART3_CTS           _L(28) /**< \brief USART3 signal: CTS on PA28 mux E */
+#define MUX_PA28E_USART3_CTS            _L(4)
+#define PINMUX_PA28E_USART3_CTS    ((PIN_PA28E_USART3_CTS << 16) | MUX_PA28E_USART3_CTS)
+#define GPIO_PA28E_USART3_CTS    _UL(1 << 28)
+#define PIN_PB07A_USART3_CTS           _L(39) /**< \brief USART3 signal: CTS on PB07 mux A */
+#define MUX_PB07A_USART3_CTS            _L(0)
+#define PINMUX_PB07A_USART3_CTS    ((PIN_PB07A_USART3_CTS << 16) | MUX_PB07A_USART3_CTS)
+#define GPIO_PB07A_USART3_CTS    _UL(1 <<  7)
+#define PIN_PA27E_USART3_RTS           _L(27) /**< \brief USART3 signal: RTS on PA27 mux E */
+#define MUX_PA27E_USART3_RTS            _L(4)
+#define PINMUX_PA27E_USART3_RTS    ((PIN_PA27E_USART3_RTS << 16) | MUX_PA27E_USART3_RTS)
+#define GPIO_PA27E_USART3_RTS    _UL(1 << 27)
+#define PIN_PB06A_USART3_RTS           _L(38) /**< \brief USART3 signal: RTS on PB06 mux A */
+#define MUX_PB06A_USART3_RTS            _L(0)
+#define PINMUX_PB06A_USART3_RTS    ((PIN_PB06A_USART3_RTS << 16) | MUX_PB06A_USART3_RTS)
+#define GPIO_PB06A_USART3_RTS    _UL(1 <<  6)
+#define PIN_PA30E_USART3_RXD           _L(30) /**< \brief USART3 signal: RXD on PA30 mux E */
+#define MUX_PA30E_USART3_RXD            _L(4)
+#define PINMUX_PA30E_USART3_RXD    ((PIN_PA30E_USART3_RXD << 16) | MUX_PA30E_USART3_RXD)
+#define GPIO_PA30E_USART3_RXD    _UL(1 << 30)
+#define PIN_PB09A_USART3_RXD           _L(41) /**< \brief USART3 signal: RXD on PB09 mux A */
+#define MUX_PB09A_USART3_RXD            _L(0)
+#define PINMUX_PB09A_USART3_RXD    ((PIN_PB09A_USART3_RXD << 16) | MUX_PB09A_USART3_RXD)
+#define GPIO_PB09A_USART3_RXD    _UL(1 <<  9)
+#define PIN_PA31E_USART3_TXD           _L(31) /**< \brief USART3 signal: TXD on PA31 mux E */
+#define MUX_PA31E_USART3_TXD            _L(4)
+#define PINMUX_PA31E_USART3_TXD    ((PIN_PA31E_USART3_TXD << 16) | MUX_PA31E_USART3_TXD)
+#define GPIO_PA31E_USART3_TXD    _UL(1 << 31)
+#define PIN_PB10A_USART3_TXD           _L(42) /**< \brief USART3 signal: TXD on PB10 mux A */
+#define MUX_PB10A_USART3_TXD            _L(0)
+#define PINMUX_PB10A_USART3_TXD    ((PIN_PB10A_USART3_TXD << 16) | MUX_PB10A_USART3_TXD)
+#define GPIO_PB10A_USART3_TXD    _UL(1 << 10)
+/* ========== GPIO definition for ADCIFE peripheral ========== */
+#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
+#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
+#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
+#define PIN_PB02A_ADCIFE_AD3           _L(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
+#define MUX_PB02A_ADCIFE_AD3            _L(0)
+#define PINMUX_PB02A_ADCIFE_AD3    ((PIN_PB02A_ADCIFE_AD3 << 16) | MUX_PB02A_ADCIFE_AD3)
+#define GPIO_PB02A_ADCIFE_AD3    _UL(1 <<  2)
+#define PIN_PB03A_ADCIFE_AD4           _L(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
+#define MUX_PB03A_ADCIFE_AD4            _L(0)
+#define PINMUX_PB03A_ADCIFE_AD4    ((PIN_PB03A_ADCIFE_AD4 << 16) | MUX_PB03A_ADCIFE_AD4)
+#define GPIO_PB03A_ADCIFE_AD4    _UL(1 <<  3)
+#define PIN_PB04A_ADCIFE_AD5           _L(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
+#define MUX_PB04A_ADCIFE_AD5            _L(0)
+#define PINMUX_PB04A_ADCIFE_AD5    ((PIN_PB04A_ADCIFE_AD5 << 16) | MUX_PB04A_ADCIFE_AD5)
+#define GPIO_PB04A_ADCIFE_AD5    _UL(1 <<  4)
+#define PIN_PB05A_ADCIFE_AD6           _L(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
+#define MUX_PB05A_ADCIFE_AD6            _L(0)
+#define PINMUX_PB05A_ADCIFE_AD6    ((PIN_PB05A_ADCIFE_AD6 << 16) | MUX_PB05A_ADCIFE_AD6)
+#define GPIO_PB05A_ADCIFE_AD6    _UL(1 <<  5)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+/* ========== GPIO definition for DACC peripheral ========== */
+#define PIN_PB04E_DACC_EXT_TRIG0       _L(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
+#define MUX_PB04E_DACC_EXT_TRIG0        _L(4)
+#define PINMUX_PB04E_DACC_EXT_TRIG0  ((PIN_PB04E_DACC_EXT_TRIG0 << 16) | MUX_PB04E_DACC_EXT_TRIG0)
+#define GPIO_PB04E_DACC_EXT_TRIG0  _UL(1 <<  4)
+#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L(0)
+#define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
+#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+/* ========== GPIO definition for ACIFC peripheral ========== */
+#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
+#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
+#define PIN_PB02E_ACIFC_ACBN0          _L(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
+#define MUX_PB02E_ACIFC_ACBN0           _L(4)
+#define PINMUX_PB02E_ACIFC_ACBN0   ((PIN_PB02E_ACIFC_ACBN0 << 16) | MUX_PB02E_ACIFC_ACBN0)
+#define GPIO_PB02E_ACIFC_ACBN0   _UL(1 <<  2)
+#define PIN_PB03E_ACIFC_ACBP0          _L(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
+#define MUX_PB03E_ACIFC_ACBP0           _L(4)
+#define PINMUX_PB03E_ACIFC_ACBP0   ((PIN_PB03E_ACIFC_ACBP0 << 16) | MUX_PB03E_ACIFC_ACBP0)
+#define GPIO_PB03E_ACIFC_ACBP0   _UL(1 <<  3)
+/* ========== GPIO definition for GLOC peripheral ========== */
+#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
+#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L(3)
+#define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
+#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L(3)
+#define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
+#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L(3)
+#define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
+#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L(3)
+#define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
+#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L(3)
+#define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
+#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L(3)
+#define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
+#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L(3)
+#define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
+#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
+#define PIN_PA27D_GLOC_IN4             _L(27) /**< \brief GLOC signal: IN4 on PA27 mux D */
+#define MUX_PA27D_GLOC_IN4              _L(3)
+#define PINMUX_PA27D_GLOC_IN4      ((PIN_PA27D_GLOC_IN4 << 16) | MUX_PA27D_GLOC_IN4)
+#define GPIO_PA27D_GLOC_IN4      _UL(1 << 27)
+#define PIN_PB06C_GLOC_IN4             _L(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
+#define MUX_PB06C_GLOC_IN4              _L(2)
+#define PINMUX_PB06C_GLOC_IN4      ((PIN_PB06C_GLOC_IN4 << 16) | MUX_PB06C_GLOC_IN4)
+#define GPIO_PB06C_GLOC_IN4      _UL(1 <<  6)
+#define PIN_PA28D_GLOC_IN5             _L(28) /**< \brief GLOC signal: IN5 on PA28 mux D */
+#define MUX_PA28D_GLOC_IN5              _L(3)
+#define PINMUX_PA28D_GLOC_IN5      ((PIN_PA28D_GLOC_IN5 << 16) | MUX_PA28D_GLOC_IN5)
+#define GPIO_PA28D_GLOC_IN5      _UL(1 << 28)
+#define PIN_PB07C_GLOC_IN5             _L(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
+#define MUX_PB07C_GLOC_IN5              _L(2)
+#define PINMUX_PB07C_GLOC_IN5      ((PIN_PB07C_GLOC_IN5 << 16) | MUX_PB07C_GLOC_IN5)
+#define GPIO_PB07C_GLOC_IN5      _UL(1 <<  7)
+#define PIN_PA29D_GLOC_IN6             _L(29) /**< \brief GLOC signal: IN6 on PA29 mux D */
+#define MUX_PA29D_GLOC_IN6              _L(3)
+#define PINMUX_PA29D_GLOC_IN6      ((PIN_PA29D_GLOC_IN6 << 16) | MUX_PA29D_GLOC_IN6)
+#define GPIO_PA29D_GLOC_IN6      _UL(1 << 29)
+#define PIN_PB08C_GLOC_IN6             _L(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
+#define MUX_PB08C_GLOC_IN6              _L(2)
+#define PINMUX_PB08C_GLOC_IN6      ((PIN_PB08C_GLOC_IN6 << 16) | MUX_PB08C_GLOC_IN6)
+#define GPIO_PB08C_GLOC_IN6      _UL(1 <<  8)
+#define PIN_PA30D_GLOC_IN7             _L(30) /**< \brief GLOC signal: IN7 on PA30 mux D */
+#define MUX_PA30D_GLOC_IN7              _L(3)
+#define PINMUX_PA30D_GLOC_IN7      ((PIN_PA30D_GLOC_IN7 << 16) | MUX_PA30D_GLOC_IN7)
+#define GPIO_PA30D_GLOC_IN7      _UL(1 << 30)
+#define PIN_PB09C_GLOC_IN7             _L(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
+#define MUX_PB09C_GLOC_IN7              _L(2)
+#define PINMUX_PB09C_GLOC_IN7      ((PIN_PB09C_GLOC_IN7 << 16) | MUX_PB09C_GLOC_IN7)
+#define GPIO_PB09C_GLOC_IN7      _UL(1 <<  9)
+#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
+#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
+#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
+#define PIN_PA31D_GLOC_OUT1            _L(31) /**< \brief GLOC signal: OUT1 on PA31 mux D */
+#define MUX_PA31D_GLOC_OUT1             _L(3)
+#define PINMUX_PA31D_GLOC_OUT1     ((PIN_PA31D_GLOC_OUT1 << 16) | MUX_PA31D_GLOC_OUT1)
+#define GPIO_PA31D_GLOC_OUT1     _UL(1 << 31)
+#define PIN_PB10C_GLOC_OUT1            _L(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
+#define MUX_PB10C_GLOC_OUT1             _L(2)
+#define PINMUX_PB10C_GLOC_OUT1     ((PIN_PB10C_GLOC_OUT1 << 16) | MUX_PB10C_GLOC_OUT1)
+#define GPIO_PB10C_GLOC_OUT1     _UL(1 << 10)
+/* ========== GPIO definition for ABDACB peripheral ========== */
+#define PIN_PA31C_ABDACB_CLK           _L(31) /**< \brief ABDACB signal: CLK on PA31 mux C */
+#define MUX_PA31C_ABDACB_CLK            _L(2)
+#define PINMUX_PA31C_ABDACB_CLK    ((PIN_PA31C_ABDACB_CLK << 16) | MUX_PA31C_ABDACB_CLK)
+#define GPIO_PA31C_ABDACB_CLK    _UL(1 << 31)
+#define PIN_PA27C_ABDACB_DAC0          _L(27) /**< \brief ABDACB signal: DAC0 on PA27 mux C */
+#define MUX_PA27C_ABDACB_DAC0           _L(2)
+#define PINMUX_PA27C_ABDACB_DAC0   ((PIN_PA27C_ABDACB_DAC0 << 16) | MUX_PA27C_ABDACB_DAC0)
+#define GPIO_PA27C_ABDACB_DAC0   _UL(1 << 27)
+#define PIN_PB02C_ABDACB_DAC0          _L(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
+#define MUX_PB02C_ABDACB_DAC0           _L(2)
+#define PINMUX_PB02C_ABDACB_DAC0   ((PIN_PB02C_ABDACB_DAC0 << 16) | MUX_PB02C_ABDACB_DAC0)
+#define GPIO_PB02C_ABDACB_DAC0   _UL(1 <<  2)
+#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
+#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
+#define PIN_PA29C_ABDACB_DAC1          _L(29) /**< \brief ABDACB signal: DAC1 on PA29 mux C */
+#define MUX_PA29C_ABDACB_DAC1           _L(2)
+#define PINMUX_PA29C_ABDACB_DAC1   ((PIN_PA29C_ABDACB_DAC1 << 16) | MUX_PA29C_ABDACB_DAC1)
+#define GPIO_PA29C_ABDACB_DAC1   _UL(1 << 29)
+#define PIN_PB04C_ABDACB_DAC1          _L(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
+#define MUX_PB04C_ABDACB_DAC1           _L(2)
+#define PINMUX_PB04C_ABDACB_DAC1   ((PIN_PB04C_ABDACB_DAC1 << 16) | MUX_PB04C_ABDACB_DAC1)
+#define GPIO_PB04C_ABDACB_DAC1   _UL(1 <<  4)
+#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
+#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
+#define PIN_PA28C_ABDACB_DACN0         _L(28) /**< \brief ABDACB signal: DACN0 on PA28 mux C */
+#define MUX_PA28C_ABDACB_DACN0          _L(2)
+#define PINMUX_PA28C_ABDACB_DACN0  ((PIN_PA28C_ABDACB_DACN0 << 16) | MUX_PA28C_ABDACB_DACN0)
+#define GPIO_PA28C_ABDACB_DACN0  _UL(1 << 28)
+#define PIN_PB03C_ABDACB_DACN0         _L(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
+#define MUX_PB03C_ABDACB_DACN0          _L(2)
+#define PINMUX_PB03C_ABDACB_DACN0  ((PIN_PB03C_ABDACB_DACN0 << 16) | MUX_PB03C_ABDACB_DACN0)
+#define GPIO_PB03C_ABDACB_DACN0  _UL(1 <<  3)
+#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
+#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
+#define PIN_PA30C_ABDACB_DACN1         _L(30) /**< \brief ABDACB signal: DACN1 on PA30 mux C */
+#define MUX_PA30C_ABDACB_DACN1          _L(2)
+#define PINMUX_PA30C_ABDACB_DACN1  ((PIN_PA30C_ABDACB_DACN1 << 16) | MUX_PA30C_ABDACB_DACN1)
+#define GPIO_PA30C_ABDACB_DACN1  _UL(1 << 30)
+#define PIN_PB05C_ABDACB_DACN1         _L(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
+#define MUX_PB05C_ABDACB_DACN1          _L(2)
+#define PINMUX_PB05C_ABDACB_DACN1  ((PIN_PB05C_ABDACB_DACN1 << 16) | MUX_PB05C_ABDACB_DACN1)
+#define GPIO_PB05C_ABDACB_DACN1  _UL(1 <<  5)
+#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
+#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+/* ========== GPIO definition for PARC peripheral ========== */
+#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
+#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
+#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
+#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
+#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
+#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
+#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
+#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
+#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
+#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
+#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
+#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
+#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
+#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
+#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
+#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
+#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
+#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
+#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
+#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
+#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+/* ========== GPIO definition for CATB peripheral ========== */
+#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L(6)
+#define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
+#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L(6)
+#define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
+#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L(6)
+#define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
+#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
+#define PIN_PA31G_CATB_DIS             _L(31) /**< \brief CATB signal: DIS on PA31 mux G */
+#define MUX_PA31G_CATB_DIS              _L(6)
+#define PINMUX_PA31G_CATB_DIS      ((PIN_PA31G_CATB_DIS << 16) | MUX_PA31G_CATB_DIS)
+#define GPIO_PA31G_CATB_DIS      _UL(1 << 31)
+#define PIN_PB03G_CATB_DIS             _L(35) /**< \brief CATB signal: DIS on PB03 mux G */
+#define MUX_PB03G_CATB_DIS              _L(6)
+#define PINMUX_PB03G_CATB_DIS      ((PIN_PB03G_CATB_DIS << 16) | MUX_PB03G_CATB_DIS)
+#define GPIO_PB03G_CATB_DIS      _UL(1 <<  3)
+#define PIN_PB12G_CATB_DIS             _L(44) /**< \brief CATB signal: DIS on PB12 mux G */
+#define MUX_PB12G_CATB_DIS              _L(6)
+#define PINMUX_PB12G_CATB_DIS      ((PIN_PB12G_CATB_DIS << 16) | MUX_PB12G_CATB_DIS)
+#define GPIO_PB12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
+#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
+#define PIN_PA27G_CATB_SENSE0          _L(27) /**< \brief CATB signal: SENSE0 on PA27 mux G */
+#define MUX_PA27G_CATB_SENSE0           _L(6)
+#define PINMUX_PA27G_CATB_SENSE0   ((PIN_PA27G_CATB_SENSE0 << 16) | MUX_PA27G_CATB_SENSE0)
+#define GPIO_PA27G_CATB_SENSE0   _UL(1 << 27)
+#define PIN_PB13G_CATB_SENSE0          _L(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
+#define MUX_PB13G_CATB_SENSE0           _L(6)
+#define PINMUX_PB13G_CATB_SENSE0   ((PIN_PB13G_CATB_SENSE0 << 16) | MUX_PB13G_CATB_SENSE0)
+#define GPIO_PB13G_CATB_SENSE0   _UL(1 << 13)
+#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
+#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
+#define PIN_PA28G_CATB_SENSE1          _L(28) /**< \brief CATB signal: SENSE1 on PA28 mux G */
+#define MUX_PA28G_CATB_SENSE1           _L(6)
+#define PINMUX_PA28G_CATB_SENSE1   ((PIN_PA28G_CATB_SENSE1 << 16) | MUX_PA28G_CATB_SENSE1)
+#define GPIO_PA28G_CATB_SENSE1   _UL(1 << 28)
+#define PIN_PB14G_CATB_SENSE1          _L(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
+#define MUX_PB14G_CATB_SENSE1           _L(6)
+#define PINMUX_PB14G_CATB_SENSE1   ((PIN_PB14G_CATB_SENSE1 << 16) | MUX_PB14G_CATB_SENSE1)
+#define GPIO_PB14G_CATB_SENSE1   _UL(1 << 14)
+#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
+#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
+#define PIN_PA29G_CATB_SENSE2          _L(29) /**< \brief CATB signal: SENSE2 on PA29 mux G */
+#define MUX_PA29G_CATB_SENSE2           _L(6)
+#define PINMUX_PA29G_CATB_SENSE2   ((PIN_PA29G_CATB_SENSE2 << 16) | MUX_PA29G_CATB_SENSE2)
+#define GPIO_PA29G_CATB_SENSE2   _UL(1 << 29)
+#define PIN_PB15G_CATB_SENSE2          _L(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
+#define MUX_PB15G_CATB_SENSE2           _L(6)
+#define PINMUX_PB15G_CATB_SENSE2   ((PIN_PB15G_CATB_SENSE2 << 16) | MUX_PB15G_CATB_SENSE2)
+#define GPIO_PB15G_CATB_SENSE2   _UL(1 << 15)
+#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
+#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
+#define PIN_PA30G_CATB_SENSE3          _L(30) /**< \brief CATB signal: SENSE3 on PA30 mux G */
+#define MUX_PA30G_CATB_SENSE3           _L(6)
+#define PINMUX_PA30G_CATB_SENSE3   ((PIN_PA30G_CATB_SENSE3 << 16) | MUX_PA30G_CATB_SENSE3)
+#define GPIO_PA30G_CATB_SENSE3   _UL(1 << 30)
+#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
+#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
+#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
+#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
+#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
+#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
+#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
+#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
+#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
+#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
+#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
+#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
+#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
+#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
+#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
+#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
+#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
+#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
+#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
+#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
+#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
+#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
+#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
+#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
+#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
+#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
+#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
+#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
+#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
+#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
+#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
+#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
+#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
+#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
+#define PIN_PB00G_CATB_SENSE21         _L(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
+#define MUX_PB00G_CATB_SENSE21          _L(6)
+#define PINMUX_PB00G_CATB_SENSE21  ((PIN_PB00G_CATB_SENSE21 << 16) | MUX_PB00G_CATB_SENSE21)
+#define GPIO_PB00G_CATB_SENSE21  _UL(1 <<  0)
+#define PIN_PB01G_CATB_SENSE22         _L(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
+#define MUX_PB01G_CATB_SENSE22          _L(6)
+#define PINMUX_PB01G_CATB_SENSE22  ((PIN_PB01G_CATB_SENSE22 << 16) | MUX_PB01G_CATB_SENSE22)
+#define GPIO_PB01G_CATB_SENSE22  _UL(1 <<  1)
+#define PIN_PB02G_CATB_SENSE23         _L(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
+#define MUX_PB02G_CATB_SENSE23          _L(6)
+#define PINMUX_PB02G_CATB_SENSE23  ((PIN_PB02G_CATB_SENSE23 << 16) | MUX_PB02G_CATB_SENSE23)
+#define GPIO_PB02G_CATB_SENSE23  _UL(1 <<  2)
+#define PIN_PB04G_CATB_SENSE24         _L(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
+#define MUX_PB04G_CATB_SENSE24          _L(6)
+#define PINMUX_PB04G_CATB_SENSE24  ((PIN_PB04G_CATB_SENSE24 << 16) | MUX_PB04G_CATB_SENSE24)
+#define GPIO_PB04G_CATB_SENSE24  _UL(1 <<  4)
+#define PIN_PB05G_CATB_SENSE25         _L(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
+#define MUX_PB05G_CATB_SENSE25          _L(6)
+#define PINMUX_PB05G_CATB_SENSE25  ((PIN_PB05G_CATB_SENSE25 << 16) | MUX_PB05G_CATB_SENSE25)
+#define GPIO_PB05G_CATB_SENSE25  _UL(1 <<  5)
+#define PIN_PB06G_CATB_SENSE26         _L(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
+#define MUX_PB06G_CATB_SENSE26          _L(6)
+#define PINMUX_PB06G_CATB_SENSE26  ((PIN_PB06G_CATB_SENSE26 << 16) | MUX_PB06G_CATB_SENSE26)
+#define GPIO_PB06G_CATB_SENSE26  _UL(1 <<  6)
+#define PIN_PB07G_CATB_SENSE27         _L(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
+#define MUX_PB07G_CATB_SENSE27          _L(6)
+#define PINMUX_PB07G_CATB_SENSE27  ((PIN_PB07G_CATB_SENSE27 << 16) | MUX_PB07G_CATB_SENSE27)
+#define GPIO_PB07G_CATB_SENSE27  _UL(1 <<  7)
+#define PIN_PB08G_CATB_SENSE28         _L(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
+#define MUX_PB08G_CATB_SENSE28          _L(6)
+#define PINMUX_PB08G_CATB_SENSE28  ((PIN_PB08G_CATB_SENSE28 << 16) | MUX_PB08G_CATB_SENSE28)
+#define GPIO_PB08G_CATB_SENSE28  _UL(1 <<  8)
+#define PIN_PB09G_CATB_SENSE29         _L(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
+#define MUX_PB09G_CATB_SENSE29          _L(6)
+#define PINMUX_PB09G_CATB_SENSE29  ((PIN_PB09G_CATB_SENSE29 << 16) | MUX_PB09G_CATB_SENSE29)
+#define GPIO_PB09G_CATB_SENSE29  _UL(1 <<  9)
+#define PIN_PB10G_CATB_SENSE30         _L(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
+#define MUX_PB10G_CATB_SENSE30          _L(6)
+#define PINMUX_PB10G_CATB_SENSE30  ((PIN_PB10G_CATB_SENSE30 << 16) | MUX_PB10G_CATB_SENSE30)
+#define GPIO_PB10G_CATB_SENSE30  _UL(1 << 10)
+#define PIN_PB11G_CATB_SENSE31         _L(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
+#define MUX_PB11G_CATB_SENSE31          _L(6)
+#define PINMUX_PB11G_CATB_SENSE31  ((PIN_PB11G_CATB_SENSE31 << 16) | MUX_PB11G_CATB_SENSE31)
+#define GPIO_PB11G_CATB_SENSE31  _UL(1 << 11)
+/* ========== GPIO definition for USBC peripheral ========== */
+#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L(0)
+#define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
+#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
+#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L(0)
+#define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
+#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+/* ========== GPIO definition for PEVC peripheral ========== */
+#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
+#define PIN_PB12C_PEVC_PAD_EVT0        _L(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
+#define MUX_PB12C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PB12C_PEVC_PAD_EVT0  ((PIN_PB12C_PEVC_PAD_EVT0 << 16) | MUX_PB12C_PEVC_PAD_EVT0)
+#define GPIO_PB12C_PEVC_PAD_EVT0  _UL(1 << 12)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
+#define PIN_PB13C_PEVC_PAD_EVT1        _L(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
+#define MUX_PB13C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PB13C_PEVC_PAD_EVT1  ((PIN_PB13C_PEVC_PAD_EVT1 << 16) | MUX_PB13C_PEVC_PAD_EVT1)
+#define GPIO_PB13C_PEVC_PAD_EVT1  _UL(1 << 13)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
+#define PIN_PB09B_PEVC_PAD_EVT2        _L(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
+#define MUX_PB09B_PEVC_PAD_EVT2         _L(1)
+#define PINMUX_PB09B_PEVC_PAD_EVT2  ((PIN_PB09B_PEVC_PAD_EVT2 << 16) | MUX_PB09B_PEVC_PAD_EVT2)
+#define GPIO_PB09B_PEVC_PAD_EVT2  _UL(1 <<  9)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
+#define PIN_PB10B_PEVC_PAD_EVT3        _L(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
+#define MUX_PB10B_PEVC_PAD_EVT3         _L(1)
+#define PINMUX_PB10B_PEVC_PAD_EVT3  ((PIN_PB10B_PEVC_PAD_EVT3 << 16) | MUX_PB10B_PEVC_PAD_EVT3)
+#define GPIO_PB10B_PEVC_PAD_EVT3  _UL(1 << 10)
+/* ========== GPIO definition for SCIF peripheral ========== */
+#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
+#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
+#define PIN_PB10E_SCIF_GCLK0           _L(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
+#define MUX_PB10E_SCIF_GCLK0            _L(4)
+#define PINMUX_PB10E_SCIF_GCLK0    ((PIN_PB10E_SCIF_GCLK0 << 16) | MUX_PB10E_SCIF_GCLK0)
+#define GPIO_PB10E_SCIF_GCLK0    _UL(1 << 10)
+#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
+#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
+#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
+#define PIN_PB11E_SCIF_GCLK1           _L(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
+#define MUX_PB11E_SCIF_GCLK1            _L(4)
+#define PINMUX_PB11E_SCIF_GCLK1    ((PIN_PB11E_SCIF_GCLK1 << 16) | MUX_PB11E_SCIF_GCLK1)
+#define GPIO_PB11E_SCIF_GCLK1    _UL(1 << 11)
+#define PIN_PB12E_SCIF_GCLK2           _L(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
+#define MUX_PB12E_SCIF_GCLK2            _L(4)
+#define PINMUX_PB12E_SCIF_GCLK2    ((PIN_PB12E_SCIF_GCLK2 << 16) | MUX_PB12E_SCIF_GCLK2)
+#define GPIO_PB12E_SCIF_GCLK2    _UL(1 << 12)
+#define PIN_PB13E_SCIF_GCLK3           _L(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
+#define MUX_PB13E_SCIF_GCLK3            _L(4)
+#define PINMUX_PB13E_SCIF_GCLK3    ((PIN_PB13E_SCIF_GCLK3 << 16) | MUX_PB13E_SCIF_GCLK3)
+#define GPIO_PB13E_SCIF_GCLK3    _UL(1 << 13)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
+#define PIN_PB14E_SCIF_GCLK_IN0        _L(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
+#define MUX_PB14E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PB14E_SCIF_GCLK_IN0  ((PIN_PB14E_SCIF_GCLK_IN0 << 16) | MUX_PB14E_SCIF_GCLK_IN0)
+#define GPIO_PB14E_SCIF_GCLK_IN0  _UL(1 << 14)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
+#define PIN_PB15E_SCIF_GCLK_IN1        _L(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
+#define MUX_PB15E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PB15E_SCIF_GCLK_IN1  ((PIN_PB15E_SCIF_GCLK_IN1 << 16) | MUX_PB15E_SCIF_GCLK_IN1)
+#define GPIO_PB15E_SCIF_GCLK_IN1  _UL(1 << 15)
+/* ========== GPIO definition for EIC peripheral ========== */
+#define PIN_PB01C_EIC_EXTINT0          _L(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
+#define MUX_PB01C_EIC_EXTINT0           _L(2)
+#define PINMUX_PB01C_EIC_EXTINT0   ((PIN_PB01C_EIC_EXTINT0 << 16) | MUX_PB01C_EIC_EXTINT0)
+#define GPIO_PB01C_EIC_EXTINT0   _UL(1 <<  1)
+#define PIN_PB01C_EIC_EXTINT_NUM        _L(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
+#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
+#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
+#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
+#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
+#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
+#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
+#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
+#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
+#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
+#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+
+#endif /* _SAM4LS2B_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4ls2b.h
+++ b/asf/sam/include/sam4l/pio/sam4ls2b.h
@@ -30,1071 +30,1071 @@
 #define _SAM4LS2B_PIO_
 
 #define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
-#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define GPIO_PA00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PA00 */
 #define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
-#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define GPIO_PA01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PA01 */
 #define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
-#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define GPIO_PA02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PA02 */
 #define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
-#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define GPIO_PA03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PA03 */
 #define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
-#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define GPIO_PA04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PA04 */
 #define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
-#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define GPIO_PA05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PA05 */
 #define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
-#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define GPIO_PA06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PA06 */
 #define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
-#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define GPIO_PA07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PA07 */
 #define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
-#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define GPIO_PA08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PA08 */
 #define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
-#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define GPIO_PA09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PA09 */
 #define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
-#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define GPIO_PA10                _UL_(1 << 10) /**< \brief GPIO Mask  for PA10 */
 #define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
-#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define GPIO_PA11                _UL_(1 << 11) /**< \brief GPIO Mask  for PA11 */
 #define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
-#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define GPIO_PA12                _UL_(1 << 12) /**< \brief GPIO Mask  for PA12 */
 #define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
-#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define GPIO_PA13                _UL_(1 << 13) /**< \brief GPIO Mask  for PA13 */
 #define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
-#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define GPIO_PA14                _UL_(1 << 14) /**< \brief GPIO Mask  for PA14 */
 #define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
-#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define GPIO_PA15                _UL_(1 << 15) /**< \brief GPIO Mask  for PA15 */
 #define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
-#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define GPIO_PA16                _UL_(1 << 16) /**< \brief GPIO Mask  for PA16 */
 #define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
-#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define GPIO_PA17                _UL_(1 << 17) /**< \brief GPIO Mask  for PA17 */
 #define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
-#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define GPIO_PA18                _UL_(1 << 18) /**< \brief GPIO Mask  for PA18 */
 #define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
-#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define GPIO_PA19                _UL_(1 << 19) /**< \brief GPIO Mask  for PA19 */
 #define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
-#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define GPIO_PA20                _UL_(1 << 20) /**< \brief GPIO Mask  for PA20 */
 #define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
-#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define GPIO_PA21                _UL_(1 << 21) /**< \brief GPIO Mask  for PA21 */
 #define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
-#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define GPIO_PA22                _UL_(1 << 22) /**< \brief GPIO Mask  for PA22 */
 #define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
-#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define GPIO_PA23                _UL_(1 << 23) /**< \brief GPIO Mask  for PA23 */
 #define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
-#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define GPIO_PA24                _UL_(1 << 24) /**< \brief GPIO Mask  for PA24 */
 #define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
-#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define GPIO_PA25                _UL_(1 << 25) /**< \brief GPIO Mask  for PA25 */
 #define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
-#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define GPIO_PA26                _UL_(1 << 26) /**< \brief GPIO Mask  for PA26 */
 #define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
-#define GPIO_PA27                _UL(1 << 27) /**< \brief GPIO Mask  for PA27 */
+#define GPIO_PA27                _UL_(1 << 27) /**< \brief GPIO Mask  for PA27 */
 #define PIN_PA28                          28  /**< \brief Pin Number for PA28 */
-#define GPIO_PA28                _UL(1 << 28) /**< \brief GPIO Mask  for PA28 */
+#define GPIO_PA28                _UL_(1 << 28) /**< \brief GPIO Mask  for PA28 */
 #define PIN_PA29                          29  /**< \brief Pin Number for PA29 */
-#define GPIO_PA29                _UL(1 << 29) /**< \brief GPIO Mask  for PA29 */
+#define GPIO_PA29                _UL_(1 << 29) /**< \brief GPIO Mask  for PA29 */
 #define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
-#define GPIO_PA30                _UL(1 << 30) /**< \brief GPIO Mask  for PA30 */
+#define GPIO_PA30                _UL_(1 << 30) /**< \brief GPIO Mask  for PA30 */
 #define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
-#define GPIO_PA31                _UL(1 << 31) /**< \brief GPIO Mask  for PA31 */
+#define GPIO_PA31                _UL_(1 << 31) /**< \brief GPIO Mask  for PA31 */
 #define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
-#define GPIO_PB00                _UL(1 <<  0) /**< \brief GPIO Mask  for PB00 */
+#define GPIO_PB00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PB00 */
 #define PIN_PB01                          33  /**< \brief Pin Number for PB01 */
-#define GPIO_PB01                _UL(1 <<  1) /**< \brief GPIO Mask  for PB01 */
+#define GPIO_PB01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PB01 */
 #define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
-#define GPIO_PB02                _UL(1 <<  2) /**< \brief GPIO Mask  for PB02 */
+#define GPIO_PB02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PB02 */
 #define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
-#define GPIO_PB03                _UL(1 <<  3) /**< \brief GPIO Mask  for PB03 */
+#define GPIO_PB03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PB03 */
 #define PIN_PB04                          36  /**< \brief Pin Number for PB04 */
-#define GPIO_PB04                _UL(1 <<  4) /**< \brief GPIO Mask  for PB04 */
+#define GPIO_PB04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PB04 */
 #define PIN_PB05                          37  /**< \brief Pin Number for PB05 */
-#define GPIO_PB05                _UL(1 <<  5) /**< \brief GPIO Mask  for PB05 */
+#define GPIO_PB05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PB05 */
 #define PIN_PB06                          38  /**< \brief Pin Number for PB06 */
-#define GPIO_PB06                _UL(1 <<  6) /**< \brief GPIO Mask  for PB06 */
+#define GPIO_PB06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PB06 */
 #define PIN_PB07                          39  /**< \brief Pin Number for PB07 */
-#define GPIO_PB07                _UL(1 <<  7) /**< \brief GPIO Mask  for PB07 */
+#define GPIO_PB07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PB07 */
 #define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
-#define GPIO_PB08                _UL(1 <<  8) /**< \brief GPIO Mask  for PB08 */
+#define GPIO_PB08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PB08 */
 #define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
-#define GPIO_PB09                _UL(1 <<  9) /**< \brief GPIO Mask  for PB09 */
+#define GPIO_PB09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PB09 */
 #define PIN_PB10                          42  /**< \brief Pin Number for PB10 */
-#define GPIO_PB10                _UL(1 << 10) /**< \brief GPIO Mask  for PB10 */
+#define GPIO_PB10                _UL_(1 << 10) /**< \brief GPIO Mask  for PB10 */
 #define PIN_PB11                          43  /**< \brief Pin Number for PB11 */
-#define GPIO_PB11                _UL(1 << 11) /**< \brief GPIO Mask  for PB11 */
+#define GPIO_PB11                _UL_(1 << 11) /**< \brief GPIO Mask  for PB11 */
 #define PIN_PB12                          44  /**< \brief Pin Number for PB12 */
-#define GPIO_PB12                _UL(1 << 12) /**< \brief GPIO Mask  for PB12 */
+#define GPIO_PB12                _UL_(1 << 12) /**< \brief GPIO Mask  for PB12 */
 #define PIN_PB13                          45  /**< \brief Pin Number for PB13 */
-#define GPIO_PB13                _UL(1 << 13) /**< \brief GPIO Mask  for PB13 */
+#define GPIO_PB13                _UL_(1 << 13) /**< \brief GPIO Mask  for PB13 */
 #define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
-#define GPIO_PB14                _UL(1 << 14) /**< \brief GPIO Mask  for PB14 */
+#define GPIO_PB14                _UL_(1 << 14) /**< \brief GPIO Mask  for PB14 */
 #define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
-#define GPIO_PB15                _UL(1 << 15) /**< \brief GPIO Mask  for PB15 */
+#define GPIO_PB15                _UL_(1 << 15) /**< \brief GPIO Mask  for PB15 */
 /* ========== GPIO definition for TWIMS0 peripheral ========== */
-#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
-#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PIN_PA24B_TWIMS0_TWCK          _L_(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L_(1)
 #define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
-#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
-#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
-#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL_(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L_(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L_(1)
 #define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
-#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+#define GPIO_PA23B_TWIMS0_TWD    _UL_(1 << 23)
 /* ========== GPIO definition for TWIMS1 peripheral ========== */
-#define PIN_PB01A_TWIMS1_TWCK          _L(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
-#define MUX_PB01A_TWIMS1_TWCK           _L(0)
+#define PIN_PB01A_TWIMS1_TWCK          _L_(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
+#define MUX_PB01A_TWIMS1_TWCK           _L_(0)
 #define PINMUX_PB01A_TWIMS1_TWCK   ((PIN_PB01A_TWIMS1_TWCK << 16) | MUX_PB01A_TWIMS1_TWCK)
-#define GPIO_PB01A_TWIMS1_TWCK   _UL(1 <<  1)
-#define PIN_PB00A_TWIMS1_TWD           _L(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
-#define MUX_PB00A_TWIMS1_TWD            _L(0)
+#define GPIO_PB01A_TWIMS1_TWCK   _UL_(1 <<  1)
+#define PIN_PB00A_TWIMS1_TWD           _L_(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
+#define MUX_PB00A_TWIMS1_TWD            _L_(0)
 #define PINMUX_PB00A_TWIMS1_TWD    ((PIN_PB00A_TWIMS1_TWD << 16) | MUX_PB00A_TWIMS1_TWD)
-#define GPIO_PB00A_TWIMS1_TWD    _UL(1 <<  0)
+#define GPIO_PB00A_TWIMS1_TWD    _UL_(1 <<  0)
 /* ========== GPIO definition for TWIMS2 peripheral ========== */
-#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
-#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PIN_PA22E_TWIMS2_TWCK          _L_(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L_(4)
 #define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
-#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
-#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
-#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL_(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L_(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L_(4)
 #define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
-#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+#define GPIO_PA21E_TWIMS2_TWD    _UL_(1 << 21)
 /* ========== GPIO definition for TWIMS3 peripheral ========== */
-#define PIN_PB15C_TWIMS3_TWCK          _L(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
-#define MUX_PB15C_TWIMS3_TWCK           _L(2)
+#define PIN_PB15C_TWIMS3_TWCK          _L_(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
+#define MUX_PB15C_TWIMS3_TWCK           _L_(2)
 #define PINMUX_PB15C_TWIMS3_TWCK   ((PIN_PB15C_TWIMS3_TWCK << 16) | MUX_PB15C_TWIMS3_TWCK)
-#define GPIO_PB15C_TWIMS3_TWCK   _UL(1 << 15)
-#define PIN_PB14C_TWIMS3_TWD           _L(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
-#define MUX_PB14C_TWIMS3_TWD            _L(2)
+#define GPIO_PB15C_TWIMS3_TWCK   _UL_(1 << 15)
+#define PIN_PB14C_TWIMS3_TWD           _L_(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
+#define MUX_PB14C_TWIMS3_TWD            _L_(2)
 #define PINMUX_PB14C_TWIMS3_TWD    ((PIN_PB14C_TWIMS3_TWD << 16) | MUX_PB14C_TWIMS3_TWD)
-#define GPIO_PB14C_TWIMS3_TWD    _UL(1 << 14)
+#define GPIO_PB14C_TWIMS3_TWD    _UL_(1 << 14)
 /* ========== GPIO definition for IISC peripheral ========== */
-#define PIN_PB05D_IISC_IMCK            _L(37) /**< \brief IISC signal: IMCK on PB05 mux D */
-#define MUX_PB05D_IISC_IMCK             _L(3)
+#define PIN_PB05D_IISC_IMCK            _L_(37) /**< \brief IISC signal: IMCK on PB05 mux D */
+#define MUX_PB05D_IISC_IMCK             _L_(3)
 #define PINMUX_PB05D_IISC_IMCK     ((PIN_PB05D_IISC_IMCK << 16) | MUX_PB05D_IISC_IMCK)
-#define GPIO_PB05D_IISC_IMCK     _UL(1 <<  5)
-#define PIN_PA31B_IISC_IMCK            _L(31) /**< \brief IISC signal: IMCK on PA31 mux B */
-#define MUX_PA31B_IISC_IMCK             _L(1)
+#define GPIO_PB05D_IISC_IMCK     _UL_(1 <<  5)
+#define PIN_PA31B_IISC_IMCK            _L_(31) /**< \brief IISC signal: IMCK on PA31 mux B */
+#define MUX_PA31B_IISC_IMCK             _L_(1)
 #define PINMUX_PA31B_IISC_IMCK     ((PIN_PA31B_IISC_IMCK << 16) | MUX_PA31B_IISC_IMCK)
-#define GPIO_PA31B_IISC_IMCK     _UL(1 << 31)
-#define PIN_PB02D_IISC_ISCK            _L(34) /**< \brief IISC signal: ISCK on PB02 mux D */
-#define MUX_PB02D_IISC_ISCK             _L(3)
+#define GPIO_PA31B_IISC_IMCK     _UL_(1 << 31)
+#define PIN_PB02D_IISC_ISCK            _L_(34) /**< \brief IISC signal: ISCK on PB02 mux D */
+#define MUX_PB02D_IISC_ISCK             _L_(3)
 #define PINMUX_PB02D_IISC_ISCK     ((PIN_PB02D_IISC_ISCK << 16) | MUX_PB02D_IISC_ISCK)
-#define GPIO_PB02D_IISC_ISCK     _UL(1 <<  2)
-#define PIN_PA27B_IISC_ISCK            _L(27) /**< \brief IISC signal: ISCK on PA27 mux B */
-#define MUX_PA27B_IISC_ISCK             _L(1)
+#define GPIO_PB02D_IISC_ISCK     _UL_(1 <<  2)
+#define PIN_PA27B_IISC_ISCK            _L_(27) /**< \brief IISC signal: ISCK on PA27 mux B */
+#define MUX_PA27B_IISC_ISCK             _L_(1)
 #define PINMUX_PA27B_IISC_ISCK     ((PIN_PA27B_IISC_ISCK << 16) | MUX_PA27B_IISC_ISCK)
-#define GPIO_PA27B_IISC_ISCK     _UL(1 << 27)
-#define PIN_PB03D_IISC_ISDI            _L(35) /**< \brief IISC signal: ISDI on PB03 mux D */
-#define MUX_PB03D_IISC_ISDI             _L(3)
+#define GPIO_PA27B_IISC_ISCK     _UL_(1 << 27)
+#define PIN_PB03D_IISC_ISDI            _L_(35) /**< \brief IISC signal: ISDI on PB03 mux D */
+#define MUX_PB03D_IISC_ISDI             _L_(3)
 #define PINMUX_PB03D_IISC_ISDI     ((PIN_PB03D_IISC_ISDI << 16) | MUX_PB03D_IISC_ISDI)
-#define GPIO_PB03D_IISC_ISDI     _UL(1 <<  3)
-#define PIN_PA28B_IISC_ISDI            _L(28) /**< \brief IISC signal: ISDI on PA28 mux B */
-#define MUX_PA28B_IISC_ISDI             _L(1)
+#define GPIO_PB03D_IISC_ISDI     _UL_(1 <<  3)
+#define PIN_PA28B_IISC_ISDI            _L_(28) /**< \brief IISC signal: ISDI on PA28 mux B */
+#define MUX_PA28B_IISC_ISDI             _L_(1)
 #define PINMUX_PA28B_IISC_ISDI     ((PIN_PA28B_IISC_ISDI << 16) | MUX_PA28B_IISC_ISDI)
-#define GPIO_PA28B_IISC_ISDI     _UL(1 << 28)
-#define PIN_PB04D_IISC_ISDO            _L(36) /**< \brief IISC signal: ISDO on PB04 mux D */
-#define MUX_PB04D_IISC_ISDO             _L(3)
+#define GPIO_PA28B_IISC_ISDI     _UL_(1 << 28)
+#define PIN_PB04D_IISC_ISDO            _L_(36) /**< \brief IISC signal: ISDO on PB04 mux D */
+#define MUX_PB04D_IISC_ISDO             _L_(3)
 #define PINMUX_PB04D_IISC_ISDO     ((PIN_PB04D_IISC_ISDO << 16) | MUX_PB04D_IISC_ISDO)
-#define GPIO_PB04D_IISC_ISDO     _UL(1 <<  4)
-#define PIN_PA30B_IISC_ISDO            _L(30) /**< \brief IISC signal: ISDO on PA30 mux B */
-#define MUX_PA30B_IISC_ISDO             _L(1)
+#define GPIO_PB04D_IISC_ISDO     _UL_(1 <<  4)
+#define PIN_PA30B_IISC_ISDO            _L_(30) /**< \brief IISC signal: ISDO on PA30 mux B */
+#define MUX_PA30B_IISC_ISDO             _L_(1)
 #define PINMUX_PA30B_IISC_ISDO     ((PIN_PA30B_IISC_ISDO << 16) | MUX_PA30B_IISC_ISDO)
-#define GPIO_PA30B_IISC_ISDO     _UL(1 << 30)
-#define PIN_PB06D_IISC_IWS             _L(38) /**< \brief IISC signal: IWS on PB06 mux D */
-#define MUX_PB06D_IISC_IWS              _L(3)
+#define GPIO_PA30B_IISC_ISDO     _UL_(1 << 30)
+#define PIN_PB06D_IISC_IWS             _L_(38) /**< \brief IISC signal: IWS on PB06 mux D */
+#define MUX_PB06D_IISC_IWS              _L_(3)
 #define PINMUX_PB06D_IISC_IWS      ((PIN_PB06D_IISC_IWS << 16) | MUX_PB06D_IISC_IWS)
-#define GPIO_PB06D_IISC_IWS      _UL(1 <<  6)
-#define PIN_PA29B_IISC_IWS             _L(29) /**< \brief IISC signal: IWS on PA29 mux B */
-#define MUX_PA29B_IISC_IWS              _L(1)
+#define GPIO_PB06D_IISC_IWS      _UL_(1 <<  6)
+#define PIN_PA29B_IISC_IWS             _L_(29) /**< \brief IISC signal: IWS on PA29 mux B */
+#define MUX_PA29B_IISC_IWS              _L_(1)
 #define PINMUX_PA29B_IISC_IWS      ((PIN_PA29B_IISC_IWS << 16) | MUX_PA29B_IISC_IWS)
-#define GPIO_PA29B_IISC_IWS      _UL(1 << 29)
+#define GPIO_PA29B_IISC_IWS      _UL_(1 << 29)
 /* ========== GPIO definition for SPI peripheral ========== */
-#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
-#define MUX_PA03B_SPI_MISO              _L(1)
+#define PIN_PA03B_SPI_MISO              _L_(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L_(1)
 #define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
-#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
-#define PIN_PB14B_SPI_MISO             _L(46) /**< \brief SPI signal: MISO on PB14 mux B */
-#define MUX_PB14B_SPI_MISO              _L(1)
+#define GPIO_PA03B_SPI_MISO      _UL_(1 <<  3)
+#define PIN_PB14B_SPI_MISO             _L_(46) /**< \brief SPI signal: MISO on PB14 mux B */
+#define MUX_PB14B_SPI_MISO              _L_(1)
 #define PINMUX_PB14B_SPI_MISO      ((PIN_PB14B_SPI_MISO << 16) | MUX_PB14B_SPI_MISO)
-#define GPIO_PB14B_SPI_MISO      _UL(1 << 14)
-#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
-#define MUX_PA21A_SPI_MISO              _L(0)
+#define GPIO_PB14B_SPI_MISO      _UL_(1 << 14)
+#define PIN_PA21A_SPI_MISO             _L_(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L_(0)
 #define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
-#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
-#define PIN_PA27A_SPI_MISO             _L(27) /**< \brief SPI signal: MISO on PA27 mux A */
-#define MUX_PA27A_SPI_MISO              _L(0)
+#define GPIO_PA21A_SPI_MISO      _UL_(1 << 21)
+#define PIN_PA27A_SPI_MISO             _L_(27) /**< \brief SPI signal: MISO on PA27 mux A */
+#define MUX_PA27A_SPI_MISO              _L_(0)
 #define PINMUX_PA27A_SPI_MISO      ((PIN_PA27A_SPI_MISO << 16) | MUX_PA27A_SPI_MISO)
-#define GPIO_PA27A_SPI_MISO      _UL(1 << 27)
-#define PIN_PB15B_SPI_MOSI             _L(47) /**< \brief SPI signal: MOSI on PB15 mux B */
-#define MUX_PB15B_SPI_MOSI              _L(1)
+#define GPIO_PA27A_SPI_MISO      _UL_(1 << 27)
+#define PIN_PB15B_SPI_MOSI             _L_(47) /**< \brief SPI signal: MOSI on PB15 mux B */
+#define MUX_PB15B_SPI_MOSI              _L_(1)
 #define PINMUX_PB15B_SPI_MOSI      ((PIN_PB15B_SPI_MOSI << 16) | MUX_PB15B_SPI_MOSI)
-#define GPIO_PB15B_SPI_MOSI      _UL(1 << 15)
-#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
-#define MUX_PA22A_SPI_MOSI              _L(0)
+#define GPIO_PB15B_SPI_MOSI      _UL_(1 << 15)
+#define PIN_PA22A_SPI_MOSI             _L_(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L_(0)
 #define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
-#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
-#define PIN_PA28A_SPI_MOSI             _L(28) /**< \brief SPI signal: MOSI on PA28 mux A */
-#define MUX_PA28A_SPI_MOSI              _L(0)
+#define GPIO_PA22A_SPI_MOSI      _UL_(1 << 22)
+#define PIN_PA28A_SPI_MOSI             _L_(28) /**< \brief SPI signal: MOSI on PA28 mux A */
+#define MUX_PA28A_SPI_MOSI              _L_(0)
 #define PINMUX_PA28A_SPI_MOSI      ((PIN_PA28A_SPI_MOSI << 16) | MUX_PA28A_SPI_MOSI)
-#define GPIO_PA28A_SPI_MOSI      _UL(1 << 28)
-#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
-#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define GPIO_PA28A_SPI_MOSI      _UL_(1 << 28)
+#define PIN_PA02B_SPI_NPCS0             _L_(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L_(1)
 #define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
-#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
-#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
-#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define GPIO_PA02B_SPI_NPCS0     _UL_(1 <<  2)
+#define PIN_PA24A_SPI_NPCS0            _L_(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L_(0)
 #define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
-#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
-#define PIN_PA30A_SPI_NPCS0            _L(30) /**< \brief SPI signal: NPCS0 on PA30 mux A */
-#define MUX_PA30A_SPI_NPCS0             _L(0)
+#define GPIO_PA24A_SPI_NPCS0     _UL_(1 << 24)
+#define PIN_PA30A_SPI_NPCS0            _L_(30) /**< \brief SPI signal: NPCS0 on PA30 mux A */
+#define MUX_PA30A_SPI_NPCS0             _L_(0)
 #define PINMUX_PA30A_SPI_NPCS0     ((PIN_PA30A_SPI_NPCS0 << 16) | MUX_PA30A_SPI_NPCS0)
-#define GPIO_PA30A_SPI_NPCS0     _UL(1 << 30)
-#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
-#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define GPIO_PA30A_SPI_NPCS0     _UL_(1 << 30)
+#define PIN_PA13C_SPI_NPCS1            _L_(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L_(2)
 #define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
-#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PB13B_SPI_NPCS1            _L(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
-#define MUX_PB13B_SPI_NPCS1             _L(1)
+#define GPIO_PA13C_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PB13B_SPI_NPCS1            _L_(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
+#define MUX_PB13B_SPI_NPCS1             _L_(1)
 #define PINMUX_PB13B_SPI_NPCS1     ((PIN_PB13B_SPI_NPCS1 << 16) | MUX_PB13B_SPI_NPCS1)
-#define GPIO_PB13B_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PA31A_SPI_NPCS1            _L(31) /**< \brief SPI signal: NPCS1 on PA31 mux A */
-#define MUX_PA31A_SPI_NPCS1             _L(0)
+#define GPIO_PB13B_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PA31A_SPI_NPCS1            _L_(31) /**< \brief SPI signal: NPCS1 on PA31 mux A */
+#define MUX_PA31A_SPI_NPCS1             _L_(0)
 #define PINMUX_PA31A_SPI_NPCS1     ((PIN_PA31A_SPI_NPCS1 << 16) | MUX_PA31A_SPI_NPCS1)
-#define GPIO_PA31A_SPI_NPCS1     _UL(1 << 31)
-#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
-#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define GPIO_PA31A_SPI_NPCS1     _UL_(1 << 31)
+#define PIN_PA14C_SPI_NPCS2            _L_(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L_(2)
 #define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
-#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
-#define PIN_PB11B_SPI_NPCS2            _L(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
-#define MUX_PB11B_SPI_NPCS2             _L(1)
+#define GPIO_PA14C_SPI_NPCS2     _UL_(1 << 14)
+#define PIN_PB11B_SPI_NPCS2            _L_(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
+#define MUX_PB11B_SPI_NPCS2             _L_(1)
 #define PINMUX_PB11B_SPI_NPCS2     ((PIN_PB11B_SPI_NPCS2 << 16) | MUX_PB11B_SPI_NPCS2)
-#define GPIO_PB11B_SPI_NPCS2     _UL(1 << 11)
-#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
-#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define GPIO_PB11B_SPI_NPCS2     _UL_(1 << 11)
+#define PIN_PA15C_SPI_NPCS3            _L_(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L_(2)
 #define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
-#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
-#define PIN_PB12B_SPI_NPCS3            _L(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
-#define MUX_PB12B_SPI_NPCS3             _L(1)
+#define GPIO_PA15C_SPI_NPCS3     _UL_(1 << 15)
+#define PIN_PB12B_SPI_NPCS3            _L_(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
+#define MUX_PB12B_SPI_NPCS3             _L_(1)
 #define PINMUX_PB12B_SPI_NPCS3     ((PIN_PB12B_SPI_NPCS3 << 16) | MUX_PB12B_SPI_NPCS3)
-#define GPIO_PB12B_SPI_NPCS3     _UL(1 << 12)
-#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
-#define MUX_PA23A_SPI_SCK               _L(0)
+#define GPIO_PB12B_SPI_NPCS3     _UL_(1 << 12)
+#define PIN_PA23A_SPI_SCK              _L_(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L_(0)
 #define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
-#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
-#define PIN_PA29A_SPI_SCK              _L(29) /**< \brief SPI signal: SCK on PA29 mux A */
-#define MUX_PA29A_SPI_SCK               _L(0)
+#define GPIO_PA23A_SPI_SCK       _UL_(1 << 23)
+#define PIN_PA29A_SPI_SCK              _L_(29) /**< \brief SPI signal: SCK on PA29 mux A */
+#define MUX_PA29A_SPI_SCK               _L_(0)
 #define PINMUX_PA29A_SPI_SCK       ((PIN_PA29A_SPI_SCK << 16) | MUX_PA29A_SPI_SCK)
-#define GPIO_PA29A_SPI_SCK       _UL(1 << 29)
+#define GPIO_PA29A_SPI_SCK       _UL_(1 << 29)
 /* ========== GPIO definition for TC0 peripheral ========== */
-#define PIN_PB07D_TC0_A0               _L(39) /**< \brief TC0 signal: A0 on PB07 mux D */
-#define MUX_PB07D_TC0_A0                _L(3)
+#define PIN_PB07D_TC0_A0               _L_(39) /**< \brief TC0 signal: A0 on PB07 mux D */
+#define MUX_PB07D_TC0_A0                _L_(3)
 #define PINMUX_PB07D_TC0_A0        ((PIN_PB07D_TC0_A0 << 16) | MUX_PB07D_TC0_A0)
-#define GPIO_PB07D_TC0_A0        _UL(1 <<  7)
-#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
-#define MUX_PA08B_TC0_A0                _L(1)
+#define GPIO_PB07D_TC0_A0        _UL_(1 <<  7)
+#define PIN_PA08B_TC0_A0                _L_(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L_(1)
 #define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
-#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
-#define PIN_PB09D_TC0_A1               _L(41) /**< \brief TC0 signal: A1 on PB09 mux D */
-#define MUX_PB09D_TC0_A1                _L(3)
+#define GPIO_PA08B_TC0_A0        _UL_(1 <<  8)
+#define PIN_PB09D_TC0_A1               _L_(41) /**< \brief TC0 signal: A1 on PB09 mux D */
+#define MUX_PB09D_TC0_A1                _L_(3)
 #define PINMUX_PB09D_TC0_A1        ((PIN_PB09D_TC0_A1 << 16) | MUX_PB09D_TC0_A1)
-#define GPIO_PB09D_TC0_A1        _UL(1 <<  9)
-#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
-#define MUX_PA10B_TC0_A1                _L(1)
+#define GPIO_PB09D_TC0_A1        _UL_(1 <<  9)
+#define PIN_PA10B_TC0_A1               _L_(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L_(1)
 #define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
-#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
-#define PIN_PB11D_TC0_A2               _L(43) /**< \brief TC0 signal: A2 on PB11 mux D */
-#define MUX_PB11D_TC0_A2                _L(3)
+#define GPIO_PA10B_TC0_A1        _UL_(1 << 10)
+#define PIN_PB11D_TC0_A2               _L_(43) /**< \brief TC0 signal: A2 on PB11 mux D */
+#define MUX_PB11D_TC0_A2                _L_(3)
 #define PINMUX_PB11D_TC0_A2        ((PIN_PB11D_TC0_A2 << 16) | MUX_PB11D_TC0_A2)
-#define GPIO_PB11D_TC0_A2        _UL(1 << 11)
-#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
-#define MUX_PA12B_TC0_A2                _L(1)
+#define GPIO_PB11D_TC0_A2        _UL_(1 << 11)
+#define PIN_PA12B_TC0_A2               _L_(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L_(1)
 #define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
-#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
-#define PIN_PB08D_TC0_B0               _L(40) /**< \brief TC0 signal: B0 on PB08 mux D */
-#define MUX_PB08D_TC0_B0                _L(3)
+#define GPIO_PA12B_TC0_A2        _UL_(1 << 12)
+#define PIN_PB08D_TC0_B0               _L_(40) /**< \brief TC0 signal: B0 on PB08 mux D */
+#define MUX_PB08D_TC0_B0                _L_(3)
 #define PINMUX_PB08D_TC0_B0        ((PIN_PB08D_TC0_B0 << 16) | MUX_PB08D_TC0_B0)
-#define GPIO_PB08D_TC0_B0        _UL(1 <<  8)
-#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
-#define MUX_PA09B_TC0_B0                _L(1)
+#define GPIO_PB08D_TC0_B0        _UL_(1 <<  8)
+#define PIN_PA09B_TC0_B0                _L_(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L_(1)
 #define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
-#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
-#define PIN_PB10D_TC0_B1               _L(42) /**< \brief TC0 signal: B1 on PB10 mux D */
-#define MUX_PB10D_TC0_B1                _L(3)
+#define GPIO_PA09B_TC0_B0        _UL_(1 <<  9)
+#define PIN_PB10D_TC0_B1               _L_(42) /**< \brief TC0 signal: B1 on PB10 mux D */
+#define MUX_PB10D_TC0_B1                _L_(3)
 #define PINMUX_PB10D_TC0_B1        ((PIN_PB10D_TC0_B1 << 16) | MUX_PB10D_TC0_B1)
-#define GPIO_PB10D_TC0_B1        _UL(1 << 10)
-#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
-#define MUX_PA11B_TC0_B1                _L(1)
+#define GPIO_PB10D_TC0_B1        _UL_(1 << 10)
+#define PIN_PA11B_TC0_B1               _L_(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L_(1)
 #define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
-#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
-#define PIN_PB12D_TC0_B2               _L(44) /**< \brief TC0 signal: B2 on PB12 mux D */
-#define MUX_PB12D_TC0_B2                _L(3)
+#define GPIO_PA11B_TC0_B1        _UL_(1 << 11)
+#define PIN_PB12D_TC0_B2               _L_(44) /**< \brief TC0 signal: B2 on PB12 mux D */
+#define MUX_PB12D_TC0_B2                _L_(3)
 #define PINMUX_PB12D_TC0_B2        ((PIN_PB12D_TC0_B2 << 16) | MUX_PB12D_TC0_B2)
-#define GPIO_PB12D_TC0_B2        _UL(1 << 12)
-#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
-#define MUX_PA13B_TC0_B2                _L(1)
+#define GPIO_PB12D_TC0_B2        _UL_(1 << 12)
+#define PIN_PA13B_TC0_B2               _L_(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L_(1)
 #define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
-#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
-#define PIN_PB13D_TC0_CLK0             _L(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
-#define MUX_PB13D_TC0_CLK0              _L(3)
+#define GPIO_PA13B_TC0_B2        _UL_(1 << 13)
+#define PIN_PB13D_TC0_CLK0             _L_(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
+#define MUX_PB13D_TC0_CLK0              _L_(3)
 #define PINMUX_PB13D_TC0_CLK0      ((PIN_PB13D_TC0_CLK0 << 16) | MUX_PB13D_TC0_CLK0)
-#define GPIO_PB13D_TC0_CLK0      _UL(1 << 13)
-#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
-#define MUX_PA14B_TC0_CLK0              _L(1)
+#define GPIO_PB13D_TC0_CLK0      _UL_(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L_(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L_(1)
 #define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
-#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
-#define PIN_PB14D_TC0_CLK1             _L(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
-#define MUX_PB14D_TC0_CLK1              _L(3)
+#define GPIO_PA14B_TC0_CLK0      _UL_(1 << 14)
+#define PIN_PB14D_TC0_CLK1             _L_(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
+#define MUX_PB14D_TC0_CLK1              _L_(3)
 #define PINMUX_PB14D_TC0_CLK1      ((PIN_PB14D_TC0_CLK1 << 16) | MUX_PB14D_TC0_CLK1)
-#define GPIO_PB14D_TC0_CLK1      _UL(1 << 14)
-#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
-#define MUX_PA15B_TC0_CLK1              _L(1)
+#define GPIO_PB14D_TC0_CLK1      _UL_(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L_(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L_(1)
 #define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
-#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
-#define PIN_PB15D_TC0_CLK2             _L(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
-#define MUX_PB15D_TC0_CLK2              _L(3)
+#define GPIO_PA15B_TC0_CLK1      _UL_(1 << 15)
+#define PIN_PB15D_TC0_CLK2             _L_(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
+#define MUX_PB15D_TC0_CLK2              _L_(3)
 #define PINMUX_PB15D_TC0_CLK2      ((PIN_PB15D_TC0_CLK2 << 16) | MUX_PB15D_TC0_CLK2)
-#define GPIO_PB15D_TC0_CLK2      _UL(1 << 15)
-#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
-#define MUX_PA16B_TC0_CLK2              _L(1)
+#define GPIO_PB15D_TC0_CLK2      _UL_(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L_(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L_(1)
 #define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
-#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+#define GPIO_PA16B_TC0_CLK2      _UL_(1 << 16)
 /* ========== GPIO definition for USART0 peripheral ========== */
-#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
-#define MUX_PA04B_USART0_CLK            _L(1)
+#define PIN_PA04B_USART0_CLK            _L_(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L_(1)
 #define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
-#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
-#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
-#define MUX_PA10A_USART0_CLK            _L(0)
+#define GPIO_PA04B_USART0_CLK    _UL_(1 <<  4)
+#define PIN_PA10A_USART0_CLK           _L_(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L_(0)
 #define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
-#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
-#define PIN_PB13A_USART0_CLK           _L(45) /**< \brief USART0 signal: CLK on PB13 mux A */
-#define MUX_PB13A_USART0_CLK            _L(0)
+#define GPIO_PA10A_USART0_CLK    _UL_(1 << 10)
+#define PIN_PB13A_USART0_CLK           _L_(45) /**< \brief USART0 signal: CLK on PB13 mux A */
+#define MUX_PB13A_USART0_CLK            _L_(0)
 #define PINMUX_PB13A_USART0_CLK    ((PIN_PB13A_USART0_CLK << 16) | MUX_PB13A_USART0_CLK)
-#define GPIO_PB13A_USART0_CLK    _UL(1 << 13)
-#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
-#define MUX_PA09A_USART0_CTS            _L(0)
+#define GPIO_PB13A_USART0_CLK    _UL_(1 << 13)
+#define PIN_PA09A_USART0_CTS            _L_(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L_(0)
 #define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
-#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
-#define PIN_PB11A_USART0_CTS           _L(43) /**< \brief USART0 signal: CTS on PB11 mux A */
-#define MUX_PB11A_USART0_CTS            _L(0)
+#define GPIO_PA09A_USART0_CTS    _UL_(1 <<  9)
+#define PIN_PB11A_USART0_CTS           _L_(43) /**< \brief USART0 signal: CTS on PB11 mux A */
+#define MUX_PB11A_USART0_CTS            _L_(0)
 #define PINMUX_PB11A_USART0_CTS    ((PIN_PB11A_USART0_CTS << 16) | MUX_PB11A_USART0_CTS)
-#define GPIO_PB11A_USART0_CTS    _UL(1 << 11)
-#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
-#define MUX_PA06B_USART0_RTS            _L(1)
+#define GPIO_PB11A_USART0_CTS    _UL_(1 << 11)
+#define PIN_PA06B_USART0_RTS            _L_(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L_(1)
 #define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
-#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
-#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
-#define MUX_PA08A_USART0_RTS            _L(0)
+#define GPIO_PA06B_USART0_RTS    _UL_(1 <<  6)
+#define PIN_PA08A_USART0_RTS            _L_(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L_(0)
 #define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
-#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
-#define PIN_PB12A_USART0_RTS           _L(44) /**< \brief USART0 signal: RTS on PB12 mux A */
-#define MUX_PB12A_USART0_RTS            _L(0)
+#define GPIO_PA08A_USART0_RTS    _UL_(1 <<  8)
+#define PIN_PB12A_USART0_RTS           _L_(44) /**< \brief USART0 signal: RTS on PB12 mux A */
+#define MUX_PB12A_USART0_RTS            _L_(0)
 #define PINMUX_PB12A_USART0_RTS    ((PIN_PB12A_USART0_RTS << 16) | MUX_PB12A_USART0_RTS)
-#define GPIO_PB12A_USART0_RTS    _UL(1 << 12)
-#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
-#define MUX_PA05B_USART0_RXD            _L(1)
+#define GPIO_PB12A_USART0_RTS    _UL_(1 << 12)
+#define PIN_PA05B_USART0_RXD            _L_(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L_(1)
 #define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
-#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
-#define PIN_PB00B_USART0_RXD           _L(32) /**< \brief USART0 signal: RXD on PB00 mux B */
-#define MUX_PB00B_USART0_RXD            _L(1)
+#define GPIO_PA05B_USART0_RXD    _UL_(1 <<  5)
+#define PIN_PB00B_USART0_RXD           _L_(32) /**< \brief USART0 signal: RXD on PB00 mux B */
+#define MUX_PB00B_USART0_RXD            _L_(1)
 #define PINMUX_PB00B_USART0_RXD    ((PIN_PB00B_USART0_RXD << 16) | MUX_PB00B_USART0_RXD)
-#define GPIO_PB00B_USART0_RXD    _UL(1 <<  0)
-#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
-#define MUX_PA11A_USART0_RXD            _L(0)
+#define GPIO_PB00B_USART0_RXD    _UL_(1 <<  0)
+#define PIN_PA11A_USART0_RXD           _L_(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L_(0)
 #define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
-#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
-#define PIN_PB14A_USART0_RXD           _L(46) /**< \brief USART0 signal: RXD on PB14 mux A */
-#define MUX_PB14A_USART0_RXD            _L(0)
+#define GPIO_PA11A_USART0_RXD    _UL_(1 << 11)
+#define PIN_PB14A_USART0_RXD           _L_(46) /**< \brief USART0 signal: RXD on PB14 mux A */
+#define MUX_PB14A_USART0_RXD            _L_(0)
 #define PINMUX_PB14A_USART0_RXD    ((PIN_PB14A_USART0_RXD << 16) | MUX_PB14A_USART0_RXD)
-#define GPIO_PB14A_USART0_RXD    _UL(1 << 14)
-#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
-#define MUX_PA07B_USART0_TXD            _L(1)
+#define GPIO_PB14A_USART0_RXD    _UL_(1 << 14)
+#define PIN_PA07B_USART0_TXD            _L_(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L_(1)
 #define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
-#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
-#define PIN_PB01B_USART0_TXD           _L(33) /**< \brief USART0 signal: TXD on PB01 mux B */
-#define MUX_PB01B_USART0_TXD            _L(1)
+#define GPIO_PA07B_USART0_TXD    _UL_(1 <<  7)
+#define PIN_PB01B_USART0_TXD           _L_(33) /**< \brief USART0 signal: TXD on PB01 mux B */
+#define MUX_PB01B_USART0_TXD            _L_(1)
 #define PINMUX_PB01B_USART0_TXD    ((PIN_PB01B_USART0_TXD << 16) | MUX_PB01B_USART0_TXD)
-#define GPIO_PB01B_USART0_TXD    _UL(1 <<  1)
-#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
-#define MUX_PA12A_USART0_TXD            _L(0)
+#define GPIO_PB01B_USART0_TXD    _UL_(1 <<  1)
+#define PIN_PA12A_USART0_TXD           _L_(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L_(0)
 #define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
-#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
-#define PIN_PB15A_USART0_TXD           _L(47) /**< \brief USART0 signal: TXD on PB15 mux A */
-#define MUX_PB15A_USART0_TXD            _L(0)
+#define GPIO_PA12A_USART0_TXD    _UL_(1 << 12)
+#define PIN_PB15A_USART0_TXD           _L_(47) /**< \brief USART0 signal: TXD on PB15 mux A */
+#define MUX_PB15A_USART0_TXD            _L_(0)
 #define PINMUX_PB15A_USART0_TXD    ((PIN_PB15A_USART0_TXD << 16) | MUX_PB15A_USART0_TXD)
-#define GPIO_PB15A_USART0_TXD    _UL(1 << 15)
+#define GPIO_PB15A_USART0_TXD    _UL_(1 << 15)
 /* ========== GPIO definition for USART1 peripheral ========== */
-#define PIN_PB03B_USART1_CLK           _L(35) /**< \brief USART1 signal: CLK on PB03 mux B */
-#define MUX_PB03B_USART1_CLK            _L(1)
+#define PIN_PB03B_USART1_CLK           _L_(35) /**< \brief USART1 signal: CLK on PB03 mux B */
+#define MUX_PB03B_USART1_CLK            _L_(1)
 #define PINMUX_PB03B_USART1_CLK    ((PIN_PB03B_USART1_CLK << 16) | MUX_PB03B_USART1_CLK)
-#define GPIO_PB03B_USART1_CLK    _UL(1 <<  3)
-#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
-#define MUX_PA14A_USART1_CLK            _L(0)
+#define GPIO_PB03B_USART1_CLK    _UL_(1 <<  3)
+#define PIN_PA14A_USART1_CLK           _L_(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L_(0)
 #define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
-#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
-#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
-#define MUX_PA21B_USART1_CTS            _L(1)
+#define GPIO_PA14A_USART1_CLK    _UL_(1 << 14)
+#define PIN_PA21B_USART1_CTS           _L_(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L_(1)
 #define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
-#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
-#define PIN_PB02B_USART1_RTS           _L(34) /**< \brief USART1 signal: RTS on PB02 mux B */
-#define MUX_PB02B_USART1_RTS            _L(1)
+#define GPIO_PA21B_USART1_CTS    _UL_(1 << 21)
+#define PIN_PB02B_USART1_RTS           _L_(34) /**< \brief USART1 signal: RTS on PB02 mux B */
+#define MUX_PB02B_USART1_RTS            _L_(1)
 #define PINMUX_PB02B_USART1_RTS    ((PIN_PB02B_USART1_RTS << 16) | MUX_PB02B_USART1_RTS)
-#define GPIO_PB02B_USART1_RTS    _UL(1 <<  2)
-#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
-#define MUX_PA13A_USART1_RTS            _L(0)
+#define GPIO_PB02B_USART1_RTS    _UL_(1 <<  2)
+#define PIN_PA13A_USART1_RTS           _L_(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L_(0)
 #define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
-#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
-#define PIN_PB04B_USART1_RXD           _L(36) /**< \brief USART1 signal: RXD on PB04 mux B */
-#define MUX_PB04B_USART1_RXD            _L(1)
+#define GPIO_PA13A_USART1_RTS    _UL_(1 << 13)
+#define PIN_PB04B_USART1_RXD           _L_(36) /**< \brief USART1 signal: RXD on PB04 mux B */
+#define MUX_PB04B_USART1_RXD            _L_(1)
 #define PINMUX_PB04B_USART1_RXD    ((PIN_PB04B_USART1_RXD << 16) | MUX_PB04B_USART1_RXD)
-#define GPIO_PB04B_USART1_RXD    _UL(1 <<  4)
-#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
-#define MUX_PA15A_USART1_RXD            _L(0)
+#define GPIO_PB04B_USART1_RXD    _UL_(1 <<  4)
+#define PIN_PA15A_USART1_RXD           _L_(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L_(0)
 #define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
-#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
-#define PIN_PB05B_USART1_TXD           _L(37) /**< \brief USART1 signal: TXD on PB05 mux B */
-#define MUX_PB05B_USART1_TXD            _L(1)
+#define GPIO_PA15A_USART1_RXD    _UL_(1 << 15)
+#define PIN_PB05B_USART1_TXD           _L_(37) /**< \brief USART1 signal: TXD on PB05 mux B */
+#define MUX_PB05B_USART1_TXD            _L_(1)
 #define PINMUX_PB05B_USART1_TXD    ((PIN_PB05B_USART1_TXD << 16) | MUX_PB05B_USART1_TXD)
-#define GPIO_PB05B_USART1_TXD    _UL(1 <<  5)
-#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
-#define MUX_PA16A_USART1_TXD            _L(0)
+#define GPIO_PB05B_USART1_TXD    _UL_(1 <<  5)
+#define PIN_PA16A_USART1_TXD           _L_(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L_(0)
 #define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
-#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+#define GPIO_PA16A_USART1_TXD    _UL_(1 << 16)
 /* ========== GPIO definition for USART2 peripheral ========== */
-#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
-#define MUX_PA18A_USART2_CLK            _L(0)
+#define PIN_PA18A_USART2_CLK           _L_(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L_(0)
 #define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
-#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
-#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
-#define MUX_PA22B_USART2_CTS            _L(1)
+#define GPIO_PA18A_USART2_CLK    _UL_(1 << 18)
+#define PIN_PA22B_USART2_CTS           _L_(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L_(1)
 #define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
-#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
-#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
-#define MUX_PA17A_USART2_RTS            _L(0)
+#define GPIO_PA22B_USART2_CTS    _UL_(1 << 22)
+#define PIN_PA17A_USART2_RTS           _L_(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L_(0)
 #define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
-#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
-#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
-#define MUX_PA25B_USART2_RXD            _L(1)
+#define GPIO_PA17A_USART2_RTS    _UL_(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L_(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L_(1)
 #define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
-#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
-#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
-#define MUX_PA19A_USART2_RXD            _L(0)
+#define GPIO_PA25B_USART2_RXD    _UL_(1 << 25)
+#define PIN_PA19A_USART2_RXD           _L_(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L_(0)
 #define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
-#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
-#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
-#define MUX_PA26B_USART2_TXD            _L(1)
+#define GPIO_PA19A_USART2_RXD    _UL_(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L_(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L_(1)
 #define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
-#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
-#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
-#define MUX_PA20A_USART2_TXD            _L(0)
+#define GPIO_PA26B_USART2_TXD    _UL_(1 << 26)
+#define PIN_PA20A_USART2_TXD           _L_(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L_(0)
 #define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
-#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+#define GPIO_PA20A_USART2_TXD    _UL_(1 << 20)
 /* ========== GPIO definition for USART3 peripheral ========== */
-#define PIN_PA29E_USART3_CLK           _L(29) /**< \brief USART3 signal: CLK on PA29 mux E */
-#define MUX_PA29E_USART3_CLK            _L(4)
+#define PIN_PA29E_USART3_CLK           _L_(29) /**< \brief USART3 signal: CLK on PA29 mux E */
+#define MUX_PA29E_USART3_CLK            _L_(4)
 #define PINMUX_PA29E_USART3_CLK    ((PIN_PA29E_USART3_CLK << 16) | MUX_PA29E_USART3_CLK)
-#define GPIO_PA29E_USART3_CLK    _UL(1 << 29)
-#define PIN_PB08A_USART3_CLK           _L(40) /**< \brief USART3 signal: CLK on PB08 mux A */
-#define MUX_PB08A_USART3_CLK            _L(0)
+#define GPIO_PA29E_USART3_CLK    _UL_(1 << 29)
+#define PIN_PB08A_USART3_CLK           _L_(40) /**< \brief USART3 signal: CLK on PB08 mux A */
+#define MUX_PB08A_USART3_CLK            _L_(0)
 #define PINMUX_PB08A_USART3_CLK    ((PIN_PB08A_USART3_CLK << 16) | MUX_PB08A_USART3_CLK)
-#define GPIO_PB08A_USART3_CLK    _UL(1 <<  8)
-#define PIN_PA28E_USART3_CTS           _L(28) /**< \brief USART3 signal: CTS on PA28 mux E */
-#define MUX_PA28E_USART3_CTS            _L(4)
+#define GPIO_PB08A_USART3_CLK    _UL_(1 <<  8)
+#define PIN_PA28E_USART3_CTS           _L_(28) /**< \brief USART3 signal: CTS on PA28 mux E */
+#define MUX_PA28E_USART3_CTS            _L_(4)
 #define PINMUX_PA28E_USART3_CTS    ((PIN_PA28E_USART3_CTS << 16) | MUX_PA28E_USART3_CTS)
-#define GPIO_PA28E_USART3_CTS    _UL(1 << 28)
-#define PIN_PB07A_USART3_CTS           _L(39) /**< \brief USART3 signal: CTS on PB07 mux A */
-#define MUX_PB07A_USART3_CTS            _L(0)
+#define GPIO_PA28E_USART3_CTS    _UL_(1 << 28)
+#define PIN_PB07A_USART3_CTS           _L_(39) /**< \brief USART3 signal: CTS on PB07 mux A */
+#define MUX_PB07A_USART3_CTS            _L_(0)
 #define PINMUX_PB07A_USART3_CTS    ((PIN_PB07A_USART3_CTS << 16) | MUX_PB07A_USART3_CTS)
-#define GPIO_PB07A_USART3_CTS    _UL(1 <<  7)
-#define PIN_PA27E_USART3_RTS           _L(27) /**< \brief USART3 signal: RTS on PA27 mux E */
-#define MUX_PA27E_USART3_RTS            _L(4)
+#define GPIO_PB07A_USART3_CTS    _UL_(1 <<  7)
+#define PIN_PA27E_USART3_RTS           _L_(27) /**< \brief USART3 signal: RTS on PA27 mux E */
+#define MUX_PA27E_USART3_RTS            _L_(4)
 #define PINMUX_PA27E_USART3_RTS    ((PIN_PA27E_USART3_RTS << 16) | MUX_PA27E_USART3_RTS)
-#define GPIO_PA27E_USART3_RTS    _UL(1 << 27)
-#define PIN_PB06A_USART3_RTS           _L(38) /**< \brief USART3 signal: RTS on PB06 mux A */
-#define MUX_PB06A_USART3_RTS            _L(0)
+#define GPIO_PA27E_USART3_RTS    _UL_(1 << 27)
+#define PIN_PB06A_USART3_RTS           _L_(38) /**< \brief USART3 signal: RTS on PB06 mux A */
+#define MUX_PB06A_USART3_RTS            _L_(0)
 #define PINMUX_PB06A_USART3_RTS    ((PIN_PB06A_USART3_RTS << 16) | MUX_PB06A_USART3_RTS)
-#define GPIO_PB06A_USART3_RTS    _UL(1 <<  6)
-#define PIN_PA30E_USART3_RXD           _L(30) /**< \brief USART3 signal: RXD on PA30 mux E */
-#define MUX_PA30E_USART3_RXD            _L(4)
+#define GPIO_PB06A_USART3_RTS    _UL_(1 <<  6)
+#define PIN_PA30E_USART3_RXD           _L_(30) /**< \brief USART3 signal: RXD on PA30 mux E */
+#define MUX_PA30E_USART3_RXD            _L_(4)
 #define PINMUX_PA30E_USART3_RXD    ((PIN_PA30E_USART3_RXD << 16) | MUX_PA30E_USART3_RXD)
-#define GPIO_PA30E_USART3_RXD    _UL(1 << 30)
-#define PIN_PB09A_USART3_RXD           _L(41) /**< \brief USART3 signal: RXD on PB09 mux A */
-#define MUX_PB09A_USART3_RXD            _L(0)
+#define GPIO_PA30E_USART3_RXD    _UL_(1 << 30)
+#define PIN_PB09A_USART3_RXD           _L_(41) /**< \brief USART3 signal: RXD on PB09 mux A */
+#define MUX_PB09A_USART3_RXD            _L_(0)
 #define PINMUX_PB09A_USART3_RXD    ((PIN_PB09A_USART3_RXD << 16) | MUX_PB09A_USART3_RXD)
-#define GPIO_PB09A_USART3_RXD    _UL(1 <<  9)
-#define PIN_PA31E_USART3_TXD           _L(31) /**< \brief USART3 signal: TXD on PA31 mux E */
-#define MUX_PA31E_USART3_TXD            _L(4)
+#define GPIO_PB09A_USART3_RXD    _UL_(1 <<  9)
+#define PIN_PA31E_USART3_TXD           _L_(31) /**< \brief USART3 signal: TXD on PA31 mux E */
+#define MUX_PA31E_USART3_TXD            _L_(4)
 #define PINMUX_PA31E_USART3_TXD    ((PIN_PA31E_USART3_TXD << 16) | MUX_PA31E_USART3_TXD)
-#define GPIO_PA31E_USART3_TXD    _UL(1 << 31)
-#define PIN_PB10A_USART3_TXD           _L(42) /**< \brief USART3 signal: TXD on PB10 mux A */
-#define MUX_PB10A_USART3_TXD            _L(0)
+#define GPIO_PA31E_USART3_TXD    _UL_(1 << 31)
+#define PIN_PB10A_USART3_TXD           _L_(42) /**< \brief USART3 signal: TXD on PB10 mux A */
+#define MUX_PB10A_USART3_TXD            _L_(0)
 #define PINMUX_PB10A_USART3_TXD    ((PIN_PB10A_USART3_TXD << 16) | MUX_PB10A_USART3_TXD)
-#define GPIO_PB10A_USART3_TXD    _UL(1 << 10)
+#define GPIO_PB10A_USART3_TXD    _UL_(1 << 10)
 /* ========== GPIO definition for ADCIFE peripheral ========== */
-#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
-#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PIN_PA04A_ADCIFE_AD0            _L_(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L_(0)
 #define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
-#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
-#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
-#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL_(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L_(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L_(0)
 #define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
-#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
-#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
-#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define GPIO_PA05A_ADCIFE_AD1    _UL_(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L_(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L_(0)
 #define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
-#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
-#define PIN_PB02A_ADCIFE_AD3           _L(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
-#define MUX_PB02A_ADCIFE_AD3            _L(0)
+#define GPIO_PA07A_ADCIFE_AD2    _UL_(1 <<  7)
+#define PIN_PB02A_ADCIFE_AD3           _L_(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
+#define MUX_PB02A_ADCIFE_AD3            _L_(0)
 #define PINMUX_PB02A_ADCIFE_AD3    ((PIN_PB02A_ADCIFE_AD3 << 16) | MUX_PB02A_ADCIFE_AD3)
-#define GPIO_PB02A_ADCIFE_AD3    _UL(1 <<  2)
-#define PIN_PB03A_ADCIFE_AD4           _L(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
-#define MUX_PB03A_ADCIFE_AD4            _L(0)
+#define GPIO_PB02A_ADCIFE_AD3    _UL_(1 <<  2)
+#define PIN_PB03A_ADCIFE_AD4           _L_(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
+#define MUX_PB03A_ADCIFE_AD4            _L_(0)
 #define PINMUX_PB03A_ADCIFE_AD4    ((PIN_PB03A_ADCIFE_AD4 << 16) | MUX_PB03A_ADCIFE_AD4)
-#define GPIO_PB03A_ADCIFE_AD4    _UL(1 <<  3)
-#define PIN_PB04A_ADCIFE_AD5           _L(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
-#define MUX_PB04A_ADCIFE_AD5            _L(0)
+#define GPIO_PB03A_ADCIFE_AD4    _UL_(1 <<  3)
+#define PIN_PB04A_ADCIFE_AD5           _L_(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
+#define MUX_PB04A_ADCIFE_AD5            _L_(0)
 #define PINMUX_PB04A_ADCIFE_AD5    ((PIN_PB04A_ADCIFE_AD5 << 16) | MUX_PB04A_ADCIFE_AD5)
-#define GPIO_PB04A_ADCIFE_AD5    _UL(1 <<  4)
-#define PIN_PB05A_ADCIFE_AD6           _L(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
-#define MUX_PB05A_ADCIFE_AD6            _L(0)
+#define GPIO_PB04A_ADCIFE_AD5    _UL_(1 <<  4)
+#define PIN_PB05A_ADCIFE_AD6           _L_(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
+#define MUX_PB05A_ADCIFE_AD6            _L_(0)
 #define PINMUX_PB05A_ADCIFE_AD6    ((PIN_PB05A_ADCIFE_AD6 << 16) | MUX_PB05A_ADCIFE_AD6)
-#define GPIO_PB05A_ADCIFE_AD6    _UL(1 <<  5)
-#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
-#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define GPIO_PB05A_ADCIFE_AD6    _UL_(1 <<  5)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L_(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L_(4)
 #define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
-#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL_(1 <<  5)
 /* ========== GPIO definition for DACC peripheral ========== */
-#define PIN_PB04E_DACC_EXT_TRIG0       _L(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
-#define MUX_PB04E_DACC_EXT_TRIG0        _L(4)
+#define PIN_PB04E_DACC_EXT_TRIG0       _L_(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
+#define MUX_PB04E_DACC_EXT_TRIG0        _L_(4)
 #define PINMUX_PB04E_DACC_EXT_TRIG0  ((PIN_PB04E_DACC_EXT_TRIG0 << 16) | MUX_PB04E_DACC_EXT_TRIG0)
-#define GPIO_PB04E_DACC_EXT_TRIG0  _UL(1 <<  4)
-#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
-#define MUX_PA06A_DACC_VOUT             _L(0)
+#define GPIO_PB04E_DACC_EXT_TRIG0  _UL_(1 <<  4)
+#define PIN_PA06A_DACC_VOUT             _L_(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L_(0)
 #define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
-#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+#define GPIO_PA06A_DACC_VOUT     _UL_(1 <<  6)
 /* ========== GPIO definition for ACIFC peripheral ========== */
-#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
-#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PIN_PA06E_ACIFC_ACAN0           _L_(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L_(4)
 #define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
-#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
-#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
-#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL_(1 <<  6)
+#define PIN_PA07E_ACIFC_ACAP0           _L_(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L_(4)
 #define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
-#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
-#define PIN_PB02E_ACIFC_ACBN0          _L(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
-#define MUX_PB02E_ACIFC_ACBN0           _L(4)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL_(1 <<  7)
+#define PIN_PB02E_ACIFC_ACBN0          _L_(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
+#define MUX_PB02E_ACIFC_ACBN0           _L_(4)
 #define PINMUX_PB02E_ACIFC_ACBN0   ((PIN_PB02E_ACIFC_ACBN0 << 16) | MUX_PB02E_ACIFC_ACBN0)
-#define GPIO_PB02E_ACIFC_ACBN0   _UL(1 <<  2)
-#define PIN_PB03E_ACIFC_ACBP0          _L(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
-#define MUX_PB03E_ACIFC_ACBP0           _L(4)
+#define GPIO_PB02E_ACIFC_ACBN0   _UL_(1 <<  2)
+#define PIN_PB03E_ACIFC_ACBP0          _L_(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
+#define MUX_PB03E_ACIFC_ACBP0           _L_(4)
 #define PINMUX_PB03E_ACIFC_ACBP0   ((PIN_PB03E_ACIFC_ACBP0 << 16) | MUX_PB03E_ACIFC_ACBP0)
-#define GPIO_PB03E_ACIFC_ACBP0   _UL(1 <<  3)
+#define GPIO_PB03E_ACIFC_ACBP0   _UL_(1 <<  3)
 /* ========== GPIO definition for GLOC peripheral ========== */
-#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
-#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PIN_PA06D_GLOC_IN0              _L_(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L_(3)
 #define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
-#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
-#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
-#define MUX_PA20D_GLOC_IN0              _L(3)
+#define GPIO_PA06D_GLOC_IN0      _UL_(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L_(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L_(3)
 #define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
-#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
-#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
-#define MUX_PA04D_GLOC_IN1              _L(3)
+#define GPIO_PA20D_GLOC_IN0      _UL_(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L_(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L_(3)
 #define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
-#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
-#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
-#define MUX_PA21D_GLOC_IN1              _L(3)
+#define GPIO_PA04D_GLOC_IN1      _UL_(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L_(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L_(3)
 #define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
-#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
-#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
-#define MUX_PA05D_GLOC_IN2              _L(3)
+#define GPIO_PA21D_GLOC_IN1      _UL_(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L_(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L_(3)
 #define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
-#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
-#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
-#define MUX_PA22D_GLOC_IN2              _L(3)
+#define GPIO_PA05D_GLOC_IN2      _UL_(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L_(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L_(3)
 #define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
-#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
-#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
-#define MUX_PA07D_GLOC_IN3              _L(3)
+#define GPIO_PA22D_GLOC_IN2      _UL_(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L_(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L_(3)
 #define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
-#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
-#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
-#define MUX_PA23D_GLOC_IN3              _L(3)
+#define GPIO_PA07D_GLOC_IN3      _UL_(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L_(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L_(3)
 #define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
-#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
-#define PIN_PA27D_GLOC_IN4             _L(27) /**< \brief GLOC signal: IN4 on PA27 mux D */
-#define MUX_PA27D_GLOC_IN4              _L(3)
+#define GPIO_PA23D_GLOC_IN3      _UL_(1 << 23)
+#define PIN_PA27D_GLOC_IN4             _L_(27) /**< \brief GLOC signal: IN4 on PA27 mux D */
+#define MUX_PA27D_GLOC_IN4              _L_(3)
 #define PINMUX_PA27D_GLOC_IN4      ((PIN_PA27D_GLOC_IN4 << 16) | MUX_PA27D_GLOC_IN4)
-#define GPIO_PA27D_GLOC_IN4      _UL(1 << 27)
-#define PIN_PB06C_GLOC_IN4             _L(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
-#define MUX_PB06C_GLOC_IN4              _L(2)
+#define GPIO_PA27D_GLOC_IN4      _UL_(1 << 27)
+#define PIN_PB06C_GLOC_IN4             _L_(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
+#define MUX_PB06C_GLOC_IN4              _L_(2)
 #define PINMUX_PB06C_GLOC_IN4      ((PIN_PB06C_GLOC_IN4 << 16) | MUX_PB06C_GLOC_IN4)
-#define GPIO_PB06C_GLOC_IN4      _UL(1 <<  6)
-#define PIN_PA28D_GLOC_IN5             _L(28) /**< \brief GLOC signal: IN5 on PA28 mux D */
-#define MUX_PA28D_GLOC_IN5              _L(3)
+#define GPIO_PB06C_GLOC_IN4      _UL_(1 <<  6)
+#define PIN_PA28D_GLOC_IN5             _L_(28) /**< \brief GLOC signal: IN5 on PA28 mux D */
+#define MUX_PA28D_GLOC_IN5              _L_(3)
 #define PINMUX_PA28D_GLOC_IN5      ((PIN_PA28D_GLOC_IN5 << 16) | MUX_PA28D_GLOC_IN5)
-#define GPIO_PA28D_GLOC_IN5      _UL(1 << 28)
-#define PIN_PB07C_GLOC_IN5             _L(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
-#define MUX_PB07C_GLOC_IN5              _L(2)
+#define GPIO_PA28D_GLOC_IN5      _UL_(1 << 28)
+#define PIN_PB07C_GLOC_IN5             _L_(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
+#define MUX_PB07C_GLOC_IN5              _L_(2)
 #define PINMUX_PB07C_GLOC_IN5      ((PIN_PB07C_GLOC_IN5 << 16) | MUX_PB07C_GLOC_IN5)
-#define GPIO_PB07C_GLOC_IN5      _UL(1 <<  7)
-#define PIN_PA29D_GLOC_IN6             _L(29) /**< \brief GLOC signal: IN6 on PA29 mux D */
-#define MUX_PA29D_GLOC_IN6              _L(3)
+#define GPIO_PB07C_GLOC_IN5      _UL_(1 <<  7)
+#define PIN_PA29D_GLOC_IN6             _L_(29) /**< \brief GLOC signal: IN6 on PA29 mux D */
+#define MUX_PA29D_GLOC_IN6              _L_(3)
 #define PINMUX_PA29D_GLOC_IN6      ((PIN_PA29D_GLOC_IN6 << 16) | MUX_PA29D_GLOC_IN6)
-#define GPIO_PA29D_GLOC_IN6      _UL(1 << 29)
-#define PIN_PB08C_GLOC_IN6             _L(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
-#define MUX_PB08C_GLOC_IN6              _L(2)
+#define GPIO_PA29D_GLOC_IN6      _UL_(1 << 29)
+#define PIN_PB08C_GLOC_IN6             _L_(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
+#define MUX_PB08C_GLOC_IN6              _L_(2)
 #define PINMUX_PB08C_GLOC_IN6      ((PIN_PB08C_GLOC_IN6 << 16) | MUX_PB08C_GLOC_IN6)
-#define GPIO_PB08C_GLOC_IN6      _UL(1 <<  8)
-#define PIN_PA30D_GLOC_IN7             _L(30) /**< \brief GLOC signal: IN7 on PA30 mux D */
-#define MUX_PA30D_GLOC_IN7              _L(3)
+#define GPIO_PB08C_GLOC_IN6      _UL_(1 <<  8)
+#define PIN_PA30D_GLOC_IN7             _L_(30) /**< \brief GLOC signal: IN7 on PA30 mux D */
+#define MUX_PA30D_GLOC_IN7              _L_(3)
 #define PINMUX_PA30D_GLOC_IN7      ((PIN_PA30D_GLOC_IN7 << 16) | MUX_PA30D_GLOC_IN7)
-#define GPIO_PA30D_GLOC_IN7      _UL(1 << 30)
-#define PIN_PB09C_GLOC_IN7             _L(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
-#define MUX_PB09C_GLOC_IN7              _L(2)
+#define GPIO_PA30D_GLOC_IN7      _UL_(1 << 30)
+#define PIN_PB09C_GLOC_IN7             _L_(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
+#define MUX_PB09C_GLOC_IN7              _L_(2)
 #define PINMUX_PB09C_GLOC_IN7      ((PIN_PB09C_GLOC_IN7 << 16) | MUX_PB09C_GLOC_IN7)
-#define GPIO_PB09C_GLOC_IN7      _UL(1 <<  9)
-#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
-#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define GPIO_PB09C_GLOC_IN7      _UL_(1 <<  9)
+#define PIN_PA08D_GLOC_OUT0             _L_(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
-#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
-#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
-#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define GPIO_PA08D_GLOC_OUT0     _UL_(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L_(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
-#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
-#define PIN_PA31D_GLOC_OUT1            _L(31) /**< \brief GLOC signal: OUT1 on PA31 mux D */
-#define MUX_PA31D_GLOC_OUT1             _L(3)
+#define GPIO_PA24D_GLOC_OUT0     _UL_(1 << 24)
+#define PIN_PA31D_GLOC_OUT1            _L_(31) /**< \brief GLOC signal: OUT1 on PA31 mux D */
+#define MUX_PA31D_GLOC_OUT1             _L_(3)
 #define PINMUX_PA31D_GLOC_OUT1     ((PIN_PA31D_GLOC_OUT1 << 16) | MUX_PA31D_GLOC_OUT1)
-#define GPIO_PA31D_GLOC_OUT1     _UL(1 << 31)
-#define PIN_PB10C_GLOC_OUT1            _L(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
-#define MUX_PB10C_GLOC_OUT1             _L(2)
+#define GPIO_PA31D_GLOC_OUT1     _UL_(1 << 31)
+#define PIN_PB10C_GLOC_OUT1            _L_(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
+#define MUX_PB10C_GLOC_OUT1             _L_(2)
 #define PINMUX_PB10C_GLOC_OUT1     ((PIN_PB10C_GLOC_OUT1 << 16) | MUX_PB10C_GLOC_OUT1)
-#define GPIO_PB10C_GLOC_OUT1     _UL(1 << 10)
+#define GPIO_PB10C_GLOC_OUT1     _UL_(1 << 10)
 /* ========== GPIO definition for ABDACB peripheral ========== */
-#define PIN_PA31C_ABDACB_CLK           _L(31) /**< \brief ABDACB signal: CLK on PA31 mux C */
-#define MUX_PA31C_ABDACB_CLK            _L(2)
+#define PIN_PA31C_ABDACB_CLK           _L_(31) /**< \brief ABDACB signal: CLK on PA31 mux C */
+#define MUX_PA31C_ABDACB_CLK            _L_(2)
 #define PINMUX_PA31C_ABDACB_CLK    ((PIN_PA31C_ABDACB_CLK << 16) | MUX_PA31C_ABDACB_CLK)
-#define GPIO_PA31C_ABDACB_CLK    _UL(1 << 31)
-#define PIN_PA27C_ABDACB_DAC0          _L(27) /**< \brief ABDACB signal: DAC0 on PA27 mux C */
-#define MUX_PA27C_ABDACB_DAC0           _L(2)
+#define GPIO_PA31C_ABDACB_CLK    _UL_(1 << 31)
+#define PIN_PA27C_ABDACB_DAC0          _L_(27) /**< \brief ABDACB signal: DAC0 on PA27 mux C */
+#define MUX_PA27C_ABDACB_DAC0           _L_(2)
 #define PINMUX_PA27C_ABDACB_DAC0   ((PIN_PA27C_ABDACB_DAC0 << 16) | MUX_PA27C_ABDACB_DAC0)
-#define GPIO_PA27C_ABDACB_DAC0   _UL(1 << 27)
-#define PIN_PB02C_ABDACB_DAC0          _L(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
-#define MUX_PB02C_ABDACB_DAC0           _L(2)
+#define GPIO_PA27C_ABDACB_DAC0   _UL_(1 << 27)
+#define PIN_PB02C_ABDACB_DAC0          _L_(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
+#define MUX_PB02C_ABDACB_DAC0           _L_(2)
 #define PINMUX_PB02C_ABDACB_DAC0   ((PIN_PB02C_ABDACB_DAC0 << 16) | MUX_PB02C_ABDACB_DAC0)
-#define GPIO_PB02C_ABDACB_DAC0   _UL(1 <<  2)
-#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
-#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define GPIO_PB02C_ABDACB_DAC0   _UL_(1 <<  2)
+#define PIN_PA17B_ABDACB_DAC0          _L_(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L_(1)
 #define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
-#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
-#define PIN_PA29C_ABDACB_DAC1          _L(29) /**< \brief ABDACB signal: DAC1 on PA29 mux C */
-#define MUX_PA29C_ABDACB_DAC1           _L(2)
+#define GPIO_PA17B_ABDACB_DAC0   _UL_(1 << 17)
+#define PIN_PA29C_ABDACB_DAC1          _L_(29) /**< \brief ABDACB signal: DAC1 on PA29 mux C */
+#define MUX_PA29C_ABDACB_DAC1           _L_(2)
 #define PINMUX_PA29C_ABDACB_DAC1   ((PIN_PA29C_ABDACB_DAC1 << 16) | MUX_PA29C_ABDACB_DAC1)
-#define GPIO_PA29C_ABDACB_DAC1   _UL(1 << 29)
-#define PIN_PB04C_ABDACB_DAC1          _L(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
-#define MUX_PB04C_ABDACB_DAC1           _L(2)
+#define GPIO_PA29C_ABDACB_DAC1   _UL_(1 << 29)
+#define PIN_PB04C_ABDACB_DAC1          _L_(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
+#define MUX_PB04C_ABDACB_DAC1           _L_(2)
 #define PINMUX_PB04C_ABDACB_DAC1   ((PIN_PB04C_ABDACB_DAC1 << 16) | MUX_PB04C_ABDACB_DAC1)
-#define GPIO_PB04C_ABDACB_DAC1   _UL(1 <<  4)
-#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
-#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define GPIO_PB04C_ABDACB_DAC1   _UL_(1 <<  4)
+#define PIN_PA19B_ABDACB_DAC1          _L_(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L_(1)
 #define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
-#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
-#define PIN_PA28C_ABDACB_DACN0         _L(28) /**< \brief ABDACB signal: DACN0 on PA28 mux C */
-#define MUX_PA28C_ABDACB_DACN0          _L(2)
+#define GPIO_PA19B_ABDACB_DAC1   _UL_(1 << 19)
+#define PIN_PA28C_ABDACB_DACN0         _L_(28) /**< \brief ABDACB signal: DACN0 on PA28 mux C */
+#define MUX_PA28C_ABDACB_DACN0          _L_(2)
 #define PINMUX_PA28C_ABDACB_DACN0  ((PIN_PA28C_ABDACB_DACN0 << 16) | MUX_PA28C_ABDACB_DACN0)
-#define GPIO_PA28C_ABDACB_DACN0  _UL(1 << 28)
-#define PIN_PB03C_ABDACB_DACN0         _L(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
-#define MUX_PB03C_ABDACB_DACN0          _L(2)
+#define GPIO_PA28C_ABDACB_DACN0  _UL_(1 << 28)
+#define PIN_PB03C_ABDACB_DACN0         _L_(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
+#define MUX_PB03C_ABDACB_DACN0          _L_(2)
 #define PINMUX_PB03C_ABDACB_DACN0  ((PIN_PB03C_ABDACB_DACN0 << 16) | MUX_PB03C_ABDACB_DACN0)
-#define GPIO_PB03C_ABDACB_DACN0  _UL(1 <<  3)
-#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
-#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define GPIO_PB03C_ABDACB_DACN0  _UL_(1 <<  3)
+#define PIN_PA18B_ABDACB_DACN0         _L_(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L_(1)
 #define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
-#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
-#define PIN_PA30C_ABDACB_DACN1         _L(30) /**< \brief ABDACB signal: DACN1 on PA30 mux C */
-#define MUX_PA30C_ABDACB_DACN1          _L(2)
+#define GPIO_PA18B_ABDACB_DACN0  _UL_(1 << 18)
+#define PIN_PA30C_ABDACB_DACN1         _L_(30) /**< \brief ABDACB signal: DACN1 on PA30 mux C */
+#define MUX_PA30C_ABDACB_DACN1          _L_(2)
 #define PINMUX_PA30C_ABDACB_DACN1  ((PIN_PA30C_ABDACB_DACN1 << 16) | MUX_PA30C_ABDACB_DACN1)
-#define GPIO_PA30C_ABDACB_DACN1  _UL(1 << 30)
-#define PIN_PB05C_ABDACB_DACN1         _L(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
-#define MUX_PB05C_ABDACB_DACN1          _L(2)
+#define GPIO_PA30C_ABDACB_DACN1  _UL_(1 << 30)
+#define PIN_PB05C_ABDACB_DACN1         _L_(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
+#define MUX_PB05C_ABDACB_DACN1          _L_(2)
 #define PINMUX_PB05C_ABDACB_DACN1  ((PIN_PB05C_ABDACB_DACN1 << 16) | MUX_PB05C_ABDACB_DACN1)
-#define GPIO_PB05C_ABDACB_DACN1  _UL(1 <<  5)
-#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
-#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define GPIO_PB05C_ABDACB_DACN1  _UL_(1 <<  5)
+#define PIN_PA20B_ABDACB_DACN1         _L_(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L_(1)
 #define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
-#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+#define GPIO_PA20B_ABDACB_DACN1  _UL_(1 << 20)
 /* ========== GPIO definition for PARC peripheral ========== */
-#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
-#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PIN_PA17D_PARC_PCCK            _L_(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L_(3)
 #define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
-#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
-#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
-#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define GPIO_PA17D_PARC_PCCK     _UL_(1 << 17)
+#define PIN_PA09D_PARC_PCDATA0          _L_(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L_(3)
 #define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
-#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
-#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
-#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define GPIO_PA09D_PARC_PCDATA0  _UL_(1 <<  9)
+#define PIN_PA10D_PARC_PCDATA1         _L_(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L_(3)
 #define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
-#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
-#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
-#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define GPIO_PA10D_PARC_PCDATA1  _UL_(1 << 10)
+#define PIN_PA11D_PARC_PCDATA2         _L_(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L_(3)
 #define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
-#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
-#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
-#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define GPIO_PA11D_PARC_PCDATA2  _UL_(1 << 11)
+#define PIN_PA12D_PARC_PCDATA3         _L_(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L_(3)
 #define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
-#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
-#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
-#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL_(1 << 12)
+#define PIN_PA13D_PARC_PCDATA4         _L_(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L_(3)
 #define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
-#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
-#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
-#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define GPIO_PA13D_PARC_PCDATA4  _UL_(1 << 13)
+#define PIN_PA14D_PARC_PCDATA5         _L_(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L_(3)
 #define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
-#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
-#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
-#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define GPIO_PA14D_PARC_PCDATA5  _UL_(1 << 14)
+#define PIN_PA15D_PARC_PCDATA6         _L_(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L_(3)
 #define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
-#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
-#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
-#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define GPIO_PA15D_PARC_PCDATA6  _UL_(1 << 15)
+#define PIN_PA16D_PARC_PCDATA7         _L_(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L_(3)
 #define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
-#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
-#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
-#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define GPIO_PA16D_PARC_PCDATA7  _UL_(1 << 16)
+#define PIN_PA18D_PARC_PCEN1           _L_(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L_(3)
 #define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
-#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
-#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
-#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define GPIO_PA18D_PARC_PCEN1    _UL_(1 << 18)
+#define PIN_PA19D_PARC_PCEN2           _L_(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L_(3)
 #define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
-#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+#define GPIO_PA19D_PARC_PCEN2    _UL_(1 << 19)
 /* ========== GPIO definition for CATB peripheral ========== */
-#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
-#define MUX_PA02G_CATB_DIS              _L(6)
+#define PIN_PA02G_CATB_DIS              _L_(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L_(6)
 #define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
-#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
-#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
-#define MUX_PA12G_CATB_DIS              _L(6)
+#define GPIO_PA02G_CATB_DIS      _UL_(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L_(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L_(6)
 #define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
-#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
-#define MUX_PA23G_CATB_DIS              _L(6)
+#define GPIO_PA12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L_(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L_(6)
 #define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
-#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
-#define PIN_PA31G_CATB_DIS             _L(31) /**< \brief CATB signal: DIS on PA31 mux G */
-#define MUX_PA31G_CATB_DIS              _L(6)
+#define GPIO_PA23G_CATB_DIS      _UL_(1 << 23)
+#define PIN_PA31G_CATB_DIS             _L_(31) /**< \brief CATB signal: DIS on PA31 mux G */
+#define MUX_PA31G_CATB_DIS              _L_(6)
 #define PINMUX_PA31G_CATB_DIS      ((PIN_PA31G_CATB_DIS << 16) | MUX_PA31G_CATB_DIS)
-#define GPIO_PA31G_CATB_DIS      _UL(1 << 31)
-#define PIN_PB03G_CATB_DIS             _L(35) /**< \brief CATB signal: DIS on PB03 mux G */
-#define MUX_PB03G_CATB_DIS              _L(6)
+#define GPIO_PA31G_CATB_DIS      _UL_(1 << 31)
+#define PIN_PB03G_CATB_DIS             _L_(35) /**< \brief CATB signal: DIS on PB03 mux G */
+#define MUX_PB03G_CATB_DIS              _L_(6)
 #define PINMUX_PB03G_CATB_DIS      ((PIN_PB03G_CATB_DIS << 16) | MUX_PB03G_CATB_DIS)
-#define GPIO_PB03G_CATB_DIS      _UL(1 <<  3)
-#define PIN_PB12G_CATB_DIS             _L(44) /**< \brief CATB signal: DIS on PB12 mux G */
-#define MUX_PB12G_CATB_DIS              _L(6)
+#define GPIO_PB03G_CATB_DIS      _UL_(1 <<  3)
+#define PIN_PB12G_CATB_DIS             _L_(44) /**< \brief CATB signal: DIS on PB12 mux G */
+#define MUX_PB12G_CATB_DIS              _L_(6)
 #define PINMUX_PB12G_CATB_DIS      ((PIN_PB12G_CATB_DIS << 16) | MUX_PB12G_CATB_DIS)
-#define GPIO_PB12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
-#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define GPIO_PB12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PA04G_CATB_SENSE0           _L_(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L_(6)
 #define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
-#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
-#define PIN_PA27G_CATB_SENSE0          _L(27) /**< \brief CATB signal: SENSE0 on PA27 mux G */
-#define MUX_PA27G_CATB_SENSE0           _L(6)
+#define GPIO_PA04G_CATB_SENSE0   _UL_(1 <<  4)
+#define PIN_PA27G_CATB_SENSE0          _L_(27) /**< \brief CATB signal: SENSE0 on PA27 mux G */
+#define MUX_PA27G_CATB_SENSE0           _L_(6)
 #define PINMUX_PA27G_CATB_SENSE0   ((PIN_PA27G_CATB_SENSE0 << 16) | MUX_PA27G_CATB_SENSE0)
-#define GPIO_PA27G_CATB_SENSE0   _UL(1 << 27)
-#define PIN_PB13G_CATB_SENSE0          _L(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
-#define MUX_PB13G_CATB_SENSE0           _L(6)
+#define GPIO_PA27G_CATB_SENSE0   _UL_(1 << 27)
+#define PIN_PB13G_CATB_SENSE0          _L_(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
+#define MUX_PB13G_CATB_SENSE0           _L_(6)
 #define PINMUX_PB13G_CATB_SENSE0   ((PIN_PB13G_CATB_SENSE0 << 16) | MUX_PB13G_CATB_SENSE0)
-#define GPIO_PB13G_CATB_SENSE0   _UL(1 << 13)
-#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
-#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define GPIO_PB13G_CATB_SENSE0   _UL_(1 << 13)
+#define PIN_PA05G_CATB_SENSE1           _L_(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L_(6)
 #define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
-#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
-#define PIN_PA28G_CATB_SENSE1          _L(28) /**< \brief CATB signal: SENSE1 on PA28 mux G */
-#define MUX_PA28G_CATB_SENSE1           _L(6)
+#define GPIO_PA05G_CATB_SENSE1   _UL_(1 <<  5)
+#define PIN_PA28G_CATB_SENSE1          _L_(28) /**< \brief CATB signal: SENSE1 on PA28 mux G */
+#define MUX_PA28G_CATB_SENSE1           _L_(6)
 #define PINMUX_PA28G_CATB_SENSE1   ((PIN_PA28G_CATB_SENSE1 << 16) | MUX_PA28G_CATB_SENSE1)
-#define GPIO_PA28G_CATB_SENSE1   _UL(1 << 28)
-#define PIN_PB14G_CATB_SENSE1          _L(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
-#define MUX_PB14G_CATB_SENSE1           _L(6)
+#define GPIO_PA28G_CATB_SENSE1   _UL_(1 << 28)
+#define PIN_PB14G_CATB_SENSE1          _L_(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
+#define MUX_PB14G_CATB_SENSE1           _L_(6)
 #define PINMUX_PB14G_CATB_SENSE1   ((PIN_PB14G_CATB_SENSE1 << 16) | MUX_PB14G_CATB_SENSE1)
-#define GPIO_PB14G_CATB_SENSE1   _UL(1 << 14)
-#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
-#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define GPIO_PB14G_CATB_SENSE1   _UL_(1 << 14)
+#define PIN_PA06G_CATB_SENSE2           _L_(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L_(6)
 #define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
-#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
-#define PIN_PA29G_CATB_SENSE2          _L(29) /**< \brief CATB signal: SENSE2 on PA29 mux G */
-#define MUX_PA29G_CATB_SENSE2           _L(6)
+#define GPIO_PA06G_CATB_SENSE2   _UL_(1 <<  6)
+#define PIN_PA29G_CATB_SENSE2          _L_(29) /**< \brief CATB signal: SENSE2 on PA29 mux G */
+#define MUX_PA29G_CATB_SENSE2           _L_(6)
 #define PINMUX_PA29G_CATB_SENSE2   ((PIN_PA29G_CATB_SENSE2 << 16) | MUX_PA29G_CATB_SENSE2)
-#define GPIO_PA29G_CATB_SENSE2   _UL(1 << 29)
-#define PIN_PB15G_CATB_SENSE2          _L(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
-#define MUX_PB15G_CATB_SENSE2           _L(6)
+#define GPIO_PA29G_CATB_SENSE2   _UL_(1 << 29)
+#define PIN_PB15G_CATB_SENSE2          _L_(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
+#define MUX_PB15G_CATB_SENSE2           _L_(6)
 #define PINMUX_PB15G_CATB_SENSE2   ((PIN_PB15G_CATB_SENSE2 << 16) | MUX_PB15G_CATB_SENSE2)
-#define GPIO_PB15G_CATB_SENSE2   _UL(1 << 15)
-#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
-#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define GPIO_PB15G_CATB_SENSE2   _UL_(1 << 15)
+#define PIN_PA07G_CATB_SENSE3           _L_(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L_(6)
 #define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
-#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
-#define PIN_PA30G_CATB_SENSE3          _L(30) /**< \brief CATB signal: SENSE3 on PA30 mux G */
-#define MUX_PA30G_CATB_SENSE3           _L(6)
+#define GPIO_PA07G_CATB_SENSE3   _UL_(1 <<  7)
+#define PIN_PA30G_CATB_SENSE3          _L_(30) /**< \brief CATB signal: SENSE3 on PA30 mux G */
+#define MUX_PA30G_CATB_SENSE3           _L_(6)
 #define PINMUX_PA30G_CATB_SENSE3   ((PIN_PA30G_CATB_SENSE3 << 16) | MUX_PA30G_CATB_SENSE3)
-#define GPIO_PA30G_CATB_SENSE3   _UL(1 << 30)
-#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
-#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define GPIO_PA30G_CATB_SENSE3   _UL_(1 << 30)
+#define PIN_PA08G_CATB_SENSE4           _L_(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L_(6)
 #define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
-#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
-#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
-#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define GPIO_PA08G_CATB_SENSE4   _UL_(1 <<  8)
+#define PIN_PA09G_CATB_SENSE5           _L_(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L_(6)
 #define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
-#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
-#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
-#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define GPIO_PA09G_CATB_SENSE5   _UL_(1 <<  9)
+#define PIN_PA10G_CATB_SENSE6          _L_(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L_(6)
 #define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
-#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
-#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
-#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define GPIO_PA10G_CATB_SENSE6   _UL_(1 << 10)
+#define PIN_PA11G_CATB_SENSE7          _L_(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L_(6)
 #define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
-#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
-#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
-#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define GPIO_PA11G_CATB_SENSE7   _UL_(1 << 11)
+#define PIN_PA13G_CATB_SENSE8          _L_(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L_(6)
 #define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
-#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
-#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
-#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define GPIO_PA13G_CATB_SENSE8   _UL_(1 << 13)
+#define PIN_PA14G_CATB_SENSE9          _L_(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L_(6)
 #define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
-#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
-#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
-#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define GPIO_PA14G_CATB_SENSE9   _UL_(1 << 14)
+#define PIN_PA15G_CATB_SENSE10         _L_(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L_(6)
 #define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
-#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
-#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
-#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define GPIO_PA15G_CATB_SENSE10  _UL_(1 << 15)
+#define PIN_PA16G_CATB_SENSE11         _L_(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L_(6)
 #define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
-#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
-#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
-#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define GPIO_PA16G_CATB_SENSE11  _UL_(1 << 16)
+#define PIN_PA17G_CATB_SENSE12         _L_(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L_(6)
 #define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
-#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
-#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
-#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define GPIO_PA17G_CATB_SENSE12  _UL_(1 << 17)
+#define PIN_PA18G_CATB_SENSE13         _L_(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L_(6)
 #define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
-#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
-#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
-#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define GPIO_PA18G_CATB_SENSE13  _UL_(1 << 18)
+#define PIN_PA19G_CATB_SENSE14         _L_(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L_(6)
 #define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
-#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
-#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
-#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define GPIO_PA19G_CATB_SENSE14  _UL_(1 << 19)
+#define PIN_PA20G_CATB_SENSE15         _L_(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L_(6)
 #define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
-#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
-#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
-#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define GPIO_PA20G_CATB_SENSE15  _UL_(1 << 20)
+#define PIN_PA21G_CATB_SENSE16         _L_(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L_(6)
 #define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
-#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
-#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
-#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define GPIO_PA21G_CATB_SENSE16  _UL_(1 << 21)
+#define PIN_PA22G_CATB_SENSE17         _L_(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L_(6)
 #define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
-#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
-#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
-#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define GPIO_PA22G_CATB_SENSE17  _UL_(1 << 22)
+#define PIN_PA24G_CATB_SENSE18         _L_(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L_(6)
 #define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
-#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
-#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
-#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define GPIO_PA24G_CATB_SENSE18  _UL_(1 << 24)
+#define PIN_PA25G_CATB_SENSE19         _L_(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L_(6)
 #define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
-#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
-#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
-#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define GPIO_PA25G_CATB_SENSE19  _UL_(1 << 25)
+#define PIN_PA26G_CATB_SENSE20         _L_(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L_(6)
 #define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
-#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
-#define PIN_PB00G_CATB_SENSE21         _L(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
-#define MUX_PB00G_CATB_SENSE21          _L(6)
+#define GPIO_PA26G_CATB_SENSE20  _UL_(1 << 26)
+#define PIN_PB00G_CATB_SENSE21         _L_(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
+#define MUX_PB00G_CATB_SENSE21          _L_(6)
 #define PINMUX_PB00G_CATB_SENSE21  ((PIN_PB00G_CATB_SENSE21 << 16) | MUX_PB00G_CATB_SENSE21)
-#define GPIO_PB00G_CATB_SENSE21  _UL(1 <<  0)
-#define PIN_PB01G_CATB_SENSE22         _L(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
-#define MUX_PB01G_CATB_SENSE22          _L(6)
+#define GPIO_PB00G_CATB_SENSE21  _UL_(1 <<  0)
+#define PIN_PB01G_CATB_SENSE22         _L_(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
+#define MUX_PB01G_CATB_SENSE22          _L_(6)
 #define PINMUX_PB01G_CATB_SENSE22  ((PIN_PB01G_CATB_SENSE22 << 16) | MUX_PB01G_CATB_SENSE22)
-#define GPIO_PB01G_CATB_SENSE22  _UL(1 <<  1)
-#define PIN_PB02G_CATB_SENSE23         _L(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
-#define MUX_PB02G_CATB_SENSE23          _L(6)
+#define GPIO_PB01G_CATB_SENSE22  _UL_(1 <<  1)
+#define PIN_PB02G_CATB_SENSE23         _L_(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
+#define MUX_PB02G_CATB_SENSE23          _L_(6)
 #define PINMUX_PB02G_CATB_SENSE23  ((PIN_PB02G_CATB_SENSE23 << 16) | MUX_PB02G_CATB_SENSE23)
-#define GPIO_PB02G_CATB_SENSE23  _UL(1 <<  2)
-#define PIN_PB04G_CATB_SENSE24         _L(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
-#define MUX_PB04G_CATB_SENSE24          _L(6)
+#define GPIO_PB02G_CATB_SENSE23  _UL_(1 <<  2)
+#define PIN_PB04G_CATB_SENSE24         _L_(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
+#define MUX_PB04G_CATB_SENSE24          _L_(6)
 #define PINMUX_PB04G_CATB_SENSE24  ((PIN_PB04G_CATB_SENSE24 << 16) | MUX_PB04G_CATB_SENSE24)
-#define GPIO_PB04G_CATB_SENSE24  _UL(1 <<  4)
-#define PIN_PB05G_CATB_SENSE25         _L(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
-#define MUX_PB05G_CATB_SENSE25          _L(6)
+#define GPIO_PB04G_CATB_SENSE24  _UL_(1 <<  4)
+#define PIN_PB05G_CATB_SENSE25         _L_(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
+#define MUX_PB05G_CATB_SENSE25          _L_(6)
 #define PINMUX_PB05G_CATB_SENSE25  ((PIN_PB05G_CATB_SENSE25 << 16) | MUX_PB05G_CATB_SENSE25)
-#define GPIO_PB05G_CATB_SENSE25  _UL(1 <<  5)
-#define PIN_PB06G_CATB_SENSE26         _L(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
-#define MUX_PB06G_CATB_SENSE26          _L(6)
+#define GPIO_PB05G_CATB_SENSE25  _UL_(1 <<  5)
+#define PIN_PB06G_CATB_SENSE26         _L_(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
+#define MUX_PB06G_CATB_SENSE26          _L_(6)
 #define PINMUX_PB06G_CATB_SENSE26  ((PIN_PB06G_CATB_SENSE26 << 16) | MUX_PB06G_CATB_SENSE26)
-#define GPIO_PB06G_CATB_SENSE26  _UL(1 <<  6)
-#define PIN_PB07G_CATB_SENSE27         _L(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
-#define MUX_PB07G_CATB_SENSE27          _L(6)
+#define GPIO_PB06G_CATB_SENSE26  _UL_(1 <<  6)
+#define PIN_PB07G_CATB_SENSE27         _L_(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
+#define MUX_PB07G_CATB_SENSE27          _L_(6)
 #define PINMUX_PB07G_CATB_SENSE27  ((PIN_PB07G_CATB_SENSE27 << 16) | MUX_PB07G_CATB_SENSE27)
-#define GPIO_PB07G_CATB_SENSE27  _UL(1 <<  7)
-#define PIN_PB08G_CATB_SENSE28         _L(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
-#define MUX_PB08G_CATB_SENSE28          _L(6)
+#define GPIO_PB07G_CATB_SENSE27  _UL_(1 <<  7)
+#define PIN_PB08G_CATB_SENSE28         _L_(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
+#define MUX_PB08G_CATB_SENSE28          _L_(6)
 #define PINMUX_PB08G_CATB_SENSE28  ((PIN_PB08G_CATB_SENSE28 << 16) | MUX_PB08G_CATB_SENSE28)
-#define GPIO_PB08G_CATB_SENSE28  _UL(1 <<  8)
-#define PIN_PB09G_CATB_SENSE29         _L(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
-#define MUX_PB09G_CATB_SENSE29          _L(6)
+#define GPIO_PB08G_CATB_SENSE28  _UL_(1 <<  8)
+#define PIN_PB09G_CATB_SENSE29         _L_(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
+#define MUX_PB09G_CATB_SENSE29          _L_(6)
 #define PINMUX_PB09G_CATB_SENSE29  ((PIN_PB09G_CATB_SENSE29 << 16) | MUX_PB09G_CATB_SENSE29)
-#define GPIO_PB09G_CATB_SENSE29  _UL(1 <<  9)
-#define PIN_PB10G_CATB_SENSE30         _L(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
-#define MUX_PB10G_CATB_SENSE30          _L(6)
+#define GPIO_PB09G_CATB_SENSE29  _UL_(1 <<  9)
+#define PIN_PB10G_CATB_SENSE30         _L_(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
+#define MUX_PB10G_CATB_SENSE30          _L_(6)
 #define PINMUX_PB10G_CATB_SENSE30  ((PIN_PB10G_CATB_SENSE30 << 16) | MUX_PB10G_CATB_SENSE30)
-#define GPIO_PB10G_CATB_SENSE30  _UL(1 << 10)
-#define PIN_PB11G_CATB_SENSE31         _L(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
-#define MUX_PB11G_CATB_SENSE31          _L(6)
+#define GPIO_PB10G_CATB_SENSE30  _UL_(1 << 10)
+#define PIN_PB11G_CATB_SENSE31         _L_(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
+#define MUX_PB11G_CATB_SENSE31          _L_(6)
 #define PINMUX_PB11G_CATB_SENSE31  ((PIN_PB11G_CATB_SENSE31 << 16) | MUX_PB11G_CATB_SENSE31)
-#define GPIO_PB11G_CATB_SENSE31  _UL(1 << 11)
+#define GPIO_PB11G_CATB_SENSE31  _UL_(1 << 11)
 /* ========== GPIO definition for USBC peripheral ========== */
-#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
-#define MUX_PA25A_USBC_DM               _L(0)
+#define PIN_PA25A_USBC_DM              _L_(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L_(0)
 #define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
-#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
-#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
-#define MUX_PA26A_USBC_DP               _L(0)
+#define GPIO_PA25A_USBC_DM       _UL_(1 << 25)
+#define PIN_PA26A_USBC_DP              _L_(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L_(0)
 #define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
-#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+#define GPIO_PA26A_USBC_DP       _UL_(1 << 26)
 /* ========== GPIO definition for PEVC peripheral ========== */
-#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
-#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PIN_PA08C_PEVC_PAD_EVT0         _L_(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
-#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
-#define PIN_PB12C_PEVC_PAD_EVT0        _L(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
-#define MUX_PB12C_PEVC_PAD_EVT0         _L(2)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL_(1 <<  8)
+#define PIN_PB12C_PEVC_PAD_EVT0        _L_(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
+#define MUX_PB12C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PB12C_PEVC_PAD_EVT0  ((PIN_PB12C_PEVC_PAD_EVT0 << 16) | MUX_PB12C_PEVC_PAD_EVT0)
-#define GPIO_PB12C_PEVC_PAD_EVT0  _UL(1 << 12)
-#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
-#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PB12C_PEVC_PAD_EVT0  _UL_(1 << 12)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L_(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
-#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
-#define PIN_PB13C_PEVC_PAD_EVT1        _L(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
-#define MUX_PB13C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL_(1 <<  9)
+#define PIN_PB13C_PEVC_PAD_EVT1        _L_(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
+#define MUX_PB13C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PB13C_PEVC_PAD_EVT1  ((PIN_PB13C_PEVC_PAD_EVT1 << 16) | MUX_PB13C_PEVC_PAD_EVT1)
-#define GPIO_PB13C_PEVC_PAD_EVT1  _UL(1 << 13)
-#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
-#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PB13C_PEVC_PAD_EVT1  _UL_(1 << 13)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L_(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
-#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
-#define PIN_PB09B_PEVC_PAD_EVT2        _L(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
-#define MUX_PB09B_PEVC_PAD_EVT2         _L(1)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL_(1 << 10)
+#define PIN_PB09B_PEVC_PAD_EVT2        _L_(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
+#define MUX_PB09B_PEVC_PAD_EVT2         _L_(1)
 #define PINMUX_PB09B_PEVC_PAD_EVT2  ((PIN_PB09B_PEVC_PAD_EVT2 << 16) | MUX_PB09B_PEVC_PAD_EVT2)
-#define GPIO_PB09B_PEVC_PAD_EVT2  _UL(1 <<  9)
-#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
-#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define GPIO_PB09B_PEVC_PAD_EVT2  _UL_(1 <<  9)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L_(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L_(2)
 #define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
-#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
-#define PIN_PB10B_PEVC_PAD_EVT3        _L(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
-#define MUX_PB10B_PEVC_PAD_EVT3         _L(1)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL_(1 << 11)
+#define PIN_PB10B_PEVC_PAD_EVT3        _L_(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
+#define MUX_PB10B_PEVC_PAD_EVT3         _L_(1)
 #define PINMUX_PB10B_PEVC_PAD_EVT3  ((PIN_PB10B_PEVC_PAD_EVT3 << 16) | MUX_PB10B_PEVC_PAD_EVT3)
-#define GPIO_PB10B_PEVC_PAD_EVT3  _UL(1 << 10)
+#define GPIO_PB10B_PEVC_PAD_EVT3  _UL_(1 << 10)
 /* ========== GPIO definition for SCIF peripheral ========== */
-#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
-#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PIN_PA19E_SCIF_GCLK0           _L_(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
-#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
-#define PIN_PB10E_SCIF_GCLK0           _L(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
-#define MUX_PB10E_SCIF_GCLK0            _L(4)
+#define GPIO_PA19E_SCIF_GCLK0    _UL_(1 << 19)
+#define PIN_PB10E_SCIF_GCLK0           _L_(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
+#define MUX_PB10E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PB10E_SCIF_GCLK0    ((PIN_PB10E_SCIF_GCLK0 << 16) | MUX_PB10E_SCIF_GCLK0)
-#define GPIO_PB10E_SCIF_GCLK0    _UL(1 << 10)
-#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
-#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define GPIO_PB10E_SCIF_GCLK0    _UL_(1 << 10)
+#define PIN_PA02A_SCIF_GCLK0            _L_(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L_(0)
 #define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
-#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
-#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
-#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define GPIO_PA02A_SCIF_GCLK0    _UL_(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L_(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
-#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
-#define PIN_PB11E_SCIF_GCLK1           _L(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
-#define MUX_PB11E_SCIF_GCLK1            _L(4)
+#define GPIO_PA20E_SCIF_GCLK1    _UL_(1 << 20)
+#define PIN_PB11E_SCIF_GCLK1           _L_(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
+#define MUX_PB11E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PB11E_SCIF_GCLK1    ((PIN_PB11E_SCIF_GCLK1 << 16) | MUX_PB11E_SCIF_GCLK1)
-#define GPIO_PB11E_SCIF_GCLK1    _UL(1 << 11)
-#define PIN_PB12E_SCIF_GCLK2           _L(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
-#define MUX_PB12E_SCIF_GCLK2            _L(4)
+#define GPIO_PB11E_SCIF_GCLK1    _UL_(1 << 11)
+#define PIN_PB12E_SCIF_GCLK2           _L_(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
+#define MUX_PB12E_SCIF_GCLK2            _L_(4)
 #define PINMUX_PB12E_SCIF_GCLK2    ((PIN_PB12E_SCIF_GCLK2 << 16) | MUX_PB12E_SCIF_GCLK2)
-#define GPIO_PB12E_SCIF_GCLK2    _UL(1 << 12)
-#define PIN_PB13E_SCIF_GCLK3           _L(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
-#define MUX_PB13E_SCIF_GCLK3            _L(4)
+#define GPIO_PB12E_SCIF_GCLK2    _UL_(1 << 12)
+#define PIN_PB13E_SCIF_GCLK3           _L_(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
+#define MUX_PB13E_SCIF_GCLK3            _L_(4)
 #define PINMUX_PB13E_SCIF_GCLK3    ((PIN_PB13E_SCIF_GCLK3 << 16) | MUX_PB13E_SCIF_GCLK3)
-#define GPIO_PB13E_SCIF_GCLK3    _UL(1 << 13)
-#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
-#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PB13E_SCIF_GCLK3    _UL_(1 << 13)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L_(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
-#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
-#define PIN_PB14E_SCIF_GCLK_IN0        _L(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
-#define MUX_PB14E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL_(1 << 23)
+#define PIN_PB14E_SCIF_GCLK_IN0        _L_(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
+#define MUX_PB14E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PB14E_SCIF_GCLK_IN0  ((PIN_PB14E_SCIF_GCLK_IN0 << 16) | MUX_PB14E_SCIF_GCLK_IN0)
-#define GPIO_PB14E_SCIF_GCLK_IN0  _UL(1 << 14)
-#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
-#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PB14E_SCIF_GCLK_IN0  _UL_(1 << 14)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L_(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
-#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
-#define PIN_PB15E_SCIF_GCLK_IN1        _L(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
-#define MUX_PB15E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL_(1 << 24)
+#define PIN_PB15E_SCIF_GCLK_IN1        _L_(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
+#define MUX_PB15E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PB15E_SCIF_GCLK_IN1  ((PIN_PB15E_SCIF_GCLK_IN1 << 16) | MUX_PB15E_SCIF_GCLK_IN1)
-#define GPIO_PB15E_SCIF_GCLK_IN1  _UL(1 << 15)
+#define GPIO_PB15E_SCIF_GCLK_IN1  _UL_(1 << 15)
 /* ========== GPIO definition for EIC peripheral ========== */
-#define PIN_PB01C_EIC_EXTINT0          _L(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
-#define MUX_PB01C_EIC_EXTINT0           _L(2)
+#define PIN_PB01C_EIC_EXTINT0          _L_(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
+#define MUX_PB01C_EIC_EXTINT0           _L_(2)
 #define PINMUX_PB01C_EIC_EXTINT0   ((PIN_PB01C_EIC_EXTINT0 << 16) | MUX_PB01C_EIC_EXTINT0)
-#define GPIO_PB01C_EIC_EXTINT0   _UL(1 <<  1)
-#define PIN_PB01C_EIC_EXTINT_NUM        _L(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
-#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
-#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define GPIO_PB01C_EIC_EXTINT0   _UL_(1 <<  1)
+#define PIN_PB01C_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PA06C_EIC_EXTINT1           _L_(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
-#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
-#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
-#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
-#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define GPIO_PA06C_EIC_EXTINT1   _UL_(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L_(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
-#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
-#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
-#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
-#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define GPIO_PA16C_EIC_EXTINT1   _UL_(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L_(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
-#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
-#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
-#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
-#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL_(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L_(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
-#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
-#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
-#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
-#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL_(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L_(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
-#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
-#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
-#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
-#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define GPIO_PA05C_EIC_EXTINT3   _UL_(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L_(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
-#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
-#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
-#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
-#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define GPIO_PA18C_EIC_EXTINT3   _UL_(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L_(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
-#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
-#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
-#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
-#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define GPIO_PA07C_EIC_EXTINT4   _UL_(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L_(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
-#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
-#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
-#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
-#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define GPIO_PA19C_EIC_EXTINT4   _UL_(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L_(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L_(2)
 #define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
-#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
-#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
-#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
-#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define GPIO_PA20C_EIC_EXTINT5   _UL_(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L_(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L_(2)
 #define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
-#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
-#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
-#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
-#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define GPIO_PA21C_EIC_EXTINT6   _UL_(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L_(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L_(2)
 #define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
-#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
-#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
-#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
-#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define GPIO_PA22C_EIC_EXTINT7   _UL_(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L_(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L_(2)
 #define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
-#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
-#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define GPIO_PA23C_EIC_EXTINT8   _UL_(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
 
 #endif /* _SAM4LS2B_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4ls2c.h
+++ b/asf/sam/include/sam4l/pio/sam4ls2c.h
@@ -30,1728 +30,1728 @@
 #define _SAM4LS2C_PIO_
 
 #define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
-#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define GPIO_PA00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PA00 */
 #define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
-#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define GPIO_PA01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PA01 */
 #define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
-#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define GPIO_PA02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PA02 */
 #define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
-#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define GPIO_PA03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PA03 */
 #define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
-#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define GPIO_PA04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PA04 */
 #define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
-#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define GPIO_PA05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PA05 */
 #define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
-#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define GPIO_PA06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PA06 */
 #define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
-#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define GPIO_PA07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PA07 */
 #define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
-#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define GPIO_PA08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PA08 */
 #define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
-#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define GPIO_PA09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PA09 */
 #define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
-#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define GPIO_PA10                _UL_(1 << 10) /**< \brief GPIO Mask  for PA10 */
 #define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
-#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define GPIO_PA11                _UL_(1 << 11) /**< \brief GPIO Mask  for PA11 */
 #define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
-#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define GPIO_PA12                _UL_(1 << 12) /**< \brief GPIO Mask  for PA12 */
 #define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
-#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define GPIO_PA13                _UL_(1 << 13) /**< \brief GPIO Mask  for PA13 */
 #define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
-#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define GPIO_PA14                _UL_(1 << 14) /**< \brief GPIO Mask  for PA14 */
 #define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
-#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define GPIO_PA15                _UL_(1 << 15) /**< \brief GPIO Mask  for PA15 */
 #define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
-#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define GPIO_PA16                _UL_(1 << 16) /**< \brief GPIO Mask  for PA16 */
 #define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
-#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define GPIO_PA17                _UL_(1 << 17) /**< \brief GPIO Mask  for PA17 */
 #define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
-#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define GPIO_PA18                _UL_(1 << 18) /**< \brief GPIO Mask  for PA18 */
 #define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
-#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define GPIO_PA19                _UL_(1 << 19) /**< \brief GPIO Mask  for PA19 */
 #define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
-#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define GPIO_PA20                _UL_(1 << 20) /**< \brief GPIO Mask  for PA20 */
 #define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
-#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define GPIO_PA21                _UL_(1 << 21) /**< \brief GPIO Mask  for PA21 */
 #define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
-#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define GPIO_PA22                _UL_(1 << 22) /**< \brief GPIO Mask  for PA22 */
 #define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
-#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define GPIO_PA23                _UL_(1 << 23) /**< \brief GPIO Mask  for PA23 */
 #define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
-#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define GPIO_PA24                _UL_(1 << 24) /**< \brief GPIO Mask  for PA24 */
 #define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
-#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define GPIO_PA25                _UL_(1 << 25) /**< \brief GPIO Mask  for PA25 */
 #define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
-#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define GPIO_PA26                _UL_(1 << 26) /**< \brief GPIO Mask  for PA26 */
 #define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
-#define GPIO_PA27                _UL(1 << 27) /**< \brief GPIO Mask  for PA27 */
+#define GPIO_PA27                _UL_(1 << 27) /**< \brief GPIO Mask  for PA27 */
 #define PIN_PA28                          28  /**< \brief Pin Number for PA28 */
-#define GPIO_PA28                _UL(1 << 28) /**< \brief GPIO Mask  for PA28 */
+#define GPIO_PA28                _UL_(1 << 28) /**< \brief GPIO Mask  for PA28 */
 #define PIN_PA29                          29  /**< \brief Pin Number for PA29 */
-#define GPIO_PA29                _UL(1 << 29) /**< \brief GPIO Mask  for PA29 */
+#define GPIO_PA29                _UL_(1 << 29) /**< \brief GPIO Mask  for PA29 */
 #define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
-#define GPIO_PA30                _UL(1 << 30) /**< \brief GPIO Mask  for PA30 */
+#define GPIO_PA30                _UL_(1 << 30) /**< \brief GPIO Mask  for PA30 */
 #define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
-#define GPIO_PA31                _UL(1 << 31) /**< \brief GPIO Mask  for PA31 */
+#define GPIO_PA31                _UL_(1 << 31) /**< \brief GPIO Mask  for PA31 */
 #define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
-#define GPIO_PB00                _UL(1 <<  0) /**< \brief GPIO Mask  for PB00 */
+#define GPIO_PB00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PB00 */
 #define PIN_PB01                          33  /**< \brief Pin Number for PB01 */
-#define GPIO_PB01                _UL(1 <<  1) /**< \brief GPIO Mask  for PB01 */
+#define GPIO_PB01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PB01 */
 #define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
-#define GPIO_PB02                _UL(1 <<  2) /**< \brief GPIO Mask  for PB02 */
+#define GPIO_PB02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PB02 */
 #define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
-#define GPIO_PB03                _UL(1 <<  3) /**< \brief GPIO Mask  for PB03 */
+#define GPIO_PB03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PB03 */
 #define PIN_PB04                          36  /**< \brief Pin Number for PB04 */
-#define GPIO_PB04                _UL(1 <<  4) /**< \brief GPIO Mask  for PB04 */
+#define GPIO_PB04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PB04 */
 #define PIN_PB05                          37  /**< \brief Pin Number for PB05 */
-#define GPIO_PB05                _UL(1 <<  5) /**< \brief GPIO Mask  for PB05 */
+#define GPIO_PB05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PB05 */
 #define PIN_PB06                          38  /**< \brief Pin Number for PB06 */
-#define GPIO_PB06                _UL(1 <<  6) /**< \brief GPIO Mask  for PB06 */
+#define GPIO_PB06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PB06 */
 #define PIN_PB07                          39  /**< \brief Pin Number for PB07 */
-#define GPIO_PB07                _UL(1 <<  7) /**< \brief GPIO Mask  for PB07 */
+#define GPIO_PB07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PB07 */
 #define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
-#define GPIO_PB08                _UL(1 <<  8) /**< \brief GPIO Mask  for PB08 */
+#define GPIO_PB08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PB08 */
 #define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
-#define GPIO_PB09                _UL(1 <<  9) /**< \brief GPIO Mask  for PB09 */
+#define GPIO_PB09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PB09 */
 #define PIN_PB10                          42  /**< \brief Pin Number for PB10 */
-#define GPIO_PB10                _UL(1 << 10) /**< \brief GPIO Mask  for PB10 */
+#define GPIO_PB10                _UL_(1 << 10) /**< \brief GPIO Mask  for PB10 */
 #define PIN_PB11                          43  /**< \brief Pin Number for PB11 */
-#define GPIO_PB11                _UL(1 << 11) /**< \brief GPIO Mask  for PB11 */
+#define GPIO_PB11                _UL_(1 << 11) /**< \brief GPIO Mask  for PB11 */
 #define PIN_PB12                          44  /**< \brief Pin Number for PB12 */
-#define GPIO_PB12                _UL(1 << 12) /**< \brief GPIO Mask  for PB12 */
+#define GPIO_PB12                _UL_(1 << 12) /**< \brief GPIO Mask  for PB12 */
 #define PIN_PB13                          45  /**< \brief Pin Number for PB13 */
-#define GPIO_PB13                _UL(1 << 13) /**< \brief GPIO Mask  for PB13 */
+#define GPIO_PB13                _UL_(1 << 13) /**< \brief GPIO Mask  for PB13 */
 #define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
-#define GPIO_PB14                _UL(1 << 14) /**< \brief GPIO Mask  for PB14 */
+#define GPIO_PB14                _UL_(1 << 14) /**< \brief GPIO Mask  for PB14 */
 #define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
-#define GPIO_PB15                _UL(1 << 15) /**< \brief GPIO Mask  for PB15 */
+#define GPIO_PB15                _UL_(1 << 15) /**< \brief GPIO Mask  for PB15 */
 #define PIN_PC00                          64  /**< \brief Pin Number for PC00 */
-#define GPIO_PC00                _UL(1 <<  0) /**< \brief GPIO Mask  for PC00 */
+#define GPIO_PC00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PC00 */
 #define PIN_PC01                          65  /**< \brief Pin Number for PC01 */
-#define GPIO_PC01                _UL(1 <<  1) /**< \brief GPIO Mask  for PC01 */
+#define GPIO_PC01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PC01 */
 #define PIN_PC02                          66  /**< \brief Pin Number for PC02 */
-#define GPIO_PC02                _UL(1 <<  2) /**< \brief GPIO Mask  for PC02 */
+#define GPIO_PC02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PC02 */
 #define PIN_PC03                          67  /**< \brief Pin Number for PC03 */
-#define GPIO_PC03                _UL(1 <<  3) /**< \brief GPIO Mask  for PC03 */
+#define GPIO_PC03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PC03 */
 #define PIN_PC04                          68  /**< \brief Pin Number for PC04 */
-#define GPIO_PC04                _UL(1 <<  4) /**< \brief GPIO Mask  for PC04 */
+#define GPIO_PC04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PC04 */
 #define PIN_PC05                          69  /**< \brief Pin Number for PC05 */
-#define GPIO_PC05                _UL(1 <<  5) /**< \brief GPIO Mask  for PC05 */
+#define GPIO_PC05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PC05 */
 #define PIN_PC06                          70  /**< \brief Pin Number for PC06 */
-#define GPIO_PC06                _UL(1 <<  6) /**< \brief GPIO Mask  for PC06 */
+#define GPIO_PC06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PC06 */
 #define PIN_PC07                          71  /**< \brief Pin Number for PC07 */
-#define GPIO_PC07                _UL(1 <<  7) /**< \brief GPIO Mask  for PC07 */
+#define GPIO_PC07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PC07 */
 #define PIN_PC08                          72  /**< \brief Pin Number for PC08 */
-#define GPIO_PC08                _UL(1 <<  8) /**< \brief GPIO Mask  for PC08 */
+#define GPIO_PC08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PC08 */
 #define PIN_PC09                          73  /**< \brief Pin Number for PC09 */
-#define GPIO_PC09                _UL(1 <<  9) /**< \brief GPIO Mask  for PC09 */
+#define GPIO_PC09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PC09 */
 #define PIN_PC10                          74  /**< \brief Pin Number for PC10 */
-#define GPIO_PC10                _UL(1 << 10) /**< \brief GPIO Mask  for PC10 */
+#define GPIO_PC10                _UL_(1 << 10) /**< \brief GPIO Mask  for PC10 */
 #define PIN_PC11                          75  /**< \brief Pin Number for PC11 */
-#define GPIO_PC11                _UL(1 << 11) /**< \brief GPIO Mask  for PC11 */
+#define GPIO_PC11                _UL_(1 << 11) /**< \brief GPIO Mask  for PC11 */
 #define PIN_PC12                          76  /**< \brief Pin Number for PC12 */
-#define GPIO_PC12                _UL(1 << 12) /**< \brief GPIO Mask  for PC12 */
+#define GPIO_PC12                _UL_(1 << 12) /**< \brief GPIO Mask  for PC12 */
 #define PIN_PC13                          77  /**< \brief Pin Number for PC13 */
-#define GPIO_PC13                _UL(1 << 13) /**< \brief GPIO Mask  for PC13 */
+#define GPIO_PC13                _UL_(1 << 13) /**< \brief GPIO Mask  for PC13 */
 #define PIN_PC14                          78  /**< \brief Pin Number for PC14 */
-#define GPIO_PC14                _UL(1 << 14) /**< \brief GPIO Mask  for PC14 */
+#define GPIO_PC14                _UL_(1 << 14) /**< \brief GPIO Mask  for PC14 */
 #define PIN_PC15                          79  /**< \brief Pin Number for PC15 */
-#define GPIO_PC15                _UL(1 << 15) /**< \brief GPIO Mask  for PC15 */
+#define GPIO_PC15                _UL_(1 << 15) /**< \brief GPIO Mask  for PC15 */
 #define PIN_PC16                          80  /**< \brief Pin Number for PC16 */
-#define GPIO_PC16                _UL(1 << 16) /**< \brief GPIO Mask  for PC16 */
+#define GPIO_PC16                _UL_(1 << 16) /**< \brief GPIO Mask  for PC16 */
 #define PIN_PC17                          81  /**< \brief Pin Number for PC17 */
-#define GPIO_PC17                _UL(1 << 17) /**< \brief GPIO Mask  for PC17 */
+#define GPIO_PC17                _UL_(1 << 17) /**< \brief GPIO Mask  for PC17 */
 #define PIN_PC18                          82  /**< \brief Pin Number for PC18 */
-#define GPIO_PC18                _UL(1 << 18) /**< \brief GPIO Mask  for PC18 */
+#define GPIO_PC18                _UL_(1 << 18) /**< \brief GPIO Mask  for PC18 */
 #define PIN_PC19                          83  /**< \brief Pin Number for PC19 */
-#define GPIO_PC19                _UL(1 << 19) /**< \brief GPIO Mask  for PC19 */
+#define GPIO_PC19                _UL_(1 << 19) /**< \brief GPIO Mask  for PC19 */
 #define PIN_PC20                          84  /**< \brief Pin Number for PC20 */
-#define GPIO_PC20                _UL(1 << 20) /**< \brief GPIO Mask  for PC20 */
+#define GPIO_PC20                _UL_(1 << 20) /**< \brief GPIO Mask  for PC20 */
 #define PIN_PC21                          85  /**< \brief Pin Number for PC21 */
-#define GPIO_PC21                _UL(1 << 21) /**< \brief GPIO Mask  for PC21 */
+#define GPIO_PC21                _UL_(1 << 21) /**< \brief GPIO Mask  for PC21 */
 #define PIN_PC22                          86  /**< \brief Pin Number for PC22 */
-#define GPIO_PC22                _UL(1 << 22) /**< \brief GPIO Mask  for PC22 */
+#define GPIO_PC22                _UL_(1 << 22) /**< \brief GPIO Mask  for PC22 */
 #define PIN_PC23                          87  /**< \brief Pin Number for PC23 */
-#define GPIO_PC23                _UL(1 << 23) /**< \brief GPIO Mask  for PC23 */
+#define GPIO_PC23                _UL_(1 << 23) /**< \brief GPIO Mask  for PC23 */
 #define PIN_PC24                          88  /**< \brief Pin Number for PC24 */
-#define GPIO_PC24                _UL(1 << 24) /**< \brief GPIO Mask  for PC24 */
+#define GPIO_PC24                _UL_(1 << 24) /**< \brief GPIO Mask  for PC24 */
 #define PIN_PC25                          89  /**< \brief Pin Number for PC25 */
-#define GPIO_PC25                _UL(1 << 25) /**< \brief GPIO Mask  for PC25 */
+#define GPIO_PC25                _UL_(1 << 25) /**< \brief GPIO Mask  for PC25 */
 #define PIN_PC26                          90  /**< \brief Pin Number for PC26 */
-#define GPIO_PC26                _UL(1 << 26) /**< \brief GPIO Mask  for PC26 */
+#define GPIO_PC26                _UL_(1 << 26) /**< \brief GPIO Mask  for PC26 */
 #define PIN_PC27                          91  /**< \brief Pin Number for PC27 */
-#define GPIO_PC27                _UL(1 << 27) /**< \brief GPIO Mask  for PC27 */
+#define GPIO_PC27                _UL_(1 << 27) /**< \brief GPIO Mask  for PC27 */
 #define PIN_PC28                          92  /**< \brief Pin Number for PC28 */
-#define GPIO_PC28                _UL(1 << 28) /**< \brief GPIO Mask  for PC28 */
+#define GPIO_PC28                _UL_(1 << 28) /**< \brief GPIO Mask  for PC28 */
 #define PIN_PC29                          93  /**< \brief Pin Number for PC29 */
-#define GPIO_PC29                _UL(1 << 29) /**< \brief GPIO Mask  for PC29 */
+#define GPIO_PC29                _UL_(1 << 29) /**< \brief GPIO Mask  for PC29 */
 #define PIN_PC30                          94  /**< \brief Pin Number for PC30 */
-#define GPIO_PC30                _UL(1 << 30) /**< \brief GPIO Mask  for PC30 */
+#define GPIO_PC30                _UL_(1 << 30) /**< \brief GPIO Mask  for PC30 */
 #define PIN_PC31                          95  /**< \brief Pin Number for PC31 */
-#define GPIO_PC31                _UL(1 << 31) /**< \brief GPIO Mask  for PC31 */
+#define GPIO_PC31                _UL_(1 << 31) /**< \brief GPIO Mask  for PC31 */
 /* ========== GPIO definition for TWIMS0 peripheral ========== */
-#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
-#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PIN_PA24B_TWIMS0_TWCK          _L_(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L_(1)
 #define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
-#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
-#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
-#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL_(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L_(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L_(1)
 #define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
-#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+#define GPIO_PA23B_TWIMS0_TWD    _UL_(1 << 23)
 /* ========== GPIO definition for TWIMS1 peripheral ========== */
-#define PIN_PB01A_TWIMS1_TWCK          _L(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
-#define MUX_PB01A_TWIMS1_TWCK           _L(0)
+#define PIN_PB01A_TWIMS1_TWCK          _L_(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
+#define MUX_PB01A_TWIMS1_TWCK           _L_(0)
 #define PINMUX_PB01A_TWIMS1_TWCK   ((PIN_PB01A_TWIMS1_TWCK << 16) | MUX_PB01A_TWIMS1_TWCK)
-#define GPIO_PB01A_TWIMS1_TWCK   _UL(1 <<  1)
-#define PIN_PB00A_TWIMS1_TWD           _L(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
-#define MUX_PB00A_TWIMS1_TWD            _L(0)
+#define GPIO_PB01A_TWIMS1_TWCK   _UL_(1 <<  1)
+#define PIN_PB00A_TWIMS1_TWD           _L_(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
+#define MUX_PB00A_TWIMS1_TWD            _L_(0)
 #define PINMUX_PB00A_TWIMS1_TWD    ((PIN_PB00A_TWIMS1_TWD << 16) | MUX_PB00A_TWIMS1_TWD)
-#define GPIO_PB00A_TWIMS1_TWD    _UL(1 <<  0)
+#define GPIO_PB00A_TWIMS1_TWD    _UL_(1 <<  0)
 /* ========== GPIO definition for TWIMS2 peripheral ========== */
-#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
-#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PIN_PA22E_TWIMS2_TWCK          _L_(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L_(4)
 #define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
-#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
-#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
-#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL_(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L_(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L_(4)
 #define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
-#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+#define GPIO_PA21E_TWIMS2_TWD    _UL_(1 << 21)
 /* ========== GPIO definition for TWIMS3 peripheral ========== */
-#define PIN_PB15C_TWIMS3_TWCK          _L(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
-#define MUX_PB15C_TWIMS3_TWCK           _L(2)
+#define PIN_PB15C_TWIMS3_TWCK          _L_(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
+#define MUX_PB15C_TWIMS3_TWCK           _L_(2)
 #define PINMUX_PB15C_TWIMS3_TWCK   ((PIN_PB15C_TWIMS3_TWCK << 16) | MUX_PB15C_TWIMS3_TWCK)
-#define GPIO_PB15C_TWIMS3_TWCK   _UL(1 << 15)
-#define PIN_PB14C_TWIMS3_TWD           _L(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
-#define MUX_PB14C_TWIMS3_TWD            _L(2)
+#define GPIO_PB15C_TWIMS3_TWCK   _UL_(1 << 15)
+#define PIN_PB14C_TWIMS3_TWD           _L_(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
+#define MUX_PB14C_TWIMS3_TWD            _L_(2)
 #define PINMUX_PB14C_TWIMS3_TWD    ((PIN_PB14C_TWIMS3_TWD << 16) | MUX_PB14C_TWIMS3_TWD)
-#define GPIO_PB14C_TWIMS3_TWD    _UL(1 << 14)
+#define GPIO_PB14C_TWIMS3_TWD    _UL_(1 << 14)
 /* ========== GPIO definition for IISC peripheral ========== */
-#define PIN_PB05D_IISC_IMCK            _L(37) /**< \brief IISC signal: IMCK on PB05 mux D */
-#define MUX_PB05D_IISC_IMCK             _L(3)
+#define PIN_PB05D_IISC_IMCK            _L_(37) /**< \brief IISC signal: IMCK on PB05 mux D */
+#define MUX_PB05D_IISC_IMCK             _L_(3)
 #define PINMUX_PB05D_IISC_IMCK     ((PIN_PB05D_IISC_IMCK << 16) | MUX_PB05D_IISC_IMCK)
-#define GPIO_PB05D_IISC_IMCK     _UL(1 <<  5)
-#define PIN_PC14D_IISC_IMCK            _L(78) /**< \brief IISC signal: IMCK on PC14 mux D */
-#define MUX_PC14D_IISC_IMCK             _L(3)
+#define GPIO_PB05D_IISC_IMCK     _UL_(1 <<  5)
+#define PIN_PC14D_IISC_IMCK            _L_(78) /**< \brief IISC signal: IMCK on PC14 mux D */
+#define MUX_PC14D_IISC_IMCK             _L_(3)
 #define PINMUX_PC14D_IISC_IMCK     ((PIN_PC14D_IISC_IMCK << 16) | MUX_PC14D_IISC_IMCK)
-#define GPIO_PC14D_IISC_IMCK     _UL(1 << 14)
-#define PIN_PA31B_IISC_IMCK            _L(31) /**< \brief IISC signal: IMCK on PA31 mux B */
-#define MUX_PA31B_IISC_IMCK             _L(1)
+#define GPIO_PC14D_IISC_IMCK     _UL_(1 << 14)
+#define PIN_PA31B_IISC_IMCK            _L_(31) /**< \brief IISC signal: IMCK on PA31 mux B */
+#define MUX_PA31B_IISC_IMCK             _L_(1)
 #define PINMUX_PA31B_IISC_IMCK     ((PIN_PA31B_IISC_IMCK << 16) | MUX_PA31B_IISC_IMCK)
-#define GPIO_PA31B_IISC_IMCK     _UL(1 << 31)
-#define PIN_PB02D_IISC_ISCK            _L(34) /**< \brief IISC signal: ISCK on PB02 mux D */
-#define MUX_PB02D_IISC_ISCK             _L(3)
+#define GPIO_PA31B_IISC_IMCK     _UL_(1 << 31)
+#define PIN_PB02D_IISC_ISCK            _L_(34) /**< \brief IISC signal: ISCK on PB02 mux D */
+#define MUX_PB02D_IISC_ISCK             _L_(3)
 #define PINMUX_PB02D_IISC_ISCK     ((PIN_PB02D_IISC_ISCK << 16) | MUX_PB02D_IISC_ISCK)
-#define GPIO_PB02D_IISC_ISCK     _UL(1 <<  2)
-#define PIN_PC09D_IISC_ISCK            _L(73) /**< \brief IISC signal: ISCK on PC09 mux D */
-#define MUX_PC09D_IISC_ISCK             _L(3)
+#define GPIO_PB02D_IISC_ISCK     _UL_(1 <<  2)
+#define PIN_PC09D_IISC_ISCK            _L_(73) /**< \brief IISC signal: ISCK on PC09 mux D */
+#define MUX_PC09D_IISC_ISCK             _L_(3)
 #define PINMUX_PC09D_IISC_ISCK     ((PIN_PC09D_IISC_ISCK << 16) | MUX_PC09D_IISC_ISCK)
-#define GPIO_PC09D_IISC_ISCK     _UL(1 <<  9)
-#define PIN_PA27B_IISC_ISCK            _L(27) /**< \brief IISC signal: ISCK on PA27 mux B */
-#define MUX_PA27B_IISC_ISCK             _L(1)
+#define GPIO_PC09D_IISC_ISCK     _UL_(1 <<  9)
+#define PIN_PA27B_IISC_ISCK            _L_(27) /**< \brief IISC signal: ISCK on PA27 mux B */
+#define MUX_PA27B_IISC_ISCK             _L_(1)
 #define PINMUX_PA27B_IISC_ISCK     ((PIN_PA27B_IISC_ISCK << 16) | MUX_PA27B_IISC_ISCK)
-#define GPIO_PA27B_IISC_ISCK     _UL(1 << 27)
-#define PIN_PB03D_IISC_ISDI            _L(35) /**< \brief IISC signal: ISDI on PB03 mux D */
-#define MUX_PB03D_IISC_ISDI             _L(3)
+#define GPIO_PA27B_IISC_ISCK     _UL_(1 << 27)
+#define PIN_PB03D_IISC_ISDI            _L_(35) /**< \brief IISC signal: ISDI on PB03 mux D */
+#define MUX_PB03D_IISC_ISDI             _L_(3)
 #define PINMUX_PB03D_IISC_ISDI     ((PIN_PB03D_IISC_ISDI << 16) | MUX_PB03D_IISC_ISDI)
-#define GPIO_PB03D_IISC_ISDI     _UL(1 <<  3)
-#define PIN_PC10D_IISC_ISDI            _L(74) /**< \brief IISC signal: ISDI on PC10 mux D */
-#define MUX_PC10D_IISC_ISDI             _L(3)
+#define GPIO_PB03D_IISC_ISDI     _UL_(1 <<  3)
+#define PIN_PC10D_IISC_ISDI            _L_(74) /**< \brief IISC signal: ISDI on PC10 mux D */
+#define MUX_PC10D_IISC_ISDI             _L_(3)
 #define PINMUX_PC10D_IISC_ISDI     ((PIN_PC10D_IISC_ISDI << 16) | MUX_PC10D_IISC_ISDI)
-#define GPIO_PC10D_IISC_ISDI     _UL(1 << 10)
-#define PIN_PA28B_IISC_ISDI            _L(28) /**< \brief IISC signal: ISDI on PA28 mux B */
-#define MUX_PA28B_IISC_ISDI             _L(1)
+#define GPIO_PC10D_IISC_ISDI     _UL_(1 << 10)
+#define PIN_PA28B_IISC_ISDI            _L_(28) /**< \brief IISC signal: ISDI on PA28 mux B */
+#define MUX_PA28B_IISC_ISDI             _L_(1)
 #define PINMUX_PA28B_IISC_ISDI     ((PIN_PA28B_IISC_ISDI << 16) | MUX_PA28B_IISC_ISDI)
-#define GPIO_PA28B_IISC_ISDI     _UL(1 << 28)
-#define PIN_PB04D_IISC_ISDO            _L(36) /**< \brief IISC signal: ISDO on PB04 mux D */
-#define MUX_PB04D_IISC_ISDO             _L(3)
+#define GPIO_PA28B_IISC_ISDI     _UL_(1 << 28)
+#define PIN_PB04D_IISC_ISDO            _L_(36) /**< \brief IISC signal: ISDO on PB04 mux D */
+#define MUX_PB04D_IISC_ISDO             _L_(3)
 #define PINMUX_PB04D_IISC_ISDO     ((PIN_PB04D_IISC_ISDO << 16) | MUX_PB04D_IISC_ISDO)
-#define GPIO_PB04D_IISC_ISDO     _UL(1 <<  4)
-#define PIN_PC13D_IISC_ISDO            _L(77) /**< \brief IISC signal: ISDO on PC13 mux D */
-#define MUX_PC13D_IISC_ISDO             _L(3)
+#define GPIO_PB04D_IISC_ISDO     _UL_(1 <<  4)
+#define PIN_PC13D_IISC_ISDO            _L_(77) /**< \brief IISC signal: ISDO on PC13 mux D */
+#define MUX_PC13D_IISC_ISDO             _L_(3)
 #define PINMUX_PC13D_IISC_ISDO     ((PIN_PC13D_IISC_ISDO << 16) | MUX_PC13D_IISC_ISDO)
-#define GPIO_PC13D_IISC_ISDO     _UL(1 << 13)
-#define PIN_PA30B_IISC_ISDO            _L(30) /**< \brief IISC signal: ISDO on PA30 mux B */
-#define MUX_PA30B_IISC_ISDO             _L(1)
+#define GPIO_PC13D_IISC_ISDO     _UL_(1 << 13)
+#define PIN_PA30B_IISC_ISDO            _L_(30) /**< \brief IISC signal: ISDO on PA30 mux B */
+#define MUX_PA30B_IISC_ISDO             _L_(1)
 #define PINMUX_PA30B_IISC_ISDO     ((PIN_PA30B_IISC_ISDO << 16) | MUX_PA30B_IISC_ISDO)
-#define GPIO_PA30B_IISC_ISDO     _UL(1 << 30)
-#define PIN_PB06D_IISC_IWS             _L(38) /**< \brief IISC signal: IWS on PB06 mux D */
-#define MUX_PB06D_IISC_IWS              _L(3)
+#define GPIO_PA30B_IISC_ISDO     _UL_(1 << 30)
+#define PIN_PB06D_IISC_IWS             _L_(38) /**< \brief IISC signal: IWS on PB06 mux D */
+#define MUX_PB06D_IISC_IWS              _L_(3)
 #define PINMUX_PB06D_IISC_IWS      ((PIN_PB06D_IISC_IWS << 16) | MUX_PB06D_IISC_IWS)
-#define GPIO_PB06D_IISC_IWS      _UL(1 <<  6)
-#define PIN_PC12D_IISC_IWS             _L(76) /**< \brief IISC signal: IWS on PC12 mux D */
-#define MUX_PC12D_IISC_IWS              _L(3)
+#define GPIO_PB06D_IISC_IWS      _UL_(1 <<  6)
+#define PIN_PC12D_IISC_IWS             _L_(76) /**< \brief IISC signal: IWS on PC12 mux D */
+#define MUX_PC12D_IISC_IWS              _L_(3)
 #define PINMUX_PC12D_IISC_IWS      ((PIN_PC12D_IISC_IWS << 16) | MUX_PC12D_IISC_IWS)
-#define GPIO_PC12D_IISC_IWS      _UL(1 << 12)
-#define PIN_PA29B_IISC_IWS             _L(29) /**< \brief IISC signal: IWS on PA29 mux B */
-#define MUX_PA29B_IISC_IWS              _L(1)
+#define GPIO_PC12D_IISC_IWS      _UL_(1 << 12)
+#define PIN_PA29B_IISC_IWS             _L_(29) /**< \brief IISC signal: IWS on PA29 mux B */
+#define MUX_PA29B_IISC_IWS              _L_(1)
 #define PINMUX_PA29B_IISC_IWS      ((PIN_PA29B_IISC_IWS << 16) | MUX_PA29B_IISC_IWS)
-#define GPIO_PA29B_IISC_IWS      _UL(1 << 29)
+#define GPIO_PA29B_IISC_IWS      _UL_(1 << 29)
 /* ========== GPIO definition for SPI peripheral ========== */
-#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
-#define MUX_PA03B_SPI_MISO              _L(1)
+#define PIN_PA03B_SPI_MISO              _L_(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L_(1)
 #define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
-#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
-#define PIN_PB14B_SPI_MISO             _L(46) /**< \brief SPI signal: MISO on PB14 mux B */
-#define MUX_PB14B_SPI_MISO              _L(1)
+#define GPIO_PA03B_SPI_MISO      _UL_(1 <<  3)
+#define PIN_PB14B_SPI_MISO             _L_(46) /**< \brief SPI signal: MISO on PB14 mux B */
+#define MUX_PB14B_SPI_MISO              _L_(1)
 #define PINMUX_PB14B_SPI_MISO      ((PIN_PB14B_SPI_MISO << 16) | MUX_PB14B_SPI_MISO)
-#define GPIO_PB14B_SPI_MISO      _UL(1 << 14)
-#define PIN_PC28B_SPI_MISO             _L(92) /**< \brief SPI signal: MISO on PC28 mux B */
-#define MUX_PC28B_SPI_MISO              _L(1)
+#define GPIO_PB14B_SPI_MISO      _UL_(1 << 14)
+#define PIN_PC28B_SPI_MISO             _L_(92) /**< \brief SPI signal: MISO on PC28 mux B */
+#define MUX_PC28B_SPI_MISO              _L_(1)
 #define PINMUX_PC28B_SPI_MISO      ((PIN_PC28B_SPI_MISO << 16) | MUX_PC28B_SPI_MISO)
-#define GPIO_PC28B_SPI_MISO      _UL(1 << 28)
-#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
-#define MUX_PA21A_SPI_MISO              _L(0)
+#define GPIO_PC28B_SPI_MISO      _UL_(1 << 28)
+#define PIN_PA21A_SPI_MISO             _L_(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L_(0)
 #define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
-#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
-#define PIN_PA27A_SPI_MISO             _L(27) /**< \brief SPI signal: MISO on PA27 mux A */
-#define MUX_PA27A_SPI_MISO              _L(0)
+#define GPIO_PA21A_SPI_MISO      _UL_(1 << 21)
+#define PIN_PA27A_SPI_MISO             _L_(27) /**< \brief SPI signal: MISO on PA27 mux A */
+#define MUX_PA27A_SPI_MISO              _L_(0)
 #define PINMUX_PA27A_SPI_MISO      ((PIN_PA27A_SPI_MISO << 16) | MUX_PA27A_SPI_MISO)
-#define GPIO_PA27A_SPI_MISO      _UL(1 << 27)
-#define PIN_PC04A_SPI_MISO             _L(68) /**< \brief SPI signal: MISO on PC04 mux A */
-#define MUX_PC04A_SPI_MISO              _L(0)
+#define GPIO_PA27A_SPI_MISO      _UL_(1 << 27)
+#define PIN_PC04A_SPI_MISO             _L_(68) /**< \brief SPI signal: MISO on PC04 mux A */
+#define MUX_PC04A_SPI_MISO              _L_(0)
 #define PINMUX_PC04A_SPI_MISO      ((PIN_PC04A_SPI_MISO << 16) | MUX_PC04A_SPI_MISO)
-#define GPIO_PC04A_SPI_MISO      _UL(1 <<  4)
-#define PIN_PB15B_SPI_MOSI             _L(47) /**< \brief SPI signal: MOSI on PB15 mux B */
-#define MUX_PB15B_SPI_MOSI              _L(1)
+#define GPIO_PC04A_SPI_MISO      _UL_(1 <<  4)
+#define PIN_PB15B_SPI_MOSI             _L_(47) /**< \brief SPI signal: MOSI on PB15 mux B */
+#define MUX_PB15B_SPI_MOSI              _L_(1)
 #define PINMUX_PB15B_SPI_MOSI      ((PIN_PB15B_SPI_MOSI << 16) | MUX_PB15B_SPI_MOSI)
-#define GPIO_PB15B_SPI_MOSI      _UL(1 << 15)
-#define PIN_PC29B_SPI_MOSI             _L(93) /**< \brief SPI signal: MOSI on PC29 mux B */
-#define MUX_PC29B_SPI_MOSI              _L(1)
+#define GPIO_PB15B_SPI_MOSI      _UL_(1 << 15)
+#define PIN_PC29B_SPI_MOSI             _L_(93) /**< \brief SPI signal: MOSI on PC29 mux B */
+#define MUX_PC29B_SPI_MOSI              _L_(1)
 #define PINMUX_PC29B_SPI_MOSI      ((PIN_PC29B_SPI_MOSI << 16) | MUX_PC29B_SPI_MOSI)
-#define GPIO_PC29B_SPI_MOSI      _UL(1 << 29)
-#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
-#define MUX_PA22A_SPI_MOSI              _L(0)
+#define GPIO_PC29B_SPI_MOSI      _UL_(1 << 29)
+#define PIN_PA22A_SPI_MOSI             _L_(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L_(0)
 #define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
-#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
-#define PIN_PA28A_SPI_MOSI             _L(28) /**< \brief SPI signal: MOSI on PA28 mux A */
-#define MUX_PA28A_SPI_MOSI              _L(0)
+#define GPIO_PA22A_SPI_MOSI      _UL_(1 << 22)
+#define PIN_PA28A_SPI_MOSI             _L_(28) /**< \brief SPI signal: MOSI on PA28 mux A */
+#define MUX_PA28A_SPI_MOSI              _L_(0)
 #define PINMUX_PA28A_SPI_MOSI      ((PIN_PA28A_SPI_MOSI << 16) | MUX_PA28A_SPI_MOSI)
-#define GPIO_PA28A_SPI_MOSI      _UL(1 << 28)
-#define PIN_PC05A_SPI_MOSI             _L(69) /**< \brief SPI signal: MOSI on PC05 mux A */
-#define MUX_PC05A_SPI_MOSI              _L(0)
+#define GPIO_PA28A_SPI_MOSI      _UL_(1 << 28)
+#define PIN_PC05A_SPI_MOSI             _L_(69) /**< \brief SPI signal: MOSI on PC05 mux A */
+#define MUX_PC05A_SPI_MOSI              _L_(0)
 #define PINMUX_PC05A_SPI_MOSI      ((PIN_PC05A_SPI_MOSI << 16) | MUX_PC05A_SPI_MOSI)
-#define GPIO_PC05A_SPI_MOSI      _UL(1 <<  5)
-#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
-#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define GPIO_PC05A_SPI_MOSI      _UL_(1 <<  5)
+#define PIN_PA02B_SPI_NPCS0             _L_(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L_(1)
 #define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
-#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
-#define PIN_PC31B_SPI_NPCS0            _L(95) /**< \brief SPI signal: NPCS0 on PC31 mux B */
-#define MUX_PC31B_SPI_NPCS0             _L(1)
+#define GPIO_PA02B_SPI_NPCS0     _UL_(1 <<  2)
+#define PIN_PC31B_SPI_NPCS0            _L_(95) /**< \brief SPI signal: NPCS0 on PC31 mux B */
+#define MUX_PC31B_SPI_NPCS0             _L_(1)
 #define PINMUX_PC31B_SPI_NPCS0     ((PIN_PC31B_SPI_NPCS0 << 16) | MUX_PC31B_SPI_NPCS0)
-#define GPIO_PC31B_SPI_NPCS0     _UL(1 << 31)
-#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
-#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define GPIO_PC31B_SPI_NPCS0     _UL_(1 << 31)
+#define PIN_PA24A_SPI_NPCS0            _L_(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L_(0)
 #define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
-#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
-#define PIN_PA30A_SPI_NPCS0            _L(30) /**< \brief SPI signal: NPCS0 on PA30 mux A */
-#define MUX_PA30A_SPI_NPCS0             _L(0)
+#define GPIO_PA24A_SPI_NPCS0     _UL_(1 << 24)
+#define PIN_PA30A_SPI_NPCS0            _L_(30) /**< \brief SPI signal: NPCS0 on PA30 mux A */
+#define MUX_PA30A_SPI_NPCS0             _L_(0)
 #define PINMUX_PA30A_SPI_NPCS0     ((PIN_PA30A_SPI_NPCS0 << 16) | MUX_PA30A_SPI_NPCS0)
-#define GPIO_PA30A_SPI_NPCS0     _UL(1 << 30)
-#define PIN_PC03A_SPI_NPCS0            _L(67) /**< \brief SPI signal: NPCS0 on PC03 mux A */
-#define MUX_PC03A_SPI_NPCS0             _L(0)
+#define GPIO_PA30A_SPI_NPCS0     _UL_(1 << 30)
+#define PIN_PC03A_SPI_NPCS0            _L_(67) /**< \brief SPI signal: NPCS0 on PC03 mux A */
+#define MUX_PC03A_SPI_NPCS0             _L_(0)
 #define PINMUX_PC03A_SPI_NPCS0     ((PIN_PC03A_SPI_NPCS0 << 16) | MUX_PC03A_SPI_NPCS0)
-#define GPIO_PC03A_SPI_NPCS0     _UL(1 <<  3)
-#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
-#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define GPIO_PC03A_SPI_NPCS0     _UL_(1 <<  3)
+#define PIN_PA13C_SPI_NPCS1            _L_(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L_(2)
 #define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
-#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PB13B_SPI_NPCS1            _L(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
-#define MUX_PB13B_SPI_NPCS1             _L(1)
+#define GPIO_PA13C_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PB13B_SPI_NPCS1            _L_(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
+#define MUX_PB13B_SPI_NPCS1             _L_(1)
 #define PINMUX_PB13B_SPI_NPCS1     ((PIN_PB13B_SPI_NPCS1 << 16) | MUX_PB13B_SPI_NPCS1)
-#define GPIO_PB13B_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PA31A_SPI_NPCS1            _L(31) /**< \brief SPI signal: NPCS1 on PA31 mux A */
-#define MUX_PA31A_SPI_NPCS1             _L(0)
+#define GPIO_PB13B_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PA31A_SPI_NPCS1            _L_(31) /**< \brief SPI signal: NPCS1 on PA31 mux A */
+#define MUX_PA31A_SPI_NPCS1             _L_(0)
 #define PINMUX_PA31A_SPI_NPCS1     ((PIN_PA31A_SPI_NPCS1 << 16) | MUX_PA31A_SPI_NPCS1)
-#define GPIO_PA31A_SPI_NPCS1     _UL(1 << 31)
-#define PIN_PC02A_SPI_NPCS1            _L(66) /**< \brief SPI signal: NPCS1 on PC02 mux A */
-#define MUX_PC02A_SPI_NPCS1             _L(0)
+#define GPIO_PA31A_SPI_NPCS1     _UL_(1 << 31)
+#define PIN_PC02A_SPI_NPCS1            _L_(66) /**< \brief SPI signal: NPCS1 on PC02 mux A */
+#define MUX_PC02A_SPI_NPCS1             _L_(0)
 #define PINMUX_PC02A_SPI_NPCS1     ((PIN_PC02A_SPI_NPCS1 << 16) | MUX_PC02A_SPI_NPCS1)
-#define GPIO_PC02A_SPI_NPCS1     _UL(1 <<  2)
-#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
-#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define GPIO_PC02A_SPI_NPCS1     _UL_(1 <<  2)
+#define PIN_PA14C_SPI_NPCS2            _L_(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L_(2)
 #define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
-#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
-#define PIN_PB11B_SPI_NPCS2            _L(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
-#define MUX_PB11B_SPI_NPCS2             _L(1)
+#define GPIO_PA14C_SPI_NPCS2     _UL_(1 << 14)
+#define PIN_PB11B_SPI_NPCS2            _L_(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
+#define MUX_PB11B_SPI_NPCS2             _L_(1)
 #define PINMUX_PB11B_SPI_NPCS2     ((PIN_PB11B_SPI_NPCS2 << 16) | MUX_PB11B_SPI_NPCS2)
-#define GPIO_PB11B_SPI_NPCS2     _UL(1 << 11)
-#define PIN_PC00A_SPI_NPCS2            _L(64) /**< \brief SPI signal: NPCS2 on PC00 mux A */
-#define MUX_PC00A_SPI_NPCS2             _L(0)
+#define GPIO_PB11B_SPI_NPCS2     _UL_(1 << 11)
+#define PIN_PC00A_SPI_NPCS2            _L_(64) /**< \brief SPI signal: NPCS2 on PC00 mux A */
+#define MUX_PC00A_SPI_NPCS2             _L_(0)
 #define PINMUX_PC00A_SPI_NPCS2     ((PIN_PC00A_SPI_NPCS2 << 16) | MUX_PC00A_SPI_NPCS2)
-#define GPIO_PC00A_SPI_NPCS2     _UL(1 <<  0)
-#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
-#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define GPIO_PC00A_SPI_NPCS2     _UL_(1 <<  0)
+#define PIN_PA15C_SPI_NPCS3            _L_(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L_(2)
 #define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
-#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
-#define PIN_PB12B_SPI_NPCS3            _L(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
-#define MUX_PB12B_SPI_NPCS3             _L(1)
+#define GPIO_PA15C_SPI_NPCS3     _UL_(1 << 15)
+#define PIN_PB12B_SPI_NPCS3            _L_(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
+#define MUX_PB12B_SPI_NPCS3             _L_(1)
 #define PINMUX_PB12B_SPI_NPCS3     ((PIN_PB12B_SPI_NPCS3 << 16) | MUX_PB12B_SPI_NPCS3)
-#define GPIO_PB12B_SPI_NPCS3     _UL(1 << 12)
-#define PIN_PC01A_SPI_NPCS3            _L(65) /**< \brief SPI signal: NPCS3 on PC01 mux A */
-#define MUX_PC01A_SPI_NPCS3             _L(0)
+#define GPIO_PB12B_SPI_NPCS3     _UL_(1 << 12)
+#define PIN_PC01A_SPI_NPCS3            _L_(65) /**< \brief SPI signal: NPCS3 on PC01 mux A */
+#define MUX_PC01A_SPI_NPCS3             _L_(0)
 #define PINMUX_PC01A_SPI_NPCS3     ((PIN_PC01A_SPI_NPCS3 << 16) | MUX_PC01A_SPI_NPCS3)
-#define GPIO_PC01A_SPI_NPCS3     _UL(1 <<  1)
-#define PIN_PC30B_SPI_SCK              _L(94) /**< \brief SPI signal: SCK on PC30 mux B */
-#define MUX_PC30B_SPI_SCK               _L(1)
+#define GPIO_PC01A_SPI_NPCS3     _UL_(1 <<  1)
+#define PIN_PC30B_SPI_SCK              _L_(94) /**< \brief SPI signal: SCK on PC30 mux B */
+#define MUX_PC30B_SPI_SCK               _L_(1)
 #define PINMUX_PC30B_SPI_SCK       ((PIN_PC30B_SPI_SCK << 16) | MUX_PC30B_SPI_SCK)
-#define GPIO_PC30B_SPI_SCK       _UL(1 << 30)
-#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
-#define MUX_PA23A_SPI_SCK               _L(0)
+#define GPIO_PC30B_SPI_SCK       _UL_(1 << 30)
+#define PIN_PA23A_SPI_SCK              _L_(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L_(0)
 #define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
-#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
-#define PIN_PA29A_SPI_SCK              _L(29) /**< \brief SPI signal: SCK on PA29 mux A */
-#define MUX_PA29A_SPI_SCK               _L(0)
+#define GPIO_PA23A_SPI_SCK       _UL_(1 << 23)
+#define PIN_PA29A_SPI_SCK              _L_(29) /**< \brief SPI signal: SCK on PA29 mux A */
+#define MUX_PA29A_SPI_SCK               _L_(0)
 #define PINMUX_PA29A_SPI_SCK       ((PIN_PA29A_SPI_SCK << 16) | MUX_PA29A_SPI_SCK)
-#define GPIO_PA29A_SPI_SCK       _UL(1 << 29)
-#define PIN_PC06A_SPI_SCK              _L(70) /**< \brief SPI signal: SCK on PC06 mux A */
-#define MUX_PC06A_SPI_SCK               _L(0)
+#define GPIO_PA29A_SPI_SCK       _UL_(1 << 29)
+#define PIN_PC06A_SPI_SCK              _L_(70) /**< \brief SPI signal: SCK on PC06 mux A */
+#define MUX_PC06A_SPI_SCK               _L_(0)
 #define PINMUX_PC06A_SPI_SCK       ((PIN_PC06A_SPI_SCK << 16) | MUX_PC06A_SPI_SCK)
-#define GPIO_PC06A_SPI_SCK       _UL(1 <<  6)
+#define GPIO_PC06A_SPI_SCK       _UL_(1 <<  6)
 /* ========== GPIO definition for TC0 peripheral ========== */
-#define PIN_PB07D_TC0_A0               _L(39) /**< \brief TC0 signal: A0 on PB07 mux D */
-#define MUX_PB07D_TC0_A0                _L(3)
+#define PIN_PB07D_TC0_A0               _L_(39) /**< \brief TC0 signal: A0 on PB07 mux D */
+#define MUX_PB07D_TC0_A0                _L_(3)
 #define PINMUX_PB07D_TC0_A0        ((PIN_PB07D_TC0_A0 << 16) | MUX_PB07D_TC0_A0)
-#define GPIO_PB07D_TC0_A0        _UL(1 <<  7)
-#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
-#define MUX_PA08B_TC0_A0                _L(1)
+#define GPIO_PB07D_TC0_A0        _UL_(1 <<  7)
+#define PIN_PA08B_TC0_A0                _L_(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L_(1)
 #define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
-#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
-#define PIN_PB09D_TC0_A1               _L(41) /**< \brief TC0 signal: A1 on PB09 mux D */
-#define MUX_PB09D_TC0_A1                _L(3)
+#define GPIO_PA08B_TC0_A0        _UL_(1 <<  8)
+#define PIN_PB09D_TC0_A1               _L_(41) /**< \brief TC0 signal: A1 on PB09 mux D */
+#define MUX_PB09D_TC0_A1                _L_(3)
 #define PINMUX_PB09D_TC0_A1        ((PIN_PB09D_TC0_A1 << 16) | MUX_PB09D_TC0_A1)
-#define GPIO_PB09D_TC0_A1        _UL(1 <<  9)
-#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
-#define MUX_PA10B_TC0_A1                _L(1)
+#define GPIO_PB09D_TC0_A1        _UL_(1 <<  9)
+#define PIN_PA10B_TC0_A1               _L_(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L_(1)
 #define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
-#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
-#define PIN_PB11D_TC0_A2               _L(43) /**< \brief TC0 signal: A2 on PB11 mux D */
-#define MUX_PB11D_TC0_A2                _L(3)
+#define GPIO_PA10B_TC0_A1        _UL_(1 << 10)
+#define PIN_PB11D_TC0_A2               _L_(43) /**< \brief TC0 signal: A2 on PB11 mux D */
+#define MUX_PB11D_TC0_A2                _L_(3)
 #define PINMUX_PB11D_TC0_A2        ((PIN_PB11D_TC0_A2 << 16) | MUX_PB11D_TC0_A2)
-#define GPIO_PB11D_TC0_A2        _UL(1 << 11)
-#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
-#define MUX_PA12B_TC0_A2                _L(1)
+#define GPIO_PB11D_TC0_A2        _UL_(1 << 11)
+#define PIN_PA12B_TC0_A2               _L_(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L_(1)
 #define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
-#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
-#define PIN_PB08D_TC0_B0               _L(40) /**< \brief TC0 signal: B0 on PB08 mux D */
-#define MUX_PB08D_TC0_B0                _L(3)
+#define GPIO_PA12B_TC0_A2        _UL_(1 << 12)
+#define PIN_PB08D_TC0_B0               _L_(40) /**< \brief TC0 signal: B0 on PB08 mux D */
+#define MUX_PB08D_TC0_B0                _L_(3)
 #define PINMUX_PB08D_TC0_B0        ((PIN_PB08D_TC0_B0 << 16) | MUX_PB08D_TC0_B0)
-#define GPIO_PB08D_TC0_B0        _UL(1 <<  8)
-#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
-#define MUX_PA09B_TC0_B0                _L(1)
+#define GPIO_PB08D_TC0_B0        _UL_(1 <<  8)
+#define PIN_PA09B_TC0_B0                _L_(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L_(1)
 #define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
-#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
-#define PIN_PB10D_TC0_B1               _L(42) /**< \brief TC0 signal: B1 on PB10 mux D */
-#define MUX_PB10D_TC0_B1                _L(3)
+#define GPIO_PA09B_TC0_B0        _UL_(1 <<  9)
+#define PIN_PB10D_TC0_B1               _L_(42) /**< \brief TC0 signal: B1 on PB10 mux D */
+#define MUX_PB10D_TC0_B1                _L_(3)
 #define PINMUX_PB10D_TC0_B1        ((PIN_PB10D_TC0_B1 << 16) | MUX_PB10D_TC0_B1)
-#define GPIO_PB10D_TC0_B1        _UL(1 << 10)
-#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
-#define MUX_PA11B_TC0_B1                _L(1)
+#define GPIO_PB10D_TC0_B1        _UL_(1 << 10)
+#define PIN_PA11B_TC0_B1               _L_(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L_(1)
 #define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
-#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
-#define PIN_PB12D_TC0_B2               _L(44) /**< \brief TC0 signal: B2 on PB12 mux D */
-#define MUX_PB12D_TC0_B2                _L(3)
+#define GPIO_PA11B_TC0_B1        _UL_(1 << 11)
+#define PIN_PB12D_TC0_B2               _L_(44) /**< \brief TC0 signal: B2 on PB12 mux D */
+#define MUX_PB12D_TC0_B2                _L_(3)
 #define PINMUX_PB12D_TC0_B2        ((PIN_PB12D_TC0_B2 << 16) | MUX_PB12D_TC0_B2)
-#define GPIO_PB12D_TC0_B2        _UL(1 << 12)
-#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
-#define MUX_PA13B_TC0_B2                _L(1)
+#define GPIO_PB12D_TC0_B2        _UL_(1 << 12)
+#define PIN_PA13B_TC0_B2               _L_(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L_(1)
 #define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
-#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
-#define PIN_PB13D_TC0_CLK0             _L(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
-#define MUX_PB13D_TC0_CLK0              _L(3)
+#define GPIO_PA13B_TC0_B2        _UL_(1 << 13)
+#define PIN_PB13D_TC0_CLK0             _L_(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
+#define MUX_PB13D_TC0_CLK0              _L_(3)
 #define PINMUX_PB13D_TC0_CLK0      ((PIN_PB13D_TC0_CLK0 << 16) | MUX_PB13D_TC0_CLK0)
-#define GPIO_PB13D_TC0_CLK0      _UL(1 << 13)
-#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
-#define MUX_PA14B_TC0_CLK0              _L(1)
+#define GPIO_PB13D_TC0_CLK0      _UL_(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L_(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L_(1)
 #define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
-#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
-#define PIN_PB14D_TC0_CLK1             _L(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
-#define MUX_PB14D_TC0_CLK1              _L(3)
+#define GPIO_PA14B_TC0_CLK0      _UL_(1 << 14)
+#define PIN_PB14D_TC0_CLK1             _L_(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
+#define MUX_PB14D_TC0_CLK1              _L_(3)
 #define PINMUX_PB14D_TC0_CLK1      ((PIN_PB14D_TC0_CLK1 << 16) | MUX_PB14D_TC0_CLK1)
-#define GPIO_PB14D_TC0_CLK1      _UL(1 << 14)
-#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
-#define MUX_PA15B_TC0_CLK1              _L(1)
+#define GPIO_PB14D_TC0_CLK1      _UL_(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L_(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L_(1)
 #define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
-#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
-#define PIN_PB15D_TC0_CLK2             _L(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
-#define MUX_PB15D_TC0_CLK2              _L(3)
+#define GPIO_PA15B_TC0_CLK1      _UL_(1 << 15)
+#define PIN_PB15D_TC0_CLK2             _L_(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
+#define MUX_PB15D_TC0_CLK2              _L_(3)
 #define PINMUX_PB15D_TC0_CLK2      ((PIN_PB15D_TC0_CLK2 << 16) | MUX_PB15D_TC0_CLK2)
-#define GPIO_PB15D_TC0_CLK2      _UL(1 << 15)
-#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
-#define MUX_PA16B_TC0_CLK2              _L(1)
+#define GPIO_PB15D_TC0_CLK2      _UL_(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L_(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L_(1)
 #define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
-#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+#define GPIO_PA16B_TC0_CLK2      _UL_(1 << 16)
 /* ========== GPIO definition for TC1 peripheral ========== */
-#define PIN_PC00D_TC1_A0               _L(64) /**< \brief TC1 signal: A0 on PC00 mux D */
-#define MUX_PC00D_TC1_A0                _L(3)
+#define PIN_PC00D_TC1_A0               _L_(64) /**< \brief TC1 signal: A0 on PC00 mux D */
+#define MUX_PC00D_TC1_A0                _L_(3)
 #define PINMUX_PC00D_TC1_A0        ((PIN_PC00D_TC1_A0 << 16) | MUX_PC00D_TC1_A0)
-#define GPIO_PC00D_TC1_A0        _UL(1 <<  0)
-#define PIN_PC15A_TC1_A0               _L(79) /**< \brief TC1 signal: A0 on PC15 mux A */
-#define MUX_PC15A_TC1_A0                _L(0)
+#define GPIO_PC00D_TC1_A0        _UL_(1 <<  0)
+#define PIN_PC15A_TC1_A0               _L_(79) /**< \brief TC1 signal: A0 on PC15 mux A */
+#define MUX_PC15A_TC1_A0                _L_(0)
 #define PINMUX_PC15A_TC1_A0        ((PIN_PC15A_TC1_A0 << 16) | MUX_PC15A_TC1_A0)
-#define GPIO_PC15A_TC1_A0        _UL(1 << 15)
-#define PIN_PC02D_TC1_A1               _L(66) /**< \brief TC1 signal: A1 on PC02 mux D */
-#define MUX_PC02D_TC1_A1                _L(3)
+#define GPIO_PC15A_TC1_A0        _UL_(1 << 15)
+#define PIN_PC02D_TC1_A1               _L_(66) /**< \brief TC1 signal: A1 on PC02 mux D */
+#define MUX_PC02D_TC1_A1                _L_(3)
 #define PINMUX_PC02D_TC1_A1        ((PIN_PC02D_TC1_A1 << 16) | MUX_PC02D_TC1_A1)
-#define GPIO_PC02D_TC1_A1        _UL(1 <<  2)
-#define PIN_PC17A_TC1_A1               _L(81) /**< \brief TC1 signal: A1 on PC17 mux A */
-#define MUX_PC17A_TC1_A1                _L(0)
+#define GPIO_PC02D_TC1_A1        _UL_(1 <<  2)
+#define PIN_PC17A_TC1_A1               _L_(81) /**< \brief TC1 signal: A1 on PC17 mux A */
+#define MUX_PC17A_TC1_A1                _L_(0)
 #define PINMUX_PC17A_TC1_A1        ((PIN_PC17A_TC1_A1 << 16) | MUX_PC17A_TC1_A1)
-#define GPIO_PC17A_TC1_A1        _UL(1 << 17)
-#define PIN_PC04D_TC1_A2               _L(68) /**< \brief TC1 signal: A2 on PC04 mux D */
-#define MUX_PC04D_TC1_A2                _L(3)
+#define GPIO_PC17A_TC1_A1        _UL_(1 << 17)
+#define PIN_PC04D_TC1_A2               _L_(68) /**< \brief TC1 signal: A2 on PC04 mux D */
+#define MUX_PC04D_TC1_A2                _L_(3)
 #define PINMUX_PC04D_TC1_A2        ((PIN_PC04D_TC1_A2 << 16) | MUX_PC04D_TC1_A2)
-#define GPIO_PC04D_TC1_A2        _UL(1 <<  4)
-#define PIN_PC19A_TC1_A2               _L(83) /**< \brief TC1 signal: A2 on PC19 mux A */
-#define MUX_PC19A_TC1_A2                _L(0)
+#define GPIO_PC04D_TC1_A2        _UL_(1 <<  4)
+#define PIN_PC19A_TC1_A2               _L_(83) /**< \brief TC1 signal: A2 on PC19 mux A */
+#define MUX_PC19A_TC1_A2                _L_(0)
 #define PINMUX_PC19A_TC1_A2        ((PIN_PC19A_TC1_A2 << 16) | MUX_PC19A_TC1_A2)
-#define GPIO_PC19A_TC1_A2        _UL(1 << 19)
-#define PIN_PC01D_TC1_B0               _L(65) /**< \brief TC1 signal: B0 on PC01 mux D */
-#define MUX_PC01D_TC1_B0                _L(3)
+#define GPIO_PC19A_TC1_A2        _UL_(1 << 19)
+#define PIN_PC01D_TC1_B0               _L_(65) /**< \brief TC1 signal: B0 on PC01 mux D */
+#define MUX_PC01D_TC1_B0                _L_(3)
 #define PINMUX_PC01D_TC1_B0        ((PIN_PC01D_TC1_B0 << 16) | MUX_PC01D_TC1_B0)
-#define GPIO_PC01D_TC1_B0        _UL(1 <<  1)
-#define PIN_PC16A_TC1_B0               _L(80) /**< \brief TC1 signal: B0 on PC16 mux A */
-#define MUX_PC16A_TC1_B0                _L(0)
+#define GPIO_PC01D_TC1_B0        _UL_(1 <<  1)
+#define PIN_PC16A_TC1_B0               _L_(80) /**< \brief TC1 signal: B0 on PC16 mux A */
+#define MUX_PC16A_TC1_B0                _L_(0)
 #define PINMUX_PC16A_TC1_B0        ((PIN_PC16A_TC1_B0 << 16) | MUX_PC16A_TC1_B0)
-#define GPIO_PC16A_TC1_B0        _UL(1 << 16)
-#define PIN_PC03D_TC1_B1               _L(67) /**< \brief TC1 signal: B1 on PC03 mux D */
-#define MUX_PC03D_TC1_B1                _L(3)
+#define GPIO_PC16A_TC1_B0        _UL_(1 << 16)
+#define PIN_PC03D_TC1_B1               _L_(67) /**< \brief TC1 signal: B1 on PC03 mux D */
+#define MUX_PC03D_TC1_B1                _L_(3)
 #define PINMUX_PC03D_TC1_B1        ((PIN_PC03D_TC1_B1 << 16) | MUX_PC03D_TC1_B1)
-#define GPIO_PC03D_TC1_B1        _UL(1 <<  3)
-#define PIN_PC18A_TC1_B1               _L(82) /**< \brief TC1 signal: B1 on PC18 mux A */
-#define MUX_PC18A_TC1_B1                _L(0)
+#define GPIO_PC03D_TC1_B1        _UL_(1 <<  3)
+#define PIN_PC18A_TC1_B1               _L_(82) /**< \brief TC1 signal: B1 on PC18 mux A */
+#define MUX_PC18A_TC1_B1                _L_(0)
 #define PINMUX_PC18A_TC1_B1        ((PIN_PC18A_TC1_B1 << 16) | MUX_PC18A_TC1_B1)
-#define GPIO_PC18A_TC1_B1        _UL(1 << 18)
-#define PIN_PC05D_TC1_B2               _L(69) /**< \brief TC1 signal: B2 on PC05 mux D */
-#define MUX_PC05D_TC1_B2                _L(3)
+#define GPIO_PC18A_TC1_B1        _UL_(1 << 18)
+#define PIN_PC05D_TC1_B2               _L_(69) /**< \brief TC1 signal: B2 on PC05 mux D */
+#define MUX_PC05D_TC1_B2                _L_(3)
 #define PINMUX_PC05D_TC1_B2        ((PIN_PC05D_TC1_B2 << 16) | MUX_PC05D_TC1_B2)
-#define GPIO_PC05D_TC1_B2        _UL(1 <<  5)
-#define PIN_PC20A_TC1_B2               _L(84) /**< \brief TC1 signal: B2 on PC20 mux A */
-#define MUX_PC20A_TC1_B2                _L(0)
+#define GPIO_PC05D_TC1_B2        _UL_(1 <<  5)
+#define PIN_PC20A_TC1_B2               _L_(84) /**< \brief TC1 signal: B2 on PC20 mux A */
+#define MUX_PC20A_TC1_B2                _L_(0)
 #define PINMUX_PC20A_TC1_B2        ((PIN_PC20A_TC1_B2 << 16) | MUX_PC20A_TC1_B2)
-#define GPIO_PC20A_TC1_B2        _UL(1 << 20)
-#define PIN_PC06D_TC1_CLK0             _L(70) /**< \brief TC1 signal: CLK0 on PC06 mux D */
-#define MUX_PC06D_TC1_CLK0              _L(3)
+#define GPIO_PC20A_TC1_B2        _UL_(1 << 20)
+#define PIN_PC06D_TC1_CLK0             _L_(70) /**< \brief TC1 signal: CLK0 on PC06 mux D */
+#define MUX_PC06D_TC1_CLK0              _L_(3)
 #define PINMUX_PC06D_TC1_CLK0      ((PIN_PC06D_TC1_CLK0 << 16) | MUX_PC06D_TC1_CLK0)
-#define GPIO_PC06D_TC1_CLK0      _UL(1 <<  6)
-#define PIN_PC21A_TC1_CLK0             _L(85) /**< \brief TC1 signal: CLK0 on PC21 mux A */
-#define MUX_PC21A_TC1_CLK0              _L(0)
+#define GPIO_PC06D_TC1_CLK0      _UL_(1 <<  6)
+#define PIN_PC21A_TC1_CLK0             _L_(85) /**< \brief TC1 signal: CLK0 on PC21 mux A */
+#define MUX_PC21A_TC1_CLK0              _L_(0)
 #define PINMUX_PC21A_TC1_CLK0      ((PIN_PC21A_TC1_CLK0 << 16) | MUX_PC21A_TC1_CLK0)
-#define GPIO_PC21A_TC1_CLK0      _UL(1 << 21)
-#define PIN_PC07D_TC1_CLK1             _L(71) /**< \brief TC1 signal: CLK1 on PC07 mux D */
-#define MUX_PC07D_TC1_CLK1              _L(3)
+#define GPIO_PC21A_TC1_CLK0      _UL_(1 << 21)
+#define PIN_PC07D_TC1_CLK1             _L_(71) /**< \brief TC1 signal: CLK1 on PC07 mux D */
+#define MUX_PC07D_TC1_CLK1              _L_(3)
 #define PINMUX_PC07D_TC1_CLK1      ((PIN_PC07D_TC1_CLK1 << 16) | MUX_PC07D_TC1_CLK1)
-#define GPIO_PC07D_TC1_CLK1      _UL(1 <<  7)
-#define PIN_PC22A_TC1_CLK1             _L(86) /**< \brief TC1 signal: CLK1 on PC22 mux A */
-#define MUX_PC22A_TC1_CLK1              _L(0)
+#define GPIO_PC07D_TC1_CLK1      _UL_(1 <<  7)
+#define PIN_PC22A_TC1_CLK1             _L_(86) /**< \brief TC1 signal: CLK1 on PC22 mux A */
+#define MUX_PC22A_TC1_CLK1              _L_(0)
 #define PINMUX_PC22A_TC1_CLK1      ((PIN_PC22A_TC1_CLK1 << 16) | MUX_PC22A_TC1_CLK1)
-#define GPIO_PC22A_TC1_CLK1      _UL(1 << 22)
-#define PIN_PC08D_TC1_CLK2             _L(72) /**< \brief TC1 signal: CLK2 on PC08 mux D */
-#define MUX_PC08D_TC1_CLK2              _L(3)
+#define GPIO_PC22A_TC1_CLK1      _UL_(1 << 22)
+#define PIN_PC08D_TC1_CLK2             _L_(72) /**< \brief TC1 signal: CLK2 on PC08 mux D */
+#define MUX_PC08D_TC1_CLK2              _L_(3)
 #define PINMUX_PC08D_TC1_CLK2      ((PIN_PC08D_TC1_CLK2 << 16) | MUX_PC08D_TC1_CLK2)
-#define GPIO_PC08D_TC1_CLK2      _UL(1 <<  8)
-#define PIN_PC23A_TC1_CLK2             _L(87) /**< \brief TC1 signal: CLK2 on PC23 mux A */
-#define MUX_PC23A_TC1_CLK2              _L(0)
+#define GPIO_PC08D_TC1_CLK2      _UL_(1 <<  8)
+#define PIN_PC23A_TC1_CLK2             _L_(87) /**< \brief TC1 signal: CLK2 on PC23 mux A */
+#define MUX_PC23A_TC1_CLK2              _L_(0)
 #define PINMUX_PC23A_TC1_CLK2      ((PIN_PC23A_TC1_CLK2 << 16) | MUX_PC23A_TC1_CLK2)
-#define GPIO_PC23A_TC1_CLK2      _UL(1 << 23)
+#define GPIO_PC23A_TC1_CLK2      _UL_(1 << 23)
 /* ========== GPIO definition for USART0 peripheral ========== */
-#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
-#define MUX_PA04B_USART0_CLK            _L(1)
+#define PIN_PA04B_USART0_CLK            _L_(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L_(1)
 #define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
-#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
-#define PIN_PC00B_USART0_CLK           _L(64) /**< \brief USART0 signal: CLK on PC00 mux B */
-#define MUX_PC00B_USART0_CLK            _L(1)
+#define GPIO_PA04B_USART0_CLK    _UL_(1 <<  4)
+#define PIN_PC00B_USART0_CLK           _L_(64) /**< \brief USART0 signal: CLK on PC00 mux B */
+#define MUX_PC00B_USART0_CLK            _L_(1)
 #define PINMUX_PC00B_USART0_CLK    ((PIN_PC00B_USART0_CLK << 16) | MUX_PC00B_USART0_CLK)
-#define GPIO_PC00B_USART0_CLK    _UL(1 <<  0)
-#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
-#define MUX_PA10A_USART0_CLK            _L(0)
+#define GPIO_PC00B_USART0_CLK    _UL_(1 <<  0)
+#define PIN_PA10A_USART0_CLK           _L_(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L_(0)
 #define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
-#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
-#define PIN_PB13A_USART0_CLK           _L(45) /**< \brief USART0 signal: CLK on PB13 mux A */
-#define MUX_PB13A_USART0_CLK            _L(0)
+#define GPIO_PA10A_USART0_CLK    _UL_(1 << 10)
+#define PIN_PB13A_USART0_CLK           _L_(45) /**< \brief USART0 signal: CLK on PB13 mux A */
+#define MUX_PB13A_USART0_CLK            _L_(0)
 #define PINMUX_PB13A_USART0_CLK    ((PIN_PB13A_USART0_CLK << 16) | MUX_PB13A_USART0_CLK)
-#define GPIO_PB13A_USART0_CLK    _UL(1 << 13)
-#define PIN_PC02B_USART0_CTS           _L(66) /**< \brief USART0 signal: CTS on PC02 mux B */
-#define MUX_PC02B_USART0_CTS            _L(1)
+#define GPIO_PB13A_USART0_CLK    _UL_(1 << 13)
+#define PIN_PC02B_USART0_CTS           _L_(66) /**< \brief USART0 signal: CTS on PC02 mux B */
+#define MUX_PC02B_USART0_CTS            _L_(1)
 #define PINMUX_PC02B_USART0_CTS    ((PIN_PC02B_USART0_CTS << 16) | MUX_PC02B_USART0_CTS)
-#define GPIO_PC02B_USART0_CTS    _UL(1 <<  2)
-#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
-#define MUX_PA09A_USART0_CTS            _L(0)
+#define GPIO_PC02B_USART0_CTS    _UL_(1 <<  2)
+#define PIN_PA09A_USART0_CTS            _L_(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L_(0)
 #define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
-#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
-#define PIN_PB11A_USART0_CTS           _L(43) /**< \brief USART0 signal: CTS on PB11 mux A */
-#define MUX_PB11A_USART0_CTS            _L(0)
+#define GPIO_PA09A_USART0_CTS    _UL_(1 <<  9)
+#define PIN_PB11A_USART0_CTS           _L_(43) /**< \brief USART0 signal: CTS on PB11 mux A */
+#define MUX_PB11A_USART0_CTS            _L_(0)
 #define PINMUX_PB11A_USART0_CTS    ((PIN_PB11A_USART0_CTS << 16) | MUX_PB11A_USART0_CTS)
-#define GPIO_PB11A_USART0_CTS    _UL(1 << 11)
-#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
-#define MUX_PA06B_USART0_RTS            _L(1)
+#define GPIO_PB11A_USART0_CTS    _UL_(1 << 11)
+#define PIN_PA06B_USART0_RTS            _L_(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L_(1)
 #define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
-#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
-#define PIN_PC01B_USART0_RTS           _L(65) /**< \brief USART0 signal: RTS on PC01 mux B */
-#define MUX_PC01B_USART0_RTS            _L(1)
+#define GPIO_PA06B_USART0_RTS    _UL_(1 <<  6)
+#define PIN_PC01B_USART0_RTS           _L_(65) /**< \brief USART0 signal: RTS on PC01 mux B */
+#define MUX_PC01B_USART0_RTS            _L_(1)
 #define PINMUX_PC01B_USART0_RTS    ((PIN_PC01B_USART0_RTS << 16) | MUX_PC01B_USART0_RTS)
-#define GPIO_PC01B_USART0_RTS    _UL(1 <<  1)
-#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
-#define MUX_PA08A_USART0_RTS            _L(0)
+#define GPIO_PC01B_USART0_RTS    _UL_(1 <<  1)
+#define PIN_PA08A_USART0_RTS            _L_(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L_(0)
 #define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
-#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
-#define PIN_PB12A_USART0_RTS           _L(44) /**< \brief USART0 signal: RTS on PB12 mux A */
-#define MUX_PB12A_USART0_RTS            _L(0)
+#define GPIO_PA08A_USART0_RTS    _UL_(1 <<  8)
+#define PIN_PB12A_USART0_RTS           _L_(44) /**< \brief USART0 signal: RTS on PB12 mux A */
+#define MUX_PB12A_USART0_RTS            _L_(0)
 #define PINMUX_PB12A_USART0_RTS    ((PIN_PB12A_USART0_RTS << 16) | MUX_PB12A_USART0_RTS)
-#define GPIO_PB12A_USART0_RTS    _UL(1 << 12)
-#define PIN_PC02C_USART0_RXD           _L(66) /**< \brief USART0 signal: RXD on PC02 mux C */
-#define MUX_PC02C_USART0_RXD            _L(2)
+#define GPIO_PB12A_USART0_RTS    _UL_(1 << 12)
+#define PIN_PC02C_USART0_RXD           _L_(66) /**< \brief USART0 signal: RXD on PC02 mux C */
+#define MUX_PC02C_USART0_RXD            _L_(2)
 #define PINMUX_PC02C_USART0_RXD    ((PIN_PC02C_USART0_RXD << 16) | MUX_PC02C_USART0_RXD)
-#define GPIO_PC02C_USART0_RXD    _UL(1 <<  2)
-#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
-#define MUX_PA05B_USART0_RXD            _L(1)
+#define GPIO_PC02C_USART0_RXD    _UL_(1 <<  2)
+#define PIN_PA05B_USART0_RXD            _L_(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L_(1)
 #define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
-#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
-#define PIN_PB00B_USART0_RXD           _L(32) /**< \brief USART0 signal: RXD on PB00 mux B */
-#define MUX_PB00B_USART0_RXD            _L(1)
+#define GPIO_PA05B_USART0_RXD    _UL_(1 <<  5)
+#define PIN_PB00B_USART0_RXD           _L_(32) /**< \brief USART0 signal: RXD on PB00 mux B */
+#define MUX_PB00B_USART0_RXD            _L_(1)
 #define PINMUX_PB00B_USART0_RXD    ((PIN_PB00B_USART0_RXD << 16) | MUX_PB00B_USART0_RXD)
-#define GPIO_PB00B_USART0_RXD    _UL(1 <<  0)
-#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
-#define MUX_PA11A_USART0_RXD            _L(0)
+#define GPIO_PB00B_USART0_RXD    _UL_(1 <<  0)
+#define PIN_PA11A_USART0_RXD           _L_(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L_(0)
 #define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
-#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
-#define PIN_PB14A_USART0_RXD           _L(46) /**< \brief USART0 signal: RXD on PB14 mux A */
-#define MUX_PB14A_USART0_RXD            _L(0)
+#define GPIO_PA11A_USART0_RXD    _UL_(1 << 11)
+#define PIN_PB14A_USART0_RXD           _L_(46) /**< \brief USART0 signal: RXD on PB14 mux A */
+#define MUX_PB14A_USART0_RXD            _L_(0)
 #define PINMUX_PB14A_USART0_RXD    ((PIN_PB14A_USART0_RXD << 16) | MUX_PB14A_USART0_RXD)
-#define GPIO_PB14A_USART0_RXD    _UL(1 << 14)
-#define PIN_PC03C_USART0_TXD           _L(67) /**< \brief USART0 signal: TXD on PC03 mux C */
-#define MUX_PC03C_USART0_TXD            _L(2)
+#define GPIO_PB14A_USART0_RXD    _UL_(1 << 14)
+#define PIN_PC03C_USART0_TXD           _L_(67) /**< \brief USART0 signal: TXD on PC03 mux C */
+#define MUX_PC03C_USART0_TXD            _L_(2)
 #define PINMUX_PC03C_USART0_TXD    ((PIN_PC03C_USART0_TXD << 16) | MUX_PC03C_USART0_TXD)
-#define GPIO_PC03C_USART0_TXD    _UL(1 <<  3)
-#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
-#define MUX_PA07B_USART0_TXD            _L(1)
+#define GPIO_PC03C_USART0_TXD    _UL_(1 <<  3)
+#define PIN_PA07B_USART0_TXD            _L_(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L_(1)
 #define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
-#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
-#define PIN_PB01B_USART0_TXD           _L(33) /**< \brief USART0 signal: TXD on PB01 mux B */
-#define MUX_PB01B_USART0_TXD            _L(1)
+#define GPIO_PA07B_USART0_TXD    _UL_(1 <<  7)
+#define PIN_PB01B_USART0_TXD           _L_(33) /**< \brief USART0 signal: TXD on PB01 mux B */
+#define MUX_PB01B_USART0_TXD            _L_(1)
 #define PINMUX_PB01B_USART0_TXD    ((PIN_PB01B_USART0_TXD << 16) | MUX_PB01B_USART0_TXD)
-#define GPIO_PB01B_USART0_TXD    _UL(1 <<  1)
-#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
-#define MUX_PA12A_USART0_TXD            _L(0)
+#define GPIO_PB01B_USART0_TXD    _UL_(1 <<  1)
+#define PIN_PA12A_USART0_TXD           _L_(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L_(0)
 #define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
-#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
-#define PIN_PB15A_USART0_TXD           _L(47) /**< \brief USART0 signal: TXD on PB15 mux A */
-#define MUX_PB15A_USART0_TXD            _L(0)
+#define GPIO_PA12A_USART0_TXD    _UL_(1 << 12)
+#define PIN_PB15A_USART0_TXD           _L_(47) /**< \brief USART0 signal: TXD on PB15 mux A */
+#define MUX_PB15A_USART0_TXD            _L_(0)
 #define PINMUX_PB15A_USART0_TXD    ((PIN_PB15A_USART0_TXD << 16) | MUX_PB15A_USART0_TXD)
-#define GPIO_PB15A_USART0_TXD    _UL(1 << 15)
+#define GPIO_PB15A_USART0_TXD    _UL_(1 << 15)
 /* ========== GPIO definition for USART1 peripheral ========== */
-#define PIN_PB03B_USART1_CLK           _L(35) /**< \brief USART1 signal: CLK on PB03 mux B */
-#define MUX_PB03B_USART1_CLK            _L(1)
+#define PIN_PB03B_USART1_CLK           _L_(35) /**< \brief USART1 signal: CLK on PB03 mux B */
+#define MUX_PB03B_USART1_CLK            _L_(1)
 #define PINMUX_PB03B_USART1_CLK    ((PIN_PB03B_USART1_CLK << 16) | MUX_PB03B_USART1_CLK)
-#define GPIO_PB03B_USART1_CLK    _UL(1 <<  3)
-#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
-#define MUX_PA14A_USART1_CLK            _L(0)
+#define GPIO_PB03B_USART1_CLK    _UL_(1 <<  3)
+#define PIN_PA14A_USART1_CLK           _L_(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L_(0)
 #define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
-#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
-#define PIN_PC25A_USART1_CLK           _L(89) /**< \brief USART1 signal: CLK on PC25 mux A */
-#define MUX_PC25A_USART1_CLK            _L(0)
+#define GPIO_PA14A_USART1_CLK    _UL_(1 << 14)
+#define PIN_PC25A_USART1_CLK           _L_(89) /**< \brief USART1 signal: CLK on PC25 mux A */
+#define MUX_PC25A_USART1_CLK            _L_(0)
 #define PINMUX_PC25A_USART1_CLK    ((PIN_PC25A_USART1_CLK << 16) | MUX_PC25A_USART1_CLK)
-#define GPIO_PC25A_USART1_CLK    _UL(1 << 25)
-#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
-#define MUX_PA21B_USART1_CTS            _L(1)
+#define GPIO_PC25A_USART1_CLK    _UL_(1 << 25)
+#define PIN_PA21B_USART1_CTS           _L_(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L_(1)
 #define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
-#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
-#define PIN_PB02B_USART1_RTS           _L(34) /**< \brief USART1 signal: RTS on PB02 mux B */
-#define MUX_PB02B_USART1_RTS            _L(1)
+#define GPIO_PA21B_USART1_CTS    _UL_(1 << 21)
+#define PIN_PB02B_USART1_RTS           _L_(34) /**< \brief USART1 signal: RTS on PB02 mux B */
+#define MUX_PB02B_USART1_RTS            _L_(1)
 #define PINMUX_PB02B_USART1_RTS    ((PIN_PB02B_USART1_RTS << 16) | MUX_PB02B_USART1_RTS)
-#define GPIO_PB02B_USART1_RTS    _UL(1 <<  2)
-#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
-#define MUX_PA13A_USART1_RTS            _L(0)
+#define GPIO_PB02B_USART1_RTS    _UL_(1 <<  2)
+#define PIN_PA13A_USART1_RTS           _L_(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L_(0)
 #define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
-#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
-#define PIN_PC24A_USART1_RTS           _L(88) /**< \brief USART1 signal: RTS on PC24 mux A */
-#define MUX_PC24A_USART1_RTS            _L(0)
+#define GPIO_PA13A_USART1_RTS    _UL_(1 << 13)
+#define PIN_PC24A_USART1_RTS           _L_(88) /**< \brief USART1 signal: RTS on PC24 mux A */
+#define MUX_PC24A_USART1_RTS            _L_(0)
 #define PINMUX_PC24A_USART1_RTS    ((PIN_PC24A_USART1_RTS << 16) | MUX_PC24A_USART1_RTS)
-#define GPIO_PC24A_USART1_RTS    _UL(1 << 24)
-#define PIN_PB04B_USART1_RXD           _L(36) /**< \brief USART1 signal: RXD on PB04 mux B */
-#define MUX_PB04B_USART1_RXD            _L(1)
+#define GPIO_PC24A_USART1_RTS    _UL_(1 << 24)
+#define PIN_PB04B_USART1_RXD           _L_(36) /**< \brief USART1 signal: RXD on PB04 mux B */
+#define MUX_PB04B_USART1_RXD            _L_(1)
 #define PINMUX_PB04B_USART1_RXD    ((PIN_PB04B_USART1_RXD << 16) | MUX_PB04B_USART1_RXD)
-#define GPIO_PB04B_USART1_RXD    _UL(1 <<  4)
-#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
-#define MUX_PA15A_USART1_RXD            _L(0)
+#define GPIO_PB04B_USART1_RXD    _UL_(1 <<  4)
+#define PIN_PA15A_USART1_RXD           _L_(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L_(0)
 #define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
-#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
-#define PIN_PC26A_USART1_RXD           _L(90) /**< \brief USART1 signal: RXD on PC26 mux A */
-#define MUX_PC26A_USART1_RXD            _L(0)
+#define GPIO_PA15A_USART1_RXD    _UL_(1 << 15)
+#define PIN_PC26A_USART1_RXD           _L_(90) /**< \brief USART1 signal: RXD on PC26 mux A */
+#define MUX_PC26A_USART1_RXD            _L_(0)
 #define PINMUX_PC26A_USART1_RXD    ((PIN_PC26A_USART1_RXD << 16) | MUX_PC26A_USART1_RXD)
-#define GPIO_PC26A_USART1_RXD    _UL(1 << 26)
-#define PIN_PB05B_USART1_TXD           _L(37) /**< \brief USART1 signal: TXD on PB05 mux B */
-#define MUX_PB05B_USART1_TXD            _L(1)
+#define GPIO_PC26A_USART1_RXD    _UL_(1 << 26)
+#define PIN_PB05B_USART1_TXD           _L_(37) /**< \brief USART1 signal: TXD on PB05 mux B */
+#define MUX_PB05B_USART1_TXD            _L_(1)
 #define PINMUX_PB05B_USART1_TXD    ((PIN_PB05B_USART1_TXD << 16) | MUX_PB05B_USART1_TXD)
-#define GPIO_PB05B_USART1_TXD    _UL(1 <<  5)
-#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
-#define MUX_PA16A_USART1_TXD            _L(0)
+#define GPIO_PB05B_USART1_TXD    _UL_(1 <<  5)
+#define PIN_PA16A_USART1_TXD           _L_(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L_(0)
 #define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
-#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
-#define PIN_PC27A_USART1_TXD           _L(91) /**< \brief USART1 signal: TXD on PC27 mux A */
-#define MUX_PC27A_USART1_TXD            _L(0)
+#define GPIO_PA16A_USART1_TXD    _UL_(1 << 16)
+#define PIN_PC27A_USART1_TXD           _L_(91) /**< \brief USART1 signal: TXD on PC27 mux A */
+#define MUX_PC27A_USART1_TXD            _L_(0)
 #define PINMUX_PC27A_USART1_TXD    ((PIN_PC27A_USART1_TXD << 16) | MUX_PC27A_USART1_TXD)
-#define GPIO_PC27A_USART1_TXD    _UL(1 << 27)
+#define GPIO_PC27A_USART1_TXD    _UL_(1 << 27)
 /* ========== GPIO definition for USART2 peripheral ========== */
-#define PIN_PC08B_USART2_CLK           _L(72) /**< \brief USART2 signal: CLK on PC08 mux B */
-#define MUX_PC08B_USART2_CLK            _L(1)
+#define PIN_PC08B_USART2_CLK           _L_(72) /**< \brief USART2 signal: CLK on PC08 mux B */
+#define MUX_PC08B_USART2_CLK            _L_(1)
 #define PINMUX_PC08B_USART2_CLK    ((PIN_PC08B_USART2_CLK << 16) | MUX_PC08B_USART2_CLK)
-#define GPIO_PC08B_USART2_CLK    _UL(1 <<  8)
-#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
-#define MUX_PA18A_USART2_CLK            _L(0)
+#define GPIO_PC08B_USART2_CLK    _UL_(1 <<  8)
+#define PIN_PA18A_USART2_CLK           _L_(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L_(0)
 #define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
-#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
-#define PIN_PC08E_USART2_CTS           _L(72) /**< \brief USART2 signal: CTS on PC08 mux E */
-#define MUX_PC08E_USART2_CTS            _L(4)
+#define GPIO_PA18A_USART2_CLK    _UL_(1 << 18)
+#define PIN_PC08E_USART2_CTS           _L_(72) /**< \brief USART2 signal: CTS on PC08 mux E */
+#define MUX_PC08E_USART2_CTS            _L_(4)
 #define PINMUX_PC08E_USART2_CTS    ((PIN_PC08E_USART2_CTS << 16) | MUX_PC08E_USART2_CTS)
-#define GPIO_PC08E_USART2_CTS    _UL(1 <<  8)
-#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
-#define MUX_PA22B_USART2_CTS            _L(1)
+#define GPIO_PC08E_USART2_CTS    _UL_(1 <<  8)
+#define PIN_PA22B_USART2_CTS           _L_(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L_(1)
 #define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
-#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
-#define PIN_PC07B_USART2_RTS           _L(71) /**< \brief USART2 signal: RTS on PC07 mux B */
-#define MUX_PC07B_USART2_RTS            _L(1)
+#define GPIO_PA22B_USART2_CTS    _UL_(1 << 22)
+#define PIN_PC07B_USART2_RTS           _L_(71) /**< \brief USART2 signal: RTS on PC07 mux B */
+#define MUX_PC07B_USART2_RTS            _L_(1)
 #define PINMUX_PC07B_USART2_RTS    ((PIN_PC07B_USART2_RTS << 16) | MUX_PC07B_USART2_RTS)
-#define GPIO_PC07B_USART2_RTS    _UL(1 <<  7)
-#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
-#define MUX_PA17A_USART2_RTS            _L(0)
+#define GPIO_PC07B_USART2_RTS    _UL_(1 <<  7)
+#define PIN_PA17A_USART2_RTS           _L_(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L_(0)
 #define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
-#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
-#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
-#define MUX_PA25B_USART2_RXD            _L(1)
+#define GPIO_PA17A_USART2_RTS    _UL_(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L_(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L_(1)
 #define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
-#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
-#define PIN_PC11B_USART2_RXD           _L(75) /**< \brief USART2 signal: RXD on PC11 mux B */
-#define MUX_PC11B_USART2_RXD            _L(1)
+#define GPIO_PA25B_USART2_RXD    _UL_(1 << 25)
+#define PIN_PC11B_USART2_RXD           _L_(75) /**< \brief USART2 signal: RXD on PC11 mux B */
+#define MUX_PC11B_USART2_RXD            _L_(1)
 #define PINMUX_PC11B_USART2_RXD    ((PIN_PC11B_USART2_RXD << 16) | MUX_PC11B_USART2_RXD)
-#define GPIO_PC11B_USART2_RXD    _UL(1 << 11)
-#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
-#define MUX_PA19A_USART2_RXD            _L(0)
+#define GPIO_PC11B_USART2_RXD    _UL_(1 << 11)
+#define PIN_PA19A_USART2_RXD           _L_(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L_(0)
 #define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
-#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
-#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
-#define MUX_PA26B_USART2_TXD            _L(1)
+#define GPIO_PA19A_USART2_RXD    _UL_(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L_(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L_(1)
 #define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
-#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
-#define PIN_PC12B_USART2_TXD           _L(76) /**< \brief USART2 signal: TXD on PC12 mux B */
-#define MUX_PC12B_USART2_TXD            _L(1)
+#define GPIO_PA26B_USART2_TXD    _UL_(1 << 26)
+#define PIN_PC12B_USART2_TXD           _L_(76) /**< \brief USART2 signal: TXD on PC12 mux B */
+#define MUX_PC12B_USART2_TXD            _L_(1)
 #define PINMUX_PC12B_USART2_TXD    ((PIN_PC12B_USART2_TXD << 16) | MUX_PC12B_USART2_TXD)
-#define GPIO_PC12B_USART2_TXD    _UL(1 << 12)
-#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
-#define MUX_PA20A_USART2_TXD            _L(0)
+#define GPIO_PC12B_USART2_TXD    _UL_(1 << 12)
+#define PIN_PA20A_USART2_TXD           _L_(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L_(0)
 #define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
-#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+#define GPIO_PA20A_USART2_TXD    _UL_(1 << 20)
 /* ========== GPIO definition for USART3 peripheral ========== */
-#define PIN_PA29E_USART3_CLK           _L(29) /**< \brief USART3 signal: CLK on PA29 mux E */
-#define MUX_PA29E_USART3_CLK            _L(4)
+#define PIN_PA29E_USART3_CLK           _L_(29) /**< \brief USART3 signal: CLK on PA29 mux E */
+#define MUX_PA29E_USART3_CLK            _L_(4)
 #define PINMUX_PA29E_USART3_CLK    ((PIN_PA29E_USART3_CLK << 16) | MUX_PA29E_USART3_CLK)
-#define GPIO_PA29E_USART3_CLK    _UL(1 << 29)
-#define PIN_PC14B_USART3_CLK           _L(78) /**< \brief USART3 signal: CLK on PC14 mux B */
-#define MUX_PC14B_USART3_CLK            _L(1)
+#define GPIO_PA29E_USART3_CLK    _UL_(1 << 29)
+#define PIN_PC14B_USART3_CLK           _L_(78) /**< \brief USART3 signal: CLK on PC14 mux B */
+#define MUX_PC14B_USART3_CLK            _L_(1)
 #define PINMUX_PC14B_USART3_CLK    ((PIN_PC14B_USART3_CLK << 16) | MUX_PC14B_USART3_CLK)
-#define GPIO_PC14B_USART3_CLK    _UL(1 << 14)
-#define PIN_PB08A_USART3_CLK           _L(40) /**< \brief USART3 signal: CLK on PB08 mux A */
-#define MUX_PB08A_USART3_CLK            _L(0)
+#define GPIO_PC14B_USART3_CLK    _UL_(1 << 14)
+#define PIN_PB08A_USART3_CLK           _L_(40) /**< \brief USART3 signal: CLK on PB08 mux A */
+#define MUX_PB08A_USART3_CLK            _L_(0)
 #define PINMUX_PB08A_USART3_CLK    ((PIN_PB08A_USART3_CLK << 16) | MUX_PB08A_USART3_CLK)
-#define GPIO_PB08A_USART3_CLK    _UL(1 <<  8)
-#define PIN_PC31A_USART3_CLK           _L(95) /**< \brief USART3 signal: CLK on PC31 mux A */
-#define MUX_PC31A_USART3_CLK            _L(0)
+#define GPIO_PB08A_USART3_CLK    _UL_(1 <<  8)
+#define PIN_PC31A_USART3_CLK           _L_(95) /**< \brief USART3 signal: CLK on PC31 mux A */
+#define MUX_PC31A_USART3_CLK            _L_(0)
 #define PINMUX_PC31A_USART3_CLK    ((PIN_PC31A_USART3_CLK << 16) | MUX_PC31A_USART3_CLK)
-#define GPIO_PC31A_USART3_CLK    _UL(1 << 31)
-#define PIN_PA28E_USART3_CTS           _L(28) /**< \brief USART3 signal: CTS on PA28 mux E */
-#define MUX_PA28E_USART3_CTS            _L(4)
+#define GPIO_PC31A_USART3_CLK    _UL_(1 << 31)
+#define PIN_PA28E_USART3_CTS           _L_(28) /**< \brief USART3 signal: CTS on PA28 mux E */
+#define MUX_PA28E_USART3_CTS            _L_(4)
 #define PINMUX_PA28E_USART3_CTS    ((PIN_PA28E_USART3_CTS << 16) | MUX_PA28E_USART3_CTS)
-#define GPIO_PA28E_USART3_CTS    _UL(1 << 28)
-#define PIN_PB07A_USART3_CTS           _L(39) /**< \brief USART3 signal: CTS on PB07 mux A */
-#define MUX_PB07A_USART3_CTS            _L(0)
+#define GPIO_PA28E_USART3_CTS    _UL_(1 << 28)
+#define PIN_PB07A_USART3_CTS           _L_(39) /**< \brief USART3 signal: CTS on PB07 mux A */
+#define MUX_PB07A_USART3_CTS            _L_(0)
 #define PINMUX_PB07A_USART3_CTS    ((PIN_PB07A_USART3_CTS << 16) | MUX_PB07A_USART3_CTS)
-#define GPIO_PB07A_USART3_CTS    _UL(1 <<  7)
-#define PIN_PA27E_USART3_RTS           _L(27) /**< \brief USART3 signal: RTS on PA27 mux E */
-#define MUX_PA27E_USART3_RTS            _L(4)
+#define GPIO_PB07A_USART3_CTS    _UL_(1 <<  7)
+#define PIN_PA27E_USART3_RTS           _L_(27) /**< \brief USART3 signal: RTS on PA27 mux E */
+#define MUX_PA27E_USART3_RTS            _L_(4)
 #define PINMUX_PA27E_USART3_RTS    ((PIN_PA27E_USART3_RTS << 16) | MUX_PA27E_USART3_RTS)
-#define GPIO_PA27E_USART3_RTS    _UL(1 << 27)
-#define PIN_PC13B_USART3_RTS           _L(77) /**< \brief USART3 signal: RTS on PC13 mux B */
-#define MUX_PC13B_USART3_RTS            _L(1)
+#define GPIO_PA27E_USART3_RTS    _UL_(1 << 27)
+#define PIN_PC13B_USART3_RTS           _L_(77) /**< \brief USART3 signal: RTS on PC13 mux B */
+#define MUX_PC13B_USART3_RTS            _L_(1)
 #define PINMUX_PC13B_USART3_RTS    ((PIN_PC13B_USART3_RTS << 16) | MUX_PC13B_USART3_RTS)
-#define GPIO_PC13B_USART3_RTS    _UL(1 << 13)
-#define PIN_PB06A_USART3_RTS           _L(38) /**< \brief USART3 signal: RTS on PB06 mux A */
-#define MUX_PB06A_USART3_RTS            _L(0)
+#define GPIO_PC13B_USART3_RTS    _UL_(1 << 13)
+#define PIN_PB06A_USART3_RTS           _L_(38) /**< \brief USART3 signal: RTS on PB06 mux A */
+#define MUX_PB06A_USART3_RTS            _L_(0)
 #define PINMUX_PB06A_USART3_RTS    ((PIN_PB06A_USART3_RTS << 16) | MUX_PB06A_USART3_RTS)
-#define GPIO_PB06A_USART3_RTS    _UL(1 <<  6)
-#define PIN_PC30A_USART3_RTS           _L(94) /**< \brief USART3 signal: RTS on PC30 mux A */
-#define MUX_PC30A_USART3_RTS            _L(0)
+#define GPIO_PB06A_USART3_RTS    _UL_(1 <<  6)
+#define PIN_PC30A_USART3_RTS           _L_(94) /**< \brief USART3 signal: RTS on PC30 mux A */
+#define MUX_PC30A_USART3_RTS            _L_(0)
 #define PINMUX_PC30A_USART3_RTS    ((PIN_PC30A_USART3_RTS << 16) | MUX_PC30A_USART3_RTS)
-#define GPIO_PC30A_USART3_RTS    _UL(1 << 30)
-#define PIN_PA30E_USART3_RXD           _L(30) /**< \brief USART3 signal: RXD on PA30 mux E */
-#define MUX_PA30E_USART3_RXD            _L(4)
+#define GPIO_PC30A_USART3_RTS    _UL_(1 << 30)
+#define PIN_PA30E_USART3_RXD           _L_(30) /**< \brief USART3 signal: RXD on PA30 mux E */
+#define MUX_PA30E_USART3_RXD            _L_(4)
 #define PINMUX_PA30E_USART3_RXD    ((PIN_PA30E_USART3_RXD << 16) | MUX_PA30E_USART3_RXD)
-#define GPIO_PA30E_USART3_RXD    _UL(1 << 30)
-#define PIN_PC09B_USART3_RXD           _L(73) /**< \brief USART3 signal: RXD on PC09 mux B */
-#define MUX_PC09B_USART3_RXD            _L(1)
+#define GPIO_PA30E_USART3_RXD    _UL_(1 << 30)
+#define PIN_PC09B_USART3_RXD           _L_(73) /**< \brief USART3 signal: RXD on PC09 mux B */
+#define MUX_PC09B_USART3_RXD            _L_(1)
 #define PINMUX_PC09B_USART3_RXD    ((PIN_PC09B_USART3_RXD << 16) | MUX_PC09B_USART3_RXD)
-#define GPIO_PC09B_USART3_RXD    _UL(1 <<  9)
-#define PIN_PB09A_USART3_RXD           _L(41) /**< \brief USART3 signal: RXD on PB09 mux A */
-#define MUX_PB09A_USART3_RXD            _L(0)
+#define GPIO_PC09B_USART3_RXD    _UL_(1 <<  9)
+#define PIN_PB09A_USART3_RXD           _L_(41) /**< \brief USART3 signal: RXD on PB09 mux A */
+#define MUX_PB09A_USART3_RXD            _L_(0)
 #define PINMUX_PB09A_USART3_RXD    ((PIN_PB09A_USART3_RXD << 16) | MUX_PB09A_USART3_RXD)
-#define GPIO_PB09A_USART3_RXD    _UL(1 <<  9)
-#define PIN_PC28A_USART3_RXD           _L(92) /**< \brief USART3 signal: RXD on PC28 mux A */
-#define MUX_PC28A_USART3_RXD            _L(0)
+#define GPIO_PB09A_USART3_RXD    _UL_(1 <<  9)
+#define PIN_PC28A_USART3_RXD           _L_(92) /**< \brief USART3 signal: RXD on PC28 mux A */
+#define MUX_PC28A_USART3_RXD            _L_(0)
 #define PINMUX_PC28A_USART3_RXD    ((PIN_PC28A_USART3_RXD << 16) | MUX_PC28A_USART3_RXD)
-#define GPIO_PC28A_USART3_RXD    _UL(1 << 28)
-#define PIN_PA31E_USART3_TXD           _L(31) /**< \brief USART3 signal: TXD on PA31 mux E */
-#define MUX_PA31E_USART3_TXD            _L(4)
+#define GPIO_PC28A_USART3_RXD    _UL_(1 << 28)
+#define PIN_PA31E_USART3_TXD           _L_(31) /**< \brief USART3 signal: TXD on PA31 mux E */
+#define MUX_PA31E_USART3_TXD            _L_(4)
 #define PINMUX_PA31E_USART3_TXD    ((PIN_PA31E_USART3_TXD << 16) | MUX_PA31E_USART3_TXD)
-#define GPIO_PA31E_USART3_TXD    _UL(1 << 31)
-#define PIN_PC10B_USART3_TXD           _L(74) /**< \brief USART3 signal: TXD on PC10 mux B */
-#define MUX_PC10B_USART3_TXD            _L(1)
+#define GPIO_PA31E_USART3_TXD    _UL_(1 << 31)
+#define PIN_PC10B_USART3_TXD           _L_(74) /**< \brief USART3 signal: TXD on PC10 mux B */
+#define MUX_PC10B_USART3_TXD            _L_(1)
 #define PINMUX_PC10B_USART3_TXD    ((PIN_PC10B_USART3_TXD << 16) | MUX_PC10B_USART3_TXD)
-#define GPIO_PC10B_USART3_TXD    _UL(1 << 10)
-#define PIN_PB10A_USART3_TXD           _L(42) /**< \brief USART3 signal: TXD on PB10 mux A */
-#define MUX_PB10A_USART3_TXD            _L(0)
+#define GPIO_PC10B_USART3_TXD    _UL_(1 << 10)
+#define PIN_PB10A_USART3_TXD           _L_(42) /**< \brief USART3 signal: TXD on PB10 mux A */
+#define MUX_PB10A_USART3_TXD            _L_(0)
 #define PINMUX_PB10A_USART3_TXD    ((PIN_PB10A_USART3_TXD << 16) | MUX_PB10A_USART3_TXD)
-#define GPIO_PB10A_USART3_TXD    _UL(1 << 10)
-#define PIN_PC29A_USART3_TXD           _L(93) /**< \brief USART3 signal: TXD on PC29 mux A */
-#define MUX_PC29A_USART3_TXD            _L(0)
+#define GPIO_PB10A_USART3_TXD    _UL_(1 << 10)
+#define PIN_PC29A_USART3_TXD           _L_(93) /**< \brief USART3 signal: TXD on PC29 mux A */
+#define MUX_PC29A_USART3_TXD            _L_(0)
 #define PINMUX_PC29A_USART3_TXD    ((PIN_PC29A_USART3_TXD << 16) | MUX_PC29A_USART3_TXD)
-#define GPIO_PC29A_USART3_TXD    _UL(1 << 29)
+#define GPIO_PC29A_USART3_TXD    _UL_(1 << 29)
 /* ========== GPIO definition for ADCIFE peripheral ========== */
-#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
-#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PIN_PA04A_ADCIFE_AD0            _L_(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L_(0)
 #define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
-#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
-#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
-#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL_(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L_(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L_(0)
 #define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
-#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
-#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
-#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define GPIO_PA05A_ADCIFE_AD1    _UL_(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L_(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L_(0)
 #define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
-#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
-#define PIN_PB02A_ADCIFE_AD3           _L(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
-#define MUX_PB02A_ADCIFE_AD3            _L(0)
+#define GPIO_PA07A_ADCIFE_AD2    _UL_(1 <<  7)
+#define PIN_PB02A_ADCIFE_AD3           _L_(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
+#define MUX_PB02A_ADCIFE_AD3            _L_(0)
 #define PINMUX_PB02A_ADCIFE_AD3    ((PIN_PB02A_ADCIFE_AD3 << 16) | MUX_PB02A_ADCIFE_AD3)
-#define GPIO_PB02A_ADCIFE_AD3    _UL(1 <<  2)
-#define PIN_PB03A_ADCIFE_AD4           _L(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
-#define MUX_PB03A_ADCIFE_AD4            _L(0)
+#define GPIO_PB02A_ADCIFE_AD3    _UL_(1 <<  2)
+#define PIN_PB03A_ADCIFE_AD4           _L_(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
+#define MUX_PB03A_ADCIFE_AD4            _L_(0)
 #define PINMUX_PB03A_ADCIFE_AD4    ((PIN_PB03A_ADCIFE_AD4 << 16) | MUX_PB03A_ADCIFE_AD4)
-#define GPIO_PB03A_ADCIFE_AD4    _UL(1 <<  3)
-#define PIN_PB04A_ADCIFE_AD5           _L(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
-#define MUX_PB04A_ADCIFE_AD5            _L(0)
+#define GPIO_PB03A_ADCIFE_AD4    _UL_(1 <<  3)
+#define PIN_PB04A_ADCIFE_AD5           _L_(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
+#define MUX_PB04A_ADCIFE_AD5            _L_(0)
 #define PINMUX_PB04A_ADCIFE_AD5    ((PIN_PB04A_ADCIFE_AD5 << 16) | MUX_PB04A_ADCIFE_AD5)
-#define GPIO_PB04A_ADCIFE_AD5    _UL(1 <<  4)
-#define PIN_PB05A_ADCIFE_AD6           _L(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
-#define MUX_PB05A_ADCIFE_AD6            _L(0)
+#define GPIO_PB04A_ADCIFE_AD5    _UL_(1 <<  4)
+#define PIN_PB05A_ADCIFE_AD6           _L_(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
+#define MUX_PB05A_ADCIFE_AD6            _L_(0)
 #define PINMUX_PB05A_ADCIFE_AD6    ((PIN_PB05A_ADCIFE_AD6 << 16) | MUX_PB05A_ADCIFE_AD6)
-#define GPIO_PB05A_ADCIFE_AD6    _UL(1 <<  5)
-#define PIN_PC07A_ADCIFE_AD7           _L(71) /**< \brief ADCIFE signal: AD7 on PC07 mux A */
-#define MUX_PC07A_ADCIFE_AD7            _L(0)
+#define GPIO_PB05A_ADCIFE_AD6    _UL_(1 <<  5)
+#define PIN_PC07A_ADCIFE_AD7           _L_(71) /**< \brief ADCIFE signal: AD7 on PC07 mux A */
+#define MUX_PC07A_ADCIFE_AD7            _L_(0)
 #define PINMUX_PC07A_ADCIFE_AD7    ((PIN_PC07A_ADCIFE_AD7 << 16) | MUX_PC07A_ADCIFE_AD7)
-#define GPIO_PC07A_ADCIFE_AD7    _UL(1 <<  7)
-#define PIN_PC08A_ADCIFE_AD8           _L(72) /**< \brief ADCIFE signal: AD8 on PC08 mux A */
-#define MUX_PC08A_ADCIFE_AD8            _L(0)
+#define GPIO_PC07A_ADCIFE_AD7    _UL_(1 <<  7)
+#define PIN_PC08A_ADCIFE_AD8           _L_(72) /**< \brief ADCIFE signal: AD8 on PC08 mux A */
+#define MUX_PC08A_ADCIFE_AD8            _L_(0)
 #define PINMUX_PC08A_ADCIFE_AD8    ((PIN_PC08A_ADCIFE_AD8 << 16) | MUX_PC08A_ADCIFE_AD8)
-#define GPIO_PC08A_ADCIFE_AD8    _UL(1 <<  8)
-#define PIN_PC09A_ADCIFE_AD9           _L(73) /**< \brief ADCIFE signal: AD9 on PC09 mux A */
-#define MUX_PC09A_ADCIFE_AD9            _L(0)
+#define GPIO_PC08A_ADCIFE_AD8    _UL_(1 <<  8)
+#define PIN_PC09A_ADCIFE_AD9           _L_(73) /**< \brief ADCIFE signal: AD9 on PC09 mux A */
+#define MUX_PC09A_ADCIFE_AD9            _L_(0)
 #define PINMUX_PC09A_ADCIFE_AD9    ((PIN_PC09A_ADCIFE_AD9 << 16) | MUX_PC09A_ADCIFE_AD9)
-#define GPIO_PC09A_ADCIFE_AD9    _UL(1 <<  9)
-#define PIN_PC10A_ADCIFE_AD10          _L(74) /**< \brief ADCIFE signal: AD10 on PC10 mux A */
-#define MUX_PC10A_ADCIFE_AD10           _L(0)
+#define GPIO_PC09A_ADCIFE_AD9    _UL_(1 <<  9)
+#define PIN_PC10A_ADCIFE_AD10          _L_(74) /**< \brief ADCIFE signal: AD10 on PC10 mux A */
+#define MUX_PC10A_ADCIFE_AD10           _L_(0)
 #define PINMUX_PC10A_ADCIFE_AD10   ((PIN_PC10A_ADCIFE_AD10 << 16) | MUX_PC10A_ADCIFE_AD10)
-#define GPIO_PC10A_ADCIFE_AD10   _UL(1 << 10)
-#define PIN_PC11A_ADCIFE_AD11          _L(75) /**< \brief ADCIFE signal: AD11 on PC11 mux A */
-#define MUX_PC11A_ADCIFE_AD11           _L(0)
+#define GPIO_PC10A_ADCIFE_AD10   _UL_(1 << 10)
+#define PIN_PC11A_ADCIFE_AD11          _L_(75) /**< \brief ADCIFE signal: AD11 on PC11 mux A */
+#define MUX_PC11A_ADCIFE_AD11           _L_(0)
 #define PINMUX_PC11A_ADCIFE_AD11   ((PIN_PC11A_ADCIFE_AD11 << 16) | MUX_PC11A_ADCIFE_AD11)
-#define GPIO_PC11A_ADCIFE_AD11   _UL(1 << 11)
-#define PIN_PC12A_ADCIFE_AD12          _L(76) /**< \brief ADCIFE signal: AD12 on PC12 mux A */
-#define MUX_PC12A_ADCIFE_AD12           _L(0)
+#define GPIO_PC11A_ADCIFE_AD11   _UL_(1 << 11)
+#define PIN_PC12A_ADCIFE_AD12          _L_(76) /**< \brief ADCIFE signal: AD12 on PC12 mux A */
+#define MUX_PC12A_ADCIFE_AD12           _L_(0)
 #define PINMUX_PC12A_ADCIFE_AD12   ((PIN_PC12A_ADCIFE_AD12 << 16) | MUX_PC12A_ADCIFE_AD12)
-#define GPIO_PC12A_ADCIFE_AD12   _UL(1 << 12)
-#define PIN_PC13A_ADCIFE_AD13          _L(77) /**< \brief ADCIFE signal: AD13 on PC13 mux A */
-#define MUX_PC13A_ADCIFE_AD13           _L(0)
+#define GPIO_PC12A_ADCIFE_AD12   _UL_(1 << 12)
+#define PIN_PC13A_ADCIFE_AD13          _L_(77) /**< \brief ADCIFE signal: AD13 on PC13 mux A */
+#define MUX_PC13A_ADCIFE_AD13           _L_(0)
 #define PINMUX_PC13A_ADCIFE_AD13   ((PIN_PC13A_ADCIFE_AD13 << 16) | MUX_PC13A_ADCIFE_AD13)
-#define GPIO_PC13A_ADCIFE_AD13   _UL(1 << 13)
-#define PIN_PC14A_ADCIFE_AD14          _L(78) /**< \brief ADCIFE signal: AD14 on PC14 mux A */
-#define MUX_PC14A_ADCIFE_AD14           _L(0)
+#define GPIO_PC13A_ADCIFE_AD13   _UL_(1 << 13)
+#define PIN_PC14A_ADCIFE_AD14          _L_(78) /**< \brief ADCIFE signal: AD14 on PC14 mux A */
+#define MUX_PC14A_ADCIFE_AD14           _L_(0)
 #define PINMUX_PC14A_ADCIFE_AD14   ((PIN_PC14A_ADCIFE_AD14 << 16) | MUX_PC14A_ADCIFE_AD14)
-#define GPIO_PC14A_ADCIFE_AD14   _UL(1 << 14)
-#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
-#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define GPIO_PC14A_ADCIFE_AD14   _UL_(1 << 14)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L_(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L_(4)
 #define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
-#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL_(1 <<  5)
 /* ========== GPIO definition for DACC peripheral ========== */
-#define PIN_PB04E_DACC_EXT_TRIG0       _L(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
-#define MUX_PB04E_DACC_EXT_TRIG0        _L(4)
+#define PIN_PB04E_DACC_EXT_TRIG0       _L_(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
+#define MUX_PB04E_DACC_EXT_TRIG0        _L_(4)
 #define PINMUX_PB04E_DACC_EXT_TRIG0  ((PIN_PB04E_DACC_EXT_TRIG0 << 16) | MUX_PB04E_DACC_EXT_TRIG0)
-#define GPIO_PB04E_DACC_EXT_TRIG0  _UL(1 <<  4)
-#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
-#define MUX_PA06A_DACC_VOUT             _L(0)
+#define GPIO_PB04E_DACC_EXT_TRIG0  _UL_(1 <<  4)
+#define PIN_PA06A_DACC_VOUT             _L_(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L_(0)
 #define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
-#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+#define GPIO_PA06A_DACC_VOUT     _UL_(1 <<  6)
 /* ========== GPIO definition for ACIFC peripheral ========== */
-#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
-#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PIN_PA06E_ACIFC_ACAN0           _L_(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L_(4)
 #define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
-#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
-#define PIN_PC09E_ACIFC_ACAN1          _L(73) /**< \brief ACIFC signal: ACAN1 on PC09 mux E */
-#define MUX_PC09E_ACIFC_ACAN1           _L(4)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL_(1 <<  6)
+#define PIN_PC09E_ACIFC_ACAN1          _L_(73) /**< \brief ACIFC signal: ACAN1 on PC09 mux E */
+#define MUX_PC09E_ACIFC_ACAN1           _L_(4)
 #define PINMUX_PC09E_ACIFC_ACAN1   ((PIN_PC09E_ACIFC_ACAN1 << 16) | MUX_PC09E_ACIFC_ACAN1)
-#define GPIO_PC09E_ACIFC_ACAN1   _UL(1 <<  9)
-#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
-#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define GPIO_PC09E_ACIFC_ACAN1   _UL_(1 <<  9)
+#define PIN_PA07E_ACIFC_ACAP0           _L_(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L_(4)
 #define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
-#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
-#define PIN_PC10E_ACIFC_ACAP1          _L(74) /**< \brief ACIFC signal: ACAP1 on PC10 mux E */
-#define MUX_PC10E_ACIFC_ACAP1           _L(4)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL_(1 <<  7)
+#define PIN_PC10E_ACIFC_ACAP1          _L_(74) /**< \brief ACIFC signal: ACAP1 on PC10 mux E */
+#define MUX_PC10E_ACIFC_ACAP1           _L_(4)
 #define PINMUX_PC10E_ACIFC_ACAP1   ((PIN_PC10E_ACIFC_ACAP1 << 16) | MUX_PC10E_ACIFC_ACAP1)
-#define GPIO_PC10E_ACIFC_ACAP1   _UL(1 << 10)
-#define PIN_PB02E_ACIFC_ACBN0          _L(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
-#define MUX_PB02E_ACIFC_ACBN0           _L(4)
+#define GPIO_PC10E_ACIFC_ACAP1   _UL_(1 << 10)
+#define PIN_PB02E_ACIFC_ACBN0          _L_(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
+#define MUX_PB02E_ACIFC_ACBN0           _L_(4)
 #define PINMUX_PB02E_ACIFC_ACBN0   ((PIN_PB02E_ACIFC_ACBN0 << 16) | MUX_PB02E_ACIFC_ACBN0)
-#define GPIO_PB02E_ACIFC_ACBN0   _UL(1 <<  2)
-#define PIN_PC13E_ACIFC_ACBN1          _L(77) /**< \brief ACIFC signal: ACBN1 on PC13 mux E */
-#define MUX_PC13E_ACIFC_ACBN1           _L(4)
+#define GPIO_PB02E_ACIFC_ACBN0   _UL_(1 <<  2)
+#define PIN_PC13E_ACIFC_ACBN1          _L_(77) /**< \brief ACIFC signal: ACBN1 on PC13 mux E */
+#define MUX_PC13E_ACIFC_ACBN1           _L_(4)
 #define PINMUX_PC13E_ACIFC_ACBN1   ((PIN_PC13E_ACIFC_ACBN1 << 16) | MUX_PC13E_ACIFC_ACBN1)
-#define GPIO_PC13E_ACIFC_ACBN1   _UL(1 << 13)
-#define PIN_PB03E_ACIFC_ACBP0          _L(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
-#define MUX_PB03E_ACIFC_ACBP0           _L(4)
+#define GPIO_PC13E_ACIFC_ACBN1   _UL_(1 << 13)
+#define PIN_PB03E_ACIFC_ACBP0          _L_(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
+#define MUX_PB03E_ACIFC_ACBP0           _L_(4)
 #define PINMUX_PB03E_ACIFC_ACBP0   ((PIN_PB03E_ACIFC_ACBP0 << 16) | MUX_PB03E_ACIFC_ACBP0)
-#define GPIO_PB03E_ACIFC_ACBP0   _UL(1 <<  3)
-#define PIN_PC14E_ACIFC_ACBP1          _L(78) /**< \brief ACIFC signal: ACBP1 on PC14 mux E */
-#define MUX_PC14E_ACIFC_ACBP1           _L(4)
+#define GPIO_PB03E_ACIFC_ACBP0   _UL_(1 <<  3)
+#define PIN_PC14E_ACIFC_ACBP1          _L_(78) /**< \brief ACIFC signal: ACBP1 on PC14 mux E */
+#define MUX_PC14E_ACIFC_ACBP1           _L_(4)
 #define PINMUX_PC14E_ACIFC_ACBP1   ((PIN_PC14E_ACIFC_ACBP1 << 16) | MUX_PC14E_ACIFC_ACBP1)
-#define GPIO_PC14E_ACIFC_ACBP1   _UL(1 << 14)
+#define GPIO_PC14E_ACIFC_ACBP1   _UL_(1 << 14)
 /* ========== GPIO definition for GLOC peripheral ========== */
-#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
-#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PIN_PA06D_GLOC_IN0              _L_(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L_(3)
 #define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
-#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
-#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
-#define MUX_PA20D_GLOC_IN0              _L(3)
+#define GPIO_PA06D_GLOC_IN0      _UL_(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L_(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L_(3)
 #define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
-#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
-#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
-#define MUX_PA04D_GLOC_IN1              _L(3)
+#define GPIO_PA20D_GLOC_IN0      _UL_(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L_(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L_(3)
 #define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
-#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
-#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
-#define MUX_PA21D_GLOC_IN1              _L(3)
+#define GPIO_PA04D_GLOC_IN1      _UL_(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L_(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L_(3)
 #define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
-#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
-#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
-#define MUX_PA05D_GLOC_IN2              _L(3)
+#define GPIO_PA21D_GLOC_IN1      _UL_(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L_(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L_(3)
 #define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
-#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
-#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
-#define MUX_PA22D_GLOC_IN2              _L(3)
+#define GPIO_PA05D_GLOC_IN2      _UL_(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L_(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L_(3)
 #define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
-#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
-#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
-#define MUX_PA07D_GLOC_IN3              _L(3)
+#define GPIO_PA22D_GLOC_IN2      _UL_(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L_(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L_(3)
 #define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
-#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
-#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
-#define MUX_PA23D_GLOC_IN3              _L(3)
+#define GPIO_PA07D_GLOC_IN3      _UL_(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L_(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L_(3)
 #define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
-#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
-#define PIN_PA27D_GLOC_IN4             _L(27) /**< \brief GLOC signal: IN4 on PA27 mux D */
-#define MUX_PA27D_GLOC_IN4              _L(3)
+#define GPIO_PA23D_GLOC_IN3      _UL_(1 << 23)
+#define PIN_PA27D_GLOC_IN4             _L_(27) /**< \brief GLOC signal: IN4 on PA27 mux D */
+#define MUX_PA27D_GLOC_IN4              _L_(3)
 #define PINMUX_PA27D_GLOC_IN4      ((PIN_PA27D_GLOC_IN4 << 16) | MUX_PA27D_GLOC_IN4)
-#define GPIO_PA27D_GLOC_IN4      _UL(1 << 27)
-#define PIN_PC15D_GLOC_IN4             _L(79) /**< \brief GLOC signal: IN4 on PC15 mux D */
-#define MUX_PC15D_GLOC_IN4              _L(3)
+#define GPIO_PA27D_GLOC_IN4      _UL_(1 << 27)
+#define PIN_PC15D_GLOC_IN4             _L_(79) /**< \brief GLOC signal: IN4 on PC15 mux D */
+#define MUX_PC15D_GLOC_IN4              _L_(3)
 #define PINMUX_PC15D_GLOC_IN4      ((PIN_PC15D_GLOC_IN4 << 16) | MUX_PC15D_GLOC_IN4)
-#define GPIO_PC15D_GLOC_IN4      _UL(1 << 15)
-#define PIN_PB06C_GLOC_IN4             _L(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
-#define MUX_PB06C_GLOC_IN4              _L(2)
+#define GPIO_PC15D_GLOC_IN4      _UL_(1 << 15)
+#define PIN_PB06C_GLOC_IN4             _L_(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
+#define MUX_PB06C_GLOC_IN4              _L_(2)
 #define PINMUX_PB06C_GLOC_IN4      ((PIN_PB06C_GLOC_IN4 << 16) | MUX_PB06C_GLOC_IN4)
-#define GPIO_PB06C_GLOC_IN4      _UL(1 <<  6)
-#define PIN_PC28C_GLOC_IN4             _L(92) /**< \brief GLOC signal: IN4 on PC28 mux C */
-#define MUX_PC28C_GLOC_IN4              _L(2)
+#define GPIO_PB06C_GLOC_IN4      _UL_(1 <<  6)
+#define PIN_PC28C_GLOC_IN4             _L_(92) /**< \brief GLOC signal: IN4 on PC28 mux C */
+#define MUX_PC28C_GLOC_IN4              _L_(2)
 #define PINMUX_PC28C_GLOC_IN4      ((PIN_PC28C_GLOC_IN4 << 16) | MUX_PC28C_GLOC_IN4)
-#define GPIO_PC28C_GLOC_IN4      _UL(1 << 28)
-#define PIN_PA28D_GLOC_IN5             _L(28) /**< \brief GLOC signal: IN5 on PA28 mux D */
-#define MUX_PA28D_GLOC_IN5              _L(3)
+#define GPIO_PC28C_GLOC_IN4      _UL_(1 << 28)
+#define PIN_PA28D_GLOC_IN5             _L_(28) /**< \brief GLOC signal: IN5 on PA28 mux D */
+#define MUX_PA28D_GLOC_IN5              _L_(3)
 #define PINMUX_PA28D_GLOC_IN5      ((PIN_PA28D_GLOC_IN5 << 16) | MUX_PA28D_GLOC_IN5)
-#define GPIO_PA28D_GLOC_IN5      _UL(1 << 28)
-#define PIN_PC16D_GLOC_IN5             _L(80) /**< \brief GLOC signal: IN5 on PC16 mux D */
-#define MUX_PC16D_GLOC_IN5              _L(3)
+#define GPIO_PA28D_GLOC_IN5      _UL_(1 << 28)
+#define PIN_PC16D_GLOC_IN5             _L_(80) /**< \brief GLOC signal: IN5 on PC16 mux D */
+#define MUX_PC16D_GLOC_IN5              _L_(3)
 #define PINMUX_PC16D_GLOC_IN5      ((PIN_PC16D_GLOC_IN5 << 16) | MUX_PC16D_GLOC_IN5)
-#define GPIO_PC16D_GLOC_IN5      _UL(1 << 16)
-#define PIN_PB07C_GLOC_IN5             _L(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
-#define MUX_PB07C_GLOC_IN5              _L(2)
+#define GPIO_PC16D_GLOC_IN5      _UL_(1 << 16)
+#define PIN_PB07C_GLOC_IN5             _L_(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
+#define MUX_PB07C_GLOC_IN5              _L_(2)
 #define PINMUX_PB07C_GLOC_IN5      ((PIN_PB07C_GLOC_IN5 << 16) | MUX_PB07C_GLOC_IN5)
-#define GPIO_PB07C_GLOC_IN5      _UL(1 <<  7)
-#define PIN_PC29C_GLOC_IN5             _L(93) /**< \brief GLOC signal: IN5 on PC29 mux C */
-#define MUX_PC29C_GLOC_IN5              _L(2)
+#define GPIO_PB07C_GLOC_IN5      _UL_(1 <<  7)
+#define PIN_PC29C_GLOC_IN5             _L_(93) /**< \brief GLOC signal: IN5 on PC29 mux C */
+#define MUX_PC29C_GLOC_IN5              _L_(2)
 #define PINMUX_PC29C_GLOC_IN5      ((PIN_PC29C_GLOC_IN5 << 16) | MUX_PC29C_GLOC_IN5)
-#define GPIO_PC29C_GLOC_IN5      _UL(1 << 29)
-#define PIN_PA29D_GLOC_IN6             _L(29) /**< \brief GLOC signal: IN6 on PA29 mux D */
-#define MUX_PA29D_GLOC_IN6              _L(3)
+#define GPIO_PC29C_GLOC_IN5      _UL_(1 << 29)
+#define PIN_PA29D_GLOC_IN6             _L_(29) /**< \brief GLOC signal: IN6 on PA29 mux D */
+#define MUX_PA29D_GLOC_IN6              _L_(3)
 #define PINMUX_PA29D_GLOC_IN6      ((PIN_PA29D_GLOC_IN6 << 16) | MUX_PA29D_GLOC_IN6)
-#define GPIO_PA29D_GLOC_IN6      _UL(1 << 29)
-#define PIN_PC17D_GLOC_IN6             _L(81) /**< \brief GLOC signal: IN6 on PC17 mux D */
-#define MUX_PC17D_GLOC_IN6              _L(3)
+#define GPIO_PA29D_GLOC_IN6      _UL_(1 << 29)
+#define PIN_PC17D_GLOC_IN6             _L_(81) /**< \brief GLOC signal: IN6 on PC17 mux D */
+#define MUX_PC17D_GLOC_IN6              _L_(3)
 #define PINMUX_PC17D_GLOC_IN6      ((PIN_PC17D_GLOC_IN6 << 16) | MUX_PC17D_GLOC_IN6)
-#define GPIO_PC17D_GLOC_IN6      _UL(1 << 17)
-#define PIN_PB08C_GLOC_IN6             _L(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
-#define MUX_PB08C_GLOC_IN6              _L(2)
+#define GPIO_PC17D_GLOC_IN6      _UL_(1 << 17)
+#define PIN_PB08C_GLOC_IN6             _L_(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
+#define MUX_PB08C_GLOC_IN6              _L_(2)
 #define PINMUX_PB08C_GLOC_IN6      ((PIN_PB08C_GLOC_IN6 << 16) | MUX_PB08C_GLOC_IN6)
-#define GPIO_PB08C_GLOC_IN6      _UL(1 <<  8)
-#define PIN_PC30C_GLOC_IN6             _L(94) /**< \brief GLOC signal: IN6 on PC30 mux C */
-#define MUX_PC30C_GLOC_IN6              _L(2)
+#define GPIO_PB08C_GLOC_IN6      _UL_(1 <<  8)
+#define PIN_PC30C_GLOC_IN6             _L_(94) /**< \brief GLOC signal: IN6 on PC30 mux C */
+#define MUX_PC30C_GLOC_IN6              _L_(2)
 #define PINMUX_PC30C_GLOC_IN6      ((PIN_PC30C_GLOC_IN6 << 16) | MUX_PC30C_GLOC_IN6)
-#define GPIO_PC30C_GLOC_IN6      _UL(1 << 30)
-#define PIN_PA30D_GLOC_IN7             _L(30) /**< \brief GLOC signal: IN7 on PA30 mux D */
-#define MUX_PA30D_GLOC_IN7              _L(3)
+#define GPIO_PC30C_GLOC_IN6      _UL_(1 << 30)
+#define PIN_PA30D_GLOC_IN7             _L_(30) /**< \brief GLOC signal: IN7 on PA30 mux D */
+#define MUX_PA30D_GLOC_IN7              _L_(3)
 #define PINMUX_PA30D_GLOC_IN7      ((PIN_PA30D_GLOC_IN7 << 16) | MUX_PA30D_GLOC_IN7)
-#define GPIO_PA30D_GLOC_IN7      _UL(1 << 30)
-#define PIN_PC18D_GLOC_IN7             _L(82) /**< \brief GLOC signal: IN7 on PC18 mux D */
-#define MUX_PC18D_GLOC_IN7              _L(3)
+#define GPIO_PA30D_GLOC_IN7      _UL_(1 << 30)
+#define PIN_PC18D_GLOC_IN7             _L_(82) /**< \brief GLOC signal: IN7 on PC18 mux D */
+#define MUX_PC18D_GLOC_IN7              _L_(3)
 #define PINMUX_PC18D_GLOC_IN7      ((PIN_PC18D_GLOC_IN7 << 16) | MUX_PC18D_GLOC_IN7)
-#define GPIO_PC18D_GLOC_IN7      _UL(1 << 18)
-#define PIN_PB09C_GLOC_IN7             _L(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
-#define MUX_PB09C_GLOC_IN7              _L(2)
+#define GPIO_PC18D_GLOC_IN7      _UL_(1 << 18)
+#define PIN_PB09C_GLOC_IN7             _L_(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
+#define MUX_PB09C_GLOC_IN7              _L_(2)
 #define PINMUX_PB09C_GLOC_IN7      ((PIN_PB09C_GLOC_IN7 << 16) | MUX_PB09C_GLOC_IN7)
-#define GPIO_PB09C_GLOC_IN7      _UL(1 <<  9)
-#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
-#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define GPIO_PB09C_GLOC_IN7      _UL_(1 <<  9)
+#define PIN_PA08D_GLOC_OUT0             _L_(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
-#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
-#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
-#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define GPIO_PA08D_GLOC_OUT0     _UL_(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L_(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
-#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
-#define PIN_PA31D_GLOC_OUT1            _L(31) /**< \brief GLOC signal: OUT1 on PA31 mux D */
-#define MUX_PA31D_GLOC_OUT1             _L(3)
+#define GPIO_PA24D_GLOC_OUT0     _UL_(1 << 24)
+#define PIN_PA31D_GLOC_OUT1            _L_(31) /**< \brief GLOC signal: OUT1 on PA31 mux D */
+#define MUX_PA31D_GLOC_OUT1             _L_(3)
 #define PINMUX_PA31D_GLOC_OUT1     ((PIN_PA31D_GLOC_OUT1 << 16) | MUX_PA31D_GLOC_OUT1)
-#define GPIO_PA31D_GLOC_OUT1     _UL(1 << 31)
-#define PIN_PC19D_GLOC_OUT1            _L(83) /**< \brief GLOC signal: OUT1 on PC19 mux D */
-#define MUX_PC19D_GLOC_OUT1             _L(3)
+#define GPIO_PA31D_GLOC_OUT1     _UL_(1 << 31)
+#define PIN_PC19D_GLOC_OUT1            _L_(83) /**< \brief GLOC signal: OUT1 on PC19 mux D */
+#define MUX_PC19D_GLOC_OUT1             _L_(3)
 #define PINMUX_PC19D_GLOC_OUT1     ((PIN_PC19D_GLOC_OUT1 << 16) | MUX_PC19D_GLOC_OUT1)
-#define GPIO_PC19D_GLOC_OUT1     _UL(1 << 19)
-#define PIN_PB10C_GLOC_OUT1            _L(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
-#define MUX_PB10C_GLOC_OUT1             _L(2)
+#define GPIO_PC19D_GLOC_OUT1     _UL_(1 << 19)
+#define PIN_PB10C_GLOC_OUT1            _L_(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
+#define MUX_PB10C_GLOC_OUT1             _L_(2)
 #define PINMUX_PB10C_GLOC_OUT1     ((PIN_PB10C_GLOC_OUT1 << 16) | MUX_PB10C_GLOC_OUT1)
-#define GPIO_PB10C_GLOC_OUT1     _UL(1 << 10)
-#define PIN_PC31C_GLOC_OUT1            _L(95) /**< \brief GLOC signal: OUT1 on PC31 mux C */
-#define MUX_PC31C_GLOC_OUT1             _L(2)
+#define GPIO_PB10C_GLOC_OUT1     _UL_(1 << 10)
+#define PIN_PC31C_GLOC_OUT1            _L_(95) /**< \brief GLOC signal: OUT1 on PC31 mux C */
+#define MUX_PC31C_GLOC_OUT1             _L_(2)
 #define PINMUX_PC31C_GLOC_OUT1     ((PIN_PC31C_GLOC_OUT1 << 16) | MUX_PC31C_GLOC_OUT1)
-#define GPIO_PC31C_GLOC_OUT1     _UL(1 << 31)
+#define GPIO_PC31C_GLOC_OUT1     _UL_(1 << 31)
 /* ========== GPIO definition for ABDACB peripheral ========== */
-#define PIN_PA31C_ABDACB_CLK           _L(31) /**< \brief ABDACB signal: CLK on PA31 mux C */
-#define MUX_PA31C_ABDACB_CLK            _L(2)
+#define PIN_PA31C_ABDACB_CLK           _L_(31) /**< \brief ABDACB signal: CLK on PA31 mux C */
+#define MUX_PA31C_ABDACB_CLK            _L_(2)
 #define PINMUX_PA31C_ABDACB_CLK    ((PIN_PA31C_ABDACB_CLK << 16) | MUX_PA31C_ABDACB_CLK)
-#define GPIO_PA31C_ABDACB_CLK    _UL(1 << 31)
-#define PIN_PC12C_ABDACB_CLK           _L(76) /**< \brief ABDACB signal: CLK on PC12 mux C */
-#define MUX_PC12C_ABDACB_CLK            _L(2)
+#define GPIO_PA31C_ABDACB_CLK    _UL_(1 << 31)
+#define PIN_PC12C_ABDACB_CLK           _L_(76) /**< \brief ABDACB signal: CLK on PC12 mux C */
+#define MUX_PC12C_ABDACB_CLK            _L_(2)
 #define PINMUX_PC12C_ABDACB_CLK    ((PIN_PC12C_ABDACB_CLK << 16) | MUX_PC12C_ABDACB_CLK)
-#define GPIO_PC12C_ABDACB_CLK    _UL(1 << 12)
-#define PIN_PA27C_ABDACB_DAC0          _L(27) /**< \brief ABDACB signal: DAC0 on PA27 mux C */
-#define MUX_PA27C_ABDACB_DAC0           _L(2)
+#define GPIO_PC12C_ABDACB_CLK    _UL_(1 << 12)
+#define PIN_PA27C_ABDACB_DAC0          _L_(27) /**< \brief ABDACB signal: DAC0 on PA27 mux C */
+#define MUX_PA27C_ABDACB_DAC0           _L_(2)
 #define PINMUX_PA27C_ABDACB_DAC0   ((PIN_PA27C_ABDACB_DAC0 << 16) | MUX_PA27C_ABDACB_DAC0)
-#define GPIO_PA27C_ABDACB_DAC0   _UL(1 << 27)
-#define PIN_PB02C_ABDACB_DAC0          _L(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
-#define MUX_PB02C_ABDACB_DAC0           _L(2)
+#define GPIO_PA27C_ABDACB_DAC0   _UL_(1 << 27)
+#define PIN_PB02C_ABDACB_DAC0          _L_(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
+#define MUX_PB02C_ABDACB_DAC0           _L_(2)
 #define PINMUX_PB02C_ABDACB_DAC0   ((PIN_PB02C_ABDACB_DAC0 << 16) | MUX_PB02C_ABDACB_DAC0)
-#define GPIO_PB02C_ABDACB_DAC0   _UL(1 <<  2)
-#define PIN_PC09C_ABDACB_DAC0          _L(73) /**< \brief ABDACB signal: DAC0 on PC09 mux C */
-#define MUX_PC09C_ABDACB_DAC0           _L(2)
+#define GPIO_PB02C_ABDACB_DAC0   _UL_(1 <<  2)
+#define PIN_PC09C_ABDACB_DAC0          _L_(73) /**< \brief ABDACB signal: DAC0 on PC09 mux C */
+#define MUX_PC09C_ABDACB_DAC0           _L_(2)
 #define PINMUX_PC09C_ABDACB_DAC0   ((PIN_PC09C_ABDACB_DAC0 << 16) | MUX_PC09C_ABDACB_DAC0)
-#define GPIO_PC09C_ABDACB_DAC0   _UL(1 <<  9)
-#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
-#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define GPIO_PC09C_ABDACB_DAC0   _UL_(1 <<  9)
+#define PIN_PA17B_ABDACB_DAC0          _L_(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L_(1)
 #define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
-#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
-#define PIN_PA29C_ABDACB_DAC1          _L(29) /**< \brief ABDACB signal: DAC1 on PA29 mux C */
-#define MUX_PA29C_ABDACB_DAC1           _L(2)
+#define GPIO_PA17B_ABDACB_DAC0   _UL_(1 << 17)
+#define PIN_PA29C_ABDACB_DAC1          _L_(29) /**< \brief ABDACB signal: DAC1 on PA29 mux C */
+#define MUX_PA29C_ABDACB_DAC1           _L_(2)
 #define PINMUX_PA29C_ABDACB_DAC1   ((PIN_PA29C_ABDACB_DAC1 << 16) | MUX_PA29C_ABDACB_DAC1)
-#define GPIO_PA29C_ABDACB_DAC1   _UL(1 << 29)
-#define PIN_PB04C_ABDACB_DAC1          _L(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
-#define MUX_PB04C_ABDACB_DAC1           _L(2)
+#define GPIO_PA29C_ABDACB_DAC1   _UL_(1 << 29)
+#define PIN_PB04C_ABDACB_DAC1          _L_(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
+#define MUX_PB04C_ABDACB_DAC1           _L_(2)
 #define PINMUX_PB04C_ABDACB_DAC1   ((PIN_PB04C_ABDACB_DAC1 << 16) | MUX_PB04C_ABDACB_DAC1)
-#define GPIO_PB04C_ABDACB_DAC1   _UL(1 <<  4)
-#define PIN_PC13C_ABDACB_DAC1          _L(77) /**< \brief ABDACB signal: DAC1 on PC13 mux C */
-#define MUX_PC13C_ABDACB_DAC1           _L(2)
+#define GPIO_PB04C_ABDACB_DAC1   _UL_(1 <<  4)
+#define PIN_PC13C_ABDACB_DAC1          _L_(77) /**< \brief ABDACB signal: DAC1 on PC13 mux C */
+#define MUX_PC13C_ABDACB_DAC1           _L_(2)
 #define PINMUX_PC13C_ABDACB_DAC1   ((PIN_PC13C_ABDACB_DAC1 << 16) | MUX_PC13C_ABDACB_DAC1)
-#define GPIO_PC13C_ABDACB_DAC1   _UL(1 << 13)
-#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
-#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define GPIO_PC13C_ABDACB_DAC1   _UL_(1 << 13)
+#define PIN_PA19B_ABDACB_DAC1          _L_(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L_(1)
 #define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
-#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
-#define PIN_PA28C_ABDACB_DACN0         _L(28) /**< \brief ABDACB signal: DACN0 on PA28 mux C */
-#define MUX_PA28C_ABDACB_DACN0          _L(2)
+#define GPIO_PA19B_ABDACB_DAC1   _UL_(1 << 19)
+#define PIN_PA28C_ABDACB_DACN0         _L_(28) /**< \brief ABDACB signal: DACN0 on PA28 mux C */
+#define MUX_PA28C_ABDACB_DACN0          _L_(2)
 #define PINMUX_PA28C_ABDACB_DACN0  ((PIN_PA28C_ABDACB_DACN0 << 16) | MUX_PA28C_ABDACB_DACN0)
-#define GPIO_PA28C_ABDACB_DACN0  _UL(1 << 28)
-#define PIN_PB03C_ABDACB_DACN0         _L(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
-#define MUX_PB03C_ABDACB_DACN0          _L(2)
+#define GPIO_PA28C_ABDACB_DACN0  _UL_(1 << 28)
+#define PIN_PB03C_ABDACB_DACN0         _L_(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
+#define MUX_PB03C_ABDACB_DACN0          _L_(2)
 #define PINMUX_PB03C_ABDACB_DACN0  ((PIN_PB03C_ABDACB_DACN0 << 16) | MUX_PB03C_ABDACB_DACN0)
-#define GPIO_PB03C_ABDACB_DACN0  _UL(1 <<  3)
-#define PIN_PC10C_ABDACB_DACN0         _L(74) /**< \brief ABDACB signal: DACN0 on PC10 mux C */
-#define MUX_PC10C_ABDACB_DACN0          _L(2)
+#define GPIO_PB03C_ABDACB_DACN0  _UL_(1 <<  3)
+#define PIN_PC10C_ABDACB_DACN0         _L_(74) /**< \brief ABDACB signal: DACN0 on PC10 mux C */
+#define MUX_PC10C_ABDACB_DACN0          _L_(2)
 #define PINMUX_PC10C_ABDACB_DACN0  ((PIN_PC10C_ABDACB_DACN0 << 16) | MUX_PC10C_ABDACB_DACN0)
-#define GPIO_PC10C_ABDACB_DACN0  _UL(1 << 10)
-#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
-#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define GPIO_PC10C_ABDACB_DACN0  _UL_(1 << 10)
+#define PIN_PA18B_ABDACB_DACN0         _L_(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L_(1)
 #define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
-#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
-#define PIN_PA30C_ABDACB_DACN1         _L(30) /**< \brief ABDACB signal: DACN1 on PA30 mux C */
-#define MUX_PA30C_ABDACB_DACN1          _L(2)
+#define GPIO_PA18B_ABDACB_DACN0  _UL_(1 << 18)
+#define PIN_PA30C_ABDACB_DACN1         _L_(30) /**< \brief ABDACB signal: DACN1 on PA30 mux C */
+#define MUX_PA30C_ABDACB_DACN1          _L_(2)
 #define PINMUX_PA30C_ABDACB_DACN1  ((PIN_PA30C_ABDACB_DACN1 << 16) | MUX_PA30C_ABDACB_DACN1)
-#define GPIO_PA30C_ABDACB_DACN1  _UL(1 << 30)
-#define PIN_PB05C_ABDACB_DACN1         _L(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
-#define MUX_PB05C_ABDACB_DACN1          _L(2)
+#define GPIO_PA30C_ABDACB_DACN1  _UL_(1 << 30)
+#define PIN_PB05C_ABDACB_DACN1         _L_(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
+#define MUX_PB05C_ABDACB_DACN1          _L_(2)
 #define PINMUX_PB05C_ABDACB_DACN1  ((PIN_PB05C_ABDACB_DACN1 << 16) | MUX_PB05C_ABDACB_DACN1)
-#define GPIO_PB05C_ABDACB_DACN1  _UL(1 <<  5)
-#define PIN_PC14C_ABDACB_DACN1         _L(78) /**< \brief ABDACB signal: DACN1 on PC14 mux C */
-#define MUX_PC14C_ABDACB_DACN1          _L(2)
+#define GPIO_PB05C_ABDACB_DACN1  _UL_(1 <<  5)
+#define PIN_PC14C_ABDACB_DACN1         _L_(78) /**< \brief ABDACB signal: DACN1 on PC14 mux C */
+#define MUX_PC14C_ABDACB_DACN1          _L_(2)
 #define PINMUX_PC14C_ABDACB_DACN1  ((PIN_PC14C_ABDACB_DACN1 << 16) | MUX_PC14C_ABDACB_DACN1)
-#define GPIO_PC14C_ABDACB_DACN1  _UL(1 << 14)
-#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
-#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define GPIO_PC14C_ABDACB_DACN1  _UL_(1 << 14)
+#define PIN_PA20B_ABDACB_DACN1         _L_(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L_(1)
 #define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
-#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+#define GPIO_PA20B_ABDACB_DACN1  _UL_(1 << 20)
 /* ========== GPIO definition for PARC peripheral ========== */
-#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
-#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PIN_PA17D_PARC_PCCK            _L_(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L_(3)
 #define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
-#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
-#define PIN_PC21D_PARC_PCCK            _L(85) /**< \brief PARC signal: PCCK on PC21 mux D */
-#define MUX_PC21D_PARC_PCCK             _L(3)
+#define GPIO_PA17D_PARC_PCCK     _UL_(1 << 17)
+#define PIN_PC21D_PARC_PCCK            _L_(85) /**< \brief PARC signal: PCCK on PC21 mux D */
+#define MUX_PC21D_PARC_PCCK             _L_(3)
 #define PINMUX_PC21D_PARC_PCCK     ((PIN_PC21D_PARC_PCCK << 16) | MUX_PC21D_PARC_PCCK)
-#define GPIO_PC21D_PARC_PCCK     _UL(1 << 21)
-#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
-#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define GPIO_PC21D_PARC_PCCK     _UL_(1 << 21)
+#define PIN_PA09D_PARC_PCDATA0          _L_(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L_(3)
 #define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
-#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
-#define PIN_PC24D_PARC_PCDATA0         _L(88) /**< \brief PARC signal: PCDATA0 on PC24 mux D */
-#define MUX_PC24D_PARC_PCDATA0          _L(3)
+#define GPIO_PA09D_PARC_PCDATA0  _UL_(1 <<  9)
+#define PIN_PC24D_PARC_PCDATA0         _L_(88) /**< \brief PARC signal: PCDATA0 on PC24 mux D */
+#define MUX_PC24D_PARC_PCDATA0          _L_(3)
 #define PINMUX_PC24D_PARC_PCDATA0  ((PIN_PC24D_PARC_PCDATA0 << 16) | MUX_PC24D_PARC_PCDATA0)
-#define GPIO_PC24D_PARC_PCDATA0  _UL(1 << 24)
-#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
-#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define GPIO_PC24D_PARC_PCDATA0  _UL_(1 << 24)
+#define PIN_PA10D_PARC_PCDATA1         _L_(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L_(3)
 #define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
-#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
-#define PIN_PC25D_PARC_PCDATA1         _L(89) /**< \brief PARC signal: PCDATA1 on PC25 mux D */
-#define MUX_PC25D_PARC_PCDATA1          _L(3)
+#define GPIO_PA10D_PARC_PCDATA1  _UL_(1 << 10)
+#define PIN_PC25D_PARC_PCDATA1         _L_(89) /**< \brief PARC signal: PCDATA1 on PC25 mux D */
+#define MUX_PC25D_PARC_PCDATA1          _L_(3)
 #define PINMUX_PC25D_PARC_PCDATA1  ((PIN_PC25D_PARC_PCDATA1 << 16) | MUX_PC25D_PARC_PCDATA1)
-#define GPIO_PC25D_PARC_PCDATA1  _UL(1 << 25)
-#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
-#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define GPIO_PC25D_PARC_PCDATA1  _UL_(1 << 25)
+#define PIN_PA11D_PARC_PCDATA2         _L_(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L_(3)
 #define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
-#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
-#define PIN_PC26D_PARC_PCDATA2         _L(90) /**< \brief PARC signal: PCDATA2 on PC26 mux D */
-#define MUX_PC26D_PARC_PCDATA2          _L(3)
+#define GPIO_PA11D_PARC_PCDATA2  _UL_(1 << 11)
+#define PIN_PC26D_PARC_PCDATA2         _L_(90) /**< \brief PARC signal: PCDATA2 on PC26 mux D */
+#define MUX_PC26D_PARC_PCDATA2          _L_(3)
 #define PINMUX_PC26D_PARC_PCDATA2  ((PIN_PC26D_PARC_PCDATA2 << 16) | MUX_PC26D_PARC_PCDATA2)
-#define GPIO_PC26D_PARC_PCDATA2  _UL(1 << 26)
-#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
-#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define GPIO_PC26D_PARC_PCDATA2  _UL_(1 << 26)
+#define PIN_PA12D_PARC_PCDATA3         _L_(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L_(3)
 #define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
-#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
-#define PIN_PC27D_PARC_PCDATA3         _L(91) /**< \brief PARC signal: PCDATA3 on PC27 mux D */
-#define MUX_PC27D_PARC_PCDATA3          _L(3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL_(1 << 12)
+#define PIN_PC27D_PARC_PCDATA3         _L_(91) /**< \brief PARC signal: PCDATA3 on PC27 mux D */
+#define MUX_PC27D_PARC_PCDATA3          _L_(3)
 #define PINMUX_PC27D_PARC_PCDATA3  ((PIN_PC27D_PARC_PCDATA3 << 16) | MUX_PC27D_PARC_PCDATA3)
-#define GPIO_PC27D_PARC_PCDATA3  _UL(1 << 27)
-#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
-#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define GPIO_PC27D_PARC_PCDATA3  _UL_(1 << 27)
+#define PIN_PA13D_PARC_PCDATA4         _L_(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L_(3)
 #define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
-#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
-#define PIN_PC28D_PARC_PCDATA4         _L(92) /**< \brief PARC signal: PCDATA4 on PC28 mux D */
-#define MUX_PC28D_PARC_PCDATA4          _L(3)
+#define GPIO_PA13D_PARC_PCDATA4  _UL_(1 << 13)
+#define PIN_PC28D_PARC_PCDATA4         _L_(92) /**< \brief PARC signal: PCDATA4 on PC28 mux D */
+#define MUX_PC28D_PARC_PCDATA4          _L_(3)
 #define PINMUX_PC28D_PARC_PCDATA4  ((PIN_PC28D_PARC_PCDATA4 << 16) | MUX_PC28D_PARC_PCDATA4)
-#define GPIO_PC28D_PARC_PCDATA4  _UL(1 << 28)
-#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
-#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define GPIO_PC28D_PARC_PCDATA4  _UL_(1 << 28)
+#define PIN_PA14D_PARC_PCDATA5         _L_(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L_(3)
 #define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
-#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
-#define PIN_PC29D_PARC_PCDATA5         _L(93) /**< \brief PARC signal: PCDATA5 on PC29 mux D */
-#define MUX_PC29D_PARC_PCDATA5          _L(3)
+#define GPIO_PA14D_PARC_PCDATA5  _UL_(1 << 14)
+#define PIN_PC29D_PARC_PCDATA5         _L_(93) /**< \brief PARC signal: PCDATA5 on PC29 mux D */
+#define MUX_PC29D_PARC_PCDATA5          _L_(3)
 #define PINMUX_PC29D_PARC_PCDATA5  ((PIN_PC29D_PARC_PCDATA5 << 16) | MUX_PC29D_PARC_PCDATA5)
-#define GPIO_PC29D_PARC_PCDATA5  _UL(1 << 29)
-#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
-#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define GPIO_PC29D_PARC_PCDATA5  _UL_(1 << 29)
+#define PIN_PA15D_PARC_PCDATA6         _L_(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L_(3)
 #define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
-#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
-#define PIN_PC30D_PARC_PCDATA6         _L(94) /**< \brief PARC signal: PCDATA6 on PC30 mux D */
-#define MUX_PC30D_PARC_PCDATA6          _L(3)
+#define GPIO_PA15D_PARC_PCDATA6  _UL_(1 << 15)
+#define PIN_PC30D_PARC_PCDATA6         _L_(94) /**< \brief PARC signal: PCDATA6 on PC30 mux D */
+#define MUX_PC30D_PARC_PCDATA6          _L_(3)
 #define PINMUX_PC30D_PARC_PCDATA6  ((PIN_PC30D_PARC_PCDATA6 << 16) | MUX_PC30D_PARC_PCDATA6)
-#define GPIO_PC30D_PARC_PCDATA6  _UL(1 << 30)
-#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
-#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define GPIO_PC30D_PARC_PCDATA6  _UL_(1 << 30)
+#define PIN_PA16D_PARC_PCDATA7         _L_(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L_(3)
 #define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
-#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
-#define PIN_PC31D_PARC_PCDATA7         _L(95) /**< \brief PARC signal: PCDATA7 on PC31 mux D */
-#define MUX_PC31D_PARC_PCDATA7          _L(3)
+#define GPIO_PA16D_PARC_PCDATA7  _UL_(1 << 16)
+#define PIN_PC31D_PARC_PCDATA7         _L_(95) /**< \brief PARC signal: PCDATA7 on PC31 mux D */
+#define MUX_PC31D_PARC_PCDATA7          _L_(3)
 #define PINMUX_PC31D_PARC_PCDATA7  ((PIN_PC31D_PARC_PCDATA7 << 16) | MUX_PC31D_PARC_PCDATA7)
-#define GPIO_PC31D_PARC_PCDATA7  _UL(1 << 31)
-#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
-#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define GPIO_PC31D_PARC_PCDATA7  _UL_(1 << 31)
+#define PIN_PA18D_PARC_PCEN1           _L_(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L_(3)
 #define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
-#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
-#define PIN_PC22D_PARC_PCEN1           _L(86) /**< \brief PARC signal: PCEN1 on PC22 mux D */
-#define MUX_PC22D_PARC_PCEN1            _L(3)
+#define GPIO_PA18D_PARC_PCEN1    _UL_(1 << 18)
+#define PIN_PC22D_PARC_PCEN1           _L_(86) /**< \brief PARC signal: PCEN1 on PC22 mux D */
+#define MUX_PC22D_PARC_PCEN1            _L_(3)
 #define PINMUX_PC22D_PARC_PCEN1    ((PIN_PC22D_PARC_PCEN1 << 16) | MUX_PC22D_PARC_PCEN1)
-#define GPIO_PC22D_PARC_PCEN1    _UL(1 << 22)
-#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
-#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define GPIO_PC22D_PARC_PCEN1    _UL_(1 << 22)
+#define PIN_PA19D_PARC_PCEN2           _L_(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L_(3)
 #define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
-#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
-#define PIN_PC23D_PARC_PCEN2           _L(87) /**< \brief PARC signal: PCEN2 on PC23 mux D */
-#define MUX_PC23D_PARC_PCEN2            _L(3)
+#define GPIO_PA19D_PARC_PCEN2    _UL_(1 << 19)
+#define PIN_PC23D_PARC_PCEN2           _L_(87) /**< \brief PARC signal: PCEN2 on PC23 mux D */
+#define MUX_PC23D_PARC_PCEN2            _L_(3)
 #define PINMUX_PC23D_PARC_PCEN2    ((PIN_PC23D_PARC_PCEN2 << 16) | MUX_PC23D_PARC_PCEN2)
-#define GPIO_PC23D_PARC_PCEN2    _UL(1 << 23)
+#define GPIO_PC23D_PARC_PCEN2    _UL_(1 << 23)
 /* ========== GPIO definition for CATB peripheral ========== */
-#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
-#define MUX_PA02G_CATB_DIS              _L(6)
+#define PIN_PA02G_CATB_DIS              _L_(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L_(6)
 #define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
-#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
-#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
-#define MUX_PA12G_CATB_DIS              _L(6)
+#define GPIO_PA02G_CATB_DIS      _UL_(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L_(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L_(6)
 #define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
-#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
-#define MUX_PA23G_CATB_DIS              _L(6)
+#define GPIO_PA12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L_(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L_(6)
 #define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
-#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
-#define PIN_PA31G_CATB_DIS             _L(31) /**< \brief CATB signal: DIS on PA31 mux G */
-#define MUX_PA31G_CATB_DIS              _L(6)
+#define GPIO_PA23G_CATB_DIS      _UL_(1 << 23)
+#define PIN_PA31G_CATB_DIS             _L_(31) /**< \brief CATB signal: DIS on PA31 mux G */
+#define MUX_PA31G_CATB_DIS              _L_(6)
 #define PINMUX_PA31G_CATB_DIS      ((PIN_PA31G_CATB_DIS << 16) | MUX_PA31G_CATB_DIS)
-#define GPIO_PA31G_CATB_DIS      _UL(1 << 31)
-#define PIN_PB03G_CATB_DIS             _L(35) /**< \brief CATB signal: DIS on PB03 mux G */
-#define MUX_PB03G_CATB_DIS              _L(6)
+#define GPIO_PA31G_CATB_DIS      _UL_(1 << 31)
+#define PIN_PB03G_CATB_DIS             _L_(35) /**< \brief CATB signal: DIS on PB03 mux G */
+#define MUX_PB03G_CATB_DIS              _L_(6)
 #define PINMUX_PB03G_CATB_DIS      ((PIN_PB03G_CATB_DIS << 16) | MUX_PB03G_CATB_DIS)
-#define GPIO_PB03G_CATB_DIS      _UL(1 <<  3)
-#define PIN_PB12G_CATB_DIS             _L(44) /**< \brief CATB signal: DIS on PB12 mux G */
-#define MUX_PB12G_CATB_DIS              _L(6)
+#define GPIO_PB03G_CATB_DIS      _UL_(1 <<  3)
+#define PIN_PB12G_CATB_DIS             _L_(44) /**< \brief CATB signal: DIS on PB12 mux G */
+#define MUX_PB12G_CATB_DIS              _L_(6)
 #define PINMUX_PB12G_CATB_DIS      ((PIN_PB12G_CATB_DIS << 16) | MUX_PB12G_CATB_DIS)
-#define GPIO_PB12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PC05G_CATB_DIS             _L(69) /**< \brief CATB signal: DIS on PC05 mux G */
-#define MUX_PC05G_CATB_DIS              _L(6)
+#define GPIO_PB12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PC05G_CATB_DIS             _L_(69) /**< \brief CATB signal: DIS on PC05 mux G */
+#define MUX_PC05G_CATB_DIS              _L_(6)
 #define PINMUX_PC05G_CATB_DIS      ((PIN_PC05G_CATB_DIS << 16) | MUX_PC05G_CATB_DIS)
-#define GPIO_PC05G_CATB_DIS      _UL(1 <<  5)
-#define PIN_PC14G_CATB_DIS             _L(78) /**< \brief CATB signal: DIS on PC14 mux G */
-#define MUX_PC14G_CATB_DIS              _L(6)
+#define GPIO_PC05G_CATB_DIS      _UL_(1 <<  5)
+#define PIN_PC14G_CATB_DIS             _L_(78) /**< \brief CATB signal: DIS on PC14 mux G */
+#define MUX_PC14G_CATB_DIS              _L_(6)
 #define PINMUX_PC14G_CATB_DIS      ((PIN_PC14G_CATB_DIS << 16) | MUX_PC14G_CATB_DIS)
-#define GPIO_PC14G_CATB_DIS      _UL(1 << 14)
-#define PIN_PC23G_CATB_DIS             _L(87) /**< \brief CATB signal: DIS on PC23 mux G */
-#define MUX_PC23G_CATB_DIS              _L(6)
+#define GPIO_PC14G_CATB_DIS      _UL_(1 << 14)
+#define PIN_PC23G_CATB_DIS             _L_(87) /**< \brief CATB signal: DIS on PC23 mux G */
+#define MUX_PC23G_CATB_DIS              _L_(6)
 #define PINMUX_PC23G_CATB_DIS      ((PIN_PC23G_CATB_DIS << 16) | MUX_PC23G_CATB_DIS)
-#define GPIO_PC23G_CATB_DIS      _UL(1 << 23)
-#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
-#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define GPIO_PC23G_CATB_DIS      _UL_(1 << 23)
+#define PIN_PA04G_CATB_SENSE0           _L_(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L_(6)
 #define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
-#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
-#define PIN_PA27G_CATB_SENSE0          _L(27) /**< \brief CATB signal: SENSE0 on PA27 mux G */
-#define MUX_PA27G_CATB_SENSE0           _L(6)
+#define GPIO_PA04G_CATB_SENSE0   _UL_(1 <<  4)
+#define PIN_PA27G_CATB_SENSE0          _L_(27) /**< \brief CATB signal: SENSE0 on PA27 mux G */
+#define MUX_PA27G_CATB_SENSE0           _L_(6)
 #define PINMUX_PA27G_CATB_SENSE0   ((PIN_PA27G_CATB_SENSE0 << 16) | MUX_PA27G_CATB_SENSE0)
-#define GPIO_PA27G_CATB_SENSE0   _UL(1 << 27)
-#define PIN_PB13G_CATB_SENSE0          _L(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
-#define MUX_PB13G_CATB_SENSE0           _L(6)
+#define GPIO_PA27G_CATB_SENSE0   _UL_(1 << 27)
+#define PIN_PB13G_CATB_SENSE0          _L_(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
+#define MUX_PB13G_CATB_SENSE0           _L_(6)
 #define PINMUX_PB13G_CATB_SENSE0   ((PIN_PB13G_CATB_SENSE0 << 16) | MUX_PB13G_CATB_SENSE0)
-#define GPIO_PB13G_CATB_SENSE0   _UL(1 << 13)
-#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
-#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define GPIO_PB13G_CATB_SENSE0   _UL_(1 << 13)
+#define PIN_PA05G_CATB_SENSE1           _L_(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L_(6)
 #define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
-#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
-#define PIN_PA28G_CATB_SENSE1          _L(28) /**< \brief CATB signal: SENSE1 on PA28 mux G */
-#define MUX_PA28G_CATB_SENSE1           _L(6)
+#define GPIO_PA05G_CATB_SENSE1   _UL_(1 <<  5)
+#define PIN_PA28G_CATB_SENSE1          _L_(28) /**< \brief CATB signal: SENSE1 on PA28 mux G */
+#define MUX_PA28G_CATB_SENSE1           _L_(6)
 #define PINMUX_PA28G_CATB_SENSE1   ((PIN_PA28G_CATB_SENSE1 << 16) | MUX_PA28G_CATB_SENSE1)
-#define GPIO_PA28G_CATB_SENSE1   _UL(1 << 28)
-#define PIN_PB14G_CATB_SENSE1          _L(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
-#define MUX_PB14G_CATB_SENSE1           _L(6)
+#define GPIO_PA28G_CATB_SENSE1   _UL_(1 << 28)
+#define PIN_PB14G_CATB_SENSE1          _L_(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
+#define MUX_PB14G_CATB_SENSE1           _L_(6)
 #define PINMUX_PB14G_CATB_SENSE1   ((PIN_PB14G_CATB_SENSE1 << 16) | MUX_PB14G_CATB_SENSE1)
-#define GPIO_PB14G_CATB_SENSE1   _UL(1 << 14)
-#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
-#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define GPIO_PB14G_CATB_SENSE1   _UL_(1 << 14)
+#define PIN_PA06G_CATB_SENSE2           _L_(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L_(6)
 #define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
-#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
-#define PIN_PA29G_CATB_SENSE2          _L(29) /**< \brief CATB signal: SENSE2 on PA29 mux G */
-#define MUX_PA29G_CATB_SENSE2           _L(6)
+#define GPIO_PA06G_CATB_SENSE2   _UL_(1 <<  6)
+#define PIN_PA29G_CATB_SENSE2          _L_(29) /**< \brief CATB signal: SENSE2 on PA29 mux G */
+#define MUX_PA29G_CATB_SENSE2           _L_(6)
 #define PINMUX_PA29G_CATB_SENSE2   ((PIN_PA29G_CATB_SENSE2 << 16) | MUX_PA29G_CATB_SENSE2)
-#define GPIO_PA29G_CATB_SENSE2   _UL(1 << 29)
-#define PIN_PB15G_CATB_SENSE2          _L(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
-#define MUX_PB15G_CATB_SENSE2           _L(6)
+#define GPIO_PA29G_CATB_SENSE2   _UL_(1 << 29)
+#define PIN_PB15G_CATB_SENSE2          _L_(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
+#define MUX_PB15G_CATB_SENSE2           _L_(6)
 #define PINMUX_PB15G_CATB_SENSE2   ((PIN_PB15G_CATB_SENSE2 << 16) | MUX_PB15G_CATB_SENSE2)
-#define GPIO_PB15G_CATB_SENSE2   _UL(1 << 15)
-#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
-#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define GPIO_PB15G_CATB_SENSE2   _UL_(1 << 15)
+#define PIN_PA07G_CATB_SENSE3           _L_(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L_(6)
 #define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
-#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
-#define PIN_PA30G_CATB_SENSE3          _L(30) /**< \brief CATB signal: SENSE3 on PA30 mux G */
-#define MUX_PA30G_CATB_SENSE3           _L(6)
+#define GPIO_PA07G_CATB_SENSE3   _UL_(1 <<  7)
+#define PIN_PA30G_CATB_SENSE3          _L_(30) /**< \brief CATB signal: SENSE3 on PA30 mux G */
+#define MUX_PA30G_CATB_SENSE3           _L_(6)
 #define PINMUX_PA30G_CATB_SENSE3   ((PIN_PA30G_CATB_SENSE3 << 16) | MUX_PA30G_CATB_SENSE3)
-#define GPIO_PA30G_CATB_SENSE3   _UL(1 << 30)
-#define PIN_PC00G_CATB_SENSE3          _L(64) /**< \brief CATB signal: SENSE3 on PC00 mux G */
-#define MUX_PC00G_CATB_SENSE3           _L(6)
+#define GPIO_PA30G_CATB_SENSE3   _UL_(1 << 30)
+#define PIN_PC00G_CATB_SENSE3          _L_(64) /**< \brief CATB signal: SENSE3 on PC00 mux G */
+#define MUX_PC00G_CATB_SENSE3           _L_(6)
 #define PINMUX_PC00G_CATB_SENSE3   ((PIN_PC00G_CATB_SENSE3 << 16) | MUX_PC00G_CATB_SENSE3)
-#define GPIO_PC00G_CATB_SENSE3   _UL(1 <<  0)
-#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
-#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define GPIO_PC00G_CATB_SENSE3   _UL_(1 <<  0)
+#define PIN_PA08G_CATB_SENSE4           _L_(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L_(6)
 #define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
-#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
-#define PIN_PC01G_CATB_SENSE4          _L(65) /**< \brief CATB signal: SENSE4 on PC01 mux G */
-#define MUX_PC01G_CATB_SENSE4           _L(6)
+#define GPIO_PA08G_CATB_SENSE4   _UL_(1 <<  8)
+#define PIN_PC01G_CATB_SENSE4          _L_(65) /**< \brief CATB signal: SENSE4 on PC01 mux G */
+#define MUX_PC01G_CATB_SENSE4           _L_(6)
 #define PINMUX_PC01G_CATB_SENSE4   ((PIN_PC01G_CATB_SENSE4 << 16) | MUX_PC01G_CATB_SENSE4)
-#define GPIO_PC01G_CATB_SENSE4   _UL(1 <<  1)
-#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
-#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define GPIO_PC01G_CATB_SENSE4   _UL_(1 <<  1)
+#define PIN_PA09G_CATB_SENSE5           _L_(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L_(6)
 #define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
-#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
-#define PIN_PC02G_CATB_SENSE5          _L(66) /**< \brief CATB signal: SENSE5 on PC02 mux G */
-#define MUX_PC02G_CATB_SENSE5           _L(6)
+#define GPIO_PA09G_CATB_SENSE5   _UL_(1 <<  9)
+#define PIN_PC02G_CATB_SENSE5          _L_(66) /**< \brief CATB signal: SENSE5 on PC02 mux G */
+#define MUX_PC02G_CATB_SENSE5           _L_(6)
 #define PINMUX_PC02G_CATB_SENSE5   ((PIN_PC02G_CATB_SENSE5 << 16) | MUX_PC02G_CATB_SENSE5)
-#define GPIO_PC02G_CATB_SENSE5   _UL(1 <<  2)
-#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
-#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define GPIO_PC02G_CATB_SENSE5   _UL_(1 <<  2)
+#define PIN_PA10G_CATB_SENSE6          _L_(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L_(6)
 #define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
-#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
-#define PIN_PC03G_CATB_SENSE6          _L(67) /**< \brief CATB signal: SENSE6 on PC03 mux G */
-#define MUX_PC03G_CATB_SENSE6           _L(6)
+#define GPIO_PA10G_CATB_SENSE6   _UL_(1 << 10)
+#define PIN_PC03G_CATB_SENSE6          _L_(67) /**< \brief CATB signal: SENSE6 on PC03 mux G */
+#define MUX_PC03G_CATB_SENSE6           _L_(6)
 #define PINMUX_PC03G_CATB_SENSE6   ((PIN_PC03G_CATB_SENSE6 << 16) | MUX_PC03G_CATB_SENSE6)
-#define GPIO_PC03G_CATB_SENSE6   _UL(1 <<  3)
-#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
-#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define GPIO_PC03G_CATB_SENSE6   _UL_(1 <<  3)
+#define PIN_PA11G_CATB_SENSE7          _L_(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L_(6)
 #define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
-#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
-#define PIN_PC04G_CATB_SENSE7          _L(68) /**< \brief CATB signal: SENSE7 on PC04 mux G */
-#define MUX_PC04G_CATB_SENSE7           _L(6)
+#define GPIO_PA11G_CATB_SENSE7   _UL_(1 << 11)
+#define PIN_PC04G_CATB_SENSE7          _L_(68) /**< \brief CATB signal: SENSE7 on PC04 mux G */
+#define MUX_PC04G_CATB_SENSE7           _L_(6)
 #define PINMUX_PC04G_CATB_SENSE7   ((PIN_PC04G_CATB_SENSE7 << 16) | MUX_PC04G_CATB_SENSE7)
-#define GPIO_PC04G_CATB_SENSE7   _UL(1 <<  4)
-#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
-#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define GPIO_PC04G_CATB_SENSE7   _UL_(1 <<  4)
+#define PIN_PA13G_CATB_SENSE8          _L_(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L_(6)
 #define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
-#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
-#define PIN_PC06G_CATB_SENSE8          _L(70) /**< \brief CATB signal: SENSE8 on PC06 mux G */
-#define MUX_PC06G_CATB_SENSE8           _L(6)
+#define GPIO_PA13G_CATB_SENSE8   _UL_(1 << 13)
+#define PIN_PC06G_CATB_SENSE8          _L_(70) /**< \brief CATB signal: SENSE8 on PC06 mux G */
+#define MUX_PC06G_CATB_SENSE8           _L_(6)
 #define PINMUX_PC06G_CATB_SENSE8   ((PIN_PC06G_CATB_SENSE8 << 16) | MUX_PC06G_CATB_SENSE8)
-#define GPIO_PC06G_CATB_SENSE8   _UL(1 <<  6)
-#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
-#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define GPIO_PC06G_CATB_SENSE8   _UL_(1 <<  6)
+#define PIN_PA14G_CATB_SENSE9          _L_(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L_(6)
 #define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
-#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
-#define PIN_PC07G_CATB_SENSE9          _L(71) /**< \brief CATB signal: SENSE9 on PC07 mux G */
-#define MUX_PC07G_CATB_SENSE9           _L(6)
+#define GPIO_PA14G_CATB_SENSE9   _UL_(1 << 14)
+#define PIN_PC07G_CATB_SENSE9          _L_(71) /**< \brief CATB signal: SENSE9 on PC07 mux G */
+#define MUX_PC07G_CATB_SENSE9           _L_(6)
 #define PINMUX_PC07G_CATB_SENSE9   ((PIN_PC07G_CATB_SENSE9 << 16) | MUX_PC07G_CATB_SENSE9)
-#define GPIO_PC07G_CATB_SENSE9   _UL(1 <<  7)
-#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
-#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define GPIO_PC07G_CATB_SENSE9   _UL_(1 <<  7)
+#define PIN_PA15G_CATB_SENSE10         _L_(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L_(6)
 #define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
-#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
-#define PIN_PC08G_CATB_SENSE10         _L(72) /**< \brief CATB signal: SENSE10 on PC08 mux G */
-#define MUX_PC08G_CATB_SENSE10          _L(6)
+#define GPIO_PA15G_CATB_SENSE10  _UL_(1 << 15)
+#define PIN_PC08G_CATB_SENSE10         _L_(72) /**< \brief CATB signal: SENSE10 on PC08 mux G */
+#define MUX_PC08G_CATB_SENSE10          _L_(6)
 #define PINMUX_PC08G_CATB_SENSE10  ((PIN_PC08G_CATB_SENSE10 << 16) | MUX_PC08G_CATB_SENSE10)
-#define GPIO_PC08G_CATB_SENSE10  _UL(1 <<  8)
-#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
-#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define GPIO_PC08G_CATB_SENSE10  _UL_(1 <<  8)
+#define PIN_PA16G_CATB_SENSE11         _L_(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L_(6)
 #define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
-#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
-#define PIN_PC09G_CATB_SENSE11         _L(73) /**< \brief CATB signal: SENSE11 on PC09 mux G */
-#define MUX_PC09G_CATB_SENSE11          _L(6)
+#define GPIO_PA16G_CATB_SENSE11  _UL_(1 << 16)
+#define PIN_PC09G_CATB_SENSE11         _L_(73) /**< \brief CATB signal: SENSE11 on PC09 mux G */
+#define MUX_PC09G_CATB_SENSE11          _L_(6)
 #define PINMUX_PC09G_CATB_SENSE11  ((PIN_PC09G_CATB_SENSE11 << 16) | MUX_PC09G_CATB_SENSE11)
-#define GPIO_PC09G_CATB_SENSE11  _UL(1 <<  9)
-#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
-#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define GPIO_PC09G_CATB_SENSE11  _UL_(1 <<  9)
+#define PIN_PA17G_CATB_SENSE12         _L_(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L_(6)
 #define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
-#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
-#define PIN_PC10G_CATB_SENSE12         _L(74) /**< \brief CATB signal: SENSE12 on PC10 mux G */
-#define MUX_PC10G_CATB_SENSE12          _L(6)
+#define GPIO_PA17G_CATB_SENSE12  _UL_(1 << 17)
+#define PIN_PC10G_CATB_SENSE12         _L_(74) /**< \brief CATB signal: SENSE12 on PC10 mux G */
+#define MUX_PC10G_CATB_SENSE12          _L_(6)
 #define PINMUX_PC10G_CATB_SENSE12  ((PIN_PC10G_CATB_SENSE12 << 16) | MUX_PC10G_CATB_SENSE12)
-#define GPIO_PC10G_CATB_SENSE12  _UL(1 << 10)
-#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
-#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define GPIO_PC10G_CATB_SENSE12  _UL_(1 << 10)
+#define PIN_PA18G_CATB_SENSE13         _L_(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L_(6)
 #define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
-#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
-#define PIN_PC11G_CATB_SENSE13         _L(75) /**< \brief CATB signal: SENSE13 on PC11 mux G */
-#define MUX_PC11G_CATB_SENSE13          _L(6)
+#define GPIO_PA18G_CATB_SENSE13  _UL_(1 << 18)
+#define PIN_PC11G_CATB_SENSE13         _L_(75) /**< \brief CATB signal: SENSE13 on PC11 mux G */
+#define MUX_PC11G_CATB_SENSE13          _L_(6)
 #define PINMUX_PC11G_CATB_SENSE13  ((PIN_PC11G_CATB_SENSE13 << 16) | MUX_PC11G_CATB_SENSE13)
-#define GPIO_PC11G_CATB_SENSE13  _UL(1 << 11)
-#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
-#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define GPIO_PC11G_CATB_SENSE13  _UL_(1 << 11)
+#define PIN_PA19G_CATB_SENSE14         _L_(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L_(6)
 #define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
-#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
-#define PIN_PC12G_CATB_SENSE14         _L(76) /**< \brief CATB signal: SENSE14 on PC12 mux G */
-#define MUX_PC12G_CATB_SENSE14          _L(6)
+#define GPIO_PA19G_CATB_SENSE14  _UL_(1 << 19)
+#define PIN_PC12G_CATB_SENSE14         _L_(76) /**< \brief CATB signal: SENSE14 on PC12 mux G */
+#define MUX_PC12G_CATB_SENSE14          _L_(6)
 #define PINMUX_PC12G_CATB_SENSE14  ((PIN_PC12G_CATB_SENSE14 << 16) | MUX_PC12G_CATB_SENSE14)
-#define GPIO_PC12G_CATB_SENSE14  _UL(1 << 12)
-#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
-#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define GPIO_PC12G_CATB_SENSE14  _UL_(1 << 12)
+#define PIN_PA20G_CATB_SENSE15         _L_(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L_(6)
 #define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
-#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
-#define PIN_PC13G_CATB_SENSE15         _L(77) /**< \brief CATB signal: SENSE15 on PC13 mux G */
-#define MUX_PC13G_CATB_SENSE15          _L(6)
+#define GPIO_PA20G_CATB_SENSE15  _UL_(1 << 20)
+#define PIN_PC13G_CATB_SENSE15         _L_(77) /**< \brief CATB signal: SENSE15 on PC13 mux G */
+#define MUX_PC13G_CATB_SENSE15          _L_(6)
 #define PINMUX_PC13G_CATB_SENSE15  ((PIN_PC13G_CATB_SENSE15 << 16) | MUX_PC13G_CATB_SENSE15)
-#define GPIO_PC13G_CATB_SENSE15  _UL(1 << 13)
-#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
-#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define GPIO_PC13G_CATB_SENSE15  _UL_(1 << 13)
+#define PIN_PA21G_CATB_SENSE16         _L_(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L_(6)
 #define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
-#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
-#define PIN_PC15G_CATB_SENSE16         _L(79) /**< \brief CATB signal: SENSE16 on PC15 mux G */
-#define MUX_PC15G_CATB_SENSE16          _L(6)
+#define GPIO_PA21G_CATB_SENSE16  _UL_(1 << 21)
+#define PIN_PC15G_CATB_SENSE16         _L_(79) /**< \brief CATB signal: SENSE16 on PC15 mux G */
+#define MUX_PC15G_CATB_SENSE16          _L_(6)
 #define PINMUX_PC15G_CATB_SENSE16  ((PIN_PC15G_CATB_SENSE16 << 16) | MUX_PC15G_CATB_SENSE16)
-#define GPIO_PC15G_CATB_SENSE16  _UL(1 << 15)
-#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
-#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define GPIO_PC15G_CATB_SENSE16  _UL_(1 << 15)
+#define PIN_PA22G_CATB_SENSE17         _L_(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L_(6)
 #define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
-#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
-#define PIN_PC16G_CATB_SENSE17         _L(80) /**< \brief CATB signal: SENSE17 on PC16 mux G */
-#define MUX_PC16G_CATB_SENSE17          _L(6)
+#define GPIO_PA22G_CATB_SENSE17  _UL_(1 << 22)
+#define PIN_PC16G_CATB_SENSE17         _L_(80) /**< \brief CATB signal: SENSE17 on PC16 mux G */
+#define MUX_PC16G_CATB_SENSE17          _L_(6)
 #define PINMUX_PC16G_CATB_SENSE17  ((PIN_PC16G_CATB_SENSE17 << 16) | MUX_PC16G_CATB_SENSE17)
-#define GPIO_PC16G_CATB_SENSE17  _UL(1 << 16)
-#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
-#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define GPIO_PC16G_CATB_SENSE17  _UL_(1 << 16)
+#define PIN_PA24G_CATB_SENSE18         _L_(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L_(6)
 #define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
-#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
-#define PIN_PC17G_CATB_SENSE18         _L(81) /**< \brief CATB signal: SENSE18 on PC17 mux G */
-#define MUX_PC17G_CATB_SENSE18          _L(6)
+#define GPIO_PA24G_CATB_SENSE18  _UL_(1 << 24)
+#define PIN_PC17G_CATB_SENSE18         _L_(81) /**< \brief CATB signal: SENSE18 on PC17 mux G */
+#define MUX_PC17G_CATB_SENSE18          _L_(6)
 #define PINMUX_PC17G_CATB_SENSE18  ((PIN_PC17G_CATB_SENSE18 << 16) | MUX_PC17G_CATB_SENSE18)
-#define GPIO_PC17G_CATB_SENSE18  _UL(1 << 17)
-#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
-#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define GPIO_PC17G_CATB_SENSE18  _UL_(1 << 17)
+#define PIN_PA25G_CATB_SENSE19         _L_(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L_(6)
 #define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
-#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
-#define PIN_PC18G_CATB_SENSE19         _L(82) /**< \brief CATB signal: SENSE19 on PC18 mux G */
-#define MUX_PC18G_CATB_SENSE19          _L(6)
+#define GPIO_PA25G_CATB_SENSE19  _UL_(1 << 25)
+#define PIN_PC18G_CATB_SENSE19         _L_(82) /**< \brief CATB signal: SENSE19 on PC18 mux G */
+#define MUX_PC18G_CATB_SENSE19          _L_(6)
 #define PINMUX_PC18G_CATB_SENSE19  ((PIN_PC18G_CATB_SENSE19 << 16) | MUX_PC18G_CATB_SENSE19)
-#define GPIO_PC18G_CATB_SENSE19  _UL(1 << 18)
-#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
-#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define GPIO_PC18G_CATB_SENSE19  _UL_(1 << 18)
+#define PIN_PA26G_CATB_SENSE20         _L_(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L_(6)
 #define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
-#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
-#define PIN_PC19G_CATB_SENSE20         _L(83) /**< \brief CATB signal: SENSE20 on PC19 mux G */
-#define MUX_PC19G_CATB_SENSE20          _L(6)
+#define GPIO_PA26G_CATB_SENSE20  _UL_(1 << 26)
+#define PIN_PC19G_CATB_SENSE20         _L_(83) /**< \brief CATB signal: SENSE20 on PC19 mux G */
+#define MUX_PC19G_CATB_SENSE20          _L_(6)
 #define PINMUX_PC19G_CATB_SENSE20  ((PIN_PC19G_CATB_SENSE20 << 16) | MUX_PC19G_CATB_SENSE20)
-#define GPIO_PC19G_CATB_SENSE20  _UL(1 << 19)
-#define PIN_PB00G_CATB_SENSE21         _L(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
-#define MUX_PB00G_CATB_SENSE21          _L(6)
+#define GPIO_PC19G_CATB_SENSE20  _UL_(1 << 19)
+#define PIN_PB00G_CATB_SENSE21         _L_(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
+#define MUX_PB00G_CATB_SENSE21          _L_(6)
 #define PINMUX_PB00G_CATB_SENSE21  ((PIN_PB00G_CATB_SENSE21 << 16) | MUX_PB00G_CATB_SENSE21)
-#define GPIO_PB00G_CATB_SENSE21  _UL(1 <<  0)
-#define PIN_PC20G_CATB_SENSE21         _L(84) /**< \brief CATB signal: SENSE21 on PC20 mux G */
-#define MUX_PC20G_CATB_SENSE21          _L(6)
+#define GPIO_PB00G_CATB_SENSE21  _UL_(1 <<  0)
+#define PIN_PC20G_CATB_SENSE21         _L_(84) /**< \brief CATB signal: SENSE21 on PC20 mux G */
+#define MUX_PC20G_CATB_SENSE21          _L_(6)
 #define PINMUX_PC20G_CATB_SENSE21  ((PIN_PC20G_CATB_SENSE21 << 16) | MUX_PC20G_CATB_SENSE21)
-#define GPIO_PC20G_CATB_SENSE21  _UL(1 << 20)
-#define PIN_PB01G_CATB_SENSE22         _L(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
-#define MUX_PB01G_CATB_SENSE22          _L(6)
+#define GPIO_PC20G_CATB_SENSE21  _UL_(1 << 20)
+#define PIN_PB01G_CATB_SENSE22         _L_(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
+#define MUX_PB01G_CATB_SENSE22          _L_(6)
 #define PINMUX_PB01G_CATB_SENSE22  ((PIN_PB01G_CATB_SENSE22 << 16) | MUX_PB01G_CATB_SENSE22)
-#define GPIO_PB01G_CATB_SENSE22  _UL(1 <<  1)
-#define PIN_PC21G_CATB_SENSE22         _L(85) /**< \brief CATB signal: SENSE22 on PC21 mux G */
-#define MUX_PC21G_CATB_SENSE22          _L(6)
+#define GPIO_PB01G_CATB_SENSE22  _UL_(1 <<  1)
+#define PIN_PC21G_CATB_SENSE22         _L_(85) /**< \brief CATB signal: SENSE22 on PC21 mux G */
+#define MUX_PC21G_CATB_SENSE22          _L_(6)
 #define PINMUX_PC21G_CATB_SENSE22  ((PIN_PC21G_CATB_SENSE22 << 16) | MUX_PC21G_CATB_SENSE22)
-#define GPIO_PC21G_CATB_SENSE22  _UL(1 << 21)
-#define PIN_PB02G_CATB_SENSE23         _L(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
-#define MUX_PB02G_CATB_SENSE23          _L(6)
+#define GPIO_PC21G_CATB_SENSE22  _UL_(1 << 21)
+#define PIN_PB02G_CATB_SENSE23         _L_(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
+#define MUX_PB02G_CATB_SENSE23          _L_(6)
 #define PINMUX_PB02G_CATB_SENSE23  ((PIN_PB02G_CATB_SENSE23 << 16) | MUX_PB02G_CATB_SENSE23)
-#define GPIO_PB02G_CATB_SENSE23  _UL(1 <<  2)
-#define PIN_PC22G_CATB_SENSE23         _L(86) /**< \brief CATB signal: SENSE23 on PC22 mux G */
-#define MUX_PC22G_CATB_SENSE23          _L(6)
+#define GPIO_PB02G_CATB_SENSE23  _UL_(1 <<  2)
+#define PIN_PC22G_CATB_SENSE23         _L_(86) /**< \brief CATB signal: SENSE23 on PC22 mux G */
+#define MUX_PC22G_CATB_SENSE23          _L_(6)
 #define PINMUX_PC22G_CATB_SENSE23  ((PIN_PC22G_CATB_SENSE23 << 16) | MUX_PC22G_CATB_SENSE23)
-#define GPIO_PC22G_CATB_SENSE23  _UL(1 << 22)
-#define PIN_PB04G_CATB_SENSE24         _L(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
-#define MUX_PB04G_CATB_SENSE24          _L(6)
+#define GPIO_PC22G_CATB_SENSE23  _UL_(1 << 22)
+#define PIN_PB04G_CATB_SENSE24         _L_(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
+#define MUX_PB04G_CATB_SENSE24          _L_(6)
 #define PINMUX_PB04G_CATB_SENSE24  ((PIN_PB04G_CATB_SENSE24 << 16) | MUX_PB04G_CATB_SENSE24)
-#define GPIO_PB04G_CATB_SENSE24  _UL(1 <<  4)
-#define PIN_PC24G_CATB_SENSE24         _L(88) /**< \brief CATB signal: SENSE24 on PC24 mux G */
-#define MUX_PC24G_CATB_SENSE24          _L(6)
+#define GPIO_PB04G_CATB_SENSE24  _UL_(1 <<  4)
+#define PIN_PC24G_CATB_SENSE24         _L_(88) /**< \brief CATB signal: SENSE24 on PC24 mux G */
+#define MUX_PC24G_CATB_SENSE24          _L_(6)
 #define PINMUX_PC24G_CATB_SENSE24  ((PIN_PC24G_CATB_SENSE24 << 16) | MUX_PC24G_CATB_SENSE24)
-#define GPIO_PC24G_CATB_SENSE24  _UL(1 << 24)
-#define PIN_PB05G_CATB_SENSE25         _L(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
-#define MUX_PB05G_CATB_SENSE25          _L(6)
+#define GPIO_PC24G_CATB_SENSE24  _UL_(1 << 24)
+#define PIN_PB05G_CATB_SENSE25         _L_(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
+#define MUX_PB05G_CATB_SENSE25          _L_(6)
 #define PINMUX_PB05G_CATB_SENSE25  ((PIN_PB05G_CATB_SENSE25 << 16) | MUX_PB05G_CATB_SENSE25)
-#define GPIO_PB05G_CATB_SENSE25  _UL(1 <<  5)
-#define PIN_PC25G_CATB_SENSE25         _L(89) /**< \brief CATB signal: SENSE25 on PC25 mux G */
-#define MUX_PC25G_CATB_SENSE25          _L(6)
+#define GPIO_PB05G_CATB_SENSE25  _UL_(1 <<  5)
+#define PIN_PC25G_CATB_SENSE25         _L_(89) /**< \brief CATB signal: SENSE25 on PC25 mux G */
+#define MUX_PC25G_CATB_SENSE25          _L_(6)
 #define PINMUX_PC25G_CATB_SENSE25  ((PIN_PC25G_CATB_SENSE25 << 16) | MUX_PC25G_CATB_SENSE25)
-#define GPIO_PC25G_CATB_SENSE25  _UL(1 << 25)
-#define PIN_PB06G_CATB_SENSE26         _L(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
-#define MUX_PB06G_CATB_SENSE26          _L(6)
+#define GPIO_PC25G_CATB_SENSE25  _UL_(1 << 25)
+#define PIN_PB06G_CATB_SENSE26         _L_(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
+#define MUX_PB06G_CATB_SENSE26          _L_(6)
 #define PINMUX_PB06G_CATB_SENSE26  ((PIN_PB06G_CATB_SENSE26 << 16) | MUX_PB06G_CATB_SENSE26)
-#define GPIO_PB06G_CATB_SENSE26  _UL(1 <<  6)
-#define PIN_PC26G_CATB_SENSE26         _L(90) /**< \brief CATB signal: SENSE26 on PC26 mux G */
-#define MUX_PC26G_CATB_SENSE26          _L(6)
+#define GPIO_PB06G_CATB_SENSE26  _UL_(1 <<  6)
+#define PIN_PC26G_CATB_SENSE26         _L_(90) /**< \brief CATB signal: SENSE26 on PC26 mux G */
+#define MUX_PC26G_CATB_SENSE26          _L_(6)
 #define PINMUX_PC26G_CATB_SENSE26  ((PIN_PC26G_CATB_SENSE26 << 16) | MUX_PC26G_CATB_SENSE26)
-#define GPIO_PC26G_CATB_SENSE26  _UL(1 << 26)
-#define PIN_PB07G_CATB_SENSE27         _L(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
-#define MUX_PB07G_CATB_SENSE27          _L(6)
+#define GPIO_PC26G_CATB_SENSE26  _UL_(1 << 26)
+#define PIN_PB07G_CATB_SENSE27         _L_(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
+#define MUX_PB07G_CATB_SENSE27          _L_(6)
 #define PINMUX_PB07G_CATB_SENSE27  ((PIN_PB07G_CATB_SENSE27 << 16) | MUX_PB07G_CATB_SENSE27)
-#define GPIO_PB07G_CATB_SENSE27  _UL(1 <<  7)
-#define PIN_PC27G_CATB_SENSE27         _L(91) /**< \brief CATB signal: SENSE27 on PC27 mux G */
-#define MUX_PC27G_CATB_SENSE27          _L(6)
+#define GPIO_PB07G_CATB_SENSE27  _UL_(1 <<  7)
+#define PIN_PC27G_CATB_SENSE27         _L_(91) /**< \brief CATB signal: SENSE27 on PC27 mux G */
+#define MUX_PC27G_CATB_SENSE27          _L_(6)
 #define PINMUX_PC27G_CATB_SENSE27  ((PIN_PC27G_CATB_SENSE27 << 16) | MUX_PC27G_CATB_SENSE27)
-#define GPIO_PC27G_CATB_SENSE27  _UL(1 << 27)
-#define PIN_PB08G_CATB_SENSE28         _L(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
-#define MUX_PB08G_CATB_SENSE28          _L(6)
+#define GPIO_PC27G_CATB_SENSE27  _UL_(1 << 27)
+#define PIN_PB08G_CATB_SENSE28         _L_(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
+#define MUX_PB08G_CATB_SENSE28          _L_(6)
 #define PINMUX_PB08G_CATB_SENSE28  ((PIN_PB08G_CATB_SENSE28 << 16) | MUX_PB08G_CATB_SENSE28)
-#define GPIO_PB08G_CATB_SENSE28  _UL(1 <<  8)
-#define PIN_PC28G_CATB_SENSE28         _L(92) /**< \brief CATB signal: SENSE28 on PC28 mux G */
-#define MUX_PC28G_CATB_SENSE28          _L(6)
+#define GPIO_PB08G_CATB_SENSE28  _UL_(1 <<  8)
+#define PIN_PC28G_CATB_SENSE28         _L_(92) /**< \brief CATB signal: SENSE28 on PC28 mux G */
+#define MUX_PC28G_CATB_SENSE28          _L_(6)
 #define PINMUX_PC28G_CATB_SENSE28  ((PIN_PC28G_CATB_SENSE28 << 16) | MUX_PC28G_CATB_SENSE28)
-#define GPIO_PC28G_CATB_SENSE28  _UL(1 << 28)
-#define PIN_PB09G_CATB_SENSE29         _L(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
-#define MUX_PB09G_CATB_SENSE29          _L(6)
+#define GPIO_PC28G_CATB_SENSE28  _UL_(1 << 28)
+#define PIN_PB09G_CATB_SENSE29         _L_(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
+#define MUX_PB09G_CATB_SENSE29          _L_(6)
 #define PINMUX_PB09G_CATB_SENSE29  ((PIN_PB09G_CATB_SENSE29 << 16) | MUX_PB09G_CATB_SENSE29)
-#define GPIO_PB09G_CATB_SENSE29  _UL(1 <<  9)
-#define PIN_PC29G_CATB_SENSE29         _L(93) /**< \brief CATB signal: SENSE29 on PC29 mux G */
-#define MUX_PC29G_CATB_SENSE29          _L(6)
+#define GPIO_PB09G_CATB_SENSE29  _UL_(1 <<  9)
+#define PIN_PC29G_CATB_SENSE29         _L_(93) /**< \brief CATB signal: SENSE29 on PC29 mux G */
+#define MUX_PC29G_CATB_SENSE29          _L_(6)
 #define PINMUX_PC29G_CATB_SENSE29  ((PIN_PC29G_CATB_SENSE29 << 16) | MUX_PC29G_CATB_SENSE29)
-#define GPIO_PC29G_CATB_SENSE29  _UL(1 << 29)
-#define PIN_PB10G_CATB_SENSE30         _L(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
-#define MUX_PB10G_CATB_SENSE30          _L(6)
+#define GPIO_PC29G_CATB_SENSE29  _UL_(1 << 29)
+#define PIN_PB10G_CATB_SENSE30         _L_(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
+#define MUX_PB10G_CATB_SENSE30          _L_(6)
 #define PINMUX_PB10G_CATB_SENSE30  ((PIN_PB10G_CATB_SENSE30 << 16) | MUX_PB10G_CATB_SENSE30)
-#define GPIO_PB10G_CATB_SENSE30  _UL(1 << 10)
-#define PIN_PC30G_CATB_SENSE30         _L(94) /**< \brief CATB signal: SENSE30 on PC30 mux G */
-#define MUX_PC30G_CATB_SENSE30          _L(6)
+#define GPIO_PB10G_CATB_SENSE30  _UL_(1 << 10)
+#define PIN_PC30G_CATB_SENSE30         _L_(94) /**< \brief CATB signal: SENSE30 on PC30 mux G */
+#define MUX_PC30G_CATB_SENSE30          _L_(6)
 #define PINMUX_PC30G_CATB_SENSE30  ((PIN_PC30G_CATB_SENSE30 << 16) | MUX_PC30G_CATB_SENSE30)
-#define GPIO_PC30G_CATB_SENSE30  _UL(1 << 30)
-#define PIN_PB11G_CATB_SENSE31         _L(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
-#define MUX_PB11G_CATB_SENSE31          _L(6)
+#define GPIO_PC30G_CATB_SENSE30  _UL_(1 << 30)
+#define PIN_PB11G_CATB_SENSE31         _L_(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
+#define MUX_PB11G_CATB_SENSE31          _L_(6)
 #define PINMUX_PB11G_CATB_SENSE31  ((PIN_PB11G_CATB_SENSE31 << 16) | MUX_PB11G_CATB_SENSE31)
-#define GPIO_PB11G_CATB_SENSE31  _UL(1 << 11)
-#define PIN_PC31G_CATB_SENSE31         _L(95) /**< \brief CATB signal: SENSE31 on PC31 mux G */
-#define MUX_PC31G_CATB_SENSE31          _L(6)
+#define GPIO_PB11G_CATB_SENSE31  _UL_(1 << 11)
+#define PIN_PC31G_CATB_SENSE31         _L_(95) /**< \brief CATB signal: SENSE31 on PC31 mux G */
+#define MUX_PC31G_CATB_SENSE31          _L_(6)
 #define PINMUX_PC31G_CATB_SENSE31  ((PIN_PC31G_CATB_SENSE31 << 16) | MUX_PC31G_CATB_SENSE31)
-#define GPIO_PC31G_CATB_SENSE31  _UL(1 << 31)
+#define GPIO_PC31G_CATB_SENSE31  _UL_(1 << 31)
 /* ========== GPIO definition for USBC peripheral ========== */
-#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
-#define MUX_PA25A_USBC_DM               _L(0)
+#define PIN_PA25A_USBC_DM              _L_(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L_(0)
 #define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
-#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
-#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
-#define MUX_PA26A_USBC_DP               _L(0)
+#define GPIO_PA25A_USBC_DM       _UL_(1 << 25)
+#define PIN_PA26A_USBC_DP              _L_(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L_(0)
 #define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
-#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+#define GPIO_PA26A_USBC_DP       _UL_(1 << 26)
 /* ========== GPIO definition for PEVC peripheral ========== */
-#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
-#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PIN_PA08C_PEVC_PAD_EVT0         _L_(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
-#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
-#define PIN_PB12C_PEVC_PAD_EVT0        _L(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
-#define MUX_PB12C_PEVC_PAD_EVT0         _L(2)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL_(1 <<  8)
+#define PIN_PB12C_PEVC_PAD_EVT0        _L_(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
+#define MUX_PB12C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PB12C_PEVC_PAD_EVT0  ((PIN_PB12C_PEVC_PAD_EVT0 << 16) | MUX_PB12C_PEVC_PAD_EVT0)
-#define GPIO_PB12C_PEVC_PAD_EVT0  _UL(1 << 12)
-#define PIN_PC07C_PEVC_PAD_EVT0        _L(71) /**< \brief PEVC signal: PAD_EVT0 on PC07 mux C */
-#define MUX_PC07C_PEVC_PAD_EVT0         _L(2)
+#define GPIO_PB12C_PEVC_PAD_EVT0  _UL_(1 << 12)
+#define PIN_PC07C_PEVC_PAD_EVT0        _L_(71) /**< \brief PEVC signal: PAD_EVT0 on PC07 mux C */
+#define MUX_PC07C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PC07C_PEVC_PAD_EVT0  ((PIN_PC07C_PEVC_PAD_EVT0 << 16) | MUX_PC07C_PEVC_PAD_EVT0)
-#define GPIO_PC07C_PEVC_PAD_EVT0  _UL(1 <<  7)
-#define PIN_PC24C_PEVC_PAD_EVT0        _L(88) /**< \brief PEVC signal: PAD_EVT0 on PC24 mux C */
-#define MUX_PC24C_PEVC_PAD_EVT0         _L(2)
+#define GPIO_PC07C_PEVC_PAD_EVT0  _UL_(1 <<  7)
+#define PIN_PC24C_PEVC_PAD_EVT0        _L_(88) /**< \brief PEVC signal: PAD_EVT0 on PC24 mux C */
+#define MUX_PC24C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PC24C_PEVC_PAD_EVT0  ((PIN_PC24C_PEVC_PAD_EVT0 << 16) | MUX_PC24C_PEVC_PAD_EVT0)
-#define GPIO_PC24C_PEVC_PAD_EVT0  _UL(1 << 24)
-#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
-#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PC24C_PEVC_PAD_EVT0  _UL_(1 << 24)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L_(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
-#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
-#define PIN_PB13C_PEVC_PAD_EVT1        _L(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
-#define MUX_PB13C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL_(1 <<  9)
+#define PIN_PB13C_PEVC_PAD_EVT1        _L_(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
+#define MUX_PB13C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PB13C_PEVC_PAD_EVT1  ((PIN_PB13C_PEVC_PAD_EVT1 << 16) | MUX_PB13C_PEVC_PAD_EVT1)
-#define GPIO_PB13C_PEVC_PAD_EVT1  _UL(1 << 13)
-#define PIN_PC08C_PEVC_PAD_EVT1        _L(72) /**< \brief PEVC signal: PAD_EVT1 on PC08 mux C */
-#define MUX_PC08C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PB13C_PEVC_PAD_EVT1  _UL_(1 << 13)
+#define PIN_PC08C_PEVC_PAD_EVT1        _L_(72) /**< \brief PEVC signal: PAD_EVT1 on PC08 mux C */
+#define MUX_PC08C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PC08C_PEVC_PAD_EVT1  ((PIN_PC08C_PEVC_PAD_EVT1 << 16) | MUX_PC08C_PEVC_PAD_EVT1)
-#define GPIO_PC08C_PEVC_PAD_EVT1  _UL(1 <<  8)
-#define PIN_PC25C_PEVC_PAD_EVT1        _L(89) /**< \brief PEVC signal: PAD_EVT1 on PC25 mux C */
-#define MUX_PC25C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PC08C_PEVC_PAD_EVT1  _UL_(1 <<  8)
+#define PIN_PC25C_PEVC_PAD_EVT1        _L_(89) /**< \brief PEVC signal: PAD_EVT1 on PC25 mux C */
+#define MUX_PC25C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PC25C_PEVC_PAD_EVT1  ((PIN_PC25C_PEVC_PAD_EVT1 << 16) | MUX_PC25C_PEVC_PAD_EVT1)
-#define GPIO_PC25C_PEVC_PAD_EVT1  _UL(1 << 25)
-#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
-#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PC25C_PEVC_PAD_EVT1  _UL_(1 << 25)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L_(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
-#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
-#define PIN_PC11C_PEVC_PAD_EVT2        _L(75) /**< \brief PEVC signal: PAD_EVT2 on PC11 mux C */
-#define MUX_PC11C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL_(1 << 10)
+#define PIN_PC11C_PEVC_PAD_EVT2        _L_(75) /**< \brief PEVC signal: PAD_EVT2 on PC11 mux C */
+#define MUX_PC11C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PC11C_PEVC_PAD_EVT2  ((PIN_PC11C_PEVC_PAD_EVT2 << 16) | MUX_PC11C_PEVC_PAD_EVT2)
-#define GPIO_PC11C_PEVC_PAD_EVT2  _UL(1 << 11)
-#define PIN_PC26C_PEVC_PAD_EVT2        _L(90) /**< \brief PEVC signal: PAD_EVT2 on PC26 mux C */
-#define MUX_PC26C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PC11C_PEVC_PAD_EVT2  _UL_(1 << 11)
+#define PIN_PC26C_PEVC_PAD_EVT2        _L_(90) /**< \brief PEVC signal: PAD_EVT2 on PC26 mux C */
+#define MUX_PC26C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PC26C_PEVC_PAD_EVT2  ((PIN_PC26C_PEVC_PAD_EVT2 << 16) | MUX_PC26C_PEVC_PAD_EVT2)
-#define GPIO_PC26C_PEVC_PAD_EVT2  _UL(1 << 26)
-#define PIN_PB09B_PEVC_PAD_EVT2        _L(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
-#define MUX_PB09B_PEVC_PAD_EVT2         _L(1)
+#define GPIO_PC26C_PEVC_PAD_EVT2  _UL_(1 << 26)
+#define PIN_PB09B_PEVC_PAD_EVT2        _L_(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
+#define MUX_PB09B_PEVC_PAD_EVT2         _L_(1)
 #define PINMUX_PB09B_PEVC_PAD_EVT2  ((PIN_PB09B_PEVC_PAD_EVT2 << 16) | MUX_PB09B_PEVC_PAD_EVT2)
-#define GPIO_PB09B_PEVC_PAD_EVT2  _UL(1 <<  9)
-#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
-#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define GPIO_PB09B_PEVC_PAD_EVT2  _UL_(1 <<  9)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L_(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L_(2)
 #define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
-#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
-#define PIN_PC27C_PEVC_PAD_EVT3        _L(91) /**< \brief PEVC signal: PAD_EVT3 on PC27 mux C */
-#define MUX_PC27C_PEVC_PAD_EVT3         _L(2)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL_(1 << 11)
+#define PIN_PC27C_PEVC_PAD_EVT3        _L_(91) /**< \brief PEVC signal: PAD_EVT3 on PC27 mux C */
+#define MUX_PC27C_PEVC_PAD_EVT3         _L_(2)
 #define PINMUX_PC27C_PEVC_PAD_EVT3  ((PIN_PC27C_PEVC_PAD_EVT3 << 16) | MUX_PC27C_PEVC_PAD_EVT3)
-#define GPIO_PC27C_PEVC_PAD_EVT3  _UL(1 << 27)
-#define PIN_PB10B_PEVC_PAD_EVT3        _L(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
-#define MUX_PB10B_PEVC_PAD_EVT3         _L(1)
+#define GPIO_PC27C_PEVC_PAD_EVT3  _UL_(1 << 27)
+#define PIN_PB10B_PEVC_PAD_EVT3        _L_(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
+#define MUX_PB10B_PEVC_PAD_EVT3         _L_(1)
 #define PINMUX_PB10B_PEVC_PAD_EVT3  ((PIN_PB10B_PEVC_PAD_EVT3 << 16) | MUX_PB10B_PEVC_PAD_EVT3)
-#define GPIO_PB10B_PEVC_PAD_EVT3  _UL(1 << 10)
+#define GPIO_PB10B_PEVC_PAD_EVT3  _UL_(1 << 10)
 /* ========== GPIO definition for SCIF peripheral ========== */
-#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
-#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PIN_PA19E_SCIF_GCLK0           _L_(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
-#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
-#define PIN_PB10E_SCIF_GCLK0           _L(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
-#define MUX_PB10E_SCIF_GCLK0            _L(4)
+#define GPIO_PA19E_SCIF_GCLK0    _UL_(1 << 19)
+#define PIN_PB10E_SCIF_GCLK0           _L_(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
+#define MUX_PB10E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PB10E_SCIF_GCLK0    ((PIN_PB10E_SCIF_GCLK0 << 16) | MUX_PB10E_SCIF_GCLK0)
-#define GPIO_PB10E_SCIF_GCLK0    _UL(1 << 10)
-#define PIN_PC26E_SCIF_GCLK0           _L(90) /**< \brief SCIF signal: GCLK0 on PC26 mux E */
-#define MUX_PC26E_SCIF_GCLK0            _L(4)
+#define GPIO_PB10E_SCIF_GCLK0    _UL_(1 << 10)
+#define PIN_PC26E_SCIF_GCLK0           _L_(90) /**< \brief SCIF signal: GCLK0 on PC26 mux E */
+#define MUX_PC26E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PC26E_SCIF_GCLK0    ((PIN_PC26E_SCIF_GCLK0 << 16) | MUX_PC26E_SCIF_GCLK0)
-#define GPIO_PC26E_SCIF_GCLK0    _UL(1 << 26)
-#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
-#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define GPIO_PC26E_SCIF_GCLK0    _UL_(1 << 26)
+#define PIN_PA02A_SCIF_GCLK0            _L_(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L_(0)
 #define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
-#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
-#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
-#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define GPIO_PA02A_SCIF_GCLK0    _UL_(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L_(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
-#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
-#define PIN_PB11E_SCIF_GCLK1           _L(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
-#define MUX_PB11E_SCIF_GCLK1            _L(4)
+#define GPIO_PA20E_SCIF_GCLK1    _UL_(1 << 20)
+#define PIN_PB11E_SCIF_GCLK1           _L_(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
+#define MUX_PB11E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PB11E_SCIF_GCLK1    ((PIN_PB11E_SCIF_GCLK1 << 16) | MUX_PB11E_SCIF_GCLK1)
-#define GPIO_PB11E_SCIF_GCLK1    _UL(1 << 11)
-#define PIN_PC27E_SCIF_GCLK1           _L(91) /**< \brief SCIF signal: GCLK1 on PC27 mux E */
-#define MUX_PC27E_SCIF_GCLK1            _L(4)
+#define GPIO_PB11E_SCIF_GCLK1    _UL_(1 << 11)
+#define PIN_PC27E_SCIF_GCLK1           _L_(91) /**< \brief SCIF signal: GCLK1 on PC27 mux E */
+#define MUX_PC27E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PC27E_SCIF_GCLK1    ((PIN_PC27E_SCIF_GCLK1 << 16) | MUX_PC27E_SCIF_GCLK1)
-#define GPIO_PC27E_SCIF_GCLK1    _UL(1 << 27)
-#define PIN_PB12E_SCIF_GCLK2           _L(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
-#define MUX_PB12E_SCIF_GCLK2            _L(4)
+#define GPIO_PC27E_SCIF_GCLK1    _UL_(1 << 27)
+#define PIN_PB12E_SCIF_GCLK2           _L_(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
+#define MUX_PB12E_SCIF_GCLK2            _L_(4)
 #define PINMUX_PB12E_SCIF_GCLK2    ((PIN_PB12E_SCIF_GCLK2 << 16) | MUX_PB12E_SCIF_GCLK2)
-#define GPIO_PB12E_SCIF_GCLK2    _UL(1 << 12)
-#define PIN_PC28E_SCIF_GCLK2           _L(92) /**< \brief SCIF signal: GCLK2 on PC28 mux E */
-#define MUX_PC28E_SCIF_GCLK2            _L(4)
+#define GPIO_PB12E_SCIF_GCLK2    _UL_(1 << 12)
+#define PIN_PC28E_SCIF_GCLK2           _L_(92) /**< \brief SCIF signal: GCLK2 on PC28 mux E */
+#define MUX_PC28E_SCIF_GCLK2            _L_(4)
 #define PINMUX_PC28E_SCIF_GCLK2    ((PIN_PC28E_SCIF_GCLK2 << 16) | MUX_PC28E_SCIF_GCLK2)
-#define GPIO_PC28E_SCIF_GCLK2    _UL(1 << 28)
-#define PIN_PB13E_SCIF_GCLK3           _L(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
-#define MUX_PB13E_SCIF_GCLK3            _L(4)
+#define GPIO_PC28E_SCIF_GCLK2    _UL_(1 << 28)
+#define PIN_PB13E_SCIF_GCLK3           _L_(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
+#define MUX_PB13E_SCIF_GCLK3            _L_(4)
 #define PINMUX_PB13E_SCIF_GCLK3    ((PIN_PB13E_SCIF_GCLK3 << 16) | MUX_PB13E_SCIF_GCLK3)
-#define GPIO_PB13E_SCIF_GCLK3    _UL(1 << 13)
-#define PIN_PC29E_SCIF_GCLK3           _L(93) /**< \brief SCIF signal: GCLK3 on PC29 mux E */
-#define MUX_PC29E_SCIF_GCLK3            _L(4)
+#define GPIO_PB13E_SCIF_GCLK3    _UL_(1 << 13)
+#define PIN_PC29E_SCIF_GCLK3           _L_(93) /**< \brief SCIF signal: GCLK3 on PC29 mux E */
+#define MUX_PC29E_SCIF_GCLK3            _L_(4)
 #define PINMUX_PC29E_SCIF_GCLK3    ((PIN_PC29E_SCIF_GCLK3 << 16) | MUX_PC29E_SCIF_GCLK3)
-#define GPIO_PC29E_SCIF_GCLK3    _UL(1 << 29)
-#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
-#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PC29E_SCIF_GCLK3    _UL_(1 << 29)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L_(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
-#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
-#define PIN_PB14E_SCIF_GCLK_IN0        _L(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
-#define MUX_PB14E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL_(1 << 23)
+#define PIN_PB14E_SCIF_GCLK_IN0        _L_(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
+#define MUX_PB14E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PB14E_SCIF_GCLK_IN0  ((PIN_PB14E_SCIF_GCLK_IN0 << 16) | MUX_PB14E_SCIF_GCLK_IN0)
-#define GPIO_PB14E_SCIF_GCLK_IN0  _UL(1 << 14)
-#define PIN_PC30E_SCIF_GCLK_IN0        _L(94) /**< \brief SCIF signal: GCLK_IN0 on PC30 mux E */
-#define MUX_PC30E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PB14E_SCIF_GCLK_IN0  _UL_(1 << 14)
+#define PIN_PC30E_SCIF_GCLK_IN0        _L_(94) /**< \brief SCIF signal: GCLK_IN0 on PC30 mux E */
+#define MUX_PC30E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PC30E_SCIF_GCLK_IN0  ((PIN_PC30E_SCIF_GCLK_IN0 << 16) | MUX_PC30E_SCIF_GCLK_IN0)
-#define GPIO_PC30E_SCIF_GCLK_IN0  _UL(1 << 30)
-#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
-#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PC30E_SCIF_GCLK_IN0  _UL_(1 << 30)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L_(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
-#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
-#define PIN_PB15E_SCIF_GCLK_IN1        _L(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
-#define MUX_PB15E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL_(1 << 24)
+#define PIN_PB15E_SCIF_GCLK_IN1        _L_(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
+#define MUX_PB15E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PB15E_SCIF_GCLK_IN1  ((PIN_PB15E_SCIF_GCLK_IN1 << 16) | MUX_PB15E_SCIF_GCLK_IN1)
-#define GPIO_PB15E_SCIF_GCLK_IN1  _UL(1 << 15)
-#define PIN_PC31E_SCIF_GCLK_IN1        _L(95) /**< \brief SCIF signal: GCLK_IN1 on PC31 mux E */
-#define MUX_PC31E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PB15E_SCIF_GCLK_IN1  _UL_(1 << 15)
+#define PIN_PC31E_SCIF_GCLK_IN1        _L_(95) /**< \brief SCIF signal: GCLK_IN1 on PC31 mux E */
+#define MUX_PC31E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PC31E_SCIF_GCLK_IN1  ((PIN_PC31E_SCIF_GCLK_IN1 << 16) | MUX_PC31E_SCIF_GCLK_IN1)
-#define GPIO_PC31E_SCIF_GCLK_IN1  _UL(1 << 31)
+#define GPIO_PC31E_SCIF_GCLK_IN1  _UL_(1 << 31)
 /* ========== GPIO definition for EIC peripheral ========== */
-#define PIN_PB01C_EIC_EXTINT0          _L(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
-#define MUX_PB01C_EIC_EXTINT0           _L(2)
+#define PIN_PB01C_EIC_EXTINT0          _L_(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
+#define MUX_PB01C_EIC_EXTINT0           _L_(2)
 #define PINMUX_PB01C_EIC_EXTINT0   ((PIN_PB01C_EIC_EXTINT0 << 16) | MUX_PB01C_EIC_EXTINT0)
-#define GPIO_PB01C_EIC_EXTINT0   _UL(1 <<  1)
-#define PIN_PB01C_EIC_EXTINT_NUM        _L(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
-#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
-#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define GPIO_PB01C_EIC_EXTINT0   _UL_(1 <<  1)
+#define PIN_PB01C_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PA06C_EIC_EXTINT1           _L_(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
-#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
-#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
-#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
-#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define GPIO_PA06C_EIC_EXTINT1   _UL_(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L_(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
-#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
-#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
-#define PIN_PC24B_EIC_EXTINT1          _L(88) /**< \brief EIC signal: EXTINT1 on PC24 mux B */
-#define MUX_PC24B_EIC_EXTINT1           _L(1)
+#define GPIO_PA16C_EIC_EXTINT1   _UL_(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PC24B_EIC_EXTINT1          _L_(88) /**< \brief EIC signal: EXTINT1 on PC24 mux B */
+#define MUX_PC24B_EIC_EXTINT1           _L_(1)
 #define PINMUX_PC24B_EIC_EXTINT1   ((PIN_PC24B_EIC_EXTINT1 << 16) | MUX_PC24B_EIC_EXTINT1)
-#define GPIO_PC24B_EIC_EXTINT1   _UL(1 << 24)
-#define PIN_PC24B_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PC24 External Interrupt Line */
-#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
-#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define GPIO_PC24B_EIC_EXTINT1   _UL_(1 << 24)
+#define PIN_PC24B_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PC24 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L_(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
-#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
-#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
-#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
-#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL_(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L_(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
-#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
-#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
-#define PIN_PC25B_EIC_EXTINT2          _L(89) /**< \brief EIC signal: EXTINT2 on PC25 mux B */
-#define MUX_PC25B_EIC_EXTINT2           _L(1)
+#define GPIO_PA17C_EIC_EXTINT2   _UL_(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PC25B_EIC_EXTINT2          _L_(89) /**< \brief EIC signal: EXTINT2 on PC25 mux B */
+#define MUX_PC25B_EIC_EXTINT2           _L_(1)
 #define PINMUX_PC25B_EIC_EXTINT2   ((PIN_PC25B_EIC_EXTINT2 << 16) | MUX_PC25B_EIC_EXTINT2)
-#define GPIO_PC25B_EIC_EXTINT2   _UL(1 << 25)
-#define PIN_PC25B_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PC25 External Interrupt Line */
-#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
-#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define GPIO_PC25B_EIC_EXTINT2   _UL_(1 << 25)
+#define PIN_PC25B_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PC25 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L_(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
-#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
-#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
-#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
-#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define GPIO_PA05C_EIC_EXTINT3   _UL_(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L_(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
-#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
-#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
-#define PIN_PC26B_EIC_EXTINT3          _L(90) /**< \brief EIC signal: EXTINT3 on PC26 mux B */
-#define MUX_PC26B_EIC_EXTINT3           _L(1)
+#define GPIO_PA18C_EIC_EXTINT3   _UL_(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PC26B_EIC_EXTINT3          _L_(90) /**< \brief EIC signal: EXTINT3 on PC26 mux B */
+#define MUX_PC26B_EIC_EXTINT3           _L_(1)
 #define PINMUX_PC26B_EIC_EXTINT3   ((PIN_PC26B_EIC_EXTINT3 << 16) | MUX_PC26B_EIC_EXTINT3)
-#define GPIO_PC26B_EIC_EXTINT3   _UL(1 << 26)
-#define PIN_PC26B_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PC26 External Interrupt Line */
-#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
-#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define GPIO_PC26B_EIC_EXTINT3   _UL_(1 << 26)
+#define PIN_PC26B_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PC26 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L_(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
-#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
-#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
-#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
-#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define GPIO_PA07C_EIC_EXTINT4   _UL_(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L_(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
-#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
-#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
-#define PIN_PC27B_EIC_EXTINT4          _L(91) /**< \brief EIC signal: EXTINT4 on PC27 mux B */
-#define MUX_PC27B_EIC_EXTINT4           _L(1)
+#define GPIO_PA19C_EIC_EXTINT4   _UL_(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PC27B_EIC_EXTINT4          _L_(91) /**< \brief EIC signal: EXTINT4 on PC27 mux B */
+#define MUX_PC27B_EIC_EXTINT4           _L_(1)
 #define PINMUX_PC27B_EIC_EXTINT4   ((PIN_PC27B_EIC_EXTINT4 << 16) | MUX_PC27B_EIC_EXTINT4)
-#define GPIO_PC27B_EIC_EXTINT4   _UL(1 << 27)
-#define PIN_PC27B_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PC27 External Interrupt Line */
-#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
-#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define GPIO_PC27B_EIC_EXTINT4   _UL_(1 << 27)
+#define PIN_PC27B_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PC27 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L_(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L_(2)
 #define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
-#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
-#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
-#define PIN_PC03B_EIC_EXTINT5          _L(67) /**< \brief EIC signal: EXTINT5 on PC03 mux B */
-#define MUX_PC03B_EIC_EXTINT5           _L(1)
+#define GPIO_PA20C_EIC_EXTINT5   _UL_(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PC03B_EIC_EXTINT5          _L_(67) /**< \brief EIC signal: EXTINT5 on PC03 mux B */
+#define MUX_PC03B_EIC_EXTINT5           _L_(1)
 #define PINMUX_PC03B_EIC_EXTINT5   ((PIN_PC03B_EIC_EXTINT5 << 16) | MUX_PC03B_EIC_EXTINT5)
-#define GPIO_PC03B_EIC_EXTINT5   _UL(1 <<  3)
-#define PIN_PC03B_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PC03 External Interrupt Line */
-#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
-#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define GPIO_PC03B_EIC_EXTINT5   _UL_(1 <<  3)
+#define PIN_PC03B_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PC03 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L_(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L_(2)
 #define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
-#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
-#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
-#define PIN_PC04B_EIC_EXTINT6          _L(68) /**< \brief EIC signal: EXTINT6 on PC04 mux B */
-#define MUX_PC04B_EIC_EXTINT6           _L(1)
+#define GPIO_PA21C_EIC_EXTINT6   _UL_(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PC04B_EIC_EXTINT6          _L_(68) /**< \brief EIC signal: EXTINT6 on PC04 mux B */
+#define MUX_PC04B_EIC_EXTINT6           _L_(1)
 #define PINMUX_PC04B_EIC_EXTINT6   ((PIN_PC04B_EIC_EXTINT6 << 16) | MUX_PC04B_EIC_EXTINT6)
-#define GPIO_PC04B_EIC_EXTINT6   _UL(1 <<  4)
-#define PIN_PC04B_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PC04 External Interrupt Line */
-#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
-#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define GPIO_PC04B_EIC_EXTINT6   _UL_(1 <<  4)
+#define PIN_PC04B_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PC04 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L_(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L_(2)
 #define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
-#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
-#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
-#define PIN_PC05B_EIC_EXTINT7          _L(69) /**< \brief EIC signal: EXTINT7 on PC05 mux B */
-#define MUX_PC05B_EIC_EXTINT7           _L(1)
+#define GPIO_PA22C_EIC_EXTINT7   _UL_(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PC05B_EIC_EXTINT7          _L_(69) /**< \brief EIC signal: EXTINT7 on PC05 mux B */
+#define MUX_PC05B_EIC_EXTINT7           _L_(1)
 #define PINMUX_PC05B_EIC_EXTINT7   ((PIN_PC05B_EIC_EXTINT7 << 16) | MUX_PC05B_EIC_EXTINT7)
-#define GPIO_PC05B_EIC_EXTINT7   _UL(1 <<  5)
-#define PIN_PC05B_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PC05 External Interrupt Line */
-#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
-#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define GPIO_PC05B_EIC_EXTINT7   _UL_(1 <<  5)
+#define PIN_PC05B_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PC05 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L_(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L_(2)
 #define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
-#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
-#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
-#define PIN_PC06B_EIC_EXTINT8          _L(70) /**< \brief EIC signal: EXTINT8 on PC06 mux B */
-#define MUX_PC06B_EIC_EXTINT8           _L(1)
+#define GPIO_PA23C_EIC_EXTINT8   _UL_(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PC06B_EIC_EXTINT8          _L_(70) /**< \brief EIC signal: EXTINT8 on PC06 mux B */
+#define MUX_PC06B_EIC_EXTINT8           _L_(1)
 #define PINMUX_PC06B_EIC_EXTINT8   ((PIN_PC06B_EIC_EXTINT8 << 16) | MUX_PC06B_EIC_EXTINT8)
-#define GPIO_PC06B_EIC_EXTINT8   _UL(1 <<  6)
-#define PIN_PC06B_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PC06 External Interrupt Line */
+#define GPIO_PC06B_EIC_EXTINT8   _UL_(1 <<  6)
+#define PIN_PC06B_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PC06 External Interrupt Line */
 
 #endif /* _SAM4LS2C_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4ls2c.h
+++ b/asf/sam/include/sam4l/pio/sam4ls2c.h
@@ -1,0 +1,1757 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAM4LS2C
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LS2C_PIO_
+#define _SAM4LS2C_PIO_
+
+#define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
+#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
+#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
+#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
+#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
+#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
+#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
+#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
+#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
+#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
+#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
+#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
+#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
+#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
+#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
+#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
+#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
+#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
+#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
+#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
+#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
+#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
+#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
+#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
+#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
+#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
+#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
+#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
+#define GPIO_PA27                _UL(1 << 27) /**< \brief GPIO Mask  for PA27 */
+#define PIN_PA28                          28  /**< \brief Pin Number for PA28 */
+#define GPIO_PA28                _UL(1 << 28) /**< \brief GPIO Mask  for PA28 */
+#define PIN_PA29                          29  /**< \brief Pin Number for PA29 */
+#define GPIO_PA29                _UL(1 << 29) /**< \brief GPIO Mask  for PA29 */
+#define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
+#define GPIO_PA30                _UL(1 << 30) /**< \brief GPIO Mask  for PA30 */
+#define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
+#define GPIO_PA31                _UL(1 << 31) /**< \brief GPIO Mask  for PA31 */
+#define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
+#define GPIO_PB00                _UL(1 <<  0) /**< \brief GPIO Mask  for PB00 */
+#define PIN_PB01                          33  /**< \brief Pin Number for PB01 */
+#define GPIO_PB01                _UL(1 <<  1) /**< \brief GPIO Mask  for PB01 */
+#define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
+#define GPIO_PB02                _UL(1 <<  2) /**< \brief GPIO Mask  for PB02 */
+#define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
+#define GPIO_PB03                _UL(1 <<  3) /**< \brief GPIO Mask  for PB03 */
+#define PIN_PB04                          36  /**< \brief Pin Number for PB04 */
+#define GPIO_PB04                _UL(1 <<  4) /**< \brief GPIO Mask  for PB04 */
+#define PIN_PB05                          37  /**< \brief Pin Number for PB05 */
+#define GPIO_PB05                _UL(1 <<  5) /**< \brief GPIO Mask  for PB05 */
+#define PIN_PB06                          38  /**< \brief Pin Number for PB06 */
+#define GPIO_PB06                _UL(1 <<  6) /**< \brief GPIO Mask  for PB06 */
+#define PIN_PB07                          39  /**< \brief Pin Number for PB07 */
+#define GPIO_PB07                _UL(1 <<  7) /**< \brief GPIO Mask  for PB07 */
+#define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
+#define GPIO_PB08                _UL(1 <<  8) /**< \brief GPIO Mask  for PB08 */
+#define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
+#define GPIO_PB09                _UL(1 <<  9) /**< \brief GPIO Mask  for PB09 */
+#define PIN_PB10                          42  /**< \brief Pin Number for PB10 */
+#define GPIO_PB10                _UL(1 << 10) /**< \brief GPIO Mask  for PB10 */
+#define PIN_PB11                          43  /**< \brief Pin Number for PB11 */
+#define GPIO_PB11                _UL(1 << 11) /**< \brief GPIO Mask  for PB11 */
+#define PIN_PB12                          44  /**< \brief Pin Number for PB12 */
+#define GPIO_PB12                _UL(1 << 12) /**< \brief GPIO Mask  for PB12 */
+#define PIN_PB13                          45  /**< \brief Pin Number for PB13 */
+#define GPIO_PB13                _UL(1 << 13) /**< \brief GPIO Mask  for PB13 */
+#define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
+#define GPIO_PB14                _UL(1 << 14) /**< \brief GPIO Mask  for PB14 */
+#define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
+#define GPIO_PB15                _UL(1 << 15) /**< \brief GPIO Mask  for PB15 */
+#define PIN_PC00                          64  /**< \brief Pin Number for PC00 */
+#define GPIO_PC00                _UL(1 <<  0) /**< \brief GPIO Mask  for PC00 */
+#define PIN_PC01                          65  /**< \brief Pin Number for PC01 */
+#define GPIO_PC01                _UL(1 <<  1) /**< \brief GPIO Mask  for PC01 */
+#define PIN_PC02                          66  /**< \brief Pin Number for PC02 */
+#define GPIO_PC02                _UL(1 <<  2) /**< \brief GPIO Mask  for PC02 */
+#define PIN_PC03                          67  /**< \brief Pin Number for PC03 */
+#define GPIO_PC03                _UL(1 <<  3) /**< \brief GPIO Mask  for PC03 */
+#define PIN_PC04                          68  /**< \brief Pin Number for PC04 */
+#define GPIO_PC04                _UL(1 <<  4) /**< \brief GPIO Mask  for PC04 */
+#define PIN_PC05                          69  /**< \brief Pin Number for PC05 */
+#define GPIO_PC05                _UL(1 <<  5) /**< \brief GPIO Mask  for PC05 */
+#define PIN_PC06                          70  /**< \brief Pin Number for PC06 */
+#define GPIO_PC06                _UL(1 <<  6) /**< \brief GPIO Mask  for PC06 */
+#define PIN_PC07                          71  /**< \brief Pin Number for PC07 */
+#define GPIO_PC07                _UL(1 <<  7) /**< \brief GPIO Mask  for PC07 */
+#define PIN_PC08                          72  /**< \brief Pin Number for PC08 */
+#define GPIO_PC08                _UL(1 <<  8) /**< \brief GPIO Mask  for PC08 */
+#define PIN_PC09                          73  /**< \brief Pin Number for PC09 */
+#define GPIO_PC09                _UL(1 <<  9) /**< \brief GPIO Mask  for PC09 */
+#define PIN_PC10                          74  /**< \brief Pin Number for PC10 */
+#define GPIO_PC10                _UL(1 << 10) /**< \brief GPIO Mask  for PC10 */
+#define PIN_PC11                          75  /**< \brief Pin Number for PC11 */
+#define GPIO_PC11                _UL(1 << 11) /**< \brief GPIO Mask  for PC11 */
+#define PIN_PC12                          76  /**< \brief Pin Number for PC12 */
+#define GPIO_PC12                _UL(1 << 12) /**< \brief GPIO Mask  for PC12 */
+#define PIN_PC13                          77  /**< \brief Pin Number for PC13 */
+#define GPIO_PC13                _UL(1 << 13) /**< \brief GPIO Mask  for PC13 */
+#define PIN_PC14                          78  /**< \brief Pin Number for PC14 */
+#define GPIO_PC14                _UL(1 << 14) /**< \brief GPIO Mask  for PC14 */
+#define PIN_PC15                          79  /**< \brief Pin Number for PC15 */
+#define GPIO_PC15                _UL(1 << 15) /**< \brief GPIO Mask  for PC15 */
+#define PIN_PC16                          80  /**< \brief Pin Number for PC16 */
+#define GPIO_PC16                _UL(1 << 16) /**< \brief GPIO Mask  for PC16 */
+#define PIN_PC17                          81  /**< \brief Pin Number for PC17 */
+#define GPIO_PC17                _UL(1 << 17) /**< \brief GPIO Mask  for PC17 */
+#define PIN_PC18                          82  /**< \brief Pin Number for PC18 */
+#define GPIO_PC18                _UL(1 << 18) /**< \brief GPIO Mask  for PC18 */
+#define PIN_PC19                          83  /**< \brief Pin Number for PC19 */
+#define GPIO_PC19                _UL(1 << 19) /**< \brief GPIO Mask  for PC19 */
+#define PIN_PC20                          84  /**< \brief Pin Number for PC20 */
+#define GPIO_PC20                _UL(1 << 20) /**< \brief GPIO Mask  for PC20 */
+#define PIN_PC21                          85  /**< \brief Pin Number for PC21 */
+#define GPIO_PC21                _UL(1 << 21) /**< \brief GPIO Mask  for PC21 */
+#define PIN_PC22                          86  /**< \brief Pin Number for PC22 */
+#define GPIO_PC22                _UL(1 << 22) /**< \brief GPIO Mask  for PC22 */
+#define PIN_PC23                          87  /**< \brief Pin Number for PC23 */
+#define GPIO_PC23                _UL(1 << 23) /**< \brief GPIO Mask  for PC23 */
+#define PIN_PC24                          88  /**< \brief Pin Number for PC24 */
+#define GPIO_PC24                _UL(1 << 24) /**< \brief GPIO Mask  for PC24 */
+#define PIN_PC25                          89  /**< \brief Pin Number for PC25 */
+#define GPIO_PC25                _UL(1 << 25) /**< \brief GPIO Mask  for PC25 */
+#define PIN_PC26                          90  /**< \brief Pin Number for PC26 */
+#define GPIO_PC26                _UL(1 << 26) /**< \brief GPIO Mask  for PC26 */
+#define PIN_PC27                          91  /**< \brief Pin Number for PC27 */
+#define GPIO_PC27                _UL(1 << 27) /**< \brief GPIO Mask  for PC27 */
+#define PIN_PC28                          92  /**< \brief Pin Number for PC28 */
+#define GPIO_PC28                _UL(1 << 28) /**< \brief GPIO Mask  for PC28 */
+#define PIN_PC29                          93  /**< \brief Pin Number for PC29 */
+#define GPIO_PC29                _UL(1 << 29) /**< \brief GPIO Mask  for PC29 */
+#define PIN_PC30                          94  /**< \brief Pin Number for PC30 */
+#define GPIO_PC30                _UL(1 << 30) /**< \brief GPIO Mask  for PC30 */
+#define PIN_PC31                          95  /**< \brief Pin Number for PC31 */
+#define GPIO_PC31                _UL(1 << 31) /**< \brief GPIO Mask  for PC31 */
+/* ========== GPIO definition for TWIMS0 peripheral ========== */
+#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
+#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+/* ========== GPIO definition for TWIMS1 peripheral ========== */
+#define PIN_PB01A_TWIMS1_TWCK          _L(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
+#define MUX_PB01A_TWIMS1_TWCK           _L(0)
+#define PINMUX_PB01A_TWIMS1_TWCK   ((PIN_PB01A_TWIMS1_TWCK << 16) | MUX_PB01A_TWIMS1_TWCK)
+#define GPIO_PB01A_TWIMS1_TWCK   _UL(1 <<  1)
+#define PIN_PB00A_TWIMS1_TWD           _L(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
+#define MUX_PB00A_TWIMS1_TWD            _L(0)
+#define PINMUX_PB00A_TWIMS1_TWD    ((PIN_PB00A_TWIMS1_TWD << 16) | MUX_PB00A_TWIMS1_TWD)
+#define GPIO_PB00A_TWIMS1_TWD    _UL(1 <<  0)
+/* ========== GPIO definition for TWIMS2 peripheral ========== */
+#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
+#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+/* ========== GPIO definition for TWIMS3 peripheral ========== */
+#define PIN_PB15C_TWIMS3_TWCK          _L(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
+#define MUX_PB15C_TWIMS3_TWCK           _L(2)
+#define PINMUX_PB15C_TWIMS3_TWCK   ((PIN_PB15C_TWIMS3_TWCK << 16) | MUX_PB15C_TWIMS3_TWCK)
+#define GPIO_PB15C_TWIMS3_TWCK   _UL(1 << 15)
+#define PIN_PB14C_TWIMS3_TWD           _L(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
+#define MUX_PB14C_TWIMS3_TWD            _L(2)
+#define PINMUX_PB14C_TWIMS3_TWD    ((PIN_PB14C_TWIMS3_TWD << 16) | MUX_PB14C_TWIMS3_TWD)
+#define GPIO_PB14C_TWIMS3_TWD    _UL(1 << 14)
+/* ========== GPIO definition for IISC peripheral ========== */
+#define PIN_PB05D_IISC_IMCK            _L(37) /**< \brief IISC signal: IMCK on PB05 mux D */
+#define MUX_PB05D_IISC_IMCK             _L(3)
+#define PINMUX_PB05D_IISC_IMCK     ((PIN_PB05D_IISC_IMCK << 16) | MUX_PB05D_IISC_IMCK)
+#define GPIO_PB05D_IISC_IMCK     _UL(1 <<  5)
+#define PIN_PC14D_IISC_IMCK            _L(78) /**< \brief IISC signal: IMCK on PC14 mux D */
+#define MUX_PC14D_IISC_IMCK             _L(3)
+#define PINMUX_PC14D_IISC_IMCK     ((PIN_PC14D_IISC_IMCK << 16) | MUX_PC14D_IISC_IMCK)
+#define GPIO_PC14D_IISC_IMCK     _UL(1 << 14)
+#define PIN_PA31B_IISC_IMCK            _L(31) /**< \brief IISC signal: IMCK on PA31 mux B */
+#define MUX_PA31B_IISC_IMCK             _L(1)
+#define PINMUX_PA31B_IISC_IMCK     ((PIN_PA31B_IISC_IMCK << 16) | MUX_PA31B_IISC_IMCK)
+#define GPIO_PA31B_IISC_IMCK     _UL(1 << 31)
+#define PIN_PB02D_IISC_ISCK            _L(34) /**< \brief IISC signal: ISCK on PB02 mux D */
+#define MUX_PB02D_IISC_ISCK             _L(3)
+#define PINMUX_PB02D_IISC_ISCK     ((PIN_PB02D_IISC_ISCK << 16) | MUX_PB02D_IISC_ISCK)
+#define GPIO_PB02D_IISC_ISCK     _UL(1 <<  2)
+#define PIN_PC09D_IISC_ISCK            _L(73) /**< \brief IISC signal: ISCK on PC09 mux D */
+#define MUX_PC09D_IISC_ISCK             _L(3)
+#define PINMUX_PC09D_IISC_ISCK     ((PIN_PC09D_IISC_ISCK << 16) | MUX_PC09D_IISC_ISCK)
+#define GPIO_PC09D_IISC_ISCK     _UL(1 <<  9)
+#define PIN_PA27B_IISC_ISCK            _L(27) /**< \brief IISC signal: ISCK on PA27 mux B */
+#define MUX_PA27B_IISC_ISCK             _L(1)
+#define PINMUX_PA27B_IISC_ISCK     ((PIN_PA27B_IISC_ISCK << 16) | MUX_PA27B_IISC_ISCK)
+#define GPIO_PA27B_IISC_ISCK     _UL(1 << 27)
+#define PIN_PB03D_IISC_ISDI            _L(35) /**< \brief IISC signal: ISDI on PB03 mux D */
+#define MUX_PB03D_IISC_ISDI             _L(3)
+#define PINMUX_PB03D_IISC_ISDI     ((PIN_PB03D_IISC_ISDI << 16) | MUX_PB03D_IISC_ISDI)
+#define GPIO_PB03D_IISC_ISDI     _UL(1 <<  3)
+#define PIN_PC10D_IISC_ISDI            _L(74) /**< \brief IISC signal: ISDI on PC10 mux D */
+#define MUX_PC10D_IISC_ISDI             _L(3)
+#define PINMUX_PC10D_IISC_ISDI     ((PIN_PC10D_IISC_ISDI << 16) | MUX_PC10D_IISC_ISDI)
+#define GPIO_PC10D_IISC_ISDI     _UL(1 << 10)
+#define PIN_PA28B_IISC_ISDI            _L(28) /**< \brief IISC signal: ISDI on PA28 mux B */
+#define MUX_PA28B_IISC_ISDI             _L(1)
+#define PINMUX_PA28B_IISC_ISDI     ((PIN_PA28B_IISC_ISDI << 16) | MUX_PA28B_IISC_ISDI)
+#define GPIO_PA28B_IISC_ISDI     _UL(1 << 28)
+#define PIN_PB04D_IISC_ISDO            _L(36) /**< \brief IISC signal: ISDO on PB04 mux D */
+#define MUX_PB04D_IISC_ISDO             _L(3)
+#define PINMUX_PB04D_IISC_ISDO     ((PIN_PB04D_IISC_ISDO << 16) | MUX_PB04D_IISC_ISDO)
+#define GPIO_PB04D_IISC_ISDO     _UL(1 <<  4)
+#define PIN_PC13D_IISC_ISDO            _L(77) /**< \brief IISC signal: ISDO on PC13 mux D */
+#define MUX_PC13D_IISC_ISDO             _L(3)
+#define PINMUX_PC13D_IISC_ISDO     ((PIN_PC13D_IISC_ISDO << 16) | MUX_PC13D_IISC_ISDO)
+#define GPIO_PC13D_IISC_ISDO     _UL(1 << 13)
+#define PIN_PA30B_IISC_ISDO            _L(30) /**< \brief IISC signal: ISDO on PA30 mux B */
+#define MUX_PA30B_IISC_ISDO             _L(1)
+#define PINMUX_PA30B_IISC_ISDO     ((PIN_PA30B_IISC_ISDO << 16) | MUX_PA30B_IISC_ISDO)
+#define GPIO_PA30B_IISC_ISDO     _UL(1 << 30)
+#define PIN_PB06D_IISC_IWS             _L(38) /**< \brief IISC signal: IWS on PB06 mux D */
+#define MUX_PB06D_IISC_IWS              _L(3)
+#define PINMUX_PB06D_IISC_IWS      ((PIN_PB06D_IISC_IWS << 16) | MUX_PB06D_IISC_IWS)
+#define GPIO_PB06D_IISC_IWS      _UL(1 <<  6)
+#define PIN_PC12D_IISC_IWS             _L(76) /**< \brief IISC signal: IWS on PC12 mux D */
+#define MUX_PC12D_IISC_IWS              _L(3)
+#define PINMUX_PC12D_IISC_IWS      ((PIN_PC12D_IISC_IWS << 16) | MUX_PC12D_IISC_IWS)
+#define GPIO_PC12D_IISC_IWS      _UL(1 << 12)
+#define PIN_PA29B_IISC_IWS             _L(29) /**< \brief IISC signal: IWS on PA29 mux B */
+#define MUX_PA29B_IISC_IWS              _L(1)
+#define PINMUX_PA29B_IISC_IWS      ((PIN_PA29B_IISC_IWS << 16) | MUX_PA29B_IISC_IWS)
+#define GPIO_PA29B_IISC_IWS      _UL(1 << 29)
+/* ========== GPIO definition for SPI peripheral ========== */
+#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L(1)
+#define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
+#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
+#define PIN_PB14B_SPI_MISO             _L(46) /**< \brief SPI signal: MISO on PB14 mux B */
+#define MUX_PB14B_SPI_MISO              _L(1)
+#define PINMUX_PB14B_SPI_MISO      ((PIN_PB14B_SPI_MISO << 16) | MUX_PB14B_SPI_MISO)
+#define GPIO_PB14B_SPI_MISO      _UL(1 << 14)
+#define PIN_PC28B_SPI_MISO             _L(92) /**< \brief SPI signal: MISO on PC28 mux B */
+#define MUX_PC28B_SPI_MISO              _L(1)
+#define PINMUX_PC28B_SPI_MISO      ((PIN_PC28B_SPI_MISO << 16) | MUX_PC28B_SPI_MISO)
+#define GPIO_PC28B_SPI_MISO      _UL(1 << 28)
+#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L(0)
+#define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
+#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
+#define PIN_PA27A_SPI_MISO             _L(27) /**< \brief SPI signal: MISO on PA27 mux A */
+#define MUX_PA27A_SPI_MISO              _L(0)
+#define PINMUX_PA27A_SPI_MISO      ((PIN_PA27A_SPI_MISO << 16) | MUX_PA27A_SPI_MISO)
+#define GPIO_PA27A_SPI_MISO      _UL(1 << 27)
+#define PIN_PC04A_SPI_MISO             _L(68) /**< \brief SPI signal: MISO on PC04 mux A */
+#define MUX_PC04A_SPI_MISO              _L(0)
+#define PINMUX_PC04A_SPI_MISO      ((PIN_PC04A_SPI_MISO << 16) | MUX_PC04A_SPI_MISO)
+#define GPIO_PC04A_SPI_MISO      _UL(1 <<  4)
+#define PIN_PB15B_SPI_MOSI             _L(47) /**< \brief SPI signal: MOSI on PB15 mux B */
+#define MUX_PB15B_SPI_MOSI              _L(1)
+#define PINMUX_PB15B_SPI_MOSI      ((PIN_PB15B_SPI_MOSI << 16) | MUX_PB15B_SPI_MOSI)
+#define GPIO_PB15B_SPI_MOSI      _UL(1 << 15)
+#define PIN_PC29B_SPI_MOSI             _L(93) /**< \brief SPI signal: MOSI on PC29 mux B */
+#define MUX_PC29B_SPI_MOSI              _L(1)
+#define PINMUX_PC29B_SPI_MOSI      ((PIN_PC29B_SPI_MOSI << 16) | MUX_PC29B_SPI_MOSI)
+#define GPIO_PC29B_SPI_MOSI      _UL(1 << 29)
+#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L(0)
+#define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
+#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
+#define PIN_PA28A_SPI_MOSI             _L(28) /**< \brief SPI signal: MOSI on PA28 mux A */
+#define MUX_PA28A_SPI_MOSI              _L(0)
+#define PINMUX_PA28A_SPI_MOSI      ((PIN_PA28A_SPI_MOSI << 16) | MUX_PA28A_SPI_MOSI)
+#define GPIO_PA28A_SPI_MOSI      _UL(1 << 28)
+#define PIN_PC05A_SPI_MOSI             _L(69) /**< \brief SPI signal: MOSI on PC05 mux A */
+#define MUX_PC05A_SPI_MOSI              _L(0)
+#define PINMUX_PC05A_SPI_MOSI      ((PIN_PC05A_SPI_MOSI << 16) | MUX_PC05A_SPI_MOSI)
+#define GPIO_PC05A_SPI_MOSI      _UL(1 <<  5)
+#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
+#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
+#define PIN_PC31B_SPI_NPCS0            _L(95) /**< \brief SPI signal: NPCS0 on PC31 mux B */
+#define MUX_PC31B_SPI_NPCS0             _L(1)
+#define PINMUX_PC31B_SPI_NPCS0     ((PIN_PC31B_SPI_NPCS0 << 16) | MUX_PC31B_SPI_NPCS0)
+#define GPIO_PC31B_SPI_NPCS0     _UL(1 << 31)
+#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
+#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
+#define PIN_PA30A_SPI_NPCS0            _L(30) /**< \brief SPI signal: NPCS0 on PA30 mux A */
+#define MUX_PA30A_SPI_NPCS0             _L(0)
+#define PINMUX_PA30A_SPI_NPCS0     ((PIN_PA30A_SPI_NPCS0 << 16) | MUX_PA30A_SPI_NPCS0)
+#define GPIO_PA30A_SPI_NPCS0     _UL(1 << 30)
+#define PIN_PC03A_SPI_NPCS0            _L(67) /**< \brief SPI signal: NPCS0 on PC03 mux A */
+#define MUX_PC03A_SPI_NPCS0             _L(0)
+#define PINMUX_PC03A_SPI_NPCS0     ((PIN_PC03A_SPI_NPCS0 << 16) | MUX_PC03A_SPI_NPCS0)
+#define GPIO_PC03A_SPI_NPCS0     _UL(1 <<  3)
+#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
+#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PB13B_SPI_NPCS1            _L(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
+#define MUX_PB13B_SPI_NPCS1             _L(1)
+#define PINMUX_PB13B_SPI_NPCS1     ((PIN_PB13B_SPI_NPCS1 << 16) | MUX_PB13B_SPI_NPCS1)
+#define GPIO_PB13B_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PA31A_SPI_NPCS1            _L(31) /**< \brief SPI signal: NPCS1 on PA31 mux A */
+#define MUX_PA31A_SPI_NPCS1             _L(0)
+#define PINMUX_PA31A_SPI_NPCS1     ((PIN_PA31A_SPI_NPCS1 << 16) | MUX_PA31A_SPI_NPCS1)
+#define GPIO_PA31A_SPI_NPCS1     _UL(1 << 31)
+#define PIN_PC02A_SPI_NPCS1            _L(66) /**< \brief SPI signal: NPCS1 on PC02 mux A */
+#define MUX_PC02A_SPI_NPCS1             _L(0)
+#define PINMUX_PC02A_SPI_NPCS1     ((PIN_PC02A_SPI_NPCS1 << 16) | MUX_PC02A_SPI_NPCS1)
+#define GPIO_PC02A_SPI_NPCS1     _UL(1 <<  2)
+#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
+#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
+#define PIN_PB11B_SPI_NPCS2            _L(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
+#define MUX_PB11B_SPI_NPCS2             _L(1)
+#define PINMUX_PB11B_SPI_NPCS2     ((PIN_PB11B_SPI_NPCS2 << 16) | MUX_PB11B_SPI_NPCS2)
+#define GPIO_PB11B_SPI_NPCS2     _UL(1 << 11)
+#define PIN_PC00A_SPI_NPCS2            _L(64) /**< \brief SPI signal: NPCS2 on PC00 mux A */
+#define MUX_PC00A_SPI_NPCS2             _L(0)
+#define PINMUX_PC00A_SPI_NPCS2     ((PIN_PC00A_SPI_NPCS2 << 16) | MUX_PC00A_SPI_NPCS2)
+#define GPIO_PC00A_SPI_NPCS2     _UL(1 <<  0)
+#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
+#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
+#define PIN_PB12B_SPI_NPCS3            _L(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
+#define MUX_PB12B_SPI_NPCS3             _L(1)
+#define PINMUX_PB12B_SPI_NPCS3     ((PIN_PB12B_SPI_NPCS3 << 16) | MUX_PB12B_SPI_NPCS3)
+#define GPIO_PB12B_SPI_NPCS3     _UL(1 << 12)
+#define PIN_PC01A_SPI_NPCS3            _L(65) /**< \brief SPI signal: NPCS3 on PC01 mux A */
+#define MUX_PC01A_SPI_NPCS3             _L(0)
+#define PINMUX_PC01A_SPI_NPCS3     ((PIN_PC01A_SPI_NPCS3 << 16) | MUX_PC01A_SPI_NPCS3)
+#define GPIO_PC01A_SPI_NPCS3     _UL(1 <<  1)
+#define PIN_PC30B_SPI_SCK              _L(94) /**< \brief SPI signal: SCK on PC30 mux B */
+#define MUX_PC30B_SPI_SCK               _L(1)
+#define PINMUX_PC30B_SPI_SCK       ((PIN_PC30B_SPI_SCK << 16) | MUX_PC30B_SPI_SCK)
+#define GPIO_PC30B_SPI_SCK       _UL(1 << 30)
+#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L(0)
+#define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
+#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
+#define PIN_PA29A_SPI_SCK              _L(29) /**< \brief SPI signal: SCK on PA29 mux A */
+#define MUX_PA29A_SPI_SCK               _L(0)
+#define PINMUX_PA29A_SPI_SCK       ((PIN_PA29A_SPI_SCK << 16) | MUX_PA29A_SPI_SCK)
+#define GPIO_PA29A_SPI_SCK       _UL(1 << 29)
+#define PIN_PC06A_SPI_SCK              _L(70) /**< \brief SPI signal: SCK on PC06 mux A */
+#define MUX_PC06A_SPI_SCK               _L(0)
+#define PINMUX_PC06A_SPI_SCK       ((PIN_PC06A_SPI_SCK << 16) | MUX_PC06A_SPI_SCK)
+#define GPIO_PC06A_SPI_SCK       _UL(1 <<  6)
+/* ========== GPIO definition for TC0 peripheral ========== */
+#define PIN_PB07D_TC0_A0               _L(39) /**< \brief TC0 signal: A0 on PB07 mux D */
+#define MUX_PB07D_TC0_A0                _L(3)
+#define PINMUX_PB07D_TC0_A0        ((PIN_PB07D_TC0_A0 << 16) | MUX_PB07D_TC0_A0)
+#define GPIO_PB07D_TC0_A0        _UL(1 <<  7)
+#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L(1)
+#define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
+#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
+#define PIN_PB09D_TC0_A1               _L(41) /**< \brief TC0 signal: A1 on PB09 mux D */
+#define MUX_PB09D_TC0_A1                _L(3)
+#define PINMUX_PB09D_TC0_A1        ((PIN_PB09D_TC0_A1 << 16) | MUX_PB09D_TC0_A1)
+#define GPIO_PB09D_TC0_A1        _UL(1 <<  9)
+#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L(1)
+#define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
+#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
+#define PIN_PB11D_TC0_A2               _L(43) /**< \brief TC0 signal: A2 on PB11 mux D */
+#define MUX_PB11D_TC0_A2                _L(3)
+#define PINMUX_PB11D_TC0_A2        ((PIN_PB11D_TC0_A2 << 16) | MUX_PB11D_TC0_A2)
+#define GPIO_PB11D_TC0_A2        _UL(1 << 11)
+#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L(1)
+#define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
+#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
+#define PIN_PB08D_TC0_B0               _L(40) /**< \brief TC0 signal: B0 on PB08 mux D */
+#define MUX_PB08D_TC0_B0                _L(3)
+#define PINMUX_PB08D_TC0_B0        ((PIN_PB08D_TC0_B0 << 16) | MUX_PB08D_TC0_B0)
+#define GPIO_PB08D_TC0_B0        _UL(1 <<  8)
+#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L(1)
+#define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
+#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
+#define PIN_PB10D_TC0_B1               _L(42) /**< \brief TC0 signal: B1 on PB10 mux D */
+#define MUX_PB10D_TC0_B1                _L(3)
+#define PINMUX_PB10D_TC0_B1        ((PIN_PB10D_TC0_B1 << 16) | MUX_PB10D_TC0_B1)
+#define GPIO_PB10D_TC0_B1        _UL(1 << 10)
+#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L(1)
+#define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
+#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
+#define PIN_PB12D_TC0_B2               _L(44) /**< \brief TC0 signal: B2 on PB12 mux D */
+#define MUX_PB12D_TC0_B2                _L(3)
+#define PINMUX_PB12D_TC0_B2        ((PIN_PB12D_TC0_B2 << 16) | MUX_PB12D_TC0_B2)
+#define GPIO_PB12D_TC0_B2        _UL(1 << 12)
+#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L(1)
+#define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
+#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
+#define PIN_PB13D_TC0_CLK0             _L(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
+#define MUX_PB13D_TC0_CLK0              _L(3)
+#define PINMUX_PB13D_TC0_CLK0      ((PIN_PB13D_TC0_CLK0 << 16) | MUX_PB13D_TC0_CLK0)
+#define GPIO_PB13D_TC0_CLK0      _UL(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L(1)
+#define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
+#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
+#define PIN_PB14D_TC0_CLK1             _L(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
+#define MUX_PB14D_TC0_CLK1              _L(3)
+#define PINMUX_PB14D_TC0_CLK1      ((PIN_PB14D_TC0_CLK1 << 16) | MUX_PB14D_TC0_CLK1)
+#define GPIO_PB14D_TC0_CLK1      _UL(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L(1)
+#define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
+#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
+#define PIN_PB15D_TC0_CLK2             _L(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
+#define MUX_PB15D_TC0_CLK2              _L(3)
+#define PINMUX_PB15D_TC0_CLK2      ((PIN_PB15D_TC0_CLK2 << 16) | MUX_PB15D_TC0_CLK2)
+#define GPIO_PB15D_TC0_CLK2      _UL(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L(1)
+#define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
+#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+/* ========== GPIO definition for TC1 peripheral ========== */
+#define PIN_PC00D_TC1_A0               _L(64) /**< \brief TC1 signal: A0 on PC00 mux D */
+#define MUX_PC00D_TC1_A0                _L(3)
+#define PINMUX_PC00D_TC1_A0        ((PIN_PC00D_TC1_A0 << 16) | MUX_PC00D_TC1_A0)
+#define GPIO_PC00D_TC1_A0        _UL(1 <<  0)
+#define PIN_PC15A_TC1_A0               _L(79) /**< \brief TC1 signal: A0 on PC15 mux A */
+#define MUX_PC15A_TC1_A0                _L(0)
+#define PINMUX_PC15A_TC1_A0        ((PIN_PC15A_TC1_A0 << 16) | MUX_PC15A_TC1_A0)
+#define GPIO_PC15A_TC1_A0        _UL(1 << 15)
+#define PIN_PC02D_TC1_A1               _L(66) /**< \brief TC1 signal: A1 on PC02 mux D */
+#define MUX_PC02D_TC1_A1                _L(3)
+#define PINMUX_PC02D_TC1_A1        ((PIN_PC02D_TC1_A1 << 16) | MUX_PC02D_TC1_A1)
+#define GPIO_PC02D_TC1_A1        _UL(1 <<  2)
+#define PIN_PC17A_TC1_A1               _L(81) /**< \brief TC1 signal: A1 on PC17 mux A */
+#define MUX_PC17A_TC1_A1                _L(0)
+#define PINMUX_PC17A_TC1_A1        ((PIN_PC17A_TC1_A1 << 16) | MUX_PC17A_TC1_A1)
+#define GPIO_PC17A_TC1_A1        _UL(1 << 17)
+#define PIN_PC04D_TC1_A2               _L(68) /**< \brief TC1 signal: A2 on PC04 mux D */
+#define MUX_PC04D_TC1_A2                _L(3)
+#define PINMUX_PC04D_TC1_A2        ((PIN_PC04D_TC1_A2 << 16) | MUX_PC04D_TC1_A2)
+#define GPIO_PC04D_TC1_A2        _UL(1 <<  4)
+#define PIN_PC19A_TC1_A2               _L(83) /**< \brief TC1 signal: A2 on PC19 mux A */
+#define MUX_PC19A_TC1_A2                _L(0)
+#define PINMUX_PC19A_TC1_A2        ((PIN_PC19A_TC1_A2 << 16) | MUX_PC19A_TC1_A2)
+#define GPIO_PC19A_TC1_A2        _UL(1 << 19)
+#define PIN_PC01D_TC1_B0               _L(65) /**< \brief TC1 signal: B0 on PC01 mux D */
+#define MUX_PC01D_TC1_B0                _L(3)
+#define PINMUX_PC01D_TC1_B0        ((PIN_PC01D_TC1_B0 << 16) | MUX_PC01D_TC1_B0)
+#define GPIO_PC01D_TC1_B0        _UL(1 <<  1)
+#define PIN_PC16A_TC1_B0               _L(80) /**< \brief TC1 signal: B0 on PC16 mux A */
+#define MUX_PC16A_TC1_B0                _L(0)
+#define PINMUX_PC16A_TC1_B0        ((PIN_PC16A_TC1_B0 << 16) | MUX_PC16A_TC1_B0)
+#define GPIO_PC16A_TC1_B0        _UL(1 << 16)
+#define PIN_PC03D_TC1_B1               _L(67) /**< \brief TC1 signal: B1 on PC03 mux D */
+#define MUX_PC03D_TC1_B1                _L(3)
+#define PINMUX_PC03D_TC1_B1        ((PIN_PC03D_TC1_B1 << 16) | MUX_PC03D_TC1_B1)
+#define GPIO_PC03D_TC1_B1        _UL(1 <<  3)
+#define PIN_PC18A_TC1_B1               _L(82) /**< \brief TC1 signal: B1 on PC18 mux A */
+#define MUX_PC18A_TC1_B1                _L(0)
+#define PINMUX_PC18A_TC1_B1        ((PIN_PC18A_TC1_B1 << 16) | MUX_PC18A_TC1_B1)
+#define GPIO_PC18A_TC1_B1        _UL(1 << 18)
+#define PIN_PC05D_TC1_B2               _L(69) /**< \brief TC1 signal: B2 on PC05 mux D */
+#define MUX_PC05D_TC1_B2                _L(3)
+#define PINMUX_PC05D_TC1_B2        ((PIN_PC05D_TC1_B2 << 16) | MUX_PC05D_TC1_B2)
+#define GPIO_PC05D_TC1_B2        _UL(1 <<  5)
+#define PIN_PC20A_TC1_B2               _L(84) /**< \brief TC1 signal: B2 on PC20 mux A */
+#define MUX_PC20A_TC1_B2                _L(0)
+#define PINMUX_PC20A_TC1_B2        ((PIN_PC20A_TC1_B2 << 16) | MUX_PC20A_TC1_B2)
+#define GPIO_PC20A_TC1_B2        _UL(1 << 20)
+#define PIN_PC06D_TC1_CLK0             _L(70) /**< \brief TC1 signal: CLK0 on PC06 mux D */
+#define MUX_PC06D_TC1_CLK0              _L(3)
+#define PINMUX_PC06D_TC1_CLK0      ((PIN_PC06D_TC1_CLK0 << 16) | MUX_PC06D_TC1_CLK0)
+#define GPIO_PC06D_TC1_CLK0      _UL(1 <<  6)
+#define PIN_PC21A_TC1_CLK0             _L(85) /**< \brief TC1 signal: CLK0 on PC21 mux A */
+#define MUX_PC21A_TC1_CLK0              _L(0)
+#define PINMUX_PC21A_TC1_CLK0      ((PIN_PC21A_TC1_CLK0 << 16) | MUX_PC21A_TC1_CLK0)
+#define GPIO_PC21A_TC1_CLK0      _UL(1 << 21)
+#define PIN_PC07D_TC1_CLK1             _L(71) /**< \brief TC1 signal: CLK1 on PC07 mux D */
+#define MUX_PC07D_TC1_CLK1              _L(3)
+#define PINMUX_PC07D_TC1_CLK1      ((PIN_PC07D_TC1_CLK1 << 16) | MUX_PC07D_TC1_CLK1)
+#define GPIO_PC07D_TC1_CLK1      _UL(1 <<  7)
+#define PIN_PC22A_TC1_CLK1             _L(86) /**< \brief TC1 signal: CLK1 on PC22 mux A */
+#define MUX_PC22A_TC1_CLK1              _L(0)
+#define PINMUX_PC22A_TC1_CLK1      ((PIN_PC22A_TC1_CLK1 << 16) | MUX_PC22A_TC1_CLK1)
+#define GPIO_PC22A_TC1_CLK1      _UL(1 << 22)
+#define PIN_PC08D_TC1_CLK2             _L(72) /**< \brief TC1 signal: CLK2 on PC08 mux D */
+#define MUX_PC08D_TC1_CLK2              _L(3)
+#define PINMUX_PC08D_TC1_CLK2      ((PIN_PC08D_TC1_CLK2 << 16) | MUX_PC08D_TC1_CLK2)
+#define GPIO_PC08D_TC1_CLK2      _UL(1 <<  8)
+#define PIN_PC23A_TC1_CLK2             _L(87) /**< \brief TC1 signal: CLK2 on PC23 mux A */
+#define MUX_PC23A_TC1_CLK2              _L(0)
+#define PINMUX_PC23A_TC1_CLK2      ((PIN_PC23A_TC1_CLK2 << 16) | MUX_PC23A_TC1_CLK2)
+#define GPIO_PC23A_TC1_CLK2      _UL(1 << 23)
+/* ========== GPIO definition for USART0 peripheral ========== */
+#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L(1)
+#define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
+#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
+#define PIN_PC00B_USART0_CLK           _L(64) /**< \brief USART0 signal: CLK on PC00 mux B */
+#define MUX_PC00B_USART0_CLK            _L(1)
+#define PINMUX_PC00B_USART0_CLK    ((PIN_PC00B_USART0_CLK << 16) | MUX_PC00B_USART0_CLK)
+#define GPIO_PC00B_USART0_CLK    _UL(1 <<  0)
+#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L(0)
+#define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
+#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
+#define PIN_PB13A_USART0_CLK           _L(45) /**< \brief USART0 signal: CLK on PB13 mux A */
+#define MUX_PB13A_USART0_CLK            _L(0)
+#define PINMUX_PB13A_USART0_CLK    ((PIN_PB13A_USART0_CLK << 16) | MUX_PB13A_USART0_CLK)
+#define GPIO_PB13A_USART0_CLK    _UL(1 << 13)
+#define PIN_PC02B_USART0_CTS           _L(66) /**< \brief USART0 signal: CTS on PC02 mux B */
+#define MUX_PC02B_USART0_CTS            _L(1)
+#define PINMUX_PC02B_USART0_CTS    ((PIN_PC02B_USART0_CTS << 16) | MUX_PC02B_USART0_CTS)
+#define GPIO_PC02B_USART0_CTS    _UL(1 <<  2)
+#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L(0)
+#define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
+#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
+#define PIN_PB11A_USART0_CTS           _L(43) /**< \brief USART0 signal: CTS on PB11 mux A */
+#define MUX_PB11A_USART0_CTS            _L(0)
+#define PINMUX_PB11A_USART0_CTS    ((PIN_PB11A_USART0_CTS << 16) | MUX_PB11A_USART0_CTS)
+#define GPIO_PB11A_USART0_CTS    _UL(1 << 11)
+#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L(1)
+#define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
+#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
+#define PIN_PC01B_USART0_RTS           _L(65) /**< \brief USART0 signal: RTS on PC01 mux B */
+#define MUX_PC01B_USART0_RTS            _L(1)
+#define PINMUX_PC01B_USART0_RTS    ((PIN_PC01B_USART0_RTS << 16) | MUX_PC01B_USART0_RTS)
+#define GPIO_PC01B_USART0_RTS    _UL(1 <<  1)
+#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L(0)
+#define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
+#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
+#define PIN_PB12A_USART0_RTS           _L(44) /**< \brief USART0 signal: RTS on PB12 mux A */
+#define MUX_PB12A_USART0_RTS            _L(0)
+#define PINMUX_PB12A_USART0_RTS    ((PIN_PB12A_USART0_RTS << 16) | MUX_PB12A_USART0_RTS)
+#define GPIO_PB12A_USART0_RTS    _UL(1 << 12)
+#define PIN_PC02C_USART0_RXD           _L(66) /**< \brief USART0 signal: RXD on PC02 mux C */
+#define MUX_PC02C_USART0_RXD            _L(2)
+#define PINMUX_PC02C_USART0_RXD    ((PIN_PC02C_USART0_RXD << 16) | MUX_PC02C_USART0_RXD)
+#define GPIO_PC02C_USART0_RXD    _UL(1 <<  2)
+#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L(1)
+#define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
+#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
+#define PIN_PB00B_USART0_RXD           _L(32) /**< \brief USART0 signal: RXD on PB00 mux B */
+#define MUX_PB00B_USART0_RXD            _L(1)
+#define PINMUX_PB00B_USART0_RXD    ((PIN_PB00B_USART0_RXD << 16) | MUX_PB00B_USART0_RXD)
+#define GPIO_PB00B_USART0_RXD    _UL(1 <<  0)
+#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L(0)
+#define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
+#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
+#define PIN_PB14A_USART0_RXD           _L(46) /**< \brief USART0 signal: RXD on PB14 mux A */
+#define MUX_PB14A_USART0_RXD            _L(0)
+#define PINMUX_PB14A_USART0_RXD    ((PIN_PB14A_USART0_RXD << 16) | MUX_PB14A_USART0_RXD)
+#define GPIO_PB14A_USART0_RXD    _UL(1 << 14)
+#define PIN_PC03C_USART0_TXD           _L(67) /**< \brief USART0 signal: TXD on PC03 mux C */
+#define MUX_PC03C_USART0_TXD            _L(2)
+#define PINMUX_PC03C_USART0_TXD    ((PIN_PC03C_USART0_TXD << 16) | MUX_PC03C_USART0_TXD)
+#define GPIO_PC03C_USART0_TXD    _UL(1 <<  3)
+#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L(1)
+#define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
+#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
+#define PIN_PB01B_USART0_TXD           _L(33) /**< \brief USART0 signal: TXD on PB01 mux B */
+#define MUX_PB01B_USART0_TXD            _L(1)
+#define PINMUX_PB01B_USART0_TXD    ((PIN_PB01B_USART0_TXD << 16) | MUX_PB01B_USART0_TXD)
+#define GPIO_PB01B_USART0_TXD    _UL(1 <<  1)
+#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L(0)
+#define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
+#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
+#define PIN_PB15A_USART0_TXD           _L(47) /**< \brief USART0 signal: TXD on PB15 mux A */
+#define MUX_PB15A_USART0_TXD            _L(0)
+#define PINMUX_PB15A_USART0_TXD    ((PIN_PB15A_USART0_TXD << 16) | MUX_PB15A_USART0_TXD)
+#define GPIO_PB15A_USART0_TXD    _UL(1 << 15)
+/* ========== GPIO definition for USART1 peripheral ========== */
+#define PIN_PB03B_USART1_CLK           _L(35) /**< \brief USART1 signal: CLK on PB03 mux B */
+#define MUX_PB03B_USART1_CLK            _L(1)
+#define PINMUX_PB03B_USART1_CLK    ((PIN_PB03B_USART1_CLK << 16) | MUX_PB03B_USART1_CLK)
+#define GPIO_PB03B_USART1_CLK    _UL(1 <<  3)
+#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L(0)
+#define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
+#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
+#define PIN_PC25A_USART1_CLK           _L(89) /**< \brief USART1 signal: CLK on PC25 mux A */
+#define MUX_PC25A_USART1_CLK            _L(0)
+#define PINMUX_PC25A_USART1_CLK    ((PIN_PC25A_USART1_CLK << 16) | MUX_PC25A_USART1_CLK)
+#define GPIO_PC25A_USART1_CLK    _UL(1 << 25)
+#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L(1)
+#define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
+#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
+#define PIN_PB02B_USART1_RTS           _L(34) /**< \brief USART1 signal: RTS on PB02 mux B */
+#define MUX_PB02B_USART1_RTS            _L(1)
+#define PINMUX_PB02B_USART1_RTS    ((PIN_PB02B_USART1_RTS << 16) | MUX_PB02B_USART1_RTS)
+#define GPIO_PB02B_USART1_RTS    _UL(1 <<  2)
+#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L(0)
+#define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
+#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
+#define PIN_PC24A_USART1_RTS           _L(88) /**< \brief USART1 signal: RTS on PC24 mux A */
+#define MUX_PC24A_USART1_RTS            _L(0)
+#define PINMUX_PC24A_USART1_RTS    ((PIN_PC24A_USART1_RTS << 16) | MUX_PC24A_USART1_RTS)
+#define GPIO_PC24A_USART1_RTS    _UL(1 << 24)
+#define PIN_PB04B_USART1_RXD           _L(36) /**< \brief USART1 signal: RXD on PB04 mux B */
+#define MUX_PB04B_USART1_RXD            _L(1)
+#define PINMUX_PB04B_USART1_RXD    ((PIN_PB04B_USART1_RXD << 16) | MUX_PB04B_USART1_RXD)
+#define GPIO_PB04B_USART1_RXD    _UL(1 <<  4)
+#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L(0)
+#define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
+#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
+#define PIN_PC26A_USART1_RXD           _L(90) /**< \brief USART1 signal: RXD on PC26 mux A */
+#define MUX_PC26A_USART1_RXD            _L(0)
+#define PINMUX_PC26A_USART1_RXD    ((PIN_PC26A_USART1_RXD << 16) | MUX_PC26A_USART1_RXD)
+#define GPIO_PC26A_USART1_RXD    _UL(1 << 26)
+#define PIN_PB05B_USART1_TXD           _L(37) /**< \brief USART1 signal: TXD on PB05 mux B */
+#define MUX_PB05B_USART1_TXD            _L(1)
+#define PINMUX_PB05B_USART1_TXD    ((PIN_PB05B_USART1_TXD << 16) | MUX_PB05B_USART1_TXD)
+#define GPIO_PB05B_USART1_TXD    _UL(1 <<  5)
+#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L(0)
+#define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
+#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+#define PIN_PC27A_USART1_TXD           _L(91) /**< \brief USART1 signal: TXD on PC27 mux A */
+#define MUX_PC27A_USART1_TXD            _L(0)
+#define PINMUX_PC27A_USART1_TXD    ((PIN_PC27A_USART1_TXD << 16) | MUX_PC27A_USART1_TXD)
+#define GPIO_PC27A_USART1_TXD    _UL(1 << 27)
+/* ========== GPIO definition for USART2 peripheral ========== */
+#define PIN_PC08B_USART2_CLK           _L(72) /**< \brief USART2 signal: CLK on PC08 mux B */
+#define MUX_PC08B_USART2_CLK            _L(1)
+#define PINMUX_PC08B_USART2_CLK    ((PIN_PC08B_USART2_CLK << 16) | MUX_PC08B_USART2_CLK)
+#define GPIO_PC08B_USART2_CLK    _UL(1 <<  8)
+#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L(0)
+#define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
+#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
+#define PIN_PC08E_USART2_CTS           _L(72) /**< \brief USART2 signal: CTS on PC08 mux E */
+#define MUX_PC08E_USART2_CTS            _L(4)
+#define PINMUX_PC08E_USART2_CTS    ((PIN_PC08E_USART2_CTS << 16) | MUX_PC08E_USART2_CTS)
+#define GPIO_PC08E_USART2_CTS    _UL(1 <<  8)
+#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L(1)
+#define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
+#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
+#define PIN_PC07B_USART2_RTS           _L(71) /**< \brief USART2 signal: RTS on PC07 mux B */
+#define MUX_PC07B_USART2_RTS            _L(1)
+#define PINMUX_PC07B_USART2_RTS    ((PIN_PC07B_USART2_RTS << 16) | MUX_PC07B_USART2_RTS)
+#define GPIO_PC07B_USART2_RTS    _UL(1 <<  7)
+#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L(0)
+#define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
+#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L(1)
+#define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
+#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
+#define PIN_PC11B_USART2_RXD           _L(75) /**< \brief USART2 signal: RXD on PC11 mux B */
+#define MUX_PC11B_USART2_RXD            _L(1)
+#define PINMUX_PC11B_USART2_RXD    ((PIN_PC11B_USART2_RXD << 16) | MUX_PC11B_USART2_RXD)
+#define GPIO_PC11B_USART2_RXD    _UL(1 << 11)
+#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L(0)
+#define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
+#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L(1)
+#define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
+#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
+#define PIN_PC12B_USART2_TXD           _L(76) /**< \brief USART2 signal: TXD on PC12 mux B */
+#define MUX_PC12B_USART2_TXD            _L(1)
+#define PINMUX_PC12B_USART2_TXD    ((PIN_PC12B_USART2_TXD << 16) | MUX_PC12B_USART2_TXD)
+#define GPIO_PC12B_USART2_TXD    _UL(1 << 12)
+#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L(0)
+#define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
+#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+/* ========== GPIO definition for USART3 peripheral ========== */
+#define PIN_PA29E_USART3_CLK           _L(29) /**< \brief USART3 signal: CLK on PA29 mux E */
+#define MUX_PA29E_USART3_CLK            _L(4)
+#define PINMUX_PA29E_USART3_CLK    ((PIN_PA29E_USART3_CLK << 16) | MUX_PA29E_USART3_CLK)
+#define GPIO_PA29E_USART3_CLK    _UL(1 << 29)
+#define PIN_PC14B_USART3_CLK           _L(78) /**< \brief USART3 signal: CLK on PC14 mux B */
+#define MUX_PC14B_USART3_CLK            _L(1)
+#define PINMUX_PC14B_USART3_CLK    ((PIN_PC14B_USART3_CLK << 16) | MUX_PC14B_USART3_CLK)
+#define GPIO_PC14B_USART3_CLK    _UL(1 << 14)
+#define PIN_PB08A_USART3_CLK           _L(40) /**< \brief USART3 signal: CLK on PB08 mux A */
+#define MUX_PB08A_USART3_CLK            _L(0)
+#define PINMUX_PB08A_USART3_CLK    ((PIN_PB08A_USART3_CLK << 16) | MUX_PB08A_USART3_CLK)
+#define GPIO_PB08A_USART3_CLK    _UL(1 <<  8)
+#define PIN_PC31A_USART3_CLK           _L(95) /**< \brief USART3 signal: CLK on PC31 mux A */
+#define MUX_PC31A_USART3_CLK            _L(0)
+#define PINMUX_PC31A_USART3_CLK    ((PIN_PC31A_USART3_CLK << 16) | MUX_PC31A_USART3_CLK)
+#define GPIO_PC31A_USART3_CLK    _UL(1 << 31)
+#define PIN_PA28E_USART3_CTS           _L(28) /**< \brief USART3 signal: CTS on PA28 mux E */
+#define MUX_PA28E_USART3_CTS            _L(4)
+#define PINMUX_PA28E_USART3_CTS    ((PIN_PA28E_USART3_CTS << 16) | MUX_PA28E_USART3_CTS)
+#define GPIO_PA28E_USART3_CTS    _UL(1 << 28)
+#define PIN_PB07A_USART3_CTS           _L(39) /**< \brief USART3 signal: CTS on PB07 mux A */
+#define MUX_PB07A_USART3_CTS            _L(0)
+#define PINMUX_PB07A_USART3_CTS    ((PIN_PB07A_USART3_CTS << 16) | MUX_PB07A_USART3_CTS)
+#define GPIO_PB07A_USART3_CTS    _UL(1 <<  7)
+#define PIN_PA27E_USART3_RTS           _L(27) /**< \brief USART3 signal: RTS on PA27 mux E */
+#define MUX_PA27E_USART3_RTS            _L(4)
+#define PINMUX_PA27E_USART3_RTS    ((PIN_PA27E_USART3_RTS << 16) | MUX_PA27E_USART3_RTS)
+#define GPIO_PA27E_USART3_RTS    _UL(1 << 27)
+#define PIN_PC13B_USART3_RTS           _L(77) /**< \brief USART3 signal: RTS on PC13 mux B */
+#define MUX_PC13B_USART3_RTS            _L(1)
+#define PINMUX_PC13B_USART3_RTS    ((PIN_PC13B_USART3_RTS << 16) | MUX_PC13B_USART3_RTS)
+#define GPIO_PC13B_USART3_RTS    _UL(1 << 13)
+#define PIN_PB06A_USART3_RTS           _L(38) /**< \brief USART3 signal: RTS on PB06 mux A */
+#define MUX_PB06A_USART3_RTS            _L(0)
+#define PINMUX_PB06A_USART3_RTS    ((PIN_PB06A_USART3_RTS << 16) | MUX_PB06A_USART3_RTS)
+#define GPIO_PB06A_USART3_RTS    _UL(1 <<  6)
+#define PIN_PC30A_USART3_RTS           _L(94) /**< \brief USART3 signal: RTS on PC30 mux A */
+#define MUX_PC30A_USART3_RTS            _L(0)
+#define PINMUX_PC30A_USART3_RTS    ((PIN_PC30A_USART3_RTS << 16) | MUX_PC30A_USART3_RTS)
+#define GPIO_PC30A_USART3_RTS    _UL(1 << 30)
+#define PIN_PA30E_USART3_RXD           _L(30) /**< \brief USART3 signal: RXD on PA30 mux E */
+#define MUX_PA30E_USART3_RXD            _L(4)
+#define PINMUX_PA30E_USART3_RXD    ((PIN_PA30E_USART3_RXD << 16) | MUX_PA30E_USART3_RXD)
+#define GPIO_PA30E_USART3_RXD    _UL(1 << 30)
+#define PIN_PC09B_USART3_RXD           _L(73) /**< \brief USART3 signal: RXD on PC09 mux B */
+#define MUX_PC09B_USART3_RXD            _L(1)
+#define PINMUX_PC09B_USART3_RXD    ((PIN_PC09B_USART3_RXD << 16) | MUX_PC09B_USART3_RXD)
+#define GPIO_PC09B_USART3_RXD    _UL(1 <<  9)
+#define PIN_PB09A_USART3_RXD           _L(41) /**< \brief USART3 signal: RXD on PB09 mux A */
+#define MUX_PB09A_USART3_RXD            _L(0)
+#define PINMUX_PB09A_USART3_RXD    ((PIN_PB09A_USART3_RXD << 16) | MUX_PB09A_USART3_RXD)
+#define GPIO_PB09A_USART3_RXD    _UL(1 <<  9)
+#define PIN_PC28A_USART3_RXD           _L(92) /**< \brief USART3 signal: RXD on PC28 mux A */
+#define MUX_PC28A_USART3_RXD            _L(0)
+#define PINMUX_PC28A_USART3_RXD    ((PIN_PC28A_USART3_RXD << 16) | MUX_PC28A_USART3_RXD)
+#define GPIO_PC28A_USART3_RXD    _UL(1 << 28)
+#define PIN_PA31E_USART3_TXD           _L(31) /**< \brief USART3 signal: TXD on PA31 mux E */
+#define MUX_PA31E_USART3_TXD            _L(4)
+#define PINMUX_PA31E_USART3_TXD    ((PIN_PA31E_USART3_TXD << 16) | MUX_PA31E_USART3_TXD)
+#define GPIO_PA31E_USART3_TXD    _UL(1 << 31)
+#define PIN_PC10B_USART3_TXD           _L(74) /**< \brief USART3 signal: TXD on PC10 mux B */
+#define MUX_PC10B_USART3_TXD            _L(1)
+#define PINMUX_PC10B_USART3_TXD    ((PIN_PC10B_USART3_TXD << 16) | MUX_PC10B_USART3_TXD)
+#define GPIO_PC10B_USART3_TXD    _UL(1 << 10)
+#define PIN_PB10A_USART3_TXD           _L(42) /**< \brief USART3 signal: TXD on PB10 mux A */
+#define MUX_PB10A_USART3_TXD            _L(0)
+#define PINMUX_PB10A_USART3_TXD    ((PIN_PB10A_USART3_TXD << 16) | MUX_PB10A_USART3_TXD)
+#define GPIO_PB10A_USART3_TXD    _UL(1 << 10)
+#define PIN_PC29A_USART3_TXD           _L(93) /**< \brief USART3 signal: TXD on PC29 mux A */
+#define MUX_PC29A_USART3_TXD            _L(0)
+#define PINMUX_PC29A_USART3_TXD    ((PIN_PC29A_USART3_TXD << 16) | MUX_PC29A_USART3_TXD)
+#define GPIO_PC29A_USART3_TXD    _UL(1 << 29)
+/* ========== GPIO definition for ADCIFE peripheral ========== */
+#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
+#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
+#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
+#define PIN_PB02A_ADCIFE_AD3           _L(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
+#define MUX_PB02A_ADCIFE_AD3            _L(0)
+#define PINMUX_PB02A_ADCIFE_AD3    ((PIN_PB02A_ADCIFE_AD3 << 16) | MUX_PB02A_ADCIFE_AD3)
+#define GPIO_PB02A_ADCIFE_AD3    _UL(1 <<  2)
+#define PIN_PB03A_ADCIFE_AD4           _L(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
+#define MUX_PB03A_ADCIFE_AD4            _L(0)
+#define PINMUX_PB03A_ADCIFE_AD4    ((PIN_PB03A_ADCIFE_AD4 << 16) | MUX_PB03A_ADCIFE_AD4)
+#define GPIO_PB03A_ADCIFE_AD4    _UL(1 <<  3)
+#define PIN_PB04A_ADCIFE_AD5           _L(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
+#define MUX_PB04A_ADCIFE_AD5            _L(0)
+#define PINMUX_PB04A_ADCIFE_AD5    ((PIN_PB04A_ADCIFE_AD5 << 16) | MUX_PB04A_ADCIFE_AD5)
+#define GPIO_PB04A_ADCIFE_AD5    _UL(1 <<  4)
+#define PIN_PB05A_ADCIFE_AD6           _L(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
+#define MUX_PB05A_ADCIFE_AD6            _L(0)
+#define PINMUX_PB05A_ADCIFE_AD6    ((PIN_PB05A_ADCIFE_AD6 << 16) | MUX_PB05A_ADCIFE_AD6)
+#define GPIO_PB05A_ADCIFE_AD6    _UL(1 <<  5)
+#define PIN_PC07A_ADCIFE_AD7           _L(71) /**< \brief ADCIFE signal: AD7 on PC07 mux A */
+#define MUX_PC07A_ADCIFE_AD7            _L(0)
+#define PINMUX_PC07A_ADCIFE_AD7    ((PIN_PC07A_ADCIFE_AD7 << 16) | MUX_PC07A_ADCIFE_AD7)
+#define GPIO_PC07A_ADCIFE_AD7    _UL(1 <<  7)
+#define PIN_PC08A_ADCIFE_AD8           _L(72) /**< \brief ADCIFE signal: AD8 on PC08 mux A */
+#define MUX_PC08A_ADCIFE_AD8            _L(0)
+#define PINMUX_PC08A_ADCIFE_AD8    ((PIN_PC08A_ADCIFE_AD8 << 16) | MUX_PC08A_ADCIFE_AD8)
+#define GPIO_PC08A_ADCIFE_AD8    _UL(1 <<  8)
+#define PIN_PC09A_ADCIFE_AD9           _L(73) /**< \brief ADCIFE signal: AD9 on PC09 mux A */
+#define MUX_PC09A_ADCIFE_AD9            _L(0)
+#define PINMUX_PC09A_ADCIFE_AD9    ((PIN_PC09A_ADCIFE_AD9 << 16) | MUX_PC09A_ADCIFE_AD9)
+#define GPIO_PC09A_ADCIFE_AD9    _UL(1 <<  9)
+#define PIN_PC10A_ADCIFE_AD10          _L(74) /**< \brief ADCIFE signal: AD10 on PC10 mux A */
+#define MUX_PC10A_ADCIFE_AD10           _L(0)
+#define PINMUX_PC10A_ADCIFE_AD10   ((PIN_PC10A_ADCIFE_AD10 << 16) | MUX_PC10A_ADCIFE_AD10)
+#define GPIO_PC10A_ADCIFE_AD10   _UL(1 << 10)
+#define PIN_PC11A_ADCIFE_AD11          _L(75) /**< \brief ADCIFE signal: AD11 on PC11 mux A */
+#define MUX_PC11A_ADCIFE_AD11           _L(0)
+#define PINMUX_PC11A_ADCIFE_AD11   ((PIN_PC11A_ADCIFE_AD11 << 16) | MUX_PC11A_ADCIFE_AD11)
+#define GPIO_PC11A_ADCIFE_AD11   _UL(1 << 11)
+#define PIN_PC12A_ADCIFE_AD12          _L(76) /**< \brief ADCIFE signal: AD12 on PC12 mux A */
+#define MUX_PC12A_ADCIFE_AD12           _L(0)
+#define PINMUX_PC12A_ADCIFE_AD12   ((PIN_PC12A_ADCIFE_AD12 << 16) | MUX_PC12A_ADCIFE_AD12)
+#define GPIO_PC12A_ADCIFE_AD12   _UL(1 << 12)
+#define PIN_PC13A_ADCIFE_AD13          _L(77) /**< \brief ADCIFE signal: AD13 on PC13 mux A */
+#define MUX_PC13A_ADCIFE_AD13           _L(0)
+#define PINMUX_PC13A_ADCIFE_AD13   ((PIN_PC13A_ADCIFE_AD13 << 16) | MUX_PC13A_ADCIFE_AD13)
+#define GPIO_PC13A_ADCIFE_AD13   _UL(1 << 13)
+#define PIN_PC14A_ADCIFE_AD14          _L(78) /**< \brief ADCIFE signal: AD14 on PC14 mux A */
+#define MUX_PC14A_ADCIFE_AD14           _L(0)
+#define PINMUX_PC14A_ADCIFE_AD14   ((PIN_PC14A_ADCIFE_AD14 << 16) | MUX_PC14A_ADCIFE_AD14)
+#define GPIO_PC14A_ADCIFE_AD14   _UL(1 << 14)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+/* ========== GPIO definition for DACC peripheral ========== */
+#define PIN_PB04E_DACC_EXT_TRIG0       _L(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
+#define MUX_PB04E_DACC_EXT_TRIG0        _L(4)
+#define PINMUX_PB04E_DACC_EXT_TRIG0  ((PIN_PB04E_DACC_EXT_TRIG0 << 16) | MUX_PB04E_DACC_EXT_TRIG0)
+#define GPIO_PB04E_DACC_EXT_TRIG0  _UL(1 <<  4)
+#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L(0)
+#define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
+#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+/* ========== GPIO definition for ACIFC peripheral ========== */
+#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
+#define PIN_PC09E_ACIFC_ACAN1          _L(73) /**< \brief ACIFC signal: ACAN1 on PC09 mux E */
+#define MUX_PC09E_ACIFC_ACAN1           _L(4)
+#define PINMUX_PC09E_ACIFC_ACAN1   ((PIN_PC09E_ACIFC_ACAN1 << 16) | MUX_PC09E_ACIFC_ACAN1)
+#define GPIO_PC09E_ACIFC_ACAN1   _UL(1 <<  9)
+#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
+#define PIN_PC10E_ACIFC_ACAP1          _L(74) /**< \brief ACIFC signal: ACAP1 on PC10 mux E */
+#define MUX_PC10E_ACIFC_ACAP1           _L(4)
+#define PINMUX_PC10E_ACIFC_ACAP1   ((PIN_PC10E_ACIFC_ACAP1 << 16) | MUX_PC10E_ACIFC_ACAP1)
+#define GPIO_PC10E_ACIFC_ACAP1   _UL(1 << 10)
+#define PIN_PB02E_ACIFC_ACBN0          _L(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
+#define MUX_PB02E_ACIFC_ACBN0           _L(4)
+#define PINMUX_PB02E_ACIFC_ACBN0   ((PIN_PB02E_ACIFC_ACBN0 << 16) | MUX_PB02E_ACIFC_ACBN0)
+#define GPIO_PB02E_ACIFC_ACBN0   _UL(1 <<  2)
+#define PIN_PC13E_ACIFC_ACBN1          _L(77) /**< \brief ACIFC signal: ACBN1 on PC13 mux E */
+#define MUX_PC13E_ACIFC_ACBN1           _L(4)
+#define PINMUX_PC13E_ACIFC_ACBN1   ((PIN_PC13E_ACIFC_ACBN1 << 16) | MUX_PC13E_ACIFC_ACBN1)
+#define GPIO_PC13E_ACIFC_ACBN1   _UL(1 << 13)
+#define PIN_PB03E_ACIFC_ACBP0          _L(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
+#define MUX_PB03E_ACIFC_ACBP0           _L(4)
+#define PINMUX_PB03E_ACIFC_ACBP0   ((PIN_PB03E_ACIFC_ACBP0 << 16) | MUX_PB03E_ACIFC_ACBP0)
+#define GPIO_PB03E_ACIFC_ACBP0   _UL(1 <<  3)
+#define PIN_PC14E_ACIFC_ACBP1          _L(78) /**< \brief ACIFC signal: ACBP1 on PC14 mux E */
+#define MUX_PC14E_ACIFC_ACBP1           _L(4)
+#define PINMUX_PC14E_ACIFC_ACBP1   ((PIN_PC14E_ACIFC_ACBP1 << 16) | MUX_PC14E_ACIFC_ACBP1)
+#define GPIO_PC14E_ACIFC_ACBP1   _UL(1 << 14)
+/* ========== GPIO definition for GLOC peripheral ========== */
+#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
+#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L(3)
+#define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
+#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L(3)
+#define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
+#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L(3)
+#define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
+#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L(3)
+#define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
+#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L(3)
+#define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
+#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L(3)
+#define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
+#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L(3)
+#define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
+#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
+#define PIN_PA27D_GLOC_IN4             _L(27) /**< \brief GLOC signal: IN4 on PA27 mux D */
+#define MUX_PA27D_GLOC_IN4              _L(3)
+#define PINMUX_PA27D_GLOC_IN4      ((PIN_PA27D_GLOC_IN4 << 16) | MUX_PA27D_GLOC_IN4)
+#define GPIO_PA27D_GLOC_IN4      _UL(1 << 27)
+#define PIN_PC15D_GLOC_IN4             _L(79) /**< \brief GLOC signal: IN4 on PC15 mux D */
+#define MUX_PC15D_GLOC_IN4              _L(3)
+#define PINMUX_PC15D_GLOC_IN4      ((PIN_PC15D_GLOC_IN4 << 16) | MUX_PC15D_GLOC_IN4)
+#define GPIO_PC15D_GLOC_IN4      _UL(1 << 15)
+#define PIN_PB06C_GLOC_IN4             _L(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
+#define MUX_PB06C_GLOC_IN4              _L(2)
+#define PINMUX_PB06C_GLOC_IN4      ((PIN_PB06C_GLOC_IN4 << 16) | MUX_PB06C_GLOC_IN4)
+#define GPIO_PB06C_GLOC_IN4      _UL(1 <<  6)
+#define PIN_PC28C_GLOC_IN4             _L(92) /**< \brief GLOC signal: IN4 on PC28 mux C */
+#define MUX_PC28C_GLOC_IN4              _L(2)
+#define PINMUX_PC28C_GLOC_IN4      ((PIN_PC28C_GLOC_IN4 << 16) | MUX_PC28C_GLOC_IN4)
+#define GPIO_PC28C_GLOC_IN4      _UL(1 << 28)
+#define PIN_PA28D_GLOC_IN5             _L(28) /**< \brief GLOC signal: IN5 on PA28 mux D */
+#define MUX_PA28D_GLOC_IN5              _L(3)
+#define PINMUX_PA28D_GLOC_IN5      ((PIN_PA28D_GLOC_IN5 << 16) | MUX_PA28D_GLOC_IN5)
+#define GPIO_PA28D_GLOC_IN5      _UL(1 << 28)
+#define PIN_PC16D_GLOC_IN5             _L(80) /**< \brief GLOC signal: IN5 on PC16 mux D */
+#define MUX_PC16D_GLOC_IN5              _L(3)
+#define PINMUX_PC16D_GLOC_IN5      ((PIN_PC16D_GLOC_IN5 << 16) | MUX_PC16D_GLOC_IN5)
+#define GPIO_PC16D_GLOC_IN5      _UL(1 << 16)
+#define PIN_PB07C_GLOC_IN5             _L(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
+#define MUX_PB07C_GLOC_IN5              _L(2)
+#define PINMUX_PB07C_GLOC_IN5      ((PIN_PB07C_GLOC_IN5 << 16) | MUX_PB07C_GLOC_IN5)
+#define GPIO_PB07C_GLOC_IN5      _UL(1 <<  7)
+#define PIN_PC29C_GLOC_IN5             _L(93) /**< \brief GLOC signal: IN5 on PC29 mux C */
+#define MUX_PC29C_GLOC_IN5              _L(2)
+#define PINMUX_PC29C_GLOC_IN5      ((PIN_PC29C_GLOC_IN5 << 16) | MUX_PC29C_GLOC_IN5)
+#define GPIO_PC29C_GLOC_IN5      _UL(1 << 29)
+#define PIN_PA29D_GLOC_IN6             _L(29) /**< \brief GLOC signal: IN6 on PA29 mux D */
+#define MUX_PA29D_GLOC_IN6              _L(3)
+#define PINMUX_PA29D_GLOC_IN6      ((PIN_PA29D_GLOC_IN6 << 16) | MUX_PA29D_GLOC_IN6)
+#define GPIO_PA29D_GLOC_IN6      _UL(1 << 29)
+#define PIN_PC17D_GLOC_IN6             _L(81) /**< \brief GLOC signal: IN6 on PC17 mux D */
+#define MUX_PC17D_GLOC_IN6              _L(3)
+#define PINMUX_PC17D_GLOC_IN6      ((PIN_PC17D_GLOC_IN6 << 16) | MUX_PC17D_GLOC_IN6)
+#define GPIO_PC17D_GLOC_IN6      _UL(1 << 17)
+#define PIN_PB08C_GLOC_IN6             _L(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
+#define MUX_PB08C_GLOC_IN6              _L(2)
+#define PINMUX_PB08C_GLOC_IN6      ((PIN_PB08C_GLOC_IN6 << 16) | MUX_PB08C_GLOC_IN6)
+#define GPIO_PB08C_GLOC_IN6      _UL(1 <<  8)
+#define PIN_PC30C_GLOC_IN6             _L(94) /**< \brief GLOC signal: IN6 on PC30 mux C */
+#define MUX_PC30C_GLOC_IN6              _L(2)
+#define PINMUX_PC30C_GLOC_IN6      ((PIN_PC30C_GLOC_IN6 << 16) | MUX_PC30C_GLOC_IN6)
+#define GPIO_PC30C_GLOC_IN6      _UL(1 << 30)
+#define PIN_PA30D_GLOC_IN7             _L(30) /**< \brief GLOC signal: IN7 on PA30 mux D */
+#define MUX_PA30D_GLOC_IN7              _L(3)
+#define PINMUX_PA30D_GLOC_IN7      ((PIN_PA30D_GLOC_IN7 << 16) | MUX_PA30D_GLOC_IN7)
+#define GPIO_PA30D_GLOC_IN7      _UL(1 << 30)
+#define PIN_PC18D_GLOC_IN7             _L(82) /**< \brief GLOC signal: IN7 on PC18 mux D */
+#define MUX_PC18D_GLOC_IN7              _L(3)
+#define PINMUX_PC18D_GLOC_IN7      ((PIN_PC18D_GLOC_IN7 << 16) | MUX_PC18D_GLOC_IN7)
+#define GPIO_PC18D_GLOC_IN7      _UL(1 << 18)
+#define PIN_PB09C_GLOC_IN7             _L(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
+#define MUX_PB09C_GLOC_IN7              _L(2)
+#define PINMUX_PB09C_GLOC_IN7      ((PIN_PB09C_GLOC_IN7 << 16) | MUX_PB09C_GLOC_IN7)
+#define GPIO_PB09C_GLOC_IN7      _UL(1 <<  9)
+#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
+#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
+#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
+#define PIN_PA31D_GLOC_OUT1            _L(31) /**< \brief GLOC signal: OUT1 on PA31 mux D */
+#define MUX_PA31D_GLOC_OUT1             _L(3)
+#define PINMUX_PA31D_GLOC_OUT1     ((PIN_PA31D_GLOC_OUT1 << 16) | MUX_PA31D_GLOC_OUT1)
+#define GPIO_PA31D_GLOC_OUT1     _UL(1 << 31)
+#define PIN_PC19D_GLOC_OUT1            _L(83) /**< \brief GLOC signal: OUT1 on PC19 mux D */
+#define MUX_PC19D_GLOC_OUT1             _L(3)
+#define PINMUX_PC19D_GLOC_OUT1     ((PIN_PC19D_GLOC_OUT1 << 16) | MUX_PC19D_GLOC_OUT1)
+#define GPIO_PC19D_GLOC_OUT1     _UL(1 << 19)
+#define PIN_PB10C_GLOC_OUT1            _L(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
+#define MUX_PB10C_GLOC_OUT1             _L(2)
+#define PINMUX_PB10C_GLOC_OUT1     ((PIN_PB10C_GLOC_OUT1 << 16) | MUX_PB10C_GLOC_OUT1)
+#define GPIO_PB10C_GLOC_OUT1     _UL(1 << 10)
+#define PIN_PC31C_GLOC_OUT1            _L(95) /**< \brief GLOC signal: OUT1 on PC31 mux C */
+#define MUX_PC31C_GLOC_OUT1             _L(2)
+#define PINMUX_PC31C_GLOC_OUT1     ((PIN_PC31C_GLOC_OUT1 << 16) | MUX_PC31C_GLOC_OUT1)
+#define GPIO_PC31C_GLOC_OUT1     _UL(1 << 31)
+/* ========== GPIO definition for ABDACB peripheral ========== */
+#define PIN_PA31C_ABDACB_CLK           _L(31) /**< \brief ABDACB signal: CLK on PA31 mux C */
+#define MUX_PA31C_ABDACB_CLK            _L(2)
+#define PINMUX_PA31C_ABDACB_CLK    ((PIN_PA31C_ABDACB_CLK << 16) | MUX_PA31C_ABDACB_CLK)
+#define GPIO_PA31C_ABDACB_CLK    _UL(1 << 31)
+#define PIN_PC12C_ABDACB_CLK           _L(76) /**< \brief ABDACB signal: CLK on PC12 mux C */
+#define MUX_PC12C_ABDACB_CLK            _L(2)
+#define PINMUX_PC12C_ABDACB_CLK    ((PIN_PC12C_ABDACB_CLK << 16) | MUX_PC12C_ABDACB_CLK)
+#define GPIO_PC12C_ABDACB_CLK    _UL(1 << 12)
+#define PIN_PA27C_ABDACB_DAC0          _L(27) /**< \brief ABDACB signal: DAC0 on PA27 mux C */
+#define MUX_PA27C_ABDACB_DAC0           _L(2)
+#define PINMUX_PA27C_ABDACB_DAC0   ((PIN_PA27C_ABDACB_DAC0 << 16) | MUX_PA27C_ABDACB_DAC0)
+#define GPIO_PA27C_ABDACB_DAC0   _UL(1 << 27)
+#define PIN_PB02C_ABDACB_DAC0          _L(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
+#define MUX_PB02C_ABDACB_DAC0           _L(2)
+#define PINMUX_PB02C_ABDACB_DAC0   ((PIN_PB02C_ABDACB_DAC0 << 16) | MUX_PB02C_ABDACB_DAC0)
+#define GPIO_PB02C_ABDACB_DAC0   _UL(1 <<  2)
+#define PIN_PC09C_ABDACB_DAC0          _L(73) /**< \brief ABDACB signal: DAC0 on PC09 mux C */
+#define MUX_PC09C_ABDACB_DAC0           _L(2)
+#define PINMUX_PC09C_ABDACB_DAC0   ((PIN_PC09C_ABDACB_DAC0 << 16) | MUX_PC09C_ABDACB_DAC0)
+#define GPIO_PC09C_ABDACB_DAC0   _UL(1 <<  9)
+#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
+#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
+#define PIN_PA29C_ABDACB_DAC1          _L(29) /**< \brief ABDACB signal: DAC1 on PA29 mux C */
+#define MUX_PA29C_ABDACB_DAC1           _L(2)
+#define PINMUX_PA29C_ABDACB_DAC1   ((PIN_PA29C_ABDACB_DAC1 << 16) | MUX_PA29C_ABDACB_DAC1)
+#define GPIO_PA29C_ABDACB_DAC1   _UL(1 << 29)
+#define PIN_PB04C_ABDACB_DAC1          _L(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
+#define MUX_PB04C_ABDACB_DAC1           _L(2)
+#define PINMUX_PB04C_ABDACB_DAC1   ((PIN_PB04C_ABDACB_DAC1 << 16) | MUX_PB04C_ABDACB_DAC1)
+#define GPIO_PB04C_ABDACB_DAC1   _UL(1 <<  4)
+#define PIN_PC13C_ABDACB_DAC1          _L(77) /**< \brief ABDACB signal: DAC1 on PC13 mux C */
+#define MUX_PC13C_ABDACB_DAC1           _L(2)
+#define PINMUX_PC13C_ABDACB_DAC1   ((PIN_PC13C_ABDACB_DAC1 << 16) | MUX_PC13C_ABDACB_DAC1)
+#define GPIO_PC13C_ABDACB_DAC1   _UL(1 << 13)
+#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
+#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
+#define PIN_PA28C_ABDACB_DACN0         _L(28) /**< \brief ABDACB signal: DACN0 on PA28 mux C */
+#define MUX_PA28C_ABDACB_DACN0          _L(2)
+#define PINMUX_PA28C_ABDACB_DACN0  ((PIN_PA28C_ABDACB_DACN0 << 16) | MUX_PA28C_ABDACB_DACN0)
+#define GPIO_PA28C_ABDACB_DACN0  _UL(1 << 28)
+#define PIN_PB03C_ABDACB_DACN0         _L(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
+#define MUX_PB03C_ABDACB_DACN0          _L(2)
+#define PINMUX_PB03C_ABDACB_DACN0  ((PIN_PB03C_ABDACB_DACN0 << 16) | MUX_PB03C_ABDACB_DACN0)
+#define GPIO_PB03C_ABDACB_DACN0  _UL(1 <<  3)
+#define PIN_PC10C_ABDACB_DACN0         _L(74) /**< \brief ABDACB signal: DACN0 on PC10 mux C */
+#define MUX_PC10C_ABDACB_DACN0          _L(2)
+#define PINMUX_PC10C_ABDACB_DACN0  ((PIN_PC10C_ABDACB_DACN0 << 16) | MUX_PC10C_ABDACB_DACN0)
+#define GPIO_PC10C_ABDACB_DACN0  _UL(1 << 10)
+#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
+#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
+#define PIN_PA30C_ABDACB_DACN1         _L(30) /**< \brief ABDACB signal: DACN1 on PA30 mux C */
+#define MUX_PA30C_ABDACB_DACN1          _L(2)
+#define PINMUX_PA30C_ABDACB_DACN1  ((PIN_PA30C_ABDACB_DACN1 << 16) | MUX_PA30C_ABDACB_DACN1)
+#define GPIO_PA30C_ABDACB_DACN1  _UL(1 << 30)
+#define PIN_PB05C_ABDACB_DACN1         _L(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
+#define MUX_PB05C_ABDACB_DACN1          _L(2)
+#define PINMUX_PB05C_ABDACB_DACN1  ((PIN_PB05C_ABDACB_DACN1 << 16) | MUX_PB05C_ABDACB_DACN1)
+#define GPIO_PB05C_ABDACB_DACN1  _UL(1 <<  5)
+#define PIN_PC14C_ABDACB_DACN1         _L(78) /**< \brief ABDACB signal: DACN1 on PC14 mux C */
+#define MUX_PC14C_ABDACB_DACN1          _L(2)
+#define PINMUX_PC14C_ABDACB_DACN1  ((PIN_PC14C_ABDACB_DACN1 << 16) | MUX_PC14C_ABDACB_DACN1)
+#define GPIO_PC14C_ABDACB_DACN1  _UL(1 << 14)
+#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
+#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+/* ========== GPIO definition for PARC peripheral ========== */
+#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
+#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
+#define PIN_PC21D_PARC_PCCK            _L(85) /**< \brief PARC signal: PCCK on PC21 mux D */
+#define MUX_PC21D_PARC_PCCK             _L(3)
+#define PINMUX_PC21D_PARC_PCCK     ((PIN_PC21D_PARC_PCCK << 16) | MUX_PC21D_PARC_PCCK)
+#define GPIO_PC21D_PARC_PCCK     _UL(1 << 21)
+#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
+#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
+#define PIN_PC24D_PARC_PCDATA0         _L(88) /**< \brief PARC signal: PCDATA0 on PC24 mux D */
+#define MUX_PC24D_PARC_PCDATA0          _L(3)
+#define PINMUX_PC24D_PARC_PCDATA0  ((PIN_PC24D_PARC_PCDATA0 << 16) | MUX_PC24D_PARC_PCDATA0)
+#define GPIO_PC24D_PARC_PCDATA0  _UL(1 << 24)
+#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
+#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
+#define PIN_PC25D_PARC_PCDATA1         _L(89) /**< \brief PARC signal: PCDATA1 on PC25 mux D */
+#define MUX_PC25D_PARC_PCDATA1          _L(3)
+#define PINMUX_PC25D_PARC_PCDATA1  ((PIN_PC25D_PARC_PCDATA1 << 16) | MUX_PC25D_PARC_PCDATA1)
+#define GPIO_PC25D_PARC_PCDATA1  _UL(1 << 25)
+#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
+#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
+#define PIN_PC26D_PARC_PCDATA2         _L(90) /**< \brief PARC signal: PCDATA2 on PC26 mux D */
+#define MUX_PC26D_PARC_PCDATA2          _L(3)
+#define PINMUX_PC26D_PARC_PCDATA2  ((PIN_PC26D_PARC_PCDATA2 << 16) | MUX_PC26D_PARC_PCDATA2)
+#define GPIO_PC26D_PARC_PCDATA2  _UL(1 << 26)
+#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
+#define PIN_PC27D_PARC_PCDATA3         _L(91) /**< \brief PARC signal: PCDATA3 on PC27 mux D */
+#define MUX_PC27D_PARC_PCDATA3          _L(3)
+#define PINMUX_PC27D_PARC_PCDATA3  ((PIN_PC27D_PARC_PCDATA3 << 16) | MUX_PC27D_PARC_PCDATA3)
+#define GPIO_PC27D_PARC_PCDATA3  _UL(1 << 27)
+#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
+#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
+#define PIN_PC28D_PARC_PCDATA4         _L(92) /**< \brief PARC signal: PCDATA4 on PC28 mux D */
+#define MUX_PC28D_PARC_PCDATA4          _L(3)
+#define PINMUX_PC28D_PARC_PCDATA4  ((PIN_PC28D_PARC_PCDATA4 << 16) | MUX_PC28D_PARC_PCDATA4)
+#define GPIO_PC28D_PARC_PCDATA4  _UL(1 << 28)
+#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
+#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
+#define PIN_PC29D_PARC_PCDATA5         _L(93) /**< \brief PARC signal: PCDATA5 on PC29 mux D */
+#define MUX_PC29D_PARC_PCDATA5          _L(3)
+#define PINMUX_PC29D_PARC_PCDATA5  ((PIN_PC29D_PARC_PCDATA5 << 16) | MUX_PC29D_PARC_PCDATA5)
+#define GPIO_PC29D_PARC_PCDATA5  _UL(1 << 29)
+#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
+#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
+#define PIN_PC30D_PARC_PCDATA6         _L(94) /**< \brief PARC signal: PCDATA6 on PC30 mux D */
+#define MUX_PC30D_PARC_PCDATA6          _L(3)
+#define PINMUX_PC30D_PARC_PCDATA6  ((PIN_PC30D_PARC_PCDATA6 << 16) | MUX_PC30D_PARC_PCDATA6)
+#define GPIO_PC30D_PARC_PCDATA6  _UL(1 << 30)
+#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
+#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
+#define PIN_PC31D_PARC_PCDATA7         _L(95) /**< \brief PARC signal: PCDATA7 on PC31 mux D */
+#define MUX_PC31D_PARC_PCDATA7          _L(3)
+#define PINMUX_PC31D_PARC_PCDATA7  ((PIN_PC31D_PARC_PCDATA7 << 16) | MUX_PC31D_PARC_PCDATA7)
+#define GPIO_PC31D_PARC_PCDATA7  _UL(1 << 31)
+#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
+#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
+#define PIN_PC22D_PARC_PCEN1           _L(86) /**< \brief PARC signal: PCEN1 on PC22 mux D */
+#define MUX_PC22D_PARC_PCEN1            _L(3)
+#define PINMUX_PC22D_PARC_PCEN1    ((PIN_PC22D_PARC_PCEN1 << 16) | MUX_PC22D_PARC_PCEN1)
+#define GPIO_PC22D_PARC_PCEN1    _UL(1 << 22)
+#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
+#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+#define PIN_PC23D_PARC_PCEN2           _L(87) /**< \brief PARC signal: PCEN2 on PC23 mux D */
+#define MUX_PC23D_PARC_PCEN2            _L(3)
+#define PINMUX_PC23D_PARC_PCEN2    ((PIN_PC23D_PARC_PCEN2 << 16) | MUX_PC23D_PARC_PCEN2)
+#define GPIO_PC23D_PARC_PCEN2    _UL(1 << 23)
+/* ========== GPIO definition for CATB peripheral ========== */
+#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L(6)
+#define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
+#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L(6)
+#define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
+#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L(6)
+#define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
+#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
+#define PIN_PA31G_CATB_DIS             _L(31) /**< \brief CATB signal: DIS on PA31 mux G */
+#define MUX_PA31G_CATB_DIS              _L(6)
+#define PINMUX_PA31G_CATB_DIS      ((PIN_PA31G_CATB_DIS << 16) | MUX_PA31G_CATB_DIS)
+#define GPIO_PA31G_CATB_DIS      _UL(1 << 31)
+#define PIN_PB03G_CATB_DIS             _L(35) /**< \brief CATB signal: DIS on PB03 mux G */
+#define MUX_PB03G_CATB_DIS              _L(6)
+#define PINMUX_PB03G_CATB_DIS      ((PIN_PB03G_CATB_DIS << 16) | MUX_PB03G_CATB_DIS)
+#define GPIO_PB03G_CATB_DIS      _UL(1 <<  3)
+#define PIN_PB12G_CATB_DIS             _L(44) /**< \brief CATB signal: DIS on PB12 mux G */
+#define MUX_PB12G_CATB_DIS              _L(6)
+#define PINMUX_PB12G_CATB_DIS      ((PIN_PB12G_CATB_DIS << 16) | MUX_PB12G_CATB_DIS)
+#define GPIO_PB12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PC05G_CATB_DIS             _L(69) /**< \brief CATB signal: DIS on PC05 mux G */
+#define MUX_PC05G_CATB_DIS              _L(6)
+#define PINMUX_PC05G_CATB_DIS      ((PIN_PC05G_CATB_DIS << 16) | MUX_PC05G_CATB_DIS)
+#define GPIO_PC05G_CATB_DIS      _UL(1 <<  5)
+#define PIN_PC14G_CATB_DIS             _L(78) /**< \brief CATB signal: DIS on PC14 mux G */
+#define MUX_PC14G_CATB_DIS              _L(6)
+#define PINMUX_PC14G_CATB_DIS      ((PIN_PC14G_CATB_DIS << 16) | MUX_PC14G_CATB_DIS)
+#define GPIO_PC14G_CATB_DIS      _UL(1 << 14)
+#define PIN_PC23G_CATB_DIS             _L(87) /**< \brief CATB signal: DIS on PC23 mux G */
+#define MUX_PC23G_CATB_DIS              _L(6)
+#define PINMUX_PC23G_CATB_DIS      ((PIN_PC23G_CATB_DIS << 16) | MUX_PC23G_CATB_DIS)
+#define GPIO_PC23G_CATB_DIS      _UL(1 << 23)
+#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
+#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
+#define PIN_PA27G_CATB_SENSE0          _L(27) /**< \brief CATB signal: SENSE0 on PA27 mux G */
+#define MUX_PA27G_CATB_SENSE0           _L(6)
+#define PINMUX_PA27G_CATB_SENSE0   ((PIN_PA27G_CATB_SENSE0 << 16) | MUX_PA27G_CATB_SENSE0)
+#define GPIO_PA27G_CATB_SENSE0   _UL(1 << 27)
+#define PIN_PB13G_CATB_SENSE0          _L(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
+#define MUX_PB13G_CATB_SENSE0           _L(6)
+#define PINMUX_PB13G_CATB_SENSE0   ((PIN_PB13G_CATB_SENSE0 << 16) | MUX_PB13G_CATB_SENSE0)
+#define GPIO_PB13G_CATB_SENSE0   _UL(1 << 13)
+#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
+#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
+#define PIN_PA28G_CATB_SENSE1          _L(28) /**< \brief CATB signal: SENSE1 on PA28 mux G */
+#define MUX_PA28G_CATB_SENSE1           _L(6)
+#define PINMUX_PA28G_CATB_SENSE1   ((PIN_PA28G_CATB_SENSE1 << 16) | MUX_PA28G_CATB_SENSE1)
+#define GPIO_PA28G_CATB_SENSE1   _UL(1 << 28)
+#define PIN_PB14G_CATB_SENSE1          _L(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
+#define MUX_PB14G_CATB_SENSE1           _L(6)
+#define PINMUX_PB14G_CATB_SENSE1   ((PIN_PB14G_CATB_SENSE1 << 16) | MUX_PB14G_CATB_SENSE1)
+#define GPIO_PB14G_CATB_SENSE1   _UL(1 << 14)
+#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
+#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
+#define PIN_PA29G_CATB_SENSE2          _L(29) /**< \brief CATB signal: SENSE2 on PA29 mux G */
+#define MUX_PA29G_CATB_SENSE2           _L(6)
+#define PINMUX_PA29G_CATB_SENSE2   ((PIN_PA29G_CATB_SENSE2 << 16) | MUX_PA29G_CATB_SENSE2)
+#define GPIO_PA29G_CATB_SENSE2   _UL(1 << 29)
+#define PIN_PB15G_CATB_SENSE2          _L(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
+#define MUX_PB15G_CATB_SENSE2           _L(6)
+#define PINMUX_PB15G_CATB_SENSE2   ((PIN_PB15G_CATB_SENSE2 << 16) | MUX_PB15G_CATB_SENSE2)
+#define GPIO_PB15G_CATB_SENSE2   _UL(1 << 15)
+#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
+#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
+#define PIN_PA30G_CATB_SENSE3          _L(30) /**< \brief CATB signal: SENSE3 on PA30 mux G */
+#define MUX_PA30G_CATB_SENSE3           _L(6)
+#define PINMUX_PA30G_CATB_SENSE3   ((PIN_PA30G_CATB_SENSE3 << 16) | MUX_PA30G_CATB_SENSE3)
+#define GPIO_PA30G_CATB_SENSE3   _UL(1 << 30)
+#define PIN_PC00G_CATB_SENSE3          _L(64) /**< \brief CATB signal: SENSE3 on PC00 mux G */
+#define MUX_PC00G_CATB_SENSE3           _L(6)
+#define PINMUX_PC00G_CATB_SENSE3   ((PIN_PC00G_CATB_SENSE3 << 16) | MUX_PC00G_CATB_SENSE3)
+#define GPIO_PC00G_CATB_SENSE3   _UL(1 <<  0)
+#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
+#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
+#define PIN_PC01G_CATB_SENSE4          _L(65) /**< \brief CATB signal: SENSE4 on PC01 mux G */
+#define MUX_PC01G_CATB_SENSE4           _L(6)
+#define PINMUX_PC01G_CATB_SENSE4   ((PIN_PC01G_CATB_SENSE4 << 16) | MUX_PC01G_CATB_SENSE4)
+#define GPIO_PC01G_CATB_SENSE4   _UL(1 <<  1)
+#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
+#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
+#define PIN_PC02G_CATB_SENSE5          _L(66) /**< \brief CATB signal: SENSE5 on PC02 mux G */
+#define MUX_PC02G_CATB_SENSE5           _L(6)
+#define PINMUX_PC02G_CATB_SENSE5   ((PIN_PC02G_CATB_SENSE5 << 16) | MUX_PC02G_CATB_SENSE5)
+#define GPIO_PC02G_CATB_SENSE5   _UL(1 <<  2)
+#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
+#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
+#define PIN_PC03G_CATB_SENSE6          _L(67) /**< \brief CATB signal: SENSE6 on PC03 mux G */
+#define MUX_PC03G_CATB_SENSE6           _L(6)
+#define PINMUX_PC03G_CATB_SENSE6   ((PIN_PC03G_CATB_SENSE6 << 16) | MUX_PC03G_CATB_SENSE6)
+#define GPIO_PC03G_CATB_SENSE6   _UL(1 <<  3)
+#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
+#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
+#define PIN_PC04G_CATB_SENSE7          _L(68) /**< \brief CATB signal: SENSE7 on PC04 mux G */
+#define MUX_PC04G_CATB_SENSE7           _L(6)
+#define PINMUX_PC04G_CATB_SENSE7   ((PIN_PC04G_CATB_SENSE7 << 16) | MUX_PC04G_CATB_SENSE7)
+#define GPIO_PC04G_CATB_SENSE7   _UL(1 <<  4)
+#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
+#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
+#define PIN_PC06G_CATB_SENSE8          _L(70) /**< \brief CATB signal: SENSE8 on PC06 mux G */
+#define MUX_PC06G_CATB_SENSE8           _L(6)
+#define PINMUX_PC06G_CATB_SENSE8   ((PIN_PC06G_CATB_SENSE8 << 16) | MUX_PC06G_CATB_SENSE8)
+#define GPIO_PC06G_CATB_SENSE8   _UL(1 <<  6)
+#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
+#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
+#define PIN_PC07G_CATB_SENSE9          _L(71) /**< \brief CATB signal: SENSE9 on PC07 mux G */
+#define MUX_PC07G_CATB_SENSE9           _L(6)
+#define PINMUX_PC07G_CATB_SENSE9   ((PIN_PC07G_CATB_SENSE9 << 16) | MUX_PC07G_CATB_SENSE9)
+#define GPIO_PC07G_CATB_SENSE9   _UL(1 <<  7)
+#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
+#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
+#define PIN_PC08G_CATB_SENSE10         _L(72) /**< \brief CATB signal: SENSE10 on PC08 mux G */
+#define MUX_PC08G_CATB_SENSE10          _L(6)
+#define PINMUX_PC08G_CATB_SENSE10  ((PIN_PC08G_CATB_SENSE10 << 16) | MUX_PC08G_CATB_SENSE10)
+#define GPIO_PC08G_CATB_SENSE10  _UL(1 <<  8)
+#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
+#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
+#define PIN_PC09G_CATB_SENSE11         _L(73) /**< \brief CATB signal: SENSE11 on PC09 mux G */
+#define MUX_PC09G_CATB_SENSE11          _L(6)
+#define PINMUX_PC09G_CATB_SENSE11  ((PIN_PC09G_CATB_SENSE11 << 16) | MUX_PC09G_CATB_SENSE11)
+#define GPIO_PC09G_CATB_SENSE11  _UL(1 <<  9)
+#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
+#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
+#define PIN_PC10G_CATB_SENSE12         _L(74) /**< \brief CATB signal: SENSE12 on PC10 mux G */
+#define MUX_PC10G_CATB_SENSE12          _L(6)
+#define PINMUX_PC10G_CATB_SENSE12  ((PIN_PC10G_CATB_SENSE12 << 16) | MUX_PC10G_CATB_SENSE12)
+#define GPIO_PC10G_CATB_SENSE12  _UL(1 << 10)
+#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
+#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
+#define PIN_PC11G_CATB_SENSE13         _L(75) /**< \brief CATB signal: SENSE13 on PC11 mux G */
+#define MUX_PC11G_CATB_SENSE13          _L(6)
+#define PINMUX_PC11G_CATB_SENSE13  ((PIN_PC11G_CATB_SENSE13 << 16) | MUX_PC11G_CATB_SENSE13)
+#define GPIO_PC11G_CATB_SENSE13  _UL(1 << 11)
+#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
+#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
+#define PIN_PC12G_CATB_SENSE14         _L(76) /**< \brief CATB signal: SENSE14 on PC12 mux G */
+#define MUX_PC12G_CATB_SENSE14          _L(6)
+#define PINMUX_PC12G_CATB_SENSE14  ((PIN_PC12G_CATB_SENSE14 << 16) | MUX_PC12G_CATB_SENSE14)
+#define GPIO_PC12G_CATB_SENSE14  _UL(1 << 12)
+#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
+#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
+#define PIN_PC13G_CATB_SENSE15         _L(77) /**< \brief CATB signal: SENSE15 on PC13 mux G */
+#define MUX_PC13G_CATB_SENSE15          _L(6)
+#define PINMUX_PC13G_CATB_SENSE15  ((PIN_PC13G_CATB_SENSE15 << 16) | MUX_PC13G_CATB_SENSE15)
+#define GPIO_PC13G_CATB_SENSE15  _UL(1 << 13)
+#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
+#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
+#define PIN_PC15G_CATB_SENSE16         _L(79) /**< \brief CATB signal: SENSE16 on PC15 mux G */
+#define MUX_PC15G_CATB_SENSE16          _L(6)
+#define PINMUX_PC15G_CATB_SENSE16  ((PIN_PC15G_CATB_SENSE16 << 16) | MUX_PC15G_CATB_SENSE16)
+#define GPIO_PC15G_CATB_SENSE16  _UL(1 << 15)
+#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
+#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
+#define PIN_PC16G_CATB_SENSE17         _L(80) /**< \brief CATB signal: SENSE17 on PC16 mux G */
+#define MUX_PC16G_CATB_SENSE17          _L(6)
+#define PINMUX_PC16G_CATB_SENSE17  ((PIN_PC16G_CATB_SENSE17 << 16) | MUX_PC16G_CATB_SENSE17)
+#define GPIO_PC16G_CATB_SENSE17  _UL(1 << 16)
+#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
+#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
+#define PIN_PC17G_CATB_SENSE18         _L(81) /**< \brief CATB signal: SENSE18 on PC17 mux G */
+#define MUX_PC17G_CATB_SENSE18          _L(6)
+#define PINMUX_PC17G_CATB_SENSE18  ((PIN_PC17G_CATB_SENSE18 << 16) | MUX_PC17G_CATB_SENSE18)
+#define GPIO_PC17G_CATB_SENSE18  _UL(1 << 17)
+#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
+#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
+#define PIN_PC18G_CATB_SENSE19         _L(82) /**< \brief CATB signal: SENSE19 on PC18 mux G */
+#define MUX_PC18G_CATB_SENSE19          _L(6)
+#define PINMUX_PC18G_CATB_SENSE19  ((PIN_PC18G_CATB_SENSE19 << 16) | MUX_PC18G_CATB_SENSE19)
+#define GPIO_PC18G_CATB_SENSE19  _UL(1 << 18)
+#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
+#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
+#define PIN_PC19G_CATB_SENSE20         _L(83) /**< \brief CATB signal: SENSE20 on PC19 mux G */
+#define MUX_PC19G_CATB_SENSE20          _L(6)
+#define PINMUX_PC19G_CATB_SENSE20  ((PIN_PC19G_CATB_SENSE20 << 16) | MUX_PC19G_CATB_SENSE20)
+#define GPIO_PC19G_CATB_SENSE20  _UL(1 << 19)
+#define PIN_PB00G_CATB_SENSE21         _L(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
+#define MUX_PB00G_CATB_SENSE21          _L(6)
+#define PINMUX_PB00G_CATB_SENSE21  ((PIN_PB00G_CATB_SENSE21 << 16) | MUX_PB00G_CATB_SENSE21)
+#define GPIO_PB00G_CATB_SENSE21  _UL(1 <<  0)
+#define PIN_PC20G_CATB_SENSE21         _L(84) /**< \brief CATB signal: SENSE21 on PC20 mux G */
+#define MUX_PC20G_CATB_SENSE21          _L(6)
+#define PINMUX_PC20G_CATB_SENSE21  ((PIN_PC20G_CATB_SENSE21 << 16) | MUX_PC20G_CATB_SENSE21)
+#define GPIO_PC20G_CATB_SENSE21  _UL(1 << 20)
+#define PIN_PB01G_CATB_SENSE22         _L(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
+#define MUX_PB01G_CATB_SENSE22          _L(6)
+#define PINMUX_PB01G_CATB_SENSE22  ((PIN_PB01G_CATB_SENSE22 << 16) | MUX_PB01G_CATB_SENSE22)
+#define GPIO_PB01G_CATB_SENSE22  _UL(1 <<  1)
+#define PIN_PC21G_CATB_SENSE22         _L(85) /**< \brief CATB signal: SENSE22 on PC21 mux G */
+#define MUX_PC21G_CATB_SENSE22          _L(6)
+#define PINMUX_PC21G_CATB_SENSE22  ((PIN_PC21G_CATB_SENSE22 << 16) | MUX_PC21G_CATB_SENSE22)
+#define GPIO_PC21G_CATB_SENSE22  _UL(1 << 21)
+#define PIN_PB02G_CATB_SENSE23         _L(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
+#define MUX_PB02G_CATB_SENSE23          _L(6)
+#define PINMUX_PB02G_CATB_SENSE23  ((PIN_PB02G_CATB_SENSE23 << 16) | MUX_PB02G_CATB_SENSE23)
+#define GPIO_PB02G_CATB_SENSE23  _UL(1 <<  2)
+#define PIN_PC22G_CATB_SENSE23         _L(86) /**< \brief CATB signal: SENSE23 on PC22 mux G */
+#define MUX_PC22G_CATB_SENSE23          _L(6)
+#define PINMUX_PC22G_CATB_SENSE23  ((PIN_PC22G_CATB_SENSE23 << 16) | MUX_PC22G_CATB_SENSE23)
+#define GPIO_PC22G_CATB_SENSE23  _UL(1 << 22)
+#define PIN_PB04G_CATB_SENSE24         _L(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
+#define MUX_PB04G_CATB_SENSE24          _L(6)
+#define PINMUX_PB04G_CATB_SENSE24  ((PIN_PB04G_CATB_SENSE24 << 16) | MUX_PB04G_CATB_SENSE24)
+#define GPIO_PB04G_CATB_SENSE24  _UL(1 <<  4)
+#define PIN_PC24G_CATB_SENSE24         _L(88) /**< \brief CATB signal: SENSE24 on PC24 mux G */
+#define MUX_PC24G_CATB_SENSE24          _L(6)
+#define PINMUX_PC24G_CATB_SENSE24  ((PIN_PC24G_CATB_SENSE24 << 16) | MUX_PC24G_CATB_SENSE24)
+#define GPIO_PC24G_CATB_SENSE24  _UL(1 << 24)
+#define PIN_PB05G_CATB_SENSE25         _L(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
+#define MUX_PB05G_CATB_SENSE25          _L(6)
+#define PINMUX_PB05G_CATB_SENSE25  ((PIN_PB05G_CATB_SENSE25 << 16) | MUX_PB05G_CATB_SENSE25)
+#define GPIO_PB05G_CATB_SENSE25  _UL(1 <<  5)
+#define PIN_PC25G_CATB_SENSE25         _L(89) /**< \brief CATB signal: SENSE25 on PC25 mux G */
+#define MUX_PC25G_CATB_SENSE25          _L(6)
+#define PINMUX_PC25G_CATB_SENSE25  ((PIN_PC25G_CATB_SENSE25 << 16) | MUX_PC25G_CATB_SENSE25)
+#define GPIO_PC25G_CATB_SENSE25  _UL(1 << 25)
+#define PIN_PB06G_CATB_SENSE26         _L(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
+#define MUX_PB06G_CATB_SENSE26          _L(6)
+#define PINMUX_PB06G_CATB_SENSE26  ((PIN_PB06G_CATB_SENSE26 << 16) | MUX_PB06G_CATB_SENSE26)
+#define GPIO_PB06G_CATB_SENSE26  _UL(1 <<  6)
+#define PIN_PC26G_CATB_SENSE26         _L(90) /**< \brief CATB signal: SENSE26 on PC26 mux G */
+#define MUX_PC26G_CATB_SENSE26          _L(6)
+#define PINMUX_PC26G_CATB_SENSE26  ((PIN_PC26G_CATB_SENSE26 << 16) | MUX_PC26G_CATB_SENSE26)
+#define GPIO_PC26G_CATB_SENSE26  _UL(1 << 26)
+#define PIN_PB07G_CATB_SENSE27         _L(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
+#define MUX_PB07G_CATB_SENSE27          _L(6)
+#define PINMUX_PB07G_CATB_SENSE27  ((PIN_PB07G_CATB_SENSE27 << 16) | MUX_PB07G_CATB_SENSE27)
+#define GPIO_PB07G_CATB_SENSE27  _UL(1 <<  7)
+#define PIN_PC27G_CATB_SENSE27         _L(91) /**< \brief CATB signal: SENSE27 on PC27 mux G */
+#define MUX_PC27G_CATB_SENSE27          _L(6)
+#define PINMUX_PC27G_CATB_SENSE27  ((PIN_PC27G_CATB_SENSE27 << 16) | MUX_PC27G_CATB_SENSE27)
+#define GPIO_PC27G_CATB_SENSE27  _UL(1 << 27)
+#define PIN_PB08G_CATB_SENSE28         _L(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
+#define MUX_PB08G_CATB_SENSE28          _L(6)
+#define PINMUX_PB08G_CATB_SENSE28  ((PIN_PB08G_CATB_SENSE28 << 16) | MUX_PB08G_CATB_SENSE28)
+#define GPIO_PB08G_CATB_SENSE28  _UL(1 <<  8)
+#define PIN_PC28G_CATB_SENSE28         _L(92) /**< \brief CATB signal: SENSE28 on PC28 mux G */
+#define MUX_PC28G_CATB_SENSE28          _L(6)
+#define PINMUX_PC28G_CATB_SENSE28  ((PIN_PC28G_CATB_SENSE28 << 16) | MUX_PC28G_CATB_SENSE28)
+#define GPIO_PC28G_CATB_SENSE28  _UL(1 << 28)
+#define PIN_PB09G_CATB_SENSE29         _L(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
+#define MUX_PB09G_CATB_SENSE29          _L(6)
+#define PINMUX_PB09G_CATB_SENSE29  ((PIN_PB09G_CATB_SENSE29 << 16) | MUX_PB09G_CATB_SENSE29)
+#define GPIO_PB09G_CATB_SENSE29  _UL(1 <<  9)
+#define PIN_PC29G_CATB_SENSE29         _L(93) /**< \brief CATB signal: SENSE29 on PC29 mux G */
+#define MUX_PC29G_CATB_SENSE29          _L(6)
+#define PINMUX_PC29G_CATB_SENSE29  ((PIN_PC29G_CATB_SENSE29 << 16) | MUX_PC29G_CATB_SENSE29)
+#define GPIO_PC29G_CATB_SENSE29  _UL(1 << 29)
+#define PIN_PB10G_CATB_SENSE30         _L(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
+#define MUX_PB10G_CATB_SENSE30          _L(6)
+#define PINMUX_PB10G_CATB_SENSE30  ((PIN_PB10G_CATB_SENSE30 << 16) | MUX_PB10G_CATB_SENSE30)
+#define GPIO_PB10G_CATB_SENSE30  _UL(1 << 10)
+#define PIN_PC30G_CATB_SENSE30         _L(94) /**< \brief CATB signal: SENSE30 on PC30 mux G */
+#define MUX_PC30G_CATB_SENSE30          _L(6)
+#define PINMUX_PC30G_CATB_SENSE30  ((PIN_PC30G_CATB_SENSE30 << 16) | MUX_PC30G_CATB_SENSE30)
+#define GPIO_PC30G_CATB_SENSE30  _UL(1 << 30)
+#define PIN_PB11G_CATB_SENSE31         _L(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
+#define MUX_PB11G_CATB_SENSE31          _L(6)
+#define PINMUX_PB11G_CATB_SENSE31  ((PIN_PB11G_CATB_SENSE31 << 16) | MUX_PB11G_CATB_SENSE31)
+#define GPIO_PB11G_CATB_SENSE31  _UL(1 << 11)
+#define PIN_PC31G_CATB_SENSE31         _L(95) /**< \brief CATB signal: SENSE31 on PC31 mux G */
+#define MUX_PC31G_CATB_SENSE31          _L(6)
+#define PINMUX_PC31G_CATB_SENSE31  ((PIN_PC31G_CATB_SENSE31 << 16) | MUX_PC31G_CATB_SENSE31)
+#define GPIO_PC31G_CATB_SENSE31  _UL(1 << 31)
+/* ========== GPIO definition for USBC peripheral ========== */
+#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L(0)
+#define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
+#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
+#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L(0)
+#define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
+#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+/* ========== GPIO definition for PEVC peripheral ========== */
+#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
+#define PIN_PB12C_PEVC_PAD_EVT0        _L(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
+#define MUX_PB12C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PB12C_PEVC_PAD_EVT0  ((PIN_PB12C_PEVC_PAD_EVT0 << 16) | MUX_PB12C_PEVC_PAD_EVT0)
+#define GPIO_PB12C_PEVC_PAD_EVT0  _UL(1 << 12)
+#define PIN_PC07C_PEVC_PAD_EVT0        _L(71) /**< \brief PEVC signal: PAD_EVT0 on PC07 mux C */
+#define MUX_PC07C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PC07C_PEVC_PAD_EVT0  ((PIN_PC07C_PEVC_PAD_EVT0 << 16) | MUX_PC07C_PEVC_PAD_EVT0)
+#define GPIO_PC07C_PEVC_PAD_EVT0  _UL(1 <<  7)
+#define PIN_PC24C_PEVC_PAD_EVT0        _L(88) /**< \brief PEVC signal: PAD_EVT0 on PC24 mux C */
+#define MUX_PC24C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PC24C_PEVC_PAD_EVT0  ((PIN_PC24C_PEVC_PAD_EVT0 << 16) | MUX_PC24C_PEVC_PAD_EVT0)
+#define GPIO_PC24C_PEVC_PAD_EVT0  _UL(1 << 24)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
+#define PIN_PB13C_PEVC_PAD_EVT1        _L(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
+#define MUX_PB13C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PB13C_PEVC_PAD_EVT1  ((PIN_PB13C_PEVC_PAD_EVT1 << 16) | MUX_PB13C_PEVC_PAD_EVT1)
+#define GPIO_PB13C_PEVC_PAD_EVT1  _UL(1 << 13)
+#define PIN_PC08C_PEVC_PAD_EVT1        _L(72) /**< \brief PEVC signal: PAD_EVT1 on PC08 mux C */
+#define MUX_PC08C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PC08C_PEVC_PAD_EVT1  ((PIN_PC08C_PEVC_PAD_EVT1 << 16) | MUX_PC08C_PEVC_PAD_EVT1)
+#define GPIO_PC08C_PEVC_PAD_EVT1  _UL(1 <<  8)
+#define PIN_PC25C_PEVC_PAD_EVT1        _L(89) /**< \brief PEVC signal: PAD_EVT1 on PC25 mux C */
+#define MUX_PC25C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PC25C_PEVC_PAD_EVT1  ((PIN_PC25C_PEVC_PAD_EVT1 << 16) | MUX_PC25C_PEVC_PAD_EVT1)
+#define GPIO_PC25C_PEVC_PAD_EVT1  _UL(1 << 25)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
+#define PIN_PC11C_PEVC_PAD_EVT2        _L(75) /**< \brief PEVC signal: PAD_EVT2 on PC11 mux C */
+#define MUX_PC11C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PC11C_PEVC_PAD_EVT2  ((PIN_PC11C_PEVC_PAD_EVT2 << 16) | MUX_PC11C_PEVC_PAD_EVT2)
+#define GPIO_PC11C_PEVC_PAD_EVT2  _UL(1 << 11)
+#define PIN_PC26C_PEVC_PAD_EVT2        _L(90) /**< \brief PEVC signal: PAD_EVT2 on PC26 mux C */
+#define MUX_PC26C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PC26C_PEVC_PAD_EVT2  ((PIN_PC26C_PEVC_PAD_EVT2 << 16) | MUX_PC26C_PEVC_PAD_EVT2)
+#define GPIO_PC26C_PEVC_PAD_EVT2  _UL(1 << 26)
+#define PIN_PB09B_PEVC_PAD_EVT2        _L(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
+#define MUX_PB09B_PEVC_PAD_EVT2         _L(1)
+#define PINMUX_PB09B_PEVC_PAD_EVT2  ((PIN_PB09B_PEVC_PAD_EVT2 << 16) | MUX_PB09B_PEVC_PAD_EVT2)
+#define GPIO_PB09B_PEVC_PAD_EVT2  _UL(1 <<  9)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
+#define PIN_PC27C_PEVC_PAD_EVT3        _L(91) /**< \brief PEVC signal: PAD_EVT3 on PC27 mux C */
+#define MUX_PC27C_PEVC_PAD_EVT3         _L(2)
+#define PINMUX_PC27C_PEVC_PAD_EVT3  ((PIN_PC27C_PEVC_PAD_EVT3 << 16) | MUX_PC27C_PEVC_PAD_EVT3)
+#define GPIO_PC27C_PEVC_PAD_EVT3  _UL(1 << 27)
+#define PIN_PB10B_PEVC_PAD_EVT3        _L(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
+#define MUX_PB10B_PEVC_PAD_EVT3         _L(1)
+#define PINMUX_PB10B_PEVC_PAD_EVT3  ((PIN_PB10B_PEVC_PAD_EVT3 << 16) | MUX_PB10B_PEVC_PAD_EVT3)
+#define GPIO_PB10B_PEVC_PAD_EVT3  _UL(1 << 10)
+/* ========== GPIO definition for SCIF peripheral ========== */
+#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
+#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
+#define PIN_PB10E_SCIF_GCLK0           _L(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
+#define MUX_PB10E_SCIF_GCLK0            _L(4)
+#define PINMUX_PB10E_SCIF_GCLK0    ((PIN_PB10E_SCIF_GCLK0 << 16) | MUX_PB10E_SCIF_GCLK0)
+#define GPIO_PB10E_SCIF_GCLK0    _UL(1 << 10)
+#define PIN_PC26E_SCIF_GCLK0           _L(90) /**< \brief SCIF signal: GCLK0 on PC26 mux E */
+#define MUX_PC26E_SCIF_GCLK0            _L(4)
+#define PINMUX_PC26E_SCIF_GCLK0    ((PIN_PC26E_SCIF_GCLK0 << 16) | MUX_PC26E_SCIF_GCLK0)
+#define GPIO_PC26E_SCIF_GCLK0    _UL(1 << 26)
+#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
+#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
+#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
+#define PIN_PB11E_SCIF_GCLK1           _L(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
+#define MUX_PB11E_SCIF_GCLK1            _L(4)
+#define PINMUX_PB11E_SCIF_GCLK1    ((PIN_PB11E_SCIF_GCLK1 << 16) | MUX_PB11E_SCIF_GCLK1)
+#define GPIO_PB11E_SCIF_GCLK1    _UL(1 << 11)
+#define PIN_PC27E_SCIF_GCLK1           _L(91) /**< \brief SCIF signal: GCLK1 on PC27 mux E */
+#define MUX_PC27E_SCIF_GCLK1            _L(4)
+#define PINMUX_PC27E_SCIF_GCLK1    ((PIN_PC27E_SCIF_GCLK1 << 16) | MUX_PC27E_SCIF_GCLK1)
+#define GPIO_PC27E_SCIF_GCLK1    _UL(1 << 27)
+#define PIN_PB12E_SCIF_GCLK2           _L(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
+#define MUX_PB12E_SCIF_GCLK2            _L(4)
+#define PINMUX_PB12E_SCIF_GCLK2    ((PIN_PB12E_SCIF_GCLK2 << 16) | MUX_PB12E_SCIF_GCLK2)
+#define GPIO_PB12E_SCIF_GCLK2    _UL(1 << 12)
+#define PIN_PC28E_SCIF_GCLK2           _L(92) /**< \brief SCIF signal: GCLK2 on PC28 mux E */
+#define MUX_PC28E_SCIF_GCLK2            _L(4)
+#define PINMUX_PC28E_SCIF_GCLK2    ((PIN_PC28E_SCIF_GCLK2 << 16) | MUX_PC28E_SCIF_GCLK2)
+#define GPIO_PC28E_SCIF_GCLK2    _UL(1 << 28)
+#define PIN_PB13E_SCIF_GCLK3           _L(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
+#define MUX_PB13E_SCIF_GCLK3            _L(4)
+#define PINMUX_PB13E_SCIF_GCLK3    ((PIN_PB13E_SCIF_GCLK3 << 16) | MUX_PB13E_SCIF_GCLK3)
+#define GPIO_PB13E_SCIF_GCLK3    _UL(1 << 13)
+#define PIN_PC29E_SCIF_GCLK3           _L(93) /**< \brief SCIF signal: GCLK3 on PC29 mux E */
+#define MUX_PC29E_SCIF_GCLK3            _L(4)
+#define PINMUX_PC29E_SCIF_GCLK3    ((PIN_PC29E_SCIF_GCLK3 << 16) | MUX_PC29E_SCIF_GCLK3)
+#define GPIO_PC29E_SCIF_GCLK3    _UL(1 << 29)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
+#define PIN_PB14E_SCIF_GCLK_IN0        _L(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
+#define MUX_PB14E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PB14E_SCIF_GCLK_IN0  ((PIN_PB14E_SCIF_GCLK_IN0 << 16) | MUX_PB14E_SCIF_GCLK_IN0)
+#define GPIO_PB14E_SCIF_GCLK_IN0  _UL(1 << 14)
+#define PIN_PC30E_SCIF_GCLK_IN0        _L(94) /**< \brief SCIF signal: GCLK_IN0 on PC30 mux E */
+#define MUX_PC30E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PC30E_SCIF_GCLK_IN0  ((PIN_PC30E_SCIF_GCLK_IN0 << 16) | MUX_PC30E_SCIF_GCLK_IN0)
+#define GPIO_PC30E_SCIF_GCLK_IN0  _UL(1 << 30)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
+#define PIN_PB15E_SCIF_GCLK_IN1        _L(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
+#define MUX_PB15E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PB15E_SCIF_GCLK_IN1  ((PIN_PB15E_SCIF_GCLK_IN1 << 16) | MUX_PB15E_SCIF_GCLK_IN1)
+#define GPIO_PB15E_SCIF_GCLK_IN1  _UL(1 << 15)
+#define PIN_PC31E_SCIF_GCLK_IN1        _L(95) /**< \brief SCIF signal: GCLK_IN1 on PC31 mux E */
+#define MUX_PC31E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PC31E_SCIF_GCLK_IN1  ((PIN_PC31E_SCIF_GCLK_IN1 << 16) | MUX_PC31E_SCIF_GCLK_IN1)
+#define GPIO_PC31E_SCIF_GCLK_IN1  _UL(1 << 31)
+/* ========== GPIO definition for EIC peripheral ========== */
+#define PIN_PB01C_EIC_EXTINT0          _L(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
+#define MUX_PB01C_EIC_EXTINT0           _L(2)
+#define PINMUX_PB01C_EIC_EXTINT0   ((PIN_PB01C_EIC_EXTINT0 << 16) | MUX_PB01C_EIC_EXTINT0)
+#define GPIO_PB01C_EIC_EXTINT0   _UL(1 <<  1)
+#define PIN_PB01C_EIC_EXTINT_NUM        _L(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
+#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
+#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PC24B_EIC_EXTINT1          _L(88) /**< \brief EIC signal: EXTINT1 on PC24 mux B */
+#define MUX_PC24B_EIC_EXTINT1           _L(1)
+#define PINMUX_PC24B_EIC_EXTINT1   ((PIN_PC24B_EIC_EXTINT1 << 16) | MUX_PC24B_EIC_EXTINT1)
+#define GPIO_PC24B_EIC_EXTINT1   _UL(1 << 24)
+#define PIN_PC24B_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PC24 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PC25B_EIC_EXTINT2          _L(89) /**< \brief EIC signal: EXTINT2 on PC25 mux B */
+#define MUX_PC25B_EIC_EXTINT2           _L(1)
+#define PINMUX_PC25B_EIC_EXTINT2   ((PIN_PC25B_EIC_EXTINT2 << 16) | MUX_PC25B_EIC_EXTINT2)
+#define GPIO_PC25B_EIC_EXTINT2   _UL(1 << 25)
+#define PIN_PC25B_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PC25 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
+#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
+#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PC26B_EIC_EXTINT3          _L(90) /**< \brief EIC signal: EXTINT3 on PC26 mux B */
+#define MUX_PC26B_EIC_EXTINT3           _L(1)
+#define PINMUX_PC26B_EIC_EXTINT3   ((PIN_PC26B_EIC_EXTINT3 << 16) | MUX_PC26B_EIC_EXTINT3)
+#define GPIO_PC26B_EIC_EXTINT3   _UL(1 << 26)
+#define PIN_PC26B_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PC26 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
+#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
+#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PC27B_EIC_EXTINT4          _L(91) /**< \brief EIC signal: EXTINT4 on PC27 mux B */
+#define MUX_PC27B_EIC_EXTINT4           _L(1)
+#define PINMUX_PC27B_EIC_EXTINT4   ((PIN_PC27B_EIC_EXTINT4 << 16) | MUX_PC27B_EIC_EXTINT4)
+#define GPIO_PC27B_EIC_EXTINT4   _UL(1 << 27)
+#define PIN_PC27B_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PC27 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
+#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PC03B_EIC_EXTINT5          _L(67) /**< \brief EIC signal: EXTINT5 on PC03 mux B */
+#define MUX_PC03B_EIC_EXTINT5           _L(1)
+#define PINMUX_PC03B_EIC_EXTINT5   ((PIN_PC03B_EIC_EXTINT5 << 16) | MUX_PC03B_EIC_EXTINT5)
+#define GPIO_PC03B_EIC_EXTINT5   _UL(1 <<  3)
+#define PIN_PC03B_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PC03 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
+#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PC04B_EIC_EXTINT6          _L(68) /**< \brief EIC signal: EXTINT6 on PC04 mux B */
+#define MUX_PC04B_EIC_EXTINT6           _L(1)
+#define PINMUX_PC04B_EIC_EXTINT6   ((PIN_PC04B_EIC_EXTINT6 << 16) | MUX_PC04B_EIC_EXTINT6)
+#define GPIO_PC04B_EIC_EXTINT6   _UL(1 <<  4)
+#define PIN_PC04B_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PC04 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
+#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PC05B_EIC_EXTINT7          _L(69) /**< \brief EIC signal: EXTINT7 on PC05 mux B */
+#define MUX_PC05B_EIC_EXTINT7           _L(1)
+#define PINMUX_PC05B_EIC_EXTINT7   ((PIN_PC05B_EIC_EXTINT7 << 16) | MUX_PC05B_EIC_EXTINT7)
+#define GPIO_PC05B_EIC_EXTINT7   _UL(1 <<  5)
+#define PIN_PC05B_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PC05 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
+#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PC06B_EIC_EXTINT8          _L(70) /**< \brief EIC signal: EXTINT8 on PC06 mux B */
+#define MUX_PC06B_EIC_EXTINT8           _L(1)
+#define PINMUX_PC06B_EIC_EXTINT8   ((PIN_PC06B_EIC_EXTINT8 << 16) | MUX_PC06B_EIC_EXTINT8)
+#define GPIO_PC06B_EIC_EXTINT8   _UL(1 <<  6)
+#define PIN_PC06B_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PC06 External Interrupt Line */
+
+#endif /* _SAM4LS2C_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4ls4a.h
+++ b/asf/sam/include/sam4l/pio/sam4ls4a.h
@@ -1,0 +1,737 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAM4LS4A
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LS4A_PIO_
+#define _SAM4LS4A_PIO_
+
+#define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
+#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
+#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
+#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
+#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
+#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
+#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
+#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
+#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
+#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
+#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
+#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
+#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
+#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
+#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
+#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
+#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
+#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
+#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
+#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
+#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
+#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
+#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
+#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
+#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
+#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
+#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
+#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
+#define GPIO_PA27                _UL(1 << 27) /**< \brief GPIO Mask  for PA27 */
+#define PIN_PA28                          28  /**< \brief Pin Number for PA28 */
+#define GPIO_PA28                _UL(1 << 28) /**< \brief GPIO Mask  for PA28 */
+#define PIN_PA29                          29  /**< \brief Pin Number for PA29 */
+#define GPIO_PA29                _UL(1 << 29) /**< \brief GPIO Mask  for PA29 */
+#define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
+#define GPIO_PA30                _UL(1 << 30) /**< \brief GPIO Mask  for PA30 */
+#define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
+#define GPIO_PA31                _UL(1 << 31) /**< \brief GPIO Mask  for PA31 */
+/* ========== GPIO definition for TWIMS0 peripheral ========== */
+#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
+#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+/* ========== GPIO definition for TWIMS2 peripheral ========== */
+#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
+#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+/* ========== GPIO definition for IISC peripheral ========== */
+#define PIN_PA31B_IISC_IMCK            _L(31) /**< \brief IISC signal: IMCK on PA31 mux B */
+#define MUX_PA31B_IISC_IMCK             _L(1)
+#define PINMUX_PA31B_IISC_IMCK     ((PIN_PA31B_IISC_IMCK << 16) | MUX_PA31B_IISC_IMCK)
+#define GPIO_PA31B_IISC_IMCK     _UL(1 << 31)
+#define PIN_PA27B_IISC_ISCK            _L(27) /**< \brief IISC signal: ISCK on PA27 mux B */
+#define MUX_PA27B_IISC_ISCK             _L(1)
+#define PINMUX_PA27B_IISC_ISCK     ((PIN_PA27B_IISC_ISCK << 16) | MUX_PA27B_IISC_ISCK)
+#define GPIO_PA27B_IISC_ISCK     _UL(1 << 27)
+#define PIN_PA28B_IISC_ISDI            _L(28) /**< \brief IISC signal: ISDI on PA28 mux B */
+#define MUX_PA28B_IISC_ISDI             _L(1)
+#define PINMUX_PA28B_IISC_ISDI     ((PIN_PA28B_IISC_ISDI << 16) | MUX_PA28B_IISC_ISDI)
+#define GPIO_PA28B_IISC_ISDI     _UL(1 << 28)
+#define PIN_PA30B_IISC_ISDO            _L(30) /**< \brief IISC signal: ISDO on PA30 mux B */
+#define MUX_PA30B_IISC_ISDO             _L(1)
+#define PINMUX_PA30B_IISC_ISDO     ((PIN_PA30B_IISC_ISDO << 16) | MUX_PA30B_IISC_ISDO)
+#define GPIO_PA30B_IISC_ISDO     _UL(1 << 30)
+#define PIN_PA29B_IISC_IWS             _L(29) /**< \brief IISC signal: IWS on PA29 mux B */
+#define MUX_PA29B_IISC_IWS              _L(1)
+#define PINMUX_PA29B_IISC_IWS      ((PIN_PA29B_IISC_IWS << 16) | MUX_PA29B_IISC_IWS)
+#define GPIO_PA29B_IISC_IWS      _UL(1 << 29)
+/* ========== GPIO definition for SPI peripheral ========== */
+#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L(1)
+#define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
+#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
+#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L(0)
+#define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
+#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
+#define PIN_PA27A_SPI_MISO             _L(27) /**< \brief SPI signal: MISO on PA27 mux A */
+#define MUX_PA27A_SPI_MISO              _L(0)
+#define PINMUX_PA27A_SPI_MISO      ((PIN_PA27A_SPI_MISO << 16) | MUX_PA27A_SPI_MISO)
+#define GPIO_PA27A_SPI_MISO      _UL(1 << 27)
+#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L(0)
+#define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
+#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
+#define PIN_PA28A_SPI_MOSI             _L(28) /**< \brief SPI signal: MOSI on PA28 mux A */
+#define MUX_PA28A_SPI_MOSI              _L(0)
+#define PINMUX_PA28A_SPI_MOSI      ((PIN_PA28A_SPI_MOSI << 16) | MUX_PA28A_SPI_MOSI)
+#define GPIO_PA28A_SPI_MOSI      _UL(1 << 28)
+#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
+#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
+#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
+#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
+#define PIN_PA30A_SPI_NPCS0            _L(30) /**< \brief SPI signal: NPCS0 on PA30 mux A */
+#define MUX_PA30A_SPI_NPCS0             _L(0)
+#define PINMUX_PA30A_SPI_NPCS0     ((PIN_PA30A_SPI_NPCS0 << 16) | MUX_PA30A_SPI_NPCS0)
+#define GPIO_PA30A_SPI_NPCS0     _UL(1 << 30)
+#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
+#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PA31A_SPI_NPCS1            _L(31) /**< \brief SPI signal: NPCS1 on PA31 mux A */
+#define MUX_PA31A_SPI_NPCS1             _L(0)
+#define PINMUX_PA31A_SPI_NPCS1     ((PIN_PA31A_SPI_NPCS1 << 16) | MUX_PA31A_SPI_NPCS1)
+#define GPIO_PA31A_SPI_NPCS1     _UL(1 << 31)
+#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
+#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
+#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
+#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
+#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L(0)
+#define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
+#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
+#define PIN_PA29A_SPI_SCK              _L(29) /**< \brief SPI signal: SCK on PA29 mux A */
+#define MUX_PA29A_SPI_SCK               _L(0)
+#define PINMUX_PA29A_SPI_SCK       ((PIN_PA29A_SPI_SCK << 16) | MUX_PA29A_SPI_SCK)
+#define GPIO_PA29A_SPI_SCK       _UL(1 << 29)
+/* ========== GPIO definition for TC0 peripheral ========== */
+#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L(1)
+#define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
+#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
+#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L(1)
+#define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
+#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
+#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L(1)
+#define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
+#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
+#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L(1)
+#define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
+#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
+#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L(1)
+#define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
+#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
+#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L(1)
+#define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
+#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L(1)
+#define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
+#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L(1)
+#define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
+#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L(1)
+#define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
+#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+/* ========== GPIO definition for USART0 peripheral ========== */
+#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L(1)
+#define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
+#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
+#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L(0)
+#define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
+#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
+#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L(0)
+#define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
+#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
+#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L(1)
+#define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
+#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
+#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L(0)
+#define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
+#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
+#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L(1)
+#define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
+#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
+#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L(0)
+#define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
+#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
+#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L(1)
+#define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
+#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
+#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L(0)
+#define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
+#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
+/* ========== GPIO definition for USART1 peripheral ========== */
+#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L(0)
+#define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
+#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
+#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L(1)
+#define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
+#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
+#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L(0)
+#define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
+#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
+#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L(0)
+#define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
+#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
+#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L(0)
+#define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
+#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+/* ========== GPIO definition for USART2 peripheral ========== */
+#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L(0)
+#define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
+#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
+#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L(1)
+#define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
+#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
+#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L(0)
+#define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
+#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L(1)
+#define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
+#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
+#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L(0)
+#define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
+#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L(1)
+#define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
+#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
+#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L(0)
+#define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
+#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+/* ========== GPIO definition for USART3 peripheral ========== */
+#define PIN_PA29E_USART3_CLK           _L(29) /**< \brief USART3 signal: CLK on PA29 mux E */
+#define MUX_PA29E_USART3_CLK            _L(4)
+#define PINMUX_PA29E_USART3_CLK    ((PIN_PA29E_USART3_CLK << 16) | MUX_PA29E_USART3_CLK)
+#define GPIO_PA29E_USART3_CLK    _UL(1 << 29)
+#define PIN_PA28E_USART3_CTS           _L(28) /**< \brief USART3 signal: CTS on PA28 mux E */
+#define MUX_PA28E_USART3_CTS            _L(4)
+#define PINMUX_PA28E_USART3_CTS    ((PIN_PA28E_USART3_CTS << 16) | MUX_PA28E_USART3_CTS)
+#define GPIO_PA28E_USART3_CTS    _UL(1 << 28)
+#define PIN_PA27E_USART3_RTS           _L(27) /**< \brief USART3 signal: RTS on PA27 mux E */
+#define MUX_PA27E_USART3_RTS            _L(4)
+#define PINMUX_PA27E_USART3_RTS    ((PIN_PA27E_USART3_RTS << 16) | MUX_PA27E_USART3_RTS)
+#define GPIO_PA27E_USART3_RTS    _UL(1 << 27)
+#define PIN_PA30E_USART3_RXD           _L(30) /**< \brief USART3 signal: RXD on PA30 mux E */
+#define MUX_PA30E_USART3_RXD            _L(4)
+#define PINMUX_PA30E_USART3_RXD    ((PIN_PA30E_USART3_RXD << 16) | MUX_PA30E_USART3_RXD)
+#define GPIO_PA30E_USART3_RXD    _UL(1 << 30)
+#define PIN_PA31E_USART3_TXD           _L(31) /**< \brief USART3 signal: TXD on PA31 mux E */
+#define MUX_PA31E_USART3_TXD            _L(4)
+#define PINMUX_PA31E_USART3_TXD    ((PIN_PA31E_USART3_TXD << 16) | MUX_PA31E_USART3_TXD)
+#define GPIO_PA31E_USART3_TXD    _UL(1 << 31)
+/* ========== GPIO definition for ADCIFE peripheral ========== */
+#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
+#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
+#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+/* ========== GPIO definition for DACC peripheral ========== */
+#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L(0)
+#define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
+#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+/* ========== GPIO definition for ACIFC peripheral ========== */
+#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
+#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
+/* ========== GPIO definition for GLOC peripheral ========== */
+#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
+#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L(3)
+#define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
+#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L(3)
+#define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
+#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L(3)
+#define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
+#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L(3)
+#define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
+#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L(3)
+#define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
+#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L(3)
+#define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
+#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L(3)
+#define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
+#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
+#define PIN_PA27D_GLOC_IN4             _L(27) /**< \brief GLOC signal: IN4 on PA27 mux D */
+#define MUX_PA27D_GLOC_IN4              _L(3)
+#define PINMUX_PA27D_GLOC_IN4      ((PIN_PA27D_GLOC_IN4 << 16) | MUX_PA27D_GLOC_IN4)
+#define GPIO_PA27D_GLOC_IN4      _UL(1 << 27)
+#define PIN_PA28D_GLOC_IN5             _L(28) /**< \brief GLOC signal: IN5 on PA28 mux D */
+#define MUX_PA28D_GLOC_IN5              _L(3)
+#define PINMUX_PA28D_GLOC_IN5      ((PIN_PA28D_GLOC_IN5 << 16) | MUX_PA28D_GLOC_IN5)
+#define GPIO_PA28D_GLOC_IN5      _UL(1 << 28)
+#define PIN_PA29D_GLOC_IN6             _L(29) /**< \brief GLOC signal: IN6 on PA29 mux D */
+#define MUX_PA29D_GLOC_IN6              _L(3)
+#define PINMUX_PA29D_GLOC_IN6      ((PIN_PA29D_GLOC_IN6 << 16) | MUX_PA29D_GLOC_IN6)
+#define GPIO_PA29D_GLOC_IN6      _UL(1 << 29)
+#define PIN_PA30D_GLOC_IN7             _L(30) /**< \brief GLOC signal: IN7 on PA30 mux D */
+#define MUX_PA30D_GLOC_IN7              _L(3)
+#define PINMUX_PA30D_GLOC_IN7      ((PIN_PA30D_GLOC_IN7 << 16) | MUX_PA30D_GLOC_IN7)
+#define GPIO_PA30D_GLOC_IN7      _UL(1 << 30)
+#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
+#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
+#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
+#define PIN_PA31D_GLOC_OUT1            _L(31) /**< \brief GLOC signal: OUT1 on PA31 mux D */
+#define MUX_PA31D_GLOC_OUT1             _L(3)
+#define PINMUX_PA31D_GLOC_OUT1     ((PIN_PA31D_GLOC_OUT1 << 16) | MUX_PA31D_GLOC_OUT1)
+#define GPIO_PA31D_GLOC_OUT1     _UL(1 << 31)
+/* ========== GPIO definition for ABDACB peripheral ========== */
+#define PIN_PA31C_ABDACB_CLK           _L(31) /**< \brief ABDACB signal: CLK on PA31 mux C */
+#define MUX_PA31C_ABDACB_CLK            _L(2)
+#define PINMUX_PA31C_ABDACB_CLK    ((PIN_PA31C_ABDACB_CLK << 16) | MUX_PA31C_ABDACB_CLK)
+#define GPIO_PA31C_ABDACB_CLK    _UL(1 << 31)
+#define PIN_PA27C_ABDACB_DAC0          _L(27) /**< \brief ABDACB signal: DAC0 on PA27 mux C */
+#define MUX_PA27C_ABDACB_DAC0           _L(2)
+#define PINMUX_PA27C_ABDACB_DAC0   ((PIN_PA27C_ABDACB_DAC0 << 16) | MUX_PA27C_ABDACB_DAC0)
+#define GPIO_PA27C_ABDACB_DAC0   _UL(1 << 27)
+#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
+#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
+#define PIN_PA29C_ABDACB_DAC1          _L(29) /**< \brief ABDACB signal: DAC1 on PA29 mux C */
+#define MUX_PA29C_ABDACB_DAC1           _L(2)
+#define PINMUX_PA29C_ABDACB_DAC1   ((PIN_PA29C_ABDACB_DAC1 << 16) | MUX_PA29C_ABDACB_DAC1)
+#define GPIO_PA29C_ABDACB_DAC1   _UL(1 << 29)
+#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
+#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
+#define PIN_PA28C_ABDACB_DACN0         _L(28) /**< \brief ABDACB signal: DACN0 on PA28 mux C */
+#define MUX_PA28C_ABDACB_DACN0          _L(2)
+#define PINMUX_PA28C_ABDACB_DACN0  ((PIN_PA28C_ABDACB_DACN0 << 16) | MUX_PA28C_ABDACB_DACN0)
+#define GPIO_PA28C_ABDACB_DACN0  _UL(1 << 28)
+#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
+#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
+#define PIN_PA30C_ABDACB_DACN1         _L(30) /**< \brief ABDACB signal: DACN1 on PA30 mux C */
+#define MUX_PA30C_ABDACB_DACN1          _L(2)
+#define PINMUX_PA30C_ABDACB_DACN1  ((PIN_PA30C_ABDACB_DACN1 << 16) | MUX_PA30C_ABDACB_DACN1)
+#define GPIO_PA30C_ABDACB_DACN1  _UL(1 << 30)
+#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
+#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+/* ========== GPIO definition for PARC peripheral ========== */
+#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
+#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
+#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
+#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
+#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
+#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
+#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
+#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
+#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
+#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
+#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
+#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
+#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
+#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
+#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
+#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
+#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
+#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
+#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
+#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
+#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+/* ========== GPIO definition for CATB peripheral ========== */
+#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L(6)
+#define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
+#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L(6)
+#define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
+#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L(6)
+#define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
+#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
+#define PIN_PA31G_CATB_DIS             _L(31) /**< \brief CATB signal: DIS on PA31 mux G */
+#define MUX_PA31G_CATB_DIS              _L(6)
+#define PINMUX_PA31G_CATB_DIS      ((PIN_PA31G_CATB_DIS << 16) | MUX_PA31G_CATB_DIS)
+#define GPIO_PA31G_CATB_DIS      _UL(1 << 31)
+#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
+#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
+#define PIN_PA27G_CATB_SENSE0          _L(27) /**< \brief CATB signal: SENSE0 on PA27 mux G */
+#define MUX_PA27G_CATB_SENSE0           _L(6)
+#define PINMUX_PA27G_CATB_SENSE0   ((PIN_PA27G_CATB_SENSE0 << 16) | MUX_PA27G_CATB_SENSE0)
+#define GPIO_PA27G_CATB_SENSE0   _UL(1 << 27)
+#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
+#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
+#define PIN_PA28G_CATB_SENSE1          _L(28) /**< \brief CATB signal: SENSE1 on PA28 mux G */
+#define MUX_PA28G_CATB_SENSE1           _L(6)
+#define PINMUX_PA28G_CATB_SENSE1   ((PIN_PA28G_CATB_SENSE1 << 16) | MUX_PA28G_CATB_SENSE1)
+#define GPIO_PA28G_CATB_SENSE1   _UL(1 << 28)
+#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
+#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
+#define PIN_PA29G_CATB_SENSE2          _L(29) /**< \brief CATB signal: SENSE2 on PA29 mux G */
+#define MUX_PA29G_CATB_SENSE2           _L(6)
+#define PINMUX_PA29G_CATB_SENSE2   ((PIN_PA29G_CATB_SENSE2 << 16) | MUX_PA29G_CATB_SENSE2)
+#define GPIO_PA29G_CATB_SENSE2   _UL(1 << 29)
+#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
+#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
+#define PIN_PA30G_CATB_SENSE3          _L(30) /**< \brief CATB signal: SENSE3 on PA30 mux G */
+#define MUX_PA30G_CATB_SENSE3           _L(6)
+#define PINMUX_PA30G_CATB_SENSE3   ((PIN_PA30G_CATB_SENSE3 << 16) | MUX_PA30G_CATB_SENSE3)
+#define GPIO_PA30G_CATB_SENSE3   _UL(1 << 30)
+#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
+#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
+#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
+#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
+#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
+#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
+#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
+#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
+#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
+#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
+#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
+#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
+#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
+#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
+#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
+#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
+#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
+#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
+#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
+#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
+#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
+#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
+#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
+#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
+#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
+#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
+#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
+#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
+#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
+#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
+#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
+#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
+#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
+#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
+/* ========== GPIO definition for USBC peripheral ========== */
+#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L(0)
+#define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
+#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
+#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L(0)
+#define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
+#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+/* ========== GPIO definition for PEVC peripheral ========== */
+#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
+/* ========== GPIO definition for SCIF peripheral ========== */
+#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
+#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
+#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
+#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
+#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
+/* ========== GPIO definition for EIC peripheral ========== */
+#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
+#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
+#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
+#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
+#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
+#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
+#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
+#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
+#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
+#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
+#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+
+#endif /* _SAM4LS4A_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4ls4a.h
+++ b/asf/sam/include/sam4l/pio/sam4ls4a.h
@@ -30,708 +30,708 @@
 #define _SAM4LS4A_PIO_
 
 #define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
-#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define GPIO_PA00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PA00 */
 #define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
-#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define GPIO_PA01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PA01 */
 #define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
-#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define GPIO_PA02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PA02 */
 #define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
-#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define GPIO_PA03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PA03 */
 #define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
-#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define GPIO_PA04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PA04 */
 #define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
-#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define GPIO_PA05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PA05 */
 #define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
-#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define GPIO_PA06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PA06 */
 #define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
-#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define GPIO_PA07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PA07 */
 #define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
-#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define GPIO_PA08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PA08 */
 #define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
-#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define GPIO_PA09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PA09 */
 #define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
-#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define GPIO_PA10                _UL_(1 << 10) /**< \brief GPIO Mask  for PA10 */
 #define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
-#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define GPIO_PA11                _UL_(1 << 11) /**< \brief GPIO Mask  for PA11 */
 #define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
-#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define GPIO_PA12                _UL_(1 << 12) /**< \brief GPIO Mask  for PA12 */
 #define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
-#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define GPIO_PA13                _UL_(1 << 13) /**< \brief GPIO Mask  for PA13 */
 #define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
-#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define GPIO_PA14                _UL_(1 << 14) /**< \brief GPIO Mask  for PA14 */
 #define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
-#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define GPIO_PA15                _UL_(1 << 15) /**< \brief GPIO Mask  for PA15 */
 #define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
-#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define GPIO_PA16                _UL_(1 << 16) /**< \brief GPIO Mask  for PA16 */
 #define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
-#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define GPIO_PA17                _UL_(1 << 17) /**< \brief GPIO Mask  for PA17 */
 #define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
-#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define GPIO_PA18                _UL_(1 << 18) /**< \brief GPIO Mask  for PA18 */
 #define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
-#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define GPIO_PA19                _UL_(1 << 19) /**< \brief GPIO Mask  for PA19 */
 #define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
-#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define GPIO_PA20                _UL_(1 << 20) /**< \brief GPIO Mask  for PA20 */
 #define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
-#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define GPIO_PA21                _UL_(1 << 21) /**< \brief GPIO Mask  for PA21 */
 #define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
-#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define GPIO_PA22                _UL_(1 << 22) /**< \brief GPIO Mask  for PA22 */
 #define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
-#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define GPIO_PA23                _UL_(1 << 23) /**< \brief GPIO Mask  for PA23 */
 #define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
-#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define GPIO_PA24                _UL_(1 << 24) /**< \brief GPIO Mask  for PA24 */
 #define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
-#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define GPIO_PA25                _UL_(1 << 25) /**< \brief GPIO Mask  for PA25 */
 #define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
-#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define GPIO_PA26                _UL_(1 << 26) /**< \brief GPIO Mask  for PA26 */
 #define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
-#define GPIO_PA27                _UL(1 << 27) /**< \brief GPIO Mask  for PA27 */
+#define GPIO_PA27                _UL_(1 << 27) /**< \brief GPIO Mask  for PA27 */
 #define PIN_PA28                          28  /**< \brief Pin Number for PA28 */
-#define GPIO_PA28                _UL(1 << 28) /**< \brief GPIO Mask  for PA28 */
+#define GPIO_PA28                _UL_(1 << 28) /**< \brief GPIO Mask  for PA28 */
 #define PIN_PA29                          29  /**< \brief Pin Number for PA29 */
-#define GPIO_PA29                _UL(1 << 29) /**< \brief GPIO Mask  for PA29 */
+#define GPIO_PA29                _UL_(1 << 29) /**< \brief GPIO Mask  for PA29 */
 #define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
-#define GPIO_PA30                _UL(1 << 30) /**< \brief GPIO Mask  for PA30 */
+#define GPIO_PA30                _UL_(1 << 30) /**< \brief GPIO Mask  for PA30 */
 #define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
-#define GPIO_PA31                _UL(1 << 31) /**< \brief GPIO Mask  for PA31 */
+#define GPIO_PA31                _UL_(1 << 31) /**< \brief GPIO Mask  for PA31 */
 /* ========== GPIO definition for TWIMS0 peripheral ========== */
-#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
-#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PIN_PA24B_TWIMS0_TWCK          _L_(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L_(1)
 #define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
-#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
-#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
-#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL_(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L_(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L_(1)
 #define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
-#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+#define GPIO_PA23B_TWIMS0_TWD    _UL_(1 << 23)
 /* ========== GPIO definition for TWIMS2 peripheral ========== */
-#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
-#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PIN_PA22E_TWIMS2_TWCK          _L_(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L_(4)
 #define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
-#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
-#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
-#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL_(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L_(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L_(4)
 #define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
-#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+#define GPIO_PA21E_TWIMS2_TWD    _UL_(1 << 21)
 /* ========== GPIO definition for IISC peripheral ========== */
-#define PIN_PA31B_IISC_IMCK            _L(31) /**< \brief IISC signal: IMCK on PA31 mux B */
-#define MUX_PA31B_IISC_IMCK             _L(1)
+#define PIN_PA31B_IISC_IMCK            _L_(31) /**< \brief IISC signal: IMCK on PA31 mux B */
+#define MUX_PA31B_IISC_IMCK             _L_(1)
 #define PINMUX_PA31B_IISC_IMCK     ((PIN_PA31B_IISC_IMCK << 16) | MUX_PA31B_IISC_IMCK)
-#define GPIO_PA31B_IISC_IMCK     _UL(1 << 31)
-#define PIN_PA27B_IISC_ISCK            _L(27) /**< \brief IISC signal: ISCK on PA27 mux B */
-#define MUX_PA27B_IISC_ISCK             _L(1)
+#define GPIO_PA31B_IISC_IMCK     _UL_(1 << 31)
+#define PIN_PA27B_IISC_ISCK            _L_(27) /**< \brief IISC signal: ISCK on PA27 mux B */
+#define MUX_PA27B_IISC_ISCK             _L_(1)
 #define PINMUX_PA27B_IISC_ISCK     ((PIN_PA27B_IISC_ISCK << 16) | MUX_PA27B_IISC_ISCK)
-#define GPIO_PA27B_IISC_ISCK     _UL(1 << 27)
-#define PIN_PA28B_IISC_ISDI            _L(28) /**< \brief IISC signal: ISDI on PA28 mux B */
-#define MUX_PA28B_IISC_ISDI             _L(1)
+#define GPIO_PA27B_IISC_ISCK     _UL_(1 << 27)
+#define PIN_PA28B_IISC_ISDI            _L_(28) /**< \brief IISC signal: ISDI on PA28 mux B */
+#define MUX_PA28B_IISC_ISDI             _L_(1)
 #define PINMUX_PA28B_IISC_ISDI     ((PIN_PA28B_IISC_ISDI << 16) | MUX_PA28B_IISC_ISDI)
-#define GPIO_PA28B_IISC_ISDI     _UL(1 << 28)
-#define PIN_PA30B_IISC_ISDO            _L(30) /**< \brief IISC signal: ISDO on PA30 mux B */
-#define MUX_PA30B_IISC_ISDO             _L(1)
+#define GPIO_PA28B_IISC_ISDI     _UL_(1 << 28)
+#define PIN_PA30B_IISC_ISDO            _L_(30) /**< \brief IISC signal: ISDO on PA30 mux B */
+#define MUX_PA30B_IISC_ISDO             _L_(1)
 #define PINMUX_PA30B_IISC_ISDO     ((PIN_PA30B_IISC_ISDO << 16) | MUX_PA30B_IISC_ISDO)
-#define GPIO_PA30B_IISC_ISDO     _UL(1 << 30)
-#define PIN_PA29B_IISC_IWS             _L(29) /**< \brief IISC signal: IWS on PA29 mux B */
-#define MUX_PA29B_IISC_IWS              _L(1)
+#define GPIO_PA30B_IISC_ISDO     _UL_(1 << 30)
+#define PIN_PA29B_IISC_IWS             _L_(29) /**< \brief IISC signal: IWS on PA29 mux B */
+#define MUX_PA29B_IISC_IWS              _L_(1)
 #define PINMUX_PA29B_IISC_IWS      ((PIN_PA29B_IISC_IWS << 16) | MUX_PA29B_IISC_IWS)
-#define GPIO_PA29B_IISC_IWS      _UL(1 << 29)
+#define GPIO_PA29B_IISC_IWS      _UL_(1 << 29)
 /* ========== GPIO definition for SPI peripheral ========== */
-#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
-#define MUX_PA03B_SPI_MISO              _L(1)
+#define PIN_PA03B_SPI_MISO              _L_(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L_(1)
 #define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
-#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
-#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
-#define MUX_PA21A_SPI_MISO              _L(0)
+#define GPIO_PA03B_SPI_MISO      _UL_(1 <<  3)
+#define PIN_PA21A_SPI_MISO             _L_(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L_(0)
 #define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
-#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
-#define PIN_PA27A_SPI_MISO             _L(27) /**< \brief SPI signal: MISO on PA27 mux A */
-#define MUX_PA27A_SPI_MISO              _L(0)
+#define GPIO_PA21A_SPI_MISO      _UL_(1 << 21)
+#define PIN_PA27A_SPI_MISO             _L_(27) /**< \brief SPI signal: MISO on PA27 mux A */
+#define MUX_PA27A_SPI_MISO              _L_(0)
 #define PINMUX_PA27A_SPI_MISO      ((PIN_PA27A_SPI_MISO << 16) | MUX_PA27A_SPI_MISO)
-#define GPIO_PA27A_SPI_MISO      _UL(1 << 27)
-#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
-#define MUX_PA22A_SPI_MOSI              _L(0)
+#define GPIO_PA27A_SPI_MISO      _UL_(1 << 27)
+#define PIN_PA22A_SPI_MOSI             _L_(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L_(0)
 #define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
-#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
-#define PIN_PA28A_SPI_MOSI             _L(28) /**< \brief SPI signal: MOSI on PA28 mux A */
-#define MUX_PA28A_SPI_MOSI              _L(0)
+#define GPIO_PA22A_SPI_MOSI      _UL_(1 << 22)
+#define PIN_PA28A_SPI_MOSI             _L_(28) /**< \brief SPI signal: MOSI on PA28 mux A */
+#define MUX_PA28A_SPI_MOSI              _L_(0)
 #define PINMUX_PA28A_SPI_MOSI      ((PIN_PA28A_SPI_MOSI << 16) | MUX_PA28A_SPI_MOSI)
-#define GPIO_PA28A_SPI_MOSI      _UL(1 << 28)
-#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
-#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define GPIO_PA28A_SPI_MOSI      _UL_(1 << 28)
+#define PIN_PA02B_SPI_NPCS0             _L_(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L_(1)
 #define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
-#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
-#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
-#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define GPIO_PA02B_SPI_NPCS0     _UL_(1 <<  2)
+#define PIN_PA24A_SPI_NPCS0            _L_(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L_(0)
 #define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
-#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
-#define PIN_PA30A_SPI_NPCS0            _L(30) /**< \brief SPI signal: NPCS0 on PA30 mux A */
-#define MUX_PA30A_SPI_NPCS0             _L(0)
+#define GPIO_PA24A_SPI_NPCS0     _UL_(1 << 24)
+#define PIN_PA30A_SPI_NPCS0            _L_(30) /**< \brief SPI signal: NPCS0 on PA30 mux A */
+#define MUX_PA30A_SPI_NPCS0             _L_(0)
 #define PINMUX_PA30A_SPI_NPCS0     ((PIN_PA30A_SPI_NPCS0 << 16) | MUX_PA30A_SPI_NPCS0)
-#define GPIO_PA30A_SPI_NPCS0     _UL(1 << 30)
-#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
-#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define GPIO_PA30A_SPI_NPCS0     _UL_(1 << 30)
+#define PIN_PA13C_SPI_NPCS1            _L_(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L_(2)
 #define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
-#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PA31A_SPI_NPCS1            _L(31) /**< \brief SPI signal: NPCS1 on PA31 mux A */
-#define MUX_PA31A_SPI_NPCS1             _L(0)
+#define GPIO_PA13C_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PA31A_SPI_NPCS1            _L_(31) /**< \brief SPI signal: NPCS1 on PA31 mux A */
+#define MUX_PA31A_SPI_NPCS1             _L_(0)
 #define PINMUX_PA31A_SPI_NPCS1     ((PIN_PA31A_SPI_NPCS1 << 16) | MUX_PA31A_SPI_NPCS1)
-#define GPIO_PA31A_SPI_NPCS1     _UL(1 << 31)
-#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
-#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define GPIO_PA31A_SPI_NPCS1     _UL_(1 << 31)
+#define PIN_PA14C_SPI_NPCS2            _L_(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L_(2)
 #define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
-#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
-#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
-#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define GPIO_PA14C_SPI_NPCS2     _UL_(1 << 14)
+#define PIN_PA15C_SPI_NPCS3            _L_(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L_(2)
 #define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
-#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
-#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
-#define MUX_PA23A_SPI_SCK               _L(0)
+#define GPIO_PA15C_SPI_NPCS3     _UL_(1 << 15)
+#define PIN_PA23A_SPI_SCK              _L_(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L_(0)
 #define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
-#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
-#define PIN_PA29A_SPI_SCK              _L(29) /**< \brief SPI signal: SCK on PA29 mux A */
-#define MUX_PA29A_SPI_SCK               _L(0)
+#define GPIO_PA23A_SPI_SCK       _UL_(1 << 23)
+#define PIN_PA29A_SPI_SCK              _L_(29) /**< \brief SPI signal: SCK on PA29 mux A */
+#define MUX_PA29A_SPI_SCK               _L_(0)
 #define PINMUX_PA29A_SPI_SCK       ((PIN_PA29A_SPI_SCK << 16) | MUX_PA29A_SPI_SCK)
-#define GPIO_PA29A_SPI_SCK       _UL(1 << 29)
+#define GPIO_PA29A_SPI_SCK       _UL_(1 << 29)
 /* ========== GPIO definition for TC0 peripheral ========== */
-#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
-#define MUX_PA08B_TC0_A0                _L(1)
+#define PIN_PA08B_TC0_A0                _L_(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L_(1)
 #define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
-#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
-#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
-#define MUX_PA10B_TC0_A1                _L(1)
+#define GPIO_PA08B_TC0_A0        _UL_(1 <<  8)
+#define PIN_PA10B_TC0_A1               _L_(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L_(1)
 #define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
-#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
-#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
-#define MUX_PA12B_TC0_A2                _L(1)
+#define GPIO_PA10B_TC0_A1        _UL_(1 << 10)
+#define PIN_PA12B_TC0_A2               _L_(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L_(1)
 #define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
-#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
-#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
-#define MUX_PA09B_TC0_B0                _L(1)
+#define GPIO_PA12B_TC0_A2        _UL_(1 << 12)
+#define PIN_PA09B_TC0_B0                _L_(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L_(1)
 #define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
-#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
-#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
-#define MUX_PA11B_TC0_B1                _L(1)
+#define GPIO_PA09B_TC0_B0        _UL_(1 <<  9)
+#define PIN_PA11B_TC0_B1               _L_(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L_(1)
 #define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
-#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
-#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
-#define MUX_PA13B_TC0_B2                _L(1)
+#define GPIO_PA11B_TC0_B1        _UL_(1 << 11)
+#define PIN_PA13B_TC0_B2               _L_(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L_(1)
 #define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
-#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
-#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
-#define MUX_PA14B_TC0_CLK0              _L(1)
+#define GPIO_PA13B_TC0_B2        _UL_(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L_(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L_(1)
 #define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
-#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
-#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
-#define MUX_PA15B_TC0_CLK1              _L(1)
+#define GPIO_PA14B_TC0_CLK0      _UL_(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L_(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L_(1)
 #define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
-#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
-#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
-#define MUX_PA16B_TC0_CLK2              _L(1)
+#define GPIO_PA15B_TC0_CLK1      _UL_(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L_(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L_(1)
 #define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
-#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+#define GPIO_PA16B_TC0_CLK2      _UL_(1 << 16)
 /* ========== GPIO definition for USART0 peripheral ========== */
-#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
-#define MUX_PA04B_USART0_CLK            _L(1)
+#define PIN_PA04B_USART0_CLK            _L_(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L_(1)
 #define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
-#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
-#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
-#define MUX_PA10A_USART0_CLK            _L(0)
+#define GPIO_PA04B_USART0_CLK    _UL_(1 <<  4)
+#define PIN_PA10A_USART0_CLK           _L_(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L_(0)
 #define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
-#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
-#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
-#define MUX_PA09A_USART0_CTS            _L(0)
+#define GPIO_PA10A_USART0_CLK    _UL_(1 << 10)
+#define PIN_PA09A_USART0_CTS            _L_(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L_(0)
 #define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
-#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
-#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
-#define MUX_PA06B_USART0_RTS            _L(1)
+#define GPIO_PA09A_USART0_CTS    _UL_(1 <<  9)
+#define PIN_PA06B_USART0_RTS            _L_(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L_(1)
 #define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
-#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
-#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
-#define MUX_PA08A_USART0_RTS            _L(0)
+#define GPIO_PA06B_USART0_RTS    _UL_(1 <<  6)
+#define PIN_PA08A_USART0_RTS            _L_(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L_(0)
 #define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
-#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
-#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
-#define MUX_PA05B_USART0_RXD            _L(1)
+#define GPIO_PA08A_USART0_RTS    _UL_(1 <<  8)
+#define PIN_PA05B_USART0_RXD            _L_(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L_(1)
 #define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
-#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
-#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
-#define MUX_PA11A_USART0_RXD            _L(0)
+#define GPIO_PA05B_USART0_RXD    _UL_(1 <<  5)
+#define PIN_PA11A_USART0_RXD           _L_(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L_(0)
 #define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
-#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
-#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
-#define MUX_PA07B_USART0_TXD            _L(1)
+#define GPIO_PA11A_USART0_RXD    _UL_(1 << 11)
+#define PIN_PA07B_USART0_TXD            _L_(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L_(1)
 #define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
-#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
-#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
-#define MUX_PA12A_USART0_TXD            _L(0)
+#define GPIO_PA07B_USART0_TXD    _UL_(1 <<  7)
+#define PIN_PA12A_USART0_TXD           _L_(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L_(0)
 #define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
-#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
+#define GPIO_PA12A_USART0_TXD    _UL_(1 << 12)
 /* ========== GPIO definition for USART1 peripheral ========== */
-#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
-#define MUX_PA14A_USART1_CLK            _L(0)
+#define PIN_PA14A_USART1_CLK           _L_(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L_(0)
 #define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
-#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
-#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
-#define MUX_PA21B_USART1_CTS            _L(1)
+#define GPIO_PA14A_USART1_CLK    _UL_(1 << 14)
+#define PIN_PA21B_USART1_CTS           _L_(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L_(1)
 #define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
-#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
-#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
-#define MUX_PA13A_USART1_RTS            _L(0)
+#define GPIO_PA21B_USART1_CTS    _UL_(1 << 21)
+#define PIN_PA13A_USART1_RTS           _L_(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L_(0)
 #define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
-#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
-#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
-#define MUX_PA15A_USART1_RXD            _L(0)
+#define GPIO_PA13A_USART1_RTS    _UL_(1 << 13)
+#define PIN_PA15A_USART1_RXD           _L_(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L_(0)
 #define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
-#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
-#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
-#define MUX_PA16A_USART1_TXD            _L(0)
+#define GPIO_PA15A_USART1_RXD    _UL_(1 << 15)
+#define PIN_PA16A_USART1_TXD           _L_(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L_(0)
 #define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
-#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+#define GPIO_PA16A_USART1_TXD    _UL_(1 << 16)
 /* ========== GPIO definition for USART2 peripheral ========== */
-#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
-#define MUX_PA18A_USART2_CLK            _L(0)
+#define PIN_PA18A_USART2_CLK           _L_(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L_(0)
 #define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
-#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
-#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
-#define MUX_PA22B_USART2_CTS            _L(1)
+#define GPIO_PA18A_USART2_CLK    _UL_(1 << 18)
+#define PIN_PA22B_USART2_CTS           _L_(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L_(1)
 #define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
-#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
-#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
-#define MUX_PA17A_USART2_RTS            _L(0)
+#define GPIO_PA22B_USART2_CTS    _UL_(1 << 22)
+#define PIN_PA17A_USART2_RTS           _L_(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L_(0)
 #define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
-#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
-#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
-#define MUX_PA25B_USART2_RXD            _L(1)
+#define GPIO_PA17A_USART2_RTS    _UL_(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L_(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L_(1)
 #define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
-#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
-#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
-#define MUX_PA19A_USART2_RXD            _L(0)
+#define GPIO_PA25B_USART2_RXD    _UL_(1 << 25)
+#define PIN_PA19A_USART2_RXD           _L_(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L_(0)
 #define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
-#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
-#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
-#define MUX_PA26B_USART2_TXD            _L(1)
+#define GPIO_PA19A_USART2_RXD    _UL_(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L_(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L_(1)
 #define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
-#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
-#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
-#define MUX_PA20A_USART2_TXD            _L(0)
+#define GPIO_PA26B_USART2_TXD    _UL_(1 << 26)
+#define PIN_PA20A_USART2_TXD           _L_(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L_(0)
 #define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
-#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+#define GPIO_PA20A_USART2_TXD    _UL_(1 << 20)
 /* ========== GPIO definition for USART3 peripheral ========== */
-#define PIN_PA29E_USART3_CLK           _L(29) /**< \brief USART3 signal: CLK on PA29 mux E */
-#define MUX_PA29E_USART3_CLK            _L(4)
+#define PIN_PA29E_USART3_CLK           _L_(29) /**< \brief USART3 signal: CLK on PA29 mux E */
+#define MUX_PA29E_USART3_CLK            _L_(4)
 #define PINMUX_PA29E_USART3_CLK    ((PIN_PA29E_USART3_CLK << 16) | MUX_PA29E_USART3_CLK)
-#define GPIO_PA29E_USART3_CLK    _UL(1 << 29)
-#define PIN_PA28E_USART3_CTS           _L(28) /**< \brief USART3 signal: CTS on PA28 mux E */
-#define MUX_PA28E_USART3_CTS            _L(4)
+#define GPIO_PA29E_USART3_CLK    _UL_(1 << 29)
+#define PIN_PA28E_USART3_CTS           _L_(28) /**< \brief USART3 signal: CTS on PA28 mux E */
+#define MUX_PA28E_USART3_CTS            _L_(4)
 #define PINMUX_PA28E_USART3_CTS    ((PIN_PA28E_USART3_CTS << 16) | MUX_PA28E_USART3_CTS)
-#define GPIO_PA28E_USART3_CTS    _UL(1 << 28)
-#define PIN_PA27E_USART3_RTS           _L(27) /**< \brief USART3 signal: RTS on PA27 mux E */
-#define MUX_PA27E_USART3_RTS            _L(4)
+#define GPIO_PA28E_USART3_CTS    _UL_(1 << 28)
+#define PIN_PA27E_USART3_RTS           _L_(27) /**< \brief USART3 signal: RTS on PA27 mux E */
+#define MUX_PA27E_USART3_RTS            _L_(4)
 #define PINMUX_PA27E_USART3_RTS    ((PIN_PA27E_USART3_RTS << 16) | MUX_PA27E_USART3_RTS)
-#define GPIO_PA27E_USART3_RTS    _UL(1 << 27)
-#define PIN_PA30E_USART3_RXD           _L(30) /**< \brief USART3 signal: RXD on PA30 mux E */
-#define MUX_PA30E_USART3_RXD            _L(4)
+#define GPIO_PA27E_USART3_RTS    _UL_(1 << 27)
+#define PIN_PA30E_USART3_RXD           _L_(30) /**< \brief USART3 signal: RXD on PA30 mux E */
+#define MUX_PA30E_USART3_RXD            _L_(4)
 #define PINMUX_PA30E_USART3_RXD    ((PIN_PA30E_USART3_RXD << 16) | MUX_PA30E_USART3_RXD)
-#define GPIO_PA30E_USART3_RXD    _UL(1 << 30)
-#define PIN_PA31E_USART3_TXD           _L(31) /**< \brief USART3 signal: TXD on PA31 mux E */
-#define MUX_PA31E_USART3_TXD            _L(4)
+#define GPIO_PA30E_USART3_RXD    _UL_(1 << 30)
+#define PIN_PA31E_USART3_TXD           _L_(31) /**< \brief USART3 signal: TXD on PA31 mux E */
+#define MUX_PA31E_USART3_TXD            _L_(4)
 #define PINMUX_PA31E_USART3_TXD    ((PIN_PA31E_USART3_TXD << 16) | MUX_PA31E_USART3_TXD)
-#define GPIO_PA31E_USART3_TXD    _UL(1 << 31)
+#define GPIO_PA31E_USART3_TXD    _UL_(1 << 31)
 /* ========== GPIO definition for ADCIFE peripheral ========== */
-#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
-#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PIN_PA04A_ADCIFE_AD0            _L_(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L_(0)
 #define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
-#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
-#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
-#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL_(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L_(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L_(0)
 #define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
-#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
-#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
-#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define GPIO_PA05A_ADCIFE_AD1    _UL_(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L_(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L_(0)
 #define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
-#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
-#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
-#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define GPIO_PA07A_ADCIFE_AD2    _UL_(1 <<  7)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L_(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L_(4)
 #define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
-#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL_(1 <<  5)
 /* ========== GPIO definition for DACC peripheral ========== */
-#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
-#define MUX_PA06A_DACC_VOUT             _L(0)
+#define PIN_PA06A_DACC_VOUT             _L_(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L_(0)
 #define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
-#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+#define GPIO_PA06A_DACC_VOUT     _UL_(1 <<  6)
 /* ========== GPIO definition for ACIFC peripheral ========== */
-#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
-#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PIN_PA06E_ACIFC_ACAN0           _L_(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L_(4)
 #define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
-#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
-#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
-#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL_(1 <<  6)
+#define PIN_PA07E_ACIFC_ACAP0           _L_(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L_(4)
 #define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
-#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL_(1 <<  7)
 /* ========== GPIO definition for GLOC peripheral ========== */
-#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
-#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PIN_PA06D_GLOC_IN0              _L_(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L_(3)
 #define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
-#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
-#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
-#define MUX_PA20D_GLOC_IN0              _L(3)
+#define GPIO_PA06D_GLOC_IN0      _UL_(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L_(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L_(3)
 #define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
-#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
-#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
-#define MUX_PA04D_GLOC_IN1              _L(3)
+#define GPIO_PA20D_GLOC_IN0      _UL_(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L_(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L_(3)
 #define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
-#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
-#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
-#define MUX_PA21D_GLOC_IN1              _L(3)
+#define GPIO_PA04D_GLOC_IN1      _UL_(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L_(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L_(3)
 #define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
-#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
-#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
-#define MUX_PA05D_GLOC_IN2              _L(3)
+#define GPIO_PA21D_GLOC_IN1      _UL_(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L_(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L_(3)
 #define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
-#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
-#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
-#define MUX_PA22D_GLOC_IN2              _L(3)
+#define GPIO_PA05D_GLOC_IN2      _UL_(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L_(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L_(3)
 #define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
-#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
-#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
-#define MUX_PA07D_GLOC_IN3              _L(3)
+#define GPIO_PA22D_GLOC_IN2      _UL_(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L_(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L_(3)
 #define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
-#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
-#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
-#define MUX_PA23D_GLOC_IN3              _L(3)
+#define GPIO_PA07D_GLOC_IN3      _UL_(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L_(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L_(3)
 #define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
-#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
-#define PIN_PA27D_GLOC_IN4             _L(27) /**< \brief GLOC signal: IN4 on PA27 mux D */
-#define MUX_PA27D_GLOC_IN4              _L(3)
+#define GPIO_PA23D_GLOC_IN3      _UL_(1 << 23)
+#define PIN_PA27D_GLOC_IN4             _L_(27) /**< \brief GLOC signal: IN4 on PA27 mux D */
+#define MUX_PA27D_GLOC_IN4              _L_(3)
 #define PINMUX_PA27D_GLOC_IN4      ((PIN_PA27D_GLOC_IN4 << 16) | MUX_PA27D_GLOC_IN4)
-#define GPIO_PA27D_GLOC_IN4      _UL(1 << 27)
-#define PIN_PA28D_GLOC_IN5             _L(28) /**< \brief GLOC signal: IN5 on PA28 mux D */
-#define MUX_PA28D_GLOC_IN5              _L(3)
+#define GPIO_PA27D_GLOC_IN4      _UL_(1 << 27)
+#define PIN_PA28D_GLOC_IN5             _L_(28) /**< \brief GLOC signal: IN5 on PA28 mux D */
+#define MUX_PA28D_GLOC_IN5              _L_(3)
 #define PINMUX_PA28D_GLOC_IN5      ((PIN_PA28D_GLOC_IN5 << 16) | MUX_PA28D_GLOC_IN5)
-#define GPIO_PA28D_GLOC_IN5      _UL(1 << 28)
-#define PIN_PA29D_GLOC_IN6             _L(29) /**< \brief GLOC signal: IN6 on PA29 mux D */
-#define MUX_PA29D_GLOC_IN6              _L(3)
+#define GPIO_PA28D_GLOC_IN5      _UL_(1 << 28)
+#define PIN_PA29D_GLOC_IN6             _L_(29) /**< \brief GLOC signal: IN6 on PA29 mux D */
+#define MUX_PA29D_GLOC_IN6              _L_(3)
 #define PINMUX_PA29D_GLOC_IN6      ((PIN_PA29D_GLOC_IN6 << 16) | MUX_PA29D_GLOC_IN6)
-#define GPIO_PA29D_GLOC_IN6      _UL(1 << 29)
-#define PIN_PA30D_GLOC_IN7             _L(30) /**< \brief GLOC signal: IN7 on PA30 mux D */
-#define MUX_PA30D_GLOC_IN7              _L(3)
+#define GPIO_PA29D_GLOC_IN6      _UL_(1 << 29)
+#define PIN_PA30D_GLOC_IN7             _L_(30) /**< \brief GLOC signal: IN7 on PA30 mux D */
+#define MUX_PA30D_GLOC_IN7              _L_(3)
 #define PINMUX_PA30D_GLOC_IN7      ((PIN_PA30D_GLOC_IN7 << 16) | MUX_PA30D_GLOC_IN7)
-#define GPIO_PA30D_GLOC_IN7      _UL(1 << 30)
-#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
-#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define GPIO_PA30D_GLOC_IN7      _UL_(1 << 30)
+#define PIN_PA08D_GLOC_OUT0             _L_(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
-#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
-#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
-#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define GPIO_PA08D_GLOC_OUT0     _UL_(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L_(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
-#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
-#define PIN_PA31D_GLOC_OUT1            _L(31) /**< \brief GLOC signal: OUT1 on PA31 mux D */
-#define MUX_PA31D_GLOC_OUT1             _L(3)
+#define GPIO_PA24D_GLOC_OUT0     _UL_(1 << 24)
+#define PIN_PA31D_GLOC_OUT1            _L_(31) /**< \brief GLOC signal: OUT1 on PA31 mux D */
+#define MUX_PA31D_GLOC_OUT1             _L_(3)
 #define PINMUX_PA31D_GLOC_OUT1     ((PIN_PA31D_GLOC_OUT1 << 16) | MUX_PA31D_GLOC_OUT1)
-#define GPIO_PA31D_GLOC_OUT1     _UL(1 << 31)
+#define GPIO_PA31D_GLOC_OUT1     _UL_(1 << 31)
 /* ========== GPIO definition for ABDACB peripheral ========== */
-#define PIN_PA31C_ABDACB_CLK           _L(31) /**< \brief ABDACB signal: CLK on PA31 mux C */
-#define MUX_PA31C_ABDACB_CLK            _L(2)
+#define PIN_PA31C_ABDACB_CLK           _L_(31) /**< \brief ABDACB signal: CLK on PA31 mux C */
+#define MUX_PA31C_ABDACB_CLK            _L_(2)
 #define PINMUX_PA31C_ABDACB_CLK    ((PIN_PA31C_ABDACB_CLK << 16) | MUX_PA31C_ABDACB_CLK)
-#define GPIO_PA31C_ABDACB_CLK    _UL(1 << 31)
-#define PIN_PA27C_ABDACB_DAC0          _L(27) /**< \brief ABDACB signal: DAC0 on PA27 mux C */
-#define MUX_PA27C_ABDACB_DAC0           _L(2)
+#define GPIO_PA31C_ABDACB_CLK    _UL_(1 << 31)
+#define PIN_PA27C_ABDACB_DAC0          _L_(27) /**< \brief ABDACB signal: DAC0 on PA27 mux C */
+#define MUX_PA27C_ABDACB_DAC0           _L_(2)
 #define PINMUX_PA27C_ABDACB_DAC0   ((PIN_PA27C_ABDACB_DAC0 << 16) | MUX_PA27C_ABDACB_DAC0)
-#define GPIO_PA27C_ABDACB_DAC0   _UL(1 << 27)
-#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
-#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define GPIO_PA27C_ABDACB_DAC0   _UL_(1 << 27)
+#define PIN_PA17B_ABDACB_DAC0          _L_(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L_(1)
 #define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
-#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
-#define PIN_PA29C_ABDACB_DAC1          _L(29) /**< \brief ABDACB signal: DAC1 on PA29 mux C */
-#define MUX_PA29C_ABDACB_DAC1           _L(2)
+#define GPIO_PA17B_ABDACB_DAC0   _UL_(1 << 17)
+#define PIN_PA29C_ABDACB_DAC1          _L_(29) /**< \brief ABDACB signal: DAC1 on PA29 mux C */
+#define MUX_PA29C_ABDACB_DAC1           _L_(2)
 #define PINMUX_PA29C_ABDACB_DAC1   ((PIN_PA29C_ABDACB_DAC1 << 16) | MUX_PA29C_ABDACB_DAC1)
-#define GPIO_PA29C_ABDACB_DAC1   _UL(1 << 29)
-#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
-#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define GPIO_PA29C_ABDACB_DAC1   _UL_(1 << 29)
+#define PIN_PA19B_ABDACB_DAC1          _L_(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L_(1)
 #define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
-#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
-#define PIN_PA28C_ABDACB_DACN0         _L(28) /**< \brief ABDACB signal: DACN0 on PA28 mux C */
-#define MUX_PA28C_ABDACB_DACN0          _L(2)
+#define GPIO_PA19B_ABDACB_DAC1   _UL_(1 << 19)
+#define PIN_PA28C_ABDACB_DACN0         _L_(28) /**< \brief ABDACB signal: DACN0 on PA28 mux C */
+#define MUX_PA28C_ABDACB_DACN0          _L_(2)
 #define PINMUX_PA28C_ABDACB_DACN0  ((PIN_PA28C_ABDACB_DACN0 << 16) | MUX_PA28C_ABDACB_DACN0)
-#define GPIO_PA28C_ABDACB_DACN0  _UL(1 << 28)
-#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
-#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define GPIO_PA28C_ABDACB_DACN0  _UL_(1 << 28)
+#define PIN_PA18B_ABDACB_DACN0         _L_(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L_(1)
 #define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
-#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
-#define PIN_PA30C_ABDACB_DACN1         _L(30) /**< \brief ABDACB signal: DACN1 on PA30 mux C */
-#define MUX_PA30C_ABDACB_DACN1          _L(2)
+#define GPIO_PA18B_ABDACB_DACN0  _UL_(1 << 18)
+#define PIN_PA30C_ABDACB_DACN1         _L_(30) /**< \brief ABDACB signal: DACN1 on PA30 mux C */
+#define MUX_PA30C_ABDACB_DACN1          _L_(2)
 #define PINMUX_PA30C_ABDACB_DACN1  ((PIN_PA30C_ABDACB_DACN1 << 16) | MUX_PA30C_ABDACB_DACN1)
-#define GPIO_PA30C_ABDACB_DACN1  _UL(1 << 30)
-#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
-#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define GPIO_PA30C_ABDACB_DACN1  _UL_(1 << 30)
+#define PIN_PA20B_ABDACB_DACN1         _L_(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L_(1)
 #define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
-#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+#define GPIO_PA20B_ABDACB_DACN1  _UL_(1 << 20)
 /* ========== GPIO definition for PARC peripheral ========== */
-#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
-#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PIN_PA17D_PARC_PCCK            _L_(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L_(3)
 #define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
-#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
-#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
-#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define GPIO_PA17D_PARC_PCCK     _UL_(1 << 17)
+#define PIN_PA09D_PARC_PCDATA0          _L_(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L_(3)
 #define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
-#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
-#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
-#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define GPIO_PA09D_PARC_PCDATA0  _UL_(1 <<  9)
+#define PIN_PA10D_PARC_PCDATA1         _L_(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L_(3)
 #define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
-#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
-#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
-#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define GPIO_PA10D_PARC_PCDATA1  _UL_(1 << 10)
+#define PIN_PA11D_PARC_PCDATA2         _L_(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L_(3)
 #define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
-#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
-#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
-#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define GPIO_PA11D_PARC_PCDATA2  _UL_(1 << 11)
+#define PIN_PA12D_PARC_PCDATA3         _L_(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L_(3)
 #define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
-#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
-#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
-#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL_(1 << 12)
+#define PIN_PA13D_PARC_PCDATA4         _L_(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L_(3)
 #define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
-#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
-#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
-#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define GPIO_PA13D_PARC_PCDATA4  _UL_(1 << 13)
+#define PIN_PA14D_PARC_PCDATA5         _L_(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L_(3)
 #define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
-#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
-#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
-#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define GPIO_PA14D_PARC_PCDATA5  _UL_(1 << 14)
+#define PIN_PA15D_PARC_PCDATA6         _L_(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L_(3)
 #define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
-#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
-#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
-#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define GPIO_PA15D_PARC_PCDATA6  _UL_(1 << 15)
+#define PIN_PA16D_PARC_PCDATA7         _L_(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L_(3)
 #define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
-#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
-#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
-#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define GPIO_PA16D_PARC_PCDATA7  _UL_(1 << 16)
+#define PIN_PA18D_PARC_PCEN1           _L_(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L_(3)
 #define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
-#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
-#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
-#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define GPIO_PA18D_PARC_PCEN1    _UL_(1 << 18)
+#define PIN_PA19D_PARC_PCEN2           _L_(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L_(3)
 #define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
-#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+#define GPIO_PA19D_PARC_PCEN2    _UL_(1 << 19)
 /* ========== GPIO definition for CATB peripheral ========== */
-#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
-#define MUX_PA02G_CATB_DIS              _L(6)
+#define PIN_PA02G_CATB_DIS              _L_(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L_(6)
 #define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
-#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
-#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
-#define MUX_PA12G_CATB_DIS              _L(6)
+#define GPIO_PA02G_CATB_DIS      _UL_(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L_(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L_(6)
 #define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
-#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
-#define MUX_PA23G_CATB_DIS              _L(6)
+#define GPIO_PA12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L_(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L_(6)
 #define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
-#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
-#define PIN_PA31G_CATB_DIS             _L(31) /**< \brief CATB signal: DIS on PA31 mux G */
-#define MUX_PA31G_CATB_DIS              _L(6)
+#define GPIO_PA23G_CATB_DIS      _UL_(1 << 23)
+#define PIN_PA31G_CATB_DIS             _L_(31) /**< \brief CATB signal: DIS on PA31 mux G */
+#define MUX_PA31G_CATB_DIS              _L_(6)
 #define PINMUX_PA31G_CATB_DIS      ((PIN_PA31G_CATB_DIS << 16) | MUX_PA31G_CATB_DIS)
-#define GPIO_PA31G_CATB_DIS      _UL(1 << 31)
-#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
-#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define GPIO_PA31G_CATB_DIS      _UL_(1 << 31)
+#define PIN_PA04G_CATB_SENSE0           _L_(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L_(6)
 #define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
-#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
-#define PIN_PA27G_CATB_SENSE0          _L(27) /**< \brief CATB signal: SENSE0 on PA27 mux G */
-#define MUX_PA27G_CATB_SENSE0           _L(6)
+#define GPIO_PA04G_CATB_SENSE0   _UL_(1 <<  4)
+#define PIN_PA27G_CATB_SENSE0          _L_(27) /**< \brief CATB signal: SENSE0 on PA27 mux G */
+#define MUX_PA27G_CATB_SENSE0           _L_(6)
 #define PINMUX_PA27G_CATB_SENSE0   ((PIN_PA27G_CATB_SENSE0 << 16) | MUX_PA27G_CATB_SENSE0)
-#define GPIO_PA27G_CATB_SENSE0   _UL(1 << 27)
-#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
-#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define GPIO_PA27G_CATB_SENSE0   _UL_(1 << 27)
+#define PIN_PA05G_CATB_SENSE1           _L_(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L_(6)
 #define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
-#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
-#define PIN_PA28G_CATB_SENSE1          _L(28) /**< \brief CATB signal: SENSE1 on PA28 mux G */
-#define MUX_PA28G_CATB_SENSE1           _L(6)
+#define GPIO_PA05G_CATB_SENSE1   _UL_(1 <<  5)
+#define PIN_PA28G_CATB_SENSE1          _L_(28) /**< \brief CATB signal: SENSE1 on PA28 mux G */
+#define MUX_PA28G_CATB_SENSE1           _L_(6)
 #define PINMUX_PA28G_CATB_SENSE1   ((PIN_PA28G_CATB_SENSE1 << 16) | MUX_PA28G_CATB_SENSE1)
-#define GPIO_PA28G_CATB_SENSE1   _UL(1 << 28)
-#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
-#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define GPIO_PA28G_CATB_SENSE1   _UL_(1 << 28)
+#define PIN_PA06G_CATB_SENSE2           _L_(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L_(6)
 #define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
-#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
-#define PIN_PA29G_CATB_SENSE2          _L(29) /**< \brief CATB signal: SENSE2 on PA29 mux G */
-#define MUX_PA29G_CATB_SENSE2           _L(6)
+#define GPIO_PA06G_CATB_SENSE2   _UL_(1 <<  6)
+#define PIN_PA29G_CATB_SENSE2          _L_(29) /**< \brief CATB signal: SENSE2 on PA29 mux G */
+#define MUX_PA29G_CATB_SENSE2           _L_(6)
 #define PINMUX_PA29G_CATB_SENSE2   ((PIN_PA29G_CATB_SENSE2 << 16) | MUX_PA29G_CATB_SENSE2)
-#define GPIO_PA29G_CATB_SENSE2   _UL(1 << 29)
-#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
-#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define GPIO_PA29G_CATB_SENSE2   _UL_(1 << 29)
+#define PIN_PA07G_CATB_SENSE3           _L_(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L_(6)
 #define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
-#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
-#define PIN_PA30G_CATB_SENSE3          _L(30) /**< \brief CATB signal: SENSE3 on PA30 mux G */
-#define MUX_PA30G_CATB_SENSE3           _L(6)
+#define GPIO_PA07G_CATB_SENSE3   _UL_(1 <<  7)
+#define PIN_PA30G_CATB_SENSE3          _L_(30) /**< \brief CATB signal: SENSE3 on PA30 mux G */
+#define MUX_PA30G_CATB_SENSE3           _L_(6)
 #define PINMUX_PA30G_CATB_SENSE3   ((PIN_PA30G_CATB_SENSE3 << 16) | MUX_PA30G_CATB_SENSE3)
-#define GPIO_PA30G_CATB_SENSE3   _UL(1 << 30)
-#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
-#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define GPIO_PA30G_CATB_SENSE3   _UL_(1 << 30)
+#define PIN_PA08G_CATB_SENSE4           _L_(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L_(6)
 #define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
-#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
-#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
-#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define GPIO_PA08G_CATB_SENSE4   _UL_(1 <<  8)
+#define PIN_PA09G_CATB_SENSE5           _L_(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L_(6)
 #define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
-#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
-#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
-#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define GPIO_PA09G_CATB_SENSE5   _UL_(1 <<  9)
+#define PIN_PA10G_CATB_SENSE6          _L_(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L_(6)
 #define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
-#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
-#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
-#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define GPIO_PA10G_CATB_SENSE6   _UL_(1 << 10)
+#define PIN_PA11G_CATB_SENSE7          _L_(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L_(6)
 #define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
-#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
-#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
-#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define GPIO_PA11G_CATB_SENSE7   _UL_(1 << 11)
+#define PIN_PA13G_CATB_SENSE8          _L_(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L_(6)
 #define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
-#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
-#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
-#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define GPIO_PA13G_CATB_SENSE8   _UL_(1 << 13)
+#define PIN_PA14G_CATB_SENSE9          _L_(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L_(6)
 #define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
-#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
-#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
-#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define GPIO_PA14G_CATB_SENSE9   _UL_(1 << 14)
+#define PIN_PA15G_CATB_SENSE10         _L_(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L_(6)
 #define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
-#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
-#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
-#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define GPIO_PA15G_CATB_SENSE10  _UL_(1 << 15)
+#define PIN_PA16G_CATB_SENSE11         _L_(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L_(6)
 #define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
-#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
-#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
-#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define GPIO_PA16G_CATB_SENSE11  _UL_(1 << 16)
+#define PIN_PA17G_CATB_SENSE12         _L_(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L_(6)
 #define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
-#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
-#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
-#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define GPIO_PA17G_CATB_SENSE12  _UL_(1 << 17)
+#define PIN_PA18G_CATB_SENSE13         _L_(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L_(6)
 #define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
-#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
-#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
-#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define GPIO_PA18G_CATB_SENSE13  _UL_(1 << 18)
+#define PIN_PA19G_CATB_SENSE14         _L_(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L_(6)
 #define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
-#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
-#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
-#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define GPIO_PA19G_CATB_SENSE14  _UL_(1 << 19)
+#define PIN_PA20G_CATB_SENSE15         _L_(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L_(6)
 #define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
-#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
-#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
-#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define GPIO_PA20G_CATB_SENSE15  _UL_(1 << 20)
+#define PIN_PA21G_CATB_SENSE16         _L_(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L_(6)
 #define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
-#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
-#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
-#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define GPIO_PA21G_CATB_SENSE16  _UL_(1 << 21)
+#define PIN_PA22G_CATB_SENSE17         _L_(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L_(6)
 #define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
-#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
-#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
-#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define GPIO_PA22G_CATB_SENSE17  _UL_(1 << 22)
+#define PIN_PA24G_CATB_SENSE18         _L_(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L_(6)
 #define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
-#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
-#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
-#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define GPIO_PA24G_CATB_SENSE18  _UL_(1 << 24)
+#define PIN_PA25G_CATB_SENSE19         _L_(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L_(6)
 #define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
-#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
-#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
-#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define GPIO_PA25G_CATB_SENSE19  _UL_(1 << 25)
+#define PIN_PA26G_CATB_SENSE20         _L_(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L_(6)
 #define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
-#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
+#define GPIO_PA26G_CATB_SENSE20  _UL_(1 << 26)
 /* ========== GPIO definition for USBC peripheral ========== */
-#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
-#define MUX_PA25A_USBC_DM               _L(0)
+#define PIN_PA25A_USBC_DM              _L_(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L_(0)
 #define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
-#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
-#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
-#define MUX_PA26A_USBC_DP               _L(0)
+#define GPIO_PA25A_USBC_DM       _UL_(1 << 25)
+#define PIN_PA26A_USBC_DP              _L_(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L_(0)
 #define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
-#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+#define GPIO_PA26A_USBC_DP       _UL_(1 << 26)
 /* ========== GPIO definition for PEVC peripheral ========== */
-#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
-#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PIN_PA08C_PEVC_PAD_EVT0         _L_(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
-#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
-#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
-#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL_(1 <<  8)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L_(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
-#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
-#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
-#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL_(1 <<  9)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L_(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
-#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
-#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
-#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL_(1 << 10)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L_(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L_(2)
 #define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
-#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL_(1 << 11)
 /* ========== GPIO definition for SCIF peripheral ========== */
-#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
-#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PIN_PA19E_SCIF_GCLK0           _L_(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
-#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
-#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
-#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define GPIO_PA19E_SCIF_GCLK0    _UL_(1 << 19)
+#define PIN_PA02A_SCIF_GCLK0            _L_(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L_(0)
 #define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
-#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
-#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
-#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define GPIO_PA02A_SCIF_GCLK0    _UL_(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L_(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
-#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
-#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
-#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PA20E_SCIF_GCLK1    _UL_(1 << 20)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L_(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
-#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
-#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
-#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL_(1 << 23)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L_(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
-#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL_(1 << 24)
 /* ========== GPIO definition for EIC peripheral ========== */
-#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
-#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define PIN_PA06C_EIC_EXTINT1           _L_(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
-#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
-#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
-#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
-#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define GPIO_PA06C_EIC_EXTINT1   _UL_(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L_(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
-#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
-#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
-#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
-#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define GPIO_PA16C_EIC_EXTINT1   _UL_(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L_(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
-#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
-#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
-#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
-#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL_(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L_(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
-#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
-#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
-#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
-#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL_(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L_(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
-#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
-#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
-#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
-#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define GPIO_PA05C_EIC_EXTINT3   _UL_(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L_(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
-#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
-#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
-#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
-#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define GPIO_PA18C_EIC_EXTINT3   _UL_(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L_(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
-#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
-#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
-#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
-#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define GPIO_PA07C_EIC_EXTINT4   _UL_(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L_(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
-#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
-#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
-#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
-#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define GPIO_PA19C_EIC_EXTINT4   _UL_(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L_(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L_(2)
 #define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
-#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
-#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
-#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
-#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define GPIO_PA20C_EIC_EXTINT5   _UL_(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L_(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L_(2)
 #define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
-#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
-#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
-#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
-#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define GPIO_PA21C_EIC_EXTINT6   _UL_(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L_(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L_(2)
 #define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
-#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
-#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
-#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
-#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define GPIO_PA22C_EIC_EXTINT7   _UL_(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L_(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L_(2)
 #define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
-#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
-#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define GPIO_PA23C_EIC_EXTINT8   _UL_(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
 
 #endif /* _SAM4LS4A_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4ls4b.h
+++ b/asf/sam/include/sam4l/pio/sam4ls4b.h
@@ -30,1071 +30,1071 @@
 #define _SAM4LS4B_PIO_
 
 #define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
-#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define GPIO_PA00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PA00 */
 #define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
-#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define GPIO_PA01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PA01 */
 #define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
-#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define GPIO_PA02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PA02 */
 #define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
-#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define GPIO_PA03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PA03 */
 #define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
-#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define GPIO_PA04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PA04 */
 #define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
-#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define GPIO_PA05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PA05 */
 #define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
-#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define GPIO_PA06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PA06 */
 #define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
-#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define GPIO_PA07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PA07 */
 #define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
-#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define GPIO_PA08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PA08 */
 #define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
-#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define GPIO_PA09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PA09 */
 #define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
-#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define GPIO_PA10                _UL_(1 << 10) /**< \brief GPIO Mask  for PA10 */
 #define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
-#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define GPIO_PA11                _UL_(1 << 11) /**< \brief GPIO Mask  for PA11 */
 #define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
-#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define GPIO_PA12                _UL_(1 << 12) /**< \brief GPIO Mask  for PA12 */
 #define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
-#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define GPIO_PA13                _UL_(1 << 13) /**< \brief GPIO Mask  for PA13 */
 #define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
-#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define GPIO_PA14                _UL_(1 << 14) /**< \brief GPIO Mask  for PA14 */
 #define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
-#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define GPIO_PA15                _UL_(1 << 15) /**< \brief GPIO Mask  for PA15 */
 #define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
-#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define GPIO_PA16                _UL_(1 << 16) /**< \brief GPIO Mask  for PA16 */
 #define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
-#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define GPIO_PA17                _UL_(1 << 17) /**< \brief GPIO Mask  for PA17 */
 #define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
-#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define GPIO_PA18                _UL_(1 << 18) /**< \brief GPIO Mask  for PA18 */
 #define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
-#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define GPIO_PA19                _UL_(1 << 19) /**< \brief GPIO Mask  for PA19 */
 #define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
-#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define GPIO_PA20                _UL_(1 << 20) /**< \brief GPIO Mask  for PA20 */
 #define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
-#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define GPIO_PA21                _UL_(1 << 21) /**< \brief GPIO Mask  for PA21 */
 #define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
-#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define GPIO_PA22                _UL_(1 << 22) /**< \brief GPIO Mask  for PA22 */
 #define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
-#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define GPIO_PA23                _UL_(1 << 23) /**< \brief GPIO Mask  for PA23 */
 #define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
-#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define GPIO_PA24                _UL_(1 << 24) /**< \brief GPIO Mask  for PA24 */
 #define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
-#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define GPIO_PA25                _UL_(1 << 25) /**< \brief GPIO Mask  for PA25 */
 #define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
-#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define GPIO_PA26                _UL_(1 << 26) /**< \brief GPIO Mask  for PA26 */
 #define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
-#define GPIO_PA27                _UL(1 << 27) /**< \brief GPIO Mask  for PA27 */
+#define GPIO_PA27                _UL_(1 << 27) /**< \brief GPIO Mask  for PA27 */
 #define PIN_PA28                          28  /**< \brief Pin Number for PA28 */
-#define GPIO_PA28                _UL(1 << 28) /**< \brief GPIO Mask  for PA28 */
+#define GPIO_PA28                _UL_(1 << 28) /**< \brief GPIO Mask  for PA28 */
 #define PIN_PA29                          29  /**< \brief Pin Number for PA29 */
-#define GPIO_PA29                _UL(1 << 29) /**< \brief GPIO Mask  for PA29 */
+#define GPIO_PA29                _UL_(1 << 29) /**< \brief GPIO Mask  for PA29 */
 #define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
-#define GPIO_PA30                _UL(1 << 30) /**< \brief GPIO Mask  for PA30 */
+#define GPIO_PA30                _UL_(1 << 30) /**< \brief GPIO Mask  for PA30 */
 #define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
-#define GPIO_PA31                _UL(1 << 31) /**< \brief GPIO Mask  for PA31 */
+#define GPIO_PA31                _UL_(1 << 31) /**< \brief GPIO Mask  for PA31 */
 #define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
-#define GPIO_PB00                _UL(1 <<  0) /**< \brief GPIO Mask  for PB00 */
+#define GPIO_PB00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PB00 */
 #define PIN_PB01                          33  /**< \brief Pin Number for PB01 */
-#define GPIO_PB01                _UL(1 <<  1) /**< \brief GPIO Mask  for PB01 */
+#define GPIO_PB01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PB01 */
 #define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
-#define GPIO_PB02                _UL(1 <<  2) /**< \brief GPIO Mask  for PB02 */
+#define GPIO_PB02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PB02 */
 #define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
-#define GPIO_PB03                _UL(1 <<  3) /**< \brief GPIO Mask  for PB03 */
+#define GPIO_PB03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PB03 */
 #define PIN_PB04                          36  /**< \brief Pin Number for PB04 */
-#define GPIO_PB04                _UL(1 <<  4) /**< \brief GPIO Mask  for PB04 */
+#define GPIO_PB04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PB04 */
 #define PIN_PB05                          37  /**< \brief Pin Number for PB05 */
-#define GPIO_PB05                _UL(1 <<  5) /**< \brief GPIO Mask  for PB05 */
+#define GPIO_PB05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PB05 */
 #define PIN_PB06                          38  /**< \brief Pin Number for PB06 */
-#define GPIO_PB06                _UL(1 <<  6) /**< \brief GPIO Mask  for PB06 */
+#define GPIO_PB06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PB06 */
 #define PIN_PB07                          39  /**< \brief Pin Number for PB07 */
-#define GPIO_PB07                _UL(1 <<  7) /**< \brief GPIO Mask  for PB07 */
+#define GPIO_PB07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PB07 */
 #define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
-#define GPIO_PB08                _UL(1 <<  8) /**< \brief GPIO Mask  for PB08 */
+#define GPIO_PB08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PB08 */
 #define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
-#define GPIO_PB09                _UL(1 <<  9) /**< \brief GPIO Mask  for PB09 */
+#define GPIO_PB09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PB09 */
 #define PIN_PB10                          42  /**< \brief Pin Number for PB10 */
-#define GPIO_PB10                _UL(1 << 10) /**< \brief GPIO Mask  for PB10 */
+#define GPIO_PB10                _UL_(1 << 10) /**< \brief GPIO Mask  for PB10 */
 #define PIN_PB11                          43  /**< \brief Pin Number for PB11 */
-#define GPIO_PB11                _UL(1 << 11) /**< \brief GPIO Mask  for PB11 */
+#define GPIO_PB11                _UL_(1 << 11) /**< \brief GPIO Mask  for PB11 */
 #define PIN_PB12                          44  /**< \brief Pin Number for PB12 */
-#define GPIO_PB12                _UL(1 << 12) /**< \brief GPIO Mask  for PB12 */
+#define GPIO_PB12                _UL_(1 << 12) /**< \brief GPIO Mask  for PB12 */
 #define PIN_PB13                          45  /**< \brief Pin Number for PB13 */
-#define GPIO_PB13                _UL(1 << 13) /**< \brief GPIO Mask  for PB13 */
+#define GPIO_PB13                _UL_(1 << 13) /**< \brief GPIO Mask  for PB13 */
 #define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
-#define GPIO_PB14                _UL(1 << 14) /**< \brief GPIO Mask  for PB14 */
+#define GPIO_PB14                _UL_(1 << 14) /**< \brief GPIO Mask  for PB14 */
 #define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
-#define GPIO_PB15                _UL(1 << 15) /**< \brief GPIO Mask  for PB15 */
+#define GPIO_PB15                _UL_(1 << 15) /**< \brief GPIO Mask  for PB15 */
 /* ========== GPIO definition for TWIMS0 peripheral ========== */
-#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
-#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PIN_PA24B_TWIMS0_TWCK          _L_(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L_(1)
 #define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
-#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
-#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
-#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL_(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L_(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L_(1)
 #define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
-#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+#define GPIO_PA23B_TWIMS0_TWD    _UL_(1 << 23)
 /* ========== GPIO definition for TWIMS1 peripheral ========== */
-#define PIN_PB01A_TWIMS1_TWCK          _L(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
-#define MUX_PB01A_TWIMS1_TWCK           _L(0)
+#define PIN_PB01A_TWIMS1_TWCK          _L_(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
+#define MUX_PB01A_TWIMS1_TWCK           _L_(0)
 #define PINMUX_PB01A_TWIMS1_TWCK   ((PIN_PB01A_TWIMS1_TWCK << 16) | MUX_PB01A_TWIMS1_TWCK)
-#define GPIO_PB01A_TWIMS1_TWCK   _UL(1 <<  1)
-#define PIN_PB00A_TWIMS1_TWD           _L(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
-#define MUX_PB00A_TWIMS1_TWD            _L(0)
+#define GPIO_PB01A_TWIMS1_TWCK   _UL_(1 <<  1)
+#define PIN_PB00A_TWIMS1_TWD           _L_(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
+#define MUX_PB00A_TWIMS1_TWD            _L_(0)
 #define PINMUX_PB00A_TWIMS1_TWD    ((PIN_PB00A_TWIMS1_TWD << 16) | MUX_PB00A_TWIMS1_TWD)
-#define GPIO_PB00A_TWIMS1_TWD    _UL(1 <<  0)
+#define GPIO_PB00A_TWIMS1_TWD    _UL_(1 <<  0)
 /* ========== GPIO definition for TWIMS2 peripheral ========== */
-#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
-#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PIN_PA22E_TWIMS2_TWCK          _L_(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L_(4)
 #define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
-#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
-#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
-#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL_(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L_(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L_(4)
 #define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
-#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+#define GPIO_PA21E_TWIMS2_TWD    _UL_(1 << 21)
 /* ========== GPIO definition for TWIMS3 peripheral ========== */
-#define PIN_PB15C_TWIMS3_TWCK          _L(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
-#define MUX_PB15C_TWIMS3_TWCK           _L(2)
+#define PIN_PB15C_TWIMS3_TWCK          _L_(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
+#define MUX_PB15C_TWIMS3_TWCK           _L_(2)
 #define PINMUX_PB15C_TWIMS3_TWCK   ((PIN_PB15C_TWIMS3_TWCK << 16) | MUX_PB15C_TWIMS3_TWCK)
-#define GPIO_PB15C_TWIMS3_TWCK   _UL(1 << 15)
-#define PIN_PB14C_TWIMS3_TWD           _L(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
-#define MUX_PB14C_TWIMS3_TWD            _L(2)
+#define GPIO_PB15C_TWIMS3_TWCK   _UL_(1 << 15)
+#define PIN_PB14C_TWIMS3_TWD           _L_(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
+#define MUX_PB14C_TWIMS3_TWD            _L_(2)
 #define PINMUX_PB14C_TWIMS3_TWD    ((PIN_PB14C_TWIMS3_TWD << 16) | MUX_PB14C_TWIMS3_TWD)
-#define GPIO_PB14C_TWIMS3_TWD    _UL(1 << 14)
+#define GPIO_PB14C_TWIMS3_TWD    _UL_(1 << 14)
 /* ========== GPIO definition for IISC peripheral ========== */
-#define PIN_PB05D_IISC_IMCK            _L(37) /**< \brief IISC signal: IMCK on PB05 mux D */
-#define MUX_PB05D_IISC_IMCK             _L(3)
+#define PIN_PB05D_IISC_IMCK            _L_(37) /**< \brief IISC signal: IMCK on PB05 mux D */
+#define MUX_PB05D_IISC_IMCK             _L_(3)
 #define PINMUX_PB05D_IISC_IMCK     ((PIN_PB05D_IISC_IMCK << 16) | MUX_PB05D_IISC_IMCK)
-#define GPIO_PB05D_IISC_IMCK     _UL(1 <<  5)
-#define PIN_PA31B_IISC_IMCK            _L(31) /**< \brief IISC signal: IMCK on PA31 mux B */
-#define MUX_PA31B_IISC_IMCK             _L(1)
+#define GPIO_PB05D_IISC_IMCK     _UL_(1 <<  5)
+#define PIN_PA31B_IISC_IMCK            _L_(31) /**< \brief IISC signal: IMCK on PA31 mux B */
+#define MUX_PA31B_IISC_IMCK             _L_(1)
 #define PINMUX_PA31B_IISC_IMCK     ((PIN_PA31B_IISC_IMCK << 16) | MUX_PA31B_IISC_IMCK)
-#define GPIO_PA31B_IISC_IMCK     _UL(1 << 31)
-#define PIN_PB02D_IISC_ISCK            _L(34) /**< \brief IISC signal: ISCK on PB02 mux D */
-#define MUX_PB02D_IISC_ISCK             _L(3)
+#define GPIO_PA31B_IISC_IMCK     _UL_(1 << 31)
+#define PIN_PB02D_IISC_ISCK            _L_(34) /**< \brief IISC signal: ISCK on PB02 mux D */
+#define MUX_PB02D_IISC_ISCK             _L_(3)
 #define PINMUX_PB02D_IISC_ISCK     ((PIN_PB02D_IISC_ISCK << 16) | MUX_PB02D_IISC_ISCK)
-#define GPIO_PB02D_IISC_ISCK     _UL(1 <<  2)
-#define PIN_PA27B_IISC_ISCK            _L(27) /**< \brief IISC signal: ISCK on PA27 mux B */
-#define MUX_PA27B_IISC_ISCK             _L(1)
+#define GPIO_PB02D_IISC_ISCK     _UL_(1 <<  2)
+#define PIN_PA27B_IISC_ISCK            _L_(27) /**< \brief IISC signal: ISCK on PA27 mux B */
+#define MUX_PA27B_IISC_ISCK             _L_(1)
 #define PINMUX_PA27B_IISC_ISCK     ((PIN_PA27B_IISC_ISCK << 16) | MUX_PA27B_IISC_ISCK)
-#define GPIO_PA27B_IISC_ISCK     _UL(1 << 27)
-#define PIN_PB03D_IISC_ISDI            _L(35) /**< \brief IISC signal: ISDI on PB03 mux D */
-#define MUX_PB03D_IISC_ISDI             _L(3)
+#define GPIO_PA27B_IISC_ISCK     _UL_(1 << 27)
+#define PIN_PB03D_IISC_ISDI            _L_(35) /**< \brief IISC signal: ISDI on PB03 mux D */
+#define MUX_PB03D_IISC_ISDI             _L_(3)
 #define PINMUX_PB03D_IISC_ISDI     ((PIN_PB03D_IISC_ISDI << 16) | MUX_PB03D_IISC_ISDI)
-#define GPIO_PB03D_IISC_ISDI     _UL(1 <<  3)
-#define PIN_PA28B_IISC_ISDI            _L(28) /**< \brief IISC signal: ISDI on PA28 mux B */
-#define MUX_PA28B_IISC_ISDI             _L(1)
+#define GPIO_PB03D_IISC_ISDI     _UL_(1 <<  3)
+#define PIN_PA28B_IISC_ISDI            _L_(28) /**< \brief IISC signal: ISDI on PA28 mux B */
+#define MUX_PA28B_IISC_ISDI             _L_(1)
 #define PINMUX_PA28B_IISC_ISDI     ((PIN_PA28B_IISC_ISDI << 16) | MUX_PA28B_IISC_ISDI)
-#define GPIO_PA28B_IISC_ISDI     _UL(1 << 28)
-#define PIN_PB04D_IISC_ISDO            _L(36) /**< \brief IISC signal: ISDO on PB04 mux D */
-#define MUX_PB04D_IISC_ISDO             _L(3)
+#define GPIO_PA28B_IISC_ISDI     _UL_(1 << 28)
+#define PIN_PB04D_IISC_ISDO            _L_(36) /**< \brief IISC signal: ISDO on PB04 mux D */
+#define MUX_PB04D_IISC_ISDO             _L_(3)
 #define PINMUX_PB04D_IISC_ISDO     ((PIN_PB04D_IISC_ISDO << 16) | MUX_PB04D_IISC_ISDO)
-#define GPIO_PB04D_IISC_ISDO     _UL(1 <<  4)
-#define PIN_PA30B_IISC_ISDO            _L(30) /**< \brief IISC signal: ISDO on PA30 mux B */
-#define MUX_PA30B_IISC_ISDO             _L(1)
+#define GPIO_PB04D_IISC_ISDO     _UL_(1 <<  4)
+#define PIN_PA30B_IISC_ISDO            _L_(30) /**< \brief IISC signal: ISDO on PA30 mux B */
+#define MUX_PA30B_IISC_ISDO             _L_(1)
 #define PINMUX_PA30B_IISC_ISDO     ((PIN_PA30B_IISC_ISDO << 16) | MUX_PA30B_IISC_ISDO)
-#define GPIO_PA30B_IISC_ISDO     _UL(1 << 30)
-#define PIN_PB06D_IISC_IWS             _L(38) /**< \brief IISC signal: IWS on PB06 mux D */
-#define MUX_PB06D_IISC_IWS              _L(3)
+#define GPIO_PA30B_IISC_ISDO     _UL_(1 << 30)
+#define PIN_PB06D_IISC_IWS             _L_(38) /**< \brief IISC signal: IWS on PB06 mux D */
+#define MUX_PB06D_IISC_IWS              _L_(3)
 #define PINMUX_PB06D_IISC_IWS      ((PIN_PB06D_IISC_IWS << 16) | MUX_PB06D_IISC_IWS)
-#define GPIO_PB06D_IISC_IWS      _UL(1 <<  6)
-#define PIN_PA29B_IISC_IWS             _L(29) /**< \brief IISC signal: IWS on PA29 mux B */
-#define MUX_PA29B_IISC_IWS              _L(1)
+#define GPIO_PB06D_IISC_IWS      _UL_(1 <<  6)
+#define PIN_PA29B_IISC_IWS             _L_(29) /**< \brief IISC signal: IWS on PA29 mux B */
+#define MUX_PA29B_IISC_IWS              _L_(1)
 #define PINMUX_PA29B_IISC_IWS      ((PIN_PA29B_IISC_IWS << 16) | MUX_PA29B_IISC_IWS)
-#define GPIO_PA29B_IISC_IWS      _UL(1 << 29)
+#define GPIO_PA29B_IISC_IWS      _UL_(1 << 29)
 /* ========== GPIO definition for SPI peripheral ========== */
-#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
-#define MUX_PA03B_SPI_MISO              _L(1)
+#define PIN_PA03B_SPI_MISO              _L_(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L_(1)
 #define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
-#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
-#define PIN_PB14B_SPI_MISO             _L(46) /**< \brief SPI signal: MISO on PB14 mux B */
-#define MUX_PB14B_SPI_MISO              _L(1)
+#define GPIO_PA03B_SPI_MISO      _UL_(1 <<  3)
+#define PIN_PB14B_SPI_MISO             _L_(46) /**< \brief SPI signal: MISO on PB14 mux B */
+#define MUX_PB14B_SPI_MISO              _L_(1)
 #define PINMUX_PB14B_SPI_MISO      ((PIN_PB14B_SPI_MISO << 16) | MUX_PB14B_SPI_MISO)
-#define GPIO_PB14B_SPI_MISO      _UL(1 << 14)
-#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
-#define MUX_PA21A_SPI_MISO              _L(0)
+#define GPIO_PB14B_SPI_MISO      _UL_(1 << 14)
+#define PIN_PA21A_SPI_MISO             _L_(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L_(0)
 #define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
-#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
-#define PIN_PA27A_SPI_MISO             _L(27) /**< \brief SPI signal: MISO on PA27 mux A */
-#define MUX_PA27A_SPI_MISO              _L(0)
+#define GPIO_PA21A_SPI_MISO      _UL_(1 << 21)
+#define PIN_PA27A_SPI_MISO             _L_(27) /**< \brief SPI signal: MISO on PA27 mux A */
+#define MUX_PA27A_SPI_MISO              _L_(0)
 #define PINMUX_PA27A_SPI_MISO      ((PIN_PA27A_SPI_MISO << 16) | MUX_PA27A_SPI_MISO)
-#define GPIO_PA27A_SPI_MISO      _UL(1 << 27)
-#define PIN_PB15B_SPI_MOSI             _L(47) /**< \brief SPI signal: MOSI on PB15 mux B */
-#define MUX_PB15B_SPI_MOSI              _L(1)
+#define GPIO_PA27A_SPI_MISO      _UL_(1 << 27)
+#define PIN_PB15B_SPI_MOSI             _L_(47) /**< \brief SPI signal: MOSI on PB15 mux B */
+#define MUX_PB15B_SPI_MOSI              _L_(1)
 #define PINMUX_PB15B_SPI_MOSI      ((PIN_PB15B_SPI_MOSI << 16) | MUX_PB15B_SPI_MOSI)
-#define GPIO_PB15B_SPI_MOSI      _UL(1 << 15)
-#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
-#define MUX_PA22A_SPI_MOSI              _L(0)
+#define GPIO_PB15B_SPI_MOSI      _UL_(1 << 15)
+#define PIN_PA22A_SPI_MOSI             _L_(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L_(0)
 #define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
-#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
-#define PIN_PA28A_SPI_MOSI             _L(28) /**< \brief SPI signal: MOSI on PA28 mux A */
-#define MUX_PA28A_SPI_MOSI              _L(0)
+#define GPIO_PA22A_SPI_MOSI      _UL_(1 << 22)
+#define PIN_PA28A_SPI_MOSI             _L_(28) /**< \brief SPI signal: MOSI on PA28 mux A */
+#define MUX_PA28A_SPI_MOSI              _L_(0)
 #define PINMUX_PA28A_SPI_MOSI      ((PIN_PA28A_SPI_MOSI << 16) | MUX_PA28A_SPI_MOSI)
-#define GPIO_PA28A_SPI_MOSI      _UL(1 << 28)
-#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
-#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define GPIO_PA28A_SPI_MOSI      _UL_(1 << 28)
+#define PIN_PA02B_SPI_NPCS0             _L_(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L_(1)
 #define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
-#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
-#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
-#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define GPIO_PA02B_SPI_NPCS0     _UL_(1 <<  2)
+#define PIN_PA24A_SPI_NPCS0            _L_(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L_(0)
 #define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
-#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
-#define PIN_PA30A_SPI_NPCS0            _L(30) /**< \brief SPI signal: NPCS0 on PA30 mux A */
-#define MUX_PA30A_SPI_NPCS0             _L(0)
+#define GPIO_PA24A_SPI_NPCS0     _UL_(1 << 24)
+#define PIN_PA30A_SPI_NPCS0            _L_(30) /**< \brief SPI signal: NPCS0 on PA30 mux A */
+#define MUX_PA30A_SPI_NPCS0             _L_(0)
 #define PINMUX_PA30A_SPI_NPCS0     ((PIN_PA30A_SPI_NPCS0 << 16) | MUX_PA30A_SPI_NPCS0)
-#define GPIO_PA30A_SPI_NPCS0     _UL(1 << 30)
-#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
-#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define GPIO_PA30A_SPI_NPCS0     _UL_(1 << 30)
+#define PIN_PA13C_SPI_NPCS1            _L_(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L_(2)
 #define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
-#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PB13B_SPI_NPCS1            _L(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
-#define MUX_PB13B_SPI_NPCS1             _L(1)
+#define GPIO_PA13C_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PB13B_SPI_NPCS1            _L_(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
+#define MUX_PB13B_SPI_NPCS1             _L_(1)
 #define PINMUX_PB13B_SPI_NPCS1     ((PIN_PB13B_SPI_NPCS1 << 16) | MUX_PB13B_SPI_NPCS1)
-#define GPIO_PB13B_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PA31A_SPI_NPCS1            _L(31) /**< \brief SPI signal: NPCS1 on PA31 mux A */
-#define MUX_PA31A_SPI_NPCS1             _L(0)
+#define GPIO_PB13B_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PA31A_SPI_NPCS1            _L_(31) /**< \brief SPI signal: NPCS1 on PA31 mux A */
+#define MUX_PA31A_SPI_NPCS1             _L_(0)
 #define PINMUX_PA31A_SPI_NPCS1     ((PIN_PA31A_SPI_NPCS1 << 16) | MUX_PA31A_SPI_NPCS1)
-#define GPIO_PA31A_SPI_NPCS1     _UL(1 << 31)
-#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
-#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define GPIO_PA31A_SPI_NPCS1     _UL_(1 << 31)
+#define PIN_PA14C_SPI_NPCS2            _L_(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L_(2)
 #define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
-#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
-#define PIN_PB11B_SPI_NPCS2            _L(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
-#define MUX_PB11B_SPI_NPCS2             _L(1)
+#define GPIO_PA14C_SPI_NPCS2     _UL_(1 << 14)
+#define PIN_PB11B_SPI_NPCS2            _L_(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
+#define MUX_PB11B_SPI_NPCS2             _L_(1)
 #define PINMUX_PB11B_SPI_NPCS2     ((PIN_PB11B_SPI_NPCS2 << 16) | MUX_PB11B_SPI_NPCS2)
-#define GPIO_PB11B_SPI_NPCS2     _UL(1 << 11)
-#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
-#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define GPIO_PB11B_SPI_NPCS2     _UL_(1 << 11)
+#define PIN_PA15C_SPI_NPCS3            _L_(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L_(2)
 #define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
-#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
-#define PIN_PB12B_SPI_NPCS3            _L(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
-#define MUX_PB12B_SPI_NPCS3             _L(1)
+#define GPIO_PA15C_SPI_NPCS3     _UL_(1 << 15)
+#define PIN_PB12B_SPI_NPCS3            _L_(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
+#define MUX_PB12B_SPI_NPCS3             _L_(1)
 #define PINMUX_PB12B_SPI_NPCS3     ((PIN_PB12B_SPI_NPCS3 << 16) | MUX_PB12B_SPI_NPCS3)
-#define GPIO_PB12B_SPI_NPCS3     _UL(1 << 12)
-#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
-#define MUX_PA23A_SPI_SCK               _L(0)
+#define GPIO_PB12B_SPI_NPCS3     _UL_(1 << 12)
+#define PIN_PA23A_SPI_SCK              _L_(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L_(0)
 #define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
-#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
-#define PIN_PA29A_SPI_SCK              _L(29) /**< \brief SPI signal: SCK on PA29 mux A */
-#define MUX_PA29A_SPI_SCK               _L(0)
+#define GPIO_PA23A_SPI_SCK       _UL_(1 << 23)
+#define PIN_PA29A_SPI_SCK              _L_(29) /**< \brief SPI signal: SCK on PA29 mux A */
+#define MUX_PA29A_SPI_SCK               _L_(0)
 #define PINMUX_PA29A_SPI_SCK       ((PIN_PA29A_SPI_SCK << 16) | MUX_PA29A_SPI_SCK)
-#define GPIO_PA29A_SPI_SCK       _UL(1 << 29)
+#define GPIO_PA29A_SPI_SCK       _UL_(1 << 29)
 /* ========== GPIO definition for TC0 peripheral ========== */
-#define PIN_PB07D_TC0_A0               _L(39) /**< \brief TC0 signal: A0 on PB07 mux D */
-#define MUX_PB07D_TC0_A0                _L(3)
+#define PIN_PB07D_TC0_A0               _L_(39) /**< \brief TC0 signal: A0 on PB07 mux D */
+#define MUX_PB07D_TC0_A0                _L_(3)
 #define PINMUX_PB07D_TC0_A0        ((PIN_PB07D_TC0_A0 << 16) | MUX_PB07D_TC0_A0)
-#define GPIO_PB07D_TC0_A0        _UL(1 <<  7)
-#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
-#define MUX_PA08B_TC0_A0                _L(1)
+#define GPIO_PB07D_TC0_A0        _UL_(1 <<  7)
+#define PIN_PA08B_TC0_A0                _L_(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L_(1)
 #define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
-#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
-#define PIN_PB09D_TC0_A1               _L(41) /**< \brief TC0 signal: A1 on PB09 mux D */
-#define MUX_PB09D_TC0_A1                _L(3)
+#define GPIO_PA08B_TC0_A0        _UL_(1 <<  8)
+#define PIN_PB09D_TC0_A1               _L_(41) /**< \brief TC0 signal: A1 on PB09 mux D */
+#define MUX_PB09D_TC0_A1                _L_(3)
 #define PINMUX_PB09D_TC0_A1        ((PIN_PB09D_TC0_A1 << 16) | MUX_PB09D_TC0_A1)
-#define GPIO_PB09D_TC0_A1        _UL(1 <<  9)
-#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
-#define MUX_PA10B_TC0_A1                _L(1)
+#define GPIO_PB09D_TC0_A1        _UL_(1 <<  9)
+#define PIN_PA10B_TC0_A1               _L_(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L_(1)
 #define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
-#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
-#define PIN_PB11D_TC0_A2               _L(43) /**< \brief TC0 signal: A2 on PB11 mux D */
-#define MUX_PB11D_TC0_A2                _L(3)
+#define GPIO_PA10B_TC0_A1        _UL_(1 << 10)
+#define PIN_PB11D_TC0_A2               _L_(43) /**< \brief TC0 signal: A2 on PB11 mux D */
+#define MUX_PB11D_TC0_A2                _L_(3)
 #define PINMUX_PB11D_TC0_A2        ((PIN_PB11D_TC0_A2 << 16) | MUX_PB11D_TC0_A2)
-#define GPIO_PB11D_TC0_A2        _UL(1 << 11)
-#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
-#define MUX_PA12B_TC0_A2                _L(1)
+#define GPIO_PB11D_TC0_A2        _UL_(1 << 11)
+#define PIN_PA12B_TC0_A2               _L_(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L_(1)
 #define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
-#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
-#define PIN_PB08D_TC0_B0               _L(40) /**< \brief TC0 signal: B0 on PB08 mux D */
-#define MUX_PB08D_TC0_B0                _L(3)
+#define GPIO_PA12B_TC0_A2        _UL_(1 << 12)
+#define PIN_PB08D_TC0_B0               _L_(40) /**< \brief TC0 signal: B0 on PB08 mux D */
+#define MUX_PB08D_TC0_B0                _L_(3)
 #define PINMUX_PB08D_TC0_B0        ((PIN_PB08D_TC0_B0 << 16) | MUX_PB08D_TC0_B0)
-#define GPIO_PB08D_TC0_B0        _UL(1 <<  8)
-#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
-#define MUX_PA09B_TC0_B0                _L(1)
+#define GPIO_PB08D_TC0_B0        _UL_(1 <<  8)
+#define PIN_PA09B_TC0_B0                _L_(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L_(1)
 #define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
-#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
-#define PIN_PB10D_TC0_B1               _L(42) /**< \brief TC0 signal: B1 on PB10 mux D */
-#define MUX_PB10D_TC0_B1                _L(3)
+#define GPIO_PA09B_TC0_B0        _UL_(1 <<  9)
+#define PIN_PB10D_TC0_B1               _L_(42) /**< \brief TC0 signal: B1 on PB10 mux D */
+#define MUX_PB10D_TC0_B1                _L_(3)
 #define PINMUX_PB10D_TC0_B1        ((PIN_PB10D_TC0_B1 << 16) | MUX_PB10D_TC0_B1)
-#define GPIO_PB10D_TC0_B1        _UL(1 << 10)
-#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
-#define MUX_PA11B_TC0_B1                _L(1)
+#define GPIO_PB10D_TC0_B1        _UL_(1 << 10)
+#define PIN_PA11B_TC0_B1               _L_(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L_(1)
 #define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
-#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
-#define PIN_PB12D_TC0_B2               _L(44) /**< \brief TC0 signal: B2 on PB12 mux D */
-#define MUX_PB12D_TC0_B2                _L(3)
+#define GPIO_PA11B_TC0_B1        _UL_(1 << 11)
+#define PIN_PB12D_TC0_B2               _L_(44) /**< \brief TC0 signal: B2 on PB12 mux D */
+#define MUX_PB12D_TC0_B2                _L_(3)
 #define PINMUX_PB12D_TC0_B2        ((PIN_PB12D_TC0_B2 << 16) | MUX_PB12D_TC0_B2)
-#define GPIO_PB12D_TC0_B2        _UL(1 << 12)
-#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
-#define MUX_PA13B_TC0_B2                _L(1)
+#define GPIO_PB12D_TC0_B2        _UL_(1 << 12)
+#define PIN_PA13B_TC0_B2               _L_(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L_(1)
 #define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
-#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
-#define PIN_PB13D_TC0_CLK0             _L(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
-#define MUX_PB13D_TC0_CLK0              _L(3)
+#define GPIO_PA13B_TC0_B2        _UL_(1 << 13)
+#define PIN_PB13D_TC0_CLK0             _L_(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
+#define MUX_PB13D_TC0_CLK0              _L_(3)
 #define PINMUX_PB13D_TC0_CLK0      ((PIN_PB13D_TC0_CLK0 << 16) | MUX_PB13D_TC0_CLK0)
-#define GPIO_PB13D_TC0_CLK0      _UL(1 << 13)
-#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
-#define MUX_PA14B_TC0_CLK0              _L(1)
+#define GPIO_PB13D_TC0_CLK0      _UL_(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L_(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L_(1)
 #define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
-#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
-#define PIN_PB14D_TC0_CLK1             _L(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
-#define MUX_PB14D_TC0_CLK1              _L(3)
+#define GPIO_PA14B_TC0_CLK0      _UL_(1 << 14)
+#define PIN_PB14D_TC0_CLK1             _L_(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
+#define MUX_PB14D_TC0_CLK1              _L_(3)
 #define PINMUX_PB14D_TC0_CLK1      ((PIN_PB14D_TC0_CLK1 << 16) | MUX_PB14D_TC0_CLK1)
-#define GPIO_PB14D_TC0_CLK1      _UL(1 << 14)
-#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
-#define MUX_PA15B_TC0_CLK1              _L(1)
+#define GPIO_PB14D_TC0_CLK1      _UL_(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L_(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L_(1)
 #define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
-#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
-#define PIN_PB15D_TC0_CLK2             _L(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
-#define MUX_PB15D_TC0_CLK2              _L(3)
+#define GPIO_PA15B_TC0_CLK1      _UL_(1 << 15)
+#define PIN_PB15D_TC0_CLK2             _L_(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
+#define MUX_PB15D_TC0_CLK2              _L_(3)
 #define PINMUX_PB15D_TC0_CLK2      ((PIN_PB15D_TC0_CLK2 << 16) | MUX_PB15D_TC0_CLK2)
-#define GPIO_PB15D_TC0_CLK2      _UL(1 << 15)
-#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
-#define MUX_PA16B_TC0_CLK2              _L(1)
+#define GPIO_PB15D_TC0_CLK2      _UL_(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L_(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L_(1)
 #define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
-#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+#define GPIO_PA16B_TC0_CLK2      _UL_(1 << 16)
 /* ========== GPIO definition for USART0 peripheral ========== */
-#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
-#define MUX_PA04B_USART0_CLK            _L(1)
+#define PIN_PA04B_USART0_CLK            _L_(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L_(1)
 #define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
-#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
-#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
-#define MUX_PA10A_USART0_CLK            _L(0)
+#define GPIO_PA04B_USART0_CLK    _UL_(1 <<  4)
+#define PIN_PA10A_USART0_CLK           _L_(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L_(0)
 #define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
-#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
-#define PIN_PB13A_USART0_CLK           _L(45) /**< \brief USART0 signal: CLK on PB13 mux A */
-#define MUX_PB13A_USART0_CLK            _L(0)
+#define GPIO_PA10A_USART0_CLK    _UL_(1 << 10)
+#define PIN_PB13A_USART0_CLK           _L_(45) /**< \brief USART0 signal: CLK on PB13 mux A */
+#define MUX_PB13A_USART0_CLK            _L_(0)
 #define PINMUX_PB13A_USART0_CLK    ((PIN_PB13A_USART0_CLK << 16) | MUX_PB13A_USART0_CLK)
-#define GPIO_PB13A_USART0_CLK    _UL(1 << 13)
-#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
-#define MUX_PA09A_USART0_CTS            _L(0)
+#define GPIO_PB13A_USART0_CLK    _UL_(1 << 13)
+#define PIN_PA09A_USART0_CTS            _L_(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L_(0)
 #define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
-#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
-#define PIN_PB11A_USART0_CTS           _L(43) /**< \brief USART0 signal: CTS on PB11 mux A */
-#define MUX_PB11A_USART0_CTS            _L(0)
+#define GPIO_PA09A_USART0_CTS    _UL_(1 <<  9)
+#define PIN_PB11A_USART0_CTS           _L_(43) /**< \brief USART0 signal: CTS on PB11 mux A */
+#define MUX_PB11A_USART0_CTS            _L_(0)
 #define PINMUX_PB11A_USART0_CTS    ((PIN_PB11A_USART0_CTS << 16) | MUX_PB11A_USART0_CTS)
-#define GPIO_PB11A_USART0_CTS    _UL(1 << 11)
-#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
-#define MUX_PA06B_USART0_RTS            _L(1)
+#define GPIO_PB11A_USART0_CTS    _UL_(1 << 11)
+#define PIN_PA06B_USART0_RTS            _L_(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L_(1)
 #define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
-#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
-#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
-#define MUX_PA08A_USART0_RTS            _L(0)
+#define GPIO_PA06B_USART0_RTS    _UL_(1 <<  6)
+#define PIN_PA08A_USART0_RTS            _L_(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L_(0)
 #define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
-#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
-#define PIN_PB12A_USART0_RTS           _L(44) /**< \brief USART0 signal: RTS on PB12 mux A */
-#define MUX_PB12A_USART0_RTS            _L(0)
+#define GPIO_PA08A_USART0_RTS    _UL_(1 <<  8)
+#define PIN_PB12A_USART0_RTS           _L_(44) /**< \brief USART0 signal: RTS on PB12 mux A */
+#define MUX_PB12A_USART0_RTS            _L_(0)
 #define PINMUX_PB12A_USART0_RTS    ((PIN_PB12A_USART0_RTS << 16) | MUX_PB12A_USART0_RTS)
-#define GPIO_PB12A_USART0_RTS    _UL(1 << 12)
-#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
-#define MUX_PA05B_USART0_RXD            _L(1)
+#define GPIO_PB12A_USART0_RTS    _UL_(1 << 12)
+#define PIN_PA05B_USART0_RXD            _L_(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L_(1)
 #define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
-#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
-#define PIN_PB00B_USART0_RXD           _L(32) /**< \brief USART0 signal: RXD on PB00 mux B */
-#define MUX_PB00B_USART0_RXD            _L(1)
+#define GPIO_PA05B_USART0_RXD    _UL_(1 <<  5)
+#define PIN_PB00B_USART0_RXD           _L_(32) /**< \brief USART0 signal: RXD on PB00 mux B */
+#define MUX_PB00B_USART0_RXD            _L_(1)
 #define PINMUX_PB00B_USART0_RXD    ((PIN_PB00B_USART0_RXD << 16) | MUX_PB00B_USART0_RXD)
-#define GPIO_PB00B_USART0_RXD    _UL(1 <<  0)
-#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
-#define MUX_PA11A_USART0_RXD            _L(0)
+#define GPIO_PB00B_USART0_RXD    _UL_(1 <<  0)
+#define PIN_PA11A_USART0_RXD           _L_(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L_(0)
 #define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
-#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
-#define PIN_PB14A_USART0_RXD           _L(46) /**< \brief USART0 signal: RXD on PB14 mux A */
-#define MUX_PB14A_USART0_RXD            _L(0)
+#define GPIO_PA11A_USART0_RXD    _UL_(1 << 11)
+#define PIN_PB14A_USART0_RXD           _L_(46) /**< \brief USART0 signal: RXD on PB14 mux A */
+#define MUX_PB14A_USART0_RXD            _L_(0)
 #define PINMUX_PB14A_USART0_RXD    ((PIN_PB14A_USART0_RXD << 16) | MUX_PB14A_USART0_RXD)
-#define GPIO_PB14A_USART0_RXD    _UL(1 << 14)
-#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
-#define MUX_PA07B_USART0_TXD            _L(1)
+#define GPIO_PB14A_USART0_RXD    _UL_(1 << 14)
+#define PIN_PA07B_USART0_TXD            _L_(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L_(1)
 #define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
-#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
-#define PIN_PB01B_USART0_TXD           _L(33) /**< \brief USART0 signal: TXD on PB01 mux B */
-#define MUX_PB01B_USART0_TXD            _L(1)
+#define GPIO_PA07B_USART0_TXD    _UL_(1 <<  7)
+#define PIN_PB01B_USART0_TXD           _L_(33) /**< \brief USART0 signal: TXD on PB01 mux B */
+#define MUX_PB01B_USART0_TXD            _L_(1)
 #define PINMUX_PB01B_USART0_TXD    ((PIN_PB01B_USART0_TXD << 16) | MUX_PB01B_USART0_TXD)
-#define GPIO_PB01B_USART0_TXD    _UL(1 <<  1)
-#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
-#define MUX_PA12A_USART0_TXD            _L(0)
+#define GPIO_PB01B_USART0_TXD    _UL_(1 <<  1)
+#define PIN_PA12A_USART0_TXD           _L_(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L_(0)
 #define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
-#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
-#define PIN_PB15A_USART0_TXD           _L(47) /**< \brief USART0 signal: TXD on PB15 mux A */
-#define MUX_PB15A_USART0_TXD            _L(0)
+#define GPIO_PA12A_USART0_TXD    _UL_(1 << 12)
+#define PIN_PB15A_USART0_TXD           _L_(47) /**< \brief USART0 signal: TXD on PB15 mux A */
+#define MUX_PB15A_USART0_TXD            _L_(0)
 #define PINMUX_PB15A_USART0_TXD    ((PIN_PB15A_USART0_TXD << 16) | MUX_PB15A_USART0_TXD)
-#define GPIO_PB15A_USART0_TXD    _UL(1 << 15)
+#define GPIO_PB15A_USART0_TXD    _UL_(1 << 15)
 /* ========== GPIO definition for USART1 peripheral ========== */
-#define PIN_PB03B_USART1_CLK           _L(35) /**< \brief USART1 signal: CLK on PB03 mux B */
-#define MUX_PB03B_USART1_CLK            _L(1)
+#define PIN_PB03B_USART1_CLK           _L_(35) /**< \brief USART1 signal: CLK on PB03 mux B */
+#define MUX_PB03B_USART1_CLK            _L_(1)
 #define PINMUX_PB03B_USART1_CLK    ((PIN_PB03B_USART1_CLK << 16) | MUX_PB03B_USART1_CLK)
-#define GPIO_PB03B_USART1_CLK    _UL(1 <<  3)
-#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
-#define MUX_PA14A_USART1_CLK            _L(0)
+#define GPIO_PB03B_USART1_CLK    _UL_(1 <<  3)
+#define PIN_PA14A_USART1_CLK           _L_(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L_(0)
 #define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
-#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
-#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
-#define MUX_PA21B_USART1_CTS            _L(1)
+#define GPIO_PA14A_USART1_CLK    _UL_(1 << 14)
+#define PIN_PA21B_USART1_CTS           _L_(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L_(1)
 #define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
-#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
-#define PIN_PB02B_USART1_RTS           _L(34) /**< \brief USART1 signal: RTS on PB02 mux B */
-#define MUX_PB02B_USART1_RTS            _L(1)
+#define GPIO_PA21B_USART1_CTS    _UL_(1 << 21)
+#define PIN_PB02B_USART1_RTS           _L_(34) /**< \brief USART1 signal: RTS on PB02 mux B */
+#define MUX_PB02B_USART1_RTS            _L_(1)
 #define PINMUX_PB02B_USART1_RTS    ((PIN_PB02B_USART1_RTS << 16) | MUX_PB02B_USART1_RTS)
-#define GPIO_PB02B_USART1_RTS    _UL(1 <<  2)
-#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
-#define MUX_PA13A_USART1_RTS            _L(0)
+#define GPIO_PB02B_USART1_RTS    _UL_(1 <<  2)
+#define PIN_PA13A_USART1_RTS           _L_(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L_(0)
 #define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
-#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
-#define PIN_PB04B_USART1_RXD           _L(36) /**< \brief USART1 signal: RXD on PB04 mux B */
-#define MUX_PB04B_USART1_RXD            _L(1)
+#define GPIO_PA13A_USART1_RTS    _UL_(1 << 13)
+#define PIN_PB04B_USART1_RXD           _L_(36) /**< \brief USART1 signal: RXD on PB04 mux B */
+#define MUX_PB04B_USART1_RXD            _L_(1)
 #define PINMUX_PB04B_USART1_RXD    ((PIN_PB04B_USART1_RXD << 16) | MUX_PB04B_USART1_RXD)
-#define GPIO_PB04B_USART1_RXD    _UL(1 <<  4)
-#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
-#define MUX_PA15A_USART1_RXD            _L(0)
+#define GPIO_PB04B_USART1_RXD    _UL_(1 <<  4)
+#define PIN_PA15A_USART1_RXD           _L_(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L_(0)
 #define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
-#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
-#define PIN_PB05B_USART1_TXD           _L(37) /**< \brief USART1 signal: TXD on PB05 mux B */
-#define MUX_PB05B_USART1_TXD            _L(1)
+#define GPIO_PA15A_USART1_RXD    _UL_(1 << 15)
+#define PIN_PB05B_USART1_TXD           _L_(37) /**< \brief USART1 signal: TXD on PB05 mux B */
+#define MUX_PB05B_USART1_TXD            _L_(1)
 #define PINMUX_PB05B_USART1_TXD    ((PIN_PB05B_USART1_TXD << 16) | MUX_PB05B_USART1_TXD)
-#define GPIO_PB05B_USART1_TXD    _UL(1 <<  5)
-#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
-#define MUX_PA16A_USART1_TXD            _L(0)
+#define GPIO_PB05B_USART1_TXD    _UL_(1 <<  5)
+#define PIN_PA16A_USART1_TXD           _L_(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L_(0)
 #define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
-#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+#define GPIO_PA16A_USART1_TXD    _UL_(1 << 16)
 /* ========== GPIO definition for USART2 peripheral ========== */
-#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
-#define MUX_PA18A_USART2_CLK            _L(0)
+#define PIN_PA18A_USART2_CLK           _L_(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L_(0)
 #define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
-#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
-#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
-#define MUX_PA22B_USART2_CTS            _L(1)
+#define GPIO_PA18A_USART2_CLK    _UL_(1 << 18)
+#define PIN_PA22B_USART2_CTS           _L_(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L_(1)
 #define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
-#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
-#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
-#define MUX_PA17A_USART2_RTS            _L(0)
+#define GPIO_PA22B_USART2_CTS    _UL_(1 << 22)
+#define PIN_PA17A_USART2_RTS           _L_(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L_(0)
 #define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
-#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
-#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
-#define MUX_PA25B_USART2_RXD            _L(1)
+#define GPIO_PA17A_USART2_RTS    _UL_(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L_(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L_(1)
 #define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
-#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
-#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
-#define MUX_PA19A_USART2_RXD            _L(0)
+#define GPIO_PA25B_USART2_RXD    _UL_(1 << 25)
+#define PIN_PA19A_USART2_RXD           _L_(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L_(0)
 #define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
-#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
-#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
-#define MUX_PA26B_USART2_TXD            _L(1)
+#define GPIO_PA19A_USART2_RXD    _UL_(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L_(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L_(1)
 #define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
-#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
-#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
-#define MUX_PA20A_USART2_TXD            _L(0)
+#define GPIO_PA26B_USART2_TXD    _UL_(1 << 26)
+#define PIN_PA20A_USART2_TXD           _L_(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L_(0)
 #define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
-#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+#define GPIO_PA20A_USART2_TXD    _UL_(1 << 20)
 /* ========== GPIO definition for USART3 peripheral ========== */
-#define PIN_PA29E_USART3_CLK           _L(29) /**< \brief USART3 signal: CLK on PA29 mux E */
-#define MUX_PA29E_USART3_CLK            _L(4)
+#define PIN_PA29E_USART3_CLK           _L_(29) /**< \brief USART3 signal: CLK on PA29 mux E */
+#define MUX_PA29E_USART3_CLK            _L_(4)
 #define PINMUX_PA29E_USART3_CLK    ((PIN_PA29E_USART3_CLK << 16) | MUX_PA29E_USART3_CLK)
-#define GPIO_PA29E_USART3_CLK    _UL(1 << 29)
-#define PIN_PB08A_USART3_CLK           _L(40) /**< \brief USART3 signal: CLK on PB08 mux A */
-#define MUX_PB08A_USART3_CLK            _L(0)
+#define GPIO_PA29E_USART3_CLK    _UL_(1 << 29)
+#define PIN_PB08A_USART3_CLK           _L_(40) /**< \brief USART3 signal: CLK on PB08 mux A */
+#define MUX_PB08A_USART3_CLK            _L_(0)
 #define PINMUX_PB08A_USART3_CLK    ((PIN_PB08A_USART3_CLK << 16) | MUX_PB08A_USART3_CLK)
-#define GPIO_PB08A_USART3_CLK    _UL(1 <<  8)
-#define PIN_PA28E_USART3_CTS           _L(28) /**< \brief USART3 signal: CTS on PA28 mux E */
-#define MUX_PA28E_USART3_CTS            _L(4)
+#define GPIO_PB08A_USART3_CLK    _UL_(1 <<  8)
+#define PIN_PA28E_USART3_CTS           _L_(28) /**< \brief USART3 signal: CTS on PA28 mux E */
+#define MUX_PA28E_USART3_CTS            _L_(4)
 #define PINMUX_PA28E_USART3_CTS    ((PIN_PA28E_USART3_CTS << 16) | MUX_PA28E_USART3_CTS)
-#define GPIO_PA28E_USART3_CTS    _UL(1 << 28)
-#define PIN_PB07A_USART3_CTS           _L(39) /**< \brief USART3 signal: CTS on PB07 mux A */
-#define MUX_PB07A_USART3_CTS            _L(0)
+#define GPIO_PA28E_USART3_CTS    _UL_(1 << 28)
+#define PIN_PB07A_USART3_CTS           _L_(39) /**< \brief USART3 signal: CTS on PB07 mux A */
+#define MUX_PB07A_USART3_CTS            _L_(0)
 #define PINMUX_PB07A_USART3_CTS    ((PIN_PB07A_USART3_CTS << 16) | MUX_PB07A_USART3_CTS)
-#define GPIO_PB07A_USART3_CTS    _UL(1 <<  7)
-#define PIN_PA27E_USART3_RTS           _L(27) /**< \brief USART3 signal: RTS on PA27 mux E */
-#define MUX_PA27E_USART3_RTS            _L(4)
+#define GPIO_PB07A_USART3_CTS    _UL_(1 <<  7)
+#define PIN_PA27E_USART3_RTS           _L_(27) /**< \brief USART3 signal: RTS on PA27 mux E */
+#define MUX_PA27E_USART3_RTS            _L_(4)
 #define PINMUX_PA27E_USART3_RTS    ((PIN_PA27E_USART3_RTS << 16) | MUX_PA27E_USART3_RTS)
-#define GPIO_PA27E_USART3_RTS    _UL(1 << 27)
-#define PIN_PB06A_USART3_RTS           _L(38) /**< \brief USART3 signal: RTS on PB06 mux A */
-#define MUX_PB06A_USART3_RTS            _L(0)
+#define GPIO_PA27E_USART3_RTS    _UL_(1 << 27)
+#define PIN_PB06A_USART3_RTS           _L_(38) /**< \brief USART3 signal: RTS on PB06 mux A */
+#define MUX_PB06A_USART3_RTS            _L_(0)
 #define PINMUX_PB06A_USART3_RTS    ((PIN_PB06A_USART3_RTS << 16) | MUX_PB06A_USART3_RTS)
-#define GPIO_PB06A_USART3_RTS    _UL(1 <<  6)
-#define PIN_PA30E_USART3_RXD           _L(30) /**< \brief USART3 signal: RXD on PA30 mux E */
-#define MUX_PA30E_USART3_RXD            _L(4)
+#define GPIO_PB06A_USART3_RTS    _UL_(1 <<  6)
+#define PIN_PA30E_USART3_RXD           _L_(30) /**< \brief USART3 signal: RXD on PA30 mux E */
+#define MUX_PA30E_USART3_RXD            _L_(4)
 #define PINMUX_PA30E_USART3_RXD    ((PIN_PA30E_USART3_RXD << 16) | MUX_PA30E_USART3_RXD)
-#define GPIO_PA30E_USART3_RXD    _UL(1 << 30)
-#define PIN_PB09A_USART3_RXD           _L(41) /**< \brief USART3 signal: RXD on PB09 mux A */
-#define MUX_PB09A_USART3_RXD            _L(0)
+#define GPIO_PA30E_USART3_RXD    _UL_(1 << 30)
+#define PIN_PB09A_USART3_RXD           _L_(41) /**< \brief USART3 signal: RXD on PB09 mux A */
+#define MUX_PB09A_USART3_RXD            _L_(0)
 #define PINMUX_PB09A_USART3_RXD    ((PIN_PB09A_USART3_RXD << 16) | MUX_PB09A_USART3_RXD)
-#define GPIO_PB09A_USART3_RXD    _UL(1 <<  9)
-#define PIN_PA31E_USART3_TXD           _L(31) /**< \brief USART3 signal: TXD on PA31 mux E */
-#define MUX_PA31E_USART3_TXD            _L(4)
+#define GPIO_PB09A_USART3_RXD    _UL_(1 <<  9)
+#define PIN_PA31E_USART3_TXD           _L_(31) /**< \brief USART3 signal: TXD on PA31 mux E */
+#define MUX_PA31E_USART3_TXD            _L_(4)
 #define PINMUX_PA31E_USART3_TXD    ((PIN_PA31E_USART3_TXD << 16) | MUX_PA31E_USART3_TXD)
-#define GPIO_PA31E_USART3_TXD    _UL(1 << 31)
-#define PIN_PB10A_USART3_TXD           _L(42) /**< \brief USART3 signal: TXD on PB10 mux A */
-#define MUX_PB10A_USART3_TXD            _L(0)
+#define GPIO_PA31E_USART3_TXD    _UL_(1 << 31)
+#define PIN_PB10A_USART3_TXD           _L_(42) /**< \brief USART3 signal: TXD on PB10 mux A */
+#define MUX_PB10A_USART3_TXD            _L_(0)
 #define PINMUX_PB10A_USART3_TXD    ((PIN_PB10A_USART3_TXD << 16) | MUX_PB10A_USART3_TXD)
-#define GPIO_PB10A_USART3_TXD    _UL(1 << 10)
+#define GPIO_PB10A_USART3_TXD    _UL_(1 << 10)
 /* ========== GPIO definition for ADCIFE peripheral ========== */
-#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
-#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PIN_PA04A_ADCIFE_AD0            _L_(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L_(0)
 #define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
-#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
-#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
-#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL_(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L_(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L_(0)
 #define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
-#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
-#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
-#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define GPIO_PA05A_ADCIFE_AD1    _UL_(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L_(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L_(0)
 #define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
-#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
-#define PIN_PB02A_ADCIFE_AD3           _L(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
-#define MUX_PB02A_ADCIFE_AD3            _L(0)
+#define GPIO_PA07A_ADCIFE_AD2    _UL_(1 <<  7)
+#define PIN_PB02A_ADCIFE_AD3           _L_(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
+#define MUX_PB02A_ADCIFE_AD3            _L_(0)
 #define PINMUX_PB02A_ADCIFE_AD3    ((PIN_PB02A_ADCIFE_AD3 << 16) | MUX_PB02A_ADCIFE_AD3)
-#define GPIO_PB02A_ADCIFE_AD3    _UL(1 <<  2)
-#define PIN_PB03A_ADCIFE_AD4           _L(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
-#define MUX_PB03A_ADCIFE_AD4            _L(0)
+#define GPIO_PB02A_ADCIFE_AD3    _UL_(1 <<  2)
+#define PIN_PB03A_ADCIFE_AD4           _L_(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
+#define MUX_PB03A_ADCIFE_AD4            _L_(0)
 #define PINMUX_PB03A_ADCIFE_AD4    ((PIN_PB03A_ADCIFE_AD4 << 16) | MUX_PB03A_ADCIFE_AD4)
-#define GPIO_PB03A_ADCIFE_AD4    _UL(1 <<  3)
-#define PIN_PB04A_ADCIFE_AD5           _L(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
-#define MUX_PB04A_ADCIFE_AD5            _L(0)
+#define GPIO_PB03A_ADCIFE_AD4    _UL_(1 <<  3)
+#define PIN_PB04A_ADCIFE_AD5           _L_(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
+#define MUX_PB04A_ADCIFE_AD5            _L_(0)
 #define PINMUX_PB04A_ADCIFE_AD5    ((PIN_PB04A_ADCIFE_AD5 << 16) | MUX_PB04A_ADCIFE_AD5)
-#define GPIO_PB04A_ADCIFE_AD5    _UL(1 <<  4)
-#define PIN_PB05A_ADCIFE_AD6           _L(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
-#define MUX_PB05A_ADCIFE_AD6            _L(0)
+#define GPIO_PB04A_ADCIFE_AD5    _UL_(1 <<  4)
+#define PIN_PB05A_ADCIFE_AD6           _L_(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
+#define MUX_PB05A_ADCIFE_AD6            _L_(0)
 #define PINMUX_PB05A_ADCIFE_AD6    ((PIN_PB05A_ADCIFE_AD6 << 16) | MUX_PB05A_ADCIFE_AD6)
-#define GPIO_PB05A_ADCIFE_AD6    _UL(1 <<  5)
-#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
-#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define GPIO_PB05A_ADCIFE_AD6    _UL_(1 <<  5)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L_(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L_(4)
 #define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
-#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL_(1 <<  5)
 /* ========== GPIO definition for DACC peripheral ========== */
-#define PIN_PB04E_DACC_EXT_TRIG0       _L(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
-#define MUX_PB04E_DACC_EXT_TRIG0        _L(4)
+#define PIN_PB04E_DACC_EXT_TRIG0       _L_(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
+#define MUX_PB04E_DACC_EXT_TRIG0        _L_(4)
 #define PINMUX_PB04E_DACC_EXT_TRIG0  ((PIN_PB04E_DACC_EXT_TRIG0 << 16) | MUX_PB04E_DACC_EXT_TRIG0)
-#define GPIO_PB04E_DACC_EXT_TRIG0  _UL(1 <<  4)
-#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
-#define MUX_PA06A_DACC_VOUT             _L(0)
+#define GPIO_PB04E_DACC_EXT_TRIG0  _UL_(1 <<  4)
+#define PIN_PA06A_DACC_VOUT             _L_(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L_(0)
 #define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
-#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+#define GPIO_PA06A_DACC_VOUT     _UL_(1 <<  6)
 /* ========== GPIO definition for ACIFC peripheral ========== */
-#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
-#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PIN_PA06E_ACIFC_ACAN0           _L_(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L_(4)
 #define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
-#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
-#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
-#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL_(1 <<  6)
+#define PIN_PA07E_ACIFC_ACAP0           _L_(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L_(4)
 #define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
-#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
-#define PIN_PB02E_ACIFC_ACBN0          _L(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
-#define MUX_PB02E_ACIFC_ACBN0           _L(4)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL_(1 <<  7)
+#define PIN_PB02E_ACIFC_ACBN0          _L_(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
+#define MUX_PB02E_ACIFC_ACBN0           _L_(4)
 #define PINMUX_PB02E_ACIFC_ACBN0   ((PIN_PB02E_ACIFC_ACBN0 << 16) | MUX_PB02E_ACIFC_ACBN0)
-#define GPIO_PB02E_ACIFC_ACBN0   _UL(1 <<  2)
-#define PIN_PB03E_ACIFC_ACBP0          _L(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
-#define MUX_PB03E_ACIFC_ACBP0           _L(4)
+#define GPIO_PB02E_ACIFC_ACBN0   _UL_(1 <<  2)
+#define PIN_PB03E_ACIFC_ACBP0          _L_(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
+#define MUX_PB03E_ACIFC_ACBP0           _L_(4)
 #define PINMUX_PB03E_ACIFC_ACBP0   ((PIN_PB03E_ACIFC_ACBP0 << 16) | MUX_PB03E_ACIFC_ACBP0)
-#define GPIO_PB03E_ACIFC_ACBP0   _UL(1 <<  3)
+#define GPIO_PB03E_ACIFC_ACBP0   _UL_(1 <<  3)
 /* ========== GPIO definition for GLOC peripheral ========== */
-#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
-#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PIN_PA06D_GLOC_IN0              _L_(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L_(3)
 #define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
-#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
-#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
-#define MUX_PA20D_GLOC_IN0              _L(3)
+#define GPIO_PA06D_GLOC_IN0      _UL_(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L_(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L_(3)
 #define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
-#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
-#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
-#define MUX_PA04D_GLOC_IN1              _L(3)
+#define GPIO_PA20D_GLOC_IN0      _UL_(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L_(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L_(3)
 #define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
-#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
-#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
-#define MUX_PA21D_GLOC_IN1              _L(3)
+#define GPIO_PA04D_GLOC_IN1      _UL_(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L_(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L_(3)
 #define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
-#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
-#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
-#define MUX_PA05D_GLOC_IN2              _L(3)
+#define GPIO_PA21D_GLOC_IN1      _UL_(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L_(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L_(3)
 #define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
-#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
-#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
-#define MUX_PA22D_GLOC_IN2              _L(3)
+#define GPIO_PA05D_GLOC_IN2      _UL_(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L_(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L_(3)
 #define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
-#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
-#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
-#define MUX_PA07D_GLOC_IN3              _L(3)
+#define GPIO_PA22D_GLOC_IN2      _UL_(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L_(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L_(3)
 #define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
-#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
-#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
-#define MUX_PA23D_GLOC_IN3              _L(3)
+#define GPIO_PA07D_GLOC_IN3      _UL_(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L_(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L_(3)
 #define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
-#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
-#define PIN_PA27D_GLOC_IN4             _L(27) /**< \brief GLOC signal: IN4 on PA27 mux D */
-#define MUX_PA27D_GLOC_IN4              _L(3)
+#define GPIO_PA23D_GLOC_IN3      _UL_(1 << 23)
+#define PIN_PA27D_GLOC_IN4             _L_(27) /**< \brief GLOC signal: IN4 on PA27 mux D */
+#define MUX_PA27D_GLOC_IN4              _L_(3)
 #define PINMUX_PA27D_GLOC_IN4      ((PIN_PA27D_GLOC_IN4 << 16) | MUX_PA27D_GLOC_IN4)
-#define GPIO_PA27D_GLOC_IN4      _UL(1 << 27)
-#define PIN_PB06C_GLOC_IN4             _L(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
-#define MUX_PB06C_GLOC_IN4              _L(2)
+#define GPIO_PA27D_GLOC_IN4      _UL_(1 << 27)
+#define PIN_PB06C_GLOC_IN4             _L_(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
+#define MUX_PB06C_GLOC_IN4              _L_(2)
 #define PINMUX_PB06C_GLOC_IN4      ((PIN_PB06C_GLOC_IN4 << 16) | MUX_PB06C_GLOC_IN4)
-#define GPIO_PB06C_GLOC_IN4      _UL(1 <<  6)
-#define PIN_PA28D_GLOC_IN5             _L(28) /**< \brief GLOC signal: IN5 on PA28 mux D */
-#define MUX_PA28D_GLOC_IN5              _L(3)
+#define GPIO_PB06C_GLOC_IN4      _UL_(1 <<  6)
+#define PIN_PA28D_GLOC_IN5             _L_(28) /**< \brief GLOC signal: IN5 on PA28 mux D */
+#define MUX_PA28D_GLOC_IN5              _L_(3)
 #define PINMUX_PA28D_GLOC_IN5      ((PIN_PA28D_GLOC_IN5 << 16) | MUX_PA28D_GLOC_IN5)
-#define GPIO_PA28D_GLOC_IN5      _UL(1 << 28)
-#define PIN_PB07C_GLOC_IN5             _L(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
-#define MUX_PB07C_GLOC_IN5              _L(2)
+#define GPIO_PA28D_GLOC_IN5      _UL_(1 << 28)
+#define PIN_PB07C_GLOC_IN5             _L_(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
+#define MUX_PB07C_GLOC_IN5              _L_(2)
 #define PINMUX_PB07C_GLOC_IN5      ((PIN_PB07C_GLOC_IN5 << 16) | MUX_PB07C_GLOC_IN5)
-#define GPIO_PB07C_GLOC_IN5      _UL(1 <<  7)
-#define PIN_PA29D_GLOC_IN6             _L(29) /**< \brief GLOC signal: IN6 on PA29 mux D */
-#define MUX_PA29D_GLOC_IN6              _L(3)
+#define GPIO_PB07C_GLOC_IN5      _UL_(1 <<  7)
+#define PIN_PA29D_GLOC_IN6             _L_(29) /**< \brief GLOC signal: IN6 on PA29 mux D */
+#define MUX_PA29D_GLOC_IN6              _L_(3)
 #define PINMUX_PA29D_GLOC_IN6      ((PIN_PA29D_GLOC_IN6 << 16) | MUX_PA29D_GLOC_IN6)
-#define GPIO_PA29D_GLOC_IN6      _UL(1 << 29)
-#define PIN_PB08C_GLOC_IN6             _L(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
-#define MUX_PB08C_GLOC_IN6              _L(2)
+#define GPIO_PA29D_GLOC_IN6      _UL_(1 << 29)
+#define PIN_PB08C_GLOC_IN6             _L_(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
+#define MUX_PB08C_GLOC_IN6              _L_(2)
 #define PINMUX_PB08C_GLOC_IN6      ((PIN_PB08C_GLOC_IN6 << 16) | MUX_PB08C_GLOC_IN6)
-#define GPIO_PB08C_GLOC_IN6      _UL(1 <<  8)
-#define PIN_PA30D_GLOC_IN7             _L(30) /**< \brief GLOC signal: IN7 on PA30 mux D */
-#define MUX_PA30D_GLOC_IN7              _L(3)
+#define GPIO_PB08C_GLOC_IN6      _UL_(1 <<  8)
+#define PIN_PA30D_GLOC_IN7             _L_(30) /**< \brief GLOC signal: IN7 on PA30 mux D */
+#define MUX_PA30D_GLOC_IN7              _L_(3)
 #define PINMUX_PA30D_GLOC_IN7      ((PIN_PA30D_GLOC_IN7 << 16) | MUX_PA30D_GLOC_IN7)
-#define GPIO_PA30D_GLOC_IN7      _UL(1 << 30)
-#define PIN_PB09C_GLOC_IN7             _L(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
-#define MUX_PB09C_GLOC_IN7              _L(2)
+#define GPIO_PA30D_GLOC_IN7      _UL_(1 << 30)
+#define PIN_PB09C_GLOC_IN7             _L_(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
+#define MUX_PB09C_GLOC_IN7              _L_(2)
 #define PINMUX_PB09C_GLOC_IN7      ((PIN_PB09C_GLOC_IN7 << 16) | MUX_PB09C_GLOC_IN7)
-#define GPIO_PB09C_GLOC_IN7      _UL(1 <<  9)
-#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
-#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define GPIO_PB09C_GLOC_IN7      _UL_(1 <<  9)
+#define PIN_PA08D_GLOC_OUT0             _L_(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
-#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
-#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
-#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define GPIO_PA08D_GLOC_OUT0     _UL_(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L_(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
-#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
-#define PIN_PA31D_GLOC_OUT1            _L(31) /**< \brief GLOC signal: OUT1 on PA31 mux D */
-#define MUX_PA31D_GLOC_OUT1             _L(3)
+#define GPIO_PA24D_GLOC_OUT0     _UL_(1 << 24)
+#define PIN_PA31D_GLOC_OUT1            _L_(31) /**< \brief GLOC signal: OUT1 on PA31 mux D */
+#define MUX_PA31D_GLOC_OUT1             _L_(3)
 #define PINMUX_PA31D_GLOC_OUT1     ((PIN_PA31D_GLOC_OUT1 << 16) | MUX_PA31D_GLOC_OUT1)
-#define GPIO_PA31D_GLOC_OUT1     _UL(1 << 31)
-#define PIN_PB10C_GLOC_OUT1            _L(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
-#define MUX_PB10C_GLOC_OUT1             _L(2)
+#define GPIO_PA31D_GLOC_OUT1     _UL_(1 << 31)
+#define PIN_PB10C_GLOC_OUT1            _L_(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
+#define MUX_PB10C_GLOC_OUT1             _L_(2)
 #define PINMUX_PB10C_GLOC_OUT1     ((PIN_PB10C_GLOC_OUT1 << 16) | MUX_PB10C_GLOC_OUT1)
-#define GPIO_PB10C_GLOC_OUT1     _UL(1 << 10)
+#define GPIO_PB10C_GLOC_OUT1     _UL_(1 << 10)
 /* ========== GPIO definition for ABDACB peripheral ========== */
-#define PIN_PA31C_ABDACB_CLK           _L(31) /**< \brief ABDACB signal: CLK on PA31 mux C */
-#define MUX_PA31C_ABDACB_CLK            _L(2)
+#define PIN_PA31C_ABDACB_CLK           _L_(31) /**< \brief ABDACB signal: CLK on PA31 mux C */
+#define MUX_PA31C_ABDACB_CLK            _L_(2)
 #define PINMUX_PA31C_ABDACB_CLK    ((PIN_PA31C_ABDACB_CLK << 16) | MUX_PA31C_ABDACB_CLK)
-#define GPIO_PA31C_ABDACB_CLK    _UL(1 << 31)
-#define PIN_PA27C_ABDACB_DAC0          _L(27) /**< \brief ABDACB signal: DAC0 on PA27 mux C */
-#define MUX_PA27C_ABDACB_DAC0           _L(2)
+#define GPIO_PA31C_ABDACB_CLK    _UL_(1 << 31)
+#define PIN_PA27C_ABDACB_DAC0          _L_(27) /**< \brief ABDACB signal: DAC0 on PA27 mux C */
+#define MUX_PA27C_ABDACB_DAC0           _L_(2)
 #define PINMUX_PA27C_ABDACB_DAC0   ((PIN_PA27C_ABDACB_DAC0 << 16) | MUX_PA27C_ABDACB_DAC0)
-#define GPIO_PA27C_ABDACB_DAC0   _UL(1 << 27)
-#define PIN_PB02C_ABDACB_DAC0          _L(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
-#define MUX_PB02C_ABDACB_DAC0           _L(2)
+#define GPIO_PA27C_ABDACB_DAC0   _UL_(1 << 27)
+#define PIN_PB02C_ABDACB_DAC0          _L_(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
+#define MUX_PB02C_ABDACB_DAC0           _L_(2)
 #define PINMUX_PB02C_ABDACB_DAC0   ((PIN_PB02C_ABDACB_DAC0 << 16) | MUX_PB02C_ABDACB_DAC0)
-#define GPIO_PB02C_ABDACB_DAC0   _UL(1 <<  2)
-#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
-#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define GPIO_PB02C_ABDACB_DAC0   _UL_(1 <<  2)
+#define PIN_PA17B_ABDACB_DAC0          _L_(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L_(1)
 #define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
-#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
-#define PIN_PA29C_ABDACB_DAC1          _L(29) /**< \brief ABDACB signal: DAC1 on PA29 mux C */
-#define MUX_PA29C_ABDACB_DAC1           _L(2)
+#define GPIO_PA17B_ABDACB_DAC0   _UL_(1 << 17)
+#define PIN_PA29C_ABDACB_DAC1          _L_(29) /**< \brief ABDACB signal: DAC1 on PA29 mux C */
+#define MUX_PA29C_ABDACB_DAC1           _L_(2)
 #define PINMUX_PA29C_ABDACB_DAC1   ((PIN_PA29C_ABDACB_DAC1 << 16) | MUX_PA29C_ABDACB_DAC1)
-#define GPIO_PA29C_ABDACB_DAC1   _UL(1 << 29)
-#define PIN_PB04C_ABDACB_DAC1          _L(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
-#define MUX_PB04C_ABDACB_DAC1           _L(2)
+#define GPIO_PA29C_ABDACB_DAC1   _UL_(1 << 29)
+#define PIN_PB04C_ABDACB_DAC1          _L_(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
+#define MUX_PB04C_ABDACB_DAC1           _L_(2)
 #define PINMUX_PB04C_ABDACB_DAC1   ((PIN_PB04C_ABDACB_DAC1 << 16) | MUX_PB04C_ABDACB_DAC1)
-#define GPIO_PB04C_ABDACB_DAC1   _UL(1 <<  4)
-#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
-#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define GPIO_PB04C_ABDACB_DAC1   _UL_(1 <<  4)
+#define PIN_PA19B_ABDACB_DAC1          _L_(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L_(1)
 #define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
-#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
-#define PIN_PA28C_ABDACB_DACN0         _L(28) /**< \brief ABDACB signal: DACN0 on PA28 mux C */
-#define MUX_PA28C_ABDACB_DACN0          _L(2)
+#define GPIO_PA19B_ABDACB_DAC1   _UL_(1 << 19)
+#define PIN_PA28C_ABDACB_DACN0         _L_(28) /**< \brief ABDACB signal: DACN0 on PA28 mux C */
+#define MUX_PA28C_ABDACB_DACN0          _L_(2)
 #define PINMUX_PA28C_ABDACB_DACN0  ((PIN_PA28C_ABDACB_DACN0 << 16) | MUX_PA28C_ABDACB_DACN0)
-#define GPIO_PA28C_ABDACB_DACN0  _UL(1 << 28)
-#define PIN_PB03C_ABDACB_DACN0         _L(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
-#define MUX_PB03C_ABDACB_DACN0          _L(2)
+#define GPIO_PA28C_ABDACB_DACN0  _UL_(1 << 28)
+#define PIN_PB03C_ABDACB_DACN0         _L_(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
+#define MUX_PB03C_ABDACB_DACN0          _L_(2)
 #define PINMUX_PB03C_ABDACB_DACN0  ((PIN_PB03C_ABDACB_DACN0 << 16) | MUX_PB03C_ABDACB_DACN0)
-#define GPIO_PB03C_ABDACB_DACN0  _UL(1 <<  3)
-#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
-#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define GPIO_PB03C_ABDACB_DACN0  _UL_(1 <<  3)
+#define PIN_PA18B_ABDACB_DACN0         _L_(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L_(1)
 #define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
-#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
-#define PIN_PA30C_ABDACB_DACN1         _L(30) /**< \brief ABDACB signal: DACN1 on PA30 mux C */
-#define MUX_PA30C_ABDACB_DACN1          _L(2)
+#define GPIO_PA18B_ABDACB_DACN0  _UL_(1 << 18)
+#define PIN_PA30C_ABDACB_DACN1         _L_(30) /**< \brief ABDACB signal: DACN1 on PA30 mux C */
+#define MUX_PA30C_ABDACB_DACN1          _L_(2)
 #define PINMUX_PA30C_ABDACB_DACN1  ((PIN_PA30C_ABDACB_DACN1 << 16) | MUX_PA30C_ABDACB_DACN1)
-#define GPIO_PA30C_ABDACB_DACN1  _UL(1 << 30)
-#define PIN_PB05C_ABDACB_DACN1         _L(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
-#define MUX_PB05C_ABDACB_DACN1          _L(2)
+#define GPIO_PA30C_ABDACB_DACN1  _UL_(1 << 30)
+#define PIN_PB05C_ABDACB_DACN1         _L_(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
+#define MUX_PB05C_ABDACB_DACN1          _L_(2)
 #define PINMUX_PB05C_ABDACB_DACN1  ((PIN_PB05C_ABDACB_DACN1 << 16) | MUX_PB05C_ABDACB_DACN1)
-#define GPIO_PB05C_ABDACB_DACN1  _UL(1 <<  5)
-#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
-#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define GPIO_PB05C_ABDACB_DACN1  _UL_(1 <<  5)
+#define PIN_PA20B_ABDACB_DACN1         _L_(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L_(1)
 #define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
-#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+#define GPIO_PA20B_ABDACB_DACN1  _UL_(1 << 20)
 /* ========== GPIO definition for PARC peripheral ========== */
-#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
-#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PIN_PA17D_PARC_PCCK            _L_(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L_(3)
 #define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
-#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
-#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
-#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define GPIO_PA17D_PARC_PCCK     _UL_(1 << 17)
+#define PIN_PA09D_PARC_PCDATA0          _L_(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L_(3)
 #define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
-#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
-#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
-#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define GPIO_PA09D_PARC_PCDATA0  _UL_(1 <<  9)
+#define PIN_PA10D_PARC_PCDATA1         _L_(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L_(3)
 #define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
-#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
-#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
-#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define GPIO_PA10D_PARC_PCDATA1  _UL_(1 << 10)
+#define PIN_PA11D_PARC_PCDATA2         _L_(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L_(3)
 #define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
-#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
-#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
-#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define GPIO_PA11D_PARC_PCDATA2  _UL_(1 << 11)
+#define PIN_PA12D_PARC_PCDATA3         _L_(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L_(3)
 #define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
-#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
-#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
-#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL_(1 << 12)
+#define PIN_PA13D_PARC_PCDATA4         _L_(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L_(3)
 #define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
-#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
-#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
-#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define GPIO_PA13D_PARC_PCDATA4  _UL_(1 << 13)
+#define PIN_PA14D_PARC_PCDATA5         _L_(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L_(3)
 #define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
-#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
-#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
-#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define GPIO_PA14D_PARC_PCDATA5  _UL_(1 << 14)
+#define PIN_PA15D_PARC_PCDATA6         _L_(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L_(3)
 #define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
-#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
-#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
-#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define GPIO_PA15D_PARC_PCDATA6  _UL_(1 << 15)
+#define PIN_PA16D_PARC_PCDATA7         _L_(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L_(3)
 #define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
-#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
-#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
-#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define GPIO_PA16D_PARC_PCDATA7  _UL_(1 << 16)
+#define PIN_PA18D_PARC_PCEN1           _L_(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L_(3)
 #define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
-#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
-#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
-#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define GPIO_PA18D_PARC_PCEN1    _UL_(1 << 18)
+#define PIN_PA19D_PARC_PCEN2           _L_(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L_(3)
 #define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
-#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+#define GPIO_PA19D_PARC_PCEN2    _UL_(1 << 19)
 /* ========== GPIO definition for CATB peripheral ========== */
-#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
-#define MUX_PA02G_CATB_DIS              _L(6)
+#define PIN_PA02G_CATB_DIS              _L_(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L_(6)
 #define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
-#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
-#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
-#define MUX_PA12G_CATB_DIS              _L(6)
+#define GPIO_PA02G_CATB_DIS      _UL_(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L_(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L_(6)
 #define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
-#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
-#define MUX_PA23G_CATB_DIS              _L(6)
+#define GPIO_PA12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L_(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L_(6)
 #define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
-#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
-#define PIN_PA31G_CATB_DIS             _L(31) /**< \brief CATB signal: DIS on PA31 mux G */
-#define MUX_PA31G_CATB_DIS              _L(6)
+#define GPIO_PA23G_CATB_DIS      _UL_(1 << 23)
+#define PIN_PA31G_CATB_DIS             _L_(31) /**< \brief CATB signal: DIS on PA31 mux G */
+#define MUX_PA31G_CATB_DIS              _L_(6)
 #define PINMUX_PA31G_CATB_DIS      ((PIN_PA31G_CATB_DIS << 16) | MUX_PA31G_CATB_DIS)
-#define GPIO_PA31G_CATB_DIS      _UL(1 << 31)
-#define PIN_PB03G_CATB_DIS             _L(35) /**< \brief CATB signal: DIS on PB03 mux G */
-#define MUX_PB03G_CATB_DIS              _L(6)
+#define GPIO_PA31G_CATB_DIS      _UL_(1 << 31)
+#define PIN_PB03G_CATB_DIS             _L_(35) /**< \brief CATB signal: DIS on PB03 mux G */
+#define MUX_PB03G_CATB_DIS              _L_(6)
 #define PINMUX_PB03G_CATB_DIS      ((PIN_PB03G_CATB_DIS << 16) | MUX_PB03G_CATB_DIS)
-#define GPIO_PB03G_CATB_DIS      _UL(1 <<  3)
-#define PIN_PB12G_CATB_DIS             _L(44) /**< \brief CATB signal: DIS on PB12 mux G */
-#define MUX_PB12G_CATB_DIS              _L(6)
+#define GPIO_PB03G_CATB_DIS      _UL_(1 <<  3)
+#define PIN_PB12G_CATB_DIS             _L_(44) /**< \brief CATB signal: DIS on PB12 mux G */
+#define MUX_PB12G_CATB_DIS              _L_(6)
 #define PINMUX_PB12G_CATB_DIS      ((PIN_PB12G_CATB_DIS << 16) | MUX_PB12G_CATB_DIS)
-#define GPIO_PB12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
-#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define GPIO_PB12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PA04G_CATB_SENSE0           _L_(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L_(6)
 #define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
-#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
-#define PIN_PA27G_CATB_SENSE0          _L(27) /**< \brief CATB signal: SENSE0 on PA27 mux G */
-#define MUX_PA27G_CATB_SENSE0           _L(6)
+#define GPIO_PA04G_CATB_SENSE0   _UL_(1 <<  4)
+#define PIN_PA27G_CATB_SENSE0          _L_(27) /**< \brief CATB signal: SENSE0 on PA27 mux G */
+#define MUX_PA27G_CATB_SENSE0           _L_(6)
 #define PINMUX_PA27G_CATB_SENSE0   ((PIN_PA27G_CATB_SENSE0 << 16) | MUX_PA27G_CATB_SENSE0)
-#define GPIO_PA27G_CATB_SENSE0   _UL(1 << 27)
-#define PIN_PB13G_CATB_SENSE0          _L(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
-#define MUX_PB13G_CATB_SENSE0           _L(6)
+#define GPIO_PA27G_CATB_SENSE0   _UL_(1 << 27)
+#define PIN_PB13G_CATB_SENSE0          _L_(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
+#define MUX_PB13G_CATB_SENSE0           _L_(6)
 #define PINMUX_PB13G_CATB_SENSE0   ((PIN_PB13G_CATB_SENSE0 << 16) | MUX_PB13G_CATB_SENSE0)
-#define GPIO_PB13G_CATB_SENSE0   _UL(1 << 13)
-#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
-#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define GPIO_PB13G_CATB_SENSE0   _UL_(1 << 13)
+#define PIN_PA05G_CATB_SENSE1           _L_(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L_(6)
 #define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
-#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
-#define PIN_PA28G_CATB_SENSE1          _L(28) /**< \brief CATB signal: SENSE1 on PA28 mux G */
-#define MUX_PA28G_CATB_SENSE1           _L(6)
+#define GPIO_PA05G_CATB_SENSE1   _UL_(1 <<  5)
+#define PIN_PA28G_CATB_SENSE1          _L_(28) /**< \brief CATB signal: SENSE1 on PA28 mux G */
+#define MUX_PA28G_CATB_SENSE1           _L_(6)
 #define PINMUX_PA28G_CATB_SENSE1   ((PIN_PA28G_CATB_SENSE1 << 16) | MUX_PA28G_CATB_SENSE1)
-#define GPIO_PA28G_CATB_SENSE1   _UL(1 << 28)
-#define PIN_PB14G_CATB_SENSE1          _L(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
-#define MUX_PB14G_CATB_SENSE1           _L(6)
+#define GPIO_PA28G_CATB_SENSE1   _UL_(1 << 28)
+#define PIN_PB14G_CATB_SENSE1          _L_(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
+#define MUX_PB14G_CATB_SENSE1           _L_(6)
 #define PINMUX_PB14G_CATB_SENSE1   ((PIN_PB14G_CATB_SENSE1 << 16) | MUX_PB14G_CATB_SENSE1)
-#define GPIO_PB14G_CATB_SENSE1   _UL(1 << 14)
-#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
-#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define GPIO_PB14G_CATB_SENSE1   _UL_(1 << 14)
+#define PIN_PA06G_CATB_SENSE2           _L_(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L_(6)
 #define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
-#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
-#define PIN_PA29G_CATB_SENSE2          _L(29) /**< \brief CATB signal: SENSE2 on PA29 mux G */
-#define MUX_PA29G_CATB_SENSE2           _L(6)
+#define GPIO_PA06G_CATB_SENSE2   _UL_(1 <<  6)
+#define PIN_PA29G_CATB_SENSE2          _L_(29) /**< \brief CATB signal: SENSE2 on PA29 mux G */
+#define MUX_PA29G_CATB_SENSE2           _L_(6)
 #define PINMUX_PA29G_CATB_SENSE2   ((PIN_PA29G_CATB_SENSE2 << 16) | MUX_PA29G_CATB_SENSE2)
-#define GPIO_PA29G_CATB_SENSE2   _UL(1 << 29)
-#define PIN_PB15G_CATB_SENSE2          _L(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
-#define MUX_PB15G_CATB_SENSE2           _L(6)
+#define GPIO_PA29G_CATB_SENSE2   _UL_(1 << 29)
+#define PIN_PB15G_CATB_SENSE2          _L_(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
+#define MUX_PB15G_CATB_SENSE2           _L_(6)
 #define PINMUX_PB15G_CATB_SENSE2   ((PIN_PB15G_CATB_SENSE2 << 16) | MUX_PB15G_CATB_SENSE2)
-#define GPIO_PB15G_CATB_SENSE2   _UL(1 << 15)
-#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
-#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define GPIO_PB15G_CATB_SENSE2   _UL_(1 << 15)
+#define PIN_PA07G_CATB_SENSE3           _L_(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L_(6)
 #define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
-#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
-#define PIN_PA30G_CATB_SENSE3          _L(30) /**< \brief CATB signal: SENSE3 on PA30 mux G */
-#define MUX_PA30G_CATB_SENSE3           _L(6)
+#define GPIO_PA07G_CATB_SENSE3   _UL_(1 <<  7)
+#define PIN_PA30G_CATB_SENSE3          _L_(30) /**< \brief CATB signal: SENSE3 on PA30 mux G */
+#define MUX_PA30G_CATB_SENSE3           _L_(6)
 #define PINMUX_PA30G_CATB_SENSE3   ((PIN_PA30G_CATB_SENSE3 << 16) | MUX_PA30G_CATB_SENSE3)
-#define GPIO_PA30G_CATB_SENSE3   _UL(1 << 30)
-#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
-#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define GPIO_PA30G_CATB_SENSE3   _UL_(1 << 30)
+#define PIN_PA08G_CATB_SENSE4           _L_(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L_(6)
 #define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
-#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
-#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
-#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define GPIO_PA08G_CATB_SENSE4   _UL_(1 <<  8)
+#define PIN_PA09G_CATB_SENSE5           _L_(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L_(6)
 #define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
-#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
-#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
-#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define GPIO_PA09G_CATB_SENSE5   _UL_(1 <<  9)
+#define PIN_PA10G_CATB_SENSE6          _L_(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L_(6)
 #define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
-#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
-#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
-#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define GPIO_PA10G_CATB_SENSE6   _UL_(1 << 10)
+#define PIN_PA11G_CATB_SENSE7          _L_(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L_(6)
 #define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
-#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
-#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
-#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define GPIO_PA11G_CATB_SENSE7   _UL_(1 << 11)
+#define PIN_PA13G_CATB_SENSE8          _L_(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L_(6)
 #define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
-#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
-#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
-#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define GPIO_PA13G_CATB_SENSE8   _UL_(1 << 13)
+#define PIN_PA14G_CATB_SENSE9          _L_(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L_(6)
 #define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
-#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
-#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
-#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define GPIO_PA14G_CATB_SENSE9   _UL_(1 << 14)
+#define PIN_PA15G_CATB_SENSE10         _L_(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L_(6)
 #define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
-#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
-#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
-#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define GPIO_PA15G_CATB_SENSE10  _UL_(1 << 15)
+#define PIN_PA16G_CATB_SENSE11         _L_(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L_(6)
 #define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
-#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
-#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
-#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define GPIO_PA16G_CATB_SENSE11  _UL_(1 << 16)
+#define PIN_PA17G_CATB_SENSE12         _L_(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L_(6)
 #define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
-#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
-#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
-#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define GPIO_PA17G_CATB_SENSE12  _UL_(1 << 17)
+#define PIN_PA18G_CATB_SENSE13         _L_(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L_(6)
 #define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
-#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
-#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
-#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define GPIO_PA18G_CATB_SENSE13  _UL_(1 << 18)
+#define PIN_PA19G_CATB_SENSE14         _L_(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L_(6)
 #define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
-#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
-#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
-#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define GPIO_PA19G_CATB_SENSE14  _UL_(1 << 19)
+#define PIN_PA20G_CATB_SENSE15         _L_(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L_(6)
 #define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
-#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
-#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
-#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define GPIO_PA20G_CATB_SENSE15  _UL_(1 << 20)
+#define PIN_PA21G_CATB_SENSE16         _L_(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L_(6)
 #define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
-#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
-#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
-#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define GPIO_PA21G_CATB_SENSE16  _UL_(1 << 21)
+#define PIN_PA22G_CATB_SENSE17         _L_(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L_(6)
 #define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
-#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
-#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
-#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define GPIO_PA22G_CATB_SENSE17  _UL_(1 << 22)
+#define PIN_PA24G_CATB_SENSE18         _L_(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L_(6)
 #define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
-#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
-#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
-#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define GPIO_PA24G_CATB_SENSE18  _UL_(1 << 24)
+#define PIN_PA25G_CATB_SENSE19         _L_(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L_(6)
 #define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
-#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
-#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
-#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define GPIO_PA25G_CATB_SENSE19  _UL_(1 << 25)
+#define PIN_PA26G_CATB_SENSE20         _L_(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L_(6)
 #define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
-#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
-#define PIN_PB00G_CATB_SENSE21         _L(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
-#define MUX_PB00G_CATB_SENSE21          _L(6)
+#define GPIO_PA26G_CATB_SENSE20  _UL_(1 << 26)
+#define PIN_PB00G_CATB_SENSE21         _L_(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
+#define MUX_PB00G_CATB_SENSE21          _L_(6)
 #define PINMUX_PB00G_CATB_SENSE21  ((PIN_PB00G_CATB_SENSE21 << 16) | MUX_PB00G_CATB_SENSE21)
-#define GPIO_PB00G_CATB_SENSE21  _UL(1 <<  0)
-#define PIN_PB01G_CATB_SENSE22         _L(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
-#define MUX_PB01G_CATB_SENSE22          _L(6)
+#define GPIO_PB00G_CATB_SENSE21  _UL_(1 <<  0)
+#define PIN_PB01G_CATB_SENSE22         _L_(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
+#define MUX_PB01G_CATB_SENSE22          _L_(6)
 #define PINMUX_PB01G_CATB_SENSE22  ((PIN_PB01G_CATB_SENSE22 << 16) | MUX_PB01G_CATB_SENSE22)
-#define GPIO_PB01G_CATB_SENSE22  _UL(1 <<  1)
-#define PIN_PB02G_CATB_SENSE23         _L(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
-#define MUX_PB02G_CATB_SENSE23          _L(6)
+#define GPIO_PB01G_CATB_SENSE22  _UL_(1 <<  1)
+#define PIN_PB02G_CATB_SENSE23         _L_(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
+#define MUX_PB02G_CATB_SENSE23          _L_(6)
 #define PINMUX_PB02G_CATB_SENSE23  ((PIN_PB02G_CATB_SENSE23 << 16) | MUX_PB02G_CATB_SENSE23)
-#define GPIO_PB02G_CATB_SENSE23  _UL(1 <<  2)
-#define PIN_PB04G_CATB_SENSE24         _L(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
-#define MUX_PB04G_CATB_SENSE24          _L(6)
+#define GPIO_PB02G_CATB_SENSE23  _UL_(1 <<  2)
+#define PIN_PB04G_CATB_SENSE24         _L_(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
+#define MUX_PB04G_CATB_SENSE24          _L_(6)
 #define PINMUX_PB04G_CATB_SENSE24  ((PIN_PB04G_CATB_SENSE24 << 16) | MUX_PB04G_CATB_SENSE24)
-#define GPIO_PB04G_CATB_SENSE24  _UL(1 <<  4)
-#define PIN_PB05G_CATB_SENSE25         _L(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
-#define MUX_PB05G_CATB_SENSE25          _L(6)
+#define GPIO_PB04G_CATB_SENSE24  _UL_(1 <<  4)
+#define PIN_PB05G_CATB_SENSE25         _L_(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
+#define MUX_PB05G_CATB_SENSE25          _L_(6)
 #define PINMUX_PB05G_CATB_SENSE25  ((PIN_PB05G_CATB_SENSE25 << 16) | MUX_PB05G_CATB_SENSE25)
-#define GPIO_PB05G_CATB_SENSE25  _UL(1 <<  5)
-#define PIN_PB06G_CATB_SENSE26         _L(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
-#define MUX_PB06G_CATB_SENSE26          _L(6)
+#define GPIO_PB05G_CATB_SENSE25  _UL_(1 <<  5)
+#define PIN_PB06G_CATB_SENSE26         _L_(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
+#define MUX_PB06G_CATB_SENSE26          _L_(6)
 #define PINMUX_PB06G_CATB_SENSE26  ((PIN_PB06G_CATB_SENSE26 << 16) | MUX_PB06G_CATB_SENSE26)
-#define GPIO_PB06G_CATB_SENSE26  _UL(1 <<  6)
-#define PIN_PB07G_CATB_SENSE27         _L(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
-#define MUX_PB07G_CATB_SENSE27          _L(6)
+#define GPIO_PB06G_CATB_SENSE26  _UL_(1 <<  6)
+#define PIN_PB07G_CATB_SENSE27         _L_(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
+#define MUX_PB07G_CATB_SENSE27          _L_(6)
 #define PINMUX_PB07G_CATB_SENSE27  ((PIN_PB07G_CATB_SENSE27 << 16) | MUX_PB07G_CATB_SENSE27)
-#define GPIO_PB07G_CATB_SENSE27  _UL(1 <<  7)
-#define PIN_PB08G_CATB_SENSE28         _L(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
-#define MUX_PB08G_CATB_SENSE28          _L(6)
+#define GPIO_PB07G_CATB_SENSE27  _UL_(1 <<  7)
+#define PIN_PB08G_CATB_SENSE28         _L_(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
+#define MUX_PB08G_CATB_SENSE28          _L_(6)
 #define PINMUX_PB08G_CATB_SENSE28  ((PIN_PB08G_CATB_SENSE28 << 16) | MUX_PB08G_CATB_SENSE28)
-#define GPIO_PB08G_CATB_SENSE28  _UL(1 <<  8)
-#define PIN_PB09G_CATB_SENSE29         _L(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
-#define MUX_PB09G_CATB_SENSE29          _L(6)
+#define GPIO_PB08G_CATB_SENSE28  _UL_(1 <<  8)
+#define PIN_PB09G_CATB_SENSE29         _L_(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
+#define MUX_PB09G_CATB_SENSE29          _L_(6)
 #define PINMUX_PB09G_CATB_SENSE29  ((PIN_PB09G_CATB_SENSE29 << 16) | MUX_PB09G_CATB_SENSE29)
-#define GPIO_PB09G_CATB_SENSE29  _UL(1 <<  9)
-#define PIN_PB10G_CATB_SENSE30         _L(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
-#define MUX_PB10G_CATB_SENSE30          _L(6)
+#define GPIO_PB09G_CATB_SENSE29  _UL_(1 <<  9)
+#define PIN_PB10G_CATB_SENSE30         _L_(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
+#define MUX_PB10G_CATB_SENSE30          _L_(6)
 #define PINMUX_PB10G_CATB_SENSE30  ((PIN_PB10G_CATB_SENSE30 << 16) | MUX_PB10G_CATB_SENSE30)
-#define GPIO_PB10G_CATB_SENSE30  _UL(1 << 10)
-#define PIN_PB11G_CATB_SENSE31         _L(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
-#define MUX_PB11G_CATB_SENSE31          _L(6)
+#define GPIO_PB10G_CATB_SENSE30  _UL_(1 << 10)
+#define PIN_PB11G_CATB_SENSE31         _L_(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
+#define MUX_PB11G_CATB_SENSE31          _L_(6)
 #define PINMUX_PB11G_CATB_SENSE31  ((PIN_PB11G_CATB_SENSE31 << 16) | MUX_PB11G_CATB_SENSE31)
-#define GPIO_PB11G_CATB_SENSE31  _UL(1 << 11)
+#define GPIO_PB11G_CATB_SENSE31  _UL_(1 << 11)
 /* ========== GPIO definition for USBC peripheral ========== */
-#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
-#define MUX_PA25A_USBC_DM               _L(0)
+#define PIN_PA25A_USBC_DM              _L_(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L_(0)
 #define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
-#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
-#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
-#define MUX_PA26A_USBC_DP               _L(0)
+#define GPIO_PA25A_USBC_DM       _UL_(1 << 25)
+#define PIN_PA26A_USBC_DP              _L_(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L_(0)
 #define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
-#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+#define GPIO_PA26A_USBC_DP       _UL_(1 << 26)
 /* ========== GPIO definition for PEVC peripheral ========== */
-#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
-#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PIN_PA08C_PEVC_PAD_EVT0         _L_(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
-#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
-#define PIN_PB12C_PEVC_PAD_EVT0        _L(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
-#define MUX_PB12C_PEVC_PAD_EVT0         _L(2)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL_(1 <<  8)
+#define PIN_PB12C_PEVC_PAD_EVT0        _L_(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
+#define MUX_PB12C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PB12C_PEVC_PAD_EVT0  ((PIN_PB12C_PEVC_PAD_EVT0 << 16) | MUX_PB12C_PEVC_PAD_EVT0)
-#define GPIO_PB12C_PEVC_PAD_EVT0  _UL(1 << 12)
-#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
-#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PB12C_PEVC_PAD_EVT0  _UL_(1 << 12)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L_(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
-#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
-#define PIN_PB13C_PEVC_PAD_EVT1        _L(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
-#define MUX_PB13C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL_(1 <<  9)
+#define PIN_PB13C_PEVC_PAD_EVT1        _L_(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
+#define MUX_PB13C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PB13C_PEVC_PAD_EVT1  ((PIN_PB13C_PEVC_PAD_EVT1 << 16) | MUX_PB13C_PEVC_PAD_EVT1)
-#define GPIO_PB13C_PEVC_PAD_EVT1  _UL(1 << 13)
-#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
-#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PB13C_PEVC_PAD_EVT1  _UL_(1 << 13)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L_(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
-#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
-#define PIN_PB09B_PEVC_PAD_EVT2        _L(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
-#define MUX_PB09B_PEVC_PAD_EVT2         _L(1)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL_(1 << 10)
+#define PIN_PB09B_PEVC_PAD_EVT2        _L_(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
+#define MUX_PB09B_PEVC_PAD_EVT2         _L_(1)
 #define PINMUX_PB09B_PEVC_PAD_EVT2  ((PIN_PB09B_PEVC_PAD_EVT2 << 16) | MUX_PB09B_PEVC_PAD_EVT2)
-#define GPIO_PB09B_PEVC_PAD_EVT2  _UL(1 <<  9)
-#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
-#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define GPIO_PB09B_PEVC_PAD_EVT2  _UL_(1 <<  9)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L_(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L_(2)
 #define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
-#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
-#define PIN_PB10B_PEVC_PAD_EVT3        _L(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
-#define MUX_PB10B_PEVC_PAD_EVT3         _L(1)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL_(1 << 11)
+#define PIN_PB10B_PEVC_PAD_EVT3        _L_(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
+#define MUX_PB10B_PEVC_PAD_EVT3         _L_(1)
 #define PINMUX_PB10B_PEVC_PAD_EVT3  ((PIN_PB10B_PEVC_PAD_EVT3 << 16) | MUX_PB10B_PEVC_PAD_EVT3)
-#define GPIO_PB10B_PEVC_PAD_EVT3  _UL(1 << 10)
+#define GPIO_PB10B_PEVC_PAD_EVT3  _UL_(1 << 10)
 /* ========== GPIO definition for SCIF peripheral ========== */
-#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
-#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PIN_PA19E_SCIF_GCLK0           _L_(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
-#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
-#define PIN_PB10E_SCIF_GCLK0           _L(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
-#define MUX_PB10E_SCIF_GCLK0            _L(4)
+#define GPIO_PA19E_SCIF_GCLK0    _UL_(1 << 19)
+#define PIN_PB10E_SCIF_GCLK0           _L_(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
+#define MUX_PB10E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PB10E_SCIF_GCLK0    ((PIN_PB10E_SCIF_GCLK0 << 16) | MUX_PB10E_SCIF_GCLK0)
-#define GPIO_PB10E_SCIF_GCLK0    _UL(1 << 10)
-#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
-#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define GPIO_PB10E_SCIF_GCLK0    _UL_(1 << 10)
+#define PIN_PA02A_SCIF_GCLK0            _L_(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L_(0)
 #define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
-#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
-#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
-#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define GPIO_PA02A_SCIF_GCLK0    _UL_(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L_(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
-#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
-#define PIN_PB11E_SCIF_GCLK1           _L(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
-#define MUX_PB11E_SCIF_GCLK1            _L(4)
+#define GPIO_PA20E_SCIF_GCLK1    _UL_(1 << 20)
+#define PIN_PB11E_SCIF_GCLK1           _L_(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
+#define MUX_PB11E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PB11E_SCIF_GCLK1    ((PIN_PB11E_SCIF_GCLK1 << 16) | MUX_PB11E_SCIF_GCLK1)
-#define GPIO_PB11E_SCIF_GCLK1    _UL(1 << 11)
-#define PIN_PB12E_SCIF_GCLK2           _L(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
-#define MUX_PB12E_SCIF_GCLK2            _L(4)
+#define GPIO_PB11E_SCIF_GCLK1    _UL_(1 << 11)
+#define PIN_PB12E_SCIF_GCLK2           _L_(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
+#define MUX_PB12E_SCIF_GCLK2            _L_(4)
 #define PINMUX_PB12E_SCIF_GCLK2    ((PIN_PB12E_SCIF_GCLK2 << 16) | MUX_PB12E_SCIF_GCLK2)
-#define GPIO_PB12E_SCIF_GCLK2    _UL(1 << 12)
-#define PIN_PB13E_SCIF_GCLK3           _L(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
-#define MUX_PB13E_SCIF_GCLK3            _L(4)
+#define GPIO_PB12E_SCIF_GCLK2    _UL_(1 << 12)
+#define PIN_PB13E_SCIF_GCLK3           _L_(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
+#define MUX_PB13E_SCIF_GCLK3            _L_(4)
 #define PINMUX_PB13E_SCIF_GCLK3    ((PIN_PB13E_SCIF_GCLK3 << 16) | MUX_PB13E_SCIF_GCLK3)
-#define GPIO_PB13E_SCIF_GCLK3    _UL(1 << 13)
-#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
-#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PB13E_SCIF_GCLK3    _UL_(1 << 13)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L_(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
-#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
-#define PIN_PB14E_SCIF_GCLK_IN0        _L(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
-#define MUX_PB14E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL_(1 << 23)
+#define PIN_PB14E_SCIF_GCLK_IN0        _L_(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
+#define MUX_PB14E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PB14E_SCIF_GCLK_IN0  ((PIN_PB14E_SCIF_GCLK_IN0 << 16) | MUX_PB14E_SCIF_GCLK_IN0)
-#define GPIO_PB14E_SCIF_GCLK_IN0  _UL(1 << 14)
-#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
-#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PB14E_SCIF_GCLK_IN0  _UL_(1 << 14)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L_(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
-#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
-#define PIN_PB15E_SCIF_GCLK_IN1        _L(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
-#define MUX_PB15E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL_(1 << 24)
+#define PIN_PB15E_SCIF_GCLK_IN1        _L_(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
+#define MUX_PB15E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PB15E_SCIF_GCLK_IN1  ((PIN_PB15E_SCIF_GCLK_IN1 << 16) | MUX_PB15E_SCIF_GCLK_IN1)
-#define GPIO_PB15E_SCIF_GCLK_IN1  _UL(1 << 15)
+#define GPIO_PB15E_SCIF_GCLK_IN1  _UL_(1 << 15)
 /* ========== GPIO definition for EIC peripheral ========== */
-#define PIN_PB01C_EIC_EXTINT0          _L(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
-#define MUX_PB01C_EIC_EXTINT0           _L(2)
+#define PIN_PB01C_EIC_EXTINT0          _L_(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
+#define MUX_PB01C_EIC_EXTINT0           _L_(2)
 #define PINMUX_PB01C_EIC_EXTINT0   ((PIN_PB01C_EIC_EXTINT0 << 16) | MUX_PB01C_EIC_EXTINT0)
-#define GPIO_PB01C_EIC_EXTINT0   _UL(1 <<  1)
-#define PIN_PB01C_EIC_EXTINT_NUM        _L(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
-#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
-#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define GPIO_PB01C_EIC_EXTINT0   _UL_(1 <<  1)
+#define PIN_PB01C_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PA06C_EIC_EXTINT1           _L_(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
-#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
-#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
-#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
-#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define GPIO_PA06C_EIC_EXTINT1   _UL_(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L_(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
-#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
-#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
-#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
-#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define GPIO_PA16C_EIC_EXTINT1   _UL_(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L_(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
-#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
-#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
-#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
-#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL_(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L_(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
-#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
-#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
-#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
-#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL_(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L_(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
-#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
-#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
-#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
-#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define GPIO_PA05C_EIC_EXTINT3   _UL_(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L_(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
-#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
-#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
-#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
-#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define GPIO_PA18C_EIC_EXTINT3   _UL_(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L_(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
-#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
-#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
-#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
-#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define GPIO_PA07C_EIC_EXTINT4   _UL_(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L_(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
-#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
-#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
-#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
-#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define GPIO_PA19C_EIC_EXTINT4   _UL_(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L_(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L_(2)
 #define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
-#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
-#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
-#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
-#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define GPIO_PA20C_EIC_EXTINT5   _UL_(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L_(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L_(2)
 #define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
-#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
-#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
-#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
-#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define GPIO_PA21C_EIC_EXTINT6   _UL_(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L_(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L_(2)
 #define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
-#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
-#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
-#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
-#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define GPIO_PA22C_EIC_EXTINT7   _UL_(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L_(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L_(2)
 #define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
-#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
-#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define GPIO_PA23C_EIC_EXTINT8   _UL_(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
 
 #endif /* _SAM4LS4B_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4ls4b.h
+++ b/asf/sam/include/sam4l/pio/sam4ls4b.h
@@ -1,0 +1,1100 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAM4LS4B
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LS4B_PIO_
+#define _SAM4LS4B_PIO_
+
+#define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
+#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
+#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
+#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
+#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
+#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
+#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
+#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
+#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
+#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
+#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
+#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
+#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
+#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
+#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
+#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
+#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
+#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
+#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
+#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
+#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
+#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
+#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
+#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
+#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
+#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
+#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
+#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
+#define GPIO_PA27                _UL(1 << 27) /**< \brief GPIO Mask  for PA27 */
+#define PIN_PA28                          28  /**< \brief Pin Number for PA28 */
+#define GPIO_PA28                _UL(1 << 28) /**< \brief GPIO Mask  for PA28 */
+#define PIN_PA29                          29  /**< \brief Pin Number for PA29 */
+#define GPIO_PA29                _UL(1 << 29) /**< \brief GPIO Mask  for PA29 */
+#define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
+#define GPIO_PA30                _UL(1 << 30) /**< \brief GPIO Mask  for PA30 */
+#define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
+#define GPIO_PA31                _UL(1 << 31) /**< \brief GPIO Mask  for PA31 */
+#define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
+#define GPIO_PB00                _UL(1 <<  0) /**< \brief GPIO Mask  for PB00 */
+#define PIN_PB01                          33  /**< \brief Pin Number for PB01 */
+#define GPIO_PB01                _UL(1 <<  1) /**< \brief GPIO Mask  for PB01 */
+#define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
+#define GPIO_PB02                _UL(1 <<  2) /**< \brief GPIO Mask  for PB02 */
+#define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
+#define GPIO_PB03                _UL(1 <<  3) /**< \brief GPIO Mask  for PB03 */
+#define PIN_PB04                          36  /**< \brief Pin Number for PB04 */
+#define GPIO_PB04                _UL(1 <<  4) /**< \brief GPIO Mask  for PB04 */
+#define PIN_PB05                          37  /**< \brief Pin Number for PB05 */
+#define GPIO_PB05                _UL(1 <<  5) /**< \brief GPIO Mask  for PB05 */
+#define PIN_PB06                          38  /**< \brief Pin Number for PB06 */
+#define GPIO_PB06                _UL(1 <<  6) /**< \brief GPIO Mask  for PB06 */
+#define PIN_PB07                          39  /**< \brief Pin Number for PB07 */
+#define GPIO_PB07                _UL(1 <<  7) /**< \brief GPIO Mask  for PB07 */
+#define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
+#define GPIO_PB08                _UL(1 <<  8) /**< \brief GPIO Mask  for PB08 */
+#define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
+#define GPIO_PB09                _UL(1 <<  9) /**< \brief GPIO Mask  for PB09 */
+#define PIN_PB10                          42  /**< \brief Pin Number for PB10 */
+#define GPIO_PB10                _UL(1 << 10) /**< \brief GPIO Mask  for PB10 */
+#define PIN_PB11                          43  /**< \brief Pin Number for PB11 */
+#define GPIO_PB11                _UL(1 << 11) /**< \brief GPIO Mask  for PB11 */
+#define PIN_PB12                          44  /**< \brief Pin Number for PB12 */
+#define GPIO_PB12                _UL(1 << 12) /**< \brief GPIO Mask  for PB12 */
+#define PIN_PB13                          45  /**< \brief Pin Number for PB13 */
+#define GPIO_PB13                _UL(1 << 13) /**< \brief GPIO Mask  for PB13 */
+#define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
+#define GPIO_PB14                _UL(1 << 14) /**< \brief GPIO Mask  for PB14 */
+#define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
+#define GPIO_PB15                _UL(1 << 15) /**< \brief GPIO Mask  for PB15 */
+/* ========== GPIO definition for TWIMS0 peripheral ========== */
+#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
+#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+/* ========== GPIO definition for TWIMS1 peripheral ========== */
+#define PIN_PB01A_TWIMS1_TWCK          _L(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
+#define MUX_PB01A_TWIMS1_TWCK           _L(0)
+#define PINMUX_PB01A_TWIMS1_TWCK   ((PIN_PB01A_TWIMS1_TWCK << 16) | MUX_PB01A_TWIMS1_TWCK)
+#define GPIO_PB01A_TWIMS1_TWCK   _UL(1 <<  1)
+#define PIN_PB00A_TWIMS1_TWD           _L(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
+#define MUX_PB00A_TWIMS1_TWD            _L(0)
+#define PINMUX_PB00A_TWIMS1_TWD    ((PIN_PB00A_TWIMS1_TWD << 16) | MUX_PB00A_TWIMS1_TWD)
+#define GPIO_PB00A_TWIMS1_TWD    _UL(1 <<  0)
+/* ========== GPIO definition for TWIMS2 peripheral ========== */
+#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
+#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+/* ========== GPIO definition for TWIMS3 peripheral ========== */
+#define PIN_PB15C_TWIMS3_TWCK          _L(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
+#define MUX_PB15C_TWIMS3_TWCK           _L(2)
+#define PINMUX_PB15C_TWIMS3_TWCK   ((PIN_PB15C_TWIMS3_TWCK << 16) | MUX_PB15C_TWIMS3_TWCK)
+#define GPIO_PB15C_TWIMS3_TWCK   _UL(1 << 15)
+#define PIN_PB14C_TWIMS3_TWD           _L(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
+#define MUX_PB14C_TWIMS3_TWD            _L(2)
+#define PINMUX_PB14C_TWIMS3_TWD    ((PIN_PB14C_TWIMS3_TWD << 16) | MUX_PB14C_TWIMS3_TWD)
+#define GPIO_PB14C_TWIMS3_TWD    _UL(1 << 14)
+/* ========== GPIO definition for IISC peripheral ========== */
+#define PIN_PB05D_IISC_IMCK            _L(37) /**< \brief IISC signal: IMCK on PB05 mux D */
+#define MUX_PB05D_IISC_IMCK             _L(3)
+#define PINMUX_PB05D_IISC_IMCK     ((PIN_PB05D_IISC_IMCK << 16) | MUX_PB05D_IISC_IMCK)
+#define GPIO_PB05D_IISC_IMCK     _UL(1 <<  5)
+#define PIN_PA31B_IISC_IMCK            _L(31) /**< \brief IISC signal: IMCK on PA31 mux B */
+#define MUX_PA31B_IISC_IMCK             _L(1)
+#define PINMUX_PA31B_IISC_IMCK     ((PIN_PA31B_IISC_IMCK << 16) | MUX_PA31B_IISC_IMCK)
+#define GPIO_PA31B_IISC_IMCK     _UL(1 << 31)
+#define PIN_PB02D_IISC_ISCK            _L(34) /**< \brief IISC signal: ISCK on PB02 mux D */
+#define MUX_PB02D_IISC_ISCK             _L(3)
+#define PINMUX_PB02D_IISC_ISCK     ((PIN_PB02D_IISC_ISCK << 16) | MUX_PB02D_IISC_ISCK)
+#define GPIO_PB02D_IISC_ISCK     _UL(1 <<  2)
+#define PIN_PA27B_IISC_ISCK            _L(27) /**< \brief IISC signal: ISCK on PA27 mux B */
+#define MUX_PA27B_IISC_ISCK             _L(1)
+#define PINMUX_PA27B_IISC_ISCK     ((PIN_PA27B_IISC_ISCK << 16) | MUX_PA27B_IISC_ISCK)
+#define GPIO_PA27B_IISC_ISCK     _UL(1 << 27)
+#define PIN_PB03D_IISC_ISDI            _L(35) /**< \brief IISC signal: ISDI on PB03 mux D */
+#define MUX_PB03D_IISC_ISDI             _L(3)
+#define PINMUX_PB03D_IISC_ISDI     ((PIN_PB03D_IISC_ISDI << 16) | MUX_PB03D_IISC_ISDI)
+#define GPIO_PB03D_IISC_ISDI     _UL(1 <<  3)
+#define PIN_PA28B_IISC_ISDI            _L(28) /**< \brief IISC signal: ISDI on PA28 mux B */
+#define MUX_PA28B_IISC_ISDI             _L(1)
+#define PINMUX_PA28B_IISC_ISDI     ((PIN_PA28B_IISC_ISDI << 16) | MUX_PA28B_IISC_ISDI)
+#define GPIO_PA28B_IISC_ISDI     _UL(1 << 28)
+#define PIN_PB04D_IISC_ISDO            _L(36) /**< \brief IISC signal: ISDO on PB04 mux D */
+#define MUX_PB04D_IISC_ISDO             _L(3)
+#define PINMUX_PB04D_IISC_ISDO     ((PIN_PB04D_IISC_ISDO << 16) | MUX_PB04D_IISC_ISDO)
+#define GPIO_PB04D_IISC_ISDO     _UL(1 <<  4)
+#define PIN_PA30B_IISC_ISDO            _L(30) /**< \brief IISC signal: ISDO on PA30 mux B */
+#define MUX_PA30B_IISC_ISDO             _L(1)
+#define PINMUX_PA30B_IISC_ISDO     ((PIN_PA30B_IISC_ISDO << 16) | MUX_PA30B_IISC_ISDO)
+#define GPIO_PA30B_IISC_ISDO     _UL(1 << 30)
+#define PIN_PB06D_IISC_IWS             _L(38) /**< \brief IISC signal: IWS on PB06 mux D */
+#define MUX_PB06D_IISC_IWS              _L(3)
+#define PINMUX_PB06D_IISC_IWS      ((PIN_PB06D_IISC_IWS << 16) | MUX_PB06D_IISC_IWS)
+#define GPIO_PB06D_IISC_IWS      _UL(1 <<  6)
+#define PIN_PA29B_IISC_IWS             _L(29) /**< \brief IISC signal: IWS on PA29 mux B */
+#define MUX_PA29B_IISC_IWS              _L(1)
+#define PINMUX_PA29B_IISC_IWS      ((PIN_PA29B_IISC_IWS << 16) | MUX_PA29B_IISC_IWS)
+#define GPIO_PA29B_IISC_IWS      _UL(1 << 29)
+/* ========== GPIO definition for SPI peripheral ========== */
+#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L(1)
+#define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
+#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
+#define PIN_PB14B_SPI_MISO             _L(46) /**< \brief SPI signal: MISO on PB14 mux B */
+#define MUX_PB14B_SPI_MISO              _L(1)
+#define PINMUX_PB14B_SPI_MISO      ((PIN_PB14B_SPI_MISO << 16) | MUX_PB14B_SPI_MISO)
+#define GPIO_PB14B_SPI_MISO      _UL(1 << 14)
+#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L(0)
+#define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
+#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
+#define PIN_PA27A_SPI_MISO             _L(27) /**< \brief SPI signal: MISO on PA27 mux A */
+#define MUX_PA27A_SPI_MISO              _L(0)
+#define PINMUX_PA27A_SPI_MISO      ((PIN_PA27A_SPI_MISO << 16) | MUX_PA27A_SPI_MISO)
+#define GPIO_PA27A_SPI_MISO      _UL(1 << 27)
+#define PIN_PB15B_SPI_MOSI             _L(47) /**< \brief SPI signal: MOSI on PB15 mux B */
+#define MUX_PB15B_SPI_MOSI              _L(1)
+#define PINMUX_PB15B_SPI_MOSI      ((PIN_PB15B_SPI_MOSI << 16) | MUX_PB15B_SPI_MOSI)
+#define GPIO_PB15B_SPI_MOSI      _UL(1 << 15)
+#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L(0)
+#define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
+#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
+#define PIN_PA28A_SPI_MOSI             _L(28) /**< \brief SPI signal: MOSI on PA28 mux A */
+#define MUX_PA28A_SPI_MOSI              _L(0)
+#define PINMUX_PA28A_SPI_MOSI      ((PIN_PA28A_SPI_MOSI << 16) | MUX_PA28A_SPI_MOSI)
+#define GPIO_PA28A_SPI_MOSI      _UL(1 << 28)
+#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
+#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
+#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
+#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
+#define PIN_PA30A_SPI_NPCS0            _L(30) /**< \brief SPI signal: NPCS0 on PA30 mux A */
+#define MUX_PA30A_SPI_NPCS0             _L(0)
+#define PINMUX_PA30A_SPI_NPCS0     ((PIN_PA30A_SPI_NPCS0 << 16) | MUX_PA30A_SPI_NPCS0)
+#define GPIO_PA30A_SPI_NPCS0     _UL(1 << 30)
+#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
+#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PB13B_SPI_NPCS1            _L(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
+#define MUX_PB13B_SPI_NPCS1             _L(1)
+#define PINMUX_PB13B_SPI_NPCS1     ((PIN_PB13B_SPI_NPCS1 << 16) | MUX_PB13B_SPI_NPCS1)
+#define GPIO_PB13B_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PA31A_SPI_NPCS1            _L(31) /**< \brief SPI signal: NPCS1 on PA31 mux A */
+#define MUX_PA31A_SPI_NPCS1             _L(0)
+#define PINMUX_PA31A_SPI_NPCS1     ((PIN_PA31A_SPI_NPCS1 << 16) | MUX_PA31A_SPI_NPCS1)
+#define GPIO_PA31A_SPI_NPCS1     _UL(1 << 31)
+#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
+#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
+#define PIN_PB11B_SPI_NPCS2            _L(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
+#define MUX_PB11B_SPI_NPCS2             _L(1)
+#define PINMUX_PB11B_SPI_NPCS2     ((PIN_PB11B_SPI_NPCS2 << 16) | MUX_PB11B_SPI_NPCS2)
+#define GPIO_PB11B_SPI_NPCS2     _UL(1 << 11)
+#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
+#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
+#define PIN_PB12B_SPI_NPCS3            _L(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
+#define MUX_PB12B_SPI_NPCS3             _L(1)
+#define PINMUX_PB12B_SPI_NPCS3     ((PIN_PB12B_SPI_NPCS3 << 16) | MUX_PB12B_SPI_NPCS3)
+#define GPIO_PB12B_SPI_NPCS3     _UL(1 << 12)
+#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L(0)
+#define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
+#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
+#define PIN_PA29A_SPI_SCK              _L(29) /**< \brief SPI signal: SCK on PA29 mux A */
+#define MUX_PA29A_SPI_SCK               _L(0)
+#define PINMUX_PA29A_SPI_SCK       ((PIN_PA29A_SPI_SCK << 16) | MUX_PA29A_SPI_SCK)
+#define GPIO_PA29A_SPI_SCK       _UL(1 << 29)
+/* ========== GPIO definition for TC0 peripheral ========== */
+#define PIN_PB07D_TC0_A0               _L(39) /**< \brief TC0 signal: A0 on PB07 mux D */
+#define MUX_PB07D_TC0_A0                _L(3)
+#define PINMUX_PB07D_TC0_A0        ((PIN_PB07D_TC0_A0 << 16) | MUX_PB07D_TC0_A0)
+#define GPIO_PB07D_TC0_A0        _UL(1 <<  7)
+#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L(1)
+#define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
+#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
+#define PIN_PB09D_TC0_A1               _L(41) /**< \brief TC0 signal: A1 on PB09 mux D */
+#define MUX_PB09D_TC0_A1                _L(3)
+#define PINMUX_PB09D_TC0_A1        ((PIN_PB09D_TC0_A1 << 16) | MUX_PB09D_TC0_A1)
+#define GPIO_PB09D_TC0_A1        _UL(1 <<  9)
+#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L(1)
+#define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
+#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
+#define PIN_PB11D_TC0_A2               _L(43) /**< \brief TC0 signal: A2 on PB11 mux D */
+#define MUX_PB11D_TC0_A2                _L(3)
+#define PINMUX_PB11D_TC0_A2        ((PIN_PB11D_TC0_A2 << 16) | MUX_PB11D_TC0_A2)
+#define GPIO_PB11D_TC0_A2        _UL(1 << 11)
+#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L(1)
+#define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
+#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
+#define PIN_PB08D_TC0_B0               _L(40) /**< \brief TC0 signal: B0 on PB08 mux D */
+#define MUX_PB08D_TC0_B0                _L(3)
+#define PINMUX_PB08D_TC0_B0        ((PIN_PB08D_TC0_B0 << 16) | MUX_PB08D_TC0_B0)
+#define GPIO_PB08D_TC0_B0        _UL(1 <<  8)
+#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L(1)
+#define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
+#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
+#define PIN_PB10D_TC0_B1               _L(42) /**< \brief TC0 signal: B1 on PB10 mux D */
+#define MUX_PB10D_TC0_B1                _L(3)
+#define PINMUX_PB10D_TC0_B1        ((PIN_PB10D_TC0_B1 << 16) | MUX_PB10D_TC0_B1)
+#define GPIO_PB10D_TC0_B1        _UL(1 << 10)
+#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L(1)
+#define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
+#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
+#define PIN_PB12D_TC0_B2               _L(44) /**< \brief TC0 signal: B2 on PB12 mux D */
+#define MUX_PB12D_TC0_B2                _L(3)
+#define PINMUX_PB12D_TC0_B2        ((PIN_PB12D_TC0_B2 << 16) | MUX_PB12D_TC0_B2)
+#define GPIO_PB12D_TC0_B2        _UL(1 << 12)
+#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L(1)
+#define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
+#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
+#define PIN_PB13D_TC0_CLK0             _L(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
+#define MUX_PB13D_TC0_CLK0              _L(3)
+#define PINMUX_PB13D_TC0_CLK0      ((PIN_PB13D_TC0_CLK0 << 16) | MUX_PB13D_TC0_CLK0)
+#define GPIO_PB13D_TC0_CLK0      _UL(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L(1)
+#define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
+#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
+#define PIN_PB14D_TC0_CLK1             _L(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
+#define MUX_PB14D_TC0_CLK1              _L(3)
+#define PINMUX_PB14D_TC0_CLK1      ((PIN_PB14D_TC0_CLK1 << 16) | MUX_PB14D_TC0_CLK1)
+#define GPIO_PB14D_TC0_CLK1      _UL(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L(1)
+#define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
+#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
+#define PIN_PB15D_TC0_CLK2             _L(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
+#define MUX_PB15D_TC0_CLK2              _L(3)
+#define PINMUX_PB15D_TC0_CLK2      ((PIN_PB15D_TC0_CLK2 << 16) | MUX_PB15D_TC0_CLK2)
+#define GPIO_PB15D_TC0_CLK2      _UL(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L(1)
+#define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
+#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+/* ========== GPIO definition for USART0 peripheral ========== */
+#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L(1)
+#define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
+#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
+#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L(0)
+#define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
+#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
+#define PIN_PB13A_USART0_CLK           _L(45) /**< \brief USART0 signal: CLK on PB13 mux A */
+#define MUX_PB13A_USART0_CLK            _L(0)
+#define PINMUX_PB13A_USART0_CLK    ((PIN_PB13A_USART0_CLK << 16) | MUX_PB13A_USART0_CLK)
+#define GPIO_PB13A_USART0_CLK    _UL(1 << 13)
+#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L(0)
+#define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
+#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
+#define PIN_PB11A_USART0_CTS           _L(43) /**< \brief USART0 signal: CTS on PB11 mux A */
+#define MUX_PB11A_USART0_CTS            _L(0)
+#define PINMUX_PB11A_USART0_CTS    ((PIN_PB11A_USART0_CTS << 16) | MUX_PB11A_USART0_CTS)
+#define GPIO_PB11A_USART0_CTS    _UL(1 << 11)
+#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L(1)
+#define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
+#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
+#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L(0)
+#define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
+#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
+#define PIN_PB12A_USART0_RTS           _L(44) /**< \brief USART0 signal: RTS on PB12 mux A */
+#define MUX_PB12A_USART0_RTS            _L(0)
+#define PINMUX_PB12A_USART0_RTS    ((PIN_PB12A_USART0_RTS << 16) | MUX_PB12A_USART0_RTS)
+#define GPIO_PB12A_USART0_RTS    _UL(1 << 12)
+#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L(1)
+#define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
+#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
+#define PIN_PB00B_USART0_RXD           _L(32) /**< \brief USART0 signal: RXD on PB00 mux B */
+#define MUX_PB00B_USART0_RXD            _L(1)
+#define PINMUX_PB00B_USART0_RXD    ((PIN_PB00B_USART0_RXD << 16) | MUX_PB00B_USART0_RXD)
+#define GPIO_PB00B_USART0_RXD    _UL(1 <<  0)
+#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L(0)
+#define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
+#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
+#define PIN_PB14A_USART0_RXD           _L(46) /**< \brief USART0 signal: RXD on PB14 mux A */
+#define MUX_PB14A_USART0_RXD            _L(0)
+#define PINMUX_PB14A_USART0_RXD    ((PIN_PB14A_USART0_RXD << 16) | MUX_PB14A_USART0_RXD)
+#define GPIO_PB14A_USART0_RXD    _UL(1 << 14)
+#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L(1)
+#define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
+#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
+#define PIN_PB01B_USART0_TXD           _L(33) /**< \brief USART0 signal: TXD on PB01 mux B */
+#define MUX_PB01B_USART0_TXD            _L(1)
+#define PINMUX_PB01B_USART0_TXD    ((PIN_PB01B_USART0_TXD << 16) | MUX_PB01B_USART0_TXD)
+#define GPIO_PB01B_USART0_TXD    _UL(1 <<  1)
+#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L(0)
+#define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
+#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
+#define PIN_PB15A_USART0_TXD           _L(47) /**< \brief USART0 signal: TXD on PB15 mux A */
+#define MUX_PB15A_USART0_TXD            _L(0)
+#define PINMUX_PB15A_USART0_TXD    ((PIN_PB15A_USART0_TXD << 16) | MUX_PB15A_USART0_TXD)
+#define GPIO_PB15A_USART0_TXD    _UL(1 << 15)
+/* ========== GPIO definition for USART1 peripheral ========== */
+#define PIN_PB03B_USART1_CLK           _L(35) /**< \brief USART1 signal: CLK on PB03 mux B */
+#define MUX_PB03B_USART1_CLK            _L(1)
+#define PINMUX_PB03B_USART1_CLK    ((PIN_PB03B_USART1_CLK << 16) | MUX_PB03B_USART1_CLK)
+#define GPIO_PB03B_USART1_CLK    _UL(1 <<  3)
+#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L(0)
+#define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
+#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
+#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L(1)
+#define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
+#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
+#define PIN_PB02B_USART1_RTS           _L(34) /**< \brief USART1 signal: RTS on PB02 mux B */
+#define MUX_PB02B_USART1_RTS            _L(1)
+#define PINMUX_PB02B_USART1_RTS    ((PIN_PB02B_USART1_RTS << 16) | MUX_PB02B_USART1_RTS)
+#define GPIO_PB02B_USART1_RTS    _UL(1 <<  2)
+#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L(0)
+#define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
+#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
+#define PIN_PB04B_USART1_RXD           _L(36) /**< \brief USART1 signal: RXD on PB04 mux B */
+#define MUX_PB04B_USART1_RXD            _L(1)
+#define PINMUX_PB04B_USART1_RXD    ((PIN_PB04B_USART1_RXD << 16) | MUX_PB04B_USART1_RXD)
+#define GPIO_PB04B_USART1_RXD    _UL(1 <<  4)
+#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L(0)
+#define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
+#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
+#define PIN_PB05B_USART1_TXD           _L(37) /**< \brief USART1 signal: TXD on PB05 mux B */
+#define MUX_PB05B_USART1_TXD            _L(1)
+#define PINMUX_PB05B_USART1_TXD    ((PIN_PB05B_USART1_TXD << 16) | MUX_PB05B_USART1_TXD)
+#define GPIO_PB05B_USART1_TXD    _UL(1 <<  5)
+#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L(0)
+#define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
+#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+/* ========== GPIO definition for USART2 peripheral ========== */
+#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L(0)
+#define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
+#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
+#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L(1)
+#define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
+#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
+#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L(0)
+#define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
+#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L(1)
+#define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
+#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
+#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L(0)
+#define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
+#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L(1)
+#define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
+#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
+#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L(0)
+#define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
+#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+/* ========== GPIO definition for USART3 peripheral ========== */
+#define PIN_PA29E_USART3_CLK           _L(29) /**< \brief USART3 signal: CLK on PA29 mux E */
+#define MUX_PA29E_USART3_CLK            _L(4)
+#define PINMUX_PA29E_USART3_CLK    ((PIN_PA29E_USART3_CLK << 16) | MUX_PA29E_USART3_CLK)
+#define GPIO_PA29E_USART3_CLK    _UL(1 << 29)
+#define PIN_PB08A_USART3_CLK           _L(40) /**< \brief USART3 signal: CLK on PB08 mux A */
+#define MUX_PB08A_USART3_CLK            _L(0)
+#define PINMUX_PB08A_USART3_CLK    ((PIN_PB08A_USART3_CLK << 16) | MUX_PB08A_USART3_CLK)
+#define GPIO_PB08A_USART3_CLK    _UL(1 <<  8)
+#define PIN_PA28E_USART3_CTS           _L(28) /**< \brief USART3 signal: CTS on PA28 mux E */
+#define MUX_PA28E_USART3_CTS            _L(4)
+#define PINMUX_PA28E_USART3_CTS    ((PIN_PA28E_USART3_CTS << 16) | MUX_PA28E_USART3_CTS)
+#define GPIO_PA28E_USART3_CTS    _UL(1 << 28)
+#define PIN_PB07A_USART3_CTS           _L(39) /**< \brief USART3 signal: CTS on PB07 mux A */
+#define MUX_PB07A_USART3_CTS            _L(0)
+#define PINMUX_PB07A_USART3_CTS    ((PIN_PB07A_USART3_CTS << 16) | MUX_PB07A_USART3_CTS)
+#define GPIO_PB07A_USART3_CTS    _UL(1 <<  7)
+#define PIN_PA27E_USART3_RTS           _L(27) /**< \brief USART3 signal: RTS on PA27 mux E */
+#define MUX_PA27E_USART3_RTS            _L(4)
+#define PINMUX_PA27E_USART3_RTS    ((PIN_PA27E_USART3_RTS << 16) | MUX_PA27E_USART3_RTS)
+#define GPIO_PA27E_USART3_RTS    _UL(1 << 27)
+#define PIN_PB06A_USART3_RTS           _L(38) /**< \brief USART3 signal: RTS on PB06 mux A */
+#define MUX_PB06A_USART3_RTS            _L(0)
+#define PINMUX_PB06A_USART3_RTS    ((PIN_PB06A_USART3_RTS << 16) | MUX_PB06A_USART3_RTS)
+#define GPIO_PB06A_USART3_RTS    _UL(1 <<  6)
+#define PIN_PA30E_USART3_RXD           _L(30) /**< \brief USART3 signal: RXD on PA30 mux E */
+#define MUX_PA30E_USART3_RXD            _L(4)
+#define PINMUX_PA30E_USART3_RXD    ((PIN_PA30E_USART3_RXD << 16) | MUX_PA30E_USART3_RXD)
+#define GPIO_PA30E_USART3_RXD    _UL(1 << 30)
+#define PIN_PB09A_USART3_RXD           _L(41) /**< \brief USART3 signal: RXD on PB09 mux A */
+#define MUX_PB09A_USART3_RXD            _L(0)
+#define PINMUX_PB09A_USART3_RXD    ((PIN_PB09A_USART3_RXD << 16) | MUX_PB09A_USART3_RXD)
+#define GPIO_PB09A_USART3_RXD    _UL(1 <<  9)
+#define PIN_PA31E_USART3_TXD           _L(31) /**< \brief USART3 signal: TXD on PA31 mux E */
+#define MUX_PA31E_USART3_TXD            _L(4)
+#define PINMUX_PA31E_USART3_TXD    ((PIN_PA31E_USART3_TXD << 16) | MUX_PA31E_USART3_TXD)
+#define GPIO_PA31E_USART3_TXD    _UL(1 << 31)
+#define PIN_PB10A_USART3_TXD           _L(42) /**< \brief USART3 signal: TXD on PB10 mux A */
+#define MUX_PB10A_USART3_TXD            _L(0)
+#define PINMUX_PB10A_USART3_TXD    ((PIN_PB10A_USART3_TXD << 16) | MUX_PB10A_USART3_TXD)
+#define GPIO_PB10A_USART3_TXD    _UL(1 << 10)
+/* ========== GPIO definition for ADCIFE peripheral ========== */
+#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
+#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
+#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
+#define PIN_PB02A_ADCIFE_AD3           _L(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
+#define MUX_PB02A_ADCIFE_AD3            _L(0)
+#define PINMUX_PB02A_ADCIFE_AD3    ((PIN_PB02A_ADCIFE_AD3 << 16) | MUX_PB02A_ADCIFE_AD3)
+#define GPIO_PB02A_ADCIFE_AD3    _UL(1 <<  2)
+#define PIN_PB03A_ADCIFE_AD4           _L(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
+#define MUX_PB03A_ADCIFE_AD4            _L(0)
+#define PINMUX_PB03A_ADCIFE_AD4    ((PIN_PB03A_ADCIFE_AD4 << 16) | MUX_PB03A_ADCIFE_AD4)
+#define GPIO_PB03A_ADCIFE_AD4    _UL(1 <<  3)
+#define PIN_PB04A_ADCIFE_AD5           _L(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
+#define MUX_PB04A_ADCIFE_AD5            _L(0)
+#define PINMUX_PB04A_ADCIFE_AD5    ((PIN_PB04A_ADCIFE_AD5 << 16) | MUX_PB04A_ADCIFE_AD5)
+#define GPIO_PB04A_ADCIFE_AD5    _UL(1 <<  4)
+#define PIN_PB05A_ADCIFE_AD6           _L(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
+#define MUX_PB05A_ADCIFE_AD6            _L(0)
+#define PINMUX_PB05A_ADCIFE_AD6    ((PIN_PB05A_ADCIFE_AD6 << 16) | MUX_PB05A_ADCIFE_AD6)
+#define GPIO_PB05A_ADCIFE_AD6    _UL(1 <<  5)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+/* ========== GPIO definition for DACC peripheral ========== */
+#define PIN_PB04E_DACC_EXT_TRIG0       _L(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
+#define MUX_PB04E_DACC_EXT_TRIG0        _L(4)
+#define PINMUX_PB04E_DACC_EXT_TRIG0  ((PIN_PB04E_DACC_EXT_TRIG0 << 16) | MUX_PB04E_DACC_EXT_TRIG0)
+#define GPIO_PB04E_DACC_EXT_TRIG0  _UL(1 <<  4)
+#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L(0)
+#define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
+#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+/* ========== GPIO definition for ACIFC peripheral ========== */
+#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
+#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
+#define PIN_PB02E_ACIFC_ACBN0          _L(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
+#define MUX_PB02E_ACIFC_ACBN0           _L(4)
+#define PINMUX_PB02E_ACIFC_ACBN0   ((PIN_PB02E_ACIFC_ACBN0 << 16) | MUX_PB02E_ACIFC_ACBN0)
+#define GPIO_PB02E_ACIFC_ACBN0   _UL(1 <<  2)
+#define PIN_PB03E_ACIFC_ACBP0          _L(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
+#define MUX_PB03E_ACIFC_ACBP0           _L(4)
+#define PINMUX_PB03E_ACIFC_ACBP0   ((PIN_PB03E_ACIFC_ACBP0 << 16) | MUX_PB03E_ACIFC_ACBP0)
+#define GPIO_PB03E_ACIFC_ACBP0   _UL(1 <<  3)
+/* ========== GPIO definition for GLOC peripheral ========== */
+#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
+#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L(3)
+#define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
+#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L(3)
+#define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
+#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L(3)
+#define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
+#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L(3)
+#define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
+#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L(3)
+#define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
+#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L(3)
+#define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
+#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L(3)
+#define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
+#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
+#define PIN_PA27D_GLOC_IN4             _L(27) /**< \brief GLOC signal: IN4 on PA27 mux D */
+#define MUX_PA27D_GLOC_IN4              _L(3)
+#define PINMUX_PA27D_GLOC_IN4      ((PIN_PA27D_GLOC_IN4 << 16) | MUX_PA27D_GLOC_IN4)
+#define GPIO_PA27D_GLOC_IN4      _UL(1 << 27)
+#define PIN_PB06C_GLOC_IN4             _L(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
+#define MUX_PB06C_GLOC_IN4              _L(2)
+#define PINMUX_PB06C_GLOC_IN4      ((PIN_PB06C_GLOC_IN4 << 16) | MUX_PB06C_GLOC_IN4)
+#define GPIO_PB06C_GLOC_IN4      _UL(1 <<  6)
+#define PIN_PA28D_GLOC_IN5             _L(28) /**< \brief GLOC signal: IN5 on PA28 mux D */
+#define MUX_PA28D_GLOC_IN5              _L(3)
+#define PINMUX_PA28D_GLOC_IN5      ((PIN_PA28D_GLOC_IN5 << 16) | MUX_PA28D_GLOC_IN5)
+#define GPIO_PA28D_GLOC_IN5      _UL(1 << 28)
+#define PIN_PB07C_GLOC_IN5             _L(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
+#define MUX_PB07C_GLOC_IN5              _L(2)
+#define PINMUX_PB07C_GLOC_IN5      ((PIN_PB07C_GLOC_IN5 << 16) | MUX_PB07C_GLOC_IN5)
+#define GPIO_PB07C_GLOC_IN5      _UL(1 <<  7)
+#define PIN_PA29D_GLOC_IN6             _L(29) /**< \brief GLOC signal: IN6 on PA29 mux D */
+#define MUX_PA29D_GLOC_IN6              _L(3)
+#define PINMUX_PA29D_GLOC_IN6      ((PIN_PA29D_GLOC_IN6 << 16) | MUX_PA29D_GLOC_IN6)
+#define GPIO_PA29D_GLOC_IN6      _UL(1 << 29)
+#define PIN_PB08C_GLOC_IN6             _L(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
+#define MUX_PB08C_GLOC_IN6              _L(2)
+#define PINMUX_PB08C_GLOC_IN6      ((PIN_PB08C_GLOC_IN6 << 16) | MUX_PB08C_GLOC_IN6)
+#define GPIO_PB08C_GLOC_IN6      _UL(1 <<  8)
+#define PIN_PA30D_GLOC_IN7             _L(30) /**< \brief GLOC signal: IN7 on PA30 mux D */
+#define MUX_PA30D_GLOC_IN7              _L(3)
+#define PINMUX_PA30D_GLOC_IN7      ((PIN_PA30D_GLOC_IN7 << 16) | MUX_PA30D_GLOC_IN7)
+#define GPIO_PA30D_GLOC_IN7      _UL(1 << 30)
+#define PIN_PB09C_GLOC_IN7             _L(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
+#define MUX_PB09C_GLOC_IN7              _L(2)
+#define PINMUX_PB09C_GLOC_IN7      ((PIN_PB09C_GLOC_IN7 << 16) | MUX_PB09C_GLOC_IN7)
+#define GPIO_PB09C_GLOC_IN7      _UL(1 <<  9)
+#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
+#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
+#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
+#define PIN_PA31D_GLOC_OUT1            _L(31) /**< \brief GLOC signal: OUT1 on PA31 mux D */
+#define MUX_PA31D_GLOC_OUT1             _L(3)
+#define PINMUX_PA31D_GLOC_OUT1     ((PIN_PA31D_GLOC_OUT1 << 16) | MUX_PA31D_GLOC_OUT1)
+#define GPIO_PA31D_GLOC_OUT1     _UL(1 << 31)
+#define PIN_PB10C_GLOC_OUT1            _L(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
+#define MUX_PB10C_GLOC_OUT1             _L(2)
+#define PINMUX_PB10C_GLOC_OUT1     ((PIN_PB10C_GLOC_OUT1 << 16) | MUX_PB10C_GLOC_OUT1)
+#define GPIO_PB10C_GLOC_OUT1     _UL(1 << 10)
+/* ========== GPIO definition for ABDACB peripheral ========== */
+#define PIN_PA31C_ABDACB_CLK           _L(31) /**< \brief ABDACB signal: CLK on PA31 mux C */
+#define MUX_PA31C_ABDACB_CLK            _L(2)
+#define PINMUX_PA31C_ABDACB_CLK    ((PIN_PA31C_ABDACB_CLK << 16) | MUX_PA31C_ABDACB_CLK)
+#define GPIO_PA31C_ABDACB_CLK    _UL(1 << 31)
+#define PIN_PA27C_ABDACB_DAC0          _L(27) /**< \brief ABDACB signal: DAC0 on PA27 mux C */
+#define MUX_PA27C_ABDACB_DAC0           _L(2)
+#define PINMUX_PA27C_ABDACB_DAC0   ((PIN_PA27C_ABDACB_DAC0 << 16) | MUX_PA27C_ABDACB_DAC0)
+#define GPIO_PA27C_ABDACB_DAC0   _UL(1 << 27)
+#define PIN_PB02C_ABDACB_DAC0          _L(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
+#define MUX_PB02C_ABDACB_DAC0           _L(2)
+#define PINMUX_PB02C_ABDACB_DAC0   ((PIN_PB02C_ABDACB_DAC0 << 16) | MUX_PB02C_ABDACB_DAC0)
+#define GPIO_PB02C_ABDACB_DAC0   _UL(1 <<  2)
+#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
+#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
+#define PIN_PA29C_ABDACB_DAC1          _L(29) /**< \brief ABDACB signal: DAC1 on PA29 mux C */
+#define MUX_PA29C_ABDACB_DAC1           _L(2)
+#define PINMUX_PA29C_ABDACB_DAC1   ((PIN_PA29C_ABDACB_DAC1 << 16) | MUX_PA29C_ABDACB_DAC1)
+#define GPIO_PA29C_ABDACB_DAC1   _UL(1 << 29)
+#define PIN_PB04C_ABDACB_DAC1          _L(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
+#define MUX_PB04C_ABDACB_DAC1           _L(2)
+#define PINMUX_PB04C_ABDACB_DAC1   ((PIN_PB04C_ABDACB_DAC1 << 16) | MUX_PB04C_ABDACB_DAC1)
+#define GPIO_PB04C_ABDACB_DAC1   _UL(1 <<  4)
+#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
+#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
+#define PIN_PA28C_ABDACB_DACN0         _L(28) /**< \brief ABDACB signal: DACN0 on PA28 mux C */
+#define MUX_PA28C_ABDACB_DACN0          _L(2)
+#define PINMUX_PA28C_ABDACB_DACN0  ((PIN_PA28C_ABDACB_DACN0 << 16) | MUX_PA28C_ABDACB_DACN0)
+#define GPIO_PA28C_ABDACB_DACN0  _UL(1 << 28)
+#define PIN_PB03C_ABDACB_DACN0         _L(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
+#define MUX_PB03C_ABDACB_DACN0          _L(2)
+#define PINMUX_PB03C_ABDACB_DACN0  ((PIN_PB03C_ABDACB_DACN0 << 16) | MUX_PB03C_ABDACB_DACN0)
+#define GPIO_PB03C_ABDACB_DACN0  _UL(1 <<  3)
+#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
+#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
+#define PIN_PA30C_ABDACB_DACN1         _L(30) /**< \brief ABDACB signal: DACN1 on PA30 mux C */
+#define MUX_PA30C_ABDACB_DACN1          _L(2)
+#define PINMUX_PA30C_ABDACB_DACN1  ((PIN_PA30C_ABDACB_DACN1 << 16) | MUX_PA30C_ABDACB_DACN1)
+#define GPIO_PA30C_ABDACB_DACN1  _UL(1 << 30)
+#define PIN_PB05C_ABDACB_DACN1         _L(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
+#define MUX_PB05C_ABDACB_DACN1          _L(2)
+#define PINMUX_PB05C_ABDACB_DACN1  ((PIN_PB05C_ABDACB_DACN1 << 16) | MUX_PB05C_ABDACB_DACN1)
+#define GPIO_PB05C_ABDACB_DACN1  _UL(1 <<  5)
+#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
+#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+/* ========== GPIO definition for PARC peripheral ========== */
+#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
+#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
+#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
+#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
+#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
+#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
+#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
+#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
+#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
+#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
+#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
+#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
+#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
+#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
+#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
+#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
+#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
+#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
+#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
+#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
+#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+/* ========== GPIO definition for CATB peripheral ========== */
+#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L(6)
+#define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
+#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L(6)
+#define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
+#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L(6)
+#define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
+#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
+#define PIN_PA31G_CATB_DIS             _L(31) /**< \brief CATB signal: DIS on PA31 mux G */
+#define MUX_PA31G_CATB_DIS              _L(6)
+#define PINMUX_PA31G_CATB_DIS      ((PIN_PA31G_CATB_DIS << 16) | MUX_PA31G_CATB_DIS)
+#define GPIO_PA31G_CATB_DIS      _UL(1 << 31)
+#define PIN_PB03G_CATB_DIS             _L(35) /**< \brief CATB signal: DIS on PB03 mux G */
+#define MUX_PB03G_CATB_DIS              _L(6)
+#define PINMUX_PB03G_CATB_DIS      ((PIN_PB03G_CATB_DIS << 16) | MUX_PB03G_CATB_DIS)
+#define GPIO_PB03G_CATB_DIS      _UL(1 <<  3)
+#define PIN_PB12G_CATB_DIS             _L(44) /**< \brief CATB signal: DIS on PB12 mux G */
+#define MUX_PB12G_CATB_DIS              _L(6)
+#define PINMUX_PB12G_CATB_DIS      ((PIN_PB12G_CATB_DIS << 16) | MUX_PB12G_CATB_DIS)
+#define GPIO_PB12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
+#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
+#define PIN_PA27G_CATB_SENSE0          _L(27) /**< \brief CATB signal: SENSE0 on PA27 mux G */
+#define MUX_PA27G_CATB_SENSE0           _L(6)
+#define PINMUX_PA27G_CATB_SENSE0   ((PIN_PA27G_CATB_SENSE0 << 16) | MUX_PA27G_CATB_SENSE0)
+#define GPIO_PA27G_CATB_SENSE0   _UL(1 << 27)
+#define PIN_PB13G_CATB_SENSE0          _L(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
+#define MUX_PB13G_CATB_SENSE0           _L(6)
+#define PINMUX_PB13G_CATB_SENSE0   ((PIN_PB13G_CATB_SENSE0 << 16) | MUX_PB13G_CATB_SENSE0)
+#define GPIO_PB13G_CATB_SENSE0   _UL(1 << 13)
+#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
+#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
+#define PIN_PA28G_CATB_SENSE1          _L(28) /**< \brief CATB signal: SENSE1 on PA28 mux G */
+#define MUX_PA28G_CATB_SENSE1           _L(6)
+#define PINMUX_PA28G_CATB_SENSE1   ((PIN_PA28G_CATB_SENSE1 << 16) | MUX_PA28G_CATB_SENSE1)
+#define GPIO_PA28G_CATB_SENSE1   _UL(1 << 28)
+#define PIN_PB14G_CATB_SENSE1          _L(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
+#define MUX_PB14G_CATB_SENSE1           _L(6)
+#define PINMUX_PB14G_CATB_SENSE1   ((PIN_PB14G_CATB_SENSE1 << 16) | MUX_PB14G_CATB_SENSE1)
+#define GPIO_PB14G_CATB_SENSE1   _UL(1 << 14)
+#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
+#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
+#define PIN_PA29G_CATB_SENSE2          _L(29) /**< \brief CATB signal: SENSE2 on PA29 mux G */
+#define MUX_PA29G_CATB_SENSE2           _L(6)
+#define PINMUX_PA29G_CATB_SENSE2   ((PIN_PA29G_CATB_SENSE2 << 16) | MUX_PA29G_CATB_SENSE2)
+#define GPIO_PA29G_CATB_SENSE2   _UL(1 << 29)
+#define PIN_PB15G_CATB_SENSE2          _L(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
+#define MUX_PB15G_CATB_SENSE2           _L(6)
+#define PINMUX_PB15G_CATB_SENSE2   ((PIN_PB15G_CATB_SENSE2 << 16) | MUX_PB15G_CATB_SENSE2)
+#define GPIO_PB15G_CATB_SENSE2   _UL(1 << 15)
+#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
+#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
+#define PIN_PA30G_CATB_SENSE3          _L(30) /**< \brief CATB signal: SENSE3 on PA30 mux G */
+#define MUX_PA30G_CATB_SENSE3           _L(6)
+#define PINMUX_PA30G_CATB_SENSE3   ((PIN_PA30G_CATB_SENSE3 << 16) | MUX_PA30G_CATB_SENSE3)
+#define GPIO_PA30G_CATB_SENSE3   _UL(1 << 30)
+#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
+#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
+#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
+#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
+#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
+#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
+#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
+#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
+#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
+#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
+#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
+#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
+#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
+#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
+#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
+#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
+#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
+#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
+#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
+#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
+#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
+#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
+#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
+#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
+#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
+#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
+#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
+#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
+#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
+#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
+#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
+#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
+#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
+#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
+#define PIN_PB00G_CATB_SENSE21         _L(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
+#define MUX_PB00G_CATB_SENSE21          _L(6)
+#define PINMUX_PB00G_CATB_SENSE21  ((PIN_PB00G_CATB_SENSE21 << 16) | MUX_PB00G_CATB_SENSE21)
+#define GPIO_PB00G_CATB_SENSE21  _UL(1 <<  0)
+#define PIN_PB01G_CATB_SENSE22         _L(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
+#define MUX_PB01G_CATB_SENSE22          _L(6)
+#define PINMUX_PB01G_CATB_SENSE22  ((PIN_PB01G_CATB_SENSE22 << 16) | MUX_PB01G_CATB_SENSE22)
+#define GPIO_PB01G_CATB_SENSE22  _UL(1 <<  1)
+#define PIN_PB02G_CATB_SENSE23         _L(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
+#define MUX_PB02G_CATB_SENSE23          _L(6)
+#define PINMUX_PB02G_CATB_SENSE23  ((PIN_PB02G_CATB_SENSE23 << 16) | MUX_PB02G_CATB_SENSE23)
+#define GPIO_PB02G_CATB_SENSE23  _UL(1 <<  2)
+#define PIN_PB04G_CATB_SENSE24         _L(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
+#define MUX_PB04G_CATB_SENSE24          _L(6)
+#define PINMUX_PB04G_CATB_SENSE24  ((PIN_PB04G_CATB_SENSE24 << 16) | MUX_PB04G_CATB_SENSE24)
+#define GPIO_PB04G_CATB_SENSE24  _UL(1 <<  4)
+#define PIN_PB05G_CATB_SENSE25         _L(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
+#define MUX_PB05G_CATB_SENSE25          _L(6)
+#define PINMUX_PB05G_CATB_SENSE25  ((PIN_PB05G_CATB_SENSE25 << 16) | MUX_PB05G_CATB_SENSE25)
+#define GPIO_PB05G_CATB_SENSE25  _UL(1 <<  5)
+#define PIN_PB06G_CATB_SENSE26         _L(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
+#define MUX_PB06G_CATB_SENSE26          _L(6)
+#define PINMUX_PB06G_CATB_SENSE26  ((PIN_PB06G_CATB_SENSE26 << 16) | MUX_PB06G_CATB_SENSE26)
+#define GPIO_PB06G_CATB_SENSE26  _UL(1 <<  6)
+#define PIN_PB07G_CATB_SENSE27         _L(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
+#define MUX_PB07G_CATB_SENSE27          _L(6)
+#define PINMUX_PB07G_CATB_SENSE27  ((PIN_PB07G_CATB_SENSE27 << 16) | MUX_PB07G_CATB_SENSE27)
+#define GPIO_PB07G_CATB_SENSE27  _UL(1 <<  7)
+#define PIN_PB08G_CATB_SENSE28         _L(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
+#define MUX_PB08G_CATB_SENSE28          _L(6)
+#define PINMUX_PB08G_CATB_SENSE28  ((PIN_PB08G_CATB_SENSE28 << 16) | MUX_PB08G_CATB_SENSE28)
+#define GPIO_PB08G_CATB_SENSE28  _UL(1 <<  8)
+#define PIN_PB09G_CATB_SENSE29         _L(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
+#define MUX_PB09G_CATB_SENSE29          _L(6)
+#define PINMUX_PB09G_CATB_SENSE29  ((PIN_PB09G_CATB_SENSE29 << 16) | MUX_PB09G_CATB_SENSE29)
+#define GPIO_PB09G_CATB_SENSE29  _UL(1 <<  9)
+#define PIN_PB10G_CATB_SENSE30         _L(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
+#define MUX_PB10G_CATB_SENSE30          _L(6)
+#define PINMUX_PB10G_CATB_SENSE30  ((PIN_PB10G_CATB_SENSE30 << 16) | MUX_PB10G_CATB_SENSE30)
+#define GPIO_PB10G_CATB_SENSE30  _UL(1 << 10)
+#define PIN_PB11G_CATB_SENSE31         _L(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
+#define MUX_PB11G_CATB_SENSE31          _L(6)
+#define PINMUX_PB11G_CATB_SENSE31  ((PIN_PB11G_CATB_SENSE31 << 16) | MUX_PB11G_CATB_SENSE31)
+#define GPIO_PB11G_CATB_SENSE31  _UL(1 << 11)
+/* ========== GPIO definition for USBC peripheral ========== */
+#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L(0)
+#define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
+#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
+#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L(0)
+#define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
+#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+/* ========== GPIO definition for PEVC peripheral ========== */
+#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
+#define PIN_PB12C_PEVC_PAD_EVT0        _L(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
+#define MUX_PB12C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PB12C_PEVC_PAD_EVT0  ((PIN_PB12C_PEVC_PAD_EVT0 << 16) | MUX_PB12C_PEVC_PAD_EVT0)
+#define GPIO_PB12C_PEVC_PAD_EVT0  _UL(1 << 12)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
+#define PIN_PB13C_PEVC_PAD_EVT1        _L(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
+#define MUX_PB13C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PB13C_PEVC_PAD_EVT1  ((PIN_PB13C_PEVC_PAD_EVT1 << 16) | MUX_PB13C_PEVC_PAD_EVT1)
+#define GPIO_PB13C_PEVC_PAD_EVT1  _UL(1 << 13)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
+#define PIN_PB09B_PEVC_PAD_EVT2        _L(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
+#define MUX_PB09B_PEVC_PAD_EVT2         _L(1)
+#define PINMUX_PB09B_PEVC_PAD_EVT2  ((PIN_PB09B_PEVC_PAD_EVT2 << 16) | MUX_PB09B_PEVC_PAD_EVT2)
+#define GPIO_PB09B_PEVC_PAD_EVT2  _UL(1 <<  9)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
+#define PIN_PB10B_PEVC_PAD_EVT3        _L(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
+#define MUX_PB10B_PEVC_PAD_EVT3         _L(1)
+#define PINMUX_PB10B_PEVC_PAD_EVT3  ((PIN_PB10B_PEVC_PAD_EVT3 << 16) | MUX_PB10B_PEVC_PAD_EVT3)
+#define GPIO_PB10B_PEVC_PAD_EVT3  _UL(1 << 10)
+/* ========== GPIO definition for SCIF peripheral ========== */
+#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
+#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
+#define PIN_PB10E_SCIF_GCLK0           _L(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
+#define MUX_PB10E_SCIF_GCLK0            _L(4)
+#define PINMUX_PB10E_SCIF_GCLK0    ((PIN_PB10E_SCIF_GCLK0 << 16) | MUX_PB10E_SCIF_GCLK0)
+#define GPIO_PB10E_SCIF_GCLK0    _UL(1 << 10)
+#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
+#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
+#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
+#define PIN_PB11E_SCIF_GCLK1           _L(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
+#define MUX_PB11E_SCIF_GCLK1            _L(4)
+#define PINMUX_PB11E_SCIF_GCLK1    ((PIN_PB11E_SCIF_GCLK1 << 16) | MUX_PB11E_SCIF_GCLK1)
+#define GPIO_PB11E_SCIF_GCLK1    _UL(1 << 11)
+#define PIN_PB12E_SCIF_GCLK2           _L(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
+#define MUX_PB12E_SCIF_GCLK2            _L(4)
+#define PINMUX_PB12E_SCIF_GCLK2    ((PIN_PB12E_SCIF_GCLK2 << 16) | MUX_PB12E_SCIF_GCLK2)
+#define GPIO_PB12E_SCIF_GCLK2    _UL(1 << 12)
+#define PIN_PB13E_SCIF_GCLK3           _L(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
+#define MUX_PB13E_SCIF_GCLK3            _L(4)
+#define PINMUX_PB13E_SCIF_GCLK3    ((PIN_PB13E_SCIF_GCLK3 << 16) | MUX_PB13E_SCIF_GCLK3)
+#define GPIO_PB13E_SCIF_GCLK3    _UL(1 << 13)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
+#define PIN_PB14E_SCIF_GCLK_IN0        _L(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
+#define MUX_PB14E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PB14E_SCIF_GCLK_IN0  ((PIN_PB14E_SCIF_GCLK_IN0 << 16) | MUX_PB14E_SCIF_GCLK_IN0)
+#define GPIO_PB14E_SCIF_GCLK_IN0  _UL(1 << 14)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
+#define PIN_PB15E_SCIF_GCLK_IN1        _L(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
+#define MUX_PB15E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PB15E_SCIF_GCLK_IN1  ((PIN_PB15E_SCIF_GCLK_IN1 << 16) | MUX_PB15E_SCIF_GCLK_IN1)
+#define GPIO_PB15E_SCIF_GCLK_IN1  _UL(1 << 15)
+/* ========== GPIO definition for EIC peripheral ========== */
+#define PIN_PB01C_EIC_EXTINT0          _L(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
+#define MUX_PB01C_EIC_EXTINT0           _L(2)
+#define PINMUX_PB01C_EIC_EXTINT0   ((PIN_PB01C_EIC_EXTINT0 << 16) | MUX_PB01C_EIC_EXTINT0)
+#define GPIO_PB01C_EIC_EXTINT0   _UL(1 <<  1)
+#define PIN_PB01C_EIC_EXTINT_NUM        _L(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
+#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
+#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
+#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
+#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
+#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
+#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
+#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
+#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
+#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
+#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+
+#endif /* _SAM4LS4B_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4ls4c.h
+++ b/asf/sam/include/sam4l/pio/sam4ls4c.h
@@ -30,1728 +30,1728 @@
 #define _SAM4LS4C_PIO_
 
 #define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
-#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define GPIO_PA00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PA00 */
 #define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
-#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define GPIO_PA01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PA01 */
 #define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
-#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define GPIO_PA02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PA02 */
 #define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
-#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define GPIO_PA03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PA03 */
 #define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
-#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define GPIO_PA04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PA04 */
 #define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
-#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define GPIO_PA05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PA05 */
 #define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
-#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define GPIO_PA06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PA06 */
 #define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
-#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define GPIO_PA07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PA07 */
 #define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
-#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define GPIO_PA08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PA08 */
 #define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
-#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define GPIO_PA09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PA09 */
 #define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
-#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define GPIO_PA10                _UL_(1 << 10) /**< \brief GPIO Mask  for PA10 */
 #define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
-#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define GPIO_PA11                _UL_(1 << 11) /**< \brief GPIO Mask  for PA11 */
 #define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
-#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define GPIO_PA12                _UL_(1 << 12) /**< \brief GPIO Mask  for PA12 */
 #define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
-#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define GPIO_PA13                _UL_(1 << 13) /**< \brief GPIO Mask  for PA13 */
 #define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
-#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define GPIO_PA14                _UL_(1 << 14) /**< \brief GPIO Mask  for PA14 */
 #define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
-#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define GPIO_PA15                _UL_(1 << 15) /**< \brief GPIO Mask  for PA15 */
 #define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
-#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define GPIO_PA16                _UL_(1 << 16) /**< \brief GPIO Mask  for PA16 */
 #define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
-#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define GPIO_PA17                _UL_(1 << 17) /**< \brief GPIO Mask  for PA17 */
 #define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
-#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define GPIO_PA18                _UL_(1 << 18) /**< \brief GPIO Mask  for PA18 */
 #define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
-#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define GPIO_PA19                _UL_(1 << 19) /**< \brief GPIO Mask  for PA19 */
 #define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
-#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define GPIO_PA20                _UL_(1 << 20) /**< \brief GPIO Mask  for PA20 */
 #define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
-#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define GPIO_PA21                _UL_(1 << 21) /**< \brief GPIO Mask  for PA21 */
 #define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
-#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define GPIO_PA22                _UL_(1 << 22) /**< \brief GPIO Mask  for PA22 */
 #define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
-#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define GPIO_PA23                _UL_(1 << 23) /**< \brief GPIO Mask  for PA23 */
 #define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
-#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define GPIO_PA24                _UL_(1 << 24) /**< \brief GPIO Mask  for PA24 */
 #define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
-#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define GPIO_PA25                _UL_(1 << 25) /**< \brief GPIO Mask  for PA25 */
 #define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
-#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define GPIO_PA26                _UL_(1 << 26) /**< \brief GPIO Mask  for PA26 */
 #define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
-#define GPIO_PA27                _UL(1 << 27) /**< \brief GPIO Mask  for PA27 */
+#define GPIO_PA27                _UL_(1 << 27) /**< \brief GPIO Mask  for PA27 */
 #define PIN_PA28                          28  /**< \brief Pin Number for PA28 */
-#define GPIO_PA28                _UL(1 << 28) /**< \brief GPIO Mask  for PA28 */
+#define GPIO_PA28                _UL_(1 << 28) /**< \brief GPIO Mask  for PA28 */
 #define PIN_PA29                          29  /**< \brief Pin Number for PA29 */
-#define GPIO_PA29                _UL(1 << 29) /**< \brief GPIO Mask  for PA29 */
+#define GPIO_PA29                _UL_(1 << 29) /**< \brief GPIO Mask  for PA29 */
 #define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
-#define GPIO_PA30                _UL(1 << 30) /**< \brief GPIO Mask  for PA30 */
+#define GPIO_PA30                _UL_(1 << 30) /**< \brief GPIO Mask  for PA30 */
 #define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
-#define GPIO_PA31                _UL(1 << 31) /**< \brief GPIO Mask  for PA31 */
+#define GPIO_PA31                _UL_(1 << 31) /**< \brief GPIO Mask  for PA31 */
 #define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
-#define GPIO_PB00                _UL(1 <<  0) /**< \brief GPIO Mask  for PB00 */
+#define GPIO_PB00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PB00 */
 #define PIN_PB01                          33  /**< \brief Pin Number for PB01 */
-#define GPIO_PB01                _UL(1 <<  1) /**< \brief GPIO Mask  for PB01 */
+#define GPIO_PB01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PB01 */
 #define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
-#define GPIO_PB02                _UL(1 <<  2) /**< \brief GPIO Mask  for PB02 */
+#define GPIO_PB02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PB02 */
 #define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
-#define GPIO_PB03                _UL(1 <<  3) /**< \brief GPIO Mask  for PB03 */
+#define GPIO_PB03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PB03 */
 #define PIN_PB04                          36  /**< \brief Pin Number for PB04 */
-#define GPIO_PB04                _UL(1 <<  4) /**< \brief GPIO Mask  for PB04 */
+#define GPIO_PB04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PB04 */
 #define PIN_PB05                          37  /**< \brief Pin Number for PB05 */
-#define GPIO_PB05                _UL(1 <<  5) /**< \brief GPIO Mask  for PB05 */
+#define GPIO_PB05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PB05 */
 #define PIN_PB06                          38  /**< \brief Pin Number for PB06 */
-#define GPIO_PB06                _UL(1 <<  6) /**< \brief GPIO Mask  for PB06 */
+#define GPIO_PB06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PB06 */
 #define PIN_PB07                          39  /**< \brief Pin Number for PB07 */
-#define GPIO_PB07                _UL(1 <<  7) /**< \brief GPIO Mask  for PB07 */
+#define GPIO_PB07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PB07 */
 #define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
-#define GPIO_PB08                _UL(1 <<  8) /**< \brief GPIO Mask  for PB08 */
+#define GPIO_PB08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PB08 */
 #define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
-#define GPIO_PB09                _UL(1 <<  9) /**< \brief GPIO Mask  for PB09 */
+#define GPIO_PB09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PB09 */
 #define PIN_PB10                          42  /**< \brief Pin Number for PB10 */
-#define GPIO_PB10                _UL(1 << 10) /**< \brief GPIO Mask  for PB10 */
+#define GPIO_PB10                _UL_(1 << 10) /**< \brief GPIO Mask  for PB10 */
 #define PIN_PB11                          43  /**< \brief Pin Number for PB11 */
-#define GPIO_PB11                _UL(1 << 11) /**< \brief GPIO Mask  for PB11 */
+#define GPIO_PB11                _UL_(1 << 11) /**< \brief GPIO Mask  for PB11 */
 #define PIN_PB12                          44  /**< \brief Pin Number for PB12 */
-#define GPIO_PB12                _UL(1 << 12) /**< \brief GPIO Mask  for PB12 */
+#define GPIO_PB12                _UL_(1 << 12) /**< \brief GPIO Mask  for PB12 */
 #define PIN_PB13                          45  /**< \brief Pin Number for PB13 */
-#define GPIO_PB13                _UL(1 << 13) /**< \brief GPIO Mask  for PB13 */
+#define GPIO_PB13                _UL_(1 << 13) /**< \brief GPIO Mask  for PB13 */
 #define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
-#define GPIO_PB14                _UL(1 << 14) /**< \brief GPIO Mask  for PB14 */
+#define GPIO_PB14                _UL_(1 << 14) /**< \brief GPIO Mask  for PB14 */
 #define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
-#define GPIO_PB15                _UL(1 << 15) /**< \brief GPIO Mask  for PB15 */
+#define GPIO_PB15                _UL_(1 << 15) /**< \brief GPIO Mask  for PB15 */
 #define PIN_PC00                          64  /**< \brief Pin Number for PC00 */
-#define GPIO_PC00                _UL(1 <<  0) /**< \brief GPIO Mask  for PC00 */
+#define GPIO_PC00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PC00 */
 #define PIN_PC01                          65  /**< \brief Pin Number for PC01 */
-#define GPIO_PC01                _UL(1 <<  1) /**< \brief GPIO Mask  for PC01 */
+#define GPIO_PC01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PC01 */
 #define PIN_PC02                          66  /**< \brief Pin Number for PC02 */
-#define GPIO_PC02                _UL(1 <<  2) /**< \brief GPIO Mask  for PC02 */
+#define GPIO_PC02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PC02 */
 #define PIN_PC03                          67  /**< \brief Pin Number for PC03 */
-#define GPIO_PC03                _UL(1 <<  3) /**< \brief GPIO Mask  for PC03 */
+#define GPIO_PC03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PC03 */
 #define PIN_PC04                          68  /**< \brief Pin Number for PC04 */
-#define GPIO_PC04                _UL(1 <<  4) /**< \brief GPIO Mask  for PC04 */
+#define GPIO_PC04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PC04 */
 #define PIN_PC05                          69  /**< \brief Pin Number for PC05 */
-#define GPIO_PC05                _UL(1 <<  5) /**< \brief GPIO Mask  for PC05 */
+#define GPIO_PC05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PC05 */
 #define PIN_PC06                          70  /**< \brief Pin Number for PC06 */
-#define GPIO_PC06                _UL(1 <<  6) /**< \brief GPIO Mask  for PC06 */
+#define GPIO_PC06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PC06 */
 #define PIN_PC07                          71  /**< \brief Pin Number for PC07 */
-#define GPIO_PC07                _UL(1 <<  7) /**< \brief GPIO Mask  for PC07 */
+#define GPIO_PC07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PC07 */
 #define PIN_PC08                          72  /**< \brief Pin Number for PC08 */
-#define GPIO_PC08                _UL(1 <<  8) /**< \brief GPIO Mask  for PC08 */
+#define GPIO_PC08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PC08 */
 #define PIN_PC09                          73  /**< \brief Pin Number for PC09 */
-#define GPIO_PC09                _UL(1 <<  9) /**< \brief GPIO Mask  for PC09 */
+#define GPIO_PC09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PC09 */
 #define PIN_PC10                          74  /**< \brief Pin Number for PC10 */
-#define GPIO_PC10                _UL(1 << 10) /**< \brief GPIO Mask  for PC10 */
+#define GPIO_PC10                _UL_(1 << 10) /**< \brief GPIO Mask  for PC10 */
 #define PIN_PC11                          75  /**< \brief Pin Number for PC11 */
-#define GPIO_PC11                _UL(1 << 11) /**< \brief GPIO Mask  for PC11 */
+#define GPIO_PC11                _UL_(1 << 11) /**< \brief GPIO Mask  for PC11 */
 #define PIN_PC12                          76  /**< \brief Pin Number for PC12 */
-#define GPIO_PC12                _UL(1 << 12) /**< \brief GPIO Mask  for PC12 */
+#define GPIO_PC12                _UL_(1 << 12) /**< \brief GPIO Mask  for PC12 */
 #define PIN_PC13                          77  /**< \brief Pin Number for PC13 */
-#define GPIO_PC13                _UL(1 << 13) /**< \brief GPIO Mask  for PC13 */
+#define GPIO_PC13                _UL_(1 << 13) /**< \brief GPIO Mask  for PC13 */
 #define PIN_PC14                          78  /**< \brief Pin Number for PC14 */
-#define GPIO_PC14                _UL(1 << 14) /**< \brief GPIO Mask  for PC14 */
+#define GPIO_PC14                _UL_(1 << 14) /**< \brief GPIO Mask  for PC14 */
 #define PIN_PC15                          79  /**< \brief Pin Number for PC15 */
-#define GPIO_PC15                _UL(1 << 15) /**< \brief GPIO Mask  for PC15 */
+#define GPIO_PC15                _UL_(1 << 15) /**< \brief GPIO Mask  for PC15 */
 #define PIN_PC16                          80  /**< \brief Pin Number for PC16 */
-#define GPIO_PC16                _UL(1 << 16) /**< \brief GPIO Mask  for PC16 */
+#define GPIO_PC16                _UL_(1 << 16) /**< \brief GPIO Mask  for PC16 */
 #define PIN_PC17                          81  /**< \brief Pin Number for PC17 */
-#define GPIO_PC17                _UL(1 << 17) /**< \brief GPIO Mask  for PC17 */
+#define GPIO_PC17                _UL_(1 << 17) /**< \brief GPIO Mask  for PC17 */
 #define PIN_PC18                          82  /**< \brief Pin Number for PC18 */
-#define GPIO_PC18                _UL(1 << 18) /**< \brief GPIO Mask  for PC18 */
+#define GPIO_PC18                _UL_(1 << 18) /**< \brief GPIO Mask  for PC18 */
 #define PIN_PC19                          83  /**< \brief Pin Number for PC19 */
-#define GPIO_PC19                _UL(1 << 19) /**< \brief GPIO Mask  for PC19 */
+#define GPIO_PC19                _UL_(1 << 19) /**< \brief GPIO Mask  for PC19 */
 #define PIN_PC20                          84  /**< \brief Pin Number for PC20 */
-#define GPIO_PC20                _UL(1 << 20) /**< \brief GPIO Mask  for PC20 */
+#define GPIO_PC20                _UL_(1 << 20) /**< \brief GPIO Mask  for PC20 */
 #define PIN_PC21                          85  /**< \brief Pin Number for PC21 */
-#define GPIO_PC21                _UL(1 << 21) /**< \brief GPIO Mask  for PC21 */
+#define GPIO_PC21                _UL_(1 << 21) /**< \brief GPIO Mask  for PC21 */
 #define PIN_PC22                          86  /**< \brief Pin Number for PC22 */
-#define GPIO_PC22                _UL(1 << 22) /**< \brief GPIO Mask  for PC22 */
+#define GPIO_PC22                _UL_(1 << 22) /**< \brief GPIO Mask  for PC22 */
 #define PIN_PC23                          87  /**< \brief Pin Number for PC23 */
-#define GPIO_PC23                _UL(1 << 23) /**< \brief GPIO Mask  for PC23 */
+#define GPIO_PC23                _UL_(1 << 23) /**< \brief GPIO Mask  for PC23 */
 #define PIN_PC24                          88  /**< \brief Pin Number for PC24 */
-#define GPIO_PC24                _UL(1 << 24) /**< \brief GPIO Mask  for PC24 */
+#define GPIO_PC24                _UL_(1 << 24) /**< \brief GPIO Mask  for PC24 */
 #define PIN_PC25                          89  /**< \brief Pin Number for PC25 */
-#define GPIO_PC25                _UL(1 << 25) /**< \brief GPIO Mask  for PC25 */
+#define GPIO_PC25                _UL_(1 << 25) /**< \brief GPIO Mask  for PC25 */
 #define PIN_PC26                          90  /**< \brief Pin Number for PC26 */
-#define GPIO_PC26                _UL(1 << 26) /**< \brief GPIO Mask  for PC26 */
+#define GPIO_PC26                _UL_(1 << 26) /**< \brief GPIO Mask  for PC26 */
 #define PIN_PC27                          91  /**< \brief Pin Number for PC27 */
-#define GPIO_PC27                _UL(1 << 27) /**< \brief GPIO Mask  for PC27 */
+#define GPIO_PC27                _UL_(1 << 27) /**< \brief GPIO Mask  for PC27 */
 #define PIN_PC28                          92  /**< \brief Pin Number for PC28 */
-#define GPIO_PC28                _UL(1 << 28) /**< \brief GPIO Mask  for PC28 */
+#define GPIO_PC28                _UL_(1 << 28) /**< \brief GPIO Mask  for PC28 */
 #define PIN_PC29                          93  /**< \brief Pin Number for PC29 */
-#define GPIO_PC29                _UL(1 << 29) /**< \brief GPIO Mask  for PC29 */
+#define GPIO_PC29                _UL_(1 << 29) /**< \brief GPIO Mask  for PC29 */
 #define PIN_PC30                          94  /**< \brief Pin Number for PC30 */
-#define GPIO_PC30                _UL(1 << 30) /**< \brief GPIO Mask  for PC30 */
+#define GPIO_PC30                _UL_(1 << 30) /**< \brief GPIO Mask  for PC30 */
 #define PIN_PC31                          95  /**< \brief Pin Number for PC31 */
-#define GPIO_PC31                _UL(1 << 31) /**< \brief GPIO Mask  for PC31 */
+#define GPIO_PC31                _UL_(1 << 31) /**< \brief GPIO Mask  for PC31 */
 /* ========== GPIO definition for TWIMS0 peripheral ========== */
-#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
-#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PIN_PA24B_TWIMS0_TWCK          _L_(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L_(1)
 #define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
-#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
-#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
-#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL_(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L_(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L_(1)
 #define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
-#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+#define GPIO_PA23B_TWIMS0_TWD    _UL_(1 << 23)
 /* ========== GPIO definition for TWIMS1 peripheral ========== */
-#define PIN_PB01A_TWIMS1_TWCK          _L(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
-#define MUX_PB01A_TWIMS1_TWCK           _L(0)
+#define PIN_PB01A_TWIMS1_TWCK          _L_(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
+#define MUX_PB01A_TWIMS1_TWCK           _L_(0)
 #define PINMUX_PB01A_TWIMS1_TWCK   ((PIN_PB01A_TWIMS1_TWCK << 16) | MUX_PB01A_TWIMS1_TWCK)
-#define GPIO_PB01A_TWIMS1_TWCK   _UL(1 <<  1)
-#define PIN_PB00A_TWIMS1_TWD           _L(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
-#define MUX_PB00A_TWIMS1_TWD            _L(0)
+#define GPIO_PB01A_TWIMS1_TWCK   _UL_(1 <<  1)
+#define PIN_PB00A_TWIMS1_TWD           _L_(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
+#define MUX_PB00A_TWIMS1_TWD            _L_(0)
 #define PINMUX_PB00A_TWIMS1_TWD    ((PIN_PB00A_TWIMS1_TWD << 16) | MUX_PB00A_TWIMS1_TWD)
-#define GPIO_PB00A_TWIMS1_TWD    _UL(1 <<  0)
+#define GPIO_PB00A_TWIMS1_TWD    _UL_(1 <<  0)
 /* ========== GPIO definition for TWIMS2 peripheral ========== */
-#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
-#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PIN_PA22E_TWIMS2_TWCK          _L_(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L_(4)
 #define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
-#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
-#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
-#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL_(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L_(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L_(4)
 #define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
-#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+#define GPIO_PA21E_TWIMS2_TWD    _UL_(1 << 21)
 /* ========== GPIO definition for TWIMS3 peripheral ========== */
-#define PIN_PB15C_TWIMS3_TWCK          _L(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
-#define MUX_PB15C_TWIMS3_TWCK           _L(2)
+#define PIN_PB15C_TWIMS3_TWCK          _L_(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
+#define MUX_PB15C_TWIMS3_TWCK           _L_(2)
 #define PINMUX_PB15C_TWIMS3_TWCK   ((PIN_PB15C_TWIMS3_TWCK << 16) | MUX_PB15C_TWIMS3_TWCK)
-#define GPIO_PB15C_TWIMS3_TWCK   _UL(1 << 15)
-#define PIN_PB14C_TWIMS3_TWD           _L(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
-#define MUX_PB14C_TWIMS3_TWD            _L(2)
+#define GPIO_PB15C_TWIMS3_TWCK   _UL_(1 << 15)
+#define PIN_PB14C_TWIMS3_TWD           _L_(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
+#define MUX_PB14C_TWIMS3_TWD            _L_(2)
 #define PINMUX_PB14C_TWIMS3_TWD    ((PIN_PB14C_TWIMS3_TWD << 16) | MUX_PB14C_TWIMS3_TWD)
-#define GPIO_PB14C_TWIMS3_TWD    _UL(1 << 14)
+#define GPIO_PB14C_TWIMS3_TWD    _UL_(1 << 14)
 /* ========== GPIO definition for IISC peripheral ========== */
-#define PIN_PB05D_IISC_IMCK            _L(37) /**< \brief IISC signal: IMCK on PB05 mux D */
-#define MUX_PB05D_IISC_IMCK             _L(3)
+#define PIN_PB05D_IISC_IMCK            _L_(37) /**< \brief IISC signal: IMCK on PB05 mux D */
+#define MUX_PB05D_IISC_IMCK             _L_(3)
 #define PINMUX_PB05D_IISC_IMCK     ((PIN_PB05D_IISC_IMCK << 16) | MUX_PB05D_IISC_IMCK)
-#define GPIO_PB05D_IISC_IMCK     _UL(1 <<  5)
-#define PIN_PC14D_IISC_IMCK            _L(78) /**< \brief IISC signal: IMCK on PC14 mux D */
-#define MUX_PC14D_IISC_IMCK             _L(3)
+#define GPIO_PB05D_IISC_IMCK     _UL_(1 <<  5)
+#define PIN_PC14D_IISC_IMCK            _L_(78) /**< \brief IISC signal: IMCK on PC14 mux D */
+#define MUX_PC14D_IISC_IMCK             _L_(3)
 #define PINMUX_PC14D_IISC_IMCK     ((PIN_PC14D_IISC_IMCK << 16) | MUX_PC14D_IISC_IMCK)
-#define GPIO_PC14D_IISC_IMCK     _UL(1 << 14)
-#define PIN_PA31B_IISC_IMCK            _L(31) /**< \brief IISC signal: IMCK on PA31 mux B */
-#define MUX_PA31B_IISC_IMCK             _L(1)
+#define GPIO_PC14D_IISC_IMCK     _UL_(1 << 14)
+#define PIN_PA31B_IISC_IMCK            _L_(31) /**< \brief IISC signal: IMCK on PA31 mux B */
+#define MUX_PA31B_IISC_IMCK             _L_(1)
 #define PINMUX_PA31B_IISC_IMCK     ((PIN_PA31B_IISC_IMCK << 16) | MUX_PA31B_IISC_IMCK)
-#define GPIO_PA31B_IISC_IMCK     _UL(1 << 31)
-#define PIN_PB02D_IISC_ISCK            _L(34) /**< \brief IISC signal: ISCK on PB02 mux D */
-#define MUX_PB02D_IISC_ISCK             _L(3)
+#define GPIO_PA31B_IISC_IMCK     _UL_(1 << 31)
+#define PIN_PB02D_IISC_ISCK            _L_(34) /**< \brief IISC signal: ISCK on PB02 mux D */
+#define MUX_PB02D_IISC_ISCK             _L_(3)
 #define PINMUX_PB02D_IISC_ISCK     ((PIN_PB02D_IISC_ISCK << 16) | MUX_PB02D_IISC_ISCK)
-#define GPIO_PB02D_IISC_ISCK     _UL(1 <<  2)
-#define PIN_PC09D_IISC_ISCK            _L(73) /**< \brief IISC signal: ISCK on PC09 mux D */
-#define MUX_PC09D_IISC_ISCK             _L(3)
+#define GPIO_PB02D_IISC_ISCK     _UL_(1 <<  2)
+#define PIN_PC09D_IISC_ISCK            _L_(73) /**< \brief IISC signal: ISCK on PC09 mux D */
+#define MUX_PC09D_IISC_ISCK             _L_(3)
 #define PINMUX_PC09D_IISC_ISCK     ((PIN_PC09D_IISC_ISCK << 16) | MUX_PC09D_IISC_ISCK)
-#define GPIO_PC09D_IISC_ISCK     _UL(1 <<  9)
-#define PIN_PA27B_IISC_ISCK            _L(27) /**< \brief IISC signal: ISCK on PA27 mux B */
-#define MUX_PA27B_IISC_ISCK             _L(1)
+#define GPIO_PC09D_IISC_ISCK     _UL_(1 <<  9)
+#define PIN_PA27B_IISC_ISCK            _L_(27) /**< \brief IISC signal: ISCK on PA27 mux B */
+#define MUX_PA27B_IISC_ISCK             _L_(1)
 #define PINMUX_PA27B_IISC_ISCK     ((PIN_PA27B_IISC_ISCK << 16) | MUX_PA27B_IISC_ISCK)
-#define GPIO_PA27B_IISC_ISCK     _UL(1 << 27)
-#define PIN_PB03D_IISC_ISDI            _L(35) /**< \brief IISC signal: ISDI on PB03 mux D */
-#define MUX_PB03D_IISC_ISDI             _L(3)
+#define GPIO_PA27B_IISC_ISCK     _UL_(1 << 27)
+#define PIN_PB03D_IISC_ISDI            _L_(35) /**< \brief IISC signal: ISDI on PB03 mux D */
+#define MUX_PB03D_IISC_ISDI             _L_(3)
 #define PINMUX_PB03D_IISC_ISDI     ((PIN_PB03D_IISC_ISDI << 16) | MUX_PB03D_IISC_ISDI)
-#define GPIO_PB03D_IISC_ISDI     _UL(1 <<  3)
-#define PIN_PC10D_IISC_ISDI            _L(74) /**< \brief IISC signal: ISDI on PC10 mux D */
-#define MUX_PC10D_IISC_ISDI             _L(3)
+#define GPIO_PB03D_IISC_ISDI     _UL_(1 <<  3)
+#define PIN_PC10D_IISC_ISDI            _L_(74) /**< \brief IISC signal: ISDI on PC10 mux D */
+#define MUX_PC10D_IISC_ISDI             _L_(3)
 #define PINMUX_PC10D_IISC_ISDI     ((PIN_PC10D_IISC_ISDI << 16) | MUX_PC10D_IISC_ISDI)
-#define GPIO_PC10D_IISC_ISDI     _UL(1 << 10)
-#define PIN_PA28B_IISC_ISDI            _L(28) /**< \brief IISC signal: ISDI on PA28 mux B */
-#define MUX_PA28B_IISC_ISDI             _L(1)
+#define GPIO_PC10D_IISC_ISDI     _UL_(1 << 10)
+#define PIN_PA28B_IISC_ISDI            _L_(28) /**< \brief IISC signal: ISDI on PA28 mux B */
+#define MUX_PA28B_IISC_ISDI             _L_(1)
 #define PINMUX_PA28B_IISC_ISDI     ((PIN_PA28B_IISC_ISDI << 16) | MUX_PA28B_IISC_ISDI)
-#define GPIO_PA28B_IISC_ISDI     _UL(1 << 28)
-#define PIN_PB04D_IISC_ISDO            _L(36) /**< \brief IISC signal: ISDO on PB04 mux D */
-#define MUX_PB04D_IISC_ISDO             _L(3)
+#define GPIO_PA28B_IISC_ISDI     _UL_(1 << 28)
+#define PIN_PB04D_IISC_ISDO            _L_(36) /**< \brief IISC signal: ISDO on PB04 mux D */
+#define MUX_PB04D_IISC_ISDO             _L_(3)
 #define PINMUX_PB04D_IISC_ISDO     ((PIN_PB04D_IISC_ISDO << 16) | MUX_PB04D_IISC_ISDO)
-#define GPIO_PB04D_IISC_ISDO     _UL(1 <<  4)
-#define PIN_PC13D_IISC_ISDO            _L(77) /**< \brief IISC signal: ISDO on PC13 mux D */
-#define MUX_PC13D_IISC_ISDO             _L(3)
+#define GPIO_PB04D_IISC_ISDO     _UL_(1 <<  4)
+#define PIN_PC13D_IISC_ISDO            _L_(77) /**< \brief IISC signal: ISDO on PC13 mux D */
+#define MUX_PC13D_IISC_ISDO             _L_(3)
 #define PINMUX_PC13D_IISC_ISDO     ((PIN_PC13D_IISC_ISDO << 16) | MUX_PC13D_IISC_ISDO)
-#define GPIO_PC13D_IISC_ISDO     _UL(1 << 13)
-#define PIN_PA30B_IISC_ISDO            _L(30) /**< \brief IISC signal: ISDO on PA30 mux B */
-#define MUX_PA30B_IISC_ISDO             _L(1)
+#define GPIO_PC13D_IISC_ISDO     _UL_(1 << 13)
+#define PIN_PA30B_IISC_ISDO            _L_(30) /**< \brief IISC signal: ISDO on PA30 mux B */
+#define MUX_PA30B_IISC_ISDO             _L_(1)
 #define PINMUX_PA30B_IISC_ISDO     ((PIN_PA30B_IISC_ISDO << 16) | MUX_PA30B_IISC_ISDO)
-#define GPIO_PA30B_IISC_ISDO     _UL(1 << 30)
-#define PIN_PB06D_IISC_IWS             _L(38) /**< \brief IISC signal: IWS on PB06 mux D */
-#define MUX_PB06D_IISC_IWS              _L(3)
+#define GPIO_PA30B_IISC_ISDO     _UL_(1 << 30)
+#define PIN_PB06D_IISC_IWS             _L_(38) /**< \brief IISC signal: IWS on PB06 mux D */
+#define MUX_PB06D_IISC_IWS              _L_(3)
 #define PINMUX_PB06D_IISC_IWS      ((PIN_PB06D_IISC_IWS << 16) | MUX_PB06D_IISC_IWS)
-#define GPIO_PB06D_IISC_IWS      _UL(1 <<  6)
-#define PIN_PC12D_IISC_IWS             _L(76) /**< \brief IISC signal: IWS on PC12 mux D */
-#define MUX_PC12D_IISC_IWS              _L(3)
+#define GPIO_PB06D_IISC_IWS      _UL_(1 <<  6)
+#define PIN_PC12D_IISC_IWS             _L_(76) /**< \brief IISC signal: IWS on PC12 mux D */
+#define MUX_PC12D_IISC_IWS              _L_(3)
 #define PINMUX_PC12D_IISC_IWS      ((PIN_PC12D_IISC_IWS << 16) | MUX_PC12D_IISC_IWS)
-#define GPIO_PC12D_IISC_IWS      _UL(1 << 12)
-#define PIN_PA29B_IISC_IWS             _L(29) /**< \brief IISC signal: IWS on PA29 mux B */
-#define MUX_PA29B_IISC_IWS              _L(1)
+#define GPIO_PC12D_IISC_IWS      _UL_(1 << 12)
+#define PIN_PA29B_IISC_IWS             _L_(29) /**< \brief IISC signal: IWS on PA29 mux B */
+#define MUX_PA29B_IISC_IWS              _L_(1)
 #define PINMUX_PA29B_IISC_IWS      ((PIN_PA29B_IISC_IWS << 16) | MUX_PA29B_IISC_IWS)
-#define GPIO_PA29B_IISC_IWS      _UL(1 << 29)
+#define GPIO_PA29B_IISC_IWS      _UL_(1 << 29)
 /* ========== GPIO definition for SPI peripheral ========== */
-#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
-#define MUX_PA03B_SPI_MISO              _L(1)
+#define PIN_PA03B_SPI_MISO              _L_(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L_(1)
 #define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
-#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
-#define PIN_PB14B_SPI_MISO             _L(46) /**< \brief SPI signal: MISO on PB14 mux B */
-#define MUX_PB14B_SPI_MISO              _L(1)
+#define GPIO_PA03B_SPI_MISO      _UL_(1 <<  3)
+#define PIN_PB14B_SPI_MISO             _L_(46) /**< \brief SPI signal: MISO on PB14 mux B */
+#define MUX_PB14B_SPI_MISO              _L_(1)
 #define PINMUX_PB14B_SPI_MISO      ((PIN_PB14B_SPI_MISO << 16) | MUX_PB14B_SPI_MISO)
-#define GPIO_PB14B_SPI_MISO      _UL(1 << 14)
-#define PIN_PC28B_SPI_MISO             _L(92) /**< \brief SPI signal: MISO on PC28 mux B */
-#define MUX_PC28B_SPI_MISO              _L(1)
+#define GPIO_PB14B_SPI_MISO      _UL_(1 << 14)
+#define PIN_PC28B_SPI_MISO             _L_(92) /**< \brief SPI signal: MISO on PC28 mux B */
+#define MUX_PC28B_SPI_MISO              _L_(1)
 #define PINMUX_PC28B_SPI_MISO      ((PIN_PC28B_SPI_MISO << 16) | MUX_PC28B_SPI_MISO)
-#define GPIO_PC28B_SPI_MISO      _UL(1 << 28)
-#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
-#define MUX_PA21A_SPI_MISO              _L(0)
+#define GPIO_PC28B_SPI_MISO      _UL_(1 << 28)
+#define PIN_PA21A_SPI_MISO             _L_(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L_(0)
 #define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
-#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
-#define PIN_PA27A_SPI_MISO             _L(27) /**< \brief SPI signal: MISO on PA27 mux A */
-#define MUX_PA27A_SPI_MISO              _L(0)
+#define GPIO_PA21A_SPI_MISO      _UL_(1 << 21)
+#define PIN_PA27A_SPI_MISO             _L_(27) /**< \brief SPI signal: MISO on PA27 mux A */
+#define MUX_PA27A_SPI_MISO              _L_(0)
 #define PINMUX_PA27A_SPI_MISO      ((PIN_PA27A_SPI_MISO << 16) | MUX_PA27A_SPI_MISO)
-#define GPIO_PA27A_SPI_MISO      _UL(1 << 27)
-#define PIN_PC04A_SPI_MISO             _L(68) /**< \brief SPI signal: MISO on PC04 mux A */
-#define MUX_PC04A_SPI_MISO              _L(0)
+#define GPIO_PA27A_SPI_MISO      _UL_(1 << 27)
+#define PIN_PC04A_SPI_MISO             _L_(68) /**< \brief SPI signal: MISO on PC04 mux A */
+#define MUX_PC04A_SPI_MISO              _L_(0)
 #define PINMUX_PC04A_SPI_MISO      ((PIN_PC04A_SPI_MISO << 16) | MUX_PC04A_SPI_MISO)
-#define GPIO_PC04A_SPI_MISO      _UL(1 <<  4)
-#define PIN_PB15B_SPI_MOSI             _L(47) /**< \brief SPI signal: MOSI on PB15 mux B */
-#define MUX_PB15B_SPI_MOSI              _L(1)
+#define GPIO_PC04A_SPI_MISO      _UL_(1 <<  4)
+#define PIN_PB15B_SPI_MOSI             _L_(47) /**< \brief SPI signal: MOSI on PB15 mux B */
+#define MUX_PB15B_SPI_MOSI              _L_(1)
 #define PINMUX_PB15B_SPI_MOSI      ((PIN_PB15B_SPI_MOSI << 16) | MUX_PB15B_SPI_MOSI)
-#define GPIO_PB15B_SPI_MOSI      _UL(1 << 15)
-#define PIN_PC29B_SPI_MOSI             _L(93) /**< \brief SPI signal: MOSI on PC29 mux B */
-#define MUX_PC29B_SPI_MOSI              _L(1)
+#define GPIO_PB15B_SPI_MOSI      _UL_(1 << 15)
+#define PIN_PC29B_SPI_MOSI             _L_(93) /**< \brief SPI signal: MOSI on PC29 mux B */
+#define MUX_PC29B_SPI_MOSI              _L_(1)
 #define PINMUX_PC29B_SPI_MOSI      ((PIN_PC29B_SPI_MOSI << 16) | MUX_PC29B_SPI_MOSI)
-#define GPIO_PC29B_SPI_MOSI      _UL(1 << 29)
-#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
-#define MUX_PA22A_SPI_MOSI              _L(0)
+#define GPIO_PC29B_SPI_MOSI      _UL_(1 << 29)
+#define PIN_PA22A_SPI_MOSI             _L_(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L_(0)
 #define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
-#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
-#define PIN_PA28A_SPI_MOSI             _L(28) /**< \brief SPI signal: MOSI on PA28 mux A */
-#define MUX_PA28A_SPI_MOSI              _L(0)
+#define GPIO_PA22A_SPI_MOSI      _UL_(1 << 22)
+#define PIN_PA28A_SPI_MOSI             _L_(28) /**< \brief SPI signal: MOSI on PA28 mux A */
+#define MUX_PA28A_SPI_MOSI              _L_(0)
 #define PINMUX_PA28A_SPI_MOSI      ((PIN_PA28A_SPI_MOSI << 16) | MUX_PA28A_SPI_MOSI)
-#define GPIO_PA28A_SPI_MOSI      _UL(1 << 28)
-#define PIN_PC05A_SPI_MOSI             _L(69) /**< \brief SPI signal: MOSI on PC05 mux A */
-#define MUX_PC05A_SPI_MOSI              _L(0)
+#define GPIO_PA28A_SPI_MOSI      _UL_(1 << 28)
+#define PIN_PC05A_SPI_MOSI             _L_(69) /**< \brief SPI signal: MOSI on PC05 mux A */
+#define MUX_PC05A_SPI_MOSI              _L_(0)
 #define PINMUX_PC05A_SPI_MOSI      ((PIN_PC05A_SPI_MOSI << 16) | MUX_PC05A_SPI_MOSI)
-#define GPIO_PC05A_SPI_MOSI      _UL(1 <<  5)
-#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
-#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define GPIO_PC05A_SPI_MOSI      _UL_(1 <<  5)
+#define PIN_PA02B_SPI_NPCS0             _L_(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L_(1)
 #define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
-#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
-#define PIN_PC31B_SPI_NPCS0            _L(95) /**< \brief SPI signal: NPCS0 on PC31 mux B */
-#define MUX_PC31B_SPI_NPCS0             _L(1)
+#define GPIO_PA02B_SPI_NPCS0     _UL_(1 <<  2)
+#define PIN_PC31B_SPI_NPCS0            _L_(95) /**< \brief SPI signal: NPCS0 on PC31 mux B */
+#define MUX_PC31B_SPI_NPCS0             _L_(1)
 #define PINMUX_PC31B_SPI_NPCS0     ((PIN_PC31B_SPI_NPCS0 << 16) | MUX_PC31B_SPI_NPCS0)
-#define GPIO_PC31B_SPI_NPCS0     _UL(1 << 31)
-#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
-#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define GPIO_PC31B_SPI_NPCS0     _UL_(1 << 31)
+#define PIN_PA24A_SPI_NPCS0            _L_(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L_(0)
 #define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
-#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
-#define PIN_PA30A_SPI_NPCS0            _L(30) /**< \brief SPI signal: NPCS0 on PA30 mux A */
-#define MUX_PA30A_SPI_NPCS0             _L(0)
+#define GPIO_PA24A_SPI_NPCS0     _UL_(1 << 24)
+#define PIN_PA30A_SPI_NPCS0            _L_(30) /**< \brief SPI signal: NPCS0 on PA30 mux A */
+#define MUX_PA30A_SPI_NPCS0             _L_(0)
 #define PINMUX_PA30A_SPI_NPCS0     ((PIN_PA30A_SPI_NPCS0 << 16) | MUX_PA30A_SPI_NPCS0)
-#define GPIO_PA30A_SPI_NPCS0     _UL(1 << 30)
-#define PIN_PC03A_SPI_NPCS0            _L(67) /**< \brief SPI signal: NPCS0 on PC03 mux A */
-#define MUX_PC03A_SPI_NPCS0             _L(0)
+#define GPIO_PA30A_SPI_NPCS0     _UL_(1 << 30)
+#define PIN_PC03A_SPI_NPCS0            _L_(67) /**< \brief SPI signal: NPCS0 on PC03 mux A */
+#define MUX_PC03A_SPI_NPCS0             _L_(0)
 #define PINMUX_PC03A_SPI_NPCS0     ((PIN_PC03A_SPI_NPCS0 << 16) | MUX_PC03A_SPI_NPCS0)
-#define GPIO_PC03A_SPI_NPCS0     _UL(1 <<  3)
-#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
-#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define GPIO_PC03A_SPI_NPCS0     _UL_(1 <<  3)
+#define PIN_PA13C_SPI_NPCS1            _L_(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L_(2)
 #define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
-#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PB13B_SPI_NPCS1            _L(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
-#define MUX_PB13B_SPI_NPCS1             _L(1)
+#define GPIO_PA13C_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PB13B_SPI_NPCS1            _L_(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
+#define MUX_PB13B_SPI_NPCS1             _L_(1)
 #define PINMUX_PB13B_SPI_NPCS1     ((PIN_PB13B_SPI_NPCS1 << 16) | MUX_PB13B_SPI_NPCS1)
-#define GPIO_PB13B_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PA31A_SPI_NPCS1            _L(31) /**< \brief SPI signal: NPCS1 on PA31 mux A */
-#define MUX_PA31A_SPI_NPCS1             _L(0)
+#define GPIO_PB13B_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PA31A_SPI_NPCS1            _L_(31) /**< \brief SPI signal: NPCS1 on PA31 mux A */
+#define MUX_PA31A_SPI_NPCS1             _L_(0)
 #define PINMUX_PA31A_SPI_NPCS1     ((PIN_PA31A_SPI_NPCS1 << 16) | MUX_PA31A_SPI_NPCS1)
-#define GPIO_PA31A_SPI_NPCS1     _UL(1 << 31)
-#define PIN_PC02A_SPI_NPCS1            _L(66) /**< \brief SPI signal: NPCS1 on PC02 mux A */
-#define MUX_PC02A_SPI_NPCS1             _L(0)
+#define GPIO_PA31A_SPI_NPCS1     _UL_(1 << 31)
+#define PIN_PC02A_SPI_NPCS1            _L_(66) /**< \brief SPI signal: NPCS1 on PC02 mux A */
+#define MUX_PC02A_SPI_NPCS1             _L_(0)
 #define PINMUX_PC02A_SPI_NPCS1     ((PIN_PC02A_SPI_NPCS1 << 16) | MUX_PC02A_SPI_NPCS1)
-#define GPIO_PC02A_SPI_NPCS1     _UL(1 <<  2)
-#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
-#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define GPIO_PC02A_SPI_NPCS1     _UL_(1 <<  2)
+#define PIN_PA14C_SPI_NPCS2            _L_(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L_(2)
 #define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
-#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
-#define PIN_PB11B_SPI_NPCS2            _L(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
-#define MUX_PB11B_SPI_NPCS2             _L(1)
+#define GPIO_PA14C_SPI_NPCS2     _UL_(1 << 14)
+#define PIN_PB11B_SPI_NPCS2            _L_(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
+#define MUX_PB11B_SPI_NPCS2             _L_(1)
 #define PINMUX_PB11B_SPI_NPCS2     ((PIN_PB11B_SPI_NPCS2 << 16) | MUX_PB11B_SPI_NPCS2)
-#define GPIO_PB11B_SPI_NPCS2     _UL(1 << 11)
-#define PIN_PC00A_SPI_NPCS2            _L(64) /**< \brief SPI signal: NPCS2 on PC00 mux A */
-#define MUX_PC00A_SPI_NPCS2             _L(0)
+#define GPIO_PB11B_SPI_NPCS2     _UL_(1 << 11)
+#define PIN_PC00A_SPI_NPCS2            _L_(64) /**< \brief SPI signal: NPCS2 on PC00 mux A */
+#define MUX_PC00A_SPI_NPCS2             _L_(0)
 #define PINMUX_PC00A_SPI_NPCS2     ((PIN_PC00A_SPI_NPCS2 << 16) | MUX_PC00A_SPI_NPCS2)
-#define GPIO_PC00A_SPI_NPCS2     _UL(1 <<  0)
-#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
-#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define GPIO_PC00A_SPI_NPCS2     _UL_(1 <<  0)
+#define PIN_PA15C_SPI_NPCS3            _L_(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L_(2)
 #define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
-#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
-#define PIN_PB12B_SPI_NPCS3            _L(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
-#define MUX_PB12B_SPI_NPCS3             _L(1)
+#define GPIO_PA15C_SPI_NPCS3     _UL_(1 << 15)
+#define PIN_PB12B_SPI_NPCS3            _L_(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
+#define MUX_PB12B_SPI_NPCS3             _L_(1)
 #define PINMUX_PB12B_SPI_NPCS3     ((PIN_PB12B_SPI_NPCS3 << 16) | MUX_PB12B_SPI_NPCS3)
-#define GPIO_PB12B_SPI_NPCS3     _UL(1 << 12)
-#define PIN_PC01A_SPI_NPCS3            _L(65) /**< \brief SPI signal: NPCS3 on PC01 mux A */
-#define MUX_PC01A_SPI_NPCS3             _L(0)
+#define GPIO_PB12B_SPI_NPCS3     _UL_(1 << 12)
+#define PIN_PC01A_SPI_NPCS3            _L_(65) /**< \brief SPI signal: NPCS3 on PC01 mux A */
+#define MUX_PC01A_SPI_NPCS3             _L_(0)
 #define PINMUX_PC01A_SPI_NPCS3     ((PIN_PC01A_SPI_NPCS3 << 16) | MUX_PC01A_SPI_NPCS3)
-#define GPIO_PC01A_SPI_NPCS3     _UL(1 <<  1)
-#define PIN_PC30B_SPI_SCK              _L(94) /**< \brief SPI signal: SCK on PC30 mux B */
-#define MUX_PC30B_SPI_SCK               _L(1)
+#define GPIO_PC01A_SPI_NPCS3     _UL_(1 <<  1)
+#define PIN_PC30B_SPI_SCK              _L_(94) /**< \brief SPI signal: SCK on PC30 mux B */
+#define MUX_PC30B_SPI_SCK               _L_(1)
 #define PINMUX_PC30B_SPI_SCK       ((PIN_PC30B_SPI_SCK << 16) | MUX_PC30B_SPI_SCK)
-#define GPIO_PC30B_SPI_SCK       _UL(1 << 30)
-#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
-#define MUX_PA23A_SPI_SCK               _L(0)
+#define GPIO_PC30B_SPI_SCK       _UL_(1 << 30)
+#define PIN_PA23A_SPI_SCK              _L_(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L_(0)
 #define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
-#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
-#define PIN_PA29A_SPI_SCK              _L(29) /**< \brief SPI signal: SCK on PA29 mux A */
-#define MUX_PA29A_SPI_SCK               _L(0)
+#define GPIO_PA23A_SPI_SCK       _UL_(1 << 23)
+#define PIN_PA29A_SPI_SCK              _L_(29) /**< \brief SPI signal: SCK on PA29 mux A */
+#define MUX_PA29A_SPI_SCK               _L_(0)
 #define PINMUX_PA29A_SPI_SCK       ((PIN_PA29A_SPI_SCK << 16) | MUX_PA29A_SPI_SCK)
-#define GPIO_PA29A_SPI_SCK       _UL(1 << 29)
-#define PIN_PC06A_SPI_SCK              _L(70) /**< \brief SPI signal: SCK on PC06 mux A */
-#define MUX_PC06A_SPI_SCK               _L(0)
+#define GPIO_PA29A_SPI_SCK       _UL_(1 << 29)
+#define PIN_PC06A_SPI_SCK              _L_(70) /**< \brief SPI signal: SCK on PC06 mux A */
+#define MUX_PC06A_SPI_SCK               _L_(0)
 #define PINMUX_PC06A_SPI_SCK       ((PIN_PC06A_SPI_SCK << 16) | MUX_PC06A_SPI_SCK)
-#define GPIO_PC06A_SPI_SCK       _UL(1 <<  6)
+#define GPIO_PC06A_SPI_SCK       _UL_(1 <<  6)
 /* ========== GPIO definition for TC0 peripheral ========== */
-#define PIN_PB07D_TC0_A0               _L(39) /**< \brief TC0 signal: A0 on PB07 mux D */
-#define MUX_PB07D_TC0_A0                _L(3)
+#define PIN_PB07D_TC0_A0               _L_(39) /**< \brief TC0 signal: A0 on PB07 mux D */
+#define MUX_PB07D_TC0_A0                _L_(3)
 #define PINMUX_PB07D_TC0_A0        ((PIN_PB07D_TC0_A0 << 16) | MUX_PB07D_TC0_A0)
-#define GPIO_PB07D_TC0_A0        _UL(1 <<  7)
-#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
-#define MUX_PA08B_TC0_A0                _L(1)
+#define GPIO_PB07D_TC0_A0        _UL_(1 <<  7)
+#define PIN_PA08B_TC0_A0                _L_(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L_(1)
 #define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
-#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
-#define PIN_PB09D_TC0_A1               _L(41) /**< \brief TC0 signal: A1 on PB09 mux D */
-#define MUX_PB09D_TC0_A1                _L(3)
+#define GPIO_PA08B_TC0_A0        _UL_(1 <<  8)
+#define PIN_PB09D_TC0_A1               _L_(41) /**< \brief TC0 signal: A1 on PB09 mux D */
+#define MUX_PB09D_TC0_A1                _L_(3)
 #define PINMUX_PB09D_TC0_A1        ((PIN_PB09D_TC0_A1 << 16) | MUX_PB09D_TC0_A1)
-#define GPIO_PB09D_TC0_A1        _UL(1 <<  9)
-#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
-#define MUX_PA10B_TC0_A1                _L(1)
+#define GPIO_PB09D_TC0_A1        _UL_(1 <<  9)
+#define PIN_PA10B_TC0_A1               _L_(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L_(1)
 #define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
-#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
-#define PIN_PB11D_TC0_A2               _L(43) /**< \brief TC0 signal: A2 on PB11 mux D */
-#define MUX_PB11D_TC0_A2                _L(3)
+#define GPIO_PA10B_TC0_A1        _UL_(1 << 10)
+#define PIN_PB11D_TC0_A2               _L_(43) /**< \brief TC0 signal: A2 on PB11 mux D */
+#define MUX_PB11D_TC0_A2                _L_(3)
 #define PINMUX_PB11D_TC0_A2        ((PIN_PB11D_TC0_A2 << 16) | MUX_PB11D_TC0_A2)
-#define GPIO_PB11D_TC0_A2        _UL(1 << 11)
-#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
-#define MUX_PA12B_TC0_A2                _L(1)
+#define GPIO_PB11D_TC0_A2        _UL_(1 << 11)
+#define PIN_PA12B_TC0_A2               _L_(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L_(1)
 #define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
-#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
-#define PIN_PB08D_TC0_B0               _L(40) /**< \brief TC0 signal: B0 on PB08 mux D */
-#define MUX_PB08D_TC0_B0                _L(3)
+#define GPIO_PA12B_TC0_A2        _UL_(1 << 12)
+#define PIN_PB08D_TC0_B0               _L_(40) /**< \brief TC0 signal: B0 on PB08 mux D */
+#define MUX_PB08D_TC0_B0                _L_(3)
 #define PINMUX_PB08D_TC0_B0        ((PIN_PB08D_TC0_B0 << 16) | MUX_PB08D_TC0_B0)
-#define GPIO_PB08D_TC0_B0        _UL(1 <<  8)
-#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
-#define MUX_PA09B_TC0_B0                _L(1)
+#define GPIO_PB08D_TC0_B0        _UL_(1 <<  8)
+#define PIN_PA09B_TC0_B0                _L_(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L_(1)
 #define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
-#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
-#define PIN_PB10D_TC0_B1               _L(42) /**< \brief TC0 signal: B1 on PB10 mux D */
-#define MUX_PB10D_TC0_B1                _L(3)
+#define GPIO_PA09B_TC0_B0        _UL_(1 <<  9)
+#define PIN_PB10D_TC0_B1               _L_(42) /**< \brief TC0 signal: B1 on PB10 mux D */
+#define MUX_PB10D_TC0_B1                _L_(3)
 #define PINMUX_PB10D_TC0_B1        ((PIN_PB10D_TC0_B1 << 16) | MUX_PB10D_TC0_B1)
-#define GPIO_PB10D_TC0_B1        _UL(1 << 10)
-#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
-#define MUX_PA11B_TC0_B1                _L(1)
+#define GPIO_PB10D_TC0_B1        _UL_(1 << 10)
+#define PIN_PA11B_TC0_B1               _L_(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L_(1)
 #define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
-#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
-#define PIN_PB12D_TC0_B2               _L(44) /**< \brief TC0 signal: B2 on PB12 mux D */
-#define MUX_PB12D_TC0_B2                _L(3)
+#define GPIO_PA11B_TC0_B1        _UL_(1 << 11)
+#define PIN_PB12D_TC0_B2               _L_(44) /**< \brief TC0 signal: B2 on PB12 mux D */
+#define MUX_PB12D_TC0_B2                _L_(3)
 #define PINMUX_PB12D_TC0_B2        ((PIN_PB12D_TC0_B2 << 16) | MUX_PB12D_TC0_B2)
-#define GPIO_PB12D_TC0_B2        _UL(1 << 12)
-#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
-#define MUX_PA13B_TC0_B2                _L(1)
+#define GPIO_PB12D_TC0_B2        _UL_(1 << 12)
+#define PIN_PA13B_TC0_B2               _L_(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L_(1)
 #define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
-#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
-#define PIN_PB13D_TC0_CLK0             _L(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
-#define MUX_PB13D_TC0_CLK0              _L(3)
+#define GPIO_PA13B_TC0_B2        _UL_(1 << 13)
+#define PIN_PB13D_TC0_CLK0             _L_(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
+#define MUX_PB13D_TC0_CLK0              _L_(3)
 #define PINMUX_PB13D_TC0_CLK0      ((PIN_PB13D_TC0_CLK0 << 16) | MUX_PB13D_TC0_CLK0)
-#define GPIO_PB13D_TC0_CLK0      _UL(1 << 13)
-#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
-#define MUX_PA14B_TC0_CLK0              _L(1)
+#define GPIO_PB13D_TC0_CLK0      _UL_(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L_(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L_(1)
 #define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
-#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
-#define PIN_PB14D_TC0_CLK1             _L(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
-#define MUX_PB14D_TC0_CLK1              _L(3)
+#define GPIO_PA14B_TC0_CLK0      _UL_(1 << 14)
+#define PIN_PB14D_TC0_CLK1             _L_(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
+#define MUX_PB14D_TC0_CLK1              _L_(3)
 #define PINMUX_PB14D_TC0_CLK1      ((PIN_PB14D_TC0_CLK1 << 16) | MUX_PB14D_TC0_CLK1)
-#define GPIO_PB14D_TC0_CLK1      _UL(1 << 14)
-#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
-#define MUX_PA15B_TC0_CLK1              _L(1)
+#define GPIO_PB14D_TC0_CLK1      _UL_(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L_(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L_(1)
 #define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
-#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
-#define PIN_PB15D_TC0_CLK2             _L(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
-#define MUX_PB15D_TC0_CLK2              _L(3)
+#define GPIO_PA15B_TC0_CLK1      _UL_(1 << 15)
+#define PIN_PB15D_TC0_CLK2             _L_(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
+#define MUX_PB15D_TC0_CLK2              _L_(3)
 #define PINMUX_PB15D_TC0_CLK2      ((PIN_PB15D_TC0_CLK2 << 16) | MUX_PB15D_TC0_CLK2)
-#define GPIO_PB15D_TC0_CLK2      _UL(1 << 15)
-#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
-#define MUX_PA16B_TC0_CLK2              _L(1)
+#define GPIO_PB15D_TC0_CLK2      _UL_(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L_(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L_(1)
 #define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
-#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+#define GPIO_PA16B_TC0_CLK2      _UL_(1 << 16)
 /* ========== GPIO definition for TC1 peripheral ========== */
-#define PIN_PC00D_TC1_A0               _L(64) /**< \brief TC1 signal: A0 on PC00 mux D */
-#define MUX_PC00D_TC1_A0                _L(3)
+#define PIN_PC00D_TC1_A0               _L_(64) /**< \brief TC1 signal: A0 on PC00 mux D */
+#define MUX_PC00D_TC1_A0                _L_(3)
 #define PINMUX_PC00D_TC1_A0        ((PIN_PC00D_TC1_A0 << 16) | MUX_PC00D_TC1_A0)
-#define GPIO_PC00D_TC1_A0        _UL(1 <<  0)
-#define PIN_PC15A_TC1_A0               _L(79) /**< \brief TC1 signal: A0 on PC15 mux A */
-#define MUX_PC15A_TC1_A0                _L(0)
+#define GPIO_PC00D_TC1_A0        _UL_(1 <<  0)
+#define PIN_PC15A_TC1_A0               _L_(79) /**< \brief TC1 signal: A0 on PC15 mux A */
+#define MUX_PC15A_TC1_A0                _L_(0)
 #define PINMUX_PC15A_TC1_A0        ((PIN_PC15A_TC1_A0 << 16) | MUX_PC15A_TC1_A0)
-#define GPIO_PC15A_TC1_A0        _UL(1 << 15)
-#define PIN_PC02D_TC1_A1               _L(66) /**< \brief TC1 signal: A1 on PC02 mux D */
-#define MUX_PC02D_TC1_A1                _L(3)
+#define GPIO_PC15A_TC1_A0        _UL_(1 << 15)
+#define PIN_PC02D_TC1_A1               _L_(66) /**< \brief TC1 signal: A1 on PC02 mux D */
+#define MUX_PC02D_TC1_A1                _L_(3)
 #define PINMUX_PC02D_TC1_A1        ((PIN_PC02D_TC1_A1 << 16) | MUX_PC02D_TC1_A1)
-#define GPIO_PC02D_TC1_A1        _UL(1 <<  2)
-#define PIN_PC17A_TC1_A1               _L(81) /**< \brief TC1 signal: A1 on PC17 mux A */
-#define MUX_PC17A_TC1_A1                _L(0)
+#define GPIO_PC02D_TC1_A1        _UL_(1 <<  2)
+#define PIN_PC17A_TC1_A1               _L_(81) /**< \brief TC1 signal: A1 on PC17 mux A */
+#define MUX_PC17A_TC1_A1                _L_(0)
 #define PINMUX_PC17A_TC1_A1        ((PIN_PC17A_TC1_A1 << 16) | MUX_PC17A_TC1_A1)
-#define GPIO_PC17A_TC1_A1        _UL(1 << 17)
-#define PIN_PC04D_TC1_A2               _L(68) /**< \brief TC1 signal: A2 on PC04 mux D */
-#define MUX_PC04D_TC1_A2                _L(3)
+#define GPIO_PC17A_TC1_A1        _UL_(1 << 17)
+#define PIN_PC04D_TC1_A2               _L_(68) /**< \brief TC1 signal: A2 on PC04 mux D */
+#define MUX_PC04D_TC1_A2                _L_(3)
 #define PINMUX_PC04D_TC1_A2        ((PIN_PC04D_TC1_A2 << 16) | MUX_PC04D_TC1_A2)
-#define GPIO_PC04D_TC1_A2        _UL(1 <<  4)
-#define PIN_PC19A_TC1_A2               _L(83) /**< \brief TC1 signal: A2 on PC19 mux A */
-#define MUX_PC19A_TC1_A2                _L(0)
+#define GPIO_PC04D_TC1_A2        _UL_(1 <<  4)
+#define PIN_PC19A_TC1_A2               _L_(83) /**< \brief TC1 signal: A2 on PC19 mux A */
+#define MUX_PC19A_TC1_A2                _L_(0)
 #define PINMUX_PC19A_TC1_A2        ((PIN_PC19A_TC1_A2 << 16) | MUX_PC19A_TC1_A2)
-#define GPIO_PC19A_TC1_A2        _UL(1 << 19)
-#define PIN_PC01D_TC1_B0               _L(65) /**< \brief TC1 signal: B0 on PC01 mux D */
-#define MUX_PC01D_TC1_B0                _L(3)
+#define GPIO_PC19A_TC1_A2        _UL_(1 << 19)
+#define PIN_PC01D_TC1_B0               _L_(65) /**< \brief TC1 signal: B0 on PC01 mux D */
+#define MUX_PC01D_TC1_B0                _L_(3)
 #define PINMUX_PC01D_TC1_B0        ((PIN_PC01D_TC1_B0 << 16) | MUX_PC01D_TC1_B0)
-#define GPIO_PC01D_TC1_B0        _UL(1 <<  1)
-#define PIN_PC16A_TC1_B0               _L(80) /**< \brief TC1 signal: B0 on PC16 mux A */
-#define MUX_PC16A_TC1_B0                _L(0)
+#define GPIO_PC01D_TC1_B0        _UL_(1 <<  1)
+#define PIN_PC16A_TC1_B0               _L_(80) /**< \brief TC1 signal: B0 on PC16 mux A */
+#define MUX_PC16A_TC1_B0                _L_(0)
 #define PINMUX_PC16A_TC1_B0        ((PIN_PC16A_TC1_B0 << 16) | MUX_PC16A_TC1_B0)
-#define GPIO_PC16A_TC1_B0        _UL(1 << 16)
-#define PIN_PC03D_TC1_B1               _L(67) /**< \brief TC1 signal: B1 on PC03 mux D */
-#define MUX_PC03D_TC1_B1                _L(3)
+#define GPIO_PC16A_TC1_B0        _UL_(1 << 16)
+#define PIN_PC03D_TC1_B1               _L_(67) /**< \brief TC1 signal: B1 on PC03 mux D */
+#define MUX_PC03D_TC1_B1                _L_(3)
 #define PINMUX_PC03D_TC1_B1        ((PIN_PC03D_TC1_B1 << 16) | MUX_PC03D_TC1_B1)
-#define GPIO_PC03D_TC1_B1        _UL(1 <<  3)
-#define PIN_PC18A_TC1_B1               _L(82) /**< \brief TC1 signal: B1 on PC18 mux A */
-#define MUX_PC18A_TC1_B1                _L(0)
+#define GPIO_PC03D_TC1_B1        _UL_(1 <<  3)
+#define PIN_PC18A_TC1_B1               _L_(82) /**< \brief TC1 signal: B1 on PC18 mux A */
+#define MUX_PC18A_TC1_B1                _L_(0)
 #define PINMUX_PC18A_TC1_B1        ((PIN_PC18A_TC1_B1 << 16) | MUX_PC18A_TC1_B1)
-#define GPIO_PC18A_TC1_B1        _UL(1 << 18)
-#define PIN_PC05D_TC1_B2               _L(69) /**< \brief TC1 signal: B2 on PC05 mux D */
-#define MUX_PC05D_TC1_B2                _L(3)
+#define GPIO_PC18A_TC1_B1        _UL_(1 << 18)
+#define PIN_PC05D_TC1_B2               _L_(69) /**< \brief TC1 signal: B2 on PC05 mux D */
+#define MUX_PC05D_TC1_B2                _L_(3)
 #define PINMUX_PC05D_TC1_B2        ((PIN_PC05D_TC1_B2 << 16) | MUX_PC05D_TC1_B2)
-#define GPIO_PC05D_TC1_B2        _UL(1 <<  5)
-#define PIN_PC20A_TC1_B2               _L(84) /**< \brief TC1 signal: B2 on PC20 mux A */
-#define MUX_PC20A_TC1_B2                _L(0)
+#define GPIO_PC05D_TC1_B2        _UL_(1 <<  5)
+#define PIN_PC20A_TC1_B2               _L_(84) /**< \brief TC1 signal: B2 on PC20 mux A */
+#define MUX_PC20A_TC1_B2                _L_(0)
 #define PINMUX_PC20A_TC1_B2        ((PIN_PC20A_TC1_B2 << 16) | MUX_PC20A_TC1_B2)
-#define GPIO_PC20A_TC1_B2        _UL(1 << 20)
-#define PIN_PC06D_TC1_CLK0             _L(70) /**< \brief TC1 signal: CLK0 on PC06 mux D */
-#define MUX_PC06D_TC1_CLK0              _L(3)
+#define GPIO_PC20A_TC1_B2        _UL_(1 << 20)
+#define PIN_PC06D_TC1_CLK0             _L_(70) /**< \brief TC1 signal: CLK0 on PC06 mux D */
+#define MUX_PC06D_TC1_CLK0              _L_(3)
 #define PINMUX_PC06D_TC1_CLK0      ((PIN_PC06D_TC1_CLK0 << 16) | MUX_PC06D_TC1_CLK0)
-#define GPIO_PC06D_TC1_CLK0      _UL(1 <<  6)
-#define PIN_PC21A_TC1_CLK0             _L(85) /**< \brief TC1 signal: CLK0 on PC21 mux A */
-#define MUX_PC21A_TC1_CLK0              _L(0)
+#define GPIO_PC06D_TC1_CLK0      _UL_(1 <<  6)
+#define PIN_PC21A_TC1_CLK0             _L_(85) /**< \brief TC1 signal: CLK0 on PC21 mux A */
+#define MUX_PC21A_TC1_CLK0              _L_(0)
 #define PINMUX_PC21A_TC1_CLK0      ((PIN_PC21A_TC1_CLK0 << 16) | MUX_PC21A_TC1_CLK0)
-#define GPIO_PC21A_TC1_CLK0      _UL(1 << 21)
-#define PIN_PC07D_TC1_CLK1             _L(71) /**< \brief TC1 signal: CLK1 on PC07 mux D */
-#define MUX_PC07D_TC1_CLK1              _L(3)
+#define GPIO_PC21A_TC1_CLK0      _UL_(1 << 21)
+#define PIN_PC07D_TC1_CLK1             _L_(71) /**< \brief TC1 signal: CLK1 on PC07 mux D */
+#define MUX_PC07D_TC1_CLK1              _L_(3)
 #define PINMUX_PC07D_TC1_CLK1      ((PIN_PC07D_TC1_CLK1 << 16) | MUX_PC07D_TC1_CLK1)
-#define GPIO_PC07D_TC1_CLK1      _UL(1 <<  7)
-#define PIN_PC22A_TC1_CLK1             _L(86) /**< \brief TC1 signal: CLK1 on PC22 mux A */
-#define MUX_PC22A_TC1_CLK1              _L(0)
+#define GPIO_PC07D_TC1_CLK1      _UL_(1 <<  7)
+#define PIN_PC22A_TC1_CLK1             _L_(86) /**< \brief TC1 signal: CLK1 on PC22 mux A */
+#define MUX_PC22A_TC1_CLK1              _L_(0)
 #define PINMUX_PC22A_TC1_CLK1      ((PIN_PC22A_TC1_CLK1 << 16) | MUX_PC22A_TC1_CLK1)
-#define GPIO_PC22A_TC1_CLK1      _UL(1 << 22)
-#define PIN_PC08D_TC1_CLK2             _L(72) /**< \brief TC1 signal: CLK2 on PC08 mux D */
-#define MUX_PC08D_TC1_CLK2              _L(3)
+#define GPIO_PC22A_TC1_CLK1      _UL_(1 << 22)
+#define PIN_PC08D_TC1_CLK2             _L_(72) /**< \brief TC1 signal: CLK2 on PC08 mux D */
+#define MUX_PC08D_TC1_CLK2              _L_(3)
 #define PINMUX_PC08D_TC1_CLK2      ((PIN_PC08D_TC1_CLK2 << 16) | MUX_PC08D_TC1_CLK2)
-#define GPIO_PC08D_TC1_CLK2      _UL(1 <<  8)
-#define PIN_PC23A_TC1_CLK2             _L(87) /**< \brief TC1 signal: CLK2 on PC23 mux A */
-#define MUX_PC23A_TC1_CLK2              _L(0)
+#define GPIO_PC08D_TC1_CLK2      _UL_(1 <<  8)
+#define PIN_PC23A_TC1_CLK2             _L_(87) /**< \brief TC1 signal: CLK2 on PC23 mux A */
+#define MUX_PC23A_TC1_CLK2              _L_(0)
 #define PINMUX_PC23A_TC1_CLK2      ((PIN_PC23A_TC1_CLK2 << 16) | MUX_PC23A_TC1_CLK2)
-#define GPIO_PC23A_TC1_CLK2      _UL(1 << 23)
+#define GPIO_PC23A_TC1_CLK2      _UL_(1 << 23)
 /* ========== GPIO definition for USART0 peripheral ========== */
-#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
-#define MUX_PA04B_USART0_CLK            _L(1)
+#define PIN_PA04B_USART0_CLK            _L_(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L_(1)
 #define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
-#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
-#define PIN_PC00B_USART0_CLK           _L(64) /**< \brief USART0 signal: CLK on PC00 mux B */
-#define MUX_PC00B_USART0_CLK            _L(1)
+#define GPIO_PA04B_USART0_CLK    _UL_(1 <<  4)
+#define PIN_PC00B_USART0_CLK           _L_(64) /**< \brief USART0 signal: CLK on PC00 mux B */
+#define MUX_PC00B_USART0_CLK            _L_(1)
 #define PINMUX_PC00B_USART0_CLK    ((PIN_PC00B_USART0_CLK << 16) | MUX_PC00B_USART0_CLK)
-#define GPIO_PC00B_USART0_CLK    _UL(1 <<  0)
-#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
-#define MUX_PA10A_USART0_CLK            _L(0)
+#define GPIO_PC00B_USART0_CLK    _UL_(1 <<  0)
+#define PIN_PA10A_USART0_CLK           _L_(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L_(0)
 #define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
-#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
-#define PIN_PB13A_USART0_CLK           _L(45) /**< \brief USART0 signal: CLK on PB13 mux A */
-#define MUX_PB13A_USART0_CLK            _L(0)
+#define GPIO_PA10A_USART0_CLK    _UL_(1 << 10)
+#define PIN_PB13A_USART0_CLK           _L_(45) /**< \brief USART0 signal: CLK on PB13 mux A */
+#define MUX_PB13A_USART0_CLK            _L_(0)
 #define PINMUX_PB13A_USART0_CLK    ((PIN_PB13A_USART0_CLK << 16) | MUX_PB13A_USART0_CLK)
-#define GPIO_PB13A_USART0_CLK    _UL(1 << 13)
-#define PIN_PC02B_USART0_CTS           _L(66) /**< \brief USART0 signal: CTS on PC02 mux B */
-#define MUX_PC02B_USART0_CTS            _L(1)
+#define GPIO_PB13A_USART0_CLK    _UL_(1 << 13)
+#define PIN_PC02B_USART0_CTS           _L_(66) /**< \brief USART0 signal: CTS on PC02 mux B */
+#define MUX_PC02B_USART0_CTS            _L_(1)
 #define PINMUX_PC02B_USART0_CTS    ((PIN_PC02B_USART0_CTS << 16) | MUX_PC02B_USART0_CTS)
-#define GPIO_PC02B_USART0_CTS    _UL(1 <<  2)
-#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
-#define MUX_PA09A_USART0_CTS            _L(0)
+#define GPIO_PC02B_USART0_CTS    _UL_(1 <<  2)
+#define PIN_PA09A_USART0_CTS            _L_(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L_(0)
 #define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
-#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
-#define PIN_PB11A_USART0_CTS           _L(43) /**< \brief USART0 signal: CTS on PB11 mux A */
-#define MUX_PB11A_USART0_CTS            _L(0)
+#define GPIO_PA09A_USART0_CTS    _UL_(1 <<  9)
+#define PIN_PB11A_USART0_CTS           _L_(43) /**< \brief USART0 signal: CTS on PB11 mux A */
+#define MUX_PB11A_USART0_CTS            _L_(0)
 #define PINMUX_PB11A_USART0_CTS    ((PIN_PB11A_USART0_CTS << 16) | MUX_PB11A_USART0_CTS)
-#define GPIO_PB11A_USART0_CTS    _UL(1 << 11)
-#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
-#define MUX_PA06B_USART0_RTS            _L(1)
+#define GPIO_PB11A_USART0_CTS    _UL_(1 << 11)
+#define PIN_PA06B_USART0_RTS            _L_(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L_(1)
 #define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
-#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
-#define PIN_PC01B_USART0_RTS           _L(65) /**< \brief USART0 signal: RTS on PC01 mux B */
-#define MUX_PC01B_USART0_RTS            _L(1)
+#define GPIO_PA06B_USART0_RTS    _UL_(1 <<  6)
+#define PIN_PC01B_USART0_RTS           _L_(65) /**< \brief USART0 signal: RTS on PC01 mux B */
+#define MUX_PC01B_USART0_RTS            _L_(1)
 #define PINMUX_PC01B_USART0_RTS    ((PIN_PC01B_USART0_RTS << 16) | MUX_PC01B_USART0_RTS)
-#define GPIO_PC01B_USART0_RTS    _UL(1 <<  1)
-#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
-#define MUX_PA08A_USART0_RTS            _L(0)
+#define GPIO_PC01B_USART0_RTS    _UL_(1 <<  1)
+#define PIN_PA08A_USART0_RTS            _L_(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L_(0)
 #define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
-#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
-#define PIN_PB12A_USART0_RTS           _L(44) /**< \brief USART0 signal: RTS on PB12 mux A */
-#define MUX_PB12A_USART0_RTS            _L(0)
+#define GPIO_PA08A_USART0_RTS    _UL_(1 <<  8)
+#define PIN_PB12A_USART0_RTS           _L_(44) /**< \brief USART0 signal: RTS on PB12 mux A */
+#define MUX_PB12A_USART0_RTS            _L_(0)
 #define PINMUX_PB12A_USART0_RTS    ((PIN_PB12A_USART0_RTS << 16) | MUX_PB12A_USART0_RTS)
-#define GPIO_PB12A_USART0_RTS    _UL(1 << 12)
-#define PIN_PC02C_USART0_RXD           _L(66) /**< \brief USART0 signal: RXD on PC02 mux C */
-#define MUX_PC02C_USART0_RXD            _L(2)
+#define GPIO_PB12A_USART0_RTS    _UL_(1 << 12)
+#define PIN_PC02C_USART0_RXD           _L_(66) /**< \brief USART0 signal: RXD on PC02 mux C */
+#define MUX_PC02C_USART0_RXD            _L_(2)
 #define PINMUX_PC02C_USART0_RXD    ((PIN_PC02C_USART0_RXD << 16) | MUX_PC02C_USART0_RXD)
-#define GPIO_PC02C_USART0_RXD    _UL(1 <<  2)
-#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
-#define MUX_PA05B_USART0_RXD            _L(1)
+#define GPIO_PC02C_USART0_RXD    _UL_(1 <<  2)
+#define PIN_PA05B_USART0_RXD            _L_(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L_(1)
 #define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
-#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
-#define PIN_PB00B_USART0_RXD           _L(32) /**< \brief USART0 signal: RXD on PB00 mux B */
-#define MUX_PB00B_USART0_RXD            _L(1)
+#define GPIO_PA05B_USART0_RXD    _UL_(1 <<  5)
+#define PIN_PB00B_USART0_RXD           _L_(32) /**< \brief USART0 signal: RXD on PB00 mux B */
+#define MUX_PB00B_USART0_RXD            _L_(1)
 #define PINMUX_PB00B_USART0_RXD    ((PIN_PB00B_USART0_RXD << 16) | MUX_PB00B_USART0_RXD)
-#define GPIO_PB00B_USART0_RXD    _UL(1 <<  0)
-#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
-#define MUX_PA11A_USART0_RXD            _L(0)
+#define GPIO_PB00B_USART0_RXD    _UL_(1 <<  0)
+#define PIN_PA11A_USART0_RXD           _L_(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L_(0)
 #define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
-#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
-#define PIN_PB14A_USART0_RXD           _L(46) /**< \brief USART0 signal: RXD on PB14 mux A */
-#define MUX_PB14A_USART0_RXD            _L(0)
+#define GPIO_PA11A_USART0_RXD    _UL_(1 << 11)
+#define PIN_PB14A_USART0_RXD           _L_(46) /**< \brief USART0 signal: RXD on PB14 mux A */
+#define MUX_PB14A_USART0_RXD            _L_(0)
 #define PINMUX_PB14A_USART0_RXD    ((PIN_PB14A_USART0_RXD << 16) | MUX_PB14A_USART0_RXD)
-#define GPIO_PB14A_USART0_RXD    _UL(1 << 14)
-#define PIN_PC03C_USART0_TXD           _L(67) /**< \brief USART0 signal: TXD on PC03 mux C */
-#define MUX_PC03C_USART0_TXD            _L(2)
+#define GPIO_PB14A_USART0_RXD    _UL_(1 << 14)
+#define PIN_PC03C_USART0_TXD           _L_(67) /**< \brief USART0 signal: TXD on PC03 mux C */
+#define MUX_PC03C_USART0_TXD            _L_(2)
 #define PINMUX_PC03C_USART0_TXD    ((PIN_PC03C_USART0_TXD << 16) | MUX_PC03C_USART0_TXD)
-#define GPIO_PC03C_USART0_TXD    _UL(1 <<  3)
-#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
-#define MUX_PA07B_USART0_TXD            _L(1)
+#define GPIO_PC03C_USART0_TXD    _UL_(1 <<  3)
+#define PIN_PA07B_USART0_TXD            _L_(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L_(1)
 #define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
-#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
-#define PIN_PB01B_USART0_TXD           _L(33) /**< \brief USART0 signal: TXD on PB01 mux B */
-#define MUX_PB01B_USART0_TXD            _L(1)
+#define GPIO_PA07B_USART0_TXD    _UL_(1 <<  7)
+#define PIN_PB01B_USART0_TXD           _L_(33) /**< \brief USART0 signal: TXD on PB01 mux B */
+#define MUX_PB01B_USART0_TXD            _L_(1)
 #define PINMUX_PB01B_USART0_TXD    ((PIN_PB01B_USART0_TXD << 16) | MUX_PB01B_USART0_TXD)
-#define GPIO_PB01B_USART0_TXD    _UL(1 <<  1)
-#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
-#define MUX_PA12A_USART0_TXD            _L(0)
+#define GPIO_PB01B_USART0_TXD    _UL_(1 <<  1)
+#define PIN_PA12A_USART0_TXD           _L_(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L_(0)
 #define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
-#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
-#define PIN_PB15A_USART0_TXD           _L(47) /**< \brief USART0 signal: TXD on PB15 mux A */
-#define MUX_PB15A_USART0_TXD            _L(0)
+#define GPIO_PA12A_USART0_TXD    _UL_(1 << 12)
+#define PIN_PB15A_USART0_TXD           _L_(47) /**< \brief USART0 signal: TXD on PB15 mux A */
+#define MUX_PB15A_USART0_TXD            _L_(0)
 #define PINMUX_PB15A_USART0_TXD    ((PIN_PB15A_USART0_TXD << 16) | MUX_PB15A_USART0_TXD)
-#define GPIO_PB15A_USART0_TXD    _UL(1 << 15)
+#define GPIO_PB15A_USART0_TXD    _UL_(1 << 15)
 /* ========== GPIO definition for USART1 peripheral ========== */
-#define PIN_PB03B_USART1_CLK           _L(35) /**< \brief USART1 signal: CLK on PB03 mux B */
-#define MUX_PB03B_USART1_CLK            _L(1)
+#define PIN_PB03B_USART1_CLK           _L_(35) /**< \brief USART1 signal: CLK on PB03 mux B */
+#define MUX_PB03B_USART1_CLK            _L_(1)
 #define PINMUX_PB03B_USART1_CLK    ((PIN_PB03B_USART1_CLK << 16) | MUX_PB03B_USART1_CLK)
-#define GPIO_PB03B_USART1_CLK    _UL(1 <<  3)
-#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
-#define MUX_PA14A_USART1_CLK            _L(0)
+#define GPIO_PB03B_USART1_CLK    _UL_(1 <<  3)
+#define PIN_PA14A_USART1_CLK           _L_(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L_(0)
 #define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
-#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
-#define PIN_PC25A_USART1_CLK           _L(89) /**< \brief USART1 signal: CLK on PC25 mux A */
-#define MUX_PC25A_USART1_CLK            _L(0)
+#define GPIO_PA14A_USART1_CLK    _UL_(1 << 14)
+#define PIN_PC25A_USART1_CLK           _L_(89) /**< \brief USART1 signal: CLK on PC25 mux A */
+#define MUX_PC25A_USART1_CLK            _L_(0)
 #define PINMUX_PC25A_USART1_CLK    ((PIN_PC25A_USART1_CLK << 16) | MUX_PC25A_USART1_CLK)
-#define GPIO_PC25A_USART1_CLK    _UL(1 << 25)
-#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
-#define MUX_PA21B_USART1_CTS            _L(1)
+#define GPIO_PC25A_USART1_CLK    _UL_(1 << 25)
+#define PIN_PA21B_USART1_CTS           _L_(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L_(1)
 #define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
-#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
-#define PIN_PB02B_USART1_RTS           _L(34) /**< \brief USART1 signal: RTS on PB02 mux B */
-#define MUX_PB02B_USART1_RTS            _L(1)
+#define GPIO_PA21B_USART1_CTS    _UL_(1 << 21)
+#define PIN_PB02B_USART1_RTS           _L_(34) /**< \brief USART1 signal: RTS on PB02 mux B */
+#define MUX_PB02B_USART1_RTS            _L_(1)
 #define PINMUX_PB02B_USART1_RTS    ((PIN_PB02B_USART1_RTS << 16) | MUX_PB02B_USART1_RTS)
-#define GPIO_PB02B_USART1_RTS    _UL(1 <<  2)
-#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
-#define MUX_PA13A_USART1_RTS            _L(0)
+#define GPIO_PB02B_USART1_RTS    _UL_(1 <<  2)
+#define PIN_PA13A_USART1_RTS           _L_(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L_(0)
 #define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
-#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
-#define PIN_PC24A_USART1_RTS           _L(88) /**< \brief USART1 signal: RTS on PC24 mux A */
-#define MUX_PC24A_USART1_RTS            _L(0)
+#define GPIO_PA13A_USART1_RTS    _UL_(1 << 13)
+#define PIN_PC24A_USART1_RTS           _L_(88) /**< \brief USART1 signal: RTS on PC24 mux A */
+#define MUX_PC24A_USART1_RTS            _L_(0)
 #define PINMUX_PC24A_USART1_RTS    ((PIN_PC24A_USART1_RTS << 16) | MUX_PC24A_USART1_RTS)
-#define GPIO_PC24A_USART1_RTS    _UL(1 << 24)
-#define PIN_PB04B_USART1_RXD           _L(36) /**< \brief USART1 signal: RXD on PB04 mux B */
-#define MUX_PB04B_USART1_RXD            _L(1)
+#define GPIO_PC24A_USART1_RTS    _UL_(1 << 24)
+#define PIN_PB04B_USART1_RXD           _L_(36) /**< \brief USART1 signal: RXD on PB04 mux B */
+#define MUX_PB04B_USART1_RXD            _L_(1)
 #define PINMUX_PB04B_USART1_RXD    ((PIN_PB04B_USART1_RXD << 16) | MUX_PB04B_USART1_RXD)
-#define GPIO_PB04B_USART1_RXD    _UL(1 <<  4)
-#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
-#define MUX_PA15A_USART1_RXD            _L(0)
+#define GPIO_PB04B_USART1_RXD    _UL_(1 <<  4)
+#define PIN_PA15A_USART1_RXD           _L_(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L_(0)
 #define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
-#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
-#define PIN_PC26A_USART1_RXD           _L(90) /**< \brief USART1 signal: RXD on PC26 mux A */
-#define MUX_PC26A_USART1_RXD            _L(0)
+#define GPIO_PA15A_USART1_RXD    _UL_(1 << 15)
+#define PIN_PC26A_USART1_RXD           _L_(90) /**< \brief USART1 signal: RXD on PC26 mux A */
+#define MUX_PC26A_USART1_RXD            _L_(0)
 #define PINMUX_PC26A_USART1_RXD    ((PIN_PC26A_USART1_RXD << 16) | MUX_PC26A_USART1_RXD)
-#define GPIO_PC26A_USART1_RXD    _UL(1 << 26)
-#define PIN_PB05B_USART1_TXD           _L(37) /**< \brief USART1 signal: TXD on PB05 mux B */
-#define MUX_PB05B_USART1_TXD            _L(1)
+#define GPIO_PC26A_USART1_RXD    _UL_(1 << 26)
+#define PIN_PB05B_USART1_TXD           _L_(37) /**< \brief USART1 signal: TXD on PB05 mux B */
+#define MUX_PB05B_USART1_TXD            _L_(1)
 #define PINMUX_PB05B_USART1_TXD    ((PIN_PB05B_USART1_TXD << 16) | MUX_PB05B_USART1_TXD)
-#define GPIO_PB05B_USART1_TXD    _UL(1 <<  5)
-#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
-#define MUX_PA16A_USART1_TXD            _L(0)
+#define GPIO_PB05B_USART1_TXD    _UL_(1 <<  5)
+#define PIN_PA16A_USART1_TXD           _L_(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L_(0)
 #define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
-#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
-#define PIN_PC27A_USART1_TXD           _L(91) /**< \brief USART1 signal: TXD on PC27 mux A */
-#define MUX_PC27A_USART1_TXD            _L(0)
+#define GPIO_PA16A_USART1_TXD    _UL_(1 << 16)
+#define PIN_PC27A_USART1_TXD           _L_(91) /**< \brief USART1 signal: TXD on PC27 mux A */
+#define MUX_PC27A_USART1_TXD            _L_(0)
 #define PINMUX_PC27A_USART1_TXD    ((PIN_PC27A_USART1_TXD << 16) | MUX_PC27A_USART1_TXD)
-#define GPIO_PC27A_USART1_TXD    _UL(1 << 27)
+#define GPIO_PC27A_USART1_TXD    _UL_(1 << 27)
 /* ========== GPIO definition for USART2 peripheral ========== */
-#define PIN_PC08B_USART2_CLK           _L(72) /**< \brief USART2 signal: CLK on PC08 mux B */
-#define MUX_PC08B_USART2_CLK            _L(1)
+#define PIN_PC08B_USART2_CLK           _L_(72) /**< \brief USART2 signal: CLK on PC08 mux B */
+#define MUX_PC08B_USART2_CLK            _L_(1)
 #define PINMUX_PC08B_USART2_CLK    ((PIN_PC08B_USART2_CLK << 16) | MUX_PC08B_USART2_CLK)
-#define GPIO_PC08B_USART2_CLK    _UL(1 <<  8)
-#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
-#define MUX_PA18A_USART2_CLK            _L(0)
+#define GPIO_PC08B_USART2_CLK    _UL_(1 <<  8)
+#define PIN_PA18A_USART2_CLK           _L_(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L_(0)
 #define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
-#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
-#define PIN_PC08E_USART2_CTS           _L(72) /**< \brief USART2 signal: CTS on PC08 mux E */
-#define MUX_PC08E_USART2_CTS            _L(4)
+#define GPIO_PA18A_USART2_CLK    _UL_(1 << 18)
+#define PIN_PC08E_USART2_CTS           _L_(72) /**< \brief USART2 signal: CTS on PC08 mux E */
+#define MUX_PC08E_USART2_CTS            _L_(4)
 #define PINMUX_PC08E_USART2_CTS    ((PIN_PC08E_USART2_CTS << 16) | MUX_PC08E_USART2_CTS)
-#define GPIO_PC08E_USART2_CTS    _UL(1 <<  8)
-#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
-#define MUX_PA22B_USART2_CTS            _L(1)
+#define GPIO_PC08E_USART2_CTS    _UL_(1 <<  8)
+#define PIN_PA22B_USART2_CTS           _L_(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L_(1)
 #define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
-#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
-#define PIN_PC07B_USART2_RTS           _L(71) /**< \brief USART2 signal: RTS on PC07 mux B */
-#define MUX_PC07B_USART2_RTS            _L(1)
+#define GPIO_PA22B_USART2_CTS    _UL_(1 << 22)
+#define PIN_PC07B_USART2_RTS           _L_(71) /**< \brief USART2 signal: RTS on PC07 mux B */
+#define MUX_PC07B_USART2_RTS            _L_(1)
 #define PINMUX_PC07B_USART2_RTS    ((PIN_PC07B_USART2_RTS << 16) | MUX_PC07B_USART2_RTS)
-#define GPIO_PC07B_USART2_RTS    _UL(1 <<  7)
-#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
-#define MUX_PA17A_USART2_RTS            _L(0)
+#define GPIO_PC07B_USART2_RTS    _UL_(1 <<  7)
+#define PIN_PA17A_USART2_RTS           _L_(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L_(0)
 #define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
-#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
-#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
-#define MUX_PA25B_USART2_RXD            _L(1)
+#define GPIO_PA17A_USART2_RTS    _UL_(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L_(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L_(1)
 #define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
-#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
-#define PIN_PC11B_USART2_RXD           _L(75) /**< \brief USART2 signal: RXD on PC11 mux B */
-#define MUX_PC11B_USART2_RXD            _L(1)
+#define GPIO_PA25B_USART2_RXD    _UL_(1 << 25)
+#define PIN_PC11B_USART2_RXD           _L_(75) /**< \brief USART2 signal: RXD on PC11 mux B */
+#define MUX_PC11B_USART2_RXD            _L_(1)
 #define PINMUX_PC11B_USART2_RXD    ((PIN_PC11B_USART2_RXD << 16) | MUX_PC11B_USART2_RXD)
-#define GPIO_PC11B_USART2_RXD    _UL(1 << 11)
-#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
-#define MUX_PA19A_USART2_RXD            _L(0)
+#define GPIO_PC11B_USART2_RXD    _UL_(1 << 11)
+#define PIN_PA19A_USART2_RXD           _L_(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L_(0)
 #define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
-#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
-#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
-#define MUX_PA26B_USART2_TXD            _L(1)
+#define GPIO_PA19A_USART2_RXD    _UL_(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L_(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L_(1)
 #define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
-#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
-#define PIN_PC12B_USART2_TXD           _L(76) /**< \brief USART2 signal: TXD on PC12 mux B */
-#define MUX_PC12B_USART2_TXD            _L(1)
+#define GPIO_PA26B_USART2_TXD    _UL_(1 << 26)
+#define PIN_PC12B_USART2_TXD           _L_(76) /**< \brief USART2 signal: TXD on PC12 mux B */
+#define MUX_PC12B_USART2_TXD            _L_(1)
 #define PINMUX_PC12B_USART2_TXD    ((PIN_PC12B_USART2_TXD << 16) | MUX_PC12B_USART2_TXD)
-#define GPIO_PC12B_USART2_TXD    _UL(1 << 12)
-#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
-#define MUX_PA20A_USART2_TXD            _L(0)
+#define GPIO_PC12B_USART2_TXD    _UL_(1 << 12)
+#define PIN_PA20A_USART2_TXD           _L_(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L_(0)
 #define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
-#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+#define GPIO_PA20A_USART2_TXD    _UL_(1 << 20)
 /* ========== GPIO definition for USART3 peripheral ========== */
-#define PIN_PA29E_USART3_CLK           _L(29) /**< \brief USART3 signal: CLK on PA29 mux E */
-#define MUX_PA29E_USART3_CLK            _L(4)
+#define PIN_PA29E_USART3_CLK           _L_(29) /**< \brief USART3 signal: CLK on PA29 mux E */
+#define MUX_PA29E_USART3_CLK            _L_(4)
 #define PINMUX_PA29E_USART3_CLK    ((PIN_PA29E_USART3_CLK << 16) | MUX_PA29E_USART3_CLK)
-#define GPIO_PA29E_USART3_CLK    _UL(1 << 29)
-#define PIN_PC14B_USART3_CLK           _L(78) /**< \brief USART3 signal: CLK on PC14 mux B */
-#define MUX_PC14B_USART3_CLK            _L(1)
+#define GPIO_PA29E_USART3_CLK    _UL_(1 << 29)
+#define PIN_PC14B_USART3_CLK           _L_(78) /**< \brief USART3 signal: CLK on PC14 mux B */
+#define MUX_PC14B_USART3_CLK            _L_(1)
 #define PINMUX_PC14B_USART3_CLK    ((PIN_PC14B_USART3_CLK << 16) | MUX_PC14B_USART3_CLK)
-#define GPIO_PC14B_USART3_CLK    _UL(1 << 14)
-#define PIN_PB08A_USART3_CLK           _L(40) /**< \brief USART3 signal: CLK on PB08 mux A */
-#define MUX_PB08A_USART3_CLK            _L(0)
+#define GPIO_PC14B_USART3_CLK    _UL_(1 << 14)
+#define PIN_PB08A_USART3_CLK           _L_(40) /**< \brief USART3 signal: CLK on PB08 mux A */
+#define MUX_PB08A_USART3_CLK            _L_(0)
 #define PINMUX_PB08A_USART3_CLK    ((PIN_PB08A_USART3_CLK << 16) | MUX_PB08A_USART3_CLK)
-#define GPIO_PB08A_USART3_CLK    _UL(1 <<  8)
-#define PIN_PC31A_USART3_CLK           _L(95) /**< \brief USART3 signal: CLK on PC31 mux A */
-#define MUX_PC31A_USART3_CLK            _L(0)
+#define GPIO_PB08A_USART3_CLK    _UL_(1 <<  8)
+#define PIN_PC31A_USART3_CLK           _L_(95) /**< \brief USART3 signal: CLK on PC31 mux A */
+#define MUX_PC31A_USART3_CLK            _L_(0)
 #define PINMUX_PC31A_USART3_CLK    ((PIN_PC31A_USART3_CLK << 16) | MUX_PC31A_USART3_CLK)
-#define GPIO_PC31A_USART3_CLK    _UL(1 << 31)
-#define PIN_PA28E_USART3_CTS           _L(28) /**< \brief USART3 signal: CTS on PA28 mux E */
-#define MUX_PA28E_USART3_CTS            _L(4)
+#define GPIO_PC31A_USART3_CLK    _UL_(1 << 31)
+#define PIN_PA28E_USART3_CTS           _L_(28) /**< \brief USART3 signal: CTS on PA28 mux E */
+#define MUX_PA28E_USART3_CTS            _L_(4)
 #define PINMUX_PA28E_USART3_CTS    ((PIN_PA28E_USART3_CTS << 16) | MUX_PA28E_USART3_CTS)
-#define GPIO_PA28E_USART3_CTS    _UL(1 << 28)
-#define PIN_PB07A_USART3_CTS           _L(39) /**< \brief USART3 signal: CTS on PB07 mux A */
-#define MUX_PB07A_USART3_CTS            _L(0)
+#define GPIO_PA28E_USART3_CTS    _UL_(1 << 28)
+#define PIN_PB07A_USART3_CTS           _L_(39) /**< \brief USART3 signal: CTS on PB07 mux A */
+#define MUX_PB07A_USART3_CTS            _L_(0)
 #define PINMUX_PB07A_USART3_CTS    ((PIN_PB07A_USART3_CTS << 16) | MUX_PB07A_USART3_CTS)
-#define GPIO_PB07A_USART3_CTS    _UL(1 <<  7)
-#define PIN_PA27E_USART3_RTS           _L(27) /**< \brief USART3 signal: RTS on PA27 mux E */
-#define MUX_PA27E_USART3_RTS            _L(4)
+#define GPIO_PB07A_USART3_CTS    _UL_(1 <<  7)
+#define PIN_PA27E_USART3_RTS           _L_(27) /**< \brief USART3 signal: RTS on PA27 mux E */
+#define MUX_PA27E_USART3_RTS            _L_(4)
 #define PINMUX_PA27E_USART3_RTS    ((PIN_PA27E_USART3_RTS << 16) | MUX_PA27E_USART3_RTS)
-#define GPIO_PA27E_USART3_RTS    _UL(1 << 27)
-#define PIN_PC13B_USART3_RTS           _L(77) /**< \brief USART3 signal: RTS on PC13 mux B */
-#define MUX_PC13B_USART3_RTS            _L(1)
+#define GPIO_PA27E_USART3_RTS    _UL_(1 << 27)
+#define PIN_PC13B_USART3_RTS           _L_(77) /**< \brief USART3 signal: RTS on PC13 mux B */
+#define MUX_PC13B_USART3_RTS            _L_(1)
 #define PINMUX_PC13B_USART3_RTS    ((PIN_PC13B_USART3_RTS << 16) | MUX_PC13B_USART3_RTS)
-#define GPIO_PC13B_USART3_RTS    _UL(1 << 13)
-#define PIN_PB06A_USART3_RTS           _L(38) /**< \brief USART3 signal: RTS on PB06 mux A */
-#define MUX_PB06A_USART3_RTS            _L(0)
+#define GPIO_PC13B_USART3_RTS    _UL_(1 << 13)
+#define PIN_PB06A_USART3_RTS           _L_(38) /**< \brief USART3 signal: RTS on PB06 mux A */
+#define MUX_PB06A_USART3_RTS            _L_(0)
 #define PINMUX_PB06A_USART3_RTS    ((PIN_PB06A_USART3_RTS << 16) | MUX_PB06A_USART3_RTS)
-#define GPIO_PB06A_USART3_RTS    _UL(1 <<  6)
-#define PIN_PC30A_USART3_RTS           _L(94) /**< \brief USART3 signal: RTS on PC30 mux A */
-#define MUX_PC30A_USART3_RTS            _L(0)
+#define GPIO_PB06A_USART3_RTS    _UL_(1 <<  6)
+#define PIN_PC30A_USART3_RTS           _L_(94) /**< \brief USART3 signal: RTS on PC30 mux A */
+#define MUX_PC30A_USART3_RTS            _L_(0)
 #define PINMUX_PC30A_USART3_RTS    ((PIN_PC30A_USART3_RTS << 16) | MUX_PC30A_USART3_RTS)
-#define GPIO_PC30A_USART3_RTS    _UL(1 << 30)
-#define PIN_PA30E_USART3_RXD           _L(30) /**< \brief USART3 signal: RXD on PA30 mux E */
-#define MUX_PA30E_USART3_RXD            _L(4)
+#define GPIO_PC30A_USART3_RTS    _UL_(1 << 30)
+#define PIN_PA30E_USART3_RXD           _L_(30) /**< \brief USART3 signal: RXD on PA30 mux E */
+#define MUX_PA30E_USART3_RXD            _L_(4)
 #define PINMUX_PA30E_USART3_RXD    ((PIN_PA30E_USART3_RXD << 16) | MUX_PA30E_USART3_RXD)
-#define GPIO_PA30E_USART3_RXD    _UL(1 << 30)
-#define PIN_PC09B_USART3_RXD           _L(73) /**< \brief USART3 signal: RXD on PC09 mux B */
-#define MUX_PC09B_USART3_RXD            _L(1)
+#define GPIO_PA30E_USART3_RXD    _UL_(1 << 30)
+#define PIN_PC09B_USART3_RXD           _L_(73) /**< \brief USART3 signal: RXD on PC09 mux B */
+#define MUX_PC09B_USART3_RXD            _L_(1)
 #define PINMUX_PC09B_USART3_RXD    ((PIN_PC09B_USART3_RXD << 16) | MUX_PC09B_USART3_RXD)
-#define GPIO_PC09B_USART3_RXD    _UL(1 <<  9)
-#define PIN_PB09A_USART3_RXD           _L(41) /**< \brief USART3 signal: RXD on PB09 mux A */
-#define MUX_PB09A_USART3_RXD            _L(0)
+#define GPIO_PC09B_USART3_RXD    _UL_(1 <<  9)
+#define PIN_PB09A_USART3_RXD           _L_(41) /**< \brief USART3 signal: RXD on PB09 mux A */
+#define MUX_PB09A_USART3_RXD            _L_(0)
 #define PINMUX_PB09A_USART3_RXD    ((PIN_PB09A_USART3_RXD << 16) | MUX_PB09A_USART3_RXD)
-#define GPIO_PB09A_USART3_RXD    _UL(1 <<  9)
-#define PIN_PC28A_USART3_RXD           _L(92) /**< \brief USART3 signal: RXD on PC28 mux A */
-#define MUX_PC28A_USART3_RXD            _L(0)
+#define GPIO_PB09A_USART3_RXD    _UL_(1 <<  9)
+#define PIN_PC28A_USART3_RXD           _L_(92) /**< \brief USART3 signal: RXD on PC28 mux A */
+#define MUX_PC28A_USART3_RXD            _L_(0)
 #define PINMUX_PC28A_USART3_RXD    ((PIN_PC28A_USART3_RXD << 16) | MUX_PC28A_USART3_RXD)
-#define GPIO_PC28A_USART3_RXD    _UL(1 << 28)
-#define PIN_PA31E_USART3_TXD           _L(31) /**< \brief USART3 signal: TXD on PA31 mux E */
-#define MUX_PA31E_USART3_TXD            _L(4)
+#define GPIO_PC28A_USART3_RXD    _UL_(1 << 28)
+#define PIN_PA31E_USART3_TXD           _L_(31) /**< \brief USART3 signal: TXD on PA31 mux E */
+#define MUX_PA31E_USART3_TXD            _L_(4)
 #define PINMUX_PA31E_USART3_TXD    ((PIN_PA31E_USART3_TXD << 16) | MUX_PA31E_USART3_TXD)
-#define GPIO_PA31E_USART3_TXD    _UL(1 << 31)
-#define PIN_PC10B_USART3_TXD           _L(74) /**< \brief USART3 signal: TXD on PC10 mux B */
-#define MUX_PC10B_USART3_TXD            _L(1)
+#define GPIO_PA31E_USART3_TXD    _UL_(1 << 31)
+#define PIN_PC10B_USART3_TXD           _L_(74) /**< \brief USART3 signal: TXD on PC10 mux B */
+#define MUX_PC10B_USART3_TXD            _L_(1)
 #define PINMUX_PC10B_USART3_TXD    ((PIN_PC10B_USART3_TXD << 16) | MUX_PC10B_USART3_TXD)
-#define GPIO_PC10B_USART3_TXD    _UL(1 << 10)
-#define PIN_PB10A_USART3_TXD           _L(42) /**< \brief USART3 signal: TXD on PB10 mux A */
-#define MUX_PB10A_USART3_TXD            _L(0)
+#define GPIO_PC10B_USART3_TXD    _UL_(1 << 10)
+#define PIN_PB10A_USART3_TXD           _L_(42) /**< \brief USART3 signal: TXD on PB10 mux A */
+#define MUX_PB10A_USART3_TXD            _L_(0)
 #define PINMUX_PB10A_USART3_TXD    ((PIN_PB10A_USART3_TXD << 16) | MUX_PB10A_USART3_TXD)
-#define GPIO_PB10A_USART3_TXD    _UL(1 << 10)
-#define PIN_PC29A_USART3_TXD           _L(93) /**< \brief USART3 signal: TXD on PC29 mux A */
-#define MUX_PC29A_USART3_TXD            _L(0)
+#define GPIO_PB10A_USART3_TXD    _UL_(1 << 10)
+#define PIN_PC29A_USART3_TXD           _L_(93) /**< \brief USART3 signal: TXD on PC29 mux A */
+#define MUX_PC29A_USART3_TXD            _L_(0)
 #define PINMUX_PC29A_USART3_TXD    ((PIN_PC29A_USART3_TXD << 16) | MUX_PC29A_USART3_TXD)
-#define GPIO_PC29A_USART3_TXD    _UL(1 << 29)
+#define GPIO_PC29A_USART3_TXD    _UL_(1 << 29)
 /* ========== GPIO definition for ADCIFE peripheral ========== */
-#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
-#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PIN_PA04A_ADCIFE_AD0            _L_(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L_(0)
 #define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
-#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
-#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
-#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL_(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L_(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L_(0)
 #define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
-#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
-#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
-#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define GPIO_PA05A_ADCIFE_AD1    _UL_(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L_(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L_(0)
 #define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
-#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
-#define PIN_PB02A_ADCIFE_AD3           _L(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
-#define MUX_PB02A_ADCIFE_AD3            _L(0)
+#define GPIO_PA07A_ADCIFE_AD2    _UL_(1 <<  7)
+#define PIN_PB02A_ADCIFE_AD3           _L_(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
+#define MUX_PB02A_ADCIFE_AD3            _L_(0)
 #define PINMUX_PB02A_ADCIFE_AD3    ((PIN_PB02A_ADCIFE_AD3 << 16) | MUX_PB02A_ADCIFE_AD3)
-#define GPIO_PB02A_ADCIFE_AD3    _UL(1 <<  2)
-#define PIN_PB03A_ADCIFE_AD4           _L(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
-#define MUX_PB03A_ADCIFE_AD4            _L(0)
+#define GPIO_PB02A_ADCIFE_AD3    _UL_(1 <<  2)
+#define PIN_PB03A_ADCIFE_AD4           _L_(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
+#define MUX_PB03A_ADCIFE_AD4            _L_(0)
 #define PINMUX_PB03A_ADCIFE_AD4    ((PIN_PB03A_ADCIFE_AD4 << 16) | MUX_PB03A_ADCIFE_AD4)
-#define GPIO_PB03A_ADCIFE_AD4    _UL(1 <<  3)
-#define PIN_PB04A_ADCIFE_AD5           _L(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
-#define MUX_PB04A_ADCIFE_AD5            _L(0)
+#define GPIO_PB03A_ADCIFE_AD4    _UL_(1 <<  3)
+#define PIN_PB04A_ADCIFE_AD5           _L_(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
+#define MUX_PB04A_ADCIFE_AD5            _L_(0)
 #define PINMUX_PB04A_ADCIFE_AD5    ((PIN_PB04A_ADCIFE_AD5 << 16) | MUX_PB04A_ADCIFE_AD5)
-#define GPIO_PB04A_ADCIFE_AD5    _UL(1 <<  4)
-#define PIN_PB05A_ADCIFE_AD6           _L(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
-#define MUX_PB05A_ADCIFE_AD6            _L(0)
+#define GPIO_PB04A_ADCIFE_AD5    _UL_(1 <<  4)
+#define PIN_PB05A_ADCIFE_AD6           _L_(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
+#define MUX_PB05A_ADCIFE_AD6            _L_(0)
 #define PINMUX_PB05A_ADCIFE_AD6    ((PIN_PB05A_ADCIFE_AD6 << 16) | MUX_PB05A_ADCIFE_AD6)
-#define GPIO_PB05A_ADCIFE_AD6    _UL(1 <<  5)
-#define PIN_PC07A_ADCIFE_AD7           _L(71) /**< \brief ADCIFE signal: AD7 on PC07 mux A */
-#define MUX_PC07A_ADCIFE_AD7            _L(0)
+#define GPIO_PB05A_ADCIFE_AD6    _UL_(1 <<  5)
+#define PIN_PC07A_ADCIFE_AD7           _L_(71) /**< \brief ADCIFE signal: AD7 on PC07 mux A */
+#define MUX_PC07A_ADCIFE_AD7            _L_(0)
 #define PINMUX_PC07A_ADCIFE_AD7    ((PIN_PC07A_ADCIFE_AD7 << 16) | MUX_PC07A_ADCIFE_AD7)
-#define GPIO_PC07A_ADCIFE_AD7    _UL(1 <<  7)
-#define PIN_PC08A_ADCIFE_AD8           _L(72) /**< \brief ADCIFE signal: AD8 on PC08 mux A */
-#define MUX_PC08A_ADCIFE_AD8            _L(0)
+#define GPIO_PC07A_ADCIFE_AD7    _UL_(1 <<  7)
+#define PIN_PC08A_ADCIFE_AD8           _L_(72) /**< \brief ADCIFE signal: AD8 on PC08 mux A */
+#define MUX_PC08A_ADCIFE_AD8            _L_(0)
 #define PINMUX_PC08A_ADCIFE_AD8    ((PIN_PC08A_ADCIFE_AD8 << 16) | MUX_PC08A_ADCIFE_AD8)
-#define GPIO_PC08A_ADCIFE_AD8    _UL(1 <<  8)
-#define PIN_PC09A_ADCIFE_AD9           _L(73) /**< \brief ADCIFE signal: AD9 on PC09 mux A */
-#define MUX_PC09A_ADCIFE_AD9            _L(0)
+#define GPIO_PC08A_ADCIFE_AD8    _UL_(1 <<  8)
+#define PIN_PC09A_ADCIFE_AD9           _L_(73) /**< \brief ADCIFE signal: AD9 on PC09 mux A */
+#define MUX_PC09A_ADCIFE_AD9            _L_(0)
 #define PINMUX_PC09A_ADCIFE_AD9    ((PIN_PC09A_ADCIFE_AD9 << 16) | MUX_PC09A_ADCIFE_AD9)
-#define GPIO_PC09A_ADCIFE_AD9    _UL(1 <<  9)
-#define PIN_PC10A_ADCIFE_AD10          _L(74) /**< \brief ADCIFE signal: AD10 on PC10 mux A */
-#define MUX_PC10A_ADCIFE_AD10           _L(0)
+#define GPIO_PC09A_ADCIFE_AD9    _UL_(1 <<  9)
+#define PIN_PC10A_ADCIFE_AD10          _L_(74) /**< \brief ADCIFE signal: AD10 on PC10 mux A */
+#define MUX_PC10A_ADCIFE_AD10           _L_(0)
 #define PINMUX_PC10A_ADCIFE_AD10   ((PIN_PC10A_ADCIFE_AD10 << 16) | MUX_PC10A_ADCIFE_AD10)
-#define GPIO_PC10A_ADCIFE_AD10   _UL(1 << 10)
-#define PIN_PC11A_ADCIFE_AD11          _L(75) /**< \brief ADCIFE signal: AD11 on PC11 mux A */
-#define MUX_PC11A_ADCIFE_AD11           _L(0)
+#define GPIO_PC10A_ADCIFE_AD10   _UL_(1 << 10)
+#define PIN_PC11A_ADCIFE_AD11          _L_(75) /**< \brief ADCIFE signal: AD11 on PC11 mux A */
+#define MUX_PC11A_ADCIFE_AD11           _L_(0)
 #define PINMUX_PC11A_ADCIFE_AD11   ((PIN_PC11A_ADCIFE_AD11 << 16) | MUX_PC11A_ADCIFE_AD11)
-#define GPIO_PC11A_ADCIFE_AD11   _UL(1 << 11)
-#define PIN_PC12A_ADCIFE_AD12          _L(76) /**< \brief ADCIFE signal: AD12 on PC12 mux A */
-#define MUX_PC12A_ADCIFE_AD12           _L(0)
+#define GPIO_PC11A_ADCIFE_AD11   _UL_(1 << 11)
+#define PIN_PC12A_ADCIFE_AD12          _L_(76) /**< \brief ADCIFE signal: AD12 on PC12 mux A */
+#define MUX_PC12A_ADCIFE_AD12           _L_(0)
 #define PINMUX_PC12A_ADCIFE_AD12   ((PIN_PC12A_ADCIFE_AD12 << 16) | MUX_PC12A_ADCIFE_AD12)
-#define GPIO_PC12A_ADCIFE_AD12   _UL(1 << 12)
-#define PIN_PC13A_ADCIFE_AD13          _L(77) /**< \brief ADCIFE signal: AD13 on PC13 mux A */
-#define MUX_PC13A_ADCIFE_AD13           _L(0)
+#define GPIO_PC12A_ADCIFE_AD12   _UL_(1 << 12)
+#define PIN_PC13A_ADCIFE_AD13          _L_(77) /**< \brief ADCIFE signal: AD13 on PC13 mux A */
+#define MUX_PC13A_ADCIFE_AD13           _L_(0)
 #define PINMUX_PC13A_ADCIFE_AD13   ((PIN_PC13A_ADCIFE_AD13 << 16) | MUX_PC13A_ADCIFE_AD13)
-#define GPIO_PC13A_ADCIFE_AD13   _UL(1 << 13)
-#define PIN_PC14A_ADCIFE_AD14          _L(78) /**< \brief ADCIFE signal: AD14 on PC14 mux A */
-#define MUX_PC14A_ADCIFE_AD14           _L(0)
+#define GPIO_PC13A_ADCIFE_AD13   _UL_(1 << 13)
+#define PIN_PC14A_ADCIFE_AD14          _L_(78) /**< \brief ADCIFE signal: AD14 on PC14 mux A */
+#define MUX_PC14A_ADCIFE_AD14           _L_(0)
 #define PINMUX_PC14A_ADCIFE_AD14   ((PIN_PC14A_ADCIFE_AD14 << 16) | MUX_PC14A_ADCIFE_AD14)
-#define GPIO_PC14A_ADCIFE_AD14   _UL(1 << 14)
-#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
-#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define GPIO_PC14A_ADCIFE_AD14   _UL_(1 << 14)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L_(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L_(4)
 #define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
-#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL_(1 <<  5)
 /* ========== GPIO definition for DACC peripheral ========== */
-#define PIN_PB04E_DACC_EXT_TRIG0       _L(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
-#define MUX_PB04E_DACC_EXT_TRIG0        _L(4)
+#define PIN_PB04E_DACC_EXT_TRIG0       _L_(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
+#define MUX_PB04E_DACC_EXT_TRIG0        _L_(4)
 #define PINMUX_PB04E_DACC_EXT_TRIG0  ((PIN_PB04E_DACC_EXT_TRIG0 << 16) | MUX_PB04E_DACC_EXT_TRIG0)
-#define GPIO_PB04E_DACC_EXT_TRIG0  _UL(1 <<  4)
-#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
-#define MUX_PA06A_DACC_VOUT             _L(0)
+#define GPIO_PB04E_DACC_EXT_TRIG0  _UL_(1 <<  4)
+#define PIN_PA06A_DACC_VOUT             _L_(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L_(0)
 #define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
-#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+#define GPIO_PA06A_DACC_VOUT     _UL_(1 <<  6)
 /* ========== GPIO definition for ACIFC peripheral ========== */
-#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
-#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PIN_PA06E_ACIFC_ACAN0           _L_(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L_(4)
 #define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
-#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
-#define PIN_PC09E_ACIFC_ACAN1          _L(73) /**< \brief ACIFC signal: ACAN1 on PC09 mux E */
-#define MUX_PC09E_ACIFC_ACAN1           _L(4)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL_(1 <<  6)
+#define PIN_PC09E_ACIFC_ACAN1          _L_(73) /**< \brief ACIFC signal: ACAN1 on PC09 mux E */
+#define MUX_PC09E_ACIFC_ACAN1           _L_(4)
 #define PINMUX_PC09E_ACIFC_ACAN1   ((PIN_PC09E_ACIFC_ACAN1 << 16) | MUX_PC09E_ACIFC_ACAN1)
-#define GPIO_PC09E_ACIFC_ACAN1   _UL(1 <<  9)
-#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
-#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define GPIO_PC09E_ACIFC_ACAN1   _UL_(1 <<  9)
+#define PIN_PA07E_ACIFC_ACAP0           _L_(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L_(4)
 #define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
-#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
-#define PIN_PC10E_ACIFC_ACAP1          _L(74) /**< \brief ACIFC signal: ACAP1 on PC10 mux E */
-#define MUX_PC10E_ACIFC_ACAP1           _L(4)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL_(1 <<  7)
+#define PIN_PC10E_ACIFC_ACAP1          _L_(74) /**< \brief ACIFC signal: ACAP1 on PC10 mux E */
+#define MUX_PC10E_ACIFC_ACAP1           _L_(4)
 #define PINMUX_PC10E_ACIFC_ACAP1   ((PIN_PC10E_ACIFC_ACAP1 << 16) | MUX_PC10E_ACIFC_ACAP1)
-#define GPIO_PC10E_ACIFC_ACAP1   _UL(1 << 10)
-#define PIN_PB02E_ACIFC_ACBN0          _L(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
-#define MUX_PB02E_ACIFC_ACBN0           _L(4)
+#define GPIO_PC10E_ACIFC_ACAP1   _UL_(1 << 10)
+#define PIN_PB02E_ACIFC_ACBN0          _L_(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
+#define MUX_PB02E_ACIFC_ACBN0           _L_(4)
 #define PINMUX_PB02E_ACIFC_ACBN0   ((PIN_PB02E_ACIFC_ACBN0 << 16) | MUX_PB02E_ACIFC_ACBN0)
-#define GPIO_PB02E_ACIFC_ACBN0   _UL(1 <<  2)
-#define PIN_PC13E_ACIFC_ACBN1          _L(77) /**< \brief ACIFC signal: ACBN1 on PC13 mux E */
-#define MUX_PC13E_ACIFC_ACBN1           _L(4)
+#define GPIO_PB02E_ACIFC_ACBN0   _UL_(1 <<  2)
+#define PIN_PC13E_ACIFC_ACBN1          _L_(77) /**< \brief ACIFC signal: ACBN1 on PC13 mux E */
+#define MUX_PC13E_ACIFC_ACBN1           _L_(4)
 #define PINMUX_PC13E_ACIFC_ACBN1   ((PIN_PC13E_ACIFC_ACBN1 << 16) | MUX_PC13E_ACIFC_ACBN1)
-#define GPIO_PC13E_ACIFC_ACBN1   _UL(1 << 13)
-#define PIN_PB03E_ACIFC_ACBP0          _L(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
-#define MUX_PB03E_ACIFC_ACBP0           _L(4)
+#define GPIO_PC13E_ACIFC_ACBN1   _UL_(1 << 13)
+#define PIN_PB03E_ACIFC_ACBP0          _L_(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
+#define MUX_PB03E_ACIFC_ACBP0           _L_(4)
 #define PINMUX_PB03E_ACIFC_ACBP0   ((PIN_PB03E_ACIFC_ACBP0 << 16) | MUX_PB03E_ACIFC_ACBP0)
-#define GPIO_PB03E_ACIFC_ACBP0   _UL(1 <<  3)
-#define PIN_PC14E_ACIFC_ACBP1          _L(78) /**< \brief ACIFC signal: ACBP1 on PC14 mux E */
-#define MUX_PC14E_ACIFC_ACBP1           _L(4)
+#define GPIO_PB03E_ACIFC_ACBP0   _UL_(1 <<  3)
+#define PIN_PC14E_ACIFC_ACBP1          _L_(78) /**< \brief ACIFC signal: ACBP1 on PC14 mux E */
+#define MUX_PC14E_ACIFC_ACBP1           _L_(4)
 #define PINMUX_PC14E_ACIFC_ACBP1   ((PIN_PC14E_ACIFC_ACBP1 << 16) | MUX_PC14E_ACIFC_ACBP1)
-#define GPIO_PC14E_ACIFC_ACBP1   _UL(1 << 14)
+#define GPIO_PC14E_ACIFC_ACBP1   _UL_(1 << 14)
 /* ========== GPIO definition for GLOC peripheral ========== */
-#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
-#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PIN_PA06D_GLOC_IN0              _L_(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L_(3)
 #define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
-#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
-#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
-#define MUX_PA20D_GLOC_IN0              _L(3)
+#define GPIO_PA06D_GLOC_IN0      _UL_(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L_(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L_(3)
 #define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
-#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
-#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
-#define MUX_PA04D_GLOC_IN1              _L(3)
+#define GPIO_PA20D_GLOC_IN0      _UL_(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L_(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L_(3)
 #define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
-#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
-#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
-#define MUX_PA21D_GLOC_IN1              _L(3)
+#define GPIO_PA04D_GLOC_IN1      _UL_(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L_(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L_(3)
 #define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
-#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
-#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
-#define MUX_PA05D_GLOC_IN2              _L(3)
+#define GPIO_PA21D_GLOC_IN1      _UL_(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L_(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L_(3)
 #define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
-#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
-#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
-#define MUX_PA22D_GLOC_IN2              _L(3)
+#define GPIO_PA05D_GLOC_IN2      _UL_(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L_(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L_(3)
 #define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
-#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
-#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
-#define MUX_PA07D_GLOC_IN3              _L(3)
+#define GPIO_PA22D_GLOC_IN2      _UL_(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L_(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L_(3)
 #define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
-#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
-#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
-#define MUX_PA23D_GLOC_IN3              _L(3)
+#define GPIO_PA07D_GLOC_IN3      _UL_(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L_(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L_(3)
 #define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
-#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
-#define PIN_PA27D_GLOC_IN4             _L(27) /**< \brief GLOC signal: IN4 on PA27 mux D */
-#define MUX_PA27D_GLOC_IN4              _L(3)
+#define GPIO_PA23D_GLOC_IN3      _UL_(1 << 23)
+#define PIN_PA27D_GLOC_IN4             _L_(27) /**< \brief GLOC signal: IN4 on PA27 mux D */
+#define MUX_PA27D_GLOC_IN4              _L_(3)
 #define PINMUX_PA27D_GLOC_IN4      ((PIN_PA27D_GLOC_IN4 << 16) | MUX_PA27D_GLOC_IN4)
-#define GPIO_PA27D_GLOC_IN4      _UL(1 << 27)
-#define PIN_PC15D_GLOC_IN4             _L(79) /**< \brief GLOC signal: IN4 on PC15 mux D */
-#define MUX_PC15D_GLOC_IN4              _L(3)
+#define GPIO_PA27D_GLOC_IN4      _UL_(1 << 27)
+#define PIN_PC15D_GLOC_IN4             _L_(79) /**< \brief GLOC signal: IN4 on PC15 mux D */
+#define MUX_PC15D_GLOC_IN4              _L_(3)
 #define PINMUX_PC15D_GLOC_IN4      ((PIN_PC15D_GLOC_IN4 << 16) | MUX_PC15D_GLOC_IN4)
-#define GPIO_PC15D_GLOC_IN4      _UL(1 << 15)
-#define PIN_PB06C_GLOC_IN4             _L(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
-#define MUX_PB06C_GLOC_IN4              _L(2)
+#define GPIO_PC15D_GLOC_IN4      _UL_(1 << 15)
+#define PIN_PB06C_GLOC_IN4             _L_(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
+#define MUX_PB06C_GLOC_IN4              _L_(2)
 #define PINMUX_PB06C_GLOC_IN4      ((PIN_PB06C_GLOC_IN4 << 16) | MUX_PB06C_GLOC_IN4)
-#define GPIO_PB06C_GLOC_IN4      _UL(1 <<  6)
-#define PIN_PC28C_GLOC_IN4             _L(92) /**< \brief GLOC signal: IN4 on PC28 mux C */
-#define MUX_PC28C_GLOC_IN4              _L(2)
+#define GPIO_PB06C_GLOC_IN4      _UL_(1 <<  6)
+#define PIN_PC28C_GLOC_IN4             _L_(92) /**< \brief GLOC signal: IN4 on PC28 mux C */
+#define MUX_PC28C_GLOC_IN4              _L_(2)
 #define PINMUX_PC28C_GLOC_IN4      ((PIN_PC28C_GLOC_IN4 << 16) | MUX_PC28C_GLOC_IN4)
-#define GPIO_PC28C_GLOC_IN4      _UL(1 << 28)
-#define PIN_PA28D_GLOC_IN5             _L(28) /**< \brief GLOC signal: IN5 on PA28 mux D */
-#define MUX_PA28D_GLOC_IN5              _L(3)
+#define GPIO_PC28C_GLOC_IN4      _UL_(1 << 28)
+#define PIN_PA28D_GLOC_IN5             _L_(28) /**< \brief GLOC signal: IN5 on PA28 mux D */
+#define MUX_PA28D_GLOC_IN5              _L_(3)
 #define PINMUX_PA28D_GLOC_IN5      ((PIN_PA28D_GLOC_IN5 << 16) | MUX_PA28D_GLOC_IN5)
-#define GPIO_PA28D_GLOC_IN5      _UL(1 << 28)
-#define PIN_PC16D_GLOC_IN5             _L(80) /**< \brief GLOC signal: IN5 on PC16 mux D */
-#define MUX_PC16D_GLOC_IN5              _L(3)
+#define GPIO_PA28D_GLOC_IN5      _UL_(1 << 28)
+#define PIN_PC16D_GLOC_IN5             _L_(80) /**< \brief GLOC signal: IN5 on PC16 mux D */
+#define MUX_PC16D_GLOC_IN5              _L_(3)
 #define PINMUX_PC16D_GLOC_IN5      ((PIN_PC16D_GLOC_IN5 << 16) | MUX_PC16D_GLOC_IN5)
-#define GPIO_PC16D_GLOC_IN5      _UL(1 << 16)
-#define PIN_PB07C_GLOC_IN5             _L(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
-#define MUX_PB07C_GLOC_IN5              _L(2)
+#define GPIO_PC16D_GLOC_IN5      _UL_(1 << 16)
+#define PIN_PB07C_GLOC_IN5             _L_(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
+#define MUX_PB07C_GLOC_IN5              _L_(2)
 #define PINMUX_PB07C_GLOC_IN5      ((PIN_PB07C_GLOC_IN5 << 16) | MUX_PB07C_GLOC_IN5)
-#define GPIO_PB07C_GLOC_IN5      _UL(1 <<  7)
-#define PIN_PC29C_GLOC_IN5             _L(93) /**< \brief GLOC signal: IN5 on PC29 mux C */
-#define MUX_PC29C_GLOC_IN5              _L(2)
+#define GPIO_PB07C_GLOC_IN5      _UL_(1 <<  7)
+#define PIN_PC29C_GLOC_IN5             _L_(93) /**< \brief GLOC signal: IN5 on PC29 mux C */
+#define MUX_PC29C_GLOC_IN5              _L_(2)
 #define PINMUX_PC29C_GLOC_IN5      ((PIN_PC29C_GLOC_IN5 << 16) | MUX_PC29C_GLOC_IN5)
-#define GPIO_PC29C_GLOC_IN5      _UL(1 << 29)
-#define PIN_PA29D_GLOC_IN6             _L(29) /**< \brief GLOC signal: IN6 on PA29 mux D */
-#define MUX_PA29D_GLOC_IN6              _L(3)
+#define GPIO_PC29C_GLOC_IN5      _UL_(1 << 29)
+#define PIN_PA29D_GLOC_IN6             _L_(29) /**< \brief GLOC signal: IN6 on PA29 mux D */
+#define MUX_PA29D_GLOC_IN6              _L_(3)
 #define PINMUX_PA29D_GLOC_IN6      ((PIN_PA29D_GLOC_IN6 << 16) | MUX_PA29D_GLOC_IN6)
-#define GPIO_PA29D_GLOC_IN6      _UL(1 << 29)
-#define PIN_PC17D_GLOC_IN6             _L(81) /**< \brief GLOC signal: IN6 on PC17 mux D */
-#define MUX_PC17D_GLOC_IN6              _L(3)
+#define GPIO_PA29D_GLOC_IN6      _UL_(1 << 29)
+#define PIN_PC17D_GLOC_IN6             _L_(81) /**< \brief GLOC signal: IN6 on PC17 mux D */
+#define MUX_PC17D_GLOC_IN6              _L_(3)
 #define PINMUX_PC17D_GLOC_IN6      ((PIN_PC17D_GLOC_IN6 << 16) | MUX_PC17D_GLOC_IN6)
-#define GPIO_PC17D_GLOC_IN6      _UL(1 << 17)
-#define PIN_PB08C_GLOC_IN6             _L(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
-#define MUX_PB08C_GLOC_IN6              _L(2)
+#define GPIO_PC17D_GLOC_IN6      _UL_(1 << 17)
+#define PIN_PB08C_GLOC_IN6             _L_(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
+#define MUX_PB08C_GLOC_IN6              _L_(2)
 #define PINMUX_PB08C_GLOC_IN6      ((PIN_PB08C_GLOC_IN6 << 16) | MUX_PB08C_GLOC_IN6)
-#define GPIO_PB08C_GLOC_IN6      _UL(1 <<  8)
-#define PIN_PC30C_GLOC_IN6             _L(94) /**< \brief GLOC signal: IN6 on PC30 mux C */
-#define MUX_PC30C_GLOC_IN6              _L(2)
+#define GPIO_PB08C_GLOC_IN6      _UL_(1 <<  8)
+#define PIN_PC30C_GLOC_IN6             _L_(94) /**< \brief GLOC signal: IN6 on PC30 mux C */
+#define MUX_PC30C_GLOC_IN6              _L_(2)
 #define PINMUX_PC30C_GLOC_IN6      ((PIN_PC30C_GLOC_IN6 << 16) | MUX_PC30C_GLOC_IN6)
-#define GPIO_PC30C_GLOC_IN6      _UL(1 << 30)
-#define PIN_PA30D_GLOC_IN7             _L(30) /**< \brief GLOC signal: IN7 on PA30 mux D */
-#define MUX_PA30D_GLOC_IN7              _L(3)
+#define GPIO_PC30C_GLOC_IN6      _UL_(1 << 30)
+#define PIN_PA30D_GLOC_IN7             _L_(30) /**< \brief GLOC signal: IN7 on PA30 mux D */
+#define MUX_PA30D_GLOC_IN7              _L_(3)
 #define PINMUX_PA30D_GLOC_IN7      ((PIN_PA30D_GLOC_IN7 << 16) | MUX_PA30D_GLOC_IN7)
-#define GPIO_PA30D_GLOC_IN7      _UL(1 << 30)
-#define PIN_PC18D_GLOC_IN7             _L(82) /**< \brief GLOC signal: IN7 on PC18 mux D */
-#define MUX_PC18D_GLOC_IN7              _L(3)
+#define GPIO_PA30D_GLOC_IN7      _UL_(1 << 30)
+#define PIN_PC18D_GLOC_IN7             _L_(82) /**< \brief GLOC signal: IN7 on PC18 mux D */
+#define MUX_PC18D_GLOC_IN7              _L_(3)
 #define PINMUX_PC18D_GLOC_IN7      ((PIN_PC18D_GLOC_IN7 << 16) | MUX_PC18D_GLOC_IN7)
-#define GPIO_PC18D_GLOC_IN7      _UL(1 << 18)
-#define PIN_PB09C_GLOC_IN7             _L(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
-#define MUX_PB09C_GLOC_IN7              _L(2)
+#define GPIO_PC18D_GLOC_IN7      _UL_(1 << 18)
+#define PIN_PB09C_GLOC_IN7             _L_(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
+#define MUX_PB09C_GLOC_IN7              _L_(2)
 #define PINMUX_PB09C_GLOC_IN7      ((PIN_PB09C_GLOC_IN7 << 16) | MUX_PB09C_GLOC_IN7)
-#define GPIO_PB09C_GLOC_IN7      _UL(1 <<  9)
-#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
-#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define GPIO_PB09C_GLOC_IN7      _UL_(1 <<  9)
+#define PIN_PA08D_GLOC_OUT0             _L_(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
-#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
-#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
-#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define GPIO_PA08D_GLOC_OUT0     _UL_(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L_(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
-#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
-#define PIN_PA31D_GLOC_OUT1            _L(31) /**< \brief GLOC signal: OUT1 on PA31 mux D */
-#define MUX_PA31D_GLOC_OUT1             _L(3)
+#define GPIO_PA24D_GLOC_OUT0     _UL_(1 << 24)
+#define PIN_PA31D_GLOC_OUT1            _L_(31) /**< \brief GLOC signal: OUT1 on PA31 mux D */
+#define MUX_PA31D_GLOC_OUT1             _L_(3)
 #define PINMUX_PA31D_GLOC_OUT1     ((PIN_PA31D_GLOC_OUT1 << 16) | MUX_PA31D_GLOC_OUT1)
-#define GPIO_PA31D_GLOC_OUT1     _UL(1 << 31)
-#define PIN_PC19D_GLOC_OUT1            _L(83) /**< \brief GLOC signal: OUT1 on PC19 mux D */
-#define MUX_PC19D_GLOC_OUT1             _L(3)
+#define GPIO_PA31D_GLOC_OUT1     _UL_(1 << 31)
+#define PIN_PC19D_GLOC_OUT1            _L_(83) /**< \brief GLOC signal: OUT1 on PC19 mux D */
+#define MUX_PC19D_GLOC_OUT1             _L_(3)
 #define PINMUX_PC19D_GLOC_OUT1     ((PIN_PC19D_GLOC_OUT1 << 16) | MUX_PC19D_GLOC_OUT1)
-#define GPIO_PC19D_GLOC_OUT1     _UL(1 << 19)
-#define PIN_PB10C_GLOC_OUT1            _L(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
-#define MUX_PB10C_GLOC_OUT1             _L(2)
+#define GPIO_PC19D_GLOC_OUT1     _UL_(1 << 19)
+#define PIN_PB10C_GLOC_OUT1            _L_(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
+#define MUX_PB10C_GLOC_OUT1             _L_(2)
 #define PINMUX_PB10C_GLOC_OUT1     ((PIN_PB10C_GLOC_OUT1 << 16) | MUX_PB10C_GLOC_OUT1)
-#define GPIO_PB10C_GLOC_OUT1     _UL(1 << 10)
-#define PIN_PC31C_GLOC_OUT1            _L(95) /**< \brief GLOC signal: OUT1 on PC31 mux C */
-#define MUX_PC31C_GLOC_OUT1             _L(2)
+#define GPIO_PB10C_GLOC_OUT1     _UL_(1 << 10)
+#define PIN_PC31C_GLOC_OUT1            _L_(95) /**< \brief GLOC signal: OUT1 on PC31 mux C */
+#define MUX_PC31C_GLOC_OUT1             _L_(2)
 #define PINMUX_PC31C_GLOC_OUT1     ((PIN_PC31C_GLOC_OUT1 << 16) | MUX_PC31C_GLOC_OUT1)
-#define GPIO_PC31C_GLOC_OUT1     _UL(1 << 31)
+#define GPIO_PC31C_GLOC_OUT1     _UL_(1 << 31)
 /* ========== GPIO definition for ABDACB peripheral ========== */
-#define PIN_PA31C_ABDACB_CLK           _L(31) /**< \brief ABDACB signal: CLK on PA31 mux C */
-#define MUX_PA31C_ABDACB_CLK            _L(2)
+#define PIN_PA31C_ABDACB_CLK           _L_(31) /**< \brief ABDACB signal: CLK on PA31 mux C */
+#define MUX_PA31C_ABDACB_CLK            _L_(2)
 #define PINMUX_PA31C_ABDACB_CLK    ((PIN_PA31C_ABDACB_CLK << 16) | MUX_PA31C_ABDACB_CLK)
-#define GPIO_PA31C_ABDACB_CLK    _UL(1 << 31)
-#define PIN_PC12C_ABDACB_CLK           _L(76) /**< \brief ABDACB signal: CLK on PC12 mux C */
-#define MUX_PC12C_ABDACB_CLK            _L(2)
+#define GPIO_PA31C_ABDACB_CLK    _UL_(1 << 31)
+#define PIN_PC12C_ABDACB_CLK           _L_(76) /**< \brief ABDACB signal: CLK on PC12 mux C */
+#define MUX_PC12C_ABDACB_CLK            _L_(2)
 #define PINMUX_PC12C_ABDACB_CLK    ((PIN_PC12C_ABDACB_CLK << 16) | MUX_PC12C_ABDACB_CLK)
-#define GPIO_PC12C_ABDACB_CLK    _UL(1 << 12)
-#define PIN_PA27C_ABDACB_DAC0          _L(27) /**< \brief ABDACB signal: DAC0 on PA27 mux C */
-#define MUX_PA27C_ABDACB_DAC0           _L(2)
+#define GPIO_PC12C_ABDACB_CLK    _UL_(1 << 12)
+#define PIN_PA27C_ABDACB_DAC0          _L_(27) /**< \brief ABDACB signal: DAC0 on PA27 mux C */
+#define MUX_PA27C_ABDACB_DAC0           _L_(2)
 #define PINMUX_PA27C_ABDACB_DAC0   ((PIN_PA27C_ABDACB_DAC0 << 16) | MUX_PA27C_ABDACB_DAC0)
-#define GPIO_PA27C_ABDACB_DAC0   _UL(1 << 27)
-#define PIN_PB02C_ABDACB_DAC0          _L(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
-#define MUX_PB02C_ABDACB_DAC0           _L(2)
+#define GPIO_PA27C_ABDACB_DAC0   _UL_(1 << 27)
+#define PIN_PB02C_ABDACB_DAC0          _L_(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
+#define MUX_PB02C_ABDACB_DAC0           _L_(2)
 #define PINMUX_PB02C_ABDACB_DAC0   ((PIN_PB02C_ABDACB_DAC0 << 16) | MUX_PB02C_ABDACB_DAC0)
-#define GPIO_PB02C_ABDACB_DAC0   _UL(1 <<  2)
-#define PIN_PC09C_ABDACB_DAC0          _L(73) /**< \brief ABDACB signal: DAC0 on PC09 mux C */
-#define MUX_PC09C_ABDACB_DAC0           _L(2)
+#define GPIO_PB02C_ABDACB_DAC0   _UL_(1 <<  2)
+#define PIN_PC09C_ABDACB_DAC0          _L_(73) /**< \brief ABDACB signal: DAC0 on PC09 mux C */
+#define MUX_PC09C_ABDACB_DAC0           _L_(2)
 #define PINMUX_PC09C_ABDACB_DAC0   ((PIN_PC09C_ABDACB_DAC0 << 16) | MUX_PC09C_ABDACB_DAC0)
-#define GPIO_PC09C_ABDACB_DAC0   _UL(1 <<  9)
-#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
-#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define GPIO_PC09C_ABDACB_DAC0   _UL_(1 <<  9)
+#define PIN_PA17B_ABDACB_DAC0          _L_(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L_(1)
 #define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
-#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
-#define PIN_PA29C_ABDACB_DAC1          _L(29) /**< \brief ABDACB signal: DAC1 on PA29 mux C */
-#define MUX_PA29C_ABDACB_DAC1           _L(2)
+#define GPIO_PA17B_ABDACB_DAC0   _UL_(1 << 17)
+#define PIN_PA29C_ABDACB_DAC1          _L_(29) /**< \brief ABDACB signal: DAC1 on PA29 mux C */
+#define MUX_PA29C_ABDACB_DAC1           _L_(2)
 #define PINMUX_PA29C_ABDACB_DAC1   ((PIN_PA29C_ABDACB_DAC1 << 16) | MUX_PA29C_ABDACB_DAC1)
-#define GPIO_PA29C_ABDACB_DAC1   _UL(1 << 29)
-#define PIN_PB04C_ABDACB_DAC1          _L(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
-#define MUX_PB04C_ABDACB_DAC1           _L(2)
+#define GPIO_PA29C_ABDACB_DAC1   _UL_(1 << 29)
+#define PIN_PB04C_ABDACB_DAC1          _L_(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
+#define MUX_PB04C_ABDACB_DAC1           _L_(2)
 #define PINMUX_PB04C_ABDACB_DAC1   ((PIN_PB04C_ABDACB_DAC1 << 16) | MUX_PB04C_ABDACB_DAC1)
-#define GPIO_PB04C_ABDACB_DAC1   _UL(1 <<  4)
-#define PIN_PC13C_ABDACB_DAC1          _L(77) /**< \brief ABDACB signal: DAC1 on PC13 mux C */
-#define MUX_PC13C_ABDACB_DAC1           _L(2)
+#define GPIO_PB04C_ABDACB_DAC1   _UL_(1 <<  4)
+#define PIN_PC13C_ABDACB_DAC1          _L_(77) /**< \brief ABDACB signal: DAC1 on PC13 mux C */
+#define MUX_PC13C_ABDACB_DAC1           _L_(2)
 #define PINMUX_PC13C_ABDACB_DAC1   ((PIN_PC13C_ABDACB_DAC1 << 16) | MUX_PC13C_ABDACB_DAC1)
-#define GPIO_PC13C_ABDACB_DAC1   _UL(1 << 13)
-#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
-#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define GPIO_PC13C_ABDACB_DAC1   _UL_(1 << 13)
+#define PIN_PA19B_ABDACB_DAC1          _L_(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L_(1)
 #define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
-#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
-#define PIN_PA28C_ABDACB_DACN0         _L(28) /**< \brief ABDACB signal: DACN0 on PA28 mux C */
-#define MUX_PA28C_ABDACB_DACN0          _L(2)
+#define GPIO_PA19B_ABDACB_DAC1   _UL_(1 << 19)
+#define PIN_PA28C_ABDACB_DACN0         _L_(28) /**< \brief ABDACB signal: DACN0 on PA28 mux C */
+#define MUX_PA28C_ABDACB_DACN0          _L_(2)
 #define PINMUX_PA28C_ABDACB_DACN0  ((PIN_PA28C_ABDACB_DACN0 << 16) | MUX_PA28C_ABDACB_DACN0)
-#define GPIO_PA28C_ABDACB_DACN0  _UL(1 << 28)
-#define PIN_PB03C_ABDACB_DACN0         _L(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
-#define MUX_PB03C_ABDACB_DACN0          _L(2)
+#define GPIO_PA28C_ABDACB_DACN0  _UL_(1 << 28)
+#define PIN_PB03C_ABDACB_DACN0         _L_(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
+#define MUX_PB03C_ABDACB_DACN0          _L_(2)
 #define PINMUX_PB03C_ABDACB_DACN0  ((PIN_PB03C_ABDACB_DACN0 << 16) | MUX_PB03C_ABDACB_DACN0)
-#define GPIO_PB03C_ABDACB_DACN0  _UL(1 <<  3)
-#define PIN_PC10C_ABDACB_DACN0         _L(74) /**< \brief ABDACB signal: DACN0 on PC10 mux C */
-#define MUX_PC10C_ABDACB_DACN0          _L(2)
+#define GPIO_PB03C_ABDACB_DACN0  _UL_(1 <<  3)
+#define PIN_PC10C_ABDACB_DACN0         _L_(74) /**< \brief ABDACB signal: DACN0 on PC10 mux C */
+#define MUX_PC10C_ABDACB_DACN0          _L_(2)
 #define PINMUX_PC10C_ABDACB_DACN0  ((PIN_PC10C_ABDACB_DACN0 << 16) | MUX_PC10C_ABDACB_DACN0)
-#define GPIO_PC10C_ABDACB_DACN0  _UL(1 << 10)
-#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
-#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define GPIO_PC10C_ABDACB_DACN0  _UL_(1 << 10)
+#define PIN_PA18B_ABDACB_DACN0         _L_(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L_(1)
 #define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
-#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
-#define PIN_PA30C_ABDACB_DACN1         _L(30) /**< \brief ABDACB signal: DACN1 on PA30 mux C */
-#define MUX_PA30C_ABDACB_DACN1          _L(2)
+#define GPIO_PA18B_ABDACB_DACN0  _UL_(1 << 18)
+#define PIN_PA30C_ABDACB_DACN1         _L_(30) /**< \brief ABDACB signal: DACN1 on PA30 mux C */
+#define MUX_PA30C_ABDACB_DACN1          _L_(2)
 #define PINMUX_PA30C_ABDACB_DACN1  ((PIN_PA30C_ABDACB_DACN1 << 16) | MUX_PA30C_ABDACB_DACN1)
-#define GPIO_PA30C_ABDACB_DACN1  _UL(1 << 30)
-#define PIN_PB05C_ABDACB_DACN1         _L(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
-#define MUX_PB05C_ABDACB_DACN1          _L(2)
+#define GPIO_PA30C_ABDACB_DACN1  _UL_(1 << 30)
+#define PIN_PB05C_ABDACB_DACN1         _L_(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
+#define MUX_PB05C_ABDACB_DACN1          _L_(2)
 #define PINMUX_PB05C_ABDACB_DACN1  ((PIN_PB05C_ABDACB_DACN1 << 16) | MUX_PB05C_ABDACB_DACN1)
-#define GPIO_PB05C_ABDACB_DACN1  _UL(1 <<  5)
-#define PIN_PC14C_ABDACB_DACN1         _L(78) /**< \brief ABDACB signal: DACN1 on PC14 mux C */
-#define MUX_PC14C_ABDACB_DACN1          _L(2)
+#define GPIO_PB05C_ABDACB_DACN1  _UL_(1 <<  5)
+#define PIN_PC14C_ABDACB_DACN1         _L_(78) /**< \brief ABDACB signal: DACN1 on PC14 mux C */
+#define MUX_PC14C_ABDACB_DACN1          _L_(2)
 #define PINMUX_PC14C_ABDACB_DACN1  ((PIN_PC14C_ABDACB_DACN1 << 16) | MUX_PC14C_ABDACB_DACN1)
-#define GPIO_PC14C_ABDACB_DACN1  _UL(1 << 14)
-#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
-#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define GPIO_PC14C_ABDACB_DACN1  _UL_(1 << 14)
+#define PIN_PA20B_ABDACB_DACN1         _L_(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L_(1)
 #define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
-#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+#define GPIO_PA20B_ABDACB_DACN1  _UL_(1 << 20)
 /* ========== GPIO definition for PARC peripheral ========== */
-#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
-#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PIN_PA17D_PARC_PCCK            _L_(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L_(3)
 #define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
-#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
-#define PIN_PC21D_PARC_PCCK            _L(85) /**< \brief PARC signal: PCCK on PC21 mux D */
-#define MUX_PC21D_PARC_PCCK             _L(3)
+#define GPIO_PA17D_PARC_PCCK     _UL_(1 << 17)
+#define PIN_PC21D_PARC_PCCK            _L_(85) /**< \brief PARC signal: PCCK on PC21 mux D */
+#define MUX_PC21D_PARC_PCCK             _L_(3)
 #define PINMUX_PC21D_PARC_PCCK     ((PIN_PC21D_PARC_PCCK << 16) | MUX_PC21D_PARC_PCCK)
-#define GPIO_PC21D_PARC_PCCK     _UL(1 << 21)
-#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
-#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define GPIO_PC21D_PARC_PCCK     _UL_(1 << 21)
+#define PIN_PA09D_PARC_PCDATA0          _L_(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L_(3)
 #define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
-#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
-#define PIN_PC24D_PARC_PCDATA0         _L(88) /**< \brief PARC signal: PCDATA0 on PC24 mux D */
-#define MUX_PC24D_PARC_PCDATA0          _L(3)
+#define GPIO_PA09D_PARC_PCDATA0  _UL_(1 <<  9)
+#define PIN_PC24D_PARC_PCDATA0         _L_(88) /**< \brief PARC signal: PCDATA0 on PC24 mux D */
+#define MUX_PC24D_PARC_PCDATA0          _L_(3)
 #define PINMUX_PC24D_PARC_PCDATA0  ((PIN_PC24D_PARC_PCDATA0 << 16) | MUX_PC24D_PARC_PCDATA0)
-#define GPIO_PC24D_PARC_PCDATA0  _UL(1 << 24)
-#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
-#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define GPIO_PC24D_PARC_PCDATA0  _UL_(1 << 24)
+#define PIN_PA10D_PARC_PCDATA1         _L_(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L_(3)
 #define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
-#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
-#define PIN_PC25D_PARC_PCDATA1         _L(89) /**< \brief PARC signal: PCDATA1 on PC25 mux D */
-#define MUX_PC25D_PARC_PCDATA1          _L(3)
+#define GPIO_PA10D_PARC_PCDATA1  _UL_(1 << 10)
+#define PIN_PC25D_PARC_PCDATA1         _L_(89) /**< \brief PARC signal: PCDATA1 on PC25 mux D */
+#define MUX_PC25D_PARC_PCDATA1          _L_(3)
 #define PINMUX_PC25D_PARC_PCDATA1  ((PIN_PC25D_PARC_PCDATA1 << 16) | MUX_PC25D_PARC_PCDATA1)
-#define GPIO_PC25D_PARC_PCDATA1  _UL(1 << 25)
-#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
-#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define GPIO_PC25D_PARC_PCDATA1  _UL_(1 << 25)
+#define PIN_PA11D_PARC_PCDATA2         _L_(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L_(3)
 #define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
-#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
-#define PIN_PC26D_PARC_PCDATA2         _L(90) /**< \brief PARC signal: PCDATA2 on PC26 mux D */
-#define MUX_PC26D_PARC_PCDATA2          _L(3)
+#define GPIO_PA11D_PARC_PCDATA2  _UL_(1 << 11)
+#define PIN_PC26D_PARC_PCDATA2         _L_(90) /**< \brief PARC signal: PCDATA2 on PC26 mux D */
+#define MUX_PC26D_PARC_PCDATA2          _L_(3)
 #define PINMUX_PC26D_PARC_PCDATA2  ((PIN_PC26D_PARC_PCDATA2 << 16) | MUX_PC26D_PARC_PCDATA2)
-#define GPIO_PC26D_PARC_PCDATA2  _UL(1 << 26)
-#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
-#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define GPIO_PC26D_PARC_PCDATA2  _UL_(1 << 26)
+#define PIN_PA12D_PARC_PCDATA3         _L_(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L_(3)
 #define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
-#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
-#define PIN_PC27D_PARC_PCDATA3         _L(91) /**< \brief PARC signal: PCDATA3 on PC27 mux D */
-#define MUX_PC27D_PARC_PCDATA3          _L(3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL_(1 << 12)
+#define PIN_PC27D_PARC_PCDATA3         _L_(91) /**< \brief PARC signal: PCDATA3 on PC27 mux D */
+#define MUX_PC27D_PARC_PCDATA3          _L_(3)
 #define PINMUX_PC27D_PARC_PCDATA3  ((PIN_PC27D_PARC_PCDATA3 << 16) | MUX_PC27D_PARC_PCDATA3)
-#define GPIO_PC27D_PARC_PCDATA3  _UL(1 << 27)
-#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
-#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define GPIO_PC27D_PARC_PCDATA3  _UL_(1 << 27)
+#define PIN_PA13D_PARC_PCDATA4         _L_(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L_(3)
 #define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
-#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
-#define PIN_PC28D_PARC_PCDATA4         _L(92) /**< \brief PARC signal: PCDATA4 on PC28 mux D */
-#define MUX_PC28D_PARC_PCDATA4          _L(3)
+#define GPIO_PA13D_PARC_PCDATA4  _UL_(1 << 13)
+#define PIN_PC28D_PARC_PCDATA4         _L_(92) /**< \brief PARC signal: PCDATA4 on PC28 mux D */
+#define MUX_PC28D_PARC_PCDATA4          _L_(3)
 #define PINMUX_PC28D_PARC_PCDATA4  ((PIN_PC28D_PARC_PCDATA4 << 16) | MUX_PC28D_PARC_PCDATA4)
-#define GPIO_PC28D_PARC_PCDATA4  _UL(1 << 28)
-#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
-#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define GPIO_PC28D_PARC_PCDATA4  _UL_(1 << 28)
+#define PIN_PA14D_PARC_PCDATA5         _L_(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L_(3)
 #define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
-#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
-#define PIN_PC29D_PARC_PCDATA5         _L(93) /**< \brief PARC signal: PCDATA5 on PC29 mux D */
-#define MUX_PC29D_PARC_PCDATA5          _L(3)
+#define GPIO_PA14D_PARC_PCDATA5  _UL_(1 << 14)
+#define PIN_PC29D_PARC_PCDATA5         _L_(93) /**< \brief PARC signal: PCDATA5 on PC29 mux D */
+#define MUX_PC29D_PARC_PCDATA5          _L_(3)
 #define PINMUX_PC29D_PARC_PCDATA5  ((PIN_PC29D_PARC_PCDATA5 << 16) | MUX_PC29D_PARC_PCDATA5)
-#define GPIO_PC29D_PARC_PCDATA5  _UL(1 << 29)
-#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
-#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define GPIO_PC29D_PARC_PCDATA5  _UL_(1 << 29)
+#define PIN_PA15D_PARC_PCDATA6         _L_(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L_(3)
 #define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
-#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
-#define PIN_PC30D_PARC_PCDATA6         _L(94) /**< \brief PARC signal: PCDATA6 on PC30 mux D */
-#define MUX_PC30D_PARC_PCDATA6          _L(3)
+#define GPIO_PA15D_PARC_PCDATA6  _UL_(1 << 15)
+#define PIN_PC30D_PARC_PCDATA6         _L_(94) /**< \brief PARC signal: PCDATA6 on PC30 mux D */
+#define MUX_PC30D_PARC_PCDATA6          _L_(3)
 #define PINMUX_PC30D_PARC_PCDATA6  ((PIN_PC30D_PARC_PCDATA6 << 16) | MUX_PC30D_PARC_PCDATA6)
-#define GPIO_PC30D_PARC_PCDATA6  _UL(1 << 30)
-#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
-#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define GPIO_PC30D_PARC_PCDATA6  _UL_(1 << 30)
+#define PIN_PA16D_PARC_PCDATA7         _L_(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L_(3)
 #define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
-#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
-#define PIN_PC31D_PARC_PCDATA7         _L(95) /**< \brief PARC signal: PCDATA7 on PC31 mux D */
-#define MUX_PC31D_PARC_PCDATA7          _L(3)
+#define GPIO_PA16D_PARC_PCDATA7  _UL_(1 << 16)
+#define PIN_PC31D_PARC_PCDATA7         _L_(95) /**< \brief PARC signal: PCDATA7 on PC31 mux D */
+#define MUX_PC31D_PARC_PCDATA7          _L_(3)
 #define PINMUX_PC31D_PARC_PCDATA7  ((PIN_PC31D_PARC_PCDATA7 << 16) | MUX_PC31D_PARC_PCDATA7)
-#define GPIO_PC31D_PARC_PCDATA7  _UL(1 << 31)
-#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
-#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define GPIO_PC31D_PARC_PCDATA7  _UL_(1 << 31)
+#define PIN_PA18D_PARC_PCEN1           _L_(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L_(3)
 #define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
-#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
-#define PIN_PC22D_PARC_PCEN1           _L(86) /**< \brief PARC signal: PCEN1 on PC22 mux D */
-#define MUX_PC22D_PARC_PCEN1            _L(3)
+#define GPIO_PA18D_PARC_PCEN1    _UL_(1 << 18)
+#define PIN_PC22D_PARC_PCEN1           _L_(86) /**< \brief PARC signal: PCEN1 on PC22 mux D */
+#define MUX_PC22D_PARC_PCEN1            _L_(3)
 #define PINMUX_PC22D_PARC_PCEN1    ((PIN_PC22D_PARC_PCEN1 << 16) | MUX_PC22D_PARC_PCEN1)
-#define GPIO_PC22D_PARC_PCEN1    _UL(1 << 22)
-#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
-#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define GPIO_PC22D_PARC_PCEN1    _UL_(1 << 22)
+#define PIN_PA19D_PARC_PCEN2           _L_(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L_(3)
 #define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
-#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
-#define PIN_PC23D_PARC_PCEN2           _L(87) /**< \brief PARC signal: PCEN2 on PC23 mux D */
-#define MUX_PC23D_PARC_PCEN2            _L(3)
+#define GPIO_PA19D_PARC_PCEN2    _UL_(1 << 19)
+#define PIN_PC23D_PARC_PCEN2           _L_(87) /**< \brief PARC signal: PCEN2 on PC23 mux D */
+#define MUX_PC23D_PARC_PCEN2            _L_(3)
 #define PINMUX_PC23D_PARC_PCEN2    ((PIN_PC23D_PARC_PCEN2 << 16) | MUX_PC23D_PARC_PCEN2)
-#define GPIO_PC23D_PARC_PCEN2    _UL(1 << 23)
+#define GPIO_PC23D_PARC_PCEN2    _UL_(1 << 23)
 /* ========== GPIO definition for CATB peripheral ========== */
-#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
-#define MUX_PA02G_CATB_DIS              _L(6)
+#define PIN_PA02G_CATB_DIS              _L_(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L_(6)
 #define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
-#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
-#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
-#define MUX_PA12G_CATB_DIS              _L(6)
+#define GPIO_PA02G_CATB_DIS      _UL_(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L_(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L_(6)
 #define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
-#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
-#define MUX_PA23G_CATB_DIS              _L(6)
+#define GPIO_PA12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L_(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L_(6)
 #define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
-#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
-#define PIN_PA31G_CATB_DIS             _L(31) /**< \brief CATB signal: DIS on PA31 mux G */
-#define MUX_PA31G_CATB_DIS              _L(6)
+#define GPIO_PA23G_CATB_DIS      _UL_(1 << 23)
+#define PIN_PA31G_CATB_DIS             _L_(31) /**< \brief CATB signal: DIS on PA31 mux G */
+#define MUX_PA31G_CATB_DIS              _L_(6)
 #define PINMUX_PA31G_CATB_DIS      ((PIN_PA31G_CATB_DIS << 16) | MUX_PA31G_CATB_DIS)
-#define GPIO_PA31G_CATB_DIS      _UL(1 << 31)
-#define PIN_PB03G_CATB_DIS             _L(35) /**< \brief CATB signal: DIS on PB03 mux G */
-#define MUX_PB03G_CATB_DIS              _L(6)
+#define GPIO_PA31G_CATB_DIS      _UL_(1 << 31)
+#define PIN_PB03G_CATB_DIS             _L_(35) /**< \brief CATB signal: DIS on PB03 mux G */
+#define MUX_PB03G_CATB_DIS              _L_(6)
 #define PINMUX_PB03G_CATB_DIS      ((PIN_PB03G_CATB_DIS << 16) | MUX_PB03G_CATB_DIS)
-#define GPIO_PB03G_CATB_DIS      _UL(1 <<  3)
-#define PIN_PB12G_CATB_DIS             _L(44) /**< \brief CATB signal: DIS on PB12 mux G */
-#define MUX_PB12G_CATB_DIS              _L(6)
+#define GPIO_PB03G_CATB_DIS      _UL_(1 <<  3)
+#define PIN_PB12G_CATB_DIS             _L_(44) /**< \brief CATB signal: DIS on PB12 mux G */
+#define MUX_PB12G_CATB_DIS              _L_(6)
 #define PINMUX_PB12G_CATB_DIS      ((PIN_PB12G_CATB_DIS << 16) | MUX_PB12G_CATB_DIS)
-#define GPIO_PB12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PC05G_CATB_DIS             _L(69) /**< \brief CATB signal: DIS on PC05 mux G */
-#define MUX_PC05G_CATB_DIS              _L(6)
+#define GPIO_PB12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PC05G_CATB_DIS             _L_(69) /**< \brief CATB signal: DIS on PC05 mux G */
+#define MUX_PC05G_CATB_DIS              _L_(6)
 #define PINMUX_PC05G_CATB_DIS      ((PIN_PC05G_CATB_DIS << 16) | MUX_PC05G_CATB_DIS)
-#define GPIO_PC05G_CATB_DIS      _UL(1 <<  5)
-#define PIN_PC14G_CATB_DIS             _L(78) /**< \brief CATB signal: DIS on PC14 mux G */
-#define MUX_PC14G_CATB_DIS              _L(6)
+#define GPIO_PC05G_CATB_DIS      _UL_(1 <<  5)
+#define PIN_PC14G_CATB_DIS             _L_(78) /**< \brief CATB signal: DIS on PC14 mux G */
+#define MUX_PC14G_CATB_DIS              _L_(6)
 #define PINMUX_PC14G_CATB_DIS      ((PIN_PC14G_CATB_DIS << 16) | MUX_PC14G_CATB_DIS)
-#define GPIO_PC14G_CATB_DIS      _UL(1 << 14)
-#define PIN_PC23G_CATB_DIS             _L(87) /**< \brief CATB signal: DIS on PC23 mux G */
-#define MUX_PC23G_CATB_DIS              _L(6)
+#define GPIO_PC14G_CATB_DIS      _UL_(1 << 14)
+#define PIN_PC23G_CATB_DIS             _L_(87) /**< \brief CATB signal: DIS on PC23 mux G */
+#define MUX_PC23G_CATB_DIS              _L_(6)
 #define PINMUX_PC23G_CATB_DIS      ((PIN_PC23G_CATB_DIS << 16) | MUX_PC23G_CATB_DIS)
-#define GPIO_PC23G_CATB_DIS      _UL(1 << 23)
-#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
-#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define GPIO_PC23G_CATB_DIS      _UL_(1 << 23)
+#define PIN_PA04G_CATB_SENSE0           _L_(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L_(6)
 #define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
-#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
-#define PIN_PA27G_CATB_SENSE0          _L(27) /**< \brief CATB signal: SENSE0 on PA27 mux G */
-#define MUX_PA27G_CATB_SENSE0           _L(6)
+#define GPIO_PA04G_CATB_SENSE0   _UL_(1 <<  4)
+#define PIN_PA27G_CATB_SENSE0          _L_(27) /**< \brief CATB signal: SENSE0 on PA27 mux G */
+#define MUX_PA27G_CATB_SENSE0           _L_(6)
 #define PINMUX_PA27G_CATB_SENSE0   ((PIN_PA27G_CATB_SENSE0 << 16) | MUX_PA27G_CATB_SENSE0)
-#define GPIO_PA27G_CATB_SENSE0   _UL(1 << 27)
-#define PIN_PB13G_CATB_SENSE0          _L(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
-#define MUX_PB13G_CATB_SENSE0           _L(6)
+#define GPIO_PA27G_CATB_SENSE0   _UL_(1 << 27)
+#define PIN_PB13G_CATB_SENSE0          _L_(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
+#define MUX_PB13G_CATB_SENSE0           _L_(6)
 #define PINMUX_PB13G_CATB_SENSE0   ((PIN_PB13G_CATB_SENSE0 << 16) | MUX_PB13G_CATB_SENSE0)
-#define GPIO_PB13G_CATB_SENSE0   _UL(1 << 13)
-#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
-#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define GPIO_PB13G_CATB_SENSE0   _UL_(1 << 13)
+#define PIN_PA05G_CATB_SENSE1           _L_(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L_(6)
 #define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
-#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
-#define PIN_PA28G_CATB_SENSE1          _L(28) /**< \brief CATB signal: SENSE1 on PA28 mux G */
-#define MUX_PA28G_CATB_SENSE1           _L(6)
+#define GPIO_PA05G_CATB_SENSE1   _UL_(1 <<  5)
+#define PIN_PA28G_CATB_SENSE1          _L_(28) /**< \brief CATB signal: SENSE1 on PA28 mux G */
+#define MUX_PA28G_CATB_SENSE1           _L_(6)
 #define PINMUX_PA28G_CATB_SENSE1   ((PIN_PA28G_CATB_SENSE1 << 16) | MUX_PA28G_CATB_SENSE1)
-#define GPIO_PA28G_CATB_SENSE1   _UL(1 << 28)
-#define PIN_PB14G_CATB_SENSE1          _L(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
-#define MUX_PB14G_CATB_SENSE1           _L(6)
+#define GPIO_PA28G_CATB_SENSE1   _UL_(1 << 28)
+#define PIN_PB14G_CATB_SENSE1          _L_(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
+#define MUX_PB14G_CATB_SENSE1           _L_(6)
 #define PINMUX_PB14G_CATB_SENSE1   ((PIN_PB14G_CATB_SENSE1 << 16) | MUX_PB14G_CATB_SENSE1)
-#define GPIO_PB14G_CATB_SENSE1   _UL(1 << 14)
-#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
-#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define GPIO_PB14G_CATB_SENSE1   _UL_(1 << 14)
+#define PIN_PA06G_CATB_SENSE2           _L_(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L_(6)
 #define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
-#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
-#define PIN_PA29G_CATB_SENSE2          _L(29) /**< \brief CATB signal: SENSE2 on PA29 mux G */
-#define MUX_PA29G_CATB_SENSE2           _L(6)
+#define GPIO_PA06G_CATB_SENSE2   _UL_(1 <<  6)
+#define PIN_PA29G_CATB_SENSE2          _L_(29) /**< \brief CATB signal: SENSE2 on PA29 mux G */
+#define MUX_PA29G_CATB_SENSE2           _L_(6)
 #define PINMUX_PA29G_CATB_SENSE2   ((PIN_PA29G_CATB_SENSE2 << 16) | MUX_PA29G_CATB_SENSE2)
-#define GPIO_PA29G_CATB_SENSE2   _UL(1 << 29)
-#define PIN_PB15G_CATB_SENSE2          _L(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
-#define MUX_PB15G_CATB_SENSE2           _L(6)
+#define GPIO_PA29G_CATB_SENSE2   _UL_(1 << 29)
+#define PIN_PB15G_CATB_SENSE2          _L_(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
+#define MUX_PB15G_CATB_SENSE2           _L_(6)
 #define PINMUX_PB15G_CATB_SENSE2   ((PIN_PB15G_CATB_SENSE2 << 16) | MUX_PB15G_CATB_SENSE2)
-#define GPIO_PB15G_CATB_SENSE2   _UL(1 << 15)
-#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
-#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define GPIO_PB15G_CATB_SENSE2   _UL_(1 << 15)
+#define PIN_PA07G_CATB_SENSE3           _L_(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L_(6)
 #define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
-#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
-#define PIN_PA30G_CATB_SENSE3          _L(30) /**< \brief CATB signal: SENSE3 on PA30 mux G */
-#define MUX_PA30G_CATB_SENSE3           _L(6)
+#define GPIO_PA07G_CATB_SENSE3   _UL_(1 <<  7)
+#define PIN_PA30G_CATB_SENSE3          _L_(30) /**< \brief CATB signal: SENSE3 on PA30 mux G */
+#define MUX_PA30G_CATB_SENSE3           _L_(6)
 #define PINMUX_PA30G_CATB_SENSE3   ((PIN_PA30G_CATB_SENSE3 << 16) | MUX_PA30G_CATB_SENSE3)
-#define GPIO_PA30G_CATB_SENSE3   _UL(1 << 30)
-#define PIN_PC00G_CATB_SENSE3          _L(64) /**< \brief CATB signal: SENSE3 on PC00 mux G */
-#define MUX_PC00G_CATB_SENSE3           _L(6)
+#define GPIO_PA30G_CATB_SENSE3   _UL_(1 << 30)
+#define PIN_PC00G_CATB_SENSE3          _L_(64) /**< \brief CATB signal: SENSE3 on PC00 mux G */
+#define MUX_PC00G_CATB_SENSE3           _L_(6)
 #define PINMUX_PC00G_CATB_SENSE3   ((PIN_PC00G_CATB_SENSE3 << 16) | MUX_PC00G_CATB_SENSE3)
-#define GPIO_PC00G_CATB_SENSE3   _UL(1 <<  0)
-#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
-#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define GPIO_PC00G_CATB_SENSE3   _UL_(1 <<  0)
+#define PIN_PA08G_CATB_SENSE4           _L_(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L_(6)
 #define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
-#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
-#define PIN_PC01G_CATB_SENSE4          _L(65) /**< \brief CATB signal: SENSE4 on PC01 mux G */
-#define MUX_PC01G_CATB_SENSE4           _L(6)
+#define GPIO_PA08G_CATB_SENSE4   _UL_(1 <<  8)
+#define PIN_PC01G_CATB_SENSE4          _L_(65) /**< \brief CATB signal: SENSE4 on PC01 mux G */
+#define MUX_PC01G_CATB_SENSE4           _L_(6)
 #define PINMUX_PC01G_CATB_SENSE4   ((PIN_PC01G_CATB_SENSE4 << 16) | MUX_PC01G_CATB_SENSE4)
-#define GPIO_PC01G_CATB_SENSE4   _UL(1 <<  1)
-#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
-#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define GPIO_PC01G_CATB_SENSE4   _UL_(1 <<  1)
+#define PIN_PA09G_CATB_SENSE5           _L_(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L_(6)
 #define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
-#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
-#define PIN_PC02G_CATB_SENSE5          _L(66) /**< \brief CATB signal: SENSE5 on PC02 mux G */
-#define MUX_PC02G_CATB_SENSE5           _L(6)
+#define GPIO_PA09G_CATB_SENSE5   _UL_(1 <<  9)
+#define PIN_PC02G_CATB_SENSE5          _L_(66) /**< \brief CATB signal: SENSE5 on PC02 mux G */
+#define MUX_PC02G_CATB_SENSE5           _L_(6)
 #define PINMUX_PC02G_CATB_SENSE5   ((PIN_PC02G_CATB_SENSE5 << 16) | MUX_PC02G_CATB_SENSE5)
-#define GPIO_PC02G_CATB_SENSE5   _UL(1 <<  2)
-#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
-#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define GPIO_PC02G_CATB_SENSE5   _UL_(1 <<  2)
+#define PIN_PA10G_CATB_SENSE6          _L_(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L_(6)
 #define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
-#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
-#define PIN_PC03G_CATB_SENSE6          _L(67) /**< \brief CATB signal: SENSE6 on PC03 mux G */
-#define MUX_PC03G_CATB_SENSE6           _L(6)
+#define GPIO_PA10G_CATB_SENSE6   _UL_(1 << 10)
+#define PIN_PC03G_CATB_SENSE6          _L_(67) /**< \brief CATB signal: SENSE6 on PC03 mux G */
+#define MUX_PC03G_CATB_SENSE6           _L_(6)
 #define PINMUX_PC03G_CATB_SENSE6   ((PIN_PC03G_CATB_SENSE6 << 16) | MUX_PC03G_CATB_SENSE6)
-#define GPIO_PC03G_CATB_SENSE6   _UL(1 <<  3)
-#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
-#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define GPIO_PC03G_CATB_SENSE6   _UL_(1 <<  3)
+#define PIN_PA11G_CATB_SENSE7          _L_(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L_(6)
 #define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
-#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
-#define PIN_PC04G_CATB_SENSE7          _L(68) /**< \brief CATB signal: SENSE7 on PC04 mux G */
-#define MUX_PC04G_CATB_SENSE7           _L(6)
+#define GPIO_PA11G_CATB_SENSE7   _UL_(1 << 11)
+#define PIN_PC04G_CATB_SENSE7          _L_(68) /**< \brief CATB signal: SENSE7 on PC04 mux G */
+#define MUX_PC04G_CATB_SENSE7           _L_(6)
 #define PINMUX_PC04G_CATB_SENSE7   ((PIN_PC04G_CATB_SENSE7 << 16) | MUX_PC04G_CATB_SENSE7)
-#define GPIO_PC04G_CATB_SENSE7   _UL(1 <<  4)
-#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
-#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define GPIO_PC04G_CATB_SENSE7   _UL_(1 <<  4)
+#define PIN_PA13G_CATB_SENSE8          _L_(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L_(6)
 #define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
-#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
-#define PIN_PC06G_CATB_SENSE8          _L(70) /**< \brief CATB signal: SENSE8 on PC06 mux G */
-#define MUX_PC06G_CATB_SENSE8           _L(6)
+#define GPIO_PA13G_CATB_SENSE8   _UL_(1 << 13)
+#define PIN_PC06G_CATB_SENSE8          _L_(70) /**< \brief CATB signal: SENSE8 on PC06 mux G */
+#define MUX_PC06G_CATB_SENSE8           _L_(6)
 #define PINMUX_PC06G_CATB_SENSE8   ((PIN_PC06G_CATB_SENSE8 << 16) | MUX_PC06G_CATB_SENSE8)
-#define GPIO_PC06G_CATB_SENSE8   _UL(1 <<  6)
-#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
-#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define GPIO_PC06G_CATB_SENSE8   _UL_(1 <<  6)
+#define PIN_PA14G_CATB_SENSE9          _L_(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L_(6)
 #define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
-#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
-#define PIN_PC07G_CATB_SENSE9          _L(71) /**< \brief CATB signal: SENSE9 on PC07 mux G */
-#define MUX_PC07G_CATB_SENSE9           _L(6)
+#define GPIO_PA14G_CATB_SENSE9   _UL_(1 << 14)
+#define PIN_PC07G_CATB_SENSE9          _L_(71) /**< \brief CATB signal: SENSE9 on PC07 mux G */
+#define MUX_PC07G_CATB_SENSE9           _L_(6)
 #define PINMUX_PC07G_CATB_SENSE9   ((PIN_PC07G_CATB_SENSE9 << 16) | MUX_PC07G_CATB_SENSE9)
-#define GPIO_PC07G_CATB_SENSE9   _UL(1 <<  7)
-#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
-#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define GPIO_PC07G_CATB_SENSE9   _UL_(1 <<  7)
+#define PIN_PA15G_CATB_SENSE10         _L_(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L_(6)
 #define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
-#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
-#define PIN_PC08G_CATB_SENSE10         _L(72) /**< \brief CATB signal: SENSE10 on PC08 mux G */
-#define MUX_PC08G_CATB_SENSE10          _L(6)
+#define GPIO_PA15G_CATB_SENSE10  _UL_(1 << 15)
+#define PIN_PC08G_CATB_SENSE10         _L_(72) /**< \brief CATB signal: SENSE10 on PC08 mux G */
+#define MUX_PC08G_CATB_SENSE10          _L_(6)
 #define PINMUX_PC08G_CATB_SENSE10  ((PIN_PC08G_CATB_SENSE10 << 16) | MUX_PC08G_CATB_SENSE10)
-#define GPIO_PC08G_CATB_SENSE10  _UL(1 <<  8)
-#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
-#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define GPIO_PC08G_CATB_SENSE10  _UL_(1 <<  8)
+#define PIN_PA16G_CATB_SENSE11         _L_(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L_(6)
 #define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
-#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
-#define PIN_PC09G_CATB_SENSE11         _L(73) /**< \brief CATB signal: SENSE11 on PC09 mux G */
-#define MUX_PC09G_CATB_SENSE11          _L(6)
+#define GPIO_PA16G_CATB_SENSE11  _UL_(1 << 16)
+#define PIN_PC09G_CATB_SENSE11         _L_(73) /**< \brief CATB signal: SENSE11 on PC09 mux G */
+#define MUX_PC09G_CATB_SENSE11          _L_(6)
 #define PINMUX_PC09G_CATB_SENSE11  ((PIN_PC09G_CATB_SENSE11 << 16) | MUX_PC09G_CATB_SENSE11)
-#define GPIO_PC09G_CATB_SENSE11  _UL(1 <<  9)
-#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
-#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define GPIO_PC09G_CATB_SENSE11  _UL_(1 <<  9)
+#define PIN_PA17G_CATB_SENSE12         _L_(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L_(6)
 #define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
-#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
-#define PIN_PC10G_CATB_SENSE12         _L(74) /**< \brief CATB signal: SENSE12 on PC10 mux G */
-#define MUX_PC10G_CATB_SENSE12          _L(6)
+#define GPIO_PA17G_CATB_SENSE12  _UL_(1 << 17)
+#define PIN_PC10G_CATB_SENSE12         _L_(74) /**< \brief CATB signal: SENSE12 on PC10 mux G */
+#define MUX_PC10G_CATB_SENSE12          _L_(6)
 #define PINMUX_PC10G_CATB_SENSE12  ((PIN_PC10G_CATB_SENSE12 << 16) | MUX_PC10G_CATB_SENSE12)
-#define GPIO_PC10G_CATB_SENSE12  _UL(1 << 10)
-#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
-#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define GPIO_PC10G_CATB_SENSE12  _UL_(1 << 10)
+#define PIN_PA18G_CATB_SENSE13         _L_(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L_(6)
 #define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
-#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
-#define PIN_PC11G_CATB_SENSE13         _L(75) /**< \brief CATB signal: SENSE13 on PC11 mux G */
-#define MUX_PC11G_CATB_SENSE13          _L(6)
+#define GPIO_PA18G_CATB_SENSE13  _UL_(1 << 18)
+#define PIN_PC11G_CATB_SENSE13         _L_(75) /**< \brief CATB signal: SENSE13 on PC11 mux G */
+#define MUX_PC11G_CATB_SENSE13          _L_(6)
 #define PINMUX_PC11G_CATB_SENSE13  ((PIN_PC11G_CATB_SENSE13 << 16) | MUX_PC11G_CATB_SENSE13)
-#define GPIO_PC11G_CATB_SENSE13  _UL(1 << 11)
-#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
-#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define GPIO_PC11G_CATB_SENSE13  _UL_(1 << 11)
+#define PIN_PA19G_CATB_SENSE14         _L_(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L_(6)
 #define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
-#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
-#define PIN_PC12G_CATB_SENSE14         _L(76) /**< \brief CATB signal: SENSE14 on PC12 mux G */
-#define MUX_PC12G_CATB_SENSE14          _L(6)
+#define GPIO_PA19G_CATB_SENSE14  _UL_(1 << 19)
+#define PIN_PC12G_CATB_SENSE14         _L_(76) /**< \brief CATB signal: SENSE14 on PC12 mux G */
+#define MUX_PC12G_CATB_SENSE14          _L_(6)
 #define PINMUX_PC12G_CATB_SENSE14  ((PIN_PC12G_CATB_SENSE14 << 16) | MUX_PC12G_CATB_SENSE14)
-#define GPIO_PC12G_CATB_SENSE14  _UL(1 << 12)
-#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
-#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define GPIO_PC12G_CATB_SENSE14  _UL_(1 << 12)
+#define PIN_PA20G_CATB_SENSE15         _L_(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L_(6)
 #define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
-#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
-#define PIN_PC13G_CATB_SENSE15         _L(77) /**< \brief CATB signal: SENSE15 on PC13 mux G */
-#define MUX_PC13G_CATB_SENSE15          _L(6)
+#define GPIO_PA20G_CATB_SENSE15  _UL_(1 << 20)
+#define PIN_PC13G_CATB_SENSE15         _L_(77) /**< \brief CATB signal: SENSE15 on PC13 mux G */
+#define MUX_PC13G_CATB_SENSE15          _L_(6)
 #define PINMUX_PC13G_CATB_SENSE15  ((PIN_PC13G_CATB_SENSE15 << 16) | MUX_PC13G_CATB_SENSE15)
-#define GPIO_PC13G_CATB_SENSE15  _UL(1 << 13)
-#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
-#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define GPIO_PC13G_CATB_SENSE15  _UL_(1 << 13)
+#define PIN_PA21G_CATB_SENSE16         _L_(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L_(6)
 #define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
-#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
-#define PIN_PC15G_CATB_SENSE16         _L(79) /**< \brief CATB signal: SENSE16 on PC15 mux G */
-#define MUX_PC15G_CATB_SENSE16          _L(6)
+#define GPIO_PA21G_CATB_SENSE16  _UL_(1 << 21)
+#define PIN_PC15G_CATB_SENSE16         _L_(79) /**< \brief CATB signal: SENSE16 on PC15 mux G */
+#define MUX_PC15G_CATB_SENSE16          _L_(6)
 #define PINMUX_PC15G_CATB_SENSE16  ((PIN_PC15G_CATB_SENSE16 << 16) | MUX_PC15G_CATB_SENSE16)
-#define GPIO_PC15G_CATB_SENSE16  _UL(1 << 15)
-#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
-#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define GPIO_PC15G_CATB_SENSE16  _UL_(1 << 15)
+#define PIN_PA22G_CATB_SENSE17         _L_(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L_(6)
 #define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
-#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
-#define PIN_PC16G_CATB_SENSE17         _L(80) /**< \brief CATB signal: SENSE17 on PC16 mux G */
-#define MUX_PC16G_CATB_SENSE17          _L(6)
+#define GPIO_PA22G_CATB_SENSE17  _UL_(1 << 22)
+#define PIN_PC16G_CATB_SENSE17         _L_(80) /**< \brief CATB signal: SENSE17 on PC16 mux G */
+#define MUX_PC16G_CATB_SENSE17          _L_(6)
 #define PINMUX_PC16G_CATB_SENSE17  ((PIN_PC16G_CATB_SENSE17 << 16) | MUX_PC16G_CATB_SENSE17)
-#define GPIO_PC16G_CATB_SENSE17  _UL(1 << 16)
-#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
-#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define GPIO_PC16G_CATB_SENSE17  _UL_(1 << 16)
+#define PIN_PA24G_CATB_SENSE18         _L_(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L_(6)
 #define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
-#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
-#define PIN_PC17G_CATB_SENSE18         _L(81) /**< \brief CATB signal: SENSE18 on PC17 mux G */
-#define MUX_PC17G_CATB_SENSE18          _L(6)
+#define GPIO_PA24G_CATB_SENSE18  _UL_(1 << 24)
+#define PIN_PC17G_CATB_SENSE18         _L_(81) /**< \brief CATB signal: SENSE18 on PC17 mux G */
+#define MUX_PC17G_CATB_SENSE18          _L_(6)
 #define PINMUX_PC17G_CATB_SENSE18  ((PIN_PC17G_CATB_SENSE18 << 16) | MUX_PC17G_CATB_SENSE18)
-#define GPIO_PC17G_CATB_SENSE18  _UL(1 << 17)
-#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
-#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define GPIO_PC17G_CATB_SENSE18  _UL_(1 << 17)
+#define PIN_PA25G_CATB_SENSE19         _L_(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L_(6)
 #define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
-#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
-#define PIN_PC18G_CATB_SENSE19         _L(82) /**< \brief CATB signal: SENSE19 on PC18 mux G */
-#define MUX_PC18G_CATB_SENSE19          _L(6)
+#define GPIO_PA25G_CATB_SENSE19  _UL_(1 << 25)
+#define PIN_PC18G_CATB_SENSE19         _L_(82) /**< \brief CATB signal: SENSE19 on PC18 mux G */
+#define MUX_PC18G_CATB_SENSE19          _L_(6)
 #define PINMUX_PC18G_CATB_SENSE19  ((PIN_PC18G_CATB_SENSE19 << 16) | MUX_PC18G_CATB_SENSE19)
-#define GPIO_PC18G_CATB_SENSE19  _UL(1 << 18)
-#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
-#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define GPIO_PC18G_CATB_SENSE19  _UL_(1 << 18)
+#define PIN_PA26G_CATB_SENSE20         _L_(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L_(6)
 #define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
-#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
-#define PIN_PC19G_CATB_SENSE20         _L(83) /**< \brief CATB signal: SENSE20 on PC19 mux G */
-#define MUX_PC19G_CATB_SENSE20          _L(6)
+#define GPIO_PA26G_CATB_SENSE20  _UL_(1 << 26)
+#define PIN_PC19G_CATB_SENSE20         _L_(83) /**< \brief CATB signal: SENSE20 on PC19 mux G */
+#define MUX_PC19G_CATB_SENSE20          _L_(6)
 #define PINMUX_PC19G_CATB_SENSE20  ((PIN_PC19G_CATB_SENSE20 << 16) | MUX_PC19G_CATB_SENSE20)
-#define GPIO_PC19G_CATB_SENSE20  _UL(1 << 19)
-#define PIN_PB00G_CATB_SENSE21         _L(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
-#define MUX_PB00G_CATB_SENSE21          _L(6)
+#define GPIO_PC19G_CATB_SENSE20  _UL_(1 << 19)
+#define PIN_PB00G_CATB_SENSE21         _L_(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
+#define MUX_PB00G_CATB_SENSE21          _L_(6)
 #define PINMUX_PB00G_CATB_SENSE21  ((PIN_PB00G_CATB_SENSE21 << 16) | MUX_PB00G_CATB_SENSE21)
-#define GPIO_PB00G_CATB_SENSE21  _UL(1 <<  0)
-#define PIN_PC20G_CATB_SENSE21         _L(84) /**< \brief CATB signal: SENSE21 on PC20 mux G */
-#define MUX_PC20G_CATB_SENSE21          _L(6)
+#define GPIO_PB00G_CATB_SENSE21  _UL_(1 <<  0)
+#define PIN_PC20G_CATB_SENSE21         _L_(84) /**< \brief CATB signal: SENSE21 on PC20 mux G */
+#define MUX_PC20G_CATB_SENSE21          _L_(6)
 #define PINMUX_PC20G_CATB_SENSE21  ((PIN_PC20G_CATB_SENSE21 << 16) | MUX_PC20G_CATB_SENSE21)
-#define GPIO_PC20G_CATB_SENSE21  _UL(1 << 20)
-#define PIN_PB01G_CATB_SENSE22         _L(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
-#define MUX_PB01G_CATB_SENSE22          _L(6)
+#define GPIO_PC20G_CATB_SENSE21  _UL_(1 << 20)
+#define PIN_PB01G_CATB_SENSE22         _L_(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
+#define MUX_PB01G_CATB_SENSE22          _L_(6)
 #define PINMUX_PB01G_CATB_SENSE22  ((PIN_PB01G_CATB_SENSE22 << 16) | MUX_PB01G_CATB_SENSE22)
-#define GPIO_PB01G_CATB_SENSE22  _UL(1 <<  1)
-#define PIN_PC21G_CATB_SENSE22         _L(85) /**< \brief CATB signal: SENSE22 on PC21 mux G */
-#define MUX_PC21G_CATB_SENSE22          _L(6)
+#define GPIO_PB01G_CATB_SENSE22  _UL_(1 <<  1)
+#define PIN_PC21G_CATB_SENSE22         _L_(85) /**< \brief CATB signal: SENSE22 on PC21 mux G */
+#define MUX_PC21G_CATB_SENSE22          _L_(6)
 #define PINMUX_PC21G_CATB_SENSE22  ((PIN_PC21G_CATB_SENSE22 << 16) | MUX_PC21G_CATB_SENSE22)
-#define GPIO_PC21G_CATB_SENSE22  _UL(1 << 21)
-#define PIN_PB02G_CATB_SENSE23         _L(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
-#define MUX_PB02G_CATB_SENSE23          _L(6)
+#define GPIO_PC21G_CATB_SENSE22  _UL_(1 << 21)
+#define PIN_PB02G_CATB_SENSE23         _L_(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
+#define MUX_PB02G_CATB_SENSE23          _L_(6)
 #define PINMUX_PB02G_CATB_SENSE23  ((PIN_PB02G_CATB_SENSE23 << 16) | MUX_PB02G_CATB_SENSE23)
-#define GPIO_PB02G_CATB_SENSE23  _UL(1 <<  2)
-#define PIN_PC22G_CATB_SENSE23         _L(86) /**< \brief CATB signal: SENSE23 on PC22 mux G */
-#define MUX_PC22G_CATB_SENSE23          _L(6)
+#define GPIO_PB02G_CATB_SENSE23  _UL_(1 <<  2)
+#define PIN_PC22G_CATB_SENSE23         _L_(86) /**< \brief CATB signal: SENSE23 on PC22 mux G */
+#define MUX_PC22G_CATB_SENSE23          _L_(6)
 #define PINMUX_PC22G_CATB_SENSE23  ((PIN_PC22G_CATB_SENSE23 << 16) | MUX_PC22G_CATB_SENSE23)
-#define GPIO_PC22G_CATB_SENSE23  _UL(1 << 22)
-#define PIN_PB04G_CATB_SENSE24         _L(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
-#define MUX_PB04G_CATB_SENSE24          _L(6)
+#define GPIO_PC22G_CATB_SENSE23  _UL_(1 << 22)
+#define PIN_PB04G_CATB_SENSE24         _L_(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
+#define MUX_PB04G_CATB_SENSE24          _L_(6)
 #define PINMUX_PB04G_CATB_SENSE24  ((PIN_PB04G_CATB_SENSE24 << 16) | MUX_PB04G_CATB_SENSE24)
-#define GPIO_PB04G_CATB_SENSE24  _UL(1 <<  4)
-#define PIN_PC24G_CATB_SENSE24         _L(88) /**< \brief CATB signal: SENSE24 on PC24 mux G */
-#define MUX_PC24G_CATB_SENSE24          _L(6)
+#define GPIO_PB04G_CATB_SENSE24  _UL_(1 <<  4)
+#define PIN_PC24G_CATB_SENSE24         _L_(88) /**< \brief CATB signal: SENSE24 on PC24 mux G */
+#define MUX_PC24G_CATB_SENSE24          _L_(6)
 #define PINMUX_PC24G_CATB_SENSE24  ((PIN_PC24G_CATB_SENSE24 << 16) | MUX_PC24G_CATB_SENSE24)
-#define GPIO_PC24G_CATB_SENSE24  _UL(1 << 24)
-#define PIN_PB05G_CATB_SENSE25         _L(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
-#define MUX_PB05G_CATB_SENSE25          _L(6)
+#define GPIO_PC24G_CATB_SENSE24  _UL_(1 << 24)
+#define PIN_PB05G_CATB_SENSE25         _L_(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
+#define MUX_PB05G_CATB_SENSE25          _L_(6)
 #define PINMUX_PB05G_CATB_SENSE25  ((PIN_PB05G_CATB_SENSE25 << 16) | MUX_PB05G_CATB_SENSE25)
-#define GPIO_PB05G_CATB_SENSE25  _UL(1 <<  5)
-#define PIN_PC25G_CATB_SENSE25         _L(89) /**< \brief CATB signal: SENSE25 on PC25 mux G */
-#define MUX_PC25G_CATB_SENSE25          _L(6)
+#define GPIO_PB05G_CATB_SENSE25  _UL_(1 <<  5)
+#define PIN_PC25G_CATB_SENSE25         _L_(89) /**< \brief CATB signal: SENSE25 on PC25 mux G */
+#define MUX_PC25G_CATB_SENSE25          _L_(6)
 #define PINMUX_PC25G_CATB_SENSE25  ((PIN_PC25G_CATB_SENSE25 << 16) | MUX_PC25G_CATB_SENSE25)
-#define GPIO_PC25G_CATB_SENSE25  _UL(1 << 25)
-#define PIN_PB06G_CATB_SENSE26         _L(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
-#define MUX_PB06G_CATB_SENSE26          _L(6)
+#define GPIO_PC25G_CATB_SENSE25  _UL_(1 << 25)
+#define PIN_PB06G_CATB_SENSE26         _L_(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
+#define MUX_PB06G_CATB_SENSE26          _L_(6)
 #define PINMUX_PB06G_CATB_SENSE26  ((PIN_PB06G_CATB_SENSE26 << 16) | MUX_PB06G_CATB_SENSE26)
-#define GPIO_PB06G_CATB_SENSE26  _UL(1 <<  6)
-#define PIN_PC26G_CATB_SENSE26         _L(90) /**< \brief CATB signal: SENSE26 on PC26 mux G */
-#define MUX_PC26G_CATB_SENSE26          _L(6)
+#define GPIO_PB06G_CATB_SENSE26  _UL_(1 <<  6)
+#define PIN_PC26G_CATB_SENSE26         _L_(90) /**< \brief CATB signal: SENSE26 on PC26 mux G */
+#define MUX_PC26G_CATB_SENSE26          _L_(6)
 #define PINMUX_PC26G_CATB_SENSE26  ((PIN_PC26G_CATB_SENSE26 << 16) | MUX_PC26G_CATB_SENSE26)
-#define GPIO_PC26G_CATB_SENSE26  _UL(1 << 26)
-#define PIN_PB07G_CATB_SENSE27         _L(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
-#define MUX_PB07G_CATB_SENSE27          _L(6)
+#define GPIO_PC26G_CATB_SENSE26  _UL_(1 << 26)
+#define PIN_PB07G_CATB_SENSE27         _L_(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
+#define MUX_PB07G_CATB_SENSE27          _L_(6)
 #define PINMUX_PB07G_CATB_SENSE27  ((PIN_PB07G_CATB_SENSE27 << 16) | MUX_PB07G_CATB_SENSE27)
-#define GPIO_PB07G_CATB_SENSE27  _UL(1 <<  7)
-#define PIN_PC27G_CATB_SENSE27         _L(91) /**< \brief CATB signal: SENSE27 on PC27 mux G */
-#define MUX_PC27G_CATB_SENSE27          _L(6)
+#define GPIO_PB07G_CATB_SENSE27  _UL_(1 <<  7)
+#define PIN_PC27G_CATB_SENSE27         _L_(91) /**< \brief CATB signal: SENSE27 on PC27 mux G */
+#define MUX_PC27G_CATB_SENSE27          _L_(6)
 #define PINMUX_PC27G_CATB_SENSE27  ((PIN_PC27G_CATB_SENSE27 << 16) | MUX_PC27G_CATB_SENSE27)
-#define GPIO_PC27G_CATB_SENSE27  _UL(1 << 27)
-#define PIN_PB08G_CATB_SENSE28         _L(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
-#define MUX_PB08G_CATB_SENSE28          _L(6)
+#define GPIO_PC27G_CATB_SENSE27  _UL_(1 << 27)
+#define PIN_PB08G_CATB_SENSE28         _L_(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
+#define MUX_PB08G_CATB_SENSE28          _L_(6)
 #define PINMUX_PB08G_CATB_SENSE28  ((PIN_PB08G_CATB_SENSE28 << 16) | MUX_PB08G_CATB_SENSE28)
-#define GPIO_PB08G_CATB_SENSE28  _UL(1 <<  8)
-#define PIN_PC28G_CATB_SENSE28         _L(92) /**< \brief CATB signal: SENSE28 on PC28 mux G */
-#define MUX_PC28G_CATB_SENSE28          _L(6)
+#define GPIO_PB08G_CATB_SENSE28  _UL_(1 <<  8)
+#define PIN_PC28G_CATB_SENSE28         _L_(92) /**< \brief CATB signal: SENSE28 on PC28 mux G */
+#define MUX_PC28G_CATB_SENSE28          _L_(6)
 #define PINMUX_PC28G_CATB_SENSE28  ((PIN_PC28G_CATB_SENSE28 << 16) | MUX_PC28G_CATB_SENSE28)
-#define GPIO_PC28G_CATB_SENSE28  _UL(1 << 28)
-#define PIN_PB09G_CATB_SENSE29         _L(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
-#define MUX_PB09G_CATB_SENSE29          _L(6)
+#define GPIO_PC28G_CATB_SENSE28  _UL_(1 << 28)
+#define PIN_PB09G_CATB_SENSE29         _L_(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
+#define MUX_PB09G_CATB_SENSE29          _L_(6)
 #define PINMUX_PB09G_CATB_SENSE29  ((PIN_PB09G_CATB_SENSE29 << 16) | MUX_PB09G_CATB_SENSE29)
-#define GPIO_PB09G_CATB_SENSE29  _UL(1 <<  9)
-#define PIN_PC29G_CATB_SENSE29         _L(93) /**< \brief CATB signal: SENSE29 on PC29 mux G */
-#define MUX_PC29G_CATB_SENSE29          _L(6)
+#define GPIO_PB09G_CATB_SENSE29  _UL_(1 <<  9)
+#define PIN_PC29G_CATB_SENSE29         _L_(93) /**< \brief CATB signal: SENSE29 on PC29 mux G */
+#define MUX_PC29G_CATB_SENSE29          _L_(6)
 #define PINMUX_PC29G_CATB_SENSE29  ((PIN_PC29G_CATB_SENSE29 << 16) | MUX_PC29G_CATB_SENSE29)
-#define GPIO_PC29G_CATB_SENSE29  _UL(1 << 29)
-#define PIN_PB10G_CATB_SENSE30         _L(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
-#define MUX_PB10G_CATB_SENSE30          _L(6)
+#define GPIO_PC29G_CATB_SENSE29  _UL_(1 << 29)
+#define PIN_PB10G_CATB_SENSE30         _L_(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
+#define MUX_PB10G_CATB_SENSE30          _L_(6)
 #define PINMUX_PB10G_CATB_SENSE30  ((PIN_PB10G_CATB_SENSE30 << 16) | MUX_PB10G_CATB_SENSE30)
-#define GPIO_PB10G_CATB_SENSE30  _UL(1 << 10)
-#define PIN_PC30G_CATB_SENSE30         _L(94) /**< \brief CATB signal: SENSE30 on PC30 mux G */
-#define MUX_PC30G_CATB_SENSE30          _L(6)
+#define GPIO_PB10G_CATB_SENSE30  _UL_(1 << 10)
+#define PIN_PC30G_CATB_SENSE30         _L_(94) /**< \brief CATB signal: SENSE30 on PC30 mux G */
+#define MUX_PC30G_CATB_SENSE30          _L_(6)
 #define PINMUX_PC30G_CATB_SENSE30  ((PIN_PC30G_CATB_SENSE30 << 16) | MUX_PC30G_CATB_SENSE30)
-#define GPIO_PC30G_CATB_SENSE30  _UL(1 << 30)
-#define PIN_PB11G_CATB_SENSE31         _L(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
-#define MUX_PB11G_CATB_SENSE31          _L(6)
+#define GPIO_PC30G_CATB_SENSE30  _UL_(1 << 30)
+#define PIN_PB11G_CATB_SENSE31         _L_(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
+#define MUX_PB11G_CATB_SENSE31          _L_(6)
 #define PINMUX_PB11G_CATB_SENSE31  ((PIN_PB11G_CATB_SENSE31 << 16) | MUX_PB11G_CATB_SENSE31)
-#define GPIO_PB11G_CATB_SENSE31  _UL(1 << 11)
-#define PIN_PC31G_CATB_SENSE31         _L(95) /**< \brief CATB signal: SENSE31 on PC31 mux G */
-#define MUX_PC31G_CATB_SENSE31          _L(6)
+#define GPIO_PB11G_CATB_SENSE31  _UL_(1 << 11)
+#define PIN_PC31G_CATB_SENSE31         _L_(95) /**< \brief CATB signal: SENSE31 on PC31 mux G */
+#define MUX_PC31G_CATB_SENSE31          _L_(6)
 #define PINMUX_PC31G_CATB_SENSE31  ((PIN_PC31G_CATB_SENSE31 << 16) | MUX_PC31G_CATB_SENSE31)
-#define GPIO_PC31G_CATB_SENSE31  _UL(1 << 31)
+#define GPIO_PC31G_CATB_SENSE31  _UL_(1 << 31)
 /* ========== GPIO definition for USBC peripheral ========== */
-#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
-#define MUX_PA25A_USBC_DM               _L(0)
+#define PIN_PA25A_USBC_DM              _L_(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L_(0)
 #define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
-#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
-#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
-#define MUX_PA26A_USBC_DP               _L(0)
+#define GPIO_PA25A_USBC_DM       _UL_(1 << 25)
+#define PIN_PA26A_USBC_DP              _L_(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L_(0)
 #define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
-#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+#define GPIO_PA26A_USBC_DP       _UL_(1 << 26)
 /* ========== GPIO definition for PEVC peripheral ========== */
-#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
-#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PIN_PA08C_PEVC_PAD_EVT0         _L_(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
-#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
-#define PIN_PB12C_PEVC_PAD_EVT0        _L(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
-#define MUX_PB12C_PEVC_PAD_EVT0         _L(2)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL_(1 <<  8)
+#define PIN_PB12C_PEVC_PAD_EVT0        _L_(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
+#define MUX_PB12C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PB12C_PEVC_PAD_EVT0  ((PIN_PB12C_PEVC_PAD_EVT0 << 16) | MUX_PB12C_PEVC_PAD_EVT0)
-#define GPIO_PB12C_PEVC_PAD_EVT0  _UL(1 << 12)
-#define PIN_PC07C_PEVC_PAD_EVT0        _L(71) /**< \brief PEVC signal: PAD_EVT0 on PC07 mux C */
-#define MUX_PC07C_PEVC_PAD_EVT0         _L(2)
+#define GPIO_PB12C_PEVC_PAD_EVT0  _UL_(1 << 12)
+#define PIN_PC07C_PEVC_PAD_EVT0        _L_(71) /**< \brief PEVC signal: PAD_EVT0 on PC07 mux C */
+#define MUX_PC07C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PC07C_PEVC_PAD_EVT0  ((PIN_PC07C_PEVC_PAD_EVT0 << 16) | MUX_PC07C_PEVC_PAD_EVT0)
-#define GPIO_PC07C_PEVC_PAD_EVT0  _UL(1 <<  7)
-#define PIN_PC24C_PEVC_PAD_EVT0        _L(88) /**< \brief PEVC signal: PAD_EVT0 on PC24 mux C */
-#define MUX_PC24C_PEVC_PAD_EVT0         _L(2)
+#define GPIO_PC07C_PEVC_PAD_EVT0  _UL_(1 <<  7)
+#define PIN_PC24C_PEVC_PAD_EVT0        _L_(88) /**< \brief PEVC signal: PAD_EVT0 on PC24 mux C */
+#define MUX_PC24C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PC24C_PEVC_PAD_EVT0  ((PIN_PC24C_PEVC_PAD_EVT0 << 16) | MUX_PC24C_PEVC_PAD_EVT0)
-#define GPIO_PC24C_PEVC_PAD_EVT0  _UL(1 << 24)
-#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
-#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PC24C_PEVC_PAD_EVT0  _UL_(1 << 24)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L_(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
-#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
-#define PIN_PB13C_PEVC_PAD_EVT1        _L(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
-#define MUX_PB13C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL_(1 <<  9)
+#define PIN_PB13C_PEVC_PAD_EVT1        _L_(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
+#define MUX_PB13C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PB13C_PEVC_PAD_EVT1  ((PIN_PB13C_PEVC_PAD_EVT1 << 16) | MUX_PB13C_PEVC_PAD_EVT1)
-#define GPIO_PB13C_PEVC_PAD_EVT1  _UL(1 << 13)
-#define PIN_PC08C_PEVC_PAD_EVT1        _L(72) /**< \brief PEVC signal: PAD_EVT1 on PC08 mux C */
-#define MUX_PC08C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PB13C_PEVC_PAD_EVT1  _UL_(1 << 13)
+#define PIN_PC08C_PEVC_PAD_EVT1        _L_(72) /**< \brief PEVC signal: PAD_EVT1 on PC08 mux C */
+#define MUX_PC08C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PC08C_PEVC_PAD_EVT1  ((PIN_PC08C_PEVC_PAD_EVT1 << 16) | MUX_PC08C_PEVC_PAD_EVT1)
-#define GPIO_PC08C_PEVC_PAD_EVT1  _UL(1 <<  8)
-#define PIN_PC25C_PEVC_PAD_EVT1        _L(89) /**< \brief PEVC signal: PAD_EVT1 on PC25 mux C */
-#define MUX_PC25C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PC08C_PEVC_PAD_EVT1  _UL_(1 <<  8)
+#define PIN_PC25C_PEVC_PAD_EVT1        _L_(89) /**< \brief PEVC signal: PAD_EVT1 on PC25 mux C */
+#define MUX_PC25C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PC25C_PEVC_PAD_EVT1  ((PIN_PC25C_PEVC_PAD_EVT1 << 16) | MUX_PC25C_PEVC_PAD_EVT1)
-#define GPIO_PC25C_PEVC_PAD_EVT1  _UL(1 << 25)
-#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
-#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PC25C_PEVC_PAD_EVT1  _UL_(1 << 25)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L_(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
-#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
-#define PIN_PC11C_PEVC_PAD_EVT2        _L(75) /**< \brief PEVC signal: PAD_EVT2 on PC11 mux C */
-#define MUX_PC11C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL_(1 << 10)
+#define PIN_PC11C_PEVC_PAD_EVT2        _L_(75) /**< \brief PEVC signal: PAD_EVT2 on PC11 mux C */
+#define MUX_PC11C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PC11C_PEVC_PAD_EVT2  ((PIN_PC11C_PEVC_PAD_EVT2 << 16) | MUX_PC11C_PEVC_PAD_EVT2)
-#define GPIO_PC11C_PEVC_PAD_EVT2  _UL(1 << 11)
-#define PIN_PC26C_PEVC_PAD_EVT2        _L(90) /**< \brief PEVC signal: PAD_EVT2 on PC26 mux C */
-#define MUX_PC26C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PC11C_PEVC_PAD_EVT2  _UL_(1 << 11)
+#define PIN_PC26C_PEVC_PAD_EVT2        _L_(90) /**< \brief PEVC signal: PAD_EVT2 on PC26 mux C */
+#define MUX_PC26C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PC26C_PEVC_PAD_EVT2  ((PIN_PC26C_PEVC_PAD_EVT2 << 16) | MUX_PC26C_PEVC_PAD_EVT2)
-#define GPIO_PC26C_PEVC_PAD_EVT2  _UL(1 << 26)
-#define PIN_PB09B_PEVC_PAD_EVT2        _L(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
-#define MUX_PB09B_PEVC_PAD_EVT2         _L(1)
+#define GPIO_PC26C_PEVC_PAD_EVT2  _UL_(1 << 26)
+#define PIN_PB09B_PEVC_PAD_EVT2        _L_(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
+#define MUX_PB09B_PEVC_PAD_EVT2         _L_(1)
 #define PINMUX_PB09B_PEVC_PAD_EVT2  ((PIN_PB09B_PEVC_PAD_EVT2 << 16) | MUX_PB09B_PEVC_PAD_EVT2)
-#define GPIO_PB09B_PEVC_PAD_EVT2  _UL(1 <<  9)
-#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
-#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define GPIO_PB09B_PEVC_PAD_EVT2  _UL_(1 <<  9)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L_(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L_(2)
 #define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
-#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
-#define PIN_PC27C_PEVC_PAD_EVT3        _L(91) /**< \brief PEVC signal: PAD_EVT3 on PC27 mux C */
-#define MUX_PC27C_PEVC_PAD_EVT3         _L(2)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL_(1 << 11)
+#define PIN_PC27C_PEVC_PAD_EVT3        _L_(91) /**< \brief PEVC signal: PAD_EVT3 on PC27 mux C */
+#define MUX_PC27C_PEVC_PAD_EVT3         _L_(2)
 #define PINMUX_PC27C_PEVC_PAD_EVT3  ((PIN_PC27C_PEVC_PAD_EVT3 << 16) | MUX_PC27C_PEVC_PAD_EVT3)
-#define GPIO_PC27C_PEVC_PAD_EVT3  _UL(1 << 27)
-#define PIN_PB10B_PEVC_PAD_EVT3        _L(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
-#define MUX_PB10B_PEVC_PAD_EVT3         _L(1)
+#define GPIO_PC27C_PEVC_PAD_EVT3  _UL_(1 << 27)
+#define PIN_PB10B_PEVC_PAD_EVT3        _L_(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
+#define MUX_PB10B_PEVC_PAD_EVT3         _L_(1)
 #define PINMUX_PB10B_PEVC_PAD_EVT3  ((PIN_PB10B_PEVC_PAD_EVT3 << 16) | MUX_PB10B_PEVC_PAD_EVT3)
-#define GPIO_PB10B_PEVC_PAD_EVT3  _UL(1 << 10)
+#define GPIO_PB10B_PEVC_PAD_EVT3  _UL_(1 << 10)
 /* ========== GPIO definition for SCIF peripheral ========== */
-#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
-#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PIN_PA19E_SCIF_GCLK0           _L_(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
-#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
-#define PIN_PB10E_SCIF_GCLK0           _L(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
-#define MUX_PB10E_SCIF_GCLK0            _L(4)
+#define GPIO_PA19E_SCIF_GCLK0    _UL_(1 << 19)
+#define PIN_PB10E_SCIF_GCLK0           _L_(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
+#define MUX_PB10E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PB10E_SCIF_GCLK0    ((PIN_PB10E_SCIF_GCLK0 << 16) | MUX_PB10E_SCIF_GCLK0)
-#define GPIO_PB10E_SCIF_GCLK0    _UL(1 << 10)
-#define PIN_PC26E_SCIF_GCLK0           _L(90) /**< \brief SCIF signal: GCLK0 on PC26 mux E */
-#define MUX_PC26E_SCIF_GCLK0            _L(4)
+#define GPIO_PB10E_SCIF_GCLK0    _UL_(1 << 10)
+#define PIN_PC26E_SCIF_GCLK0           _L_(90) /**< \brief SCIF signal: GCLK0 on PC26 mux E */
+#define MUX_PC26E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PC26E_SCIF_GCLK0    ((PIN_PC26E_SCIF_GCLK0 << 16) | MUX_PC26E_SCIF_GCLK0)
-#define GPIO_PC26E_SCIF_GCLK0    _UL(1 << 26)
-#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
-#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define GPIO_PC26E_SCIF_GCLK0    _UL_(1 << 26)
+#define PIN_PA02A_SCIF_GCLK0            _L_(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L_(0)
 #define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
-#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
-#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
-#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define GPIO_PA02A_SCIF_GCLK0    _UL_(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L_(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
-#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
-#define PIN_PB11E_SCIF_GCLK1           _L(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
-#define MUX_PB11E_SCIF_GCLK1            _L(4)
+#define GPIO_PA20E_SCIF_GCLK1    _UL_(1 << 20)
+#define PIN_PB11E_SCIF_GCLK1           _L_(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
+#define MUX_PB11E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PB11E_SCIF_GCLK1    ((PIN_PB11E_SCIF_GCLK1 << 16) | MUX_PB11E_SCIF_GCLK1)
-#define GPIO_PB11E_SCIF_GCLK1    _UL(1 << 11)
-#define PIN_PC27E_SCIF_GCLK1           _L(91) /**< \brief SCIF signal: GCLK1 on PC27 mux E */
-#define MUX_PC27E_SCIF_GCLK1            _L(4)
+#define GPIO_PB11E_SCIF_GCLK1    _UL_(1 << 11)
+#define PIN_PC27E_SCIF_GCLK1           _L_(91) /**< \brief SCIF signal: GCLK1 on PC27 mux E */
+#define MUX_PC27E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PC27E_SCIF_GCLK1    ((PIN_PC27E_SCIF_GCLK1 << 16) | MUX_PC27E_SCIF_GCLK1)
-#define GPIO_PC27E_SCIF_GCLK1    _UL(1 << 27)
-#define PIN_PB12E_SCIF_GCLK2           _L(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
-#define MUX_PB12E_SCIF_GCLK2            _L(4)
+#define GPIO_PC27E_SCIF_GCLK1    _UL_(1 << 27)
+#define PIN_PB12E_SCIF_GCLK2           _L_(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
+#define MUX_PB12E_SCIF_GCLK2            _L_(4)
 #define PINMUX_PB12E_SCIF_GCLK2    ((PIN_PB12E_SCIF_GCLK2 << 16) | MUX_PB12E_SCIF_GCLK2)
-#define GPIO_PB12E_SCIF_GCLK2    _UL(1 << 12)
-#define PIN_PC28E_SCIF_GCLK2           _L(92) /**< \brief SCIF signal: GCLK2 on PC28 mux E */
-#define MUX_PC28E_SCIF_GCLK2            _L(4)
+#define GPIO_PB12E_SCIF_GCLK2    _UL_(1 << 12)
+#define PIN_PC28E_SCIF_GCLK2           _L_(92) /**< \brief SCIF signal: GCLK2 on PC28 mux E */
+#define MUX_PC28E_SCIF_GCLK2            _L_(4)
 #define PINMUX_PC28E_SCIF_GCLK2    ((PIN_PC28E_SCIF_GCLK2 << 16) | MUX_PC28E_SCIF_GCLK2)
-#define GPIO_PC28E_SCIF_GCLK2    _UL(1 << 28)
-#define PIN_PB13E_SCIF_GCLK3           _L(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
-#define MUX_PB13E_SCIF_GCLK3            _L(4)
+#define GPIO_PC28E_SCIF_GCLK2    _UL_(1 << 28)
+#define PIN_PB13E_SCIF_GCLK3           _L_(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
+#define MUX_PB13E_SCIF_GCLK3            _L_(4)
 #define PINMUX_PB13E_SCIF_GCLK3    ((PIN_PB13E_SCIF_GCLK3 << 16) | MUX_PB13E_SCIF_GCLK3)
-#define GPIO_PB13E_SCIF_GCLK3    _UL(1 << 13)
-#define PIN_PC29E_SCIF_GCLK3           _L(93) /**< \brief SCIF signal: GCLK3 on PC29 mux E */
-#define MUX_PC29E_SCIF_GCLK3            _L(4)
+#define GPIO_PB13E_SCIF_GCLK3    _UL_(1 << 13)
+#define PIN_PC29E_SCIF_GCLK3           _L_(93) /**< \brief SCIF signal: GCLK3 on PC29 mux E */
+#define MUX_PC29E_SCIF_GCLK3            _L_(4)
 #define PINMUX_PC29E_SCIF_GCLK3    ((PIN_PC29E_SCIF_GCLK3 << 16) | MUX_PC29E_SCIF_GCLK3)
-#define GPIO_PC29E_SCIF_GCLK3    _UL(1 << 29)
-#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
-#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PC29E_SCIF_GCLK3    _UL_(1 << 29)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L_(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
-#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
-#define PIN_PB14E_SCIF_GCLK_IN0        _L(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
-#define MUX_PB14E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL_(1 << 23)
+#define PIN_PB14E_SCIF_GCLK_IN0        _L_(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
+#define MUX_PB14E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PB14E_SCIF_GCLK_IN0  ((PIN_PB14E_SCIF_GCLK_IN0 << 16) | MUX_PB14E_SCIF_GCLK_IN0)
-#define GPIO_PB14E_SCIF_GCLK_IN0  _UL(1 << 14)
-#define PIN_PC30E_SCIF_GCLK_IN0        _L(94) /**< \brief SCIF signal: GCLK_IN0 on PC30 mux E */
-#define MUX_PC30E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PB14E_SCIF_GCLK_IN0  _UL_(1 << 14)
+#define PIN_PC30E_SCIF_GCLK_IN0        _L_(94) /**< \brief SCIF signal: GCLK_IN0 on PC30 mux E */
+#define MUX_PC30E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PC30E_SCIF_GCLK_IN0  ((PIN_PC30E_SCIF_GCLK_IN0 << 16) | MUX_PC30E_SCIF_GCLK_IN0)
-#define GPIO_PC30E_SCIF_GCLK_IN0  _UL(1 << 30)
-#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
-#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PC30E_SCIF_GCLK_IN0  _UL_(1 << 30)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L_(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
-#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
-#define PIN_PB15E_SCIF_GCLK_IN1        _L(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
-#define MUX_PB15E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL_(1 << 24)
+#define PIN_PB15E_SCIF_GCLK_IN1        _L_(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
+#define MUX_PB15E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PB15E_SCIF_GCLK_IN1  ((PIN_PB15E_SCIF_GCLK_IN1 << 16) | MUX_PB15E_SCIF_GCLK_IN1)
-#define GPIO_PB15E_SCIF_GCLK_IN1  _UL(1 << 15)
-#define PIN_PC31E_SCIF_GCLK_IN1        _L(95) /**< \brief SCIF signal: GCLK_IN1 on PC31 mux E */
-#define MUX_PC31E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PB15E_SCIF_GCLK_IN1  _UL_(1 << 15)
+#define PIN_PC31E_SCIF_GCLK_IN1        _L_(95) /**< \brief SCIF signal: GCLK_IN1 on PC31 mux E */
+#define MUX_PC31E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PC31E_SCIF_GCLK_IN1  ((PIN_PC31E_SCIF_GCLK_IN1 << 16) | MUX_PC31E_SCIF_GCLK_IN1)
-#define GPIO_PC31E_SCIF_GCLK_IN1  _UL(1 << 31)
+#define GPIO_PC31E_SCIF_GCLK_IN1  _UL_(1 << 31)
 /* ========== GPIO definition for EIC peripheral ========== */
-#define PIN_PB01C_EIC_EXTINT0          _L(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
-#define MUX_PB01C_EIC_EXTINT0           _L(2)
+#define PIN_PB01C_EIC_EXTINT0          _L_(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
+#define MUX_PB01C_EIC_EXTINT0           _L_(2)
 #define PINMUX_PB01C_EIC_EXTINT0   ((PIN_PB01C_EIC_EXTINT0 << 16) | MUX_PB01C_EIC_EXTINT0)
-#define GPIO_PB01C_EIC_EXTINT0   _UL(1 <<  1)
-#define PIN_PB01C_EIC_EXTINT_NUM        _L(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
-#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
-#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define GPIO_PB01C_EIC_EXTINT0   _UL_(1 <<  1)
+#define PIN_PB01C_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PA06C_EIC_EXTINT1           _L_(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
-#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
-#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
-#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
-#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define GPIO_PA06C_EIC_EXTINT1   _UL_(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L_(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
-#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
-#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
-#define PIN_PC24B_EIC_EXTINT1          _L(88) /**< \brief EIC signal: EXTINT1 on PC24 mux B */
-#define MUX_PC24B_EIC_EXTINT1           _L(1)
+#define GPIO_PA16C_EIC_EXTINT1   _UL_(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PC24B_EIC_EXTINT1          _L_(88) /**< \brief EIC signal: EXTINT1 on PC24 mux B */
+#define MUX_PC24B_EIC_EXTINT1           _L_(1)
 #define PINMUX_PC24B_EIC_EXTINT1   ((PIN_PC24B_EIC_EXTINT1 << 16) | MUX_PC24B_EIC_EXTINT1)
-#define GPIO_PC24B_EIC_EXTINT1   _UL(1 << 24)
-#define PIN_PC24B_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PC24 External Interrupt Line */
-#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
-#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define GPIO_PC24B_EIC_EXTINT1   _UL_(1 << 24)
+#define PIN_PC24B_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PC24 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L_(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
-#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
-#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
-#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
-#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL_(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L_(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
-#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
-#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
-#define PIN_PC25B_EIC_EXTINT2          _L(89) /**< \brief EIC signal: EXTINT2 on PC25 mux B */
-#define MUX_PC25B_EIC_EXTINT2           _L(1)
+#define GPIO_PA17C_EIC_EXTINT2   _UL_(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PC25B_EIC_EXTINT2          _L_(89) /**< \brief EIC signal: EXTINT2 on PC25 mux B */
+#define MUX_PC25B_EIC_EXTINT2           _L_(1)
 #define PINMUX_PC25B_EIC_EXTINT2   ((PIN_PC25B_EIC_EXTINT2 << 16) | MUX_PC25B_EIC_EXTINT2)
-#define GPIO_PC25B_EIC_EXTINT2   _UL(1 << 25)
-#define PIN_PC25B_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PC25 External Interrupt Line */
-#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
-#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define GPIO_PC25B_EIC_EXTINT2   _UL_(1 << 25)
+#define PIN_PC25B_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PC25 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L_(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
-#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
-#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
-#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
-#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define GPIO_PA05C_EIC_EXTINT3   _UL_(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L_(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
-#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
-#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
-#define PIN_PC26B_EIC_EXTINT3          _L(90) /**< \brief EIC signal: EXTINT3 on PC26 mux B */
-#define MUX_PC26B_EIC_EXTINT3           _L(1)
+#define GPIO_PA18C_EIC_EXTINT3   _UL_(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PC26B_EIC_EXTINT3          _L_(90) /**< \brief EIC signal: EXTINT3 on PC26 mux B */
+#define MUX_PC26B_EIC_EXTINT3           _L_(1)
 #define PINMUX_PC26B_EIC_EXTINT3   ((PIN_PC26B_EIC_EXTINT3 << 16) | MUX_PC26B_EIC_EXTINT3)
-#define GPIO_PC26B_EIC_EXTINT3   _UL(1 << 26)
-#define PIN_PC26B_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PC26 External Interrupt Line */
-#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
-#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define GPIO_PC26B_EIC_EXTINT3   _UL_(1 << 26)
+#define PIN_PC26B_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PC26 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L_(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
-#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
-#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
-#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
-#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define GPIO_PA07C_EIC_EXTINT4   _UL_(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L_(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
-#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
-#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
-#define PIN_PC27B_EIC_EXTINT4          _L(91) /**< \brief EIC signal: EXTINT4 on PC27 mux B */
-#define MUX_PC27B_EIC_EXTINT4           _L(1)
+#define GPIO_PA19C_EIC_EXTINT4   _UL_(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PC27B_EIC_EXTINT4          _L_(91) /**< \brief EIC signal: EXTINT4 on PC27 mux B */
+#define MUX_PC27B_EIC_EXTINT4           _L_(1)
 #define PINMUX_PC27B_EIC_EXTINT4   ((PIN_PC27B_EIC_EXTINT4 << 16) | MUX_PC27B_EIC_EXTINT4)
-#define GPIO_PC27B_EIC_EXTINT4   _UL(1 << 27)
-#define PIN_PC27B_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PC27 External Interrupt Line */
-#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
-#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define GPIO_PC27B_EIC_EXTINT4   _UL_(1 << 27)
+#define PIN_PC27B_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PC27 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L_(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L_(2)
 #define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
-#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
-#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
-#define PIN_PC03B_EIC_EXTINT5          _L(67) /**< \brief EIC signal: EXTINT5 on PC03 mux B */
-#define MUX_PC03B_EIC_EXTINT5           _L(1)
+#define GPIO_PA20C_EIC_EXTINT5   _UL_(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PC03B_EIC_EXTINT5          _L_(67) /**< \brief EIC signal: EXTINT5 on PC03 mux B */
+#define MUX_PC03B_EIC_EXTINT5           _L_(1)
 #define PINMUX_PC03B_EIC_EXTINT5   ((PIN_PC03B_EIC_EXTINT5 << 16) | MUX_PC03B_EIC_EXTINT5)
-#define GPIO_PC03B_EIC_EXTINT5   _UL(1 <<  3)
-#define PIN_PC03B_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PC03 External Interrupt Line */
-#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
-#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define GPIO_PC03B_EIC_EXTINT5   _UL_(1 <<  3)
+#define PIN_PC03B_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PC03 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L_(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L_(2)
 #define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
-#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
-#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
-#define PIN_PC04B_EIC_EXTINT6          _L(68) /**< \brief EIC signal: EXTINT6 on PC04 mux B */
-#define MUX_PC04B_EIC_EXTINT6           _L(1)
+#define GPIO_PA21C_EIC_EXTINT6   _UL_(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PC04B_EIC_EXTINT6          _L_(68) /**< \brief EIC signal: EXTINT6 on PC04 mux B */
+#define MUX_PC04B_EIC_EXTINT6           _L_(1)
 #define PINMUX_PC04B_EIC_EXTINT6   ((PIN_PC04B_EIC_EXTINT6 << 16) | MUX_PC04B_EIC_EXTINT6)
-#define GPIO_PC04B_EIC_EXTINT6   _UL(1 <<  4)
-#define PIN_PC04B_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PC04 External Interrupt Line */
-#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
-#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define GPIO_PC04B_EIC_EXTINT6   _UL_(1 <<  4)
+#define PIN_PC04B_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PC04 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L_(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L_(2)
 #define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
-#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
-#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
-#define PIN_PC05B_EIC_EXTINT7          _L(69) /**< \brief EIC signal: EXTINT7 on PC05 mux B */
-#define MUX_PC05B_EIC_EXTINT7           _L(1)
+#define GPIO_PA22C_EIC_EXTINT7   _UL_(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PC05B_EIC_EXTINT7          _L_(69) /**< \brief EIC signal: EXTINT7 on PC05 mux B */
+#define MUX_PC05B_EIC_EXTINT7           _L_(1)
 #define PINMUX_PC05B_EIC_EXTINT7   ((PIN_PC05B_EIC_EXTINT7 << 16) | MUX_PC05B_EIC_EXTINT7)
-#define GPIO_PC05B_EIC_EXTINT7   _UL(1 <<  5)
-#define PIN_PC05B_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PC05 External Interrupt Line */
-#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
-#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define GPIO_PC05B_EIC_EXTINT7   _UL_(1 <<  5)
+#define PIN_PC05B_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PC05 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L_(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L_(2)
 #define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
-#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
-#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
-#define PIN_PC06B_EIC_EXTINT8          _L(70) /**< \brief EIC signal: EXTINT8 on PC06 mux B */
-#define MUX_PC06B_EIC_EXTINT8           _L(1)
+#define GPIO_PA23C_EIC_EXTINT8   _UL_(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PC06B_EIC_EXTINT8          _L_(70) /**< \brief EIC signal: EXTINT8 on PC06 mux B */
+#define MUX_PC06B_EIC_EXTINT8           _L_(1)
 #define PINMUX_PC06B_EIC_EXTINT8   ((PIN_PC06B_EIC_EXTINT8 << 16) | MUX_PC06B_EIC_EXTINT8)
-#define GPIO_PC06B_EIC_EXTINT8   _UL(1 <<  6)
-#define PIN_PC06B_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PC06 External Interrupt Line */
+#define GPIO_PC06B_EIC_EXTINT8   _UL_(1 <<  6)
+#define PIN_PC06B_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PC06 External Interrupt Line */
 
 #endif /* _SAM4LS4C_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4ls4c.h
+++ b/asf/sam/include/sam4l/pio/sam4ls4c.h
@@ -1,0 +1,1757 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAM4LS4C
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LS4C_PIO_
+#define _SAM4LS4C_PIO_
+
+#define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
+#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
+#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
+#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
+#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
+#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
+#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
+#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
+#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
+#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
+#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
+#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
+#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
+#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
+#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
+#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
+#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
+#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
+#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
+#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
+#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
+#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
+#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
+#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
+#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
+#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
+#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
+#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
+#define GPIO_PA27                _UL(1 << 27) /**< \brief GPIO Mask  for PA27 */
+#define PIN_PA28                          28  /**< \brief Pin Number for PA28 */
+#define GPIO_PA28                _UL(1 << 28) /**< \brief GPIO Mask  for PA28 */
+#define PIN_PA29                          29  /**< \brief Pin Number for PA29 */
+#define GPIO_PA29                _UL(1 << 29) /**< \brief GPIO Mask  for PA29 */
+#define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
+#define GPIO_PA30                _UL(1 << 30) /**< \brief GPIO Mask  for PA30 */
+#define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
+#define GPIO_PA31                _UL(1 << 31) /**< \brief GPIO Mask  for PA31 */
+#define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
+#define GPIO_PB00                _UL(1 <<  0) /**< \brief GPIO Mask  for PB00 */
+#define PIN_PB01                          33  /**< \brief Pin Number for PB01 */
+#define GPIO_PB01                _UL(1 <<  1) /**< \brief GPIO Mask  for PB01 */
+#define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
+#define GPIO_PB02                _UL(1 <<  2) /**< \brief GPIO Mask  for PB02 */
+#define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
+#define GPIO_PB03                _UL(1 <<  3) /**< \brief GPIO Mask  for PB03 */
+#define PIN_PB04                          36  /**< \brief Pin Number for PB04 */
+#define GPIO_PB04                _UL(1 <<  4) /**< \brief GPIO Mask  for PB04 */
+#define PIN_PB05                          37  /**< \brief Pin Number for PB05 */
+#define GPIO_PB05                _UL(1 <<  5) /**< \brief GPIO Mask  for PB05 */
+#define PIN_PB06                          38  /**< \brief Pin Number for PB06 */
+#define GPIO_PB06                _UL(1 <<  6) /**< \brief GPIO Mask  for PB06 */
+#define PIN_PB07                          39  /**< \brief Pin Number for PB07 */
+#define GPIO_PB07                _UL(1 <<  7) /**< \brief GPIO Mask  for PB07 */
+#define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
+#define GPIO_PB08                _UL(1 <<  8) /**< \brief GPIO Mask  for PB08 */
+#define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
+#define GPIO_PB09                _UL(1 <<  9) /**< \brief GPIO Mask  for PB09 */
+#define PIN_PB10                          42  /**< \brief Pin Number for PB10 */
+#define GPIO_PB10                _UL(1 << 10) /**< \brief GPIO Mask  for PB10 */
+#define PIN_PB11                          43  /**< \brief Pin Number for PB11 */
+#define GPIO_PB11                _UL(1 << 11) /**< \brief GPIO Mask  for PB11 */
+#define PIN_PB12                          44  /**< \brief Pin Number for PB12 */
+#define GPIO_PB12                _UL(1 << 12) /**< \brief GPIO Mask  for PB12 */
+#define PIN_PB13                          45  /**< \brief Pin Number for PB13 */
+#define GPIO_PB13                _UL(1 << 13) /**< \brief GPIO Mask  for PB13 */
+#define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
+#define GPIO_PB14                _UL(1 << 14) /**< \brief GPIO Mask  for PB14 */
+#define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
+#define GPIO_PB15                _UL(1 << 15) /**< \brief GPIO Mask  for PB15 */
+#define PIN_PC00                          64  /**< \brief Pin Number for PC00 */
+#define GPIO_PC00                _UL(1 <<  0) /**< \brief GPIO Mask  for PC00 */
+#define PIN_PC01                          65  /**< \brief Pin Number for PC01 */
+#define GPIO_PC01                _UL(1 <<  1) /**< \brief GPIO Mask  for PC01 */
+#define PIN_PC02                          66  /**< \brief Pin Number for PC02 */
+#define GPIO_PC02                _UL(1 <<  2) /**< \brief GPIO Mask  for PC02 */
+#define PIN_PC03                          67  /**< \brief Pin Number for PC03 */
+#define GPIO_PC03                _UL(1 <<  3) /**< \brief GPIO Mask  for PC03 */
+#define PIN_PC04                          68  /**< \brief Pin Number for PC04 */
+#define GPIO_PC04                _UL(1 <<  4) /**< \brief GPIO Mask  for PC04 */
+#define PIN_PC05                          69  /**< \brief Pin Number for PC05 */
+#define GPIO_PC05                _UL(1 <<  5) /**< \brief GPIO Mask  for PC05 */
+#define PIN_PC06                          70  /**< \brief Pin Number for PC06 */
+#define GPIO_PC06                _UL(1 <<  6) /**< \brief GPIO Mask  for PC06 */
+#define PIN_PC07                          71  /**< \brief Pin Number for PC07 */
+#define GPIO_PC07                _UL(1 <<  7) /**< \brief GPIO Mask  for PC07 */
+#define PIN_PC08                          72  /**< \brief Pin Number for PC08 */
+#define GPIO_PC08                _UL(1 <<  8) /**< \brief GPIO Mask  for PC08 */
+#define PIN_PC09                          73  /**< \brief Pin Number for PC09 */
+#define GPIO_PC09                _UL(1 <<  9) /**< \brief GPIO Mask  for PC09 */
+#define PIN_PC10                          74  /**< \brief Pin Number for PC10 */
+#define GPIO_PC10                _UL(1 << 10) /**< \brief GPIO Mask  for PC10 */
+#define PIN_PC11                          75  /**< \brief Pin Number for PC11 */
+#define GPIO_PC11                _UL(1 << 11) /**< \brief GPIO Mask  for PC11 */
+#define PIN_PC12                          76  /**< \brief Pin Number for PC12 */
+#define GPIO_PC12                _UL(1 << 12) /**< \brief GPIO Mask  for PC12 */
+#define PIN_PC13                          77  /**< \brief Pin Number for PC13 */
+#define GPIO_PC13                _UL(1 << 13) /**< \brief GPIO Mask  for PC13 */
+#define PIN_PC14                          78  /**< \brief Pin Number for PC14 */
+#define GPIO_PC14                _UL(1 << 14) /**< \brief GPIO Mask  for PC14 */
+#define PIN_PC15                          79  /**< \brief Pin Number for PC15 */
+#define GPIO_PC15                _UL(1 << 15) /**< \brief GPIO Mask  for PC15 */
+#define PIN_PC16                          80  /**< \brief Pin Number for PC16 */
+#define GPIO_PC16                _UL(1 << 16) /**< \brief GPIO Mask  for PC16 */
+#define PIN_PC17                          81  /**< \brief Pin Number for PC17 */
+#define GPIO_PC17                _UL(1 << 17) /**< \brief GPIO Mask  for PC17 */
+#define PIN_PC18                          82  /**< \brief Pin Number for PC18 */
+#define GPIO_PC18                _UL(1 << 18) /**< \brief GPIO Mask  for PC18 */
+#define PIN_PC19                          83  /**< \brief Pin Number for PC19 */
+#define GPIO_PC19                _UL(1 << 19) /**< \brief GPIO Mask  for PC19 */
+#define PIN_PC20                          84  /**< \brief Pin Number for PC20 */
+#define GPIO_PC20                _UL(1 << 20) /**< \brief GPIO Mask  for PC20 */
+#define PIN_PC21                          85  /**< \brief Pin Number for PC21 */
+#define GPIO_PC21                _UL(1 << 21) /**< \brief GPIO Mask  for PC21 */
+#define PIN_PC22                          86  /**< \brief Pin Number for PC22 */
+#define GPIO_PC22                _UL(1 << 22) /**< \brief GPIO Mask  for PC22 */
+#define PIN_PC23                          87  /**< \brief Pin Number for PC23 */
+#define GPIO_PC23                _UL(1 << 23) /**< \brief GPIO Mask  for PC23 */
+#define PIN_PC24                          88  /**< \brief Pin Number for PC24 */
+#define GPIO_PC24                _UL(1 << 24) /**< \brief GPIO Mask  for PC24 */
+#define PIN_PC25                          89  /**< \brief Pin Number for PC25 */
+#define GPIO_PC25                _UL(1 << 25) /**< \brief GPIO Mask  for PC25 */
+#define PIN_PC26                          90  /**< \brief Pin Number for PC26 */
+#define GPIO_PC26                _UL(1 << 26) /**< \brief GPIO Mask  for PC26 */
+#define PIN_PC27                          91  /**< \brief Pin Number for PC27 */
+#define GPIO_PC27                _UL(1 << 27) /**< \brief GPIO Mask  for PC27 */
+#define PIN_PC28                          92  /**< \brief Pin Number for PC28 */
+#define GPIO_PC28                _UL(1 << 28) /**< \brief GPIO Mask  for PC28 */
+#define PIN_PC29                          93  /**< \brief Pin Number for PC29 */
+#define GPIO_PC29                _UL(1 << 29) /**< \brief GPIO Mask  for PC29 */
+#define PIN_PC30                          94  /**< \brief Pin Number for PC30 */
+#define GPIO_PC30                _UL(1 << 30) /**< \brief GPIO Mask  for PC30 */
+#define PIN_PC31                          95  /**< \brief Pin Number for PC31 */
+#define GPIO_PC31                _UL(1 << 31) /**< \brief GPIO Mask  for PC31 */
+/* ========== GPIO definition for TWIMS0 peripheral ========== */
+#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
+#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+/* ========== GPIO definition for TWIMS1 peripheral ========== */
+#define PIN_PB01A_TWIMS1_TWCK          _L(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
+#define MUX_PB01A_TWIMS1_TWCK           _L(0)
+#define PINMUX_PB01A_TWIMS1_TWCK   ((PIN_PB01A_TWIMS1_TWCK << 16) | MUX_PB01A_TWIMS1_TWCK)
+#define GPIO_PB01A_TWIMS1_TWCK   _UL(1 <<  1)
+#define PIN_PB00A_TWIMS1_TWD           _L(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
+#define MUX_PB00A_TWIMS1_TWD            _L(0)
+#define PINMUX_PB00A_TWIMS1_TWD    ((PIN_PB00A_TWIMS1_TWD << 16) | MUX_PB00A_TWIMS1_TWD)
+#define GPIO_PB00A_TWIMS1_TWD    _UL(1 <<  0)
+/* ========== GPIO definition for TWIMS2 peripheral ========== */
+#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
+#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+/* ========== GPIO definition for TWIMS3 peripheral ========== */
+#define PIN_PB15C_TWIMS3_TWCK          _L(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
+#define MUX_PB15C_TWIMS3_TWCK           _L(2)
+#define PINMUX_PB15C_TWIMS3_TWCK   ((PIN_PB15C_TWIMS3_TWCK << 16) | MUX_PB15C_TWIMS3_TWCK)
+#define GPIO_PB15C_TWIMS3_TWCK   _UL(1 << 15)
+#define PIN_PB14C_TWIMS3_TWD           _L(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
+#define MUX_PB14C_TWIMS3_TWD            _L(2)
+#define PINMUX_PB14C_TWIMS3_TWD    ((PIN_PB14C_TWIMS3_TWD << 16) | MUX_PB14C_TWIMS3_TWD)
+#define GPIO_PB14C_TWIMS3_TWD    _UL(1 << 14)
+/* ========== GPIO definition for IISC peripheral ========== */
+#define PIN_PB05D_IISC_IMCK            _L(37) /**< \brief IISC signal: IMCK on PB05 mux D */
+#define MUX_PB05D_IISC_IMCK             _L(3)
+#define PINMUX_PB05D_IISC_IMCK     ((PIN_PB05D_IISC_IMCK << 16) | MUX_PB05D_IISC_IMCK)
+#define GPIO_PB05D_IISC_IMCK     _UL(1 <<  5)
+#define PIN_PC14D_IISC_IMCK            _L(78) /**< \brief IISC signal: IMCK on PC14 mux D */
+#define MUX_PC14D_IISC_IMCK             _L(3)
+#define PINMUX_PC14D_IISC_IMCK     ((PIN_PC14D_IISC_IMCK << 16) | MUX_PC14D_IISC_IMCK)
+#define GPIO_PC14D_IISC_IMCK     _UL(1 << 14)
+#define PIN_PA31B_IISC_IMCK            _L(31) /**< \brief IISC signal: IMCK on PA31 mux B */
+#define MUX_PA31B_IISC_IMCK             _L(1)
+#define PINMUX_PA31B_IISC_IMCK     ((PIN_PA31B_IISC_IMCK << 16) | MUX_PA31B_IISC_IMCK)
+#define GPIO_PA31B_IISC_IMCK     _UL(1 << 31)
+#define PIN_PB02D_IISC_ISCK            _L(34) /**< \brief IISC signal: ISCK on PB02 mux D */
+#define MUX_PB02D_IISC_ISCK             _L(3)
+#define PINMUX_PB02D_IISC_ISCK     ((PIN_PB02D_IISC_ISCK << 16) | MUX_PB02D_IISC_ISCK)
+#define GPIO_PB02D_IISC_ISCK     _UL(1 <<  2)
+#define PIN_PC09D_IISC_ISCK            _L(73) /**< \brief IISC signal: ISCK on PC09 mux D */
+#define MUX_PC09D_IISC_ISCK             _L(3)
+#define PINMUX_PC09D_IISC_ISCK     ((PIN_PC09D_IISC_ISCK << 16) | MUX_PC09D_IISC_ISCK)
+#define GPIO_PC09D_IISC_ISCK     _UL(1 <<  9)
+#define PIN_PA27B_IISC_ISCK            _L(27) /**< \brief IISC signal: ISCK on PA27 mux B */
+#define MUX_PA27B_IISC_ISCK             _L(1)
+#define PINMUX_PA27B_IISC_ISCK     ((PIN_PA27B_IISC_ISCK << 16) | MUX_PA27B_IISC_ISCK)
+#define GPIO_PA27B_IISC_ISCK     _UL(1 << 27)
+#define PIN_PB03D_IISC_ISDI            _L(35) /**< \brief IISC signal: ISDI on PB03 mux D */
+#define MUX_PB03D_IISC_ISDI             _L(3)
+#define PINMUX_PB03D_IISC_ISDI     ((PIN_PB03D_IISC_ISDI << 16) | MUX_PB03D_IISC_ISDI)
+#define GPIO_PB03D_IISC_ISDI     _UL(1 <<  3)
+#define PIN_PC10D_IISC_ISDI            _L(74) /**< \brief IISC signal: ISDI on PC10 mux D */
+#define MUX_PC10D_IISC_ISDI             _L(3)
+#define PINMUX_PC10D_IISC_ISDI     ((PIN_PC10D_IISC_ISDI << 16) | MUX_PC10D_IISC_ISDI)
+#define GPIO_PC10D_IISC_ISDI     _UL(1 << 10)
+#define PIN_PA28B_IISC_ISDI            _L(28) /**< \brief IISC signal: ISDI on PA28 mux B */
+#define MUX_PA28B_IISC_ISDI             _L(1)
+#define PINMUX_PA28B_IISC_ISDI     ((PIN_PA28B_IISC_ISDI << 16) | MUX_PA28B_IISC_ISDI)
+#define GPIO_PA28B_IISC_ISDI     _UL(1 << 28)
+#define PIN_PB04D_IISC_ISDO            _L(36) /**< \brief IISC signal: ISDO on PB04 mux D */
+#define MUX_PB04D_IISC_ISDO             _L(3)
+#define PINMUX_PB04D_IISC_ISDO     ((PIN_PB04D_IISC_ISDO << 16) | MUX_PB04D_IISC_ISDO)
+#define GPIO_PB04D_IISC_ISDO     _UL(1 <<  4)
+#define PIN_PC13D_IISC_ISDO            _L(77) /**< \brief IISC signal: ISDO on PC13 mux D */
+#define MUX_PC13D_IISC_ISDO             _L(3)
+#define PINMUX_PC13D_IISC_ISDO     ((PIN_PC13D_IISC_ISDO << 16) | MUX_PC13D_IISC_ISDO)
+#define GPIO_PC13D_IISC_ISDO     _UL(1 << 13)
+#define PIN_PA30B_IISC_ISDO            _L(30) /**< \brief IISC signal: ISDO on PA30 mux B */
+#define MUX_PA30B_IISC_ISDO             _L(1)
+#define PINMUX_PA30B_IISC_ISDO     ((PIN_PA30B_IISC_ISDO << 16) | MUX_PA30B_IISC_ISDO)
+#define GPIO_PA30B_IISC_ISDO     _UL(1 << 30)
+#define PIN_PB06D_IISC_IWS             _L(38) /**< \brief IISC signal: IWS on PB06 mux D */
+#define MUX_PB06D_IISC_IWS              _L(3)
+#define PINMUX_PB06D_IISC_IWS      ((PIN_PB06D_IISC_IWS << 16) | MUX_PB06D_IISC_IWS)
+#define GPIO_PB06D_IISC_IWS      _UL(1 <<  6)
+#define PIN_PC12D_IISC_IWS             _L(76) /**< \brief IISC signal: IWS on PC12 mux D */
+#define MUX_PC12D_IISC_IWS              _L(3)
+#define PINMUX_PC12D_IISC_IWS      ((PIN_PC12D_IISC_IWS << 16) | MUX_PC12D_IISC_IWS)
+#define GPIO_PC12D_IISC_IWS      _UL(1 << 12)
+#define PIN_PA29B_IISC_IWS             _L(29) /**< \brief IISC signal: IWS on PA29 mux B */
+#define MUX_PA29B_IISC_IWS              _L(1)
+#define PINMUX_PA29B_IISC_IWS      ((PIN_PA29B_IISC_IWS << 16) | MUX_PA29B_IISC_IWS)
+#define GPIO_PA29B_IISC_IWS      _UL(1 << 29)
+/* ========== GPIO definition for SPI peripheral ========== */
+#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L(1)
+#define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
+#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
+#define PIN_PB14B_SPI_MISO             _L(46) /**< \brief SPI signal: MISO on PB14 mux B */
+#define MUX_PB14B_SPI_MISO              _L(1)
+#define PINMUX_PB14B_SPI_MISO      ((PIN_PB14B_SPI_MISO << 16) | MUX_PB14B_SPI_MISO)
+#define GPIO_PB14B_SPI_MISO      _UL(1 << 14)
+#define PIN_PC28B_SPI_MISO             _L(92) /**< \brief SPI signal: MISO on PC28 mux B */
+#define MUX_PC28B_SPI_MISO              _L(1)
+#define PINMUX_PC28B_SPI_MISO      ((PIN_PC28B_SPI_MISO << 16) | MUX_PC28B_SPI_MISO)
+#define GPIO_PC28B_SPI_MISO      _UL(1 << 28)
+#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L(0)
+#define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
+#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
+#define PIN_PA27A_SPI_MISO             _L(27) /**< \brief SPI signal: MISO on PA27 mux A */
+#define MUX_PA27A_SPI_MISO              _L(0)
+#define PINMUX_PA27A_SPI_MISO      ((PIN_PA27A_SPI_MISO << 16) | MUX_PA27A_SPI_MISO)
+#define GPIO_PA27A_SPI_MISO      _UL(1 << 27)
+#define PIN_PC04A_SPI_MISO             _L(68) /**< \brief SPI signal: MISO on PC04 mux A */
+#define MUX_PC04A_SPI_MISO              _L(0)
+#define PINMUX_PC04A_SPI_MISO      ((PIN_PC04A_SPI_MISO << 16) | MUX_PC04A_SPI_MISO)
+#define GPIO_PC04A_SPI_MISO      _UL(1 <<  4)
+#define PIN_PB15B_SPI_MOSI             _L(47) /**< \brief SPI signal: MOSI on PB15 mux B */
+#define MUX_PB15B_SPI_MOSI              _L(1)
+#define PINMUX_PB15B_SPI_MOSI      ((PIN_PB15B_SPI_MOSI << 16) | MUX_PB15B_SPI_MOSI)
+#define GPIO_PB15B_SPI_MOSI      _UL(1 << 15)
+#define PIN_PC29B_SPI_MOSI             _L(93) /**< \brief SPI signal: MOSI on PC29 mux B */
+#define MUX_PC29B_SPI_MOSI              _L(1)
+#define PINMUX_PC29B_SPI_MOSI      ((PIN_PC29B_SPI_MOSI << 16) | MUX_PC29B_SPI_MOSI)
+#define GPIO_PC29B_SPI_MOSI      _UL(1 << 29)
+#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L(0)
+#define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
+#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
+#define PIN_PA28A_SPI_MOSI             _L(28) /**< \brief SPI signal: MOSI on PA28 mux A */
+#define MUX_PA28A_SPI_MOSI              _L(0)
+#define PINMUX_PA28A_SPI_MOSI      ((PIN_PA28A_SPI_MOSI << 16) | MUX_PA28A_SPI_MOSI)
+#define GPIO_PA28A_SPI_MOSI      _UL(1 << 28)
+#define PIN_PC05A_SPI_MOSI             _L(69) /**< \brief SPI signal: MOSI on PC05 mux A */
+#define MUX_PC05A_SPI_MOSI              _L(0)
+#define PINMUX_PC05A_SPI_MOSI      ((PIN_PC05A_SPI_MOSI << 16) | MUX_PC05A_SPI_MOSI)
+#define GPIO_PC05A_SPI_MOSI      _UL(1 <<  5)
+#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
+#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
+#define PIN_PC31B_SPI_NPCS0            _L(95) /**< \brief SPI signal: NPCS0 on PC31 mux B */
+#define MUX_PC31B_SPI_NPCS0             _L(1)
+#define PINMUX_PC31B_SPI_NPCS0     ((PIN_PC31B_SPI_NPCS0 << 16) | MUX_PC31B_SPI_NPCS0)
+#define GPIO_PC31B_SPI_NPCS0     _UL(1 << 31)
+#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
+#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
+#define PIN_PA30A_SPI_NPCS0            _L(30) /**< \brief SPI signal: NPCS0 on PA30 mux A */
+#define MUX_PA30A_SPI_NPCS0             _L(0)
+#define PINMUX_PA30A_SPI_NPCS0     ((PIN_PA30A_SPI_NPCS0 << 16) | MUX_PA30A_SPI_NPCS0)
+#define GPIO_PA30A_SPI_NPCS0     _UL(1 << 30)
+#define PIN_PC03A_SPI_NPCS0            _L(67) /**< \brief SPI signal: NPCS0 on PC03 mux A */
+#define MUX_PC03A_SPI_NPCS0             _L(0)
+#define PINMUX_PC03A_SPI_NPCS0     ((PIN_PC03A_SPI_NPCS0 << 16) | MUX_PC03A_SPI_NPCS0)
+#define GPIO_PC03A_SPI_NPCS0     _UL(1 <<  3)
+#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
+#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PB13B_SPI_NPCS1            _L(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
+#define MUX_PB13B_SPI_NPCS1             _L(1)
+#define PINMUX_PB13B_SPI_NPCS1     ((PIN_PB13B_SPI_NPCS1 << 16) | MUX_PB13B_SPI_NPCS1)
+#define GPIO_PB13B_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PA31A_SPI_NPCS1            _L(31) /**< \brief SPI signal: NPCS1 on PA31 mux A */
+#define MUX_PA31A_SPI_NPCS1             _L(0)
+#define PINMUX_PA31A_SPI_NPCS1     ((PIN_PA31A_SPI_NPCS1 << 16) | MUX_PA31A_SPI_NPCS1)
+#define GPIO_PA31A_SPI_NPCS1     _UL(1 << 31)
+#define PIN_PC02A_SPI_NPCS1            _L(66) /**< \brief SPI signal: NPCS1 on PC02 mux A */
+#define MUX_PC02A_SPI_NPCS1             _L(0)
+#define PINMUX_PC02A_SPI_NPCS1     ((PIN_PC02A_SPI_NPCS1 << 16) | MUX_PC02A_SPI_NPCS1)
+#define GPIO_PC02A_SPI_NPCS1     _UL(1 <<  2)
+#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
+#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
+#define PIN_PB11B_SPI_NPCS2            _L(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
+#define MUX_PB11B_SPI_NPCS2             _L(1)
+#define PINMUX_PB11B_SPI_NPCS2     ((PIN_PB11B_SPI_NPCS2 << 16) | MUX_PB11B_SPI_NPCS2)
+#define GPIO_PB11B_SPI_NPCS2     _UL(1 << 11)
+#define PIN_PC00A_SPI_NPCS2            _L(64) /**< \brief SPI signal: NPCS2 on PC00 mux A */
+#define MUX_PC00A_SPI_NPCS2             _L(0)
+#define PINMUX_PC00A_SPI_NPCS2     ((PIN_PC00A_SPI_NPCS2 << 16) | MUX_PC00A_SPI_NPCS2)
+#define GPIO_PC00A_SPI_NPCS2     _UL(1 <<  0)
+#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
+#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
+#define PIN_PB12B_SPI_NPCS3            _L(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
+#define MUX_PB12B_SPI_NPCS3             _L(1)
+#define PINMUX_PB12B_SPI_NPCS3     ((PIN_PB12B_SPI_NPCS3 << 16) | MUX_PB12B_SPI_NPCS3)
+#define GPIO_PB12B_SPI_NPCS3     _UL(1 << 12)
+#define PIN_PC01A_SPI_NPCS3            _L(65) /**< \brief SPI signal: NPCS3 on PC01 mux A */
+#define MUX_PC01A_SPI_NPCS3             _L(0)
+#define PINMUX_PC01A_SPI_NPCS3     ((PIN_PC01A_SPI_NPCS3 << 16) | MUX_PC01A_SPI_NPCS3)
+#define GPIO_PC01A_SPI_NPCS3     _UL(1 <<  1)
+#define PIN_PC30B_SPI_SCK              _L(94) /**< \brief SPI signal: SCK on PC30 mux B */
+#define MUX_PC30B_SPI_SCK               _L(1)
+#define PINMUX_PC30B_SPI_SCK       ((PIN_PC30B_SPI_SCK << 16) | MUX_PC30B_SPI_SCK)
+#define GPIO_PC30B_SPI_SCK       _UL(1 << 30)
+#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L(0)
+#define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
+#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
+#define PIN_PA29A_SPI_SCK              _L(29) /**< \brief SPI signal: SCK on PA29 mux A */
+#define MUX_PA29A_SPI_SCK               _L(0)
+#define PINMUX_PA29A_SPI_SCK       ((PIN_PA29A_SPI_SCK << 16) | MUX_PA29A_SPI_SCK)
+#define GPIO_PA29A_SPI_SCK       _UL(1 << 29)
+#define PIN_PC06A_SPI_SCK              _L(70) /**< \brief SPI signal: SCK on PC06 mux A */
+#define MUX_PC06A_SPI_SCK               _L(0)
+#define PINMUX_PC06A_SPI_SCK       ((PIN_PC06A_SPI_SCK << 16) | MUX_PC06A_SPI_SCK)
+#define GPIO_PC06A_SPI_SCK       _UL(1 <<  6)
+/* ========== GPIO definition for TC0 peripheral ========== */
+#define PIN_PB07D_TC0_A0               _L(39) /**< \brief TC0 signal: A0 on PB07 mux D */
+#define MUX_PB07D_TC0_A0                _L(3)
+#define PINMUX_PB07D_TC0_A0        ((PIN_PB07D_TC0_A0 << 16) | MUX_PB07D_TC0_A0)
+#define GPIO_PB07D_TC0_A0        _UL(1 <<  7)
+#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L(1)
+#define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
+#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
+#define PIN_PB09D_TC0_A1               _L(41) /**< \brief TC0 signal: A1 on PB09 mux D */
+#define MUX_PB09D_TC0_A1                _L(3)
+#define PINMUX_PB09D_TC0_A1        ((PIN_PB09D_TC0_A1 << 16) | MUX_PB09D_TC0_A1)
+#define GPIO_PB09D_TC0_A1        _UL(1 <<  9)
+#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L(1)
+#define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
+#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
+#define PIN_PB11D_TC0_A2               _L(43) /**< \brief TC0 signal: A2 on PB11 mux D */
+#define MUX_PB11D_TC0_A2                _L(3)
+#define PINMUX_PB11D_TC0_A2        ((PIN_PB11D_TC0_A2 << 16) | MUX_PB11D_TC0_A2)
+#define GPIO_PB11D_TC0_A2        _UL(1 << 11)
+#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L(1)
+#define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
+#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
+#define PIN_PB08D_TC0_B0               _L(40) /**< \brief TC0 signal: B0 on PB08 mux D */
+#define MUX_PB08D_TC0_B0                _L(3)
+#define PINMUX_PB08D_TC0_B0        ((PIN_PB08D_TC0_B0 << 16) | MUX_PB08D_TC0_B0)
+#define GPIO_PB08D_TC0_B0        _UL(1 <<  8)
+#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L(1)
+#define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
+#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
+#define PIN_PB10D_TC0_B1               _L(42) /**< \brief TC0 signal: B1 on PB10 mux D */
+#define MUX_PB10D_TC0_B1                _L(3)
+#define PINMUX_PB10D_TC0_B1        ((PIN_PB10D_TC0_B1 << 16) | MUX_PB10D_TC0_B1)
+#define GPIO_PB10D_TC0_B1        _UL(1 << 10)
+#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L(1)
+#define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
+#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
+#define PIN_PB12D_TC0_B2               _L(44) /**< \brief TC0 signal: B2 on PB12 mux D */
+#define MUX_PB12D_TC0_B2                _L(3)
+#define PINMUX_PB12D_TC0_B2        ((PIN_PB12D_TC0_B2 << 16) | MUX_PB12D_TC0_B2)
+#define GPIO_PB12D_TC0_B2        _UL(1 << 12)
+#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L(1)
+#define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
+#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
+#define PIN_PB13D_TC0_CLK0             _L(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
+#define MUX_PB13D_TC0_CLK0              _L(3)
+#define PINMUX_PB13D_TC0_CLK0      ((PIN_PB13D_TC0_CLK0 << 16) | MUX_PB13D_TC0_CLK0)
+#define GPIO_PB13D_TC0_CLK0      _UL(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L(1)
+#define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
+#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
+#define PIN_PB14D_TC0_CLK1             _L(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
+#define MUX_PB14D_TC0_CLK1              _L(3)
+#define PINMUX_PB14D_TC0_CLK1      ((PIN_PB14D_TC0_CLK1 << 16) | MUX_PB14D_TC0_CLK1)
+#define GPIO_PB14D_TC0_CLK1      _UL(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L(1)
+#define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
+#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
+#define PIN_PB15D_TC0_CLK2             _L(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
+#define MUX_PB15D_TC0_CLK2              _L(3)
+#define PINMUX_PB15D_TC0_CLK2      ((PIN_PB15D_TC0_CLK2 << 16) | MUX_PB15D_TC0_CLK2)
+#define GPIO_PB15D_TC0_CLK2      _UL(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L(1)
+#define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
+#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+/* ========== GPIO definition for TC1 peripheral ========== */
+#define PIN_PC00D_TC1_A0               _L(64) /**< \brief TC1 signal: A0 on PC00 mux D */
+#define MUX_PC00D_TC1_A0                _L(3)
+#define PINMUX_PC00D_TC1_A0        ((PIN_PC00D_TC1_A0 << 16) | MUX_PC00D_TC1_A0)
+#define GPIO_PC00D_TC1_A0        _UL(1 <<  0)
+#define PIN_PC15A_TC1_A0               _L(79) /**< \brief TC1 signal: A0 on PC15 mux A */
+#define MUX_PC15A_TC1_A0                _L(0)
+#define PINMUX_PC15A_TC1_A0        ((PIN_PC15A_TC1_A0 << 16) | MUX_PC15A_TC1_A0)
+#define GPIO_PC15A_TC1_A0        _UL(1 << 15)
+#define PIN_PC02D_TC1_A1               _L(66) /**< \brief TC1 signal: A1 on PC02 mux D */
+#define MUX_PC02D_TC1_A1                _L(3)
+#define PINMUX_PC02D_TC1_A1        ((PIN_PC02D_TC1_A1 << 16) | MUX_PC02D_TC1_A1)
+#define GPIO_PC02D_TC1_A1        _UL(1 <<  2)
+#define PIN_PC17A_TC1_A1               _L(81) /**< \brief TC1 signal: A1 on PC17 mux A */
+#define MUX_PC17A_TC1_A1                _L(0)
+#define PINMUX_PC17A_TC1_A1        ((PIN_PC17A_TC1_A1 << 16) | MUX_PC17A_TC1_A1)
+#define GPIO_PC17A_TC1_A1        _UL(1 << 17)
+#define PIN_PC04D_TC1_A2               _L(68) /**< \brief TC1 signal: A2 on PC04 mux D */
+#define MUX_PC04D_TC1_A2                _L(3)
+#define PINMUX_PC04D_TC1_A2        ((PIN_PC04D_TC1_A2 << 16) | MUX_PC04D_TC1_A2)
+#define GPIO_PC04D_TC1_A2        _UL(1 <<  4)
+#define PIN_PC19A_TC1_A2               _L(83) /**< \brief TC1 signal: A2 on PC19 mux A */
+#define MUX_PC19A_TC1_A2                _L(0)
+#define PINMUX_PC19A_TC1_A2        ((PIN_PC19A_TC1_A2 << 16) | MUX_PC19A_TC1_A2)
+#define GPIO_PC19A_TC1_A2        _UL(1 << 19)
+#define PIN_PC01D_TC1_B0               _L(65) /**< \brief TC1 signal: B0 on PC01 mux D */
+#define MUX_PC01D_TC1_B0                _L(3)
+#define PINMUX_PC01D_TC1_B0        ((PIN_PC01D_TC1_B0 << 16) | MUX_PC01D_TC1_B0)
+#define GPIO_PC01D_TC1_B0        _UL(1 <<  1)
+#define PIN_PC16A_TC1_B0               _L(80) /**< \brief TC1 signal: B0 on PC16 mux A */
+#define MUX_PC16A_TC1_B0                _L(0)
+#define PINMUX_PC16A_TC1_B0        ((PIN_PC16A_TC1_B0 << 16) | MUX_PC16A_TC1_B0)
+#define GPIO_PC16A_TC1_B0        _UL(1 << 16)
+#define PIN_PC03D_TC1_B1               _L(67) /**< \brief TC1 signal: B1 on PC03 mux D */
+#define MUX_PC03D_TC1_B1                _L(3)
+#define PINMUX_PC03D_TC1_B1        ((PIN_PC03D_TC1_B1 << 16) | MUX_PC03D_TC1_B1)
+#define GPIO_PC03D_TC1_B1        _UL(1 <<  3)
+#define PIN_PC18A_TC1_B1               _L(82) /**< \brief TC1 signal: B1 on PC18 mux A */
+#define MUX_PC18A_TC1_B1                _L(0)
+#define PINMUX_PC18A_TC1_B1        ((PIN_PC18A_TC1_B1 << 16) | MUX_PC18A_TC1_B1)
+#define GPIO_PC18A_TC1_B1        _UL(1 << 18)
+#define PIN_PC05D_TC1_B2               _L(69) /**< \brief TC1 signal: B2 on PC05 mux D */
+#define MUX_PC05D_TC1_B2                _L(3)
+#define PINMUX_PC05D_TC1_B2        ((PIN_PC05D_TC1_B2 << 16) | MUX_PC05D_TC1_B2)
+#define GPIO_PC05D_TC1_B2        _UL(1 <<  5)
+#define PIN_PC20A_TC1_B2               _L(84) /**< \brief TC1 signal: B2 on PC20 mux A */
+#define MUX_PC20A_TC1_B2                _L(0)
+#define PINMUX_PC20A_TC1_B2        ((PIN_PC20A_TC1_B2 << 16) | MUX_PC20A_TC1_B2)
+#define GPIO_PC20A_TC1_B2        _UL(1 << 20)
+#define PIN_PC06D_TC1_CLK0             _L(70) /**< \brief TC1 signal: CLK0 on PC06 mux D */
+#define MUX_PC06D_TC1_CLK0              _L(3)
+#define PINMUX_PC06D_TC1_CLK0      ((PIN_PC06D_TC1_CLK0 << 16) | MUX_PC06D_TC1_CLK0)
+#define GPIO_PC06D_TC1_CLK0      _UL(1 <<  6)
+#define PIN_PC21A_TC1_CLK0             _L(85) /**< \brief TC1 signal: CLK0 on PC21 mux A */
+#define MUX_PC21A_TC1_CLK0              _L(0)
+#define PINMUX_PC21A_TC1_CLK0      ((PIN_PC21A_TC1_CLK0 << 16) | MUX_PC21A_TC1_CLK0)
+#define GPIO_PC21A_TC1_CLK0      _UL(1 << 21)
+#define PIN_PC07D_TC1_CLK1             _L(71) /**< \brief TC1 signal: CLK1 on PC07 mux D */
+#define MUX_PC07D_TC1_CLK1              _L(3)
+#define PINMUX_PC07D_TC1_CLK1      ((PIN_PC07D_TC1_CLK1 << 16) | MUX_PC07D_TC1_CLK1)
+#define GPIO_PC07D_TC1_CLK1      _UL(1 <<  7)
+#define PIN_PC22A_TC1_CLK1             _L(86) /**< \brief TC1 signal: CLK1 on PC22 mux A */
+#define MUX_PC22A_TC1_CLK1              _L(0)
+#define PINMUX_PC22A_TC1_CLK1      ((PIN_PC22A_TC1_CLK1 << 16) | MUX_PC22A_TC1_CLK1)
+#define GPIO_PC22A_TC1_CLK1      _UL(1 << 22)
+#define PIN_PC08D_TC1_CLK2             _L(72) /**< \brief TC1 signal: CLK2 on PC08 mux D */
+#define MUX_PC08D_TC1_CLK2              _L(3)
+#define PINMUX_PC08D_TC1_CLK2      ((PIN_PC08D_TC1_CLK2 << 16) | MUX_PC08D_TC1_CLK2)
+#define GPIO_PC08D_TC1_CLK2      _UL(1 <<  8)
+#define PIN_PC23A_TC1_CLK2             _L(87) /**< \brief TC1 signal: CLK2 on PC23 mux A */
+#define MUX_PC23A_TC1_CLK2              _L(0)
+#define PINMUX_PC23A_TC1_CLK2      ((PIN_PC23A_TC1_CLK2 << 16) | MUX_PC23A_TC1_CLK2)
+#define GPIO_PC23A_TC1_CLK2      _UL(1 << 23)
+/* ========== GPIO definition for USART0 peripheral ========== */
+#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L(1)
+#define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
+#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
+#define PIN_PC00B_USART0_CLK           _L(64) /**< \brief USART0 signal: CLK on PC00 mux B */
+#define MUX_PC00B_USART0_CLK            _L(1)
+#define PINMUX_PC00B_USART0_CLK    ((PIN_PC00B_USART0_CLK << 16) | MUX_PC00B_USART0_CLK)
+#define GPIO_PC00B_USART0_CLK    _UL(1 <<  0)
+#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L(0)
+#define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
+#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
+#define PIN_PB13A_USART0_CLK           _L(45) /**< \brief USART0 signal: CLK on PB13 mux A */
+#define MUX_PB13A_USART0_CLK            _L(0)
+#define PINMUX_PB13A_USART0_CLK    ((PIN_PB13A_USART0_CLK << 16) | MUX_PB13A_USART0_CLK)
+#define GPIO_PB13A_USART0_CLK    _UL(1 << 13)
+#define PIN_PC02B_USART0_CTS           _L(66) /**< \brief USART0 signal: CTS on PC02 mux B */
+#define MUX_PC02B_USART0_CTS            _L(1)
+#define PINMUX_PC02B_USART0_CTS    ((PIN_PC02B_USART0_CTS << 16) | MUX_PC02B_USART0_CTS)
+#define GPIO_PC02B_USART0_CTS    _UL(1 <<  2)
+#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L(0)
+#define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
+#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
+#define PIN_PB11A_USART0_CTS           _L(43) /**< \brief USART0 signal: CTS on PB11 mux A */
+#define MUX_PB11A_USART0_CTS            _L(0)
+#define PINMUX_PB11A_USART0_CTS    ((PIN_PB11A_USART0_CTS << 16) | MUX_PB11A_USART0_CTS)
+#define GPIO_PB11A_USART0_CTS    _UL(1 << 11)
+#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L(1)
+#define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
+#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
+#define PIN_PC01B_USART0_RTS           _L(65) /**< \brief USART0 signal: RTS on PC01 mux B */
+#define MUX_PC01B_USART0_RTS            _L(1)
+#define PINMUX_PC01B_USART0_RTS    ((PIN_PC01B_USART0_RTS << 16) | MUX_PC01B_USART0_RTS)
+#define GPIO_PC01B_USART0_RTS    _UL(1 <<  1)
+#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L(0)
+#define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
+#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
+#define PIN_PB12A_USART0_RTS           _L(44) /**< \brief USART0 signal: RTS on PB12 mux A */
+#define MUX_PB12A_USART0_RTS            _L(0)
+#define PINMUX_PB12A_USART0_RTS    ((PIN_PB12A_USART0_RTS << 16) | MUX_PB12A_USART0_RTS)
+#define GPIO_PB12A_USART0_RTS    _UL(1 << 12)
+#define PIN_PC02C_USART0_RXD           _L(66) /**< \brief USART0 signal: RXD on PC02 mux C */
+#define MUX_PC02C_USART0_RXD            _L(2)
+#define PINMUX_PC02C_USART0_RXD    ((PIN_PC02C_USART0_RXD << 16) | MUX_PC02C_USART0_RXD)
+#define GPIO_PC02C_USART0_RXD    _UL(1 <<  2)
+#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L(1)
+#define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
+#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
+#define PIN_PB00B_USART0_RXD           _L(32) /**< \brief USART0 signal: RXD on PB00 mux B */
+#define MUX_PB00B_USART0_RXD            _L(1)
+#define PINMUX_PB00B_USART0_RXD    ((PIN_PB00B_USART0_RXD << 16) | MUX_PB00B_USART0_RXD)
+#define GPIO_PB00B_USART0_RXD    _UL(1 <<  0)
+#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L(0)
+#define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
+#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
+#define PIN_PB14A_USART0_RXD           _L(46) /**< \brief USART0 signal: RXD on PB14 mux A */
+#define MUX_PB14A_USART0_RXD            _L(0)
+#define PINMUX_PB14A_USART0_RXD    ((PIN_PB14A_USART0_RXD << 16) | MUX_PB14A_USART0_RXD)
+#define GPIO_PB14A_USART0_RXD    _UL(1 << 14)
+#define PIN_PC03C_USART0_TXD           _L(67) /**< \brief USART0 signal: TXD on PC03 mux C */
+#define MUX_PC03C_USART0_TXD            _L(2)
+#define PINMUX_PC03C_USART0_TXD    ((PIN_PC03C_USART0_TXD << 16) | MUX_PC03C_USART0_TXD)
+#define GPIO_PC03C_USART0_TXD    _UL(1 <<  3)
+#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L(1)
+#define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
+#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
+#define PIN_PB01B_USART0_TXD           _L(33) /**< \brief USART0 signal: TXD on PB01 mux B */
+#define MUX_PB01B_USART0_TXD            _L(1)
+#define PINMUX_PB01B_USART0_TXD    ((PIN_PB01B_USART0_TXD << 16) | MUX_PB01B_USART0_TXD)
+#define GPIO_PB01B_USART0_TXD    _UL(1 <<  1)
+#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L(0)
+#define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
+#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
+#define PIN_PB15A_USART0_TXD           _L(47) /**< \brief USART0 signal: TXD on PB15 mux A */
+#define MUX_PB15A_USART0_TXD            _L(0)
+#define PINMUX_PB15A_USART0_TXD    ((PIN_PB15A_USART0_TXD << 16) | MUX_PB15A_USART0_TXD)
+#define GPIO_PB15A_USART0_TXD    _UL(1 << 15)
+/* ========== GPIO definition for USART1 peripheral ========== */
+#define PIN_PB03B_USART1_CLK           _L(35) /**< \brief USART1 signal: CLK on PB03 mux B */
+#define MUX_PB03B_USART1_CLK            _L(1)
+#define PINMUX_PB03B_USART1_CLK    ((PIN_PB03B_USART1_CLK << 16) | MUX_PB03B_USART1_CLK)
+#define GPIO_PB03B_USART1_CLK    _UL(1 <<  3)
+#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L(0)
+#define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
+#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
+#define PIN_PC25A_USART1_CLK           _L(89) /**< \brief USART1 signal: CLK on PC25 mux A */
+#define MUX_PC25A_USART1_CLK            _L(0)
+#define PINMUX_PC25A_USART1_CLK    ((PIN_PC25A_USART1_CLK << 16) | MUX_PC25A_USART1_CLK)
+#define GPIO_PC25A_USART1_CLK    _UL(1 << 25)
+#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L(1)
+#define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
+#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
+#define PIN_PB02B_USART1_RTS           _L(34) /**< \brief USART1 signal: RTS on PB02 mux B */
+#define MUX_PB02B_USART1_RTS            _L(1)
+#define PINMUX_PB02B_USART1_RTS    ((PIN_PB02B_USART1_RTS << 16) | MUX_PB02B_USART1_RTS)
+#define GPIO_PB02B_USART1_RTS    _UL(1 <<  2)
+#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L(0)
+#define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
+#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
+#define PIN_PC24A_USART1_RTS           _L(88) /**< \brief USART1 signal: RTS on PC24 mux A */
+#define MUX_PC24A_USART1_RTS            _L(0)
+#define PINMUX_PC24A_USART1_RTS    ((PIN_PC24A_USART1_RTS << 16) | MUX_PC24A_USART1_RTS)
+#define GPIO_PC24A_USART1_RTS    _UL(1 << 24)
+#define PIN_PB04B_USART1_RXD           _L(36) /**< \brief USART1 signal: RXD on PB04 mux B */
+#define MUX_PB04B_USART1_RXD            _L(1)
+#define PINMUX_PB04B_USART1_RXD    ((PIN_PB04B_USART1_RXD << 16) | MUX_PB04B_USART1_RXD)
+#define GPIO_PB04B_USART1_RXD    _UL(1 <<  4)
+#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L(0)
+#define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
+#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
+#define PIN_PC26A_USART1_RXD           _L(90) /**< \brief USART1 signal: RXD on PC26 mux A */
+#define MUX_PC26A_USART1_RXD            _L(0)
+#define PINMUX_PC26A_USART1_RXD    ((PIN_PC26A_USART1_RXD << 16) | MUX_PC26A_USART1_RXD)
+#define GPIO_PC26A_USART1_RXD    _UL(1 << 26)
+#define PIN_PB05B_USART1_TXD           _L(37) /**< \brief USART1 signal: TXD on PB05 mux B */
+#define MUX_PB05B_USART1_TXD            _L(1)
+#define PINMUX_PB05B_USART1_TXD    ((PIN_PB05B_USART1_TXD << 16) | MUX_PB05B_USART1_TXD)
+#define GPIO_PB05B_USART1_TXD    _UL(1 <<  5)
+#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L(0)
+#define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
+#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+#define PIN_PC27A_USART1_TXD           _L(91) /**< \brief USART1 signal: TXD on PC27 mux A */
+#define MUX_PC27A_USART1_TXD            _L(0)
+#define PINMUX_PC27A_USART1_TXD    ((PIN_PC27A_USART1_TXD << 16) | MUX_PC27A_USART1_TXD)
+#define GPIO_PC27A_USART1_TXD    _UL(1 << 27)
+/* ========== GPIO definition for USART2 peripheral ========== */
+#define PIN_PC08B_USART2_CLK           _L(72) /**< \brief USART2 signal: CLK on PC08 mux B */
+#define MUX_PC08B_USART2_CLK            _L(1)
+#define PINMUX_PC08B_USART2_CLK    ((PIN_PC08B_USART2_CLK << 16) | MUX_PC08B_USART2_CLK)
+#define GPIO_PC08B_USART2_CLK    _UL(1 <<  8)
+#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L(0)
+#define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
+#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
+#define PIN_PC08E_USART2_CTS           _L(72) /**< \brief USART2 signal: CTS on PC08 mux E */
+#define MUX_PC08E_USART2_CTS            _L(4)
+#define PINMUX_PC08E_USART2_CTS    ((PIN_PC08E_USART2_CTS << 16) | MUX_PC08E_USART2_CTS)
+#define GPIO_PC08E_USART2_CTS    _UL(1 <<  8)
+#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L(1)
+#define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
+#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
+#define PIN_PC07B_USART2_RTS           _L(71) /**< \brief USART2 signal: RTS on PC07 mux B */
+#define MUX_PC07B_USART2_RTS            _L(1)
+#define PINMUX_PC07B_USART2_RTS    ((PIN_PC07B_USART2_RTS << 16) | MUX_PC07B_USART2_RTS)
+#define GPIO_PC07B_USART2_RTS    _UL(1 <<  7)
+#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L(0)
+#define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
+#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L(1)
+#define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
+#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
+#define PIN_PC11B_USART2_RXD           _L(75) /**< \brief USART2 signal: RXD on PC11 mux B */
+#define MUX_PC11B_USART2_RXD            _L(1)
+#define PINMUX_PC11B_USART2_RXD    ((PIN_PC11B_USART2_RXD << 16) | MUX_PC11B_USART2_RXD)
+#define GPIO_PC11B_USART2_RXD    _UL(1 << 11)
+#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L(0)
+#define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
+#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L(1)
+#define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
+#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
+#define PIN_PC12B_USART2_TXD           _L(76) /**< \brief USART2 signal: TXD on PC12 mux B */
+#define MUX_PC12B_USART2_TXD            _L(1)
+#define PINMUX_PC12B_USART2_TXD    ((PIN_PC12B_USART2_TXD << 16) | MUX_PC12B_USART2_TXD)
+#define GPIO_PC12B_USART2_TXD    _UL(1 << 12)
+#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L(0)
+#define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
+#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+/* ========== GPIO definition for USART3 peripheral ========== */
+#define PIN_PA29E_USART3_CLK           _L(29) /**< \brief USART3 signal: CLK on PA29 mux E */
+#define MUX_PA29E_USART3_CLK            _L(4)
+#define PINMUX_PA29E_USART3_CLK    ((PIN_PA29E_USART3_CLK << 16) | MUX_PA29E_USART3_CLK)
+#define GPIO_PA29E_USART3_CLK    _UL(1 << 29)
+#define PIN_PC14B_USART3_CLK           _L(78) /**< \brief USART3 signal: CLK on PC14 mux B */
+#define MUX_PC14B_USART3_CLK            _L(1)
+#define PINMUX_PC14B_USART3_CLK    ((PIN_PC14B_USART3_CLK << 16) | MUX_PC14B_USART3_CLK)
+#define GPIO_PC14B_USART3_CLK    _UL(1 << 14)
+#define PIN_PB08A_USART3_CLK           _L(40) /**< \brief USART3 signal: CLK on PB08 mux A */
+#define MUX_PB08A_USART3_CLK            _L(0)
+#define PINMUX_PB08A_USART3_CLK    ((PIN_PB08A_USART3_CLK << 16) | MUX_PB08A_USART3_CLK)
+#define GPIO_PB08A_USART3_CLK    _UL(1 <<  8)
+#define PIN_PC31A_USART3_CLK           _L(95) /**< \brief USART3 signal: CLK on PC31 mux A */
+#define MUX_PC31A_USART3_CLK            _L(0)
+#define PINMUX_PC31A_USART3_CLK    ((PIN_PC31A_USART3_CLK << 16) | MUX_PC31A_USART3_CLK)
+#define GPIO_PC31A_USART3_CLK    _UL(1 << 31)
+#define PIN_PA28E_USART3_CTS           _L(28) /**< \brief USART3 signal: CTS on PA28 mux E */
+#define MUX_PA28E_USART3_CTS            _L(4)
+#define PINMUX_PA28E_USART3_CTS    ((PIN_PA28E_USART3_CTS << 16) | MUX_PA28E_USART3_CTS)
+#define GPIO_PA28E_USART3_CTS    _UL(1 << 28)
+#define PIN_PB07A_USART3_CTS           _L(39) /**< \brief USART3 signal: CTS on PB07 mux A */
+#define MUX_PB07A_USART3_CTS            _L(0)
+#define PINMUX_PB07A_USART3_CTS    ((PIN_PB07A_USART3_CTS << 16) | MUX_PB07A_USART3_CTS)
+#define GPIO_PB07A_USART3_CTS    _UL(1 <<  7)
+#define PIN_PA27E_USART3_RTS           _L(27) /**< \brief USART3 signal: RTS on PA27 mux E */
+#define MUX_PA27E_USART3_RTS            _L(4)
+#define PINMUX_PA27E_USART3_RTS    ((PIN_PA27E_USART3_RTS << 16) | MUX_PA27E_USART3_RTS)
+#define GPIO_PA27E_USART3_RTS    _UL(1 << 27)
+#define PIN_PC13B_USART3_RTS           _L(77) /**< \brief USART3 signal: RTS on PC13 mux B */
+#define MUX_PC13B_USART3_RTS            _L(1)
+#define PINMUX_PC13B_USART3_RTS    ((PIN_PC13B_USART3_RTS << 16) | MUX_PC13B_USART3_RTS)
+#define GPIO_PC13B_USART3_RTS    _UL(1 << 13)
+#define PIN_PB06A_USART3_RTS           _L(38) /**< \brief USART3 signal: RTS on PB06 mux A */
+#define MUX_PB06A_USART3_RTS            _L(0)
+#define PINMUX_PB06A_USART3_RTS    ((PIN_PB06A_USART3_RTS << 16) | MUX_PB06A_USART3_RTS)
+#define GPIO_PB06A_USART3_RTS    _UL(1 <<  6)
+#define PIN_PC30A_USART3_RTS           _L(94) /**< \brief USART3 signal: RTS on PC30 mux A */
+#define MUX_PC30A_USART3_RTS            _L(0)
+#define PINMUX_PC30A_USART3_RTS    ((PIN_PC30A_USART3_RTS << 16) | MUX_PC30A_USART3_RTS)
+#define GPIO_PC30A_USART3_RTS    _UL(1 << 30)
+#define PIN_PA30E_USART3_RXD           _L(30) /**< \brief USART3 signal: RXD on PA30 mux E */
+#define MUX_PA30E_USART3_RXD            _L(4)
+#define PINMUX_PA30E_USART3_RXD    ((PIN_PA30E_USART3_RXD << 16) | MUX_PA30E_USART3_RXD)
+#define GPIO_PA30E_USART3_RXD    _UL(1 << 30)
+#define PIN_PC09B_USART3_RXD           _L(73) /**< \brief USART3 signal: RXD on PC09 mux B */
+#define MUX_PC09B_USART3_RXD            _L(1)
+#define PINMUX_PC09B_USART3_RXD    ((PIN_PC09B_USART3_RXD << 16) | MUX_PC09B_USART3_RXD)
+#define GPIO_PC09B_USART3_RXD    _UL(1 <<  9)
+#define PIN_PB09A_USART3_RXD           _L(41) /**< \brief USART3 signal: RXD on PB09 mux A */
+#define MUX_PB09A_USART3_RXD            _L(0)
+#define PINMUX_PB09A_USART3_RXD    ((PIN_PB09A_USART3_RXD << 16) | MUX_PB09A_USART3_RXD)
+#define GPIO_PB09A_USART3_RXD    _UL(1 <<  9)
+#define PIN_PC28A_USART3_RXD           _L(92) /**< \brief USART3 signal: RXD on PC28 mux A */
+#define MUX_PC28A_USART3_RXD            _L(0)
+#define PINMUX_PC28A_USART3_RXD    ((PIN_PC28A_USART3_RXD << 16) | MUX_PC28A_USART3_RXD)
+#define GPIO_PC28A_USART3_RXD    _UL(1 << 28)
+#define PIN_PA31E_USART3_TXD           _L(31) /**< \brief USART3 signal: TXD on PA31 mux E */
+#define MUX_PA31E_USART3_TXD            _L(4)
+#define PINMUX_PA31E_USART3_TXD    ((PIN_PA31E_USART3_TXD << 16) | MUX_PA31E_USART3_TXD)
+#define GPIO_PA31E_USART3_TXD    _UL(1 << 31)
+#define PIN_PC10B_USART3_TXD           _L(74) /**< \brief USART3 signal: TXD on PC10 mux B */
+#define MUX_PC10B_USART3_TXD            _L(1)
+#define PINMUX_PC10B_USART3_TXD    ((PIN_PC10B_USART3_TXD << 16) | MUX_PC10B_USART3_TXD)
+#define GPIO_PC10B_USART3_TXD    _UL(1 << 10)
+#define PIN_PB10A_USART3_TXD           _L(42) /**< \brief USART3 signal: TXD on PB10 mux A */
+#define MUX_PB10A_USART3_TXD            _L(0)
+#define PINMUX_PB10A_USART3_TXD    ((PIN_PB10A_USART3_TXD << 16) | MUX_PB10A_USART3_TXD)
+#define GPIO_PB10A_USART3_TXD    _UL(1 << 10)
+#define PIN_PC29A_USART3_TXD           _L(93) /**< \brief USART3 signal: TXD on PC29 mux A */
+#define MUX_PC29A_USART3_TXD            _L(0)
+#define PINMUX_PC29A_USART3_TXD    ((PIN_PC29A_USART3_TXD << 16) | MUX_PC29A_USART3_TXD)
+#define GPIO_PC29A_USART3_TXD    _UL(1 << 29)
+/* ========== GPIO definition for ADCIFE peripheral ========== */
+#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
+#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
+#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
+#define PIN_PB02A_ADCIFE_AD3           _L(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
+#define MUX_PB02A_ADCIFE_AD3            _L(0)
+#define PINMUX_PB02A_ADCIFE_AD3    ((PIN_PB02A_ADCIFE_AD3 << 16) | MUX_PB02A_ADCIFE_AD3)
+#define GPIO_PB02A_ADCIFE_AD3    _UL(1 <<  2)
+#define PIN_PB03A_ADCIFE_AD4           _L(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
+#define MUX_PB03A_ADCIFE_AD4            _L(0)
+#define PINMUX_PB03A_ADCIFE_AD4    ((PIN_PB03A_ADCIFE_AD4 << 16) | MUX_PB03A_ADCIFE_AD4)
+#define GPIO_PB03A_ADCIFE_AD4    _UL(1 <<  3)
+#define PIN_PB04A_ADCIFE_AD5           _L(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
+#define MUX_PB04A_ADCIFE_AD5            _L(0)
+#define PINMUX_PB04A_ADCIFE_AD5    ((PIN_PB04A_ADCIFE_AD5 << 16) | MUX_PB04A_ADCIFE_AD5)
+#define GPIO_PB04A_ADCIFE_AD5    _UL(1 <<  4)
+#define PIN_PB05A_ADCIFE_AD6           _L(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
+#define MUX_PB05A_ADCIFE_AD6            _L(0)
+#define PINMUX_PB05A_ADCIFE_AD6    ((PIN_PB05A_ADCIFE_AD6 << 16) | MUX_PB05A_ADCIFE_AD6)
+#define GPIO_PB05A_ADCIFE_AD6    _UL(1 <<  5)
+#define PIN_PC07A_ADCIFE_AD7           _L(71) /**< \brief ADCIFE signal: AD7 on PC07 mux A */
+#define MUX_PC07A_ADCIFE_AD7            _L(0)
+#define PINMUX_PC07A_ADCIFE_AD7    ((PIN_PC07A_ADCIFE_AD7 << 16) | MUX_PC07A_ADCIFE_AD7)
+#define GPIO_PC07A_ADCIFE_AD7    _UL(1 <<  7)
+#define PIN_PC08A_ADCIFE_AD8           _L(72) /**< \brief ADCIFE signal: AD8 on PC08 mux A */
+#define MUX_PC08A_ADCIFE_AD8            _L(0)
+#define PINMUX_PC08A_ADCIFE_AD8    ((PIN_PC08A_ADCIFE_AD8 << 16) | MUX_PC08A_ADCIFE_AD8)
+#define GPIO_PC08A_ADCIFE_AD8    _UL(1 <<  8)
+#define PIN_PC09A_ADCIFE_AD9           _L(73) /**< \brief ADCIFE signal: AD9 on PC09 mux A */
+#define MUX_PC09A_ADCIFE_AD9            _L(0)
+#define PINMUX_PC09A_ADCIFE_AD9    ((PIN_PC09A_ADCIFE_AD9 << 16) | MUX_PC09A_ADCIFE_AD9)
+#define GPIO_PC09A_ADCIFE_AD9    _UL(1 <<  9)
+#define PIN_PC10A_ADCIFE_AD10          _L(74) /**< \brief ADCIFE signal: AD10 on PC10 mux A */
+#define MUX_PC10A_ADCIFE_AD10           _L(0)
+#define PINMUX_PC10A_ADCIFE_AD10   ((PIN_PC10A_ADCIFE_AD10 << 16) | MUX_PC10A_ADCIFE_AD10)
+#define GPIO_PC10A_ADCIFE_AD10   _UL(1 << 10)
+#define PIN_PC11A_ADCIFE_AD11          _L(75) /**< \brief ADCIFE signal: AD11 on PC11 mux A */
+#define MUX_PC11A_ADCIFE_AD11           _L(0)
+#define PINMUX_PC11A_ADCIFE_AD11   ((PIN_PC11A_ADCIFE_AD11 << 16) | MUX_PC11A_ADCIFE_AD11)
+#define GPIO_PC11A_ADCIFE_AD11   _UL(1 << 11)
+#define PIN_PC12A_ADCIFE_AD12          _L(76) /**< \brief ADCIFE signal: AD12 on PC12 mux A */
+#define MUX_PC12A_ADCIFE_AD12           _L(0)
+#define PINMUX_PC12A_ADCIFE_AD12   ((PIN_PC12A_ADCIFE_AD12 << 16) | MUX_PC12A_ADCIFE_AD12)
+#define GPIO_PC12A_ADCIFE_AD12   _UL(1 << 12)
+#define PIN_PC13A_ADCIFE_AD13          _L(77) /**< \brief ADCIFE signal: AD13 on PC13 mux A */
+#define MUX_PC13A_ADCIFE_AD13           _L(0)
+#define PINMUX_PC13A_ADCIFE_AD13   ((PIN_PC13A_ADCIFE_AD13 << 16) | MUX_PC13A_ADCIFE_AD13)
+#define GPIO_PC13A_ADCIFE_AD13   _UL(1 << 13)
+#define PIN_PC14A_ADCIFE_AD14          _L(78) /**< \brief ADCIFE signal: AD14 on PC14 mux A */
+#define MUX_PC14A_ADCIFE_AD14           _L(0)
+#define PINMUX_PC14A_ADCIFE_AD14   ((PIN_PC14A_ADCIFE_AD14 << 16) | MUX_PC14A_ADCIFE_AD14)
+#define GPIO_PC14A_ADCIFE_AD14   _UL(1 << 14)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+/* ========== GPIO definition for DACC peripheral ========== */
+#define PIN_PB04E_DACC_EXT_TRIG0       _L(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
+#define MUX_PB04E_DACC_EXT_TRIG0        _L(4)
+#define PINMUX_PB04E_DACC_EXT_TRIG0  ((PIN_PB04E_DACC_EXT_TRIG0 << 16) | MUX_PB04E_DACC_EXT_TRIG0)
+#define GPIO_PB04E_DACC_EXT_TRIG0  _UL(1 <<  4)
+#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L(0)
+#define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
+#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+/* ========== GPIO definition for ACIFC peripheral ========== */
+#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
+#define PIN_PC09E_ACIFC_ACAN1          _L(73) /**< \brief ACIFC signal: ACAN1 on PC09 mux E */
+#define MUX_PC09E_ACIFC_ACAN1           _L(4)
+#define PINMUX_PC09E_ACIFC_ACAN1   ((PIN_PC09E_ACIFC_ACAN1 << 16) | MUX_PC09E_ACIFC_ACAN1)
+#define GPIO_PC09E_ACIFC_ACAN1   _UL(1 <<  9)
+#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
+#define PIN_PC10E_ACIFC_ACAP1          _L(74) /**< \brief ACIFC signal: ACAP1 on PC10 mux E */
+#define MUX_PC10E_ACIFC_ACAP1           _L(4)
+#define PINMUX_PC10E_ACIFC_ACAP1   ((PIN_PC10E_ACIFC_ACAP1 << 16) | MUX_PC10E_ACIFC_ACAP1)
+#define GPIO_PC10E_ACIFC_ACAP1   _UL(1 << 10)
+#define PIN_PB02E_ACIFC_ACBN0          _L(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
+#define MUX_PB02E_ACIFC_ACBN0           _L(4)
+#define PINMUX_PB02E_ACIFC_ACBN0   ((PIN_PB02E_ACIFC_ACBN0 << 16) | MUX_PB02E_ACIFC_ACBN0)
+#define GPIO_PB02E_ACIFC_ACBN0   _UL(1 <<  2)
+#define PIN_PC13E_ACIFC_ACBN1          _L(77) /**< \brief ACIFC signal: ACBN1 on PC13 mux E */
+#define MUX_PC13E_ACIFC_ACBN1           _L(4)
+#define PINMUX_PC13E_ACIFC_ACBN1   ((PIN_PC13E_ACIFC_ACBN1 << 16) | MUX_PC13E_ACIFC_ACBN1)
+#define GPIO_PC13E_ACIFC_ACBN1   _UL(1 << 13)
+#define PIN_PB03E_ACIFC_ACBP0          _L(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
+#define MUX_PB03E_ACIFC_ACBP0           _L(4)
+#define PINMUX_PB03E_ACIFC_ACBP0   ((PIN_PB03E_ACIFC_ACBP0 << 16) | MUX_PB03E_ACIFC_ACBP0)
+#define GPIO_PB03E_ACIFC_ACBP0   _UL(1 <<  3)
+#define PIN_PC14E_ACIFC_ACBP1          _L(78) /**< \brief ACIFC signal: ACBP1 on PC14 mux E */
+#define MUX_PC14E_ACIFC_ACBP1           _L(4)
+#define PINMUX_PC14E_ACIFC_ACBP1   ((PIN_PC14E_ACIFC_ACBP1 << 16) | MUX_PC14E_ACIFC_ACBP1)
+#define GPIO_PC14E_ACIFC_ACBP1   _UL(1 << 14)
+/* ========== GPIO definition for GLOC peripheral ========== */
+#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
+#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L(3)
+#define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
+#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L(3)
+#define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
+#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L(3)
+#define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
+#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L(3)
+#define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
+#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L(3)
+#define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
+#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L(3)
+#define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
+#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L(3)
+#define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
+#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
+#define PIN_PA27D_GLOC_IN4             _L(27) /**< \brief GLOC signal: IN4 on PA27 mux D */
+#define MUX_PA27D_GLOC_IN4              _L(3)
+#define PINMUX_PA27D_GLOC_IN4      ((PIN_PA27D_GLOC_IN4 << 16) | MUX_PA27D_GLOC_IN4)
+#define GPIO_PA27D_GLOC_IN4      _UL(1 << 27)
+#define PIN_PC15D_GLOC_IN4             _L(79) /**< \brief GLOC signal: IN4 on PC15 mux D */
+#define MUX_PC15D_GLOC_IN4              _L(3)
+#define PINMUX_PC15D_GLOC_IN4      ((PIN_PC15D_GLOC_IN4 << 16) | MUX_PC15D_GLOC_IN4)
+#define GPIO_PC15D_GLOC_IN4      _UL(1 << 15)
+#define PIN_PB06C_GLOC_IN4             _L(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
+#define MUX_PB06C_GLOC_IN4              _L(2)
+#define PINMUX_PB06C_GLOC_IN4      ((PIN_PB06C_GLOC_IN4 << 16) | MUX_PB06C_GLOC_IN4)
+#define GPIO_PB06C_GLOC_IN4      _UL(1 <<  6)
+#define PIN_PC28C_GLOC_IN4             _L(92) /**< \brief GLOC signal: IN4 on PC28 mux C */
+#define MUX_PC28C_GLOC_IN4              _L(2)
+#define PINMUX_PC28C_GLOC_IN4      ((PIN_PC28C_GLOC_IN4 << 16) | MUX_PC28C_GLOC_IN4)
+#define GPIO_PC28C_GLOC_IN4      _UL(1 << 28)
+#define PIN_PA28D_GLOC_IN5             _L(28) /**< \brief GLOC signal: IN5 on PA28 mux D */
+#define MUX_PA28D_GLOC_IN5              _L(3)
+#define PINMUX_PA28D_GLOC_IN5      ((PIN_PA28D_GLOC_IN5 << 16) | MUX_PA28D_GLOC_IN5)
+#define GPIO_PA28D_GLOC_IN5      _UL(1 << 28)
+#define PIN_PC16D_GLOC_IN5             _L(80) /**< \brief GLOC signal: IN5 on PC16 mux D */
+#define MUX_PC16D_GLOC_IN5              _L(3)
+#define PINMUX_PC16D_GLOC_IN5      ((PIN_PC16D_GLOC_IN5 << 16) | MUX_PC16D_GLOC_IN5)
+#define GPIO_PC16D_GLOC_IN5      _UL(1 << 16)
+#define PIN_PB07C_GLOC_IN5             _L(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
+#define MUX_PB07C_GLOC_IN5              _L(2)
+#define PINMUX_PB07C_GLOC_IN5      ((PIN_PB07C_GLOC_IN5 << 16) | MUX_PB07C_GLOC_IN5)
+#define GPIO_PB07C_GLOC_IN5      _UL(1 <<  7)
+#define PIN_PC29C_GLOC_IN5             _L(93) /**< \brief GLOC signal: IN5 on PC29 mux C */
+#define MUX_PC29C_GLOC_IN5              _L(2)
+#define PINMUX_PC29C_GLOC_IN5      ((PIN_PC29C_GLOC_IN5 << 16) | MUX_PC29C_GLOC_IN5)
+#define GPIO_PC29C_GLOC_IN5      _UL(1 << 29)
+#define PIN_PA29D_GLOC_IN6             _L(29) /**< \brief GLOC signal: IN6 on PA29 mux D */
+#define MUX_PA29D_GLOC_IN6              _L(3)
+#define PINMUX_PA29D_GLOC_IN6      ((PIN_PA29D_GLOC_IN6 << 16) | MUX_PA29D_GLOC_IN6)
+#define GPIO_PA29D_GLOC_IN6      _UL(1 << 29)
+#define PIN_PC17D_GLOC_IN6             _L(81) /**< \brief GLOC signal: IN6 on PC17 mux D */
+#define MUX_PC17D_GLOC_IN6              _L(3)
+#define PINMUX_PC17D_GLOC_IN6      ((PIN_PC17D_GLOC_IN6 << 16) | MUX_PC17D_GLOC_IN6)
+#define GPIO_PC17D_GLOC_IN6      _UL(1 << 17)
+#define PIN_PB08C_GLOC_IN6             _L(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
+#define MUX_PB08C_GLOC_IN6              _L(2)
+#define PINMUX_PB08C_GLOC_IN6      ((PIN_PB08C_GLOC_IN6 << 16) | MUX_PB08C_GLOC_IN6)
+#define GPIO_PB08C_GLOC_IN6      _UL(1 <<  8)
+#define PIN_PC30C_GLOC_IN6             _L(94) /**< \brief GLOC signal: IN6 on PC30 mux C */
+#define MUX_PC30C_GLOC_IN6              _L(2)
+#define PINMUX_PC30C_GLOC_IN6      ((PIN_PC30C_GLOC_IN6 << 16) | MUX_PC30C_GLOC_IN6)
+#define GPIO_PC30C_GLOC_IN6      _UL(1 << 30)
+#define PIN_PA30D_GLOC_IN7             _L(30) /**< \brief GLOC signal: IN7 on PA30 mux D */
+#define MUX_PA30D_GLOC_IN7              _L(3)
+#define PINMUX_PA30D_GLOC_IN7      ((PIN_PA30D_GLOC_IN7 << 16) | MUX_PA30D_GLOC_IN7)
+#define GPIO_PA30D_GLOC_IN7      _UL(1 << 30)
+#define PIN_PC18D_GLOC_IN7             _L(82) /**< \brief GLOC signal: IN7 on PC18 mux D */
+#define MUX_PC18D_GLOC_IN7              _L(3)
+#define PINMUX_PC18D_GLOC_IN7      ((PIN_PC18D_GLOC_IN7 << 16) | MUX_PC18D_GLOC_IN7)
+#define GPIO_PC18D_GLOC_IN7      _UL(1 << 18)
+#define PIN_PB09C_GLOC_IN7             _L(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
+#define MUX_PB09C_GLOC_IN7              _L(2)
+#define PINMUX_PB09C_GLOC_IN7      ((PIN_PB09C_GLOC_IN7 << 16) | MUX_PB09C_GLOC_IN7)
+#define GPIO_PB09C_GLOC_IN7      _UL(1 <<  9)
+#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
+#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
+#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
+#define PIN_PA31D_GLOC_OUT1            _L(31) /**< \brief GLOC signal: OUT1 on PA31 mux D */
+#define MUX_PA31D_GLOC_OUT1             _L(3)
+#define PINMUX_PA31D_GLOC_OUT1     ((PIN_PA31D_GLOC_OUT1 << 16) | MUX_PA31D_GLOC_OUT1)
+#define GPIO_PA31D_GLOC_OUT1     _UL(1 << 31)
+#define PIN_PC19D_GLOC_OUT1            _L(83) /**< \brief GLOC signal: OUT1 on PC19 mux D */
+#define MUX_PC19D_GLOC_OUT1             _L(3)
+#define PINMUX_PC19D_GLOC_OUT1     ((PIN_PC19D_GLOC_OUT1 << 16) | MUX_PC19D_GLOC_OUT1)
+#define GPIO_PC19D_GLOC_OUT1     _UL(1 << 19)
+#define PIN_PB10C_GLOC_OUT1            _L(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
+#define MUX_PB10C_GLOC_OUT1             _L(2)
+#define PINMUX_PB10C_GLOC_OUT1     ((PIN_PB10C_GLOC_OUT1 << 16) | MUX_PB10C_GLOC_OUT1)
+#define GPIO_PB10C_GLOC_OUT1     _UL(1 << 10)
+#define PIN_PC31C_GLOC_OUT1            _L(95) /**< \brief GLOC signal: OUT1 on PC31 mux C */
+#define MUX_PC31C_GLOC_OUT1             _L(2)
+#define PINMUX_PC31C_GLOC_OUT1     ((PIN_PC31C_GLOC_OUT1 << 16) | MUX_PC31C_GLOC_OUT1)
+#define GPIO_PC31C_GLOC_OUT1     _UL(1 << 31)
+/* ========== GPIO definition for ABDACB peripheral ========== */
+#define PIN_PA31C_ABDACB_CLK           _L(31) /**< \brief ABDACB signal: CLK on PA31 mux C */
+#define MUX_PA31C_ABDACB_CLK            _L(2)
+#define PINMUX_PA31C_ABDACB_CLK    ((PIN_PA31C_ABDACB_CLK << 16) | MUX_PA31C_ABDACB_CLK)
+#define GPIO_PA31C_ABDACB_CLK    _UL(1 << 31)
+#define PIN_PC12C_ABDACB_CLK           _L(76) /**< \brief ABDACB signal: CLK on PC12 mux C */
+#define MUX_PC12C_ABDACB_CLK            _L(2)
+#define PINMUX_PC12C_ABDACB_CLK    ((PIN_PC12C_ABDACB_CLK << 16) | MUX_PC12C_ABDACB_CLK)
+#define GPIO_PC12C_ABDACB_CLK    _UL(1 << 12)
+#define PIN_PA27C_ABDACB_DAC0          _L(27) /**< \brief ABDACB signal: DAC0 on PA27 mux C */
+#define MUX_PA27C_ABDACB_DAC0           _L(2)
+#define PINMUX_PA27C_ABDACB_DAC0   ((PIN_PA27C_ABDACB_DAC0 << 16) | MUX_PA27C_ABDACB_DAC0)
+#define GPIO_PA27C_ABDACB_DAC0   _UL(1 << 27)
+#define PIN_PB02C_ABDACB_DAC0          _L(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
+#define MUX_PB02C_ABDACB_DAC0           _L(2)
+#define PINMUX_PB02C_ABDACB_DAC0   ((PIN_PB02C_ABDACB_DAC0 << 16) | MUX_PB02C_ABDACB_DAC0)
+#define GPIO_PB02C_ABDACB_DAC0   _UL(1 <<  2)
+#define PIN_PC09C_ABDACB_DAC0          _L(73) /**< \brief ABDACB signal: DAC0 on PC09 mux C */
+#define MUX_PC09C_ABDACB_DAC0           _L(2)
+#define PINMUX_PC09C_ABDACB_DAC0   ((PIN_PC09C_ABDACB_DAC0 << 16) | MUX_PC09C_ABDACB_DAC0)
+#define GPIO_PC09C_ABDACB_DAC0   _UL(1 <<  9)
+#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
+#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
+#define PIN_PA29C_ABDACB_DAC1          _L(29) /**< \brief ABDACB signal: DAC1 on PA29 mux C */
+#define MUX_PA29C_ABDACB_DAC1           _L(2)
+#define PINMUX_PA29C_ABDACB_DAC1   ((PIN_PA29C_ABDACB_DAC1 << 16) | MUX_PA29C_ABDACB_DAC1)
+#define GPIO_PA29C_ABDACB_DAC1   _UL(1 << 29)
+#define PIN_PB04C_ABDACB_DAC1          _L(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
+#define MUX_PB04C_ABDACB_DAC1           _L(2)
+#define PINMUX_PB04C_ABDACB_DAC1   ((PIN_PB04C_ABDACB_DAC1 << 16) | MUX_PB04C_ABDACB_DAC1)
+#define GPIO_PB04C_ABDACB_DAC1   _UL(1 <<  4)
+#define PIN_PC13C_ABDACB_DAC1          _L(77) /**< \brief ABDACB signal: DAC1 on PC13 mux C */
+#define MUX_PC13C_ABDACB_DAC1           _L(2)
+#define PINMUX_PC13C_ABDACB_DAC1   ((PIN_PC13C_ABDACB_DAC1 << 16) | MUX_PC13C_ABDACB_DAC1)
+#define GPIO_PC13C_ABDACB_DAC1   _UL(1 << 13)
+#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
+#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
+#define PIN_PA28C_ABDACB_DACN0         _L(28) /**< \brief ABDACB signal: DACN0 on PA28 mux C */
+#define MUX_PA28C_ABDACB_DACN0          _L(2)
+#define PINMUX_PA28C_ABDACB_DACN0  ((PIN_PA28C_ABDACB_DACN0 << 16) | MUX_PA28C_ABDACB_DACN0)
+#define GPIO_PA28C_ABDACB_DACN0  _UL(1 << 28)
+#define PIN_PB03C_ABDACB_DACN0         _L(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
+#define MUX_PB03C_ABDACB_DACN0          _L(2)
+#define PINMUX_PB03C_ABDACB_DACN0  ((PIN_PB03C_ABDACB_DACN0 << 16) | MUX_PB03C_ABDACB_DACN0)
+#define GPIO_PB03C_ABDACB_DACN0  _UL(1 <<  3)
+#define PIN_PC10C_ABDACB_DACN0         _L(74) /**< \brief ABDACB signal: DACN0 on PC10 mux C */
+#define MUX_PC10C_ABDACB_DACN0          _L(2)
+#define PINMUX_PC10C_ABDACB_DACN0  ((PIN_PC10C_ABDACB_DACN0 << 16) | MUX_PC10C_ABDACB_DACN0)
+#define GPIO_PC10C_ABDACB_DACN0  _UL(1 << 10)
+#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
+#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
+#define PIN_PA30C_ABDACB_DACN1         _L(30) /**< \brief ABDACB signal: DACN1 on PA30 mux C */
+#define MUX_PA30C_ABDACB_DACN1          _L(2)
+#define PINMUX_PA30C_ABDACB_DACN1  ((PIN_PA30C_ABDACB_DACN1 << 16) | MUX_PA30C_ABDACB_DACN1)
+#define GPIO_PA30C_ABDACB_DACN1  _UL(1 << 30)
+#define PIN_PB05C_ABDACB_DACN1         _L(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
+#define MUX_PB05C_ABDACB_DACN1          _L(2)
+#define PINMUX_PB05C_ABDACB_DACN1  ((PIN_PB05C_ABDACB_DACN1 << 16) | MUX_PB05C_ABDACB_DACN1)
+#define GPIO_PB05C_ABDACB_DACN1  _UL(1 <<  5)
+#define PIN_PC14C_ABDACB_DACN1         _L(78) /**< \brief ABDACB signal: DACN1 on PC14 mux C */
+#define MUX_PC14C_ABDACB_DACN1          _L(2)
+#define PINMUX_PC14C_ABDACB_DACN1  ((PIN_PC14C_ABDACB_DACN1 << 16) | MUX_PC14C_ABDACB_DACN1)
+#define GPIO_PC14C_ABDACB_DACN1  _UL(1 << 14)
+#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
+#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+/* ========== GPIO definition for PARC peripheral ========== */
+#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
+#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
+#define PIN_PC21D_PARC_PCCK            _L(85) /**< \brief PARC signal: PCCK on PC21 mux D */
+#define MUX_PC21D_PARC_PCCK             _L(3)
+#define PINMUX_PC21D_PARC_PCCK     ((PIN_PC21D_PARC_PCCK << 16) | MUX_PC21D_PARC_PCCK)
+#define GPIO_PC21D_PARC_PCCK     _UL(1 << 21)
+#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
+#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
+#define PIN_PC24D_PARC_PCDATA0         _L(88) /**< \brief PARC signal: PCDATA0 on PC24 mux D */
+#define MUX_PC24D_PARC_PCDATA0          _L(3)
+#define PINMUX_PC24D_PARC_PCDATA0  ((PIN_PC24D_PARC_PCDATA0 << 16) | MUX_PC24D_PARC_PCDATA0)
+#define GPIO_PC24D_PARC_PCDATA0  _UL(1 << 24)
+#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
+#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
+#define PIN_PC25D_PARC_PCDATA1         _L(89) /**< \brief PARC signal: PCDATA1 on PC25 mux D */
+#define MUX_PC25D_PARC_PCDATA1          _L(3)
+#define PINMUX_PC25D_PARC_PCDATA1  ((PIN_PC25D_PARC_PCDATA1 << 16) | MUX_PC25D_PARC_PCDATA1)
+#define GPIO_PC25D_PARC_PCDATA1  _UL(1 << 25)
+#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
+#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
+#define PIN_PC26D_PARC_PCDATA2         _L(90) /**< \brief PARC signal: PCDATA2 on PC26 mux D */
+#define MUX_PC26D_PARC_PCDATA2          _L(3)
+#define PINMUX_PC26D_PARC_PCDATA2  ((PIN_PC26D_PARC_PCDATA2 << 16) | MUX_PC26D_PARC_PCDATA2)
+#define GPIO_PC26D_PARC_PCDATA2  _UL(1 << 26)
+#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
+#define PIN_PC27D_PARC_PCDATA3         _L(91) /**< \brief PARC signal: PCDATA3 on PC27 mux D */
+#define MUX_PC27D_PARC_PCDATA3          _L(3)
+#define PINMUX_PC27D_PARC_PCDATA3  ((PIN_PC27D_PARC_PCDATA3 << 16) | MUX_PC27D_PARC_PCDATA3)
+#define GPIO_PC27D_PARC_PCDATA3  _UL(1 << 27)
+#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
+#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
+#define PIN_PC28D_PARC_PCDATA4         _L(92) /**< \brief PARC signal: PCDATA4 on PC28 mux D */
+#define MUX_PC28D_PARC_PCDATA4          _L(3)
+#define PINMUX_PC28D_PARC_PCDATA4  ((PIN_PC28D_PARC_PCDATA4 << 16) | MUX_PC28D_PARC_PCDATA4)
+#define GPIO_PC28D_PARC_PCDATA4  _UL(1 << 28)
+#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
+#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
+#define PIN_PC29D_PARC_PCDATA5         _L(93) /**< \brief PARC signal: PCDATA5 on PC29 mux D */
+#define MUX_PC29D_PARC_PCDATA5          _L(3)
+#define PINMUX_PC29D_PARC_PCDATA5  ((PIN_PC29D_PARC_PCDATA5 << 16) | MUX_PC29D_PARC_PCDATA5)
+#define GPIO_PC29D_PARC_PCDATA5  _UL(1 << 29)
+#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
+#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
+#define PIN_PC30D_PARC_PCDATA6         _L(94) /**< \brief PARC signal: PCDATA6 on PC30 mux D */
+#define MUX_PC30D_PARC_PCDATA6          _L(3)
+#define PINMUX_PC30D_PARC_PCDATA6  ((PIN_PC30D_PARC_PCDATA6 << 16) | MUX_PC30D_PARC_PCDATA6)
+#define GPIO_PC30D_PARC_PCDATA6  _UL(1 << 30)
+#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
+#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
+#define PIN_PC31D_PARC_PCDATA7         _L(95) /**< \brief PARC signal: PCDATA7 on PC31 mux D */
+#define MUX_PC31D_PARC_PCDATA7          _L(3)
+#define PINMUX_PC31D_PARC_PCDATA7  ((PIN_PC31D_PARC_PCDATA7 << 16) | MUX_PC31D_PARC_PCDATA7)
+#define GPIO_PC31D_PARC_PCDATA7  _UL(1 << 31)
+#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
+#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
+#define PIN_PC22D_PARC_PCEN1           _L(86) /**< \brief PARC signal: PCEN1 on PC22 mux D */
+#define MUX_PC22D_PARC_PCEN1            _L(3)
+#define PINMUX_PC22D_PARC_PCEN1    ((PIN_PC22D_PARC_PCEN1 << 16) | MUX_PC22D_PARC_PCEN1)
+#define GPIO_PC22D_PARC_PCEN1    _UL(1 << 22)
+#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
+#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+#define PIN_PC23D_PARC_PCEN2           _L(87) /**< \brief PARC signal: PCEN2 on PC23 mux D */
+#define MUX_PC23D_PARC_PCEN2            _L(3)
+#define PINMUX_PC23D_PARC_PCEN2    ((PIN_PC23D_PARC_PCEN2 << 16) | MUX_PC23D_PARC_PCEN2)
+#define GPIO_PC23D_PARC_PCEN2    _UL(1 << 23)
+/* ========== GPIO definition for CATB peripheral ========== */
+#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L(6)
+#define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
+#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L(6)
+#define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
+#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L(6)
+#define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
+#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
+#define PIN_PA31G_CATB_DIS             _L(31) /**< \brief CATB signal: DIS on PA31 mux G */
+#define MUX_PA31G_CATB_DIS              _L(6)
+#define PINMUX_PA31G_CATB_DIS      ((PIN_PA31G_CATB_DIS << 16) | MUX_PA31G_CATB_DIS)
+#define GPIO_PA31G_CATB_DIS      _UL(1 << 31)
+#define PIN_PB03G_CATB_DIS             _L(35) /**< \brief CATB signal: DIS on PB03 mux G */
+#define MUX_PB03G_CATB_DIS              _L(6)
+#define PINMUX_PB03G_CATB_DIS      ((PIN_PB03G_CATB_DIS << 16) | MUX_PB03G_CATB_DIS)
+#define GPIO_PB03G_CATB_DIS      _UL(1 <<  3)
+#define PIN_PB12G_CATB_DIS             _L(44) /**< \brief CATB signal: DIS on PB12 mux G */
+#define MUX_PB12G_CATB_DIS              _L(6)
+#define PINMUX_PB12G_CATB_DIS      ((PIN_PB12G_CATB_DIS << 16) | MUX_PB12G_CATB_DIS)
+#define GPIO_PB12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PC05G_CATB_DIS             _L(69) /**< \brief CATB signal: DIS on PC05 mux G */
+#define MUX_PC05G_CATB_DIS              _L(6)
+#define PINMUX_PC05G_CATB_DIS      ((PIN_PC05G_CATB_DIS << 16) | MUX_PC05G_CATB_DIS)
+#define GPIO_PC05G_CATB_DIS      _UL(1 <<  5)
+#define PIN_PC14G_CATB_DIS             _L(78) /**< \brief CATB signal: DIS on PC14 mux G */
+#define MUX_PC14G_CATB_DIS              _L(6)
+#define PINMUX_PC14G_CATB_DIS      ((PIN_PC14G_CATB_DIS << 16) | MUX_PC14G_CATB_DIS)
+#define GPIO_PC14G_CATB_DIS      _UL(1 << 14)
+#define PIN_PC23G_CATB_DIS             _L(87) /**< \brief CATB signal: DIS on PC23 mux G */
+#define MUX_PC23G_CATB_DIS              _L(6)
+#define PINMUX_PC23G_CATB_DIS      ((PIN_PC23G_CATB_DIS << 16) | MUX_PC23G_CATB_DIS)
+#define GPIO_PC23G_CATB_DIS      _UL(1 << 23)
+#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
+#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
+#define PIN_PA27G_CATB_SENSE0          _L(27) /**< \brief CATB signal: SENSE0 on PA27 mux G */
+#define MUX_PA27G_CATB_SENSE0           _L(6)
+#define PINMUX_PA27G_CATB_SENSE0   ((PIN_PA27G_CATB_SENSE0 << 16) | MUX_PA27G_CATB_SENSE0)
+#define GPIO_PA27G_CATB_SENSE0   _UL(1 << 27)
+#define PIN_PB13G_CATB_SENSE0          _L(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
+#define MUX_PB13G_CATB_SENSE0           _L(6)
+#define PINMUX_PB13G_CATB_SENSE0   ((PIN_PB13G_CATB_SENSE0 << 16) | MUX_PB13G_CATB_SENSE0)
+#define GPIO_PB13G_CATB_SENSE0   _UL(1 << 13)
+#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
+#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
+#define PIN_PA28G_CATB_SENSE1          _L(28) /**< \brief CATB signal: SENSE1 on PA28 mux G */
+#define MUX_PA28G_CATB_SENSE1           _L(6)
+#define PINMUX_PA28G_CATB_SENSE1   ((PIN_PA28G_CATB_SENSE1 << 16) | MUX_PA28G_CATB_SENSE1)
+#define GPIO_PA28G_CATB_SENSE1   _UL(1 << 28)
+#define PIN_PB14G_CATB_SENSE1          _L(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
+#define MUX_PB14G_CATB_SENSE1           _L(6)
+#define PINMUX_PB14G_CATB_SENSE1   ((PIN_PB14G_CATB_SENSE1 << 16) | MUX_PB14G_CATB_SENSE1)
+#define GPIO_PB14G_CATB_SENSE1   _UL(1 << 14)
+#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
+#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
+#define PIN_PA29G_CATB_SENSE2          _L(29) /**< \brief CATB signal: SENSE2 on PA29 mux G */
+#define MUX_PA29G_CATB_SENSE2           _L(6)
+#define PINMUX_PA29G_CATB_SENSE2   ((PIN_PA29G_CATB_SENSE2 << 16) | MUX_PA29G_CATB_SENSE2)
+#define GPIO_PA29G_CATB_SENSE2   _UL(1 << 29)
+#define PIN_PB15G_CATB_SENSE2          _L(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
+#define MUX_PB15G_CATB_SENSE2           _L(6)
+#define PINMUX_PB15G_CATB_SENSE2   ((PIN_PB15G_CATB_SENSE2 << 16) | MUX_PB15G_CATB_SENSE2)
+#define GPIO_PB15G_CATB_SENSE2   _UL(1 << 15)
+#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
+#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
+#define PIN_PA30G_CATB_SENSE3          _L(30) /**< \brief CATB signal: SENSE3 on PA30 mux G */
+#define MUX_PA30G_CATB_SENSE3           _L(6)
+#define PINMUX_PA30G_CATB_SENSE3   ((PIN_PA30G_CATB_SENSE3 << 16) | MUX_PA30G_CATB_SENSE3)
+#define GPIO_PA30G_CATB_SENSE3   _UL(1 << 30)
+#define PIN_PC00G_CATB_SENSE3          _L(64) /**< \brief CATB signal: SENSE3 on PC00 mux G */
+#define MUX_PC00G_CATB_SENSE3           _L(6)
+#define PINMUX_PC00G_CATB_SENSE3   ((PIN_PC00G_CATB_SENSE3 << 16) | MUX_PC00G_CATB_SENSE3)
+#define GPIO_PC00G_CATB_SENSE3   _UL(1 <<  0)
+#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
+#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
+#define PIN_PC01G_CATB_SENSE4          _L(65) /**< \brief CATB signal: SENSE4 on PC01 mux G */
+#define MUX_PC01G_CATB_SENSE4           _L(6)
+#define PINMUX_PC01G_CATB_SENSE4   ((PIN_PC01G_CATB_SENSE4 << 16) | MUX_PC01G_CATB_SENSE4)
+#define GPIO_PC01G_CATB_SENSE4   _UL(1 <<  1)
+#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
+#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
+#define PIN_PC02G_CATB_SENSE5          _L(66) /**< \brief CATB signal: SENSE5 on PC02 mux G */
+#define MUX_PC02G_CATB_SENSE5           _L(6)
+#define PINMUX_PC02G_CATB_SENSE5   ((PIN_PC02G_CATB_SENSE5 << 16) | MUX_PC02G_CATB_SENSE5)
+#define GPIO_PC02G_CATB_SENSE5   _UL(1 <<  2)
+#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
+#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
+#define PIN_PC03G_CATB_SENSE6          _L(67) /**< \brief CATB signal: SENSE6 on PC03 mux G */
+#define MUX_PC03G_CATB_SENSE6           _L(6)
+#define PINMUX_PC03G_CATB_SENSE6   ((PIN_PC03G_CATB_SENSE6 << 16) | MUX_PC03G_CATB_SENSE6)
+#define GPIO_PC03G_CATB_SENSE6   _UL(1 <<  3)
+#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
+#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
+#define PIN_PC04G_CATB_SENSE7          _L(68) /**< \brief CATB signal: SENSE7 on PC04 mux G */
+#define MUX_PC04G_CATB_SENSE7           _L(6)
+#define PINMUX_PC04G_CATB_SENSE7   ((PIN_PC04G_CATB_SENSE7 << 16) | MUX_PC04G_CATB_SENSE7)
+#define GPIO_PC04G_CATB_SENSE7   _UL(1 <<  4)
+#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
+#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
+#define PIN_PC06G_CATB_SENSE8          _L(70) /**< \brief CATB signal: SENSE8 on PC06 mux G */
+#define MUX_PC06G_CATB_SENSE8           _L(6)
+#define PINMUX_PC06G_CATB_SENSE8   ((PIN_PC06G_CATB_SENSE8 << 16) | MUX_PC06G_CATB_SENSE8)
+#define GPIO_PC06G_CATB_SENSE8   _UL(1 <<  6)
+#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
+#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
+#define PIN_PC07G_CATB_SENSE9          _L(71) /**< \brief CATB signal: SENSE9 on PC07 mux G */
+#define MUX_PC07G_CATB_SENSE9           _L(6)
+#define PINMUX_PC07G_CATB_SENSE9   ((PIN_PC07G_CATB_SENSE9 << 16) | MUX_PC07G_CATB_SENSE9)
+#define GPIO_PC07G_CATB_SENSE9   _UL(1 <<  7)
+#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
+#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
+#define PIN_PC08G_CATB_SENSE10         _L(72) /**< \brief CATB signal: SENSE10 on PC08 mux G */
+#define MUX_PC08G_CATB_SENSE10          _L(6)
+#define PINMUX_PC08G_CATB_SENSE10  ((PIN_PC08G_CATB_SENSE10 << 16) | MUX_PC08G_CATB_SENSE10)
+#define GPIO_PC08G_CATB_SENSE10  _UL(1 <<  8)
+#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
+#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
+#define PIN_PC09G_CATB_SENSE11         _L(73) /**< \brief CATB signal: SENSE11 on PC09 mux G */
+#define MUX_PC09G_CATB_SENSE11          _L(6)
+#define PINMUX_PC09G_CATB_SENSE11  ((PIN_PC09G_CATB_SENSE11 << 16) | MUX_PC09G_CATB_SENSE11)
+#define GPIO_PC09G_CATB_SENSE11  _UL(1 <<  9)
+#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
+#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
+#define PIN_PC10G_CATB_SENSE12         _L(74) /**< \brief CATB signal: SENSE12 on PC10 mux G */
+#define MUX_PC10G_CATB_SENSE12          _L(6)
+#define PINMUX_PC10G_CATB_SENSE12  ((PIN_PC10G_CATB_SENSE12 << 16) | MUX_PC10G_CATB_SENSE12)
+#define GPIO_PC10G_CATB_SENSE12  _UL(1 << 10)
+#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
+#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
+#define PIN_PC11G_CATB_SENSE13         _L(75) /**< \brief CATB signal: SENSE13 on PC11 mux G */
+#define MUX_PC11G_CATB_SENSE13          _L(6)
+#define PINMUX_PC11G_CATB_SENSE13  ((PIN_PC11G_CATB_SENSE13 << 16) | MUX_PC11G_CATB_SENSE13)
+#define GPIO_PC11G_CATB_SENSE13  _UL(1 << 11)
+#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
+#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
+#define PIN_PC12G_CATB_SENSE14         _L(76) /**< \brief CATB signal: SENSE14 on PC12 mux G */
+#define MUX_PC12G_CATB_SENSE14          _L(6)
+#define PINMUX_PC12G_CATB_SENSE14  ((PIN_PC12G_CATB_SENSE14 << 16) | MUX_PC12G_CATB_SENSE14)
+#define GPIO_PC12G_CATB_SENSE14  _UL(1 << 12)
+#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
+#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
+#define PIN_PC13G_CATB_SENSE15         _L(77) /**< \brief CATB signal: SENSE15 on PC13 mux G */
+#define MUX_PC13G_CATB_SENSE15          _L(6)
+#define PINMUX_PC13G_CATB_SENSE15  ((PIN_PC13G_CATB_SENSE15 << 16) | MUX_PC13G_CATB_SENSE15)
+#define GPIO_PC13G_CATB_SENSE15  _UL(1 << 13)
+#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
+#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
+#define PIN_PC15G_CATB_SENSE16         _L(79) /**< \brief CATB signal: SENSE16 on PC15 mux G */
+#define MUX_PC15G_CATB_SENSE16          _L(6)
+#define PINMUX_PC15G_CATB_SENSE16  ((PIN_PC15G_CATB_SENSE16 << 16) | MUX_PC15G_CATB_SENSE16)
+#define GPIO_PC15G_CATB_SENSE16  _UL(1 << 15)
+#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
+#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
+#define PIN_PC16G_CATB_SENSE17         _L(80) /**< \brief CATB signal: SENSE17 on PC16 mux G */
+#define MUX_PC16G_CATB_SENSE17          _L(6)
+#define PINMUX_PC16G_CATB_SENSE17  ((PIN_PC16G_CATB_SENSE17 << 16) | MUX_PC16G_CATB_SENSE17)
+#define GPIO_PC16G_CATB_SENSE17  _UL(1 << 16)
+#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
+#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
+#define PIN_PC17G_CATB_SENSE18         _L(81) /**< \brief CATB signal: SENSE18 on PC17 mux G */
+#define MUX_PC17G_CATB_SENSE18          _L(6)
+#define PINMUX_PC17G_CATB_SENSE18  ((PIN_PC17G_CATB_SENSE18 << 16) | MUX_PC17G_CATB_SENSE18)
+#define GPIO_PC17G_CATB_SENSE18  _UL(1 << 17)
+#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
+#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
+#define PIN_PC18G_CATB_SENSE19         _L(82) /**< \brief CATB signal: SENSE19 on PC18 mux G */
+#define MUX_PC18G_CATB_SENSE19          _L(6)
+#define PINMUX_PC18G_CATB_SENSE19  ((PIN_PC18G_CATB_SENSE19 << 16) | MUX_PC18G_CATB_SENSE19)
+#define GPIO_PC18G_CATB_SENSE19  _UL(1 << 18)
+#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
+#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
+#define PIN_PC19G_CATB_SENSE20         _L(83) /**< \brief CATB signal: SENSE20 on PC19 mux G */
+#define MUX_PC19G_CATB_SENSE20          _L(6)
+#define PINMUX_PC19G_CATB_SENSE20  ((PIN_PC19G_CATB_SENSE20 << 16) | MUX_PC19G_CATB_SENSE20)
+#define GPIO_PC19G_CATB_SENSE20  _UL(1 << 19)
+#define PIN_PB00G_CATB_SENSE21         _L(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
+#define MUX_PB00G_CATB_SENSE21          _L(6)
+#define PINMUX_PB00G_CATB_SENSE21  ((PIN_PB00G_CATB_SENSE21 << 16) | MUX_PB00G_CATB_SENSE21)
+#define GPIO_PB00G_CATB_SENSE21  _UL(1 <<  0)
+#define PIN_PC20G_CATB_SENSE21         _L(84) /**< \brief CATB signal: SENSE21 on PC20 mux G */
+#define MUX_PC20G_CATB_SENSE21          _L(6)
+#define PINMUX_PC20G_CATB_SENSE21  ((PIN_PC20G_CATB_SENSE21 << 16) | MUX_PC20G_CATB_SENSE21)
+#define GPIO_PC20G_CATB_SENSE21  _UL(1 << 20)
+#define PIN_PB01G_CATB_SENSE22         _L(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
+#define MUX_PB01G_CATB_SENSE22          _L(6)
+#define PINMUX_PB01G_CATB_SENSE22  ((PIN_PB01G_CATB_SENSE22 << 16) | MUX_PB01G_CATB_SENSE22)
+#define GPIO_PB01G_CATB_SENSE22  _UL(1 <<  1)
+#define PIN_PC21G_CATB_SENSE22         _L(85) /**< \brief CATB signal: SENSE22 on PC21 mux G */
+#define MUX_PC21G_CATB_SENSE22          _L(6)
+#define PINMUX_PC21G_CATB_SENSE22  ((PIN_PC21G_CATB_SENSE22 << 16) | MUX_PC21G_CATB_SENSE22)
+#define GPIO_PC21G_CATB_SENSE22  _UL(1 << 21)
+#define PIN_PB02G_CATB_SENSE23         _L(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
+#define MUX_PB02G_CATB_SENSE23          _L(6)
+#define PINMUX_PB02G_CATB_SENSE23  ((PIN_PB02G_CATB_SENSE23 << 16) | MUX_PB02G_CATB_SENSE23)
+#define GPIO_PB02G_CATB_SENSE23  _UL(1 <<  2)
+#define PIN_PC22G_CATB_SENSE23         _L(86) /**< \brief CATB signal: SENSE23 on PC22 mux G */
+#define MUX_PC22G_CATB_SENSE23          _L(6)
+#define PINMUX_PC22G_CATB_SENSE23  ((PIN_PC22G_CATB_SENSE23 << 16) | MUX_PC22G_CATB_SENSE23)
+#define GPIO_PC22G_CATB_SENSE23  _UL(1 << 22)
+#define PIN_PB04G_CATB_SENSE24         _L(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
+#define MUX_PB04G_CATB_SENSE24          _L(6)
+#define PINMUX_PB04G_CATB_SENSE24  ((PIN_PB04G_CATB_SENSE24 << 16) | MUX_PB04G_CATB_SENSE24)
+#define GPIO_PB04G_CATB_SENSE24  _UL(1 <<  4)
+#define PIN_PC24G_CATB_SENSE24         _L(88) /**< \brief CATB signal: SENSE24 on PC24 mux G */
+#define MUX_PC24G_CATB_SENSE24          _L(6)
+#define PINMUX_PC24G_CATB_SENSE24  ((PIN_PC24G_CATB_SENSE24 << 16) | MUX_PC24G_CATB_SENSE24)
+#define GPIO_PC24G_CATB_SENSE24  _UL(1 << 24)
+#define PIN_PB05G_CATB_SENSE25         _L(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
+#define MUX_PB05G_CATB_SENSE25          _L(6)
+#define PINMUX_PB05G_CATB_SENSE25  ((PIN_PB05G_CATB_SENSE25 << 16) | MUX_PB05G_CATB_SENSE25)
+#define GPIO_PB05G_CATB_SENSE25  _UL(1 <<  5)
+#define PIN_PC25G_CATB_SENSE25         _L(89) /**< \brief CATB signal: SENSE25 on PC25 mux G */
+#define MUX_PC25G_CATB_SENSE25          _L(6)
+#define PINMUX_PC25G_CATB_SENSE25  ((PIN_PC25G_CATB_SENSE25 << 16) | MUX_PC25G_CATB_SENSE25)
+#define GPIO_PC25G_CATB_SENSE25  _UL(1 << 25)
+#define PIN_PB06G_CATB_SENSE26         _L(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
+#define MUX_PB06G_CATB_SENSE26          _L(6)
+#define PINMUX_PB06G_CATB_SENSE26  ((PIN_PB06G_CATB_SENSE26 << 16) | MUX_PB06G_CATB_SENSE26)
+#define GPIO_PB06G_CATB_SENSE26  _UL(1 <<  6)
+#define PIN_PC26G_CATB_SENSE26         _L(90) /**< \brief CATB signal: SENSE26 on PC26 mux G */
+#define MUX_PC26G_CATB_SENSE26          _L(6)
+#define PINMUX_PC26G_CATB_SENSE26  ((PIN_PC26G_CATB_SENSE26 << 16) | MUX_PC26G_CATB_SENSE26)
+#define GPIO_PC26G_CATB_SENSE26  _UL(1 << 26)
+#define PIN_PB07G_CATB_SENSE27         _L(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
+#define MUX_PB07G_CATB_SENSE27          _L(6)
+#define PINMUX_PB07G_CATB_SENSE27  ((PIN_PB07G_CATB_SENSE27 << 16) | MUX_PB07G_CATB_SENSE27)
+#define GPIO_PB07G_CATB_SENSE27  _UL(1 <<  7)
+#define PIN_PC27G_CATB_SENSE27         _L(91) /**< \brief CATB signal: SENSE27 on PC27 mux G */
+#define MUX_PC27G_CATB_SENSE27          _L(6)
+#define PINMUX_PC27G_CATB_SENSE27  ((PIN_PC27G_CATB_SENSE27 << 16) | MUX_PC27G_CATB_SENSE27)
+#define GPIO_PC27G_CATB_SENSE27  _UL(1 << 27)
+#define PIN_PB08G_CATB_SENSE28         _L(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
+#define MUX_PB08G_CATB_SENSE28          _L(6)
+#define PINMUX_PB08G_CATB_SENSE28  ((PIN_PB08G_CATB_SENSE28 << 16) | MUX_PB08G_CATB_SENSE28)
+#define GPIO_PB08G_CATB_SENSE28  _UL(1 <<  8)
+#define PIN_PC28G_CATB_SENSE28         _L(92) /**< \brief CATB signal: SENSE28 on PC28 mux G */
+#define MUX_PC28G_CATB_SENSE28          _L(6)
+#define PINMUX_PC28G_CATB_SENSE28  ((PIN_PC28G_CATB_SENSE28 << 16) | MUX_PC28G_CATB_SENSE28)
+#define GPIO_PC28G_CATB_SENSE28  _UL(1 << 28)
+#define PIN_PB09G_CATB_SENSE29         _L(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
+#define MUX_PB09G_CATB_SENSE29          _L(6)
+#define PINMUX_PB09G_CATB_SENSE29  ((PIN_PB09G_CATB_SENSE29 << 16) | MUX_PB09G_CATB_SENSE29)
+#define GPIO_PB09G_CATB_SENSE29  _UL(1 <<  9)
+#define PIN_PC29G_CATB_SENSE29         _L(93) /**< \brief CATB signal: SENSE29 on PC29 mux G */
+#define MUX_PC29G_CATB_SENSE29          _L(6)
+#define PINMUX_PC29G_CATB_SENSE29  ((PIN_PC29G_CATB_SENSE29 << 16) | MUX_PC29G_CATB_SENSE29)
+#define GPIO_PC29G_CATB_SENSE29  _UL(1 << 29)
+#define PIN_PB10G_CATB_SENSE30         _L(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
+#define MUX_PB10G_CATB_SENSE30          _L(6)
+#define PINMUX_PB10G_CATB_SENSE30  ((PIN_PB10G_CATB_SENSE30 << 16) | MUX_PB10G_CATB_SENSE30)
+#define GPIO_PB10G_CATB_SENSE30  _UL(1 << 10)
+#define PIN_PC30G_CATB_SENSE30         _L(94) /**< \brief CATB signal: SENSE30 on PC30 mux G */
+#define MUX_PC30G_CATB_SENSE30          _L(6)
+#define PINMUX_PC30G_CATB_SENSE30  ((PIN_PC30G_CATB_SENSE30 << 16) | MUX_PC30G_CATB_SENSE30)
+#define GPIO_PC30G_CATB_SENSE30  _UL(1 << 30)
+#define PIN_PB11G_CATB_SENSE31         _L(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
+#define MUX_PB11G_CATB_SENSE31          _L(6)
+#define PINMUX_PB11G_CATB_SENSE31  ((PIN_PB11G_CATB_SENSE31 << 16) | MUX_PB11G_CATB_SENSE31)
+#define GPIO_PB11G_CATB_SENSE31  _UL(1 << 11)
+#define PIN_PC31G_CATB_SENSE31         _L(95) /**< \brief CATB signal: SENSE31 on PC31 mux G */
+#define MUX_PC31G_CATB_SENSE31          _L(6)
+#define PINMUX_PC31G_CATB_SENSE31  ((PIN_PC31G_CATB_SENSE31 << 16) | MUX_PC31G_CATB_SENSE31)
+#define GPIO_PC31G_CATB_SENSE31  _UL(1 << 31)
+/* ========== GPIO definition for USBC peripheral ========== */
+#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L(0)
+#define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
+#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
+#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L(0)
+#define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
+#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+/* ========== GPIO definition for PEVC peripheral ========== */
+#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
+#define PIN_PB12C_PEVC_PAD_EVT0        _L(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
+#define MUX_PB12C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PB12C_PEVC_PAD_EVT0  ((PIN_PB12C_PEVC_PAD_EVT0 << 16) | MUX_PB12C_PEVC_PAD_EVT0)
+#define GPIO_PB12C_PEVC_PAD_EVT0  _UL(1 << 12)
+#define PIN_PC07C_PEVC_PAD_EVT0        _L(71) /**< \brief PEVC signal: PAD_EVT0 on PC07 mux C */
+#define MUX_PC07C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PC07C_PEVC_PAD_EVT0  ((PIN_PC07C_PEVC_PAD_EVT0 << 16) | MUX_PC07C_PEVC_PAD_EVT0)
+#define GPIO_PC07C_PEVC_PAD_EVT0  _UL(1 <<  7)
+#define PIN_PC24C_PEVC_PAD_EVT0        _L(88) /**< \brief PEVC signal: PAD_EVT0 on PC24 mux C */
+#define MUX_PC24C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PC24C_PEVC_PAD_EVT0  ((PIN_PC24C_PEVC_PAD_EVT0 << 16) | MUX_PC24C_PEVC_PAD_EVT0)
+#define GPIO_PC24C_PEVC_PAD_EVT0  _UL(1 << 24)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
+#define PIN_PB13C_PEVC_PAD_EVT1        _L(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
+#define MUX_PB13C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PB13C_PEVC_PAD_EVT1  ((PIN_PB13C_PEVC_PAD_EVT1 << 16) | MUX_PB13C_PEVC_PAD_EVT1)
+#define GPIO_PB13C_PEVC_PAD_EVT1  _UL(1 << 13)
+#define PIN_PC08C_PEVC_PAD_EVT1        _L(72) /**< \brief PEVC signal: PAD_EVT1 on PC08 mux C */
+#define MUX_PC08C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PC08C_PEVC_PAD_EVT1  ((PIN_PC08C_PEVC_PAD_EVT1 << 16) | MUX_PC08C_PEVC_PAD_EVT1)
+#define GPIO_PC08C_PEVC_PAD_EVT1  _UL(1 <<  8)
+#define PIN_PC25C_PEVC_PAD_EVT1        _L(89) /**< \brief PEVC signal: PAD_EVT1 on PC25 mux C */
+#define MUX_PC25C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PC25C_PEVC_PAD_EVT1  ((PIN_PC25C_PEVC_PAD_EVT1 << 16) | MUX_PC25C_PEVC_PAD_EVT1)
+#define GPIO_PC25C_PEVC_PAD_EVT1  _UL(1 << 25)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
+#define PIN_PC11C_PEVC_PAD_EVT2        _L(75) /**< \brief PEVC signal: PAD_EVT2 on PC11 mux C */
+#define MUX_PC11C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PC11C_PEVC_PAD_EVT2  ((PIN_PC11C_PEVC_PAD_EVT2 << 16) | MUX_PC11C_PEVC_PAD_EVT2)
+#define GPIO_PC11C_PEVC_PAD_EVT2  _UL(1 << 11)
+#define PIN_PC26C_PEVC_PAD_EVT2        _L(90) /**< \brief PEVC signal: PAD_EVT2 on PC26 mux C */
+#define MUX_PC26C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PC26C_PEVC_PAD_EVT2  ((PIN_PC26C_PEVC_PAD_EVT2 << 16) | MUX_PC26C_PEVC_PAD_EVT2)
+#define GPIO_PC26C_PEVC_PAD_EVT2  _UL(1 << 26)
+#define PIN_PB09B_PEVC_PAD_EVT2        _L(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
+#define MUX_PB09B_PEVC_PAD_EVT2         _L(1)
+#define PINMUX_PB09B_PEVC_PAD_EVT2  ((PIN_PB09B_PEVC_PAD_EVT2 << 16) | MUX_PB09B_PEVC_PAD_EVT2)
+#define GPIO_PB09B_PEVC_PAD_EVT2  _UL(1 <<  9)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
+#define PIN_PC27C_PEVC_PAD_EVT3        _L(91) /**< \brief PEVC signal: PAD_EVT3 on PC27 mux C */
+#define MUX_PC27C_PEVC_PAD_EVT3         _L(2)
+#define PINMUX_PC27C_PEVC_PAD_EVT3  ((PIN_PC27C_PEVC_PAD_EVT3 << 16) | MUX_PC27C_PEVC_PAD_EVT3)
+#define GPIO_PC27C_PEVC_PAD_EVT3  _UL(1 << 27)
+#define PIN_PB10B_PEVC_PAD_EVT3        _L(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
+#define MUX_PB10B_PEVC_PAD_EVT3         _L(1)
+#define PINMUX_PB10B_PEVC_PAD_EVT3  ((PIN_PB10B_PEVC_PAD_EVT3 << 16) | MUX_PB10B_PEVC_PAD_EVT3)
+#define GPIO_PB10B_PEVC_PAD_EVT3  _UL(1 << 10)
+/* ========== GPIO definition for SCIF peripheral ========== */
+#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
+#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
+#define PIN_PB10E_SCIF_GCLK0           _L(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
+#define MUX_PB10E_SCIF_GCLK0            _L(4)
+#define PINMUX_PB10E_SCIF_GCLK0    ((PIN_PB10E_SCIF_GCLK0 << 16) | MUX_PB10E_SCIF_GCLK0)
+#define GPIO_PB10E_SCIF_GCLK0    _UL(1 << 10)
+#define PIN_PC26E_SCIF_GCLK0           _L(90) /**< \brief SCIF signal: GCLK0 on PC26 mux E */
+#define MUX_PC26E_SCIF_GCLK0            _L(4)
+#define PINMUX_PC26E_SCIF_GCLK0    ((PIN_PC26E_SCIF_GCLK0 << 16) | MUX_PC26E_SCIF_GCLK0)
+#define GPIO_PC26E_SCIF_GCLK0    _UL(1 << 26)
+#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
+#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
+#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
+#define PIN_PB11E_SCIF_GCLK1           _L(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
+#define MUX_PB11E_SCIF_GCLK1            _L(4)
+#define PINMUX_PB11E_SCIF_GCLK1    ((PIN_PB11E_SCIF_GCLK1 << 16) | MUX_PB11E_SCIF_GCLK1)
+#define GPIO_PB11E_SCIF_GCLK1    _UL(1 << 11)
+#define PIN_PC27E_SCIF_GCLK1           _L(91) /**< \brief SCIF signal: GCLK1 on PC27 mux E */
+#define MUX_PC27E_SCIF_GCLK1            _L(4)
+#define PINMUX_PC27E_SCIF_GCLK1    ((PIN_PC27E_SCIF_GCLK1 << 16) | MUX_PC27E_SCIF_GCLK1)
+#define GPIO_PC27E_SCIF_GCLK1    _UL(1 << 27)
+#define PIN_PB12E_SCIF_GCLK2           _L(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
+#define MUX_PB12E_SCIF_GCLK2            _L(4)
+#define PINMUX_PB12E_SCIF_GCLK2    ((PIN_PB12E_SCIF_GCLK2 << 16) | MUX_PB12E_SCIF_GCLK2)
+#define GPIO_PB12E_SCIF_GCLK2    _UL(1 << 12)
+#define PIN_PC28E_SCIF_GCLK2           _L(92) /**< \brief SCIF signal: GCLK2 on PC28 mux E */
+#define MUX_PC28E_SCIF_GCLK2            _L(4)
+#define PINMUX_PC28E_SCIF_GCLK2    ((PIN_PC28E_SCIF_GCLK2 << 16) | MUX_PC28E_SCIF_GCLK2)
+#define GPIO_PC28E_SCIF_GCLK2    _UL(1 << 28)
+#define PIN_PB13E_SCIF_GCLK3           _L(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
+#define MUX_PB13E_SCIF_GCLK3            _L(4)
+#define PINMUX_PB13E_SCIF_GCLK3    ((PIN_PB13E_SCIF_GCLK3 << 16) | MUX_PB13E_SCIF_GCLK3)
+#define GPIO_PB13E_SCIF_GCLK3    _UL(1 << 13)
+#define PIN_PC29E_SCIF_GCLK3           _L(93) /**< \brief SCIF signal: GCLK3 on PC29 mux E */
+#define MUX_PC29E_SCIF_GCLK3            _L(4)
+#define PINMUX_PC29E_SCIF_GCLK3    ((PIN_PC29E_SCIF_GCLK3 << 16) | MUX_PC29E_SCIF_GCLK3)
+#define GPIO_PC29E_SCIF_GCLK3    _UL(1 << 29)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
+#define PIN_PB14E_SCIF_GCLK_IN0        _L(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
+#define MUX_PB14E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PB14E_SCIF_GCLK_IN0  ((PIN_PB14E_SCIF_GCLK_IN0 << 16) | MUX_PB14E_SCIF_GCLK_IN0)
+#define GPIO_PB14E_SCIF_GCLK_IN0  _UL(1 << 14)
+#define PIN_PC30E_SCIF_GCLK_IN0        _L(94) /**< \brief SCIF signal: GCLK_IN0 on PC30 mux E */
+#define MUX_PC30E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PC30E_SCIF_GCLK_IN0  ((PIN_PC30E_SCIF_GCLK_IN0 << 16) | MUX_PC30E_SCIF_GCLK_IN0)
+#define GPIO_PC30E_SCIF_GCLK_IN0  _UL(1 << 30)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
+#define PIN_PB15E_SCIF_GCLK_IN1        _L(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
+#define MUX_PB15E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PB15E_SCIF_GCLK_IN1  ((PIN_PB15E_SCIF_GCLK_IN1 << 16) | MUX_PB15E_SCIF_GCLK_IN1)
+#define GPIO_PB15E_SCIF_GCLK_IN1  _UL(1 << 15)
+#define PIN_PC31E_SCIF_GCLK_IN1        _L(95) /**< \brief SCIF signal: GCLK_IN1 on PC31 mux E */
+#define MUX_PC31E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PC31E_SCIF_GCLK_IN1  ((PIN_PC31E_SCIF_GCLK_IN1 << 16) | MUX_PC31E_SCIF_GCLK_IN1)
+#define GPIO_PC31E_SCIF_GCLK_IN1  _UL(1 << 31)
+/* ========== GPIO definition for EIC peripheral ========== */
+#define PIN_PB01C_EIC_EXTINT0          _L(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
+#define MUX_PB01C_EIC_EXTINT0           _L(2)
+#define PINMUX_PB01C_EIC_EXTINT0   ((PIN_PB01C_EIC_EXTINT0 << 16) | MUX_PB01C_EIC_EXTINT0)
+#define GPIO_PB01C_EIC_EXTINT0   _UL(1 <<  1)
+#define PIN_PB01C_EIC_EXTINT_NUM        _L(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
+#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
+#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PC24B_EIC_EXTINT1          _L(88) /**< \brief EIC signal: EXTINT1 on PC24 mux B */
+#define MUX_PC24B_EIC_EXTINT1           _L(1)
+#define PINMUX_PC24B_EIC_EXTINT1   ((PIN_PC24B_EIC_EXTINT1 << 16) | MUX_PC24B_EIC_EXTINT1)
+#define GPIO_PC24B_EIC_EXTINT1   _UL(1 << 24)
+#define PIN_PC24B_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PC24 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PC25B_EIC_EXTINT2          _L(89) /**< \brief EIC signal: EXTINT2 on PC25 mux B */
+#define MUX_PC25B_EIC_EXTINT2           _L(1)
+#define PINMUX_PC25B_EIC_EXTINT2   ((PIN_PC25B_EIC_EXTINT2 << 16) | MUX_PC25B_EIC_EXTINT2)
+#define GPIO_PC25B_EIC_EXTINT2   _UL(1 << 25)
+#define PIN_PC25B_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PC25 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
+#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
+#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PC26B_EIC_EXTINT3          _L(90) /**< \brief EIC signal: EXTINT3 on PC26 mux B */
+#define MUX_PC26B_EIC_EXTINT3           _L(1)
+#define PINMUX_PC26B_EIC_EXTINT3   ((PIN_PC26B_EIC_EXTINT3 << 16) | MUX_PC26B_EIC_EXTINT3)
+#define GPIO_PC26B_EIC_EXTINT3   _UL(1 << 26)
+#define PIN_PC26B_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PC26 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
+#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
+#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PC27B_EIC_EXTINT4          _L(91) /**< \brief EIC signal: EXTINT4 on PC27 mux B */
+#define MUX_PC27B_EIC_EXTINT4           _L(1)
+#define PINMUX_PC27B_EIC_EXTINT4   ((PIN_PC27B_EIC_EXTINT4 << 16) | MUX_PC27B_EIC_EXTINT4)
+#define GPIO_PC27B_EIC_EXTINT4   _UL(1 << 27)
+#define PIN_PC27B_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PC27 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
+#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PC03B_EIC_EXTINT5          _L(67) /**< \brief EIC signal: EXTINT5 on PC03 mux B */
+#define MUX_PC03B_EIC_EXTINT5           _L(1)
+#define PINMUX_PC03B_EIC_EXTINT5   ((PIN_PC03B_EIC_EXTINT5 << 16) | MUX_PC03B_EIC_EXTINT5)
+#define GPIO_PC03B_EIC_EXTINT5   _UL(1 <<  3)
+#define PIN_PC03B_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PC03 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
+#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PC04B_EIC_EXTINT6          _L(68) /**< \brief EIC signal: EXTINT6 on PC04 mux B */
+#define MUX_PC04B_EIC_EXTINT6           _L(1)
+#define PINMUX_PC04B_EIC_EXTINT6   ((PIN_PC04B_EIC_EXTINT6 << 16) | MUX_PC04B_EIC_EXTINT6)
+#define GPIO_PC04B_EIC_EXTINT6   _UL(1 <<  4)
+#define PIN_PC04B_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PC04 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
+#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PC05B_EIC_EXTINT7          _L(69) /**< \brief EIC signal: EXTINT7 on PC05 mux B */
+#define MUX_PC05B_EIC_EXTINT7           _L(1)
+#define PINMUX_PC05B_EIC_EXTINT7   ((PIN_PC05B_EIC_EXTINT7 << 16) | MUX_PC05B_EIC_EXTINT7)
+#define GPIO_PC05B_EIC_EXTINT7   _UL(1 <<  5)
+#define PIN_PC05B_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PC05 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
+#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PC06B_EIC_EXTINT8          _L(70) /**< \brief EIC signal: EXTINT8 on PC06 mux B */
+#define MUX_PC06B_EIC_EXTINT8           _L(1)
+#define PINMUX_PC06B_EIC_EXTINT8   ((PIN_PC06B_EIC_EXTINT8 << 16) | MUX_PC06B_EIC_EXTINT8)
+#define GPIO_PC06B_EIC_EXTINT8   _UL(1 <<  6)
+#define PIN_PC06B_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PC06 External Interrupt Line */
+
+#endif /* _SAM4LS4C_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4ls8a.h
+++ b/asf/sam/include/sam4l/pio/sam4ls8a.h
@@ -1,0 +1,737 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAM4LS8A
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LS8A_PIO_
+#define _SAM4LS8A_PIO_
+
+#define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
+#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
+#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
+#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
+#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
+#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
+#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
+#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
+#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
+#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
+#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
+#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
+#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
+#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
+#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
+#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
+#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
+#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
+#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
+#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
+#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
+#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
+#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
+#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
+#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
+#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
+#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
+#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
+#define GPIO_PA27                _UL(1 << 27) /**< \brief GPIO Mask  for PA27 */
+#define PIN_PA28                          28  /**< \brief Pin Number for PA28 */
+#define GPIO_PA28                _UL(1 << 28) /**< \brief GPIO Mask  for PA28 */
+#define PIN_PA29                          29  /**< \brief Pin Number for PA29 */
+#define GPIO_PA29                _UL(1 << 29) /**< \brief GPIO Mask  for PA29 */
+#define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
+#define GPIO_PA30                _UL(1 << 30) /**< \brief GPIO Mask  for PA30 */
+#define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
+#define GPIO_PA31                _UL(1 << 31) /**< \brief GPIO Mask  for PA31 */
+/* ========== GPIO definition for TWIMS0 peripheral ========== */
+#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
+#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+/* ========== GPIO definition for TWIMS2 peripheral ========== */
+#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
+#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+/* ========== GPIO definition for IISC peripheral ========== */
+#define PIN_PA31B_IISC_IMCK            _L(31) /**< \brief IISC signal: IMCK on PA31 mux B */
+#define MUX_PA31B_IISC_IMCK             _L(1)
+#define PINMUX_PA31B_IISC_IMCK     ((PIN_PA31B_IISC_IMCK << 16) | MUX_PA31B_IISC_IMCK)
+#define GPIO_PA31B_IISC_IMCK     _UL(1 << 31)
+#define PIN_PA27B_IISC_ISCK            _L(27) /**< \brief IISC signal: ISCK on PA27 mux B */
+#define MUX_PA27B_IISC_ISCK             _L(1)
+#define PINMUX_PA27B_IISC_ISCK     ((PIN_PA27B_IISC_ISCK << 16) | MUX_PA27B_IISC_ISCK)
+#define GPIO_PA27B_IISC_ISCK     _UL(1 << 27)
+#define PIN_PA28B_IISC_ISDI            _L(28) /**< \brief IISC signal: ISDI on PA28 mux B */
+#define MUX_PA28B_IISC_ISDI             _L(1)
+#define PINMUX_PA28B_IISC_ISDI     ((PIN_PA28B_IISC_ISDI << 16) | MUX_PA28B_IISC_ISDI)
+#define GPIO_PA28B_IISC_ISDI     _UL(1 << 28)
+#define PIN_PA30B_IISC_ISDO            _L(30) /**< \brief IISC signal: ISDO on PA30 mux B */
+#define MUX_PA30B_IISC_ISDO             _L(1)
+#define PINMUX_PA30B_IISC_ISDO     ((PIN_PA30B_IISC_ISDO << 16) | MUX_PA30B_IISC_ISDO)
+#define GPIO_PA30B_IISC_ISDO     _UL(1 << 30)
+#define PIN_PA29B_IISC_IWS             _L(29) /**< \brief IISC signal: IWS on PA29 mux B */
+#define MUX_PA29B_IISC_IWS              _L(1)
+#define PINMUX_PA29B_IISC_IWS      ((PIN_PA29B_IISC_IWS << 16) | MUX_PA29B_IISC_IWS)
+#define GPIO_PA29B_IISC_IWS      _UL(1 << 29)
+/* ========== GPIO definition for SPI peripheral ========== */
+#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L(1)
+#define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
+#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
+#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L(0)
+#define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
+#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
+#define PIN_PA27A_SPI_MISO             _L(27) /**< \brief SPI signal: MISO on PA27 mux A */
+#define MUX_PA27A_SPI_MISO              _L(0)
+#define PINMUX_PA27A_SPI_MISO      ((PIN_PA27A_SPI_MISO << 16) | MUX_PA27A_SPI_MISO)
+#define GPIO_PA27A_SPI_MISO      _UL(1 << 27)
+#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L(0)
+#define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
+#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
+#define PIN_PA28A_SPI_MOSI             _L(28) /**< \brief SPI signal: MOSI on PA28 mux A */
+#define MUX_PA28A_SPI_MOSI              _L(0)
+#define PINMUX_PA28A_SPI_MOSI      ((PIN_PA28A_SPI_MOSI << 16) | MUX_PA28A_SPI_MOSI)
+#define GPIO_PA28A_SPI_MOSI      _UL(1 << 28)
+#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
+#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
+#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
+#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
+#define PIN_PA30A_SPI_NPCS0            _L(30) /**< \brief SPI signal: NPCS0 on PA30 mux A */
+#define MUX_PA30A_SPI_NPCS0             _L(0)
+#define PINMUX_PA30A_SPI_NPCS0     ((PIN_PA30A_SPI_NPCS0 << 16) | MUX_PA30A_SPI_NPCS0)
+#define GPIO_PA30A_SPI_NPCS0     _UL(1 << 30)
+#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
+#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PA31A_SPI_NPCS1            _L(31) /**< \brief SPI signal: NPCS1 on PA31 mux A */
+#define MUX_PA31A_SPI_NPCS1             _L(0)
+#define PINMUX_PA31A_SPI_NPCS1     ((PIN_PA31A_SPI_NPCS1 << 16) | MUX_PA31A_SPI_NPCS1)
+#define GPIO_PA31A_SPI_NPCS1     _UL(1 << 31)
+#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
+#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
+#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
+#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
+#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L(0)
+#define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
+#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
+#define PIN_PA29A_SPI_SCK              _L(29) /**< \brief SPI signal: SCK on PA29 mux A */
+#define MUX_PA29A_SPI_SCK               _L(0)
+#define PINMUX_PA29A_SPI_SCK       ((PIN_PA29A_SPI_SCK << 16) | MUX_PA29A_SPI_SCK)
+#define GPIO_PA29A_SPI_SCK       _UL(1 << 29)
+/* ========== GPIO definition for TC0 peripheral ========== */
+#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L(1)
+#define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
+#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
+#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L(1)
+#define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
+#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
+#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L(1)
+#define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
+#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
+#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L(1)
+#define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
+#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
+#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L(1)
+#define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
+#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
+#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L(1)
+#define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
+#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L(1)
+#define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
+#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L(1)
+#define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
+#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L(1)
+#define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
+#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+/* ========== GPIO definition for USART0 peripheral ========== */
+#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L(1)
+#define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
+#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
+#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L(0)
+#define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
+#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
+#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L(0)
+#define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
+#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
+#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L(1)
+#define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
+#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
+#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L(0)
+#define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
+#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
+#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L(1)
+#define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
+#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
+#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L(0)
+#define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
+#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
+#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L(1)
+#define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
+#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
+#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L(0)
+#define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
+#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
+/* ========== GPIO definition for USART1 peripheral ========== */
+#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L(0)
+#define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
+#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
+#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L(1)
+#define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
+#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
+#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L(0)
+#define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
+#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
+#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L(0)
+#define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
+#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
+#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L(0)
+#define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
+#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+/* ========== GPIO definition for USART2 peripheral ========== */
+#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L(0)
+#define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
+#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
+#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L(1)
+#define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
+#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
+#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L(0)
+#define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
+#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L(1)
+#define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
+#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
+#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L(0)
+#define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
+#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L(1)
+#define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
+#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
+#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L(0)
+#define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
+#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+/* ========== GPIO definition for USART3 peripheral ========== */
+#define PIN_PA29E_USART3_CLK           _L(29) /**< \brief USART3 signal: CLK on PA29 mux E */
+#define MUX_PA29E_USART3_CLK            _L(4)
+#define PINMUX_PA29E_USART3_CLK    ((PIN_PA29E_USART3_CLK << 16) | MUX_PA29E_USART3_CLK)
+#define GPIO_PA29E_USART3_CLK    _UL(1 << 29)
+#define PIN_PA28E_USART3_CTS           _L(28) /**< \brief USART3 signal: CTS on PA28 mux E */
+#define MUX_PA28E_USART3_CTS            _L(4)
+#define PINMUX_PA28E_USART3_CTS    ((PIN_PA28E_USART3_CTS << 16) | MUX_PA28E_USART3_CTS)
+#define GPIO_PA28E_USART3_CTS    _UL(1 << 28)
+#define PIN_PA27E_USART3_RTS           _L(27) /**< \brief USART3 signal: RTS on PA27 mux E */
+#define MUX_PA27E_USART3_RTS            _L(4)
+#define PINMUX_PA27E_USART3_RTS    ((PIN_PA27E_USART3_RTS << 16) | MUX_PA27E_USART3_RTS)
+#define GPIO_PA27E_USART3_RTS    _UL(1 << 27)
+#define PIN_PA30E_USART3_RXD           _L(30) /**< \brief USART3 signal: RXD on PA30 mux E */
+#define MUX_PA30E_USART3_RXD            _L(4)
+#define PINMUX_PA30E_USART3_RXD    ((PIN_PA30E_USART3_RXD << 16) | MUX_PA30E_USART3_RXD)
+#define GPIO_PA30E_USART3_RXD    _UL(1 << 30)
+#define PIN_PA31E_USART3_TXD           _L(31) /**< \brief USART3 signal: TXD on PA31 mux E */
+#define MUX_PA31E_USART3_TXD            _L(4)
+#define PINMUX_PA31E_USART3_TXD    ((PIN_PA31E_USART3_TXD << 16) | MUX_PA31E_USART3_TXD)
+#define GPIO_PA31E_USART3_TXD    _UL(1 << 31)
+/* ========== GPIO definition for ADCIFE peripheral ========== */
+#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
+#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
+#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+/* ========== GPIO definition for DACC peripheral ========== */
+#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L(0)
+#define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
+#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+/* ========== GPIO definition for ACIFC peripheral ========== */
+#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
+#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
+/* ========== GPIO definition for GLOC peripheral ========== */
+#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
+#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L(3)
+#define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
+#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L(3)
+#define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
+#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L(3)
+#define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
+#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L(3)
+#define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
+#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L(3)
+#define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
+#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L(3)
+#define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
+#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L(3)
+#define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
+#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
+#define PIN_PA27D_GLOC_IN4             _L(27) /**< \brief GLOC signal: IN4 on PA27 mux D */
+#define MUX_PA27D_GLOC_IN4              _L(3)
+#define PINMUX_PA27D_GLOC_IN4      ((PIN_PA27D_GLOC_IN4 << 16) | MUX_PA27D_GLOC_IN4)
+#define GPIO_PA27D_GLOC_IN4      _UL(1 << 27)
+#define PIN_PA28D_GLOC_IN5             _L(28) /**< \brief GLOC signal: IN5 on PA28 mux D */
+#define MUX_PA28D_GLOC_IN5              _L(3)
+#define PINMUX_PA28D_GLOC_IN5      ((PIN_PA28D_GLOC_IN5 << 16) | MUX_PA28D_GLOC_IN5)
+#define GPIO_PA28D_GLOC_IN5      _UL(1 << 28)
+#define PIN_PA29D_GLOC_IN6             _L(29) /**< \brief GLOC signal: IN6 on PA29 mux D */
+#define MUX_PA29D_GLOC_IN6              _L(3)
+#define PINMUX_PA29D_GLOC_IN6      ((PIN_PA29D_GLOC_IN6 << 16) | MUX_PA29D_GLOC_IN6)
+#define GPIO_PA29D_GLOC_IN6      _UL(1 << 29)
+#define PIN_PA30D_GLOC_IN7             _L(30) /**< \brief GLOC signal: IN7 on PA30 mux D */
+#define MUX_PA30D_GLOC_IN7              _L(3)
+#define PINMUX_PA30D_GLOC_IN7      ((PIN_PA30D_GLOC_IN7 << 16) | MUX_PA30D_GLOC_IN7)
+#define GPIO_PA30D_GLOC_IN7      _UL(1 << 30)
+#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
+#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
+#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
+#define PIN_PA31D_GLOC_OUT1            _L(31) /**< \brief GLOC signal: OUT1 on PA31 mux D */
+#define MUX_PA31D_GLOC_OUT1             _L(3)
+#define PINMUX_PA31D_GLOC_OUT1     ((PIN_PA31D_GLOC_OUT1 << 16) | MUX_PA31D_GLOC_OUT1)
+#define GPIO_PA31D_GLOC_OUT1     _UL(1 << 31)
+/* ========== GPIO definition for ABDACB peripheral ========== */
+#define PIN_PA31C_ABDACB_CLK           _L(31) /**< \brief ABDACB signal: CLK on PA31 mux C */
+#define MUX_PA31C_ABDACB_CLK            _L(2)
+#define PINMUX_PA31C_ABDACB_CLK    ((PIN_PA31C_ABDACB_CLK << 16) | MUX_PA31C_ABDACB_CLK)
+#define GPIO_PA31C_ABDACB_CLK    _UL(1 << 31)
+#define PIN_PA27C_ABDACB_DAC0          _L(27) /**< \brief ABDACB signal: DAC0 on PA27 mux C */
+#define MUX_PA27C_ABDACB_DAC0           _L(2)
+#define PINMUX_PA27C_ABDACB_DAC0   ((PIN_PA27C_ABDACB_DAC0 << 16) | MUX_PA27C_ABDACB_DAC0)
+#define GPIO_PA27C_ABDACB_DAC0   _UL(1 << 27)
+#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
+#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
+#define PIN_PA29C_ABDACB_DAC1          _L(29) /**< \brief ABDACB signal: DAC1 on PA29 mux C */
+#define MUX_PA29C_ABDACB_DAC1           _L(2)
+#define PINMUX_PA29C_ABDACB_DAC1   ((PIN_PA29C_ABDACB_DAC1 << 16) | MUX_PA29C_ABDACB_DAC1)
+#define GPIO_PA29C_ABDACB_DAC1   _UL(1 << 29)
+#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
+#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
+#define PIN_PA28C_ABDACB_DACN0         _L(28) /**< \brief ABDACB signal: DACN0 on PA28 mux C */
+#define MUX_PA28C_ABDACB_DACN0          _L(2)
+#define PINMUX_PA28C_ABDACB_DACN0  ((PIN_PA28C_ABDACB_DACN0 << 16) | MUX_PA28C_ABDACB_DACN0)
+#define GPIO_PA28C_ABDACB_DACN0  _UL(1 << 28)
+#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
+#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
+#define PIN_PA30C_ABDACB_DACN1         _L(30) /**< \brief ABDACB signal: DACN1 on PA30 mux C */
+#define MUX_PA30C_ABDACB_DACN1          _L(2)
+#define PINMUX_PA30C_ABDACB_DACN1  ((PIN_PA30C_ABDACB_DACN1 << 16) | MUX_PA30C_ABDACB_DACN1)
+#define GPIO_PA30C_ABDACB_DACN1  _UL(1 << 30)
+#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
+#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+/* ========== GPIO definition for PARC peripheral ========== */
+#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
+#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
+#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
+#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
+#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
+#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
+#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
+#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
+#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
+#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
+#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
+#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
+#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
+#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
+#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
+#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
+#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
+#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
+#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
+#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
+#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+/* ========== GPIO definition for CATB peripheral ========== */
+#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L(6)
+#define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
+#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L(6)
+#define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
+#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L(6)
+#define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
+#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
+#define PIN_PA31G_CATB_DIS             _L(31) /**< \brief CATB signal: DIS on PA31 mux G */
+#define MUX_PA31G_CATB_DIS              _L(6)
+#define PINMUX_PA31G_CATB_DIS      ((PIN_PA31G_CATB_DIS << 16) | MUX_PA31G_CATB_DIS)
+#define GPIO_PA31G_CATB_DIS      _UL(1 << 31)
+#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
+#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
+#define PIN_PA27G_CATB_SENSE0          _L(27) /**< \brief CATB signal: SENSE0 on PA27 mux G */
+#define MUX_PA27G_CATB_SENSE0           _L(6)
+#define PINMUX_PA27G_CATB_SENSE0   ((PIN_PA27G_CATB_SENSE0 << 16) | MUX_PA27G_CATB_SENSE0)
+#define GPIO_PA27G_CATB_SENSE0   _UL(1 << 27)
+#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
+#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
+#define PIN_PA28G_CATB_SENSE1          _L(28) /**< \brief CATB signal: SENSE1 on PA28 mux G */
+#define MUX_PA28G_CATB_SENSE1           _L(6)
+#define PINMUX_PA28G_CATB_SENSE1   ((PIN_PA28G_CATB_SENSE1 << 16) | MUX_PA28G_CATB_SENSE1)
+#define GPIO_PA28G_CATB_SENSE1   _UL(1 << 28)
+#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
+#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
+#define PIN_PA29G_CATB_SENSE2          _L(29) /**< \brief CATB signal: SENSE2 on PA29 mux G */
+#define MUX_PA29G_CATB_SENSE2           _L(6)
+#define PINMUX_PA29G_CATB_SENSE2   ((PIN_PA29G_CATB_SENSE2 << 16) | MUX_PA29G_CATB_SENSE2)
+#define GPIO_PA29G_CATB_SENSE2   _UL(1 << 29)
+#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
+#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
+#define PIN_PA30G_CATB_SENSE3          _L(30) /**< \brief CATB signal: SENSE3 on PA30 mux G */
+#define MUX_PA30G_CATB_SENSE3           _L(6)
+#define PINMUX_PA30G_CATB_SENSE3   ((PIN_PA30G_CATB_SENSE3 << 16) | MUX_PA30G_CATB_SENSE3)
+#define GPIO_PA30G_CATB_SENSE3   _UL(1 << 30)
+#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
+#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
+#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
+#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
+#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
+#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
+#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
+#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
+#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
+#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
+#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
+#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
+#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
+#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
+#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
+#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
+#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
+#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
+#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
+#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
+#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
+#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
+#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
+#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
+#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
+#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
+#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
+#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
+#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
+#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
+#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
+#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
+#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
+#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
+/* ========== GPIO definition for USBC peripheral ========== */
+#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L(0)
+#define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
+#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
+#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L(0)
+#define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
+#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+/* ========== GPIO definition for PEVC peripheral ========== */
+#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
+/* ========== GPIO definition for SCIF peripheral ========== */
+#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
+#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
+#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
+#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
+#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
+/* ========== GPIO definition for EIC peripheral ========== */
+#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
+#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
+#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
+#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
+#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
+#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
+#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
+#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
+#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
+#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
+#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+
+#endif /* _SAM4LS8A_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4ls8a.h
+++ b/asf/sam/include/sam4l/pio/sam4ls8a.h
@@ -30,708 +30,708 @@
 #define _SAM4LS8A_PIO_
 
 #define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
-#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define GPIO_PA00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PA00 */
 #define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
-#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define GPIO_PA01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PA01 */
 #define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
-#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define GPIO_PA02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PA02 */
 #define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
-#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define GPIO_PA03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PA03 */
 #define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
-#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define GPIO_PA04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PA04 */
 #define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
-#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define GPIO_PA05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PA05 */
 #define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
-#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define GPIO_PA06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PA06 */
 #define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
-#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define GPIO_PA07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PA07 */
 #define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
-#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define GPIO_PA08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PA08 */
 #define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
-#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define GPIO_PA09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PA09 */
 #define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
-#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define GPIO_PA10                _UL_(1 << 10) /**< \brief GPIO Mask  for PA10 */
 #define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
-#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define GPIO_PA11                _UL_(1 << 11) /**< \brief GPIO Mask  for PA11 */
 #define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
-#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define GPIO_PA12                _UL_(1 << 12) /**< \brief GPIO Mask  for PA12 */
 #define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
-#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define GPIO_PA13                _UL_(1 << 13) /**< \brief GPIO Mask  for PA13 */
 #define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
-#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define GPIO_PA14                _UL_(1 << 14) /**< \brief GPIO Mask  for PA14 */
 #define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
-#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define GPIO_PA15                _UL_(1 << 15) /**< \brief GPIO Mask  for PA15 */
 #define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
-#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define GPIO_PA16                _UL_(1 << 16) /**< \brief GPIO Mask  for PA16 */
 #define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
-#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define GPIO_PA17                _UL_(1 << 17) /**< \brief GPIO Mask  for PA17 */
 #define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
-#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define GPIO_PA18                _UL_(1 << 18) /**< \brief GPIO Mask  for PA18 */
 #define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
-#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define GPIO_PA19                _UL_(1 << 19) /**< \brief GPIO Mask  for PA19 */
 #define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
-#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define GPIO_PA20                _UL_(1 << 20) /**< \brief GPIO Mask  for PA20 */
 #define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
-#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define GPIO_PA21                _UL_(1 << 21) /**< \brief GPIO Mask  for PA21 */
 #define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
-#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define GPIO_PA22                _UL_(1 << 22) /**< \brief GPIO Mask  for PA22 */
 #define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
-#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define GPIO_PA23                _UL_(1 << 23) /**< \brief GPIO Mask  for PA23 */
 #define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
-#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define GPIO_PA24                _UL_(1 << 24) /**< \brief GPIO Mask  for PA24 */
 #define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
-#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define GPIO_PA25                _UL_(1 << 25) /**< \brief GPIO Mask  for PA25 */
 #define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
-#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define GPIO_PA26                _UL_(1 << 26) /**< \brief GPIO Mask  for PA26 */
 #define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
-#define GPIO_PA27                _UL(1 << 27) /**< \brief GPIO Mask  for PA27 */
+#define GPIO_PA27                _UL_(1 << 27) /**< \brief GPIO Mask  for PA27 */
 #define PIN_PA28                          28  /**< \brief Pin Number for PA28 */
-#define GPIO_PA28                _UL(1 << 28) /**< \brief GPIO Mask  for PA28 */
+#define GPIO_PA28                _UL_(1 << 28) /**< \brief GPIO Mask  for PA28 */
 #define PIN_PA29                          29  /**< \brief Pin Number for PA29 */
-#define GPIO_PA29                _UL(1 << 29) /**< \brief GPIO Mask  for PA29 */
+#define GPIO_PA29                _UL_(1 << 29) /**< \brief GPIO Mask  for PA29 */
 #define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
-#define GPIO_PA30                _UL(1 << 30) /**< \brief GPIO Mask  for PA30 */
+#define GPIO_PA30                _UL_(1 << 30) /**< \brief GPIO Mask  for PA30 */
 #define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
-#define GPIO_PA31                _UL(1 << 31) /**< \brief GPIO Mask  for PA31 */
+#define GPIO_PA31                _UL_(1 << 31) /**< \brief GPIO Mask  for PA31 */
 /* ========== GPIO definition for TWIMS0 peripheral ========== */
-#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
-#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PIN_PA24B_TWIMS0_TWCK          _L_(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L_(1)
 #define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
-#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
-#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
-#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL_(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L_(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L_(1)
 #define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
-#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+#define GPIO_PA23B_TWIMS0_TWD    _UL_(1 << 23)
 /* ========== GPIO definition for TWIMS2 peripheral ========== */
-#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
-#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PIN_PA22E_TWIMS2_TWCK          _L_(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L_(4)
 #define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
-#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
-#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
-#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL_(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L_(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L_(4)
 #define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
-#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+#define GPIO_PA21E_TWIMS2_TWD    _UL_(1 << 21)
 /* ========== GPIO definition for IISC peripheral ========== */
-#define PIN_PA31B_IISC_IMCK            _L(31) /**< \brief IISC signal: IMCK on PA31 mux B */
-#define MUX_PA31B_IISC_IMCK             _L(1)
+#define PIN_PA31B_IISC_IMCK            _L_(31) /**< \brief IISC signal: IMCK on PA31 mux B */
+#define MUX_PA31B_IISC_IMCK             _L_(1)
 #define PINMUX_PA31B_IISC_IMCK     ((PIN_PA31B_IISC_IMCK << 16) | MUX_PA31B_IISC_IMCK)
-#define GPIO_PA31B_IISC_IMCK     _UL(1 << 31)
-#define PIN_PA27B_IISC_ISCK            _L(27) /**< \brief IISC signal: ISCK on PA27 mux B */
-#define MUX_PA27B_IISC_ISCK             _L(1)
+#define GPIO_PA31B_IISC_IMCK     _UL_(1 << 31)
+#define PIN_PA27B_IISC_ISCK            _L_(27) /**< \brief IISC signal: ISCK on PA27 mux B */
+#define MUX_PA27B_IISC_ISCK             _L_(1)
 #define PINMUX_PA27B_IISC_ISCK     ((PIN_PA27B_IISC_ISCK << 16) | MUX_PA27B_IISC_ISCK)
-#define GPIO_PA27B_IISC_ISCK     _UL(1 << 27)
-#define PIN_PA28B_IISC_ISDI            _L(28) /**< \brief IISC signal: ISDI on PA28 mux B */
-#define MUX_PA28B_IISC_ISDI             _L(1)
+#define GPIO_PA27B_IISC_ISCK     _UL_(1 << 27)
+#define PIN_PA28B_IISC_ISDI            _L_(28) /**< \brief IISC signal: ISDI on PA28 mux B */
+#define MUX_PA28B_IISC_ISDI             _L_(1)
 #define PINMUX_PA28B_IISC_ISDI     ((PIN_PA28B_IISC_ISDI << 16) | MUX_PA28B_IISC_ISDI)
-#define GPIO_PA28B_IISC_ISDI     _UL(1 << 28)
-#define PIN_PA30B_IISC_ISDO            _L(30) /**< \brief IISC signal: ISDO on PA30 mux B */
-#define MUX_PA30B_IISC_ISDO             _L(1)
+#define GPIO_PA28B_IISC_ISDI     _UL_(1 << 28)
+#define PIN_PA30B_IISC_ISDO            _L_(30) /**< \brief IISC signal: ISDO on PA30 mux B */
+#define MUX_PA30B_IISC_ISDO             _L_(1)
 #define PINMUX_PA30B_IISC_ISDO     ((PIN_PA30B_IISC_ISDO << 16) | MUX_PA30B_IISC_ISDO)
-#define GPIO_PA30B_IISC_ISDO     _UL(1 << 30)
-#define PIN_PA29B_IISC_IWS             _L(29) /**< \brief IISC signal: IWS on PA29 mux B */
-#define MUX_PA29B_IISC_IWS              _L(1)
+#define GPIO_PA30B_IISC_ISDO     _UL_(1 << 30)
+#define PIN_PA29B_IISC_IWS             _L_(29) /**< \brief IISC signal: IWS on PA29 mux B */
+#define MUX_PA29B_IISC_IWS              _L_(1)
 #define PINMUX_PA29B_IISC_IWS      ((PIN_PA29B_IISC_IWS << 16) | MUX_PA29B_IISC_IWS)
-#define GPIO_PA29B_IISC_IWS      _UL(1 << 29)
+#define GPIO_PA29B_IISC_IWS      _UL_(1 << 29)
 /* ========== GPIO definition for SPI peripheral ========== */
-#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
-#define MUX_PA03B_SPI_MISO              _L(1)
+#define PIN_PA03B_SPI_MISO              _L_(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L_(1)
 #define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
-#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
-#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
-#define MUX_PA21A_SPI_MISO              _L(0)
+#define GPIO_PA03B_SPI_MISO      _UL_(1 <<  3)
+#define PIN_PA21A_SPI_MISO             _L_(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L_(0)
 #define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
-#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
-#define PIN_PA27A_SPI_MISO             _L(27) /**< \brief SPI signal: MISO on PA27 mux A */
-#define MUX_PA27A_SPI_MISO              _L(0)
+#define GPIO_PA21A_SPI_MISO      _UL_(1 << 21)
+#define PIN_PA27A_SPI_MISO             _L_(27) /**< \brief SPI signal: MISO on PA27 mux A */
+#define MUX_PA27A_SPI_MISO              _L_(0)
 #define PINMUX_PA27A_SPI_MISO      ((PIN_PA27A_SPI_MISO << 16) | MUX_PA27A_SPI_MISO)
-#define GPIO_PA27A_SPI_MISO      _UL(1 << 27)
-#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
-#define MUX_PA22A_SPI_MOSI              _L(0)
+#define GPIO_PA27A_SPI_MISO      _UL_(1 << 27)
+#define PIN_PA22A_SPI_MOSI             _L_(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L_(0)
 #define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
-#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
-#define PIN_PA28A_SPI_MOSI             _L(28) /**< \brief SPI signal: MOSI on PA28 mux A */
-#define MUX_PA28A_SPI_MOSI              _L(0)
+#define GPIO_PA22A_SPI_MOSI      _UL_(1 << 22)
+#define PIN_PA28A_SPI_MOSI             _L_(28) /**< \brief SPI signal: MOSI on PA28 mux A */
+#define MUX_PA28A_SPI_MOSI              _L_(0)
 #define PINMUX_PA28A_SPI_MOSI      ((PIN_PA28A_SPI_MOSI << 16) | MUX_PA28A_SPI_MOSI)
-#define GPIO_PA28A_SPI_MOSI      _UL(1 << 28)
-#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
-#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define GPIO_PA28A_SPI_MOSI      _UL_(1 << 28)
+#define PIN_PA02B_SPI_NPCS0             _L_(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L_(1)
 #define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
-#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
-#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
-#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define GPIO_PA02B_SPI_NPCS0     _UL_(1 <<  2)
+#define PIN_PA24A_SPI_NPCS0            _L_(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L_(0)
 #define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
-#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
-#define PIN_PA30A_SPI_NPCS0            _L(30) /**< \brief SPI signal: NPCS0 on PA30 mux A */
-#define MUX_PA30A_SPI_NPCS0             _L(0)
+#define GPIO_PA24A_SPI_NPCS0     _UL_(1 << 24)
+#define PIN_PA30A_SPI_NPCS0            _L_(30) /**< \brief SPI signal: NPCS0 on PA30 mux A */
+#define MUX_PA30A_SPI_NPCS0             _L_(0)
 #define PINMUX_PA30A_SPI_NPCS0     ((PIN_PA30A_SPI_NPCS0 << 16) | MUX_PA30A_SPI_NPCS0)
-#define GPIO_PA30A_SPI_NPCS0     _UL(1 << 30)
-#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
-#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define GPIO_PA30A_SPI_NPCS0     _UL_(1 << 30)
+#define PIN_PA13C_SPI_NPCS1            _L_(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L_(2)
 #define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
-#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PA31A_SPI_NPCS1            _L(31) /**< \brief SPI signal: NPCS1 on PA31 mux A */
-#define MUX_PA31A_SPI_NPCS1             _L(0)
+#define GPIO_PA13C_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PA31A_SPI_NPCS1            _L_(31) /**< \brief SPI signal: NPCS1 on PA31 mux A */
+#define MUX_PA31A_SPI_NPCS1             _L_(0)
 #define PINMUX_PA31A_SPI_NPCS1     ((PIN_PA31A_SPI_NPCS1 << 16) | MUX_PA31A_SPI_NPCS1)
-#define GPIO_PA31A_SPI_NPCS1     _UL(1 << 31)
-#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
-#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define GPIO_PA31A_SPI_NPCS1     _UL_(1 << 31)
+#define PIN_PA14C_SPI_NPCS2            _L_(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L_(2)
 #define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
-#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
-#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
-#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define GPIO_PA14C_SPI_NPCS2     _UL_(1 << 14)
+#define PIN_PA15C_SPI_NPCS3            _L_(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L_(2)
 #define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
-#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
-#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
-#define MUX_PA23A_SPI_SCK               _L(0)
+#define GPIO_PA15C_SPI_NPCS3     _UL_(1 << 15)
+#define PIN_PA23A_SPI_SCK              _L_(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L_(0)
 #define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
-#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
-#define PIN_PA29A_SPI_SCK              _L(29) /**< \brief SPI signal: SCK on PA29 mux A */
-#define MUX_PA29A_SPI_SCK               _L(0)
+#define GPIO_PA23A_SPI_SCK       _UL_(1 << 23)
+#define PIN_PA29A_SPI_SCK              _L_(29) /**< \brief SPI signal: SCK on PA29 mux A */
+#define MUX_PA29A_SPI_SCK               _L_(0)
 #define PINMUX_PA29A_SPI_SCK       ((PIN_PA29A_SPI_SCK << 16) | MUX_PA29A_SPI_SCK)
-#define GPIO_PA29A_SPI_SCK       _UL(1 << 29)
+#define GPIO_PA29A_SPI_SCK       _UL_(1 << 29)
 /* ========== GPIO definition for TC0 peripheral ========== */
-#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
-#define MUX_PA08B_TC0_A0                _L(1)
+#define PIN_PA08B_TC0_A0                _L_(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L_(1)
 #define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
-#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
-#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
-#define MUX_PA10B_TC0_A1                _L(1)
+#define GPIO_PA08B_TC0_A0        _UL_(1 <<  8)
+#define PIN_PA10B_TC0_A1               _L_(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L_(1)
 #define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
-#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
-#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
-#define MUX_PA12B_TC0_A2                _L(1)
+#define GPIO_PA10B_TC0_A1        _UL_(1 << 10)
+#define PIN_PA12B_TC0_A2               _L_(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L_(1)
 #define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
-#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
-#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
-#define MUX_PA09B_TC0_B0                _L(1)
+#define GPIO_PA12B_TC0_A2        _UL_(1 << 12)
+#define PIN_PA09B_TC0_B0                _L_(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L_(1)
 #define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
-#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
-#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
-#define MUX_PA11B_TC0_B1                _L(1)
+#define GPIO_PA09B_TC0_B0        _UL_(1 <<  9)
+#define PIN_PA11B_TC0_B1               _L_(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L_(1)
 #define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
-#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
-#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
-#define MUX_PA13B_TC0_B2                _L(1)
+#define GPIO_PA11B_TC0_B1        _UL_(1 << 11)
+#define PIN_PA13B_TC0_B2               _L_(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L_(1)
 #define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
-#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
-#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
-#define MUX_PA14B_TC0_CLK0              _L(1)
+#define GPIO_PA13B_TC0_B2        _UL_(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L_(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L_(1)
 #define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
-#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
-#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
-#define MUX_PA15B_TC0_CLK1              _L(1)
+#define GPIO_PA14B_TC0_CLK0      _UL_(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L_(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L_(1)
 #define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
-#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
-#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
-#define MUX_PA16B_TC0_CLK2              _L(1)
+#define GPIO_PA15B_TC0_CLK1      _UL_(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L_(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L_(1)
 #define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
-#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+#define GPIO_PA16B_TC0_CLK2      _UL_(1 << 16)
 /* ========== GPIO definition for USART0 peripheral ========== */
-#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
-#define MUX_PA04B_USART0_CLK            _L(1)
+#define PIN_PA04B_USART0_CLK            _L_(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L_(1)
 #define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
-#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
-#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
-#define MUX_PA10A_USART0_CLK            _L(0)
+#define GPIO_PA04B_USART0_CLK    _UL_(1 <<  4)
+#define PIN_PA10A_USART0_CLK           _L_(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L_(0)
 #define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
-#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
-#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
-#define MUX_PA09A_USART0_CTS            _L(0)
+#define GPIO_PA10A_USART0_CLK    _UL_(1 << 10)
+#define PIN_PA09A_USART0_CTS            _L_(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L_(0)
 #define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
-#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
-#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
-#define MUX_PA06B_USART0_RTS            _L(1)
+#define GPIO_PA09A_USART0_CTS    _UL_(1 <<  9)
+#define PIN_PA06B_USART0_RTS            _L_(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L_(1)
 #define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
-#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
-#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
-#define MUX_PA08A_USART0_RTS            _L(0)
+#define GPIO_PA06B_USART0_RTS    _UL_(1 <<  6)
+#define PIN_PA08A_USART0_RTS            _L_(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L_(0)
 #define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
-#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
-#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
-#define MUX_PA05B_USART0_RXD            _L(1)
+#define GPIO_PA08A_USART0_RTS    _UL_(1 <<  8)
+#define PIN_PA05B_USART0_RXD            _L_(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L_(1)
 #define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
-#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
-#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
-#define MUX_PA11A_USART0_RXD            _L(0)
+#define GPIO_PA05B_USART0_RXD    _UL_(1 <<  5)
+#define PIN_PA11A_USART0_RXD           _L_(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L_(0)
 #define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
-#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
-#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
-#define MUX_PA07B_USART0_TXD            _L(1)
+#define GPIO_PA11A_USART0_RXD    _UL_(1 << 11)
+#define PIN_PA07B_USART0_TXD            _L_(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L_(1)
 #define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
-#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
-#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
-#define MUX_PA12A_USART0_TXD            _L(0)
+#define GPIO_PA07B_USART0_TXD    _UL_(1 <<  7)
+#define PIN_PA12A_USART0_TXD           _L_(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L_(0)
 #define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
-#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
+#define GPIO_PA12A_USART0_TXD    _UL_(1 << 12)
 /* ========== GPIO definition for USART1 peripheral ========== */
-#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
-#define MUX_PA14A_USART1_CLK            _L(0)
+#define PIN_PA14A_USART1_CLK           _L_(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L_(0)
 #define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
-#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
-#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
-#define MUX_PA21B_USART1_CTS            _L(1)
+#define GPIO_PA14A_USART1_CLK    _UL_(1 << 14)
+#define PIN_PA21B_USART1_CTS           _L_(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L_(1)
 #define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
-#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
-#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
-#define MUX_PA13A_USART1_RTS            _L(0)
+#define GPIO_PA21B_USART1_CTS    _UL_(1 << 21)
+#define PIN_PA13A_USART1_RTS           _L_(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L_(0)
 #define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
-#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
-#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
-#define MUX_PA15A_USART1_RXD            _L(0)
+#define GPIO_PA13A_USART1_RTS    _UL_(1 << 13)
+#define PIN_PA15A_USART1_RXD           _L_(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L_(0)
 #define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
-#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
-#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
-#define MUX_PA16A_USART1_TXD            _L(0)
+#define GPIO_PA15A_USART1_RXD    _UL_(1 << 15)
+#define PIN_PA16A_USART1_TXD           _L_(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L_(0)
 #define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
-#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+#define GPIO_PA16A_USART1_TXD    _UL_(1 << 16)
 /* ========== GPIO definition for USART2 peripheral ========== */
-#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
-#define MUX_PA18A_USART2_CLK            _L(0)
+#define PIN_PA18A_USART2_CLK           _L_(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L_(0)
 #define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
-#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
-#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
-#define MUX_PA22B_USART2_CTS            _L(1)
+#define GPIO_PA18A_USART2_CLK    _UL_(1 << 18)
+#define PIN_PA22B_USART2_CTS           _L_(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L_(1)
 #define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
-#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
-#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
-#define MUX_PA17A_USART2_RTS            _L(0)
+#define GPIO_PA22B_USART2_CTS    _UL_(1 << 22)
+#define PIN_PA17A_USART2_RTS           _L_(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L_(0)
 #define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
-#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
-#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
-#define MUX_PA25B_USART2_RXD            _L(1)
+#define GPIO_PA17A_USART2_RTS    _UL_(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L_(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L_(1)
 #define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
-#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
-#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
-#define MUX_PA19A_USART2_RXD            _L(0)
+#define GPIO_PA25B_USART2_RXD    _UL_(1 << 25)
+#define PIN_PA19A_USART2_RXD           _L_(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L_(0)
 #define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
-#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
-#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
-#define MUX_PA26B_USART2_TXD            _L(1)
+#define GPIO_PA19A_USART2_RXD    _UL_(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L_(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L_(1)
 #define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
-#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
-#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
-#define MUX_PA20A_USART2_TXD            _L(0)
+#define GPIO_PA26B_USART2_TXD    _UL_(1 << 26)
+#define PIN_PA20A_USART2_TXD           _L_(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L_(0)
 #define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
-#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+#define GPIO_PA20A_USART2_TXD    _UL_(1 << 20)
 /* ========== GPIO definition for USART3 peripheral ========== */
-#define PIN_PA29E_USART3_CLK           _L(29) /**< \brief USART3 signal: CLK on PA29 mux E */
-#define MUX_PA29E_USART3_CLK            _L(4)
+#define PIN_PA29E_USART3_CLK           _L_(29) /**< \brief USART3 signal: CLK on PA29 mux E */
+#define MUX_PA29E_USART3_CLK            _L_(4)
 #define PINMUX_PA29E_USART3_CLK    ((PIN_PA29E_USART3_CLK << 16) | MUX_PA29E_USART3_CLK)
-#define GPIO_PA29E_USART3_CLK    _UL(1 << 29)
-#define PIN_PA28E_USART3_CTS           _L(28) /**< \brief USART3 signal: CTS on PA28 mux E */
-#define MUX_PA28E_USART3_CTS            _L(4)
+#define GPIO_PA29E_USART3_CLK    _UL_(1 << 29)
+#define PIN_PA28E_USART3_CTS           _L_(28) /**< \brief USART3 signal: CTS on PA28 mux E */
+#define MUX_PA28E_USART3_CTS            _L_(4)
 #define PINMUX_PA28E_USART3_CTS    ((PIN_PA28E_USART3_CTS << 16) | MUX_PA28E_USART3_CTS)
-#define GPIO_PA28E_USART3_CTS    _UL(1 << 28)
-#define PIN_PA27E_USART3_RTS           _L(27) /**< \brief USART3 signal: RTS on PA27 mux E */
-#define MUX_PA27E_USART3_RTS            _L(4)
+#define GPIO_PA28E_USART3_CTS    _UL_(1 << 28)
+#define PIN_PA27E_USART3_RTS           _L_(27) /**< \brief USART3 signal: RTS on PA27 mux E */
+#define MUX_PA27E_USART3_RTS            _L_(4)
 #define PINMUX_PA27E_USART3_RTS    ((PIN_PA27E_USART3_RTS << 16) | MUX_PA27E_USART3_RTS)
-#define GPIO_PA27E_USART3_RTS    _UL(1 << 27)
-#define PIN_PA30E_USART3_RXD           _L(30) /**< \brief USART3 signal: RXD on PA30 mux E */
-#define MUX_PA30E_USART3_RXD            _L(4)
+#define GPIO_PA27E_USART3_RTS    _UL_(1 << 27)
+#define PIN_PA30E_USART3_RXD           _L_(30) /**< \brief USART3 signal: RXD on PA30 mux E */
+#define MUX_PA30E_USART3_RXD            _L_(4)
 #define PINMUX_PA30E_USART3_RXD    ((PIN_PA30E_USART3_RXD << 16) | MUX_PA30E_USART3_RXD)
-#define GPIO_PA30E_USART3_RXD    _UL(1 << 30)
-#define PIN_PA31E_USART3_TXD           _L(31) /**< \brief USART3 signal: TXD on PA31 mux E */
-#define MUX_PA31E_USART3_TXD            _L(4)
+#define GPIO_PA30E_USART3_RXD    _UL_(1 << 30)
+#define PIN_PA31E_USART3_TXD           _L_(31) /**< \brief USART3 signal: TXD on PA31 mux E */
+#define MUX_PA31E_USART3_TXD            _L_(4)
 #define PINMUX_PA31E_USART3_TXD    ((PIN_PA31E_USART3_TXD << 16) | MUX_PA31E_USART3_TXD)
-#define GPIO_PA31E_USART3_TXD    _UL(1 << 31)
+#define GPIO_PA31E_USART3_TXD    _UL_(1 << 31)
 /* ========== GPIO definition for ADCIFE peripheral ========== */
-#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
-#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PIN_PA04A_ADCIFE_AD0            _L_(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L_(0)
 #define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
-#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
-#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
-#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL_(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L_(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L_(0)
 #define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
-#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
-#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
-#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define GPIO_PA05A_ADCIFE_AD1    _UL_(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L_(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L_(0)
 #define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
-#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
-#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
-#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define GPIO_PA07A_ADCIFE_AD2    _UL_(1 <<  7)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L_(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L_(4)
 #define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
-#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL_(1 <<  5)
 /* ========== GPIO definition for DACC peripheral ========== */
-#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
-#define MUX_PA06A_DACC_VOUT             _L(0)
+#define PIN_PA06A_DACC_VOUT             _L_(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L_(0)
 #define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
-#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+#define GPIO_PA06A_DACC_VOUT     _UL_(1 <<  6)
 /* ========== GPIO definition for ACIFC peripheral ========== */
-#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
-#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PIN_PA06E_ACIFC_ACAN0           _L_(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L_(4)
 #define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
-#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
-#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
-#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL_(1 <<  6)
+#define PIN_PA07E_ACIFC_ACAP0           _L_(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L_(4)
 #define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
-#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL_(1 <<  7)
 /* ========== GPIO definition for GLOC peripheral ========== */
-#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
-#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PIN_PA06D_GLOC_IN0              _L_(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L_(3)
 #define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
-#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
-#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
-#define MUX_PA20D_GLOC_IN0              _L(3)
+#define GPIO_PA06D_GLOC_IN0      _UL_(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L_(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L_(3)
 #define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
-#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
-#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
-#define MUX_PA04D_GLOC_IN1              _L(3)
+#define GPIO_PA20D_GLOC_IN0      _UL_(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L_(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L_(3)
 #define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
-#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
-#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
-#define MUX_PA21D_GLOC_IN1              _L(3)
+#define GPIO_PA04D_GLOC_IN1      _UL_(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L_(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L_(3)
 #define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
-#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
-#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
-#define MUX_PA05D_GLOC_IN2              _L(3)
+#define GPIO_PA21D_GLOC_IN1      _UL_(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L_(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L_(3)
 #define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
-#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
-#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
-#define MUX_PA22D_GLOC_IN2              _L(3)
+#define GPIO_PA05D_GLOC_IN2      _UL_(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L_(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L_(3)
 #define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
-#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
-#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
-#define MUX_PA07D_GLOC_IN3              _L(3)
+#define GPIO_PA22D_GLOC_IN2      _UL_(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L_(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L_(3)
 #define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
-#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
-#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
-#define MUX_PA23D_GLOC_IN3              _L(3)
+#define GPIO_PA07D_GLOC_IN3      _UL_(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L_(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L_(3)
 #define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
-#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
-#define PIN_PA27D_GLOC_IN4             _L(27) /**< \brief GLOC signal: IN4 on PA27 mux D */
-#define MUX_PA27D_GLOC_IN4              _L(3)
+#define GPIO_PA23D_GLOC_IN3      _UL_(1 << 23)
+#define PIN_PA27D_GLOC_IN4             _L_(27) /**< \brief GLOC signal: IN4 on PA27 mux D */
+#define MUX_PA27D_GLOC_IN4              _L_(3)
 #define PINMUX_PA27D_GLOC_IN4      ((PIN_PA27D_GLOC_IN4 << 16) | MUX_PA27D_GLOC_IN4)
-#define GPIO_PA27D_GLOC_IN4      _UL(1 << 27)
-#define PIN_PA28D_GLOC_IN5             _L(28) /**< \brief GLOC signal: IN5 on PA28 mux D */
-#define MUX_PA28D_GLOC_IN5              _L(3)
+#define GPIO_PA27D_GLOC_IN4      _UL_(1 << 27)
+#define PIN_PA28D_GLOC_IN5             _L_(28) /**< \brief GLOC signal: IN5 on PA28 mux D */
+#define MUX_PA28D_GLOC_IN5              _L_(3)
 #define PINMUX_PA28D_GLOC_IN5      ((PIN_PA28D_GLOC_IN5 << 16) | MUX_PA28D_GLOC_IN5)
-#define GPIO_PA28D_GLOC_IN5      _UL(1 << 28)
-#define PIN_PA29D_GLOC_IN6             _L(29) /**< \brief GLOC signal: IN6 on PA29 mux D */
-#define MUX_PA29D_GLOC_IN6              _L(3)
+#define GPIO_PA28D_GLOC_IN5      _UL_(1 << 28)
+#define PIN_PA29D_GLOC_IN6             _L_(29) /**< \brief GLOC signal: IN6 on PA29 mux D */
+#define MUX_PA29D_GLOC_IN6              _L_(3)
 #define PINMUX_PA29D_GLOC_IN6      ((PIN_PA29D_GLOC_IN6 << 16) | MUX_PA29D_GLOC_IN6)
-#define GPIO_PA29D_GLOC_IN6      _UL(1 << 29)
-#define PIN_PA30D_GLOC_IN7             _L(30) /**< \brief GLOC signal: IN7 on PA30 mux D */
-#define MUX_PA30D_GLOC_IN7              _L(3)
+#define GPIO_PA29D_GLOC_IN6      _UL_(1 << 29)
+#define PIN_PA30D_GLOC_IN7             _L_(30) /**< \brief GLOC signal: IN7 on PA30 mux D */
+#define MUX_PA30D_GLOC_IN7              _L_(3)
 #define PINMUX_PA30D_GLOC_IN7      ((PIN_PA30D_GLOC_IN7 << 16) | MUX_PA30D_GLOC_IN7)
-#define GPIO_PA30D_GLOC_IN7      _UL(1 << 30)
-#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
-#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define GPIO_PA30D_GLOC_IN7      _UL_(1 << 30)
+#define PIN_PA08D_GLOC_OUT0             _L_(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
-#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
-#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
-#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define GPIO_PA08D_GLOC_OUT0     _UL_(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L_(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
-#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
-#define PIN_PA31D_GLOC_OUT1            _L(31) /**< \brief GLOC signal: OUT1 on PA31 mux D */
-#define MUX_PA31D_GLOC_OUT1             _L(3)
+#define GPIO_PA24D_GLOC_OUT0     _UL_(1 << 24)
+#define PIN_PA31D_GLOC_OUT1            _L_(31) /**< \brief GLOC signal: OUT1 on PA31 mux D */
+#define MUX_PA31D_GLOC_OUT1             _L_(3)
 #define PINMUX_PA31D_GLOC_OUT1     ((PIN_PA31D_GLOC_OUT1 << 16) | MUX_PA31D_GLOC_OUT1)
-#define GPIO_PA31D_GLOC_OUT1     _UL(1 << 31)
+#define GPIO_PA31D_GLOC_OUT1     _UL_(1 << 31)
 /* ========== GPIO definition for ABDACB peripheral ========== */
-#define PIN_PA31C_ABDACB_CLK           _L(31) /**< \brief ABDACB signal: CLK on PA31 mux C */
-#define MUX_PA31C_ABDACB_CLK            _L(2)
+#define PIN_PA31C_ABDACB_CLK           _L_(31) /**< \brief ABDACB signal: CLK on PA31 mux C */
+#define MUX_PA31C_ABDACB_CLK            _L_(2)
 #define PINMUX_PA31C_ABDACB_CLK    ((PIN_PA31C_ABDACB_CLK << 16) | MUX_PA31C_ABDACB_CLK)
-#define GPIO_PA31C_ABDACB_CLK    _UL(1 << 31)
-#define PIN_PA27C_ABDACB_DAC0          _L(27) /**< \brief ABDACB signal: DAC0 on PA27 mux C */
-#define MUX_PA27C_ABDACB_DAC0           _L(2)
+#define GPIO_PA31C_ABDACB_CLK    _UL_(1 << 31)
+#define PIN_PA27C_ABDACB_DAC0          _L_(27) /**< \brief ABDACB signal: DAC0 on PA27 mux C */
+#define MUX_PA27C_ABDACB_DAC0           _L_(2)
 #define PINMUX_PA27C_ABDACB_DAC0   ((PIN_PA27C_ABDACB_DAC0 << 16) | MUX_PA27C_ABDACB_DAC0)
-#define GPIO_PA27C_ABDACB_DAC0   _UL(1 << 27)
-#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
-#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define GPIO_PA27C_ABDACB_DAC0   _UL_(1 << 27)
+#define PIN_PA17B_ABDACB_DAC0          _L_(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L_(1)
 #define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
-#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
-#define PIN_PA29C_ABDACB_DAC1          _L(29) /**< \brief ABDACB signal: DAC1 on PA29 mux C */
-#define MUX_PA29C_ABDACB_DAC1           _L(2)
+#define GPIO_PA17B_ABDACB_DAC0   _UL_(1 << 17)
+#define PIN_PA29C_ABDACB_DAC1          _L_(29) /**< \brief ABDACB signal: DAC1 on PA29 mux C */
+#define MUX_PA29C_ABDACB_DAC1           _L_(2)
 #define PINMUX_PA29C_ABDACB_DAC1   ((PIN_PA29C_ABDACB_DAC1 << 16) | MUX_PA29C_ABDACB_DAC1)
-#define GPIO_PA29C_ABDACB_DAC1   _UL(1 << 29)
-#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
-#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define GPIO_PA29C_ABDACB_DAC1   _UL_(1 << 29)
+#define PIN_PA19B_ABDACB_DAC1          _L_(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L_(1)
 #define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
-#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
-#define PIN_PA28C_ABDACB_DACN0         _L(28) /**< \brief ABDACB signal: DACN0 on PA28 mux C */
-#define MUX_PA28C_ABDACB_DACN0          _L(2)
+#define GPIO_PA19B_ABDACB_DAC1   _UL_(1 << 19)
+#define PIN_PA28C_ABDACB_DACN0         _L_(28) /**< \brief ABDACB signal: DACN0 on PA28 mux C */
+#define MUX_PA28C_ABDACB_DACN0          _L_(2)
 #define PINMUX_PA28C_ABDACB_DACN0  ((PIN_PA28C_ABDACB_DACN0 << 16) | MUX_PA28C_ABDACB_DACN0)
-#define GPIO_PA28C_ABDACB_DACN0  _UL(1 << 28)
-#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
-#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define GPIO_PA28C_ABDACB_DACN0  _UL_(1 << 28)
+#define PIN_PA18B_ABDACB_DACN0         _L_(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L_(1)
 #define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
-#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
-#define PIN_PA30C_ABDACB_DACN1         _L(30) /**< \brief ABDACB signal: DACN1 on PA30 mux C */
-#define MUX_PA30C_ABDACB_DACN1          _L(2)
+#define GPIO_PA18B_ABDACB_DACN0  _UL_(1 << 18)
+#define PIN_PA30C_ABDACB_DACN1         _L_(30) /**< \brief ABDACB signal: DACN1 on PA30 mux C */
+#define MUX_PA30C_ABDACB_DACN1          _L_(2)
 #define PINMUX_PA30C_ABDACB_DACN1  ((PIN_PA30C_ABDACB_DACN1 << 16) | MUX_PA30C_ABDACB_DACN1)
-#define GPIO_PA30C_ABDACB_DACN1  _UL(1 << 30)
-#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
-#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define GPIO_PA30C_ABDACB_DACN1  _UL_(1 << 30)
+#define PIN_PA20B_ABDACB_DACN1         _L_(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L_(1)
 #define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
-#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+#define GPIO_PA20B_ABDACB_DACN1  _UL_(1 << 20)
 /* ========== GPIO definition for PARC peripheral ========== */
-#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
-#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PIN_PA17D_PARC_PCCK            _L_(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L_(3)
 #define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
-#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
-#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
-#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define GPIO_PA17D_PARC_PCCK     _UL_(1 << 17)
+#define PIN_PA09D_PARC_PCDATA0          _L_(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L_(3)
 #define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
-#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
-#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
-#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define GPIO_PA09D_PARC_PCDATA0  _UL_(1 <<  9)
+#define PIN_PA10D_PARC_PCDATA1         _L_(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L_(3)
 #define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
-#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
-#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
-#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define GPIO_PA10D_PARC_PCDATA1  _UL_(1 << 10)
+#define PIN_PA11D_PARC_PCDATA2         _L_(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L_(3)
 #define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
-#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
-#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
-#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define GPIO_PA11D_PARC_PCDATA2  _UL_(1 << 11)
+#define PIN_PA12D_PARC_PCDATA3         _L_(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L_(3)
 #define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
-#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
-#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
-#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL_(1 << 12)
+#define PIN_PA13D_PARC_PCDATA4         _L_(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L_(3)
 #define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
-#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
-#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
-#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define GPIO_PA13D_PARC_PCDATA4  _UL_(1 << 13)
+#define PIN_PA14D_PARC_PCDATA5         _L_(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L_(3)
 #define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
-#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
-#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
-#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define GPIO_PA14D_PARC_PCDATA5  _UL_(1 << 14)
+#define PIN_PA15D_PARC_PCDATA6         _L_(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L_(3)
 #define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
-#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
-#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
-#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define GPIO_PA15D_PARC_PCDATA6  _UL_(1 << 15)
+#define PIN_PA16D_PARC_PCDATA7         _L_(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L_(3)
 #define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
-#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
-#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
-#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define GPIO_PA16D_PARC_PCDATA7  _UL_(1 << 16)
+#define PIN_PA18D_PARC_PCEN1           _L_(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L_(3)
 #define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
-#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
-#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
-#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define GPIO_PA18D_PARC_PCEN1    _UL_(1 << 18)
+#define PIN_PA19D_PARC_PCEN2           _L_(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L_(3)
 #define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
-#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+#define GPIO_PA19D_PARC_PCEN2    _UL_(1 << 19)
 /* ========== GPIO definition for CATB peripheral ========== */
-#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
-#define MUX_PA02G_CATB_DIS              _L(6)
+#define PIN_PA02G_CATB_DIS              _L_(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L_(6)
 #define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
-#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
-#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
-#define MUX_PA12G_CATB_DIS              _L(6)
+#define GPIO_PA02G_CATB_DIS      _UL_(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L_(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L_(6)
 #define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
-#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
-#define MUX_PA23G_CATB_DIS              _L(6)
+#define GPIO_PA12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L_(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L_(6)
 #define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
-#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
-#define PIN_PA31G_CATB_DIS             _L(31) /**< \brief CATB signal: DIS on PA31 mux G */
-#define MUX_PA31G_CATB_DIS              _L(6)
+#define GPIO_PA23G_CATB_DIS      _UL_(1 << 23)
+#define PIN_PA31G_CATB_DIS             _L_(31) /**< \brief CATB signal: DIS on PA31 mux G */
+#define MUX_PA31G_CATB_DIS              _L_(6)
 #define PINMUX_PA31G_CATB_DIS      ((PIN_PA31G_CATB_DIS << 16) | MUX_PA31G_CATB_DIS)
-#define GPIO_PA31G_CATB_DIS      _UL(1 << 31)
-#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
-#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define GPIO_PA31G_CATB_DIS      _UL_(1 << 31)
+#define PIN_PA04G_CATB_SENSE0           _L_(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L_(6)
 #define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
-#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
-#define PIN_PA27G_CATB_SENSE0          _L(27) /**< \brief CATB signal: SENSE0 on PA27 mux G */
-#define MUX_PA27G_CATB_SENSE0           _L(6)
+#define GPIO_PA04G_CATB_SENSE0   _UL_(1 <<  4)
+#define PIN_PA27G_CATB_SENSE0          _L_(27) /**< \brief CATB signal: SENSE0 on PA27 mux G */
+#define MUX_PA27G_CATB_SENSE0           _L_(6)
 #define PINMUX_PA27G_CATB_SENSE0   ((PIN_PA27G_CATB_SENSE0 << 16) | MUX_PA27G_CATB_SENSE0)
-#define GPIO_PA27G_CATB_SENSE0   _UL(1 << 27)
-#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
-#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define GPIO_PA27G_CATB_SENSE0   _UL_(1 << 27)
+#define PIN_PA05G_CATB_SENSE1           _L_(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L_(6)
 #define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
-#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
-#define PIN_PA28G_CATB_SENSE1          _L(28) /**< \brief CATB signal: SENSE1 on PA28 mux G */
-#define MUX_PA28G_CATB_SENSE1           _L(6)
+#define GPIO_PA05G_CATB_SENSE1   _UL_(1 <<  5)
+#define PIN_PA28G_CATB_SENSE1          _L_(28) /**< \brief CATB signal: SENSE1 on PA28 mux G */
+#define MUX_PA28G_CATB_SENSE1           _L_(6)
 #define PINMUX_PA28G_CATB_SENSE1   ((PIN_PA28G_CATB_SENSE1 << 16) | MUX_PA28G_CATB_SENSE1)
-#define GPIO_PA28G_CATB_SENSE1   _UL(1 << 28)
-#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
-#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define GPIO_PA28G_CATB_SENSE1   _UL_(1 << 28)
+#define PIN_PA06G_CATB_SENSE2           _L_(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L_(6)
 #define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
-#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
-#define PIN_PA29G_CATB_SENSE2          _L(29) /**< \brief CATB signal: SENSE2 on PA29 mux G */
-#define MUX_PA29G_CATB_SENSE2           _L(6)
+#define GPIO_PA06G_CATB_SENSE2   _UL_(1 <<  6)
+#define PIN_PA29G_CATB_SENSE2          _L_(29) /**< \brief CATB signal: SENSE2 on PA29 mux G */
+#define MUX_PA29G_CATB_SENSE2           _L_(6)
 #define PINMUX_PA29G_CATB_SENSE2   ((PIN_PA29G_CATB_SENSE2 << 16) | MUX_PA29G_CATB_SENSE2)
-#define GPIO_PA29G_CATB_SENSE2   _UL(1 << 29)
-#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
-#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define GPIO_PA29G_CATB_SENSE2   _UL_(1 << 29)
+#define PIN_PA07G_CATB_SENSE3           _L_(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L_(6)
 #define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
-#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
-#define PIN_PA30G_CATB_SENSE3          _L(30) /**< \brief CATB signal: SENSE3 on PA30 mux G */
-#define MUX_PA30G_CATB_SENSE3           _L(6)
+#define GPIO_PA07G_CATB_SENSE3   _UL_(1 <<  7)
+#define PIN_PA30G_CATB_SENSE3          _L_(30) /**< \brief CATB signal: SENSE3 on PA30 mux G */
+#define MUX_PA30G_CATB_SENSE3           _L_(6)
 #define PINMUX_PA30G_CATB_SENSE3   ((PIN_PA30G_CATB_SENSE3 << 16) | MUX_PA30G_CATB_SENSE3)
-#define GPIO_PA30G_CATB_SENSE3   _UL(1 << 30)
-#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
-#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define GPIO_PA30G_CATB_SENSE3   _UL_(1 << 30)
+#define PIN_PA08G_CATB_SENSE4           _L_(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L_(6)
 #define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
-#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
-#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
-#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define GPIO_PA08G_CATB_SENSE4   _UL_(1 <<  8)
+#define PIN_PA09G_CATB_SENSE5           _L_(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L_(6)
 #define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
-#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
-#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
-#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define GPIO_PA09G_CATB_SENSE5   _UL_(1 <<  9)
+#define PIN_PA10G_CATB_SENSE6          _L_(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L_(6)
 #define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
-#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
-#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
-#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define GPIO_PA10G_CATB_SENSE6   _UL_(1 << 10)
+#define PIN_PA11G_CATB_SENSE7          _L_(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L_(6)
 #define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
-#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
-#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
-#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define GPIO_PA11G_CATB_SENSE7   _UL_(1 << 11)
+#define PIN_PA13G_CATB_SENSE8          _L_(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L_(6)
 #define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
-#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
-#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
-#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define GPIO_PA13G_CATB_SENSE8   _UL_(1 << 13)
+#define PIN_PA14G_CATB_SENSE9          _L_(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L_(6)
 #define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
-#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
-#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
-#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define GPIO_PA14G_CATB_SENSE9   _UL_(1 << 14)
+#define PIN_PA15G_CATB_SENSE10         _L_(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L_(6)
 #define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
-#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
-#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
-#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define GPIO_PA15G_CATB_SENSE10  _UL_(1 << 15)
+#define PIN_PA16G_CATB_SENSE11         _L_(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L_(6)
 #define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
-#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
-#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
-#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define GPIO_PA16G_CATB_SENSE11  _UL_(1 << 16)
+#define PIN_PA17G_CATB_SENSE12         _L_(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L_(6)
 #define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
-#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
-#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
-#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define GPIO_PA17G_CATB_SENSE12  _UL_(1 << 17)
+#define PIN_PA18G_CATB_SENSE13         _L_(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L_(6)
 #define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
-#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
-#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
-#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define GPIO_PA18G_CATB_SENSE13  _UL_(1 << 18)
+#define PIN_PA19G_CATB_SENSE14         _L_(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L_(6)
 #define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
-#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
-#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
-#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define GPIO_PA19G_CATB_SENSE14  _UL_(1 << 19)
+#define PIN_PA20G_CATB_SENSE15         _L_(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L_(6)
 #define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
-#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
-#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
-#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define GPIO_PA20G_CATB_SENSE15  _UL_(1 << 20)
+#define PIN_PA21G_CATB_SENSE16         _L_(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L_(6)
 #define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
-#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
-#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
-#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define GPIO_PA21G_CATB_SENSE16  _UL_(1 << 21)
+#define PIN_PA22G_CATB_SENSE17         _L_(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L_(6)
 #define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
-#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
-#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
-#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define GPIO_PA22G_CATB_SENSE17  _UL_(1 << 22)
+#define PIN_PA24G_CATB_SENSE18         _L_(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L_(6)
 #define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
-#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
-#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
-#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define GPIO_PA24G_CATB_SENSE18  _UL_(1 << 24)
+#define PIN_PA25G_CATB_SENSE19         _L_(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L_(6)
 #define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
-#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
-#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
-#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define GPIO_PA25G_CATB_SENSE19  _UL_(1 << 25)
+#define PIN_PA26G_CATB_SENSE20         _L_(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L_(6)
 #define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
-#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
+#define GPIO_PA26G_CATB_SENSE20  _UL_(1 << 26)
 /* ========== GPIO definition for USBC peripheral ========== */
-#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
-#define MUX_PA25A_USBC_DM               _L(0)
+#define PIN_PA25A_USBC_DM              _L_(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L_(0)
 #define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
-#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
-#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
-#define MUX_PA26A_USBC_DP               _L(0)
+#define GPIO_PA25A_USBC_DM       _UL_(1 << 25)
+#define PIN_PA26A_USBC_DP              _L_(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L_(0)
 #define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
-#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+#define GPIO_PA26A_USBC_DP       _UL_(1 << 26)
 /* ========== GPIO definition for PEVC peripheral ========== */
-#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
-#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PIN_PA08C_PEVC_PAD_EVT0         _L_(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
-#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
-#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
-#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL_(1 <<  8)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L_(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
-#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
-#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
-#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL_(1 <<  9)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L_(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
-#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
-#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
-#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL_(1 << 10)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L_(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L_(2)
 #define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
-#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL_(1 << 11)
 /* ========== GPIO definition for SCIF peripheral ========== */
-#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
-#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PIN_PA19E_SCIF_GCLK0           _L_(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
-#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
-#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
-#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define GPIO_PA19E_SCIF_GCLK0    _UL_(1 << 19)
+#define PIN_PA02A_SCIF_GCLK0            _L_(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L_(0)
 #define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
-#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
-#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
-#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define GPIO_PA02A_SCIF_GCLK0    _UL_(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L_(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
-#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
-#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
-#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PA20E_SCIF_GCLK1    _UL_(1 << 20)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L_(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
-#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
-#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
-#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL_(1 << 23)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L_(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
-#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL_(1 << 24)
 /* ========== GPIO definition for EIC peripheral ========== */
-#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
-#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define PIN_PA06C_EIC_EXTINT1           _L_(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
-#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
-#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
-#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
-#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define GPIO_PA06C_EIC_EXTINT1   _UL_(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L_(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
-#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
-#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
-#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
-#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define GPIO_PA16C_EIC_EXTINT1   _UL_(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L_(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
-#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
-#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
-#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
-#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL_(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L_(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
-#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
-#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
-#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
-#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL_(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L_(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
-#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
-#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
-#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
-#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define GPIO_PA05C_EIC_EXTINT3   _UL_(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L_(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
-#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
-#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
-#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
-#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define GPIO_PA18C_EIC_EXTINT3   _UL_(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L_(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
-#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
-#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
-#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
-#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define GPIO_PA07C_EIC_EXTINT4   _UL_(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L_(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
-#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
-#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
-#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
-#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define GPIO_PA19C_EIC_EXTINT4   _UL_(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L_(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L_(2)
 #define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
-#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
-#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
-#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
-#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define GPIO_PA20C_EIC_EXTINT5   _UL_(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L_(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L_(2)
 #define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
-#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
-#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
-#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
-#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define GPIO_PA21C_EIC_EXTINT6   _UL_(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L_(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L_(2)
 #define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
-#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
-#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
-#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
-#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define GPIO_PA22C_EIC_EXTINT7   _UL_(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L_(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L_(2)
 #define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
-#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
-#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define GPIO_PA23C_EIC_EXTINT8   _UL_(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
 
 #endif /* _SAM4LS8A_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4ls8b.h
+++ b/asf/sam/include/sam4l/pio/sam4ls8b.h
@@ -1,0 +1,1100 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAM4LS8B
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LS8B_PIO_
+#define _SAM4LS8B_PIO_
+
+#define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
+#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
+#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
+#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
+#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
+#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
+#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
+#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
+#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
+#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
+#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
+#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
+#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
+#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
+#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
+#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
+#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
+#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
+#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
+#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
+#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
+#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
+#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
+#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
+#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
+#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
+#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
+#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
+#define GPIO_PA27                _UL(1 << 27) /**< \brief GPIO Mask  for PA27 */
+#define PIN_PA28                          28  /**< \brief Pin Number for PA28 */
+#define GPIO_PA28                _UL(1 << 28) /**< \brief GPIO Mask  for PA28 */
+#define PIN_PA29                          29  /**< \brief Pin Number for PA29 */
+#define GPIO_PA29                _UL(1 << 29) /**< \brief GPIO Mask  for PA29 */
+#define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
+#define GPIO_PA30                _UL(1 << 30) /**< \brief GPIO Mask  for PA30 */
+#define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
+#define GPIO_PA31                _UL(1 << 31) /**< \brief GPIO Mask  for PA31 */
+#define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
+#define GPIO_PB00                _UL(1 <<  0) /**< \brief GPIO Mask  for PB00 */
+#define PIN_PB01                          33  /**< \brief Pin Number for PB01 */
+#define GPIO_PB01                _UL(1 <<  1) /**< \brief GPIO Mask  for PB01 */
+#define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
+#define GPIO_PB02                _UL(1 <<  2) /**< \brief GPIO Mask  for PB02 */
+#define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
+#define GPIO_PB03                _UL(1 <<  3) /**< \brief GPIO Mask  for PB03 */
+#define PIN_PB04                          36  /**< \brief Pin Number for PB04 */
+#define GPIO_PB04                _UL(1 <<  4) /**< \brief GPIO Mask  for PB04 */
+#define PIN_PB05                          37  /**< \brief Pin Number for PB05 */
+#define GPIO_PB05                _UL(1 <<  5) /**< \brief GPIO Mask  for PB05 */
+#define PIN_PB06                          38  /**< \brief Pin Number for PB06 */
+#define GPIO_PB06                _UL(1 <<  6) /**< \brief GPIO Mask  for PB06 */
+#define PIN_PB07                          39  /**< \brief Pin Number for PB07 */
+#define GPIO_PB07                _UL(1 <<  7) /**< \brief GPIO Mask  for PB07 */
+#define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
+#define GPIO_PB08                _UL(1 <<  8) /**< \brief GPIO Mask  for PB08 */
+#define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
+#define GPIO_PB09                _UL(1 <<  9) /**< \brief GPIO Mask  for PB09 */
+#define PIN_PB10                          42  /**< \brief Pin Number for PB10 */
+#define GPIO_PB10                _UL(1 << 10) /**< \brief GPIO Mask  for PB10 */
+#define PIN_PB11                          43  /**< \brief Pin Number for PB11 */
+#define GPIO_PB11                _UL(1 << 11) /**< \brief GPIO Mask  for PB11 */
+#define PIN_PB12                          44  /**< \brief Pin Number for PB12 */
+#define GPIO_PB12                _UL(1 << 12) /**< \brief GPIO Mask  for PB12 */
+#define PIN_PB13                          45  /**< \brief Pin Number for PB13 */
+#define GPIO_PB13                _UL(1 << 13) /**< \brief GPIO Mask  for PB13 */
+#define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
+#define GPIO_PB14                _UL(1 << 14) /**< \brief GPIO Mask  for PB14 */
+#define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
+#define GPIO_PB15                _UL(1 << 15) /**< \brief GPIO Mask  for PB15 */
+/* ========== GPIO definition for TWIMS0 peripheral ========== */
+#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
+#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+/* ========== GPIO definition for TWIMS1 peripheral ========== */
+#define PIN_PB01A_TWIMS1_TWCK          _L(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
+#define MUX_PB01A_TWIMS1_TWCK           _L(0)
+#define PINMUX_PB01A_TWIMS1_TWCK   ((PIN_PB01A_TWIMS1_TWCK << 16) | MUX_PB01A_TWIMS1_TWCK)
+#define GPIO_PB01A_TWIMS1_TWCK   _UL(1 <<  1)
+#define PIN_PB00A_TWIMS1_TWD           _L(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
+#define MUX_PB00A_TWIMS1_TWD            _L(0)
+#define PINMUX_PB00A_TWIMS1_TWD    ((PIN_PB00A_TWIMS1_TWD << 16) | MUX_PB00A_TWIMS1_TWD)
+#define GPIO_PB00A_TWIMS1_TWD    _UL(1 <<  0)
+/* ========== GPIO definition for TWIMS2 peripheral ========== */
+#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
+#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+/* ========== GPIO definition for TWIMS3 peripheral ========== */
+#define PIN_PB15C_TWIMS3_TWCK          _L(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
+#define MUX_PB15C_TWIMS3_TWCK           _L(2)
+#define PINMUX_PB15C_TWIMS3_TWCK   ((PIN_PB15C_TWIMS3_TWCK << 16) | MUX_PB15C_TWIMS3_TWCK)
+#define GPIO_PB15C_TWIMS3_TWCK   _UL(1 << 15)
+#define PIN_PB14C_TWIMS3_TWD           _L(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
+#define MUX_PB14C_TWIMS3_TWD            _L(2)
+#define PINMUX_PB14C_TWIMS3_TWD    ((PIN_PB14C_TWIMS3_TWD << 16) | MUX_PB14C_TWIMS3_TWD)
+#define GPIO_PB14C_TWIMS3_TWD    _UL(1 << 14)
+/* ========== GPIO definition for IISC peripheral ========== */
+#define PIN_PB05D_IISC_IMCK            _L(37) /**< \brief IISC signal: IMCK on PB05 mux D */
+#define MUX_PB05D_IISC_IMCK             _L(3)
+#define PINMUX_PB05D_IISC_IMCK     ((PIN_PB05D_IISC_IMCK << 16) | MUX_PB05D_IISC_IMCK)
+#define GPIO_PB05D_IISC_IMCK     _UL(1 <<  5)
+#define PIN_PA31B_IISC_IMCK            _L(31) /**< \brief IISC signal: IMCK on PA31 mux B */
+#define MUX_PA31B_IISC_IMCK             _L(1)
+#define PINMUX_PA31B_IISC_IMCK     ((PIN_PA31B_IISC_IMCK << 16) | MUX_PA31B_IISC_IMCK)
+#define GPIO_PA31B_IISC_IMCK     _UL(1 << 31)
+#define PIN_PB02D_IISC_ISCK            _L(34) /**< \brief IISC signal: ISCK on PB02 mux D */
+#define MUX_PB02D_IISC_ISCK             _L(3)
+#define PINMUX_PB02D_IISC_ISCK     ((PIN_PB02D_IISC_ISCK << 16) | MUX_PB02D_IISC_ISCK)
+#define GPIO_PB02D_IISC_ISCK     _UL(1 <<  2)
+#define PIN_PA27B_IISC_ISCK            _L(27) /**< \brief IISC signal: ISCK on PA27 mux B */
+#define MUX_PA27B_IISC_ISCK             _L(1)
+#define PINMUX_PA27B_IISC_ISCK     ((PIN_PA27B_IISC_ISCK << 16) | MUX_PA27B_IISC_ISCK)
+#define GPIO_PA27B_IISC_ISCK     _UL(1 << 27)
+#define PIN_PB03D_IISC_ISDI            _L(35) /**< \brief IISC signal: ISDI on PB03 mux D */
+#define MUX_PB03D_IISC_ISDI             _L(3)
+#define PINMUX_PB03D_IISC_ISDI     ((PIN_PB03D_IISC_ISDI << 16) | MUX_PB03D_IISC_ISDI)
+#define GPIO_PB03D_IISC_ISDI     _UL(1 <<  3)
+#define PIN_PA28B_IISC_ISDI            _L(28) /**< \brief IISC signal: ISDI on PA28 mux B */
+#define MUX_PA28B_IISC_ISDI             _L(1)
+#define PINMUX_PA28B_IISC_ISDI     ((PIN_PA28B_IISC_ISDI << 16) | MUX_PA28B_IISC_ISDI)
+#define GPIO_PA28B_IISC_ISDI     _UL(1 << 28)
+#define PIN_PB04D_IISC_ISDO            _L(36) /**< \brief IISC signal: ISDO on PB04 mux D */
+#define MUX_PB04D_IISC_ISDO             _L(3)
+#define PINMUX_PB04D_IISC_ISDO     ((PIN_PB04D_IISC_ISDO << 16) | MUX_PB04D_IISC_ISDO)
+#define GPIO_PB04D_IISC_ISDO     _UL(1 <<  4)
+#define PIN_PA30B_IISC_ISDO            _L(30) /**< \brief IISC signal: ISDO on PA30 mux B */
+#define MUX_PA30B_IISC_ISDO             _L(1)
+#define PINMUX_PA30B_IISC_ISDO     ((PIN_PA30B_IISC_ISDO << 16) | MUX_PA30B_IISC_ISDO)
+#define GPIO_PA30B_IISC_ISDO     _UL(1 << 30)
+#define PIN_PB06D_IISC_IWS             _L(38) /**< \brief IISC signal: IWS on PB06 mux D */
+#define MUX_PB06D_IISC_IWS              _L(3)
+#define PINMUX_PB06D_IISC_IWS      ((PIN_PB06D_IISC_IWS << 16) | MUX_PB06D_IISC_IWS)
+#define GPIO_PB06D_IISC_IWS      _UL(1 <<  6)
+#define PIN_PA29B_IISC_IWS             _L(29) /**< \brief IISC signal: IWS on PA29 mux B */
+#define MUX_PA29B_IISC_IWS              _L(1)
+#define PINMUX_PA29B_IISC_IWS      ((PIN_PA29B_IISC_IWS << 16) | MUX_PA29B_IISC_IWS)
+#define GPIO_PA29B_IISC_IWS      _UL(1 << 29)
+/* ========== GPIO definition for SPI peripheral ========== */
+#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L(1)
+#define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
+#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
+#define PIN_PB14B_SPI_MISO             _L(46) /**< \brief SPI signal: MISO on PB14 mux B */
+#define MUX_PB14B_SPI_MISO              _L(1)
+#define PINMUX_PB14B_SPI_MISO      ((PIN_PB14B_SPI_MISO << 16) | MUX_PB14B_SPI_MISO)
+#define GPIO_PB14B_SPI_MISO      _UL(1 << 14)
+#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L(0)
+#define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
+#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
+#define PIN_PA27A_SPI_MISO             _L(27) /**< \brief SPI signal: MISO on PA27 mux A */
+#define MUX_PA27A_SPI_MISO              _L(0)
+#define PINMUX_PA27A_SPI_MISO      ((PIN_PA27A_SPI_MISO << 16) | MUX_PA27A_SPI_MISO)
+#define GPIO_PA27A_SPI_MISO      _UL(1 << 27)
+#define PIN_PB15B_SPI_MOSI             _L(47) /**< \brief SPI signal: MOSI on PB15 mux B */
+#define MUX_PB15B_SPI_MOSI              _L(1)
+#define PINMUX_PB15B_SPI_MOSI      ((PIN_PB15B_SPI_MOSI << 16) | MUX_PB15B_SPI_MOSI)
+#define GPIO_PB15B_SPI_MOSI      _UL(1 << 15)
+#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L(0)
+#define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
+#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
+#define PIN_PA28A_SPI_MOSI             _L(28) /**< \brief SPI signal: MOSI on PA28 mux A */
+#define MUX_PA28A_SPI_MOSI              _L(0)
+#define PINMUX_PA28A_SPI_MOSI      ((PIN_PA28A_SPI_MOSI << 16) | MUX_PA28A_SPI_MOSI)
+#define GPIO_PA28A_SPI_MOSI      _UL(1 << 28)
+#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
+#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
+#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
+#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
+#define PIN_PA30A_SPI_NPCS0            _L(30) /**< \brief SPI signal: NPCS0 on PA30 mux A */
+#define MUX_PA30A_SPI_NPCS0             _L(0)
+#define PINMUX_PA30A_SPI_NPCS0     ((PIN_PA30A_SPI_NPCS0 << 16) | MUX_PA30A_SPI_NPCS0)
+#define GPIO_PA30A_SPI_NPCS0     _UL(1 << 30)
+#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
+#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PB13B_SPI_NPCS1            _L(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
+#define MUX_PB13B_SPI_NPCS1             _L(1)
+#define PINMUX_PB13B_SPI_NPCS1     ((PIN_PB13B_SPI_NPCS1 << 16) | MUX_PB13B_SPI_NPCS1)
+#define GPIO_PB13B_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PA31A_SPI_NPCS1            _L(31) /**< \brief SPI signal: NPCS1 on PA31 mux A */
+#define MUX_PA31A_SPI_NPCS1             _L(0)
+#define PINMUX_PA31A_SPI_NPCS1     ((PIN_PA31A_SPI_NPCS1 << 16) | MUX_PA31A_SPI_NPCS1)
+#define GPIO_PA31A_SPI_NPCS1     _UL(1 << 31)
+#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
+#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
+#define PIN_PB11B_SPI_NPCS2            _L(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
+#define MUX_PB11B_SPI_NPCS2             _L(1)
+#define PINMUX_PB11B_SPI_NPCS2     ((PIN_PB11B_SPI_NPCS2 << 16) | MUX_PB11B_SPI_NPCS2)
+#define GPIO_PB11B_SPI_NPCS2     _UL(1 << 11)
+#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
+#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
+#define PIN_PB12B_SPI_NPCS3            _L(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
+#define MUX_PB12B_SPI_NPCS3             _L(1)
+#define PINMUX_PB12B_SPI_NPCS3     ((PIN_PB12B_SPI_NPCS3 << 16) | MUX_PB12B_SPI_NPCS3)
+#define GPIO_PB12B_SPI_NPCS3     _UL(1 << 12)
+#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L(0)
+#define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
+#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
+#define PIN_PA29A_SPI_SCK              _L(29) /**< \brief SPI signal: SCK on PA29 mux A */
+#define MUX_PA29A_SPI_SCK               _L(0)
+#define PINMUX_PA29A_SPI_SCK       ((PIN_PA29A_SPI_SCK << 16) | MUX_PA29A_SPI_SCK)
+#define GPIO_PA29A_SPI_SCK       _UL(1 << 29)
+/* ========== GPIO definition for TC0 peripheral ========== */
+#define PIN_PB07D_TC0_A0               _L(39) /**< \brief TC0 signal: A0 on PB07 mux D */
+#define MUX_PB07D_TC0_A0                _L(3)
+#define PINMUX_PB07D_TC0_A0        ((PIN_PB07D_TC0_A0 << 16) | MUX_PB07D_TC0_A0)
+#define GPIO_PB07D_TC0_A0        _UL(1 <<  7)
+#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L(1)
+#define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
+#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
+#define PIN_PB09D_TC0_A1               _L(41) /**< \brief TC0 signal: A1 on PB09 mux D */
+#define MUX_PB09D_TC0_A1                _L(3)
+#define PINMUX_PB09D_TC0_A1        ((PIN_PB09D_TC0_A1 << 16) | MUX_PB09D_TC0_A1)
+#define GPIO_PB09D_TC0_A1        _UL(1 <<  9)
+#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L(1)
+#define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
+#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
+#define PIN_PB11D_TC0_A2               _L(43) /**< \brief TC0 signal: A2 on PB11 mux D */
+#define MUX_PB11D_TC0_A2                _L(3)
+#define PINMUX_PB11D_TC0_A2        ((PIN_PB11D_TC0_A2 << 16) | MUX_PB11D_TC0_A2)
+#define GPIO_PB11D_TC0_A2        _UL(1 << 11)
+#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L(1)
+#define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
+#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
+#define PIN_PB08D_TC0_B0               _L(40) /**< \brief TC0 signal: B0 on PB08 mux D */
+#define MUX_PB08D_TC0_B0                _L(3)
+#define PINMUX_PB08D_TC0_B0        ((PIN_PB08D_TC0_B0 << 16) | MUX_PB08D_TC0_B0)
+#define GPIO_PB08D_TC0_B0        _UL(1 <<  8)
+#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L(1)
+#define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
+#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
+#define PIN_PB10D_TC0_B1               _L(42) /**< \brief TC0 signal: B1 on PB10 mux D */
+#define MUX_PB10D_TC0_B1                _L(3)
+#define PINMUX_PB10D_TC0_B1        ((PIN_PB10D_TC0_B1 << 16) | MUX_PB10D_TC0_B1)
+#define GPIO_PB10D_TC0_B1        _UL(1 << 10)
+#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L(1)
+#define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
+#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
+#define PIN_PB12D_TC0_B2               _L(44) /**< \brief TC0 signal: B2 on PB12 mux D */
+#define MUX_PB12D_TC0_B2                _L(3)
+#define PINMUX_PB12D_TC0_B2        ((PIN_PB12D_TC0_B2 << 16) | MUX_PB12D_TC0_B2)
+#define GPIO_PB12D_TC0_B2        _UL(1 << 12)
+#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L(1)
+#define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
+#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
+#define PIN_PB13D_TC0_CLK0             _L(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
+#define MUX_PB13D_TC0_CLK0              _L(3)
+#define PINMUX_PB13D_TC0_CLK0      ((PIN_PB13D_TC0_CLK0 << 16) | MUX_PB13D_TC0_CLK0)
+#define GPIO_PB13D_TC0_CLK0      _UL(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L(1)
+#define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
+#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
+#define PIN_PB14D_TC0_CLK1             _L(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
+#define MUX_PB14D_TC0_CLK1              _L(3)
+#define PINMUX_PB14D_TC0_CLK1      ((PIN_PB14D_TC0_CLK1 << 16) | MUX_PB14D_TC0_CLK1)
+#define GPIO_PB14D_TC0_CLK1      _UL(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L(1)
+#define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
+#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
+#define PIN_PB15D_TC0_CLK2             _L(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
+#define MUX_PB15D_TC0_CLK2              _L(3)
+#define PINMUX_PB15D_TC0_CLK2      ((PIN_PB15D_TC0_CLK2 << 16) | MUX_PB15D_TC0_CLK2)
+#define GPIO_PB15D_TC0_CLK2      _UL(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L(1)
+#define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
+#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+/* ========== GPIO definition for USART0 peripheral ========== */
+#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L(1)
+#define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
+#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
+#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L(0)
+#define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
+#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
+#define PIN_PB13A_USART0_CLK           _L(45) /**< \brief USART0 signal: CLK on PB13 mux A */
+#define MUX_PB13A_USART0_CLK            _L(0)
+#define PINMUX_PB13A_USART0_CLK    ((PIN_PB13A_USART0_CLK << 16) | MUX_PB13A_USART0_CLK)
+#define GPIO_PB13A_USART0_CLK    _UL(1 << 13)
+#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L(0)
+#define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
+#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
+#define PIN_PB11A_USART0_CTS           _L(43) /**< \brief USART0 signal: CTS on PB11 mux A */
+#define MUX_PB11A_USART0_CTS            _L(0)
+#define PINMUX_PB11A_USART0_CTS    ((PIN_PB11A_USART0_CTS << 16) | MUX_PB11A_USART0_CTS)
+#define GPIO_PB11A_USART0_CTS    _UL(1 << 11)
+#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L(1)
+#define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
+#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
+#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L(0)
+#define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
+#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
+#define PIN_PB12A_USART0_RTS           _L(44) /**< \brief USART0 signal: RTS on PB12 mux A */
+#define MUX_PB12A_USART0_RTS            _L(0)
+#define PINMUX_PB12A_USART0_RTS    ((PIN_PB12A_USART0_RTS << 16) | MUX_PB12A_USART0_RTS)
+#define GPIO_PB12A_USART0_RTS    _UL(1 << 12)
+#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L(1)
+#define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
+#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
+#define PIN_PB00B_USART0_RXD           _L(32) /**< \brief USART0 signal: RXD on PB00 mux B */
+#define MUX_PB00B_USART0_RXD            _L(1)
+#define PINMUX_PB00B_USART0_RXD    ((PIN_PB00B_USART0_RXD << 16) | MUX_PB00B_USART0_RXD)
+#define GPIO_PB00B_USART0_RXD    _UL(1 <<  0)
+#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L(0)
+#define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
+#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
+#define PIN_PB14A_USART0_RXD           _L(46) /**< \brief USART0 signal: RXD on PB14 mux A */
+#define MUX_PB14A_USART0_RXD            _L(0)
+#define PINMUX_PB14A_USART0_RXD    ((PIN_PB14A_USART0_RXD << 16) | MUX_PB14A_USART0_RXD)
+#define GPIO_PB14A_USART0_RXD    _UL(1 << 14)
+#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L(1)
+#define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
+#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
+#define PIN_PB01B_USART0_TXD           _L(33) /**< \brief USART0 signal: TXD on PB01 mux B */
+#define MUX_PB01B_USART0_TXD            _L(1)
+#define PINMUX_PB01B_USART0_TXD    ((PIN_PB01B_USART0_TXD << 16) | MUX_PB01B_USART0_TXD)
+#define GPIO_PB01B_USART0_TXD    _UL(1 <<  1)
+#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L(0)
+#define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
+#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
+#define PIN_PB15A_USART0_TXD           _L(47) /**< \brief USART0 signal: TXD on PB15 mux A */
+#define MUX_PB15A_USART0_TXD            _L(0)
+#define PINMUX_PB15A_USART0_TXD    ((PIN_PB15A_USART0_TXD << 16) | MUX_PB15A_USART0_TXD)
+#define GPIO_PB15A_USART0_TXD    _UL(1 << 15)
+/* ========== GPIO definition for USART1 peripheral ========== */
+#define PIN_PB03B_USART1_CLK           _L(35) /**< \brief USART1 signal: CLK on PB03 mux B */
+#define MUX_PB03B_USART1_CLK            _L(1)
+#define PINMUX_PB03B_USART1_CLK    ((PIN_PB03B_USART1_CLK << 16) | MUX_PB03B_USART1_CLK)
+#define GPIO_PB03B_USART1_CLK    _UL(1 <<  3)
+#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L(0)
+#define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
+#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
+#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L(1)
+#define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
+#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
+#define PIN_PB02B_USART1_RTS           _L(34) /**< \brief USART1 signal: RTS on PB02 mux B */
+#define MUX_PB02B_USART1_RTS            _L(1)
+#define PINMUX_PB02B_USART1_RTS    ((PIN_PB02B_USART1_RTS << 16) | MUX_PB02B_USART1_RTS)
+#define GPIO_PB02B_USART1_RTS    _UL(1 <<  2)
+#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L(0)
+#define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
+#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
+#define PIN_PB04B_USART1_RXD           _L(36) /**< \brief USART1 signal: RXD on PB04 mux B */
+#define MUX_PB04B_USART1_RXD            _L(1)
+#define PINMUX_PB04B_USART1_RXD    ((PIN_PB04B_USART1_RXD << 16) | MUX_PB04B_USART1_RXD)
+#define GPIO_PB04B_USART1_RXD    _UL(1 <<  4)
+#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L(0)
+#define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
+#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
+#define PIN_PB05B_USART1_TXD           _L(37) /**< \brief USART1 signal: TXD on PB05 mux B */
+#define MUX_PB05B_USART1_TXD            _L(1)
+#define PINMUX_PB05B_USART1_TXD    ((PIN_PB05B_USART1_TXD << 16) | MUX_PB05B_USART1_TXD)
+#define GPIO_PB05B_USART1_TXD    _UL(1 <<  5)
+#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L(0)
+#define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
+#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+/* ========== GPIO definition for USART2 peripheral ========== */
+#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L(0)
+#define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
+#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
+#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L(1)
+#define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
+#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
+#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L(0)
+#define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
+#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L(1)
+#define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
+#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
+#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L(0)
+#define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
+#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L(1)
+#define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
+#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
+#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L(0)
+#define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
+#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+/* ========== GPIO definition for USART3 peripheral ========== */
+#define PIN_PA29E_USART3_CLK           _L(29) /**< \brief USART3 signal: CLK on PA29 mux E */
+#define MUX_PA29E_USART3_CLK            _L(4)
+#define PINMUX_PA29E_USART3_CLK    ((PIN_PA29E_USART3_CLK << 16) | MUX_PA29E_USART3_CLK)
+#define GPIO_PA29E_USART3_CLK    _UL(1 << 29)
+#define PIN_PB08A_USART3_CLK           _L(40) /**< \brief USART3 signal: CLK on PB08 mux A */
+#define MUX_PB08A_USART3_CLK            _L(0)
+#define PINMUX_PB08A_USART3_CLK    ((PIN_PB08A_USART3_CLK << 16) | MUX_PB08A_USART3_CLK)
+#define GPIO_PB08A_USART3_CLK    _UL(1 <<  8)
+#define PIN_PA28E_USART3_CTS           _L(28) /**< \brief USART3 signal: CTS on PA28 mux E */
+#define MUX_PA28E_USART3_CTS            _L(4)
+#define PINMUX_PA28E_USART3_CTS    ((PIN_PA28E_USART3_CTS << 16) | MUX_PA28E_USART3_CTS)
+#define GPIO_PA28E_USART3_CTS    _UL(1 << 28)
+#define PIN_PB07A_USART3_CTS           _L(39) /**< \brief USART3 signal: CTS on PB07 mux A */
+#define MUX_PB07A_USART3_CTS            _L(0)
+#define PINMUX_PB07A_USART3_CTS    ((PIN_PB07A_USART3_CTS << 16) | MUX_PB07A_USART3_CTS)
+#define GPIO_PB07A_USART3_CTS    _UL(1 <<  7)
+#define PIN_PA27E_USART3_RTS           _L(27) /**< \brief USART3 signal: RTS on PA27 mux E */
+#define MUX_PA27E_USART3_RTS            _L(4)
+#define PINMUX_PA27E_USART3_RTS    ((PIN_PA27E_USART3_RTS << 16) | MUX_PA27E_USART3_RTS)
+#define GPIO_PA27E_USART3_RTS    _UL(1 << 27)
+#define PIN_PB06A_USART3_RTS           _L(38) /**< \brief USART3 signal: RTS on PB06 mux A */
+#define MUX_PB06A_USART3_RTS            _L(0)
+#define PINMUX_PB06A_USART3_RTS    ((PIN_PB06A_USART3_RTS << 16) | MUX_PB06A_USART3_RTS)
+#define GPIO_PB06A_USART3_RTS    _UL(1 <<  6)
+#define PIN_PA30E_USART3_RXD           _L(30) /**< \brief USART3 signal: RXD on PA30 mux E */
+#define MUX_PA30E_USART3_RXD            _L(4)
+#define PINMUX_PA30E_USART3_RXD    ((PIN_PA30E_USART3_RXD << 16) | MUX_PA30E_USART3_RXD)
+#define GPIO_PA30E_USART3_RXD    _UL(1 << 30)
+#define PIN_PB09A_USART3_RXD           _L(41) /**< \brief USART3 signal: RXD on PB09 mux A */
+#define MUX_PB09A_USART3_RXD            _L(0)
+#define PINMUX_PB09A_USART3_RXD    ((PIN_PB09A_USART3_RXD << 16) | MUX_PB09A_USART3_RXD)
+#define GPIO_PB09A_USART3_RXD    _UL(1 <<  9)
+#define PIN_PA31E_USART3_TXD           _L(31) /**< \brief USART3 signal: TXD on PA31 mux E */
+#define MUX_PA31E_USART3_TXD            _L(4)
+#define PINMUX_PA31E_USART3_TXD    ((PIN_PA31E_USART3_TXD << 16) | MUX_PA31E_USART3_TXD)
+#define GPIO_PA31E_USART3_TXD    _UL(1 << 31)
+#define PIN_PB10A_USART3_TXD           _L(42) /**< \brief USART3 signal: TXD on PB10 mux A */
+#define MUX_PB10A_USART3_TXD            _L(0)
+#define PINMUX_PB10A_USART3_TXD    ((PIN_PB10A_USART3_TXD << 16) | MUX_PB10A_USART3_TXD)
+#define GPIO_PB10A_USART3_TXD    _UL(1 << 10)
+/* ========== GPIO definition for ADCIFE peripheral ========== */
+#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
+#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
+#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
+#define PIN_PB02A_ADCIFE_AD3           _L(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
+#define MUX_PB02A_ADCIFE_AD3            _L(0)
+#define PINMUX_PB02A_ADCIFE_AD3    ((PIN_PB02A_ADCIFE_AD3 << 16) | MUX_PB02A_ADCIFE_AD3)
+#define GPIO_PB02A_ADCIFE_AD3    _UL(1 <<  2)
+#define PIN_PB03A_ADCIFE_AD4           _L(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
+#define MUX_PB03A_ADCIFE_AD4            _L(0)
+#define PINMUX_PB03A_ADCIFE_AD4    ((PIN_PB03A_ADCIFE_AD4 << 16) | MUX_PB03A_ADCIFE_AD4)
+#define GPIO_PB03A_ADCIFE_AD4    _UL(1 <<  3)
+#define PIN_PB04A_ADCIFE_AD5           _L(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
+#define MUX_PB04A_ADCIFE_AD5            _L(0)
+#define PINMUX_PB04A_ADCIFE_AD5    ((PIN_PB04A_ADCIFE_AD5 << 16) | MUX_PB04A_ADCIFE_AD5)
+#define GPIO_PB04A_ADCIFE_AD5    _UL(1 <<  4)
+#define PIN_PB05A_ADCIFE_AD6           _L(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
+#define MUX_PB05A_ADCIFE_AD6            _L(0)
+#define PINMUX_PB05A_ADCIFE_AD6    ((PIN_PB05A_ADCIFE_AD6 << 16) | MUX_PB05A_ADCIFE_AD6)
+#define GPIO_PB05A_ADCIFE_AD6    _UL(1 <<  5)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+/* ========== GPIO definition for DACC peripheral ========== */
+#define PIN_PB04E_DACC_EXT_TRIG0       _L(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
+#define MUX_PB04E_DACC_EXT_TRIG0        _L(4)
+#define PINMUX_PB04E_DACC_EXT_TRIG0  ((PIN_PB04E_DACC_EXT_TRIG0 << 16) | MUX_PB04E_DACC_EXT_TRIG0)
+#define GPIO_PB04E_DACC_EXT_TRIG0  _UL(1 <<  4)
+#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L(0)
+#define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
+#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+/* ========== GPIO definition for ACIFC peripheral ========== */
+#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
+#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
+#define PIN_PB02E_ACIFC_ACBN0          _L(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
+#define MUX_PB02E_ACIFC_ACBN0           _L(4)
+#define PINMUX_PB02E_ACIFC_ACBN0   ((PIN_PB02E_ACIFC_ACBN0 << 16) | MUX_PB02E_ACIFC_ACBN0)
+#define GPIO_PB02E_ACIFC_ACBN0   _UL(1 <<  2)
+#define PIN_PB03E_ACIFC_ACBP0          _L(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
+#define MUX_PB03E_ACIFC_ACBP0           _L(4)
+#define PINMUX_PB03E_ACIFC_ACBP0   ((PIN_PB03E_ACIFC_ACBP0 << 16) | MUX_PB03E_ACIFC_ACBP0)
+#define GPIO_PB03E_ACIFC_ACBP0   _UL(1 <<  3)
+/* ========== GPIO definition for GLOC peripheral ========== */
+#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
+#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L(3)
+#define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
+#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L(3)
+#define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
+#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L(3)
+#define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
+#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L(3)
+#define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
+#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L(3)
+#define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
+#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L(3)
+#define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
+#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L(3)
+#define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
+#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
+#define PIN_PA27D_GLOC_IN4             _L(27) /**< \brief GLOC signal: IN4 on PA27 mux D */
+#define MUX_PA27D_GLOC_IN4              _L(3)
+#define PINMUX_PA27D_GLOC_IN4      ((PIN_PA27D_GLOC_IN4 << 16) | MUX_PA27D_GLOC_IN4)
+#define GPIO_PA27D_GLOC_IN4      _UL(1 << 27)
+#define PIN_PB06C_GLOC_IN4             _L(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
+#define MUX_PB06C_GLOC_IN4              _L(2)
+#define PINMUX_PB06C_GLOC_IN4      ((PIN_PB06C_GLOC_IN4 << 16) | MUX_PB06C_GLOC_IN4)
+#define GPIO_PB06C_GLOC_IN4      _UL(1 <<  6)
+#define PIN_PA28D_GLOC_IN5             _L(28) /**< \brief GLOC signal: IN5 on PA28 mux D */
+#define MUX_PA28D_GLOC_IN5              _L(3)
+#define PINMUX_PA28D_GLOC_IN5      ((PIN_PA28D_GLOC_IN5 << 16) | MUX_PA28D_GLOC_IN5)
+#define GPIO_PA28D_GLOC_IN5      _UL(1 << 28)
+#define PIN_PB07C_GLOC_IN5             _L(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
+#define MUX_PB07C_GLOC_IN5              _L(2)
+#define PINMUX_PB07C_GLOC_IN5      ((PIN_PB07C_GLOC_IN5 << 16) | MUX_PB07C_GLOC_IN5)
+#define GPIO_PB07C_GLOC_IN5      _UL(1 <<  7)
+#define PIN_PA29D_GLOC_IN6             _L(29) /**< \brief GLOC signal: IN6 on PA29 mux D */
+#define MUX_PA29D_GLOC_IN6              _L(3)
+#define PINMUX_PA29D_GLOC_IN6      ((PIN_PA29D_GLOC_IN6 << 16) | MUX_PA29D_GLOC_IN6)
+#define GPIO_PA29D_GLOC_IN6      _UL(1 << 29)
+#define PIN_PB08C_GLOC_IN6             _L(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
+#define MUX_PB08C_GLOC_IN6              _L(2)
+#define PINMUX_PB08C_GLOC_IN6      ((PIN_PB08C_GLOC_IN6 << 16) | MUX_PB08C_GLOC_IN6)
+#define GPIO_PB08C_GLOC_IN6      _UL(1 <<  8)
+#define PIN_PA30D_GLOC_IN7             _L(30) /**< \brief GLOC signal: IN7 on PA30 mux D */
+#define MUX_PA30D_GLOC_IN7              _L(3)
+#define PINMUX_PA30D_GLOC_IN7      ((PIN_PA30D_GLOC_IN7 << 16) | MUX_PA30D_GLOC_IN7)
+#define GPIO_PA30D_GLOC_IN7      _UL(1 << 30)
+#define PIN_PB09C_GLOC_IN7             _L(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
+#define MUX_PB09C_GLOC_IN7              _L(2)
+#define PINMUX_PB09C_GLOC_IN7      ((PIN_PB09C_GLOC_IN7 << 16) | MUX_PB09C_GLOC_IN7)
+#define GPIO_PB09C_GLOC_IN7      _UL(1 <<  9)
+#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
+#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
+#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
+#define PIN_PA31D_GLOC_OUT1            _L(31) /**< \brief GLOC signal: OUT1 on PA31 mux D */
+#define MUX_PA31D_GLOC_OUT1             _L(3)
+#define PINMUX_PA31D_GLOC_OUT1     ((PIN_PA31D_GLOC_OUT1 << 16) | MUX_PA31D_GLOC_OUT1)
+#define GPIO_PA31D_GLOC_OUT1     _UL(1 << 31)
+#define PIN_PB10C_GLOC_OUT1            _L(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
+#define MUX_PB10C_GLOC_OUT1             _L(2)
+#define PINMUX_PB10C_GLOC_OUT1     ((PIN_PB10C_GLOC_OUT1 << 16) | MUX_PB10C_GLOC_OUT1)
+#define GPIO_PB10C_GLOC_OUT1     _UL(1 << 10)
+/* ========== GPIO definition for ABDACB peripheral ========== */
+#define PIN_PA31C_ABDACB_CLK           _L(31) /**< \brief ABDACB signal: CLK on PA31 mux C */
+#define MUX_PA31C_ABDACB_CLK            _L(2)
+#define PINMUX_PA31C_ABDACB_CLK    ((PIN_PA31C_ABDACB_CLK << 16) | MUX_PA31C_ABDACB_CLK)
+#define GPIO_PA31C_ABDACB_CLK    _UL(1 << 31)
+#define PIN_PA27C_ABDACB_DAC0          _L(27) /**< \brief ABDACB signal: DAC0 on PA27 mux C */
+#define MUX_PA27C_ABDACB_DAC0           _L(2)
+#define PINMUX_PA27C_ABDACB_DAC0   ((PIN_PA27C_ABDACB_DAC0 << 16) | MUX_PA27C_ABDACB_DAC0)
+#define GPIO_PA27C_ABDACB_DAC0   _UL(1 << 27)
+#define PIN_PB02C_ABDACB_DAC0          _L(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
+#define MUX_PB02C_ABDACB_DAC0           _L(2)
+#define PINMUX_PB02C_ABDACB_DAC0   ((PIN_PB02C_ABDACB_DAC0 << 16) | MUX_PB02C_ABDACB_DAC0)
+#define GPIO_PB02C_ABDACB_DAC0   _UL(1 <<  2)
+#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
+#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
+#define PIN_PA29C_ABDACB_DAC1          _L(29) /**< \brief ABDACB signal: DAC1 on PA29 mux C */
+#define MUX_PA29C_ABDACB_DAC1           _L(2)
+#define PINMUX_PA29C_ABDACB_DAC1   ((PIN_PA29C_ABDACB_DAC1 << 16) | MUX_PA29C_ABDACB_DAC1)
+#define GPIO_PA29C_ABDACB_DAC1   _UL(1 << 29)
+#define PIN_PB04C_ABDACB_DAC1          _L(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
+#define MUX_PB04C_ABDACB_DAC1           _L(2)
+#define PINMUX_PB04C_ABDACB_DAC1   ((PIN_PB04C_ABDACB_DAC1 << 16) | MUX_PB04C_ABDACB_DAC1)
+#define GPIO_PB04C_ABDACB_DAC1   _UL(1 <<  4)
+#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
+#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
+#define PIN_PA28C_ABDACB_DACN0         _L(28) /**< \brief ABDACB signal: DACN0 on PA28 mux C */
+#define MUX_PA28C_ABDACB_DACN0          _L(2)
+#define PINMUX_PA28C_ABDACB_DACN0  ((PIN_PA28C_ABDACB_DACN0 << 16) | MUX_PA28C_ABDACB_DACN0)
+#define GPIO_PA28C_ABDACB_DACN0  _UL(1 << 28)
+#define PIN_PB03C_ABDACB_DACN0         _L(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
+#define MUX_PB03C_ABDACB_DACN0          _L(2)
+#define PINMUX_PB03C_ABDACB_DACN0  ((PIN_PB03C_ABDACB_DACN0 << 16) | MUX_PB03C_ABDACB_DACN0)
+#define GPIO_PB03C_ABDACB_DACN0  _UL(1 <<  3)
+#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
+#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
+#define PIN_PA30C_ABDACB_DACN1         _L(30) /**< \brief ABDACB signal: DACN1 on PA30 mux C */
+#define MUX_PA30C_ABDACB_DACN1          _L(2)
+#define PINMUX_PA30C_ABDACB_DACN1  ((PIN_PA30C_ABDACB_DACN1 << 16) | MUX_PA30C_ABDACB_DACN1)
+#define GPIO_PA30C_ABDACB_DACN1  _UL(1 << 30)
+#define PIN_PB05C_ABDACB_DACN1         _L(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
+#define MUX_PB05C_ABDACB_DACN1          _L(2)
+#define PINMUX_PB05C_ABDACB_DACN1  ((PIN_PB05C_ABDACB_DACN1 << 16) | MUX_PB05C_ABDACB_DACN1)
+#define GPIO_PB05C_ABDACB_DACN1  _UL(1 <<  5)
+#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
+#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+/* ========== GPIO definition for PARC peripheral ========== */
+#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
+#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
+#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
+#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
+#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
+#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
+#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
+#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
+#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
+#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
+#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
+#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
+#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
+#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
+#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
+#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
+#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
+#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
+#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
+#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
+#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+/* ========== GPIO definition for CATB peripheral ========== */
+#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L(6)
+#define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
+#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L(6)
+#define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
+#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L(6)
+#define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
+#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
+#define PIN_PA31G_CATB_DIS             _L(31) /**< \brief CATB signal: DIS on PA31 mux G */
+#define MUX_PA31G_CATB_DIS              _L(6)
+#define PINMUX_PA31G_CATB_DIS      ((PIN_PA31G_CATB_DIS << 16) | MUX_PA31G_CATB_DIS)
+#define GPIO_PA31G_CATB_DIS      _UL(1 << 31)
+#define PIN_PB03G_CATB_DIS             _L(35) /**< \brief CATB signal: DIS on PB03 mux G */
+#define MUX_PB03G_CATB_DIS              _L(6)
+#define PINMUX_PB03G_CATB_DIS      ((PIN_PB03G_CATB_DIS << 16) | MUX_PB03G_CATB_DIS)
+#define GPIO_PB03G_CATB_DIS      _UL(1 <<  3)
+#define PIN_PB12G_CATB_DIS             _L(44) /**< \brief CATB signal: DIS on PB12 mux G */
+#define MUX_PB12G_CATB_DIS              _L(6)
+#define PINMUX_PB12G_CATB_DIS      ((PIN_PB12G_CATB_DIS << 16) | MUX_PB12G_CATB_DIS)
+#define GPIO_PB12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
+#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
+#define PIN_PA27G_CATB_SENSE0          _L(27) /**< \brief CATB signal: SENSE0 on PA27 mux G */
+#define MUX_PA27G_CATB_SENSE0           _L(6)
+#define PINMUX_PA27G_CATB_SENSE0   ((PIN_PA27G_CATB_SENSE0 << 16) | MUX_PA27G_CATB_SENSE0)
+#define GPIO_PA27G_CATB_SENSE0   _UL(1 << 27)
+#define PIN_PB13G_CATB_SENSE0          _L(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
+#define MUX_PB13G_CATB_SENSE0           _L(6)
+#define PINMUX_PB13G_CATB_SENSE0   ((PIN_PB13G_CATB_SENSE0 << 16) | MUX_PB13G_CATB_SENSE0)
+#define GPIO_PB13G_CATB_SENSE0   _UL(1 << 13)
+#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
+#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
+#define PIN_PA28G_CATB_SENSE1          _L(28) /**< \brief CATB signal: SENSE1 on PA28 mux G */
+#define MUX_PA28G_CATB_SENSE1           _L(6)
+#define PINMUX_PA28G_CATB_SENSE1   ((PIN_PA28G_CATB_SENSE1 << 16) | MUX_PA28G_CATB_SENSE1)
+#define GPIO_PA28G_CATB_SENSE1   _UL(1 << 28)
+#define PIN_PB14G_CATB_SENSE1          _L(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
+#define MUX_PB14G_CATB_SENSE1           _L(6)
+#define PINMUX_PB14G_CATB_SENSE1   ((PIN_PB14G_CATB_SENSE1 << 16) | MUX_PB14G_CATB_SENSE1)
+#define GPIO_PB14G_CATB_SENSE1   _UL(1 << 14)
+#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
+#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
+#define PIN_PA29G_CATB_SENSE2          _L(29) /**< \brief CATB signal: SENSE2 on PA29 mux G */
+#define MUX_PA29G_CATB_SENSE2           _L(6)
+#define PINMUX_PA29G_CATB_SENSE2   ((PIN_PA29G_CATB_SENSE2 << 16) | MUX_PA29G_CATB_SENSE2)
+#define GPIO_PA29G_CATB_SENSE2   _UL(1 << 29)
+#define PIN_PB15G_CATB_SENSE2          _L(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
+#define MUX_PB15G_CATB_SENSE2           _L(6)
+#define PINMUX_PB15G_CATB_SENSE2   ((PIN_PB15G_CATB_SENSE2 << 16) | MUX_PB15G_CATB_SENSE2)
+#define GPIO_PB15G_CATB_SENSE2   _UL(1 << 15)
+#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
+#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
+#define PIN_PA30G_CATB_SENSE3          _L(30) /**< \brief CATB signal: SENSE3 on PA30 mux G */
+#define MUX_PA30G_CATB_SENSE3           _L(6)
+#define PINMUX_PA30G_CATB_SENSE3   ((PIN_PA30G_CATB_SENSE3 << 16) | MUX_PA30G_CATB_SENSE3)
+#define GPIO_PA30G_CATB_SENSE3   _UL(1 << 30)
+#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
+#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
+#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
+#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
+#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
+#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
+#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
+#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
+#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
+#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
+#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
+#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
+#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
+#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
+#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
+#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
+#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
+#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
+#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
+#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
+#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
+#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
+#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
+#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
+#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
+#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
+#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
+#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
+#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
+#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
+#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
+#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
+#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
+#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
+#define PIN_PB00G_CATB_SENSE21         _L(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
+#define MUX_PB00G_CATB_SENSE21          _L(6)
+#define PINMUX_PB00G_CATB_SENSE21  ((PIN_PB00G_CATB_SENSE21 << 16) | MUX_PB00G_CATB_SENSE21)
+#define GPIO_PB00G_CATB_SENSE21  _UL(1 <<  0)
+#define PIN_PB01G_CATB_SENSE22         _L(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
+#define MUX_PB01G_CATB_SENSE22          _L(6)
+#define PINMUX_PB01G_CATB_SENSE22  ((PIN_PB01G_CATB_SENSE22 << 16) | MUX_PB01G_CATB_SENSE22)
+#define GPIO_PB01G_CATB_SENSE22  _UL(1 <<  1)
+#define PIN_PB02G_CATB_SENSE23         _L(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
+#define MUX_PB02G_CATB_SENSE23          _L(6)
+#define PINMUX_PB02G_CATB_SENSE23  ((PIN_PB02G_CATB_SENSE23 << 16) | MUX_PB02G_CATB_SENSE23)
+#define GPIO_PB02G_CATB_SENSE23  _UL(1 <<  2)
+#define PIN_PB04G_CATB_SENSE24         _L(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
+#define MUX_PB04G_CATB_SENSE24          _L(6)
+#define PINMUX_PB04G_CATB_SENSE24  ((PIN_PB04G_CATB_SENSE24 << 16) | MUX_PB04G_CATB_SENSE24)
+#define GPIO_PB04G_CATB_SENSE24  _UL(1 <<  4)
+#define PIN_PB05G_CATB_SENSE25         _L(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
+#define MUX_PB05G_CATB_SENSE25          _L(6)
+#define PINMUX_PB05G_CATB_SENSE25  ((PIN_PB05G_CATB_SENSE25 << 16) | MUX_PB05G_CATB_SENSE25)
+#define GPIO_PB05G_CATB_SENSE25  _UL(1 <<  5)
+#define PIN_PB06G_CATB_SENSE26         _L(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
+#define MUX_PB06G_CATB_SENSE26          _L(6)
+#define PINMUX_PB06G_CATB_SENSE26  ((PIN_PB06G_CATB_SENSE26 << 16) | MUX_PB06G_CATB_SENSE26)
+#define GPIO_PB06G_CATB_SENSE26  _UL(1 <<  6)
+#define PIN_PB07G_CATB_SENSE27         _L(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
+#define MUX_PB07G_CATB_SENSE27          _L(6)
+#define PINMUX_PB07G_CATB_SENSE27  ((PIN_PB07G_CATB_SENSE27 << 16) | MUX_PB07G_CATB_SENSE27)
+#define GPIO_PB07G_CATB_SENSE27  _UL(1 <<  7)
+#define PIN_PB08G_CATB_SENSE28         _L(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
+#define MUX_PB08G_CATB_SENSE28          _L(6)
+#define PINMUX_PB08G_CATB_SENSE28  ((PIN_PB08G_CATB_SENSE28 << 16) | MUX_PB08G_CATB_SENSE28)
+#define GPIO_PB08G_CATB_SENSE28  _UL(1 <<  8)
+#define PIN_PB09G_CATB_SENSE29         _L(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
+#define MUX_PB09G_CATB_SENSE29          _L(6)
+#define PINMUX_PB09G_CATB_SENSE29  ((PIN_PB09G_CATB_SENSE29 << 16) | MUX_PB09G_CATB_SENSE29)
+#define GPIO_PB09G_CATB_SENSE29  _UL(1 <<  9)
+#define PIN_PB10G_CATB_SENSE30         _L(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
+#define MUX_PB10G_CATB_SENSE30          _L(6)
+#define PINMUX_PB10G_CATB_SENSE30  ((PIN_PB10G_CATB_SENSE30 << 16) | MUX_PB10G_CATB_SENSE30)
+#define GPIO_PB10G_CATB_SENSE30  _UL(1 << 10)
+#define PIN_PB11G_CATB_SENSE31         _L(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
+#define MUX_PB11G_CATB_SENSE31          _L(6)
+#define PINMUX_PB11G_CATB_SENSE31  ((PIN_PB11G_CATB_SENSE31 << 16) | MUX_PB11G_CATB_SENSE31)
+#define GPIO_PB11G_CATB_SENSE31  _UL(1 << 11)
+/* ========== GPIO definition for USBC peripheral ========== */
+#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L(0)
+#define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
+#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
+#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L(0)
+#define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
+#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+/* ========== GPIO definition for PEVC peripheral ========== */
+#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
+#define PIN_PB12C_PEVC_PAD_EVT0        _L(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
+#define MUX_PB12C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PB12C_PEVC_PAD_EVT0  ((PIN_PB12C_PEVC_PAD_EVT0 << 16) | MUX_PB12C_PEVC_PAD_EVT0)
+#define GPIO_PB12C_PEVC_PAD_EVT0  _UL(1 << 12)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
+#define PIN_PB13C_PEVC_PAD_EVT1        _L(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
+#define MUX_PB13C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PB13C_PEVC_PAD_EVT1  ((PIN_PB13C_PEVC_PAD_EVT1 << 16) | MUX_PB13C_PEVC_PAD_EVT1)
+#define GPIO_PB13C_PEVC_PAD_EVT1  _UL(1 << 13)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
+#define PIN_PB09B_PEVC_PAD_EVT2        _L(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
+#define MUX_PB09B_PEVC_PAD_EVT2         _L(1)
+#define PINMUX_PB09B_PEVC_PAD_EVT2  ((PIN_PB09B_PEVC_PAD_EVT2 << 16) | MUX_PB09B_PEVC_PAD_EVT2)
+#define GPIO_PB09B_PEVC_PAD_EVT2  _UL(1 <<  9)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
+#define PIN_PB10B_PEVC_PAD_EVT3        _L(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
+#define MUX_PB10B_PEVC_PAD_EVT3         _L(1)
+#define PINMUX_PB10B_PEVC_PAD_EVT3  ((PIN_PB10B_PEVC_PAD_EVT3 << 16) | MUX_PB10B_PEVC_PAD_EVT3)
+#define GPIO_PB10B_PEVC_PAD_EVT3  _UL(1 << 10)
+/* ========== GPIO definition for SCIF peripheral ========== */
+#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
+#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
+#define PIN_PB10E_SCIF_GCLK0           _L(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
+#define MUX_PB10E_SCIF_GCLK0            _L(4)
+#define PINMUX_PB10E_SCIF_GCLK0    ((PIN_PB10E_SCIF_GCLK0 << 16) | MUX_PB10E_SCIF_GCLK0)
+#define GPIO_PB10E_SCIF_GCLK0    _UL(1 << 10)
+#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
+#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
+#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
+#define PIN_PB11E_SCIF_GCLK1           _L(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
+#define MUX_PB11E_SCIF_GCLK1            _L(4)
+#define PINMUX_PB11E_SCIF_GCLK1    ((PIN_PB11E_SCIF_GCLK1 << 16) | MUX_PB11E_SCIF_GCLK1)
+#define GPIO_PB11E_SCIF_GCLK1    _UL(1 << 11)
+#define PIN_PB12E_SCIF_GCLK2           _L(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
+#define MUX_PB12E_SCIF_GCLK2            _L(4)
+#define PINMUX_PB12E_SCIF_GCLK2    ((PIN_PB12E_SCIF_GCLK2 << 16) | MUX_PB12E_SCIF_GCLK2)
+#define GPIO_PB12E_SCIF_GCLK2    _UL(1 << 12)
+#define PIN_PB13E_SCIF_GCLK3           _L(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
+#define MUX_PB13E_SCIF_GCLK3            _L(4)
+#define PINMUX_PB13E_SCIF_GCLK3    ((PIN_PB13E_SCIF_GCLK3 << 16) | MUX_PB13E_SCIF_GCLK3)
+#define GPIO_PB13E_SCIF_GCLK3    _UL(1 << 13)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
+#define PIN_PB14E_SCIF_GCLK_IN0        _L(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
+#define MUX_PB14E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PB14E_SCIF_GCLK_IN0  ((PIN_PB14E_SCIF_GCLK_IN0 << 16) | MUX_PB14E_SCIF_GCLK_IN0)
+#define GPIO_PB14E_SCIF_GCLK_IN0  _UL(1 << 14)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
+#define PIN_PB15E_SCIF_GCLK_IN1        _L(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
+#define MUX_PB15E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PB15E_SCIF_GCLK_IN1  ((PIN_PB15E_SCIF_GCLK_IN1 << 16) | MUX_PB15E_SCIF_GCLK_IN1)
+#define GPIO_PB15E_SCIF_GCLK_IN1  _UL(1 << 15)
+/* ========== GPIO definition for EIC peripheral ========== */
+#define PIN_PB01C_EIC_EXTINT0          _L(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
+#define MUX_PB01C_EIC_EXTINT0           _L(2)
+#define PINMUX_PB01C_EIC_EXTINT0   ((PIN_PB01C_EIC_EXTINT0 << 16) | MUX_PB01C_EIC_EXTINT0)
+#define GPIO_PB01C_EIC_EXTINT0   _UL(1 <<  1)
+#define PIN_PB01C_EIC_EXTINT_NUM        _L(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
+#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
+#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
+#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
+#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
+#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
+#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
+#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
+#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
+#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
+#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+
+#endif /* _SAM4LS8B_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4ls8b.h
+++ b/asf/sam/include/sam4l/pio/sam4ls8b.h
@@ -30,1071 +30,1071 @@
 #define _SAM4LS8B_PIO_
 
 #define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
-#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define GPIO_PA00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PA00 */
 #define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
-#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define GPIO_PA01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PA01 */
 #define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
-#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define GPIO_PA02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PA02 */
 #define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
-#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define GPIO_PA03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PA03 */
 #define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
-#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define GPIO_PA04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PA04 */
 #define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
-#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define GPIO_PA05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PA05 */
 #define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
-#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define GPIO_PA06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PA06 */
 #define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
-#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define GPIO_PA07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PA07 */
 #define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
-#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define GPIO_PA08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PA08 */
 #define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
-#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define GPIO_PA09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PA09 */
 #define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
-#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define GPIO_PA10                _UL_(1 << 10) /**< \brief GPIO Mask  for PA10 */
 #define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
-#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define GPIO_PA11                _UL_(1 << 11) /**< \brief GPIO Mask  for PA11 */
 #define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
-#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define GPIO_PA12                _UL_(1 << 12) /**< \brief GPIO Mask  for PA12 */
 #define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
-#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define GPIO_PA13                _UL_(1 << 13) /**< \brief GPIO Mask  for PA13 */
 #define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
-#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define GPIO_PA14                _UL_(1 << 14) /**< \brief GPIO Mask  for PA14 */
 #define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
-#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define GPIO_PA15                _UL_(1 << 15) /**< \brief GPIO Mask  for PA15 */
 #define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
-#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define GPIO_PA16                _UL_(1 << 16) /**< \brief GPIO Mask  for PA16 */
 #define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
-#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define GPIO_PA17                _UL_(1 << 17) /**< \brief GPIO Mask  for PA17 */
 #define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
-#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define GPIO_PA18                _UL_(1 << 18) /**< \brief GPIO Mask  for PA18 */
 #define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
-#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define GPIO_PA19                _UL_(1 << 19) /**< \brief GPIO Mask  for PA19 */
 #define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
-#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define GPIO_PA20                _UL_(1 << 20) /**< \brief GPIO Mask  for PA20 */
 #define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
-#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define GPIO_PA21                _UL_(1 << 21) /**< \brief GPIO Mask  for PA21 */
 #define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
-#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define GPIO_PA22                _UL_(1 << 22) /**< \brief GPIO Mask  for PA22 */
 #define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
-#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define GPIO_PA23                _UL_(1 << 23) /**< \brief GPIO Mask  for PA23 */
 #define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
-#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define GPIO_PA24                _UL_(1 << 24) /**< \brief GPIO Mask  for PA24 */
 #define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
-#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define GPIO_PA25                _UL_(1 << 25) /**< \brief GPIO Mask  for PA25 */
 #define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
-#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define GPIO_PA26                _UL_(1 << 26) /**< \brief GPIO Mask  for PA26 */
 #define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
-#define GPIO_PA27                _UL(1 << 27) /**< \brief GPIO Mask  for PA27 */
+#define GPIO_PA27                _UL_(1 << 27) /**< \brief GPIO Mask  for PA27 */
 #define PIN_PA28                          28  /**< \brief Pin Number for PA28 */
-#define GPIO_PA28                _UL(1 << 28) /**< \brief GPIO Mask  for PA28 */
+#define GPIO_PA28                _UL_(1 << 28) /**< \brief GPIO Mask  for PA28 */
 #define PIN_PA29                          29  /**< \brief Pin Number for PA29 */
-#define GPIO_PA29                _UL(1 << 29) /**< \brief GPIO Mask  for PA29 */
+#define GPIO_PA29                _UL_(1 << 29) /**< \brief GPIO Mask  for PA29 */
 #define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
-#define GPIO_PA30                _UL(1 << 30) /**< \brief GPIO Mask  for PA30 */
+#define GPIO_PA30                _UL_(1 << 30) /**< \brief GPIO Mask  for PA30 */
 #define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
-#define GPIO_PA31                _UL(1 << 31) /**< \brief GPIO Mask  for PA31 */
+#define GPIO_PA31                _UL_(1 << 31) /**< \brief GPIO Mask  for PA31 */
 #define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
-#define GPIO_PB00                _UL(1 <<  0) /**< \brief GPIO Mask  for PB00 */
+#define GPIO_PB00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PB00 */
 #define PIN_PB01                          33  /**< \brief Pin Number for PB01 */
-#define GPIO_PB01                _UL(1 <<  1) /**< \brief GPIO Mask  for PB01 */
+#define GPIO_PB01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PB01 */
 #define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
-#define GPIO_PB02                _UL(1 <<  2) /**< \brief GPIO Mask  for PB02 */
+#define GPIO_PB02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PB02 */
 #define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
-#define GPIO_PB03                _UL(1 <<  3) /**< \brief GPIO Mask  for PB03 */
+#define GPIO_PB03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PB03 */
 #define PIN_PB04                          36  /**< \brief Pin Number for PB04 */
-#define GPIO_PB04                _UL(1 <<  4) /**< \brief GPIO Mask  for PB04 */
+#define GPIO_PB04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PB04 */
 #define PIN_PB05                          37  /**< \brief Pin Number for PB05 */
-#define GPIO_PB05                _UL(1 <<  5) /**< \brief GPIO Mask  for PB05 */
+#define GPIO_PB05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PB05 */
 #define PIN_PB06                          38  /**< \brief Pin Number for PB06 */
-#define GPIO_PB06                _UL(1 <<  6) /**< \brief GPIO Mask  for PB06 */
+#define GPIO_PB06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PB06 */
 #define PIN_PB07                          39  /**< \brief Pin Number for PB07 */
-#define GPIO_PB07                _UL(1 <<  7) /**< \brief GPIO Mask  for PB07 */
+#define GPIO_PB07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PB07 */
 #define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
-#define GPIO_PB08                _UL(1 <<  8) /**< \brief GPIO Mask  for PB08 */
+#define GPIO_PB08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PB08 */
 #define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
-#define GPIO_PB09                _UL(1 <<  9) /**< \brief GPIO Mask  for PB09 */
+#define GPIO_PB09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PB09 */
 #define PIN_PB10                          42  /**< \brief Pin Number for PB10 */
-#define GPIO_PB10                _UL(1 << 10) /**< \brief GPIO Mask  for PB10 */
+#define GPIO_PB10                _UL_(1 << 10) /**< \brief GPIO Mask  for PB10 */
 #define PIN_PB11                          43  /**< \brief Pin Number for PB11 */
-#define GPIO_PB11                _UL(1 << 11) /**< \brief GPIO Mask  for PB11 */
+#define GPIO_PB11                _UL_(1 << 11) /**< \brief GPIO Mask  for PB11 */
 #define PIN_PB12                          44  /**< \brief Pin Number for PB12 */
-#define GPIO_PB12                _UL(1 << 12) /**< \brief GPIO Mask  for PB12 */
+#define GPIO_PB12                _UL_(1 << 12) /**< \brief GPIO Mask  for PB12 */
 #define PIN_PB13                          45  /**< \brief Pin Number for PB13 */
-#define GPIO_PB13                _UL(1 << 13) /**< \brief GPIO Mask  for PB13 */
+#define GPIO_PB13                _UL_(1 << 13) /**< \brief GPIO Mask  for PB13 */
 #define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
-#define GPIO_PB14                _UL(1 << 14) /**< \brief GPIO Mask  for PB14 */
+#define GPIO_PB14                _UL_(1 << 14) /**< \brief GPIO Mask  for PB14 */
 #define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
-#define GPIO_PB15                _UL(1 << 15) /**< \brief GPIO Mask  for PB15 */
+#define GPIO_PB15                _UL_(1 << 15) /**< \brief GPIO Mask  for PB15 */
 /* ========== GPIO definition for TWIMS0 peripheral ========== */
-#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
-#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PIN_PA24B_TWIMS0_TWCK          _L_(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L_(1)
 #define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
-#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
-#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
-#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL_(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L_(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L_(1)
 #define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
-#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+#define GPIO_PA23B_TWIMS0_TWD    _UL_(1 << 23)
 /* ========== GPIO definition for TWIMS1 peripheral ========== */
-#define PIN_PB01A_TWIMS1_TWCK          _L(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
-#define MUX_PB01A_TWIMS1_TWCK           _L(0)
+#define PIN_PB01A_TWIMS1_TWCK          _L_(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
+#define MUX_PB01A_TWIMS1_TWCK           _L_(0)
 #define PINMUX_PB01A_TWIMS1_TWCK   ((PIN_PB01A_TWIMS1_TWCK << 16) | MUX_PB01A_TWIMS1_TWCK)
-#define GPIO_PB01A_TWIMS1_TWCK   _UL(1 <<  1)
-#define PIN_PB00A_TWIMS1_TWD           _L(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
-#define MUX_PB00A_TWIMS1_TWD            _L(0)
+#define GPIO_PB01A_TWIMS1_TWCK   _UL_(1 <<  1)
+#define PIN_PB00A_TWIMS1_TWD           _L_(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
+#define MUX_PB00A_TWIMS1_TWD            _L_(0)
 #define PINMUX_PB00A_TWIMS1_TWD    ((PIN_PB00A_TWIMS1_TWD << 16) | MUX_PB00A_TWIMS1_TWD)
-#define GPIO_PB00A_TWIMS1_TWD    _UL(1 <<  0)
+#define GPIO_PB00A_TWIMS1_TWD    _UL_(1 <<  0)
 /* ========== GPIO definition for TWIMS2 peripheral ========== */
-#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
-#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PIN_PA22E_TWIMS2_TWCK          _L_(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L_(4)
 #define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
-#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
-#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
-#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL_(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L_(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L_(4)
 #define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
-#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+#define GPIO_PA21E_TWIMS2_TWD    _UL_(1 << 21)
 /* ========== GPIO definition for TWIMS3 peripheral ========== */
-#define PIN_PB15C_TWIMS3_TWCK          _L(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
-#define MUX_PB15C_TWIMS3_TWCK           _L(2)
+#define PIN_PB15C_TWIMS3_TWCK          _L_(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
+#define MUX_PB15C_TWIMS3_TWCK           _L_(2)
 #define PINMUX_PB15C_TWIMS3_TWCK   ((PIN_PB15C_TWIMS3_TWCK << 16) | MUX_PB15C_TWIMS3_TWCK)
-#define GPIO_PB15C_TWIMS3_TWCK   _UL(1 << 15)
-#define PIN_PB14C_TWIMS3_TWD           _L(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
-#define MUX_PB14C_TWIMS3_TWD            _L(2)
+#define GPIO_PB15C_TWIMS3_TWCK   _UL_(1 << 15)
+#define PIN_PB14C_TWIMS3_TWD           _L_(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
+#define MUX_PB14C_TWIMS3_TWD            _L_(2)
 #define PINMUX_PB14C_TWIMS3_TWD    ((PIN_PB14C_TWIMS3_TWD << 16) | MUX_PB14C_TWIMS3_TWD)
-#define GPIO_PB14C_TWIMS3_TWD    _UL(1 << 14)
+#define GPIO_PB14C_TWIMS3_TWD    _UL_(1 << 14)
 /* ========== GPIO definition for IISC peripheral ========== */
-#define PIN_PB05D_IISC_IMCK            _L(37) /**< \brief IISC signal: IMCK on PB05 mux D */
-#define MUX_PB05D_IISC_IMCK             _L(3)
+#define PIN_PB05D_IISC_IMCK            _L_(37) /**< \brief IISC signal: IMCK on PB05 mux D */
+#define MUX_PB05D_IISC_IMCK             _L_(3)
 #define PINMUX_PB05D_IISC_IMCK     ((PIN_PB05D_IISC_IMCK << 16) | MUX_PB05D_IISC_IMCK)
-#define GPIO_PB05D_IISC_IMCK     _UL(1 <<  5)
-#define PIN_PA31B_IISC_IMCK            _L(31) /**< \brief IISC signal: IMCK on PA31 mux B */
-#define MUX_PA31B_IISC_IMCK             _L(1)
+#define GPIO_PB05D_IISC_IMCK     _UL_(1 <<  5)
+#define PIN_PA31B_IISC_IMCK            _L_(31) /**< \brief IISC signal: IMCK on PA31 mux B */
+#define MUX_PA31B_IISC_IMCK             _L_(1)
 #define PINMUX_PA31B_IISC_IMCK     ((PIN_PA31B_IISC_IMCK << 16) | MUX_PA31B_IISC_IMCK)
-#define GPIO_PA31B_IISC_IMCK     _UL(1 << 31)
-#define PIN_PB02D_IISC_ISCK            _L(34) /**< \brief IISC signal: ISCK on PB02 mux D */
-#define MUX_PB02D_IISC_ISCK             _L(3)
+#define GPIO_PA31B_IISC_IMCK     _UL_(1 << 31)
+#define PIN_PB02D_IISC_ISCK            _L_(34) /**< \brief IISC signal: ISCK on PB02 mux D */
+#define MUX_PB02D_IISC_ISCK             _L_(3)
 #define PINMUX_PB02D_IISC_ISCK     ((PIN_PB02D_IISC_ISCK << 16) | MUX_PB02D_IISC_ISCK)
-#define GPIO_PB02D_IISC_ISCK     _UL(1 <<  2)
-#define PIN_PA27B_IISC_ISCK            _L(27) /**< \brief IISC signal: ISCK on PA27 mux B */
-#define MUX_PA27B_IISC_ISCK             _L(1)
+#define GPIO_PB02D_IISC_ISCK     _UL_(1 <<  2)
+#define PIN_PA27B_IISC_ISCK            _L_(27) /**< \brief IISC signal: ISCK on PA27 mux B */
+#define MUX_PA27B_IISC_ISCK             _L_(1)
 #define PINMUX_PA27B_IISC_ISCK     ((PIN_PA27B_IISC_ISCK << 16) | MUX_PA27B_IISC_ISCK)
-#define GPIO_PA27B_IISC_ISCK     _UL(1 << 27)
-#define PIN_PB03D_IISC_ISDI            _L(35) /**< \brief IISC signal: ISDI on PB03 mux D */
-#define MUX_PB03D_IISC_ISDI             _L(3)
+#define GPIO_PA27B_IISC_ISCK     _UL_(1 << 27)
+#define PIN_PB03D_IISC_ISDI            _L_(35) /**< \brief IISC signal: ISDI on PB03 mux D */
+#define MUX_PB03D_IISC_ISDI             _L_(3)
 #define PINMUX_PB03D_IISC_ISDI     ((PIN_PB03D_IISC_ISDI << 16) | MUX_PB03D_IISC_ISDI)
-#define GPIO_PB03D_IISC_ISDI     _UL(1 <<  3)
-#define PIN_PA28B_IISC_ISDI            _L(28) /**< \brief IISC signal: ISDI on PA28 mux B */
-#define MUX_PA28B_IISC_ISDI             _L(1)
+#define GPIO_PB03D_IISC_ISDI     _UL_(1 <<  3)
+#define PIN_PA28B_IISC_ISDI            _L_(28) /**< \brief IISC signal: ISDI on PA28 mux B */
+#define MUX_PA28B_IISC_ISDI             _L_(1)
 #define PINMUX_PA28B_IISC_ISDI     ((PIN_PA28B_IISC_ISDI << 16) | MUX_PA28B_IISC_ISDI)
-#define GPIO_PA28B_IISC_ISDI     _UL(1 << 28)
-#define PIN_PB04D_IISC_ISDO            _L(36) /**< \brief IISC signal: ISDO on PB04 mux D */
-#define MUX_PB04D_IISC_ISDO             _L(3)
+#define GPIO_PA28B_IISC_ISDI     _UL_(1 << 28)
+#define PIN_PB04D_IISC_ISDO            _L_(36) /**< \brief IISC signal: ISDO on PB04 mux D */
+#define MUX_PB04D_IISC_ISDO             _L_(3)
 #define PINMUX_PB04D_IISC_ISDO     ((PIN_PB04D_IISC_ISDO << 16) | MUX_PB04D_IISC_ISDO)
-#define GPIO_PB04D_IISC_ISDO     _UL(1 <<  4)
-#define PIN_PA30B_IISC_ISDO            _L(30) /**< \brief IISC signal: ISDO on PA30 mux B */
-#define MUX_PA30B_IISC_ISDO             _L(1)
+#define GPIO_PB04D_IISC_ISDO     _UL_(1 <<  4)
+#define PIN_PA30B_IISC_ISDO            _L_(30) /**< \brief IISC signal: ISDO on PA30 mux B */
+#define MUX_PA30B_IISC_ISDO             _L_(1)
 #define PINMUX_PA30B_IISC_ISDO     ((PIN_PA30B_IISC_ISDO << 16) | MUX_PA30B_IISC_ISDO)
-#define GPIO_PA30B_IISC_ISDO     _UL(1 << 30)
-#define PIN_PB06D_IISC_IWS             _L(38) /**< \brief IISC signal: IWS on PB06 mux D */
-#define MUX_PB06D_IISC_IWS              _L(3)
+#define GPIO_PA30B_IISC_ISDO     _UL_(1 << 30)
+#define PIN_PB06D_IISC_IWS             _L_(38) /**< \brief IISC signal: IWS on PB06 mux D */
+#define MUX_PB06D_IISC_IWS              _L_(3)
 #define PINMUX_PB06D_IISC_IWS      ((PIN_PB06D_IISC_IWS << 16) | MUX_PB06D_IISC_IWS)
-#define GPIO_PB06D_IISC_IWS      _UL(1 <<  6)
-#define PIN_PA29B_IISC_IWS             _L(29) /**< \brief IISC signal: IWS on PA29 mux B */
-#define MUX_PA29B_IISC_IWS              _L(1)
+#define GPIO_PB06D_IISC_IWS      _UL_(1 <<  6)
+#define PIN_PA29B_IISC_IWS             _L_(29) /**< \brief IISC signal: IWS on PA29 mux B */
+#define MUX_PA29B_IISC_IWS              _L_(1)
 #define PINMUX_PA29B_IISC_IWS      ((PIN_PA29B_IISC_IWS << 16) | MUX_PA29B_IISC_IWS)
-#define GPIO_PA29B_IISC_IWS      _UL(1 << 29)
+#define GPIO_PA29B_IISC_IWS      _UL_(1 << 29)
 /* ========== GPIO definition for SPI peripheral ========== */
-#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
-#define MUX_PA03B_SPI_MISO              _L(1)
+#define PIN_PA03B_SPI_MISO              _L_(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L_(1)
 #define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
-#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
-#define PIN_PB14B_SPI_MISO             _L(46) /**< \brief SPI signal: MISO on PB14 mux B */
-#define MUX_PB14B_SPI_MISO              _L(1)
+#define GPIO_PA03B_SPI_MISO      _UL_(1 <<  3)
+#define PIN_PB14B_SPI_MISO             _L_(46) /**< \brief SPI signal: MISO on PB14 mux B */
+#define MUX_PB14B_SPI_MISO              _L_(1)
 #define PINMUX_PB14B_SPI_MISO      ((PIN_PB14B_SPI_MISO << 16) | MUX_PB14B_SPI_MISO)
-#define GPIO_PB14B_SPI_MISO      _UL(1 << 14)
-#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
-#define MUX_PA21A_SPI_MISO              _L(0)
+#define GPIO_PB14B_SPI_MISO      _UL_(1 << 14)
+#define PIN_PA21A_SPI_MISO             _L_(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L_(0)
 #define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
-#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
-#define PIN_PA27A_SPI_MISO             _L(27) /**< \brief SPI signal: MISO on PA27 mux A */
-#define MUX_PA27A_SPI_MISO              _L(0)
+#define GPIO_PA21A_SPI_MISO      _UL_(1 << 21)
+#define PIN_PA27A_SPI_MISO             _L_(27) /**< \brief SPI signal: MISO on PA27 mux A */
+#define MUX_PA27A_SPI_MISO              _L_(0)
 #define PINMUX_PA27A_SPI_MISO      ((PIN_PA27A_SPI_MISO << 16) | MUX_PA27A_SPI_MISO)
-#define GPIO_PA27A_SPI_MISO      _UL(1 << 27)
-#define PIN_PB15B_SPI_MOSI             _L(47) /**< \brief SPI signal: MOSI on PB15 mux B */
-#define MUX_PB15B_SPI_MOSI              _L(1)
+#define GPIO_PA27A_SPI_MISO      _UL_(1 << 27)
+#define PIN_PB15B_SPI_MOSI             _L_(47) /**< \brief SPI signal: MOSI on PB15 mux B */
+#define MUX_PB15B_SPI_MOSI              _L_(1)
 #define PINMUX_PB15B_SPI_MOSI      ((PIN_PB15B_SPI_MOSI << 16) | MUX_PB15B_SPI_MOSI)
-#define GPIO_PB15B_SPI_MOSI      _UL(1 << 15)
-#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
-#define MUX_PA22A_SPI_MOSI              _L(0)
+#define GPIO_PB15B_SPI_MOSI      _UL_(1 << 15)
+#define PIN_PA22A_SPI_MOSI             _L_(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L_(0)
 #define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
-#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
-#define PIN_PA28A_SPI_MOSI             _L(28) /**< \brief SPI signal: MOSI on PA28 mux A */
-#define MUX_PA28A_SPI_MOSI              _L(0)
+#define GPIO_PA22A_SPI_MOSI      _UL_(1 << 22)
+#define PIN_PA28A_SPI_MOSI             _L_(28) /**< \brief SPI signal: MOSI on PA28 mux A */
+#define MUX_PA28A_SPI_MOSI              _L_(0)
 #define PINMUX_PA28A_SPI_MOSI      ((PIN_PA28A_SPI_MOSI << 16) | MUX_PA28A_SPI_MOSI)
-#define GPIO_PA28A_SPI_MOSI      _UL(1 << 28)
-#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
-#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define GPIO_PA28A_SPI_MOSI      _UL_(1 << 28)
+#define PIN_PA02B_SPI_NPCS0             _L_(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L_(1)
 #define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
-#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
-#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
-#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define GPIO_PA02B_SPI_NPCS0     _UL_(1 <<  2)
+#define PIN_PA24A_SPI_NPCS0            _L_(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L_(0)
 #define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
-#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
-#define PIN_PA30A_SPI_NPCS0            _L(30) /**< \brief SPI signal: NPCS0 on PA30 mux A */
-#define MUX_PA30A_SPI_NPCS0             _L(0)
+#define GPIO_PA24A_SPI_NPCS0     _UL_(1 << 24)
+#define PIN_PA30A_SPI_NPCS0            _L_(30) /**< \brief SPI signal: NPCS0 on PA30 mux A */
+#define MUX_PA30A_SPI_NPCS0             _L_(0)
 #define PINMUX_PA30A_SPI_NPCS0     ((PIN_PA30A_SPI_NPCS0 << 16) | MUX_PA30A_SPI_NPCS0)
-#define GPIO_PA30A_SPI_NPCS0     _UL(1 << 30)
-#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
-#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define GPIO_PA30A_SPI_NPCS0     _UL_(1 << 30)
+#define PIN_PA13C_SPI_NPCS1            _L_(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L_(2)
 #define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
-#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PB13B_SPI_NPCS1            _L(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
-#define MUX_PB13B_SPI_NPCS1             _L(1)
+#define GPIO_PA13C_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PB13B_SPI_NPCS1            _L_(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
+#define MUX_PB13B_SPI_NPCS1             _L_(1)
 #define PINMUX_PB13B_SPI_NPCS1     ((PIN_PB13B_SPI_NPCS1 << 16) | MUX_PB13B_SPI_NPCS1)
-#define GPIO_PB13B_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PA31A_SPI_NPCS1            _L(31) /**< \brief SPI signal: NPCS1 on PA31 mux A */
-#define MUX_PA31A_SPI_NPCS1             _L(0)
+#define GPIO_PB13B_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PA31A_SPI_NPCS1            _L_(31) /**< \brief SPI signal: NPCS1 on PA31 mux A */
+#define MUX_PA31A_SPI_NPCS1             _L_(0)
 #define PINMUX_PA31A_SPI_NPCS1     ((PIN_PA31A_SPI_NPCS1 << 16) | MUX_PA31A_SPI_NPCS1)
-#define GPIO_PA31A_SPI_NPCS1     _UL(1 << 31)
-#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
-#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define GPIO_PA31A_SPI_NPCS1     _UL_(1 << 31)
+#define PIN_PA14C_SPI_NPCS2            _L_(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L_(2)
 #define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
-#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
-#define PIN_PB11B_SPI_NPCS2            _L(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
-#define MUX_PB11B_SPI_NPCS2             _L(1)
+#define GPIO_PA14C_SPI_NPCS2     _UL_(1 << 14)
+#define PIN_PB11B_SPI_NPCS2            _L_(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
+#define MUX_PB11B_SPI_NPCS2             _L_(1)
 #define PINMUX_PB11B_SPI_NPCS2     ((PIN_PB11B_SPI_NPCS2 << 16) | MUX_PB11B_SPI_NPCS2)
-#define GPIO_PB11B_SPI_NPCS2     _UL(1 << 11)
-#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
-#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define GPIO_PB11B_SPI_NPCS2     _UL_(1 << 11)
+#define PIN_PA15C_SPI_NPCS3            _L_(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L_(2)
 #define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
-#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
-#define PIN_PB12B_SPI_NPCS3            _L(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
-#define MUX_PB12B_SPI_NPCS3             _L(1)
+#define GPIO_PA15C_SPI_NPCS3     _UL_(1 << 15)
+#define PIN_PB12B_SPI_NPCS3            _L_(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
+#define MUX_PB12B_SPI_NPCS3             _L_(1)
 #define PINMUX_PB12B_SPI_NPCS3     ((PIN_PB12B_SPI_NPCS3 << 16) | MUX_PB12B_SPI_NPCS3)
-#define GPIO_PB12B_SPI_NPCS3     _UL(1 << 12)
-#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
-#define MUX_PA23A_SPI_SCK               _L(0)
+#define GPIO_PB12B_SPI_NPCS3     _UL_(1 << 12)
+#define PIN_PA23A_SPI_SCK              _L_(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L_(0)
 #define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
-#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
-#define PIN_PA29A_SPI_SCK              _L(29) /**< \brief SPI signal: SCK on PA29 mux A */
-#define MUX_PA29A_SPI_SCK               _L(0)
+#define GPIO_PA23A_SPI_SCK       _UL_(1 << 23)
+#define PIN_PA29A_SPI_SCK              _L_(29) /**< \brief SPI signal: SCK on PA29 mux A */
+#define MUX_PA29A_SPI_SCK               _L_(0)
 #define PINMUX_PA29A_SPI_SCK       ((PIN_PA29A_SPI_SCK << 16) | MUX_PA29A_SPI_SCK)
-#define GPIO_PA29A_SPI_SCK       _UL(1 << 29)
+#define GPIO_PA29A_SPI_SCK       _UL_(1 << 29)
 /* ========== GPIO definition for TC0 peripheral ========== */
-#define PIN_PB07D_TC0_A0               _L(39) /**< \brief TC0 signal: A0 on PB07 mux D */
-#define MUX_PB07D_TC0_A0                _L(3)
+#define PIN_PB07D_TC0_A0               _L_(39) /**< \brief TC0 signal: A0 on PB07 mux D */
+#define MUX_PB07D_TC0_A0                _L_(3)
 #define PINMUX_PB07D_TC0_A0        ((PIN_PB07D_TC0_A0 << 16) | MUX_PB07D_TC0_A0)
-#define GPIO_PB07D_TC0_A0        _UL(1 <<  7)
-#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
-#define MUX_PA08B_TC0_A0                _L(1)
+#define GPIO_PB07D_TC0_A0        _UL_(1 <<  7)
+#define PIN_PA08B_TC0_A0                _L_(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L_(1)
 #define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
-#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
-#define PIN_PB09D_TC0_A1               _L(41) /**< \brief TC0 signal: A1 on PB09 mux D */
-#define MUX_PB09D_TC0_A1                _L(3)
+#define GPIO_PA08B_TC0_A0        _UL_(1 <<  8)
+#define PIN_PB09D_TC0_A1               _L_(41) /**< \brief TC0 signal: A1 on PB09 mux D */
+#define MUX_PB09D_TC0_A1                _L_(3)
 #define PINMUX_PB09D_TC0_A1        ((PIN_PB09D_TC0_A1 << 16) | MUX_PB09D_TC0_A1)
-#define GPIO_PB09D_TC0_A1        _UL(1 <<  9)
-#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
-#define MUX_PA10B_TC0_A1                _L(1)
+#define GPIO_PB09D_TC0_A1        _UL_(1 <<  9)
+#define PIN_PA10B_TC0_A1               _L_(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L_(1)
 #define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
-#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
-#define PIN_PB11D_TC0_A2               _L(43) /**< \brief TC0 signal: A2 on PB11 mux D */
-#define MUX_PB11D_TC0_A2                _L(3)
+#define GPIO_PA10B_TC0_A1        _UL_(1 << 10)
+#define PIN_PB11D_TC0_A2               _L_(43) /**< \brief TC0 signal: A2 on PB11 mux D */
+#define MUX_PB11D_TC0_A2                _L_(3)
 #define PINMUX_PB11D_TC0_A2        ((PIN_PB11D_TC0_A2 << 16) | MUX_PB11D_TC0_A2)
-#define GPIO_PB11D_TC0_A2        _UL(1 << 11)
-#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
-#define MUX_PA12B_TC0_A2                _L(1)
+#define GPIO_PB11D_TC0_A2        _UL_(1 << 11)
+#define PIN_PA12B_TC0_A2               _L_(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L_(1)
 #define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
-#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
-#define PIN_PB08D_TC0_B0               _L(40) /**< \brief TC0 signal: B0 on PB08 mux D */
-#define MUX_PB08D_TC0_B0                _L(3)
+#define GPIO_PA12B_TC0_A2        _UL_(1 << 12)
+#define PIN_PB08D_TC0_B0               _L_(40) /**< \brief TC0 signal: B0 on PB08 mux D */
+#define MUX_PB08D_TC0_B0                _L_(3)
 #define PINMUX_PB08D_TC0_B0        ((PIN_PB08D_TC0_B0 << 16) | MUX_PB08D_TC0_B0)
-#define GPIO_PB08D_TC0_B0        _UL(1 <<  8)
-#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
-#define MUX_PA09B_TC0_B0                _L(1)
+#define GPIO_PB08D_TC0_B0        _UL_(1 <<  8)
+#define PIN_PA09B_TC0_B0                _L_(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L_(1)
 #define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
-#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
-#define PIN_PB10D_TC0_B1               _L(42) /**< \brief TC0 signal: B1 on PB10 mux D */
-#define MUX_PB10D_TC0_B1                _L(3)
+#define GPIO_PA09B_TC0_B0        _UL_(1 <<  9)
+#define PIN_PB10D_TC0_B1               _L_(42) /**< \brief TC0 signal: B1 on PB10 mux D */
+#define MUX_PB10D_TC0_B1                _L_(3)
 #define PINMUX_PB10D_TC0_B1        ((PIN_PB10D_TC0_B1 << 16) | MUX_PB10D_TC0_B1)
-#define GPIO_PB10D_TC0_B1        _UL(1 << 10)
-#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
-#define MUX_PA11B_TC0_B1                _L(1)
+#define GPIO_PB10D_TC0_B1        _UL_(1 << 10)
+#define PIN_PA11B_TC0_B1               _L_(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L_(1)
 #define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
-#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
-#define PIN_PB12D_TC0_B2               _L(44) /**< \brief TC0 signal: B2 on PB12 mux D */
-#define MUX_PB12D_TC0_B2                _L(3)
+#define GPIO_PA11B_TC0_B1        _UL_(1 << 11)
+#define PIN_PB12D_TC0_B2               _L_(44) /**< \brief TC0 signal: B2 on PB12 mux D */
+#define MUX_PB12D_TC0_B2                _L_(3)
 #define PINMUX_PB12D_TC0_B2        ((PIN_PB12D_TC0_B2 << 16) | MUX_PB12D_TC0_B2)
-#define GPIO_PB12D_TC0_B2        _UL(1 << 12)
-#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
-#define MUX_PA13B_TC0_B2                _L(1)
+#define GPIO_PB12D_TC0_B2        _UL_(1 << 12)
+#define PIN_PA13B_TC0_B2               _L_(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L_(1)
 #define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
-#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
-#define PIN_PB13D_TC0_CLK0             _L(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
-#define MUX_PB13D_TC0_CLK0              _L(3)
+#define GPIO_PA13B_TC0_B2        _UL_(1 << 13)
+#define PIN_PB13D_TC0_CLK0             _L_(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
+#define MUX_PB13D_TC0_CLK0              _L_(3)
 #define PINMUX_PB13D_TC0_CLK0      ((PIN_PB13D_TC0_CLK0 << 16) | MUX_PB13D_TC0_CLK0)
-#define GPIO_PB13D_TC0_CLK0      _UL(1 << 13)
-#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
-#define MUX_PA14B_TC0_CLK0              _L(1)
+#define GPIO_PB13D_TC0_CLK0      _UL_(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L_(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L_(1)
 #define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
-#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
-#define PIN_PB14D_TC0_CLK1             _L(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
-#define MUX_PB14D_TC0_CLK1              _L(3)
+#define GPIO_PA14B_TC0_CLK0      _UL_(1 << 14)
+#define PIN_PB14D_TC0_CLK1             _L_(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
+#define MUX_PB14D_TC0_CLK1              _L_(3)
 #define PINMUX_PB14D_TC0_CLK1      ((PIN_PB14D_TC0_CLK1 << 16) | MUX_PB14D_TC0_CLK1)
-#define GPIO_PB14D_TC0_CLK1      _UL(1 << 14)
-#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
-#define MUX_PA15B_TC0_CLK1              _L(1)
+#define GPIO_PB14D_TC0_CLK1      _UL_(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L_(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L_(1)
 #define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
-#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
-#define PIN_PB15D_TC0_CLK2             _L(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
-#define MUX_PB15D_TC0_CLK2              _L(3)
+#define GPIO_PA15B_TC0_CLK1      _UL_(1 << 15)
+#define PIN_PB15D_TC0_CLK2             _L_(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
+#define MUX_PB15D_TC0_CLK2              _L_(3)
 #define PINMUX_PB15D_TC0_CLK2      ((PIN_PB15D_TC0_CLK2 << 16) | MUX_PB15D_TC0_CLK2)
-#define GPIO_PB15D_TC0_CLK2      _UL(1 << 15)
-#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
-#define MUX_PA16B_TC0_CLK2              _L(1)
+#define GPIO_PB15D_TC0_CLK2      _UL_(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L_(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L_(1)
 #define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
-#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+#define GPIO_PA16B_TC0_CLK2      _UL_(1 << 16)
 /* ========== GPIO definition for USART0 peripheral ========== */
-#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
-#define MUX_PA04B_USART0_CLK            _L(1)
+#define PIN_PA04B_USART0_CLK            _L_(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L_(1)
 #define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
-#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
-#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
-#define MUX_PA10A_USART0_CLK            _L(0)
+#define GPIO_PA04B_USART0_CLK    _UL_(1 <<  4)
+#define PIN_PA10A_USART0_CLK           _L_(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L_(0)
 #define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
-#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
-#define PIN_PB13A_USART0_CLK           _L(45) /**< \brief USART0 signal: CLK on PB13 mux A */
-#define MUX_PB13A_USART0_CLK            _L(0)
+#define GPIO_PA10A_USART0_CLK    _UL_(1 << 10)
+#define PIN_PB13A_USART0_CLK           _L_(45) /**< \brief USART0 signal: CLK on PB13 mux A */
+#define MUX_PB13A_USART0_CLK            _L_(0)
 #define PINMUX_PB13A_USART0_CLK    ((PIN_PB13A_USART0_CLK << 16) | MUX_PB13A_USART0_CLK)
-#define GPIO_PB13A_USART0_CLK    _UL(1 << 13)
-#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
-#define MUX_PA09A_USART0_CTS            _L(0)
+#define GPIO_PB13A_USART0_CLK    _UL_(1 << 13)
+#define PIN_PA09A_USART0_CTS            _L_(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L_(0)
 #define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
-#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
-#define PIN_PB11A_USART0_CTS           _L(43) /**< \brief USART0 signal: CTS on PB11 mux A */
-#define MUX_PB11A_USART0_CTS            _L(0)
+#define GPIO_PA09A_USART0_CTS    _UL_(1 <<  9)
+#define PIN_PB11A_USART0_CTS           _L_(43) /**< \brief USART0 signal: CTS on PB11 mux A */
+#define MUX_PB11A_USART0_CTS            _L_(0)
 #define PINMUX_PB11A_USART0_CTS    ((PIN_PB11A_USART0_CTS << 16) | MUX_PB11A_USART0_CTS)
-#define GPIO_PB11A_USART0_CTS    _UL(1 << 11)
-#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
-#define MUX_PA06B_USART0_RTS            _L(1)
+#define GPIO_PB11A_USART0_CTS    _UL_(1 << 11)
+#define PIN_PA06B_USART0_RTS            _L_(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L_(1)
 #define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
-#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
-#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
-#define MUX_PA08A_USART0_RTS            _L(0)
+#define GPIO_PA06B_USART0_RTS    _UL_(1 <<  6)
+#define PIN_PA08A_USART0_RTS            _L_(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L_(0)
 #define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
-#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
-#define PIN_PB12A_USART0_RTS           _L(44) /**< \brief USART0 signal: RTS on PB12 mux A */
-#define MUX_PB12A_USART0_RTS            _L(0)
+#define GPIO_PA08A_USART0_RTS    _UL_(1 <<  8)
+#define PIN_PB12A_USART0_RTS           _L_(44) /**< \brief USART0 signal: RTS on PB12 mux A */
+#define MUX_PB12A_USART0_RTS            _L_(0)
 #define PINMUX_PB12A_USART0_RTS    ((PIN_PB12A_USART0_RTS << 16) | MUX_PB12A_USART0_RTS)
-#define GPIO_PB12A_USART0_RTS    _UL(1 << 12)
-#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
-#define MUX_PA05B_USART0_RXD            _L(1)
+#define GPIO_PB12A_USART0_RTS    _UL_(1 << 12)
+#define PIN_PA05B_USART0_RXD            _L_(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L_(1)
 #define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
-#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
-#define PIN_PB00B_USART0_RXD           _L(32) /**< \brief USART0 signal: RXD on PB00 mux B */
-#define MUX_PB00B_USART0_RXD            _L(1)
+#define GPIO_PA05B_USART0_RXD    _UL_(1 <<  5)
+#define PIN_PB00B_USART0_RXD           _L_(32) /**< \brief USART0 signal: RXD on PB00 mux B */
+#define MUX_PB00B_USART0_RXD            _L_(1)
 #define PINMUX_PB00B_USART0_RXD    ((PIN_PB00B_USART0_RXD << 16) | MUX_PB00B_USART0_RXD)
-#define GPIO_PB00B_USART0_RXD    _UL(1 <<  0)
-#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
-#define MUX_PA11A_USART0_RXD            _L(0)
+#define GPIO_PB00B_USART0_RXD    _UL_(1 <<  0)
+#define PIN_PA11A_USART0_RXD           _L_(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L_(0)
 #define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
-#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
-#define PIN_PB14A_USART0_RXD           _L(46) /**< \brief USART0 signal: RXD on PB14 mux A */
-#define MUX_PB14A_USART0_RXD            _L(0)
+#define GPIO_PA11A_USART0_RXD    _UL_(1 << 11)
+#define PIN_PB14A_USART0_RXD           _L_(46) /**< \brief USART0 signal: RXD on PB14 mux A */
+#define MUX_PB14A_USART0_RXD            _L_(0)
 #define PINMUX_PB14A_USART0_RXD    ((PIN_PB14A_USART0_RXD << 16) | MUX_PB14A_USART0_RXD)
-#define GPIO_PB14A_USART0_RXD    _UL(1 << 14)
-#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
-#define MUX_PA07B_USART0_TXD            _L(1)
+#define GPIO_PB14A_USART0_RXD    _UL_(1 << 14)
+#define PIN_PA07B_USART0_TXD            _L_(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L_(1)
 #define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
-#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
-#define PIN_PB01B_USART0_TXD           _L(33) /**< \brief USART0 signal: TXD on PB01 mux B */
-#define MUX_PB01B_USART0_TXD            _L(1)
+#define GPIO_PA07B_USART0_TXD    _UL_(1 <<  7)
+#define PIN_PB01B_USART0_TXD           _L_(33) /**< \brief USART0 signal: TXD on PB01 mux B */
+#define MUX_PB01B_USART0_TXD            _L_(1)
 #define PINMUX_PB01B_USART0_TXD    ((PIN_PB01B_USART0_TXD << 16) | MUX_PB01B_USART0_TXD)
-#define GPIO_PB01B_USART0_TXD    _UL(1 <<  1)
-#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
-#define MUX_PA12A_USART0_TXD            _L(0)
+#define GPIO_PB01B_USART0_TXD    _UL_(1 <<  1)
+#define PIN_PA12A_USART0_TXD           _L_(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L_(0)
 #define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
-#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
-#define PIN_PB15A_USART0_TXD           _L(47) /**< \brief USART0 signal: TXD on PB15 mux A */
-#define MUX_PB15A_USART0_TXD            _L(0)
+#define GPIO_PA12A_USART0_TXD    _UL_(1 << 12)
+#define PIN_PB15A_USART0_TXD           _L_(47) /**< \brief USART0 signal: TXD on PB15 mux A */
+#define MUX_PB15A_USART0_TXD            _L_(0)
 #define PINMUX_PB15A_USART0_TXD    ((PIN_PB15A_USART0_TXD << 16) | MUX_PB15A_USART0_TXD)
-#define GPIO_PB15A_USART0_TXD    _UL(1 << 15)
+#define GPIO_PB15A_USART0_TXD    _UL_(1 << 15)
 /* ========== GPIO definition for USART1 peripheral ========== */
-#define PIN_PB03B_USART1_CLK           _L(35) /**< \brief USART1 signal: CLK on PB03 mux B */
-#define MUX_PB03B_USART1_CLK            _L(1)
+#define PIN_PB03B_USART1_CLK           _L_(35) /**< \brief USART1 signal: CLK on PB03 mux B */
+#define MUX_PB03B_USART1_CLK            _L_(1)
 #define PINMUX_PB03B_USART1_CLK    ((PIN_PB03B_USART1_CLK << 16) | MUX_PB03B_USART1_CLK)
-#define GPIO_PB03B_USART1_CLK    _UL(1 <<  3)
-#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
-#define MUX_PA14A_USART1_CLK            _L(0)
+#define GPIO_PB03B_USART1_CLK    _UL_(1 <<  3)
+#define PIN_PA14A_USART1_CLK           _L_(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L_(0)
 #define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
-#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
-#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
-#define MUX_PA21B_USART1_CTS            _L(1)
+#define GPIO_PA14A_USART1_CLK    _UL_(1 << 14)
+#define PIN_PA21B_USART1_CTS           _L_(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L_(1)
 #define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
-#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
-#define PIN_PB02B_USART1_RTS           _L(34) /**< \brief USART1 signal: RTS on PB02 mux B */
-#define MUX_PB02B_USART1_RTS            _L(1)
+#define GPIO_PA21B_USART1_CTS    _UL_(1 << 21)
+#define PIN_PB02B_USART1_RTS           _L_(34) /**< \brief USART1 signal: RTS on PB02 mux B */
+#define MUX_PB02B_USART1_RTS            _L_(1)
 #define PINMUX_PB02B_USART1_RTS    ((PIN_PB02B_USART1_RTS << 16) | MUX_PB02B_USART1_RTS)
-#define GPIO_PB02B_USART1_RTS    _UL(1 <<  2)
-#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
-#define MUX_PA13A_USART1_RTS            _L(0)
+#define GPIO_PB02B_USART1_RTS    _UL_(1 <<  2)
+#define PIN_PA13A_USART1_RTS           _L_(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L_(0)
 #define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
-#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
-#define PIN_PB04B_USART1_RXD           _L(36) /**< \brief USART1 signal: RXD on PB04 mux B */
-#define MUX_PB04B_USART1_RXD            _L(1)
+#define GPIO_PA13A_USART1_RTS    _UL_(1 << 13)
+#define PIN_PB04B_USART1_RXD           _L_(36) /**< \brief USART1 signal: RXD on PB04 mux B */
+#define MUX_PB04B_USART1_RXD            _L_(1)
 #define PINMUX_PB04B_USART1_RXD    ((PIN_PB04B_USART1_RXD << 16) | MUX_PB04B_USART1_RXD)
-#define GPIO_PB04B_USART1_RXD    _UL(1 <<  4)
-#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
-#define MUX_PA15A_USART1_RXD            _L(0)
+#define GPIO_PB04B_USART1_RXD    _UL_(1 <<  4)
+#define PIN_PA15A_USART1_RXD           _L_(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L_(0)
 #define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
-#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
-#define PIN_PB05B_USART1_TXD           _L(37) /**< \brief USART1 signal: TXD on PB05 mux B */
-#define MUX_PB05B_USART1_TXD            _L(1)
+#define GPIO_PA15A_USART1_RXD    _UL_(1 << 15)
+#define PIN_PB05B_USART1_TXD           _L_(37) /**< \brief USART1 signal: TXD on PB05 mux B */
+#define MUX_PB05B_USART1_TXD            _L_(1)
 #define PINMUX_PB05B_USART1_TXD    ((PIN_PB05B_USART1_TXD << 16) | MUX_PB05B_USART1_TXD)
-#define GPIO_PB05B_USART1_TXD    _UL(1 <<  5)
-#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
-#define MUX_PA16A_USART1_TXD            _L(0)
+#define GPIO_PB05B_USART1_TXD    _UL_(1 <<  5)
+#define PIN_PA16A_USART1_TXD           _L_(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L_(0)
 #define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
-#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+#define GPIO_PA16A_USART1_TXD    _UL_(1 << 16)
 /* ========== GPIO definition for USART2 peripheral ========== */
-#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
-#define MUX_PA18A_USART2_CLK            _L(0)
+#define PIN_PA18A_USART2_CLK           _L_(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L_(0)
 #define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
-#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
-#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
-#define MUX_PA22B_USART2_CTS            _L(1)
+#define GPIO_PA18A_USART2_CLK    _UL_(1 << 18)
+#define PIN_PA22B_USART2_CTS           _L_(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L_(1)
 #define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
-#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
-#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
-#define MUX_PA17A_USART2_RTS            _L(0)
+#define GPIO_PA22B_USART2_CTS    _UL_(1 << 22)
+#define PIN_PA17A_USART2_RTS           _L_(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L_(0)
 #define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
-#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
-#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
-#define MUX_PA25B_USART2_RXD            _L(1)
+#define GPIO_PA17A_USART2_RTS    _UL_(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L_(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L_(1)
 #define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
-#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
-#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
-#define MUX_PA19A_USART2_RXD            _L(0)
+#define GPIO_PA25B_USART2_RXD    _UL_(1 << 25)
+#define PIN_PA19A_USART2_RXD           _L_(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L_(0)
 #define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
-#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
-#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
-#define MUX_PA26B_USART2_TXD            _L(1)
+#define GPIO_PA19A_USART2_RXD    _UL_(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L_(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L_(1)
 #define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
-#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
-#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
-#define MUX_PA20A_USART2_TXD            _L(0)
+#define GPIO_PA26B_USART2_TXD    _UL_(1 << 26)
+#define PIN_PA20A_USART2_TXD           _L_(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L_(0)
 #define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
-#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+#define GPIO_PA20A_USART2_TXD    _UL_(1 << 20)
 /* ========== GPIO definition for USART3 peripheral ========== */
-#define PIN_PA29E_USART3_CLK           _L(29) /**< \brief USART3 signal: CLK on PA29 mux E */
-#define MUX_PA29E_USART3_CLK            _L(4)
+#define PIN_PA29E_USART3_CLK           _L_(29) /**< \brief USART3 signal: CLK on PA29 mux E */
+#define MUX_PA29E_USART3_CLK            _L_(4)
 #define PINMUX_PA29E_USART3_CLK    ((PIN_PA29E_USART3_CLK << 16) | MUX_PA29E_USART3_CLK)
-#define GPIO_PA29E_USART3_CLK    _UL(1 << 29)
-#define PIN_PB08A_USART3_CLK           _L(40) /**< \brief USART3 signal: CLK on PB08 mux A */
-#define MUX_PB08A_USART3_CLK            _L(0)
+#define GPIO_PA29E_USART3_CLK    _UL_(1 << 29)
+#define PIN_PB08A_USART3_CLK           _L_(40) /**< \brief USART3 signal: CLK on PB08 mux A */
+#define MUX_PB08A_USART3_CLK            _L_(0)
 #define PINMUX_PB08A_USART3_CLK    ((PIN_PB08A_USART3_CLK << 16) | MUX_PB08A_USART3_CLK)
-#define GPIO_PB08A_USART3_CLK    _UL(1 <<  8)
-#define PIN_PA28E_USART3_CTS           _L(28) /**< \brief USART3 signal: CTS on PA28 mux E */
-#define MUX_PA28E_USART3_CTS            _L(4)
+#define GPIO_PB08A_USART3_CLK    _UL_(1 <<  8)
+#define PIN_PA28E_USART3_CTS           _L_(28) /**< \brief USART3 signal: CTS on PA28 mux E */
+#define MUX_PA28E_USART3_CTS            _L_(4)
 #define PINMUX_PA28E_USART3_CTS    ((PIN_PA28E_USART3_CTS << 16) | MUX_PA28E_USART3_CTS)
-#define GPIO_PA28E_USART3_CTS    _UL(1 << 28)
-#define PIN_PB07A_USART3_CTS           _L(39) /**< \brief USART3 signal: CTS on PB07 mux A */
-#define MUX_PB07A_USART3_CTS            _L(0)
+#define GPIO_PA28E_USART3_CTS    _UL_(1 << 28)
+#define PIN_PB07A_USART3_CTS           _L_(39) /**< \brief USART3 signal: CTS on PB07 mux A */
+#define MUX_PB07A_USART3_CTS            _L_(0)
 #define PINMUX_PB07A_USART3_CTS    ((PIN_PB07A_USART3_CTS << 16) | MUX_PB07A_USART3_CTS)
-#define GPIO_PB07A_USART3_CTS    _UL(1 <<  7)
-#define PIN_PA27E_USART3_RTS           _L(27) /**< \brief USART3 signal: RTS on PA27 mux E */
-#define MUX_PA27E_USART3_RTS            _L(4)
+#define GPIO_PB07A_USART3_CTS    _UL_(1 <<  7)
+#define PIN_PA27E_USART3_RTS           _L_(27) /**< \brief USART3 signal: RTS on PA27 mux E */
+#define MUX_PA27E_USART3_RTS            _L_(4)
 #define PINMUX_PA27E_USART3_RTS    ((PIN_PA27E_USART3_RTS << 16) | MUX_PA27E_USART3_RTS)
-#define GPIO_PA27E_USART3_RTS    _UL(1 << 27)
-#define PIN_PB06A_USART3_RTS           _L(38) /**< \brief USART3 signal: RTS on PB06 mux A */
-#define MUX_PB06A_USART3_RTS            _L(0)
+#define GPIO_PA27E_USART3_RTS    _UL_(1 << 27)
+#define PIN_PB06A_USART3_RTS           _L_(38) /**< \brief USART3 signal: RTS on PB06 mux A */
+#define MUX_PB06A_USART3_RTS            _L_(0)
 #define PINMUX_PB06A_USART3_RTS    ((PIN_PB06A_USART3_RTS << 16) | MUX_PB06A_USART3_RTS)
-#define GPIO_PB06A_USART3_RTS    _UL(1 <<  6)
-#define PIN_PA30E_USART3_RXD           _L(30) /**< \brief USART3 signal: RXD on PA30 mux E */
-#define MUX_PA30E_USART3_RXD            _L(4)
+#define GPIO_PB06A_USART3_RTS    _UL_(1 <<  6)
+#define PIN_PA30E_USART3_RXD           _L_(30) /**< \brief USART3 signal: RXD on PA30 mux E */
+#define MUX_PA30E_USART3_RXD            _L_(4)
 #define PINMUX_PA30E_USART3_RXD    ((PIN_PA30E_USART3_RXD << 16) | MUX_PA30E_USART3_RXD)
-#define GPIO_PA30E_USART3_RXD    _UL(1 << 30)
-#define PIN_PB09A_USART3_RXD           _L(41) /**< \brief USART3 signal: RXD on PB09 mux A */
-#define MUX_PB09A_USART3_RXD            _L(0)
+#define GPIO_PA30E_USART3_RXD    _UL_(1 << 30)
+#define PIN_PB09A_USART3_RXD           _L_(41) /**< \brief USART3 signal: RXD on PB09 mux A */
+#define MUX_PB09A_USART3_RXD            _L_(0)
 #define PINMUX_PB09A_USART3_RXD    ((PIN_PB09A_USART3_RXD << 16) | MUX_PB09A_USART3_RXD)
-#define GPIO_PB09A_USART3_RXD    _UL(1 <<  9)
-#define PIN_PA31E_USART3_TXD           _L(31) /**< \brief USART3 signal: TXD on PA31 mux E */
-#define MUX_PA31E_USART3_TXD            _L(4)
+#define GPIO_PB09A_USART3_RXD    _UL_(1 <<  9)
+#define PIN_PA31E_USART3_TXD           _L_(31) /**< \brief USART3 signal: TXD on PA31 mux E */
+#define MUX_PA31E_USART3_TXD            _L_(4)
 #define PINMUX_PA31E_USART3_TXD    ((PIN_PA31E_USART3_TXD << 16) | MUX_PA31E_USART3_TXD)
-#define GPIO_PA31E_USART3_TXD    _UL(1 << 31)
-#define PIN_PB10A_USART3_TXD           _L(42) /**< \brief USART3 signal: TXD on PB10 mux A */
-#define MUX_PB10A_USART3_TXD            _L(0)
+#define GPIO_PA31E_USART3_TXD    _UL_(1 << 31)
+#define PIN_PB10A_USART3_TXD           _L_(42) /**< \brief USART3 signal: TXD on PB10 mux A */
+#define MUX_PB10A_USART3_TXD            _L_(0)
 #define PINMUX_PB10A_USART3_TXD    ((PIN_PB10A_USART3_TXD << 16) | MUX_PB10A_USART3_TXD)
-#define GPIO_PB10A_USART3_TXD    _UL(1 << 10)
+#define GPIO_PB10A_USART3_TXD    _UL_(1 << 10)
 /* ========== GPIO definition for ADCIFE peripheral ========== */
-#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
-#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PIN_PA04A_ADCIFE_AD0            _L_(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L_(0)
 #define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
-#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
-#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
-#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL_(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L_(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L_(0)
 #define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
-#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
-#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
-#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define GPIO_PA05A_ADCIFE_AD1    _UL_(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L_(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L_(0)
 #define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
-#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
-#define PIN_PB02A_ADCIFE_AD3           _L(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
-#define MUX_PB02A_ADCIFE_AD3            _L(0)
+#define GPIO_PA07A_ADCIFE_AD2    _UL_(1 <<  7)
+#define PIN_PB02A_ADCIFE_AD3           _L_(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
+#define MUX_PB02A_ADCIFE_AD3            _L_(0)
 #define PINMUX_PB02A_ADCIFE_AD3    ((PIN_PB02A_ADCIFE_AD3 << 16) | MUX_PB02A_ADCIFE_AD3)
-#define GPIO_PB02A_ADCIFE_AD3    _UL(1 <<  2)
-#define PIN_PB03A_ADCIFE_AD4           _L(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
-#define MUX_PB03A_ADCIFE_AD4            _L(0)
+#define GPIO_PB02A_ADCIFE_AD3    _UL_(1 <<  2)
+#define PIN_PB03A_ADCIFE_AD4           _L_(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
+#define MUX_PB03A_ADCIFE_AD4            _L_(0)
 #define PINMUX_PB03A_ADCIFE_AD4    ((PIN_PB03A_ADCIFE_AD4 << 16) | MUX_PB03A_ADCIFE_AD4)
-#define GPIO_PB03A_ADCIFE_AD4    _UL(1 <<  3)
-#define PIN_PB04A_ADCIFE_AD5           _L(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
-#define MUX_PB04A_ADCIFE_AD5            _L(0)
+#define GPIO_PB03A_ADCIFE_AD4    _UL_(1 <<  3)
+#define PIN_PB04A_ADCIFE_AD5           _L_(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
+#define MUX_PB04A_ADCIFE_AD5            _L_(0)
 #define PINMUX_PB04A_ADCIFE_AD5    ((PIN_PB04A_ADCIFE_AD5 << 16) | MUX_PB04A_ADCIFE_AD5)
-#define GPIO_PB04A_ADCIFE_AD5    _UL(1 <<  4)
-#define PIN_PB05A_ADCIFE_AD6           _L(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
-#define MUX_PB05A_ADCIFE_AD6            _L(0)
+#define GPIO_PB04A_ADCIFE_AD5    _UL_(1 <<  4)
+#define PIN_PB05A_ADCIFE_AD6           _L_(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
+#define MUX_PB05A_ADCIFE_AD6            _L_(0)
 #define PINMUX_PB05A_ADCIFE_AD6    ((PIN_PB05A_ADCIFE_AD6 << 16) | MUX_PB05A_ADCIFE_AD6)
-#define GPIO_PB05A_ADCIFE_AD6    _UL(1 <<  5)
-#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
-#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define GPIO_PB05A_ADCIFE_AD6    _UL_(1 <<  5)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L_(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L_(4)
 #define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
-#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL_(1 <<  5)
 /* ========== GPIO definition for DACC peripheral ========== */
-#define PIN_PB04E_DACC_EXT_TRIG0       _L(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
-#define MUX_PB04E_DACC_EXT_TRIG0        _L(4)
+#define PIN_PB04E_DACC_EXT_TRIG0       _L_(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
+#define MUX_PB04E_DACC_EXT_TRIG0        _L_(4)
 #define PINMUX_PB04E_DACC_EXT_TRIG0  ((PIN_PB04E_DACC_EXT_TRIG0 << 16) | MUX_PB04E_DACC_EXT_TRIG0)
-#define GPIO_PB04E_DACC_EXT_TRIG0  _UL(1 <<  4)
-#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
-#define MUX_PA06A_DACC_VOUT             _L(0)
+#define GPIO_PB04E_DACC_EXT_TRIG0  _UL_(1 <<  4)
+#define PIN_PA06A_DACC_VOUT             _L_(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L_(0)
 #define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
-#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+#define GPIO_PA06A_DACC_VOUT     _UL_(1 <<  6)
 /* ========== GPIO definition for ACIFC peripheral ========== */
-#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
-#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PIN_PA06E_ACIFC_ACAN0           _L_(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L_(4)
 #define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
-#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
-#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
-#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL_(1 <<  6)
+#define PIN_PA07E_ACIFC_ACAP0           _L_(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L_(4)
 #define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
-#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
-#define PIN_PB02E_ACIFC_ACBN0          _L(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
-#define MUX_PB02E_ACIFC_ACBN0           _L(4)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL_(1 <<  7)
+#define PIN_PB02E_ACIFC_ACBN0          _L_(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
+#define MUX_PB02E_ACIFC_ACBN0           _L_(4)
 #define PINMUX_PB02E_ACIFC_ACBN0   ((PIN_PB02E_ACIFC_ACBN0 << 16) | MUX_PB02E_ACIFC_ACBN0)
-#define GPIO_PB02E_ACIFC_ACBN0   _UL(1 <<  2)
-#define PIN_PB03E_ACIFC_ACBP0          _L(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
-#define MUX_PB03E_ACIFC_ACBP0           _L(4)
+#define GPIO_PB02E_ACIFC_ACBN0   _UL_(1 <<  2)
+#define PIN_PB03E_ACIFC_ACBP0          _L_(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
+#define MUX_PB03E_ACIFC_ACBP0           _L_(4)
 #define PINMUX_PB03E_ACIFC_ACBP0   ((PIN_PB03E_ACIFC_ACBP0 << 16) | MUX_PB03E_ACIFC_ACBP0)
-#define GPIO_PB03E_ACIFC_ACBP0   _UL(1 <<  3)
+#define GPIO_PB03E_ACIFC_ACBP0   _UL_(1 <<  3)
 /* ========== GPIO definition for GLOC peripheral ========== */
-#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
-#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PIN_PA06D_GLOC_IN0              _L_(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L_(3)
 #define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
-#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
-#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
-#define MUX_PA20D_GLOC_IN0              _L(3)
+#define GPIO_PA06D_GLOC_IN0      _UL_(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L_(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L_(3)
 #define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
-#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
-#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
-#define MUX_PA04D_GLOC_IN1              _L(3)
+#define GPIO_PA20D_GLOC_IN0      _UL_(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L_(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L_(3)
 #define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
-#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
-#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
-#define MUX_PA21D_GLOC_IN1              _L(3)
+#define GPIO_PA04D_GLOC_IN1      _UL_(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L_(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L_(3)
 #define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
-#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
-#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
-#define MUX_PA05D_GLOC_IN2              _L(3)
+#define GPIO_PA21D_GLOC_IN1      _UL_(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L_(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L_(3)
 #define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
-#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
-#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
-#define MUX_PA22D_GLOC_IN2              _L(3)
+#define GPIO_PA05D_GLOC_IN2      _UL_(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L_(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L_(3)
 #define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
-#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
-#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
-#define MUX_PA07D_GLOC_IN3              _L(3)
+#define GPIO_PA22D_GLOC_IN2      _UL_(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L_(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L_(3)
 #define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
-#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
-#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
-#define MUX_PA23D_GLOC_IN3              _L(3)
+#define GPIO_PA07D_GLOC_IN3      _UL_(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L_(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L_(3)
 #define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
-#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
-#define PIN_PA27D_GLOC_IN4             _L(27) /**< \brief GLOC signal: IN4 on PA27 mux D */
-#define MUX_PA27D_GLOC_IN4              _L(3)
+#define GPIO_PA23D_GLOC_IN3      _UL_(1 << 23)
+#define PIN_PA27D_GLOC_IN4             _L_(27) /**< \brief GLOC signal: IN4 on PA27 mux D */
+#define MUX_PA27D_GLOC_IN4              _L_(3)
 #define PINMUX_PA27D_GLOC_IN4      ((PIN_PA27D_GLOC_IN4 << 16) | MUX_PA27D_GLOC_IN4)
-#define GPIO_PA27D_GLOC_IN4      _UL(1 << 27)
-#define PIN_PB06C_GLOC_IN4             _L(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
-#define MUX_PB06C_GLOC_IN4              _L(2)
+#define GPIO_PA27D_GLOC_IN4      _UL_(1 << 27)
+#define PIN_PB06C_GLOC_IN4             _L_(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
+#define MUX_PB06C_GLOC_IN4              _L_(2)
 #define PINMUX_PB06C_GLOC_IN4      ((PIN_PB06C_GLOC_IN4 << 16) | MUX_PB06C_GLOC_IN4)
-#define GPIO_PB06C_GLOC_IN4      _UL(1 <<  6)
-#define PIN_PA28D_GLOC_IN5             _L(28) /**< \brief GLOC signal: IN5 on PA28 mux D */
-#define MUX_PA28D_GLOC_IN5              _L(3)
+#define GPIO_PB06C_GLOC_IN4      _UL_(1 <<  6)
+#define PIN_PA28D_GLOC_IN5             _L_(28) /**< \brief GLOC signal: IN5 on PA28 mux D */
+#define MUX_PA28D_GLOC_IN5              _L_(3)
 #define PINMUX_PA28D_GLOC_IN5      ((PIN_PA28D_GLOC_IN5 << 16) | MUX_PA28D_GLOC_IN5)
-#define GPIO_PA28D_GLOC_IN5      _UL(1 << 28)
-#define PIN_PB07C_GLOC_IN5             _L(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
-#define MUX_PB07C_GLOC_IN5              _L(2)
+#define GPIO_PA28D_GLOC_IN5      _UL_(1 << 28)
+#define PIN_PB07C_GLOC_IN5             _L_(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
+#define MUX_PB07C_GLOC_IN5              _L_(2)
 #define PINMUX_PB07C_GLOC_IN5      ((PIN_PB07C_GLOC_IN5 << 16) | MUX_PB07C_GLOC_IN5)
-#define GPIO_PB07C_GLOC_IN5      _UL(1 <<  7)
-#define PIN_PA29D_GLOC_IN6             _L(29) /**< \brief GLOC signal: IN6 on PA29 mux D */
-#define MUX_PA29D_GLOC_IN6              _L(3)
+#define GPIO_PB07C_GLOC_IN5      _UL_(1 <<  7)
+#define PIN_PA29D_GLOC_IN6             _L_(29) /**< \brief GLOC signal: IN6 on PA29 mux D */
+#define MUX_PA29D_GLOC_IN6              _L_(3)
 #define PINMUX_PA29D_GLOC_IN6      ((PIN_PA29D_GLOC_IN6 << 16) | MUX_PA29D_GLOC_IN6)
-#define GPIO_PA29D_GLOC_IN6      _UL(1 << 29)
-#define PIN_PB08C_GLOC_IN6             _L(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
-#define MUX_PB08C_GLOC_IN6              _L(2)
+#define GPIO_PA29D_GLOC_IN6      _UL_(1 << 29)
+#define PIN_PB08C_GLOC_IN6             _L_(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
+#define MUX_PB08C_GLOC_IN6              _L_(2)
 #define PINMUX_PB08C_GLOC_IN6      ((PIN_PB08C_GLOC_IN6 << 16) | MUX_PB08C_GLOC_IN6)
-#define GPIO_PB08C_GLOC_IN6      _UL(1 <<  8)
-#define PIN_PA30D_GLOC_IN7             _L(30) /**< \brief GLOC signal: IN7 on PA30 mux D */
-#define MUX_PA30D_GLOC_IN7              _L(3)
+#define GPIO_PB08C_GLOC_IN6      _UL_(1 <<  8)
+#define PIN_PA30D_GLOC_IN7             _L_(30) /**< \brief GLOC signal: IN7 on PA30 mux D */
+#define MUX_PA30D_GLOC_IN7              _L_(3)
 #define PINMUX_PA30D_GLOC_IN7      ((PIN_PA30D_GLOC_IN7 << 16) | MUX_PA30D_GLOC_IN7)
-#define GPIO_PA30D_GLOC_IN7      _UL(1 << 30)
-#define PIN_PB09C_GLOC_IN7             _L(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
-#define MUX_PB09C_GLOC_IN7              _L(2)
+#define GPIO_PA30D_GLOC_IN7      _UL_(1 << 30)
+#define PIN_PB09C_GLOC_IN7             _L_(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
+#define MUX_PB09C_GLOC_IN7              _L_(2)
 #define PINMUX_PB09C_GLOC_IN7      ((PIN_PB09C_GLOC_IN7 << 16) | MUX_PB09C_GLOC_IN7)
-#define GPIO_PB09C_GLOC_IN7      _UL(1 <<  9)
-#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
-#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define GPIO_PB09C_GLOC_IN7      _UL_(1 <<  9)
+#define PIN_PA08D_GLOC_OUT0             _L_(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
-#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
-#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
-#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define GPIO_PA08D_GLOC_OUT0     _UL_(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L_(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
-#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
-#define PIN_PA31D_GLOC_OUT1            _L(31) /**< \brief GLOC signal: OUT1 on PA31 mux D */
-#define MUX_PA31D_GLOC_OUT1             _L(3)
+#define GPIO_PA24D_GLOC_OUT0     _UL_(1 << 24)
+#define PIN_PA31D_GLOC_OUT1            _L_(31) /**< \brief GLOC signal: OUT1 on PA31 mux D */
+#define MUX_PA31D_GLOC_OUT1             _L_(3)
 #define PINMUX_PA31D_GLOC_OUT1     ((PIN_PA31D_GLOC_OUT1 << 16) | MUX_PA31D_GLOC_OUT1)
-#define GPIO_PA31D_GLOC_OUT1     _UL(1 << 31)
-#define PIN_PB10C_GLOC_OUT1            _L(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
-#define MUX_PB10C_GLOC_OUT1             _L(2)
+#define GPIO_PA31D_GLOC_OUT1     _UL_(1 << 31)
+#define PIN_PB10C_GLOC_OUT1            _L_(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
+#define MUX_PB10C_GLOC_OUT1             _L_(2)
 #define PINMUX_PB10C_GLOC_OUT1     ((PIN_PB10C_GLOC_OUT1 << 16) | MUX_PB10C_GLOC_OUT1)
-#define GPIO_PB10C_GLOC_OUT1     _UL(1 << 10)
+#define GPIO_PB10C_GLOC_OUT1     _UL_(1 << 10)
 /* ========== GPIO definition for ABDACB peripheral ========== */
-#define PIN_PA31C_ABDACB_CLK           _L(31) /**< \brief ABDACB signal: CLK on PA31 mux C */
-#define MUX_PA31C_ABDACB_CLK            _L(2)
+#define PIN_PA31C_ABDACB_CLK           _L_(31) /**< \brief ABDACB signal: CLK on PA31 mux C */
+#define MUX_PA31C_ABDACB_CLK            _L_(2)
 #define PINMUX_PA31C_ABDACB_CLK    ((PIN_PA31C_ABDACB_CLK << 16) | MUX_PA31C_ABDACB_CLK)
-#define GPIO_PA31C_ABDACB_CLK    _UL(1 << 31)
-#define PIN_PA27C_ABDACB_DAC0          _L(27) /**< \brief ABDACB signal: DAC0 on PA27 mux C */
-#define MUX_PA27C_ABDACB_DAC0           _L(2)
+#define GPIO_PA31C_ABDACB_CLK    _UL_(1 << 31)
+#define PIN_PA27C_ABDACB_DAC0          _L_(27) /**< \brief ABDACB signal: DAC0 on PA27 mux C */
+#define MUX_PA27C_ABDACB_DAC0           _L_(2)
 #define PINMUX_PA27C_ABDACB_DAC0   ((PIN_PA27C_ABDACB_DAC0 << 16) | MUX_PA27C_ABDACB_DAC0)
-#define GPIO_PA27C_ABDACB_DAC0   _UL(1 << 27)
-#define PIN_PB02C_ABDACB_DAC0          _L(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
-#define MUX_PB02C_ABDACB_DAC0           _L(2)
+#define GPIO_PA27C_ABDACB_DAC0   _UL_(1 << 27)
+#define PIN_PB02C_ABDACB_DAC0          _L_(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
+#define MUX_PB02C_ABDACB_DAC0           _L_(2)
 #define PINMUX_PB02C_ABDACB_DAC0   ((PIN_PB02C_ABDACB_DAC0 << 16) | MUX_PB02C_ABDACB_DAC0)
-#define GPIO_PB02C_ABDACB_DAC0   _UL(1 <<  2)
-#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
-#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define GPIO_PB02C_ABDACB_DAC0   _UL_(1 <<  2)
+#define PIN_PA17B_ABDACB_DAC0          _L_(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L_(1)
 #define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
-#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
-#define PIN_PA29C_ABDACB_DAC1          _L(29) /**< \brief ABDACB signal: DAC1 on PA29 mux C */
-#define MUX_PA29C_ABDACB_DAC1           _L(2)
+#define GPIO_PA17B_ABDACB_DAC0   _UL_(1 << 17)
+#define PIN_PA29C_ABDACB_DAC1          _L_(29) /**< \brief ABDACB signal: DAC1 on PA29 mux C */
+#define MUX_PA29C_ABDACB_DAC1           _L_(2)
 #define PINMUX_PA29C_ABDACB_DAC1   ((PIN_PA29C_ABDACB_DAC1 << 16) | MUX_PA29C_ABDACB_DAC1)
-#define GPIO_PA29C_ABDACB_DAC1   _UL(1 << 29)
-#define PIN_PB04C_ABDACB_DAC1          _L(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
-#define MUX_PB04C_ABDACB_DAC1           _L(2)
+#define GPIO_PA29C_ABDACB_DAC1   _UL_(1 << 29)
+#define PIN_PB04C_ABDACB_DAC1          _L_(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
+#define MUX_PB04C_ABDACB_DAC1           _L_(2)
 #define PINMUX_PB04C_ABDACB_DAC1   ((PIN_PB04C_ABDACB_DAC1 << 16) | MUX_PB04C_ABDACB_DAC1)
-#define GPIO_PB04C_ABDACB_DAC1   _UL(1 <<  4)
-#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
-#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define GPIO_PB04C_ABDACB_DAC1   _UL_(1 <<  4)
+#define PIN_PA19B_ABDACB_DAC1          _L_(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L_(1)
 #define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
-#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
-#define PIN_PA28C_ABDACB_DACN0         _L(28) /**< \brief ABDACB signal: DACN0 on PA28 mux C */
-#define MUX_PA28C_ABDACB_DACN0          _L(2)
+#define GPIO_PA19B_ABDACB_DAC1   _UL_(1 << 19)
+#define PIN_PA28C_ABDACB_DACN0         _L_(28) /**< \brief ABDACB signal: DACN0 on PA28 mux C */
+#define MUX_PA28C_ABDACB_DACN0          _L_(2)
 #define PINMUX_PA28C_ABDACB_DACN0  ((PIN_PA28C_ABDACB_DACN0 << 16) | MUX_PA28C_ABDACB_DACN0)
-#define GPIO_PA28C_ABDACB_DACN0  _UL(1 << 28)
-#define PIN_PB03C_ABDACB_DACN0         _L(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
-#define MUX_PB03C_ABDACB_DACN0          _L(2)
+#define GPIO_PA28C_ABDACB_DACN0  _UL_(1 << 28)
+#define PIN_PB03C_ABDACB_DACN0         _L_(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
+#define MUX_PB03C_ABDACB_DACN0          _L_(2)
 #define PINMUX_PB03C_ABDACB_DACN0  ((PIN_PB03C_ABDACB_DACN0 << 16) | MUX_PB03C_ABDACB_DACN0)
-#define GPIO_PB03C_ABDACB_DACN0  _UL(1 <<  3)
-#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
-#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define GPIO_PB03C_ABDACB_DACN0  _UL_(1 <<  3)
+#define PIN_PA18B_ABDACB_DACN0         _L_(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L_(1)
 #define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
-#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
-#define PIN_PA30C_ABDACB_DACN1         _L(30) /**< \brief ABDACB signal: DACN1 on PA30 mux C */
-#define MUX_PA30C_ABDACB_DACN1          _L(2)
+#define GPIO_PA18B_ABDACB_DACN0  _UL_(1 << 18)
+#define PIN_PA30C_ABDACB_DACN1         _L_(30) /**< \brief ABDACB signal: DACN1 on PA30 mux C */
+#define MUX_PA30C_ABDACB_DACN1          _L_(2)
 #define PINMUX_PA30C_ABDACB_DACN1  ((PIN_PA30C_ABDACB_DACN1 << 16) | MUX_PA30C_ABDACB_DACN1)
-#define GPIO_PA30C_ABDACB_DACN1  _UL(1 << 30)
-#define PIN_PB05C_ABDACB_DACN1         _L(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
-#define MUX_PB05C_ABDACB_DACN1          _L(2)
+#define GPIO_PA30C_ABDACB_DACN1  _UL_(1 << 30)
+#define PIN_PB05C_ABDACB_DACN1         _L_(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
+#define MUX_PB05C_ABDACB_DACN1          _L_(2)
 #define PINMUX_PB05C_ABDACB_DACN1  ((PIN_PB05C_ABDACB_DACN1 << 16) | MUX_PB05C_ABDACB_DACN1)
-#define GPIO_PB05C_ABDACB_DACN1  _UL(1 <<  5)
-#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
-#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define GPIO_PB05C_ABDACB_DACN1  _UL_(1 <<  5)
+#define PIN_PA20B_ABDACB_DACN1         _L_(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L_(1)
 #define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
-#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+#define GPIO_PA20B_ABDACB_DACN1  _UL_(1 << 20)
 /* ========== GPIO definition for PARC peripheral ========== */
-#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
-#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PIN_PA17D_PARC_PCCK            _L_(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L_(3)
 #define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
-#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
-#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
-#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define GPIO_PA17D_PARC_PCCK     _UL_(1 << 17)
+#define PIN_PA09D_PARC_PCDATA0          _L_(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L_(3)
 #define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
-#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
-#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
-#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define GPIO_PA09D_PARC_PCDATA0  _UL_(1 <<  9)
+#define PIN_PA10D_PARC_PCDATA1         _L_(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L_(3)
 #define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
-#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
-#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
-#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define GPIO_PA10D_PARC_PCDATA1  _UL_(1 << 10)
+#define PIN_PA11D_PARC_PCDATA2         _L_(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L_(3)
 #define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
-#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
-#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
-#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define GPIO_PA11D_PARC_PCDATA2  _UL_(1 << 11)
+#define PIN_PA12D_PARC_PCDATA3         _L_(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L_(3)
 #define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
-#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
-#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
-#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL_(1 << 12)
+#define PIN_PA13D_PARC_PCDATA4         _L_(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L_(3)
 #define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
-#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
-#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
-#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define GPIO_PA13D_PARC_PCDATA4  _UL_(1 << 13)
+#define PIN_PA14D_PARC_PCDATA5         _L_(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L_(3)
 #define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
-#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
-#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
-#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define GPIO_PA14D_PARC_PCDATA5  _UL_(1 << 14)
+#define PIN_PA15D_PARC_PCDATA6         _L_(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L_(3)
 #define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
-#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
-#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
-#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define GPIO_PA15D_PARC_PCDATA6  _UL_(1 << 15)
+#define PIN_PA16D_PARC_PCDATA7         _L_(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L_(3)
 #define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
-#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
-#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
-#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define GPIO_PA16D_PARC_PCDATA7  _UL_(1 << 16)
+#define PIN_PA18D_PARC_PCEN1           _L_(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L_(3)
 #define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
-#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
-#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
-#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define GPIO_PA18D_PARC_PCEN1    _UL_(1 << 18)
+#define PIN_PA19D_PARC_PCEN2           _L_(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L_(3)
 #define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
-#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+#define GPIO_PA19D_PARC_PCEN2    _UL_(1 << 19)
 /* ========== GPIO definition for CATB peripheral ========== */
-#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
-#define MUX_PA02G_CATB_DIS              _L(6)
+#define PIN_PA02G_CATB_DIS              _L_(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L_(6)
 #define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
-#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
-#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
-#define MUX_PA12G_CATB_DIS              _L(6)
+#define GPIO_PA02G_CATB_DIS      _UL_(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L_(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L_(6)
 #define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
-#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
-#define MUX_PA23G_CATB_DIS              _L(6)
+#define GPIO_PA12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L_(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L_(6)
 #define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
-#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
-#define PIN_PA31G_CATB_DIS             _L(31) /**< \brief CATB signal: DIS on PA31 mux G */
-#define MUX_PA31G_CATB_DIS              _L(6)
+#define GPIO_PA23G_CATB_DIS      _UL_(1 << 23)
+#define PIN_PA31G_CATB_DIS             _L_(31) /**< \brief CATB signal: DIS on PA31 mux G */
+#define MUX_PA31G_CATB_DIS              _L_(6)
 #define PINMUX_PA31G_CATB_DIS      ((PIN_PA31G_CATB_DIS << 16) | MUX_PA31G_CATB_DIS)
-#define GPIO_PA31G_CATB_DIS      _UL(1 << 31)
-#define PIN_PB03G_CATB_DIS             _L(35) /**< \brief CATB signal: DIS on PB03 mux G */
-#define MUX_PB03G_CATB_DIS              _L(6)
+#define GPIO_PA31G_CATB_DIS      _UL_(1 << 31)
+#define PIN_PB03G_CATB_DIS             _L_(35) /**< \brief CATB signal: DIS on PB03 mux G */
+#define MUX_PB03G_CATB_DIS              _L_(6)
 #define PINMUX_PB03G_CATB_DIS      ((PIN_PB03G_CATB_DIS << 16) | MUX_PB03G_CATB_DIS)
-#define GPIO_PB03G_CATB_DIS      _UL(1 <<  3)
-#define PIN_PB12G_CATB_DIS             _L(44) /**< \brief CATB signal: DIS on PB12 mux G */
-#define MUX_PB12G_CATB_DIS              _L(6)
+#define GPIO_PB03G_CATB_DIS      _UL_(1 <<  3)
+#define PIN_PB12G_CATB_DIS             _L_(44) /**< \brief CATB signal: DIS on PB12 mux G */
+#define MUX_PB12G_CATB_DIS              _L_(6)
 #define PINMUX_PB12G_CATB_DIS      ((PIN_PB12G_CATB_DIS << 16) | MUX_PB12G_CATB_DIS)
-#define GPIO_PB12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
-#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define GPIO_PB12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PA04G_CATB_SENSE0           _L_(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L_(6)
 #define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
-#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
-#define PIN_PA27G_CATB_SENSE0          _L(27) /**< \brief CATB signal: SENSE0 on PA27 mux G */
-#define MUX_PA27G_CATB_SENSE0           _L(6)
+#define GPIO_PA04G_CATB_SENSE0   _UL_(1 <<  4)
+#define PIN_PA27G_CATB_SENSE0          _L_(27) /**< \brief CATB signal: SENSE0 on PA27 mux G */
+#define MUX_PA27G_CATB_SENSE0           _L_(6)
 #define PINMUX_PA27G_CATB_SENSE0   ((PIN_PA27G_CATB_SENSE0 << 16) | MUX_PA27G_CATB_SENSE0)
-#define GPIO_PA27G_CATB_SENSE0   _UL(1 << 27)
-#define PIN_PB13G_CATB_SENSE0          _L(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
-#define MUX_PB13G_CATB_SENSE0           _L(6)
+#define GPIO_PA27G_CATB_SENSE0   _UL_(1 << 27)
+#define PIN_PB13G_CATB_SENSE0          _L_(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
+#define MUX_PB13G_CATB_SENSE0           _L_(6)
 #define PINMUX_PB13G_CATB_SENSE0   ((PIN_PB13G_CATB_SENSE0 << 16) | MUX_PB13G_CATB_SENSE0)
-#define GPIO_PB13G_CATB_SENSE0   _UL(1 << 13)
-#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
-#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define GPIO_PB13G_CATB_SENSE0   _UL_(1 << 13)
+#define PIN_PA05G_CATB_SENSE1           _L_(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L_(6)
 #define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
-#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
-#define PIN_PA28G_CATB_SENSE1          _L(28) /**< \brief CATB signal: SENSE1 on PA28 mux G */
-#define MUX_PA28G_CATB_SENSE1           _L(6)
+#define GPIO_PA05G_CATB_SENSE1   _UL_(1 <<  5)
+#define PIN_PA28G_CATB_SENSE1          _L_(28) /**< \brief CATB signal: SENSE1 on PA28 mux G */
+#define MUX_PA28G_CATB_SENSE1           _L_(6)
 #define PINMUX_PA28G_CATB_SENSE1   ((PIN_PA28G_CATB_SENSE1 << 16) | MUX_PA28G_CATB_SENSE1)
-#define GPIO_PA28G_CATB_SENSE1   _UL(1 << 28)
-#define PIN_PB14G_CATB_SENSE1          _L(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
-#define MUX_PB14G_CATB_SENSE1           _L(6)
+#define GPIO_PA28G_CATB_SENSE1   _UL_(1 << 28)
+#define PIN_PB14G_CATB_SENSE1          _L_(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
+#define MUX_PB14G_CATB_SENSE1           _L_(6)
 #define PINMUX_PB14G_CATB_SENSE1   ((PIN_PB14G_CATB_SENSE1 << 16) | MUX_PB14G_CATB_SENSE1)
-#define GPIO_PB14G_CATB_SENSE1   _UL(1 << 14)
-#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
-#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define GPIO_PB14G_CATB_SENSE1   _UL_(1 << 14)
+#define PIN_PA06G_CATB_SENSE2           _L_(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L_(6)
 #define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
-#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
-#define PIN_PA29G_CATB_SENSE2          _L(29) /**< \brief CATB signal: SENSE2 on PA29 mux G */
-#define MUX_PA29G_CATB_SENSE2           _L(6)
+#define GPIO_PA06G_CATB_SENSE2   _UL_(1 <<  6)
+#define PIN_PA29G_CATB_SENSE2          _L_(29) /**< \brief CATB signal: SENSE2 on PA29 mux G */
+#define MUX_PA29G_CATB_SENSE2           _L_(6)
 #define PINMUX_PA29G_CATB_SENSE2   ((PIN_PA29G_CATB_SENSE2 << 16) | MUX_PA29G_CATB_SENSE2)
-#define GPIO_PA29G_CATB_SENSE2   _UL(1 << 29)
-#define PIN_PB15G_CATB_SENSE2          _L(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
-#define MUX_PB15G_CATB_SENSE2           _L(6)
+#define GPIO_PA29G_CATB_SENSE2   _UL_(1 << 29)
+#define PIN_PB15G_CATB_SENSE2          _L_(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
+#define MUX_PB15G_CATB_SENSE2           _L_(6)
 #define PINMUX_PB15G_CATB_SENSE2   ((PIN_PB15G_CATB_SENSE2 << 16) | MUX_PB15G_CATB_SENSE2)
-#define GPIO_PB15G_CATB_SENSE2   _UL(1 << 15)
-#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
-#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define GPIO_PB15G_CATB_SENSE2   _UL_(1 << 15)
+#define PIN_PA07G_CATB_SENSE3           _L_(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L_(6)
 #define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
-#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
-#define PIN_PA30G_CATB_SENSE3          _L(30) /**< \brief CATB signal: SENSE3 on PA30 mux G */
-#define MUX_PA30G_CATB_SENSE3           _L(6)
+#define GPIO_PA07G_CATB_SENSE3   _UL_(1 <<  7)
+#define PIN_PA30G_CATB_SENSE3          _L_(30) /**< \brief CATB signal: SENSE3 on PA30 mux G */
+#define MUX_PA30G_CATB_SENSE3           _L_(6)
 #define PINMUX_PA30G_CATB_SENSE3   ((PIN_PA30G_CATB_SENSE3 << 16) | MUX_PA30G_CATB_SENSE3)
-#define GPIO_PA30G_CATB_SENSE3   _UL(1 << 30)
-#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
-#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define GPIO_PA30G_CATB_SENSE3   _UL_(1 << 30)
+#define PIN_PA08G_CATB_SENSE4           _L_(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L_(6)
 #define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
-#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
-#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
-#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define GPIO_PA08G_CATB_SENSE4   _UL_(1 <<  8)
+#define PIN_PA09G_CATB_SENSE5           _L_(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L_(6)
 #define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
-#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
-#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
-#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define GPIO_PA09G_CATB_SENSE5   _UL_(1 <<  9)
+#define PIN_PA10G_CATB_SENSE6          _L_(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L_(6)
 #define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
-#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
-#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
-#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define GPIO_PA10G_CATB_SENSE6   _UL_(1 << 10)
+#define PIN_PA11G_CATB_SENSE7          _L_(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L_(6)
 #define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
-#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
-#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
-#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define GPIO_PA11G_CATB_SENSE7   _UL_(1 << 11)
+#define PIN_PA13G_CATB_SENSE8          _L_(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L_(6)
 #define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
-#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
-#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
-#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define GPIO_PA13G_CATB_SENSE8   _UL_(1 << 13)
+#define PIN_PA14G_CATB_SENSE9          _L_(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L_(6)
 #define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
-#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
-#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
-#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define GPIO_PA14G_CATB_SENSE9   _UL_(1 << 14)
+#define PIN_PA15G_CATB_SENSE10         _L_(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L_(6)
 #define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
-#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
-#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
-#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define GPIO_PA15G_CATB_SENSE10  _UL_(1 << 15)
+#define PIN_PA16G_CATB_SENSE11         _L_(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L_(6)
 #define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
-#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
-#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
-#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define GPIO_PA16G_CATB_SENSE11  _UL_(1 << 16)
+#define PIN_PA17G_CATB_SENSE12         _L_(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L_(6)
 #define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
-#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
-#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
-#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define GPIO_PA17G_CATB_SENSE12  _UL_(1 << 17)
+#define PIN_PA18G_CATB_SENSE13         _L_(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L_(6)
 #define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
-#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
-#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
-#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define GPIO_PA18G_CATB_SENSE13  _UL_(1 << 18)
+#define PIN_PA19G_CATB_SENSE14         _L_(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L_(6)
 #define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
-#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
-#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
-#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define GPIO_PA19G_CATB_SENSE14  _UL_(1 << 19)
+#define PIN_PA20G_CATB_SENSE15         _L_(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L_(6)
 #define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
-#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
-#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
-#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define GPIO_PA20G_CATB_SENSE15  _UL_(1 << 20)
+#define PIN_PA21G_CATB_SENSE16         _L_(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L_(6)
 #define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
-#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
-#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
-#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define GPIO_PA21G_CATB_SENSE16  _UL_(1 << 21)
+#define PIN_PA22G_CATB_SENSE17         _L_(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L_(6)
 #define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
-#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
-#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
-#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define GPIO_PA22G_CATB_SENSE17  _UL_(1 << 22)
+#define PIN_PA24G_CATB_SENSE18         _L_(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L_(6)
 #define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
-#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
-#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
-#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define GPIO_PA24G_CATB_SENSE18  _UL_(1 << 24)
+#define PIN_PA25G_CATB_SENSE19         _L_(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L_(6)
 #define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
-#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
-#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
-#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define GPIO_PA25G_CATB_SENSE19  _UL_(1 << 25)
+#define PIN_PA26G_CATB_SENSE20         _L_(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L_(6)
 #define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
-#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
-#define PIN_PB00G_CATB_SENSE21         _L(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
-#define MUX_PB00G_CATB_SENSE21          _L(6)
+#define GPIO_PA26G_CATB_SENSE20  _UL_(1 << 26)
+#define PIN_PB00G_CATB_SENSE21         _L_(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
+#define MUX_PB00G_CATB_SENSE21          _L_(6)
 #define PINMUX_PB00G_CATB_SENSE21  ((PIN_PB00G_CATB_SENSE21 << 16) | MUX_PB00G_CATB_SENSE21)
-#define GPIO_PB00G_CATB_SENSE21  _UL(1 <<  0)
-#define PIN_PB01G_CATB_SENSE22         _L(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
-#define MUX_PB01G_CATB_SENSE22          _L(6)
+#define GPIO_PB00G_CATB_SENSE21  _UL_(1 <<  0)
+#define PIN_PB01G_CATB_SENSE22         _L_(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
+#define MUX_PB01G_CATB_SENSE22          _L_(6)
 #define PINMUX_PB01G_CATB_SENSE22  ((PIN_PB01G_CATB_SENSE22 << 16) | MUX_PB01G_CATB_SENSE22)
-#define GPIO_PB01G_CATB_SENSE22  _UL(1 <<  1)
-#define PIN_PB02G_CATB_SENSE23         _L(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
-#define MUX_PB02G_CATB_SENSE23          _L(6)
+#define GPIO_PB01G_CATB_SENSE22  _UL_(1 <<  1)
+#define PIN_PB02G_CATB_SENSE23         _L_(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
+#define MUX_PB02G_CATB_SENSE23          _L_(6)
 #define PINMUX_PB02G_CATB_SENSE23  ((PIN_PB02G_CATB_SENSE23 << 16) | MUX_PB02G_CATB_SENSE23)
-#define GPIO_PB02G_CATB_SENSE23  _UL(1 <<  2)
-#define PIN_PB04G_CATB_SENSE24         _L(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
-#define MUX_PB04G_CATB_SENSE24          _L(6)
+#define GPIO_PB02G_CATB_SENSE23  _UL_(1 <<  2)
+#define PIN_PB04G_CATB_SENSE24         _L_(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
+#define MUX_PB04G_CATB_SENSE24          _L_(6)
 #define PINMUX_PB04G_CATB_SENSE24  ((PIN_PB04G_CATB_SENSE24 << 16) | MUX_PB04G_CATB_SENSE24)
-#define GPIO_PB04G_CATB_SENSE24  _UL(1 <<  4)
-#define PIN_PB05G_CATB_SENSE25         _L(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
-#define MUX_PB05G_CATB_SENSE25          _L(6)
+#define GPIO_PB04G_CATB_SENSE24  _UL_(1 <<  4)
+#define PIN_PB05G_CATB_SENSE25         _L_(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
+#define MUX_PB05G_CATB_SENSE25          _L_(6)
 #define PINMUX_PB05G_CATB_SENSE25  ((PIN_PB05G_CATB_SENSE25 << 16) | MUX_PB05G_CATB_SENSE25)
-#define GPIO_PB05G_CATB_SENSE25  _UL(1 <<  5)
-#define PIN_PB06G_CATB_SENSE26         _L(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
-#define MUX_PB06G_CATB_SENSE26          _L(6)
+#define GPIO_PB05G_CATB_SENSE25  _UL_(1 <<  5)
+#define PIN_PB06G_CATB_SENSE26         _L_(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
+#define MUX_PB06G_CATB_SENSE26          _L_(6)
 #define PINMUX_PB06G_CATB_SENSE26  ((PIN_PB06G_CATB_SENSE26 << 16) | MUX_PB06G_CATB_SENSE26)
-#define GPIO_PB06G_CATB_SENSE26  _UL(1 <<  6)
-#define PIN_PB07G_CATB_SENSE27         _L(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
-#define MUX_PB07G_CATB_SENSE27          _L(6)
+#define GPIO_PB06G_CATB_SENSE26  _UL_(1 <<  6)
+#define PIN_PB07G_CATB_SENSE27         _L_(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
+#define MUX_PB07G_CATB_SENSE27          _L_(6)
 #define PINMUX_PB07G_CATB_SENSE27  ((PIN_PB07G_CATB_SENSE27 << 16) | MUX_PB07G_CATB_SENSE27)
-#define GPIO_PB07G_CATB_SENSE27  _UL(1 <<  7)
-#define PIN_PB08G_CATB_SENSE28         _L(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
-#define MUX_PB08G_CATB_SENSE28          _L(6)
+#define GPIO_PB07G_CATB_SENSE27  _UL_(1 <<  7)
+#define PIN_PB08G_CATB_SENSE28         _L_(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
+#define MUX_PB08G_CATB_SENSE28          _L_(6)
 #define PINMUX_PB08G_CATB_SENSE28  ((PIN_PB08G_CATB_SENSE28 << 16) | MUX_PB08G_CATB_SENSE28)
-#define GPIO_PB08G_CATB_SENSE28  _UL(1 <<  8)
-#define PIN_PB09G_CATB_SENSE29         _L(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
-#define MUX_PB09G_CATB_SENSE29          _L(6)
+#define GPIO_PB08G_CATB_SENSE28  _UL_(1 <<  8)
+#define PIN_PB09G_CATB_SENSE29         _L_(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
+#define MUX_PB09G_CATB_SENSE29          _L_(6)
 #define PINMUX_PB09G_CATB_SENSE29  ((PIN_PB09G_CATB_SENSE29 << 16) | MUX_PB09G_CATB_SENSE29)
-#define GPIO_PB09G_CATB_SENSE29  _UL(1 <<  9)
-#define PIN_PB10G_CATB_SENSE30         _L(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
-#define MUX_PB10G_CATB_SENSE30          _L(6)
+#define GPIO_PB09G_CATB_SENSE29  _UL_(1 <<  9)
+#define PIN_PB10G_CATB_SENSE30         _L_(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
+#define MUX_PB10G_CATB_SENSE30          _L_(6)
 #define PINMUX_PB10G_CATB_SENSE30  ((PIN_PB10G_CATB_SENSE30 << 16) | MUX_PB10G_CATB_SENSE30)
-#define GPIO_PB10G_CATB_SENSE30  _UL(1 << 10)
-#define PIN_PB11G_CATB_SENSE31         _L(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
-#define MUX_PB11G_CATB_SENSE31          _L(6)
+#define GPIO_PB10G_CATB_SENSE30  _UL_(1 << 10)
+#define PIN_PB11G_CATB_SENSE31         _L_(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
+#define MUX_PB11G_CATB_SENSE31          _L_(6)
 #define PINMUX_PB11G_CATB_SENSE31  ((PIN_PB11G_CATB_SENSE31 << 16) | MUX_PB11G_CATB_SENSE31)
-#define GPIO_PB11G_CATB_SENSE31  _UL(1 << 11)
+#define GPIO_PB11G_CATB_SENSE31  _UL_(1 << 11)
 /* ========== GPIO definition for USBC peripheral ========== */
-#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
-#define MUX_PA25A_USBC_DM               _L(0)
+#define PIN_PA25A_USBC_DM              _L_(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L_(0)
 #define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
-#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
-#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
-#define MUX_PA26A_USBC_DP               _L(0)
+#define GPIO_PA25A_USBC_DM       _UL_(1 << 25)
+#define PIN_PA26A_USBC_DP              _L_(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L_(0)
 #define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
-#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+#define GPIO_PA26A_USBC_DP       _UL_(1 << 26)
 /* ========== GPIO definition for PEVC peripheral ========== */
-#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
-#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PIN_PA08C_PEVC_PAD_EVT0         _L_(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
-#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
-#define PIN_PB12C_PEVC_PAD_EVT0        _L(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
-#define MUX_PB12C_PEVC_PAD_EVT0         _L(2)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL_(1 <<  8)
+#define PIN_PB12C_PEVC_PAD_EVT0        _L_(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
+#define MUX_PB12C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PB12C_PEVC_PAD_EVT0  ((PIN_PB12C_PEVC_PAD_EVT0 << 16) | MUX_PB12C_PEVC_PAD_EVT0)
-#define GPIO_PB12C_PEVC_PAD_EVT0  _UL(1 << 12)
-#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
-#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PB12C_PEVC_PAD_EVT0  _UL_(1 << 12)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L_(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
-#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
-#define PIN_PB13C_PEVC_PAD_EVT1        _L(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
-#define MUX_PB13C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL_(1 <<  9)
+#define PIN_PB13C_PEVC_PAD_EVT1        _L_(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
+#define MUX_PB13C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PB13C_PEVC_PAD_EVT1  ((PIN_PB13C_PEVC_PAD_EVT1 << 16) | MUX_PB13C_PEVC_PAD_EVT1)
-#define GPIO_PB13C_PEVC_PAD_EVT1  _UL(1 << 13)
-#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
-#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PB13C_PEVC_PAD_EVT1  _UL_(1 << 13)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L_(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
-#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
-#define PIN_PB09B_PEVC_PAD_EVT2        _L(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
-#define MUX_PB09B_PEVC_PAD_EVT2         _L(1)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL_(1 << 10)
+#define PIN_PB09B_PEVC_PAD_EVT2        _L_(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
+#define MUX_PB09B_PEVC_PAD_EVT2         _L_(1)
 #define PINMUX_PB09B_PEVC_PAD_EVT2  ((PIN_PB09B_PEVC_PAD_EVT2 << 16) | MUX_PB09B_PEVC_PAD_EVT2)
-#define GPIO_PB09B_PEVC_PAD_EVT2  _UL(1 <<  9)
-#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
-#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define GPIO_PB09B_PEVC_PAD_EVT2  _UL_(1 <<  9)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L_(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L_(2)
 #define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
-#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
-#define PIN_PB10B_PEVC_PAD_EVT3        _L(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
-#define MUX_PB10B_PEVC_PAD_EVT3         _L(1)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL_(1 << 11)
+#define PIN_PB10B_PEVC_PAD_EVT3        _L_(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
+#define MUX_PB10B_PEVC_PAD_EVT3         _L_(1)
 #define PINMUX_PB10B_PEVC_PAD_EVT3  ((PIN_PB10B_PEVC_PAD_EVT3 << 16) | MUX_PB10B_PEVC_PAD_EVT3)
-#define GPIO_PB10B_PEVC_PAD_EVT3  _UL(1 << 10)
+#define GPIO_PB10B_PEVC_PAD_EVT3  _UL_(1 << 10)
 /* ========== GPIO definition for SCIF peripheral ========== */
-#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
-#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PIN_PA19E_SCIF_GCLK0           _L_(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
-#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
-#define PIN_PB10E_SCIF_GCLK0           _L(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
-#define MUX_PB10E_SCIF_GCLK0            _L(4)
+#define GPIO_PA19E_SCIF_GCLK0    _UL_(1 << 19)
+#define PIN_PB10E_SCIF_GCLK0           _L_(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
+#define MUX_PB10E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PB10E_SCIF_GCLK0    ((PIN_PB10E_SCIF_GCLK0 << 16) | MUX_PB10E_SCIF_GCLK0)
-#define GPIO_PB10E_SCIF_GCLK0    _UL(1 << 10)
-#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
-#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define GPIO_PB10E_SCIF_GCLK0    _UL_(1 << 10)
+#define PIN_PA02A_SCIF_GCLK0            _L_(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L_(0)
 #define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
-#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
-#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
-#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define GPIO_PA02A_SCIF_GCLK0    _UL_(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L_(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
-#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
-#define PIN_PB11E_SCIF_GCLK1           _L(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
-#define MUX_PB11E_SCIF_GCLK1            _L(4)
+#define GPIO_PA20E_SCIF_GCLK1    _UL_(1 << 20)
+#define PIN_PB11E_SCIF_GCLK1           _L_(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
+#define MUX_PB11E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PB11E_SCIF_GCLK1    ((PIN_PB11E_SCIF_GCLK1 << 16) | MUX_PB11E_SCIF_GCLK1)
-#define GPIO_PB11E_SCIF_GCLK1    _UL(1 << 11)
-#define PIN_PB12E_SCIF_GCLK2           _L(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
-#define MUX_PB12E_SCIF_GCLK2            _L(4)
+#define GPIO_PB11E_SCIF_GCLK1    _UL_(1 << 11)
+#define PIN_PB12E_SCIF_GCLK2           _L_(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
+#define MUX_PB12E_SCIF_GCLK2            _L_(4)
 #define PINMUX_PB12E_SCIF_GCLK2    ((PIN_PB12E_SCIF_GCLK2 << 16) | MUX_PB12E_SCIF_GCLK2)
-#define GPIO_PB12E_SCIF_GCLK2    _UL(1 << 12)
-#define PIN_PB13E_SCIF_GCLK3           _L(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
-#define MUX_PB13E_SCIF_GCLK3            _L(4)
+#define GPIO_PB12E_SCIF_GCLK2    _UL_(1 << 12)
+#define PIN_PB13E_SCIF_GCLK3           _L_(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
+#define MUX_PB13E_SCIF_GCLK3            _L_(4)
 #define PINMUX_PB13E_SCIF_GCLK3    ((PIN_PB13E_SCIF_GCLK3 << 16) | MUX_PB13E_SCIF_GCLK3)
-#define GPIO_PB13E_SCIF_GCLK3    _UL(1 << 13)
-#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
-#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PB13E_SCIF_GCLK3    _UL_(1 << 13)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L_(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
-#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
-#define PIN_PB14E_SCIF_GCLK_IN0        _L(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
-#define MUX_PB14E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL_(1 << 23)
+#define PIN_PB14E_SCIF_GCLK_IN0        _L_(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
+#define MUX_PB14E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PB14E_SCIF_GCLK_IN0  ((PIN_PB14E_SCIF_GCLK_IN0 << 16) | MUX_PB14E_SCIF_GCLK_IN0)
-#define GPIO_PB14E_SCIF_GCLK_IN0  _UL(1 << 14)
-#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
-#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PB14E_SCIF_GCLK_IN0  _UL_(1 << 14)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L_(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
-#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
-#define PIN_PB15E_SCIF_GCLK_IN1        _L(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
-#define MUX_PB15E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL_(1 << 24)
+#define PIN_PB15E_SCIF_GCLK_IN1        _L_(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
+#define MUX_PB15E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PB15E_SCIF_GCLK_IN1  ((PIN_PB15E_SCIF_GCLK_IN1 << 16) | MUX_PB15E_SCIF_GCLK_IN1)
-#define GPIO_PB15E_SCIF_GCLK_IN1  _UL(1 << 15)
+#define GPIO_PB15E_SCIF_GCLK_IN1  _UL_(1 << 15)
 /* ========== GPIO definition for EIC peripheral ========== */
-#define PIN_PB01C_EIC_EXTINT0          _L(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
-#define MUX_PB01C_EIC_EXTINT0           _L(2)
+#define PIN_PB01C_EIC_EXTINT0          _L_(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
+#define MUX_PB01C_EIC_EXTINT0           _L_(2)
 #define PINMUX_PB01C_EIC_EXTINT0   ((PIN_PB01C_EIC_EXTINT0 << 16) | MUX_PB01C_EIC_EXTINT0)
-#define GPIO_PB01C_EIC_EXTINT0   _UL(1 <<  1)
-#define PIN_PB01C_EIC_EXTINT_NUM        _L(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
-#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
-#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define GPIO_PB01C_EIC_EXTINT0   _UL_(1 <<  1)
+#define PIN_PB01C_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PA06C_EIC_EXTINT1           _L_(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
-#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
-#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
-#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
-#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define GPIO_PA06C_EIC_EXTINT1   _UL_(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L_(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
-#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
-#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
-#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
-#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define GPIO_PA16C_EIC_EXTINT1   _UL_(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L_(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
-#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
-#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
-#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
-#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL_(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L_(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
-#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
-#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
-#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
-#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL_(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L_(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
-#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
-#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
-#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
-#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define GPIO_PA05C_EIC_EXTINT3   _UL_(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L_(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
-#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
-#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
-#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
-#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define GPIO_PA18C_EIC_EXTINT3   _UL_(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L_(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
-#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
-#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
-#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
-#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define GPIO_PA07C_EIC_EXTINT4   _UL_(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L_(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
-#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
-#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
-#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
-#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define GPIO_PA19C_EIC_EXTINT4   _UL_(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L_(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L_(2)
 #define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
-#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
-#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
-#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
-#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define GPIO_PA20C_EIC_EXTINT5   _UL_(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L_(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L_(2)
 #define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
-#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
-#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
-#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
-#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define GPIO_PA21C_EIC_EXTINT6   _UL_(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L_(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L_(2)
 #define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
-#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
-#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
-#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
-#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define GPIO_PA22C_EIC_EXTINT7   _UL_(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L_(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L_(2)
 #define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
-#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
-#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define GPIO_PA23C_EIC_EXTINT8   _UL_(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
 
 #endif /* _SAM4LS8B_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4ls8c.h
+++ b/asf/sam/include/sam4l/pio/sam4ls8c.h
@@ -30,1728 +30,1728 @@
 #define _SAM4LS8C_PIO_
 
 #define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
-#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define GPIO_PA00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PA00 */
 #define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
-#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define GPIO_PA01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PA01 */
 #define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
-#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define GPIO_PA02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PA02 */
 #define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
-#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define GPIO_PA03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PA03 */
 #define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
-#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define GPIO_PA04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PA04 */
 #define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
-#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define GPIO_PA05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PA05 */
 #define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
-#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define GPIO_PA06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PA06 */
 #define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
-#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define GPIO_PA07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PA07 */
 #define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
-#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define GPIO_PA08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PA08 */
 #define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
-#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define GPIO_PA09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PA09 */
 #define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
-#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define GPIO_PA10                _UL_(1 << 10) /**< \brief GPIO Mask  for PA10 */
 #define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
-#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define GPIO_PA11                _UL_(1 << 11) /**< \brief GPIO Mask  for PA11 */
 #define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
-#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define GPIO_PA12                _UL_(1 << 12) /**< \brief GPIO Mask  for PA12 */
 #define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
-#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define GPIO_PA13                _UL_(1 << 13) /**< \brief GPIO Mask  for PA13 */
 #define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
-#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define GPIO_PA14                _UL_(1 << 14) /**< \brief GPIO Mask  for PA14 */
 #define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
-#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define GPIO_PA15                _UL_(1 << 15) /**< \brief GPIO Mask  for PA15 */
 #define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
-#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define GPIO_PA16                _UL_(1 << 16) /**< \brief GPIO Mask  for PA16 */
 #define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
-#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define GPIO_PA17                _UL_(1 << 17) /**< \brief GPIO Mask  for PA17 */
 #define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
-#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define GPIO_PA18                _UL_(1 << 18) /**< \brief GPIO Mask  for PA18 */
 #define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
-#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define GPIO_PA19                _UL_(1 << 19) /**< \brief GPIO Mask  for PA19 */
 #define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
-#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define GPIO_PA20                _UL_(1 << 20) /**< \brief GPIO Mask  for PA20 */
 #define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
-#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define GPIO_PA21                _UL_(1 << 21) /**< \brief GPIO Mask  for PA21 */
 #define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
-#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define GPIO_PA22                _UL_(1 << 22) /**< \brief GPIO Mask  for PA22 */
 #define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
-#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define GPIO_PA23                _UL_(1 << 23) /**< \brief GPIO Mask  for PA23 */
 #define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
-#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define GPIO_PA24                _UL_(1 << 24) /**< \brief GPIO Mask  for PA24 */
 #define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
-#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define GPIO_PA25                _UL_(1 << 25) /**< \brief GPIO Mask  for PA25 */
 #define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
-#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define GPIO_PA26                _UL_(1 << 26) /**< \brief GPIO Mask  for PA26 */
 #define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
-#define GPIO_PA27                _UL(1 << 27) /**< \brief GPIO Mask  for PA27 */
+#define GPIO_PA27                _UL_(1 << 27) /**< \brief GPIO Mask  for PA27 */
 #define PIN_PA28                          28  /**< \brief Pin Number for PA28 */
-#define GPIO_PA28                _UL(1 << 28) /**< \brief GPIO Mask  for PA28 */
+#define GPIO_PA28                _UL_(1 << 28) /**< \brief GPIO Mask  for PA28 */
 #define PIN_PA29                          29  /**< \brief Pin Number for PA29 */
-#define GPIO_PA29                _UL(1 << 29) /**< \brief GPIO Mask  for PA29 */
+#define GPIO_PA29                _UL_(1 << 29) /**< \brief GPIO Mask  for PA29 */
 #define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
-#define GPIO_PA30                _UL(1 << 30) /**< \brief GPIO Mask  for PA30 */
+#define GPIO_PA30                _UL_(1 << 30) /**< \brief GPIO Mask  for PA30 */
 #define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
-#define GPIO_PA31                _UL(1 << 31) /**< \brief GPIO Mask  for PA31 */
+#define GPIO_PA31                _UL_(1 << 31) /**< \brief GPIO Mask  for PA31 */
 #define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
-#define GPIO_PB00                _UL(1 <<  0) /**< \brief GPIO Mask  for PB00 */
+#define GPIO_PB00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PB00 */
 #define PIN_PB01                          33  /**< \brief Pin Number for PB01 */
-#define GPIO_PB01                _UL(1 <<  1) /**< \brief GPIO Mask  for PB01 */
+#define GPIO_PB01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PB01 */
 #define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
-#define GPIO_PB02                _UL(1 <<  2) /**< \brief GPIO Mask  for PB02 */
+#define GPIO_PB02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PB02 */
 #define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
-#define GPIO_PB03                _UL(1 <<  3) /**< \brief GPIO Mask  for PB03 */
+#define GPIO_PB03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PB03 */
 #define PIN_PB04                          36  /**< \brief Pin Number for PB04 */
-#define GPIO_PB04                _UL(1 <<  4) /**< \brief GPIO Mask  for PB04 */
+#define GPIO_PB04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PB04 */
 #define PIN_PB05                          37  /**< \brief Pin Number for PB05 */
-#define GPIO_PB05                _UL(1 <<  5) /**< \brief GPIO Mask  for PB05 */
+#define GPIO_PB05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PB05 */
 #define PIN_PB06                          38  /**< \brief Pin Number for PB06 */
-#define GPIO_PB06                _UL(1 <<  6) /**< \brief GPIO Mask  for PB06 */
+#define GPIO_PB06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PB06 */
 #define PIN_PB07                          39  /**< \brief Pin Number for PB07 */
-#define GPIO_PB07                _UL(1 <<  7) /**< \brief GPIO Mask  for PB07 */
+#define GPIO_PB07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PB07 */
 #define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
-#define GPIO_PB08                _UL(1 <<  8) /**< \brief GPIO Mask  for PB08 */
+#define GPIO_PB08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PB08 */
 #define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
-#define GPIO_PB09                _UL(1 <<  9) /**< \brief GPIO Mask  for PB09 */
+#define GPIO_PB09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PB09 */
 #define PIN_PB10                          42  /**< \brief Pin Number for PB10 */
-#define GPIO_PB10                _UL(1 << 10) /**< \brief GPIO Mask  for PB10 */
+#define GPIO_PB10                _UL_(1 << 10) /**< \brief GPIO Mask  for PB10 */
 #define PIN_PB11                          43  /**< \brief Pin Number for PB11 */
-#define GPIO_PB11                _UL(1 << 11) /**< \brief GPIO Mask  for PB11 */
+#define GPIO_PB11                _UL_(1 << 11) /**< \brief GPIO Mask  for PB11 */
 #define PIN_PB12                          44  /**< \brief Pin Number for PB12 */
-#define GPIO_PB12                _UL(1 << 12) /**< \brief GPIO Mask  for PB12 */
+#define GPIO_PB12                _UL_(1 << 12) /**< \brief GPIO Mask  for PB12 */
 #define PIN_PB13                          45  /**< \brief Pin Number for PB13 */
-#define GPIO_PB13                _UL(1 << 13) /**< \brief GPIO Mask  for PB13 */
+#define GPIO_PB13                _UL_(1 << 13) /**< \brief GPIO Mask  for PB13 */
 #define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
-#define GPIO_PB14                _UL(1 << 14) /**< \brief GPIO Mask  for PB14 */
+#define GPIO_PB14                _UL_(1 << 14) /**< \brief GPIO Mask  for PB14 */
 #define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
-#define GPIO_PB15                _UL(1 << 15) /**< \brief GPIO Mask  for PB15 */
+#define GPIO_PB15                _UL_(1 << 15) /**< \brief GPIO Mask  for PB15 */
 #define PIN_PC00                          64  /**< \brief Pin Number for PC00 */
-#define GPIO_PC00                _UL(1 <<  0) /**< \brief GPIO Mask  for PC00 */
+#define GPIO_PC00                _UL_(1 <<  0) /**< \brief GPIO Mask  for PC00 */
 #define PIN_PC01                          65  /**< \brief Pin Number for PC01 */
-#define GPIO_PC01                _UL(1 <<  1) /**< \brief GPIO Mask  for PC01 */
+#define GPIO_PC01                _UL_(1 <<  1) /**< \brief GPIO Mask  for PC01 */
 #define PIN_PC02                          66  /**< \brief Pin Number for PC02 */
-#define GPIO_PC02                _UL(1 <<  2) /**< \brief GPIO Mask  for PC02 */
+#define GPIO_PC02                _UL_(1 <<  2) /**< \brief GPIO Mask  for PC02 */
 #define PIN_PC03                          67  /**< \brief Pin Number for PC03 */
-#define GPIO_PC03                _UL(1 <<  3) /**< \brief GPIO Mask  for PC03 */
+#define GPIO_PC03                _UL_(1 <<  3) /**< \brief GPIO Mask  for PC03 */
 #define PIN_PC04                          68  /**< \brief Pin Number for PC04 */
-#define GPIO_PC04                _UL(1 <<  4) /**< \brief GPIO Mask  for PC04 */
+#define GPIO_PC04                _UL_(1 <<  4) /**< \brief GPIO Mask  for PC04 */
 #define PIN_PC05                          69  /**< \brief Pin Number for PC05 */
-#define GPIO_PC05                _UL(1 <<  5) /**< \brief GPIO Mask  for PC05 */
+#define GPIO_PC05                _UL_(1 <<  5) /**< \brief GPIO Mask  for PC05 */
 #define PIN_PC06                          70  /**< \brief Pin Number for PC06 */
-#define GPIO_PC06                _UL(1 <<  6) /**< \brief GPIO Mask  for PC06 */
+#define GPIO_PC06                _UL_(1 <<  6) /**< \brief GPIO Mask  for PC06 */
 #define PIN_PC07                          71  /**< \brief Pin Number for PC07 */
-#define GPIO_PC07                _UL(1 <<  7) /**< \brief GPIO Mask  for PC07 */
+#define GPIO_PC07                _UL_(1 <<  7) /**< \brief GPIO Mask  for PC07 */
 #define PIN_PC08                          72  /**< \brief Pin Number for PC08 */
-#define GPIO_PC08                _UL(1 <<  8) /**< \brief GPIO Mask  for PC08 */
+#define GPIO_PC08                _UL_(1 <<  8) /**< \brief GPIO Mask  for PC08 */
 #define PIN_PC09                          73  /**< \brief Pin Number for PC09 */
-#define GPIO_PC09                _UL(1 <<  9) /**< \brief GPIO Mask  for PC09 */
+#define GPIO_PC09                _UL_(1 <<  9) /**< \brief GPIO Mask  for PC09 */
 #define PIN_PC10                          74  /**< \brief Pin Number for PC10 */
-#define GPIO_PC10                _UL(1 << 10) /**< \brief GPIO Mask  for PC10 */
+#define GPIO_PC10                _UL_(1 << 10) /**< \brief GPIO Mask  for PC10 */
 #define PIN_PC11                          75  /**< \brief Pin Number for PC11 */
-#define GPIO_PC11                _UL(1 << 11) /**< \brief GPIO Mask  for PC11 */
+#define GPIO_PC11                _UL_(1 << 11) /**< \brief GPIO Mask  for PC11 */
 #define PIN_PC12                          76  /**< \brief Pin Number for PC12 */
-#define GPIO_PC12                _UL(1 << 12) /**< \brief GPIO Mask  for PC12 */
+#define GPIO_PC12                _UL_(1 << 12) /**< \brief GPIO Mask  for PC12 */
 #define PIN_PC13                          77  /**< \brief Pin Number for PC13 */
-#define GPIO_PC13                _UL(1 << 13) /**< \brief GPIO Mask  for PC13 */
+#define GPIO_PC13                _UL_(1 << 13) /**< \brief GPIO Mask  for PC13 */
 #define PIN_PC14                          78  /**< \brief Pin Number for PC14 */
-#define GPIO_PC14                _UL(1 << 14) /**< \brief GPIO Mask  for PC14 */
+#define GPIO_PC14                _UL_(1 << 14) /**< \brief GPIO Mask  for PC14 */
 #define PIN_PC15                          79  /**< \brief Pin Number for PC15 */
-#define GPIO_PC15                _UL(1 << 15) /**< \brief GPIO Mask  for PC15 */
+#define GPIO_PC15                _UL_(1 << 15) /**< \brief GPIO Mask  for PC15 */
 #define PIN_PC16                          80  /**< \brief Pin Number for PC16 */
-#define GPIO_PC16                _UL(1 << 16) /**< \brief GPIO Mask  for PC16 */
+#define GPIO_PC16                _UL_(1 << 16) /**< \brief GPIO Mask  for PC16 */
 #define PIN_PC17                          81  /**< \brief Pin Number for PC17 */
-#define GPIO_PC17                _UL(1 << 17) /**< \brief GPIO Mask  for PC17 */
+#define GPIO_PC17                _UL_(1 << 17) /**< \brief GPIO Mask  for PC17 */
 #define PIN_PC18                          82  /**< \brief Pin Number for PC18 */
-#define GPIO_PC18                _UL(1 << 18) /**< \brief GPIO Mask  for PC18 */
+#define GPIO_PC18                _UL_(1 << 18) /**< \brief GPIO Mask  for PC18 */
 #define PIN_PC19                          83  /**< \brief Pin Number for PC19 */
-#define GPIO_PC19                _UL(1 << 19) /**< \brief GPIO Mask  for PC19 */
+#define GPIO_PC19                _UL_(1 << 19) /**< \brief GPIO Mask  for PC19 */
 #define PIN_PC20                          84  /**< \brief Pin Number for PC20 */
-#define GPIO_PC20                _UL(1 << 20) /**< \brief GPIO Mask  for PC20 */
+#define GPIO_PC20                _UL_(1 << 20) /**< \brief GPIO Mask  for PC20 */
 #define PIN_PC21                          85  /**< \brief Pin Number for PC21 */
-#define GPIO_PC21                _UL(1 << 21) /**< \brief GPIO Mask  for PC21 */
+#define GPIO_PC21                _UL_(1 << 21) /**< \brief GPIO Mask  for PC21 */
 #define PIN_PC22                          86  /**< \brief Pin Number for PC22 */
-#define GPIO_PC22                _UL(1 << 22) /**< \brief GPIO Mask  for PC22 */
+#define GPIO_PC22                _UL_(1 << 22) /**< \brief GPIO Mask  for PC22 */
 #define PIN_PC23                          87  /**< \brief Pin Number for PC23 */
-#define GPIO_PC23                _UL(1 << 23) /**< \brief GPIO Mask  for PC23 */
+#define GPIO_PC23                _UL_(1 << 23) /**< \brief GPIO Mask  for PC23 */
 #define PIN_PC24                          88  /**< \brief Pin Number for PC24 */
-#define GPIO_PC24                _UL(1 << 24) /**< \brief GPIO Mask  for PC24 */
+#define GPIO_PC24                _UL_(1 << 24) /**< \brief GPIO Mask  for PC24 */
 #define PIN_PC25                          89  /**< \brief Pin Number for PC25 */
-#define GPIO_PC25                _UL(1 << 25) /**< \brief GPIO Mask  for PC25 */
+#define GPIO_PC25                _UL_(1 << 25) /**< \brief GPIO Mask  for PC25 */
 #define PIN_PC26                          90  /**< \brief Pin Number for PC26 */
-#define GPIO_PC26                _UL(1 << 26) /**< \brief GPIO Mask  for PC26 */
+#define GPIO_PC26                _UL_(1 << 26) /**< \brief GPIO Mask  for PC26 */
 #define PIN_PC27                          91  /**< \brief Pin Number for PC27 */
-#define GPIO_PC27                _UL(1 << 27) /**< \brief GPIO Mask  for PC27 */
+#define GPIO_PC27                _UL_(1 << 27) /**< \brief GPIO Mask  for PC27 */
 #define PIN_PC28                          92  /**< \brief Pin Number for PC28 */
-#define GPIO_PC28                _UL(1 << 28) /**< \brief GPIO Mask  for PC28 */
+#define GPIO_PC28                _UL_(1 << 28) /**< \brief GPIO Mask  for PC28 */
 #define PIN_PC29                          93  /**< \brief Pin Number for PC29 */
-#define GPIO_PC29                _UL(1 << 29) /**< \brief GPIO Mask  for PC29 */
+#define GPIO_PC29                _UL_(1 << 29) /**< \brief GPIO Mask  for PC29 */
 #define PIN_PC30                          94  /**< \brief Pin Number for PC30 */
-#define GPIO_PC30                _UL(1 << 30) /**< \brief GPIO Mask  for PC30 */
+#define GPIO_PC30                _UL_(1 << 30) /**< \brief GPIO Mask  for PC30 */
 #define PIN_PC31                          95  /**< \brief Pin Number for PC31 */
-#define GPIO_PC31                _UL(1 << 31) /**< \brief GPIO Mask  for PC31 */
+#define GPIO_PC31                _UL_(1 << 31) /**< \brief GPIO Mask  for PC31 */
 /* ========== GPIO definition for TWIMS0 peripheral ========== */
-#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
-#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PIN_PA24B_TWIMS0_TWCK          _L_(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L_(1)
 #define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
-#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
-#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
-#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL_(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L_(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L_(1)
 #define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
-#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+#define GPIO_PA23B_TWIMS0_TWD    _UL_(1 << 23)
 /* ========== GPIO definition for TWIMS1 peripheral ========== */
-#define PIN_PB01A_TWIMS1_TWCK          _L(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
-#define MUX_PB01A_TWIMS1_TWCK           _L(0)
+#define PIN_PB01A_TWIMS1_TWCK          _L_(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
+#define MUX_PB01A_TWIMS1_TWCK           _L_(0)
 #define PINMUX_PB01A_TWIMS1_TWCK   ((PIN_PB01A_TWIMS1_TWCK << 16) | MUX_PB01A_TWIMS1_TWCK)
-#define GPIO_PB01A_TWIMS1_TWCK   _UL(1 <<  1)
-#define PIN_PB00A_TWIMS1_TWD           _L(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
-#define MUX_PB00A_TWIMS1_TWD            _L(0)
+#define GPIO_PB01A_TWIMS1_TWCK   _UL_(1 <<  1)
+#define PIN_PB00A_TWIMS1_TWD           _L_(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
+#define MUX_PB00A_TWIMS1_TWD            _L_(0)
 #define PINMUX_PB00A_TWIMS1_TWD    ((PIN_PB00A_TWIMS1_TWD << 16) | MUX_PB00A_TWIMS1_TWD)
-#define GPIO_PB00A_TWIMS1_TWD    _UL(1 <<  0)
+#define GPIO_PB00A_TWIMS1_TWD    _UL_(1 <<  0)
 /* ========== GPIO definition for TWIMS2 peripheral ========== */
-#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
-#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PIN_PA22E_TWIMS2_TWCK          _L_(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L_(4)
 #define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
-#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
-#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
-#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL_(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L_(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L_(4)
 #define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
-#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+#define GPIO_PA21E_TWIMS2_TWD    _UL_(1 << 21)
 /* ========== GPIO definition for TWIMS3 peripheral ========== */
-#define PIN_PB15C_TWIMS3_TWCK          _L(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
-#define MUX_PB15C_TWIMS3_TWCK           _L(2)
+#define PIN_PB15C_TWIMS3_TWCK          _L_(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
+#define MUX_PB15C_TWIMS3_TWCK           _L_(2)
 #define PINMUX_PB15C_TWIMS3_TWCK   ((PIN_PB15C_TWIMS3_TWCK << 16) | MUX_PB15C_TWIMS3_TWCK)
-#define GPIO_PB15C_TWIMS3_TWCK   _UL(1 << 15)
-#define PIN_PB14C_TWIMS3_TWD           _L(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
-#define MUX_PB14C_TWIMS3_TWD            _L(2)
+#define GPIO_PB15C_TWIMS3_TWCK   _UL_(1 << 15)
+#define PIN_PB14C_TWIMS3_TWD           _L_(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
+#define MUX_PB14C_TWIMS3_TWD            _L_(2)
 #define PINMUX_PB14C_TWIMS3_TWD    ((PIN_PB14C_TWIMS3_TWD << 16) | MUX_PB14C_TWIMS3_TWD)
-#define GPIO_PB14C_TWIMS3_TWD    _UL(1 << 14)
+#define GPIO_PB14C_TWIMS3_TWD    _UL_(1 << 14)
 /* ========== GPIO definition for IISC peripheral ========== */
-#define PIN_PB05D_IISC_IMCK            _L(37) /**< \brief IISC signal: IMCK on PB05 mux D */
-#define MUX_PB05D_IISC_IMCK             _L(3)
+#define PIN_PB05D_IISC_IMCK            _L_(37) /**< \brief IISC signal: IMCK on PB05 mux D */
+#define MUX_PB05D_IISC_IMCK             _L_(3)
 #define PINMUX_PB05D_IISC_IMCK     ((PIN_PB05D_IISC_IMCK << 16) | MUX_PB05D_IISC_IMCK)
-#define GPIO_PB05D_IISC_IMCK     _UL(1 <<  5)
-#define PIN_PC14D_IISC_IMCK            _L(78) /**< \brief IISC signal: IMCK on PC14 mux D */
-#define MUX_PC14D_IISC_IMCK             _L(3)
+#define GPIO_PB05D_IISC_IMCK     _UL_(1 <<  5)
+#define PIN_PC14D_IISC_IMCK            _L_(78) /**< \brief IISC signal: IMCK on PC14 mux D */
+#define MUX_PC14D_IISC_IMCK             _L_(3)
 #define PINMUX_PC14D_IISC_IMCK     ((PIN_PC14D_IISC_IMCK << 16) | MUX_PC14D_IISC_IMCK)
-#define GPIO_PC14D_IISC_IMCK     _UL(1 << 14)
-#define PIN_PA31B_IISC_IMCK            _L(31) /**< \brief IISC signal: IMCK on PA31 mux B */
-#define MUX_PA31B_IISC_IMCK             _L(1)
+#define GPIO_PC14D_IISC_IMCK     _UL_(1 << 14)
+#define PIN_PA31B_IISC_IMCK            _L_(31) /**< \brief IISC signal: IMCK on PA31 mux B */
+#define MUX_PA31B_IISC_IMCK             _L_(1)
 #define PINMUX_PA31B_IISC_IMCK     ((PIN_PA31B_IISC_IMCK << 16) | MUX_PA31B_IISC_IMCK)
-#define GPIO_PA31B_IISC_IMCK     _UL(1 << 31)
-#define PIN_PB02D_IISC_ISCK            _L(34) /**< \brief IISC signal: ISCK on PB02 mux D */
-#define MUX_PB02D_IISC_ISCK             _L(3)
+#define GPIO_PA31B_IISC_IMCK     _UL_(1 << 31)
+#define PIN_PB02D_IISC_ISCK            _L_(34) /**< \brief IISC signal: ISCK on PB02 mux D */
+#define MUX_PB02D_IISC_ISCK             _L_(3)
 #define PINMUX_PB02D_IISC_ISCK     ((PIN_PB02D_IISC_ISCK << 16) | MUX_PB02D_IISC_ISCK)
-#define GPIO_PB02D_IISC_ISCK     _UL(1 <<  2)
-#define PIN_PC09D_IISC_ISCK            _L(73) /**< \brief IISC signal: ISCK on PC09 mux D */
-#define MUX_PC09D_IISC_ISCK             _L(3)
+#define GPIO_PB02D_IISC_ISCK     _UL_(1 <<  2)
+#define PIN_PC09D_IISC_ISCK            _L_(73) /**< \brief IISC signal: ISCK on PC09 mux D */
+#define MUX_PC09D_IISC_ISCK             _L_(3)
 #define PINMUX_PC09D_IISC_ISCK     ((PIN_PC09D_IISC_ISCK << 16) | MUX_PC09D_IISC_ISCK)
-#define GPIO_PC09D_IISC_ISCK     _UL(1 <<  9)
-#define PIN_PA27B_IISC_ISCK            _L(27) /**< \brief IISC signal: ISCK on PA27 mux B */
-#define MUX_PA27B_IISC_ISCK             _L(1)
+#define GPIO_PC09D_IISC_ISCK     _UL_(1 <<  9)
+#define PIN_PA27B_IISC_ISCK            _L_(27) /**< \brief IISC signal: ISCK on PA27 mux B */
+#define MUX_PA27B_IISC_ISCK             _L_(1)
 #define PINMUX_PA27B_IISC_ISCK     ((PIN_PA27B_IISC_ISCK << 16) | MUX_PA27B_IISC_ISCK)
-#define GPIO_PA27B_IISC_ISCK     _UL(1 << 27)
-#define PIN_PB03D_IISC_ISDI            _L(35) /**< \brief IISC signal: ISDI on PB03 mux D */
-#define MUX_PB03D_IISC_ISDI             _L(3)
+#define GPIO_PA27B_IISC_ISCK     _UL_(1 << 27)
+#define PIN_PB03D_IISC_ISDI            _L_(35) /**< \brief IISC signal: ISDI on PB03 mux D */
+#define MUX_PB03D_IISC_ISDI             _L_(3)
 #define PINMUX_PB03D_IISC_ISDI     ((PIN_PB03D_IISC_ISDI << 16) | MUX_PB03D_IISC_ISDI)
-#define GPIO_PB03D_IISC_ISDI     _UL(1 <<  3)
-#define PIN_PC10D_IISC_ISDI            _L(74) /**< \brief IISC signal: ISDI on PC10 mux D */
-#define MUX_PC10D_IISC_ISDI             _L(3)
+#define GPIO_PB03D_IISC_ISDI     _UL_(1 <<  3)
+#define PIN_PC10D_IISC_ISDI            _L_(74) /**< \brief IISC signal: ISDI on PC10 mux D */
+#define MUX_PC10D_IISC_ISDI             _L_(3)
 #define PINMUX_PC10D_IISC_ISDI     ((PIN_PC10D_IISC_ISDI << 16) | MUX_PC10D_IISC_ISDI)
-#define GPIO_PC10D_IISC_ISDI     _UL(1 << 10)
-#define PIN_PA28B_IISC_ISDI            _L(28) /**< \brief IISC signal: ISDI on PA28 mux B */
-#define MUX_PA28B_IISC_ISDI             _L(1)
+#define GPIO_PC10D_IISC_ISDI     _UL_(1 << 10)
+#define PIN_PA28B_IISC_ISDI            _L_(28) /**< \brief IISC signal: ISDI on PA28 mux B */
+#define MUX_PA28B_IISC_ISDI             _L_(1)
 #define PINMUX_PA28B_IISC_ISDI     ((PIN_PA28B_IISC_ISDI << 16) | MUX_PA28B_IISC_ISDI)
-#define GPIO_PA28B_IISC_ISDI     _UL(1 << 28)
-#define PIN_PB04D_IISC_ISDO            _L(36) /**< \brief IISC signal: ISDO on PB04 mux D */
-#define MUX_PB04D_IISC_ISDO             _L(3)
+#define GPIO_PA28B_IISC_ISDI     _UL_(1 << 28)
+#define PIN_PB04D_IISC_ISDO            _L_(36) /**< \brief IISC signal: ISDO on PB04 mux D */
+#define MUX_PB04D_IISC_ISDO             _L_(3)
 #define PINMUX_PB04D_IISC_ISDO     ((PIN_PB04D_IISC_ISDO << 16) | MUX_PB04D_IISC_ISDO)
-#define GPIO_PB04D_IISC_ISDO     _UL(1 <<  4)
-#define PIN_PC13D_IISC_ISDO            _L(77) /**< \brief IISC signal: ISDO on PC13 mux D */
-#define MUX_PC13D_IISC_ISDO             _L(3)
+#define GPIO_PB04D_IISC_ISDO     _UL_(1 <<  4)
+#define PIN_PC13D_IISC_ISDO            _L_(77) /**< \brief IISC signal: ISDO on PC13 mux D */
+#define MUX_PC13D_IISC_ISDO             _L_(3)
 #define PINMUX_PC13D_IISC_ISDO     ((PIN_PC13D_IISC_ISDO << 16) | MUX_PC13D_IISC_ISDO)
-#define GPIO_PC13D_IISC_ISDO     _UL(1 << 13)
-#define PIN_PA30B_IISC_ISDO            _L(30) /**< \brief IISC signal: ISDO on PA30 mux B */
-#define MUX_PA30B_IISC_ISDO             _L(1)
+#define GPIO_PC13D_IISC_ISDO     _UL_(1 << 13)
+#define PIN_PA30B_IISC_ISDO            _L_(30) /**< \brief IISC signal: ISDO on PA30 mux B */
+#define MUX_PA30B_IISC_ISDO             _L_(1)
 #define PINMUX_PA30B_IISC_ISDO     ((PIN_PA30B_IISC_ISDO << 16) | MUX_PA30B_IISC_ISDO)
-#define GPIO_PA30B_IISC_ISDO     _UL(1 << 30)
-#define PIN_PB06D_IISC_IWS             _L(38) /**< \brief IISC signal: IWS on PB06 mux D */
-#define MUX_PB06D_IISC_IWS              _L(3)
+#define GPIO_PA30B_IISC_ISDO     _UL_(1 << 30)
+#define PIN_PB06D_IISC_IWS             _L_(38) /**< \brief IISC signal: IWS on PB06 mux D */
+#define MUX_PB06D_IISC_IWS              _L_(3)
 #define PINMUX_PB06D_IISC_IWS      ((PIN_PB06D_IISC_IWS << 16) | MUX_PB06D_IISC_IWS)
-#define GPIO_PB06D_IISC_IWS      _UL(1 <<  6)
-#define PIN_PC12D_IISC_IWS             _L(76) /**< \brief IISC signal: IWS on PC12 mux D */
-#define MUX_PC12D_IISC_IWS              _L(3)
+#define GPIO_PB06D_IISC_IWS      _UL_(1 <<  6)
+#define PIN_PC12D_IISC_IWS             _L_(76) /**< \brief IISC signal: IWS on PC12 mux D */
+#define MUX_PC12D_IISC_IWS              _L_(3)
 #define PINMUX_PC12D_IISC_IWS      ((PIN_PC12D_IISC_IWS << 16) | MUX_PC12D_IISC_IWS)
-#define GPIO_PC12D_IISC_IWS      _UL(1 << 12)
-#define PIN_PA29B_IISC_IWS             _L(29) /**< \brief IISC signal: IWS on PA29 mux B */
-#define MUX_PA29B_IISC_IWS              _L(1)
+#define GPIO_PC12D_IISC_IWS      _UL_(1 << 12)
+#define PIN_PA29B_IISC_IWS             _L_(29) /**< \brief IISC signal: IWS on PA29 mux B */
+#define MUX_PA29B_IISC_IWS              _L_(1)
 #define PINMUX_PA29B_IISC_IWS      ((PIN_PA29B_IISC_IWS << 16) | MUX_PA29B_IISC_IWS)
-#define GPIO_PA29B_IISC_IWS      _UL(1 << 29)
+#define GPIO_PA29B_IISC_IWS      _UL_(1 << 29)
 /* ========== GPIO definition for SPI peripheral ========== */
-#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
-#define MUX_PA03B_SPI_MISO              _L(1)
+#define PIN_PA03B_SPI_MISO              _L_(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L_(1)
 #define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
-#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
-#define PIN_PB14B_SPI_MISO             _L(46) /**< \brief SPI signal: MISO on PB14 mux B */
-#define MUX_PB14B_SPI_MISO              _L(1)
+#define GPIO_PA03B_SPI_MISO      _UL_(1 <<  3)
+#define PIN_PB14B_SPI_MISO             _L_(46) /**< \brief SPI signal: MISO on PB14 mux B */
+#define MUX_PB14B_SPI_MISO              _L_(1)
 #define PINMUX_PB14B_SPI_MISO      ((PIN_PB14B_SPI_MISO << 16) | MUX_PB14B_SPI_MISO)
-#define GPIO_PB14B_SPI_MISO      _UL(1 << 14)
-#define PIN_PC28B_SPI_MISO             _L(92) /**< \brief SPI signal: MISO on PC28 mux B */
-#define MUX_PC28B_SPI_MISO              _L(1)
+#define GPIO_PB14B_SPI_MISO      _UL_(1 << 14)
+#define PIN_PC28B_SPI_MISO             _L_(92) /**< \brief SPI signal: MISO on PC28 mux B */
+#define MUX_PC28B_SPI_MISO              _L_(1)
 #define PINMUX_PC28B_SPI_MISO      ((PIN_PC28B_SPI_MISO << 16) | MUX_PC28B_SPI_MISO)
-#define GPIO_PC28B_SPI_MISO      _UL(1 << 28)
-#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
-#define MUX_PA21A_SPI_MISO              _L(0)
+#define GPIO_PC28B_SPI_MISO      _UL_(1 << 28)
+#define PIN_PA21A_SPI_MISO             _L_(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L_(0)
 #define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
-#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
-#define PIN_PA27A_SPI_MISO             _L(27) /**< \brief SPI signal: MISO on PA27 mux A */
-#define MUX_PA27A_SPI_MISO              _L(0)
+#define GPIO_PA21A_SPI_MISO      _UL_(1 << 21)
+#define PIN_PA27A_SPI_MISO             _L_(27) /**< \brief SPI signal: MISO on PA27 mux A */
+#define MUX_PA27A_SPI_MISO              _L_(0)
 #define PINMUX_PA27A_SPI_MISO      ((PIN_PA27A_SPI_MISO << 16) | MUX_PA27A_SPI_MISO)
-#define GPIO_PA27A_SPI_MISO      _UL(1 << 27)
-#define PIN_PC04A_SPI_MISO             _L(68) /**< \brief SPI signal: MISO on PC04 mux A */
-#define MUX_PC04A_SPI_MISO              _L(0)
+#define GPIO_PA27A_SPI_MISO      _UL_(1 << 27)
+#define PIN_PC04A_SPI_MISO             _L_(68) /**< \brief SPI signal: MISO on PC04 mux A */
+#define MUX_PC04A_SPI_MISO              _L_(0)
 #define PINMUX_PC04A_SPI_MISO      ((PIN_PC04A_SPI_MISO << 16) | MUX_PC04A_SPI_MISO)
-#define GPIO_PC04A_SPI_MISO      _UL(1 <<  4)
-#define PIN_PB15B_SPI_MOSI             _L(47) /**< \brief SPI signal: MOSI on PB15 mux B */
-#define MUX_PB15B_SPI_MOSI              _L(1)
+#define GPIO_PC04A_SPI_MISO      _UL_(1 <<  4)
+#define PIN_PB15B_SPI_MOSI             _L_(47) /**< \brief SPI signal: MOSI on PB15 mux B */
+#define MUX_PB15B_SPI_MOSI              _L_(1)
 #define PINMUX_PB15B_SPI_MOSI      ((PIN_PB15B_SPI_MOSI << 16) | MUX_PB15B_SPI_MOSI)
-#define GPIO_PB15B_SPI_MOSI      _UL(1 << 15)
-#define PIN_PC29B_SPI_MOSI             _L(93) /**< \brief SPI signal: MOSI on PC29 mux B */
-#define MUX_PC29B_SPI_MOSI              _L(1)
+#define GPIO_PB15B_SPI_MOSI      _UL_(1 << 15)
+#define PIN_PC29B_SPI_MOSI             _L_(93) /**< \brief SPI signal: MOSI on PC29 mux B */
+#define MUX_PC29B_SPI_MOSI              _L_(1)
 #define PINMUX_PC29B_SPI_MOSI      ((PIN_PC29B_SPI_MOSI << 16) | MUX_PC29B_SPI_MOSI)
-#define GPIO_PC29B_SPI_MOSI      _UL(1 << 29)
-#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
-#define MUX_PA22A_SPI_MOSI              _L(0)
+#define GPIO_PC29B_SPI_MOSI      _UL_(1 << 29)
+#define PIN_PA22A_SPI_MOSI             _L_(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L_(0)
 #define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
-#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
-#define PIN_PA28A_SPI_MOSI             _L(28) /**< \brief SPI signal: MOSI on PA28 mux A */
-#define MUX_PA28A_SPI_MOSI              _L(0)
+#define GPIO_PA22A_SPI_MOSI      _UL_(1 << 22)
+#define PIN_PA28A_SPI_MOSI             _L_(28) /**< \brief SPI signal: MOSI on PA28 mux A */
+#define MUX_PA28A_SPI_MOSI              _L_(0)
 #define PINMUX_PA28A_SPI_MOSI      ((PIN_PA28A_SPI_MOSI << 16) | MUX_PA28A_SPI_MOSI)
-#define GPIO_PA28A_SPI_MOSI      _UL(1 << 28)
-#define PIN_PC05A_SPI_MOSI             _L(69) /**< \brief SPI signal: MOSI on PC05 mux A */
-#define MUX_PC05A_SPI_MOSI              _L(0)
+#define GPIO_PA28A_SPI_MOSI      _UL_(1 << 28)
+#define PIN_PC05A_SPI_MOSI             _L_(69) /**< \brief SPI signal: MOSI on PC05 mux A */
+#define MUX_PC05A_SPI_MOSI              _L_(0)
 #define PINMUX_PC05A_SPI_MOSI      ((PIN_PC05A_SPI_MOSI << 16) | MUX_PC05A_SPI_MOSI)
-#define GPIO_PC05A_SPI_MOSI      _UL(1 <<  5)
-#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
-#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define GPIO_PC05A_SPI_MOSI      _UL_(1 <<  5)
+#define PIN_PA02B_SPI_NPCS0             _L_(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L_(1)
 #define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
-#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
-#define PIN_PC31B_SPI_NPCS0            _L(95) /**< \brief SPI signal: NPCS0 on PC31 mux B */
-#define MUX_PC31B_SPI_NPCS0             _L(1)
+#define GPIO_PA02B_SPI_NPCS0     _UL_(1 <<  2)
+#define PIN_PC31B_SPI_NPCS0            _L_(95) /**< \brief SPI signal: NPCS0 on PC31 mux B */
+#define MUX_PC31B_SPI_NPCS0             _L_(1)
 #define PINMUX_PC31B_SPI_NPCS0     ((PIN_PC31B_SPI_NPCS0 << 16) | MUX_PC31B_SPI_NPCS0)
-#define GPIO_PC31B_SPI_NPCS0     _UL(1 << 31)
-#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
-#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define GPIO_PC31B_SPI_NPCS0     _UL_(1 << 31)
+#define PIN_PA24A_SPI_NPCS0            _L_(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L_(0)
 #define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
-#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
-#define PIN_PA30A_SPI_NPCS0            _L(30) /**< \brief SPI signal: NPCS0 on PA30 mux A */
-#define MUX_PA30A_SPI_NPCS0             _L(0)
+#define GPIO_PA24A_SPI_NPCS0     _UL_(1 << 24)
+#define PIN_PA30A_SPI_NPCS0            _L_(30) /**< \brief SPI signal: NPCS0 on PA30 mux A */
+#define MUX_PA30A_SPI_NPCS0             _L_(0)
 #define PINMUX_PA30A_SPI_NPCS0     ((PIN_PA30A_SPI_NPCS0 << 16) | MUX_PA30A_SPI_NPCS0)
-#define GPIO_PA30A_SPI_NPCS0     _UL(1 << 30)
-#define PIN_PC03A_SPI_NPCS0            _L(67) /**< \brief SPI signal: NPCS0 on PC03 mux A */
-#define MUX_PC03A_SPI_NPCS0             _L(0)
+#define GPIO_PA30A_SPI_NPCS0     _UL_(1 << 30)
+#define PIN_PC03A_SPI_NPCS0            _L_(67) /**< \brief SPI signal: NPCS0 on PC03 mux A */
+#define MUX_PC03A_SPI_NPCS0             _L_(0)
 #define PINMUX_PC03A_SPI_NPCS0     ((PIN_PC03A_SPI_NPCS0 << 16) | MUX_PC03A_SPI_NPCS0)
-#define GPIO_PC03A_SPI_NPCS0     _UL(1 <<  3)
-#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
-#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define GPIO_PC03A_SPI_NPCS0     _UL_(1 <<  3)
+#define PIN_PA13C_SPI_NPCS1            _L_(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L_(2)
 #define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
-#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PB13B_SPI_NPCS1            _L(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
-#define MUX_PB13B_SPI_NPCS1             _L(1)
+#define GPIO_PA13C_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PB13B_SPI_NPCS1            _L_(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
+#define MUX_PB13B_SPI_NPCS1             _L_(1)
 #define PINMUX_PB13B_SPI_NPCS1     ((PIN_PB13B_SPI_NPCS1 << 16) | MUX_PB13B_SPI_NPCS1)
-#define GPIO_PB13B_SPI_NPCS1     _UL(1 << 13)
-#define PIN_PA31A_SPI_NPCS1            _L(31) /**< \brief SPI signal: NPCS1 on PA31 mux A */
-#define MUX_PA31A_SPI_NPCS1             _L(0)
+#define GPIO_PB13B_SPI_NPCS1     _UL_(1 << 13)
+#define PIN_PA31A_SPI_NPCS1            _L_(31) /**< \brief SPI signal: NPCS1 on PA31 mux A */
+#define MUX_PA31A_SPI_NPCS1             _L_(0)
 #define PINMUX_PA31A_SPI_NPCS1     ((PIN_PA31A_SPI_NPCS1 << 16) | MUX_PA31A_SPI_NPCS1)
-#define GPIO_PA31A_SPI_NPCS1     _UL(1 << 31)
-#define PIN_PC02A_SPI_NPCS1            _L(66) /**< \brief SPI signal: NPCS1 on PC02 mux A */
-#define MUX_PC02A_SPI_NPCS1             _L(0)
+#define GPIO_PA31A_SPI_NPCS1     _UL_(1 << 31)
+#define PIN_PC02A_SPI_NPCS1            _L_(66) /**< \brief SPI signal: NPCS1 on PC02 mux A */
+#define MUX_PC02A_SPI_NPCS1             _L_(0)
 #define PINMUX_PC02A_SPI_NPCS1     ((PIN_PC02A_SPI_NPCS1 << 16) | MUX_PC02A_SPI_NPCS1)
-#define GPIO_PC02A_SPI_NPCS1     _UL(1 <<  2)
-#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
-#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define GPIO_PC02A_SPI_NPCS1     _UL_(1 <<  2)
+#define PIN_PA14C_SPI_NPCS2            _L_(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L_(2)
 #define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
-#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
-#define PIN_PB11B_SPI_NPCS2            _L(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
-#define MUX_PB11B_SPI_NPCS2             _L(1)
+#define GPIO_PA14C_SPI_NPCS2     _UL_(1 << 14)
+#define PIN_PB11B_SPI_NPCS2            _L_(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
+#define MUX_PB11B_SPI_NPCS2             _L_(1)
 #define PINMUX_PB11B_SPI_NPCS2     ((PIN_PB11B_SPI_NPCS2 << 16) | MUX_PB11B_SPI_NPCS2)
-#define GPIO_PB11B_SPI_NPCS2     _UL(1 << 11)
-#define PIN_PC00A_SPI_NPCS2            _L(64) /**< \brief SPI signal: NPCS2 on PC00 mux A */
-#define MUX_PC00A_SPI_NPCS2             _L(0)
+#define GPIO_PB11B_SPI_NPCS2     _UL_(1 << 11)
+#define PIN_PC00A_SPI_NPCS2            _L_(64) /**< \brief SPI signal: NPCS2 on PC00 mux A */
+#define MUX_PC00A_SPI_NPCS2             _L_(0)
 #define PINMUX_PC00A_SPI_NPCS2     ((PIN_PC00A_SPI_NPCS2 << 16) | MUX_PC00A_SPI_NPCS2)
-#define GPIO_PC00A_SPI_NPCS2     _UL(1 <<  0)
-#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
-#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define GPIO_PC00A_SPI_NPCS2     _UL_(1 <<  0)
+#define PIN_PA15C_SPI_NPCS3            _L_(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L_(2)
 #define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
-#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
-#define PIN_PB12B_SPI_NPCS3            _L(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
-#define MUX_PB12B_SPI_NPCS3             _L(1)
+#define GPIO_PA15C_SPI_NPCS3     _UL_(1 << 15)
+#define PIN_PB12B_SPI_NPCS3            _L_(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
+#define MUX_PB12B_SPI_NPCS3             _L_(1)
 #define PINMUX_PB12B_SPI_NPCS3     ((PIN_PB12B_SPI_NPCS3 << 16) | MUX_PB12B_SPI_NPCS3)
-#define GPIO_PB12B_SPI_NPCS3     _UL(1 << 12)
-#define PIN_PC01A_SPI_NPCS3            _L(65) /**< \brief SPI signal: NPCS3 on PC01 mux A */
-#define MUX_PC01A_SPI_NPCS3             _L(0)
+#define GPIO_PB12B_SPI_NPCS3     _UL_(1 << 12)
+#define PIN_PC01A_SPI_NPCS3            _L_(65) /**< \brief SPI signal: NPCS3 on PC01 mux A */
+#define MUX_PC01A_SPI_NPCS3             _L_(0)
 #define PINMUX_PC01A_SPI_NPCS3     ((PIN_PC01A_SPI_NPCS3 << 16) | MUX_PC01A_SPI_NPCS3)
-#define GPIO_PC01A_SPI_NPCS3     _UL(1 <<  1)
-#define PIN_PC30B_SPI_SCK              _L(94) /**< \brief SPI signal: SCK on PC30 mux B */
-#define MUX_PC30B_SPI_SCK               _L(1)
+#define GPIO_PC01A_SPI_NPCS3     _UL_(1 <<  1)
+#define PIN_PC30B_SPI_SCK              _L_(94) /**< \brief SPI signal: SCK on PC30 mux B */
+#define MUX_PC30B_SPI_SCK               _L_(1)
 #define PINMUX_PC30B_SPI_SCK       ((PIN_PC30B_SPI_SCK << 16) | MUX_PC30B_SPI_SCK)
-#define GPIO_PC30B_SPI_SCK       _UL(1 << 30)
-#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
-#define MUX_PA23A_SPI_SCK               _L(0)
+#define GPIO_PC30B_SPI_SCK       _UL_(1 << 30)
+#define PIN_PA23A_SPI_SCK              _L_(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L_(0)
 #define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
-#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
-#define PIN_PA29A_SPI_SCK              _L(29) /**< \brief SPI signal: SCK on PA29 mux A */
-#define MUX_PA29A_SPI_SCK               _L(0)
+#define GPIO_PA23A_SPI_SCK       _UL_(1 << 23)
+#define PIN_PA29A_SPI_SCK              _L_(29) /**< \brief SPI signal: SCK on PA29 mux A */
+#define MUX_PA29A_SPI_SCK               _L_(0)
 #define PINMUX_PA29A_SPI_SCK       ((PIN_PA29A_SPI_SCK << 16) | MUX_PA29A_SPI_SCK)
-#define GPIO_PA29A_SPI_SCK       _UL(1 << 29)
-#define PIN_PC06A_SPI_SCK              _L(70) /**< \brief SPI signal: SCK on PC06 mux A */
-#define MUX_PC06A_SPI_SCK               _L(0)
+#define GPIO_PA29A_SPI_SCK       _UL_(1 << 29)
+#define PIN_PC06A_SPI_SCK              _L_(70) /**< \brief SPI signal: SCK on PC06 mux A */
+#define MUX_PC06A_SPI_SCK               _L_(0)
 #define PINMUX_PC06A_SPI_SCK       ((PIN_PC06A_SPI_SCK << 16) | MUX_PC06A_SPI_SCK)
-#define GPIO_PC06A_SPI_SCK       _UL(1 <<  6)
+#define GPIO_PC06A_SPI_SCK       _UL_(1 <<  6)
 /* ========== GPIO definition for TC0 peripheral ========== */
-#define PIN_PB07D_TC0_A0               _L(39) /**< \brief TC0 signal: A0 on PB07 mux D */
-#define MUX_PB07D_TC0_A0                _L(3)
+#define PIN_PB07D_TC0_A0               _L_(39) /**< \brief TC0 signal: A0 on PB07 mux D */
+#define MUX_PB07D_TC0_A0                _L_(3)
 #define PINMUX_PB07D_TC0_A0        ((PIN_PB07D_TC0_A0 << 16) | MUX_PB07D_TC0_A0)
-#define GPIO_PB07D_TC0_A0        _UL(1 <<  7)
-#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
-#define MUX_PA08B_TC0_A0                _L(1)
+#define GPIO_PB07D_TC0_A0        _UL_(1 <<  7)
+#define PIN_PA08B_TC0_A0                _L_(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L_(1)
 #define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
-#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
-#define PIN_PB09D_TC0_A1               _L(41) /**< \brief TC0 signal: A1 on PB09 mux D */
-#define MUX_PB09D_TC0_A1                _L(3)
+#define GPIO_PA08B_TC0_A0        _UL_(1 <<  8)
+#define PIN_PB09D_TC0_A1               _L_(41) /**< \brief TC0 signal: A1 on PB09 mux D */
+#define MUX_PB09D_TC0_A1                _L_(3)
 #define PINMUX_PB09D_TC0_A1        ((PIN_PB09D_TC0_A1 << 16) | MUX_PB09D_TC0_A1)
-#define GPIO_PB09D_TC0_A1        _UL(1 <<  9)
-#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
-#define MUX_PA10B_TC0_A1                _L(1)
+#define GPIO_PB09D_TC0_A1        _UL_(1 <<  9)
+#define PIN_PA10B_TC0_A1               _L_(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L_(1)
 #define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
-#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
-#define PIN_PB11D_TC0_A2               _L(43) /**< \brief TC0 signal: A2 on PB11 mux D */
-#define MUX_PB11D_TC0_A2                _L(3)
+#define GPIO_PA10B_TC0_A1        _UL_(1 << 10)
+#define PIN_PB11D_TC0_A2               _L_(43) /**< \brief TC0 signal: A2 on PB11 mux D */
+#define MUX_PB11D_TC0_A2                _L_(3)
 #define PINMUX_PB11D_TC0_A2        ((PIN_PB11D_TC0_A2 << 16) | MUX_PB11D_TC0_A2)
-#define GPIO_PB11D_TC0_A2        _UL(1 << 11)
-#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
-#define MUX_PA12B_TC0_A2                _L(1)
+#define GPIO_PB11D_TC0_A2        _UL_(1 << 11)
+#define PIN_PA12B_TC0_A2               _L_(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L_(1)
 #define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
-#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
-#define PIN_PB08D_TC0_B0               _L(40) /**< \brief TC0 signal: B0 on PB08 mux D */
-#define MUX_PB08D_TC0_B0                _L(3)
+#define GPIO_PA12B_TC0_A2        _UL_(1 << 12)
+#define PIN_PB08D_TC0_B0               _L_(40) /**< \brief TC0 signal: B0 on PB08 mux D */
+#define MUX_PB08D_TC0_B0                _L_(3)
 #define PINMUX_PB08D_TC0_B0        ((PIN_PB08D_TC0_B0 << 16) | MUX_PB08D_TC0_B0)
-#define GPIO_PB08D_TC0_B0        _UL(1 <<  8)
-#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
-#define MUX_PA09B_TC0_B0                _L(1)
+#define GPIO_PB08D_TC0_B0        _UL_(1 <<  8)
+#define PIN_PA09B_TC0_B0                _L_(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L_(1)
 #define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
-#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
-#define PIN_PB10D_TC0_B1               _L(42) /**< \brief TC0 signal: B1 on PB10 mux D */
-#define MUX_PB10D_TC0_B1                _L(3)
+#define GPIO_PA09B_TC0_B0        _UL_(1 <<  9)
+#define PIN_PB10D_TC0_B1               _L_(42) /**< \brief TC0 signal: B1 on PB10 mux D */
+#define MUX_PB10D_TC0_B1                _L_(3)
 #define PINMUX_PB10D_TC0_B1        ((PIN_PB10D_TC0_B1 << 16) | MUX_PB10D_TC0_B1)
-#define GPIO_PB10D_TC0_B1        _UL(1 << 10)
-#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
-#define MUX_PA11B_TC0_B1                _L(1)
+#define GPIO_PB10D_TC0_B1        _UL_(1 << 10)
+#define PIN_PA11B_TC0_B1               _L_(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L_(1)
 #define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
-#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
-#define PIN_PB12D_TC0_B2               _L(44) /**< \brief TC0 signal: B2 on PB12 mux D */
-#define MUX_PB12D_TC0_B2                _L(3)
+#define GPIO_PA11B_TC0_B1        _UL_(1 << 11)
+#define PIN_PB12D_TC0_B2               _L_(44) /**< \brief TC0 signal: B2 on PB12 mux D */
+#define MUX_PB12D_TC0_B2                _L_(3)
 #define PINMUX_PB12D_TC0_B2        ((PIN_PB12D_TC0_B2 << 16) | MUX_PB12D_TC0_B2)
-#define GPIO_PB12D_TC0_B2        _UL(1 << 12)
-#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
-#define MUX_PA13B_TC0_B2                _L(1)
+#define GPIO_PB12D_TC0_B2        _UL_(1 << 12)
+#define PIN_PA13B_TC0_B2               _L_(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L_(1)
 #define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
-#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
-#define PIN_PB13D_TC0_CLK0             _L(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
-#define MUX_PB13D_TC0_CLK0              _L(3)
+#define GPIO_PA13B_TC0_B2        _UL_(1 << 13)
+#define PIN_PB13D_TC0_CLK0             _L_(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
+#define MUX_PB13D_TC0_CLK0              _L_(3)
 #define PINMUX_PB13D_TC0_CLK0      ((PIN_PB13D_TC0_CLK0 << 16) | MUX_PB13D_TC0_CLK0)
-#define GPIO_PB13D_TC0_CLK0      _UL(1 << 13)
-#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
-#define MUX_PA14B_TC0_CLK0              _L(1)
+#define GPIO_PB13D_TC0_CLK0      _UL_(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L_(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L_(1)
 #define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
-#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
-#define PIN_PB14D_TC0_CLK1             _L(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
-#define MUX_PB14D_TC0_CLK1              _L(3)
+#define GPIO_PA14B_TC0_CLK0      _UL_(1 << 14)
+#define PIN_PB14D_TC0_CLK1             _L_(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
+#define MUX_PB14D_TC0_CLK1              _L_(3)
 #define PINMUX_PB14D_TC0_CLK1      ((PIN_PB14D_TC0_CLK1 << 16) | MUX_PB14D_TC0_CLK1)
-#define GPIO_PB14D_TC0_CLK1      _UL(1 << 14)
-#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
-#define MUX_PA15B_TC0_CLK1              _L(1)
+#define GPIO_PB14D_TC0_CLK1      _UL_(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L_(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L_(1)
 #define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
-#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
-#define PIN_PB15D_TC0_CLK2             _L(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
-#define MUX_PB15D_TC0_CLK2              _L(3)
+#define GPIO_PA15B_TC0_CLK1      _UL_(1 << 15)
+#define PIN_PB15D_TC0_CLK2             _L_(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
+#define MUX_PB15D_TC0_CLK2              _L_(3)
 #define PINMUX_PB15D_TC0_CLK2      ((PIN_PB15D_TC0_CLK2 << 16) | MUX_PB15D_TC0_CLK2)
-#define GPIO_PB15D_TC0_CLK2      _UL(1 << 15)
-#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
-#define MUX_PA16B_TC0_CLK2              _L(1)
+#define GPIO_PB15D_TC0_CLK2      _UL_(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L_(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L_(1)
 #define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
-#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+#define GPIO_PA16B_TC0_CLK2      _UL_(1 << 16)
 /* ========== GPIO definition for TC1 peripheral ========== */
-#define PIN_PC00D_TC1_A0               _L(64) /**< \brief TC1 signal: A0 on PC00 mux D */
-#define MUX_PC00D_TC1_A0                _L(3)
+#define PIN_PC00D_TC1_A0               _L_(64) /**< \brief TC1 signal: A0 on PC00 mux D */
+#define MUX_PC00D_TC1_A0                _L_(3)
 #define PINMUX_PC00D_TC1_A0        ((PIN_PC00D_TC1_A0 << 16) | MUX_PC00D_TC1_A0)
-#define GPIO_PC00D_TC1_A0        _UL(1 <<  0)
-#define PIN_PC15A_TC1_A0               _L(79) /**< \brief TC1 signal: A0 on PC15 mux A */
-#define MUX_PC15A_TC1_A0                _L(0)
+#define GPIO_PC00D_TC1_A0        _UL_(1 <<  0)
+#define PIN_PC15A_TC1_A0               _L_(79) /**< \brief TC1 signal: A0 on PC15 mux A */
+#define MUX_PC15A_TC1_A0                _L_(0)
 #define PINMUX_PC15A_TC1_A0        ((PIN_PC15A_TC1_A0 << 16) | MUX_PC15A_TC1_A0)
-#define GPIO_PC15A_TC1_A0        _UL(1 << 15)
-#define PIN_PC02D_TC1_A1               _L(66) /**< \brief TC1 signal: A1 on PC02 mux D */
-#define MUX_PC02D_TC1_A1                _L(3)
+#define GPIO_PC15A_TC1_A0        _UL_(1 << 15)
+#define PIN_PC02D_TC1_A1               _L_(66) /**< \brief TC1 signal: A1 on PC02 mux D */
+#define MUX_PC02D_TC1_A1                _L_(3)
 #define PINMUX_PC02D_TC1_A1        ((PIN_PC02D_TC1_A1 << 16) | MUX_PC02D_TC1_A1)
-#define GPIO_PC02D_TC1_A1        _UL(1 <<  2)
-#define PIN_PC17A_TC1_A1               _L(81) /**< \brief TC1 signal: A1 on PC17 mux A */
-#define MUX_PC17A_TC1_A1                _L(0)
+#define GPIO_PC02D_TC1_A1        _UL_(1 <<  2)
+#define PIN_PC17A_TC1_A1               _L_(81) /**< \brief TC1 signal: A1 on PC17 mux A */
+#define MUX_PC17A_TC1_A1                _L_(0)
 #define PINMUX_PC17A_TC1_A1        ((PIN_PC17A_TC1_A1 << 16) | MUX_PC17A_TC1_A1)
-#define GPIO_PC17A_TC1_A1        _UL(1 << 17)
-#define PIN_PC04D_TC1_A2               _L(68) /**< \brief TC1 signal: A2 on PC04 mux D */
-#define MUX_PC04D_TC1_A2                _L(3)
+#define GPIO_PC17A_TC1_A1        _UL_(1 << 17)
+#define PIN_PC04D_TC1_A2               _L_(68) /**< \brief TC1 signal: A2 on PC04 mux D */
+#define MUX_PC04D_TC1_A2                _L_(3)
 #define PINMUX_PC04D_TC1_A2        ((PIN_PC04D_TC1_A2 << 16) | MUX_PC04D_TC1_A2)
-#define GPIO_PC04D_TC1_A2        _UL(1 <<  4)
-#define PIN_PC19A_TC1_A2               _L(83) /**< \brief TC1 signal: A2 on PC19 mux A */
-#define MUX_PC19A_TC1_A2                _L(0)
+#define GPIO_PC04D_TC1_A2        _UL_(1 <<  4)
+#define PIN_PC19A_TC1_A2               _L_(83) /**< \brief TC1 signal: A2 on PC19 mux A */
+#define MUX_PC19A_TC1_A2                _L_(0)
 #define PINMUX_PC19A_TC1_A2        ((PIN_PC19A_TC1_A2 << 16) | MUX_PC19A_TC1_A2)
-#define GPIO_PC19A_TC1_A2        _UL(1 << 19)
-#define PIN_PC01D_TC1_B0               _L(65) /**< \brief TC1 signal: B0 on PC01 mux D */
-#define MUX_PC01D_TC1_B0                _L(3)
+#define GPIO_PC19A_TC1_A2        _UL_(1 << 19)
+#define PIN_PC01D_TC1_B0               _L_(65) /**< \brief TC1 signal: B0 on PC01 mux D */
+#define MUX_PC01D_TC1_B0                _L_(3)
 #define PINMUX_PC01D_TC1_B0        ((PIN_PC01D_TC1_B0 << 16) | MUX_PC01D_TC1_B0)
-#define GPIO_PC01D_TC1_B0        _UL(1 <<  1)
-#define PIN_PC16A_TC1_B0               _L(80) /**< \brief TC1 signal: B0 on PC16 mux A */
-#define MUX_PC16A_TC1_B0                _L(0)
+#define GPIO_PC01D_TC1_B0        _UL_(1 <<  1)
+#define PIN_PC16A_TC1_B0               _L_(80) /**< \brief TC1 signal: B0 on PC16 mux A */
+#define MUX_PC16A_TC1_B0                _L_(0)
 #define PINMUX_PC16A_TC1_B0        ((PIN_PC16A_TC1_B0 << 16) | MUX_PC16A_TC1_B0)
-#define GPIO_PC16A_TC1_B0        _UL(1 << 16)
-#define PIN_PC03D_TC1_B1               _L(67) /**< \brief TC1 signal: B1 on PC03 mux D */
-#define MUX_PC03D_TC1_B1                _L(3)
+#define GPIO_PC16A_TC1_B0        _UL_(1 << 16)
+#define PIN_PC03D_TC1_B1               _L_(67) /**< \brief TC1 signal: B1 on PC03 mux D */
+#define MUX_PC03D_TC1_B1                _L_(3)
 #define PINMUX_PC03D_TC1_B1        ((PIN_PC03D_TC1_B1 << 16) | MUX_PC03D_TC1_B1)
-#define GPIO_PC03D_TC1_B1        _UL(1 <<  3)
-#define PIN_PC18A_TC1_B1               _L(82) /**< \brief TC1 signal: B1 on PC18 mux A */
-#define MUX_PC18A_TC1_B1                _L(0)
+#define GPIO_PC03D_TC1_B1        _UL_(1 <<  3)
+#define PIN_PC18A_TC1_B1               _L_(82) /**< \brief TC1 signal: B1 on PC18 mux A */
+#define MUX_PC18A_TC1_B1                _L_(0)
 #define PINMUX_PC18A_TC1_B1        ((PIN_PC18A_TC1_B1 << 16) | MUX_PC18A_TC1_B1)
-#define GPIO_PC18A_TC1_B1        _UL(1 << 18)
-#define PIN_PC05D_TC1_B2               _L(69) /**< \brief TC1 signal: B2 on PC05 mux D */
-#define MUX_PC05D_TC1_B2                _L(3)
+#define GPIO_PC18A_TC1_B1        _UL_(1 << 18)
+#define PIN_PC05D_TC1_B2               _L_(69) /**< \brief TC1 signal: B2 on PC05 mux D */
+#define MUX_PC05D_TC1_B2                _L_(3)
 #define PINMUX_PC05D_TC1_B2        ((PIN_PC05D_TC1_B2 << 16) | MUX_PC05D_TC1_B2)
-#define GPIO_PC05D_TC1_B2        _UL(1 <<  5)
-#define PIN_PC20A_TC1_B2               _L(84) /**< \brief TC1 signal: B2 on PC20 mux A */
-#define MUX_PC20A_TC1_B2                _L(0)
+#define GPIO_PC05D_TC1_B2        _UL_(1 <<  5)
+#define PIN_PC20A_TC1_B2               _L_(84) /**< \brief TC1 signal: B2 on PC20 mux A */
+#define MUX_PC20A_TC1_B2                _L_(0)
 #define PINMUX_PC20A_TC1_B2        ((PIN_PC20A_TC1_B2 << 16) | MUX_PC20A_TC1_B2)
-#define GPIO_PC20A_TC1_B2        _UL(1 << 20)
-#define PIN_PC06D_TC1_CLK0             _L(70) /**< \brief TC1 signal: CLK0 on PC06 mux D */
-#define MUX_PC06D_TC1_CLK0              _L(3)
+#define GPIO_PC20A_TC1_B2        _UL_(1 << 20)
+#define PIN_PC06D_TC1_CLK0             _L_(70) /**< \brief TC1 signal: CLK0 on PC06 mux D */
+#define MUX_PC06D_TC1_CLK0              _L_(3)
 #define PINMUX_PC06D_TC1_CLK0      ((PIN_PC06D_TC1_CLK0 << 16) | MUX_PC06D_TC1_CLK0)
-#define GPIO_PC06D_TC1_CLK0      _UL(1 <<  6)
-#define PIN_PC21A_TC1_CLK0             _L(85) /**< \brief TC1 signal: CLK0 on PC21 mux A */
-#define MUX_PC21A_TC1_CLK0              _L(0)
+#define GPIO_PC06D_TC1_CLK0      _UL_(1 <<  6)
+#define PIN_PC21A_TC1_CLK0             _L_(85) /**< \brief TC1 signal: CLK0 on PC21 mux A */
+#define MUX_PC21A_TC1_CLK0              _L_(0)
 #define PINMUX_PC21A_TC1_CLK0      ((PIN_PC21A_TC1_CLK0 << 16) | MUX_PC21A_TC1_CLK0)
-#define GPIO_PC21A_TC1_CLK0      _UL(1 << 21)
-#define PIN_PC07D_TC1_CLK1             _L(71) /**< \brief TC1 signal: CLK1 on PC07 mux D */
-#define MUX_PC07D_TC1_CLK1              _L(3)
+#define GPIO_PC21A_TC1_CLK0      _UL_(1 << 21)
+#define PIN_PC07D_TC1_CLK1             _L_(71) /**< \brief TC1 signal: CLK1 on PC07 mux D */
+#define MUX_PC07D_TC1_CLK1              _L_(3)
 #define PINMUX_PC07D_TC1_CLK1      ((PIN_PC07D_TC1_CLK1 << 16) | MUX_PC07D_TC1_CLK1)
-#define GPIO_PC07D_TC1_CLK1      _UL(1 <<  7)
-#define PIN_PC22A_TC1_CLK1             _L(86) /**< \brief TC1 signal: CLK1 on PC22 mux A */
-#define MUX_PC22A_TC1_CLK1              _L(0)
+#define GPIO_PC07D_TC1_CLK1      _UL_(1 <<  7)
+#define PIN_PC22A_TC1_CLK1             _L_(86) /**< \brief TC1 signal: CLK1 on PC22 mux A */
+#define MUX_PC22A_TC1_CLK1              _L_(0)
 #define PINMUX_PC22A_TC1_CLK1      ((PIN_PC22A_TC1_CLK1 << 16) | MUX_PC22A_TC1_CLK1)
-#define GPIO_PC22A_TC1_CLK1      _UL(1 << 22)
-#define PIN_PC08D_TC1_CLK2             _L(72) /**< \brief TC1 signal: CLK2 on PC08 mux D */
-#define MUX_PC08D_TC1_CLK2              _L(3)
+#define GPIO_PC22A_TC1_CLK1      _UL_(1 << 22)
+#define PIN_PC08D_TC1_CLK2             _L_(72) /**< \brief TC1 signal: CLK2 on PC08 mux D */
+#define MUX_PC08D_TC1_CLK2              _L_(3)
 #define PINMUX_PC08D_TC1_CLK2      ((PIN_PC08D_TC1_CLK2 << 16) | MUX_PC08D_TC1_CLK2)
-#define GPIO_PC08D_TC1_CLK2      _UL(1 <<  8)
-#define PIN_PC23A_TC1_CLK2             _L(87) /**< \brief TC1 signal: CLK2 on PC23 mux A */
-#define MUX_PC23A_TC1_CLK2              _L(0)
+#define GPIO_PC08D_TC1_CLK2      _UL_(1 <<  8)
+#define PIN_PC23A_TC1_CLK2             _L_(87) /**< \brief TC1 signal: CLK2 on PC23 mux A */
+#define MUX_PC23A_TC1_CLK2              _L_(0)
 #define PINMUX_PC23A_TC1_CLK2      ((PIN_PC23A_TC1_CLK2 << 16) | MUX_PC23A_TC1_CLK2)
-#define GPIO_PC23A_TC1_CLK2      _UL(1 << 23)
+#define GPIO_PC23A_TC1_CLK2      _UL_(1 << 23)
 /* ========== GPIO definition for USART0 peripheral ========== */
-#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
-#define MUX_PA04B_USART0_CLK            _L(1)
+#define PIN_PA04B_USART0_CLK            _L_(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L_(1)
 #define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
-#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
-#define PIN_PC00B_USART0_CLK           _L(64) /**< \brief USART0 signal: CLK on PC00 mux B */
-#define MUX_PC00B_USART0_CLK            _L(1)
+#define GPIO_PA04B_USART0_CLK    _UL_(1 <<  4)
+#define PIN_PC00B_USART0_CLK           _L_(64) /**< \brief USART0 signal: CLK on PC00 mux B */
+#define MUX_PC00B_USART0_CLK            _L_(1)
 #define PINMUX_PC00B_USART0_CLK    ((PIN_PC00B_USART0_CLK << 16) | MUX_PC00B_USART0_CLK)
-#define GPIO_PC00B_USART0_CLK    _UL(1 <<  0)
-#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
-#define MUX_PA10A_USART0_CLK            _L(0)
+#define GPIO_PC00B_USART0_CLK    _UL_(1 <<  0)
+#define PIN_PA10A_USART0_CLK           _L_(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L_(0)
 #define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
-#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
-#define PIN_PB13A_USART0_CLK           _L(45) /**< \brief USART0 signal: CLK on PB13 mux A */
-#define MUX_PB13A_USART0_CLK            _L(0)
+#define GPIO_PA10A_USART0_CLK    _UL_(1 << 10)
+#define PIN_PB13A_USART0_CLK           _L_(45) /**< \brief USART0 signal: CLK on PB13 mux A */
+#define MUX_PB13A_USART0_CLK            _L_(0)
 #define PINMUX_PB13A_USART0_CLK    ((PIN_PB13A_USART0_CLK << 16) | MUX_PB13A_USART0_CLK)
-#define GPIO_PB13A_USART0_CLK    _UL(1 << 13)
-#define PIN_PC02B_USART0_CTS           _L(66) /**< \brief USART0 signal: CTS on PC02 mux B */
-#define MUX_PC02B_USART0_CTS            _L(1)
+#define GPIO_PB13A_USART0_CLK    _UL_(1 << 13)
+#define PIN_PC02B_USART0_CTS           _L_(66) /**< \brief USART0 signal: CTS on PC02 mux B */
+#define MUX_PC02B_USART0_CTS            _L_(1)
 #define PINMUX_PC02B_USART0_CTS    ((PIN_PC02B_USART0_CTS << 16) | MUX_PC02B_USART0_CTS)
-#define GPIO_PC02B_USART0_CTS    _UL(1 <<  2)
-#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
-#define MUX_PA09A_USART0_CTS            _L(0)
+#define GPIO_PC02B_USART0_CTS    _UL_(1 <<  2)
+#define PIN_PA09A_USART0_CTS            _L_(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L_(0)
 #define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
-#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
-#define PIN_PB11A_USART0_CTS           _L(43) /**< \brief USART0 signal: CTS on PB11 mux A */
-#define MUX_PB11A_USART0_CTS            _L(0)
+#define GPIO_PA09A_USART0_CTS    _UL_(1 <<  9)
+#define PIN_PB11A_USART0_CTS           _L_(43) /**< \brief USART0 signal: CTS on PB11 mux A */
+#define MUX_PB11A_USART0_CTS            _L_(0)
 #define PINMUX_PB11A_USART0_CTS    ((PIN_PB11A_USART0_CTS << 16) | MUX_PB11A_USART0_CTS)
-#define GPIO_PB11A_USART0_CTS    _UL(1 << 11)
-#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
-#define MUX_PA06B_USART0_RTS            _L(1)
+#define GPIO_PB11A_USART0_CTS    _UL_(1 << 11)
+#define PIN_PA06B_USART0_RTS            _L_(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L_(1)
 #define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
-#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
-#define PIN_PC01B_USART0_RTS           _L(65) /**< \brief USART0 signal: RTS on PC01 mux B */
-#define MUX_PC01B_USART0_RTS            _L(1)
+#define GPIO_PA06B_USART0_RTS    _UL_(1 <<  6)
+#define PIN_PC01B_USART0_RTS           _L_(65) /**< \brief USART0 signal: RTS on PC01 mux B */
+#define MUX_PC01B_USART0_RTS            _L_(1)
 #define PINMUX_PC01B_USART0_RTS    ((PIN_PC01B_USART0_RTS << 16) | MUX_PC01B_USART0_RTS)
-#define GPIO_PC01B_USART0_RTS    _UL(1 <<  1)
-#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
-#define MUX_PA08A_USART0_RTS            _L(0)
+#define GPIO_PC01B_USART0_RTS    _UL_(1 <<  1)
+#define PIN_PA08A_USART0_RTS            _L_(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L_(0)
 #define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
-#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
-#define PIN_PB12A_USART0_RTS           _L(44) /**< \brief USART0 signal: RTS on PB12 mux A */
-#define MUX_PB12A_USART0_RTS            _L(0)
+#define GPIO_PA08A_USART0_RTS    _UL_(1 <<  8)
+#define PIN_PB12A_USART0_RTS           _L_(44) /**< \brief USART0 signal: RTS on PB12 mux A */
+#define MUX_PB12A_USART0_RTS            _L_(0)
 #define PINMUX_PB12A_USART0_RTS    ((PIN_PB12A_USART0_RTS << 16) | MUX_PB12A_USART0_RTS)
-#define GPIO_PB12A_USART0_RTS    _UL(1 << 12)
-#define PIN_PC02C_USART0_RXD           _L(66) /**< \brief USART0 signal: RXD on PC02 mux C */
-#define MUX_PC02C_USART0_RXD            _L(2)
+#define GPIO_PB12A_USART0_RTS    _UL_(1 << 12)
+#define PIN_PC02C_USART0_RXD           _L_(66) /**< \brief USART0 signal: RXD on PC02 mux C */
+#define MUX_PC02C_USART0_RXD            _L_(2)
 #define PINMUX_PC02C_USART0_RXD    ((PIN_PC02C_USART0_RXD << 16) | MUX_PC02C_USART0_RXD)
-#define GPIO_PC02C_USART0_RXD    _UL(1 <<  2)
-#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
-#define MUX_PA05B_USART0_RXD            _L(1)
+#define GPIO_PC02C_USART0_RXD    _UL_(1 <<  2)
+#define PIN_PA05B_USART0_RXD            _L_(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L_(1)
 #define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
-#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
-#define PIN_PB00B_USART0_RXD           _L(32) /**< \brief USART0 signal: RXD on PB00 mux B */
-#define MUX_PB00B_USART0_RXD            _L(1)
+#define GPIO_PA05B_USART0_RXD    _UL_(1 <<  5)
+#define PIN_PB00B_USART0_RXD           _L_(32) /**< \brief USART0 signal: RXD on PB00 mux B */
+#define MUX_PB00B_USART0_RXD            _L_(1)
 #define PINMUX_PB00B_USART0_RXD    ((PIN_PB00B_USART0_RXD << 16) | MUX_PB00B_USART0_RXD)
-#define GPIO_PB00B_USART0_RXD    _UL(1 <<  0)
-#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
-#define MUX_PA11A_USART0_RXD            _L(0)
+#define GPIO_PB00B_USART0_RXD    _UL_(1 <<  0)
+#define PIN_PA11A_USART0_RXD           _L_(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L_(0)
 #define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
-#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
-#define PIN_PB14A_USART0_RXD           _L(46) /**< \brief USART0 signal: RXD on PB14 mux A */
-#define MUX_PB14A_USART0_RXD            _L(0)
+#define GPIO_PA11A_USART0_RXD    _UL_(1 << 11)
+#define PIN_PB14A_USART0_RXD           _L_(46) /**< \brief USART0 signal: RXD on PB14 mux A */
+#define MUX_PB14A_USART0_RXD            _L_(0)
 #define PINMUX_PB14A_USART0_RXD    ((PIN_PB14A_USART0_RXD << 16) | MUX_PB14A_USART0_RXD)
-#define GPIO_PB14A_USART0_RXD    _UL(1 << 14)
-#define PIN_PC03C_USART0_TXD           _L(67) /**< \brief USART0 signal: TXD on PC03 mux C */
-#define MUX_PC03C_USART0_TXD            _L(2)
+#define GPIO_PB14A_USART0_RXD    _UL_(1 << 14)
+#define PIN_PC03C_USART0_TXD           _L_(67) /**< \brief USART0 signal: TXD on PC03 mux C */
+#define MUX_PC03C_USART0_TXD            _L_(2)
 #define PINMUX_PC03C_USART0_TXD    ((PIN_PC03C_USART0_TXD << 16) | MUX_PC03C_USART0_TXD)
-#define GPIO_PC03C_USART0_TXD    _UL(1 <<  3)
-#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
-#define MUX_PA07B_USART0_TXD            _L(1)
+#define GPIO_PC03C_USART0_TXD    _UL_(1 <<  3)
+#define PIN_PA07B_USART0_TXD            _L_(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L_(1)
 #define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
-#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
-#define PIN_PB01B_USART0_TXD           _L(33) /**< \brief USART0 signal: TXD on PB01 mux B */
-#define MUX_PB01B_USART0_TXD            _L(1)
+#define GPIO_PA07B_USART0_TXD    _UL_(1 <<  7)
+#define PIN_PB01B_USART0_TXD           _L_(33) /**< \brief USART0 signal: TXD on PB01 mux B */
+#define MUX_PB01B_USART0_TXD            _L_(1)
 #define PINMUX_PB01B_USART0_TXD    ((PIN_PB01B_USART0_TXD << 16) | MUX_PB01B_USART0_TXD)
-#define GPIO_PB01B_USART0_TXD    _UL(1 <<  1)
-#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
-#define MUX_PA12A_USART0_TXD            _L(0)
+#define GPIO_PB01B_USART0_TXD    _UL_(1 <<  1)
+#define PIN_PA12A_USART0_TXD           _L_(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L_(0)
 #define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
-#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
-#define PIN_PB15A_USART0_TXD           _L(47) /**< \brief USART0 signal: TXD on PB15 mux A */
-#define MUX_PB15A_USART0_TXD            _L(0)
+#define GPIO_PA12A_USART0_TXD    _UL_(1 << 12)
+#define PIN_PB15A_USART0_TXD           _L_(47) /**< \brief USART0 signal: TXD on PB15 mux A */
+#define MUX_PB15A_USART0_TXD            _L_(0)
 #define PINMUX_PB15A_USART0_TXD    ((PIN_PB15A_USART0_TXD << 16) | MUX_PB15A_USART0_TXD)
-#define GPIO_PB15A_USART0_TXD    _UL(1 << 15)
+#define GPIO_PB15A_USART0_TXD    _UL_(1 << 15)
 /* ========== GPIO definition for USART1 peripheral ========== */
-#define PIN_PB03B_USART1_CLK           _L(35) /**< \brief USART1 signal: CLK on PB03 mux B */
-#define MUX_PB03B_USART1_CLK            _L(1)
+#define PIN_PB03B_USART1_CLK           _L_(35) /**< \brief USART1 signal: CLK on PB03 mux B */
+#define MUX_PB03B_USART1_CLK            _L_(1)
 #define PINMUX_PB03B_USART1_CLK    ((PIN_PB03B_USART1_CLK << 16) | MUX_PB03B_USART1_CLK)
-#define GPIO_PB03B_USART1_CLK    _UL(1 <<  3)
-#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
-#define MUX_PA14A_USART1_CLK            _L(0)
+#define GPIO_PB03B_USART1_CLK    _UL_(1 <<  3)
+#define PIN_PA14A_USART1_CLK           _L_(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L_(0)
 #define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
-#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
-#define PIN_PC25A_USART1_CLK           _L(89) /**< \brief USART1 signal: CLK on PC25 mux A */
-#define MUX_PC25A_USART1_CLK            _L(0)
+#define GPIO_PA14A_USART1_CLK    _UL_(1 << 14)
+#define PIN_PC25A_USART1_CLK           _L_(89) /**< \brief USART1 signal: CLK on PC25 mux A */
+#define MUX_PC25A_USART1_CLK            _L_(0)
 #define PINMUX_PC25A_USART1_CLK    ((PIN_PC25A_USART1_CLK << 16) | MUX_PC25A_USART1_CLK)
-#define GPIO_PC25A_USART1_CLK    _UL(1 << 25)
-#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
-#define MUX_PA21B_USART1_CTS            _L(1)
+#define GPIO_PC25A_USART1_CLK    _UL_(1 << 25)
+#define PIN_PA21B_USART1_CTS           _L_(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L_(1)
 #define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
-#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
-#define PIN_PB02B_USART1_RTS           _L(34) /**< \brief USART1 signal: RTS on PB02 mux B */
-#define MUX_PB02B_USART1_RTS            _L(1)
+#define GPIO_PA21B_USART1_CTS    _UL_(1 << 21)
+#define PIN_PB02B_USART1_RTS           _L_(34) /**< \brief USART1 signal: RTS on PB02 mux B */
+#define MUX_PB02B_USART1_RTS            _L_(1)
 #define PINMUX_PB02B_USART1_RTS    ((PIN_PB02B_USART1_RTS << 16) | MUX_PB02B_USART1_RTS)
-#define GPIO_PB02B_USART1_RTS    _UL(1 <<  2)
-#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
-#define MUX_PA13A_USART1_RTS            _L(0)
+#define GPIO_PB02B_USART1_RTS    _UL_(1 <<  2)
+#define PIN_PA13A_USART1_RTS           _L_(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L_(0)
 #define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
-#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
-#define PIN_PC24A_USART1_RTS           _L(88) /**< \brief USART1 signal: RTS on PC24 mux A */
-#define MUX_PC24A_USART1_RTS            _L(0)
+#define GPIO_PA13A_USART1_RTS    _UL_(1 << 13)
+#define PIN_PC24A_USART1_RTS           _L_(88) /**< \brief USART1 signal: RTS on PC24 mux A */
+#define MUX_PC24A_USART1_RTS            _L_(0)
 #define PINMUX_PC24A_USART1_RTS    ((PIN_PC24A_USART1_RTS << 16) | MUX_PC24A_USART1_RTS)
-#define GPIO_PC24A_USART1_RTS    _UL(1 << 24)
-#define PIN_PB04B_USART1_RXD           _L(36) /**< \brief USART1 signal: RXD on PB04 mux B */
-#define MUX_PB04B_USART1_RXD            _L(1)
+#define GPIO_PC24A_USART1_RTS    _UL_(1 << 24)
+#define PIN_PB04B_USART1_RXD           _L_(36) /**< \brief USART1 signal: RXD on PB04 mux B */
+#define MUX_PB04B_USART1_RXD            _L_(1)
 #define PINMUX_PB04B_USART1_RXD    ((PIN_PB04B_USART1_RXD << 16) | MUX_PB04B_USART1_RXD)
-#define GPIO_PB04B_USART1_RXD    _UL(1 <<  4)
-#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
-#define MUX_PA15A_USART1_RXD            _L(0)
+#define GPIO_PB04B_USART1_RXD    _UL_(1 <<  4)
+#define PIN_PA15A_USART1_RXD           _L_(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L_(0)
 #define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
-#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
-#define PIN_PC26A_USART1_RXD           _L(90) /**< \brief USART1 signal: RXD on PC26 mux A */
-#define MUX_PC26A_USART1_RXD            _L(0)
+#define GPIO_PA15A_USART1_RXD    _UL_(1 << 15)
+#define PIN_PC26A_USART1_RXD           _L_(90) /**< \brief USART1 signal: RXD on PC26 mux A */
+#define MUX_PC26A_USART1_RXD            _L_(0)
 #define PINMUX_PC26A_USART1_RXD    ((PIN_PC26A_USART1_RXD << 16) | MUX_PC26A_USART1_RXD)
-#define GPIO_PC26A_USART1_RXD    _UL(1 << 26)
-#define PIN_PB05B_USART1_TXD           _L(37) /**< \brief USART1 signal: TXD on PB05 mux B */
-#define MUX_PB05B_USART1_TXD            _L(1)
+#define GPIO_PC26A_USART1_RXD    _UL_(1 << 26)
+#define PIN_PB05B_USART1_TXD           _L_(37) /**< \brief USART1 signal: TXD on PB05 mux B */
+#define MUX_PB05B_USART1_TXD            _L_(1)
 #define PINMUX_PB05B_USART1_TXD    ((PIN_PB05B_USART1_TXD << 16) | MUX_PB05B_USART1_TXD)
-#define GPIO_PB05B_USART1_TXD    _UL(1 <<  5)
-#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
-#define MUX_PA16A_USART1_TXD            _L(0)
+#define GPIO_PB05B_USART1_TXD    _UL_(1 <<  5)
+#define PIN_PA16A_USART1_TXD           _L_(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L_(0)
 #define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
-#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
-#define PIN_PC27A_USART1_TXD           _L(91) /**< \brief USART1 signal: TXD on PC27 mux A */
-#define MUX_PC27A_USART1_TXD            _L(0)
+#define GPIO_PA16A_USART1_TXD    _UL_(1 << 16)
+#define PIN_PC27A_USART1_TXD           _L_(91) /**< \brief USART1 signal: TXD on PC27 mux A */
+#define MUX_PC27A_USART1_TXD            _L_(0)
 #define PINMUX_PC27A_USART1_TXD    ((PIN_PC27A_USART1_TXD << 16) | MUX_PC27A_USART1_TXD)
-#define GPIO_PC27A_USART1_TXD    _UL(1 << 27)
+#define GPIO_PC27A_USART1_TXD    _UL_(1 << 27)
 /* ========== GPIO definition for USART2 peripheral ========== */
-#define PIN_PC08B_USART2_CLK           _L(72) /**< \brief USART2 signal: CLK on PC08 mux B */
-#define MUX_PC08B_USART2_CLK            _L(1)
+#define PIN_PC08B_USART2_CLK           _L_(72) /**< \brief USART2 signal: CLK on PC08 mux B */
+#define MUX_PC08B_USART2_CLK            _L_(1)
 #define PINMUX_PC08B_USART2_CLK    ((PIN_PC08B_USART2_CLK << 16) | MUX_PC08B_USART2_CLK)
-#define GPIO_PC08B_USART2_CLK    _UL(1 <<  8)
-#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
-#define MUX_PA18A_USART2_CLK            _L(0)
+#define GPIO_PC08B_USART2_CLK    _UL_(1 <<  8)
+#define PIN_PA18A_USART2_CLK           _L_(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L_(0)
 #define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
-#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
-#define PIN_PC08E_USART2_CTS           _L(72) /**< \brief USART2 signal: CTS on PC08 mux E */
-#define MUX_PC08E_USART2_CTS            _L(4)
+#define GPIO_PA18A_USART2_CLK    _UL_(1 << 18)
+#define PIN_PC08E_USART2_CTS           _L_(72) /**< \brief USART2 signal: CTS on PC08 mux E */
+#define MUX_PC08E_USART2_CTS            _L_(4)
 #define PINMUX_PC08E_USART2_CTS    ((PIN_PC08E_USART2_CTS << 16) | MUX_PC08E_USART2_CTS)
-#define GPIO_PC08E_USART2_CTS    _UL(1 <<  8)
-#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
-#define MUX_PA22B_USART2_CTS            _L(1)
+#define GPIO_PC08E_USART2_CTS    _UL_(1 <<  8)
+#define PIN_PA22B_USART2_CTS           _L_(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L_(1)
 #define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
-#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
-#define PIN_PC07B_USART2_RTS           _L(71) /**< \brief USART2 signal: RTS on PC07 mux B */
-#define MUX_PC07B_USART2_RTS            _L(1)
+#define GPIO_PA22B_USART2_CTS    _UL_(1 << 22)
+#define PIN_PC07B_USART2_RTS           _L_(71) /**< \brief USART2 signal: RTS on PC07 mux B */
+#define MUX_PC07B_USART2_RTS            _L_(1)
 #define PINMUX_PC07B_USART2_RTS    ((PIN_PC07B_USART2_RTS << 16) | MUX_PC07B_USART2_RTS)
-#define GPIO_PC07B_USART2_RTS    _UL(1 <<  7)
-#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
-#define MUX_PA17A_USART2_RTS            _L(0)
+#define GPIO_PC07B_USART2_RTS    _UL_(1 <<  7)
+#define PIN_PA17A_USART2_RTS           _L_(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L_(0)
 #define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
-#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
-#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
-#define MUX_PA25B_USART2_RXD            _L(1)
+#define GPIO_PA17A_USART2_RTS    _UL_(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L_(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L_(1)
 #define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
-#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
-#define PIN_PC11B_USART2_RXD           _L(75) /**< \brief USART2 signal: RXD on PC11 mux B */
-#define MUX_PC11B_USART2_RXD            _L(1)
+#define GPIO_PA25B_USART2_RXD    _UL_(1 << 25)
+#define PIN_PC11B_USART2_RXD           _L_(75) /**< \brief USART2 signal: RXD on PC11 mux B */
+#define MUX_PC11B_USART2_RXD            _L_(1)
 #define PINMUX_PC11B_USART2_RXD    ((PIN_PC11B_USART2_RXD << 16) | MUX_PC11B_USART2_RXD)
-#define GPIO_PC11B_USART2_RXD    _UL(1 << 11)
-#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
-#define MUX_PA19A_USART2_RXD            _L(0)
+#define GPIO_PC11B_USART2_RXD    _UL_(1 << 11)
+#define PIN_PA19A_USART2_RXD           _L_(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L_(0)
 #define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
-#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
-#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
-#define MUX_PA26B_USART2_TXD            _L(1)
+#define GPIO_PA19A_USART2_RXD    _UL_(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L_(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L_(1)
 #define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
-#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
-#define PIN_PC12B_USART2_TXD           _L(76) /**< \brief USART2 signal: TXD on PC12 mux B */
-#define MUX_PC12B_USART2_TXD            _L(1)
+#define GPIO_PA26B_USART2_TXD    _UL_(1 << 26)
+#define PIN_PC12B_USART2_TXD           _L_(76) /**< \brief USART2 signal: TXD on PC12 mux B */
+#define MUX_PC12B_USART2_TXD            _L_(1)
 #define PINMUX_PC12B_USART2_TXD    ((PIN_PC12B_USART2_TXD << 16) | MUX_PC12B_USART2_TXD)
-#define GPIO_PC12B_USART2_TXD    _UL(1 << 12)
-#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
-#define MUX_PA20A_USART2_TXD            _L(0)
+#define GPIO_PC12B_USART2_TXD    _UL_(1 << 12)
+#define PIN_PA20A_USART2_TXD           _L_(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L_(0)
 #define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
-#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+#define GPIO_PA20A_USART2_TXD    _UL_(1 << 20)
 /* ========== GPIO definition for USART3 peripheral ========== */
-#define PIN_PA29E_USART3_CLK           _L(29) /**< \brief USART3 signal: CLK on PA29 mux E */
-#define MUX_PA29E_USART3_CLK            _L(4)
+#define PIN_PA29E_USART3_CLK           _L_(29) /**< \brief USART3 signal: CLK on PA29 mux E */
+#define MUX_PA29E_USART3_CLK            _L_(4)
 #define PINMUX_PA29E_USART3_CLK    ((PIN_PA29E_USART3_CLK << 16) | MUX_PA29E_USART3_CLK)
-#define GPIO_PA29E_USART3_CLK    _UL(1 << 29)
-#define PIN_PC14B_USART3_CLK           _L(78) /**< \brief USART3 signal: CLK on PC14 mux B */
-#define MUX_PC14B_USART3_CLK            _L(1)
+#define GPIO_PA29E_USART3_CLK    _UL_(1 << 29)
+#define PIN_PC14B_USART3_CLK           _L_(78) /**< \brief USART3 signal: CLK on PC14 mux B */
+#define MUX_PC14B_USART3_CLK            _L_(1)
 #define PINMUX_PC14B_USART3_CLK    ((PIN_PC14B_USART3_CLK << 16) | MUX_PC14B_USART3_CLK)
-#define GPIO_PC14B_USART3_CLK    _UL(1 << 14)
-#define PIN_PB08A_USART3_CLK           _L(40) /**< \brief USART3 signal: CLK on PB08 mux A */
-#define MUX_PB08A_USART3_CLK            _L(0)
+#define GPIO_PC14B_USART3_CLK    _UL_(1 << 14)
+#define PIN_PB08A_USART3_CLK           _L_(40) /**< \brief USART3 signal: CLK on PB08 mux A */
+#define MUX_PB08A_USART3_CLK            _L_(0)
 #define PINMUX_PB08A_USART3_CLK    ((PIN_PB08A_USART3_CLK << 16) | MUX_PB08A_USART3_CLK)
-#define GPIO_PB08A_USART3_CLK    _UL(1 <<  8)
-#define PIN_PC31A_USART3_CLK           _L(95) /**< \brief USART3 signal: CLK on PC31 mux A */
-#define MUX_PC31A_USART3_CLK            _L(0)
+#define GPIO_PB08A_USART3_CLK    _UL_(1 <<  8)
+#define PIN_PC31A_USART3_CLK           _L_(95) /**< \brief USART3 signal: CLK on PC31 mux A */
+#define MUX_PC31A_USART3_CLK            _L_(0)
 #define PINMUX_PC31A_USART3_CLK    ((PIN_PC31A_USART3_CLK << 16) | MUX_PC31A_USART3_CLK)
-#define GPIO_PC31A_USART3_CLK    _UL(1 << 31)
-#define PIN_PA28E_USART3_CTS           _L(28) /**< \brief USART3 signal: CTS on PA28 mux E */
-#define MUX_PA28E_USART3_CTS            _L(4)
+#define GPIO_PC31A_USART3_CLK    _UL_(1 << 31)
+#define PIN_PA28E_USART3_CTS           _L_(28) /**< \brief USART3 signal: CTS on PA28 mux E */
+#define MUX_PA28E_USART3_CTS            _L_(4)
 #define PINMUX_PA28E_USART3_CTS    ((PIN_PA28E_USART3_CTS << 16) | MUX_PA28E_USART3_CTS)
-#define GPIO_PA28E_USART3_CTS    _UL(1 << 28)
-#define PIN_PB07A_USART3_CTS           _L(39) /**< \brief USART3 signal: CTS on PB07 mux A */
-#define MUX_PB07A_USART3_CTS            _L(0)
+#define GPIO_PA28E_USART3_CTS    _UL_(1 << 28)
+#define PIN_PB07A_USART3_CTS           _L_(39) /**< \brief USART3 signal: CTS on PB07 mux A */
+#define MUX_PB07A_USART3_CTS            _L_(0)
 #define PINMUX_PB07A_USART3_CTS    ((PIN_PB07A_USART3_CTS << 16) | MUX_PB07A_USART3_CTS)
-#define GPIO_PB07A_USART3_CTS    _UL(1 <<  7)
-#define PIN_PA27E_USART3_RTS           _L(27) /**< \brief USART3 signal: RTS on PA27 mux E */
-#define MUX_PA27E_USART3_RTS            _L(4)
+#define GPIO_PB07A_USART3_CTS    _UL_(1 <<  7)
+#define PIN_PA27E_USART3_RTS           _L_(27) /**< \brief USART3 signal: RTS on PA27 mux E */
+#define MUX_PA27E_USART3_RTS            _L_(4)
 #define PINMUX_PA27E_USART3_RTS    ((PIN_PA27E_USART3_RTS << 16) | MUX_PA27E_USART3_RTS)
-#define GPIO_PA27E_USART3_RTS    _UL(1 << 27)
-#define PIN_PC13B_USART3_RTS           _L(77) /**< \brief USART3 signal: RTS on PC13 mux B */
-#define MUX_PC13B_USART3_RTS            _L(1)
+#define GPIO_PA27E_USART3_RTS    _UL_(1 << 27)
+#define PIN_PC13B_USART3_RTS           _L_(77) /**< \brief USART3 signal: RTS on PC13 mux B */
+#define MUX_PC13B_USART3_RTS            _L_(1)
 #define PINMUX_PC13B_USART3_RTS    ((PIN_PC13B_USART3_RTS << 16) | MUX_PC13B_USART3_RTS)
-#define GPIO_PC13B_USART3_RTS    _UL(1 << 13)
-#define PIN_PB06A_USART3_RTS           _L(38) /**< \brief USART3 signal: RTS on PB06 mux A */
-#define MUX_PB06A_USART3_RTS            _L(0)
+#define GPIO_PC13B_USART3_RTS    _UL_(1 << 13)
+#define PIN_PB06A_USART3_RTS           _L_(38) /**< \brief USART3 signal: RTS on PB06 mux A */
+#define MUX_PB06A_USART3_RTS            _L_(0)
 #define PINMUX_PB06A_USART3_RTS    ((PIN_PB06A_USART3_RTS << 16) | MUX_PB06A_USART3_RTS)
-#define GPIO_PB06A_USART3_RTS    _UL(1 <<  6)
-#define PIN_PC30A_USART3_RTS           _L(94) /**< \brief USART3 signal: RTS on PC30 mux A */
-#define MUX_PC30A_USART3_RTS            _L(0)
+#define GPIO_PB06A_USART3_RTS    _UL_(1 <<  6)
+#define PIN_PC30A_USART3_RTS           _L_(94) /**< \brief USART3 signal: RTS on PC30 mux A */
+#define MUX_PC30A_USART3_RTS            _L_(0)
 #define PINMUX_PC30A_USART3_RTS    ((PIN_PC30A_USART3_RTS << 16) | MUX_PC30A_USART3_RTS)
-#define GPIO_PC30A_USART3_RTS    _UL(1 << 30)
-#define PIN_PA30E_USART3_RXD           _L(30) /**< \brief USART3 signal: RXD on PA30 mux E */
-#define MUX_PA30E_USART3_RXD            _L(4)
+#define GPIO_PC30A_USART3_RTS    _UL_(1 << 30)
+#define PIN_PA30E_USART3_RXD           _L_(30) /**< \brief USART3 signal: RXD on PA30 mux E */
+#define MUX_PA30E_USART3_RXD            _L_(4)
 #define PINMUX_PA30E_USART3_RXD    ((PIN_PA30E_USART3_RXD << 16) | MUX_PA30E_USART3_RXD)
-#define GPIO_PA30E_USART3_RXD    _UL(1 << 30)
-#define PIN_PC09B_USART3_RXD           _L(73) /**< \brief USART3 signal: RXD on PC09 mux B */
-#define MUX_PC09B_USART3_RXD            _L(1)
+#define GPIO_PA30E_USART3_RXD    _UL_(1 << 30)
+#define PIN_PC09B_USART3_RXD           _L_(73) /**< \brief USART3 signal: RXD on PC09 mux B */
+#define MUX_PC09B_USART3_RXD            _L_(1)
 #define PINMUX_PC09B_USART3_RXD    ((PIN_PC09B_USART3_RXD << 16) | MUX_PC09B_USART3_RXD)
-#define GPIO_PC09B_USART3_RXD    _UL(1 <<  9)
-#define PIN_PB09A_USART3_RXD           _L(41) /**< \brief USART3 signal: RXD on PB09 mux A */
-#define MUX_PB09A_USART3_RXD            _L(0)
+#define GPIO_PC09B_USART3_RXD    _UL_(1 <<  9)
+#define PIN_PB09A_USART3_RXD           _L_(41) /**< \brief USART3 signal: RXD on PB09 mux A */
+#define MUX_PB09A_USART3_RXD            _L_(0)
 #define PINMUX_PB09A_USART3_RXD    ((PIN_PB09A_USART3_RXD << 16) | MUX_PB09A_USART3_RXD)
-#define GPIO_PB09A_USART3_RXD    _UL(1 <<  9)
-#define PIN_PC28A_USART3_RXD           _L(92) /**< \brief USART3 signal: RXD on PC28 mux A */
-#define MUX_PC28A_USART3_RXD            _L(0)
+#define GPIO_PB09A_USART3_RXD    _UL_(1 <<  9)
+#define PIN_PC28A_USART3_RXD           _L_(92) /**< \brief USART3 signal: RXD on PC28 mux A */
+#define MUX_PC28A_USART3_RXD            _L_(0)
 #define PINMUX_PC28A_USART3_RXD    ((PIN_PC28A_USART3_RXD << 16) | MUX_PC28A_USART3_RXD)
-#define GPIO_PC28A_USART3_RXD    _UL(1 << 28)
-#define PIN_PA31E_USART3_TXD           _L(31) /**< \brief USART3 signal: TXD on PA31 mux E */
-#define MUX_PA31E_USART3_TXD            _L(4)
+#define GPIO_PC28A_USART3_RXD    _UL_(1 << 28)
+#define PIN_PA31E_USART3_TXD           _L_(31) /**< \brief USART3 signal: TXD on PA31 mux E */
+#define MUX_PA31E_USART3_TXD            _L_(4)
 #define PINMUX_PA31E_USART3_TXD    ((PIN_PA31E_USART3_TXD << 16) | MUX_PA31E_USART3_TXD)
-#define GPIO_PA31E_USART3_TXD    _UL(1 << 31)
-#define PIN_PC10B_USART3_TXD           _L(74) /**< \brief USART3 signal: TXD on PC10 mux B */
-#define MUX_PC10B_USART3_TXD            _L(1)
+#define GPIO_PA31E_USART3_TXD    _UL_(1 << 31)
+#define PIN_PC10B_USART3_TXD           _L_(74) /**< \brief USART3 signal: TXD on PC10 mux B */
+#define MUX_PC10B_USART3_TXD            _L_(1)
 #define PINMUX_PC10B_USART3_TXD    ((PIN_PC10B_USART3_TXD << 16) | MUX_PC10B_USART3_TXD)
-#define GPIO_PC10B_USART3_TXD    _UL(1 << 10)
-#define PIN_PB10A_USART3_TXD           _L(42) /**< \brief USART3 signal: TXD on PB10 mux A */
-#define MUX_PB10A_USART3_TXD            _L(0)
+#define GPIO_PC10B_USART3_TXD    _UL_(1 << 10)
+#define PIN_PB10A_USART3_TXD           _L_(42) /**< \brief USART3 signal: TXD on PB10 mux A */
+#define MUX_PB10A_USART3_TXD            _L_(0)
 #define PINMUX_PB10A_USART3_TXD    ((PIN_PB10A_USART3_TXD << 16) | MUX_PB10A_USART3_TXD)
-#define GPIO_PB10A_USART3_TXD    _UL(1 << 10)
-#define PIN_PC29A_USART3_TXD           _L(93) /**< \brief USART3 signal: TXD on PC29 mux A */
-#define MUX_PC29A_USART3_TXD            _L(0)
+#define GPIO_PB10A_USART3_TXD    _UL_(1 << 10)
+#define PIN_PC29A_USART3_TXD           _L_(93) /**< \brief USART3 signal: TXD on PC29 mux A */
+#define MUX_PC29A_USART3_TXD            _L_(0)
 #define PINMUX_PC29A_USART3_TXD    ((PIN_PC29A_USART3_TXD << 16) | MUX_PC29A_USART3_TXD)
-#define GPIO_PC29A_USART3_TXD    _UL(1 << 29)
+#define GPIO_PC29A_USART3_TXD    _UL_(1 << 29)
 /* ========== GPIO definition for ADCIFE peripheral ========== */
-#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
-#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PIN_PA04A_ADCIFE_AD0            _L_(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L_(0)
 #define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
-#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
-#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
-#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL_(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L_(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L_(0)
 #define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
-#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
-#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
-#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define GPIO_PA05A_ADCIFE_AD1    _UL_(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L_(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L_(0)
 #define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
-#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
-#define PIN_PB02A_ADCIFE_AD3           _L(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
-#define MUX_PB02A_ADCIFE_AD3            _L(0)
+#define GPIO_PA07A_ADCIFE_AD2    _UL_(1 <<  7)
+#define PIN_PB02A_ADCIFE_AD3           _L_(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
+#define MUX_PB02A_ADCIFE_AD3            _L_(0)
 #define PINMUX_PB02A_ADCIFE_AD3    ((PIN_PB02A_ADCIFE_AD3 << 16) | MUX_PB02A_ADCIFE_AD3)
-#define GPIO_PB02A_ADCIFE_AD3    _UL(1 <<  2)
-#define PIN_PB03A_ADCIFE_AD4           _L(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
-#define MUX_PB03A_ADCIFE_AD4            _L(0)
+#define GPIO_PB02A_ADCIFE_AD3    _UL_(1 <<  2)
+#define PIN_PB03A_ADCIFE_AD4           _L_(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
+#define MUX_PB03A_ADCIFE_AD4            _L_(0)
 #define PINMUX_PB03A_ADCIFE_AD4    ((PIN_PB03A_ADCIFE_AD4 << 16) | MUX_PB03A_ADCIFE_AD4)
-#define GPIO_PB03A_ADCIFE_AD4    _UL(1 <<  3)
-#define PIN_PB04A_ADCIFE_AD5           _L(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
-#define MUX_PB04A_ADCIFE_AD5            _L(0)
+#define GPIO_PB03A_ADCIFE_AD4    _UL_(1 <<  3)
+#define PIN_PB04A_ADCIFE_AD5           _L_(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
+#define MUX_PB04A_ADCIFE_AD5            _L_(0)
 #define PINMUX_PB04A_ADCIFE_AD5    ((PIN_PB04A_ADCIFE_AD5 << 16) | MUX_PB04A_ADCIFE_AD5)
-#define GPIO_PB04A_ADCIFE_AD5    _UL(1 <<  4)
-#define PIN_PB05A_ADCIFE_AD6           _L(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
-#define MUX_PB05A_ADCIFE_AD6            _L(0)
+#define GPIO_PB04A_ADCIFE_AD5    _UL_(1 <<  4)
+#define PIN_PB05A_ADCIFE_AD6           _L_(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
+#define MUX_PB05A_ADCIFE_AD6            _L_(0)
 #define PINMUX_PB05A_ADCIFE_AD6    ((PIN_PB05A_ADCIFE_AD6 << 16) | MUX_PB05A_ADCIFE_AD6)
-#define GPIO_PB05A_ADCIFE_AD6    _UL(1 <<  5)
-#define PIN_PC07A_ADCIFE_AD7           _L(71) /**< \brief ADCIFE signal: AD7 on PC07 mux A */
-#define MUX_PC07A_ADCIFE_AD7            _L(0)
+#define GPIO_PB05A_ADCIFE_AD6    _UL_(1 <<  5)
+#define PIN_PC07A_ADCIFE_AD7           _L_(71) /**< \brief ADCIFE signal: AD7 on PC07 mux A */
+#define MUX_PC07A_ADCIFE_AD7            _L_(0)
 #define PINMUX_PC07A_ADCIFE_AD7    ((PIN_PC07A_ADCIFE_AD7 << 16) | MUX_PC07A_ADCIFE_AD7)
-#define GPIO_PC07A_ADCIFE_AD7    _UL(1 <<  7)
-#define PIN_PC08A_ADCIFE_AD8           _L(72) /**< \brief ADCIFE signal: AD8 on PC08 mux A */
-#define MUX_PC08A_ADCIFE_AD8            _L(0)
+#define GPIO_PC07A_ADCIFE_AD7    _UL_(1 <<  7)
+#define PIN_PC08A_ADCIFE_AD8           _L_(72) /**< \brief ADCIFE signal: AD8 on PC08 mux A */
+#define MUX_PC08A_ADCIFE_AD8            _L_(0)
 #define PINMUX_PC08A_ADCIFE_AD8    ((PIN_PC08A_ADCIFE_AD8 << 16) | MUX_PC08A_ADCIFE_AD8)
-#define GPIO_PC08A_ADCIFE_AD8    _UL(1 <<  8)
-#define PIN_PC09A_ADCIFE_AD9           _L(73) /**< \brief ADCIFE signal: AD9 on PC09 mux A */
-#define MUX_PC09A_ADCIFE_AD9            _L(0)
+#define GPIO_PC08A_ADCIFE_AD8    _UL_(1 <<  8)
+#define PIN_PC09A_ADCIFE_AD9           _L_(73) /**< \brief ADCIFE signal: AD9 on PC09 mux A */
+#define MUX_PC09A_ADCIFE_AD9            _L_(0)
 #define PINMUX_PC09A_ADCIFE_AD9    ((PIN_PC09A_ADCIFE_AD9 << 16) | MUX_PC09A_ADCIFE_AD9)
-#define GPIO_PC09A_ADCIFE_AD9    _UL(1 <<  9)
-#define PIN_PC10A_ADCIFE_AD10          _L(74) /**< \brief ADCIFE signal: AD10 on PC10 mux A */
-#define MUX_PC10A_ADCIFE_AD10           _L(0)
+#define GPIO_PC09A_ADCIFE_AD9    _UL_(1 <<  9)
+#define PIN_PC10A_ADCIFE_AD10          _L_(74) /**< \brief ADCIFE signal: AD10 on PC10 mux A */
+#define MUX_PC10A_ADCIFE_AD10           _L_(0)
 #define PINMUX_PC10A_ADCIFE_AD10   ((PIN_PC10A_ADCIFE_AD10 << 16) | MUX_PC10A_ADCIFE_AD10)
-#define GPIO_PC10A_ADCIFE_AD10   _UL(1 << 10)
-#define PIN_PC11A_ADCIFE_AD11          _L(75) /**< \brief ADCIFE signal: AD11 on PC11 mux A */
-#define MUX_PC11A_ADCIFE_AD11           _L(0)
+#define GPIO_PC10A_ADCIFE_AD10   _UL_(1 << 10)
+#define PIN_PC11A_ADCIFE_AD11          _L_(75) /**< \brief ADCIFE signal: AD11 on PC11 mux A */
+#define MUX_PC11A_ADCIFE_AD11           _L_(0)
 #define PINMUX_PC11A_ADCIFE_AD11   ((PIN_PC11A_ADCIFE_AD11 << 16) | MUX_PC11A_ADCIFE_AD11)
-#define GPIO_PC11A_ADCIFE_AD11   _UL(1 << 11)
-#define PIN_PC12A_ADCIFE_AD12          _L(76) /**< \brief ADCIFE signal: AD12 on PC12 mux A */
-#define MUX_PC12A_ADCIFE_AD12           _L(0)
+#define GPIO_PC11A_ADCIFE_AD11   _UL_(1 << 11)
+#define PIN_PC12A_ADCIFE_AD12          _L_(76) /**< \brief ADCIFE signal: AD12 on PC12 mux A */
+#define MUX_PC12A_ADCIFE_AD12           _L_(0)
 #define PINMUX_PC12A_ADCIFE_AD12   ((PIN_PC12A_ADCIFE_AD12 << 16) | MUX_PC12A_ADCIFE_AD12)
-#define GPIO_PC12A_ADCIFE_AD12   _UL(1 << 12)
-#define PIN_PC13A_ADCIFE_AD13          _L(77) /**< \brief ADCIFE signal: AD13 on PC13 mux A */
-#define MUX_PC13A_ADCIFE_AD13           _L(0)
+#define GPIO_PC12A_ADCIFE_AD12   _UL_(1 << 12)
+#define PIN_PC13A_ADCIFE_AD13          _L_(77) /**< \brief ADCIFE signal: AD13 on PC13 mux A */
+#define MUX_PC13A_ADCIFE_AD13           _L_(0)
 #define PINMUX_PC13A_ADCIFE_AD13   ((PIN_PC13A_ADCIFE_AD13 << 16) | MUX_PC13A_ADCIFE_AD13)
-#define GPIO_PC13A_ADCIFE_AD13   _UL(1 << 13)
-#define PIN_PC14A_ADCIFE_AD14          _L(78) /**< \brief ADCIFE signal: AD14 on PC14 mux A */
-#define MUX_PC14A_ADCIFE_AD14           _L(0)
+#define GPIO_PC13A_ADCIFE_AD13   _UL_(1 << 13)
+#define PIN_PC14A_ADCIFE_AD14          _L_(78) /**< \brief ADCIFE signal: AD14 on PC14 mux A */
+#define MUX_PC14A_ADCIFE_AD14           _L_(0)
 #define PINMUX_PC14A_ADCIFE_AD14   ((PIN_PC14A_ADCIFE_AD14 << 16) | MUX_PC14A_ADCIFE_AD14)
-#define GPIO_PC14A_ADCIFE_AD14   _UL(1 << 14)
-#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
-#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define GPIO_PC14A_ADCIFE_AD14   _UL_(1 << 14)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L_(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L_(4)
 #define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
-#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL_(1 <<  5)
 /* ========== GPIO definition for DACC peripheral ========== */
-#define PIN_PB04E_DACC_EXT_TRIG0       _L(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
-#define MUX_PB04E_DACC_EXT_TRIG0        _L(4)
+#define PIN_PB04E_DACC_EXT_TRIG0       _L_(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
+#define MUX_PB04E_DACC_EXT_TRIG0        _L_(4)
 #define PINMUX_PB04E_DACC_EXT_TRIG0  ((PIN_PB04E_DACC_EXT_TRIG0 << 16) | MUX_PB04E_DACC_EXT_TRIG0)
-#define GPIO_PB04E_DACC_EXT_TRIG0  _UL(1 <<  4)
-#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
-#define MUX_PA06A_DACC_VOUT             _L(0)
+#define GPIO_PB04E_DACC_EXT_TRIG0  _UL_(1 <<  4)
+#define PIN_PA06A_DACC_VOUT             _L_(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L_(0)
 #define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
-#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+#define GPIO_PA06A_DACC_VOUT     _UL_(1 <<  6)
 /* ========== GPIO definition for ACIFC peripheral ========== */
-#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
-#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PIN_PA06E_ACIFC_ACAN0           _L_(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L_(4)
 #define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
-#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
-#define PIN_PC09E_ACIFC_ACAN1          _L(73) /**< \brief ACIFC signal: ACAN1 on PC09 mux E */
-#define MUX_PC09E_ACIFC_ACAN1           _L(4)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL_(1 <<  6)
+#define PIN_PC09E_ACIFC_ACAN1          _L_(73) /**< \brief ACIFC signal: ACAN1 on PC09 mux E */
+#define MUX_PC09E_ACIFC_ACAN1           _L_(4)
 #define PINMUX_PC09E_ACIFC_ACAN1   ((PIN_PC09E_ACIFC_ACAN1 << 16) | MUX_PC09E_ACIFC_ACAN1)
-#define GPIO_PC09E_ACIFC_ACAN1   _UL(1 <<  9)
-#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
-#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define GPIO_PC09E_ACIFC_ACAN1   _UL_(1 <<  9)
+#define PIN_PA07E_ACIFC_ACAP0           _L_(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L_(4)
 #define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
-#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
-#define PIN_PC10E_ACIFC_ACAP1          _L(74) /**< \brief ACIFC signal: ACAP1 on PC10 mux E */
-#define MUX_PC10E_ACIFC_ACAP1           _L(4)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL_(1 <<  7)
+#define PIN_PC10E_ACIFC_ACAP1          _L_(74) /**< \brief ACIFC signal: ACAP1 on PC10 mux E */
+#define MUX_PC10E_ACIFC_ACAP1           _L_(4)
 #define PINMUX_PC10E_ACIFC_ACAP1   ((PIN_PC10E_ACIFC_ACAP1 << 16) | MUX_PC10E_ACIFC_ACAP1)
-#define GPIO_PC10E_ACIFC_ACAP1   _UL(1 << 10)
-#define PIN_PB02E_ACIFC_ACBN0          _L(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
-#define MUX_PB02E_ACIFC_ACBN0           _L(4)
+#define GPIO_PC10E_ACIFC_ACAP1   _UL_(1 << 10)
+#define PIN_PB02E_ACIFC_ACBN0          _L_(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
+#define MUX_PB02E_ACIFC_ACBN0           _L_(4)
 #define PINMUX_PB02E_ACIFC_ACBN0   ((PIN_PB02E_ACIFC_ACBN0 << 16) | MUX_PB02E_ACIFC_ACBN0)
-#define GPIO_PB02E_ACIFC_ACBN0   _UL(1 <<  2)
-#define PIN_PC13E_ACIFC_ACBN1          _L(77) /**< \brief ACIFC signal: ACBN1 on PC13 mux E */
-#define MUX_PC13E_ACIFC_ACBN1           _L(4)
+#define GPIO_PB02E_ACIFC_ACBN0   _UL_(1 <<  2)
+#define PIN_PC13E_ACIFC_ACBN1          _L_(77) /**< \brief ACIFC signal: ACBN1 on PC13 mux E */
+#define MUX_PC13E_ACIFC_ACBN1           _L_(4)
 #define PINMUX_PC13E_ACIFC_ACBN1   ((PIN_PC13E_ACIFC_ACBN1 << 16) | MUX_PC13E_ACIFC_ACBN1)
-#define GPIO_PC13E_ACIFC_ACBN1   _UL(1 << 13)
-#define PIN_PB03E_ACIFC_ACBP0          _L(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
-#define MUX_PB03E_ACIFC_ACBP0           _L(4)
+#define GPIO_PC13E_ACIFC_ACBN1   _UL_(1 << 13)
+#define PIN_PB03E_ACIFC_ACBP0          _L_(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
+#define MUX_PB03E_ACIFC_ACBP0           _L_(4)
 #define PINMUX_PB03E_ACIFC_ACBP0   ((PIN_PB03E_ACIFC_ACBP0 << 16) | MUX_PB03E_ACIFC_ACBP0)
-#define GPIO_PB03E_ACIFC_ACBP0   _UL(1 <<  3)
-#define PIN_PC14E_ACIFC_ACBP1          _L(78) /**< \brief ACIFC signal: ACBP1 on PC14 mux E */
-#define MUX_PC14E_ACIFC_ACBP1           _L(4)
+#define GPIO_PB03E_ACIFC_ACBP0   _UL_(1 <<  3)
+#define PIN_PC14E_ACIFC_ACBP1          _L_(78) /**< \brief ACIFC signal: ACBP1 on PC14 mux E */
+#define MUX_PC14E_ACIFC_ACBP1           _L_(4)
 #define PINMUX_PC14E_ACIFC_ACBP1   ((PIN_PC14E_ACIFC_ACBP1 << 16) | MUX_PC14E_ACIFC_ACBP1)
-#define GPIO_PC14E_ACIFC_ACBP1   _UL(1 << 14)
+#define GPIO_PC14E_ACIFC_ACBP1   _UL_(1 << 14)
 /* ========== GPIO definition for GLOC peripheral ========== */
-#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
-#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PIN_PA06D_GLOC_IN0              _L_(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L_(3)
 #define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
-#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
-#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
-#define MUX_PA20D_GLOC_IN0              _L(3)
+#define GPIO_PA06D_GLOC_IN0      _UL_(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L_(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L_(3)
 #define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
-#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
-#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
-#define MUX_PA04D_GLOC_IN1              _L(3)
+#define GPIO_PA20D_GLOC_IN0      _UL_(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L_(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L_(3)
 #define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
-#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
-#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
-#define MUX_PA21D_GLOC_IN1              _L(3)
+#define GPIO_PA04D_GLOC_IN1      _UL_(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L_(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L_(3)
 #define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
-#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
-#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
-#define MUX_PA05D_GLOC_IN2              _L(3)
+#define GPIO_PA21D_GLOC_IN1      _UL_(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L_(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L_(3)
 #define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
-#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
-#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
-#define MUX_PA22D_GLOC_IN2              _L(3)
+#define GPIO_PA05D_GLOC_IN2      _UL_(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L_(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L_(3)
 #define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
-#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
-#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
-#define MUX_PA07D_GLOC_IN3              _L(3)
+#define GPIO_PA22D_GLOC_IN2      _UL_(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L_(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L_(3)
 #define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
-#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
-#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
-#define MUX_PA23D_GLOC_IN3              _L(3)
+#define GPIO_PA07D_GLOC_IN3      _UL_(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L_(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L_(3)
 #define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
-#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
-#define PIN_PA27D_GLOC_IN4             _L(27) /**< \brief GLOC signal: IN4 on PA27 mux D */
-#define MUX_PA27D_GLOC_IN4              _L(3)
+#define GPIO_PA23D_GLOC_IN3      _UL_(1 << 23)
+#define PIN_PA27D_GLOC_IN4             _L_(27) /**< \brief GLOC signal: IN4 on PA27 mux D */
+#define MUX_PA27D_GLOC_IN4              _L_(3)
 #define PINMUX_PA27D_GLOC_IN4      ((PIN_PA27D_GLOC_IN4 << 16) | MUX_PA27D_GLOC_IN4)
-#define GPIO_PA27D_GLOC_IN4      _UL(1 << 27)
-#define PIN_PC15D_GLOC_IN4             _L(79) /**< \brief GLOC signal: IN4 on PC15 mux D */
-#define MUX_PC15D_GLOC_IN4              _L(3)
+#define GPIO_PA27D_GLOC_IN4      _UL_(1 << 27)
+#define PIN_PC15D_GLOC_IN4             _L_(79) /**< \brief GLOC signal: IN4 on PC15 mux D */
+#define MUX_PC15D_GLOC_IN4              _L_(3)
 #define PINMUX_PC15D_GLOC_IN4      ((PIN_PC15D_GLOC_IN4 << 16) | MUX_PC15D_GLOC_IN4)
-#define GPIO_PC15D_GLOC_IN4      _UL(1 << 15)
-#define PIN_PB06C_GLOC_IN4             _L(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
-#define MUX_PB06C_GLOC_IN4              _L(2)
+#define GPIO_PC15D_GLOC_IN4      _UL_(1 << 15)
+#define PIN_PB06C_GLOC_IN4             _L_(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
+#define MUX_PB06C_GLOC_IN4              _L_(2)
 #define PINMUX_PB06C_GLOC_IN4      ((PIN_PB06C_GLOC_IN4 << 16) | MUX_PB06C_GLOC_IN4)
-#define GPIO_PB06C_GLOC_IN4      _UL(1 <<  6)
-#define PIN_PC28C_GLOC_IN4             _L(92) /**< \brief GLOC signal: IN4 on PC28 mux C */
-#define MUX_PC28C_GLOC_IN4              _L(2)
+#define GPIO_PB06C_GLOC_IN4      _UL_(1 <<  6)
+#define PIN_PC28C_GLOC_IN4             _L_(92) /**< \brief GLOC signal: IN4 on PC28 mux C */
+#define MUX_PC28C_GLOC_IN4              _L_(2)
 #define PINMUX_PC28C_GLOC_IN4      ((PIN_PC28C_GLOC_IN4 << 16) | MUX_PC28C_GLOC_IN4)
-#define GPIO_PC28C_GLOC_IN4      _UL(1 << 28)
-#define PIN_PA28D_GLOC_IN5             _L(28) /**< \brief GLOC signal: IN5 on PA28 mux D */
-#define MUX_PA28D_GLOC_IN5              _L(3)
+#define GPIO_PC28C_GLOC_IN4      _UL_(1 << 28)
+#define PIN_PA28D_GLOC_IN5             _L_(28) /**< \brief GLOC signal: IN5 on PA28 mux D */
+#define MUX_PA28D_GLOC_IN5              _L_(3)
 #define PINMUX_PA28D_GLOC_IN5      ((PIN_PA28D_GLOC_IN5 << 16) | MUX_PA28D_GLOC_IN5)
-#define GPIO_PA28D_GLOC_IN5      _UL(1 << 28)
-#define PIN_PC16D_GLOC_IN5             _L(80) /**< \brief GLOC signal: IN5 on PC16 mux D */
-#define MUX_PC16D_GLOC_IN5              _L(3)
+#define GPIO_PA28D_GLOC_IN5      _UL_(1 << 28)
+#define PIN_PC16D_GLOC_IN5             _L_(80) /**< \brief GLOC signal: IN5 on PC16 mux D */
+#define MUX_PC16D_GLOC_IN5              _L_(3)
 #define PINMUX_PC16D_GLOC_IN5      ((PIN_PC16D_GLOC_IN5 << 16) | MUX_PC16D_GLOC_IN5)
-#define GPIO_PC16D_GLOC_IN5      _UL(1 << 16)
-#define PIN_PB07C_GLOC_IN5             _L(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
-#define MUX_PB07C_GLOC_IN5              _L(2)
+#define GPIO_PC16D_GLOC_IN5      _UL_(1 << 16)
+#define PIN_PB07C_GLOC_IN5             _L_(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
+#define MUX_PB07C_GLOC_IN5              _L_(2)
 #define PINMUX_PB07C_GLOC_IN5      ((PIN_PB07C_GLOC_IN5 << 16) | MUX_PB07C_GLOC_IN5)
-#define GPIO_PB07C_GLOC_IN5      _UL(1 <<  7)
-#define PIN_PC29C_GLOC_IN5             _L(93) /**< \brief GLOC signal: IN5 on PC29 mux C */
-#define MUX_PC29C_GLOC_IN5              _L(2)
+#define GPIO_PB07C_GLOC_IN5      _UL_(1 <<  7)
+#define PIN_PC29C_GLOC_IN5             _L_(93) /**< \brief GLOC signal: IN5 on PC29 mux C */
+#define MUX_PC29C_GLOC_IN5              _L_(2)
 #define PINMUX_PC29C_GLOC_IN5      ((PIN_PC29C_GLOC_IN5 << 16) | MUX_PC29C_GLOC_IN5)
-#define GPIO_PC29C_GLOC_IN5      _UL(1 << 29)
-#define PIN_PA29D_GLOC_IN6             _L(29) /**< \brief GLOC signal: IN6 on PA29 mux D */
-#define MUX_PA29D_GLOC_IN6              _L(3)
+#define GPIO_PC29C_GLOC_IN5      _UL_(1 << 29)
+#define PIN_PA29D_GLOC_IN6             _L_(29) /**< \brief GLOC signal: IN6 on PA29 mux D */
+#define MUX_PA29D_GLOC_IN6              _L_(3)
 #define PINMUX_PA29D_GLOC_IN6      ((PIN_PA29D_GLOC_IN6 << 16) | MUX_PA29D_GLOC_IN6)
-#define GPIO_PA29D_GLOC_IN6      _UL(1 << 29)
-#define PIN_PC17D_GLOC_IN6             _L(81) /**< \brief GLOC signal: IN6 on PC17 mux D */
-#define MUX_PC17D_GLOC_IN6              _L(3)
+#define GPIO_PA29D_GLOC_IN6      _UL_(1 << 29)
+#define PIN_PC17D_GLOC_IN6             _L_(81) /**< \brief GLOC signal: IN6 on PC17 mux D */
+#define MUX_PC17D_GLOC_IN6              _L_(3)
 #define PINMUX_PC17D_GLOC_IN6      ((PIN_PC17D_GLOC_IN6 << 16) | MUX_PC17D_GLOC_IN6)
-#define GPIO_PC17D_GLOC_IN6      _UL(1 << 17)
-#define PIN_PB08C_GLOC_IN6             _L(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
-#define MUX_PB08C_GLOC_IN6              _L(2)
+#define GPIO_PC17D_GLOC_IN6      _UL_(1 << 17)
+#define PIN_PB08C_GLOC_IN6             _L_(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
+#define MUX_PB08C_GLOC_IN6              _L_(2)
 #define PINMUX_PB08C_GLOC_IN6      ((PIN_PB08C_GLOC_IN6 << 16) | MUX_PB08C_GLOC_IN6)
-#define GPIO_PB08C_GLOC_IN6      _UL(1 <<  8)
-#define PIN_PC30C_GLOC_IN6             _L(94) /**< \brief GLOC signal: IN6 on PC30 mux C */
-#define MUX_PC30C_GLOC_IN6              _L(2)
+#define GPIO_PB08C_GLOC_IN6      _UL_(1 <<  8)
+#define PIN_PC30C_GLOC_IN6             _L_(94) /**< \brief GLOC signal: IN6 on PC30 mux C */
+#define MUX_PC30C_GLOC_IN6              _L_(2)
 #define PINMUX_PC30C_GLOC_IN6      ((PIN_PC30C_GLOC_IN6 << 16) | MUX_PC30C_GLOC_IN6)
-#define GPIO_PC30C_GLOC_IN6      _UL(1 << 30)
-#define PIN_PA30D_GLOC_IN7             _L(30) /**< \brief GLOC signal: IN7 on PA30 mux D */
-#define MUX_PA30D_GLOC_IN7              _L(3)
+#define GPIO_PC30C_GLOC_IN6      _UL_(1 << 30)
+#define PIN_PA30D_GLOC_IN7             _L_(30) /**< \brief GLOC signal: IN7 on PA30 mux D */
+#define MUX_PA30D_GLOC_IN7              _L_(3)
 #define PINMUX_PA30D_GLOC_IN7      ((PIN_PA30D_GLOC_IN7 << 16) | MUX_PA30D_GLOC_IN7)
-#define GPIO_PA30D_GLOC_IN7      _UL(1 << 30)
-#define PIN_PC18D_GLOC_IN7             _L(82) /**< \brief GLOC signal: IN7 on PC18 mux D */
-#define MUX_PC18D_GLOC_IN7              _L(3)
+#define GPIO_PA30D_GLOC_IN7      _UL_(1 << 30)
+#define PIN_PC18D_GLOC_IN7             _L_(82) /**< \brief GLOC signal: IN7 on PC18 mux D */
+#define MUX_PC18D_GLOC_IN7              _L_(3)
 #define PINMUX_PC18D_GLOC_IN7      ((PIN_PC18D_GLOC_IN7 << 16) | MUX_PC18D_GLOC_IN7)
-#define GPIO_PC18D_GLOC_IN7      _UL(1 << 18)
-#define PIN_PB09C_GLOC_IN7             _L(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
-#define MUX_PB09C_GLOC_IN7              _L(2)
+#define GPIO_PC18D_GLOC_IN7      _UL_(1 << 18)
+#define PIN_PB09C_GLOC_IN7             _L_(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
+#define MUX_PB09C_GLOC_IN7              _L_(2)
 #define PINMUX_PB09C_GLOC_IN7      ((PIN_PB09C_GLOC_IN7 << 16) | MUX_PB09C_GLOC_IN7)
-#define GPIO_PB09C_GLOC_IN7      _UL(1 <<  9)
-#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
-#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define GPIO_PB09C_GLOC_IN7      _UL_(1 <<  9)
+#define PIN_PA08D_GLOC_OUT0             _L_(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
-#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
-#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
-#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define GPIO_PA08D_GLOC_OUT0     _UL_(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L_(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L_(3)
 #define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
-#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
-#define PIN_PA31D_GLOC_OUT1            _L(31) /**< \brief GLOC signal: OUT1 on PA31 mux D */
-#define MUX_PA31D_GLOC_OUT1             _L(3)
+#define GPIO_PA24D_GLOC_OUT0     _UL_(1 << 24)
+#define PIN_PA31D_GLOC_OUT1            _L_(31) /**< \brief GLOC signal: OUT1 on PA31 mux D */
+#define MUX_PA31D_GLOC_OUT1             _L_(3)
 #define PINMUX_PA31D_GLOC_OUT1     ((PIN_PA31D_GLOC_OUT1 << 16) | MUX_PA31D_GLOC_OUT1)
-#define GPIO_PA31D_GLOC_OUT1     _UL(1 << 31)
-#define PIN_PC19D_GLOC_OUT1            _L(83) /**< \brief GLOC signal: OUT1 on PC19 mux D */
-#define MUX_PC19D_GLOC_OUT1             _L(3)
+#define GPIO_PA31D_GLOC_OUT1     _UL_(1 << 31)
+#define PIN_PC19D_GLOC_OUT1            _L_(83) /**< \brief GLOC signal: OUT1 on PC19 mux D */
+#define MUX_PC19D_GLOC_OUT1             _L_(3)
 #define PINMUX_PC19D_GLOC_OUT1     ((PIN_PC19D_GLOC_OUT1 << 16) | MUX_PC19D_GLOC_OUT1)
-#define GPIO_PC19D_GLOC_OUT1     _UL(1 << 19)
-#define PIN_PB10C_GLOC_OUT1            _L(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
-#define MUX_PB10C_GLOC_OUT1             _L(2)
+#define GPIO_PC19D_GLOC_OUT1     _UL_(1 << 19)
+#define PIN_PB10C_GLOC_OUT1            _L_(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
+#define MUX_PB10C_GLOC_OUT1             _L_(2)
 #define PINMUX_PB10C_GLOC_OUT1     ((PIN_PB10C_GLOC_OUT1 << 16) | MUX_PB10C_GLOC_OUT1)
-#define GPIO_PB10C_GLOC_OUT1     _UL(1 << 10)
-#define PIN_PC31C_GLOC_OUT1            _L(95) /**< \brief GLOC signal: OUT1 on PC31 mux C */
-#define MUX_PC31C_GLOC_OUT1             _L(2)
+#define GPIO_PB10C_GLOC_OUT1     _UL_(1 << 10)
+#define PIN_PC31C_GLOC_OUT1            _L_(95) /**< \brief GLOC signal: OUT1 on PC31 mux C */
+#define MUX_PC31C_GLOC_OUT1             _L_(2)
 #define PINMUX_PC31C_GLOC_OUT1     ((PIN_PC31C_GLOC_OUT1 << 16) | MUX_PC31C_GLOC_OUT1)
-#define GPIO_PC31C_GLOC_OUT1     _UL(1 << 31)
+#define GPIO_PC31C_GLOC_OUT1     _UL_(1 << 31)
 /* ========== GPIO definition for ABDACB peripheral ========== */
-#define PIN_PA31C_ABDACB_CLK           _L(31) /**< \brief ABDACB signal: CLK on PA31 mux C */
-#define MUX_PA31C_ABDACB_CLK            _L(2)
+#define PIN_PA31C_ABDACB_CLK           _L_(31) /**< \brief ABDACB signal: CLK on PA31 mux C */
+#define MUX_PA31C_ABDACB_CLK            _L_(2)
 #define PINMUX_PA31C_ABDACB_CLK    ((PIN_PA31C_ABDACB_CLK << 16) | MUX_PA31C_ABDACB_CLK)
-#define GPIO_PA31C_ABDACB_CLK    _UL(1 << 31)
-#define PIN_PC12C_ABDACB_CLK           _L(76) /**< \brief ABDACB signal: CLK on PC12 mux C */
-#define MUX_PC12C_ABDACB_CLK            _L(2)
+#define GPIO_PA31C_ABDACB_CLK    _UL_(1 << 31)
+#define PIN_PC12C_ABDACB_CLK           _L_(76) /**< \brief ABDACB signal: CLK on PC12 mux C */
+#define MUX_PC12C_ABDACB_CLK            _L_(2)
 #define PINMUX_PC12C_ABDACB_CLK    ((PIN_PC12C_ABDACB_CLK << 16) | MUX_PC12C_ABDACB_CLK)
-#define GPIO_PC12C_ABDACB_CLK    _UL(1 << 12)
-#define PIN_PA27C_ABDACB_DAC0          _L(27) /**< \brief ABDACB signal: DAC0 on PA27 mux C */
-#define MUX_PA27C_ABDACB_DAC0           _L(2)
+#define GPIO_PC12C_ABDACB_CLK    _UL_(1 << 12)
+#define PIN_PA27C_ABDACB_DAC0          _L_(27) /**< \brief ABDACB signal: DAC0 on PA27 mux C */
+#define MUX_PA27C_ABDACB_DAC0           _L_(2)
 #define PINMUX_PA27C_ABDACB_DAC0   ((PIN_PA27C_ABDACB_DAC0 << 16) | MUX_PA27C_ABDACB_DAC0)
-#define GPIO_PA27C_ABDACB_DAC0   _UL(1 << 27)
-#define PIN_PB02C_ABDACB_DAC0          _L(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
-#define MUX_PB02C_ABDACB_DAC0           _L(2)
+#define GPIO_PA27C_ABDACB_DAC0   _UL_(1 << 27)
+#define PIN_PB02C_ABDACB_DAC0          _L_(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
+#define MUX_PB02C_ABDACB_DAC0           _L_(2)
 #define PINMUX_PB02C_ABDACB_DAC0   ((PIN_PB02C_ABDACB_DAC0 << 16) | MUX_PB02C_ABDACB_DAC0)
-#define GPIO_PB02C_ABDACB_DAC0   _UL(1 <<  2)
-#define PIN_PC09C_ABDACB_DAC0          _L(73) /**< \brief ABDACB signal: DAC0 on PC09 mux C */
-#define MUX_PC09C_ABDACB_DAC0           _L(2)
+#define GPIO_PB02C_ABDACB_DAC0   _UL_(1 <<  2)
+#define PIN_PC09C_ABDACB_DAC0          _L_(73) /**< \brief ABDACB signal: DAC0 on PC09 mux C */
+#define MUX_PC09C_ABDACB_DAC0           _L_(2)
 #define PINMUX_PC09C_ABDACB_DAC0   ((PIN_PC09C_ABDACB_DAC0 << 16) | MUX_PC09C_ABDACB_DAC0)
-#define GPIO_PC09C_ABDACB_DAC0   _UL(1 <<  9)
-#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
-#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define GPIO_PC09C_ABDACB_DAC0   _UL_(1 <<  9)
+#define PIN_PA17B_ABDACB_DAC0          _L_(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L_(1)
 #define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
-#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
-#define PIN_PA29C_ABDACB_DAC1          _L(29) /**< \brief ABDACB signal: DAC1 on PA29 mux C */
-#define MUX_PA29C_ABDACB_DAC1           _L(2)
+#define GPIO_PA17B_ABDACB_DAC0   _UL_(1 << 17)
+#define PIN_PA29C_ABDACB_DAC1          _L_(29) /**< \brief ABDACB signal: DAC1 on PA29 mux C */
+#define MUX_PA29C_ABDACB_DAC1           _L_(2)
 #define PINMUX_PA29C_ABDACB_DAC1   ((PIN_PA29C_ABDACB_DAC1 << 16) | MUX_PA29C_ABDACB_DAC1)
-#define GPIO_PA29C_ABDACB_DAC1   _UL(1 << 29)
-#define PIN_PB04C_ABDACB_DAC1          _L(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
-#define MUX_PB04C_ABDACB_DAC1           _L(2)
+#define GPIO_PA29C_ABDACB_DAC1   _UL_(1 << 29)
+#define PIN_PB04C_ABDACB_DAC1          _L_(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
+#define MUX_PB04C_ABDACB_DAC1           _L_(2)
 #define PINMUX_PB04C_ABDACB_DAC1   ((PIN_PB04C_ABDACB_DAC1 << 16) | MUX_PB04C_ABDACB_DAC1)
-#define GPIO_PB04C_ABDACB_DAC1   _UL(1 <<  4)
-#define PIN_PC13C_ABDACB_DAC1          _L(77) /**< \brief ABDACB signal: DAC1 on PC13 mux C */
-#define MUX_PC13C_ABDACB_DAC1           _L(2)
+#define GPIO_PB04C_ABDACB_DAC1   _UL_(1 <<  4)
+#define PIN_PC13C_ABDACB_DAC1          _L_(77) /**< \brief ABDACB signal: DAC1 on PC13 mux C */
+#define MUX_PC13C_ABDACB_DAC1           _L_(2)
 #define PINMUX_PC13C_ABDACB_DAC1   ((PIN_PC13C_ABDACB_DAC1 << 16) | MUX_PC13C_ABDACB_DAC1)
-#define GPIO_PC13C_ABDACB_DAC1   _UL(1 << 13)
-#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
-#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define GPIO_PC13C_ABDACB_DAC1   _UL_(1 << 13)
+#define PIN_PA19B_ABDACB_DAC1          _L_(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L_(1)
 #define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
-#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
-#define PIN_PA28C_ABDACB_DACN0         _L(28) /**< \brief ABDACB signal: DACN0 on PA28 mux C */
-#define MUX_PA28C_ABDACB_DACN0          _L(2)
+#define GPIO_PA19B_ABDACB_DAC1   _UL_(1 << 19)
+#define PIN_PA28C_ABDACB_DACN0         _L_(28) /**< \brief ABDACB signal: DACN0 on PA28 mux C */
+#define MUX_PA28C_ABDACB_DACN0          _L_(2)
 #define PINMUX_PA28C_ABDACB_DACN0  ((PIN_PA28C_ABDACB_DACN0 << 16) | MUX_PA28C_ABDACB_DACN0)
-#define GPIO_PA28C_ABDACB_DACN0  _UL(1 << 28)
-#define PIN_PB03C_ABDACB_DACN0         _L(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
-#define MUX_PB03C_ABDACB_DACN0          _L(2)
+#define GPIO_PA28C_ABDACB_DACN0  _UL_(1 << 28)
+#define PIN_PB03C_ABDACB_DACN0         _L_(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
+#define MUX_PB03C_ABDACB_DACN0          _L_(2)
 #define PINMUX_PB03C_ABDACB_DACN0  ((PIN_PB03C_ABDACB_DACN0 << 16) | MUX_PB03C_ABDACB_DACN0)
-#define GPIO_PB03C_ABDACB_DACN0  _UL(1 <<  3)
-#define PIN_PC10C_ABDACB_DACN0         _L(74) /**< \brief ABDACB signal: DACN0 on PC10 mux C */
-#define MUX_PC10C_ABDACB_DACN0          _L(2)
+#define GPIO_PB03C_ABDACB_DACN0  _UL_(1 <<  3)
+#define PIN_PC10C_ABDACB_DACN0         _L_(74) /**< \brief ABDACB signal: DACN0 on PC10 mux C */
+#define MUX_PC10C_ABDACB_DACN0          _L_(2)
 #define PINMUX_PC10C_ABDACB_DACN0  ((PIN_PC10C_ABDACB_DACN0 << 16) | MUX_PC10C_ABDACB_DACN0)
-#define GPIO_PC10C_ABDACB_DACN0  _UL(1 << 10)
-#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
-#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define GPIO_PC10C_ABDACB_DACN0  _UL_(1 << 10)
+#define PIN_PA18B_ABDACB_DACN0         _L_(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L_(1)
 #define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
-#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
-#define PIN_PA30C_ABDACB_DACN1         _L(30) /**< \brief ABDACB signal: DACN1 on PA30 mux C */
-#define MUX_PA30C_ABDACB_DACN1          _L(2)
+#define GPIO_PA18B_ABDACB_DACN0  _UL_(1 << 18)
+#define PIN_PA30C_ABDACB_DACN1         _L_(30) /**< \brief ABDACB signal: DACN1 on PA30 mux C */
+#define MUX_PA30C_ABDACB_DACN1          _L_(2)
 #define PINMUX_PA30C_ABDACB_DACN1  ((PIN_PA30C_ABDACB_DACN1 << 16) | MUX_PA30C_ABDACB_DACN1)
-#define GPIO_PA30C_ABDACB_DACN1  _UL(1 << 30)
-#define PIN_PB05C_ABDACB_DACN1         _L(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
-#define MUX_PB05C_ABDACB_DACN1          _L(2)
+#define GPIO_PA30C_ABDACB_DACN1  _UL_(1 << 30)
+#define PIN_PB05C_ABDACB_DACN1         _L_(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
+#define MUX_PB05C_ABDACB_DACN1          _L_(2)
 #define PINMUX_PB05C_ABDACB_DACN1  ((PIN_PB05C_ABDACB_DACN1 << 16) | MUX_PB05C_ABDACB_DACN1)
-#define GPIO_PB05C_ABDACB_DACN1  _UL(1 <<  5)
-#define PIN_PC14C_ABDACB_DACN1         _L(78) /**< \brief ABDACB signal: DACN1 on PC14 mux C */
-#define MUX_PC14C_ABDACB_DACN1          _L(2)
+#define GPIO_PB05C_ABDACB_DACN1  _UL_(1 <<  5)
+#define PIN_PC14C_ABDACB_DACN1         _L_(78) /**< \brief ABDACB signal: DACN1 on PC14 mux C */
+#define MUX_PC14C_ABDACB_DACN1          _L_(2)
 #define PINMUX_PC14C_ABDACB_DACN1  ((PIN_PC14C_ABDACB_DACN1 << 16) | MUX_PC14C_ABDACB_DACN1)
-#define GPIO_PC14C_ABDACB_DACN1  _UL(1 << 14)
-#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
-#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define GPIO_PC14C_ABDACB_DACN1  _UL_(1 << 14)
+#define PIN_PA20B_ABDACB_DACN1         _L_(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L_(1)
 #define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
-#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+#define GPIO_PA20B_ABDACB_DACN1  _UL_(1 << 20)
 /* ========== GPIO definition for PARC peripheral ========== */
-#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
-#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PIN_PA17D_PARC_PCCK            _L_(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L_(3)
 #define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
-#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
-#define PIN_PC21D_PARC_PCCK            _L(85) /**< \brief PARC signal: PCCK on PC21 mux D */
-#define MUX_PC21D_PARC_PCCK             _L(3)
+#define GPIO_PA17D_PARC_PCCK     _UL_(1 << 17)
+#define PIN_PC21D_PARC_PCCK            _L_(85) /**< \brief PARC signal: PCCK on PC21 mux D */
+#define MUX_PC21D_PARC_PCCK             _L_(3)
 #define PINMUX_PC21D_PARC_PCCK     ((PIN_PC21D_PARC_PCCK << 16) | MUX_PC21D_PARC_PCCK)
-#define GPIO_PC21D_PARC_PCCK     _UL(1 << 21)
-#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
-#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define GPIO_PC21D_PARC_PCCK     _UL_(1 << 21)
+#define PIN_PA09D_PARC_PCDATA0          _L_(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L_(3)
 #define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
-#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
-#define PIN_PC24D_PARC_PCDATA0         _L(88) /**< \brief PARC signal: PCDATA0 on PC24 mux D */
-#define MUX_PC24D_PARC_PCDATA0          _L(3)
+#define GPIO_PA09D_PARC_PCDATA0  _UL_(1 <<  9)
+#define PIN_PC24D_PARC_PCDATA0         _L_(88) /**< \brief PARC signal: PCDATA0 on PC24 mux D */
+#define MUX_PC24D_PARC_PCDATA0          _L_(3)
 #define PINMUX_PC24D_PARC_PCDATA0  ((PIN_PC24D_PARC_PCDATA0 << 16) | MUX_PC24D_PARC_PCDATA0)
-#define GPIO_PC24D_PARC_PCDATA0  _UL(1 << 24)
-#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
-#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define GPIO_PC24D_PARC_PCDATA0  _UL_(1 << 24)
+#define PIN_PA10D_PARC_PCDATA1         _L_(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L_(3)
 #define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
-#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
-#define PIN_PC25D_PARC_PCDATA1         _L(89) /**< \brief PARC signal: PCDATA1 on PC25 mux D */
-#define MUX_PC25D_PARC_PCDATA1          _L(3)
+#define GPIO_PA10D_PARC_PCDATA1  _UL_(1 << 10)
+#define PIN_PC25D_PARC_PCDATA1         _L_(89) /**< \brief PARC signal: PCDATA1 on PC25 mux D */
+#define MUX_PC25D_PARC_PCDATA1          _L_(3)
 #define PINMUX_PC25D_PARC_PCDATA1  ((PIN_PC25D_PARC_PCDATA1 << 16) | MUX_PC25D_PARC_PCDATA1)
-#define GPIO_PC25D_PARC_PCDATA1  _UL(1 << 25)
-#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
-#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define GPIO_PC25D_PARC_PCDATA1  _UL_(1 << 25)
+#define PIN_PA11D_PARC_PCDATA2         _L_(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L_(3)
 #define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
-#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
-#define PIN_PC26D_PARC_PCDATA2         _L(90) /**< \brief PARC signal: PCDATA2 on PC26 mux D */
-#define MUX_PC26D_PARC_PCDATA2          _L(3)
+#define GPIO_PA11D_PARC_PCDATA2  _UL_(1 << 11)
+#define PIN_PC26D_PARC_PCDATA2         _L_(90) /**< \brief PARC signal: PCDATA2 on PC26 mux D */
+#define MUX_PC26D_PARC_PCDATA2          _L_(3)
 #define PINMUX_PC26D_PARC_PCDATA2  ((PIN_PC26D_PARC_PCDATA2 << 16) | MUX_PC26D_PARC_PCDATA2)
-#define GPIO_PC26D_PARC_PCDATA2  _UL(1 << 26)
-#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
-#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define GPIO_PC26D_PARC_PCDATA2  _UL_(1 << 26)
+#define PIN_PA12D_PARC_PCDATA3         _L_(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L_(3)
 #define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
-#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
-#define PIN_PC27D_PARC_PCDATA3         _L(91) /**< \brief PARC signal: PCDATA3 on PC27 mux D */
-#define MUX_PC27D_PARC_PCDATA3          _L(3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL_(1 << 12)
+#define PIN_PC27D_PARC_PCDATA3         _L_(91) /**< \brief PARC signal: PCDATA3 on PC27 mux D */
+#define MUX_PC27D_PARC_PCDATA3          _L_(3)
 #define PINMUX_PC27D_PARC_PCDATA3  ((PIN_PC27D_PARC_PCDATA3 << 16) | MUX_PC27D_PARC_PCDATA3)
-#define GPIO_PC27D_PARC_PCDATA3  _UL(1 << 27)
-#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
-#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define GPIO_PC27D_PARC_PCDATA3  _UL_(1 << 27)
+#define PIN_PA13D_PARC_PCDATA4         _L_(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L_(3)
 #define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
-#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
-#define PIN_PC28D_PARC_PCDATA4         _L(92) /**< \brief PARC signal: PCDATA4 on PC28 mux D */
-#define MUX_PC28D_PARC_PCDATA4          _L(3)
+#define GPIO_PA13D_PARC_PCDATA4  _UL_(1 << 13)
+#define PIN_PC28D_PARC_PCDATA4         _L_(92) /**< \brief PARC signal: PCDATA4 on PC28 mux D */
+#define MUX_PC28D_PARC_PCDATA4          _L_(3)
 #define PINMUX_PC28D_PARC_PCDATA4  ((PIN_PC28D_PARC_PCDATA4 << 16) | MUX_PC28D_PARC_PCDATA4)
-#define GPIO_PC28D_PARC_PCDATA4  _UL(1 << 28)
-#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
-#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define GPIO_PC28D_PARC_PCDATA4  _UL_(1 << 28)
+#define PIN_PA14D_PARC_PCDATA5         _L_(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L_(3)
 #define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
-#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
-#define PIN_PC29D_PARC_PCDATA5         _L(93) /**< \brief PARC signal: PCDATA5 on PC29 mux D */
-#define MUX_PC29D_PARC_PCDATA5          _L(3)
+#define GPIO_PA14D_PARC_PCDATA5  _UL_(1 << 14)
+#define PIN_PC29D_PARC_PCDATA5         _L_(93) /**< \brief PARC signal: PCDATA5 on PC29 mux D */
+#define MUX_PC29D_PARC_PCDATA5          _L_(3)
 #define PINMUX_PC29D_PARC_PCDATA5  ((PIN_PC29D_PARC_PCDATA5 << 16) | MUX_PC29D_PARC_PCDATA5)
-#define GPIO_PC29D_PARC_PCDATA5  _UL(1 << 29)
-#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
-#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define GPIO_PC29D_PARC_PCDATA5  _UL_(1 << 29)
+#define PIN_PA15D_PARC_PCDATA6         _L_(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L_(3)
 #define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
-#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
-#define PIN_PC30D_PARC_PCDATA6         _L(94) /**< \brief PARC signal: PCDATA6 on PC30 mux D */
-#define MUX_PC30D_PARC_PCDATA6          _L(3)
+#define GPIO_PA15D_PARC_PCDATA6  _UL_(1 << 15)
+#define PIN_PC30D_PARC_PCDATA6         _L_(94) /**< \brief PARC signal: PCDATA6 on PC30 mux D */
+#define MUX_PC30D_PARC_PCDATA6          _L_(3)
 #define PINMUX_PC30D_PARC_PCDATA6  ((PIN_PC30D_PARC_PCDATA6 << 16) | MUX_PC30D_PARC_PCDATA6)
-#define GPIO_PC30D_PARC_PCDATA6  _UL(1 << 30)
-#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
-#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define GPIO_PC30D_PARC_PCDATA6  _UL_(1 << 30)
+#define PIN_PA16D_PARC_PCDATA7         _L_(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L_(3)
 #define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
-#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
-#define PIN_PC31D_PARC_PCDATA7         _L(95) /**< \brief PARC signal: PCDATA7 on PC31 mux D */
-#define MUX_PC31D_PARC_PCDATA7          _L(3)
+#define GPIO_PA16D_PARC_PCDATA7  _UL_(1 << 16)
+#define PIN_PC31D_PARC_PCDATA7         _L_(95) /**< \brief PARC signal: PCDATA7 on PC31 mux D */
+#define MUX_PC31D_PARC_PCDATA7          _L_(3)
 #define PINMUX_PC31D_PARC_PCDATA7  ((PIN_PC31D_PARC_PCDATA7 << 16) | MUX_PC31D_PARC_PCDATA7)
-#define GPIO_PC31D_PARC_PCDATA7  _UL(1 << 31)
-#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
-#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define GPIO_PC31D_PARC_PCDATA7  _UL_(1 << 31)
+#define PIN_PA18D_PARC_PCEN1           _L_(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L_(3)
 #define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
-#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
-#define PIN_PC22D_PARC_PCEN1           _L(86) /**< \brief PARC signal: PCEN1 on PC22 mux D */
-#define MUX_PC22D_PARC_PCEN1            _L(3)
+#define GPIO_PA18D_PARC_PCEN1    _UL_(1 << 18)
+#define PIN_PC22D_PARC_PCEN1           _L_(86) /**< \brief PARC signal: PCEN1 on PC22 mux D */
+#define MUX_PC22D_PARC_PCEN1            _L_(3)
 #define PINMUX_PC22D_PARC_PCEN1    ((PIN_PC22D_PARC_PCEN1 << 16) | MUX_PC22D_PARC_PCEN1)
-#define GPIO_PC22D_PARC_PCEN1    _UL(1 << 22)
-#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
-#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define GPIO_PC22D_PARC_PCEN1    _UL_(1 << 22)
+#define PIN_PA19D_PARC_PCEN2           _L_(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L_(3)
 #define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
-#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
-#define PIN_PC23D_PARC_PCEN2           _L(87) /**< \brief PARC signal: PCEN2 on PC23 mux D */
-#define MUX_PC23D_PARC_PCEN2            _L(3)
+#define GPIO_PA19D_PARC_PCEN2    _UL_(1 << 19)
+#define PIN_PC23D_PARC_PCEN2           _L_(87) /**< \brief PARC signal: PCEN2 on PC23 mux D */
+#define MUX_PC23D_PARC_PCEN2            _L_(3)
 #define PINMUX_PC23D_PARC_PCEN2    ((PIN_PC23D_PARC_PCEN2 << 16) | MUX_PC23D_PARC_PCEN2)
-#define GPIO_PC23D_PARC_PCEN2    _UL(1 << 23)
+#define GPIO_PC23D_PARC_PCEN2    _UL_(1 << 23)
 /* ========== GPIO definition for CATB peripheral ========== */
-#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
-#define MUX_PA02G_CATB_DIS              _L(6)
+#define PIN_PA02G_CATB_DIS              _L_(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L_(6)
 #define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
-#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
-#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
-#define MUX_PA12G_CATB_DIS              _L(6)
+#define GPIO_PA02G_CATB_DIS      _UL_(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L_(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L_(6)
 #define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
-#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
-#define MUX_PA23G_CATB_DIS              _L(6)
+#define GPIO_PA12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L_(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L_(6)
 #define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
-#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
-#define PIN_PA31G_CATB_DIS             _L(31) /**< \brief CATB signal: DIS on PA31 mux G */
-#define MUX_PA31G_CATB_DIS              _L(6)
+#define GPIO_PA23G_CATB_DIS      _UL_(1 << 23)
+#define PIN_PA31G_CATB_DIS             _L_(31) /**< \brief CATB signal: DIS on PA31 mux G */
+#define MUX_PA31G_CATB_DIS              _L_(6)
 #define PINMUX_PA31G_CATB_DIS      ((PIN_PA31G_CATB_DIS << 16) | MUX_PA31G_CATB_DIS)
-#define GPIO_PA31G_CATB_DIS      _UL(1 << 31)
-#define PIN_PB03G_CATB_DIS             _L(35) /**< \brief CATB signal: DIS on PB03 mux G */
-#define MUX_PB03G_CATB_DIS              _L(6)
+#define GPIO_PA31G_CATB_DIS      _UL_(1 << 31)
+#define PIN_PB03G_CATB_DIS             _L_(35) /**< \brief CATB signal: DIS on PB03 mux G */
+#define MUX_PB03G_CATB_DIS              _L_(6)
 #define PINMUX_PB03G_CATB_DIS      ((PIN_PB03G_CATB_DIS << 16) | MUX_PB03G_CATB_DIS)
-#define GPIO_PB03G_CATB_DIS      _UL(1 <<  3)
-#define PIN_PB12G_CATB_DIS             _L(44) /**< \brief CATB signal: DIS on PB12 mux G */
-#define MUX_PB12G_CATB_DIS              _L(6)
+#define GPIO_PB03G_CATB_DIS      _UL_(1 <<  3)
+#define PIN_PB12G_CATB_DIS             _L_(44) /**< \brief CATB signal: DIS on PB12 mux G */
+#define MUX_PB12G_CATB_DIS              _L_(6)
 #define PINMUX_PB12G_CATB_DIS      ((PIN_PB12G_CATB_DIS << 16) | MUX_PB12G_CATB_DIS)
-#define GPIO_PB12G_CATB_DIS      _UL(1 << 12)
-#define PIN_PC05G_CATB_DIS             _L(69) /**< \brief CATB signal: DIS on PC05 mux G */
-#define MUX_PC05G_CATB_DIS              _L(6)
+#define GPIO_PB12G_CATB_DIS      _UL_(1 << 12)
+#define PIN_PC05G_CATB_DIS             _L_(69) /**< \brief CATB signal: DIS on PC05 mux G */
+#define MUX_PC05G_CATB_DIS              _L_(6)
 #define PINMUX_PC05G_CATB_DIS      ((PIN_PC05G_CATB_DIS << 16) | MUX_PC05G_CATB_DIS)
-#define GPIO_PC05G_CATB_DIS      _UL(1 <<  5)
-#define PIN_PC14G_CATB_DIS             _L(78) /**< \brief CATB signal: DIS on PC14 mux G */
-#define MUX_PC14G_CATB_DIS              _L(6)
+#define GPIO_PC05G_CATB_DIS      _UL_(1 <<  5)
+#define PIN_PC14G_CATB_DIS             _L_(78) /**< \brief CATB signal: DIS on PC14 mux G */
+#define MUX_PC14G_CATB_DIS              _L_(6)
 #define PINMUX_PC14G_CATB_DIS      ((PIN_PC14G_CATB_DIS << 16) | MUX_PC14G_CATB_DIS)
-#define GPIO_PC14G_CATB_DIS      _UL(1 << 14)
-#define PIN_PC23G_CATB_DIS             _L(87) /**< \brief CATB signal: DIS on PC23 mux G */
-#define MUX_PC23G_CATB_DIS              _L(6)
+#define GPIO_PC14G_CATB_DIS      _UL_(1 << 14)
+#define PIN_PC23G_CATB_DIS             _L_(87) /**< \brief CATB signal: DIS on PC23 mux G */
+#define MUX_PC23G_CATB_DIS              _L_(6)
 #define PINMUX_PC23G_CATB_DIS      ((PIN_PC23G_CATB_DIS << 16) | MUX_PC23G_CATB_DIS)
-#define GPIO_PC23G_CATB_DIS      _UL(1 << 23)
-#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
-#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define GPIO_PC23G_CATB_DIS      _UL_(1 << 23)
+#define PIN_PA04G_CATB_SENSE0           _L_(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L_(6)
 #define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
-#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
-#define PIN_PA27G_CATB_SENSE0          _L(27) /**< \brief CATB signal: SENSE0 on PA27 mux G */
-#define MUX_PA27G_CATB_SENSE0           _L(6)
+#define GPIO_PA04G_CATB_SENSE0   _UL_(1 <<  4)
+#define PIN_PA27G_CATB_SENSE0          _L_(27) /**< \brief CATB signal: SENSE0 on PA27 mux G */
+#define MUX_PA27G_CATB_SENSE0           _L_(6)
 #define PINMUX_PA27G_CATB_SENSE0   ((PIN_PA27G_CATB_SENSE0 << 16) | MUX_PA27G_CATB_SENSE0)
-#define GPIO_PA27G_CATB_SENSE0   _UL(1 << 27)
-#define PIN_PB13G_CATB_SENSE0          _L(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
-#define MUX_PB13G_CATB_SENSE0           _L(6)
+#define GPIO_PA27G_CATB_SENSE0   _UL_(1 << 27)
+#define PIN_PB13G_CATB_SENSE0          _L_(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
+#define MUX_PB13G_CATB_SENSE0           _L_(6)
 #define PINMUX_PB13G_CATB_SENSE0   ((PIN_PB13G_CATB_SENSE0 << 16) | MUX_PB13G_CATB_SENSE0)
-#define GPIO_PB13G_CATB_SENSE0   _UL(1 << 13)
-#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
-#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define GPIO_PB13G_CATB_SENSE0   _UL_(1 << 13)
+#define PIN_PA05G_CATB_SENSE1           _L_(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L_(6)
 #define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
-#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
-#define PIN_PA28G_CATB_SENSE1          _L(28) /**< \brief CATB signal: SENSE1 on PA28 mux G */
-#define MUX_PA28G_CATB_SENSE1           _L(6)
+#define GPIO_PA05G_CATB_SENSE1   _UL_(1 <<  5)
+#define PIN_PA28G_CATB_SENSE1          _L_(28) /**< \brief CATB signal: SENSE1 on PA28 mux G */
+#define MUX_PA28G_CATB_SENSE1           _L_(6)
 #define PINMUX_PA28G_CATB_SENSE1   ((PIN_PA28G_CATB_SENSE1 << 16) | MUX_PA28G_CATB_SENSE1)
-#define GPIO_PA28G_CATB_SENSE1   _UL(1 << 28)
-#define PIN_PB14G_CATB_SENSE1          _L(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
-#define MUX_PB14G_CATB_SENSE1           _L(6)
+#define GPIO_PA28G_CATB_SENSE1   _UL_(1 << 28)
+#define PIN_PB14G_CATB_SENSE1          _L_(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
+#define MUX_PB14G_CATB_SENSE1           _L_(6)
 #define PINMUX_PB14G_CATB_SENSE1   ((PIN_PB14G_CATB_SENSE1 << 16) | MUX_PB14G_CATB_SENSE1)
-#define GPIO_PB14G_CATB_SENSE1   _UL(1 << 14)
-#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
-#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define GPIO_PB14G_CATB_SENSE1   _UL_(1 << 14)
+#define PIN_PA06G_CATB_SENSE2           _L_(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L_(6)
 #define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
-#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
-#define PIN_PA29G_CATB_SENSE2          _L(29) /**< \brief CATB signal: SENSE2 on PA29 mux G */
-#define MUX_PA29G_CATB_SENSE2           _L(6)
+#define GPIO_PA06G_CATB_SENSE2   _UL_(1 <<  6)
+#define PIN_PA29G_CATB_SENSE2          _L_(29) /**< \brief CATB signal: SENSE2 on PA29 mux G */
+#define MUX_PA29G_CATB_SENSE2           _L_(6)
 #define PINMUX_PA29G_CATB_SENSE2   ((PIN_PA29G_CATB_SENSE2 << 16) | MUX_PA29G_CATB_SENSE2)
-#define GPIO_PA29G_CATB_SENSE2   _UL(1 << 29)
-#define PIN_PB15G_CATB_SENSE2          _L(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
-#define MUX_PB15G_CATB_SENSE2           _L(6)
+#define GPIO_PA29G_CATB_SENSE2   _UL_(1 << 29)
+#define PIN_PB15G_CATB_SENSE2          _L_(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
+#define MUX_PB15G_CATB_SENSE2           _L_(6)
 #define PINMUX_PB15G_CATB_SENSE2   ((PIN_PB15G_CATB_SENSE2 << 16) | MUX_PB15G_CATB_SENSE2)
-#define GPIO_PB15G_CATB_SENSE2   _UL(1 << 15)
-#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
-#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define GPIO_PB15G_CATB_SENSE2   _UL_(1 << 15)
+#define PIN_PA07G_CATB_SENSE3           _L_(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L_(6)
 #define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
-#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
-#define PIN_PA30G_CATB_SENSE3          _L(30) /**< \brief CATB signal: SENSE3 on PA30 mux G */
-#define MUX_PA30G_CATB_SENSE3           _L(6)
+#define GPIO_PA07G_CATB_SENSE3   _UL_(1 <<  7)
+#define PIN_PA30G_CATB_SENSE3          _L_(30) /**< \brief CATB signal: SENSE3 on PA30 mux G */
+#define MUX_PA30G_CATB_SENSE3           _L_(6)
 #define PINMUX_PA30G_CATB_SENSE3   ((PIN_PA30G_CATB_SENSE3 << 16) | MUX_PA30G_CATB_SENSE3)
-#define GPIO_PA30G_CATB_SENSE3   _UL(1 << 30)
-#define PIN_PC00G_CATB_SENSE3          _L(64) /**< \brief CATB signal: SENSE3 on PC00 mux G */
-#define MUX_PC00G_CATB_SENSE3           _L(6)
+#define GPIO_PA30G_CATB_SENSE3   _UL_(1 << 30)
+#define PIN_PC00G_CATB_SENSE3          _L_(64) /**< \brief CATB signal: SENSE3 on PC00 mux G */
+#define MUX_PC00G_CATB_SENSE3           _L_(6)
 #define PINMUX_PC00G_CATB_SENSE3   ((PIN_PC00G_CATB_SENSE3 << 16) | MUX_PC00G_CATB_SENSE3)
-#define GPIO_PC00G_CATB_SENSE3   _UL(1 <<  0)
-#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
-#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define GPIO_PC00G_CATB_SENSE3   _UL_(1 <<  0)
+#define PIN_PA08G_CATB_SENSE4           _L_(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L_(6)
 #define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
-#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
-#define PIN_PC01G_CATB_SENSE4          _L(65) /**< \brief CATB signal: SENSE4 on PC01 mux G */
-#define MUX_PC01G_CATB_SENSE4           _L(6)
+#define GPIO_PA08G_CATB_SENSE4   _UL_(1 <<  8)
+#define PIN_PC01G_CATB_SENSE4          _L_(65) /**< \brief CATB signal: SENSE4 on PC01 mux G */
+#define MUX_PC01G_CATB_SENSE4           _L_(6)
 #define PINMUX_PC01G_CATB_SENSE4   ((PIN_PC01G_CATB_SENSE4 << 16) | MUX_PC01G_CATB_SENSE4)
-#define GPIO_PC01G_CATB_SENSE4   _UL(1 <<  1)
-#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
-#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define GPIO_PC01G_CATB_SENSE4   _UL_(1 <<  1)
+#define PIN_PA09G_CATB_SENSE5           _L_(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L_(6)
 #define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
-#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
-#define PIN_PC02G_CATB_SENSE5          _L(66) /**< \brief CATB signal: SENSE5 on PC02 mux G */
-#define MUX_PC02G_CATB_SENSE5           _L(6)
+#define GPIO_PA09G_CATB_SENSE5   _UL_(1 <<  9)
+#define PIN_PC02G_CATB_SENSE5          _L_(66) /**< \brief CATB signal: SENSE5 on PC02 mux G */
+#define MUX_PC02G_CATB_SENSE5           _L_(6)
 #define PINMUX_PC02G_CATB_SENSE5   ((PIN_PC02G_CATB_SENSE5 << 16) | MUX_PC02G_CATB_SENSE5)
-#define GPIO_PC02G_CATB_SENSE5   _UL(1 <<  2)
-#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
-#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define GPIO_PC02G_CATB_SENSE5   _UL_(1 <<  2)
+#define PIN_PA10G_CATB_SENSE6          _L_(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L_(6)
 #define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
-#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
-#define PIN_PC03G_CATB_SENSE6          _L(67) /**< \brief CATB signal: SENSE6 on PC03 mux G */
-#define MUX_PC03G_CATB_SENSE6           _L(6)
+#define GPIO_PA10G_CATB_SENSE6   _UL_(1 << 10)
+#define PIN_PC03G_CATB_SENSE6          _L_(67) /**< \brief CATB signal: SENSE6 on PC03 mux G */
+#define MUX_PC03G_CATB_SENSE6           _L_(6)
 #define PINMUX_PC03G_CATB_SENSE6   ((PIN_PC03G_CATB_SENSE6 << 16) | MUX_PC03G_CATB_SENSE6)
-#define GPIO_PC03G_CATB_SENSE6   _UL(1 <<  3)
-#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
-#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define GPIO_PC03G_CATB_SENSE6   _UL_(1 <<  3)
+#define PIN_PA11G_CATB_SENSE7          _L_(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L_(6)
 #define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
-#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
-#define PIN_PC04G_CATB_SENSE7          _L(68) /**< \brief CATB signal: SENSE7 on PC04 mux G */
-#define MUX_PC04G_CATB_SENSE7           _L(6)
+#define GPIO_PA11G_CATB_SENSE7   _UL_(1 << 11)
+#define PIN_PC04G_CATB_SENSE7          _L_(68) /**< \brief CATB signal: SENSE7 on PC04 mux G */
+#define MUX_PC04G_CATB_SENSE7           _L_(6)
 #define PINMUX_PC04G_CATB_SENSE7   ((PIN_PC04G_CATB_SENSE7 << 16) | MUX_PC04G_CATB_SENSE7)
-#define GPIO_PC04G_CATB_SENSE7   _UL(1 <<  4)
-#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
-#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define GPIO_PC04G_CATB_SENSE7   _UL_(1 <<  4)
+#define PIN_PA13G_CATB_SENSE8          _L_(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L_(6)
 #define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
-#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
-#define PIN_PC06G_CATB_SENSE8          _L(70) /**< \brief CATB signal: SENSE8 on PC06 mux G */
-#define MUX_PC06G_CATB_SENSE8           _L(6)
+#define GPIO_PA13G_CATB_SENSE8   _UL_(1 << 13)
+#define PIN_PC06G_CATB_SENSE8          _L_(70) /**< \brief CATB signal: SENSE8 on PC06 mux G */
+#define MUX_PC06G_CATB_SENSE8           _L_(6)
 #define PINMUX_PC06G_CATB_SENSE8   ((PIN_PC06G_CATB_SENSE8 << 16) | MUX_PC06G_CATB_SENSE8)
-#define GPIO_PC06G_CATB_SENSE8   _UL(1 <<  6)
-#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
-#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define GPIO_PC06G_CATB_SENSE8   _UL_(1 <<  6)
+#define PIN_PA14G_CATB_SENSE9          _L_(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L_(6)
 #define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
-#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
-#define PIN_PC07G_CATB_SENSE9          _L(71) /**< \brief CATB signal: SENSE9 on PC07 mux G */
-#define MUX_PC07G_CATB_SENSE9           _L(6)
+#define GPIO_PA14G_CATB_SENSE9   _UL_(1 << 14)
+#define PIN_PC07G_CATB_SENSE9          _L_(71) /**< \brief CATB signal: SENSE9 on PC07 mux G */
+#define MUX_PC07G_CATB_SENSE9           _L_(6)
 #define PINMUX_PC07G_CATB_SENSE9   ((PIN_PC07G_CATB_SENSE9 << 16) | MUX_PC07G_CATB_SENSE9)
-#define GPIO_PC07G_CATB_SENSE9   _UL(1 <<  7)
-#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
-#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define GPIO_PC07G_CATB_SENSE9   _UL_(1 <<  7)
+#define PIN_PA15G_CATB_SENSE10         _L_(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L_(6)
 #define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
-#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
-#define PIN_PC08G_CATB_SENSE10         _L(72) /**< \brief CATB signal: SENSE10 on PC08 mux G */
-#define MUX_PC08G_CATB_SENSE10          _L(6)
+#define GPIO_PA15G_CATB_SENSE10  _UL_(1 << 15)
+#define PIN_PC08G_CATB_SENSE10         _L_(72) /**< \brief CATB signal: SENSE10 on PC08 mux G */
+#define MUX_PC08G_CATB_SENSE10          _L_(6)
 #define PINMUX_PC08G_CATB_SENSE10  ((PIN_PC08G_CATB_SENSE10 << 16) | MUX_PC08G_CATB_SENSE10)
-#define GPIO_PC08G_CATB_SENSE10  _UL(1 <<  8)
-#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
-#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define GPIO_PC08G_CATB_SENSE10  _UL_(1 <<  8)
+#define PIN_PA16G_CATB_SENSE11         _L_(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L_(6)
 #define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
-#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
-#define PIN_PC09G_CATB_SENSE11         _L(73) /**< \brief CATB signal: SENSE11 on PC09 mux G */
-#define MUX_PC09G_CATB_SENSE11          _L(6)
+#define GPIO_PA16G_CATB_SENSE11  _UL_(1 << 16)
+#define PIN_PC09G_CATB_SENSE11         _L_(73) /**< \brief CATB signal: SENSE11 on PC09 mux G */
+#define MUX_PC09G_CATB_SENSE11          _L_(6)
 #define PINMUX_PC09G_CATB_SENSE11  ((PIN_PC09G_CATB_SENSE11 << 16) | MUX_PC09G_CATB_SENSE11)
-#define GPIO_PC09G_CATB_SENSE11  _UL(1 <<  9)
-#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
-#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define GPIO_PC09G_CATB_SENSE11  _UL_(1 <<  9)
+#define PIN_PA17G_CATB_SENSE12         _L_(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L_(6)
 #define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
-#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
-#define PIN_PC10G_CATB_SENSE12         _L(74) /**< \brief CATB signal: SENSE12 on PC10 mux G */
-#define MUX_PC10G_CATB_SENSE12          _L(6)
+#define GPIO_PA17G_CATB_SENSE12  _UL_(1 << 17)
+#define PIN_PC10G_CATB_SENSE12         _L_(74) /**< \brief CATB signal: SENSE12 on PC10 mux G */
+#define MUX_PC10G_CATB_SENSE12          _L_(6)
 #define PINMUX_PC10G_CATB_SENSE12  ((PIN_PC10G_CATB_SENSE12 << 16) | MUX_PC10G_CATB_SENSE12)
-#define GPIO_PC10G_CATB_SENSE12  _UL(1 << 10)
-#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
-#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define GPIO_PC10G_CATB_SENSE12  _UL_(1 << 10)
+#define PIN_PA18G_CATB_SENSE13         _L_(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L_(6)
 #define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
-#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
-#define PIN_PC11G_CATB_SENSE13         _L(75) /**< \brief CATB signal: SENSE13 on PC11 mux G */
-#define MUX_PC11G_CATB_SENSE13          _L(6)
+#define GPIO_PA18G_CATB_SENSE13  _UL_(1 << 18)
+#define PIN_PC11G_CATB_SENSE13         _L_(75) /**< \brief CATB signal: SENSE13 on PC11 mux G */
+#define MUX_PC11G_CATB_SENSE13          _L_(6)
 #define PINMUX_PC11G_CATB_SENSE13  ((PIN_PC11G_CATB_SENSE13 << 16) | MUX_PC11G_CATB_SENSE13)
-#define GPIO_PC11G_CATB_SENSE13  _UL(1 << 11)
-#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
-#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define GPIO_PC11G_CATB_SENSE13  _UL_(1 << 11)
+#define PIN_PA19G_CATB_SENSE14         _L_(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L_(6)
 #define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
-#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
-#define PIN_PC12G_CATB_SENSE14         _L(76) /**< \brief CATB signal: SENSE14 on PC12 mux G */
-#define MUX_PC12G_CATB_SENSE14          _L(6)
+#define GPIO_PA19G_CATB_SENSE14  _UL_(1 << 19)
+#define PIN_PC12G_CATB_SENSE14         _L_(76) /**< \brief CATB signal: SENSE14 on PC12 mux G */
+#define MUX_PC12G_CATB_SENSE14          _L_(6)
 #define PINMUX_PC12G_CATB_SENSE14  ((PIN_PC12G_CATB_SENSE14 << 16) | MUX_PC12G_CATB_SENSE14)
-#define GPIO_PC12G_CATB_SENSE14  _UL(1 << 12)
-#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
-#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define GPIO_PC12G_CATB_SENSE14  _UL_(1 << 12)
+#define PIN_PA20G_CATB_SENSE15         _L_(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L_(6)
 #define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
-#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
-#define PIN_PC13G_CATB_SENSE15         _L(77) /**< \brief CATB signal: SENSE15 on PC13 mux G */
-#define MUX_PC13G_CATB_SENSE15          _L(6)
+#define GPIO_PA20G_CATB_SENSE15  _UL_(1 << 20)
+#define PIN_PC13G_CATB_SENSE15         _L_(77) /**< \brief CATB signal: SENSE15 on PC13 mux G */
+#define MUX_PC13G_CATB_SENSE15          _L_(6)
 #define PINMUX_PC13G_CATB_SENSE15  ((PIN_PC13G_CATB_SENSE15 << 16) | MUX_PC13G_CATB_SENSE15)
-#define GPIO_PC13G_CATB_SENSE15  _UL(1 << 13)
-#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
-#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define GPIO_PC13G_CATB_SENSE15  _UL_(1 << 13)
+#define PIN_PA21G_CATB_SENSE16         _L_(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L_(6)
 #define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
-#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
-#define PIN_PC15G_CATB_SENSE16         _L(79) /**< \brief CATB signal: SENSE16 on PC15 mux G */
-#define MUX_PC15G_CATB_SENSE16          _L(6)
+#define GPIO_PA21G_CATB_SENSE16  _UL_(1 << 21)
+#define PIN_PC15G_CATB_SENSE16         _L_(79) /**< \brief CATB signal: SENSE16 on PC15 mux G */
+#define MUX_PC15G_CATB_SENSE16          _L_(6)
 #define PINMUX_PC15G_CATB_SENSE16  ((PIN_PC15G_CATB_SENSE16 << 16) | MUX_PC15G_CATB_SENSE16)
-#define GPIO_PC15G_CATB_SENSE16  _UL(1 << 15)
-#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
-#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define GPIO_PC15G_CATB_SENSE16  _UL_(1 << 15)
+#define PIN_PA22G_CATB_SENSE17         _L_(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L_(6)
 #define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
-#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
-#define PIN_PC16G_CATB_SENSE17         _L(80) /**< \brief CATB signal: SENSE17 on PC16 mux G */
-#define MUX_PC16G_CATB_SENSE17          _L(6)
+#define GPIO_PA22G_CATB_SENSE17  _UL_(1 << 22)
+#define PIN_PC16G_CATB_SENSE17         _L_(80) /**< \brief CATB signal: SENSE17 on PC16 mux G */
+#define MUX_PC16G_CATB_SENSE17          _L_(6)
 #define PINMUX_PC16G_CATB_SENSE17  ((PIN_PC16G_CATB_SENSE17 << 16) | MUX_PC16G_CATB_SENSE17)
-#define GPIO_PC16G_CATB_SENSE17  _UL(1 << 16)
-#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
-#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define GPIO_PC16G_CATB_SENSE17  _UL_(1 << 16)
+#define PIN_PA24G_CATB_SENSE18         _L_(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L_(6)
 #define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
-#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
-#define PIN_PC17G_CATB_SENSE18         _L(81) /**< \brief CATB signal: SENSE18 on PC17 mux G */
-#define MUX_PC17G_CATB_SENSE18          _L(6)
+#define GPIO_PA24G_CATB_SENSE18  _UL_(1 << 24)
+#define PIN_PC17G_CATB_SENSE18         _L_(81) /**< \brief CATB signal: SENSE18 on PC17 mux G */
+#define MUX_PC17G_CATB_SENSE18          _L_(6)
 #define PINMUX_PC17G_CATB_SENSE18  ((PIN_PC17G_CATB_SENSE18 << 16) | MUX_PC17G_CATB_SENSE18)
-#define GPIO_PC17G_CATB_SENSE18  _UL(1 << 17)
-#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
-#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define GPIO_PC17G_CATB_SENSE18  _UL_(1 << 17)
+#define PIN_PA25G_CATB_SENSE19         _L_(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L_(6)
 #define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
-#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
-#define PIN_PC18G_CATB_SENSE19         _L(82) /**< \brief CATB signal: SENSE19 on PC18 mux G */
-#define MUX_PC18G_CATB_SENSE19          _L(6)
+#define GPIO_PA25G_CATB_SENSE19  _UL_(1 << 25)
+#define PIN_PC18G_CATB_SENSE19         _L_(82) /**< \brief CATB signal: SENSE19 on PC18 mux G */
+#define MUX_PC18G_CATB_SENSE19          _L_(6)
 #define PINMUX_PC18G_CATB_SENSE19  ((PIN_PC18G_CATB_SENSE19 << 16) | MUX_PC18G_CATB_SENSE19)
-#define GPIO_PC18G_CATB_SENSE19  _UL(1 << 18)
-#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
-#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define GPIO_PC18G_CATB_SENSE19  _UL_(1 << 18)
+#define PIN_PA26G_CATB_SENSE20         _L_(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L_(6)
 #define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
-#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
-#define PIN_PC19G_CATB_SENSE20         _L(83) /**< \brief CATB signal: SENSE20 on PC19 mux G */
-#define MUX_PC19G_CATB_SENSE20          _L(6)
+#define GPIO_PA26G_CATB_SENSE20  _UL_(1 << 26)
+#define PIN_PC19G_CATB_SENSE20         _L_(83) /**< \brief CATB signal: SENSE20 on PC19 mux G */
+#define MUX_PC19G_CATB_SENSE20          _L_(6)
 #define PINMUX_PC19G_CATB_SENSE20  ((PIN_PC19G_CATB_SENSE20 << 16) | MUX_PC19G_CATB_SENSE20)
-#define GPIO_PC19G_CATB_SENSE20  _UL(1 << 19)
-#define PIN_PB00G_CATB_SENSE21         _L(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
-#define MUX_PB00G_CATB_SENSE21          _L(6)
+#define GPIO_PC19G_CATB_SENSE20  _UL_(1 << 19)
+#define PIN_PB00G_CATB_SENSE21         _L_(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
+#define MUX_PB00G_CATB_SENSE21          _L_(6)
 #define PINMUX_PB00G_CATB_SENSE21  ((PIN_PB00G_CATB_SENSE21 << 16) | MUX_PB00G_CATB_SENSE21)
-#define GPIO_PB00G_CATB_SENSE21  _UL(1 <<  0)
-#define PIN_PC20G_CATB_SENSE21         _L(84) /**< \brief CATB signal: SENSE21 on PC20 mux G */
-#define MUX_PC20G_CATB_SENSE21          _L(6)
+#define GPIO_PB00G_CATB_SENSE21  _UL_(1 <<  0)
+#define PIN_PC20G_CATB_SENSE21         _L_(84) /**< \brief CATB signal: SENSE21 on PC20 mux G */
+#define MUX_PC20G_CATB_SENSE21          _L_(6)
 #define PINMUX_PC20G_CATB_SENSE21  ((PIN_PC20G_CATB_SENSE21 << 16) | MUX_PC20G_CATB_SENSE21)
-#define GPIO_PC20G_CATB_SENSE21  _UL(1 << 20)
-#define PIN_PB01G_CATB_SENSE22         _L(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
-#define MUX_PB01G_CATB_SENSE22          _L(6)
+#define GPIO_PC20G_CATB_SENSE21  _UL_(1 << 20)
+#define PIN_PB01G_CATB_SENSE22         _L_(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
+#define MUX_PB01G_CATB_SENSE22          _L_(6)
 #define PINMUX_PB01G_CATB_SENSE22  ((PIN_PB01G_CATB_SENSE22 << 16) | MUX_PB01G_CATB_SENSE22)
-#define GPIO_PB01G_CATB_SENSE22  _UL(1 <<  1)
-#define PIN_PC21G_CATB_SENSE22         _L(85) /**< \brief CATB signal: SENSE22 on PC21 mux G */
-#define MUX_PC21G_CATB_SENSE22          _L(6)
+#define GPIO_PB01G_CATB_SENSE22  _UL_(1 <<  1)
+#define PIN_PC21G_CATB_SENSE22         _L_(85) /**< \brief CATB signal: SENSE22 on PC21 mux G */
+#define MUX_PC21G_CATB_SENSE22          _L_(6)
 #define PINMUX_PC21G_CATB_SENSE22  ((PIN_PC21G_CATB_SENSE22 << 16) | MUX_PC21G_CATB_SENSE22)
-#define GPIO_PC21G_CATB_SENSE22  _UL(1 << 21)
-#define PIN_PB02G_CATB_SENSE23         _L(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
-#define MUX_PB02G_CATB_SENSE23          _L(6)
+#define GPIO_PC21G_CATB_SENSE22  _UL_(1 << 21)
+#define PIN_PB02G_CATB_SENSE23         _L_(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
+#define MUX_PB02G_CATB_SENSE23          _L_(6)
 #define PINMUX_PB02G_CATB_SENSE23  ((PIN_PB02G_CATB_SENSE23 << 16) | MUX_PB02G_CATB_SENSE23)
-#define GPIO_PB02G_CATB_SENSE23  _UL(1 <<  2)
-#define PIN_PC22G_CATB_SENSE23         _L(86) /**< \brief CATB signal: SENSE23 on PC22 mux G */
-#define MUX_PC22G_CATB_SENSE23          _L(6)
+#define GPIO_PB02G_CATB_SENSE23  _UL_(1 <<  2)
+#define PIN_PC22G_CATB_SENSE23         _L_(86) /**< \brief CATB signal: SENSE23 on PC22 mux G */
+#define MUX_PC22G_CATB_SENSE23          _L_(6)
 #define PINMUX_PC22G_CATB_SENSE23  ((PIN_PC22G_CATB_SENSE23 << 16) | MUX_PC22G_CATB_SENSE23)
-#define GPIO_PC22G_CATB_SENSE23  _UL(1 << 22)
-#define PIN_PB04G_CATB_SENSE24         _L(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
-#define MUX_PB04G_CATB_SENSE24          _L(6)
+#define GPIO_PC22G_CATB_SENSE23  _UL_(1 << 22)
+#define PIN_PB04G_CATB_SENSE24         _L_(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
+#define MUX_PB04G_CATB_SENSE24          _L_(6)
 #define PINMUX_PB04G_CATB_SENSE24  ((PIN_PB04G_CATB_SENSE24 << 16) | MUX_PB04G_CATB_SENSE24)
-#define GPIO_PB04G_CATB_SENSE24  _UL(1 <<  4)
-#define PIN_PC24G_CATB_SENSE24         _L(88) /**< \brief CATB signal: SENSE24 on PC24 mux G */
-#define MUX_PC24G_CATB_SENSE24          _L(6)
+#define GPIO_PB04G_CATB_SENSE24  _UL_(1 <<  4)
+#define PIN_PC24G_CATB_SENSE24         _L_(88) /**< \brief CATB signal: SENSE24 on PC24 mux G */
+#define MUX_PC24G_CATB_SENSE24          _L_(6)
 #define PINMUX_PC24G_CATB_SENSE24  ((PIN_PC24G_CATB_SENSE24 << 16) | MUX_PC24G_CATB_SENSE24)
-#define GPIO_PC24G_CATB_SENSE24  _UL(1 << 24)
-#define PIN_PB05G_CATB_SENSE25         _L(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
-#define MUX_PB05G_CATB_SENSE25          _L(6)
+#define GPIO_PC24G_CATB_SENSE24  _UL_(1 << 24)
+#define PIN_PB05G_CATB_SENSE25         _L_(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
+#define MUX_PB05G_CATB_SENSE25          _L_(6)
 #define PINMUX_PB05G_CATB_SENSE25  ((PIN_PB05G_CATB_SENSE25 << 16) | MUX_PB05G_CATB_SENSE25)
-#define GPIO_PB05G_CATB_SENSE25  _UL(1 <<  5)
-#define PIN_PC25G_CATB_SENSE25         _L(89) /**< \brief CATB signal: SENSE25 on PC25 mux G */
-#define MUX_PC25G_CATB_SENSE25          _L(6)
+#define GPIO_PB05G_CATB_SENSE25  _UL_(1 <<  5)
+#define PIN_PC25G_CATB_SENSE25         _L_(89) /**< \brief CATB signal: SENSE25 on PC25 mux G */
+#define MUX_PC25G_CATB_SENSE25          _L_(6)
 #define PINMUX_PC25G_CATB_SENSE25  ((PIN_PC25G_CATB_SENSE25 << 16) | MUX_PC25G_CATB_SENSE25)
-#define GPIO_PC25G_CATB_SENSE25  _UL(1 << 25)
-#define PIN_PB06G_CATB_SENSE26         _L(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
-#define MUX_PB06G_CATB_SENSE26          _L(6)
+#define GPIO_PC25G_CATB_SENSE25  _UL_(1 << 25)
+#define PIN_PB06G_CATB_SENSE26         _L_(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
+#define MUX_PB06G_CATB_SENSE26          _L_(6)
 #define PINMUX_PB06G_CATB_SENSE26  ((PIN_PB06G_CATB_SENSE26 << 16) | MUX_PB06G_CATB_SENSE26)
-#define GPIO_PB06G_CATB_SENSE26  _UL(1 <<  6)
-#define PIN_PC26G_CATB_SENSE26         _L(90) /**< \brief CATB signal: SENSE26 on PC26 mux G */
-#define MUX_PC26G_CATB_SENSE26          _L(6)
+#define GPIO_PB06G_CATB_SENSE26  _UL_(1 <<  6)
+#define PIN_PC26G_CATB_SENSE26         _L_(90) /**< \brief CATB signal: SENSE26 on PC26 mux G */
+#define MUX_PC26G_CATB_SENSE26          _L_(6)
 #define PINMUX_PC26G_CATB_SENSE26  ((PIN_PC26G_CATB_SENSE26 << 16) | MUX_PC26G_CATB_SENSE26)
-#define GPIO_PC26G_CATB_SENSE26  _UL(1 << 26)
-#define PIN_PB07G_CATB_SENSE27         _L(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
-#define MUX_PB07G_CATB_SENSE27          _L(6)
+#define GPIO_PC26G_CATB_SENSE26  _UL_(1 << 26)
+#define PIN_PB07G_CATB_SENSE27         _L_(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
+#define MUX_PB07G_CATB_SENSE27          _L_(6)
 #define PINMUX_PB07G_CATB_SENSE27  ((PIN_PB07G_CATB_SENSE27 << 16) | MUX_PB07G_CATB_SENSE27)
-#define GPIO_PB07G_CATB_SENSE27  _UL(1 <<  7)
-#define PIN_PC27G_CATB_SENSE27         _L(91) /**< \brief CATB signal: SENSE27 on PC27 mux G */
-#define MUX_PC27G_CATB_SENSE27          _L(6)
+#define GPIO_PB07G_CATB_SENSE27  _UL_(1 <<  7)
+#define PIN_PC27G_CATB_SENSE27         _L_(91) /**< \brief CATB signal: SENSE27 on PC27 mux G */
+#define MUX_PC27G_CATB_SENSE27          _L_(6)
 #define PINMUX_PC27G_CATB_SENSE27  ((PIN_PC27G_CATB_SENSE27 << 16) | MUX_PC27G_CATB_SENSE27)
-#define GPIO_PC27G_CATB_SENSE27  _UL(1 << 27)
-#define PIN_PB08G_CATB_SENSE28         _L(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
-#define MUX_PB08G_CATB_SENSE28          _L(6)
+#define GPIO_PC27G_CATB_SENSE27  _UL_(1 << 27)
+#define PIN_PB08G_CATB_SENSE28         _L_(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
+#define MUX_PB08G_CATB_SENSE28          _L_(6)
 #define PINMUX_PB08G_CATB_SENSE28  ((PIN_PB08G_CATB_SENSE28 << 16) | MUX_PB08G_CATB_SENSE28)
-#define GPIO_PB08G_CATB_SENSE28  _UL(1 <<  8)
-#define PIN_PC28G_CATB_SENSE28         _L(92) /**< \brief CATB signal: SENSE28 on PC28 mux G */
-#define MUX_PC28G_CATB_SENSE28          _L(6)
+#define GPIO_PB08G_CATB_SENSE28  _UL_(1 <<  8)
+#define PIN_PC28G_CATB_SENSE28         _L_(92) /**< \brief CATB signal: SENSE28 on PC28 mux G */
+#define MUX_PC28G_CATB_SENSE28          _L_(6)
 #define PINMUX_PC28G_CATB_SENSE28  ((PIN_PC28G_CATB_SENSE28 << 16) | MUX_PC28G_CATB_SENSE28)
-#define GPIO_PC28G_CATB_SENSE28  _UL(1 << 28)
-#define PIN_PB09G_CATB_SENSE29         _L(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
-#define MUX_PB09G_CATB_SENSE29          _L(6)
+#define GPIO_PC28G_CATB_SENSE28  _UL_(1 << 28)
+#define PIN_PB09G_CATB_SENSE29         _L_(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
+#define MUX_PB09G_CATB_SENSE29          _L_(6)
 #define PINMUX_PB09G_CATB_SENSE29  ((PIN_PB09G_CATB_SENSE29 << 16) | MUX_PB09G_CATB_SENSE29)
-#define GPIO_PB09G_CATB_SENSE29  _UL(1 <<  9)
-#define PIN_PC29G_CATB_SENSE29         _L(93) /**< \brief CATB signal: SENSE29 on PC29 mux G */
-#define MUX_PC29G_CATB_SENSE29          _L(6)
+#define GPIO_PB09G_CATB_SENSE29  _UL_(1 <<  9)
+#define PIN_PC29G_CATB_SENSE29         _L_(93) /**< \brief CATB signal: SENSE29 on PC29 mux G */
+#define MUX_PC29G_CATB_SENSE29          _L_(6)
 #define PINMUX_PC29G_CATB_SENSE29  ((PIN_PC29G_CATB_SENSE29 << 16) | MUX_PC29G_CATB_SENSE29)
-#define GPIO_PC29G_CATB_SENSE29  _UL(1 << 29)
-#define PIN_PB10G_CATB_SENSE30         _L(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
-#define MUX_PB10G_CATB_SENSE30          _L(6)
+#define GPIO_PC29G_CATB_SENSE29  _UL_(1 << 29)
+#define PIN_PB10G_CATB_SENSE30         _L_(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
+#define MUX_PB10G_CATB_SENSE30          _L_(6)
 #define PINMUX_PB10G_CATB_SENSE30  ((PIN_PB10G_CATB_SENSE30 << 16) | MUX_PB10G_CATB_SENSE30)
-#define GPIO_PB10G_CATB_SENSE30  _UL(1 << 10)
-#define PIN_PC30G_CATB_SENSE30         _L(94) /**< \brief CATB signal: SENSE30 on PC30 mux G */
-#define MUX_PC30G_CATB_SENSE30          _L(6)
+#define GPIO_PB10G_CATB_SENSE30  _UL_(1 << 10)
+#define PIN_PC30G_CATB_SENSE30         _L_(94) /**< \brief CATB signal: SENSE30 on PC30 mux G */
+#define MUX_PC30G_CATB_SENSE30          _L_(6)
 #define PINMUX_PC30G_CATB_SENSE30  ((PIN_PC30G_CATB_SENSE30 << 16) | MUX_PC30G_CATB_SENSE30)
-#define GPIO_PC30G_CATB_SENSE30  _UL(1 << 30)
-#define PIN_PB11G_CATB_SENSE31         _L(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
-#define MUX_PB11G_CATB_SENSE31          _L(6)
+#define GPIO_PC30G_CATB_SENSE30  _UL_(1 << 30)
+#define PIN_PB11G_CATB_SENSE31         _L_(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
+#define MUX_PB11G_CATB_SENSE31          _L_(6)
 #define PINMUX_PB11G_CATB_SENSE31  ((PIN_PB11G_CATB_SENSE31 << 16) | MUX_PB11G_CATB_SENSE31)
-#define GPIO_PB11G_CATB_SENSE31  _UL(1 << 11)
-#define PIN_PC31G_CATB_SENSE31         _L(95) /**< \brief CATB signal: SENSE31 on PC31 mux G */
-#define MUX_PC31G_CATB_SENSE31          _L(6)
+#define GPIO_PB11G_CATB_SENSE31  _UL_(1 << 11)
+#define PIN_PC31G_CATB_SENSE31         _L_(95) /**< \brief CATB signal: SENSE31 on PC31 mux G */
+#define MUX_PC31G_CATB_SENSE31          _L_(6)
 #define PINMUX_PC31G_CATB_SENSE31  ((PIN_PC31G_CATB_SENSE31 << 16) | MUX_PC31G_CATB_SENSE31)
-#define GPIO_PC31G_CATB_SENSE31  _UL(1 << 31)
+#define GPIO_PC31G_CATB_SENSE31  _UL_(1 << 31)
 /* ========== GPIO definition for USBC peripheral ========== */
-#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
-#define MUX_PA25A_USBC_DM               _L(0)
+#define PIN_PA25A_USBC_DM              _L_(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L_(0)
 #define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
-#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
-#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
-#define MUX_PA26A_USBC_DP               _L(0)
+#define GPIO_PA25A_USBC_DM       _UL_(1 << 25)
+#define PIN_PA26A_USBC_DP              _L_(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L_(0)
 #define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
-#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+#define GPIO_PA26A_USBC_DP       _UL_(1 << 26)
 /* ========== GPIO definition for PEVC peripheral ========== */
-#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
-#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PIN_PA08C_PEVC_PAD_EVT0         _L_(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
-#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
-#define PIN_PB12C_PEVC_PAD_EVT0        _L(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
-#define MUX_PB12C_PEVC_PAD_EVT0         _L(2)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL_(1 <<  8)
+#define PIN_PB12C_PEVC_PAD_EVT0        _L_(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
+#define MUX_PB12C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PB12C_PEVC_PAD_EVT0  ((PIN_PB12C_PEVC_PAD_EVT0 << 16) | MUX_PB12C_PEVC_PAD_EVT0)
-#define GPIO_PB12C_PEVC_PAD_EVT0  _UL(1 << 12)
-#define PIN_PC07C_PEVC_PAD_EVT0        _L(71) /**< \brief PEVC signal: PAD_EVT0 on PC07 mux C */
-#define MUX_PC07C_PEVC_PAD_EVT0         _L(2)
+#define GPIO_PB12C_PEVC_PAD_EVT0  _UL_(1 << 12)
+#define PIN_PC07C_PEVC_PAD_EVT0        _L_(71) /**< \brief PEVC signal: PAD_EVT0 on PC07 mux C */
+#define MUX_PC07C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PC07C_PEVC_PAD_EVT0  ((PIN_PC07C_PEVC_PAD_EVT0 << 16) | MUX_PC07C_PEVC_PAD_EVT0)
-#define GPIO_PC07C_PEVC_PAD_EVT0  _UL(1 <<  7)
-#define PIN_PC24C_PEVC_PAD_EVT0        _L(88) /**< \brief PEVC signal: PAD_EVT0 on PC24 mux C */
-#define MUX_PC24C_PEVC_PAD_EVT0         _L(2)
+#define GPIO_PC07C_PEVC_PAD_EVT0  _UL_(1 <<  7)
+#define PIN_PC24C_PEVC_PAD_EVT0        _L_(88) /**< \brief PEVC signal: PAD_EVT0 on PC24 mux C */
+#define MUX_PC24C_PEVC_PAD_EVT0         _L_(2)
 #define PINMUX_PC24C_PEVC_PAD_EVT0  ((PIN_PC24C_PEVC_PAD_EVT0 << 16) | MUX_PC24C_PEVC_PAD_EVT0)
-#define GPIO_PC24C_PEVC_PAD_EVT0  _UL(1 << 24)
-#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
-#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PC24C_PEVC_PAD_EVT0  _UL_(1 << 24)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L_(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
-#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
-#define PIN_PB13C_PEVC_PAD_EVT1        _L(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
-#define MUX_PB13C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL_(1 <<  9)
+#define PIN_PB13C_PEVC_PAD_EVT1        _L_(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
+#define MUX_PB13C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PB13C_PEVC_PAD_EVT1  ((PIN_PB13C_PEVC_PAD_EVT1 << 16) | MUX_PB13C_PEVC_PAD_EVT1)
-#define GPIO_PB13C_PEVC_PAD_EVT1  _UL(1 << 13)
-#define PIN_PC08C_PEVC_PAD_EVT1        _L(72) /**< \brief PEVC signal: PAD_EVT1 on PC08 mux C */
-#define MUX_PC08C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PB13C_PEVC_PAD_EVT1  _UL_(1 << 13)
+#define PIN_PC08C_PEVC_PAD_EVT1        _L_(72) /**< \brief PEVC signal: PAD_EVT1 on PC08 mux C */
+#define MUX_PC08C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PC08C_PEVC_PAD_EVT1  ((PIN_PC08C_PEVC_PAD_EVT1 << 16) | MUX_PC08C_PEVC_PAD_EVT1)
-#define GPIO_PC08C_PEVC_PAD_EVT1  _UL(1 <<  8)
-#define PIN_PC25C_PEVC_PAD_EVT1        _L(89) /**< \brief PEVC signal: PAD_EVT1 on PC25 mux C */
-#define MUX_PC25C_PEVC_PAD_EVT1         _L(2)
+#define GPIO_PC08C_PEVC_PAD_EVT1  _UL_(1 <<  8)
+#define PIN_PC25C_PEVC_PAD_EVT1        _L_(89) /**< \brief PEVC signal: PAD_EVT1 on PC25 mux C */
+#define MUX_PC25C_PEVC_PAD_EVT1         _L_(2)
 #define PINMUX_PC25C_PEVC_PAD_EVT1  ((PIN_PC25C_PEVC_PAD_EVT1 << 16) | MUX_PC25C_PEVC_PAD_EVT1)
-#define GPIO_PC25C_PEVC_PAD_EVT1  _UL(1 << 25)
-#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
-#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PC25C_PEVC_PAD_EVT1  _UL_(1 << 25)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L_(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
-#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
-#define PIN_PC11C_PEVC_PAD_EVT2        _L(75) /**< \brief PEVC signal: PAD_EVT2 on PC11 mux C */
-#define MUX_PC11C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL_(1 << 10)
+#define PIN_PC11C_PEVC_PAD_EVT2        _L_(75) /**< \brief PEVC signal: PAD_EVT2 on PC11 mux C */
+#define MUX_PC11C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PC11C_PEVC_PAD_EVT2  ((PIN_PC11C_PEVC_PAD_EVT2 << 16) | MUX_PC11C_PEVC_PAD_EVT2)
-#define GPIO_PC11C_PEVC_PAD_EVT2  _UL(1 << 11)
-#define PIN_PC26C_PEVC_PAD_EVT2        _L(90) /**< \brief PEVC signal: PAD_EVT2 on PC26 mux C */
-#define MUX_PC26C_PEVC_PAD_EVT2         _L(2)
+#define GPIO_PC11C_PEVC_PAD_EVT2  _UL_(1 << 11)
+#define PIN_PC26C_PEVC_PAD_EVT2        _L_(90) /**< \brief PEVC signal: PAD_EVT2 on PC26 mux C */
+#define MUX_PC26C_PEVC_PAD_EVT2         _L_(2)
 #define PINMUX_PC26C_PEVC_PAD_EVT2  ((PIN_PC26C_PEVC_PAD_EVT2 << 16) | MUX_PC26C_PEVC_PAD_EVT2)
-#define GPIO_PC26C_PEVC_PAD_EVT2  _UL(1 << 26)
-#define PIN_PB09B_PEVC_PAD_EVT2        _L(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
-#define MUX_PB09B_PEVC_PAD_EVT2         _L(1)
+#define GPIO_PC26C_PEVC_PAD_EVT2  _UL_(1 << 26)
+#define PIN_PB09B_PEVC_PAD_EVT2        _L_(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
+#define MUX_PB09B_PEVC_PAD_EVT2         _L_(1)
 #define PINMUX_PB09B_PEVC_PAD_EVT2  ((PIN_PB09B_PEVC_PAD_EVT2 << 16) | MUX_PB09B_PEVC_PAD_EVT2)
-#define GPIO_PB09B_PEVC_PAD_EVT2  _UL(1 <<  9)
-#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
-#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define GPIO_PB09B_PEVC_PAD_EVT2  _UL_(1 <<  9)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L_(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L_(2)
 #define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
-#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
-#define PIN_PC27C_PEVC_PAD_EVT3        _L(91) /**< \brief PEVC signal: PAD_EVT3 on PC27 mux C */
-#define MUX_PC27C_PEVC_PAD_EVT3         _L(2)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL_(1 << 11)
+#define PIN_PC27C_PEVC_PAD_EVT3        _L_(91) /**< \brief PEVC signal: PAD_EVT3 on PC27 mux C */
+#define MUX_PC27C_PEVC_PAD_EVT3         _L_(2)
 #define PINMUX_PC27C_PEVC_PAD_EVT3  ((PIN_PC27C_PEVC_PAD_EVT3 << 16) | MUX_PC27C_PEVC_PAD_EVT3)
-#define GPIO_PC27C_PEVC_PAD_EVT3  _UL(1 << 27)
-#define PIN_PB10B_PEVC_PAD_EVT3        _L(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
-#define MUX_PB10B_PEVC_PAD_EVT3         _L(1)
+#define GPIO_PC27C_PEVC_PAD_EVT3  _UL_(1 << 27)
+#define PIN_PB10B_PEVC_PAD_EVT3        _L_(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
+#define MUX_PB10B_PEVC_PAD_EVT3         _L_(1)
 #define PINMUX_PB10B_PEVC_PAD_EVT3  ((PIN_PB10B_PEVC_PAD_EVT3 << 16) | MUX_PB10B_PEVC_PAD_EVT3)
-#define GPIO_PB10B_PEVC_PAD_EVT3  _UL(1 << 10)
+#define GPIO_PB10B_PEVC_PAD_EVT3  _UL_(1 << 10)
 /* ========== GPIO definition for SCIF peripheral ========== */
-#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
-#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PIN_PA19E_SCIF_GCLK0           _L_(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
-#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
-#define PIN_PB10E_SCIF_GCLK0           _L(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
-#define MUX_PB10E_SCIF_GCLK0            _L(4)
+#define GPIO_PA19E_SCIF_GCLK0    _UL_(1 << 19)
+#define PIN_PB10E_SCIF_GCLK0           _L_(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
+#define MUX_PB10E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PB10E_SCIF_GCLK0    ((PIN_PB10E_SCIF_GCLK0 << 16) | MUX_PB10E_SCIF_GCLK0)
-#define GPIO_PB10E_SCIF_GCLK0    _UL(1 << 10)
-#define PIN_PC26E_SCIF_GCLK0           _L(90) /**< \brief SCIF signal: GCLK0 on PC26 mux E */
-#define MUX_PC26E_SCIF_GCLK0            _L(4)
+#define GPIO_PB10E_SCIF_GCLK0    _UL_(1 << 10)
+#define PIN_PC26E_SCIF_GCLK0           _L_(90) /**< \brief SCIF signal: GCLK0 on PC26 mux E */
+#define MUX_PC26E_SCIF_GCLK0            _L_(4)
 #define PINMUX_PC26E_SCIF_GCLK0    ((PIN_PC26E_SCIF_GCLK0 << 16) | MUX_PC26E_SCIF_GCLK0)
-#define GPIO_PC26E_SCIF_GCLK0    _UL(1 << 26)
-#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
-#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define GPIO_PC26E_SCIF_GCLK0    _UL_(1 << 26)
+#define PIN_PA02A_SCIF_GCLK0            _L_(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L_(0)
 #define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
-#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
-#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
-#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define GPIO_PA02A_SCIF_GCLK0    _UL_(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L_(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
-#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
-#define PIN_PB11E_SCIF_GCLK1           _L(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
-#define MUX_PB11E_SCIF_GCLK1            _L(4)
+#define GPIO_PA20E_SCIF_GCLK1    _UL_(1 << 20)
+#define PIN_PB11E_SCIF_GCLK1           _L_(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
+#define MUX_PB11E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PB11E_SCIF_GCLK1    ((PIN_PB11E_SCIF_GCLK1 << 16) | MUX_PB11E_SCIF_GCLK1)
-#define GPIO_PB11E_SCIF_GCLK1    _UL(1 << 11)
-#define PIN_PC27E_SCIF_GCLK1           _L(91) /**< \brief SCIF signal: GCLK1 on PC27 mux E */
-#define MUX_PC27E_SCIF_GCLK1            _L(4)
+#define GPIO_PB11E_SCIF_GCLK1    _UL_(1 << 11)
+#define PIN_PC27E_SCIF_GCLK1           _L_(91) /**< \brief SCIF signal: GCLK1 on PC27 mux E */
+#define MUX_PC27E_SCIF_GCLK1            _L_(4)
 #define PINMUX_PC27E_SCIF_GCLK1    ((PIN_PC27E_SCIF_GCLK1 << 16) | MUX_PC27E_SCIF_GCLK1)
-#define GPIO_PC27E_SCIF_GCLK1    _UL(1 << 27)
-#define PIN_PB12E_SCIF_GCLK2           _L(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
-#define MUX_PB12E_SCIF_GCLK2            _L(4)
+#define GPIO_PC27E_SCIF_GCLK1    _UL_(1 << 27)
+#define PIN_PB12E_SCIF_GCLK2           _L_(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
+#define MUX_PB12E_SCIF_GCLK2            _L_(4)
 #define PINMUX_PB12E_SCIF_GCLK2    ((PIN_PB12E_SCIF_GCLK2 << 16) | MUX_PB12E_SCIF_GCLK2)
-#define GPIO_PB12E_SCIF_GCLK2    _UL(1 << 12)
-#define PIN_PC28E_SCIF_GCLK2           _L(92) /**< \brief SCIF signal: GCLK2 on PC28 mux E */
-#define MUX_PC28E_SCIF_GCLK2            _L(4)
+#define GPIO_PB12E_SCIF_GCLK2    _UL_(1 << 12)
+#define PIN_PC28E_SCIF_GCLK2           _L_(92) /**< \brief SCIF signal: GCLK2 on PC28 mux E */
+#define MUX_PC28E_SCIF_GCLK2            _L_(4)
 #define PINMUX_PC28E_SCIF_GCLK2    ((PIN_PC28E_SCIF_GCLK2 << 16) | MUX_PC28E_SCIF_GCLK2)
-#define GPIO_PC28E_SCIF_GCLK2    _UL(1 << 28)
-#define PIN_PB13E_SCIF_GCLK3           _L(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
-#define MUX_PB13E_SCIF_GCLK3            _L(4)
+#define GPIO_PC28E_SCIF_GCLK2    _UL_(1 << 28)
+#define PIN_PB13E_SCIF_GCLK3           _L_(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
+#define MUX_PB13E_SCIF_GCLK3            _L_(4)
 #define PINMUX_PB13E_SCIF_GCLK3    ((PIN_PB13E_SCIF_GCLK3 << 16) | MUX_PB13E_SCIF_GCLK3)
-#define GPIO_PB13E_SCIF_GCLK3    _UL(1 << 13)
-#define PIN_PC29E_SCIF_GCLK3           _L(93) /**< \brief SCIF signal: GCLK3 on PC29 mux E */
-#define MUX_PC29E_SCIF_GCLK3            _L(4)
+#define GPIO_PB13E_SCIF_GCLK3    _UL_(1 << 13)
+#define PIN_PC29E_SCIF_GCLK3           _L_(93) /**< \brief SCIF signal: GCLK3 on PC29 mux E */
+#define MUX_PC29E_SCIF_GCLK3            _L_(4)
 #define PINMUX_PC29E_SCIF_GCLK3    ((PIN_PC29E_SCIF_GCLK3 << 16) | MUX_PC29E_SCIF_GCLK3)
-#define GPIO_PC29E_SCIF_GCLK3    _UL(1 << 29)
-#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
-#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PC29E_SCIF_GCLK3    _UL_(1 << 29)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L_(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
-#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
-#define PIN_PB14E_SCIF_GCLK_IN0        _L(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
-#define MUX_PB14E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL_(1 << 23)
+#define PIN_PB14E_SCIF_GCLK_IN0        _L_(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
+#define MUX_PB14E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PB14E_SCIF_GCLK_IN0  ((PIN_PB14E_SCIF_GCLK_IN0 << 16) | MUX_PB14E_SCIF_GCLK_IN0)
-#define GPIO_PB14E_SCIF_GCLK_IN0  _UL(1 << 14)
-#define PIN_PC30E_SCIF_GCLK_IN0        _L(94) /**< \brief SCIF signal: GCLK_IN0 on PC30 mux E */
-#define MUX_PC30E_SCIF_GCLK_IN0         _L(4)
+#define GPIO_PB14E_SCIF_GCLK_IN0  _UL_(1 << 14)
+#define PIN_PC30E_SCIF_GCLK_IN0        _L_(94) /**< \brief SCIF signal: GCLK_IN0 on PC30 mux E */
+#define MUX_PC30E_SCIF_GCLK_IN0         _L_(4)
 #define PINMUX_PC30E_SCIF_GCLK_IN0  ((PIN_PC30E_SCIF_GCLK_IN0 << 16) | MUX_PC30E_SCIF_GCLK_IN0)
-#define GPIO_PC30E_SCIF_GCLK_IN0  _UL(1 << 30)
-#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
-#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PC30E_SCIF_GCLK_IN0  _UL_(1 << 30)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L_(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
-#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
-#define PIN_PB15E_SCIF_GCLK_IN1        _L(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
-#define MUX_PB15E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL_(1 << 24)
+#define PIN_PB15E_SCIF_GCLK_IN1        _L_(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
+#define MUX_PB15E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PB15E_SCIF_GCLK_IN1  ((PIN_PB15E_SCIF_GCLK_IN1 << 16) | MUX_PB15E_SCIF_GCLK_IN1)
-#define GPIO_PB15E_SCIF_GCLK_IN1  _UL(1 << 15)
-#define PIN_PC31E_SCIF_GCLK_IN1        _L(95) /**< \brief SCIF signal: GCLK_IN1 on PC31 mux E */
-#define MUX_PC31E_SCIF_GCLK_IN1         _L(4)
+#define GPIO_PB15E_SCIF_GCLK_IN1  _UL_(1 << 15)
+#define PIN_PC31E_SCIF_GCLK_IN1        _L_(95) /**< \brief SCIF signal: GCLK_IN1 on PC31 mux E */
+#define MUX_PC31E_SCIF_GCLK_IN1         _L_(4)
 #define PINMUX_PC31E_SCIF_GCLK_IN1  ((PIN_PC31E_SCIF_GCLK_IN1 << 16) | MUX_PC31E_SCIF_GCLK_IN1)
-#define GPIO_PC31E_SCIF_GCLK_IN1  _UL(1 << 31)
+#define GPIO_PC31E_SCIF_GCLK_IN1  _UL_(1 << 31)
 /* ========== GPIO definition for EIC peripheral ========== */
-#define PIN_PB01C_EIC_EXTINT0          _L(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
-#define MUX_PB01C_EIC_EXTINT0           _L(2)
+#define PIN_PB01C_EIC_EXTINT0          _L_(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
+#define MUX_PB01C_EIC_EXTINT0           _L_(2)
 #define PINMUX_PB01C_EIC_EXTINT0   ((PIN_PB01C_EIC_EXTINT0 << 16) | MUX_PB01C_EIC_EXTINT0)
-#define GPIO_PB01C_EIC_EXTINT0   _UL(1 <<  1)
-#define PIN_PB01C_EIC_EXTINT_NUM        _L(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
-#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
-#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define GPIO_PB01C_EIC_EXTINT0   _UL_(1 <<  1)
+#define PIN_PB01C_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PA06C_EIC_EXTINT1           _L_(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
-#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
-#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
-#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
-#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define GPIO_PA06C_EIC_EXTINT1   _UL_(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L_(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L_(2)
 #define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
-#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
-#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
-#define PIN_PC24B_EIC_EXTINT1          _L(88) /**< \brief EIC signal: EXTINT1 on PC24 mux B */
-#define MUX_PC24B_EIC_EXTINT1           _L(1)
+#define GPIO_PA16C_EIC_EXTINT1   _UL_(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PC24B_EIC_EXTINT1          _L_(88) /**< \brief EIC signal: EXTINT1 on PC24 mux B */
+#define MUX_PC24B_EIC_EXTINT1           _L_(1)
 #define PINMUX_PC24B_EIC_EXTINT1   ((PIN_PC24B_EIC_EXTINT1 << 16) | MUX_PC24B_EIC_EXTINT1)
-#define GPIO_PC24B_EIC_EXTINT1   _UL(1 << 24)
-#define PIN_PC24B_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PC24 External Interrupt Line */
-#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
-#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define GPIO_PC24B_EIC_EXTINT1   _UL_(1 << 24)
+#define PIN_PC24B_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PC24 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L_(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
-#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
-#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
-#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
-#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL_(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L_(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L_(2)
 #define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
-#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
-#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
-#define PIN_PC25B_EIC_EXTINT2          _L(89) /**< \brief EIC signal: EXTINT2 on PC25 mux B */
-#define MUX_PC25B_EIC_EXTINT2           _L(1)
+#define GPIO_PA17C_EIC_EXTINT2   _UL_(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PC25B_EIC_EXTINT2          _L_(89) /**< \brief EIC signal: EXTINT2 on PC25 mux B */
+#define MUX_PC25B_EIC_EXTINT2           _L_(1)
 #define PINMUX_PC25B_EIC_EXTINT2   ((PIN_PC25B_EIC_EXTINT2 << 16) | MUX_PC25B_EIC_EXTINT2)
-#define GPIO_PC25B_EIC_EXTINT2   _UL(1 << 25)
-#define PIN_PC25B_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PC25 External Interrupt Line */
-#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
-#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define GPIO_PC25B_EIC_EXTINT2   _UL_(1 << 25)
+#define PIN_PC25B_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PC25 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L_(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
-#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
-#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
-#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
-#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define GPIO_PA05C_EIC_EXTINT3   _UL_(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L_(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L_(2)
 #define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
-#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
-#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
-#define PIN_PC26B_EIC_EXTINT3          _L(90) /**< \brief EIC signal: EXTINT3 on PC26 mux B */
-#define MUX_PC26B_EIC_EXTINT3           _L(1)
+#define GPIO_PA18C_EIC_EXTINT3   _UL_(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PC26B_EIC_EXTINT3          _L_(90) /**< \brief EIC signal: EXTINT3 on PC26 mux B */
+#define MUX_PC26B_EIC_EXTINT3           _L_(1)
 #define PINMUX_PC26B_EIC_EXTINT3   ((PIN_PC26B_EIC_EXTINT3 << 16) | MUX_PC26B_EIC_EXTINT3)
-#define GPIO_PC26B_EIC_EXTINT3   _UL(1 << 26)
-#define PIN_PC26B_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PC26 External Interrupt Line */
-#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
-#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define GPIO_PC26B_EIC_EXTINT3   _UL_(1 << 26)
+#define PIN_PC26B_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PC26 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L_(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
-#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
-#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
-#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
-#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define GPIO_PA07C_EIC_EXTINT4   _UL_(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L_(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L_(2)
 #define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
-#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
-#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
-#define PIN_PC27B_EIC_EXTINT4          _L(91) /**< \brief EIC signal: EXTINT4 on PC27 mux B */
-#define MUX_PC27B_EIC_EXTINT4           _L(1)
+#define GPIO_PA19C_EIC_EXTINT4   _UL_(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PC27B_EIC_EXTINT4          _L_(91) /**< \brief EIC signal: EXTINT4 on PC27 mux B */
+#define MUX_PC27B_EIC_EXTINT4           _L_(1)
 #define PINMUX_PC27B_EIC_EXTINT4   ((PIN_PC27B_EIC_EXTINT4 << 16) | MUX_PC27B_EIC_EXTINT4)
-#define GPIO_PC27B_EIC_EXTINT4   _UL(1 << 27)
-#define PIN_PC27B_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PC27 External Interrupt Line */
-#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
-#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define GPIO_PC27B_EIC_EXTINT4   _UL_(1 << 27)
+#define PIN_PC27B_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PC27 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L_(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L_(2)
 #define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
-#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
-#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
-#define PIN_PC03B_EIC_EXTINT5          _L(67) /**< \brief EIC signal: EXTINT5 on PC03 mux B */
-#define MUX_PC03B_EIC_EXTINT5           _L(1)
+#define GPIO_PA20C_EIC_EXTINT5   _UL_(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PC03B_EIC_EXTINT5          _L_(67) /**< \brief EIC signal: EXTINT5 on PC03 mux B */
+#define MUX_PC03B_EIC_EXTINT5           _L_(1)
 #define PINMUX_PC03B_EIC_EXTINT5   ((PIN_PC03B_EIC_EXTINT5 << 16) | MUX_PC03B_EIC_EXTINT5)
-#define GPIO_PC03B_EIC_EXTINT5   _UL(1 <<  3)
-#define PIN_PC03B_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PC03 External Interrupt Line */
-#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
-#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define GPIO_PC03B_EIC_EXTINT5   _UL_(1 <<  3)
+#define PIN_PC03B_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PC03 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L_(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L_(2)
 #define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
-#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
-#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
-#define PIN_PC04B_EIC_EXTINT6          _L(68) /**< \brief EIC signal: EXTINT6 on PC04 mux B */
-#define MUX_PC04B_EIC_EXTINT6           _L(1)
+#define GPIO_PA21C_EIC_EXTINT6   _UL_(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PC04B_EIC_EXTINT6          _L_(68) /**< \brief EIC signal: EXTINT6 on PC04 mux B */
+#define MUX_PC04B_EIC_EXTINT6           _L_(1)
 #define PINMUX_PC04B_EIC_EXTINT6   ((PIN_PC04B_EIC_EXTINT6 << 16) | MUX_PC04B_EIC_EXTINT6)
-#define GPIO_PC04B_EIC_EXTINT6   _UL(1 <<  4)
-#define PIN_PC04B_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PC04 External Interrupt Line */
-#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
-#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define GPIO_PC04B_EIC_EXTINT6   _UL_(1 <<  4)
+#define PIN_PC04B_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PC04 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L_(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L_(2)
 #define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
-#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
-#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
-#define PIN_PC05B_EIC_EXTINT7          _L(69) /**< \brief EIC signal: EXTINT7 on PC05 mux B */
-#define MUX_PC05B_EIC_EXTINT7           _L(1)
+#define GPIO_PA22C_EIC_EXTINT7   _UL_(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PC05B_EIC_EXTINT7          _L_(69) /**< \brief EIC signal: EXTINT7 on PC05 mux B */
+#define MUX_PC05B_EIC_EXTINT7           _L_(1)
 #define PINMUX_PC05B_EIC_EXTINT7   ((PIN_PC05B_EIC_EXTINT7 << 16) | MUX_PC05B_EIC_EXTINT7)
-#define GPIO_PC05B_EIC_EXTINT7   _UL(1 <<  5)
-#define PIN_PC05B_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PC05 External Interrupt Line */
-#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
-#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define GPIO_PC05B_EIC_EXTINT7   _UL_(1 <<  5)
+#define PIN_PC05B_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PC05 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L_(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L_(2)
 #define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
-#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
-#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
-#define PIN_PC06B_EIC_EXTINT8          _L(70) /**< \brief EIC signal: EXTINT8 on PC06 mux B */
-#define MUX_PC06B_EIC_EXTINT8           _L(1)
+#define GPIO_PA23C_EIC_EXTINT8   _UL_(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PC06B_EIC_EXTINT8          _L_(70) /**< \brief EIC signal: EXTINT8 on PC06 mux B */
+#define MUX_PC06B_EIC_EXTINT8           _L_(1)
 #define PINMUX_PC06B_EIC_EXTINT8   ((PIN_PC06B_EIC_EXTINT8 << 16) | MUX_PC06B_EIC_EXTINT8)
-#define GPIO_PC06B_EIC_EXTINT8   _UL(1 <<  6)
-#define PIN_PC06B_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PC06 External Interrupt Line */
+#define GPIO_PC06B_EIC_EXTINT8   _UL_(1 <<  6)
+#define PIN_PC06B_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PC06 External Interrupt Line */
 
 #endif /* _SAM4LS8C_PIO_ */

--- a/asf/sam/include/sam4l/pio/sam4ls8c.h
+++ b/asf/sam/include/sam4l/pio/sam4ls8c.h
@@ -1,0 +1,1757 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAM4LS8C
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LS8C_PIO_
+#define _SAM4LS8C_PIO_
+
+#define PIN_PA00                           0  /**< \brief Pin Number for PA00 */
+#define GPIO_PA00                _UL(1 <<  0) /**< \brief GPIO Mask  for PA00 */
+#define PIN_PA01                           1  /**< \brief Pin Number for PA01 */
+#define GPIO_PA01                _UL(1 <<  1) /**< \brief GPIO Mask  for PA01 */
+#define PIN_PA02                           2  /**< \brief Pin Number for PA02 */
+#define GPIO_PA02                _UL(1 <<  2) /**< \brief GPIO Mask  for PA02 */
+#define PIN_PA03                           3  /**< \brief Pin Number for PA03 */
+#define GPIO_PA03                _UL(1 <<  3) /**< \brief GPIO Mask  for PA03 */
+#define PIN_PA04                           4  /**< \brief Pin Number for PA04 */
+#define GPIO_PA04                _UL(1 <<  4) /**< \brief GPIO Mask  for PA04 */
+#define PIN_PA05                           5  /**< \brief Pin Number for PA05 */
+#define GPIO_PA05                _UL(1 <<  5) /**< \brief GPIO Mask  for PA05 */
+#define PIN_PA06                           6  /**< \brief Pin Number for PA06 */
+#define GPIO_PA06                _UL(1 <<  6) /**< \brief GPIO Mask  for PA06 */
+#define PIN_PA07                           7  /**< \brief Pin Number for PA07 */
+#define GPIO_PA07                _UL(1 <<  7) /**< \brief GPIO Mask  for PA07 */
+#define PIN_PA08                           8  /**< \brief Pin Number for PA08 */
+#define GPIO_PA08                _UL(1 <<  8) /**< \brief GPIO Mask  for PA08 */
+#define PIN_PA09                           9  /**< \brief Pin Number for PA09 */
+#define GPIO_PA09                _UL(1 <<  9) /**< \brief GPIO Mask  for PA09 */
+#define PIN_PA10                          10  /**< \brief Pin Number for PA10 */
+#define GPIO_PA10                _UL(1 << 10) /**< \brief GPIO Mask  for PA10 */
+#define PIN_PA11                          11  /**< \brief Pin Number for PA11 */
+#define GPIO_PA11                _UL(1 << 11) /**< \brief GPIO Mask  for PA11 */
+#define PIN_PA12                          12  /**< \brief Pin Number for PA12 */
+#define GPIO_PA12                _UL(1 << 12) /**< \brief GPIO Mask  for PA12 */
+#define PIN_PA13                          13  /**< \brief Pin Number for PA13 */
+#define GPIO_PA13                _UL(1 << 13) /**< \brief GPIO Mask  for PA13 */
+#define PIN_PA14                          14  /**< \brief Pin Number for PA14 */
+#define GPIO_PA14                _UL(1 << 14) /**< \brief GPIO Mask  for PA14 */
+#define PIN_PA15                          15  /**< \brief Pin Number for PA15 */
+#define GPIO_PA15                _UL(1 << 15) /**< \brief GPIO Mask  for PA15 */
+#define PIN_PA16                          16  /**< \brief Pin Number for PA16 */
+#define GPIO_PA16                _UL(1 << 16) /**< \brief GPIO Mask  for PA16 */
+#define PIN_PA17                          17  /**< \brief Pin Number for PA17 */
+#define GPIO_PA17                _UL(1 << 17) /**< \brief GPIO Mask  for PA17 */
+#define PIN_PA18                          18  /**< \brief Pin Number for PA18 */
+#define GPIO_PA18                _UL(1 << 18) /**< \brief GPIO Mask  for PA18 */
+#define PIN_PA19                          19  /**< \brief Pin Number for PA19 */
+#define GPIO_PA19                _UL(1 << 19) /**< \brief GPIO Mask  for PA19 */
+#define PIN_PA20                          20  /**< \brief Pin Number for PA20 */
+#define GPIO_PA20                _UL(1 << 20) /**< \brief GPIO Mask  for PA20 */
+#define PIN_PA21                          21  /**< \brief Pin Number for PA21 */
+#define GPIO_PA21                _UL(1 << 21) /**< \brief GPIO Mask  for PA21 */
+#define PIN_PA22                          22  /**< \brief Pin Number for PA22 */
+#define GPIO_PA22                _UL(1 << 22) /**< \brief GPIO Mask  for PA22 */
+#define PIN_PA23                          23  /**< \brief Pin Number for PA23 */
+#define GPIO_PA23                _UL(1 << 23) /**< \brief GPIO Mask  for PA23 */
+#define PIN_PA24                          24  /**< \brief Pin Number for PA24 */
+#define GPIO_PA24                _UL(1 << 24) /**< \brief GPIO Mask  for PA24 */
+#define PIN_PA25                          25  /**< \brief Pin Number for PA25 */
+#define GPIO_PA25                _UL(1 << 25) /**< \brief GPIO Mask  for PA25 */
+#define PIN_PA26                          26  /**< \brief Pin Number for PA26 */
+#define GPIO_PA26                _UL(1 << 26) /**< \brief GPIO Mask  for PA26 */
+#define PIN_PA27                          27  /**< \brief Pin Number for PA27 */
+#define GPIO_PA27                _UL(1 << 27) /**< \brief GPIO Mask  for PA27 */
+#define PIN_PA28                          28  /**< \brief Pin Number for PA28 */
+#define GPIO_PA28                _UL(1 << 28) /**< \brief GPIO Mask  for PA28 */
+#define PIN_PA29                          29  /**< \brief Pin Number for PA29 */
+#define GPIO_PA29                _UL(1 << 29) /**< \brief GPIO Mask  for PA29 */
+#define PIN_PA30                          30  /**< \brief Pin Number for PA30 */
+#define GPIO_PA30                _UL(1 << 30) /**< \brief GPIO Mask  for PA30 */
+#define PIN_PA31                          31  /**< \brief Pin Number for PA31 */
+#define GPIO_PA31                _UL(1 << 31) /**< \brief GPIO Mask  for PA31 */
+#define PIN_PB00                          32  /**< \brief Pin Number for PB00 */
+#define GPIO_PB00                _UL(1 <<  0) /**< \brief GPIO Mask  for PB00 */
+#define PIN_PB01                          33  /**< \brief Pin Number for PB01 */
+#define GPIO_PB01                _UL(1 <<  1) /**< \brief GPIO Mask  for PB01 */
+#define PIN_PB02                          34  /**< \brief Pin Number for PB02 */
+#define GPIO_PB02                _UL(1 <<  2) /**< \brief GPIO Mask  for PB02 */
+#define PIN_PB03                          35  /**< \brief Pin Number for PB03 */
+#define GPIO_PB03                _UL(1 <<  3) /**< \brief GPIO Mask  for PB03 */
+#define PIN_PB04                          36  /**< \brief Pin Number for PB04 */
+#define GPIO_PB04                _UL(1 <<  4) /**< \brief GPIO Mask  for PB04 */
+#define PIN_PB05                          37  /**< \brief Pin Number for PB05 */
+#define GPIO_PB05                _UL(1 <<  5) /**< \brief GPIO Mask  for PB05 */
+#define PIN_PB06                          38  /**< \brief Pin Number for PB06 */
+#define GPIO_PB06                _UL(1 <<  6) /**< \brief GPIO Mask  for PB06 */
+#define PIN_PB07                          39  /**< \brief Pin Number for PB07 */
+#define GPIO_PB07                _UL(1 <<  7) /**< \brief GPIO Mask  for PB07 */
+#define PIN_PB08                          40  /**< \brief Pin Number for PB08 */
+#define GPIO_PB08                _UL(1 <<  8) /**< \brief GPIO Mask  for PB08 */
+#define PIN_PB09                          41  /**< \brief Pin Number for PB09 */
+#define GPIO_PB09                _UL(1 <<  9) /**< \brief GPIO Mask  for PB09 */
+#define PIN_PB10                          42  /**< \brief Pin Number for PB10 */
+#define GPIO_PB10                _UL(1 << 10) /**< \brief GPIO Mask  for PB10 */
+#define PIN_PB11                          43  /**< \brief Pin Number for PB11 */
+#define GPIO_PB11                _UL(1 << 11) /**< \brief GPIO Mask  for PB11 */
+#define PIN_PB12                          44  /**< \brief Pin Number for PB12 */
+#define GPIO_PB12                _UL(1 << 12) /**< \brief GPIO Mask  for PB12 */
+#define PIN_PB13                          45  /**< \brief Pin Number for PB13 */
+#define GPIO_PB13                _UL(1 << 13) /**< \brief GPIO Mask  for PB13 */
+#define PIN_PB14                          46  /**< \brief Pin Number for PB14 */
+#define GPIO_PB14                _UL(1 << 14) /**< \brief GPIO Mask  for PB14 */
+#define PIN_PB15                          47  /**< \brief Pin Number for PB15 */
+#define GPIO_PB15                _UL(1 << 15) /**< \brief GPIO Mask  for PB15 */
+#define PIN_PC00                          64  /**< \brief Pin Number for PC00 */
+#define GPIO_PC00                _UL(1 <<  0) /**< \brief GPIO Mask  for PC00 */
+#define PIN_PC01                          65  /**< \brief Pin Number for PC01 */
+#define GPIO_PC01                _UL(1 <<  1) /**< \brief GPIO Mask  for PC01 */
+#define PIN_PC02                          66  /**< \brief Pin Number for PC02 */
+#define GPIO_PC02                _UL(1 <<  2) /**< \brief GPIO Mask  for PC02 */
+#define PIN_PC03                          67  /**< \brief Pin Number for PC03 */
+#define GPIO_PC03                _UL(1 <<  3) /**< \brief GPIO Mask  for PC03 */
+#define PIN_PC04                          68  /**< \brief Pin Number for PC04 */
+#define GPIO_PC04                _UL(1 <<  4) /**< \brief GPIO Mask  for PC04 */
+#define PIN_PC05                          69  /**< \brief Pin Number for PC05 */
+#define GPIO_PC05                _UL(1 <<  5) /**< \brief GPIO Mask  for PC05 */
+#define PIN_PC06                          70  /**< \brief Pin Number for PC06 */
+#define GPIO_PC06                _UL(1 <<  6) /**< \brief GPIO Mask  for PC06 */
+#define PIN_PC07                          71  /**< \brief Pin Number for PC07 */
+#define GPIO_PC07                _UL(1 <<  7) /**< \brief GPIO Mask  for PC07 */
+#define PIN_PC08                          72  /**< \brief Pin Number for PC08 */
+#define GPIO_PC08                _UL(1 <<  8) /**< \brief GPIO Mask  for PC08 */
+#define PIN_PC09                          73  /**< \brief Pin Number for PC09 */
+#define GPIO_PC09                _UL(1 <<  9) /**< \brief GPIO Mask  for PC09 */
+#define PIN_PC10                          74  /**< \brief Pin Number for PC10 */
+#define GPIO_PC10                _UL(1 << 10) /**< \brief GPIO Mask  for PC10 */
+#define PIN_PC11                          75  /**< \brief Pin Number for PC11 */
+#define GPIO_PC11                _UL(1 << 11) /**< \brief GPIO Mask  for PC11 */
+#define PIN_PC12                          76  /**< \brief Pin Number for PC12 */
+#define GPIO_PC12                _UL(1 << 12) /**< \brief GPIO Mask  for PC12 */
+#define PIN_PC13                          77  /**< \brief Pin Number for PC13 */
+#define GPIO_PC13                _UL(1 << 13) /**< \brief GPIO Mask  for PC13 */
+#define PIN_PC14                          78  /**< \brief Pin Number for PC14 */
+#define GPIO_PC14                _UL(1 << 14) /**< \brief GPIO Mask  for PC14 */
+#define PIN_PC15                          79  /**< \brief Pin Number for PC15 */
+#define GPIO_PC15                _UL(1 << 15) /**< \brief GPIO Mask  for PC15 */
+#define PIN_PC16                          80  /**< \brief Pin Number for PC16 */
+#define GPIO_PC16                _UL(1 << 16) /**< \brief GPIO Mask  for PC16 */
+#define PIN_PC17                          81  /**< \brief Pin Number for PC17 */
+#define GPIO_PC17                _UL(1 << 17) /**< \brief GPIO Mask  for PC17 */
+#define PIN_PC18                          82  /**< \brief Pin Number for PC18 */
+#define GPIO_PC18                _UL(1 << 18) /**< \brief GPIO Mask  for PC18 */
+#define PIN_PC19                          83  /**< \brief Pin Number for PC19 */
+#define GPIO_PC19                _UL(1 << 19) /**< \brief GPIO Mask  for PC19 */
+#define PIN_PC20                          84  /**< \brief Pin Number for PC20 */
+#define GPIO_PC20                _UL(1 << 20) /**< \brief GPIO Mask  for PC20 */
+#define PIN_PC21                          85  /**< \brief Pin Number for PC21 */
+#define GPIO_PC21                _UL(1 << 21) /**< \brief GPIO Mask  for PC21 */
+#define PIN_PC22                          86  /**< \brief Pin Number for PC22 */
+#define GPIO_PC22                _UL(1 << 22) /**< \brief GPIO Mask  for PC22 */
+#define PIN_PC23                          87  /**< \brief Pin Number for PC23 */
+#define GPIO_PC23                _UL(1 << 23) /**< \brief GPIO Mask  for PC23 */
+#define PIN_PC24                          88  /**< \brief Pin Number for PC24 */
+#define GPIO_PC24                _UL(1 << 24) /**< \brief GPIO Mask  for PC24 */
+#define PIN_PC25                          89  /**< \brief Pin Number for PC25 */
+#define GPIO_PC25                _UL(1 << 25) /**< \brief GPIO Mask  for PC25 */
+#define PIN_PC26                          90  /**< \brief Pin Number for PC26 */
+#define GPIO_PC26                _UL(1 << 26) /**< \brief GPIO Mask  for PC26 */
+#define PIN_PC27                          91  /**< \brief Pin Number for PC27 */
+#define GPIO_PC27                _UL(1 << 27) /**< \brief GPIO Mask  for PC27 */
+#define PIN_PC28                          92  /**< \brief Pin Number for PC28 */
+#define GPIO_PC28                _UL(1 << 28) /**< \brief GPIO Mask  for PC28 */
+#define PIN_PC29                          93  /**< \brief Pin Number for PC29 */
+#define GPIO_PC29                _UL(1 << 29) /**< \brief GPIO Mask  for PC29 */
+#define PIN_PC30                          94  /**< \brief Pin Number for PC30 */
+#define GPIO_PC30                _UL(1 << 30) /**< \brief GPIO Mask  for PC30 */
+#define PIN_PC31                          95  /**< \brief Pin Number for PC31 */
+#define GPIO_PC31                _UL(1 << 31) /**< \brief GPIO Mask  for PC31 */
+/* ========== GPIO definition for TWIMS0 peripheral ========== */
+#define PIN_PA24B_TWIMS0_TWCK          _L(24) /**< \brief TWIMS0 signal: TWCK on PA24 mux B */
+#define MUX_PA24B_TWIMS0_TWCK           _L(1)
+#define PINMUX_PA24B_TWIMS0_TWCK   ((PIN_PA24B_TWIMS0_TWCK << 16) | MUX_PA24B_TWIMS0_TWCK)
+#define GPIO_PA24B_TWIMS0_TWCK   _UL(1 << 24)
+#define PIN_PA23B_TWIMS0_TWD           _L(23) /**< \brief TWIMS0 signal: TWD on PA23 mux B */
+#define MUX_PA23B_TWIMS0_TWD            _L(1)
+#define PINMUX_PA23B_TWIMS0_TWD    ((PIN_PA23B_TWIMS0_TWD << 16) | MUX_PA23B_TWIMS0_TWD)
+#define GPIO_PA23B_TWIMS0_TWD    _UL(1 << 23)
+/* ========== GPIO definition for TWIMS1 peripheral ========== */
+#define PIN_PB01A_TWIMS1_TWCK          _L(33) /**< \brief TWIMS1 signal: TWCK on PB01 mux A */
+#define MUX_PB01A_TWIMS1_TWCK           _L(0)
+#define PINMUX_PB01A_TWIMS1_TWCK   ((PIN_PB01A_TWIMS1_TWCK << 16) | MUX_PB01A_TWIMS1_TWCK)
+#define GPIO_PB01A_TWIMS1_TWCK   _UL(1 <<  1)
+#define PIN_PB00A_TWIMS1_TWD           _L(32) /**< \brief TWIMS1 signal: TWD on PB00 mux A */
+#define MUX_PB00A_TWIMS1_TWD            _L(0)
+#define PINMUX_PB00A_TWIMS1_TWD    ((PIN_PB00A_TWIMS1_TWD << 16) | MUX_PB00A_TWIMS1_TWD)
+#define GPIO_PB00A_TWIMS1_TWD    _UL(1 <<  0)
+/* ========== GPIO definition for TWIMS2 peripheral ========== */
+#define PIN_PA22E_TWIMS2_TWCK          _L(22) /**< \brief TWIMS2 signal: TWCK on PA22 mux E */
+#define MUX_PA22E_TWIMS2_TWCK           _L(4)
+#define PINMUX_PA22E_TWIMS2_TWCK   ((PIN_PA22E_TWIMS2_TWCK << 16) | MUX_PA22E_TWIMS2_TWCK)
+#define GPIO_PA22E_TWIMS2_TWCK   _UL(1 << 22)
+#define PIN_PA21E_TWIMS2_TWD           _L(21) /**< \brief TWIMS2 signal: TWD on PA21 mux E */
+#define MUX_PA21E_TWIMS2_TWD            _L(4)
+#define PINMUX_PA21E_TWIMS2_TWD    ((PIN_PA21E_TWIMS2_TWD << 16) | MUX_PA21E_TWIMS2_TWD)
+#define GPIO_PA21E_TWIMS2_TWD    _UL(1 << 21)
+/* ========== GPIO definition for TWIMS3 peripheral ========== */
+#define PIN_PB15C_TWIMS3_TWCK          _L(47) /**< \brief TWIMS3 signal: TWCK on PB15 mux C */
+#define MUX_PB15C_TWIMS3_TWCK           _L(2)
+#define PINMUX_PB15C_TWIMS3_TWCK   ((PIN_PB15C_TWIMS3_TWCK << 16) | MUX_PB15C_TWIMS3_TWCK)
+#define GPIO_PB15C_TWIMS3_TWCK   _UL(1 << 15)
+#define PIN_PB14C_TWIMS3_TWD           _L(46) /**< \brief TWIMS3 signal: TWD on PB14 mux C */
+#define MUX_PB14C_TWIMS3_TWD            _L(2)
+#define PINMUX_PB14C_TWIMS3_TWD    ((PIN_PB14C_TWIMS3_TWD << 16) | MUX_PB14C_TWIMS3_TWD)
+#define GPIO_PB14C_TWIMS3_TWD    _UL(1 << 14)
+/* ========== GPIO definition for IISC peripheral ========== */
+#define PIN_PB05D_IISC_IMCK            _L(37) /**< \brief IISC signal: IMCK on PB05 mux D */
+#define MUX_PB05D_IISC_IMCK             _L(3)
+#define PINMUX_PB05D_IISC_IMCK     ((PIN_PB05D_IISC_IMCK << 16) | MUX_PB05D_IISC_IMCK)
+#define GPIO_PB05D_IISC_IMCK     _UL(1 <<  5)
+#define PIN_PC14D_IISC_IMCK            _L(78) /**< \brief IISC signal: IMCK on PC14 mux D */
+#define MUX_PC14D_IISC_IMCK             _L(3)
+#define PINMUX_PC14D_IISC_IMCK     ((PIN_PC14D_IISC_IMCK << 16) | MUX_PC14D_IISC_IMCK)
+#define GPIO_PC14D_IISC_IMCK     _UL(1 << 14)
+#define PIN_PA31B_IISC_IMCK            _L(31) /**< \brief IISC signal: IMCK on PA31 mux B */
+#define MUX_PA31B_IISC_IMCK             _L(1)
+#define PINMUX_PA31B_IISC_IMCK     ((PIN_PA31B_IISC_IMCK << 16) | MUX_PA31B_IISC_IMCK)
+#define GPIO_PA31B_IISC_IMCK     _UL(1 << 31)
+#define PIN_PB02D_IISC_ISCK            _L(34) /**< \brief IISC signal: ISCK on PB02 mux D */
+#define MUX_PB02D_IISC_ISCK             _L(3)
+#define PINMUX_PB02D_IISC_ISCK     ((PIN_PB02D_IISC_ISCK << 16) | MUX_PB02D_IISC_ISCK)
+#define GPIO_PB02D_IISC_ISCK     _UL(1 <<  2)
+#define PIN_PC09D_IISC_ISCK            _L(73) /**< \brief IISC signal: ISCK on PC09 mux D */
+#define MUX_PC09D_IISC_ISCK             _L(3)
+#define PINMUX_PC09D_IISC_ISCK     ((PIN_PC09D_IISC_ISCK << 16) | MUX_PC09D_IISC_ISCK)
+#define GPIO_PC09D_IISC_ISCK     _UL(1 <<  9)
+#define PIN_PA27B_IISC_ISCK            _L(27) /**< \brief IISC signal: ISCK on PA27 mux B */
+#define MUX_PA27B_IISC_ISCK             _L(1)
+#define PINMUX_PA27B_IISC_ISCK     ((PIN_PA27B_IISC_ISCK << 16) | MUX_PA27B_IISC_ISCK)
+#define GPIO_PA27B_IISC_ISCK     _UL(1 << 27)
+#define PIN_PB03D_IISC_ISDI            _L(35) /**< \brief IISC signal: ISDI on PB03 mux D */
+#define MUX_PB03D_IISC_ISDI             _L(3)
+#define PINMUX_PB03D_IISC_ISDI     ((PIN_PB03D_IISC_ISDI << 16) | MUX_PB03D_IISC_ISDI)
+#define GPIO_PB03D_IISC_ISDI     _UL(1 <<  3)
+#define PIN_PC10D_IISC_ISDI            _L(74) /**< \brief IISC signal: ISDI on PC10 mux D */
+#define MUX_PC10D_IISC_ISDI             _L(3)
+#define PINMUX_PC10D_IISC_ISDI     ((PIN_PC10D_IISC_ISDI << 16) | MUX_PC10D_IISC_ISDI)
+#define GPIO_PC10D_IISC_ISDI     _UL(1 << 10)
+#define PIN_PA28B_IISC_ISDI            _L(28) /**< \brief IISC signal: ISDI on PA28 mux B */
+#define MUX_PA28B_IISC_ISDI             _L(1)
+#define PINMUX_PA28B_IISC_ISDI     ((PIN_PA28B_IISC_ISDI << 16) | MUX_PA28B_IISC_ISDI)
+#define GPIO_PA28B_IISC_ISDI     _UL(1 << 28)
+#define PIN_PB04D_IISC_ISDO            _L(36) /**< \brief IISC signal: ISDO on PB04 mux D */
+#define MUX_PB04D_IISC_ISDO             _L(3)
+#define PINMUX_PB04D_IISC_ISDO     ((PIN_PB04D_IISC_ISDO << 16) | MUX_PB04D_IISC_ISDO)
+#define GPIO_PB04D_IISC_ISDO     _UL(1 <<  4)
+#define PIN_PC13D_IISC_ISDO            _L(77) /**< \brief IISC signal: ISDO on PC13 mux D */
+#define MUX_PC13D_IISC_ISDO             _L(3)
+#define PINMUX_PC13D_IISC_ISDO     ((PIN_PC13D_IISC_ISDO << 16) | MUX_PC13D_IISC_ISDO)
+#define GPIO_PC13D_IISC_ISDO     _UL(1 << 13)
+#define PIN_PA30B_IISC_ISDO            _L(30) /**< \brief IISC signal: ISDO on PA30 mux B */
+#define MUX_PA30B_IISC_ISDO             _L(1)
+#define PINMUX_PA30B_IISC_ISDO     ((PIN_PA30B_IISC_ISDO << 16) | MUX_PA30B_IISC_ISDO)
+#define GPIO_PA30B_IISC_ISDO     _UL(1 << 30)
+#define PIN_PB06D_IISC_IWS             _L(38) /**< \brief IISC signal: IWS on PB06 mux D */
+#define MUX_PB06D_IISC_IWS              _L(3)
+#define PINMUX_PB06D_IISC_IWS      ((PIN_PB06D_IISC_IWS << 16) | MUX_PB06D_IISC_IWS)
+#define GPIO_PB06D_IISC_IWS      _UL(1 <<  6)
+#define PIN_PC12D_IISC_IWS             _L(76) /**< \brief IISC signal: IWS on PC12 mux D */
+#define MUX_PC12D_IISC_IWS              _L(3)
+#define PINMUX_PC12D_IISC_IWS      ((PIN_PC12D_IISC_IWS << 16) | MUX_PC12D_IISC_IWS)
+#define GPIO_PC12D_IISC_IWS      _UL(1 << 12)
+#define PIN_PA29B_IISC_IWS             _L(29) /**< \brief IISC signal: IWS on PA29 mux B */
+#define MUX_PA29B_IISC_IWS              _L(1)
+#define PINMUX_PA29B_IISC_IWS      ((PIN_PA29B_IISC_IWS << 16) | MUX_PA29B_IISC_IWS)
+#define GPIO_PA29B_IISC_IWS      _UL(1 << 29)
+/* ========== GPIO definition for SPI peripheral ========== */
+#define PIN_PA03B_SPI_MISO              _L(3) /**< \brief SPI signal: MISO on PA03 mux B */
+#define MUX_PA03B_SPI_MISO              _L(1)
+#define PINMUX_PA03B_SPI_MISO      ((PIN_PA03B_SPI_MISO << 16) | MUX_PA03B_SPI_MISO)
+#define GPIO_PA03B_SPI_MISO      _UL(1 <<  3)
+#define PIN_PB14B_SPI_MISO             _L(46) /**< \brief SPI signal: MISO on PB14 mux B */
+#define MUX_PB14B_SPI_MISO              _L(1)
+#define PINMUX_PB14B_SPI_MISO      ((PIN_PB14B_SPI_MISO << 16) | MUX_PB14B_SPI_MISO)
+#define GPIO_PB14B_SPI_MISO      _UL(1 << 14)
+#define PIN_PC28B_SPI_MISO             _L(92) /**< \brief SPI signal: MISO on PC28 mux B */
+#define MUX_PC28B_SPI_MISO              _L(1)
+#define PINMUX_PC28B_SPI_MISO      ((PIN_PC28B_SPI_MISO << 16) | MUX_PC28B_SPI_MISO)
+#define GPIO_PC28B_SPI_MISO      _UL(1 << 28)
+#define PIN_PA21A_SPI_MISO             _L(21) /**< \brief SPI signal: MISO on PA21 mux A */
+#define MUX_PA21A_SPI_MISO              _L(0)
+#define PINMUX_PA21A_SPI_MISO      ((PIN_PA21A_SPI_MISO << 16) | MUX_PA21A_SPI_MISO)
+#define GPIO_PA21A_SPI_MISO      _UL(1 << 21)
+#define PIN_PA27A_SPI_MISO             _L(27) /**< \brief SPI signal: MISO on PA27 mux A */
+#define MUX_PA27A_SPI_MISO              _L(0)
+#define PINMUX_PA27A_SPI_MISO      ((PIN_PA27A_SPI_MISO << 16) | MUX_PA27A_SPI_MISO)
+#define GPIO_PA27A_SPI_MISO      _UL(1 << 27)
+#define PIN_PC04A_SPI_MISO             _L(68) /**< \brief SPI signal: MISO on PC04 mux A */
+#define MUX_PC04A_SPI_MISO              _L(0)
+#define PINMUX_PC04A_SPI_MISO      ((PIN_PC04A_SPI_MISO << 16) | MUX_PC04A_SPI_MISO)
+#define GPIO_PC04A_SPI_MISO      _UL(1 <<  4)
+#define PIN_PB15B_SPI_MOSI             _L(47) /**< \brief SPI signal: MOSI on PB15 mux B */
+#define MUX_PB15B_SPI_MOSI              _L(1)
+#define PINMUX_PB15B_SPI_MOSI      ((PIN_PB15B_SPI_MOSI << 16) | MUX_PB15B_SPI_MOSI)
+#define GPIO_PB15B_SPI_MOSI      _UL(1 << 15)
+#define PIN_PC29B_SPI_MOSI             _L(93) /**< \brief SPI signal: MOSI on PC29 mux B */
+#define MUX_PC29B_SPI_MOSI              _L(1)
+#define PINMUX_PC29B_SPI_MOSI      ((PIN_PC29B_SPI_MOSI << 16) | MUX_PC29B_SPI_MOSI)
+#define GPIO_PC29B_SPI_MOSI      _UL(1 << 29)
+#define PIN_PA22A_SPI_MOSI             _L(22) /**< \brief SPI signal: MOSI on PA22 mux A */
+#define MUX_PA22A_SPI_MOSI              _L(0)
+#define PINMUX_PA22A_SPI_MOSI      ((PIN_PA22A_SPI_MOSI << 16) | MUX_PA22A_SPI_MOSI)
+#define GPIO_PA22A_SPI_MOSI      _UL(1 << 22)
+#define PIN_PA28A_SPI_MOSI             _L(28) /**< \brief SPI signal: MOSI on PA28 mux A */
+#define MUX_PA28A_SPI_MOSI              _L(0)
+#define PINMUX_PA28A_SPI_MOSI      ((PIN_PA28A_SPI_MOSI << 16) | MUX_PA28A_SPI_MOSI)
+#define GPIO_PA28A_SPI_MOSI      _UL(1 << 28)
+#define PIN_PC05A_SPI_MOSI             _L(69) /**< \brief SPI signal: MOSI on PC05 mux A */
+#define MUX_PC05A_SPI_MOSI              _L(0)
+#define PINMUX_PC05A_SPI_MOSI      ((PIN_PC05A_SPI_MOSI << 16) | MUX_PC05A_SPI_MOSI)
+#define GPIO_PC05A_SPI_MOSI      _UL(1 <<  5)
+#define PIN_PA02B_SPI_NPCS0             _L(2) /**< \brief SPI signal: NPCS0 on PA02 mux B */
+#define MUX_PA02B_SPI_NPCS0             _L(1)
+#define PINMUX_PA02B_SPI_NPCS0     ((PIN_PA02B_SPI_NPCS0 << 16) | MUX_PA02B_SPI_NPCS0)
+#define GPIO_PA02B_SPI_NPCS0     _UL(1 <<  2)
+#define PIN_PC31B_SPI_NPCS0            _L(95) /**< \brief SPI signal: NPCS0 on PC31 mux B */
+#define MUX_PC31B_SPI_NPCS0             _L(1)
+#define PINMUX_PC31B_SPI_NPCS0     ((PIN_PC31B_SPI_NPCS0 << 16) | MUX_PC31B_SPI_NPCS0)
+#define GPIO_PC31B_SPI_NPCS0     _UL(1 << 31)
+#define PIN_PA24A_SPI_NPCS0            _L(24) /**< \brief SPI signal: NPCS0 on PA24 mux A */
+#define MUX_PA24A_SPI_NPCS0             _L(0)
+#define PINMUX_PA24A_SPI_NPCS0     ((PIN_PA24A_SPI_NPCS0 << 16) | MUX_PA24A_SPI_NPCS0)
+#define GPIO_PA24A_SPI_NPCS0     _UL(1 << 24)
+#define PIN_PA30A_SPI_NPCS0            _L(30) /**< \brief SPI signal: NPCS0 on PA30 mux A */
+#define MUX_PA30A_SPI_NPCS0             _L(0)
+#define PINMUX_PA30A_SPI_NPCS0     ((PIN_PA30A_SPI_NPCS0 << 16) | MUX_PA30A_SPI_NPCS0)
+#define GPIO_PA30A_SPI_NPCS0     _UL(1 << 30)
+#define PIN_PC03A_SPI_NPCS0            _L(67) /**< \brief SPI signal: NPCS0 on PC03 mux A */
+#define MUX_PC03A_SPI_NPCS0             _L(0)
+#define PINMUX_PC03A_SPI_NPCS0     ((PIN_PC03A_SPI_NPCS0 << 16) | MUX_PC03A_SPI_NPCS0)
+#define GPIO_PC03A_SPI_NPCS0     _UL(1 <<  3)
+#define PIN_PA13C_SPI_NPCS1            _L(13) /**< \brief SPI signal: NPCS1 on PA13 mux C */
+#define MUX_PA13C_SPI_NPCS1             _L(2)
+#define PINMUX_PA13C_SPI_NPCS1     ((PIN_PA13C_SPI_NPCS1 << 16) | MUX_PA13C_SPI_NPCS1)
+#define GPIO_PA13C_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PB13B_SPI_NPCS1            _L(45) /**< \brief SPI signal: NPCS1 on PB13 mux B */
+#define MUX_PB13B_SPI_NPCS1             _L(1)
+#define PINMUX_PB13B_SPI_NPCS1     ((PIN_PB13B_SPI_NPCS1 << 16) | MUX_PB13B_SPI_NPCS1)
+#define GPIO_PB13B_SPI_NPCS1     _UL(1 << 13)
+#define PIN_PA31A_SPI_NPCS1            _L(31) /**< \brief SPI signal: NPCS1 on PA31 mux A */
+#define MUX_PA31A_SPI_NPCS1             _L(0)
+#define PINMUX_PA31A_SPI_NPCS1     ((PIN_PA31A_SPI_NPCS1 << 16) | MUX_PA31A_SPI_NPCS1)
+#define GPIO_PA31A_SPI_NPCS1     _UL(1 << 31)
+#define PIN_PC02A_SPI_NPCS1            _L(66) /**< \brief SPI signal: NPCS1 on PC02 mux A */
+#define MUX_PC02A_SPI_NPCS1             _L(0)
+#define PINMUX_PC02A_SPI_NPCS1     ((PIN_PC02A_SPI_NPCS1 << 16) | MUX_PC02A_SPI_NPCS1)
+#define GPIO_PC02A_SPI_NPCS1     _UL(1 <<  2)
+#define PIN_PA14C_SPI_NPCS2            _L(14) /**< \brief SPI signal: NPCS2 on PA14 mux C */
+#define MUX_PA14C_SPI_NPCS2             _L(2)
+#define PINMUX_PA14C_SPI_NPCS2     ((PIN_PA14C_SPI_NPCS2 << 16) | MUX_PA14C_SPI_NPCS2)
+#define GPIO_PA14C_SPI_NPCS2     _UL(1 << 14)
+#define PIN_PB11B_SPI_NPCS2            _L(43) /**< \brief SPI signal: NPCS2 on PB11 mux B */
+#define MUX_PB11B_SPI_NPCS2             _L(1)
+#define PINMUX_PB11B_SPI_NPCS2     ((PIN_PB11B_SPI_NPCS2 << 16) | MUX_PB11B_SPI_NPCS2)
+#define GPIO_PB11B_SPI_NPCS2     _UL(1 << 11)
+#define PIN_PC00A_SPI_NPCS2            _L(64) /**< \brief SPI signal: NPCS2 on PC00 mux A */
+#define MUX_PC00A_SPI_NPCS2             _L(0)
+#define PINMUX_PC00A_SPI_NPCS2     ((PIN_PC00A_SPI_NPCS2 << 16) | MUX_PC00A_SPI_NPCS2)
+#define GPIO_PC00A_SPI_NPCS2     _UL(1 <<  0)
+#define PIN_PA15C_SPI_NPCS3            _L(15) /**< \brief SPI signal: NPCS3 on PA15 mux C */
+#define MUX_PA15C_SPI_NPCS3             _L(2)
+#define PINMUX_PA15C_SPI_NPCS3     ((PIN_PA15C_SPI_NPCS3 << 16) | MUX_PA15C_SPI_NPCS3)
+#define GPIO_PA15C_SPI_NPCS3     _UL(1 << 15)
+#define PIN_PB12B_SPI_NPCS3            _L(44) /**< \brief SPI signal: NPCS3 on PB12 mux B */
+#define MUX_PB12B_SPI_NPCS3             _L(1)
+#define PINMUX_PB12B_SPI_NPCS3     ((PIN_PB12B_SPI_NPCS3 << 16) | MUX_PB12B_SPI_NPCS3)
+#define GPIO_PB12B_SPI_NPCS3     _UL(1 << 12)
+#define PIN_PC01A_SPI_NPCS3            _L(65) /**< \brief SPI signal: NPCS3 on PC01 mux A */
+#define MUX_PC01A_SPI_NPCS3             _L(0)
+#define PINMUX_PC01A_SPI_NPCS3     ((PIN_PC01A_SPI_NPCS3 << 16) | MUX_PC01A_SPI_NPCS3)
+#define GPIO_PC01A_SPI_NPCS3     _UL(1 <<  1)
+#define PIN_PC30B_SPI_SCK              _L(94) /**< \brief SPI signal: SCK on PC30 mux B */
+#define MUX_PC30B_SPI_SCK               _L(1)
+#define PINMUX_PC30B_SPI_SCK       ((PIN_PC30B_SPI_SCK << 16) | MUX_PC30B_SPI_SCK)
+#define GPIO_PC30B_SPI_SCK       _UL(1 << 30)
+#define PIN_PA23A_SPI_SCK              _L(23) /**< \brief SPI signal: SCK on PA23 mux A */
+#define MUX_PA23A_SPI_SCK               _L(0)
+#define PINMUX_PA23A_SPI_SCK       ((PIN_PA23A_SPI_SCK << 16) | MUX_PA23A_SPI_SCK)
+#define GPIO_PA23A_SPI_SCK       _UL(1 << 23)
+#define PIN_PA29A_SPI_SCK              _L(29) /**< \brief SPI signal: SCK on PA29 mux A */
+#define MUX_PA29A_SPI_SCK               _L(0)
+#define PINMUX_PA29A_SPI_SCK       ((PIN_PA29A_SPI_SCK << 16) | MUX_PA29A_SPI_SCK)
+#define GPIO_PA29A_SPI_SCK       _UL(1 << 29)
+#define PIN_PC06A_SPI_SCK              _L(70) /**< \brief SPI signal: SCK on PC06 mux A */
+#define MUX_PC06A_SPI_SCK               _L(0)
+#define PINMUX_PC06A_SPI_SCK       ((PIN_PC06A_SPI_SCK << 16) | MUX_PC06A_SPI_SCK)
+#define GPIO_PC06A_SPI_SCK       _UL(1 <<  6)
+/* ========== GPIO definition for TC0 peripheral ========== */
+#define PIN_PB07D_TC0_A0               _L(39) /**< \brief TC0 signal: A0 on PB07 mux D */
+#define MUX_PB07D_TC0_A0                _L(3)
+#define PINMUX_PB07D_TC0_A0        ((PIN_PB07D_TC0_A0 << 16) | MUX_PB07D_TC0_A0)
+#define GPIO_PB07D_TC0_A0        _UL(1 <<  7)
+#define PIN_PA08B_TC0_A0                _L(8) /**< \brief TC0 signal: A0 on PA08 mux B */
+#define MUX_PA08B_TC0_A0                _L(1)
+#define PINMUX_PA08B_TC0_A0        ((PIN_PA08B_TC0_A0 << 16) | MUX_PA08B_TC0_A0)
+#define GPIO_PA08B_TC0_A0        _UL(1 <<  8)
+#define PIN_PB09D_TC0_A1               _L(41) /**< \brief TC0 signal: A1 on PB09 mux D */
+#define MUX_PB09D_TC0_A1                _L(3)
+#define PINMUX_PB09D_TC0_A1        ((PIN_PB09D_TC0_A1 << 16) | MUX_PB09D_TC0_A1)
+#define GPIO_PB09D_TC0_A1        _UL(1 <<  9)
+#define PIN_PA10B_TC0_A1               _L(10) /**< \brief TC0 signal: A1 on PA10 mux B */
+#define MUX_PA10B_TC0_A1                _L(1)
+#define PINMUX_PA10B_TC0_A1        ((PIN_PA10B_TC0_A1 << 16) | MUX_PA10B_TC0_A1)
+#define GPIO_PA10B_TC0_A1        _UL(1 << 10)
+#define PIN_PB11D_TC0_A2               _L(43) /**< \brief TC0 signal: A2 on PB11 mux D */
+#define MUX_PB11D_TC0_A2                _L(3)
+#define PINMUX_PB11D_TC0_A2        ((PIN_PB11D_TC0_A2 << 16) | MUX_PB11D_TC0_A2)
+#define GPIO_PB11D_TC0_A2        _UL(1 << 11)
+#define PIN_PA12B_TC0_A2               _L(12) /**< \brief TC0 signal: A2 on PA12 mux B */
+#define MUX_PA12B_TC0_A2                _L(1)
+#define PINMUX_PA12B_TC0_A2        ((PIN_PA12B_TC0_A2 << 16) | MUX_PA12B_TC0_A2)
+#define GPIO_PA12B_TC0_A2        _UL(1 << 12)
+#define PIN_PB08D_TC0_B0               _L(40) /**< \brief TC0 signal: B0 on PB08 mux D */
+#define MUX_PB08D_TC0_B0                _L(3)
+#define PINMUX_PB08D_TC0_B0        ((PIN_PB08D_TC0_B0 << 16) | MUX_PB08D_TC0_B0)
+#define GPIO_PB08D_TC0_B0        _UL(1 <<  8)
+#define PIN_PA09B_TC0_B0                _L(9) /**< \brief TC0 signal: B0 on PA09 mux B */
+#define MUX_PA09B_TC0_B0                _L(1)
+#define PINMUX_PA09B_TC0_B0        ((PIN_PA09B_TC0_B0 << 16) | MUX_PA09B_TC0_B0)
+#define GPIO_PA09B_TC0_B0        _UL(1 <<  9)
+#define PIN_PB10D_TC0_B1               _L(42) /**< \brief TC0 signal: B1 on PB10 mux D */
+#define MUX_PB10D_TC0_B1                _L(3)
+#define PINMUX_PB10D_TC0_B1        ((PIN_PB10D_TC0_B1 << 16) | MUX_PB10D_TC0_B1)
+#define GPIO_PB10D_TC0_B1        _UL(1 << 10)
+#define PIN_PA11B_TC0_B1               _L(11) /**< \brief TC0 signal: B1 on PA11 mux B */
+#define MUX_PA11B_TC0_B1                _L(1)
+#define PINMUX_PA11B_TC0_B1        ((PIN_PA11B_TC0_B1 << 16) | MUX_PA11B_TC0_B1)
+#define GPIO_PA11B_TC0_B1        _UL(1 << 11)
+#define PIN_PB12D_TC0_B2               _L(44) /**< \brief TC0 signal: B2 on PB12 mux D */
+#define MUX_PB12D_TC0_B2                _L(3)
+#define PINMUX_PB12D_TC0_B2        ((PIN_PB12D_TC0_B2 << 16) | MUX_PB12D_TC0_B2)
+#define GPIO_PB12D_TC0_B2        _UL(1 << 12)
+#define PIN_PA13B_TC0_B2               _L(13) /**< \brief TC0 signal: B2 on PA13 mux B */
+#define MUX_PA13B_TC0_B2                _L(1)
+#define PINMUX_PA13B_TC0_B2        ((PIN_PA13B_TC0_B2 << 16) | MUX_PA13B_TC0_B2)
+#define GPIO_PA13B_TC0_B2        _UL(1 << 13)
+#define PIN_PB13D_TC0_CLK0             _L(45) /**< \brief TC0 signal: CLK0 on PB13 mux D */
+#define MUX_PB13D_TC0_CLK0              _L(3)
+#define PINMUX_PB13D_TC0_CLK0      ((PIN_PB13D_TC0_CLK0 << 16) | MUX_PB13D_TC0_CLK0)
+#define GPIO_PB13D_TC0_CLK0      _UL(1 << 13)
+#define PIN_PA14B_TC0_CLK0             _L(14) /**< \brief TC0 signal: CLK0 on PA14 mux B */
+#define MUX_PA14B_TC0_CLK0              _L(1)
+#define PINMUX_PA14B_TC0_CLK0      ((PIN_PA14B_TC0_CLK0 << 16) | MUX_PA14B_TC0_CLK0)
+#define GPIO_PA14B_TC0_CLK0      _UL(1 << 14)
+#define PIN_PB14D_TC0_CLK1             _L(46) /**< \brief TC0 signal: CLK1 on PB14 mux D */
+#define MUX_PB14D_TC0_CLK1              _L(3)
+#define PINMUX_PB14D_TC0_CLK1      ((PIN_PB14D_TC0_CLK1 << 16) | MUX_PB14D_TC0_CLK1)
+#define GPIO_PB14D_TC0_CLK1      _UL(1 << 14)
+#define PIN_PA15B_TC0_CLK1             _L(15) /**< \brief TC0 signal: CLK1 on PA15 mux B */
+#define MUX_PA15B_TC0_CLK1              _L(1)
+#define PINMUX_PA15B_TC0_CLK1      ((PIN_PA15B_TC0_CLK1 << 16) | MUX_PA15B_TC0_CLK1)
+#define GPIO_PA15B_TC0_CLK1      _UL(1 << 15)
+#define PIN_PB15D_TC0_CLK2             _L(47) /**< \brief TC0 signal: CLK2 on PB15 mux D */
+#define MUX_PB15D_TC0_CLK2              _L(3)
+#define PINMUX_PB15D_TC0_CLK2      ((PIN_PB15D_TC0_CLK2 << 16) | MUX_PB15D_TC0_CLK2)
+#define GPIO_PB15D_TC0_CLK2      _UL(1 << 15)
+#define PIN_PA16B_TC0_CLK2             _L(16) /**< \brief TC0 signal: CLK2 on PA16 mux B */
+#define MUX_PA16B_TC0_CLK2              _L(1)
+#define PINMUX_PA16B_TC0_CLK2      ((PIN_PA16B_TC0_CLK2 << 16) | MUX_PA16B_TC0_CLK2)
+#define GPIO_PA16B_TC0_CLK2      _UL(1 << 16)
+/* ========== GPIO definition for TC1 peripheral ========== */
+#define PIN_PC00D_TC1_A0               _L(64) /**< \brief TC1 signal: A0 on PC00 mux D */
+#define MUX_PC00D_TC1_A0                _L(3)
+#define PINMUX_PC00D_TC1_A0        ((PIN_PC00D_TC1_A0 << 16) | MUX_PC00D_TC1_A0)
+#define GPIO_PC00D_TC1_A0        _UL(1 <<  0)
+#define PIN_PC15A_TC1_A0               _L(79) /**< \brief TC1 signal: A0 on PC15 mux A */
+#define MUX_PC15A_TC1_A0                _L(0)
+#define PINMUX_PC15A_TC1_A0        ((PIN_PC15A_TC1_A0 << 16) | MUX_PC15A_TC1_A0)
+#define GPIO_PC15A_TC1_A0        _UL(1 << 15)
+#define PIN_PC02D_TC1_A1               _L(66) /**< \brief TC1 signal: A1 on PC02 mux D */
+#define MUX_PC02D_TC1_A1                _L(3)
+#define PINMUX_PC02D_TC1_A1        ((PIN_PC02D_TC1_A1 << 16) | MUX_PC02D_TC1_A1)
+#define GPIO_PC02D_TC1_A1        _UL(1 <<  2)
+#define PIN_PC17A_TC1_A1               _L(81) /**< \brief TC1 signal: A1 on PC17 mux A */
+#define MUX_PC17A_TC1_A1                _L(0)
+#define PINMUX_PC17A_TC1_A1        ((PIN_PC17A_TC1_A1 << 16) | MUX_PC17A_TC1_A1)
+#define GPIO_PC17A_TC1_A1        _UL(1 << 17)
+#define PIN_PC04D_TC1_A2               _L(68) /**< \brief TC1 signal: A2 on PC04 mux D */
+#define MUX_PC04D_TC1_A2                _L(3)
+#define PINMUX_PC04D_TC1_A2        ((PIN_PC04D_TC1_A2 << 16) | MUX_PC04D_TC1_A2)
+#define GPIO_PC04D_TC1_A2        _UL(1 <<  4)
+#define PIN_PC19A_TC1_A2               _L(83) /**< \brief TC1 signal: A2 on PC19 mux A */
+#define MUX_PC19A_TC1_A2                _L(0)
+#define PINMUX_PC19A_TC1_A2        ((PIN_PC19A_TC1_A2 << 16) | MUX_PC19A_TC1_A2)
+#define GPIO_PC19A_TC1_A2        _UL(1 << 19)
+#define PIN_PC01D_TC1_B0               _L(65) /**< \brief TC1 signal: B0 on PC01 mux D */
+#define MUX_PC01D_TC1_B0                _L(3)
+#define PINMUX_PC01D_TC1_B0        ((PIN_PC01D_TC1_B0 << 16) | MUX_PC01D_TC1_B0)
+#define GPIO_PC01D_TC1_B0        _UL(1 <<  1)
+#define PIN_PC16A_TC1_B0               _L(80) /**< \brief TC1 signal: B0 on PC16 mux A */
+#define MUX_PC16A_TC1_B0                _L(0)
+#define PINMUX_PC16A_TC1_B0        ((PIN_PC16A_TC1_B0 << 16) | MUX_PC16A_TC1_B0)
+#define GPIO_PC16A_TC1_B0        _UL(1 << 16)
+#define PIN_PC03D_TC1_B1               _L(67) /**< \brief TC1 signal: B1 on PC03 mux D */
+#define MUX_PC03D_TC1_B1                _L(3)
+#define PINMUX_PC03D_TC1_B1        ((PIN_PC03D_TC1_B1 << 16) | MUX_PC03D_TC1_B1)
+#define GPIO_PC03D_TC1_B1        _UL(1 <<  3)
+#define PIN_PC18A_TC1_B1               _L(82) /**< \brief TC1 signal: B1 on PC18 mux A */
+#define MUX_PC18A_TC1_B1                _L(0)
+#define PINMUX_PC18A_TC1_B1        ((PIN_PC18A_TC1_B1 << 16) | MUX_PC18A_TC1_B1)
+#define GPIO_PC18A_TC1_B1        _UL(1 << 18)
+#define PIN_PC05D_TC1_B2               _L(69) /**< \brief TC1 signal: B2 on PC05 mux D */
+#define MUX_PC05D_TC1_B2                _L(3)
+#define PINMUX_PC05D_TC1_B2        ((PIN_PC05D_TC1_B2 << 16) | MUX_PC05D_TC1_B2)
+#define GPIO_PC05D_TC1_B2        _UL(1 <<  5)
+#define PIN_PC20A_TC1_B2               _L(84) /**< \brief TC1 signal: B2 on PC20 mux A */
+#define MUX_PC20A_TC1_B2                _L(0)
+#define PINMUX_PC20A_TC1_B2        ((PIN_PC20A_TC1_B2 << 16) | MUX_PC20A_TC1_B2)
+#define GPIO_PC20A_TC1_B2        _UL(1 << 20)
+#define PIN_PC06D_TC1_CLK0             _L(70) /**< \brief TC1 signal: CLK0 on PC06 mux D */
+#define MUX_PC06D_TC1_CLK0              _L(3)
+#define PINMUX_PC06D_TC1_CLK0      ((PIN_PC06D_TC1_CLK0 << 16) | MUX_PC06D_TC1_CLK0)
+#define GPIO_PC06D_TC1_CLK0      _UL(1 <<  6)
+#define PIN_PC21A_TC1_CLK0             _L(85) /**< \brief TC1 signal: CLK0 on PC21 mux A */
+#define MUX_PC21A_TC1_CLK0              _L(0)
+#define PINMUX_PC21A_TC1_CLK0      ((PIN_PC21A_TC1_CLK0 << 16) | MUX_PC21A_TC1_CLK0)
+#define GPIO_PC21A_TC1_CLK0      _UL(1 << 21)
+#define PIN_PC07D_TC1_CLK1             _L(71) /**< \brief TC1 signal: CLK1 on PC07 mux D */
+#define MUX_PC07D_TC1_CLK1              _L(3)
+#define PINMUX_PC07D_TC1_CLK1      ((PIN_PC07D_TC1_CLK1 << 16) | MUX_PC07D_TC1_CLK1)
+#define GPIO_PC07D_TC1_CLK1      _UL(1 <<  7)
+#define PIN_PC22A_TC1_CLK1             _L(86) /**< \brief TC1 signal: CLK1 on PC22 mux A */
+#define MUX_PC22A_TC1_CLK1              _L(0)
+#define PINMUX_PC22A_TC1_CLK1      ((PIN_PC22A_TC1_CLK1 << 16) | MUX_PC22A_TC1_CLK1)
+#define GPIO_PC22A_TC1_CLK1      _UL(1 << 22)
+#define PIN_PC08D_TC1_CLK2             _L(72) /**< \brief TC1 signal: CLK2 on PC08 mux D */
+#define MUX_PC08D_TC1_CLK2              _L(3)
+#define PINMUX_PC08D_TC1_CLK2      ((PIN_PC08D_TC1_CLK2 << 16) | MUX_PC08D_TC1_CLK2)
+#define GPIO_PC08D_TC1_CLK2      _UL(1 <<  8)
+#define PIN_PC23A_TC1_CLK2             _L(87) /**< \brief TC1 signal: CLK2 on PC23 mux A */
+#define MUX_PC23A_TC1_CLK2              _L(0)
+#define PINMUX_PC23A_TC1_CLK2      ((PIN_PC23A_TC1_CLK2 << 16) | MUX_PC23A_TC1_CLK2)
+#define GPIO_PC23A_TC1_CLK2      _UL(1 << 23)
+/* ========== GPIO definition for USART0 peripheral ========== */
+#define PIN_PA04B_USART0_CLK            _L(4) /**< \brief USART0 signal: CLK on PA04 mux B */
+#define MUX_PA04B_USART0_CLK            _L(1)
+#define PINMUX_PA04B_USART0_CLK    ((PIN_PA04B_USART0_CLK << 16) | MUX_PA04B_USART0_CLK)
+#define GPIO_PA04B_USART0_CLK    _UL(1 <<  4)
+#define PIN_PC00B_USART0_CLK           _L(64) /**< \brief USART0 signal: CLK on PC00 mux B */
+#define MUX_PC00B_USART0_CLK            _L(1)
+#define PINMUX_PC00B_USART0_CLK    ((PIN_PC00B_USART0_CLK << 16) | MUX_PC00B_USART0_CLK)
+#define GPIO_PC00B_USART0_CLK    _UL(1 <<  0)
+#define PIN_PA10A_USART0_CLK           _L(10) /**< \brief USART0 signal: CLK on PA10 mux A */
+#define MUX_PA10A_USART0_CLK            _L(0)
+#define PINMUX_PA10A_USART0_CLK    ((PIN_PA10A_USART0_CLK << 16) | MUX_PA10A_USART0_CLK)
+#define GPIO_PA10A_USART0_CLK    _UL(1 << 10)
+#define PIN_PB13A_USART0_CLK           _L(45) /**< \brief USART0 signal: CLK on PB13 mux A */
+#define MUX_PB13A_USART0_CLK            _L(0)
+#define PINMUX_PB13A_USART0_CLK    ((PIN_PB13A_USART0_CLK << 16) | MUX_PB13A_USART0_CLK)
+#define GPIO_PB13A_USART0_CLK    _UL(1 << 13)
+#define PIN_PC02B_USART0_CTS           _L(66) /**< \brief USART0 signal: CTS on PC02 mux B */
+#define MUX_PC02B_USART0_CTS            _L(1)
+#define PINMUX_PC02B_USART0_CTS    ((PIN_PC02B_USART0_CTS << 16) | MUX_PC02B_USART0_CTS)
+#define GPIO_PC02B_USART0_CTS    _UL(1 <<  2)
+#define PIN_PA09A_USART0_CTS            _L(9) /**< \brief USART0 signal: CTS on PA09 mux A */
+#define MUX_PA09A_USART0_CTS            _L(0)
+#define PINMUX_PA09A_USART0_CTS    ((PIN_PA09A_USART0_CTS << 16) | MUX_PA09A_USART0_CTS)
+#define GPIO_PA09A_USART0_CTS    _UL(1 <<  9)
+#define PIN_PB11A_USART0_CTS           _L(43) /**< \brief USART0 signal: CTS on PB11 mux A */
+#define MUX_PB11A_USART0_CTS            _L(0)
+#define PINMUX_PB11A_USART0_CTS    ((PIN_PB11A_USART0_CTS << 16) | MUX_PB11A_USART0_CTS)
+#define GPIO_PB11A_USART0_CTS    _UL(1 << 11)
+#define PIN_PA06B_USART0_RTS            _L(6) /**< \brief USART0 signal: RTS on PA06 mux B */
+#define MUX_PA06B_USART0_RTS            _L(1)
+#define PINMUX_PA06B_USART0_RTS    ((PIN_PA06B_USART0_RTS << 16) | MUX_PA06B_USART0_RTS)
+#define GPIO_PA06B_USART0_RTS    _UL(1 <<  6)
+#define PIN_PC01B_USART0_RTS           _L(65) /**< \brief USART0 signal: RTS on PC01 mux B */
+#define MUX_PC01B_USART0_RTS            _L(1)
+#define PINMUX_PC01B_USART0_RTS    ((PIN_PC01B_USART0_RTS << 16) | MUX_PC01B_USART0_RTS)
+#define GPIO_PC01B_USART0_RTS    _UL(1 <<  1)
+#define PIN_PA08A_USART0_RTS            _L(8) /**< \brief USART0 signal: RTS on PA08 mux A */
+#define MUX_PA08A_USART0_RTS            _L(0)
+#define PINMUX_PA08A_USART0_RTS    ((PIN_PA08A_USART0_RTS << 16) | MUX_PA08A_USART0_RTS)
+#define GPIO_PA08A_USART0_RTS    _UL(1 <<  8)
+#define PIN_PB12A_USART0_RTS           _L(44) /**< \brief USART0 signal: RTS on PB12 mux A */
+#define MUX_PB12A_USART0_RTS            _L(0)
+#define PINMUX_PB12A_USART0_RTS    ((PIN_PB12A_USART0_RTS << 16) | MUX_PB12A_USART0_RTS)
+#define GPIO_PB12A_USART0_RTS    _UL(1 << 12)
+#define PIN_PC02C_USART0_RXD           _L(66) /**< \brief USART0 signal: RXD on PC02 mux C */
+#define MUX_PC02C_USART0_RXD            _L(2)
+#define PINMUX_PC02C_USART0_RXD    ((PIN_PC02C_USART0_RXD << 16) | MUX_PC02C_USART0_RXD)
+#define GPIO_PC02C_USART0_RXD    _UL(1 <<  2)
+#define PIN_PA05B_USART0_RXD            _L(5) /**< \brief USART0 signal: RXD on PA05 mux B */
+#define MUX_PA05B_USART0_RXD            _L(1)
+#define PINMUX_PA05B_USART0_RXD    ((PIN_PA05B_USART0_RXD << 16) | MUX_PA05B_USART0_RXD)
+#define GPIO_PA05B_USART0_RXD    _UL(1 <<  5)
+#define PIN_PB00B_USART0_RXD           _L(32) /**< \brief USART0 signal: RXD on PB00 mux B */
+#define MUX_PB00B_USART0_RXD            _L(1)
+#define PINMUX_PB00B_USART0_RXD    ((PIN_PB00B_USART0_RXD << 16) | MUX_PB00B_USART0_RXD)
+#define GPIO_PB00B_USART0_RXD    _UL(1 <<  0)
+#define PIN_PA11A_USART0_RXD           _L(11) /**< \brief USART0 signal: RXD on PA11 mux A */
+#define MUX_PA11A_USART0_RXD            _L(0)
+#define PINMUX_PA11A_USART0_RXD    ((PIN_PA11A_USART0_RXD << 16) | MUX_PA11A_USART0_RXD)
+#define GPIO_PA11A_USART0_RXD    _UL(1 << 11)
+#define PIN_PB14A_USART0_RXD           _L(46) /**< \brief USART0 signal: RXD on PB14 mux A */
+#define MUX_PB14A_USART0_RXD            _L(0)
+#define PINMUX_PB14A_USART0_RXD    ((PIN_PB14A_USART0_RXD << 16) | MUX_PB14A_USART0_RXD)
+#define GPIO_PB14A_USART0_RXD    _UL(1 << 14)
+#define PIN_PC03C_USART0_TXD           _L(67) /**< \brief USART0 signal: TXD on PC03 mux C */
+#define MUX_PC03C_USART0_TXD            _L(2)
+#define PINMUX_PC03C_USART0_TXD    ((PIN_PC03C_USART0_TXD << 16) | MUX_PC03C_USART0_TXD)
+#define GPIO_PC03C_USART0_TXD    _UL(1 <<  3)
+#define PIN_PA07B_USART0_TXD            _L(7) /**< \brief USART0 signal: TXD on PA07 mux B */
+#define MUX_PA07B_USART0_TXD            _L(1)
+#define PINMUX_PA07B_USART0_TXD    ((PIN_PA07B_USART0_TXD << 16) | MUX_PA07B_USART0_TXD)
+#define GPIO_PA07B_USART0_TXD    _UL(1 <<  7)
+#define PIN_PB01B_USART0_TXD           _L(33) /**< \brief USART0 signal: TXD on PB01 mux B */
+#define MUX_PB01B_USART0_TXD            _L(1)
+#define PINMUX_PB01B_USART0_TXD    ((PIN_PB01B_USART0_TXD << 16) | MUX_PB01B_USART0_TXD)
+#define GPIO_PB01B_USART0_TXD    _UL(1 <<  1)
+#define PIN_PA12A_USART0_TXD           _L(12) /**< \brief USART0 signal: TXD on PA12 mux A */
+#define MUX_PA12A_USART0_TXD            _L(0)
+#define PINMUX_PA12A_USART0_TXD    ((PIN_PA12A_USART0_TXD << 16) | MUX_PA12A_USART0_TXD)
+#define GPIO_PA12A_USART0_TXD    _UL(1 << 12)
+#define PIN_PB15A_USART0_TXD           _L(47) /**< \brief USART0 signal: TXD on PB15 mux A */
+#define MUX_PB15A_USART0_TXD            _L(0)
+#define PINMUX_PB15A_USART0_TXD    ((PIN_PB15A_USART0_TXD << 16) | MUX_PB15A_USART0_TXD)
+#define GPIO_PB15A_USART0_TXD    _UL(1 << 15)
+/* ========== GPIO definition for USART1 peripheral ========== */
+#define PIN_PB03B_USART1_CLK           _L(35) /**< \brief USART1 signal: CLK on PB03 mux B */
+#define MUX_PB03B_USART1_CLK            _L(1)
+#define PINMUX_PB03B_USART1_CLK    ((PIN_PB03B_USART1_CLK << 16) | MUX_PB03B_USART1_CLK)
+#define GPIO_PB03B_USART1_CLK    _UL(1 <<  3)
+#define PIN_PA14A_USART1_CLK           _L(14) /**< \brief USART1 signal: CLK on PA14 mux A */
+#define MUX_PA14A_USART1_CLK            _L(0)
+#define PINMUX_PA14A_USART1_CLK    ((PIN_PA14A_USART1_CLK << 16) | MUX_PA14A_USART1_CLK)
+#define GPIO_PA14A_USART1_CLK    _UL(1 << 14)
+#define PIN_PC25A_USART1_CLK           _L(89) /**< \brief USART1 signal: CLK on PC25 mux A */
+#define MUX_PC25A_USART1_CLK            _L(0)
+#define PINMUX_PC25A_USART1_CLK    ((PIN_PC25A_USART1_CLK << 16) | MUX_PC25A_USART1_CLK)
+#define GPIO_PC25A_USART1_CLK    _UL(1 << 25)
+#define PIN_PA21B_USART1_CTS           _L(21) /**< \brief USART1 signal: CTS on PA21 mux B */
+#define MUX_PA21B_USART1_CTS            _L(1)
+#define PINMUX_PA21B_USART1_CTS    ((PIN_PA21B_USART1_CTS << 16) | MUX_PA21B_USART1_CTS)
+#define GPIO_PA21B_USART1_CTS    _UL(1 << 21)
+#define PIN_PB02B_USART1_RTS           _L(34) /**< \brief USART1 signal: RTS on PB02 mux B */
+#define MUX_PB02B_USART1_RTS            _L(1)
+#define PINMUX_PB02B_USART1_RTS    ((PIN_PB02B_USART1_RTS << 16) | MUX_PB02B_USART1_RTS)
+#define GPIO_PB02B_USART1_RTS    _UL(1 <<  2)
+#define PIN_PA13A_USART1_RTS           _L(13) /**< \brief USART1 signal: RTS on PA13 mux A */
+#define MUX_PA13A_USART1_RTS            _L(0)
+#define PINMUX_PA13A_USART1_RTS    ((PIN_PA13A_USART1_RTS << 16) | MUX_PA13A_USART1_RTS)
+#define GPIO_PA13A_USART1_RTS    _UL(1 << 13)
+#define PIN_PC24A_USART1_RTS           _L(88) /**< \brief USART1 signal: RTS on PC24 mux A */
+#define MUX_PC24A_USART1_RTS            _L(0)
+#define PINMUX_PC24A_USART1_RTS    ((PIN_PC24A_USART1_RTS << 16) | MUX_PC24A_USART1_RTS)
+#define GPIO_PC24A_USART1_RTS    _UL(1 << 24)
+#define PIN_PB04B_USART1_RXD           _L(36) /**< \brief USART1 signal: RXD on PB04 mux B */
+#define MUX_PB04B_USART1_RXD            _L(1)
+#define PINMUX_PB04B_USART1_RXD    ((PIN_PB04B_USART1_RXD << 16) | MUX_PB04B_USART1_RXD)
+#define GPIO_PB04B_USART1_RXD    _UL(1 <<  4)
+#define PIN_PA15A_USART1_RXD           _L(15) /**< \brief USART1 signal: RXD on PA15 mux A */
+#define MUX_PA15A_USART1_RXD            _L(0)
+#define PINMUX_PA15A_USART1_RXD    ((PIN_PA15A_USART1_RXD << 16) | MUX_PA15A_USART1_RXD)
+#define GPIO_PA15A_USART1_RXD    _UL(1 << 15)
+#define PIN_PC26A_USART1_RXD           _L(90) /**< \brief USART1 signal: RXD on PC26 mux A */
+#define MUX_PC26A_USART1_RXD            _L(0)
+#define PINMUX_PC26A_USART1_RXD    ((PIN_PC26A_USART1_RXD << 16) | MUX_PC26A_USART1_RXD)
+#define GPIO_PC26A_USART1_RXD    _UL(1 << 26)
+#define PIN_PB05B_USART1_TXD           _L(37) /**< \brief USART1 signal: TXD on PB05 mux B */
+#define MUX_PB05B_USART1_TXD            _L(1)
+#define PINMUX_PB05B_USART1_TXD    ((PIN_PB05B_USART1_TXD << 16) | MUX_PB05B_USART1_TXD)
+#define GPIO_PB05B_USART1_TXD    _UL(1 <<  5)
+#define PIN_PA16A_USART1_TXD           _L(16) /**< \brief USART1 signal: TXD on PA16 mux A */
+#define MUX_PA16A_USART1_TXD            _L(0)
+#define PINMUX_PA16A_USART1_TXD    ((PIN_PA16A_USART1_TXD << 16) | MUX_PA16A_USART1_TXD)
+#define GPIO_PA16A_USART1_TXD    _UL(1 << 16)
+#define PIN_PC27A_USART1_TXD           _L(91) /**< \brief USART1 signal: TXD on PC27 mux A */
+#define MUX_PC27A_USART1_TXD            _L(0)
+#define PINMUX_PC27A_USART1_TXD    ((PIN_PC27A_USART1_TXD << 16) | MUX_PC27A_USART1_TXD)
+#define GPIO_PC27A_USART1_TXD    _UL(1 << 27)
+/* ========== GPIO definition for USART2 peripheral ========== */
+#define PIN_PC08B_USART2_CLK           _L(72) /**< \brief USART2 signal: CLK on PC08 mux B */
+#define MUX_PC08B_USART2_CLK            _L(1)
+#define PINMUX_PC08B_USART2_CLK    ((PIN_PC08B_USART2_CLK << 16) | MUX_PC08B_USART2_CLK)
+#define GPIO_PC08B_USART2_CLK    _UL(1 <<  8)
+#define PIN_PA18A_USART2_CLK           _L(18) /**< \brief USART2 signal: CLK on PA18 mux A */
+#define MUX_PA18A_USART2_CLK            _L(0)
+#define PINMUX_PA18A_USART2_CLK    ((PIN_PA18A_USART2_CLK << 16) | MUX_PA18A_USART2_CLK)
+#define GPIO_PA18A_USART2_CLK    _UL(1 << 18)
+#define PIN_PC08E_USART2_CTS           _L(72) /**< \brief USART2 signal: CTS on PC08 mux E */
+#define MUX_PC08E_USART2_CTS            _L(4)
+#define PINMUX_PC08E_USART2_CTS    ((PIN_PC08E_USART2_CTS << 16) | MUX_PC08E_USART2_CTS)
+#define GPIO_PC08E_USART2_CTS    _UL(1 <<  8)
+#define PIN_PA22B_USART2_CTS           _L(22) /**< \brief USART2 signal: CTS on PA22 mux B */
+#define MUX_PA22B_USART2_CTS            _L(1)
+#define PINMUX_PA22B_USART2_CTS    ((PIN_PA22B_USART2_CTS << 16) | MUX_PA22B_USART2_CTS)
+#define GPIO_PA22B_USART2_CTS    _UL(1 << 22)
+#define PIN_PC07B_USART2_RTS           _L(71) /**< \brief USART2 signal: RTS on PC07 mux B */
+#define MUX_PC07B_USART2_RTS            _L(1)
+#define PINMUX_PC07B_USART2_RTS    ((PIN_PC07B_USART2_RTS << 16) | MUX_PC07B_USART2_RTS)
+#define GPIO_PC07B_USART2_RTS    _UL(1 <<  7)
+#define PIN_PA17A_USART2_RTS           _L(17) /**< \brief USART2 signal: RTS on PA17 mux A */
+#define MUX_PA17A_USART2_RTS            _L(0)
+#define PINMUX_PA17A_USART2_RTS    ((PIN_PA17A_USART2_RTS << 16) | MUX_PA17A_USART2_RTS)
+#define GPIO_PA17A_USART2_RTS    _UL(1 << 17)
+#define PIN_PA25B_USART2_RXD           _L(25) /**< \brief USART2 signal: RXD on PA25 mux B */
+#define MUX_PA25B_USART2_RXD            _L(1)
+#define PINMUX_PA25B_USART2_RXD    ((PIN_PA25B_USART2_RXD << 16) | MUX_PA25B_USART2_RXD)
+#define GPIO_PA25B_USART2_RXD    _UL(1 << 25)
+#define PIN_PC11B_USART2_RXD           _L(75) /**< \brief USART2 signal: RXD on PC11 mux B */
+#define MUX_PC11B_USART2_RXD            _L(1)
+#define PINMUX_PC11B_USART2_RXD    ((PIN_PC11B_USART2_RXD << 16) | MUX_PC11B_USART2_RXD)
+#define GPIO_PC11B_USART2_RXD    _UL(1 << 11)
+#define PIN_PA19A_USART2_RXD           _L(19) /**< \brief USART2 signal: RXD on PA19 mux A */
+#define MUX_PA19A_USART2_RXD            _L(0)
+#define PINMUX_PA19A_USART2_RXD    ((PIN_PA19A_USART2_RXD << 16) | MUX_PA19A_USART2_RXD)
+#define GPIO_PA19A_USART2_RXD    _UL(1 << 19)
+#define PIN_PA26B_USART2_TXD           _L(26) /**< \brief USART2 signal: TXD on PA26 mux B */
+#define MUX_PA26B_USART2_TXD            _L(1)
+#define PINMUX_PA26B_USART2_TXD    ((PIN_PA26B_USART2_TXD << 16) | MUX_PA26B_USART2_TXD)
+#define GPIO_PA26B_USART2_TXD    _UL(1 << 26)
+#define PIN_PC12B_USART2_TXD           _L(76) /**< \brief USART2 signal: TXD on PC12 mux B */
+#define MUX_PC12B_USART2_TXD            _L(1)
+#define PINMUX_PC12B_USART2_TXD    ((PIN_PC12B_USART2_TXD << 16) | MUX_PC12B_USART2_TXD)
+#define GPIO_PC12B_USART2_TXD    _UL(1 << 12)
+#define PIN_PA20A_USART2_TXD           _L(20) /**< \brief USART2 signal: TXD on PA20 mux A */
+#define MUX_PA20A_USART2_TXD            _L(0)
+#define PINMUX_PA20A_USART2_TXD    ((PIN_PA20A_USART2_TXD << 16) | MUX_PA20A_USART2_TXD)
+#define GPIO_PA20A_USART2_TXD    _UL(1 << 20)
+/* ========== GPIO definition for USART3 peripheral ========== */
+#define PIN_PA29E_USART3_CLK           _L(29) /**< \brief USART3 signal: CLK on PA29 mux E */
+#define MUX_PA29E_USART3_CLK            _L(4)
+#define PINMUX_PA29E_USART3_CLK    ((PIN_PA29E_USART3_CLK << 16) | MUX_PA29E_USART3_CLK)
+#define GPIO_PA29E_USART3_CLK    _UL(1 << 29)
+#define PIN_PC14B_USART3_CLK           _L(78) /**< \brief USART3 signal: CLK on PC14 mux B */
+#define MUX_PC14B_USART3_CLK            _L(1)
+#define PINMUX_PC14B_USART3_CLK    ((PIN_PC14B_USART3_CLK << 16) | MUX_PC14B_USART3_CLK)
+#define GPIO_PC14B_USART3_CLK    _UL(1 << 14)
+#define PIN_PB08A_USART3_CLK           _L(40) /**< \brief USART3 signal: CLK on PB08 mux A */
+#define MUX_PB08A_USART3_CLK            _L(0)
+#define PINMUX_PB08A_USART3_CLK    ((PIN_PB08A_USART3_CLK << 16) | MUX_PB08A_USART3_CLK)
+#define GPIO_PB08A_USART3_CLK    _UL(1 <<  8)
+#define PIN_PC31A_USART3_CLK           _L(95) /**< \brief USART3 signal: CLK on PC31 mux A */
+#define MUX_PC31A_USART3_CLK            _L(0)
+#define PINMUX_PC31A_USART3_CLK    ((PIN_PC31A_USART3_CLK << 16) | MUX_PC31A_USART3_CLK)
+#define GPIO_PC31A_USART3_CLK    _UL(1 << 31)
+#define PIN_PA28E_USART3_CTS           _L(28) /**< \brief USART3 signal: CTS on PA28 mux E */
+#define MUX_PA28E_USART3_CTS            _L(4)
+#define PINMUX_PA28E_USART3_CTS    ((PIN_PA28E_USART3_CTS << 16) | MUX_PA28E_USART3_CTS)
+#define GPIO_PA28E_USART3_CTS    _UL(1 << 28)
+#define PIN_PB07A_USART3_CTS           _L(39) /**< \brief USART3 signal: CTS on PB07 mux A */
+#define MUX_PB07A_USART3_CTS            _L(0)
+#define PINMUX_PB07A_USART3_CTS    ((PIN_PB07A_USART3_CTS << 16) | MUX_PB07A_USART3_CTS)
+#define GPIO_PB07A_USART3_CTS    _UL(1 <<  7)
+#define PIN_PA27E_USART3_RTS           _L(27) /**< \brief USART3 signal: RTS on PA27 mux E */
+#define MUX_PA27E_USART3_RTS            _L(4)
+#define PINMUX_PA27E_USART3_RTS    ((PIN_PA27E_USART3_RTS << 16) | MUX_PA27E_USART3_RTS)
+#define GPIO_PA27E_USART3_RTS    _UL(1 << 27)
+#define PIN_PC13B_USART3_RTS           _L(77) /**< \brief USART3 signal: RTS on PC13 mux B */
+#define MUX_PC13B_USART3_RTS            _L(1)
+#define PINMUX_PC13B_USART3_RTS    ((PIN_PC13B_USART3_RTS << 16) | MUX_PC13B_USART3_RTS)
+#define GPIO_PC13B_USART3_RTS    _UL(1 << 13)
+#define PIN_PB06A_USART3_RTS           _L(38) /**< \brief USART3 signal: RTS on PB06 mux A */
+#define MUX_PB06A_USART3_RTS            _L(0)
+#define PINMUX_PB06A_USART3_RTS    ((PIN_PB06A_USART3_RTS << 16) | MUX_PB06A_USART3_RTS)
+#define GPIO_PB06A_USART3_RTS    _UL(1 <<  6)
+#define PIN_PC30A_USART3_RTS           _L(94) /**< \brief USART3 signal: RTS on PC30 mux A */
+#define MUX_PC30A_USART3_RTS            _L(0)
+#define PINMUX_PC30A_USART3_RTS    ((PIN_PC30A_USART3_RTS << 16) | MUX_PC30A_USART3_RTS)
+#define GPIO_PC30A_USART3_RTS    _UL(1 << 30)
+#define PIN_PA30E_USART3_RXD           _L(30) /**< \brief USART3 signal: RXD on PA30 mux E */
+#define MUX_PA30E_USART3_RXD            _L(4)
+#define PINMUX_PA30E_USART3_RXD    ((PIN_PA30E_USART3_RXD << 16) | MUX_PA30E_USART3_RXD)
+#define GPIO_PA30E_USART3_RXD    _UL(1 << 30)
+#define PIN_PC09B_USART3_RXD           _L(73) /**< \brief USART3 signal: RXD on PC09 mux B */
+#define MUX_PC09B_USART3_RXD            _L(1)
+#define PINMUX_PC09B_USART3_RXD    ((PIN_PC09B_USART3_RXD << 16) | MUX_PC09B_USART3_RXD)
+#define GPIO_PC09B_USART3_RXD    _UL(1 <<  9)
+#define PIN_PB09A_USART3_RXD           _L(41) /**< \brief USART3 signal: RXD on PB09 mux A */
+#define MUX_PB09A_USART3_RXD            _L(0)
+#define PINMUX_PB09A_USART3_RXD    ((PIN_PB09A_USART3_RXD << 16) | MUX_PB09A_USART3_RXD)
+#define GPIO_PB09A_USART3_RXD    _UL(1 <<  9)
+#define PIN_PC28A_USART3_RXD           _L(92) /**< \brief USART3 signal: RXD on PC28 mux A */
+#define MUX_PC28A_USART3_RXD            _L(0)
+#define PINMUX_PC28A_USART3_RXD    ((PIN_PC28A_USART3_RXD << 16) | MUX_PC28A_USART3_RXD)
+#define GPIO_PC28A_USART3_RXD    _UL(1 << 28)
+#define PIN_PA31E_USART3_TXD           _L(31) /**< \brief USART3 signal: TXD on PA31 mux E */
+#define MUX_PA31E_USART3_TXD            _L(4)
+#define PINMUX_PA31E_USART3_TXD    ((PIN_PA31E_USART3_TXD << 16) | MUX_PA31E_USART3_TXD)
+#define GPIO_PA31E_USART3_TXD    _UL(1 << 31)
+#define PIN_PC10B_USART3_TXD           _L(74) /**< \brief USART3 signal: TXD on PC10 mux B */
+#define MUX_PC10B_USART3_TXD            _L(1)
+#define PINMUX_PC10B_USART3_TXD    ((PIN_PC10B_USART3_TXD << 16) | MUX_PC10B_USART3_TXD)
+#define GPIO_PC10B_USART3_TXD    _UL(1 << 10)
+#define PIN_PB10A_USART3_TXD           _L(42) /**< \brief USART3 signal: TXD on PB10 mux A */
+#define MUX_PB10A_USART3_TXD            _L(0)
+#define PINMUX_PB10A_USART3_TXD    ((PIN_PB10A_USART3_TXD << 16) | MUX_PB10A_USART3_TXD)
+#define GPIO_PB10A_USART3_TXD    _UL(1 << 10)
+#define PIN_PC29A_USART3_TXD           _L(93) /**< \brief USART3 signal: TXD on PC29 mux A */
+#define MUX_PC29A_USART3_TXD            _L(0)
+#define PINMUX_PC29A_USART3_TXD    ((PIN_PC29A_USART3_TXD << 16) | MUX_PC29A_USART3_TXD)
+#define GPIO_PC29A_USART3_TXD    _UL(1 << 29)
+/* ========== GPIO definition for ADCIFE peripheral ========== */
+#define PIN_PA04A_ADCIFE_AD0            _L(4) /**< \brief ADCIFE signal: AD0 on PA04 mux A */
+#define MUX_PA04A_ADCIFE_AD0            _L(0)
+#define PINMUX_PA04A_ADCIFE_AD0    ((PIN_PA04A_ADCIFE_AD0 << 16) | MUX_PA04A_ADCIFE_AD0)
+#define GPIO_PA04A_ADCIFE_AD0    _UL(1 <<  4)
+#define PIN_PA05A_ADCIFE_AD1            _L(5) /**< \brief ADCIFE signal: AD1 on PA05 mux A */
+#define MUX_PA05A_ADCIFE_AD1            _L(0)
+#define PINMUX_PA05A_ADCIFE_AD1    ((PIN_PA05A_ADCIFE_AD1 << 16) | MUX_PA05A_ADCIFE_AD1)
+#define GPIO_PA05A_ADCIFE_AD1    _UL(1 <<  5)
+#define PIN_PA07A_ADCIFE_AD2            _L(7) /**< \brief ADCIFE signal: AD2 on PA07 mux A */
+#define MUX_PA07A_ADCIFE_AD2            _L(0)
+#define PINMUX_PA07A_ADCIFE_AD2    ((PIN_PA07A_ADCIFE_AD2 << 16) | MUX_PA07A_ADCIFE_AD2)
+#define GPIO_PA07A_ADCIFE_AD2    _UL(1 <<  7)
+#define PIN_PB02A_ADCIFE_AD3           _L(34) /**< \brief ADCIFE signal: AD3 on PB02 mux A */
+#define MUX_PB02A_ADCIFE_AD3            _L(0)
+#define PINMUX_PB02A_ADCIFE_AD3    ((PIN_PB02A_ADCIFE_AD3 << 16) | MUX_PB02A_ADCIFE_AD3)
+#define GPIO_PB02A_ADCIFE_AD3    _UL(1 <<  2)
+#define PIN_PB03A_ADCIFE_AD4           _L(35) /**< \brief ADCIFE signal: AD4 on PB03 mux A */
+#define MUX_PB03A_ADCIFE_AD4            _L(0)
+#define PINMUX_PB03A_ADCIFE_AD4    ((PIN_PB03A_ADCIFE_AD4 << 16) | MUX_PB03A_ADCIFE_AD4)
+#define GPIO_PB03A_ADCIFE_AD4    _UL(1 <<  3)
+#define PIN_PB04A_ADCIFE_AD5           _L(36) /**< \brief ADCIFE signal: AD5 on PB04 mux A */
+#define MUX_PB04A_ADCIFE_AD5            _L(0)
+#define PINMUX_PB04A_ADCIFE_AD5    ((PIN_PB04A_ADCIFE_AD5 << 16) | MUX_PB04A_ADCIFE_AD5)
+#define GPIO_PB04A_ADCIFE_AD5    _UL(1 <<  4)
+#define PIN_PB05A_ADCIFE_AD6           _L(37) /**< \brief ADCIFE signal: AD6 on PB05 mux A */
+#define MUX_PB05A_ADCIFE_AD6            _L(0)
+#define PINMUX_PB05A_ADCIFE_AD6    ((PIN_PB05A_ADCIFE_AD6 << 16) | MUX_PB05A_ADCIFE_AD6)
+#define GPIO_PB05A_ADCIFE_AD6    _UL(1 <<  5)
+#define PIN_PC07A_ADCIFE_AD7           _L(71) /**< \brief ADCIFE signal: AD7 on PC07 mux A */
+#define MUX_PC07A_ADCIFE_AD7            _L(0)
+#define PINMUX_PC07A_ADCIFE_AD7    ((PIN_PC07A_ADCIFE_AD7 << 16) | MUX_PC07A_ADCIFE_AD7)
+#define GPIO_PC07A_ADCIFE_AD7    _UL(1 <<  7)
+#define PIN_PC08A_ADCIFE_AD8           _L(72) /**< \brief ADCIFE signal: AD8 on PC08 mux A */
+#define MUX_PC08A_ADCIFE_AD8            _L(0)
+#define PINMUX_PC08A_ADCIFE_AD8    ((PIN_PC08A_ADCIFE_AD8 << 16) | MUX_PC08A_ADCIFE_AD8)
+#define GPIO_PC08A_ADCIFE_AD8    _UL(1 <<  8)
+#define PIN_PC09A_ADCIFE_AD9           _L(73) /**< \brief ADCIFE signal: AD9 on PC09 mux A */
+#define MUX_PC09A_ADCIFE_AD9            _L(0)
+#define PINMUX_PC09A_ADCIFE_AD9    ((PIN_PC09A_ADCIFE_AD9 << 16) | MUX_PC09A_ADCIFE_AD9)
+#define GPIO_PC09A_ADCIFE_AD9    _UL(1 <<  9)
+#define PIN_PC10A_ADCIFE_AD10          _L(74) /**< \brief ADCIFE signal: AD10 on PC10 mux A */
+#define MUX_PC10A_ADCIFE_AD10           _L(0)
+#define PINMUX_PC10A_ADCIFE_AD10   ((PIN_PC10A_ADCIFE_AD10 << 16) | MUX_PC10A_ADCIFE_AD10)
+#define GPIO_PC10A_ADCIFE_AD10   _UL(1 << 10)
+#define PIN_PC11A_ADCIFE_AD11          _L(75) /**< \brief ADCIFE signal: AD11 on PC11 mux A */
+#define MUX_PC11A_ADCIFE_AD11           _L(0)
+#define PINMUX_PC11A_ADCIFE_AD11   ((PIN_PC11A_ADCIFE_AD11 << 16) | MUX_PC11A_ADCIFE_AD11)
+#define GPIO_PC11A_ADCIFE_AD11   _UL(1 << 11)
+#define PIN_PC12A_ADCIFE_AD12          _L(76) /**< \brief ADCIFE signal: AD12 on PC12 mux A */
+#define MUX_PC12A_ADCIFE_AD12           _L(0)
+#define PINMUX_PC12A_ADCIFE_AD12   ((PIN_PC12A_ADCIFE_AD12 << 16) | MUX_PC12A_ADCIFE_AD12)
+#define GPIO_PC12A_ADCIFE_AD12   _UL(1 << 12)
+#define PIN_PC13A_ADCIFE_AD13          _L(77) /**< \brief ADCIFE signal: AD13 on PC13 mux A */
+#define MUX_PC13A_ADCIFE_AD13           _L(0)
+#define PINMUX_PC13A_ADCIFE_AD13   ((PIN_PC13A_ADCIFE_AD13 << 16) | MUX_PC13A_ADCIFE_AD13)
+#define GPIO_PC13A_ADCIFE_AD13   _UL(1 << 13)
+#define PIN_PC14A_ADCIFE_AD14          _L(78) /**< \brief ADCIFE signal: AD14 on PC14 mux A */
+#define MUX_PC14A_ADCIFE_AD14           _L(0)
+#define PINMUX_PC14A_ADCIFE_AD14   ((PIN_PC14A_ADCIFE_AD14 << 16) | MUX_PC14A_ADCIFE_AD14)
+#define GPIO_PC14A_ADCIFE_AD14   _UL(1 << 14)
+#define PIN_PA05E_ADCIFE_TRIGGER        _L(5) /**< \brief ADCIFE signal: TRIGGER on PA05 mux E */
+#define MUX_PA05E_ADCIFE_TRIGGER        _L(4)
+#define PINMUX_PA05E_ADCIFE_TRIGGER  ((PIN_PA05E_ADCIFE_TRIGGER << 16) | MUX_PA05E_ADCIFE_TRIGGER)
+#define GPIO_PA05E_ADCIFE_TRIGGER  _UL(1 <<  5)
+/* ========== GPIO definition for DACC peripheral ========== */
+#define PIN_PB04E_DACC_EXT_TRIG0       _L(36) /**< \brief DACC signal: EXT_TRIG0 on PB04 mux E */
+#define MUX_PB04E_DACC_EXT_TRIG0        _L(4)
+#define PINMUX_PB04E_DACC_EXT_TRIG0  ((PIN_PB04E_DACC_EXT_TRIG0 << 16) | MUX_PB04E_DACC_EXT_TRIG0)
+#define GPIO_PB04E_DACC_EXT_TRIG0  _UL(1 <<  4)
+#define PIN_PA06A_DACC_VOUT             _L(6) /**< \brief DACC signal: VOUT on PA06 mux A */
+#define MUX_PA06A_DACC_VOUT             _L(0)
+#define PINMUX_PA06A_DACC_VOUT     ((PIN_PA06A_DACC_VOUT << 16) | MUX_PA06A_DACC_VOUT)
+#define GPIO_PA06A_DACC_VOUT     _UL(1 <<  6)
+/* ========== GPIO definition for ACIFC peripheral ========== */
+#define PIN_PA06E_ACIFC_ACAN0           _L(6) /**< \brief ACIFC signal: ACAN0 on PA06 mux E */
+#define MUX_PA06E_ACIFC_ACAN0           _L(4)
+#define PINMUX_PA06E_ACIFC_ACAN0   ((PIN_PA06E_ACIFC_ACAN0 << 16) | MUX_PA06E_ACIFC_ACAN0)
+#define GPIO_PA06E_ACIFC_ACAN0   _UL(1 <<  6)
+#define PIN_PC09E_ACIFC_ACAN1          _L(73) /**< \brief ACIFC signal: ACAN1 on PC09 mux E */
+#define MUX_PC09E_ACIFC_ACAN1           _L(4)
+#define PINMUX_PC09E_ACIFC_ACAN1   ((PIN_PC09E_ACIFC_ACAN1 << 16) | MUX_PC09E_ACIFC_ACAN1)
+#define GPIO_PC09E_ACIFC_ACAN1   _UL(1 <<  9)
+#define PIN_PA07E_ACIFC_ACAP0           _L(7) /**< \brief ACIFC signal: ACAP0 on PA07 mux E */
+#define MUX_PA07E_ACIFC_ACAP0           _L(4)
+#define PINMUX_PA07E_ACIFC_ACAP0   ((PIN_PA07E_ACIFC_ACAP0 << 16) | MUX_PA07E_ACIFC_ACAP0)
+#define GPIO_PA07E_ACIFC_ACAP0   _UL(1 <<  7)
+#define PIN_PC10E_ACIFC_ACAP1          _L(74) /**< \brief ACIFC signal: ACAP1 on PC10 mux E */
+#define MUX_PC10E_ACIFC_ACAP1           _L(4)
+#define PINMUX_PC10E_ACIFC_ACAP1   ((PIN_PC10E_ACIFC_ACAP1 << 16) | MUX_PC10E_ACIFC_ACAP1)
+#define GPIO_PC10E_ACIFC_ACAP1   _UL(1 << 10)
+#define PIN_PB02E_ACIFC_ACBN0          _L(34) /**< \brief ACIFC signal: ACBN0 on PB02 mux E */
+#define MUX_PB02E_ACIFC_ACBN0           _L(4)
+#define PINMUX_PB02E_ACIFC_ACBN0   ((PIN_PB02E_ACIFC_ACBN0 << 16) | MUX_PB02E_ACIFC_ACBN0)
+#define GPIO_PB02E_ACIFC_ACBN0   _UL(1 <<  2)
+#define PIN_PC13E_ACIFC_ACBN1          _L(77) /**< \brief ACIFC signal: ACBN1 on PC13 mux E */
+#define MUX_PC13E_ACIFC_ACBN1           _L(4)
+#define PINMUX_PC13E_ACIFC_ACBN1   ((PIN_PC13E_ACIFC_ACBN1 << 16) | MUX_PC13E_ACIFC_ACBN1)
+#define GPIO_PC13E_ACIFC_ACBN1   _UL(1 << 13)
+#define PIN_PB03E_ACIFC_ACBP0          _L(35) /**< \brief ACIFC signal: ACBP0 on PB03 mux E */
+#define MUX_PB03E_ACIFC_ACBP0           _L(4)
+#define PINMUX_PB03E_ACIFC_ACBP0   ((PIN_PB03E_ACIFC_ACBP0 << 16) | MUX_PB03E_ACIFC_ACBP0)
+#define GPIO_PB03E_ACIFC_ACBP0   _UL(1 <<  3)
+#define PIN_PC14E_ACIFC_ACBP1          _L(78) /**< \brief ACIFC signal: ACBP1 on PC14 mux E */
+#define MUX_PC14E_ACIFC_ACBP1           _L(4)
+#define PINMUX_PC14E_ACIFC_ACBP1   ((PIN_PC14E_ACIFC_ACBP1 << 16) | MUX_PC14E_ACIFC_ACBP1)
+#define GPIO_PC14E_ACIFC_ACBP1   _UL(1 << 14)
+/* ========== GPIO definition for GLOC peripheral ========== */
+#define PIN_PA06D_GLOC_IN0              _L(6) /**< \brief GLOC signal: IN0 on PA06 mux D */
+#define MUX_PA06D_GLOC_IN0              _L(3)
+#define PINMUX_PA06D_GLOC_IN0      ((PIN_PA06D_GLOC_IN0 << 16) | MUX_PA06D_GLOC_IN0)
+#define GPIO_PA06D_GLOC_IN0      _UL(1 <<  6)
+#define PIN_PA20D_GLOC_IN0             _L(20) /**< \brief GLOC signal: IN0 on PA20 mux D */
+#define MUX_PA20D_GLOC_IN0              _L(3)
+#define PINMUX_PA20D_GLOC_IN0      ((PIN_PA20D_GLOC_IN0 << 16) | MUX_PA20D_GLOC_IN0)
+#define GPIO_PA20D_GLOC_IN0      _UL(1 << 20)
+#define PIN_PA04D_GLOC_IN1              _L(4) /**< \brief GLOC signal: IN1 on PA04 mux D */
+#define MUX_PA04D_GLOC_IN1              _L(3)
+#define PINMUX_PA04D_GLOC_IN1      ((PIN_PA04D_GLOC_IN1 << 16) | MUX_PA04D_GLOC_IN1)
+#define GPIO_PA04D_GLOC_IN1      _UL(1 <<  4)
+#define PIN_PA21D_GLOC_IN1             _L(21) /**< \brief GLOC signal: IN1 on PA21 mux D */
+#define MUX_PA21D_GLOC_IN1              _L(3)
+#define PINMUX_PA21D_GLOC_IN1      ((PIN_PA21D_GLOC_IN1 << 16) | MUX_PA21D_GLOC_IN1)
+#define GPIO_PA21D_GLOC_IN1      _UL(1 << 21)
+#define PIN_PA05D_GLOC_IN2              _L(5) /**< \brief GLOC signal: IN2 on PA05 mux D */
+#define MUX_PA05D_GLOC_IN2              _L(3)
+#define PINMUX_PA05D_GLOC_IN2      ((PIN_PA05D_GLOC_IN2 << 16) | MUX_PA05D_GLOC_IN2)
+#define GPIO_PA05D_GLOC_IN2      _UL(1 <<  5)
+#define PIN_PA22D_GLOC_IN2             _L(22) /**< \brief GLOC signal: IN2 on PA22 mux D */
+#define MUX_PA22D_GLOC_IN2              _L(3)
+#define PINMUX_PA22D_GLOC_IN2      ((PIN_PA22D_GLOC_IN2 << 16) | MUX_PA22D_GLOC_IN2)
+#define GPIO_PA22D_GLOC_IN2      _UL(1 << 22)
+#define PIN_PA07D_GLOC_IN3              _L(7) /**< \brief GLOC signal: IN3 on PA07 mux D */
+#define MUX_PA07D_GLOC_IN3              _L(3)
+#define PINMUX_PA07D_GLOC_IN3      ((PIN_PA07D_GLOC_IN3 << 16) | MUX_PA07D_GLOC_IN3)
+#define GPIO_PA07D_GLOC_IN3      _UL(1 <<  7)
+#define PIN_PA23D_GLOC_IN3             _L(23) /**< \brief GLOC signal: IN3 on PA23 mux D */
+#define MUX_PA23D_GLOC_IN3              _L(3)
+#define PINMUX_PA23D_GLOC_IN3      ((PIN_PA23D_GLOC_IN3 << 16) | MUX_PA23D_GLOC_IN3)
+#define GPIO_PA23D_GLOC_IN3      _UL(1 << 23)
+#define PIN_PA27D_GLOC_IN4             _L(27) /**< \brief GLOC signal: IN4 on PA27 mux D */
+#define MUX_PA27D_GLOC_IN4              _L(3)
+#define PINMUX_PA27D_GLOC_IN4      ((PIN_PA27D_GLOC_IN4 << 16) | MUX_PA27D_GLOC_IN4)
+#define GPIO_PA27D_GLOC_IN4      _UL(1 << 27)
+#define PIN_PC15D_GLOC_IN4             _L(79) /**< \brief GLOC signal: IN4 on PC15 mux D */
+#define MUX_PC15D_GLOC_IN4              _L(3)
+#define PINMUX_PC15D_GLOC_IN4      ((PIN_PC15D_GLOC_IN4 << 16) | MUX_PC15D_GLOC_IN4)
+#define GPIO_PC15D_GLOC_IN4      _UL(1 << 15)
+#define PIN_PB06C_GLOC_IN4             _L(38) /**< \brief GLOC signal: IN4 on PB06 mux C */
+#define MUX_PB06C_GLOC_IN4              _L(2)
+#define PINMUX_PB06C_GLOC_IN4      ((PIN_PB06C_GLOC_IN4 << 16) | MUX_PB06C_GLOC_IN4)
+#define GPIO_PB06C_GLOC_IN4      _UL(1 <<  6)
+#define PIN_PC28C_GLOC_IN4             _L(92) /**< \brief GLOC signal: IN4 on PC28 mux C */
+#define MUX_PC28C_GLOC_IN4              _L(2)
+#define PINMUX_PC28C_GLOC_IN4      ((PIN_PC28C_GLOC_IN4 << 16) | MUX_PC28C_GLOC_IN4)
+#define GPIO_PC28C_GLOC_IN4      _UL(1 << 28)
+#define PIN_PA28D_GLOC_IN5             _L(28) /**< \brief GLOC signal: IN5 on PA28 mux D */
+#define MUX_PA28D_GLOC_IN5              _L(3)
+#define PINMUX_PA28D_GLOC_IN5      ((PIN_PA28D_GLOC_IN5 << 16) | MUX_PA28D_GLOC_IN5)
+#define GPIO_PA28D_GLOC_IN5      _UL(1 << 28)
+#define PIN_PC16D_GLOC_IN5             _L(80) /**< \brief GLOC signal: IN5 on PC16 mux D */
+#define MUX_PC16D_GLOC_IN5              _L(3)
+#define PINMUX_PC16D_GLOC_IN5      ((PIN_PC16D_GLOC_IN5 << 16) | MUX_PC16D_GLOC_IN5)
+#define GPIO_PC16D_GLOC_IN5      _UL(1 << 16)
+#define PIN_PB07C_GLOC_IN5             _L(39) /**< \brief GLOC signal: IN5 on PB07 mux C */
+#define MUX_PB07C_GLOC_IN5              _L(2)
+#define PINMUX_PB07C_GLOC_IN5      ((PIN_PB07C_GLOC_IN5 << 16) | MUX_PB07C_GLOC_IN5)
+#define GPIO_PB07C_GLOC_IN5      _UL(1 <<  7)
+#define PIN_PC29C_GLOC_IN5             _L(93) /**< \brief GLOC signal: IN5 on PC29 mux C */
+#define MUX_PC29C_GLOC_IN5              _L(2)
+#define PINMUX_PC29C_GLOC_IN5      ((PIN_PC29C_GLOC_IN5 << 16) | MUX_PC29C_GLOC_IN5)
+#define GPIO_PC29C_GLOC_IN5      _UL(1 << 29)
+#define PIN_PA29D_GLOC_IN6             _L(29) /**< \brief GLOC signal: IN6 on PA29 mux D */
+#define MUX_PA29D_GLOC_IN6              _L(3)
+#define PINMUX_PA29D_GLOC_IN6      ((PIN_PA29D_GLOC_IN6 << 16) | MUX_PA29D_GLOC_IN6)
+#define GPIO_PA29D_GLOC_IN6      _UL(1 << 29)
+#define PIN_PC17D_GLOC_IN6             _L(81) /**< \brief GLOC signal: IN6 on PC17 mux D */
+#define MUX_PC17D_GLOC_IN6              _L(3)
+#define PINMUX_PC17D_GLOC_IN6      ((PIN_PC17D_GLOC_IN6 << 16) | MUX_PC17D_GLOC_IN6)
+#define GPIO_PC17D_GLOC_IN6      _UL(1 << 17)
+#define PIN_PB08C_GLOC_IN6             _L(40) /**< \brief GLOC signal: IN6 on PB08 mux C */
+#define MUX_PB08C_GLOC_IN6              _L(2)
+#define PINMUX_PB08C_GLOC_IN6      ((PIN_PB08C_GLOC_IN6 << 16) | MUX_PB08C_GLOC_IN6)
+#define GPIO_PB08C_GLOC_IN6      _UL(1 <<  8)
+#define PIN_PC30C_GLOC_IN6             _L(94) /**< \brief GLOC signal: IN6 on PC30 mux C */
+#define MUX_PC30C_GLOC_IN6              _L(2)
+#define PINMUX_PC30C_GLOC_IN6      ((PIN_PC30C_GLOC_IN6 << 16) | MUX_PC30C_GLOC_IN6)
+#define GPIO_PC30C_GLOC_IN6      _UL(1 << 30)
+#define PIN_PA30D_GLOC_IN7             _L(30) /**< \brief GLOC signal: IN7 on PA30 mux D */
+#define MUX_PA30D_GLOC_IN7              _L(3)
+#define PINMUX_PA30D_GLOC_IN7      ((PIN_PA30D_GLOC_IN7 << 16) | MUX_PA30D_GLOC_IN7)
+#define GPIO_PA30D_GLOC_IN7      _UL(1 << 30)
+#define PIN_PC18D_GLOC_IN7             _L(82) /**< \brief GLOC signal: IN7 on PC18 mux D */
+#define MUX_PC18D_GLOC_IN7              _L(3)
+#define PINMUX_PC18D_GLOC_IN7      ((PIN_PC18D_GLOC_IN7 << 16) | MUX_PC18D_GLOC_IN7)
+#define GPIO_PC18D_GLOC_IN7      _UL(1 << 18)
+#define PIN_PB09C_GLOC_IN7             _L(41) /**< \brief GLOC signal: IN7 on PB09 mux C */
+#define MUX_PB09C_GLOC_IN7              _L(2)
+#define PINMUX_PB09C_GLOC_IN7      ((PIN_PB09C_GLOC_IN7 << 16) | MUX_PB09C_GLOC_IN7)
+#define GPIO_PB09C_GLOC_IN7      _UL(1 <<  9)
+#define PIN_PA08D_GLOC_OUT0             _L(8) /**< \brief GLOC signal: OUT0 on PA08 mux D */
+#define MUX_PA08D_GLOC_OUT0             _L(3)
+#define PINMUX_PA08D_GLOC_OUT0     ((PIN_PA08D_GLOC_OUT0 << 16) | MUX_PA08D_GLOC_OUT0)
+#define GPIO_PA08D_GLOC_OUT0     _UL(1 <<  8)
+#define PIN_PA24D_GLOC_OUT0            _L(24) /**< \brief GLOC signal: OUT0 on PA24 mux D */
+#define MUX_PA24D_GLOC_OUT0             _L(3)
+#define PINMUX_PA24D_GLOC_OUT0     ((PIN_PA24D_GLOC_OUT0 << 16) | MUX_PA24D_GLOC_OUT0)
+#define GPIO_PA24D_GLOC_OUT0     _UL(1 << 24)
+#define PIN_PA31D_GLOC_OUT1            _L(31) /**< \brief GLOC signal: OUT1 on PA31 mux D */
+#define MUX_PA31D_GLOC_OUT1             _L(3)
+#define PINMUX_PA31D_GLOC_OUT1     ((PIN_PA31D_GLOC_OUT1 << 16) | MUX_PA31D_GLOC_OUT1)
+#define GPIO_PA31D_GLOC_OUT1     _UL(1 << 31)
+#define PIN_PC19D_GLOC_OUT1            _L(83) /**< \brief GLOC signal: OUT1 on PC19 mux D */
+#define MUX_PC19D_GLOC_OUT1             _L(3)
+#define PINMUX_PC19D_GLOC_OUT1     ((PIN_PC19D_GLOC_OUT1 << 16) | MUX_PC19D_GLOC_OUT1)
+#define GPIO_PC19D_GLOC_OUT1     _UL(1 << 19)
+#define PIN_PB10C_GLOC_OUT1            _L(42) /**< \brief GLOC signal: OUT1 on PB10 mux C */
+#define MUX_PB10C_GLOC_OUT1             _L(2)
+#define PINMUX_PB10C_GLOC_OUT1     ((PIN_PB10C_GLOC_OUT1 << 16) | MUX_PB10C_GLOC_OUT1)
+#define GPIO_PB10C_GLOC_OUT1     _UL(1 << 10)
+#define PIN_PC31C_GLOC_OUT1            _L(95) /**< \brief GLOC signal: OUT1 on PC31 mux C */
+#define MUX_PC31C_GLOC_OUT1             _L(2)
+#define PINMUX_PC31C_GLOC_OUT1     ((PIN_PC31C_GLOC_OUT1 << 16) | MUX_PC31C_GLOC_OUT1)
+#define GPIO_PC31C_GLOC_OUT1     _UL(1 << 31)
+/* ========== GPIO definition for ABDACB peripheral ========== */
+#define PIN_PA31C_ABDACB_CLK           _L(31) /**< \brief ABDACB signal: CLK on PA31 mux C */
+#define MUX_PA31C_ABDACB_CLK            _L(2)
+#define PINMUX_PA31C_ABDACB_CLK    ((PIN_PA31C_ABDACB_CLK << 16) | MUX_PA31C_ABDACB_CLK)
+#define GPIO_PA31C_ABDACB_CLK    _UL(1 << 31)
+#define PIN_PC12C_ABDACB_CLK           _L(76) /**< \brief ABDACB signal: CLK on PC12 mux C */
+#define MUX_PC12C_ABDACB_CLK            _L(2)
+#define PINMUX_PC12C_ABDACB_CLK    ((PIN_PC12C_ABDACB_CLK << 16) | MUX_PC12C_ABDACB_CLK)
+#define GPIO_PC12C_ABDACB_CLK    _UL(1 << 12)
+#define PIN_PA27C_ABDACB_DAC0          _L(27) /**< \brief ABDACB signal: DAC0 on PA27 mux C */
+#define MUX_PA27C_ABDACB_DAC0           _L(2)
+#define PINMUX_PA27C_ABDACB_DAC0   ((PIN_PA27C_ABDACB_DAC0 << 16) | MUX_PA27C_ABDACB_DAC0)
+#define GPIO_PA27C_ABDACB_DAC0   _UL(1 << 27)
+#define PIN_PB02C_ABDACB_DAC0          _L(34) /**< \brief ABDACB signal: DAC0 on PB02 mux C */
+#define MUX_PB02C_ABDACB_DAC0           _L(2)
+#define PINMUX_PB02C_ABDACB_DAC0   ((PIN_PB02C_ABDACB_DAC0 << 16) | MUX_PB02C_ABDACB_DAC0)
+#define GPIO_PB02C_ABDACB_DAC0   _UL(1 <<  2)
+#define PIN_PC09C_ABDACB_DAC0          _L(73) /**< \brief ABDACB signal: DAC0 on PC09 mux C */
+#define MUX_PC09C_ABDACB_DAC0           _L(2)
+#define PINMUX_PC09C_ABDACB_DAC0   ((PIN_PC09C_ABDACB_DAC0 << 16) | MUX_PC09C_ABDACB_DAC0)
+#define GPIO_PC09C_ABDACB_DAC0   _UL(1 <<  9)
+#define PIN_PA17B_ABDACB_DAC0          _L(17) /**< \brief ABDACB signal: DAC0 on PA17 mux B */
+#define MUX_PA17B_ABDACB_DAC0           _L(1)
+#define PINMUX_PA17B_ABDACB_DAC0   ((PIN_PA17B_ABDACB_DAC0 << 16) | MUX_PA17B_ABDACB_DAC0)
+#define GPIO_PA17B_ABDACB_DAC0   _UL(1 << 17)
+#define PIN_PA29C_ABDACB_DAC1          _L(29) /**< \brief ABDACB signal: DAC1 on PA29 mux C */
+#define MUX_PA29C_ABDACB_DAC1           _L(2)
+#define PINMUX_PA29C_ABDACB_DAC1   ((PIN_PA29C_ABDACB_DAC1 << 16) | MUX_PA29C_ABDACB_DAC1)
+#define GPIO_PA29C_ABDACB_DAC1   _UL(1 << 29)
+#define PIN_PB04C_ABDACB_DAC1          _L(36) /**< \brief ABDACB signal: DAC1 on PB04 mux C */
+#define MUX_PB04C_ABDACB_DAC1           _L(2)
+#define PINMUX_PB04C_ABDACB_DAC1   ((PIN_PB04C_ABDACB_DAC1 << 16) | MUX_PB04C_ABDACB_DAC1)
+#define GPIO_PB04C_ABDACB_DAC1   _UL(1 <<  4)
+#define PIN_PC13C_ABDACB_DAC1          _L(77) /**< \brief ABDACB signal: DAC1 on PC13 mux C */
+#define MUX_PC13C_ABDACB_DAC1           _L(2)
+#define PINMUX_PC13C_ABDACB_DAC1   ((PIN_PC13C_ABDACB_DAC1 << 16) | MUX_PC13C_ABDACB_DAC1)
+#define GPIO_PC13C_ABDACB_DAC1   _UL(1 << 13)
+#define PIN_PA19B_ABDACB_DAC1          _L(19) /**< \brief ABDACB signal: DAC1 on PA19 mux B */
+#define MUX_PA19B_ABDACB_DAC1           _L(1)
+#define PINMUX_PA19B_ABDACB_DAC1   ((PIN_PA19B_ABDACB_DAC1 << 16) | MUX_PA19B_ABDACB_DAC1)
+#define GPIO_PA19B_ABDACB_DAC1   _UL(1 << 19)
+#define PIN_PA28C_ABDACB_DACN0         _L(28) /**< \brief ABDACB signal: DACN0 on PA28 mux C */
+#define MUX_PA28C_ABDACB_DACN0          _L(2)
+#define PINMUX_PA28C_ABDACB_DACN0  ((PIN_PA28C_ABDACB_DACN0 << 16) | MUX_PA28C_ABDACB_DACN0)
+#define GPIO_PA28C_ABDACB_DACN0  _UL(1 << 28)
+#define PIN_PB03C_ABDACB_DACN0         _L(35) /**< \brief ABDACB signal: DACN0 on PB03 mux C */
+#define MUX_PB03C_ABDACB_DACN0          _L(2)
+#define PINMUX_PB03C_ABDACB_DACN0  ((PIN_PB03C_ABDACB_DACN0 << 16) | MUX_PB03C_ABDACB_DACN0)
+#define GPIO_PB03C_ABDACB_DACN0  _UL(1 <<  3)
+#define PIN_PC10C_ABDACB_DACN0         _L(74) /**< \brief ABDACB signal: DACN0 on PC10 mux C */
+#define MUX_PC10C_ABDACB_DACN0          _L(2)
+#define PINMUX_PC10C_ABDACB_DACN0  ((PIN_PC10C_ABDACB_DACN0 << 16) | MUX_PC10C_ABDACB_DACN0)
+#define GPIO_PC10C_ABDACB_DACN0  _UL(1 << 10)
+#define PIN_PA18B_ABDACB_DACN0         _L(18) /**< \brief ABDACB signal: DACN0 on PA18 mux B */
+#define MUX_PA18B_ABDACB_DACN0          _L(1)
+#define PINMUX_PA18B_ABDACB_DACN0  ((PIN_PA18B_ABDACB_DACN0 << 16) | MUX_PA18B_ABDACB_DACN0)
+#define GPIO_PA18B_ABDACB_DACN0  _UL(1 << 18)
+#define PIN_PA30C_ABDACB_DACN1         _L(30) /**< \brief ABDACB signal: DACN1 on PA30 mux C */
+#define MUX_PA30C_ABDACB_DACN1          _L(2)
+#define PINMUX_PA30C_ABDACB_DACN1  ((PIN_PA30C_ABDACB_DACN1 << 16) | MUX_PA30C_ABDACB_DACN1)
+#define GPIO_PA30C_ABDACB_DACN1  _UL(1 << 30)
+#define PIN_PB05C_ABDACB_DACN1         _L(37) /**< \brief ABDACB signal: DACN1 on PB05 mux C */
+#define MUX_PB05C_ABDACB_DACN1          _L(2)
+#define PINMUX_PB05C_ABDACB_DACN1  ((PIN_PB05C_ABDACB_DACN1 << 16) | MUX_PB05C_ABDACB_DACN1)
+#define GPIO_PB05C_ABDACB_DACN1  _UL(1 <<  5)
+#define PIN_PC14C_ABDACB_DACN1         _L(78) /**< \brief ABDACB signal: DACN1 on PC14 mux C */
+#define MUX_PC14C_ABDACB_DACN1          _L(2)
+#define PINMUX_PC14C_ABDACB_DACN1  ((PIN_PC14C_ABDACB_DACN1 << 16) | MUX_PC14C_ABDACB_DACN1)
+#define GPIO_PC14C_ABDACB_DACN1  _UL(1 << 14)
+#define PIN_PA20B_ABDACB_DACN1         _L(20) /**< \brief ABDACB signal: DACN1 on PA20 mux B */
+#define MUX_PA20B_ABDACB_DACN1          _L(1)
+#define PINMUX_PA20B_ABDACB_DACN1  ((PIN_PA20B_ABDACB_DACN1 << 16) | MUX_PA20B_ABDACB_DACN1)
+#define GPIO_PA20B_ABDACB_DACN1  _UL(1 << 20)
+/* ========== GPIO definition for PARC peripheral ========== */
+#define PIN_PA17D_PARC_PCCK            _L(17) /**< \brief PARC signal: PCCK on PA17 mux D */
+#define MUX_PA17D_PARC_PCCK             _L(3)
+#define PINMUX_PA17D_PARC_PCCK     ((PIN_PA17D_PARC_PCCK << 16) | MUX_PA17D_PARC_PCCK)
+#define GPIO_PA17D_PARC_PCCK     _UL(1 << 17)
+#define PIN_PC21D_PARC_PCCK            _L(85) /**< \brief PARC signal: PCCK on PC21 mux D */
+#define MUX_PC21D_PARC_PCCK             _L(3)
+#define PINMUX_PC21D_PARC_PCCK     ((PIN_PC21D_PARC_PCCK << 16) | MUX_PC21D_PARC_PCCK)
+#define GPIO_PC21D_PARC_PCCK     _UL(1 << 21)
+#define PIN_PA09D_PARC_PCDATA0          _L(9) /**< \brief PARC signal: PCDATA0 on PA09 mux D */
+#define MUX_PA09D_PARC_PCDATA0          _L(3)
+#define PINMUX_PA09D_PARC_PCDATA0  ((PIN_PA09D_PARC_PCDATA0 << 16) | MUX_PA09D_PARC_PCDATA0)
+#define GPIO_PA09D_PARC_PCDATA0  _UL(1 <<  9)
+#define PIN_PC24D_PARC_PCDATA0         _L(88) /**< \brief PARC signal: PCDATA0 on PC24 mux D */
+#define MUX_PC24D_PARC_PCDATA0          _L(3)
+#define PINMUX_PC24D_PARC_PCDATA0  ((PIN_PC24D_PARC_PCDATA0 << 16) | MUX_PC24D_PARC_PCDATA0)
+#define GPIO_PC24D_PARC_PCDATA0  _UL(1 << 24)
+#define PIN_PA10D_PARC_PCDATA1         _L(10) /**< \brief PARC signal: PCDATA1 on PA10 mux D */
+#define MUX_PA10D_PARC_PCDATA1          _L(3)
+#define PINMUX_PA10D_PARC_PCDATA1  ((PIN_PA10D_PARC_PCDATA1 << 16) | MUX_PA10D_PARC_PCDATA1)
+#define GPIO_PA10D_PARC_PCDATA1  _UL(1 << 10)
+#define PIN_PC25D_PARC_PCDATA1         _L(89) /**< \brief PARC signal: PCDATA1 on PC25 mux D */
+#define MUX_PC25D_PARC_PCDATA1          _L(3)
+#define PINMUX_PC25D_PARC_PCDATA1  ((PIN_PC25D_PARC_PCDATA1 << 16) | MUX_PC25D_PARC_PCDATA1)
+#define GPIO_PC25D_PARC_PCDATA1  _UL(1 << 25)
+#define PIN_PA11D_PARC_PCDATA2         _L(11) /**< \brief PARC signal: PCDATA2 on PA11 mux D */
+#define MUX_PA11D_PARC_PCDATA2          _L(3)
+#define PINMUX_PA11D_PARC_PCDATA2  ((PIN_PA11D_PARC_PCDATA2 << 16) | MUX_PA11D_PARC_PCDATA2)
+#define GPIO_PA11D_PARC_PCDATA2  _UL(1 << 11)
+#define PIN_PC26D_PARC_PCDATA2         _L(90) /**< \brief PARC signal: PCDATA2 on PC26 mux D */
+#define MUX_PC26D_PARC_PCDATA2          _L(3)
+#define PINMUX_PC26D_PARC_PCDATA2  ((PIN_PC26D_PARC_PCDATA2 << 16) | MUX_PC26D_PARC_PCDATA2)
+#define GPIO_PC26D_PARC_PCDATA2  _UL(1 << 26)
+#define PIN_PA12D_PARC_PCDATA3         _L(12) /**< \brief PARC signal: PCDATA3 on PA12 mux D */
+#define MUX_PA12D_PARC_PCDATA3          _L(3)
+#define PINMUX_PA12D_PARC_PCDATA3  ((PIN_PA12D_PARC_PCDATA3 << 16) | MUX_PA12D_PARC_PCDATA3)
+#define GPIO_PA12D_PARC_PCDATA3  _UL(1 << 12)
+#define PIN_PC27D_PARC_PCDATA3         _L(91) /**< \brief PARC signal: PCDATA3 on PC27 mux D */
+#define MUX_PC27D_PARC_PCDATA3          _L(3)
+#define PINMUX_PC27D_PARC_PCDATA3  ((PIN_PC27D_PARC_PCDATA3 << 16) | MUX_PC27D_PARC_PCDATA3)
+#define GPIO_PC27D_PARC_PCDATA3  _UL(1 << 27)
+#define PIN_PA13D_PARC_PCDATA4         _L(13) /**< \brief PARC signal: PCDATA4 on PA13 mux D */
+#define MUX_PA13D_PARC_PCDATA4          _L(3)
+#define PINMUX_PA13D_PARC_PCDATA4  ((PIN_PA13D_PARC_PCDATA4 << 16) | MUX_PA13D_PARC_PCDATA4)
+#define GPIO_PA13D_PARC_PCDATA4  _UL(1 << 13)
+#define PIN_PC28D_PARC_PCDATA4         _L(92) /**< \brief PARC signal: PCDATA4 on PC28 mux D */
+#define MUX_PC28D_PARC_PCDATA4          _L(3)
+#define PINMUX_PC28D_PARC_PCDATA4  ((PIN_PC28D_PARC_PCDATA4 << 16) | MUX_PC28D_PARC_PCDATA4)
+#define GPIO_PC28D_PARC_PCDATA4  _UL(1 << 28)
+#define PIN_PA14D_PARC_PCDATA5         _L(14) /**< \brief PARC signal: PCDATA5 on PA14 mux D */
+#define MUX_PA14D_PARC_PCDATA5          _L(3)
+#define PINMUX_PA14D_PARC_PCDATA5  ((PIN_PA14D_PARC_PCDATA5 << 16) | MUX_PA14D_PARC_PCDATA5)
+#define GPIO_PA14D_PARC_PCDATA5  _UL(1 << 14)
+#define PIN_PC29D_PARC_PCDATA5         _L(93) /**< \brief PARC signal: PCDATA5 on PC29 mux D */
+#define MUX_PC29D_PARC_PCDATA5          _L(3)
+#define PINMUX_PC29D_PARC_PCDATA5  ((PIN_PC29D_PARC_PCDATA5 << 16) | MUX_PC29D_PARC_PCDATA5)
+#define GPIO_PC29D_PARC_PCDATA5  _UL(1 << 29)
+#define PIN_PA15D_PARC_PCDATA6         _L(15) /**< \brief PARC signal: PCDATA6 on PA15 mux D */
+#define MUX_PA15D_PARC_PCDATA6          _L(3)
+#define PINMUX_PA15D_PARC_PCDATA6  ((PIN_PA15D_PARC_PCDATA6 << 16) | MUX_PA15D_PARC_PCDATA6)
+#define GPIO_PA15D_PARC_PCDATA6  _UL(1 << 15)
+#define PIN_PC30D_PARC_PCDATA6         _L(94) /**< \brief PARC signal: PCDATA6 on PC30 mux D */
+#define MUX_PC30D_PARC_PCDATA6          _L(3)
+#define PINMUX_PC30D_PARC_PCDATA6  ((PIN_PC30D_PARC_PCDATA6 << 16) | MUX_PC30D_PARC_PCDATA6)
+#define GPIO_PC30D_PARC_PCDATA6  _UL(1 << 30)
+#define PIN_PA16D_PARC_PCDATA7         _L(16) /**< \brief PARC signal: PCDATA7 on PA16 mux D */
+#define MUX_PA16D_PARC_PCDATA7          _L(3)
+#define PINMUX_PA16D_PARC_PCDATA7  ((PIN_PA16D_PARC_PCDATA7 << 16) | MUX_PA16D_PARC_PCDATA7)
+#define GPIO_PA16D_PARC_PCDATA7  _UL(1 << 16)
+#define PIN_PC31D_PARC_PCDATA7         _L(95) /**< \brief PARC signal: PCDATA7 on PC31 mux D */
+#define MUX_PC31D_PARC_PCDATA7          _L(3)
+#define PINMUX_PC31D_PARC_PCDATA7  ((PIN_PC31D_PARC_PCDATA7 << 16) | MUX_PC31D_PARC_PCDATA7)
+#define GPIO_PC31D_PARC_PCDATA7  _UL(1 << 31)
+#define PIN_PA18D_PARC_PCEN1           _L(18) /**< \brief PARC signal: PCEN1 on PA18 mux D */
+#define MUX_PA18D_PARC_PCEN1            _L(3)
+#define PINMUX_PA18D_PARC_PCEN1    ((PIN_PA18D_PARC_PCEN1 << 16) | MUX_PA18D_PARC_PCEN1)
+#define GPIO_PA18D_PARC_PCEN1    _UL(1 << 18)
+#define PIN_PC22D_PARC_PCEN1           _L(86) /**< \brief PARC signal: PCEN1 on PC22 mux D */
+#define MUX_PC22D_PARC_PCEN1            _L(3)
+#define PINMUX_PC22D_PARC_PCEN1    ((PIN_PC22D_PARC_PCEN1 << 16) | MUX_PC22D_PARC_PCEN1)
+#define GPIO_PC22D_PARC_PCEN1    _UL(1 << 22)
+#define PIN_PA19D_PARC_PCEN2           _L(19) /**< \brief PARC signal: PCEN2 on PA19 mux D */
+#define MUX_PA19D_PARC_PCEN2            _L(3)
+#define PINMUX_PA19D_PARC_PCEN2    ((PIN_PA19D_PARC_PCEN2 << 16) | MUX_PA19D_PARC_PCEN2)
+#define GPIO_PA19D_PARC_PCEN2    _UL(1 << 19)
+#define PIN_PC23D_PARC_PCEN2           _L(87) /**< \brief PARC signal: PCEN2 on PC23 mux D */
+#define MUX_PC23D_PARC_PCEN2            _L(3)
+#define PINMUX_PC23D_PARC_PCEN2    ((PIN_PC23D_PARC_PCEN2 << 16) | MUX_PC23D_PARC_PCEN2)
+#define GPIO_PC23D_PARC_PCEN2    _UL(1 << 23)
+/* ========== GPIO definition for CATB peripheral ========== */
+#define PIN_PA02G_CATB_DIS              _L(2) /**< \brief CATB signal: DIS on PA02 mux G */
+#define MUX_PA02G_CATB_DIS              _L(6)
+#define PINMUX_PA02G_CATB_DIS      ((PIN_PA02G_CATB_DIS << 16) | MUX_PA02G_CATB_DIS)
+#define GPIO_PA02G_CATB_DIS      _UL(1 <<  2)
+#define PIN_PA12G_CATB_DIS             _L(12) /**< \brief CATB signal: DIS on PA12 mux G */
+#define MUX_PA12G_CATB_DIS              _L(6)
+#define PINMUX_PA12G_CATB_DIS      ((PIN_PA12G_CATB_DIS << 16) | MUX_PA12G_CATB_DIS)
+#define GPIO_PA12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PA23G_CATB_DIS             _L(23) /**< \brief CATB signal: DIS on PA23 mux G */
+#define MUX_PA23G_CATB_DIS              _L(6)
+#define PINMUX_PA23G_CATB_DIS      ((PIN_PA23G_CATB_DIS << 16) | MUX_PA23G_CATB_DIS)
+#define GPIO_PA23G_CATB_DIS      _UL(1 << 23)
+#define PIN_PA31G_CATB_DIS             _L(31) /**< \brief CATB signal: DIS on PA31 mux G */
+#define MUX_PA31G_CATB_DIS              _L(6)
+#define PINMUX_PA31G_CATB_DIS      ((PIN_PA31G_CATB_DIS << 16) | MUX_PA31G_CATB_DIS)
+#define GPIO_PA31G_CATB_DIS      _UL(1 << 31)
+#define PIN_PB03G_CATB_DIS             _L(35) /**< \brief CATB signal: DIS on PB03 mux G */
+#define MUX_PB03G_CATB_DIS              _L(6)
+#define PINMUX_PB03G_CATB_DIS      ((PIN_PB03G_CATB_DIS << 16) | MUX_PB03G_CATB_DIS)
+#define GPIO_PB03G_CATB_DIS      _UL(1 <<  3)
+#define PIN_PB12G_CATB_DIS             _L(44) /**< \brief CATB signal: DIS on PB12 mux G */
+#define MUX_PB12G_CATB_DIS              _L(6)
+#define PINMUX_PB12G_CATB_DIS      ((PIN_PB12G_CATB_DIS << 16) | MUX_PB12G_CATB_DIS)
+#define GPIO_PB12G_CATB_DIS      _UL(1 << 12)
+#define PIN_PC05G_CATB_DIS             _L(69) /**< \brief CATB signal: DIS on PC05 mux G */
+#define MUX_PC05G_CATB_DIS              _L(6)
+#define PINMUX_PC05G_CATB_DIS      ((PIN_PC05G_CATB_DIS << 16) | MUX_PC05G_CATB_DIS)
+#define GPIO_PC05G_CATB_DIS      _UL(1 <<  5)
+#define PIN_PC14G_CATB_DIS             _L(78) /**< \brief CATB signal: DIS on PC14 mux G */
+#define MUX_PC14G_CATB_DIS              _L(6)
+#define PINMUX_PC14G_CATB_DIS      ((PIN_PC14G_CATB_DIS << 16) | MUX_PC14G_CATB_DIS)
+#define GPIO_PC14G_CATB_DIS      _UL(1 << 14)
+#define PIN_PC23G_CATB_DIS             _L(87) /**< \brief CATB signal: DIS on PC23 mux G */
+#define MUX_PC23G_CATB_DIS              _L(6)
+#define PINMUX_PC23G_CATB_DIS      ((PIN_PC23G_CATB_DIS << 16) | MUX_PC23G_CATB_DIS)
+#define GPIO_PC23G_CATB_DIS      _UL(1 << 23)
+#define PIN_PA04G_CATB_SENSE0           _L(4) /**< \brief CATB signal: SENSE0 on PA04 mux G */
+#define MUX_PA04G_CATB_SENSE0           _L(6)
+#define PINMUX_PA04G_CATB_SENSE0   ((PIN_PA04G_CATB_SENSE0 << 16) | MUX_PA04G_CATB_SENSE0)
+#define GPIO_PA04G_CATB_SENSE0   _UL(1 <<  4)
+#define PIN_PA27G_CATB_SENSE0          _L(27) /**< \brief CATB signal: SENSE0 on PA27 mux G */
+#define MUX_PA27G_CATB_SENSE0           _L(6)
+#define PINMUX_PA27G_CATB_SENSE0   ((PIN_PA27G_CATB_SENSE0 << 16) | MUX_PA27G_CATB_SENSE0)
+#define GPIO_PA27G_CATB_SENSE0   _UL(1 << 27)
+#define PIN_PB13G_CATB_SENSE0          _L(45) /**< \brief CATB signal: SENSE0 on PB13 mux G */
+#define MUX_PB13G_CATB_SENSE0           _L(6)
+#define PINMUX_PB13G_CATB_SENSE0   ((PIN_PB13G_CATB_SENSE0 << 16) | MUX_PB13G_CATB_SENSE0)
+#define GPIO_PB13G_CATB_SENSE0   _UL(1 << 13)
+#define PIN_PA05G_CATB_SENSE1           _L(5) /**< \brief CATB signal: SENSE1 on PA05 mux G */
+#define MUX_PA05G_CATB_SENSE1           _L(6)
+#define PINMUX_PA05G_CATB_SENSE1   ((PIN_PA05G_CATB_SENSE1 << 16) | MUX_PA05G_CATB_SENSE1)
+#define GPIO_PA05G_CATB_SENSE1   _UL(1 <<  5)
+#define PIN_PA28G_CATB_SENSE1          _L(28) /**< \brief CATB signal: SENSE1 on PA28 mux G */
+#define MUX_PA28G_CATB_SENSE1           _L(6)
+#define PINMUX_PA28G_CATB_SENSE1   ((PIN_PA28G_CATB_SENSE1 << 16) | MUX_PA28G_CATB_SENSE1)
+#define GPIO_PA28G_CATB_SENSE1   _UL(1 << 28)
+#define PIN_PB14G_CATB_SENSE1          _L(46) /**< \brief CATB signal: SENSE1 on PB14 mux G */
+#define MUX_PB14G_CATB_SENSE1           _L(6)
+#define PINMUX_PB14G_CATB_SENSE1   ((PIN_PB14G_CATB_SENSE1 << 16) | MUX_PB14G_CATB_SENSE1)
+#define GPIO_PB14G_CATB_SENSE1   _UL(1 << 14)
+#define PIN_PA06G_CATB_SENSE2           _L(6) /**< \brief CATB signal: SENSE2 on PA06 mux G */
+#define MUX_PA06G_CATB_SENSE2           _L(6)
+#define PINMUX_PA06G_CATB_SENSE2   ((PIN_PA06G_CATB_SENSE2 << 16) | MUX_PA06G_CATB_SENSE2)
+#define GPIO_PA06G_CATB_SENSE2   _UL(1 <<  6)
+#define PIN_PA29G_CATB_SENSE2          _L(29) /**< \brief CATB signal: SENSE2 on PA29 mux G */
+#define MUX_PA29G_CATB_SENSE2           _L(6)
+#define PINMUX_PA29G_CATB_SENSE2   ((PIN_PA29G_CATB_SENSE2 << 16) | MUX_PA29G_CATB_SENSE2)
+#define GPIO_PA29G_CATB_SENSE2   _UL(1 << 29)
+#define PIN_PB15G_CATB_SENSE2          _L(47) /**< \brief CATB signal: SENSE2 on PB15 mux G */
+#define MUX_PB15G_CATB_SENSE2           _L(6)
+#define PINMUX_PB15G_CATB_SENSE2   ((PIN_PB15G_CATB_SENSE2 << 16) | MUX_PB15G_CATB_SENSE2)
+#define GPIO_PB15G_CATB_SENSE2   _UL(1 << 15)
+#define PIN_PA07G_CATB_SENSE3           _L(7) /**< \brief CATB signal: SENSE3 on PA07 mux G */
+#define MUX_PA07G_CATB_SENSE3           _L(6)
+#define PINMUX_PA07G_CATB_SENSE3   ((PIN_PA07G_CATB_SENSE3 << 16) | MUX_PA07G_CATB_SENSE3)
+#define GPIO_PA07G_CATB_SENSE3   _UL(1 <<  7)
+#define PIN_PA30G_CATB_SENSE3          _L(30) /**< \brief CATB signal: SENSE3 on PA30 mux G */
+#define MUX_PA30G_CATB_SENSE3           _L(6)
+#define PINMUX_PA30G_CATB_SENSE3   ((PIN_PA30G_CATB_SENSE3 << 16) | MUX_PA30G_CATB_SENSE3)
+#define GPIO_PA30G_CATB_SENSE3   _UL(1 << 30)
+#define PIN_PC00G_CATB_SENSE3          _L(64) /**< \brief CATB signal: SENSE3 on PC00 mux G */
+#define MUX_PC00G_CATB_SENSE3           _L(6)
+#define PINMUX_PC00G_CATB_SENSE3   ((PIN_PC00G_CATB_SENSE3 << 16) | MUX_PC00G_CATB_SENSE3)
+#define GPIO_PC00G_CATB_SENSE3   _UL(1 <<  0)
+#define PIN_PA08G_CATB_SENSE4           _L(8) /**< \brief CATB signal: SENSE4 on PA08 mux G */
+#define MUX_PA08G_CATB_SENSE4           _L(6)
+#define PINMUX_PA08G_CATB_SENSE4   ((PIN_PA08G_CATB_SENSE4 << 16) | MUX_PA08G_CATB_SENSE4)
+#define GPIO_PA08G_CATB_SENSE4   _UL(1 <<  8)
+#define PIN_PC01G_CATB_SENSE4          _L(65) /**< \brief CATB signal: SENSE4 on PC01 mux G */
+#define MUX_PC01G_CATB_SENSE4           _L(6)
+#define PINMUX_PC01G_CATB_SENSE4   ((PIN_PC01G_CATB_SENSE4 << 16) | MUX_PC01G_CATB_SENSE4)
+#define GPIO_PC01G_CATB_SENSE4   _UL(1 <<  1)
+#define PIN_PA09G_CATB_SENSE5           _L(9) /**< \brief CATB signal: SENSE5 on PA09 mux G */
+#define MUX_PA09G_CATB_SENSE5           _L(6)
+#define PINMUX_PA09G_CATB_SENSE5   ((PIN_PA09G_CATB_SENSE5 << 16) | MUX_PA09G_CATB_SENSE5)
+#define GPIO_PA09G_CATB_SENSE5   _UL(1 <<  9)
+#define PIN_PC02G_CATB_SENSE5          _L(66) /**< \brief CATB signal: SENSE5 on PC02 mux G */
+#define MUX_PC02G_CATB_SENSE5           _L(6)
+#define PINMUX_PC02G_CATB_SENSE5   ((PIN_PC02G_CATB_SENSE5 << 16) | MUX_PC02G_CATB_SENSE5)
+#define GPIO_PC02G_CATB_SENSE5   _UL(1 <<  2)
+#define PIN_PA10G_CATB_SENSE6          _L(10) /**< \brief CATB signal: SENSE6 on PA10 mux G */
+#define MUX_PA10G_CATB_SENSE6           _L(6)
+#define PINMUX_PA10G_CATB_SENSE6   ((PIN_PA10G_CATB_SENSE6 << 16) | MUX_PA10G_CATB_SENSE6)
+#define GPIO_PA10G_CATB_SENSE6   _UL(1 << 10)
+#define PIN_PC03G_CATB_SENSE6          _L(67) /**< \brief CATB signal: SENSE6 on PC03 mux G */
+#define MUX_PC03G_CATB_SENSE6           _L(6)
+#define PINMUX_PC03G_CATB_SENSE6   ((PIN_PC03G_CATB_SENSE6 << 16) | MUX_PC03G_CATB_SENSE6)
+#define GPIO_PC03G_CATB_SENSE6   _UL(1 <<  3)
+#define PIN_PA11G_CATB_SENSE7          _L(11) /**< \brief CATB signal: SENSE7 on PA11 mux G */
+#define MUX_PA11G_CATB_SENSE7           _L(6)
+#define PINMUX_PA11G_CATB_SENSE7   ((PIN_PA11G_CATB_SENSE7 << 16) | MUX_PA11G_CATB_SENSE7)
+#define GPIO_PA11G_CATB_SENSE7   _UL(1 << 11)
+#define PIN_PC04G_CATB_SENSE7          _L(68) /**< \brief CATB signal: SENSE7 on PC04 mux G */
+#define MUX_PC04G_CATB_SENSE7           _L(6)
+#define PINMUX_PC04G_CATB_SENSE7   ((PIN_PC04G_CATB_SENSE7 << 16) | MUX_PC04G_CATB_SENSE7)
+#define GPIO_PC04G_CATB_SENSE7   _UL(1 <<  4)
+#define PIN_PA13G_CATB_SENSE8          _L(13) /**< \brief CATB signal: SENSE8 on PA13 mux G */
+#define MUX_PA13G_CATB_SENSE8           _L(6)
+#define PINMUX_PA13G_CATB_SENSE8   ((PIN_PA13G_CATB_SENSE8 << 16) | MUX_PA13G_CATB_SENSE8)
+#define GPIO_PA13G_CATB_SENSE8   _UL(1 << 13)
+#define PIN_PC06G_CATB_SENSE8          _L(70) /**< \brief CATB signal: SENSE8 on PC06 mux G */
+#define MUX_PC06G_CATB_SENSE8           _L(6)
+#define PINMUX_PC06G_CATB_SENSE8   ((PIN_PC06G_CATB_SENSE8 << 16) | MUX_PC06G_CATB_SENSE8)
+#define GPIO_PC06G_CATB_SENSE8   _UL(1 <<  6)
+#define PIN_PA14G_CATB_SENSE9          _L(14) /**< \brief CATB signal: SENSE9 on PA14 mux G */
+#define MUX_PA14G_CATB_SENSE9           _L(6)
+#define PINMUX_PA14G_CATB_SENSE9   ((PIN_PA14G_CATB_SENSE9 << 16) | MUX_PA14G_CATB_SENSE9)
+#define GPIO_PA14G_CATB_SENSE9   _UL(1 << 14)
+#define PIN_PC07G_CATB_SENSE9          _L(71) /**< \brief CATB signal: SENSE9 on PC07 mux G */
+#define MUX_PC07G_CATB_SENSE9           _L(6)
+#define PINMUX_PC07G_CATB_SENSE9   ((PIN_PC07G_CATB_SENSE9 << 16) | MUX_PC07G_CATB_SENSE9)
+#define GPIO_PC07G_CATB_SENSE9   _UL(1 <<  7)
+#define PIN_PA15G_CATB_SENSE10         _L(15) /**< \brief CATB signal: SENSE10 on PA15 mux G */
+#define MUX_PA15G_CATB_SENSE10          _L(6)
+#define PINMUX_PA15G_CATB_SENSE10  ((PIN_PA15G_CATB_SENSE10 << 16) | MUX_PA15G_CATB_SENSE10)
+#define GPIO_PA15G_CATB_SENSE10  _UL(1 << 15)
+#define PIN_PC08G_CATB_SENSE10         _L(72) /**< \brief CATB signal: SENSE10 on PC08 mux G */
+#define MUX_PC08G_CATB_SENSE10          _L(6)
+#define PINMUX_PC08G_CATB_SENSE10  ((PIN_PC08G_CATB_SENSE10 << 16) | MUX_PC08G_CATB_SENSE10)
+#define GPIO_PC08G_CATB_SENSE10  _UL(1 <<  8)
+#define PIN_PA16G_CATB_SENSE11         _L(16) /**< \brief CATB signal: SENSE11 on PA16 mux G */
+#define MUX_PA16G_CATB_SENSE11          _L(6)
+#define PINMUX_PA16G_CATB_SENSE11  ((PIN_PA16G_CATB_SENSE11 << 16) | MUX_PA16G_CATB_SENSE11)
+#define GPIO_PA16G_CATB_SENSE11  _UL(1 << 16)
+#define PIN_PC09G_CATB_SENSE11         _L(73) /**< \brief CATB signal: SENSE11 on PC09 mux G */
+#define MUX_PC09G_CATB_SENSE11          _L(6)
+#define PINMUX_PC09G_CATB_SENSE11  ((PIN_PC09G_CATB_SENSE11 << 16) | MUX_PC09G_CATB_SENSE11)
+#define GPIO_PC09G_CATB_SENSE11  _UL(1 <<  9)
+#define PIN_PA17G_CATB_SENSE12         _L(17) /**< \brief CATB signal: SENSE12 on PA17 mux G */
+#define MUX_PA17G_CATB_SENSE12          _L(6)
+#define PINMUX_PA17G_CATB_SENSE12  ((PIN_PA17G_CATB_SENSE12 << 16) | MUX_PA17G_CATB_SENSE12)
+#define GPIO_PA17G_CATB_SENSE12  _UL(1 << 17)
+#define PIN_PC10G_CATB_SENSE12         _L(74) /**< \brief CATB signal: SENSE12 on PC10 mux G */
+#define MUX_PC10G_CATB_SENSE12          _L(6)
+#define PINMUX_PC10G_CATB_SENSE12  ((PIN_PC10G_CATB_SENSE12 << 16) | MUX_PC10G_CATB_SENSE12)
+#define GPIO_PC10G_CATB_SENSE12  _UL(1 << 10)
+#define PIN_PA18G_CATB_SENSE13         _L(18) /**< \brief CATB signal: SENSE13 on PA18 mux G */
+#define MUX_PA18G_CATB_SENSE13          _L(6)
+#define PINMUX_PA18G_CATB_SENSE13  ((PIN_PA18G_CATB_SENSE13 << 16) | MUX_PA18G_CATB_SENSE13)
+#define GPIO_PA18G_CATB_SENSE13  _UL(1 << 18)
+#define PIN_PC11G_CATB_SENSE13         _L(75) /**< \brief CATB signal: SENSE13 on PC11 mux G */
+#define MUX_PC11G_CATB_SENSE13          _L(6)
+#define PINMUX_PC11G_CATB_SENSE13  ((PIN_PC11G_CATB_SENSE13 << 16) | MUX_PC11G_CATB_SENSE13)
+#define GPIO_PC11G_CATB_SENSE13  _UL(1 << 11)
+#define PIN_PA19G_CATB_SENSE14         _L(19) /**< \brief CATB signal: SENSE14 on PA19 mux G */
+#define MUX_PA19G_CATB_SENSE14          _L(6)
+#define PINMUX_PA19G_CATB_SENSE14  ((PIN_PA19G_CATB_SENSE14 << 16) | MUX_PA19G_CATB_SENSE14)
+#define GPIO_PA19G_CATB_SENSE14  _UL(1 << 19)
+#define PIN_PC12G_CATB_SENSE14         _L(76) /**< \brief CATB signal: SENSE14 on PC12 mux G */
+#define MUX_PC12G_CATB_SENSE14          _L(6)
+#define PINMUX_PC12G_CATB_SENSE14  ((PIN_PC12G_CATB_SENSE14 << 16) | MUX_PC12G_CATB_SENSE14)
+#define GPIO_PC12G_CATB_SENSE14  _UL(1 << 12)
+#define PIN_PA20G_CATB_SENSE15         _L(20) /**< \brief CATB signal: SENSE15 on PA20 mux G */
+#define MUX_PA20G_CATB_SENSE15          _L(6)
+#define PINMUX_PA20G_CATB_SENSE15  ((PIN_PA20G_CATB_SENSE15 << 16) | MUX_PA20G_CATB_SENSE15)
+#define GPIO_PA20G_CATB_SENSE15  _UL(1 << 20)
+#define PIN_PC13G_CATB_SENSE15         _L(77) /**< \brief CATB signal: SENSE15 on PC13 mux G */
+#define MUX_PC13G_CATB_SENSE15          _L(6)
+#define PINMUX_PC13G_CATB_SENSE15  ((PIN_PC13G_CATB_SENSE15 << 16) | MUX_PC13G_CATB_SENSE15)
+#define GPIO_PC13G_CATB_SENSE15  _UL(1 << 13)
+#define PIN_PA21G_CATB_SENSE16         _L(21) /**< \brief CATB signal: SENSE16 on PA21 mux G */
+#define MUX_PA21G_CATB_SENSE16          _L(6)
+#define PINMUX_PA21G_CATB_SENSE16  ((PIN_PA21G_CATB_SENSE16 << 16) | MUX_PA21G_CATB_SENSE16)
+#define GPIO_PA21G_CATB_SENSE16  _UL(1 << 21)
+#define PIN_PC15G_CATB_SENSE16         _L(79) /**< \brief CATB signal: SENSE16 on PC15 mux G */
+#define MUX_PC15G_CATB_SENSE16          _L(6)
+#define PINMUX_PC15G_CATB_SENSE16  ((PIN_PC15G_CATB_SENSE16 << 16) | MUX_PC15G_CATB_SENSE16)
+#define GPIO_PC15G_CATB_SENSE16  _UL(1 << 15)
+#define PIN_PA22G_CATB_SENSE17         _L(22) /**< \brief CATB signal: SENSE17 on PA22 mux G */
+#define MUX_PA22G_CATB_SENSE17          _L(6)
+#define PINMUX_PA22G_CATB_SENSE17  ((PIN_PA22G_CATB_SENSE17 << 16) | MUX_PA22G_CATB_SENSE17)
+#define GPIO_PA22G_CATB_SENSE17  _UL(1 << 22)
+#define PIN_PC16G_CATB_SENSE17         _L(80) /**< \brief CATB signal: SENSE17 on PC16 mux G */
+#define MUX_PC16G_CATB_SENSE17          _L(6)
+#define PINMUX_PC16G_CATB_SENSE17  ((PIN_PC16G_CATB_SENSE17 << 16) | MUX_PC16G_CATB_SENSE17)
+#define GPIO_PC16G_CATB_SENSE17  _UL(1 << 16)
+#define PIN_PA24G_CATB_SENSE18         _L(24) /**< \brief CATB signal: SENSE18 on PA24 mux G */
+#define MUX_PA24G_CATB_SENSE18          _L(6)
+#define PINMUX_PA24G_CATB_SENSE18  ((PIN_PA24G_CATB_SENSE18 << 16) | MUX_PA24G_CATB_SENSE18)
+#define GPIO_PA24G_CATB_SENSE18  _UL(1 << 24)
+#define PIN_PC17G_CATB_SENSE18         _L(81) /**< \brief CATB signal: SENSE18 on PC17 mux G */
+#define MUX_PC17G_CATB_SENSE18          _L(6)
+#define PINMUX_PC17G_CATB_SENSE18  ((PIN_PC17G_CATB_SENSE18 << 16) | MUX_PC17G_CATB_SENSE18)
+#define GPIO_PC17G_CATB_SENSE18  _UL(1 << 17)
+#define PIN_PA25G_CATB_SENSE19         _L(25) /**< \brief CATB signal: SENSE19 on PA25 mux G */
+#define MUX_PA25G_CATB_SENSE19          _L(6)
+#define PINMUX_PA25G_CATB_SENSE19  ((PIN_PA25G_CATB_SENSE19 << 16) | MUX_PA25G_CATB_SENSE19)
+#define GPIO_PA25G_CATB_SENSE19  _UL(1 << 25)
+#define PIN_PC18G_CATB_SENSE19         _L(82) /**< \brief CATB signal: SENSE19 on PC18 mux G */
+#define MUX_PC18G_CATB_SENSE19          _L(6)
+#define PINMUX_PC18G_CATB_SENSE19  ((PIN_PC18G_CATB_SENSE19 << 16) | MUX_PC18G_CATB_SENSE19)
+#define GPIO_PC18G_CATB_SENSE19  _UL(1 << 18)
+#define PIN_PA26G_CATB_SENSE20         _L(26) /**< \brief CATB signal: SENSE20 on PA26 mux G */
+#define MUX_PA26G_CATB_SENSE20          _L(6)
+#define PINMUX_PA26G_CATB_SENSE20  ((PIN_PA26G_CATB_SENSE20 << 16) | MUX_PA26G_CATB_SENSE20)
+#define GPIO_PA26G_CATB_SENSE20  _UL(1 << 26)
+#define PIN_PC19G_CATB_SENSE20         _L(83) /**< \brief CATB signal: SENSE20 on PC19 mux G */
+#define MUX_PC19G_CATB_SENSE20          _L(6)
+#define PINMUX_PC19G_CATB_SENSE20  ((PIN_PC19G_CATB_SENSE20 << 16) | MUX_PC19G_CATB_SENSE20)
+#define GPIO_PC19G_CATB_SENSE20  _UL(1 << 19)
+#define PIN_PB00G_CATB_SENSE21         _L(32) /**< \brief CATB signal: SENSE21 on PB00 mux G */
+#define MUX_PB00G_CATB_SENSE21          _L(6)
+#define PINMUX_PB00G_CATB_SENSE21  ((PIN_PB00G_CATB_SENSE21 << 16) | MUX_PB00G_CATB_SENSE21)
+#define GPIO_PB00G_CATB_SENSE21  _UL(1 <<  0)
+#define PIN_PC20G_CATB_SENSE21         _L(84) /**< \brief CATB signal: SENSE21 on PC20 mux G */
+#define MUX_PC20G_CATB_SENSE21          _L(6)
+#define PINMUX_PC20G_CATB_SENSE21  ((PIN_PC20G_CATB_SENSE21 << 16) | MUX_PC20G_CATB_SENSE21)
+#define GPIO_PC20G_CATB_SENSE21  _UL(1 << 20)
+#define PIN_PB01G_CATB_SENSE22         _L(33) /**< \brief CATB signal: SENSE22 on PB01 mux G */
+#define MUX_PB01G_CATB_SENSE22          _L(6)
+#define PINMUX_PB01G_CATB_SENSE22  ((PIN_PB01G_CATB_SENSE22 << 16) | MUX_PB01G_CATB_SENSE22)
+#define GPIO_PB01G_CATB_SENSE22  _UL(1 <<  1)
+#define PIN_PC21G_CATB_SENSE22         _L(85) /**< \brief CATB signal: SENSE22 on PC21 mux G */
+#define MUX_PC21G_CATB_SENSE22          _L(6)
+#define PINMUX_PC21G_CATB_SENSE22  ((PIN_PC21G_CATB_SENSE22 << 16) | MUX_PC21G_CATB_SENSE22)
+#define GPIO_PC21G_CATB_SENSE22  _UL(1 << 21)
+#define PIN_PB02G_CATB_SENSE23         _L(34) /**< \brief CATB signal: SENSE23 on PB02 mux G */
+#define MUX_PB02G_CATB_SENSE23          _L(6)
+#define PINMUX_PB02G_CATB_SENSE23  ((PIN_PB02G_CATB_SENSE23 << 16) | MUX_PB02G_CATB_SENSE23)
+#define GPIO_PB02G_CATB_SENSE23  _UL(1 <<  2)
+#define PIN_PC22G_CATB_SENSE23         _L(86) /**< \brief CATB signal: SENSE23 on PC22 mux G */
+#define MUX_PC22G_CATB_SENSE23          _L(6)
+#define PINMUX_PC22G_CATB_SENSE23  ((PIN_PC22G_CATB_SENSE23 << 16) | MUX_PC22G_CATB_SENSE23)
+#define GPIO_PC22G_CATB_SENSE23  _UL(1 << 22)
+#define PIN_PB04G_CATB_SENSE24         _L(36) /**< \brief CATB signal: SENSE24 on PB04 mux G */
+#define MUX_PB04G_CATB_SENSE24          _L(6)
+#define PINMUX_PB04G_CATB_SENSE24  ((PIN_PB04G_CATB_SENSE24 << 16) | MUX_PB04G_CATB_SENSE24)
+#define GPIO_PB04G_CATB_SENSE24  _UL(1 <<  4)
+#define PIN_PC24G_CATB_SENSE24         _L(88) /**< \brief CATB signal: SENSE24 on PC24 mux G */
+#define MUX_PC24G_CATB_SENSE24          _L(6)
+#define PINMUX_PC24G_CATB_SENSE24  ((PIN_PC24G_CATB_SENSE24 << 16) | MUX_PC24G_CATB_SENSE24)
+#define GPIO_PC24G_CATB_SENSE24  _UL(1 << 24)
+#define PIN_PB05G_CATB_SENSE25         _L(37) /**< \brief CATB signal: SENSE25 on PB05 mux G */
+#define MUX_PB05G_CATB_SENSE25          _L(6)
+#define PINMUX_PB05G_CATB_SENSE25  ((PIN_PB05G_CATB_SENSE25 << 16) | MUX_PB05G_CATB_SENSE25)
+#define GPIO_PB05G_CATB_SENSE25  _UL(1 <<  5)
+#define PIN_PC25G_CATB_SENSE25         _L(89) /**< \brief CATB signal: SENSE25 on PC25 mux G */
+#define MUX_PC25G_CATB_SENSE25          _L(6)
+#define PINMUX_PC25G_CATB_SENSE25  ((PIN_PC25G_CATB_SENSE25 << 16) | MUX_PC25G_CATB_SENSE25)
+#define GPIO_PC25G_CATB_SENSE25  _UL(1 << 25)
+#define PIN_PB06G_CATB_SENSE26         _L(38) /**< \brief CATB signal: SENSE26 on PB06 mux G */
+#define MUX_PB06G_CATB_SENSE26          _L(6)
+#define PINMUX_PB06G_CATB_SENSE26  ((PIN_PB06G_CATB_SENSE26 << 16) | MUX_PB06G_CATB_SENSE26)
+#define GPIO_PB06G_CATB_SENSE26  _UL(1 <<  6)
+#define PIN_PC26G_CATB_SENSE26         _L(90) /**< \brief CATB signal: SENSE26 on PC26 mux G */
+#define MUX_PC26G_CATB_SENSE26          _L(6)
+#define PINMUX_PC26G_CATB_SENSE26  ((PIN_PC26G_CATB_SENSE26 << 16) | MUX_PC26G_CATB_SENSE26)
+#define GPIO_PC26G_CATB_SENSE26  _UL(1 << 26)
+#define PIN_PB07G_CATB_SENSE27         _L(39) /**< \brief CATB signal: SENSE27 on PB07 mux G */
+#define MUX_PB07G_CATB_SENSE27          _L(6)
+#define PINMUX_PB07G_CATB_SENSE27  ((PIN_PB07G_CATB_SENSE27 << 16) | MUX_PB07G_CATB_SENSE27)
+#define GPIO_PB07G_CATB_SENSE27  _UL(1 <<  7)
+#define PIN_PC27G_CATB_SENSE27         _L(91) /**< \brief CATB signal: SENSE27 on PC27 mux G */
+#define MUX_PC27G_CATB_SENSE27          _L(6)
+#define PINMUX_PC27G_CATB_SENSE27  ((PIN_PC27G_CATB_SENSE27 << 16) | MUX_PC27G_CATB_SENSE27)
+#define GPIO_PC27G_CATB_SENSE27  _UL(1 << 27)
+#define PIN_PB08G_CATB_SENSE28         _L(40) /**< \brief CATB signal: SENSE28 on PB08 mux G */
+#define MUX_PB08G_CATB_SENSE28          _L(6)
+#define PINMUX_PB08G_CATB_SENSE28  ((PIN_PB08G_CATB_SENSE28 << 16) | MUX_PB08G_CATB_SENSE28)
+#define GPIO_PB08G_CATB_SENSE28  _UL(1 <<  8)
+#define PIN_PC28G_CATB_SENSE28         _L(92) /**< \brief CATB signal: SENSE28 on PC28 mux G */
+#define MUX_PC28G_CATB_SENSE28          _L(6)
+#define PINMUX_PC28G_CATB_SENSE28  ((PIN_PC28G_CATB_SENSE28 << 16) | MUX_PC28G_CATB_SENSE28)
+#define GPIO_PC28G_CATB_SENSE28  _UL(1 << 28)
+#define PIN_PB09G_CATB_SENSE29         _L(41) /**< \brief CATB signal: SENSE29 on PB09 mux G */
+#define MUX_PB09G_CATB_SENSE29          _L(6)
+#define PINMUX_PB09G_CATB_SENSE29  ((PIN_PB09G_CATB_SENSE29 << 16) | MUX_PB09G_CATB_SENSE29)
+#define GPIO_PB09G_CATB_SENSE29  _UL(1 <<  9)
+#define PIN_PC29G_CATB_SENSE29         _L(93) /**< \brief CATB signal: SENSE29 on PC29 mux G */
+#define MUX_PC29G_CATB_SENSE29          _L(6)
+#define PINMUX_PC29G_CATB_SENSE29  ((PIN_PC29G_CATB_SENSE29 << 16) | MUX_PC29G_CATB_SENSE29)
+#define GPIO_PC29G_CATB_SENSE29  _UL(1 << 29)
+#define PIN_PB10G_CATB_SENSE30         _L(42) /**< \brief CATB signal: SENSE30 on PB10 mux G */
+#define MUX_PB10G_CATB_SENSE30          _L(6)
+#define PINMUX_PB10G_CATB_SENSE30  ((PIN_PB10G_CATB_SENSE30 << 16) | MUX_PB10G_CATB_SENSE30)
+#define GPIO_PB10G_CATB_SENSE30  _UL(1 << 10)
+#define PIN_PC30G_CATB_SENSE30         _L(94) /**< \brief CATB signal: SENSE30 on PC30 mux G */
+#define MUX_PC30G_CATB_SENSE30          _L(6)
+#define PINMUX_PC30G_CATB_SENSE30  ((PIN_PC30G_CATB_SENSE30 << 16) | MUX_PC30G_CATB_SENSE30)
+#define GPIO_PC30G_CATB_SENSE30  _UL(1 << 30)
+#define PIN_PB11G_CATB_SENSE31         _L(43) /**< \brief CATB signal: SENSE31 on PB11 mux G */
+#define MUX_PB11G_CATB_SENSE31          _L(6)
+#define PINMUX_PB11G_CATB_SENSE31  ((PIN_PB11G_CATB_SENSE31 << 16) | MUX_PB11G_CATB_SENSE31)
+#define GPIO_PB11G_CATB_SENSE31  _UL(1 << 11)
+#define PIN_PC31G_CATB_SENSE31         _L(95) /**< \brief CATB signal: SENSE31 on PC31 mux G */
+#define MUX_PC31G_CATB_SENSE31          _L(6)
+#define PINMUX_PC31G_CATB_SENSE31  ((PIN_PC31G_CATB_SENSE31 << 16) | MUX_PC31G_CATB_SENSE31)
+#define GPIO_PC31G_CATB_SENSE31  _UL(1 << 31)
+/* ========== GPIO definition for USBC peripheral ========== */
+#define PIN_PA25A_USBC_DM              _L(25) /**< \brief USBC signal: DM on PA25 mux A */
+#define MUX_PA25A_USBC_DM               _L(0)
+#define PINMUX_PA25A_USBC_DM       ((PIN_PA25A_USBC_DM << 16) | MUX_PA25A_USBC_DM)
+#define GPIO_PA25A_USBC_DM       _UL(1 << 25)
+#define PIN_PA26A_USBC_DP              _L(26) /**< \brief USBC signal: DP on PA26 mux A */
+#define MUX_PA26A_USBC_DP               _L(0)
+#define PINMUX_PA26A_USBC_DP       ((PIN_PA26A_USBC_DP << 16) | MUX_PA26A_USBC_DP)
+#define GPIO_PA26A_USBC_DP       _UL(1 << 26)
+/* ========== GPIO definition for PEVC peripheral ========== */
+#define PIN_PA08C_PEVC_PAD_EVT0         _L(8) /**< \brief PEVC signal: PAD_EVT0 on PA08 mux C */
+#define MUX_PA08C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PA08C_PEVC_PAD_EVT0  ((PIN_PA08C_PEVC_PAD_EVT0 << 16) | MUX_PA08C_PEVC_PAD_EVT0)
+#define GPIO_PA08C_PEVC_PAD_EVT0  _UL(1 <<  8)
+#define PIN_PB12C_PEVC_PAD_EVT0        _L(44) /**< \brief PEVC signal: PAD_EVT0 on PB12 mux C */
+#define MUX_PB12C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PB12C_PEVC_PAD_EVT0  ((PIN_PB12C_PEVC_PAD_EVT0 << 16) | MUX_PB12C_PEVC_PAD_EVT0)
+#define GPIO_PB12C_PEVC_PAD_EVT0  _UL(1 << 12)
+#define PIN_PC07C_PEVC_PAD_EVT0        _L(71) /**< \brief PEVC signal: PAD_EVT0 on PC07 mux C */
+#define MUX_PC07C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PC07C_PEVC_PAD_EVT0  ((PIN_PC07C_PEVC_PAD_EVT0 << 16) | MUX_PC07C_PEVC_PAD_EVT0)
+#define GPIO_PC07C_PEVC_PAD_EVT0  _UL(1 <<  7)
+#define PIN_PC24C_PEVC_PAD_EVT0        _L(88) /**< \brief PEVC signal: PAD_EVT0 on PC24 mux C */
+#define MUX_PC24C_PEVC_PAD_EVT0         _L(2)
+#define PINMUX_PC24C_PEVC_PAD_EVT0  ((PIN_PC24C_PEVC_PAD_EVT0 << 16) | MUX_PC24C_PEVC_PAD_EVT0)
+#define GPIO_PC24C_PEVC_PAD_EVT0  _UL(1 << 24)
+#define PIN_PA09C_PEVC_PAD_EVT1         _L(9) /**< \brief PEVC signal: PAD_EVT1 on PA09 mux C */
+#define MUX_PA09C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PA09C_PEVC_PAD_EVT1  ((PIN_PA09C_PEVC_PAD_EVT1 << 16) | MUX_PA09C_PEVC_PAD_EVT1)
+#define GPIO_PA09C_PEVC_PAD_EVT1  _UL(1 <<  9)
+#define PIN_PB13C_PEVC_PAD_EVT1        _L(45) /**< \brief PEVC signal: PAD_EVT1 on PB13 mux C */
+#define MUX_PB13C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PB13C_PEVC_PAD_EVT1  ((PIN_PB13C_PEVC_PAD_EVT1 << 16) | MUX_PB13C_PEVC_PAD_EVT1)
+#define GPIO_PB13C_PEVC_PAD_EVT1  _UL(1 << 13)
+#define PIN_PC08C_PEVC_PAD_EVT1        _L(72) /**< \brief PEVC signal: PAD_EVT1 on PC08 mux C */
+#define MUX_PC08C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PC08C_PEVC_PAD_EVT1  ((PIN_PC08C_PEVC_PAD_EVT1 << 16) | MUX_PC08C_PEVC_PAD_EVT1)
+#define GPIO_PC08C_PEVC_PAD_EVT1  _UL(1 <<  8)
+#define PIN_PC25C_PEVC_PAD_EVT1        _L(89) /**< \brief PEVC signal: PAD_EVT1 on PC25 mux C */
+#define MUX_PC25C_PEVC_PAD_EVT1         _L(2)
+#define PINMUX_PC25C_PEVC_PAD_EVT1  ((PIN_PC25C_PEVC_PAD_EVT1 << 16) | MUX_PC25C_PEVC_PAD_EVT1)
+#define GPIO_PC25C_PEVC_PAD_EVT1  _UL(1 << 25)
+#define PIN_PA10C_PEVC_PAD_EVT2        _L(10) /**< \brief PEVC signal: PAD_EVT2 on PA10 mux C */
+#define MUX_PA10C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PA10C_PEVC_PAD_EVT2  ((PIN_PA10C_PEVC_PAD_EVT2 << 16) | MUX_PA10C_PEVC_PAD_EVT2)
+#define GPIO_PA10C_PEVC_PAD_EVT2  _UL(1 << 10)
+#define PIN_PC11C_PEVC_PAD_EVT2        _L(75) /**< \brief PEVC signal: PAD_EVT2 on PC11 mux C */
+#define MUX_PC11C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PC11C_PEVC_PAD_EVT2  ((PIN_PC11C_PEVC_PAD_EVT2 << 16) | MUX_PC11C_PEVC_PAD_EVT2)
+#define GPIO_PC11C_PEVC_PAD_EVT2  _UL(1 << 11)
+#define PIN_PC26C_PEVC_PAD_EVT2        _L(90) /**< \brief PEVC signal: PAD_EVT2 on PC26 mux C */
+#define MUX_PC26C_PEVC_PAD_EVT2         _L(2)
+#define PINMUX_PC26C_PEVC_PAD_EVT2  ((PIN_PC26C_PEVC_PAD_EVT2 << 16) | MUX_PC26C_PEVC_PAD_EVT2)
+#define GPIO_PC26C_PEVC_PAD_EVT2  _UL(1 << 26)
+#define PIN_PB09B_PEVC_PAD_EVT2        _L(41) /**< \brief PEVC signal: PAD_EVT2 on PB09 mux B */
+#define MUX_PB09B_PEVC_PAD_EVT2         _L(1)
+#define PINMUX_PB09B_PEVC_PAD_EVT2  ((PIN_PB09B_PEVC_PAD_EVT2 << 16) | MUX_PB09B_PEVC_PAD_EVT2)
+#define GPIO_PB09B_PEVC_PAD_EVT2  _UL(1 <<  9)
+#define PIN_PA11C_PEVC_PAD_EVT3        _L(11) /**< \brief PEVC signal: PAD_EVT3 on PA11 mux C */
+#define MUX_PA11C_PEVC_PAD_EVT3         _L(2)
+#define PINMUX_PA11C_PEVC_PAD_EVT3  ((PIN_PA11C_PEVC_PAD_EVT3 << 16) | MUX_PA11C_PEVC_PAD_EVT3)
+#define GPIO_PA11C_PEVC_PAD_EVT3  _UL(1 << 11)
+#define PIN_PC27C_PEVC_PAD_EVT3        _L(91) /**< \brief PEVC signal: PAD_EVT3 on PC27 mux C */
+#define MUX_PC27C_PEVC_PAD_EVT3         _L(2)
+#define PINMUX_PC27C_PEVC_PAD_EVT3  ((PIN_PC27C_PEVC_PAD_EVT3 << 16) | MUX_PC27C_PEVC_PAD_EVT3)
+#define GPIO_PC27C_PEVC_PAD_EVT3  _UL(1 << 27)
+#define PIN_PB10B_PEVC_PAD_EVT3        _L(42) /**< \brief PEVC signal: PAD_EVT3 on PB10 mux B */
+#define MUX_PB10B_PEVC_PAD_EVT3         _L(1)
+#define PINMUX_PB10B_PEVC_PAD_EVT3  ((PIN_PB10B_PEVC_PAD_EVT3 << 16) | MUX_PB10B_PEVC_PAD_EVT3)
+#define GPIO_PB10B_PEVC_PAD_EVT3  _UL(1 << 10)
+/* ========== GPIO definition for SCIF peripheral ========== */
+#define PIN_PA19E_SCIF_GCLK0           _L(19) /**< \brief SCIF signal: GCLK0 on PA19 mux E */
+#define MUX_PA19E_SCIF_GCLK0            _L(4)
+#define PINMUX_PA19E_SCIF_GCLK0    ((PIN_PA19E_SCIF_GCLK0 << 16) | MUX_PA19E_SCIF_GCLK0)
+#define GPIO_PA19E_SCIF_GCLK0    _UL(1 << 19)
+#define PIN_PB10E_SCIF_GCLK0           _L(42) /**< \brief SCIF signal: GCLK0 on PB10 mux E */
+#define MUX_PB10E_SCIF_GCLK0            _L(4)
+#define PINMUX_PB10E_SCIF_GCLK0    ((PIN_PB10E_SCIF_GCLK0 << 16) | MUX_PB10E_SCIF_GCLK0)
+#define GPIO_PB10E_SCIF_GCLK0    _UL(1 << 10)
+#define PIN_PC26E_SCIF_GCLK0           _L(90) /**< \brief SCIF signal: GCLK0 on PC26 mux E */
+#define MUX_PC26E_SCIF_GCLK0            _L(4)
+#define PINMUX_PC26E_SCIF_GCLK0    ((PIN_PC26E_SCIF_GCLK0 << 16) | MUX_PC26E_SCIF_GCLK0)
+#define GPIO_PC26E_SCIF_GCLK0    _UL(1 << 26)
+#define PIN_PA02A_SCIF_GCLK0            _L(2) /**< \brief SCIF signal: GCLK0 on PA02 mux A */
+#define MUX_PA02A_SCIF_GCLK0            _L(0)
+#define PINMUX_PA02A_SCIF_GCLK0    ((PIN_PA02A_SCIF_GCLK0 << 16) | MUX_PA02A_SCIF_GCLK0)
+#define GPIO_PA02A_SCIF_GCLK0    _UL(1 <<  2)
+#define PIN_PA20E_SCIF_GCLK1           _L(20) /**< \brief SCIF signal: GCLK1 on PA20 mux E */
+#define MUX_PA20E_SCIF_GCLK1            _L(4)
+#define PINMUX_PA20E_SCIF_GCLK1    ((PIN_PA20E_SCIF_GCLK1 << 16) | MUX_PA20E_SCIF_GCLK1)
+#define GPIO_PA20E_SCIF_GCLK1    _UL(1 << 20)
+#define PIN_PB11E_SCIF_GCLK1           _L(43) /**< \brief SCIF signal: GCLK1 on PB11 mux E */
+#define MUX_PB11E_SCIF_GCLK1            _L(4)
+#define PINMUX_PB11E_SCIF_GCLK1    ((PIN_PB11E_SCIF_GCLK1 << 16) | MUX_PB11E_SCIF_GCLK1)
+#define GPIO_PB11E_SCIF_GCLK1    _UL(1 << 11)
+#define PIN_PC27E_SCIF_GCLK1           _L(91) /**< \brief SCIF signal: GCLK1 on PC27 mux E */
+#define MUX_PC27E_SCIF_GCLK1            _L(4)
+#define PINMUX_PC27E_SCIF_GCLK1    ((PIN_PC27E_SCIF_GCLK1 << 16) | MUX_PC27E_SCIF_GCLK1)
+#define GPIO_PC27E_SCIF_GCLK1    _UL(1 << 27)
+#define PIN_PB12E_SCIF_GCLK2           _L(44) /**< \brief SCIF signal: GCLK2 on PB12 mux E */
+#define MUX_PB12E_SCIF_GCLK2            _L(4)
+#define PINMUX_PB12E_SCIF_GCLK2    ((PIN_PB12E_SCIF_GCLK2 << 16) | MUX_PB12E_SCIF_GCLK2)
+#define GPIO_PB12E_SCIF_GCLK2    _UL(1 << 12)
+#define PIN_PC28E_SCIF_GCLK2           _L(92) /**< \brief SCIF signal: GCLK2 on PC28 mux E */
+#define MUX_PC28E_SCIF_GCLK2            _L(4)
+#define PINMUX_PC28E_SCIF_GCLK2    ((PIN_PC28E_SCIF_GCLK2 << 16) | MUX_PC28E_SCIF_GCLK2)
+#define GPIO_PC28E_SCIF_GCLK2    _UL(1 << 28)
+#define PIN_PB13E_SCIF_GCLK3           _L(45) /**< \brief SCIF signal: GCLK3 on PB13 mux E */
+#define MUX_PB13E_SCIF_GCLK3            _L(4)
+#define PINMUX_PB13E_SCIF_GCLK3    ((PIN_PB13E_SCIF_GCLK3 << 16) | MUX_PB13E_SCIF_GCLK3)
+#define GPIO_PB13E_SCIF_GCLK3    _UL(1 << 13)
+#define PIN_PC29E_SCIF_GCLK3           _L(93) /**< \brief SCIF signal: GCLK3 on PC29 mux E */
+#define MUX_PC29E_SCIF_GCLK3            _L(4)
+#define PINMUX_PC29E_SCIF_GCLK3    ((PIN_PC29E_SCIF_GCLK3 << 16) | MUX_PC29E_SCIF_GCLK3)
+#define GPIO_PC29E_SCIF_GCLK3    _UL(1 << 29)
+#define PIN_PA23E_SCIF_GCLK_IN0        _L(23) /**< \brief SCIF signal: GCLK_IN0 on PA23 mux E */
+#define MUX_PA23E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PA23E_SCIF_GCLK_IN0  ((PIN_PA23E_SCIF_GCLK_IN0 << 16) | MUX_PA23E_SCIF_GCLK_IN0)
+#define GPIO_PA23E_SCIF_GCLK_IN0  _UL(1 << 23)
+#define PIN_PB14E_SCIF_GCLK_IN0        _L(46) /**< \brief SCIF signal: GCLK_IN0 on PB14 mux E */
+#define MUX_PB14E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PB14E_SCIF_GCLK_IN0  ((PIN_PB14E_SCIF_GCLK_IN0 << 16) | MUX_PB14E_SCIF_GCLK_IN0)
+#define GPIO_PB14E_SCIF_GCLK_IN0  _UL(1 << 14)
+#define PIN_PC30E_SCIF_GCLK_IN0        _L(94) /**< \brief SCIF signal: GCLK_IN0 on PC30 mux E */
+#define MUX_PC30E_SCIF_GCLK_IN0         _L(4)
+#define PINMUX_PC30E_SCIF_GCLK_IN0  ((PIN_PC30E_SCIF_GCLK_IN0 << 16) | MUX_PC30E_SCIF_GCLK_IN0)
+#define GPIO_PC30E_SCIF_GCLK_IN0  _UL(1 << 30)
+#define PIN_PA24E_SCIF_GCLK_IN1        _L(24) /**< \brief SCIF signal: GCLK_IN1 on PA24 mux E */
+#define MUX_PA24E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PA24E_SCIF_GCLK_IN1  ((PIN_PA24E_SCIF_GCLK_IN1 << 16) | MUX_PA24E_SCIF_GCLK_IN1)
+#define GPIO_PA24E_SCIF_GCLK_IN1  _UL(1 << 24)
+#define PIN_PB15E_SCIF_GCLK_IN1        _L(47) /**< \brief SCIF signal: GCLK_IN1 on PB15 mux E */
+#define MUX_PB15E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PB15E_SCIF_GCLK_IN1  ((PIN_PB15E_SCIF_GCLK_IN1 << 16) | MUX_PB15E_SCIF_GCLK_IN1)
+#define GPIO_PB15E_SCIF_GCLK_IN1  _UL(1 << 15)
+#define PIN_PC31E_SCIF_GCLK_IN1        _L(95) /**< \brief SCIF signal: GCLK_IN1 on PC31 mux E */
+#define MUX_PC31E_SCIF_GCLK_IN1         _L(4)
+#define PINMUX_PC31E_SCIF_GCLK_IN1  ((PIN_PC31E_SCIF_GCLK_IN1 << 16) | MUX_PC31E_SCIF_GCLK_IN1)
+#define GPIO_PC31E_SCIF_GCLK_IN1  _UL(1 << 31)
+/* ========== GPIO definition for EIC peripheral ========== */
+#define PIN_PB01C_EIC_EXTINT0          _L(33) /**< \brief EIC signal: EXTINT0 on PB01 mux C */
+#define MUX_PB01C_EIC_EXTINT0           _L(2)
+#define PINMUX_PB01C_EIC_EXTINT0   ((PIN_PB01C_EIC_EXTINT0 << 16) | MUX_PB01C_EIC_EXTINT0)
+#define GPIO_PB01C_EIC_EXTINT0   _UL(1 <<  1)
+#define PIN_PB01C_EIC_EXTINT_NUM        _L(0) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PA06C_EIC_EXTINT1           _L(6) /**< \brief EIC signal: EXTINT1 on PA06 mux C */
+#define MUX_PA06C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA06C_EIC_EXTINT1   ((PIN_PA06C_EIC_EXTINT1 << 16) | MUX_PA06C_EIC_EXTINT1)
+#define GPIO_PA06C_EIC_EXTINT1   _UL(1 <<  6)
+#define PIN_PA06C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA16C_EIC_EXTINT1          _L(16) /**< \brief EIC signal: EXTINT1 on PA16 mux C */
+#define MUX_PA16C_EIC_EXTINT1           _L(2)
+#define PINMUX_PA16C_EIC_EXTINT1   ((PIN_PA16C_EIC_EXTINT1 << 16) | MUX_PA16C_EIC_EXTINT1)
+#define GPIO_PA16C_EIC_EXTINT1   _UL(1 << 16)
+#define PIN_PA16C_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PC24B_EIC_EXTINT1          _L(88) /**< \brief EIC signal: EXTINT1 on PC24 mux B */
+#define MUX_PC24B_EIC_EXTINT1           _L(1)
+#define PINMUX_PC24B_EIC_EXTINT1   ((PIN_PC24B_EIC_EXTINT1 << 16) | MUX_PC24B_EIC_EXTINT1)
+#define GPIO_PC24B_EIC_EXTINT1   _UL(1 << 24)
+#define PIN_PC24B_EIC_EXTINT_NUM        _L(1) /**< \brief EIC signal: PIN_PC24 External Interrupt Line */
+#define PIN_PA04C_EIC_EXTINT2           _L(4) /**< \brief EIC signal: EXTINT2 on PA04 mux C */
+#define MUX_PA04C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA04C_EIC_EXTINT2   ((PIN_PA04C_EIC_EXTINT2 << 16) | MUX_PA04C_EIC_EXTINT2)
+#define GPIO_PA04C_EIC_EXTINT2   _UL(1 <<  4)
+#define PIN_PA04C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA17C_EIC_EXTINT2          _L(17) /**< \brief EIC signal: EXTINT2 on PA17 mux C */
+#define MUX_PA17C_EIC_EXTINT2           _L(2)
+#define PINMUX_PA17C_EIC_EXTINT2   ((PIN_PA17C_EIC_EXTINT2 << 16) | MUX_PA17C_EIC_EXTINT2)
+#define GPIO_PA17C_EIC_EXTINT2   _UL(1 << 17)
+#define PIN_PA17C_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PC25B_EIC_EXTINT2          _L(89) /**< \brief EIC signal: EXTINT2 on PC25 mux B */
+#define MUX_PC25B_EIC_EXTINT2           _L(1)
+#define PINMUX_PC25B_EIC_EXTINT2   ((PIN_PC25B_EIC_EXTINT2 << 16) | MUX_PC25B_EIC_EXTINT2)
+#define GPIO_PC25B_EIC_EXTINT2   _UL(1 << 25)
+#define PIN_PC25B_EIC_EXTINT_NUM        _L(2) /**< \brief EIC signal: PIN_PC25 External Interrupt Line */
+#define PIN_PA05C_EIC_EXTINT3           _L(5) /**< \brief EIC signal: EXTINT3 on PA05 mux C */
+#define MUX_PA05C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA05C_EIC_EXTINT3   ((PIN_PA05C_EIC_EXTINT3 << 16) | MUX_PA05C_EIC_EXTINT3)
+#define GPIO_PA05C_EIC_EXTINT3   _UL(1 <<  5)
+#define PIN_PA05C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA18C_EIC_EXTINT3          _L(18) /**< \brief EIC signal: EXTINT3 on PA18 mux C */
+#define MUX_PA18C_EIC_EXTINT3           _L(2)
+#define PINMUX_PA18C_EIC_EXTINT3   ((PIN_PA18C_EIC_EXTINT3 << 16) | MUX_PA18C_EIC_EXTINT3)
+#define GPIO_PA18C_EIC_EXTINT3   _UL(1 << 18)
+#define PIN_PA18C_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PC26B_EIC_EXTINT3          _L(90) /**< \brief EIC signal: EXTINT3 on PC26 mux B */
+#define MUX_PC26B_EIC_EXTINT3           _L(1)
+#define PINMUX_PC26B_EIC_EXTINT3   ((PIN_PC26B_EIC_EXTINT3 << 16) | MUX_PC26B_EIC_EXTINT3)
+#define GPIO_PC26B_EIC_EXTINT3   _UL(1 << 26)
+#define PIN_PC26B_EIC_EXTINT_NUM        _L(3) /**< \brief EIC signal: PIN_PC26 External Interrupt Line */
+#define PIN_PA07C_EIC_EXTINT4           _L(7) /**< \brief EIC signal: EXTINT4 on PA07 mux C */
+#define MUX_PA07C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA07C_EIC_EXTINT4   ((PIN_PA07C_EIC_EXTINT4 << 16) | MUX_PA07C_EIC_EXTINT4)
+#define GPIO_PA07C_EIC_EXTINT4   _UL(1 <<  7)
+#define PIN_PA07C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA19C_EIC_EXTINT4          _L(19) /**< \brief EIC signal: EXTINT4 on PA19 mux C */
+#define MUX_PA19C_EIC_EXTINT4           _L(2)
+#define PINMUX_PA19C_EIC_EXTINT4   ((PIN_PA19C_EIC_EXTINT4 << 16) | MUX_PA19C_EIC_EXTINT4)
+#define GPIO_PA19C_EIC_EXTINT4   _UL(1 << 19)
+#define PIN_PA19C_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PC27B_EIC_EXTINT4          _L(91) /**< \brief EIC signal: EXTINT4 on PC27 mux B */
+#define MUX_PC27B_EIC_EXTINT4           _L(1)
+#define PINMUX_PC27B_EIC_EXTINT4   ((PIN_PC27B_EIC_EXTINT4 << 16) | MUX_PC27B_EIC_EXTINT4)
+#define GPIO_PC27B_EIC_EXTINT4   _UL(1 << 27)
+#define PIN_PC27B_EIC_EXTINT_NUM        _L(4) /**< \brief EIC signal: PIN_PC27 External Interrupt Line */
+#define PIN_PA20C_EIC_EXTINT5          _L(20) /**< \brief EIC signal: EXTINT5 on PA20 mux C */
+#define MUX_PA20C_EIC_EXTINT5           _L(2)
+#define PINMUX_PA20C_EIC_EXTINT5   ((PIN_PA20C_EIC_EXTINT5 << 16) | MUX_PA20C_EIC_EXTINT5)
+#define GPIO_PA20C_EIC_EXTINT5   _UL(1 << 20)
+#define PIN_PA20C_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PC03B_EIC_EXTINT5          _L(67) /**< \brief EIC signal: EXTINT5 on PC03 mux B */
+#define MUX_PC03B_EIC_EXTINT5           _L(1)
+#define PINMUX_PC03B_EIC_EXTINT5   ((PIN_PC03B_EIC_EXTINT5 << 16) | MUX_PC03B_EIC_EXTINT5)
+#define GPIO_PC03B_EIC_EXTINT5   _UL(1 <<  3)
+#define PIN_PC03B_EIC_EXTINT_NUM        _L(5) /**< \brief EIC signal: PIN_PC03 External Interrupt Line */
+#define PIN_PA21C_EIC_EXTINT6          _L(21) /**< \brief EIC signal: EXTINT6 on PA21 mux C */
+#define MUX_PA21C_EIC_EXTINT6           _L(2)
+#define PINMUX_PA21C_EIC_EXTINT6   ((PIN_PA21C_EIC_EXTINT6 << 16) | MUX_PA21C_EIC_EXTINT6)
+#define GPIO_PA21C_EIC_EXTINT6   _UL(1 << 21)
+#define PIN_PA21C_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PC04B_EIC_EXTINT6          _L(68) /**< \brief EIC signal: EXTINT6 on PC04 mux B */
+#define MUX_PC04B_EIC_EXTINT6           _L(1)
+#define PINMUX_PC04B_EIC_EXTINT6   ((PIN_PC04B_EIC_EXTINT6 << 16) | MUX_PC04B_EIC_EXTINT6)
+#define GPIO_PC04B_EIC_EXTINT6   _UL(1 <<  4)
+#define PIN_PC04B_EIC_EXTINT_NUM        _L(6) /**< \brief EIC signal: PIN_PC04 External Interrupt Line */
+#define PIN_PA22C_EIC_EXTINT7          _L(22) /**< \brief EIC signal: EXTINT7 on PA22 mux C */
+#define MUX_PA22C_EIC_EXTINT7           _L(2)
+#define PINMUX_PA22C_EIC_EXTINT7   ((PIN_PA22C_EIC_EXTINT7 << 16) | MUX_PA22C_EIC_EXTINT7)
+#define GPIO_PA22C_EIC_EXTINT7   _UL(1 << 22)
+#define PIN_PA22C_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PC05B_EIC_EXTINT7          _L(69) /**< \brief EIC signal: EXTINT7 on PC05 mux B */
+#define MUX_PC05B_EIC_EXTINT7           _L(1)
+#define PINMUX_PC05B_EIC_EXTINT7   ((PIN_PC05B_EIC_EXTINT7 << 16) | MUX_PC05B_EIC_EXTINT7)
+#define GPIO_PC05B_EIC_EXTINT7   _UL(1 <<  5)
+#define PIN_PC05B_EIC_EXTINT_NUM        _L(7) /**< \brief EIC signal: PIN_PC05 External Interrupt Line */
+#define PIN_PA23C_EIC_EXTINT8          _L(23) /**< \brief EIC signal: EXTINT8 on PA23 mux C */
+#define MUX_PA23C_EIC_EXTINT8           _L(2)
+#define PINMUX_PA23C_EIC_EXTINT8   ((PIN_PA23C_EIC_EXTINT8 << 16) | MUX_PA23C_EIC_EXTINT8)
+#define GPIO_PA23C_EIC_EXTINT8   _UL(1 << 23)
+#define PIN_PA23C_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PC06B_EIC_EXTINT8          _L(70) /**< \brief EIC signal: EXTINT8 on PC06 mux B */
+#define MUX_PC06B_EIC_EXTINT8           _L(1)
+#define PINMUX_PC06B_EIC_EXTINT8   ((PIN_PC06B_EIC_EXTINT8 << 16) | MUX_PC06B_EIC_EXTINT8)
+#define GPIO_PC06B_EIC_EXTINT8   _UL(1 <<  6)
+#define PIN_PC06B_EIC_EXTINT_NUM        _L(8) /**< \brief EIC signal: PIN_PC06 External Interrupt Line */
+
+#endif /* _SAM4LS8C_PIO_ */

--- a/asf/sam/include/sam4l/sam4lc2a.h
+++ b/asf/sam/include/sam4l/sam4lc2a.h
@@ -1,0 +1,913 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAM4LC2A
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LC2A_
+#define _SAM4LC2A_
+
+/**
+ * \ingroup SAM4L_definitions
+ * \addtogroup SAM4LC2A_definitions SAM4LC2A definitions
+ * This file defines all structures and symbols for SAM4LC2A:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#if !defined(_UL)
+#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#endif
+#else
+#if !defined(_UL)
+#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif
+#endif
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAM4LC2A */
+/* ************************************************************************** */
+/** \defgroup SAM4LC2A_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M4 Processor Exceptions Numbers ******************************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn           = -13,/**<  3 Cortex-M4 Hard Fault Interrupt        */
+  MemoryManagement_IRQn    = -12,/**<  4 Cortex-M4 Memory Management Interrupt */
+  BusFault_IRQn            = -11,/**<  5 Cortex-M4 Bus Fault Interrupt         */
+  UsageFault_IRQn          = -10,/**<  6 Cortex-M4 Usage Fault Interrupt       */
+  SVCall_IRQn              = -5, /**< 11 Cortex-M4 SV Call Interrupt           */
+  DebugMonitor_IRQn        = -4, /**< 12 Cortex-M4 Debug Monitor Interrupt     */
+  PendSV_IRQn              = -2, /**< 14 Cortex-M4 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 Cortex-M4 System Tick Interrupt       */
+  /******  SAM4LC2A-specific Interrupt Numbers ***********************/
+  HFLASHC_IRQn             =  0, /**<  0 SAM4LC2A Flash Controller (HFLASHC) */
+  PDCA_0_IRQn              =  1, /**<  1 SAM4LC2A Peripheral DMA Controller (PDCA): PDCA_0 */
+  PDCA_1_IRQn              =  2, /**<  2 SAM4LC2A Peripheral DMA Controller (PDCA): PDCA_1 */
+  PDCA_2_IRQn              =  3, /**<  3 SAM4LC2A Peripheral DMA Controller (PDCA): PDCA_2 */
+  PDCA_3_IRQn              =  4, /**<  4 SAM4LC2A Peripheral DMA Controller (PDCA): PDCA_3 */
+  PDCA_4_IRQn              =  5, /**<  5 SAM4LC2A Peripheral DMA Controller (PDCA): PDCA_4 */
+  PDCA_5_IRQn              =  6, /**<  6 SAM4LC2A Peripheral DMA Controller (PDCA): PDCA_5 */
+  PDCA_6_IRQn              =  7, /**<  7 SAM4LC2A Peripheral DMA Controller (PDCA): PDCA_6 */
+  PDCA_7_IRQn              =  8, /**<  8 SAM4LC2A Peripheral DMA Controller (PDCA): PDCA_7 */
+  PDCA_8_IRQn              =  9, /**<  9 SAM4LC2A Peripheral DMA Controller (PDCA): PDCA_8 */
+  PDCA_9_IRQn              = 10, /**< 10 SAM4LC2A Peripheral DMA Controller (PDCA): PDCA_9 */
+  PDCA_10_IRQn             = 11, /**< 11 SAM4LC2A Peripheral DMA Controller (PDCA): PDCA_10 */
+  PDCA_11_IRQn             = 12, /**< 12 SAM4LC2A Peripheral DMA Controller (PDCA): PDCA_11 */
+  PDCA_12_IRQn             = 13, /**< 13 SAM4LC2A Peripheral DMA Controller (PDCA): PDCA_12 */
+  PDCA_13_IRQn             = 14, /**< 14 SAM4LC2A Peripheral DMA Controller (PDCA): PDCA_13 */
+  PDCA_14_IRQn             = 15, /**< 15 SAM4LC2A Peripheral DMA Controller (PDCA): PDCA_14 */
+  PDCA_15_IRQn             = 16, /**< 16 SAM4LC2A Peripheral DMA Controller (PDCA): PDCA_15 */
+  CRCCU_IRQn               = 17, /**< 17 SAM4LC2A CRC Calculation Unit (CRCCU) */
+  USBC_IRQn                = 18, /**< 18 SAM4LC2A USB 2.0 Interface (USBC) */
+  PEVC_0_IRQn              = 19, /**< 19 SAM4LC2A Peripheral Event Controller (PEVC): PEVC_TR */
+  PEVC_1_IRQn              = 20, /**< 20 SAM4LC2A Peripheral Event Controller (PEVC): PEVC_OV */
+  AESA_IRQn                = 21, /**< 21 SAM4LC2A Advanced Encryption Standard (AESA) */
+  PM_IRQn                  = 22, /**< 22 SAM4LC2A Power Manager (PM) */
+  SCIF_IRQn                = 23, /**< 23 SAM4LC2A System Control Interface (SCIF) */
+  FREQM_IRQn               = 24, /**< 24 SAM4LC2A Frequency Meter (FREQM) */
+  GPIO_0_IRQn              = 25, /**< 25 SAM4LC2A General-Purpose Input/Output Controller (GPIO): GPIO_0 */
+  GPIO_1_IRQn              = 26, /**< 26 SAM4LC2A General-Purpose Input/Output Controller (GPIO): GPIO_1 */
+  GPIO_2_IRQn              = 27, /**< 27 SAM4LC2A General-Purpose Input/Output Controller (GPIO): GPIO_2 */
+  GPIO_3_IRQn              = 28, /**< 28 SAM4LC2A General-Purpose Input/Output Controller (GPIO): GPIO_3 */
+  GPIO_4_IRQn              = 29, /**< 29 SAM4LC2A General-Purpose Input/Output Controller (GPIO): GPIO_4 */
+  GPIO_5_IRQn              = 30, /**< 30 SAM4LC2A General-Purpose Input/Output Controller (GPIO): GPIO_5 */
+  GPIO_6_IRQn              = 31, /**< 31 SAM4LC2A General-Purpose Input/Output Controller (GPIO): GPIO_6 */
+  GPIO_7_IRQn              = 32, /**< 32 SAM4LC2A General-Purpose Input/Output Controller (GPIO): GPIO_7 */
+  GPIO_8_IRQn              = 33, /**< 33 SAM4LC2A General-Purpose Input/Output Controller (GPIO): GPIO_8 */
+  GPIO_9_IRQn              = 34, /**< 34 SAM4LC2A General-Purpose Input/Output Controller (GPIO): GPIO_9 */
+  GPIO_10_IRQn             = 35, /**< 35 SAM4LC2A General-Purpose Input/Output Controller (GPIO): GPIO_10 */
+  GPIO_11_IRQn             = 36, /**< 36 SAM4LC2A General-Purpose Input/Output Controller (GPIO): GPIO_11 */
+  BPM_IRQn                 = 37, /**< 37 SAM4LC2A Backup Power Manager (BPM) */
+  BSCIF_IRQn               = 38, /**< 38 SAM4LC2A Backup System Control Interface (BSCIF) */
+  AST_0_IRQn               = 39, /**< 39 SAM4LC2A Asynchronous Timer (AST): AST_ALARM */
+  AST_1_IRQn               = 40, /**< 40 SAM4LC2A Asynchronous Timer (AST): AST_PER */
+  AST_2_IRQn               = 41, /**< 41 SAM4LC2A Asynchronous Timer (AST): AST_OVF */
+  AST_3_IRQn               = 42, /**< 42 SAM4LC2A Asynchronous Timer (AST): AST_READY */
+  AST_4_IRQn               = 43, /**< 43 SAM4LC2A Asynchronous Timer (AST): AST_CLKREADY */
+  WDT_IRQn                 = 44, /**< 44 SAM4LC2A Watchdog Timer (WDT) */
+  EIC_0_IRQn               = 45, /**< 45 SAM4LC2A External Interrupt Controller (EIC): EIC_1 */
+  EIC_1_IRQn               = 46, /**< 46 SAM4LC2A External Interrupt Controller (EIC): EIC_2 */
+  EIC_2_IRQn               = 47, /**< 47 SAM4LC2A External Interrupt Controller (EIC): EIC_3 */
+  EIC_3_IRQn               = 48, /**< 48 SAM4LC2A External Interrupt Controller (EIC): EIC_4 */
+  EIC_4_IRQn               = 49, /**< 49 SAM4LC2A External Interrupt Controller (EIC): EIC_5 */
+  EIC_5_IRQn               = 50, /**< 50 SAM4LC2A External Interrupt Controller (EIC): EIC_6 */
+  EIC_6_IRQn               = 51, /**< 51 SAM4LC2A External Interrupt Controller (EIC): EIC_7 */
+  EIC_7_IRQn               = 52, /**< 52 SAM4LC2A External Interrupt Controller (EIC): EIC_8 */
+  IISC_IRQn                = 53, /**< 53 SAM4LC2A Inter-IC Sound (I2S) Controller (IISC) */
+  SPI_IRQn                 = 54, /**< 54 SAM4LC2A Serial Peripheral Interface (SPI) */
+  TC0_0_IRQn               = 55, /**< 55 SAM4LC2A Timer/Counter 0 (TC0): TC00 */
+  TC0_1_IRQn               = 56, /**< 56 SAM4LC2A Timer/Counter 0 (TC0): TC01 */
+  TC0_2_IRQn               = 57, /**< 57 SAM4LC2A Timer/Counter 0 (TC0): TC02 */
+  TC1_0_IRQn               = 58, /**< 58 SAM4LC2A Timer/Counter 1 (TC1): TC10 */
+  TC1_1_IRQn               = 59, /**< 59 SAM4LC2A Timer/Counter 1 (TC1): TC11 */
+  TC1_2_IRQn               = 60, /**< 60 SAM4LC2A Timer/Counter 1 (TC1): TC12 */
+  TWIM0_IRQn               = 61, /**< 61 SAM4LC2A Two-wire Master Interface 0 (TWIM0) */
+  TWIS0_IRQn               = 62, /**< 62 SAM4LC2A Two-wire Slave Interface 0 (TWIS0) */
+  TWIM1_IRQn               = 63, /**< 63 SAM4LC2A Two-wire Master Interface 1 (TWIM1) */
+  TWIS1_IRQn               = 64, /**< 64 SAM4LC2A Two-wire Slave Interface 1 (TWIS1) */
+  USART0_IRQn              = 65, /**< 65 SAM4LC2A Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+  USART1_IRQn              = 66, /**< 66 SAM4LC2A Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+  USART2_IRQn              = 67, /**< 67 SAM4LC2A Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+  USART3_IRQn              = 68, /**< 68 SAM4LC2A Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+  ADCIFE_IRQn              = 69, /**< 69 SAM4LC2A ADC controller interface (ADCIFE) */
+  DACC_IRQn                = 70, /**< 70 SAM4LC2A DAC Controller (DACC) */
+  ACIFC_IRQn               = 71, /**< 71 SAM4LC2A Analog Comparator Interface (ACIFC) */
+  ABDACB_IRQn              = 72, /**< 72 SAM4LC2A Audio Bitstream DAC (ABDACB) */
+  TRNG_IRQn                = 73, /**< 73 SAM4LC2A True Random Number Generator (TRNG) */
+  PARC_IRQn                = 74, /**< 74 SAM4LC2A Parallel Capture (PARC) */
+  CATB_IRQn                = 75, /**< 75 SAM4LC2A Capacitive Touch Module B (CATB) */
+  TWIM2_IRQn               = 77, /**< 77 SAM4LC2A Two-wire Master Interface 2 (TWIM2) */
+  TWIM3_IRQn               = 78, /**< 78 SAM4LC2A Two-wire Master Interface 3 (TWIM3) */
+  LCDCA_IRQn               = 79, /**< 79 SAM4LC2A LCD Controller (LCDCA) */
+
+  PERIPH_COUNT_IRQn        = 80  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNMI_Handler;
+  void* pfnHardFault_Handler;
+  void* pfnMemManage_Handler;
+  void* pfnBusFault_Handler;
+  void* pfnUsageFault_Handler;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVC_Handler;
+  void* pfnDebugMon_Handler;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnHFLASHC_Handler;               /*  0 Flash Controller */
+  void* pfnPDCA_0_Handler;                /*  1 Peripheral DMA Controller IRQ 0 */
+  void* pfnPDCA_1_Handler;                /*  2 Peripheral DMA Controller IRQ 1 */
+  void* pfnPDCA_2_Handler;                /*  3 Peripheral DMA Controller IRQ 2 */
+  void* pfnPDCA_3_Handler;                /*  4 Peripheral DMA Controller IRQ 3 */
+  void* pfnPDCA_4_Handler;                /*  5 Peripheral DMA Controller IRQ 4 */
+  void* pfnPDCA_5_Handler;                /*  6 Peripheral DMA Controller IRQ 5 */
+  void* pfnPDCA_6_Handler;                /*  7 Peripheral DMA Controller IRQ 6 */
+  void* pfnPDCA_7_Handler;                /*  8 Peripheral DMA Controller IRQ 7 */
+  void* pfnPDCA_8_Handler;                /*  9 Peripheral DMA Controller IRQ 8 */
+  void* pfnPDCA_9_Handler;                /* 10 Peripheral DMA Controller IRQ 9 */
+  void* pfnPDCA_10_Handler;               /* 11 Peripheral DMA Controller IRQ 10 */
+  void* pfnPDCA_11_Handler;               /* 12 Peripheral DMA Controller IRQ 11 */
+  void* pfnPDCA_12_Handler;               /* 13 Peripheral DMA Controller IRQ 12 */
+  void* pfnPDCA_13_Handler;               /* 14 Peripheral DMA Controller IRQ 13 */
+  void* pfnPDCA_14_Handler;               /* 15 Peripheral DMA Controller IRQ 14 */
+  void* pfnPDCA_15_Handler;               /* 16 Peripheral DMA Controller IRQ 15 */
+  void* pfnCRCCU_Handler;                 /* 17 CRC Calculation Unit */
+  void* pfnUSBC_Handler;                  /* 18 USB 2.0 Interface */
+  void* pfnPEVC_0_Handler;                /* 19 Peripheral Event Controller IRQ 0 */
+  void* pfnPEVC_1_Handler;                /* 20 Peripheral Event Controller IRQ 1 */
+  void* pfnAESA_Handler;                  /* 21 Advanced Encryption Standard */
+  void* pfnPM_Handler;                    /* 22 Power Manager */
+  void* pfnSCIF_Handler;                  /* 23 System Control Interface */
+  void* pfnFREQM_Handler;                 /* 24 Frequency Meter */
+  void* pfnGPIO_0_Handler;                /* 25 General-Purpose Input/Output Controller IRQ 0 */
+  void* pfnGPIO_1_Handler;                /* 26 General-Purpose Input/Output Controller IRQ 1 */
+  void* pfnGPIO_2_Handler;                /* 27 General-Purpose Input/Output Controller IRQ 2 */
+  void* pfnGPIO_3_Handler;                /* 28 General-Purpose Input/Output Controller IRQ 3 */
+  void* pfnGPIO_4_Handler;                /* 29 General-Purpose Input/Output Controller IRQ 4 */
+  void* pfnGPIO_5_Handler;                /* 30 General-Purpose Input/Output Controller IRQ 5 */
+  void* pfnGPIO_6_Handler;                /* 31 General-Purpose Input/Output Controller IRQ 6 */
+  void* pfnGPIO_7_Handler;                /* 32 General-Purpose Input/Output Controller IRQ 7 */
+  void* pfnGPIO_8_Handler;                /* 33 General-Purpose Input/Output Controller IRQ 8 */
+  void* pfnGPIO_9_Handler;                /* 34 General-Purpose Input/Output Controller IRQ 9 */
+  void* pfnGPIO_10_Handler;               /* 35 General-Purpose Input/Output Controller IRQ 10 */
+  void* pfnGPIO_11_Handler;               /* 36 General-Purpose Input/Output Controller IRQ 11 */
+  void* pfnBPM_Handler;                   /* 37 Backup Power Manager */
+  void* pfnBSCIF_Handler;                 /* 38 Backup System Control Interface */
+  void* pfnAST_0_Handler;                 /* 39 Asynchronous Timer IRQ 0 */
+  void* pfnAST_1_Handler;                 /* 40 Asynchronous Timer IRQ 1 */
+  void* pfnAST_2_Handler;                 /* 41 Asynchronous Timer IRQ 2 */
+  void* pfnAST_3_Handler;                 /* 42 Asynchronous Timer IRQ 3 */
+  void* pfnAST_4_Handler;                 /* 43 Asynchronous Timer IRQ 4 */
+  void* pfnWDT_Handler;                   /* 44 Watchdog Timer */
+  void* pfnEIC_0_Handler;                 /* 45 External Interrupt Controller IRQ 0 */
+  void* pfnEIC_1_Handler;                 /* 46 External Interrupt Controller IRQ 1 */
+  void* pfnEIC_2_Handler;                 /* 47 External Interrupt Controller IRQ 2 */
+  void* pfnEIC_3_Handler;                 /* 48 External Interrupt Controller IRQ 3 */
+  void* pfnEIC_4_Handler;                 /* 49 External Interrupt Controller IRQ 4 */
+  void* pfnEIC_5_Handler;                 /* 50 External Interrupt Controller IRQ 5 */
+  void* pfnEIC_6_Handler;                 /* 51 External Interrupt Controller IRQ 6 */
+  void* pfnEIC_7_Handler;                 /* 52 External Interrupt Controller IRQ 7 */
+  void* pfnIISC_Handler;                  /* 53 Inter-IC Sound (I2S) Controller */
+  void* pfnSPI_Handler;                   /* 54 Serial Peripheral Interface */
+  void* pfnTC0_0_Handler;                 /* 55 Timer/Counter 0 IRQ 0 */
+  void* pfnTC0_1_Handler;                 /* 56 Timer/Counter 0 IRQ 1 */
+  void* pfnTC0_2_Handler;                 /* 57 Timer/Counter 0 IRQ 2 */
+  void* pfnTC1_0_Handler;                 /* 58 Timer/Counter 1 IRQ 0 */
+  void* pfnTC1_1_Handler;                 /* 59 Timer/Counter 1 IRQ 1 */
+  void* pfnTC1_2_Handler;                 /* 60 Timer/Counter 1 IRQ 2 */
+  void* pfnTWIM0_Handler;                 /* 61 Two-wire Master Interface 0 */
+  void* pfnTWIS0_Handler;                 /* 62 Two-wire Slave Interface 0 */
+  void* pfnTWIM1_Handler;                 /* 63 Two-wire Master Interface 1 */
+  void* pfnTWIS1_Handler;                 /* 64 Two-wire Slave Interface 1 */
+  void* pfnUSART0_Handler;                /* 65 Universal Synchronous Asynchronous Receiver Transmitter 0 */
+  void* pfnUSART1_Handler;                /* 66 Universal Synchronous Asynchronous Receiver Transmitter 1 */
+  void* pfnUSART2_Handler;                /* 67 Universal Synchronous Asynchronous Receiver Transmitter 2 */
+  void* pfnUSART3_Handler;                /* 68 Universal Synchronous Asynchronous Receiver Transmitter 3 */
+  void* pfnADCIFE_Handler;                /* 69 ADC controller interface */
+  void* pfnDACC_Handler;                  /* 70 DAC Controller */
+  void* pfnACIFC_Handler;                 /* 71 Analog Comparator Interface */
+  void* pfnABDACB_Handler;                /* 72 Audio Bitstream DAC */
+  void* pfnTRNG_Handler;                  /* 73 True Random Number Generator */
+  void* pfnPARC_Handler;                  /* 74 Parallel Capture */
+  void* pfnCATB_Handler;                  /* 75 Capacitive Touch Module B */
+  void* pvReserved76;
+  void* pfnTWIM2_Handler;                 /* 77 Two-wire Master Interface 2 */
+  void* pfnTWIM3_Handler;                 /* 78 Two-wire Master Interface 3 */
+  void* pfnLCDCA_Handler;                 /* 79 LCD Controller */
+} DeviceVectors;
+
+/* Cortex-M4 processor handlers */
+void Reset_Handler               ( void );
+void NMI_Handler                 ( void );
+void HardFault_Handler           ( void );
+void MemManage_Handler           ( void );
+void BusFault_Handler            ( void );
+void UsageFault_Handler          ( void );
+void SVC_Handler                 ( void );
+void DebugMon_Handler            ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void HFLASHC_Handler             ( void );
+void PDCA_0_Handler              ( void );
+void PDCA_1_Handler              ( void );
+void PDCA_2_Handler              ( void );
+void PDCA_3_Handler              ( void );
+void PDCA_4_Handler              ( void );
+void PDCA_5_Handler              ( void );
+void PDCA_6_Handler              ( void );
+void PDCA_7_Handler              ( void );
+void PDCA_8_Handler              ( void );
+void PDCA_9_Handler              ( void );
+void PDCA_10_Handler             ( void );
+void PDCA_11_Handler             ( void );
+void PDCA_12_Handler             ( void );
+void PDCA_13_Handler             ( void );
+void PDCA_14_Handler             ( void );
+void PDCA_15_Handler             ( void );
+void CRCCU_Handler               ( void );
+void USBC_Handler                ( void );
+void PEVC_0_Handler              ( void );
+void PEVC_1_Handler              ( void );
+void AESA_Handler                ( void );
+void PM_Handler                  ( void );
+void SCIF_Handler                ( void );
+void FREQM_Handler               ( void );
+void GPIO_0_Handler              ( void );
+void GPIO_1_Handler              ( void );
+void GPIO_2_Handler              ( void );
+void GPIO_3_Handler              ( void );
+void GPIO_4_Handler              ( void );
+void GPIO_5_Handler              ( void );
+void GPIO_6_Handler              ( void );
+void GPIO_7_Handler              ( void );
+void GPIO_8_Handler              ( void );
+void GPIO_9_Handler              ( void );
+void GPIO_10_Handler             ( void );
+void GPIO_11_Handler             ( void );
+void BPM_Handler                 ( void );
+void BSCIF_Handler               ( void );
+void AST_0_Handler               ( void );
+void AST_1_Handler               ( void );
+void AST_2_Handler               ( void );
+void AST_3_Handler               ( void );
+void AST_4_Handler               ( void );
+void WDT_Handler                 ( void );
+void EIC_0_Handler               ( void );
+void EIC_1_Handler               ( void );
+void EIC_2_Handler               ( void );
+void EIC_3_Handler               ( void );
+void EIC_4_Handler               ( void );
+void EIC_5_Handler               ( void );
+void EIC_6_Handler               ( void );
+void EIC_7_Handler               ( void );
+void IISC_Handler                ( void );
+void SPI_Handler                 ( void );
+void TC0_0_Handler               ( void );
+void TC0_1_Handler               ( void );
+void TC0_2_Handler               ( void );
+void TC1_0_Handler               ( void );
+void TC1_1_Handler               ( void );
+void TC1_2_Handler               ( void );
+void TWIM0_Handler               ( void );
+void TWIS0_Handler               ( void );
+void TWIM1_Handler               ( void );
+void TWIS1_Handler               ( void );
+void USART0_Handler              ( void );
+void USART1_Handler              ( void );
+void USART2_Handler              ( void );
+void USART3_Handler              ( void );
+void ADCIFE_Handler              ( void );
+void DACC_Handler                ( void );
+void ACIFC_Handler               ( void );
+void ABDACB_Handler              ( void );
+void TRNG_Handler                ( void );
+void PARC_Handler                ( void );
+void CATB_Handler                ( void );
+void TWIM2_Handler               ( void );
+void TWIM3_Handler               ( void );
+void LCDCA_Handler               ( void );
+
+/*
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
+ */
+
+#define LITTLE_ENDIAN          1        
+#define __BB_PRESENT           0         /*!< BIT_BANDING present or not */
+#define __CLKGATE_PRESENT      1         /*!< CLKGATE present or not */
+#define __CM4_REV              1         /*!< Core revision r0p1 */
+#define __DEBUG_LVL            3         /*!< Full debug plus DWT data matching */
+#define __FPU_PRESENT          0         /*!< FPU present or not */
+#define __JTAG_PRESENT         1         /*!< JTAG present or not */
+#define __MPU_PRESENT          1         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       4         /*!< Number of bits used for Priority Levels */
+#define __TRACE_LVL            1         /*!< Standard trace: ITM and DWT triggers and counters, but no ETM */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+#define __WIC_PRESENT          0         /*!< WIC present or not */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm4.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_sam4l.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAM4LC2A */
+/* ************************************************************************** */
+/** \defgroup SAM4LC2A_api Peripheral Software API */
+/*@{*/
+
+#include "component/abdacb.h"
+#include "component/acifc.h"
+#include "component/adcife.h"
+#include "component/aesa.h"
+#include "component/ast.h"
+#include "component/bpm.h"
+#include "component/bscif.h"
+#include "component/catb.h"
+#include "component/chipid.h"
+#include "component/crccu.h"
+#include "component/dacc.h"
+#include "component/eic.h"
+#include "component/flashcalw.h"
+#include "component/freqm.h"
+#include "component/gloc.h"
+#include "component/gpio.h"
+#include "component/hcache.h"
+#include "component/hmatrixb.h"
+#include "component/iisc.h"
+#include "component/lcdca.h"
+#include "component/parc.h"
+#include "component/pdca.h"
+#include "component/pevc.h"
+#include "component/picouart.h"
+#include "component/pm.h"
+#include "component/scif.h"
+#include "component/smap.h"
+#include "component/spi.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twim.h"
+#include "component/twis.h"
+#include "component/usart.h"
+#include "component/usbc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAM4LC2A */
+/* ************************************************************************** */
+/** \defgroup SAM4LC2A_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/abdacb.h"
+#include "instance/acifc.h"
+#include "instance/adcife.h"
+#include "instance/aesa.h"
+#include "instance/ast.h"
+#include "instance/bpm.h"
+#include "instance/bscif.h"
+#include "instance/catb.h"
+#include "instance/chipid.h"
+#include "instance/crccu.h"
+#include "instance/dacc.h"
+#include "instance/eic.h"
+#include "instance/hflashc.h"
+#include "instance/freqm.h"
+#include "instance/gloc.h"
+#include "instance/gpio.h"
+#include "instance/hcache.h"
+#include "instance/hmatrix.h"
+#include "instance/iisc.h"
+#include "instance/lcdca.h"
+#include "instance/parc.h"
+#include "instance/pdca.h"
+#include "instance/pevc.h"
+#include "instance/picouart.h"
+#include "instance/pm.h"
+#include "instance/scif.h"
+#include "instance/smap.h"
+#include "instance/spi.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/trng.h"
+#include "instance/twim0.h"
+#include "instance/twim1.h"
+#include "instance/twim2.h"
+#include "instance/twim3.h"
+#include "instance/twis0.h"
+#include "instance/twis1.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usart3.h"
+#include "instance/usbc.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAM4LC2A */
+/* ************************************************************************** */
+/** \defgroup SAM4LC2A_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HTOP0 bridge
+#define ID_IISC           0 /**< \brief Inter-IC Sound (I2S) Controller (IISC) */
+#define ID_SPI            1 /**< \brief Serial Peripheral Interface (SPI) */
+#define ID_TC0            2 /**< \brief Timer/Counter 0 (TC0) */
+#define ID_TC1            3 /**< \brief Timer/Counter 1 (TC1) */
+#define ID_TWIM0          4 /**< \brief Two-wire Master Interface 0 (TWIM0) */
+#define ID_TWIS0          5 /**< \brief Two-wire Slave Interface 0 (TWIS0) */
+#define ID_TWIM1          6 /**< \brief Two-wire Master Interface 1 (TWIM1) */
+#define ID_TWIS1          7 /**< \brief Two-wire Slave Interface 1 (TWIS1) */
+#define ID_USART0         8 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+#define ID_USART1         9 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+#define ID_USART2        10 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+#define ID_USART3        11 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+#define ID_ADCIFE        12 /**< \brief ADC controller interface (ADCIFE) */
+#define ID_DACC          13 /**< \brief DAC Controller (DACC) */
+#define ID_ACIFC         14 /**< \brief Analog Comparator Interface (ACIFC) */
+#define ID_GLOC          15 /**< \brief Glue Logic Controller (GLOC) */
+#define ID_ABDACB        16 /**< \brief Audio Bitstream DAC (ABDACB) */
+#define ID_TRNG          17 /**< \brief True Random Number Generator (TRNG) */
+#define ID_PARC          18 /**< \brief Parallel Capture (PARC) */
+#define ID_CATB          19 /**< \brief Capacitive Touch Module B (CATB) */
+#define ID_TWIM2         21 /**< \brief Two-wire Master Interface 2 (TWIM2) */
+#define ID_TWIM3         22 /**< \brief Two-wire Master Interface 3 (TWIM3) */
+#define ID_LCDCA         23 /**< \brief LCD Controller (LCDCA) */
+
+// Peripheral instances on HTOP1 bridge
+#define ID_HFLASHC       32 /**< \brief Flash Controller (HFLASHC) */
+#define ID_HCACHE        33 /**< \brief Cortex M I&D Cache Controller (HCACHE) */
+#define ID_HMATRIX       34 /**< \brief HSB Matrix (HMATRIX) */
+#define ID_PDCA          35 /**< \brief Peripheral DMA Controller (PDCA) */
+#define ID_SMAP          36 /**< \brief System Manager Access Port (SMAP) */
+#define ID_CRCCU         37 /**< \brief CRC Calculation Unit (CRCCU) */
+#define ID_USBC          38 /**< \brief USB 2.0 Interface (USBC) */
+#define ID_PEVC          39 /**< \brief Peripheral Event Controller (PEVC) */
+
+// Peripheral instances on HTOP2 bridge
+#define ID_PM            64 /**< \brief Power Manager (PM) */
+#define ID_CHIPID        65 /**< \brief Chip ID Registers (CHIPID) */
+#define ID_SCIF          66 /**< \brief System Control Interface (SCIF) */
+#define ID_FREQM         67 /**< \brief Frequency Meter (FREQM) */
+#define ID_GPIO          68 /**< \brief General-Purpose Input/Output Controller (GPIO) */
+
+// Peripheral instances on HTOP3 bridge
+#define ID_BPM           96 /**< \brief Backup Power Manager (BPM) */
+#define ID_BSCIF         97 /**< \brief Backup System Control Interface (BSCIF) */
+#define ID_AST           98 /**< \brief Asynchronous Timer (AST) */
+#define ID_WDT           99 /**< \brief Watchdog Timer (WDT) */
+#define ID_EIC          100 /**< \brief External Interrupt Controller (EIC) */
+#define ID_PICOUART     101 /**< \brief Pico UART (PICOUART) */
+
+// Peripheral instances on AHB (as if on bridge 4)
+#define ID_AESA         128 /**< \brief Advanced Encryption Standard (AESA) */
+
+#define ID_PERIPH_COUNT 129 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAM4LC2A */
+/* ************************************************************************** */
+/** \defgroup SAM4LC2A_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define ABDACB                        (0x40064000) /**< \brief (ABDACB) APB Base Address */
+#define ACIFC                         (0x40040000) /**< \brief (ACIFC) APB Base Address */
+#define ADCIFE                        (0x40038000) /**< \brief (ADCIFE) APB Base Address */
+#define AESA                          (0x400B0000) /**< \brief (AESA) AHB Base Address */
+#define AST                           (0x400F0800) /**< \brief (AST) APB Base Address */
+#define BPM                           (0x400F0000) /**< \brief (BPM) APB Base Address */
+#define BSCIF                         (0x400F0400) /**< \brief (BSCIF) APB Base Address */
+#define CATB                          (0x40070000) /**< \brief (CATB) APB Base Address */
+#define CHIPID                        (0x400E0400) /**< \brief (CHIPID) APB Base Address */
+#define CRCCU                         (0x400A4000) /**< \brief (CRCCU) APB Base Address */
+#define DACC                          (0x4003C000) /**< \brief (DACC) APB Base Address */
+#define EIC                           (0x400F1000) /**< \brief (EIC) APB Base Address */
+#define HFLASHC                       (0x400A0000) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000) /**< \brief (HFLASHC) USER Base Address */
+#define FREQM                         (0x400E0C00) /**< \brief (FREQM) APB Base Address */
+#define GLOC                          (0x40060000) /**< \brief (GLOC) APB Base Address */
+#define GPIO                          (0x400E1000) /**< \brief (GPIO) APB Base Address */
+#define HCACHE                        (0x400A0400) /**< \brief (HCACHE) APB Base Address */
+#define HMATRIX                       (0x400A1000) /**< \brief (HMATRIX) APB Base Address */
+#define IISC                          (0x40004000) /**< \brief (IISC) APB Base Address */
+#define LCDCA                         (0x40080000) /**< \brief (LCDCA) APB Base Address */
+#define PARC                          (0x4006C000) /**< \brief (PARC) APB Base Address */
+#define PDCA                          (0x400A2000) /**< \brief (PDCA) APB Base Address */
+#define PEVC                          (0x400A6000) /**< \brief (PEVC) APB Base Address */
+#define PICOUART                      (0x400F1400) /**< \brief (PICOUART) APB Base Address */
+#define PM                            (0x400E0000) /**< \brief (PM) APB Base Address */
+#define SCIF                          (0x400E0800) /**< \brief (SCIF) APB Base Address */
+#define SMAP                          (0x400A3000) /**< \brief (SMAP) APB Base Address */
+#define SPI                           (0x40008000) /**< \brief (SPI) APB Base Address */
+#define TC0                           (0x40010000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x40014000) /**< \brief (TC1) APB Base Address */
+#define TRNG                          (0x40068000) /**< \brief (TRNG) APB Base Address */
+#define TWIM0                         (0x40018000) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1                         (0x4001C000) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2                         (0x40078000) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3                         (0x4007C000) /**< \brief (TWIM3) APB Base Address */
+#define TWIS0                         (0x40018400) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1                         (0x4001C400) /**< \brief (TWIS1) APB Base Address */
+#define USART0                        (0x40024000) /**< \brief (USART0) APB Base Address */
+#define USART1                        (0x40028000) /**< \brief (USART1) APB Base Address */
+#define USART2                        (0x4002C000) /**< \brief (USART2) APB Base Address */
+#define USART3                        (0x40030000) /**< \brief (USART3) APB Base Address */
+#define USBC                          (0x400A5000) /**< \brief (USBC) APB Base Address */
+#define WDT                           (0x400F0C00) /**< \brief (WDT) APB Base Address */
+#else
+#define ABDACB            ((Abdacb   *)0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_ADDR                   (0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_INST_NUM   1                          /**< \brief (ABDACB) Number of instances */
+#define ABDACB_INSTS      { ABDACB }                 /**< \brief (ABDACB) Instances List */
+
+#define ACIFC             ((Acifc    *)0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_ADDR                    (0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_INST_NUM    1                          /**< \brief (ACIFC) Number of instances */
+#define ACIFC_INSTS       { ACIFC }                  /**< \brief (ACIFC) Instances List */
+
+#define ADCIFE            ((Adcife   *)0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_ADDR                   (0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_INST_NUM   1                          /**< \brief (ADCIFE) Number of instances */
+#define ADCIFE_INSTS      { ADCIFE }                 /**< \brief (ADCIFE) Instances List */
+
+#define AESA              ((Aesa     *)0x400B0000UL) /**< \brief (AESA) AHB Base Address */
+#define AESA_ADDR                     (0x400B0000UL) /**< \brief (AESA) AHB Base Address */
+#define AESA_INST_NUM     1                          /**< \brief (AESA) Number of instances */
+#define AESA_INSTS        { AESA }                   /**< \brief (AESA) Instances List */
+
+#define AST               ((Ast      *)0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_ADDR                      (0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_INST_NUM      1                          /**< \brief (AST) Number of instances */
+#define AST_INSTS         { AST }                    /**< \brief (AST) Instances List */
+
+#define BPM               ((Bpm      *)0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_ADDR                      (0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_INST_NUM      1                          /**< \brief (BPM) Number of instances */
+#define BPM_INSTS         { BPM }                    /**< \brief (BPM) Instances List */
+
+#define BSCIF             ((Bscif    *)0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_ADDR                    (0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_INST_NUM    1                          /**< \brief (BSCIF) Number of instances */
+#define BSCIF_INSTS       { BSCIF }                  /**< \brief (BSCIF) Instances List */
+
+#define CATB              ((Catb     *)0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_ADDR                     (0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_INST_NUM     1                          /**< \brief (CATB) Number of instances */
+#define CATB_INSTS        { CATB }                   /**< \brief (CATB) Instances List */
+
+#define CHIPID            ((Chipid   *)0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_ADDR                   (0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_INST_NUM   1                          /**< \brief (CHIPID) Number of instances */
+#define CHIPID_INSTS      { CHIPID }                 /**< \brief (CHIPID) Instances List */
+
+#define CRCCU             ((Crccu    *)0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_ADDR                    (0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_INST_NUM    1                          /**< \brief (CRCCU) Number of instances */
+#define CRCCU_INSTS       { CRCCU }                  /**< \brief (CRCCU) Instances List */
+
+#define DACC              ((Dacc     *)0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_ADDR                     (0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_INST_NUM     1                          /**< \brief (DACC) Number of instances */
+#define DACC_INSTS        { DACC }                   /**< \brief (DACC) Instances List */
+
+#define EIC               ((Eic      *)0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_ADDR                      (0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define HFLASHC           ((Flashcalw *)0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_ADDR                  (0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_FROW_ADDR             (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define HFLASHC_USER_ADDR             (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define FLASHCALW_INST_NUM 1                          /**< \brief (FLASHCALW) Number of instances */
+#define FLASHCALW_INSTS   { HFLASHC }                /**< \brief (FLASHCALW) Instances List */
+
+#define FREQM             ((Freqm    *)0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_ADDR                    (0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_INST_NUM    1                          /**< \brief (FREQM) Number of instances */
+#define FREQM_INSTS       { FREQM }                  /**< \brief (FREQM) Instances List */
+
+#define GLOC              ((Gloc     *)0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_ADDR                     (0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_INST_NUM     1                          /**< \brief (GLOC) Number of instances */
+#define GLOC_INSTS        { GLOC }                   /**< \brief (GLOC) Instances List */
+
+#define GPIO              ((Gpio     *)0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_ADDR                     (0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_INST_NUM     1                          /**< \brief (GPIO) Number of instances */
+#define GPIO_INSTS        { GPIO }                   /**< \brief (GPIO) Instances List */
+
+#define HCACHE            ((Hcache   *)0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_ADDR                   (0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_INST_NUM   1                          /**< \brief (HCACHE) Number of instances */
+#define HCACHE_INSTS      { HCACHE }                 /**< \brief (HCACHE) Instances List */
+
+#define HMATRIX           ((Hmatrixb *)0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIX_ADDR                  (0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIXB_INST_NUM 1                          /**< \brief (HMATRIXB) Number of instances */
+#define HMATRIXB_INSTS    { HMATRIX }                /**< \brief (HMATRIXB) Instances List */
+
+#define IISC              ((Iisc     *)0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_ADDR                     (0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_INST_NUM     1                          /**< \brief (IISC) Number of instances */
+#define IISC_INSTS        { IISC }                   /**< \brief (IISC) Instances List */
+
+#define LCDCA             ((Lcdca    *)0x40080000UL) /**< \brief (LCDCA) APB Base Address */
+#define LCDCA_ADDR                    (0x40080000UL) /**< \brief (LCDCA) APB Base Address */
+#define LCDCA_INST_NUM    1                          /**< \brief (LCDCA) Number of instances */
+#define LCDCA_INSTS       { LCDCA }                  /**< \brief (LCDCA) Instances List */
+
+#define PARC              ((Parc     *)0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_ADDR                     (0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_INST_NUM     1                          /**< \brief (PARC) Number of instances */
+#define PARC_INSTS        { PARC }                   /**< \brief (PARC) Instances List */
+
+#define PDCA              ((Pdca     *)0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_ADDR                     (0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_INST_NUM     1                          /**< \brief (PDCA) Number of instances */
+#define PDCA_INSTS        { PDCA }                   /**< \brief (PDCA) Instances List */
+
+#define PEVC              ((Pevc     *)0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_ADDR                     (0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_INST_NUM     1                          /**< \brief (PEVC) Number of instances */
+#define PEVC_INSTS        { PEVC }                   /**< \brief (PEVC) Instances List */
+
+#define PICOUART          ((Picouart *)0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_ADDR                 (0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_INST_NUM 1                          /**< \brief (PICOUART) Number of instances */
+#define PICOUART_INSTS    { PICOUART }               /**< \brief (PICOUART) Instances List */
+
+#define PM                ((Pm       *)0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_ADDR                       (0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define SCIF              ((Scif     *)0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_ADDR                     (0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_INST_NUM     1                          /**< \brief (SCIF) Number of instances */
+#define SCIF_INSTS        { SCIF }                   /**< \brief (SCIF) Instances List */
+
+#define SMAP              ((Smap     *)0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_ADDR                     (0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_INST_NUM     1                          /**< \brief (SMAP) Number of instances */
+#define SMAP_INSTS        { SMAP }                   /**< \brief (SMAP) Instances List */
+
+#define SPI               ((Spi      *)0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_ADDR                      (0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_INST_NUM      1                          /**< \brief (SPI) Number of instances */
+#define SPI_INSTS         { SPI }                    /**< \brief (SPI) Instances List */
+
+#define TC0               ((Tc       *)0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC0_ADDR                      (0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC1_ADDR                      (0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC_INST_NUM       2                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1 }               /**< \brief (TC) Instances List */
+
+#define TRNG              ((Trng     *)0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_ADDR                     (0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_INST_NUM     1                          /**< \brief (TRNG) Number of instances */
+#define TRNG_INSTS        { TRNG }                   /**< \brief (TRNG) Instances List */
+
+#define TWIM0             ((Twim     *)0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM0_ADDR                    (0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1             ((Twim     *)0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM1_ADDR                    (0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2             ((Twim     *)0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM2_ADDR                    (0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3             ((Twim     *)0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM3_ADDR                    (0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM_INST_NUM     4                          /**< \brief (TWIM) Number of instances */
+#define TWIM_INSTS        { TWIM0, TWIM1, TWIM2, TWIM3 } /**< \brief (TWIM) Instances List */
+
+#define TWIS0             ((Twis     *)0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS0_ADDR                    (0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1             ((Twis     *)0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS1_ADDR                    (0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS_INST_NUM     2                          /**< \brief (TWIS) Number of instances */
+#define TWIS_INSTS        { TWIS0, TWIS1 }           /**< \brief (TWIS) Instances List */
+
+#define USART0            ((Usart    *)0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART0_ADDR                   (0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART1            ((Usart    *)0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART1_ADDR                   (0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART2            ((Usart    *)0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART2_ADDR                   (0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART3            ((Usart    *)0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART3_ADDR                   (0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART_INST_NUM    4                          /**< \brief (USART) Number of instances */
+#define USART_INSTS       { USART0, USART1, USART2, USART3 } /**< \brief (USART) Instances List */
+
+#define USBC              ((Usbc     *)0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_ADDR                     (0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_INST_NUM     1                          /**< \brief (USBC) Number of instances */
+#define USBC_INSTS        { USBC }                   /**< \brief (USBC) Instances List */
+
+#define WDT               ((Wdt      *)0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_ADDR                      (0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  GPIO DEFINITIONS FOR SAM4LC2A */
+/* ************************************************************************** */
+/** \defgroup SAM4LC2A_gpio GPIO Definitions */
+/*@{*/
+
+#include "pio/sam4lc2a.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  ADDITIONAL DEFINITIONS FOR COMPATIBILITY */
+/* ************************************************************************** */
+/** \addtogroup SAM4LC2A_compat Definitions */
+/*@{*/
+// These defines are used to keep compatibility with existing 
+// sam/drivers/usart implementation from SAM3/4 products with SAM4L product.
+#define US_MR_USART_MODE_HW_HANDSHAKING  US_MR_USART_MODE_HARDWARE
+#define US_MR_USART_MODE_IS07816_T_0     US_MR_USART_MODE_ISO7816_T0
+#define US_MR_USART_MODE_IS07816_T_1     US_MR_USART_MODE_ISO7816_T1
+#define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
+#define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
+#define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_8_BIT      US_MR_CHRL_8
+#define US_MR_PAR_NO          US_MR_PAR_NONE
+#define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI
+#define US_IF                 US_IFR
+#define US_WPSR_WPVS          US_WPSR_WPV_1
+
+#define USBC_UPCFG0_PBK_Msk   (0x1u << USBC_UPCFG0_PBK_Pos)
+
+// These defines for homogeneity with other SAM header files.
+#define CHIP_FREQ_FWS_0       (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 */
+#define CHIP_FREQ_FWS_1       (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 */
+// WARNING NOTE: these are preliminary values.
+#define CHIP_FREQ_FLASH_HSEN_FWS_0 (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 and the FLASH HS mode is enabled */
+#define CHIP_FREQ_FLASH_HSEN_FWS_1 (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 and the FLASH HS mode is enabled */
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/tc implementation from SAM3/4 products with SAM4L product. 
+#define TC_CMR_LDRA_RISING    TC_CMR_LDRA_POS_EDGE_TIOA
+#define TC_CMR_LDRB_FALLING   TC_CMR_LDRB_NEG_EDGE_TIOA
+#define TC_CMR_ETRGEDG_FALLING TC_CMR_ETRGEDG_NEG_EDGE
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/spi implementation from SAM3/4 products with SAM4L product. 
+#define SPI_CSR_BITS_8_BIT    SPI_CSR_BITS_8_BPT
+#define SPI_WPCR_SPIWPKEY_VALUE SPI_WPCR_WPKEY_VALUE
+#define SPI_WPCR_SPIWPEN      SPI_WPCR_WPEN
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/crccu implementation from SAM3/4 products with SAM4L product. 
+#define CRCCU_DMA_EN          CRCCU_DMAEN
+#define CRCCU_DMA_DIS         CRCCU_DMADIS
+#define CRCCU_DMA_SR          CRCCU_DMASR
+#define CRCCU_DMA_IER         CRCCU_DMAIER
+#define CRCCU_DMA_IDR         CRCCU_DMAIDR
+#define CRCCU_DMA_IMR         CRCCU_DMAIMR
+#define CRCCU_DMA_ISR         CRCCU_DMAISR
+#define CRCCU_DMA_EN_DMAEN    CRCCU_DMAEN_DMAEN
+#define CRCCU_DMA_DIS_DMADIS  CRCCU_DMADIS_DMADIS
+#define CRCCU_DMA_SR_DMASR    CRCCU_DMASR_DMASR
+#define CRCCU_DMA_IER_DMAIER  CRCCU_DMAIER_DMAIER
+#define CRCCU_DMA_IDR_DMAIDR  CRCCU_DMAIDR_DMAIDR
+#define CRCCU_DMA_IMR_DMAIMR  CRCCU_DMAIMR_DMAIMR
+#define CRCCU_DMA_ISR_DMAISR  CRCCU_DMAISR_DMAISR
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAM4LC2A */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL(0x00020000) /* 128 kB */
+#define FLASH_PAGE_SIZE       512
+#define FLASH_NB_OF_PAGES     256
+#define FLASH_USER_PAGE_SIZE  512
+#define HRAMC0_SIZE           _UL(0x00008000) /* 32 kB */
+#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+
+#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+
+#define DSU_DID_RESETVALUE    _UL(0xAB0A07E0)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAM4LC2A */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAM4LC2A_H */

--- a/asf/sam/include/sam4l/sam4lc2a.h
+++ b/asf/sam/include/sam4l/sam4lc2a.h
@@ -62,15 +62,15 @@ typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volati
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
 #if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#define _U_(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
 #if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#define _U_(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 
@@ -881,23 +881,23 @@ void LCDCA_Handler               ( void );
 /**  MEMORY MAPPING DEFINITIONS FOR SAM4LC2A */
 /* ************************************************************************** */
 
-#define FLASH_SIZE            _UL(0x00020000) /* 128 kB */
+#define FLASH_SIZE            _UL_(0x00020000) /* 128 kB */
 #define FLASH_PAGE_SIZE       512
 #define FLASH_NB_OF_PAGES     256
 #define FLASH_USER_PAGE_SIZE  512
-#define HRAMC0_SIZE           _UL(0x00008000) /* 32 kB */
-#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+#define HRAMC0_SIZE           _UL_(0x00008000) /* 32 kB */
+#define HRAMC1_SIZE           _UL_(0x00000800) /* 2 kB */
 
-#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
-#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
-#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
-#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
-#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
-#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
-#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
-#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL_(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL_(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL_(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL_(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL_(0x400F0000) /**< HTOP3 base address */
 
-#define DSU_DID_RESETVALUE    _UL(0xAB0A07E0)
+#define DSU_DID_RESETVALUE    _UL_(0xAB0A07E0)
 
 /* ************************************************************************** */
 /**  ELECTRICAL DEFINITIONS FOR SAM4LC2A */

--- a/asf/sam/include/sam4l/sam4lc2b.h
+++ b/asf/sam/include/sam4l/sam4lc2b.h
@@ -62,15 +62,15 @@ typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volati
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
 #if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#define _U_(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
 #if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#define _U_(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 
@@ -881,23 +881,23 @@ void LCDCA_Handler               ( void );
 /**  MEMORY MAPPING DEFINITIONS FOR SAM4LC2B */
 /* ************************************************************************** */
 
-#define FLASH_SIZE            _UL(0x00020000) /* 128 kB */
+#define FLASH_SIZE            _UL_(0x00020000) /* 128 kB */
 #define FLASH_PAGE_SIZE       512
 #define FLASH_NB_OF_PAGES     256
 #define FLASH_USER_PAGE_SIZE  512
-#define HRAMC0_SIZE           _UL(0x00008000) /* 32 kB */
-#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+#define HRAMC0_SIZE           _UL_(0x00008000) /* 32 kB */
+#define HRAMC1_SIZE           _UL_(0x00000800) /* 2 kB */
 
-#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
-#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
-#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
-#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
-#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
-#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
-#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
-#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL_(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL_(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL_(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL_(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL_(0x400F0000) /**< HTOP3 base address */
 
-#define DSU_DID_RESETVALUE    _UL(0xAB0A07E0)
+#define DSU_DID_RESETVALUE    _UL_(0xAB0A07E0)
 
 /* ************************************************************************** */
 /**  ELECTRICAL DEFINITIONS FOR SAM4LC2B */

--- a/asf/sam/include/sam4l/sam4lc2b.h
+++ b/asf/sam/include/sam4l/sam4lc2b.h
@@ -1,0 +1,913 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAM4LC2B
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LC2B_
+#define _SAM4LC2B_
+
+/**
+ * \ingroup SAM4L_definitions
+ * \addtogroup SAM4LC2B_definitions SAM4LC2B definitions
+ * This file defines all structures and symbols for SAM4LC2B:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#if !defined(_UL)
+#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#endif
+#else
+#if !defined(_UL)
+#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif
+#endif
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAM4LC2B */
+/* ************************************************************************** */
+/** \defgroup SAM4LC2B_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M4 Processor Exceptions Numbers ******************************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn           = -13,/**<  3 Cortex-M4 Hard Fault Interrupt        */
+  MemoryManagement_IRQn    = -12,/**<  4 Cortex-M4 Memory Management Interrupt */
+  BusFault_IRQn            = -11,/**<  5 Cortex-M4 Bus Fault Interrupt         */
+  UsageFault_IRQn          = -10,/**<  6 Cortex-M4 Usage Fault Interrupt       */
+  SVCall_IRQn              = -5, /**< 11 Cortex-M4 SV Call Interrupt           */
+  DebugMonitor_IRQn        = -4, /**< 12 Cortex-M4 Debug Monitor Interrupt     */
+  PendSV_IRQn              = -2, /**< 14 Cortex-M4 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 Cortex-M4 System Tick Interrupt       */
+  /******  SAM4LC2B-specific Interrupt Numbers ***********************/
+  HFLASHC_IRQn             =  0, /**<  0 SAM4LC2B Flash Controller (HFLASHC) */
+  PDCA_0_IRQn              =  1, /**<  1 SAM4LC2B Peripheral DMA Controller (PDCA): PDCA_0 */
+  PDCA_1_IRQn              =  2, /**<  2 SAM4LC2B Peripheral DMA Controller (PDCA): PDCA_1 */
+  PDCA_2_IRQn              =  3, /**<  3 SAM4LC2B Peripheral DMA Controller (PDCA): PDCA_2 */
+  PDCA_3_IRQn              =  4, /**<  4 SAM4LC2B Peripheral DMA Controller (PDCA): PDCA_3 */
+  PDCA_4_IRQn              =  5, /**<  5 SAM4LC2B Peripheral DMA Controller (PDCA): PDCA_4 */
+  PDCA_5_IRQn              =  6, /**<  6 SAM4LC2B Peripheral DMA Controller (PDCA): PDCA_5 */
+  PDCA_6_IRQn              =  7, /**<  7 SAM4LC2B Peripheral DMA Controller (PDCA): PDCA_6 */
+  PDCA_7_IRQn              =  8, /**<  8 SAM4LC2B Peripheral DMA Controller (PDCA): PDCA_7 */
+  PDCA_8_IRQn              =  9, /**<  9 SAM4LC2B Peripheral DMA Controller (PDCA): PDCA_8 */
+  PDCA_9_IRQn              = 10, /**< 10 SAM4LC2B Peripheral DMA Controller (PDCA): PDCA_9 */
+  PDCA_10_IRQn             = 11, /**< 11 SAM4LC2B Peripheral DMA Controller (PDCA): PDCA_10 */
+  PDCA_11_IRQn             = 12, /**< 12 SAM4LC2B Peripheral DMA Controller (PDCA): PDCA_11 */
+  PDCA_12_IRQn             = 13, /**< 13 SAM4LC2B Peripheral DMA Controller (PDCA): PDCA_12 */
+  PDCA_13_IRQn             = 14, /**< 14 SAM4LC2B Peripheral DMA Controller (PDCA): PDCA_13 */
+  PDCA_14_IRQn             = 15, /**< 15 SAM4LC2B Peripheral DMA Controller (PDCA): PDCA_14 */
+  PDCA_15_IRQn             = 16, /**< 16 SAM4LC2B Peripheral DMA Controller (PDCA): PDCA_15 */
+  CRCCU_IRQn               = 17, /**< 17 SAM4LC2B CRC Calculation Unit (CRCCU) */
+  USBC_IRQn                = 18, /**< 18 SAM4LC2B USB 2.0 Interface (USBC) */
+  PEVC_0_IRQn              = 19, /**< 19 SAM4LC2B Peripheral Event Controller (PEVC): PEVC_TR */
+  PEVC_1_IRQn              = 20, /**< 20 SAM4LC2B Peripheral Event Controller (PEVC): PEVC_OV */
+  AESA_IRQn                = 21, /**< 21 SAM4LC2B Advanced Encryption Standard (AESA) */
+  PM_IRQn                  = 22, /**< 22 SAM4LC2B Power Manager (PM) */
+  SCIF_IRQn                = 23, /**< 23 SAM4LC2B System Control Interface (SCIF) */
+  FREQM_IRQn               = 24, /**< 24 SAM4LC2B Frequency Meter (FREQM) */
+  GPIO_0_IRQn              = 25, /**< 25 SAM4LC2B General-Purpose Input/Output Controller (GPIO): GPIO_0 */
+  GPIO_1_IRQn              = 26, /**< 26 SAM4LC2B General-Purpose Input/Output Controller (GPIO): GPIO_1 */
+  GPIO_2_IRQn              = 27, /**< 27 SAM4LC2B General-Purpose Input/Output Controller (GPIO): GPIO_2 */
+  GPIO_3_IRQn              = 28, /**< 28 SAM4LC2B General-Purpose Input/Output Controller (GPIO): GPIO_3 */
+  GPIO_4_IRQn              = 29, /**< 29 SAM4LC2B General-Purpose Input/Output Controller (GPIO): GPIO_4 */
+  GPIO_5_IRQn              = 30, /**< 30 SAM4LC2B General-Purpose Input/Output Controller (GPIO): GPIO_5 */
+  GPIO_6_IRQn              = 31, /**< 31 SAM4LC2B General-Purpose Input/Output Controller (GPIO): GPIO_6 */
+  GPIO_7_IRQn              = 32, /**< 32 SAM4LC2B General-Purpose Input/Output Controller (GPIO): GPIO_7 */
+  GPIO_8_IRQn              = 33, /**< 33 SAM4LC2B General-Purpose Input/Output Controller (GPIO): GPIO_8 */
+  GPIO_9_IRQn              = 34, /**< 34 SAM4LC2B General-Purpose Input/Output Controller (GPIO): GPIO_9 */
+  GPIO_10_IRQn             = 35, /**< 35 SAM4LC2B General-Purpose Input/Output Controller (GPIO): GPIO_10 */
+  GPIO_11_IRQn             = 36, /**< 36 SAM4LC2B General-Purpose Input/Output Controller (GPIO): GPIO_11 */
+  BPM_IRQn                 = 37, /**< 37 SAM4LC2B Backup Power Manager (BPM) */
+  BSCIF_IRQn               = 38, /**< 38 SAM4LC2B Backup System Control Interface (BSCIF) */
+  AST_0_IRQn               = 39, /**< 39 SAM4LC2B Asynchronous Timer (AST): AST_ALARM */
+  AST_1_IRQn               = 40, /**< 40 SAM4LC2B Asynchronous Timer (AST): AST_PER */
+  AST_2_IRQn               = 41, /**< 41 SAM4LC2B Asynchronous Timer (AST): AST_OVF */
+  AST_3_IRQn               = 42, /**< 42 SAM4LC2B Asynchronous Timer (AST): AST_READY */
+  AST_4_IRQn               = 43, /**< 43 SAM4LC2B Asynchronous Timer (AST): AST_CLKREADY */
+  WDT_IRQn                 = 44, /**< 44 SAM4LC2B Watchdog Timer (WDT) */
+  EIC_0_IRQn               = 45, /**< 45 SAM4LC2B External Interrupt Controller (EIC): EIC_1 */
+  EIC_1_IRQn               = 46, /**< 46 SAM4LC2B External Interrupt Controller (EIC): EIC_2 */
+  EIC_2_IRQn               = 47, /**< 47 SAM4LC2B External Interrupt Controller (EIC): EIC_3 */
+  EIC_3_IRQn               = 48, /**< 48 SAM4LC2B External Interrupt Controller (EIC): EIC_4 */
+  EIC_4_IRQn               = 49, /**< 49 SAM4LC2B External Interrupt Controller (EIC): EIC_5 */
+  EIC_5_IRQn               = 50, /**< 50 SAM4LC2B External Interrupt Controller (EIC): EIC_6 */
+  EIC_6_IRQn               = 51, /**< 51 SAM4LC2B External Interrupt Controller (EIC): EIC_7 */
+  EIC_7_IRQn               = 52, /**< 52 SAM4LC2B External Interrupt Controller (EIC): EIC_8 */
+  IISC_IRQn                = 53, /**< 53 SAM4LC2B Inter-IC Sound (I2S) Controller (IISC) */
+  SPI_IRQn                 = 54, /**< 54 SAM4LC2B Serial Peripheral Interface (SPI) */
+  TC0_0_IRQn               = 55, /**< 55 SAM4LC2B Timer/Counter 0 (TC0): TC00 */
+  TC0_1_IRQn               = 56, /**< 56 SAM4LC2B Timer/Counter 0 (TC0): TC01 */
+  TC0_2_IRQn               = 57, /**< 57 SAM4LC2B Timer/Counter 0 (TC0): TC02 */
+  TC1_0_IRQn               = 58, /**< 58 SAM4LC2B Timer/Counter 1 (TC1): TC10 */
+  TC1_1_IRQn               = 59, /**< 59 SAM4LC2B Timer/Counter 1 (TC1): TC11 */
+  TC1_2_IRQn               = 60, /**< 60 SAM4LC2B Timer/Counter 1 (TC1): TC12 */
+  TWIM0_IRQn               = 61, /**< 61 SAM4LC2B Two-wire Master Interface 0 (TWIM0) */
+  TWIS0_IRQn               = 62, /**< 62 SAM4LC2B Two-wire Slave Interface 0 (TWIS0) */
+  TWIM1_IRQn               = 63, /**< 63 SAM4LC2B Two-wire Master Interface 1 (TWIM1) */
+  TWIS1_IRQn               = 64, /**< 64 SAM4LC2B Two-wire Slave Interface 1 (TWIS1) */
+  USART0_IRQn              = 65, /**< 65 SAM4LC2B Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+  USART1_IRQn              = 66, /**< 66 SAM4LC2B Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+  USART2_IRQn              = 67, /**< 67 SAM4LC2B Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+  USART3_IRQn              = 68, /**< 68 SAM4LC2B Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+  ADCIFE_IRQn              = 69, /**< 69 SAM4LC2B ADC controller interface (ADCIFE) */
+  DACC_IRQn                = 70, /**< 70 SAM4LC2B DAC Controller (DACC) */
+  ACIFC_IRQn               = 71, /**< 71 SAM4LC2B Analog Comparator Interface (ACIFC) */
+  ABDACB_IRQn              = 72, /**< 72 SAM4LC2B Audio Bitstream DAC (ABDACB) */
+  TRNG_IRQn                = 73, /**< 73 SAM4LC2B True Random Number Generator (TRNG) */
+  PARC_IRQn                = 74, /**< 74 SAM4LC2B Parallel Capture (PARC) */
+  CATB_IRQn                = 75, /**< 75 SAM4LC2B Capacitive Touch Module B (CATB) */
+  TWIM2_IRQn               = 77, /**< 77 SAM4LC2B Two-wire Master Interface 2 (TWIM2) */
+  TWIM3_IRQn               = 78, /**< 78 SAM4LC2B Two-wire Master Interface 3 (TWIM3) */
+  LCDCA_IRQn               = 79, /**< 79 SAM4LC2B LCD Controller (LCDCA) */
+
+  PERIPH_COUNT_IRQn        = 80  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNMI_Handler;
+  void* pfnHardFault_Handler;
+  void* pfnMemManage_Handler;
+  void* pfnBusFault_Handler;
+  void* pfnUsageFault_Handler;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVC_Handler;
+  void* pfnDebugMon_Handler;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnHFLASHC_Handler;               /*  0 Flash Controller */
+  void* pfnPDCA_0_Handler;                /*  1 Peripheral DMA Controller IRQ 0 */
+  void* pfnPDCA_1_Handler;                /*  2 Peripheral DMA Controller IRQ 1 */
+  void* pfnPDCA_2_Handler;                /*  3 Peripheral DMA Controller IRQ 2 */
+  void* pfnPDCA_3_Handler;                /*  4 Peripheral DMA Controller IRQ 3 */
+  void* pfnPDCA_4_Handler;                /*  5 Peripheral DMA Controller IRQ 4 */
+  void* pfnPDCA_5_Handler;                /*  6 Peripheral DMA Controller IRQ 5 */
+  void* pfnPDCA_6_Handler;                /*  7 Peripheral DMA Controller IRQ 6 */
+  void* pfnPDCA_7_Handler;                /*  8 Peripheral DMA Controller IRQ 7 */
+  void* pfnPDCA_8_Handler;                /*  9 Peripheral DMA Controller IRQ 8 */
+  void* pfnPDCA_9_Handler;                /* 10 Peripheral DMA Controller IRQ 9 */
+  void* pfnPDCA_10_Handler;               /* 11 Peripheral DMA Controller IRQ 10 */
+  void* pfnPDCA_11_Handler;               /* 12 Peripheral DMA Controller IRQ 11 */
+  void* pfnPDCA_12_Handler;               /* 13 Peripheral DMA Controller IRQ 12 */
+  void* pfnPDCA_13_Handler;               /* 14 Peripheral DMA Controller IRQ 13 */
+  void* pfnPDCA_14_Handler;               /* 15 Peripheral DMA Controller IRQ 14 */
+  void* pfnPDCA_15_Handler;               /* 16 Peripheral DMA Controller IRQ 15 */
+  void* pfnCRCCU_Handler;                 /* 17 CRC Calculation Unit */
+  void* pfnUSBC_Handler;                  /* 18 USB 2.0 Interface */
+  void* pfnPEVC_0_Handler;                /* 19 Peripheral Event Controller IRQ 0 */
+  void* pfnPEVC_1_Handler;                /* 20 Peripheral Event Controller IRQ 1 */
+  void* pfnAESA_Handler;                  /* 21 Advanced Encryption Standard */
+  void* pfnPM_Handler;                    /* 22 Power Manager */
+  void* pfnSCIF_Handler;                  /* 23 System Control Interface */
+  void* pfnFREQM_Handler;                 /* 24 Frequency Meter */
+  void* pfnGPIO_0_Handler;                /* 25 General-Purpose Input/Output Controller IRQ 0 */
+  void* pfnGPIO_1_Handler;                /* 26 General-Purpose Input/Output Controller IRQ 1 */
+  void* pfnGPIO_2_Handler;                /* 27 General-Purpose Input/Output Controller IRQ 2 */
+  void* pfnGPIO_3_Handler;                /* 28 General-Purpose Input/Output Controller IRQ 3 */
+  void* pfnGPIO_4_Handler;                /* 29 General-Purpose Input/Output Controller IRQ 4 */
+  void* pfnGPIO_5_Handler;                /* 30 General-Purpose Input/Output Controller IRQ 5 */
+  void* pfnGPIO_6_Handler;                /* 31 General-Purpose Input/Output Controller IRQ 6 */
+  void* pfnGPIO_7_Handler;                /* 32 General-Purpose Input/Output Controller IRQ 7 */
+  void* pfnGPIO_8_Handler;                /* 33 General-Purpose Input/Output Controller IRQ 8 */
+  void* pfnGPIO_9_Handler;                /* 34 General-Purpose Input/Output Controller IRQ 9 */
+  void* pfnGPIO_10_Handler;               /* 35 General-Purpose Input/Output Controller IRQ 10 */
+  void* pfnGPIO_11_Handler;               /* 36 General-Purpose Input/Output Controller IRQ 11 */
+  void* pfnBPM_Handler;                   /* 37 Backup Power Manager */
+  void* pfnBSCIF_Handler;                 /* 38 Backup System Control Interface */
+  void* pfnAST_0_Handler;                 /* 39 Asynchronous Timer IRQ 0 */
+  void* pfnAST_1_Handler;                 /* 40 Asynchronous Timer IRQ 1 */
+  void* pfnAST_2_Handler;                 /* 41 Asynchronous Timer IRQ 2 */
+  void* pfnAST_3_Handler;                 /* 42 Asynchronous Timer IRQ 3 */
+  void* pfnAST_4_Handler;                 /* 43 Asynchronous Timer IRQ 4 */
+  void* pfnWDT_Handler;                   /* 44 Watchdog Timer */
+  void* pfnEIC_0_Handler;                 /* 45 External Interrupt Controller IRQ 0 */
+  void* pfnEIC_1_Handler;                 /* 46 External Interrupt Controller IRQ 1 */
+  void* pfnEIC_2_Handler;                 /* 47 External Interrupt Controller IRQ 2 */
+  void* pfnEIC_3_Handler;                 /* 48 External Interrupt Controller IRQ 3 */
+  void* pfnEIC_4_Handler;                 /* 49 External Interrupt Controller IRQ 4 */
+  void* pfnEIC_5_Handler;                 /* 50 External Interrupt Controller IRQ 5 */
+  void* pfnEIC_6_Handler;                 /* 51 External Interrupt Controller IRQ 6 */
+  void* pfnEIC_7_Handler;                 /* 52 External Interrupt Controller IRQ 7 */
+  void* pfnIISC_Handler;                  /* 53 Inter-IC Sound (I2S) Controller */
+  void* pfnSPI_Handler;                   /* 54 Serial Peripheral Interface */
+  void* pfnTC0_0_Handler;                 /* 55 Timer/Counter 0 IRQ 0 */
+  void* pfnTC0_1_Handler;                 /* 56 Timer/Counter 0 IRQ 1 */
+  void* pfnTC0_2_Handler;                 /* 57 Timer/Counter 0 IRQ 2 */
+  void* pfnTC1_0_Handler;                 /* 58 Timer/Counter 1 IRQ 0 */
+  void* pfnTC1_1_Handler;                 /* 59 Timer/Counter 1 IRQ 1 */
+  void* pfnTC1_2_Handler;                 /* 60 Timer/Counter 1 IRQ 2 */
+  void* pfnTWIM0_Handler;                 /* 61 Two-wire Master Interface 0 */
+  void* pfnTWIS0_Handler;                 /* 62 Two-wire Slave Interface 0 */
+  void* pfnTWIM1_Handler;                 /* 63 Two-wire Master Interface 1 */
+  void* pfnTWIS1_Handler;                 /* 64 Two-wire Slave Interface 1 */
+  void* pfnUSART0_Handler;                /* 65 Universal Synchronous Asynchronous Receiver Transmitter 0 */
+  void* pfnUSART1_Handler;                /* 66 Universal Synchronous Asynchronous Receiver Transmitter 1 */
+  void* pfnUSART2_Handler;                /* 67 Universal Synchronous Asynchronous Receiver Transmitter 2 */
+  void* pfnUSART3_Handler;                /* 68 Universal Synchronous Asynchronous Receiver Transmitter 3 */
+  void* pfnADCIFE_Handler;                /* 69 ADC controller interface */
+  void* pfnDACC_Handler;                  /* 70 DAC Controller */
+  void* pfnACIFC_Handler;                 /* 71 Analog Comparator Interface */
+  void* pfnABDACB_Handler;                /* 72 Audio Bitstream DAC */
+  void* pfnTRNG_Handler;                  /* 73 True Random Number Generator */
+  void* pfnPARC_Handler;                  /* 74 Parallel Capture */
+  void* pfnCATB_Handler;                  /* 75 Capacitive Touch Module B */
+  void* pvReserved76;
+  void* pfnTWIM2_Handler;                 /* 77 Two-wire Master Interface 2 */
+  void* pfnTWIM3_Handler;                 /* 78 Two-wire Master Interface 3 */
+  void* pfnLCDCA_Handler;                 /* 79 LCD Controller */
+} DeviceVectors;
+
+/* Cortex-M4 processor handlers */
+void Reset_Handler               ( void );
+void NMI_Handler                 ( void );
+void HardFault_Handler           ( void );
+void MemManage_Handler           ( void );
+void BusFault_Handler            ( void );
+void UsageFault_Handler          ( void );
+void SVC_Handler                 ( void );
+void DebugMon_Handler            ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void HFLASHC_Handler             ( void );
+void PDCA_0_Handler              ( void );
+void PDCA_1_Handler              ( void );
+void PDCA_2_Handler              ( void );
+void PDCA_3_Handler              ( void );
+void PDCA_4_Handler              ( void );
+void PDCA_5_Handler              ( void );
+void PDCA_6_Handler              ( void );
+void PDCA_7_Handler              ( void );
+void PDCA_8_Handler              ( void );
+void PDCA_9_Handler              ( void );
+void PDCA_10_Handler             ( void );
+void PDCA_11_Handler             ( void );
+void PDCA_12_Handler             ( void );
+void PDCA_13_Handler             ( void );
+void PDCA_14_Handler             ( void );
+void PDCA_15_Handler             ( void );
+void CRCCU_Handler               ( void );
+void USBC_Handler                ( void );
+void PEVC_0_Handler              ( void );
+void PEVC_1_Handler              ( void );
+void AESA_Handler                ( void );
+void PM_Handler                  ( void );
+void SCIF_Handler                ( void );
+void FREQM_Handler               ( void );
+void GPIO_0_Handler              ( void );
+void GPIO_1_Handler              ( void );
+void GPIO_2_Handler              ( void );
+void GPIO_3_Handler              ( void );
+void GPIO_4_Handler              ( void );
+void GPIO_5_Handler              ( void );
+void GPIO_6_Handler              ( void );
+void GPIO_7_Handler              ( void );
+void GPIO_8_Handler              ( void );
+void GPIO_9_Handler              ( void );
+void GPIO_10_Handler             ( void );
+void GPIO_11_Handler             ( void );
+void BPM_Handler                 ( void );
+void BSCIF_Handler               ( void );
+void AST_0_Handler               ( void );
+void AST_1_Handler               ( void );
+void AST_2_Handler               ( void );
+void AST_3_Handler               ( void );
+void AST_4_Handler               ( void );
+void WDT_Handler                 ( void );
+void EIC_0_Handler               ( void );
+void EIC_1_Handler               ( void );
+void EIC_2_Handler               ( void );
+void EIC_3_Handler               ( void );
+void EIC_4_Handler               ( void );
+void EIC_5_Handler               ( void );
+void EIC_6_Handler               ( void );
+void EIC_7_Handler               ( void );
+void IISC_Handler                ( void );
+void SPI_Handler                 ( void );
+void TC0_0_Handler               ( void );
+void TC0_1_Handler               ( void );
+void TC0_2_Handler               ( void );
+void TC1_0_Handler               ( void );
+void TC1_1_Handler               ( void );
+void TC1_2_Handler               ( void );
+void TWIM0_Handler               ( void );
+void TWIS0_Handler               ( void );
+void TWIM1_Handler               ( void );
+void TWIS1_Handler               ( void );
+void USART0_Handler              ( void );
+void USART1_Handler              ( void );
+void USART2_Handler              ( void );
+void USART3_Handler              ( void );
+void ADCIFE_Handler              ( void );
+void DACC_Handler                ( void );
+void ACIFC_Handler               ( void );
+void ABDACB_Handler              ( void );
+void TRNG_Handler                ( void );
+void PARC_Handler                ( void );
+void CATB_Handler                ( void );
+void TWIM2_Handler               ( void );
+void TWIM3_Handler               ( void );
+void LCDCA_Handler               ( void );
+
+/*
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
+ */
+
+#define LITTLE_ENDIAN          1        
+#define __BB_PRESENT           0         /*!< BIT_BANDING present or not */
+#define __CLKGATE_PRESENT      1         /*!< CLKGATE present or not */
+#define __CM4_REV              1         /*!< Core revision r0p1 */
+#define __DEBUG_LVL            3         /*!< Full debug plus DWT data matching */
+#define __FPU_PRESENT          0         /*!< FPU present or not */
+#define __JTAG_PRESENT         1         /*!< JTAG present or not */
+#define __MPU_PRESENT          1         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       4         /*!< Number of bits used for Priority Levels */
+#define __TRACE_LVL            1         /*!< Standard trace: ITM and DWT triggers and counters, but no ETM */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+#define __WIC_PRESENT          0         /*!< WIC present or not */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm4.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_sam4l.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAM4LC2B */
+/* ************************************************************************** */
+/** \defgroup SAM4LC2B_api Peripheral Software API */
+/*@{*/
+
+#include "component/abdacb.h"
+#include "component/acifc.h"
+#include "component/adcife.h"
+#include "component/aesa.h"
+#include "component/ast.h"
+#include "component/bpm.h"
+#include "component/bscif.h"
+#include "component/catb.h"
+#include "component/chipid.h"
+#include "component/crccu.h"
+#include "component/dacc.h"
+#include "component/eic.h"
+#include "component/flashcalw.h"
+#include "component/freqm.h"
+#include "component/gloc.h"
+#include "component/gpio.h"
+#include "component/hcache.h"
+#include "component/hmatrixb.h"
+#include "component/iisc.h"
+#include "component/lcdca.h"
+#include "component/parc.h"
+#include "component/pdca.h"
+#include "component/pevc.h"
+#include "component/picouart.h"
+#include "component/pm.h"
+#include "component/scif.h"
+#include "component/smap.h"
+#include "component/spi.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twim.h"
+#include "component/twis.h"
+#include "component/usart.h"
+#include "component/usbc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAM4LC2B */
+/* ************************************************************************** */
+/** \defgroup SAM4LC2B_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/abdacb.h"
+#include "instance/acifc.h"
+#include "instance/adcife.h"
+#include "instance/aesa.h"
+#include "instance/ast.h"
+#include "instance/bpm.h"
+#include "instance/bscif.h"
+#include "instance/catb.h"
+#include "instance/chipid.h"
+#include "instance/crccu.h"
+#include "instance/dacc.h"
+#include "instance/eic.h"
+#include "instance/hflashc.h"
+#include "instance/freqm.h"
+#include "instance/gloc.h"
+#include "instance/gpio.h"
+#include "instance/hcache.h"
+#include "instance/hmatrix.h"
+#include "instance/iisc.h"
+#include "instance/lcdca.h"
+#include "instance/parc.h"
+#include "instance/pdca.h"
+#include "instance/pevc.h"
+#include "instance/picouart.h"
+#include "instance/pm.h"
+#include "instance/scif.h"
+#include "instance/smap.h"
+#include "instance/spi.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/trng.h"
+#include "instance/twim0.h"
+#include "instance/twim1.h"
+#include "instance/twim2.h"
+#include "instance/twim3.h"
+#include "instance/twis0.h"
+#include "instance/twis1.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usart3.h"
+#include "instance/usbc.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAM4LC2B */
+/* ************************************************************************** */
+/** \defgroup SAM4LC2B_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HTOP0 bridge
+#define ID_IISC           0 /**< \brief Inter-IC Sound (I2S) Controller (IISC) */
+#define ID_SPI            1 /**< \brief Serial Peripheral Interface (SPI) */
+#define ID_TC0            2 /**< \brief Timer/Counter 0 (TC0) */
+#define ID_TC1            3 /**< \brief Timer/Counter 1 (TC1) */
+#define ID_TWIM0          4 /**< \brief Two-wire Master Interface 0 (TWIM0) */
+#define ID_TWIS0          5 /**< \brief Two-wire Slave Interface 0 (TWIS0) */
+#define ID_TWIM1          6 /**< \brief Two-wire Master Interface 1 (TWIM1) */
+#define ID_TWIS1          7 /**< \brief Two-wire Slave Interface 1 (TWIS1) */
+#define ID_USART0         8 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+#define ID_USART1         9 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+#define ID_USART2        10 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+#define ID_USART3        11 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+#define ID_ADCIFE        12 /**< \brief ADC controller interface (ADCIFE) */
+#define ID_DACC          13 /**< \brief DAC Controller (DACC) */
+#define ID_ACIFC         14 /**< \brief Analog Comparator Interface (ACIFC) */
+#define ID_GLOC          15 /**< \brief Glue Logic Controller (GLOC) */
+#define ID_ABDACB        16 /**< \brief Audio Bitstream DAC (ABDACB) */
+#define ID_TRNG          17 /**< \brief True Random Number Generator (TRNG) */
+#define ID_PARC          18 /**< \brief Parallel Capture (PARC) */
+#define ID_CATB          19 /**< \brief Capacitive Touch Module B (CATB) */
+#define ID_TWIM2         21 /**< \brief Two-wire Master Interface 2 (TWIM2) */
+#define ID_TWIM3         22 /**< \brief Two-wire Master Interface 3 (TWIM3) */
+#define ID_LCDCA         23 /**< \brief LCD Controller (LCDCA) */
+
+// Peripheral instances on HTOP1 bridge
+#define ID_HFLASHC       32 /**< \brief Flash Controller (HFLASHC) */
+#define ID_HCACHE        33 /**< \brief Cortex M I&D Cache Controller (HCACHE) */
+#define ID_HMATRIX       34 /**< \brief HSB Matrix (HMATRIX) */
+#define ID_PDCA          35 /**< \brief Peripheral DMA Controller (PDCA) */
+#define ID_SMAP          36 /**< \brief System Manager Access Port (SMAP) */
+#define ID_CRCCU         37 /**< \brief CRC Calculation Unit (CRCCU) */
+#define ID_USBC          38 /**< \brief USB 2.0 Interface (USBC) */
+#define ID_PEVC          39 /**< \brief Peripheral Event Controller (PEVC) */
+
+// Peripheral instances on HTOP2 bridge
+#define ID_PM            64 /**< \brief Power Manager (PM) */
+#define ID_CHIPID        65 /**< \brief Chip ID Registers (CHIPID) */
+#define ID_SCIF          66 /**< \brief System Control Interface (SCIF) */
+#define ID_FREQM         67 /**< \brief Frequency Meter (FREQM) */
+#define ID_GPIO          68 /**< \brief General-Purpose Input/Output Controller (GPIO) */
+
+// Peripheral instances on HTOP3 bridge
+#define ID_BPM           96 /**< \brief Backup Power Manager (BPM) */
+#define ID_BSCIF         97 /**< \brief Backup System Control Interface (BSCIF) */
+#define ID_AST           98 /**< \brief Asynchronous Timer (AST) */
+#define ID_WDT           99 /**< \brief Watchdog Timer (WDT) */
+#define ID_EIC          100 /**< \brief External Interrupt Controller (EIC) */
+#define ID_PICOUART     101 /**< \brief Pico UART (PICOUART) */
+
+// Peripheral instances on AHB (as if on bridge 4)
+#define ID_AESA         128 /**< \brief Advanced Encryption Standard (AESA) */
+
+#define ID_PERIPH_COUNT 129 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAM4LC2B */
+/* ************************************************************************** */
+/** \defgroup SAM4LC2B_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define ABDACB                        (0x40064000) /**< \brief (ABDACB) APB Base Address */
+#define ACIFC                         (0x40040000) /**< \brief (ACIFC) APB Base Address */
+#define ADCIFE                        (0x40038000) /**< \brief (ADCIFE) APB Base Address */
+#define AESA                          (0x400B0000) /**< \brief (AESA) AHB Base Address */
+#define AST                           (0x400F0800) /**< \brief (AST) APB Base Address */
+#define BPM                           (0x400F0000) /**< \brief (BPM) APB Base Address */
+#define BSCIF                         (0x400F0400) /**< \brief (BSCIF) APB Base Address */
+#define CATB                          (0x40070000) /**< \brief (CATB) APB Base Address */
+#define CHIPID                        (0x400E0400) /**< \brief (CHIPID) APB Base Address */
+#define CRCCU                         (0x400A4000) /**< \brief (CRCCU) APB Base Address */
+#define DACC                          (0x4003C000) /**< \brief (DACC) APB Base Address */
+#define EIC                           (0x400F1000) /**< \brief (EIC) APB Base Address */
+#define HFLASHC                       (0x400A0000) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000) /**< \brief (HFLASHC) USER Base Address */
+#define FREQM                         (0x400E0C00) /**< \brief (FREQM) APB Base Address */
+#define GLOC                          (0x40060000) /**< \brief (GLOC) APB Base Address */
+#define GPIO                          (0x400E1000) /**< \brief (GPIO) APB Base Address */
+#define HCACHE                        (0x400A0400) /**< \brief (HCACHE) APB Base Address */
+#define HMATRIX                       (0x400A1000) /**< \brief (HMATRIX) APB Base Address */
+#define IISC                          (0x40004000) /**< \brief (IISC) APB Base Address */
+#define LCDCA                         (0x40080000) /**< \brief (LCDCA) APB Base Address */
+#define PARC                          (0x4006C000) /**< \brief (PARC) APB Base Address */
+#define PDCA                          (0x400A2000) /**< \brief (PDCA) APB Base Address */
+#define PEVC                          (0x400A6000) /**< \brief (PEVC) APB Base Address */
+#define PICOUART                      (0x400F1400) /**< \brief (PICOUART) APB Base Address */
+#define PM                            (0x400E0000) /**< \brief (PM) APB Base Address */
+#define SCIF                          (0x400E0800) /**< \brief (SCIF) APB Base Address */
+#define SMAP                          (0x400A3000) /**< \brief (SMAP) APB Base Address */
+#define SPI                           (0x40008000) /**< \brief (SPI) APB Base Address */
+#define TC0                           (0x40010000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x40014000) /**< \brief (TC1) APB Base Address */
+#define TRNG                          (0x40068000) /**< \brief (TRNG) APB Base Address */
+#define TWIM0                         (0x40018000) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1                         (0x4001C000) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2                         (0x40078000) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3                         (0x4007C000) /**< \brief (TWIM3) APB Base Address */
+#define TWIS0                         (0x40018400) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1                         (0x4001C400) /**< \brief (TWIS1) APB Base Address */
+#define USART0                        (0x40024000) /**< \brief (USART0) APB Base Address */
+#define USART1                        (0x40028000) /**< \brief (USART1) APB Base Address */
+#define USART2                        (0x4002C000) /**< \brief (USART2) APB Base Address */
+#define USART3                        (0x40030000) /**< \brief (USART3) APB Base Address */
+#define USBC                          (0x400A5000) /**< \brief (USBC) APB Base Address */
+#define WDT                           (0x400F0C00) /**< \brief (WDT) APB Base Address */
+#else
+#define ABDACB            ((Abdacb   *)0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_ADDR                   (0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_INST_NUM   1                          /**< \brief (ABDACB) Number of instances */
+#define ABDACB_INSTS      { ABDACB }                 /**< \brief (ABDACB) Instances List */
+
+#define ACIFC             ((Acifc    *)0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_ADDR                    (0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_INST_NUM    1                          /**< \brief (ACIFC) Number of instances */
+#define ACIFC_INSTS       { ACIFC }                  /**< \brief (ACIFC) Instances List */
+
+#define ADCIFE            ((Adcife   *)0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_ADDR                   (0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_INST_NUM   1                          /**< \brief (ADCIFE) Number of instances */
+#define ADCIFE_INSTS      { ADCIFE }                 /**< \brief (ADCIFE) Instances List */
+
+#define AESA              ((Aesa     *)0x400B0000UL) /**< \brief (AESA) AHB Base Address */
+#define AESA_ADDR                     (0x400B0000UL) /**< \brief (AESA) AHB Base Address */
+#define AESA_INST_NUM     1                          /**< \brief (AESA) Number of instances */
+#define AESA_INSTS        { AESA }                   /**< \brief (AESA) Instances List */
+
+#define AST               ((Ast      *)0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_ADDR                      (0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_INST_NUM      1                          /**< \brief (AST) Number of instances */
+#define AST_INSTS         { AST }                    /**< \brief (AST) Instances List */
+
+#define BPM               ((Bpm      *)0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_ADDR                      (0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_INST_NUM      1                          /**< \brief (BPM) Number of instances */
+#define BPM_INSTS         { BPM }                    /**< \brief (BPM) Instances List */
+
+#define BSCIF             ((Bscif    *)0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_ADDR                    (0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_INST_NUM    1                          /**< \brief (BSCIF) Number of instances */
+#define BSCIF_INSTS       { BSCIF }                  /**< \brief (BSCIF) Instances List */
+
+#define CATB              ((Catb     *)0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_ADDR                     (0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_INST_NUM     1                          /**< \brief (CATB) Number of instances */
+#define CATB_INSTS        { CATB }                   /**< \brief (CATB) Instances List */
+
+#define CHIPID            ((Chipid   *)0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_ADDR                   (0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_INST_NUM   1                          /**< \brief (CHIPID) Number of instances */
+#define CHIPID_INSTS      { CHIPID }                 /**< \brief (CHIPID) Instances List */
+
+#define CRCCU             ((Crccu    *)0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_ADDR                    (0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_INST_NUM    1                          /**< \brief (CRCCU) Number of instances */
+#define CRCCU_INSTS       { CRCCU }                  /**< \brief (CRCCU) Instances List */
+
+#define DACC              ((Dacc     *)0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_ADDR                     (0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_INST_NUM     1                          /**< \brief (DACC) Number of instances */
+#define DACC_INSTS        { DACC }                   /**< \brief (DACC) Instances List */
+
+#define EIC               ((Eic      *)0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_ADDR                      (0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define HFLASHC           ((Flashcalw *)0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_ADDR                  (0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_FROW_ADDR             (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define HFLASHC_USER_ADDR             (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define FLASHCALW_INST_NUM 1                          /**< \brief (FLASHCALW) Number of instances */
+#define FLASHCALW_INSTS   { HFLASHC }                /**< \brief (FLASHCALW) Instances List */
+
+#define FREQM             ((Freqm    *)0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_ADDR                    (0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_INST_NUM    1                          /**< \brief (FREQM) Number of instances */
+#define FREQM_INSTS       { FREQM }                  /**< \brief (FREQM) Instances List */
+
+#define GLOC              ((Gloc     *)0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_ADDR                     (0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_INST_NUM     1                          /**< \brief (GLOC) Number of instances */
+#define GLOC_INSTS        { GLOC }                   /**< \brief (GLOC) Instances List */
+
+#define GPIO              ((Gpio     *)0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_ADDR                     (0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_INST_NUM     1                          /**< \brief (GPIO) Number of instances */
+#define GPIO_INSTS        { GPIO }                   /**< \brief (GPIO) Instances List */
+
+#define HCACHE            ((Hcache   *)0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_ADDR                   (0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_INST_NUM   1                          /**< \brief (HCACHE) Number of instances */
+#define HCACHE_INSTS      { HCACHE }                 /**< \brief (HCACHE) Instances List */
+
+#define HMATRIX           ((Hmatrixb *)0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIX_ADDR                  (0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIXB_INST_NUM 1                          /**< \brief (HMATRIXB) Number of instances */
+#define HMATRIXB_INSTS    { HMATRIX }                /**< \brief (HMATRIXB) Instances List */
+
+#define IISC              ((Iisc     *)0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_ADDR                     (0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_INST_NUM     1                          /**< \brief (IISC) Number of instances */
+#define IISC_INSTS        { IISC }                   /**< \brief (IISC) Instances List */
+
+#define LCDCA             ((Lcdca    *)0x40080000UL) /**< \brief (LCDCA) APB Base Address */
+#define LCDCA_ADDR                    (0x40080000UL) /**< \brief (LCDCA) APB Base Address */
+#define LCDCA_INST_NUM    1                          /**< \brief (LCDCA) Number of instances */
+#define LCDCA_INSTS       { LCDCA }                  /**< \brief (LCDCA) Instances List */
+
+#define PARC              ((Parc     *)0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_ADDR                     (0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_INST_NUM     1                          /**< \brief (PARC) Number of instances */
+#define PARC_INSTS        { PARC }                   /**< \brief (PARC) Instances List */
+
+#define PDCA              ((Pdca     *)0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_ADDR                     (0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_INST_NUM     1                          /**< \brief (PDCA) Number of instances */
+#define PDCA_INSTS        { PDCA }                   /**< \brief (PDCA) Instances List */
+
+#define PEVC              ((Pevc     *)0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_ADDR                     (0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_INST_NUM     1                          /**< \brief (PEVC) Number of instances */
+#define PEVC_INSTS        { PEVC }                   /**< \brief (PEVC) Instances List */
+
+#define PICOUART          ((Picouart *)0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_ADDR                 (0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_INST_NUM 1                          /**< \brief (PICOUART) Number of instances */
+#define PICOUART_INSTS    { PICOUART }               /**< \brief (PICOUART) Instances List */
+
+#define PM                ((Pm       *)0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_ADDR                       (0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define SCIF              ((Scif     *)0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_ADDR                     (0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_INST_NUM     1                          /**< \brief (SCIF) Number of instances */
+#define SCIF_INSTS        { SCIF }                   /**< \brief (SCIF) Instances List */
+
+#define SMAP              ((Smap     *)0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_ADDR                     (0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_INST_NUM     1                          /**< \brief (SMAP) Number of instances */
+#define SMAP_INSTS        { SMAP }                   /**< \brief (SMAP) Instances List */
+
+#define SPI               ((Spi      *)0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_ADDR                      (0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_INST_NUM      1                          /**< \brief (SPI) Number of instances */
+#define SPI_INSTS         { SPI }                    /**< \brief (SPI) Instances List */
+
+#define TC0               ((Tc       *)0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC0_ADDR                      (0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC1_ADDR                      (0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC_INST_NUM       2                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1 }               /**< \brief (TC) Instances List */
+
+#define TRNG              ((Trng     *)0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_ADDR                     (0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_INST_NUM     1                          /**< \brief (TRNG) Number of instances */
+#define TRNG_INSTS        { TRNG }                   /**< \brief (TRNG) Instances List */
+
+#define TWIM0             ((Twim     *)0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM0_ADDR                    (0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1             ((Twim     *)0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM1_ADDR                    (0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2             ((Twim     *)0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM2_ADDR                    (0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3             ((Twim     *)0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM3_ADDR                    (0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM_INST_NUM     4                          /**< \brief (TWIM) Number of instances */
+#define TWIM_INSTS        { TWIM0, TWIM1, TWIM2, TWIM3 } /**< \brief (TWIM) Instances List */
+
+#define TWIS0             ((Twis     *)0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS0_ADDR                    (0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1             ((Twis     *)0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS1_ADDR                    (0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS_INST_NUM     2                          /**< \brief (TWIS) Number of instances */
+#define TWIS_INSTS        { TWIS0, TWIS1 }           /**< \brief (TWIS) Instances List */
+
+#define USART0            ((Usart    *)0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART0_ADDR                   (0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART1            ((Usart    *)0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART1_ADDR                   (0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART2            ((Usart    *)0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART2_ADDR                   (0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART3            ((Usart    *)0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART3_ADDR                   (0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART_INST_NUM    4                          /**< \brief (USART) Number of instances */
+#define USART_INSTS       { USART0, USART1, USART2, USART3 } /**< \brief (USART) Instances List */
+
+#define USBC              ((Usbc     *)0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_ADDR                     (0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_INST_NUM     1                          /**< \brief (USBC) Number of instances */
+#define USBC_INSTS        { USBC }                   /**< \brief (USBC) Instances List */
+
+#define WDT               ((Wdt      *)0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_ADDR                      (0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  GPIO DEFINITIONS FOR SAM4LC2B */
+/* ************************************************************************** */
+/** \defgroup SAM4LC2B_gpio GPIO Definitions */
+/*@{*/
+
+#include "pio/sam4lc2b.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  ADDITIONAL DEFINITIONS FOR COMPATIBILITY */
+/* ************************************************************************** */
+/** \addtogroup SAM4LC2B_compat Definitions */
+/*@{*/
+// These defines are used to keep compatibility with existing 
+// sam/drivers/usart implementation from SAM3/4 products with SAM4L product.
+#define US_MR_USART_MODE_HW_HANDSHAKING  US_MR_USART_MODE_HARDWARE
+#define US_MR_USART_MODE_IS07816_T_0     US_MR_USART_MODE_ISO7816_T0
+#define US_MR_USART_MODE_IS07816_T_1     US_MR_USART_MODE_ISO7816_T1
+#define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
+#define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
+#define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_8_BIT      US_MR_CHRL_8
+#define US_MR_PAR_NO          US_MR_PAR_NONE
+#define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI
+#define US_IF                 US_IFR
+#define US_WPSR_WPVS          US_WPSR_WPV_1
+
+#define USBC_UPCFG0_PBK_Msk   (0x1u << USBC_UPCFG0_PBK_Pos)
+
+// These defines for homogeneity with other SAM header files.
+#define CHIP_FREQ_FWS_0       (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 */
+#define CHIP_FREQ_FWS_1       (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 */
+// WARNING NOTE: these are preliminary values.
+#define CHIP_FREQ_FLASH_HSEN_FWS_0 (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 and the FLASH HS mode is enabled */
+#define CHIP_FREQ_FLASH_HSEN_FWS_1 (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 and the FLASH HS mode is enabled */
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/tc implementation from SAM3/4 products with SAM4L product. 
+#define TC_CMR_LDRA_RISING    TC_CMR_LDRA_POS_EDGE_TIOA
+#define TC_CMR_LDRB_FALLING   TC_CMR_LDRB_NEG_EDGE_TIOA
+#define TC_CMR_ETRGEDG_FALLING TC_CMR_ETRGEDG_NEG_EDGE
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/spi implementation from SAM3/4 products with SAM4L product. 
+#define SPI_CSR_BITS_8_BIT    SPI_CSR_BITS_8_BPT
+#define SPI_WPCR_SPIWPKEY_VALUE SPI_WPCR_WPKEY_VALUE
+#define SPI_WPCR_SPIWPEN      SPI_WPCR_WPEN
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/crccu implementation from SAM3/4 products with SAM4L product. 
+#define CRCCU_DMA_EN          CRCCU_DMAEN
+#define CRCCU_DMA_DIS         CRCCU_DMADIS
+#define CRCCU_DMA_SR          CRCCU_DMASR
+#define CRCCU_DMA_IER         CRCCU_DMAIER
+#define CRCCU_DMA_IDR         CRCCU_DMAIDR
+#define CRCCU_DMA_IMR         CRCCU_DMAIMR
+#define CRCCU_DMA_ISR         CRCCU_DMAISR
+#define CRCCU_DMA_EN_DMAEN    CRCCU_DMAEN_DMAEN
+#define CRCCU_DMA_DIS_DMADIS  CRCCU_DMADIS_DMADIS
+#define CRCCU_DMA_SR_DMASR    CRCCU_DMASR_DMASR
+#define CRCCU_DMA_IER_DMAIER  CRCCU_DMAIER_DMAIER
+#define CRCCU_DMA_IDR_DMAIDR  CRCCU_DMAIDR_DMAIDR
+#define CRCCU_DMA_IMR_DMAIMR  CRCCU_DMAIMR_DMAIMR
+#define CRCCU_DMA_ISR_DMAISR  CRCCU_DMAISR_DMAISR
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAM4LC2B */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL(0x00020000) /* 128 kB */
+#define FLASH_PAGE_SIZE       512
+#define FLASH_NB_OF_PAGES     256
+#define FLASH_USER_PAGE_SIZE  512
+#define HRAMC0_SIZE           _UL(0x00008000) /* 32 kB */
+#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+
+#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+
+#define DSU_DID_RESETVALUE    _UL(0xAB0A07E0)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAM4LC2B */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAM4LC2B_H */

--- a/asf/sam/include/sam4l/sam4lc2c.h
+++ b/asf/sam/include/sam4l/sam4lc2c.h
@@ -1,0 +1,913 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAM4LC2C
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LC2C_
+#define _SAM4LC2C_
+
+/**
+ * \ingroup SAM4L_definitions
+ * \addtogroup SAM4LC2C_definitions SAM4LC2C definitions
+ * This file defines all structures and symbols for SAM4LC2C:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#if !defined(_UL)
+#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#endif
+#else
+#if !defined(_UL)
+#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif
+#endif
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAM4LC2C */
+/* ************************************************************************** */
+/** \defgroup SAM4LC2C_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M4 Processor Exceptions Numbers ******************************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn           = -13,/**<  3 Cortex-M4 Hard Fault Interrupt        */
+  MemoryManagement_IRQn    = -12,/**<  4 Cortex-M4 Memory Management Interrupt */
+  BusFault_IRQn            = -11,/**<  5 Cortex-M4 Bus Fault Interrupt         */
+  UsageFault_IRQn          = -10,/**<  6 Cortex-M4 Usage Fault Interrupt       */
+  SVCall_IRQn              = -5, /**< 11 Cortex-M4 SV Call Interrupt           */
+  DebugMonitor_IRQn        = -4, /**< 12 Cortex-M4 Debug Monitor Interrupt     */
+  PendSV_IRQn              = -2, /**< 14 Cortex-M4 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 Cortex-M4 System Tick Interrupt       */
+  /******  SAM4LC2C-specific Interrupt Numbers ***********************/
+  HFLASHC_IRQn             =  0, /**<  0 SAM4LC2C Flash Controller (HFLASHC) */
+  PDCA_0_IRQn              =  1, /**<  1 SAM4LC2C Peripheral DMA Controller (PDCA): PDCA_0 */
+  PDCA_1_IRQn              =  2, /**<  2 SAM4LC2C Peripheral DMA Controller (PDCA): PDCA_1 */
+  PDCA_2_IRQn              =  3, /**<  3 SAM4LC2C Peripheral DMA Controller (PDCA): PDCA_2 */
+  PDCA_3_IRQn              =  4, /**<  4 SAM4LC2C Peripheral DMA Controller (PDCA): PDCA_3 */
+  PDCA_4_IRQn              =  5, /**<  5 SAM4LC2C Peripheral DMA Controller (PDCA): PDCA_4 */
+  PDCA_5_IRQn              =  6, /**<  6 SAM4LC2C Peripheral DMA Controller (PDCA): PDCA_5 */
+  PDCA_6_IRQn              =  7, /**<  7 SAM4LC2C Peripheral DMA Controller (PDCA): PDCA_6 */
+  PDCA_7_IRQn              =  8, /**<  8 SAM4LC2C Peripheral DMA Controller (PDCA): PDCA_7 */
+  PDCA_8_IRQn              =  9, /**<  9 SAM4LC2C Peripheral DMA Controller (PDCA): PDCA_8 */
+  PDCA_9_IRQn              = 10, /**< 10 SAM4LC2C Peripheral DMA Controller (PDCA): PDCA_9 */
+  PDCA_10_IRQn             = 11, /**< 11 SAM4LC2C Peripheral DMA Controller (PDCA): PDCA_10 */
+  PDCA_11_IRQn             = 12, /**< 12 SAM4LC2C Peripheral DMA Controller (PDCA): PDCA_11 */
+  PDCA_12_IRQn             = 13, /**< 13 SAM4LC2C Peripheral DMA Controller (PDCA): PDCA_12 */
+  PDCA_13_IRQn             = 14, /**< 14 SAM4LC2C Peripheral DMA Controller (PDCA): PDCA_13 */
+  PDCA_14_IRQn             = 15, /**< 15 SAM4LC2C Peripheral DMA Controller (PDCA): PDCA_14 */
+  PDCA_15_IRQn             = 16, /**< 16 SAM4LC2C Peripheral DMA Controller (PDCA): PDCA_15 */
+  CRCCU_IRQn               = 17, /**< 17 SAM4LC2C CRC Calculation Unit (CRCCU) */
+  USBC_IRQn                = 18, /**< 18 SAM4LC2C USB 2.0 Interface (USBC) */
+  PEVC_0_IRQn              = 19, /**< 19 SAM4LC2C Peripheral Event Controller (PEVC): PEVC_TR */
+  PEVC_1_IRQn              = 20, /**< 20 SAM4LC2C Peripheral Event Controller (PEVC): PEVC_OV */
+  AESA_IRQn                = 21, /**< 21 SAM4LC2C Advanced Encryption Standard (AESA) */
+  PM_IRQn                  = 22, /**< 22 SAM4LC2C Power Manager (PM) */
+  SCIF_IRQn                = 23, /**< 23 SAM4LC2C System Control Interface (SCIF) */
+  FREQM_IRQn               = 24, /**< 24 SAM4LC2C Frequency Meter (FREQM) */
+  GPIO_0_IRQn              = 25, /**< 25 SAM4LC2C General-Purpose Input/Output Controller (GPIO): GPIO_0 */
+  GPIO_1_IRQn              = 26, /**< 26 SAM4LC2C General-Purpose Input/Output Controller (GPIO): GPIO_1 */
+  GPIO_2_IRQn              = 27, /**< 27 SAM4LC2C General-Purpose Input/Output Controller (GPIO): GPIO_2 */
+  GPIO_3_IRQn              = 28, /**< 28 SAM4LC2C General-Purpose Input/Output Controller (GPIO): GPIO_3 */
+  GPIO_4_IRQn              = 29, /**< 29 SAM4LC2C General-Purpose Input/Output Controller (GPIO): GPIO_4 */
+  GPIO_5_IRQn              = 30, /**< 30 SAM4LC2C General-Purpose Input/Output Controller (GPIO): GPIO_5 */
+  GPIO_6_IRQn              = 31, /**< 31 SAM4LC2C General-Purpose Input/Output Controller (GPIO): GPIO_6 */
+  GPIO_7_IRQn              = 32, /**< 32 SAM4LC2C General-Purpose Input/Output Controller (GPIO): GPIO_7 */
+  GPIO_8_IRQn              = 33, /**< 33 SAM4LC2C General-Purpose Input/Output Controller (GPIO): GPIO_8 */
+  GPIO_9_IRQn              = 34, /**< 34 SAM4LC2C General-Purpose Input/Output Controller (GPIO): GPIO_9 */
+  GPIO_10_IRQn             = 35, /**< 35 SAM4LC2C General-Purpose Input/Output Controller (GPIO): GPIO_10 */
+  GPIO_11_IRQn             = 36, /**< 36 SAM4LC2C General-Purpose Input/Output Controller (GPIO): GPIO_11 */
+  BPM_IRQn                 = 37, /**< 37 SAM4LC2C Backup Power Manager (BPM) */
+  BSCIF_IRQn               = 38, /**< 38 SAM4LC2C Backup System Control Interface (BSCIF) */
+  AST_0_IRQn               = 39, /**< 39 SAM4LC2C Asynchronous Timer (AST): AST_ALARM */
+  AST_1_IRQn               = 40, /**< 40 SAM4LC2C Asynchronous Timer (AST): AST_PER */
+  AST_2_IRQn               = 41, /**< 41 SAM4LC2C Asynchronous Timer (AST): AST_OVF */
+  AST_3_IRQn               = 42, /**< 42 SAM4LC2C Asynchronous Timer (AST): AST_READY */
+  AST_4_IRQn               = 43, /**< 43 SAM4LC2C Asynchronous Timer (AST): AST_CLKREADY */
+  WDT_IRQn                 = 44, /**< 44 SAM4LC2C Watchdog Timer (WDT) */
+  EIC_0_IRQn               = 45, /**< 45 SAM4LC2C External Interrupt Controller (EIC): EIC_1 */
+  EIC_1_IRQn               = 46, /**< 46 SAM4LC2C External Interrupt Controller (EIC): EIC_2 */
+  EIC_2_IRQn               = 47, /**< 47 SAM4LC2C External Interrupt Controller (EIC): EIC_3 */
+  EIC_3_IRQn               = 48, /**< 48 SAM4LC2C External Interrupt Controller (EIC): EIC_4 */
+  EIC_4_IRQn               = 49, /**< 49 SAM4LC2C External Interrupt Controller (EIC): EIC_5 */
+  EIC_5_IRQn               = 50, /**< 50 SAM4LC2C External Interrupt Controller (EIC): EIC_6 */
+  EIC_6_IRQn               = 51, /**< 51 SAM4LC2C External Interrupt Controller (EIC): EIC_7 */
+  EIC_7_IRQn               = 52, /**< 52 SAM4LC2C External Interrupt Controller (EIC): EIC_8 */
+  IISC_IRQn                = 53, /**< 53 SAM4LC2C Inter-IC Sound (I2S) Controller (IISC) */
+  SPI_IRQn                 = 54, /**< 54 SAM4LC2C Serial Peripheral Interface (SPI) */
+  TC0_0_IRQn               = 55, /**< 55 SAM4LC2C Timer/Counter 0 (TC0): TC00 */
+  TC0_1_IRQn               = 56, /**< 56 SAM4LC2C Timer/Counter 0 (TC0): TC01 */
+  TC0_2_IRQn               = 57, /**< 57 SAM4LC2C Timer/Counter 0 (TC0): TC02 */
+  TC1_0_IRQn               = 58, /**< 58 SAM4LC2C Timer/Counter 1 (TC1): TC10 */
+  TC1_1_IRQn               = 59, /**< 59 SAM4LC2C Timer/Counter 1 (TC1): TC11 */
+  TC1_2_IRQn               = 60, /**< 60 SAM4LC2C Timer/Counter 1 (TC1): TC12 */
+  TWIM0_IRQn               = 61, /**< 61 SAM4LC2C Two-wire Master Interface 0 (TWIM0) */
+  TWIS0_IRQn               = 62, /**< 62 SAM4LC2C Two-wire Slave Interface 0 (TWIS0) */
+  TWIM1_IRQn               = 63, /**< 63 SAM4LC2C Two-wire Master Interface 1 (TWIM1) */
+  TWIS1_IRQn               = 64, /**< 64 SAM4LC2C Two-wire Slave Interface 1 (TWIS1) */
+  USART0_IRQn              = 65, /**< 65 SAM4LC2C Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+  USART1_IRQn              = 66, /**< 66 SAM4LC2C Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+  USART2_IRQn              = 67, /**< 67 SAM4LC2C Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+  USART3_IRQn              = 68, /**< 68 SAM4LC2C Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+  ADCIFE_IRQn              = 69, /**< 69 SAM4LC2C ADC controller interface (ADCIFE) */
+  DACC_IRQn                = 70, /**< 70 SAM4LC2C DAC Controller (DACC) */
+  ACIFC_IRQn               = 71, /**< 71 SAM4LC2C Analog Comparator Interface (ACIFC) */
+  ABDACB_IRQn              = 72, /**< 72 SAM4LC2C Audio Bitstream DAC (ABDACB) */
+  TRNG_IRQn                = 73, /**< 73 SAM4LC2C True Random Number Generator (TRNG) */
+  PARC_IRQn                = 74, /**< 74 SAM4LC2C Parallel Capture (PARC) */
+  CATB_IRQn                = 75, /**< 75 SAM4LC2C Capacitive Touch Module B (CATB) */
+  TWIM2_IRQn               = 77, /**< 77 SAM4LC2C Two-wire Master Interface 2 (TWIM2) */
+  TWIM3_IRQn               = 78, /**< 78 SAM4LC2C Two-wire Master Interface 3 (TWIM3) */
+  LCDCA_IRQn               = 79, /**< 79 SAM4LC2C LCD Controller (LCDCA) */
+
+  PERIPH_COUNT_IRQn        = 80  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNMI_Handler;
+  void* pfnHardFault_Handler;
+  void* pfnMemManage_Handler;
+  void* pfnBusFault_Handler;
+  void* pfnUsageFault_Handler;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVC_Handler;
+  void* pfnDebugMon_Handler;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnHFLASHC_Handler;               /*  0 Flash Controller */
+  void* pfnPDCA_0_Handler;                /*  1 Peripheral DMA Controller IRQ 0 */
+  void* pfnPDCA_1_Handler;                /*  2 Peripheral DMA Controller IRQ 1 */
+  void* pfnPDCA_2_Handler;                /*  3 Peripheral DMA Controller IRQ 2 */
+  void* pfnPDCA_3_Handler;                /*  4 Peripheral DMA Controller IRQ 3 */
+  void* pfnPDCA_4_Handler;                /*  5 Peripheral DMA Controller IRQ 4 */
+  void* pfnPDCA_5_Handler;                /*  6 Peripheral DMA Controller IRQ 5 */
+  void* pfnPDCA_6_Handler;                /*  7 Peripheral DMA Controller IRQ 6 */
+  void* pfnPDCA_7_Handler;                /*  8 Peripheral DMA Controller IRQ 7 */
+  void* pfnPDCA_8_Handler;                /*  9 Peripheral DMA Controller IRQ 8 */
+  void* pfnPDCA_9_Handler;                /* 10 Peripheral DMA Controller IRQ 9 */
+  void* pfnPDCA_10_Handler;               /* 11 Peripheral DMA Controller IRQ 10 */
+  void* pfnPDCA_11_Handler;               /* 12 Peripheral DMA Controller IRQ 11 */
+  void* pfnPDCA_12_Handler;               /* 13 Peripheral DMA Controller IRQ 12 */
+  void* pfnPDCA_13_Handler;               /* 14 Peripheral DMA Controller IRQ 13 */
+  void* pfnPDCA_14_Handler;               /* 15 Peripheral DMA Controller IRQ 14 */
+  void* pfnPDCA_15_Handler;               /* 16 Peripheral DMA Controller IRQ 15 */
+  void* pfnCRCCU_Handler;                 /* 17 CRC Calculation Unit */
+  void* pfnUSBC_Handler;                  /* 18 USB 2.0 Interface */
+  void* pfnPEVC_0_Handler;                /* 19 Peripheral Event Controller IRQ 0 */
+  void* pfnPEVC_1_Handler;                /* 20 Peripheral Event Controller IRQ 1 */
+  void* pfnAESA_Handler;                  /* 21 Advanced Encryption Standard */
+  void* pfnPM_Handler;                    /* 22 Power Manager */
+  void* pfnSCIF_Handler;                  /* 23 System Control Interface */
+  void* pfnFREQM_Handler;                 /* 24 Frequency Meter */
+  void* pfnGPIO_0_Handler;                /* 25 General-Purpose Input/Output Controller IRQ 0 */
+  void* pfnGPIO_1_Handler;                /* 26 General-Purpose Input/Output Controller IRQ 1 */
+  void* pfnGPIO_2_Handler;                /* 27 General-Purpose Input/Output Controller IRQ 2 */
+  void* pfnGPIO_3_Handler;                /* 28 General-Purpose Input/Output Controller IRQ 3 */
+  void* pfnGPIO_4_Handler;                /* 29 General-Purpose Input/Output Controller IRQ 4 */
+  void* pfnGPIO_5_Handler;                /* 30 General-Purpose Input/Output Controller IRQ 5 */
+  void* pfnGPIO_6_Handler;                /* 31 General-Purpose Input/Output Controller IRQ 6 */
+  void* pfnGPIO_7_Handler;                /* 32 General-Purpose Input/Output Controller IRQ 7 */
+  void* pfnGPIO_8_Handler;                /* 33 General-Purpose Input/Output Controller IRQ 8 */
+  void* pfnGPIO_9_Handler;                /* 34 General-Purpose Input/Output Controller IRQ 9 */
+  void* pfnGPIO_10_Handler;               /* 35 General-Purpose Input/Output Controller IRQ 10 */
+  void* pfnGPIO_11_Handler;               /* 36 General-Purpose Input/Output Controller IRQ 11 */
+  void* pfnBPM_Handler;                   /* 37 Backup Power Manager */
+  void* pfnBSCIF_Handler;                 /* 38 Backup System Control Interface */
+  void* pfnAST_0_Handler;                 /* 39 Asynchronous Timer IRQ 0 */
+  void* pfnAST_1_Handler;                 /* 40 Asynchronous Timer IRQ 1 */
+  void* pfnAST_2_Handler;                 /* 41 Asynchronous Timer IRQ 2 */
+  void* pfnAST_3_Handler;                 /* 42 Asynchronous Timer IRQ 3 */
+  void* pfnAST_4_Handler;                 /* 43 Asynchronous Timer IRQ 4 */
+  void* pfnWDT_Handler;                   /* 44 Watchdog Timer */
+  void* pfnEIC_0_Handler;                 /* 45 External Interrupt Controller IRQ 0 */
+  void* pfnEIC_1_Handler;                 /* 46 External Interrupt Controller IRQ 1 */
+  void* pfnEIC_2_Handler;                 /* 47 External Interrupt Controller IRQ 2 */
+  void* pfnEIC_3_Handler;                 /* 48 External Interrupt Controller IRQ 3 */
+  void* pfnEIC_4_Handler;                 /* 49 External Interrupt Controller IRQ 4 */
+  void* pfnEIC_5_Handler;                 /* 50 External Interrupt Controller IRQ 5 */
+  void* pfnEIC_6_Handler;                 /* 51 External Interrupt Controller IRQ 6 */
+  void* pfnEIC_7_Handler;                 /* 52 External Interrupt Controller IRQ 7 */
+  void* pfnIISC_Handler;                  /* 53 Inter-IC Sound (I2S) Controller */
+  void* pfnSPI_Handler;                   /* 54 Serial Peripheral Interface */
+  void* pfnTC0_0_Handler;                 /* 55 Timer/Counter 0 IRQ 0 */
+  void* pfnTC0_1_Handler;                 /* 56 Timer/Counter 0 IRQ 1 */
+  void* pfnTC0_2_Handler;                 /* 57 Timer/Counter 0 IRQ 2 */
+  void* pfnTC1_0_Handler;                 /* 58 Timer/Counter 1 IRQ 0 */
+  void* pfnTC1_1_Handler;                 /* 59 Timer/Counter 1 IRQ 1 */
+  void* pfnTC1_2_Handler;                 /* 60 Timer/Counter 1 IRQ 2 */
+  void* pfnTWIM0_Handler;                 /* 61 Two-wire Master Interface 0 */
+  void* pfnTWIS0_Handler;                 /* 62 Two-wire Slave Interface 0 */
+  void* pfnTWIM1_Handler;                 /* 63 Two-wire Master Interface 1 */
+  void* pfnTWIS1_Handler;                 /* 64 Two-wire Slave Interface 1 */
+  void* pfnUSART0_Handler;                /* 65 Universal Synchronous Asynchronous Receiver Transmitter 0 */
+  void* pfnUSART1_Handler;                /* 66 Universal Synchronous Asynchronous Receiver Transmitter 1 */
+  void* pfnUSART2_Handler;                /* 67 Universal Synchronous Asynchronous Receiver Transmitter 2 */
+  void* pfnUSART3_Handler;                /* 68 Universal Synchronous Asynchronous Receiver Transmitter 3 */
+  void* pfnADCIFE_Handler;                /* 69 ADC controller interface */
+  void* pfnDACC_Handler;                  /* 70 DAC Controller */
+  void* pfnACIFC_Handler;                 /* 71 Analog Comparator Interface */
+  void* pfnABDACB_Handler;                /* 72 Audio Bitstream DAC */
+  void* pfnTRNG_Handler;                  /* 73 True Random Number Generator */
+  void* pfnPARC_Handler;                  /* 74 Parallel Capture */
+  void* pfnCATB_Handler;                  /* 75 Capacitive Touch Module B */
+  void* pvReserved76;
+  void* pfnTWIM2_Handler;                 /* 77 Two-wire Master Interface 2 */
+  void* pfnTWIM3_Handler;                 /* 78 Two-wire Master Interface 3 */
+  void* pfnLCDCA_Handler;                 /* 79 LCD Controller */
+} DeviceVectors;
+
+/* Cortex-M4 processor handlers */
+void Reset_Handler               ( void );
+void NMI_Handler                 ( void );
+void HardFault_Handler           ( void );
+void MemManage_Handler           ( void );
+void BusFault_Handler            ( void );
+void UsageFault_Handler          ( void );
+void SVC_Handler                 ( void );
+void DebugMon_Handler            ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void HFLASHC_Handler             ( void );
+void PDCA_0_Handler              ( void );
+void PDCA_1_Handler              ( void );
+void PDCA_2_Handler              ( void );
+void PDCA_3_Handler              ( void );
+void PDCA_4_Handler              ( void );
+void PDCA_5_Handler              ( void );
+void PDCA_6_Handler              ( void );
+void PDCA_7_Handler              ( void );
+void PDCA_8_Handler              ( void );
+void PDCA_9_Handler              ( void );
+void PDCA_10_Handler             ( void );
+void PDCA_11_Handler             ( void );
+void PDCA_12_Handler             ( void );
+void PDCA_13_Handler             ( void );
+void PDCA_14_Handler             ( void );
+void PDCA_15_Handler             ( void );
+void CRCCU_Handler               ( void );
+void USBC_Handler                ( void );
+void PEVC_0_Handler              ( void );
+void PEVC_1_Handler              ( void );
+void AESA_Handler                ( void );
+void PM_Handler                  ( void );
+void SCIF_Handler                ( void );
+void FREQM_Handler               ( void );
+void GPIO_0_Handler              ( void );
+void GPIO_1_Handler              ( void );
+void GPIO_2_Handler              ( void );
+void GPIO_3_Handler              ( void );
+void GPIO_4_Handler              ( void );
+void GPIO_5_Handler              ( void );
+void GPIO_6_Handler              ( void );
+void GPIO_7_Handler              ( void );
+void GPIO_8_Handler              ( void );
+void GPIO_9_Handler              ( void );
+void GPIO_10_Handler             ( void );
+void GPIO_11_Handler             ( void );
+void BPM_Handler                 ( void );
+void BSCIF_Handler               ( void );
+void AST_0_Handler               ( void );
+void AST_1_Handler               ( void );
+void AST_2_Handler               ( void );
+void AST_3_Handler               ( void );
+void AST_4_Handler               ( void );
+void WDT_Handler                 ( void );
+void EIC_0_Handler               ( void );
+void EIC_1_Handler               ( void );
+void EIC_2_Handler               ( void );
+void EIC_3_Handler               ( void );
+void EIC_4_Handler               ( void );
+void EIC_5_Handler               ( void );
+void EIC_6_Handler               ( void );
+void EIC_7_Handler               ( void );
+void IISC_Handler                ( void );
+void SPI_Handler                 ( void );
+void TC0_0_Handler               ( void );
+void TC0_1_Handler               ( void );
+void TC0_2_Handler               ( void );
+void TC1_0_Handler               ( void );
+void TC1_1_Handler               ( void );
+void TC1_2_Handler               ( void );
+void TWIM0_Handler               ( void );
+void TWIS0_Handler               ( void );
+void TWIM1_Handler               ( void );
+void TWIS1_Handler               ( void );
+void USART0_Handler              ( void );
+void USART1_Handler              ( void );
+void USART2_Handler              ( void );
+void USART3_Handler              ( void );
+void ADCIFE_Handler              ( void );
+void DACC_Handler                ( void );
+void ACIFC_Handler               ( void );
+void ABDACB_Handler              ( void );
+void TRNG_Handler                ( void );
+void PARC_Handler                ( void );
+void CATB_Handler                ( void );
+void TWIM2_Handler               ( void );
+void TWIM3_Handler               ( void );
+void LCDCA_Handler               ( void );
+
+/*
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
+ */
+
+#define LITTLE_ENDIAN          1        
+#define __BB_PRESENT           0         /*!< BIT_BANDING present or not */
+#define __CLKGATE_PRESENT      1         /*!< CLKGATE present or not */
+#define __CM4_REV              1         /*!< Core revision r0p1 */
+#define __DEBUG_LVL            3         /*!< Full debug plus DWT data matching */
+#define __FPU_PRESENT          0         /*!< FPU present or not */
+#define __JTAG_PRESENT         1         /*!< JTAG present or not */
+#define __MPU_PRESENT          1         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       4         /*!< Number of bits used for Priority Levels */
+#define __TRACE_LVL            1         /*!< Standard trace: ITM and DWT triggers and counters, but no ETM */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+#define __WIC_PRESENT          0         /*!< WIC present or not */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm4.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_sam4l.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAM4LC2C */
+/* ************************************************************************** */
+/** \defgroup SAM4LC2C_api Peripheral Software API */
+/*@{*/
+
+#include "component/abdacb.h"
+#include "component/acifc.h"
+#include "component/adcife.h"
+#include "component/aesa.h"
+#include "component/ast.h"
+#include "component/bpm.h"
+#include "component/bscif.h"
+#include "component/catb.h"
+#include "component/chipid.h"
+#include "component/crccu.h"
+#include "component/dacc.h"
+#include "component/eic.h"
+#include "component/flashcalw.h"
+#include "component/freqm.h"
+#include "component/gloc.h"
+#include "component/gpio.h"
+#include "component/hcache.h"
+#include "component/hmatrixb.h"
+#include "component/iisc.h"
+#include "component/lcdca.h"
+#include "component/parc.h"
+#include "component/pdca.h"
+#include "component/pevc.h"
+#include "component/picouart.h"
+#include "component/pm.h"
+#include "component/scif.h"
+#include "component/smap.h"
+#include "component/spi.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twim.h"
+#include "component/twis.h"
+#include "component/usart.h"
+#include "component/usbc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAM4LC2C */
+/* ************************************************************************** */
+/** \defgroup SAM4LC2C_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/abdacb.h"
+#include "instance/acifc.h"
+#include "instance/adcife.h"
+#include "instance/aesa.h"
+#include "instance/ast.h"
+#include "instance/bpm.h"
+#include "instance/bscif.h"
+#include "instance/catb.h"
+#include "instance/chipid.h"
+#include "instance/crccu.h"
+#include "instance/dacc.h"
+#include "instance/eic.h"
+#include "instance/hflashc.h"
+#include "instance/freqm.h"
+#include "instance/gloc.h"
+#include "instance/gpio.h"
+#include "instance/hcache.h"
+#include "instance/hmatrix.h"
+#include "instance/iisc.h"
+#include "instance/lcdca.h"
+#include "instance/parc.h"
+#include "instance/pdca.h"
+#include "instance/pevc.h"
+#include "instance/picouart.h"
+#include "instance/pm.h"
+#include "instance/scif.h"
+#include "instance/smap.h"
+#include "instance/spi.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/trng.h"
+#include "instance/twim0.h"
+#include "instance/twim1.h"
+#include "instance/twim2.h"
+#include "instance/twim3.h"
+#include "instance/twis0.h"
+#include "instance/twis1.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usart3.h"
+#include "instance/usbc.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAM4LC2C */
+/* ************************************************************************** */
+/** \defgroup SAM4LC2C_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HTOP0 bridge
+#define ID_IISC           0 /**< \brief Inter-IC Sound (I2S) Controller (IISC) */
+#define ID_SPI            1 /**< \brief Serial Peripheral Interface (SPI) */
+#define ID_TC0            2 /**< \brief Timer/Counter 0 (TC0) */
+#define ID_TC1            3 /**< \brief Timer/Counter 1 (TC1) */
+#define ID_TWIM0          4 /**< \brief Two-wire Master Interface 0 (TWIM0) */
+#define ID_TWIS0          5 /**< \brief Two-wire Slave Interface 0 (TWIS0) */
+#define ID_TWIM1          6 /**< \brief Two-wire Master Interface 1 (TWIM1) */
+#define ID_TWIS1          7 /**< \brief Two-wire Slave Interface 1 (TWIS1) */
+#define ID_USART0         8 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+#define ID_USART1         9 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+#define ID_USART2        10 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+#define ID_USART3        11 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+#define ID_ADCIFE        12 /**< \brief ADC controller interface (ADCIFE) */
+#define ID_DACC          13 /**< \brief DAC Controller (DACC) */
+#define ID_ACIFC         14 /**< \brief Analog Comparator Interface (ACIFC) */
+#define ID_GLOC          15 /**< \brief Glue Logic Controller (GLOC) */
+#define ID_ABDACB        16 /**< \brief Audio Bitstream DAC (ABDACB) */
+#define ID_TRNG          17 /**< \brief True Random Number Generator (TRNG) */
+#define ID_PARC          18 /**< \brief Parallel Capture (PARC) */
+#define ID_CATB          19 /**< \brief Capacitive Touch Module B (CATB) */
+#define ID_TWIM2         21 /**< \brief Two-wire Master Interface 2 (TWIM2) */
+#define ID_TWIM3         22 /**< \brief Two-wire Master Interface 3 (TWIM3) */
+#define ID_LCDCA         23 /**< \brief LCD Controller (LCDCA) */
+
+// Peripheral instances on HTOP1 bridge
+#define ID_HFLASHC       32 /**< \brief Flash Controller (HFLASHC) */
+#define ID_HCACHE        33 /**< \brief Cortex M I&D Cache Controller (HCACHE) */
+#define ID_HMATRIX       34 /**< \brief HSB Matrix (HMATRIX) */
+#define ID_PDCA          35 /**< \brief Peripheral DMA Controller (PDCA) */
+#define ID_SMAP          36 /**< \brief System Manager Access Port (SMAP) */
+#define ID_CRCCU         37 /**< \brief CRC Calculation Unit (CRCCU) */
+#define ID_USBC          38 /**< \brief USB 2.0 Interface (USBC) */
+#define ID_PEVC          39 /**< \brief Peripheral Event Controller (PEVC) */
+
+// Peripheral instances on HTOP2 bridge
+#define ID_PM            64 /**< \brief Power Manager (PM) */
+#define ID_CHIPID        65 /**< \brief Chip ID Registers (CHIPID) */
+#define ID_SCIF          66 /**< \brief System Control Interface (SCIF) */
+#define ID_FREQM         67 /**< \brief Frequency Meter (FREQM) */
+#define ID_GPIO          68 /**< \brief General-Purpose Input/Output Controller (GPIO) */
+
+// Peripheral instances on HTOP3 bridge
+#define ID_BPM           96 /**< \brief Backup Power Manager (BPM) */
+#define ID_BSCIF         97 /**< \brief Backup System Control Interface (BSCIF) */
+#define ID_AST           98 /**< \brief Asynchronous Timer (AST) */
+#define ID_WDT           99 /**< \brief Watchdog Timer (WDT) */
+#define ID_EIC          100 /**< \brief External Interrupt Controller (EIC) */
+#define ID_PICOUART     101 /**< \brief Pico UART (PICOUART) */
+
+// Peripheral instances on AHB (as if on bridge 4)
+#define ID_AESA         128 /**< \brief Advanced Encryption Standard (AESA) */
+
+#define ID_PERIPH_COUNT 129 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAM4LC2C */
+/* ************************************************************************** */
+/** \defgroup SAM4LC2C_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define ABDACB                        (0x40064000) /**< \brief (ABDACB) APB Base Address */
+#define ACIFC                         (0x40040000) /**< \brief (ACIFC) APB Base Address */
+#define ADCIFE                        (0x40038000) /**< \brief (ADCIFE) APB Base Address */
+#define AESA                          (0x400B0000) /**< \brief (AESA) AHB Base Address */
+#define AST                           (0x400F0800) /**< \brief (AST) APB Base Address */
+#define BPM                           (0x400F0000) /**< \brief (BPM) APB Base Address */
+#define BSCIF                         (0x400F0400) /**< \brief (BSCIF) APB Base Address */
+#define CATB                          (0x40070000) /**< \brief (CATB) APB Base Address */
+#define CHIPID                        (0x400E0400) /**< \brief (CHIPID) APB Base Address */
+#define CRCCU                         (0x400A4000) /**< \brief (CRCCU) APB Base Address */
+#define DACC                          (0x4003C000) /**< \brief (DACC) APB Base Address */
+#define EIC                           (0x400F1000) /**< \brief (EIC) APB Base Address */
+#define HFLASHC                       (0x400A0000) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000) /**< \brief (HFLASHC) USER Base Address */
+#define FREQM                         (0x400E0C00) /**< \brief (FREQM) APB Base Address */
+#define GLOC                          (0x40060000) /**< \brief (GLOC) APB Base Address */
+#define GPIO                          (0x400E1000) /**< \brief (GPIO) APB Base Address */
+#define HCACHE                        (0x400A0400) /**< \brief (HCACHE) APB Base Address */
+#define HMATRIX                       (0x400A1000) /**< \brief (HMATRIX) APB Base Address */
+#define IISC                          (0x40004000) /**< \brief (IISC) APB Base Address */
+#define LCDCA                         (0x40080000) /**< \brief (LCDCA) APB Base Address */
+#define PARC                          (0x4006C000) /**< \brief (PARC) APB Base Address */
+#define PDCA                          (0x400A2000) /**< \brief (PDCA) APB Base Address */
+#define PEVC                          (0x400A6000) /**< \brief (PEVC) APB Base Address */
+#define PICOUART                      (0x400F1400) /**< \brief (PICOUART) APB Base Address */
+#define PM                            (0x400E0000) /**< \brief (PM) APB Base Address */
+#define SCIF                          (0x400E0800) /**< \brief (SCIF) APB Base Address */
+#define SMAP                          (0x400A3000) /**< \brief (SMAP) APB Base Address */
+#define SPI                           (0x40008000) /**< \brief (SPI) APB Base Address */
+#define TC0                           (0x40010000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x40014000) /**< \brief (TC1) APB Base Address */
+#define TRNG                          (0x40068000) /**< \brief (TRNG) APB Base Address */
+#define TWIM0                         (0x40018000) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1                         (0x4001C000) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2                         (0x40078000) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3                         (0x4007C000) /**< \brief (TWIM3) APB Base Address */
+#define TWIS0                         (0x40018400) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1                         (0x4001C400) /**< \brief (TWIS1) APB Base Address */
+#define USART0                        (0x40024000) /**< \brief (USART0) APB Base Address */
+#define USART1                        (0x40028000) /**< \brief (USART1) APB Base Address */
+#define USART2                        (0x4002C000) /**< \brief (USART2) APB Base Address */
+#define USART3                        (0x40030000) /**< \brief (USART3) APB Base Address */
+#define USBC                          (0x400A5000) /**< \brief (USBC) APB Base Address */
+#define WDT                           (0x400F0C00) /**< \brief (WDT) APB Base Address */
+#else
+#define ABDACB            ((Abdacb   *)0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_ADDR                   (0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_INST_NUM   1                          /**< \brief (ABDACB) Number of instances */
+#define ABDACB_INSTS      { ABDACB }                 /**< \brief (ABDACB) Instances List */
+
+#define ACIFC             ((Acifc    *)0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_ADDR                    (0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_INST_NUM    1                          /**< \brief (ACIFC) Number of instances */
+#define ACIFC_INSTS       { ACIFC }                  /**< \brief (ACIFC) Instances List */
+
+#define ADCIFE            ((Adcife   *)0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_ADDR                   (0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_INST_NUM   1                          /**< \brief (ADCIFE) Number of instances */
+#define ADCIFE_INSTS      { ADCIFE }                 /**< \brief (ADCIFE) Instances List */
+
+#define AESA              ((Aesa     *)0x400B0000UL) /**< \brief (AESA) AHB Base Address */
+#define AESA_ADDR                     (0x400B0000UL) /**< \brief (AESA) AHB Base Address */
+#define AESA_INST_NUM     1                          /**< \brief (AESA) Number of instances */
+#define AESA_INSTS        { AESA }                   /**< \brief (AESA) Instances List */
+
+#define AST               ((Ast      *)0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_ADDR                      (0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_INST_NUM      1                          /**< \brief (AST) Number of instances */
+#define AST_INSTS         { AST }                    /**< \brief (AST) Instances List */
+
+#define BPM               ((Bpm      *)0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_ADDR                      (0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_INST_NUM      1                          /**< \brief (BPM) Number of instances */
+#define BPM_INSTS         { BPM }                    /**< \brief (BPM) Instances List */
+
+#define BSCIF             ((Bscif    *)0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_ADDR                    (0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_INST_NUM    1                          /**< \brief (BSCIF) Number of instances */
+#define BSCIF_INSTS       { BSCIF }                  /**< \brief (BSCIF) Instances List */
+
+#define CATB              ((Catb     *)0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_ADDR                     (0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_INST_NUM     1                          /**< \brief (CATB) Number of instances */
+#define CATB_INSTS        { CATB }                   /**< \brief (CATB) Instances List */
+
+#define CHIPID            ((Chipid   *)0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_ADDR                   (0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_INST_NUM   1                          /**< \brief (CHIPID) Number of instances */
+#define CHIPID_INSTS      { CHIPID }                 /**< \brief (CHIPID) Instances List */
+
+#define CRCCU             ((Crccu    *)0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_ADDR                    (0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_INST_NUM    1                          /**< \brief (CRCCU) Number of instances */
+#define CRCCU_INSTS       { CRCCU }                  /**< \brief (CRCCU) Instances List */
+
+#define DACC              ((Dacc     *)0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_ADDR                     (0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_INST_NUM     1                          /**< \brief (DACC) Number of instances */
+#define DACC_INSTS        { DACC }                   /**< \brief (DACC) Instances List */
+
+#define EIC               ((Eic      *)0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_ADDR                      (0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define HFLASHC           ((Flashcalw *)0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_ADDR                  (0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_FROW_ADDR             (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define HFLASHC_USER_ADDR             (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define FLASHCALW_INST_NUM 1                          /**< \brief (FLASHCALW) Number of instances */
+#define FLASHCALW_INSTS   { HFLASHC }                /**< \brief (FLASHCALW) Instances List */
+
+#define FREQM             ((Freqm    *)0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_ADDR                    (0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_INST_NUM    1                          /**< \brief (FREQM) Number of instances */
+#define FREQM_INSTS       { FREQM }                  /**< \brief (FREQM) Instances List */
+
+#define GLOC              ((Gloc     *)0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_ADDR                     (0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_INST_NUM     1                          /**< \brief (GLOC) Number of instances */
+#define GLOC_INSTS        { GLOC }                   /**< \brief (GLOC) Instances List */
+
+#define GPIO              ((Gpio     *)0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_ADDR                     (0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_INST_NUM     1                          /**< \brief (GPIO) Number of instances */
+#define GPIO_INSTS        { GPIO }                   /**< \brief (GPIO) Instances List */
+
+#define HCACHE            ((Hcache   *)0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_ADDR                   (0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_INST_NUM   1                          /**< \brief (HCACHE) Number of instances */
+#define HCACHE_INSTS      { HCACHE }                 /**< \brief (HCACHE) Instances List */
+
+#define HMATRIX           ((Hmatrixb *)0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIX_ADDR                  (0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIXB_INST_NUM 1                          /**< \brief (HMATRIXB) Number of instances */
+#define HMATRIXB_INSTS    { HMATRIX }                /**< \brief (HMATRIXB) Instances List */
+
+#define IISC              ((Iisc     *)0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_ADDR                     (0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_INST_NUM     1                          /**< \brief (IISC) Number of instances */
+#define IISC_INSTS        { IISC }                   /**< \brief (IISC) Instances List */
+
+#define LCDCA             ((Lcdca    *)0x40080000UL) /**< \brief (LCDCA) APB Base Address */
+#define LCDCA_ADDR                    (0x40080000UL) /**< \brief (LCDCA) APB Base Address */
+#define LCDCA_INST_NUM    1                          /**< \brief (LCDCA) Number of instances */
+#define LCDCA_INSTS       { LCDCA }                  /**< \brief (LCDCA) Instances List */
+
+#define PARC              ((Parc     *)0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_ADDR                     (0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_INST_NUM     1                          /**< \brief (PARC) Number of instances */
+#define PARC_INSTS        { PARC }                   /**< \brief (PARC) Instances List */
+
+#define PDCA              ((Pdca     *)0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_ADDR                     (0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_INST_NUM     1                          /**< \brief (PDCA) Number of instances */
+#define PDCA_INSTS        { PDCA }                   /**< \brief (PDCA) Instances List */
+
+#define PEVC              ((Pevc     *)0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_ADDR                     (0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_INST_NUM     1                          /**< \brief (PEVC) Number of instances */
+#define PEVC_INSTS        { PEVC }                   /**< \brief (PEVC) Instances List */
+
+#define PICOUART          ((Picouart *)0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_ADDR                 (0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_INST_NUM 1                          /**< \brief (PICOUART) Number of instances */
+#define PICOUART_INSTS    { PICOUART }               /**< \brief (PICOUART) Instances List */
+
+#define PM                ((Pm       *)0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_ADDR                       (0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define SCIF              ((Scif     *)0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_ADDR                     (0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_INST_NUM     1                          /**< \brief (SCIF) Number of instances */
+#define SCIF_INSTS        { SCIF }                   /**< \brief (SCIF) Instances List */
+
+#define SMAP              ((Smap     *)0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_ADDR                     (0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_INST_NUM     1                          /**< \brief (SMAP) Number of instances */
+#define SMAP_INSTS        { SMAP }                   /**< \brief (SMAP) Instances List */
+
+#define SPI               ((Spi      *)0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_ADDR                      (0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_INST_NUM      1                          /**< \brief (SPI) Number of instances */
+#define SPI_INSTS         { SPI }                    /**< \brief (SPI) Instances List */
+
+#define TC0               ((Tc       *)0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC0_ADDR                      (0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC1_ADDR                      (0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC_INST_NUM       2                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1 }               /**< \brief (TC) Instances List */
+
+#define TRNG              ((Trng     *)0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_ADDR                     (0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_INST_NUM     1                          /**< \brief (TRNG) Number of instances */
+#define TRNG_INSTS        { TRNG }                   /**< \brief (TRNG) Instances List */
+
+#define TWIM0             ((Twim     *)0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM0_ADDR                    (0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1             ((Twim     *)0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM1_ADDR                    (0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2             ((Twim     *)0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM2_ADDR                    (0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3             ((Twim     *)0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM3_ADDR                    (0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM_INST_NUM     4                          /**< \brief (TWIM) Number of instances */
+#define TWIM_INSTS        { TWIM0, TWIM1, TWIM2, TWIM3 } /**< \brief (TWIM) Instances List */
+
+#define TWIS0             ((Twis     *)0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS0_ADDR                    (0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1             ((Twis     *)0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS1_ADDR                    (0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS_INST_NUM     2                          /**< \brief (TWIS) Number of instances */
+#define TWIS_INSTS        { TWIS0, TWIS1 }           /**< \brief (TWIS) Instances List */
+
+#define USART0            ((Usart    *)0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART0_ADDR                   (0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART1            ((Usart    *)0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART1_ADDR                   (0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART2            ((Usart    *)0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART2_ADDR                   (0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART3            ((Usart    *)0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART3_ADDR                   (0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART_INST_NUM    4                          /**< \brief (USART) Number of instances */
+#define USART_INSTS       { USART0, USART1, USART2, USART3 } /**< \brief (USART) Instances List */
+
+#define USBC              ((Usbc     *)0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_ADDR                     (0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_INST_NUM     1                          /**< \brief (USBC) Number of instances */
+#define USBC_INSTS        { USBC }                   /**< \brief (USBC) Instances List */
+
+#define WDT               ((Wdt      *)0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_ADDR                      (0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  GPIO DEFINITIONS FOR SAM4LC2C */
+/* ************************************************************************** */
+/** \defgroup SAM4LC2C_gpio GPIO Definitions */
+/*@{*/
+
+#include "pio/sam4lc2c.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  ADDITIONAL DEFINITIONS FOR COMPATIBILITY */
+/* ************************************************************************** */
+/** \addtogroup SAM4LC2C_compat Definitions */
+/*@{*/
+// These defines are used to keep compatibility with existing 
+// sam/drivers/usart implementation from SAM3/4 products with SAM4L product.
+#define US_MR_USART_MODE_HW_HANDSHAKING  US_MR_USART_MODE_HARDWARE
+#define US_MR_USART_MODE_IS07816_T_0     US_MR_USART_MODE_ISO7816_T0
+#define US_MR_USART_MODE_IS07816_T_1     US_MR_USART_MODE_ISO7816_T1
+#define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
+#define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
+#define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_8_BIT      US_MR_CHRL_8
+#define US_MR_PAR_NO          US_MR_PAR_NONE
+#define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI
+#define US_IF                 US_IFR
+#define US_WPSR_WPVS          US_WPSR_WPV_1
+
+#define USBC_UPCFG0_PBK_Msk   (0x1u << USBC_UPCFG0_PBK_Pos)
+
+// These defines for homogeneity with other SAM header files.
+#define CHIP_FREQ_FWS_0       (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 */
+#define CHIP_FREQ_FWS_1       (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 */
+// WARNING NOTE: these are preliminary values.
+#define CHIP_FREQ_FLASH_HSEN_FWS_0 (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 and the FLASH HS mode is enabled */
+#define CHIP_FREQ_FLASH_HSEN_FWS_1 (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 and the FLASH HS mode is enabled */
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/tc implementation from SAM3/4 products with SAM4L product. 
+#define TC_CMR_LDRA_RISING    TC_CMR_LDRA_POS_EDGE_TIOA
+#define TC_CMR_LDRB_FALLING   TC_CMR_LDRB_NEG_EDGE_TIOA
+#define TC_CMR_ETRGEDG_FALLING TC_CMR_ETRGEDG_NEG_EDGE
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/spi implementation from SAM3/4 products with SAM4L product. 
+#define SPI_CSR_BITS_8_BIT    SPI_CSR_BITS_8_BPT
+#define SPI_WPCR_SPIWPKEY_VALUE SPI_WPCR_WPKEY_VALUE
+#define SPI_WPCR_SPIWPEN      SPI_WPCR_WPEN
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/crccu implementation from SAM3/4 products with SAM4L product. 
+#define CRCCU_DMA_EN          CRCCU_DMAEN
+#define CRCCU_DMA_DIS         CRCCU_DMADIS
+#define CRCCU_DMA_SR          CRCCU_DMASR
+#define CRCCU_DMA_IER         CRCCU_DMAIER
+#define CRCCU_DMA_IDR         CRCCU_DMAIDR
+#define CRCCU_DMA_IMR         CRCCU_DMAIMR
+#define CRCCU_DMA_ISR         CRCCU_DMAISR
+#define CRCCU_DMA_EN_DMAEN    CRCCU_DMAEN_DMAEN
+#define CRCCU_DMA_DIS_DMADIS  CRCCU_DMADIS_DMADIS
+#define CRCCU_DMA_SR_DMASR    CRCCU_DMASR_DMASR
+#define CRCCU_DMA_IER_DMAIER  CRCCU_DMAIER_DMAIER
+#define CRCCU_DMA_IDR_DMAIDR  CRCCU_DMAIDR_DMAIDR
+#define CRCCU_DMA_IMR_DMAIMR  CRCCU_DMAIMR_DMAIMR
+#define CRCCU_DMA_ISR_DMAISR  CRCCU_DMAISR_DMAISR
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAM4LC2C */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL(0x00020000) /* 128 kB */
+#define FLASH_PAGE_SIZE       512
+#define FLASH_NB_OF_PAGES     256
+#define FLASH_USER_PAGE_SIZE  512
+#define HRAMC0_SIZE           _UL(0x00008000) /* 32 kB */
+#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+
+#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+
+#define DSU_DID_RESETVALUE    _UL(0xAB0A07E0)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAM4LC2C */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAM4LC2C_H */

--- a/asf/sam/include/sam4l/sam4lc2c.h
+++ b/asf/sam/include/sam4l/sam4lc2c.h
@@ -62,15 +62,15 @@ typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volati
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
 #if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#define _U_(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
 #if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#define _U_(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 
@@ -881,23 +881,23 @@ void LCDCA_Handler               ( void );
 /**  MEMORY MAPPING DEFINITIONS FOR SAM4LC2C */
 /* ************************************************************************** */
 
-#define FLASH_SIZE            _UL(0x00020000) /* 128 kB */
+#define FLASH_SIZE            _UL_(0x00020000) /* 128 kB */
 #define FLASH_PAGE_SIZE       512
 #define FLASH_NB_OF_PAGES     256
 #define FLASH_USER_PAGE_SIZE  512
-#define HRAMC0_SIZE           _UL(0x00008000) /* 32 kB */
-#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+#define HRAMC0_SIZE           _UL_(0x00008000) /* 32 kB */
+#define HRAMC1_SIZE           _UL_(0x00000800) /* 2 kB */
 
-#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
-#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
-#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
-#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
-#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
-#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
-#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
-#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL_(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL_(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL_(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL_(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL_(0x400F0000) /**< HTOP3 base address */
 
-#define DSU_DID_RESETVALUE    _UL(0xAB0A07E0)
+#define DSU_DID_RESETVALUE    _UL_(0xAB0A07E0)
 
 /* ************************************************************************** */
 /**  ELECTRICAL DEFINITIONS FOR SAM4LC2C */

--- a/asf/sam/include/sam4l/sam4lc4a.h
+++ b/asf/sam/include/sam4l/sam4lc4a.h
@@ -62,15 +62,15 @@ typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volati
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
 #if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#define _U_(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
 #if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#define _U_(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 
@@ -881,23 +881,23 @@ void LCDCA_Handler               ( void );
 /**  MEMORY MAPPING DEFINITIONS FOR SAM4LC4A */
 /* ************************************************************************** */
 
-#define FLASH_SIZE            _UL(0x00040000) /* 256 kB */
+#define FLASH_SIZE            _UL_(0x00040000) /* 256 kB */
 #define FLASH_PAGE_SIZE       512
 #define FLASH_NB_OF_PAGES     512
 #define FLASH_USER_PAGE_SIZE  512
-#define HRAMC0_SIZE           _UL(0x00008000) /* 32 kB */
-#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+#define HRAMC0_SIZE           _UL_(0x00008000) /* 32 kB */
+#define HRAMC1_SIZE           _UL_(0x00000800) /* 2 kB */
 
-#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
-#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
-#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
-#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
-#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
-#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
-#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
-#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL_(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL_(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL_(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL_(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL_(0x400F0000) /**< HTOP3 base address */
 
-#define DSU_DID_RESETVALUE    _UL(0xAB0A09E0)
+#define DSU_DID_RESETVALUE    _UL_(0xAB0A09E0)
 
 /* ************************************************************************** */
 /**  ELECTRICAL DEFINITIONS FOR SAM4LC4A */

--- a/asf/sam/include/sam4l/sam4lc4a.h
+++ b/asf/sam/include/sam4l/sam4lc4a.h
@@ -1,0 +1,913 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAM4LC4A
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LC4A_
+#define _SAM4LC4A_
+
+/**
+ * \ingroup SAM4L_definitions
+ * \addtogroup SAM4LC4A_definitions SAM4LC4A definitions
+ * This file defines all structures and symbols for SAM4LC4A:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#if !defined(_UL)
+#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#endif
+#else
+#if !defined(_UL)
+#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif
+#endif
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAM4LC4A */
+/* ************************************************************************** */
+/** \defgroup SAM4LC4A_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M4 Processor Exceptions Numbers ******************************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn           = -13,/**<  3 Cortex-M4 Hard Fault Interrupt        */
+  MemoryManagement_IRQn    = -12,/**<  4 Cortex-M4 Memory Management Interrupt */
+  BusFault_IRQn            = -11,/**<  5 Cortex-M4 Bus Fault Interrupt         */
+  UsageFault_IRQn          = -10,/**<  6 Cortex-M4 Usage Fault Interrupt       */
+  SVCall_IRQn              = -5, /**< 11 Cortex-M4 SV Call Interrupt           */
+  DebugMonitor_IRQn        = -4, /**< 12 Cortex-M4 Debug Monitor Interrupt     */
+  PendSV_IRQn              = -2, /**< 14 Cortex-M4 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 Cortex-M4 System Tick Interrupt       */
+  /******  SAM4LC4A-specific Interrupt Numbers ***********************/
+  HFLASHC_IRQn             =  0, /**<  0 SAM4LC4A Flash Controller (HFLASHC) */
+  PDCA_0_IRQn              =  1, /**<  1 SAM4LC4A Peripheral DMA Controller (PDCA): PDCA_0 */
+  PDCA_1_IRQn              =  2, /**<  2 SAM4LC4A Peripheral DMA Controller (PDCA): PDCA_1 */
+  PDCA_2_IRQn              =  3, /**<  3 SAM4LC4A Peripheral DMA Controller (PDCA): PDCA_2 */
+  PDCA_3_IRQn              =  4, /**<  4 SAM4LC4A Peripheral DMA Controller (PDCA): PDCA_3 */
+  PDCA_4_IRQn              =  5, /**<  5 SAM4LC4A Peripheral DMA Controller (PDCA): PDCA_4 */
+  PDCA_5_IRQn              =  6, /**<  6 SAM4LC4A Peripheral DMA Controller (PDCA): PDCA_5 */
+  PDCA_6_IRQn              =  7, /**<  7 SAM4LC4A Peripheral DMA Controller (PDCA): PDCA_6 */
+  PDCA_7_IRQn              =  8, /**<  8 SAM4LC4A Peripheral DMA Controller (PDCA): PDCA_7 */
+  PDCA_8_IRQn              =  9, /**<  9 SAM4LC4A Peripheral DMA Controller (PDCA): PDCA_8 */
+  PDCA_9_IRQn              = 10, /**< 10 SAM4LC4A Peripheral DMA Controller (PDCA): PDCA_9 */
+  PDCA_10_IRQn             = 11, /**< 11 SAM4LC4A Peripheral DMA Controller (PDCA): PDCA_10 */
+  PDCA_11_IRQn             = 12, /**< 12 SAM4LC4A Peripheral DMA Controller (PDCA): PDCA_11 */
+  PDCA_12_IRQn             = 13, /**< 13 SAM4LC4A Peripheral DMA Controller (PDCA): PDCA_12 */
+  PDCA_13_IRQn             = 14, /**< 14 SAM4LC4A Peripheral DMA Controller (PDCA): PDCA_13 */
+  PDCA_14_IRQn             = 15, /**< 15 SAM4LC4A Peripheral DMA Controller (PDCA): PDCA_14 */
+  PDCA_15_IRQn             = 16, /**< 16 SAM4LC4A Peripheral DMA Controller (PDCA): PDCA_15 */
+  CRCCU_IRQn               = 17, /**< 17 SAM4LC4A CRC Calculation Unit (CRCCU) */
+  USBC_IRQn                = 18, /**< 18 SAM4LC4A USB 2.0 Interface (USBC) */
+  PEVC_0_IRQn              = 19, /**< 19 SAM4LC4A Peripheral Event Controller (PEVC): PEVC_TR */
+  PEVC_1_IRQn              = 20, /**< 20 SAM4LC4A Peripheral Event Controller (PEVC): PEVC_OV */
+  AESA_IRQn                = 21, /**< 21 SAM4LC4A Advanced Encryption Standard (AESA) */
+  PM_IRQn                  = 22, /**< 22 SAM4LC4A Power Manager (PM) */
+  SCIF_IRQn                = 23, /**< 23 SAM4LC4A System Control Interface (SCIF) */
+  FREQM_IRQn               = 24, /**< 24 SAM4LC4A Frequency Meter (FREQM) */
+  GPIO_0_IRQn              = 25, /**< 25 SAM4LC4A General-Purpose Input/Output Controller (GPIO): GPIO_0 */
+  GPIO_1_IRQn              = 26, /**< 26 SAM4LC4A General-Purpose Input/Output Controller (GPIO): GPIO_1 */
+  GPIO_2_IRQn              = 27, /**< 27 SAM4LC4A General-Purpose Input/Output Controller (GPIO): GPIO_2 */
+  GPIO_3_IRQn              = 28, /**< 28 SAM4LC4A General-Purpose Input/Output Controller (GPIO): GPIO_3 */
+  GPIO_4_IRQn              = 29, /**< 29 SAM4LC4A General-Purpose Input/Output Controller (GPIO): GPIO_4 */
+  GPIO_5_IRQn              = 30, /**< 30 SAM4LC4A General-Purpose Input/Output Controller (GPIO): GPIO_5 */
+  GPIO_6_IRQn              = 31, /**< 31 SAM4LC4A General-Purpose Input/Output Controller (GPIO): GPIO_6 */
+  GPIO_7_IRQn              = 32, /**< 32 SAM4LC4A General-Purpose Input/Output Controller (GPIO): GPIO_7 */
+  GPIO_8_IRQn              = 33, /**< 33 SAM4LC4A General-Purpose Input/Output Controller (GPIO): GPIO_8 */
+  GPIO_9_IRQn              = 34, /**< 34 SAM4LC4A General-Purpose Input/Output Controller (GPIO): GPIO_9 */
+  GPIO_10_IRQn             = 35, /**< 35 SAM4LC4A General-Purpose Input/Output Controller (GPIO): GPIO_10 */
+  GPIO_11_IRQn             = 36, /**< 36 SAM4LC4A General-Purpose Input/Output Controller (GPIO): GPIO_11 */
+  BPM_IRQn                 = 37, /**< 37 SAM4LC4A Backup Power Manager (BPM) */
+  BSCIF_IRQn               = 38, /**< 38 SAM4LC4A Backup System Control Interface (BSCIF) */
+  AST_0_IRQn               = 39, /**< 39 SAM4LC4A Asynchronous Timer (AST): AST_ALARM */
+  AST_1_IRQn               = 40, /**< 40 SAM4LC4A Asynchronous Timer (AST): AST_PER */
+  AST_2_IRQn               = 41, /**< 41 SAM4LC4A Asynchronous Timer (AST): AST_OVF */
+  AST_3_IRQn               = 42, /**< 42 SAM4LC4A Asynchronous Timer (AST): AST_READY */
+  AST_4_IRQn               = 43, /**< 43 SAM4LC4A Asynchronous Timer (AST): AST_CLKREADY */
+  WDT_IRQn                 = 44, /**< 44 SAM4LC4A Watchdog Timer (WDT) */
+  EIC_0_IRQn               = 45, /**< 45 SAM4LC4A External Interrupt Controller (EIC): EIC_1 */
+  EIC_1_IRQn               = 46, /**< 46 SAM4LC4A External Interrupt Controller (EIC): EIC_2 */
+  EIC_2_IRQn               = 47, /**< 47 SAM4LC4A External Interrupt Controller (EIC): EIC_3 */
+  EIC_3_IRQn               = 48, /**< 48 SAM4LC4A External Interrupt Controller (EIC): EIC_4 */
+  EIC_4_IRQn               = 49, /**< 49 SAM4LC4A External Interrupt Controller (EIC): EIC_5 */
+  EIC_5_IRQn               = 50, /**< 50 SAM4LC4A External Interrupt Controller (EIC): EIC_6 */
+  EIC_6_IRQn               = 51, /**< 51 SAM4LC4A External Interrupt Controller (EIC): EIC_7 */
+  EIC_7_IRQn               = 52, /**< 52 SAM4LC4A External Interrupt Controller (EIC): EIC_8 */
+  IISC_IRQn                = 53, /**< 53 SAM4LC4A Inter-IC Sound (I2S) Controller (IISC) */
+  SPI_IRQn                 = 54, /**< 54 SAM4LC4A Serial Peripheral Interface (SPI) */
+  TC0_0_IRQn               = 55, /**< 55 SAM4LC4A Timer/Counter 0 (TC0): TC00 */
+  TC0_1_IRQn               = 56, /**< 56 SAM4LC4A Timer/Counter 0 (TC0): TC01 */
+  TC0_2_IRQn               = 57, /**< 57 SAM4LC4A Timer/Counter 0 (TC0): TC02 */
+  TC1_0_IRQn               = 58, /**< 58 SAM4LC4A Timer/Counter 1 (TC1): TC10 */
+  TC1_1_IRQn               = 59, /**< 59 SAM4LC4A Timer/Counter 1 (TC1): TC11 */
+  TC1_2_IRQn               = 60, /**< 60 SAM4LC4A Timer/Counter 1 (TC1): TC12 */
+  TWIM0_IRQn               = 61, /**< 61 SAM4LC4A Two-wire Master Interface 0 (TWIM0) */
+  TWIS0_IRQn               = 62, /**< 62 SAM4LC4A Two-wire Slave Interface 0 (TWIS0) */
+  TWIM1_IRQn               = 63, /**< 63 SAM4LC4A Two-wire Master Interface 1 (TWIM1) */
+  TWIS1_IRQn               = 64, /**< 64 SAM4LC4A Two-wire Slave Interface 1 (TWIS1) */
+  USART0_IRQn              = 65, /**< 65 SAM4LC4A Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+  USART1_IRQn              = 66, /**< 66 SAM4LC4A Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+  USART2_IRQn              = 67, /**< 67 SAM4LC4A Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+  USART3_IRQn              = 68, /**< 68 SAM4LC4A Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+  ADCIFE_IRQn              = 69, /**< 69 SAM4LC4A ADC controller interface (ADCIFE) */
+  DACC_IRQn                = 70, /**< 70 SAM4LC4A DAC Controller (DACC) */
+  ACIFC_IRQn               = 71, /**< 71 SAM4LC4A Analog Comparator Interface (ACIFC) */
+  ABDACB_IRQn              = 72, /**< 72 SAM4LC4A Audio Bitstream DAC (ABDACB) */
+  TRNG_IRQn                = 73, /**< 73 SAM4LC4A True Random Number Generator (TRNG) */
+  PARC_IRQn                = 74, /**< 74 SAM4LC4A Parallel Capture (PARC) */
+  CATB_IRQn                = 75, /**< 75 SAM4LC4A Capacitive Touch Module B (CATB) */
+  TWIM2_IRQn               = 77, /**< 77 SAM4LC4A Two-wire Master Interface 2 (TWIM2) */
+  TWIM3_IRQn               = 78, /**< 78 SAM4LC4A Two-wire Master Interface 3 (TWIM3) */
+  LCDCA_IRQn               = 79, /**< 79 SAM4LC4A LCD Controller (LCDCA) */
+
+  PERIPH_COUNT_IRQn        = 80  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNMI_Handler;
+  void* pfnHardFault_Handler;
+  void* pfnMemManage_Handler;
+  void* pfnBusFault_Handler;
+  void* pfnUsageFault_Handler;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVC_Handler;
+  void* pfnDebugMon_Handler;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnHFLASHC_Handler;               /*  0 Flash Controller */
+  void* pfnPDCA_0_Handler;                /*  1 Peripheral DMA Controller IRQ 0 */
+  void* pfnPDCA_1_Handler;                /*  2 Peripheral DMA Controller IRQ 1 */
+  void* pfnPDCA_2_Handler;                /*  3 Peripheral DMA Controller IRQ 2 */
+  void* pfnPDCA_3_Handler;                /*  4 Peripheral DMA Controller IRQ 3 */
+  void* pfnPDCA_4_Handler;                /*  5 Peripheral DMA Controller IRQ 4 */
+  void* pfnPDCA_5_Handler;                /*  6 Peripheral DMA Controller IRQ 5 */
+  void* pfnPDCA_6_Handler;                /*  7 Peripheral DMA Controller IRQ 6 */
+  void* pfnPDCA_7_Handler;                /*  8 Peripheral DMA Controller IRQ 7 */
+  void* pfnPDCA_8_Handler;                /*  9 Peripheral DMA Controller IRQ 8 */
+  void* pfnPDCA_9_Handler;                /* 10 Peripheral DMA Controller IRQ 9 */
+  void* pfnPDCA_10_Handler;               /* 11 Peripheral DMA Controller IRQ 10 */
+  void* pfnPDCA_11_Handler;               /* 12 Peripheral DMA Controller IRQ 11 */
+  void* pfnPDCA_12_Handler;               /* 13 Peripheral DMA Controller IRQ 12 */
+  void* pfnPDCA_13_Handler;               /* 14 Peripheral DMA Controller IRQ 13 */
+  void* pfnPDCA_14_Handler;               /* 15 Peripheral DMA Controller IRQ 14 */
+  void* pfnPDCA_15_Handler;               /* 16 Peripheral DMA Controller IRQ 15 */
+  void* pfnCRCCU_Handler;                 /* 17 CRC Calculation Unit */
+  void* pfnUSBC_Handler;                  /* 18 USB 2.0 Interface */
+  void* pfnPEVC_0_Handler;                /* 19 Peripheral Event Controller IRQ 0 */
+  void* pfnPEVC_1_Handler;                /* 20 Peripheral Event Controller IRQ 1 */
+  void* pfnAESA_Handler;                  /* 21 Advanced Encryption Standard */
+  void* pfnPM_Handler;                    /* 22 Power Manager */
+  void* pfnSCIF_Handler;                  /* 23 System Control Interface */
+  void* pfnFREQM_Handler;                 /* 24 Frequency Meter */
+  void* pfnGPIO_0_Handler;                /* 25 General-Purpose Input/Output Controller IRQ 0 */
+  void* pfnGPIO_1_Handler;                /* 26 General-Purpose Input/Output Controller IRQ 1 */
+  void* pfnGPIO_2_Handler;                /* 27 General-Purpose Input/Output Controller IRQ 2 */
+  void* pfnGPIO_3_Handler;                /* 28 General-Purpose Input/Output Controller IRQ 3 */
+  void* pfnGPIO_4_Handler;                /* 29 General-Purpose Input/Output Controller IRQ 4 */
+  void* pfnGPIO_5_Handler;                /* 30 General-Purpose Input/Output Controller IRQ 5 */
+  void* pfnGPIO_6_Handler;                /* 31 General-Purpose Input/Output Controller IRQ 6 */
+  void* pfnGPIO_7_Handler;                /* 32 General-Purpose Input/Output Controller IRQ 7 */
+  void* pfnGPIO_8_Handler;                /* 33 General-Purpose Input/Output Controller IRQ 8 */
+  void* pfnGPIO_9_Handler;                /* 34 General-Purpose Input/Output Controller IRQ 9 */
+  void* pfnGPIO_10_Handler;               /* 35 General-Purpose Input/Output Controller IRQ 10 */
+  void* pfnGPIO_11_Handler;               /* 36 General-Purpose Input/Output Controller IRQ 11 */
+  void* pfnBPM_Handler;                   /* 37 Backup Power Manager */
+  void* pfnBSCIF_Handler;                 /* 38 Backup System Control Interface */
+  void* pfnAST_0_Handler;                 /* 39 Asynchronous Timer IRQ 0 */
+  void* pfnAST_1_Handler;                 /* 40 Asynchronous Timer IRQ 1 */
+  void* pfnAST_2_Handler;                 /* 41 Asynchronous Timer IRQ 2 */
+  void* pfnAST_3_Handler;                 /* 42 Asynchronous Timer IRQ 3 */
+  void* pfnAST_4_Handler;                 /* 43 Asynchronous Timer IRQ 4 */
+  void* pfnWDT_Handler;                   /* 44 Watchdog Timer */
+  void* pfnEIC_0_Handler;                 /* 45 External Interrupt Controller IRQ 0 */
+  void* pfnEIC_1_Handler;                 /* 46 External Interrupt Controller IRQ 1 */
+  void* pfnEIC_2_Handler;                 /* 47 External Interrupt Controller IRQ 2 */
+  void* pfnEIC_3_Handler;                 /* 48 External Interrupt Controller IRQ 3 */
+  void* pfnEIC_4_Handler;                 /* 49 External Interrupt Controller IRQ 4 */
+  void* pfnEIC_5_Handler;                 /* 50 External Interrupt Controller IRQ 5 */
+  void* pfnEIC_6_Handler;                 /* 51 External Interrupt Controller IRQ 6 */
+  void* pfnEIC_7_Handler;                 /* 52 External Interrupt Controller IRQ 7 */
+  void* pfnIISC_Handler;                  /* 53 Inter-IC Sound (I2S) Controller */
+  void* pfnSPI_Handler;                   /* 54 Serial Peripheral Interface */
+  void* pfnTC0_0_Handler;                 /* 55 Timer/Counter 0 IRQ 0 */
+  void* pfnTC0_1_Handler;                 /* 56 Timer/Counter 0 IRQ 1 */
+  void* pfnTC0_2_Handler;                 /* 57 Timer/Counter 0 IRQ 2 */
+  void* pfnTC1_0_Handler;                 /* 58 Timer/Counter 1 IRQ 0 */
+  void* pfnTC1_1_Handler;                 /* 59 Timer/Counter 1 IRQ 1 */
+  void* pfnTC1_2_Handler;                 /* 60 Timer/Counter 1 IRQ 2 */
+  void* pfnTWIM0_Handler;                 /* 61 Two-wire Master Interface 0 */
+  void* pfnTWIS0_Handler;                 /* 62 Two-wire Slave Interface 0 */
+  void* pfnTWIM1_Handler;                 /* 63 Two-wire Master Interface 1 */
+  void* pfnTWIS1_Handler;                 /* 64 Two-wire Slave Interface 1 */
+  void* pfnUSART0_Handler;                /* 65 Universal Synchronous Asynchronous Receiver Transmitter 0 */
+  void* pfnUSART1_Handler;                /* 66 Universal Synchronous Asynchronous Receiver Transmitter 1 */
+  void* pfnUSART2_Handler;                /* 67 Universal Synchronous Asynchronous Receiver Transmitter 2 */
+  void* pfnUSART3_Handler;                /* 68 Universal Synchronous Asynchronous Receiver Transmitter 3 */
+  void* pfnADCIFE_Handler;                /* 69 ADC controller interface */
+  void* pfnDACC_Handler;                  /* 70 DAC Controller */
+  void* pfnACIFC_Handler;                 /* 71 Analog Comparator Interface */
+  void* pfnABDACB_Handler;                /* 72 Audio Bitstream DAC */
+  void* pfnTRNG_Handler;                  /* 73 True Random Number Generator */
+  void* pfnPARC_Handler;                  /* 74 Parallel Capture */
+  void* pfnCATB_Handler;                  /* 75 Capacitive Touch Module B */
+  void* pvReserved76;
+  void* pfnTWIM2_Handler;                 /* 77 Two-wire Master Interface 2 */
+  void* pfnTWIM3_Handler;                 /* 78 Two-wire Master Interface 3 */
+  void* pfnLCDCA_Handler;                 /* 79 LCD Controller */
+} DeviceVectors;
+
+/* Cortex-M4 processor handlers */
+void Reset_Handler               ( void );
+void NMI_Handler                 ( void );
+void HardFault_Handler           ( void );
+void MemManage_Handler           ( void );
+void BusFault_Handler            ( void );
+void UsageFault_Handler          ( void );
+void SVC_Handler                 ( void );
+void DebugMon_Handler            ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void HFLASHC_Handler             ( void );
+void PDCA_0_Handler              ( void );
+void PDCA_1_Handler              ( void );
+void PDCA_2_Handler              ( void );
+void PDCA_3_Handler              ( void );
+void PDCA_4_Handler              ( void );
+void PDCA_5_Handler              ( void );
+void PDCA_6_Handler              ( void );
+void PDCA_7_Handler              ( void );
+void PDCA_8_Handler              ( void );
+void PDCA_9_Handler              ( void );
+void PDCA_10_Handler             ( void );
+void PDCA_11_Handler             ( void );
+void PDCA_12_Handler             ( void );
+void PDCA_13_Handler             ( void );
+void PDCA_14_Handler             ( void );
+void PDCA_15_Handler             ( void );
+void CRCCU_Handler               ( void );
+void USBC_Handler                ( void );
+void PEVC_0_Handler              ( void );
+void PEVC_1_Handler              ( void );
+void AESA_Handler                ( void );
+void PM_Handler                  ( void );
+void SCIF_Handler                ( void );
+void FREQM_Handler               ( void );
+void GPIO_0_Handler              ( void );
+void GPIO_1_Handler              ( void );
+void GPIO_2_Handler              ( void );
+void GPIO_3_Handler              ( void );
+void GPIO_4_Handler              ( void );
+void GPIO_5_Handler              ( void );
+void GPIO_6_Handler              ( void );
+void GPIO_7_Handler              ( void );
+void GPIO_8_Handler              ( void );
+void GPIO_9_Handler              ( void );
+void GPIO_10_Handler             ( void );
+void GPIO_11_Handler             ( void );
+void BPM_Handler                 ( void );
+void BSCIF_Handler               ( void );
+void AST_0_Handler               ( void );
+void AST_1_Handler               ( void );
+void AST_2_Handler               ( void );
+void AST_3_Handler               ( void );
+void AST_4_Handler               ( void );
+void WDT_Handler                 ( void );
+void EIC_0_Handler               ( void );
+void EIC_1_Handler               ( void );
+void EIC_2_Handler               ( void );
+void EIC_3_Handler               ( void );
+void EIC_4_Handler               ( void );
+void EIC_5_Handler               ( void );
+void EIC_6_Handler               ( void );
+void EIC_7_Handler               ( void );
+void IISC_Handler                ( void );
+void SPI_Handler                 ( void );
+void TC0_0_Handler               ( void );
+void TC0_1_Handler               ( void );
+void TC0_2_Handler               ( void );
+void TC1_0_Handler               ( void );
+void TC1_1_Handler               ( void );
+void TC1_2_Handler               ( void );
+void TWIM0_Handler               ( void );
+void TWIS0_Handler               ( void );
+void TWIM1_Handler               ( void );
+void TWIS1_Handler               ( void );
+void USART0_Handler              ( void );
+void USART1_Handler              ( void );
+void USART2_Handler              ( void );
+void USART3_Handler              ( void );
+void ADCIFE_Handler              ( void );
+void DACC_Handler                ( void );
+void ACIFC_Handler               ( void );
+void ABDACB_Handler              ( void );
+void TRNG_Handler                ( void );
+void PARC_Handler                ( void );
+void CATB_Handler                ( void );
+void TWIM2_Handler               ( void );
+void TWIM3_Handler               ( void );
+void LCDCA_Handler               ( void );
+
+/*
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
+ */
+
+#define LITTLE_ENDIAN          1        
+#define __BB_PRESENT           0         /*!< BIT_BANDING present or not */
+#define __CLKGATE_PRESENT      1         /*!< CLKGATE present or not */
+#define __CM4_REV              1         /*!< Core revision r0p1 */
+#define __DEBUG_LVL            3         /*!< Full debug plus DWT data matching */
+#define __FPU_PRESENT          0         /*!< FPU present or not */
+#define __JTAG_PRESENT         1         /*!< JTAG present or not */
+#define __MPU_PRESENT          1         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       4         /*!< Number of bits used for Priority Levels */
+#define __TRACE_LVL            1         /*!< Standard trace: ITM and DWT triggers and counters, but no ETM */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+#define __WIC_PRESENT          0         /*!< WIC present or not */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm4.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_sam4l.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAM4LC4A */
+/* ************************************************************************** */
+/** \defgroup SAM4LC4A_api Peripheral Software API */
+/*@{*/
+
+#include "component/abdacb.h"
+#include "component/acifc.h"
+#include "component/adcife.h"
+#include "component/aesa.h"
+#include "component/ast.h"
+#include "component/bpm.h"
+#include "component/bscif.h"
+#include "component/catb.h"
+#include "component/chipid.h"
+#include "component/crccu.h"
+#include "component/dacc.h"
+#include "component/eic.h"
+#include "component/flashcalw.h"
+#include "component/freqm.h"
+#include "component/gloc.h"
+#include "component/gpio.h"
+#include "component/hcache.h"
+#include "component/hmatrixb.h"
+#include "component/iisc.h"
+#include "component/lcdca.h"
+#include "component/parc.h"
+#include "component/pdca.h"
+#include "component/pevc.h"
+#include "component/picouart.h"
+#include "component/pm.h"
+#include "component/scif.h"
+#include "component/smap.h"
+#include "component/spi.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twim.h"
+#include "component/twis.h"
+#include "component/usart.h"
+#include "component/usbc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAM4LC4A */
+/* ************************************************************************** */
+/** \defgroup SAM4LC4A_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/abdacb.h"
+#include "instance/acifc.h"
+#include "instance/adcife.h"
+#include "instance/aesa.h"
+#include "instance/ast.h"
+#include "instance/bpm.h"
+#include "instance/bscif.h"
+#include "instance/catb.h"
+#include "instance/chipid.h"
+#include "instance/crccu.h"
+#include "instance/dacc.h"
+#include "instance/eic.h"
+#include "instance/hflashc.h"
+#include "instance/freqm.h"
+#include "instance/gloc.h"
+#include "instance/gpio.h"
+#include "instance/hcache.h"
+#include "instance/hmatrix.h"
+#include "instance/iisc.h"
+#include "instance/lcdca.h"
+#include "instance/parc.h"
+#include "instance/pdca.h"
+#include "instance/pevc.h"
+#include "instance/picouart.h"
+#include "instance/pm.h"
+#include "instance/scif.h"
+#include "instance/smap.h"
+#include "instance/spi.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/trng.h"
+#include "instance/twim0.h"
+#include "instance/twim1.h"
+#include "instance/twim2.h"
+#include "instance/twim3.h"
+#include "instance/twis0.h"
+#include "instance/twis1.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usart3.h"
+#include "instance/usbc.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAM4LC4A */
+/* ************************************************************************** */
+/** \defgroup SAM4LC4A_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HTOP0 bridge
+#define ID_IISC           0 /**< \brief Inter-IC Sound (I2S) Controller (IISC) */
+#define ID_SPI            1 /**< \brief Serial Peripheral Interface (SPI) */
+#define ID_TC0            2 /**< \brief Timer/Counter 0 (TC0) */
+#define ID_TC1            3 /**< \brief Timer/Counter 1 (TC1) */
+#define ID_TWIM0          4 /**< \brief Two-wire Master Interface 0 (TWIM0) */
+#define ID_TWIS0          5 /**< \brief Two-wire Slave Interface 0 (TWIS0) */
+#define ID_TWIM1          6 /**< \brief Two-wire Master Interface 1 (TWIM1) */
+#define ID_TWIS1          7 /**< \brief Two-wire Slave Interface 1 (TWIS1) */
+#define ID_USART0         8 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+#define ID_USART1         9 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+#define ID_USART2        10 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+#define ID_USART3        11 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+#define ID_ADCIFE        12 /**< \brief ADC controller interface (ADCIFE) */
+#define ID_DACC          13 /**< \brief DAC Controller (DACC) */
+#define ID_ACIFC         14 /**< \brief Analog Comparator Interface (ACIFC) */
+#define ID_GLOC          15 /**< \brief Glue Logic Controller (GLOC) */
+#define ID_ABDACB        16 /**< \brief Audio Bitstream DAC (ABDACB) */
+#define ID_TRNG          17 /**< \brief True Random Number Generator (TRNG) */
+#define ID_PARC          18 /**< \brief Parallel Capture (PARC) */
+#define ID_CATB          19 /**< \brief Capacitive Touch Module B (CATB) */
+#define ID_TWIM2         21 /**< \brief Two-wire Master Interface 2 (TWIM2) */
+#define ID_TWIM3         22 /**< \brief Two-wire Master Interface 3 (TWIM3) */
+#define ID_LCDCA         23 /**< \brief LCD Controller (LCDCA) */
+
+// Peripheral instances on HTOP1 bridge
+#define ID_HFLASHC       32 /**< \brief Flash Controller (HFLASHC) */
+#define ID_HCACHE        33 /**< \brief Cortex M I&D Cache Controller (HCACHE) */
+#define ID_HMATRIX       34 /**< \brief HSB Matrix (HMATRIX) */
+#define ID_PDCA          35 /**< \brief Peripheral DMA Controller (PDCA) */
+#define ID_SMAP          36 /**< \brief System Manager Access Port (SMAP) */
+#define ID_CRCCU         37 /**< \brief CRC Calculation Unit (CRCCU) */
+#define ID_USBC          38 /**< \brief USB 2.0 Interface (USBC) */
+#define ID_PEVC          39 /**< \brief Peripheral Event Controller (PEVC) */
+
+// Peripheral instances on HTOP2 bridge
+#define ID_PM            64 /**< \brief Power Manager (PM) */
+#define ID_CHIPID        65 /**< \brief Chip ID Registers (CHIPID) */
+#define ID_SCIF          66 /**< \brief System Control Interface (SCIF) */
+#define ID_FREQM         67 /**< \brief Frequency Meter (FREQM) */
+#define ID_GPIO          68 /**< \brief General-Purpose Input/Output Controller (GPIO) */
+
+// Peripheral instances on HTOP3 bridge
+#define ID_BPM           96 /**< \brief Backup Power Manager (BPM) */
+#define ID_BSCIF         97 /**< \brief Backup System Control Interface (BSCIF) */
+#define ID_AST           98 /**< \brief Asynchronous Timer (AST) */
+#define ID_WDT           99 /**< \brief Watchdog Timer (WDT) */
+#define ID_EIC          100 /**< \brief External Interrupt Controller (EIC) */
+#define ID_PICOUART     101 /**< \brief Pico UART (PICOUART) */
+
+// Peripheral instances on AHB (as if on bridge 4)
+#define ID_AESA         128 /**< \brief Advanced Encryption Standard (AESA) */
+
+#define ID_PERIPH_COUNT 129 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAM4LC4A */
+/* ************************************************************************** */
+/** \defgroup SAM4LC4A_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define ABDACB                        (0x40064000) /**< \brief (ABDACB) APB Base Address */
+#define ACIFC                         (0x40040000) /**< \brief (ACIFC) APB Base Address */
+#define ADCIFE                        (0x40038000) /**< \brief (ADCIFE) APB Base Address */
+#define AESA                          (0x400B0000) /**< \brief (AESA) AHB Base Address */
+#define AST                           (0x400F0800) /**< \brief (AST) APB Base Address */
+#define BPM                           (0x400F0000) /**< \brief (BPM) APB Base Address */
+#define BSCIF                         (0x400F0400) /**< \brief (BSCIF) APB Base Address */
+#define CATB                          (0x40070000) /**< \brief (CATB) APB Base Address */
+#define CHIPID                        (0x400E0400) /**< \brief (CHIPID) APB Base Address */
+#define CRCCU                         (0x400A4000) /**< \brief (CRCCU) APB Base Address */
+#define DACC                          (0x4003C000) /**< \brief (DACC) APB Base Address */
+#define EIC                           (0x400F1000) /**< \brief (EIC) APB Base Address */
+#define HFLASHC                       (0x400A0000) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000) /**< \brief (HFLASHC) USER Base Address */
+#define FREQM                         (0x400E0C00) /**< \brief (FREQM) APB Base Address */
+#define GLOC                          (0x40060000) /**< \brief (GLOC) APB Base Address */
+#define GPIO                          (0x400E1000) /**< \brief (GPIO) APB Base Address */
+#define HCACHE                        (0x400A0400) /**< \brief (HCACHE) APB Base Address */
+#define HMATRIX                       (0x400A1000) /**< \brief (HMATRIX) APB Base Address */
+#define IISC                          (0x40004000) /**< \brief (IISC) APB Base Address */
+#define LCDCA                         (0x40080000) /**< \brief (LCDCA) APB Base Address */
+#define PARC                          (0x4006C000) /**< \brief (PARC) APB Base Address */
+#define PDCA                          (0x400A2000) /**< \brief (PDCA) APB Base Address */
+#define PEVC                          (0x400A6000) /**< \brief (PEVC) APB Base Address */
+#define PICOUART                      (0x400F1400) /**< \brief (PICOUART) APB Base Address */
+#define PM                            (0x400E0000) /**< \brief (PM) APB Base Address */
+#define SCIF                          (0x400E0800) /**< \brief (SCIF) APB Base Address */
+#define SMAP                          (0x400A3000) /**< \brief (SMAP) APB Base Address */
+#define SPI                           (0x40008000) /**< \brief (SPI) APB Base Address */
+#define TC0                           (0x40010000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x40014000) /**< \brief (TC1) APB Base Address */
+#define TRNG                          (0x40068000) /**< \brief (TRNG) APB Base Address */
+#define TWIM0                         (0x40018000) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1                         (0x4001C000) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2                         (0x40078000) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3                         (0x4007C000) /**< \brief (TWIM3) APB Base Address */
+#define TWIS0                         (0x40018400) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1                         (0x4001C400) /**< \brief (TWIS1) APB Base Address */
+#define USART0                        (0x40024000) /**< \brief (USART0) APB Base Address */
+#define USART1                        (0x40028000) /**< \brief (USART1) APB Base Address */
+#define USART2                        (0x4002C000) /**< \brief (USART2) APB Base Address */
+#define USART3                        (0x40030000) /**< \brief (USART3) APB Base Address */
+#define USBC                          (0x400A5000) /**< \brief (USBC) APB Base Address */
+#define WDT                           (0x400F0C00) /**< \brief (WDT) APB Base Address */
+#else
+#define ABDACB            ((Abdacb   *)0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_ADDR                   (0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_INST_NUM   1                          /**< \brief (ABDACB) Number of instances */
+#define ABDACB_INSTS      { ABDACB }                 /**< \brief (ABDACB) Instances List */
+
+#define ACIFC             ((Acifc    *)0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_ADDR                    (0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_INST_NUM    1                          /**< \brief (ACIFC) Number of instances */
+#define ACIFC_INSTS       { ACIFC }                  /**< \brief (ACIFC) Instances List */
+
+#define ADCIFE            ((Adcife   *)0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_ADDR                   (0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_INST_NUM   1                          /**< \brief (ADCIFE) Number of instances */
+#define ADCIFE_INSTS      { ADCIFE }                 /**< \brief (ADCIFE) Instances List */
+
+#define AESA              ((Aesa     *)0x400B0000UL) /**< \brief (AESA) AHB Base Address */
+#define AESA_ADDR                     (0x400B0000UL) /**< \brief (AESA) AHB Base Address */
+#define AESA_INST_NUM     1                          /**< \brief (AESA) Number of instances */
+#define AESA_INSTS        { AESA }                   /**< \brief (AESA) Instances List */
+
+#define AST               ((Ast      *)0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_ADDR                      (0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_INST_NUM      1                          /**< \brief (AST) Number of instances */
+#define AST_INSTS         { AST }                    /**< \brief (AST) Instances List */
+
+#define BPM               ((Bpm      *)0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_ADDR                      (0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_INST_NUM      1                          /**< \brief (BPM) Number of instances */
+#define BPM_INSTS         { BPM }                    /**< \brief (BPM) Instances List */
+
+#define BSCIF             ((Bscif    *)0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_ADDR                    (0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_INST_NUM    1                          /**< \brief (BSCIF) Number of instances */
+#define BSCIF_INSTS       { BSCIF }                  /**< \brief (BSCIF) Instances List */
+
+#define CATB              ((Catb     *)0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_ADDR                     (0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_INST_NUM     1                          /**< \brief (CATB) Number of instances */
+#define CATB_INSTS        { CATB }                   /**< \brief (CATB) Instances List */
+
+#define CHIPID            ((Chipid   *)0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_ADDR                   (0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_INST_NUM   1                          /**< \brief (CHIPID) Number of instances */
+#define CHIPID_INSTS      { CHIPID }                 /**< \brief (CHIPID) Instances List */
+
+#define CRCCU             ((Crccu    *)0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_ADDR                    (0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_INST_NUM    1                          /**< \brief (CRCCU) Number of instances */
+#define CRCCU_INSTS       { CRCCU }                  /**< \brief (CRCCU) Instances List */
+
+#define DACC              ((Dacc     *)0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_ADDR                     (0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_INST_NUM     1                          /**< \brief (DACC) Number of instances */
+#define DACC_INSTS        { DACC }                   /**< \brief (DACC) Instances List */
+
+#define EIC               ((Eic      *)0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_ADDR                      (0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define HFLASHC           ((Flashcalw *)0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_ADDR                  (0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_FROW_ADDR             (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define HFLASHC_USER_ADDR             (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define FLASHCALW_INST_NUM 1                          /**< \brief (FLASHCALW) Number of instances */
+#define FLASHCALW_INSTS   { HFLASHC }                /**< \brief (FLASHCALW) Instances List */
+
+#define FREQM             ((Freqm    *)0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_ADDR                    (0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_INST_NUM    1                          /**< \brief (FREQM) Number of instances */
+#define FREQM_INSTS       { FREQM }                  /**< \brief (FREQM) Instances List */
+
+#define GLOC              ((Gloc     *)0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_ADDR                     (0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_INST_NUM     1                          /**< \brief (GLOC) Number of instances */
+#define GLOC_INSTS        { GLOC }                   /**< \brief (GLOC) Instances List */
+
+#define GPIO              ((Gpio     *)0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_ADDR                     (0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_INST_NUM     1                          /**< \brief (GPIO) Number of instances */
+#define GPIO_INSTS        { GPIO }                   /**< \brief (GPIO) Instances List */
+
+#define HCACHE            ((Hcache   *)0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_ADDR                   (0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_INST_NUM   1                          /**< \brief (HCACHE) Number of instances */
+#define HCACHE_INSTS      { HCACHE }                 /**< \brief (HCACHE) Instances List */
+
+#define HMATRIX           ((Hmatrixb *)0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIX_ADDR                  (0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIXB_INST_NUM 1                          /**< \brief (HMATRIXB) Number of instances */
+#define HMATRIXB_INSTS    { HMATRIX }                /**< \brief (HMATRIXB) Instances List */
+
+#define IISC              ((Iisc     *)0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_ADDR                     (0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_INST_NUM     1                          /**< \brief (IISC) Number of instances */
+#define IISC_INSTS        { IISC }                   /**< \brief (IISC) Instances List */
+
+#define LCDCA             ((Lcdca    *)0x40080000UL) /**< \brief (LCDCA) APB Base Address */
+#define LCDCA_ADDR                    (0x40080000UL) /**< \brief (LCDCA) APB Base Address */
+#define LCDCA_INST_NUM    1                          /**< \brief (LCDCA) Number of instances */
+#define LCDCA_INSTS       { LCDCA }                  /**< \brief (LCDCA) Instances List */
+
+#define PARC              ((Parc     *)0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_ADDR                     (0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_INST_NUM     1                          /**< \brief (PARC) Number of instances */
+#define PARC_INSTS        { PARC }                   /**< \brief (PARC) Instances List */
+
+#define PDCA              ((Pdca     *)0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_ADDR                     (0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_INST_NUM     1                          /**< \brief (PDCA) Number of instances */
+#define PDCA_INSTS        { PDCA }                   /**< \brief (PDCA) Instances List */
+
+#define PEVC              ((Pevc     *)0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_ADDR                     (0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_INST_NUM     1                          /**< \brief (PEVC) Number of instances */
+#define PEVC_INSTS        { PEVC }                   /**< \brief (PEVC) Instances List */
+
+#define PICOUART          ((Picouart *)0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_ADDR                 (0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_INST_NUM 1                          /**< \brief (PICOUART) Number of instances */
+#define PICOUART_INSTS    { PICOUART }               /**< \brief (PICOUART) Instances List */
+
+#define PM                ((Pm       *)0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_ADDR                       (0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define SCIF              ((Scif     *)0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_ADDR                     (0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_INST_NUM     1                          /**< \brief (SCIF) Number of instances */
+#define SCIF_INSTS        { SCIF }                   /**< \brief (SCIF) Instances List */
+
+#define SMAP              ((Smap     *)0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_ADDR                     (0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_INST_NUM     1                          /**< \brief (SMAP) Number of instances */
+#define SMAP_INSTS        { SMAP }                   /**< \brief (SMAP) Instances List */
+
+#define SPI               ((Spi      *)0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_ADDR                      (0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_INST_NUM      1                          /**< \brief (SPI) Number of instances */
+#define SPI_INSTS         { SPI }                    /**< \brief (SPI) Instances List */
+
+#define TC0               ((Tc       *)0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC0_ADDR                      (0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC1_ADDR                      (0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC_INST_NUM       2                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1 }               /**< \brief (TC) Instances List */
+
+#define TRNG              ((Trng     *)0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_ADDR                     (0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_INST_NUM     1                          /**< \brief (TRNG) Number of instances */
+#define TRNG_INSTS        { TRNG }                   /**< \brief (TRNG) Instances List */
+
+#define TWIM0             ((Twim     *)0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM0_ADDR                    (0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1             ((Twim     *)0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM1_ADDR                    (0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2             ((Twim     *)0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM2_ADDR                    (0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3             ((Twim     *)0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM3_ADDR                    (0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM_INST_NUM     4                          /**< \brief (TWIM) Number of instances */
+#define TWIM_INSTS        { TWIM0, TWIM1, TWIM2, TWIM3 } /**< \brief (TWIM) Instances List */
+
+#define TWIS0             ((Twis     *)0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS0_ADDR                    (0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1             ((Twis     *)0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS1_ADDR                    (0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS_INST_NUM     2                          /**< \brief (TWIS) Number of instances */
+#define TWIS_INSTS        { TWIS0, TWIS1 }           /**< \brief (TWIS) Instances List */
+
+#define USART0            ((Usart    *)0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART0_ADDR                   (0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART1            ((Usart    *)0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART1_ADDR                   (0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART2            ((Usart    *)0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART2_ADDR                   (0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART3            ((Usart    *)0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART3_ADDR                   (0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART_INST_NUM    4                          /**< \brief (USART) Number of instances */
+#define USART_INSTS       { USART0, USART1, USART2, USART3 } /**< \brief (USART) Instances List */
+
+#define USBC              ((Usbc     *)0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_ADDR                     (0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_INST_NUM     1                          /**< \brief (USBC) Number of instances */
+#define USBC_INSTS        { USBC }                   /**< \brief (USBC) Instances List */
+
+#define WDT               ((Wdt      *)0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_ADDR                      (0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  GPIO DEFINITIONS FOR SAM4LC4A */
+/* ************************************************************************** */
+/** \defgroup SAM4LC4A_gpio GPIO Definitions */
+/*@{*/
+
+#include "pio/sam4lc4a.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  ADDITIONAL DEFINITIONS FOR COMPATIBILITY */
+/* ************************************************************************** */
+/** \addtogroup SAM4LC4A_compat Definitions */
+/*@{*/
+// These defines are used to keep compatibility with existing 
+// sam/drivers/usart implementation from SAM3/4 products with SAM4L product.
+#define US_MR_USART_MODE_HW_HANDSHAKING  US_MR_USART_MODE_HARDWARE
+#define US_MR_USART_MODE_IS07816_T_0     US_MR_USART_MODE_ISO7816_T0
+#define US_MR_USART_MODE_IS07816_T_1     US_MR_USART_MODE_ISO7816_T1
+#define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
+#define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
+#define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_8_BIT      US_MR_CHRL_8
+#define US_MR_PAR_NO          US_MR_PAR_NONE
+#define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI
+#define US_IF                 US_IFR
+#define US_WPSR_WPVS          US_WPSR_WPV_1
+
+#define USBC_UPCFG0_PBK_Msk   (0x1u << USBC_UPCFG0_PBK_Pos)
+
+// These defines for homogeneity with other SAM header files.
+#define CHIP_FREQ_FWS_0       (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 */
+#define CHIP_FREQ_FWS_1       (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 */
+// WARNING NOTE: these are preliminary values.
+#define CHIP_FREQ_FLASH_HSEN_FWS_0 (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 and the FLASH HS mode is enabled */
+#define CHIP_FREQ_FLASH_HSEN_FWS_1 (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 and the FLASH HS mode is enabled */
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/tc implementation from SAM3/4 products with SAM4L product. 
+#define TC_CMR_LDRA_RISING    TC_CMR_LDRA_POS_EDGE_TIOA
+#define TC_CMR_LDRB_FALLING   TC_CMR_LDRB_NEG_EDGE_TIOA
+#define TC_CMR_ETRGEDG_FALLING TC_CMR_ETRGEDG_NEG_EDGE
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/spi implementation from SAM3/4 products with SAM4L product. 
+#define SPI_CSR_BITS_8_BIT    SPI_CSR_BITS_8_BPT
+#define SPI_WPCR_SPIWPKEY_VALUE SPI_WPCR_WPKEY_VALUE
+#define SPI_WPCR_SPIWPEN      SPI_WPCR_WPEN
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/crccu implementation from SAM3/4 products with SAM4L product. 
+#define CRCCU_DMA_EN          CRCCU_DMAEN
+#define CRCCU_DMA_DIS         CRCCU_DMADIS
+#define CRCCU_DMA_SR          CRCCU_DMASR
+#define CRCCU_DMA_IER         CRCCU_DMAIER
+#define CRCCU_DMA_IDR         CRCCU_DMAIDR
+#define CRCCU_DMA_IMR         CRCCU_DMAIMR
+#define CRCCU_DMA_ISR         CRCCU_DMAISR
+#define CRCCU_DMA_EN_DMAEN    CRCCU_DMAEN_DMAEN
+#define CRCCU_DMA_DIS_DMADIS  CRCCU_DMADIS_DMADIS
+#define CRCCU_DMA_SR_DMASR    CRCCU_DMASR_DMASR
+#define CRCCU_DMA_IER_DMAIER  CRCCU_DMAIER_DMAIER
+#define CRCCU_DMA_IDR_DMAIDR  CRCCU_DMAIDR_DMAIDR
+#define CRCCU_DMA_IMR_DMAIMR  CRCCU_DMAIMR_DMAIMR
+#define CRCCU_DMA_ISR_DMAISR  CRCCU_DMAISR_DMAISR
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAM4LC4A */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL(0x00040000) /* 256 kB */
+#define FLASH_PAGE_SIZE       512
+#define FLASH_NB_OF_PAGES     512
+#define FLASH_USER_PAGE_SIZE  512
+#define HRAMC0_SIZE           _UL(0x00008000) /* 32 kB */
+#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+
+#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+
+#define DSU_DID_RESETVALUE    _UL(0xAB0A09E0)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAM4LC4A */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAM4LC4A_H */

--- a/asf/sam/include/sam4l/sam4lc4b.h
+++ b/asf/sam/include/sam4l/sam4lc4b.h
@@ -1,0 +1,913 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAM4LC4B
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LC4B_
+#define _SAM4LC4B_
+
+/**
+ * \ingroup SAM4L_definitions
+ * \addtogroup SAM4LC4B_definitions SAM4LC4B definitions
+ * This file defines all structures and symbols for SAM4LC4B:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#if !defined(_UL)
+#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#endif
+#else
+#if !defined(_UL)
+#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif
+#endif
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAM4LC4B */
+/* ************************************************************************** */
+/** \defgroup SAM4LC4B_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M4 Processor Exceptions Numbers ******************************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn           = -13,/**<  3 Cortex-M4 Hard Fault Interrupt        */
+  MemoryManagement_IRQn    = -12,/**<  4 Cortex-M4 Memory Management Interrupt */
+  BusFault_IRQn            = -11,/**<  5 Cortex-M4 Bus Fault Interrupt         */
+  UsageFault_IRQn          = -10,/**<  6 Cortex-M4 Usage Fault Interrupt       */
+  SVCall_IRQn              = -5, /**< 11 Cortex-M4 SV Call Interrupt           */
+  DebugMonitor_IRQn        = -4, /**< 12 Cortex-M4 Debug Monitor Interrupt     */
+  PendSV_IRQn              = -2, /**< 14 Cortex-M4 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 Cortex-M4 System Tick Interrupt       */
+  /******  SAM4LC4B-specific Interrupt Numbers ***********************/
+  HFLASHC_IRQn             =  0, /**<  0 SAM4LC4B Flash Controller (HFLASHC) */
+  PDCA_0_IRQn              =  1, /**<  1 SAM4LC4B Peripheral DMA Controller (PDCA): PDCA_0 */
+  PDCA_1_IRQn              =  2, /**<  2 SAM4LC4B Peripheral DMA Controller (PDCA): PDCA_1 */
+  PDCA_2_IRQn              =  3, /**<  3 SAM4LC4B Peripheral DMA Controller (PDCA): PDCA_2 */
+  PDCA_3_IRQn              =  4, /**<  4 SAM4LC4B Peripheral DMA Controller (PDCA): PDCA_3 */
+  PDCA_4_IRQn              =  5, /**<  5 SAM4LC4B Peripheral DMA Controller (PDCA): PDCA_4 */
+  PDCA_5_IRQn              =  6, /**<  6 SAM4LC4B Peripheral DMA Controller (PDCA): PDCA_5 */
+  PDCA_6_IRQn              =  7, /**<  7 SAM4LC4B Peripheral DMA Controller (PDCA): PDCA_6 */
+  PDCA_7_IRQn              =  8, /**<  8 SAM4LC4B Peripheral DMA Controller (PDCA): PDCA_7 */
+  PDCA_8_IRQn              =  9, /**<  9 SAM4LC4B Peripheral DMA Controller (PDCA): PDCA_8 */
+  PDCA_9_IRQn              = 10, /**< 10 SAM4LC4B Peripheral DMA Controller (PDCA): PDCA_9 */
+  PDCA_10_IRQn             = 11, /**< 11 SAM4LC4B Peripheral DMA Controller (PDCA): PDCA_10 */
+  PDCA_11_IRQn             = 12, /**< 12 SAM4LC4B Peripheral DMA Controller (PDCA): PDCA_11 */
+  PDCA_12_IRQn             = 13, /**< 13 SAM4LC4B Peripheral DMA Controller (PDCA): PDCA_12 */
+  PDCA_13_IRQn             = 14, /**< 14 SAM4LC4B Peripheral DMA Controller (PDCA): PDCA_13 */
+  PDCA_14_IRQn             = 15, /**< 15 SAM4LC4B Peripheral DMA Controller (PDCA): PDCA_14 */
+  PDCA_15_IRQn             = 16, /**< 16 SAM4LC4B Peripheral DMA Controller (PDCA): PDCA_15 */
+  CRCCU_IRQn               = 17, /**< 17 SAM4LC4B CRC Calculation Unit (CRCCU) */
+  USBC_IRQn                = 18, /**< 18 SAM4LC4B USB 2.0 Interface (USBC) */
+  PEVC_0_IRQn              = 19, /**< 19 SAM4LC4B Peripheral Event Controller (PEVC): PEVC_TR */
+  PEVC_1_IRQn              = 20, /**< 20 SAM4LC4B Peripheral Event Controller (PEVC): PEVC_OV */
+  AESA_IRQn                = 21, /**< 21 SAM4LC4B Advanced Encryption Standard (AESA) */
+  PM_IRQn                  = 22, /**< 22 SAM4LC4B Power Manager (PM) */
+  SCIF_IRQn                = 23, /**< 23 SAM4LC4B System Control Interface (SCIF) */
+  FREQM_IRQn               = 24, /**< 24 SAM4LC4B Frequency Meter (FREQM) */
+  GPIO_0_IRQn              = 25, /**< 25 SAM4LC4B General-Purpose Input/Output Controller (GPIO): GPIO_0 */
+  GPIO_1_IRQn              = 26, /**< 26 SAM4LC4B General-Purpose Input/Output Controller (GPIO): GPIO_1 */
+  GPIO_2_IRQn              = 27, /**< 27 SAM4LC4B General-Purpose Input/Output Controller (GPIO): GPIO_2 */
+  GPIO_3_IRQn              = 28, /**< 28 SAM4LC4B General-Purpose Input/Output Controller (GPIO): GPIO_3 */
+  GPIO_4_IRQn              = 29, /**< 29 SAM4LC4B General-Purpose Input/Output Controller (GPIO): GPIO_4 */
+  GPIO_5_IRQn              = 30, /**< 30 SAM4LC4B General-Purpose Input/Output Controller (GPIO): GPIO_5 */
+  GPIO_6_IRQn              = 31, /**< 31 SAM4LC4B General-Purpose Input/Output Controller (GPIO): GPIO_6 */
+  GPIO_7_IRQn              = 32, /**< 32 SAM4LC4B General-Purpose Input/Output Controller (GPIO): GPIO_7 */
+  GPIO_8_IRQn              = 33, /**< 33 SAM4LC4B General-Purpose Input/Output Controller (GPIO): GPIO_8 */
+  GPIO_9_IRQn              = 34, /**< 34 SAM4LC4B General-Purpose Input/Output Controller (GPIO): GPIO_9 */
+  GPIO_10_IRQn             = 35, /**< 35 SAM4LC4B General-Purpose Input/Output Controller (GPIO): GPIO_10 */
+  GPIO_11_IRQn             = 36, /**< 36 SAM4LC4B General-Purpose Input/Output Controller (GPIO): GPIO_11 */
+  BPM_IRQn                 = 37, /**< 37 SAM4LC4B Backup Power Manager (BPM) */
+  BSCIF_IRQn               = 38, /**< 38 SAM4LC4B Backup System Control Interface (BSCIF) */
+  AST_0_IRQn               = 39, /**< 39 SAM4LC4B Asynchronous Timer (AST): AST_ALARM */
+  AST_1_IRQn               = 40, /**< 40 SAM4LC4B Asynchronous Timer (AST): AST_PER */
+  AST_2_IRQn               = 41, /**< 41 SAM4LC4B Asynchronous Timer (AST): AST_OVF */
+  AST_3_IRQn               = 42, /**< 42 SAM4LC4B Asynchronous Timer (AST): AST_READY */
+  AST_4_IRQn               = 43, /**< 43 SAM4LC4B Asynchronous Timer (AST): AST_CLKREADY */
+  WDT_IRQn                 = 44, /**< 44 SAM4LC4B Watchdog Timer (WDT) */
+  EIC_0_IRQn               = 45, /**< 45 SAM4LC4B External Interrupt Controller (EIC): EIC_1 */
+  EIC_1_IRQn               = 46, /**< 46 SAM4LC4B External Interrupt Controller (EIC): EIC_2 */
+  EIC_2_IRQn               = 47, /**< 47 SAM4LC4B External Interrupt Controller (EIC): EIC_3 */
+  EIC_3_IRQn               = 48, /**< 48 SAM4LC4B External Interrupt Controller (EIC): EIC_4 */
+  EIC_4_IRQn               = 49, /**< 49 SAM4LC4B External Interrupt Controller (EIC): EIC_5 */
+  EIC_5_IRQn               = 50, /**< 50 SAM4LC4B External Interrupt Controller (EIC): EIC_6 */
+  EIC_6_IRQn               = 51, /**< 51 SAM4LC4B External Interrupt Controller (EIC): EIC_7 */
+  EIC_7_IRQn               = 52, /**< 52 SAM4LC4B External Interrupt Controller (EIC): EIC_8 */
+  IISC_IRQn                = 53, /**< 53 SAM4LC4B Inter-IC Sound (I2S) Controller (IISC) */
+  SPI_IRQn                 = 54, /**< 54 SAM4LC4B Serial Peripheral Interface (SPI) */
+  TC0_0_IRQn               = 55, /**< 55 SAM4LC4B Timer/Counter 0 (TC0): TC00 */
+  TC0_1_IRQn               = 56, /**< 56 SAM4LC4B Timer/Counter 0 (TC0): TC01 */
+  TC0_2_IRQn               = 57, /**< 57 SAM4LC4B Timer/Counter 0 (TC0): TC02 */
+  TC1_0_IRQn               = 58, /**< 58 SAM4LC4B Timer/Counter 1 (TC1): TC10 */
+  TC1_1_IRQn               = 59, /**< 59 SAM4LC4B Timer/Counter 1 (TC1): TC11 */
+  TC1_2_IRQn               = 60, /**< 60 SAM4LC4B Timer/Counter 1 (TC1): TC12 */
+  TWIM0_IRQn               = 61, /**< 61 SAM4LC4B Two-wire Master Interface 0 (TWIM0) */
+  TWIS0_IRQn               = 62, /**< 62 SAM4LC4B Two-wire Slave Interface 0 (TWIS0) */
+  TWIM1_IRQn               = 63, /**< 63 SAM4LC4B Two-wire Master Interface 1 (TWIM1) */
+  TWIS1_IRQn               = 64, /**< 64 SAM4LC4B Two-wire Slave Interface 1 (TWIS1) */
+  USART0_IRQn              = 65, /**< 65 SAM4LC4B Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+  USART1_IRQn              = 66, /**< 66 SAM4LC4B Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+  USART2_IRQn              = 67, /**< 67 SAM4LC4B Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+  USART3_IRQn              = 68, /**< 68 SAM4LC4B Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+  ADCIFE_IRQn              = 69, /**< 69 SAM4LC4B ADC controller interface (ADCIFE) */
+  DACC_IRQn                = 70, /**< 70 SAM4LC4B DAC Controller (DACC) */
+  ACIFC_IRQn               = 71, /**< 71 SAM4LC4B Analog Comparator Interface (ACIFC) */
+  ABDACB_IRQn              = 72, /**< 72 SAM4LC4B Audio Bitstream DAC (ABDACB) */
+  TRNG_IRQn                = 73, /**< 73 SAM4LC4B True Random Number Generator (TRNG) */
+  PARC_IRQn                = 74, /**< 74 SAM4LC4B Parallel Capture (PARC) */
+  CATB_IRQn                = 75, /**< 75 SAM4LC4B Capacitive Touch Module B (CATB) */
+  TWIM2_IRQn               = 77, /**< 77 SAM4LC4B Two-wire Master Interface 2 (TWIM2) */
+  TWIM3_IRQn               = 78, /**< 78 SAM4LC4B Two-wire Master Interface 3 (TWIM3) */
+  LCDCA_IRQn               = 79, /**< 79 SAM4LC4B LCD Controller (LCDCA) */
+
+  PERIPH_COUNT_IRQn        = 80  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNMI_Handler;
+  void* pfnHardFault_Handler;
+  void* pfnMemManage_Handler;
+  void* pfnBusFault_Handler;
+  void* pfnUsageFault_Handler;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVC_Handler;
+  void* pfnDebugMon_Handler;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnHFLASHC_Handler;               /*  0 Flash Controller */
+  void* pfnPDCA_0_Handler;                /*  1 Peripheral DMA Controller IRQ 0 */
+  void* pfnPDCA_1_Handler;                /*  2 Peripheral DMA Controller IRQ 1 */
+  void* pfnPDCA_2_Handler;                /*  3 Peripheral DMA Controller IRQ 2 */
+  void* pfnPDCA_3_Handler;                /*  4 Peripheral DMA Controller IRQ 3 */
+  void* pfnPDCA_4_Handler;                /*  5 Peripheral DMA Controller IRQ 4 */
+  void* pfnPDCA_5_Handler;                /*  6 Peripheral DMA Controller IRQ 5 */
+  void* pfnPDCA_6_Handler;                /*  7 Peripheral DMA Controller IRQ 6 */
+  void* pfnPDCA_7_Handler;                /*  8 Peripheral DMA Controller IRQ 7 */
+  void* pfnPDCA_8_Handler;                /*  9 Peripheral DMA Controller IRQ 8 */
+  void* pfnPDCA_9_Handler;                /* 10 Peripheral DMA Controller IRQ 9 */
+  void* pfnPDCA_10_Handler;               /* 11 Peripheral DMA Controller IRQ 10 */
+  void* pfnPDCA_11_Handler;               /* 12 Peripheral DMA Controller IRQ 11 */
+  void* pfnPDCA_12_Handler;               /* 13 Peripheral DMA Controller IRQ 12 */
+  void* pfnPDCA_13_Handler;               /* 14 Peripheral DMA Controller IRQ 13 */
+  void* pfnPDCA_14_Handler;               /* 15 Peripheral DMA Controller IRQ 14 */
+  void* pfnPDCA_15_Handler;               /* 16 Peripheral DMA Controller IRQ 15 */
+  void* pfnCRCCU_Handler;                 /* 17 CRC Calculation Unit */
+  void* pfnUSBC_Handler;                  /* 18 USB 2.0 Interface */
+  void* pfnPEVC_0_Handler;                /* 19 Peripheral Event Controller IRQ 0 */
+  void* pfnPEVC_1_Handler;                /* 20 Peripheral Event Controller IRQ 1 */
+  void* pfnAESA_Handler;                  /* 21 Advanced Encryption Standard */
+  void* pfnPM_Handler;                    /* 22 Power Manager */
+  void* pfnSCIF_Handler;                  /* 23 System Control Interface */
+  void* pfnFREQM_Handler;                 /* 24 Frequency Meter */
+  void* pfnGPIO_0_Handler;                /* 25 General-Purpose Input/Output Controller IRQ 0 */
+  void* pfnGPIO_1_Handler;                /* 26 General-Purpose Input/Output Controller IRQ 1 */
+  void* pfnGPIO_2_Handler;                /* 27 General-Purpose Input/Output Controller IRQ 2 */
+  void* pfnGPIO_3_Handler;                /* 28 General-Purpose Input/Output Controller IRQ 3 */
+  void* pfnGPIO_4_Handler;                /* 29 General-Purpose Input/Output Controller IRQ 4 */
+  void* pfnGPIO_5_Handler;                /* 30 General-Purpose Input/Output Controller IRQ 5 */
+  void* pfnGPIO_6_Handler;                /* 31 General-Purpose Input/Output Controller IRQ 6 */
+  void* pfnGPIO_7_Handler;                /* 32 General-Purpose Input/Output Controller IRQ 7 */
+  void* pfnGPIO_8_Handler;                /* 33 General-Purpose Input/Output Controller IRQ 8 */
+  void* pfnGPIO_9_Handler;                /* 34 General-Purpose Input/Output Controller IRQ 9 */
+  void* pfnGPIO_10_Handler;               /* 35 General-Purpose Input/Output Controller IRQ 10 */
+  void* pfnGPIO_11_Handler;               /* 36 General-Purpose Input/Output Controller IRQ 11 */
+  void* pfnBPM_Handler;                   /* 37 Backup Power Manager */
+  void* pfnBSCIF_Handler;                 /* 38 Backup System Control Interface */
+  void* pfnAST_0_Handler;                 /* 39 Asynchronous Timer IRQ 0 */
+  void* pfnAST_1_Handler;                 /* 40 Asynchronous Timer IRQ 1 */
+  void* pfnAST_2_Handler;                 /* 41 Asynchronous Timer IRQ 2 */
+  void* pfnAST_3_Handler;                 /* 42 Asynchronous Timer IRQ 3 */
+  void* pfnAST_4_Handler;                 /* 43 Asynchronous Timer IRQ 4 */
+  void* pfnWDT_Handler;                   /* 44 Watchdog Timer */
+  void* pfnEIC_0_Handler;                 /* 45 External Interrupt Controller IRQ 0 */
+  void* pfnEIC_1_Handler;                 /* 46 External Interrupt Controller IRQ 1 */
+  void* pfnEIC_2_Handler;                 /* 47 External Interrupt Controller IRQ 2 */
+  void* pfnEIC_3_Handler;                 /* 48 External Interrupt Controller IRQ 3 */
+  void* pfnEIC_4_Handler;                 /* 49 External Interrupt Controller IRQ 4 */
+  void* pfnEIC_5_Handler;                 /* 50 External Interrupt Controller IRQ 5 */
+  void* pfnEIC_6_Handler;                 /* 51 External Interrupt Controller IRQ 6 */
+  void* pfnEIC_7_Handler;                 /* 52 External Interrupt Controller IRQ 7 */
+  void* pfnIISC_Handler;                  /* 53 Inter-IC Sound (I2S) Controller */
+  void* pfnSPI_Handler;                   /* 54 Serial Peripheral Interface */
+  void* pfnTC0_0_Handler;                 /* 55 Timer/Counter 0 IRQ 0 */
+  void* pfnTC0_1_Handler;                 /* 56 Timer/Counter 0 IRQ 1 */
+  void* pfnTC0_2_Handler;                 /* 57 Timer/Counter 0 IRQ 2 */
+  void* pfnTC1_0_Handler;                 /* 58 Timer/Counter 1 IRQ 0 */
+  void* pfnTC1_1_Handler;                 /* 59 Timer/Counter 1 IRQ 1 */
+  void* pfnTC1_2_Handler;                 /* 60 Timer/Counter 1 IRQ 2 */
+  void* pfnTWIM0_Handler;                 /* 61 Two-wire Master Interface 0 */
+  void* pfnTWIS0_Handler;                 /* 62 Two-wire Slave Interface 0 */
+  void* pfnTWIM1_Handler;                 /* 63 Two-wire Master Interface 1 */
+  void* pfnTWIS1_Handler;                 /* 64 Two-wire Slave Interface 1 */
+  void* pfnUSART0_Handler;                /* 65 Universal Synchronous Asynchronous Receiver Transmitter 0 */
+  void* pfnUSART1_Handler;                /* 66 Universal Synchronous Asynchronous Receiver Transmitter 1 */
+  void* pfnUSART2_Handler;                /* 67 Universal Synchronous Asynchronous Receiver Transmitter 2 */
+  void* pfnUSART3_Handler;                /* 68 Universal Synchronous Asynchronous Receiver Transmitter 3 */
+  void* pfnADCIFE_Handler;                /* 69 ADC controller interface */
+  void* pfnDACC_Handler;                  /* 70 DAC Controller */
+  void* pfnACIFC_Handler;                 /* 71 Analog Comparator Interface */
+  void* pfnABDACB_Handler;                /* 72 Audio Bitstream DAC */
+  void* pfnTRNG_Handler;                  /* 73 True Random Number Generator */
+  void* pfnPARC_Handler;                  /* 74 Parallel Capture */
+  void* pfnCATB_Handler;                  /* 75 Capacitive Touch Module B */
+  void* pvReserved76;
+  void* pfnTWIM2_Handler;                 /* 77 Two-wire Master Interface 2 */
+  void* pfnTWIM3_Handler;                 /* 78 Two-wire Master Interface 3 */
+  void* pfnLCDCA_Handler;                 /* 79 LCD Controller */
+} DeviceVectors;
+
+/* Cortex-M4 processor handlers */
+void Reset_Handler               ( void );
+void NMI_Handler                 ( void );
+void HardFault_Handler           ( void );
+void MemManage_Handler           ( void );
+void BusFault_Handler            ( void );
+void UsageFault_Handler          ( void );
+void SVC_Handler                 ( void );
+void DebugMon_Handler            ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void HFLASHC_Handler             ( void );
+void PDCA_0_Handler              ( void );
+void PDCA_1_Handler              ( void );
+void PDCA_2_Handler              ( void );
+void PDCA_3_Handler              ( void );
+void PDCA_4_Handler              ( void );
+void PDCA_5_Handler              ( void );
+void PDCA_6_Handler              ( void );
+void PDCA_7_Handler              ( void );
+void PDCA_8_Handler              ( void );
+void PDCA_9_Handler              ( void );
+void PDCA_10_Handler             ( void );
+void PDCA_11_Handler             ( void );
+void PDCA_12_Handler             ( void );
+void PDCA_13_Handler             ( void );
+void PDCA_14_Handler             ( void );
+void PDCA_15_Handler             ( void );
+void CRCCU_Handler               ( void );
+void USBC_Handler                ( void );
+void PEVC_0_Handler              ( void );
+void PEVC_1_Handler              ( void );
+void AESA_Handler                ( void );
+void PM_Handler                  ( void );
+void SCIF_Handler                ( void );
+void FREQM_Handler               ( void );
+void GPIO_0_Handler              ( void );
+void GPIO_1_Handler              ( void );
+void GPIO_2_Handler              ( void );
+void GPIO_3_Handler              ( void );
+void GPIO_4_Handler              ( void );
+void GPIO_5_Handler              ( void );
+void GPIO_6_Handler              ( void );
+void GPIO_7_Handler              ( void );
+void GPIO_8_Handler              ( void );
+void GPIO_9_Handler              ( void );
+void GPIO_10_Handler             ( void );
+void GPIO_11_Handler             ( void );
+void BPM_Handler                 ( void );
+void BSCIF_Handler               ( void );
+void AST_0_Handler               ( void );
+void AST_1_Handler               ( void );
+void AST_2_Handler               ( void );
+void AST_3_Handler               ( void );
+void AST_4_Handler               ( void );
+void WDT_Handler                 ( void );
+void EIC_0_Handler               ( void );
+void EIC_1_Handler               ( void );
+void EIC_2_Handler               ( void );
+void EIC_3_Handler               ( void );
+void EIC_4_Handler               ( void );
+void EIC_5_Handler               ( void );
+void EIC_6_Handler               ( void );
+void EIC_7_Handler               ( void );
+void IISC_Handler                ( void );
+void SPI_Handler                 ( void );
+void TC0_0_Handler               ( void );
+void TC0_1_Handler               ( void );
+void TC0_2_Handler               ( void );
+void TC1_0_Handler               ( void );
+void TC1_1_Handler               ( void );
+void TC1_2_Handler               ( void );
+void TWIM0_Handler               ( void );
+void TWIS0_Handler               ( void );
+void TWIM1_Handler               ( void );
+void TWIS1_Handler               ( void );
+void USART0_Handler              ( void );
+void USART1_Handler              ( void );
+void USART2_Handler              ( void );
+void USART3_Handler              ( void );
+void ADCIFE_Handler              ( void );
+void DACC_Handler                ( void );
+void ACIFC_Handler               ( void );
+void ABDACB_Handler              ( void );
+void TRNG_Handler                ( void );
+void PARC_Handler                ( void );
+void CATB_Handler                ( void );
+void TWIM2_Handler               ( void );
+void TWIM3_Handler               ( void );
+void LCDCA_Handler               ( void );
+
+/*
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
+ */
+
+#define LITTLE_ENDIAN          1        
+#define __BB_PRESENT           0         /*!< BIT_BANDING present or not */
+#define __CLKGATE_PRESENT      1         /*!< CLKGATE present or not */
+#define __CM4_REV              1         /*!< Core revision r0p1 */
+#define __DEBUG_LVL            3         /*!< Full debug plus DWT data matching */
+#define __FPU_PRESENT          0         /*!< FPU present or not */
+#define __JTAG_PRESENT         1         /*!< JTAG present or not */
+#define __MPU_PRESENT          1         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       4         /*!< Number of bits used for Priority Levels */
+#define __TRACE_LVL            1         /*!< Standard trace: ITM and DWT triggers and counters, but no ETM */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+#define __WIC_PRESENT          0         /*!< WIC present or not */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm4.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_sam4l.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAM4LC4B */
+/* ************************************************************************** */
+/** \defgroup SAM4LC4B_api Peripheral Software API */
+/*@{*/
+
+#include "component/abdacb.h"
+#include "component/acifc.h"
+#include "component/adcife.h"
+#include "component/aesa.h"
+#include "component/ast.h"
+#include "component/bpm.h"
+#include "component/bscif.h"
+#include "component/catb.h"
+#include "component/chipid.h"
+#include "component/crccu.h"
+#include "component/dacc.h"
+#include "component/eic.h"
+#include "component/flashcalw.h"
+#include "component/freqm.h"
+#include "component/gloc.h"
+#include "component/gpio.h"
+#include "component/hcache.h"
+#include "component/hmatrixb.h"
+#include "component/iisc.h"
+#include "component/lcdca.h"
+#include "component/parc.h"
+#include "component/pdca.h"
+#include "component/pevc.h"
+#include "component/picouart.h"
+#include "component/pm.h"
+#include "component/scif.h"
+#include "component/smap.h"
+#include "component/spi.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twim.h"
+#include "component/twis.h"
+#include "component/usart.h"
+#include "component/usbc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAM4LC4B */
+/* ************************************************************************** */
+/** \defgroup SAM4LC4B_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/abdacb.h"
+#include "instance/acifc.h"
+#include "instance/adcife.h"
+#include "instance/aesa.h"
+#include "instance/ast.h"
+#include "instance/bpm.h"
+#include "instance/bscif.h"
+#include "instance/catb.h"
+#include "instance/chipid.h"
+#include "instance/crccu.h"
+#include "instance/dacc.h"
+#include "instance/eic.h"
+#include "instance/hflashc.h"
+#include "instance/freqm.h"
+#include "instance/gloc.h"
+#include "instance/gpio.h"
+#include "instance/hcache.h"
+#include "instance/hmatrix.h"
+#include "instance/iisc.h"
+#include "instance/lcdca.h"
+#include "instance/parc.h"
+#include "instance/pdca.h"
+#include "instance/pevc.h"
+#include "instance/picouart.h"
+#include "instance/pm.h"
+#include "instance/scif.h"
+#include "instance/smap.h"
+#include "instance/spi.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/trng.h"
+#include "instance/twim0.h"
+#include "instance/twim1.h"
+#include "instance/twim2.h"
+#include "instance/twim3.h"
+#include "instance/twis0.h"
+#include "instance/twis1.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usart3.h"
+#include "instance/usbc.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAM4LC4B */
+/* ************************************************************************** */
+/** \defgroup SAM4LC4B_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HTOP0 bridge
+#define ID_IISC           0 /**< \brief Inter-IC Sound (I2S) Controller (IISC) */
+#define ID_SPI            1 /**< \brief Serial Peripheral Interface (SPI) */
+#define ID_TC0            2 /**< \brief Timer/Counter 0 (TC0) */
+#define ID_TC1            3 /**< \brief Timer/Counter 1 (TC1) */
+#define ID_TWIM0          4 /**< \brief Two-wire Master Interface 0 (TWIM0) */
+#define ID_TWIS0          5 /**< \brief Two-wire Slave Interface 0 (TWIS0) */
+#define ID_TWIM1          6 /**< \brief Two-wire Master Interface 1 (TWIM1) */
+#define ID_TWIS1          7 /**< \brief Two-wire Slave Interface 1 (TWIS1) */
+#define ID_USART0         8 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+#define ID_USART1         9 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+#define ID_USART2        10 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+#define ID_USART3        11 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+#define ID_ADCIFE        12 /**< \brief ADC controller interface (ADCIFE) */
+#define ID_DACC          13 /**< \brief DAC Controller (DACC) */
+#define ID_ACIFC         14 /**< \brief Analog Comparator Interface (ACIFC) */
+#define ID_GLOC          15 /**< \brief Glue Logic Controller (GLOC) */
+#define ID_ABDACB        16 /**< \brief Audio Bitstream DAC (ABDACB) */
+#define ID_TRNG          17 /**< \brief True Random Number Generator (TRNG) */
+#define ID_PARC          18 /**< \brief Parallel Capture (PARC) */
+#define ID_CATB          19 /**< \brief Capacitive Touch Module B (CATB) */
+#define ID_TWIM2         21 /**< \brief Two-wire Master Interface 2 (TWIM2) */
+#define ID_TWIM3         22 /**< \brief Two-wire Master Interface 3 (TWIM3) */
+#define ID_LCDCA         23 /**< \brief LCD Controller (LCDCA) */
+
+// Peripheral instances on HTOP1 bridge
+#define ID_HFLASHC       32 /**< \brief Flash Controller (HFLASHC) */
+#define ID_HCACHE        33 /**< \brief Cortex M I&D Cache Controller (HCACHE) */
+#define ID_HMATRIX       34 /**< \brief HSB Matrix (HMATRIX) */
+#define ID_PDCA          35 /**< \brief Peripheral DMA Controller (PDCA) */
+#define ID_SMAP          36 /**< \brief System Manager Access Port (SMAP) */
+#define ID_CRCCU         37 /**< \brief CRC Calculation Unit (CRCCU) */
+#define ID_USBC          38 /**< \brief USB 2.0 Interface (USBC) */
+#define ID_PEVC          39 /**< \brief Peripheral Event Controller (PEVC) */
+
+// Peripheral instances on HTOP2 bridge
+#define ID_PM            64 /**< \brief Power Manager (PM) */
+#define ID_CHIPID        65 /**< \brief Chip ID Registers (CHIPID) */
+#define ID_SCIF          66 /**< \brief System Control Interface (SCIF) */
+#define ID_FREQM         67 /**< \brief Frequency Meter (FREQM) */
+#define ID_GPIO          68 /**< \brief General-Purpose Input/Output Controller (GPIO) */
+
+// Peripheral instances on HTOP3 bridge
+#define ID_BPM           96 /**< \brief Backup Power Manager (BPM) */
+#define ID_BSCIF         97 /**< \brief Backup System Control Interface (BSCIF) */
+#define ID_AST           98 /**< \brief Asynchronous Timer (AST) */
+#define ID_WDT           99 /**< \brief Watchdog Timer (WDT) */
+#define ID_EIC          100 /**< \brief External Interrupt Controller (EIC) */
+#define ID_PICOUART     101 /**< \brief Pico UART (PICOUART) */
+
+// Peripheral instances on AHB (as if on bridge 4)
+#define ID_AESA         128 /**< \brief Advanced Encryption Standard (AESA) */
+
+#define ID_PERIPH_COUNT 129 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAM4LC4B */
+/* ************************************************************************** */
+/** \defgroup SAM4LC4B_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define ABDACB                        (0x40064000) /**< \brief (ABDACB) APB Base Address */
+#define ACIFC                         (0x40040000) /**< \brief (ACIFC) APB Base Address */
+#define ADCIFE                        (0x40038000) /**< \brief (ADCIFE) APB Base Address */
+#define AESA                          (0x400B0000) /**< \brief (AESA) AHB Base Address */
+#define AST                           (0x400F0800) /**< \brief (AST) APB Base Address */
+#define BPM                           (0x400F0000) /**< \brief (BPM) APB Base Address */
+#define BSCIF                         (0x400F0400) /**< \brief (BSCIF) APB Base Address */
+#define CATB                          (0x40070000) /**< \brief (CATB) APB Base Address */
+#define CHIPID                        (0x400E0400) /**< \brief (CHIPID) APB Base Address */
+#define CRCCU                         (0x400A4000) /**< \brief (CRCCU) APB Base Address */
+#define DACC                          (0x4003C000) /**< \brief (DACC) APB Base Address */
+#define EIC                           (0x400F1000) /**< \brief (EIC) APB Base Address */
+#define HFLASHC                       (0x400A0000) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000) /**< \brief (HFLASHC) USER Base Address */
+#define FREQM                         (0x400E0C00) /**< \brief (FREQM) APB Base Address */
+#define GLOC                          (0x40060000) /**< \brief (GLOC) APB Base Address */
+#define GPIO                          (0x400E1000) /**< \brief (GPIO) APB Base Address */
+#define HCACHE                        (0x400A0400) /**< \brief (HCACHE) APB Base Address */
+#define HMATRIX                       (0x400A1000) /**< \brief (HMATRIX) APB Base Address */
+#define IISC                          (0x40004000) /**< \brief (IISC) APB Base Address */
+#define LCDCA                         (0x40080000) /**< \brief (LCDCA) APB Base Address */
+#define PARC                          (0x4006C000) /**< \brief (PARC) APB Base Address */
+#define PDCA                          (0x400A2000) /**< \brief (PDCA) APB Base Address */
+#define PEVC                          (0x400A6000) /**< \brief (PEVC) APB Base Address */
+#define PICOUART                      (0x400F1400) /**< \brief (PICOUART) APB Base Address */
+#define PM                            (0x400E0000) /**< \brief (PM) APB Base Address */
+#define SCIF                          (0x400E0800) /**< \brief (SCIF) APB Base Address */
+#define SMAP                          (0x400A3000) /**< \brief (SMAP) APB Base Address */
+#define SPI                           (0x40008000) /**< \brief (SPI) APB Base Address */
+#define TC0                           (0x40010000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x40014000) /**< \brief (TC1) APB Base Address */
+#define TRNG                          (0x40068000) /**< \brief (TRNG) APB Base Address */
+#define TWIM0                         (0x40018000) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1                         (0x4001C000) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2                         (0x40078000) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3                         (0x4007C000) /**< \brief (TWIM3) APB Base Address */
+#define TWIS0                         (0x40018400) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1                         (0x4001C400) /**< \brief (TWIS1) APB Base Address */
+#define USART0                        (0x40024000) /**< \brief (USART0) APB Base Address */
+#define USART1                        (0x40028000) /**< \brief (USART1) APB Base Address */
+#define USART2                        (0x4002C000) /**< \brief (USART2) APB Base Address */
+#define USART3                        (0x40030000) /**< \brief (USART3) APB Base Address */
+#define USBC                          (0x400A5000) /**< \brief (USBC) APB Base Address */
+#define WDT                           (0x400F0C00) /**< \brief (WDT) APB Base Address */
+#else
+#define ABDACB            ((Abdacb   *)0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_ADDR                   (0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_INST_NUM   1                          /**< \brief (ABDACB) Number of instances */
+#define ABDACB_INSTS      { ABDACB }                 /**< \brief (ABDACB) Instances List */
+
+#define ACIFC             ((Acifc    *)0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_ADDR                    (0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_INST_NUM    1                          /**< \brief (ACIFC) Number of instances */
+#define ACIFC_INSTS       { ACIFC }                  /**< \brief (ACIFC) Instances List */
+
+#define ADCIFE            ((Adcife   *)0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_ADDR                   (0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_INST_NUM   1                          /**< \brief (ADCIFE) Number of instances */
+#define ADCIFE_INSTS      { ADCIFE }                 /**< \brief (ADCIFE) Instances List */
+
+#define AESA              ((Aesa     *)0x400B0000UL) /**< \brief (AESA) AHB Base Address */
+#define AESA_ADDR                     (0x400B0000UL) /**< \brief (AESA) AHB Base Address */
+#define AESA_INST_NUM     1                          /**< \brief (AESA) Number of instances */
+#define AESA_INSTS        { AESA }                   /**< \brief (AESA) Instances List */
+
+#define AST               ((Ast      *)0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_ADDR                      (0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_INST_NUM      1                          /**< \brief (AST) Number of instances */
+#define AST_INSTS         { AST }                    /**< \brief (AST) Instances List */
+
+#define BPM               ((Bpm      *)0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_ADDR                      (0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_INST_NUM      1                          /**< \brief (BPM) Number of instances */
+#define BPM_INSTS         { BPM }                    /**< \brief (BPM) Instances List */
+
+#define BSCIF             ((Bscif    *)0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_ADDR                    (0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_INST_NUM    1                          /**< \brief (BSCIF) Number of instances */
+#define BSCIF_INSTS       { BSCIF }                  /**< \brief (BSCIF) Instances List */
+
+#define CATB              ((Catb     *)0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_ADDR                     (0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_INST_NUM     1                          /**< \brief (CATB) Number of instances */
+#define CATB_INSTS        { CATB }                   /**< \brief (CATB) Instances List */
+
+#define CHIPID            ((Chipid   *)0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_ADDR                   (0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_INST_NUM   1                          /**< \brief (CHIPID) Number of instances */
+#define CHIPID_INSTS      { CHIPID }                 /**< \brief (CHIPID) Instances List */
+
+#define CRCCU             ((Crccu    *)0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_ADDR                    (0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_INST_NUM    1                          /**< \brief (CRCCU) Number of instances */
+#define CRCCU_INSTS       { CRCCU }                  /**< \brief (CRCCU) Instances List */
+
+#define DACC              ((Dacc     *)0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_ADDR                     (0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_INST_NUM     1                          /**< \brief (DACC) Number of instances */
+#define DACC_INSTS        { DACC }                   /**< \brief (DACC) Instances List */
+
+#define EIC               ((Eic      *)0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_ADDR                      (0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define HFLASHC           ((Flashcalw *)0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_ADDR                  (0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_FROW_ADDR             (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define HFLASHC_USER_ADDR             (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define FLASHCALW_INST_NUM 1                          /**< \brief (FLASHCALW) Number of instances */
+#define FLASHCALW_INSTS   { HFLASHC }                /**< \brief (FLASHCALW) Instances List */
+
+#define FREQM             ((Freqm    *)0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_ADDR                    (0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_INST_NUM    1                          /**< \brief (FREQM) Number of instances */
+#define FREQM_INSTS       { FREQM }                  /**< \brief (FREQM) Instances List */
+
+#define GLOC              ((Gloc     *)0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_ADDR                     (0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_INST_NUM     1                          /**< \brief (GLOC) Number of instances */
+#define GLOC_INSTS        { GLOC }                   /**< \brief (GLOC) Instances List */
+
+#define GPIO              ((Gpio     *)0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_ADDR                     (0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_INST_NUM     1                          /**< \brief (GPIO) Number of instances */
+#define GPIO_INSTS        { GPIO }                   /**< \brief (GPIO) Instances List */
+
+#define HCACHE            ((Hcache   *)0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_ADDR                   (0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_INST_NUM   1                          /**< \brief (HCACHE) Number of instances */
+#define HCACHE_INSTS      { HCACHE }                 /**< \brief (HCACHE) Instances List */
+
+#define HMATRIX           ((Hmatrixb *)0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIX_ADDR                  (0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIXB_INST_NUM 1                          /**< \brief (HMATRIXB) Number of instances */
+#define HMATRIXB_INSTS    { HMATRIX }                /**< \brief (HMATRIXB) Instances List */
+
+#define IISC              ((Iisc     *)0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_ADDR                     (0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_INST_NUM     1                          /**< \brief (IISC) Number of instances */
+#define IISC_INSTS        { IISC }                   /**< \brief (IISC) Instances List */
+
+#define LCDCA             ((Lcdca    *)0x40080000UL) /**< \brief (LCDCA) APB Base Address */
+#define LCDCA_ADDR                    (0x40080000UL) /**< \brief (LCDCA) APB Base Address */
+#define LCDCA_INST_NUM    1                          /**< \brief (LCDCA) Number of instances */
+#define LCDCA_INSTS       { LCDCA }                  /**< \brief (LCDCA) Instances List */
+
+#define PARC              ((Parc     *)0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_ADDR                     (0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_INST_NUM     1                          /**< \brief (PARC) Number of instances */
+#define PARC_INSTS        { PARC }                   /**< \brief (PARC) Instances List */
+
+#define PDCA              ((Pdca     *)0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_ADDR                     (0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_INST_NUM     1                          /**< \brief (PDCA) Number of instances */
+#define PDCA_INSTS        { PDCA }                   /**< \brief (PDCA) Instances List */
+
+#define PEVC              ((Pevc     *)0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_ADDR                     (0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_INST_NUM     1                          /**< \brief (PEVC) Number of instances */
+#define PEVC_INSTS        { PEVC }                   /**< \brief (PEVC) Instances List */
+
+#define PICOUART          ((Picouart *)0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_ADDR                 (0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_INST_NUM 1                          /**< \brief (PICOUART) Number of instances */
+#define PICOUART_INSTS    { PICOUART }               /**< \brief (PICOUART) Instances List */
+
+#define PM                ((Pm       *)0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_ADDR                       (0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define SCIF              ((Scif     *)0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_ADDR                     (0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_INST_NUM     1                          /**< \brief (SCIF) Number of instances */
+#define SCIF_INSTS        { SCIF }                   /**< \brief (SCIF) Instances List */
+
+#define SMAP              ((Smap     *)0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_ADDR                     (0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_INST_NUM     1                          /**< \brief (SMAP) Number of instances */
+#define SMAP_INSTS        { SMAP }                   /**< \brief (SMAP) Instances List */
+
+#define SPI               ((Spi      *)0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_ADDR                      (0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_INST_NUM      1                          /**< \brief (SPI) Number of instances */
+#define SPI_INSTS         { SPI }                    /**< \brief (SPI) Instances List */
+
+#define TC0               ((Tc       *)0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC0_ADDR                      (0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC1_ADDR                      (0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC_INST_NUM       2                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1 }               /**< \brief (TC) Instances List */
+
+#define TRNG              ((Trng     *)0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_ADDR                     (0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_INST_NUM     1                          /**< \brief (TRNG) Number of instances */
+#define TRNG_INSTS        { TRNG }                   /**< \brief (TRNG) Instances List */
+
+#define TWIM0             ((Twim     *)0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM0_ADDR                    (0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1             ((Twim     *)0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM1_ADDR                    (0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2             ((Twim     *)0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM2_ADDR                    (0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3             ((Twim     *)0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM3_ADDR                    (0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM_INST_NUM     4                          /**< \brief (TWIM) Number of instances */
+#define TWIM_INSTS        { TWIM0, TWIM1, TWIM2, TWIM3 } /**< \brief (TWIM) Instances List */
+
+#define TWIS0             ((Twis     *)0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS0_ADDR                    (0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1             ((Twis     *)0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS1_ADDR                    (0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS_INST_NUM     2                          /**< \brief (TWIS) Number of instances */
+#define TWIS_INSTS        { TWIS0, TWIS1 }           /**< \brief (TWIS) Instances List */
+
+#define USART0            ((Usart    *)0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART0_ADDR                   (0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART1            ((Usart    *)0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART1_ADDR                   (0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART2            ((Usart    *)0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART2_ADDR                   (0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART3            ((Usart    *)0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART3_ADDR                   (0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART_INST_NUM    4                          /**< \brief (USART) Number of instances */
+#define USART_INSTS       { USART0, USART1, USART2, USART3 } /**< \brief (USART) Instances List */
+
+#define USBC              ((Usbc     *)0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_ADDR                     (0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_INST_NUM     1                          /**< \brief (USBC) Number of instances */
+#define USBC_INSTS        { USBC }                   /**< \brief (USBC) Instances List */
+
+#define WDT               ((Wdt      *)0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_ADDR                      (0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  GPIO DEFINITIONS FOR SAM4LC4B */
+/* ************************************************************************** */
+/** \defgroup SAM4LC4B_gpio GPIO Definitions */
+/*@{*/
+
+#include "pio/sam4lc4b.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  ADDITIONAL DEFINITIONS FOR COMPATIBILITY */
+/* ************************************************************************** */
+/** \addtogroup SAM4LC4B_compat Definitions */
+/*@{*/
+// These defines are used to keep compatibility with existing 
+// sam/drivers/usart implementation from SAM3/4 products with SAM4L product.
+#define US_MR_USART_MODE_HW_HANDSHAKING  US_MR_USART_MODE_HARDWARE
+#define US_MR_USART_MODE_IS07816_T_0     US_MR_USART_MODE_ISO7816_T0
+#define US_MR_USART_MODE_IS07816_T_1     US_MR_USART_MODE_ISO7816_T1
+#define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
+#define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
+#define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_8_BIT      US_MR_CHRL_8
+#define US_MR_PAR_NO          US_MR_PAR_NONE
+#define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI
+#define US_IF                 US_IFR
+#define US_WPSR_WPVS          US_WPSR_WPV_1
+
+#define USBC_UPCFG0_PBK_Msk   (0x1u << USBC_UPCFG0_PBK_Pos)
+
+// These defines for homogeneity with other SAM header files.
+#define CHIP_FREQ_FWS_0       (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 */
+#define CHIP_FREQ_FWS_1       (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 */
+// WARNING NOTE: these are preliminary values.
+#define CHIP_FREQ_FLASH_HSEN_FWS_0 (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 and the FLASH HS mode is enabled */
+#define CHIP_FREQ_FLASH_HSEN_FWS_1 (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 and the FLASH HS mode is enabled */
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/tc implementation from SAM3/4 products with SAM4L product. 
+#define TC_CMR_LDRA_RISING    TC_CMR_LDRA_POS_EDGE_TIOA
+#define TC_CMR_LDRB_FALLING   TC_CMR_LDRB_NEG_EDGE_TIOA
+#define TC_CMR_ETRGEDG_FALLING TC_CMR_ETRGEDG_NEG_EDGE
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/spi implementation from SAM3/4 products with SAM4L product. 
+#define SPI_CSR_BITS_8_BIT    SPI_CSR_BITS_8_BPT
+#define SPI_WPCR_SPIWPKEY_VALUE SPI_WPCR_WPKEY_VALUE
+#define SPI_WPCR_SPIWPEN      SPI_WPCR_WPEN
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/crccu implementation from SAM3/4 products with SAM4L product. 
+#define CRCCU_DMA_EN          CRCCU_DMAEN
+#define CRCCU_DMA_DIS         CRCCU_DMADIS
+#define CRCCU_DMA_SR          CRCCU_DMASR
+#define CRCCU_DMA_IER         CRCCU_DMAIER
+#define CRCCU_DMA_IDR         CRCCU_DMAIDR
+#define CRCCU_DMA_IMR         CRCCU_DMAIMR
+#define CRCCU_DMA_ISR         CRCCU_DMAISR
+#define CRCCU_DMA_EN_DMAEN    CRCCU_DMAEN_DMAEN
+#define CRCCU_DMA_DIS_DMADIS  CRCCU_DMADIS_DMADIS
+#define CRCCU_DMA_SR_DMASR    CRCCU_DMASR_DMASR
+#define CRCCU_DMA_IER_DMAIER  CRCCU_DMAIER_DMAIER
+#define CRCCU_DMA_IDR_DMAIDR  CRCCU_DMAIDR_DMAIDR
+#define CRCCU_DMA_IMR_DMAIMR  CRCCU_DMAIMR_DMAIMR
+#define CRCCU_DMA_ISR_DMAISR  CRCCU_DMAISR_DMAISR
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAM4LC4B */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL(0x00040000) /* 256 kB */
+#define FLASH_PAGE_SIZE       512
+#define FLASH_NB_OF_PAGES     512
+#define FLASH_USER_PAGE_SIZE  512
+#define HRAMC0_SIZE           _UL(0x00008000) /* 32 kB */
+#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+
+#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+
+#define DSU_DID_RESETVALUE    _UL(0xAB0A09E0)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAM4LC4B */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAM4LC4B_H */

--- a/asf/sam/include/sam4l/sam4lc4b.h
+++ b/asf/sam/include/sam4l/sam4lc4b.h
@@ -62,15 +62,15 @@ typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volati
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
 #if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#define _U_(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
 #if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#define _U_(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 
@@ -881,23 +881,23 @@ void LCDCA_Handler               ( void );
 /**  MEMORY MAPPING DEFINITIONS FOR SAM4LC4B */
 /* ************************************************************************** */
 
-#define FLASH_SIZE            _UL(0x00040000) /* 256 kB */
+#define FLASH_SIZE            _UL_(0x00040000) /* 256 kB */
 #define FLASH_PAGE_SIZE       512
 #define FLASH_NB_OF_PAGES     512
 #define FLASH_USER_PAGE_SIZE  512
-#define HRAMC0_SIZE           _UL(0x00008000) /* 32 kB */
-#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+#define HRAMC0_SIZE           _UL_(0x00008000) /* 32 kB */
+#define HRAMC1_SIZE           _UL_(0x00000800) /* 2 kB */
 
-#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
-#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
-#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
-#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
-#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
-#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
-#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
-#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL_(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL_(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL_(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL_(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL_(0x400F0000) /**< HTOP3 base address */
 
-#define DSU_DID_RESETVALUE    _UL(0xAB0A09E0)
+#define DSU_DID_RESETVALUE    _UL_(0xAB0A09E0)
 
 /* ************************************************************************** */
 /**  ELECTRICAL DEFINITIONS FOR SAM4LC4B */

--- a/asf/sam/include/sam4l/sam4lc4c.h
+++ b/asf/sam/include/sam4l/sam4lc4c.h
@@ -1,0 +1,913 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAM4LC4C
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LC4C_
+#define _SAM4LC4C_
+
+/**
+ * \ingroup SAM4L_definitions
+ * \addtogroup SAM4LC4C_definitions SAM4LC4C definitions
+ * This file defines all structures and symbols for SAM4LC4C:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#if !defined(_UL)
+#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#endif
+#else
+#if !defined(_UL)
+#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif
+#endif
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAM4LC4C */
+/* ************************************************************************** */
+/** \defgroup SAM4LC4C_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M4 Processor Exceptions Numbers ******************************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn           = -13,/**<  3 Cortex-M4 Hard Fault Interrupt        */
+  MemoryManagement_IRQn    = -12,/**<  4 Cortex-M4 Memory Management Interrupt */
+  BusFault_IRQn            = -11,/**<  5 Cortex-M4 Bus Fault Interrupt         */
+  UsageFault_IRQn          = -10,/**<  6 Cortex-M4 Usage Fault Interrupt       */
+  SVCall_IRQn              = -5, /**< 11 Cortex-M4 SV Call Interrupt           */
+  DebugMonitor_IRQn        = -4, /**< 12 Cortex-M4 Debug Monitor Interrupt     */
+  PendSV_IRQn              = -2, /**< 14 Cortex-M4 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 Cortex-M4 System Tick Interrupt       */
+  /******  SAM4LC4C-specific Interrupt Numbers ***********************/
+  HFLASHC_IRQn             =  0, /**<  0 SAM4LC4C Flash Controller (HFLASHC) */
+  PDCA_0_IRQn              =  1, /**<  1 SAM4LC4C Peripheral DMA Controller (PDCA): PDCA_0 */
+  PDCA_1_IRQn              =  2, /**<  2 SAM4LC4C Peripheral DMA Controller (PDCA): PDCA_1 */
+  PDCA_2_IRQn              =  3, /**<  3 SAM4LC4C Peripheral DMA Controller (PDCA): PDCA_2 */
+  PDCA_3_IRQn              =  4, /**<  4 SAM4LC4C Peripheral DMA Controller (PDCA): PDCA_3 */
+  PDCA_4_IRQn              =  5, /**<  5 SAM4LC4C Peripheral DMA Controller (PDCA): PDCA_4 */
+  PDCA_5_IRQn              =  6, /**<  6 SAM4LC4C Peripheral DMA Controller (PDCA): PDCA_5 */
+  PDCA_6_IRQn              =  7, /**<  7 SAM4LC4C Peripheral DMA Controller (PDCA): PDCA_6 */
+  PDCA_7_IRQn              =  8, /**<  8 SAM4LC4C Peripheral DMA Controller (PDCA): PDCA_7 */
+  PDCA_8_IRQn              =  9, /**<  9 SAM4LC4C Peripheral DMA Controller (PDCA): PDCA_8 */
+  PDCA_9_IRQn              = 10, /**< 10 SAM4LC4C Peripheral DMA Controller (PDCA): PDCA_9 */
+  PDCA_10_IRQn             = 11, /**< 11 SAM4LC4C Peripheral DMA Controller (PDCA): PDCA_10 */
+  PDCA_11_IRQn             = 12, /**< 12 SAM4LC4C Peripheral DMA Controller (PDCA): PDCA_11 */
+  PDCA_12_IRQn             = 13, /**< 13 SAM4LC4C Peripheral DMA Controller (PDCA): PDCA_12 */
+  PDCA_13_IRQn             = 14, /**< 14 SAM4LC4C Peripheral DMA Controller (PDCA): PDCA_13 */
+  PDCA_14_IRQn             = 15, /**< 15 SAM4LC4C Peripheral DMA Controller (PDCA): PDCA_14 */
+  PDCA_15_IRQn             = 16, /**< 16 SAM4LC4C Peripheral DMA Controller (PDCA): PDCA_15 */
+  CRCCU_IRQn               = 17, /**< 17 SAM4LC4C CRC Calculation Unit (CRCCU) */
+  USBC_IRQn                = 18, /**< 18 SAM4LC4C USB 2.0 Interface (USBC) */
+  PEVC_0_IRQn              = 19, /**< 19 SAM4LC4C Peripheral Event Controller (PEVC): PEVC_TR */
+  PEVC_1_IRQn              = 20, /**< 20 SAM4LC4C Peripheral Event Controller (PEVC): PEVC_OV */
+  AESA_IRQn                = 21, /**< 21 SAM4LC4C Advanced Encryption Standard (AESA) */
+  PM_IRQn                  = 22, /**< 22 SAM4LC4C Power Manager (PM) */
+  SCIF_IRQn                = 23, /**< 23 SAM4LC4C System Control Interface (SCIF) */
+  FREQM_IRQn               = 24, /**< 24 SAM4LC4C Frequency Meter (FREQM) */
+  GPIO_0_IRQn              = 25, /**< 25 SAM4LC4C General-Purpose Input/Output Controller (GPIO): GPIO_0 */
+  GPIO_1_IRQn              = 26, /**< 26 SAM4LC4C General-Purpose Input/Output Controller (GPIO): GPIO_1 */
+  GPIO_2_IRQn              = 27, /**< 27 SAM4LC4C General-Purpose Input/Output Controller (GPIO): GPIO_2 */
+  GPIO_3_IRQn              = 28, /**< 28 SAM4LC4C General-Purpose Input/Output Controller (GPIO): GPIO_3 */
+  GPIO_4_IRQn              = 29, /**< 29 SAM4LC4C General-Purpose Input/Output Controller (GPIO): GPIO_4 */
+  GPIO_5_IRQn              = 30, /**< 30 SAM4LC4C General-Purpose Input/Output Controller (GPIO): GPIO_5 */
+  GPIO_6_IRQn              = 31, /**< 31 SAM4LC4C General-Purpose Input/Output Controller (GPIO): GPIO_6 */
+  GPIO_7_IRQn              = 32, /**< 32 SAM4LC4C General-Purpose Input/Output Controller (GPIO): GPIO_7 */
+  GPIO_8_IRQn              = 33, /**< 33 SAM4LC4C General-Purpose Input/Output Controller (GPIO): GPIO_8 */
+  GPIO_9_IRQn              = 34, /**< 34 SAM4LC4C General-Purpose Input/Output Controller (GPIO): GPIO_9 */
+  GPIO_10_IRQn             = 35, /**< 35 SAM4LC4C General-Purpose Input/Output Controller (GPIO): GPIO_10 */
+  GPIO_11_IRQn             = 36, /**< 36 SAM4LC4C General-Purpose Input/Output Controller (GPIO): GPIO_11 */
+  BPM_IRQn                 = 37, /**< 37 SAM4LC4C Backup Power Manager (BPM) */
+  BSCIF_IRQn               = 38, /**< 38 SAM4LC4C Backup System Control Interface (BSCIF) */
+  AST_0_IRQn               = 39, /**< 39 SAM4LC4C Asynchronous Timer (AST): AST_ALARM */
+  AST_1_IRQn               = 40, /**< 40 SAM4LC4C Asynchronous Timer (AST): AST_PER */
+  AST_2_IRQn               = 41, /**< 41 SAM4LC4C Asynchronous Timer (AST): AST_OVF */
+  AST_3_IRQn               = 42, /**< 42 SAM4LC4C Asynchronous Timer (AST): AST_READY */
+  AST_4_IRQn               = 43, /**< 43 SAM4LC4C Asynchronous Timer (AST): AST_CLKREADY */
+  WDT_IRQn                 = 44, /**< 44 SAM4LC4C Watchdog Timer (WDT) */
+  EIC_0_IRQn               = 45, /**< 45 SAM4LC4C External Interrupt Controller (EIC): EIC_1 */
+  EIC_1_IRQn               = 46, /**< 46 SAM4LC4C External Interrupt Controller (EIC): EIC_2 */
+  EIC_2_IRQn               = 47, /**< 47 SAM4LC4C External Interrupt Controller (EIC): EIC_3 */
+  EIC_3_IRQn               = 48, /**< 48 SAM4LC4C External Interrupt Controller (EIC): EIC_4 */
+  EIC_4_IRQn               = 49, /**< 49 SAM4LC4C External Interrupt Controller (EIC): EIC_5 */
+  EIC_5_IRQn               = 50, /**< 50 SAM4LC4C External Interrupt Controller (EIC): EIC_6 */
+  EIC_6_IRQn               = 51, /**< 51 SAM4LC4C External Interrupt Controller (EIC): EIC_7 */
+  EIC_7_IRQn               = 52, /**< 52 SAM4LC4C External Interrupt Controller (EIC): EIC_8 */
+  IISC_IRQn                = 53, /**< 53 SAM4LC4C Inter-IC Sound (I2S) Controller (IISC) */
+  SPI_IRQn                 = 54, /**< 54 SAM4LC4C Serial Peripheral Interface (SPI) */
+  TC0_0_IRQn               = 55, /**< 55 SAM4LC4C Timer/Counter 0 (TC0): TC00 */
+  TC0_1_IRQn               = 56, /**< 56 SAM4LC4C Timer/Counter 0 (TC0): TC01 */
+  TC0_2_IRQn               = 57, /**< 57 SAM4LC4C Timer/Counter 0 (TC0): TC02 */
+  TC1_0_IRQn               = 58, /**< 58 SAM4LC4C Timer/Counter 1 (TC1): TC10 */
+  TC1_1_IRQn               = 59, /**< 59 SAM4LC4C Timer/Counter 1 (TC1): TC11 */
+  TC1_2_IRQn               = 60, /**< 60 SAM4LC4C Timer/Counter 1 (TC1): TC12 */
+  TWIM0_IRQn               = 61, /**< 61 SAM4LC4C Two-wire Master Interface 0 (TWIM0) */
+  TWIS0_IRQn               = 62, /**< 62 SAM4LC4C Two-wire Slave Interface 0 (TWIS0) */
+  TWIM1_IRQn               = 63, /**< 63 SAM4LC4C Two-wire Master Interface 1 (TWIM1) */
+  TWIS1_IRQn               = 64, /**< 64 SAM4LC4C Two-wire Slave Interface 1 (TWIS1) */
+  USART0_IRQn              = 65, /**< 65 SAM4LC4C Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+  USART1_IRQn              = 66, /**< 66 SAM4LC4C Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+  USART2_IRQn              = 67, /**< 67 SAM4LC4C Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+  USART3_IRQn              = 68, /**< 68 SAM4LC4C Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+  ADCIFE_IRQn              = 69, /**< 69 SAM4LC4C ADC controller interface (ADCIFE) */
+  DACC_IRQn                = 70, /**< 70 SAM4LC4C DAC Controller (DACC) */
+  ACIFC_IRQn               = 71, /**< 71 SAM4LC4C Analog Comparator Interface (ACIFC) */
+  ABDACB_IRQn              = 72, /**< 72 SAM4LC4C Audio Bitstream DAC (ABDACB) */
+  TRNG_IRQn                = 73, /**< 73 SAM4LC4C True Random Number Generator (TRNG) */
+  PARC_IRQn                = 74, /**< 74 SAM4LC4C Parallel Capture (PARC) */
+  CATB_IRQn                = 75, /**< 75 SAM4LC4C Capacitive Touch Module B (CATB) */
+  TWIM2_IRQn               = 77, /**< 77 SAM4LC4C Two-wire Master Interface 2 (TWIM2) */
+  TWIM3_IRQn               = 78, /**< 78 SAM4LC4C Two-wire Master Interface 3 (TWIM3) */
+  LCDCA_IRQn               = 79, /**< 79 SAM4LC4C LCD Controller (LCDCA) */
+
+  PERIPH_COUNT_IRQn        = 80  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNMI_Handler;
+  void* pfnHardFault_Handler;
+  void* pfnMemManage_Handler;
+  void* pfnBusFault_Handler;
+  void* pfnUsageFault_Handler;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVC_Handler;
+  void* pfnDebugMon_Handler;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnHFLASHC_Handler;               /*  0 Flash Controller */
+  void* pfnPDCA_0_Handler;                /*  1 Peripheral DMA Controller IRQ 0 */
+  void* pfnPDCA_1_Handler;                /*  2 Peripheral DMA Controller IRQ 1 */
+  void* pfnPDCA_2_Handler;                /*  3 Peripheral DMA Controller IRQ 2 */
+  void* pfnPDCA_3_Handler;                /*  4 Peripheral DMA Controller IRQ 3 */
+  void* pfnPDCA_4_Handler;                /*  5 Peripheral DMA Controller IRQ 4 */
+  void* pfnPDCA_5_Handler;                /*  6 Peripheral DMA Controller IRQ 5 */
+  void* pfnPDCA_6_Handler;                /*  7 Peripheral DMA Controller IRQ 6 */
+  void* pfnPDCA_7_Handler;                /*  8 Peripheral DMA Controller IRQ 7 */
+  void* pfnPDCA_8_Handler;                /*  9 Peripheral DMA Controller IRQ 8 */
+  void* pfnPDCA_9_Handler;                /* 10 Peripheral DMA Controller IRQ 9 */
+  void* pfnPDCA_10_Handler;               /* 11 Peripheral DMA Controller IRQ 10 */
+  void* pfnPDCA_11_Handler;               /* 12 Peripheral DMA Controller IRQ 11 */
+  void* pfnPDCA_12_Handler;               /* 13 Peripheral DMA Controller IRQ 12 */
+  void* pfnPDCA_13_Handler;               /* 14 Peripheral DMA Controller IRQ 13 */
+  void* pfnPDCA_14_Handler;               /* 15 Peripheral DMA Controller IRQ 14 */
+  void* pfnPDCA_15_Handler;               /* 16 Peripheral DMA Controller IRQ 15 */
+  void* pfnCRCCU_Handler;                 /* 17 CRC Calculation Unit */
+  void* pfnUSBC_Handler;                  /* 18 USB 2.0 Interface */
+  void* pfnPEVC_0_Handler;                /* 19 Peripheral Event Controller IRQ 0 */
+  void* pfnPEVC_1_Handler;                /* 20 Peripheral Event Controller IRQ 1 */
+  void* pfnAESA_Handler;                  /* 21 Advanced Encryption Standard */
+  void* pfnPM_Handler;                    /* 22 Power Manager */
+  void* pfnSCIF_Handler;                  /* 23 System Control Interface */
+  void* pfnFREQM_Handler;                 /* 24 Frequency Meter */
+  void* pfnGPIO_0_Handler;                /* 25 General-Purpose Input/Output Controller IRQ 0 */
+  void* pfnGPIO_1_Handler;                /* 26 General-Purpose Input/Output Controller IRQ 1 */
+  void* pfnGPIO_2_Handler;                /* 27 General-Purpose Input/Output Controller IRQ 2 */
+  void* pfnGPIO_3_Handler;                /* 28 General-Purpose Input/Output Controller IRQ 3 */
+  void* pfnGPIO_4_Handler;                /* 29 General-Purpose Input/Output Controller IRQ 4 */
+  void* pfnGPIO_5_Handler;                /* 30 General-Purpose Input/Output Controller IRQ 5 */
+  void* pfnGPIO_6_Handler;                /* 31 General-Purpose Input/Output Controller IRQ 6 */
+  void* pfnGPIO_7_Handler;                /* 32 General-Purpose Input/Output Controller IRQ 7 */
+  void* pfnGPIO_8_Handler;                /* 33 General-Purpose Input/Output Controller IRQ 8 */
+  void* pfnGPIO_9_Handler;                /* 34 General-Purpose Input/Output Controller IRQ 9 */
+  void* pfnGPIO_10_Handler;               /* 35 General-Purpose Input/Output Controller IRQ 10 */
+  void* pfnGPIO_11_Handler;               /* 36 General-Purpose Input/Output Controller IRQ 11 */
+  void* pfnBPM_Handler;                   /* 37 Backup Power Manager */
+  void* pfnBSCIF_Handler;                 /* 38 Backup System Control Interface */
+  void* pfnAST_0_Handler;                 /* 39 Asynchronous Timer IRQ 0 */
+  void* pfnAST_1_Handler;                 /* 40 Asynchronous Timer IRQ 1 */
+  void* pfnAST_2_Handler;                 /* 41 Asynchronous Timer IRQ 2 */
+  void* pfnAST_3_Handler;                 /* 42 Asynchronous Timer IRQ 3 */
+  void* pfnAST_4_Handler;                 /* 43 Asynchronous Timer IRQ 4 */
+  void* pfnWDT_Handler;                   /* 44 Watchdog Timer */
+  void* pfnEIC_0_Handler;                 /* 45 External Interrupt Controller IRQ 0 */
+  void* pfnEIC_1_Handler;                 /* 46 External Interrupt Controller IRQ 1 */
+  void* pfnEIC_2_Handler;                 /* 47 External Interrupt Controller IRQ 2 */
+  void* pfnEIC_3_Handler;                 /* 48 External Interrupt Controller IRQ 3 */
+  void* pfnEIC_4_Handler;                 /* 49 External Interrupt Controller IRQ 4 */
+  void* pfnEIC_5_Handler;                 /* 50 External Interrupt Controller IRQ 5 */
+  void* pfnEIC_6_Handler;                 /* 51 External Interrupt Controller IRQ 6 */
+  void* pfnEIC_7_Handler;                 /* 52 External Interrupt Controller IRQ 7 */
+  void* pfnIISC_Handler;                  /* 53 Inter-IC Sound (I2S) Controller */
+  void* pfnSPI_Handler;                   /* 54 Serial Peripheral Interface */
+  void* pfnTC0_0_Handler;                 /* 55 Timer/Counter 0 IRQ 0 */
+  void* pfnTC0_1_Handler;                 /* 56 Timer/Counter 0 IRQ 1 */
+  void* pfnTC0_2_Handler;                 /* 57 Timer/Counter 0 IRQ 2 */
+  void* pfnTC1_0_Handler;                 /* 58 Timer/Counter 1 IRQ 0 */
+  void* pfnTC1_1_Handler;                 /* 59 Timer/Counter 1 IRQ 1 */
+  void* pfnTC1_2_Handler;                 /* 60 Timer/Counter 1 IRQ 2 */
+  void* pfnTWIM0_Handler;                 /* 61 Two-wire Master Interface 0 */
+  void* pfnTWIS0_Handler;                 /* 62 Two-wire Slave Interface 0 */
+  void* pfnTWIM1_Handler;                 /* 63 Two-wire Master Interface 1 */
+  void* pfnTWIS1_Handler;                 /* 64 Two-wire Slave Interface 1 */
+  void* pfnUSART0_Handler;                /* 65 Universal Synchronous Asynchronous Receiver Transmitter 0 */
+  void* pfnUSART1_Handler;                /* 66 Universal Synchronous Asynchronous Receiver Transmitter 1 */
+  void* pfnUSART2_Handler;                /* 67 Universal Synchronous Asynchronous Receiver Transmitter 2 */
+  void* pfnUSART3_Handler;                /* 68 Universal Synchronous Asynchronous Receiver Transmitter 3 */
+  void* pfnADCIFE_Handler;                /* 69 ADC controller interface */
+  void* pfnDACC_Handler;                  /* 70 DAC Controller */
+  void* pfnACIFC_Handler;                 /* 71 Analog Comparator Interface */
+  void* pfnABDACB_Handler;                /* 72 Audio Bitstream DAC */
+  void* pfnTRNG_Handler;                  /* 73 True Random Number Generator */
+  void* pfnPARC_Handler;                  /* 74 Parallel Capture */
+  void* pfnCATB_Handler;                  /* 75 Capacitive Touch Module B */
+  void* pvReserved76;
+  void* pfnTWIM2_Handler;                 /* 77 Two-wire Master Interface 2 */
+  void* pfnTWIM3_Handler;                 /* 78 Two-wire Master Interface 3 */
+  void* pfnLCDCA_Handler;                 /* 79 LCD Controller */
+} DeviceVectors;
+
+/* Cortex-M4 processor handlers */
+void Reset_Handler               ( void );
+void NMI_Handler                 ( void );
+void HardFault_Handler           ( void );
+void MemManage_Handler           ( void );
+void BusFault_Handler            ( void );
+void UsageFault_Handler          ( void );
+void SVC_Handler                 ( void );
+void DebugMon_Handler            ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void HFLASHC_Handler             ( void );
+void PDCA_0_Handler              ( void );
+void PDCA_1_Handler              ( void );
+void PDCA_2_Handler              ( void );
+void PDCA_3_Handler              ( void );
+void PDCA_4_Handler              ( void );
+void PDCA_5_Handler              ( void );
+void PDCA_6_Handler              ( void );
+void PDCA_7_Handler              ( void );
+void PDCA_8_Handler              ( void );
+void PDCA_9_Handler              ( void );
+void PDCA_10_Handler             ( void );
+void PDCA_11_Handler             ( void );
+void PDCA_12_Handler             ( void );
+void PDCA_13_Handler             ( void );
+void PDCA_14_Handler             ( void );
+void PDCA_15_Handler             ( void );
+void CRCCU_Handler               ( void );
+void USBC_Handler                ( void );
+void PEVC_0_Handler              ( void );
+void PEVC_1_Handler              ( void );
+void AESA_Handler                ( void );
+void PM_Handler                  ( void );
+void SCIF_Handler                ( void );
+void FREQM_Handler               ( void );
+void GPIO_0_Handler              ( void );
+void GPIO_1_Handler              ( void );
+void GPIO_2_Handler              ( void );
+void GPIO_3_Handler              ( void );
+void GPIO_4_Handler              ( void );
+void GPIO_5_Handler              ( void );
+void GPIO_6_Handler              ( void );
+void GPIO_7_Handler              ( void );
+void GPIO_8_Handler              ( void );
+void GPIO_9_Handler              ( void );
+void GPIO_10_Handler             ( void );
+void GPIO_11_Handler             ( void );
+void BPM_Handler                 ( void );
+void BSCIF_Handler               ( void );
+void AST_0_Handler               ( void );
+void AST_1_Handler               ( void );
+void AST_2_Handler               ( void );
+void AST_3_Handler               ( void );
+void AST_4_Handler               ( void );
+void WDT_Handler                 ( void );
+void EIC_0_Handler               ( void );
+void EIC_1_Handler               ( void );
+void EIC_2_Handler               ( void );
+void EIC_3_Handler               ( void );
+void EIC_4_Handler               ( void );
+void EIC_5_Handler               ( void );
+void EIC_6_Handler               ( void );
+void EIC_7_Handler               ( void );
+void IISC_Handler                ( void );
+void SPI_Handler                 ( void );
+void TC0_0_Handler               ( void );
+void TC0_1_Handler               ( void );
+void TC0_2_Handler               ( void );
+void TC1_0_Handler               ( void );
+void TC1_1_Handler               ( void );
+void TC1_2_Handler               ( void );
+void TWIM0_Handler               ( void );
+void TWIS0_Handler               ( void );
+void TWIM1_Handler               ( void );
+void TWIS1_Handler               ( void );
+void USART0_Handler              ( void );
+void USART1_Handler              ( void );
+void USART2_Handler              ( void );
+void USART3_Handler              ( void );
+void ADCIFE_Handler              ( void );
+void DACC_Handler                ( void );
+void ACIFC_Handler               ( void );
+void ABDACB_Handler              ( void );
+void TRNG_Handler                ( void );
+void PARC_Handler                ( void );
+void CATB_Handler                ( void );
+void TWIM2_Handler               ( void );
+void TWIM3_Handler               ( void );
+void LCDCA_Handler               ( void );
+
+/*
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
+ */
+
+#define LITTLE_ENDIAN          1        
+#define __BB_PRESENT           0         /*!< BIT_BANDING present or not */
+#define __CLKGATE_PRESENT      1         /*!< CLKGATE present or not */
+#define __CM4_REV              1         /*!< Core revision r0p1 */
+#define __DEBUG_LVL            3         /*!< Full debug plus DWT data matching */
+#define __FPU_PRESENT          0         /*!< FPU present or not */
+#define __JTAG_PRESENT         1         /*!< JTAG present or not */
+#define __MPU_PRESENT          1         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       4         /*!< Number of bits used for Priority Levels */
+#define __TRACE_LVL            1         /*!< Standard trace: ITM and DWT triggers and counters, but no ETM */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+#define __WIC_PRESENT          0         /*!< WIC present or not */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm4.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_sam4l.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAM4LC4C */
+/* ************************************************************************** */
+/** \defgroup SAM4LC4C_api Peripheral Software API */
+/*@{*/
+
+#include "component/abdacb.h"
+#include "component/acifc.h"
+#include "component/adcife.h"
+#include "component/aesa.h"
+#include "component/ast.h"
+#include "component/bpm.h"
+#include "component/bscif.h"
+#include "component/catb.h"
+#include "component/chipid.h"
+#include "component/crccu.h"
+#include "component/dacc.h"
+#include "component/eic.h"
+#include "component/flashcalw.h"
+#include "component/freqm.h"
+#include "component/gloc.h"
+#include "component/gpio.h"
+#include "component/hcache.h"
+#include "component/hmatrixb.h"
+#include "component/iisc.h"
+#include "component/lcdca.h"
+#include "component/parc.h"
+#include "component/pdca.h"
+#include "component/pevc.h"
+#include "component/picouart.h"
+#include "component/pm.h"
+#include "component/scif.h"
+#include "component/smap.h"
+#include "component/spi.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twim.h"
+#include "component/twis.h"
+#include "component/usart.h"
+#include "component/usbc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAM4LC4C */
+/* ************************************************************************** */
+/** \defgroup SAM4LC4C_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/abdacb.h"
+#include "instance/acifc.h"
+#include "instance/adcife.h"
+#include "instance/aesa.h"
+#include "instance/ast.h"
+#include "instance/bpm.h"
+#include "instance/bscif.h"
+#include "instance/catb.h"
+#include "instance/chipid.h"
+#include "instance/crccu.h"
+#include "instance/dacc.h"
+#include "instance/eic.h"
+#include "instance/hflashc.h"
+#include "instance/freqm.h"
+#include "instance/gloc.h"
+#include "instance/gpio.h"
+#include "instance/hcache.h"
+#include "instance/hmatrix.h"
+#include "instance/iisc.h"
+#include "instance/lcdca.h"
+#include "instance/parc.h"
+#include "instance/pdca.h"
+#include "instance/pevc.h"
+#include "instance/picouart.h"
+#include "instance/pm.h"
+#include "instance/scif.h"
+#include "instance/smap.h"
+#include "instance/spi.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/trng.h"
+#include "instance/twim0.h"
+#include "instance/twim1.h"
+#include "instance/twim2.h"
+#include "instance/twim3.h"
+#include "instance/twis0.h"
+#include "instance/twis1.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usart3.h"
+#include "instance/usbc.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAM4LC4C */
+/* ************************************************************************** */
+/** \defgroup SAM4LC4C_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HTOP0 bridge
+#define ID_IISC           0 /**< \brief Inter-IC Sound (I2S) Controller (IISC) */
+#define ID_SPI            1 /**< \brief Serial Peripheral Interface (SPI) */
+#define ID_TC0            2 /**< \brief Timer/Counter 0 (TC0) */
+#define ID_TC1            3 /**< \brief Timer/Counter 1 (TC1) */
+#define ID_TWIM0          4 /**< \brief Two-wire Master Interface 0 (TWIM0) */
+#define ID_TWIS0          5 /**< \brief Two-wire Slave Interface 0 (TWIS0) */
+#define ID_TWIM1          6 /**< \brief Two-wire Master Interface 1 (TWIM1) */
+#define ID_TWIS1          7 /**< \brief Two-wire Slave Interface 1 (TWIS1) */
+#define ID_USART0         8 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+#define ID_USART1         9 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+#define ID_USART2        10 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+#define ID_USART3        11 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+#define ID_ADCIFE        12 /**< \brief ADC controller interface (ADCIFE) */
+#define ID_DACC          13 /**< \brief DAC Controller (DACC) */
+#define ID_ACIFC         14 /**< \brief Analog Comparator Interface (ACIFC) */
+#define ID_GLOC          15 /**< \brief Glue Logic Controller (GLOC) */
+#define ID_ABDACB        16 /**< \brief Audio Bitstream DAC (ABDACB) */
+#define ID_TRNG          17 /**< \brief True Random Number Generator (TRNG) */
+#define ID_PARC          18 /**< \brief Parallel Capture (PARC) */
+#define ID_CATB          19 /**< \brief Capacitive Touch Module B (CATB) */
+#define ID_TWIM2         21 /**< \brief Two-wire Master Interface 2 (TWIM2) */
+#define ID_TWIM3         22 /**< \brief Two-wire Master Interface 3 (TWIM3) */
+#define ID_LCDCA         23 /**< \brief LCD Controller (LCDCA) */
+
+// Peripheral instances on HTOP1 bridge
+#define ID_HFLASHC       32 /**< \brief Flash Controller (HFLASHC) */
+#define ID_HCACHE        33 /**< \brief Cortex M I&D Cache Controller (HCACHE) */
+#define ID_HMATRIX       34 /**< \brief HSB Matrix (HMATRIX) */
+#define ID_PDCA          35 /**< \brief Peripheral DMA Controller (PDCA) */
+#define ID_SMAP          36 /**< \brief System Manager Access Port (SMAP) */
+#define ID_CRCCU         37 /**< \brief CRC Calculation Unit (CRCCU) */
+#define ID_USBC          38 /**< \brief USB 2.0 Interface (USBC) */
+#define ID_PEVC          39 /**< \brief Peripheral Event Controller (PEVC) */
+
+// Peripheral instances on HTOP2 bridge
+#define ID_PM            64 /**< \brief Power Manager (PM) */
+#define ID_CHIPID        65 /**< \brief Chip ID Registers (CHIPID) */
+#define ID_SCIF          66 /**< \brief System Control Interface (SCIF) */
+#define ID_FREQM         67 /**< \brief Frequency Meter (FREQM) */
+#define ID_GPIO          68 /**< \brief General-Purpose Input/Output Controller (GPIO) */
+
+// Peripheral instances on HTOP3 bridge
+#define ID_BPM           96 /**< \brief Backup Power Manager (BPM) */
+#define ID_BSCIF         97 /**< \brief Backup System Control Interface (BSCIF) */
+#define ID_AST           98 /**< \brief Asynchronous Timer (AST) */
+#define ID_WDT           99 /**< \brief Watchdog Timer (WDT) */
+#define ID_EIC          100 /**< \brief External Interrupt Controller (EIC) */
+#define ID_PICOUART     101 /**< \brief Pico UART (PICOUART) */
+
+// Peripheral instances on AHB (as if on bridge 4)
+#define ID_AESA         128 /**< \brief Advanced Encryption Standard (AESA) */
+
+#define ID_PERIPH_COUNT 129 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAM4LC4C */
+/* ************************************************************************** */
+/** \defgroup SAM4LC4C_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define ABDACB                        (0x40064000) /**< \brief (ABDACB) APB Base Address */
+#define ACIFC                         (0x40040000) /**< \brief (ACIFC) APB Base Address */
+#define ADCIFE                        (0x40038000) /**< \brief (ADCIFE) APB Base Address */
+#define AESA                          (0x400B0000) /**< \brief (AESA) AHB Base Address */
+#define AST                           (0x400F0800) /**< \brief (AST) APB Base Address */
+#define BPM                           (0x400F0000) /**< \brief (BPM) APB Base Address */
+#define BSCIF                         (0x400F0400) /**< \brief (BSCIF) APB Base Address */
+#define CATB                          (0x40070000) /**< \brief (CATB) APB Base Address */
+#define CHIPID                        (0x400E0400) /**< \brief (CHIPID) APB Base Address */
+#define CRCCU                         (0x400A4000) /**< \brief (CRCCU) APB Base Address */
+#define DACC                          (0x4003C000) /**< \brief (DACC) APB Base Address */
+#define EIC                           (0x400F1000) /**< \brief (EIC) APB Base Address */
+#define HFLASHC                       (0x400A0000) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000) /**< \brief (HFLASHC) USER Base Address */
+#define FREQM                         (0x400E0C00) /**< \brief (FREQM) APB Base Address */
+#define GLOC                          (0x40060000) /**< \brief (GLOC) APB Base Address */
+#define GPIO                          (0x400E1000) /**< \brief (GPIO) APB Base Address */
+#define HCACHE                        (0x400A0400) /**< \brief (HCACHE) APB Base Address */
+#define HMATRIX                       (0x400A1000) /**< \brief (HMATRIX) APB Base Address */
+#define IISC                          (0x40004000) /**< \brief (IISC) APB Base Address */
+#define LCDCA                         (0x40080000) /**< \brief (LCDCA) APB Base Address */
+#define PARC                          (0x4006C000) /**< \brief (PARC) APB Base Address */
+#define PDCA                          (0x400A2000) /**< \brief (PDCA) APB Base Address */
+#define PEVC                          (0x400A6000) /**< \brief (PEVC) APB Base Address */
+#define PICOUART                      (0x400F1400) /**< \brief (PICOUART) APB Base Address */
+#define PM                            (0x400E0000) /**< \brief (PM) APB Base Address */
+#define SCIF                          (0x400E0800) /**< \brief (SCIF) APB Base Address */
+#define SMAP                          (0x400A3000) /**< \brief (SMAP) APB Base Address */
+#define SPI                           (0x40008000) /**< \brief (SPI) APB Base Address */
+#define TC0                           (0x40010000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x40014000) /**< \brief (TC1) APB Base Address */
+#define TRNG                          (0x40068000) /**< \brief (TRNG) APB Base Address */
+#define TWIM0                         (0x40018000) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1                         (0x4001C000) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2                         (0x40078000) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3                         (0x4007C000) /**< \brief (TWIM3) APB Base Address */
+#define TWIS0                         (0x40018400) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1                         (0x4001C400) /**< \brief (TWIS1) APB Base Address */
+#define USART0                        (0x40024000) /**< \brief (USART0) APB Base Address */
+#define USART1                        (0x40028000) /**< \brief (USART1) APB Base Address */
+#define USART2                        (0x4002C000) /**< \brief (USART2) APB Base Address */
+#define USART3                        (0x40030000) /**< \brief (USART3) APB Base Address */
+#define USBC                          (0x400A5000) /**< \brief (USBC) APB Base Address */
+#define WDT                           (0x400F0C00) /**< \brief (WDT) APB Base Address */
+#else
+#define ABDACB            ((Abdacb   *)0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_ADDR                   (0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_INST_NUM   1                          /**< \brief (ABDACB) Number of instances */
+#define ABDACB_INSTS      { ABDACB }                 /**< \brief (ABDACB) Instances List */
+
+#define ACIFC             ((Acifc    *)0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_ADDR                    (0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_INST_NUM    1                          /**< \brief (ACIFC) Number of instances */
+#define ACIFC_INSTS       { ACIFC }                  /**< \brief (ACIFC) Instances List */
+
+#define ADCIFE            ((Adcife   *)0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_ADDR                   (0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_INST_NUM   1                          /**< \brief (ADCIFE) Number of instances */
+#define ADCIFE_INSTS      { ADCIFE }                 /**< \brief (ADCIFE) Instances List */
+
+#define AESA              ((Aesa     *)0x400B0000UL) /**< \brief (AESA) AHB Base Address */
+#define AESA_ADDR                     (0x400B0000UL) /**< \brief (AESA) AHB Base Address */
+#define AESA_INST_NUM     1                          /**< \brief (AESA) Number of instances */
+#define AESA_INSTS        { AESA }                   /**< \brief (AESA) Instances List */
+
+#define AST               ((Ast      *)0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_ADDR                      (0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_INST_NUM      1                          /**< \brief (AST) Number of instances */
+#define AST_INSTS         { AST }                    /**< \brief (AST) Instances List */
+
+#define BPM               ((Bpm      *)0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_ADDR                      (0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_INST_NUM      1                          /**< \brief (BPM) Number of instances */
+#define BPM_INSTS         { BPM }                    /**< \brief (BPM) Instances List */
+
+#define BSCIF             ((Bscif    *)0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_ADDR                    (0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_INST_NUM    1                          /**< \brief (BSCIF) Number of instances */
+#define BSCIF_INSTS       { BSCIF }                  /**< \brief (BSCIF) Instances List */
+
+#define CATB              ((Catb     *)0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_ADDR                     (0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_INST_NUM     1                          /**< \brief (CATB) Number of instances */
+#define CATB_INSTS        { CATB }                   /**< \brief (CATB) Instances List */
+
+#define CHIPID            ((Chipid   *)0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_ADDR                   (0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_INST_NUM   1                          /**< \brief (CHIPID) Number of instances */
+#define CHIPID_INSTS      { CHIPID }                 /**< \brief (CHIPID) Instances List */
+
+#define CRCCU             ((Crccu    *)0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_ADDR                    (0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_INST_NUM    1                          /**< \brief (CRCCU) Number of instances */
+#define CRCCU_INSTS       { CRCCU }                  /**< \brief (CRCCU) Instances List */
+
+#define DACC              ((Dacc     *)0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_ADDR                     (0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_INST_NUM     1                          /**< \brief (DACC) Number of instances */
+#define DACC_INSTS        { DACC }                   /**< \brief (DACC) Instances List */
+
+#define EIC               ((Eic      *)0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_ADDR                      (0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define HFLASHC           ((Flashcalw *)0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_ADDR                  (0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_FROW_ADDR             (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define HFLASHC_USER_ADDR             (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define FLASHCALW_INST_NUM 1                          /**< \brief (FLASHCALW) Number of instances */
+#define FLASHCALW_INSTS   { HFLASHC }                /**< \brief (FLASHCALW) Instances List */
+
+#define FREQM             ((Freqm    *)0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_ADDR                    (0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_INST_NUM    1                          /**< \brief (FREQM) Number of instances */
+#define FREQM_INSTS       { FREQM }                  /**< \brief (FREQM) Instances List */
+
+#define GLOC              ((Gloc     *)0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_ADDR                     (0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_INST_NUM     1                          /**< \brief (GLOC) Number of instances */
+#define GLOC_INSTS        { GLOC }                   /**< \brief (GLOC) Instances List */
+
+#define GPIO              ((Gpio     *)0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_ADDR                     (0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_INST_NUM     1                          /**< \brief (GPIO) Number of instances */
+#define GPIO_INSTS        { GPIO }                   /**< \brief (GPIO) Instances List */
+
+#define HCACHE            ((Hcache   *)0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_ADDR                   (0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_INST_NUM   1                          /**< \brief (HCACHE) Number of instances */
+#define HCACHE_INSTS      { HCACHE }                 /**< \brief (HCACHE) Instances List */
+
+#define HMATRIX           ((Hmatrixb *)0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIX_ADDR                  (0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIXB_INST_NUM 1                          /**< \brief (HMATRIXB) Number of instances */
+#define HMATRIXB_INSTS    { HMATRIX }                /**< \brief (HMATRIXB) Instances List */
+
+#define IISC              ((Iisc     *)0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_ADDR                     (0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_INST_NUM     1                          /**< \brief (IISC) Number of instances */
+#define IISC_INSTS        { IISC }                   /**< \brief (IISC) Instances List */
+
+#define LCDCA             ((Lcdca    *)0x40080000UL) /**< \brief (LCDCA) APB Base Address */
+#define LCDCA_ADDR                    (0x40080000UL) /**< \brief (LCDCA) APB Base Address */
+#define LCDCA_INST_NUM    1                          /**< \brief (LCDCA) Number of instances */
+#define LCDCA_INSTS       { LCDCA }                  /**< \brief (LCDCA) Instances List */
+
+#define PARC              ((Parc     *)0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_ADDR                     (0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_INST_NUM     1                          /**< \brief (PARC) Number of instances */
+#define PARC_INSTS        { PARC }                   /**< \brief (PARC) Instances List */
+
+#define PDCA              ((Pdca     *)0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_ADDR                     (0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_INST_NUM     1                          /**< \brief (PDCA) Number of instances */
+#define PDCA_INSTS        { PDCA }                   /**< \brief (PDCA) Instances List */
+
+#define PEVC              ((Pevc     *)0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_ADDR                     (0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_INST_NUM     1                          /**< \brief (PEVC) Number of instances */
+#define PEVC_INSTS        { PEVC }                   /**< \brief (PEVC) Instances List */
+
+#define PICOUART          ((Picouart *)0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_ADDR                 (0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_INST_NUM 1                          /**< \brief (PICOUART) Number of instances */
+#define PICOUART_INSTS    { PICOUART }               /**< \brief (PICOUART) Instances List */
+
+#define PM                ((Pm       *)0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_ADDR                       (0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define SCIF              ((Scif     *)0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_ADDR                     (0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_INST_NUM     1                          /**< \brief (SCIF) Number of instances */
+#define SCIF_INSTS        { SCIF }                   /**< \brief (SCIF) Instances List */
+
+#define SMAP              ((Smap     *)0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_ADDR                     (0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_INST_NUM     1                          /**< \brief (SMAP) Number of instances */
+#define SMAP_INSTS        { SMAP }                   /**< \brief (SMAP) Instances List */
+
+#define SPI               ((Spi      *)0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_ADDR                      (0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_INST_NUM      1                          /**< \brief (SPI) Number of instances */
+#define SPI_INSTS         { SPI }                    /**< \brief (SPI) Instances List */
+
+#define TC0               ((Tc       *)0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC0_ADDR                      (0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC1_ADDR                      (0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC_INST_NUM       2                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1 }               /**< \brief (TC) Instances List */
+
+#define TRNG              ((Trng     *)0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_ADDR                     (0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_INST_NUM     1                          /**< \brief (TRNG) Number of instances */
+#define TRNG_INSTS        { TRNG }                   /**< \brief (TRNG) Instances List */
+
+#define TWIM0             ((Twim     *)0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM0_ADDR                    (0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1             ((Twim     *)0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM1_ADDR                    (0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2             ((Twim     *)0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM2_ADDR                    (0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3             ((Twim     *)0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM3_ADDR                    (0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM_INST_NUM     4                          /**< \brief (TWIM) Number of instances */
+#define TWIM_INSTS        { TWIM0, TWIM1, TWIM2, TWIM3 } /**< \brief (TWIM) Instances List */
+
+#define TWIS0             ((Twis     *)0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS0_ADDR                    (0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1             ((Twis     *)0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS1_ADDR                    (0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS_INST_NUM     2                          /**< \brief (TWIS) Number of instances */
+#define TWIS_INSTS        { TWIS0, TWIS1 }           /**< \brief (TWIS) Instances List */
+
+#define USART0            ((Usart    *)0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART0_ADDR                   (0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART1            ((Usart    *)0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART1_ADDR                   (0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART2            ((Usart    *)0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART2_ADDR                   (0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART3            ((Usart    *)0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART3_ADDR                   (0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART_INST_NUM    4                          /**< \brief (USART) Number of instances */
+#define USART_INSTS       { USART0, USART1, USART2, USART3 } /**< \brief (USART) Instances List */
+
+#define USBC              ((Usbc     *)0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_ADDR                     (0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_INST_NUM     1                          /**< \brief (USBC) Number of instances */
+#define USBC_INSTS        { USBC }                   /**< \brief (USBC) Instances List */
+
+#define WDT               ((Wdt      *)0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_ADDR                      (0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  GPIO DEFINITIONS FOR SAM4LC4C */
+/* ************************************************************************** */
+/** \defgroup SAM4LC4C_gpio GPIO Definitions */
+/*@{*/
+
+#include "pio/sam4lc4c.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  ADDITIONAL DEFINITIONS FOR COMPATIBILITY */
+/* ************************************************************************** */
+/** \addtogroup SAM4LC4C_compat Definitions */
+/*@{*/
+// These defines are used to keep compatibility with existing 
+// sam/drivers/usart implementation from SAM3/4 products with SAM4L product.
+#define US_MR_USART_MODE_HW_HANDSHAKING  US_MR_USART_MODE_HARDWARE
+#define US_MR_USART_MODE_IS07816_T_0     US_MR_USART_MODE_ISO7816_T0
+#define US_MR_USART_MODE_IS07816_T_1     US_MR_USART_MODE_ISO7816_T1
+#define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
+#define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
+#define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_8_BIT      US_MR_CHRL_8
+#define US_MR_PAR_NO          US_MR_PAR_NONE
+#define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI
+#define US_IF                 US_IFR
+#define US_WPSR_WPVS          US_WPSR_WPV_1
+
+#define USBC_UPCFG0_PBK_Msk   (0x1u << USBC_UPCFG0_PBK_Pos)
+
+// These defines for homogeneity with other SAM header files.
+#define CHIP_FREQ_FWS_0       (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 */
+#define CHIP_FREQ_FWS_1       (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 */
+// WARNING NOTE: these are preliminary values.
+#define CHIP_FREQ_FLASH_HSEN_FWS_0 (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 and the FLASH HS mode is enabled */
+#define CHIP_FREQ_FLASH_HSEN_FWS_1 (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 and the FLASH HS mode is enabled */
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/tc implementation from SAM3/4 products with SAM4L product. 
+#define TC_CMR_LDRA_RISING    TC_CMR_LDRA_POS_EDGE_TIOA
+#define TC_CMR_LDRB_FALLING   TC_CMR_LDRB_NEG_EDGE_TIOA
+#define TC_CMR_ETRGEDG_FALLING TC_CMR_ETRGEDG_NEG_EDGE
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/spi implementation from SAM3/4 products with SAM4L product. 
+#define SPI_CSR_BITS_8_BIT    SPI_CSR_BITS_8_BPT
+#define SPI_WPCR_SPIWPKEY_VALUE SPI_WPCR_WPKEY_VALUE
+#define SPI_WPCR_SPIWPEN      SPI_WPCR_WPEN
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/crccu implementation from SAM3/4 products with SAM4L product. 
+#define CRCCU_DMA_EN          CRCCU_DMAEN
+#define CRCCU_DMA_DIS         CRCCU_DMADIS
+#define CRCCU_DMA_SR          CRCCU_DMASR
+#define CRCCU_DMA_IER         CRCCU_DMAIER
+#define CRCCU_DMA_IDR         CRCCU_DMAIDR
+#define CRCCU_DMA_IMR         CRCCU_DMAIMR
+#define CRCCU_DMA_ISR         CRCCU_DMAISR
+#define CRCCU_DMA_EN_DMAEN    CRCCU_DMAEN_DMAEN
+#define CRCCU_DMA_DIS_DMADIS  CRCCU_DMADIS_DMADIS
+#define CRCCU_DMA_SR_DMASR    CRCCU_DMASR_DMASR
+#define CRCCU_DMA_IER_DMAIER  CRCCU_DMAIER_DMAIER
+#define CRCCU_DMA_IDR_DMAIDR  CRCCU_DMAIDR_DMAIDR
+#define CRCCU_DMA_IMR_DMAIMR  CRCCU_DMAIMR_DMAIMR
+#define CRCCU_DMA_ISR_DMAISR  CRCCU_DMAISR_DMAISR
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAM4LC4C */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL(0x00040000) /* 256 kB */
+#define FLASH_PAGE_SIZE       512
+#define FLASH_NB_OF_PAGES     512
+#define FLASH_USER_PAGE_SIZE  512
+#define HRAMC0_SIZE           _UL(0x00008000) /* 32 kB */
+#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+
+#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+
+#define DSU_DID_RESETVALUE    _UL(0xAB0A09E0)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAM4LC4C */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAM4LC4C_H */

--- a/asf/sam/include/sam4l/sam4lc4c.h
+++ b/asf/sam/include/sam4l/sam4lc4c.h
@@ -62,15 +62,15 @@ typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volati
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
 #if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#define _U_(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
 #if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#define _U_(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 
@@ -881,23 +881,23 @@ void LCDCA_Handler               ( void );
 /**  MEMORY MAPPING DEFINITIONS FOR SAM4LC4C */
 /* ************************************************************************** */
 
-#define FLASH_SIZE            _UL(0x00040000) /* 256 kB */
+#define FLASH_SIZE            _UL_(0x00040000) /* 256 kB */
 #define FLASH_PAGE_SIZE       512
 #define FLASH_NB_OF_PAGES     512
 #define FLASH_USER_PAGE_SIZE  512
-#define HRAMC0_SIZE           _UL(0x00008000) /* 32 kB */
-#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+#define HRAMC0_SIZE           _UL_(0x00008000) /* 32 kB */
+#define HRAMC1_SIZE           _UL_(0x00000800) /* 2 kB */
 
-#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
-#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
-#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
-#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
-#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
-#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
-#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
-#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL_(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL_(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL_(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL_(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL_(0x400F0000) /**< HTOP3 base address */
 
-#define DSU_DID_RESETVALUE    _UL(0xAB0A09E0)
+#define DSU_DID_RESETVALUE    _UL_(0xAB0A09E0)
 
 /* ************************************************************************** */
 /**  ELECTRICAL DEFINITIONS FOR SAM4LC4C */

--- a/asf/sam/include/sam4l/sam4lc8a.h
+++ b/asf/sam/include/sam4l/sam4lc8a.h
@@ -1,0 +1,913 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAM4LC8A
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LC8A_
+#define _SAM4LC8A_
+
+/**
+ * \ingroup SAM4L_definitions
+ * \addtogroup SAM4LC8A_definitions SAM4LC8A definitions
+ * This file defines all structures and symbols for SAM4LC8A:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#if !defined(_UL)
+#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#endif
+#else
+#if !defined(_UL)
+#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif
+#endif
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAM4LC8A */
+/* ************************************************************************** */
+/** \defgroup SAM4LC8A_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M4 Processor Exceptions Numbers ******************************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn           = -13,/**<  3 Cortex-M4 Hard Fault Interrupt        */
+  MemoryManagement_IRQn    = -12,/**<  4 Cortex-M4 Memory Management Interrupt */
+  BusFault_IRQn            = -11,/**<  5 Cortex-M4 Bus Fault Interrupt         */
+  UsageFault_IRQn          = -10,/**<  6 Cortex-M4 Usage Fault Interrupt       */
+  SVCall_IRQn              = -5, /**< 11 Cortex-M4 SV Call Interrupt           */
+  DebugMonitor_IRQn        = -4, /**< 12 Cortex-M4 Debug Monitor Interrupt     */
+  PendSV_IRQn              = -2, /**< 14 Cortex-M4 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 Cortex-M4 System Tick Interrupt       */
+  /******  SAM4LC8A-specific Interrupt Numbers ***********************/
+  HFLASHC_IRQn             =  0, /**<  0 SAM4LC8A Flash Controller (HFLASHC) */
+  PDCA_0_IRQn              =  1, /**<  1 SAM4LC8A Peripheral DMA Controller (PDCA): PDCA_0 */
+  PDCA_1_IRQn              =  2, /**<  2 SAM4LC8A Peripheral DMA Controller (PDCA): PDCA_1 */
+  PDCA_2_IRQn              =  3, /**<  3 SAM4LC8A Peripheral DMA Controller (PDCA): PDCA_2 */
+  PDCA_3_IRQn              =  4, /**<  4 SAM4LC8A Peripheral DMA Controller (PDCA): PDCA_3 */
+  PDCA_4_IRQn              =  5, /**<  5 SAM4LC8A Peripheral DMA Controller (PDCA): PDCA_4 */
+  PDCA_5_IRQn              =  6, /**<  6 SAM4LC8A Peripheral DMA Controller (PDCA): PDCA_5 */
+  PDCA_6_IRQn              =  7, /**<  7 SAM4LC8A Peripheral DMA Controller (PDCA): PDCA_6 */
+  PDCA_7_IRQn              =  8, /**<  8 SAM4LC8A Peripheral DMA Controller (PDCA): PDCA_7 */
+  PDCA_8_IRQn              =  9, /**<  9 SAM4LC8A Peripheral DMA Controller (PDCA): PDCA_8 */
+  PDCA_9_IRQn              = 10, /**< 10 SAM4LC8A Peripheral DMA Controller (PDCA): PDCA_9 */
+  PDCA_10_IRQn             = 11, /**< 11 SAM4LC8A Peripheral DMA Controller (PDCA): PDCA_10 */
+  PDCA_11_IRQn             = 12, /**< 12 SAM4LC8A Peripheral DMA Controller (PDCA): PDCA_11 */
+  PDCA_12_IRQn             = 13, /**< 13 SAM4LC8A Peripheral DMA Controller (PDCA): PDCA_12 */
+  PDCA_13_IRQn             = 14, /**< 14 SAM4LC8A Peripheral DMA Controller (PDCA): PDCA_13 */
+  PDCA_14_IRQn             = 15, /**< 15 SAM4LC8A Peripheral DMA Controller (PDCA): PDCA_14 */
+  PDCA_15_IRQn             = 16, /**< 16 SAM4LC8A Peripheral DMA Controller (PDCA): PDCA_15 */
+  CRCCU_IRQn               = 17, /**< 17 SAM4LC8A CRC Calculation Unit (CRCCU) */
+  USBC_IRQn                = 18, /**< 18 SAM4LC8A USB 2.0 Interface (USBC) */
+  PEVC_0_IRQn              = 19, /**< 19 SAM4LC8A Peripheral Event Controller (PEVC): PEVC_TR */
+  PEVC_1_IRQn              = 20, /**< 20 SAM4LC8A Peripheral Event Controller (PEVC): PEVC_OV */
+  AESA_IRQn                = 21, /**< 21 SAM4LC8A Advanced Encryption Standard (AESA) */
+  PM_IRQn                  = 22, /**< 22 SAM4LC8A Power Manager (PM) */
+  SCIF_IRQn                = 23, /**< 23 SAM4LC8A System Control Interface (SCIF) */
+  FREQM_IRQn               = 24, /**< 24 SAM4LC8A Frequency Meter (FREQM) */
+  GPIO_0_IRQn              = 25, /**< 25 SAM4LC8A General-Purpose Input/Output Controller (GPIO): GPIO_0 */
+  GPIO_1_IRQn              = 26, /**< 26 SAM4LC8A General-Purpose Input/Output Controller (GPIO): GPIO_1 */
+  GPIO_2_IRQn              = 27, /**< 27 SAM4LC8A General-Purpose Input/Output Controller (GPIO): GPIO_2 */
+  GPIO_3_IRQn              = 28, /**< 28 SAM4LC8A General-Purpose Input/Output Controller (GPIO): GPIO_3 */
+  GPIO_4_IRQn              = 29, /**< 29 SAM4LC8A General-Purpose Input/Output Controller (GPIO): GPIO_4 */
+  GPIO_5_IRQn              = 30, /**< 30 SAM4LC8A General-Purpose Input/Output Controller (GPIO): GPIO_5 */
+  GPIO_6_IRQn              = 31, /**< 31 SAM4LC8A General-Purpose Input/Output Controller (GPIO): GPIO_6 */
+  GPIO_7_IRQn              = 32, /**< 32 SAM4LC8A General-Purpose Input/Output Controller (GPIO): GPIO_7 */
+  GPIO_8_IRQn              = 33, /**< 33 SAM4LC8A General-Purpose Input/Output Controller (GPIO): GPIO_8 */
+  GPIO_9_IRQn              = 34, /**< 34 SAM4LC8A General-Purpose Input/Output Controller (GPIO): GPIO_9 */
+  GPIO_10_IRQn             = 35, /**< 35 SAM4LC8A General-Purpose Input/Output Controller (GPIO): GPIO_10 */
+  GPIO_11_IRQn             = 36, /**< 36 SAM4LC8A General-Purpose Input/Output Controller (GPIO): GPIO_11 */
+  BPM_IRQn                 = 37, /**< 37 SAM4LC8A Backup Power Manager (BPM) */
+  BSCIF_IRQn               = 38, /**< 38 SAM4LC8A Backup System Control Interface (BSCIF) */
+  AST_0_IRQn               = 39, /**< 39 SAM4LC8A Asynchronous Timer (AST): AST_ALARM */
+  AST_1_IRQn               = 40, /**< 40 SAM4LC8A Asynchronous Timer (AST): AST_PER */
+  AST_2_IRQn               = 41, /**< 41 SAM4LC8A Asynchronous Timer (AST): AST_OVF */
+  AST_3_IRQn               = 42, /**< 42 SAM4LC8A Asynchronous Timer (AST): AST_READY */
+  AST_4_IRQn               = 43, /**< 43 SAM4LC8A Asynchronous Timer (AST): AST_CLKREADY */
+  WDT_IRQn                 = 44, /**< 44 SAM4LC8A Watchdog Timer (WDT) */
+  EIC_0_IRQn               = 45, /**< 45 SAM4LC8A External Interrupt Controller (EIC): EIC_1 */
+  EIC_1_IRQn               = 46, /**< 46 SAM4LC8A External Interrupt Controller (EIC): EIC_2 */
+  EIC_2_IRQn               = 47, /**< 47 SAM4LC8A External Interrupt Controller (EIC): EIC_3 */
+  EIC_3_IRQn               = 48, /**< 48 SAM4LC8A External Interrupt Controller (EIC): EIC_4 */
+  EIC_4_IRQn               = 49, /**< 49 SAM4LC8A External Interrupt Controller (EIC): EIC_5 */
+  EIC_5_IRQn               = 50, /**< 50 SAM4LC8A External Interrupt Controller (EIC): EIC_6 */
+  EIC_6_IRQn               = 51, /**< 51 SAM4LC8A External Interrupt Controller (EIC): EIC_7 */
+  EIC_7_IRQn               = 52, /**< 52 SAM4LC8A External Interrupt Controller (EIC): EIC_8 */
+  IISC_IRQn                = 53, /**< 53 SAM4LC8A Inter-IC Sound (I2S) Controller (IISC) */
+  SPI_IRQn                 = 54, /**< 54 SAM4LC8A Serial Peripheral Interface (SPI) */
+  TC0_0_IRQn               = 55, /**< 55 SAM4LC8A Timer/Counter 0 (TC0): TC00 */
+  TC0_1_IRQn               = 56, /**< 56 SAM4LC8A Timer/Counter 0 (TC0): TC01 */
+  TC0_2_IRQn               = 57, /**< 57 SAM4LC8A Timer/Counter 0 (TC0): TC02 */
+  TC1_0_IRQn               = 58, /**< 58 SAM4LC8A Timer/Counter 1 (TC1): TC10 */
+  TC1_1_IRQn               = 59, /**< 59 SAM4LC8A Timer/Counter 1 (TC1): TC11 */
+  TC1_2_IRQn               = 60, /**< 60 SAM4LC8A Timer/Counter 1 (TC1): TC12 */
+  TWIM0_IRQn               = 61, /**< 61 SAM4LC8A Two-wire Master Interface 0 (TWIM0) */
+  TWIS0_IRQn               = 62, /**< 62 SAM4LC8A Two-wire Slave Interface 0 (TWIS0) */
+  TWIM1_IRQn               = 63, /**< 63 SAM4LC8A Two-wire Master Interface 1 (TWIM1) */
+  TWIS1_IRQn               = 64, /**< 64 SAM4LC8A Two-wire Slave Interface 1 (TWIS1) */
+  USART0_IRQn              = 65, /**< 65 SAM4LC8A Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+  USART1_IRQn              = 66, /**< 66 SAM4LC8A Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+  USART2_IRQn              = 67, /**< 67 SAM4LC8A Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+  USART3_IRQn              = 68, /**< 68 SAM4LC8A Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+  ADCIFE_IRQn              = 69, /**< 69 SAM4LC8A ADC controller interface (ADCIFE) */
+  DACC_IRQn                = 70, /**< 70 SAM4LC8A DAC Controller (DACC) */
+  ACIFC_IRQn               = 71, /**< 71 SAM4LC8A Analog Comparator Interface (ACIFC) */
+  ABDACB_IRQn              = 72, /**< 72 SAM4LC8A Audio Bitstream DAC (ABDACB) */
+  TRNG_IRQn                = 73, /**< 73 SAM4LC8A True Random Number Generator (TRNG) */
+  PARC_IRQn                = 74, /**< 74 SAM4LC8A Parallel Capture (PARC) */
+  CATB_IRQn                = 75, /**< 75 SAM4LC8A Capacitive Touch Module B (CATB) */
+  TWIM2_IRQn               = 77, /**< 77 SAM4LC8A Two-wire Master Interface 2 (TWIM2) */
+  TWIM3_IRQn               = 78, /**< 78 SAM4LC8A Two-wire Master Interface 3 (TWIM3) */
+  LCDCA_IRQn               = 79, /**< 79 SAM4LC8A LCD Controller (LCDCA) */
+
+  PERIPH_COUNT_IRQn        = 80  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNMI_Handler;
+  void* pfnHardFault_Handler;
+  void* pfnMemManage_Handler;
+  void* pfnBusFault_Handler;
+  void* pfnUsageFault_Handler;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVC_Handler;
+  void* pfnDebugMon_Handler;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnHFLASHC_Handler;               /*  0 Flash Controller */
+  void* pfnPDCA_0_Handler;                /*  1 Peripheral DMA Controller IRQ 0 */
+  void* pfnPDCA_1_Handler;                /*  2 Peripheral DMA Controller IRQ 1 */
+  void* pfnPDCA_2_Handler;                /*  3 Peripheral DMA Controller IRQ 2 */
+  void* pfnPDCA_3_Handler;                /*  4 Peripheral DMA Controller IRQ 3 */
+  void* pfnPDCA_4_Handler;                /*  5 Peripheral DMA Controller IRQ 4 */
+  void* pfnPDCA_5_Handler;                /*  6 Peripheral DMA Controller IRQ 5 */
+  void* pfnPDCA_6_Handler;                /*  7 Peripheral DMA Controller IRQ 6 */
+  void* pfnPDCA_7_Handler;                /*  8 Peripheral DMA Controller IRQ 7 */
+  void* pfnPDCA_8_Handler;                /*  9 Peripheral DMA Controller IRQ 8 */
+  void* pfnPDCA_9_Handler;                /* 10 Peripheral DMA Controller IRQ 9 */
+  void* pfnPDCA_10_Handler;               /* 11 Peripheral DMA Controller IRQ 10 */
+  void* pfnPDCA_11_Handler;               /* 12 Peripheral DMA Controller IRQ 11 */
+  void* pfnPDCA_12_Handler;               /* 13 Peripheral DMA Controller IRQ 12 */
+  void* pfnPDCA_13_Handler;               /* 14 Peripheral DMA Controller IRQ 13 */
+  void* pfnPDCA_14_Handler;               /* 15 Peripheral DMA Controller IRQ 14 */
+  void* pfnPDCA_15_Handler;               /* 16 Peripheral DMA Controller IRQ 15 */
+  void* pfnCRCCU_Handler;                 /* 17 CRC Calculation Unit */
+  void* pfnUSBC_Handler;                  /* 18 USB 2.0 Interface */
+  void* pfnPEVC_0_Handler;                /* 19 Peripheral Event Controller IRQ 0 */
+  void* pfnPEVC_1_Handler;                /* 20 Peripheral Event Controller IRQ 1 */
+  void* pfnAESA_Handler;                  /* 21 Advanced Encryption Standard */
+  void* pfnPM_Handler;                    /* 22 Power Manager */
+  void* pfnSCIF_Handler;                  /* 23 System Control Interface */
+  void* pfnFREQM_Handler;                 /* 24 Frequency Meter */
+  void* pfnGPIO_0_Handler;                /* 25 General-Purpose Input/Output Controller IRQ 0 */
+  void* pfnGPIO_1_Handler;                /* 26 General-Purpose Input/Output Controller IRQ 1 */
+  void* pfnGPIO_2_Handler;                /* 27 General-Purpose Input/Output Controller IRQ 2 */
+  void* pfnGPIO_3_Handler;                /* 28 General-Purpose Input/Output Controller IRQ 3 */
+  void* pfnGPIO_4_Handler;                /* 29 General-Purpose Input/Output Controller IRQ 4 */
+  void* pfnGPIO_5_Handler;                /* 30 General-Purpose Input/Output Controller IRQ 5 */
+  void* pfnGPIO_6_Handler;                /* 31 General-Purpose Input/Output Controller IRQ 6 */
+  void* pfnGPIO_7_Handler;                /* 32 General-Purpose Input/Output Controller IRQ 7 */
+  void* pfnGPIO_8_Handler;                /* 33 General-Purpose Input/Output Controller IRQ 8 */
+  void* pfnGPIO_9_Handler;                /* 34 General-Purpose Input/Output Controller IRQ 9 */
+  void* pfnGPIO_10_Handler;               /* 35 General-Purpose Input/Output Controller IRQ 10 */
+  void* pfnGPIO_11_Handler;               /* 36 General-Purpose Input/Output Controller IRQ 11 */
+  void* pfnBPM_Handler;                   /* 37 Backup Power Manager */
+  void* pfnBSCIF_Handler;                 /* 38 Backup System Control Interface */
+  void* pfnAST_0_Handler;                 /* 39 Asynchronous Timer IRQ 0 */
+  void* pfnAST_1_Handler;                 /* 40 Asynchronous Timer IRQ 1 */
+  void* pfnAST_2_Handler;                 /* 41 Asynchronous Timer IRQ 2 */
+  void* pfnAST_3_Handler;                 /* 42 Asynchronous Timer IRQ 3 */
+  void* pfnAST_4_Handler;                 /* 43 Asynchronous Timer IRQ 4 */
+  void* pfnWDT_Handler;                   /* 44 Watchdog Timer */
+  void* pfnEIC_0_Handler;                 /* 45 External Interrupt Controller IRQ 0 */
+  void* pfnEIC_1_Handler;                 /* 46 External Interrupt Controller IRQ 1 */
+  void* pfnEIC_2_Handler;                 /* 47 External Interrupt Controller IRQ 2 */
+  void* pfnEIC_3_Handler;                 /* 48 External Interrupt Controller IRQ 3 */
+  void* pfnEIC_4_Handler;                 /* 49 External Interrupt Controller IRQ 4 */
+  void* pfnEIC_5_Handler;                 /* 50 External Interrupt Controller IRQ 5 */
+  void* pfnEIC_6_Handler;                 /* 51 External Interrupt Controller IRQ 6 */
+  void* pfnEIC_7_Handler;                 /* 52 External Interrupt Controller IRQ 7 */
+  void* pfnIISC_Handler;                  /* 53 Inter-IC Sound (I2S) Controller */
+  void* pfnSPI_Handler;                   /* 54 Serial Peripheral Interface */
+  void* pfnTC0_0_Handler;                 /* 55 Timer/Counter 0 IRQ 0 */
+  void* pfnTC0_1_Handler;                 /* 56 Timer/Counter 0 IRQ 1 */
+  void* pfnTC0_2_Handler;                 /* 57 Timer/Counter 0 IRQ 2 */
+  void* pfnTC1_0_Handler;                 /* 58 Timer/Counter 1 IRQ 0 */
+  void* pfnTC1_1_Handler;                 /* 59 Timer/Counter 1 IRQ 1 */
+  void* pfnTC1_2_Handler;                 /* 60 Timer/Counter 1 IRQ 2 */
+  void* pfnTWIM0_Handler;                 /* 61 Two-wire Master Interface 0 */
+  void* pfnTWIS0_Handler;                 /* 62 Two-wire Slave Interface 0 */
+  void* pfnTWIM1_Handler;                 /* 63 Two-wire Master Interface 1 */
+  void* pfnTWIS1_Handler;                 /* 64 Two-wire Slave Interface 1 */
+  void* pfnUSART0_Handler;                /* 65 Universal Synchronous Asynchronous Receiver Transmitter 0 */
+  void* pfnUSART1_Handler;                /* 66 Universal Synchronous Asynchronous Receiver Transmitter 1 */
+  void* pfnUSART2_Handler;                /* 67 Universal Synchronous Asynchronous Receiver Transmitter 2 */
+  void* pfnUSART3_Handler;                /* 68 Universal Synchronous Asynchronous Receiver Transmitter 3 */
+  void* pfnADCIFE_Handler;                /* 69 ADC controller interface */
+  void* pfnDACC_Handler;                  /* 70 DAC Controller */
+  void* pfnACIFC_Handler;                 /* 71 Analog Comparator Interface */
+  void* pfnABDACB_Handler;                /* 72 Audio Bitstream DAC */
+  void* pfnTRNG_Handler;                  /* 73 True Random Number Generator */
+  void* pfnPARC_Handler;                  /* 74 Parallel Capture */
+  void* pfnCATB_Handler;                  /* 75 Capacitive Touch Module B */
+  void* pvReserved76;
+  void* pfnTWIM2_Handler;                 /* 77 Two-wire Master Interface 2 */
+  void* pfnTWIM3_Handler;                 /* 78 Two-wire Master Interface 3 */
+  void* pfnLCDCA_Handler;                 /* 79 LCD Controller */
+} DeviceVectors;
+
+/* Cortex-M4 processor handlers */
+void Reset_Handler               ( void );
+void NMI_Handler                 ( void );
+void HardFault_Handler           ( void );
+void MemManage_Handler           ( void );
+void BusFault_Handler            ( void );
+void UsageFault_Handler          ( void );
+void SVC_Handler                 ( void );
+void DebugMon_Handler            ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void HFLASHC_Handler             ( void );
+void PDCA_0_Handler              ( void );
+void PDCA_1_Handler              ( void );
+void PDCA_2_Handler              ( void );
+void PDCA_3_Handler              ( void );
+void PDCA_4_Handler              ( void );
+void PDCA_5_Handler              ( void );
+void PDCA_6_Handler              ( void );
+void PDCA_7_Handler              ( void );
+void PDCA_8_Handler              ( void );
+void PDCA_9_Handler              ( void );
+void PDCA_10_Handler             ( void );
+void PDCA_11_Handler             ( void );
+void PDCA_12_Handler             ( void );
+void PDCA_13_Handler             ( void );
+void PDCA_14_Handler             ( void );
+void PDCA_15_Handler             ( void );
+void CRCCU_Handler               ( void );
+void USBC_Handler                ( void );
+void PEVC_0_Handler              ( void );
+void PEVC_1_Handler              ( void );
+void AESA_Handler                ( void );
+void PM_Handler                  ( void );
+void SCIF_Handler                ( void );
+void FREQM_Handler               ( void );
+void GPIO_0_Handler              ( void );
+void GPIO_1_Handler              ( void );
+void GPIO_2_Handler              ( void );
+void GPIO_3_Handler              ( void );
+void GPIO_4_Handler              ( void );
+void GPIO_5_Handler              ( void );
+void GPIO_6_Handler              ( void );
+void GPIO_7_Handler              ( void );
+void GPIO_8_Handler              ( void );
+void GPIO_9_Handler              ( void );
+void GPIO_10_Handler             ( void );
+void GPIO_11_Handler             ( void );
+void BPM_Handler                 ( void );
+void BSCIF_Handler               ( void );
+void AST_0_Handler               ( void );
+void AST_1_Handler               ( void );
+void AST_2_Handler               ( void );
+void AST_3_Handler               ( void );
+void AST_4_Handler               ( void );
+void WDT_Handler                 ( void );
+void EIC_0_Handler               ( void );
+void EIC_1_Handler               ( void );
+void EIC_2_Handler               ( void );
+void EIC_3_Handler               ( void );
+void EIC_4_Handler               ( void );
+void EIC_5_Handler               ( void );
+void EIC_6_Handler               ( void );
+void EIC_7_Handler               ( void );
+void IISC_Handler                ( void );
+void SPI_Handler                 ( void );
+void TC0_0_Handler               ( void );
+void TC0_1_Handler               ( void );
+void TC0_2_Handler               ( void );
+void TC1_0_Handler               ( void );
+void TC1_1_Handler               ( void );
+void TC1_2_Handler               ( void );
+void TWIM0_Handler               ( void );
+void TWIS0_Handler               ( void );
+void TWIM1_Handler               ( void );
+void TWIS1_Handler               ( void );
+void USART0_Handler              ( void );
+void USART1_Handler              ( void );
+void USART2_Handler              ( void );
+void USART3_Handler              ( void );
+void ADCIFE_Handler              ( void );
+void DACC_Handler                ( void );
+void ACIFC_Handler               ( void );
+void ABDACB_Handler              ( void );
+void TRNG_Handler                ( void );
+void PARC_Handler                ( void );
+void CATB_Handler                ( void );
+void TWIM2_Handler               ( void );
+void TWIM3_Handler               ( void );
+void LCDCA_Handler               ( void );
+
+/*
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
+ */
+
+#define LITTLE_ENDIAN          1        
+#define __BB_PRESENT           0         /*!< BIT_BANDING present or not */
+#define __CLKGATE_PRESENT      1         /*!< CLKGATE present or not */
+#define __CM4_REV              1         /*!< Core revision r0p1 */
+#define __DEBUG_LVL            3         /*!< Full debug plus DWT data matching */
+#define __FPU_PRESENT          0         /*!< FPU present or not */
+#define __JTAG_PRESENT         1         /*!< JTAG present or not */
+#define __MPU_PRESENT          1         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       4         /*!< Number of bits used for Priority Levels */
+#define __TRACE_LVL            1         /*!< Standard trace: ITM and DWT triggers and counters, but no ETM */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+#define __WIC_PRESENT          0         /*!< WIC present or not */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm4.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_sam4l.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAM4LC8A */
+/* ************************************************************************** */
+/** \defgroup SAM4LC8A_api Peripheral Software API */
+/*@{*/
+
+#include "component/abdacb.h"
+#include "component/acifc.h"
+#include "component/adcife.h"
+#include "component/aesa.h"
+#include "component/ast.h"
+#include "component/bpm.h"
+#include "component/bscif.h"
+#include "component/catb.h"
+#include "component/chipid.h"
+#include "component/crccu.h"
+#include "component/dacc.h"
+#include "component/eic.h"
+#include "component/flashcalw.h"
+#include "component/freqm.h"
+#include "component/gloc.h"
+#include "component/gpio.h"
+#include "component/hcache.h"
+#include "component/hmatrixb.h"
+#include "component/iisc.h"
+#include "component/lcdca.h"
+#include "component/parc.h"
+#include "component/pdca.h"
+#include "component/pevc.h"
+#include "component/picouart.h"
+#include "component/pm.h"
+#include "component/scif.h"
+#include "component/smap.h"
+#include "component/spi.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twim.h"
+#include "component/twis.h"
+#include "component/usart.h"
+#include "component/usbc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAM4LC8A */
+/* ************************************************************************** */
+/** \defgroup SAM4LC8A_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/abdacb.h"
+#include "instance/acifc.h"
+#include "instance/adcife.h"
+#include "instance/aesa.h"
+#include "instance/ast.h"
+#include "instance/bpm.h"
+#include "instance/bscif.h"
+#include "instance/catb.h"
+#include "instance/chipid.h"
+#include "instance/crccu.h"
+#include "instance/dacc.h"
+#include "instance/eic.h"
+#include "instance/hflashc.h"
+#include "instance/freqm.h"
+#include "instance/gloc.h"
+#include "instance/gpio.h"
+#include "instance/hcache.h"
+#include "instance/hmatrix.h"
+#include "instance/iisc.h"
+#include "instance/lcdca.h"
+#include "instance/parc.h"
+#include "instance/pdca.h"
+#include "instance/pevc.h"
+#include "instance/picouart.h"
+#include "instance/pm.h"
+#include "instance/scif.h"
+#include "instance/smap.h"
+#include "instance/spi.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/trng.h"
+#include "instance/twim0.h"
+#include "instance/twim1.h"
+#include "instance/twim2.h"
+#include "instance/twim3.h"
+#include "instance/twis0.h"
+#include "instance/twis1.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usart3.h"
+#include "instance/usbc.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAM4LC8A */
+/* ************************************************************************** */
+/** \defgroup SAM4LC8A_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HTOP0 bridge
+#define ID_IISC           0 /**< \brief Inter-IC Sound (I2S) Controller (IISC) */
+#define ID_SPI            1 /**< \brief Serial Peripheral Interface (SPI) */
+#define ID_TC0            2 /**< \brief Timer/Counter 0 (TC0) */
+#define ID_TC1            3 /**< \brief Timer/Counter 1 (TC1) */
+#define ID_TWIM0          4 /**< \brief Two-wire Master Interface 0 (TWIM0) */
+#define ID_TWIS0          5 /**< \brief Two-wire Slave Interface 0 (TWIS0) */
+#define ID_TWIM1          6 /**< \brief Two-wire Master Interface 1 (TWIM1) */
+#define ID_TWIS1          7 /**< \brief Two-wire Slave Interface 1 (TWIS1) */
+#define ID_USART0         8 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+#define ID_USART1         9 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+#define ID_USART2        10 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+#define ID_USART3        11 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+#define ID_ADCIFE        12 /**< \brief ADC controller interface (ADCIFE) */
+#define ID_DACC          13 /**< \brief DAC Controller (DACC) */
+#define ID_ACIFC         14 /**< \brief Analog Comparator Interface (ACIFC) */
+#define ID_GLOC          15 /**< \brief Glue Logic Controller (GLOC) */
+#define ID_ABDACB        16 /**< \brief Audio Bitstream DAC (ABDACB) */
+#define ID_TRNG          17 /**< \brief True Random Number Generator (TRNG) */
+#define ID_PARC          18 /**< \brief Parallel Capture (PARC) */
+#define ID_CATB          19 /**< \brief Capacitive Touch Module B (CATB) */
+#define ID_TWIM2         21 /**< \brief Two-wire Master Interface 2 (TWIM2) */
+#define ID_TWIM3         22 /**< \brief Two-wire Master Interface 3 (TWIM3) */
+#define ID_LCDCA         23 /**< \brief LCD Controller (LCDCA) */
+
+// Peripheral instances on HTOP1 bridge
+#define ID_HFLASHC       32 /**< \brief Flash Controller (HFLASHC) */
+#define ID_HCACHE        33 /**< \brief Cortex M I&D Cache Controller (HCACHE) */
+#define ID_HMATRIX       34 /**< \brief HSB Matrix (HMATRIX) */
+#define ID_PDCA          35 /**< \brief Peripheral DMA Controller (PDCA) */
+#define ID_SMAP          36 /**< \brief System Manager Access Port (SMAP) */
+#define ID_CRCCU         37 /**< \brief CRC Calculation Unit (CRCCU) */
+#define ID_USBC          38 /**< \brief USB 2.0 Interface (USBC) */
+#define ID_PEVC          39 /**< \brief Peripheral Event Controller (PEVC) */
+
+// Peripheral instances on HTOP2 bridge
+#define ID_PM            64 /**< \brief Power Manager (PM) */
+#define ID_CHIPID        65 /**< \brief Chip ID Registers (CHIPID) */
+#define ID_SCIF          66 /**< \brief System Control Interface (SCIF) */
+#define ID_FREQM         67 /**< \brief Frequency Meter (FREQM) */
+#define ID_GPIO          68 /**< \brief General-Purpose Input/Output Controller (GPIO) */
+
+// Peripheral instances on HTOP3 bridge
+#define ID_BPM           96 /**< \brief Backup Power Manager (BPM) */
+#define ID_BSCIF         97 /**< \brief Backup System Control Interface (BSCIF) */
+#define ID_AST           98 /**< \brief Asynchronous Timer (AST) */
+#define ID_WDT           99 /**< \brief Watchdog Timer (WDT) */
+#define ID_EIC          100 /**< \brief External Interrupt Controller (EIC) */
+#define ID_PICOUART     101 /**< \brief Pico UART (PICOUART) */
+
+// Peripheral instances on AHB (as if on bridge 4)
+#define ID_AESA         128 /**< \brief Advanced Encryption Standard (AESA) */
+
+#define ID_PERIPH_COUNT 129 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAM4LC8A */
+/* ************************************************************************** */
+/** \defgroup SAM4LC8A_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define ABDACB                        (0x40064000) /**< \brief (ABDACB) APB Base Address */
+#define ACIFC                         (0x40040000) /**< \brief (ACIFC) APB Base Address */
+#define ADCIFE                        (0x40038000) /**< \brief (ADCIFE) APB Base Address */
+#define AESA                          (0x400B0000) /**< \brief (AESA) AHB Base Address */
+#define AST                           (0x400F0800) /**< \brief (AST) APB Base Address */
+#define BPM                           (0x400F0000) /**< \brief (BPM) APB Base Address */
+#define BSCIF                         (0x400F0400) /**< \brief (BSCIF) APB Base Address */
+#define CATB                          (0x40070000) /**< \brief (CATB) APB Base Address */
+#define CHIPID                        (0x400E0400) /**< \brief (CHIPID) APB Base Address */
+#define CRCCU                         (0x400A4000) /**< \brief (CRCCU) APB Base Address */
+#define DACC                          (0x4003C000) /**< \brief (DACC) APB Base Address */
+#define EIC                           (0x400F1000) /**< \brief (EIC) APB Base Address */
+#define HFLASHC                       (0x400A0000) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000) /**< \brief (HFLASHC) USER Base Address */
+#define FREQM                         (0x400E0C00) /**< \brief (FREQM) APB Base Address */
+#define GLOC                          (0x40060000) /**< \brief (GLOC) APB Base Address */
+#define GPIO                          (0x400E1000) /**< \brief (GPIO) APB Base Address */
+#define HCACHE                        (0x400A0400) /**< \brief (HCACHE) APB Base Address */
+#define HMATRIX                       (0x400A1000) /**< \brief (HMATRIX) APB Base Address */
+#define IISC                          (0x40004000) /**< \brief (IISC) APB Base Address */
+#define LCDCA                         (0x40080000) /**< \brief (LCDCA) APB Base Address */
+#define PARC                          (0x4006C000) /**< \brief (PARC) APB Base Address */
+#define PDCA                          (0x400A2000) /**< \brief (PDCA) APB Base Address */
+#define PEVC                          (0x400A6000) /**< \brief (PEVC) APB Base Address */
+#define PICOUART                      (0x400F1400) /**< \brief (PICOUART) APB Base Address */
+#define PM                            (0x400E0000) /**< \brief (PM) APB Base Address */
+#define SCIF                          (0x400E0800) /**< \brief (SCIF) APB Base Address */
+#define SMAP                          (0x400A3000) /**< \brief (SMAP) APB Base Address */
+#define SPI                           (0x40008000) /**< \brief (SPI) APB Base Address */
+#define TC0                           (0x40010000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x40014000) /**< \brief (TC1) APB Base Address */
+#define TRNG                          (0x40068000) /**< \brief (TRNG) APB Base Address */
+#define TWIM0                         (0x40018000) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1                         (0x4001C000) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2                         (0x40078000) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3                         (0x4007C000) /**< \brief (TWIM3) APB Base Address */
+#define TWIS0                         (0x40018400) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1                         (0x4001C400) /**< \brief (TWIS1) APB Base Address */
+#define USART0                        (0x40024000) /**< \brief (USART0) APB Base Address */
+#define USART1                        (0x40028000) /**< \brief (USART1) APB Base Address */
+#define USART2                        (0x4002C000) /**< \brief (USART2) APB Base Address */
+#define USART3                        (0x40030000) /**< \brief (USART3) APB Base Address */
+#define USBC                          (0x400A5000) /**< \brief (USBC) APB Base Address */
+#define WDT                           (0x400F0C00) /**< \brief (WDT) APB Base Address */
+#else
+#define ABDACB            ((Abdacb   *)0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_ADDR                   (0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_INST_NUM   1                          /**< \brief (ABDACB) Number of instances */
+#define ABDACB_INSTS      { ABDACB }                 /**< \brief (ABDACB) Instances List */
+
+#define ACIFC             ((Acifc    *)0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_ADDR                    (0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_INST_NUM    1                          /**< \brief (ACIFC) Number of instances */
+#define ACIFC_INSTS       { ACIFC }                  /**< \brief (ACIFC) Instances List */
+
+#define ADCIFE            ((Adcife   *)0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_ADDR                   (0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_INST_NUM   1                          /**< \brief (ADCIFE) Number of instances */
+#define ADCIFE_INSTS      { ADCIFE }                 /**< \brief (ADCIFE) Instances List */
+
+#define AESA              ((Aesa     *)0x400B0000UL) /**< \brief (AESA) AHB Base Address */
+#define AESA_ADDR                     (0x400B0000UL) /**< \brief (AESA) AHB Base Address */
+#define AESA_INST_NUM     1                          /**< \brief (AESA) Number of instances */
+#define AESA_INSTS        { AESA }                   /**< \brief (AESA) Instances List */
+
+#define AST               ((Ast      *)0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_ADDR                      (0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_INST_NUM      1                          /**< \brief (AST) Number of instances */
+#define AST_INSTS         { AST }                    /**< \brief (AST) Instances List */
+
+#define BPM               ((Bpm      *)0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_ADDR                      (0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_INST_NUM      1                          /**< \brief (BPM) Number of instances */
+#define BPM_INSTS         { BPM }                    /**< \brief (BPM) Instances List */
+
+#define BSCIF             ((Bscif    *)0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_ADDR                    (0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_INST_NUM    1                          /**< \brief (BSCIF) Number of instances */
+#define BSCIF_INSTS       { BSCIF }                  /**< \brief (BSCIF) Instances List */
+
+#define CATB              ((Catb     *)0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_ADDR                     (0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_INST_NUM     1                          /**< \brief (CATB) Number of instances */
+#define CATB_INSTS        { CATB }                   /**< \brief (CATB) Instances List */
+
+#define CHIPID            ((Chipid   *)0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_ADDR                   (0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_INST_NUM   1                          /**< \brief (CHIPID) Number of instances */
+#define CHIPID_INSTS      { CHIPID }                 /**< \brief (CHIPID) Instances List */
+
+#define CRCCU             ((Crccu    *)0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_ADDR                    (0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_INST_NUM    1                          /**< \brief (CRCCU) Number of instances */
+#define CRCCU_INSTS       { CRCCU }                  /**< \brief (CRCCU) Instances List */
+
+#define DACC              ((Dacc     *)0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_ADDR                     (0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_INST_NUM     1                          /**< \brief (DACC) Number of instances */
+#define DACC_INSTS        { DACC }                   /**< \brief (DACC) Instances List */
+
+#define EIC               ((Eic      *)0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_ADDR                      (0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define HFLASHC           ((Flashcalw *)0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_ADDR                  (0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_FROW_ADDR             (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define HFLASHC_USER_ADDR             (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define FLASHCALW_INST_NUM 1                          /**< \brief (FLASHCALW) Number of instances */
+#define FLASHCALW_INSTS   { HFLASHC }                /**< \brief (FLASHCALW) Instances List */
+
+#define FREQM             ((Freqm    *)0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_ADDR                    (0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_INST_NUM    1                          /**< \brief (FREQM) Number of instances */
+#define FREQM_INSTS       { FREQM }                  /**< \brief (FREQM) Instances List */
+
+#define GLOC              ((Gloc     *)0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_ADDR                     (0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_INST_NUM     1                          /**< \brief (GLOC) Number of instances */
+#define GLOC_INSTS        { GLOC }                   /**< \brief (GLOC) Instances List */
+
+#define GPIO              ((Gpio     *)0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_ADDR                     (0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_INST_NUM     1                          /**< \brief (GPIO) Number of instances */
+#define GPIO_INSTS        { GPIO }                   /**< \brief (GPIO) Instances List */
+
+#define HCACHE            ((Hcache   *)0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_ADDR                   (0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_INST_NUM   1                          /**< \brief (HCACHE) Number of instances */
+#define HCACHE_INSTS      { HCACHE }                 /**< \brief (HCACHE) Instances List */
+
+#define HMATRIX           ((Hmatrixb *)0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIX_ADDR                  (0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIXB_INST_NUM 1                          /**< \brief (HMATRIXB) Number of instances */
+#define HMATRIXB_INSTS    { HMATRIX }                /**< \brief (HMATRIXB) Instances List */
+
+#define IISC              ((Iisc     *)0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_ADDR                     (0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_INST_NUM     1                          /**< \brief (IISC) Number of instances */
+#define IISC_INSTS        { IISC }                   /**< \brief (IISC) Instances List */
+
+#define LCDCA             ((Lcdca    *)0x40080000UL) /**< \brief (LCDCA) APB Base Address */
+#define LCDCA_ADDR                    (0x40080000UL) /**< \brief (LCDCA) APB Base Address */
+#define LCDCA_INST_NUM    1                          /**< \brief (LCDCA) Number of instances */
+#define LCDCA_INSTS       { LCDCA }                  /**< \brief (LCDCA) Instances List */
+
+#define PARC              ((Parc     *)0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_ADDR                     (0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_INST_NUM     1                          /**< \brief (PARC) Number of instances */
+#define PARC_INSTS        { PARC }                   /**< \brief (PARC) Instances List */
+
+#define PDCA              ((Pdca     *)0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_ADDR                     (0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_INST_NUM     1                          /**< \brief (PDCA) Number of instances */
+#define PDCA_INSTS        { PDCA }                   /**< \brief (PDCA) Instances List */
+
+#define PEVC              ((Pevc     *)0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_ADDR                     (0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_INST_NUM     1                          /**< \brief (PEVC) Number of instances */
+#define PEVC_INSTS        { PEVC }                   /**< \brief (PEVC) Instances List */
+
+#define PICOUART          ((Picouart *)0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_ADDR                 (0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_INST_NUM 1                          /**< \brief (PICOUART) Number of instances */
+#define PICOUART_INSTS    { PICOUART }               /**< \brief (PICOUART) Instances List */
+
+#define PM                ((Pm       *)0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_ADDR                       (0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define SCIF              ((Scif     *)0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_ADDR                     (0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_INST_NUM     1                          /**< \brief (SCIF) Number of instances */
+#define SCIF_INSTS        { SCIF }                   /**< \brief (SCIF) Instances List */
+
+#define SMAP              ((Smap     *)0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_ADDR                     (0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_INST_NUM     1                          /**< \brief (SMAP) Number of instances */
+#define SMAP_INSTS        { SMAP }                   /**< \brief (SMAP) Instances List */
+
+#define SPI               ((Spi      *)0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_ADDR                      (0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_INST_NUM      1                          /**< \brief (SPI) Number of instances */
+#define SPI_INSTS         { SPI }                    /**< \brief (SPI) Instances List */
+
+#define TC0               ((Tc       *)0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC0_ADDR                      (0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC1_ADDR                      (0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC_INST_NUM       2                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1 }               /**< \brief (TC) Instances List */
+
+#define TRNG              ((Trng     *)0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_ADDR                     (0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_INST_NUM     1                          /**< \brief (TRNG) Number of instances */
+#define TRNG_INSTS        { TRNG }                   /**< \brief (TRNG) Instances List */
+
+#define TWIM0             ((Twim     *)0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM0_ADDR                    (0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1             ((Twim     *)0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM1_ADDR                    (0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2             ((Twim     *)0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM2_ADDR                    (0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3             ((Twim     *)0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM3_ADDR                    (0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM_INST_NUM     4                          /**< \brief (TWIM) Number of instances */
+#define TWIM_INSTS        { TWIM0, TWIM1, TWIM2, TWIM3 } /**< \brief (TWIM) Instances List */
+
+#define TWIS0             ((Twis     *)0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS0_ADDR                    (0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1             ((Twis     *)0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS1_ADDR                    (0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS_INST_NUM     2                          /**< \brief (TWIS) Number of instances */
+#define TWIS_INSTS        { TWIS0, TWIS1 }           /**< \brief (TWIS) Instances List */
+
+#define USART0            ((Usart    *)0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART0_ADDR                   (0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART1            ((Usart    *)0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART1_ADDR                   (0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART2            ((Usart    *)0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART2_ADDR                   (0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART3            ((Usart    *)0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART3_ADDR                   (0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART_INST_NUM    4                          /**< \brief (USART) Number of instances */
+#define USART_INSTS       { USART0, USART1, USART2, USART3 } /**< \brief (USART) Instances List */
+
+#define USBC              ((Usbc     *)0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_ADDR                     (0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_INST_NUM     1                          /**< \brief (USBC) Number of instances */
+#define USBC_INSTS        { USBC }                   /**< \brief (USBC) Instances List */
+
+#define WDT               ((Wdt      *)0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_ADDR                      (0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  GPIO DEFINITIONS FOR SAM4LC8A */
+/* ************************************************************************** */
+/** \defgroup SAM4LC8A_gpio GPIO Definitions */
+/*@{*/
+
+#include "pio/sam4lc8a.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  ADDITIONAL DEFINITIONS FOR COMPATIBILITY */
+/* ************************************************************************** */
+/** \addtogroup SAM4LC8A_compat Definitions */
+/*@{*/
+// These defines are used to keep compatibility with existing 
+// sam/drivers/usart implementation from SAM3/4 products with SAM4L product.
+#define US_MR_USART_MODE_HW_HANDSHAKING  US_MR_USART_MODE_HARDWARE
+#define US_MR_USART_MODE_IS07816_T_0     US_MR_USART_MODE_ISO7816_T0
+#define US_MR_USART_MODE_IS07816_T_1     US_MR_USART_MODE_ISO7816_T1
+#define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
+#define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
+#define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_8_BIT      US_MR_CHRL_8
+#define US_MR_PAR_NO          US_MR_PAR_NONE
+#define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI
+#define US_IF                 US_IFR
+#define US_WPSR_WPVS          US_WPSR_WPV_1
+
+#define USBC_UPCFG0_PBK_Msk   (0x1u << USBC_UPCFG0_PBK_Pos)
+
+// These defines for homogeneity with other SAM header files.
+#define CHIP_FREQ_FWS_0       (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 */
+#define CHIP_FREQ_FWS_1       (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 */
+// WARNING NOTE: these are preliminary values.
+#define CHIP_FREQ_FLASH_HSEN_FWS_0 (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 and the FLASH HS mode is enabled */
+#define CHIP_FREQ_FLASH_HSEN_FWS_1 (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 and the FLASH HS mode is enabled */
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/tc implementation from SAM3/4 products with SAM4L product. 
+#define TC_CMR_LDRA_RISING    TC_CMR_LDRA_POS_EDGE_TIOA
+#define TC_CMR_LDRB_FALLING   TC_CMR_LDRB_NEG_EDGE_TIOA
+#define TC_CMR_ETRGEDG_FALLING TC_CMR_ETRGEDG_NEG_EDGE
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/spi implementation from SAM3/4 products with SAM4L product. 
+#define SPI_CSR_BITS_8_BIT    SPI_CSR_BITS_8_BPT
+#define SPI_WPCR_SPIWPKEY_VALUE SPI_WPCR_WPKEY_VALUE
+#define SPI_WPCR_SPIWPEN      SPI_WPCR_WPEN
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/crccu implementation from SAM3/4 products with SAM4L product. 
+#define CRCCU_DMA_EN          CRCCU_DMAEN
+#define CRCCU_DMA_DIS         CRCCU_DMADIS
+#define CRCCU_DMA_SR          CRCCU_DMASR
+#define CRCCU_DMA_IER         CRCCU_DMAIER
+#define CRCCU_DMA_IDR         CRCCU_DMAIDR
+#define CRCCU_DMA_IMR         CRCCU_DMAIMR
+#define CRCCU_DMA_ISR         CRCCU_DMAISR
+#define CRCCU_DMA_EN_DMAEN    CRCCU_DMAEN_DMAEN
+#define CRCCU_DMA_DIS_DMADIS  CRCCU_DMADIS_DMADIS
+#define CRCCU_DMA_SR_DMASR    CRCCU_DMASR_DMASR
+#define CRCCU_DMA_IER_DMAIER  CRCCU_DMAIER_DMAIER
+#define CRCCU_DMA_IDR_DMAIDR  CRCCU_DMAIDR_DMAIDR
+#define CRCCU_DMA_IMR_DMAIMR  CRCCU_DMAIMR_DMAIMR
+#define CRCCU_DMA_ISR_DMAISR  CRCCU_DMAISR_DMAISR
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAM4LC8A */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL(0x00080000) /* 512 kB */
+#define FLASH_PAGE_SIZE       512
+#define FLASH_NB_OF_PAGES     1024
+#define FLASH_USER_PAGE_SIZE  512
+#define HRAMC0_SIZE           _UL(0x00010000) /* 64 kB */
+#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+
+#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+
+#define DSU_DID_RESETVALUE    _UL(0xAB0B0AE0)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAM4LC8A */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAM4LC8A_H */

--- a/asf/sam/include/sam4l/sam4lc8a.h
+++ b/asf/sam/include/sam4l/sam4lc8a.h
@@ -62,15 +62,15 @@ typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volati
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
 #if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#define _U_(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
 #if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#define _U_(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 
@@ -881,23 +881,23 @@ void LCDCA_Handler               ( void );
 /**  MEMORY MAPPING DEFINITIONS FOR SAM4LC8A */
 /* ************************************************************************** */
 
-#define FLASH_SIZE            _UL(0x00080000) /* 512 kB */
+#define FLASH_SIZE            _UL_(0x00080000) /* 512 kB */
 #define FLASH_PAGE_SIZE       512
 #define FLASH_NB_OF_PAGES     1024
 #define FLASH_USER_PAGE_SIZE  512
-#define HRAMC0_SIZE           _UL(0x00010000) /* 64 kB */
-#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+#define HRAMC0_SIZE           _UL_(0x00010000) /* 64 kB */
+#define HRAMC1_SIZE           _UL_(0x00000800) /* 2 kB */
 
-#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
-#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
-#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
-#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
-#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
-#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
-#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
-#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL_(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL_(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL_(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL_(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL_(0x400F0000) /**< HTOP3 base address */
 
-#define DSU_DID_RESETVALUE    _UL(0xAB0B0AE0)
+#define DSU_DID_RESETVALUE    _UL_(0xAB0B0AE0)
 
 /* ************************************************************************** */
 /**  ELECTRICAL DEFINITIONS FOR SAM4LC8A */

--- a/asf/sam/include/sam4l/sam4lc8b.h
+++ b/asf/sam/include/sam4l/sam4lc8b.h
@@ -62,15 +62,15 @@ typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volati
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
 #if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#define _U_(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
 #if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#define _U_(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 
@@ -881,23 +881,23 @@ void LCDCA_Handler               ( void );
 /**  MEMORY MAPPING DEFINITIONS FOR SAM4LC8B */
 /* ************************************************************************** */
 
-#define FLASH_SIZE            _UL(0x00080000) /* 512 kB */
+#define FLASH_SIZE            _UL_(0x00080000) /* 512 kB */
 #define FLASH_PAGE_SIZE       512
 #define FLASH_NB_OF_PAGES     1024
 #define FLASH_USER_PAGE_SIZE  512
-#define HRAMC0_SIZE           _UL(0x00010000) /* 64 kB */
-#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+#define HRAMC0_SIZE           _UL_(0x00010000) /* 64 kB */
+#define HRAMC1_SIZE           _UL_(0x00000800) /* 2 kB */
 
-#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
-#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
-#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
-#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
-#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
-#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
-#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
-#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL_(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL_(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL_(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL_(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL_(0x400F0000) /**< HTOP3 base address */
 
-#define DSU_DID_RESETVALUE    _UL(0xAB0B0AE0)
+#define DSU_DID_RESETVALUE    _UL_(0xAB0B0AE0)
 
 /* ************************************************************************** */
 /**  ELECTRICAL DEFINITIONS FOR SAM4LC8B */

--- a/asf/sam/include/sam4l/sam4lc8b.h
+++ b/asf/sam/include/sam4l/sam4lc8b.h
@@ -1,0 +1,913 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAM4LC8B
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LC8B_
+#define _SAM4LC8B_
+
+/**
+ * \ingroup SAM4L_definitions
+ * \addtogroup SAM4LC8B_definitions SAM4LC8B definitions
+ * This file defines all structures and symbols for SAM4LC8B:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#if !defined(_UL)
+#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#endif
+#else
+#if !defined(_UL)
+#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif
+#endif
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAM4LC8B */
+/* ************************************************************************** */
+/** \defgroup SAM4LC8B_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M4 Processor Exceptions Numbers ******************************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn           = -13,/**<  3 Cortex-M4 Hard Fault Interrupt        */
+  MemoryManagement_IRQn    = -12,/**<  4 Cortex-M4 Memory Management Interrupt */
+  BusFault_IRQn            = -11,/**<  5 Cortex-M4 Bus Fault Interrupt         */
+  UsageFault_IRQn          = -10,/**<  6 Cortex-M4 Usage Fault Interrupt       */
+  SVCall_IRQn              = -5, /**< 11 Cortex-M4 SV Call Interrupt           */
+  DebugMonitor_IRQn        = -4, /**< 12 Cortex-M4 Debug Monitor Interrupt     */
+  PendSV_IRQn              = -2, /**< 14 Cortex-M4 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 Cortex-M4 System Tick Interrupt       */
+  /******  SAM4LC8B-specific Interrupt Numbers ***********************/
+  HFLASHC_IRQn             =  0, /**<  0 SAM4LC8B Flash Controller (HFLASHC) */
+  PDCA_0_IRQn              =  1, /**<  1 SAM4LC8B Peripheral DMA Controller (PDCA): PDCA_0 */
+  PDCA_1_IRQn              =  2, /**<  2 SAM4LC8B Peripheral DMA Controller (PDCA): PDCA_1 */
+  PDCA_2_IRQn              =  3, /**<  3 SAM4LC8B Peripheral DMA Controller (PDCA): PDCA_2 */
+  PDCA_3_IRQn              =  4, /**<  4 SAM4LC8B Peripheral DMA Controller (PDCA): PDCA_3 */
+  PDCA_4_IRQn              =  5, /**<  5 SAM4LC8B Peripheral DMA Controller (PDCA): PDCA_4 */
+  PDCA_5_IRQn              =  6, /**<  6 SAM4LC8B Peripheral DMA Controller (PDCA): PDCA_5 */
+  PDCA_6_IRQn              =  7, /**<  7 SAM4LC8B Peripheral DMA Controller (PDCA): PDCA_6 */
+  PDCA_7_IRQn              =  8, /**<  8 SAM4LC8B Peripheral DMA Controller (PDCA): PDCA_7 */
+  PDCA_8_IRQn              =  9, /**<  9 SAM4LC8B Peripheral DMA Controller (PDCA): PDCA_8 */
+  PDCA_9_IRQn              = 10, /**< 10 SAM4LC8B Peripheral DMA Controller (PDCA): PDCA_9 */
+  PDCA_10_IRQn             = 11, /**< 11 SAM4LC8B Peripheral DMA Controller (PDCA): PDCA_10 */
+  PDCA_11_IRQn             = 12, /**< 12 SAM4LC8B Peripheral DMA Controller (PDCA): PDCA_11 */
+  PDCA_12_IRQn             = 13, /**< 13 SAM4LC8B Peripheral DMA Controller (PDCA): PDCA_12 */
+  PDCA_13_IRQn             = 14, /**< 14 SAM4LC8B Peripheral DMA Controller (PDCA): PDCA_13 */
+  PDCA_14_IRQn             = 15, /**< 15 SAM4LC8B Peripheral DMA Controller (PDCA): PDCA_14 */
+  PDCA_15_IRQn             = 16, /**< 16 SAM4LC8B Peripheral DMA Controller (PDCA): PDCA_15 */
+  CRCCU_IRQn               = 17, /**< 17 SAM4LC8B CRC Calculation Unit (CRCCU) */
+  USBC_IRQn                = 18, /**< 18 SAM4LC8B USB 2.0 Interface (USBC) */
+  PEVC_0_IRQn              = 19, /**< 19 SAM4LC8B Peripheral Event Controller (PEVC): PEVC_TR */
+  PEVC_1_IRQn              = 20, /**< 20 SAM4LC8B Peripheral Event Controller (PEVC): PEVC_OV */
+  AESA_IRQn                = 21, /**< 21 SAM4LC8B Advanced Encryption Standard (AESA) */
+  PM_IRQn                  = 22, /**< 22 SAM4LC8B Power Manager (PM) */
+  SCIF_IRQn                = 23, /**< 23 SAM4LC8B System Control Interface (SCIF) */
+  FREQM_IRQn               = 24, /**< 24 SAM4LC8B Frequency Meter (FREQM) */
+  GPIO_0_IRQn              = 25, /**< 25 SAM4LC8B General-Purpose Input/Output Controller (GPIO): GPIO_0 */
+  GPIO_1_IRQn              = 26, /**< 26 SAM4LC8B General-Purpose Input/Output Controller (GPIO): GPIO_1 */
+  GPIO_2_IRQn              = 27, /**< 27 SAM4LC8B General-Purpose Input/Output Controller (GPIO): GPIO_2 */
+  GPIO_3_IRQn              = 28, /**< 28 SAM4LC8B General-Purpose Input/Output Controller (GPIO): GPIO_3 */
+  GPIO_4_IRQn              = 29, /**< 29 SAM4LC8B General-Purpose Input/Output Controller (GPIO): GPIO_4 */
+  GPIO_5_IRQn              = 30, /**< 30 SAM4LC8B General-Purpose Input/Output Controller (GPIO): GPIO_5 */
+  GPIO_6_IRQn              = 31, /**< 31 SAM4LC8B General-Purpose Input/Output Controller (GPIO): GPIO_6 */
+  GPIO_7_IRQn              = 32, /**< 32 SAM4LC8B General-Purpose Input/Output Controller (GPIO): GPIO_7 */
+  GPIO_8_IRQn              = 33, /**< 33 SAM4LC8B General-Purpose Input/Output Controller (GPIO): GPIO_8 */
+  GPIO_9_IRQn              = 34, /**< 34 SAM4LC8B General-Purpose Input/Output Controller (GPIO): GPIO_9 */
+  GPIO_10_IRQn             = 35, /**< 35 SAM4LC8B General-Purpose Input/Output Controller (GPIO): GPIO_10 */
+  GPIO_11_IRQn             = 36, /**< 36 SAM4LC8B General-Purpose Input/Output Controller (GPIO): GPIO_11 */
+  BPM_IRQn                 = 37, /**< 37 SAM4LC8B Backup Power Manager (BPM) */
+  BSCIF_IRQn               = 38, /**< 38 SAM4LC8B Backup System Control Interface (BSCIF) */
+  AST_0_IRQn               = 39, /**< 39 SAM4LC8B Asynchronous Timer (AST): AST_ALARM */
+  AST_1_IRQn               = 40, /**< 40 SAM4LC8B Asynchronous Timer (AST): AST_PER */
+  AST_2_IRQn               = 41, /**< 41 SAM4LC8B Asynchronous Timer (AST): AST_OVF */
+  AST_3_IRQn               = 42, /**< 42 SAM4LC8B Asynchronous Timer (AST): AST_READY */
+  AST_4_IRQn               = 43, /**< 43 SAM4LC8B Asynchronous Timer (AST): AST_CLKREADY */
+  WDT_IRQn                 = 44, /**< 44 SAM4LC8B Watchdog Timer (WDT) */
+  EIC_0_IRQn               = 45, /**< 45 SAM4LC8B External Interrupt Controller (EIC): EIC_1 */
+  EIC_1_IRQn               = 46, /**< 46 SAM4LC8B External Interrupt Controller (EIC): EIC_2 */
+  EIC_2_IRQn               = 47, /**< 47 SAM4LC8B External Interrupt Controller (EIC): EIC_3 */
+  EIC_3_IRQn               = 48, /**< 48 SAM4LC8B External Interrupt Controller (EIC): EIC_4 */
+  EIC_4_IRQn               = 49, /**< 49 SAM4LC8B External Interrupt Controller (EIC): EIC_5 */
+  EIC_5_IRQn               = 50, /**< 50 SAM4LC8B External Interrupt Controller (EIC): EIC_6 */
+  EIC_6_IRQn               = 51, /**< 51 SAM4LC8B External Interrupt Controller (EIC): EIC_7 */
+  EIC_7_IRQn               = 52, /**< 52 SAM4LC8B External Interrupt Controller (EIC): EIC_8 */
+  IISC_IRQn                = 53, /**< 53 SAM4LC8B Inter-IC Sound (I2S) Controller (IISC) */
+  SPI_IRQn                 = 54, /**< 54 SAM4LC8B Serial Peripheral Interface (SPI) */
+  TC0_0_IRQn               = 55, /**< 55 SAM4LC8B Timer/Counter 0 (TC0): TC00 */
+  TC0_1_IRQn               = 56, /**< 56 SAM4LC8B Timer/Counter 0 (TC0): TC01 */
+  TC0_2_IRQn               = 57, /**< 57 SAM4LC8B Timer/Counter 0 (TC0): TC02 */
+  TC1_0_IRQn               = 58, /**< 58 SAM4LC8B Timer/Counter 1 (TC1): TC10 */
+  TC1_1_IRQn               = 59, /**< 59 SAM4LC8B Timer/Counter 1 (TC1): TC11 */
+  TC1_2_IRQn               = 60, /**< 60 SAM4LC8B Timer/Counter 1 (TC1): TC12 */
+  TWIM0_IRQn               = 61, /**< 61 SAM4LC8B Two-wire Master Interface 0 (TWIM0) */
+  TWIS0_IRQn               = 62, /**< 62 SAM4LC8B Two-wire Slave Interface 0 (TWIS0) */
+  TWIM1_IRQn               = 63, /**< 63 SAM4LC8B Two-wire Master Interface 1 (TWIM1) */
+  TWIS1_IRQn               = 64, /**< 64 SAM4LC8B Two-wire Slave Interface 1 (TWIS1) */
+  USART0_IRQn              = 65, /**< 65 SAM4LC8B Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+  USART1_IRQn              = 66, /**< 66 SAM4LC8B Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+  USART2_IRQn              = 67, /**< 67 SAM4LC8B Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+  USART3_IRQn              = 68, /**< 68 SAM4LC8B Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+  ADCIFE_IRQn              = 69, /**< 69 SAM4LC8B ADC controller interface (ADCIFE) */
+  DACC_IRQn                = 70, /**< 70 SAM4LC8B DAC Controller (DACC) */
+  ACIFC_IRQn               = 71, /**< 71 SAM4LC8B Analog Comparator Interface (ACIFC) */
+  ABDACB_IRQn              = 72, /**< 72 SAM4LC8B Audio Bitstream DAC (ABDACB) */
+  TRNG_IRQn                = 73, /**< 73 SAM4LC8B True Random Number Generator (TRNG) */
+  PARC_IRQn                = 74, /**< 74 SAM4LC8B Parallel Capture (PARC) */
+  CATB_IRQn                = 75, /**< 75 SAM4LC8B Capacitive Touch Module B (CATB) */
+  TWIM2_IRQn               = 77, /**< 77 SAM4LC8B Two-wire Master Interface 2 (TWIM2) */
+  TWIM3_IRQn               = 78, /**< 78 SAM4LC8B Two-wire Master Interface 3 (TWIM3) */
+  LCDCA_IRQn               = 79, /**< 79 SAM4LC8B LCD Controller (LCDCA) */
+
+  PERIPH_COUNT_IRQn        = 80  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNMI_Handler;
+  void* pfnHardFault_Handler;
+  void* pfnMemManage_Handler;
+  void* pfnBusFault_Handler;
+  void* pfnUsageFault_Handler;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVC_Handler;
+  void* pfnDebugMon_Handler;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnHFLASHC_Handler;               /*  0 Flash Controller */
+  void* pfnPDCA_0_Handler;                /*  1 Peripheral DMA Controller IRQ 0 */
+  void* pfnPDCA_1_Handler;                /*  2 Peripheral DMA Controller IRQ 1 */
+  void* pfnPDCA_2_Handler;                /*  3 Peripheral DMA Controller IRQ 2 */
+  void* pfnPDCA_3_Handler;                /*  4 Peripheral DMA Controller IRQ 3 */
+  void* pfnPDCA_4_Handler;                /*  5 Peripheral DMA Controller IRQ 4 */
+  void* pfnPDCA_5_Handler;                /*  6 Peripheral DMA Controller IRQ 5 */
+  void* pfnPDCA_6_Handler;                /*  7 Peripheral DMA Controller IRQ 6 */
+  void* pfnPDCA_7_Handler;                /*  8 Peripheral DMA Controller IRQ 7 */
+  void* pfnPDCA_8_Handler;                /*  9 Peripheral DMA Controller IRQ 8 */
+  void* pfnPDCA_9_Handler;                /* 10 Peripheral DMA Controller IRQ 9 */
+  void* pfnPDCA_10_Handler;               /* 11 Peripheral DMA Controller IRQ 10 */
+  void* pfnPDCA_11_Handler;               /* 12 Peripheral DMA Controller IRQ 11 */
+  void* pfnPDCA_12_Handler;               /* 13 Peripheral DMA Controller IRQ 12 */
+  void* pfnPDCA_13_Handler;               /* 14 Peripheral DMA Controller IRQ 13 */
+  void* pfnPDCA_14_Handler;               /* 15 Peripheral DMA Controller IRQ 14 */
+  void* pfnPDCA_15_Handler;               /* 16 Peripheral DMA Controller IRQ 15 */
+  void* pfnCRCCU_Handler;                 /* 17 CRC Calculation Unit */
+  void* pfnUSBC_Handler;                  /* 18 USB 2.0 Interface */
+  void* pfnPEVC_0_Handler;                /* 19 Peripheral Event Controller IRQ 0 */
+  void* pfnPEVC_1_Handler;                /* 20 Peripheral Event Controller IRQ 1 */
+  void* pfnAESA_Handler;                  /* 21 Advanced Encryption Standard */
+  void* pfnPM_Handler;                    /* 22 Power Manager */
+  void* pfnSCIF_Handler;                  /* 23 System Control Interface */
+  void* pfnFREQM_Handler;                 /* 24 Frequency Meter */
+  void* pfnGPIO_0_Handler;                /* 25 General-Purpose Input/Output Controller IRQ 0 */
+  void* pfnGPIO_1_Handler;                /* 26 General-Purpose Input/Output Controller IRQ 1 */
+  void* pfnGPIO_2_Handler;                /* 27 General-Purpose Input/Output Controller IRQ 2 */
+  void* pfnGPIO_3_Handler;                /* 28 General-Purpose Input/Output Controller IRQ 3 */
+  void* pfnGPIO_4_Handler;                /* 29 General-Purpose Input/Output Controller IRQ 4 */
+  void* pfnGPIO_5_Handler;                /* 30 General-Purpose Input/Output Controller IRQ 5 */
+  void* pfnGPIO_6_Handler;                /* 31 General-Purpose Input/Output Controller IRQ 6 */
+  void* pfnGPIO_7_Handler;                /* 32 General-Purpose Input/Output Controller IRQ 7 */
+  void* pfnGPIO_8_Handler;                /* 33 General-Purpose Input/Output Controller IRQ 8 */
+  void* pfnGPIO_9_Handler;                /* 34 General-Purpose Input/Output Controller IRQ 9 */
+  void* pfnGPIO_10_Handler;               /* 35 General-Purpose Input/Output Controller IRQ 10 */
+  void* pfnGPIO_11_Handler;               /* 36 General-Purpose Input/Output Controller IRQ 11 */
+  void* pfnBPM_Handler;                   /* 37 Backup Power Manager */
+  void* pfnBSCIF_Handler;                 /* 38 Backup System Control Interface */
+  void* pfnAST_0_Handler;                 /* 39 Asynchronous Timer IRQ 0 */
+  void* pfnAST_1_Handler;                 /* 40 Asynchronous Timer IRQ 1 */
+  void* pfnAST_2_Handler;                 /* 41 Asynchronous Timer IRQ 2 */
+  void* pfnAST_3_Handler;                 /* 42 Asynchronous Timer IRQ 3 */
+  void* pfnAST_4_Handler;                 /* 43 Asynchronous Timer IRQ 4 */
+  void* pfnWDT_Handler;                   /* 44 Watchdog Timer */
+  void* pfnEIC_0_Handler;                 /* 45 External Interrupt Controller IRQ 0 */
+  void* pfnEIC_1_Handler;                 /* 46 External Interrupt Controller IRQ 1 */
+  void* pfnEIC_2_Handler;                 /* 47 External Interrupt Controller IRQ 2 */
+  void* pfnEIC_3_Handler;                 /* 48 External Interrupt Controller IRQ 3 */
+  void* pfnEIC_4_Handler;                 /* 49 External Interrupt Controller IRQ 4 */
+  void* pfnEIC_5_Handler;                 /* 50 External Interrupt Controller IRQ 5 */
+  void* pfnEIC_6_Handler;                 /* 51 External Interrupt Controller IRQ 6 */
+  void* pfnEIC_7_Handler;                 /* 52 External Interrupt Controller IRQ 7 */
+  void* pfnIISC_Handler;                  /* 53 Inter-IC Sound (I2S) Controller */
+  void* pfnSPI_Handler;                   /* 54 Serial Peripheral Interface */
+  void* pfnTC0_0_Handler;                 /* 55 Timer/Counter 0 IRQ 0 */
+  void* pfnTC0_1_Handler;                 /* 56 Timer/Counter 0 IRQ 1 */
+  void* pfnTC0_2_Handler;                 /* 57 Timer/Counter 0 IRQ 2 */
+  void* pfnTC1_0_Handler;                 /* 58 Timer/Counter 1 IRQ 0 */
+  void* pfnTC1_1_Handler;                 /* 59 Timer/Counter 1 IRQ 1 */
+  void* pfnTC1_2_Handler;                 /* 60 Timer/Counter 1 IRQ 2 */
+  void* pfnTWIM0_Handler;                 /* 61 Two-wire Master Interface 0 */
+  void* pfnTWIS0_Handler;                 /* 62 Two-wire Slave Interface 0 */
+  void* pfnTWIM1_Handler;                 /* 63 Two-wire Master Interface 1 */
+  void* pfnTWIS1_Handler;                 /* 64 Two-wire Slave Interface 1 */
+  void* pfnUSART0_Handler;                /* 65 Universal Synchronous Asynchronous Receiver Transmitter 0 */
+  void* pfnUSART1_Handler;                /* 66 Universal Synchronous Asynchronous Receiver Transmitter 1 */
+  void* pfnUSART2_Handler;                /* 67 Universal Synchronous Asynchronous Receiver Transmitter 2 */
+  void* pfnUSART3_Handler;                /* 68 Universal Synchronous Asynchronous Receiver Transmitter 3 */
+  void* pfnADCIFE_Handler;                /* 69 ADC controller interface */
+  void* pfnDACC_Handler;                  /* 70 DAC Controller */
+  void* pfnACIFC_Handler;                 /* 71 Analog Comparator Interface */
+  void* pfnABDACB_Handler;                /* 72 Audio Bitstream DAC */
+  void* pfnTRNG_Handler;                  /* 73 True Random Number Generator */
+  void* pfnPARC_Handler;                  /* 74 Parallel Capture */
+  void* pfnCATB_Handler;                  /* 75 Capacitive Touch Module B */
+  void* pvReserved76;
+  void* pfnTWIM2_Handler;                 /* 77 Two-wire Master Interface 2 */
+  void* pfnTWIM3_Handler;                 /* 78 Two-wire Master Interface 3 */
+  void* pfnLCDCA_Handler;                 /* 79 LCD Controller */
+} DeviceVectors;
+
+/* Cortex-M4 processor handlers */
+void Reset_Handler               ( void );
+void NMI_Handler                 ( void );
+void HardFault_Handler           ( void );
+void MemManage_Handler           ( void );
+void BusFault_Handler            ( void );
+void UsageFault_Handler          ( void );
+void SVC_Handler                 ( void );
+void DebugMon_Handler            ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void HFLASHC_Handler             ( void );
+void PDCA_0_Handler              ( void );
+void PDCA_1_Handler              ( void );
+void PDCA_2_Handler              ( void );
+void PDCA_3_Handler              ( void );
+void PDCA_4_Handler              ( void );
+void PDCA_5_Handler              ( void );
+void PDCA_6_Handler              ( void );
+void PDCA_7_Handler              ( void );
+void PDCA_8_Handler              ( void );
+void PDCA_9_Handler              ( void );
+void PDCA_10_Handler             ( void );
+void PDCA_11_Handler             ( void );
+void PDCA_12_Handler             ( void );
+void PDCA_13_Handler             ( void );
+void PDCA_14_Handler             ( void );
+void PDCA_15_Handler             ( void );
+void CRCCU_Handler               ( void );
+void USBC_Handler                ( void );
+void PEVC_0_Handler              ( void );
+void PEVC_1_Handler              ( void );
+void AESA_Handler                ( void );
+void PM_Handler                  ( void );
+void SCIF_Handler                ( void );
+void FREQM_Handler               ( void );
+void GPIO_0_Handler              ( void );
+void GPIO_1_Handler              ( void );
+void GPIO_2_Handler              ( void );
+void GPIO_3_Handler              ( void );
+void GPIO_4_Handler              ( void );
+void GPIO_5_Handler              ( void );
+void GPIO_6_Handler              ( void );
+void GPIO_7_Handler              ( void );
+void GPIO_8_Handler              ( void );
+void GPIO_9_Handler              ( void );
+void GPIO_10_Handler             ( void );
+void GPIO_11_Handler             ( void );
+void BPM_Handler                 ( void );
+void BSCIF_Handler               ( void );
+void AST_0_Handler               ( void );
+void AST_1_Handler               ( void );
+void AST_2_Handler               ( void );
+void AST_3_Handler               ( void );
+void AST_4_Handler               ( void );
+void WDT_Handler                 ( void );
+void EIC_0_Handler               ( void );
+void EIC_1_Handler               ( void );
+void EIC_2_Handler               ( void );
+void EIC_3_Handler               ( void );
+void EIC_4_Handler               ( void );
+void EIC_5_Handler               ( void );
+void EIC_6_Handler               ( void );
+void EIC_7_Handler               ( void );
+void IISC_Handler                ( void );
+void SPI_Handler                 ( void );
+void TC0_0_Handler               ( void );
+void TC0_1_Handler               ( void );
+void TC0_2_Handler               ( void );
+void TC1_0_Handler               ( void );
+void TC1_1_Handler               ( void );
+void TC1_2_Handler               ( void );
+void TWIM0_Handler               ( void );
+void TWIS0_Handler               ( void );
+void TWIM1_Handler               ( void );
+void TWIS1_Handler               ( void );
+void USART0_Handler              ( void );
+void USART1_Handler              ( void );
+void USART2_Handler              ( void );
+void USART3_Handler              ( void );
+void ADCIFE_Handler              ( void );
+void DACC_Handler                ( void );
+void ACIFC_Handler               ( void );
+void ABDACB_Handler              ( void );
+void TRNG_Handler                ( void );
+void PARC_Handler                ( void );
+void CATB_Handler                ( void );
+void TWIM2_Handler               ( void );
+void TWIM3_Handler               ( void );
+void LCDCA_Handler               ( void );
+
+/*
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
+ */
+
+#define LITTLE_ENDIAN          1        
+#define __BB_PRESENT           0         /*!< BIT_BANDING present or not */
+#define __CLKGATE_PRESENT      1         /*!< CLKGATE present or not */
+#define __CM4_REV              1         /*!< Core revision r0p1 */
+#define __DEBUG_LVL            3         /*!< Full debug plus DWT data matching */
+#define __FPU_PRESENT          0         /*!< FPU present or not */
+#define __JTAG_PRESENT         1         /*!< JTAG present or not */
+#define __MPU_PRESENT          1         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       4         /*!< Number of bits used for Priority Levels */
+#define __TRACE_LVL            1         /*!< Standard trace: ITM and DWT triggers and counters, but no ETM */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+#define __WIC_PRESENT          0         /*!< WIC present or not */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm4.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_sam4l.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAM4LC8B */
+/* ************************************************************************** */
+/** \defgroup SAM4LC8B_api Peripheral Software API */
+/*@{*/
+
+#include "component/abdacb.h"
+#include "component/acifc.h"
+#include "component/adcife.h"
+#include "component/aesa.h"
+#include "component/ast.h"
+#include "component/bpm.h"
+#include "component/bscif.h"
+#include "component/catb.h"
+#include "component/chipid.h"
+#include "component/crccu.h"
+#include "component/dacc.h"
+#include "component/eic.h"
+#include "component/flashcalw.h"
+#include "component/freqm.h"
+#include "component/gloc.h"
+#include "component/gpio.h"
+#include "component/hcache.h"
+#include "component/hmatrixb.h"
+#include "component/iisc.h"
+#include "component/lcdca.h"
+#include "component/parc.h"
+#include "component/pdca.h"
+#include "component/pevc.h"
+#include "component/picouart.h"
+#include "component/pm.h"
+#include "component/scif.h"
+#include "component/smap.h"
+#include "component/spi.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twim.h"
+#include "component/twis.h"
+#include "component/usart.h"
+#include "component/usbc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAM4LC8B */
+/* ************************************************************************** */
+/** \defgroup SAM4LC8B_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/abdacb.h"
+#include "instance/acifc.h"
+#include "instance/adcife.h"
+#include "instance/aesa.h"
+#include "instance/ast.h"
+#include "instance/bpm.h"
+#include "instance/bscif.h"
+#include "instance/catb.h"
+#include "instance/chipid.h"
+#include "instance/crccu.h"
+#include "instance/dacc.h"
+#include "instance/eic.h"
+#include "instance/hflashc.h"
+#include "instance/freqm.h"
+#include "instance/gloc.h"
+#include "instance/gpio.h"
+#include "instance/hcache.h"
+#include "instance/hmatrix.h"
+#include "instance/iisc.h"
+#include "instance/lcdca.h"
+#include "instance/parc.h"
+#include "instance/pdca.h"
+#include "instance/pevc.h"
+#include "instance/picouart.h"
+#include "instance/pm.h"
+#include "instance/scif.h"
+#include "instance/smap.h"
+#include "instance/spi.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/trng.h"
+#include "instance/twim0.h"
+#include "instance/twim1.h"
+#include "instance/twim2.h"
+#include "instance/twim3.h"
+#include "instance/twis0.h"
+#include "instance/twis1.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usart3.h"
+#include "instance/usbc.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAM4LC8B */
+/* ************************************************************************** */
+/** \defgroup SAM4LC8B_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HTOP0 bridge
+#define ID_IISC           0 /**< \brief Inter-IC Sound (I2S) Controller (IISC) */
+#define ID_SPI            1 /**< \brief Serial Peripheral Interface (SPI) */
+#define ID_TC0            2 /**< \brief Timer/Counter 0 (TC0) */
+#define ID_TC1            3 /**< \brief Timer/Counter 1 (TC1) */
+#define ID_TWIM0          4 /**< \brief Two-wire Master Interface 0 (TWIM0) */
+#define ID_TWIS0          5 /**< \brief Two-wire Slave Interface 0 (TWIS0) */
+#define ID_TWIM1          6 /**< \brief Two-wire Master Interface 1 (TWIM1) */
+#define ID_TWIS1          7 /**< \brief Two-wire Slave Interface 1 (TWIS1) */
+#define ID_USART0         8 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+#define ID_USART1         9 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+#define ID_USART2        10 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+#define ID_USART3        11 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+#define ID_ADCIFE        12 /**< \brief ADC controller interface (ADCIFE) */
+#define ID_DACC          13 /**< \brief DAC Controller (DACC) */
+#define ID_ACIFC         14 /**< \brief Analog Comparator Interface (ACIFC) */
+#define ID_GLOC          15 /**< \brief Glue Logic Controller (GLOC) */
+#define ID_ABDACB        16 /**< \brief Audio Bitstream DAC (ABDACB) */
+#define ID_TRNG          17 /**< \brief True Random Number Generator (TRNG) */
+#define ID_PARC          18 /**< \brief Parallel Capture (PARC) */
+#define ID_CATB          19 /**< \brief Capacitive Touch Module B (CATB) */
+#define ID_TWIM2         21 /**< \brief Two-wire Master Interface 2 (TWIM2) */
+#define ID_TWIM3         22 /**< \brief Two-wire Master Interface 3 (TWIM3) */
+#define ID_LCDCA         23 /**< \brief LCD Controller (LCDCA) */
+
+// Peripheral instances on HTOP1 bridge
+#define ID_HFLASHC       32 /**< \brief Flash Controller (HFLASHC) */
+#define ID_HCACHE        33 /**< \brief Cortex M I&D Cache Controller (HCACHE) */
+#define ID_HMATRIX       34 /**< \brief HSB Matrix (HMATRIX) */
+#define ID_PDCA          35 /**< \brief Peripheral DMA Controller (PDCA) */
+#define ID_SMAP          36 /**< \brief System Manager Access Port (SMAP) */
+#define ID_CRCCU         37 /**< \brief CRC Calculation Unit (CRCCU) */
+#define ID_USBC          38 /**< \brief USB 2.0 Interface (USBC) */
+#define ID_PEVC          39 /**< \brief Peripheral Event Controller (PEVC) */
+
+// Peripheral instances on HTOP2 bridge
+#define ID_PM            64 /**< \brief Power Manager (PM) */
+#define ID_CHIPID        65 /**< \brief Chip ID Registers (CHIPID) */
+#define ID_SCIF          66 /**< \brief System Control Interface (SCIF) */
+#define ID_FREQM         67 /**< \brief Frequency Meter (FREQM) */
+#define ID_GPIO          68 /**< \brief General-Purpose Input/Output Controller (GPIO) */
+
+// Peripheral instances on HTOP3 bridge
+#define ID_BPM           96 /**< \brief Backup Power Manager (BPM) */
+#define ID_BSCIF         97 /**< \brief Backup System Control Interface (BSCIF) */
+#define ID_AST           98 /**< \brief Asynchronous Timer (AST) */
+#define ID_WDT           99 /**< \brief Watchdog Timer (WDT) */
+#define ID_EIC          100 /**< \brief External Interrupt Controller (EIC) */
+#define ID_PICOUART     101 /**< \brief Pico UART (PICOUART) */
+
+// Peripheral instances on AHB (as if on bridge 4)
+#define ID_AESA         128 /**< \brief Advanced Encryption Standard (AESA) */
+
+#define ID_PERIPH_COUNT 129 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAM4LC8B */
+/* ************************************************************************** */
+/** \defgroup SAM4LC8B_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define ABDACB                        (0x40064000) /**< \brief (ABDACB) APB Base Address */
+#define ACIFC                         (0x40040000) /**< \brief (ACIFC) APB Base Address */
+#define ADCIFE                        (0x40038000) /**< \brief (ADCIFE) APB Base Address */
+#define AESA                          (0x400B0000) /**< \brief (AESA) AHB Base Address */
+#define AST                           (0x400F0800) /**< \brief (AST) APB Base Address */
+#define BPM                           (0x400F0000) /**< \brief (BPM) APB Base Address */
+#define BSCIF                         (0x400F0400) /**< \brief (BSCIF) APB Base Address */
+#define CATB                          (0x40070000) /**< \brief (CATB) APB Base Address */
+#define CHIPID                        (0x400E0400) /**< \brief (CHIPID) APB Base Address */
+#define CRCCU                         (0x400A4000) /**< \brief (CRCCU) APB Base Address */
+#define DACC                          (0x4003C000) /**< \brief (DACC) APB Base Address */
+#define EIC                           (0x400F1000) /**< \brief (EIC) APB Base Address */
+#define HFLASHC                       (0x400A0000) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000) /**< \brief (HFLASHC) USER Base Address */
+#define FREQM                         (0x400E0C00) /**< \brief (FREQM) APB Base Address */
+#define GLOC                          (0x40060000) /**< \brief (GLOC) APB Base Address */
+#define GPIO                          (0x400E1000) /**< \brief (GPIO) APB Base Address */
+#define HCACHE                        (0x400A0400) /**< \brief (HCACHE) APB Base Address */
+#define HMATRIX                       (0x400A1000) /**< \brief (HMATRIX) APB Base Address */
+#define IISC                          (0x40004000) /**< \brief (IISC) APB Base Address */
+#define LCDCA                         (0x40080000) /**< \brief (LCDCA) APB Base Address */
+#define PARC                          (0x4006C000) /**< \brief (PARC) APB Base Address */
+#define PDCA                          (0x400A2000) /**< \brief (PDCA) APB Base Address */
+#define PEVC                          (0x400A6000) /**< \brief (PEVC) APB Base Address */
+#define PICOUART                      (0x400F1400) /**< \brief (PICOUART) APB Base Address */
+#define PM                            (0x400E0000) /**< \brief (PM) APB Base Address */
+#define SCIF                          (0x400E0800) /**< \brief (SCIF) APB Base Address */
+#define SMAP                          (0x400A3000) /**< \brief (SMAP) APB Base Address */
+#define SPI                           (0x40008000) /**< \brief (SPI) APB Base Address */
+#define TC0                           (0x40010000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x40014000) /**< \brief (TC1) APB Base Address */
+#define TRNG                          (0x40068000) /**< \brief (TRNG) APB Base Address */
+#define TWIM0                         (0x40018000) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1                         (0x4001C000) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2                         (0x40078000) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3                         (0x4007C000) /**< \brief (TWIM3) APB Base Address */
+#define TWIS0                         (0x40018400) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1                         (0x4001C400) /**< \brief (TWIS1) APB Base Address */
+#define USART0                        (0x40024000) /**< \brief (USART0) APB Base Address */
+#define USART1                        (0x40028000) /**< \brief (USART1) APB Base Address */
+#define USART2                        (0x4002C000) /**< \brief (USART2) APB Base Address */
+#define USART3                        (0x40030000) /**< \brief (USART3) APB Base Address */
+#define USBC                          (0x400A5000) /**< \brief (USBC) APB Base Address */
+#define WDT                           (0x400F0C00) /**< \brief (WDT) APB Base Address */
+#else
+#define ABDACB            ((Abdacb   *)0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_ADDR                   (0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_INST_NUM   1                          /**< \brief (ABDACB) Number of instances */
+#define ABDACB_INSTS      { ABDACB }                 /**< \brief (ABDACB) Instances List */
+
+#define ACIFC             ((Acifc    *)0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_ADDR                    (0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_INST_NUM    1                          /**< \brief (ACIFC) Number of instances */
+#define ACIFC_INSTS       { ACIFC }                  /**< \brief (ACIFC) Instances List */
+
+#define ADCIFE            ((Adcife   *)0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_ADDR                   (0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_INST_NUM   1                          /**< \brief (ADCIFE) Number of instances */
+#define ADCIFE_INSTS      { ADCIFE }                 /**< \brief (ADCIFE) Instances List */
+
+#define AESA              ((Aesa     *)0x400B0000UL) /**< \brief (AESA) AHB Base Address */
+#define AESA_ADDR                     (0x400B0000UL) /**< \brief (AESA) AHB Base Address */
+#define AESA_INST_NUM     1                          /**< \brief (AESA) Number of instances */
+#define AESA_INSTS        { AESA }                   /**< \brief (AESA) Instances List */
+
+#define AST               ((Ast      *)0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_ADDR                      (0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_INST_NUM      1                          /**< \brief (AST) Number of instances */
+#define AST_INSTS         { AST }                    /**< \brief (AST) Instances List */
+
+#define BPM               ((Bpm      *)0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_ADDR                      (0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_INST_NUM      1                          /**< \brief (BPM) Number of instances */
+#define BPM_INSTS         { BPM }                    /**< \brief (BPM) Instances List */
+
+#define BSCIF             ((Bscif    *)0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_ADDR                    (0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_INST_NUM    1                          /**< \brief (BSCIF) Number of instances */
+#define BSCIF_INSTS       { BSCIF }                  /**< \brief (BSCIF) Instances List */
+
+#define CATB              ((Catb     *)0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_ADDR                     (0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_INST_NUM     1                          /**< \brief (CATB) Number of instances */
+#define CATB_INSTS        { CATB }                   /**< \brief (CATB) Instances List */
+
+#define CHIPID            ((Chipid   *)0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_ADDR                   (0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_INST_NUM   1                          /**< \brief (CHIPID) Number of instances */
+#define CHIPID_INSTS      { CHIPID }                 /**< \brief (CHIPID) Instances List */
+
+#define CRCCU             ((Crccu    *)0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_ADDR                    (0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_INST_NUM    1                          /**< \brief (CRCCU) Number of instances */
+#define CRCCU_INSTS       { CRCCU }                  /**< \brief (CRCCU) Instances List */
+
+#define DACC              ((Dacc     *)0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_ADDR                     (0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_INST_NUM     1                          /**< \brief (DACC) Number of instances */
+#define DACC_INSTS        { DACC }                   /**< \brief (DACC) Instances List */
+
+#define EIC               ((Eic      *)0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_ADDR                      (0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define HFLASHC           ((Flashcalw *)0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_ADDR                  (0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_FROW_ADDR             (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define HFLASHC_USER_ADDR             (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define FLASHCALW_INST_NUM 1                          /**< \brief (FLASHCALW) Number of instances */
+#define FLASHCALW_INSTS   { HFLASHC }                /**< \brief (FLASHCALW) Instances List */
+
+#define FREQM             ((Freqm    *)0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_ADDR                    (0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_INST_NUM    1                          /**< \brief (FREQM) Number of instances */
+#define FREQM_INSTS       { FREQM }                  /**< \brief (FREQM) Instances List */
+
+#define GLOC              ((Gloc     *)0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_ADDR                     (0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_INST_NUM     1                          /**< \brief (GLOC) Number of instances */
+#define GLOC_INSTS        { GLOC }                   /**< \brief (GLOC) Instances List */
+
+#define GPIO              ((Gpio     *)0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_ADDR                     (0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_INST_NUM     1                          /**< \brief (GPIO) Number of instances */
+#define GPIO_INSTS        { GPIO }                   /**< \brief (GPIO) Instances List */
+
+#define HCACHE            ((Hcache   *)0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_ADDR                   (0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_INST_NUM   1                          /**< \brief (HCACHE) Number of instances */
+#define HCACHE_INSTS      { HCACHE }                 /**< \brief (HCACHE) Instances List */
+
+#define HMATRIX           ((Hmatrixb *)0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIX_ADDR                  (0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIXB_INST_NUM 1                          /**< \brief (HMATRIXB) Number of instances */
+#define HMATRIXB_INSTS    { HMATRIX }                /**< \brief (HMATRIXB) Instances List */
+
+#define IISC              ((Iisc     *)0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_ADDR                     (0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_INST_NUM     1                          /**< \brief (IISC) Number of instances */
+#define IISC_INSTS        { IISC }                   /**< \brief (IISC) Instances List */
+
+#define LCDCA             ((Lcdca    *)0x40080000UL) /**< \brief (LCDCA) APB Base Address */
+#define LCDCA_ADDR                    (0x40080000UL) /**< \brief (LCDCA) APB Base Address */
+#define LCDCA_INST_NUM    1                          /**< \brief (LCDCA) Number of instances */
+#define LCDCA_INSTS       { LCDCA }                  /**< \brief (LCDCA) Instances List */
+
+#define PARC              ((Parc     *)0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_ADDR                     (0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_INST_NUM     1                          /**< \brief (PARC) Number of instances */
+#define PARC_INSTS        { PARC }                   /**< \brief (PARC) Instances List */
+
+#define PDCA              ((Pdca     *)0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_ADDR                     (0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_INST_NUM     1                          /**< \brief (PDCA) Number of instances */
+#define PDCA_INSTS        { PDCA }                   /**< \brief (PDCA) Instances List */
+
+#define PEVC              ((Pevc     *)0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_ADDR                     (0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_INST_NUM     1                          /**< \brief (PEVC) Number of instances */
+#define PEVC_INSTS        { PEVC }                   /**< \brief (PEVC) Instances List */
+
+#define PICOUART          ((Picouart *)0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_ADDR                 (0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_INST_NUM 1                          /**< \brief (PICOUART) Number of instances */
+#define PICOUART_INSTS    { PICOUART }               /**< \brief (PICOUART) Instances List */
+
+#define PM                ((Pm       *)0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_ADDR                       (0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define SCIF              ((Scif     *)0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_ADDR                     (0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_INST_NUM     1                          /**< \brief (SCIF) Number of instances */
+#define SCIF_INSTS        { SCIF }                   /**< \brief (SCIF) Instances List */
+
+#define SMAP              ((Smap     *)0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_ADDR                     (0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_INST_NUM     1                          /**< \brief (SMAP) Number of instances */
+#define SMAP_INSTS        { SMAP }                   /**< \brief (SMAP) Instances List */
+
+#define SPI               ((Spi      *)0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_ADDR                      (0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_INST_NUM      1                          /**< \brief (SPI) Number of instances */
+#define SPI_INSTS         { SPI }                    /**< \brief (SPI) Instances List */
+
+#define TC0               ((Tc       *)0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC0_ADDR                      (0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC1_ADDR                      (0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC_INST_NUM       2                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1 }               /**< \brief (TC) Instances List */
+
+#define TRNG              ((Trng     *)0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_ADDR                     (0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_INST_NUM     1                          /**< \brief (TRNG) Number of instances */
+#define TRNG_INSTS        { TRNG }                   /**< \brief (TRNG) Instances List */
+
+#define TWIM0             ((Twim     *)0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM0_ADDR                    (0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1             ((Twim     *)0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM1_ADDR                    (0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2             ((Twim     *)0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM2_ADDR                    (0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3             ((Twim     *)0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM3_ADDR                    (0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM_INST_NUM     4                          /**< \brief (TWIM) Number of instances */
+#define TWIM_INSTS        { TWIM0, TWIM1, TWIM2, TWIM3 } /**< \brief (TWIM) Instances List */
+
+#define TWIS0             ((Twis     *)0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS0_ADDR                    (0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1             ((Twis     *)0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS1_ADDR                    (0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS_INST_NUM     2                          /**< \brief (TWIS) Number of instances */
+#define TWIS_INSTS        { TWIS0, TWIS1 }           /**< \brief (TWIS) Instances List */
+
+#define USART0            ((Usart    *)0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART0_ADDR                   (0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART1            ((Usart    *)0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART1_ADDR                   (0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART2            ((Usart    *)0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART2_ADDR                   (0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART3            ((Usart    *)0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART3_ADDR                   (0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART_INST_NUM    4                          /**< \brief (USART) Number of instances */
+#define USART_INSTS       { USART0, USART1, USART2, USART3 } /**< \brief (USART) Instances List */
+
+#define USBC              ((Usbc     *)0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_ADDR                     (0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_INST_NUM     1                          /**< \brief (USBC) Number of instances */
+#define USBC_INSTS        { USBC }                   /**< \brief (USBC) Instances List */
+
+#define WDT               ((Wdt      *)0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_ADDR                      (0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  GPIO DEFINITIONS FOR SAM4LC8B */
+/* ************************************************************************** */
+/** \defgroup SAM4LC8B_gpio GPIO Definitions */
+/*@{*/
+
+#include "pio/sam4lc8b.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  ADDITIONAL DEFINITIONS FOR COMPATIBILITY */
+/* ************************************************************************** */
+/** \addtogroup SAM4LC8B_compat Definitions */
+/*@{*/
+// These defines are used to keep compatibility with existing 
+// sam/drivers/usart implementation from SAM3/4 products with SAM4L product.
+#define US_MR_USART_MODE_HW_HANDSHAKING  US_MR_USART_MODE_HARDWARE
+#define US_MR_USART_MODE_IS07816_T_0     US_MR_USART_MODE_ISO7816_T0
+#define US_MR_USART_MODE_IS07816_T_1     US_MR_USART_MODE_ISO7816_T1
+#define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
+#define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
+#define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_8_BIT      US_MR_CHRL_8
+#define US_MR_PAR_NO          US_MR_PAR_NONE
+#define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI
+#define US_IF                 US_IFR
+#define US_WPSR_WPVS          US_WPSR_WPV_1
+
+#define USBC_UPCFG0_PBK_Msk   (0x1u << USBC_UPCFG0_PBK_Pos)
+
+// These defines for homogeneity with other SAM header files.
+#define CHIP_FREQ_FWS_0       (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 */
+#define CHIP_FREQ_FWS_1       (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 */
+// WARNING NOTE: these are preliminary values.
+#define CHIP_FREQ_FLASH_HSEN_FWS_0 (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 and the FLASH HS mode is enabled */
+#define CHIP_FREQ_FLASH_HSEN_FWS_1 (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 and the FLASH HS mode is enabled */
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/tc implementation from SAM3/4 products with SAM4L product. 
+#define TC_CMR_LDRA_RISING    TC_CMR_LDRA_POS_EDGE_TIOA
+#define TC_CMR_LDRB_FALLING   TC_CMR_LDRB_NEG_EDGE_TIOA
+#define TC_CMR_ETRGEDG_FALLING TC_CMR_ETRGEDG_NEG_EDGE
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/spi implementation from SAM3/4 products with SAM4L product. 
+#define SPI_CSR_BITS_8_BIT    SPI_CSR_BITS_8_BPT
+#define SPI_WPCR_SPIWPKEY_VALUE SPI_WPCR_WPKEY_VALUE
+#define SPI_WPCR_SPIWPEN      SPI_WPCR_WPEN
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/crccu implementation from SAM3/4 products with SAM4L product. 
+#define CRCCU_DMA_EN          CRCCU_DMAEN
+#define CRCCU_DMA_DIS         CRCCU_DMADIS
+#define CRCCU_DMA_SR          CRCCU_DMASR
+#define CRCCU_DMA_IER         CRCCU_DMAIER
+#define CRCCU_DMA_IDR         CRCCU_DMAIDR
+#define CRCCU_DMA_IMR         CRCCU_DMAIMR
+#define CRCCU_DMA_ISR         CRCCU_DMAISR
+#define CRCCU_DMA_EN_DMAEN    CRCCU_DMAEN_DMAEN
+#define CRCCU_DMA_DIS_DMADIS  CRCCU_DMADIS_DMADIS
+#define CRCCU_DMA_SR_DMASR    CRCCU_DMASR_DMASR
+#define CRCCU_DMA_IER_DMAIER  CRCCU_DMAIER_DMAIER
+#define CRCCU_DMA_IDR_DMAIDR  CRCCU_DMAIDR_DMAIDR
+#define CRCCU_DMA_IMR_DMAIMR  CRCCU_DMAIMR_DMAIMR
+#define CRCCU_DMA_ISR_DMAISR  CRCCU_DMAISR_DMAISR
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAM4LC8B */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL(0x00080000) /* 512 kB */
+#define FLASH_PAGE_SIZE       512
+#define FLASH_NB_OF_PAGES     1024
+#define FLASH_USER_PAGE_SIZE  512
+#define HRAMC0_SIZE           _UL(0x00010000) /* 64 kB */
+#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+
+#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+
+#define DSU_DID_RESETVALUE    _UL(0xAB0B0AE0)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAM4LC8B */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAM4LC8B_H */

--- a/asf/sam/include/sam4l/sam4lc8c.h
+++ b/asf/sam/include/sam4l/sam4lc8c.h
@@ -62,15 +62,15 @@ typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volati
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
 #if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#define _U_(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
 #if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#define _U_(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 
@@ -881,23 +881,23 @@ void LCDCA_Handler               ( void );
 /**  MEMORY MAPPING DEFINITIONS FOR SAM4LC8C */
 /* ************************************************************************** */
 
-#define FLASH_SIZE            _UL(0x00080000) /* 512 kB */
+#define FLASH_SIZE            _UL_(0x00080000) /* 512 kB */
 #define FLASH_PAGE_SIZE       512
 #define FLASH_NB_OF_PAGES     1024
 #define FLASH_USER_PAGE_SIZE  512
-#define HRAMC0_SIZE           _UL(0x00010000) /* 64 kB */
-#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+#define HRAMC0_SIZE           _UL_(0x00010000) /* 64 kB */
+#define HRAMC1_SIZE           _UL_(0x00000800) /* 2 kB */
 
-#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
-#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
-#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
-#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
-#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
-#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
-#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
-#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL_(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL_(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL_(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL_(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL_(0x400F0000) /**< HTOP3 base address */
 
-#define DSU_DID_RESETVALUE    _UL(0xAB0B0AE0)
+#define DSU_DID_RESETVALUE    _UL_(0xAB0B0AE0)
 
 /* ************************************************************************** */
 /**  ELECTRICAL DEFINITIONS FOR SAM4LC8C */

--- a/asf/sam/include/sam4l/sam4lc8c.h
+++ b/asf/sam/include/sam4l/sam4lc8c.h
@@ -1,0 +1,913 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAM4LC8C
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LC8C_
+#define _SAM4LC8C_
+
+/**
+ * \ingroup SAM4L_definitions
+ * \addtogroup SAM4LC8C_definitions SAM4LC8C definitions
+ * This file defines all structures and symbols for SAM4LC8C:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#if !defined(_UL)
+#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#endif
+#else
+#if !defined(_UL)
+#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif
+#endif
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAM4LC8C */
+/* ************************************************************************** */
+/** \defgroup SAM4LC8C_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M4 Processor Exceptions Numbers ******************************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn           = -13,/**<  3 Cortex-M4 Hard Fault Interrupt        */
+  MemoryManagement_IRQn    = -12,/**<  4 Cortex-M4 Memory Management Interrupt */
+  BusFault_IRQn            = -11,/**<  5 Cortex-M4 Bus Fault Interrupt         */
+  UsageFault_IRQn          = -10,/**<  6 Cortex-M4 Usage Fault Interrupt       */
+  SVCall_IRQn              = -5, /**< 11 Cortex-M4 SV Call Interrupt           */
+  DebugMonitor_IRQn        = -4, /**< 12 Cortex-M4 Debug Monitor Interrupt     */
+  PendSV_IRQn              = -2, /**< 14 Cortex-M4 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 Cortex-M4 System Tick Interrupt       */
+  /******  SAM4LC8C-specific Interrupt Numbers ***********************/
+  HFLASHC_IRQn             =  0, /**<  0 SAM4LC8C Flash Controller (HFLASHC) */
+  PDCA_0_IRQn              =  1, /**<  1 SAM4LC8C Peripheral DMA Controller (PDCA): PDCA_0 */
+  PDCA_1_IRQn              =  2, /**<  2 SAM4LC8C Peripheral DMA Controller (PDCA): PDCA_1 */
+  PDCA_2_IRQn              =  3, /**<  3 SAM4LC8C Peripheral DMA Controller (PDCA): PDCA_2 */
+  PDCA_3_IRQn              =  4, /**<  4 SAM4LC8C Peripheral DMA Controller (PDCA): PDCA_3 */
+  PDCA_4_IRQn              =  5, /**<  5 SAM4LC8C Peripheral DMA Controller (PDCA): PDCA_4 */
+  PDCA_5_IRQn              =  6, /**<  6 SAM4LC8C Peripheral DMA Controller (PDCA): PDCA_5 */
+  PDCA_6_IRQn              =  7, /**<  7 SAM4LC8C Peripheral DMA Controller (PDCA): PDCA_6 */
+  PDCA_7_IRQn              =  8, /**<  8 SAM4LC8C Peripheral DMA Controller (PDCA): PDCA_7 */
+  PDCA_8_IRQn              =  9, /**<  9 SAM4LC8C Peripheral DMA Controller (PDCA): PDCA_8 */
+  PDCA_9_IRQn              = 10, /**< 10 SAM4LC8C Peripheral DMA Controller (PDCA): PDCA_9 */
+  PDCA_10_IRQn             = 11, /**< 11 SAM4LC8C Peripheral DMA Controller (PDCA): PDCA_10 */
+  PDCA_11_IRQn             = 12, /**< 12 SAM4LC8C Peripheral DMA Controller (PDCA): PDCA_11 */
+  PDCA_12_IRQn             = 13, /**< 13 SAM4LC8C Peripheral DMA Controller (PDCA): PDCA_12 */
+  PDCA_13_IRQn             = 14, /**< 14 SAM4LC8C Peripheral DMA Controller (PDCA): PDCA_13 */
+  PDCA_14_IRQn             = 15, /**< 15 SAM4LC8C Peripheral DMA Controller (PDCA): PDCA_14 */
+  PDCA_15_IRQn             = 16, /**< 16 SAM4LC8C Peripheral DMA Controller (PDCA): PDCA_15 */
+  CRCCU_IRQn               = 17, /**< 17 SAM4LC8C CRC Calculation Unit (CRCCU) */
+  USBC_IRQn                = 18, /**< 18 SAM4LC8C USB 2.0 Interface (USBC) */
+  PEVC_0_IRQn              = 19, /**< 19 SAM4LC8C Peripheral Event Controller (PEVC): PEVC_TR */
+  PEVC_1_IRQn              = 20, /**< 20 SAM4LC8C Peripheral Event Controller (PEVC): PEVC_OV */
+  AESA_IRQn                = 21, /**< 21 SAM4LC8C Advanced Encryption Standard (AESA) */
+  PM_IRQn                  = 22, /**< 22 SAM4LC8C Power Manager (PM) */
+  SCIF_IRQn                = 23, /**< 23 SAM4LC8C System Control Interface (SCIF) */
+  FREQM_IRQn               = 24, /**< 24 SAM4LC8C Frequency Meter (FREQM) */
+  GPIO_0_IRQn              = 25, /**< 25 SAM4LC8C General-Purpose Input/Output Controller (GPIO): GPIO_0 */
+  GPIO_1_IRQn              = 26, /**< 26 SAM4LC8C General-Purpose Input/Output Controller (GPIO): GPIO_1 */
+  GPIO_2_IRQn              = 27, /**< 27 SAM4LC8C General-Purpose Input/Output Controller (GPIO): GPIO_2 */
+  GPIO_3_IRQn              = 28, /**< 28 SAM4LC8C General-Purpose Input/Output Controller (GPIO): GPIO_3 */
+  GPIO_4_IRQn              = 29, /**< 29 SAM4LC8C General-Purpose Input/Output Controller (GPIO): GPIO_4 */
+  GPIO_5_IRQn              = 30, /**< 30 SAM4LC8C General-Purpose Input/Output Controller (GPIO): GPIO_5 */
+  GPIO_6_IRQn              = 31, /**< 31 SAM4LC8C General-Purpose Input/Output Controller (GPIO): GPIO_6 */
+  GPIO_7_IRQn              = 32, /**< 32 SAM4LC8C General-Purpose Input/Output Controller (GPIO): GPIO_7 */
+  GPIO_8_IRQn              = 33, /**< 33 SAM4LC8C General-Purpose Input/Output Controller (GPIO): GPIO_8 */
+  GPIO_9_IRQn              = 34, /**< 34 SAM4LC8C General-Purpose Input/Output Controller (GPIO): GPIO_9 */
+  GPIO_10_IRQn             = 35, /**< 35 SAM4LC8C General-Purpose Input/Output Controller (GPIO): GPIO_10 */
+  GPIO_11_IRQn             = 36, /**< 36 SAM4LC8C General-Purpose Input/Output Controller (GPIO): GPIO_11 */
+  BPM_IRQn                 = 37, /**< 37 SAM4LC8C Backup Power Manager (BPM) */
+  BSCIF_IRQn               = 38, /**< 38 SAM4LC8C Backup System Control Interface (BSCIF) */
+  AST_0_IRQn               = 39, /**< 39 SAM4LC8C Asynchronous Timer (AST): AST_ALARM */
+  AST_1_IRQn               = 40, /**< 40 SAM4LC8C Asynchronous Timer (AST): AST_PER */
+  AST_2_IRQn               = 41, /**< 41 SAM4LC8C Asynchronous Timer (AST): AST_OVF */
+  AST_3_IRQn               = 42, /**< 42 SAM4LC8C Asynchronous Timer (AST): AST_READY */
+  AST_4_IRQn               = 43, /**< 43 SAM4LC8C Asynchronous Timer (AST): AST_CLKREADY */
+  WDT_IRQn                 = 44, /**< 44 SAM4LC8C Watchdog Timer (WDT) */
+  EIC_0_IRQn               = 45, /**< 45 SAM4LC8C External Interrupt Controller (EIC): EIC_1 */
+  EIC_1_IRQn               = 46, /**< 46 SAM4LC8C External Interrupt Controller (EIC): EIC_2 */
+  EIC_2_IRQn               = 47, /**< 47 SAM4LC8C External Interrupt Controller (EIC): EIC_3 */
+  EIC_3_IRQn               = 48, /**< 48 SAM4LC8C External Interrupt Controller (EIC): EIC_4 */
+  EIC_4_IRQn               = 49, /**< 49 SAM4LC8C External Interrupt Controller (EIC): EIC_5 */
+  EIC_5_IRQn               = 50, /**< 50 SAM4LC8C External Interrupt Controller (EIC): EIC_6 */
+  EIC_6_IRQn               = 51, /**< 51 SAM4LC8C External Interrupt Controller (EIC): EIC_7 */
+  EIC_7_IRQn               = 52, /**< 52 SAM4LC8C External Interrupt Controller (EIC): EIC_8 */
+  IISC_IRQn                = 53, /**< 53 SAM4LC8C Inter-IC Sound (I2S) Controller (IISC) */
+  SPI_IRQn                 = 54, /**< 54 SAM4LC8C Serial Peripheral Interface (SPI) */
+  TC0_0_IRQn               = 55, /**< 55 SAM4LC8C Timer/Counter 0 (TC0): TC00 */
+  TC0_1_IRQn               = 56, /**< 56 SAM4LC8C Timer/Counter 0 (TC0): TC01 */
+  TC0_2_IRQn               = 57, /**< 57 SAM4LC8C Timer/Counter 0 (TC0): TC02 */
+  TC1_0_IRQn               = 58, /**< 58 SAM4LC8C Timer/Counter 1 (TC1): TC10 */
+  TC1_1_IRQn               = 59, /**< 59 SAM4LC8C Timer/Counter 1 (TC1): TC11 */
+  TC1_2_IRQn               = 60, /**< 60 SAM4LC8C Timer/Counter 1 (TC1): TC12 */
+  TWIM0_IRQn               = 61, /**< 61 SAM4LC8C Two-wire Master Interface 0 (TWIM0) */
+  TWIS0_IRQn               = 62, /**< 62 SAM4LC8C Two-wire Slave Interface 0 (TWIS0) */
+  TWIM1_IRQn               = 63, /**< 63 SAM4LC8C Two-wire Master Interface 1 (TWIM1) */
+  TWIS1_IRQn               = 64, /**< 64 SAM4LC8C Two-wire Slave Interface 1 (TWIS1) */
+  USART0_IRQn              = 65, /**< 65 SAM4LC8C Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+  USART1_IRQn              = 66, /**< 66 SAM4LC8C Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+  USART2_IRQn              = 67, /**< 67 SAM4LC8C Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+  USART3_IRQn              = 68, /**< 68 SAM4LC8C Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+  ADCIFE_IRQn              = 69, /**< 69 SAM4LC8C ADC controller interface (ADCIFE) */
+  DACC_IRQn                = 70, /**< 70 SAM4LC8C DAC Controller (DACC) */
+  ACIFC_IRQn               = 71, /**< 71 SAM4LC8C Analog Comparator Interface (ACIFC) */
+  ABDACB_IRQn              = 72, /**< 72 SAM4LC8C Audio Bitstream DAC (ABDACB) */
+  TRNG_IRQn                = 73, /**< 73 SAM4LC8C True Random Number Generator (TRNG) */
+  PARC_IRQn                = 74, /**< 74 SAM4LC8C Parallel Capture (PARC) */
+  CATB_IRQn                = 75, /**< 75 SAM4LC8C Capacitive Touch Module B (CATB) */
+  TWIM2_IRQn               = 77, /**< 77 SAM4LC8C Two-wire Master Interface 2 (TWIM2) */
+  TWIM3_IRQn               = 78, /**< 78 SAM4LC8C Two-wire Master Interface 3 (TWIM3) */
+  LCDCA_IRQn               = 79, /**< 79 SAM4LC8C LCD Controller (LCDCA) */
+
+  PERIPH_COUNT_IRQn        = 80  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNMI_Handler;
+  void* pfnHardFault_Handler;
+  void* pfnMemManage_Handler;
+  void* pfnBusFault_Handler;
+  void* pfnUsageFault_Handler;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVC_Handler;
+  void* pfnDebugMon_Handler;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnHFLASHC_Handler;               /*  0 Flash Controller */
+  void* pfnPDCA_0_Handler;                /*  1 Peripheral DMA Controller IRQ 0 */
+  void* pfnPDCA_1_Handler;                /*  2 Peripheral DMA Controller IRQ 1 */
+  void* pfnPDCA_2_Handler;                /*  3 Peripheral DMA Controller IRQ 2 */
+  void* pfnPDCA_3_Handler;                /*  4 Peripheral DMA Controller IRQ 3 */
+  void* pfnPDCA_4_Handler;                /*  5 Peripheral DMA Controller IRQ 4 */
+  void* pfnPDCA_5_Handler;                /*  6 Peripheral DMA Controller IRQ 5 */
+  void* pfnPDCA_6_Handler;                /*  7 Peripheral DMA Controller IRQ 6 */
+  void* pfnPDCA_7_Handler;                /*  8 Peripheral DMA Controller IRQ 7 */
+  void* pfnPDCA_8_Handler;                /*  9 Peripheral DMA Controller IRQ 8 */
+  void* pfnPDCA_9_Handler;                /* 10 Peripheral DMA Controller IRQ 9 */
+  void* pfnPDCA_10_Handler;               /* 11 Peripheral DMA Controller IRQ 10 */
+  void* pfnPDCA_11_Handler;               /* 12 Peripheral DMA Controller IRQ 11 */
+  void* pfnPDCA_12_Handler;               /* 13 Peripheral DMA Controller IRQ 12 */
+  void* pfnPDCA_13_Handler;               /* 14 Peripheral DMA Controller IRQ 13 */
+  void* pfnPDCA_14_Handler;               /* 15 Peripheral DMA Controller IRQ 14 */
+  void* pfnPDCA_15_Handler;               /* 16 Peripheral DMA Controller IRQ 15 */
+  void* pfnCRCCU_Handler;                 /* 17 CRC Calculation Unit */
+  void* pfnUSBC_Handler;                  /* 18 USB 2.0 Interface */
+  void* pfnPEVC_0_Handler;                /* 19 Peripheral Event Controller IRQ 0 */
+  void* pfnPEVC_1_Handler;                /* 20 Peripheral Event Controller IRQ 1 */
+  void* pfnAESA_Handler;                  /* 21 Advanced Encryption Standard */
+  void* pfnPM_Handler;                    /* 22 Power Manager */
+  void* pfnSCIF_Handler;                  /* 23 System Control Interface */
+  void* pfnFREQM_Handler;                 /* 24 Frequency Meter */
+  void* pfnGPIO_0_Handler;                /* 25 General-Purpose Input/Output Controller IRQ 0 */
+  void* pfnGPIO_1_Handler;                /* 26 General-Purpose Input/Output Controller IRQ 1 */
+  void* pfnGPIO_2_Handler;                /* 27 General-Purpose Input/Output Controller IRQ 2 */
+  void* pfnGPIO_3_Handler;                /* 28 General-Purpose Input/Output Controller IRQ 3 */
+  void* pfnGPIO_4_Handler;                /* 29 General-Purpose Input/Output Controller IRQ 4 */
+  void* pfnGPIO_5_Handler;                /* 30 General-Purpose Input/Output Controller IRQ 5 */
+  void* pfnGPIO_6_Handler;                /* 31 General-Purpose Input/Output Controller IRQ 6 */
+  void* pfnGPIO_7_Handler;                /* 32 General-Purpose Input/Output Controller IRQ 7 */
+  void* pfnGPIO_8_Handler;                /* 33 General-Purpose Input/Output Controller IRQ 8 */
+  void* pfnGPIO_9_Handler;                /* 34 General-Purpose Input/Output Controller IRQ 9 */
+  void* pfnGPIO_10_Handler;               /* 35 General-Purpose Input/Output Controller IRQ 10 */
+  void* pfnGPIO_11_Handler;               /* 36 General-Purpose Input/Output Controller IRQ 11 */
+  void* pfnBPM_Handler;                   /* 37 Backup Power Manager */
+  void* pfnBSCIF_Handler;                 /* 38 Backup System Control Interface */
+  void* pfnAST_0_Handler;                 /* 39 Asynchronous Timer IRQ 0 */
+  void* pfnAST_1_Handler;                 /* 40 Asynchronous Timer IRQ 1 */
+  void* pfnAST_2_Handler;                 /* 41 Asynchronous Timer IRQ 2 */
+  void* pfnAST_3_Handler;                 /* 42 Asynchronous Timer IRQ 3 */
+  void* pfnAST_4_Handler;                 /* 43 Asynchronous Timer IRQ 4 */
+  void* pfnWDT_Handler;                   /* 44 Watchdog Timer */
+  void* pfnEIC_0_Handler;                 /* 45 External Interrupt Controller IRQ 0 */
+  void* pfnEIC_1_Handler;                 /* 46 External Interrupt Controller IRQ 1 */
+  void* pfnEIC_2_Handler;                 /* 47 External Interrupt Controller IRQ 2 */
+  void* pfnEIC_3_Handler;                 /* 48 External Interrupt Controller IRQ 3 */
+  void* pfnEIC_4_Handler;                 /* 49 External Interrupt Controller IRQ 4 */
+  void* pfnEIC_5_Handler;                 /* 50 External Interrupt Controller IRQ 5 */
+  void* pfnEIC_6_Handler;                 /* 51 External Interrupt Controller IRQ 6 */
+  void* pfnEIC_7_Handler;                 /* 52 External Interrupt Controller IRQ 7 */
+  void* pfnIISC_Handler;                  /* 53 Inter-IC Sound (I2S) Controller */
+  void* pfnSPI_Handler;                   /* 54 Serial Peripheral Interface */
+  void* pfnTC0_0_Handler;                 /* 55 Timer/Counter 0 IRQ 0 */
+  void* pfnTC0_1_Handler;                 /* 56 Timer/Counter 0 IRQ 1 */
+  void* pfnTC0_2_Handler;                 /* 57 Timer/Counter 0 IRQ 2 */
+  void* pfnTC1_0_Handler;                 /* 58 Timer/Counter 1 IRQ 0 */
+  void* pfnTC1_1_Handler;                 /* 59 Timer/Counter 1 IRQ 1 */
+  void* pfnTC1_2_Handler;                 /* 60 Timer/Counter 1 IRQ 2 */
+  void* pfnTWIM0_Handler;                 /* 61 Two-wire Master Interface 0 */
+  void* pfnTWIS0_Handler;                 /* 62 Two-wire Slave Interface 0 */
+  void* pfnTWIM1_Handler;                 /* 63 Two-wire Master Interface 1 */
+  void* pfnTWIS1_Handler;                 /* 64 Two-wire Slave Interface 1 */
+  void* pfnUSART0_Handler;                /* 65 Universal Synchronous Asynchronous Receiver Transmitter 0 */
+  void* pfnUSART1_Handler;                /* 66 Universal Synchronous Asynchronous Receiver Transmitter 1 */
+  void* pfnUSART2_Handler;                /* 67 Universal Synchronous Asynchronous Receiver Transmitter 2 */
+  void* pfnUSART3_Handler;                /* 68 Universal Synchronous Asynchronous Receiver Transmitter 3 */
+  void* pfnADCIFE_Handler;                /* 69 ADC controller interface */
+  void* pfnDACC_Handler;                  /* 70 DAC Controller */
+  void* pfnACIFC_Handler;                 /* 71 Analog Comparator Interface */
+  void* pfnABDACB_Handler;                /* 72 Audio Bitstream DAC */
+  void* pfnTRNG_Handler;                  /* 73 True Random Number Generator */
+  void* pfnPARC_Handler;                  /* 74 Parallel Capture */
+  void* pfnCATB_Handler;                  /* 75 Capacitive Touch Module B */
+  void* pvReserved76;
+  void* pfnTWIM2_Handler;                 /* 77 Two-wire Master Interface 2 */
+  void* pfnTWIM3_Handler;                 /* 78 Two-wire Master Interface 3 */
+  void* pfnLCDCA_Handler;                 /* 79 LCD Controller */
+} DeviceVectors;
+
+/* Cortex-M4 processor handlers */
+void Reset_Handler               ( void );
+void NMI_Handler                 ( void );
+void HardFault_Handler           ( void );
+void MemManage_Handler           ( void );
+void BusFault_Handler            ( void );
+void UsageFault_Handler          ( void );
+void SVC_Handler                 ( void );
+void DebugMon_Handler            ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void HFLASHC_Handler             ( void );
+void PDCA_0_Handler              ( void );
+void PDCA_1_Handler              ( void );
+void PDCA_2_Handler              ( void );
+void PDCA_3_Handler              ( void );
+void PDCA_4_Handler              ( void );
+void PDCA_5_Handler              ( void );
+void PDCA_6_Handler              ( void );
+void PDCA_7_Handler              ( void );
+void PDCA_8_Handler              ( void );
+void PDCA_9_Handler              ( void );
+void PDCA_10_Handler             ( void );
+void PDCA_11_Handler             ( void );
+void PDCA_12_Handler             ( void );
+void PDCA_13_Handler             ( void );
+void PDCA_14_Handler             ( void );
+void PDCA_15_Handler             ( void );
+void CRCCU_Handler               ( void );
+void USBC_Handler                ( void );
+void PEVC_0_Handler              ( void );
+void PEVC_1_Handler              ( void );
+void AESA_Handler                ( void );
+void PM_Handler                  ( void );
+void SCIF_Handler                ( void );
+void FREQM_Handler               ( void );
+void GPIO_0_Handler              ( void );
+void GPIO_1_Handler              ( void );
+void GPIO_2_Handler              ( void );
+void GPIO_3_Handler              ( void );
+void GPIO_4_Handler              ( void );
+void GPIO_5_Handler              ( void );
+void GPIO_6_Handler              ( void );
+void GPIO_7_Handler              ( void );
+void GPIO_8_Handler              ( void );
+void GPIO_9_Handler              ( void );
+void GPIO_10_Handler             ( void );
+void GPIO_11_Handler             ( void );
+void BPM_Handler                 ( void );
+void BSCIF_Handler               ( void );
+void AST_0_Handler               ( void );
+void AST_1_Handler               ( void );
+void AST_2_Handler               ( void );
+void AST_3_Handler               ( void );
+void AST_4_Handler               ( void );
+void WDT_Handler                 ( void );
+void EIC_0_Handler               ( void );
+void EIC_1_Handler               ( void );
+void EIC_2_Handler               ( void );
+void EIC_3_Handler               ( void );
+void EIC_4_Handler               ( void );
+void EIC_5_Handler               ( void );
+void EIC_6_Handler               ( void );
+void EIC_7_Handler               ( void );
+void IISC_Handler                ( void );
+void SPI_Handler                 ( void );
+void TC0_0_Handler               ( void );
+void TC0_1_Handler               ( void );
+void TC0_2_Handler               ( void );
+void TC1_0_Handler               ( void );
+void TC1_1_Handler               ( void );
+void TC1_2_Handler               ( void );
+void TWIM0_Handler               ( void );
+void TWIS0_Handler               ( void );
+void TWIM1_Handler               ( void );
+void TWIS1_Handler               ( void );
+void USART0_Handler              ( void );
+void USART1_Handler              ( void );
+void USART2_Handler              ( void );
+void USART3_Handler              ( void );
+void ADCIFE_Handler              ( void );
+void DACC_Handler                ( void );
+void ACIFC_Handler               ( void );
+void ABDACB_Handler              ( void );
+void TRNG_Handler                ( void );
+void PARC_Handler                ( void );
+void CATB_Handler                ( void );
+void TWIM2_Handler               ( void );
+void TWIM3_Handler               ( void );
+void LCDCA_Handler               ( void );
+
+/*
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
+ */
+
+#define LITTLE_ENDIAN          1        
+#define __BB_PRESENT           0         /*!< BIT_BANDING present or not */
+#define __CLKGATE_PRESENT      1         /*!< CLKGATE present or not */
+#define __CM4_REV              1         /*!< Core revision r0p1 */
+#define __DEBUG_LVL            3         /*!< Full debug plus DWT data matching */
+#define __FPU_PRESENT          0         /*!< FPU present or not */
+#define __JTAG_PRESENT         1         /*!< JTAG present or not */
+#define __MPU_PRESENT          1         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       4         /*!< Number of bits used for Priority Levels */
+#define __TRACE_LVL            1         /*!< Standard trace: ITM and DWT triggers and counters, but no ETM */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+#define __WIC_PRESENT          0         /*!< WIC present or not */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm4.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_sam4l.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAM4LC8C */
+/* ************************************************************************** */
+/** \defgroup SAM4LC8C_api Peripheral Software API */
+/*@{*/
+
+#include "component/abdacb.h"
+#include "component/acifc.h"
+#include "component/adcife.h"
+#include "component/aesa.h"
+#include "component/ast.h"
+#include "component/bpm.h"
+#include "component/bscif.h"
+#include "component/catb.h"
+#include "component/chipid.h"
+#include "component/crccu.h"
+#include "component/dacc.h"
+#include "component/eic.h"
+#include "component/flashcalw.h"
+#include "component/freqm.h"
+#include "component/gloc.h"
+#include "component/gpio.h"
+#include "component/hcache.h"
+#include "component/hmatrixb.h"
+#include "component/iisc.h"
+#include "component/lcdca.h"
+#include "component/parc.h"
+#include "component/pdca.h"
+#include "component/pevc.h"
+#include "component/picouart.h"
+#include "component/pm.h"
+#include "component/scif.h"
+#include "component/smap.h"
+#include "component/spi.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twim.h"
+#include "component/twis.h"
+#include "component/usart.h"
+#include "component/usbc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAM4LC8C */
+/* ************************************************************************** */
+/** \defgroup SAM4LC8C_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/abdacb.h"
+#include "instance/acifc.h"
+#include "instance/adcife.h"
+#include "instance/aesa.h"
+#include "instance/ast.h"
+#include "instance/bpm.h"
+#include "instance/bscif.h"
+#include "instance/catb.h"
+#include "instance/chipid.h"
+#include "instance/crccu.h"
+#include "instance/dacc.h"
+#include "instance/eic.h"
+#include "instance/hflashc.h"
+#include "instance/freqm.h"
+#include "instance/gloc.h"
+#include "instance/gpio.h"
+#include "instance/hcache.h"
+#include "instance/hmatrix.h"
+#include "instance/iisc.h"
+#include "instance/lcdca.h"
+#include "instance/parc.h"
+#include "instance/pdca.h"
+#include "instance/pevc.h"
+#include "instance/picouart.h"
+#include "instance/pm.h"
+#include "instance/scif.h"
+#include "instance/smap.h"
+#include "instance/spi.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/trng.h"
+#include "instance/twim0.h"
+#include "instance/twim1.h"
+#include "instance/twim2.h"
+#include "instance/twim3.h"
+#include "instance/twis0.h"
+#include "instance/twis1.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usart3.h"
+#include "instance/usbc.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAM4LC8C */
+/* ************************************************************************** */
+/** \defgroup SAM4LC8C_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HTOP0 bridge
+#define ID_IISC           0 /**< \brief Inter-IC Sound (I2S) Controller (IISC) */
+#define ID_SPI            1 /**< \brief Serial Peripheral Interface (SPI) */
+#define ID_TC0            2 /**< \brief Timer/Counter 0 (TC0) */
+#define ID_TC1            3 /**< \brief Timer/Counter 1 (TC1) */
+#define ID_TWIM0          4 /**< \brief Two-wire Master Interface 0 (TWIM0) */
+#define ID_TWIS0          5 /**< \brief Two-wire Slave Interface 0 (TWIS0) */
+#define ID_TWIM1          6 /**< \brief Two-wire Master Interface 1 (TWIM1) */
+#define ID_TWIS1          7 /**< \brief Two-wire Slave Interface 1 (TWIS1) */
+#define ID_USART0         8 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+#define ID_USART1         9 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+#define ID_USART2        10 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+#define ID_USART3        11 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+#define ID_ADCIFE        12 /**< \brief ADC controller interface (ADCIFE) */
+#define ID_DACC          13 /**< \brief DAC Controller (DACC) */
+#define ID_ACIFC         14 /**< \brief Analog Comparator Interface (ACIFC) */
+#define ID_GLOC          15 /**< \brief Glue Logic Controller (GLOC) */
+#define ID_ABDACB        16 /**< \brief Audio Bitstream DAC (ABDACB) */
+#define ID_TRNG          17 /**< \brief True Random Number Generator (TRNG) */
+#define ID_PARC          18 /**< \brief Parallel Capture (PARC) */
+#define ID_CATB          19 /**< \brief Capacitive Touch Module B (CATB) */
+#define ID_TWIM2         21 /**< \brief Two-wire Master Interface 2 (TWIM2) */
+#define ID_TWIM3         22 /**< \brief Two-wire Master Interface 3 (TWIM3) */
+#define ID_LCDCA         23 /**< \brief LCD Controller (LCDCA) */
+
+// Peripheral instances on HTOP1 bridge
+#define ID_HFLASHC       32 /**< \brief Flash Controller (HFLASHC) */
+#define ID_HCACHE        33 /**< \brief Cortex M I&D Cache Controller (HCACHE) */
+#define ID_HMATRIX       34 /**< \brief HSB Matrix (HMATRIX) */
+#define ID_PDCA          35 /**< \brief Peripheral DMA Controller (PDCA) */
+#define ID_SMAP          36 /**< \brief System Manager Access Port (SMAP) */
+#define ID_CRCCU         37 /**< \brief CRC Calculation Unit (CRCCU) */
+#define ID_USBC          38 /**< \brief USB 2.0 Interface (USBC) */
+#define ID_PEVC          39 /**< \brief Peripheral Event Controller (PEVC) */
+
+// Peripheral instances on HTOP2 bridge
+#define ID_PM            64 /**< \brief Power Manager (PM) */
+#define ID_CHIPID        65 /**< \brief Chip ID Registers (CHIPID) */
+#define ID_SCIF          66 /**< \brief System Control Interface (SCIF) */
+#define ID_FREQM         67 /**< \brief Frequency Meter (FREQM) */
+#define ID_GPIO          68 /**< \brief General-Purpose Input/Output Controller (GPIO) */
+
+// Peripheral instances on HTOP3 bridge
+#define ID_BPM           96 /**< \brief Backup Power Manager (BPM) */
+#define ID_BSCIF         97 /**< \brief Backup System Control Interface (BSCIF) */
+#define ID_AST           98 /**< \brief Asynchronous Timer (AST) */
+#define ID_WDT           99 /**< \brief Watchdog Timer (WDT) */
+#define ID_EIC          100 /**< \brief External Interrupt Controller (EIC) */
+#define ID_PICOUART     101 /**< \brief Pico UART (PICOUART) */
+
+// Peripheral instances on AHB (as if on bridge 4)
+#define ID_AESA         128 /**< \brief Advanced Encryption Standard (AESA) */
+
+#define ID_PERIPH_COUNT 129 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAM4LC8C */
+/* ************************************************************************** */
+/** \defgroup SAM4LC8C_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define ABDACB                        (0x40064000) /**< \brief (ABDACB) APB Base Address */
+#define ACIFC                         (0x40040000) /**< \brief (ACIFC) APB Base Address */
+#define ADCIFE                        (0x40038000) /**< \brief (ADCIFE) APB Base Address */
+#define AESA                          (0x400B0000) /**< \brief (AESA) AHB Base Address */
+#define AST                           (0x400F0800) /**< \brief (AST) APB Base Address */
+#define BPM                           (0x400F0000) /**< \brief (BPM) APB Base Address */
+#define BSCIF                         (0x400F0400) /**< \brief (BSCIF) APB Base Address */
+#define CATB                          (0x40070000) /**< \brief (CATB) APB Base Address */
+#define CHIPID                        (0x400E0400) /**< \brief (CHIPID) APB Base Address */
+#define CRCCU                         (0x400A4000) /**< \brief (CRCCU) APB Base Address */
+#define DACC                          (0x4003C000) /**< \brief (DACC) APB Base Address */
+#define EIC                           (0x400F1000) /**< \brief (EIC) APB Base Address */
+#define HFLASHC                       (0x400A0000) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000) /**< \brief (HFLASHC) USER Base Address */
+#define FREQM                         (0x400E0C00) /**< \brief (FREQM) APB Base Address */
+#define GLOC                          (0x40060000) /**< \brief (GLOC) APB Base Address */
+#define GPIO                          (0x400E1000) /**< \brief (GPIO) APB Base Address */
+#define HCACHE                        (0x400A0400) /**< \brief (HCACHE) APB Base Address */
+#define HMATRIX                       (0x400A1000) /**< \brief (HMATRIX) APB Base Address */
+#define IISC                          (0x40004000) /**< \brief (IISC) APB Base Address */
+#define LCDCA                         (0x40080000) /**< \brief (LCDCA) APB Base Address */
+#define PARC                          (0x4006C000) /**< \brief (PARC) APB Base Address */
+#define PDCA                          (0x400A2000) /**< \brief (PDCA) APB Base Address */
+#define PEVC                          (0x400A6000) /**< \brief (PEVC) APB Base Address */
+#define PICOUART                      (0x400F1400) /**< \brief (PICOUART) APB Base Address */
+#define PM                            (0x400E0000) /**< \brief (PM) APB Base Address */
+#define SCIF                          (0x400E0800) /**< \brief (SCIF) APB Base Address */
+#define SMAP                          (0x400A3000) /**< \brief (SMAP) APB Base Address */
+#define SPI                           (0x40008000) /**< \brief (SPI) APB Base Address */
+#define TC0                           (0x40010000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x40014000) /**< \brief (TC1) APB Base Address */
+#define TRNG                          (0x40068000) /**< \brief (TRNG) APB Base Address */
+#define TWIM0                         (0x40018000) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1                         (0x4001C000) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2                         (0x40078000) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3                         (0x4007C000) /**< \brief (TWIM3) APB Base Address */
+#define TWIS0                         (0x40018400) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1                         (0x4001C400) /**< \brief (TWIS1) APB Base Address */
+#define USART0                        (0x40024000) /**< \brief (USART0) APB Base Address */
+#define USART1                        (0x40028000) /**< \brief (USART1) APB Base Address */
+#define USART2                        (0x4002C000) /**< \brief (USART2) APB Base Address */
+#define USART3                        (0x40030000) /**< \brief (USART3) APB Base Address */
+#define USBC                          (0x400A5000) /**< \brief (USBC) APB Base Address */
+#define WDT                           (0x400F0C00) /**< \brief (WDT) APB Base Address */
+#else
+#define ABDACB            ((Abdacb   *)0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_ADDR                   (0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_INST_NUM   1                          /**< \brief (ABDACB) Number of instances */
+#define ABDACB_INSTS      { ABDACB }                 /**< \brief (ABDACB) Instances List */
+
+#define ACIFC             ((Acifc    *)0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_ADDR                    (0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_INST_NUM    1                          /**< \brief (ACIFC) Number of instances */
+#define ACIFC_INSTS       { ACIFC }                  /**< \brief (ACIFC) Instances List */
+
+#define ADCIFE            ((Adcife   *)0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_ADDR                   (0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_INST_NUM   1                          /**< \brief (ADCIFE) Number of instances */
+#define ADCIFE_INSTS      { ADCIFE }                 /**< \brief (ADCIFE) Instances List */
+
+#define AESA              ((Aesa     *)0x400B0000UL) /**< \brief (AESA) AHB Base Address */
+#define AESA_ADDR                     (0x400B0000UL) /**< \brief (AESA) AHB Base Address */
+#define AESA_INST_NUM     1                          /**< \brief (AESA) Number of instances */
+#define AESA_INSTS        { AESA }                   /**< \brief (AESA) Instances List */
+
+#define AST               ((Ast      *)0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_ADDR                      (0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_INST_NUM      1                          /**< \brief (AST) Number of instances */
+#define AST_INSTS         { AST }                    /**< \brief (AST) Instances List */
+
+#define BPM               ((Bpm      *)0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_ADDR                      (0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_INST_NUM      1                          /**< \brief (BPM) Number of instances */
+#define BPM_INSTS         { BPM }                    /**< \brief (BPM) Instances List */
+
+#define BSCIF             ((Bscif    *)0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_ADDR                    (0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_INST_NUM    1                          /**< \brief (BSCIF) Number of instances */
+#define BSCIF_INSTS       { BSCIF }                  /**< \brief (BSCIF) Instances List */
+
+#define CATB              ((Catb     *)0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_ADDR                     (0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_INST_NUM     1                          /**< \brief (CATB) Number of instances */
+#define CATB_INSTS        { CATB }                   /**< \brief (CATB) Instances List */
+
+#define CHIPID            ((Chipid   *)0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_ADDR                   (0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_INST_NUM   1                          /**< \brief (CHIPID) Number of instances */
+#define CHIPID_INSTS      { CHIPID }                 /**< \brief (CHIPID) Instances List */
+
+#define CRCCU             ((Crccu    *)0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_ADDR                    (0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_INST_NUM    1                          /**< \brief (CRCCU) Number of instances */
+#define CRCCU_INSTS       { CRCCU }                  /**< \brief (CRCCU) Instances List */
+
+#define DACC              ((Dacc     *)0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_ADDR                     (0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_INST_NUM     1                          /**< \brief (DACC) Number of instances */
+#define DACC_INSTS        { DACC }                   /**< \brief (DACC) Instances List */
+
+#define EIC               ((Eic      *)0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_ADDR                      (0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define HFLASHC           ((Flashcalw *)0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_ADDR                  (0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_FROW_ADDR             (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define HFLASHC_USER_ADDR             (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define FLASHCALW_INST_NUM 1                          /**< \brief (FLASHCALW) Number of instances */
+#define FLASHCALW_INSTS   { HFLASHC }                /**< \brief (FLASHCALW) Instances List */
+
+#define FREQM             ((Freqm    *)0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_ADDR                    (0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_INST_NUM    1                          /**< \brief (FREQM) Number of instances */
+#define FREQM_INSTS       { FREQM }                  /**< \brief (FREQM) Instances List */
+
+#define GLOC              ((Gloc     *)0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_ADDR                     (0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_INST_NUM     1                          /**< \brief (GLOC) Number of instances */
+#define GLOC_INSTS        { GLOC }                   /**< \brief (GLOC) Instances List */
+
+#define GPIO              ((Gpio     *)0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_ADDR                     (0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_INST_NUM     1                          /**< \brief (GPIO) Number of instances */
+#define GPIO_INSTS        { GPIO }                   /**< \brief (GPIO) Instances List */
+
+#define HCACHE            ((Hcache   *)0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_ADDR                   (0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_INST_NUM   1                          /**< \brief (HCACHE) Number of instances */
+#define HCACHE_INSTS      { HCACHE }                 /**< \brief (HCACHE) Instances List */
+
+#define HMATRIX           ((Hmatrixb *)0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIX_ADDR                  (0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIXB_INST_NUM 1                          /**< \brief (HMATRIXB) Number of instances */
+#define HMATRIXB_INSTS    { HMATRIX }                /**< \brief (HMATRIXB) Instances List */
+
+#define IISC              ((Iisc     *)0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_ADDR                     (0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_INST_NUM     1                          /**< \brief (IISC) Number of instances */
+#define IISC_INSTS        { IISC }                   /**< \brief (IISC) Instances List */
+
+#define LCDCA             ((Lcdca    *)0x40080000UL) /**< \brief (LCDCA) APB Base Address */
+#define LCDCA_ADDR                    (0x40080000UL) /**< \brief (LCDCA) APB Base Address */
+#define LCDCA_INST_NUM    1                          /**< \brief (LCDCA) Number of instances */
+#define LCDCA_INSTS       { LCDCA }                  /**< \brief (LCDCA) Instances List */
+
+#define PARC              ((Parc     *)0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_ADDR                     (0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_INST_NUM     1                          /**< \brief (PARC) Number of instances */
+#define PARC_INSTS        { PARC }                   /**< \brief (PARC) Instances List */
+
+#define PDCA              ((Pdca     *)0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_ADDR                     (0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_INST_NUM     1                          /**< \brief (PDCA) Number of instances */
+#define PDCA_INSTS        { PDCA }                   /**< \brief (PDCA) Instances List */
+
+#define PEVC              ((Pevc     *)0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_ADDR                     (0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_INST_NUM     1                          /**< \brief (PEVC) Number of instances */
+#define PEVC_INSTS        { PEVC }                   /**< \brief (PEVC) Instances List */
+
+#define PICOUART          ((Picouart *)0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_ADDR                 (0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_INST_NUM 1                          /**< \brief (PICOUART) Number of instances */
+#define PICOUART_INSTS    { PICOUART }               /**< \brief (PICOUART) Instances List */
+
+#define PM                ((Pm       *)0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_ADDR                       (0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define SCIF              ((Scif     *)0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_ADDR                     (0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_INST_NUM     1                          /**< \brief (SCIF) Number of instances */
+#define SCIF_INSTS        { SCIF }                   /**< \brief (SCIF) Instances List */
+
+#define SMAP              ((Smap     *)0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_ADDR                     (0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_INST_NUM     1                          /**< \brief (SMAP) Number of instances */
+#define SMAP_INSTS        { SMAP }                   /**< \brief (SMAP) Instances List */
+
+#define SPI               ((Spi      *)0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_ADDR                      (0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_INST_NUM      1                          /**< \brief (SPI) Number of instances */
+#define SPI_INSTS         { SPI }                    /**< \brief (SPI) Instances List */
+
+#define TC0               ((Tc       *)0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC0_ADDR                      (0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC1_ADDR                      (0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC_INST_NUM       2                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1 }               /**< \brief (TC) Instances List */
+
+#define TRNG              ((Trng     *)0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_ADDR                     (0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_INST_NUM     1                          /**< \brief (TRNG) Number of instances */
+#define TRNG_INSTS        { TRNG }                   /**< \brief (TRNG) Instances List */
+
+#define TWIM0             ((Twim     *)0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM0_ADDR                    (0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1             ((Twim     *)0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM1_ADDR                    (0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2             ((Twim     *)0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM2_ADDR                    (0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3             ((Twim     *)0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM3_ADDR                    (0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM_INST_NUM     4                          /**< \brief (TWIM) Number of instances */
+#define TWIM_INSTS        { TWIM0, TWIM1, TWIM2, TWIM3 } /**< \brief (TWIM) Instances List */
+
+#define TWIS0             ((Twis     *)0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS0_ADDR                    (0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1             ((Twis     *)0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS1_ADDR                    (0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS_INST_NUM     2                          /**< \brief (TWIS) Number of instances */
+#define TWIS_INSTS        { TWIS0, TWIS1 }           /**< \brief (TWIS) Instances List */
+
+#define USART0            ((Usart    *)0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART0_ADDR                   (0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART1            ((Usart    *)0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART1_ADDR                   (0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART2            ((Usart    *)0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART2_ADDR                   (0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART3            ((Usart    *)0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART3_ADDR                   (0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART_INST_NUM    4                          /**< \brief (USART) Number of instances */
+#define USART_INSTS       { USART0, USART1, USART2, USART3 } /**< \brief (USART) Instances List */
+
+#define USBC              ((Usbc     *)0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_ADDR                     (0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_INST_NUM     1                          /**< \brief (USBC) Number of instances */
+#define USBC_INSTS        { USBC }                   /**< \brief (USBC) Instances List */
+
+#define WDT               ((Wdt      *)0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_ADDR                      (0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  GPIO DEFINITIONS FOR SAM4LC8C */
+/* ************************************************************************** */
+/** \defgroup SAM4LC8C_gpio GPIO Definitions */
+/*@{*/
+
+#include "pio/sam4lc8c.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  ADDITIONAL DEFINITIONS FOR COMPATIBILITY */
+/* ************************************************************************** */
+/** \addtogroup SAM4LC8C_compat Definitions */
+/*@{*/
+// These defines are used to keep compatibility with existing 
+// sam/drivers/usart implementation from SAM3/4 products with SAM4L product.
+#define US_MR_USART_MODE_HW_HANDSHAKING  US_MR_USART_MODE_HARDWARE
+#define US_MR_USART_MODE_IS07816_T_0     US_MR_USART_MODE_ISO7816_T0
+#define US_MR_USART_MODE_IS07816_T_1     US_MR_USART_MODE_ISO7816_T1
+#define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
+#define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
+#define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_8_BIT      US_MR_CHRL_8
+#define US_MR_PAR_NO          US_MR_PAR_NONE
+#define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI
+#define US_IF                 US_IFR
+#define US_WPSR_WPVS          US_WPSR_WPV_1
+
+#define USBC_UPCFG0_PBK_Msk   (0x1u << USBC_UPCFG0_PBK_Pos)
+
+// These defines for homogeneity with other SAM header files.
+#define CHIP_FREQ_FWS_0       (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 */
+#define CHIP_FREQ_FWS_1       (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 */
+// WARNING NOTE: these are preliminary values.
+#define CHIP_FREQ_FLASH_HSEN_FWS_0 (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 and the FLASH HS mode is enabled */
+#define CHIP_FREQ_FLASH_HSEN_FWS_1 (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 and the FLASH HS mode is enabled */
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/tc implementation from SAM3/4 products with SAM4L product. 
+#define TC_CMR_LDRA_RISING    TC_CMR_LDRA_POS_EDGE_TIOA
+#define TC_CMR_LDRB_FALLING   TC_CMR_LDRB_NEG_EDGE_TIOA
+#define TC_CMR_ETRGEDG_FALLING TC_CMR_ETRGEDG_NEG_EDGE
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/spi implementation from SAM3/4 products with SAM4L product. 
+#define SPI_CSR_BITS_8_BIT    SPI_CSR_BITS_8_BPT
+#define SPI_WPCR_SPIWPKEY_VALUE SPI_WPCR_WPKEY_VALUE
+#define SPI_WPCR_SPIWPEN      SPI_WPCR_WPEN
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/crccu implementation from SAM3/4 products with SAM4L product. 
+#define CRCCU_DMA_EN          CRCCU_DMAEN
+#define CRCCU_DMA_DIS         CRCCU_DMADIS
+#define CRCCU_DMA_SR          CRCCU_DMASR
+#define CRCCU_DMA_IER         CRCCU_DMAIER
+#define CRCCU_DMA_IDR         CRCCU_DMAIDR
+#define CRCCU_DMA_IMR         CRCCU_DMAIMR
+#define CRCCU_DMA_ISR         CRCCU_DMAISR
+#define CRCCU_DMA_EN_DMAEN    CRCCU_DMAEN_DMAEN
+#define CRCCU_DMA_DIS_DMADIS  CRCCU_DMADIS_DMADIS
+#define CRCCU_DMA_SR_DMASR    CRCCU_DMASR_DMASR
+#define CRCCU_DMA_IER_DMAIER  CRCCU_DMAIER_DMAIER
+#define CRCCU_DMA_IDR_DMAIDR  CRCCU_DMAIDR_DMAIDR
+#define CRCCU_DMA_IMR_DMAIMR  CRCCU_DMAIMR_DMAIMR
+#define CRCCU_DMA_ISR_DMAISR  CRCCU_DMAISR_DMAISR
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAM4LC8C */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL(0x00080000) /* 512 kB */
+#define FLASH_PAGE_SIZE       512
+#define FLASH_NB_OF_PAGES     1024
+#define FLASH_USER_PAGE_SIZE  512
+#define HRAMC0_SIZE           _UL(0x00010000) /* 64 kB */
+#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+
+#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+
+#define DSU_DID_RESETVALUE    _UL(0xAB0B0AE0)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAM4LC8C */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAM4LC8C_H */

--- a/asf/sam/include/sam4l/sam4ls2a.h
+++ b/asf/sam/include/sam4l/sam4ls2a.h
@@ -62,15 +62,15 @@ typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volati
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
 #if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#define _U_(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
 #if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#define _U_(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 
@@ -857,23 +857,23 @@ void TWIM3_Handler               ( void );
 /**  MEMORY MAPPING DEFINITIONS FOR SAM4LS2A */
 /* ************************************************************************** */
 
-#define FLASH_SIZE            _UL(0x00020000) /* 128 kB */
+#define FLASH_SIZE            _UL_(0x00020000) /* 128 kB */
 #define FLASH_PAGE_SIZE       512
 #define FLASH_NB_OF_PAGES     256
 #define FLASH_USER_PAGE_SIZE  512
-#define HRAMC0_SIZE           _UL(0x00008000) /* 32 kB */
-#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+#define HRAMC0_SIZE           _UL_(0x00008000) /* 32 kB */
+#define HRAMC1_SIZE           _UL_(0x00000800) /* 2 kB */
 
-#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
-#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
-#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
-#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
-#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
-#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
-#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
-#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL_(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL_(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL_(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL_(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL_(0x400F0000) /**< HTOP3 base address */
 
-#define DSU_DID_RESETVALUE    _UL(0xAB0A07E0)
+#define DSU_DID_RESETVALUE    _UL_(0xAB0A07E0)
 
 /* ************************************************************************** */
 /**  ELECTRICAL DEFINITIONS FOR SAM4LS2A */

--- a/asf/sam/include/sam4l/sam4ls2a.h
+++ b/asf/sam/include/sam4l/sam4ls2a.h
@@ -1,0 +1,889 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAM4LS2A
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LS2A_
+#define _SAM4LS2A_
+
+/**
+ * \ingroup SAM4L_definitions
+ * \addtogroup SAM4LS2A_definitions SAM4LS2A definitions
+ * This file defines all structures and symbols for SAM4LS2A:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#if !defined(_UL)
+#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#endif
+#else
+#if !defined(_UL)
+#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif
+#endif
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAM4LS2A */
+/* ************************************************************************** */
+/** \defgroup SAM4LS2A_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M4 Processor Exceptions Numbers ******************************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn           = -13,/**<  3 Cortex-M4 Hard Fault Interrupt        */
+  MemoryManagement_IRQn    = -12,/**<  4 Cortex-M4 Memory Management Interrupt */
+  BusFault_IRQn            = -11,/**<  5 Cortex-M4 Bus Fault Interrupt         */
+  UsageFault_IRQn          = -10,/**<  6 Cortex-M4 Usage Fault Interrupt       */
+  SVCall_IRQn              = -5, /**< 11 Cortex-M4 SV Call Interrupt           */
+  DebugMonitor_IRQn        = -4, /**< 12 Cortex-M4 Debug Monitor Interrupt     */
+  PendSV_IRQn              = -2, /**< 14 Cortex-M4 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 Cortex-M4 System Tick Interrupt       */
+  /******  SAM4LS2A-specific Interrupt Numbers ***********************/
+  HFLASHC_IRQn             =  0, /**<  0 SAM4LS2A Flash Controller (HFLASHC) */
+  PDCA_0_IRQn              =  1, /**<  1 SAM4LS2A Peripheral DMA Controller (PDCA): PDCA_0 */
+  PDCA_1_IRQn              =  2, /**<  2 SAM4LS2A Peripheral DMA Controller (PDCA): PDCA_1 */
+  PDCA_2_IRQn              =  3, /**<  3 SAM4LS2A Peripheral DMA Controller (PDCA): PDCA_2 */
+  PDCA_3_IRQn              =  4, /**<  4 SAM4LS2A Peripheral DMA Controller (PDCA): PDCA_3 */
+  PDCA_4_IRQn              =  5, /**<  5 SAM4LS2A Peripheral DMA Controller (PDCA): PDCA_4 */
+  PDCA_5_IRQn              =  6, /**<  6 SAM4LS2A Peripheral DMA Controller (PDCA): PDCA_5 */
+  PDCA_6_IRQn              =  7, /**<  7 SAM4LS2A Peripheral DMA Controller (PDCA): PDCA_6 */
+  PDCA_7_IRQn              =  8, /**<  8 SAM4LS2A Peripheral DMA Controller (PDCA): PDCA_7 */
+  PDCA_8_IRQn              =  9, /**<  9 SAM4LS2A Peripheral DMA Controller (PDCA): PDCA_8 */
+  PDCA_9_IRQn              = 10, /**< 10 SAM4LS2A Peripheral DMA Controller (PDCA): PDCA_9 */
+  PDCA_10_IRQn             = 11, /**< 11 SAM4LS2A Peripheral DMA Controller (PDCA): PDCA_10 */
+  PDCA_11_IRQn             = 12, /**< 12 SAM4LS2A Peripheral DMA Controller (PDCA): PDCA_11 */
+  PDCA_12_IRQn             = 13, /**< 13 SAM4LS2A Peripheral DMA Controller (PDCA): PDCA_12 */
+  PDCA_13_IRQn             = 14, /**< 14 SAM4LS2A Peripheral DMA Controller (PDCA): PDCA_13 */
+  PDCA_14_IRQn             = 15, /**< 15 SAM4LS2A Peripheral DMA Controller (PDCA): PDCA_14 */
+  PDCA_15_IRQn             = 16, /**< 16 SAM4LS2A Peripheral DMA Controller (PDCA): PDCA_15 */
+  CRCCU_IRQn               = 17, /**< 17 SAM4LS2A CRC Calculation Unit (CRCCU) */
+  USBC_IRQn                = 18, /**< 18 SAM4LS2A USB 2.0 Interface (USBC) */
+  PEVC_0_IRQn              = 19, /**< 19 SAM4LS2A Peripheral Event Controller (PEVC): PEVC_TR */
+  PEVC_1_IRQn              = 20, /**< 20 SAM4LS2A Peripheral Event Controller (PEVC): PEVC_OV */
+  PM_IRQn                  = 22, /**< 22 SAM4LS2A Power Manager (PM) */
+  SCIF_IRQn                = 23, /**< 23 SAM4LS2A System Control Interface (SCIF) */
+  FREQM_IRQn               = 24, /**< 24 SAM4LS2A Frequency Meter (FREQM) */
+  GPIO_0_IRQn              = 25, /**< 25 SAM4LS2A General-Purpose Input/Output Controller (GPIO): GPIO_0 */
+  GPIO_1_IRQn              = 26, /**< 26 SAM4LS2A General-Purpose Input/Output Controller (GPIO): GPIO_1 */
+  GPIO_2_IRQn              = 27, /**< 27 SAM4LS2A General-Purpose Input/Output Controller (GPIO): GPIO_2 */
+  GPIO_3_IRQn              = 28, /**< 28 SAM4LS2A General-Purpose Input/Output Controller (GPIO): GPIO_3 */
+  GPIO_4_IRQn              = 29, /**< 29 SAM4LS2A General-Purpose Input/Output Controller (GPIO): GPIO_4 */
+  GPIO_5_IRQn              = 30, /**< 30 SAM4LS2A General-Purpose Input/Output Controller (GPIO): GPIO_5 */
+  GPIO_6_IRQn              = 31, /**< 31 SAM4LS2A General-Purpose Input/Output Controller (GPIO): GPIO_6 */
+  GPIO_7_IRQn              = 32, /**< 32 SAM4LS2A General-Purpose Input/Output Controller (GPIO): GPIO_7 */
+  GPIO_8_IRQn              = 33, /**< 33 SAM4LS2A General-Purpose Input/Output Controller (GPIO): GPIO_8 */
+  GPIO_9_IRQn              = 34, /**< 34 SAM4LS2A General-Purpose Input/Output Controller (GPIO): GPIO_9 */
+  GPIO_10_IRQn             = 35, /**< 35 SAM4LS2A General-Purpose Input/Output Controller (GPIO): GPIO_10 */
+  GPIO_11_IRQn             = 36, /**< 36 SAM4LS2A General-Purpose Input/Output Controller (GPIO): GPIO_11 */
+  BPM_IRQn                 = 37, /**< 37 SAM4LS2A Backup Power Manager (BPM) */
+  BSCIF_IRQn               = 38, /**< 38 SAM4LS2A Backup System Control Interface (BSCIF) */
+  AST_0_IRQn               = 39, /**< 39 SAM4LS2A Asynchronous Timer (AST): AST_ALARM */
+  AST_1_IRQn               = 40, /**< 40 SAM4LS2A Asynchronous Timer (AST): AST_PER */
+  AST_2_IRQn               = 41, /**< 41 SAM4LS2A Asynchronous Timer (AST): AST_OVF */
+  AST_3_IRQn               = 42, /**< 42 SAM4LS2A Asynchronous Timer (AST): AST_READY */
+  AST_4_IRQn               = 43, /**< 43 SAM4LS2A Asynchronous Timer (AST): AST_CLKREADY */
+  WDT_IRQn                 = 44, /**< 44 SAM4LS2A Watchdog Timer (WDT) */
+  EIC_0_IRQn               = 45, /**< 45 SAM4LS2A External Interrupt Controller (EIC): EIC_1 */
+  EIC_1_IRQn               = 46, /**< 46 SAM4LS2A External Interrupt Controller (EIC): EIC_2 */
+  EIC_2_IRQn               = 47, /**< 47 SAM4LS2A External Interrupt Controller (EIC): EIC_3 */
+  EIC_3_IRQn               = 48, /**< 48 SAM4LS2A External Interrupt Controller (EIC): EIC_4 */
+  EIC_4_IRQn               = 49, /**< 49 SAM4LS2A External Interrupt Controller (EIC): EIC_5 */
+  EIC_5_IRQn               = 50, /**< 50 SAM4LS2A External Interrupt Controller (EIC): EIC_6 */
+  EIC_6_IRQn               = 51, /**< 51 SAM4LS2A External Interrupt Controller (EIC): EIC_7 */
+  EIC_7_IRQn               = 52, /**< 52 SAM4LS2A External Interrupt Controller (EIC): EIC_8 */
+  IISC_IRQn                = 53, /**< 53 SAM4LS2A Inter-IC Sound (I2S) Controller (IISC) */
+  SPI_IRQn                 = 54, /**< 54 SAM4LS2A Serial Peripheral Interface (SPI) */
+  TC0_0_IRQn               = 55, /**< 55 SAM4LS2A Timer/Counter 0 (TC0): TC00 */
+  TC0_1_IRQn               = 56, /**< 56 SAM4LS2A Timer/Counter 0 (TC0): TC01 */
+  TC0_2_IRQn               = 57, /**< 57 SAM4LS2A Timer/Counter 0 (TC0): TC02 */
+  TC1_0_IRQn               = 58, /**< 58 SAM4LS2A Timer/Counter 1 (TC1): TC10 */
+  TC1_1_IRQn               = 59, /**< 59 SAM4LS2A Timer/Counter 1 (TC1): TC11 */
+  TC1_2_IRQn               = 60, /**< 60 SAM4LS2A Timer/Counter 1 (TC1): TC12 */
+  TWIM0_IRQn               = 61, /**< 61 SAM4LS2A Two-wire Master Interface 0 (TWIM0) */
+  TWIS0_IRQn               = 62, /**< 62 SAM4LS2A Two-wire Slave Interface 0 (TWIS0) */
+  TWIM1_IRQn               = 63, /**< 63 SAM4LS2A Two-wire Master Interface 1 (TWIM1) */
+  TWIS1_IRQn               = 64, /**< 64 SAM4LS2A Two-wire Slave Interface 1 (TWIS1) */
+  USART0_IRQn              = 65, /**< 65 SAM4LS2A Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+  USART1_IRQn              = 66, /**< 66 SAM4LS2A Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+  USART2_IRQn              = 67, /**< 67 SAM4LS2A Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+  USART3_IRQn              = 68, /**< 68 SAM4LS2A Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+  ADCIFE_IRQn              = 69, /**< 69 SAM4LS2A ADC controller interface (ADCIFE) */
+  DACC_IRQn                = 70, /**< 70 SAM4LS2A DAC Controller (DACC) */
+  ACIFC_IRQn               = 71, /**< 71 SAM4LS2A Analog Comparator Interface (ACIFC) */
+  ABDACB_IRQn              = 72, /**< 72 SAM4LS2A Audio Bitstream DAC (ABDACB) */
+  TRNG_IRQn                = 73, /**< 73 SAM4LS2A True Random Number Generator (TRNG) */
+  PARC_IRQn                = 74, /**< 74 SAM4LS2A Parallel Capture (PARC) */
+  CATB_IRQn                = 75, /**< 75 SAM4LS2A Capacitive Touch Module B (CATB) */
+  TWIM2_IRQn               = 77, /**< 77 SAM4LS2A Two-wire Master Interface 2 (TWIM2) */
+  TWIM3_IRQn               = 78, /**< 78 SAM4LS2A Two-wire Master Interface 3 (TWIM3) */
+
+  PERIPH_COUNT_IRQn        = 80  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNMI_Handler;
+  void* pfnHardFault_Handler;
+  void* pfnMemManage_Handler;
+  void* pfnBusFault_Handler;
+  void* pfnUsageFault_Handler;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVC_Handler;
+  void* pfnDebugMon_Handler;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnHFLASHC_Handler;               /*  0 Flash Controller */
+  void* pfnPDCA_0_Handler;                /*  1 Peripheral DMA Controller IRQ 0 */
+  void* pfnPDCA_1_Handler;                /*  2 Peripheral DMA Controller IRQ 1 */
+  void* pfnPDCA_2_Handler;                /*  3 Peripheral DMA Controller IRQ 2 */
+  void* pfnPDCA_3_Handler;                /*  4 Peripheral DMA Controller IRQ 3 */
+  void* pfnPDCA_4_Handler;                /*  5 Peripheral DMA Controller IRQ 4 */
+  void* pfnPDCA_5_Handler;                /*  6 Peripheral DMA Controller IRQ 5 */
+  void* pfnPDCA_6_Handler;                /*  7 Peripheral DMA Controller IRQ 6 */
+  void* pfnPDCA_7_Handler;                /*  8 Peripheral DMA Controller IRQ 7 */
+  void* pfnPDCA_8_Handler;                /*  9 Peripheral DMA Controller IRQ 8 */
+  void* pfnPDCA_9_Handler;                /* 10 Peripheral DMA Controller IRQ 9 */
+  void* pfnPDCA_10_Handler;               /* 11 Peripheral DMA Controller IRQ 10 */
+  void* pfnPDCA_11_Handler;               /* 12 Peripheral DMA Controller IRQ 11 */
+  void* pfnPDCA_12_Handler;               /* 13 Peripheral DMA Controller IRQ 12 */
+  void* pfnPDCA_13_Handler;               /* 14 Peripheral DMA Controller IRQ 13 */
+  void* pfnPDCA_14_Handler;               /* 15 Peripheral DMA Controller IRQ 14 */
+  void* pfnPDCA_15_Handler;               /* 16 Peripheral DMA Controller IRQ 15 */
+  void* pfnCRCCU_Handler;                 /* 17 CRC Calculation Unit */
+  void* pfnUSBC_Handler;                  /* 18 USB 2.0 Interface */
+  void* pfnPEVC_0_Handler;                /* 19 Peripheral Event Controller IRQ 0 */
+  void* pfnPEVC_1_Handler;                /* 20 Peripheral Event Controller IRQ 1 */
+  void* pvReserved21;
+  void* pfnPM_Handler;                    /* 22 Power Manager */
+  void* pfnSCIF_Handler;                  /* 23 System Control Interface */
+  void* pfnFREQM_Handler;                 /* 24 Frequency Meter */
+  void* pfnGPIO_0_Handler;                /* 25 General-Purpose Input/Output Controller IRQ 0 */
+  void* pfnGPIO_1_Handler;                /* 26 General-Purpose Input/Output Controller IRQ 1 */
+  void* pfnGPIO_2_Handler;                /* 27 General-Purpose Input/Output Controller IRQ 2 */
+  void* pfnGPIO_3_Handler;                /* 28 General-Purpose Input/Output Controller IRQ 3 */
+  void* pfnGPIO_4_Handler;                /* 29 General-Purpose Input/Output Controller IRQ 4 */
+  void* pfnGPIO_5_Handler;                /* 30 General-Purpose Input/Output Controller IRQ 5 */
+  void* pfnGPIO_6_Handler;                /* 31 General-Purpose Input/Output Controller IRQ 6 */
+  void* pfnGPIO_7_Handler;                /* 32 General-Purpose Input/Output Controller IRQ 7 */
+  void* pfnGPIO_8_Handler;                /* 33 General-Purpose Input/Output Controller IRQ 8 */
+  void* pfnGPIO_9_Handler;                /* 34 General-Purpose Input/Output Controller IRQ 9 */
+  void* pfnGPIO_10_Handler;               /* 35 General-Purpose Input/Output Controller IRQ 10 */
+  void* pfnGPIO_11_Handler;               /* 36 General-Purpose Input/Output Controller IRQ 11 */
+  void* pfnBPM_Handler;                   /* 37 Backup Power Manager */
+  void* pfnBSCIF_Handler;                 /* 38 Backup System Control Interface */
+  void* pfnAST_0_Handler;                 /* 39 Asynchronous Timer IRQ 0 */
+  void* pfnAST_1_Handler;                 /* 40 Asynchronous Timer IRQ 1 */
+  void* pfnAST_2_Handler;                 /* 41 Asynchronous Timer IRQ 2 */
+  void* pfnAST_3_Handler;                 /* 42 Asynchronous Timer IRQ 3 */
+  void* pfnAST_4_Handler;                 /* 43 Asynchronous Timer IRQ 4 */
+  void* pfnWDT_Handler;                   /* 44 Watchdog Timer */
+  void* pfnEIC_0_Handler;                 /* 45 External Interrupt Controller IRQ 0 */
+  void* pfnEIC_1_Handler;                 /* 46 External Interrupt Controller IRQ 1 */
+  void* pfnEIC_2_Handler;                 /* 47 External Interrupt Controller IRQ 2 */
+  void* pfnEIC_3_Handler;                 /* 48 External Interrupt Controller IRQ 3 */
+  void* pfnEIC_4_Handler;                 /* 49 External Interrupt Controller IRQ 4 */
+  void* pfnEIC_5_Handler;                 /* 50 External Interrupt Controller IRQ 5 */
+  void* pfnEIC_6_Handler;                 /* 51 External Interrupt Controller IRQ 6 */
+  void* pfnEIC_7_Handler;                 /* 52 External Interrupt Controller IRQ 7 */
+  void* pfnIISC_Handler;                  /* 53 Inter-IC Sound (I2S) Controller */
+  void* pfnSPI_Handler;                   /* 54 Serial Peripheral Interface */
+  void* pfnTC0_0_Handler;                 /* 55 Timer/Counter 0 IRQ 0 */
+  void* pfnTC0_1_Handler;                 /* 56 Timer/Counter 0 IRQ 1 */
+  void* pfnTC0_2_Handler;                 /* 57 Timer/Counter 0 IRQ 2 */
+  void* pfnTC1_0_Handler;                 /* 58 Timer/Counter 1 IRQ 0 */
+  void* pfnTC1_1_Handler;                 /* 59 Timer/Counter 1 IRQ 1 */
+  void* pfnTC1_2_Handler;                 /* 60 Timer/Counter 1 IRQ 2 */
+  void* pfnTWIM0_Handler;                 /* 61 Two-wire Master Interface 0 */
+  void* pfnTWIS0_Handler;                 /* 62 Two-wire Slave Interface 0 */
+  void* pfnTWIM1_Handler;                 /* 63 Two-wire Master Interface 1 */
+  void* pfnTWIS1_Handler;                 /* 64 Two-wire Slave Interface 1 */
+  void* pfnUSART0_Handler;                /* 65 Universal Synchronous Asynchronous Receiver Transmitter 0 */
+  void* pfnUSART1_Handler;                /* 66 Universal Synchronous Asynchronous Receiver Transmitter 1 */
+  void* pfnUSART2_Handler;                /* 67 Universal Synchronous Asynchronous Receiver Transmitter 2 */
+  void* pfnUSART3_Handler;                /* 68 Universal Synchronous Asynchronous Receiver Transmitter 3 */
+  void* pfnADCIFE_Handler;                /* 69 ADC controller interface */
+  void* pfnDACC_Handler;                  /* 70 DAC Controller */
+  void* pfnACIFC_Handler;                 /* 71 Analog Comparator Interface */
+  void* pfnABDACB_Handler;                /* 72 Audio Bitstream DAC */
+  void* pfnTRNG_Handler;                  /* 73 True Random Number Generator */
+  void* pfnPARC_Handler;                  /* 74 Parallel Capture */
+  void* pfnCATB_Handler;                  /* 75 Capacitive Touch Module B */
+  void* pvReserved76;
+  void* pfnTWIM2_Handler;                 /* 77 Two-wire Master Interface 2 */
+  void* pfnTWIM3_Handler;                 /* 78 Two-wire Master Interface 3 */
+  void* pvReserved79;
+} DeviceVectors;
+
+/* Cortex-M4 processor handlers */
+void Reset_Handler               ( void );
+void NMI_Handler                 ( void );
+void HardFault_Handler           ( void );
+void MemManage_Handler           ( void );
+void BusFault_Handler            ( void );
+void UsageFault_Handler          ( void );
+void SVC_Handler                 ( void );
+void DebugMon_Handler            ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void HFLASHC_Handler             ( void );
+void PDCA_0_Handler              ( void );
+void PDCA_1_Handler              ( void );
+void PDCA_2_Handler              ( void );
+void PDCA_3_Handler              ( void );
+void PDCA_4_Handler              ( void );
+void PDCA_5_Handler              ( void );
+void PDCA_6_Handler              ( void );
+void PDCA_7_Handler              ( void );
+void PDCA_8_Handler              ( void );
+void PDCA_9_Handler              ( void );
+void PDCA_10_Handler             ( void );
+void PDCA_11_Handler             ( void );
+void PDCA_12_Handler             ( void );
+void PDCA_13_Handler             ( void );
+void PDCA_14_Handler             ( void );
+void PDCA_15_Handler             ( void );
+void CRCCU_Handler               ( void );
+void USBC_Handler                ( void );
+void PEVC_0_Handler              ( void );
+void PEVC_1_Handler              ( void );
+void PM_Handler                  ( void );
+void SCIF_Handler                ( void );
+void FREQM_Handler               ( void );
+void GPIO_0_Handler              ( void );
+void GPIO_1_Handler              ( void );
+void GPIO_2_Handler              ( void );
+void GPIO_3_Handler              ( void );
+void GPIO_4_Handler              ( void );
+void GPIO_5_Handler              ( void );
+void GPIO_6_Handler              ( void );
+void GPIO_7_Handler              ( void );
+void GPIO_8_Handler              ( void );
+void GPIO_9_Handler              ( void );
+void GPIO_10_Handler             ( void );
+void GPIO_11_Handler             ( void );
+void BPM_Handler                 ( void );
+void BSCIF_Handler               ( void );
+void AST_0_Handler               ( void );
+void AST_1_Handler               ( void );
+void AST_2_Handler               ( void );
+void AST_3_Handler               ( void );
+void AST_4_Handler               ( void );
+void WDT_Handler                 ( void );
+void EIC_0_Handler               ( void );
+void EIC_1_Handler               ( void );
+void EIC_2_Handler               ( void );
+void EIC_3_Handler               ( void );
+void EIC_4_Handler               ( void );
+void EIC_5_Handler               ( void );
+void EIC_6_Handler               ( void );
+void EIC_7_Handler               ( void );
+void IISC_Handler                ( void );
+void SPI_Handler                 ( void );
+void TC0_0_Handler               ( void );
+void TC0_1_Handler               ( void );
+void TC0_2_Handler               ( void );
+void TC1_0_Handler               ( void );
+void TC1_1_Handler               ( void );
+void TC1_2_Handler               ( void );
+void TWIM0_Handler               ( void );
+void TWIS0_Handler               ( void );
+void TWIM1_Handler               ( void );
+void TWIS1_Handler               ( void );
+void USART0_Handler              ( void );
+void USART1_Handler              ( void );
+void USART2_Handler              ( void );
+void USART3_Handler              ( void );
+void ADCIFE_Handler              ( void );
+void DACC_Handler                ( void );
+void ACIFC_Handler               ( void );
+void ABDACB_Handler              ( void );
+void TRNG_Handler                ( void );
+void PARC_Handler                ( void );
+void CATB_Handler                ( void );
+void TWIM2_Handler               ( void );
+void TWIM3_Handler               ( void );
+
+/*
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
+ */
+
+#define LITTLE_ENDIAN          1        
+#define __BB_PRESENT           0         /*!< BIT_BANDING present or not */
+#define __CLKGATE_PRESENT      1         /*!< CLKGATE present or not */
+#define __CM4_REV              1         /*!< Core revision r0p1 */
+#define __DEBUG_LVL            3         /*!< Full debug plus DWT data matching */
+#define __FPU_PRESENT          0         /*!< FPU present or not */
+#define __JTAG_PRESENT         1         /*!< JTAG present or not */
+#define __MPU_PRESENT          1         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       4         /*!< Number of bits used for Priority Levels */
+#define __TRACE_LVL            1         /*!< Standard trace: ITM and DWT triggers and counters, but no ETM */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+#define __WIC_PRESENT          0         /*!< WIC present or not */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm4.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_sam4l.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAM4LS2A */
+/* ************************************************************************** */
+/** \defgroup SAM4LS2A_api Peripheral Software API */
+/*@{*/
+
+#include "component/abdacb.h"
+#include "component/acifc.h"
+#include "component/adcife.h"
+#include "component/ast.h"
+#include "component/bpm.h"
+#include "component/bscif.h"
+#include "component/catb.h"
+#include "component/chipid.h"
+#include "component/crccu.h"
+#include "component/dacc.h"
+#include "component/eic.h"
+#include "component/flashcalw.h"
+#include "component/freqm.h"
+#include "component/gloc.h"
+#include "component/gpio.h"
+#include "component/hcache.h"
+#include "component/hmatrixb.h"
+#include "component/iisc.h"
+#include "component/parc.h"
+#include "component/pdca.h"
+#include "component/pevc.h"
+#include "component/picouart.h"
+#include "component/pm.h"
+#include "component/scif.h"
+#include "component/smap.h"
+#include "component/spi.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twim.h"
+#include "component/twis.h"
+#include "component/usart.h"
+#include "component/usbc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAM4LS2A */
+/* ************************************************************************** */
+/** \defgroup SAM4LS2A_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/abdacb.h"
+#include "instance/acifc.h"
+#include "instance/adcife.h"
+#include "instance/ast.h"
+#include "instance/bpm.h"
+#include "instance/bscif.h"
+#include "instance/catb.h"
+#include "instance/chipid.h"
+#include "instance/crccu.h"
+#include "instance/dacc.h"
+#include "instance/eic.h"
+#include "instance/hflashc.h"
+#include "instance/freqm.h"
+#include "instance/gloc.h"
+#include "instance/gpio.h"
+#include "instance/hcache.h"
+#include "instance/hmatrix.h"
+#include "instance/iisc.h"
+#include "instance/parc.h"
+#include "instance/pdca.h"
+#include "instance/pevc.h"
+#include "instance/picouart.h"
+#include "instance/pm.h"
+#include "instance/scif.h"
+#include "instance/smap.h"
+#include "instance/spi.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/trng.h"
+#include "instance/twim0.h"
+#include "instance/twim1.h"
+#include "instance/twim2.h"
+#include "instance/twim3.h"
+#include "instance/twis0.h"
+#include "instance/twis1.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usart3.h"
+#include "instance/usbc.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAM4LS2A */
+/* ************************************************************************** */
+/** \defgroup SAM4LS2A_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HTOP0 bridge
+#define ID_IISC           0 /**< \brief Inter-IC Sound (I2S) Controller (IISC) */
+#define ID_SPI            1 /**< \brief Serial Peripheral Interface (SPI) */
+#define ID_TC0            2 /**< \brief Timer/Counter 0 (TC0) */
+#define ID_TC1            3 /**< \brief Timer/Counter 1 (TC1) */
+#define ID_TWIM0          4 /**< \brief Two-wire Master Interface 0 (TWIM0) */
+#define ID_TWIS0          5 /**< \brief Two-wire Slave Interface 0 (TWIS0) */
+#define ID_TWIM1          6 /**< \brief Two-wire Master Interface 1 (TWIM1) */
+#define ID_TWIS1          7 /**< \brief Two-wire Slave Interface 1 (TWIS1) */
+#define ID_USART0         8 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+#define ID_USART1         9 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+#define ID_USART2        10 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+#define ID_USART3        11 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+#define ID_ADCIFE        12 /**< \brief ADC controller interface (ADCIFE) */
+#define ID_DACC          13 /**< \brief DAC Controller (DACC) */
+#define ID_ACIFC         14 /**< \brief Analog Comparator Interface (ACIFC) */
+#define ID_GLOC          15 /**< \brief Glue Logic Controller (GLOC) */
+#define ID_ABDACB        16 /**< \brief Audio Bitstream DAC (ABDACB) */
+#define ID_TRNG          17 /**< \brief True Random Number Generator (TRNG) */
+#define ID_PARC          18 /**< \brief Parallel Capture (PARC) */
+#define ID_CATB          19 /**< \brief Capacitive Touch Module B (CATB) */
+#define ID_TWIM2         21 /**< \brief Two-wire Master Interface 2 (TWIM2) */
+#define ID_TWIM3         22 /**< \brief Two-wire Master Interface 3 (TWIM3) */
+
+// Peripheral instances on HTOP1 bridge
+#define ID_HFLASHC       32 /**< \brief Flash Controller (HFLASHC) */
+#define ID_HCACHE        33 /**< \brief Cortex M I&D Cache Controller (HCACHE) */
+#define ID_HMATRIX       34 /**< \brief HSB Matrix (HMATRIX) */
+#define ID_PDCA          35 /**< \brief Peripheral DMA Controller (PDCA) */
+#define ID_SMAP          36 /**< \brief System Manager Access Port (SMAP) */
+#define ID_CRCCU         37 /**< \brief CRC Calculation Unit (CRCCU) */
+#define ID_USBC          38 /**< \brief USB 2.0 Interface (USBC) */
+#define ID_PEVC          39 /**< \brief Peripheral Event Controller (PEVC) */
+
+// Peripheral instances on HTOP2 bridge
+#define ID_PM            64 /**< \brief Power Manager (PM) */
+#define ID_CHIPID        65 /**< \brief Chip ID Registers (CHIPID) */
+#define ID_SCIF          66 /**< \brief System Control Interface (SCIF) */
+#define ID_FREQM         67 /**< \brief Frequency Meter (FREQM) */
+#define ID_GPIO          68 /**< \brief General-Purpose Input/Output Controller (GPIO) */
+
+// Peripheral instances on HTOP3 bridge
+#define ID_BPM           96 /**< \brief Backup Power Manager (BPM) */
+#define ID_BSCIF         97 /**< \brief Backup System Control Interface (BSCIF) */
+#define ID_AST           98 /**< \brief Asynchronous Timer (AST) */
+#define ID_WDT           99 /**< \brief Watchdog Timer (WDT) */
+#define ID_EIC          100 /**< \brief External Interrupt Controller (EIC) */
+#define ID_PICOUART     101 /**< \brief Pico UART (PICOUART) */
+
+#define ID_PERIPH_COUNT 102 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAM4LS2A */
+/* ************************************************************************** */
+/** \defgroup SAM4LS2A_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define ABDACB                        (0x40064000) /**< \brief (ABDACB) APB Base Address */
+#define ACIFC                         (0x40040000) /**< \brief (ACIFC) APB Base Address */
+#define ADCIFE                        (0x40038000) /**< \brief (ADCIFE) APB Base Address */
+#define AST                           (0x400F0800) /**< \brief (AST) APB Base Address */
+#define BPM                           (0x400F0000) /**< \brief (BPM) APB Base Address */
+#define BSCIF                         (0x400F0400) /**< \brief (BSCIF) APB Base Address */
+#define CATB                          (0x40070000) /**< \brief (CATB) APB Base Address */
+#define CHIPID                        (0x400E0400) /**< \brief (CHIPID) APB Base Address */
+#define CRCCU                         (0x400A4000) /**< \brief (CRCCU) APB Base Address */
+#define DACC                          (0x4003C000) /**< \brief (DACC) APB Base Address */
+#define EIC                           (0x400F1000) /**< \brief (EIC) APB Base Address */
+#define HFLASHC                       (0x400A0000) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000) /**< \brief (HFLASHC) USER Base Address */
+#define FREQM                         (0x400E0C00) /**< \brief (FREQM) APB Base Address */
+#define GLOC                          (0x40060000) /**< \brief (GLOC) APB Base Address */
+#define GPIO                          (0x400E1000) /**< \brief (GPIO) APB Base Address */
+#define HCACHE                        (0x400A0400) /**< \brief (HCACHE) APB Base Address */
+#define HMATRIX                       (0x400A1000) /**< \brief (HMATRIX) APB Base Address */
+#define IISC                          (0x40004000) /**< \brief (IISC) APB Base Address */
+#define PARC                          (0x4006C000) /**< \brief (PARC) APB Base Address */
+#define PDCA                          (0x400A2000) /**< \brief (PDCA) APB Base Address */
+#define PEVC                          (0x400A6000) /**< \brief (PEVC) APB Base Address */
+#define PICOUART                      (0x400F1400) /**< \brief (PICOUART) APB Base Address */
+#define PM                            (0x400E0000) /**< \brief (PM) APB Base Address */
+#define SCIF                          (0x400E0800) /**< \brief (SCIF) APB Base Address */
+#define SMAP                          (0x400A3000) /**< \brief (SMAP) APB Base Address */
+#define SPI                           (0x40008000) /**< \brief (SPI) APB Base Address */
+#define TC0                           (0x40010000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x40014000) /**< \brief (TC1) APB Base Address */
+#define TRNG                          (0x40068000) /**< \brief (TRNG) APB Base Address */
+#define TWIM0                         (0x40018000) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1                         (0x4001C000) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2                         (0x40078000) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3                         (0x4007C000) /**< \brief (TWIM3) APB Base Address */
+#define TWIS0                         (0x40018400) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1                         (0x4001C400) /**< \brief (TWIS1) APB Base Address */
+#define USART0                        (0x40024000) /**< \brief (USART0) APB Base Address */
+#define USART1                        (0x40028000) /**< \brief (USART1) APB Base Address */
+#define USART2                        (0x4002C000) /**< \brief (USART2) APB Base Address */
+#define USART3                        (0x40030000) /**< \brief (USART3) APB Base Address */
+#define USBC                          (0x400A5000) /**< \brief (USBC) APB Base Address */
+#define WDT                           (0x400F0C00) /**< \brief (WDT) APB Base Address */
+#else
+#define ABDACB            ((Abdacb   *)0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_ADDR                   (0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_INST_NUM   1                          /**< \brief (ABDACB) Number of instances */
+#define ABDACB_INSTS      { ABDACB }                 /**< \brief (ABDACB) Instances List */
+
+#define ACIFC             ((Acifc    *)0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_ADDR                    (0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_INST_NUM    1                          /**< \brief (ACIFC) Number of instances */
+#define ACIFC_INSTS       { ACIFC }                  /**< \brief (ACIFC) Instances List */
+
+#define ADCIFE            ((Adcife   *)0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_ADDR                   (0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_INST_NUM   1                          /**< \brief (ADCIFE) Number of instances */
+#define ADCIFE_INSTS      { ADCIFE }                 /**< \brief (ADCIFE) Instances List */
+
+#define AST               ((Ast      *)0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_ADDR                      (0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_INST_NUM      1                          /**< \brief (AST) Number of instances */
+#define AST_INSTS         { AST }                    /**< \brief (AST) Instances List */
+
+#define BPM               ((Bpm      *)0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_ADDR                      (0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_INST_NUM      1                          /**< \brief (BPM) Number of instances */
+#define BPM_INSTS         { BPM }                    /**< \brief (BPM) Instances List */
+
+#define BSCIF             ((Bscif    *)0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_ADDR                    (0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_INST_NUM    1                          /**< \brief (BSCIF) Number of instances */
+#define BSCIF_INSTS       { BSCIF }                  /**< \brief (BSCIF) Instances List */
+
+#define CATB              ((Catb     *)0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_ADDR                     (0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_INST_NUM     1                          /**< \brief (CATB) Number of instances */
+#define CATB_INSTS        { CATB }                   /**< \brief (CATB) Instances List */
+
+#define CHIPID            ((Chipid   *)0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_ADDR                   (0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_INST_NUM   1                          /**< \brief (CHIPID) Number of instances */
+#define CHIPID_INSTS      { CHIPID }                 /**< \brief (CHIPID) Instances List */
+
+#define CRCCU             ((Crccu    *)0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_ADDR                    (0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_INST_NUM    1                          /**< \brief (CRCCU) Number of instances */
+#define CRCCU_INSTS       { CRCCU }                  /**< \brief (CRCCU) Instances List */
+
+#define DACC              ((Dacc     *)0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_ADDR                     (0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_INST_NUM     1                          /**< \brief (DACC) Number of instances */
+#define DACC_INSTS        { DACC }                   /**< \brief (DACC) Instances List */
+
+#define EIC               ((Eic      *)0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_ADDR                      (0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define HFLASHC           ((Flashcalw *)0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_ADDR                  (0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_FROW_ADDR             (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define HFLASHC_USER_ADDR             (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define FLASHCALW_INST_NUM 1                          /**< \brief (FLASHCALW) Number of instances */
+#define FLASHCALW_INSTS   { HFLASHC }                /**< \brief (FLASHCALW) Instances List */
+
+#define FREQM             ((Freqm    *)0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_ADDR                    (0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_INST_NUM    1                          /**< \brief (FREQM) Number of instances */
+#define FREQM_INSTS       { FREQM }                  /**< \brief (FREQM) Instances List */
+
+#define GLOC              ((Gloc     *)0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_ADDR                     (0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_INST_NUM     1                          /**< \brief (GLOC) Number of instances */
+#define GLOC_INSTS        { GLOC }                   /**< \brief (GLOC) Instances List */
+
+#define GPIO              ((Gpio     *)0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_ADDR                     (0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_INST_NUM     1                          /**< \brief (GPIO) Number of instances */
+#define GPIO_INSTS        { GPIO }                   /**< \brief (GPIO) Instances List */
+
+#define HCACHE            ((Hcache   *)0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_ADDR                   (0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_INST_NUM   1                          /**< \brief (HCACHE) Number of instances */
+#define HCACHE_INSTS      { HCACHE }                 /**< \brief (HCACHE) Instances List */
+
+#define HMATRIX           ((Hmatrixb *)0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIX_ADDR                  (0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIXB_INST_NUM 1                          /**< \brief (HMATRIXB) Number of instances */
+#define HMATRIXB_INSTS    { HMATRIX }                /**< \brief (HMATRIXB) Instances List */
+
+#define IISC              ((Iisc     *)0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_ADDR                     (0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_INST_NUM     1                          /**< \brief (IISC) Number of instances */
+#define IISC_INSTS        { IISC }                   /**< \brief (IISC) Instances List */
+
+#define PARC              ((Parc     *)0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_ADDR                     (0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_INST_NUM     1                          /**< \brief (PARC) Number of instances */
+#define PARC_INSTS        { PARC }                   /**< \brief (PARC) Instances List */
+
+#define PDCA              ((Pdca     *)0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_ADDR                     (0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_INST_NUM     1                          /**< \brief (PDCA) Number of instances */
+#define PDCA_INSTS        { PDCA }                   /**< \brief (PDCA) Instances List */
+
+#define PEVC              ((Pevc     *)0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_ADDR                     (0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_INST_NUM     1                          /**< \brief (PEVC) Number of instances */
+#define PEVC_INSTS        { PEVC }                   /**< \brief (PEVC) Instances List */
+
+#define PICOUART          ((Picouart *)0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_ADDR                 (0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_INST_NUM 1                          /**< \brief (PICOUART) Number of instances */
+#define PICOUART_INSTS    { PICOUART }               /**< \brief (PICOUART) Instances List */
+
+#define PM                ((Pm       *)0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_ADDR                       (0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define SCIF              ((Scif     *)0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_ADDR                     (0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_INST_NUM     1                          /**< \brief (SCIF) Number of instances */
+#define SCIF_INSTS        { SCIF }                   /**< \brief (SCIF) Instances List */
+
+#define SMAP              ((Smap     *)0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_ADDR                     (0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_INST_NUM     1                          /**< \brief (SMAP) Number of instances */
+#define SMAP_INSTS        { SMAP }                   /**< \brief (SMAP) Instances List */
+
+#define SPI               ((Spi      *)0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_ADDR                      (0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_INST_NUM      1                          /**< \brief (SPI) Number of instances */
+#define SPI_INSTS         { SPI }                    /**< \brief (SPI) Instances List */
+
+#define TC0               ((Tc       *)0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC0_ADDR                      (0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC1_ADDR                      (0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC_INST_NUM       2                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1 }               /**< \brief (TC) Instances List */
+
+#define TRNG              ((Trng     *)0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_ADDR                     (0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_INST_NUM     1                          /**< \brief (TRNG) Number of instances */
+#define TRNG_INSTS        { TRNG }                   /**< \brief (TRNG) Instances List */
+
+#define TWIM0             ((Twim     *)0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM0_ADDR                    (0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1             ((Twim     *)0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM1_ADDR                    (0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2             ((Twim     *)0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM2_ADDR                    (0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3             ((Twim     *)0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM3_ADDR                    (0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM_INST_NUM     4                          /**< \brief (TWIM) Number of instances */
+#define TWIM_INSTS        { TWIM0, TWIM1, TWIM2, TWIM3 } /**< \brief (TWIM) Instances List */
+
+#define TWIS0             ((Twis     *)0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS0_ADDR                    (0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1             ((Twis     *)0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS1_ADDR                    (0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS_INST_NUM     2                          /**< \brief (TWIS) Number of instances */
+#define TWIS_INSTS        { TWIS0, TWIS1 }           /**< \brief (TWIS) Instances List */
+
+#define USART0            ((Usart    *)0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART0_ADDR                   (0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART1            ((Usart    *)0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART1_ADDR                   (0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART2            ((Usart    *)0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART2_ADDR                   (0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART3            ((Usart    *)0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART3_ADDR                   (0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART_INST_NUM    4                          /**< \brief (USART) Number of instances */
+#define USART_INSTS       { USART0, USART1, USART2, USART3 } /**< \brief (USART) Instances List */
+
+#define USBC              ((Usbc     *)0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_ADDR                     (0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_INST_NUM     1                          /**< \brief (USBC) Number of instances */
+#define USBC_INSTS        { USBC }                   /**< \brief (USBC) Instances List */
+
+#define WDT               ((Wdt      *)0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_ADDR                      (0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  GPIO DEFINITIONS FOR SAM4LS2A */
+/* ************************************************************************** */
+/** \defgroup SAM4LS2A_gpio GPIO Definitions */
+/*@{*/
+
+#include "pio/sam4ls2a.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  ADDITIONAL DEFINITIONS FOR COMPATIBILITY */
+/* ************************************************************************** */
+/** \addtogroup SAM4LS2A_compat Definitions */
+/*@{*/
+// These defines are used to keep compatibility with existing 
+// sam/drivers/usart implementation from SAM3/4 products with SAM4L product.
+#define US_MR_USART_MODE_HW_HANDSHAKING  US_MR_USART_MODE_HARDWARE
+#define US_MR_USART_MODE_IS07816_T_0     US_MR_USART_MODE_ISO7816_T0
+#define US_MR_USART_MODE_IS07816_T_1     US_MR_USART_MODE_ISO7816_T1
+#define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
+#define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
+#define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_8_BIT      US_MR_CHRL_8
+#define US_MR_PAR_NO          US_MR_PAR_NONE
+#define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI
+#define US_IF                 US_IFR
+#define US_WPSR_WPVS          US_WPSR_WPV_1
+
+#define USBC_UPCFG0_PBK_Msk   (0x1u << USBC_UPCFG0_PBK_Pos)
+
+// These defines for homogeneity with other SAM header files.
+#define CHIP_FREQ_FWS_0       (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 */
+#define CHIP_FREQ_FWS_1       (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 */
+// WARNING NOTE: these are preliminary values.
+#define CHIP_FREQ_FLASH_HSEN_FWS_0 (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 and the FLASH HS mode is enabled */
+#define CHIP_FREQ_FLASH_HSEN_FWS_1 (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 and the FLASH HS mode is enabled */
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/tc implementation from SAM3/4 products with SAM4L product. 
+#define TC_CMR_LDRA_RISING    TC_CMR_LDRA_POS_EDGE_TIOA
+#define TC_CMR_LDRB_FALLING   TC_CMR_LDRB_NEG_EDGE_TIOA
+#define TC_CMR_ETRGEDG_FALLING TC_CMR_ETRGEDG_NEG_EDGE
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/spi implementation from SAM3/4 products with SAM4L product. 
+#define SPI_CSR_BITS_8_BIT    SPI_CSR_BITS_8_BPT
+#define SPI_WPCR_SPIWPKEY_VALUE SPI_WPCR_WPKEY_VALUE
+#define SPI_WPCR_SPIWPEN      SPI_WPCR_WPEN
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/crccu implementation from SAM3/4 products with SAM4L product. 
+#define CRCCU_DMA_EN          CRCCU_DMAEN
+#define CRCCU_DMA_DIS         CRCCU_DMADIS
+#define CRCCU_DMA_SR          CRCCU_DMASR
+#define CRCCU_DMA_IER         CRCCU_DMAIER
+#define CRCCU_DMA_IDR         CRCCU_DMAIDR
+#define CRCCU_DMA_IMR         CRCCU_DMAIMR
+#define CRCCU_DMA_ISR         CRCCU_DMAISR
+#define CRCCU_DMA_EN_DMAEN    CRCCU_DMAEN_DMAEN
+#define CRCCU_DMA_DIS_DMADIS  CRCCU_DMADIS_DMADIS
+#define CRCCU_DMA_SR_DMASR    CRCCU_DMASR_DMASR
+#define CRCCU_DMA_IER_DMAIER  CRCCU_DMAIER_DMAIER
+#define CRCCU_DMA_IDR_DMAIDR  CRCCU_DMAIDR_DMAIDR
+#define CRCCU_DMA_IMR_DMAIMR  CRCCU_DMAIMR_DMAIMR
+#define CRCCU_DMA_ISR_DMAISR  CRCCU_DMAISR_DMAISR
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAM4LS2A */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL(0x00020000) /* 128 kB */
+#define FLASH_PAGE_SIZE       512
+#define FLASH_NB_OF_PAGES     256
+#define FLASH_USER_PAGE_SIZE  512
+#define HRAMC0_SIZE           _UL(0x00008000) /* 32 kB */
+#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+
+#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+
+#define DSU_DID_RESETVALUE    _UL(0xAB0A07E0)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAM4LS2A */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAM4LS2A_H */

--- a/asf/sam/include/sam4l/sam4ls2b.h
+++ b/asf/sam/include/sam4l/sam4ls2b.h
@@ -62,15 +62,15 @@ typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volati
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
 #if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#define _U_(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
 #if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#define _U_(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 
@@ -857,23 +857,23 @@ void TWIM3_Handler               ( void );
 /**  MEMORY MAPPING DEFINITIONS FOR SAM4LS2B */
 /* ************************************************************************** */
 
-#define FLASH_SIZE            _UL(0x00020000) /* 128 kB */
+#define FLASH_SIZE            _UL_(0x00020000) /* 128 kB */
 #define FLASH_PAGE_SIZE       512
 #define FLASH_NB_OF_PAGES     256
 #define FLASH_USER_PAGE_SIZE  512
-#define HRAMC0_SIZE           _UL(0x00008000) /* 32 kB */
-#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+#define HRAMC0_SIZE           _UL_(0x00008000) /* 32 kB */
+#define HRAMC1_SIZE           _UL_(0x00000800) /* 2 kB */
 
-#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
-#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
-#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
-#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
-#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
-#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
-#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
-#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL_(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL_(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL_(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL_(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL_(0x400F0000) /**< HTOP3 base address */
 
-#define DSU_DID_RESETVALUE    _UL(0xAB0A07E0)
+#define DSU_DID_RESETVALUE    _UL_(0xAB0A07E0)
 
 /* ************************************************************************** */
 /**  ELECTRICAL DEFINITIONS FOR SAM4LS2B */

--- a/asf/sam/include/sam4l/sam4ls2b.h
+++ b/asf/sam/include/sam4l/sam4ls2b.h
@@ -1,0 +1,889 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAM4LS2B
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LS2B_
+#define _SAM4LS2B_
+
+/**
+ * \ingroup SAM4L_definitions
+ * \addtogroup SAM4LS2B_definitions SAM4LS2B definitions
+ * This file defines all structures and symbols for SAM4LS2B:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#if !defined(_UL)
+#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#endif
+#else
+#if !defined(_UL)
+#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif
+#endif
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAM4LS2B */
+/* ************************************************************************** */
+/** \defgroup SAM4LS2B_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M4 Processor Exceptions Numbers ******************************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn           = -13,/**<  3 Cortex-M4 Hard Fault Interrupt        */
+  MemoryManagement_IRQn    = -12,/**<  4 Cortex-M4 Memory Management Interrupt */
+  BusFault_IRQn            = -11,/**<  5 Cortex-M4 Bus Fault Interrupt         */
+  UsageFault_IRQn          = -10,/**<  6 Cortex-M4 Usage Fault Interrupt       */
+  SVCall_IRQn              = -5, /**< 11 Cortex-M4 SV Call Interrupt           */
+  DebugMonitor_IRQn        = -4, /**< 12 Cortex-M4 Debug Monitor Interrupt     */
+  PendSV_IRQn              = -2, /**< 14 Cortex-M4 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 Cortex-M4 System Tick Interrupt       */
+  /******  SAM4LS2B-specific Interrupt Numbers ***********************/
+  HFLASHC_IRQn             =  0, /**<  0 SAM4LS2B Flash Controller (HFLASHC) */
+  PDCA_0_IRQn              =  1, /**<  1 SAM4LS2B Peripheral DMA Controller (PDCA): PDCA_0 */
+  PDCA_1_IRQn              =  2, /**<  2 SAM4LS2B Peripheral DMA Controller (PDCA): PDCA_1 */
+  PDCA_2_IRQn              =  3, /**<  3 SAM4LS2B Peripheral DMA Controller (PDCA): PDCA_2 */
+  PDCA_3_IRQn              =  4, /**<  4 SAM4LS2B Peripheral DMA Controller (PDCA): PDCA_3 */
+  PDCA_4_IRQn              =  5, /**<  5 SAM4LS2B Peripheral DMA Controller (PDCA): PDCA_4 */
+  PDCA_5_IRQn              =  6, /**<  6 SAM4LS2B Peripheral DMA Controller (PDCA): PDCA_5 */
+  PDCA_6_IRQn              =  7, /**<  7 SAM4LS2B Peripheral DMA Controller (PDCA): PDCA_6 */
+  PDCA_7_IRQn              =  8, /**<  8 SAM4LS2B Peripheral DMA Controller (PDCA): PDCA_7 */
+  PDCA_8_IRQn              =  9, /**<  9 SAM4LS2B Peripheral DMA Controller (PDCA): PDCA_8 */
+  PDCA_9_IRQn              = 10, /**< 10 SAM4LS2B Peripheral DMA Controller (PDCA): PDCA_9 */
+  PDCA_10_IRQn             = 11, /**< 11 SAM4LS2B Peripheral DMA Controller (PDCA): PDCA_10 */
+  PDCA_11_IRQn             = 12, /**< 12 SAM4LS2B Peripheral DMA Controller (PDCA): PDCA_11 */
+  PDCA_12_IRQn             = 13, /**< 13 SAM4LS2B Peripheral DMA Controller (PDCA): PDCA_12 */
+  PDCA_13_IRQn             = 14, /**< 14 SAM4LS2B Peripheral DMA Controller (PDCA): PDCA_13 */
+  PDCA_14_IRQn             = 15, /**< 15 SAM4LS2B Peripheral DMA Controller (PDCA): PDCA_14 */
+  PDCA_15_IRQn             = 16, /**< 16 SAM4LS2B Peripheral DMA Controller (PDCA): PDCA_15 */
+  CRCCU_IRQn               = 17, /**< 17 SAM4LS2B CRC Calculation Unit (CRCCU) */
+  USBC_IRQn                = 18, /**< 18 SAM4LS2B USB 2.0 Interface (USBC) */
+  PEVC_0_IRQn              = 19, /**< 19 SAM4LS2B Peripheral Event Controller (PEVC): PEVC_TR */
+  PEVC_1_IRQn              = 20, /**< 20 SAM4LS2B Peripheral Event Controller (PEVC): PEVC_OV */
+  PM_IRQn                  = 22, /**< 22 SAM4LS2B Power Manager (PM) */
+  SCIF_IRQn                = 23, /**< 23 SAM4LS2B System Control Interface (SCIF) */
+  FREQM_IRQn               = 24, /**< 24 SAM4LS2B Frequency Meter (FREQM) */
+  GPIO_0_IRQn              = 25, /**< 25 SAM4LS2B General-Purpose Input/Output Controller (GPIO): GPIO_0 */
+  GPIO_1_IRQn              = 26, /**< 26 SAM4LS2B General-Purpose Input/Output Controller (GPIO): GPIO_1 */
+  GPIO_2_IRQn              = 27, /**< 27 SAM4LS2B General-Purpose Input/Output Controller (GPIO): GPIO_2 */
+  GPIO_3_IRQn              = 28, /**< 28 SAM4LS2B General-Purpose Input/Output Controller (GPIO): GPIO_3 */
+  GPIO_4_IRQn              = 29, /**< 29 SAM4LS2B General-Purpose Input/Output Controller (GPIO): GPIO_4 */
+  GPIO_5_IRQn              = 30, /**< 30 SAM4LS2B General-Purpose Input/Output Controller (GPIO): GPIO_5 */
+  GPIO_6_IRQn              = 31, /**< 31 SAM4LS2B General-Purpose Input/Output Controller (GPIO): GPIO_6 */
+  GPIO_7_IRQn              = 32, /**< 32 SAM4LS2B General-Purpose Input/Output Controller (GPIO): GPIO_7 */
+  GPIO_8_IRQn              = 33, /**< 33 SAM4LS2B General-Purpose Input/Output Controller (GPIO): GPIO_8 */
+  GPIO_9_IRQn              = 34, /**< 34 SAM4LS2B General-Purpose Input/Output Controller (GPIO): GPIO_9 */
+  GPIO_10_IRQn             = 35, /**< 35 SAM4LS2B General-Purpose Input/Output Controller (GPIO): GPIO_10 */
+  GPIO_11_IRQn             = 36, /**< 36 SAM4LS2B General-Purpose Input/Output Controller (GPIO): GPIO_11 */
+  BPM_IRQn                 = 37, /**< 37 SAM4LS2B Backup Power Manager (BPM) */
+  BSCIF_IRQn               = 38, /**< 38 SAM4LS2B Backup System Control Interface (BSCIF) */
+  AST_0_IRQn               = 39, /**< 39 SAM4LS2B Asynchronous Timer (AST): AST_ALARM */
+  AST_1_IRQn               = 40, /**< 40 SAM4LS2B Asynchronous Timer (AST): AST_PER */
+  AST_2_IRQn               = 41, /**< 41 SAM4LS2B Asynchronous Timer (AST): AST_OVF */
+  AST_3_IRQn               = 42, /**< 42 SAM4LS2B Asynchronous Timer (AST): AST_READY */
+  AST_4_IRQn               = 43, /**< 43 SAM4LS2B Asynchronous Timer (AST): AST_CLKREADY */
+  WDT_IRQn                 = 44, /**< 44 SAM4LS2B Watchdog Timer (WDT) */
+  EIC_0_IRQn               = 45, /**< 45 SAM4LS2B External Interrupt Controller (EIC): EIC_1 */
+  EIC_1_IRQn               = 46, /**< 46 SAM4LS2B External Interrupt Controller (EIC): EIC_2 */
+  EIC_2_IRQn               = 47, /**< 47 SAM4LS2B External Interrupt Controller (EIC): EIC_3 */
+  EIC_3_IRQn               = 48, /**< 48 SAM4LS2B External Interrupt Controller (EIC): EIC_4 */
+  EIC_4_IRQn               = 49, /**< 49 SAM4LS2B External Interrupt Controller (EIC): EIC_5 */
+  EIC_5_IRQn               = 50, /**< 50 SAM4LS2B External Interrupt Controller (EIC): EIC_6 */
+  EIC_6_IRQn               = 51, /**< 51 SAM4LS2B External Interrupt Controller (EIC): EIC_7 */
+  EIC_7_IRQn               = 52, /**< 52 SAM4LS2B External Interrupt Controller (EIC): EIC_8 */
+  IISC_IRQn                = 53, /**< 53 SAM4LS2B Inter-IC Sound (I2S) Controller (IISC) */
+  SPI_IRQn                 = 54, /**< 54 SAM4LS2B Serial Peripheral Interface (SPI) */
+  TC0_0_IRQn               = 55, /**< 55 SAM4LS2B Timer/Counter 0 (TC0): TC00 */
+  TC0_1_IRQn               = 56, /**< 56 SAM4LS2B Timer/Counter 0 (TC0): TC01 */
+  TC0_2_IRQn               = 57, /**< 57 SAM4LS2B Timer/Counter 0 (TC0): TC02 */
+  TC1_0_IRQn               = 58, /**< 58 SAM4LS2B Timer/Counter 1 (TC1): TC10 */
+  TC1_1_IRQn               = 59, /**< 59 SAM4LS2B Timer/Counter 1 (TC1): TC11 */
+  TC1_2_IRQn               = 60, /**< 60 SAM4LS2B Timer/Counter 1 (TC1): TC12 */
+  TWIM0_IRQn               = 61, /**< 61 SAM4LS2B Two-wire Master Interface 0 (TWIM0) */
+  TWIS0_IRQn               = 62, /**< 62 SAM4LS2B Two-wire Slave Interface 0 (TWIS0) */
+  TWIM1_IRQn               = 63, /**< 63 SAM4LS2B Two-wire Master Interface 1 (TWIM1) */
+  TWIS1_IRQn               = 64, /**< 64 SAM4LS2B Two-wire Slave Interface 1 (TWIS1) */
+  USART0_IRQn              = 65, /**< 65 SAM4LS2B Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+  USART1_IRQn              = 66, /**< 66 SAM4LS2B Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+  USART2_IRQn              = 67, /**< 67 SAM4LS2B Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+  USART3_IRQn              = 68, /**< 68 SAM4LS2B Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+  ADCIFE_IRQn              = 69, /**< 69 SAM4LS2B ADC controller interface (ADCIFE) */
+  DACC_IRQn                = 70, /**< 70 SAM4LS2B DAC Controller (DACC) */
+  ACIFC_IRQn               = 71, /**< 71 SAM4LS2B Analog Comparator Interface (ACIFC) */
+  ABDACB_IRQn              = 72, /**< 72 SAM4LS2B Audio Bitstream DAC (ABDACB) */
+  TRNG_IRQn                = 73, /**< 73 SAM4LS2B True Random Number Generator (TRNG) */
+  PARC_IRQn                = 74, /**< 74 SAM4LS2B Parallel Capture (PARC) */
+  CATB_IRQn                = 75, /**< 75 SAM4LS2B Capacitive Touch Module B (CATB) */
+  TWIM2_IRQn               = 77, /**< 77 SAM4LS2B Two-wire Master Interface 2 (TWIM2) */
+  TWIM3_IRQn               = 78, /**< 78 SAM4LS2B Two-wire Master Interface 3 (TWIM3) */
+
+  PERIPH_COUNT_IRQn        = 80  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNMI_Handler;
+  void* pfnHardFault_Handler;
+  void* pfnMemManage_Handler;
+  void* pfnBusFault_Handler;
+  void* pfnUsageFault_Handler;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVC_Handler;
+  void* pfnDebugMon_Handler;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnHFLASHC_Handler;               /*  0 Flash Controller */
+  void* pfnPDCA_0_Handler;                /*  1 Peripheral DMA Controller IRQ 0 */
+  void* pfnPDCA_1_Handler;                /*  2 Peripheral DMA Controller IRQ 1 */
+  void* pfnPDCA_2_Handler;                /*  3 Peripheral DMA Controller IRQ 2 */
+  void* pfnPDCA_3_Handler;                /*  4 Peripheral DMA Controller IRQ 3 */
+  void* pfnPDCA_4_Handler;                /*  5 Peripheral DMA Controller IRQ 4 */
+  void* pfnPDCA_5_Handler;                /*  6 Peripheral DMA Controller IRQ 5 */
+  void* pfnPDCA_6_Handler;                /*  7 Peripheral DMA Controller IRQ 6 */
+  void* pfnPDCA_7_Handler;                /*  8 Peripheral DMA Controller IRQ 7 */
+  void* pfnPDCA_8_Handler;                /*  9 Peripheral DMA Controller IRQ 8 */
+  void* pfnPDCA_9_Handler;                /* 10 Peripheral DMA Controller IRQ 9 */
+  void* pfnPDCA_10_Handler;               /* 11 Peripheral DMA Controller IRQ 10 */
+  void* pfnPDCA_11_Handler;               /* 12 Peripheral DMA Controller IRQ 11 */
+  void* pfnPDCA_12_Handler;               /* 13 Peripheral DMA Controller IRQ 12 */
+  void* pfnPDCA_13_Handler;               /* 14 Peripheral DMA Controller IRQ 13 */
+  void* pfnPDCA_14_Handler;               /* 15 Peripheral DMA Controller IRQ 14 */
+  void* pfnPDCA_15_Handler;               /* 16 Peripheral DMA Controller IRQ 15 */
+  void* pfnCRCCU_Handler;                 /* 17 CRC Calculation Unit */
+  void* pfnUSBC_Handler;                  /* 18 USB 2.0 Interface */
+  void* pfnPEVC_0_Handler;                /* 19 Peripheral Event Controller IRQ 0 */
+  void* pfnPEVC_1_Handler;                /* 20 Peripheral Event Controller IRQ 1 */
+  void* pvReserved21;
+  void* pfnPM_Handler;                    /* 22 Power Manager */
+  void* pfnSCIF_Handler;                  /* 23 System Control Interface */
+  void* pfnFREQM_Handler;                 /* 24 Frequency Meter */
+  void* pfnGPIO_0_Handler;                /* 25 General-Purpose Input/Output Controller IRQ 0 */
+  void* pfnGPIO_1_Handler;                /* 26 General-Purpose Input/Output Controller IRQ 1 */
+  void* pfnGPIO_2_Handler;                /* 27 General-Purpose Input/Output Controller IRQ 2 */
+  void* pfnGPIO_3_Handler;                /* 28 General-Purpose Input/Output Controller IRQ 3 */
+  void* pfnGPIO_4_Handler;                /* 29 General-Purpose Input/Output Controller IRQ 4 */
+  void* pfnGPIO_5_Handler;                /* 30 General-Purpose Input/Output Controller IRQ 5 */
+  void* pfnGPIO_6_Handler;                /* 31 General-Purpose Input/Output Controller IRQ 6 */
+  void* pfnGPIO_7_Handler;                /* 32 General-Purpose Input/Output Controller IRQ 7 */
+  void* pfnGPIO_8_Handler;                /* 33 General-Purpose Input/Output Controller IRQ 8 */
+  void* pfnGPIO_9_Handler;                /* 34 General-Purpose Input/Output Controller IRQ 9 */
+  void* pfnGPIO_10_Handler;               /* 35 General-Purpose Input/Output Controller IRQ 10 */
+  void* pfnGPIO_11_Handler;               /* 36 General-Purpose Input/Output Controller IRQ 11 */
+  void* pfnBPM_Handler;                   /* 37 Backup Power Manager */
+  void* pfnBSCIF_Handler;                 /* 38 Backup System Control Interface */
+  void* pfnAST_0_Handler;                 /* 39 Asynchronous Timer IRQ 0 */
+  void* pfnAST_1_Handler;                 /* 40 Asynchronous Timer IRQ 1 */
+  void* pfnAST_2_Handler;                 /* 41 Asynchronous Timer IRQ 2 */
+  void* pfnAST_3_Handler;                 /* 42 Asynchronous Timer IRQ 3 */
+  void* pfnAST_4_Handler;                 /* 43 Asynchronous Timer IRQ 4 */
+  void* pfnWDT_Handler;                   /* 44 Watchdog Timer */
+  void* pfnEIC_0_Handler;                 /* 45 External Interrupt Controller IRQ 0 */
+  void* pfnEIC_1_Handler;                 /* 46 External Interrupt Controller IRQ 1 */
+  void* pfnEIC_2_Handler;                 /* 47 External Interrupt Controller IRQ 2 */
+  void* pfnEIC_3_Handler;                 /* 48 External Interrupt Controller IRQ 3 */
+  void* pfnEIC_4_Handler;                 /* 49 External Interrupt Controller IRQ 4 */
+  void* pfnEIC_5_Handler;                 /* 50 External Interrupt Controller IRQ 5 */
+  void* pfnEIC_6_Handler;                 /* 51 External Interrupt Controller IRQ 6 */
+  void* pfnEIC_7_Handler;                 /* 52 External Interrupt Controller IRQ 7 */
+  void* pfnIISC_Handler;                  /* 53 Inter-IC Sound (I2S) Controller */
+  void* pfnSPI_Handler;                   /* 54 Serial Peripheral Interface */
+  void* pfnTC0_0_Handler;                 /* 55 Timer/Counter 0 IRQ 0 */
+  void* pfnTC0_1_Handler;                 /* 56 Timer/Counter 0 IRQ 1 */
+  void* pfnTC0_2_Handler;                 /* 57 Timer/Counter 0 IRQ 2 */
+  void* pfnTC1_0_Handler;                 /* 58 Timer/Counter 1 IRQ 0 */
+  void* pfnTC1_1_Handler;                 /* 59 Timer/Counter 1 IRQ 1 */
+  void* pfnTC1_2_Handler;                 /* 60 Timer/Counter 1 IRQ 2 */
+  void* pfnTWIM0_Handler;                 /* 61 Two-wire Master Interface 0 */
+  void* pfnTWIS0_Handler;                 /* 62 Two-wire Slave Interface 0 */
+  void* pfnTWIM1_Handler;                 /* 63 Two-wire Master Interface 1 */
+  void* pfnTWIS1_Handler;                 /* 64 Two-wire Slave Interface 1 */
+  void* pfnUSART0_Handler;                /* 65 Universal Synchronous Asynchronous Receiver Transmitter 0 */
+  void* pfnUSART1_Handler;                /* 66 Universal Synchronous Asynchronous Receiver Transmitter 1 */
+  void* pfnUSART2_Handler;                /* 67 Universal Synchronous Asynchronous Receiver Transmitter 2 */
+  void* pfnUSART3_Handler;                /* 68 Universal Synchronous Asynchronous Receiver Transmitter 3 */
+  void* pfnADCIFE_Handler;                /* 69 ADC controller interface */
+  void* pfnDACC_Handler;                  /* 70 DAC Controller */
+  void* pfnACIFC_Handler;                 /* 71 Analog Comparator Interface */
+  void* pfnABDACB_Handler;                /* 72 Audio Bitstream DAC */
+  void* pfnTRNG_Handler;                  /* 73 True Random Number Generator */
+  void* pfnPARC_Handler;                  /* 74 Parallel Capture */
+  void* pfnCATB_Handler;                  /* 75 Capacitive Touch Module B */
+  void* pvReserved76;
+  void* pfnTWIM2_Handler;                 /* 77 Two-wire Master Interface 2 */
+  void* pfnTWIM3_Handler;                 /* 78 Two-wire Master Interface 3 */
+  void* pvReserved79;
+} DeviceVectors;
+
+/* Cortex-M4 processor handlers */
+void Reset_Handler               ( void );
+void NMI_Handler                 ( void );
+void HardFault_Handler           ( void );
+void MemManage_Handler           ( void );
+void BusFault_Handler            ( void );
+void UsageFault_Handler          ( void );
+void SVC_Handler                 ( void );
+void DebugMon_Handler            ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void HFLASHC_Handler             ( void );
+void PDCA_0_Handler              ( void );
+void PDCA_1_Handler              ( void );
+void PDCA_2_Handler              ( void );
+void PDCA_3_Handler              ( void );
+void PDCA_4_Handler              ( void );
+void PDCA_5_Handler              ( void );
+void PDCA_6_Handler              ( void );
+void PDCA_7_Handler              ( void );
+void PDCA_8_Handler              ( void );
+void PDCA_9_Handler              ( void );
+void PDCA_10_Handler             ( void );
+void PDCA_11_Handler             ( void );
+void PDCA_12_Handler             ( void );
+void PDCA_13_Handler             ( void );
+void PDCA_14_Handler             ( void );
+void PDCA_15_Handler             ( void );
+void CRCCU_Handler               ( void );
+void USBC_Handler                ( void );
+void PEVC_0_Handler              ( void );
+void PEVC_1_Handler              ( void );
+void PM_Handler                  ( void );
+void SCIF_Handler                ( void );
+void FREQM_Handler               ( void );
+void GPIO_0_Handler              ( void );
+void GPIO_1_Handler              ( void );
+void GPIO_2_Handler              ( void );
+void GPIO_3_Handler              ( void );
+void GPIO_4_Handler              ( void );
+void GPIO_5_Handler              ( void );
+void GPIO_6_Handler              ( void );
+void GPIO_7_Handler              ( void );
+void GPIO_8_Handler              ( void );
+void GPIO_9_Handler              ( void );
+void GPIO_10_Handler             ( void );
+void GPIO_11_Handler             ( void );
+void BPM_Handler                 ( void );
+void BSCIF_Handler               ( void );
+void AST_0_Handler               ( void );
+void AST_1_Handler               ( void );
+void AST_2_Handler               ( void );
+void AST_3_Handler               ( void );
+void AST_4_Handler               ( void );
+void WDT_Handler                 ( void );
+void EIC_0_Handler               ( void );
+void EIC_1_Handler               ( void );
+void EIC_2_Handler               ( void );
+void EIC_3_Handler               ( void );
+void EIC_4_Handler               ( void );
+void EIC_5_Handler               ( void );
+void EIC_6_Handler               ( void );
+void EIC_7_Handler               ( void );
+void IISC_Handler                ( void );
+void SPI_Handler                 ( void );
+void TC0_0_Handler               ( void );
+void TC0_1_Handler               ( void );
+void TC0_2_Handler               ( void );
+void TC1_0_Handler               ( void );
+void TC1_1_Handler               ( void );
+void TC1_2_Handler               ( void );
+void TWIM0_Handler               ( void );
+void TWIS0_Handler               ( void );
+void TWIM1_Handler               ( void );
+void TWIS1_Handler               ( void );
+void USART0_Handler              ( void );
+void USART1_Handler              ( void );
+void USART2_Handler              ( void );
+void USART3_Handler              ( void );
+void ADCIFE_Handler              ( void );
+void DACC_Handler                ( void );
+void ACIFC_Handler               ( void );
+void ABDACB_Handler              ( void );
+void TRNG_Handler                ( void );
+void PARC_Handler                ( void );
+void CATB_Handler                ( void );
+void TWIM2_Handler               ( void );
+void TWIM3_Handler               ( void );
+
+/*
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
+ */
+
+#define LITTLE_ENDIAN          1        
+#define __BB_PRESENT           0         /*!< BIT_BANDING present or not */
+#define __CLKGATE_PRESENT      1         /*!< CLKGATE present or not */
+#define __CM4_REV              1         /*!< Core revision r0p1 */
+#define __DEBUG_LVL            3         /*!< Full debug plus DWT data matching */
+#define __FPU_PRESENT          0         /*!< FPU present or not */
+#define __JTAG_PRESENT         1         /*!< JTAG present or not */
+#define __MPU_PRESENT          1         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       4         /*!< Number of bits used for Priority Levels */
+#define __TRACE_LVL            1         /*!< Standard trace: ITM and DWT triggers and counters, but no ETM */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+#define __WIC_PRESENT          0         /*!< WIC present or not */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm4.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_sam4l.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAM4LS2B */
+/* ************************************************************************** */
+/** \defgroup SAM4LS2B_api Peripheral Software API */
+/*@{*/
+
+#include "component/abdacb.h"
+#include "component/acifc.h"
+#include "component/adcife.h"
+#include "component/ast.h"
+#include "component/bpm.h"
+#include "component/bscif.h"
+#include "component/catb.h"
+#include "component/chipid.h"
+#include "component/crccu.h"
+#include "component/dacc.h"
+#include "component/eic.h"
+#include "component/flashcalw.h"
+#include "component/freqm.h"
+#include "component/gloc.h"
+#include "component/gpio.h"
+#include "component/hcache.h"
+#include "component/hmatrixb.h"
+#include "component/iisc.h"
+#include "component/parc.h"
+#include "component/pdca.h"
+#include "component/pevc.h"
+#include "component/picouart.h"
+#include "component/pm.h"
+#include "component/scif.h"
+#include "component/smap.h"
+#include "component/spi.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twim.h"
+#include "component/twis.h"
+#include "component/usart.h"
+#include "component/usbc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAM4LS2B */
+/* ************************************************************************** */
+/** \defgroup SAM4LS2B_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/abdacb.h"
+#include "instance/acifc.h"
+#include "instance/adcife.h"
+#include "instance/ast.h"
+#include "instance/bpm.h"
+#include "instance/bscif.h"
+#include "instance/catb.h"
+#include "instance/chipid.h"
+#include "instance/crccu.h"
+#include "instance/dacc.h"
+#include "instance/eic.h"
+#include "instance/hflashc.h"
+#include "instance/freqm.h"
+#include "instance/gloc.h"
+#include "instance/gpio.h"
+#include "instance/hcache.h"
+#include "instance/hmatrix.h"
+#include "instance/iisc.h"
+#include "instance/parc.h"
+#include "instance/pdca.h"
+#include "instance/pevc.h"
+#include "instance/picouart.h"
+#include "instance/pm.h"
+#include "instance/scif.h"
+#include "instance/smap.h"
+#include "instance/spi.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/trng.h"
+#include "instance/twim0.h"
+#include "instance/twim1.h"
+#include "instance/twim2.h"
+#include "instance/twim3.h"
+#include "instance/twis0.h"
+#include "instance/twis1.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usart3.h"
+#include "instance/usbc.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAM4LS2B */
+/* ************************************************************************** */
+/** \defgroup SAM4LS2B_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HTOP0 bridge
+#define ID_IISC           0 /**< \brief Inter-IC Sound (I2S) Controller (IISC) */
+#define ID_SPI            1 /**< \brief Serial Peripheral Interface (SPI) */
+#define ID_TC0            2 /**< \brief Timer/Counter 0 (TC0) */
+#define ID_TC1            3 /**< \brief Timer/Counter 1 (TC1) */
+#define ID_TWIM0          4 /**< \brief Two-wire Master Interface 0 (TWIM0) */
+#define ID_TWIS0          5 /**< \brief Two-wire Slave Interface 0 (TWIS0) */
+#define ID_TWIM1          6 /**< \brief Two-wire Master Interface 1 (TWIM1) */
+#define ID_TWIS1          7 /**< \brief Two-wire Slave Interface 1 (TWIS1) */
+#define ID_USART0         8 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+#define ID_USART1         9 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+#define ID_USART2        10 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+#define ID_USART3        11 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+#define ID_ADCIFE        12 /**< \brief ADC controller interface (ADCIFE) */
+#define ID_DACC          13 /**< \brief DAC Controller (DACC) */
+#define ID_ACIFC         14 /**< \brief Analog Comparator Interface (ACIFC) */
+#define ID_GLOC          15 /**< \brief Glue Logic Controller (GLOC) */
+#define ID_ABDACB        16 /**< \brief Audio Bitstream DAC (ABDACB) */
+#define ID_TRNG          17 /**< \brief True Random Number Generator (TRNG) */
+#define ID_PARC          18 /**< \brief Parallel Capture (PARC) */
+#define ID_CATB          19 /**< \brief Capacitive Touch Module B (CATB) */
+#define ID_TWIM2         21 /**< \brief Two-wire Master Interface 2 (TWIM2) */
+#define ID_TWIM3         22 /**< \brief Two-wire Master Interface 3 (TWIM3) */
+
+// Peripheral instances on HTOP1 bridge
+#define ID_HFLASHC       32 /**< \brief Flash Controller (HFLASHC) */
+#define ID_HCACHE        33 /**< \brief Cortex M I&D Cache Controller (HCACHE) */
+#define ID_HMATRIX       34 /**< \brief HSB Matrix (HMATRIX) */
+#define ID_PDCA          35 /**< \brief Peripheral DMA Controller (PDCA) */
+#define ID_SMAP          36 /**< \brief System Manager Access Port (SMAP) */
+#define ID_CRCCU         37 /**< \brief CRC Calculation Unit (CRCCU) */
+#define ID_USBC          38 /**< \brief USB 2.0 Interface (USBC) */
+#define ID_PEVC          39 /**< \brief Peripheral Event Controller (PEVC) */
+
+// Peripheral instances on HTOP2 bridge
+#define ID_PM            64 /**< \brief Power Manager (PM) */
+#define ID_CHIPID        65 /**< \brief Chip ID Registers (CHIPID) */
+#define ID_SCIF          66 /**< \brief System Control Interface (SCIF) */
+#define ID_FREQM         67 /**< \brief Frequency Meter (FREQM) */
+#define ID_GPIO          68 /**< \brief General-Purpose Input/Output Controller (GPIO) */
+
+// Peripheral instances on HTOP3 bridge
+#define ID_BPM           96 /**< \brief Backup Power Manager (BPM) */
+#define ID_BSCIF         97 /**< \brief Backup System Control Interface (BSCIF) */
+#define ID_AST           98 /**< \brief Asynchronous Timer (AST) */
+#define ID_WDT           99 /**< \brief Watchdog Timer (WDT) */
+#define ID_EIC          100 /**< \brief External Interrupt Controller (EIC) */
+#define ID_PICOUART     101 /**< \brief Pico UART (PICOUART) */
+
+#define ID_PERIPH_COUNT 102 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAM4LS2B */
+/* ************************************************************************** */
+/** \defgroup SAM4LS2B_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define ABDACB                        (0x40064000) /**< \brief (ABDACB) APB Base Address */
+#define ACIFC                         (0x40040000) /**< \brief (ACIFC) APB Base Address */
+#define ADCIFE                        (0x40038000) /**< \brief (ADCIFE) APB Base Address */
+#define AST                           (0x400F0800) /**< \brief (AST) APB Base Address */
+#define BPM                           (0x400F0000) /**< \brief (BPM) APB Base Address */
+#define BSCIF                         (0x400F0400) /**< \brief (BSCIF) APB Base Address */
+#define CATB                          (0x40070000) /**< \brief (CATB) APB Base Address */
+#define CHIPID                        (0x400E0400) /**< \brief (CHIPID) APB Base Address */
+#define CRCCU                         (0x400A4000) /**< \brief (CRCCU) APB Base Address */
+#define DACC                          (0x4003C000) /**< \brief (DACC) APB Base Address */
+#define EIC                           (0x400F1000) /**< \brief (EIC) APB Base Address */
+#define HFLASHC                       (0x400A0000) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000) /**< \brief (HFLASHC) USER Base Address */
+#define FREQM                         (0x400E0C00) /**< \brief (FREQM) APB Base Address */
+#define GLOC                          (0x40060000) /**< \brief (GLOC) APB Base Address */
+#define GPIO                          (0x400E1000) /**< \brief (GPIO) APB Base Address */
+#define HCACHE                        (0x400A0400) /**< \brief (HCACHE) APB Base Address */
+#define HMATRIX                       (0x400A1000) /**< \brief (HMATRIX) APB Base Address */
+#define IISC                          (0x40004000) /**< \brief (IISC) APB Base Address */
+#define PARC                          (0x4006C000) /**< \brief (PARC) APB Base Address */
+#define PDCA                          (0x400A2000) /**< \brief (PDCA) APB Base Address */
+#define PEVC                          (0x400A6000) /**< \brief (PEVC) APB Base Address */
+#define PICOUART                      (0x400F1400) /**< \brief (PICOUART) APB Base Address */
+#define PM                            (0x400E0000) /**< \brief (PM) APB Base Address */
+#define SCIF                          (0x400E0800) /**< \brief (SCIF) APB Base Address */
+#define SMAP                          (0x400A3000) /**< \brief (SMAP) APB Base Address */
+#define SPI                           (0x40008000) /**< \brief (SPI) APB Base Address */
+#define TC0                           (0x40010000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x40014000) /**< \brief (TC1) APB Base Address */
+#define TRNG                          (0x40068000) /**< \brief (TRNG) APB Base Address */
+#define TWIM0                         (0x40018000) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1                         (0x4001C000) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2                         (0x40078000) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3                         (0x4007C000) /**< \brief (TWIM3) APB Base Address */
+#define TWIS0                         (0x40018400) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1                         (0x4001C400) /**< \brief (TWIS1) APB Base Address */
+#define USART0                        (0x40024000) /**< \brief (USART0) APB Base Address */
+#define USART1                        (0x40028000) /**< \brief (USART1) APB Base Address */
+#define USART2                        (0x4002C000) /**< \brief (USART2) APB Base Address */
+#define USART3                        (0x40030000) /**< \brief (USART3) APB Base Address */
+#define USBC                          (0x400A5000) /**< \brief (USBC) APB Base Address */
+#define WDT                           (0x400F0C00) /**< \brief (WDT) APB Base Address */
+#else
+#define ABDACB            ((Abdacb   *)0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_ADDR                   (0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_INST_NUM   1                          /**< \brief (ABDACB) Number of instances */
+#define ABDACB_INSTS      { ABDACB }                 /**< \brief (ABDACB) Instances List */
+
+#define ACIFC             ((Acifc    *)0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_ADDR                    (0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_INST_NUM    1                          /**< \brief (ACIFC) Number of instances */
+#define ACIFC_INSTS       { ACIFC }                  /**< \brief (ACIFC) Instances List */
+
+#define ADCIFE            ((Adcife   *)0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_ADDR                   (0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_INST_NUM   1                          /**< \brief (ADCIFE) Number of instances */
+#define ADCIFE_INSTS      { ADCIFE }                 /**< \brief (ADCIFE) Instances List */
+
+#define AST               ((Ast      *)0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_ADDR                      (0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_INST_NUM      1                          /**< \brief (AST) Number of instances */
+#define AST_INSTS         { AST }                    /**< \brief (AST) Instances List */
+
+#define BPM               ((Bpm      *)0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_ADDR                      (0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_INST_NUM      1                          /**< \brief (BPM) Number of instances */
+#define BPM_INSTS         { BPM }                    /**< \brief (BPM) Instances List */
+
+#define BSCIF             ((Bscif    *)0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_ADDR                    (0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_INST_NUM    1                          /**< \brief (BSCIF) Number of instances */
+#define BSCIF_INSTS       { BSCIF }                  /**< \brief (BSCIF) Instances List */
+
+#define CATB              ((Catb     *)0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_ADDR                     (0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_INST_NUM     1                          /**< \brief (CATB) Number of instances */
+#define CATB_INSTS        { CATB }                   /**< \brief (CATB) Instances List */
+
+#define CHIPID            ((Chipid   *)0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_ADDR                   (0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_INST_NUM   1                          /**< \brief (CHIPID) Number of instances */
+#define CHIPID_INSTS      { CHIPID }                 /**< \brief (CHIPID) Instances List */
+
+#define CRCCU             ((Crccu    *)0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_ADDR                    (0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_INST_NUM    1                          /**< \brief (CRCCU) Number of instances */
+#define CRCCU_INSTS       { CRCCU }                  /**< \brief (CRCCU) Instances List */
+
+#define DACC              ((Dacc     *)0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_ADDR                     (0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_INST_NUM     1                          /**< \brief (DACC) Number of instances */
+#define DACC_INSTS        { DACC }                   /**< \brief (DACC) Instances List */
+
+#define EIC               ((Eic      *)0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_ADDR                      (0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define HFLASHC           ((Flashcalw *)0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_ADDR                  (0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_FROW_ADDR             (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define HFLASHC_USER_ADDR             (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define FLASHCALW_INST_NUM 1                          /**< \brief (FLASHCALW) Number of instances */
+#define FLASHCALW_INSTS   { HFLASHC }                /**< \brief (FLASHCALW) Instances List */
+
+#define FREQM             ((Freqm    *)0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_ADDR                    (0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_INST_NUM    1                          /**< \brief (FREQM) Number of instances */
+#define FREQM_INSTS       { FREQM }                  /**< \brief (FREQM) Instances List */
+
+#define GLOC              ((Gloc     *)0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_ADDR                     (0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_INST_NUM     1                          /**< \brief (GLOC) Number of instances */
+#define GLOC_INSTS        { GLOC }                   /**< \brief (GLOC) Instances List */
+
+#define GPIO              ((Gpio     *)0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_ADDR                     (0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_INST_NUM     1                          /**< \brief (GPIO) Number of instances */
+#define GPIO_INSTS        { GPIO }                   /**< \brief (GPIO) Instances List */
+
+#define HCACHE            ((Hcache   *)0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_ADDR                   (0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_INST_NUM   1                          /**< \brief (HCACHE) Number of instances */
+#define HCACHE_INSTS      { HCACHE }                 /**< \brief (HCACHE) Instances List */
+
+#define HMATRIX           ((Hmatrixb *)0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIX_ADDR                  (0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIXB_INST_NUM 1                          /**< \brief (HMATRIXB) Number of instances */
+#define HMATRIXB_INSTS    { HMATRIX }                /**< \brief (HMATRIXB) Instances List */
+
+#define IISC              ((Iisc     *)0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_ADDR                     (0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_INST_NUM     1                          /**< \brief (IISC) Number of instances */
+#define IISC_INSTS        { IISC }                   /**< \brief (IISC) Instances List */
+
+#define PARC              ((Parc     *)0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_ADDR                     (0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_INST_NUM     1                          /**< \brief (PARC) Number of instances */
+#define PARC_INSTS        { PARC }                   /**< \brief (PARC) Instances List */
+
+#define PDCA              ((Pdca     *)0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_ADDR                     (0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_INST_NUM     1                          /**< \brief (PDCA) Number of instances */
+#define PDCA_INSTS        { PDCA }                   /**< \brief (PDCA) Instances List */
+
+#define PEVC              ((Pevc     *)0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_ADDR                     (0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_INST_NUM     1                          /**< \brief (PEVC) Number of instances */
+#define PEVC_INSTS        { PEVC }                   /**< \brief (PEVC) Instances List */
+
+#define PICOUART          ((Picouart *)0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_ADDR                 (0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_INST_NUM 1                          /**< \brief (PICOUART) Number of instances */
+#define PICOUART_INSTS    { PICOUART }               /**< \brief (PICOUART) Instances List */
+
+#define PM                ((Pm       *)0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_ADDR                       (0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define SCIF              ((Scif     *)0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_ADDR                     (0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_INST_NUM     1                          /**< \brief (SCIF) Number of instances */
+#define SCIF_INSTS        { SCIF }                   /**< \brief (SCIF) Instances List */
+
+#define SMAP              ((Smap     *)0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_ADDR                     (0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_INST_NUM     1                          /**< \brief (SMAP) Number of instances */
+#define SMAP_INSTS        { SMAP }                   /**< \brief (SMAP) Instances List */
+
+#define SPI               ((Spi      *)0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_ADDR                      (0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_INST_NUM      1                          /**< \brief (SPI) Number of instances */
+#define SPI_INSTS         { SPI }                    /**< \brief (SPI) Instances List */
+
+#define TC0               ((Tc       *)0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC0_ADDR                      (0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC1_ADDR                      (0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC_INST_NUM       2                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1 }               /**< \brief (TC) Instances List */
+
+#define TRNG              ((Trng     *)0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_ADDR                     (0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_INST_NUM     1                          /**< \brief (TRNG) Number of instances */
+#define TRNG_INSTS        { TRNG }                   /**< \brief (TRNG) Instances List */
+
+#define TWIM0             ((Twim     *)0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM0_ADDR                    (0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1             ((Twim     *)0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM1_ADDR                    (0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2             ((Twim     *)0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM2_ADDR                    (0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3             ((Twim     *)0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM3_ADDR                    (0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM_INST_NUM     4                          /**< \brief (TWIM) Number of instances */
+#define TWIM_INSTS        { TWIM0, TWIM1, TWIM2, TWIM3 } /**< \brief (TWIM) Instances List */
+
+#define TWIS0             ((Twis     *)0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS0_ADDR                    (0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1             ((Twis     *)0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS1_ADDR                    (0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS_INST_NUM     2                          /**< \brief (TWIS) Number of instances */
+#define TWIS_INSTS        { TWIS0, TWIS1 }           /**< \brief (TWIS) Instances List */
+
+#define USART0            ((Usart    *)0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART0_ADDR                   (0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART1            ((Usart    *)0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART1_ADDR                   (0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART2            ((Usart    *)0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART2_ADDR                   (0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART3            ((Usart    *)0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART3_ADDR                   (0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART_INST_NUM    4                          /**< \brief (USART) Number of instances */
+#define USART_INSTS       { USART0, USART1, USART2, USART3 } /**< \brief (USART) Instances List */
+
+#define USBC              ((Usbc     *)0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_ADDR                     (0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_INST_NUM     1                          /**< \brief (USBC) Number of instances */
+#define USBC_INSTS        { USBC }                   /**< \brief (USBC) Instances List */
+
+#define WDT               ((Wdt      *)0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_ADDR                      (0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  GPIO DEFINITIONS FOR SAM4LS2B */
+/* ************************************************************************** */
+/** \defgroup SAM4LS2B_gpio GPIO Definitions */
+/*@{*/
+
+#include "pio/sam4ls2b.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  ADDITIONAL DEFINITIONS FOR COMPATIBILITY */
+/* ************************************************************************** */
+/** \addtogroup SAM4LS2B_compat Definitions */
+/*@{*/
+// These defines are used to keep compatibility with existing 
+// sam/drivers/usart implementation from SAM3/4 products with SAM4L product.
+#define US_MR_USART_MODE_HW_HANDSHAKING  US_MR_USART_MODE_HARDWARE
+#define US_MR_USART_MODE_IS07816_T_0     US_MR_USART_MODE_ISO7816_T0
+#define US_MR_USART_MODE_IS07816_T_1     US_MR_USART_MODE_ISO7816_T1
+#define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
+#define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
+#define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_8_BIT      US_MR_CHRL_8
+#define US_MR_PAR_NO          US_MR_PAR_NONE
+#define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI
+#define US_IF                 US_IFR
+#define US_WPSR_WPVS          US_WPSR_WPV_1
+
+#define USBC_UPCFG0_PBK_Msk   (0x1u << USBC_UPCFG0_PBK_Pos)
+
+// These defines for homogeneity with other SAM header files.
+#define CHIP_FREQ_FWS_0       (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 */
+#define CHIP_FREQ_FWS_1       (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 */
+// WARNING NOTE: these are preliminary values.
+#define CHIP_FREQ_FLASH_HSEN_FWS_0 (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 and the FLASH HS mode is enabled */
+#define CHIP_FREQ_FLASH_HSEN_FWS_1 (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 and the FLASH HS mode is enabled */
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/tc implementation from SAM3/4 products with SAM4L product. 
+#define TC_CMR_LDRA_RISING    TC_CMR_LDRA_POS_EDGE_TIOA
+#define TC_CMR_LDRB_FALLING   TC_CMR_LDRB_NEG_EDGE_TIOA
+#define TC_CMR_ETRGEDG_FALLING TC_CMR_ETRGEDG_NEG_EDGE
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/spi implementation from SAM3/4 products with SAM4L product. 
+#define SPI_CSR_BITS_8_BIT    SPI_CSR_BITS_8_BPT
+#define SPI_WPCR_SPIWPKEY_VALUE SPI_WPCR_WPKEY_VALUE
+#define SPI_WPCR_SPIWPEN      SPI_WPCR_WPEN
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/crccu implementation from SAM3/4 products with SAM4L product. 
+#define CRCCU_DMA_EN          CRCCU_DMAEN
+#define CRCCU_DMA_DIS         CRCCU_DMADIS
+#define CRCCU_DMA_SR          CRCCU_DMASR
+#define CRCCU_DMA_IER         CRCCU_DMAIER
+#define CRCCU_DMA_IDR         CRCCU_DMAIDR
+#define CRCCU_DMA_IMR         CRCCU_DMAIMR
+#define CRCCU_DMA_ISR         CRCCU_DMAISR
+#define CRCCU_DMA_EN_DMAEN    CRCCU_DMAEN_DMAEN
+#define CRCCU_DMA_DIS_DMADIS  CRCCU_DMADIS_DMADIS
+#define CRCCU_DMA_SR_DMASR    CRCCU_DMASR_DMASR
+#define CRCCU_DMA_IER_DMAIER  CRCCU_DMAIER_DMAIER
+#define CRCCU_DMA_IDR_DMAIDR  CRCCU_DMAIDR_DMAIDR
+#define CRCCU_DMA_IMR_DMAIMR  CRCCU_DMAIMR_DMAIMR
+#define CRCCU_DMA_ISR_DMAISR  CRCCU_DMAISR_DMAISR
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAM4LS2B */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL(0x00020000) /* 128 kB */
+#define FLASH_PAGE_SIZE       512
+#define FLASH_NB_OF_PAGES     256
+#define FLASH_USER_PAGE_SIZE  512
+#define HRAMC0_SIZE           _UL(0x00008000) /* 32 kB */
+#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+
+#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+
+#define DSU_DID_RESETVALUE    _UL(0xAB0A07E0)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAM4LS2B */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAM4LS2B_H */

--- a/asf/sam/include/sam4l/sam4ls2c.h
+++ b/asf/sam/include/sam4l/sam4ls2c.h
@@ -1,0 +1,889 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAM4LS2C
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LS2C_
+#define _SAM4LS2C_
+
+/**
+ * \ingroup SAM4L_definitions
+ * \addtogroup SAM4LS2C_definitions SAM4LS2C definitions
+ * This file defines all structures and symbols for SAM4LS2C:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#if !defined(_UL)
+#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#endif
+#else
+#if !defined(_UL)
+#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif
+#endif
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAM4LS2C */
+/* ************************************************************************** */
+/** \defgroup SAM4LS2C_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M4 Processor Exceptions Numbers ******************************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn           = -13,/**<  3 Cortex-M4 Hard Fault Interrupt        */
+  MemoryManagement_IRQn    = -12,/**<  4 Cortex-M4 Memory Management Interrupt */
+  BusFault_IRQn            = -11,/**<  5 Cortex-M4 Bus Fault Interrupt         */
+  UsageFault_IRQn          = -10,/**<  6 Cortex-M4 Usage Fault Interrupt       */
+  SVCall_IRQn              = -5, /**< 11 Cortex-M4 SV Call Interrupt           */
+  DebugMonitor_IRQn        = -4, /**< 12 Cortex-M4 Debug Monitor Interrupt     */
+  PendSV_IRQn              = -2, /**< 14 Cortex-M4 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 Cortex-M4 System Tick Interrupt       */
+  /******  SAM4LS2C-specific Interrupt Numbers ***********************/
+  HFLASHC_IRQn             =  0, /**<  0 SAM4LS2C Flash Controller (HFLASHC) */
+  PDCA_0_IRQn              =  1, /**<  1 SAM4LS2C Peripheral DMA Controller (PDCA): PDCA_0 */
+  PDCA_1_IRQn              =  2, /**<  2 SAM4LS2C Peripheral DMA Controller (PDCA): PDCA_1 */
+  PDCA_2_IRQn              =  3, /**<  3 SAM4LS2C Peripheral DMA Controller (PDCA): PDCA_2 */
+  PDCA_3_IRQn              =  4, /**<  4 SAM4LS2C Peripheral DMA Controller (PDCA): PDCA_3 */
+  PDCA_4_IRQn              =  5, /**<  5 SAM4LS2C Peripheral DMA Controller (PDCA): PDCA_4 */
+  PDCA_5_IRQn              =  6, /**<  6 SAM4LS2C Peripheral DMA Controller (PDCA): PDCA_5 */
+  PDCA_6_IRQn              =  7, /**<  7 SAM4LS2C Peripheral DMA Controller (PDCA): PDCA_6 */
+  PDCA_7_IRQn              =  8, /**<  8 SAM4LS2C Peripheral DMA Controller (PDCA): PDCA_7 */
+  PDCA_8_IRQn              =  9, /**<  9 SAM4LS2C Peripheral DMA Controller (PDCA): PDCA_8 */
+  PDCA_9_IRQn              = 10, /**< 10 SAM4LS2C Peripheral DMA Controller (PDCA): PDCA_9 */
+  PDCA_10_IRQn             = 11, /**< 11 SAM4LS2C Peripheral DMA Controller (PDCA): PDCA_10 */
+  PDCA_11_IRQn             = 12, /**< 12 SAM4LS2C Peripheral DMA Controller (PDCA): PDCA_11 */
+  PDCA_12_IRQn             = 13, /**< 13 SAM4LS2C Peripheral DMA Controller (PDCA): PDCA_12 */
+  PDCA_13_IRQn             = 14, /**< 14 SAM4LS2C Peripheral DMA Controller (PDCA): PDCA_13 */
+  PDCA_14_IRQn             = 15, /**< 15 SAM4LS2C Peripheral DMA Controller (PDCA): PDCA_14 */
+  PDCA_15_IRQn             = 16, /**< 16 SAM4LS2C Peripheral DMA Controller (PDCA): PDCA_15 */
+  CRCCU_IRQn               = 17, /**< 17 SAM4LS2C CRC Calculation Unit (CRCCU) */
+  USBC_IRQn                = 18, /**< 18 SAM4LS2C USB 2.0 Interface (USBC) */
+  PEVC_0_IRQn              = 19, /**< 19 SAM4LS2C Peripheral Event Controller (PEVC): PEVC_TR */
+  PEVC_1_IRQn              = 20, /**< 20 SAM4LS2C Peripheral Event Controller (PEVC): PEVC_OV */
+  PM_IRQn                  = 22, /**< 22 SAM4LS2C Power Manager (PM) */
+  SCIF_IRQn                = 23, /**< 23 SAM4LS2C System Control Interface (SCIF) */
+  FREQM_IRQn               = 24, /**< 24 SAM4LS2C Frequency Meter (FREQM) */
+  GPIO_0_IRQn              = 25, /**< 25 SAM4LS2C General-Purpose Input/Output Controller (GPIO): GPIO_0 */
+  GPIO_1_IRQn              = 26, /**< 26 SAM4LS2C General-Purpose Input/Output Controller (GPIO): GPIO_1 */
+  GPIO_2_IRQn              = 27, /**< 27 SAM4LS2C General-Purpose Input/Output Controller (GPIO): GPIO_2 */
+  GPIO_3_IRQn              = 28, /**< 28 SAM4LS2C General-Purpose Input/Output Controller (GPIO): GPIO_3 */
+  GPIO_4_IRQn              = 29, /**< 29 SAM4LS2C General-Purpose Input/Output Controller (GPIO): GPIO_4 */
+  GPIO_5_IRQn              = 30, /**< 30 SAM4LS2C General-Purpose Input/Output Controller (GPIO): GPIO_5 */
+  GPIO_6_IRQn              = 31, /**< 31 SAM4LS2C General-Purpose Input/Output Controller (GPIO): GPIO_6 */
+  GPIO_7_IRQn              = 32, /**< 32 SAM4LS2C General-Purpose Input/Output Controller (GPIO): GPIO_7 */
+  GPIO_8_IRQn              = 33, /**< 33 SAM4LS2C General-Purpose Input/Output Controller (GPIO): GPIO_8 */
+  GPIO_9_IRQn              = 34, /**< 34 SAM4LS2C General-Purpose Input/Output Controller (GPIO): GPIO_9 */
+  GPIO_10_IRQn             = 35, /**< 35 SAM4LS2C General-Purpose Input/Output Controller (GPIO): GPIO_10 */
+  GPIO_11_IRQn             = 36, /**< 36 SAM4LS2C General-Purpose Input/Output Controller (GPIO): GPIO_11 */
+  BPM_IRQn                 = 37, /**< 37 SAM4LS2C Backup Power Manager (BPM) */
+  BSCIF_IRQn               = 38, /**< 38 SAM4LS2C Backup System Control Interface (BSCIF) */
+  AST_0_IRQn               = 39, /**< 39 SAM4LS2C Asynchronous Timer (AST): AST_ALARM */
+  AST_1_IRQn               = 40, /**< 40 SAM4LS2C Asynchronous Timer (AST): AST_PER */
+  AST_2_IRQn               = 41, /**< 41 SAM4LS2C Asynchronous Timer (AST): AST_OVF */
+  AST_3_IRQn               = 42, /**< 42 SAM4LS2C Asynchronous Timer (AST): AST_READY */
+  AST_4_IRQn               = 43, /**< 43 SAM4LS2C Asynchronous Timer (AST): AST_CLKREADY */
+  WDT_IRQn                 = 44, /**< 44 SAM4LS2C Watchdog Timer (WDT) */
+  EIC_0_IRQn               = 45, /**< 45 SAM4LS2C External Interrupt Controller (EIC): EIC_1 */
+  EIC_1_IRQn               = 46, /**< 46 SAM4LS2C External Interrupt Controller (EIC): EIC_2 */
+  EIC_2_IRQn               = 47, /**< 47 SAM4LS2C External Interrupt Controller (EIC): EIC_3 */
+  EIC_3_IRQn               = 48, /**< 48 SAM4LS2C External Interrupt Controller (EIC): EIC_4 */
+  EIC_4_IRQn               = 49, /**< 49 SAM4LS2C External Interrupt Controller (EIC): EIC_5 */
+  EIC_5_IRQn               = 50, /**< 50 SAM4LS2C External Interrupt Controller (EIC): EIC_6 */
+  EIC_6_IRQn               = 51, /**< 51 SAM4LS2C External Interrupt Controller (EIC): EIC_7 */
+  EIC_7_IRQn               = 52, /**< 52 SAM4LS2C External Interrupt Controller (EIC): EIC_8 */
+  IISC_IRQn                = 53, /**< 53 SAM4LS2C Inter-IC Sound (I2S) Controller (IISC) */
+  SPI_IRQn                 = 54, /**< 54 SAM4LS2C Serial Peripheral Interface (SPI) */
+  TC0_0_IRQn               = 55, /**< 55 SAM4LS2C Timer/Counter 0 (TC0): TC00 */
+  TC0_1_IRQn               = 56, /**< 56 SAM4LS2C Timer/Counter 0 (TC0): TC01 */
+  TC0_2_IRQn               = 57, /**< 57 SAM4LS2C Timer/Counter 0 (TC0): TC02 */
+  TC1_0_IRQn               = 58, /**< 58 SAM4LS2C Timer/Counter 1 (TC1): TC10 */
+  TC1_1_IRQn               = 59, /**< 59 SAM4LS2C Timer/Counter 1 (TC1): TC11 */
+  TC1_2_IRQn               = 60, /**< 60 SAM4LS2C Timer/Counter 1 (TC1): TC12 */
+  TWIM0_IRQn               = 61, /**< 61 SAM4LS2C Two-wire Master Interface 0 (TWIM0) */
+  TWIS0_IRQn               = 62, /**< 62 SAM4LS2C Two-wire Slave Interface 0 (TWIS0) */
+  TWIM1_IRQn               = 63, /**< 63 SAM4LS2C Two-wire Master Interface 1 (TWIM1) */
+  TWIS1_IRQn               = 64, /**< 64 SAM4LS2C Two-wire Slave Interface 1 (TWIS1) */
+  USART0_IRQn              = 65, /**< 65 SAM4LS2C Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+  USART1_IRQn              = 66, /**< 66 SAM4LS2C Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+  USART2_IRQn              = 67, /**< 67 SAM4LS2C Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+  USART3_IRQn              = 68, /**< 68 SAM4LS2C Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+  ADCIFE_IRQn              = 69, /**< 69 SAM4LS2C ADC controller interface (ADCIFE) */
+  DACC_IRQn                = 70, /**< 70 SAM4LS2C DAC Controller (DACC) */
+  ACIFC_IRQn               = 71, /**< 71 SAM4LS2C Analog Comparator Interface (ACIFC) */
+  ABDACB_IRQn              = 72, /**< 72 SAM4LS2C Audio Bitstream DAC (ABDACB) */
+  TRNG_IRQn                = 73, /**< 73 SAM4LS2C True Random Number Generator (TRNG) */
+  PARC_IRQn                = 74, /**< 74 SAM4LS2C Parallel Capture (PARC) */
+  CATB_IRQn                = 75, /**< 75 SAM4LS2C Capacitive Touch Module B (CATB) */
+  TWIM2_IRQn               = 77, /**< 77 SAM4LS2C Two-wire Master Interface 2 (TWIM2) */
+  TWIM3_IRQn               = 78, /**< 78 SAM4LS2C Two-wire Master Interface 3 (TWIM3) */
+
+  PERIPH_COUNT_IRQn        = 80  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNMI_Handler;
+  void* pfnHardFault_Handler;
+  void* pfnMemManage_Handler;
+  void* pfnBusFault_Handler;
+  void* pfnUsageFault_Handler;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVC_Handler;
+  void* pfnDebugMon_Handler;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnHFLASHC_Handler;               /*  0 Flash Controller */
+  void* pfnPDCA_0_Handler;                /*  1 Peripheral DMA Controller IRQ 0 */
+  void* pfnPDCA_1_Handler;                /*  2 Peripheral DMA Controller IRQ 1 */
+  void* pfnPDCA_2_Handler;                /*  3 Peripheral DMA Controller IRQ 2 */
+  void* pfnPDCA_3_Handler;                /*  4 Peripheral DMA Controller IRQ 3 */
+  void* pfnPDCA_4_Handler;                /*  5 Peripheral DMA Controller IRQ 4 */
+  void* pfnPDCA_5_Handler;                /*  6 Peripheral DMA Controller IRQ 5 */
+  void* pfnPDCA_6_Handler;                /*  7 Peripheral DMA Controller IRQ 6 */
+  void* pfnPDCA_7_Handler;                /*  8 Peripheral DMA Controller IRQ 7 */
+  void* pfnPDCA_8_Handler;                /*  9 Peripheral DMA Controller IRQ 8 */
+  void* pfnPDCA_9_Handler;                /* 10 Peripheral DMA Controller IRQ 9 */
+  void* pfnPDCA_10_Handler;               /* 11 Peripheral DMA Controller IRQ 10 */
+  void* pfnPDCA_11_Handler;               /* 12 Peripheral DMA Controller IRQ 11 */
+  void* pfnPDCA_12_Handler;               /* 13 Peripheral DMA Controller IRQ 12 */
+  void* pfnPDCA_13_Handler;               /* 14 Peripheral DMA Controller IRQ 13 */
+  void* pfnPDCA_14_Handler;               /* 15 Peripheral DMA Controller IRQ 14 */
+  void* pfnPDCA_15_Handler;               /* 16 Peripheral DMA Controller IRQ 15 */
+  void* pfnCRCCU_Handler;                 /* 17 CRC Calculation Unit */
+  void* pfnUSBC_Handler;                  /* 18 USB 2.0 Interface */
+  void* pfnPEVC_0_Handler;                /* 19 Peripheral Event Controller IRQ 0 */
+  void* pfnPEVC_1_Handler;                /* 20 Peripheral Event Controller IRQ 1 */
+  void* pvReserved21;
+  void* pfnPM_Handler;                    /* 22 Power Manager */
+  void* pfnSCIF_Handler;                  /* 23 System Control Interface */
+  void* pfnFREQM_Handler;                 /* 24 Frequency Meter */
+  void* pfnGPIO_0_Handler;                /* 25 General-Purpose Input/Output Controller IRQ 0 */
+  void* pfnGPIO_1_Handler;                /* 26 General-Purpose Input/Output Controller IRQ 1 */
+  void* pfnGPIO_2_Handler;                /* 27 General-Purpose Input/Output Controller IRQ 2 */
+  void* pfnGPIO_3_Handler;                /* 28 General-Purpose Input/Output Controller IRQ 3 */
+  void* pfnGPIO_4_Handler;                /* 29 General-Purpose Input/Output Controller IRQ 4 */
+  void* pfnGPIO_5_Handler;                /* 30 General-Purpose Input/Output Controller IRQ 5 */
+  void* pfnGPIO_6_Handler;                /* 31 General-Purpose Input/Output Controller IRQ 6 */
+  void* pfnGPIO_7_Handler;                /* 32 General-Purpose Input/Output Controller IRQ 7 */
+  void* pfnGPIO_8_Handler;                /* 33 General-Purpose Input/Output Controller IRQ 8 */
+  void* pfnGPIO_9_Handler;                /* 34 General-Purpose Input/Output Controller IRQ 9 */
+  void* pfnGPIO_10_Handler;               /* 35 General-Purpose Input/Output Controller IRQ 10 */
+  void* pfnGPIO_11_Handler;               /* 36 General-Purpose Input/Output Controller IRQ 11 */
+  void* pfnBPM_Handler;                   /* 37 Backup Power Manager */
+  void* pfnBSCIF_Handler;                 /* 38 Backup System Control Interface */
+  void* pfnAST_0_Handler;                 /* 39 Asynchronous Timer IRQ 0 */
+  void* pfnAST_1_Handler;                 /* 40 Asynchronous Timer IRQ 1 */
+  void* pfnAST_2_Handler;                 /* 41 Asynchronous Timer IRQ 2 */
+  void* pfnAST_3_Handler;                 /* 42 Asynchronous Timer IRQ 3 */
+  void* pfnAST_4_Handler;                 /* 43 Asynchronous Timer IRQ 4 */
+  void* pfnWDT_Handler;                   /* 44 Watchdog Timer */
+  void* pfnEIC_0_Handler;                 /* 45 External Interrupt Controller IRQ 0 */
+  void* pfnEIC_1_Handler;                 /* 46 External Interrupt Controller IRQ 1 */
+  void* pfnEIC_2_Handler;                 /* 47 External Interrupt Controller IRQ 2 */
+  void* pfnEIC_3_Handler;                 /* 48 External Interrupt Controller IRQ 3 */
+  void* pfnEIC_4_Handler;                 /* 49 External Interrupt Controller IRQ 4 */
+  void* pfnEIC_5_Handler;                 /* 50 External Interrupt Controller IRQ 5 */
+  void* pfnEIC_6_Handler;                 /* 51 External Interrupt Controller IRQ 6 */
+  void* pfnEIC_7_Handler;                 /* 52 External Interrupt Controller IRQ 7 */
+  void* pfnIISC_Handler;                  /* 53 Inter-IC Sound (I2S) Controller */
+  void* pfnSPI_Handler;                   /* 54 Serial Peripheral Interface */
+  void* pfnTC0_0_Handler;                 /* 55 Timer/Counter 0 IRQ 0 */
+  void* pfnTC0_1_Handler;                 /* 56 Timer/Counter 0 IRQ 1 */
+  void* pfnTC0_2_Handler;                 /* 57 Timer/Counter 0 IRQ 2 */
+  void* pfnTC1_0_Handler;                 /* 58 Timer/Counter 1 IRQ 0 */
+  void* pfnTC1_1_Handler;                 /* 59 Timer/Counter 1 IRQ 1 */
+  void* pfnTC1_2_Handler;                 /* 60 Timer/Counter 1 IRQ 2 */
+  void* pfnTWIM0_Handler;                 /* 61 Two-wire Master Interface 0 */
+  void* pfnTWIS0_Handler;                 /* 62 Two-wire Slave Interface 0 */
+  void* pfnTWIM1_Handler;                 /* 63 Two-wire Master Interface 1 */
+  void* pfnTWIS1_Handler;                 /* 64 Two-wire Slave Interface 1 */
+  void* pfnUSART0_Handler;                /* 65 Universal Synchronous Asynchronous Receiver Transmitter 0 */
+  void* pfnUSART1_Handler;                /* 66 Universal Synchronous Asynchronous Receiver Transmitter 1 */
+  void* pfnUSART2_Handler;                /* 67 Universal Synchronous Asynchronous Receiver Transmitter 2 */
+  void* pfnUSART3_Handler;                /* 68 Universal Synchronous Asynchronous Receiver Transmitter 3 */
+  void* pfnADCIFE_Handler;                /* 69 ADC controller interface */
+  void* pfnDACC_Handler;                  /* 70 DAC Controller */
+  void* pfnACIFC_Handler;                 /* 71 Analog Comparator Interface */
+  void* pfnABDACB_Handler;                /* 72 Audio Bitstream DAC */
+  void* pfnTRNG_Handler;                  /* 73 True Random Number Generator */
+  void* pfnPARC_Handler;                  /* 74 Parallel Capture */
+  void* pfnCATB_Handler;                  /* 75 Capacitive Touch Module B */
+  void* pvReserved76;
+  void* pfnTWIM2_Handler;                 /* 77 Two-wire Master Interface 2 */
+  void* pfnTWIM3_Handler;                 /* 78 Two-wire Master Interface 3 */
+  void* pvReserved79;
+} DeviceVectors;
+
+/* Cortex-M4 processor handlers */
+void Reset_Handler               ( void );
+void NMI_Handler                 ( void );
+void HardFault_Handler           ( void );
+void MemManage_Handler           ( void );
+void BusFault_Handler            ( void );
+void UsageFault_Handler          ( void );
+void SVC_Handler                 ( void );
+void DebugMon_Handler            ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void HFLASHC_Handler             ( void );
+void PDCA_0_Handler              ( void );
+void PDCA_1_Handler              ( void );
+void PDCA_2_Handler              ( void );
+void PDCA_3_Handler              ( void );
+void PDCA_4_Handler              ( void );
+void PDCA_5_Handler              ( void );
+void PDCA_6_Handler              ( void );
+void PDCA_7_Handler              ( void );
+void PDCA_8_Handler              ( void );
+void PDCA_9_Handler              ( void );
+void PDCA_10_Handler             ( void );
+void PDCA_11_Handler             ( void );
+void PDCA_12_Handler             ( void );
+void PDCA_13_Handler             ( void );
+void PDCA_14_Handler             ( void );
+void PDCA_15_Handler             ( void );
+void CRCCU_Handler               ( void );
+void USBC_Handler                ( void );
+void PEVC_0_Handler              ( void );
+void PEVC_1_Handler              ( void );
+void PM_Handler                  ( void );
+void SCIF_Handler                ( void );
+void FREQM_Handler               ( void );
+void GPIO_0_Handler              ( void );
+void GPIO_1_Handler              ( void );
+void GPIO_2_Handler              ( void );
+void GPIO_3_Handler              ( void );
+void GPIO_4_Handler              ( void );
+void GPIO_5_Handler              ( void );
+void GPIO_6_Handler              ( void );
+void GPIO_7_Handler              ( void );
+void GPIO_8_Handler              ( void );
+void GPIO_9_Handler              ( void );
+void GPIO_10_Handler             ( void );
+void GPIO_11_Handler             ( void );
+void BPM_Handler                 ( void );
+void BSCIF_Handler               ( void );
+void AST_0_Handler               ( void );
+void AST_1_Handler               ( void );
+void AST_2_Handler               ( void );
+void AST_3_Handler               ( void );
+void AST_4_Handler               ( void );
+void WDT_Handler                 ( void );
+void EIC_0_Handler               ( void );
+void EIC_1_Handler               ( void );
+void EIC_2_Handler               ( void );
+void EIC_3_Handler               ( void );
+void EIC_4_Handler               ( void );
+void EIC_5_Handler               ( void );
+void EIC_6_Handler               ( void );
+void EIC_7_Handler               ( void );
+void IISC_Handler                ( void );
+void SPI_Handler                 ( void );
+void TC0_0_Handler               ( void );
+void TC0_1_Handler               ( void );
+void TC0_2_Handler               ( void );
+void TC1_0_Handler               ( void );
+void TC1_1_Handler               ( void );
+void TC1_2_Handler               ( void );
+void TWIM0_Handler               ( void );
+void TWIS0_Handler               ( void );
+void TWIM1_Handler               ( void );
+void TWIS1_Handler               ( void );
+void USART0_Handler              ( void );
+void USART1_Handler              ( void );
+void USART2_Handler              ( void );
+void USART3_Handler              ( void );
+void ADCIFE_Handler              ( void );
+void DACC_Handler                ( void );
+void ACIFC_Handler               ( void );
+void ABDACB_Handler              ( void );
+void TRNG_Handler                ( void );
+void PARC_Handler                ( void );
+void CATB_Handler                ( void );
+void TWIM2_Handler               ( void );
+void TWIM3_Handler               ( void );
+
+/*
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
+ */
+
+#define LITTLE_ENDIAN          1        
+#define __BB_PRESENT           0         /*!< BIT_BANDING present or not */
+#define __CLKGATE_PRESENT      1         /*!< CLKGATE present or not */
+#define __CM4_REV              1         /*!< Core revision r0p1 */
+#define __DEBUG_LVL            3         /*!< Full debug plus DWT data matching */
+#define __FPU_PRESENT          0         /*!< FPU present or not */
+#define __JTAG_PRESENT         1         /*!< JTAG present or not */
+#define __MPU_PRESENT          1         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       4         /*!< Number of bits used for Priority Levels */
+#define __TRACE_LVL            1         /*!< Standard trace: ITM and DWT triggers and counters, but no ETM */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+#define __WIC_PRESENT          0         /*!< WIC present or not */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm4.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_sam4l.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAM4LS2C */
+/* ************************************************************************** */
+/** \defgroup SAM4LS2C_api Peripheral Software API */
+/*@{*/
+
+#include "component/abdacb.h"
+#include "component/acifc.h"
+#include "component/adcife.h"
+#include "component/ast.h"
+#include "component/bpm.h"
+#include "component/bscif.h"
+#include "component/catb.h"
+#include "component/chipid.h"
+#include "component/crccu.h"
+#include "component/dacc.h"
+#include "component/eic.h"
+#include "component/flashcalw.h"
+#include "component/freqm.h"
+#include "component/gloc.h"
+#include "component/gpio.h"
+#include "component/hcache.h"
+#include "component/hmatrixb.h"
+#include "component/iisc.h"
+#include "component/parc.h"
+#include "component/pdca.h"
+#include "component/pevc.h"
+#include "component/picouart.h"
+#include "component/pm.h"
+#include "component/scif.h"
+#include "component/smap.h"
+#include "component/spi.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twim.h"
+#include "component/twis.h"
+#include "component/usart.h"
+#include "component/usbc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAM4LS2C */
+/* ************************************************************************** */
+/** \defgroup SAM4LS2C_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/abdacb.h"
+#include "instance/acifc.h"
+#include "instance/adcife.h"
+#include "instance/ast.h"
+#include "instance/bpm.h"
+#include "instance/bscif.h"
+#include "instance/catb.h"
+#include "instance/chipid.h"
+#include "instance/crccu.h"
+#include "instance/dacc.h"
+#include "instance/eic.h"
+#include "instance/hflashc.h"
+#include "instance/freqm.h"
+#include "instance/gloc.h"
+#include "instance/gpio.h"
+#include "instance/hcache.h"
+#include "instance/hmatrix.h"
+#include "instance/iisc.h"
+#include "instance/parc.h"
+#include "instance/pdca.h"
+#include "instance/pevc.h"
+#include "instance/picouart.h"
+#include "instance/pm.h"
+#include "instance/scif.h"
+#include "instance/smap.h"
+#include "instance/spi.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/trng.h"
+#include "instance/twim0.h"
+#include "instance/twim1.h"
+#include "instance/twim2.h"
+#include "instance/twim3.h"
+#include "instance/twis0.h"
+#include "instance/twis1.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usart3.h"
+#include "instance/usbc.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAM4LS2C */
+/* ************************************************************************** */
+/** \defgroup SAM4LS2C_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HTOP0 bridge
+#define ID_IISC           0 /**< \brief Inter-IC Sound (I2S) Controller (IISC) */
+#define ID_SPI            1 /**< \brief Serial Peripheral Interface (SPI) */
+#define ID_TC0            2 /**< \brief Timer/Counter 0 (TC0) */
+#define ID_TC1            3 /**< \brief Timer/Counter 1 (TC1) */
+#define ID_TWIM0          4 /**< \brief Two-wire Master Interface 0 (TWIM0) */
+#define ID_TWIS0          5 /**< \brief Two-wire Slave Interface 0 (TWIS0) */
+#define ID_TWIM1          6 /**< \brief Two-wire Master Interface 1 (TWIM1) */
+#define ID_TWIS1          7 /**< \brief Two-wire Slave Interface 1 (TWIS1) */
+#define ID_USART0         8 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+#define ID_USART1         9 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+#define ID_USART2        10 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+#define ID_USART3        11 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+#define ID_ADCIFE        12 /**< \brief ADC controller interface (ADCIFE) */
+#define ID_DACC          13 /**< \brief DAC Controller (DACC) */
+#define ID_ACIFC         14 /**< \brief Analog Comparator Interface (ACIFC) */
+#define ID_GLOC          15 /**< \brief Glue Logic Controller (GLOC) */
+#define ID_ABDACB        16 /**< \brief Audio Bitstream DAC (ABDACB) */
+#define ID_TRNG          17 /**< \brief True Random Number Generator (TRNG) */
+#define ID_PARC          18 /**< \brief Parallel Capture (PARC) */
+#define ID_CATB          19 /**< \brief Capacitive Touch Module B (CATB) */
+#define ID_TWIM2         21 /**< \brief Two-wire Master Interface 2 (TWIM2) */
+#define ID_TWIM3         22 /**< \brief Two-wire Master Interface 3 (TWIM3) */
+
+// Peripheral instances on HTOP1 bridge
+#define ID_HFLASHC       32 /**< \brief Flash Controller (HFLASHC) */
+#define ID_HCACHE        33 /**< \brief Cortex M I&D Cache Controller (HCACHE) */
+#define ID_HMATRIX       34 /**< \brief HSB Matrix (HMATRIX) */
+#define ID_PDCA          35 /**< \brief Peripheral DMA Controller (PDCA) */
+#define ID_SMAP          36 /**< \brief System Manager Access Port (SMAP) */
+#define ID_CRCCU         37 /**< \brief CRC Calculation Unit (CRCCU) */
+#define ID_USBC          38 /**< \brief USB 2.0 Interface (USBC) */
+#define ID_PEVC          39 /**< \brief Peripheral Event Controller (PEVC) */
+
+// Peripheral instances on HTOP2 bridge
+#define ID_PM            64 /**< \brief Power Manager (PM) */
+#define ID_CHIPID        65 /**< \brief Chip ID Registers (CHIPID) */
+#define ID_SCIF          66 /**< \brief System Control Interface (SCIF) */
+#define ID_FREQM         67 /**< \brief Frequency Meter (FREQM) */
+#define ID_GPIO          68 /**< \brief General-Purpose Input/Output Controller (GPIO) */
+
+// Peripheral instances on HTOP3 bridge
+#define ID_BPM           96 /**< \brief Backup Power Manager (BPM) */
+#define ID_BSCIF         97 /**< \brief Backup System Control Interface (BSCIF) */
+#define ID_AST           98 /**< \brief Asynchronous Timer (AST) */
+#define ID_WDT           99 /**< \brief Watchdog Timer (WDT) */
+#define ID_EIC          100 /**< \brief External Interrupt Controller (EIC) */
+#define ID_PICOUART     101 /**< \brief Pico UART (PICOUART) */
+
+#define ID_PERIPH_COUNT 102 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAM4LS2C */
+/* ************************************************************************** */
+/** \defgroup SAM4LS2C_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define ABDACB                        (0x40064000) /**< \brief (ABDACB) APB Base Address */
+#define ACIFC                         (0x40040000) /**< \brief (ACIFC) APB Base Address */
+#define ADCIFE                        (0x40038000) /**< \brief (ADCIFE) APB Base Address */
+#define AST                           (0x400F0800) /**< \brief (AST) APB Base Address */
+#define BPM                           (0x400F0000) /**< \brief (BPM) APB Base Address */
+#define BSCIF                         (0x400F0400) /**< \brief (BSCIF) APB Base Address */
+#define CATB                          (0x40070000) /**< \brief (CATB) APB Base Address */
+#define CHIPID                        (0x400E0400) /**< \brief (CHIPID) APB Base Address */
+#define CRCCU                         (0x400A4000) /**< \brief (CRCCU) APB Base Address */
+#define DACC                          (0x4003C000) /**< \brief (DACC) APB Base Address */
+#define EIC                           (0x400F1000) /**< \brief (EIC) APB Base Address */
+#define HFLASHC                       (0x400A0000) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000) /**< \brief (HFLASHC) USER Base Address */
+#define FREQM                         (0x400E0C00) /**< \brief (FREQM) APB Base Address */
+#define GLOC                          (0x40060000) /**< \brief (GLOC) APB Base Address */
+#define GPIO                          (0x400E1000) /**< \brief (GPIO) APB Base Address */
+#define HCACHE                        (0x400A0400) /**< \brief (HCACHE) APB Base Address */
+#define HMATRIX                       (0x400A1000) /**< \brief (HMATRIX) APB Base Address */
+#define IISC                          (0x40004000) /**< \brief (IISC) APB Base Address */
+#define PARC                          (0x4006C000) /**< \brief (PARC) APB Base Address */
+#define PDCA                          (0x400A2000) /**< \brief (PDCA) APB Base Address */
+#define PEVC                          (0x400A6000) /**< \brief (PEVC) APB Base Address */
+#define PICOUART                      (0x400F1400) /**< \brief (PICOUART) APB Base Address */
+#define PM                            (0x400E0000) /**< \brief (PM) APB Base Address */
+#define SCIF                          (0x400E0800) /**< \brief (SCIF) APB Base Address */
+#define SMAP                          (0x400A3000) /**< \brief (SMAP) APB Base Address */
+#define SPI                           (0x40008000) /**< \brief (SPI) APB Base Address */
+#define TC0                           (0x40010000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x40014000) /**< \brief (TC1) APB Base Address */
+#define TRNG                          (0x40068000) /**< \brief (TRNG) APB Base Address */
+#define TWIM0                         (0x40018000) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1                         (0x4001C000) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2                         (0x40078000) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3                         (0x4007C000) /**< \brief (TWIM3) APB Base Address */
+#define TWIS0                         (0x40018400) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1                         (0x4001C400) /**< \brief (TWIS1) APB Base Address */
+#define USART0                        (0x40024000) /**< \brief (USART0) APB Base Address */
+#define USART1                        (0x40028000) /**< \brief (USART1) APB Base Address */
+#define USART2                        (0x4002C000) /**< \brief (USART2) APB Base Address */
+#define USART3                        (0x40030000) /**< \brief (USART3) APB Base Address */
+#define USBC                          (0x400A5000) /**< \brief (USBC) APB Base Address */
+#define WDT                           (0x400F0C00) /**< \brief (WDT) APB Base Address */
+#else
+#define ABDACB            ((Abdacb   *)0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_ADDR                   (0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_INST_NUM   1                          /**< \brief (ABDACB) Number of instances */
+#define ABDACB_INSTS      { ABDACB }                 /**< \brief (ABDACB) Instances List */
+
+#define ACIFC             ((Acifc    *)0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_ADDR                    (0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_INST_NUM    1                          /**< \brief (ACIFC) Number of instances */
+#define ACIFC_INSTS       { ACIFC }                  /**< \brief (ACIFC) Instances List */
+
+#define ADCIFE            ((Adcife   *)0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_ADDR                   (0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_INST_NUM   1                          /**< \brief (ADCIFE) Number of instances */
+#define ADCIFE_INSTS      { ADCIFE }                 /**< \brief (ADCIFE) Instances List */
+
+#define AST               ((Ast      *)0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_ADDR                      (0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_INST_NUM      1                          /**< \brief (AST) Number of instances */
+#define AST_INSTS         { AST }                    /**< \brief (AST) Instances List */
+
+#define BPM               ((Bpm      *)0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_ADDR                      (0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_INST_NUM      1                          /**< \brief (BPM) Number of instances */
+#define BPM_INSTS         { BPM }                    /**< \brief (BPM) Instances List */
+
+#define BSCIF             ((Bscif    *)0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_ADDR                    (0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_INST_NUM    1                          /**< \brief (BSCIF) Number of instances */
+#define BSCIF_INSTS       { BSCIF }                  /**< \brief (BSCIF) Instances List */
+
+#define CATB              ((Catb     *)0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_ADDR                     (0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_INST_NUM     1                          /**< \brief (CATB) Number of instances */
+#define CATB_INSTS        { CATB }                   /**< \brief (CATB) Instances List */
+
+#define CHIPID            ((Chipid   *)0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_ADDR                   (0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_INST_NUM   1                          /**< \brief (CHIPID) Number of instances */
+#define CHIPID_INSTS      { CHIPID }                 /**< \brief (CHIPID) Instances List */
+
+#define CRCCU             ((Crccu    *)0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_ADDR                    (0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_INST_NUM    1                          /**< \brief (CRCCU) Number of instances */
+#define CRCCU_INSTS       { CRCCU }                  /**< \brief (CRCCU) Instances List */
+
+#define DACC              ((Dacc     *)0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_ADDR                     (0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_INST_NUM     1                          /**< \brief (DACC) Number of instances */
+#define DACC_INSTS        { DACC }                   /**< \brief (DACC) Instances List */
+
+#define EIC               ((Eic      *)0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_ADDR                      (0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define HFLASHC           ((Flashcalw *)0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_ADDR                  (0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_FROW_ADDR             (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define HFLASHC_USER_ADDR             (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define FLASHCALW_INST_NUM 1                          /**< \brief (FLASHCALW) Number of instances */
+#define FLASHCALW_INSTS   { HFLASHC }                /**< \brief (FLASHCALW) Instances List */
+
+#define FREQM             ((Freqm    *)0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_ADDR                    (0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_INST_NUM    1                          /**< \brief (FREQM) Number of instances */
+#define FREQM_INSTS       { FREQM }                  /**< \brief (FREQM) Instances List */
+
+#define GLOC              ((Gloc     *)0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_ADDR                     (0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_INST_NUM     1                          /**< \brief (GLOC) Number of instances */
+#define GLOC_INSTS        { GLOC }                   /**< \brief (GLOC) Instances List */
+
+#define GPIO              ((Gpio     *)0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_ADDR                     (0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_INST_NUM     1                          /**< \brief (GPIO) Number of instances */
+#define GPIO_INSTS        { GPIO }                   /**< \brief (GPIO) Instances List */
+
+#define HCACHE            ((Hcache   *)0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_ADDR                   (0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_INST_NUM   1                          /**< \brief (HCACHE) Number of instances */
+#define HCACHE_INSTS      { HCACHE }                 /**< \brief (HCACHE) Instances List */
+
+#define HMATRIX           ((Hmatrixb *)0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIX_ADDR                  (0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIXB_INST_NUM 1                          /**< \brief (HMATRIXB) Number of instances */
+#define HMATRIXB_INSTS    { HMATRIX }                /**< \brief (HMATRIXB) Instances List */
+
+#define IISC              ((Iisc     *)0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_ADDR                     (0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_INST_NUM     1                          /**< \brief (IISC) Number of instances */
+#define IISC_INSTS        { IISC }                   /**< \brief (IISC) Instances List */
+
+#define PARC              ((Parc     *)0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_ADDR                     (0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_INST_NUM     1                          /**< \brief (PARC) Number of instances */
+#define PARC_INSTS        { PARC }                   /**< \brief (PARC) Instances List */
+
+#define PDCA              ((Pdca     *)0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_ADDR                     (0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_INST_NUM     1                          /**< \brief (PDCA) Number of instances */
+#define PDCA_INSTS        { PDCA }                   /**< \brief (PDCA) Instances List */
+
+#define PEVC              ((Pevc     *)0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_ADDR                     (0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_INST_NUM     1                          /**< \brief (PEVC) Number of instances */
+#define PEVC_INSTS        { PEVC }                   /**< \brief (PEVC) Instances List */
+
+#define PICOUART          ((Picouart *)0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_ADDR                 (0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_INST_NUM 1                          /**< \brief (PICOUART) Number of instances */
+#define PICOUART_INSTS    { PICOUART }               /**< \brief (PICOUART) Instances List */
+
+#define PM                ((Pm       *)0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_ADDR                       (0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define SCIF              ((Scif     *)0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_ADDR                     (0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_INST_NUM     1                          /**< \brief (SCIF) Number of instances */
+#define SCIF_INSTS        { SCIF }                   /**< \brief (SCIF) Instances List */
+
+#define SMAP              ((Smap     *)0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_ADDR                     (0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_INST_NUM     1                          /**< \brief (SMAP) Number of instances */
+#define SMAP_INSTS        { SMAP }                   /**< \brief (SMAP) Instances List */
+
+#define SPI               ((Spi      *)0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_ADDR                      (0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_INST_NUM      1                          /**< \brief (SPI) Number of instances */
+#define SPI_INSTS         { SPI }                    /**< \brief (SPI) Instances List */
+
+#define TC0               ((Tc       *)0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC0_ADDR                      (0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC1_ADDR                      (0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC_INST_NUM       2                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1 }               /**< \brief (TC) Instances List */
+
+#define TRNG              ((Trng     *)0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_ADDR                     (0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_INST_NUM     1                          /**< \brief (TRNG) Number of instances */
+#define TRNG_INSTS        { TRNG }                   /**< \brief (TRNG) Instances List */
+
+#define TWIM0             ((Twim     *)0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM0_ADDR                    (0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1             ((Twim     *)0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM1_ADDR                    (0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2             ((Twim     *)0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM2_ADDR                    (0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3             ((Twim     *)0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM3_ADDR                    (0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM_INST_NUM     4                          /**< \brief (TWIM) Number of instances */
+#define TWIM_INSTS        { TWIM0, TWIM1, TWIM2, TWIM3 } /**< \brief (TWIM) Instances List */
+
+#define TWIS0             ((Twis     *)0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS0_ADDR                    (0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1             ((Twis     *)0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS1_ADDR                    (0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS_INST_NUM     2                          /**< \brief (TWIS) Number of instances */
+#define TWIS_INSTS        { TWIS0, TWIS1 }           /**< \brief (TWIS) Instances List */
+
+#define USART0            ((Usart    *)0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART0_ADDR                   (0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART1            ((Usart    *)0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART1_ADDR                   (0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART2            ((Usart    *)0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART2_ADDR                   (0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART3            ((Usart    *)0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART3_ADDR                   (0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART_INST_NUM    4                          /**< \brief (USART) Number of instances */
+#define USART_INSTS       { USART0, USART1, USART2, USART3 } /**< \brief (USART) Instances List */
+
+#define USBC              ((Usbc     *)0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_ADDR                     (0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_INST_NUM     1                          /**< \brief (USBC) Number of instances */
+#define USBC_INSTS        { USBC }                   /**< \brief (USBC) Instances List */
+
+#define WDT               ((Wdt      *)0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_ADDR                      (0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  GPIO DEFINITIONS FOR SAM4LS2C */
+/* ************************************************************************** */
+/** \defgroup SAM4LS2C_gpio GPIO Definitions */
+/*@{*/
+
+#include "pio/sam4ls2c.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  ADDITIONAL DEFINITIONS FOR COMPATIBILITY */
+/* ************************************************************************** */
+/** \addtogroup SAM4LS2C_compat Definitions */
+/*@{*/
+// These defines are used to keep compatibility with existing 
+// sam/drivers/usart implementation from SAM3/4 products with SAM4L product.
+#define US_MR_USART_MODE_HW_HANDSHAKING  US_MR_USART_MODE_HARDWARE
+#define US_MR_USART_MODE_IS07816_T_0     US_MR_USART_MODE_ISO7816_T0
+#define US_MR_USART_MODE_IS07816_T_1     US_MR_USART_MODE_ISO7816_T1
+#define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
+#define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
+#define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_8_BIT      US_MR_CHRL_8
+#define US_MR_PAR_NO          US_MR_PAR_NONE
+#define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI
+#define US_IF                 US_IFR
+#define US_WPSR_WPVS          US_WPSR_WPV_1
+
+#define USBC_UPCFG0_PBK_Msk   (0x1u << USBC_UPCFG0_PBK_Pos)
+
+// These defines for homogeneity with other SAM header files.
+#define CHIP_FREQ_FWS_0       (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 */
+#define CHIP_FREQ_FWS_1       (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 */
+// WARNING NOTE: these are preliminary values.
+#define CHIP_FREQ_FLASH_HSEN_FWS_0 (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 and the FLASH HS mode is enabled */
+#define CHIP_FREQ_FLASH_HSEN_FWS_1 (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 and the FLASH HS mode is enabled */
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/tc implementation from SAM3/4 products with SAM4L product. 
+#define TC_CMR_LDRA_RISING    TC_CMR_LDRA_POS_EDGE_TIOA
+#define TC_CMR_LDRB_FALLING   TC_CMR_LDRB_NEG_EDGE_TIOA
+#define TC_CMR_ETRGEDG_FALLING TC_CMR_ETRGEDG_NEG_EDGE
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/spi implementation from SAM3/4 products with SAM4L product. 
+#define SPI_CSR_BITS_8_BIT    SPI_CSR_BITS_8_BPT
+#define SPI_WPCR_SPIWPKEY_VALUE SPI_WPCR_WPKEY_VALUE
+#define SPI_WPCR_SPIWPEN      SPI_WPCR_WPEN
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/crccu implementation from SAM3/4 products with SAM4L product. 
+#define CRCCU_DMA_EN          CRCCU_DMAEN
+#define CRCCU_DMA_DIS         CRCCU_DMADIS
+#define CRCCU_DMA_SR          CRCCU_DMASR
+#define CRCCU_DMA_IER         CRCCU_DMAIER
+#define CRCCU_DMA_IDR         CRCCU_DMAIDR
+#define CRCCU_DMA_IMR         CRCCU_DMAIMR
+#define CRCCU_DMA_ISR         CRCCU_DMAISR
+#define CRCCU_DMA_EN_DMAEN    CRCCU_DMAEN_DMAEN
+#define CRCCU_DMA_DIS_DMADIS  CRCCU_DMADIS_DMADIS
+#define CRCCU_DMA_SR_DMASR    CRCCU_DMASR_DMASR
+#define CRCCU_DMA_IER_DMAIER  CRCCU_DMAIER_DMAIER
+#define CRCCU_DMA_IDR_DMAIDR  CRCCU_DMAIDR_DMAIDR
+#define CRCCU_DMA_IMR_DMAIMR  CRCCU_DMAIMR_DMAIMR
+#define CRCCU_DMA_ISR_DMAISR  CRCCU_DMAISR_DMAISR
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAM4LS2C */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL(0x00020000) /* 128 kB */
+#define FLASH_PAGE_SIZE       512
+#define FLASH_NB_OF_PAGES     256
+#define FLASH_USER_PAGE_SIZE  512
+#define HRAMC0_SIZE           _UL(0x00008000) /* 32 kB */
+#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+
+#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+
+#define DSU_DID_RESETVALUE    _UL(0xAB0A07E0)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAM4LS2C */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAM4LS2C_H */

--- a/asf/sam/include/sam4l/sam4ls2c.h
+++ b/asf/sam/include/sam4l/sam4ls2c.h
@@ -62,15 +62,15 @@ typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volati
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
 #if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#define _U_(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
 #if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#define _U_(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 
@@ -857,23 +857,23 @@ void TWIM3_Handler               ( void );
 /**  MEMORY MAPPING DEFINITIONS FOR SAM4LS2C */
 /* ************************************************************************** */
 
-#define FLASH_SIZE            _UL(0x00020000) /* 128 kB */
+#define FLASH_SIZE            _UL_(0x00020000) /* 128 kB */
 #define FLASH_PAGE_SIZE       512
 #define FLASH_NB_OF_PAGES     256
 #define FLASH_USER_PAGE_SIZE  512
-#define HRAMC0_SIZE           _UL(0x00008000) /* 32 kB */
-#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+#define HRAMC0_SIZE           _UL_(0x00008000) /* 32 kB */
+#define HRAMC1_SIZE           _UL_(0x00000800) /* 2 kB */
 
-#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
-#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
-#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
-#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
-#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
-#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
-#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
-#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL_(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL_(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL_(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL_(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL_(0x400F0000) /**< HTOP3 base address */
 
-#define DSU_DID_RESETVALUE    _UL(0xAB0A07E0)
+#define DSU_DID_RESETVALUE    _UL_(0xAB0A07E0)
 
 /* ************************************************************************** */
 /**  ELECTRICAL DEFINITIONS FOR SAM4LS2C */

--- a/asf/sam/include/sam4l/sam4ls4a.h
+++ b/asf/sam/include/sam4l/sam4ls4a.h
@@ -1,0 +1,889 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAM4LS4A
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LS4A_
+#define _SAM4LS4A_
+
+/**
+ * \ingroup SAM4L_definitions
+ * \addtogroup SAM4LS4A_definitions SAM4LS4A definitions
+ * This file defines all structures and symbols for SAM4LS4A:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#if !defined(_UL)
+#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#endif
+#else
+#if !defined(_UL)
+#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif
+#endif
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAM4LS4A */
+/* ************************************************************************** */
+/** \defgroup SAM4LS4A_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M4 Processor Exceptions Numbers ******************************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn           = -13,/**<  3 Cortex-M4 Hard Fault Interrupt        */
+  MemoryManagement_IRQn    = -12,/**<  4 Cortex-M4 Memory Management Interrupt */
+  BusFault_IRQn            = -11,/**<  5 Cortex-M4 Bus Fault Interrupt         */
+  UsageFault_IRQn          = -10,/**<  6 Cortex-M4 Usage Fault Interrupt       */
+  SVCall_IRQn              = -5, /**< 11 Cortex-M4 SV Call Interrupt           */
+  DebugMonitor_IRQn        = -4, /**< 12 Cortex-M4 Debug Monitor Interrupt     */
+  PendSV_IRQn              = -2, /**< 14 Cortex-M4 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 Cortex-M4 System Tick Interrupt       */
+  /******  SAM4LS4A-specific Interrupt Numbers ***********************/
+  HFLASHC_IRQn             =  0, /**<  0 SAM4LS4A Flash Controller (HFLASHC) */
+  PDCA_0_IRQn              =  1, /**<  1 SAM4LS4A Peripheral DMA Controller (PDCA): PDCA_0 */
+  PDCA_1_IRQn              =  2, /**<  2 SAM4LS4A Peripheral DMA Controller (PDCA): PDCA_1 */
+  PDCA_2_IRQn              =  3, /**<  3 SAM4LS4A Peripheral DMA Controller (PDCA): PDCA_2 */
+  PDCA_3_IRQn              =  4, /**<  4 SAM4LS4A Peripheral DMA Controller (PDCA): PDCA_3 */
+  PDCA_4_IRQn              =  5, /**<  5 SAM4LS4A Peripheral DMA Controller (PDCA): PDCA_4 */
+  PDCA_5_IRQn              =  6, /**<  6 SAM4LS4A Peripheral DMA Controller (PDCA): PDCA_5 */
+  PDCA_6_IRQn              =  7, /**<  7 SAM4LS4A Peripheral DMA Controller (PDCA): PDCA_6 */
+  PDCA_7_IRQn              =  8, /**<  8 SAM4LS4A Peripheral DMA Controller (PDCA): PDCA_7 */
+  PDCA_8_IRQn              =  9, /**<  9 SAM4LS4A Peripheral DMA Controller (PDCA): PDCA_8 */
+  PDCA_9_IRQn              = 10, /**< 10 SAM4LS4A Peripheral DMA Controller (PDCA): PDCA_9 */
+  PDCA_10_IRQn             = 11, /**< 11 SAM4LS4A Peripheral DMA Controller (PDCA): PDCA_10 */
+  PDCA_11_IRQn             = 12, /**< 12 SAM4LS4A Peripheral DMA Controller (PDCA): PDCA_11 */
+  PDCA_12_IRQn             = 13, /**< 13 SAM4LS4A Peripheral DMA Controller (PDCA): PDCA_12 */
+  PDCA_13_IRQn             = 14, /**< 14 SAM4LS4A Peripheral DMA Controller (PDCA): PDCA_13 */
+  PDCA_14_IRQn             = 15, /**< 15 SAM4LS4A Peripheral DMA Controller (PDCA): PDCA_14 */
+  PDCA_15_IRQn             = 16, /**< 16 SAM4LS4A Peripheral DMA Controller (PDCA): PDCA_15 */
+  CRCCU_IRQn               = 17, /**< 17 SAM4LS4A CRC Calculation Unit (CRCCU) */
+  USBC_IRQn                = 18, /**< 18 SAM4LS4A USB 2.0 Interface (USBC) */
+  PEVC_0_IRQn              = 19, /**< 19 SAM4LS4A Peripheral Event Controller (PEVC): PEVC_TR */
+  PEVC_1_IRQn              = 20, /**< 20 SAM4LS4A Peripheral Event Controller (PEVC): PEVC_OV */
+  PM_IRQn                  = 22, /**< 22 SAM4LS4A Power Manager (PM) */
+  SCIF_IRQn                = 23, /**< 23 SAM4LS4A System Control Interface (SCIF) */
+  FREQM_IRQn               = 24, /**< 24 SAM4LS4A Frequency Meter (FREQM) */
+  GPIO_0_IRQn              = 25, /**< 25 SAM4LS4A General-Purpose Input/Output Controller (GPIO): GPIO_0 */
+  GPIO_1_IRQn              = 26, /**< 26 SAM4LS4A General-Purpose Input/Output Controller (GPIO): GPIO_1 */
+  GPIO_2_IRQn              = 27, /**< 27 SAM4LS4A General-Purpose Input/Output Controller (GPIO): GPIO_2 */
+  GPIO_3_IRQn              = 28, /**< 28 SAM4LS4A General-Purpose Input/Output Controller (GPIO): GPIO_3 */
+  GPIO_4_IRQn              = 29, /**< 29 SAM4LS4A General-Purpose Input/Output Controller (GPIO): GPIO_4 */
+  GPIO_5_IRQn              = 30, /**< 30 SAM4LS4A General-Purpose Input/Output Controller (GPIO): GPIO_5 */
+  GPIO_6_IRQn              = 31, /**< 31 SAM4LS4A General-Purpose Input/Output Controller (GPIO): GPIO_6 */
+  GPIO_7_IRQn              = 32, /**< 32 SAM4LS4A General-Purpose Input/Output Controller (GPIO): GPIO_7 */
+  GPIO_8_IRQn              = 33, /**< 33 SAM4LS4A General-Purpose Input/Output Controller (GPIO): GPIO_8 */
+  GPIO_9_IRQn              = 34, /**< 34 SAM4LS4A General-Purpose Input/Output Controller (GPIO): GPIO_9 */
+  GPIO_10_IRQn             = 35, /**< 35 SAM4LS4A General-Purpose Input/Output Controller (GPIO): GPIO_10 */
+  GPIO_11_IRQn             = 36, /**< 36 SAM4LS4A General-Purpose Input/Output Controller (GPIO): GPIO_11 */
+  BPM_IRQn                 = 37, /**< 37 SAM4LS4A Backup Power Manager (BPM) */
+  BSCIF_IRQn               = 38, /**< 38 SAM4LS4A Backup System Control Interface (BSCIF) */
+  AST_0_IRQn               = 39, /**< 39 SAM4LS4A Asynchronous Timer (AST): AST_ALARM */
+  AST_1_IRQn               = 40, /**< 40 SAM4LS4A Asynchronous Timer (AST): AST_PER */
+  AST_2_IRQn               = 41, /**< 41 SAM4LS4A Asynchronous Timer (AST): AST_OVF */
+  AST_3_IRQn               = 42, /**< 42 SAM4LS4A Asynchronous Timer (AST): AST_READY */
+  AST_4_IRQn               = 43, /**< 43 SAM4LS4A Asynchronous Timer (AST): AST_CLKREADY */
+  WDT_IRQn                 = 44, /**< 44 SAM4LS4A Watchdog Timer (WDT) */
+  EIC_0_IRQn               = 45, /**< 45 SAM4LS4A External Interrupt Controller (EIC): EIC_1 */
+  EIC_1_IRQn               = 46, /**< 46 SAM4LS4A External Interrupt Controller (EIC): EIC_2 */
+  EIC_2_IRQn               = 47, /**< 47 SAM4LS4A External Interrupt Controller (EIC): EIC_3 */
+  EIC_3_IRQn               = 48, /**< 48 SAM4LS4A External Interrupt Controller (EIC): EIC_4 */
+  EIC_4_IRQn               = 49, /**< 49 SAM4LS4A External Interrupt Controller (EIC): EIC_5 */
+  EIC_5_IRQn               = 50, /**< 50 SAM4LS4A External Interrupt Controller (EIC): EIC_6 */
+  EIC_6_IRQn               = 51, /**< 51 SAM4LS4A External Interrupt Controller (EIC): EIC_7 */
+  EIC_7_IRQn               = 52, /**< 52 SAM4LS4A External Interrupt Controller (EIC): EIC_8 */
+  IISC_IRQn                = 53, /**< 53 SAM4LS4A Inter-IC Sound (I2S) Controller (IISC) */
+  SPI_IRQn                 = 54, /**< 54 SAM4LS4A Serial Peripheral Interface (SPI) */
+  TC0_0_IRQn               = 55, /**< 55 SAM4LS4A Timer/Counter 0 (TC0): TC00 */
+  TC0_1_IRQn               = 56, /**< 56 SAM4LS4A Timer/Counter 0 (TC0): TC01 */
+  TC0_2_IRQn               = 57, /**< 57 SAM4LS4A Timer/Counter 0 (TC0): TC02 */
+  TC1_0_IRQn               = 58, /**< 58 SAM4LS4A Timer/Counter 1 (TC1): TC10 */
+  TC1_1_IRQn               = 59, /**< 59 SAM4LS4A Timer/Counter 1 (TC1): TC11 */
+  TC1_2_IRQn               = 60, /**< 60 SAM4LS4A Timer/Counter 1 (TC1): TC12 */
+  TWIM0_IRQn               = 61, /**< 61 SAM4LS4A Two-wire Master Interface 0 (TWIM0) */
+  TWIS0_IRQn               = 62, /**< 62 SAM4LS4A Two-wire Slave Interface 0 (TWIS0) */
+  TWIM1_IRQn               = 63, /**< 63 SAM4LS4A Two-wire Master Interface 1 (TWIM1) */
+  TWIS1_IRQn               = 64, /**< 64 SAM4LS4A Two-wire Slave Interface 1 (TWIS1) */
+  USART0_IRQn              = 65, /**< 65 SAM4LS4A Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+  USART1_IRQn              = 66, /**< 66 SAM4LS4A Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+  USART2_IRQn              = 67, /**< 67 SAM4LS4A Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+  USART3_IRQn              = 68, /**< 68 SAM4LS4A Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+  ADCIFE_IRQn              = 69, /**< 69 SAM4LS4A ADC controller interface (ADCIFE) */
+  DACC_IRQn                = 70, /**< 70 SAM4LS4A DAC Controller (DACC) */
+  ACIFC_IRQn               = 71, /**< 71 SAM4LS4A Analog Comparator Interface (ACIFC) */
+  ABDACB_IRQn              = 72, /**< 72 SAM4LS4A Audio Bitstream DAC (ABDACB) */
+  TRNG_IRQn                = 73, /**< 73 SAM4LS4A True Random Number Generator (TRNG) */
+  PARC_IRQn                = 74, /**< 74 SAM4LS4A Parallel Capture (PARC) */
+  CATB_IRQn                = 75, /**< 75 SAM4LS4A Capacitive Touch Module B (CATB) */
+  TWIM2_IRQn               = 77, /**< 77 SAM4LS4A Two-wire Master Interface 2 (TWIM2) */
+  TWIM3_IRQn               = 78, /**< 78 SAM4LS4A Two-wire Master Interface 3 (TWIM3) */
+
+  PERIPH_COUNT_IRQn        = 80  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNMI_Handler;
+  void* pfnHardFault_Handler;
+  void* pfnMemManage_Handler;
+  void* pfnBusFault_Handler;
+  void* pfnUsageFault_Handler;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVC_Handler;
+  void* pfnDebugMon_Handler;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnHFLASHC_Handler;               /*  0 Flash Controller */
+  void* pfnPDCA_0_Handler;                /*  1 Peripheral DMA Controller IRQ 0 */
+  void* pfnPDCA_1_Handler;                /*  2 Peripheral DMA Controller IRQ 1 */
+  void* pfnPDCA_2_Handler;                /*  3 Peripheral DMA Controller IRQ 2 */
+  void* pfnPDCA_3_Handler;                /*  4 Peripheral DMA Controller IRQ 3 */
+  void* pfnPDCA_4_Handler;                /*  5 Peripheral DMA Controller IRQ 4 */
+  void* pfnPDCA_5_Handler;                /*  6 Peripheral DMA Controller IRQ 5 */
+  void* pfnPDCA_6_Handler;                /*  7 Peripheral DMA Controller IRQ 6 */
+  void* pfnPDCA_7_Handler;                /*  8 Peripheral DMA Controller IRQ 7 */
+  void* pfnPDCA_8_Handler;                /*  9 Peripheral DMA Controller IRQ 8 */
+  void* pfnPDCA_9_Handler;                /* 10 Peripheral DMA Controller IRQ 9 */
+  void* pfnPDCA_10_Handler;               /* 11 Peripheral DMA Controller IRQ 10 */
+  void* pfnPDCA_11_Handler;               /* 12 Peripheral DMA Controller IRQ 11 */
+  void* pfnPDCA_12_Handler;               /* 13 Peripheral DMA Controller IRQ 12 */
+  void* pfnPDCA_13_Handler;               /* 14 Peripheral DMA Controller IRQ 13 */
+  void* pfnPDCA_14_Handler;               /* 15 Peripheral DMA Controller IRQ 14 */
+  void* pfnPDCA_15_Handler;               /* 16 Peripheral DMA Controller IRQ 15 */
+  void* pfnCRCCU_Handler;                 /* 17 CRC Calculation Unit */
+  void* pfnUSBC_Handler;                  /* 18 USB 2.0 Interface */
+  void* pfnPEVC_0_Handler;                /* 19 Peripheral Event Controller IRQ 0 */
+  void* pfnPEVC_1_Handler;                /* 20 Peripheral Event Controller IRQ 1 */
+  void* pvReserved21;
+  void* pfnPM_Handler;                    /* 22 Power Manager */
+  void* pfnSCIF_Handler;                  /* 23 System Control Interface */
+  void* pfnFREQM_Handler;                 /* 24 Frequency Meter */
+  void* pfnGPIO_0_Handler;                /* 25 General-Purpose Input/Output Controller IRQ 0 */
+  void* pfnGPIO_1_Handler;                /* 26 General-Purpose Input/Output Controller IRQ 1 */
+  void* pfnGPIO_2_Handler;                /* 27 General-Purpose Input/Output Controller IRQ 2 */
+  void* pfnGPIO_3_Handler;                /* 28 General-Purpose Input/Output Controller IRQ 3 */
+  void* pfnGPIO_4_Handler;                /* 29 General-Purpose Input/Output Controller IRQ 4 */
+  void* pfnGPIO_5_Handler;                /* 30 General-Purpose Input/Output Controller IRQ 5 */
+  void* pfnGPIO_6_Handler;                /* 31 General-Purpose Input/Output Controller IRQ 6 */
+  void* pfnGPIO_7_Handler;                /* 32 General-Purpose Input/Output Controller IRQ 7 */
+  void* pfnGPIO_8_Handler;                /* 33 General-Purpose Input/Output Controller IRQ 8 */
+  void* pfnGPIO_9_Handler;                /* 34 General-Purpose Input/Output Controller IRQ 9 */
+  void* pfnGPIO_10_Handler;               /* 35 General-Purpose Input/Output Controller IRQ 10 */
+  void* pfnGPIO_11_Handler;               /* 36 General-Purpose Input/Output Controller IRQ 11 */
+  void* pfnBPM_Handler;                   /* 37 Backup Power Manager */
+  void* pfnBSCIF_Handler;                 /* 38 Backup System Control Interface */
+  void* pfnAST_0_Handler;                 /* 39 Asynchronous Timer IRQ 0 */
+  void* pfnAST_1_Handler;                 /* 40 Asynchronous Timer IRQ 1 */
+  void* pfnAST_2_Handler;                 /* 41 Asynchronous Timer IRQ 2 */
+  void* pfnAST_3_Handler;                 /* 42 Asynchronous Timer IRQ 3 */
+  void* pfnAST_4_Handler;                 /* 43 Asynchronous Timer IRQ 4 */
+  void* pfnWDT_Handler;                   /* 44 Watchdog Timer */
+  void* pfnEIC_0_Handler;                 /* 45 External Interrupt Controller IRQ 0 */
+  void* pfnEIC_1_Handler;                 /* 46 External Interrupt Controller IRQ 1 */
+  void* pfnEIC_2_Handler;                 /* 47 External Interrupt Controller IRQ 2 */
+  void* pfnEIC_3_Handler;                 /* 48 External Interrupt Controller IRQ 3 */
+  void* pfnEIC_4_Handler;                 /* 49 External Interrupt Controller IRQ 4 */
+  void* pfnEIC_5_Handler;                 /* 50 External Interrupt Controller IRQ 5 */
+  void* pfnEIC_6_Handler;                 /* 51 External Interrupt Controller IRQ 6 */
+  void* pfnEIC_7_Handler;                 /* 52 External Interrupt Controller IRQ 7 */
+  void* pfnIISC_Handler;                  /* 53 Inter-IC Sound (I2S) Controller */
+  void* pfnSPI_Handler;                   /* 54 Serial Peripheral Interface */
+  void* pfnTC0_0_Handler;                 /* 55 Timer/Counter 0 IRQ 0 */
+  void* pfnTC0_1_Handler;                 /* 56 Timer/Counter 0 IRQ 1 */
+  void* pfnTC0_2_Handler;                 /* 57 Timer/Counter 0 IRQ 2 */
+  void* pfnTC1_0_Handler;                 /* 58 Timer/Counter 1 IRQ 0 */
+  void* pfnTC1_1_Handler;                 /* 59 Timer/Counter 1 IRQ 1 */
+  void* pfnTC1_2_Handler;                 /* 60 Timer/Counter 1 IRQ 2 */
+  void* pfnTWIM0_Handler;                 /* 61 Two-wire Master Interface 0 */
+  void* pfnTWIS0_Handler;                 /* 62 Two-wire Slave Interface 0 */
+  void* pfnTWIM1_Handler;                 /* 63 Two-wire Master Interface 1 */
+  void* pfnTWIS1_Handler;                 /* 64 Two-wire Slave Interface 1 */
+  void* pfnUSART0_Handler;                /* 65 Universal Synchronous Asynchronous Receiver Transmitter 0 */
+  void* pfnUSART1_Handler;                /* 66 Universal Synchronous Asynchronous Receiver Transmitter 1 */
+  void* pfnUSART2_Handler;                /* 67 Universal Synchronous Asynchronous Receiver Transmitter 2 */
+  void* pfnUSART3_Handler;                /* 68 Universal Synchronous Asynchronous Receiver Transmitter 3 */
+  void* pfnADCIFE_Handler;                /* 69 ADC controller interface */
+  void* pfnDACC_Handler;                  /* 70 DAC Controller */
+  void* pfnACIFC_Handler;                 /* 71 Analog Comparator Interface */
+  void* pfnABDACB_Handler;                /* 72 Audio Bitstream DAC */
+  void* pfnTRNG_Handler;                  /* 73 True Random Number Generator */
+  void* pfnPARC_Handler;                  /* 74 Parallel Capture */
+  void* pfnCATB_Handler;                  /* 75 Capacitive Touch Module B */
+  void* pvReserved76;
+  void* pfnTWIM2_Handler;                 /* 77 Two-wire Master Interface 2 */
+  void* pfnTWIM3_Handler;                 /* 78 Two-wire Master Interface 3 */
+  void* pvReserved79;
+} DeviceVectors;
+
+/* Cortex-M4 processor handlers */
+void Reset_Handler               ( void );
+void NMI_Handler                 ( void );
+void HardFault_Handler           ( void );
+void MemManage_Handler           ( void );
+void BusFault_Handler            ( void );
+void UsageFault_Handler          ( void );
+void SVC_Handler                 ( void );
+void DebugMon_Handler            ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void HFLASHC_Handler             ( void );
+void PDCA_0_Handler              ( void );
+void PDCA_1_Handler              ( void );
+void PDCA_2_Handler              ( void );
+void PDCA_3_Handler              ( void );
+void PDCA_4_Handler              ( void );
+void PDCA_5_Handler              ( void );
+void PDCA_6_Handler              ( void );
+void PDCA_7_Handler              ( void );
+void PDCA_8_Handler              ( void );
+void PDCA_9_Handler              ( void );
+void PDCA_10_Handler             ( void );
+void PDCA_11_Handler             ( void );
+void PDCA_12_Handler             ( void );
+void PDCA_13_Handler             ( void );
+void PDCA_14_Handler             ( void );
+void PDCA_15_Handler             ( void );
+void CRCCU_Handler               ( void );
+void USBC_Handler                ( void );
+void PEVC_0_Handler              ( void );
+void PEVC_1_Handler              ( void );
+void PM_Handler                  ( void );
+void SCIF_Handler                ( void );
+void FREQM_Handler               ( void );
+void GPIO_0_Handler              ( void );
+void GPIO_1_Handler              ( void );
+void GPIO_2_Handler              ( void );
+void GPIO_3_Handler              ( void );
+void GPIO_4_Handler              ( void );
+void GPIO_5_Handler              ( void );
+void GPIO_6_Handler              ( void );
+void GPIO_7_Handler              ( void );
+void GPIO_8_Handler              ( void );
+void GPIO_9_Handler              ( void );
+void GPIO_10_Handler             ( void );
+void GPIO_11_Handler             ( void );
+void BPM_Handler                 ( void );
+void BSCIF_Handler               ( void );
+void AST_0_Handler               ( void );
+void AST_1_Handler               ( void );
+void AST_2_Handler               ( void );
+void AST_3_Handler               ( void );
+void AST_4_Handler               ( void );
+void WDT_Handler                 ( void );
+void EIC_0_Handler               ( void );
+void EIC_1_Handler               ( void );
+void EIC_2_Handler               ( void );
+void EIC_3_Handler               ( void );
+void EIC_4_Handler               ( void );
+void EIC_5_Handler               ( void );
+void EIC_6_Handler               ( void );
+void EIC_7_Handler               ( void );
+void IISC_Handler                ( void );
+void SPI_Handler                 ( void );
+void TC0_0_Handler               ( void );
+void TC0_1_Handler               ( void );
+void TC0_2_Handler               ( void );
+void TC1_0_Handler               ( void );
+void TC1_1_Handler               ( void );
+void TC1_2_Handler               ( void );
+void TWIM0_Handler               ( void );
+void TWIS0_Handler               ( void );
+void TWIM1_Handler               ( void );
+void TWIS1_Handler               ( void );
+void USART0_Handler              ( void );
+void USART1_Handler              ( void );
+void USART2_Handler              ( void );
+void USART3_Handler              ( void );
+void ADCIFE_Handler              ( void );
+void DACC_Handler                ( void );
+void ACIFC_Handler               ( void );
+void ABDACB_Handler              ( void );
+void TRNG_Handler                ( void );
+void PARC_Handler                ( void );
+void CATB_Handler                ( void );
+void TWIM2_Handler               ( void );
+void TWIM3_Handler               ( void );
+
+/*
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
+ */
+
+#define LITTLE_ENDIAN          1        
+#define __BB_PRESENT           0         /*!< BIT_BANDING present or not */
+#define __CLKGATE_PRESENT      1         /*!< CLKGATE present or not */
+#define __CM4_REV              1         /*!< Core revision r0p1 */
+#define __DEBUG_LVL            3         /*!< Full debug plus DWT data matching */
+#define __FPU_PRESENT          0         /*!< FPU present or not */
+#define __JTAG_PRESENT         1         /*!< JTAG present or not */
+#define __MPU_PRESENT          1         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       4         /*!< Number of bits used for Priority Levels */
+#define __TRACE_LVL            1         /*!< Standard trace: ITM and DWT triggers and counters, but no ETM */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+#define __WIC_PRESENT          0         /*!< WIC present or not */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm4.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_sam4l.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAM4LS4A */
+/* ************************************************************************** */
+/** \defgroup SAM4LS4A_api Peripheral Software API */
+/*@{*/
+
+#include "component/abdacb.h"
+#include "component/acifc.h"
+#include "component/adcife.h"
+#include "component/ast.h"
+#include "component/bpm.h"
+#include "component/bscif.h"
+#include "component/catb.h"
+#include "component/chipid.h"
+#include "component/crccu.h"
+#include "component/dacc.h"
+#include "component/eic.h"
+#include "component/flashcalw.h"
+#include "component/freqm.h"
+#include "component/gloc.h"
+#include "component/gpio.h"
+#include "component/hcache.h"
+#include "component/hmatrixb.h"
+#include "component/iisc.h"
+#include "component/parc.h"
+#include "component/pdca.h"
+#include "component/pevc.h"
+#include "component/picouart.h"
+#include "component/pm.h"
+#include "component/scif.h"
+#include "component/smap.h"
+#include "component/spi.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twim.h"
+#include "component/twis.h"
+#include "component/usart.h"
+#include "component/usbc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAM4LS4A */
+/* ************************************************************************** */
+/** \defgroup SAM4LS4A_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/abdacb.h"
+#include "instance/acifc.h"
+#include "instance/adcife.h"
+#include "instance/ast.h"
+#include "instance/bpm.h"
+#include "instance/bscif.h"
+#include "instance/catb.h"
+#include "instance/chipid.h"
+#include "instance/crccu.h"
+#include "instance/dacc.h"
+#include "instance/eic.h"
+#include "instance/hflashc.h"
+#include "instance/freqm.h"
+#include "instance/gloc.h"
+#include "instance/gpio.h"
+#include "instance/hcache.h"
+#include "instance/hmatrix.h"
+#include "instance/iisc.h"
+#include "instance/parc.h"
+#include "instance/pdca.h"
+#include "instance/pevc.h"
+#include "instance/picouart.h"
+#include "instance/pm.h"
+#include "instance/scif.h"
+#include "instance/smap.h"
+#include "instance/spi.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/trng.h"
+#include "instance/twim0.h"
+#include "instance/twim1.h"
+#include "instance/twim2.h"
+#include "instance/twim3.h"
+#include "instance/twis0.h"
+#include "instance/twis1.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usart3.h"
+#include "instance/usbc.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAM4LS4A */
+/* ************************************************************************** */
+/** \defgroup SAM4LS4A_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HTOP0 bridge
+#define ID_IISC           0 /**< \brief Inter-IC Sound (I2S) Controller (IISC) */
+#define ID_SPI            1 /**< \brief Serial Peripheral Interface (SPI) */
+#define ID_TC0            2 /**< \brief Timer/Counter 0 (TC0) */
+#define ID_TC1            3 /**< \brief Timer/Counter 1 (TC1) */
+#define ID_TWIM0          4 /**< \brief Two-wire Master Interface 0 (TWIM0) */
+#define ID_TWIS0          5 /**< \brief Two-wire Slave Interface 0 (TWIS0) */
+#define ID_TWIM1          6 /**< \brief Two-wire Master Interface 1 (TWIM1) */
+#define ID_TWIS1          7 /**< \brief Two-wire Slave Interface 1 (TWIS1) */
+#define ID_USART0         8 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+#define ID_USART1         9 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+#define ID_USART2        10 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+#define ID_USART3        11 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+#define ID_ADCIFE        12 /**< \brief ADC controller interface (ADCIFE) */
+#define ID_DACC          13 /**< \brief DAC Controller (DACC) */
+#define ID_ACIFC         14 /**< \brief Analog Comparator Interface (ACIFC) */
+#define ID_GLOC          15 /**< \brief Glue Logic Controller (GLOC) */
+#define ID_ABDACB        16 /**< \brief Audio Bitstream DAC (ABDACB) */
+#define ID_TRNG          17 /**< \brief True Random Number Generator (TRNG) */
+#define ID_PARC          18 /**< \brief Parallel Capture (PARC) */
+#define ID_CATB          19 /**< \brief Capacitive Touch Module B (CATB) */
+#define ID_TWIM2         21 /**< \brief Two-wire Master Interface 2 (TWIM2) */
+#define ID_TWIM3         22 /**< \brief Two-wire Master Interface 3 (TWIM3) */
+
+// Peripheral instances on HTOP1 bridge
+#define ID_HFLASHC       32 /**< \brief Flash Controller (HFLASHC) */
+#define ID_HCACHE        33 /**< \brief Cortex M I&D Cache Controller (HCACHE) */
+#define ID_HMATRIX       34 /**< \brief HSB Matrix (HMATRIX) */
+#define ID_PDCA          35 /**< \brief Peripheral DMA Controller (PDCA) */
+#define ID_SMAP          36 /**< \brief System Manager Access Port (SMAP) */
+#define ID_CRCCU         37 /**< \brief CRC Calculation Unit (CRCCU) */
+#define ID_USBC          38 /**< \brief USB 2.0 Interface (USBC) */
+#define ID_PEVC          39 /**< \brief Peripheral Event Controller (PEVC) */
+
+// Peripheral instances on HTOP2 bridge
+#define ID_PM            64 /**< \brief Power Manager (PM) */
+#define ID_CHIPID        65 /**< \brief Chip ID Registers (CHIPID) */
+#define ID_SCIF          66 /**< \brief System Control Interface (SCIF) */
+#define ID_FREQM         67 /**< \brief Frequency Meter (FREQM) */
+#define ID_GPIO          68 /**< \brief General-Purpose Input/Output Controller (GPIO) */
+
+// Peripheral instances on HTOP3 bridge
+#define ID_BPM           96 /**< \brief Backup Power Manager (BPM) */
+#define ID_BSCIF         97 /**< \brief Backup System Control Interface (BSCIF) */
+#define ID_AST           98 /**< \brief Asynchronous Timer (AST) */
+#define ID_WDT           99 /**< \brief Watchdog Timer (WDT) */
+#define ID_EIC          100 /**< \brief External Interrupt Controller (EIC) */
+#define ID_PICOUART     101 /**< \brief Pico UART (PICOUART) */
+
+#define ID_PERIPH_COUNT 102 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAM4LS4A */
+/* ************************************************************************** */
+/** \defgroup SAM4LS4A_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define ABDACB                        (0x40064000) /**< \brief (ABDACB) APB Base Address */
+#define ACIFC                         (0x40040000) /**< \brief (ACIFC) APB Base Address */
+#define ADCIFE                        (0x40038000) /**< \brief (ADCIFE) APB Base Address */
+#define AST                           (0x400F0800) /**< \brief (AST) APB Base Address */
+#define BPM                           (0x400F0000) /**< \brief (BPM) APB Base Address */
+#define BSCIF                         (0x400F0400) /**< \brief (BSCIF) APB Base Address */
+#define CATB                          (0x40070000) /**< \brief (CATB) APB Base Address */
+#define CHIPID                        (0x400E0400) /**< \brief (CHIPID) APB Base Address */
+#define CRCCU                         (0x400A4000) /**< \brief (CRCCU) APB Base Address */
+#define DACC                          (0x4003C000) /**< \brief (DACC) APB Base Address */
+#define EIC                           (0x400F1000) /**< \brief (EIC) APB Base Address */
+#define HFLASHC                       (0x400A0000) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000) /**< \brief (HFLASHC) USER Base Address */
+#define FREQM                         (0x400E0C00) /**< \brief (FREQM) APB Base Address */
+#define GLOC                          (0x40060000) /**< \brief (GLOC) APB Base Address */
+#define GPIO                          (0x400E1000) /**< \brief (GPIO) APB Base Address */
+#define HCACHE                        (0x400A0400) /**< \brief (HCACHE) APB Base Address */
+#define HMATRIX                       (0x400A1000) /**< \brief (HMATRIX) APB Base Address */
+#define IISC                          (0x40004000) /**< \brief (IISC) APB Base Address */
+#define PARC                          (0x4006C000) /**< \brief (PARC) APB Base Address */
+#define PDCA                          (0x400A2000) /**< \brief (PDCA) APB Base Address */
+#define PEVC                          (0x400A6000) /**< \brief (PEVC) APB Base Address */
+#define PICOUART                      (0x400F1400) /**< \brief (PICOUART) APB Base Address */
+#define PM                            (0x400E0000) /**< \brief (PM) APB Base Address */
+#define SCIF                          (0x400E0800) /**< \brief (SCIF) APB Base Address */
+#define SMAP                          (0x400A3000) /**< \brief (SMAP) APB Base Address */
+#define SPI                           (0x40008000) /**< \brief (SPI) APB Base Address */
+#define TC0                           (0x40010000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x40014000) /**< \brief (TC1) APB Base Address */
+#define TRNG                          (0x40068000) /**< \brief (TRNG) APB Base Address */
+#define TWIM0                         (0x40018000) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1                         (0x4001C000) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2                         (0x40078000) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3                         (0x4007C000) /**< \brief (TWIM3) APB Base Address */
+#define TWIS0                         (0x40018400) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1                         (0x4001C400) /**< \brief (TWIS1) APB Base Address */
+#define USART0                        (0x40024000) /**< \brief (USART0) APB Base Address */
+#define USART1                        (0x40028000) /**< \brief (USART1) APB Base Address */
+#define USART2                        (0x4002C000) /**< \brief (USART2) APB Base Address */
+#define USART3                        (0x40030000) /**< \brief (USART3) APB Base Address */
+#define USBC                          (0x400A5000) /**< \brief (USBC) APB Base Address */
+#define WDT                           (0x400F0C00) /**< \brief (WDT) APB Base Address */
+#else
+#define ABDACB            ((Abdacb   *)0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_ADDR                   (0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_INST_NUM   1                          /**< \brief (ABDACB) Number of instances */
+#define ABDACB_INSTS      { ABDACB }                 /**< \brief (ABDACB) Instances List */
+
+#define ACIFC             ((Acifc    *)0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_ADDR                    (0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_INST_NUM    1                          /**< \brief (ACIFC) Number of instances */
+#define ACIFC_INSTS       { ACIFC }                  /**< \brief (ACIFC) Instances List */
+
+#define ADCIFE            ((Adcife   *)0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_ADDR                   (0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_INST_NUM   1                          /**< \brief (ADCIFE) Number of instances */
+#define ADCIFE_INSTS      { ADCIFE }                 /**< \brief (ADCIFE) Instances List */
+
+#define AST               ((Ast      *)0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_ADDR                      (0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_INST_NUM      1                          /**< \brief (AST) Number of instances */
+#define AST_INSTS         { AST }                    /**< \brief (AST) Instances List */
+
+#define BPM               ((Bpm      *)0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_ADDR                      (0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_INST_NUM      1                          /**< \brief (BPM) Number of instances */
+#define BPM_INSTS         { BPM }                    /**< \brief (BPM) Instances List */
+
+#define BSCIF             ((Bscif    *)0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_ADDR                    (0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_INST_NUM    1                          /**< \brief (BSCIF) Number of instances */
+#define BSCIF_INSTS       { BSCIF }                  /**< \brief (BSCIF) Instances List */
+
+#define CATB              ((Catb     *)0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_ADDR                     (0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_INST_NUM     1                          /**< \brief (CATB) Number of instances */
+#define CATB_INSTS        { CATB }                   /**< \brief (CATB) Instances List */
+
+#define CHIPID            ((Chipid   *)0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_ADDR                   (0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_INST_NUM   1                          /**< \brief (CHIPID) Number of instances */
+#define CHIPID_INSTS      { CHIPID }                 /**< \brief (CHIPID) Instances List */
+
+#define CRCCU             ((Crccu    *)0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_ADDR                    (0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_INST_NUM    1                          /**< \brief (CRCCU) Number of instances */
+#define CRCCU_INSTS       { CRCCU }                  /**< \brief (CRCCU) Instances List */
+
+#define DACC              ((Dacc     *)0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_ADDR                     (0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_INST_NUM     1                          /**< \brief (DACC) Number of instances */
+#define DACC_INSTS        { DACC }                   /**< \brief (DACC) Instances List */
+
+#define EIC               ((Eic      *)0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_ADDR                      (0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define HFLASHC           ((Flashcalw *)0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_ADDR                  (0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_FROW_ADDR             (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define HFLASHC_USER_ADDR             (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define FLASHCALW_INST_NUM 1                          /**< \brief (FLASHCALW) Number of instances */
+#define FLASHCALW_INSTS   { HFLASHC }                /**< \brief (FLASHCALW) Instances List */
+
+#define FREQM             ((Freqm    *)0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_ADDR                    (0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_INST_NUM    1                          /**< \brief (FREQM) Number of instances */
+#define FREQM_INSTS       { FREQM }                  /**< \brief (FREQM) Instances List */
+
+#define GLOC              ((Gloc     *)0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_ADDR                     (0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_INST_NUM     1                          /**< \brief (GLOC) Number of instances */
+#define GLOC_INSTS        { GLOC }                   /**< \brief (GLOC) Instances List */
+
+#define GPIO              ((Gpio     *)0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_ADDR                     (0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_INST_NUM     1                          /**< \brief (GPIO) Number of instances */
+#define GPIO_INSTS        { GPIO }                   /**< \brief (GPIO) Instances List */
+
+#define HCACHE            ((Hcache   *)0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_ADDR                   (0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_INST_NUM   1                          /**< \brief (HCACHE) Number of instances */
+#define HCACHE_INSTS      { HCACHE }                 /**< \brief (HCACHE) Instances List */
+
+#define HMATRIX           ((Hmatrixb *)0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIX_ADDR                  (0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIXB_INST_NUM 1                          /**< \brief (HMATRIXB) Number of instances */
+#define HMATRIXB_INSTS    { HMATRIX }                /**< \brief (HMATRIXB) Instances List */
+
+#define IISC              ((Iisc     *)0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_ADDR                     (0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_INST_NUM     1                          /**< \brief (IISC) Number of instances */
+#define IISC_INSTS        { IISC }                   /**< \brief (IISC) Instances List */
+
+#define PARC              ((Parc     *)0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_ADDR                     (0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_INST_NUM     1                          /**< \brief (PARC) Number of instances */
+#define PARC_INSTS        { PARC }                   /**< \brief (PARC) Instances List */
+
+#define PDCA              ((Pdca     *)0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_ADDR                     (0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_INST_NUM     1                          /**< \brief (PDCA) Number of instances */
+#define PDCA_INSTS        { PDCA }                   /**< \brief (PDCA) Instances List */
+
+#define PEVC              ((Pevc     *)0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_ADDR                     (0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_INST_NUM     1                          /**< \brief (PEVC) Number of instances */
+#define PEVC_INSTS        { PEVC }                   /**< \brief (PEVC) Instances List */
+
+#define PICOUART          ((Picouart *)0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_ADDR                 (0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_INST_NUM 1                          /**< \brief (PICOUART) Number of instances */
+#define PICOUART_INSTS    { PICOUART }               /**< \brief (PICOUART) Instances List */
+
+#define PM                ((Pm       *)0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_ADDR                       (0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define SCIF              ((Scif     *)0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_ADDR                     (0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_INST_NUM     1                          /**< \brief (SCIF) Number of instances */
+#define SCIF_INSTS        { SCIF }                   /**< \brief (SCIF) Instances List */
+
+#define SMAP              ((Smap     *)0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_ADDR                     (0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_INST_NUM     1                          /**< \brief (SMAP) Number of instances */
+#define SMAP_INSTS        { SMAP }                   /**< \brief (SMAP) Instances List */
+
+#define SPI               ((Spi      *)0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_ADDR                      (0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_INST_NUM      1                          /**< \brief (SPI) Number of instances */
+#define SPI_INSTS         { SPI }                    /**< \brief (SPI) Instances List */
+
+#define TC0               ((Tc       *)0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC0_ADDR                      (0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC1_ADDR                      (0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC_INST_NUM       2                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1 }               /**< \brief (TC) Instances List */
+
+#define TRNG              ((Trng     *)0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_ADDR                     (0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_INST_NUM     1                          /**< \brief (TRNG) Number of instances */
+#define TRNG_INSTS        { TRNG }                   /**< \brief (TRNG) Instances List */
+
+#define TWIM0             ((Twim     *)0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM0_ADDR                    (0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1             ((Twim     *)0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM1_ADDR                    (0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2             ((Twim     *)0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM2_ADDR                    (0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3             ((Twim     *)0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM3_ADDR                    (0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM_INST_NUM     4                          /**< \brief (TWIM) Number of instances */
+#define TWIM_INSTS        { TWIM0, TWIM1, TWIM2, TWIM3 } /**< \brief (TWIM) Instances List */
+
+#define TWIS0             ((Twis     *)0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS0_ADDR                    (0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1             ((Twis     *)0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS1_ADDR                    (0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS_INST_NUM     2                          /**< \brief (TWIS) Number of instances */
+#define TWIS_INSTS        { TWIS0, TWIS1 }           /**< \brief (TWIS) Instances List */
+
+#define USART0            ((Usart    *)0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART0_ADDR                   (0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART1            ((Usart    *)0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART1_ADDR                   (0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART2            ((Usart    *)0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART2_ADDR                   (0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART3            ((Usart    *)0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART3_ADDR                   (0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART_INST_NUM    4                          /**< \brief (USART) Number of instances */
+#define USART_INSTS       { USART0, USART1, USART2, USART3 } /**< \brief (USART) Instances List */
+
+#define USBC              ((Usbc     *)0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_ADDR                     (0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_INST_NUM     1                          /**< \brief (USBC) Number of instances */
+#define USBC_INSTS        { USBC }                   /**< \brief (USBC) Instances List */
+
+#define WDT               ((Wdt      *)0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_ADDR                      (0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  GPIO DEFINITIONS FOR SAM4LS4A */
+/* ************************************************************************** */
+/** \defgroup SAM4LS4A_gpio GPIO Definitions */
+/*@{*/
+
+#include "pio/sam4ls4a.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  ADDITIONAL DEFINITIONS FOR COMPATIBILITY */
+/* ************************************************************************** */
+/** \addtogroup SAM4LS4A_compat Definitions */
+/*@{*/
+// These defines are used to keep compatibility with existing 
+// sam/drivers/usart implementation from SAM3/4 products with SAM4L product.
+#define US_MR_USART_MODE_HW_HANDSHAKING  US_MR_USART_MODE_HARDWARE
+#define US_MR_USART_MODE_IS07816_T_0     US_MR_USART_MODE_ISO7816_T0
+#define US_MR_USART_MODE_IS07816_T_1     US_MR_USART_MODE_ISO7816_T1
+#define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
+#define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
+#define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_8_BIT      US_MR_CHRL_8
+#define US_MR_PAR_NO          US_MR_PAR_NONE
+#define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI
+#define US_IF                 US_IFR
+#define US_WPSR_WPVS          US_WPSR_WPV_1
+
+#define USBC_UPCFG0_PBK_Msk   (0x1u << USBC_UPCFG0_PBK_Pos)
+
+// These defines for homogeneity with other SAM header files.
+#define CHIP_FREQ_FWS_0       (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 */
+#define CHIP_FREQ_FWS_1       (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 */
+// WARNING NOTE: these are preliminary values.
+#define CHIP_FREQ_FLASH_HSEN_FWS_0 (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 and the FLASH HS mode is enabled */
+#define CHIP_FREQ_FLASH_HSEN_FWS_1 (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 and the FLASH HS mode is enabled */
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/tc implementation from SAM3/4 products with SAM4L product. 
+#define TC_CMR_LDRA_RISING    TC_CMR_LDRA_POS_EDGE_TIOA
+#define TC_CMR_LDRB_FALLING   TC_CMR_LDRB_NEG_EDGE_TIOA
+#define TC_CMR_ETRGEDG_FALLING TC_CMR_ETRGEDG_NEG_EDGE
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/spi implementation from SAM3/4 products with SAM4L product. 
+#define SPI_CSR_BITS_8_BIT    SPI_CSR_BITS_8_BPT
+#define SPI_WPCR_SPIWPKEY_VALUE SPI_WPCR_WPKEY_VALUE
+#define SPI_WPCR_SPIWPEN      SPI_WPCR_WPEN
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/crccu implementation from SAM3/4 products with SAM4L product. 
+#define CRCCU_DMA_EN          CRCCU_DMAEN
+#define CRCCU_DMA_DIS         CRCCU_DMADIS
+#define CRCCU_DMA_SR          CRCCU_DMASR
+#define CRCCU_DMA_IER         CRCCU_DMAIER
+#define CRCCU_DMA_IDR         CRCCU_DMAIDR
+#define CRCCU_DMA_IMR         CRCCU_DMAIMR
+#define CRCCU_DMA_ISR         CRCCU_DMAISR
+#define CRCCU_DMA_EN_DMAEN    CRCCU_DMAEN_DMAEN
+#define CRCCU_DMA_DIS_DMADIS  CRCCU_DMADIS_DMADIS
+#define CRCCU_DMA_SR_DMASR    CRCCU_DMASR_DMASR
+#define CRCCU_DMA_IER_DMAIER  CRCCU_DMAIER_DMAIER
+#define CRCCU_DMA_IDR_DMAIDR  CRCCU_DMAIDR_DMAIDR
+#define CRCCU_DMA_IMR_DMAIMR  CRCCU_DMAIMR_DMAIMR
+#define CRCCU_DMA_ISR_DMAISR  CRCCU_DMAISR_DMAISR
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAM4LS4A */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL(0x00040000) /* 256 kB */
+#define FLASH_PAGE_SIZE       512
+#define FLASH_NB_OF_PAGES     512
+#define FLASH_USER_PAGE_SIZE  512
+#define HRAMC0_SIZE           _UL(0x00008000) /* 32 kB */
+#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+
+#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+
+#define DSU_DID_RESETVALUE    _UL(0xAB0A09E0)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAM4LS4A */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAM4LS4A_H */

--- a/asf/sam/include/sam4l/sam4ls4a.h
+++ b/asf/sam/include/sam4l/sam4ls4a.h
@@ -62,15 +62,15 @@ typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volati
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
 #if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#define _U_(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
 #if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#define _U_(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 
@@ -857,23 +857,23 @@ void TWIM3_Handler               ( void );
 /**  MEMORY MAPPING DEFINITIONS FOR SAM4LS4A */
 /* ************************************************************************** */
 
-#define FLASH_SIZE            _UL(0x00040000) /* 256 kB */
+#define FLASH_SIZE            _UL_(0x00040000) /* 256 kB */
 #define FLASH_PAGE_SIZE       512
 #define FLASH_NB_OF_PAGES     512
 #define FLASH_USER_PAGE_SIZE  512
-#define HRAMC0_SIZE           _UL(0x00008000) /* 32 kB */
-#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+#define HRAMC0_SIZE           _UL_(0x00008000) /* 32 kB */
+#define HRAMC1_SIZE           _UL_(0x00000800) /* 2 kB */
 
-#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
-#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
-#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
-#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
-#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
-#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
-#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
-#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL_(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL_(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL_(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL_(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL_(0x400F0000) /**< HTOP3 base address */
 
-#define DSU_DID_RESETVALUE    _UL(0xAB0A09E0)
+#define DSU_DID_RESETVALUE    _UL_(0xAB0A09E0)
 
 /* ************************************************************************** */
 /**  ELECTRICAL DEFINITIONS FOR SAM4LS4A */

--- a/asf/sam/include/sam4l/sam4ls4b.h
+++ b/asf/sam/include/sam4l/sam4ls4b.h
@@ -1,0 +1,889 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAM4LS4B
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LS4B_
+#define _SAM4LS4B_
+
+/**
+ * \ingroup SAM4L_definitions
+ * \addtogroup SAM4LS4B_definitions SAM4LS4B definitions
+ * This file defines all structures and symbols for SAM4LS4B:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#if !defined(_UL)
+#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#endif
+#else
+#if !defined(_UL)
+#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif
+#endif
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAM4LS4B */
+/* ************************************************************************** */
+/** \defgroup SAM4LS4B_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M4 Processor Exceptions Numbers ******************************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn           = -13,/**<  3 Cortex-M4 Hard Fault Interrupt        */
+  MemoryManagement_IRQn    = -12,/**<  4 Cortex-M4 Memory Management Interrupt */
+  BusFault_IRQn            = -11,/**<  5 Cortex-M4 Bus Fault Interrupt         */
+  UsageFault_IRQn          = -10,/**<  6 Cortex-M4 Usage Fault Interrupt       */
+  SVCall_IRQn              = -5, /**< 11 Cortex-M4 SV Call Interrupt           */
+  DebugMonitor_IRQn        = -4, /**< 12 Cortex-M4 Debug Monitor Interrupt     */
+  PendSV_IRQn              = -2, /**< 14 Cortex-M4 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 Cortex-M4 System Tick Interrupt       */
+  /******  SAM4LS4B-specific Interrupt Numbers ***********************/
+  HFLASHC_IRQn             =  0, /**<  0 SAM4LS4B Flash Controller (HFLASHC) */
+  PDCA_0_IRQn              =  1, /**<  1 SAM4LS4B Peripheral DMA Controller (PDCA): PDCA_0 */
+  PDCA_1_IRQn              =  2, /**<  2 SAM4LS4B Peripheral DMA Controller (PDCA): PDCA_1 */
+  PDCA_2_IRQn              =  3, /**<  3 SAM4LS4B Peripheral DMA Controller (PDCA): PDCA_2 */
+  PDCA_3_IRQn              =  4, /**<  4 SAM4LS4B Peripheral DMA Controller (PDCA): PDCA_3 */
+  PDCA_4_IRQn              =  5, /**<  5 SAM4LS4B Peripheral DMA Controller (PDCA): PDCA_4 */
+  PDCA_5_IRQn              =  6, /**<  6 SAM4LS4B Peripheral DMA Controller (PDCA): PDCA_5 */
+  PDCA_6_IRQn              =  7, /**<  7 SAM4LS4B Peripheral DMA Controller (PDCA): PDCA_6 */
+  PDCA_7_IRQn              =  8, /**<  8 SAM4LS4B Peripheral DMA Controller (PDCA): PDCA_7 */
+  PDCA_8_IRQn              =  9, /**<  9 SAM4LS4B Peripheral DMA Controller (PDCA): PDCA_8 */
+  PDCA_9_IRQn              = 10, /**< 10 SAM4LS4B Peripheral DMA Controller (PDCA): PDCA_9 */
+  PDCA_10_IRQn             = 11, /**< 11 SAM4LS4B Peripheral DMA Controller (PDCA): PDCA_10 */
+  PDCA_11_IRQn             = 12, /**< 12 SAM4LS4B Peripheral DMA Controller (PDCA): PDCA_11 */
+  PDCA_12_IRQn             = 13, /**< 13 SAM4LS4B Peripheral DMA Controller (PDCA): PDCA_12 */
+  PDCA_13_IRQn             = 14, /**< 14 SAM4LS4B Peripheral DMA Controller (PDCA): PDCA_13 */
+  PDCA_14_IRQn             = 15, /**< 15 SAM4LS4B Peripheral DMA Controller (PDCA): PDCA_14 */
+  PDCA_15_IRQn             = 16, /**< 16 SAM4LS4B Peripheral DMA Controller (PDCA): PDCA_15 */
+  CRCCU_IRQn               = 17, /**< 17 SAM4LS4B CRC Calculation Unit (CRCCU) */
+  USBC_IRQn                = 18, /**< 18 SAM4LS4B USB 2.0 Interface (USBC) */
+  PEVC_0_IRQn              = 19, /**< 19 SAM4LS4B Peripheral Event Controller (PEVC): PEVC_TR */
+  PEVC_1_IRQn              = 20, /**< 20 SAM4LS4B Peripheral Event Controller (PEVC): PEVC_OV */
+  PM_IRQn                  = 22, /**< 22 SAM4LS4B Power Manager (PM) */
+  SCIF_IRQn                = 23, /**< 23 SAM4LS4B System Control Interface (SCIF) */
+  FREQM_IRQn               = 24, /**< 24 SAM4LS4B Frequency Meter (FREQM) */
+  GPIO_0_IRQn              = 25, /**< 25 SAM4LS4B General-Purpose Input/Output Controller (GPIO): GPIO_0 */
+  GPIO_1_IRQn              = 26, /**< 26 SAM4LS4B General-Purpose Input/Output Controller (GPIO): GPIO_1 */
+  GPIO_2_IRQn              = 27, /**< 27 SAM4LS4B General-Purpose Input/Output Controller (GPIO): GPIO_2 */
+  GPIO_3_IRQn              = 28, /**< 28 SAM4LS4B General-Purpose Input/Output Controller (GPIO): GPIO_3 */
+  GPIO_4_IRQn              = 29, /**< 29 SAM4LS4B General-Purpose Input/Output Controller (GPIO): GPIO_4 */
+  GPIO_5_IRQn              = 30, /**< 30 SAM4LS4B General-Purpose Input/Output Controller (GPIO): GPIO_5 */
+  GPIO_6_IRQn              = 31, /**< 31 SAM4LS4B General-Purpose Input/Output Controller (GPIO): GPIO_6 */
+  GPIO_7_IRQn              = 32, /**< 32 SAM4LS4B General-Purpose Input/Output Controller (GPIO): GPIO_7 */
+  GPIO_8_IRQn              = 33, /**< 33 SAM4LS4B General-Purpose Input/Output Controller (GPIO): GPIO_8 */
+  GPIO_9_IRQn              = 34, /**< 34 SAM4LS4B General-Purpose Input/Output Controller (GPIO): GPIO_9 */
+  GPIO_10_IRQn             = 35, /**< 35 SAM4LS4B General-Purpose Input/Output Controller (GPIO): GPIO_10 */
+  GPIO_11_IRQn             = 36, /**< 36 SAM4LS4B General-Purpose Input/Output Controller (GPIO): GPIO_11 */
+  BPM_IRQn                 = 37, /**< 37 SAM4LS4B Backup Power Manager (BPM) */
+  BSCIF_IRQn               = 38, /**< 38 SAM4LS4B Backup System Control Interface (BSCIF) */
+  AST_0_IRQn               = 39, /**< 39 SAM4LS4B Asynchronous Timer (AST): AST_ALARM */
+  AST_1_IRQn               = 40, /**< 40 SAM4LS4B Asynchronous Timer (AST): AST_PER */
+  AST_2_IRQn               = 41, /**< 41 SAM4LS4B Asynchronous Timer (AST): AST_OVF */
+  AST_3_IRQn               = 42, /**< 42 SAM4LS4B Asynchronous Timer (AST): AST_READY */
+  AST_4_IRQn               = 43, /**< 43 SAM4LS4B Asynchronous Timer (AST): AST_CLKREADY */
+  WDT_IRQn                 = 44, /**< 44 SAM4LS4B Watchdog Timer (WDT) */
+  EIC_0_IRQn               = 45, /**< 45 SAM4LS4B External Interrupt Controller (EIC): EIC_1 */
+  EIC_1_IRQn               = 46, /**< 46 SAM4LS4B External Interrupt Controller (EIC): EIC_2 */
+  EIC_2_IRQn               = 47, /**< 47 SAM4LS4B External Interrupt Controller (EIC): EIC_3 */
+  EIC_3_IRQn               = 48, /**< 48 SAM4LS4B External Interrupt Controller (EIC): EIC_4 */
+  EIC_4_IRQn               = 49, /**< 49 SAM4LS4B External Interrupt Controller (EIC): EIC_5 */
+  EIC_5_IRQn               = 50, /**< 50 SAM4LS4B External Interrupt Controller (EIC): EIC_6 */
+  EIC_6_IRQn               = 51, /**< 51 SAM4LS4B External Interrupt Controller (EIC): EIC_7 */
+  EIC_7_IRQn               = 52, /**< 52 SAM4LS4B External Interrupt Controller (EIC): EIC_8 */
+  IISC_IRQn                = 53, /**< 53 SAM4LS4B Inter-IC Sound (I2S) Controller (IISC) */
+  SPI_IRQn                 = 54, /**< 54 SAM4LS4B Serial Peripheral Interface (SPI) */
+  TC0_0_IRQn               = 55, /**< 55 SAM4LS4B Timer/Counter 0 (TC0): TC00 */
+  TC0_1_IRQn               = 56, /**< 56 SAM4LS4B Timer/Counter 0 (TC0): TC01 */
+  TC0_2_IRQn               = 57, /**< 57 SAM4LS4B Timer/Counter 0 (TC0): TC02 */
+  TC1_0_IRQn               = 58, /**< 58 SAM4LS4B Timer/Counter 1 (TC1): TC10 */
+  TC1_1_IRQn               = 59, /**< 59 SAM4LS4B Timer/Counter 1 (TC1): TC11 */
+  TC1_2_IRQn               = 60, /**< 60 SAM4LS4B Timer/Counter 1 (TC1): TC12 */
+  TWIM0_IRQn               = 61, /**< 61 SAM4LS4B Two-wire Master Interface 0 (TWIM0) */
+  TWIS0_IRQn               = 62, /**< 62 SAM4LS4B Two-wire Slave Interface 0 (TWIS0) */
+  TWIM1_IRQn               = 63, /**< 63 SAM4LS4B Two-wire Master Interface 1 (TWIM1) */
+  TWIS1_IRQn               = 64, /**< 64 SAM4LS4B Two-wire Slave Interface 1 (TWIS1) */
+  USART0_IRQn              = 65, /**< 65 SAM4LS4B Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+  USART1_IRQn              = 66, /**< 66 SAM4LS4B Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+  USART2_IRQn              = 67, /**< 67 SAM4LS4B Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+  USART3_IRQn              = 68, /**< 68 SAM4LS4B Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+  ADCIFE_IRQn              = 69, /**< 69 SAM4LS4B ADC controller interface (ADCIFE) */
+  DACC_IRQn                = 70, /**< 70 SAM4LS4B DAC Controller (DACC) */
+  ACIFC_IRQn               = 71, /**< 71 SAM4LS4B Analog Comparator Interface (ACIFC) */
+  ABDACB_IRQn              = 72, /**< 72 SAM4LS4B Audio Bitstream DAC (ABDACB) */
+  TRNG_IRQn                = 73, /**< 73 SAM4LS4B True Random Number Generator (TRNG) */
+  PARC_IRQn                = 74, /**< 74 SAM4LS4B Parallel Capture (PARC) */
+  CATB_IRQn                = 75, /**< 75 SAM4LS4B Capacitive Touch Module B (CATB) */
+  TWIM2_IRQn               = 77, /**< 77 SAM4LS4B Two-wire Master Interface 2 (TWIM2) */
+  TWIM3_IRQn               = 78, /**< 78 SAM4LS4B Two-wire Master Interface 3 (TWIM3) */
+
+  PERIPH_COUNT_IRQn        = 80  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNMI_Handler;
+  void* pfnHardFault_Handler;
+  void* pfnMemManage_Handler;
+  void* pfnBusFault_Handler;
+  void* pfnUsageFault_Handler;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVC_Handler;
+  void* pfnDebugMon_Handler;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnHFLASHC_Handler;               /*  0 Flash Controller */
+  void* pfnPDCA_0_Handler;                /*  1 Peripheral DMA Controller IRQ 0 */
+  void* pfnPDCA_1_Handler;                /*  2 Peripheral DMA Controller IRQ 1 */
+  void* pfnPDCA_2_Handler;                /*  3 Peripheral DMA Controller IRQ 2 */
+  void* pfnPDCA_3_Handler;                /*  4 Peripheral DMA Controller IRQ 3 */
+  void* pfnPDCA_4_Handler;                /*  5 Peripheral DMA Controller IRQ 4 */
+  void* pfnPDCA_5_Handler;                /*  6 Peripheral DMA Controller IRQ 5 */
+  void* pfnPDCA_6_Handler;                /*  7 Peripheral DMA Controller IRQ 6 */
+  void* pfnPDCA_7_Handler;                /*  8 Peripheral DMA Controller IRQ 7 */
+  void* pfnPDCA_8_Handler;                /*  9 Peripheral DMA Controller IRQ 8 */
+  void* pfnPDCA_9_Handler;                /* 10 Peripheral DMA Controller IRQ 9 */
+  void* pfnPDCA_10_Handler;               /* 11 Peripheral DMA Controller IRQ 10 */
+  void* pfnPDCA_11_Handler;               /* 12 Peripheral DMA Controller IRQ 11 */
+  void* pfnPDCA_12_Handler;               /* 13 Peripheral DMA Controller IRQ 12 */
+  void* pfnPDCA_13_Handler;               /* 14 Peripheral DMA Controller IRQ 13 */
+  void* pfnPDCA_14_Handler;               /* 15 Peripheral DMA Controller IRQ 14 */
+  void* pfnPDCA_15_Handler;               /* 16 Peripheral DMA Controller IRQ 15 */
+  void* pfnCRCCU_Handler;                 /* 17 CRC Calculation Unit */
+  void* pfnUSBC_Handler;                  /* 18 USB 2.0 Interface */
+  void* pfnPEVC_0_Handler;                /* 19 Peripheral Event Controller IRQ 0 */
+  void* pfnPEVC_1_Handler;                /* 20 Peripheral Event Controller IRQ 1 */
+  void* pvReserved21;
+  void* pfnPM_Handler;                    /* 22 Power Manager */
+  void* pfnSCIF_Handler;                  /* 23 System Control Interface */
+  void* pfnFREQM_Handler;                 /* 24 Frequency Meter */
+  void* pfnGPIO_0_Handler;                /* 25 General-Purpose Input/Output Controller IRQ 0 */
+  void* pfnGPIO_1_Handler;                /* 26 General-Purpose Input/Output Controller IRQ 1 */
+  void* pfnGPIO_2_Handler;                /* 27 General-Purpose Input/Output Controller IRQ 2 */
+  void* pfnGPIO_3_Handler;                /* 28 General-Purpose Input/Output Controller IRQ 3 */
+  void* pfnGPIO_4_Handler;                /* 29 General-Purpose Input/Output Controller IRQ 4 */
+  void* pfnGPIO_5_Handler;                /* 30 General-Purpose Input/Output Controller IRQ 5 */
+  void* pfnGPIO_6_Handler;                /* 31 General-Purpose Input/Output Controller IRQ 6 */
+  void* pfnGPIO_7_Handler;                /* 32 General-Purpose Input/Output Controller IRQ 7 */
+  void* pfnGPIO_8_Handler;                /* 33 General-Purpose Input/Output Controller IRQ 8 */
+  void* pfnGPIO_9_Handler;                /* 34 General-Purpose Input/Output Controller IRQ 9 */
+  void* pfnGPIO_10_Handler;               /* 35 General-Purpose Input/Output Controller IRQ 10 */
+  void* pfnGPIO_11_Handler;               /* 36 General-Purpose Input/Output Controller IRQ 11 */
+  void* pfnBPM_Handler;                   /* 37 Backup Power Manager */
+  void* pfnBSCIF_Handler;                 /* 38 Backup System Control Interface */
+  void* pfnAST_0_Handler;                 /* 39 Asynchronous Timer IRQ 0 */
+  void* pfnAST_1_Handler;                 /* 40 Asynchronous Timer IRQ 1 */
+  void* pfnAST_2_Handler;                 /* 41 Asynchronous Timer IRQ 2 */
+  void* pfnAST_3_Handler;                 /* 42 Asynchronous Timer IRQ 3 */
+  void* pfnAST_4_Handler;                 /* 43 Asynchronous Timer IRQ 4 */
+  void* pfnWDT_Handler;                   /* 44 Watchdog Timer */
+  void* pfnEIC_0_Handler;                 /* 45 External Interrupt Controller IRQ 0 */
+  void* pfnEIC_1_Handler;                 /* 46 External Interrupt Controller IRQ 1 */
+  void* pfnEIC_2_Handler;                 /* 47 External Interrupt Controller IRQ 2 */
+  void* pfnEIC_3_Handler;                 /* 48 External Interrupt Controller IRQ 3 */
+  void* pfnEIC_4_Handler;                 /* 49 External Interrupt Controller IRQ 4 */
+  void* pfnEIC_5_Handler;                 /* 50 External Interrupt Controller IRQ 5 */
+  void* pfnEIC_6_Handler;                 /* 51 External Interrupt Controller IRQ 6 */
+  void* pfnEIC_7_Handler;                 /* 52 External Interrupt Controller IRQ 7 */
+  void* pfnIISC_Handler;                  /* 53 Inter-IC Sound (I2S) Controller */
+  void* pfnSPI_Handler;                   /* 54 Serial Peripheral Interface */
+  void* pfnTC0_0_Handler;                 /* 55 Timer/Counter 0 IRQ 0 */
+  void* pfnTC0_1_Handler;                 /* 56 Timer/Counter 0 IRQ 1 */
+  void* pfnTC0_2_Handler;                 /* 57 Timer/Counter 0 IRQ 2 */
+  void* pfnTC1_0_Handler;                 /* 58 Timer/Counter 1 IRQ 0 */
+  void* pfnTC1_1_Handler;                 /* 59 Timer/Counter 1 IRQ 1 */
+  void* pfnTC1_2_Handler;                 /* 60 Timer/Counter 1 IRQ 2 */
+  void* pfnTWIM0_Handler;                 /* 61 Two-wire Master Interface 0 */
+  void* pfnTWIS0_Handler;                 /* 62 Two-wire Slave Interface 0 */
+  void* pfnTWIM1_Handler;                 /* 63 Two-wire Master Interface 1 */
+  void* pfnTWIS1_Handler;                 /* 64 Two-wire Slave Interface 1 */
+  void* pfnUSART0_Handler;                /* 65 Universal Synchronous Asynchronous Receiver Transmitter 0 */
+  void* pfnUSART1_Handler;                /* 66 Universal Synchronous Asynchronous Receiver Transmitter 1 */
+  void* pfnUSART2_Handler;                /* 67 Universal Synchronous Asynchronous Receiver Transmitter 2 */
+  void* pfnUSART3_Handler;                /* 68 Universal Synchronous Asynchronous Receiver Transmitter 3 */
+  void* pfnADCIFE_Handler;                /* 69 ADC controller interface */
+  void* pfnDACC_Handler;                  /* 70 DAC Controller */
+  void* pfnACIFC_Handler;                 /* 71 Analog Comparator Interface */
+  void* pfnABDACB_Handler;                /* 72 Audio Bitstream DAC */
+  void* pfnTRNG_Handler;                  /* 73 True Random Number Generator */
+  void* pfnPARC_Handler;                  /* 74 Parallel Capture */
+  void* pfnCATB_Handler;                  /* 75 Capacitive Touch Module B */
+  void* pvReserved76;
+  void* pfnTWIM2_Handler;                 /* 77 Two-wire Master Interface 2 */
+  void* pfnTWIM3_Handler;                 /* 78 Two-wire Master Interface 3 */
+  void* pvReserved79;
+} DeviceVectors;
+
+/* Cortex-M4 processor handlers */
+void Reset_Handler               ( void );
+void NMI_Handler                 ( void );
+void HardFault_Handler           ( void );
+void MemManage_Handler           ( void );
+void BusFault_Handler            ( void );
+void UsageFault_Handler          ( void );
+void SVC_Handler                 ( void );
+void DebugMon_Handler            ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void HFLASHC_Handler             ( void );
+void PDCA_0_Handler              ( void );
+void PDCA_1_Handler              ( void );
+void PDCA_2_Handler              ( void );
+void PDCA_3_Handler              ( void );
+void PDCA_4_Handler              ( void );
+void PDCA_5_Handler              ( void );
+void PDCA_6_Handler              ( void );
+void PDCA_7_Handler              ( void );
+void PDCA_8_Handler              ( void );
+void PDCA_9_Handler              ( void );
+void PDCA_10_Handler             ( void );
+void PDCA_11_Handler             ( void );
+void PDCA_12_Handler             ( void );
+void PDCA_13_Handler             ( void );
+void PDCA_14_Handler             ( void );
+void PDCA_15_Handler             ( void );
+void CRCCU_Handler               ( void );
+void USBC_Handler                ( void );
+void PEVC_0_Handler              ( void );
+void PEVC_1_Handler              ( void );
+void PM_Handler                  ( void );
+void SCIF_Handler                ( void );
+void FREQM_Handler               ( void );
+void GPIO_0_Handler              ( void );
+void GPIO_1_Handler              ( void );
+void GPIO_2_Handler              ( void );
+void GPIO_3_Handler              ( void );
+void GPIO_4_Handler              ( void );
+void GPIO_5_Handler              ( void );
+void GPIO_6_Handler              ( void );
+void GPIO_7_Handler              ( void );
+void GPIO_8_Handler              ( void );
+void GPIO_9_Handler              ( void );
+void GPIO_10_Handler             ( void );
+void GPIO_11_Handler             ( void );
+void BPM_Handler                 ( void );
+void BSCIF_Handler               ( void );
+void AST_0_Handler               ( void );
+void AST_1_Handler               ( void );
+void AST_2_Handler               ( void );
+void AST_3_Handler               ( void );
+void AST_4_Handler               ( void );
+void WDT_Handler                 ( void );
+void EIC_0_Handler               ( void );
+void EIC_1_Handler               ( void );
+void EIC_2_Handler               ( void );
+void EIC_3_Handler               ( void );
+void EIC_4_Handler               ( void );
+void EIC_5_Handler               ( void );
+void EIC_6_Handler               ( void );
+void EIC_7_Handler               ( void );
+void IISC_Handler                ( void );
+void SPI_Handler                 ( void );
+void TC0_0_Handler               ( void );
+void TC0_1_Handler               ( void );
+void TC0_2_Handler               ( void );
+void TC1_0_Handler               ( void );
+void TC1_1_Handler               ( void );
+void TC1_2_Handler               ( void );
+void TWIM0_Handler               ( void );
+void TWIS0_Handler               ( void );
+void TWIM1_Handler               ( void );
+void TWIS1_Handler               ( void );
+void USART0_Handler              ( void );
+void USART1_Handler              ( void );
+void USART2_Handler              ( void );
+void USART3_Handler              ( void );
+void ADCIFE_Handler              ( void );
+void DACC_Handler                ( void );
+void ACIFC_Handler               ( void );
+void ABDACB_Handler              ( void );
+void TRNG_Handler                ( void );
+void PARC_Handler                ( void );
+void CATB_Handler                ( void );
+void TWIM2_Handler               ( void );
+void TWIM3_Handler               ( void );
+
+/*
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
+ */
+
+#define LITTLE_ENDIAN          1        
+#define __BB_PRESENT           0         /*!< BIT_BANDING present or not */
+#define __CLKGATE_PRESENT      1         /*!< CLKGATE present or not */
+#define __CM4_REV              1         /*!< Core revision r0p1 */
+#define __DEBUG_LVL            3         /*!< Full debug plus DWT data matching */
+#define __FPU_PRESENT          0         /*!< FPU present or not */
+#define __JTAG_PRESENT         1         /*!< JTAG present or not */
+#define __MPU_PRESENT          1         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       4         /*!< Number of bits used for Priority Levels */
+#define __TRACE_LVL            1         /*!< Standard trace: ITM and DWT triggers and counters, but no ETM */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+#define __WIC_PRESENT          0         /*!< WIC present or not */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm4.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_sam4l.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAM4LS4B */
+/* ************************************************************************** */
+/** \defgroup SAM4LS4B_api Peripheral Software API */
+/*@{*/
+
+#include "component/abdacb.h"
+#include "component/acifc.h"
+#include "component/adcife.h"
+#include "component/ast.h"
+#include "component/bpm.h"
+#include "component/bscif.h"
+#include "component/catb.h"
+#include "component/chipid.h"
+#include "component/crccu.h"
+#include "component/dacc.h"
+#include "component/eic.h"
+#include "component/flashcalw.h"
+#include "component/freqm.h"
+#include "component/gloc.h"
+#include "component/gpio.h"
+#include "component/hcache.h"
+#include "component/hmatrixb.h"
+#include "component/iisc.h"
+#include "component/parc.h"
+#include "component/pdca.h"
+#include "component/pevc.h"
+#include "component/picouart.h"
+#include "component/pm.h"
+#include "component/scif.h"
+#include "component/smap.h"
+#include "component/spi.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twim.h"
+#include "component/twis.h"
+#include "component/usart.h"
+#include "component/usbc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAM4LS4B */
+/* ************************************************************************** */
+/** \defgroup SAM4LS4B_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/abdacb.h"
+#include "instance/acifc.h"
+#include "instance/adcife.h"
+#include "instance/ast.h"
+#include "instance/bpm.h"
+#include "instance/bscif.h"
+#include "instance/catb.h"
+#include "instance/chipid.h"
+#include "instance/crccu.h"
+#include "instance/dacc.h"
+#include "instance/eic.h"
+#include "instance/hflashc.h"
+#include "instance/freqm.h"
+#include "instance/gloc.h"
+#include "instance/gpio.h"
+#include "instance/hcache.h"
+#include "instance/hmatrix.h"
+#include "instance/iisc.h"
+#include "instance/parc.h"
+#include "instance/pdca.h"
+#include "instance/pevc.h"
+#include "instance/picouart.h"
+#include "instance/pm.h"
+#include "instance/scif.h"
+#include "instance/smap.h"
+#include "instance/spi.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/trng.h"
+#include "instance/twim0.h"
+#include "instance/twim1.h"
+#include "instance/twim2.h"
+#include "instance/twim3.h"
+#include "instance/twis0.h"
+#include "instance/twis1.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usart3.h"
+#include "instance/usbc.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAM4LS4B */
+/* ************************************************************************** */
+/** \defgroup SAM4LS4B_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HTOP0 bridge
+#define ID_IISC           0 /**< \brief Inter-IC Sound (I2S) Controller (IISC) */
+#define ID_SPI            1 /**< \brief Serial Peripheral Interface (SPI) */
+#define ID_TC0            2 /**< \brief Timer/Counter 0 (TC0) */
+#define ID_TC1            3 /**< \brief Timer/Counter 1 (TC1) */
+#define ID_TWIM0          4 /**< \brief Two-wire Master Interface 0 (TWIM0) */
+#define ID_TWIS0          5 /**< \brief Two-wire Slave Interface 0 (TWIS0) */
+#define ID_TWIM1          6 /**< \brief Two-wire Master Interface 1 (TWIM1) */
+#define ID_TWIS1          7 /**< \brief Two-wire Slave Interface 1 (TWIS1) */
+#define ID_USART0         8 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+#define ID_USART1         9 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+#define ID_USART2        10 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+#define ID_USART3        11 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+#define ID_ADCIFE        12 /**< \brief ADC controller interface (ADCIFE) */
+#define ID_DACC          13 /**< \brief DAC Controller (DACC) */
+#define ID_ACIFC         14 /**< \brief Analog Comparator Interface (ACIFC) */
+#define ID_GLOC          15 /**< \brief Glue Logic Controller (GLOC) */
+#define ID_ABDACB        16 /**< \brief Audio Bitstream DAC (ABDACB) */
+#define ID_TRNG          17 /**< \brief True Random Number Generator (TRNG) */
+#define ID_PARC          18 /**< \brief Parallel Capture (PARC) */
+#define ID_CATB          19 /**< \brief Capacitive Touch Module B (CATB) */
+#define ID_TWIM2         21 /**< \brief Two-wire Master Interface 2 (TWIM2) */
+#define ID_TWIM3         22 /**< \brief Two-wire Master Interface 3 (TWIM3) */
+
+// Peripheral instances on HTOP1 bridge
+#define ID_HFLASHC       32 /**< \brief Flash Controller (HFLASHC) */
+#define ID_HCACHE        33 /**< \brief Cortex M I&D Cache Controller (HCACHE) */
+#define ID_HMATRIX       34 /**< \brief HSB Matrix (HMATRIX) */
+#define ID_PDCA          35 /**< \brief Peripheral DMA Controller (PDCA) */
+#define ID_SMAP          36 /**< \brief System Manager Access Port (SMAP) */
+#define ID_CRCCU         37 /**< \brief CRC Calculation Unit (CRCCU) */
+#define ID_USBC          38 /**< \brief USB 2.0 Interface (USBC) */
+#define ID_PEVC          39 /**< \brief Peripheral Event Controller (PEVC) */
+
+// Peripheral instances on HTOP2 bridge
+#define ID_PM            64 /**< \brief Power Manager (PM) */
+#define ID_CHIPID        65 /**< \brief Chip ID Registers (CHIPID) */
+#define ID_SCIF          66 /**< \brief System Control Interface (SCIF) */
+#define ID_FREQM         67 /**< \brief Frequency Meter (FREQM) */
+#define ID_GPIO          68 /**< \brief General-Purpose Input/Output Controller (GPIO) */
+
+// Peripheral instances on HTOP3 bridge
+#define ID_BPM           96 /**< \brief Backup Power Manager (BPM) */
+#define ID_BSCIF         97 /**< \brief Backup System Control Interface (BSCIF) */
+#define ID_AST           98 /**< \brief Asynchronous Timer (AST) */
+#define ID_WDT           99 /**< \brief Watchdog Timer (WDT) */
+#define ID_EIC          100 /**< \brief External Interrupt Controller (EIC) */
+#define ID_PICOUART     101 /**< \brief Pico UART (PICOUART) */
+
+#define ID_PERIPH_COUNT 102 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAM4LS4B */
+/* ************************************************************************** */
+/** \defgroup SAM4LS4B_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define ABDACB                        (0x40064000) /**< \brief (ABDACB) APB Base Address */
+#define ACIFC                         (0x40040000) /**< \brief (ACIFC) APB Base Address */
+#define ADCIFE                        (0x40038000) /**< \brief (ADCIFE) APB Base Address */
+#define AST                           (0x400F0800) /**< \brief (AST) APB Base Address */
+#define BPM                           (0x400F0000) /**< \brief (BPM) APB Base Address */
+#define BSCIF                         (0x400F0400) /**< \brief (BSCIF) APB Base Address */
+#define CATB                          (0x40070000) /**< \brief (CATB) APB Base Address */
+#define CHIPID                        (0x400E0400) /**< \brief (CHIPID) APB Base Address */
+#define CRCCU                         (0x400A4000) /**< \brief (CRCCU) APB Base Address */
+#define DACC                          (0x4003C000) /**< \brief (DACC) APB Base Address */
+#define EIC                           (0x400F1000) /**< \brief (EIC) APB Base Address */
+#define HFLASHC                       (0x400A0000) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000) /**< \brief (HFLASHC) USER Base Address */
+#define FREQM                         (0x400E0C00) /**< \brief (FREQM) APB Base Address */
+#define GLOC                          (0x40060000) /**< \brief (GLOC) APB Base Address */
+#define GPIO                          (0x400E1000) /**< \brief (GPIO) APB Base Address */
+#define HCACHE                        (0x400A0400) /**< \brief (HCACHE) APB Base Address */
+#define HMATRIX                       (0x400A1000) /**< \brief (HMATRIX) APB Base Address */
+#define IISC                          (0x40004000) /**< \brief (IISC) APB Base Address */
+#define PARC                          (0x4006C000) /**< \brief (PARC) APB Base Address */
+#define PDCA                          (0x400A2000) /**< \brief (PDCA) APB Base Address */
+#define PEVC                          (0x400A6000) /**< \brief (PEVC) APB Base Address */
+#define PICOUART                      (0x400F1400) /**< \brief (PICOUART) APB Base Address */
+#define PM                            (0x400E0000) /**< \brief (PM) APB Base Address */
+#define SCIF                          (0x400E0800) /**< \brief (SCIF) APB Base Address */
+#define SMAP                          (0x400A3000) /**< \brief (SMAP) APB Base Address */
+#define SPI                           (0x40008000) /**< \brief (SPI) APB Base Address */
+#define TC0                           (0x40010000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x40014000) /**< \brief (TC1) APB Base Address */
+#define TRNG                          (0x40068000) /**< \brief (TRNG) APB Base Address */
+#define TWIM0                         (0x40018000) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1                         (0x4001C000) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2                         (0x40078000) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3                         (0x4007C000) /**< \brief (TWIM3) APB Base Address */
+#define TWIS0                         (0x40018400) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1                         (0x4001C400) /**< \brief (TWIS1) APB Base Address */
+#define USART0                        (0x40024000) /**< \brief (USART0) APB Base Address */
+#define USART1                        (0x40028000) /**< \brief (USART1) APB Base Address */
+#define USART2                        (0x4002C000) /**< \brief (USART2) APB Base Address */
+#define USART3                        (0x40030000) /**< \brief (USART3) APB Base Address */
+#define USBC                          (0x400A5000) /**< \brief (USBC) APB Base Address */
+#define WDT                           (0x400F0C00) /**< \brief (WDT) APB Base Address */
+#else
+#define ABDACB            ((Abdacb   *)0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_ADDR                   (0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_INST_NUM   1                          /**< \brief (ABDACB) Number of instances */
+#define ABDACB_INSTS      { ABDACB }                 /**< \brief (ABDACB) Instances List */
+
+#define ACIFC             ((Acifc    *)0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_ADDR                    (0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_INST_NUM    1                          /**< \brief (ACIFC) Number of instances */
+#define ACIFC_INSTS       { ACIFC }                  /**< \brief (ACIFC) Instances List */
+
+#define ADCIFE            ((Adcife   *)0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_ADDR                   (0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_INST_NUM   1                          /**< \brief (ADCIFE) Number of instances */
+#define ADCIFE_INSTS      { ADCIFE }                 /**< \brief (ADCIFE) Instances List */
+
+#define AST               ((Ast      *)0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_ADDR                      (0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_INST_NUM      1                          /**< \brief (AST) Number of instances */
+#define AST_INSTS         { AST }                    /**< \brief (AST) Instances List */
+
+#define BPM               ((Bpm      *)0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_ADDR                      (0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_INST_NUM      1                          /**< \brief (BPM) Number of instances */
+#define BPM_INSTS         { BPM }                    /**< \brief (BPM) Instances List */
+
+#define BSCIF             ((Bscif    *)0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_ADDR                    (0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_INST_NUM    1                          /**< \brief (BSCIF) Number of instances */
+#define BSCIF_INSTS       { BSCIF }                  /**< \brief (BSCIF) Instances List */
+
+#define CATB              ((Catb     *)0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_ADDR                     (0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_INST_NUM     1                          /**< \brief (CATB) Number of instances */
+#define CATB_INSTS        { CATB }                   /**< \brief (CATB) Instances List */
+
+#define CHIPID            ((Chipid   *)0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_ADDR                   (0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_INST_NUM   1                          /**< \brief (CHIPID) Number of instances */
+#define CHIPID_INSTS      { CHIPID }                 /**< \brief (CHIPID) Instances List */
+
+#define CRCCU             ((Crccu    *)0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_ADDR                    (0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_INST_NUM    1                          /**< \brief (CRCCU) Number of instances */
+#define CRCCU_INSTS       { CRCCU }                  /**< \brief (CRCCU) Instances List */
+
+#define DACC              ((Dacc     *)0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_ADDR                     (0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_INST_NUM     1                          /**< \brief (DACC) Number of instances */
+#define DACC_INSTS        { DACC }                   /**< \brief (DACC) Instances List */
+
+#define EIC               ((Eic      *)0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_ADDR                      (0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define HFLASHC           ((Flashcalw *)0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_ADDR                  (0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_FROW_ADDR             (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define HFLASHC_USER_ADDR             (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define FLASHCALW_INST_NUM 1                          /**< \brief (FLASHCALW) Number of instances */
+#define FLASHCALW_INSTS   { HFLASHC }                /**< \brief (FLASHCALW) Instances List */
+
+#define FREQM             ((Freqm    *)0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_ADDR                    (0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_INST_NUM    1                          /**< \brief (FREQM) Number of instances */
+#define FREQM_INSTS       { FREQM }                  /**< \brief (FREQM) Instances List */
+
+#define GLOC              ((Gloc     *)0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_ADDR                     (0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_INST_NUM     1                          /**< \brief (GLOC) Number of instances */
+#define GLOC_INSTS        { GLOC }                   /**< \brief (GLOC) Instances List */
+
+#define GPIO              ((Gpio     *)0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_ADDR                     (0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_INST_NUM     1                          /**< \brief (GPIO) Number of instances */
+#define GPIO_INSTS        { GPIO }                   /**< \brief (GPIO) Instances List */
+
+#define HCACHE            ((Hcache   *)0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_ADDR                   (0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_INST_NUM   1                          /**< \brief (HCACHE) Number of instances */
+#define HCACHE_INSTS      { HCACHE }                 /**< \brief (HCACHE) Instances List */
+
+#define HMATRIX           ((Hmatrixb *)0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIX_ADDR                  (0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIXB_INST_NUM 1                          /**< \brief (HMATRIXB) Number of instances */
+#define HMATRIXB_INSTS    { HMATRIX }                /**< \brief (HMATRIXB) Instances List */
+
+#define IISC              ((Iisc     *)0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_ADDR                     (0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_INST_NUM     1                          /**< \brief (IISC) Number of instances */
+#define IISC_INSTS        { IISC }                   /**< \brief (IISC) Instances List */
+
+#define PARC              ((Parc     *)0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_ADDR                     (0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_INST_NUM     1                          /**< \brief (PARC) Number of instances */
+#define PARC_INSTS        { PARC }                   /**< \brief (PARC) Instances List */
+
+#define PDCA              ((Pdca     *)0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_ADDR                     (0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_INST_NUM     1                          /**< \brief (PDCA) Number of instances */
+#define PDCA_INSTS        { PDCA }                   /**< \brief (PDCA) Instances List */
+
+#define PEVC              ((Pevc     *)0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_ADDR                     (0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_INST_NUM     1                          /**< \brief (PEVC) Number of instances */
+#define PEVC_INSTS        { PEVC }                   /**< \brief (PEVC) Instances List */
+
+#define PICOUART          ((Picouart *)0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_ADDR                 (0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_INST_NUM 1                          /**< \brief (PICOUART) Number of instances */
+#define PICOUART_INSTS    { PICOUART }               /**< \brief (PICOUART) Instances List */
+
+#define PM                ((Pm       *)0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_ADDR                       (0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define SCIF              ((Scif     *)0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_ADDR                     (0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_INST_NUM     1                          /**< \brief (SCIF) Number of instances */
+#define SCIF_INSTS        { SCIF }                   /**< \brief (SCIF) Instances List */
+
+#define SMAP              ((Smap     *)0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_ADDR                     (0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_INST_NUM     1                          /**< \brief (SMAP) Number of instances */
+#define SMAP_INSTS        { SMAP }                   /**< \brief (SMAP) Instances List */
+
+#define SPI               ((Spi      *)0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_ADDR                      (0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_INST_NUM      1                          /**< \brief (SPI) Number of instances */
+#define SPI_INSTS         { SPI }                    /**< \brief (SPI) Instances List */
+
+#define TC0               ((Tc       *)0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC0_ADDR                      (0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC1_ADDR                      (0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC_INST_NUM       2                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1 }               /**< \brief (TC) Instances List */
+
+#define TRNG              ((Trng     *)0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_ADDR                     (0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_INST_NUM     1                          /**< \brief (TRNG) Number of instances */
+#define TRNG_INSTS        { TRNG }                   /**< \brief (TRNG) Instances List */
+
+#define TWIM0             ((Twim     *)0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM0_ADDR                    (0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1             ((Twim     *)0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM1_ADDR                    (0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2             ((Twim     *)0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM2_ADDR                    (0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3             ((Twim     *)0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM3_ADDR                    (0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM_INST_NUM     4                          /**< \brief (TWIM) Number of instances */
+#define TWIM_INSTS        { TWIM0, TWIM1, TWIM2, TWIM3 } /**< \brief (TWIM) Instances List */
+
+#define TWIS0             ((Twis     *)0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS0_ADDR                    (0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1             ((Twis     *)0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS1_ADDR                    (0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS_INST_NUM     2                          /**< \brief (TWIS) Number of instances */
+#define TWIS_INSTS        { TWIS0, TWIS1 }           /**< \brief (TWIS) Instances List */
+
+#define USART0            ((Usart    *)0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART0_ADDR                   (0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART1            ((Usart    *)0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART1_ADDR                   (0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART2            ((Usart    *)0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART2_ADDR                   (0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART3            ((Usart    *)0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART3_ADDR                   (0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART_INST_NUM    4                          /**< \brief (USART) Number of instances */
+#define USART_INSTS       { USART0, USART1, USART2, USART3 } /**< \brief (USART) Instances List */
+
+#define USBC              ((Usbc     *)0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_ADDR                     (0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_INST_NUM     1                          /**< \brief (USBC) Number of instances */
+#define USBC_INSTS        { USBC }                   /**< \brief (USBC) Instances List */
+
+#define WDT               ((Wdt      *)0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_ADDR                      (0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  GPIO DEFINITIONS FOR SAM4LS4B */
+/* ************************************************************************** */
+/** \defgroup SAM4LS4B_gpio GPIO Definitions */
+/*@{*/
+
+#include "pio/sam4ls4b.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  ADDITIONAL DEFINITIONS FOR COMPATIBILITY */
+/* ************************************************************************** */
+/** \addtogroup SAM4LS4B_compat Definitions */
+/*@{*/
+// These defines are used to keep compatibility with existing 
+// sam/drivers/usart implementation from SAM3/4 products with SAM4L product.
+#define US_MR_USART_MODE_HW_HANDSHAKING  US_MR_USART_MODE_HARDWARE
+#define US_MR_USART_MODE_IS07816_T_0     US_MR_USART_MODE_ISO7816_T0
+#define US_MR_USART_MODE_IS07816_T_1     US_MR_USART_MODE_ISO7816_T1
+#define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
+#define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
+#define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_8_BIT      US_MR_CHRL_8
+#define US_MR_PAR_NO          US_MR_PAR_NONE
+#define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI
+#define US_IF                 US_IFR
+#define US_WPSR_WPVS          US_WPSR_WPV_1
+
+#define USBC_UPCFG0_PBK_Msk   (0x1u << USBC_UPCFG0_PBK_Pos)
+
+// These defines for homogeneity with other SAM header files.
+#define CHIP_FREQ_FWS_0       (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 */
+#define CHIP_FREQ_FWS_1       (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 */
+// WARNING NOTE: these are preliminary values.
+#define CHIP_FREQ_FLASH_HSEN_FWS_0 (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 and the FLASH HS mode is enabled */
+#define CHIP_FREQ_FLASH_HSEN_FWS_1 (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 and the FLASH HS mode is enabled */
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/tc implementation from SAM3/4 products with SAM4L product. 
+#define TC_CMR_LDRA_RISING    TC_CMR_LDRA_POS_EDGE_TIOA
+#define TC_CMR_LDRB_FALLING   TC_CMR_LDRB_NEG_EDGE_TIOA
+#define TC_CMR_ETRGEDG_FALLING TC_CMR_ETRGEDG_NEG_EDGE
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/spi implementation from SAM3/4 products with SAM4L product. 
+#define SPI_CSR_BITS_8_BIT    SPI_CSR_BITS_8_BPT
+#define SPI_WPCR_SPIWPKEY_VALUE SPI_WPCR_WPKEY_VALUE
+#define SPI_WPCR_SPIWPEN      SPI_WPCR_WPEN
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/crccu implementation from SAM3/4 products with SAM4L product. 
+#define CRCCU_DMA_EN          CRCCU_DMAEN
+#define CRCCU_DMA_DIS         CRCCU_DMADIS
+#define CRCCU_DMA_SR          CRCCU_DMASR
+#define CRCCU_DMA_IER         CRCCU_DMAIER
+#define CRCCU_DMA_IDR         CRCCU_DMAIDR
+#define CRCCU_DMA_IMR         CRCCU_DMAIMR
+#define CRCCU_DMA_ISR         CRCCU_DMAISR
+#define CRCCU_DMA_EN_DMAEN    CRCCU_DMAEN_DMAEN
+#define CRCCU_DMA_DIS_DMADIS  CRCCU_DMADIS_DMADIS
+#define CRCCU_DMA_SR_DMASR    CRCCU_DMASR_DMASR
+#define CRCCU_DMA_IER_DMAIER  CRCCU_DMAIER_DMAIER
+#define CRCCU_DMA_IDR_DMAIDR  CRCCU_DMAIDR_DMAIDR
+#define CRCCU_DMA_IMR_DMAIMR  CRCCU_DMAIMR_DMAIMR
+#define CRCCU_DMA_ISR_DMAISR  CRCCU_DMAISR_DMAISR
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAM4LS4B */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL(0x00040000) /* 256 kB */
+#define FLASH_PAGE_SIZE       512
+#define FLASH_NB_OF_PAGES     512
+#define FLASH_USER_PAGE_SIZE  512
+#define HRAMC0_SIZE           _UL(0x00008000) /* 32 kB */
+#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+
+#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+
+#define DSU_DID_RESETVALUE    _UL(0xAB0A09E0)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAM4LS4B */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAM4LS4B_H */

--- a/asf/sam/include/sam4l/sam4ls4b.h
+++ b/asf/sam/include/sam4l/sam4ls4b.h
@@ -62,15 +62,15 @@ typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volati
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
 #if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#define _U_(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
 #if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#define _U_(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 
@@ -857,23 +857,23 @@ void TWIM3_Handler               ( void );
 /**  MEMORY MAPPING DEFINITIONS FOR SAM4LS4B */
 /* ************************************************************************** */
 
-#define FLASH_SIZE            _UL(0x00040000) /* 256 kB */
+#define FLASH_SIZE            _UL_(0x00040000) /* 256 kB */
 #define FLASH_PAGE_SIZE       512
 #define FLASH_NB_OF_PAGES     512
 #define FLASH_USER_PAGE_SIZE  512
-#define HRAMC0_SIZE           _UL(0x00008000) /* 32 kB */
-#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+#define HRAMC0_SIZE           _UL_(0x00008000) /* 32 kB */
+#define HRAMC1_SIZE           _UL_(0x00000800) /* 2 kB */
 
-#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
-#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
-#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
-#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
-#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
-#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
-#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
-#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL_(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL_(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL_(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL_(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL_(0x400F0000) /**< HTOP3 base address */
 
-#define DSU_DID_RESETVALUE    _UL(0xAB0A09E0)
+#define DSU_DID_RESETVALUE    _UL_(0xAB0A09E0)
 
 /* ************************************************************************** */
 /**  ELECTRICAL DEFINITIONS FOR SAM4LS4B */

--- a/asf/sam/include/sam4l/sam4ls4c.h
+++ b/asf/sam/include/sam4l/sam4ls4c.h
@@ -62,15 +62,15 @@ typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volati
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
 #if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#define _U_(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
 #if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#define _U_(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 
@@ -857,23 +857,23 @@ void TWIM3_Handler               ( void );
 /**  MEMORY MAPPING DEFINITIONS FOR SAM4LS4C */
 /* ************************************************************************** */
 
-#define FLASH_SIZE            _UL(0x00040000) /* 256 kB */
+#define FLASH_SIZE            _UL_(0x00040000) /* 256 kB */
 #define FLASH_PAGE_SIZE       512
 #define FLASH_NB_OF_PAGES     512
 #define FLASH_USER_PAGE_SIZE  512
-#define HRAMC0_SIZE           _UL(0x00008000) /* 32 kB */
-#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+#define HRAMC0_SIZE           _UL_(0x00008000) /* 32 kB */
+#define HRAMC1_SIZE           _UL_(0x00000800) /* 2 kB */
 
-#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
-#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
-#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
-#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
-#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
-#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
-#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
-#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL_(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL_(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL_(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL_(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL_(0x400F0000) /**< HTOP3 base address */
 
-#define DSU_DID_RESETVALUE    _UL(0xAB0A09E0)
+#define DSU_DID_RESETVALUE    _UL_(0xAB0A09E0)
 
 /* ************************************************************************** */
 /**  ELECTRICAL DEFINITIONS FOR SAM4LS4C */

--- a/asf/sam/include/sam4l/sam4ls4c.h
+++ b/asf/sam/include/sam4l/sam4ls4c.h
@@ -1,0 +1,889 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAM4LS4C
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LS4C_
+#define _SAM4LS4C_
+
+/**
+ * \ingroup SAM4L_definitions
+ * \addtogroup SAM4LS4C_definitions SAM4LS4C definitions
+ * This file defines all structures and symbols for SAM4LS4C:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#if !defined(_UL)
+#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#endif
+#else
+#if !defined(_UL)
+#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif
+#endif
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAM4LS4C */
+/* ************************************************************************** */
+/** \defgroup SAM4LS4C_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M4 Processor Exceptions Numbers ******************************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn           = -13,/**<  3 Cortex-M4 Hard Fault Interrupt        */
+  MemoryManagement_IRQn    = -12,/**<  4 Cortex-M4 Memory Management Interrupt */
+  BusFault_IRQn            = -11,/**<  5 Cortex-M4 Bus Fault Interrupt         */
+  UsageFault_IRQn          = -10,/**<  6 Cortex-M4 Usage Fault Interrupt       */
+  SVCall_IRQn              = -5, /**< 11 Cortex-M4 SV Call Interrupt           */
+  DebugMonitor_IRQn        = -4, /**< 12 Cortex-M4 Debug Monitor Interrupt     */
+  PendSV_IRQn              = -2, /**< 14 Cortex-M4 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 Cortex-M4 System Tick Interrupt       */
+  /******  SAM4LS4C-specific Interrupt Numbers ***********************/
+  HFLASHC_IRQn             =  0, /**<  0 SAM4LS4C Flash Controller (HFLASHC) */
+  PDCA_0_IRQn              =  1, /**<  1 SAM4LS4C Peripheral DMA Controller (PDCA): PDCA_0 */
+  PDCA_1_IRQn              =  2, /**<  2 SAM4LS4C Peripheral DMA Controller (PDCA): PDCA_1 */
+  PDCA_2_IRQn              =  3, /**<  3 SAM4LS4C Peripheral DMA Controller (PDCA): PDCA_2 */
+  PDCA_3_IRQn              =  4, /**<  4 SAM4LS4C Peripheral DMA Controller (PDCA): PDCA_3 */
+  PDCA_4_IRQn              =  5, /**<  5 SAM4LS4C Peripheral DMA Controller (PDCA): PDCA_4 */
+  PDCA_5_IRQn              =  6, /**<  6 SAM4LS4C Peripheral DMA Controller (PDCA): PDCA_5 */
+  PDCA_6_IRQn              =  7, /**<  7 SAM4LS4C Peripheral DMA Controller (PDCA): PDCA_6 */
+  PDCA_7_IRQn              =  8, /**<  8 SAM4LS4C Peripheral DMA Controller (PDCA): PDCA_7 */
+  PDCA_8_IRQn              =  9, /**<  9 SAM4LS4C Peripheral DMA Controller (PDCA): PDCA_8 */
+  PDCA_9_IRQn              = 10, /**< 10 SAM4LS4C Peripheral DMA Controller (PDCA): PDCA_9 */
+  PDCA_10_IRQn             = 11, /**< 11 SAM4LS4C Peripheral DMA Controller (PDCA): PDCA_10 */
+  PDCA_11_IRQn             = 12, /**< 12 SAM4LS4C Peripheral DMA Controller (PDCA): PDCA_11 */
+  PDCA_12_IRQn             = 13, /**< 13 SAM4LS4C Peripheral DMA Controller (PDCA): PDCA_12 */
+  PDCA_13_IRQn             = 14, /**< 14 SAM4LS4C Peripheral DMA Controller (PDCA): PDCA_13 */
+  PDCA_14_IRQn             = 15, /**< 15 SAM4LS4C Peripheral DMA Controller (PDCA): PDCA_14 */
+  PDCA_15_IRQn             = 16, /**< 16 SAM4LS4C Peripheral DMA Controller (PDCA): PDCA_15 */
+  CRCCU_IRQn               = 17, /**< 17 SAM4LS4C CRC Calculation Unit (CRCCU) */
+  USBC_IRQn                = 18, /**< 18 SAM4LS4C USB 2.0 Interface (USBC) */
+  PEVC_0_IRQn              = 19, /**< 19 SAM4LS4C Peripheral Event Controller (PEVC): PEVC_TR */
+  PEVC_1_IRQn              = 20, /**< 20 SAM4LS4C Peripheral Event Controller (PEVC): PEVC_OV */
+  PM_IRQn                  = 22, /**< 22 SAM4LS4C Power Manager (PM) */
+  SCIF_IRQn                = 23, /**< 23 SAM4LS4C System Control Interface (SCIF) */
+  FREQM_IRQn               = 24, /**< 24 SAM4LS4C Frequency Meter (FREQM) */
+  GPIO_0_IRQn              = 25, /**< 25 SAM4LS4C General-Purpose Input/Output Controller (GPIO): GPIO_0 */
+  GPIO_1_IRQn              = 26, /**< 26 SAM4LS4C General-Purpose Input/Output Controller (GPIO): GPIO_1 */
+  GPIO_2_IRQn              = 27, /**< 27 SAM4LS4C General-Purpose Input/Output Controller (GPIO): GPIO_2 */
+  GPIO_3_IRQn              = 28, /**< 28 SAM4LS4C General-Purpose Input/Output Controller (GPIO): GPIO_3 */
+  GPIO_4_IRQn              = 29, /**< 29 SAM4LS4C General-Purpose Input/Output Controller (GPIO): GPIO_4 */
+  GPIO_5_IRQn              = 30, /**< 30 SAM4LS4C General-Purpose Input/Output Controller (GPIO): GPIO_5 */
+  GPIO_6_IRQn              = 31, /**< 31 SAM4LS4C General-Purpose Input/Output Controller (GPIO): GPIO_6 */
+  GPIO_7_IRQn              = 32, /**< 32 SAM4LS4C General-Purpose Input/Output Controller (GPIO): GPIO_7 */
+  GPIO_8_IRQn              = 33, /**< 33 SAM4LS4C General-Purpose Input/Output Controller (GPIO): GPIO_8 */
+  GPIO_9_IRQn              = 34, /**< 34 SAM4LS4C General-Purpose Input/Output Controller (GPIO): GPIO_9 */
+  GPIO_10_IRQn             = 35, /**< 35 SAM4LS4C General-Purpose Input/Output Controller (GPIO): GPIO_10 */
+  GPIO_11_IRQn             = 36, /**< 36 SAM4LS4C General-Purpose Input/Output Controller (GPIO): GPIO_11 */
+  BPM_IRQn                 = 37, /**< 37 SAM4LS4C Backup Power Manager (BPM) */
+  BSCIF_IRQn               = 38, /**< 38 SAM4LS4C Backup System Control Interface (BSCIF) */
+  AST_0_IRQn               = 39, /**< 39 SAM4LS4C Asynchronous Timer (AST): AST_ALARM */
+  AST_1_IRQn               = 40, /**< 40 SAM4LS4C Asynchronous Timer (AST): AST_PER */
+  AST_2_IRQn               = 41, /**< 41 SAM4LS4C Asynchronous Timer (AST): AST_OVF */
+  AST_3_IRQn               = 42, /**< 42 SAM4LS4C Asynchronous Timer (AST): AST_READY */
+  AST_4_IRQn               = 43, /**< 43 SAM4LS4C Asynchronous Timer (AST): AST_CLKREADY */
+  WDT_IRQn                 = 44, /**< 44 SAM4LS4C Watchdog Timer (WDT) */
+  EIC_0_IRQn               = 45, /**< 45 SAM4LS4C External Interrupt Controller (EIC): EIC_1 */
+  EIC_1_IRQn               = 46, /**< 46 SAM4LS4C External Interrupt Controller (EIC): EIC_2 */
+  EIC_2_IRQn               = 47, /**< 47 SAM4LS4C External Interrupt Controller (EIC): EIC_3 */
+  EIC_3_IRQn               = 48, /**< 48 SAM4LS4C External Interrupt Controller (EIC): EIC_4 */
+  EIC_4_IRQn               = 49, /**< 49 SAM4LS4C External Interrupt Controller (EIC): EIC_5 */
+  EIC_5_IRQn               = 50, /**< 50 SAM4LS4C External Interrupt Controller (EIC): EIC_6 */
+  EIC_6_IRQn               = 51, /**< 51 SAM4LS4C External Interrupt Controller (EIC): EIC_7 */
+  EIC_7_IRQn               = 52, /**< 52 SAM4LS4C External Interrupt Controller (EIC): EIC_8 */
+  IISC_IRQn                = 53, /**< 53 SAM4LS4C Inter-IC Sound (I2S) Controller (IISC) */
+  SPI_IRQn                 = 54, /**< 54 SAM4LS4C Serial Peripheral Interface (SPI) */
+  TC0_0_IRQn               = 55, /**< 55 SAM4LS4C Timer/Counter 0 (TC0): TC00 */
+  TC0_1_IRQn               = 56, /**< 56 SAM4LS4C Timer/Counter 0 (TC0): TC01 */
+  TC0_2_IRQn               = 57, /**< 57 SAM4LS4C Timer/Counter 0 (TC0): TC02 */
+  TC1_0_IRQn               = 58, /**< 58 SAM4LS4C Timer/Counter 1 (TC1): TC10 */
+  TC1_1_IRQn               = 59, /**< 59 SAM4LS4C Timer/Counter 1 (TC1): TC11 */
+  TC1_2_IRQn               = 60, /**< 60 SAM4LS4C Timer/Counter 1 (TC1): TC12 */
+  TWIM0_IRQn               = 61, /**< 61 SAM4LS4C Two-wire Master Interface 0 (TWIM0) */
+  TWIS0_IRQn               = 62, /**< 62 SAM4LS4C Two-wire Slave Interface 0 (TWIS0) */
+  TWIM1_IRQn               = 63, /**< 63 SAM4LS4C Two-wire Master Interface 1 (TWIM1) */
+  TWIS1_IRQn               = 64, /**< 64 SAM4LS4C Two-wire Slave Interface 1 (TWIS1) */
+  USART0_IRQn              = 65, /**< 65 SAM4LS4C Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+  USART1_IRQn              = 66, /**< 66 SAM4LS4C Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+  USART2_IRQn              = 67, /**< 67 SAM4LS4C Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+  USART3_IRQn              = 68, /**< 68 SAM4LS4C Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+  ADCIFE_IRQn              = 69, /**< 69 SAM4LS4C ADC controller interface (ADCIFE) */
+  DACC_IRQn                = 70, /**< 70 SAM4LS4C DAC Controller (DACC) */
+  ACIFC_IRQn               = 71, /**< 71 SAM4LS4C Analog Comparator Interface (ACIFC) */
+  ABDACB_IRQn              = 72, /**< 72 SAM4LS4C Audio Bitstream DAC (ABDACB) */
+  TRNG_IRQn                = 73, /**< 73 SAM4LS4C True Random Number Generator (TRNG) */
+  PARC_IRQn                = 74, /**< 74 SAM4LS4C Parallel Capture (PARC) */
+  CATB_IRQn                = 75, /**< 75 SAM4LS4C Capacitive Touch Module B (CATB) */
+  TWIM2_IRQn               = 77, /**< 77 SAM4LS4C Two-wire Master Interface 2 (TWIM2) */
+  TWIM3_IRQn               = 78, /**< 78 SAM4LS4C Two-wire Master Interface 3 (TWIM3) */
+
+  PERIPH_COUNT_IRQn        = 80  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNMI_Handler;
+  void* pfnHardFault_Handler;
+  void* pfnMemManage_Handler;
+  void* pfnBusFault_Handler;
+  void* pfnUsageFault_Handler;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVC_Handler;
+  void* pfnDebugMon_Handler;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnHFLASHC_Handler;               /*  0 Flash Controller */
+  void* pfnPDCA_0_Handler;                /*  1 Peripheral DMA Controller IRQ 0 */
+  void* pfnPDCA_1_Handler;                /*  2 Peripheral DMA Controller IRQ 1 */
+  void* pfnPDCA_2_Handler;                /*  3 Peripheral DMA Controller IRQ 2 */
+  void* pfnPDCA_3_Handler;                /*  4 Peripheral DMA Controller IRQ 3 */
+  void* pfnPDCA_4_Handler;                /*  5 Peripheral DMA Controller IRQ 4 */
+  void* pfnPDCA_5_Handler;                /*  6 Peripheral DMA Controller IRQ 5 */
+  void* pfnPDCA_6_Handler;                /*  7 Peripheral DMA Controller IRQ 6 */
+  void* pfnPDCA_7_Handler;                /*  8 Peripheral DMA Controller IRQ 7 */
+  void* pfnPDCA_8_Handler;                /*  9 Peripheral DMA Controller IRQ 8 */
+  void* pfnPDCA_9_Handler;                /* 10 Peripheral DMA Controller IRQ 9 */
+  void* pfnPDCA_10_Handler;               /* 11 Peripheral DMA Controller IRQ 10 */
+  void* pfnPDCA_11_Handler;               /* 12 Peripheral DMA Controller IRQ 11 */
+  void* pfnPDCA_12_Handler;               /* 13 Peripheral DMA Controller IRQ 12 */
+  void* pfnPDCA_13_Handler;               /* 14 Peripheral DMA Controller IRQ 13 */
+  void* pfnPDCA_14_Handler;               /* 15 Peripheral DMA Controller IRQ 14 */
+  void* pfnPDCA_15_Handler;               /* 16 Peripheral DMA Controller IRQ 15 */
+  void* pfnCRCCU_Handler;                 /* 17 CRC Calculation Unit */
+  void* pfnUSBC_Handler;                  /* 18 USB 2.0 Interface */
+  void* pfnPEVC_0_Handler;                /* 19 Peripheral Event Controller IRQ 0 */
+  void* pfnPEVC_1_Handler;                /* 20 Peripheral Event Controller IRQ 1 */
+  void* pvReserved21;
+  void* pfnPM_Handler;                    /* 22 Power Manager */
+  void* pfnSCIF_Handler;                  /* 23 System Control Interface */
+  void* pfnFREQM_Handler;                 /* 24 Frequency Meter */
+  void* pfnGPIO_0_Handler;                /* 25 General-Purpose Input/Output Controller IRQ 0 */
+  void* pfnGPIO_1_Handler;                /* 26 General-Purpose Input/Output Controller IRQ 1 */
+  void* pfnGPIO_2_Handler;                /* 27 General-Purpose Input/Output Controller IRQ 2 */
+  void* pfnGPIO_3_Handler;                /* 28 General-Purpose Input/Output Controller IRQ 3 */
+  void* pfnGPIO_4_Handler;                /* 29 General-Purpose Input/Output Controller IRQ 4 */
+  void* pfnGPIO_5_Handler;                /* 30 General-Purpose Input/Output Controller IRQ 5 */
+  void* pfnGPIO_6_Handler;                /* 31 General-Purpose Input/Output Controller IRQ 6 */
+  void* pfnGPIO_7_Handler;                /* 32 General-Purpose Input/Output Controller IRQ 7 */
+  void* pfnGPIO_8_Handler;                /* 33 General-Purpose Input/Output Controller IRQ 8 */
+  void* pfnGPIO_9_Handler;                /* 34 General-Purpose Input/Output Controller IRQ 9 */
+  void* pfnGPIO_10_Handler;               /* 35 General-Purpose Input/Output Controller IRQ 10 */
+  void* pfnGPIO_11_Handler;               /* 36 General-Purpose Input/Output Controller IRQ 11 */
+  void* pfnBPM_Handler;                   /* 37 Backup Power Manager */
+  void* pfnBSCIF_Handler;                 /* 38 Backup System Control Interface */
+  void* pfnAST_0_Handler;                 /* 39 Asynchronous Timer IRQ 0 */
+  void* pfnAST_1_Handler;                 /* 40 Asynchronous Timer IRQ 1 */
+  void* pfnAST_2_Handler;                 /* 41 Asynchronous Timer IRQ 2 */
+  void* pfnAST_3_Handler;                 /* 42 Asynchronous Timer IRQ 3 */
+  void* pfnAST_4_Handler;                 /* 43 Asynchronous Timer IRQ 4 */
+  void* pfnWDT_Handler;                   /* 44 Watchdog Timer */
+  void* pfnEIC_0_Handler;                 /* 45 External Interrupt Controller IRQ 0 */
+  void* pfnEIC_1_Handler;                 /* 46 External Interrupt Controller IRQ 1 */
+  void* pfnEIC_2_Handler;                 /* 47 External Interrupt Controller IRQ 2 */
+  void* pfnEIC_3_Handler;                 /* 48 External Interrupt Controller IRQ 3 */
+  void* pfnEIC_4_Handler;                 /* 49 External Interrupt Controller IRQ 4 */
+  void* pfnEIC_5_Handler;                 /* 50 External Interrupt Controller IRQ 5 */
+  void* pfnEIC_6_Handler;                 /* 51 External Interrupt Controller IRQ 6 */
+  void* pfnEIC_7_Handler;                 /* 52 External Interrupt Controller IRQ 7 */
+  void* pfnIISC_Handler;                  /* 53 Inter-IC Sound (I2S) Controller */
+  void* pfnSPI_Handler;                   /* 54 Serial Peripheral Interface */
+  void* pfnTC0_0_Handler;                 /* 55 Timer/Counter 0 IRQ 0 */
+  void* pfnTC0_1_Handler;                 /* 56 Timer/Counter 0 IRQ 1 */
+  void* pfnTC0_2_Handler;                 /* 57 Timer/Counter 0 IRQ 2 */
+  void* pfnTC1_0_Handler;                 /* 58 Timer/Counter 1 IRQ 0 */
+  void* pfnTC1_1_Handler;                 /* 59 Timer/Counter 1 IRQ 1 */
+  void* pfnTC1_2_Handler;                 /* 60 Timer/Counter 1 IRQ 2 */
+  void* pfnTWIM0_Handler;                 /* 61 Two-wire Master Interface 0 */
+  void* pfnTWIS0_Handler;                 /* 62 Two-wire Slave Interface 0 */
+  void* pfnTWIM1_Handler;                 /* 63 Two-wire Master Interface 1 */
+  void* pfnTWIS1_Handler;                 /* 64 Two-wire Slave Interface 1 */
+  void* pfnUSART0_Handler;                /* 65 Universal Synchronous Asynchronous Receiver Transmitter 0 */
+  void* pfnUSART1_Handler;                /* 66 Universal Synchronous Asynchronous Receiver Transmitter 1 */
+  void* pfnUSART2_Handler;                /* 67 Universal Synchronous Asynchronous Receiver Transmitter 2 */
+  void* pfnUSART3_Handler;                /* 68 Universal Synchronous Asynchronous Receiver Transmitter 3 */
+  void* pfnADCIFE_Handler;                /* 69 ADC controller interface */
+  void* pfnDACC_Handler;                  /* 70 DAC Controller */
+  void* pfnACIFC_Handler;                 /* 71 Analog Comparator Interface */
+  void* pfnABDACB_Handler;                /* 72 Audio Bitstream DAC */
+  void* pfnTRNG_Handler;                  /* 73 True Random Number Generator */
+  void* pfnPARC_Handler;                  /* 74 Parallel Capture */
+  void* pfnCATB_Handler;                  /* 75 Capacitive Touch Module B */
+  void* pvReserved76;
+  void* pfnTWIM2_Handler;                 /* 77 Two-wire Master Interface 2 */
+  void* pfnTWIM3_Handler;                 /* 78 Two-wire Master Interface 3 */
+  void* pvReserved79;
+} DeviceVectors;
+
+/* Cortex-M4 processor handlers */
+void Reset_Handler               ( void );
+void NMI_Handler                 ( void );
+void HardFault_Handler           ( void );
+void MemManage_Handler           ( void );
+void BusFault_Handler            ( void );
+void UsageFault_Handler          ( void );
+void SVC_Handler                 ( void );
+void DebugMon_Handler            ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void HFLASHC_Handler             ( void );
+void PDCA_0_Handler              ( void );
+void PDCA_1_Handler              ( void );
+void PDCA_2_Handler              ( void );
+void PDCA_3_Handler              ( void );
+void PDCA_4_Handler              ( void );
+void PDCA_5_Handler              ( void );
+void PDCA_6_Handler              ( void );
+void PDCA_7_Handler              ( void );
+void PDCA_8_Handler              ( void );
+void PDCA_9_Handler              ( void );
+void PDCA_10_Handler             ( void );
+void PDCA_11_Handler             ( void );
+void PDCA_12_Handler             ( void );
+void PDCA_13_Handler             ( void );
+void PDCA_14_Handler             ( void );
+void PDCA_15_Handler             ( void );
+void CRCCU_Handler               ( void );
+void USBC_Handler                ( void );
+void PEVC_0_Handler              ( void );
+void PEVC_1_Handler              ( void );
+void PM_Handler                  ( void );
+void SCIF_Handler                ( void );
+void FREQM_Handler               ( void );
+void GPIO_0_Handler              ( void );
+void GPIO_1_Handler              ( void );
+void GPIO_2_Handler              ( void );
+void GPIO_3_Handler              ( void );
+void GPIO_4_Handler              ( void );
+void GPIO_5_Handler              ( void );
+void GPIO_6_Handler              ( void );
+void GPIO_7_Handler              ( void );
+void GPIO_8_Handler              ( void );
+void GPIO_9_Handler              ( void );
+void GPIO_10_Handler             ( void );
+void GPIO_11_Handler             ( void );
+void BPM_Handler                 ( void );
+void BSCIF_Handler               ( void );
+void AST_0_Handler               ( void );
+void AST_1_Handler               ( void );
+void AST_2_Handler               ( void );
+void AST_3_Handler               ( void );
+void AST_4_Handler               ( void );
+void WDT_Handler                 ( void );
+void EIC_0_Handler               ( void );
+void EIC_1_Handler               ( void );
+void EIC_2_Handler               ( void );
+void EIC_3_Handler               ( void );
+void EIC_4_Handler               ( void );
+void EIC_5_Handler               ( void );
+void EIC_6_Handler               ( void );
+void EIC_7_Handler               ( void );
+void IISC_Handler                ( void );
+void SPI_Handler                 ( void );
+void TC0_0_Handler               ( void );
+void TC0_1_Handler               ( void );
+void TC0_2_Handler               ( void );
+void TC1_0_Handler               ( void );
+void TC1_1_Handler               ( void );
+void TC1_2_Handler               ( void );
+void TWIM0_Handler               ( void );
+void TWIS0_Handler               ( void );
+void TWIM1_Handler               ( void );
+void TWIS1_Handler               ( void );
+void USART0_Handler              ( void );
+void USART1_Handler              ( void );
+void USART2_Handler              ( void );
+void USART3_Handler              ( void );
+void ADCIFE_Handler              ( void );
+void DACC_Handler                ( void );
+void ACIFC_Handler               ( void );
+void ABDACB_Handler              ( void );
+void TRNG_Handler                ( void );
+void PARC_Handler                ( void );
+void CATB_Handler                ( void );
+void TWIM2_Handler               ( void );
+void TWIM3_Handler               ( void );
+
+/*
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
+ */
+
+#define LITTLE_ENDIAN          1        
+#define __BB_PRESENT           0         /*!< BIT_BANDING present or not */
+#define __CLKGATE_PRESENT      1         /*!< CLKGATE present or not */
+#define __CM4_REV              1         /*!< Core revision r0p1 */
+#define __DEBUG_LVL            3         /*!< Full debug plus DWT data matching */
+#define __FPU_PRESENT          0         /*!< FPU present or not */
+#define __JTAG_PRESENT         1         /*!< JTAG present or not */
+#define __MPU_PRESENT          1         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       4         /*!< Number of bits used for Priority Levels */
+#define __TRACE_LVL            1         /*!< Standard trace: ITM and DWT triggers and counters, but no ETM */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+#define __WIC_PRESENT          0         /*!< WIC present or not */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm4.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_sam4l.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAM4LS4C */
+/* ************************************************************************** */
+/** \defgroup SAM4LS4C_api Peripheral Software API */
+/*@{*/
+
+#include "component/abdacb.h"
+#include "component/acifc.h"
+#include "component/adcife.h"
+#include "component/ast.h"
+#include "component/bpm.h"
+#include "component/bscif.h"
+#include "component/catb.h"
+#include "component/chipid.h"
+#include "component/crccu.h"
+#include "component/dacc.h"
+#include "component/eic.h"
+#include "component/flashcalw.h"
+#include "component/freqm.h"
+#include "component/gloc.h"
+#include "component/gpio.h"
+#include "component/hcache.h"
+#include "component/hmatrixb.h"
+#include "component/iisc.h"
+#include "component/parc.h"
+#include "component/pdca.h"
+#include "component/pevc.h"
+#include "component/picouart.h"
+#include "component/pm.h"
+#include "component/scif.h"
+#include "component/smap.h"
+#include "component/spi.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twim.h"
+#include "component/twis.h"
+#include "component/usart.h"
+#include "component/usbc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAM4LS4C */
+/* ************************************************************************** */
+/** \defgroup SAM4LS4C_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/abdacb.h"
+#include "instance/acifc.h"
+#include "instance/adcife.h"
+#include "instance/ast.h"
+#include "instance/bpm.h"
+#include "instance/bscif.h"
+#include "instance/catb.h"
+#include "instance/chipid.h"
+#include "instance/crccu.h"
+#include "instance/dacc.h"
+#include "instance/eic.h"
+#include "instance/hflashc.h"
+#include "instance/freqm.h"
+#include "instance/gloc.h"
+#include "instance/gpio.h"
+#include "instance/hcache.h"
+#include "instance/hmatrix.h"
+#include "instance/iisc.h"
+#include "instance/parc.h"
+#include "instance/pdca.h"
+#include "instance/pevc.h"
+#include "instance/picouart.h"
+#include "instance/pm.h"
+#include "instance/scif.h"
+#include "instance/smap.h"
+#include "instance/spi.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/trng.h"
+#include "instance/twim0.h"
+#include "instance/twim1.h"
+#include "instance/twim2.h"
+#include "instance/twim3.h"
+#include "instance/twis0.h"
+#include "instance/twis1.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usart3.h"
+#include "instance/usbc.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAM4LS4C */
+/* ************************************************************************** */
+/** \defgroup SAM4LS4C_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HTOP0 bridge
+#define ID_IISC           0 /**< \brief Inter-IC Sound (I2S) Controller (IISC) */
+#define ID_SPI            1 /**< \brief Serial Peripheral Interface (SPI) */
+#define ID_TC0            2 /**< \brief Timer/Counter 0 (TC0) */
+#define ID_TC1            3 /**< \brief Timer/Counter 1 (TC1) */
+#define ID_TWIM0          4 /**< \brief Two-wire Master Interface 0 (TWIM0) */
+#define ID_TWIS0          5 /**< \brief Two-wire Slave Interface 0 (TWIS0) */
+#define ID_TWIM1          6 /**< \brief Two-wire Master Interface 1 (TWIM1) */
+#define ID_TWIS1          7 /**< \brief Two-wire Slave Interface 1 (TWIS1) */
+#define ID_USART0         8 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+#define ID_USART1         9 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+#define ID_USART2        10 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+#define ID_USART3        11 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+#define ID_ADCIFE        12 /**< \brief ADC controller interface (ADCIFE) */
+#define ID_DACC          13 /**< \brief DAC Controller (DACC) */
+#define ID_ACIFC         14 /**< \brief Analog Comparator Interface (ACIFC) */
+#define ID_GLOC          15 /**< \brief Glue Logic Controller (GLOC) */
+#define ID_ABDACB        16 /**< \brief Audio Bitstream DAC (ABDACB) */
+#define ID_TRNG          17 /**< \brief True Random Number Generator (TRNG) */
+#define ID_PARC          18 /**< \brief Parallel Capture (PARC) */
+#define ID_CATB          19 /**< \brief Capacitive Touch Module B (CATB) */
+#define ID_TWIM2         21 /**< \brief Two-wire Master Interface 2 (TWIM2) */
+#define ID_TWIM3         22 /**< \brief Two-wire Master Interface 3 (TWIM3) */
+
+// Peripheral instances on HTOP1 bridge
+#define ID_HFLASHC       32 /**< \brief Flash Controller (HFLASHC) */
+#define ID_HCACHE        33 /**< \brief Cortex M I&D Cache Controller (HCACHE) */
+#define ID_HMATRIX       34 /**< \brief HSB Matrix (HMATRIX) */
+#define ID_PDCA          35 /**< \brief Peripheral DMA Controller (PDCA) */
+#define ID_SMAP          36 /**< \brief System Manager Access Port (SMAP) */
+#define ID_CRCCU         37 /**< \brief CRC Calculation Unit (CRCCU) */
+#define ID_USBC          38 /**< \brief USB 2.0 Interface (USBC) */
+#define ID_PEVC          39 /**< \brief Peripheral Event Controller (PEVC) */
+
+// Peripheral instances on HTOP2 bridge
+#define ID_PM            64 /**< \brief Power Manager (PM) */
+#define ID_CHIPID        65 /**< \brief Chip ID Registers (CHIPID) */
+#define ID_SCIF          66 /**< \brief System Control Interface (SCIF) */
+#define ID_FREQM         67 /**< \brief Frequency Meter (FREQM) */
+#define ID_GPIO          68 /**< \brief General-Purpose Input/Output Controller (GPIO) */
+
+// Peripheral instances on HTOP3 bridge
+#define ID_BPM           96 /**< \brief Backup Power Manager (BPM) */
+#define ID_BSCIF         97 /**< \brief Backup System Control Interface (BSCIF) */
+#define ID_AST           98 /**< \brief Asynchronous Timer (AST) */
+#define ID_WDT           99 /**< \brief Watchdog Timer (WDT) */
+#define ID_EIC          100 /**< \brief External Interrupt Controller (EIC) */
+#define ID_PICOUART     101 /**< \brief Pico UART (PICOUART) */
+
+#define ID_PERIPH_COUNT 102 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAM4LS4C */
+/* ************************************************************************** */
+/** \defgroup SAM4LS4C_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define ABDACB                        (0x40064000) /**< \brief (ABDACB) APB Base Address */
+#define ACIFC                         (0x40040000) /**< \brief (ACIFC) APB Base Address */
+#define ADCIFE                        (0x40038000) /**< \brief (ADCIFE) APB Base Address */
+#define AST                           (0x400F0800) /**< \brief (AST) APB Base Address */
+#define BPM                           (0x400F0000) /**< \brief (BPM) APB Base Address */
+#define BSCIF                         (0x400F0400) /**< \brief (BSCIF) APB Base Address */
+#define CATB                          (0x40070000) /**< \brief (CATB) APB Base Address */
+#define CHIPID                        (0x400E0400) /**< \brief (CHIPID) APB Base Address */
+#define CRCCU                         (0x400A4000) /**< \brief (CRCCU) APB Base Address */
+#define DACC                          (0x4003C000) /**< \brief (DACC) APB Base Address */
+#define EIC                           (0x400F1000) /**< \brief (EIC) APB Base Address */
+#define HFLASHC                       (0x400A0000) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000) /**< \brief (HFLASHC) USER Base Address */
+#define FREQM                         (0x400E0C00) /**< \brief (FREQM) APB Base Address */
+#define GLOC                          (0x40060000) /**< \brief (GLOC) APB Base Address */
+#define GPIO                          (0x400E1000) /**< \brief (GPIO) APB Base Address */
+#define HCACHE                        (0x400A0400) /**< \brief (HCACHE) APB Base Address */
+#define HMATRIX                       (0x400A1000) /**< \brief (HMATRIX) APB Base Address */
+#define IISC                          (0x40004000) /**< \brief (IISC) APB Base Address */
+#define PARC                          (0x4006C000) /**< \brief (PARC) APB Base Address */
+#define PDCA                          (0x400A2000) /**< \brief (PDCA) APB Base Address */
+#define PEVC                          (0x400A6000) /**< \brief (PEVC) APB Base Address */
+#define PICOUART                      (0x400F1400) /**< \brief (PICOUART) APB Base Address */
+#define PM                            (0x400E0000) /**< \brief (PM) APB Base Address */
+#define SCIF                          (0x400E0800) /**< \brief (SCIF) APB Base Address */
+#define SMAP                          (0x400A3000) /**< \brief (SMAP) APB Base Address */
+#define SPI                           (0x40008000) /**< \brief (SPI) APB Base Address */
+#define TC0                           (0x40010000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x40014000) /**< \brief (TC1) APB Base Address */
+#define TRNG                          (0x40068000) /**< \brief (TRNG) APB Base Address */
+#define TWIM0                         (0x40018000) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1                         (0x4001C000) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2                         (0x40078000) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3                         (0x4007C000) /**< \brief (TWIM3) APB Base Address */
+#define TWIS0                         (0x40018400) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1                         (0x4001C400) /**< \brief (TWIS1) APB Base Address */
+#define USART0                        (0x40024000) /**< \brief (USART0) APB Base Address */
+#define USART1                        (0x40028000) /**< \brief (USART1) APB Base Address */
+#define USART2                        (0x4002C000) /**< \brief (USART2) APB Base Address */
+#define USART3                        (0x40030000) /**< \brief (USART3) APB Base Address */
+#define USBC                          (0x400A5000) /**< \brief (USBC) APB Base Address */
+#define WDT                           (0x400F0C00) /**< \brief (WDT) APB Base Address */
+#else
+#define ABDACB            ((Abdacb   *)0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_ADDR                   (0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_INST_NUM   1                          /**< \brief (ABDACB) Number of instances */
+#define ABDACB_INSTS      { ABDACB }                 /**< \brief (ABDACB) Instances List */
+
+#define ACIFC             ((Acifc    *)0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_ADDR                    (0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_INST_NUM    1                          /**< \brief (ACIFC) Number of instances */
+#define ACIFC_INSTS       { ACIFC }                  /**< \brief (ACIFC) Instances List */
+
+#define ADCIFE            ((Adcife   *)0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_ADDR                   (0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_INST_NUM   1                          /**< \brief (ADCIFE) Number of instances */
+#define ADCIFE_INSTS      { ADCIFE }                 /**< \brief (ADCIFE) Instances List */
+
+#define AST               ((Ast      *)0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_ADDR                      (0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_INST_NUM      1                          /**< \brief (AST) Number of instances */
+#define AST_INSTS         { AST }                    /**< \brief (AST) Instances List */
+
+#define BPM               ((Bpm      *)0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_ADDR                      (0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_INST_NUM      1                          /**< \brief (BPM) Number of instances */
+#define BPM_INSTS         { BPM }                    /**< \brief (BPM) Instances List */
+
+#define BSCIF             ((Bscif    *)0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_ADDR                    (0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_INST_NUM    1                          /**< \brief (BSCIF) Number of instances */
+#define BSCIF_INSTS       { BSCIF }                  /**< \brief (BSCIF) Instances List */
+
+#define CATB              ((Catb     *)0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_ADDR                     (0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_INST_NUM     1                          /**< \brief (CATB) Number of instances */
+#define CATB_INSTS        { CATB }                   /**< \brief (CATB) Instances List */
+
+#define CHIPID            ((Chipid   *)0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_ADDR                   (0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_INST_NUM   1                          /**< \brief (CHIPID) Number of instances */
+#define CHIPID_INSTS      { CHIPID }                 /**< \brief (CHIPID) Instances List */
+
+#define CRCCU             ((Crccu    *)0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_ADDR                    (0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_INST_NUM    1                          /**< \brief (CRCCU) Number of instances */
+#define CRCCU_INSTS       { CRCCU }                  /**< \brief (CRCCU) Instances List */
+
+#define DACC              ((Dacc     *)0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_ADDR                     (0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_INST_NUM     1                          /**< \brief (DACC) Number of instances */
+#define DACC_INSTS        { DACC }                   /**< \brief (DACC) Instances List */
+
+#define EIC               ((Eic      *)0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_ADDR                      (0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define HFLASHC           ((Flashcalw *)0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_ADDR                  (0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_FROW_ADDR             (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define HFLASHC_USER_ADDR             (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define FLASHCALW_INST_NUM 1                          /**< \brief (FLASHCALW) Number of instances */
+#define FLASHCALW_INSTS   { HFLASHC }                /**< \brief (FLASHCALW) Instances List */
+
+#define FREQM             ((Freqm    *)0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_ADDR                    (0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_INST_NUM    1                          /**< \brief (FREQM) Number of instances */
+#define FREQM_INSTS       { FREQM }                  /**< \brief (FREQM) Instances List */
+
+#define GLOC              ((Gloc     *)0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_ADDR                     (0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_INST_NUM     1                          /**< \brief (GLOC) Number of instances */
+#define GLOC_INSTS        { GLOC }                   /**< \brief (GLOC) Instances List */
+
+#define GPIO              ((Gpio     *)0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_ADDR                     (0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_INST_NUM     1                          /**< \brief (GPIO) Number of instances */
+#define GPIO_INSTS        { GPIO }                   /**< \brief (GPIO) Instances List */
+
+#define HCACHE            ((Hcache   *)0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_ADDR                   (0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_INST_NUM   1                          /**< \brief (HCACHE) Number of instances */
+#define HCACHE_INSTS      { HCACHE }                 /**< \brief (HCACHE) Instances List */
+
+#define HMATRIX           ((Hmatrixb *)0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIX_ADDR                  (0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIXB_INST_NUM 1                          /**< \brief (HMATRIXB) Number of instances */
+#define HMATRIXB_INSTS    { HMATRIX }                /**< \brief (HMATRIXB) Instances List */
+
+#define IISC              ((Iisc     *)0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_ADDR                     (0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_INST_NUM     1                          /**< \brief (IISC) Number of instances */
+#define IISC_INSTS        { IISC }                   /**< \brief (IISC) Instances List */
+
+#define PARC              ((Parc     *)0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_ADDR                     (0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_INST_NUM     1                          /**< \brief (PARC) Number of instances */
+#define PARC_INSTS        { PARC }                   /**< \brief (PARC) Instances List */
+
+#define PDCA              ((Pdca     *)0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_ADDR                     (0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_INST_NUM     1                          /**< \brief (PDCA) Number of instances */
+#define PDCA_INSTS        { PDCA }                   /**< \brief (PDCA) Instances List */
+
+#define PEVC              ((Pevc     *)0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_ADDR                     (0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_INST_NUM     1                          /**< \brief (PEVC) Number of instances */
+#define PEVC_INSTS        { PEVC }                   /**< \brief (PEVC) Instances List */
+
+#define PICOUART          ((Picouart *)0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_ADDR                 (0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_INST_NUM 1                          /**< \brief (PICOUART) Number of instances */
+#define PICOUART_INSTS    { PICOUART }               /**< \brief (PICOUART) Instances List */
+
+#define PM                ((Pm       *)0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_ADDR                       (0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define SCIF              ((Scif     *)0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_ADDR                     (0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_INST_NUM     1                          /**< \brief (SCIF) Number of instances */
+#define SCIF_INSTS        { SCIF }                   /**< \brief (SCIF) Instances List */
+
+#define SMAP              ((Smap     *)0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_ADDR                     (0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_INST_NUM     1                          /**< \brief (SMAP) Number of instances */
+#define SMAP_INSTS        { SMAP }                   /**< \brief (SMAP) Instances List */
+
+#define SPI               ((Spi      *)0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_ADDR                      (0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_INST_NUM      1                          /**< \brief (SPI) Number of instances */
+#define SPI_INSTS         { SPI }                    /**< \brief (SPI) Instances List */
+
+#define TC0               ((Tc       *)0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC0_ADDR                      (0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC1_ADDR                      (0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC_INST_NUM       2                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1 }               /**< \brief (TC) Instances List */
+
+#define TRNG              ((Trng     *)0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_ADDR                     (0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_INST_NUM     1                          /**< \brief (TRNG) Number of instances */
+#define TRNG_INSTS        { TRNG }                   /**< \brief (TRNG) Instances List */
+
+#define TWIM0             ((Twim     *)0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM0_ADDR                    (0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1             ((Twim     *)0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM1_ADDR                    (0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2             ((Twim     *)0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM2_ADDR                    (0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3             ((Twim     *)0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM3_ADDR                    (0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM_INST_NUM     4                          /**< \brief (TWIM) Number of instances */
+#define TWIM_INSTS        { TWIM0, TWIM1, TWIM2, TWIM3 } /**< \brief (TWIM) Instances List */
+
+#define TWIS0             ((Twis     *)0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS0_ADDR                    (0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1             ((Twis     *)0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS1_ADDR                    (0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS_INST_NUM     2                          /**< \brief (TWIS) Number of instances */
+#define TWIS_INSTS        { TWIS0, TWIS1 }           /**< \brief (TWIS) Instances List */
+
+#define USART0            ((Usart    *)0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART0_ADDR                   (0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART1            ((Usart    *)0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART1_ADDR                   (0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART2            ((Usart    *)0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART2_ADDR                   (0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART3            ((Usart    *)0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART3_ADDR                   (0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART_INST_NUM    4                          /**< \brief (USART) Number of instances */
+#define USART_INSTS       { USART0, USART1, USART2, USART3 } /**< \brief (USART) Instances List */
+
+#define USBC              ((Usbc     *)0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_ADDR                     (0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_INST_NUM     1                          /**< \brief (USBC) Number of instances */
+#define USBC_INSTS        { USBC }                   /**< \brief (USBC) Instances List */
+
+#define WDT               ((Wdt      *)0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_ADDR                      (0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  GPIO DEFINITIONS FOR SAM4LS4C */
+/* ************************************************************************** */
+/** \defgroup SAM4LS4C_gpio GPIO Definitions */
+/*@{*/
+
+#include "pio/sam4ls4c.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  ADDITIONAL DEFINITIONS FOR COMPATIBILITY */
+/* ************************************************************************** */
+/** \addtogroup SAM4LS4C_compat Definitions */
+/*@{*/
+// These defines are used to keep compatibility with existing 
+// sam/drivers/usart implementation from SAM3/4 products with SAM4L product.
+#define US_MR_USART_MODE_HW_HANDSHAKING  US_MR_USART_MODE_HARDWARE
+#define US_MR_USART_MODE_IS07816_T_0     US_MR_USART_MODE_ISO7816_T0
+#define US_MR_USART_MODE_IS07816_T_1     US_MR_USART_MODE_ISO7816_T1
+#define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
+#define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
+#define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_8_BIT      US_MR_CHRL_8
+#define US_MR_PAR_NO          US_MR_PAR_NONE
+#define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI
+#define US_IF                 US_IFR
+#define US_WPSR_WPVS          US_WPSR_WPV_1
+
+#define USBC_UPCFG0_PBK_Msk   (0x1u << USBC_UPCFG0_PBK_Pos)
+
+// These defines for homogeneity with other SAM header files.
+#define CHIP_FREQ_FWS_0       (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 */
+#define CHIP_FREQ_FWS_1       (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 */
+// WARNING NOTE: these are preliminary values.
+#define CHIP_FREQ_FLASH_HSEN_FWS_0 (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 and the FLASH HS mode is enabled */
+#define CHIP_FREQ_FLASH_HSEN_FWS_1 (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 and the FLASH HS mode is enabled */
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/tc implementation from SAM3/4 products with SAM4L product. 
+#define TC_CMR_LDRA_RISING    TC_CMR_LDRA_POS_EDGE_TIOA
+#define TC_CMR_LDRB_FALLING   TC_CMR_LDRB_NEG_EDGE_TIOA
+#define TC_CMR_ETRGEDG_FALLING TC_CMR_ETRGEDG_NEG_EDGE
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/spi implementation from SAM3/4 products with SAM4L product. 
+#define SPI_CSR_BITS_8_BIT    SPI_CSR_BITS_8_BPT
+#define SPI_WPCR_SPIWPKEY_VALUE SPI_WPCR_WPKEY_VALUE
+#define SPI_WPCR_SPIWPEN      SPI_WPCR_WPEN
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/crccu implementation from SAM3/4 products with SAM4L product. 
+#define CRCCU_DMA_EN          CRCCU_DMAEN
+#define CRCCU_DMA_DIS         CRCCU_DMADIS
+#define CRCCU_DMA_SR          CRCCU_DMASR
+#define CRCCU_DMA_IER         CRCCU_DMAIER
+#define CRCCU_DMA_IDR         CRCCU_DMAIDR
+#define CRCCU_DMA_IMR         CRCCU_DMAIMR
+#define CRCCU_DMA_ISR         CRCCU_DMAISR
+#define CRCCU_DMA_EN_DMAEN    CRCCU_DMAEN_DMAEN
+#define CRCCU_DMA_DIS_DMADIS  CRCCU_DMADIS_DMADIS
+#define CRCCU_DMA_SR_DMASR    CRCCU_DMASR_DMASR
+#define CRCCU_DMA_IER_DMAIER  CRCCU_DMAIER_DMAIER
+#define CRCCU_DMA_IDR_DMAIDR  CRCCU_DMAIDR_DMAIDR
+#define CRCCU_DMA_IMR_DMAIMR  CRCCU_DMAIMR_DMAIMR
+#define CRCCU_DMA_ISR_DMAISR  CRCCU_DMAISR_DMAISR
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAM4LS4C */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL(0x00040000) /* 256 kB */
+#define FLASH_PAGE_SIZE       512
+#define FLASH_NB_OF_PAGES     512
+#define FLASH_USER_PAGE_SIZE  512
+#define HRAMC0_SIZE           _UL(0x00008000) /* 32 kB */
+#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+
+#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+
+#define DSU_DID_RESETVALUE    _UL(0xAB0A09E0)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAM4LS4C */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAM4LS4C_H */

--- a/asf/sam/include/sam4l/sam4ls8a.h
+++ b/asf/sam/include/sam4l/sam4ls8a.h
@@ -62,15 +62,15 @@ typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volati
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
 #if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#define _U_(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
 #if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#define _U_(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 
@@ -857,23 +857,23 @@ void TWIM3_Handler               ( void );
 /**  MEMORY MAPPING DEFINITIONS FOR SAM4LS8A */
 /* ************************************************************************** */
 
-#define FLASH_SIZE            _UL(0x00080000) /* 512 kB */
+#define FLASH_SIZE            _UL_(0x00080000) /* 512 kB */
 #define FLASH_PAGE_SIZE       512
 #define FLASH_NB_OF_PAGES     1024
 #define FLASH_USER_PAGE_SIZE  512
-#define HRAMC0_SIZE           _UL(0x00010000) /* 64 kB */
-#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+#define HRAMC0_SIZE           _UL_(0x00010000) /* 64 kB */
+#define HRAMC1_SIZE           _UL_(0x00000800) /* 2 kB */
 
-#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
-#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
-#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
-#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
-#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
-#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
-#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
-#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL_(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL_(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL_(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL_(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL_(0x400F0000) /**< HTOP3 base address */
 
-#define DSU_DID_RESETVALUE    _UL(0xAB0B0AE0)
+#define DSU_DID_RESETVALUE    _UL_(0xAB0B0AE0)
 
 /* ************************************************************************** */
 /**  ELECTRICAL DEFINITIONS FOR SAM4LS8A */

--- a/asf/sam/include/sam4l/sam4ls8a.h
+++ b/asf/sam/include/sam4l/sam4ls8a.h
@@ -1,0 +1,889 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAM4LS8A
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LS8A_
+#define _SAM4LS8A_
+
+/**
+ * \ingroup SAM4L_definitions
+ * \addtogroup SAM4LS8A_definitions SAM4LS8A definitions
+ * This file defines all structures and symbols for SAM4LS8A:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#if !defined(_UL)
+#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#endif
+#else
+#if !defined(_UL)
+#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif
+#endif
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAM4LS8A */
+/* ************************************************************************** */
+/** \defgroup SAM4LS8A_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M4 Processor Exceptions Numbers ******************************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn           = -13,/**<  3 Cortex-M4 Hard Fault Interrupt        */
+  MemoryManagement_IRQn    = -12,/**<  4 Cortex-M4 Memory Management Interrupt */
+  BusFault_IRQn            = -11,/**<  5 Cortex-M4 Bus Fault Interrupt         */
+  UsageFault_IRQn          = -10,/**<  6 Cortex-M4 Usage Fault Interrupt       */
+  SVCall_IRQn              = -5, /**< 11 Cortex-M4 SV Call Interrupt           */
+  DebugMonitor_IRQn        = -4, /**< 12 Cortex-M4 Debug Monitor Interrupt     */
+  PendSV_IRQn              = -2, /**< 14 Cortex-M4 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 Cortex-M4 System Tick Interrupt       */
+  /******  SAM4LS8A-specific Interrupt Numbers ***********************/
+  HFLASHC_IRQn             =  0, /**<  0 SAM4LS8A Flash Controller (HFLASHC) */
+  PDCA_0_IRQn              =  1, /**<  1 SAM4LS8A Peripheral DMA Controller (PDCA): PDCA_0 */
+  PDCA_1_IRQn              =  2, /**<  2 SAM4LS8A Peripheral DMA Controller (PDCA): PDCA_1 */
+  PDCA_2_IRQn              =  3, /**<  3 SAM4LS8A Peripheral DMA Controller (PDCA): PDCA_2 */
+  PDCA_3_IRQn              =  4, /**<  4 SAM4LS8A Peripheral DMA Controller (PDCA): PDCA_3 */
+  PDCA_4_IRQn              =  5, /**<  5 SAM4LS8A Peripheral DMA Controller (PDCA): PDCA_4 */
+  PDCA_5_IRQn              =  6, /**<  6 SAM4LS8A Peripheral DMA Controller (PDCA): PDCA_5 */
+  PDCA_6_IRQn              =  7, /**<  7 SAM4LS8A Peripheral DMA Controller (PDCA): PDCA_6 */
+  PDCA_7_IRQn              =  8, /**<  8 SAM4LS8A Peripheral DMA Controller (PDCA): PDCA_7 */
+  PDCA_8_IRQn              =  9, /**<  9 SAM4LS8A Peripheral DMA Controller (PDCA): PDCA_8 */
+  PDCA_9_IRQn              = 10, /**< 10 SAM4LS8A Peripheral DMA Controller (PDCA): PDCA_9 */
+  PDCA_10_IRQn             = 11, /**< 11 SAM4LS8A Peripheral DMA Controller (PDCA): PDCA_10 */
+  PDCA_11_IRQn             = 12, /**< 12 SAM4LS8A Peripheral DMA Controller (PDCA): PDCA_11 */
+  PDCA_12_IRQn             = 13, /**< 13 SAM4LS8A Peripheral DMA Controller (PDCA): PDCA_12 */
+  PDCA_13_IRQn             = 14, /**< 14 SAM4LS8A Peripheral DMA Controller (PDCA): PDCA_13 */
+  PDCA_14_IRQn             = 15, /**< 15 SAM4LS8A Peripheral DMA Controller (PDCA): PDCA_14 */
+  PDCA_15_IRQn             = 16, /**< 16 SAM4LS8A Peripheral DMA Controller (PDCA): PDCA_15 */
+  CRCCU_IRQn               = 17, /**< 17 SAM4LS8A CRC Calculation Unit (CRCCU) */
+  USBC_IRQn                = 18, /**< 18 SAM4LS8A USB 2.0 Interface (USBC) */
+  PEVC_0_IRQn              = 19, /**< 19 SAM4LS8A Peripheral Event Controller (PEVC): PEVC_TR */
+  PEVC_1_IRQn              = 20, /**< 20 SAM4LS8A Peripheral Event Controller (PEVC): PEVC_OV */
+  PM_IRQn                  = 22, /**< 22 SAM4LS8A Power Manager (PM) */
+  SCIF_IRQn                = 23, /**< 23 SAM4LS8A System Control Interface (SCIF) */
+  FREQM_IRQn               = 24, /**< 24 SAM4LS8A Frequency Meter (FREQM) */
+  GPIO_0_IRQn              = 25, /**< 25 SAM4LS8A General-Purpose Input/Output Controller (GPIO): GPIO_0 */
+  GPIO_1_IRQn              = 26, /**< 26 SAM4LS8A General-Purpose Input/Output Controller (GPIO): GPIO_1 */
+  GPIO_2_IRQn              = 27, /**< 27 SAM4LS8A General-Purpose Input/Output Controller (GPIO): GPIO_2 */
+  GPIO_3_IRQn              = 28, /**< 28 SAM4LS8A General-Purpose Input/Output Controller (GPIO): GPIO_3 */
+  GPIO_4_IRQn              = 29, /**< 29 SAM4LS8A General-Purpose Input/Output Controller (GPIO): GPIO_4 */
+  GPIO_5_IRQn              = 30, /**< 30 SAM4LS8A General-Purpose Input/Output Controller (GPIO): GPIO_5 */
+  GPIO_6_IRQn              = 31, /**< 31 SAM4LS8A General-Purpose Input/Output Controller (GPIO): GPIO_6 */
+  GPIO_7_IRQn              = 32, /**< 32 SAM4LS8A General-Purpose Input/Output Controller (GPIO): GPIO_7 */
+  GPIO_8_IRQn              = 33, /**< 33 SAM4LS8A General-Purpose Input/Output Controller (GPIO): GPIO_8 */
+  GPIO_9_IRQn              = 34, /**< 34 SAM4LS8A General-Purpose Input/Output Controller (GPIO): GPIO_9 */
+  GPIO_10_IRQn             = 35, /**< 35 SAM4LS8A General-Purpose Input/Output Controller (GPIO): GPIO_10 */
+  GPIO_11_IRQn             = 36, /**< 36 SAM4LS8A General-Purpose Input/Output Controller (GPIO): GPIO_11 */
+  BPM_IRQn                 = 37, /**< 37 SAM4LS8A Backup Power Manager (BPM) */
+  BSCIF_IRQn               = 38, /**< 38 SAM4LS8A Backup System Control Interface (BSCIF) */
+  AST_0_IRQn               = 39, /**< 39 SAM4LS8A Asynchronous Timer (AST): AST_ALARM */
+  AST_1_IRQn               = 40, /**< 40 SAM4LS8A Asynchronous Timer (AST): AST_PER */
+  AST_2_IRQn               = 41, /**< 41 SAM4LS8A Asynchronous Timer (AST): AST_OVF */
+  AST_3_IRQn               = 42, /**< 42 SAM4LS8A Asynchronous Timer (AST): AST_READY */
+  AST_4_IRQn               = 43, /**< 43 SAM4LS8A Asynchronous Timer (AST): AST_CLKREADY */
+  WDT_IRQn                 = 44, /**< 44 SAM4LS8A Watchdog Timer (WDT) */
+  EIC_0_IRQn               = 45, /**< 45 SAM4LS8A External Interrupt Controller (EIC): EIC_1 */
+  EIC_1_IRQn               = 46, /**< 46 SAM4LS8A External Interrupt Controller (EIC): EIC_2 */
+  EIC_2_IRQn               = 47, /**< 47 SAM4LS8A External Interrupt Controller (EIC): EIC_3 */
+  EIC_3_IRQn               = 48, /**< 48 SAM4LS8A External Interrupt Controller (EIC): EIC_4 */
+  EIC_4_IRQn               = 49, /**< 49 SAM4LS8A External Interrupt Controller (EIC): EIC_5 */
+  EIC_5_IRQn               = 50, /**< 50 SAM4LS8A External Interrupt Controller (EIC): EIC_6 */
+  EIC_6_IRQn               = 51, /**< 51 SAM4LS8A External Interrupt Controller (EIC): EIC_7 */
+  EIC_7_IRQn               = 52, /**< 52 SAM4LS8A External Interrupt Controller (EIC): EIC_8 */
+  IISC_IRQn                = 53, /**< 53 SAM4LS8A Inter-IC Sound (I2S) Controller (IISC) */
+  SPI_IRQn                 = 54, /**< 54 SAM4LS8A Serial Peripheral Interface (SPI) */
+  TC0_0_IRQn               = 55, /**< 55 SAM4LS8A Timer/Counter 0 (TC0): TC00 */
+  TC0_1_IRQn               = 56, /**< 56 SAM4LS8A Timer/Counter 0 (TC0): TC01 */
+  TC0_2_IRQn               = 57, /**< 57 SAM4LS8A Timer/Counter 0 (TC0): TC02 */
+  TC1_0_IRQn               = 58, /**< 58 SAM4LS8A Timer/Counter 1 (TC1): TC10 */
+  TC1_1_IRQn               = 59, /**< 59 SAM4LS8A Timer/Counter 1 (TC1): TC11 */
+  TC1_2_IRQn               = 60, /**< 60 SAM4LS8A Timer/Counter 1 (TC1): TC12 */
+  TWIM0_IRQn               = 61, /**< 61 SAM4LS8A Two-wire Master Interface 0 (TWIM0) */
+  TWIS0_IRQn               = 62, /**< 62 SAM4LS8A Two-wire Slave Interface 0 (TWIS0) */
+  TWIM1_IRQn               = 63, /**< 63 SAM4LS8A Two-wire Master Interface 1 (TWIM1) */
+  TWIS1_IRQn               = 64, /**< 64 SAM4LS8A Two-wire Slave Interface 1 (TWIS1) */
+  USART0_IRQn              = 65, /**< 65 SAM4LS8A Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+  USART1_IRQn              = 66, /**< 66 SAM4LS8A Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+  USART2_IRQn              = 67, /**< 67 SAM4LS8A Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+  USART3_IRQn              = 68, /**< 68 SAM4LS8A Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+  ADCIFE_IRQn              = 69, /**< 69 SAM4LS8A ADC controller interface (ADCIFE) */
+  DACC_IRQn                = 70, /**< 70 SAM4LS8A DAC Controller (DACC) */
+  ACIFC_IRQn               = 71, /**< 71 SAM4LS8A Analog Comparator Interface (ACIFC) */
+  ABDACB_IRQn              = 72, /**< 72 SAM4LS8A Audio Bitstream DAC (ABDACB) */
+  TRNG_IRQn                = 73, /**< 73 SAM4LS8A True Random Number Generator (TRNG) */
+  PARC_IRQn                = 74, /**< 74 SAM4LS8A Parallel Capture (PARC) */
+  CATB_IRQn                = 75, /**< 75 SAM4LS8A Capacitive Touch Module B (CATB) */
+  TWIM2_IRQn               = 77, /**< 77 SAM4LS8A Two-wire Master Interface 2 (TWIM2) */
+  TWIM3_IRQn               = 78, /**< 78 SAM4LS8A Two-wire Master Interface 3 (TWIM3) */
+
+  PERIPH_COUNT_IRQn        = 80  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNMI_Handler;
+  void* pfnHardFault_Handler;
+  void* pfnMemManage_Handler;
+  void* pfnBusFault_Handler;
+  void* pfnUsageFault_Handler;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVC_Handler;
+  void* pfnDebugMon_Handler;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnHFLASHC_Handler;               /*  0 Flash Controller */
+  void* pfnPDCA_0_Handler;                /*  1 Peripheral DMA Controller IRQ 0 */
+  void* pfnPDCA_1_Handler;                /*  2 Peripheral DMA Controller IRQ 1 */
+  void* pfnPDCA_2_Handler;                /*  3 Peripheral DMA Controller IRQ 2 */
+  void* pfnPDCA_3_Handler;                /*  4 Peripheral DMA Controller IRQ 3 */
+  void* pfnPDCA_4_Handler;                /*  5 Peripheral DMA Controller IRQ 4 */
+  void* pfnPDCA_5_Handler;                /*  6 Peripheral DMA Controller IRQ 5 */
+  void* pfnPDCA_6_Handler;                /*  7 Peripheral DMA Controller IRQ 6 */
+  void* pfnPDCA_7_Handler;                /*  8 Peripheral DMA Controller IRQ 7 */
+  void* pfnPDCA_8_Handler;                /*  9 Peripheral DMA Controller IRQ 8 */
+  void* pfnPDCA_9_Handler;                /* 10 Peripheral DMA Controller IRQ 9 */
+  void* pfnPDCA_10_Handler;               /* 11 Peripheral DMA Controller IRQ 10 */
+  void* pfnPDCA_11_Handler;               /* 12 Peripheral DMA Controller IRQ 11 */
+  void* pfnPDCA_12_Handler;               /* 13 Peripheral DMA Controller IRQ 12 */
+  void* pfnPDCA_13_Handler;               /* 14 Peripheral DMA Controller IRQ 13 */
+  void* pfnPDCA_14_Handler;               /* 15 Peripheral DMA Controller IRQ 14 */
+  void* pfnPDCA_15_Handler;               /* 16 Peripheral DMA Controller IRQ 15 */
+  void* pfnCRCCU_Handler;                 /* 17 CRC Calculation Unit */
+  void* pfnUSBC_Handler;                  /* 18 USB 2.0 Interface */
+  void* pfnPEVC_0_Handler;                /* 19 Peripheral Event Controller IRQ 0 */
+  void* pfnPEVC_1_Handler;                /* 20 Peripheral Event Controller IRQ 1 */
+  void* pvReserved21;
+  void* pfnPM_Handler;                    /* 22 Power Manager */
+  void* pfnSCIF_Handler;                  /* 23 System Control Interface */
+  void* pfnFREQM_Handler;                 /* 24 Frequency Meter */
+  void* pfnGPIO_0_Handler;                /* 25 General-Purpose Input/Output Controller IRQ 0 */
+  void* pfnGPIO_1_Handler;                /* 26 General-Purpose Input/Output Controller IRQ 1 */
+  void* pfnGPIO_2_Handler;                /* 27 General-Purpose Input/Output Controller IRQ 2 */
+  void* pfnGPIO_3_Handler;                /* 28 General-Purpose Input/Output Controller IRQ 3 */
+  void* pfnGPIO_4_Handler;                /* 29 General-Purpose Input/Output Controller IRQ 4 */
+  void* pfnGPIO_5_Handler;                /* 30 General-Purpose Input/Output Controller IRQ 5 */
+  void* pfnGPIO_6_Handler;                /* 31 General-Purpose Input/Output Controller IRQ 6 */
+  void* pfnGPIO_7_Handler;                /* 32 General-Purpose Input/Output Controller IRQ 7 */
+  void* pfnGPIO_8_Handler;                /* 33 General-Purpose Input/Output Controller IRQ 8 */
+  void* pfnGPIO_9_Handler;                /* 34 General-Purpose Input/Output Controller IRQ 9 */
+  void* pfnGPIO_10_Handler;               /* 35 General-Purpose Input/Output Controller IRQ 10 */
+  void* pfnGPIO_11_Handler;               /* 36 General-Purpose Input/Output Controller IRQ 11 */
+  void* pfnBPM_Handler;                   /* 37 Backup Power Manager */
+  void* pfnBSCIF_Handler;                 /* 38 Backup System Control Interface */
+  void* pfnAST_0_Handler;                 /* 39 Asynchronous Timer IRQ 0 */
+  void* pfnAST_1_Handler;                 /* 40 Asynchronous Timer IRQ 1 */
+  void* pfnAST_2_Handler;                 /* 41 Asynchronous Timer IRQ 2 */
+  void* pfnAST_3_Handler;                 /* 42 Asynchronous Timer IRQ 3 */
+  void* pfnAST_4_Handler;                 /* 43 Asynchronous Timer IRQ 4 */
+  void* pfnWDT_Handler;                   /* 44 Watchdog Timer */
+  void* pfnEIC_0_Handler;                 /* 45 External Interrupt Controller IRQ 0 */
+  void* pfnEIC_1_Handler;                 /* 46 External Interrupt Controller IRQ 1 */
+  void* pfnEIC_2_Handler;                 /* 47 External Interrupt Controller IRQ 2 */
+  void* pfnEIC_3_Handler;                 /* 48 External Interrupt Controller IRQ 3 */
+  void* pfnEIC_4_Handler;                 /* 49 External Interrupt Controller IRQ 4 */
+  void* pfnEIC_5_Handler;                 /* 50 External Interrupt Controller IRQ 5 */
+  void* pfnEIC_6_Handler;                 /* 51 External Interrupt Controller IRQ 6 */
+  void* pfnEIC_7_Handler;                 /* 52 External Interrupt Controller IRQ 7 */
+  void* pfnIISC_Handler;                  /* 53 Inter-IC Sound (I2S) Controller */
+  void* pfnSPI_Handler;                   /* 54 Serial Peripheral Interface */
+  void* pfnTC0_0_Handler;                 /* 55 Timer/Counter 0 IRQ 0 */
+  void* pfnTC0_1_Handler;                 /* 56 Timer/Counter 0 IRQ 1 */
+  void* pfnTC0_2_Handler;                 /* 57 Timer/Counter 0 IRQ 2 */
+  void* pfnTC1_0_Handler;                 /* 58 Timer/Counter 1 IRQ 0 */
+  void* pfnTC1_1_Handler;                 /* 59 Timer/Counter 1 IRQ 1 */
+  void* pfnTC1_2_Handler;                 /* 60 Timer/Counter 1 IRQ 2 */
+  void* pfnTWIM0_Handler;                 /* 61 Two-wire Master Interface 0 */
+  void* pfnTWIS0_Handler;                 /* 62 Two-wire Slave Interface 0 */
+  void* pfnTWIM1_Handler;                 /* 63 Two-wire Master Interface 1 */
+  void* pfnTWIS1_Handler;                 /* 64 Two-wire Slave Interface 1 */
+  void* pfnUSART0_Handler;                /* 65 Universal Synchronous Asynchronous Receiver Transmitter 0 */
+  void* pfnUSART1_Handler;                /* 66 Universal Synchronous Asynchronous Receiver Transmitter 1 */
+  void* pfnUSART2_Handler;                /* 67 Universal Synchronous Asynchronous Receiver Transmitter 2 */
+  void* pfnUSART3_Handler;                /* 68 Universal Synchronous Asynchronous Receiver Transmitter 3 */
+  void* pfnADCIFE_Handler;                /* 69 ADC controller interface */
+  void* pfnDACC_Handler;                  /* 70 DAC Controller */
+  void* pfnACIFC_Handler;                 /* 71 Analog Comparator Interface */
+  void* pfnABDACB_Handler;                /* 72 Audio Bitstream DAC */
+  void* pfnTRNG_Handler;                  /* 73 True Random Number Generator */
+  void* pfnPARC_Handler;                  /* 74 Parallel Capture */
+  void* pfnCATB_Handler;                  /* 75 Capacitive Touch Module B */
+  void* pvReserved76;
+  void* pfnTWIM2_Handler;                 /* 77 Two-wire Master Interface 2 */
+  void* pfnTWIM3_Handler;                 /* 78 Two-wire Master Interface 3 */
+  void* pvReserved79;
+} DeviceVectors;
+
+/* Cortex-M4 processor handlers */
+void Reset_Handler               ( void );
+void NMI_Handler                 ( void );
+void HardFault_Handler           ( void );
+void MemManage_Handler           ( void );
+void BusFault_Handler            ( void );
+void UsageFault_Handler          ( void );
+void SVC_Handler                 ( void );
+void DebugMon_Handler            ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void HFLASHC_Handler             ( void );
+void PDCA_0_Handler              ( void );
+void PDCA_1_Handler              ( void );
+void PDCA_2_Handler              ( void );
+void PDCA_3_Handler              ( void );
+void PDCA_4_Handler              ( void );
+void PDCA_5_Handler              ( void );
+void PDCA_6_Handler              ( void );
+void PDCA_7_Handler              ( void );
+void PDCA_8_Handler              ( void );
+void PDCA_9_Handler              ( void );
+void PDCA_10_Handler             ( void );
+void PDCA_11_Handler             ( void );
+void PDCA_12_Handler             ( void );
+void PDCA_13_Handler             ( void );
+void PDCA_14_Handler             ( void );
+void PDCA_15_Handler             ( void );
+void CRCCU_Handler               ( void );
+void USBC_Handler                ( void );
+void PEVC_0_Handler              ( void );
+void PEVC_1_Handler              ( void );
+void PM_Handler                  ( void );
+void SCIF_Handler                ( void );
+void FREQM_Handler               ( void );
+void GPIO_0_Handler              ( void );
+void GPIO_1_Handler              ( void );
+void GPIO_2_Handler              ( void );
+void GPIO_3_Handler              ( void );
+void GPIO_4_Handler              ( void );
+void GPIO_5_Handler              ( void );
+void GPIO_6_Handler              ( void );
+void GPIO_7_Handler              ( void );
+void GPIO_8_Handler              ( void );
+void GPIO_9_Handler              ( void );
+void GPIO_10_Handler             ( void );
+void GPIO_11_Handler             ( void );
+void BPM_Handler                 ( void );
+void BSCIF_Handler               ( void );
+void AST_0_Handler               ( void );
+void AST_1_Handler               ( void );
+void AST_2_Handler               ( void );
+void AST_3_Handler               ( void );
+void AST_4_Handler               ( void );
+void WDT_Handler                 ( void );
+void EIC_0_Handler               ( void );
+void EIC_1_Handler               ( void );
+void EIC_2_Handler               ( void );
+void EIC_3_Handler               ( void );
+void EIC_4_Handler               ( void );
+void EIC_5_Handler               ( void );
+void EIC_6_Handler               ( void );
+void EIC_7_Handler               ( void );
+void IISC_Handler                ( void );
+void SPI_Handler                 ( void );
+void TC0_0_Handler               ( void );
+void TC0_1_Handler               ( void );
+void TC0_2_Handler               ( void );
+void TC1_0_Handler               ( void );
+void TC1_1_Handler               ( void );
+void TC1_2_Handler               ( void );
+void TWIM0_Handler               ( void );
+void TWIS0_Handler               ( void );
+void TWIM1_Handler               ( void );
+void TWIS1_Handler               ( void );
+void USART0_Handler              ( void );
+void USART1_Handler              ( void );
+void USART2_Handler              ( void );
+void USART3_Handler              ( void );
+void ADCIFE_Handler              ( void );
+void DACC_Handler                ( void );
+void ACIFC_Handler               ( void );
+void ABDACB_Handler              ( void );
+void TRNG_Handler                ( void );
+void PARC_Handler                ( void );
+void CATB_Handler                ( void );
+void TWIM2_Handler               ( void );
+void TWIM3_Handler               ( void );
+
+/*
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
+ */
+
+#define LITTLE_ENDIAN          1        
+#define __BB_PRESENT           0         /*!< BIT_BANDING present or not */
+#define __CLKGATE_PRESENT      1         /*!< CLKGATE present or not */
+#define __CM4_REV              1         /*!< Core revision r0p1 */
+#define __DEBUG_LVL            3         /*!< Full debug plus DWT data matching */
+#define __FPU_PRESENT          0         /*!< FPU present or not */
+#define __JTAG_PRESENT         1         /*!< JTAG present or not */
+#define __MPU_PRESENT          1         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       4         /*!< Number of bits used for Priority Levels */
+#define __TRACE_LVL            1         /*!< Standard trace: ITM and DWT triggers and counters, but no ETM */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+#define __WIC_PRESENT          0         /*!< WIC present or not */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm4.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_sam4l.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAM4LS8A */
+/* ************************************************************************** */
+/** \defgroup SAM4LS8A_api Peripheral Software API */
+/*@{*/
+
+#include "component/abdacb.h"
+#include "component/acifc.h"
+#include "component/adcife.h"
+#include "component/ast.h"
+#include "component/bpm.h"
+#include "component/bscif.h"
+#include "component/catb.h"
+#include "component/chipid.h"
+#include "component/crccu.h"
+#include "component/dacc.h"
+#include "component/eic.h"
+#include "component/flashcalw.h"
+#include "component/freqm.h"
+#include "component/gloc.h"
+#include "component/gpio.h"
+#include "component/hcache.h"
+#include "component/hmatrixb.h"
+#include "component/iisc.h"
+#include "component/parc.h"
+#include "component/pdca.h"
+#include "component/pevc.h"
+#include "component/picouart.h"
+#include "component/pm.h"
+#include "component/scif.h"
+#include "component/smap.h"
+#include "component/spi.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twim.h"
+#include "component/twis.h"
+#include "component/usart.h"
+#include "component/usbc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAM4LS8A */
+/* ************************************************************************** */
+/** \defgroup SAM4LS8A_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/abdacb.h"
+#include "instance/acifc.h"
+#include "instance/adcife.h"
+#include "instance/ast.h"
+#include "instance/bpm.h"
+#include "instance/bscif.h"
+#include "instance/catb.h"
+#include "instance/chipid.h"
+#include "instance/crccu.h"
+#include "instance/dacc.h"
+#include "instance/eic.h"
+#include "instance/hflashc.h"
+#include "instance/freqm.h"
+#include "instance/gloc.h"
+#include "instance/gpio.h"
+#include "instance/hcache.h"
+#include "instance/hmatrix.h"
+#include "instance/iisc.h"
+#include "instance/parc.h"
+#include "instance/pdca.h"
+#include "instance/pevc.h"
+#include "instance/picouart.h"
+#include "instance/pm.h"
+#include "instance/scif.h"
+#include "instance/smap.h"
+#include "instance/spi.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/trng.h"
+#include "instance/twim0.h"
+#include "instance/twim1.h"
+#include "instance/twim2.h"
+#include "instance/twim3.h"
+#include "instance/twis0.h"
+#include "instance/twis1.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usart3.h"
+#include "instance/usbc.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAM4LS8A */
+/* ************************************************************************** */
+/** \defgroup SAM4LS8A_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HTOP0 bridge
+#define ID_IISC           0 /**< \brief Inter-IC Sound (I2S) Controller (IISC) */
+#define ID_SPI            1 /**< \brief Serial Peripheral Interface (SPI) */
+#define ID_TC0            2 /**< \brief Timer/Counter 0 (TC0) */
+#define ID_TC1            3 /**< \brief Timer/Counter 1 (TC1) */
+#define ID_TWIM0          4 /**< \brief Two-wire Master Interface 0 (TWIM0) */
+#define ID_TWIS0          5 /**< \brief Two-wire Slave Interface 0 (TWIS0) */
+#define ID_TWIM1          6 /**< \brief Two-wire Master Interface 1 (TWIM1) */
+#define ID_TWIS1          7 /**< \brief Two-wire Slave Interface 1 (TWIS1) */
+#define ID_USART0         8 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+#define ID_USART1         9 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+#define ID_USART2        10 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+#define ID_USART3        11 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+#define ID_ADCIFE        12 /**< \brief ADC controller interface (ADCIFE) */
+#define ID_DACC          13 /**< \brief DAC Controller (DACC) */
+#define ID_ACIFC         14 /**< \brief Analog Comparator Interface (ACIFC) */
+#define ID_GLOC          15 /**< \brief Glue Logic Controller (GLOC) */
+#define ID_ABDACB        16 /**< \brief Audio Bitstream DAC (ABDACB) */
+#define ID_TRNG          17 /**< \brief True Random Number Generator (TRNG) */
+#define ID_PARC          18 /**< \brief Parallel Capture (PARC) */
+#define ID_CATB          19 /**< \brief Capacitive Touch Module B (CATB) */
+#define ID_TWIM2         21 /**< \brief Two-wire Master Interface 2 (TWIM2) */
+#define ID_TWIM3         22 /**< \brief Two-wire Master Interface 3 (TWIM3) */
+
+// Peripheral instances on HTOP1 bridge
+#define ID_HFLASHC       32 /**< \brief Flash Controller (HFLASHC) */
+#define ID_HCACHE        33 /**< \brief Cortex M I&D Cache Controller (HCACHE) */
+#define ID_HMATRIX       34 /**< \brief HSB Matrix (HMATRIX) */
+#define ID_PDCA          35 /**< \brief Peripheral DMA Controller (PDCA) */
+#define ID_SMAP          36 /**< \brief System Manager Access Port (SMAP) */
+#define ID_CRCCU         37 /**< \brief CRC Calculation Unit (CRCCU) */
+#define ID_USBC          38 /**< \brief USB 2.0 Interface (USBC) */
+#define ID_PEVC          39 /**< \brief Peripheral Event Controller (PEVC) */
+
+// Peripheral instances on HTOP2 bridge
+#define ID_PM            64 /**< \brief Power Manager (PM) */
+#define ID_CHIPID        65 /**< \brief Chip ID Registers (CHIPID) */
+#define ID_SCIF          66 /**< \brief System Control Interface (SCIF) */
+#define ID_FREQM         67 /**< \brief Frequency Meter (FREQM) */
+#define ID_GPIO          68 /**< \brief General-Purpose Input/Output Controller (GPIO) */
+
+// Peripheral instances on HTOP3 bridge
+#define ID_BPM           96 /**< \brief Backup Power Manager (BPM) */
+#define ID_BSCIF         97 /**< \brief Backup System Control Interface (BSCIF) */
+#define ID_AST           98 /**< \brief Asynchronous Timer (AST) */
+#define ID_WDT           99 /**< \brief Watchdog Timer (WDT) */
+#define ID_EIC          100 /**< \brief External Interrupt Controller (EIC) */
+#define ID_PICOUART     101 /**< \brief Pico UART (PICOUART) */
+
+#define ID_PERIPH_COUNT 102 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAM4LS8A */
+/* ************************************************************************** */
+/** \defgroup SAM4LS8A_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define ABDACB                        (0x40064000) /**< \brief (ABDACB) APB Base Address */
+#define ACIFC                         (0x40040000) /**< \brief (ACIFC) APB Base Address */
+#define ADCIFE                        (0x40038000) /**< \brief (ADCIFE) APB Base Address */
+#define AST                           (0x400F0800) /**< \brief (AST) APB Base Address */
+#define BPM                           (0x400F0000) /**< \brief (BPM) APB Base Address */
+#define BSCIF                         (0x400F0400) /**< \brief (BSCIF) APB Base Address */
+#define CATB                          (0x40070000) /**< \brief (CATB) APB Base Address */
+#define CHIPID                        (0x400E0400) /**< \brief (CHIPID) APB Base Address */
+#define CRCCU                         (0x400A4000) /**< \brief (CRCCU) APB Base Address */
+#define DACC                          (0x4003C000) /**< \brief (DACC) APB Base Address */
+#define EIC                           (0x400F1000) /**< \brief (EIC) APB Base Address */
+#define HFLASHC                       (0x400A0000) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000) /**< \brief (HFLASHC) USER Base Address */
+#define FREQM                         (0x400E0C00) /**< \brief (FREQM) APB Base Address */
+#define GLOC                          (0x40060000) /**< \brief (GLOC) APB Base Address */
+#define GPIO                          (0x400E1000) /**< \brief (GPIO) APB Base Address */
+#define HCACHE                        (0x400A0400) /**< \brief (HCACHE) APB Base Address */
+#define HMATRIX                       (0x400A1000) /**< \brief (HMATRIX) APB Base Address */
+#define IISC                          (0x40004000) /**< \brief (IISC) APB Base Address */
+#define PARC                          (0x4006C000) /**< \brief (PARC) APB Base Address */
+#define PDCA                          (0x400A2000) /**< \brief (PDCA) APB Base Address */
+#define PEVC                          (0x400A6000) /**< \brief (PEVC) APB Base Address */
+#define PICOUART                      (0x400F1400) /**< \brief (PICOUART) APB Base Address */
+#define PM                            (0x400E0000) /**< \brief (PM) APB Base Address */
+#define SCIF                          (0x400E0800) /**< \brief (SCIF) APB Base Address */
+#define SMAP                          (0x400A3000) /**< \brief (SMAP) APB Base Address */
+#define SPI                           (0x40008000) /**< \brief (SPI) APB Base Address */
+#define TC0                           (0x40010000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x40014000) /**< \brief (TC1) APB Base Address */
+#define TRNG                          (0x40068000) /**< \brief (TRNG) APB Base Address */
+#define TWIM0                         (0x40018000) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1                         (0x4001C000) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2                         (0x40078000) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3                         (0x4007C000) /**< \brief (TWIM3) APB Base Address */
+#define TWIS0                         (0x40018400) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1                         (0x4001C400) /**< \brief (TWIS1) APB Base Address */
+#define USART0                        (0x40024000) /**< \brief (USART0) APB Base Address */
+#define USART1                        (0x40028000) /**< \brief (USART1) APB Base Address */
+#define USART2                        (0x4002C000) /**< \brief (USART2) APB Base Address */
+#define USART3                        (0x40030000) /**< \brief (USART3) APB Base Address */
+#define USBC                          (0x400A5000) /**< \brief (USBC) APB Base Address */
+#define WDT                           (0x400F0C00) /**< \brief (WDT) APB Base Address */
+#else
+#define ABDACB            ((Abdacb   *)0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_ADDR                   (0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_INST_NUM   1                          /**< \brief (ABDACB) Number of instances */
+#define ABDACB_INSTS      { ABDACB }                 /**< \brief (ABDACB) Instances List */
+
+#define ACIFC             ((Acifc    *)0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_ADDR                    (0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_INST_NUM    1                          /**< \brief (ACIFC) Number of instances */
+#define ACIFC_INSTS       { ACIFC }                  /**< \brief (ACIFC) Instances List */
+
+#define ADCIFE            ((Adcife   *)0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_ADDR                   (0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_INST_NUM   1                          /**< \brief (ADCIFE) Number of instances */
+#define ADCIFE_INSTS      { ADCIFE }                 /**< \brief (ADCIFE) Instances List */
+
+#define AST               ((Ast      *)0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_ADDR                      (0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_INST_NUM      1                          /**< \brief (AST) Number of instances */
+#define AST_INSTS         { AST }                    /**< \brief (AST) Instances List */
+
+#define BPM               ((Bpm      *)0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_ADDR                      (0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_INST_NUM      1                          /**< \brief (BPM) Number of instances */
+#define BPM_INSTS         { BPM }                    /**< \brief (BPM) Instances List */
+
+#define BSCIF             ((Bscif    *)0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_ADDR                    (0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_INST_NUM    1                          /**< \brief (BSCIF) Number of instances */
+#define BSCIF_INSTS       { BSCIF }                  /**< \brief (BSCIF) Instances List */
+
+#define CATB              ((Catb     *)0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_ADDR                     (0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_INST_NUM     1                          /**< \brief (CATB) Number of instances */
+#define CATB_INSTS        { CATB }                   /**< \brief (CATB) Instances List */
+
+#define CHIPID            ((Chipid   *)0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_ADDR                   (0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_INST_NUM   1                          /**< \brief (CHIPID) Number of instances */
+#define CHIPID_INSTS      { CHIPID }                 /**< \brief (CHIPID) Instances List */
+
+#define CRCCU             ((Crccu    *)0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_ADDR                    (0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_INST_NUM    1                          /**< \brief (CRCCU) Number of instances */
+#define CRCCU_INSTS       { CRCCU }                  /**< \brief (CRCCU) Instances List */
+
+#define DACC              ((Dacc     *)0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_ADDR                     (0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_INST_NUM     1                          /**< \brief (DACC) Number of instances */
+#define DACC_INSTS        { DACC }                   /**< \brief (DACC) Instances List */
+
+#define EIC               ((Eic      *)0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_ADDR                      (0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define HFLASHC           ((Flashcalw *)0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_ADDR                  (0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_FROW_ADDR             (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define HFLASHC_USER_ADDR             (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define FLASHCALW_INST_NUM 1                          /**< \brief (FLASHCALW) Number of instances */
+#define FLASHCALW_INSTS   { HFLASHC }                /**< \brief (FLASHCALW) Instances List */
+
+#define FREQM             ((Freqm    *)0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_ADDR                    (0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_INST_NUM    1                          /**< \brief (FREQM) Number of instances */
+#define FREQM_INSTS       { FREQM }                  /**< \brief (FREQM) Instances List */
+
+#define GLOC              ((Gloc     *)0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_ADDR                     (0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_INST_NUM     1                          /**< \brief (GLOC) Number of instances */
+#define GLOC_INSTS        { GLOC }                   /**< \brief (GLOC) Instances List */
+
+#define GPIO              ((Gpio     *)0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_ADDR                     (0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_INST_NUM     1                          /**< \brief (GPIO) Number of instances */
+#define GPIO_INSTS        { GPIO }                   /**< \brief (GPIO) Instances List */
+
+#define HCACHE            ((Hcache   *)0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_ADDR                   (0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_INST_NUM   1                          /**< \brief (HCACHE) Number of instances */
+#define HCACHE_INSTS      { HCACHE }                 /**< \brief (HCACHE) Instances List */
+
+#define HMATRIX           ((Hmatrixb *)0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIX_ADDR                  (0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIXB_INST_NUM 1                          /**< \brief (HMATRIXB) Number of instances */
+#define HMATRIXB_INSTS    { HMATRIX }                /**< \brief (HMATRIXB) Instances List */
+
+#define IISC              ((Iisc     *)0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_ADDR                     (0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_INST_NUM     1                          /**< \brief (IISC) Number of instances */
+#define IISC_INSTS        { IISC }                   /**< \brief (IISC) Instances List */
+
+#define PARC              ((Parc     *)0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_ADDR                     (0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_INST_NUM     1                          /**< \brief (PARC) Number of instances */
+#define PARC_INSTS        { PARC }                   /**< \brief (PARC) Instances List */
+
+#define PDCA              ((Pdca     *)0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_ADDR                     (0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_INST_NUM     1                          /**< \brief (PDCA) Number of instances */
+#define PDCA_INSTS        { PDCA }                   /**< \brief (PDCA) Instances List */
+
+#define PEVC              ((Pevc     *)0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_ADDR                     (0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_INST_NUM     1                          /**< \brief (PEVC) Number of instances */
+#define PEVC_INSTS        { PEVC }                   /**< \brief (PEVC) Instances List */
+
+#define PICOUART          ((Picouart *)0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_ADDR                 (0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_INST_NUM 1                          /**< \brief (PICOUART) Number of instances */
+#define PICOUART_INSTS    { PICOUART }               /**< \brief (PICOUART) Instances List */
+
+#define PM                ((Pm       *)0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_ADDR                       (0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define SCIF              ((Scif     *)0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_ADDR                     (0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_INST_NUM     1                          /**< \brief (SCIF) Number of instances */
+#define SCIF_INSTS        { SCIF }                   /**< \brief (SCIF) Instances List */
+
+#define SMAP              ((Smap     *)0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_ADDR                     (0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_INST_NUM     1                          /**< \brief (SMAP) Number of instances */
+#define SMAP_INSTS        { SMAP }                   /**< \brief (SMAP) Instances List */
+
+#define SPI               ((Spi      *)0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_ADDR                      (0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_INST_NUM      1                          /**< \brief (SPI) Number of instances */
+#define SPI_INSTS         { SPI }                    /**< \brief (SPI) Instances List */
+
+#define TC0               ((Tc       *)0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC0_ADDR                      (0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC1_ADDR                      (0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC_INST_NUM       2                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1 }               /**< \brief (TC) Instances List */
+
+#define TRNG              ((Trng     *)0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_ADDR                     (0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_INST_NUM     1                          /**< \brief (TRNG) Number of instances */
+#define TRNG_INSTS        { TRNG }                   /**< \brief (TRNG) Instances List */
+
+#define TWIM0             ((Twim     *)0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM0_ADDR                    (0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1             ((Twim     *)0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM1_ADDR                    (0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2             ((Twim     *)0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM2_ADDR                    (0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3             ((Twim     *)0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM3_ADDR                    (0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM_INST_NUM     4                          /**< \brief (TWIM) Number of instances */
+#define TWIM_INSTS        { TWIM0, TWIM1, TWIM2, TWIM3 } /**< \brief (TWIM) Instances List */
+
+#define TWIS0             ((Twis     *)0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS0_ADDR                    (0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1             ((Twis     *)0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS1_ADDR                    (0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS_INST_NUM     2                          /**< \brief (TWIS) Number of instances */
+#define TWIS_INSTS        { TWIS0, TWIS1 }           /**< \brief (TWIS) Instances List */
+
+#define USART0            ((Usart    *)0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART0_ADDR                   (0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART1            ((Usart    *)0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART1_ADDR                   (0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART2            ((Usart    *)0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART2_ADDR                   (0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART3            ((Usart    *)0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART3_ADDR                   (0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART_INST_NUM    4                          /**< \brief (USART) Number of instances */
+#define USART_INSTS       { USART0, USART1, USART2, USART3 } /**< \brief (USART) Instances List */
+
+#define USBC              ((Usbc     *)0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_ADDR                     (0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_INST_NUM     1                          /**< \brief (USBC) Number of instances */
+#define USBC_INSTS        { USBC }                   /**< \brief (USBC) Instances List */
+
+#define WDT               ((Wdt      *)0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_ADDR                      (0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  GPIO DEFINITIONS FOR SAM4LS8A */
+/* ************************************************************************** */
+/** \defgroup SAM4LS8A_gpio GPIO Definitions */
+/*@{*/
+
+#include "pio/sam4ls8a.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  ADDITIONAL DEFINITIONS FOR COMPATIBILITY */
+/* ************************************************************************** */
+/** \addtogroup SAM4LS8A_compat Definitions */
+/*@{*/
+// These defines are used to keep compatibility with existing 
+// sam/drivers/usart implementation from SAM3/4 products with SAM4L product.
+#define US_MR_USART_MODE_HW_HANDSHAKING  US_MR_USART_MODE_HARDWARE
+#define US_MR_USART_MODE_IS07816_T_0     US_MR_USART_MODE_ISO7816_T0
+#define US_MR_USART_MODE_IS07816_T_1     US_MR_USART_MODE_ISO7816_T1
+#define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
+#define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
+#define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_8_BIT      US_MR_CHRL_8
+#define US_MR_PAR_NO          US_MR_PAR_NONE
+#define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI
+#define US_IF                 US_IFR
+#define US_WPSR_WPVS          US_WPSR_WPV_1
+
+#define USBC_UPCFG0_PBK_Msk   (0x1u << USBC_UPCFG0_PBK_Pos)
+
+// These defines for homogeneity with other SAM header files.
+#define CHIP_FREQ_FWS_0       (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 */
+#define CHIP_FREQ_FWS_1       (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 */
+// WARNING NOTE: these are preliminary values.
+#define CHIP_FREQ_FLASH_HSEN_FWS_0 (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 and the FLASH HS mode is enabled */
+#define CHIP_FREQ_FLASH_HSEN_FWS_1 (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 and the FLASH HS mode is enabled */
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/tc implementation from SAM3/4 products with SAM4L product. 
+#define TC_CMR_LDRA_RISING    TC_CMR_LDRA_POS_EDGE_TIOA
+#define TC_CMR_LDRB_FALLING   TC_CMR_LDRB_NEG_EDGE_TIOA
+#define TC_CMR_ETRGEDG_FALLING TC_CMR_ETRGEDG_NEG_EDGE
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/spi implementation from SAM3/4 products with SAM4L product. 
+#define SPI_CSR_BITS_8_BIT    SPI_CSR_BITS_8_BPT
+#define SPI_WPCR_SPIWPKEY_VALUE SPI_WPCR_WPKEY_VALUE
+#define SPI_WPCR_SPIWPEN      SPI_WPCR_WPEN
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/crccu implementation from SAM3/4 products with SAM4L product. 
+#define CRCCU_DMA_EN          CRCCU_DMAEN
+#define CRCCU_DMA_DIS         CRCCU_DMADIS
+#define CRCCU_DMA_SR          CRCCU_DMASR
+#define CRCCU_DMA_IER         CRCCU_DMAIER
+#define CRCCU_DMA_IDR         CRCCU_DMAIDR
+#define CRCCU_DMA_IMR         CRCCU_DMAIMR
+#define CRCCU_DMA_ISR         CRCCU_DMAISR
+#define CRCCU_DMA_EN_DMAEN    CRCCU_DMAEN_DMAEN
+#define CRCCU_DMA_DIS_DMADIS  CRCCU_DMADIS_DMADIS
+#define CRCCU_DMA_SR_DMASR    CRCCU_DMASR_DMASR
+#define CRCCU_DMA_IER_DMAIER  CRCCU_DMAIER_DMAIER
+#define CRCCU_DMA_IDR_DMAIDR  CRCCU_DMAIDR_DMAIDR
+#define CRCCU_DMA_IMR_DMAIMR  CRCCU_DMAIMR_DMAIMR
+#define CRCCU_DMA_ISR_DMAISR  CRCCU_DMAISR_DMAISR
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAM4LS8A */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL(0x00080000) /* 512 kB */
+#define FLASH_PAGE_SIZE       512
+#define FLASH_NB_OF_PAGES     1024
+#define FLASH_USER_PAGE_SIZE  512
+#define HRAMC0_SIZE           _UL(0x00010000) /* 64 kB */
+#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+
+#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+
+#define DSU_DID_RESETVALUE    _UL(0xAB0B0AE0)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAM4LS8A */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAM4LS8A_H */

--- a/asf/sam/include/sam4l/sam4ls8b.h
+++ b/asf/sam/include/sam4l/sam4ls8b.h
@@ -1,0 +1,889 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAM4LS8B
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LS8B_
+#define _SAM4LS8B_
+
+/**
+ * \ingroup SAM4L_definitions
+ * \addtogroup SAM4LS8B_definitions SAM4LS8B definitions
+ * This file defines all structures and symbols for SAM4LS8B:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#if !defined(_UL)
+#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#endif
+#else
+#if !defined(_UL)
+#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif
+#endif
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAM4LS8B */
+/* ************************************************************************** */
+/** \defgroup SAM4LS8B_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M4 Processor Exceptions Numbers ******************************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn           = -13,/**<  3 Cortex-M4 Hard Fault Interrupt        */
+  MemoryManagement_IRQn    = -12,/**<  4 Cortex-M4 Memory Management Interrupt */
+  BusFault_IRQn            = -11,/**<  5 Cortex-M4 Bus Fault Interrupt         */
+  UsageFault_IRQn          = -10,/**<  6 Cortex-M4 Usage Fault Interrupt       */
+  SVCall_IRQn              = -5, /**< 11 Cortex-M4 SV Call Interrupt           */
+  DebugMonitor_IRQn        = -4, /**< 12 Cortex-M4 Debug Monitor Interrupt     */
+  PendSV_IRQn              = -2, /**< 14 Cortex-M4 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 Cortex-M4 System Tick Interrupt       */
+  /******  SAM4LS8B-specific Interrupt Numbers ***********************/
+  HFLASHC_IRQn             =  0, /**<  0 SAM4LS8B Flash Controller (HFLASHC) */
+  PDCA_0_IRQn              =  1, /**<  1 SAM4LS8B Peripheral DMA Controller (PDCA): PDCA_0 */
+  PDCA_1_IRQn              =  2, /**<  2 SAM4LS8B Peripheral DMA Controller (PDCA): PDCA_1 */
+  PDCA_2_IRQn              =  3, /**<  3 SAM4LS8B Peripheral DMA Controller (PDCA): PDCA_2 */
+  PDCA_3_IRQn              =  4, /**<  4 SAM4LS8B Peripheral DMA Controller (PDCA): PDCA_3 */
+  PDCA_4_IRQn              =  5, /**<  5 SAM4LS8B Peripheral DMA Controller (PDCA): PDCA_4 */
+  PDCA_5_IRQn              =  6, /**<  6 SAM4LS8B Peripheral DMA Controller (PDCA): PDCA_5 */
+  PDCA_6_IRQn              =  7, /**<  7 SAM4LS8B Peripheral DMA Controller (PDCA): PDCA_6 */
+  PDCA_7_IRQn              =  8, /**<  8 SAM4LS8B Peripheral DMA Controller (PDCA): PDCA_7 */
+  PDCA_8_IRQn              =  9, /**<  9 SAM4LS8B Peripheral DMA Controller (PDCA): PDCA_8 */
+  PDCA_9_IRQn              = 10, /**< 10 SAM4LS8B Peripheral DMA Controller (PDCA): PDCA_9 */
+  PDCA_10_IRQn             = 11, /**< 11 SAM4LS8B Peripheral DMA Controller (PDCA): PDCA_10 */
+  PDCA_11_IRQn             = 12, /**< 12 SAM4LS8B Peripheral DMA Controller (PDCA): PDCA_11 */
+  PDCA_12_IRQn             = 13, /**< 13 SAM4LS8B Peripheral DMA Controller (PDCA): PDCA_12 */
+  PDCA_13_IRQn             = 14, /**< 14 SAM4LS8B Peripheral DMA Controller (PDCA): PDCA_13 */
+  PDCA_14_IRQn             = 15, /**< 15 SAM4LS8B Peripheral DMA Controller (PDCA): PDCA_14 */
+  PDCA_15_IRQn             = 16, /**< 16 SAM4LS8B Peripheral DMA Controller (PDCA): PDCA_15 */
+  CRCCU_IRQn               = 17, /**< 17 SAM4LS8B CRC Calculation Unit (CRCCU) */
+  USBC_IRQn                = 18, /**< 18 SAM4LS8B USB 2.0 Interface (USBC) */
+  PEVC_0_IRQn              = 19, /**< 19 SAM4LS8B Peripheral Event Controller (PEVC): PEVC_TR */
+  PEVC_1_IRQn              = 20, /**< 20 SAM4LS8B Peripheral Event Controller (PEVC): PEVC_OV */
+  PM_IRQn                  = 22, /**< 22 SAM4LS8B Power Manager (PM) */
+  SCIF_IRQn                = 23, /**< 23 SAM4LS8B System Control Interface (SCIF) */
+  FREQM_IRQn               = 24, /**< 24 SAM4LS8B Frequency Meter (FREQM) */
+  GPIO_0_IRQn              = 25, /**< 25 SAM4LS8B General-Purpose Input/Output Controller (GPIO): GPIO_0 */
+  GPIO_1_IRQn              = 26, /**< 26 SAM4LS8B General-Purpose Input/Output Controller (GPIO): GPIO_1 */
+  GPIO_2_IRQn              = 27, /**< 27 SAM4LS8B General-Purpose Input/Output Controller (GPIO): GPIO_2 */
+  GPIO_3_IRQn              = 28, /**< 28 SAM4LS8B General-Purpose Input/Output Controller (GPIO): GPIO_3 */
+  GPIO_4_IRQn              = 29, /**< 29 SAM4LS8B General-Purpose Input/Output Controller (GPIO): GPIO_4 */
+  GPIO_5_IRQn              = 30, /**< 30 SAM4LS8B General-Purpose Input/Output Controller (GPIO): GPIO_5 */
+  GPIO_6_IRQn              = 31, /**< 31 SAM4LS8B General-Purpose Input/Output Controller (GPIO): GPIO_6 */
+  GPIO_7_IRQn              = 32, /**< 32 SAM4LS8B General-Purpose Input/Output Controller (GPIO): GPIO_7 */
+  GPIO_8_IRQn              = 33, /**< 33 SAM4LS8B General-Purpose Input/Output Controller (GPIO): GPIO_8 */
+  GPIO_9_IRQn              = 34, /**< 34 SAM4LS8B General-Purpose Input/Output Controller (GPIO): GPIO_9 */
+  GPIO_10_IRQn             = 35, /**< 35 SAM4LS8B General-Purpose Input/Output Controller (GPIO): GPIO_10 */
+  GPIO_11_IRQn             = 36, /**< 36 SAM4LS8B General-Purpose Input/Output Controller (GPIO): GPIO_11 */
+  BPM_IRQn                 = 37, /**< 37 SAM4LS8B Backup Power Manager (BPM) */
+  BSCIF_IRQn               = 38, /**< 38 SAM4LS8B Backup System Control Interface (BSCIF) */
+  AST_0_IRQn               = 39, /**< 39 SAM4LS8B Asynchronous Timer (AST): AST_ALARM */
+  AST_1_IRQn               = 40, /**< 40 SAM4LS8B Asynchronous Timer (AST): AST_PER */
+  AST_2_IRQn               = 41, /**< 41 SAM4LS8B Asynchronous Timer (AST): AST_OVF */
+  AST_3_IRQn               = 42, /**< 42 SAM4LS8B Asynchronous Timer (AST): AST_READY */
+  AST_4_IRQn               = 43, /**< 43 SAM4LS8B Asynchronous Timer (AST): AST_CLKREADY */
+  WDT_IRQn                 = 44, /**< 44 SAM4LS8B Watchdog Timer (WDT) */
+  EIC_0_IRQn               = 45, /**< 45 SAM4LS8B External Interrupt Controller (EIC): EIC_1 */
+  EIC_1_IRQn               = 46, /**< 46 SAM4LS8B External Interrupt Controller (EIC): EIC_2 */
+  EIC_2_IRQn               = 47, /**< 47 SAM4LS8B External Interrupt Controller (EIC): EIC_3 */
+  EIC_3_IRQn               = 48, /**< 48 SAM4LS8B External Interrupt Controller (EIC): EIC_4 */
+  EIC_4_IRQn               = 49, /**< 49 SAM4LS8B External Interrupt Controller (EIC): EIC_5 */
+  EIC_5_IRQn               = 50, /**< 50 SAM4LS8B External Interrupt Controller (EIC): EIC_6 */
+  EIC_6_IRQn               = 51, /**< 51 SAM4LS8B External Interrupt Controller (EIC): EIC_7 */
+  EIC_7_IRQn               = 52, /**< 52 SAM4LS8B External Interrupt Controller (EIC): EIC_8 */
+  IISC_IRQn                = 53, /**< 53 SAM4LS8B Inter-IC Sound (I2S) Controller (IISC) */
+  SPI_IRQn                 = 54, /**< 54 SAM4LS8B Serial Peripheral Interface (SPI) */
+  TC0_0_IRQn               = 55, /**< 55 SAM4LS8B Timer/Counter 0 (TC0): TC00 */
+  TC0_1_IRQn               = 56, /**< 56 SAM4LS8B Timer/Counter 0 (TC0): TC01 */
+  TC0_2_IRQn               = 57, /**< 57 SAM4LS8B Timer/Counter 0 (TC0): TC02 */
+  TC1_0_IRQn               = 58, /**< 58 SAM4LS8B Timer/Counter 1 (TC1): TC10 */
+  TC1_1_IRQn               = 59, /**< 59 SAM4LS8B Timer/Counter 1 (TC1): TC11 */
+  TC1_2_IRQn               = 60, /**< 60 SAM4LS8B Timer/Counter 1 (TC1): TC12 */
+  TWIM0_IRQn               = 61, /**< 61 SAM4LS8B Two-wire Master Interface 0 (TWIM0) */
+  TWIS0_IRQn               = 62, /**< 62 SAM4LS8B Two-wire Slave Interface 0 (TWIS0) */
+  TWIM1_IRQn               = 63, /**< 63 SAM4LS8B Two-wire Master Interface 1 (TWIM1) */
+  TWIS1_IRQn               = 64, /**< 64 SAM4LS8B Two-wire Slave Interface 1 (TWIS1) */
+  USART0_IRQn              = 65, /**< 65 SAM4LS8B Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+  USART1_IRQn              = 66, /**< 66 SAM4LS8B Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+  USART2_IRQn              = 67, /**< 67 SAM4LS8B Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+  USART3_IRQn              = 68, /**< 68 SAM4LS8B Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+  ADCIFE_IRQn              = 69, /**< 69 SAM4LS8B ADC controller interface (ADCIFE) */
+  DACC_IRQn                = 70, /**< 70 SAM4LS8B DAC Controller (DACC) */
+  ACIFC_IRQn               = 71, /**< 71 SAM4LS8B Analog Comparator Interface (ACIFC) */
+  ABDACB_IRQn              = 72, /**< 72 SAM4LS8B Audio Bitstream DAC (ABDACB) */
+  TRNG_IRQn                = 73, /**< 73 SAM4LS8B True Random Number Generator (TRNG) */
+  PARC_IRQn                = 74, /**< 74 SAM4LS8B Parallel Capture (PARC) */
+  CATB_IRQn                = 75, /**< 75 SAM4LS8B Capacitive Touch Module B (CATB) */
+  TWIM2_IRQn               = 77, /**< 77 SAM4LS8B Two-wire Master Interface 2 (TWIM2) */
+  TWIM3_IRQn               = 78, /**< 78 SAM4LS8B Two-wire Master Interface 3 (TWIM3) */
+
+  PERIPH_COUNT_IRQn        = 80  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNMI_Handler;
+  void* pfnHardFault_Handler;
+  void* pfnMemManage_Handler;
+  void* pfnBusFault_Handler;
+  void* pfnUsageFault_Handler;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVC_Handler;
+  void* pfnDebugMon_Handler;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnHFLASHC_Handler;               /*  0 Flash Controller */
+  void* pfnPDCA_0_Handler;                /*  1 Peripheral DMA Controller IRQ 0 */
+  void* pfnPDCA_1_Handler;                /*  2 Peripheral DMA Controller IRQ 1 */
+  void* pfnPDCA_2_Handler;                /*  3 Peripheral DMA Controller IRQ 2 */
+  void* pfnPDCA_3_Handler;                /*  4 Peripheral DMA Controller IRQ 3 */
+  void* pfnPDCA_4_Handler;                /*  5 Peripheral DMA Controller IRQ 4 */
+  void* pfnPDCA_5_Handler;                /*  6 Peripheral DMA Controller IRQ 5 */
+  void* pfnPDCA_6_Handler;                /*  7 Peripheral DMA Controller IRQ 6 */
+  void* pfnPDCA_7_Handler;                /*  8 Peripheral DMA Controller IRQ 7 */
+  void* pfnPDCA_8_Handler;                /*  9 Peripheral DMA Controller IRQ 8 */
+  void* pfnPDCA_9_Handler;                /* 10 Peripheral DMA Controller IRQ 9 */
+  void* pfnPDCA_10_Handler;               /* 11 Peripheral DMA Controller IRQ 10 */
+  void* pfnPDCA_11_Handler;               /* 12 Peripheral DMA Controller IRQ 11 */
+  void* pfnPDCA_12_Handler;               /* 13 Peripheral DMA Controller IRQ 12 */
+  void* pfnPDCA_13_Handler;               /* 14 Peripheral DMA Controller IRQ 13 */
+  void* pfnPDCA_14_Handler;               /* 15 Peripheral DMA Controller IRQ 14 */
+  void* pfnPDCA_15_Handler;               /* 16 Peripheral DMA Controller IRQ 15 */
+  void* pfnCRCCU_Handler;                 /* 17 CRC Calculation Unit */
+  void* pfnUSBC_Handler;                  /* 18 USB 2.0 Interface */
+  void* pfnPEVC_0_Handler;                /* 19 Peripheral Event Controller IRQ 0 */
+  void* pfnPEVC_1_Handler;                /* 20 Peripheral Event Controller IRQ 1 */
+  void* pvReserved21;
+  void* pfnPM_Handler;                    /* 22 Power Manager */
+  void* pfnSCIF_Handler;                  /* 23 System Control Interface */
+  void* pfnFREQM_Handler;                 /* 24 Frequency Meter */
+  void* pfnGPIO_0_Handler;                /* 25 General-Purpose Input/Output Controller IRQ 0 */
+  void* pfnGPIO_1_Handler;                /* 26 General-Purpose Input/Output Controller IRQ 1 */
+  void* pfnGPIO_2_Handler;                /* 27 General-Purpose Input/Output Controller IRQ 2 */
+  void* pfnGPIO_3_Handler;                /* 28 General-Purpose Input/Output Controller IRQ 3 */
+  void* pfnGPIO_4_Handler;                /* 29 General-Purpose Input/Output Controller IRQ 4 */
+  void* pfnGPIO_5_Handler;                /* 30 General-Purpose Input/Output Controller IRQ 5 */
+  void* pfnGPIO_6_Handler;                /* 31 General-Purpose Input/Output Controller IRQ 6 */
+  void* pfnGPIO_7_Handler;                /* 32 General-Purpose Input/Output Controller IRQ 7 */
+  void* pfnGPIO_8_Handler;                /* 33 General-Purpose Input/Output Controller IRQ 8 */
+  void* pfnGPIO_9_Handler;                /* 34 General-Purpose Input/Output Controller IRQ 9 */
+  void* pfnGPIO_10_Handler;               /* 35 General-Purpose Input/Output Controller IRQ 10 */
+  void* pfnGPIO_11_Handler;               /* 36 General-Purpose Input/Output Controller IRQ 11 */
+  void* pfnBPM_Handler;                   /* 37 Backup Power Manager */
+  void* pfnBSCIF_Handler;                 /* 38 Backup System Control Interface */
+  void* pfnAST_0_Handler;                 /* 39 Asynchronous Timer IRQ 0 */
+  void* pfnAST_1_Handler;                 /* 40 Asynchronous Timer IRQ 1 */
+  void* pfnAST_2_Handler;                 /* 41 Asynchronous Timer IRQ 2 */
+  void* pfnAST_3_Handler;                 /* 42 Asynchronous Timer IRQ 3 */
+  void* pfnAST_4_Handler;                 /* 43 Asynchronous Timer IRQ 4 */
+  void* pfnWDT_Handler;                   /* 44 Watchdog Timer */
+  void* pfnEIC_0_Handler;                 /* 45 External Interrupt Controller IRQ 0 */
+  void* pfnEIC_1_Handler;                 /* 46 External Interrupt Controller IRQ 1 */
+  void* pfnEIC_2_Handler;                 /* 47 External Interrupt Controller IRQ 2 */
+  void* pfnEIC_3_Handler;                 /* 48 External Interrupt Controller IRQ 3 */
+  void* pfnEIC_4_Handler;                 /* 49 External Interrupt Controller IRQ 4 */
+  void* pfnEIC_5_Handler;                 /* 50 External Interrupt Controller IRQ 5 */
+  void* pfnEIC_6_Handler;                 /* 51 External Interrupt Controller IRQ 6 */
+  void* pfnEIC_7_Handler;                 /* 52 External Interrupt Controller IRQ 7 */
+  void* pfnIISC_Handler;                  /* 53 Inter-IC Sound (I2S) Controller */
+  void* pfnSPI_Handler;                   /* 54 Serial Peripheral Interface */
+  void* pfnTC0_0_Handler;                 /* 55 Timer/Counter 0 IRQ 0 */
+  void* pfnTC0_1_Handler;                 /* 56 Timer/Counter 0 IRQ 1 */
+  void* pfnTC0_2_Handler;                 /* 57 Timer/Counter 0 IRQ 2 */
+  void* pfnTC1_0_Handler;                 /* 58 Timer/Counter 1 IRQ 0 */
+  void* pfnTC1_1_Handler;                 /* 59 Timer/Counter 1 IRQ 1 */
+  void* pfnTC1_2_Handler;                 /* 60 Timer/Counter 1 IRQ 2 */
+  void* pfnTWIM0_Handler;                 /* 61 Two-wire Master Interface 0 */
+  void* pfnTWIS0_Handler;                 /* 62 Two-wire Slave Interface 0 */
+  void* pfnTWIM1_Handler;                 /* 63 Two-wire Master Interface 1 */
+  void* pfnTWIS1_Handler;                 /* 64 Two-wire Slave Interface 1 */
+  void* pfnUSART0_Handler;                /* 65 Universal Synchronous Asynchronous Receiver Transmitter 0 */
+  void* pfnUSART1_Handler;                /* 66 Universal Synchronous Asynchronous Receiver Transmitter 1 */
+  void* pfnUSART2_Handler;                /* 67 Universal Synchronous Asynchronous Receiver Transmitter 2 */
+  void* pfnUSART3_Handler;                /* 68 Universal Synchronous Asynchronous Receiver Transmitter 3 */
+  void* pfnADCIFE_Handler;                /* 69 ADC controller interface */
+  void* pfnDACC_Handler;                  /* 70 DAC Controller */
+  void* pfnACIFC_Handler;                 /* 71 Analog Comparator Interface */
+  void* pfnABDACB_Handler;                /* 72 Audio Bitstream DAC */
+  void* pfnTRNG_Handler;                  /* 73 True Random Number Generator */
+  void* pfnPARC_Handler;                  /* 74 Parallel Capture */
+  void* pfnCATB_Handler;                  /* 75 Capacitive Touch Module B */
+  void* pvReserved76;
+  void* pfnTWIM2_Handler;                 /* 77 Two-wire Master Interface 2 */
+  void* pfnTWIM3_Handler;                 /* 78 Two-wire Master Interface 3 */
+  void* pvReserved79;
+} DeviceVectors;
+
+/* Cortex-M4 processor handlers */
+void Reset_Handler               ( void );
+void NMI_Handler                 ( void );
+void HardFault_Handler           ( void );
+void MemManage_Handler           ( void );
+void BusFault_Handler            ( void );
+void UsageFault_Handler          ( void );
+void SVC_Handler                 ( void );
+void DebugMon_Handler            ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void HFLASHC_Handler             ( void );
+void PDCA_0_Handler              ( void );
+void PDCA_1_Handler              ( void );
+void PDCA_2_Handler              ( void );
+void PDCA_3_Handler              ( void );
+void PDCA_4_Handler              ( void );
+void PDCA_5_Handler              ( void );
+void PDCA_6_Handler              ( void );
+void PDCA_7_Handler              ( void );
+void PDCA_8_Handler              ( void );
+void PDCA_9_Handler              ( void );
+void PDCA_10_Handler             ( void );
+void PDCA_11_Handler             ( void );
+void PDCA_12_Handler             ( void );
+void PDCA_13_Handler             ( void );
+void PDCA_14_Handler             ( void );
+void PDCA_15_Handler             ( void );
+void CRCCU_Handler               ( void );
+void USBC_Handler                ( void );
+void PEVC_0_Handler              ( void );
+void PEVC_1_Handler              ( void );
+void PM_Handler                  ( void );
+void SCIF_Handler                ( void );
+void FREQM_Handler               ( void );
+void GPIO_0_Handler              ( void );
+void GPIO_1_Handler              ( void );
+void GPIO_2_Handler              ( void );
+void GPIO_3_Handler              ( void );
+void GPIO_4_Handler              ( void );
+void GPIO_5_Handler              ( void );
+void GPIO_6_Handler              ( void );
+void GPIO_7_Handler              ( void );
+void GPIO_8_Handler              ( void );
+void GPIO_9_Handler              ( void );
+void GPIO_10_Handler             ( void );
+void GPIO_11_Handler             ( void );
+void BPM_Handler                 ( void );
+void BSCIF_Handler               ( void );
+void AST_0_Handler               ( void );
+void AST_1_Handler               ( void );
+void AST_2_Handler               ( void );
+void AST_3_Handler               ( void );
+void AST_4_Handler               ( void );
+void WDT_Handler                 ( void );
+void EIC_0_Handler               ( void );
+void EIC_1_Handler               ( void );
+void EIC_2_Handler               ( void );
+void EIC_3_Handler               ( void );
+void EIC_4_Handler               ( void );
+void EIC_5_Handler               ( void );
+void EIC_6_Handler               ( void );
+void EIC_7_Handler               ( void );
+void IISC_Handler                ( void );
+void SPI_Handler                 ( void );
+void TC0_0_Handler               ( void );
+void TC0_1_Handler               ( void );
+void TC0_2_Handler               ( void );
+void TC1_0_Handler               ( void );
+void TC1_1_Handler               ( void );
+void TC1_2_Handler               ( void );
+void TWIM0_Handler               ( void );
+void TWIS0_Handler               ( void );
+void TWIM1_Handler               ( void );
+void TWIS1_Handler               ( void );
+void USART0_Handler              ( void );
+void USART1_Handler              ( void );
+void USART2_Handler              ( void );
+void USART3_Handler              ( void );
+void ADCIFE_Handler              ( void );
+void DACC_Handler                ( void );
+void ACIFC_Handler               ( void );
+void ABDACB_Handler              ( void );
+void TRNG_Handler                ( void );
+void PARC_Handler                ( void );
+void CATB_Handler                ( void );
+void TWIM2_Handler               ( void );
+void TWIM3_Handler               ( void );
+
+/*
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
+ */
+
+#define LITTLE_ENDIAN          1        
+#define __BB_PRESENT           0         /*!< BIT_BANDING present or not */
+#define __CLKGATE_PRESENT      1         /*!< CLKGATE present or not */
+#define __CM4_REV              1         /*!< Core revision r0p1 */
+#define __DEBUG_LVL            3         /*!< Full debug plus DWT data matching */
+#define __FPU_PRESENT          0         /*!< FPU present or not */
+#define __JTAG_PRESENT         1         /*!< JTAG present or not */
+#define __MPU_PRESENT          1         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       4         /*!< Number of bits used for Priority Levels */
+#define __TRACE_LVL            1         /*!< Standard trace: ITM and DWT triggers and counters, but no ETM */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+#define __WIC_PRESENT          0         /*!< WIC present or not */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm4.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_sam4l.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAM4LS8B */
+/* ************************************************************************** */
+/** \defgroup SAM4LS8B_api Peripheral Software API */
+/*@{*/
+
+#include "component/abdacb.h"
+#include "component/acifc.h"
+#include "component/adcife.h"
+#include "component/ast.h"
+#include "component/bpm.h"
+#include "component/bscif.h"
+#include "component/catb.h"
+#include "component/chipid.h"
+#include "component/crccu.h"
+#include "component/dacc.h"
+#include "component/eic.h"
+#include "component/flashcalw.h"
+#include "component/freqm.h"
+#include "component/gloc.h"
+#include "component/gpio.h"
+#include "component/hcache.h"
+#include "component/hmatrixb.h"
+#include "component/iisc.h"
+#include "component/parc.h"
+#include "component/pdca.h"
+#include "component/pevc.h"
+#include "component/picouart.h"
+#include "component/pm.h"
+#include "component/scif.h"
+#include "component/smap.h"
+#include "component/spi.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twim.h"
+#include "component/twis.h"
+#include "component/usart.h"
+#include "component/usbc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAM4LS8B */
+/* ************************************************************************** */
+/** \defgroup SAM4LS8B_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/abdacb.h"
+#include "instance/acifc.h"
+#include "instance/adcife.h"
+#include "instance/ast.h"
+#include "instance/bpm.h"
+#include "instance/bscif.h"
+#include "instance/catb.h"
+#include "instance/chipid.h"
+#include "instance/crccu.h"
+#include "instance/dacc.h"
+#include "instance/eic.h"
+#include "instance/hflashc.h"
+#include "instance/freqm.h"
+#include "instance/gloc.h"
+#include "instance/gpio.h"
+#include "instance/hcache.h"
+#include "instance/hmatrix.h"
+#include "instance/iisc.h"
+#include "instance/parc.h"
+#include "instance/pdca.h"
+#include "instance/pevc.h"
+#include "instance/picouart.h"
+#include "instance/pm.h"
+#include "instance/scif.h"
+#include "instance/smap.h"
+#include "instance/spi.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/trng.h"
+#include "instance/twim0.h"
+#include "instance/twim1.h"
+#include "instance/twim2.h"
+#include "instance/twim3.h"
+#include "instance/twis0.h"
+#include "instance/twis1.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usart3.h"
+#include "instance/usbc.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAM4LS8B */
+/* ************************************************************************** */
+/** \defgroup SAM4LS8B_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HTOP0 bridge
+#define ID_IISC           0 /**< \brief Inter-IC Sound (I2S) Controller (IISC) */
+#define ID_SPI            1 /**< \brief Serial Peripheral Interface (SPI) */
+#define ID_TC0            2 /**< \brief Timer/Counter 0 (TC0) */
+#define ID_TC1            3 /**< \brief Timer/Counter 1 (TC1) */
+#define ID_TWIM0          4 /**< \brief Two-wire Master Interface 0 (TWIM0) */
+#define ID_TWIS0          5 /**< \brief Two-wire Slave Interface 0 (TWIS0) */
+#define ID_TWIM1          6 /**< \brief Two-wire Master Interface 1 (TWIM1) */
+#define ID_TWIS1          7 /**< \brief Two-wire Slave Interface 1 (TWIS1) */
+#define ID_USART0         8 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+#define ID_USART1         9 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+#define ID_USART2        10 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+#define ID_USART3        11 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+#define ID_ADCIFE        12 /**< \brief ADC controller interface (ADCIFE) */
+#define ID_DACC          13 /**< \brief DAC Controller (DACC) */
+#define ID_ACIFC         14 /**< \brief Analog Comparator Interface (ACIFC) */
+#define ID_GLOC          15 /**< \brief Glue Logic Controller (GLOC) */
+#define ID_ABDACB        16 /**< \brief Audio Bitstream DAC (ABDACB) */
+#define ID_TRNG          17 /**< \brief True Random Number Generator (TRNG) */
+#define ID_PARC          18 /**< \brief Parallel Capture (PARC) */
+#define ID_CATB          19 /**< \brief Capacitive Touch Module B (CATB) */
+#define ID_TWIM2         21 /**< \brief Two-wire Master Interface 2 (TWIM2) */
+#define ID_TWIM3         22 /**< \brief Two-wire Master Interface 3 (TWIM3) */
+
+// Peripheral instances on HTOP1 bridge
+#define ID_HFLASHC       32 /**< \brief Flash Controller (HFLASHC) */
+#define ID_HCACHE        33 /**< \brief Cortex M I&D Cache Controller (HCACHE) */
+#define ID_HMATRIX       34 /**< \brief HSB Matrix (HMATRIX) */
+#define ID_PDCA          35 /**< \brief Peripheral DMA Controller (PDCA) */
+#define ID_SMAP          36 /**< \brief System Manager Access Port (SMAP) */
+#define ID_CRCCU         37 /**< \brief CRC Calculation Unit (CRCCU) */
+#define ID_USBC          38 /**< \brief USB 2.0 Interface (USBC) */
+#define ID_PEVC          39 /**< \brief Peripheral Event Controller (PEVC) */
+
+// Peripheral instances on HTOP2 bridge
+#define ID_PM            64 /**< \brief Power Manager (PM) */
+#define ID_CHIPID        65 /**< \brief Chip ID Registers (CHIPID) */
+#define ID_SCIF          66 /**< \brief System Control Interface (SCIF) */
+#define ID_FREQM         67 /**< \brief Frequency Meter (FREQM) */
+#define ID_GPIO          68 /**< \brief General-Purpose Input/Output Controller (GPIO) */
+
+// Peripheral instances on HTOP3 bridge
+#define ID_BPM           96 /**< \brief Backup Power Manager (BPM) */
+#define ID_BSCIF         97 /**< \brief Backup System Control Interface (BSCIF) */
+#define ID_AST           98 /**< \brief Asynchronous Timer (AST) */
+#define ID_WDT           99 /**< \brief Watchdog Timer (WDT) */
+#define ID_EIC          100 /**< \brief External Interrupt Controller (EIC) */
+#define ID_PICOUART     101 /**< \brief Pico UART (PICOUART) */
+
+#define ID_PERIPH_COUNT 102 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAM4LS8B */
+/* ************************************************************************** */
+/** \defgroup SAM4LS8B_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define ABDACB                        (0x40064000) /**< \brief (ABDACB) APB Base Address */
+#define ACIFC                         (0x40040000) /**< \brief (ACIFC) APB Base Address */
+#define ADCIFE                        (0x40038000) /**< \brief (ADCIFE) APB Base Address */
+#define AST                           (0x400F0800) /**< \brief (AST) APB Base Address */
+#define BPM                           (0x400F0000) /**< \brief (BPM) APB Base Address */
+#define BSCIF                         (0x400F0400) /**< \brief (BSCIF) APB Base Address */
+#define CATB                          (0x40070000) /**< \brief (CATB) APB Base Address */
+#define CHIPID                        (0x400E0400) /**< \brief (CHIPID) APB Base Address */
+#define CRCCU                         (0x400A4000) /**< \brief (CRCCU) APB Base Address */
+#define DACC                          (0x4003C000) /**< \brief (DACC) APB Base Address */
+#define EIC                           (0x400F1000) /**< \brief (EIC) APB Base Address */
+#define HFLASHC                       (0x400A0000) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000) /**< \brief (HFLASHC) USER Base Address */
+#define FREQM                         (0x400E0C00) /**< \brief (FREQM) APB Base Address */
+#define GLOC                          (0x40060000) /**< \brief (GLOC) APB Base Address */
+#define GPIO                          (0x400E1000) /**< \brief (GPIO) APB Base Address */
+#define HCACHE                        (0x400A0400) /**< \brief (HCACHE) APB Base Address */
+#define HMATRIX                       (0x400A1000) /**< \brief (HMATRIX) APB Base Address */
+#define IISC                          (0x40004000) /**< \brief (IISC) APB Base Address */
+#define PARC                          (0x4006C000) /**< \brief (PARC) APB Base Address */
+#define PDCA                          (0x400A2000) /**< \brief (PDCA) APB Base Address */
+#define PEVC                          (0x400A6000) /**< \brief (PEVC) APB Base Address */
+#define PICOUART                      (0x400F1400) /**< \brief (PICOUART) APB Base Address */
+#define PM                            (0x400E0000) /**< \brief (PM) APB Base Address */
+#define SCIF                          (0x400E0800) /**< \brief (SCIF) APB Base Address */
+#define SMAP                          (0x400A3000) /**< \brief (SMAP) APB Base Address */
+#define SPI                           (0x40008000) /**< \brief (SPI) APB Base Address */
+#define TC0                           (0x40010000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x40014000) /**< \brief (TC1) APB Base Address */
+#define TRNG                          (0x40068000) /**< \brief (TRNG) APB Base Address */
+#define TWIM0                         (0x40018000) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1                         (0x4001C000) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2                         (0x40078000) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3                         (0x4007C000) /**< \brief (TWIM3) APB Base Address */
+#define TWIS0                         (0x40018400) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1                         (0x4001C400) /**< \brief (TWIS1) APB Base Address */
+#define USART0                        (0x40024000) /**< \brief (USART0) APB Base Address */
+#define USART1                        (0x40028000) /**< \brief (USART1) APB Base Address */
+#define USART2                        (0x4002C000) /**< \brief (USART2) APB Base Address */
+#define USART3                        (0x40030000) /**< \brief (USART3) APB Base Address */
+#define USBC                          (0x400A5000) /**< \brief (USBC) APB Base Address */
+#define WDT                           (0x400F0C00) /**< \brief (WDT) APB Base Address */
+#else
+#define ABDACB            ((Abdacb   *)0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_ADDR                   (0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_INST_NUM   1                          /**< \brief (ABDACB) Number of instances */
+#define ABDACB_INSTS      { ABDACB }                 /**< \brief (ABDACB) Instances List */
+
+#define ACIFC             ((Acifc    *)0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_ADDR                    (0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_INST_NUM    1                          /**< \brief (ACIFC) Number of instances */
+#define ACIFC_INSTS       { ACIFC }                  /**< \brief (ACIFC) Instances List */
+
+#define ADCIFE            ((Adcife   *)0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_ADDR                   (0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_INST_NUM   1                          /**< \brief (ADCIFE) Number of instances */
+#define ADCIFE_INSTS      { ADCIFE }                 /**< \brief (ADCIFE) Instances List */
+
+#define AST               ((Ast      *)0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_ADDR                      (0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_INST_NUM      1                          /**< \brief (AST) Number of instances */
+#define AST_INSTS         { AST }                    /**< \brief (AST) Instances List */
+
+#define BPM               ((Bpm      *)0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_ADDR                      (0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_INST_NUM      1                          /**< \brief (BPM) Number of instances */
+#define BPM_INSTS         { BPM }                    /**< \brief (BPM) Instances List */
+
+#define BSCIF             ((Bscif    *)0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_ADDR                    (0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_INST_NUM    1                          /**< \brief (BSCIF) Number of instances */
+#define BSCIF_INSTS       { BSCIF }                  /**< \brief (BSCIF) Instances List */
+
+#define CATB              ((Catb     *)0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_ADDR                     (0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_INST_NUM     1                          /**< \brief (CATB) Number of instances */
+#define CATB_INSTS        { CATB }                   /**< \brief (CATB) Instances List */
+
+#define CHIPID            ((Chipid   *)0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_ADDR                   (0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_INST_NUM   1                          /**< \brief (CHIPID) Number of instances */
+#define CHIPID_INSTS      { CHIPID }                 /**< \brief (CHIPID) Instances List */
+
+#define CRCCU             ((Crccu    *)0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_ADDR                    (0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_INST_NUM    1                          /**< \brief (CRCCU) Number of instances */
+#define CRCCU_INSTS       { CRCCU }                  /**< \brief (CRCCU) Instances List */
+
+#define DACC              ((Dacc     *)0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_ADDR                     (0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_INST_NUM     1                          /**< \brief (DACC) Number of instances */
+#define DACC_INSTS        { DACC }                   /**< \brief (DACC) Instances List */
+
+#define EIC               ((Eic      *)0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_ADDR                      (0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define HFLASHC           ((Flashcalw *)0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_ADDR                  (0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_FROW_ADDR             (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define HFLASHC_USER_ADDR             (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define FLASHCALW_INST_NUM 1                          /**< \brief (FLASHCALW) Number of instances */
+#define FLASHCALW_INSTS   { HFLASHC }                /**< \brief (FLASHCALW) Instances List */
+
+#define FREQM             ((Freqm    *)0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_ADDR                    (0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_INST_NUM    1                          /**< \brief (FREQM) Number of instances */
+#define FREQM_INSTS       { FREQM }                  /**< \brief (FREQM) Instances List */
+
+#define GLOC              ((Gloc     *)0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_ADDR                     (0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_INST_NUM     1                          /**< \brief (GLOC) Number of instances */
+#define GLOC_INSTS        { GLOC }                   /**< \brief (GLOC) Instances List */
+
+#define GPIO              ((Gpio     *)0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_ADDR                     (0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_INST_NUM     1                          /**< \brief (GPIO) Number of instances */
+#define GPIO_INSTS        { GPIO }                   /**< \brief (GPIO) Instances List */
+
+#define HCACHE            ((Hcache   *)0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_ADDR                   (0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_INST_NUM   1                          /**< \brief (HCACHE) Number of instances */
+#define HCACHE_INSTS      { HCACHE }                 /**< \brief (HCACHE) Instances List */
+
+#define HMATRIX           ((Hmatrixb *)0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIX_ADDR                  (0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIXB_INST_NUM 1                          /**< \brief (HMATRIXB) Number of instances */
+#define HMATRIXB_INSTS    { HMATRIX }                /**< \brief (HMATRIXB) Instances List */
+
+#define IISC              ((Iisc     *)0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_ADDR                     (0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_INST_NUM     1                          /**< \brief (IISC) Number of instances */
+#define IISC_INSTS        { IISC }                   /**< \brief (IISC) Instances List */
+
+#define PARC              ((Parc     *)0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_ADDR                     (0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_INST_NUM     1                          /**< \brief (PARC) Number of instances */
+#define PARC_INSTS        { PARC }                   /**< \brief (PARC) Instances List */
+
+#define PDCA              ((Pdca     *)0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_ADDR                     (0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_INST_NUM     1                          /**< \brief (PDCA) Number of instances */
+#define PDCA_INSTS        { PDCA }                   /**< \brief (PDCA) Instances List */
+
+#define PEVC              ((Pevc     *)0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_ADDR                     (0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_INST_NUM     1                          /**< \brief (PEVC) Number of instances */
+#define PEVC_INSTS        { PEVC }                   /**< \brief (PEVC) Instances List */
+
+#define PICOUART          ((Picouart *)0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_ADDR                 (0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_INST_NUM 1                          /**< \brief (PICOUART) Number of instances */
+#define PICOUART_INSTS    { PICOUART }               /**< \brief (PICOUART) Instances List */
+
+#define PM                ((Pm       *)0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_ADDR                       (0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define SCIF              ((Scif     *)0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_ADDR                     (0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_INST_NUM     1                          /**< \brief (SCIF) Number of instances */
+#define SCIF_INSTS        { SCIF }                   /**< \brief (SCIF) Instances List */
+
+#define SMAP              ((Smap     *)0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_ADDR                     (0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_INST_NUM     1                          /**< \brief (SMAP) Number of instances */
+#define SMAP_INSTS        { SMAP }                   /**< \brief (SMAP) Instances List */
+
+#define SPI               ((Spi      *)0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_ADDR                      (0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_INST_NUM      1                          /**< \brief (SPI) Number of instances */
+#define SPI_INSTS         { SPI }                    /**< \brief (SPI) Instances List */
+
+#define TC0               ((Tc       *)0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC0_ADDR                      (0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC1_ADDR                      (0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC_INST_NUM       2                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1 }               /**< \brief (TC) Instances List */
+
+#define TRNG              ((Trng     *)0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_ADDR                     (0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_INST_NUM     1                          /**< \brief (TRNG) Number of instances */
+#define TRNG_INSTS        { TRNG }                   /**< \brief (TRNG) Instances List */
+
+#define TWIM0             ((Twim     *)0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM0_ADDR                    (0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1             ((Twim     *)0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM1_ADDR                    (0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2             ((Twim     *)0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM2_ADDR                    (0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3             ((Twim     *)0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM3_ADDR                    (0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM_INST_NUM     4                          /**< \brief (TWIM) Number of instances */
+#define TWIM_INSTS        { TWIM0, TWIM1, TWIM2, TWIM3 } /**< \brief (TWIM) Instances List */
+
+#define TWIS0             ((Twis     *)0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS0_ADDR                    (0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1             ((Twis     *)0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS1_ADDR                    (0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS_INST_NUM     2                          /**< \brief (TWIS) Number of instances */
+#define TWIS_INSTS        { TWIS0, TWIS1 }           /**< \brief (TWIS) Instances List */
+
+#define USART0            ((Usart    *)0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART0_ADDR                   (0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART1            ((Usart    *)0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART1_ADDR                   (0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART2            ((Usart    *)0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART2_ADDR                   (0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART3            ((Usart    *)0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART3_ADDR                   (0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART_INST_NUM    4                          /**< \brief (USART) Number of instances */
+#define USART_INSTS       { USART0, USART1, USART2, USART3 } /**< \brief (USART) Instances List */
+
+#define USBC              ((Usbc     *)0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_ADDR                     (0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_INST_NUM     1                          /**< \brief (USBC) Number of instances */
+#define USBC_INSTS        { USBC }                   /**< \brief (USBC) Instances List */
+
+#define WDT               ((Wdt      *)0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_ADDR                      (0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  GPIO DEFINITIONS FOR SAM4LS8B */
+/* ************************************************************************** */
+/** \defgroup SAM4LS8B_gpio GPIO Definitions */
+/*@{*/
+
+#include "pio/sam4ls8b.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  ADDITIONAL DEFINITIONS FOR COMPATIBILITY */
+/* ************************************************************************** */
+/** \addtogroup SAM4LS8B_compat Definitions */
+/*@{*/
+// These defines are used to keep compatibility with existing 
+// sam/drivers/usart implementation from SAM3/4 products with SAM4L product.
+#define US_MR_USART_MODE_HW_HANDSHAKING  US_MR_USART_MODE_HARDWARE
+#define US_MR_USART_MODE_IS07816_T_0     US_MR_USART_MODE_ISO7816_T0
+#define US_MR_USART_MODE_IS07816_T_1     US_MR_USART_MODE_ISO7816_T1
+#define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
+#define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
+#define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_8_BIT      US_MR_CHRL_8
+#define US_MR_PAR_NO          US_MR_PAR_NONE
+#define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI
+#define US_IF                 US_IFR
+#define US_WPSR_WPVS          US_WPSR_WPV_1
+
+#define USBC_UPCFG0_PBK_Msk   (0x1u << USBC_UPCFG0_PBK_Pos)
+
+// These defines for homogeneity with other SAM header files.
+#define CHIP_FREQ_FWS_0       (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 */
+#define CHIP_FREQ_FWS_1       (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 */
+// WARNING NOTE: these are preliminary values.
+#define CHIP_FREQ_FLASH_HSEN_FWS_0 (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 and the FLASH HS mode is enabled */
+#define CHIP_FREQ_FLASH_HSEN_FWS_1 (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 and the FLASH HS mode is enabled */
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/tc implementation from SAM3/4 products with SAM4L product. 
+#define TC_CMR_LDRA_RISING    TC_CMR_LDRA_POS_EDGE_TIOA
+#define TC_CMR_LDRB_FALLING   TC_CMR_LDRB_NEG_EDGE_TIOA
+#define TC_CMR_ETRGEDG_FALLING TC_CMR_ETRGEDG_NEG_EDGE
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/spi implementation from SAM3/4 products with SAM4L product. 
+#define SPI_CSR_BITS_8_BIT    SPI_CSR_BITS_8_BPT
+#define SPI_WPCR_SPIWPKEY_VALUE SPI_WPCR_WPKEY_VALUE
+#define SPI_WPCR_SPIWPEN      SPI_WPCR_WPEN
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/crccu implementation from SAM3/4 products with SAM4L product. 
+#define CRCCU_DMA_EN          CRCCU_DMAEN
+#define CRCCU_DMA_DIS         CRCCU_DMADIS
+#define CRCCU_DMA_SR          CRCCU_DMASR
+#define CRCCU_DMA_IER         CRCCU_DMAIER
+#define CRCCU_DMA_IDR         CRCCU_DMAIDR
+#define CRCCU_DMA_IMR         CRCCU_DMAIMR
+#define CRCCU_DMA_ISR         CRCCU_DMAISR
+#define CRCCU_DMA_EN_DMAEN    CRCCU_DMAEN_DMAEN
+#define CRCCU_DMA_DIS_DMADIS  CRCCU_DMADIS_DMADIS
+#define CRCCU_DMA_SR_DMASR    CRCCU_DMASR_DMASR
+#define CRCCU_DMA_IER_DMAIER  CRCCU_DMAIER_DMAIER
+#define CRCCU_DMA_IDR_DMAIDR  CRCCU_DMAIDR_DMAIDR
+#define CRCCU_DMA_IMR_DMAIMR  CRCCU_DMAIMR_DMAIMR
+#define CRCCU_DMA_ISR_DMAISR  CRCCU_DMAISR_DMAISR
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAM4LS8B */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL(0x00080000) /* 512 kB */
+#define FLASH_PAGE_SIZE       512
+#define FLASH_NB_OF_PAGES     1024
+#define FLASH_USER_PAGE_SIZE  512
+#define HRAMC0_SIZE           _UL(0x00010000) /* 64 kB */
+#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+
+#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+
+#define DSU_DID_RESETVALUE    _UL(0xAB0B0AE0)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAM4LS8B */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAM4LS8B_H */

--- a/asf/sam/include/sam4l/sam4ls8b.h
+++ b/asf/sam/include/sam4l/sam4ls8b.h
@@ -62,15 +62,15 @@ typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volati
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
 #if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#define _U_(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
 #if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#define _U_(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 
@@ -857,23 +857,23 @@ void TWIM3_Handler               ( void );
 /**  MEMORY MAPPING DEFINITIONS FOR SAM4LS8B */
 /* ************************************************************************** */
 
-#define FLASH_SIZE            _UL(0x00080000) /* 512 kB */
+#define FLASH_SIZE            _UL_(0x00080000) /* 512 kB */
 #define FLASH_PAGE_SIZE       512
 #define FLASH_NB_OF_PAGES     1024
 #define FLASH_USER_PAGE_SIZE  512
-#define HRAMC0_SIZE           _UL(0x00010000) /* 64 kB */
-#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+#define HRAMC0_SIZE           _UL_(0x00010000) /* 64 kB */
+#define HRAMC1_SIZE           _UL_(0x00000800) /* 2 kB */
 
-#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
-#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
-#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
-#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
-#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
-#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
-#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
-#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL_(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL_(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL_(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL_(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL_(0x400F0000) /**< HTOP3 base address */
 
-#define DSU_DID_RESETVALUE    _UL(0xAB0B0AE0)
+#define DSU_DID_RESETVALUE    _UL_(0xAB0B0AE0)
 
 /* ************************************************************************** */
 /**  ELECTRICAL DEFINITIONS FOR SAM4LS8B */

--- a/asf/sam/include/sam4l/sam4ls8c.h
+++ b/asf/sam/include/sam4l/sam4ls8c.h
@@ -62,15 +62,15 @@ typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volati
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
 #if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#define _U_(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
 #if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#define _U_(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 
@@ -857,23 +857,23 @@ void TWIM3_Handler               ( void );
 /**  MEMORY MAPPING DEFINITIONS FOR SAM4LS8C */
 /* ************************************************************************** */
 
-#define FLASH_SIZE            _UL(0x00080000) /* 512 kB */
+#define FLASH_SIZE            _UL_(0x00080000) /* 512 kB */
 #define FLASH_PAGE_SIZE       512
 #define FLASH_NB_OF_PAGES     1024
 #define FLASH_USER_PAGE_SIZE  512
-#define HRAMC0_SIZE           _UL(0x00010000) /* 64 kB */
-#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+#define HRAMC0_SIZE           _UL_(0x00010000) /* 64 kB */
+#define HRAMC1_SIZE           _UL_(0x00000800) /* 2 kB */
 
-#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
-#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
-#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
-#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
-#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
-#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
-#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
-#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL_(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL_(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL_(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL_(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL_(0x400F0000) /**< HTOP3 base address */
 
-#define DSU_DID_RESETVALUE    _UL(0xAB0B0AE0)
+#define DSU_DID_RESETVALUE    _UL_(0xAB0B0AE0)
 
 /* ************************************************************************** */
 /**  ELECTRICAL DEFINITIONS FOR SAM4LS8C */

--- a/asf/sam/include/sam4l/sam4ls8c.h
+++ b/asf/sam/include/sam4l/sam4ls8c.h
@@ -1,0 +1,889 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAM4LS8C
+ *
+ * Copyright (c) 2016 Atmel Corporation,
+ *                    a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAM4LS8C_
+#define _SAM4LS8C_
+
+/**
+ * \ingroup SAM4L_definitions
+ * \addtogroup SAM4LS8C_definitions SAM4LS8C definitions
+ * This file defines all structures and symbols for SAM4LS8C:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#if !defined(_UL)
+#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#endif
+#else
+#if !defined(_UL)
+#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif
+#endif
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAM4LS8C */
+/* ************************************************************************** */
+/** \defgroup SAM4LS8C_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M4 Processor Exceptions Numbers ******************************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt                */
+  HardFault_IRQn           = -13,/**<  3 Cortex-M4 Hard Fault Interrupt        */
+  MemoryManagement_IRQn    = -12,/**<  4 Cortex-M4 Memory Management Interrupt */
+  BusFault_IRQn            = -11,/**<  5 Cortex-M4 Bus Fault Interrupt         */
+  UsageFault_IRQn          = -10,/**<  6 Cortex-M4 Usage Fault Interrupt       */
+  SVCall_IRQn              = -5, /**< 11 Cortex-M4 SV Call Interrupt           */
+  DebugMonitor_IRQn        = -4, /**< 12 Cortex-M4 Debug Monitor Interrupt     */
+  PendSV_IRQn              = -2, /**< 14 Cortex-M4 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 Cortex-M4 System Tick Interrupt       */
+  /******  SAM4LS8C-specific Interrupt Numbers ***********************/
+  HFLASHC_IRQn             =  0, /**<  0 SAM4LS8C Flash Controller (HFLASHC) */
+  PDCA_0_IRQn              =  1, /**<  1 SAM4LS8C Peripheral DMA Controller (PDCA): PDCA_0 */
+  PDCA_1_IRQn              =  2, /**<  2 SAM4LS8C Peripheral DMA Controller (PDCA): PDCA_1 */
+  PDCA_2_IRQn              =  3, /**<  3 SAM4LS8C Peripheral DMA Controller (PDCA): PDCA_2 */
+  PDCA_3_IRQn              =  4, /**<  4 SAM4LS8C Peripheral DMA Controller (PDCA): PDCA_3 */
+  PDCA_4_IRQn              =  5, /**<  5 SAM4LS8C Peripheral DMA Controller (PDCA): PDCA_4 */
+  PDCA_5_IRQn              =  6, /**<  6 SAM4LS8C Peripheral DMA Controller (PDCA): PDCA_5 */
+  PDCA_6_IRQn              =  7, /**<  7 SAM4LS8C Peripheral DMA Controller (PDCA): PDCA_6 */
+  PDCA_7_IRQn              =  8, /**<  8 SAM4LS8C Peripheral DMA Controller (PDCA): PDCA_7 */
+  PDCA_8_IRQn              =  9, /**<  9 SAM4LS8C Peripheral DMA Controller (PDCA): PDCA_8 */
+  PDCA_9_IRQn              = 10, /**< 10 SAM4LS8C Peripheral DMA Controller (PDCA): PDCA_9 */
+  PDCA_10_IRQn             = 11, /**< 11 SAM4LS8C Peripheral DMA Controller (PDCA): PDCA_10 */
+  PDCA_11_IRQn             = 12, /**< 12 SAM4LS8C Peripheral DMA Controller (PDCA): PDCA_11 */
+  PDCA_12_IRQn             = 13, /**< 13 SAM4LS8C Peripheral DMA Controller (PDCA): PDCA_12 */
+  PDCA_13_IRQn             = 14, /**< 14 SAM4LS8C Peripheral DMA Controller (PDCA): PDCA_13 */
+  PDCA_14_IRQn             = 15, /**< 15 SAM4LS8C Peripheral DMA Controller (PDCA): PDCA_14 */
+  PDCA_15_IRQn             = 16, /**< 16 SAM4LS8C Peripheral DMA Controller (PDCA): PDCA_15 */
+  CRCCU_IRQn               = 17, /**< 17 SAM4LS8C CRC Calculation Unit (CRCCU) */
+  USBC_IRQn                = 18, /**< 18 SAM4LS8C USB 2.0 Interface (USBC) */
+  PEVC_0_IRQn              = 19, /**< 19 SAM4LS8C Peripheral Event Controller (PEVC): PEVC_TR */
+  PEVC_1_IRQn              = 20, /**< 20 SAM4LS8C Peripheral Event Controller (PEVC): PEVC_OV */
+  PM_IRQn                  = 22, /**< 22 SAM4LS8C Power Manager (PM) */
+  SCIF_IRQn                = 23, /**< 23 SAM4LS8C System Control Interface (SCIF) */
+  FREQM_IRQn               = 24, /**< 24 SAM4LS8C Frequency Meter (FREQM) */
+  GPIO_0_IRQn              = 25, /**< 25 SAM4LS8C General-Purpose Input/Output Controller (GPIO): GPIO_0 */
+  GPIO_1_IRQn              = 26, /**< 26 SAM4LS8C General-Purpose Input/Output Controller (GPIO): GPIO_1 */
+  GPIO_2_IRQn              = 27, /**< 27 SAM4LS8C General-Purpose Input/Output Controller (GPIO): GPIO_2 */
+  GPIO_3_IRQn              = 28, /**< 28 SAM4LS8C General-Purpose Input/Output Controller (GPIO): GPIO_3 */
+  GPIO_4_IRQn              = 29, /**< 29 SAM4LS8C General-Purpose Input/Output Controller (GPIO): GPIO_4 */
+  GPIO_5_IRQn              = 30, /**< 30 SAM4LS8C General-Purpose Input/Output Controller (GPIO): GPIO_5 */
+  GPIO_6_IRQn              = 31, /**< 31 SAM4LS8C General-Purpose Input/Output Controller (GPIO): GPIO_6 */
+  GPIO_7_IRQn              = 32, /**< 32 SAM4LS8C General-Purpose Input/Output Controller (GPIO): GPIO_7 */
+  GPIO_8_IRQn              = 33, /**< 33 SAM4LS8C General-Purpose Input/Output Controller (GPIO): GPIO_8 */
+  GPIO_9_IRQn              = 34, /**< 34 SAM4LS8C General-Purpose Input/Output Controller (GPIO): GPIO_9 */
+  GPIO_10_IRQn             = 35, /**< 35 SAM4LS8C General-Purpose Input/Output Controller (GPIO): GPIO_10 */
+  GPIO_11_IRQn             = 36, /**< 36 SAM4LS8C General-Purpose Input/Output Controller (GPIO): GPIO_11 */
+  BPM_IRQn                 = 37, /**< 37 SAM4LS8C Backup Power Manager (BPM) */
+  BSCIF_IRQn               = 38, /**< 38 SAM4LS8C Backup System Control Interface (BSCIF) */
+  AST_0_IRQn               = 39, /**< 39 SAM4LS8C Asynchronous Timer (AST): AST_ALARM */
+  AST_1_IRQn               = 40, /**< 40 SAM4LS8C Asynchronous Timer (AST): AST_PER */
+  AST_2_IRQn               = 41, /**< 41 SAM4LS8C Asynchronous Timer (AST): AST_OVF */
+  AST_3_IRQn               = 42, /**< 42 SAM4LS8C Asynchronous Timer (AST): AST_READY */
+  AST_4_IRQn               = 43, /**< 43 SAM4LS8C Asynchronous Timer (AST): AST_CLKREADY */
+  WDT_IRQn                 = 44, /**< 44 SAM4LS8C Watchdog Timer (WDT) */
+  EIC_0_IRQn               = 45, /**< 45 SAM4LS8C External Interrupt Controller (EIC): EIC_1 */
+  EIC_1_IRQn               = 46, /**< 46 SAM4LS8C External Interrupt Controller (EIC): EIC_2 */
+  EIC_2_IRQn               = 47, /**< 47 SAM4LS8C External Interrupt Controller (EIC): EIC_3 */
+  EIC_3_IRQn               = 48, /**< 48 SAM4LS8C External Interrupt Controller (EIC): EIC_4 */
+  EIC_4_IRQn               = 49, /**< 49 SAM4LS8C External Interrupt Controller (EIC): EIC_5 */
+  EIC_5_IRQn               = 50, /**< 50 SAM4LS8C External Interrupt Controller (EIC): EIC_6 */
+  EIC_6_IRQn               = 51, /**< 51 SAM4LS8C External Interrupt Controller (EIC): EIC_7 */
+  EIC_7_IRQn               = 52, /**< 52 SAM4LS8C External Interrupt Controller (EIC): EIC_8 */
+  IISC_IRQn                = 53, /**< 53 SAM4LS8C Inter-IC Sound (I2S) Controller (IISC) */
+  SPI_IRQn                 = 54, /**< 54 SAM4LS8C Serial Peripheral Interface (SPI) */
+  TC0_0_IRQn               = 55, /**< 55 SAM4LS8C Timer/Counter 0 (TC0): TC00 */
+  TC0_1_IRQn               = 56, /**< 56 SAM4LS8C Timer/Counter 0 (TC0): TC01 */
+  TC0_2_IRQn               = 57, /**< 57 SAM4LS8C Timer/Counter 0 (TC0): TC02 */
+  TC1_0_IRQn               = 58, /**< 58 SAM4LS8C Timer/Counter 1 (TC1): TC10 */
+  TC1_1_IRQn               = 59, /**< 59 SAM4LS8C Timer/Counter 1 (TC1): TC11 */
+  TC1_2_IRQn               = 60, /**< 60 SAM4LS8C Timer/Counter 1 (TC1): TC12 */
+  TWIM0_IRQn               = 61, /**< 61 SAM4LS8C Two-wire Master Interface 0 (TWIM0) */
+  TWIS0_IRQn               = 62, /**< 62 SAM4LS8C Two-wire Slave Interface 0 (TWIS0) */
+  TWIM1_IRQn               = 63, /**< 63 SAM4LS8C Two-wire Master Interface 1 (TWIM1) */
+  TWIS1_IRQn               = 64, /**< 64 SAM4LS8C Two-wire Slave Interface 1 (TWIS1) */
+  USART0_IRQn              = 65, /**< 65 SAM4LS8C Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+  USART1_IRQn              = 66, /**< 66 SAM4LS8C Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+  USART2_IRQn              = 67, /**< 67 SAM4LS8C Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+  USART3_IRQn              = 68, /**< 68 SAM4LS8C Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+  ADCIFE_IRQn              = 69, /**< 69 SAM4LS8C ADC controller interface (ADCIFE) */
+  DACC_IRQn                = 70, /**< 70 SAM4LS8C DAC Controller (DACC) */
+  ACIFC_IRQn               = 71, /**< 71 SAM4LS8C Analog Comparator Interface (ACIFC) */
+  ABDACB_IRQn              = 72, /**< 72 SAM4LS8C Audio Bitstream DAC (ABDACB) */
+  TRNG_IRQn                = 73, /**< 73 SAM4LS8C True Random Number Generator (TRNG) */
+  PARC_IRQn                = 74, /**< 74 SAM4LS8C Parallel Capture (PARC) */
+  CATB_IRQn                = 75, /**< 75 SAM4LS8C Capacitive Touch Module B (CATB) */
+  TWIM2_IRQn               = 77, /**< 77 SAM4LS8C Two-wire Master Interface 2 (TWIM2) */
+  TWIM3_IRQn               = 78, /**< 78 SAM4LS8C Two-wire Master Interface 3 (TWIM3) */
+
+  PERIPH_COUNT_IRQn        = 80  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNMI_Handler;
+  void* pfnHardFault_Handler;
+  void* pfnMemManage_Handler;
+  void* pfnBusFault_Handler;
+  void* pfnUsageFault_Handler;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVC_Handler;
+  void* pfnDebugMon_Handler;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnHFLASHC_Handler;               /*  0 Flash Controller */
+  void* pfnPDCA_0_Handler;                /*  1 Peripheral DMA Controller IRQ 0 */
+  void* pfnPDCA_1_Handler;                /*  2 Peripheral DMA Controller IRQ 1 */
+  void* pfnPDCA_2_Handler;                /*  3 Peripheral DMA Controller IRQ 2 */
+  void* pfnPDCA_3_Handler;                /*  4 Peripheral DMA Controller IRQ 3 */
+  void* pfnPDCA_4_Handler;                /*  5 Peripheral DMA Controller IRQ 4 */
+  void* pfnPDCA_5_Handler;                /*  6 Peripheral DMA Controller IRQ 5 */
+  void* pfnPDCA_6_Handler;                /*  7 Peripheral DMA Controller IRQ 6 */
+  void* pfnPDCA_7_Handler;                /*  8 Peripheral DMA Controller IRQ 7 */
+  void* pfnPDCA_8_Handler;                /*  9 Peripheral DMA Controller IRQ 8 */
+  void* pfnPDCA_9_Handler;                /* 10 Peripheral DMA Controller IRQ 9 */
+  void* pfnPDCA_10_Handler;               /* 11 Peripheral DMA Controller IRQ 10 */
+  void* pfnPDCA_11_Handler;               /* 12 Peripheral DMA Controller IRQ 11 */
+  void* pfnPDCA_12_Handler;               /* 13 Peripheral DMA Controller IRQ 12 */
+  void* pfnPDCA_13_Handler;               /* 14 Peripheral DMA Controller IRQ 13 */
+  void* pfnPDCA_14_Handler;               /* 15 Peripheral DMA Controller IRQ 14 */
+  void* pfnPDCA_15_Handler;               /* 16 Peripheral DMA Controller IRQ 15 */
+  void* pfnCRCCU_Handler;                 /* 17 CRC Calculation Unit */
+  void* pfnUSBC_Handler;                  /* 18 USB 2.0 Interface */
+  void* pfnPEVC_0_Handler;                /* 19 Peripheral Event Controller IRQ 0 */
+  void* pfnPEVC_1_Handler;                /* 20 Peripheral Event Controller IRQ 1 */
+  void* pvReserved21;
+  void* pfnPM_Handler;                    /* 22 Power Manager */
+  void* pfnSCIF_Handler;                  /* 23 System Control Interface */
+  void* pfnFREQM_Handler;                 /* 24 Frequency Meter */
+  void* pfnGPIO_0_Handler;                /* 25 General-Purpose Input/Output Controller IRQ 0 */
+  void* pfnGPIO_1_Handler;                /* 26 General-Purpose Input/Output Controller IRQ 1 */
+  void* pfnGPIO_2_Handler;                /* 27 General-Purpose Input/Output Controller IRQ 2 */
+  void* pfnGPIO_3_Handler;                /* 28 General-Purpose Input/Output Controller IRQ 3 */
+  void* pfnGPIO_4_Handler;                /* 29 General-Purpose Input/Output Controller IRQ 4 */
+  void* pfnGPIO_5_Handler;                /* 30 General-Purpose Input/Output Controller IRQ 5 */
+  void* pfnGPIO_6_Handler;                /* 31 General-Purpose Input/Output Controller IRQ 6 */
+  void* pfnGPIO_7_Handler;                /* 32 General-Purpose Input/Output Controller IRQ 7 */
+  void* pfnGPIO_8_Handler;                /* 33 General-Purpose Input/Output Controller IRQ 8 */
+  void* pfnGPIO_9_Handler;                /* 34 General-Purpose Input/Output Controller IRQ 9 */
+  void* pfnGPIO_10_Handler;               /* 35 General-Purpose Input/Output Controller IRQ 10 */
+  void* pfnGPIO_11_Handler;               /* 36 General-Purpose Input/Output Controller IRQ 11 */
+  void* pfnBPM_Handler;                   /* 37 Backup Power Manager */
+  void* pfnBSCIF_Handler;                 /* 38 Backup System Control Interface */
+  void* pfnAST_0_Handler;                 /* 39 Asynchronous Timer IRQ 0 */
+  void* pfnAST_1_Handler;                 /* 40 Asynchronous Timer IRQ 1 */
+  void* pfnAST_2_Handler;                 /* 41 Asynchronous Timer IRQ 2 */
+  void* pfnAST_3_Handler;                 /* 42 Asynchronous Timer IRQ 3 */
+  void* pfnAST_4_Handler;                 /* 43 Asynchronous Timer IRQ 4 */
+  void* pfnWDT_Handler;                   /* 44 Watchdog Timer */
+  void* pfnEIC_0_Handler;                 /* 45 External Interrupt Controller IRQ 0 */
+  void* pfnEIC_1_Handler;                 /* 46 External Interrupt Controller IRQ 1 */
+  void* pfnEIC_2_Handler;                 /* 47 External Interrupt Controller IRQ 2 */
+  void* pfnEIC_3_Handler;                 /* 48 External Interrupt Controller IRQ 3 */
+  void* pfnEIC_4_Handler;                 /* 49 External Interrupt Controller IRQ 4 */
+  void* pfnEIC_5_Handler;                 /* 50 External Interrupt Controller IRQ 5 */
+  void* pfnEIC_6_Handler;                 /* 51 External Interrupt Controller IRQ 6 */
+  void* pfnEIC_7_Handler;                 /* 52 External Interrupt Controller IRQ 7 */
+  void* pfnIISC_Handler;                  /* 53 Inter-IC Sound (I2S) Controller */
+  void* pfnSPI_Handler;                   /* 54 Serial Peripheral Interface */
+  void* pfnTC0_0_Handler;                 /* 55 Timer/Counter 0 IRQ 0 */
+  void* pfnTC0_1_Handler;                 /* 56 Timer/Counter 0 IRQ 1 */
+  void* pfnTC0_2_Handler;                 /* 57 Timer/Counter 0 IRQ 2 */
+  void* pfnTC1_0_Handler;                 /* 58 Timer/Counter 1 IRQ 0 */
+  void* pfnTC1_1_Handler;                 /* 59 Timer/Counter 1 IRQ 1 */
+  void* pfnTC1_2_Handler;                 /* 60 Timer/Counter 1 IRQ 2 */
+  void* pfnTWIM0_Handler;                 /* 61 Two-wire Master Interface 0 */
+  void* pfnTWIS0_Handler;                 /* 62 Two-wire Slave Interface 0 */
+  void* pfnTWIM1_Handler;                 /* 63 Two-wire Master Interface 1 */
+  void* pfnTWIS1_Handler;                 /* 64 Two-wire Slave Interface 1 */
+  void* pfnUSART0_Handler;                /* 65 Universal Synchronous Asynchronous Receiver Transmitter 0 */
+  void* pfnUSART1_Handler;                /* 66 Universal Synchronous Asynchronous Receiver Transmitter 1 */
+  void* pfnUSART2_Handler;                /* 67 Universal Synchronous Asynchronous Receiver Transmitter 2 */
+  void* pfnUSART3_Handler;                /* 68 Universal Synchronous Asynchronous Receiver Transmitter 3 */
+  void* pfnADCIFE_Handler;                /* 69 ADC controller interface */
+  void* pfnDACC_Handler;                  /* 70 DAC Controller */
+  void* pfnACIFC_Handler;                 /* 71 Analog Comparator Interface */
+  void* pfnABDACB_Handler;                /* 72 Audio Bitstream DAC */
+  void* pfnTRNG_Handler;                  /* 73 True Random Number Generator */
+  void* pfnPARC_Handler;                  /* 74 Parallel Capture */
+  void* pfnCATB_Handler;                  /* 75 Capacitive Touch Module B */
+  void* pvReserved76;
+  void* pfnTWIM2_Handler;                 /* 77 Two-wire Master Interface 2 */
+  void* pfnTWIM3_Handler;                 /* 78 Two-wire Master Interface 3 */
+  void* pvReserved79;
+} DeviceVectors;
+
+/* Cortex-M4 processor handlers */
+void Reset_Handler               ( void );
+void NMI_Handler                 ( void );
+void HardFault_Handler           ( void );
+void MemManage_Handler           ( void );
+void BusFault_Handler            ( void );
+void UsageFault_Handler          ( void );
+void SVC_Handler                 ( void );
+void DebugMon_Handler            ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void HFLASHC_Handler             ( void );
+void PDCA_0_Handler              ( void );
+void PDCA_1_Handler              ( void );
+void PDCA_2_Handler              ( void );
+void PDCA_3_Handler              ( void );
+void PDCA_4_Handler              ( void );
+void PDCA_5_Handler              ( void );
+void PDCA_6_Handler              ( void );
+void PDCA_7_Handler              ( void );
+void PDCA_8_Handler              ( void );
+void PDCA_9_Handler              ( void );
+void PDCA_10_Handler             ( void );
+void PDCA_11_Handler             ( void );
+void PDCA_12_Handler             ( void );
+void PDCA_13_Handler             ( void );
+void PDCA_14_Handler             ( void );
+void PDCA_15_Handler             ( void );
+void CRCCU_Handler               ( void );
+void USBC_Handler                ( void );
+void PEVC_0_Handler              ( void );
+void PEVC_1_Handler              ( void );
+void PM_Handler                  ( void );
+void SCIF_Handler                ( void );
+void FREQM_Handler               ( void );
+void GPIO_0_Handler              ( void );
+void GPIO_1_Handler              ( void );
+void GPIO_2_Handler              ( void );
+void GPIO_3_Handler              ( void );
+void GPIO_4_Handler              ( void );
+void GPIO_5_Handler              ( void );
+void GPIO_6_Handler              ( void );
+void GPIO_7_Handler              ( void );
+void GPIO_8_Handler              ( void );
+void GPIO_9_Handler              ( void );
+void GPIO_10_Handler             ( void );
+void GPIO_11_Handler             ( void );
+void BPM_Handler                 ( void );
+void BSCIF_Handler               ( void );
+void AST_0_Handler               ( void );
+void AST_1_Handler               ( void );
+void AST_2_Handler               ( void );
+void AST_3_Handler               ( void );
+void AST_4_Handler               ( void );
+void WDT_Handler                 ( void );
+void EIC_0_Handler               ( void );
+void EIC_1_Handler               ( void );
+void EIC_2_Handler               ( void );
+void EIC_3_Handler               ( void );
+void EIC_4_Handler               ( void );
+void EIC_5_Handler               ( void );
+void EIC_6_Handler               ( void );
+void EIC_7_Handler               ( void );
+void IISC_Handler                ( void );
+void SPI_Handler                 ( void );
+void TC0_0_Handler               ( void );
+void TC0_1_Handler               ( void );
+void TC0_2_Handler               ( void );
+void TC1_0_Handler               ( void );
+void TC1_1_Handler               ( void );
+void TC1_2_Handler               ( void );
+void TWIM0_Handler               ( void );
+void TWIS0_Handler               ( void );
+void TWIM1_Handler               ( void );
+void TWIS1_Handler               ( void );
+void USART0_Handler              ( void );
+void USART1_Handler              ( void );
+void USART2_Handler              ( void );
+void USART3_Handler              ( void );
+void ADCIFE_Handler              ( void );
+void DACC_Handler                ( void );
+void ACIFC_Handler               ( void );
+void ABDACB_Handler              ( void );
+void TRNG_Handler                ( void );
+void PARC_Handler                ( void );
+void CATB_Handler                ( void );
+void TWIM2_Handler               ( void );
+void TWIM3_Handler               ( void );
+
+/*
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals
+ */
+
+#define LITTLE_ENDIAN          1        
+#define __BB_PRESENT           0         /*!< BIT_BANDING present or not */
+#define __CLKGATE_PRESENT      1         /*!< CLKGATE present or not */
+#define __CM4_REV              1         /*!< Core revision r0p1 */
+#define __DEBUG_LVL            3         /*!< Full debug plus DWT data matching */
+#define __FPU_PRESENT          0         /*!< FPU present or not */
+#define __JTAG_PRESENT         1         /*!< JTAG present or not */
+#define __MPU_PRESENT          1         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       4         /*!< Number of bits used for Priority Levels */
+#define __TRACE_LVL            1         /*!< Standard trace: ITM and DWT triggers and counters, but no ETM */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+#define __WIC_PRESENT          0         /*!< WIC present or not */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm4.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_sam4l.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAM4LS8C */
+/* ************************************************************************** */
+/** \defgroup SAM4LS8C_api Peripheral Software API */
+/*@{*/
+
+#include "component/abdacb.h"
+#include "component/acifc.h"
+#include "component/adcife.h"
+#include "component/ast.h"
+#include "component/bpm.h"
+#include "component/bscif.h"
+#include "component/catb.h"
+#include "component/chipid.h"
+#include "component/crccu.h"
+#include "component/dacc.h"
+#include "component/eic.h"
+#include "component/flashcalw.h"
+#include "component/freqm.h"
+#include "component/gloc.h"
+#include "component/gpio.h"
+#include "component/hcache.h"
+#include "component/hmatrixb.h"
+#include "component/iisc.h"
+#include "component/parc.h"
+#include "component/pdca.h"
+#include "component/pevc.h"
+#include "component/picouart.h"
+#include "component/pm.h"
+#include "component/scif.h"
+#include "component/smap.h"
+#include "component/spi.h"
+#include "component/tc.h"
+#include "component/trng.h"
+#include "component/twim.h"
+#include "component/twis.h"
+#include "component/usart.h"
+#include "component/usbc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAM4LS8C */
+/* ************************************************************************** */
+/** \defgroup SAM4LS8C_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/abdacb.h"
+#include "instance/acifc.h"
+#include "instance/adcife.h"
+#include "instance/ast.h"
+#include "instance/bpm.h"
+#include "instance/bscif.h"
+#include "instance/catb.h"
+#include "instance/chipid.h"
+#include "instance/crccu.h"
+#include "instance/dacc.h"
+#include "instance/eic.h"
+#include "instance/hflashc.h"
+#include "instance/freqm.h"
+#include "instance/gloc.h"
+#include "instance/gpio.h"
+#include "instance/hcache.h"
+#include "instance/hmatrix.h"
+#include "instance/iisc.h"
+#include "instance/parc.h"
+#include "instance/pdca.h"
+#include "instance/pevc.h"
+#include "instance/picouart.h"
+#include "instance/pm.h"
+#include "instance/scif.h"
+#include "instance/smap.h"
+#include "instance/spi.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/trng.h"
+#include "instance/twim0.h"
+#include "instance/twim1.h"
+#include "instance/twim2.h"
+#include "instance/twim3.h"
+#include "instance/twis0.h"
+#include "instance/twis1.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/usart2.h"
+#include "instance/usart3.h"
+#include "instance/usbc.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAM4LS8C */
+/* ************************************************************************** */
+/** \defgroup SAM4LS8C_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HTOP0 bridge
+#define ID_IISC           0 /**< \brief Inter-IC Sound (I2S) Controller (IISC) */
+#define ID_SPI            1 /**< \brief Serial Peripheral Interface (SPI) */
+#define ID_TC0            2 /**< \brief Timer/Counter 0 (TC0) */
+#define ID_TC1            3 /**< \brief Timer/Counter 1 (TC1) */
+#define ID_TWIM0          4 /**< \brief Two-wire Master Interface 0 (TWIM0) */
+#define ID_TWIS0          5 /**< \brief Two-wire Slave Interface 0 (TWIS0) */
+#define ID_TWIM1          6 /**< \brief Two-wire Master Interface 1 (TWIM1) */
+#define ID_TWIS1          7 /**< \brief Two-wire Slave Interface 1 (TWIS1) */
+#define ID_USART0         8 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 0 (USART0) */
+#define ID_USART1         9 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 1 (USART1) */
+#define ID_USART2        10 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 2 (USART2) */
+#define ID_USART3        11 /**< \brief Universal Synchronous Asynchronous Receiver Transmitter 3 (USART3) */
+#define ID_ADCIFE        12 /**< \brief ADC controller interface (ADCIFE) */
+#define ID_DACC          13 /**< \brief DAC Controller (DACC) */
+#define ID_ACIFC         14 /**< \brief Analog Comparator Interface (ACIFC) */
+#define ID_GLOC          15 /**< \brief Glue Logic Controller (GLOC) */
+#define ID_ABDACB        16 /**< \brief Audio Bitstream DAC (ABDACB) */
+#define ID_TRNG          17 /**< \brief True Random Number Generator (TRNG) */
+#define ID_PARC          18 /**< \brief Parallel Capture (PARC) */
+#define ID_CATB          19 /**< \brief Capacitive Touch Module B (CATB) */
+#define ID_TWIM2         21 /**< \brief Two-wire Master Interface 2 (TWIM2) */
+#define ID_TWIM3         22 /**< \brief Two-wire Master Interface 3 (TWIM3) */
+
+// Peripheral instances on HTOP1 bridge
+#define ID_HFLASHC       32 /**< \brief Flash Controller (HFLASHC) */
+#define ID_HCACHE        33 /**< \brief Cortex M I&D Cache Controller (HCACHE) */
+#define ID_HMATRIX       34 /**< \brief HSB Matrix (HMATRIX) */
+#define ID_PDCA          35 /**< \brief Peripheral DMA Controller (PDCA) */
+#define ID_SMAP          36 /**< \brief System Manager Access Port (SMAP) */
+#define ID_CRCCU         37 /**< \brief CRC Calculation Unit (CRCCU) */
+#define ID_USBC          38 /**< \brief USB 2.0 Interface (USBC) */
+#define ID_PEVC          39 /**< \brief Peripheral Event Controller (PEVC) */
+
+// Peripheral instances on HTOP2 bridge
+#define ID_PM            64 /**< \brief Power Manager (PM) */
+#define ID_CHIPID        65 /**< \brief Chip ID Registers (CHIPID) */
+#define ID_SCIF          66 /**< \brief System Control Interface (SCIF) */
+#define ID_FREQM         67 /**< \brief Frequency Meter (FREQM) */
+#define ID_GPIO          68 /**< \brief General-Purpose Input/Output Controller (GPIO) */
+
+// Peripheral instances on HTOP3 bridge
+#define ID_BPM           96 /**< \brief Backup Power Manager (BPM) */
+#define ID_BSCIF         97 /**< \brief Backup System Control Interface (BSCIF) */
+#define ID_AST           98 /**< \brief Asynchronous Timer (AST) */
+#define ID_WDT           99 /**< \brief Watchdog Timer (WDT) */
+#define ID_EIC          100 /**< \brief External Interrupt Controller (EIC) */
+#define ID_PICOUART     101 /**< \brief Pico UART (PICOUART) */
+
+#define ID_PERIPH_COUNT 102 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAM4LS8C */
+/* ************************************************************************** */
+/** \defgroup SAM4LS8C_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define ABDACB                        (0x40064000) /**< \brief (ABDACB) APB Base Address */
+#define ACIFC                         (0x40040000) /**< \brief (ACIFC) APB Base Address */
+#define ADCIFE                        (0x40038000) /**< \brief (ADCIFE) APB Base Address */
+#define AST                           (0x400F0800) /**< \brief (AST) APB Base Address */
+#define BPM                           (0x400F0000) /**< \brief (BPM) APB Base Address */
+#define BSCIF                         (0x400F0400) /**< \brief (BSCIF) APB Base Address */
+#define CATB                          (0x40070000) /**< \brief (CATB) APB Base Address */
+#define CHIPID                        (0x400E0400) /**< \brief (CHIPID) APB Base Address */
+#define CRCCU                         (0x400A4000) /**< \brief (CRCCU) APB Base Address */
+#define DACC                          (0x4003C000) /**< \brief (DACC) APB Base Address */
+#define EIC                           (0x400F1000) /**< \brief (EIC) APB Base Address */
+#define HFLASHC                       (0x400A0000) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000) /**< \brief (HFLASHC) USER Base Address */
+#define FREQM                         (0x400E0C00) /**< \brief (FREQM) APB Base Address */
+#define GLOC                          (0x40060000) /**< \brief (GLOC) APB Base Address */
+#define GPIO                          (0x400E1000) /**< \brief (GPIO) APB Base Address */
+#define HCACHE                        (0x400A0400) /**< \brief (HCACHE) APB Base Address */
+#define HMATRIX                       (0x400A1000) /**< \brief (HMATRIX) APB Base Address */
+#define IISC                          (0x40004000) /**< \brief (IISC) APB Base Address */
+#define PARC                          (0x4006C000) /**< \brief (PARC) APB Base Address */
+#define PDCA                          (0x400A2000) /**< \brief (PDCA) APB Base Address */
+#define PEVC                          (0x400A6000) /**< \brief (PEVC) APB Base Address */
+#define PICOUART                      (0x400F1400) /**< \brief (PICOUART) APB Base Address */
+#define PM                            (0x400E0000) /**< \brief (PM) APB Base Address */
+#define SCIF                          (0x400E0800) /**< \brief (SCIF) APB Base Address */
+#define SMAP                          (0x400A3000) /**< \brief (SMAP) APB Base Address */
+#define SPI                           (0x40008000) /**< \brief (SPI) APB Base Address */
+#define TC0                           (0x40010000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x40014000) /**< \brief (TC1) APB Base Address */
+#define TRNG                          (0x40068000) /**< \brief (TRNG) APB Base Address */
+#define TWIM0                         (0x40018000) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1                         (0x4001C000) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2                         (0x40078000) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3                         (0x4007C000) /**< \brief (TWIM3) APB Base Address */
+#define TWIS0                         (0x40018400) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1                         (0x4001C400) /**< \brief (TWIS1) APB Base Address */
+#define USART0                        (0x40024000) /**< \brief (USART0) APB Base Address */
+#define USART1                        (0x40028000) /**< \brief (USART1) APB Base Address */
+#define USART2                        (0x4002C000) /**< \brief (USART2) APB Base Address */
+#define USART3                        (0x40030000) /**< \brief (USART3) APB Base Address */
+#define USBC                          (0x400A5000) /**< \brief (USBC) APB Base Address */
+#define WDT                           (0x400F0C00) /**< \brief (WDT) APB Base Address */
+#else
+#define ABDACB            ((Abdacb   *)0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_ADDR                   (0x40064000UL) /**< \brief (ABDACB) APB Base Address */
+#define ABDACB_INST_NUM   1                          /**< \brief (ABDACB) Number of instances */
+#define ABDACB_INSTS      { ABDACB }                 /**< \brief (ABDACB) Instances List */
+
+#define ACIFC             ((Acifc    *)0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_ADDR                    (0x40040000UL) /**< \brief (ACIFC) APB Base Address */
+#define ACIFC_INST_NUM    1                          /**< \brief (ACIFC) Number of instances */
+#define ACIFC_INSTS       { ACIFC }                  /**< \brief (ACIFC) Instances List */
+
+#define ADCIFE            ((Adcife   *)0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_ADDR                   (0x40038000UL) /**< \brief (ADCIFE) APB Base Address */
+#define ADCIFE_INST_NUM   1                          /**< \brief (ADCIFE) Number of instances */
+#define ADCIFE_INSTS      { ADCIFE }                 /**< \brief (ADCIFE) Instances List */
+
+#define AST               ((Ast      *)0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_ADDR                      (0x400F0800UL) /**< \brief (AST) APB Base Address */
+#define AST_INST_NUM      1                          /**< \brief (AST) Number of instances */
+#define AST_INSTS         { AST }                    /**< \brief (AST) Instances List */
+
+#define BPM               ((Bpm      *)0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_ADDR                      (0x400F0000UL) /**< \brief (BPM) APB Base Address */
+#define BPM_INST_NUM      1                          /**< \brief (BPM) Number of instances */
+#define BPM_INSTS         { BPM }                    /**< \brief (BPM) Instances List */
+
+#define BSCIF             ((Bscif    *)0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_ADDR                    (0x400F0400UL) /**< \brief (BSCIF) APB Base Address */
+#define BSCIF_INST_NUM    1                          /**< \brief (BSCIF) Number of instances */
+#define BSCIF_INSTS       { BSCIF }                  /**< \brief (BSCIF) Instances List */
+
+#define CATB              ((Catb     *)0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_ADDR                     (0x40070000UL) /**< \brief (CATB) APB Base Address */
+#define CATB_INST_NUM     1                          /**< \brief (CATB) Number of instances */
+#define CATB_INSTS        { CATB }                   /**< \brief (CATB) Instances List */
+
+#define CHIPID            ((Chipid   *)0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_ADDR                   (0x400E0400UL) /**< \brief (CHIPID) APB Base Address */
+#define CHIPID_INST_NUM   1                          /**< \brief (CHIPID) Number of instances */
+#define CHIPID_INSTS      { CHIPID }                 /**< \brief (CHIPID) Instances List */
+
+#define CRCCU             ((Crccu    *)0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_ADDR                    (0x400A4000UL) /**< \brief (CRCCU) APB Base Address */
+#define CRCCU_INST_NUM    1                          /**< \brief (CRCCU) Number of instances */
+#define CRCCU_INSTS       { CRCCU }                  /**< \brief (CRCCU) Instances List */
+
+#define DACC              ((Dacc     *)0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_ADDR                     (0x4003C000UL) /**< \brief (DACC) APB Base Address */
+#define DACC_INST_NUM     1                          /**< \brief (DACC) Number of instances */
+#define DACC_INSTS        { DACC }                   /**< \brief (DACC) Instances List */
+
+#define EIC               ((Eic      *)0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_ADDR                      (0x400F1000UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define HFLASHC           ((Flashcalw *)0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_ADDR                  (0x400A0000UL) /**< \brief (HFLASHC) APB Base Address */
+#define HFLASHC_FROW                  (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_FROW_ADDR             (0x00800200UL) /**< \brief (HFLASHC) FROW Base Address */
+#define HFLASHC_USER                  (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define HFLASHC_USER_ADDR             (0x00800000UL) /**< \brief (HFLASHC) USER Base Address */
+#define FLASHCALW_INST_NUM 1                          /**< \brief (FLASHCALW) Number of instances */
+#define FLASHCALW_INSTS   { HFLASHC }                /**< \brief (FLASHCALW) Instances List */
+
+#define FREQM             ((Freqm    *)0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_ADDR                    (0x400E0C00UL) /**< \brief (FREQM) APB Base Address */
+#define FREQM_INST_NUM    1                          /**< \brief (FREQM) Number of instances */
+#define FREQM_INSTS       { FREQM }                  /**< \brief (FREQM) Instances List */
+
+#define GLOC              ((Gloc     *)0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_ADDR                     (0x40060000UL) /**< \brief (GLOC) APB Base Address */
+#define GLOC_INST_NUM     1                          /**< \brief (GLOC) Number of instances */
+#define GLOC_INSTS        { GLOC }                   /**< \brief (GLOC) Instances List */
+
+#define GPIO              ((Gpio     *)0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_ADDR                     (0x400E1000UL) /**< \brief (GPIO) APB Base Address */
+#define GPIO_INST_NUM     1                          /**< \brief (GPIO) Number of instances */
+#define GPIO_INSTS        { GPIO }                   /**< \brief (GPIO) Instances List */
+
+#define HCACHE            ((Hcache   *)0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_ADDR                   (0x400A0400UL) /**< \brief (HCACHE) APB Base Address */
+#define HCACHE_INST_NUM   1                          /**< \brief (HCACHE) Number of instances */
+#define HCACHE_INSTS      { HCACHE }                 /**< \brief (HCACHE) Instances List */
+
+#define HMATRIX           ((Hmatrixb *)0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIX_ADDR                  (0x400A1000UL) /**< \brief (HMATRIX) APB Base Address */
+#define HMATRIXB_INST_NUM 1                          /**< \brief (HMATRIXB) Number of instances */
+#define HMATRIXB_INSTS    { HMATRIX }                /**< \brief (HMATRIXB) Instances List */
+
+#define IISC              ((Iisc     *)0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_ADDR                     (0x40004000UL) /**< \brief (IISC) APB Base Address */
+#define IISC_INST_NUM     1                          /**< \brief (IISC) Number of instances */
+#define IISC_INSTS        { IISC }                   /**< \brief (IISC) Instances List */
+
+#define PARC              ((Parc     *)0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_ADDR                     (0x4006C000UL) /**< \brief (PARC) APB Base Address */
+#define PARC_INST_NUM     1                          /**< \brief (PARC) Number of instances */
+#define PARC_INSTS        { PARC }                   /**< \brief (PARC) Instances List */
+
+#define PDCA              ((Pdca     *)0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_ADDR                     (0x400A2000UL) /**< \brief (PDCA) APB Base Address */
+#define PDCA_INST_NUM     1                          /**< \brief (PDCA) Number of instances */
+#define PDCA_INSTS        { PDCA }                   /**< \brief (PDCA) Instances List */
+
+#define PEVC              ((Pevc     *)0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_ADDR                     (0x400A6000UL) /**< \brief (PEVC) APB Base Address */
+#define PEVC_INST_NUM     1                          /**< \brief (PEVC) Number of instances */
+#define PEVC_INSTS        { PEVC }                   /**< \brief (PEVC) Instances List */
+
+#define PICOUART          ((Picouart *)0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_ADDR                 (0x400F1400UL) /**< \brief (PICOUART) APB Base Address */
+#define PICOUART_INST_NUM 1                          /**< \brief (PICOUART) Number of instances */
+#define PICOUART_INSTS    { PICOUART }               /**< \brief (PICOUART) Instances List */
+
+#define PM                ((Pm       *)0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_ADDR                       (0x400E0000UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define SCIF              ((Scif     *)0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_ADDR                     (0x400E0800UL) /**< \brief (SCIF) APB Base Address */
+#define SCIF_INST_NUM     1                          /**< \brief (SCIF) Number of instances */
+#define SCIF_INSTS        { SCIF }                   /**< \brief (SCIF) Instances List */
+
+#define SMAP              ((Smap     *)0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_ADDR                     (0x400A3000UL) /**< \brief (SMAP) APB Base Address */
+#define SMAP_INST_NUM     1                          /**< \brief (SMAP) Number of instances */
+#define SMAP_INSTS        { SMAP }                   /**< \brief (SMAP) Instances List */
+
+#define SPI               ((Spi      *)0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_ADDR                      (0x40008000UL) /**< \brief (SPI) APB Base Address */
+#define SPI_INST_NUM      1                          /**< \brief (SPI) Number of instances */
+#define SPI_INSTS         { SPI }                    /**< \brief (SPI) Instances List */
+
+#define TC0               ((Tc       *)0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC0_ADDR                      (0x40010000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC1_ADDR                      (0x40014000UL) /**< \brief (TC1) APB Base Address */
+#define TC_INST_NUM       2                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1 }               /**< \brief (TC) Instances List */
+
+#define TRNG              ((Trng     *)0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_ADDR                     (0x40068000UL) /**< \brief (TRNG) APB Base Address */
+#define TRNG_INST_NUM     1                          /**< \brief (TRNG) Number of instances */
+#define TRNG_INSTS        { TRNG }                   /**< \brief (TRNG) Instances List */
+
+#define TWIM0             ((Twim     *)0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM0_ADDR                    (0x40018000UL) /**< \brief (TWIM0) APB Base Address */
+#define TWIM1             ((Twim     *)0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM1_ADDR                    (0x4001C000UL) /**< \brief (TWIM1) APB Base Address */
+#define TWIM2             ((Twim     *)0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM2_ADDR                    (0x40078000UL) /**< \brief (TWIM2) APB Base Address */
+#define TWIM3             ((Twim     *)0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM3_ADDR                    (0x4007C000UL) /**< \brief (TWIM3) APB Base Address */
+#define TWIM_INST_NUM     4                          /**< \brief (TWIM) Number of instances */
+#define TWIM_INSTS        { TWIM0, TWIM1, TWIM2, TWIM3 } /**< \brief (TWIM) Instances List */
+
+#define TWIS0             ((Twis     *)0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS0_ADDR                    (0x40018400UL) /**< \brief (TWIS0) APB Base Address */
+#define TWIS1             ((Twis     *)0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS1_ADDR                    (0x4001C400UL) /**< \brief (TWIS1) APB Base Address */
+#define TWIS_INST_NUM     2                          /**< \brief (TWIS) Number of instances */
+#define TWIS_INSTS        { TWIS0, TWIS1 }           /**< \brief (TWIS) Instances List */
+
+#define USART0            ((Usart    *)0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART0_ADDR                   (0x40024000UL) /**< \brief (USART0) APB Base Address */
+#define USART1            ((Usart    *)0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART1_ADDR                   (0x40028000UL) /**< \brief (USART1) APB Base Address */
+#define USART2            ((Usart    *)0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART2_ADDR                   (0x4002C000UL) /**< \brief (USART2) APB Base Address */
+#define USART3            ((Usart    *)0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART3_ADDR                   (0x40030000UL) /**< \brief (USART3) APB Base Address */
+#define USART_INST_NUM    4                          /**< \brief (USART) Number of instances */
+#define USART_INSTS       { USART0, USART1, USART2, USART3 } /**< \brief (USART) Instances List */
+
+#define USBC              ((Usbc     *)0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_ADDR                     (0x400A5000UL) /**< \brief (USBC) APB Base Address */
+#define USBC_INST_NUM     1                          /**< \brief (USBC) Number of instances */
+#define USBC_INSTS        { USBC }                   /**< \brief (USBC) Instances List */
+
+#define WDT               ((Wdt      *)0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_ADDR                      (0x400F0C00UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  GPIO DEFINITIONS FOR SAM4LS8C */
+/* ************************************************************************** */
+/** \defgroup SAM4LS8C_gpio GPIO Definitions */
+/*@{*/
+
+#include "pio/sam4ls8c.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  ADDITIONAL DEFINITIONS FOR COMPATIBILITY */
+/* ************************************************************************** */
+/** \addtogroup SAM4LS8C_compat Definitions */
+/*@{*/
+// These defines are used to keep compatibility with existing 
+// sam/drivers/usart implementation from SAM3/4 products with SAM4L product.
+#define US_MR_USART_MODE_HW_HANDSHAKING  US_MR_USART_MODE_HARDWARE
+#define US_MR_USART_MODE_IS07816_T_0     US_MR_USART_MODE_ISO7816_T0
+#define US_MR_USART_MODE_IS07816_T_1     US_MR_USART_MODE_ISO7816_T1
+#define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
+#define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
+#define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_8_BIT      US_MR_CHRL_8
+#define US_MR_PAR_NO          US_MR_PAR_NONE
+#define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI
+#define US_IF                 US_IFR
+#define US_WPSR_WPVS          US_WPSR_WPV_1
+
+#define USBC_UPCFG0_PBK_Msk   (0x1u << USBC_UPCFG0_PBK_Pos)
+
+// These defines for homogeneity with other SAM header files.
+#define CHIP_FREQ_FWS_0       (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 */
+#define CHIP_FREQ_FWS_1       (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 */
+// WARNING NOTE: these are preliminary values.
+#define CHIP_FREQ_FLASH_HSEN_FWS_0 (18000000UL) /**< \brief Maximum operating frequency when FWS is 0 and the FLASH HS mode is enabled */
+#define CHIP_FREQ_FLASH_HSEN_FWS_1 (36000000UL) /**< \brief Maximum operating frequency when FWS is 1 and the FLASH HS mode is enabled */
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/tc implementation from SAM3/4 products with SAM4L product. 
+#define TC_CMR_LDRA_RISING    TC_CMR_LDRA_POS_EDGE_TIOA
+#define TC_CMR_LDRB_FALLING   TC_CMR_LDRB_NEG_EDGE_TIOA
+#define TC_CMR_ETRGEDG_FALLING TC_CMR_ETRGEDG_NEG_EDGE
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/spi implementation from SAM3/4 products with SAM4L product. 
+#define SPI_CSR_BITS_8_BIT    SPI_CSR_BITS_8_BPT
+#define SPI_WPCR_SPIWPKEY_VALUE SPI_WPCR_WPKEY_VALUE
+#define SPI_WPCR_SPIWPEN      SPI_WPCR_WPEN
+
+// These defines are used to keep compatibility with existing 
+// sam/drivers/crccu implementation from SAM3/4 products with SAM4L product. 
+#define CRCCU_DMA_EN          CRCCU_DMAEN
+#define CRCCU_DMA_DIS         CRCCU_DMADIS
+#define CRCCU_DMA_SR          CRCCU_DMASR
+#define CRCCU_DMA_IER         CRCCU_DMAIER
+#define CRCCU_DMA_IDR         CRCCU_DMAIDR
+#define CRCCU_DMA_IMR         CRCCU_DMAIMR
+#define CRCCU_DMA_ISR         CRCCU_DMAISR
+#define CRCCU_DMA_EN_DMAEN    CRCCU_DMAEN_DMAEN
+#define CRCCU_DMA_DIS_DMADIS  CRCCU_DMADIS_DMADIS
+#define CRCCU_DMA_SR_DMASR    CRCCU_DMASR_DMASR
+#define CRCCU_DMA_IER_DMAIER  CRCCU_DMAIER_DMAIER
+#define CRCCU_DMA_IDR_DMAIDR  CRCCU_DMAIDR_DMAIDR
+#define CRCCU_DMA_IMR_DMAIMR  CRCCU_DMAIMR_DMAIMR
+#define CRCCU_DMA_ISR_DMAISR  CRCCU_DMAISR_DMAISR
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAM4LS8C */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL(0x00080000) /* 512 kB */
+#define FLASH_PAGE_SIZE       512
+#define FLASH_NB_OF_PAGES     1024
+#define FLASH_USER_PAGE_SIZE  512
+#define HRAMC0_SIZE           _UL(0x00010000) /* 64 kB */
+#define HRAMC1_SIZE           _UL(0x00000800) /* 2 kB */
+
+#define FLASH_ADDR            _UL(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL(0x20000000) /**< HRAMC0 base address */
+#define HRAMC1_ADDR           _UL(0x21000000) /**< HRAMC1 base address */
+#define HTOP0_ADDR            _UL(0x40000000) /**< HTOP0 base address */
+#define HTOP1_ADDR            _UL(0x400A0000) /**< HTOP1 base address */
+#define HTOP2_ADDR            _UL(0x400E0000) /**< HTOP2 base address */
+#define HTOP3_ADDR            _UL(0x400F0000) /**< HTOP3 base address */
+
+#define DSU_DID_RESETVALUE    _UL(0xAB0B0AE0)
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAM4LS8C */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAM4LS8C_H */


### PR DESCRIPTION
Origin: Atmel SAM4L Series Device Support (1.1.61)
License: Apache-2.0
URL: http://packs.download.atmel.com/Atmel.SAM4L_DFP.1.1.61.atpack
Purpose: Introduction of ASF for the SAM4L series.
Maintained-by: External
Signed-off-by: Gerson Fernando Budke nandojve@gmail.com
Zephyr: https://github.com/zephyrproject-rtos/zephyr/pull/26821